### PR TITLE
修复反复切换音色并启动语音时 Electron 卡死的问题。音色变更不再触发整页刷新，改为结束当前语音 session 并原地刷新后端音色…

### DIFF
--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -3023,9 +3023,9 @@ async def update_catgirl_voice_id(name: str, request: Request):
         legacy_keys=('voice_id',)
     ))
 
-    # 幂等保护：提交同值时直接返回，避免无实际变更触发 reload_page。
+    # 幂等保护：提交同值时直接返回，避免无实际变更触发会话重置。
     if old_voice_id == voice_id:
-        logger.info("猫娘 %s 的 voice_id 未变化，跳过刷新流程", name)
+        logger.info("猫娘 %s 的 voice_id 未变化，跳过会话重置流程", name)
         return {"success": True, "session_restarted": False, "voice_id_changed": False}
 
     if _is_current_catgirl_voice_session_starting(name, characters, session_manager):
@@ -3052,10 +3052,12 @@ async def update_catgirl_voice_id(name: str, request: Request):
     if is_current_catgirl and name in session_manager:
         # 检查是否有活跃的session
         if session_manager[name].is_active:
-            logger.info(f"检测到 {name} 的voice_id已更新（{old_voice_id} -> {voice_id}），准备刷新...")
+            logger.info(f"检测到 {name} 的voice_id已更新（{old_voice_id} -> {voice_id}），准备结束当前语音会话...")
 
-            # 1. 先发送刷新消息（WebSocket还连着）
-            await send_reload_page_notice(session_manager[name])
+            # 1. 通知前端按 session 结束路径收口，避免 Electron 为音色切换整页重载。
+            notify_session_ended = getattr(session_manager[name], "send_session_ended_by_server", None)
+            if callable(notify_session_ended):
+                await notify_session_ended()
 
             # 2. 立刻关闭session（这会断开WebSocket）
             try:
@@ -3065,7 +3067,7 @@ async def update_catgirl_voice_id(name: str, request: Request):
             except Exception as e:
                 logger.error(f"结束session时出错: {e}")
             # 切音色后，前一会话累计的失败计数 / 熔断不再适用：
-            # reload 页面后用户的下一次 start_session 应是全新尝试，否则
+            # 用户的下一次 start_session 应是全新尝试，否则
             # 这条 SessionManager 实例还会被旧失败计数 / 熔断继续静默拦截。
             session_manager[name].reset_session_start_circuit()
 
@@ -3367,8 +3369,10 @@ async def unregister_voice(name: str):
 
         if is_current_catgirl and name in session_manager:
             if session_manager[name].is_active:
-                logger.info(f"检测到 {name} 的voice_id已清空（{old_voice_id} -> ''），准备刷新...")
-                await send_reload_page_notice(session_manager[name], "音色已清除，页面即将刷新")
+                logger.info(f"检测到 {name} 的voice_id已清空（{old_voice_id} -> ''），准备结束当前语音会话...")
+                notify_session_ended = getattr(session_manager[name], "send_session_ended_by_server", None)
+                if callable(notify_session_ended):
+                    await notify_session_ended()
                 try:
                     await session_manager[name].end_session(by_server=True)
                     session_ended = True
@@ -3376,7 +3380,7 @@ async def unregister_voice(name: str):
                 except Exception as e:
                     logger.error(f"结束session时出错: {e}")
                 # 与 set_voice_id 路径对偶：清掉前一会话的失败计数 / 熔断，
-                # 否则 reload 后新 start_session 会被旧熔断静默拦截。
+                # 否则下一次 start_session 会被旧熔断静默拦截。
                 session_manager[name].reset_session_start_circuit()
 
         # Fast path：只刷新被编辑角色的 session_manager（voice_id），不遍历其它 N-1 个。
@@ -4008,10 +4012,12 @@ async def update_catgirl(name: str, request: Request):
         session_manager = get_session_manager()
         is_current_catgirl = (name == characters.get('当前猫娘', ''))
 
-        # 如果是当前活跃的猫娘，需要先通知前端，再关闭 session
+        # 如果是当前活跃的猫娘，只结束当前语音会话；voice_id 会在下方刷新到 session_manager。
         if is_current_catgirl and name in session_manager and session_manager[name].is_active:
-            logger.info(f"检测到 {name} 的voice_id已变更（{old_voice_id} -> {new_voice_id}），准备刷新...")
-            await send_reload_page_notice(session_manager[name])
+            logger.info(f"检测到 {name} 的voice_id已变更（{old_voice_id} -> {new_voice_id}），准备结束当前语音会话...")
+            notify_session_ended = getattr(session_manager[name], "send_session_ended_by_server", None)
+            if callable(notify_session_ended):
+                await notify_session_ended()
             try:
                 await session_manager[name].end_session(by_server=True)
                 session_ended = True
@@ -4019,7 +4025,7 @@ async def update_catgirl(name: str, request: Request):
             except Exception as e:
                 logger.error(f"结束session时出错: {e}")
             # 与 set_voice_id 路径对偶：清掉前一会话的失败计数 / 熔断，
-            # 否则 reload 后新 start_session 会被旧熔断静默拦截。
+            # 否则下一次 start_session 会被旧熔断静默拦截。
             session_manager[name].reset_session_start_circuit()
 
         if is_current_catgirl:
@@ -5107,9 +5113,11 @@ async def delete_voice(voice_id: str):
 
                 # 对于受影响的活跃角色，并行通知 + 结束 session（每个 end_session ≈ 1s）
                 async def _refresh_one(name):
-                    logger.info(f"检测到活跃角色 {name} 的 voice_id 已被删除，准备刷新...")
-                    # 1. 发送刷新通知
-                    await send_reload_page_notice(session_manager[name], "音色已删除，页面即将刷新")
+                    logger.info(f"检测到活跃角色 {name} 的 voice_id 已被删除，准备结束当前语音会话...")
+                    # 1. 通知前端按 session 结束路径收口，避免 Electron 为音色切换整页重载。
+                    notify_session_ended = getattr(session_manager[name], "send_session_ended_by_server", None)
+                    if callable(notify_session_ended):
+                        await notify_session_ended()
                     # 2. 结束 session
                     try:
                         await session_manager[name].end_session(by_server=True)
@@ -5117,7 +5125,7 @@ async def delete_voice(voice_id: str):
                     except Exception as e:
                         logger.error(f"结束受影响角色 {name} 的 session 时出错: {e}")
                     # 与 set_voice_id 路径对偶：清掉前一会话的失败计数 / 熔断，
-                    # 否则 reload 后新 start_session 会被旧熔断静默拦截。
+                    # 否则下一次 start_session 会被旧熔断静默拦截。
                     session_manager[name].reset_session_start_circuit()
 
                 if affected_active_names:

--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -37,14 +37,20 @@
     }
 
     function getVoiceStartErrorMessage(error) {
-        var fallback = (typeof window.safeT === 'function')
-            ? window.safeT('app.sessionFailed', 'Session启动失败')
-            : 'Session启动失败';
+        var fallbackKey = 'app.sessionFailed';
+        var defaultFallback = 'Session启动失败';
         function usableText(value) {
             if (typeof value !== 'string') return '';
             var text = value.trim();
             if (!text || text === '[object Module]' || text === '[object Object]') return '';
             return value;
+        }
+        var fallback = defaultFallback;
+        if (typeof window.t === 'function') {
+            var translatedFallback = usableText(window.t(fallbackKey, defaultFallback));
+            if (translatedFallback && translatedFallback.trim() !== fallbackKey) {
+                fallback = translatedFallback;
+            }
         }
 
         var message = usableText(error && error.message);

--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -36,6 +36,33 @@
         rejecter(error);
     }
 
+    function getVoiceStartErrorMessage(error) {
+        var fallback = (typeof window.safeT === 'function')
+            ? window.safeT('app.sessionFailed', 'Session启动失败')
+            : 'Session启动失败';
+        function usableText(value) {
+            if (typeof value !== 'string') return '';
+            var text = value.trim();
+            if (!text || text === '[object Module]' || text === '[object Object]') return '';
+            return value;
+        }
+
+        var message = usableText(error && error.message);
+        if (message) return message;
+        message = usableText(typeof error === 'string' ? error : '');
+        if (message) return message;
+
+        if (error && typeof error === 'object' && typeof window.translateStatusMessage === 'function') {
+            message = usableText(window.translateStatusMessage(error));
+            if (message) return message;
+        }
+
+        if (error !== undefined && error !== null) {
+            console.warn('[VoiceStart] Non-string error message ignored:', error);
+        }
+        return fallback;
+    }
+
     function isHomeTutorialInteractionLocked() {
         try {
             return typeof window.isNekoHomeTutorialInteractionLocked === 'function'
@@ -2113,6 +2140,7 @@
                 S.isSwitchingMode = false;
 
             } catch (error) {
+                var voiceStartErrorMessage = getVoiceStartErrorMessage(error);
                 var isVoiceStartCancelled = !!(error && error.voiceStartCancelled);
                 var preserveGoodbyeUi = isVoiceStartCancelled
                     && typeof window.isNekoGoodbyeModeActive === 'function'
@@ -2137,7 +2165,7 @@
                 }
 
                 if (error && error.voiceConfigSwitchTimedOut) {
-                    window.showVoicePreparingToast(error.message);
+                    window.showVoicePreparingToast(voiceStartErrorMessage);
                 } else {
                     window.hideVoicePreparingToast();
                 }
@@ -2173,9 +2201,9 @@
                 if (preserveGoodbyeUi) {
                     window.showStatusToast('', 0);
                 } else if (error && error.voiceConfigSwitchTimedOut) {
-                    window.showStatusToast(error.message, 5000);
+                    window.showStatusToast(voiceStartErrorMessage, 5000);
                 } else {
-                    window.showStatusToast(window.t ? window.t('app.startFailed', { error: error.message }) : '\u542F\u52A8\u5931\u8D25: ' + error.message, 5000);
+                    window.showStatusToast(window.t ? window.t('app.startFailed', { error: voiceStartErrorMessage }) : '\u542F\u52A8\u5931\u8D25: ' + voiceStartErrorMessage, 5000);
                 }
 
                 screenButton.classList.remove('active');

--- a/static/app-state.js
+++ b/static/app-state.js
@@ -108,6 +108,7 @@
         voiceChatActive: false,
         voiceStartPending: false,
         isTextSessionActive: false,
+        suppressAssistantStreamUntilNextSession: false,
         isSwitchingMode: false,
         sessionStartedResolver: null,
         sessionStartedRejecter: null,

--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -417,15 +417,21 @@
     // ================================================================
 
     function normalizeVoiceToastMessage(message) {
-        var fallback = (typeof window.safeT === 'function')
-            ? window.safeT('app.voiceSystemPreparing', '语音系统准备中...')
-            : '语音系统准备中...';
+        var fallbackKey = 'app.voiceSystemPreparing';
+        var defaultFallback = '语音系统准备中...';
 
         function usableText(value) {
             if (typeof value !== 'string') return '';
             var text = value.trim();
             if (!text || text === '[object Module]' || text === '[object Object]') return '';
             return value;
+        }
+        var fallback = defaultFallback;
+        if (typeof window.t === 'function') {
+            var translatedFallback = usableText(window.t(fallbackKey, defaultFallback));
+            if (translatedFallback && translatedFallback.trim() !== fallbackKey) {
+                fallback = translatedFallback;
+            }
         }
 
         var directText = usableText(message);

--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -416,6 +416,38 @@
     //  2. Voice toasts & prominent notice  (app.js lines 3674-3999)
     // ================================================================
 
+    function normalizeVoiceToastMessage(message) {
+        var fallback = (typeof window.safeT === 'function')
+            ? window.safeT('app.voiceSystemPreparing', '语音系统准备中...')
+            : '语音系统准备中...';
+
+        function usableText(value) {
+            if (typeof value !== 'string') return '';
+            var text = value.trim();
+            if (!text || text === '[object Module]' || text === '[object Object]') return '';
+            return value;
+        }
+
+        var directText = usableText(message);
+        if (directText) return directText;
+
+        if (message && typeof message === 'object') {
+            if (typeof window.translateStatusMessage === 'function') {
+                var translated = usableText(window.translateStatusMessage(message));
+                if (translated) return translated;
+            }
+            var nestedText = usableText(message.message);
+            if (nestedText) return nestedText;
+            var codeText = usableText(message.code);
+            if (codeText) return codeText;
+            console.warn('[VoiceToast] Non-string message ignored:', message);
+        } else if (message !== undefined && message !== null) {
+            console.warn('[VoiceToast] Unusable message ignored:', message);
+        }
+
+        return fallback;
+    }
+
     // --- showVoicePreparingToast ---
     function showVoicePreparingToast(message) {
         // 检查是否已存在提示框，避免重复创建
@@ -485,7 +517,7 @@
         var spinner = document.createElement('div');
         spinner.style.cssText = 'width:20px;height:20px;border:3px solid rgba(255,255,255,0.3);border-top-color:white;border-radius:50%;animation:spin 1s linear infinite;';
         var msgSpan = document.createElement('span');
-        msgSpan.textContent = message;
+        msgSpan.textContent = normalizeVoiceToastMessage(message);
         toast.appendChild(spinner);
         toast.appendChild(msgSpan);
 

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -769,6 +769,16 @@
         S.pendingTextTurnSubmitAt = 0;
     }
 
+    function clearPendingRollbackForRequest(requestId) {
+        if (window.reactChatWindowHost && typeof window.reactChatWindowHost.clearPendingRollbackDraft === 'function') {
+            window.reactChatWindowHost.clearPendingRollbackDraft(requestId);
+        }
+        if (requestId && window._lastSubmittedRequestId === requestId) {
+            window._lastSubmittedText = '';
+            window._lastSubmittedRequestId = '';
+        }
+    }
+
     function isNewUserIcebreakerMirrorTurnEnd(response) {
         var meta = response && response.meta;
         if (!meta || typeof meta !== 'object') return false;
@@ -2664,17 +2674,12 @@
                 } else if (response.type === 'system' && response.data === 'turn end agent_callback') {
                     if (S.suppressAssistantStreamUntilNextSession) {
                         console.log('[App] discard assistant turn_end after session ended by server');
+                        clearPendingRollbackForRequest(response.request_id);
                         clearPendingAssistantTurnStart();
                         return;
                     }
-                    if (window.reactChatWindowHost && typeof window.reactChatWindowHost.clearPendingRollbackDraft === 'function') {
-                        window.reactChatWindowHost.clearPendingRollbackDraft(response.request_id);
-                    }
-                    if (response.request_id && window._lastSubmittedRequestId === response.request_id) {
-                        window._lastSubmittedText = '';
-                        window._lastSubmittedRequestId = '';
-                    }
-                    console.log('[WS] turn end (agent_callback) — skipping proactive chat schedule');
+                    clearPendingRollbackForRequest(response.request_id);
+                    console.log('[WS] turn end (agent_callback) - skipping proactive chat schedule');
                     logAssistantLifecycle('ws:turn_end_agent_callback:received');
                     try {
                         flushRealisticBufferOnTurnEnd();
@@ -2708,16 +2713,11 @@
                 } else if (response.type === 'system' && response.data === 'turn end') {
                     if (S.suppressAssistantStreamUntilNextSession) {
                         console.log('[App] discard assistant turn_end after session ended by server');
+                        clearPendingRollbackForRequest(response.request_id);
                         clearPendingAssistantTurnStart();
                         return;
                     }
-                    if (window.reactChatWindowHost && typeof window.reactChatWindowHost.clearPendingRollbackDraft === 'function') {
-                        window.reactChatWindowHost.clearPendingRollbackDraft(response.request_id);
-                    }
-                    if (response.request_id && window._lastSubmittedRequestId === response.request_id) {
-                        window._lastSubmittedText = '';
-                        window._lastSubmittedRequestId = '';
-                    }
+                    clearPendingRollbackForRequest(response.request_id);
                     console.log(window.t('console.turnEndReceived'));
                     logAssistantLifecycle('ws:turn_end:received');
                     // Flush remaining buffer

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -1660,6 +1660,13 @@
                 } else if (response.type === 'response_discarded') {
                     clearPendingUserActivityCancel();
                     window.invalidatePendingMusicSearch();
+                    if (S.suppressAssistantStreamUntilNextSession) {
+                        logAssistantLifecycle('response_discarded_suppressed_after_session_end', {
+                            reason: response.reason,
+                            willRetry: !!response.will_retry
+                        });
+                        return;
+                    }
                     emitAssistantSpeechCancel('response_discarded');
                     S.assistantTurnId = null;
                     window._nekoAssistantTurnId = null;

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -1131,6 +1131,47 @@
         });
     }
 
+    function stopAssistantTextOutputOnSessionEnd(source) {
+        S.suppressAssistantStreamUntilNextSession = true;
+        window._realisticGeminiVersion = (window._realisticGeminiVersion || 0) + 1;
+        window._realisticGeminiQueue = [];
+        window._realisticGeminiBuffer = '';
+        window._geminiTurnFullText = '';
+        window._pendingMusicCommand = '';
+        window._structuredGeminiStreaming = false;
+        window._isProcessingRealisticQueue = false;
+        window._realisticProcessingOwner = null;
+        window._geminiTurnEndSealed = true;
+
+        var currentBubbles = Array.isArray(window.currentTurnGeminiBubbles)
+            ? window.currentTurnGeminiBubbles.slice()
+            : [];
+        if (currentBubbles.length === 0 && window.currentGeminiMessage) {
+            currentBubbles = [window.currentGeminiMessage];
+        }
+        var currentBubbleIds = [];
+        currentBubbles.forEach(function (bubble) {
+            if (bubble && bubble.dataset && bubble.dataset.reactChatMessageId) {
+                currentBubbleIds.push(bubble.dataset.reactChatMessageId);
+            }
+            if (typeof window.setReactMessageStatus === 'function') {
+                try {
+                    window.setReactMessageStatus(bubble, 'assistant', 'sent');
+                } catch (_) {}
+            }
+        });
+        if (currentBubbleIds.length > 0 && typeof window._clearPendingHostMessagesByIds === 'function') {
+            window._clearPendingHostMessagesByIds(currentBubbleIds);
+        }
+
+        window.currentGeminiMessage = null;
+        window.currentTurnGeminiBubbles = [];
+        window.realisticGeminiCurrentTurnId = null;
+        logAssistantLifecycle('stopAssistantTextOutputOnSessionEnd', {
+            source: source || 'session_end'
+        });
+    }
+
     window.addEventListener('neko-assistant-turn-start', clearPendingUserActivityCancel);
     window.addEventListener('neko-assistant-speech-start', clearPendingUserActivityCancel);
     window.addEventListener('neko-assistant-speech-cancel', clearPendingUserActivityCancel);
@@ -1548,6 +1589,10 @@
 
                 // -------- gemini_response --------
                 if (response.type === 'gemini_response') {
+                    if (S.suppressAssistantStreamUntilNextSession) {
+                        console.log('[App] discard assistant chunk after session ended by server');
+                        return;
+                    }
                     var isNewMessage = response.isNewMessage || false;
                     if (response.metadata && response.metadata.game_route) {
                         var gameMeta = response.metadata.game_route;
@@ -2610,6 +2655,11 @@
 
                 // -------- system turn end (agent_callback — no proactive chat) --------
                 } else if (response.type === 'system' && response.data === 'turn end agent_callback') {
+                    if (S.suppressAssistantStreamUntilNextSession) {
+                        console.log('[App] discard assistant turn_end after session ended by server');
+                        clearPendingAssistantTurnStart();
+                        return;
+                    }
                     if (window.reactChatWindowHost && typeof window.reactChatWindowHost.clearPendingRollbackDraft === 'function') {
                         window.reactChatWindowHost.clearPendingRollbackDraft(response.request_id);
                     }
@@ -2649,6 +2699,11 @@
 
                 // -------- system turn end --------
                 } else if (response.type === 'system' && response.data === 'turn end') {
+                    if (S.suppressAssistantStreamUntilNextSession) {
+                        console.log('[App] discard assistant turn_end after session ended by server');
+                        clearPendingAssistantTurnStart();
+                        return;
+                    }
                     if (window.reactChatWindowHost && typeof window.reactChatWindowHost.clearPendingRollbackDraft === 'function') {
                         window.reactChatWindowHost.clearPendingRollbackDraft(response.request_id);
                     }
@@ -2758,6 +2813,7 @@
                         return;
                     }
                     console.log(window.t('console.sessionStartedReceived'), response.input_mode);
+                    S.suppressAssistantStreamUntilNextSession = false;
                     S.isTextSessionActive = response.input_mode === 'text';
                     S.voiceChatActive = response.input_mode !== 'text';
                     S.voiceStartPending = false;
@@ -2880,6 +2936,7 @@
                     S.isTextSessionActive = false;
                     S.voiceChatActive = false;
                     S.voiceStartPending = false;
+                    stopAssistantTextOutputOnSessionEnd('session_ended_by_server');
                     clearAssistantLifecycleOnDisconnect('session_ended_by_server');
 
                     if (S.sessionStartedRejecter) {

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -228,6 +228,19 @@ def test_session_ended_by_server_stops_assistant_text_output():
         1,
     )[0]
 
+    discard_block = source.split("// -------- response_discarded --------", 1)[1].split(
+        "// -------- summary_response --------",
+        1,
+    )[0]
+    assert "if (S.suppressAssistantStreamUntilNextSession)" in discard_block
+    assert discard_block.index("if (S.suppressAssistantStreamUntilNextSession)") < discard_block.index(
+        "// Fallback: clear trailing gemini bubbles not tracked"
+    )
+    assert "return;" in discard_block.split("if (S.suppressAssistantStreamUntilNextSession)", 1)[1].split(
+        "emitAssistantSpeechCancel('response_discarded');",
+        1,
+    )[0]
+
     session_started_block = source.split("// -------- session_started --------", 1)[1].split(
         "// -------- session_failed --------",
         1,

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -187,6 +187,63 @@ def test_goodbye_blocks_stale_audio_session_started():
     assert "return;" in stale_audio_guard
 
 
+def test_session_ended_by_server_stops_assistant_text_output():
+    source = APP_WEBSOCKET_PATH.read_text(encoding="utf-8")
+
+    helper_block = source.split("function stopAssistantTextOutputOnSessionEnd(source)", 1)[1].split(
+        "window.addEventListener('neko-assistant-turn-start'",
+        1,
+    )[0]
+    assert "S.suppressAssistantStreamUntilNextSession = true;" in helper_block
+    assert "window._realisticGeminiVersion = (window._realisticGeminiVersion || 0) + 1;" in helper_block
+    assert "window._realisticGeminiQueue = [];" in helper_block
+    assert "window._realisticGeminiBuffer = '';" in helper_block
+    assert "window._geminiTurnFullText = '';" in helper_block
+    assert "window._isProcessingRealisticQueue = false;" in helper_block
+    assert "window._realisticProcessingOwner = null;" in helper_block
+    assert "window.setReactMessageStatus(bubble, 'assistant', 'sent');" in helper_block
+    assert "window._clearPendingHostMessagesByIds(currentBubbleIds);" in helper_block
+    assert "window.currentGeminiMessage = null;" in helper_block
+    assert "window.currentTurnGeminiBubbles = [];" in helper_block
+
+    session_ended_block = source.split("// -------- session_ended_by_server --------", 1)[1].split(
+        "// -------- reload_page --------",
+        1,
+    )[0]
+    assert "stopAssistantTextOutputOnSessionEnd('session_ended_by_server');" in session_ended_block
+    assert session_ended_block.index("stopAssistantTextOutputOnSessionEnd('session_ended_by_server');") < session_ended_block.index(
+        "clearAssistantLifecycleOnDisconnect('session_ended_by_server');"
+    )
+
+    gemini_block = source.split("// -------- gemini_response --------", 1)[1].split(
+        "// -------- response_discarded --------",
+        1,
+    )[0]
+    assert "if (S.suppressAssistantStreamUntilNextSession)" in gemini_block
+    assert gemini_block.index("if (S.suppressAssistantStreamUntilNextSession)") < gemini_block.index(
+        "window.appendMessage(response.text, 'gemini', isNewMessage)"
+    )
+    assert "return;" in gemini_block.split("if (S.suppressAssistantStreamUntilNextSession)", 1)[1].split(
+        "var isNewMessage",
+        1,
+    )[0]
+
+    session_started_block = source.split("// -------- session_started --------", 1)[1].split(
+        "// -------- session_failed --------",
+        1,
+    )[0]
+    assert "S.suppressAssistantStreamUntilNextSession = false;" in session_started_block
+
+    turn_end_block = source.split("// -------- system turn end --------", 1)[1].split(
+        "// AI turn_end 后只 reschedule",
+        1,
+    )[0]
+    assert "if (S.suppressAssistantStreamUntilNextSession)" in turn_end_block
+    assert turn_end_block.index("if (S.suppressAssistantStreamUntilNextSession)") < turn_end_block.index(
+        "flushRealisticBufferOnTurnEnd();"
+    )
+
+
 def test_ws_open_resyncs_goodbye_state_and_defers_regular_greeting_until_release():
     source = APP_WEBSOCKET_PATH.read_text(encoding="utf-8")
 

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 
 APP_WEBSOCKET_PATH = Path(__file__).resolve().parents[2] / "static" / "app-websocket.js"
+APP_STATE_PATH = Path(__file__).resolve().parents[2] / "static" / "app-state.js"
 
 
 def test_response_discarded_visible_in_react_chat():
@@ -189,7 +190,9 @@ def test_goodbye_blocks_stale_audio_session_started():
 
 def test_session_ended_by_server_stops_assistant_text_output():
     source = APP_WEBSOCKET_PATH.read_text(encoding="utf-8")
+    app_state = APP_STATE_PATH.read_text(encoding="utf-8")
 
+    assert "suppressAssistantStreamUntilNextSession: false," in app_state
     helper_block = source.split("function stopAssistantTextOutputOnSessionEnd(source)", 1)[1].split(
         "window.addEventListener('neko-assistant-turn-start'",
         1,

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -206,6 +206,15 @@ def test_session_ended_by_server_stops_assistant_text_output():
     assert "window.currentGeminiMessage = null;" in helper_block
     assert "window.currentTurnGeminiBubbles = [];" in helper_block
 
+    rollback_helper = source.split("function clearPendingRollbackForRequest(requestId)", 1)[1].split(
+        "function isNewUserIcebreakerMirrorTurnEnd(response)",
+        1,
+    )[0]
+    assert "window.reactChatWindowHost.clearPendingRollbackDraft(requestId);" in rollback_helper
+    assert "window._lastSubmittedRequestId === requestId" in rollback_helper
+    assert "window._lastSubmittedText = '';" in rollback_helper
+    assert "window._lastSubmittedRequestId = '';" in rollback_helper
+
     session_ended_block = source.split("// -------- session_ended_by_server --------", 1)[1].split(
         "// -------- reload_page --------",
         1,
@@ -247,6 +256,18 @@ def test_session_ended_by_server_stops_assistant_text_output():
     )[0]
     assert "S.suppressAssistantStreamUntilNextSession = false;" in session_started_block
 
+    agent_callback_turn_end_block = source.split("// -------- system turn end (agent_callback", 1)[1].split(
+        "// -------- system turn end --------",
+        1,
+    )[0]
+    assert "if (S.suppressAssistantStreamUntilNextSession)" in agent_callback_turn_end_block
+    assert agent_callback_turn_end_block.index("if (S.suppressAssistantStreamUntilNextSession)") < agent_callback_turn_end_block.index(
+        "flushRealisticBufferOnTurnEnd();"
+    )
+    assert agent_callback_turn_end_block.index("clearPendingRollbackForRequest(response.request_id);") < agent_callback_turn_end_block.index(
+        "clearPendingAssistantTurnStart();"
+    )
+
     turn_end_block = source.split("// -------- system turn end --------", 1)[1].split(
         "// AI turn_end 后只 reschedule",
         1,
@@ -254,6 +275,9 @@ def test_session_ended_by_server_stops_assistant_text_output():
     assert "if (S.suppressAssistantStreamUntilNextSession)" in turn_end_block
     assert turn_end_block.index("if (S.suppressAssistantStreamUntilNextSession)") < turn_end_block.index(
         "flushRealisticBufferOnTurnEnd();"
+    )
+    assert turn_end_block.index("clearPendingRollbackForRequest(response.request_id);") < turn_end_block.index(
+        "clearPendingAssistantTurnStart();"
     )
 
 

--- a/tests/unit/test_character_persona_router.py
+++ b/tests/unit/test_character_persona_router.py
@@ -718,6 +718,72 @@ async def test_clear_character_persona_selection_closes_original_session_when_re
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_update_catgirl_voice_id_ends_active_session_without_reload_page():
+    with TemporaryDirectory() as td:
+        config_manager = _make_config_manager(Path(td))
+        bootstrap_local_cloudsave_environment(config_manager)
+
+        async def _noop(*args, **kwargs):
+            return None
+
+        current_name = config_manager.load_characters()["当前猫娘"]
+        characters = config_manager.load_characters()
+        characters["猫娘"][current_name].setdefault("_reserved", {})["voice_id"] = "old-voice"
+        config_manager.save_characters(characters)
+
+        current_session = SimpleNamespace(
+            is_active=True,
+            websocket=object(),
+            session=object(),
+            end_session=AsyncMock(),
+            send_session_ended_by_server=AsyncMock(),
+            reset_session_start_circuit=Mock(),
+        )
+        role_state = {
+            current_name: SimpleNamespace(session_manager=current_session),
+        }
+        init_one_catgirl = AsyncMock()
+
+        with patch("utils.config_manager._config_manager", config_manager), patch.object(
+            config_manager,
+            "validate_voice_id",
+            return_value=True,
+        ), patch.object(
+            config_manager,
+            "voice_id_to_storage_value",
+            side_effect=lambda voice_id: voice_id,
+        ):
+            init_shared_state(
+                role_state=role_state,
+                steamworks=None,
+                templates=None,
+                config_manager=config_manager,
+                logger=None,
+                initialize_character_data=_noop,
+                switch_current_catgirl_fast=_noop,
+                init_one_catgirl=init_one_catgirl,
+                remove_one_catgirl=_noop,
+            )
+
+            router_module = importlib.reload(importlib.import_module("main_routers.characters_router"))
+            with patch.object(router_module, "send_reload_page_notice", AsyncMock(return_value=True)) as reload_notice:
+                result = await router_module.update_catgirl_voice_id(
+                    current_name,
+                    _DummyRequest({"voice_id": "new-voice"}),
+                )
+
+        assert result == {"success": True, "session_restarted": True, "voice_id_changed": True}
+        reload_notice.assert_not_awaited()
+        current_session.send_session_ended_by_server.assert_awaited_once_with()
+        current_session.end_session.assert_awaited_once_with(by_server=True)
+        current_session.reset_session_start_circuit.assert_called_once_with()
+        init_one_catgirl.assert_awaited_once_with(current_name, is_new=False)
+        saved_characters = config_manager.load_characters()
+        assert saved_characters["猫娘"][current_name]["_reserved"]["voice_id"] == "new-voice"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_update_catgirl_profile_fields_refreshes_active_context():
     with TemporaryDirectory() as td:
         config_manager = _make_config_manager(Path(td))

--- a/tests/unit/test_voice_start_failure_static.py
+++ b/tests/unit/test_voice_start_failure_static.py
@@ -335,7 +335,9 @@ def test_voice_preparing_toast_ignores_module_object_messages():
     normalizer = _js_function_block(source, "normalizeVoiceToastMessage")
     toast = _js_function_block(source, "showVoicePreparingToast")
 
-    assert "window.safeT('app.voiceSystemPreparing'" in normalizer
+    assert "fallbackKey = 'app.voiceSystemPreparing'" in normalizer
+    assert "window.safeT('app.voiceSystemPreparing'" not in normalizer
+    assert "translatedFallback.trim() !== fallbackKey" in normalizer
     assert "text === '[object Module]'" in normalizer
     assert "text === '[object Object]'" in normalizer
     assert "window.translateStatusMessage(message)" in normalizer
@@ -351,7 +353,9 @@ def test_outer_voice_start_failure_uses_sanitized_toast_message():
     assert len(catch_split) == 2, "missing outer catch in mic button start flow"
     failure = catch_split[1]
 
-    assert "window.safeT('app.sessionFailed'" in normalizer
+    assert "fallbackKey = 'app.sessionFailed'" in normalizer
+    assert "window.safeT('app.sessionFailed'" not in normalizer
+    assert "translatedFallback.trim() !== fallbackKey" in normalizer
     assert "text === '[object Module]'" in normalizer
     assert "text === '[object Object]'" in normalizer
     assert "window.translateStatusMessage(error)" in normalizer

--- a/tests/unit/test_voice_start_failure_static.py
+++ b/tests/unit/test_voice_start_failure_static.py
@@ -330,6 +330,38 @@ def test_outer_voice_start_failure_clears_pending_flags_before_composer_restore(
     assert failure.index("S.voiceChatActive = false;") < failure.index(sync_call)
 
 
+def test_voice_preparing_toast_ignores_module_object_messages():
+    source = _read(APP_UI_PATH)
+    normalizer = _js_function_block(source, "normalizeVoiceToastMessage")
+    toast = _js_function_block(source, "showVoicePreparingToast")
+
+    assert "window.safeT('app.voiceSystemPreparing'" in normalizer
+    assert "text === '[object Module]'" in normalizer
+    assert "text === '[object Object]'" in normalizer
+    assert "window.translateStatusMessage(message)" in normalizer
+    assert "msgSpan.textContent = normalizeVoiceToastMessage(message);" in toast
+    assert "msgSpan.textContent = message;" not in toast
+
+
+def test_outer_voice_start_failure_uses_sanitized_toast_message():
+    source = _read(APP_BUTTONS_PATH)
+    normalizer = _js_function_block(source, "getVoiceStartErrorMessage")
+    start_flow = _mic_button_start_flow(source)
+    catch_split = start_flow.split("} catch (error) {", 1)
+    assert len(catch_split) == 2, "missing outer catch in mic button start flow"
+    failure = catch_split[1]
+
+    assert "window.safeT('app.sessionFailed'" in normalizer
+    assert "text === '[object Module]'" in normalizer
+    assert "text === '[object Object]'" in normalizer
+    assert "window.translateStatusMessage(error)" in normalizer
+    assert "var voiceStartErrorMessage = getVoiceStartErrorMessage(error);" in failure
+    assert "window.showVoicePreparingToast(voiceStartErrorMessage);" in failure
+    assert "window.showStatusToast(voiceStartErrorMessage, 5000);" in failure
+    assert "window.showVoicePreparingToast(error.message)" not in failure
+    assert "window.showStatusToast(error.message, 5000)" not in failure
+
+
 def test_floating_mic_stale_active_state_reenters_main_voice_start_lifecycle():
     source = _read(APP_UI_PATH)
     listeners = _js_function_block(source, "initFloatingButtonListeners")


### PR DESCRIPTION
…配置；同时修复 [object Module] 语音提示兜底，并在音色切换结束 session 时立即停止聊天框中正在流式输出的旧回复

<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复反复切换音色并启动语音时 Electron 卡死的问题

## 回归报告 / Regression Report

改动了什么
修改了 main_routers/characters_router.py  中音色相关路径：设置 voice_id、清空角色音色、通用角色更新里的 voice_id 变更、删除正在使用的音色时，不再发送 reload_page，改为发送已有的 session_ended_by_server，随后 end_session(by_server=True)、清 session 启动熔断，并用 init_one_catgirl() / initialize_character_data() 刷新后端角色配置。

理由 / 必要性
原来切换音色会触发 Electron 整页刷新。用户高频执行“切音色 -> 说话 -> 再切音色 -> 再说话”时，页面 reload、WebSocket、语音 session、音频队列、前端音色切换等待状态会叠在一起，导致 Electron renderer 卡死。音色变更本质只需要让当前语音 session 结束并让下一次 session 读取新 voice_id，不需要整页刷新。

改动前后的表现对比
改动前：音色变化时后端发 reload_page，前端 2.5 秒后 window.location.reload()，反复操作容易卡死；刷新也会粗暴打断聊天输出。
改动后：音色变化时前端收到 session_ended_by_server，语音 UI、录音、音频队列和当前聊天文本输出都会收口；页面不刷新，下一次启动语音时使用新音色。

潜在回归点  
音色更新是否真的生效：依赖 init_one_catgirl() 更新当前 session_manager.voice_id，以及下一次 start_session 重新读取配置。  
语音 UI 是否能正确复位：依赖前端 session_ended_by_server 路径恢复按钮、输入框、录音和音频队列。  
人格/角色设定 reload 是否被误伤：这些路径仍保留 send_reload_page_notice()，未改成 session-only。  
音色切换期间旧回复是否继续输出：前端已补 stopAssistantTextOutputOnSessionEnd() 阻止旧 gemini_response 继续进入聊天框。  
少用路径文案/行为：部分 voice clone 页面仍有“页面即将刷新”的旧文案，角色管理页内嵌克隆音色保存路径仍有手动 location.reload()，但普通音色切换路径不受影响。

## 测试 / Testing

手动测试切换


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化语音会话在更换/清空/删除语音时的收口：避免不必要的整页刷新；在会话结束时优先走更平滑的结束通知流程，并完成会话熔断重置。
  * 统一并净化“语音启动失败/准备中”提示文案：从异常/非预期结构中提取可展示文本，避免空白或“[object Object]”类内容。
  * 会话结束后阻断后续助手文本流：在关键分发与 turn 结束阶段提前终止输出并清理相关状态。
* **Tests**
  * 新增单测与静态校验：覆盖会话结束阻断、voice_id 更新不触发刷新，以及 toast 文案归一化/净化逻辑。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->