### PR TITLE
猫玩毛线球动作结束时带出释放事件和猫旁落点信息

### DIFF
--- a/plugin/plugins/study_companion/__init__.py
+++ b/plugin/plugins/study_companion/__init__.py
@@ -563,7 +563,9 @@ class StudyCompanionPlugin(
             window_seconds=self._cfg.awareness.context_window_minutes * 60,
             snapshot_interval=self._cfg.awareness.snapshot_interval_seconds,
         )
-        self._last_awareness_push_at = 0.0
+        self._last_awareness_push_at = (
+            time.monotonic() - float(self._cfg.awareness.push_to_llm_interval_seconds)
+        )
         self._awareness_idle_ticks = 0
         self._consecutive_os_read_failures = 0
         self._awareness_task = asyncio.create_task(self._run_awareness_loop())

--- a/plugin/tests/unit/plugins/test_study_companion.py
+++ b/plugin/tests/unit/plugins/test_study_companion.py
@@ -573,6 +573,34 @@ async def test_start_awareness_loop_runs_async_tick_and_pushes_context(
 
 
 @pytest.mark.asyncio
+async def test_start_awareness_loop_primes_first_push_before_uptime_interval(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin = StudyCompanionPlugin(
+        _Ctx(tmp_path, {"study": {"language": "en", "auto_open_ui": False}})
+    )
+    plugin._cfg = StudyConfig(
+        awareness=AwarenessConfig(
+            enabled=True,
+            snapshot_interval_seconds=60,
+            push_to_llm_mode="read",
+            os_signals_enabled=False,
+        )
+    )
+    plugin._ocr_pipeline = object()
+    monkeypatch.setattr(study_companion_module.time, "monotonic", lambda: 10.0)
+
+    plugin.start_awareness_loop()
+    try:
+        assert plugin._last_awareness_push_at == pytest.approx(-290.0)
+        assert plugin._should_push_context() is True
+    finally:
+        plugin.stop_awareness_loop()
+        await plugin._await_awareness_stop()
+
+
+@pytest.mark.asyncio
 async def test_awareness_tick_counts_unusable_snapshot_as_idle(tmp_path: Path) -> None:
     class _NoActivitySnapshot:
         status = "ok"

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -990,6 +990,43 @@
         showIdleCat1CompactMirror(detail);
     }
 
+    function getIdleCat1PlayYarnReleaseTargetRect(detail) {
+        if (!detail || typeof detail !== 'object') return null;
+        var target = normalizeCompactDesktopRect(detail.targetRect);
+        if (target || isElectronChatWindow()) return target;
+        var screenTarget = normalizeCompactDesktopRect(detail.targetScreenRect);
+        if (!screenTarget) return null;
+        var screenX = Number.isFinite(Number(window.screenX)) ? Number(window.screenX) : Number(window.screenLeft);
+        var screenY = Number.isFinite(Number(window.screenY)) ? Number(window.screenY) : Number(window.screenTop);
+        if (!Number.isFinite(screenX) || !Number.isFinite(screenY)) return null;
+        return normalizeCompactDesktopRect({
+            left: screenTarget.left - screenX,
+            top: screenTarget.top - screenY,
+            width: screenTarget.width,
+            height: screenTarget.height
+        });
+    }
+
+    function applyIdleCat1PlayYarnRelease(detail) {
+        if (!detail || !detail.releaseDrag) return;
+        if (dragState) {
+            stopDrag({ suppressClick: true });
+        }
+        if (isElectronChatWindow()) return;
+        var shell = getShell();
+        if (!shell || !shell.classList || !shell.classList.contains('is-minimized')) return;
+        var target = getIdleCat1PlayYarnReleaseTargetRect(detail);
+        if (!target) return;
+        var shellRect = shell.getBoundingClientRect();
+        var width = shellRect && shellRect.width > 0 ? shellRect.width : MINIMIZED_SIZE;
+        var height = shellRect && shellRect.height > 0 ? shellRect.height : MINIMIZED_SIZE;
+        applyPosition(
+            target.left + target.width / 2 - width / 2,
+            target.top + target.height / 2 - height / 2
+        );
+        syncCompactInteractionGeometry();
+    }
+
     function handleIdleCat1PlayYarnVisibility(event) {
         var detail = event && event.detail && typeof event.detail === 'object' ? event.detail : null;
         var hidden = !!(detail && detail.hidden);
@@ -1003,10 +1040,17 @@
                 syncCompactInteractionGeometry();
             }
         }
+        if (!hidden) {
+            applyIdleCat1PlayYarnRelease(detail);
+        }
         var bridge = window.nekoChatWindow;
         if (bridge && typeof bridge.setCompactChatBallTemporarilyHidden === 'function') {
             try {
-                bridge.setCompactChatBallTemporarilyHidden(hidden);
+                bridge.setCompactChatBallTemporarilyHidden(hidden, {
+                    releaseDrag: !!(detail && detail.releaseDrag),
+                    targetScreenRect: detail && detail.targetScreenRect ? detail.targetScreenRect : null,
+                    releaseReason: detail && detail.releaseReason ? detail.releaseReason : ''
+                });
             } catch (_) {}
         }
     }

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -992,19 +992,20 @@
 
     function getIdleCat1PlayYarnReleaseTargetRect(detail) {
         if (!detail || typeof detail !== 'object') return null;
-        var target = normalizeCompactDesktopRect(detail.targetRect);
-        if (target || isElectronChatWindow()) return target;
         var screenTarget = normalizeCompactDesktopRect(detail.targetScreenRect);
-        if (!screenTarget) return null;
-        var screenX = Number.isFinite(Number(window.screenX)) ? Number(window.screenX) : Number(window.screenLeft);
-        var screenY = Number.isFinite(Number(window.screenY)) ? Number(window.screenY) : Number(window.screenTop);
-        if (!Number.isFinite(screenX) || !Number.isFinite(screenY)) return null;
-        return normalizeCompactDesktopRect({
-            left: screenTarget.left - screenX,
-            top: screenTarget.top - screenY,
-            width: screenTarget.width,
-            height: screenTarget.height
-        });
+        if (screenTarget && !isElectronChatWindow()) {
+            var screenX = Number.isFinite(Number(window.screenX)) ? Number(window.screenX) : Number(window.screenLeft);
+            var screenY = Number.isFinite(Number(window.screenY)) ? Number(window.screenY) : Number(window.screenTop);
+            if (Number.isFinite(screenX) && Number.isFinite(screenY)) {
+                return normalizeCompactDesktopRect({
+                    left: screenTarget.left - screenX,
+                    top: screenTarget.top - screenY,
+                    width: screenTarget.width,
+                    height: screenTarget.height
+                });
+            }
+        }
+        return normalizeCompactDesktopRect(detail.targetRect);
     }
 
     function applyIdleCat1PlayYarnRelease(detail) {

--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -998,14 +998,79 @@ function _setNekoIdleCat1PlayActionClass(button, active) {
     }
 }
 
-function _postNekoIdleCat1PlayYarnVisibilityState(hidden) {
-    const message = {
+function _normalizeNekoIdleRectForMessage(rect) {
+    if (!rect) return null;
+    const left = Math.round(Number(rect.left));
+    const top = Math.round(Number(rect.top));
+    const width = Math.round(Number(rect.width));
+    const height = Math.round(Number(rect.height));
+    if (![left, top, width, height].every(Number.isFinite) || width <= 0 || height <= 0) return null;
+    return {
+        left,
+        top,
+        width,
+        height,
+        right: Math.round(Number.isFinite(Number(rect.right)) ? Number(rect.right) : left + width),
+        bottom: Math.round(Number.isFinite(Number(rect.bottom)) ? Number(rect.bottom) : top + height)
+    };
+}
+
+function _getNekoIdleScreenOffset() {
+    const x = Number.isFinite(Number(window.screenX)) ? Number(window.screenX) : Number(window.screenLeft);
+    const y = Number.isFinite(Number(window.screenY)) ? Number(window.screenY) : Number(window.screenTop);
+    if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+    return { x, y };
+}
+
+function _getNekoIdleCat1PlayYarnReleasePayload(button, state, reason) {
+    const payload = {
+        releaseDrag: true,
+        releaseReason: reason || 'cat1-play-action-finished'
+    };
+    const container = _getNekoIdleReturnContainerFromButton(button);
+    const rect = container && typeof container.getBoundingClientRect === 'function'
+        ? container.getBoundingClientRect()
+        : null;
+    if (!rect || rect.width <= 0 || rect.height <= 0) return payload;
+
+    const ballSize = 58;
+    const gap = 12;
+    const facingRight = state && typeof state.releaseFacingRight === 'boolean'
+        ? state.releaseFacingRight
+        : !!(button && button.classList && button.classList.contains('is-cat1-facing-right'));
+    const left = facingRight ? rect.right + gap : rect.left - ballSize - gap;
+    const top = rect.top + rect.height * 0.58 - ballSize / 2;
+    const maxLeft = Math.max(0, window.innerWidth - ballSize);
+    const maxTop = Math.max(0, window.innerHeight - ballSize);
+    const targetRect = _normalizeNekoIdleRectForMessage({
+        left: Math.max(0, Math.min(left, maxLeft)),
+        top: Math.max(0, Math.min(top, maxTop)),
+        width: ballSize,
+        height: ballSize
+    });
+    if (!targetRect) return payload;
+    payload.targetRect = targetRect;
+
+    const screenOffset = _getNekoIdleScreenOffset();
+    if (screenOffset) {
+        payload.targetScreenRect = _normalizeNekoIdleRectForMessage({
+            left: targetRect.left + screenOffset.x,
+            top: targetRect.top + screenOffset.y,
+            width: targetRect.width,
+            height: targetRect.height
+        });
+    }
+    return payload;
+}
+
+function _postNekoIdleCat1PlayYarnVisibilityState(hidden, detail = {}) {
+    const message = Object.assign({}, detail && typeof detail === 'object' ? detail : {}, {
         action: 'idle_cat1_play_yarn_visibility',
         source: 'pet-window',
         lanlan_name: _getNekoIdleCurrentLanlanName(),
         hidden: !!hidden,
         timestamp: Date.now()
-    };
+    });
     try {
         window.dispatchEvent(new CustomEvent('neko:idle-cat1-play-yarn-visibility', {
             detail: Object.assign({ via: 'local' }, message)
@@ -1022,7 +1087,7 @@ function _postNekoIdleCat1PlayYarnVisibilityState(hidden) {
     }
 }
 
-function _setNekoIdleCat1PlayYarnHidden(state, hidden) {
+function _setNekoIdleCat1PlayYarnHidden(state, hidden, detail = {}) {
     if (!state) return;
     if (hidden) {
         if (state.yarnHidden) return;
@@ -1043,7 +1108,7 @@ function _setNekoIdleCat1PlayYarnHidden(state, hidden) {
         shell.removeAttribute('data-neko-cat1-play-hidden');
     }
     if (wasHidden) {
-        _postNekoIdleCat1PlayYarnVisibilityState(false);
+        _postNekoIdleCat1PlayYarnVisibilityState(false, detail);
     }
 }
 
@@ -1086,7 +1151,11 @@ function _cancelNekoIdleCat1PlayAction(button, options = {}) {
     _clearNekoIdleCat1PlayActionTimers(state);
     _stopNekoIdleSoundAudio(state);
     _setNekoIdleCat1PlayActionClass(button, false);
-    _setNekoIdleCat1PlayYarnHidden(state, false);
+    _setNekoIdleCat1PlayYarnHidden(
+        state,
+        false,
+        _getNekoIdleCat1PlayYarnReleasePayload(button, state, options.reason || 'cat1-play-action-cancelled')
+    );
     _restoreNekoIdleCat1PlayActionArt(button, state, options);
     state.resumeJourney = false;
     if (wasActive && options.restoreArt !== false) {
@@ -1139,6 +1208,9 @@ function _playNekoIdleCat1PlayAction(button) {
     state.active = true;
     state.token += 1;
     state.resumeJourney = shouldResumeJourney;
+    state.releaseFacingRight = journey && typeof journey.facingRight === 'boolean'
+        ? journey.facingRight
+        : !!(button.classList && button.classList.contains('is-cat1-facing-right'));
     const token = state.token;
     const startedAt = Date.now();
     let gifDone = false;

--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -266,6 +266,7 @@ const _NEKO_IDLE_DESKTOP_COMPACT_SURFACE_RECT_STALE_MS = 10 * 1000;
 const _NEKO_IDLE_RETURN_DRAG_PENDING_CLASS = 'is-drag-action-pending';
 const _NEKO_IDLE_RETURN_DRAG_ACTION_CLASS = 'is-drag-action';
 const _NEKO_IDLE_CAT1_PLAY_FINISHING_ATTR = 'data-neko-cat1-play-finishing';
+const _NEKO_IDLE_CAT1_PLAY_YARN_RELEASE_SIZE_PX = 51;
 const _NEKO_IDLE_CAT1_RAPID_DRAG_ASSET_URL = '/static/assets/neko-idle/cat-idle-cat-move-5.gif';
 const _NEKO_IDLE_CAT1_RAPID_DRAG_SOUND_URL = '/static/assets/neko-idle/cat1-voice-funny.mp3';
 const _NEKO_IDLE_CAT1_RAPID_DRAG_REACTION_MS = 5000;
@@ -1033,7 +1034,7 @@ function _getNekoIdleCat1PlayYarnReleasePayload(button, state, reason) {
         : null;
     if (!rect || rect.width <= 0 || rect.height <= 0) return payload;
 
-    const ballSize = 58;
+    const ballSize = _NEKO_IDLE_CAT1_PLAY_YARN_RELEASE_SIZE_PX;
     const gap = 12;
     const facingRight = state && typeof state.releaseFacingRight === 'boolean'
         ? state.releaseFacingRight

--- a/tests/unit/test_avatar_return_button_cat1_static.py
+++ b/tests/unit/test_avatar_return_button_cat1_static.py
@@ -74,13 +74,19 @@ def test_cat1_play_action_module_is_independent_from_eat_action():
     assert "art.setAttribute(_NEKO_IDLE_CAT1_PLAY_FINISHING_ATTR, 'true');" in finish_play_block
     assert "art.removeAttribute(_NEKO_IDLE_CAT1_PLAY_FINISHING_ATTR);" in source
     assert "_setNekoIdleCat1PlayYarnHidden(state, true);" in play_block
-    assert "_setNekoIdleCat1PlayYarnHidden(state, false);" in source
+    assert "_getNekoIdleCat1PlayYarnReleasePayload(button, state" in source
+    assert "_setNekoIdleCat1PlayYarnHidden(" in source
+    assert "_NEKO_IDLE_CAT1_PLAY_YARN_RELEASE_SIZE_PX = 51" in source
     assert "data-neko-cat1-play-hidden" in source
     assert "idle_cat1_play_yarn_visibility" in source
+    assert "targetScreenRect" in source
     assert "idle_cat1_play_yarn_visibility" in interpage_source
     assert "dispatchIdleCat1PlayYarnVisibility(event.data)" in interpage_source
     assert "neko:idle-cat1-play-yarn-visibility" in chat_source
-    assert "setCompactChatBallTemporarilyHidden(hidden)" in chat_source
+    assert "setCompactChatBallTemporarilyHidden(hidden, {" in chat_source
+    assert "releaseDrag: !!(detail && detail.releaseDrag)" in chat_source
+    assert "targetScreenRect: detail && detail.targetScreenRect" in chat_source
+    assert "applyIdleCat1PlayYarnRelease(detail)" in chat_source
     assert "showCompactChatBall(" not in chat_source
     assert "hideCompactChatBall(" not in chat_source
 


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

猫玩毛线球动作结束时带出释放事件和猫旁落点信息

## 测试 / Testing

手动测试猫咪形态


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 优化猫咪“玩毛线”释放/恢复时的定位与几何同步，回到更精确的目标区域。
  * 增强跨窗口通信携带释放细节（如释放拖拽与目标屏幕矩形），提升交互衔接体验。
* **Bug Fixes**
  * 修复最小化/收起后恢复位置不准确的问题。
  * 改进取消交互时的隐藏/释放处理，减少状态错位与误触发。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->