### PR TITLE
修复插件管理页刷新前后顶部工具栏布局不一致的问题，固定为默认两排行为，并提前加载插件市场入口状态，避免市场/登录按钮延迟出现导致 UI 抖动

### DIFF
--- a/frontend/plugin-manager/src/views/PluginList.vue
+++ b/frontend/plugin-manager/src/views/PluginList.vue
@@ -660,6 +660,19 @@ function closeDangerDialog() {
   pendingDangerPlugin.value = null
 }
 
+async function loadMarketEntry() {
+  try {
+    const res = await fetch('/market/status')
+    if (!res.ok) return
+    const data = await res.json()
+    if (!data.market_url) return
+    marketUrl.value = data.market_url
+    loadMarketAuthStatus().catch(() => {})
+  } catch {
+    // Market is optional; keep the local plugin list usable if it is absent.
+  }
+}
+
 function openDangerDialog(
   action: ResolvedPluginListAction,
   plugin: PluginMeta & { status?: string; enabled?: boolean; autoStart?: boolean },
@@ -1052,20 +1065,9 @@ watch(packagePanelVisible, (visible) => {
 
 onMounted(async () => {
   window.addEventListener(TUTORIAL_ACTION_EVENT, handleTutorialAction)
+  const marketEntryPromise = loadMarketEntry()
   await handleRefresh()
-  // 获取 Market URL（用于显示"获取新插件"入口）
-  try {
-    const res = await fetch('/market/status')
-    if (res.ok) {
-      const data = await res.json()
-      if (data.market_url) {
-        marketUrl.value = data.market_url
-        loadMarketAuthStatus().catch(() => {})
-      }
-    }
-  } catch {
-    // 静默失败
-  }
+  await marketEntryPromise
 })
 
 onUnmounted(() => {
@@ -1162,9 +1164,9 @@ onUnmounted(() => {
 
 .workbench-header {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: flex-start;
   gap: 10px;
 }
 
@@ -1625,7 +1627,8 @@ onUnmounted(() => {
   gap: 8px;
   align-items: center;
   flex-wrap: wrap;
-  justify-content: flex-end;
+  justify-content: flex-start;
+  width: 100%;
   flex: 0 1 auto;
   min-width: 0;
 }

--- a/frontend/plugin-manager/src/views/PluginList.vue
+++ b/frontend/plugin-manager/src/views/PluginList.vue
@@ -361,6 +361,7 @@ import type {
   GroupChoiceDescriptor,
   LayoutChoiceDescriptor,
 } from '@/composables/workbenchDescriptors'
+import { getMarketUrl } from '@/api/market'
 import { reloadAllPlugins, deletePlugin } from '@/api/plugins'
 import { uploadAndInstallPlugin, buildPluginCli, downloadPluginPackage } from '@/api/pluginCli'
 import { usePluginListContextActions, type ResolvedPluginListAction } from '@/composables/usePluginListContextActions'
@@ -662,11 +663,9 @@ function closeDangerDialog() {
 
 async function loadMarketEntry() {
   try {
-    const res = await fetch('/market/status')
-    if (!res.ok) return
-    const data = await res.json()
-    if (!data.market_url) return
-    marketUrl.value = data.market_url
+    const url = await getMarketUrl()
+    if (!url) return
+    marketUrl.value = url
     loadMarketAuthStatus().catch(() => {})
   } catch {
     // Market is optional; keep the local plugin list usable if it is absent.
@@ -1065,9 +1064,7 @@ watch(packagePanelVisible, (visible) => {
 
 onMounted(async () => {
   window.addEventListener(TUTORIAL_ACTION_EVENT, handleTutorialAction)
-  const marketEntryPromise = loadMarketEntry()
-  await handleRefresh()
-  await marketEntryPromise
+  await Promise.all([loadMarketEntry(), handleRefresh()])
 })
 
 onUnmounted(() => {


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复插件管理页刷新前后顶部工具栏布局不一致的问题

## 测试 / Testing

手动测试插件页面


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 插件列表页会自动尝试获取市场入口信息，并在可用时更新市场状态。
  * 刷新插件列表时，市场入口加载与列表刷新改为并行执行，提升响应速度。

* **Bug 修复**
  * 当市场地址或状态不可用、请求失败时，不影响本地插件列表的正常展示（静默降级）。
  * 页面头部布局调整为纵向堆叠，操作区对齐更稳定，适配窄宽场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->