### PR TITLE
修复离开再回来后发送聊天框图片误触发语音/实时视觉模式的问题。将聊天框导入、粘贴、历史拖入的图片按 user_image 发送，保留真实截…

### DIFF
--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -755,6 +755,14 @@
         }).filter(Boolean);
     };
 
+    function getPendingAttachmentInputType(item) {
+        var source = item && item.dataset ? String(item.dataset.source || '') : '';
+        if (source === 'user-image' || source === 'clipboard-image' || source === 'compact-history' || source === 'user') {
+            return 'user_image';
+        }
+        return U.isMobile() ? 'camera' : 'screen';
+    }
+
     mod.syncPendingComposerAttachments = function syncPendingComposerAttachments() {
         if (window.reactChatWindowHost && typeof window.reactChatWindowHost.setComposerAttachments === 'function') {
             window.reactChatWindowHost.setComposerAttachments(mod.getPendingComposerAttachments());
@@ -807,7 +815,7 @@
 
         return mod.normalizeImageBlobForPendingList(file)
             .then(function (dataUrl) {
-                mod.addScreenshotToList(dataUrl);
+                mod.addScreenshotToList(dataUrl, null, { source: 'user-image' });
                 return dataUrl;
             });
     };
@@ -2751,7 +2759,7 @@
                                 var msg = {
                                     action: 'stream_data',
                                     data: img.src,
-                                    input_type: U.isMobile() ? 'camera' : 'screen'
+                                    input_type: getPendingAttachmentInputType(screenshotItems[i])
                                 };
                                 if (text) {
                                     msg.request_id = requestId;
@@ -3616,7 +3624,7 @@
                     if (!blob) continue;
                     mod.normalizeImageBlobForPendingList(blob)
                         .then(function (dataUrl) {
-                            mod.addScreenshotToList(dataUrl);
+                            mod.addScreenshotToList(dataUrl, null, { source: 'clipboard-image' });
                             window.showStatusToast(
                                 window.t ? window.t('app.screenshotAdded') : '\u622A\u56FE\u5DF2\u6DFB\u52A0\uFF0C\u70B9\u51FB\u53D1\u9001\u4E00\u8D77\u53D1\u9001',
                                 3000

--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -757,7 +757,7 @@
 
     function getPendingAttachmentInputType(item) {
         var source = item && item.dataset ? String(item.dataset.source || '') : '';
-        if (source === 'user-image' || source === 'clipboard-image' || source === 'compact-history' || source === 'user') {
+        if (source === 'user-image' || source === 'clipboard-image' || source === 'compact-history') {
             return 'user_image';
         }
         return U.isMobile() ? 'camera' : 'screen';

--- a/tests/frontend/test_chat_user_message_dedup.py
+++ b/tests/frontend/test_chat_user_message_dedup.py
@@ -239,6 +239,78 @@ def test_import_image_without_mime_converts_to_jpeg_attachment(
 
 
 @pytest.mark.frontend
+def test_imported_chat_image_sends_as_user_image_when_text_session_restarts(
+    mock_page: Page,
+    running_server: str,
+):
+    mock_page.add_init_script(
+        "window.localStorage.setItem('neko_tutorial_settings', 'seen')"
+    )
+    mock_page.goto(f"{running_server}/chat", wait_until="domcontentloaded")
+    mock_page.wait_for_function(
+        "() => window.reactChatWindowHost"
+        " && window.appButtons"
+        " && window.appChat"
+        " && window.appState"
+        " && typeof window.sendTextPayload === 'function'"
+    )
+    _install_chat_send_harness(mock_page, resolve_delay_ms=0)
+
+    result = mock_page.evaluate(
+        """async () => {
+            const b64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO9Wj3sAAAAASUVORK5CYII=';
+            const bytes = Uint8Array.from(atob(b64), (char) => char.charCodeAt(0));
+            const file = new File([bytes], 'tiny-image.png', { type: 'image/png' });
+
+            await window.appButtons.importImageFilesToPendingList([file]);
+            window.appState.isTextSessionActive = false;
+            window.appState.voiceChatActive = false;
+
+            const ok = await window.sendTextPayload('', {
+                source: 'react-chat-window',
+                requestId: 'req-imported-image-only'
+            });
+
+            const state = window.reactChatWindowHost.getState();
+            return {
+                ok,
+                attachmentCount: state.composerAttachments.length,
+                message: state.messages[0] ? {
+                    status: state.messages[0].status,
+                    blocks: state.messages[0].blocks
+                } : null,
+                sentPayloads: window.__chatTest.sentPayloads
+            };
+        }"""
+    )
+
+    assert result["ok"] is True
+    assert result["attachmentCount"] == 0
+    start_sessions = [
+        payload
+        for payload in result["sentPayloads"]
+        if payload.get("action") == "start_session"
+    ]
+    assert start_sessions[-1]["input_type"] == "text"
+
+    sent_images = [
+        payload
+        for payload in result["sentPayloads"]
+        if payload.get("action") == "stream_data" and payload.get("input_type") == "user_image"
+    ]
+    unexpected_realtime_images = [
+        payload
+        for payload in result["sentPayloads"]
+        if payload.get("action") == "stream_data" and payload.get("input_type") in ("screen", "camera")
+    ]
+    assert len(sent_images) == 1
+    assert sent_images[0]["data"].startswith("data:image/jpeg;base64,")
+    assert unexpected_realtime_images == []
+    assert result["message"]["status"] == "sent"
+    assert [block["type"] for block in result["message"]["blocks"]] == ["image"]
+
+
+@pytest.mark.frontend
 def test_drop_image_on_chat_imports_pending_attachment_without_navigation(
     mock_page: Page,
     running_server: str,
@@ -632,7 +704,17 @@ def test_compact_history_drop_sends_only_dropped_image_and_restores_pending_atta
     mock_page: Page,
     running_server: str,
 ):
-    _open_react_chat_page(mock_page, running_server)
+    mock_page.add_init_script(
+        "window.localStorage.setItem('neko_tutorial_settings', 'seen')"
+    )
+    mock_page.goto(f"{running_server}/chat", wait_until="domcontentloaded")
+    mock_page.wait_for_function(
+        "() => window.reactChatWindowHost"
+        " && window.appButtons"
+        " && window.appChat"
+        " && window.appState"
+        " && typeof window.appButtons.sendCompactHistoryDropPayload === 'function'"
+    )
     _install_chat_send_harness(mock_page, resolve_delay_ms=0)
 
     result = mock_page.evaluate(
@@ -686,7 +768,7 @@ def test_compact_history_drop_sends_only_dropped_image_and_restores_pending_atta
     sent_images = [
         payload
         for payload in result["sentPayloads"]
-        if payload.get("action") == "stream_data" and payload.get("input_type") == "screen"
+        if payload.get("action") == "stream_data" and payload.get("input_type") == "user_image"
     ]
     sent_texts = [
         payload
@@ -701,6 +783,7 @@ def test_compact_history_drop_sends_only_dropped_image_and_restores_pending_atta
         "data": "drop image text",
         "input_type": "text",
         "request_id": "req-compact-history-drop-test",
+        "source": "react-chat-window",
     }]
 
     assert result["message"]["status"] == "sent"

--- a/tests/frontend/test_chat_user_message_dedup.py
+++ b/tests/frontend/test_chat_user_message_dedup.py
@@ -732,7 +732,7 @@ def test_compact_history_drop_sends_only_dropped_image_and_restores_pending_atta
             const dropped = makeDataUrl('#cc3355');
             window.appButtons.addScreenshotToList(existing, null, {
                 alt: 'Existing pending',
-                source: 'user'
+                source: 'user-image'
             });
             const before = window.appButtons.getPendingComposerAttachments();
 

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -2436,6 +2436,41 @@ def test_chat_image_file_drop_uses_import_pipeline_and_blocks_browser_navigation
     assert "mod.importImageFilesToPendingList(files, { logPrefix: '[拖放图片]' });" in drop_block
 
 
+def test_chat_composer_user_images_use_text_attachment_input_type():
+    script = APP_BUTTONS_PATH.read_text(encoding="utf-8")
+
+    helper_block = script.split("function getPendingAttachmentInputType(item)", 1)[1].split(
+        "mod.syncPendingComposerAttachments",
+        1,
+    )[0]
+    assert "source === 'user-image'" in helper_block
+    assert "source === 'clipboard-image'" in helper_block
+    assert "source === 'compact-history'" in helper_block
+    assert "return 'user_image';" in helper_block
+    assert "return U.isMobile() ? 'camera' : 'screen';" in helper_block
+
+    import_block = script.split(
+        "mod.importImageFileToPendingList = function importImageFileToPendingList(file)",
+        1,
+    )[1].split(
+        "mod.importImageFilesToPendingList = function importImageFilesToPendingList(files, options)",
+        1,
+    )[0]
+    paste_block = script.split("document.addEventListener('paste'", 1)[1].split(
+        "document.addEventListener('dragover'",
+        1,
+    )[0]
+    send_block = script.split("// Send screenshots first", 1)[1].split(
+        "if (!isReactWindowSource)",
+        1,
+    )[0]
+
+    assert "mod.addScreenshotToList(dataUrl, null, { source: 'user-image' });" in import_block
+    assert "mod.addScreenshotToList(dataUrl, null, { source: 'clipboard-image' });" in paste_block
+    assert "input_type: getPendingAttachmentInputType(screenshotItems[i])" in send_block
+    assert "input_type: U.isMobile() ? 'camera' : 'screen'" not in send_block
+
+
 def test_text_mode_screenshot_payload_only_tags_paired_text_turn():
     script = APP_BUTTONS_PATH.read_text(encoding="utf-8")
 


### PR DESCRIPTION
…图继续使用 screen/camera，并补充回归测试

<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复离开再回来后发送聊天框图片误触发语音/实时视觉模式的问题

## 测试 / Testing

手动进行复现操作测试


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 图片发送可按来源更准确地识别类型，并在发送时应用匹配的标记（如用户图片、剪贴板图片、紧凑历史）。
  * 从导入、粘贴或历史记录恢复的图片，在后续会话恢复/发送中行为更一致。
* **Bug 修复**
  * 修复部分图片在会话恢复、继续发送或丢弃“紧凑历史”场景下被误判为截图/相机来源的问题。
  * 优化发送后附件清理与消息状态表现，确保只发送预期内容。
* **测试**
  * 新增/更新相关前端与单元测试覆盖用户图片输入类型与发送校验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->