### PR TITLE
统一云存档管理页返回按钮样式，将文字“返回”按钮替换为左上角同款叉图标按钮，并保留原有关闭/回退行为

### DIFF
--- a/static/css/cloudsave_manager.css
+++ b/static/css/cloudsave_manager.css
@@ -154,6 +154,12 @@ body .container-header {
     opacity: 0.9;
 }
 
+.container-header .close-page-btn:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.85);
+    outline-offset: 2px;
+    box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.18);
+}
+
 .container-content {
     padding: 24px 32px;
     background: #e3f4ff;

--- a/static/css/cloudsave_manager.css
+++ b/static/css/cloudsave_manager.css
@@ -121,6 +121,39 @@ body .container-header {
     -webkit-app-region: no-drag;
 }
 
+.container-header .close-page-btn {
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    cursor: pointer;
+    line-height: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.2s, transform 0.1s ease, opacity 0.2s ease;
+    -webkit-app-region: no-drag;
+}
+
+.container-header .close-page-btn img {
+    width: 32px;
+    height: 32px;
+    display: block;
+}
+
+.container-header .close-page-btn:hover {
+    background: rgba(255, 255, 255, 0.2);
+    transform: translateY(-1px);
+}
+
+.container-header .close-page-btn:active {
+    background: rgba(255, 255, 255, 0.3);
+    transform: translateY(1px) scale(0.95);
+    opacity: 0.9;
+}
+
 .container-content {
     padding: 24px 32px;
     background: #e3f4ff;

--- a/templates/cloudsave_manager.html
+++ b/templates/cloudsave_manager.html
@@ -19,13 +19,15 @@
             <h2 data-i18n="cloudsave.headerTitle" data-text="Cloud Save Manager">云存档管理</h2>
             <div class="header-actions">
                 <button type="button" class="btn sm secondary" id="refresh-cloudsave-btn" data-i18n="cloudsave.refresh">刷新</button>
-                <button type="button" class="btn sm" id="back-to-chara-manager-btn" data-i18n="cloudsave.backToCharacterManager">返回</button>
                 <div class="neko-window-controls">
                     <button type="button" class="neko-window-control-btn" data-neko-window-control="minimize" data-i18n-title="common.minimize" data-i18n-aria="common.minimize" title="最小化" aria-label="最小化">
                         <span class="neko-window-minimize-icon"></span>
                     </button>
                     <button type="button" class="neko-window-control-btn" data-neko-window-control="maximize" data-i18n-title="common.maximize" data-i18n-aria="common.maximize" title="最大化" aria-label="最大化">
                         <span class="neko-window-maximize-icon"></span>
+                    </button>
+                    <button type="button" class="close-page-btn" id="back-to-chara-manager-btn" data-i18n-title="cloudsave.backToCharacterManager" data-i18n-aria="cloudsave.backToCharacterManager" title="返回" aria-label="返回">
+                        <img src="/static/icons/close_button.png" alt="" data-i18n-alt="common.close" draggable="false">
                     </button>
                 </div>
             </div>

--- a/tests/unit/test_cloudsave_i18n.py
+++ b/tests/unit/test_cloudsave_i18n.py
@@ -53,7 +53,8 @@ def test_cloudsave_templates_use_i18n_keys():
     assert 'data-i18n="cloudsave.headerTitle"' in cloudsave_template
     assert 'data-i18n="cloudsave.subtitle"' in cloudsave_template
     assert 'data-i18n="cloudsave.refresh"' in cloudsave_template
-    assert 'data-i18n="cloudsave.backToCharacterManager"' in cloudsave_template
+    assert 'data-i18n-title="cloudsave.backToCharacterManager"' in cloudsave_template
+    assert 'data-i18n-aria="cloudsave.backToCharacterManager"' in cloudsave_template
     assert 'id="cloudsave-provider-status"' in cloudsave_template
     assert 'data-i18n="cloudsave.loadingSummary"' in cloudsave_template
     assert 'id="cloudsave-current-character"' in cloudsave_template


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

统一云存档管理页返回按钮样式

## 测试 / Testing

手动测试

## 对比
之前:
<img width="458" height="91" alt="image" src="https://github.com/user-attachments/assets/632449c2-2016-4edb-bbc6-5985f50ee6b9" />

之后:
<img width="373" height="94" alt="image" src="https://github.com/user-attachments/assets/43e0b12e-8356-4772-a334-9c9555c1a3d1" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **用户界面**
  * 统一并优化页面顶部按钮区域布局与样式，新增用于关闭页面的按钮外观与交互反馈（含悬停/按压状态与键盘聚焦可见效果）。
  * 调整返回按钮与窗口控制按钮的组织方式：将返回按钮整合进窗口控制区域，并替换为新的关闭按钮样式与图标渲染。
  * 补充与完善返回按钮的可访问性信息（title/aria）与对应 i18n 键，提升可用性与一致性。
* **测试**
  * 更新模板 i18n 键断言，覆盖 title 与 aria 的校验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->