### PR TITLE
fix(chat): allow compact placement refresh without override

### DIFF
--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -3456,7 +3456,7 @@ function CompactChatApp({
         updatePlacement(desktopLayoutOverride);
       });
     };
-    const schedulePlacementUpdateWithDesktopLayout = (layout: DesktopCompactChoicePlacementLayout | null) => {
+    const schedulePlacementUpdateWithDesktopLayout = (layout?: DesktopCompactChoicePlacementLayout | null) => {
       scheduledDesktopLayoutOverride = layout;
       schedulePlacementUpdate();
     };


### PR DESCRIPTION
## 改动概述 / Summary

**使win侧拖拽修复可以正确应用**
(´இωஇ｀)
修正 React chat compact choice 布局刷新函数的参数签名，允许在没有桌面布局覆盖值时直接触发布局刷新。
该改动匹配现有调用方式，避免 TypeScript 对无参刷新路径产生类型不一致，同时不改变 compact choice 的实际布局计算逻辑。


以下pr的后续完善：https://github.com/Project-N-E-K-O/N.E.K.O/pull/2151
https://github.com/Project-N-E-K-O/N.E.K.O.-PC/pull/285 的拖拽抖动/闪烁问题优化
## 回归报告 / Regression Report

不适用

## 不拆分理由 / Why Not Split

不适用

## 测试 / Testing

- `npm.cmd run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了聊天界面桌面端的布局更新处理，提升了在某些情况下切换选择层位置时的稳定性。
  * 改进了布局更新逻辑对缺省参数的兼容性，减少了因参数缺失导致的异常情况。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->