### PR TITLE
修复模型管理页自定义触摸区域预览闪烁问题，将预览底图改为打开时单帧截图，后续交互仅重绘静态截图和区域覆盖层，避免持续读取实时 Live2D 画布

### DIFF
--- a/static/touch-config.js
+++ b/static/touch-config.js
@@ -787,6 +787,7 @@ function openCustomTouchAreaWindow(options = {}) {
     }
     let initialSelectionApplied = false
     let previewBaseBounds = null
+    let previewScreenshotCanvas = null
     const MIN_SELECTION_SIZE = 10
     const RESIZE_HIT_PADDING = 10
     const HOVER_LABEL_OFFSET_X = 16
@@ -794,6 +795,49 @@ function openCustomTouchAreaWindow(options = {}) {
     const HOVER_LABEL_DAMPING = 0.22
     const previewBaseAreaRecords = getCustomTouchAreaRecordsFromSet(options.touchSet || {})
         .filter(record => record.area.id !== editingArea?.id)
+
+    function renderSourceOnceForPreviewScreenshot() {
+        const app = manager?.pixi_app
+        const renderer = app?.renderer
+        const stage = app?.stage
+        if (!renderer || !stage || typeof renderer.render !== 'function') return
+
+        try {
+            renderer.render(stage)
+        } catch (_) {}
+    }
+
+    function capturePreviewScreenshotCanvas() {
+        const frameSource = manager?.pixi_app?.renderer?.view || manager?.pixi_app?.view || sourceCanvas
+        const fallbackWidth = sourceCanvas?.width || previewWrap.clientWidth || 1
+        const fallbackHeight = sourceCanvas?.height || previewWrap.clientHeight || 1
+        if (!frameSource || frameSource.width <= 0 || frameSource.height <= 0) {
+            const fallback = document.createElement('canvas')
+            fallback.width = Math.max(1, fallbackWidth)
+            fallback.height = Math.max(1, fallbackHeight)
+            return fallback
+        }
+
+        renderSourceOnceForPreviewScreenshot()
+
+        const screenshot = document.createElement('canvas')
+        screenshot.width = frameSource.width
+        screenshot.height = frameSource.height
+        const screenshotCtx = screenshot.getContext('2d')
+        if (!screenshotCtx) return screenshot
+
+        try {
+            screenshotCtx.drawImage(frameSource, 0, 0)
+        } catch (_) {}
+        return screenshot
+    }
+
+    function getPreviewScreenshotCanvas() {
+        if (!previewScreenshotCanvas) {
+            previewScreenshotCanvas = capturePreviewScreenshotCanvas()
+        }
+        return previewScreenshotCanvas
+    }
 
     function getSourceCssSize() {
         const screen = manager.pixi_app?.renderer?.screen
@@ -1255,6 +1299,7 @@ function openCustomTouchAreaWindow(options = {}) {
 
     function drawPreviewFrame() {
         const metrics = updatePreviewMetrics()
+        const frameSourceCanvas = getPreviewScreenshotCanvas()
         const dpr = window.devicePixelRatio || 1
         const targetWidth = Math.max(1, Math.round(metrics.wrapWidth * dpr))
         const targetHeight = Math.max(1, Math.round(metrics.wrapHeight * dpr))
@@ -1267,8 +1312,8 @@ function openCustomTouchAreaWindow(options = {}) {
             ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
             ctx.clearRect(0, 0, metrics.wrapWidth, metrics.wrapHeight)
             try {
-                const sourceScaleX = sourceCanvas.width / metrics.sourceWidth
-                const sourceScaleY = sourceCanvas.height / metrics.sourceHeight
+                const sourceScaleX = frameSourceCanvas.width / metrics.sourceWidth
+                const sourceScaleY = frameSourceCanvas.height / metrics.sourceHeight
                 const sx = Math.max(0, metrics.cropLeft)
                 const sy = Math.max(0, metrics.cropTop)
                 const ex = Math.min(metrics.sourceWidth, metrics.cropLeft + metrics.cropWidth)
@@ -1277,7 +1322,7 @@ function openCustomTouchAreaWindow(options = {}) {
                 const sh = Math.max(0, ey - sy)
                 if (sw > 0 && sh > 0) {
                     ctx.drawImage(
-                        sourceCanvas,
+                        frameSourceCanvas,
                         sx * sourceScaleX,
                         sy * sourceScaleY,
                         sw * sourceScaleX,
@@ -1424,9 +1469,10 @@ function openCustomTouchAreaWindow(options = {}) {
             cancelAnimationFrame(animationFrameId)
             animationFrameId = null
         }
+        previewScreenshotCanvas = null
     }
 
-    requestAnimationFrame(drawPreviewFrame)
+    animationFrameId = requestAnimationFrame(drawPreviewFrame)
 }
 
 function closeAllMultiselects(e){


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复模型管理页自定义触摸区域预览闪烁问题

## 测试 / Testing

手动测试


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了自定义触摸区域预览的渲染方式，预览截图现在更稳定，显示效果更接近实际渲染结果。
  * 在画布尺寸不可用时增加了备用处理，减少预览空白或异常显示的情况。
  * 关闭预览时会正确停止动画并清理缓存，提升交互流畅度。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->