### PR TITLE
自定义触摸区域改为独立渲染预览模型，关闭预览后通过模型管理页正常重载当前 Live2D 模型

### DIFF
--- a/static/css/touch-config.css
+++ b/static/css/touch-config.css
@@ -537,6 +537,7 @@
     touch-action: none;
 }
 
+.touch-custom-live2d-canvas,
 .touch-custom-preview-canvas {
     position: absolute;
     inset: 0;
@@ -545,9 +546,23 @@
     pointer-events: none;
 }
 
+.touch-custom-live2d-canvas {
+    z-index: 1;
+    opacity: 0;
+}
+
+.touch-custom-live2d-canvas.is-ready {
+    opacity: 1;
+}
+
+.touch-custom-preview-canvas {
+    z-index: 2;
+}
+
 .touch-custom-model-bounds {
     position: absolute;
     display: none;
+    z-index: 3;
     border: 1px dashed rgba(64, 197, 241, 0.65);
     pointer-events: none;
     box-sizing: border-box;
@@ -556,6 +571,7 @@
 .touch-custom-selection {
     position: absolute;
     display: none;
+    z-index: 4;
     border: 2px solid var(--color-n-main);
     background: rgba(64, 197, 241, 0.07);
     box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.7) inset;

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -8194,7 +8194,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
 
     // 加载模型的函数
-    async function loadModel(modelName, modelInfo, steam_id) {
+    async function loadModel(modelName, modelInfo, steam_id, options = {}) {
         if (!modelName || !modelInfo) return;
 
         // 确保获取正确的steam_id，优先使用传入的，然后从modelInfo中获取
@@ -8268,7 +8268,13 @@ document.addEventListener('DOMContentLoaded', async () => {
 
             // 5. Load preferences
             const preferences = await window.live2dManager.loadUserPreferences();
-            const modelPreferences = preferences.find(p => p && p.model_path === modelInfo.path) || null;
+            const storedModelPreferences = preferences.find(p => p && p.model_path === modelInfo.path) || null;
+            const preferenceOverride = options.preferencesOverride && typeof options.preferencesOverride === 'object'
+                ? options.preferencesOverride
+                : null;
+            const modelPreferences = preferenceOverride
+                ? { ...(storedModelPreferences || {}), ...preferenceOverride }
+                : storedModelPreferences;
 
             // 6. Load model FROM THE MODIFIED OBJECT
             await window.live2dManager.loadModel(modelConfig, {
@@ -8354,13 +8360,55 @@ document.addEventListener('DOMContentLoaded', async () => {
 
             // 恢复 Live2D 待机动作（如果之前保存过）
             restoreLive2DIdleAnimation();
+            return true;
 
         } catch (error) {
             showStatus(t('live2d.modelLoadFailed', `加载模型 ${modelName} 失败`, { model: modelName }));
             console.error(error);
             setControlsDisabled(false);
+            return false;
         }
     }
+
+    function createLive2DModelRuntimePreferenceOverride(currentModel) {
+        if (!currentModel || currentModel.destroyed || !currentModelInfo || !currentModelInfo.path) return null;
+
+        const posX = Number(currentModel.x);
+        const posY = Number(currentModel.y);
+        const scaleX = Number(currentModel.scale?.x);
+        const scaleY = Number(currentModel.scale?.y);
+        if (![posX, posY, scaleX, scaleY].every(Number.isFinite)) return null;
+
+        const rendererScreen = window.live2dManager?.pixi_app?.renderer?.screen;
+        const viewportWidth = Number(rendererScreen?.width) || window.innerWidth || document.documentElement.clientWidth || 0;
+        const viewportHeight = Number(rendererScreen?.height) || window.innerHeight || document.documentElement.clientHeight || 0;
+        const preferenceOverride = {
+            model_path: currentModelInfo.path,
+            position: { x: posX, y: posY },
+            scale: { x: scaleX, y: scaleY }
+        };
+        if (Number.isFinite(viewportWidth) && Number.isFinite(viewportHeight) && viewportWidth > 0 && viewportHeight > 0) {
+            preferenceOverride.viewport = {
+                width: viewportWidth,
+                height: viewportHeight
+            };
+        }
+        return preferenceOverride;
+    }
+
+    window.reloadCurrentLive2DModelInModelManager = async function(options = {}) {
+        if (currentModelType !== 'live2d' || !currentModelInfo || !window.live2dManager) return false;
+
+        const currentModel = typeof window.live2dManager.getCurrentModel === 'function'
+            ? window.live2dManager.getCurrentModel()
+            : window.live2dManager.currentModel;
+        const preferencesOverride = options.preserveRuntimeTransform === false
+            ? null
+            : createLive2DModelRuntimePreferenceOverride(currentModel);
+        const steamId = currentModelInfo.item_id;
+
+        return await loadModel(currentModelInfo.name, currentModelInfo, steamId, { preferencesOverride });
+    };
 
     playMotionBtn.addEventListener('click', () => {
         if (!live2dModel) {

--- a/static/touch-config.js
+++ b/static/touch-config.js
@@ -684,8 +684,7 @@ function createTouchAreaConfigItem(hitArea, options) {
 function openCustomTouchAreaWindow(options = {}) {
     const manager = window.live2dManager
     const model = manager?.getCurrentModel?.()
-    const sourceCanvas = manager?.pixi_app?.view || manager?.pixi_app?.renderer?.view || document.getElementById('live2d-canvas')
-    if (!manager || !model || !sourceCanvas) {
+    if (!manager || !model) {
         createTouchConfigFloatingWindow({ content: touchAnimText('previewUnavailable', '当前无法打开自定义区域预览') })
         return
     }
@@ -720,6 +719,10 @@ function openCustomTouchAreaWindow(options = {}) {
 
     const previewWrap = document.createElement('div')
     previewWrap.className = 'touch-custom-preview-wrap'
+
+    const previewLive2dCanvas = document.createElement('canvas')
+    previewLive2dCanvas.className = 'touch-custom-live2d-canvas'
+    previewWrap.appendChild(previewLive2dCanvas)
 
     const previewCanvas = document.createElement('canvas')
     previewCanvas.className = 'touch-custom-preview-canvas'
@@ -787,6 +790,13 @@ function openCustomTouchAreaWindow(options = {}) {
     }
     let initialSelectionApplied = false
     let previewBaseBounds = null
+    let previewApp = null
+    let previewModel = null
+    let previewModelReady = false
+    let previewDisposed = false
+    let previewLoadStarted = false
+    let previewModelFitted = false
+    let previewRendererSize = { width: 0, height: 0 }
     const MIN_SELECTION_SIZE = 10
     const RESIZE_HIT_PADDING = 10
     const HOVER_LABEL_OFFSET_X = 16
@@ -795,17 +805,154 @@ function openCustomTouchAreaWindow(options = {}) {
     const previewBaseAreaRecords = getCustomTouchAreaRecordsFromSet(options.touchSet || {})
         .filter(record => record.area.id !== editingArea?.id)
 
-    function getSourceCssSize() {
-        const screen = manager.pixi_app?.renderer?.screen
-        const width = Number(screen?.width) || sourceCanvas.clientWidth || window.innerWidth || sourceCanvas.width
-        const height = Number(screen?.height) || sourceCanvas.clientHeight || window.innerHeight || sourceCanvas.height
-        return { width: Math.max(1, width), height: Math.max(1, height) }
+    function getPreviewWrapSize() {
+        return {
+            width: Math.max(1, previewWrap.clientWidth || previewWrap.offsetWidth || 1),
+            height: Math.max(1, previewWrap.clientHeight || previewWrap.offsetHeight || 1)
+        }
+    }
+
+    function getPreviewModelPath() {
+        const candidates = [
+            manager?._lastLoadedModelPath,
+            manager?.lastLoadedModelPath,
+            model?.internalModel?.settings?.url,
+            model?.internalModel?.settings?.json?.url,
+            model?.internalModel?.settings?.json?.Url,
+            model?.url
+        ]
+        return candidates.find(candidate => typeof candidate === 'string' && candidate.trim())
+    }
+
+    function getPreviewLive2DModelClass() {
+        return window.Live2DModel
+            || window.PIXI?.live2d?.Live2DModel
+            || window.PIXI?.live2d?.cubism4?.Live2DModel
+    }
+
+    function resizePreviewRenderer() {
+        if (!previewApp?.renderer) return false
+        const size = getPreviewWrapSize()
+        if (previewRendererSize.width === size.width && previewRendererSize.height === size.height) return false
+
+        previewRendererSize = size
+        try {
+            previewApp.renderer.resize(size.width, size.height)
+        } catch (_) {}
+        previewBaseBounds = null
+        previewModelFitted = false
+        return true
+    }
+
+    function fitPreviewModelToWrap() {
+        if (!previewModel || !previewApp?.renderer) return false
+        const size = getPreviewWrapSize()
+
+        try {
+            previewModel.x = 0
+            previewModel.y = 0
+            if (previewModel.scale && typeof previewModel.scale.set === 'function') {
+                previewModel.scale.set(1, 1)
+            } else if (previewModel.scale) {
+                previewModel.scale.x = 1
+                previewModel.scale.y = 1
+            }
+            previewApp.renderer.render(previewApp.stage)
+        } catch (_) {}
+
+        const bounds = normalizePixiBoundsRect(previewModel.getBounds?.())
+        if (!bounds || bounds.width <= 0 || bounds.height <= 0) return false
+
+        const paddedWidth = bounds.width * 1.18
+        const paddedHeight = bounds.height * 1.18
+        const scale = Math.min(size.width / paddedWidth, size.height / paddedHeight)
+        if (!Number.isFinite(scale) || scale <= 0) return false
+
+        if (previewModel.scale && typeof previewModel.scale.set === 'function') {
+            previewModel.scale.set(scale, scale)
+        } else if (previewModel.scale) {
+            previewModel.scale.x = scale
+            previewModel.scale.y = scale
+        }
+        previewModel.x = (size.width - bounds.width * scale) / 2 - bounds.left * scale
+        previewModel.y = (size.height - bounds.height * scale) / 2 - bounds.top * scale
+        previewBaseBounds = null
+
+        try {
+            previewApp.renderer.render(previewApp.stage)
+        } catch (_) {}
+        return true
+    }
+
+    async function loadPreviewModel() {
+        const modelPath = getPreviewModelPath()
+        const PixiApplication = window.PIXI?.Application
+        const Live2DModelClass = getPreviewLive2DModelClass()
+        if (!modelPath || !PixiApplication || !Live2DModelClass) {
+            throw new Error('Live2D preview dependencies are unavailable')
+        }
+
+        const size = getPreviewWrapSize()
+        previewApp = new PixiApplication({
+            view: previewLive2dCanvas,
+            width: size.width,
+            height: size.height,
+            transparent: true,
+            backgroundAlpha: 0,
+            autoDensity: true,
+            resolution: window.devicePixelRatio || 1
+        })
+        previewRendererSize = size
+        previewLoadStarted = true
+
+        const loadedModel = await Live2DModelClass.from(modelPath, { autoFocus: false })
+        if (previewDisposed) {
+            try {
+                loadedModel?.destroy?.({ children: true, texture: false, baseTexture: false })
+            } catch (_) {}
+            return
+        }
+
+        previewModel = loadedModel
+        previewApp.stage.addChild(previewModel)
+        previewModelReady = true
+        previewLive2dCanvas.classList.add('is-ready')
+        resizePreviewRenderer()
+        previewModelFitted = fitPreviewModelToWrap()
+    }
+
+    function destroyPreviewModel() {
+        previewDisposed = true
+        previewModelReady = false
+        previewModelFitted = false
+        previewBaseBounds = null
+        previewLive2dCanvas.classList.remove('is-ready')
+
+        const modelToDestroy = previewModel
+        const appToDestroy = previewApp
+        previewModel = null
+        previewApp = null
+
+        try {
+            if (modelToDestroy?.parent) modelToDestroy.parent.removeChild(modelToDestroy)
+        } catch (_) {}
+        try {
+            modelToDestroy?.destroy?.({ children: true, texture: false, baseTexture: false })
+        } catch (_) {}
+        try {
+            appToDestroy?.destroy?.(false, { children: true, texture: false, baseTexture: false })
+        } catch (_) {
+            try {
+                appToDestroy?.destroy?.(false)
+            } catch (_) {}
+        }
     }
 
     function getPreviewBaseBounds() {
         if (previewBaseBounds) return previewBaseBounds
+        if (!previewModelReady || !previewModel) return null
         try {
-            const bounds = normalizePixiBoundsRect(model.getBounds())
+            const bounds = normalizePixiBoundsRect(previewModel.getBounds?.())
             if (!bounds) return null
             previewBaseBounds = {
                 left: bounds.left,
@@ -824,44 +971,14 @@ function openCustomTouchAreaWindow(options = {}) {
     function updatePreviewMetrics() {
         const wrapWidth = previewWrap.clientWidth || 1
         const wrapHeight = previewWrap.clientHeight || 1
-        const sourceSize = getSourceCssSize()
         const bounds = getPreviewBaseBounds()
-        const previewAspect = wrapWidth / wrapHeight
-        const padding = bounds ? Math.max(bounds.width, bounds.height) * 0.18 : 0
-        let cropWidth = bounds ? bounds.width + padding * 2 : sourceSize.width
-        let cropHeight = bounds ? bounds.height + padding * 2 : sourceSize.height
-        if (cropWidth / cropHeight < previewAspect) {
-            cropWidth = cropHeight * previewAspect
-        } else {
-            cropHeight = cropWidth / previewAspect
-        }
-        const centerX = bounds ? bounds.left + bounds.width / 2 : sourceSize.width / 2
-        const centerY = bounds ? bounds.top + bounds.height / 2 : sourceSize.height / 2
-        const cropLeft = centerX - cropWidth / 2
-        const cropTop = centerY - cropHeight / 2
-        const scale = Math.min(wrapWidth / cropWidth, wrapHeight / cropHeight)
-        const drawWidth = cropWidth * scale
-        const drawHeight = cropHeight * scale
-        const offsetX = (wrapWidth - drawWidth) / 2
-        const offsetY = (wrapHeight - drawHeight) / 2
         const modelRect = bounds ? {
-            x: offsetX + (bounds.left - cropLeft) * scale,
-            y: offsetY + (bounds.top - cropTop) * scale,
-            width: bounds.width * scale,
-            height: bounds.height * scale
+            x: bounds.left,
+            y: bounds.top,
+            width: bounds.width,
+            height: bounds.height
         } : null
         previewMetrics = {
-            sourceWidth: sourceSize.width,
-            sourceHeight: sourceSize.height,
-            cropLeft,
-            cropTop,
-            cropWidth,
-            cropHeight,
-            scale,
-            drawWidth,
-            drawHeight,
-            offsetX,
-            offsetY,
             wrapWidth,
             wrapHeight,
             modelRect
@@ -1254,6 +1371,10 @@ function openCustomTouchAreaWindow(options = {}) {
     }
 
     function drawPreviewFrame() {
+        const previewSizeChanged = resizePreviewRenderer()
+        if (previewModelReady && (!previewModelFitted || previewSizeChanged)) {
+            previewModelFitted = fitPreviewModelToWrap()
+        }
         const metrics = updatePreviewMetrics()
         const dpr = window.devicePixelRatio || 1
         const targetWidth = Math.max(1, Math.round(metrics.wrapWidth * dpr))
@@ -1266,29 +1387,6 @@ function openCustomTouchAreaWindow(options = {}) {
         if (ctx) {
             ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
             ctx.clearRect(0, 0, metrics.wrapWidth, metrics.wrapHeight)
-            try {
-                const sourceScaleX = sourceCanvas.width / metrics.sourceWidth
-                const sourceScaleY = sourceCanvas.height / metrics.sourceHeight
-                const sx = Math.max(0, metrics.cropLeft)
-                const sy = Math.max(0, metrics.cropTop)
-                const ex = Math.min(metrics.sourceWidth, metrics.cropLeft + metrics.cropWidth)
-                const ey = Math.min(metrics.sourceHeight, metrics.cropTop + metrics.cropHeight)
-                const sw = Math.max(0, ex - sx)
-                const sh = Math.max(0, ey - sy)
-                if (sw > 0 && sh > 0) {
-                    ctx.drawImage(
-                        sourceCanvas,
-                        sx * sourceScaleX,
-                        sy * sourceScaleY,
-                        sw * sourceScaleX,
-                        sh * sourceScaleY,
-                        metrics.offsetX + (sx - metrics.cropLeft) * metrics.scale,
-                        metrics.offsetY + (sy - metrics.cropTop) * metrics.scale,
-                        sw * metrics.scale,
-                        sh * metrics.scale
-                    )
-                }
-            } catch (_) {}
         }
 
         const modelPreviewRect = getModelPreviewRect()
@@ -1394,7 +1492,35 @@ function openCustomTouchAreaWindow(options = {}) {
         hideHoverLabel()
     })
 
-    saveButton.onclick = function() {
+    async function waitForActiveTouchSetSave() {
+        const startTime = Date.now()
+        while (isSaving && Date.now() - startTime < 3000) {
+            await new Promise(resolve => setTimeout(resolve, 50))
+        }
+        return !isSaving
+    }
+
+    async function flushTouchSetSaveBeforePreviewClose() {
+        if (autoSaveTimeout) {
+            clearTimeout(autoSaveTimeout)
+            autoSaveTimeout = null
+        }
+
+        const saveSlotAvailable = await waitForActiveTouchSetSave()
+        if (!saveSlotAvailable) return false
+
+        isSaving = true
+        try {
+            const success = await saveTouchSetToServer()
+            if (success) showSaveIndicator()
+            return success
+        } finally {
+            isSaving = false
+        }
+    }
+
+    saveButton.onclick = async function() {
+        if (saveButton.disabled) return
         const rect = selectionToNormalizedRect()
         if (!rect) {
             status.textContent = touchAnimText('selectAreaFirst', '请先框选一个有效区域')
@@ -1416,6 +1542,15 @@ function openCustomTouchAreaWindow(options = {}) {
                 rect
             })
         }
+        saveButton.disabled = true
+        const saveSuccess = await flushTouchSetSaveBeforePreviewClose()
+        saveButton.disabled = false
+        if (!saveSuccess) {
+            status.textContent = window.t
+                ? window.t('live2d.saveFailedGeneral', '保存失败!')
+                : '保存失败!'
+            return
+        }
         floatingWindow.close()
     }
 
@@ -1424,9 +1559,26 @@ function openCustomTouchAreaWindow(options = {}) {
             cancelAnimationFrame(animationFrameId)
             animationFrameId = null
         }
+        const shouldReloadSourceModel = previewLoadStarted
+        destroyPreviewModel()
+        if (shouldReloadSourceModel && typeof window.reloadCurrentLive2DModelInModelManager === 'function') {
+            const reloadPromise = window.reloadCurrentLive2DModelInModelManager({
+                reason: 'custom-touch-area-preview-close'
+            })
+            if (reloadPromise && typeof reloadPromise.catch === 'function') {
+                reloadPromise.catch(error => {
+                    console.warn('[TouchConfig] Failed to reload model manager Live2D model:', error)
+                })
+            }
+        }
     }
 
-    requestAnimationFrame(drawPreviewFrame)
+    loadPreviewModel().catch(error => {
+        if (previewDisposed) return
+        console.warn('[TouchConfig] Failed to load custom touch area preview model:', error)
+        status.textContent = touchAnimText('previewUnavailable', '当前无法打开自定义区域预览')
+    })
+    animationFrameId = requestAnimationFrame(drawPreviewFrame)
 }
 
 function closeAllMultiselects(e){

--- a/static/touch-config.js
+++ b/static/touch-config.js
@@ -842,6 +842,58 @@ function openCustomTouchAreaWindow(options = {}) {
             || window.PIXI?.live2d?.cubism4?.Live2DModel
     }
 
+    function getCoreParameterId(coreModel, index) {
+        if (!coreModel || !Number.isInteger(index) || index < 0) return null
+        try {
+            const id = coreModel._parameterIds?.[index]
+                ?? coreModel._model?.parameters?.ids?.[index]
+                ?? coreModel.model?.parameters?.ids?.[index]
+                ?? coreModel.parameters?.ids?.[index]
+            if (id) return String(id)
+        } catch (_) {}
+        try {
+            if (typeof coreModel.getParameterId === 'function') {
+                const id = coreModel.getParameterId(index)
+                if (id) return String(id)
+            }
+        } catch (_) {}
+        return null
+    }
+
+    function copyCurrentModelParametersToPreview() {
+        const sourceCoreModel = model?.internalModel?.coreModel
+        const previewCoreModel = previewModel?.internalModel?.coreModel
+        if (!sourceCoreModel || !previewCoreModel) return
+
+        const sourceCount = typeof sourceCoreModel.getParameterCount === 'function'
+            ? Number(sourceCoreModel.getParameterCount())
+            : 0
+        const previewCount = typeof previewCoreModel.getParameterCount === 'function'
+            ? Number(previewCoreModel.getParameterCount())
+            : 0
+        if (!Number.isFinite(sourceCount) || sourceCount <= 0) return
+
+        for (let index = 0; index < sourceCount; index += 1) {
+            const paramId = getCoreParameterId(sourceCoreModel, index)
+            if (paramId && /(?:opacity|visibility)/i.test(paramId)) continue
+
+            let targetIndex = -1
+            if (paramId && typeof previewCoreModel.getParameterIndex === 'function') {
+                try {
+                    targetIndex = previewCoreModel.getParameterIndex(paramId)
+                } catch (_) {}
+            }
+            if (targetIndex < 0 && index < previewCount) targetIndex = index
+            if (targetIndex < 0) continue
+
+            try {
+                const value = Number(sourceCoreModel.getParameterValueByIndex(index))
+                if (!Number.isFinite(value)) continue
+                previewCoreModel.setParameterValueByIndex(targetIndex, value)
+            } catch (_) {}
+        }
+    }
+
     function resizePreviewRenderer() {
         if (!previewApp?.renderer) return false
         const size = getPreviewWrapSize()
@@ -927,6 +979,7 @@ function openCustomTouchAreaWindow(options = {}) {
 
         previewModel = loadedModel
         previewApp.stage.addChild(previewModel)
+        copyCurrentModelParametersToPreview()
         previewModelReady = true
         previewLive2dCanvas.classList.add('is-ready')
         resizePreviewRenderer()

--- a/static/touch-config.js
+++ b/static/touch-config.js
@@ -311,6 +311,8 @@ async function InitializationTouchSet(characterJson) {
     window.live2dManager.setupHitAreaInteraction(model)
 }
 
+const TOUCH_SET_SAVE_TIMEOUT_MS = 10000
+
 async function saveTouchSetToServer() {
     const modelName = window.live2dManager?.modelName;
     const lanlanName = new URLSearchParams(window.location.search).get('lanlan_name') || window.lanlan_config?.lanlan_name;
@@ -322,12 +324,18 @@ async function saveTouchSetToServer() {
     
     const touchSetData = syncCurrentTouchSetConfigToManager();
     
+    const saveController = typeof AbortController !== 'undefined' ? new AbortController() : null
+    const saveTimeout = saveController
+        ? setTimeout(() => saveController.abort(), TOUCH_SET_SAVE_TIMEOUT_MS)
+        : null
+
     try {
         const response = await fetch(`/api/characters/catgirl/${encodeURIComponent(lanlanName)}/touch_set`, {
             method: 'PATCH',
             headers: {
                 'Content-Type': 'application/json'
             },
+            ...(saveController ? { signal: saveController.signal } : {}),
             body: JSON.stringify({
                 model_name: modelName,
                 touch_set: touchSetData
@@ -347,6 +355,8 @@ async function saveTouchSetToServer() {
     } catch (error) {
         console.error('[TouchSet] 保存请求失败:', error);
         return false;
+    } finally {
+        if (saveTimeout) clearTimeout(saveTimeout)
     }
 }
 
@@ -754,7 +764,6 @@ function openCustomTouchAreaWindow(options = {}) {
     content.appendChild(status)
 
     let saveBeforeCloseInProgress = false
-    let touchSetSaveFlushedBeforeClose = false
     const closeFloatingWindow = floatingWindow.close.bind(floatingWindow)
     floatingWindow.close = function(cleanup) {
         if (saveBeforeCloseInProgress) {
@@ -1564,9 +1573,15 @@ function openCustomTouchAreaWindow(options = {}) {
     })
 
     async function waitForActiveTouchSetSave() {
+        const startedAt = Date.now()
         while (isSaving) {
+            if (Date.now() - startedAt >= TOUCH_SET_SAVE_TIMEOUT_MS) {
+                console.error('[TouchSet] Waiting for active save timed out')
+                return false
+            }
             await new Promise(resolve => setTimeout(resolve, 50))
         }
+        return true
     }
 
     async function flushTouchSetSaveBeforePreviewClose() {
@@ -1575,7 +1590,8 @@ function openCustomTouchAreaWindow(options = {}) {
             autoSaveTimeout = null
         }
 
-        await waitForActiveTouchSetSave()
+        const saveAvailable = await waitForActiveTouchSetSave()
+        if (!saveAvailable) return false
         if (autoSaveTimeout) {
             clearTimeout(autoSaveTimeout)
             autoSaveTimeout = null
@@ -1585,7 +1601,6 @@ function openCustomTouchAreaWindow(options = {}) {
         try {
             const success = await saveTouchSetToServer()
             if (success) {
-                touchSetSaveFlushedBeforeClose = true
                 showSaveIndicator()
             }
             return success
@@ -1628,7 +1643,6 @@ function openCustomTouchAreaWindow(options = {}) {
                     : '保存失败!'
                 return
             }
-            touchSetSaveFlushedBeforeClose = true
         } finally {
             saveBeforeCloseInProgress = false
             saveButton.disabled = false
@@ -1643,12 +1657,8 @@ function openCustomTouchAreaWindow(options = {}) {
             animationFrameId = null
         }
         const shouldReloadSourceModel = previewLoadStarted
-        let canReloadSourceModel = true
-        if (shouldReloadSourceModel && !touchSetSaveFlushedBeforeClose) {
-            canReloadSourceModel = await flushTouchSetSaveBeforePreviewClose()
-        }
         destroyPreviewModel()
-        if (shouldReloadSourceModel && canReloadSourceModel && typeof window.reloadCurrentLive2DModelInModelManager === 'function') {
+        if (shouldReloadSourceModel && typeof window.reloadCurrentLive2DModelInModelManager === 'function') {
             const reloadPromise = window.reloadCurrentLive2DModelInModelManager({
                 reason: 'custom-touch-area-preview-close'
             })

--- a/static/touch-config.js
+++ b/static/touch-config.js
@@ -754,6 +754,7 @@ function openCustomTouchAreaWindow(options = {}) {
     content.appendChild(status)
 
     let saveBeforeCloseInProgress = false
+    let touchSetSaveFlushedBeforeClose = false
     const closeFloatingWindow = floatingWindow.close.bind(floatingWindow)
     floatingWindow.close = function(cleanup) {
         if (saveBeforeCloseInProgress) {
@@ -1578,7 +1579,10 @@ function openCustomTouchAreaWindow(options = {}) {
         isSaving = true
         try {
             const success = await saveTouchSetToServer()
-            if (success) showSaveIndicator()
+            if (success) {
+                touchSetSaveFlushedBeforeClose = true
+                showSaveIndicator()
+            }
             return success
         } finally {
             isSaving = false
@@ -1619,6 +1623,7 @@ function openCustomTouchAreaWindow(options = {}) {
                     : '保存失败!'
                 return
             }
+            touchSetSaveFlushedBeforeClose = true
         } finally {
             saveBeforeCloseInProgress = false
             saveButton.disabled = false
@@ -1627,14 +1632,18 @@ function openCustomTouchAreaWindow(options = {}) {
         floatingWindow.close()
     }
 
-    floatingWindow.onClose = function() {
+    floatingWindow.onClose = async function() {
         if (animationFrameId) {
             cancelAnimationFrame(animationFrameId)
             animationFrameId = null
         }
         const shouldReloadSourceModel = previewLoadStarted
+        let canReloadSourceModel = true
+        if (shouldReloadSourceModel && !touchSetSaveFlushedBeforeClose) {
+            canReloadSourceModel = await flushTouchSetSaveBeforePreviewClose()
+        }
         destroyPreviewModel()
-        if (shouldReloadSourceModel && typeof window.reloadCurrentLive2DModelInModelManager === 'function') {
+        if (shouldReloadSourceModel && canReloadSourceModel && typeof window.reloadCurrentLive2DModelInModelManager === 'function') {
             const reloadPromise = window.reloadCurrentLive2DModelInModelManager({
                 reason: 'custom-touch-area-preview-close'
             })

--- a/static/touch-config.js
+++ b/static/touch-config.js
@@ -753,6 +753,18 @@ function openCustomTouchAreaWindow(options = {}) {
     status.setAttribute('aria-live', 'polite')
     content.appendChild(status)
 
+    let saveBeforeCloseInProgress = false
+    const closeFloatingWindow = floatingWindow.close.bind(floatingWindow)
+    floatingWindow.close = function(cleanup) {
+        if (saveBeforeCloseInProgress) {
+            status.textContent = window.t
+                ? window.t('live2d.savingSettings', '正在保存设置...')
+                : '正在保存设置...'
+            return
+        }
+        closeFloatingWindow(cleanup)
+    }
+
     const buttons = document.createElement('div')
     buttons.className = 'hitarea-buttons touch-custom-buttons'
 
@@ -1493,11 +1505,9 @@ function openCustomTouchAreaWindow(options = {}) {
     })
 
     async function waitForActiveTouchSetSave() {
-        const startTime = Date.now()
-        while (isSaving && Date.now() - startTime < 3000) {
+        while (isSaving) {
             await new Promise(resolve => setTimeout(resolve, 50))
         }
-        return !isSaving
     }
 
     async function flushTouchSetSaveBeforePreviewClose() {
@@ -1506,8 +1516,11 @@ function openCustomTouchAreaWindow(options = {}) {
             autoSaveTimeout = null
         }
 
-        const saveSlotAvailable = await waitForActiveTouchSetSave()
-        if (!saveSlotAvailable) return false
+        await waitForActiveTouchSetSave()
+        if (autoSaveTimeout) {
+            clearTimeout(autoSaveTimeout)
+            autoSaveTimeout = null
+        }
 
         isSaving = true
         try {
@@ -1543,13 +1556,20 @@ function openCustomTouchAreaWindow(options = {}) {
             })
         }
         saveButton.disabled = true
-        const saveSuccess = await flushTouchSetSaveBeforePreviewClose()
-        saveButton.disabled = false
-        if (!saveSuccess) {
-            status.textContent = window.t
-                ? window.t('live2d.saveFailedGeneral', '保存失败!')
-                : '保存失败!'
-            return
+        cancelButton.disabled = true
+        saveBeforeCloseInProgress = true
+        try {
+            const saveSuccess = await flushTouchSetSaveBeforePreviewClose()
+            if (!saveSuccess) {
+                status.textContent = window.t
+                    ? window.t('live2d.saveFailedGeneral', '保存失败!')
+                    : '保存失败!'
+                return
+            }
+        } finally {
+            saveBeforeCloseInProgress = false
+            saveButton.disabled = false
+            cancelButton.disabled = false
         }
         floatingWindow.close()
     }

--- a/static/touch-config.js
+++ b/static/touch-config.js
@@ -1609,6 +1609,30 @@ function openCustomTouchAreaWindow(options = {}) {
         }
     }
 
+    async function drainTouchSetSaveBeforePreviewReload() {
+        let shouldFlushQueuedSave = !!autoSaveTimeout
+        if (shouldFlushQueuedSave) {
+            clearTimeout(autoSaveTimeout)
+            autoSaveTimeout = null
+        }
+
+        const saveAvailable = await waitForActiveTouchSetSave()
+        if (!saveAvailable) return false
+        if (autoSaveTimeout) {
+            clearTimeout(autoSaveTimeout)
+            autoSaveTimeout = null
+            shouldFlushQueuedSave = true
+        }
+        if (!shouldFlushQueuedSave) return true
+
+        isSaving = true
+        try {
+            return await saveTouchSetToServer()
+        } finally {
+            isSaving = false
+        }
+    }
+
     saveButton.onclick = async function() {
         if (saveButton.disabled) return
         const rect = selectionToNormalizedRect()
@@ -1657,8 +1681,11 @@ function openCustomTouchAreaWindow(options = {}) {
             animationFrameId = null
         }
         const shouldReloadSourceModel = previewLoadStarted
+        const canReloadSourceModel = shouldReloadSourceModel
+            ? await drainTouchSetSaveBeforePreviewReload()
+            : true
         destroyPreviewModel()
-        if (shouldReloadSourceModel && typeof window.reloadCurrentLive2DModelInModelManager === 'function') {
+        if (shouldReloadSourceModel && canReloadSourceModel && typeof window.reloadCurrentLive2DModelInModelManager === 'function') {
             const reloadPromise = window.reloadCurrentLive2DModelInModelManager({
                 reason: 'custom-touch-area-preview-close'
             })

--- a/static/touch-config.js
+++ b/static/touch-config.js
@@ -1437,11 +1437,16 @@ function openCustomTouchAreaWindow(options = {}) {
     }
 
     function drawPreviewFrame() {
+        const selectionBeforeLayout = !drawing && selectionRect ? selectionToNormalizedRect() : null
         const previewSizeChanged = resizePreviewRenderer()
         if (previewModelReady && (!previewModelFitted || previewSizeChanged)) {
             previewModelFitted = fitPreviewModelToWrap()
         }
         const metrics = updatePreviewMetrics()
+        if (selectionBeforeLayout && metrics.modelRect) {
+            selectionRect = normalizedRectToPreviewRect(selectionBeforeLayout, metrics.modelRect)
+            applyBoxRect(selectionBox, selectionRect)
+        }
         const dpr = window.devicePixelRatio || 1
         const targetWidth = Math.max(1, Math.round(metrics.wrapWidth * dpr))
         const targetHeight = Math.max(1, Math.round(metrics.wrapHeight * dpr))


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

自定义触摸区域改为独立渲染预览模型，关闭预览后通过模型管理页正常重载当前 Live2D 模型

## 测试 / Testing

手动测试自定义区域


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 自定义触控区域预览新增专用 Live2D 渲染层，并在就绪后自动切换显示；同时调整画布与交互覆盖层的显示顺序与透明度。
  * 支持重载当前模型时选择保留或重置运行时摆放与缩放（可通过偏好覆盖影响加载效果）。
* **Bug 修复**
  * 优化预览模型的加载、销毁与重绘流程，减少闪烁并统一基于预览边界的指标计算与渲染适配。
  * 改进保存与关闭的时序：避免保存中关闭、提升失败提示与恢复一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->