### PR TITLE
[codex] 修复备忘提醒触发生命周期

### DIFF
--- a/plugin/plugins/memo_reminder/__init__.py
+++ b/plugin/plugins/memo_reminder/__init__.py
@@ -163,8 +163,9 @@ class MemoReminderPlugin(NekoPluginBase):
         if not isinstance(data, list):
             return []
         return [
-            self._strip_legacy_deferred_fields(r) if isinstance(r, dict) else r
+            self._strip_legacy_deferred_fields(r)
             for r in data
+            if isinstance(r, dict)
         ]
 
     def _save_reminders_unlocked(self, reminders: List[Dict[str, Any]]) -> None:
@@ -675,12 +676,9 @@ class MemoReminderPlugin(NekoPluginBase):
     def _bind_task_sync(self, reminder_id: str, agent_task_id: str) -> bool:
         with self._reminders_lock:
             reminders = self._load_reminders_unlocked()
-            for idx, r in enumerate(reminders):
+            for r in reminders:
                 if r.get("id") == reminder_id:
-                    cleaned = self._strip_legacy_deferred_fields(r)
-                    if cleaned != r:
-                        reminders[idx] = cleaned
-                        self._save_reminders_unlocked(reminders)
+                    self._save_reminders_unlocked(reminders)
                     self.logger.info(
                         "Ignored legacy bind_task agent_task_id={} for reminder={}",
                         agent_task_id,

--- a/plugin/plugins/memo_reminder/__init__.py
+++ b/plugin/plugins/memo_reminder/__init__.py
@@ -31,7 +31,6 @@ _STORE_KEY = "reminders"
 
 _TZ_UTC = timezone.utc
 _DEFAULT_TZ = "Asia/Shanghai"
-DEFERRED_WINDOW_SECONDS = 3600  # 与 agent_server 的 DEFERRED_TASK_TIMEOUT 对齐（1小时）
 
 _FORMATS_WITH_DATE = (
     ("%Y-%m-%d %H:%M:%S", True),
@@ -161,7 +160,12 @@ class MemoReminderPlugin(NekoPluginBase):
 
     def _load_reminders_unlocked(self) -> List[Dict[str, Any]]:
         data = self._store_get_sync(_STORE_KEY, [])
-        return data if isinstance(data, list) else []
+        if not isinstance(data, list):
+            return []
+        return [
+            self._strip_legacy_deferred_fields(r) if isinstance(r, dict) else r
+            for r in data
+        ]
 
     def _save_reminders_unlocked(self, reminders: List[Dict[str, Any]]) -> None:
         self._store_set_sync(_STORE_KEY, reminders)
@@ -173,6 +177,23 @@ class MemoReminderPlugin(NekoPluginBase):
     def _save_reminders(self, reminders: List[Dict[str, Any]]) -> None:
         with self._reminders_lock:
             self._save_reminders_unlocked(reminders)
+
+    @staticmethod
+    def _strip_legacy_deferred_fields(reminder: Dict[str, Any]) -> Dict[str, Any]:
+        """Drop old deferred-task callback fields from persisted reminders."""
+        legacy_keys = (
+            "agent_task_id",
+            "deferred_bind_pending",
+            "callback_pending",
+            "callback_error",
+            "callback_retry_count",
+        )
+        if not any(key in reminder for key in legacy_keys):
+            return reminder
+        cleaned = dict(reminder)
+        for key in legacy_keys:
+            cleaned.pop(key, None)
+        return cleaned
 
     def _notify_change(self) -> None:
         """唤醒 checker 线程，使其立即重新计算下次触发时间。若线程已死则重启。"""
@@ -279,9 +300,8 @@ class MemoReminderPlugin(NekoPluginBase):
         self.logger.info("Checker thread exiting")
 
     def _fire_due_reminders(self) -> None:
-        # Phase 1 — under lock: classify reminders, save snapshot
+        # Phase 1 - under lock: classify reminders and save a cleaned snapshot.
         to_push: List[Dict[str, Any]] = []
-        to_retry_cb: List[Dict[str, Any]] = []
 
         self.logger.info("_fire_due: acquiring lock...")
         with self._reminders_lock:
@@ -299,7 +319,8 @@ class MemoReminderPlugin(NekoPluginBase):
                 self.logger.info("Checker tick: {} reminders, now={}", len(reminders), now.isoformat())
             kept: List[Dict[str, Any]] = []
 
-            for r in reminders:
+            for raw in reminders:
+                r = self._strip_legacy_deferred_fields(raw)
                 trigger_iso = r.get("trigger_at", "")
                 try:
                     trigger_dt = datetime.fromisoformat(trigger_iso)
@@ -307,31 +328,17 @@ class MemoReminderPlugin(NekoPluginBase):
                     kept.append(r)
                     continue
 
-                if r.get("delivered") and r.get("callback_pending"):
-                    to_retry_cb.append(r)
-                    continue
-
                 if trigger_dt <= now:
-                    if r.get("deferred_bind_pending") and r.get("agent_task_id") is None:
-                        try:
-                            created_dt = datetime.fromisoformat(
-                                r.get("created_at", "").replace("Z", "+00:00")
-                            )
-                            if (now - created_dt).total_seconds() < 5.0:
-                                kept.append(r)
-                                continue
-                        except (ValueError, TypeError):
-                            pass
                     to_push.append(r)
                 else:
                     kept.append(r)
 
-            self._save_reminders_unlocked(kept + to_push + to_retry_cb)
+            self._save_reminders_unlocked(kept + to_push)
 
-        if not to_push and not to_retry_cb:
+        if not to_push:
             return
 
-        # Phase 2 — NO lock: do all I/O (ZMQ push, HTTP callbacks)
+        # Phase 2 - no lock: push reminder events. Reminder firing does not complete agent tasks.
         fired_ids: List[str] = []
 
         for r in to_push:
@@ -341,50 +348,13 @@ class MemoReminderPlugin(NekoPluginBase):
             except Exception:
                 self.logger.exception("Failed to push reminder {}", rid)
                 continue
-            if not r.get("callback_pending"):
-                fired_ids.append(rid)
+            fired_ids.append(rid)
 
-        for r in to_retry_cb:
-            rid = r.get("id", "?")
-            agent_task_id = r.get("agent_task_id")
-            if not agent_task_id:
-                fired_ids.append(rid)
-                continue
-            try:
-                import httpx as _httpx
-                from config import TOOL_SERVER_PORT
-                with _httpx.Client(timeout=2.0, proxy=None, trust_env=False) as c:
-                    resp = c.post(f"http://127.0.0.1:{TOOL_SERVER_PORT}/api/agent/tasks/{agent_task_id}/complete")
-                    if resp.is_success:
-                        r["callback_pending"] = False
-                        r["callback_error"] = None
-                        self.logger.info("Retry callback succeeded for reminder {}", rid)
-                        fired_ids.append(rid)
-                        continue
-                    elif resp.status_code == 404:
-                        r["callback_pending"] = False
-                        r["callback_error"] = "Task not found (404)"
-                        self.logger.warning("Retry callback abandoned for reminder {}: 404", rid)
-                        fired_ids.append(rid)
-                        continue
-                    else:
-                        self.logger.warning("Retry callback failed for reminder {}: HTTP {}", rid, resp.status_code)
-            except Exception as e:
-                self.logger.warning("Retry callback exception for reminder {}: {}", rid, e)
-            retry_count = r.get("callback_retry_count", 0) + 1
-            if retry_count >= 5:
-                self.logger.warning("Retry callback abandoned for reminder {}: max retries", rid)
-                r["callback_pending"] = False
-                r["callback_error"] = "Max retries exceeded"
-                fired_ids.append(rid)
-            else:
-                r["callback_retry_count"] = retry_count
-
-        # Phase 3 — under lock: merge results back (handles concurrent add/delete)
+        # Phase 3 - under lock: merge results back (handles concurrent add/delete).
         with self._reminders_lock:
-            processed_ids = {r.get("id") for r in to_push + to_retry_cb}
+            processed_ids = {r.get("id") for r in to_push}
             final: List[Dict[str, Any]] = []
-            for r in to_push + to_retry_cb:
+            for r in to_push:
                 rid = r.get("id", "?")
                 if rid in fired_ids:
                     updated = self._reschedule(r, now)
@@ -409,11 +379,12 @@ class MemoReminderPlugin(NekoPluginBase):
                 source="memo_reminder",
                 visibility=[],
                 ai_behavior="respond",
-                parts=[{"type": "text", "text": f"⏰ 提醒: {msg}"}],
+                parts=[{"type": "text", "text": f"⏰ 之前设置的提醒时间到了：{msg}"}],
                 priority=8,
                 metadata={
                     "task_id": rid,
                     "reminder_id": rid,
+                    "event_type": "reminder_fired",
                     "repeat": repeat_label,
                     "trigger_at": r.get("trigger_at"),
                     "created_at": r.get("created_at"),
@@ -424,28 +395,6 @@ class MemoReminderPlugin(NekoPluginBase):
             )
             # 标记消息已发送
             r["delivered"] = True
-
-        # 通知 agent_server deferred 任务已完成
-        agent_task_id = r.get("agent_task_id")
-        if agent_task_id:
-            try:
-                import httpx as _httpx
-                from config import TOOL_SERVER_PORT
-                with _httpx.Client(timeout=2.0, proxy=None, trust_env=False) as c:
-                    resp = c.post(f"http://127.0.0.1:{TOOL_SERVER_PORT}/api/agent/tasks/{agent_task_id}/complete")
-                    if not resp.is_success:
-                        self.logger.warning(
-                            "Failed to notify agent task completion for reminder {}: HTTP {} - {}",
-                            rid, resp.status_code, resp.text
-                        )
-                        # 标记回调待重试（但不抛出异常，避免消息重复发送）
-                        r["callback_pending"] = True
-                        r["callback_error"] = f"HTTP {resp.status_code}: {resp.text}"
-            except Exception as e:
-                self.logger.warning("Failed to notify agent task completion for reminder {}: {}", rid, e)
-                # 标记回调待重试
-                r["callback_pending"] = True
-                r["callback_error"] = str(e)
 
     @staticmethod
     def _reschedule(r: Dict[str, Any], now: datetime) -> Optional[Dict[str, Any]]:
@@ -500,7 +449,7 @@ class MemoReminderPlugin(NekoPluginBase):
         r.pop("callback_pending", None)
         r.pop("callback_error", None)
         r.pop("callback_retry_count", None)
-        # 清除旧的任务关联，下次触发时会生成新的 agent_task_id
+        # Drop legacy deferred-task fields so repeats stay on the reminder-only lifecycle.
         r.pop("agent_task_id", None)
         r.pop("deferred_bind_pending", None)
         return r
@@ -602,10 +551,6 @@ class MemoReminderPlugin(NekoPluginBase):
         if not lanlan_name:
             lanlan_name = getattr(self.ctx, "_current_lanlan", None)
 
-        # 只有当触发时间在 1 小时内时才需要 deferred 机制（与 agent_server 的 DEFERRED_TASK_TIMEOUT 对齐）
-        trigger_delay = (trigger_dt - now).total_seconds()
-        needs_deferred = trigger_delay < DEFERRED_WINDOW_SECONDS
-
         rid = uuid.uuid4().hex[:12]
         reminder = {
             "id": rid,
@@ -614,8 +559,6 @@ class MemoReminderPlugin(NekoPluginBase):
             "created_at": now.isoformat(),
             "repeat": repeat,
             "lanlan_name": lanlan_name,
-            "agent_task_id": None,
-            "deferred_bind_pending": needs_deferred,
         }
         if max_count is not None and repeat != "once":
             reminder["max_count"] = int(max_count)
@@ -640,7 +583,6 @@ class MemoReminderPlugin(NekoPluginBase):
 
         return Ok({
             "status": "scheduled",
-            "deferred": needs_deferred,
             "reminder_id": rid,
             "trigger_at_local": local_str,
             "repeat": repeat,
@@ -657,14 +599,14 @@ class MemoReminderPlugin(NekoPluginBase):
     @plugin_entry(
         id="bind_task",
         name="绑定Agent任务ID",
-        description="内部接口：将 agent_task_id 关联到提醒记录，用于 deferred 完成通知",
+        description="兼容旧 deferred 调用；提醒触发不再绑定 agent_task_id 或回调完成任务",
     )
     async def bind_task(self, reminder_id: str, agent_task_id: str, **kwargs):
-        """将 agent_task_id 写回到对应的提醒记录，供 daemon 触发时回调使用"""
+        """Compatibility no-op for old deferred reminder binding calls."""
         bound = await asyncio.to_thread(self._bind_task_sync, reminder_id, agent_task_id)
         if bound:
             self._notify_change()
-            return Ok({"bound": True})
+            return Ok({"bound": True, "ignored": True})
         return Err(SdkError(f"Reminder {reminder_id} not found"))
 
     @plugin_entry(
@@ -733,12 +675,17 @@ class MemoReminderPlugin(NekoPluginBase):
     def _bind_task_sync(self, reminder_id: str, agent_task_id: str) -> bool:
         with self._reminders_lock:
             reminders = self._load_reminders_unlocked()
-            for r in reminders:
+            for idx, r in enumerate(reminders):
                 if r.get("id") == reminder_id:
-                    r["agent_task_id"] = agent_task_id
-                    r["deferred_bind_pending"] = False
-                    self._save_reminders_unlocked(reminders)
-                    self.logger.info("Bound agent_task_id={} to reminder={}", agent_task_id, reminder_id)
+                    cleaned = self._strip_legacy_deferred_fields(r)
+                    if cleaned != r:
+                        reminders[idx] = cleaned
+                        self._save_reminders_unlocked(reminders)
+                    self.logger.info(
+                        "Ignored legacy bind_task agent_task_id={} for reminder={}",
+                        agent_task_id,
+                        reminder_id,
+                    )
                     return True
         return False
 

--- a/plugin/tests/unit/plugins/test_memo_reminder_lifecycle.py
+++ b/plugin/tests/unit/plugins/test_memo_reminder_lifecycle.py
@@ -180,6 +180,38 @@ def test_repeating_due_reminder_reschedules_and_strips_legacy_deferred_fields() 
 
 
 @pytest.mark.plugin_unit
+def test_load_reminders_drops_non_dict_dirty_records() -> None:
+    plugin = _plugin()
+    future = (datetime.now(timezone.utc) + timedelta(minutes=10)).isoformat()
+    plugin.store.data[_STORE_KEY] = [
+        "bad-record",
+        None,
+        42,
+        {
+            "id": "valid123456",
+            "message": "喝水",
+            "trigger_at": future,
+            "created_at": future,
+            "repeat": "once",
+            "agent_task_id": "task-1",
+            "callback_pending": True,
+        },
+    ]
+
+    reminders = plugin._load_reminders()
+
+    assert reminders == [
+        {
+            "id": "valid123456",
+            "message": "喝水",
+            "trigger_at": future,
+            "created_at": future,
+            "repeat": "once",
+        }
+    ]
+
+
+@pytest.mark.plugin_unit
 @pytest.mark.asyncio
 async def test_bind_task_is_kept_as_compatibility_noop() -> None:
     plugin = _plugin()
@@ -191,6 +223,11 @@ async def test_bind_task_is_kept_as_compatibility_noop() -> None:
             "trigger_at": future,
             "created_at": future,
             "repeat": "once",
+            "agent_task_id": "old-task",
+            "deferred_bind_pending": True,
+            "callback_pending": True,
+            "callback_error": "old failure",
+            "callback_retry_count": 2,
         }
     ])
 

--- a/plugin/tests/unit/plugins/test_memo_reminder_lifecycle.py
+++ b/plugin/tests/unit/plugins/test_memo_reminder_lifecycle.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import threading
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from plugin.plugins.memo_reminder import MemoReminderPlugin, _STORE_KEY
+
+
+class _Logger:
+    def info(self, *args, **kwargs) -> None:
+        pass
+
+    def warning(self, *args, **kwargs) -> None:
+        pass
+
+    def exception(self, *args, **kwargs) -> None:
+        pass
+
+
+class _Store:
+    enabled = True
+    _db_path = ":memory:"
+
+    def __init__(self) -> None:
+        self.data: dict[str, object] = {}
+
+    def _read_value(self, key: str, default: object = None) -> object:
+        return self.data.get(key, default)
+
+    def _write_value(self, key: str, value: object) -> None:
+        self.data[key] = value
+
+
+class _Context:
+    _current_lanlan = "Lanlan"
+
+    def __init__(self) -> None:
+        self.pushed: list[dict[str, object]] = []
+
+    def push_message(self, **kwargs: object) -> dict[str, object]:
+        self.pushed.append(kwargs)
+        return {"ok": True}
+
+
+def _plugin() -> MemoReminderPlugin:
+    plugin = MemoReminderPlugin.__new__(MemoReminderPlugin)
+    plugin.ctx = _Context()
+    plugin.store = _Store()
+    plugin.logger = _Logger()
+    plugin._reminders_lock = threading.Lock()
+    plugin._wake_event = threading.Event()
+    plugin._stop_event = threading.Event()
+    plugin._checker_thread = None
+    plugin._tz = ZoneInfo("Asia/Shanghai")
+    return plugin
+
+
+def _due_iso(seconds_ago: int = 1) -> str:
+    return (datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)).isoformat()
+
+
+def _legacy_keys() -> set[str]:
+    return {
+        "agent_task_id",
+        "deferred_bind_pending",
+        "callback_pending",
+        "callback_error",
+        "callback_retry_count",
+    }
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_add_reminder_completes_scheduling_without_deferred_task_fields() -> None:
+    plugin = _plugin()
+
+    result = await plugin.add_reminder(time="30m", message="喝水")
+
+    assert result.is_ok()
+    payload = result.value
+    assert payload["status"] == "scheduled"
+    assert "deferred" not in payload
+
+    reminders = plugin.store.data[_STORE_KEY]
+    assert isinstance(reminders, list)
+    assert len(reminders) == 1
+    reminder = reminders[0]
+    assert isinstance(reminder, dict)
+    assert reminder["message"] == "喝水"
+    assert _legacy_keys().isdisjoint(reminder)
+
+
+@pytest.mark.plugin_unit
+def test_due_legacy_deferred_record_pushes_reminder_without_task_callback() -> None:
+    plugin = _plugin()
+    due = _due_iso()
+    plugin._save_reminders([
+        {
+            "id": "legacy123456",
+            "message": "喝水",
+            "trigger_at": due,
+            "created_at": due,
+            "repeat": "once",
+            "agent_task_id": "task-1",
+            "deferred_bind_pending": False,
+            "callback_pending": True,
+            "callback_error": "old failure",
+            "callback_retry_count": 2,
+        }
+    ])
+
+    plugin._fire_due_reminders()
+
+    assert len(plugin.ctx.pushed) == 1
+    pushed = plugin.ctx.pushed[0]
+    assert pushed["parts"] == [{"type": "text", "text": "⏰ 之前设置的提醒时间到了：喝水"}]
+    assert pushed["metadata"]["event_type"] == "reminder_fired"
+    assert plugin.store.data[_STORE_KEY] == []
+
+
+@pytest.mark.plugin_unit
+def test_delivered_legacy_callback_record_is_removed_without_duplicate_push() -> None:
+    plugin = _plugin()
+    due = _due_iso()
+    plugin._save_reminders([
+        {
+            "id": "delivered123",
+            "message": "喝水",
+            "trigger_at": due,
+            "created_at": due,
+            "repeat": "once",
+            "delivered": True,
+            "agent_task_id": "task-1",
+            "callback_pending": True,
+            "callback_retry_count": 3,
+        }
+    ])
+
+    plugin._fire_due_reminders()
+
+    assert plugin.ctx.pushed == []
+    assert plugin.store.data[_STORE_KEY] == []
+
+
+@pytest.mark.plugin_unit
+def test_repeating_due_reminder_reschedules_and_strips_legacy_deferred_fields() -> None:
+    plugin = _plugin()
+    due = _due_iso()
+    plugin._save_reminders([
+        {
+            "id": "repeat123456",
+            "message": "站起来",
+            "trigger_at": due,
+            "created_at": due,
+            "repeat": "10s",
+            "max_count": 2,
+            "fire_count": 0,
+            "agent_task_id": "task-1",
+            "deferred_bind_pending": False,
+            "callback_pending": True,
+        }
+    ])
+
+    plugin._fire_due_reminders()
+
+    assert len(plugin.ctx.pushed) == 1
+    reminders = plugin.store.data[_STORE_KEY]
+    assert isinstance(reminders, list)
+    assert len(reminders) == 1
+    reminder = reminders[0]
+    assert isinstance(reminder, dict)
+    assert reminder["id"] == "repeat123456"
+    assert reminder["fire_count"] == 1
+    assert "delivered" not in reminder
+    assert _legacy_keys().isdisjoint(reminder)
+    assert datetime.fromisoformat(reminder["trigger_at"]) > datetime.now(timezone.utc)
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_bind_task_is_kept_as_compatibility_noop() -> None:
+    plugin = _plugin()
+    future = (datetime.now(timezone.utc) + timedelta(minutes=10)).isoformat()
+    plugin._save_reminders([
+        {
+            "id": "compat123456",
+            "message": "喝水",
+            "trigger_at": future,
+            "created_at": future,
+            "repeat": "once",
+        }
+    ])
+
+    result = await plugin.bind_task(reminder_id="compat123456", agent_task_id="task-1")
+
+    assert result.is_ok()
+    assert result.value == {"bound": True, "ignored": True}
+    reminder = plugin.store.data[_STORE_KEY][0]
+    assert _legacy_keys().isdisjoint(reminder)


### PR DESCRIPTION
## 改动概述

备忘提醒的设置动作现在只负责保存提醒计划，成功后立即结束；提醒到点由后台检查线程推送独立提醒事件，不再复用 agent task 的 deferred completion 生命周期。

这次同时清理旧持久化记录中的 `agent_task_id`、`deferred_bind_pending`、`callback_pending` 等历史字段，避免旧提醒继续触发任务完成回调；`bind_task` 入口保留为兼容 no-op，降低旧调用直接失败的风险。

## 风险与边界

本轮只调整 `memo_reminder` 插件生命周期和对应单元测试，不引入 HUD 倒计时，也不删除 `bind_task` 入口。主要回归风险集中在提醒触发、旧记录兼容和重复提醒重排路径；后续如果需要提醒倒计时，应单独设计 reminder 状态，而不是复用 agent task 生命周期。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 提醒触发改为以提醒自身到期时间为准，不再依赖旧的回调完成链路。
  * 清理旧版遗留的触发/回调字段，避免历史数据干扰；重复到期会自动重排并提升状态一致性。
  * 触发后推送文案与事件标识更新；旧的绑定任务逻辑已兼容但会被忽略。
* **Tests**
  * 新增/补全提醒生命周期与遗留字段兼容的单元测试覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->