### PR TITLE
Fix NetEase Music cookie injection compatibility

### DIFF
--- a/main_routers/music_router.py
+++ b/main_routers/music_router.py
@@ -120,14 +120,14 @@ def _ensure_pyncm() -> bool:
 def _sync_pyncm_session_cookies(session, cookies: dict[str, str]) -> bool:
     """Sync NetEase cookies into the current pyncm_async session across API versions."""
     cookie_jar = getattr(session, "cookies", None)
-    if cookie_jar is None:
-        client = getattr(session, "client", None)
-        cookie_jar = getattr(client, "cookies", None)
-
     cookie_setter = getattr(cookie_jar, "set", None)
     if not callable(cookie_setter):
-        logger.warning("[音乐播放] pyncm_async Session 不支持 Cookie 注入，已跳过登录态同步")
-        return False
+        client = getattr(session, "client", None)
+        cookie_jar = getattr(client, "cookies", None)
+        cookie_setter = getattr(cookie_jar, "set", None)
+        if not callable(cookie_setter):
+            logger.warning("[音乐播放] pyncm_async Session 不支持 Cookie 注入，已跳过登录态同步")
+            return False
 
     for key, value in cookies.items():
         cookie_setter(key, value)

--- a/main_routers/music_router.py
+++ b/main_routers/music_router.py
@@ -119,18 +119,26 @@ def _ensure_pyncm() -> bool:
 
 def _sync_pyncm_session_cookies(session, cookies: dict[str, str]) -> bool:
     """Sync NetEase cookies into the current pyncm_async session across API versions."""
-    cookie_jar = getattr(session, "cookies", None)
-    cookie_setter = getattr(cookie_jar, "set", None)
-    if not callable(cookie_setter):
-        client = getattr(session, "client", None)
-        cookie_jar = getattr(client, "cookies", None)
+    cookie_setters = []
+    seen_cookie_jars = set()
+    for cookie_jar in (
+        getattr(session, "cookies", None),
+        getattr(getattr(session, "client", None), "cookies", None),
+    ):
+        if cookie_jar is None or id(cookie_jar) in seen_cookie_jars:
+            continue
         cookie_setter = getattr(cookie_jar, "set", None)
-        if not callable(cookie_setter):
-            logger.warning("[音乐播放] pyncm_async Session 不支持 Cookie 注入，已跳过登录态同步")
-            return False
+        if callable(cookie_setter):
+            cookie_setters.append(cookie_setter)
+            seen_cookie_jars.add(id(cookie_jar))
+
+    if not cookie_setters:
+        logger.warning("[音乐播放] pyncm_async Session 不支持 Cookie 注入，已跳过登录态同步")
+        return False
 
     for key, value in cookies.items():
-        cookie_setter(key, value)
+        for cookie_setter in cookie_setters:
+            cookie_setter(key, value)
     return True
 
 # ==================== 音乐代理缓存 ====================

--- a/main_routers/music_router.py
+++ b/main_routers/music_router.py
@@ -136,10 +136,19 @@ def _sync_pyncm_session_cookies(session, cookies: dict[str, str]) -> bool:
         logger.warning("[音乐播放] pyncm_async Session 不支持 Cookie 注入，已跳过登录态同步")
         return False
 
-    for key, value in cookies.items():
-        for cookie_setter in cookie_setters:
-            cookie_setter(key, value)
-    return True
+    synced = False
+    for cookie_setter in cookie_setters:
+        try:
+            for key, value in cookies.items():
+                cookie_setter(key, value)
+        except Exception as exc:
+            logger.warning("[音乐播放] pyncm_async Cookie 注入失败，尝试下一个 CookieJar: %s", exc)
+            continue
+        synced = True
+
+    if not synced:
+        logger.warning("[音乐播放] pyncm_async Session 不支持 Cookie 注入，已跳过登录态同步")
+    return synced
 
 # ==================== 音乐代理缓存 ====================
 # 仅缓存小文件（<10MB），大文件流式传输

--- a/main_routers/music_router.py
+++ b/main_routers/music_router.py
@@ -116,6 +116,23 @@ def _ensure_pyncm() -> bool:
         logger.error("[Music] pyncm_async unavailable, netease VIP playback disabled: %s", _pyncm_err)
     return _PYNCM_AVAILABLE
 
+
+def _sync_pyncm_session_cookies(session, cookies: dict[str, str]) -> bool:
+    """Sync NetEase cookies into the current pyncm_async session across API versions."""
+    cookie_jar = getattr(session, "cookies", None)
+    if cookie_jar is None:
+        client = getattr(session, "client", None)
+        cookie_jar = getattr(client, "cookies", None)
+
+    cookie_setter = getattr(cookie_jar, "set", None)
+    if not callable(cookie_setter):
+        logger.warning("[音乐播放] pyncm_async Session 不支持 Cookie 注入，已跳过登录态同步")
+        return False
+
+    for key, value in cookies.items():
+        cookie_setter(key, value)
+    return True
+
 # ==================== 音乐代理缓存 ====================
 # 仅缓存小文件（<10MB），大文件流式传输
 MUSIC_PROXY_CACHE = TTLCache(
@@ -391,9 +408,7 @@ async def play_netease_music(song_id: str):
         cookies = await asyncio.to_thread(load_cookies_from_file, 'netease')
         if cookies:
             session = pyncm_async.GetCurrentSession()
-            # 兼容性处理：pyncm_async 内部使用 httpx，直接注入 cookiejar
-            for k, v in cookies.items():
-                session.client.cookies.set(k, v)
+            _sync_pyncm_session_cookies(session, cookies)
 
         # 获取真实播放地址 (IDs 接受列表)
         # 默认获取 standard 标准音质，VIP 账户通常可获得更多 Token 授权

--- a/tests/unit/test_music_router.py
+++ b/tests/unit/test_music_router.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+
+import pytest
+
+from main_routers import music_router
+
+
+class CookieRecorder:
+    def __init__(self):
+        self.values = {}
+
+    def set(self, key, value):
+        self.values[key] = value
+
+
+def test_sync_pyncm_session_cookies_uses_modern_session_cookie_jar():
+    session = SimpleNamespace(cookies=CookieRecorder())
+
+    assert music_router._sync_pyncm_session_cookies(session, {"MUSIC_U": "token"}) is True
+    assert session.cookies.values == {"MUSIC_U": "token"}
+
+
+def test_sync_pyncm_session_cookies_supports_legacy_client_cookie_jar():
+    legacy_client = SimpleNamespace(cookies=CookieRecorder())
+    session = SimpleNamespace(client=legacy_client)
+
+    assert music_router._sync_pyncm_session_cookies(session, {"MUSIC_U": "token"}) is True
+    assert legacy_client.cookies.values == {"MUSIC_U": "token"}
+
+
+@pytest.mark.asyncio
+async def test_play_netease_music_syncs_cookies_without_session_client(monkeypatch):
+    session = SimpleNamespace(cookies=CookieRecorder())
+
+    async def fake_get_track_audio(song_ids):
+        assert song_ids == [2070160351]
+        return {"data": [{"url": "https://m7.music.126.net/song.mp3"}]}
+
+    monkeypatch.setattr(
+        music_router,
+        "pyncm_async",
+        SimpleNamespace(GetCurrentSession=lambda: session),
+    )
+    monkeypatch.setattr(music_router, "GetTrackAudio", fake_get_track_audio)
+    monkeypatch.setattr(music_router, "_PYNCM_AVAILABLE", True)
+    monkeypatch.setattr(
+        music_router,
+        "load_cookies_from_file",
+        lambda platform: {"MUSIC_U": "token"} if platform == "netease" else {},
+    )
+
+    response = await music_router.play_netease_music("2070160351")
+
+    assert response.status_code == 307
+    assert response.headers["location"] == "https://m7.music.126.net/song.mp3"
+    assert session.cookies.values == {"MUSIC_U": "token"}

--- a/tests/unit/test_music_router.py
+++ b/tests/unit/test_music_router.py
@@ -28,6 +28,14 @@ def test_sync_pyncm_session_cookies_supports_legacy_client_cookie_jar():
     assert legacy_client.cookies.values == {"MUSIC_U": "token"}
 
 
+def test_sync_pyncm_session_cookies_falls_back_when_session_cookies_is_not_mutable():
+    legacy_client = SimpleNamespace(cookies=CookieRecorder())
+    session = SimpleNamespace(cookies=object(), client=legacy_client)
+
+    assert music_router._sync_pyncm_session_cookies(session, {"MUSIC_U": "token"}) is True
+    assert legacy_client.cookies.values == {"MUSIC_U": "token"}
+
+
 @pytest.mark.asyncio
 async def test_play_netease_music_syncs_cookies_without_session_client(monkeypatch):
     session = SimpleNamespace(cookies=CookieRecorder())

--- a/tests/unit/test_music_router.py
+++ b/tests/unit/test_music_router.py
@@ -36,6 +36,19 @@ def test_sync_pyncm_session_cookies_falls_back_when_session_cookies_is_not_mutab
     assert legacy_client.cookies.values == {"MUSIC_U": "token"}
 
 
+def test_sync_pyncm_session_cookies_writes_all_mutable_cookie_jars():
+    session_cookies = CookieRecorder()
+    client_cookies = CookieRecorder()
+    session = SimpleNamespace(
+        cookies=session_cookies,
+        client=SimpleNamespace(cookies=client_cookies),
+    )
+
+    assert music_router._sync_pyncm_session_cookies(session, {"MUSIC_U": "token"}) is True
+    assert session_cookies.values == {"MUSIC_U": "token"}
+    assert client_cookies.values == {"MUSIC_U": "token"}
+
+
 @pytest.mark.asyncio
 async def test_play_netease_music_syncs_cookies_without_session_client(monkeypatch):
     session = SimpleNamespace(cookies=CookieRecorder())

--- a/tests/unit/test_music_router.py
+++ b/tests/unit/test_music_router.py
@@ -13,6 +13,11 @@ class CookieRecorder:
         self.values[key] = value
 
 
+class FailingCookieRecorder:
+    def set(self, key, value):
+        raise RuntimeError("detached jar")
+
+
 def test_sync_pyncm_session_cookies_uses_modern_session_cookie_jar():
     session = SimpleNamespace(cookies=CookieRecorder())
 
@@ -46,6 +51,17 @@ def test_sync_pyncm_session_cookies_writes_all_mutable_cookie_jars():
 
     assert music_router._sync_pyncm_session_cookies(session, {"MUSIC_U": "token"}) is True
     assert session_cookies.values == {"MUSIC_U": "token"}
+    assert client_cookies.values == {"MUSIC_U": "token"}
+
+
+def test_sync_pyncm_session_cookies_continues_after_setter_failure():
+    client_cookies = CookieRecorder()
+    session = SimpleNamespace(
+        cookies=FailingCookieRecorder(),
+        client=SimpleNamespace(cookies=client_cookies),
+    )
+
+    assert music_router._sync_pyncm_session_cookies(session, {"MUSIC_U": "token"}) is True
     assert client_cookies.values == {"MUSIC_U": "token"}
 
 


### PR DESCRIPTION
## 改动概述 / Summary

Fixes NetEase Music authenticated playback URL resolution failing with `'Session' object has no attribute 'client'`.

The playback route now syncs cookies through `session.cookies` for the current `pyncm_async` Session implementation, while keeping a fallback for older `session.client.cookies`-style objects.

## 回归报告 / Regression Report

- 改动了什么：
  - Updated `main_routers/music_router.py` to sync NetEase cookies through a compatibility helper.
  - The helper first tries `session.cookies.set(...)`, then falls back to `session.client.cookies.set(...)` when the direct cookie jar is missing or not mutable.

- 理由 / 必要性：
  - The current locked `pyncm_async` Session is itself an `httpx.AsyncClient`, so cookies live on `session.cookies`.
  - The previous code assumed `session.client.cookies`, which raises `'Session' object has no attribute 'client'` and prevents authenticated playback URL resolution.

- 改动前后的表现对比：
  - Before: NetEase playback could fail during cookie injection before calling `GetTrackAudio`, then fall back to the unauthenticated public outer URL.
  - After: Cookies are injected for both modern and legacy Session shapes, allowing authenticated real playback URL resolution to proceed.

- 潜在回归点：
  - NetEase playback route cookie synchronization.
  - Legacy `pyncm_async`-style Session objects that expose cookies through `session.client.cookies`.
  - No changes to music search or proxy behavior.

- 验证方式：
  - Added unit coverage for modern `session.cookies`, legacy `session.client.cookies`, and the fallback case where `session.cookies` exists but is not mutable.
  - Ran music route and crawler tests successfully.

## 不拆分理由 / Why Not Split

不适用

## 测试 / Testing

- `.\.venv\Scripts\python.exe -m pytest tests\unit\test_music_router.py tests\unit\test_music_crawlers.py`

Result: `12 passed, 1 skipped`.
——end——

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化网易云音乐播放流程的 Cookie 同步：自动兼容不同会话 Cookie 容器（现代与 legacy），必要时进行降级注入，提升稳定性与登录态传递成功率。
  * 无法获取真实播放链接时，仍保持备用地址跳转，减少播放失败。
* **Tests**
  * 扩展 Cookie 同步与异常场景的单元测试，并新增播放接口异步测试，覆盖缺失客户端会话等情况。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->