### PR TITLE
移除 goodbye 恢复流程里触发独立猫爪任务窗口的调用，只恢复页面内原有任务 HUD，并补充回归断言

### DIFF
--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -296,9 +296,6 @@
                 if (typeof window.checkAndToggleTaskHUD === 'function') {
                     window.checkAndToggleTaskHUD();
                 }
-                if (window.nekoAgentHud && typeof window.nekoAgentHud.show === 'function') {
-                    window.nekoAgentHud.show();
-                }
             } catch (error) {
                 console.warn('[GoodbyeResource] Agent HUD restore failed:', error);
             }

--- a/templates/agenthud.html
+++ b/templates/agenthud.html
@@ -13,7 +13,7 @@
         html, body {
             margin: 0; padding: 0;
             width: 100%; height: 100%;
-            background: #1a1a2e;
+            background: transparent !important;
             overflow: hidden;
         }
         /* AgentHUD 独立窗口：复用 common-ui-hud.js 的样式 */

--- a/templates/agenthud.html
+++ b/templates/agenthud.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="agent-hud-standalone-page">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -10,7 +10,8 @@
     <link rel="stylesheet" href="/static/css/dark-mode.css">
     <script src="/static/theme-manager.js"></script>
     <style>
-        html, body {
+        html.agent-hud-standalone-page,
+        body.agent-hud-standalone-page:not(.lanlan-pet-mode) {
             margin: 0; padding: 0;
             width: 100%; height: 100%;
             background: transparent !important;

--- a/tests/unit/test_goodbye_resource_suspend_static.py
+++ b/tests/unit/test_goodbye_resource_suspend_static.py
@@ -10,6 +10,7 @@ APP_AGENT_PATH = REPO_ROOT / "static" / "app-agent.js"
 APP_UI_PATH = REPO_ROOT / "static" / "app-ui.js"
 APP_WEBSOCKET_PATH = REPO_ROOT / "static" / "app-websocket.js"
 COMMON_UI_HUD_PATH = REPO_ROOT / "static" / "common-ui-hud.js"
+AGENTHUD_TEMPLATE_PATH = REPO_ROOT / "templates" / "agenthud.html"
 PNGTUBER_PATH = REPO_ROOT / "static" / "pngtuber-core.js"
 PLUGIN_DASHBOARD_PATH = REPO_ROOT / "frontend" / "plugin-manager" / "src" / "views" / "Dashboard.vue"
 PLUGIN_METRICS_VIEW_PATH = REPO_ROOT / "frontend" / "plugin-manager" / "src" / "views" / "Metrics.vue"
@@ -131,6 +132,9 @@ def test_goodbye_resource_suspend_waits_for_cat_transition_and_uses_token_snapsh
     assert "goodbyeResourceSuspendToken += 1;" in restore_suspend
     assert restore_suspend.index("resumeModelRenderingFromGoodbye(snapshot);") < restore_suspend.index("publishGoodbyeResourceState(null, reason || 'goodbye-resource-restoring');")
     assert "restoreWindow: true" in restore_suspend
+    assert "window.AgentHUD.showAgentTaskHUD();" in restore_suspend
+    assert "window.checkAndToggleTaskHUD();" in restore_suspend
+    assert "window.nekoAgentHud.show();" not in restore_suspend
 
 
 @pytest.mark.unit
@@ -294,3 +298,11 @@ def test_goodbye_agent_hud_and_websocket_ui_timers_are_suppressed_without_stoppi
     assert "stop_plugin" not in hud_source
     assert "stop_plugin" not in websocket_source
     assert "stop_plugin" not in metrics_source
+
+
+@pytest.mark.unit
+def test_standalone_agent_hud_page_keeps_root_background_transparent():
+    template = _read(AGENTHUD_TEMPLATE_PATH)
+
+    assert "background: transparent !important;" in template
+    assert "background: #1a1a2e;" not in template

--- a/tests/unit/test_goodbye_resource_suspend_static.py
+++ b/tests/unit/test_goodbye_resource_suspend_static.py
@@ -304,5 +304,8 @@ def test_goodbye_agent_hud_and_websocket_ui_timers_are_suppressed_without_stoppi
 def test_standalone_agent_hud_page_keeps_root_background_transparent():
     template = _read(AGENTHUD_TEMPLATE_PATH)
 
+    assert '<html lang="en" class="agent-hud-standalone-page">' in template
+    assert "html.agent-hud-standalone-page," in template
+    assert "body.agent-hud-standalone-page:not(.lanlan-pet-mode)" in template
     assert "background: transparent !important;" in template
     assert "background: #1a1a2e;" not in template


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

移除 goodbye 恢复流程里触发独立猫爪任务窗口的调用，只恢复页面内原有任务 HUD，并补充回归断言

## 测试 / Testing

手动测试


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 独立的 Agent HUD 窗口现在可将根背景设置为透明显示，更贴合悬浮面板的视觉效果。

* **Bug 修复**
  * 在“资源暂停/恢复”恢复阶段，任务 HUD 的显示状态会进一步同步/切换，减少恢复后出现的状态不一致。
  * 恢复流程中减少不必要的界面切换，提升显示稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->