### PR TITLE
fix(chat): cancel stale minimize scale frames

### DIFF
--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -4723,6 +4723,13 @@
             if (!idleDockTriggeredMinimize || idleDockActive || !isIdleDockTierActive()) return;
             var latestShell = getShell();
             if (!latestShell) return;
+            if (isMinimizeTransitioning) {
+                var pendingSurfaceMode = pendingChatSurfaceMode;
+                var pendingSurfaceCommit = pendingMinimizedSurfaceCommit;
+                cancelActiveAnimation();
+                pendingChatSurfaceMode = pendingSurfaceMode;
+                pendingMinimizedSurfaceCommit = pendingSurfaceCommit;
+            }
             minimized = true;
             latestShell.classList.remove('is-collapsing', 'is-expanding');
             latestShell.style.transform = 'none';
@@ -4732,6 +4739,12 @@
             latestShell.style.removeProperty('bottom');
             latestShell.classList.add('is-minimized');
             syncChatSurfaceModeUI();
+            commitPendingMinimizedSurfaceMode();
+            flushPendingChatSurfaceModeIfNeeded();
+            if (!minimized || getCurrentChatSurfaceMode() !== 'minimized') {
+                clearIdleDockState();
+                return;
+            }
             finishIdleDockMinimize(latestShell);
         }, 460);
     }
@@ -5791,20 +5804,38 @@
             shell.classList.add('is-collapsing');
             void shell.offsetHeight; // 强制 reflow
 
+            var handled = false;
+            var collapseTimer = null;
+            var collapseScaleFrame = 0;
+            var collapseScaleInnerFrame = 0;
+            function cancelCollapseScaleFrames() {
+                if (collapseScaleFrame) {
+                    window.cancelAnimationFrame(collapseScaleFrame);
+                    collapseScaleFrame = 0;
+                }
+                if (collapseScaleInnerFrame) {
+                    window.cancelAnimationFrame(collapseScaleInnerFrame);
+                    collapseScaleInnerFrame = 0;
+                }
+            }
+
             // 5. 设置目标 transform，触发动画
             //    动画期间 left/top 不动，只通过动态 origin 缩放到 target。
-            requestAnimationFrame(function () {
-                requestAnimationFrame(function () {
+            collapseScaleFrame = requestAnimationFrame(function () {
+                collapseScaleFrame = 0;
+                if (handled || !shell.classList.contains('is-collapsing') || shell.classList.contains('is-minimized')) return;
+                collapseScaleInnerFrame = requestAnimationFrame(function () {
+                    collapseScaleInnerFrame = 0;
+                    if (handled || !shell.classList.contains('is-collapsing') || shell.classList.contains('is-minimized')) return;
                     shell.style.transform = 'scale(' + sx + ', ' + sy + ')';
                 });
             });
 
             // 6. 过渡结束后切换到最终的 minimized 状态
-            var handled = false;
-            var collapseTimer = null;
             var finishCollapse = function () {
                 if (handled) return;
                 handled = true;
+                cancelCollapseScaleFrames();
                 clearTimeout(collapseTimer);
                 shell.removeEventListener('transitionend', onEnd);
                 activeAnimationCleanup = null;
@@ -5839,6 +5870,7 @@
 
             // 注册清理句柄，供 closeWindow / 下次动画调用
             activeAnimationCleanup = function () {
+                cancelCollapseScaleFrames();
                 clearTimeout(collapseTimer);
                 shell.removeEventListener('transitionend', onEnd);
                 shell.classList.remove('is-collapsing');

--- a/tests/unit/test_react_chat_idle_dock_static.py
+++ b/tests/unit/test_react_chat_idle_dock_static.py
@@ -423,6 +423,49 @@ def test_idle_dock_uses_mutation_observer_to_detect_minimize_completion():
     assert "shell.classList.remove('is-minimized', 'is-collapsing', 'is-idle-docked')" in source
 
 
+def test_minimize_collapse_deferred_scale_write_is_cancellable():
+    source = _read(APP_REACT_CHAT_WINDOW_PATH)
+    minimize_block = _between(
+        source,
+        "if (willMinimize) {",
+        "        } else {",
+    )
+
+    assert "var collapseScaleFrame = 0;" in minimize_block
+    assert "var collapseScaleInnerFrame = 0;" in minimize_block
+    assert "function cancelCollapseScaleFrames()" in minimize_block
+    assert "window.cancelAnimationFrame(collapseScaleFrame)" in minimize_block
+    assert "window.cancelAnimationFrame(collapseScaleInnerFrame)" in minimize_block
+    assert minimize_block.count("cancelCollapseScaleFrames();") >= 2
+    assert (
+        "if (handled || !shell.classList.contains('is-collapsing') || "
+        "shell.classList.contains('is-minimized')) return;"
+    ) in minimize_block
+
+
+def test_idle_dock_minimize_fallback_preserves_pending_surface_mode():
+    source = _read(APP_REACT_CHAT_WINDOW_PATH)
+    fallback_block = _between(
+        source,
+        "function scheduleIdleDockMinimizeFallback(shell) {",
+        "function getElectronIdleDockBridge() {",
+    )
+
+    assert "var pendingSurfaceMode = pendingChatSurfaceMode;" in fallback_block
+    assert "var pendingSurfaceCommit = pendingMinimizedSurfaceCommit;" in fallback_block
+    assert "pendingChatSurfaceMode = pendingSurfaceMode;" in fallback_block
+    assert "pendingMinimizedSurfaceCommit = pendingSurfaceCommit;" in fallback_block
+    assert "commitPendingMinimizedSurfaceMode();" in fallback_block
+    assert "flushPendingChatSurfaceModeIfNeeded();" in fallback_block
+    assert (
+        "if (!minimized || getCurrentChatSurfaceMode() !== 'minimized') {"
+    ) in fallback_block
+
+    flush_index = fallback_block.index("flushPendingChatSurfaceModeIfNeeded();")
+    finish_index = fallback_block.index("finishIdleDockMinimize(latestShell);")
+    assert flush_index < finish_index
+
+
 def test_idle_dock_does_not_follow_return_ball_after_initial_dock():
     source = _read(APP_REACT_CHAT_WINDOW_PATH)
     electron_return_block = _between(


### PR DESCRIPTION
## 改动概述 / Summary

修复 CAT2/CAT3 idle-dock 自动进入毛线球形态时，web 端最小化折叠动画的延迟 `requestAnimationFrame` 可能在 fallback 或动画清理后继续写入非等比 `scale(sx, sy)`，导致毛线球偶发被压成很窄的一条。

链接：https://github.com/Project-N-E-K-O/N.E.K.O.-PC/pull/290
本次改动：

- 让折叠动画中的延迟 scale 写入可取消。
- 在延迟写入前确认 shell 仍处于 `is-collapsing`，且尚未进入 `is-minimized`。
- idle-dock fallback 强制收敛为 minimized 前，先取消仍在进行的最小化动画。
- 增加静态回归测试，锁定该 rAF 清理和状态守卫逻辑。

## 回归报告 / Regression Report

不适用。

本 PR 未触碰 `app/`、`main_logic/`、`main_routers/`、`memory/` 下的 Python 文件。

## 不拆分理由 / Why Not Split

不适用。

本 PR 只改动 2 个文件，其中 1 个为测试文件，未超过不拆分说明阈值。

## 测试 / Testing

已验证：

- `uv run pytest tests/unit/test_react_chat_idle_dock_static.py -q`
- `uv run pytest tests/unit/test_react_chat_idle_dock_static.py tests/unit/test_avatar_return_button_cat1_static.py -q`
- `node --check static/app-react-chat-window.js`
- `git diff --check -- static/app-react-chat-window.js tests/unit/test_react_chat_idle_dock_static.py`

结果：

- 相关 pytest 用例通过：`35 passed`
- JS 语法检查通过
- diff 空白检查通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进聊天窗口最小化/折叠的动画取消与清理流程：切换或取消时可中止未完成的缩放帧，避免残留样式导致异常缩放。
  * 在空闲最小化超时兜底时，安全终止进行中的过渡，并保留/恢复待提交的界面模式，确保最终状态与实际界面一致。

* **Tests**
  * 新增单元测试，覆盖折叠缩放的可取消性与超时兜底下待提交状态的保留/刷新顺序。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->