### PR TITLE
fix: guard realtime TTS jitter buffer during interrupt

### DIFF
--- a/main_logic/tts_client/_infra.py
+++ b/main_logic/tts_client/_infra.py
@@ -101,12 +101,21 @@ class AudioJitterBuffer:
         self._steady_buffer_bytes = steady_buffer_bytes
         self.buffer = bytearray()
         self.started = False
+        self._discarding = False
+
+    def begin_interrupt(self):
+        self._discarding = True
+
+    def end_interrupt(self):
+        self._discarding = False
 
     def reset(self):
         self.buffer.clear()
         self.started = False
 
     def append(self, audio_bytes):
+        if self._discarding:
+            return
         if not audio_bytes:
             return
         self.buffer.extend(audio_bytes)
@@ -119,6 +128,8 @@ class AudioJitterBuffer:
             self._flush()
 
     def flush(self):
+        if self._discarding:
+            return
         self._flush()
 
     def _flush(self):

--- a/main_logic/tts_client/workers/elevenlabs.py
+++ b/main_logic/tts_client/workers/elevenlabs.py
@@ -149,8 +149,11 @@ def elevenlabs_tts_worker(request_queue, response_queue, audio_api_key, voice_id
                 receive_task.cancel()
                 try:
                     await receive_task
-                except (asyncio.CancelledError, Exception):
+                except asyncio.CancelledError:
+                    # Expected during interrupt teardown.
                     pass
+                except Exception as exc:
+                    logger.debug("ElevenLabs interrupted receive task cleanup failed: %s", exc)
                 receive_task = None
             if ws is not None:
                 if send_final_empty and not text_done_sent:
@@ -175,8 +178,11 @@ def elevenlabs_tts_worker(request_queue, response_queue, audio_api_key, voice_id
                 receive_task.cancel()
                 try:
                     await receive_task
-                except (asyncio.CancelledError, Exception):
+                except asyncio.CancelledError:
+                    # Expected when closing an active receive loop.
                     pass
+                except Exception as exc:
+                    logger.debug("ElevenLabs receive task cleanup failed: %s", exc)
             receive_task = None
 
         async def _open_ws(speech_id: str) -> None:

--- a/main_logic/tts_client/workers/elevenlabs.py
+++ b/main_logic/tts_client/workers/elevenlabs.py
@@ -139,8 +139,19 @@ def elevenlabs_tts_worker(request_queue, response_queue, audio_api_key, voice_id
             # receive_task），避免上一轮残留音频串入新轮次首包。
             audio_jitter.reset()
 
-        async def _close_ws(send_final_empty: bool = False, wait_for_final: bool = False) -> None:
+        async def _close_ws(
+            send_final_empty: bool = False,
+            wait_for_final: bool = False,
+            interrupt: bool = False,
+        ) -> None:
             nonlocal ws, receive_task, text_done_sent
+            if interrupt and receive_task and not receive_task.done():
+                receive_task.cancel()
+                try:
+                    await receive_task
+                except (asyncio.CancelledError, Exception):
+                    pass
+                receive_task = None
             if ws is not None:
                 if send_final_empty and not text_done_sent:
                     try:
@@ -159,6 +170,8 @@ def elevenlabs_tts_worker(request_queue, response_queue, audio_api_key, voice_id
                     pass
             ws = None
             if receive_task and not receive_task.done():
+                if not interrupt:
+                    audio_jitter.flush()
                 receive_task.cancel()
                 try:
                     await receive_task
@@ -193,6 +206,7 @@ def elevenlabs_tts_worker(request_queue, response_queue, audio_api_key, voice_id
             await ws.send(json.dumps(init_payload))
 
         async def _receive_ws_messages(speech_id: str) -> None:
+            cancelled = False
             try:
                 async for message in ws:
                     audio_bytes = None
@@ -267,10 +281,13 @@ def elevenlabs_tts_worker(request_queue, response_queue, audio_api_key, voice_id
                         exc.reason,
                     )
             except asyncio.CancelledError:
+                cancelled = True
                 raise
             except Exception as exc:
                 logger.error("ElevenLabs WS receive failed: %s", exc)
             finally:
+                if not cancelled:
+                    audio_jitter.flush()
                 response_finished.set()
 
         async def _send_text(text: str, speech_id: str, *, final: bool = False) -> None:
@@ -332,11 +349,15 @@ def elevenlabs_tts_worker(request_queue, response_queue, audio_api_key, voice_id
                     break
 
                 if sid == "__interrupt__":
-                    await _close_ws(send_final_empty=False, wait_for_final=False)
-                    current_speech_id = None
-                    pending_text.clear()
-                    pending_text_sid = None
-                    audio_jitter.reset()  # 打断：丢弃未放出的缓冲音频
+                    audio_jitter.begin_interrupt()
+                    try:
+                        await _close_ws(send_final_empty=False, wait_for_final=False, interrupt=True)
+                        current_speech_id = None
+                        pending_text.clear()
+                        pending_text_sid = None
+                        audio_jitter.reset()  # 打断：丢弃未放出的缓冲音频
+                    finally:
+                        audio_jitter.end_interrupt()
                     continue
 
                 if sid is None:

--- a/main_logic/tts_client/workers/grok.py
+++ b/main_logic/tts_client/workers/grok.py
@@ -108,6 +108,7 @@ def grok_streaming_tts_worker(request_queue, response_queue, audio_api_key, voic
             # xAI 实际可能发 binary frame（raw PCM）或 JSON-wrapped base64 audio.delta，
             # 文档未明确给出，两路径都保留。字段名走 'delta'（OpenAI Realtime 标准）
             # 但保留 'audio' 作为兜底，未来如果 xAI 改名也不会立刻挂。
+            cancelled = False
             try:
                 async for message in ws:
                     if isinstance(message, bytes):
@@ -150,8 +151,14 @@ def grok_streaming_tts_worker(request_queue, response_queue, audio_api_key, voic
                 # 避免 worker 每次 sid 切换主动 close 时也刷一行。
                 if e.code != 1000:
                     logger.info(f"xAI TTS WebSocket closed: code={e.code} reason={e.reason!r}")
+            except asyncio.CancelledError:
+                cancelled = True
+                raise
             except Exception as e:
                 logger.error(f"xAI TTS 接收出错: {type(e).__name__}: {e}")
+            finally:
+                if not cancelled:
+                    audio_jitter.flush()
 
         try:
             # close_timeout=0.5：上限 close handshake 等待，避免半开连接在 sid 切换
@@ -173,24 +180,28 @@ def grok_streaming_tts_worker(request_queue, response_queue, audio_api_key, voic
                     break
 
                 if sid == "__interrupt__":
-                    if ws:
-                        try:
-                            await asyncio.wait_for(ws.close(), timeout=0.5)
-                        except Exception:
-                            pass
-                        ws = None
-                    if receive_task and not receive_task.done():
-                        receive_task.cancel()
-                        try:
-                            await receive_task
-                        except asyncio.CancelledError:
-                            pass
-                        receive_task = None
-                    current_speech_id = None
-                    text_done_sent = False
-                    pending_text.clear()
-                    pending_text_sid = None
-                    audio_jitter.reset()  # 打断：丢弃未放出的缓冲音频
+                    audio_jitter.begin_interrupt()
+                    try:
+                        if receive_task and not receive_task.done():
+                            receive_task.cancel()
+                            try:
+                                await receive_task
+                            except (asyncio.CancelledError, Exception):
+                                pass
+                            receive_task = None
+                        if ws:
+                            try:
+                                await asyncio.wait_for(ws.close(), timeout=0.5)
+                            except Exception:
+                                pass
+                            ws = None
+                    finally:
+                        current_speech_id = None
+                        text_done_sent = False
+                        pending_text.clear()
+                        pending_text_sid = None
+                        audio_jitter.reset()  # 打断：丢弃未放出的缓冲音频
+                        audio_jitter.end_interrupt()
                     continue
 
                 if sid is None:
@@ -270,6 +281,7 @@ def grok_streaming_tts_worker(request_queue, response_queue, audio_api_key, voic
                             pass
                         ws = None
                     if receive_task and not receive_task.done():
+                        audio_jitter.flush()
                         receive_task.cancel()
                         try:
                             await receive_task

--- a/main_logic/tts_client/workers/grok.py
+++ b/main_logic/tts_client/workers/grok.py
@@ -186,14 +186,17 @@ def grok_streaming_tts_worker(request_queue, response_queue, audio_api_key, voic
                             receive_task.cancel()
                             try:
                                 await receive_task
-                            except (asyncio.CancelledError, Exception):
+                            except asyncio.CancelledError:
+                                # Expected during interrupt teardown.
                                 pass
+                            except Exception as e:
+                                logger.debug(f"xAI TTS interrupted receive task cleanup failed: {e}")
                             receive_task = None
                         if ws:
                             try:
                                 await asyncio.wait_for(ws.close(), timeout=0.5)
-                            except Exception:
-                                pass
+                            except Exception as e:
+                                logger.debug(f"xAI TTS interrupted websocket close failed: {e}")
                             ws = None
                     finally:
                         current_speech_id = None

--- a/main_logic/tts_client/workers/qwen.py
+++ b/main_logic/tts_client/workers/qwen.py
@@ -192,6 +192,7 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
             async def receive_messages_initial():
                 """Initial receive task"""
                 nonlocal ws
+                cancelled = False
                 try:
                     async for message in ws:
                         event = json.loads(message)
@@ -219,9 +220,14 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                             response_done.set()
                 except websockets.exceptions.ConnectionClosed:
                     pass
+                except asyncio.CancelledError:
+                    cancelled = True
+                    raise
                 except Exception as e:
                     logger.error(f"消息接收出错: {e}")
                 finally:
+                    if not cancelled:
+                        qwen_audio_jitter.flush()
                     # 接收循环退出（超时/断开），清理连接状态以便主循环按需重连
                     if ws:
                         try:
@@ -252,25 +258,29 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
 
                 if sid == "__interrupt__":
                     # 打断：立即关闭连接，不发 commit、不等服务器确认
-                    if ws:
-                        try:
-                            await ws.close()
-                        except Exception:
-                            pass
-                        ws = None
-                    if receive_task and not receive_task.done():
-                        receive_task.cancel()
-                        try:
-                            await receive_task
-                        except asyncio.CancelledError:
-                            pass
-                        receive_task = None
-                    session_ready.clear()
-                    current_speech_id = None
-                    buffer_committed = False
-                    session_configured = False
-                    pending_text_buffer = ""
-                    qwen_audio_jitter.reset()
+                    qwen_audio_jitter.begin_interrupt()
+                    try:
+                        if receive_task and not receive_task.done():
+                            receive_task.cancel()
+                            try:
+                                await receive_task
+                            except (asyncio.CancelledError, Exception):
+                                pass
+                            receive_task = None
+                        if ws:
+                            try:
+                                await ws.close()
+                            except Exception:
+                                pass
+                            ws = None
+                    finally:
+                        session_ready.clear()
+                        current_speech_id = None
+                        buffer_committed = False
+                        session_configured = False
+                        pending_text_buffer = ""
+                        qwen_audio_jitter.reset()
+                        qwen_audio_jitter.end_interrupt()
                     continue
 
                 if sid is None:
@@ -312,6 +322,7 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                         except:  # noqa: E722
                             pass
                     if receive_task and not receive_task.done():
+                        qwen_audio_jitter.flush()
                         receive_task.cancel()
                         try:
                             await receive_task
@@ -330,6 +341,7 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                         # 启动新的接收任务（合并 session.updated 监听）
                         async def receive_messages():
                             nonlocal ws
+                            cancelled = False
                             try:
                                 async for message in ws:
                                     event = json.loads(message)
@@ -359,9 +371,14 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                                         response_done.set()
                             except websockets.exceptions.ConnectionClosed:
                                 pass
+                            except asyncio.CancelledError:
+                                cancelled = True
+                                raise
                             except Exception as e:
                                 logger.error(f"消息接收出错: {e}")
                             finally:
+                                if not cancelled:
+                                    qwen_audio_jitter.flush()
                                 # 接收循环退出（超时/断开），清理连接状态以便主循环按需重连
                                 if ws:
                                     try:

--- a/main_logic/tts_client/workers/qwen.py
+++ b/main_logic/tts_client/workers/qwen.py
@@ -264,14 +264,17 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                             receive_task.cancel()
                             try:
                                 await receive_task
-                            except (asyncio.CancelledError, Exception):
+                            except asyncio.CancelledError:
+                                # Expected during interrupt teardown.
                                 pass
+                            except Exception as e:
+                                logger.debug(f"Qwen TTS interrupted receive task cleanup failed: {e}")
                             receive_task = None
                         if ws:
                             try:
                                 await ws.close()
-                            except Exception:
-                                pass
+                            except Exception as e:
+                                logger.debug(f"Qwen TTS interrupted websocket close failed: {e}")
                             ws = None
                     finally:
                         session_ready.clear()

--- a/main_logic/tts_client/workers/step.py
+++ b/main_logic/tts_client/workers/step.py
@@ -336,14 +336,17 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                             receive_task.cancel()
                             try:
                                 await receive_task
-                            except (asyncio.CancelledError, Exception):
+                            except asyncio.CancelledError:
+                                # Expected during interrupt teardown.
                                 pass
+                            except Exception as e:
+                                logger.debug(f"Step TTS interrupted receive task cleanup failed: {e}")
                             receive_task = None
                         if ws:
                             try:
                                 await ws.close()
-                            except Exception:
-                                pass
+                            except Exception as e:
+                                logger.debug(f"Step TTS interrupted websocket close failed: {e}")
                             ws = None
                     finally:
                         session_id = None

--- a/main_logic/tts_client/workers/step.py
+++ b/main_logic/tts_client/workers/step.py
@@ -266,6 +266,7 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
             async def receive_messages_initial():
                 """Initial receive task"""
                 nonlocal _text_done_error_suppressed
+                cancelled = False
                 try:
                     async for message in ws:
                         event = json.loads(message)
@@ -305,8 +306,14 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                             response_done.set()
                 except websockets.exceptions.ConnectionClosed:
                     pass
+                except asyncio.CancelledError:
+                    cancelled = True
+                    raise
                 except Exception as e:
                     logger.error(f"消息接收出错: {e}")
+                finally:
+                    if not cancelled:
+                        audio_jitter.flush()
             
             receive_task = asyncio.create_task(receive_messages_initial())
             
@@ -323,26 +330,30 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
 
                 if sid == "__interrupt__":
                     # 打断：立即关闭连接，不发 tts.text.done、不等服务器确认
-                    if ws:
-                        try:
-                            await ws.close()
-                        except Exception:
-                            pass
-                        ws = None
-                    if receive_task and not receive_task.done():
-                        receive_task.cancel()
-                        try:
-                            await receive_task
-                        except asyncio.CancelledError:
-                            pass
-                        receive_task = None
-                    session_id = None
-                    session_ready.clear()
-                    current_speech_id = None
-                    text_done_sent = False
-                    session_created = False
-                    pending_text_buffer = ""
-                    audio_jitter.reset()  # 打断：丢弃未放出的缓冲音频
+                    audio_jitter.begin_interrupt()
+                    try:
+                        if receive_task and not receive_task.done():
+                            receive_task.cancel()
+                            try:
+                                await receive_task
+                            except (asyncio.CancelledError, Exception):
+                                pass
+                            receive_task = None
+                        if ws:
+                            try:
+                                await ws.close()
+                            except Exception:
+                                pass
+                            ws = None
+                    finally:
+                        session_id = None
+                        session_ready.clear()
+                        current_speech_id = None
+                        text_done_sent = False
+                        session_created = False
+                        pending_text_buffer = ""
+                        audio_jitter.reset()  # 打断：丢弃未放出的缓冲音频
+                        audio_jitter.end_interrupt()
                     continue
 
                 if sid is None:
@@ -380,6 +391,7 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                         except:  # noqa: E722
                             pass
                     if receive_task and not receive_task.done():
+                        audio_jitter.flush()
                         receive_task.cancel()
                         try:
                             await receive_task
@@ -425,6 +437,7 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
 
                         async def receive_messages():
                             nonlocal _text_done_error_suppressed
+                            cancelled = False
                             try:
                                 async for message in ws:
                                     event = json.loads(message)
@@ -462,8 +475,14 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                                         response_done.set()
                             except websockets.exceptions.ConnectionClosed:
                                 pass
+                            except asyncio.CancelledError:
+                                cancelled = True
+                                raise
                             except Exception as e:
                                 logger.error(f"消息接收出错: {e}")
+                            finally:
+                                if not cancelled:
+                                    audio_jitter.flush()
                         
                         receive_task = asyncio.create_task(receive_messages())
                         

--- a/tests/unit/test_audio_jitter_buffer.py
+++ b/tests/unit/test_audio_jitter_buffer.py
@@ -14,11 +14,24 @@
 
 """Shared TTS jitter buffer semantics (qwen / step / other streaming workers)."""
 
+import re
+from pathlib import Path
+
 from main_logic.tts_client._infra import (
     AudioJitterBuffer,
     make_audio_jitter_buffer,
     _TTS_OUTPUT_BYTES_PER_SECOND,
 )
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+REALTIME_WORKERS = {
+    "step": PROJECT_ROOT / "main_logic/tts_client/workers/step.py",
+    "qwen": PROJECT_ROOT / "main_logic/tts_client/workers/qwen.py",
+    "grok": PROJECT_ROOT / "main_logic/tts_client/workers/grok.py",
+    "elevenlabs": PROJECT_ROOT / "main_logic/tts_client/workers/elevenlabs.py",
+}
 
 
 class _FakeQueue:
@@ -95,6 +108,22 @@ def test_reset_discards_unsent_buffer_and_restarts_head_start():
     assert q.items == []
 
 
+def test_interrupt_guard_drops_append_and_flush_until_resumed():
+    q = _FakeQueue()
+    buf = AudioJitterBuffer(q, initial_buffer_bytes=4, steady_buffer_bytes=2)
+
+    buf.append(b"ab")
+    buf.begin_interrupt()
+    buf.append(b"cd")
+    buf.flush()
+    assert q.items == []
+
+    buf.reset()
+    buf.end_interrupt()
+    buf.append(b"wxyz")
+    assert q.items == [b"wxyz"]
+
+
 def test_empty_append_is_noop():
     q = _FakeQueue()
     buf = AudioJitterBuffer(q, initial_buffer_bytes=4, steady_buffer_bytes=4)
@@ -134,3 +163,65 @@ def test_factory_generic_env_wins_over_legacy(monkeypatch):
     q = _FakeQueue()
     buf = make_audio_jitter_buffer(q, legacy_env_prefix="NEKO_QWEN_TTS")
     assert buf._initial_buffer_bytes == int(500 / 1000 * _TTS_OUTPUT_BYTES_PER_SECOND)
+
+
+def test_realtime_workers_guard_interrupt_close_windows():
+    for provider, path in REALTIME_WORKERS.items():
+        source = path.read_text(encoding="utf-8")
+        assert ".begin_interrupt()" in source, provider
+        assert ".end_interrupt()" in source, provider
+
+    for provider in ("step", "qwen", "grok"):
+        source = REALTIME_WORKERS[provider].read_text(encoding="utf-8")
+        start = source.index('if sid == "__interrupt__":')
+        end = source.index("continue", start)
+        block = source[start:end]
+        assert block.index(".begin_interrupt()") < block.index("receive_task.cancel()"), provider
+        assert block.index("receive_task.cancel()") < block.index("ws.close"), provider
+
+    elevenlabs = REALTIME_WORKERS["elevenlabs"].read_text(encoding="utf-8")
+    interrupt_start = elevenlabs.index('if sid == "__interrupt__":')
+    interrupt_end = elevenlabs.index("continue", interrupt_start)
+    interrupt_block = elevenlabs[interrupt_start:interrupt_end]
+    assert "interrupt=True" in interrupt_block
+
+    close_start = elevenlabs.index("async def _close_ws")
+    close_end = elevenlabs.index("async def _open_ws", close_start)
+    close_block = elevenlabs[close_start:close_end]
+    assert close_block.index("if interrupt and receive_task") < close_block.index("if ws is not None")
+
+
+def test_realtime_workers_flush_jitter_on_non_cancelled_receiver_exit():
+    expected_flush_guards = {
+        "step": 2,
+        "qwen": 2,
+        "grok": 1,
+        "elevenlabs": 1,
+    }
+    pattern = re.compile(
+        r"finally:\s+if not cancelled:\s+(?:qwen_)?audio_jitter\.flush\(\)",
+        re.MULTILINE,
+    )
+
+    for provider, expected_count in expected_flush_guards.items():
+        source = REALTIME_WORKERS[provider].read_text(encoding="utf-8")
+        assert len(pattern.findall(source)) >= expected_count, provider
+
+
+def test_realtime_workers_flush_tail_before_normal_receiver_cancel():
+    for provider in ("step", "qwen", "grok"):
+        source = REALTIME_WORKERS[provider].read_text(encoding="utf-8")
+        start = source.index("if current_speech_id != sid:")
+        end = source.index("receive_task = asyncio.create_task", start)
+        block = source[start:end]
+        flush_call = "qwen_audio_jitter.flush()" if provider == "qwen" else "audio_jitter.flush()"
+        assert block.index(flush_call) < block.index("receive_task.cancel()"), provider
+
+    elevenlabs = REALTIME_WORKERS["elevenlabs"].read_text(encoding="utf-8")
+    close_start = elevenlabs.index("async def _close_ws")
+    close_end = elevenlabs.index("async def _open_ws", close_start)
+    close_block = elevenlabs[close_start:close_end]
+    normal_cancel_start = close_block.index("if receive_task and not receive_task.done():")
+    normal_cancel_block = close_block[normal_cancel_start:]
+    assert normal_cancel_block.index("if not interrupt:") < normal_cancel_block.index("audio_jitter.flush()")
+    assert normal_cancel_block.index("audio_jitter.flush()") < normal_cancel_block.index("receive_task.cancel()")


### PR DESCRIPTION
## 改动概览 / Summary

- add an interrupt discard guard to the shared realtime TTS jitter buffer
- cancel receive loops before closing interrupted realtime TTS websockets so stale audio cannot flush after an interrupt
- flush buffered tail audio on normal receive-loop exit / speech-id switch so short final audio is not lost

Fixes #1986.

## 回归报告 / Regression Report

This PR changes the native realtime TTS jitter-buffer lifecycle under `main_logic/tts_client`.

Change and necessity: realtime TTS workers share `AudioJitterBuffer`, but the buffer previously had no interrupt state. During an interrupt close window, an old receive task could still append audio or flush a buffered tail into `tts_response_queue`. Conversely, on a normal websocket close without an explicit final/done event, the remaining tail audio could stay below the steady jitter threshold and be lost. The fix adds an explicit interrupt discard guard to the shared buffer and updates Step, Qwen, Grok, and ElevenLabs workers to apply that guard only during interrupts while flushing tails during normal receiver exits.

Before: interrupting speech could leak a small stale audio fragment after the user had already started a new turn, and normal websocket termination could clip the final short audio packet.

After: interrupt windows discard pending/stale buffered audio, while normal close / receive-loop completion / speech-id switches flush remaining tail audio before receiver cancellation. Generated voice content, voice model, sample rate, and normal steady-state streaming behavior are unchanged.

Regression risk: this touches realtime TTS close/cancel ordering for Step, Qwen, Grok, and ElevenLabs. The main risk is accidentally flushing audio during interrupt or dropping tail audio during normal close. The regression tests cover interrupt discard behavior, non-cancelled receiver-exit flushes, and normal receiver-cancel ordering. Manual/backend observability remains the same: flushed audio is still delivered as bytes through `tts_response_queue` and then `send_speech`.

## 不拆分理由 / Why Not Split

Not applicable. This PR changes a small, coupled set of realtime TTS workers plus their shared jitter buffer because the bug is caused by the shared lifecycle contract between them.

## 测试 / Testing

- `uv run pytest tests/unit/test_audio_jitter_buffer.py`
- `uv run python -m py_compile main_logic\tts_client\_infra.py main_logic\tts_client\workers\step.py main_logic\tts_client\workers\qwen.py main_logic\tts_client\workers\grok.py main_logic\tts_client\workers\elevenlabs.py tests\unit\test_audio_jitter_buffer.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 优化了实时语音播放在中断与重连时的处理流程，支持更稳定的暂停/继续体验。

* **Bug 修复**
  * 减少中断或取消时残留音频被误播放的问题。
  * 改善切换会话时的尾音处理，降低重复输出和杂音出现的概率。
  * 提升流式语音输出在异常退出场景下的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->