### PR TITLE
fix(proactive): 停止把英文内部字面量泄露进非英文主动搭话 prompt

### DIFF
--- a/config/prompts/prompts_activity.py
+++ b/config/prompts/prompts_activity.py
@@ -1245,6 +1245,23 @@ def _label_before_colon(line: str) -> str | None:
     return None
 
 
+# Activity / propensity enum literals that are ordinary standalone English
+# words (unlike the multi-token enums such as ``focused_work`` /
+# ``restricted_screen_only``). These are EXCLUDED from the proactive leak
+# denylist: ``_strip_proactive_intent_label_leak`` drops a whole first line
+# when it matches a denied label, so denying a bare "idle" / "gaming" / "open"
+# would scrub a legitimate English reply that opens with the word. The
+# multi-token enums never occur as natural speech, so they stay denied.
+# ⚠️ Keep in sync with ``ActivityState`` / ``Propensity`` in
+# ``main_logic/activity/snapshot.py``: a newly added SINGLE-WORD state/propensity
+# must be listed here, otherwise it will (wrongly) start being stripped from
+# replies. Multi-token additions need no change — they are denied by default.
+_ACTIVITY_ENUM_COMMON_WORDS = frozenset({
+    'away', 'gaming', 'chatting', 'idle', 'transitioning', 'private',  # ActivityState
+    'open', 'closed',                                                  # Propensity
+})
+
+
 @lru_cache(maxsize=1)
 def get_proactive_intent_leak_labels() -> frozenset[str]:
     """All internal guidance labels that must never reach spoken output.
@@ -1286,22 +1303,20 @@ def get_proactive_intent_leak_labels() -> frozenset[str]:
 
     # Activity state / propensity enum literals + their English labels.
     # The activity-state section historically rendered the bare English enum
-    # keys (state line / scores line), and weak models echo them as the
-    # reply's first line — always a MULTI-TOKEN form (focused_work,
-    # restricted_screen_only, "focused work"). Deny only those: an underscore
-    # enum key or a multi-word label never occurs as natural speech, so it is
-    # safe as a last-resort strip. A bare common word — open / idle / gaming —
-    # CAN legitimately open an English reply, and _strip matches whole first
-    # lines, so single-token forms are skipped to avoid scrubbing real speech.
-    # English only on purpose: the leak is always the English literal, and
-    # localized labels would risk scrubbing common-word openers too.
+    # keys (state line / scores line), and weak models echo them as the reply's
+    # first line. Deny every enum key + English label EXCEPT the ordinary single
+    # words in ``_ACTIVITY_ENUM_COMMON_WORDS`` (see its docstring): denying a
+    # bare "idle" / "open" would let ``_strip`` scrub a legit reply opening with
+    # the word, while multi-token forms (focused_work, "focused work") never
+    # occur as natural speech and are safe to strip. English only on purpose:
+    # the leak is always the English literal.
     for state_key, en_label in ACTIVITY_STATE_LABELS['en'].items():
-        if '_' in state_key:
+        if state_key not in _ACTIVITY_ENUM_COMMON_WORDS:
             labels.add(state_key)
-        if ' ' in en_label:
+        if en_label not in _ACTIVITY_ENUM_COMMON_WORDS:
             labels.add(en_label)
     for prop_key in ACTIVITY_PROPENSITY_DIRECTIVES['en']:
-        if '_' in prop_key:
+        if prop_key not in _ACTIVITY_ENUM_COMMON_WORDS:
             labels.add(prop_key)
 
     return frozenset(label.casefold() for label in labels if label)

--- a/config/prompts/prompts_activity.py
+++ b/config/prompts/prompts_activity.py
@@ -1284,6 +1284,20 @@ def get_proactive_intent_leak_labels() -> frozenset[str]:
         if label:
             labels.add(label)
 
+    # Activity state / propensity enum literals + their English labels.
+    # The activity-state section historically rendered the bare English
+    # enum keys (state line / scores line), and weak models echo them as
+    # the reply's first line. Deny the raw enums and their English labels
+    # so a leaked state word is stripped as a last resort. English only on
+    # purpose: the leak is always the English literal, and adding localized
+    # labels (e.g. "空闲" / "idle") risks scrubbing a legitimate reply that
+    # happens to open with such a common word.
+    for state_key, en_label in ACTIVITY_STATE_LABELS['en'].items():
+        labels.add(state_key)
+        labels.add(en_label)
+    for prop_key in ACTIVITY_PROPENSITY_DIRECTIVES['en']:
+        labels.add(prop_key)
+
     return frozenset(label.casefold() for label in labels if label)
 
 

--- a/config/prompts/prompts_activity.py
+++ b/config/prompts/prompts_activity.py
@@ -1285,18 +1285,24 @@ def get_proactive_intent_leak_labels() -> frozenset[str]:
             labels.add(label)
 
     # Activity state / propensity enum literals + their English labels.
-    # The activity-state section historically rendered the bare English
-    # enum keys (state line / scores line), and weak models echo them as
-    # the reply's first line. Deny the raw enums and their English labels
-    # so a leaked state word is stripped as a last resort. English only on
-    # purpose: the leak is always the English literal, and adding localized
-    # labels (e.g. "空闲" / "idle") risks scrubbing a legitimate reply that
-    # happens to open with such a common word.
+    # The activity-state section historically rendered the bare English enum
+    # keys (state line / scores line), and weak models echo them as the
+    # reply's first line — always a MULTI-TOKEN form (focused_work,
+    # restricted_screen_only, "focused work"). Deny only those: an underscore
+    # enum key or a multi-word label never occurs as natural speech, so it is
+    # safe as a last-resort strip. A bare common word — open / idle / gaming —
+    # CAN legitimately open an English reply, and _strip matches whole first
+    # lines, so single-token forms are skipped to avoid scrubbing real speech.
+    # English only on purpose: the leak is always the English literal, and
+    # localized labels would risk scrubbing common-word openers too.
     for state_key, en_label in ACTIVITY_STATE_LABELS['en'].items():
-        labels.add(state_key)
-        labels.add(en_label)
+        if '_' in state_key:
+            labels.add(state_key)
+        if ' ' in en_label:
+            labels.add(en_label)
     for prop_key in ACTIVITY_PROPENSITY_DIRECTIVES['en']:
-        labels.add(prop_key)
+        if '_' in prop_key:
+            labels.add(prop_key)
 
     return frozenset(label.casefold() for label in labels if label)
 

--- a/main_logic/activity/snapshot.py
+++ b/main_logic/activity/snapshot.py
@@ -556,18 +556,21 @@ from config.prompts.prompts_activity import (
 def _render_reason(reason: tuple[str, dict], lang_key: str) -> str:
     """Render one structured reason via the per-language template table.
 
-    Falls back to English template if the locale entry is missing,
-    and to the raw reason code if even English is missing (defensive —
-    keeps ``state_section`` printable when a new code is added but the
-    table hasn't been updated yet).
+    Falls back to the English template if the locale entry is missing.
+    If even English lacks the code, returns '' rather than the raw code:
+    a bare English reason code (e.g. ``high_gpu``) must never reach the
+    prompt, where weak models echo it into spoken output. The caller
+    drops empty reasons.
     """
     code, params = reason
     table = ACTIVITY_REASON_TEMPLATES.get(lang_key, ACTIVITY_REASON_TEMPLATES['en'])
-    template = table.get(code) or ACTIVITY_REASON_TEMPLATES['en'].get(code) or code
+    template = table.get(code) or ACTIVITY_REASON_TEMPLATES['en'].get(code)
+    if not template:
+        return ''
     try:
         return template.format(**params)
     except (KeyError, IndexError):
-        return code
+        return ''
 
 
 def _normalize_lang(lang: str) -> str:
@@ -605,11 +608,11 @@ def format_activity_state_section(snap: 'ActivitySnapshot', lang: str = 'zh') ->
     Layout (compact example):
 
         ======Activity state======
-        focused_work (focused work) -> brief screen-only comment
+        focused work -> brief screen-only comment
         Focused in VS Code for 200s; CPU 30s 75%
         18:00 evening | user 30s ago | AI 2min ago
         Unfinished thread: "...what time are you leaving?" (60s ago)
-        Scores: focused_work 0.7 · chatting 0.2 · idle 0.1
+        Scores: focused work 0.7 · chatting 0.2 · idle 0.1
         Narrative: user is debugging in VS Code after asking for help
         Open threads:
         - AI promised to inspect tests later
@@ -640,12 +643,16 @@ def format_activity_state_section(snap: 'ActivitySnapshot', lang: str = 'zh') ->
         return ''
     L = _normalize_lang(lang)
     labels = ACTIVITY_STATE_SECTION_LABELS.get(L, ACTIVITY_STATE_SECTION_LABELS['en'])
-    state_label = ACTIVITY_STATE_LABELS.get(L, ACTIVITY_STATE_LABELS['en']).get(
-        snap.state, snap.state,
-    )
+    # Localized label only — the fallback deliberately lands on '' rather
+    # than the bare English enum key (snap.state / snap.propensity). Weak
+    # models copy those keys into spoken output verbatim, so a zh user
+    # hears "focused_work" / "restricted_screen_only". The line degrades
+    # gracefully below when a label is missing.
+    _state_labels = ACTIVITY_STATE_LABELS.get(L, ACTIVITY_STATE_LABELS['en'])
+    state_label = _state_labels.get(snap.state, '')
     propensity_directive = ACTIVITY_PROPENSITY_DIRECTIVES.get(
         L, ACTIVITY_PROPENSITY_DIRECTIVES['en'],
-    ).get(snap.propensity, snap.propensity)
+    ).get(snap.propensity, '')
 
     period_key = f'period_{snap.period}'
     period_label = labels.get(period_key, snap.period)
@@ -657,13 +664,24 @@ def format_activity_state_section(snap: 'ActivitySnapshot', lang: str = 'zh') ->
         header = header + ' ' + OS_DEGRADED_MARKER.get(L, OS_DEGRADED_MARKER['en'])
     lines: list[str] = [header]
 
-    # Line 1: state + propensity directive on a single line.
-    lines.append(f"{snap.state}（{state_label}）→ {propensity_directive}")
+    # Line 1: localized state label + propensity directive. The bare
+    # English enum (snap.state) is intentionally NOT rendered — only the
+    # localized label — so weak models can't echo it into spoken output.
+    # Empty parts are dropped so a missing label/directive never leaves a
+    # stray "→".
+    state_parts = [p for p in (state_label, propensity_directive) if p]
+    if state_parts:
+        lines.append(' → '.join(state_parts))
 
-    # Line 2: rule reasons (skip if empty — happens for unknown states).
+    # Line 2: rule reasons (skip if empty — happens for unknown states or
+    # when a code has no template in any locale; _render_reason returns ''
+    # rather than leaking the raw English reason code).
     if snap.propensity_reasons:
-        rendered_reasons = [_render_reason(r, L) for r in snap.propensity_reasons]
-        lines.append('; '.join(rendered_reasons))
+        rendered_reasons = [
+            s for s in (_render_reason(r, L) for r in snap.propensity_reasons) if s
+        ]
+        if rendered_reasons:
+            lines.append('; '.join(rendered_reasons))
 
     # Line 3: time + msg recency. Compact form, side(s) omitted when no data.
     time_str = labels['time_fmt'].format(hour=snap.hour, period=period_label)
@@ -705,8 +723,15 @@ def format_activity_state_section(snap: 'ActivitySnapshot', lang: str = 'zh') ->
             (kv for kv in snap.activity_scores.items() if kv[1] >= 0.05),
             key=lambda kv: -kv[1],
         )[:3]
-        if ordered:
-            score_str = ' · '.join(f'{name} {score:.1f}' for name, score in ordered)
+        # Keys are English state enums (the emotion-tier LLM returns them
+        # per _SCORED_STATES). Map to the localized label before rendering
+        # so the scores line can't leak "focused_work" into the reply; an
+        # unmapped key (LLM hallucinated an off-list state) is dropped.
+        scored = [(_state_labels.get(name), score) for name, score in ordered]
+        score_str = ' · '.join(
+            f'{label} {score:.1f}' for label, score in scored if label
+        )
+        if score_str:
             lines.append(f"{labels['activity_scores_label']}: {score_str}")
     if snap.activity_guess:
         lines.append(f"{labels['activity_guess_label']}: {snap.activity_guess}")

--- a/main_logic/topic/delivery.py
+++ b/main_logic/topic/delivery.py
@@ -18,42 +18,42 @@ _session_manager_getter: _SessionManagerGetter | None = None
 _DETAIL_TEMPLATES = {
     'en': {
         'interest': 'Recent focus: {value}',
-        'online': 'Online supplement: after searching "{query}", the concrete angle is: {angle}. Use one concrete detail naturally; if it cannot fit this turn, do not trigger this hook.',
+        'online': 'Online supplement: after searching "{query}", the concrete angle is: {angle}. Use one concrete detail naturally; if it cannot fit this turn, do not raise this topic.',
         'final': 'Generate only one natural opening sentence, as if it just came to mind. Do not say "based on your recent interests" and do not make it feel like a survey.'
     },
     'es': {
         'interest': 'Lo que le importa ahora: {value}',
-        'online': 'Complemento en línea: tras buscar "{query}", el ángulo concreto es: {angle}. Usa un detalle concreto de forma natural; si no encaja en este turno, no actives este hook.',
+        'online': 'Complemento en línea: tras buscar "{query}", el ángulo concreto es: {angle}. Usa un detalle concreto de forma natural; si no encaja en este turno, no saques este tema.',
         'final': 'Genera solo una frase inicial natural, como si se te acabara de ocurrir. No digas "según tus intereses recientes" ni lo hagas sonar como una encuesta.'
     },
     'ja': {
         'interest': '最近気にしていること：{value}',
-        'online': 'オンライン補足：「{query}」で調べた具体的な角度：{angle}。具体情報を一つだけ自然に使ってください。このターンで自然に使えないなら、この hook は発火しないでください。',
+        'online': 'オンライン補足：「{query}」で調べた具体的な角度：{angle}。具体情報を一つだけ自然に使ってください。このターンで自然に使えないなら、この話題は持ち出さないでください。',
         'final': '自然な一言の切り出しだけを生成してください。ふと思い出したように短く。「最近の興味によると」のような言い方や、アンケートっぽい聞き方は避けてください。'
     },
     'ko': {
         'interest': '요즘 신경 쓰는 것: {value}',
-        'online': '온라인 보충: "{query}" 검색 후 얻은 구체적인 각도: {angle}. 구체 정보 하나를 자연스럽게 사용하세요. 이번 턴에 자연스럽지 않다면 이 hook을 발동하지 마세요.',
+        'online': '온라인 보충: "{query}" 검색 후 얻은 구체적인 각도: {angle}. 구체 정보 하나를 자연스럽게 사용하세요. 이번 턴에 자연스럽지 않다면 이 화제를 꺼내지 마세요.',
         'final': '자연스러운 첫 문장 하나만 생성하세요. 문득 떠올린 말처럼 짧게 말하세요. "최근 관심사에 따르면" 같은 표현이나 설문처럼 느껴지는 질문은 피하세요.'
     },
     'pt': {
         'interest': 'O que anda importando: {value}',
-        'online': 'Complemento online: após buscar "{query}", o ângulo concreto é: {angle}. Use um detalhe concreto com naturalidade; se não couber neste turno, não acione este hook.',
+        'online': 'Complemento online: após buscar "{query}", o ângulo concreto é: {angle}. Use um detalhe concreto com naturalidade; se não couber neste turno, não puxe este assunto.',
         'final': 'Gere apenas uma frase de abertura natural, como se tivesse acabado de lembrar. Não diga "com base nos seus interesses recentes" e não soe como um questionário.'
     },
     'ru': {
         'interest': 'Что сейчас занимает: {value}',
-        'online': 'Онлайн-дополнение: после поиска "{query}" конкретный угол такой: {angle}. Естественно используй одну конкретную деталь; если она не подходит этому ходу, не запускай этот hook.',
+        'online': 'Онлайн-дополнение: после поиска "{query}" конкретный угол такой: {angle}. Естественно используй одну конкретную деталь; если она не подходит этому ходу, не поднимай эту тему.',
         'final': 'Сгенерируй только одну естественную вступительную фразу, будто она просто пришла в голову. Не говори "судя по твоим недавним интересам" и не делай это похожим на анкету.'
     },
     'zh': {
         'interest': '最近关注：{value}',
-        'online': '联网补充：查询「{query}」后得到的具体角度：{angle}。必须自然用上其中一个具体信息；如果这轮用不上，就不要触发这个 hook。',
+        'online': '联网补充：查询「{query}」后得到的具体角度：{angle}。必须自然用上其中一个具体信息；如果这轮用不上，就不要发起这个话题。',
         'final': '请只生成一句自然开场，像随口想起来，不要说“根据你的近期兴趣”，不要像问卷。'
     },
     'zh-TW': {
         'interest': '最近關注：{value}',
-        'online': '聯網補充：查詢「{query}」後得到的具體角度：{angle}。必須自然用上其中一個具體資訊；如果這輪用不上，就不要觸發這個 hook。',
+        'online': '聯網補充：查詢「{query}」後得到的具體角度：{angle}。必須自然用上其中一個具體資訊；如果這輪用不上，就不要發起這個話題。',
         'final': '請只生成一句自然開場，像隨口想起來，不要說「根據你的近期興趣」，不要像問卷。'
     },
 }

--- a/tests/test_activity_tracker_followup.py
+++ b/tests/test_activity_tracker_followup.py
@@ -519,6 +519,41 @@ def test_activity_state_unfinished_thread_hides_followup_count():
     assert '/1' not in out
 
 
+@pytest.mark.unit
+def test_activity_state_line_uses_localized_label_not_english_enum():
+    """Regression: the state line renders only the localized label, never
+    the bare English enum (snap.state / snap.propensity). Weak models echo
+    a leaked enum as the reply's first line, so a zh user ends up hearing
+    'focused_work' / 'restricted_screen_only'."""
+    snap = ActivitySnapshot(
+        state='focused_work', state_age_seconds=10.0, previous_state=None,
+        transitioned_recently=False, stale_returning=False,
+        propensity='restricted_screen_only', tone='concise',
+    )
+    out = format_activity_state_section(snap, lang='zh')
+    assert '专注工作中' in out
+    assert 'focused_work' not in out
+    assert 'restricted_screen_only' not in out
+
+
+@pytest.mark.unit
+def test_activity_scores_line_maps_english_state_keys_to_localized_labels():
+    """Regression: the scores line maps English state keys to localized
+    labels instead of emitting 'focused_work' raw. The keys come from the
+    emotion-tier LLM under an English contract — the subtlest leak source."""
+    snap = ActivitySnapshot(
+        state='focused_work', state_age_seconds=10.0, previous_state=None,
+        transitioned_recently=False, stale_returning=False,
+        propensity='open', tone='concise',
+        activity_scores={'focused_work': 0.7, 'chatting': 0.2, 'idle': 0.1},
+    )
+    out = format_activity_state_section(snap, lang='zh')
+    assert '专注工作中 0.7' in out
+    assert '聊天中 0.2' in out
+    assert 'focused_work' not in out
+    assert 'chatting' not in out
+
+
 # ── #1 / skip_probability ───────────────────────────────────────────
 
 

--- a/tests/unit/test_proactive_intent_label_leak.py
+++ b/tests/unit/test_proactive_intent_label_leak.py
@@ -49,6 +49,17 @@ def test_registry_covers_latin_labels() -> None:
         assert lab.casefold() in labels, f"registry missing {lab!r}"
 
 
+def test_registry_covers_activity_state_enums() -> None:
+    # The activity-state section historically rendered bare English state
+    # enums (focused_work / restricted_screen_only) that weak models echoed
+    # as the reply's first line. The denylist must strip both the raw enum
+    # and its English label as a last resort.
+    labels = get_proactive_intent_leak_labels()
+    for lab in ('focused_work', 'gaming', 'idle', 'chatting',
+                'focused work', 'casual browsing'):
+        assert lab.casefold() in labels, f"registry missing activity enum {lab!r}"
+
+
 def test_registry_skips_colonless_sentence_bullets() -> None:
     # The hushed 2nd bullet is a full sentence with no "<label>：" shape; it must
     # NOT become a denylist entry (would be an over-broad, sentence-long label).

--- a/tests/unit/test_proactive_intent_label_leak.py
+++ b/tests/unit/test_proactive_intent_label_leak.py
@@ -50,14 +50,21 @@ def test_registry_covers_latin_labels() -> None:
 
 
 def test_registry_covers_activity_state_enums() -> None:
-    # The activity-state section historically rendered bare English state
-    # enums (focused_work / restricted_screen_only) that weak models echoed
-    # as the reply's first line. The denylist must strip both the raw enum
-    # and its English label as a last resort.
+    # Multi-token activity enums / labels are leak-prone and safe to deny: an
+    # underscore key or multi-word label never occurs as natural speech.
     labels = get_proactive_intent_leak_labels()
-    for lab in ('focused_work', 'gaming', 'idle', 'chatting',
+    for lab in ('focused_work', 'restricted_screen_only', 'casual_browsing',
                 'focused work', 'casual browsing'):
         assert lab.casefold() in labels, f"registry missing activity enum {lab!r}"
+
+
+def test_registry_skips_single_common_word_enums() -> None:
+    # Single common words (idle / gaming / open) are deliberately NOT denied —
+    # they can legitimately open an English reply and _strip matches whole
+    # first lines, so denying them would scrub real speech (greptile P2 #2173).
+    labels = get_proactive_intent_leak_labels()
+    for common in ('idle', 'gaming', 'open', 'away', 'chatting'):
+        assert common.casefold() not in labels, f"common word wrongly denied: {common!r}"
 
 
 def test_registry_skips_colonless_sentence_bullets() -> None:

--- a/tests/unit/test_proactive_intent_label_leak.py
+++ b/tests/unit/test_proactive_intent_label_leak.py
@@ -67,6 +67,25 @@ def test_registry_skips_single_common_word_enums() -> None:
         assert common.casefold() not in labels, f"common word wrongly denied: {common!r}"
 
 
+def test_common_word_exclusions_cover_all_single_token_enums() -> None:
+    # Contract: every single-token ActivityState/Propensity enum must be in the
+    # exclusion set, else it would be denied and could scrub a legit English
+    # reply opening with the word. This pins the exclusion set to stay complete
+    # as the enums evolve — a new one-word state fails here instead of silently
+    # stripping speech.
+    from typing import get_args
+
+    from config.prompts.prompts_activity import _ACTIVITY_ENUM_COMMON_WORDS
+    from main_logic.activity.snapshot import ActivityState, Propensity
+
+    single_token = [
+        e for e in (*get_args(ActivityState), *get_args(Propensity))
+        if '_' not in e and ' ' not in e
+    ]
+    missing = [e for e in single_token if e not in _ACTIVITY_ENUM_COMMON_WORDS]
+    assert not missing, f"single-word enums missing from exclusion set: {missing}"
+
+
 def test_registry_skips_colonless_sentence_bullets() -> None:
     # The hushed 2nd bullet is a full sentence with no "<label>：" shape; it must
     # NOT become a denylist entry (would be an over-broad, sentence-long label).

--- a/tests/unit/test_topic_delivery.py
+++ b/tests/unit/test_topic_delivery.py
@@ -117,6 +117,18 @@ def test_build_topic_hook_callback_preserves_traditional_chinese():
     assert "请只生成一句自然开场" not in detail
 
 
+def test_detail_templates_online_clause_has_no_english_hook_term():
+    """Regression: the online sub-clause must not leak the English internal
+    term 'hook' into any locale's prompt. When a topic is online-enriched
+    (has online_angle), every locale's detail carries the online clause and
+    weak models echo the trailing 'hook' as spoken text (non-EN especially)."""
+    from main_logic.topic.delivery import _DETAIL_TEMPLATES
+    for locale, tmpl in _DETAIL_TEMPLATES.items():
+        assert 'hook' not in tmpl['online'].lower(), (
+            f"{locale} online template still leaks the English term 'hook'"
+        )
+
+
 @pytest.mark.asyncio
 async def test_trigger_topic_hook_once_enqueues_existing_manager_callback(monkeypatch):
     mgr = MagicMock()


### PR DESCRIPTION
## 改动概述 / Summary

主动搭话（proactive_chat）的 prompt 把**未本地化的英文内部字面量**喂给了对话模型，弱模型会把它们当台词首行念出来——**中文用户因此听到 `focused_work` / `restricted_screen_only` / `hook`**。本 PR 修三个确定泄露源 + 一道输出侧兜底。

### A 注入侧根治（`main_logic/activity/snapshot.py`）
- **state 行**：删掉直插的英文枚举 `snap.state`，只渲染本地化 label（`focused_work（专注工作中）→ …` → `专注工作中 → …`）。
- **scores 行**：英文 state 键映射成本地化 label（键由 emotion-tier LLM 按英文约定返回，是最隐蔽的一处泄露）。
- **fallback 加固**：`state_label` / `propensity` / `reason` 三处二级 fallback 从「兜裸英文 key」改成兜空 + 渲染优雅降级，杜绝将来新增枚举未同步 i18n 时的泄露。

### hook 泄露（`main_logic/topic/delivery.py`）
- deep-topic hook 的 online 子句**全部 8 个 locale** 都硬编码了英文内部术语 `hook`，经 `build_topic_hook_callback` → `prompt_ephemeral` 进对话 prompt，交付链无 strip。改用各 locale 自然语言的「话题」。

### B 输出侧兜底（`config/prompts/prompts_activity.py`）
- `get_proactive_intent_leak_labels` 追加 activity state / propensity 的英文枚举 + 英文 label，让 `_strip_proactive_intent_label_leak` 剥掉漏网的英文状态词。**刻意只收英文**，避免误伤以通用词开头的中文台词。

## 回归报告 / Regression Report

**改了什么**：主动搭话 Phase 2（及 deep-topic hook）prompt 组装链路里，三处把英文内部枚举/标识符裸露给对话模型的地方，加一处输出侧兜底。

**为什么必要**：这些英文字面量无条件（或联网增强时）进入送给对话模型的 prompt，且 `snap.state` 不随 locale 本地化，弱模型把它们当正文首行复述。这是「中文用户角色台词里冒出英文词」的直接根因，破坏沉浸感。

**前后行为**：

| 位置 | Before | After |
|---|---|---|
| state 行 | `focused_work（专注工作中）→ …` | `专注工作中 → …` |
| scores 行 | `评估: focused_work 0.7 · chatting 0.2` | `评估: 专注工作中 0.7 · 聊天中 0.2` |
| hook online 子句（非英文 locale） | `…就不要触发这个 hook。` | `…就不要发起这个话题。` |
| fallback（新增枚举未填 i18n 时） | 打印裸英文 key | 兜空，渲染跳过 |

**潜在回归与已排查**：
- **state section 语义不减**：只移除英文枚举字面量，保留 label / propensity directive / reason / narrative / tone 等全部语义提示（英文 locale 下 `focused_work（focused work）` 本就括号内外重复冗余）。
- **B denylist 误伤**：`_strip_proactive_intent_label_leak` 是首行整行精确匹配；只加英文枚举/英文 label、不加中文 label，中文台词首行不受影响。既有 false-positive guard 测试全过。
- **hook 交付语义不变**：只替换英文术语词，online 子句其余语义保留；detail 组装测试（含 ja / zh-TW）全过。
- **测试**：新增 4 条回归（state/scores 行无英文枚举、denylist 覆盖枚举、online 模板全 locale 无 hook）。相关 proactive/topic/activity 单测 **138 passed**，连带 **635 passed**；6 个 pre-existing 失败（`test_proactive_vision_screenshot_staging`，stash 到 base 同样红，`OmniOfflineClient` mock 缺 `llm` 属性）与本 PR 无关。

## 不拆分理由 / Why Not Split
计入上限的文件仅 3 个（远低于 20），且围绕同一目标：消除主动搭话 prompt 的英文内部字面量泄露。

## 已识别但未纳入 / Deferred
- `main_routers/system_router.py:6259 / 6393` 的 `PROACTIVE_SOURCE_LABELS.get(m, m)` 二级 fallback（对偶两处，Phase 1 筛选 prompt 内部）：当前 7 locale 齐全属 dead-path，泄露风险等级低于对话 prompt，留作独立防御性 follow-up（须成对修）。
- `main_logic/topic/delivery.py` 的 `_DETAIL_TEMPLATES` 内联多语言 dict 违反「i18n 进 `config/prompts`」约定，属既有技术债，搬家作独立 follow-up。

## 测试 / Testing
```powershell
.venv\Scripts\python.exe -m pytest tests\test_activity_tracker_followup.py tests\unit\test_proactive_intent_label_leak.py tests\unit\test_topic_delivery.py -q
# 138 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 强化活动状态/倾向本地化展示：不再回显原始英文枚举；状态行与分数行改用对应中文标签并丢弃无法映射项。
  * 更严格的原因文案渲染：当缺少模板时不再回退输出原始标识，避免未本地化内容泄漏。
  * 统一话题交付多语言模板表述，并确保在线模板不包含英文内部术语；扩展主动意图泄漏防护的枚举排除策略。
* **测试**
  * 新增回归覆盖本地化不含英文枚举、模板不含英文术语，以及泄漏拦截规则的边界场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->