### PR TITLE
优化高频刷新和日志噪音

### DIFF
--- a/frontend/plugin-manager/src/stores/plugin.ts
+++ b/frontend/plugin-manager/src/stores/plugin.ts
@@ -163,7 +163,7 @@ export const usePluginStore = defineStore('plugin', () => {
     }
 
     await fetchPlugins(true)
-    registrySynced.value = true
+    registrySynced.value = registryRefreshed
     return {
       registryRefreshed,
       warningMessage,

--- a/frontend/plugin-manager/src/stores/plugin.ts
+++ b/frontend/plugin-manager/src/stores/plugin.ts
@@ -140,7 +140,7 @@ export const usePluginStore = defineStore('plugin', () => {
 
     try {
       const response = await refreshPluginsRegistry()
-      registryRefreshed = true
+      registryRefreshed = response.success !== false
       if (response.success === false) {
         const firstFailure = response.failed[0]
         if (firstFailure) {

--- a/frontend/plugin-manager/src/stores/plugin.ts
+++ b/frontend/plugin-manager/src/stores/plugin.ts
@@ -29,6 +29,8 @@ export const usePluginStore = defineStore('plugin', () => {
   const selectedPluginId = ref<string | null>(null)
   const loading = ref(false)
   const error = ref<string | null>(null)
+  const pluginsLoaded = ref(false)
+  const registrySynced = ref(false)
   
   // 防止请求堆积：正在进行的请求
   let pendingFetchPlugins: Promise<void> | null = null
@@ -115,6 +117,7 @@ export const usePluginStore = defineStore('plugin', () => {
         // 忽略过期响应，防止旧数据覆盖新数据
         if (seq !== fetchPluginsSeq) return
         plugins.value = response.plugins || []
+        pluginsLoaded.value = true
       } catch (err: any) {
         if (seq !== fetchPluginsSeq) return
         error.value = err.message || '获取插件列表失败'
@@ -160,6 +163,7 @@ export const usePluginStore = defineStore('plugin', () => {
     }
 
     await fetchPlugins(true)
+    registrySynced.value = true
     return {
       registryRefreshed,
       warningMessage,
@@ -278,6 +282,8 @@ export const usePluginStore = defineStore('plugin', () => {
     pluginsWithStatus,
     normalPlugins,
     extensions,
+    pluginsLoaded,
+    registrySynced,
     loading,
     error,
     // 操作

--- a/frontend/plugin-manager/src/views/PluginList.vue
+++ b/frontend/plugin-manager/src/views/PluginList.vue
@@ -450,6 +450,8 @@ const loading = computed(() => pluginStore.loading)
 const showMetrics = ref(false)
 let metricsRefreshTimer: number | null = null
 let initialLoadPromise: Promise<void> | null = null
+let lastDashboardReuseRefreshTimestamp = 0
+const PLUGIN_DASHBOARD_REUSE_REFRESH_KEY = 'neko-plugin-dashboard-reuse-refresh-v1'
 
 // Show-source-detail mirrors the Metrics toggle pattern. Turning it on
 // also kicks off a best-effort fetch of the Market's latest versions so
@@ -597,7 +599,46 @@ async function runInitialLoad() {
 function handlePluginDashboardReuseMessage(event: MessageEvent) {
   if (event.origin !== window.location.origin) return
   const data = event.data
-  if (!data || data.type !== 'neko-plugin-dashboard-reuse' || data.action !== 'refresh-plugin-list') return
+  if (!isPluginDashboardReuseRefresh(data)) return
+  requestPluginDataRefreshAfterDashboardReuse(data)
+}
+
+function handlePluginDashboardReuseStorage(event: StorageEvent) {
+  if (event.key !== PLUGIN_DASHBOARD_REUSE_REFRESH_KEY || !event.newValue) return
+  try {
+    const data = JSON.parse(event.newValue)
+    if (isPluginDashboardReuseRefresh(data)) {
+      requestPluginDataRefreshAfterDashboardReuse(data)
+    }
+  } catch {
+    // Ignore malformed refresh hints from older windows.
+  }
+}
+
+function consumePendingPluginDashboardReuseRefresh() {
+  try {
+    const raw = window.localStorage.getItem(PLUGIN_DASHBOARD_REUSE_REFRESH_KEY)
+    if (!raw) return
+    const data = JSON.parse(raw)
+    window.localStorage.removeItem(PLUGIN_DASHBOARD_REUSE_REFRESH_KEY)
+    if (isPluginDashboardReuseRefresh(data)) {
+      requestPluginDataRefreshAfterDashboardReuse(data)
+    }
+  } catch {
+    // Storage can be unavailable in restricted environments; the direct message path still works.
+  }
+}
+
+function isPluginDashboardReuseRefresh(data: unknown): data is { timestamp?: number } {
+  if (!data || typeof data !== 'object') return false
+  const payload = data as { type?: unknown; action?: unknown }
+  return payload.type === 'neko-plugin-dashboard-reuse' && payload.action === 'refresh-plugin-list'
+}
+
+function requestPluginDataRefreshAfterDashboardReuse(data: { timestamp?: number }) {
+  const timestamp = Number.isFinite(data.timestamp) ? Number(data.timestamp) : 0
+  if (timestamp && timestamp === lastDashboardReuseRefreshTimestamp) return
+  lastDashboardReuseRefreshTimestamp = timestamp
   handleInitialLoad().catch((error) => {
     console.warn('Failed to refresh plugin data after dashboard reuse:', error)
   })
@@ -1105,12 +1146,15 @@ watch(packagePanelVisible, (visible) => {
 onMounted(async () => {
   window.addEventListener(TUTORIAL_ACTION_EVENT, handleTutorialAction)
   window.addEventListener('message', handlePluginDashboardReuseMessage)
+  window.addEventListener('storage', handlePluginDashboardReuseStorage)
+  consumePendingPluginDashboardReuseRefresh()
   await Promise.all([loadMarketEntry(), handleInitialLoad()])
 })
 
 onUnmounted(() => {
   window.removeEventListener(TUTORIAL_ACTION_EVENT, handleTutorialAction)
   window.removeEventListener('message', handlePluginDashboardReuseMessage)
+  window.removeEventListener('storage', handlePluginDashboardReuseStorage)
   closePluginContextMenu()
   closeDangerDialog()
   stopMetricsAutoRefresh()

--- a/frontend/plugin-manager/src/views/PluginList.vue
+++ b/frontend/plugin-manager/src/views/PluginList.vue
@@ -452,6 +452,7 @@ let metricsRefreshTimer: number | null = null
 let initialLoadPromise: Promise<void> | null = null
 let lastDashboardReuseRefreshTimestamp = 0
 const PLUGIN_DASHBOARD_REUSE_REFRESH_KEY = 'neko-plugin-dashboard-reuse-refresh-v1'
+const PLUGIN_DASHBOARD_OPENER_ORIGIN_QUERY_PARAM = 'yui_opener_origin'
 
 // Show-source-detail mirrors the Metrics toggle pattern. Turning it on
 // also kicks off a best-effort fetch of the Market's latest versions so
@@ -581,10 +582,11 @@ async function handleInitialLoad() {
 async function runInitialLoad() {
   let warningMessage = ''
   try {
+    // First open recognizes the registry; later reuse only backfills a missing list before status refresh.
     if (!pluginStore.registrySynced) {
       const syncResult = await pluginStore.syncRegistryAndFetch()
       warningMessage = syncResult.warningMessage || ''
-    } else {
+    } else if (!pluginStore.pluginsLoaded) {
       await pluginStore.fetchPlugins()
     }
     await pluginStore.fetchPluginStatus()
@@ -597,10 +599,53 @@ async function runInitialLoad() {
 }
 
 function handlePluginDashboardReuseMessage(event: MessageEvent) {
-  if (event.origin !== window.location.origin) return
+  if (!isTrustedPluginDashboardReuseOrigin(event.origin)) return
   const data = event.data
   if (!isPluginDashboardReuseRefresh(data)) return
   requestPluginDataRefreshAfterDashboardReuse(data)
+}
+
+function normalizePluginDashboardReuseOrigin(value: string | null | undefined) {
+  const rawValue = String(value || '').trim()
+  if (!rawValue) return ''
+  try {
+    return new URL(rawValue).origin
+  } catch {
+    return ''
+  }
+}
+
+function isLoopbackPluginDashboardReuseOrigin(origin: string) {
+  try {
+    const url = new URL(origin)
+    const hostname = url.hostname.toLowerCase()
+    return (
+      (url.protocol === 'http:' || url.protocol === 'https:')
+      && (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1')
+    )
+  } catch {
+    return false
+  }
+}
+
+function getPluginDashboardReuseAllowedOrigins() {
+  const origins = new Set<string>([window.location.origin])
+  try {
+    const params = new URLSearchParams(window.location.search || '')
+    const openerOrigin = normalizePluginDashboardReuseOrigin(params.get(PLUGIN_DASHBOARD_OPENER_ORIGIN_QUERY_PARAM))
+    if (openerOrigin && isLoopbackPluginDashboardReuseOrigin(openerOrigin)) {
+      origins.add(openerOrigin)
+    }
+  } catch {
+    // Keep same-origin message handling when query parsing is unavailable.
+  }
+  return origins
+}
+
+const pluginDashboardReuseAllowedOrigins = getPluginDashboardReuseAllowedOrigins()
+
+function isTrustedPluginDashboardReuseOrigin(origin: string) {
+  return pluginDashboardReuseAllowedOrigins.has(origin)
 }
 
 function handlePluginDashboardReuseStorage(event: StorageEvent) {

--- a/frontend/plugin-manager/src/views/PluginList.vue
+++ b/frontend/plugin-manager/src/views/PluginList.vue
@@ -563,6 +563,24 @@ async function handleRefresh() {
   }
 }
 
+async function handleInitialLoad() {
+  let warningMessage = ''
+  try {
+    if (!pluginStore.registrySynced) {
+      const syncResult = await pluginStore.syncRegistryAndFetch()
+      warningMessage = syncResult.warningMessage || ''
+    } else if (!pluginStore.pluginsLoaded) {
+      await pluginStore.fetchPlugins()
+    }
+    await pluginStore.fetchPluginStatus()
+  } catch (error) {
+    console.warn('Failed to load plugin data:', error)
+  }
+  if (warningMessage) {
+    ElMessage.warning(warningMessage)
+  }
+}
+
 async function toggleMetrics() {
   if (!showMetrics.value) {
     showMetrics.value = true
@@ -1064,7 +1082,7 @@ watch(packagePanelVisible, (visible) => {
 
 onMounted(async () => {
   window.addEventListener(TUTORIAL_ACTION_EVENT, handleTutorialAction)
-  await Promise.all([loadMarketEntry(), handleRefresh()])
+  await Promise.all([loadMarketEntry(), handleInitialLoad()])
 })
 
 onUnmounted(() => {

--- a/frontend/plugin-manager/src/views/PluginList.vue
+++ b/frontend/plugin-manager/src/views/PluginList.vue
@@ -449,6 +449,7 @@ const {
 const loading = computed(() => pluginStore.loading)
 const showMetrics = ref(false)
 let metricsRefreshTimer: number | null = null
+let initialLoadPromise: Promise<void> | null = null
 
 // Show-source-detail mirrors the Metrics toggle pattern. Turning it on
 // also kicks off a best-effort fetch of the Market's latest versions so
@@ -564,12 +565,24 @@ async function handleRefresh() {
 }
 
 async function handleInitialLoad() {
+  if (initialLoadPromise) {
+    return initialLoadPromise
+  }
+  initialLoadPromise = runInitialLoad()
+  try {
+    await initialLoadPromise
+  } finally {
+    initialLoadPromise = null
+  }
+}
+
+async function runInitialLoad() {
   let warningMessage = ''
   try {
     if (!pluginStore.registrySynced) {
       const syncResult = await pluginStore.syncRegistryAndFetch()
       warningMessage = syncResult.warningMessage || ''
-    } else if (!pluginStore.pluginsLoaded) {
+    } else {
       await pluginStore.fetchPlugins()
     }
     await pluginStore.fetchPluginStatus()
@@ -579,6 +592,15 @@ async function handleInitialLoad() {
   if (warningMessage) {
     ElMessage.warning(warningMessage)
   }
+}
+
+function handlePluginDashboardReuseMessage(event: MessageEvent) {
+  if (event.origin !== window.location.origin) return
+  const data = event.data
+  if (!data || data.type !== 'neko-plugin-dashboard-reuse' || data.action !== 'refresh-plugin-list') return
+  handleInitialLoad().catch((error) => {
+    console.warn('Failed to refresh plugin data after dashboard reuse:', error)
+  })
 }
 
 async function toggleMetrics() {
@@ -1082,11 +1104,13 @@ watch(packagePanelVisible, (visible) => {
 
 onMounted(async () => {
   window.addEventListener(TUTORIAL_ACTION_EVENT, handleTutorialAction)
+  window.addEventListener('message', handlePluginDashboardReuseMessage)
   await Promise.all([loadMarketEntry(), handleInitialLoad()])
 })
 
 onUnmounted(() => {
   window.removeEventListener(TUTORIAL_ACTION_EVENT, handleTutorialAction)
+  window.removeEventListener('message', handlePluginDashboardReuseMessage)
   closePluginContextMenu()
   closeDangerDialog()
   stopMetricsAutoRefresh()

--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -39,7 +39,8 @@
         idle_chat_minimized_state: true,
         idle_chat_compact_surface_state: true,
         idle_cat1_compact_mirror_state: true,
-        idle_chat_pair_move_bounds: true
+        idle_chat_pair_move_bounds: true,
+        idle_cat1_play_yarn_visibility: true
     };
     var _lastCrossWindowIdleActivityAt = 0;
     var yuiGuideTargetGeometryRegistry = null;

--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -33,6 +33,14 @@
     // =====================================================================
     var _processedMsgKeys = {};
     var CROSS_WINDOW_IDLE_ACTIVITY_MIN_INTERVAL_MS = 250;
+    var BROADCAST_CHANNEL_QUIET_ACTIONS = {
+        idle_activity: true,
+        idle_return_ball_state: true,
+        idle_chat_minimized_state: true,
+        idle_chat_compact_surface_state: true,
+        idle_cat1_compact_mirror_state: true,
+        idle_chat_pair_move_bounds: true
+    };
     var _lastCrossWindowIdleActivityAt = 0;
     var yuiGuideTargetGeometryRegistry = null;
     var yuiGuideBridgeCommandBus = null;
@@ -154,6 +162,13 @@
         _processedMsgKeys[key] = true;
         setTimeout(function () { delete _processedMsgKeys[key]; }, 5000);
         return false;
+    }
+
+    function shouldLogBroadcastChannelMessage(action) {
+        if (window.NEKO_DEBUG_BROADCAST_CHANNEL === true) {
+            return true;
+        }
+        return !Object.prototype.hasOwnProperty.call(BROADCAST_CHANNEL_QUIET_ACTIONS, action);
     }
 
     function shouldBypassYuiGuideMessageDedup(action, message) {
@@ -3145,7 +3160,9 @@
                     !shouldBypassYuiGuideMessageDedup(message.action, message)
                     && isDuplicateMessage(message.action, message.timestamp)
                 ) {
-                    console.log('[BroadcastChannel] 跳过重复消息:', message.action);
+                    if (shouldLogBroadcastChannelMessage(message.action)) {
+                        console.log('[BroadcastChannel] 跳过重复消息:', message.action);
+                    }
                     return;
                 }
 
@@ -3158,7 +3175,9 @@
                     return;
                 }
 
-                console.log('[BroadcastChannel] 收到消息:', event.data.action);
+                if (shouldLogBroadcastChannelMessage(message.action)) {
+                    console.log('[BroadcastChannel] 收到消息:', message.action);
+                }
 
                 switch (event.data.action) {
                     case 'reload_model':

--- a/static/common-ui-hud.js
+++ b/static/common-ui-hud.js
@@ -330,7 +330,7 @@ window.AgentHUD._createAgentPopupContent = function (popup) {
                     icon: '⚙',
                     url: getPluginDashboardRedirectUrl,
                     windowName: 'neko_plugin_dashboard',
-                    forceReloadOnReuse: true
+                    forceReloadOnReuse: false
                 }
                 : {
                     actionId: 'openclaw-guide',
@@ -410,11 +410,13 @@ window.AgentHUD._createAgentPopupContent = function (popup) {
                     : absoluteUrl;
                 const existingWindow = window._openedWindows && window._openedWindows[actionConfig.windowName];
                 let openedWindow = null;
-                if (actionConfig.forceReloadOnReuse && existingWindow && !existingWindow.closed) {
-                    try {
-                        existingWindow.location.replace(targetUrl);
-                    } catch (_) {
-                        existingWindow.location.href = targetUrl;
+                if (existingWindow && !existingWindow.closed) {
+                    if (actionConfig.forceReloadOnReuse) {
+                        try {
+                            existingWindow.location.replace(targetUrl);
+                        } catch (_) {
+                            existingWindow.location.href = targetUrl;
+                        }
                     }
                     if (typeof window.requestOpenedWindowRestore === 'function') {
                         window.requestOpenedWindowRestore(existingWindow);

--- a/static/common-ui-hud.js
+++ b/static/common-ui-hud.js
@@ -422,6 +422,15 @@ window.AgentHUD._createAgentPopupContent = function (popup) {
                         window.requestOpenedWindowRestore(existingWindow);
                     }
                     existingWindow.focus();
+                    if (!actionConfig.forceReloadOnReuse && actionConfig.windowName === 'neko_plugin_dashboard') {
+                        try {
+                            existingWindow.postMessage({
+                                type: 'neko-plugin-dashboard-reuse',
+                                action: 'refresh-plugin-list',
+                                timestamp: Date.now()
+                            }, new URL(absoluteUrl).origin);
+                        } catch (_) {}
+                    }
                     openedWindow = existingWindow;
                 } else if (typeof window.openOrFocusWindow === 'function') {
                     openedWindow = window.openOrFocusWindow(targetUrl, actionConfig.windowName, features, {

--- a/static/common-ui-hud.js
+++ b/static/common-ui-hud.js
@@ -330,6 +330,7 @@ window.AgentHUD._createAgentPopupContent = function (popup) {
                     icon: '⚙',
                     url: getPluginDashboardRedirectUrl,
                     windowName: 'neko_plugin_dashboard',
+                    cacheBustOnOpen: true,
                     forceReloadOnReuse: false
                 }
                 : {
@@ -339,6 +340,7 @@ window.AgentHUD._createAgentPopupContent = function (popup) {
                     icon: '📘',
                     url: '/api/agent/openclaw/guide',
                     windowName: 'neko_openclaw_guide',
+                    cacheBustOnOpen: true,
                     forceReloadOnReuse: true
                 };
             const existingActionButton = document.getElementById(`neko-sidepanel-action-${toggle.id}-${actionConfig.actionId}`);
@@ -405,7 +407,8 @@ window.AgentHUD._createAgentPopupContent = function (popup) {
                     ? actionConfig.url()
                     : actionConfig.url;
                 const absoluteUrl = new URL(rawUrl, document.baseURI || window.location.href).toString();
-                const targetUrl = actionConfig.forceReloadOnReuse
+                const shouldCacheBustOnOpen = actionConfig.cacheBustOnOpen !== false;
+                const targetUrl = shouldCacheBustOnOpen
                     ? appendCacheBuster(absoluteUrl)
                     : absoluteUrl;
                 const existingWindow = window._openedWindows && window._openedWindows[actionConfig.windowName];

--- a/static/common-ui-hud.js
+++ b/static/common-ui-hud.js
@@ -6,6 +6,7 @@
 window.AgentHUD = window.AgentHUD || {};
 
 var PLUGIN_DASHBOARD_REDIRECT_URL = '/api/agent/user_plugin/dashboard';
+var DEFAULT_PLUGIN_DASHBOARD_MESSAGE_ORIGIN = 'http://127.0.0.1:48916';
 const STANDALONE_HUD_POSITION = Object.freeze({
     top: '0',
     left: '0',
@@ -29,6 +30,40 @@ function getPluginDashboardRedirectUrl() {
 function appendCacheBuster(url) {
     var separator = typeof url === 'string' && url.indexOf('?') >= 0 ? '&' : '?';
     return `${url}${separator}v=${Date.now()}`;
+}
+
+function getPluginDashboardMessageOrigins(redirectUrl) {
+    const origins = [];
+    const seenOrigins = Object.create(null);
+    const addOrigin = (value, baseUrl) => {
+        if (!value) return;
+        try {
+            const origin = new URL(String(value), baseUrl || window.location.href).origin;
+            if (!seenOrigins[origin]) {
+                seenOrigins[origin] = true;
+                origins.push(origin);
+            }
+        } catch (_) {}
+    };
+
+    addOrigin(redirectUrl, window.location.href);
+    try {
+        if (window.YuiGuidePageHandoff && typeof window.YuiGuidePageHandoff.getPluginDashboardExpectedOrigin === 'function') {
+            addOrigin(window.YuiGuidePageHandoff.getPluginDashboardExpectedOrigin(), window.location.href);
+        }
+    } catch (_) {}
+    try { addOrigin(window.YUI_GUIDE_PLUGIN_DASHBOARD_ORIGIN, window.location.href); } catch (_) {}
+    try { addOrigin(window.NEKO_USER_PLUGIN_BASE, window.location.href); } catch (_) {}
+    addOrigin(DEFAULT_PLUGIN_DASHBOARD_MESSAGE_ORIGIN, window.location.href);
+    return origins;
+}
+
+function postPluginDashboardReuseRefresh(targetWindow, payload, redirectUrl) {
+    getPluginDashboardMessageOrigins(redirectUrl).forEach((messageOrigin) => {
+        try {
+            targetWindow.postMessage(payload, messageOrigin);
+        } catch (_) {}
+    });
 }
 
 function isStandaloneAgentHudPage() {
@@ -429,6 +464,7 @@ window.AgentHUD._createAgentPopupContent = function (popup) {
                         const reuseRefreshPayload = {
                             type: 'neko-plugin-dashboard-reuse',
                             action: 'refresh-plugin-list',
+                            openerOrigin: window.location.origin,
                             timestamp: Date.now()
                         };
                         try {
@@ -437,9 +473,7 @@ window.AgentHUD._createAgentPopupContent = function (popup) {
                                 JSON.stringify(reuseRefreshPayload)
                             );
                         } catch (_) {}
-                        try {
-                            existingWindow.postMessage(reuseRefreshPayload, new URL(absoluteUrl).origin);
-                        } catch (_) {}
+                        postPluginDashboardReuseRefresh(existingWindow, reuseRefreshPayload, absoluteUrl);
                     }
                     openedWindow = existingWindow;
                 } else if (typeof window.openOrFocusWindow === 'function') {

--- a/static/common-ui-hud.js
+++ b/static/common-ui-hud.js
@@ -426,12 +426,19 @@ window.AgentHUD._createAgentPopupContent = function (popup) {
                     }
                     existingWindow.focus();
                     if (!actionConfig.forceReloadOnReuse && actionConfig.windowName === 'neko_plugin_dashboard') {
+                        const reuseRefreshPayload = {
+                            type: 'neko-plugin-dashboard-reuse',
+                            action: 'refresh-plugin-list',
+                            timestamp: Date.now()
+                        };
                         try {
-                            existingWindow.postMessage({
-                                type: 'neko-plugin-dashboard-reuse',
-                                action: 'refresh-plugin-list',
-                                timestamp: Date.now()
-                            }, new URL(absoluteUrl).origin);
+                            window.localStorage.setItem(
+                                'neko-plugin-dashboard-reuse-refresh-v1',
+                                JSON.stringify(reuseRefreshPayload)
+                            );
+                        } catch (_) {}
+                        try {
+                            existingWindow.postMessage(reuseRefreshPayload, new URL(absoluteUrl).origin);
                         } catch (_) {}
                     }
                     openedWindow = existingWindow;

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -246,6 +246,22 @@ def test_home_page_opens_plugin_dashboard_through_backend_redirect_for_handoff()
     assert "var PLUGIN_DASHBOARD_REDIRECT_URL = 'http://127.0.0.1:48916/ui';" not in hud_source
 
 
+def test_plugin_dashboard_reuse_refresh_targets_redirected_origin_and_opener():
+    hud_source = Path("static/common-ui-hud.js").read_text(encoding="utf-8")
+    plugin_list_source = Path("frontend/plugin-manager/src/views/PluginList.vue").read_text(encoding="utf-8")
+
+    assert "DEFAULT_PLUGIN_DASHBOARD_MESSAGE_ORIGIN = 'http://127.0.0.1:48916'" in hud_source
+    assert "getPluginDashboardMessageOrigins(redirectUrl)" in hud_source
+    assert "postPluginDashboardReuseRefresh(existingWindow, reuseRefreshPayload, absoluteUrl)" in hud_source
+    assert "existingWindow.postMessage(reuseRefreshPayload, new URL(absoluteUrl).origin)" not in hud_source
+
+    assert "PLUGIN_DASHBOARD_OPENER_ORIGIN_QUERY_PARAM = 'yui_opener_origin'" in plugin_list_source
+    assert "isLoopbackPluginDashboardReuseOrigin(openerOrigin)" in plugin_list_source
+    assert "isTrustedPluginDashboardReuseOrigin(event.origin)" in plugin_list_source
+    assert "else if (!pluginStore.pluginsLoaded)" in plugin_list_source
+    assert "if (event.origin !== window.location.origin) return" not in plugin_list_source
+
+
 def test_standalone_agent_hud_show_hide_keeps_origin_position():
     hud_source = Path("static/common-ui-hud.js").read_text(encoding="utf-8")
     show_match = re.search(


### PR DESCRIPTION
默认静音聊天框移动等高频 BroadcastChannel 同步日志，并保留调试开关；插件管理面板复用已打开窗口时不再强制重载；插件管理页首次打开仍执行一次插件识别/注册表同步，之后切回只刷新插件状态，手动刷新仍保留完整刷新逻辑。

<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

优化高频刷新和日志噪音

## 测试 / Testing

手动测试并查看日志


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 插件列表首次加载增加并发去重与状态标记，注册表同步与插件拉取更有序。
  * 页面复用刷新支持跨页面触发插件列表更新，并增加可信来源校验与事件鉴权。
* **改进**
  * 仪表盘复用打开时的缓存破坏策略更细化（按场景控制）。
  * 广播通道高频消息在非调试模式下减少控制台日志噪音。
* **Bug 修复**
  * 避免复用刷新链路中重复初始化与非同源事件误触发。
* **测试**
  * 新增复用刷新“重定向后来源/开放者来源”相关回归用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->