### PR TITLE
修复多屏幕环境下猫爪任务窗口拖拽松手后可能消失的问题。现在位置限制统一使用页面视口坐标，并会自动校正旧的离屏位置

### DIFF
--- a/static/common-ui-hud.js
+++ b/static/common-ui-hud.js
@@ -158,6 +158,53 @@ let cachedDisplayHUD = {
     height: window.innerHeight
 };
 
+function getAgentHudViewportBounds() {
+    return {
+        left: 0,
+        top: 0,
+        width: Math.max(1, Math.round(Number(window.innerWidth) || 1)),
+        height: Math.max(1, Math.round(Number(window.innerHeight) || 1))
+    };
+}
+
+function clampAgentHudViewportPosition(left, top, width, height) {
+    const viewport = getAgentHudViewportBounds();
+    const safeWidth = Math.max(1, Number(width) || 1);
+    const safeHeight = Math.max(1, Number(height) || 1);
+    const maxLeft = Math.max(viewport.left, viewport.left + viewport.width - safeWidth);
+    const maxTop = Math.max(viewport.top, viewport.top + viewport.height - safeHeight);
+    return {
+        left: Math.max(viewport.left, Math.min(Number(left) || 0, maxLeft)),
+        top: Math.max(viewport.top, Math.min(Number(top) || 0, maxTop))
+    };
+}
+
+function clampAgentHudElementToViewport(hud, options = {}) {
+    if (!hud) return null;
+    const rect = hud.getBoundingClientRect();
+    const currentLeft = Number.isFinite(parseFloat(hud.style.left)) ? parseFloat(hud.style.left) : rect.left;
+    const currentTop = Number.isFinite(parseFloat(hud.style.top)) ? parseFloat(hud.style.top) : rect.top;
+    const clamped = clampAgentHudViewportPosition(currentLeft, currentTop, rect.width, rect.height);
+    hud.style.left = clamped.left + 'px';
+    hud.style.top = clamped.top + 'px';
+    hud.style.right = 'auto';
+    hud.style.transform = 'none';
+
+    if (options.persist) {
+        try {
+            localStorage.setItem('agent-task-hud-position', JSON.stringify({
+                left: hud.style.left,
+                top: hud.style.top,
+                right: hud.style.right,
+                transform: hud.style.transform
+            }));
+        } catch (error) {
+            console.warn('Failed to save position to localStorage:', error);
+        }
+    }
+    return clamped;
+}
+
 // 更新显示器边界信息
 async function updateDisplayBounds(centerX, centerY) {
     if (!window.electronScreen || !window.electronScreen.getAllDisplays) {
@@ -820,6 +867,7 @@ window.AgentHUD.showAgentTaskHUD = function () {
         } catch (e) {
             hud.style.transform = 'translateY(-50%) translateX(0)';
         }
+        clampAgentHudElementToViewport(hud, { persist: true });
     } else {
         hud.style.transform = 'translateY(-50%) translateX(0)';
     }
@@ -1670,43 +1718,9 @@ window.AgentHUD._setupDragging = function (hud) {
         // 恢复视觉状态
         resetDragVisualState();
 
-        // 最终位置校准（多屏幕支持）
+        // DOM HUD 使用 viewport 坐标；不要混用 Electron screen 坐标。
         requestAnimationFrame(() => {
-            const rect = hud.getBoundingClientRect();
-
-            // 使用缓存的屏幕边界进行限制
-            if (!cachedDisplayHUD) {
-                console.warn('cachedDisplayHUD not initialized, skipping bounds check');
-                return;
-            }
-            const displayLeft = cachedDisplayHUD.x;
-            const displayTop = cachedDisplayHUD.y;
-            const displayRight = cachedDisplayHUD.x + cachedDisplayHUD.width;
-            const displayBottom = cachedDisplayHUD.y + cachedDisplayHUD.height;
-
-            // 确保位置在当前屏幕内
-            let finalLeft = parseFloat(hud.style.left) || 0;
-            let finalTop = parseFloat(hud.style.top) || 0;
-
-            finalLeft = Math.max(displayLeft, Math.min(finalLeft, displayRight - rect.width));
-            finalTop = Math.max(displayTop, Math.min(finalTop, displayBottom - rect.height));
-
-            hud.style.left = finalLeft + 'px';
-            hud.style.top = finalTop + 'px';
-
-            // 保存位置到localStorage
-            const position = {
-                left: hud.style.left,
-                top: hud.style.top,
-                right: hud.style.right,
-                transform: hud.style.transform
-            };
-
-            try {
-                localStorage.setItem('agent-task-hud-position', JSON.stringify(position));
-            } catch (error) {
-                console.warn('Failed to save position to localStorage:', error);
-            }
+            clampAgentHudElementToViewport(hud, { persist: true });
         });
 
         e.preventDefault();
@@ -1776,43 +1790,9 @@ window.AgentHUD._setupDragging = function (hud) {
         // 恢复视觉状态
         resetDragVisualState();
 
-        // 最终位置校准（多屏幕支持）
+        // DOM HUD 使用 viewport 坐标；不要混用 Electron screen 坐标。
         requestAnimationFrame(() => {
-            const rect = hud.getBoundingClientRect();
-
-            // 使用缓存的屏幕边界进行限制
-            if (!cachedDisplayHUD) {
-                console.warn('cachedDisplayHUD not initialized, skipping bounds check');
-                return;
-            }
-            const displayLeft = cachedDisplayHUD.x;
-            const displayTop = cachedDisplayHUD.y;
-            const displayRight = cachedDisplayHUD.x + cachedDisplayHUD.width;
-            const displayBottom = cachedDisplayHUD.y + cachedDisplayHUD.height;
-
-            // 确保位置在当前屏幕内
-            let finalLeft = parseFloat(hud.style.left) || 0;
-            let finalTop = parseFloat(hud.style.top) || 0;
-
-            finalLeft = Math.max(displayLeft, Math.min(finalLeft, displayRight - rect.width));
-            finalTop = Math.max(displayTop, Math.min(finalTop, displayBottom - rect.height));
-
-            hud.style.left = finalLeft + 'px';
-            hud.style.top = finalTop + 'px';
-
-            // 保存位置到localStorage
-            const position = {
-                left: hud.style.left,
-                top: hud.style.top,
-                right: hud.style.right,
-                transform: hud.style.transform
-            };
-
-            try {
-                localStorage.setItem('agent-task-hud-position', JSON.stringify(position));
-            } catch (error) {
-                console.warn('Failed to save position to localStorage:', error);
-            }
+            clampAgentHudElementToViewport(hud, { persist: true });
         });
 
         e.preventDefault();
@@ -1838,43 +1818,11 @@ window.AgentHUD._setupDragging = function (hud) {
 
         requestAnimationFrame(() => {
             const rect = hud.getBoundingClientRect();
+            const viewport = getAgentHudViewportBounds();
 
-            // 使用缓存的屏幕边界进行限制
-            if (!cachedDisplayHUD) {
-                console.warn('cachedDisplayHUD not initialized, skipping bounds check');
-                return;
-            }
-            const displayLeft = cachedDisplayHUD.x;
-            const displayTop = cachedDisplayHUD.y;
-            const displayRight = cachedDisplayHUD.x + cachedDisplayHUD.width;
-            const displayBottom = cachedDisplayHUD.y + cachedDisplayHUD.height;
-
-            // 如果HUD超出当前屏幕，调整到可见位置
-            if (rect.left < displayLeft || rect.top < displayTop ||
-                rect.right > displayRight || rect.bottom > displayBottom) {
-
-                let newLeft = parseFloat(hud.style.left) || 0;
-                let newTop = parseFloat(hud.style.top) || 0;
-
-                newLeft = Math.max(displayLeft, Math.min(newLeft, displayRight - rect.width));
-                newTop = Math.max(displayTop, Math.min(newTop, displayBottom - rect.height));
-
-                hud.style.left = newLeft + 'px';
-                hud.style.top = newTop + 'px';
-
-                // 更新保存的位置
-                const position = {
-                    left: hud.style.left,
-                    top: hud.style.top,
-                    right: hud.style.right,
-                    transform: hud.style.transform
-                };
-
-                try {
-                    localStorage.setItem('agent-task-hud-position', JSON.stringify(position));
-                } catch (error) {
-                    console.warn('Failed to save position to localStorage:', error);
-                }
+            if (rect.left < viewport.left || rect.top < viewport.top ||
+                rect.right > viewport.left + viewport.width || rect.bottom > viewport.top + viewport.height) {
+                clampAgentHudElementToViewport(hud, { persist: true });
             }
         });
     };

--- a/static/common-ui-hud.js
+++ b/static/common-ui-hud.js
@@ -507,9 +507,6 @@ window.AgentHUD.createAgentTaskHUD = function () {
         this._cleanupDragging = null;
     }
 
-    // 初始化显示器边界缓存
-    updateDisplayBounds();
-
     const hud = document.createElement('div');
     hud.id = 'agent-task-hud';
 
@@ -1807,14 +1804,8 @@ window.AgentHUD._setupDragging = function (hud) {
     window.addEventListener('pointercancel', cancelDragState, true);
 
     // 窗口大小变化时重新校准位置（多屏幕支持）
-    const handleResize = async () => {
+    const handleResize = () => {
         if (isDragging || touchDragging) return;
-
-        // 更新屏幕信息
-        const rect = hud.getBoundingClientRect();
-        const centerX = rect.left + rect.width / 2;
-        const centerY = rect.top + rect.height / 2;
-        await updateDisplayBounds(centerX, centerY);
 
         requestAnimationFrame(() => {
             const rect = hud.getBoundingClientRect();

--- a/static/common-ui-hud.js
+++ b/static/common-ui-hud.js
@@ -179,11 +179,21 @@ function clampAgentHudViewportPosition(left, top, width, height) {
     };
 }
 
+function getAgentHudPixelCoordinate(value, fallback) {
+    const normalized = typeof value === 'string' ? value.trim().toLowerCase() : '';
+    const numeric = parseFloat(normalized);
+    if (normalized.endsWith('px') && Number.isFinite(numeric)) {
+        return numeric;
+    }
+    const safeFallback = Number(fallback);
+    return Number.isFinite(safeFallback) ? safeFallback : 0;
+}
+
 function clampAgentHudElementToViewport(hud, options = {}) {
     if (!hud) return null;
     const rect = hud.getBoundingClientRect();
-    const currentLeft = Number.isFinite(parseFloat(hud.style.left)) ? parseFloat(hud.style.left) : rect.left;
-    const currentTop = Number.isFinite(parseFloat(hud.style.top)) ? parseFloat(hud.style.top) : rect.top;
+    const currentLeft = getAgentHudPixelCoordinate(hud.style.left, rect.left);
+    const currentTop = getAgentHudPixelCoordinate(hud.style.top, rect.top);
     const clamped = clampAgentHudViewportPosition(currentLeft, currentTop, rect.width, rect.height);
     hud.style.left = clamped.left + 'px';
     hud.style.top = clamped.top + 'px';

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -276,6 +276,16 @@ def test_standalone_agent_hud_show_hide_keeps_origin_position():
     assert "translateY(-50%) translateX(20px)" in hide_body
 
 
+def test_agent_hud_viewport_clamp_uses_layout_for_non_pixel_positions():
+    hud_source = Path("static/common-ui-hud.js").read_text(encoding="utf-8")
+
+    assert "function getAgentHudPixelCoordinate(value, fallback)" in hud_source
+    assert "normalized.endsWith('px') && Number.isFinite(numeric)" in hud_source
+    assert "const currentLeft = getAgentHudPixelCoordinate(hud.style.left, rect.left);" in hud_source
+    assert "const currentTop = getAgentHudPixelCoordinate(hud.style.top, rect.top);" in hud_source
+    assert "Number.isFinite(parseFloat(hud.style.top))" not in hud_source
+
+
 def test_agent_server_expected_event_driven_endpoints_exist():
     paths = _route_paths_from_decorators("app/agent_server.py", "app")
     for expected in {


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->
## 改动概述 / Summary

修复多屏幕环境下猫爪任务窗口拖拽松手后可能消失的问题

## 测试 / Testing

手动测试


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化 HUD 在不同视口尺寸下的可见性：拖动结束、触摸结束、窗口缩放或重新显示时都会自动将面板夹紧到当前浏览器可视区域内，避免跑出屏幕。
  * 当持久化开启时会保存夹紧后的可用位置（并在必要时重置样式），提升下次打开的准确性与可找回性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->