### PR TITLE
优化插件管理列表刷新策略，避免每次进入都完整扫描注册表；同时过滤聊天框移动时的高频 BroadcastChannel 日志，减少控制台刷屏

### DIFF
--- a/frontend/plugin-manager/src/composables/usePluginListContextActions.ts
+++ b/frontend/plugin-manager/src/composables/usePluginListContextActions.ts
@@ -307,7 +307,7 @@ export function usePluginListContextActions() {
       }
       case 'delete':
         await deletePlugin(plugin.id)
-        await pluginStore.fetchPlugins(true)
+        await pluginStore.syncRegistryAndFetch()
         await pluginStore.fetchPluginStatus()
         ElMessage.success(t('messages.pluginDeleted'))
         return

--- a/frontend/plugin-manager/src/composables/usePluginListContextActions.ts
+++ b/frontend/plugin-manager/src/composables/usePluginListContextActions.ts
@@ -307,9 +307,13 @@ export function usePluginListContextActions() {
       }
       case 'delete':
         await deletePlugin(plugin.id)
-        await pluginStore.syncRegistryAndFetch()
-        await pluginStore.fetchPluginStatus()
         ElMessage.success(t('messages.pluginDeleted'))
+        try {
+          await pluginStore.syncRegistryAndFetch()
+          await pluginStore.fetchPluginStatus()
+        } catch (error) {
+          console.warn('Failed to refresh plugin data after delete:', error)
+        }
         return
       case 'enable_extension':
         await pluginStore.enableExt(plugin.id)

--- a/frontend/plugin-manager/src/stores/plugin.ts
+++ b/frontend/plugin-manager/src/stores/plugin.ts
@@ -22,6 +22,10 @@ type RegistrySyncResult = {
   warningMessage: string | null
 }
 
+type PluginMutationOptions = {
+  refresh?: boolean
+}
+
 export const usePluginStore = defineStore('plugin', () => {
   // 状态
   const plugins = ref<PluginMeta[]>([])
@@ -33,6 +37,8 @@ export const usePluginStore = defineStore('plugin', () => {
   // 防止请求堆积：正在进行的请求
   let pendingFetchPlugins: Promise<void> | null = null
   let pendingFetchStatus: Promise<void> | null = null
+  let pendingPluginListRegistrySync: Promise<RegistrySyncResult> | null = null
+  const pluginListRegistrySynced = ref(false)
   // 请求超时自动清理（防止请求堆积）
   const REQUEST_TIMEOUT = 15000 // 15秒
   // 请求序列号，用于忽略过期响应
@@ -160,10 +166,24 @@ export const usePluginStore = defineStore('plugin', () => {
     }
 
     await fetchPlugins(true)
+    pluginListRegistrySynced.value = true
     return {
       registryRefreshed,
       warningMessage,
     }
+  }
+
+  async function ensurePluginListRegistrySynced(): Promise<RegistrySyncResult | null> {
+    if (pluginListRegistrySynced.value) {
+      return null
+    }
+    if (pendingPluginListRegistrySync) {
+      return pendingPluginListRegistrySync
+    }
+    pendingPluginListRegistrySync = syncRegistryAndFetch().finally(() => {
+      pendingPluginListRegistrySync = null
+    })
+    return pendingPluginListRegistrySync
   }
 
   async function fetchPluginStatus(pluginId?: string) {
@@ -217,31 +237,37 @@ export const usePluginStore = defineStore('plugin', () => {
     }
   }
 
-  async function start(pluginId: string) {
+  async function start(pluginId: string, options: PluginMutationOptions = {}) {
     try {
       await startPlugin(pluginId)
-      await fetchPluginStatus(pluginId)
-      await fetchPlugins(true)
+      if (options.refresh !== false) {
+        await fetchPluginStatus(pluginId)
+        await fetchPlugins(true)
+      }
     } catch (err: any) {
       throw err
     }
   }
 
-  async function stop(pluginId: string) {
+  async function stop(pluginId: string, options: PluginMutationOptions = {}) {
     try {
       await stopPlugin(pluginId)
-      await fetchPluginStatus(pluginId)
-      await fetchPlugins(true)
+      if (options.refresh !== false) {
+        await fetchPluginStatus(pluginId)
+        await fetchPlugins(true)
+      }
     } catch (err: any) {
       throw err
     }
   }
 
-  async function reload(pluginId: string) {
+  async function reload(pluginId: string, options: PluginMutationOptions = {}) {
     try {
       await reloadPlugin(pluginId)
-      await fetchPluginStatus(pluginId)
-      await fetchPlugins(true)
+      if (options.refresh !== false) {
+        await fetchPluginStatus(pluginId)
+        await fetchPlugins(true)
+      }
     } catch (err: any) {
       throw err
     }
@@ -278,11 +304,13 @@ export const usePluginStore = defineStore('plugin', () => {
     pluginsWithStatus,
     normalPlugins,
     extensions,
+    pluginListRegistrySynced,
     loading,
     error,
     // 操作
     fetchPlugins,
     syncRegistryAndFetch,
+    ensurePluginListRegistrySynced,
     fetchPluginStatus,
     start,
     stop,

--- a/frontend/plugin-manager/src/stores/pluginRefreshPolicy.test.ts
+++ b/frontend/plugin-manager/src/stores/pluginRefreshPolicy.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+import { usePluginStore } from './plugin'
+import { getPlugins, getPluginStatus, refreshPluginsRegistry, startPlugin } from '@/api/plugins'
+
+vi.mock('@/i18n', () => ({
+  getLocale: () => 'zh-CN',
+}))
+
+vi.mock('@/api/plugins', () => ({
+  getPlugins: vi.fn(),
+  getPluginStatus: vi.fn(),
+  startPlugin: vi.fn(),
+  stopPlugin: vi.fn(),
+  reloadPlugin: vi.fn(),
+  disableExtension: vi.fn(),
+  enableExtension: vi.fn(),
+  refreshPluginsRegistry: vi.fn(),
+}))
+
+function registryRefreshResult() {
+  return {
+    success: true,
+    added: [],
+    updated: [],
+    removed: [],
+    removed_running: [],
+    unchanged: [],
+    failed: [],
+    scanned_count: 0,
+  }
+}
+
+describe('plugin store registry refresh policy', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    vi.mocked(getPlugins).mockResolvedValue({ plugins: [], message: '' })
+    vi.mocked(getPluginStatus).mockResolvedValue({} as any)
+    vi.mocked(startPlugin).mockResolvedValue({ success: true, plugin_id: 'demo', message: '' })
+    vi.mocked(refreshPluginsRegistry).mockResolvedValue(registryRefreshResult())
+  })
+
+  it('runs the plugin list registry sync only once per manager window', async () => {
+    const store = usePluginStore()
+
+    const first = await store.ensurePluginListRegistrySynced()
+    const second = await store.ensurePluginListRegistrySynced()
+
+    expect(first?.registryRefreshed).toBe(true)
+    expect(second).toBeNull()
+    expect(store.pluginListRegistrySynced).toBe(true)
+    expect(refreshPluginsRegistry).toHaveBeenCalledTimes(1)
+    expect(getPlugins).toHaveBeenCalledTimes(1)
+  })
+
+  it('marks explicit registry syncs as satisfying the first plugin list open', async () => {
+    const store = usePluginStore()
+
+    await store.syncRegistryAndFetch()
+    const initialOpenResult = await store.ensurePluginListRegistrySynced()
+
+    expect(initialOpenResult).toBeNull()
+    expect(store.pluginListRegistrySynced).toBe(true)
+    expect(refreshPluginsRegistry).toHaveBeenCalledTimes(1)
+    expect(getPlugins).toHaveBeenCalledTimes(1)
+  })
+
+  it('can defer lifecycle refreshes so batch operations refresh once afterward', async () => {
+    const store = usePluginStore()
+
+    await store.start('demo', { refresh: false })
+
+    expect(startPlugin).toHaveBeenCalledWith('demo')
+    expect(getPluginStatus).not.toHaveBeenCalled()
+    expect(getPlugins).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/plugin-manager/src/views/PluginList.vue
+++ b/frontend/plugin-manager/src/views/PluginList.vue
@@ -542,11 +542,23 @@ const filterRuleGroups = computed<FilterRuleGroupDescriptor[]>(() => [
   },
 ])
 
-async function handleRefresh() {
+type PluginListRefreshMode = 'full' | 'initial-open' | 'light'
+
+async function refreshPluginListData(mode: PluginListRefreshMode) {
   let warningMessage = ''
   try {
-    const syncResult = await pluginStore.syncRegistryAndFetch()
-    warningMessage = syncResult.warningMessage || ''
+    if (mode === 'full') {
+      const syncResult = await pluginStore.syncRegistryAndFetch()
+      warningMessage = syncResult.warningMessage || ''
+    } else if (mode === 'initial-open') {
+      const syncResult = await pluginStore.ensurePluginListRegistrySynced()
+      warningMessage = syncResult?.warningMessage || ''
+      if (!syncResult) {
+        await pluginStore.fetchPlugins()
+      }
+    } else {
+      await pluginStore.fetchPlugins()
+    }
     await pluginStore.fetchPluginStatus()
   } catch (error) {
     console.warn('Failed to refresh plugin data:', error)
@@ -561,6 +573,18 @@ async function handleRefresh() {
   if (warningMessage) {
     ElMessage.warning(warningMessage)
   }
+}
+
+async function handleRefresh() {
+  await refreshPluginListData('full')
+}
+
+async function refreshAfterPluginChange() {
+  await refreshPluginListData('full')
+}
+
+async function refreshForInitialOpen() {
+  await refreshPluginListData('initial-open')
 }
 
 async function toggleMetrics() {
@@ -818,7 +842,7 @@ async function handleImportFileChange(event: Event) {
     const result = await uploadAndInstallPlugin(file)
     const count = result.install.installed_plugin_count ?? 0
     ElMessage.success(t('plugins.importSuccess', { name: file.name, count }))
-    await handleRefresh()
+    await refreshAfterPluginChange()
   } catch (error: any) {
     console.error('Failed to import plugin package:', error)
     const detail = formatHttpError(error)
@@ -898,12 +922,12 @@ async function handleBatchStart() {
   batchBusy.value = true
   let ok = 0; let fail = 0
   for (const p of plugins) {
-    try { await pluginStore.start(p.id); ok++ } catch { fail++ }
+    try { await pluginStore.start(p.id, { refresh: false }); ok++ } catch { fail++ }
   }
   batchBusy.value = false
   if (fail === 0) ElMessage.success(t('plugins.batchStartSuccess', { count: ok }))
   else ElMessage.warning(t('plugins.batchPartial', { success: ok, fail }))
-  await handleRefresh()
+  await refreshAfterPluginChange()
 }
 
 async function handleBatchStop() {
@@ -923,12 +947,12 @@ async function handleBatchStop() {
   batchBusy.value = true
   let ok = 0; let fail = 0
   for (const p of plugins) {
-    try { await pluginStore.stop(p.id); ok++ } catch { fail++ }
+    try { await pluginStore.stop(p.id, { refresh: false }); ok++ } catch { fail++ }
   }
   batchBusy.value = false
   if (fail === 0) ElMessage.success(t('plugins.batchStopSuccess', { count: ok }))
   else ElMessage.warning(t('plugins.batchPartial', { success: ok, fail }))
-  await handleRefresh()
+  await refreshAfterPluginChange()
 }
 
 async function handleBatchReload() {
@@ -948,12 +972,12 @@ async function handleBatchReload() {
   batchBusy.value = true
   let ok = 0; let fail = 0
   for (const p of plugins) {
-    try { await pluginStore.reload(p.id); ok++ } catch { fail++ }
+    try { await pluginStore.reload(p.id, { refresh: false }); ok++ } catch { fail++ }
   }
   batchBusy.value = false
   if (fail === 0) ElMessage.success(t('plugins.batchReloadSuccess', { count: ok }))
   else ElMessage.warning(t('plugins.batchPartial', { success: ok, fail }))
-  await handleRefresh()
+  await refreshAfterPluginChange()
 }
 
 async function handleBatchDelete() {
@@ -976,7 +1000,7 @@ async function handleBatchDelete() {
   clearSelection()
   if (fail === 0) ElMessage.success(t('plugins.batchDeleteSuccess', { count: ok }))
   else ElMessage.warning(t('plugins.batchPartial', { success: ok, fail }))
-  await handleRefresh()
+  await refreshAfterPluginChange()
 }
 
 async function handleReloadAll() {
@@ -1020,7 +1044,7 @@ async function handleReloadAll() {
     reloadingAll.value = false
   }
 
-  await handleRefresh()
+  await refreshAfterPluginChange()
 }
 
 watch(
@@ -1064,7 +1088,7 @@ watch(packagePanelVisible, (visible) => {
 
 onMounted(async () => {
   window.addEventListener(TUTORIAL_ACTION_EVENT, handleTutorialAction)
-  await Promise.all([loadMarketEntry(), handleRefresh()])
+  await Promise.all([loadMarketEntry(), refreshForInitialOpen()])
 })
 
 onUnmounted(() => {

--- a/frontend/plugin-manager/src/views/PluginList.vue
+++ b/frontend/plugin-manager/src/views/PluginList.vue
@@ -551,9 +551,14 @@ async function refreshPluginListData(mode: PluginListRefreshMode) {
       const syncResult = await pluginStore.syncRegistryAndFetch()
       warningMessage = syncResult.warningMessage || ''
     } else if (mode === 'initial-open') {
-      const syncResult = await pluginStore.ensurePluginListRegistrySynced()
-      warningMessage = syncResult?.warningMessage || ''
-      if (!syncResult) {
+      try {
+        const syncResult = await pluginStore.ensurePluginListRegistrySynced()
+        warningMessage = syncResult?.warningMessage || ''
+        if (!syncResult) {
+          await pluginStore.fetchPlugins()
+        }
+      } catch (syncError) {
+        console.warn('Failed to sync plugin registry on first plugin list open:', syncError)
         await pluginStore.fetchPlugins()
       }
     } else {

--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -170,6 +170,14 @@
             || action === 'yui_guide_set_compact_tool_wheel_index';
     }
 
+    function isHighVolumeBroadcastChannelAction(action) {
+        return action === 'idle_return_ball_state'
+            || action === 'idle_chat_minimized_state'
+            || action === 'idle_chat_compact_surface_state'
+            || action === 'idle_cat1_compact_mirror_state'
+            || action === 'idle_chat_pair_move_bounds';
+    }
+
     function isMainUIHiddenByModelManager() {
         return window[MAIN_UI_HIDDEN_BY_MODEL_MANAGER_KEY] === true;
     }
@@ -3158,7 +3166,9 @@
                     return;
                 }
 
-                console.log('[BroadcastChannel] 收到消息:', event.data.action);
+                if (!isHighVolumeBroadcastChannelAction(message.action)) {
+                    console.log('[BroadcastChannel] 收到消息:', message.action);
+                }
 
                 switch (event.data.action) {
                     case 'reload_model':

--- a/static/yui-guide-common.test.cjs
+++ b/static/yui-guide-common.test.cjs
@@ -2732,7 +2732,7 @@ test('external chat ignores stale guide commands after lifecycle ended', () => {
         1
     )[0];
     const broadcastStaleGuardBlock = appInterpageSource.split('nekoBroadcastChannel.onmessage = async function (event) {')[1].split(
-        '                console.log(\'[BroadcastChannel] 收到消息:\', event.data.action);',
+        '                switch (event.data.action) {',
         1
     )[0];
 

--- a/tests/unit/test_app_auto_goodbye_phase1.py
+++ b/tests/unit/test_app_auto_goodbye_phase1.py
@@ -878,7 +878,10 @@ def test_app_interpage_relays_idle_chat_minimized_state_to_pet_window():
     assert "case 'idle_chat_minimized_state':" in source
     assert "function dispatchIdleChatMinimizedState(detail)" in source
     assert "new CustomEvent('neko:idle-chat-minimized-state'" in source
-    assert "nekoBroadcastChannel.postMessage(Object.assign({" in source
+    assert "postInterpageMessage(Object.assign({" in source
+    assert "function isHighVolumeBroadcastChannelAction(action)" in source
+    assert "action === 'idle_chat_minimized_state'" in source
+    assert "if (!isHighVolumeBroadcastChannelAction(message.action))" in source
 
 
 def test_app_interpage_relays_idle_chat_pair_move_bounds_to_chat_window():


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

优化插件管理列表刷新策略，避免每次进入都完整扫描注册表
同时过滤聊天框移动时的高频 BroadcastChannel 日志

## 测试 / Testing

手动查看日志


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 插件列表支持更一致的刷新体验，页面打开、导入、批量操作后可更及时看到最新状态。
  * 批量启动、停止、重载和删除后，列表与状态更新更稳定。

* **Bug 修复**
  * 删除插件后改进了刷新流程，减少列表不同步或延迟显示的问题。
  * 优化了后台消息处理，降低高频通知造成的日志干扰，提升整体流畅度。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->