### PR TITLE
修复普通页面教程的“跳过”按钮点击穿透问题

### DIFF
--- a/static/tutorial/core/page-tutorial-manager.js
+++ b/static/tutorial/core/page-tutorial-manager.js
@@ -926,20 +926,40 @@
 
         showSkipButton() {
             this.hideSkipButton();
-            this.installSkipSafeAreaRefreshHooks();
-            const button = document.createElement('button');
-            button.type = 'button';
-            button.id = 'neko-page-tutorial-skip-btn';
-            button.className = 'neko-page-tutorial-skip-btn';
-            button.textContent = this.t('tutorial.buttons.skip', '跳过');
-            button.addEventListener('click', () => {
+            let skipHandled = false;
+            const handleSkipRequest = (event) => {
+                if (skipHandled) {
+                    return;
+                }
+                skipHandled = true;
+                if (event && typeof event.preventDefault === 'function') {
+                    event.preventDefault();
+                }
+                if (event && typeof event.stopImmediatePropagation === 'function') {
+                    event.stopImmediatePropagation();
+                }
+                if (event && typeof event.stopPropagation === 'function') {
+                    event.stopPropagation();
+                }
                 this.endReason = 'skip';
                 if (this.driver && typeof this.driver.destroy === 'function') {
                     this.driver.destroy();
                 } else {
                     this.handleTutorialEnd('skip');
                 }
-            });
+            };
+            this.installSkipSafeAreaRefreshHooks();
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.id = 'neko-page-tutorial-skip-btn';
+            button.className = 'neko-page-tutorial-skip-btn';
+            button.style.setProperty('pointer-events', 'auto', 'important');
+            button.style.setProperty('z-index', '2147483647', 'important');
+            button.textContent = this.t('tutorial.buttons.skip', '跳过');
+            button.addEventListener('pointerdown', handleSkipRequest);
+            button.addEventListener('mousedown', handleSkipRequest);
+            button.addEventListener('touchstart', handleSkipRequest, { passive: false });
+            button.addEventListener('click', handleSkipRequest);
             const controller = this.ensureSkipSafeAreaController();
             const host = controller && typeof controller.getButtonHost === 'function'
                 ? controller.getButtonHost()
@@ -955,6 +975,9 @@
 
         hideSkipButton() {
             this.clearSkipSafeAreaRefreshHooks();
+            if (this._skipSafeAreaController && typeof this._skipSafeAreaController.hide === 'function') {
+                this._skipSafeAreaController.hide();
+            }
             if (this.skipButton && this.skipButton.parentNode) {
                 this.skipButton.parentNode.removeChild(this.skipButton);
             }

--- a/static/tutorial/core/page-tutorial-manager.js
+++ b/static/tutorial/core/page-tutorial-manager.js
@@ -968,6 +968,7 @@
             button.className = 'neko-page-tutorial-skip-btn';
             button.style.setProperty('pointer-events', 'auto', 'important');
             button.style.setProperty('z-index', '2147483647', 'important');
+            button.style.touchAction = 'manipulation';
             button.textContent = this.t('tutorial.buttons.skip', '跳过');
             button.addEventListener('pointerdown', handleSkipPress);
             button.addEventListener('mousedown', handleSkipPress);

--- a/static/tutorial/core/page-tutorial-manager.js
+++ b/static/tutorial/core/page-tutorial-manager.js
@@ -197,14 +197,20 @@
         }
 
         shouldManageCurrentPage() {
-            // Honor the same mobile bailout as the homepage tutorial: at mobile
-            // widths initUniversalTutorialManager() deliberately disables tutorials
-            // to avoid masks / interaction takeovers, so page tutorials must not
-            // re-enable the Driver overlay there. Gating here covers every start
-            // path (auto-init, reset/manual intent, model-manager mode listener),
-            // since checkAndStartTutorial() and startTutorial() both funnel through it.
-            if (window.innerWidth <= 768) return false;
-            return SUPPORTED_PAGES.includes(this.currentPage);
+            if (!SUPPORTED_PAGES.includes(this.currentPage)) return false;
+
+            // Honor the same mobile bailout as the homepage tutorial, but keep
+            // desktop popup pages usable. Voice clone is intentionally opened in
+            // a 700px desktop popup, which otherwise looks like mobile width here.
+            if (window.innerWidth <= 768 && !this.shouldAllowCompactDesktopTutorial()) return false;
+            return true;
+        }
+
+        shouldAllowCompactDesktopTutorial() {
+            if (this.currentPage !== 'voice_clone') return false;
+            const viewportWidth = Number(window.innerWidth || 0);
+            const screenWidth = Number(window.screen && window.screen.width || 0);
+            return viewportWidth >= 640 && screenWidth > 768;
         }
 
         waitForDriver() {
@@ -653,14 +659,14 @@
         getVoiceCloneSteps() {
             return [
                 {
-                    element: '#provider-notice, .alibaba-api-notice',
+                    element: '#provider-notice, .alibaba-api-notice, #voiceProvider-dropdown-trigger, #voiceProvider',
                     popover: {
                         title: this.t('tutorial.voice_clone.step1.title', '重要提示'),
                         description: this.t('tutorial.voice_clone.step1.desc', '语音克隆功能需要对应的 API 或本地语音服务，请先确认 API 设置可用。')
                     }
                 },
                 {
-                    element: '#refLanguage',
+                    element: '#refLanguage-dropdown-trigger, #refLanguage',
                     popover: {
                         title: this.t('tutorial.voice_clone.step2.title', '选择参考音频语言'),
                         description: this.t('tutorial.voice_clone.step2.desc', '选择您上传的音频文件的语言。这帮助系统更准确地识别和克隆声音特征。')

--- a/static/tutorial/core/page-tutorial-manager.js
+++ b/static/tutorial/core/page-tutorial-manager.js
@@ -927,11 +927,7 @@
         showSkipButton() {
             this.hideSkipButton();
             let skipHandled = false;
-            const handleSkipRequest = (event) => {
-                if (skipHandled) {
-                    return;
-                }
-                skipHandled = true;
+            const absorbSkipEvent = (event) => {
                 if (event && typeof event.preventDefault === 'function') {
                     event.preventDefault();
                 }
@@ -941,12 +937,29 @@
                 if (event && typeof event.stopPropagation === 'function') {
                     event.stopPropagation();
                 }
+            };
+            const completeSkipRequest = () => {
                 this.endReason = 'skip';
                 if (this.driver && typeof this.driver.destroy === 'function') {
                     this.driver.destroy();
                 } else {
                     this.handleTutorialEnd('skip');
                 }
+            };
+            const handleSkipPress = (event) => {
+                absorbSkipEvent(event);
+            };
+            const handleSkipRequest = (event, delayMs = 0) => {
+                absorbSkipEvent(event);
+                if (skipHandled) {
+                    return;
+                }
+                skipHandled = true;
+                if (delayMs > 0) {
+                    window.setTimeout(completeSkipRequest, delayMs);
+                    return;
+                }
+                completeSkipRequest();
             };
             this.installSkipSafeAreaRefreshHooks();
             const button = document.createElement('button');
@@ -956,9 +969,11 @@
             button.style.setProperty('pointer-events', 'auto', 'important');
             button.style.setProperty('z-index', '2147483647', 'important');
             button.textContent = this.t('tutorial.buttons.skip', '跳过');
-            button.addEventListener('pointerdown', handleSkipRequest);
-            button.addEventListener('mousedown', handleSkipRequest);
-            button.addEventListener('touchstart', handleSkipRequest, { passive: false });
+            button.addEventListener('pointerdown', handleSkipPress);
+            button.addEventListener('mousedown', handleSkipPress);
+            button.addEventListener('touchstart', handleSkipPress, { passive: false });
+            button.addEventListener('pointerup', (event) => handleSkipRequest(event, 80));
+            button.addEventListener('touchend', (event) => handleSkipRequest(event, 80), { passive: false });
             button.addEventListener('click', handleSkipRequest);
             const controller = this.ensureSkipSafeAreaController();
             const host = controller && typeof controller.getButtonHost === 'function'

--- a/tests/unit/test_universal_tutorial_manager_static.py
+++ b/tests/unit/test_universal_tutorial_manager_static.py
@@ -261,6 +261,7 @@ def test_page_tutorial_skip_button_restores_pointer_events_inside_fixed_portal()
     assert "button.addEventListener('click', handleSkipRequest);" in show_block
     assert "button.style.setProperty('pointer-events', 'auto', 'important');" in show_block
     assert "button.style.setProperty('z-index', '2147483647', 'important');" in show_block
+    assert "button.style.touchAction = 'manipulation';" in show_block
     assert "this._skipSafeAreaController.hide();" in hide_block
 
 

--- a/tests/unit/test_universal_tutorial_manager_static.py
+++ b/tests/unit/test_universal_tutorial_manager_static.py
@@ -165,7 +165,7 @@ def test_non_home_page_tutorials_are_restored_in_separate_driver_runtime():
     assert "window.resetPageTutorialStorage = resetPageTutorialStorage;" in page_source
     assert "if (path === '/' || path === '/index.html' || path === '/chat')" in page_source
     assert "return 'home';" in page_source
-    assert "return SUPPORTED_PAGES.includes(this.currentPage);" in page_source
+    assert "if (!SUPPORTED_PAGES.includes(this.currentPage)) return false;" in page_source
     assert "const DriverClass = window.driver;" in page_source
     assert "this.driver = new DriverClass({" in page_source
     assert "getModelManagerSteps()" in page_source
@@ -225,8 +225,35 @@ def test_page_tutorial_manager_honors_mobile_viewport_bailout():
     # and startTutorial() funnel through this method.
     assert "window.innerWidth <= 768" in manage_block
     assert manage_block.index("window.innerWidth <= 768") < manage_block.index(
-        "return SUPPORTED_PAGES.includes(this.currentPage);"
+        "return true;"
     )
+    assert "!this.shouldAllowCompactDesktopTutorial()" in manage_block
+
+
+def test_page_tutorial_manager_allows_voice_clone_desktop_popup_width():
+    page_source = _read_page_manager()
+
+    compact_block = page_source.split("        shouldAllowCompactDesktopTutorial() {", 1)[1].split(
+        "        }",
+        1,
+    )[0]
+
+    assert "this.currentPage !== 'voice_clone'" in compact_block
+    assert "viewportWidth >= 640" in compact_block
+    assert "screenWidth > 768" in compact_block
+
+
+def test_voice_clone_tutorial_targets_visible_dropdown_triggers():
+    page_source = _read_page_manager()
+
+    voice_clone_block = page_source.split("        getVoiceCloneSteps() {", 1)[1].split(
+        "        getSteamWorkshopSteps() {",
+        1,
+    )[0]
+
+    assert "#voiceProvider-dropdown-trigger" in voice_clone_block
+    assert "#refLanguage-dropdown-trigger" in voice_clone_block
+    assert voice_clone_block.index("#refLanguage-dropdown-trigger") < voice_clone_block.index("#refLanguage'")
 
 
 def test_page_tutorial_skip_button_restores_pointer_events_inside_fixed_portal():

--- a/tests/unit/test_universal_tutorial_manager_static.py
+++ b/tests/unit/test_universal_tutorial_manager_static.py
@@ -229,6 +229,34 @@ def test_page_tutorial_manager_honors_mobile_viewport_bailout():
     )
 
 
+def test_page_tutorial_skip_button_restores_pointer_events_inside_fixed_portal():
+    page_source = _read_page_manager()
+    show_block = page_source.split("        showSkipButton() {", 1)[1].split(
+        "        hideSkipButton() {",
+        1,
+    )[0]
+    hide_block = page_source.split("        hideSkipButton() {", 1)[1].split(
+        "        handleTutorialEnd",
+        1,
+    )[0]
+
+    assert "let skipHandled = false;" in show_block
+    assert "if (skipHandled) {" in show_block
+    assert "skipHandled = true;" in show_block
+    assert "const handleSkipRequest = (event) => {" in show_block
+    assert "event.preventDefault();" in show_block
+    assert "event.stopImmediatePropagation();" in show_block
+    assert "event.stopPropagation();" in show_block
+    assert "const controller = this.ensureSkipSafeAreaController();" in show_block
+    assert "const host = controller && typeof controller.getButtonHost === 'function'" in show_block
+    assert "button.className = 'neko-page-tutorial-skip-btn';" in show_block
+    for event_name in ("pointerdown", "mousedown", "touchstart", "click"):
+        assert f"button.addEventListener('{event_name}', handleSkipRequest" in show_block
+    assert "button.style.setProperty('pointer-events', 'auto', 'important');" in show_block
+    assert "button.style.setProperty('z-index', '2147483647', 'important');" in show_block
+    assert "this._skipSafeAreaController.hide();" in hide_block
+
+
 def test_page_tutorial_manager_waits_for_api_settings_loading_overlay():
     page_source = _read_page_manager()
 

--- a/tests/unit/test_universal_tutorial_manager_static.py
+++ b/tests/unit/test_universal_tutorial_manager_static.py
@@ -241,17 +241,24 @@ def test_page_tutorial_skip_button_restores_pointer_events_inside_fixed_portal()
     )[0]
 
     assert "let skipHandled = false;" in show_block
-    assert "if (skipHandled) {" in show_block
-    assert "skipHandled = true;" in show_block
-    assert "const handleSkipRequest = (event) => {" in show_block
+    assert "const absorbSkipEvent = (event) => {" in show_block
     assert "event.preventDefault();" in show_block
     assert "event.stopImmediatePropagation();" in show_block
     assert "event.stopPropagation();" in show_block
+    assert "const completeSkipRequest = () => {" in show_block
+    assert "const handleSkipPress = (event) => {" in show_block
+    assert "const handleSkipRequest = (event, delayMs = 0) => {" in show_block
+    assert "if (skipHandled) {" in show_block
+    assert "skipHandled = true;" in show_block
+    assert "window.setTimeout(completeSkipRequest, delayMs);" in show_block
     assert "const controller = this.ensureSkipSafeAreaController();" in show_block
     assert "const host = controller && typeof controller.getButtonHost === 'function'" in show_block
     assert "button.className = 'neko-page-tutorial-skip-btn';" in show_block
-    for event_name in ("pointerdown", "mousedown", "touchstart", "click"):
-        assert f"button.addEventListener('{event_name}', handleSkipRequest" in show_block
+    for event_name in ("pointerdown", "mousedown", "touchstart"):
+        assert f"button.addEventListener('{event_name}', handleSkipPress" in show_block
+    assert "button.addEventListener('pointerup', (event) => handleSkipRequest(event, 80));" in show_block
+    assert "button.addEventListener('touchend', (event) => handleSkipRequest(event, 80), { passive: false });" in show_block
+    assert "button.addEventListener('click', handleSkipRequest);" in show_block
     assert "button.style.setProperty('pointer-events', 'auto', 'important');" in show_block
     assert "button.style.setProperty('z-index', '2147483647', 'important');" in show_block
     assert "this._skipSafeAreaController.hide();" in hide_block


### PR DESCRIPTION
跳过按钮位于固定 portal 中时显式恢复 pointer-events，并统一拦截 pointerdown、mousedown、touchstart、click 事件，确保点击会正确结束教程而不是落到下层页面元素。新增静态回归测试覆盖该行为。

<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复普通页面教程的“跳过”按钮点击穿透问题

## 测试 / Testing

手动测试各个页面的教程


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 调整教程在移动端/桌面端的启动门控：更精确地放行“语音克隆”紧凑桌面情形。
  * “语音克隆”教程第一步重要提示的高亮范围扩大，覆盖下拉触发器与相关容器，提升引导准确性。
  * 优化“跳过教程”按钮的多端交互响应（点击/按压/触摸），阻止默认行为与事件冒泡，避免重复触发；隐藏时先收起安全区域再清理按钮与内容。
* **Tests**
  * 更新并新增静态源码断言，覆盖紧凑桌面宽度、下拉触发器高亮选择器与跳过按钮事件阻断/隐藏路径。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->