### PR TITLE
fix(tutorial): align capsule spotlight to text and fix screen coordinate bounds

### DIFF
--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -4081,10 +4081,7 @@
     }
 
     function getYuiGuidePcOverlayRunIdFromMessage(message) {
-        var runId = message && typeof message.tutorialRunId === 'string'
-            ? message.tutorialRunId
-            : '';
-        return rememberYuiGuidePcOverlayRunId(runId);
+        return resolveCanonicalYuiGuideBridgeRunId(message);
     }
 
     function isYuiGuideLifecycleScopedAction(action) {
@@ -4207,6 +4204,10 @@
                 y: Number.isFinite(window.screenY) ? window.screenY : 0
             }
         };
+    }
+
+    function getYuiGuideScreenCoordinateBounds(metrics) {
+        return metrics && (metrics.bounds || metrics.contentBounds) || { x: 0, y: 0 };
     }
 
     function normalizeYuiGuideNiriPetPhysicalCropBounds(bounds) {
@@ -4432,7 +4433,7 @@
                 cropState
             );
         }
-        var bounds = metrics.contentBounds || metrics.bounds || { x: 0, y: 0 };
+        var bounds = getYuiGuideScreenCoordinateBounds(metrics);
         var viewport = shouldApplyYuiGuideVisualViewportOffset(metrics) ? (window.visualViewport || null) : null;
         var offsetLeft = viewport && Number.isFinite(Number(viewport.offsetLeft)) ? Number(viewport.offsetLeft) : 0;
         var offsetTop = viewport && Number.isFinite(Number(viewport.offsetTop)) ? Number(viewport.offsetTop) : 0;
@@ -4602,6 +4603,15 @@
         return entry && entry.shape ? entry.shape : 'rounded-rect';
     }
 
+    function shouldAlignYuiGuideChatSpotlightToCapsuleText(kind, variant) {
+        if (kind === 'input' && variant === 'plain-capsule') {
+            return true;
+        }
+        return false;
+    }
+
+    var YUI_GUIDE_CHAT_CAPSULE_TEXT_ALIGNMENT_RATIO = 0.6;
+
     function getYuiGuideChatSpotlightTarget(kind) {
         if (!kind || typeof document === 'undefined') {
             return null;
@@ -4639,6 +4649,44 @@
         }
 
         return null;
+    }
+
+    function getYuiGuideChatCapsuleTextAnchor() {
+        var anchor = getYuiGuideChatVisibleElement('#react-chat-window-root [data-compact-hit-region-id="capsule:text"]')
+            || getYuiGuideChatVisibleElement('#react-chat-window-root .compact-chat-capsule-button');
+        if (!anchor || typeof anchor.getBoundingClientRect !== 'function') {
+            return null;
+        }
+        var rect = anchor.getBoundingClientRect();
+        if (!rect || rect.width <= 0 || rect.height <= 0) {
+            return null;
+        }
+        return {
+            element: anchor,
+            rect: rect
+        };
+    }
+
+    function getYuiGuideChatSpotlightSourceRect(kind, variant, rect) {
+        var sourceRect = {
+            left: rect.left,
+            top: rect.top,
+            width: rect.width,
+            height: rect.height
+        };
+        if (shouldAlignYuiGuideChatSpotlightToCapsuleText(kind, variant)) {
+            var anchor = getYuiGuideChatCapsuleTextAnchor();
+            var anchorRect = anchor && anchor.rect;
+            if (
+                anchorRect
+                && anchorRect.left > rect.left
+                && anchorRect.left < rect.left + rect.width
+            ) {
+                var anchorOffsetX = anchorRect.left - rect.left;
+                sourceRect.left = rect.left + anchorOffsetX * YUI_GUIDE_CHAT_CAPSULE_TEXT_ALIGNMENT_RATIO;
+            }
+        }
+        return { rect: sourceRect };
     }
 
     function getYuiGuideChatVisibleElement(selector, root) {
@@ -5137,8 +5185,10 @@
         var rect = target && typeof target.getBoundingClientRect === 'function'
             ? target.getBoundingClientRect()
             : null;
+        var sourceRectInfo = rect ? getYuiGuideChatSpotlightSourceRect(kind, yuiGuideChatSpotlightVariant, rect) : null;
+        var sourceRect = sourceRectInfo ? sourceRectInfo.rect : rect;
 
-        if (!rect || rect.width <= 0 || rect.height <= 0) {
+        if (!sourceRect || sourceRect.width <= 0 || sourceRect.height <= 0) {
             if (pcOverlayAvailable) {
                 if (
                     kind
@@ -5161,13 +5211,13 @@
         }
 
         var padding = kind === 'window' ? 10 : 8;
-        var radius = kind === 'window' ? 26 : Math.min(34, Math.max(18, Math.round((rect.height + padding * 2) / 2)));
+        var radius = kind === 'window' ? 26 : Math.min(34, Math.max(18, Math.round((sourceRect.height + padding * 2) / 2)));
         if (pcOverlayAvailable) {
             var pcRects = [toYuiGuideScreenRect({
-                left: rect.left - padding,
-                top: rect.top - padding,
-                width: rect.width + padding * 2,
-                height: rect.height + padding * 2
+                left: sourceRect.left - padding,
+                top: sourceRect.top - padding,
+                width: sourceRect.width + padding * 2,
+                height: sourceRect.height + padding * 2
             }, kind, yuiGuideChatSpotlightVariant)].filter(Boolean);
             rememberYuiGuideChatPcSpotlightRects(kind, pcRects, yuiGuideChatSpotlightVariant);
             sendYuiGuidePcOverlayPatch({ spotlights: pcRects }, false, patchOptions);
@@ -5184,10 +5234,10 @@
         spotlight.classList.remove('is-window', 'is-input');
         spotlight.classList.add(kind === 'window' ? 'is-window' : 'is-input');
         spotlight.classList.add('is-visible');
-        spotlight.style.left = Math.round(rect.left - padding) + 'px';
-        spotlight.style.top = Math.round(rect.top - padding) + 'px';
-        spotlight.style.width = Math.round(rect.width + padding * 2) + 'px';
-        spotlight.style.height = Math.round(rect.height + padding * 2) + 'px';
+        spotlight.style.left = Math.round(sourceRect.left - padding) + 'px';
+        spotlight.style.top = Math.round(sourceRect.top - padding) + 'px';
+        spotlight.style.width = Math.round(sourceRect.width + padding * 2) + 'px';
+        spotlight.style.height = Math.round(sourceRect.height + padding * 2) + 'px';
         spotlight.style.borderRadius = radius + 'px';
     }
 

--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -4604,10 +4604,7 @@
     }
 
     function shouldAlignYuiGuideChatSpotlightToCapsuleText(kind, variant) {
-        if (kind === 'input' && variant === 'plain-capsule') {
-            return true;
-        }
-        return false;
+        return kind === 'input' && variant === 'plain-capsule';
     }
 
     var YUI_GUIDE_CHAT_CAPSULE_TEXT_ALIGNMENT_RATIO = 0.6;

--- a/static/tutorial/yui-guide/director.js
+++ b/static/tutorial/yui-guide/director.js
@@ -4891,6 +4891,10 @@
             }
         }
 
+        getGuideScreenCoordinateBounds(metrics) {
+            return metrics && (metrics.bounds || metrics.contentBounds) || null;
+        }
+
         screenPointToLocalPoint(point) {
             if (!point || !Number.isFinite(point.x) || !Number.isFinite(point.y)) {
                 return null;
@@ -4910,7 +4914,7 @@
                     y: localPoint.y
                 };
             }
-            let bounds = metrics && (metrics.contentBounds || metrics.bounds);
+            let bounds = this.getGuideScreenCoordinateBounds(metrics);
             if (!bounds) {
                 bounds = {
                     x: Number.isFinite(window.screenX) ? window.screenX : 0,
@@ -4942,7 +4946,7 @@
                     y: Number(screenBounds.y || 0) + virtualPoint.y
                 };
             }
-            let bounds = metrics && (metrics.contentBounds || metrics.bounds);
+            let bounds = this.getGuideScreenCoordinateBounds(metrics);
             if (!bounds) {
                 bounds = {
                     x: Number.isFinite(window.screenX) ? window.screenX : 0,

--- a/static/tutorial/yui-guide/overlay.js
+++ b/static/tutorial/yui-guide/overlay.js
@@ -212,6 +212,9 @@
                 zoomFactor: 1
             };
         };
+        const getScreenCoordinateBounds = (metrics) => (
+            metrics && (metrics.bounds || metrics.contentBounds) || { x: 0, y: 0 }
+        );
 
         const normalizeNiriPetPhysicalCropBounds = (bounds) => {
             if (!bounds || typeof bounds !== 'object') {
@@ -417,7 +420,7 @@
                     cropState
                 );
             }
-            const bounds = metrics.contentBounds || metrics.bounds || { x: 0, y: 0 };
+            const bounds = getScreenCoordinateBounds(metrics);
             const viewport = shouldApplyVisualViewportOffset(metrics) ? (window.visualViewport || null) : null;
             const offsetLeft = viewport && Number.isFinite(Number(viewport.offsetLeft)) ? Number(viewport.offsetLeft) : 0;
             const offsetTop = viewport && Number.isFinite(Number(viewport.offsetTop)) ? Number(viewport.offsetTop) : 0;

--- a/static/yui-guide-common.test.cjs
+++ b/static/yui-guide-common.test.cjs
@@ -1186,7 +1186,7 @@ test('interpage consumes common tutorial geometry before chat bridge scripts run
     assert.match(appInterpageSource, /getYuiGuideChatTargetShape\(kind\)/);
     assert.match(appInterpageSource, /getYuiGuideChatTargetShape\(kind\) === 'circle'/);
     assert.match(appInterpageSource, /function shouldAlignYuiGuideChatSpotlightToCapsuleText\(kind, variant\)/);
-    assert.match(appInterpageSource, /kind === 'input' && variant === 'plain-capsule'[\s\S]*return true;/);
+    assert.match(appInterpageSource, /function shouldAlignYuiGuideChatSpotlightToCapsuleText\(kind, variant\) \{\s*return kind === 'input' && variant === 'plain-capsule';\s*\}/);
     assert.match(appInterpageSource, /function getYuiGuideChatSpotlightSourceRect\(kind, variant, rect\)/);
     assert.match(appInterpageSource, /anchorOffsetX \* YUI_GUIDE_CHAT_CAPSULE_TEXT_ALIGNMENT_RATIO/);
     assert.match(appInterpageSource, /return \{ rect: sourceRect \};/);

--- a/static/yui-guide-common.test.cjs
+++ b/static/yui-guide-common.test.cjs
@@ -662,6 +662,7 @@ test('target geometry registry and chat window adapter expose phase two boundari
     const capsule = registry.resolve('chat-capsule-input');
     assert.equal(capsule.externalKind, 'capsule-input');
     assert.equal(capsule.fallbackGroup, 'chat-input');
+    assert.ok(capsule.localSelectors[0].includes('capsuleBody'));
     assert.ok(capsule.localSelectors.some((selector) => selector.includes('capsuleBody')));
     assert.equal(registry.getExternalKind('chat-galgame'), 'galgame');
     assert.equal(typeof registry.getByExternalKind, 'function');
@@ -1183,6 +1184,11 @@ test('interpage consumes common tutorial geometry before chat bridge scripts run
     assert.match(appInterpageSource, /entry\.localSelectors\.some\(function \(selector\)/);
     assert.match(appInterpageSource, /getYuiGuideChatTargetShape\(kind\)/);
     assert.match(appInterpageSource, /getYuiGuideChatTargetShape\(kind\) === 'circle'/);
+    assert.match(appInterpageSource, /function shouldAlignYuiGuideChatSpotlightToCapsuleText\(kind, variant\)/);
+    assert.match(appInterpageSource, /kind === 'input' && variant === 'plain-capsule'[\s\S]*return true;/);
+    assert.match(appInterpageSource, /function getYuiGuideChatSpotlightSourceRect\(kind, variant, rect\)/);
+    assert.match(appInterpageSource, /anchorOffsetX \* YUI_GUIDE_CHAT_CAPSULE_TEXT_ALIGNMENT_RATIO/);
+    assert.match(appInterpageSource, /return \{ rect: sourceRect \};/);
 });
 
 test('daily guide files consume common helpers instead of redeclaring shared helpers', () => {

--- a/static/yui-guide-common.test.cjs
+++ b/static/yui-guide-common.test.cjs
@@ -662,6 +662,7 @@ test('target geometry registry and chat window adapter expose phase two boundari
     const capsule = registry.resolve('chat-capsule-input');
     assert.equal(capsule.externalKind, 'capsule-input');
     assert.equal(capsule.fallbackGroup, 'chat-input');
+    assert.ok(capsule.localSelectors.length > 0, 'localSelectors must be non-empty');
     assert.ok(capsule.localSelectors[0].includes('capsuleBody'));
     assert.ok(capsule.localSelectors.some((selector) => selector.includes('capsuleBody')));
     assert.equal(registry.getExternalKind('chat-galgame'), 'galgame');
@@ -2674,7 +2675,8 @@ test('PC global overlay cleanup notifies external chat windows to stop overlay r
     const lifecycleMessageBlock = clearOverlayBlock.split('const lifecycleEndedMessage = {')[1].split('};', 1)[0];
     assert.match(lifecycleMessageBlock, /tutorialRunId:\s*tutorialRunId/);
     assert.match(appInterpageSource, /if \(message\.tutorialRunId && message\.action !== 'yui_guide_tutorial_lifecycle_ended'\) \{/);
-    assert.match(appInterpageSource, /var bounds = metrics\.contentBounds \|\| metrics\.bounds \|\| \{ x: 0, y: 0 \};/);
+    assert.match(appInterpageSource, /function getYuiGuideScreenCoordinateBounds\(metrics\) \{/);
+    assert.match(appInterpageSource, /return metrics && \(metrics\.bounds \|\| metrics\.contentBounds\) \|\| \{ x: 0, y: 0 \};/);
     assert.match(externalCleanupBlock, /yuiGuidePcOverlayActive = false;/);
     assert.match(externalCleanupBlock, /yuiGuidePcOverlayReady = false;/);
     assert.match(externalCleanupBlock, /var endedRunId = typeof tutorialRunId === 'string' && tutorialRunId/);

--- a/static/yui-guide-day1-round-structure.test.cjs
+++ b/static/yui-guide-day1-round-structure.test.cjs
@@ -251,8 +251,10 @@ test('Day1 return control cursor moves to the capsule primary target before the 
   assert.match(directorSource, /'chat-capsule-input': 'capsule-input'/);
   assert.match(targetGeometryRegistrySource, /'chat-capsule-input': Object\.freeze\(\{[\s\S]*externalKind: 'capsule-input'[\s\S]*data-compact-geometry-part="capsuleBody"/);
   assert.match(appInterpageSource, /getYuiGuideChatTargetRegistryEntryByExternalKind\(kind\)[\s\S]*entry\.localSelectors\.some/);
-  assert.match(appInterpageSource, /function updateYuiGuideChatSpotlight\(kind\) \{[\s\S]*var pcOverlayAvailable = isYuiGuidePcOverlayAvailable\(\);/);
-  assert.match(appInterpageSource, /function updateYuiGuideChatSpotlight\(kind\) \{[\s\S]*sendYuiGuidePcOverlayPatch\(\{ spotlights: pcRects \}\);/);
+  assert.match(appInterpageSource, /function shouldAlignYuiGuideChatSpotlightToCapsuleText\(kind, variant\)[\s\S]*kind === 'input' && variant === 'plain-capsule'[\s\S]*return true;/);
+  assert.match(appInterpageSource, /function getYuiGuideChatSpotlightSourceRect\(kind, variant, rect\)[\s\S]*anchorOffsetX \* YUI_GUIDE_CHAT_CAPSULE_TEXT_ALIGNMENT_RATIO[\s\S]*return \{ rect: sourceRect \};/);
+  assert.match(appInterpageSource, /function updateYuiGuideChatSpotlight\(kind,\s*pcOverlayRunId\) \{[\s\S]*var pcOverlayAvailable = isYuiGuidePcOverlayAvailable\(\);/);
+  assert.match(appInterpageSource, /function updateYuiGuideChatSpotlight\(kind,\s*pcOverlayRunId\) \{[\s\S]*var sourceRectInfo = rect \? getYuiGuideChatSpotlightSourceRect\(kind, yuiGuideChatSpotlightVariant, rect\) : null;[\s\S]*sendYuiGuidePcOverlayPatch\(\{ spotlights: pcRects \}, false, patchOptions\);/);
   assert.doesNotMatch(appInterpageSource, /function renderYuiGuideChatSpotlight/);
   assert.doesNotMatch(appInterpageSource, /function isYuiGuideInputLikeChatTarget/);
   assert.match(directorSource, /setExternalizedChatCursorEffect\(kind,\s*effect,\s*options\)[\s\S]*this\.rememberExternalizedChatCursorHandoffPoint\(normalizedKind,\s*cursorOptions\.effect\);[\s\S]*this\.interactionTakeover\.setExternalizedChatCursor\(normalizedKind,\s*cursorOptions\);/);

--- a/static/yui-guide-day1-round-structure.test.cjs
+++ b/static/yui-guide-day1-round-structure.test.cjs
@@ -251,7 +251,7 @@ test('Day1 return control cursor moves to the capsule primary target before the 
   assert.match(directorSource, /'chat-capsule-input': 'capsule-input'/);
   assert.match(targetGeometryRegistrySource, /'chat-capsule-input': Object\.freeze\(\{[\s\S]*externalKind: 'capsule-input'[\s\S]*data-compact-geometry-part="capsuleBody"/);
   assert.match(appInterpageSource, /getYuiGuideChatTargetRegistryEntryByExternalKind\(kind\)[\s\S]*entry\.localSelectors\.some/);
-  assert.match(appInterpageSource, /function shouldAlignYuiGuideChatSpotlightToCapsuleText\(kind, variant\)[\s\S]*kind === 'input' && variant === 'plain-capsule'[\s\S]*return true;/);
+  assert.match(appInterpageSource, /function shouldAlignYuiGuideChatSpotlightToCapsuleText\(kind, variant\) \{\s*return kind === 'input' && variant === 'plain-capsule';\s*\}/);
   assert.match(appInterpageSource, /function getYuiGuideChatSpotlightSourceRect\(kind, variant, rect\)[\s\S]*anchorOffsetX \* YUI_GUIDE_CHAT_CAPSULE_TEXT_ALIGNMENT_RATIO[\s\S]*return \{ rect: sourceRect \};/);
   assert.match(appInterpageSource, /function updateYuiGuideChatSpotlight\(kind,\s*pcOverlayRunId\) \{[\s\S]*var pcOverlayAvailable = isYuiGuidePcOverlayAvailable\(\);/);
   assert.match(appInterpageSource, /function updateYuiGuideChatSpotlight\(kind,\s*pcOverlayRunId\) \{[\s\S]*var sourceRectInfo = rect \? getYuiGuideChatSpotlightSourceRect\(kind, yuiGuideChatSpotlightVariant, rect\) : null;[\s\S]*sendYuiGuidePcOverlayPatch\(\{ spotlights: pcRects \}, false, patchOptions\);/);

--- a/tests/unit/test_avatar_floating_day1_round_contracts.py
+++ b/tests/unit/test_avatar_floating_day1_round_contracts.py
@@ -685,9 +685,12 @@ def test_pc_overlay_screen_coordinates_use_niri_virtual_origin_and_crop_safe_are
     assert "top: max(14px, env(safe-area-inset-top));" not in yui_skip_rule
     assert "top: max(14px, env(safe-area-inset-top));" not in tutorial_skip_rule
     assert "top: 18px;" not in page_skip_rule
-    assert "metrics.bounds || metrics.contentBounds" not in overlay_source
-    assert "metrics.bounds || metrics.contentBounds" not in interpage_source
-    assert "bounds = metrics && (metrics.bounds || metrics.contentBounds);" not in director_source
+    assert "const getScreenCoordinateBounds = (metrics) => (" in overlay_source
+    assert "const bounds = getScreenCoordinateBounds(metrics);" in overlay_source
+    assert "function getYuiGuideScreenCoordinateBounds(metrics)" in interpage_source
+    assert "var bounds = getYuiGuideScreenCoordinateBounds(metrics);" in interpage_source
+    assert "getGuideScreenCoordinateBounds(metrics)" in director_source
+    assert "let bounds = this.getGuideScreenCoordinateBounds(metrics);" in director_source
     assert "- topInset" not in interpage_source
     assert "- topInset" not in overlay_source
     assert "usesNiriPetPhysicalCrop" not in director_source

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -1257,18 +1257,23 @@ def test_externalized_chat_input_spotlight_uses_pc_overlay_rounded_rect_radius()
 def test_externalized_chat_input_spotlight_uses_global_overlay_only():
     script = (Path(__file__).resolve().parents[2] / "static" / "app-interpage.js").read_text(encoding="utf-8")
 
-    update_block = script.split("function updateYuiGuideChatSpotlight(kind)", 1)[1].split(
-        "function applyYuiGuideChatSpotlight(kind)",
+    update_block = script.split("function updateYuiGuideChatSpotlight(kind, pcOverlayRunId)", 1)[1].split(
+        "function applyYuiGuideChatSpotlight(kind, options)",
         1,
     )[0]
 
-    assert "if (isYuiGuidePcOverlayAvailable()) {" in update_block
+    assert "var pcOverlayAvailable = isYuiGuidePcOverlayAvailable();" in update_block
+    assert "if (pcOverlayAvailable) {" in update_block
+    assert "var sourceRectInfo = rect ? getYuiGuideChatSpotlightSourceRect(kind, yuiGuideChatSpotlightVariant, rect) : null;" in update_block
+    assert "var sourceRect = sourceRectInfo ? sourceRectInfo.rect : rect;" in update_block
+    assert "toYuiGuideScreenRect({" in update_block
+    assert "}, kind, yuiGuideChatSpotlightVariant)" in update_block
     assert "kind !== 'input' && isYuiGuidePcOverlayAvailable()" not in update_block
     assert "hideYuiGuideChatSpotlightElement" not in script
     assert "hideYuiGuideChatSpotlightElements" not in script
     assert "is-plain-capsule" not in update_block
+    assert "getYuiGuideChatSpotlightElement(!pcOverlayAvailable)" in update_block
     assert "renderYuiGuideChatSpotlight(" not in update_block
-    assert "getYuiGuideChatSpotlightElement(" not in script
     assert "function renderYuiGuideChatSpotlight" not in script
 
 
@@ -1506,14 +1511,15 @@ def test_interpage_bundle_uses_static_asset_version_on_home_and_chat():
 def test_externalized_chat_input_spotlight_retries_after_message_layout():
     script = (Path(__file__).resolve().parents[2] / "static" / "app-interpage.js").read_text(encoding="utf-8")
 
-    retry_block = script.split("function scheduleYuiGuideChatInputSpotlightRetry()", 1)[1].split(
-        "function updateYuiGuideChatSpotlight(kind)",
+    retry_block = script.split("function scheduleYuiGuideChatInputSpotlightRetry(kind, pcOverlayRunId)", 1)[1].split(
+        "function updateYuiGuideChatSpotlight(kind, pcOverlayRunId)",
         1,
     )[0]
 
-    assert "if (yuiGuideChatSpotlightKind !== 'input')" in retry_block
-    assert "updateYuiGuideChatSpotlight('input');" in retry_block
-    assert "scheduleYuiGuideChatInputSpotlightRetry();" in script
+    assert "if (!isYuiGuideChatInputSpotlightKind(retryKind))" in retry_block
+    assert "if (yuiGuideChatSpotlightKind === retryKind)" in retry_block
+    assert "updateYuiGuideChatSpotlight(retryKind, retryRunId);" in retry_block
+    assert "scheduleYuiGuideChatInputSpotlightRetry(normalizedKind, pcOverlayRunId);" in script
 
 
 def test_compact_tutorial_guide_preview_scrolls_without_ellipsis():


### PR DESCRIPTION
## Summary
- adjust external chat tutorial spotlight coordinates for the compact capsule dialog without changing spotlight size or style
- preserve screen-coordinate bounds ordering for Wayland/GNOME overlay geometry
- add geometry debug metadata and static regression coverage for the capsule spotlight path

## Tests
- node --check static/app-interpage.js static/tutorial/core/target-geometry-registry.js static/tutorial/yui-guide/director.js static/tutorial/yui-guide/overlay.js
- node --test --test-name-pattern "interpage consumes common tutorial geometry|Day1 return control cursor moves|external chat reuses tutorial PC overlay run id" static/yui-guide-common.test.cjs static/yui-guide-day1-round-structure.test.cjs
- uv run pytest tests/unit/test_avatar_floating_day1_round_contracts.py::test_externalized_chat_spotlight_preserves_plain_capsule_variant_for_pc_overlay tests/unit/test_react_chat_window_static.py::test_externalized_chat_input_spotlight_uses_global_overlay_only -q


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 聊天引导的高亮区域可按比例对齐文本气泡，提升视觉一致性与几何贴合度。
* **Bug 修复**
  * 统一并规范外部聊天的引导映射标识计算；屏幕坐标边界获取逻辑集中化，优先使用更合适的边界字段，减少定位偏移。
  * 更新聚焦更新与重试流程，兼容更多布局变化，并在无效几何时更安全地中止。
* **测试**
  * 扩展与调整相关断言，覆盖新的对齐、边界与参数化更新行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->