### PR TITLE
fix(neko): restore immediate return-ball dragging

### DIFF
--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -4643,6 +4643,8 @@
             if (isThoughtBubbleEventTarget(event)) return;
             const point = getTouchScreenPoint(event.touches[0]);
             if (!point) return;
+            event.preventDefault();
+            event.stopImmediatePropagation();
             beginDrag(point.x, point.y, event);
         };
         state.handleTouchMove = (event) => {

--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -2521,8 +2521,6 @@
     const MULTI_WINDOW_RETURN_BALL_DRAG_SHRINK_SIZE = 160;
     const RETURN_BALL_DRAG_RECOVERY_POLL_MS = 250;
     const RETURN_BALL_DRAG_STALE_RECOVERY_MS = 12000;
-    const RETURN_BALL_LONG_PRESS_DRAG_MS = 280;
-    const RETURN_BALL_LONG_PRESS_PENDING_ATTR = 'data-neko-return-long-press-pending';
     const MULTI_WINDOW_RETURN_BALL_DRAG_SHRINK_FALLBACK_MS = 220;
     const MULTI_WINDOW_RETURN_BALL_DRAG_RESTORE_FALLBACK_MS = 600;
     const MULTI_WINDOW_RETURN_BALL_REVEAL_FALLBACK_MS = 600;
@@ -3877,10 +3875,6 @@
         window.removeEventListener('blur', state.handleWindowBlur);
         window.removeEventListener('pagehide', state.handlePageHide);
         document.removeEventListener('visibilitychange', state.handleVisibilityChange);
-        if (state.pendingLongPressTimer) {
-            clearTimeout(state.pendingLongPressTimer);
-            state.pendingLongPressTimer = null;
-        }
         if (state.suppressDomClickTimer) {
             clearTimeout(state.suppressDomClickTimer);
             state.suppressDomClickTimer = null;
@@ -3890,7 +3884,6 @@
             restoreSavedReturnBallStyle(state.container, state);
             resetReturnBallTemporaryStyle(state.container);
             state.container.setAttribute('data-dragging', 'false');
-            state.container.removeAttribute(RETURN_BALL_LONG_PRESS_PENDING_ATTR);
             state.container.removeAttribute('data-neko-return-click-suppressed');
         }
         delete document.body.dataset.nekoBallDrag;
@@ -3944,16 +3937,6 @@
             dragSessionToken: 0,
             dragRecoveryTimer: null,
             lastPointerEventAt: 0,
-            pendingLongPress: false,
-            pendingLongPressTimer: null,
-            pendingStartScreenX: 0,
-            pendingStartScreenY: 0,
-            pendingLatestScreenX: 0,
-            pendingLatestScreenY: 0,
-            pendingLatestSourcePoint: null,
-            pendingPointerType: '',
-            pendingMovedPastClickThreshold: false,
-            cancelNoMoveClick: false,
             suppressDomClickTimer: null,
             handleClick: null,
             handleMouseDown: null,
@@ -4132,36 +4115,6 @@
             });
         }
 
-        function clearPendingLongPressDrag() {
-            if (state.pendingLongPressTimer) {
-                clearTimeout(state.pendingLongPressTimer);
-                state.pendingLongPressTimer = null;
-            }
-            container.removeAttribute(RETURN_BALL_LONG_PRESS_PENDING_ATTR);
-            state.pendingLongPress = false;
-            state.pendingPointerType = '';
-            state.pendingLatestSourcePoint = null;
-            state.pendingMovedPastClickThreshold = false;
-            if (!state.isDragging) {
-                container.setAttribute('data-dragging', 'false');
-            }
-        }
-
-        function updatePendingLongPressDrag(screenX, screenY, sourcePoint) {
-            if (!state.pendingLongPress) return false;
-            state.pendingLatestScreenX = screenX;
-            state.pendingLatestScreenY = screenY;
-            state.pendingLatestSourcePoint = sourcePoint || null;
-            if (
-                Math.abs(screenX - state.pendingStartScreenX) > CLICK_THRESHOLD ||
-                Math.abs(screenY - state.pendingStartScreenY) > CLICK_THRESHOLD
-            ) {
-                state.pendingMovedPastClickThreshold = true;
-            }
-            markDragPointerActivity();
-            return true;
-        }
-
         function scheduleReturnBallDragRecoveryCheck() {
             clearReturnBallDragRecoveryTimer(state);
             if (!state.isDragging) return;
@@ -4315,14 +4268,13 @@
             return bounds;
         }
 
-        function beginDrag(screenX, screenY, event, options = {}) {
+        function beginDrag(screenX, screenY, event) {
             clearMultiWindowReturnBallDeferredWork(state);
             state.dragSessionToken += 1;
             const dragToken = state.dragSessionToken;
 
             const dragStarted = window.nekoPetDrag.start(screenX, screenY);
             if (dragStarted === false) {
-                state.cancelNoMoveClick = false;
                 container.setAttribute('data-dragging', 'false');
                 setReturnBallDomClickSuppressed(false);
                 return;
@@ -4343,7 +4295,6 @@
             state.releaseScreenY = screenY;
             state.savedWindowW = window.innerWidth;
             state.savedWindowH = window.innerHeight;
-            state.cancelNoMoveClick = options.cancelNoMoveClick === true;
             state.niriPhysicalCropDrag = isNiriPhysicalCropReturnBallDragActive();
             markDragPointerActivity();
 
@@ -4424,40 +4375,6 @@
             }
         }
 
-        function scheduleLongPressDrag(screenX, screenY, event, pointerType = 'mouse') {
-            clearPendingLongPressDrag();
-            state.pendingLongPress = true;
-            state.pendingPointerType = pointerType;
-            state.pendingStartScreenX = screenX;
-            state.pendingStartScreenY = screenY;
-            state.pendingLatestScreenX = screenX;
-            state.pendingLatestScreenY = screenY;
-            state.pendingLatestSourcePoint = event || null;
-            state.pendingMovedPastClickThreshold = false;
-            markDragPointerActivity();
-            setReturnBallDomClickSuppressed(true, RETURN_BALL_LONG_PRESS_DRAG_MS + 180);
-            container.setAttribute(RETURN_BALL_LONG_PRESS_PENDING_ATTR, 'true');
-            state.pendingLongPressTimer = setTimeout(() => {
-                state.pendingLongPressTimer = null;
-                if (!state.pendingLongPress) return;
-                const startX = state.pendingStartScreenX;
-                const startY = state.pendingStartScreenY;
-                const latestX = state.pendingLatestScreenX;
-                const latestY = state.pendingLatestScreenY;
-                const latestSourcePoint = state.pendingLatestSourcePoint;
-                state.pendingLongPress = false;
-                state.pendingPointerType = '';
-                state.pendingLatestSourcePoint = null;
-                container.removeAttribute(RETURN_BALL_LONG_PRESS_PENDING_ATTR);
-                setReturnBallDomClickSuppressed(true, 1200);
-                beginDrag(startX, startY, latestSourcePoint || event, { cancelNoMoveClick: true });
-                if (state.isDragging) {
-                    container.setAttribute('data-dragging', 'pending');
-                    updateDrag(latestX, latestY, latestSourcePoint);
-                }
-            }, RETURN_BALL_LONG_PRESS_DRAG_MS);
-        }
-
         function sendReturnBallNativeDragMove(screenX, screenY) {
             if (!state.niriPhysicalCropDrag ||
                 !window.nekoPetDrag ||
@@ -4521,8 +4438,7 @@
 
             const options = arguments[2] && typeof arguments[2] === 'object' ? arguments[2] : {};
             const suppressClick = options.suppressClick === true;
-            const suppressNoMoveClick = suppressClick || state.cancelNoMoveClick === true;
-            state.cancelNoMoveClick = false;
+            const suppressNoMoveClick = suppressClick;
             state.isDragging = false;
             state.releaseScreenX = screenX;
             state.releaseScreenY = screenY;
@@ -4702,74 +4618,34 @@
                 return;
             }
             if (isThoughtBubbleEventTarget(event)) return;
-            scheduleLongPressDrag(event.screenX, event.screenY, event, 'mouse');
-            event.preventDefault();
-            event.stopImmediatePropagation();
+            beginDrag(event.screenX, event.screenY, event);
         };
         state.handleMouseMove = (event) => {
-            if (updatePendingLongPressDrag(event.screenX, event.screenY, event)) return;
             if (finishDragIfMouseButtonReleased(event, 'mousemove-buttons-released')) return;
             updateDrag(event.screenX, event.screenY, event);
         };
         state.handleMouseUp = (event) => {
-            if (state.pendingLongPress) {
-                const shouldDispatchClick = state.pendingMovedPastClickThreshold !== true;
-                clearPendingLongPressDrag();
-                if (shouldDispatchClick) {
-                    setReturnBallDomClickSuppressed(true, 500);
-                    dispatchReturnBallClick();
-                } else {
-                    setReturnBallDomClickSuppressed(true, 160);
-                }
-                event.preventDefault();
-                event.stopImmediatePropagation();
-                return;
-            }
             void finishDrag(event.screenX, event.screenY);
         };
         state.handlePointerMove = (event) => {
-            if (event && event.pointerType === 'mouse' && updatePendingLongPressDrag(event.screenX, event.screenY, event)) return;
             if (finishDragIfMouseButtonReleased(event, 'pointermove-buttons-released')) return;
             if (event && event.pointerType === 'mouse') {
                 updateDrag(event.screenX, event.screenY, event);
             }
         };
         state.handlePointerUp = (event) => {
-            if (event && event.pointerType === 'mouse' && state.pendingLongPress) {
-                const shouldDispatchClick = state.pendingMovedPastClickThreshold !== true;
-                clearPendingLongPressDrag();
-                if (shouldDispatchClick) {
-                    setReturnBallDomClickSuppressed(true, 500);
-                    dispatchReturnBallClick();
-                } else {
-                    setReturnBallDomClickSuppressed(true, 160);
-                }
-                event.preventDefault();
-                event.stopImmediatePropagation();
-                return;
-            }
             void finishDrag(event.screenX, event.screenY);
         };
         state.handlePointerCancel = () => {
-            clearPendingLongPressDrag();
             cancelActiveDrag('pointercancel');
         };
         state.handleTouchStart = (event) => {
             if (isThoughtBubbleEventTarget(event)) return;
             const point = getTouchScreenPoint(event.touches[0]);
             if (!point) return;
-            scheduleLongPressDrag(point.x, point.y, event, 'touch');
-            event.preventDefault();
-            event.stopImmediatePropagation();
+            beginDrag(point.x, point.y, event);
         };
         state.handleTouchMove = (event) => {
-            if (state.pendingLongPress) {
-                const pendingPoint = getTouchScreenPoint(event.touches[0]);
-                if (!pendingPoint) return;
-                event.preventDefault();
-                updatePendingLongPressDrag(pendingPoint.x, pendingPoint.y, event.touches[0]);
-                return;
-            }
             if (!state.isDragging) return;
             const point = getTouchScreenPoint(event.touches[0]);
             if (!point) return;
@@ -4778,53 +4654,33 @@
         };
         state.handleTouchEnd = (event) => {
             const point = getTouchScreenPoint(event.changedTouches && event.changedTouches[0]);
-            if (state.pendingLongPress) {
-                const shouldDispatchClick = state.pendingMovedPastClickThreshold !== true;
-                clearPendingLongPressDrag();
-                if (shouldDispatchClick) {
-                    setReturnBallDomClickSuppressed(true, 500);
-                    dispatchReturnBallClick();
-                } else {
-                    setReturnBallDomClickSuppressed(true, 160);
-                }
-                event.preventDefault();
-                event.stopImmediatePropagation();
-                return;
-            }
             void finishDrag(
                 point ? point.x : state.releaseScreenX,
                 point ? point.y : state.releaseScreenY
             );
         };
         state.handleWindowBlur = () => {
-            if (state.pendingLongPress) {
-                clearPendingLongPressDrag();
-                cancelActiveDrag('window-blur-pending');
-                return;
-            }
             if (!state.isDragging) return;
             // Native return-ball dragging may legitimately blur the Pet window when
             // the companion chat layer has focus; stale recovery handles lost release.
             scheduleReturnBallDragRecoveryCheck();
         };
         state.handlePageHide = () => {
-            clearPendingLongPressDrag();
             cancelActiveDrag('pagehide');
         };
         state.handleVisibilityChange = () => {
             if (document.hidden) {
-                clearPendingLongPressDrag();
                 cancelActiveDrag('visibility-hidden');
             }
         };
         state.handleClick = (event) => {
             const isSuppressed = container.getAttribute('data-neko-return-click-suppressed') === 'true';
-            const isLongPressPending = container.getAttribute(RETURN_BALL_LONG_PRESS_PENDING_ATTR) === 'true';
-            const isNativeDragPending = container.getAttribute('data-dragging') === 'pending';
-            if (!isSuppressed && !isLongPressPending && !isNativeDragPending) return;
+            const isNativeDragActive = container.getAttribute('data-dragging') === 'true' ||
+                container.getAttribute('data-dragging') === 'pending';
+            if (!isSuppressed && !isNativeDragActive) return;
             event.preventDefault();
             event.stopImmediatePropagation();
-            if (!isLongPressPending && !isNativeDragPending) {
+            if (!isNativeDragActive) {
                 setReturnBallDomClickSuppressed(false);
             }
         };

--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -265,8 +265,6 @@ const _NEKO_IDLE_DESKTOP_CHAT_RECT_STALE_MS = 2500;
 const _NEKO_IDLE_DESKTOP_COMPACT_SURFACE_RECT_STALE_MS = 10 * 1000;
 const _NEKO_IDLE_RETURN_DRAG_PENDING_CLASS = 'is-drag-action-pending';
 const _NEKO_IDLE_RETURN_DRAG_ACTION_CLASS = 'is-drag-action';
-const _NEKO_IDLE_RETURN_DRAG_LONG_PRESS_MS = 280;
-const _NEKO_IDLE_RETURN_LONG_PRESS_PENDING_ATTR = 'data-neko-return-long-press-pending';
 const _NEKO_IDLE_CAT1_PLAY_FINISHING_ATTR = 'data-neko-cat1-play-finishing';
 const _NEKO_IDLE_CAT1_PLAY_YARN_RELEASE_SIZE_PX = 51;
 const _NEKO_IDLE_CAT1_RAPID_DRAG_ASSET_URL = '/static/assets/neko-idle/cat-idle-cat-move-5.gif';
@@ -5647,9 +5645,6 @@ const AvatarButtonMixin = {
             }
 
             if (this._returnButtonDragHandlers) {
-                if (typeof this._returnButtonDragHandlers.cancelPendingLongPress === 'function') {
-                    this._returnButtonDragHandlers.cancelPendingLongPress();
-                }
                 document.removeEventListener('mousemove', this._returnButtonDragHandlers.mouseMove);
                 document.removeEventListener('mouseup', this._returnButtonDragHandlers.mouseUp);
                 document.removeEventListener('touchmove', this._returnButtonDragHandlers.touchMove);
@@ -6078,7 +6073,6 @@ const AvatarButtonMixin = {
                 if (
                     returnButtonContainer.getAttribute('data-dragging') === 'true' ||
                     returnButtonContainer.getAttribute('data-dragging') === 'pending' ||
-                    returnButtonContainer.getAttribute(_NEKO_IDLE_RETURN_LONG_PRESS_PENDING_ATTR) === 'true' ||
                     returnButtonContainer.getAttribute('data-neko-return-click-suppressed') === 'true' ||
                     returnButtonContainer.getAttribute('data-neko-model-cat-transitioning') === 'cat-to-model' ||
                     (typeof window.isNekoModelCatTransitionActive === 'function' && window.isNekoModelCatTransitionActive())
@@ -6189,14 +6183,6 @@ const AvatarButtonMixin = {
             let dragSafetyTimer = 0;
             let dragSafetyToken = 0;
             let dragPointerType = '';
-            let dragLongPressTimer = 0;
-            let dragLongPressPending = false;
-            let dragLongPressMovedPastClickThreshold = false;
-            let pendingDragPointerType = '';
-            let pendingDragStartX = 0, pendingDragStartY = 0, pendingDragLatestX = 0, pendingDragLatestY = 0;
-            let pendingDragStartVirtualX = 0, pendingDragStartVirtualY = 0;
-            let pendingDragLatestVirtualX = 0, pendingDragLatestVirtualY = 0;
-            let pendingDragSourceEvent = null;
             let dragStartX = 0, dragStartY = 0, containerStartX = 0, containerStartY = 0;
             let dragStartVirtualX = 0, dragStartVirtualY = 0;
             let dragGrabOffsetX = 0, dragGrabOffsetY = 0;
@@ -6375,39 +6361,11 @@ const AvatarButtonMixin = {
                 dragSafetyTimer = 0;
             };
 
-            const clearDragLongPressTimer = () => {
-                if (!dragLongPressTimer) return;
-                clearTimeout(dragLongPressTimer);
-                dragLongPressTimer = 0;
-            };
-
             const setReturnClickSuppressed = (suppressed) => {
                 if (suppressed) {
                     container.setAttribute('data-neko-return-click-suppressed', 'true');
                 } else {
                     container.removeAttribute('data-neko-return-click-suppressed');
-                }
-            };
-
-            const setReturnLongPressPending = (pending) => {
-                if (pending) {
-                    container.setAttribute(_NEKO_IDLE_RETURN_LONG_PRESS_PENDING_ATTR, 'true');
-                } else {
-                    container.removeAttribute(_NEKO_IDLE_RETURN_LONG_PRESS_PENDING_ATTR);
-                }
-            };
-
-            const clearPendingLongPressDrag = () => {
-                clearDragLongPressTimer();
-                dragLongPressPending = false;
-                dragLongPressMovedPastClickThreshold = false;
-                pendingDragPointerType = '';
-                pendingDragSourceEvent = null;
-                setReturnLongPressPending(false);
-                if (!isDragging) {
-                    container.setAttribute('data-dragging', 'false');
-                    container.style.cursor = 'grab';
-                    setReturnClickSuppressed(false);
                 }
             };
 
@@ -6455,7 +6413,6 @@ const AvatarButtonMixin = {
             };
 
             const cancelDragState = () => {
-                clearPendingLongPressDrag();
                 clearDragSafetyTimer();
                 stopDragCursorPolling();
                 if (!isDragging) return;
@@ -6561,7 +6518,6 @@ const AvatarButtonMixin = {
             const handleStart = (clientX, clientY, pointerType = 'mouse', sourceEvent = null, startPoint = null) => {
                 clearDragSafetyTimer();
                 stopDragCursorPolling();
-                setReturnLongPressPending(false);
                 setReturnClickSuppressed(true);
                 const point = startPoint || getDragPoint(sourceEvent, clientX, clientY);
                 if (!isUsableDragPoint(point)) return;
@@ -6595,90 +6551,7 @@ const AvatarButtonMixin = {
                 startDragCursorPolling();
             };
 
-            const scheduleLongPressDrag = (clientX, clientY, pointerType = 'mouse', sourceEvent = null) => {
-                clearPendingLongPressDrag();
-                const point = getDragPoint(sourceEvent, clientX, clientY);
-                if (!isUsableDragPoint(point)) return;
-                const screenPoint = getDragScreenPointFromVirtualPoint(point.virtualX, point.virtualY, sourceEvent, clientX, clientY);
-                dragLongPressPending = true;
-                pendingDragPointerType = pointerType;
-                pendingDragStartX = point.localX;
-                pendingDragStartY = point.localY;
-                pendingDragLatestX = point.localX;
-                pendingDragLatestY = point.localY;
-                pendingDragStartVirtualX = point.virtualX;
-                pendingDragStartVirtualY = point.virtualY;
-                pendingDragLatestVirtualX = point.virtualX;
-                pendingDragLatestVirtualY = point.virtualY;
-                pendingDragSourceEvent = sourceEvent;
-                dragLongPressMovedPastClickThreshold = false;
-                setReturnLongPressPending(true);
-                container.style.cursor = 'grabbing';
-                _dispatchNekoIdleReturnBallManualMove(container, 'return-ball-drag-pending', {
-                    clientX: point.localX,
-                    clientY: point.localY,
-                    screenX: Number.isFinite(screenPoint.x) ? screenPoint.x : (sourceEvent && Number.isFinite(sourceEvent.screenX) ? sourceEvent.screenX : clientX),
-                    screenY: Number.isFinite(screenPoint.y) ? screenPoint.y : (sourceEvent && Number.isFinite(sourceEvent.screenY) ? sourceEvent.screenY : clientY),
-                    timestamp: Date.now()
-                });
-                dragLongPressTimer = setTimeout(() => {
-                    dragLongPressTimer = 0;
-                    if (!dragLongPressPending) return;
-                    const startX = pendingDragStartX;
-                    const startY = pendingDragStartY;
-                    const latestX = pendingDragLatestX;
-                    const latestY = pendingDragLatestY;
-                    const startVirtualX = pendingDragStartVirtualX;
-                    const startVirtualY = pendingDragStartVirtualY;
-                    const latestVirtualX = pendingDragLatestVirtualX;
-                    const latestVirtualY = pendingDragLatestVirtualY;
-                    const latestSourceEvent = pendingDragSourceEvent;
-                    const activePointerType = pendingDragPointerType || pointerType;
-                    dragLongPressPending = false;
-                    pendingDragPointerType = '';
-                    pendingDragSourceEvent = null;
-                    handleStart(
-                        startX,
-                        startY,
-                        activePointerType,
-                        latestSourceEvent,
-                        buildDragPointSnapshot(startX, startY, startVirtualX, startVirtualY)
-                    );
-                    handleMove(
-                        latestX,
-                        latestY,
-                        latestSourceEvent,
-                        buildDragPointSnapshot(latestX, latestY, latestVirtualX, latestVirtualY)
-                    );
-                }, _NEKO_IDLE_RETURN_DRAG_LONG_PRESS_MS);
-            };
-
-            const updatePendingLongPressDrag = (clientX, clientY, sourceEvent = null) => {
-                if (!dragLongPressPending) return false;
-                const point = getDragPoint(sourceEvent, clientX, clientY);
-                if (!isUsableDragPoint(point)) return true;
-                pendingDragLatestX = point.localX;
-                pendingDragLatestY = point.localY;
-                pendingDragLatestVirtualX = point.virtualX;
-                pendingDragLatestVirtualY = point.virtualY;
-                pendingDragSourceEvent = sourceEvent;
-                if (Math.abs(point.virtualX - pendingDragStartVirtualX) > 5 ||
-                    Math.abs(point.virtualY - pendingDragStartVirtualY) > 5) {
-                    dragLongPressMovedPastClickThreshold = true;
-                }
-                return true;
-            };
-
             const handleEnd = () => {
-                if (dragLongPressPending) {
-                    const suppressClick = dragLongPressMovedPastClickThreshold;
-                    clearPendingLongPressDrag();
-                    if (suppressClick) {
-                        setReturnClickSuppressed(true);
-                        setTimeout(() => setReturnClickSuppressed(false), 160);
-                    }
-                    return;
-                }
                 clearDragSafetyTimer();
                 stopDragCursorPolling();
                 if (isDragging) {
@@ -6709,15 +6582,13 @@ const AvatarButtonMixin = {
                     e.preventDefault();
                     e.stopImmediatePropagation();
                     const point = getDragPoint(e, e.clientX, e.clientY);
-                    scheduleLongPressDrag(point.x, point.y, 'mouse', e);
+                    handleStart(point.x, point.y, 'mouse', e, point);
                 }
             });
 
             this._returnButtonDragHandlers = {
-                cancelPendingLongPress: clearPendingLongPressDrag,
                 mouseMove: (e) => {
                     const point = getDragPoint(e, e.clientX, e.clientY);
-                    if (updatePendingLongPressDrag(point.x, point.y, e)) return;
                     if (isDragging && dragPointerType === 'mouse' && e.buttons === 0) {
                         handleEnd();
                         return;
@@ -6726,12 +6597,6 @@ const AvatarButtonMixin = {
                 },
                 mouseUp: handleEnd,
                 touchMove: (e) => {
-                    if (dragLongPressPending && e.touches && e.touches[0]) {
-                        e.preventDefault();
-                        const point = getDragPoint(e.touches[0], e.touches[0].clientX, e.touches[0].clientY);
-                        updatePendingLongPressDrag(point.x, point.y, e.touches[0]);
-                        return;
-                    }
                     if (isDragging && e.touches && e.touches[0]) {
                         e.preventDefault();
                         const point = getDragPoint(e.touches[0], e.touches[0].clientX, e.touches[0].clientY);
@@ -6756,7 +6621,7 @@ const AvatarButtonMixin = {
                 }
                 if (container.contains(e.target) && e.touches && e.touches[0]) {
                     const point = getDragPoint(e.touches[0], e.touches[0].clientX, e.touches[0].clientY);
-                    scheduleLongPressDrag(point.x, point.y, 'touch', e.touches[0]);
+                    handleStart(point.x, point.y, 'touch', e.touches[0], point);
                 }
             }, { passive: false });
             document.addEventListener('touchmove', this._returnButtonDragHandlers.touchMove, { passive: false });
@@ -7068,9 +6933,6 @@ const AvatarButtonMixin = {
             }
 
             if (this._returnButtonDragHandlers) {
-                if (typeof this._returnButtonDragHandlers.cancelPendingLongPress === 'function') {
-                    this._returnButtonDragHandlers.cancelPendingLongPress();
-                }
                 document.removeEventListener('mousemove', this._returnButtonDragHandlers.mouseMove);
                 document.removeEventListener('mouseup', this._returnButtonDragHandlers.mouseUp);
                 document.removeEventListener('touchmove', this._returnButtonDragHandlers.touchMove);

--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -6430,7 +6430,11 @@ const AvatarButtonMixin = {
                         dragCancelled: true
                     });
                 }
-                setTimeout(() => setReturnClickSuppressed(false), 120);
+                if (moved) {
+                    setTimeout(() => setReturnClickSuppressed(false), 120);
+                } else {
+                    setReturnClickSuppressed(false);
+                }
             };
 
             const resetDragStateAfterMissingEnd = (safetyToken) => {
@@ -6593,9 +6597,13 @@ const AvatarButtonMixin = {
                     dragActiveDispatched = false;
                     dragPointerType = '';
                     container.style.cursor = 'grab';
-                    setTimeout(() => {
+                    if (moved) {
+                        setTimeout(() => {
+                            finishDragState(moved, safetyToken);
+                        }, 10);
+                    } else {
                         finishDragState(moved, safetyToken);
-                    }, 10);
+                    }
                 }
             };
 

--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -6242,6 +6242,20 @@ const AvatarButtonMixin = {
             };
 
             const getDragPoint = (sourceEvent, fallbackX, fallbackY) => {
+                if (!isDragNiriCropCoordinateActive()) {
+                    const localX = Number(fallbackX);
+                    const localY = Number(fallbackY);
+                    return {
+                        x: localX,
+                        y: localY,
+                        localX: localX,
+                        localY: localY,
+                        virtualX: localX,
+                        virtualY: localY,
+                        offsetX: 0,
+                        offsetY: 0
+                    };
+                }
                 const offset = getDragCropOffset();
                 let localX = Number(fallbackX);
                 let localY = Number(fallbackY);
@@ -6289,6 +6303,24 @@ const AvatarButtonMixin = {
 
             const getDragContainerVirtualRect = () => {
                 const rect = container.getBoundingClientRect && container.getBoundingClientRect();
+                if (!isDragNiriCropCoordinateActive()) {
+                    if (!rect) {
+                        const left = Number.parseFloat(container.style.left);
+                        const top = Number.parseFloat(container.style.top);
+                        return {
+                            left: Number.isFinite(left) ? left : 0,
+                            top: Number.isFinite(top) ? top : 0,
+                            width: container.offsetWidth || 64,
+                            height: container.offsetHeight || 64
+                        };
+                    }
+                    return {
+                        left: Number(rect.left),
+                        top: Number(rect.top),
+                        width: Number(rect.width) || container.offsetWidth || 64,
+                        height: Number(rect.height) || container.offsetHeight || 64
+                    };
+                }
                 const offset = getDragCropOffset();
                 if (!rect) {
                     const left = Number.parseFloat(container.style.left);

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -766,7 +766,6 @@ body.neko-game-active [id$="-lock-icon"] {
 }
 
 .neko-idle-return-btn[data-neko-idle-tier="none"] .neko-idle-thought-bubble,
-.neko-idle-return-button-container[data-neko-return-long-press-pending="true"] .neko-idle-thought-bubble,
 .neko-idle-return-btn.is-drag-action-pending .neko-idle-thought-bubble,
 .neko-idle-return-btn.is-drag-action .neko-idle-thought-bubble,
 .neko-idle-return-btn.is-cat1-walking .neko-idle-thought-bubble,

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -2072,6 +2072,23 @@ def test_idle_thought_bubble_is_sound_triggered_with_fade():
         "beginDrag(event.screenX, event.screenY, event);",
     )
     assert "state.handleTouchStart = (event) => {\n            if (isThoughtBubbleEventTarget(event)) return;" in app_ui_source
+    native_touch_drag_block = _source_slice_between(
+        app_ui_source,
+        "state.handleTouchStart = (event) => {",
+        "state.handleTouchMove = (event) => {",
+        "desktop native return-ball touch drag start",
+    )
+    _assert_source_order(
+        native_touch_drag_block,
+        "desktop native return-ball touch drag blocks default gestures before drag",
+        "state.handleTouchStart = (event) => {",
+        "if (isThoughtBubbleEventTarget(event)) return;",
+        "const point = getTouchScreenPoint(event.touches[0]);",
+        "if (!point) return;",
+        "event.preventDefault();",
+        "event.stopImmediatePropagation();",
+        "beginDrag(point.x, point.y, event);",
+    )
 
     bubble_bg_block = _extract_css_block(css_source, ".neko-idle-thought-bubble-bg")
     assert "position: absolute;" in bubble_bg_block

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -718,7 +718,7 @@ def test_cat1_edge_peek_only_applies_after_drag_release():
     drag_start_block = _source_slice_between(
         source,
         "const handleStart = (clientX, clientY, pointerType = 'mouse', sourceEvent = null, startPoint = null) => {",
-        "const scheduleLongPressDrag = (clientX, clientY, pointerType = 'mouse', sourceEvent = null) => {",
+        "const handleEnd = () => {",
         "return button drag start",
     )
     _assert_source_order(
@@ -799,7 +799,7 @@ def test_cat1_edge_peek_only_applies_after_drag_release():
 
     native_begin_block = _source_slice_between(
         app_ui_source,
-        "function beginDrag(screenX, screenY, event, options = {})",
+        "function beginDrag(screenX, screenY, event)",
         "function updateDrag(screenX, screenY, sourcePoint = null)",
         "native return-ball drag start",
     )
@@ -888,7 +888,8 @@ def test_desktop_return_ball_drag_lifecycle_waits_for_restored_viewport_before_r
     assert "MULTI_WINDOW_RETURN_BALL_DRAG_SHRINK_FALLBACK_MS = 220" in source
     assert "MULTI_WINDOW_RETURN_BALL_DRAG_RESTORE_FALLBACK_MS = 600" in source
     assert "MULTI_WINDOW_RETURN_BALL_REVEAL_FALLBACK_MS = 600" in source
-    assert "RETURN_BALL_LONG_PRESS_DRAG_MS = 280" in source
+    assert "RETURN_BALL_LONG_PRESS_DRAG_MS" not in source
+    assert "RETURN_BALL_LONG_PRESS_PENDING_ATTR" not in source
     assert "continueOnFallback" in source
     assert "waitForViewportSize timed out; continuing best-effort cleanup" in source
     assert "keeping return-ball hidden until viewport is restored" in source
@@ -933,7 +934,6 @@ def test_desktop_return_ball_drag_lifecycle_waits_for_restored_viewport_before_r
         "function ensureMultiWindowReturnBallDrag(container)",
         "native return-ball drag cleanup",
     )
-    assert "state.container.removeAttribute(RETURN_BALL_LONG_PRESS_PENDING_ATTR);" in cleanup_block
     assert "state.container.removeAttribute('data-neko-return-click-suppressed');" in cleanup_block
     _assert_source_order(
         source,
@@ -946,7 +946,7 @@ def test_desktop_return_ball_drag_lifecycle_waits_for_restored_viewport_before_r
         "syncIdleReturnBallDesktopStateFromManualMove(event && event.detail);",
     )
 
-    begin_index = source.index("function beginDrag(screenX, screenY, event, options = {})")
+    begin_index = source.index("function beginDrag(screenX, screenY, event)")
     native_start_index = source.index("const dragStarted = window.nekoPetDrag.start(screenX, screenY)", begin_index)
     dispatch_start_index = source.index("reason: 'return-ball-drag-start'", begin_index)
     drag_style_index = source.index("document.body.dataset.nekoBallDrag = '1'", begin_index)
@@ -954,8 +954,8 @@ def test_desktop_return_ball_drag_lifecycle_waits_for_restored_viewport_before_r
     assert begin_index < native_start_index < dispatch_start_index < drag_style_index
     begin_block = _source_slice_between(
         source,
-        "function beginDrag(screenX, screenY, event, options = {})",
-        "function scheduleLongPressDrag(screenX, screenY, event, pointerType = 'mouse')",
+        "function beginDrag(screenX, screenY, event)",
+        "function sendReturnBallNativeDragMove(screenX, screenY)",
         "native return-ball drag start",
     )
     niri_begin_block = _source_slice_between(
@@ -968,26 +968,10 @@ def test_desktop_return_ball_drag_lifecycle_waits_for_restored_viewport_before_r
     assert "container.style.left = `${centeredLeft}px`;" not in niri_begin_block
     assert "waitForViewportSize(" not in niri_begin_block
 
-    long_press_block = _source_slice_between(
-        source,
-        "function scheduleLongPressDrag(screenX, screenY, event, pointerType = 'mouse')",
-        "function updateDrag(screenX, screenY, sourcePoint = null)",
-        "native return-ball long press drag scheduler",
-    )
-    _assert_source_order(
-        long_press_block,
-        "native return-ball delays native drag until long press threshold",
-        "setReturnBallDomClickSuppressed(true, RETURN_BALL_LONG_PRESS_DRAG_MS + 180);",
-        "container.setAttribute(RETURN_BALL_LONG_PRESS_PENDING_ATTR, 'true');",
-        "state.pendingLongPressTimer = setTimeout(() => {",
-        "const startX = state.pendingStartScreenX;",
-        "container.removeAttribute(RETURN_BALL_LONG_PRESS_PENDING_ATTR);",
-        "setReturnBallDomClickSuppressed(true, 1200);",
-        "beginDrag(startX, startY, latestSourcePoint || event, { cancelNoMoveClick: true });",
-        "if (state.isDragging) {\n                    container.setAttribute('data-dragging', 'pending');",
-        "updateDrag(latestX, latestY, latestSourcePoint);",
-    )
-    assert "beginDrag(screenX, screenY, event, { cancelNoMoveClick: false });" not in long_press_block
+    assert "function scheduleLongPressDrag" not in source
+    assert "function updatePendingLongPressDrag" not in source
+    assert "pendingLongPress" not in source
+    assert "setTimeout(() => {\n                state.pendingLongPressTimer" not in source
     update_drag_block = _source_slice_between(
         source,
         "function updateDrag(screenX, screenY, sourcePoint = null)",
@@ -1010,9 +994,9 @@ def test_desktop_return_ball_drag_lifecycle_waits_for_restored_viewport_before_r
     )
     _assert_source_order(
         mouse_move_block,
-        "native pending long press ignores early zero-buttons recovery",
-        "if (updatePendingLongPressDrag(event.screenX, event.screenY, event)) return;",
+        "native return-ball mousemove recovers released mouse before moving",
         "if (finishDragIfMouseButtonReleased(event, 'mousemove-buttons-released')) return;",
+        "updateDrag(event.screenX, event.screenY, event);",
     )
     mouse_up_block = _source_slice_between(
         source,
@@ -1020,21 +1004,7 @@ def test_desktop_return_ball_drag_lifecycle_waits_for_restored_viewport_before_r
         "state.handlePointerMove = (event) => {",
         "native return-ball mouseup handler",
     )
-    _assert_source_order(
-        mouse_up_block,
-        "native short press dispatches return click on release before native drag starts",
-        "if (state.pendingLongPress) {",
-        "const shouldDispatchClick = state.pendingMovedPastClickThreshold !== true;",
-        "clearPendingLongPressDrag();",
-        "if (shouldDispatchClick) {",
-        "setReturnBallDomClickSuppressed(true, 500);",
-        "dispatchReturnBallClick();",
-        "} else {",
-        "setReturnBallDomClickSuppressed(true, 160);",
-        "event.preventDefault();",
-        "event.stopImmediatePropagation();",
-        "void finishDrag(event.screenX, event.screenY);",
-    )
+    assert mouse_up_block.strip() == "state.handleMouseUp = (event) => {\n            void finishDrag(event.screenX, event.screenY);\n        };"
     click_guard_block = _source_slice_between(
         source,
         "state.handleClick = (event) => {",
@@ -1043,14 +1013,14 @@ def test_desktop_return_ball_drag_lifecycle_waits_for_restored_viewport_before_r
     )
     _assert_source_order(
         click_guard_block,
-        "native return-ball blocks DOM clicks while long press is pending",
+        "native return-ball blocks DOM clicks while drag/click suppression is active",
         "const isSuppressed = container.getAttribute('data-neko-return-click-suppressed') === 'true';",
-        "const isLongPressPending = container.getAttribute(RETURN_BALL_LONG_PRESS_PENDING_ATTR) === 'true';",
-        "const isNativeDragPending = container.getAttribute('data-dragging') === 'pending';",
-        "if (!isSuppressed && !isLongPressPending && !isNativeDragPending) return;",
+        "const isNativeDragActive = container.getAttribute('data-dragging') === 'true' ||",
+        "container.getAttribute('data-dragging') === 'pending';",
+        "if (!isSuppressed && !isNativeDragActive) return;",
         "event.preventDefault();",
         "event.stopImmediatePropagation();",
-        "if (!isLongPressPending && !isNativeDragPending) {",
+        "if (!isNativeDragActive) {",
         "setReturnBallDomClickSuppressed(false);",
     )
 
@@ -1128,11 +1098,7 @@ def test_desktop_return_ball_drag_recovers_when_mouse_release_is_lost():
     window_blur_block = source[window_blur_start:window_blur_end]
     _assert_source_order(
         window_blur_block,
-        "pending native return-ball blur cancels while active drag still uses recovery",
-        "if (state.pendingLongPress) {",
-        "clearPendingLongPressDrag();",
-        "cancelActiveDrag('window-blur-pending');",
-        "return;",
+        "native return-ball blur keeps active drag recovery",
         "if (!state.isDragging) return;",
         "scheduleReturnBallDragRecoveryCheck();",
     )
@@ -1232,14 +1198,14 @@ def test_cat1_walk_hover_invalidates_pending_playback_rate_source():
     assert 'art.src = clickSrc' in repeat_hover_block
 
 
-def test_idle_thought_bubble_hides_during_pending_long_press():
+def test_idle_thought_bubble_hides_during_drag_action():
     source = AVATAR_UI_BUTTONS_PATH.read_text(encoding="utf-8")
     app_ui_source = APP_UI_PATH.read_text(encoding="utf-8")
     css_source = INDEX_CSS_PATH.read_text(encoding="utf-8")
 
     assert "_NEKO_IDLE_RETURN_DRAG_PENDING_CLASS = 'is-drag-action-pending'" in source
     assert "function _setNekoIdleReturnDragPendingClasses(button, active)" in source
-    assert "_NEKO_IDLE_RETURN_LONG_PRESS_PENDING_ATTR = 'data-neko-return-long-press-pending'" in source
+    assert "_NEKO_IDLE_RETURN_LONG_PRESS_PENDING_ATTR" not in source
     assert "_setNekoIdleReturnDragPendingClasses(button, true);" in source
     assert "_setNekoIdleReturnDragPendingClasses(button, false);" in source
 
@@ -1293,7 +1259,7 @@ def test_idle_thought_bubble_hides_during_pending_long_press():
         "return button drag cancel handler",
     )
     assert ".neko-idle-return-btn.is-drag-action-pending .neko-idle-thought-bubble" in css_source
-    assert '.neko-idle-return-button-container[data-neko-return-long-press-pending="true"] .neko-idle-thought-bubble' in css_source
+    assert 'data-neko-return-long-press-pending' not in css_source
 
 
 def test_return_button_drag_randomizes_asset_once_per_drag_action():
@@ -1407,7 +1373,6 @@ def test_local_return_button_drag_recovers_lost_release_without_active_timeout()
         mouse_move_block,
         "local return-ball lost mouseup recovery",
         "const point = getDragPoint(e, e.clientX, e.clientY);",
-        "if (updatePendingLongPressDrag(point.x, point.y, e)) return;",
         "if (isDragging && dragPointerType === 'mouse' && e.buttons === 0) {",
         "handleEnd();",
         "handleMove(point.x, point.y, e);",
@@ -2074,7 +2039,7 @@ def test_idle_thought_bubble_is_sound_triggered_with_fade():
         "return !!(bubble && bubble.closest('.neko-idle-return-btn.is-thought-bubble-active'));",
         "state.handleMouseDown = (event) => {",
         "if (isThoughtBubbleEventTarget(event)) return;",
-        "scheduleLongPressDrag(event.screenX, event.screenY, event, 'mouse');",
+        "beginDrag(event.screenX, event.screenY, event);",
     )
     assert "state.handleTouchStart = (event) => {\n            if (isThoughtBubbleEventTarget(event)) return;" in app_ui_source
 
@@ -2439,7 +2404,7 @@ def test_cat1_walk_to_minimized_chat_contract_is_present():
     assert 'restoreArt: !resumeCat1Walking' not in source
     assert "'neko:return-ball-manual-move'" in source
     assert "'neko:return-ball-manual-move'" in app_ui_source
-    assert "'return-ball-drag-pending'" in source
+    assert "'return-ball-drag-pending'" not in source
     assert "detail.reason === 'return-ball-drag-start'" in source
     assert "resetArt: false" in source
     assert "'return-ball-drag-start'" in app_ui_source
@@ -2455,10 +2420,9 @@ def test_cat1_walk_to_minimized_chat_contract_is_present():
 def test_cat1_walk_is_blocked_while_return_ball_drag_is_active_or_pending():
     source = AVATAR_UI_BUTTONS_PATH.read_text(encoding="utf-8")
 
-    assert "_NEKO_IDLE_RETURN_DRAG_LONG_PRESS_MS = 280" in source
-    assert "_NEKO_IDLE_RETURN_LONG_PRESS_PENDING_ATTR = 'data-neko-return-long-press-pending'" in source
+    assert "_NEKO_IDLE_RETURN_DRAG_LONG_PRESS_MS" not in source
+    assert "_NEKO_IDLE_RETURN_LONG_PRESS_PENDING_ATTR" not in source
     assert "returnButtonContainer.getAttribute('data-neko-return-click-suppressed') === 'true'" in source
-    assert "returnButtonContainer.getAttribute(_NEKO_IDLE_RETURN_LONG_PRESS_PENDING_ATTR) === 'true'" in source
     assert "returnButtonContainer.getAttribute('data-dragging') === 'pending'" in source
 
     drag_setup = _source_slice_between(
@@ -2470,7 +2434,7 @@ def test_cat1_walk_is_blocked_while_return_ball_drag_is_active_or_pending():
     handle_start = _source_slice_between(
         source,
         "const handleStart = (clientX, clientY, pointerType = 'mouse', sourceEvent = null, startPoint = null) => {",
-        "const scheduleLongPressDrag = (clientX, clientY, pointerType = 'mouse', sourceEvent = null) => {",
+        "const handleEnd = () => {",
         "return button drag start handler",
     )
     handle_end = _source_slice_between(
@@ -2483,8 +2447,6 @@ def test_cat1_walk_is_blocked_while_return_ball_drag_is_active_or_pending():
     for expected in (
         "let dragSafetyTimer = 0;",
         "let dragSafetyToken = 0;",
-        "let dragLongPressTimer = 0;",
-        "let pendingDragStartVirtualX = 0, pendingDragStartVirtualY = 0;",
         "let dragStartVirtualX = 0, dragStartVirtualY = 0;",
         "let dragCursorPollFrame = 0;",
         "const getDragPoint = (sourceEvent, fallbackX, fallbackY) => {",
@@ -2499,8 +2461,6 @@ def test_cat1_walk_is_blocked_while_return_ball_drag_is_active_or_pending():
         "const stopDragCursorPolling = () => {",
         "const isUsableDragPoint = (point) => {",
         "const clearDragSafetyTimer = () => {",
-        "const clearDragLongPressTimer = () => {",
-        "const clearPendingLongPressDrag = () => {",
         "const resetDragStateAfterMissingEnd = (safetyToken) => {",
         "if (dragSafetyToken !== safetyToken || !isDragging) return;",
         "const finishDragState = (moved, safetyToken) => {",
@@ -2516,52 +2476,32 @@ def test_cat1_walk_is_blocked_while_return_ball_drag_is_active_or_pending():
         "const resetDragStateAfterMissingEnd = (safetyToken) => {",
         "finishDragState(moved, safetyToken);",
     )
-    long_press_setup = _source_slice_between(
-        drag_setup,
-        "const scheduleLongPressDrag = (clientX, clientY, pointerType = 'mouse', sourceEvent = null) => {",
-        "const updatePendingLongPressDrag = (clientX, clientY, sourceEvent = null) => {",
-        "return button long press scheduler",
-    )
-    _assert_source_order(
-        long_press_setup,
-        "return button long press scheduler starts drag after threshold",
-        "setReturnLongPressPending(true);",
-        "_dispatchNekoIdleReturnBallManualMove(container, 'return-ball-drag-pending'",
-        "dragLongPressTimer = setTimeout(() => {",
-        "buildDragPointSnapshot(startX, startY, startVirtualX, startVirtualY)",
-        "handleMove(",
-        "buildDragPointSnapshot(latestX, latestY, latestVirtualX, latestVirtualY)",
-        "}, _NEKO_IDLE_RETURN_DRAG_LONG_PRESS_MS);",
-    )
-    assert "container.setAttribute('data-dragging', 'pending');" not in long_press_setup
+    assert "const scheduleLongPressDrag" not in drag_setup
+    assert "const updatePendingLongPressDrag" not in drag_setup
+    assert "dragLongPress" not in drag_setup
     mouse_down_block = _source_slice_between(
         source,
         "container.addEventListener('mousedown', (e) => {",
         "this._returnButtonDragHandlers = {",
         "local return-ball mousedown handler",
     )
-    mouse_down_contains_block = _source_slice_between(
-        mouse_down_block,
-        "if (container.contains(e.target)) {",
-        "scheduleLongPressDrag(point.x, point.y, 'mouse', e);",
-        "local return-ball mousedown target branch",
+    mouse_down_contains_block = (
+        "if (container.contains(e.target)) {"
+        + mouse_down_block.split("if (container.contains(e.target)) {", 1)[1].split("}", 1)[0]
     )
     _assert_source_order(
         mouse_down_contains_block,
-        "local return-ball mousedown keeps long press decision local",
+        "local return-ball mousedown starts drag immediately",
         "if (container.contains(e.target)) {",
         "e.preventDefault();",
         "e.stopImmediatePropagation();",
+        "const point = getDragPoint(e, e.clientX, e.clientY);",
+        "handleStart(point.x, point.y, 'mouse', e, point);",
     )
     _assert_source_contains(
         mouse_down_block,
-        "e.stopImmediatePropagation();\n                    const point = getDragPoint(e, e.clientX, e.clientY);\n                    scheduleLongPressDrag(point.x, point.y, 'mouse', e);",
+        "e.stopImmediatePropagation();\n                    const point = getDragPoint(e, e.clientX, e.clientY);\n                    handleStart(point.x, point.y, 'mouse', e, point);",
         "local return-ball mousedown handler",
-    )
-    _assert_source_contains(
-        drag_setup,
-        "const updatePendingLongPressDrag = (clientX, clientY, sourceEvent = null) => {",
-        "return button drag setup",
     )
     _assert_source_contains(
         handle_start,
@@ -2581,7 +2521,6 @@ def test_cat1_walk_is_blocked_while_return_ball_drag_is_active_or_pending():
         "return button drag start handler",
         "clearDragSafetyTimer();",
         "stopDragCursorPolling();",
-        "setReturnLongPressPending(false);",
         "container.setAttribute('data-dragging', 'pending')",
         "dragSafetyTimer = setTimeout(() => {",
         "startDragCursorPolling();",
@@ -2610,10 +2549,11 @@ def test_cat1_walk_is_blocked_while_return_ball_drag_is_active_or_pending():
     )
     _assert_source_order(
         mouse_move_block,
-        "local pending long press ignores early zero-buttons recovery",
+        "local return-ball mousemove recovers released mouse before moving",
         "const point = getDragPoint(e, e.clientX, e.clientY);",
-        "if (updatePendingLongPressDrag(point.x, point.y, e)) return;",
         "if (isDragging && dragPointerType === 'mouse' && e.buttons === 0) {",
+        "handleEnd();",
+        "handleMove(point.x, point.y, e);",
     )
 
     sync_block = _source_slice_between(

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -1616,6 +1616,20 @@ def test_cat1_rapid_drag_reaction_is_same_drag_motion_only():
     )
     _assert_source_contains(
         local_drag_setup,
+        "if (!isDragNiriCropCoordinateActive()) {\n                    const localX = Number(fallbackX);",
+        "return button drag setup",
+    )
+    _assert_source_order(
+        local_drag_setup,
+        "plain return-button drag does not read niri crop coordinates",
+        "const getDragPoint = (sourceEvent, fallbackX, fallbackY) => {",
+        "if (!isDragNiriCropCoordinateActive()) {",
+        "offsetX: 0,",
+        "const offset = getDragCropOffset();",
+        "cropApi.getEventCoordinates(sourceEvent)",
+    )
+    _assert_source_contains(
+        local_drag_setup,
         "const isUsableDragPoint = (point) => {",
         "return button drag setup",
     )
@@ -1628,6 +1642,22 @@ def test_cat1_rapid_drag_reaction_is_same_drag_motion_only():
         local_drag_setup,
         "const getDragContainerVirtualRect = () => {",
         "return button drag setup",
+    )
+    drag_container_rect_block = _source_slice_between(
+        local_drag_setup,
+        "const getDragContainerVirtualRect = () => {",
+        "const getDragScreenPointFromVirtualPoint = (virtualX, virtualY, sourceEvent = null, fallbackX = virtualX, fallbackY = virtualY) => {",
+        "return button drag container rect",
+    )
+    _assert_source_order(
+        drag_container_rect_block,
+        "plain return-button drag container rect does not include niri crop offset",
+        "const getDragContainerVirtualRect = () => {",
+        "if (!isDragNiriCropCoordinateActive()) {",
+        "left: Number.isFinite(left) ? left : 0,",
+        "left: Number(rect.left),",
+        "const offset = getDragCropOffset();",
+        "left: Number(rect.left) + offset.x",
     )
     _assert_source_contains(
         local_drag_setup,
@@ -2469,6 +2499,32 @@ def test_cat1_walk_is_blocked_while_return_ball_drag_is_active_or_pending():
         "_dispatchNekoIdleReturnBallManualMove(container, 'return-ball-drag-end'",
     ):
         _assert_source_contains(drag_setup, expected, "return button drag setup")
+    _assert_source_order(
+        drag_setup,
+        "plain return-button drag bypasses niri crop point conversion",
+        "const getDragPoint = (sourceEvent, fallbackX, fallbackY) => {",
+        "if (!isDragNiriCropCoordinateActive()) {",
+        "virtualX: localX,",
+        "offsetX: 0,",
+        "const offset = getDragCropOffset();",
+        "cropApi.getEventCoordinates(sourceEvent)",
+    )
+    drag_container_rect_block = _source_slice_between(
+        drag_setup,
+        "const getDragContainerVirtualRect = () => {",
+        "const getDragScreenPointFromVirtualPoint = (virtualX, virtualY, sourceEvent = null, fallbackX = virtualX, fallbackY = virtualY) => {",
+        "return button drag container rect",
+    )
+    _assert_source_order(
+        drag_container_rect_block,
+        "plain return-button drag bypasses niri crop container offset",
+        "const getDragContainerVirtualRect = () => {",
+        "if (!isDragNiriCropCoordinateActive()) {",
+        "left: Number.isFinite(left) ? left : 0,",
+        "left: Number(rect.left),",
+        "const offset = getDragCropOffset();",
+        "left: Number(rect.left) + offset.x",
+    )
     _assert_source_order(
         drag_setup,
         "return button drag setup helpers",

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -2589,6 +2589,11 @@ def test_cat1_walk_is_blocked_while_return_ball_drag_is_active_or_pending():
         "finishDragState(moved, safetyToken);",
         "return button drag end handler",
     )
+    _assert_source_contains(
+        handle_end,
+        "if (moved) {\n                        setTimeout(() => {\n                            finishDragState(moved, safetyToken);\n                        }, 10);\n                    } else {\n                        finishDragState(moved, safetyToken);\n                    }",
+        "no-move return click clears pending state before browser click",
+    )
     _assert_source_order(
         handle_end,
         "return button drag end handler",
@@ -2610,6 +2615,17 @@ def test_cat1_walk_is_blocked_while_return_ball_drag_is_active_or_pending():
         "if (isDragging && dragPointerType === 'mouse' && e.buttons === 0) {",
         "handleEnd();",
         "handleMove(point.x, point.y, e);",
+    )
+    finish_drag_state_block = _source_slice_between(
+        drag_setup,
+        "const finishDragState = (moved, safetyToken) => {",
+        "const resetDragStateAfterMissingEnd = (safetyToken) => {",
+        "return button drag finish state",
+    )
+    _assert_source_contains(
+        finish_drag_state_block,
+        "if (moved) {\n                    setTimeout(() => setReturnClickSuppressed(false), 120);\n                } else {\n                    setReturnClickSuppressed(false);\n                }",
+        "drag suppresses click briefly while no-move click is restored immediately",
     )
 
     sync_block = _source_slice_between(


### PR DESCRIPTION
## 改动概述 / Summary
链接桌面端：https://github.com/Project-N-E-K-O/N.E.K.O.-PC/pull/296

本次修复将 https://github.com/Project-N-E-K-O/N.E.K.O/pull/2121  Niri/Linux 引入的污染逻辑限制在对应平台或 physical crop active 场景：

- 普通网页猫拖拽恢复直接使用 `clientX/clientY` 与 `getBoundingClientRect()`
- Win/mac 独立毛线球恢复移动超过阈值即开始拖拽
- Linux/Niri 仍保留原有长按与坐标保护逻辑

## 回归报告 / Regression Report

不适用

## 不拆分理由 / Why Not Split

不适用

## 测试 / Testing

- `node --check static/avatar-ui-buttons.js`
- `.venv\Scripts\python.exe -m pytest tests/unit/test_avatar_return_button_idle_tiers_static.py -q`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **优化/新功能**
  * 简化“返回球”触摸与鼠标拖拽启动流程，拖拽结束后的恢复更顺畅一致。
* **Bug 修复**
  * 调整点击抑制与无移动释放等边界场景，减少误触并避免状态残留。
* **界面调整**
  * 更新猫咪思考气泡的隐藏逻辑：不再依赖长按挂起状态，结合拖拽与多活动场景更稳定；未启用 NIRI 裁剪时拖拽定位更准确。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->