### PR TITLE
fix(tutorial): repair day4 guide spotlight placement

### DIFF
--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -16,8 +16,49 @@ function isNekoYuiGuideFloatingToolbarSuppressed() {
     );
 }
 
+const NEKO_YUI_GUIDE_LOCK_SPOTLIGHT_DEFAULT_BOTTOM_PX = 112;
+
+function isNekoYuiGuideLockSpotlightSafeAreaActive() {
+    return !!(
+        typeof window !== 'undefined'
+        && window.nekoYuiGuideLockSpotlightSafeAreaActive === true
+    );
+}
+
+function getNekoYuiGuideLockSpotlightBottomPx() {
+    if (typeof window === 'undefined') {
+        return NEKO_YUI_GUIDE_LOCK_SPOTLIGHT_DEFAULT_BOTTOM_PX;
+    }
+    const configured = Number(window.nekoYuiGuideLockSpotlightSafeAreaBottomPx);
+    return Number.isFinite(configured) && configured >= 0
+        ? configured
+        : NEKO_YUI_GUIDE_LOCK_SPOTLIGHT_DEFAULT_BOTTOM_PX;
+}
+
+function getNekoYuiGuideLockIconMaxTop(defaultMaxTop, iconSize) {
+    const fallbackMaxTop = Number(defaultMaxTop);
+    const normalizedDefault = Number.isFinite(fallbackMaxTop) ? fallbackMaxTop : 0;
+    if (!isNekoYuiGuideLockSpotlightSafeAreaActive() || typeof window === 'undefined') {
+        return normalizedDefault;
+    }
+    const viewportHeight = Number(window.innerHeight);
+    if (!Number.isFinite(viewportHeight) || viewportHeight <= 0) {
+        return normalizedDefault;
+    }
+    const normalizedIconSize = Number.isFinite(Number(iconSize)) && Number(iconSize) > 0
+        ? Number(iconSize)
+        : 40;
+    const safeMaxTop = Math.max(
+        0,
+        viewportHeight - normalizedIconSize - getNekoYuiGuideLockSpotlightBottomPx()
+    );
+    return Math.min(normalizedDefault, safeMaxTop);
+}
+
 if (typeof window !== 'undefined') {
     window.isNekoYuiGuideFloatingToolbarSuppressed = isNekoYuiGuideFloatingToolbarSuppressed;
+    window.isNekoYuiGuideLockSpotlightSafeAreaActive = isNekoYuiGuideLockSpotlightSafeAreaActive;
+    window.getNekoYuiGuideLockIconMaxTop = getNekoYuiGuideLockIconMaxTop;
 }
 
 function _ensureFloatingButtonsAnimationStyles() {
@@ -6934,6 +6975,7 @@ const AvatarButtonMixin = {
                 cancelAnimationFrame(this._uiUpdateLoopId);
                 this._uiUpdateLoopId = null;
             }
+            this._updateFloatingButtonsPositionNow = null;
 
             // 摘除浮动按钮 / 锁图标 ticker —— 下方会删掉它们的 DOM，但 _removeFloatingButtonsElement
             // 只调 el.remove() 不会摘 ticker；与 setupFloatingButtonsBase 同病：不在此处摘除，旧 ticker 会

--- a/static/live2d-ui-buttons.js
+++ b/static/live2d-ui-buttons.js
@@ -216,8 +216,11 @@ Live2DManager.prototype.setupHTMLLockIcon = function(model) {
             const targetX = bounds.right * 0.7 + bounds.left * 0.3;
             const targetY = bounds.top * 0.3 + bounds.bottom * 0.7;
 
+            const maxLockTop = typeof window.getNekoYuiGuideLockIconMaxTop === 'function'
+                ? window.getNekoYuiGuideLockIconMaxTop(screenHeight - 40, 40)
+                : screenHeight - 40;
             lockIcon.style.left = `${Math.max(0, Math.min(targetX, screenWidth - 40))}px`;
-            lockIcon.style.top = `${Math.max(0, Math.min(targetY, screenHeight - 40))}px`;
+            lockIcon.style.top = `${Math.max(0, Math.min(targetY, maxLockTop))}px`;
 
             const lockRect = lockIcon.getBoundingClientRect();
             let isOverlapped = false;

--- a/static/mmd-ui-buttons.js
+++ b/static/mmd-ui-buttons.js
@@ -826,7 +826,8 @@ MMDManager.prototype._startUIUpdateLoop = function() {
                             ? window.getNekoYuiGuideLockIconMaxTop(defaultMaxLockY, actualLockIconSize)
                             : defaultMaxLockY;
                         const boundedLockX = Math.max(0, Math.min(lockTargetX, maxLockX));
-                        const boundedLockY = Math.max(20, Math.min(lockTargetY, maxLockY));
+                        const minLockY = Math.min(20, maxLockY);
+                        const boundedLockY = Math.max(minLockY, Math.min(lockTargetY, maxLockY));
 
                         const rawLockLeft = parseFloat(lockIcon.style.left);
                         if (Number.isNaN(rawLockLeft)) {

--- a/static/mmd-ui-buttons.js
+++ b/static/mmd-ui-buttons.js
@@ -821,7 +821,10 @@ MMDManager.prototype._startUIUpdateLoop = function() {
                         const baseLockIconSize = 32;
                         const actualLockIconSize = baseLockIconSize * scale;
                         const maxLockX = screenWidth - actualLockIconSize;
-                        const maxLockY = screenHeight - actualLockIconSize - 20;
+                        const defaultMaxLockY = screenHeight - actualLockIconSize - 20;
+                        const maxLockY = typeof window.getNekoYuiGuideLockIconMaxTop === 'function'
+                            ? window.getNekoYuiGuideLockIconMaxTop(defaultMaxLockY, actualLockIconSize)
+                            : defaultMaxLockY;
                         const boundedLockX = Math.max(0, Math.min(lockTargetX, maxLockX));
                         const boundedLockY = Math.max(20, Math.min(lockTargetY, maxLockY));
 
@@ -875,6 +878,12 @@ MMDManager.prototype._startUIUpdateLoop = function() {
         }
     };
 
+    this._updateFloatingButtonsPositionNow = () => {
+        if (this._uiUpdateLoopId === null || this._uiUpdateLoopId === undefined) return;
+        cancelAnimationFrame(this._uiUpdateLoopId);
+        this._uiUpdateLoopId = 0;
+        update();
+    };
     this._uiUpdateLoopId = requestAnimationFrame(update);
 };
 

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -1265,8 +1265,12 @@
             const lockVerticalGap = 80;
             const targetX = rect.right * 0.7 + rect.left * 0.3 + lockGap;
             const targetY = rect.top * 0.3 + rect.bottom * 0.7 + lockVerticalGap;
+            const defaultMaxTop = window.innerHeight - 40;
+            const maxTop = typeof window.getNekoYuiGuideLockIconMaxTop === 'function'
+                ? window.getNekoYuiGuideLockIconMaxTop(defaultMaxTop, 40)
+                : defaultMaxTop;
             lockIcon.style.left = `${Math.max(0, Math.min(targetX, window.innerWidth - 40))}px`;
-            lockIcon.style.top = `${Math.max(0, Math.min(targetY, window.innerHeight - 40))}px`;
+            lockIcon.style.top = `${Math.max(0, Math.min(targetY, maxTop))}px`;
             lockIcon.style.display = 'block';
             lockIcon.style.visibility = 'visible';
 

--- a/static/tutorial/core/scene-orchestrator.js
+++ b/static/tutorial/core/scene-orchestrator.js
@@ -282,6 +282,9 @@
             if (typeof director.syncAvatarFloatingToolbarForScene === 'function') {
                 director.syncAvatarFloatingToolbarForScene(scene, scene.id || 'scene');
             }
+            if (typeof director.syncDay4LockSpotlightSafeAreaForScene === 'function') {
+                director.syncDay4LockSpotlightSafeAreaForScene(scene);
+            }
             const isFirstDailyScene = index === 0;
             const preserveExternalizedChatGuideTarget = !!(
                 director.shouldPreserveExternalizedChatCursor(previousSceneId, scene)
@@ -991,6 +994,9 @@
                     director.clearAllExtraSpotlights();
                     director.clearSpotlightGeometryHints();
                     director.clearSpotlightVariantHints();
+                    if (typeof director.setDay4LockSpotlightSafeAreaActive === 'function') {
+                        director.setDay4LockSpotlightSafeAreaActive(false, 'round-complete');
+                    }
                     director.overlay.clearPersistentSpotlight();
                     director.overlay.clearActionSpotlight();
                     director.cursor.hide();

--- a/static/tutorial/yui-guide/days/day4-companion-guide.js
+++ b/static/tutorial/yui-guide/days/day4-companion-guide.js
@@ -162,7 +162,7 @@
                     timeline: [
                         { at: 0, command: 'chat.message' },
                         { at: 0, command: 'emotion.set' },
-                        { at: 0, command: 'spotlight.show', key: 'day4_wrap', target: 'chat-input' },
+                        { at: 0, command: 'spotlight.show', key: 'day4_wrap', target: 'chat-capsule-input' },
                         {
                             at: 220,
                             command: 'cursor.move',
@@ -196,14 +196,13 @@
                     voiceKey: 'avatar_floating_day4_wrap',
                     text: '真正舒服的陪伴才不是一刻不停地粘着你呢~ 而是懂得什么时候该悄悄靠近抓抓你的衣角撒个娇，什么时候该安安静静地趴在一旁，用目光默默守候着你喵~',
                     emotion: 'happy',
-                    target: 'chat-input',
+                    target: 'chat-capsule-input',
                     cursorTarget: 'chat-capsule-input',
                     cursorAction: 'move',
                     cursorMoveDurationMs: 900,
                     freezeCursorAfterMove: true,
                     operation: 'cleanup',
                     preserveExternalizedChatGuideTarget: true,
-                    spotlightVariant: 'plain-capsule',
                     petalTransition: true
                 }
             ]

--- a/static/tutorial/yui-guide/director.js
+++ b/static/tutorial/yui-guide/director.js
@@ -760,6 +760,8 @@
         return Math.max(min, Math.min(max, value));
     }
 
+    const DAY4_LOCK_SPOTLIGHT_SAFE_BOTTOM_PX = 112;
+
     const HOME_TUTORIAL_PLATFORM_PROFILES = Object.freeze({
         windows: Object.freeze({
             supportsExternalChat: true,
@@ -2734,6 +2736,7 @@
             this.avatarFloatingGuideSuppressionActive = false;
             this.avatarFloatingGuideTutorialModeActive = false;
             this.avatarFloatingGuidePreviousIsInTutorial = false;
+            this.day4LockSpotlightSafeAreaActive = false;
             this.avatarStandInShowTimer = null;
             this.avatarStandInHideTimer = null;
             this.avatarStandInPerformanceHandle = null;
@@ -4143,6 +4146,77 @@
             return target && this.isElementVisible(target) ? target : null;
         }
 
+        setDay4LockSpotlightSafeAreaActive(active, reason) {
+            const shouldActivate = active === true;
+            this.day4LockSpotlightSafeAreaActive = shouldActivate;
+            try {
+                window.nekoYuiGuideLockSpotlightSafeAreaActive = shouldActivate;
+                if (shouldActivate) {
+                    window.nekoYuiGuideLockSpotlightSafeAreaBottomPx = DAY4_LOCK_SPOTLIGHT_SAFE_BOTTOM_PX;
+                } else {
+                    delete window.nekoYuiGuideLockSpotlightSafeAreaBottomPx;
+                }
+            } catch (error) {
+                console.warn('[YuiGuide] 同步 Day4 锁按钮安全区状态失败:', reason || 'scene', error);
+            }
+            this.refreshAvatarFloatingLockIconPosition();
+            return shouldActivate;
+        }
+
+        syncDay4LockSpotlightSafeAreaForScene(scene) {
+            const sceneId = scene && typeof scene.id === 'string' ? scene.id : '';
+            return this.setDay4LockSpotlightSafeAreaActive(sceneId === 'day4_model_lock', sceneId || 'scene');
+        }
+
+        refreshAvatarFloatingLockIconPosition() {
+            [
+                window.live2dManager,
+                window.vrmManager,
+                window.mmdManager,
+                window.pngtuberManager
+            ].forEach((manager) => {
+                if (!manager) {
+                    return;
+                }
+                [
+                    '_updateFloatingButtonsPositionNow',
+                    'updateFloatingButtonsPosition',
+                    'updateLockIconPosition',
+                    '_floatingButtonsTicker'
+                ].forEach((methodName) => {
+                    if (typeof manager[methodName] !== 'function') {
+                        return;
+                    }
+                    try {
+                        manager[methodName]();
+                    } catch (_) {}
+                });
+            });
+        }
+
+        adjustDay4LockSpotlightTarget(lockIcon) {
+            if (!lockIcon || this.day4LockSpotlightSafeAreaActive !== true) {
+                return false;
+            }
+            const rect = this.getElementRect(lockIcon);
+            if (!rect || rect.height <= 0 || !Number.isFinite(rect.top)) {
+                return false;
+            }
+            const fallbackMaxTop = Math.max(0, window.innerHeight - rect.height);
+            const maxTop = typeof window.getNekoYuiGuideLockIconMaxTop === 'function'
+                ? window.getNekoYuiGuideLockIconMaxTop(fallbackMaxTop, rect.height)
+                : Math.max(0, window.innerHeight - rect.height - DAY4_LOCK_SPOTLIGHT_SAFE_BOTTOM_PX);
+            if (!Number.isFinite(maxTop) || rect.top <= maxTop) {
+                return false;
+            }
+            const currentTop = Number.parseFloat(lockIcon.style.top);
+            if (!Number.isFinite(currentTop)) {
+                return false;
+            }
+            lockIcon.style.top = Math.max(0, currentTop - (rect.top - maxTop)) + 'px';
+            return true;
+        }
+
         getAvatarFloatingLockIconElement() {
             const prefixes = [];
             const addPrefix = (value) => {
@@ -4165,6 +4239,7 @@
         }
 
         getDay4LockButtonSpotlightTarget() {
+            this.setDay4LockSpotlightSafeAreaActive(true, 'day4_model_lock');
             const lockIcon = this.getAvatarFloatingLockIconElement();
             if (!lockIcon) {
                 return null;
@@ -4172,6 +4247,7 @@
             lockIcon.style.setProperty('display', 'block', 'important');
             lockIcon.style.setProperty('visibility', 'visible', 'important');
             lockIcon.style.setProperty('opacity', '1', 'important');
+            this.adjustDay4LockSpotlightTarget(lockIcon);
             return this.getFloatingButtonShell(lockIcon) || lockIcon;
         }
 
@@ -11384,6 +11460,7 @@
             this.clearGuideChatStreamTimers();
             this.clearGuideChatMessages();
             this.clearQueuedGuideChatBridgeMessages();
+            this.setDay4LockSpotlightSafeAreaActive(false, 'termination-cleanup');
             if (this.overlay && typeof this.overlay.setSpotlightSuppressed === 'function') {
                 this.overlay.setSpotlightSuppressed(true);
             }

--- a/static/tutorial/yui-guide/director.js
+++ b/static/tutorial/yui-guide/director.js
@@ -4148,6 +4148,9 @@
 
         setDay4LockSpotlightSafeAreaActive(active, reason) {
             const shouldActivate = active === true;
+            if (this.day4LockSpotlightSafeAreaActive === shouldActivate) {
+                return shouldActivate;
+            }
             this.day4LockSpotlightSafeAreaActive = shouldActivate;
             try {
                 window.nekoYuiGuideLockSpotlightSafeAreaActive = shouldActivate;

--- a/static/vrm-ui-buttons.js
+++ b/static/vrm-ui-buttons.js
@@ -715,7 +715,8 @@ VRMManager.prototype._startUIUpdateLoop = function() {
                             ? window.getNekoYuiGuideLockIconMaxTop(defaultMaxLockY, actualLockIconSize)
                             : defaultMaxLockY;
                         const boundedLockX = Math.max(0, Math.min(lockTargetX, maxLockX));
-                        const boundedLockY = Math.max(20, Math.min(lockTargetY, maxLockY));
+                        const minLockY = Math.min(20, maxLockY);
+                        const boundedLockY = Math.max(minLockY, Math.min(lockTargetY, maxLockY));
 
                         const rawLockLeft = parseFloat(lockIcon.style.left);
                         if (Number.isNaN(rawLockLeft)) {

--- a/static/vrm-ui-buttons.js
+++ b/static/vrm-ui-buttons.js
@@ -710,7 +710,10 @@ VRMManager.prototype._startUIUpdateLoop = function() {
                         const baseLockIconSize = 32;
                         const actualLockIconSize = baseLockIconSize * scale;
                         const maxLockX = screenWidth - actualLockIconSize;
-                        const maxLockY = screenHeight - actualLockIconSize - 20;
+                        const defaultMaxLockY = screenHeight - actualLockIconSize - 20;
+                        const maxLockY = typeof window.getNekoYuiGuideLockIconMaxTop === 'function'
+                            ? window.getNekoYuiGuideLockIconMaxTop(defaultMaxLockY, actualLockIconSize)
+                            : defaultMaxLockY;
                         const boundedLockX = Math.max(0, Math.min(lockTargetX, maxLockX));
                         const boundedLockY = Math.max(20, Math.min(lockTargetY, maxLockY));
 
@@ -764,6 +767,12 @@ VRMManager.prototype._startUIUpdateLoop = function() {
         }
     };
 
+    this._updateFloatingButtonsPositionNow = () => {
+        if (this._uiUpdateLoopId === null || this._uiUpdateLoopId === undefined) return;
+        cancelAnimationFrame(this._uiUpdateLoopId);
+        this._uiUpdateLoopId = 0;
+        update();
+    };
     this._uiUpdateLoopId = requestAnimationFrame(update);
 };
 

--- a/static/yui-guide-day4-lock-safe-area.test.cjs
+++ b/static/yui-guide-day4-lock-safe-area.test.cjs
@@ -35,4 +35,6 @@ test('day4 model lock spotlight uses a scene-scoped lock icon safe area', () => 
 
     assert.match(readStatic('vrm-ui-buttons.js'), /_updateFloatingButtonsPositionNow/);
     assert.match(readStatic('mmd-ui-buttons.js'), /_updateFloatingButtonsPositionNow/);
+    assert.match(readStatic('vrm-ui-buttons.js'), /const minLockY = Math\.min\(20, maxLockY\);[\s\S]*const boundedLockY = Math\.max\(minLockY, Math\.min\(lockTargetY, maxLockY\)\);/);
+    assert.match(readStatic('mmd-ui-buttons.js'), /const minLockY = Math\.min\(20, maxLockY\);[\s\S]*const boundedLockY = Math\.max\(minLockY, Math\.min\(lockTargetY, maxLockY\)\);/);
 });

--- a/static/yui-guide-day4-lock-safe-area.test.cjs
+++ b/static/yui-guide-day4-lock-safe-area.test.cjs
@@ -14,6 +14,7 @@ test('day4 model lock spotlight uses a scene-scoped lock icon safe area', () => 
 
     assert.match(directorSource, /const DAY4_LOCK_SPOTLIGHT_SAFE_BOTTOM_PX = 112;/);
     assert.match(directorSource, /syncDay4LockSpotlightSafeAreaForScene\(scene\) \{[\s\S]*sceneId === 'day4_model_lock'/);
+    assert.match(directorSource, /if \(this\.day4LockSpotlightSafeAreaActive === shouldActivate\) \{[\s\S]*return shouldActivate;/);
     assert.match(directorSource, /getDay4LockButtonSpotlightTarget\(\) \{[\s\S]*setDay4LockSpotlightSafeAreaActive\(true, 'day4_model_lock'\)[\s\S]*adjustDay4LockSpotlightTarget\(lockIcon\)/);
     assert.match(directorSource, /setDay4LockSpotlightSafeAreaActive\(false, 'termination-cleanup'\)/);
     assert.match(orchestratorSource, /syncDay4LockSpotlightSafeAreaForScene\(scene\)/);

--- a/static/yui-guide-day4-lock-safe-area.test.cjs
+++ b/static/yui-guide-day4-lock-safe-area.test.cjs
@@ -1,0 +1,38 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+function readStatic(relativePath) {
+    return fs.readFileSync(path.join(__dirname, relativePath), 'utf8');
+}
+
+test('day4 model lock spotlight uses a scene-scoped lock icon safe area', () => {
+    const directorSource = readStatic('tutorial/yui-guide/director.js');
+    const orchestratorSource = readStatic('tutorial/core/scene-orchestrator.js');
+    const sharedButtonsSource = readStatic('avatar-ui-buttons.js');
+
+    assert.match(directorSource, /const DAY4_LOCK_SPOTLIGHT_SAFE_BOTTOM_PX = 112;/);
+    assert.match(directorSource, /syncDay4LockSpotlightSafeAreaForScene\(scene\) \{[\s\S]*sceneId === 'day4_model_lock'/);
+    assert.match(directorSource, /getDay4LockButtonSpotlightTarget\(\) \{[\s\S]*setDay4LockSpotlightSafeAreaActive\(true, 'day4_model_lock'\)[\s\S]*adjustDay4LockSpotlightTarget\(lockIcon\)/);
+    assert.match(directorSource, /setDay4LockSpotlightSafeAreaActive\(false, 'termination-cleanup'\)/);
+    assert.match(orchestratorSource, /syncDay4LockSpotlightSafeAreaForScene\(scene\)/);
+    assert.match(orchestratorSource, /setDay4LockSpotlightSafeAreaActive\(false, 'round-complete'\)/);
+    assert.match(sharedButtonsSource, /window\.getNekoYuiGuideLockIconMaxTop = getNekoYuiGuideLockIconMaxTop;/);
+
+    [
+        'live2d-ui-buttons.js',
+        'vrm-ui-buttons.js',
+        'mmd-ui-buttons.js',
+        'pngtuber-core.js'
+    ].forEach((fileName) => {
+        assert.match(
+            readStatic(fileName),
+            /getNekoYuiGuideLockIconMaxTop/,
+            `${fileName} should honor the tutorial lock spotlight safe area`
+        );
+    });
+
+    assert.match(readStatic('vrm-ui-buttons.js'), /_updateFloatingButtonsPositionNow/);
+    assert.match(readStatic('mmd-ui-buttons.js'), /_updateFloatingButtonsPositionNow/);
+});

--- a/static/yui-guide-day4-wrap-spotlight.test.cjs
+++ b/static/yui-guide-day4-wrap-spotlight.test.cjs
@@ -1,0 +1,19 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+function readStatic(relativePath) {
+    return fs.readFileSync(path.join(__dirname, relativePath), 'utf8');
+}
+
+test('day4 wrap spotlight and cursor target the same chat capsule', () => {
+    const day4Source = readStatic('tutorial/yui-guide/days/day4-companion-guide.js');
+    const wrapScene = day4Source.match(/id:\s*'day4_wrap'[\s\S]*?petalTransition:\s*true/);
+
+    assert.ok(wrapScene, 'day4_wrap scene should exist');
+    assert.match(wrapScene[0], /command:\s*'spotlight\.show'[\s\S]*target:\s*'chat-capsule-input'/);
+    assert.match(wrapScene[0], /target:\s*'chat-capsule-input'/);
+    assert.match(wrapScene[0], /cursorTarget:\s*'chat-capsule-input'/);
+    assert.doesNotMatch(wrapScene[0], /spotlightVariant:\s*'plain-capsule'/);
+});


### PR DESCRIPTION
## Summary
- align the Day 4 wrap spotlight with the chat capsule target and restore the decorated spotlight style
- add a Day 4-only lock spotlight safe area so the lock icon remains visible across Live2D, VRM, MMD, and PNGTuber flows
- add regression coverage for the wrap spotlight target and lock safe-area wiring

## Tests
- node --test static/yui-guide-day4-wrap-spotlight.test.cjs static/yui-guide-day4-lock-safe-area.test.cjs static/tutorial-visual-runtime.test.cjs static/yui-guide-scene-orchestrator.test.cjs
- node --check static/tutorial/yui-guide/director.js && node --check static/tutorial/core/scene-orchestrator.js && node --check static/avatar-ui-buttons.js && node --check static/live2d-ui-buttons.js && node --check static/vrm-ui-buttons.js && node --check static/mmd-ui-buttons.js && node --check static/pngtuber-core.js && node --check static/tutorial/yui-guide/days/day4-companion-guide.js
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * Day4「锁按钮」引导新增安全区适配：场景切换时自动同步启用/停用，并根据屏幕边界动态限制锁图标可放置的顶部位置。
* **Bug 修复**
  * 锁图标最大垂直边界改为可配置的动态计算，降低在不同界面出现越界/遮挡的情况。
  * Day4 引导高亮目标切换为“聊天胶囊输入框”，并补全浮动按钮销毁与刷新位置的清理/强制更新逻辑。
* **Tests**
  * 新增 Day4 锁按钮安全区与 spotlight 配置相关的自动化校验用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->