### PR TITLE
修复MAC版本的快速切换人猫变换导致人物消失

### DIFF
--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -5289,7 +5289,20 @@
 
             // 触发原有的离开逻辑
             if (resetSessionButton) {
-                setTimeout(() => {
+                if (window._goodbyeResetClickTimerId) {
+                    clearTimeout(window._goodbyeResetClickTimerId);
+                }
+                window._goodbyeResetClickTimerId = setTimeout(() => {
+                    window._goodbyeResetClickTimerId = null;
+                    const goodbyeStillActive = !!(
+                        (window.live2dManager && window.live2dManager._goodbyeClicked) ||
+                        (window.vrmManager && window.vrmManager._goodbyeClicked) ||
+                        (window.mmdManager && window.mmdManager._goodbyeClicked)
+                    );
+                    if (!goodbyeStillActive) {
+                        console.log('[App] 跳过过期的 resetSessionButton.click()：当前已不在 goodbye 状态');
+                        return;
+                    }
                     console.log('[App] 触发 resetSessionButton.click()，当前 goodbyeClicked 状态:', window.live2dManager ? window.live2dManager._goodbyeClicked : 'undefined');
                     // 语音启动会把侧栏离开按钮置为 disabled；程序化 click 需要先恢复，
                     // 后续最终按钮状态仍交给 reset handler 统一收口。
@@ -5327,6 +5340,10 @@
                 console.warn('[App] 请她回来已暂缓：Pet viewport 仍处于猫形态小窗口，保留 return 状态');
                 restoreReturnBallAfterBlockedModelViewport(event);
                 return;
+            }
+            if (window._goodbyeResetClickTimerId) {
+                clearTimeout(window._goodbyeResetClickTimerId);
+                window._goodbyeResetClickTimerId = null;
             }
             const isReturningToPngtuber = (window.lanlan_config?.model_type || '').toLowerCase() === 'pngtuber';
             if (multiWindowReturnBallDragState) {

--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -5344,6 +5344,11 @@
                 clearTimeout(window._goodbyeResetClickTimerId);
                 window._goodbyeResetClickTimerId = null;
             }
+            if (window._goodbyeHideTimerId) {
+                clearTimeout(window._goodbyeHideTimerId);
+                window._goodbyeHideTimerId = null;
+                console.log('[App] handleReturnClick: 已取消 goodbye 延迟隐藏定时器');
+            }
             const preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel();
             if (!preReturnViewportReady.ready) {
                 console.warn('[App] 请她回来已暂缓：Pet viewport 仍处于猫形态小窗口，保留 return 状态');
@@ -5357,13 +5362,6 @@
             if (multiWindowReturnBallDragState) {
                 multiWindowReturnBallDragState.dragSessionToken += 1;
                 clearMultiWindowReturnBallDeferredWork(multiWindowReturnBallDragState);
-            }
-
-            // 取消延迟隐藏定时器
-            if (window._goodbyeHideTimerId) {
-                clearTimeout(window._goodbyeHideTimerId);
-                window._goodbyeHideTimerId = null;
-                console.log('[App] handleReturnClick: 已取消 goodbye 延迟隐藏定时器');
             }
             // 同步 window 中的设置值到状态
             if (typeof window.focusModeEnabled !== 'undefined') {

--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -5288,26 +5288,30 @@
             }
 
             // 触发原有的离开逻辑
+            const runGoodbyeResetClickIfActive = (reason) => {
+                const goodbyeStillActive = !!(
+                    (window.live2dManager && window.live2dManager._goodbyeClicked) ||
+                    (window.vrmManager && window.vrmManager._goodbyeClicked) ||
+                    (window.mmdManager && window.mmdManager._goodbyeClicked)
+                );
+                if (!goodbyeStillActive) {
+                    console.log('[App] 跳过过期的 resetSessionButton.click()：当前已不在 goodbye 状态', reason || '');
+                    return false;
+                }
+                console.log('[App] 触发 resetSessionButton.click()，当前 goodbyeClicked 状态:', window.live2dManager ? window.live2dManager._goodbyeClicked : 'undefined', 'reason:', reason || 'delayed-goodbye-reset');
+                // 语音启动会把侧栏离开按钮置为 disabled；程序化 click 需要先恢复，
+                // 后续最终按钮状态仍交给 reset handler 统一收口。
+                resetSessionButton.disabled = false;
+                resetSessionButton.click();
+                return true;
+            };
             if (resetSessionButton) {
                 if (window._goodbyeResetClickTimerId) {
                     clearTimeout(window._goodbyeResetClickTimerId);
                 }
                 window._goodbyeResetClickTimerId = setTimeout(() => {
                     window._goodbyeResetClickTimerId = null;
-                    const goodbyeStillActive = !!(
-                        (window.live2dManager && window.live2dManager._goodbyeClicked) ||
-                        (window.vrmManager && window.vrmManager._goodbyeClicked) ||
-                        (window.mmdManager && window.mmdManager._goodbyeClicked)
-                    );
-                    if (!goodbyeStillActive) {
-                        console.log('[App] 跳过过期的 resetSessionButton.click()：当前已不在 goodbye 状态');
-                        return;
-                    }
-                    console.log('[App] 触发 resetSessionButton.click()，当前 goodbyeClicked 状态:', window.live2dManager ? window.live2dManager._goodbyeClicked : 'undefined');
-                    // 语音启动会把侧栏离开按钮置为 disabled；程序化 click 需要先恢复，
-                    // 后续最终按钮状态仍交给 reset handler 统一收口。
-                    resetSessionButton.disabled = false;
-                    resetSessionButton.click();
+                    runGoodbyeResetClickIfActive('delayed-goodbye-reset');
                 }, 10);
             } else {
                 console.error('[App] resetSessionButton 未找到！');
@@ -5335,15 +5339,19 @@
                 console.log('[App] 模型正在切换为猫形态，忽略本次请她回来事件');
                 return;
             }
+            const hadPendingGoodbyeReset = !!window._goodbyeResetClickTimerId;
+            if (hadPendingGoodbyeReset) {
+                clearTimeout(window._goodbyeResetClickTimerId);
+                window._goodbyeResetClickTimerId = null;
+            }
             const preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel();
             if (!preReturnViewportReady.ready) {
                 console.warn('[App] 请她回来已暂缓：Pet viewport 仍处于猫形态小窗口，保留 return 状态');
                 restoreReturnBallAfterBlockedModelViewport(event);
+                if (hadPendingGoodbyeReset) {
+                    runGoodbyeResetClickIfActive('return-viewport-blocked');
+                }
                 return;
-            }
-            if (window._goodbyeResetClickTimerId) {
-                clearTimeout(window._goodbyeResetClickTimerId);
-                window._goodbyeResetClickTimerId = null;
             }
             const isReturningToPngtuber = (window.lanlan_config?.model_type || '').toLowerCase() === 'pngtuber';
             if (multiWindowReturnBallDragState) {

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -340,6 +340,9 @@ def test_model_cat_transition_contract_is_present():
         "if (hadPendingGoodbyeReset) {",
         "clearTimeout(window._goodbyeResetClickTimerId);",
         "window._goodbyeResetClickTimerId = null;",
+        "if (window._goodbyeHideTimerId) {",
+        "clearTimeout(window._goodbyeHideTimerId);",
+        "window._goodbyeHideTimerId = null;",
         "const preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel();",
     )
     return_handler_after_viewport_guard_block = return_handler_full_block[

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -331,19 +331,28 @@ def test_model_cat_transition_contract_is_present():
     assert "window._goodbyeResetClickTimerId = setTimeout(() => {" in source
     assert "const goodbyeStillActive = !!(" in source
     assert "跳过过期的 resetSessionButton.click()" in source
+    assert "const hadPendingGoodbyeReset = !!window._goodbyeResetClickTimerId;" in source
+    assert "runGoodbyeResetClickIfActive('return-viewport-blocked')" in source
+    _assert_source_order(
+        return_handler_full_block,
+        "return handler neutralizes stale goodbye reset before viewport await",
+        "const hadPendingGoodbyeReset = !!window._goodbyeResetClickTimerId;",
+        "if (hadPendingGoodbyeReset) {",
+        "clearTimeout(window._goodbyeResetClickTimerId);",
+        "window._goodbyeResetClickTimerId = null;",
+        "const preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel();",
+    )
     return_handler_after_viewport_guard_block = return_handler_full_block[
         pre_return_guard_start:
     ]
     _assert_source_order(
         return_handler_after_viewport_guard_block,
-        "return handler cancels stale goodbye reset after viewport is ready",
-        "const preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel();",
+        "return handler runs goodbye reset cleanup when viewport remains blocked",
         "if (!preReturnViewportReady.ready) {",
         "restoreReturnBallAfterBlockedModelViewport(event);",
+        "if (hadPendingGoodbyeReset) {",
+        "runGoodbyeResetClickIfActive('return-viewport-blocked');",
         "return;",
-        "if (window._goodbyeResetClickTimerId) {",
-        "clearTimeout(window._goodbyeResetClickTimerId);",
-        "window._goodbyeResetClickTimerId = null;",
     )
     assert return_handler_full_block.index("const preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel();") < return_handler_full_block.index("window.live2dManager._goodbyeClicked = false;")
     restore_block = source[

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -328,6 +328,23 @@ def test_model_cat_transition_contract_is_present():
         "restoreReturnBallAfterBlockedModelViewport(event);",
         "return;",
     )
+    assert "window._goodbyeResetClickTimerId = setTimeout(() => {" in source
+    assert "const goodbyeStillActive = !!(" in source
+    assert "跳过过期的 resetSessionButton.click()" in source
+    return_handler_after_viewport_guard_block = return_handler_full_block[
+        pre_return_guard_start:
+    ]
+    _assert_source_order(
+        return_handler_after_viewport_guard_block,
+        "return handler cancels stale goodbye reset after viewport is ready",
+        "const preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel();",
+        "if (!preReturnViewportReady.ready) {",
+        "restoreReturnBallAfterBlockedModelViewport(event);",
+        "return;",
+        "if (window._goodbyeResetClickTimerId) {",
+        "clearTimeout(window._goodbyeResetClickTimerId);",
+        "window._goodbyeResetClickTimerId = null;",
+    )
     assert return_handler_full_block.index("const preReturnViewportReady = await ensureModelViewportReadyBeforeShowCurrentModel();") < return_handler_full_block.index("window.live2dManager._goodbyeClicked = false;")
     restore_block = source[
         source.index("function restoreReturnBallAfterBlockedModelViewport(event)"):


### PR DESCRIPTION
## 概要

修复“请她离开 / 请她回来”快速切换时，旧的延迟 goodbye reset 可能晚到执行，导致人物低概率消失的问题。

## 改动内容

- 为 goodbye 流程里延迟触发的 `resetSessionButton.click()` 保存 timer id。
- 在“请她回来”流程开始时取消尚未执行的 goodbye reset timer。
- 在 delayed reset 真正执行前再次确认当前仍处于 goodbye 状态；如果已经回来，则跳过这次过期 reset。
- 增加静态回归测试，约束回来流程必须先取消过期 goodbye reset，再继续恢复人物。

## 原因

原逻辑在“请她离开”时会通过 `setTimeout(..., 10)` 延迟触发一次 `resetSessionButton.click()`。

当用户快速点击“请她离开”再“请她回来”时，这个旧的 reset 任务可能在回来流程开始后才执行，从而重新触发离开/隐藏逻辑，造成角色低概率消失或状态异常。

## 测试

- `node --check static/app-ui.js`
- `python3 -m py_compile tests/unit/test_avatar_return_button_idle_tiers_static.py`
- 静态顺序断言：`stale goodbye reset guard assertion passed`
- `.venv/bin/pytest tests/unit/test_avatar_return_button_idle_tiers_static.py::test_model_cat_transition_contract_is_present -q`

结果：`1 passed`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化“请她离开”延迟重置：改为可追踪的定时器，并在执行前确认仍处于 goodbye 状态；若已退出则跳过点击并记录日志。
  * “请她回来”恢复前先清理并置空待执行的重置定时任务；若视窗恢复被阻塞，会根据当前状态决定是否继续执行重置。
* **Tests**
  * 加强 return 处理顺序与分支覆盖：验证过期重置清理/置空，以及视窗阻塞情况下的条件触发逻辑。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->