### PR TITLE
保留 Live2D 保存外观基准

### DIFF
--- a/static/live2d-core.js
+++ b/static/live2d-core.js
@@ -118,6 +118,7 @@ class Live2DManager {
         this.modelRootPath = null; // 记录当前模型根路径，如 /static/<modelName>
         this.savedModelParameters = null; // 保存的模型参数（从parameters.json加载），供定时器定期应用
         this._shouldApplySavedParams = false; // 是否应该应用保存的参数
+        this.appearanceBaselineParameters = {}; // 用户保存后的外观基准，用于表情/motion 重置
         this._savedParamsTimer = null; // 保存参数应用的定时器
         this._mouseTrackingEnabled = window.mouseTrackingEnabled !== false; // 鼠标跟踪启用状态
         this._fullscreenTrackingEnabled = window.live2dFullscreenTrackingEnabled === true; // 全屏跟踪启用状态

--- a/static/live2d-emotion.js
+++ b/static/live2d-emotion.js
@@ -135,7 +135,24 @@ Live2DManager.prototype.recordInitialParameters = function() {
         
         // 结束可折叠日志组
         if (_verbose) console.groupEnd();
-        this.appearanceBaselineParameters = { ...this.initialParameters };
+        this.appearanceBaselineParameters = {};
+        if (typeof this._resolveModelParameterKey === 'function' && typeof this._isRuntimeManagedAppearanceParam === 'function') {
+            for (const [paramId, value] of Object.entries(this.initialParameters)) {
+                if (typeof value !== 'number' || !Number.isFinite(value)) continue;
+
+                const resolved = this._resolveModelParameterKey(coreModel, paramId);
+                if (!resolved) continue;
+
+                const resolvedParamId = resolved.resolvedId;
+                if (this._isRuntimeManagedAppearanceParam(paramId, resolvedParamId, coreModel)) {
+                    continue;
+                }
+
+                this.appearanceBaselineParameters[paramId] = value;
+                this.appearanceBaselineParameters[resolvedParamId] = value;
+                this.appearanceBaselineParameters[`param_${resolved.idx}`] = value;
+            }
+        }
         
         console.log(`[Live2D] 已记录${Object.keys(this.initialParameters).length}个初始参数 (跳过${paramCount - Object.keys(this.initialParameters).length}个位置/嘴巴参数)，${Object.keys(this.motionBaselineParameters).length}个motion基线`);
     } catch (error) {

--- a/static/live2d-emotion.js
+++ b/static/live2d-emotion.js
@@ -24,6 +24,7 @@ Live2DManager.prototype.recordInitialParameters = function() {
         const coreModel = this.currentModel.internalModel.coreModel;
         this.initialParameters = {};
         this.motionBaselineParameters = {};
+        this.appearanceBaselineParameters = {};
         this._activeExpressionParamIds = null;
         this._activeMotionParamIds = null;
         this._motionParameterTrackGeneration = (this._motionParameterTrackGeneration || 0) + 1;
@@ -134,12 +135,14 @@ Live2DManager.prototype.recordInitialParameters = function() {
         
         // 结束可折叠日志组
         if (_verbose) console.groupEnd();
+        this.appearanceBaselineParameters = { ...this.initialParameters };
         
         console.log(`[Live2D] 已记录${Object.keys(this.initialParameters).length}个初始参数 (跳过${paramCount - Object.keys(this.initialParameters).length}个位置/嘴巴参数)，${Object.keys(this.motionBaselineParameters).length}个motion基线`);
     } catch (error) {
         console.warn('记录初始参数失败:', error);
         this.initialParameters = {};
         this.motionBaselineParameters = {};
+        this.appearanceBaselineParameters = {};
         this._activeExpressionParamIds = null;
         this._activeMotionParamIds = null;
         this._motionParameterTrackGeneration = (this._motionParameterTrackGeneration || 0) + 1;
@@ -271,6 +274,11 @@ Live2DManager.prototype._resetParametersToInitialState = function(options = {}) 
 
     for (const [paramId, initialValue] of Object.entries(this.initialParameters)) {
         try {
+            const baseline = this._findRecordedParameterBaseline(paramId, coreModel, {
+                includeSavedParameters: true
+            });
+            const resetValue = baseline.found ? baseline.value : initialValue;
+
             if (paramId.startsWith('param_')) {
                 const paramIndex = parseInt(paramId.substring(6), 10);
                 if (!isNaN(paramIndex)) {
@@ -284,12 +292,12 @@ Live2DManager.prototype._resetParametersToInitialState = function(options = {}) 
                         resolvedParamId = null;
                     }
                     if (resolvedParamId && protectedIds.has(resolvedParamId)) continue;
-                    coreModel.setParameterValueByIndex(paramIndex, initialValue);
+                    coreModel.setParameterValueByIndex(paramIndex, resetValue);
                     resetCount++;
                 }
             } else {
                 if (protectedIds.has(paramId)) continue;
-                coreModel.setParameterValueById(paramId, initialValue);
+                coreModel.setParameterValueById(paramId, resetValue);
                 resetCount++;
             }
         } catch (e) {
@@ -362,7 +370,7 @@ Live2DManager.prototype._trackActiveMotionParametersFromFile = async function(mo
 Live2DManager.prototype._findRecordedParameterBaseline = function(paramId, coreModel, options = {}) {
     const includeSavedParameters = options.includeSavedParameters === true;
     const baselineSources = includeSavedParameters
-        ? [this.savedModelParameters, this.motionBaselineParameters, this.initialParameters]
+        ? [this.appearanceBaselineParameters, this.savedModelParameters, this.motionBaselineParameters, this.initialParameters]
         : [this.motionBaselineParameters, this.initialParameters];
 
     for (const source of baselineSources) {

--- a/static/live2d-emotion.js
+++ b/static/live2d-emotion.js
@@ -387,7 +387,7 @@ Live2DManager.prototype._trackActiveMotionParametersFromFile = async function(mo
 Live2DManager.prototype._findRecordedParameterBaseline = function(paramId, coreModel, options = {}) {
     const includeSavedParameters = options.includeSavedParameters === true;
     const baselineSources = includeSavedParameters
-        ? [this.appearanceBaselineParameters, this.savedModelParameters, this.motionBaselineParameters, this.initialParameters]
+        ? [this.appearanceBaselineParameters, this.motionBaselineParameters, this.initialParameters]
         : [this.motionBaselineParameters, this.initialParameters];
 
     for (const source of baselineSources) {

--- a/static/live2d-model.js
+++ b/static/live2d-model.js
@@ -209,10 +209,12 @@ Live2DManager.prototype._resolveModelParameterKey = function(coreModel, paramId)
     if (!coreModel || paramId === undefined || paramId === null) return null;
 
     const key = String(paramId);
+    const isIndexKey = /^(?:param_)?\d+$/.test(key);
     let idx = -1;
     let resolvedId = key;
+    let hasResolvedId = !isIndexKey;
 
-    if (/^(?:param_)?\d+$/.test(key)) {
+    if (isIndexKey) {
         const parsedIndex = parseInt(key.replace(/^param_/, ''), 10);
         const parameterCount = typeof coreModel.getParameterCount === 'function'
             ? coreModel.getParameterCount()
@@ -222,7 +224,10 @@ Live2DManager.prototype._resolveModelParameterKey = function(coreModel, paramId)
             try {
                 if (typeof coreModel.getParameterId === 'function') {
                     const id = coreModel.getParameterId(idx);
-                    if (id) resolvedId = id;
+                    if (id) {
+                        resolvedId = id;
+                        hasResolvedId = true;
+                    }
                 }
             } catch (_) {}
         }
@@ -232,14 +237,23 @@ Live2DManager.prototype._resolveModelParameterKey = function(coreModel, paramId)
         } catch (_) {}
     }
 
-    return idx >= 0 ? { idx, resolvedId } : null;
+    if (idx >= 0 && isIndexKey && !hasResolvedId) {
+        resolvedId = `param_${idx}`;
+    }
+
+    return idx >= 0 ? { idx, resolvedId, hasResolvedId, isIndexKey } : null;
 };
 
 Live2DManager.prototype._isRuntimeManagedAppearanceParam = function(paramId, resolvedParamId, coreModel) {
-    const ids = [paramId, resolvedParamId].filter(Boolean);
+    const ids = [paramId, resolvedParamId].filter(Boolean).map(id => String(id));
     if (ids.length === 0) return true;
 
-    const lipSyncParams = Array.isArray(window.LIPSYNC_PARAMS)
+    const hasNamedParamId = ids.some(id => !/^(?:param_)?\d+$/.test(id));
+    if (!hasNamedParamId) {
+        return true;
+    }
+
+    const lipSyncParams = typeof window !== 'undefined' && Array.isArray(window.LIPSYNC_PARAMS)
         ? window.LIPSYNC_PARAMS
         : ['ParamMouthOpenY', 'ParamMouthForm', 'ParamMouthOpen', 'ParamA', 'ParamI', 'ParamU', 'ParamE', 'ParamO'];
     const runtimeParamIds = new Set([
@@ -280,27 +294,33 @@ Live2DManager.prototype.mergeAppearanceBaselineParameters = function(model, para
     }
 
     const coreModel = model.internalModel.coreModel;
-    if (!this.appearanceBaselineParameters || Object.keys(this.appearanceBaselineParameters).length === 0) {
-        this.appearanceBaselineParameters = { ...this.initialParameters };
-    }
-
-    for (const paramId in parameters) {
-        if (!Object.prototype.hasOwnProperty.call(parameters, paramId)) continue;
-
-        const value = parameters[paramId];
-        if (typeof value !== 'number' || !Number.isFinite(value)) continue;
+    const mergeAppearanceParam = (paramId, value) => {
+        if (typeof value !== 'number' || !Number.isFinite(value)) return;
 
         const resolved = this._resolveModelParameterKey(coreModel, paramId);
-        if (!resolved) continue;
+        if (!resolved) return;
 
         const resolvedParamId = resolved.resolvedId;
         if (this._isRuntimeManagedAppearanceParam(paramId, resolvedParamId, coreModel)) {
-            continue;
+            return;
         }
 
         this.appearanceBaselineParameters[paramId] = value;
         this.appearanceBaselineParameters[resolvedParamId] = value;
         this.appearanceBaselineParameters[`param_${resolved.idx}`] = value;
+    };
+
+    if (!this.appearanceBaselineParameters || Object.keys(this.appearanceBaselineParameters).length === 0) {
+        this.appearanceBaselineParameters = {};
+        for (const paramId in this.initialParameters) {
+            if (!Object.prototype.hasOwnProperty.call(this.initialParameters, paramId)) continue;
+            mergeAppearanceParam(paramId, this.initialParameters[paramId]);
+        }
+    }
+
+    for (const paramId in parameters) {
+        if (!Object.prototype.hasOwnProperty.call(parameters, paramId)) continue;
+        mergeAppearanceParam(paramId, parameters[paramId]);
     }
 };
 

--- a/static/live2d-model.js
+++ b/static/live2d-model.js
@@ -86,6 +86,7 @@ Live2DManager.prototype.removeModel = async function(options = {}) {
     }
     this.initialParameters = {};
     this.motionBaselineParameters = {};
+    this.appearanceBaselineParameters = {};
     this._activeExpressionParamIds = null;
     this._activeMotionParamIds = null;
     this._motionParameterTrackGeneration = (this._motionParameterTrackGeneration || 0) + 1;
@@ -201,6 +202,105 @@ Live2DManager.prototype.removeModel = async function(options = {}) {
     this._isModelReadyForInteraction = false;
     if (!this._isLoadingModel) {
         this._modelLoadState = 'idle';
+    }
+};
+
+Live2DManager.prototype._resolveModelParameterKey = function(coreModel, paramId) {
+    if (!coreModel || paramId === undefined || paramId === null) return null;
+
+    const key = String(paramId);
+    let idx = -1;
+    let resolvedId = key;
+
+    if (/^(?:param_)?\d+$/.test(key)) {
+        const parsedIndex = parseInt(key.replace(/^param_/, ''), 10);
+        const parameterCount = typeof coreModel.getParameterCount === 'function'
+            ? coreModel.getParameterCount()
+            : Number.POSITIVE_INFINITY;
+        if (parsedIndex >= 0 && parsedIndex < parameterCount) {
+            idx = parsedIndex;
+            try {
+                if (typeof coreModel.getParameterId === 'function') {
+                    const id = coreModel.getParameterId(idx);
+                    if (id) resolvedId = id;
+                }
+            } catch (_) {}
+        }
+    } else {
+        try {
+            idx = coreModel.getParameterIndex(key);
+        } catch (_) {}
+    }
+
+    return idx >= 0 ? { idx, resolvedId } : null;
+};
+
+Live2DManager.prototype._isRuntimeManagedAppearanceParam = function(paramId, resolvedParamId, coreModel) {
+    const ids = [paramId, resolvedParamId].filter(Boolean);
+    if (ids.length === 0) return true;
+
+    const lipSyncParams = Array.isArray(window.LIPSYNC_PARAMS)
+        ? window.LIPSYNC_PARAMS
+        : ['ParamMouthOpenY', 'ParamMouthForm', 'ParamMouthOpen', 'ParamA', 'ParamI', 'ParamU', 'ParamE', 'ParamO'];
+    const runtimeParamIds = new Set([
+        ...lipSyncParams,
+        'ParamAngleX', 'ParamAngleY', 'ParamAngleZ',
+        'ParamBodyAngleX', 'ParamBodyAngleY', 'ParamBodyAngleZ',
+        'ParamEyeBallX', 'ParamEyeBallY',
+        'ParamLookAtX', 'ParamLookAtY',
+        'ParamBreath', 'ParamBreath2', 'ParamBreath3',
+        'ParamShake',
+        'ParamOpacity', 'ParamVisibility'
+    ]);
+
+    try {
+        const breathParams = typeof this._resolveRuntimeBreathParams === 'function'
+            ? this._resolveRuntimeBreathParams(coreModel)
+            : [];
+        breathParams.forEach(id => runtimeParamIds.add(id));
+    } catch (_) {}
+
+    try {
+        if (typeof this.getPersistentExpressionParamIds === 'function') {
+            const persistentParamIds = this.getPersistentExpressionParamIds();
+            if (ids.some(id => persistentParamIds.has(id))) return true;
+        }
+    } catch (_) {}
+
+    return ids.some(id => runtimeParamIds.has(id) || this._isEyeBlinkParamId(id));
+};
+
+Live2DManager.prototype.mergeAppearanceBaselineParameters = function(model, parameters) {
+    if (!model || !model.internalModel || !model.internalModel.coreModel || !parameters) {
+        return;
+    }
+
+    if (!this.initialParameters || Object.keys(this.initialParameters).length === 0) {
+        return;
+    }
+
+    const coreModel = model.internalModel.coreModel;
+    if (!this.appearanceBaselineParameters || Object.keys(this.appearanceBaselineParameters).length === 0) {
+        this.appearanceBaselineParameters = { ...this.initialParameters };
+    }
+
+    for (const paramId in parameters) {
+        if (!Object.prototype.hasOwnProperty.call(parameters, paramId)) continue;
+
+        const value = parameters[paramId];
+        if (typeof value !== 'number' || !Number.isFinite(value)) continue;
+
+        const resolved = this._resolveModelParameterKey(coreModel, paramId);
+        if (!resolved) continue;
+
+        const resolvedParamId = resolved.resolvedId;
+        if (this._isRuntimeManagedAppearanceParam(paramId, resolvedParamId, coreModel)) {
+            continue;
+        }
+
+        this.appearanceBaselineParameters[paramId] = value;
+        this.appearanceBaselineParameters[resolvedParamId] = value;
+        this.appearanceBaselineParameters[`param_${resolved.idx}`] = value;
     }
 };
 
@@ -2611,32 +2711,6 @@ Live2DManager.prototype.applyModelParameters = function(model, parameters) {
     const coreModel = model.internalModel.coreModel;
     const persistentParamIds = this.getPersistentExpressionParamIds();
     const visibilityParams = ['ParamOpacity', 'ParamVisibility']; // 跳过可见性参数，防止模型被设置为不可见
-    const resolveParameterKey = (paramId) => {
-        let idx = -1;
-        let resolvedId = paramId;
-        if (/^(?:param_)?\d+$/.test(paramId)) {
-            const parsedIndex = parseInt(paramId.replace(/^param_/, ''), 10);
-            const parameterCount = typeof coreModel.getParameterCount === 'function'
-                ? coreModel.getParameterCount()
-                : Number.POSITIVE_INFINITY;
-            if (parsedIndex >= 0 && parsedIndex < parameterCount) {
-                idx = parsedIndex;
-                try {
-                    if (typeof coreModel.getParameterId === 'function') {
-                        const id = coreModel.getParameterId(idx);
-                        if (id) resolvedId = id;
-                    }
-                } catch (_) {}
-            }
-        } else {
-            try {
-                idx = coreModel.getParameterIndex(paramId);
-            } catch (e) {
-                // Ignore
-            }
-        }
-        return idx >= 0 ? { idx, resolvedId } : null;
-    };
 
     for (const paramId in parameters) {
         if (parameters.hasOwnProperty(paramId)) {
@@ -2646,7 +2720,7 @@ Live2DManager.prototype.applyModelParameters = function(model, parameters) {
                     continue;
                 }
 
-                const resolved = resolveParameterKey(paramId);
+                const resolved = this._resolveModelParameterKey(coreModel, paramId);
                 if (!resolved) {
                     continue;
                 }
@@ -2674,6 +2748,7 @@ Live2DManager.prototype.applyModelParameters = function(model, parameters) {
         }
     }
     
+    this.mergeAppearanceBaselineParameters(model, parameters);
     // 参数已应用
 };
 

--- a/tests/unit/test_live2d_appearance_baseline_static.py
+++ b/tests/unit/test_live2d_appearance_baseline_static.py
@@ -218,7 +218,7 @@ def test_live2d_reset_ignores_unfiltered_saved_runtime_baseline():
           ParamBodyAngleX: 0,
         }};
         manager.motionBaselineParameters = {{
-          ParamBodyAngleX: 0,
+          ParamBodyAngleX: 5,
           param_1: 0,
         }};
         manager.appearanceBaselineParameters = {{
@@ -233,7 +233,7 @@ def test_live2d_reset_ignores_unfiltered_saved_runtime_baseline():
         manager._resetParametersToInitialState({{ preserveExpression: false }});
 
         assert.strictEqual(values[0], 1);
-        assert.strictEqual(values[1], 0);
+        assert.strictEqual(values[1], 5);
         """
     )
 

--- a/tests/unit/test_live2d_appearance_baseline_static.py
+++ b/tests/unit/test_live2d_appearance_baseline_static.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+LIVE2D_CORE_PATH = PROJECT_ROOT / "static" / "live2d-core.js"
+LIVE2D_MODEL_PATH = PROJECT_ROOT / "static" / "live2d-model.js"
+LIVE2D_EMOTION_PATH = PROJECT_ROOT / "static" / "live2d-emotion.js"
+
+
+def test_saved_live2d_parameters_feed_appearance_baseline():
+    core_source = LIVE2D_CORE_PATH.read_text(encoding="utf-8")
+    model_source = LIVE2D_MODEL_PATH.read_text(encoding="utf-8")
+
+    assert "this.appearanceBaselineParameters = {};" in core_source
+    assert "Live2DManager.prototype.mergeAppearanceBaselineParameters" in model_source
+    assert "this.mergeAppearanceBaselineParameters(model, parameters);" in model_source
+    assert "this._isRuntimeManagedAppearanceParam" in model_source
+
+
+def test_full_live2d_reset_prefers_saved_appearance_baseline():
+    source = LIVE2D_EMOTION_PATH.read_text(encoding="utf-8")
+
+    assert "this.appearanceBaselineParameters = { ...this.initialParameters };" in source
+    assert "? [this.appearanceBaselineParameters, this.savedModelParameters, this.motionBaselineParameters, this.initialParameters]" in source
+    assert "const resetValue = baseline.found ? baseline.value : initialValue;" in source
+    assert "coreModel.setParameterValueByIndex(paramIndex, resetValue);" in source
+    assert "coreModel.setParameterValueById(paramId, resetValue);" in source

--- a/tests/unit/test_live2d_appearance_baseline_static.py
+++ b/tests/unit/test_live2d_appearance_baseline_static.py
@@ -42,7 +42,8 @@ def test_full_live2d_reset_prefers_saved_appearance_baseline():
     source = LIVE2D_EMOTION_PATH.read_text(encoding="utf-8")
 
     assert "this._isRuntimeManagedAppearanceParam(paramId, resolvedParamId, coreModel)" in source
-    assert "? [this.appearanceBaselineParameters, this.savedModelParameters, this.motionBaselineParameters, this.initialParameters]" in source
+    assert "? [this.appearanceBaselineParameters, this.motionBaselineParameters, this.initialParameters]" in source
+    assert "? [this.appearanceBaselineParameters, this.savedModelParameters, this.motionBaselineParameters" not in source
     assert "const resetValue = baseline.found ? baseline.value : initialValue;" in source
     assert "coreModel.setParameterValueByIndex(paramIndex, resetValue);" in source
     assert "coreModel.setParameterValueById(paramId, resetValue);" in source
@@ -163,6 +164,76 @@ def test_live2d_appearance_baseline_skips_unresolved_numeric_keys():
         );
 
         assert.deepStrictEqual(Object.keys(manager.appearanceBaselineParameters), []);
+        """
+    )
+
+    result = _run_node_harness(script)
+    assert result.returncode == 0, result.stderr
+
+
+def test_live2d_reset_ignores_unfiltered_saved_runtime_baseline():
+    script = textwrap.dedent(
+        f"""
+        const assert = require('node:assert');
+        const fs = require('node:fs');
+        const vm = require('node:vm');
+
+        const context = {{
+          console: {{
+            log() {{}},
+            warn() {{}},
+            error() {{}},
+            groupCollapsed() {{}},
+            groupEnd() {{}},
+          }},
+          window: {{ LIPSYNC_PARAMS: ['ParamMouthOpenY', 'ParamMouthForm'] }},
+          Live2DManager: function Live2DManager() {{}},
+          setTimeout,
+          clearTimeout,
+          setInterval,
+          clearInterval,
+        }};
+        context.global = context;
+        context.window.Live2DManager = context.Live2DManager;
+
+        vm.createContext(context);
+        vm.runInContext(fs.readFileSync({json.dumps(str(LIVE2D_MODEL_PATH))}, 'utf8'), context);
+        vm.runInContext(fs.readFileSync({json.dumps(str(LIVE2D_EMOTION_PATH))}, 'utf8'), context);
+
+        const ids = ['ParamAllColor1', 'ParamBodyAngleX'];
+        const values = [0, 0];
+        const coreModel = {{
+          getParameterCount() {{ return ids.length; }},
+          getParameterId(index) {{ return ids[index]; }},
+          getParameterIndex(id) {{ return ids.indexOf(id); }},
+          getParameterValueByIndex(index) {{ return values[index]; }},
+          setParameterValueByIndex(index, value) {{ values[index] = value; }},
+          setParameterValueById(id, value) {{ values[ids.indexOf(id)] = value; }},
+        }};
+
+        const manager = new context.Live2DManager();
+        manager.currentModel = {{ internalModel: {{ coreModel }} }};
+        manager.initialParameters = {{
+          ParamAllColor1: 0,
+          ParamBodyAngleX: 0,
+        }};
+        manager.motionBaselineParameters = {{
+          ParamBodyAngleX: 0,
+          param_1: 0,
+        }};
+        manager.appearanceBaselineParameters = {{
+          ParamAllColor1: 1,
+          param_0: 1,
+        }};
+        manager.savedModelParameters = {{
+          ParamBodyAngleX: 30,
+          param_1: 30,
+        }};
+
+        manager._resetParametersToInitialState({{ preserveExpression: false }});
+
+        assert.strictEqual(values[0], 1);
+        assert.strictEqual(values[1], 0);
         """
     )
 

--- a/tests/unit/test_live2d_appearance_baseline_static.py
+++ b/tests/unit/test_live2d_appearance_baseline_static.py
@@ -1,10 +1,31 @@
+import json
+import shutil
+import subprocess
+import textwrap
 from pathlib import Path
+
+import pytest
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 LIVE2D_CORE_PATH = PROJECT_ROOT / "static" / "live2d-core.js"
 LIVE2D_MODEL_PATH = PROJECT_ROOT / "static" / "live2d-model.js"
 LIVE2D_EMOTION_PATH = PROJECT_ROOT / "static" / "live2d-emotion.js"
+
+
+def _run_node_harness(script: str) -> subprocess.CompletedProcess[str]:
+    node_executable = shutil.which("node")
+    if node_executable is None:
+        pytest.skip("node not found")
+    return subprocess.run(
+        [node_executable, "-"],
+        input=script,
+        text=True,
+        capture_output=True,
+        cwd=PROJECT_ROOT,
+        timeout=10,
+        check=False,
+    )
 
 
 def test_saved_live2d_parameters_feed_appearance_baseline():
@@ -20,8 +41,130 @@ def test_saved_live2d_parameters_feed_appearance_baseline():
 def test_full_live2d_reset_prefers_saved_appearance_baseline():
     source = LIVE2D_EMOTION_PATH.read_text(encoding="utf-8")
 
-    assert "this.appearanceBaselineParameters = { ...this.initialParameters };" in source
+    assert "this._isRuntimeManagedAppearanceParam(paramId, resolvedParamId, coreModel)" in source
     assert "? [this.appearanceBaselineParameters, this.savedModelParameters, this.motionBaselineParameters, this.initialParameters]" in source
     assert "const resetValue = baseline.found ? baseline.value : initialValue;" in source
     assert "coreModel.setParameterValueByIndex(paramIndex, resetValue);" in source
     assert "coreModel.setParameterValueById(paramId, resetValue);" in source
+
+
+def test_live2d_appearance_baseline_filters_runtime_parameters():
+    script = textwrap.dedent(
+        f"""
+        const assert = require('node:assert');
+        const fs = require('node:fs');
+        const vm = require('node:vm');
+
+        const context = {{
+          console: {{
+            log() {{}},
+            warn() {{}},
+            error() {{}},
+            groupCollapsed() {{}},
+            groupEnd() {{}},
+          }},
+          window: {{ LIPSYNC_PARAMS: ['ParamMouthOpenY', 'ParamMouthForm'] }},
+          Live2DManager: function Live2DManager() {{}},
+          setTimeout,
+          clearTimeout,
+          setInterval,
+          clearInterval,
+        }};
+        context.global = context;
+        context.window.Live2DManager = context.Live2DManager;
+
+        vm.createContext(context);
+        vm.runInContext(fs.readFileSync({json.dumps(str(LIVE2D_MODEL_PATH))}, 'utf8'), context);
+        vm.runInContext(fs.readFileSync({json.dumps(str(LIVE2D_EMOTION_PATH))}, 'utf8'), context);
+
+        const ids = [
+          'ParamAngleX',
+          'ParamBodyAngleX',
+          'ParamBreath',
+          'ParamLookAtX',
+          'ParamAllColor1',
+          'ParamHairFront',
+        ];
+        const values = [10, 20, 0.4, 0.5, 1, 0.25];
+        const coreModel = {{
+          getParameterCount() {{ return ids.length; }},
+          getParameterId(index) {{ return ids[index]; }},
+          getParameterIndex(id) {{ return ids.indexOf(id); }},
+          getParameterValueByIndex(index) {{ return values[index]; }},
+        }};
+        const manager = new context.Live2DManager();
+        manager.currentModel = {{ internalModel: {{ coreModel }} }};
+
+        manager.recordInitialParameters();
+
+        assert.strictEqual(manager.appearanceBaselineParameters.ParamAllColor1, 1);
+        assert.strictEqual(manager.appearanceBaselineParameters.ParamHairFront, 0.25);
+        assert.strictEqual(
+          Object.prototype.hasOwnProperty.call(manager.appearanceBaselineParameters, 'ParamBodyAngleX'),
+          false,
+        );
+        assert.strictEqual(
+          Object.prototype.hasOwnProperty.call(manager.appearanceBaselineParameters, 'ParamBreath'),
+          false,
+        );
+        assert.strictEqual(
+          Object.prototype.hasOwnProperty.call(manager.appearanceBaselineParameters, 'ParamLookAtX'),
+          false,
+        );
+        """
+    )
+
+    result = _run_node_harness(script)
+    assert result.returncode == 0, result.stderr
+
+
+def test_live2d_appearance_baseline_skips_unresolved_numeric_keys():
+    script = textwrap.dedent(
+        f"""
+        const assert = require('node:assert');
+        const fs = require('node:fs');
+        const vm = require('node:vm');
+
+        const context = {{
+          console: {{
+            log() {{}},
+            warn() {{}},
+            error() {{}},
+            groupCollapsed() {{}},
+            groupEnd() {{}},
+          }},
+          window: {{ LIPSYNC_PARAMS: ['ParamMouthOpenY', 'ParamMouthForm'] }},
+          Live2DManager: function Live2DManager() {{}},
+          setTimeout,
+          clearTimeout,
+          setInterval,
+          clearInterval,
+        }};
+        context.global = context;
+        context.window.Live2DManager = context.Live2DManager;
+
+        vm.createContext(context);
+        vm.runInContext(fs.readFileSync({json.dumps(str(LIVE2D_MODEL_PATH))}, 'utf8'), context);
+
+        const coreModel = {{
+          getParameterCount() {{ return 3; }},
+          getParameterIndex(id) {{
+            const match = String(id).match(/^param_(\\d+)$/);
+            return match ? Number(match[1]) : -1;
+          }},
+        }};
+        const manager = new context.Live2DManager();
+        manager.initialParameters = {{ param_0: 0, param_1: 0, param_2: 0 }};
+        manager.appearanceBaselineParameters = {{}};
+
+        manager.mergeAppearanceBaselineParameters(
+          {{ internalModel: {{ coreModel }} }},
+          {{ '1': 0.8, param_2: 0.7 }},
+        );
+
+        assert.deepStrictEqual(Object.keys(manager.appearanceBaselineParameters), []);
+        """
+    )
+
+    result = _run_node_harness(script)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
﻿## 改动概述

Live2D 表情/情绪切换会触发参数 reset，原逻辑主要回到模型初始参数；用户保存过的外观参数没有进入 reset 基准时，颜色类外观会在切表情后回到模型默认值。

这次为 Live2D manager 增加保存后的外观基准参数，并在应用模型目录参数或用户偏好参数时同步合并。全量 reset 时优先使用外观基准，再回退到保存参数、motion 基准和模型初始参数，避免把用户保存的颜色/外观洗回默认状态。

## 风险与边界

本 PR 只调整 Live2D 参数基准与 reset 行为，不改表情、motion 播放流程，也不调整参数编辑器的筛选规则。

外观基准合并会跳过口型、眨眼、呼吸、视线/角度、透明度和常驻表情参数，避免把运行时参数误固化为外观。风险主要在模型存在非标准参数语义时，某些作者自定义参数可能需要继续按具体模型观察。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持外观基准的保存与合并：在切换模型后仍可继续使用用户已保存的外观基准作为后续恢复参考。
* **Bug 修复**
  * 表情/动作重置更一致：重置时优先使用已保存的外观基准，并对运行时接管的外观相关参数进行过滤与正确写回；异常/无法解析的键会被跳过，避免错误覆盖。
  * 切模型时清空旧外观基准，防止跨模型残留影响。
* **Tests**
  * 新增与扩展外观基准相关单测，覆盖保存合并、重置优先级、过滤规则及异常键跳过。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->