### PR TITLE
fix(tutorial): stabilize day one icebreaker and reset selector contrast

### DIFF
--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -156,6 +156,11 @@
         return false;
     }
 
+    function getYuiGuideBridgeMessageTimestamp(message) {
+        var timestamp = Number(message && message.timestamp);
+        return Number.isFinite(timestamp) && timestamp > 0 ? timestamp : Date.now();
+    }
+
     function shouldBypassYuiGuideMessageDedup(action, message) {
         return (message && message.bypassDedup === true)
             || action === 'yui_guide_set_chat_spotlight'

--- a/static/css/dark-mode.css
+++ b/static/css/dark-mode.css
@@ -1402,6 +1402,20 @@ html[data-theme="dark"].subtitle-window-host body.subtitle-window-host {
   border-color: #3a5a6e;
 }
 
+[data-theme="dark"] .tutorial-cascader-trigger,
+[data-theme="dark"] .tutorial-cascader-option {
+  color: #0f5f7a;
+}
+
+[data-theme="dark"] .tutorial-cascader-trigger:hover,
+[data-theme="dark"] .tutorial-cascader-trigger:focus-visible,
+[data-theme="dark"] .tutorial-cascader-trigger.is-open,
+[data-theme="dark"] .tutorial-cascader-option:hover,
+[data-theme="dark"] .tutorial-cascader-option:focus-visible,
+[data-theme="dark"] .tutorial-cascader-option.is-selected {
+  color: #075985;
+}
+
 [data-theme="dark"] .tutorial-reset-wrapper select:hover,
 [data-theme="dark"] .tutorial-reset-btn:hover {
   background: #383838;

--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -1754,13 +1754,24 @@ class UniversalTutorialManager {
         });
     }
 
-    closeDay1SystrayIntroModal() {
+    closeDay1SystrayIntroModal(options = {}) {
         const existing = document.getElementById('neko-day1-systray-intro-modal');
+        const hadBodyClass = !!(document.body && document.body.classList.contains('neko-day1-systray-intro-open'));
+        const shouldNotify = options.notify !== false;
         if (existing) {
             existing.remove();
         }
         if (document.body) {
             document.body.classList.remove('neko-day1-systray-intro-open');
+        }
+        if (shouldNotify && (existing || hadBodyClass)) {
+            window.dispatchEvent(new CustomEvent('neko:day1-systray-intro-closed', {
+                detail: {
+                    source: 'day1_systray_intro',
+                    reason: 'closed',
+                    timestamp: Date.now()
+                }
+            }));
         }
     }
 
@@ -1769,7 +1780,7 @@ class UniversalTutorialManager {
             return;
         }
 
-        this.closeDay1SystrayIntroModal();
+        this.closeDay1SystrayIntroModal({ notify: false });
 
         const t = (key, fallback) => this.t(key, fallback);
         const escape = (text) => this.safeEscapeHtml(t(text.key, text.fallback));

--- a/static/tutorial/icebreaker/new-user-icebreaker.js
+++ b/static/tutorial/icebreaker/new-user-icebreaker.js
@@ -1610,7 +1610,8 @@
     function startFromEndStateWhenTutorialIdle(endState) {
         if (!endState) return Promise.resolve(false);
         if (isTutorialBlockingIcebreaker()) {
-            if (Date.now() >= getEndStateTriggerDeadline(endState)) return Promise.resolve(false);
+            // The Day 1 systray intro is a user-controlled modal; keep the guide end state until it closes.
+            if (!isDay1SystrayIntroBlockingIcebreaker() && Date.now() >= getEndStateTriggerDeadline(endState)) return Promise.resolve(false);
             return new Promise(function (resolve) {
                 window.setTimeout(resolve, TUTORIAL_IDLE_RETRY_MS);
             }).then(function () {
@@ -1641,9 +1642,6 @@
         }).then(function (started) {
             pendingGuideEndStartPromise = null;
             return started;
-        }, function (error) {
-            pendingGuideEndStartPromise = null;
-            throw error;
         });
         return pendingGuideEndStartPromise;
     }

--- a/static/tutorial/icebreaker/new-user-icebreaker.js
+++ b/static/tutorial/icebreaker/new-user-icebreaker.js
@@ -23,6 +23,8 @@
     var activeSession = null;
     var pendingStartDay = '';
     var pendingGuideEndStateDay = '';
+    var pendingGuideEndState = null;
+    var pendingGuideEndStartPromise = null;
     var scriptPromise = null;
     var localePromises = Object.create(null);
     var icebreakerSortKeySeq = 0;
@@ -170,11 +172,17 @@
         if (pendingGuideEndStateDay === dayKey) {
             pendingGuideEndStateDay = '';
         }
+        if (pendingGuideEndState && String(pendingGuideEndState.day || '') === dayKey) {
+            pendingGuideEndState = null;
+        }
     }
 
     function markPendingStartFromEndState(endState) {
         var dayKey = String(endState && endState.day || '');
-        if (dayKey) pendingGuideEndStateDay = dayKey;
+        if (dayKey) {
+            pendingGuideEndStateDay = dayKey;
+            pendingGuideEndState = endState;
+        }
         return dayKey;
     }
 
@@ -1050,6 +1058,18 @@
         return false;
     }
 
+    function isDay1SystrayIntroBlockingIcebreaker() {
+        try {
+            if (document.body && document.body.classList.contains('neko-day1-systray-intro-open')) {
+                return true;
+            }
+        } catch (_) {}
+        return hasVisibleTutorialBlocker([
+            '#neko-day1-systray-intro-modal',
+            '.neko-day1-systray-intro-modal'
+        ]);
+    }
+
     function isTutorialBlockingIcebreaker() {
         try {
             if (window.isInTutorial) return true;
@@ -1064,6 +1084,7 @@
                 return true;
             }
         } catch (_) {}
+        if (isDay1SystrayIntroBlockingIcebreaker()) return true;
         return hasVisibleTutorialBlocker([
             '#neko-tutorial-skip-btn',
             '#home-avatar-floating-guide-player',
@@ -1599,6 +1620,34 @@
         return Promise.resolve(startFromEndState(endState));
     }
 
+    function attemptStartFromGuideEndState(endState, pendingDay) {
+        if (!endState) return Promise.resolve(false);
+        var dayKey = String(pendingDay || endState.day || '');
+        if (activeSession) return Promise.resolve(true);
+        if (!pendingGuideEndState) return Promise.resolve(true);
+        if (dayKey && String(pendingGuideEndState.day || '') !== dayKey) return Promise.resolve(true);
+        if (pendingGuideEndStartPromise) return pendingGuideEndStartPromise;
+        pendingGuideEndStartPromise = startFromEndStateWhenTutorialIdle(endState).then(function (started) {
+            if (!started) {
+                clearPendingGuideEndStateDay(pendingDay);
+                dispatchIcebreakerEnded('start_failed');
+            }
+            return started;
+        }).catch(function (error) {
+            console.warn('[NewUserIcebreaker] deferred start failed:', error);
+            clearPendingGuideEndStateDay(pendingDay);
+            dispatchIcebreakerEnded('start_failed');
+            return false;
+        }).then(function (started) {
+            pendingGuideEndStartPromise = null;
+            return started;
+        }, function (error) {
+            pendingGuideEndStartPromise = null;
+            throw error;
+        });
+        return pendingGuideEndStartPromise;
+    }
+
     function synthesizeEndStateFromEvent(eventType, detail) {
         var normalizedDetail = detail && typeof detail === 'object' ? detail : {};
         var day = normalizedDetail.day;
@@ -1642,16 +1691,7 @@
         var endState = resolveLatestEndState(detail, eventType);
         var pendingDay = markPendingStartFromEndState(endState);
         window.setTimeout(function () {
-            startFromEndStateWhenTutorialIdle(endState).then(function (started) {
-                if (!started) {
-                    clearPendingGuideEndStateDay(pendingDay);
-                    dispatchIcebreakerEnded('start_failed');
-                }
-            }).catch(function (error) {
-                console.warn('[NewUserIcebreaker] deferred start failed:', error);
-                clearPendingGuideEndStateDay(pendingDay);
-                dispatchIcebreakerEnded('start_failed');
-            });
+            attemptStartFromGuideEndState(endState, pendingDay);
         }, 500);
     }
 
@@ -1665,6 +1705,10 @@
     window.addEventListener('neko:avatar-floating-guide-skip', handleGuideEndEvent);
     window.addEventListener('neko:tutorial-completed', handleGuideEndEvent);
     window.addEventListener('neko:tutorial-skipped', handleGuideEndEvent);
+    window.addEventListener('neko:day1-systray-intro-closed', function () {
+        if (!pendingGuideEndState) return;
+        attemptStartFromGuideEndState(pendingGuideEndState, String(pendingGuideEndState.day || ''));
+    });
     window.addEventListener('pagehide', function () {
         endIcebreakerRouteOnPageExit('icebreaker_pagehide');
     });

--- a/tests/frontend/test_memory_browser.py
+++ b/tests/frontend/test_memory_browser.py
@@ -189,6 +189,42 @@ def test_memory_browser_page_load(mock_page: Page, running_server: str, seed_mem
 
 
 @pytest.mark.frontend
+def test_memory_browser_tutorial_cascader_dark_mode_uses_readable_text(
+    mock_page: Page,
+    running_server: str,
+    seed_memory_file,
+):
+    _install_ready_memory_browser_routes(mock_page, seed_memory_file)
+    mock_page.add_init_script("window.localStorage.setItem('neko-dark-mode', 'true')")
+
+    mock_page.goto(f"{running_server}/memory_browser")
+    mock_page.wait_for_selector(".tutorial-cascader-trigger", timeout=10000)
+    mock_page.locator(".tutorial-cascader-trigger").click()
+
+    colors = mock_page.evaluate(
+        """
+        () => {
+            const trigger = document.querySelector('.tutorial-cascader-trigger');
+            const option = document.querySelector('.tutorial-cascader-option[data-tutorial-page="home"]');
+            return {
+                theme: document.documentElement.getAttribute('data-theme'),
+                triggerColor: getComputedStyle(trigger).color,
+                optionColor: getComputedStyle(option).color,
+                optionBackground: getComputedStyle(option).backgroundColor,
+            };
+        }
+        """
+    )
+
+    assert colors == {
+        "theme": "dark",
+        "triggerColor": "rgb(15, 95, 122)",
+        "optionColor": "rgb(15, 95, 122)",
+        "optionBackground": "rgba(0, 0, 0, 0)",
+    }
+
+
+@pytest.mark.frontend
 def test_memory_browser_current_personality_reset_requests_home_reselect(
     mock_page: Page,
     running_server: str,

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -885,13 +885,18 @@ def test_icebreaker_defers_while_home_tutorial_is_active():
 
     assert "function isIcebreakerBlockerVisible(el)" in runtime
     assert "function hasVisibleTutorialBlocker(selectors)" in runtime
+    assert "function isDay1SystrayIntroBlockingIcebreaker()" in runtime
     assert "function isTutorialBlockingIcebreaker()" in runtime
     assert "window.isInTutorial" in runtime
     assert "manager.isTutorialRunning" in runtime
     assert "manager._teardownPromise" in runtime
+    assert "neko-day1-systray-intro-open" in runtime
+    assert "#neko-day1-systray-intro-modal" in runtime
+    assert ".neko-day1-systray-intro-modal" in runtime
     assert "startFromEndStateWhenTutorialIdle" in runtime
     assert "TUTORIAL_IDLE_RETRY_MS" in runtime
     assert "if (isTutorialBlockingIcebreaker())" in runtime
+    assert "window.addEventListener('neko:day1-systray-intro-closed'" in runtime
     assert "return false;" in runtime
     assert "getEndStateTriggerDeadline(endState)" in runtime
     assert "retryCount >= TUTORIAL_IDLE_MAX_RETRIES" not in runtime
@@ -921,11 +926,26 @@ def test_icebreaker_tutorial_end_events_start_from_explicit_event_state():
     assert "startFromEndState(resolveLatestEndState(detail, eventType))" not in body
     assert "var endState = resolveLatestEndState(detail, eventType);" in body
     assert "var pendingDay = markPendingStartFromEndState(endState);" in body
-    assert "startFromEndStateWhenTutorialIdle(endState)" in body
-    assert "clearPendingGuideEndStateDay(pendingDay)" in body
-    assert ".catch(function (error)" in body
-    assert "console.warn('[NewUserIcebreaker] deferred start failed:', error);" in body
-    assert "dispatchIcebreakerEnded('start_failed')" in body
+    assert "attemptStartFromGuideEndState(endState, pendingDay)" in body
+
+
+def test_day1_systray_intro_close_releases_icebreaker_and_desktop_passthrough():
+    runtime = RUNTIME_PATH.read_text(encoding="utf-8")
+    manager = UNIVERSAL_TUTORIAL_MANAGER_PATH.read_text(encoding="utf-8")
+
+    assert "pendingGuideEndState = endState;" in runtime
+    assert "attemptStartFromGuideEndState(pendingGuideEndState" in runtime
+    assert "window.addEventListener('neko:day1-systray-intro-closed'" in runtime
+    assert "window.dispatchEvent(new CustomEvent('neko:day1-systray-intro-closed'" in manager
+    assert "document.body.classList.remove('neko-day1-systray-intro-open')" in manager
+
+
+def test_yui_guide_bridge_timestamp_helper_exists_for_cursor_relay():
+    interpage = APP_INTERPAGE_PATH.read_text(encoding="utf-8")
+
+    assert "function getYuiGuideBridgeMessageTimestamp(message)" in interpage
+    assert "timestamp: getYuiGuideBridgeMessageTimestamp(message)" in interpage
+    assert "getYuiGuideBridgeMessageTimestamp is not defined" not in interpage
 
 
 def test_icebreaker_does_not_bootstrap_from_persisted_end_state_on_cold_start():

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -940,6 +940,42 @@ def test_day1_systray_intro_close_releases_icebreaker_and_desktop_passthrough():
     assert "document.body.classList.remove('neko-day1-systray-intro-open')" in manager
 
 
+def test_icebreaker_keeps_pending_start_while_day1_systray_intro_is_open():
+    runtime = RUNTIME_PATH.read_text(encoding="utf-8")
+    match = re.search(
+        r"function startFromEndStateWhenTutorialIdle\(endState\) \{(?P<body>.*?)\n    \}",
+        runtime,
+        re.DOTALL,
+    )
+
+    assert match is not None
+    body = match.group("body")
+    assert "if (isTutorialBlockingIcebreaker())" in body
+    assert (
+        "!isDay1SystrayIntroBlockingIcebreaker() && Date.now() >= getEndStateTriggerDeadline(endState)"
+        in body
+    )
+    assert body.index("!isDay1SystrayIntroBlockingIcebreaker()") < body.index(
+        "window.setTimeout(resolve, TUTORIAL_IDLE_RETRY_MS)"
+    )
+
+
+def test_icebreaker_deferred_start_promise_cleanup_has_no_unreachable_rejection_handler():
+    runtime = RUNTIME_PATH.read_text(encoding="utf-8")
+    match = re.search(
+        r"function attemptStartFromGuideEndState\(endState, pendingDay\) \{(?P<body>.*?)\n    \}",
+        runtime,
+        re.DOTALL,
+    )
+
+    assert match is not None
+    body = match.group("body")
+    assert "}).catch(function (error) {" in body
+    assert "}).then(function (started) {" in body
+    assert "}, function (error) {" not in body
+    assert "throw error;" not in body
+
+
 def test_yui_guide_bridge_timestamp_helper_exists_for_cursor_relay():
     interpage = APP_INTERPAGE_PATH.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## 改动概述 / Summary

本 PR 修复两个新手引导相关问题：
1. 首次启动流程中，用户跳过 Day1 新手引导并确认托盘图标介绍弹窗后，如果先手动切换到猫形态并拖拽猫，再切回模型形态，模型窗口的透明区域大多数时候不再穿透鼠标事件。
   - 破冰不会再抢在托盘介绍弹窗背后启动。
   - 托盘介绍弹窗关闭后，会派发明确的关闭事件，释放等待中的破冰启动。
   - 同时补齐 YUI guide 跨窗口 cursor relay 缺失的 timestamp helper，避免教程结束阶段出现 `ReferenceError`。

2. 修复记忆浏览页暗色模式下“新手引导”页面选择器的文字可读性。
   - 暗色模式的全局 button 灰色不再覆盖白底选择项。
   - 页面选择项和选中/悬停状态使用更深的蓝色文字，提升对比度。

链接：https://github.com/Project-N-E-K-O/N.E.K.O.-PC/pull/299

## 回归报告 / Regression Report

不适用。

本 PR 未修改 `app/`、`main_logic/`、`main_routers/`、`memory/` 下的 Python 文件。

## 不拆分理由 / Why Not Split

不适用。

本 PR 计入上限的文件数 ≤ 20。

## 测试 / Testing

- `.\.venv\Scripts\python.exe -m pytest tests\unit\test_new_user_icebreaker_static_contracts.py`
- `.\.venv\Scripts\python.exe -m pytest tests\frontend\test_memory_browser.py::test_memory_browser_tutorial_cascader_dark_mode_uses_readable_text`
- `node --check static\tutorial\icebreaker\new-user-icebreaker.js`
- `node --check static\tutorial\core\universal-manager.js`
- `node --check static\app-interpage.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 深色模式教程级联选择器在基础/悬停/聚焦/打开/选中等状态下文字更清晰。
  * 破冰/引导流程在 Day1 托盘介绍弹窗打开与关闭场景下更稳定：支持挂起后继续启动，减少卡住或重复触发。
* **Bug 修复**
  * 统一跨页消息时间戳：对无效或非正数值回退到当前时间，避免影响后续处理。
  * 优化 Day1 托盘引导关闭通知：按需派发结束事件，减少重复关闭带来的异常行为。
* **测试**
  * 新增端到端与单元测试覆盖深色模式样式及关键事件时序。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->