### PR TITLE
离开后阻止屏幕分享残余帧重启语音会话,防止反复重启语音对话

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -117,6 +117,7 @@ _MAGIC_COMMAND_IMAGE_DROP_REQUEST_MAX = 64
 _VOICE_PROACTIVE_ACK_GRACE_S = 0.05
 _TEXT_SESSION_INPUT_TYPES = frozenset({"text", "avatar_drop_image", "user_image"})
 _IMAGE_INPUT_TYPES = frozenset({"screen", "camera", "avatar_drop_image", "user_image"})
+_LIVE_VISION_STREAM_INPUT_TYPES = frozenset({"screen", "camera"})
 _CONTEXT_APPEND_DEDUP_TTL_SECONDS = 120.0
 _CONTEXT_APPEND_DEDUP_MAX_ENTRIES = 256
 _CONTEXT_APPEND_READY_FLUSH_MAX_PASSES = 8
@@ -9385,13 +9386,18 @@ class LLMSessionManager:
         await self.cleanup(expected_session=expected_session)
     
     async def stream_data(self, message: dict):  # 向Core API发送Media数据
-        if message.get("input_type") == "audio":
+        input_type = message.get("input_type")
+        if input_type in _LIVE_VISION_STREAM_INPUT_TYPES and self.is_goodbye_silent():
+            return
+        if input_type == "audio":
             await self._enqueue_audio_stream_data(message)
             return
         await self._stream_data_now(message)
 
     async def _stream_data_now(self, message: dict):
         input_type = message.get("input_type")
+        if input_type in _LIVE_VISION_STREAM_INPUT_TYPES and self.is_goodbye_silent():
+            return
         # 检查session是否就绪
         async with self.input_cache_lock:
             if not self.session_ready:
@@ -9410,6 +9416,8 @@ class LLMSessionManager:
         # 在锁外检查是否需要创建新session（不要在锁内创建session，避免死锁）
         if not self.session_ready and self._starting_session_count == 0:
             if not self.session or not self.is_active:
+                if input_type in _LIVE_VISION_STREAM_INPUT_TYPES:
+                    return
                 # Memory Server 专属冷却检查
                 if self._emit_cooldown_turn_end_if_needed():
                     return
@@ -9434,6 +9442,8 @@ class LLMSessionManager:
         """Internal method: the actual stream_data processing logic"""
         data = message.get("data")
         input_type = message.get("input_type")
+        if input_type in _LIVE_VISION_STREAM_INPUT_TYPES and self.is_goodbye_silent():
+            return
         # 检查session是否发生致命错误（如1011错误、Response timeout）
         if self.session and isinstance(self.session, OmniRealtimeClient):
             if hasattr(self.session, '_fatal_error_occurred') and self.session._fatal_error_occurred:
@@ -9447,6 +9457,8 @@ class LLMSessionManager:
 
         # 如果 session 不存在或不活跃，检查是否可以自动重建
         if not self.session or not self.is_active:
+            if input_type in _LIVE_VISION_STREAM_INPUT_TYPES:
+                return
             # Memory Server 专属冷却检查
             if self._emit_cooldown_turn_end_if_needed():
                 return

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -9386,6 +9386,7 @@ class LLMSessionManager:
         await self.cleanup(expected_session=expected_session)
     
     def _should_drop_live_vision_stream(self, input_type: str | None) -> bool:
+        """Deliberately checked at each stream boundary; callers may enter below stream_data."""
         return input_type in _LIVE_VISION_STREAM_INPUT_TYPES and self.is_goodbye_silent()
 
     async def stream_data(self, message: dict):  # 向Core API发送Media数据

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -9385,9 +9385,12 @@ class LLMSessionManager:
         self.sync_message_queue.put({'type': 'system', 'data': 'API server disconnected'})
         await self.cleanup(expected_session=expected_session)
     
+    def _should_drop_live_vision_stream(self, input_type: str | None) -> bool:
+        return input_type in _LIVE_VISION_STREAM_INPUT_TYPES and self.is_goodbye_silent()
+
     async def stream_data(self, message: dict):  # 向Core API发送Media数据
         input_type = message.get("input_type")
-        if input_type in _LIVE_VISION_STREAM_INPUT_TYPES and self.is_goodbye_silent():
+        if self._should_drop_live_vision_stream(input_type):
             return
         if input_type == "audio":
             await self._enqueue_audio_stream_data(message)
@@ -9396,7 +9399,7 @@ class LLMSessionManager:
 
     async def _stream_data_now(self, message: dict):
         input_type = message.get("input_type")
-        if input_type in _LIVE_VISION_STREAM_INPUT_TYPES and self.is_goodbye_silent():
+        if self._should_drop_live_vision_stream(input_type):
             return
         # 检查session是否就绪
         async with self.input_cache_lock:
@@ -9442,7 +9445,7 @@ class LLMSessionManager:
         """Internal method: the actual stream_data processing logic"""
         data = message.get("data")
         input_type = message.get("input_type")
-        if input_type in _LIVE_VISION_STREAM_INPUT_TYPES and self.is_goodbye_silent():
+        if self._should_drop_live_vision_stream(input_type):
             return
         # 检查session是否发生致命错误（如1011错误、Response timeout）
         if self.session and isinstance(self.session, OmniRealtimeClient):

--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -2284,6 +2284,10 @@
                 display: live2dContainer ? getComputedStyle(live2dContainer).display : 'undefined'
             });
 
+            if (typeof window.stopScreening === 'function') {
+                window.stopScreening();
+            }
+
             if (S.socket && S.socket.readyState === WebSocket.OPEN) {
                 S._suppressCharacterLeft = true;
                 S.socket.send(JSON.stringify({

--- a/static/app-screen.js
+++ b/static/app-screen.js
@@ -687,10 +687,11 @@
     mod.canSendLiveVisionStreamFrame = canSendLiveVisionStreamFrame;
 
     async function stopLiveVisionStreamIfBlocked(inputType) {
-        if (!getLiveVisionStreamBlockedReason(inputType)) {
+        var blockedReason = getLiveVisionStreamBlockedReason(inputType);
+        if (!blockedReason) {
             return false;
         }
-        await stopScreenSharing(true);
+        await stopScreenSharing(blockedReason === 'goodbye_active');
         return true;
     }
     mod.stopLiveVisionStreamIfBlocked = stopLiveVisionStreamIfBlocked;

--- a/static/app-screen.js
+++ b/static/app-screen.js
@@ -660,6 +660,32 @@
     }
     mod.buildStreamDataMessage = buildStreamDataMessage;
 
+    function getLiveVisionStreamBlockedReason(inputType) {
+        if (inputType !== 'screen' && inputType !== 'camera') {
+            return '';
+        }
+        if (typeof window.isNekoGoodbyeModeActive === 'function' && window.isNekoGoodbyeModeActive()) {
+            return 'goodbye_active';
+        }
+        if (!S.isRecording) {
+            return 'recording_stopped';
+        }
+        if (!S.voiceChatActive) {
+            return 'voice_session_inactive';
+        }
+        return '';
+    }
+    mod.getLiveVisionStreamBlockedReason = getLiveVisionStreamBlockedReason;
+
+    function canSendLiveVisionStreamFrame(inputType) {
+        if (inputType !== 'screen' && inputType !== 'camera') {
+            return true;
+        }
+        if (getLiveVisionStreamBlockedReason(inputType)) return false;
+        return true;
+    }
+    mod.canSendLiveVisionStreamFrame = canSendLiveVisionStreamFrame;
+
     // ======================== startScreenVideoStreaming ========================
     function startScreenVideoStreaming(stream, input_type) {
         // 更新最后使用时间并调度闲置检查
@@ -686,6 +712,11 @@
             }
 
             S.videoSenderInterval = setInterval(function () {
+                var blockedReason = getLiveVisionStreamBlockedReason(input_type);
+                if (blockedReason) {
+                    stopScreening();
+                    return;
+                }
                 var frame = captureCanvasFrame(video, 0.8);
                 if (frame && frame.dataUrl && S.socket && S.socket.readyState === WebSocket.OPEN) {
                     S.socket.send(JSON.stringify(buildStreamDataMessage(frame.dataUrl, input_type)));
@@ -939,16 +970,21 @@
                 console.log('[屏幕源] 进入后端 pyautogui 轮询模式');
 
                 // 立即发送第一帧
-                if (S.socket && S.socket.readyState === WebSocket.OPEN) {
+                if (canSendLiveVisionStreamFrame('screen') && S.socket && S.socket.readyState === WebSocket.OPEN) {
                     S.socket.send(JSON.stringify(buildStreamDataMessage(backendTest, 'screen')));
                 }
 
                 // 复用 videoSenderInterval，stopScreening() 可统一清理
                 S.videoSenderInterval = setInterval(async function () {
                     try {
+                        var blockedReason = getLiveVisionStreamBlockedReason('screen');
+                        if (blockedReason) {
+                            stopScreening();
+                            return;
+                        }
                         var r = await fetchBackendScreenshot();
                         var frame = r.dataUrl;
-                        if (frame && S.socket && S.socket.readyState === WebSocket.OPEN) {
+                        if (frame && canSendLiveVisionStreamFrame('screen') && S.socket && S.socket.readyState === WebSocket.OPEN) {
                             S.socket.send(JSON.stringify(buildStreamDataMessage(frame, 'screen')));
                         }
                     } catch (e) {

--- a/static/app-screen.js
+++ b/static/app-screen.js
@@ -686,6 +686,15 @@
     }
     mod.canSendLiveVisionStreamFrame = canSendLiveVisionStreamFrame;
 
+    async function stopLiveVisionStreamIfBlocked(inputType) {
+        if (!getLiveVisionStreamBlockedReason(inputType)) {
+            return false;
+        }
+        await stopScreenSharing(true);
+        return true;
+    }
+    mod.stopLiveVisionStreamIfBlocked = stopLiveVisionStreamIfBlocked;
+
     // ======================== startScreenVideoStreaming ========================
     function startScreenVideoStreaming(stream, input_type) {
         // 更新最后使用时间并调度闲置检查
@@ -702,7 +711,10 @@
         S.videoTrack = stream.getVideoTracks()[0];
 
         // 定时抓取当前帧并编码为jpeg（使用统一的 captureCanvasFrame）
-        video.play().then(function () {
+        video.play().then(async function () {
+            if (await stopLiveVisionStreamIfBlocked(input_type)) {
+                return;
+            }
             if (video.videoWidth && video.videoHeight) {
                 var vw = video.videoWidth, vh = video.videoHeight;
                 if (vw > C.MAX_SCREENSHOT_WIDTH || vh > C.MAX_SCREENSHOT_HEIGHT) {
@@ -711,10 +723,8 @@
                 }
             }
 
-            S.videoSenderInterval = setInterval(function () {
-                var blockedReason = getLiveVisionStreamBlockedReason(input_type);
-                if (blockedReason) {
-                    stopScreening();
+            S.videoSenderInterval = setInterval(async function () {
+                if (await stopLiveVisionStreamIfBlocked(input_type)) {
                     return;
                 }
                 var frame = captureCanvasFrame(video, 0.8);
@@ -939,7 +949,11 @@
                 S.screenCaptureStreamLastUsed = Date.now();
                 scheduleScreenCaptureIdleCheck();
 
-                startScreenVideoStreaming(S.screenCaptureStream, isMobile() ? 'camera' : 'screen');
+                var streamInputType = isMobile() ? 'camera' : 'screen';
+                if (await stopLiveVisionStreamIfBlocked(streamInputType)) {
+                    return;
+                }
+                startScreenVideoStreaming(S.screenCaptureStream, streamInputType);
 
                 // 当用户停止共享屏幕时
                 S.screenCaptureStream.getVideoTracks()[0].onended = function () {
@@ -967,6 +981,9 @@
                 if (!backendTest) {
                     throw new Error('所有屏幕捕获方式均失败（含后端兜底）');
                 }
+                if (await stopLiveVisionStreamIfBlocked('screen')) {
+                    return;
+                }
                 console.log('[屏幕源] 进入后端 pyautogui 轮询模式');
 
                 // 立即发送第一帧
@@ -977,9 +994,7 @@
                 // 复用 videoSenderInterval，stopScreening() 可统一清理
                 S.videoSenderInterval = setInterval(async function () {
                     try {
-                        var blockedReason = getLiveVisionStreamBlockedReason('screen');
-                        if (blockedReason) {
-                            stopScreening();
+                        if (await stopLiveVisionStreamIfBlocked('screen')) {
                             return;
                         }
                         var r = await fetchBackendScreenshot();

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -2770,6 +2770,11 @@
                 } else if (response.type === 'session_preparing') {
                     console.log(window.t('console.sessionPreparingReceived'), response.input_mode);
                     if (response.input_mode !== 'text') {
+                        if (typeof window.isNekoGoodbyeModeActive === 'function'
+                                && window.isNekoGoodbyeModeActive()) {
+                            if (typeof window.hideVoicePreparingToast === 'function') window.hideVoicePreparingToast();
+                            return;
+                        }
                         var preparingMessage = window.t ? window.t('app.voiceSystemPreparing') : '语音系统准备中，请稍候...';
                         if (typeof window.showVoicePreparingToast === 'function') window.showVoicePreparingToast(preparingMessage);
                     }
@@ -2780,6 +2785,7 @@
                             && typeof window.isNekoGoodbyeModeActive === 'function'
                             && window.isNekoGoodbyeModeActive()) {
                         console.log('[App] ignore stale audio session_started while goodbye is active');
+                        if (typeof window.stopScreening === 'function') window.stopScreening();
                         if (typeof window.cancelPendingSessionStart === 'function') {
                             window.cancelPendingSessionStart('Voice start cancelled by goodbye');
                         } else {
@@ -2943,6 +2949,7 @@
                     S.isTextSessionActive = false;
                     S.voiceChatActive = false;
                     S.voiceStartPending = false;
+                    if (typeof window.stopScreening === 'function') window.stopScreening();
                     stopAssistantTextOutputOnSessionEnd('session_ended_by_server');
                     clearAssistantLifecycleOnDisconnect('session_ended_by_server');
 

--- a/tests/unit/test_audio_stream_queue.py
+++ b/tests/unit/test_audio_stream_queue.py
@@ -21,6 +21,39 @@ async def test_starting_session_audio_does_not_enter_pending_input_data():
     assert mgr.pending_input_data == []
 
 
+async def test_goodbye_silent_drops_live_vision_stream_before_processing():
+    mgr = LLMSessionManager.__new__(LLMSessionManager)
+    mgr.lanlan_name = "Test"
+    mgr.goodbye_silent = True
+    mgr._stream_data_now = AsyncMock()
+
+    await LLMSessionManager.stream_data(
+        mgr,
+        {"input_type": "screen", "data": "data:image/jpeg;base64,abc"},
+    )
+
+    mgr._stream_data_now.assert_not_awaited()
+
+
+async def test_live_vision_stream_does_not_auto_start_session_when_inactive():
+    mgr = LLMSessionManager.__new__(LLMSessionManager)
+    mgr.lanlan_name = "Test"
+    mgr.goodbye_silent = False
+    mgr.session_ready = False
+    mgr._starting_session_count = 0
+    mgr.session = None
+    mgr.is_active = False
+    mgr.input_cache_lock = asyncio.Lock()
+    mgr.start_session = AsyncMock()
+
+    await LLMSessionManager._stream_data_now(
+        mgr,
+        {"input_type": "screen", "data": "data:image/jpeg;base64,abc"},
+    )
+
+    mgr.start_session.assert_not_awaited()
+
+
 async def test_flush_pending_input_data_routes_audio_through_bounded_queue():
     mgr = LLMSessionManager.__new__(LLMSessionManager)
     audio_msg = {"input_type": "audio", "data": [1] * 480}

--- a/tests/unit/test_audio_stream_queue.py
+++ b/tests/unit/test_audio_stream_queue.py
@@ -1,7 +1,7 @@
 import asyncio
 import os
 import sys
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
 
@@ -52,6 +52,22 @@ async def test_live_vision_stream_does_not_auto_start_session_when_inactive():
     )
 
     mgr.start_session.assert_not_awaited()
+
+
+async def test_goodbye_silent_drops_live_vision_stream_in_internal_processor():
+    mgr = LLMSessionManager.__new__(LLMSessionManager)
+    mgr.lanlan_name = "Test"
+    mgr.goodbye_silent = True
+    mgr.session = MagicMock()
+    mgr.session.stream_image = AsyncMock()
+    mgr.is_active = True
+
+    await LLMSessionManager._process_stream_data_internal(
+        mgr,
+        {"input_type": "camera", "data": "data:image/jpeg;base64,abc"},
+    )
+
+    mgr.session.stream_image.assert_not_called()
 
 
 async def test_flush_pending_input_data_routes_audio_through_bounded_queue():


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

离开后阻止屏幕分享残余帧重启语音会话,防止反复重启语音对话

## 回归报告 / Regression Report

- 改动了什么
  - 在 `main_logic/core.py` 中增加对 `screen` / `camera` 实时视觉流的保护：当角色已进入 goodbye silent 状态，或当前没有活跃 session 时，残余屏幕分享/摄像头帧不再触发自动创建 session。
  - 在前端屏幕分享推帧逻辑中增加状态检查：语音会话结束、录音停止、goodbye 状态激活时，静默停止屏幕分享推帧。
  - 在 goodbye / session ended 等路径中补充停止屏幕分享推帧，避免前端继续向后端发送残余帧。
  - 添加回归测试覆盖 goodbye 后丢弃实时视觉流，以及 inactive session 下实时视觉流不会自动拉起 session。

- 理由 / 必要性
  - 修复“开启语音并打开屏幕分享后立即请她离开”时，残余 `screen` 帧可能被后端当作输入，反复触发 `start_session(input_mode=audio)`，导致持续弹出“语音系统准备中”并刷日志的问题。
  - `screen` / `camera` 是被动持续输入，不应在会话已结束或角色离开后重新拉起语音 session。

- 改动前后的表现对比
  - 改动前：goodbye 后屏幕分享残余帧仍可能继续发送到后端，后端在 session 不存在/未就绪时自动创建新 session，造成语音准备提示反复出现。
  - 改动后：goodbye 或 session ended 后，前端停止推送残余屏幕分享帧；即使残余帧到达后端，也会被静默丢弃，不会重新创建语音 session。

- 潜在回归点
  - 影响链路：语音会话中的屏幕分享、摄像头视觉输入、session 结束/重连、goodbye 流程。
  - 风险点：正常语音会话中 `screen` / `camera` 推帧不能被误拦截；文本和音频输入的自动建 session 行为不能受影响。
  - 验证方式：
    - `uv run pytest tests/unit/test_audio_stream_queue.py`
    - `uv run python -m py_compile main_logic/core.py`
    - `node --check static/app-screen.js`
    - `node --check static/app-buttons.js`
    - `node --check static/app-websocket.js`
    - `git diff --check`


## 测试 / Testing

手动尝试复现


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 在“静默离别”期间新增实时视觉（屏幕/摄像头）发送门控：自动生成阻断原因并阻止后续帧捕获与发送。
* **Bug Fixes**
  * 重置与会话生命周期关键阶段会同步停止屏幕分享，避免准备/启动/结束阶段残留状态与旧音频相关流程继续生效。
* **Tests**
  * 新增单元测试：覆盖静默退出与非激活状态下的屏幕/摄像头输入丢弃、不会触发视觉处理与不会自动启动会话。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->