### PR TITLE
给 React Chat host 暴露统一的截图触发入口，让外部调用复用聊天框截图按钮的完整逻辑

### DIFF
--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -3116,19 +3116,23 @@
     }
 
     function handleComposerScreenshot() {
+        var handled = false;
         if (typeof state.onComposerScreenshot === 'function') {
+            handled = true;
             try {
                 state.onComposerScreenshot();
             } catch (error) {
                 console.error('[ReactChatWindow] onComposerScreenshot failed:', error);
             }
         } else if (window.appButtons && typeof window.appButtons.captureScreenshotToPendingList === 'function') {
+            handled = true;
             window.appButtons.captureScreenshotToPendingList();
         } else {
             console.warn('[ReactChatWindow] no screenshot handler available');
         }
 
         dispatchHostEvent('screenshot', {});
+        return handled;
     }
 
     function handleComposerRemoveAttachment(attachmentId) {
@@ -7139,6 +7143,7 @@
         setOnComposerScreenshot: function (handler) {
             state.onComposerScreenshot = typeof handler === 'function' ? handler : null;
         },
+        triggerComposerScreenshot: handleComposerScreenshot,
         setOnComposerRemoveAttachment: function (handler) {
             state.onComposerRemoveAttachment = typeof handler === 'function' ? handler : null;
         },

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -3118,20 +3118,26 @@
     function handleComposerScreenshot() {
         var handled = false;
         if (typeof state.onComposerScreenshot === 'function') {
-            handled = true;
             try {
                 state.onComposerScreenshot();
+                handled = true;
             } catch (error) {
                 console.error('[ReactChatWindow] onComposerScreenshot failed:', error);
+                handled = false;
             }
         } else if (window.appButtons && typeof window.appButtons.captureScreenshotToPendingList === 'function') {
-            handled = true;
-            window.appButtons.captureScreenshotToPendingList();
+            try {
+                window.appButtons.captureScreenshotToPendingList();
+                handled = true;
+            } catch (error) {
+                console.error('[ReactChatWindow] captureScreenshotToPendingList failed:', error);
+                handled = false;
+            }
         } else {
             console.warn('[ReactChatWindow] no screenshot handler available');
         }
 
-        dispatchHostEvent('screenshot', {});
+        dispatchHostEvent('screenshot', { handled: handled });
         return handled;
     }
 


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

给 React Chat host 暴露统一的截图触发入口，让外部调用复用聊天框截图按钮的完整逻辑

## 测试 / Testing

配合neko_pc的修改一同手动测试


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 宿主端现在可以主动触发聊天窗口截图，并获得是否已成功处理的结果。
* **改进**
  * 截图事件会在触发后统一发送，提升与宿主侧的联动一致性。
  * 截图处理逻辑会根据当前可用能力自动选择执行方式，增强兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->