### PR TITLE
优化 新用户3D 模型默认 3D模型为MMD 引导与将残留的 Live3D 备用文案改为 3D模型

### DIFF
--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -3831,8 +3831,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         const previousModelType = currentModelType;
         currentModelType = type;
         window._modelManagerCurrentAvatarType = type;
-        if (type === 'live3d' && subType) {
-            currentLive3dSubType = subType;
+        if (type === 'live3d') {
+            currentLive3dSubType = (subType === 'vrm' || subType === 'mmd') ? subType : 'mmd';
         } else if (type !== 'live3d') {
             currentLive3dSubType = '';
         }
@@ -4634,8 +4634,8 @@ document.addEventListener('DOMContentLoaded', async () => {
                         const charactersData = await RequestHelper.fetchJson('/api/characters');
                         const catgirlConfig = charactersData['猫娘']?.[lanlanName];
                         if (vrmModelSelect) {
-                            // 使用 live3d_sub_type 决定优先匹配哪种模型，避免 PR#702 保留双模型路径后总是选到 MMD
-                            const activeSubType = String(catgirlConfig?.live3d_sub_type || '').toLowerCase();
+                            // 使用 live3d_sub_type 决定优先匹配哪种模型；新用户无配置时沿用当前入口子类型。
+                            const activeSubType = String(catgirlConfig?.live3d_sub_type || currentLive3dSubType || '').toLowerCase();
 
                             const _mmdPathSwitch = catgirlConfig && catgirlConfig.mmd
                                 ? (typeof catgirlConfig.mmd === 'string' ? catgirlConfig.mmd : catgirlConfig.mmd.model_path)
@@ -6245,9 +6245,25 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     }
 
-    // 自动选择默认 Live3D 模型（sister1.0.vrm），当角色无已配置的 VRM/MMD 模型时使用
+    // 自动选择默认 Live3D 模型，当角色无已配置的 VRM/MMD 模型时使用
     function selectDefaultLive3DModel(options = {}) {
         if (!vrmModelSelect || vrmModelSelect.options.length === 0) return false;
+        if ((options.preferredSubType || currentLive3dSubType) === 'mmd') {
+            const mmdOption = Array.from(vrmModelSelect.options).find(opt =>
+                opt.value && opt.getAttribute('data-sub-type') === 'mmd'
+            );
+            if (mmdOption) {
+                vrmModelSelect.value = mmdOption.value;
+                window._modelManagerLoadedFallbackModel = true;
+                if (options.suppressChange) {
+                    suppressModelManagerChange(() => dispatchModelManagerChange(vrmModelSelect));
+                } else {
+                    dispatchModelManagerChange(vrmModelSelect);
+                }
+                console.log('[模型管理] 自动加载默认 MMD 模型:', mmdOption.getAttribute('data-filename') || mmdOption.value);
+                return true;
+            }
+        }
         const defaultFilename = 'sister1.0.vrm';
         const matchedOption = Array.from(vrmModelSelect.options).find(opt => {
             if (!opt.value) return false;

--- a/static/tutorial/core/page-tutorial-manager.js
+++ b/static/tutorial/core/page-tutorial-manager.js
@@ -498,7 +498,7 @@
                     element: '#vrm-model-select-btn',
                     popover: {
                         title: this.t('tutorial.model_manager.mmd.step1.title', '选择 MMD 模型'),
-                        description: this.t('tutorial.model_manager.mmd.step1.desc', '在 Live3D（MMD）模式下从这里选择要使用的模型。MMD 与 VRM 共用同一模型列表。')
+                        description: this.t('tutorial.model_manager.mmd.step1.desc', '在 3D模型（MMD）模式下从这里选择要使用的模型。MMD 与 VRM 共用同一模型列表。')
                     }
                 },
                 {
@@ -519,7 +519,7 @@
                     element: '#live3d-emotion-config-btn',
                     popover: {
                         title: this.t('tutorial.model_manager.mmd.step4.title', '情感配置'),
-                        description: this.t('tutorial.model_manager.mmd.step4.desc', '先选好模型后，可由此进入情感配置，为不同情感设置表现（Live3D 下 MMD 与 VRM 共用此入口）。')
+                        description: this.t('tutorial.model_manager.mmd.step4.desc', '先选好模型后，可由此进入情感配置，为不同情感设置表现（3D模型下 MMD 与 VRM 共用此入口）。')
                     }
                 }
             ];


### PR DESCRIPTION
## 改动概述 / Summary

- 调整 3D 模型入口的新用户默认子类型逻辑：
  - 当已有 `live3d_sub_type` 为 `vrm` 或 `mmd` 时，继续尊重已有选择。
  - 当新用户或配置为空时，首次进入 `3D模型` 默认进入 MMD。
- 调整 3D 模型默认模型选择逻辑：
  - 当前子类型为 MMD 时，优先选择第一个可用 MMD 模型。
  - 如果没有可用 MMD 模型，再回退到旧的默认 VRM 模型。
- 同步模型管理教程 fallback 文案：
  - 将残留的 `Live3D` 备用文案改为 `3D模型`，与当前用户可见文案保持一致。

## 回归报告 / Regression Report

不适用。

本 PR 未修改 `app/`、`main_logic/`、`main_routers/`、`memory/` 下的 Python 文件。

## 不拆分理由 / Why Not Split

不适用。

本 PR 只修改 2 个前端文件，改动范围集中在 3D 模型入口默认逻辑和教程备用文案。

## 测试 / Testing

- `node --check static/js/model_manager.js`
- `node --check static/tutorial/core/page-tutorial-manager.js`
- 手动验证：
  - 清空模型选择缓存后，首次点击 `3D模型` 默认进入 MMD。
  - 已有用户如果保存过 VRM/MMD 选择，仍按已有配置进入。
  - 教程 fallback 文案不再显示 `Live3D`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了 3D 模型切换后的默认选择逻辑，减少在 VRM 和 MMD 之间误判的情况。
  * 当未明确指定子类型时，会更稳定地回退到当前可用的 3D 模型类型。
  * 默认模型选择现在更贴合当前子类型偏好，并提升了自动选中结果的一致性。

* **Documentation**
  * 更新了 MMD 教程中的部分文案，使 3D 模型相关说明更清晰一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->