### PR TITLE
修复 NekoClaw 任务 HUD 在 i18n 就绪前渲染导致的文案加载异常

### DIFF
--- a/static/common-ui-hud.js
+++ b/static/common-ui-hud.js
@@ -2010,7 +2010,15 @@ window.AgentHUD.refreshHudI18n = function () {
 
     const title = document.getElementById('agent-task-hud-title');
     if (title) {
-        title.innerHTML = '<span style="color: var(--neko-popup-accent, #2a7bc4); margin-right: 8px;">⚡</span>' + titleText;
+        // 用 DOM 节点重建（图标 span + 文本节点），避免 innerHTML 拼接触发静态扫描告警；
+        // titleText 是受信任的 i18n 文案，此处仅为规避 innerHTML 用法。
+        title.textContent = '';
+        const icon = document.createElement('span');
+        icon.textContent = '⚡';
+        icon.style.color = 'var(--neko-popup-accent, #2a7bc4)';
+        icon.style.marginRight = '8px';
+        title.appendChild(icon);
+        title.appendChild(document.createTextNode(titleText));
     }
     const stats = document.getElementById('agent-task-hud-stats');
     if (stats) {
@@ -2028,16 +2036,16 @@ window.AgentHUD.refreshHudI18n = function () {
     }
 
     // 用缓存的任务快照重渲染卡片，刷新状态 / 类型 / 终止按钮等文案。
-    // 仅在 HUD 已存在且当前可见时执行：_doUpdateAgentTaskHUD 在 HUD 缺失时会创建、
+    // 仅在 HUD 已存在且当前可见时执行：updateAgentTaskHUD 在 HUD 缺失时会创建、
     // 在有活动任务且隐藏时会自动显示，纯 i18n 重译不应触发这些副作用。
     const hud = document.getElementById('agent-task-hud');
     const hudVisible = !!(hud && hud.style.display !== 'none' && hud.style.opacity !== '0');
-    if (hudVisible && this._latestTasksData && typeof this._doUpdateAgentTaskHUD === 'function') {
+    if (hudVisible && this._latestTasksData && typeof this.updateAgentTaskHUD === 'function') {
         // 卡片走差分更新：_updateTaskCard 仅在状态变化时改状态徽标，且从不更新类型标签 /
         // 卡片终止按钮 title。语言切换而任务状态不变时（例如运行中的 computer_use 任务）
         // 卡片文案会停留旧语言。差分门控是每次 WS 更新的热路径，不宜改动；因此在这条低频的
-        // 重译路径里显式清空已有卡片，交由 _doUpdateAgentTaskHUD 用当前语言重建，完整覆盖
-        // 状态 / 类型 / 终止按钮等本地化字段。
+        // 重译路径里显式清空已有卡片，再走 updateAgentTaskHUD（保留其 RAF 节流，与常规渲染
+        // 管线一致）用当前语言重建，完整覆盖状态 / 类型 / 终止按钮等本地化字段。
         const taskList = document.getElementById('agent-task-list');
         if (taskList) {
             taskList.querySelectorAll('.task-card').forEach((card) => {
@@ -2048,7 +2056,7 @@ window.AgentHUD.refreshHudI18n = function () {
                 card.remove();
             });
         }
-        try { this._doUpdateAgentTaskHUD(); } catch (_) { /* ignore */ }
+        try { this.updateAgentTaskHUD(this._latestTasksData); } catch (_) { /* ignore */ }
     }
 };
 

--- a/static/common-ui-hud.js
+++ b/static/common-ui-hud.js
@@ -2033,6 +2033,21 @@ window.AgentHUD.refreshHudI18n = function () {
     const hud = document.getElementById('agent-task-hud');
     const hudVisible = !!(hud && hud.style.display !== 'none' && hud.style.opacity !== '0');
     if (hudVisible && this._latestTasksData && typeof this._doUpdateAgentTaskHUD === 'function') {
+        // 卡片走差分更新：_updateTaskCard 仅在状态变化时改状态徽标，且从不更新类型标签 /
+        // 卡片终止按钮 title。语言切换而任务状态不变时（例如运行中的 computer_use 任务）
+        // 卡片文案会停留旧语言。差分门控是每次 WS 更新的热路径，不宜改动；因此在这条低频的
+        // 重译路径里显式清空已有卡片，交由 _doUpdateAgentTaskHUD 用当前语言重建，完整覆盖
+        // 状态 / 类型 / 终止按钮等本地化字段。
+        const taskList = document.getElementById('agent-task-list');
+        if (taskList) {
+            taskList.querySelectorAll('.task-card').forEach((card) => {
+                const descRow = card.querySelector('.task-card-desc');
+                if (descRow && window.NekoTooltip && typeof window.NekoTooltip.destroyFor === 'function') {
+                    try { window.NekoTooltip.destroyFor(descRow); } catch (_) { /* ignore */ }
+                }
+                card.remove();
+            });
+        }
         try { this._doUpdateAgentTaskHUD(); } catch (_) { /* ignore */ }
     }
 };

--- a/static/common-ui-hud.js
+++ b/static/common-ui-hud.js
@@ -1994,3 +1994,53 @@ window.AgentHUD._setupDragging = function (hud) {
     `;
     document.head.appendChild(style);
 })();
+
+// ===== i18n 就绪 / 语言切换后重译任务 HUD 外壳 =====
+// HUD 外壳文案（标题 / 统计 / 折叠·终止按钮 title / 空态文本）由 createAgentTaskHUD
+// 用 window.t 直接写入且没有 data-i18n 属性，因此 i18n 的 updatePageTexts() 不会重译它们。
+// 当 HUD 在 i18n 初始化完成前就抢先构建时（典型场景：启动时后端恢复了上次 NekoClaw 会话的
+// 任务，agenthud 页面拉到 active_tasks 后立即渲染 HUD），这些外壳文案会停留在初始兜底态，
+// 表现为「i18n 文字加载异常」。这里监听 localechange（i18n 初始化完成及语言切换时派发），
+// 补一次外壳重译，并用缓存快照刷新任务卡片状态/类型文案。
+window.AgentHUD.refreshHudI18n = function () {
+    if (typeof window.t !== 'function') return;
+    // 仅当 i18n 真正解析出翻译（而非降级返回 key）时才重译，避免把兜底文案覆盖成 key。
+    const titleText = window.t('agent.taskHud.title');
+    if (!titleText || titleText === 'agent.taskHud.title') return;
+
+    const title = document.getElementById('agent-task-hud-title');
+    if (title) {
+        title.innerHTML = '<span style="color: var(--neko-popup-accent, #2a7bc4); margin-right: 8px;">⚡</span>' + titleText;
+    }
+    const stats = document.getElementById('agent-task-hud-stats');
+    if (stats) {
+        const labelled = stats.querySelectorAll('span[title]');
+        if (labelled[0]) labelled[0].title = window.t('agent.taskHud.running');
+        if (labelled[1]) labelled[1].title = window.t('agent.taskHud.queued');
+    }
+    const minimizeBtn = document.getElementById('agent-task-hud-minimize');
+    if (minimizeBtn) minimizeBtn.title = window.t('agent.taskHud.minimize');
+    const cancelBtn = document.getElementById('agent-task-hud-cancel');
+    if (cancelBtn) cancelBtn.title = window.t('agent.taskHud.cancelAll');
+    const emptyState = document.getElementById('agent-task-empty');
+    if (emptyState && emptyState.firstElementChild) {
+        emptyState.firstElementChild.textContent = window.t('agent.taskHud.noTasks');
+    }
+
+    // 用缓存的任务快照重渲染卡片，刷新状态 / 类型 / 终止按钮等文案。
+    // 仅在 HUD 已存在且当前可见时执行：_doUpdateAgentTaskHUD 在 HUD 缺失时会创建、
+    // 在有活动任务且隐藏时会自动显示，纯 i18n 重译不应触发这些副作用。
+    const hud = document.getElementById('agent-task-hud');
+    const hudVisible = !!(hud && hud.style.display !== 'none' && hud.style.opacity !== '0');
+    if (hudVisible && this._latestTasksData && typeof this._doUpdateAgentTaskHUD === 'function') {
+        try { this._doUpdateAgentTaskHUD(); } catch (_) { /* ignore */ }
+    }
+};
+
+window.addEventListener('localechange', function () {
+    try {
+        if (window.AgentHUD && typeof window.AgentHUD.refreshHudI18n === 'function') {
+            window.AgentHUD.refreshHudI18n();
+        }
+    } catch (_) { /* ignore */ }
+});


### PR DESCRIPTION
## 问题
上次启动过 NekoClaw 后关闭 N.E.K.O，下次打开时后端会恢复上次会话的活动任务，`agenthud` 页面拉到 `active_tasks` 后会立即渲染任务 HUD。若此时 i18next 尚未完成异步初始化（需拉取语言设置 + 加载语言包），HUD 外壳文案（标题 / 统计 / 折叠·终止按钮 title / 空态文本）由 `createAgentTaskHUD` 用 `window.t` 直接写入且没有 `data-i18n` 属性，`updatePageTexts()` 不会重译它们，于是停留在初始兜底态，表现为「i18n 文字加载异常」。

## 修改
- `static/common-ui-hud.js` 新增 `AgentHUD.refreshHudI18n()` 并监听 `localechange`（i18n 初始化完成与语言切换时派发）：补一次 HUD 外壳文案重译，并用缓存的 `_latestTasksData` 刷新任务卡片状态/类型文案。
- 防护 1：仅当确有翻译（`window.t(key) !== key`）时才重译，避免 i18n 真正失败降级时把兜底文案覆盖成原始 key。
- 防护 2：卡片重渲染仅在 HUD 已存在且可见时执行，避免 `_doUpdateAgentTaskHUD` 的「缺失则创建 / 有任务则自动弹出」副作用在语言切换时误弹 HUD。

## 影响
仅涉及前端 `common-ui-hud.js`，纯增量、幂等、低风险。

## 测试
- [x] 启动过 NekoClaw 后关闭并重开 N.E.K.O，确认任务 HUD 文案正确加载
- [ ] 运行中切换语言，确认 HUD 文案随之刷新
- [ ] 无活动任务时不会误弹 HUD

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增 HUD 的语言切换自动刷新能力：当可用的 i18n 已解析出真实文案时，会重译任务 HUD 的标题、运行/队列统计提示、折叠与终止按钮提示，以及空状态首段文本。
  * 若当前 HUD 正在展示且已有任务数据缓存，会先清理现有任务卡片（含相关提示内容），再按当前语言重建任务卡片。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->