### PR TITLE
修复完整聊天窗口在关闭语音模式后输入栏和功能菜单不恢复的问题。

### DIFF
--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -1929,6 +1929,8 @@
     var VOICE_CONFIG_SWITCH_STALE_MS = 45000;
     var _voiceConfigSwitchOps = {};
     var _voiceConfigSwitchWaiters = [];
+    var _pendingVoiceChatComposerHiddenByLanlan = {};
+    var VOICE_CHAT_COMPOSER_PENDING_STALE_MS = 30000;
 
     function getCurrentLanlanName() {
         try {
@@ -1987,25 +1989,73 @@
         postVoiceChatComposerHiddenElectron(payload);
     }
 
+    function getVoiceChatComposerHiddenMessageTimestamp(data) {
+        var timestamp = Number(data && data.timestamp);
+        return Number.isFinite(timestamp) ? timestamp : Date.now();
+    }
+
+    function prunePendingVoiceChatComposerHiddenMessages(now) {
+        now = now || Date.now();
+        Object.keys(_pendingVoiceChatComposerHiddenByLanlan).forEach(function (lanlanName) {
+            var data = _pendingVoiceChatComposerHiddenByLanlan[lanlanName];
+            if (!data || now - getVoiceChatComposerHiddenMessageTimestamp(data) > VOICE_CHAT_COMPOSER_PENDING_STALE_MS) {
+                delete _pendingVoiceChatComposerHiddenByLanlan[lanlanName];
+            }
+        });
+    }
+
+    function rememberPendingVoiceChatComposerHiddenMessage(data) {
+        if (!data || !data.lanlan_name) return false;
+        var lanlanName = String(data.lanlan_name);
+        var timestamp = getVoiceChatComposerHiddenMessageTimestamp(data);
+        prunePendingVoiceChatComposerHiddenMessages(timestamp);
+        var previous = _pendingVoiceChatComposerHiddenByLanlan[lanlanName];
+        if (!previous || timestamp >= getVoiceChatComposerHiddenMessageTimestamp(previous)) {
+            _pendingVoiceChatComposerHiddenByLanlan[lanlanName] = Object.assign({}, data, {
+                timestamp: timestamp
+            });
+        }
+        return true;
+    }
+
+    function applyVoiceComposerHiddenFromActive(active) {
+        var requestedHidden = !!active;
+        if (S) {
+            S.voiceChatActive = requestedHidden;
+        }
+        var effectiveHidden = requestedHidden || (!requestedHidden && shouldKeepVoiceComposerHidden());
+        if (S) {
+            S.voiceChatActive = effectiveHidden;
+        }
+        applyVoiceChatComposerHidden(effectiveHidden);
+        return effectiveHidden;
+    }
+
     function isVoiceChatComposerHiddenMessageForCurrentLanlan(data) {
         if (!data || !data.lanlan_name) return true;
         var currentName = getCurrentLanlanName();
-        if (currentName) return data.lanlan_name === currentName;
-        return data.active === false;
+        return !!currentName && data.lanlan_name === currentName;
     }
 
-    function handleVoiceChatComposerHiddenMessage(data, via) {
+    function handleVoiceChatComposerHiddenMessage(data) {
         if (!data || data.action !== 'voice_chat_active') return false;
+        if (data.lanlan_name && !getCurrentLanlanName()) {
+            rememberPendingVoiceChatComposerHiddenMessage(data);
+            return true;
+        }
         if (!isVoiceChatComposerHiddenMessageForCurrentLanlan(data)) return true;
-        var vcHidden = !!data.active;
-        if (S) {
-            S.voiceChatActive = vcHidden;
-        }
-        var vcEffectiveHidden = vcHidden || (!vcHidden && shouldKeepVoiceComposerHidden());
-        if (S) {
-            S.voiceChatActive = vcEffectiveHidden;
-        }
-        applyVoiceChatComposerHidden(vcEffectiveHidden);
+        applyVoiceComposerHiddenFromActive(data.active);
+        return true;
+    }
+
+    function consumePendingVoiceChatComposerHiddenMessage(lanlanName) {
+        var currentName = lanlanName || getCurrentLanlanName();
+        if (!currentName) return false;
+        prunePendingVoiceChatComposerHiddenMessages(Date.now());
+        var data = _pendingVoiceChatComposerHiddenByLanlan[currentName];
+        if (!data) return false;
+        delete _pendingVoiceChatComposerHiddenByLanlan[currentName];
+        applyVoiceComposerHiddenFromActive(data.active);
         return true;
     }
 
@@ -2259,15 +2309,7 @@
      * @param {boolean} hidden - true 表示收起输入栏；false 表示允许展开输入栏
      */
     function syncVoiceChatComposerHidden(hidden) {
-        var requestedHidden = !!hidden;
-        if (S) {
-            S.voiceChatActive = requestedHidden;
-        }
-        var effectiveHidden = requestedHidden || (!requestedHidden && shouldKeepVoiceComposerHidden());
-        if (S) {
-            S.voiceChatActive = effectiveHidden;
-        }
-        applyVoiceChatComposerHidden(effectiveHidden);
+        var effectiveHidden = applyVoiceComposerHiddenFromActive(hidden);
         // 同步给其它页面（chat.html ↔ index.html）
         postVoiceChatComposerHiddenPayload({
             action: 'voice_chat_active',
@@ -3238,7 +3280,7 @@
                     case 'voice_chat_active': {
                         // 来自另一个窗口的语音对话状态变更，同步本地 React composer 隐藏状态
                         // 校验 lanlan_name：多角色场景下避免串状态
-                        handleVoiceChatComposerHiddenMessage(event.data, 'broadcast');
+                        handleVoiceChatComposerHiddenMessage(event.data);
                         break;
                     }
                     case 'goodbye_chat_composer_hidden': {
@@ -5611,7 +5653,14 @@
     });
 
     window.addEventListener('neko:electron-voice-chat-composer-hidden', function (event) {
-        handleVoiceChatComposerHiddenMessage((event && event.detail) || {}, 'electron-ipc');
+        handleVoiceChatComposerHiddenMessage((event && event.detail) || {});
+    });
+
+    window.addEventListener('neko:config-injected', function (event) {
+        var detail = (event && event.detail) || {};
+        consumePendingVoiceChatComposerHiddenMessage(
+            getCurrentLanlanName() || detail.lanlan_name || ''
+        );
     });
 
     window.addEventListener('message', function (event) {
@@ -5750,8 +5799,10 @@
     mod.cleanupPNGTuberOverlayUI = cleanupPNGTuberOverlayUI;
     mod.syncVoiceChatComposerHidden = syncVoiceChatComposerHidden;
     mod.shouldKeepVoiceComposerHidden = shouldKeepVoiceComposerHidden;
+    mod.applyVoiceComposerHiddenFromActive = applyVoiceComposerHiddenFromActive;
     mod.postVoiceChatComposerHiddenElectron = postVoiceChatComposerHiddenElectron;
     mod.handleVoiceChatComposerHiddenMessage = handleVoiceChatComposerHiddenMessage;
+    mod.consumePendingVoiceChatComposerHiddenMessage = consumePendingVoiceChatComposerHiddenMessage;
     mod.applyGoodbyeChatComposerHidden = applyGoodbyeChatComposerHidden;
     mod.postGoodbyeChatComposerHiddenElectron = postGoodbyeChatComposerHiddenElectron;
     mod.handleGoodbyeChatComposerHiddenMessage = handleGoodbyeChatComposerHiddenMessage;

--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -1965,6 +1965,50 @@
         }
     }
 
+    function getVoiceChatComposerHiddenElectronBridge() {
+        var bridge = window.nekoElectronVoiceChatComposerHidden;
+        return bridge && typeof bridge.send === 'function' ? bridge : null;
+    }
+
+    function postVoiceChatComposerHiddenElectron(payload) {
+        var bridge = getVoiceChatComposerHiddenElectronBridge();
+        if (!bridge) return false;
+        try {
+            bridge.send(payload || {});
+            return true;
+        } catch (err) {
+            console.warn('[VoiceChat] Electron composer hidden bridge failed:', err);
+            return false;
+        }
+    }
+
+    function postVoiceChatComposerHiddenPayload(payload) {
+        postInterpageMessage(payload);
+        postVoiceChatComposerHiddenElectron(payload);
+    }
+
+    function isVoiceChatComposerHiddenMessageForCurrentLanlan(data) {
+        if (!data || !data.lanlan_name) return true;
+        var currentName = getCurrentLanlanName();
+        if (currentName) return data.lanlan_name === currentName;
+        return data.active === false;
+    }
+
+    function handleVoiceChatComposerHiddenMessage(data, via) {
+        if (!data || data.action !== 'voice_chat_active') return false;
+        if (!isVoiceChatComposerHiddenMessageForCurrentLanlan(data)) return true;
+        var vcHidden = !!data.active;
+        if (S) {
+            S.voiceChatActive = vcHidden;
+        }
+        var vcEffectiveHidden = vcHidden || (!vcHidden && shouldKeepVoiceComposerHidden());
+        if (S) {
+            S.voiceChatActive = vcEffectiveHidden;
+        }
+        applyVoiceChatComposerHidden(vcEffectiveHidden);
+        return true;
+    }
+
     function readGoodbyeChatComposerHidden() {
         try {
             if (typeof window.isNekoGoodbyeModeActive === 'function'
@@ -2225,7 +2269,7 @@
         }
         applyVoiceChatComposerHidden(effectiveHidden);
         // 同步给其它页面（chat.html ↔ index.html）
-        postInterpageMessage({
+        postVoiceChatComposerHiddenPayload({
             action: 'voice_chat_active',
             active: effectiveHidden,
             lanlan_name: getCurrentLanlanName(),
@@ -3194,17 +3238,7 @@
                     case 'voice_chat_active': {
                         // 来自另一个窗口的语音对话状态变更，同步本地 React composer 隐藏状态
                         // 校验 lanlan_name：多角色场景下避免串状态
-                        var vcCurrentName = getCurrentLanlanName();
-                        if (event.data.lanlan_name && (!vcCurrentName || event.data.lanlan_name !== vcCurrentName)) break;
-                        var vcHidden = !!event.data.active;
-                        if (S) {
-                            S.voiceChatActive = vcHidden;
-                        }
-                        var vcEffectiveHidden = vcHidden || (!vcHidden && shouldKeepVoiceComposerHidden());
-                        if (S) {
-                            S.voiceChatActive = vcEffectiveHidden;
-                        }
-                        applyVoiceChatComposerHidden(vcEffectiveHidden);
+                        handleVoiceChatComposerHiddenMessage(event.data, 'broadcast');
                         break;
                     }
                     case 'goodbye_chat_composer_hidden': {
@@ -5576,6 +5610,10 @@
         handleGoodbyeChatComposerHiddenMessage((event && event.detail) || {}, 'electron-ipc');
     });
 
+    window.addEventListener('neko:electron-voice-chat-composer-hidden', function (event) {
+        handleVoiceChatComposerHiddenMessage((event && event.detail) || {}, 'electron-ipc');
+    });
+
     window.addEventListener('message', function (event) {
         if (event.origin !== window.location.origin) {
             console.warn('[Security] 拒绝来自不同源的 idle_activity 消息:', event.origin);
@@ -5712,6 +5750,8 @@
     mod.cleanupPNGTuberOverlayUI = cleanupPNGTuberOverlayUI;
     mod.syncVoiceChatComposerHidden = syncVoiceChatComposerHidden;
     mod.shouldKeepVoiceComposerHidden = shouldKeepVoiceComposerHidden;
+    mod.postVoiceChatComposerHiddenElectron = postVoiceChatComposerHiddenElectron;
+    mod.handleVoiceChatComposerHiddenMessage = handleVoiceChatComposerHiddenMessage;
     mod.applyGoodbyeChatComposerHidden = applyGoodbyeChatComposerHidden;
     mod.postGoodbyeChatComposerHiddenElectron = postGoodbyeChatComposerHiddenElectron;
     mod.handleGoodbyeChatComposerHiddenMessage = handleGoodbyeChatComposerHiddenMessage;

--- a/static/voice-chat-composer-hidden-contract.test.cjs
+++ b/static/voice-chat-composer-hidden-contract.test.cjs
@@ -4,8 +4,144 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
+const vm = require('node:vm');
 
 const source = fs.readFileSync(path.join(__dirname, 'app-interpage.js'), 'utf8');
+
+function createEventTarget() {
+    const listeners = new Map();
+    return {
+        addEventListener(type, handler) {
+            if (!listeners.has(type)) listeners.set(type, []);
+            listeners.get(type).push(handler);
+        },
+        removeEventListener(type, handler) {
+            const list = listeners.get(type);
+            if (!list) return;
+            const index = list.indexOf(handler);
+            if (index !== -1) list.splice(index, 1);
+        },
+        dispatchEvent(event) {
+            const list = listeners.get(event && event.type) || [];
+            for (const handler of list.slice()) {
+                handler.call(this, event);
+            }
+            return true;
+        },
+    };
+}
+
+function loadHarness() {
+    const windowTarget = createEventTarget();
+    const documentTarget = createEventTarget();
+    let composerHidden = null;
+    const localStorageData = new Map();
+    const document = Object.assign(documentTarget, {
+        hidden: false,
+        visibilityState: 'visible',
+        body: createEventTarget(),
+        documentElement: { classList: { add() {}, remove() {} }, style: {} },
+        getElementById() { return null; },
+        querySelector() { return null; },
+        querySelectorAll() { return []; },
+        createElement() {
+            return Object.assign(createEventTarget(), {
+                style: {},
+                classList: { add() {}, remove() {}, contains() { return false; } },
+                appendChild() {},
+                setAttribute() {},
+                removeAttribute() {},
+            });
+        },
+    });
+    function CustomEvent(type, options) {
+        this.type = type;
+        this.detail = options && options.detail;
+    }
+    const window = Object.assign(windowTarget, {
+        window: null,
+        document,
+        console,
+        location: { pathname: '/chat_full', origin: 'http://localhost', search: '', href: 'http://localhost/chat_full' },
+        appState: {
+            lanlan_name: '',
+            isRecording: false,
+            voiceChatActive: false,
+            voiceStartPending: false,
+        },
+        appConst: {},
+        appUtils: { isMobile: () => false },
+        reactChatWindowHost: {
+            setComposerHidden(hidden) {
+                composerHidden = !!hidden;
+            },
+        },
+        YuiGuideCommon: {
+            createScopedTutorialResources() {
+                return {
+                    addEventListener(target, type, handler, options) {
+                        target.addEventListener(type, handler, options);
+                        return handler;
+                    },
+                    setTimeout: () => 0,
+                    clearTimeout() {},
+                    setInterval: () => 0,
+                    clearInterval() {},
+                    destroy() {},
+                };
+            },
+        },
+        CustomEvent,
+        localStorage: {
+            getItem(key) { return localStorageData.get(key) || null; },
+            setItem(key, value) { localStorageData.set(key, String(value)); },
+            removeItem(key) { localStorageData.delete(key); },
+        },
+        sessionStorage: {
+            getItem() { return null; },
+            setItem() {},
+            removeItem() {},
+        },
+        navigator: { language: 'en-US' },
+        setTimeout: () => 0,
+        clearTimeout() {},
+        setInterval: () => 0,
+        clearInterval() {},
+        requestAnimationFrame: () => 0,
+        cancelAnimationFrame() {},
+        getComputedStyle() { return {}; },
+    });
+    window.window = window;
+    const context = {
+        window,
+        document,
+        console,
+        CustomEvent,
+        Date,
+        Math,
+        Object,
+        Array,
+        String,
+        Number,
+        Boolean,
+        URLSearchParams,
+        setTimeout: window.setTimeout,
+        clearTimeout: window.clearTimeout,
+        setInterval: window.setInterval,
+        clearInterval: window.clearInterval,
+        requestAnimationFrame: window.requestAnimationFrame,
+        cancelAnimationFrame: window.cancelAnimationFrame,
+        localStorage: window.localStorage,
+        sessionStorage: window.sessionStorage,
+    };
+    vm.runInNewContext(source, context, { filename: 'app-interpage.js' });
+    return {
+        window,
+        get composerHidden() {
+            return composerHidden;
+        },
+    };
+}
 
 test('voice chat composer sync posts through BroadcastChannel and Electron bridge', () => {
     assert.match(source, /function getVoiceChatComposerHiddenElectronBridge\(\)/);
@@ -17,14 +153,55 @@ test('voice chat composer sync posts through BroadcastChannel and Electron bridg
 });
 
 test('voice chat composer sync handles Electron restore events without rebroadcasting', () => {
-    assert.match(source, /function handleVoiceChatComposerHiddenMessage\(data, via\)/);
+    assert.match(source, /function handleVoiceChatComposerHiddenMessage\(data\)/);
     assert.match(source, /window\.addEventListener\('neko:electron-voice-chat-composer-hidden'/);
-    assert.match(source, /handleVoiceChatComposerHiddenMessage\(\(event && event\.detail\) \|\| \{\}, 'electron-ipc'\);/);
+    assert.match(source, /handleVoiceChatComposerHiddenMessage\(\(event && event\.detail\) \|\| \{\}\);/);
 });
 
-test('voice chat composer restore is allowed before full chat config hydration', () => {
+test('voice chat composer state is buffered before full chat config hydration', () => {
     assert.match(
         source,
-        /function isVoiceChatComposerHiddenMessageForCurrentLanlan\(data\) \{[\s\S]*?if \(currentName\) return data\.lanlan_name === currentName;[\s\S]*?return data\.active === false;[\s\S]*?\}/,
+        /function handleVoiceChatComposerHiddenMessage\(data\) \{[\s\S]*?if \(data\.lanlan_name && !getCurrentLanlanName\(\)\) \{[\s\S]*?rememberPendingVoiceChatComposerHiddenMessage\(data\);[\s\S]*?return true;[\s\S]*?\}/,
     );
+    assert.doesNotMatch(source, /return data\.active === false;/);
+});
+
+test('voice chat composer handler buffers scoped restore until matching config arrives', () => {
+    const harness = loadHarness();
+    assert.equal(harness.composerHidden, null);
+
+    assert.equal(harness.window.appInterpage.handleVoiceChatComposerHiddenMessage({
+        action: 'voice_chat_active',
+        active: false,
+        lanlan_name: 'A',
+        timestamp: Date.now(),
+    }), true);
+    assert.equal(harness.composerHidden, null);
+
+    harness.window.dispatchEvent(new harness.window.CustomEvent('neko:config-injected', {
+        detail: { lanlan_name: 'B' },
+    }));
+    assert.equal(harness.composerHidden, null);
+
+    harness.window.appState.lanlan_name = 'A';
+    harness.window.lanlan_config = { lanlan_name: 'A' };
+    harness.window.dispatchEvent(new harness.window.CustomEvent('neko:config-injected', {
+        detail: { lanlan_name: 'A' },
+    }));
+    assert.equal(harness.composerHidden, false);
+    assert.equal(harness.window.appState.voiceChatActive, false);
+});
+
+test('voice chat composer helper applies active state through the shared effective-hidden path', () => {
+    const harness = loadHarness();
+    harness.window.appState.lanlan_name = 'A';
+    harness.window.lanlan_config = { lanlan_name: 'A' };
+
+    harness.window.appInterpage.applyVoiceComposerHiddenFromActive(true);
+    assert.equal(harness.composerHidden, true);
+    assert.equal(harness.window.appState.voiceChatActive, true);
+
+    harness.window.appInterpage.applyVoiceComposerHiddenFromActive(false);
+    assert.equal(harness.composerHidden, false);
+    assert.equal(harness.window.appState.voiceChatActive, false);
 });

--- a/static/voice-chat-composer-hidden-contract.test.cjs
+++ b/static/voice-chat-composer-hidden-contract.test.cjs
@@ -1,0 +1,30 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const source = fs.readFileSync(path.join(__dirname, 'app-interpage.js'), 'utf8');
+
+test('voice chat composer sync posts through BroadcastChannel and Electron bridge', () => {
+    assert.match(source, /function getVoiceChatComposerHiddenElectronBridge\(\)/);
+    assert.match(source, /function postVoiceChatComposerHiddenElectron\(payload\)/);
+    assert.match(source, /function postVoiceChatComposerHiddenPayload\(payload\)/);
+    assert.match(source, /postInterpageMessage\(payload\);/);
+    assert.match(source, /postVoiceChatComposerHiddenElectron\(payload\);/);
+    assert.match(source, /postVoiceChatComposerHiddenPayload\(\{\s*action: 'voice_chat_active'/);
+});
+
+test('voice chat composer sync handles Electron restore events without rebroadcasting', () => {
+    assert.match(source, /function handleVoiceChatComposerHiddenMessage\(data, via\)/);
+    assert.match(source, /window\.addEventListener\('neko:electron-voice-chat-composer-hidden'/);
+    assert.match(source, /handleVoiceChatComposerHiddenMessage\(\(event && event\.detail\) \|\| \{\}, 'electron-ipc'\);/);
+});
+
+test('voice chat composer restore is allowed before full chat config hydration', () => {
+    assert.match(
+        source,
+        /function isVoiceChatComposerHiddenMessageForCurrentLanlan\(data\) \{[\s\S]*?if \(currentName\) return data\.lanlan_name === currentName;[\s\S]*?return data\.active === false;[\s\S]*?\}/,
+    );
+});


### PR DESCRIPTION
## 改动概述 / Summary

修复完整聊天窗口在关闭语音模式后输入栏和功能菜单不恢复的问题。

配套 PC PR：[Project-N-E-K-O/N.E.K.O.-PC#303](https://github.com/Project-N-E-K-O/N.E.K.O.-PC/pull/303)

本体侧改动：
- 为 `voice_chat_active` composer 隐藏状态增加 Electron bridge 发送路径，保留原 BroadcastChannel 同步。
- 统一 BroadcastChannel / Electron IPC 收到状态后的处理逻辑。
- 完整聊天窗口在角色配置尚未注入时，按 `lanlan_name` 暂存语音 composer 状态，并在 `neko:config-injected` 后只消费当前角色匹配的状态，避免跨角色恢复。
- 增加合同测试和 VM harness，覆盖发送路径、Electron 接收、hydration 前暂存与匹配配置后恢复。

## 回归报告 / Regression Report

不适用。未触碰 `app/`、`main_logic/`、`memory/` 下的 Python 文件。

## 不拆分理由 / Why Not Split

不适用。计入上限的文件数 ≤ 20。

## 测试 / Testing

- `node --check static/app-interpage.js`
- `node --test static/voice-chat-composer-hidden-contract.test.cjs`