### PR TITLE
上移紧凑 Electron 聊天默认位置

### DIFF
--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -386,6 +386,7 @@
     var COMPACT_SURFACE_VIEWPORT_PAD_X = 16;
     var COMPACT_SURFACE_VIEWPORT_PAD_TOP = 12;
     var COMPACT_SURFACE_VIEWPORT_PAD_BOTTOM = 18;
+    var COMPACT_SURFACE_ELECTRON_DEFAULT_BOTTOM_GAP = 320;
     var COMPACT_SURFACE_DEFAULT_HEIGHT = 64;
     var COMPACT_SURFACE_AVATAR_VERTICAL_RATIO = 0.72;
     var COMPACT_SURFACE_POSITION_STORAGE_KEY = 'neko.reactChatWindow.compactSurfacePosition';
@@ -1340,9 +1341,12 @@
         var metrics = getCompactSurfaceMetrics();
         var viewportWidth = window.innerWidth;
         var viewportHeight = window.innerHeight;
+        var fallbackBottomGap = isCompactOnlyElectronChatHost()
+            ? Math.max(COMPACT_SURFACE_VIEWPORT_PAD_BOTTOM, COMPACT_SURFACE_ELECTRON_DEFAULT_BOTTOM_GAP)
+            : COMPACT_SURFACE_VIEWPORT_PAD_BOTTOM;
         var fallbackTop = Math.max(
             COMPACT_SURFACE_VIEWPORT_PAD_TOP,
-            viewportHeight - metrics.height - COMPACT_SURFACE_VIEWPORT_PAD_BOTTOM
+            viewportHeight - metrics.height - fallbackBottomGap
         );
 
         if (isElectronChatWindow()) {

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -132,6 +132,20 @@
         );
     }
 
+    function isElectronChatRuntime() {
+        var body = document.body;
+        return !!(
+            (body && body.classList.contains('neko-electron-runtime')) ||
+            window.nekoChatWindow ||
+            /Electron/i.test(navigator.userAgent || '') ||
+            (window.process && window.process.versions && window.process.versions.electron)
+        );
+    }
+
+    function isCompactOnlyElectronRuntimeChatHost() {
+        return !!(isCompactOnlyElectronChatHost() && isElectronChatRuntime());
+    }
+
     function coerceChatSurfaceModeForHost(mode) {
         var normalized = normalizeChatSurfaceMode(mode);
         // /chat 是 Electron 紧凑宿主；full 由 /chat_full 独立窗口承载，避免历史 full 状态污染透明承载窗。
@@ -1341,7 +1355,7 @@
         var metrics = getCompactSurfaceMetrics();
         var viewportWidth = window.innerWidth;
         var viewportHeight = window.innerHeight;
-        var fallbackBottomGap = isCompactOnlyElectronChatHost()
+        var fallbackBottomGap = isCompactOnlyElectronRuntimeChatHost()
             ? Math.max(COMPACT_SURFACE_VIEWPORT_PAD_BOTTOM, COMPACT_SURFACE_ELECTRON_DEFAULT_BOTTOM_GAP)
             : COMPACT_SURFACE_VIEWPORT_PAD_BOTTOM;
         var fallbackTop = Math.max(


### PR DESCRIPTION
## 改动概述 / Summary

上移紧凑 Electron 聊天宿主的默认 surface fallback 位置，避免冷启动时聊天框贴近任务栏并触发下方选项向上折叠。该默认间距仅作用于 compact Electron chat host，不影响 full chat、网页端或移动端。

## 测试 / Testing

- `node --check static\app-react-chat-window.js`
手动测试

## 另一边
[NEKO_PC](https://github.com/Project-N-E-K-O/N.E.K.O.-PC/pull/304)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化紧凑窗口在桌面应用（Electron）环境中的默认垂直位置，减少贴近底部或显示不完整的问题。
  * 针对紧凑 Electron 聊天运行场景，自动选择更合适的底部留白策略，提升窗口显示稳定性与可读性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->