### PR TITLE
修复完整聊天窗口导出对话按钮误复用 /chat_full 窗口句柄导致预览不弹出的问题，并补充静态契约测试

### DIFF
--- a/static/app-chat-export.js
+++ b/static/app-chat-export.js
@@ -157,8 +157,21 @@
         }
     }
 
+    function isExportPreviewDocumentWindow(win) {
+        if (!win || win.closed || isCurrentChatWindowHandle(win)) return false;
+        try {
+            if (win.__nekoChatExportPreviewWindow === true) return true;
+            return !!(win.document && win.document.body && win.document.body.classList.contains('chat-export-window'));
+        } catch (_) {
+            return false;
+        }
+    }
+
     function isReusableExportPreviewWindow(win) {
-        return !!(win && !win.closed && !isCurrentChatWindowHandle(win) && isExportPreviewShellUrl(getWindowHref(win)));
+        return !!(win
+            && !win.closed
+            && !isCurrentChatWindowHandle(win)
+            && (isExportPreviewShellUrl(getWindowHref(win)) || isExportPreviewDocumentWindow(win)));
     }
 
     function isExportPreviewShellReady(previewWindow, targetUrl) {
@@ -3153,6 +3166,9 @@
         try {
             if (typeof previewWindow.stop === 'function') previewWindow.stop();
         } catch (_) {}
+        try {
+            previewWindow.__nekoChatExportPreviewWindow = true;
+        } catch (_) {}
         var doc = previewWindow.document;
         doc.open();
         doc.write('<!DOCTYPE html><html lang="' + escapeHtml(document.documentElement.lang || 'en') + '"' + getPreviewThemeAttributesHtml() + '><head><meta charset="utf-8">'
@@ -3178,6 +3194,9 @@
             + 'html[data-theme="dark"] body.chat-export-window .chat-export-preview-body,html[data-theme="dark"] body.chat-export-window .chat-export-preview-frame{background:#0f172a;}'
             + '</style></head><body class="chat-export-window"></body></html>');
         doc.close();
+        try {
+            previewWindow.__nekoChatExportPreviewWindow = true;
+        } catch (_) {}
         applyPreviewThemeToDocument(doc);
         previewWindow.focus();
         if (!previewWindow._chatExportBeforeUnloadHandler) {

--- a/static/app-chat-export.js
+++ b/static/app-chat-export.js
@@ -128,6 +128,39 @@
         }
     }
 
+    function getWindowHref(win) {
+        if (!win || win.closed) return '';
+        try {
+            return String(win.location && win.location.href || '');
+        } catch (_) {
+            return '';
+        }
+    }
+
+    function isCurrentChatWindowHandle(win) {
+        if (win === window) return true;
+        try {
+            return !!(win && win.document === document);
+        } catch (_) {
+            return false;
+        }
+    }
+
+    function isExportPreviewShellUrl(href) {
+        if (!href) return false;
+        try {
+            var current = new URL(href, window.location.href);
+            var target = new URL(getExportPreviewShellUrl(), window.location.href);
+            return current.origin === target.origin && current.pathname === target.pathname;
+        } catch (_) {
+            return false;
+        }
+    }
+
+    function isReusableExportPreviewWindow(win) {
+        return !!(win && !win.closed && !isCurrentChatWindowHandle(win) && isExportPreviewShellUrl(getWindowHref(win)));
+    }
+
     function isExportPreviewShellReady(previewWindow, targetUrl) {
         if (!previewWindow || previewWindow.closed) return false;
         try {
@@ -3071,25 +3104,50 @@
 
     async function openExportPreviewWindow() {
         var previewTitle = translateLabel('chat.exportPreviewTitle', 'Export Preview');
-        var isExistingWindow = !!(state.previewWindow && !state.previewWindow.closed);
-        var previewWindow = isExistingWindow
+        var existingPreviewWindow = isReusableExportPreviewWindow(state.previewWindow)
             ? state.previewWindow
-            : window.open(getExportPreviewShellUrl(), 'neko-chat-export-preview', buildExportWindowFeatures());
+            : null;
+        if (state.previewWindow && !existingPreviewWindow && !state.previewWindow.closed) {
+            console.warn('[ChatExport] ignoring stale export preview window handle', {
+                href: getWindowHref(state.previewWindow)
+            });
+            state.previewWindow = null;
+        }
+        var isExistingWindow = !!existingPreviewWindow;
+        var previewWindow = isExistingWindow
+            ? existingPreviewWindow
+            : window.open('', '_blank', buildExportWindowFeatures());
         if (!previewWindow) return null;
+        if (isCurrentChatWindowHandle(previewWindow)) {
+            console.warn('[ChatExport] export preview window resolved to the current chat window; aborting.');
+            if (state.previewWindow === previewWindow) state.previewWindow = null;
+            return null;
+        }
+        var returnedHref = getWindowHref(previewWindow);
+        if (returnedHref && returnedHref !== 'about:blank' && !isExportPreviewShellUrl(returnedHref)) {
+            console.warn('[ChatExport] export preview window returned unexpected handle; aborting.', {
+                href: returnedHref
+            });
+            if (state.previewWindow === previewWindow) state.previewWindow = null;
+            return null;
+        }
 
         if (isExistingWindow) {
             disposePreviewModal(false);
         }
         state.previewWindow = previewWindow;
         if (!isExistingWindow) {
-            var canRewritePreview = await waitForExportPreviewRewriteGate(previewWindow, getExportPreviewShellUrl());
-            if (!previewWindow || previewWindow.closed) return null;
-            if (!canRewritePreview) {
-                if (state.previewWindow === previewWindow) state.previewWindow = null;
-                try {
-                    previewWindow.close();
-                } catch (_) {}
-                return null;
+            var openedShellWindow = isExportPreviewShellUrl(returnedHref);
+            if (openedShellWindow) {
+                var canRewritePreview = await waitForExportPreviewRewriteGate(previewWindow, getExportPreviewShellUrl());
+                if (!previewWindow || previewWindow.closed) return null;
+                if (!canRewritePreview) {
+                    if (state.previewWindow === previewWindow) state.previewWindow = null;
+                    try {
+                        previewWindow.close();
+                    } catch (_) {}
+                    return null;
+                }
             }
         }
         try {

--- a/tests/unit/test_chat_export_static_contracts.py
+++ b/tests/unit/test_chat_export_static_contracts.py
@@ -33,3 +33,24 @@ def test_neko_export_group_time_uses_single_send_time():
 
     assert "return times[0];" in get_group_time
     assert "times[0] + ' - ' + times[times.length - 1]" not in get_group_time
+
+
+def test_export_preview_reuses_only_shell_window_handles():
+    script = CHAT_EXPORT_JS.read_text(encoding="utf-8")
+
+    assert "function isReusableExportPreviewWindow(win)" in script
+    assert "!isCurrentChatWindowHandle(win) && isExportPreviewShellUrl(getWindowHref(win))" in script
+
+    function_start = script.index("async function openExportPreviewWindow()")
+    function_end = script.index("async function openPreviewModal", function_start)
+    open_export = script[function_start:function_end]
+
+    assert "var existingPreviewWindow = isReusableExportPreviewWindow(state.previewWindow)" in open_export
+    assert "state.previewWindow = null;" in open_export
+    assert "function isCurrentChatWindowHandle(win)" in script
+    assert "win.document === document" in script
+    assert "window.open('', '_blank', buildExportWindowFeatures())" in open_export
+    assert "if (isCurrentChatWindowHandle(previewWindow))" in open_export
+    assert "var returnedHref = getWindowHref(previewWindow);" in open_export
+    assert "returnedHref !== 'about:blank' && !isExportPreviewShellUrl(returnedHref)" in open_export
+    assert "var openedShellWindow = isExportPreviewShellUrl(returnedHref);" in open_export

--- a/tests/unit/test_chat_export_static_contracts.py
+++ b/tests/unit/test_chat_export_static_contracts.py
@@ -39,7 +39,10 @@ def test_export_preview_reuses_only_shell_window_handles():
     script = CHAT_EXPORT_JS.read_text(encoding="utf-8")
 
     assert "function isReusableExportPreviewWindow(win)" in script
-    assert "!isCurrentChatWindowHandle(win) && isExportPreviewShellUrl(getWindowHref(win))" in script
+    assert "function isExportPreviewDocumentWindow(win)" in script
+    assert "win.__nekoChatExportPreviewWindow === true" in script
+    assert "classList.contains('chat-export-window')" in script
+    assert "isExportPreviewShellUrl(getWindowHref(win)) || isExportPreviewDocumentWindow(win)" in script
 
     function_start = script.index("async function openExportPreviewWindow()")
     function_end = script.index("async function openPreviewModal", function_start)
@@ -54,3 +57,4 @@ def test_export_preview_reuses_only_shell_window_handles():
     assert "var returnedHref = getWindowHref(previewWindow);" in open_export
     assert "returnedHref !== 'about:blank' && !isExportPreviewShellUrl(returnedHref)" in open_export
     assert "var openedShellWindow = isExportPreviewShellUrl(returnedHref);" in open_export
+    assert "previewWindow.__nekoChatExportPreviewWindow = true;" in open_export


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复完整聊天窗口导出对话按钮误复用 /chat_full 窗口句柄导致预览不弹出的问题，并补充静态契约测试

## 测试 / Testing

手动使用完整聊天框的导出功能


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - 优化导出预览窗口复用：仅复用满足条件的旧窗口句柄，并排除与当前聊天窗口同句柄的情况。
  - 增强预览窗口校验：对 `about:blank` 与导出预览 Shell URL 做分支判断，异常则自动终止并清理。
  - 调整新建窗口的打开与门控校验流程，避免渲染失败或状态错配。
- **Tests**
  - 新增单元测试，覆盖“仅复用 Shell 窗口句柄”的关键契约逻辑。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->