### PR TITLE
记录用户手动停止自动启动插件的状态，避免下次启动时再次自动拉起，并补充路由回归测试

### DIFF
--- a/plugin/server/application/plugins/lifecycle_service.py
+++ b/plugin/server/application/plugins/lifecycle_service.py
@@ -603,6 +603,9 @@ class PluginLifecycleService:
                 error_type="PluginFrozen",
             )
 
+        if persist_user_intent:
+            await asyncio.to_thread(set_runtime_override, current_plugin_id, True)
+
         if refresh_registry:
             try:
                 refresh_payload = await plugin_registry_service.refresh_plugin(current_plugin_id)

--- a/plugin/server/infrastructure/runtime_overrides.py
+++ b/plugin/server/infrastructure/runtime_overrides.py
@@ -1,10 +1,9 @@
 """User-level persistence for per-plugin runtime toggles.
 
 Plugin manifests declare a default ``plugin_runtime.enabled`` value. The plugin
-manager UI lets users override that default at runtime (currently only the
-"Disable / Enable Extension" buttons exposed by ``PluginActions.vue``). Without
-persistence those toggles live only in :data:`plugin.core.state.state.plugins`
-and are lost on restart.
+manager UI lets users override that default at runtime via plugin start/stop and
+extension enable/disable actions. Without persistence those toggles live only in
+:data:`plugin.core.state.state.plugins` and are lost on restart.
 
 This module persists the user-toggled subset to ``plugin_runtime_overrides.json``
 under the user's app config directory (``ConfigManager.config_dir``). On the

--- a/plugin/server/routes/plugins.py
+++ b/plugin/server/routes/plugins.py
@@ -59,7 +59,7 @@ async def refresh_plugin_endpoint(plugin_id: str, _: str = require_admin) -> dic
 @router.post("/plugin/{plugin_id}/stop")
 async def stop_plugin_endpoint(plugin_id: str, _: str = require_admin) -> dict[str, object]:
     try:
-        return await lifecycle_service.stop_plugin(plugin_id, persist_user_intent=False)
+        return await lifecycle_service.stop_plugin(plugin_id, persist_user_intent=True)
     except ServerDomainError as error:
         raise_http_from_domain(error, logger=logger)
 

--- a/plugin/tests/unit/server/test_plugins_lifecycle_service.py
+++ b/plugin/tests/unit/server/test_plugins_lifecycle_service.py
@@ -311,6 +311,85 @@ async def test_start_plugin_refreshes_registry_before_loading(
 
 @pytest.mark.plugin_unit
 @pytest.mark.asyncio
+async def test_start_plugin_persist_user_intent_clears_stop_override_before_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _isolate_runtime_overrides: dict,
+) -> None:
+    config_path = tmp_path / "demo_plugin" / "plugin.toml"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        "\n".join(
+            [
+                "[plugin]",
+                "id = 'demo_plugin'",
+                "name = 'Demo Plugin'",
+                "entry = 'tests.fake:Plugin'",
+                "",
+                "[plugin_runtime]",
+                "enabled = true",
+                "auto_start = true",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    seen: dict[str, object] = {}
+
+    async def _refresh_plugin(plugin_id: str) -> dict[str, object]:
+        seen["override_at_refresh"] = runtime_overrides_module.get_runtime_override(plugin_id)
+        return {"success": True, "plugin_id": plugin_id}
+
+    async def _list_extension_configs_for_host(_plugin_id: str) -> list[dict[str, str]]:
+        return []
+
+    monkeypatch.setattr(module.plugin_registry_service, "refresh_plugin", _refresh_plugin)
+    monkeypatch.setattr(module.plugin_registry_service, "list_extension_configs_for_host", _list_extension_configs_for_host)
+    monkeypatch.setattr(module, "_get_plugin_config_path", lambda _plugin_id: config_path)
+    monkeypatch.setattr(
+        module,
+        "resolve_plugin_config_from_path",
+        lambda *args, **kwargs: {
+            "effective_config": kwargs["base_config"],
+            "warnings": [],
+        },
+    )
+    monkeypatch.setattr(module, "_resolve_plugin_id_conflict", lambda *args, **kwargs: args[0])
+    monkeypatch.setattr(module, "_find_missing_python_requirements", lambda *args, **kwargs: [])
+    monkeypatch.setattr(module, "PluginProcessHost", _FakeProcessHost)
+    monkeypatch.setattr(module, "_import_plugin_module", lambda *args, **kwargs: SimpleNamespace(Plugin=type("Plugin", (), {})))
+    monkeypatch.setattr(module, "emit_lifecycle_event", lambda event: None)
+
+    plugins_backup = copy.deepcopy(module.state.plugins)
+    hosts_backup = dict(module.state.plugin_hosts)
+    cache_backup = copy.deepcopy(module.state._snapshot_cache)
+
+    try:
+        with module.state.acquire_plugins_write_lock():
+            module.state.plugins.clear()
+        with module.state.acquire_plugin_hosts_write_lock():
+            module.state.plugin_hosts.clear()
+
+        runtime_overrides_module.set_runtime_override("demo_plugin", False)
+
+        response = await module.PluginLifecycleService().start_plugin("demo_plugin", persist_user_intent=True)
+
+        assert response["success"] is True
+        assert seen["override_at_refresh"] is True
+        assert _isolate_runtime_overrides == {"demo_plugin": True}
+    finally:
+        with module.state.acquire_plugins_write_lock():
+            module.state.plugins.clear()
+            module.state.plugins.update(plugins_backup)
+        with module.state.acquire_plugin_hosts_write_lock():
+            module.state.plugin_hosts.clear()
+            module.state.plugin_hosts.update(hosts_backup)
+        with module.state._snapshot_cache_lock:
+            module.state._snapshot_cache = cache_backup
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
 async def test_start_plugin_checks_python_requirements_against_vendor_paths(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/plugin/tests/unit/server/test_plugins_route.py
+++ b/plugin/tests/unit/server/test_plugins_route.py
@@ -59,3 +59,25 @@ async def test_delete_plugin_route_delegates_to_lifecycle_service(
         response = await client.delete("/plugin/demo")
         assert response.status_code == 200
         assert response.json()["plugin_id"] == "demo"
+
+
+@pytest.mark.asyncio
+async def test_stop_plugin_route_persists_user_intent(
+    plugin_route_test_app: FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, bool]] = []
+
+    async def _stop_plugin(plugin_id: str, *, persist_user_intent: bool = False) -> dict[str, object]:
+        calls.append((plugin_id, persist_user_intent))
+        return {"success": True, "plugin_id": plugin_id, "message": "stopped"}
+
+    monkeypatch.setattr(route_module.lifecycle_service, "stop_plugin", _stop_plugin)
+
+    transport = ASGITransport(app=plugin_route_test_app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.post("/plugin/demo/stop")
+
+    assert response.status_code == 200
+    assert response.json()["plugin_id"] == "demo"
+    assert calls == [("demo", True)]


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

记录用户手动停止自动启动插件的状态，避免下次启动时再次自动拉起，并补充路由回归测试

## 测试 / Testing

手动关闭测试


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 停止插件时会持久化用户意图，确保重启后启用/禁用状态符合选择。
  * 当以“保留用户意图”启动插件时，会更早应用运行时覆盖，避免刷新阶段状态不一致。
* **Tests**
  * 新增单测覆盖“停止插件”与“启动插件”时用户意图持久化、运行时覆盖的关键行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->