### PR TITLE
feat(steam): 用 Progress Stat 驱动计时成就

### DIFF
--- a/.agent/skills/achievement-system/skill.md
+++ b/.agent/skills/achievement-system/skill.md
@@ -12,14 +12,17 @@
 - 🎯 在代码中集成成就触发点
 - 🧪 测试成就解锁功能
 - 📊 查看成就统计和状态
-- ⏱️ 自动追踪游戏时长（Steam 统计）
+- ⏱️ 基于 Steam Progress Stat（`PLAY_TIME_SECONDS`）自动解锁计时成就
 
 ## 已实现的成就
 
-### 时长相关成就（自动追踪）✅
-1. **ACH_TIME_5MIN** - 茶歇时刻（5分钟）
-2. **ACH_TIME_1HR** - 渐入佳境（1小时）
-3. **ACH_TIME_100HR** - 朝夕相伴（100小时）
+### 时长相关成就（Progress Stat）✅
+1. **ACH_TIME_5MIN** - 茶歇时刻（5分钟 / 300 秒）
+2. **ACH_TIME_1HR** - 渐入佳境（1小时 / 3600 秒）
+3. **ACH_TIME_100HR** - 朝夕相伴（100小时 / 360000 秒）
+
+> 官方推荐：在 Steamworks 后台创建 Stat `PLAY_TIME_SECONDS`，并将上述成就绑定为 Progress Stat（阈值分别为 300 / 3600 / 360000）。
+> 游戏只负责本地累加并定期 `SetStat` + `StoreStats`；Steam 服务器在同步后自动解锁成就。
 
 ### 一次性成就
 4. **ACH_FIRST_DIALOGUE** - 初次邂逅 ✅
@@ -38,12 +41,13 @@
 
 1. **前端成就管理器**
    - 文件：`static/achievement_manager.js`
-   - 功能：统一管理所有成就的定义、解锁逻辑、计数器追踪
+   - 功能：统一管理所有成就的定义、解锁逻辑、计数器追踪；计时成就由主窗口/Pet 本地累加并每 60s / 页面隐藏时上报 Progress Stat（Chat 窗口不重复上报，避免双倍计时）
 
 2. **后端 API**
    - 文件：`main_routers/system_router.py`
-   - 端点：`/api/steam/set-achievement-status/{name}`
-   - 功能：调用 Steamworks API 解锁成就
+   - 端点：
+     - `/api/steam/set-achievement-status/{name}` — 显式解锁（一次性/计数型）
+     - `/api/steam/update-playtime` — 累加 `PLAY_TIME_SECONDS` 并 `StoreStats`（**不**调用 `SetAchievement`）
 
 3. **Steam SDK**
    - 文件：`steamworks/interfaces/userstats.py`
@@ -67,6 +71,24 @@ steamworks.UserStats.SetAchievement()
 steamworks.UserStats.StoreStats()
     ↓
 Steam 客户端弹出成就通知 🎉
+```
+
+### 计时成就流程（Progress Stat）
+
+```text
+achievement_manager.js
+    ├─ 本地累加会话秒数
+    ├─ 每 60s / pagehide / visibility hidden
+    └─ POST /api/steam/update-playtime {seconds}
+         ↓
+system_router.py
+    ├─ GetStatInt(PLAY_TIME_SECONDS)
+    ├─ SetStat(PLAY_TIME_SECONDS, current + seconds)
+    ├─ StoreStats() + run_callbacks()
+    └─ 读取 progressUnlocked（Steam 已自动解锁的 ACH_TIME_*）
+         ↓
+Steam 服务器：Stat 达绑定阈值 → 自动解锁成就并弹窗
+前端：仅同步本地缓存 / toast，不主动 SetAchievement
 ```
 
 ## 成就类型
@@ -199,9 +221,10 @@ window.addEventListener('achievement-unlocked', (e) => {
 
 1. **成就只能解锁，不能撤销** - 一旦解锁，无法通过代码撤销
 2. **Steam 客户端必须运行** - 否则成就解锁会失败
-3. **本地存储同步** - 计数器存储在 localStorage，清除浏览器数据会重置
-4. **防重复解锁** - 成就管理器会自动检查，避免重复调用 API
-5. **跨窗口通信** - 子窗口需要通过 `window.parent` 或 `window.opener` 访问主窗口的成就管理器
+3. **计时成就依赖 Steamworks Progress Stat 绑定** - 后台需创建 `PLAY_TIME_SECONDS` 并将 `ACH_TIME_*` 绑定阈值；游戏侧只上报 Stat，不主动 `SetAchievement`
+4. **本地存储同步** - 计数器存储在 localStorage，清除浏览器数据会重置
+5. **防重复解锁** - 成就管理器会自动检查，避免重复调用 API
+6. **跨窗口通信** - 子窗口需要通过 `window.parent` 或 `window.opener` 访问主窗口的成就管理器
 
 ## 示例：添加一个新成就
 

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -4089,6 +4089,10 @@ async def update_playtime(request: Request):
     seconds_to_add = min(seconds_to_add, 3600)
 
     try:
+        # Ensure Steam has delivered current stats before read/modify/write;
+        # otherwise GetStatInt may return 0 and StoreStats would clobber progress.
+        await _prepare_steam_user_stats(steamworks)
+
         try:
             current_playtime = steamworks.UserStats.GetStatInt(_PLAYTIME_PROGRESS_STAT)
         except Exception as e:
@@ -4149,7 +4153,7 @@ async def update_playtime(request: Request):
             "progressUnlocked": progress_unlocked,
         })
     except Exception as e:
-        logger.error(f"更新游戏时长失败: {e}")
+        logger.error("更新游戏时长失败: %s", e)
         return JSONResponse(content={"success": False, "error": str(e)}, status_code=500)
 
 

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -3946,6 +3946,79 @@ async def emotion_analysis(request: Request):
         }
 
 
+# Progress Stat for timed achievements. Steamworks Partner must bind
+# ACH_TIME_* achievements to this stat with matching thresholds; Steam unlocks
+# them automatically when StoreStats syncs a value past the bound threshold.
+_PLAYTIME_PROGRESS_STAT = "PLAY_TIME_SECONDS"
+_PLAYTIME_PROGRESS_ACHIEVEMENTS: tuple[str, ...] = (
+    "ACH_TIME_5MIN",
+    "ACH_TIME_1HR",
+    "ACH_TIME_100HR",
+)
+
+
+async def _prepare_steam_user_stats(steamworks: Any) -> None:
+    steamworks.UserStats.RequestCurrentStats()
+    for _ in range(10):
+        steamworks.run_callbacks()
+        await asyncio.sleep(0.1)
+
+
+async def _unlock_steam_achievement(steamworks: Any, name: str) -> dict[str, Any]:
+    """Unlock one Steam achievement. Returns a status dict (no HTTP response)."""
+    await _prepare_steam_user_stats(steamworks)
+    achievement_status = steamworks.UserStats.GetAchievement(name)
+    logger.info("Achievement status: %s=%s", name, achievement_status)
+    if achievement_status:
+        return {
+            "success": True,
+            "achievement": name,
+            "newlyUnlocked": False,
+            "alreadyUnlocked": True,
+            "message": f"成就 {name} 已经解锁",
+        }
+
+    result = steamworks.UserStats.SetAchievement(name)
+    if not result:
+        logger.warning("设置成就首次尝试失败，正在重试: %s", name)
+        await asyncio.sleep(0.5)
+        steamworks.run_callbacks()
+        result = steamworks.UserStats.SetAchievement(name)
+
+    if not result:
+        logger.error("设置成就失败: %s，请确认成就ID在Steam后台已配置", name)
+        return {
+            "success": False,
+            "achievement": name,
+            "newlyUnlocked": False,
+            "alreadyUnlocked": False,
+            "error": f"设置成就失败: {name}，请确认成就ID在Steam后台已配置",
+        }
+
+    steamworks.UserStats.StoreStats()
+    steamworks.run_callbacks()
+    logger.info("成功设置成就: %s", name)
+    return {
+        "success": True,
+        "achievement": name,
+        "newlyUnlocked": True,
+        "alreadyUnlocked": False,
+        "message": f"成就 {name} 已解锁",
+    }
+
+
+def _read_progress_unlocked_achievements(steamworks: Any) -> list[str]:
+    """Read which progress-stat achievements Steam has already unlocked."""
+    unlocked: list[str] = []
+    for achievement_name in _PLAYTIME_PROGRESS_ACHIEVEMENTS:
+        try:
+            if steamworks.UserStats.GetAchievement(achievement_name):
+                unlocked.append(achievement_name)
+        except Exception as exc:
+            logger.debug("读取进度成就状态失败 %s: %s", achievement_name, exc)
+    return unlocked
+
+
 @router.post('/steam/set-achievement-status/{name}')
 async def set_achievement_status(name: str, request: Request):
     """
@@ -3954,158 +4027,130 @@ async def set_achievement_status(name: str, request: Request):
     - receives the achievement name as a path parameter and sets the achievement via the Steamworks API
     - first requests current stats and runs callbacks to ensure the data is loaded
     - checks the achievement's current state; if already unlocked, returns success directly
-    - if not unlocked, tries to set it; returns success if it works, otherwise waits 1 second and retries
-    - retries at most 10 times; if still failing, returns an error hinting at possible configuration issues
+    - if not unlocked, tries to set it; returns success if it works, otherwise waits and retries once
     """
     validation_error = _validate_local_mutation_request(request)
     if validation_error is not None:
         return validation_error
 
     steamworks = get_steamworks()
-    if steamworks is not None:
-        try:
-            # 先请求统计数据并运行回调，确保数据已加载
-            steamworks.UserStats.RequestCurrentStats()
-            # 运行回调等待数据加载（多次运行以确保接收到响应）
-            for _ in range(10):
-                steamworks.run_callbacks()
-                await asyncio.sleep(0.1)
-            
-            achievement_status = steamworks.UserStats.GetAchievement(name)
-            logger.info(f"Achievement status: {achievement_status}")
-            if not achievement_status:
-                result = steamworks.UserStats.SetAchievement(name)
-                if result:
-                    logger.info(f"成功设置成就: {name}")
-                    steamworks.UserStats.StoreStats()
-                    steamworks.run_callbacks()
-                    return JSONResponse(content={
-                        "success": True,
-                        "achievement": name,
-                        "newlyUnlocked": True,
-                        "alreadyUnlocked": False,
-                        "message": f"成就 {name} 已解锁",
-                    })
-                else:
-                    # 第一次失败，等待后重试一次
-                    logger.warning(f"设置成就首次尝试失败，正在重试: {name}")
-                    await asyncio.sleep(0.5)
-                    steamworks.run_callbacks()
-                    result = steamworks.UserStats.SetAchievement(name)
-                    if result:
-                        logger.info(f"成功设置成就（重试后）: {name}")
-                        steamworks.UserStats.StoreStats()
-                        steamworks.run_callbacks()
-                        return JSONResponse(content={
-                            "success": True,
-                            "achievement": name,
-                            "newlyUnlocked": True,
-                            "alreadyUnlocked": False,
-                            "message": f"成就 {name} 已解锁",
-                        })
-                    else:
-                        logger.error(f"设置成就失败: {name}，请确认成就ID在Steam后台已配置")
-                        return JSONResponse(content={"success": False, "error": f"设置成就失败: {name}，请确认成就ID在Steam后台已配置"}, status_code=500)
-            else:
-                logger.info(f"成就已解锁，无需重复设置: {name}")
-                return JSONResponse(content={
-                    "success": True,
-                    "achievement": name,
-                    "newlyUnlocked": False,
-                    "alreadyUnlocked": True,
-                    "message": f"成就 {name} 已经解锁",
-                })
-        except Exception as e:
-            logger.error(f"设置成就失败: {e}")
-            return JSONResponse(content={"success": False, "error": str(e)}, status_code=500)
-    else:
+    if steamworks is None:
         return JSONResponse(content={"success": False, "error": "Steamworks未初始化"}, status_code=503)
+
+    try:
+        result = await _unlock_steam_achievement(steamworks, name)
+        if not result.get("success"):
+            return JSONResponse(content=result, status_code=500)
+        return JSONResponse(content=result)
+    except Exception as e:
+        logger.error(f"设置成就失败: {e}")
+        return JSONResponse(content={"success": False, "error": str(e)}, status_code=500)
 
 
 @router.post('/steam/update-playtime')
 async def update_playtime(request: Request):
     """
-    Update playtime statistics (PLAY_TIME_SECONDS).
+    Accumulate PLAY_TIME_SECONDS progress stat and StoreStats.
+
+    Timed achievements (ACH_TIME_*) must be bound to this Progress Stat in
+    Steamworks Partner. Steam unlocks them automatically when the synced value
+    crosses the configured threshold — this endpoint never calls SetAchievement.
     """
     validation_error = _validate_local_mutation_request(request)
     if validation_error is not None:
         return validation_error
 
     steamworks = get_steamworks()
-    if steamworks is not None:
-        try:
-            data = await request.json()
-            seconds_to_add = data.get('seconds', 10)
-
-            # 验证 seconds 参数
-            try:
-                seconds_to_add = int(seconds_to_add)
-                if seconds_to_add < 0:
-                    return JSONResponse(
-                        content={"success": False, "error": "seconds must be non-negative"},
-                        status_code=400
-                    )
-            except (ValueError, TypeError):
-                return JSONResponse(
-                    content={"success": False, "error": "seconds must be a valid integer"},
-                    status_code=400
-                )
-
-            # 注意:不需要每次都调用 RequestCurrentStats()
-            # RequestCurrentStats() 应该只在应用启动时调用一次
-            # 频繁调用可能导致性能问题和同步延迟
-            # 这里直接获取和更新统计值即可
-
-            # 获取当前游戏时长（如果统计不存在，从 0 开始）
-            try:
-                current_playtime = steamworks.UserStats.GetStatInt('PLAY_TIME_SECONDS')
-            except Exception as e:
-                logger.warning(f"获取 PLAY_TIME_SECONDS 失败，从 0 开始: {e}")
-                current_playtime = 0
-
-            # 增加时长
-            new_playtime = current_playtime + seconds_to_add
-
-            # 设置新的时长
-            try:
-                result = steamworks.UserStats.SetStat('PLAY_TIME_SECONDS', new_playtime)
-
-                if result:
-                    # 存储统计数据
-                    steamworks.UserStats.StoreStats()
-                    steamworks.run_callbacks()
-
-                    logger.debug(f"游戏时长已更新: {current_playtime}s -> {new_playtime}s (+{seconds_to_add}s)")
-
-                    return JSONResponse(content={
-                        "success": True,
-                        "totalPlayTime": new_playtime,
-                        "added": seconds_to_add
-                    })
-                else:
-                    logger.debug("SetStat 返回 False - PLAY_TIME_SECONDS 统计可能未在 Steamworks 后台配置")
-                    # 即使失败也返回成功，避免前端报错
-                    return JSONResponse(content={
-                        "success": True,
-                        "totalPlayTime": new_playtime,
-                        "added": seconds_to_add,
-                        "warning": "Steam stat not configured"
-                    })
-            except Exception as stat_error:
-                logger.warning(f"设置 Steam 统计失败: {stat_error} - 统计可能未在 Steamworks 后台配置")
-                # 即使失败也返回成功，避免前端报错
-                return JSONResponse(content={
-                    "success": True,
-                    "totalPlayTime": new_playtime,
-                    "added": seconds_to_add,
-                    "warning": "Steam stat not configured"
-                })
-
-        except Exception as e:
-            logger.error(f"更新游戏时长失败: {e}")
-            return JSONResponse(content={"success": False, "error": str(e)}, status_code=500)
-    else:
+    if steamworks is None:
         return JSONResponse(content={"success": False, "error": "Steamworks未初始化"}, status_code=503)
+
+    try:
+        data = await request.json()
+    except Exception:
+        data = {}
+    if not isinstance(data, dict):
+        data = {}
+
+    seconds_to_add = data.get("seconds", 10)
+    try:
+        seconds_to_add = int(seconds_to_add)
+        if seconds_to_add < 0:
+            return JSONResponse(
+                content={"success": False, "error": "seconds must be non-negative"},
+                status_code=400,
+            )
+    except (ValueError, TypeError):
+        return JSONResponse(
+            content={"success": False, "error": "seconds must be a valid integer"},
+            status_code=400,
+        )
+
+    # Cap a single report to 1 hour to limit abuse / clock-jump spikes.
+    seconds_to_add = min(seconds_to_add, 3600)
+
+    try:
+        try:
+            current_playtime = steamworks.UserStats.GetStatInt(_PLAYTIME_PROGRESS_STAT)
+        except Exception as e:
+            logger.warning("获取 %s 失败，从 0 开始: %s", _PLAYTIME_PROGRESS_STAT, e)
+            current_playtime = 0
+
+        new_playtime = int(current_playtime) + seconds_to_add
+
+        try:
+            result = steamworks.UserStats.SetStat(_PLAYTIME_PROGRESS_STAT, new_playtime)
+        except Exception as stat_error:
+            logger.warning(
+                "设置 Steam 进度统计失败: %s - 统计可能未在 Steamworks 后台配置",
+                stat_error,
+            )
+            return JSONResponse(content={
+                "success": True,
+                "totalPlayTime": new_playtime,
+                "added": seconds_to_add,
+                "stat": _PLAYTIME_PROGRESS_STAT,
+                "warning": "Steam progress stat not configured",
+                "progressUnlocked": [],
+            })
+
+        if not result:
+            logger.debug(
+                "SetStat 返回 False - %s 统计可能未在 Steamworks 后台配置",
+                _PLAYTIME_PROGRESS_STAT,
+            )
+            return JSONResponse(content={
+                "success": True,
+                "totalPlayTime": new_playtime,
+                "added": seconds_to_add,
+                "stat": _PLAYTIME_PROGRESS_STAT,
+                "warning": "Steam progress stat not configured",
+                "progressUnlocked": [],
+            })
+
+        steamworks.UserStats.StoreStats()
+        # Give Steam a short window to apply Progress Stat → achievement unlocks.
+        for _ in range(5):
+            steamworks.run_callbacks()
+            await asyncio.sleep(0.05)
+
+        progress_unlocked = _read_progress_unlocked_achievements(steamworks)
+        logger.debug(
+            "游戏时长进度已更新: %ss -> %ss (+%ss); progressUnlocked=%s",
+            current_playtime,
+            new_playtime,
+            seconds_to_add,
+            progress_unlocked,
+        )
+        return JSONResponse(content={
+            "success": True,
+            "totalPlayTime": new_playtime,
+            "added": seconds_to_add,
+            "stat": _PLAYTIME_PROGRESS_STAT,
+            "progressUnlocked": progress_unlocked,
+        })
+    except Exception as e:
+        logger.error(f"更新游戏时长失败: {e}")
+        return JSONResponse(content={"success": False, "error": str(e)}, status_code=500)
 
 
 @router.get('/steam/list-achievements')

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -4043,7 +4043,7 @@ async def set_achievement_status(name: str, request: Request):
             return JSONResponse(content=result, status_code=500)
         return JSONResponse(content=result)
     except Exception as e:
-        logger.error(f"设置成就失败: {e}")
+        logger.error("设置成就失败: %s", e)
         return JSONResponse(content={"success": False, "error": str(e)}, status_code=500)
 
 

--- a/static/achievement_manager.js
+++ b/static/achievement_manager.js
@@ -15,27 +15,26 @@
             checkOnce: true
         },
 
-        // 2. 茶歇时刻 - 5分钟
+        // 2-4. 计时成就：由 Steam Progress Stat PLAY_TIME_SECONDS 绑定阈值自动解锁
+        // Steamworks 后台需将 ACH_TIME_* 绑定到该 Stat（阈值分别为 300 / 3600 / 360000 秒）
         ACH_TIME_5MIN: {
             name: 'ACH_TIME_5MIN',
             description: '茶歇时刻',
-            steamStat: 'PLAY_TIME_SECONDS',
+            steamProgressStat: 'PLAY_TIME_SECONDS',
             threshold: 300  // 5分钟 = 300秒
         },
 
-        // 3. 渐入佳境 - 1小时
         ACH_TIME_1HR: {
             name: 'ACH_TIME_1HR',
             description: '渐入佳境',
-            steamStat: 'PLAY_TIME_SECONDS',
+            steamProgressStat: 'PLAY_TIME_SECONDS',
             threshold: 3600  // 1小时 = 3600秒
         },
 
-        // 4. 朝夕相伴 - 100小时
         ACH_TIME_100HR: {
             name: 'ACH_TIME_100HR',
             description: '朝夕相伴',
-            steamStat: 'PLAY_TIME_SECONDS',
+            steamProgressStat: 'PLAY_TIME_SECONDS',
             threshold: 360000  // 100小时 = 360000秒
         },
 
@@ -73,6 +72,18 @@
     const STORAGE_KEY = 'neko_achievement_counters';
     const UNLOCKED_KEY = 'neko_unlocked_achievements';
 
+    // Pet + React Chat 都会加载本脚本；时长 Progress Stat 只能由一个窗口上报。
+    function shouldOwnPlaytimeTracking() {
+        if (window.__NEKO_STANDALONE_CHAT__ === true) {
+            return false;
+        }
+        const path = String(window.location.pathname || '');
+        if (window.__NEKO_MULTI_WINDOW__ === true && /^\/chat(?:_full)?(?:\/|$)/.test(path)) {
+            return false;
+        }
+        return true;
+    }
+
     // 成就管理器类
     class AchievementManager {
         constructor() {
@@ -81,8 +92,10 @@
             this.sessionStartTime = Date.now();
             this.pendingAchievements = new Set(); // 防竞态：追踪正在解锁的成就
 
-            // 启动时长追踪（用于 Steam 统计）
-            this.startPlayTimeTracking();
+            // 仅主窗口/Pet 上报 Progress Stat，避免 Pet+Chat 双窗口把时长翻倍
+            if (shouldOwnPlaytimeTracking()) {
+                this.startPlayTimeTracking();
+            }
 
         }
 
@@ -268,19 +281,31 @@
         }
 
 
-        // 启动游戏时长追踪（用于 Steam 统计 PLAY_TIME_SECONDS）
+        // 本地累加会话时长，定期 SetStat(PLAY_TIME_SECONDS)+StoreStats；
+        // 计时成就由 Steam 按 Progress Stat 绑定阈值自动解锁，前端不主动 SetAchievement。
         startPlayTimeTracking() {
-            // 使用递归 setTimeout 避免重叠调用
-            let prevTs = Date.now(); // 记录上次更新的时间戳
+            // 约每 60 秒上报一次（官方常见节奏：定期/存档点/退出时同步）
+            const REPORT_INTERVAL_MS = 60000;
+            let prevTs = Date.now();
+            let reporting = false;
 
-            const updatePlayTime = async () => {
+            const flushPlayTime = async ({ force = false } = {}) => {
+                if (reporting) return;
                 const now = Date.now();
-                // 计算实际经过的秒数（毫秒转秒，至少1秒）
-                // 限制单次最多发送3600秒（1小时），防止累积过多
-                const elapsedSeconds = Math.min(3600, Math.max(1, Math.floor((now - prevTs) / 1000)));
+                const elapsedSeconds = Math.min(
+                    3600,
+                    Math.max(0, Math.floor((now - prevTs) / 1000))
+                );
+                if (!force && elapsedSeconds < 1) {
+                    return;
+                }
+                if (elapsedSeconds < 1) {
+                    prevTs = now;
+                    return;
+                }
 
+                reporting = true;
                 try {
-                    // 调用后端 API 更新 Steam 统计，发送实际经过的秒数
                     const playtimeHeaders = { 'Content-Type': 'application/json' };
                     const sec = window.nekoLocalMutationSecurity;
                     if (sec && typeof sec.getMutationHeaders === 'function') {
@@ -289,49 +314,61 @@
                     const response = await fetch('/api/steam/update-playtime', {
                         method: 'POST',
                         headers: playtimeHeaders,
-                        body: JSON.stringify({
-                            seconds: elapsedSeconds
-                        })
+                        body: JSON.stringify({ seconds: elapsedSeconds })
                     });
 
                     if (response.ok) {
-                        const data = await response.json();
-                        // 只有在成功更新后才更新时间戳，避免时间丢失
                         prevTs = now;
-                        // 检查时间相关成就
-                        await this.checkPlayTimeAchievements(data.totalPlayTime);
+                        const data = await response.json().catch(() => ({}));
+                        this.syncProgressStatAchievements(data);
                     } else if (response.status === 503) {
-                        // Steam 未初始化，静默失败（不显示错误）
-                        console.debug('Steam 未初始化，跳过时长更新');
-                        // Steam 未初始化时也更新时间戳，避免累积过多时间
+                        // Steam 未初始化：丢弃这段间隔，避免离线堆积后一次灌入
+                        console.debug('Steam 未初始化，跳过时长进度上报');
                         prevTs = now;
                     }
-                    // 如果响应不是 ok 且不是 503，不更新时间戳，下次会重试
+                    // 其他错误保留 prevTs，下次重试这段时间
                 } catch (error) {
-                    // 网络错误或其他问题，不更新时间戳，下次会重试发送这段时间
-                    console.debug('更新游戏时长失败:', error.message);
+                    console.debug('更新游戏时长进度失败:', error.message);
                 } finally {
-                    // 无论成功或失败，都在10秒后继续下一次更新
-                    setTimeout(updatePlayTime, 10000);
+                    reporting = false;
                 }
             };
 
-            // 立即启动第一次更新，不等待10秒
-            updatePlayTime();
+            const scheduleNext = () => {
+                setTimeout(async () => {
+                    await flushPlayTime();
+                    scheduleNext();
+                }, REPORT_INTERVAL_MS);
+            };
+
+            // 页面隐藏/退出时尽量冲刷一次，贴近官方“退出时同步”
+            const flushOnLeave = () => {
+                void flushPlayTime({ force: true });
+            };
+            document.addEventListener('visibilitychange', () => {
+                if (document.visibilityState === 'hidden') {
+                    flushOnLeave();
+                }
+            });
+            window.addEventListener('pagehide', flushOnLeave);
+
+            // 启动后稍等再首次上报，避免刚进页就打空请求
+            setTimeout(async () => {
+                await flushPlayTime();
+                scheduleNext();
+            }, REPORT_INTERVAL_MS);
         }
 
-        // 检查游戏时长相关成就
-        async checkPlayTimeAchievements(currentPlayTime) {
-            if (!currentPlayTime) return;
-
-            // 遍历所有基于 Steam 统计的成就
-            for (const [key, achievement] of Object.entries(ACHIEVEMENTS)) {
-                if (achievement.steamStat === 'PLAY_TIME_SECONDS' &&
-                    achievement.threshold &&
-                    currentPlayTime >= achievement.threshold &&
-                    !this.isUnlocked(key)) {
-                    await this.unlockAchievement(key);
-                }
+        // 同步 Steam 已通过 Progress Stat 解锁的计时成就到本地缓存（不主动 SetAchievement）
+        syncProgressStatAchievements(data) {
+            if (!data || data.success !== true) return;
+            const unlocked = Array.isArray(data.progressUnlocked) ? data.progressUnlocked : [];
+            for (const achievementName of unlocked) {
+                if (!ACHIEVEMENTS[achievementName]) continue;
+                if (this.isUnlocked(achievementName)) continue;
+                this.markUnlockedLocally(achievementName);
+                // Steam 客户端会弹官方成就通知；这里只补本地 toast/缓存
+                this.showAchievementNotification(ACHIEVEMENTS[achievementName]);
             }
         }
 

--- a/static/achievement_manager.js
+++ b/static/achievement_manager.js
@@ -288,9 +288,18 @@
             const REPORT_INTERVAL_MS = 60000;
             let prevTs = Date.now();
             let reporting = false;
+            let activeController = null;
 
             const flushPlayTime = async ({ force = false } = {}) => {
-                if (reporting) return;
+                // Unload flush must not be dropped by the in-flight sentinel:
+                // abort the regular request (no keepalive) and re-send with keepalive.
+                if (reporting) {
+                    if (!force) return;
+                    if (activeController) {
+                        try { activeController.abort(); } catch (_) { }
+                        activeController = null;
+                    }
+                }
                 const now = Date.now();
                 const elapsedSeconds = Math.min(
                     3600,
@@ -305,19 +314,23 @@
                 }
 
                 reporting = true;
+                const controller = force ? null : new AbortController();
+                if (controller) activeController = controller;
                 try {
                     const playtimeHeaders = { 'Content-Type': 'application/json' };
                     const sec = window.nekoLocalMutationSecurity;
                     if (sec && typeof sec.getMutationHeaders === 'function') {
                         try { Object.assign(playtimeHeaders, await sec.getMutationHeaders()); } catch (_) { }
                     }
-                    const response = await fetch('/api/steam/update-playtime', {
+                    const fetchOpts = {
                         method: 'POST',
                         headers: playtimeHeaders,
                         // pagehide / visibility hidden 时页面可能正在卸载，keepalive 保证请求能发完
                         keepalive: !!force,
                         body: JSON.stringify({ seconds: elapsedSeconds })
-                    });
+                    };
+                    if (controller) fetchOpts.signal = controller.signal;
+                    const response = await fetch('/api/steam/update-playtime', fetchOpts);
 
                     if (response.ok) {
                         prevTs = now;
@@ -330,8 +343,13 @@
                     }
                     // 其他错误保留 prevTs，下次重试这段时间
                 } catch (error) {
+                    if (error && error.name === 'AbortError') {
+                        // Superseded by a force/keepalive flush; keep prevTs for that retry.
+                        return;
+                    }
                     console.debug('更新游戏时长进度失败:', error.message);
                 } finally {
+                    if (activeController === controller) activeController = null;
                     reporting = false;
                 }
             };

--- a/static/achievement_manager.js
+++ b/static/achievement_manager.js
@@ -314,6 +314,8 @@
                     const response = await fetch('/api/steam/update-playtime', {
                         method: 'POST',
                         headers: playtimeHeaders,
+                        // pagehide / visibility hidden 时页面可能正在卸载，keepalive 保证请求能发完
+                        keepalive: !!force,
                         body: JSON.stringify({ seconds: elapsedSeconds })
                     });
 

--- a/static/achievement_manager.js
+++ b/static/achievement_manager.js
@@ -289,16 +289,22 @@
             let prevTs = Date.now();
             let reporting = false;
             let activeController = null;
+            let forceFlushInFlight = false;
 
             const flushPlayTime = async ({ force = false } = {}) => {
+                // visibilitychange(hidden) + pagehide often fire together; only one
+                // keepalive unload flush should run for the same elapsed window.
+                if (force && forceFlushInFlight) return;
+
                 // Unload flush must not be dropped by the in-flight sentinel:
                 // abort the regular request (no keepalive) and re-send with keepalive.
                 if (reporting) {
                     if (!force) return;
-                    if (activeController) {
-                        try { activeController.abort(); } catch (_) { }
-                        activeController = null;
-                    }
+                    // A force flush is already in flight (no AbortController) — do not
+                    // start a second keepalive with the same elapsedSeconds.
+                    if (!activeController) return;
+                    try { activeController.abort(); } catch (_) { }
+                    activeController = null;
                 }
                 const now = Date.now();
                 const elapsedSeconds = Math.min(
@@ -314,6 +320,7 @@
                 }
 
                 reporting = true;
+                if (force) forceFlushInFlight = true;
                 const controller = force ? null : new AbortController();
                 if (controller) activeController = controller;
                 try {
@@ -350,6 +357,7 @@
                     console.debug('更新游戏时长进度失败:', error.message);
                 } finally {
                     if (activeController === controller) activeController = null;
+                    if (force) forceFlushInFlight = false;
                     reporting = false;
                 }
             };

--- a/tests/frontend/test_storage_location_startup.py
+++ b/tests/frontend/test_storage_location_startup.py
@@ -400,7 +400,7 @@ def test_storage_location_overlay_blocks_independent_startup_requests_while_barr
         route.fulfill(
             status=200,
             content_type="application/json",
-            body='{"totalPlayTime": 0}',
+            body='{"success": true, "totalPlayTime": 0, "added": 0, "progressUnlocked": []}',
         )
 
     page.route("**/api/config/page_config**", handle_page_config)

--- a/tests/unit/test_steam_achievement_router.py
+++ b/tests/unit/test_steam_achievement_router.py
@@ -8,13 +8,26 @@ from main_routers import system_router as system_router_module
 
 
 class _FakeUserStats:
-    def __init__(self, *, unlocked: bool, set_result: bool = True) -> None:
-        self.unlocked = unlocked
+    def __init__(
+        self,
+        *,
+        unlocked: bool = False,
+        unlocked_names: set[str] | None = None,
+        set_result: bool = True,
+        playtime: int = 0,
+        set_stat_result: bool = True,
+    ) -> None:
+        self.unlocked_names = set(unlocked_names or ())
+        self._legacy_all_unlocked = bool(unlocked)
         self.set_result = set_result
+        self.playtime = playtime
+        self.set_stat_result = set_stat_result
         self.request_count = 0
         self.get_count = 0
         self.set_count = 0
         self.store_count = 0
+        self.set_names: list[str] = []
+        self.set_stat_calls: list[tuple[str, object]] = []
 
     def RequestCurrentStats(self) -> bool:
         self.request_count += 1
@@ -22,13 +35,37 @@ class _FakeUserStats:
 
     def GetAchievement(self, name: str) -> bool:
         self.get_count += 1
-        return self.unlocked
+        if self._legacy_all_unlocked:
+            return True
+        return name in self.unlocked_names
 
     def SetAchievement(self, name: str) -> bool:
         self.set_count += 1
+        self.set_names.append(name)
         if self.set_result:
-            self.unlocked = True
-        return self.set_result
+            self.unlocked_names.add(name)
+            return True
+        return False
+
+    def GetStatInt(self, name: str) -> int:
+        if name != "PLAY_TIME_SECONDS":
+            raise KeyError(name)
+        return self.playtime
+
+    def SetStat(self, name: str, value: object) -> bool:
+        self.set_stat_calls.append((name, value))
+        if not self.set_stat_result:
+            return False
+        if name == "PLAY_TIME_SECONDS":
+            self.playtime = int(value)
+            # Simulate Steam Progress Stat auto-unlock after StoreStats.
+            if self.playtime >= 300:
+                self.unlocked_names.add("ACH_TIME_5MIN")
+            if self.playtime >= 3600:
+                self.unlocked_names.add("ACH_TIME_1HR")
+            if self.playtime >= 360000:
+                self.unlocked_names.add("ACH_TIME_100HR")
+        return True
 
     def StoreStats(self) -> bool:
         self.store_count += 1
@@ -115,3 +152,111 @@ def test_set_achievement_reports_newly_unlocked_and_stores(
     }
     assert stats.set_count == 1
     assert stats.store_count == 1
+
+
+@pytest.mark.unit
+def test_update_playtime_requires_steamworks(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(system_router_module, "get_steamworks", lambda: None)
+
+    response = client.post(
+        "/api/steam/update-playtime",
+        headers=_auth_headers(),
+        json={"seconds": 10},
+    )
+
+    assert response.status_code == 503
+    assert response.json()["error"] == "Steamworks未初始化"
+
+
+@pytest.mark.unit
+def test_update_playtime_sets_progress_stat_without_set_achievement(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stats = _FakeUserStats(playtime=100)
+    steamworks = _FakeSteamworks(stats)
+    monkeypatch.setattr(system_router_module, "get_steamworks", lambda: steamworks)
+
+    response = client.post(
+        "/api/steam/update-playtime",
+        headers=_auth_headers(),
+        json={"seconds": 50},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["success"] is True
+    assert body["totalPlayTime"] == 150
+    assert body["added"] == 50
+    assert body["stat"] == "PLAY_TIME_SECONDS"
+    assert body["progressUnlocked"] == []
+    assert stats.set_stat_calls == [("PLAY_TIME_SECONDS", 150)]
+    assert stats.store_count == 1
+    assert stats.set_count == 0  # Progress Stat path never calls SetAchievement
+
+
+@pytest.mark.unit
+def test_update_playtime_reports_progress_unlocked_after_threshold(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stats = _FakeUserStats(playtime=280)
+    steamworks = _FakeSteamworks(stats)
+    monkeypatch.setattr(system_router_module, "get_steamworks", lambda: steamworks)
+
+    response = client.post(
+        "/api/steam/update-playtime",
+        headers=_auth_headers(),
+        json={"seconds": 30},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["totalPlayTime"] == 310
+    assert body["progressUnlocked"] == ["ACH_TIME_5MIN"]
+    assert stats.set_count == 0
+    assert "ACH_TIME_5MIN" in stats.unlocked_names
+
+
+@pytest.mark.unit
+def test_update_playtime_caps_single_report_to_one_hour(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stats = _FakeUserStats(playtime=0)
+    steamworks = _FakeSteamworks(stats)
+    monkeypatch.setattr(system_router_module, "get_steamworks", lambda: steamworks)
+
+    response = client.post(
+        "/api/steam/update-playtime",
+        headers=_auth_headers(),
+        json={"seconds": 99999},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["added"] == 3600
+    assert body["totalPlayTime"] == 3600
+    assert stats.set_stat_calls == [("PLAY_TIME_SECONDS", 3600)]
+
+
+@pytest.mark.unit
+def test_update_playtime_rejects_negative_seconds(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stats = _FakeUserStats()
+    steamworks = _FakeSteamworks(stats)
+    monkeypatch.setattr(system_router_module, "get_steamworks", lambda: steamworks)
+
+    response = client.post(
+        "/api/steam/update-playtime",
+        headers=_auth_headers(),
+        json={"seconds": -1},
+    )
+
+    assert response.status_code == 400
+    assert stats.set_stat_calls == []


### PR DESCRIPTION
## 改动概述 / Summary

- 计时成就改为官方 Progress Stat 流程：本地累加会话时长，定期 `SetStat(PLAY_TIME_SECONDS)` + `StoreStats`，由 Steam 按后台绑定阈值自动解锁 `ACH_TIME_*`（不再主动 `SetAchievement`）。
- 仅主窗口/Pet 上报时长，避免 Pet + Chat 双窗口把 `PLAY_TIME_SECONDS` 翻倍。
- 补充/更新 Steam 成就单测与 achievement-system skill 文档。

## 回归报告 / Regression Report

- **改动了什么**：`main_routers/system_router.py` 的 `/api/steam/update-playtime` 从“累加自定义 Stat 后由前端主动解锁计时成就”改为纯 Progress Stat 上报（`SetStat` + `StoreStats`，不调用 `SetAchievement`）；`set_achievement_status` 解锁逻辑抽成 `_unlock_steam_achievement` 复用。前端 `achievement_manager.js` 改为 60s/退出时上报，并由 `shouldOwnPlaytimeTracking()` 限制仅 Pet/主窗口计时。
- **理由 / 必要性**：对齐 Steamworks Progress Stat 官方推荐做法，让成就进度条与解锁由 Steam 服务器在 Stat 达阈值时触发；同时修复多窗口重复上报导致时长翻倍。
- **改动前后对比**：
  - 前：前端约每 10s 上报秒数并在本地按阈值调用 `set-achievement-status` 解锁 `ACH_TIME_*`。
  - 后：前端约每 60s（及 pagehide/visibility hidden）上报秒数；后端只更新 `PLAY_TIME_SECONDS`；计时成就依赖 Steamworks 后台 Progress Stat 绑定自动解锁；Chat 窗口不再上报。
- **潜在回归点**：
  - Steamworks 未绑定 `PLAY_TIME_SECONDS` → `ACH_TIME_*` 时，Stat 会更新但成就不会自动解锁（需后台配置）。
  - 卸载瞬间上报依赖 `keepalive`；若 Electron 环境仍取消请求，退出前最后几秒可能丢失（下次会话会继续累加）。
  - 一次性/计数型成就仍走 `set-achievement-status`，行为应不变。

## 不拆分理由 / Why Not Split

不适用

## 测试 / Testing

- [x] `pytest tests/unit/test_steam_achievement_router.py -q` 通过
- [x] 运行时验证：仅 `path:/` 上报，约每 5s（调试间隔）一次 `StoreStats ok`，`progressUnlocked` 含全部计时成就
- [ ] Steam 登录态启动桌面端，确认正式 60s 节奏下 `/api/steam/update-playtime` 成功且仅来自 Pet/主窗口
- [ ] Steamworks 后台已绑定 Progress Stat 时，阈值跨越后 Steam 自动弹成就

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 计时类成就改为基于 Steam 时长进度（Progress Stat）阈值的绑定解锁，前端仅同步并展示进度解锁提示。
  * 时长上报策略增强：在页面隐藏/切换等场景触发补报，降低漏报与重复计时。
* **Bug 修复**
  * 强化时长上报参数校验与单次上限；Steamworks 未初始化时返回明确错误。
  * 时长上报结果结构更新：增加已解锁进度列表（progressUnlocked）用于同步显示。
* **文档**
  * 更新《Achievement System Skill》：补充官方推荐流程与注意事项。
* **测试**
  * 更新并新增 Steam 成就解锁与时长上报相关单测，覆盖成功、边界与异常场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->