### PR TITLE
修复角色音色从已设置切换为“未指定音色”后，角色管理面板本地缓存未及时同步导致 UI 显示滞后的问题

### DIFF
--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -3205,6 +3205,16 @@ function mergeFreshCatgirlRawDataWithLocal(freshRawData, localRawData) {
     return merged;
 }
 
+function applyLocalVoiceIdToRawData(rawData, voiceId) {
+    if (!rawData || typeof rawData !== 'object') return rawData;
+    const normalizedVoiceId = String(voiceId || '').trim();
+    rawData.voice_id = normalizedVoiceId;
+    if (rawData.voice && typeof rawData.voice === 'object') {
+        rawData.voice.voice_id = normalizedVoiceId;
+    }
+    return rawData;
+}
+
 function syncCharacterCardCache(catgirlName, rawData, options = {}) {
     if (!catgirlName) return;
     if (!Array.isArray(window.characterCards)) {
@@ -7148,6 +7158,7 @@ async function saveCatgirlFromPanel(form, originalName, isNew) {
             if (nameInput) nameInput.value = savedCatgirlName;
         }
         const localRawData = buildLocalCatgirlRawData(savedCatgirlName, data, fieldOrder);
+        let savedVoiceIdForLocalRawData = null;
         let savedRawDataForCache = localRawData;
         syncCharacterCardCache(savedCatgirlName, localRawData, { render: !shouldSelectAfterSave });
         if (form._autoCreatedDetachedName) {
@@ -7191,6 +7202,9 @@ async function saveCatgirlFromPanel(form, originalName, isNew) {
                             window.t ? window.t('character.partialSaveVoiceFailed', { error: detail }) : '角色已保存，但音色更新失败: ' + detail,
                             'error'
                         );
+                    } else {
+                        savedVoiceIdForLocalRawData = selectedVoiceId;
+                        applyLocalVoiceIdToRawData(localRawData, savedVoiceIdForLocalRawData);
                     }
                 } catch (voiceErr) {
                     showMessage(
@@ -7214,6 +7228,9 @@ async function saveCatgirlFromPanel(form, originalName, isNew) {
                             window.t ? window.t('character.partialSaveVoiceFailed', { error: detail }) : '角色已保存，但音色更新失败: ' + detail,
                             'error'
                         );
+                    } else {
+                        savedVoiceIdForLocalRawData = '';
+                        applyLocalVoiceIdToRawData(localRawData, savedVoiceIdForLocalRawData);
                     }
                 } catch (clearErr) {
                     showMessage(
@@ -7309,15 +7326,24 @@ async function saveCatgirlFromPanel(form, originalName, isNew) {
                     ? freshData['猫娘'][savedCatgirlName]
                     : {};
                 savedRawDataForCache = mergeFreshCatgirlRawDataWithLocal(freshRawData, localRawData);
+                if (savedVoiceIdForLocalRawData !== null) {
+                    applyLocalVoiceIdToRawData(savedRawDataForCache, savedVoiceIdForLocalRawData);
+                }
                 setLocalRawDataFieldOrder(savedRawDataForCache, fieldOrder);
                 syncCharacterCardCache(savedCatgirlName, savedRawDataForCache);
                 buildCatgirlDetailForm(savedCatgirlName, savedRawDataForCache, false, container);
             } catch (e) {
                 console.error('重新加载猫娘数据失败:', e);
+                if (savedVoiceIdForLocalRawData !== null) {
+                    applyLocalVoiceIdToRawData(localRawData, savedVoiceIdForLocalRawData);
+                }
                 buildCatgirlDetailForm(savedCatgirlName, localRawData, false, container);
             }
         }
         await loadCharacterCards();
+        if (savedVoiceIdForLocalRawData !== null) {
+            applyLocalVoiceIdToRawData(savedRawDataForCache, savedVoiceIdForLocalRawData);
+        }
         setLocalRawDataFieldOrder(savedRawDataForCache, fieldOrder);
         syncCharacterCardCache(savedCatgirlName, savedRawDataForCache);
         return true;

--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -3207,7 +3207,7 @@ function mergeFreshCatgirlRawDataWithLocal(freshRawData, localRawData) {
 
 function applyLocalVoiceIdToRawData(rawData, voiceId) {
     if (!rawData || typeof rawData !== 'object') return rawData;
-    const normalizedVoiceId = String(voiceId || '').trim();
+    const normalizedVoiceId = (voiceId == null ? '' : String(voiceId)).trim();
     rawData.voice_id = normalizedVoiceId;
     if (rawData.voice && typeof rawData.voice === 'object') {
         rawData.voice.voice_id = normalizedVoiceId;
@@ -7341,9 +7341,6 @@ async function saveCatgirlFromPanel(form, originalName, isNew) {
             }
         }
         await loadCharacterCards();
-        if (savedVoiceIdForLocalRawData !== null) {
-            applyLocalVoiceIdToRawData(savedRawDataForCache, savedVoiceIdForLocalRawData);
-        }
         setLocalRawDataFieldOrder(savedRawDataForCache, fieldOrder);
         syncCharacterCardCache(savedCatgirlName, savedRawDataForCache);
         return true;


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复角色音色从已设置切换为“未指定音色”后，角色管理面板本地缓存未及时同步导致 UI 显示滞后的问题

## 测试 / Testing

手动切换音色


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 保存或清除音色后，本地缓存会自动写入最新的音色 ID（包括嵌套音色字段），避免界面重载后仍显示旧音色。
  * 在重新加载详情面板并重建内容时，无论重载成功或回退渲染，都将使用已更新的音色信息，提升保存一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->