### PR TITLE
修复模型旁浮动按钮中语音控制、屏幕分享主按钮会误触发小三角旋转动画的问题

### DIFF
--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -6888,14 +6888,13 @@ const AvatarButtonMixin = {
                 return;
             }
 
-            const buttonActive = !!(buttonData && buttonData.button && buttonData.button.dataset.active === 'true');
             const popup = document.getElementById(`${this._avatarPrefix}-popup-${buttonId}`);
             const popupExpanded = !!(
                 popup &&
                 popup.style.display === 'flex' &&
                 (popup.style.opacity !== '0' || popup.classList.contains('is-positioning'))
             );
-            triggerIcon.style.transform = (buttonActive || popupExpanded) ? 'rotate(180deg)' : 'rotate(0deg)';
+            triggerIcon.style.transform = popupExpanded ? 'rotate(180deg)' : 'rotate(0deg)';
         };
 
         /**


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复模型旁浮动按钮中语音控制、屏幕分享主按钮会误触发小三角旋转动画的问题

## 测试 / Testing

手动开启按钮测试


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了分离弹窗触发器图标的旋转状态：现在只有在弹窗实际展开时才会旋转，避免按钮自身状态导致的显示不一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->