### PR TITLE
[NEKO Live split 01/26] Contracts foundation

### DIFF
--- a/plugin/plugins/neko_roast/core/contracts.py
+++ b/plugin/plugins/neko_roast/core/contracts.py
@@ -1,317 +1,44 @@
-"""Shared contracts for the Neko Roast viewer-interaction pipeline."""
+"""Compatibility facade for NEKO Live shared contracts.
+
+Concrete contract groups live in focused ``contracts_*`` modules. Keep importing
+from ``core.contracts`` in feature code unless a module needs a narrower owner.
+"""
 
 from __future__ import annotations
 
-import re
-from dataclasses import asdict, dataclass, field
-from datetime import datetime, timezone
-from typing import Any, Literal
+from .contracts_config import RoastConfig, normalize_live_platform, parse_room_id
+from .contracts_events import LiveEvent, ViewerEvent
+from .contracts_interaction import InteractionRequest, InteractionResult, PipelineStep
+from .contracts_safety import LiveRoomStatus, SafetyDecision
+from .contracts_types import (
+    ActivityLevel,
+    LiveMode,
+    RoastStrength,
+    SafetyStatus,
+    TriggerSource,
+    _response_latency_ms,
+    utc_now_iso,
+)
+from .contracts_viewer import ViewerIdentity, ViewerProfile
 
-LiveMode = Literal["co_stream", "solo_stream"]
-RoastStrength = Literal["gentle", "normal", "sharp"]
-TriggerSource = Literal["live_danmaku", "developer_sandbox", "manual_live_simulation"]
-SafetyStatus = Literal["running", "paused", "degraded", "tripped", "disconnected"]
-
-
-def utc_now_iso() -> str:
-    return datetime.now(timezone.utc).isoformat(timespec="seconds")
-
-
-_LIVE_ROOM_URL_RE = re.compile(r"live\.bilibili\.com/(?:h5/|blanc/)?(\d+)", re.IGNORECASE)
-
-
-def parse_room_id(value: Any) -> int:
-    """房号 / 纯数字串 / B站直播间链接 → 数字房号；解析不出返回 0。
-
-    接受 int、纯数字串、含 ``live.bilibili.com/<id>`` 的 URL（可带 ``/h5/``、``/blanc/``、
-    query、路径）。让面板/动作能直接粘直播间链接，而不必手动找房号。
-    """
-    if isinstance(value, bool):
-        return 0
-    if isinstance(value, int):
-        return value if value > 0 else 0
-    text = str(value or "").strip()
-    if not text:
-        return 0
-    if text.isdigit():
-        return int(text)
-    match = _LIVE_ROOM_URL_RE.search(text)
-    if match:
-        try:
-            return int(match.group(1))
-        except ValueError:
-            return 0
-    return 0
-
-
-@dataclass
-class RoastConfig:
-    live_room_id: int = 0
-    live_mode: LiveMode = "co_stream"
-    live_enabled: bool = False
-    developer_tools_enabled: bool = False
-    dry_run: bool = True  # 安全测试态：跑完整 pipeline 但不真的投给猫猫
-    roast_once_per_uid: bool = True
-    roast_strength: RoastStrength = "normal"
-    co_stream_output_policy: str = "auto_low_interrupt"
-    solo_output_policy: str = "auto_rate_limited"
-    avatar_fetch_timeout_seconds: float = 8.0
-    recent_limit: int = 30
-    rate_limit_seconds: int = 20
-    queue_limit: int = 5
-    safety_auto_stop_enabled: bool = True
-    safety_window_seconds: int = 60
-    safety_pipeline_failure_limit: int = 3
-    safety_output_failure_limit: int = 2
-    safety_queue_overflow_limit: int = 3
-    viewer_store_dir: str = ""  # 观众档案 JSON 存储目录；留空=插件数据目录。主播可在「设置」改。
-
-    @classmethod
-    def from_mapping(cls, data: dict[str, Any] | None) -> "RoastConfig":
-        raw = dict(data or {})
-        live_mode = str(raw.get("live_mode") or "co_stream")
-        if live_mode == "solo":
-            live_mode = "solo_stream"
-        if live_mode not in {"co_stream", "solo_stream"}:
-            live_mode = "co_stream"
-        roast_strength = str(raw.get("roast_strength") or "normal")
-        if roast_strength not in {"gentle", "normal", "sharp"}:
-            roast_strength = "normal"
-        return cls(
-            live_room_id=parse_room_id(raw.get("live_room_id")),
-            live_mode=live_mode,  # type: ignore[arg-type]
-            live_enabled=bool(raw.get("live_enabled", False)),
-            developer_tools_enabled=bool(raw.get("developer_tools_enabled", False)),
-            dry_run=bool(raw.get("dry_run", True)),
-            roast_once_per_uid=bool(raw.get("roast_once_per_uid", True)),
-            roast_strength=roast_strength,  # type: ignore[arg-type]
-            co_stream_output_policy=str(raw.get("co_stream_output_policy") or "auto_low_interrupt"),
-            solo_output_policy=str(raw.get("solo_output_policy") or "auto_rate_limited"),
-            avatar_fetch_timeout_seconds=float(
-                raw.get("avatar_fetch_timeout_seconds")
-                if raw.get("avatar_fetch_timeout_seconds") is not None
-                else 8
-            ),
-            recent_limit=max(1, min(int(raw.get("recent_limit") or 30), 200)),
-            rate_limit_seconds=max(0, min(int(raw.get("rate_limit_seconds") if raw.get("rate_limit_seconds") is not None else 20), 3600)),
-            queue_limit=max(1, min(int(raw.get("queue_limit") or 5), 100)),
-            safety_auto_stop_enabled=bool(raw.get("safety_auto_stop_enabled", True)),
-            safety_window_seconds=max(5, min(int(raw.get("safety_window_seconds") or 60), 3600)),
-            safety_pipeline_failure_limit=max(1, min(int(raw.get("safety_pipeline_failure_limit") or 3), 100)),
-            safety_output_failure_limit=max(1, min(int(raw.get("safety_output_failure_limit") or 2), 100)),
-            safety_queue_overflow_limit=max(1, min(int(raw.get("safety_queue_overflow_limit") or 3), 100)),
-            viewer_store_dir=str(raw.get("viewer_store_dir") or "").strip(),
-        )
-
-    def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
-
-
-@dataclass
-class ViewerEvent:
-    uid: str
-    nickname: str = ""
-    avatar_url: str = ""
-    danmaku_text: str = ""
-    target_lanlan: str = ""
-    source: TriggerSource = "developer_sandbox"
-    live_mode: LiveMode = "co_stream"
-    seen_at: str = field(default_factory=utc_now_iso)
-    raw: dict[str, Any] = field(default_factory=dict)
-
-    def to_dict(self) -> dict[str, Any]:
-        data = asdict(self)
-        data.pop("raw", None)
-        return data
-
-
-@dataclass
-class LiveEvent:
-    """直播事件统一信封：把各类直播事件（弹幕 / 礼物 / SC / 上舰 / 进场…）包成同一形状，
-    经 ``EventBus`` 按 ``type`` 路由给订阅了该类型的 handler 模块。这是「分发给其他开发者
-    各写各事件 handler」的核心数据契约。
-
-    - ``type``：路由键（``"danmaku"`` / ``"gift"`` / ``"super_chat"`` / ``"guard"`` /
-      ``"entry"`` / …）。接入侧由命令名映射而来。
-    - ``uid``：触发用户 UID（str；空串=无主体事件）。
-    - ``payload``：该类型专属字段的轻量 dict（handler 自解）。**各类型的精确 payload schema
-      随对应 handler 落地时敲定**（见 roadmap §7-2，由首个非弹幕事件决定形状）。
-    - ``source``：事件来源（``"live"`` / ``"developer_sandbox"`` / …）。
-    - ``ts``：事件时间戳（epoch 秒；由调用方注入，便于测试确定性）。
-    - ``schema_version``：信封版本，演进时供兼容判断。
-    - ``raw``：原始富模型对象（如 ``LiveDanmaku``）。需要完整字段（如 ``get_score()``）的
-      handler 走 ``raw``；信封本身不约束其形状。
-    """
-
-    type: str
-    uid: str = ""
-    payload: dict[str, Any] = field(default_factory=dict)
-    source: str = "live"
-    ts: float = 0.0
-    schema_version: int = 1
-    raw: Any = None
-
-    def to_dict(self) -> dict[str, Any]:
-        # 不含 raw（富模型可能很大 / 不可序列化）；轻量调试视图。
-        return {
-            "type": self.type,
-            "uid": self.uid,
-            "payload": dict(self.payload),
-            "source": self.source,
-            "ts": self.ts,
-            "schema_version": self.schema_version,
-        }
-
-
-@dataclass
-class ViewerIdentity:
-    uid: str
-    nickname: str
-    name: str = ""
-    email: str = ""
-    avatar_url: str = ""
-    avatar_bytes: bytes | None = None
-    avatar_mime: str = ""
-    source_url: str = ""
-    fetched: bool = False
-    error: str = ""
-    # 头像形态 META：用于自适应锐评焦点 + 头像识别不了时的兜底素材。
-    # avatar_bytes 是否可用走 has_avatar；这里只描述"这个人头像的配置"。
-    is_default_avatar: bool = False  # B 站默认头像（noface），无可锐评内容
-    is_animated_avatar: bool = False  # 动图头像（大会员），只取了代表帧
-    pendant: str = ""                 # 头像挂件/装扮名（出框效果来源），无则空
-
-    @property
-    def avatar_vision_ok(self) -> bool:
-        """是否拿到了可喂给视觉的真实头像帧。看不到就别脑补，走 META/ID。"""
-        return bool(self.avatar_bytes)
-
-    def to_public_dict(self) -> dict[str, Any]:
-        return {
-            "uid": self.uid,
-            "nickname": self.nickname,
-            "name": self.name or self.nickname,
-            "avatar_url": self.avatar_url,
-            "avatar_mime": self.avatar_mime,
-            "has_avatar": bool(self.avatar_bytes),
-            "is_default_avatar": self.is_default_avatar,
-            "is_animated_avatar": self.is_animated_avatar,
-            "pendant": self.pendant,
-            "source_url": self.source_url,
-            "fetched": self.fetched,
-            "error": self.error,
-        }
-
-
-@dataclass
-class ViewerProfile:
-    uid: str
-    nickname: str
-    avatar_url: str = ""
-    first_seen_at: str = field(default_factory=utc_now_iso)
-    last_seen_at: str = field(default_factory=utc_now_iso)
-    roast_count: int = 0
-    last_roast_at: str = ""
-    last_result: str = ""
-
-    def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
-
-
-@dataclass
-class InteractionRequest:
-    event: ViewerEvent
-    identity: ViewerIdentity
-    profile: ViewerProfile
-    prompt_text: str
-    live_mode: LiveMode
-    strength: RoastStrength
-    should_push: bool = True
-    dry_run: bool = False
-    reason: str = ""
-
-    def to_public_dict(self) -> dict[str, Any]:
-        return {
-            "event": self.event.to_dict(),
-            "identity": self.identity.to_public_dict(),
-            "profile": self.profile.to_dict(),
-            "prompt_text": self.prompt_text,
-            "live_mode": self.live_mode,
-            "strength": self.strength,
-            "should_push": self.should_push,
-            "dry_run": self.dry_run,
-            "reason": self.reason,
-        }
-
-
-@dataclass
-class PipelineStep:
-    id: str
-    status: Literal["ok", "skipped", "failed"]
-    message: str = ""
-
-    def to_dict(self) -> dict[str, str]:
-        return asdict(self)
-
-
-@dataclass
-class InteractionResult:
-    accepted: bool
-    status: Literal["queued", "pushed", "skipped", "failed"]
-    event: ViewerEvent
-    identity: ViewerIdentity | None = None
-    profile: ViewerProfile | None = None
-    request: InteractionRequest | None = None
-    output: str = ""
-    reason: str = ""
-    steps: list[PipelineStep] = field(default_factory=list)
-    created_at: str = field(default_factory=utc_now_iso)
-
-    def to_public_dict(self) -> dict[str, Any]:
-        return {
-            "accepted": self.accepted,
-            "status": self.status,
-            "event": self.event.to_dict(),
-            "identity": self.identity.to_public_dict() if self.identity else None,
-            "profile": self.profile.to_dict() if self.profile else None,
-            "request": self.request.to_public_dict() if self.request else None,
-            "output": self.output,
-            "reason": self.reason,
-            "steps": [step.to_dict() for step in self.steps],
-            "created_at": self.created_at,
-        }
-
-    def to_sandbox_dict(self) -> dict[str, Any]:
-        return {
-            "accepted": self.accepted,
-            "status": self.status,
-            "uid": self.event.uid,
-            "nickname": self.event.nickname,
-            "output": self.output,
-            "reason": self.reason,
-            "steps": [step.to_dict() for step in self.steps],
-            "created_at": self.created_at,
-        }
-
-
-@dataclass
-class SafetyDecision:
-    allowed: bool
-    status: SafetyStatus = "running"
-    reason: str = ""
-
-    def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
-
-
-@dataclass
-class LiveRoomStatus:
-    room_id: int
-    ok: bool
-    title: str = ""
-    anchor_name: str = ""
-    live_status: str = "unknown"
-    message: str = ""
-
-    def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+__all__ = [
+    "ActivityLevel",
+    "InteractionRequest",
+    "InteractionResult",
+    "LiveEvent",
+    "LiveMode",
+    "LiveRoomStatus",
+    "PipelineStep",
+    "RoastConfig",
+    "RoastStrength",
+    "SafetyDecision",
+    "SafetyStatus",
+    "TriggerSource",
+    "ViewerEvent",
+    "ViewerIdentity",
+    "ViewerProfile",
+    "_response_latency_ms",
+    "normalize_live_platform",
+    "parse_room_id",
+    "utc_now_iso",
+]

--- a/plugin/plugins/neko_roast/core/contracts_config.py
+++ b/plugin/plugins/neko_roast/core/contracts_config.py
@@ -1,0 +1,294 @@
+"""Configuration contracts for NEKO Live runtime behavior."""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from .contracts_public import public_bool, public_text
+from .contracts_types import ActivityLevel, LiveMode, RoastStrength
+
+
+_LIVE_ROOM_URL_RE = re.compile(
+    r"live\.bilibili\.com/(?:h5/|blanc/)?(\d+)", re.IGNORECASE
+)
+
+
+def parse_room_id(value: Any) -> int:
+    """Parse a numeric room id or a Bilibili live-room URL; return 0 on failure."""
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value if value > 0 else 0
+    if not isinstance(value, str):
+        return 0
+    text = value.strip()
+    if not text:
+        return 0
+    if text.isdigit():
+        return int(text)
+    match = _LIVE_ROOM_URL_RE.search(text)
+    if match:
+        try:
+            return int(match.group(1))
+        except ValueError:
+            return 0
+    return 0
+
+
+def normalize_live_platform(value: Any) -> str:
+    platform = value.strip().lower() if isinstance(value, str) else "bilibili"
+    if platform in {"bili", "bilibili"}:
+        return "bilibili"
+    if platform in {"douyin", "dy"}:
+        return "douyin"
+    return "bilibili"
+
+
+@dataclass
+class RoastConfig:
+    live_platform: str = "bilibili"
+    live_room_ref: str = ""
+    live_room_id: int = 0
+    live_mode: LiveMode = "co_stream"
+    live_enabled: bool = False
+    developer_tools_enabled: bool = False
+    dry_run: bool = False  # Run the full pipeline without pushing output to NEKO.
+    roast_once_per_uid: bool = True
+    roast_strength: RoastStrength = "normal"
+    activity_level: ActivityLevel = "standard"
+    co_stream_output_policy: str = "auto_low_interrupt"
+    solo_output_policy: str = "auto_rate_limited"
+    avatar_fetch_timeout_seconds: float = 8.0
+    recent_limit: int = 30
+    rate_limit_seconds: int = 20
+    queue_limit: int = 5
+    safety_auto_stop_enabled: bool = True
+    safety_window_seconds: int = 60
+    safety_pipeline_failure_limit: int = 3
+    safety_output_failure_limit: int = 2
+    safety_queue_overflow_limit: int = 3
+    viewer_store_dir: str = ""  # Empty means the plugin data directory.
+    stream_theme: str = ""
+    stream_goal: str = ""
+    stream_columns: str = ""
+    stream_avoid_topics: str = ""
+
+    @classmethod
+    def from_mapping(cls, data: dict[str, Any] | None) -> "RoastConfig":
+        raw = dict(data or {})
+        live_mode = _safe_text(raw.get("live_mode"), default="co_stream")
+        if live_mode == "solo":
+            live_mode = "solo_stream"
+        if live_mode not in {"co_stream", "solo_stream"}:
+            live_mode = "co_stream"
+        roast_strength = _safe_text(raw.get("roast_strength"), default="normal")
+        if roast_strength not in {"gentle", "normal", "sharp"}:
+            roast_strength = "normal"
+        activity_level = _safe_text(raw.get("activity_level"), default="standard")
+        if activity_level not in {"quiet", "standard", "active"}:
+            activity_level = "standard"
+        live_platform = normalize_live_platform(raw.get("live_platform"))
+        live_room_ref = raw.get("live_room_ref").strip() if isinstance(raw.get("live_room_ref"), str) else ""
+        live_room_id = parse_room_id(raw.get("live_room_id"))
+        if live_platform == "bilibili":
+            if live_room_id <= 0 and live_room_ref:
+                live_room_id = parse_room_id(live_room_ref)
+            if not live_room_ref and live_room_id > 0:
+                live_room_ref = str(live_room_id)
+        else:
+            live_room_id = 0
+        return cls(
+            live_platform=live_platform,
+            live_room_ref=live_room_ref,
+            live_room_id=live_room_id,
+            live_mode=live_mode,  # type: ignore[arg-type]
+            live_enabled=_safe_bool(raw.get("live_enabled"), default=False),
+            developer_tools_enabled=_safe_bool(raw.get("developer_tools_enabled"), default=False),
+            dry_run=_safe_bool(raw.get("dry_run"), default=False),
+            roast_once_per_uid=_safe_bool(raw.get("roast_once_per_uid"), default=True),
+            roast_strength=roast_strength,  # type: ignore[arg-type]
+            activity_level=activity_level,  # type: ignore[arg-type]
+            co_stream_output_policy=_safe_text(
+                raw.get("co_stream_output_policy"),
+                default="auto_low_interrupt",
+            ),
+            solo_output_policy=_safe_text(
+                raw.get("solo_output_policy"),
+                default="auto_rate_limited",
+            ),
+            avatar_fetch_timeout_seconds=_safe_float(
+                raw.get("avatar_fetch_timeout_seconds"),
+                default=8.0,
+                minimum=0.0,
+            ),
+            recent_limit=_safe_int(raw.get("recent_limit"), default=30, minimum=1, maximum=200),
+            rate_limit_seconds=_safe_int(
+                raw.get("rate_limit_seconds"),
+                default=20,
+                minimum=0,
+                maximum=3600,
+            ),
+            queue_limit=_safe_int(raw.get("queue_limit"), default=5, minimum=1, maximum=100),
+            safety_auto_stop_enabled=_safe_bool(raw.get("safety_auto_stop_enabled"), default=True),
+            safety_window_seconds=_safe_int(
+                raw.get("safety_window_seconds"),
+                default=60,
+                minimum=5,
+                maximum=3600,
+            ),
+            safety_pipeline_failure_limit=_safe_int(
+                raw.get("safety_pipeline_failure_limit"),
+                default=3,
+                minimum=1,
+                maximum=100,
+            ),
+            safety_output_failure_limit=_safe_int(
+                raw.get("safety_output_failure_limit"),
+                default=2,
+                minimum=1,
+                maximum=100,
+            ),
+            safety_queue_overflow_limit=_safe_int(
+                raw.get("safety_queue_overflow_limit"),
+                default=3,
+                minimum=1,
+                maximum=100,
+            ),
+            viewer_store_dir=(
+                raw.get("viewer_store_dir").strip()
+                if isinstance(raw.get("viewer_store_dir"), str)
+                else ""
+            ),
+            stream_theme=_safe_optional_text(raw.get("stream_theme"), max_len=120),
+            stream_goal=_safe_optional_text(raw.get("stream_goal"), max_len=160),
+            stream_columns=_safe_optional_text(raw.get("stream_columns"), max_len=160),
+            stream_avoid_topics=_safe_optional_text(raw.get("stream_avoid_topics"), max_len=160),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def to_public_dict(self) -> dict[str, Any]:
+        live_platform = normalize_live_platform(self.live_platform)
+        live_room_ref = public_text(self.live_room_ref)
+        live_room_id = parse_room_id(self.live_room_id)
+        if live_platform == "bilibili":
+            if live_room_id <= 0 and live_room_ref:
+                live_room_id = parse_room_id(live_room_ref)
+            if not live_room_ref and live_room_id > 0:
+                live_room_ref = str(live_room_id)
+        else:
+            live_room_id = 0
+        return {
+            "live_platform": live_platform,
+            "live_room_ref": live_room_ref,
+            "live_room_id": live_room_id,
+            "live_mode": self.live_mode if isinstance(self.live_mode, str) and self.live_mode in {"co_stream", "solo_stream"} else "co_stream",
+            "live_enabled": public_bool(self.live_enabled),
+            "developer_tools_enabled": public_bool(self.developer_tools_enabled),
+            "dry_run": public_bool(self.dry_run, default=False),
+            "roast_once_per_uid": public_bool(self.roast_once_per_uid, default=True),
+            "roast_strength": self.roast_strength if isinstance(self.roast_strength, str) and self.roast_strength in {"gentle", "normal", "sharp"} else "normal",
+            "activity_level": self.activity_level if isinstance(self.activity_level, str) and self.activity_level in {"quiet", "standard", "active"} else "standard",
+            "co_stream_output_policy": public_text(self.co_stream_output_policy) or "auto_low_interrupt",
+            "solo_output_policy": public_text(self.solo_output_policy) or "auto_rate_limited",
+            "avatar_fetch_timeout_seconds": _safe_float(
+                self.avatar_fetch_timeout_seconds,
+                default=8.0,
+                minimum=0.0,
+            ),
+            "recent_limit": _safe_int(self.recent_limit, default=30, minimum=1, maximum=200),
+            "rate_limit_seconds": _safe_int(self.rate_limit_seconds, default=20, minimum=0, maximum=3600),
+            "queue_limit": _safe_int(self.queue_limit, default=5, minimum=1, maximum=100),
+            "safety_auto_stop_enabled": public_bool(self.safety_auto_stop_enabled, default=True),
+            "safety_window_seconds": _safe_int(self.safety_window_seconds, default=60, minimum=5, maximum=3600),
+            "safety_pipeline_failure_limit": _safe_int(
+                self.safety_pipeline_failure_limit,
+                default=3,
+                minimum=1,
+                maximum=100,
+            ),
+            "safety_output_failure_limit": _safe_int(
+                self.safety_output_failure_limit,
+                default=2,
+                minimum=1,
+                maximum=100,
+            ),
+            "safety_queue_overflow_limit": _safe_int(
+                self.safety_queue_overflow_limit,
+                default=3,
+                minimum=1,
+                maximum=100,
+            ),
+            "viewer_store_dir": public_text(self.viewer_store_dir),
+            "stream_theme": public_text(self.stream_theme, max_len=120),
+            "stream_goal": public_text(self.stream_goal, max_len=160),
+            "stream_columns": public_text(self.stream_columns, max_len=160),
+            "stream_avoid_topics": public_text(self.stream_avoid_topics, max_len=160),
+        }
+
+
+def _safe_text(value: Any, *, default: str) -> str:
+    if not isinstance(value, str):
+        return default
+    text = value.strip()
+    return text if text else default
+
+
+def _safe_optional_text(value: Any, *, max_len: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    return public_text(value.strip(), max_len=max_len)
+
+
+def _safe_bool(value: Any, *, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)) and math.isfinite(float(value)):
+        if value == 1:
+            return True
+        if value == 0:
+            return False
+    if isinstance(value, str):
+        text = value.strip().lower()
+        if text in {"true", "1", "yes", "on"}:
+            return True
+        if text in {"false", "0", "no", "off"}:
+            return False
+    return default
+
+
+def _safe_int(value: Any, *, default: int, minimum: int, maximum: int) -> int:
+    number: int
+    if isinstance(value, bool):
+        number = default
+    elif isinstance(value, int):
+        number = value
+    elif isinstance(value, float) and math.isfinite(value) and value.is_integer():
+        number = int(value)
+    elif isinstance(value, str) and re.fullmatch(r"-?\d+", value.strip()):
+        number = int(value.strip())
+    else:
+        number = default
+    return max(minimum, min(number, maximum))
+
+
+def _safe_float(value: Any, *, default: float, minimum: float) -> float:
+    number: float
+    if isinstance(value, bool):
+        number = default
+    elif isinstance(value, (int, float)):
+        number = float(value)
+    elif isinstance(value, str):
+        try:
+            number = float(value.strip())
+        except ValueError:
+            number = default
+    else:
+        number = default
+    if not math.isfinite(number):
+        number = default
+    return max(minimum, number)

--- a/plugin/plugins/neko_roast/core/contracts_events.py
+++ b/plugin/plugins/neko_roast/core/contracts_events.py
@@ -1,0 +1,126 @@
+"""Live and viewer event contracts for NEKO Live routing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .contracts_public import public_int, public_text, public_value
+from .contracts_types import LiveMode, TriggerSource, utc_now_iso
+
+
+@dataclass
+class ViewerEvent:
+    uid: str
+    nickname: str = ""
+    avatar_url: str = ""
+    danmaku_text: str = ""
+    target_lanlan: str = ""
+    source: TriggerSource = "developer_sandbox"
+    live_mode: LiveMode = "co_stream"
+    trace_id: str = ""
+    seen_at: str = field(default_factory=utc_now_iso)
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = {
+            "uid": public_text(self.uid),
+            "nickname": public_text(self.nickname),
+            "avatar_url": public_text(self.avatar_url),
+            "danmaku_text": public_text(self.danmaku_text),
+            "target_lanlan": public_text(self.target_lanlan),
+            "source": public_text(self.source),
+            "live_mode": public_text(self.live_mode),
+            "trace_id": public_text(self.trace_id),
+            "seen_at": public_text(self.seen_at),
+        }
+        if isinstance(self.raw, dict):
+            event_type = public_text(self.raw.get("event_type"))
+            if event_type:
+                data["event_type"] = event_type
+            gift_name = public_text(self.raw.get("gift_name"), max_len=80)
+            if gift_name:
+                data["gift_name"] = gift_name
+                data["support_gift_name"] = gift_name
+            gift_coin_type = public_text(self.raw.get("gift_coin_type"), max_len=80)
+            if gift_coin_type:
+                data["support_gift_coin_type"] = gift_coin_type
+            for raw_key, public_key in (
+                ("gift_count", "gift_count"),
+                ("gift_value", "gift_value"),
+                ("gift_num", "support_gift_num"),
+                ("gift_total_coin", "support_gift_total_coin"),
+                ("gift_price", "support_gift_price"),
+                ("guard_level", "support_guard_level"),
+            ):
+                value = public_int(self.raw.get(raw_key), default=0, minimum=0)
+                if value:
+                    data[public_key] = value
+            topic = self.raw.get("topic_material")
+            if isinstance(topic, dict):
+                for raw_key, public_key in (
+                    ("source", "topic_source"),
+                    ("shape", "topic_shape"),
+                    ("title", "topic_title"),
+                    ("key", "topic_key"),
+                    ("family", "topic_family"),
+                    ("fun_axis", "topic_fun_axis"),
+                    ("hook", "topic_hook"),
+                    ("pattern", "topic_pattern"),
+                    ("intent", "topic_intent"),
+                    ("live_column", "topic_live_column"),
+                    ("topic_pack", "topic_pack"),
+                    ("reply_affordance", "topic_reply_affordance"),
+                    ("recent_topic_skip_reason", "topic_recent_skip_reason"),
+                ):
+                    value = public_text(topic.get(raw_key))
+                    if value:
+                        data[public_key] = value
+            host_beat = self.raw.get("host_beat")
+            if isinstance(host_beat, dict):
+                for raw_key, public_key in (
+                    ("key", "host_beat_key"),
+                    ("shape", "host_beat_shape"),
+                    ("family", "host_beat_family"),
+                    ("fun_axis", "host_beat_fun_axis"),
+                    ("title", "host_beat_title"),
+                    ("hint", "host_beat_hint"),
+                    ("live_column", "host_beat_live_column"),
+                    ("idle_stage", "host_beat_idle_stage"),
+                    ("reply_affordance", "host_beat_reply_affordance"),
+                ):
+                    value = public_text(host_beat.get(raw_key))
+                    if value:
+                        data[public_key] = value
+        return data
+
+
+@dataclass
+class LiveEvent:
+    """Lightweight envelope routed by EventBus using ``type``."""
+
+    type: str
+    uid: str = ""
+    payload: dict[str, Any] = field(default_factory=dict)
+    source: str = "live"
+    ts: float = 0.0
+    schema_version: int = 1
+    raw: Any = None
+
+    def to_dict(self) -> dict[str, Any]:
+        # Keep raw out of lightweight debug/status projections.
+        return {
+            "type": public_text(self.type),
+            "uid": public_text(self.uid),
+            "payload": public_value(self.payload),
+            "source": public_text(self.source),
+            "ts": _public_timestamp(self.ts),
+            "schema_version": public_int(self.schema_version, default=1, minimum=1),
+        }
+
+
+def _public_timestamp(value: Any) -> float:
+    projected = public_value(value)
+    if isinstance(projected, bool) or not isinstance(projected, (int, float)):
+        return 0.0
+    return float(projected)

--- a/plugin/plugins/neko_roast/core/contracts_interaction.py
+++ b/plugin/plugins/neko_roast/core/contracts_interaction.py
@@ -1,0 +1,133 @@
+"""Pipeline request/result contracts for NEKO Live interactions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from .contracts_events import ViewerEvent
+from .contracts_public import public_bool, public_dict, public_text
+from .contracts_types import LiveMode, RoastStrength, _response_latency_ms, utc_now_iso
+from .contracts_viewer import ViewerIdentity, ViewerProfile
+
+
+@dataclass
+class InteractionRequest:
+    event: ViewerEvent
+    identity: ViewerIdentity
+    profile: ViewerProfile
+    prompt_text: str
+    live_mode: LiveMode
+    strength: RoastStrength
+    should_push: bool = True
+    dry_run: bool = False
+    allow_avatar_image: bool = False
+    reason: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return {
+            "event": self.event.to_dict(),
+            "identity": self.identity.to_public_dict(),
+            "profile": self.profile.to_dict(),
+            "live_mode": _safe_live_mode(self.live_mode),
+            "strength": _safe_strength(self.strength),
+            "should_push": public_bool(self.should_push),
+            "dry_run": public_bool(self.dry_run),
+            "allow_avatar_image": public_bool(self.allow_avatar_image),
+            "reason": public_text(self.reason),
+            "metadata": public_dict(self.metadata),
+        }
+
+
+@dataclass
+class PipelineStep:
+    id: str
+    status: Literal["ok", "dry_run", "skipped", "failed"]
+    message: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "id": public_text(self.id),
+            "status": _safe_step_status(self.status),
+            "message": public_text(self.message),
+        }
+
+
+@dataclass
+class InteractionResult:
+    accepted: bool
+    status: Literal["queued", "dry_run", "pushed", "skipped", "failed"]
+    event: ViewerEvent
+    identity: ViewerIdentity | None = None
+    profile: ViewerProfile | None = None
+    request: InteractionRequest | None = None
+    output: str = ""
+    reason: str = ""
+    steps: list[PipelineStep] = field(default_factory=list)
+    created_at: str = field(default_factory=utc_now_iso)
+    dispatcher_latency_ms: int | None = None
+
+    def to_public_dict(self) -> dict[str, Any]:
+        response_latency_ms = _response_latency_ms(self.event.seen_at, self.created_at)
+        pipeline_latency_ms = response_latency_ms
+        return {
+            "accepted": public_bool(self.accepted),
+            "status": _safe_result_status(self.status),
+            "event": self.event.to_dict(),
+            "identity": self.identity.to_public_dict() if self.identity else None,
+            "profile": self.profile.to_dict() if self.profile else None,
+            "request": self.request.to_public_dict() if self.request else None,
+            "output": public_text(self.output),
+            "reason": public_text(self.reason),
+            "steps": [step.to_dict() for step in self.steps],
+            "created_at": public_text(self.created_at),
+            "response_latency_ms": response_latency_ms,
+            "pipeline_latency_ms": pipeline_latency_ms,
+            "dispatcher_latency_ms": _safe_latency_ms(self.dispatcher_latency_ms),
+        }
+
+    def to_sandbox_dict(self) -> dict[str, Any]:
+        response_latency_ms = _response_latency_ms(self.event.seen_at, self.created_at)
+        pipeline_latency_ms = response_latency_ms
+        return {
+            "accepted": public_bool(self.accepted),
+            "status": _safe_result_status(self.status),
+            "uid": public_text(self.event.uid),
+            "nickname": public_text(self.event.nickname),
+            "output": public_text(self.output),
+            "reason": public_text(self.reason),
+            "steps": [step.to_dict() for step in self.steps],
+            "created_at": public_text(self.created_at),
+            "response_latency_ms": response_latency_ms,
+            "pipeline_latency_ms": pipeline_latency_ms,
+            "dispatcher_latency_ms": _safe_latency_ms(self.dispatcher_latency_ms),
+        }
+
+
+def _safe_live_mode(value: Any) -> str:
+    return value if isinstance(value, str) and value in {"co_stream", "solo_stream"} else "co_stream"
+
+
+def _safe_strength(value: Any) -> str:
+    return value if isinstance(value, str) and value in {"gentle", "normal", "sharp"} else "normal"
+
+
+def _safe_step_status(value: Any) -> str:
+    return value if isinstance(value, str) and value in {"ok", "dry_run", "skipped", "failed"} else "failed"
+
+
+def _safe_result_status(value: Any) -> str:
+    if isinstance(value, str) and value in {"queued", "dry_run", "pushed", "skipped", "failed"}:
+        return value
+    return "failed"
+
+
+def _safe_latency_ms(value: Any) -> int | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        latency = int(value)
+    except (TypeError, ValueError):
+        return None
+    return max(0, latency)

--- a/plugin/plugins/neko_roast/core/contracts_public.py
+++ b/plugin/plugins/neko_roast/core/contracts_public.py
@@ -1,0 +1,87 @@
+"""Public projection helpers for NEKO Live contracts."""
+
+from __future__ import annotations
+
+import math
+import re
+from typing import Any
+
+MAX_PUBLIC_TEXT = 240
+MAX_PUBLIC_DEPTH = 4
+
+_SENSITIVE_AUTH_RE = re.compile(r"\bauthorization\s*:\s*(?:bearer|basic)?\s*[^\s;,]+", re.IGNORECASE)
+_SENSITIVE_TEXT_RE = re.compile(
+    r"\b(?:cookie|token|access_token|refresh_token|signature|webcast_sign|ttwid|odin_tt|sessionid|"
+    r"sessdata|bili_jct|dedeuserid|buvid3|x-tt-token)\b\s*[:=]\s*[^;\s,&]+",
+    re.IGNORECASE,
+)
+
+
+def public_text(value: Any, *, max_len: int = MAX_PUBLIC_TEXT) -> str:
+    if not isinstance(value, str):
+        return ""
+    text = " ".join(value.replace("\r", " ").replace("\n", " ").split())
+    if not text:
+        return ""
+    text = _SENSITIVE_AUTH_RE.sub("[redacted]", text)
+    text = _SENSITIVE_TEXT_RE.sub("[redacted]", text)
+    if len(text) > max_len:
+        if max_len <= 0:
+            return ""
+        suffix = "..."
+        if max_len <= len(suffix):
+            return suffix[:max_len]
+        return text[: max_len - len(suffix)] + suffix
+    return text
+
+
+def public_bool(value: Any, *, default: bool = False) -> bool:
+    return value if isinstance(value, bool) else default
+
+
+def public_int(value: Any, *, default: int = 0, minimum: int | None = None) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        return default
+    if minimum is not None and value < minimum:
+        return minimum
+    return value
+
+
+def public_dict(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    return _public_dict(value, depth=0)
+
+
+def public_value(value: Any, *, depth: int = 0) -> Any:
+    if depth >= MAX_PUBLIC_DEPTH:
+        return None
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else 0.0
+    if isinstance(value, str):
+        return public_text(value)
+    if isinstance(value, dict):
+        return _public_dict(value, depth=depth)
+    if isinstance(value, (list, tuple)):
+        return [public_value(item, depth=depth + 1) for item in value[:20]]
+    return ""
+
+
+def _public_dict(value: dict[Any, Any], *, depth: int) -> dict[str, Any]:
+    if depth >= MAX_PUBLIC_DEPTH:
+        return {}
+    result: dict[str, Any] = {}
+    for raw_key, raw_value in value.items():
+        if not isinstance(raw_key, str):
+            continue
+        key = public_text(raw_key)
+        if not key:
+            continue
+        result[key] = public_value(raw_value, depth=depth + 1)
+    return result

--- a/plugin/plugins/neko_roast/core/contracts_safety.py
+++ b/plugin/plugins/neko_roast/core/contracts_safety.py
@@ -1,0 +1,31 @@
+"""Safety and live-room status contracts for NEKO Live integrations."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from .contracts_types import SafetyStatus
+
+
+@dataclass
+class SafetyDecision:
+    allowed: bool
+    status: SafetyStatus = "running"
+    reason: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class LiveRoomStatus:
+    room_id: int
+    ok: bool
+    title: str = ""
+    anchor_name: str = ""
+    live_status: str = "unknown"
+    message: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)

--- a/plugin/plugins/neko_roast/core/contracts_types.py
+++ b/plugin/plugins/neko_roast/core/contracts_types.py
@@ -1,0 +1,38 @@
+"""Shared type aliases and time helpers for NEKO Live contracts."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Literal
+
+LiveMode = Literal["co_stream", "solo_stream"]
+RoastStrength = Literal["gentle", "normal", "sharp"]
+ActivityLevel = Literal["quiet", "standard", "active"]
+TriggerSource = Literal[
+    "live_danmaku",
+    "developer_sandbox",
+    "manual_live_simulation",
+    "idle_hosting",
+    "active_engagement",
+    "warmup_hosting",
+]
+SafetyStatus = Literal["running", "paused", "degraded", "tripped", "disconnected"]
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _response_latency_ms(seen_at: str, created_at: str) -> int | None:
+    if not seen_at or not created_at:
+        return None
+    try:
+        seen = datetime.fromisoformat(str(seen_at).replace("Z", "+00:00"))
+        created = datetime.fromisoformat(str(created_at).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if seen.tzinfo is None:
+        seen = seen.replace(tzinfo=timezone.utc)
+    if created.tzinfo is None:
+        created = created.replace(tzinfo=timezone.utc)
+    return max(0, int(round((created - seen).total_seconds() * 1000)))

--- a/plugin/plugins/neko_roast/core/contracts_viewer.py
+++ b/plugin/plugins/neko_roast/core/contracts_viewer.py
@@ -1,0 +1,104 @@
+"""Viewer identity and profile contracts for NEKO Live memory."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .contracts_public import public_bool, public_int, public_text
+from .contracts_types import utc_now_iso
+
+
+@dataclass
+class ViewerIdentity:
+    uid: str
+    nickname: str
+    name: str = ""
+    email: str = ""
+    avatar_url: str = ""
+    avatar_bytes: bytes | None = None
+    avatar_mime: str = ""
+    source_url: str = ""
+    fetched: bool = False
+    error: str = ""
+    # Avatar metadata helps modules avoid inventing visual details.
+    is_default_avatar: bool = False
+    is_animated_avatar: bool = False
+    pendant: str = ""
+
+    @property
+    def avatar_vision_ok(self) -> bool:
+        """Whether an actual avatar frame is available for vision input."""
+        return bool(self.avatar_bytes)
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return {
+            "uid": public_text(self.uid),
+            "nickname": public_text(self.nickname),
+            "name": public_text(self.name) or public_text(self.nickname),
+            "avatar_url": public_text(self.avatar_url),
+            "avatar_mime": public_text(self.avatar_mime),
+            "has_avatar": bool(self.avatar_bytes),
+            "is_default_avatar": public_bool(self.is_default_avatar),
+            "is_animated_avatar": public_bool(self.is_animated_avatar),
+            "pendant": public_text(self.pendant),
+            "source_url": public_text(self.source_url),
+            "fetched": public_bool(self.fetched),
+            "error": public_text(self.error),
+        }
+
+
+@dataclass
+class ViewerProfile:
+    uid: str
+    nickname: str
+    avatar_url: str = ""
+    first_seen_at: str = field(default_factory=utc_now_iso)
+    last_seen_at: str = field(default_factory=utc_now_iso)
+    roast_count: int = 0
+    last_roast_at: str = ""
+    last_result: str = ""
+    danmaku_count: int = 0
+    preference_tags: dict[str, int] = field(default_factory=dict)
+    favorite_topics: dict[str, int] = field(default_factory=dict)
+    running_jokes: dict[str, int] = field(default_factory=dict)
+    interaction_style: str = ""
+    response_preference: str = ""
+    last_interaction_summary: str = ""
+    impression_summary: str = ""
+    avoid_guidance: str = ""
+    last_interaction_at: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "uid": public_text(self.uid),
+            "nickname": public_text(self.nickname),
+            "avatar_url": public_text(self.avatar_url),
+            "first_seen_at": public_text(self.first_seen_at),
+            "last_seen_at": public_text(self.last_seen_at),
+            "roast_count": public_int(self.roast_count, default=0, minimum=0),
+            "last_roast_at": public_text(self.last_roast_at),
+            "last_result": public_text(self.last_result),
+            "danmaku_count": public_int(self.danmaku_count, default=0, minimum=0),
+            "preference_tags": {
+                public_text(key, max_len=48): public_int(value, default=0, minimum=0)
+                for key, value in self.preference_tags.items()
+                if public_text(key, max_len=48)
+            },
+            "favorite_topics": {
+                public_text(key, max_len=48): public_int(value, default=0, minimum=0)
+                for key, value in self.favorite_topics.items()
+                if public_text(key, max_len=48)
+            },
+            "running_jokes": {
+                public_text(key, max_len=48): public_int(value, default=0, minimum=0)
+                for key, value in self.running_jokes.items()
+                if public_text(key, max_len=48)
+            },
+            "interaction_style": public_text(self.interaction_style, max_len=48),
+            "response_preference": public_text(self.response_preference, max_len=180),
+            "last_interaction_summary": public_text(self.last_interaction_summary, max_len=160),
+            "impression_summary": public_text(self.impression_summary, max_len=180),
+            "avoid_guidance": public_text(self.avoid_guidance, max_len=180),
+            "last_interaction_at": public_text(self.last_interaction_at),
+        }

--- a/plugin/plugins/neko_roast/core/event_bus.py
+++ b/plugin/plugins/neko_roast/core/event_bus.py
@@ -23,6 +23,7 @@ handler 可同步可异步：同步 handler 内联调用（沿用插件既有「
 from __future__ import annotations
 
 import asyncio
+import time
 from collections.abc import Callable
 from typing import Any
 
@@ -41,6 +42,9 @@ class EventBus:
         self._subs: dict[str, list[_Subscription]] = {}
         self._audit = audit
         self._tasks: set[asyncio.Task[Any]] = set()
+        self._last_publish_at: float = 0.0
+        self._last_event_type: str = ""
+        self._publish_count: int = 0
 
     def subscribe(self, event_type: str, handler: Callable[[Any], Any], *, owner: str = "") -> Callable[[], None]:
         """订阅某类直播事件。``owner``=归属模块 id（失败 audit 用）。返回取消订阅的句柄。"""
@@ -59,14 +63,26 @@ class EventBus:
 
     def publish(self, event_type: str, event: Any) -> None:
         """按类型逐订阅者隔离派发。无订阅者 = 静默丢弃。"""
-        for sub in list(self._subs.get(str(event_type), [])):
+        event_type = str(event_type)
+        if getattr(event, "schema_version", None) is not None and getattr(event, "type", ""):
+            self._last_publish_at = time.time()
+            self._last_event_type = event_type
+            self._publish_count += 1
+        for sub in list(self._subs.get(event_type, [])):
             try:
                 result = sub.handler(event)
             except Exception as exc:  # noqa: BLE001 — 单订阅者失败隔离，不波及其余
                 self._record_error(sub.owner, str(event_type), exc)
                 continue
             if asyncio.iscoroutine(result):
-                self._spawn_isolated(result, sub.owner, str(event_type))
+                self._spawn_isolated(result, sub.owner, event_type)
+
+    def status(self) -> dict[str, Any]:
+        return {
+            "last_publish_at": self._last_publish_at,
+            "last_event_type": self._last_event_type,
+            "publish_count": self._publish_count,
+        }
 
     # —— 向后兼容的观测别名（runtime 的 sandbox_result / result 仍走这俩；无订阅者即 no-op）——
     def on(self, event: str, listener: Callable[[Any], Any]) -> Callable[[], None]:

--- a/plugin/plugins/neko_roast/core/module_registry.py
+++ b/plugin/plugins/neko_roast/core/module_registry.py
@@ -1,19 +1,15 @@
-"""Feature-module registry for Neko Roast.
-
-兜底（模块故障隔离）：`setup_all` / `teardown_all` 逐模块 try/except——任何单个模块
-setup/teardown 抛错都只标记该模块 `degraded` 并记 audit，**其余模块照常起停**，绝不让
-一个坏模块（尤其未来多人写的）拖垮整个直播中心。`snapshot()` 对每个模块的 `status()` /
-`config_schema()` 也做守卫，坏模块退化成一条降级记录而非整盘崩。
-
-模块贡献（面向 UI / 未来扩展）：模块除 `status()` 外可声明 `domain`（生命周期/能力域归属）
-与 `config_schema()`（声明式配置字段，面板据此自动渲染该功能自己的设置卡，见
-docs/ui-architecture.md）。两者都是可选项，缺省安全降级。
-"""
+"""Feature-module registry for Neko Roast."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from typing import Any, Protocol
+
+from .module_registry_lifecycle import (
+    setup_all_modules,
+    teardown_all_modules,
+    toggle_module,
+)
+from .module_registry_snapshot import ModuleRecord, module_snapshot
 
 
 class InteractionModule(Protocol):
@@ -42,23 +38,10 @@ class InteractionModule(Protocol):
         raise NotImplementedError
 
 
-@dataclass
-class ModuleRecord:
-    id: str
-    title: str
-    version: str
-    enabled: bool
-    status: dict[str, Any]
-    domain: str = ""
-    config_schema: list[dict[str, Any]] = field(default_factory=list)
-    degraded: bool = False
-    error: str = ""
-
-
 class ModuleRegistry:
     def __init__(self) -> None:
         self._modules: dict[str, InteractionModule] = {}
-        self._degraded: dict[str, str] = {}  # module_id -> 失败原因（setup 抛错时填）
+        self._degraded: dict[str, str] = {}
 
     def register(self, module: InteractionModule) -> None:
         if module.id in self._modules:
@@ -66,62 +49,16 @@ class ModuleRegistry:
         self._modules[module.id] = module
 
     async def setup_all(self, ctx: Any) -> None:
-        """逐模块 setup，单点失败隔离：坏模块标 degraded + 记 audit，其余照常起。"""
-        self._degraded.clear()
-        for module in self._modules.values():
-            try:
-                await module.setup(ctx)
-            except Exception as exc:
-                message = str(exc).strip() or type(exc).__name__
-                self._degraded[module.id] = message
-                self._record_failure(ctx, "module_setup_failed", module.id, message)
+        await setup_all_modules(self._modules, self._degraded, ctx)
 
     async def teardown_all(self) -> None:
-        """逐模块 teardown，单点失败隔离：一个模块 teardown 抛错不阻断其余。"""
-        for module in reversed(list(self._modules.values())):
-            try:
-                await module.teardown()
-            except Exception:  # noqa: BLE001
-                pass
+        await teardown_all_modules(self._modules)
 
     async def enable(self, module_id: str, ctx: Any) -> bool:
-        """启用模块并触发 on_enable，单点失败隔离（标 degraded + 记 audit，不抛、不波及其余）。
-
-        返回 True=钩子成功（或无钩子）/ False=未知模块或钩子抛错。注：地基件——
-        per-module 启停的真实调用方（如把 live_enabled 接到 avatar_roast）落地后再接入。
-        """
-        return await self._toggle(module_id, True, ctx)
+        return await toggle_module(self._modules, self._degraded, module_id, True, ctx)
 
     async def disable(self, module_id: str, ctx: Any) -> bool:
-        """停用模块并触发 on_disable，单点失败隔离。返回约定同 enable。"""
-        return await self._toggle(module_id, False, ctx)
-
-    async def _toggle(self, module_id: str, enabled: bool, ctx: Any) -> bool:
-        module = self._modules.get(module_id)
-        if module is None:
-            return False
-        previous_enabled = bool(getattr(module, "enabled", False))
-        hook = getattr(module, "on_enable" if enabled else "on_disable", None)
-        if not callable(hook):
-            module.enabled = enabled
-            self._degraded.pop(module_id, None)
-            return True
-        try:
-            await (hook(ctx) if enabled else hook())
-            module.enabled = enabled
-            self._degraded.pop(module_id, None)
-            return True
-        except Exception as exc:  # noqa: BLE001
-            module.enabled = previous_enabled
-            message = str(exc).strip() or type(exc).__name__
-            self._degraded[module_id] = message
-            self._record_failure(
-                ctx,
-                "module_enable_failed" if enabled else "module_disable_failed",
-                module_id,
-                message,
-            )
-            return False
+        return await toggle_module(self._modules, self._degraded, module_id, False, ctx)
 
     def get(self, module_id: str) -> InteractionModule:
         return self._modules[module_id]
@@ -129,53 +66,12 @@ class ModuleRegistry:
     def is_degraded(self, module_id: str) -> bool:
         return module_id in self._degraded
 
-    @staticmethod
-    def _record_failure(ctx: Any, op: str, module_id: str, message: str) -> None:
-        audit = getattr(ctx, "audit", None)
-        record = getattr(audit, "record", None)
-        if callable(record):
-            try:
-                record(op, f"module {module_id}: {message}", level="error", detail={"module": module_id})
-            except Exception:  # noqa: BLE001 — 连记录都失败也不能反过来炸 setup 流程
-                pass
-
-    @staticmethod
-    def _safe_meta(module: InteractionModule) -> tuple[dict[str, Any], str, list[dict[str, Any]]]:
-        """守卫式提取 status / domain / config_schema：坏模块不拖垮整盘 snapshot。"""
-        try:
-            status = module.status()
-            if not isinstance(status, dict):
-                status = {"value": status}
-        except Exception as exc:  # noqa: BLE001
-            status = {"error": str(exc).strip() or type(exc).__name__}
-        domain = str(getattr(module, "domain", "") or "")
-        schema: list[dict[str, Any]] = []
-        getter = getattr(module, "config_schema", None)
-        if callable(getter):
-            try:
-                raw = getter()
-                if isinstance(raw, list):
-                    schema = [item for item in raw if isinstance(item, dict)]
-            except Exception:  # noqa: BLE001
-                schema = []
-        return status, domain, schema
-
     def snapshot(self) -> list[dict[str, Any]]:
-        records: list[dict[str, Any]] = []
-        for module in self._modules.values():
-            status, domain, schema = self._safe_meta(module)
-            error = self._degraded.get(module.id, "")
-            records.append(
-                ModuleRecord(
-                    id=module.id,
-                    title=str(getattr(module, "title", module.id) or module.id),
-                    version=str(getattr(module, "version", "") or ""),
-                    enabled=bool(getattr(module, "enabled", False)),
-                    status=status,
-                    domain=domain,
-                    config_schema=schema,
-                    degraded=bool(error),
-                    error=error,
-                ).__dict__
-            )
-        return records
+        return module_snapshot(self._modules, self._degraded)
+
+
+__all__ = [
+    "InteractionModule",
+    "ModuleRecord",
+    "ModuleRegistry",
+]

--- a/plugin/plugins/neko_roast/core/module_registry_lifecycle.py
+++ b/plugin/plugins/neko_roast/core/module_registry_lifecycle.py
@@ -1,0 +1,84 @@
+"""Lifecycle isolation helpers for feature modules."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+async def setup_all_modules(
+    modules: dict[str, Any],
+    degraded: dict[str, str],
+    ctx: Any,
+) -> None:
+    degraded.clear()
+    for module in modules.values():
+        try:
+            await module.setup(ctx)
+        except Exception as exc:  # noqa: BLE001
+            message = _error_message(exc)
+            degraded[module.id] = message
+            record_failure(ctx, "module_setup_failed", module.id, message)
+
+
+async def teardown_all_modules(modules: dict[str, Any]) -> None:
+    for module in reversed(list(modules.values())):
+        try:
+            await module.teardown()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+async def toggle_module(
+    modules: dict[str, Any],
+    degraded: dict[str, str],
+    module_id: str,
+    enabled: bool,
+    ctx: Any,
+) -> bool:
+    module = modules.get(module_id)
+    if module is None:
+        return False
+
+    previous_enabled = bool(getattr(module, "enabled", False))
+    hook = getattr(module, "on_enable" if enabled else "on_disable", None)
+    if not callable(hook):
+        module.enabled = enabled
+        degraded.pop(module_id, None)
+        return True
+
+    try:
+        await (hook(ctx) if enabled else hook())
+        module.enabled = enabled
+        degraded.pop(module_id, None)
+        return True
+    except Exception as exc:  # noqa: BLE001
+        module.enabled = previous_enabled
+        message = _error_message(exc)
+        degraded[module_id] = message
+        record_failure(
+            ctx,
+            "module_enable_failed" if enabled else "module_disable_failed",
+            module_id,
+            message,
+        )
+        return False
+
+
+def record_failure(ctx: Any, op: str, module_id: str, message: str) -> None:
+    audit = getattr(ctx, "audit", None)
+    record = getattr(audit, "record", None)
+    if not callable(record):
+        return
+    try:
+        record(
+            op,
+            f"module {module_id}: {message}",
+            level="error",
+            detail={"module": module_id},
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _error_message(exc: Exception) -> str:
+    return str(exc).strip() or type(exc).__name__

--- a/plugin/plugins/neko_roast/core/module_registry_snapshot.py
+++ b/plugin/plugins/neko_roast/core/module_registry_snapshot.py
@@ -1,0 +1,119 @@
+"""Safe module metadata projection for dashboards and hosted UI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import math
+import re
+from typing import Any
+
+_MAX_TEXT = 240
+_MAX_DEPTH = 4
+_SENSITIVE_AUTH_RE = re.compile(r"(?i)\bauthorization\b\s*[:=]\s*[^,;]+")
+_SENSITIVE_TEXT_RE = re.compile(
+    r"(?i)\b(?:"
+    r"cookie|authorization|x-tt-token|ttwid|odin_tt|sessionid|sessionid_ss|sid_tt|uid_tt|"
+    r"webcast_sign|signature|sign|token|sessdata|bili_jct"
+    r")\b\s*[:=]\s*[^;&\s]+"
+)
+
+
+@dataclass
+class ModuleRecord:
+    id: str
+    title: str
+    version: str
+    enabled: bool
+    status: dict[str, Any]
+    domain: str = ""
+    config_schema: list[dict[str, Any]] = field(default_factory=list)
+    degraded: bool = False
+    error: str = ""
+
+
+def module_snapshot(
+    modules: dict[str, Any],
+    degraded: dict[str, str],
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for module in modules.values():
+        status, domain, schema = safe_meta(module)
+        module_id = _safe_text(getattr(module, "id", ""))
+        error = _safe_text(degraded.get(module.id, ""))
+        records.append(
+            ModuleRecord(
+                id=module_id,
+                title=_safe_text(getattr(module, "title", module_id) or module_id),
+                version=_safe_text(getattr(module, "version", "") or ""),
+                enabled=getattr(module, "enabled", False) is True,
+                status=status,
+                domain=domain,
+                config_schema=schema,
+                degraded=bool(error),
+                error=error,
+            ).__dict__
+        )
+    return records
+
+
+def safe_meta(module: Any) -> tuple[dict[str, Any], str, list[dict[str, Any]]]:
+    try:
+        status = module.status()
+        if not isinstance(status, dict):
+            status = {"value": status}
+    except Exception as exc:  # noqa: BLE001
+        status = {"error": _safe_text(str(exc).strip() or type(exc).__name__)}
+    else:
+        status = _safe_public_dict(status)
+
+    domain = _safe_text(getattr(module, "domain", "") or "")
+    schema: list[dict[str, Any]] = []
+    getter = getattr(module, "config_schema", None)
+    if callable(getter):
+        try:
+            raw = getter()
+            if isinstance(raw, list):
+                schema = [_safe_public_dict(item) for item in raw if isinstance(item, dict)]
+        except Exception:  # noqa: BLE001
+            schema = []
+    return status, domain, schema
+
+
+def _safe_public_dict(value: dict[str, Any]) -> dict[str, Any]:
+    safe: dict[str, Any] = {}
+    for key, item in value.items():
+        if not isinstance(key, str):
+            continue
+        safe[key] = _safe_public_value(item, depth=0)
+    return safe
+
+
+def _safe_public_value(value: Any, *, depth: int) -> Any:
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else 0.0
+    if isinstance(value, str):
+        return _safe_text(value)
+    if depth >= _MAX_DEPTH:
+        return None
+    if isinstance(value, dict):
+        return {
+            key: _safe_public_value(item, depth=depth + 1)
+            for key, item in value.items()
+            if isinstance(key, str)
+        }
+    if isinstance(value, (list, tuple)):
+        return [_safe_public_value(item, depth=depth + 1) for item in value]
+    return ""
+
+
+def _safe_text(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    text = " ".join(value.split()).strip()
+    text = _SENSITIVE_AUTH_RE.sub("[redacted]", text)
+    text = _SENSITIVE_TEXT_RE.sub("[redacted]", text)
+    return text[:_MAX_TEXT]

--- a/plugin/plugins/neko_roast/core/permission_gate.py
+++ b/plugin/plugins/neko_roast/core/permission_gate.py
@@ -17,7 +17,13 @@ class PermissionGate:
             if not self.config.developer_tools_enabled:
                 return False, "developer tools are disabled"
             return True, ""
-        if source in {"live_danmaku", "manual_live_simulation"}:
+        if source == "manual_live_simulation":
+            if not self.config.developer_tools_enabled:
+                return False, "developer tools are disabled"
+            if not self.config.live_enabled:
+                return False, "live roast is disabled"
+            return True, ""
+        if source in {"live_danmaku", "idle_hosting", "active_engagement", "warmup_hosting"}:
             if not self.config.live_enabled:
                 return False, "live roast is disabled"
             return True, ""

--- a/plugin/plugins/neko_roast/core/safety_guard.py
+++ b/plugin/plugins/neko_roast/core/safety_guard.py
@@ -2,18 +2,32 @@
 
 from __future__ import annotations
 
-import time
 from dataclasses import dataclass, field
-from typing import Any, Literal
+from typing import Any
 
+from . import safety_guard_cooldown, safety_guard_failures
 from .contracts import RoastConfig, SafetyDecision, SafetyStatus, ViewerEvent
+from .safety_guard_types import FailureKind
 
-FailureKind = Literal["pipeline", "output"]
+
+_LIVE_CONNECTED_SOURCES = {
+    "live_danmaku",
+    "manual_live_simulation",
+    "idle_hosting",
+    "active_engagement",
+    "warmup_hosting",
+}
+
+
+def _requires_live_connection(event: ViewerEvent | None) -> bool:
+    if event is None:
+        return False
+    return event.source in _LIVE_CONNECTED_SOURCES
 
 
 @dataclass
 class SafetyGuard:
-    """Keeps live failures from leaking into the stream or spamming output."""
+    """Public safety gate facade for stream input, output, and circuit breaks."""
 
     config: RoastConfig
     audit: Any
@@ -26,6 +40,7 @@ class SafetyGuard:
     _pipeline_failures: list[float] = field(default_factory=list)
     _output_failures: list[float] = field(default_factory=list)
     _last_output_at: float = 0.0
+    _last_support_output_at: float = 0.0
 
     def update(self, config: RoastConfig) -> None:
         self.config = config
@@ -43,6 +58,7 @@ class SafetyGuard:
         self._pipeline_failures.clear()
         self._output_failures.clear()
         self._last_output_at = 0.0
+        self._last_support_output_at = 0.0
         self.clear_queue()
         self.audit.record("safety_resumed", "safety guard reset", level="info")
 
@@ -53,8 +69,10 @@ class SafetyGuard:
         self.connected = bool(connected)
 
     def before_event(self, event: ViewerEvent) -> SafetyDecision:
-        if event.source == "live_danmaku" and not self.connected:
-            return SafetyDecision(False, "disconnected", "live event source is disconnected")
+        if _requires_live_connection(event) and not self.connected:
+            return SafetyDecision(
+                False, "disconnected", "live event source is disconnected"
+            )
         if self.manual_paused:
             return SafetyDecision(False, "paused", "roast is manually paused")
         if self.auto_paused:
@@ -67,7 +85,10 @@ class SafetyGuard:
                 "safety_queue_overflow",
                 "queue limit reached",
                 level="warning",
-                detail={"queue_size": self.queue_size, "queue_limit": self.config.queue_limit},
+                detail={
+                    "queue_size": self.queue_size,
+                    "queue_limit": self.config.queue_limit,
+                },
             )
             return SafetyDecision(False, self.status(), "queue limit reached")
         self.queue_size += 1
@@ -77,60 +98,28 @@ class SafetyGuard:
         self.queue_size = max(0, self.queue_size - 1)
 
     def before_output(self, event: ViewerEvent | None = None) -> SafetyDecision:
+        if _requires_live_connection(event) and not self.connected:
+            return SafetyDecision(
+                False, "disconnected", "live output source is disconnected"
+            )
         if self.manual_paused:
             return SafetyDecision(False, "paused", "output is manually paused")
         if self.auto_paused:
             return SafetyDecision(False, "tripped", "automatic safety stop is active")
-        # 限流：直播态按 rate_limit_seconds 控制最小锐评间隔；开发者沙盒不限流（要即时调试反馈）。
-        is_sandbox = event is not None and event.source == "developer_sandbox"
-        if not is_sandbox and self.config.rate_limit_seconds > 0:
-            now = time.monotonic()
-            if (now - self._last_output_at) < self.config.rate_limit_seconds:
-                return SafetyDecision(False, self.status(), "rate limited")
-            self._last_output_at = now
+        cooldown_decision = safety_guard_cooldown.before_output_cooldown(self, event)
+        if cooldown_decision is not None:
+            return cooldown_decision
         return SafetyDecision(True, self.status(), "")
 
     def output_cooldown_remaining(self, now: float | None = None) -> float:
-        """到下一次允许投递还剩多少秒（按 rate_limit_seconds）。
-
-        限流关闭（``rate_limit_seconds <= 0``）或冷却已过返回 ``0.0``。只描述限流时序，
-        不含暂停/急停（那是 ``before_output`` 的硬闸门）。供 ``live_events`` 中枢把开窗
-        择优对齐到这段冷却：窗口在冷却结束时 flush，胜者不会反被 ``before_output`` 判限流。
-        """
-        if self.config.rate_limit_seconds <= 0:
-            return 0.0
-        current = time.monotonic() if now is None else now
-        remaining = self.config.rate_limit_seconds - (current - self._last_output_at)
-        return remaining if remaining > 0 else 0.0
+        """Return seconds until output cooldown opens; pause/trip are separate gates."""
+        return safety_guard_cooldown.output_cooldown_remaining(self, now)
 
     def record_failure(self, kind: FailureKind, message: str) -> None:
-        now = time.monotonic()
-        bucket = self._pipeline_failures if kind == "pipeline" else self._output_failures
-        bucket.append(now)
-        self._trim(bucket, now)
-        limit = (
-            self.config.safety_pipeline_failure_limit
-            if kind == "pipeline"
-            else self.config.safety_output_failure_limit
-        )
-        self.audit.record(
-            f"safety_{kind}_failure",
-            message,
-            level="error",
-            detail={"count": len(bucket), "limit": limit},
-        )
-        if self.config.safety_auto_stop_enabled and len(bucket) >= limit:
-            self.auto_paused = True
-            self.audit.record(
-                "safety_auto_stop",
-                f"automatic stop after {len(bucket)} {kind} failures",
-                level="error",
-                detail={"kind": kind, "window_seconds": self.config.safety_window_seconds},
-            )
+        safety_guard_failures.record_failure(self, kind, message)
 
     def _trim(self, bucket: list[float], now: float) -> None:
-        window = self.config.safety_window_seconds
-        bucket[:] = [item for item in bucket if now - item <= window]
+        safety_guard_failures.trim_failure_bucket(self, bucket, now)
 
     def status(self) -> SafetyStatus:
         if not self.connected:

--- a/plugin/plugins/neko_roast/core/safety_guard_cooldown.py
+++ b/plugin/plugins/neko_roast/core/safety_guard_cooldown.py
@@ -1,0 +1,54 @@
+"""Output cooldown helpers for the live safety guard."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from .contracts import SafetyDecision, ViewerEvent
+
+
+THROTTLED_SUPPORT_EVENT_TYPES = {"gift"}
+UNTHROTTLED_SUPPORT_EVENT_TYPES = {"super_chat", "guard"}
+SUPPORT_EVENT_COOLDOWN_SECONDS = 1.5
+
+
+def _support_event_type(event: ViewerEvent | None) -> str:
+    if event is None or not isinstance(event.raw, dict):
+        return ""
+    value = event.raw.get("event_type")
+    if not isinstance(value, str):
+        return ""
+    normalized = value.strip().lower()
+    return "super_chat" if normalized == "sc" else normalized
+
+
+def before_output_cooldown(
+    guard: Any, event: ViewerEvent | None = None
+) -> SafetyDecision | None:
+    if event is not None and event.source == "developer_sandbox":
+        return None
+    if guard.config.rate_limit_seconds <= 0:
+        return None
+    now = time.monotonic()
+    support_type = _support_event_type(event)
+    if support_type in THROTTLED_SUPPORT_EVENT_TYPES:
+        last_support = float(getattr(guard, "_last_support_output_at", 0.0) or 0.0)
+        if (now - last_support) < SUPPORT_EVENT_COOLDOWN_SECONDS:
+            return SafetyDecision(False, guard.status(), "support event rate limited")
+        guard._last_support_output_at = now
+        return None
+    if support_type in UNTHROTTLED_SUPPORT_EVENT_TYPES:
+        return None
+    if (now - guard._last_output_at) < guard.config.rate_limit_seconds:
+        return SafetyDecision(False, guard.status(), "rate limited")
+    guard._last_output_at = now
+    return None
+
+
+def output_cooldown_remaining(guard: Any, now: float | None = None) -> float:
+    if guard.config.rate_limit_seconds <= 0:
+        return 0.0
+    current = time.monotonic() if now is None else now
+    remaining = guard.config.rate_limit_seconds - (current - guard._last_output_at)
+    return remaining if remaining > 0 else 0.0

--- a/plugin/plugins/neko_roast/core/safety_guard_failures.py
+++ b/plugin/plugins/neko_roast/core/safety_guard_failures.py
@@ -1,0 +1,42 @@
+"""Failure-window and auto-stop helpers for the live safety guard."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from .safety_guard_types import FailureKind
+
+
+def record_failure(guard: Any, kind: FailureKind, message: str) -> None:
+    now = time.monotonic()
+    bucket = guard._pipeline_failures if kind == "pipeline" else guard._output_failures
+    bucket.append(now)
+    trim_failure_bucket(guard, bucket, now)
+    limit = (
+        guard.config.safety_pipeline_failure_limit
+        if kind == "pipeline"
+        else guard.config.safety_output_failure_limit
+    )
+    guard.audit.record(
+        f"safety_{kind}_failure",
+        message,
+        level="error",
+        detail={"count": len(bucket), "limit": limit},
+    )
+    if guard.config.safety_auto_stop_enabled and len(bucket) >= limit:
+        guard.auto_paused = True
+        guard.audit.record(
+            "safety_auto_stop",
+            f"automatic stop after {len(bucket)} {kind} failures",
+            level="error",
+            detail={
+                "kind": kind,
+                "window_seconds": guard.config.safety_window_seconds,
+            },
+        )
+
+
+def trim_failure_bucket(guard: Any, bucket: list[float], now: float) -> None:
+    window = guard.config.safety_window_seconds
+    bucket[:] = [item for item in bucket if now - item <= window]

--- a/plugin/plugins/neko_roast/core/safety_guard_types.py
+++ b/plugin/plugins/neko_roast/core/safety_guard_types.py
@@ -1,0 +1,7 @@
+"""Shared safety guard type aliases."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+FailureKind = Literal["pipeline", "output"]

--- a/plugin/plugins/neko_roast/tests/test_config_contracts.py
+++ b/plugin/plugins/neko_roast/tests/test_config_contracts.py
@@ -6,16 +6,17 @@ import pytest
 from plugin.plugins.neko_roast.adapters.bili_auth_service import BiliAuthService
 from plugin.plugins.neko_roast.adapters.neko_dispatcher import NekoDispatcher
 from plugin.plugins.neko_roast.core.contracts import InteractionRequest, RoastConfig, SafetyDecision, ViewerEvent, ViewerIdentity, ViewerProfile, utc_now_iso
+from plugin.plugins.neko_roast.core.contracts_public import public_text
 from plugin.plugins.neko_roast.core.module_registry import ModuleRegistry
 from plugin.plugins.neko_roast.core.permission_gate import PermissionGate
 from plugin.plugins.neko_roast.core.pipeline import RoastPipeline
 from plugin.plugins.neko_roast.modules.bili_identity import BiliIdentityModule
 
 
-def test_roast_config_defaults_to_dry_run_for_real_room_safety():
-    assert RoastConfig().dry_run is True
-    assert RoastConfig.from_mapping({}).dry_run is True
-    assert RoastConfig.from_mapping(None).dry_run is True
+def test_roast_config_defaults_to_real_output_with_live_disabled():
+    assert RoastConfig().dry_run is False
+    assert RoastConfig.from_mapping({}).dry_run is False
+    assert RoastConfig.from_mapping(None).dry_run is False
 
 
 def test_roast_config_preserves_explicit_dry_run_false_for_real_output_window():
@@ -24,6 +25,41 @@ def test_roast_config_preserves_explicit_dry_run_false_for_real_output_window():
 
 def test_roast_config_preserves_explicit_avatar_timeout_zero():
     assert RoastConfig.from_mapping({"avatar_fetch_timeout_seconds": 0}).avatar_fetch_timeout_seconds == 0
+
+
+def test_roast_config_accepts_whole_number_float_int_fields():
+    config = RoastConfig.from_mapping(
+        {
+            "rate_limit_seconds": 30.0,
+            "queue_limit": 7.0,
+            "recent_limit": 12.5,
+        }
+    )
+
+    assert config.rate_limit_seconds == 30
+    assert config.queue_limit == 7
+    assert config.recent_limit == 30
+
+
+def test_public_text_truncation_respects_max_len():
+    assert public_text("abcdef", max_len=5) == "ab..."
+    assert public_text("abcdef", max_len=3) == "..."
+    assert public_text("abcdef", max_len=2) == ".."
+    assert public_text("abcdef", max_len=0) == ""
+
+
+def test_viewer_event_public_projection_sanitizes_trace_and_drops_raw():
+    projected = ViewerEvent(
+        uid="1",
+        nickname="tester",
+        trace_id="token=secret",
+        raw={"token": "secret", "event_type": "danmaku"},
+    ).to_dict()
+
+    assert "raw" not in projected
+    assert projected["trace_id"] == "[redacted]"
+    assert projected["event_type"] == "danmaku"
+    assert "token" not in projected
 
 
 def test_utc_now_iso_returns_timezone_aware_utc_timestamp():


### PR DESCRIPTION
## Summary
Stacked PR slice 1/26 for bringing the modular NEKO Live / neko_roast plugin changes into upstream main while keeping each review unit small.

## Scope
- Branch: `agent/neko-live-contracts`
- Base / merge order: first PR against `main`
- Files changed in this commit: 18
- Path boundary: only `plugin/plugins/neko_roast/**`

## Module Slice
Contracts foundation.

## Protected Modules / Review Gate
Touches core contracts, EventBus/module registry, permission and safety guard boundaries. Review with plugin Owner roles from `plugin/plugins/neko_roast/AGENTS.md`.

## Regression Report
- Updated the NEKO Live config contract test to match the current packaged behavior: `dry_run` defaults to false while `live_enabled` still defaults to false.
- Local upstream-main validation:
  - `uv run pytest plugin/plugins/neko_roast/tests -q --maxfail=1` -> `69 passed, 1 warning`
  - `uv run pytest plugin/tests/unit/core/test_host_dynamic_entry_refresh.py::test_host_rebuilds_entry_map_for_dynamic_entry -q` -> `1 passed, 2 warnings`
  - `git diff --check -- plugin/plugins/neko_roast` -> clean

## Rollback / Degrade
Revert this PR before merging dependent stacked PRs, or drop this branch from the stack and rebuild later branches from `main`.

## Notes
This is a Draft stacked PR. Later PRs will target the previous branch so reviewers can inspect one small slice at a time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 增强直播配置与事件数据的结构化支持，提升导入/展示的一致性。
  * 新增面向公开展示的数据脱敏与投影（自动隐藏敏感凭据），并完善查看器、交互与安全状态的序列化输出。
  * 提供模块运行观测与安全快照能力，便于查看状态与错误概览。
* **Bug 修复**
  * 优化安全限流、失败统计与自动暂停/冷却协同，提升异常场景下的稳定性。
  * 调整空配置默认行为：当直播未启用时，dry-run 不再默认开启。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->