### PR TITLE
[NEKO Live split 07/26] Bilibili ingest

### DIFF
--- a/plugin/plugins/neko_roast/core/live_host_theme.py
+++ b/plugin/plugins/neko_roast/core/live_host_theme.py
@@ -1,0 +1,98 @@
+"""Stable stream-theme prompt anchor for NEKO Live."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+from .contracts_public import public_text
+
+
+def live_host_theme_block(config: Any | None = None, *, kind: str = "reply") -> str:
+    """Render a private style anchor that keeps live beats from feeling random."""
+
+    source = config
+    config = getattr(source, "config", source)
+    room_context = getattr(source, "live_room_context", {})
+    if not isinstance(room_context, dict):
+        room_context = {}
+    stream_theme = _optional_text(getattr(config, "stream_theme", ""), max_len=120)
+    live_mode = _optional_text(getattr(config, "live_mode", ""), max_len=40)
+    room_title = _optional_text(room_context.get("title"), max_len=120)
+    anchor_name = _optional_text(room_context.get("anchor_name"), max_len=80)
+    live_status = _prompt_live_status(room_context.get("live_status"))
+    stream_goal = _optional_text(getattr(config, "stream_goal", ""), max_len=160)
+    stream_columns = _optional_text(getattr(config, "stream_columns", ""), max_len=160)
+    stream_avoid_topics = _optional_text(getattr(config, "stream_avoid_topics", ""), max_len=160)
+
+    lines = [
+        "Current stream theme (private style anchor):",
+        "- continuity_rule: use this only as light flavor; never announce the theme name or explain the format.",
+    ]
+    if stream_theme:
+        lines.extend(
+            [
+                f"- human_theme: {stream_theme}",
+                "- premise: this is today's configured stream anchor; keep replies and idle beats connected to it when relevant.",
+                "- variety_rule: use the theme as continuity, not a slogan; do not force every line to repeat it.",
+            ]
+        )
+    elif room_title:
+        lines.extend(
+            [
+                f"- live_room_title_theme: {room_title}",
+                "- premise: use the current live-room title as today's stream anchor when it is relevant to the danmaku or hosting beat.",
+                "- variety_rule: treat the title as context, not a slogan; do not force every line to repeat it.",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                "- theme_name: NEKO tiny radio patrol",
+                "- premise: NEKO is a small cat host keeping a tiny room-radio desk alive while watching the room.",
+                "- recurring_motifs: tiny radio, desk patrol, paw stamp, room weather, snack inventory, password card.",
+                "- variety_rule: rotate motifs; do not force every line to mention radio, desk, paw, weather, or snacks.",
+            ]
+        )
+    if anchor_name:
+        lines.append(f"- live_room_anchor_name: {anchor_name}")
+    if live_status:
+        lines.append(f"- live_room_status: {live_status}")
+    if stream_goal:
+        lines.append(f"- stream_goal: {stream_goal}")
+    if stream_columns:
+        lines.append(f"- preferred_columns_or_style: {stream_columns}")
+    if stream_avoid_topics:
+        lines.append(f"- avoid_topics_or_bits: {stream_avoid_topics}")
+    if kind == "host":
+        lines.extend(
+            [
+                "- host_rule: make idle/warmup/active beats feel like beads from the same tiny show, not unrelated random prompts.",
+                "- host_hook_rule: if asking, use one natural non-numeric danmaku cue; one concrete reply handle is enough, then leave space for viewers.",
+            ]
+        )
+        if live_mode == "solo_stream":
+            lines.append(
+                "- solo_stream_rule: NEKO is the on-stage host; do not address an unseen human host/operator or ask them to provide content."
+            )
+    else:
+        lines.extend(
+            [
+                "- reply_rule: answer the current viewer first; theme flavor may only be a small callback after the answer is clear.",
+                "- no_drift_rule: do not ignore the danmaku just to continue the theme.",
+            ]
+        )
+    return "\n".join(lines) + "\n\n"
+
+
+def _optional_text(value: Any, *, max_len: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    return public_text(value.strip(), max_len=max_len)
+
+
+def _prompt_live_status(value: Any) -> str:
+    text = _optional_text(value, max_len=40).casefold()
+    if text in {"offline", "ended", "finish", "finished", "unknown"}:
+        return ""
+    return text

--- a/plugin/plugins/neko_roast/core/runtime_active_engagement.py
+++ b/plugin/plugins/neko_roast/core/runtime_active_engagement.py
@@ -31,7 +31,7 @@ async def trigger_active_engagement(runtime: Any) -> InteractionResult:
         return record_active_engagement_skip(runtime, skip_event, f"active_engagement.{reason}")
     event = await active_engagement_event(runtime, live_state)
     result = await runtime.pipeline.handle_event(event)
-    if str(getattr(result, "status", "") or "") == "pushed":
+    if str(getattr(result, "status", "") or "") in {"pushed", "dry_run"}:
         runtime._active_engagement_last_attempt_at = float(runtime._active_engagement_now())
     return result
 

--- a/plugin/plugins/neko_roast/core/runtime_live_input.py
+++ b/plugin/plugins/neko_roast/core/runtime_live_input.py
@@ -135,7 +135,9 @@ async def lookup_live_room(runtime: Any, room_id: Any) -> dict[str, Any]:
     normalized = runtime.live_provider.normalize_room_ref(room_id)
     room_ref = _public_lookup_room_ref(normalized.get("room_ref") if isinstance(normalized, dict) else "")
     status = await runtime.live_provider.lookup_room_status(room_id)
-    remember_live_room_context(runtime, status, platform=runtime.live_provider.platform, room_ref=room_ref)
+    configured_room_ref = _public_lookup_room_ref(runtime.live_provider.configured_room_ref())
+    if not configured_room_ref or room_ref == configured_room_ref:
+        remember_live_room_context(runtime, status, platform=runtime.live_provider.platform, room_ref=room_ref)
     level = "info" if status.ok else "warning"
     runtime.audit.record(
         "live_room_lookup",

--- a/plugin/plugins/neko_roast/core/viewer_addressing.py
+++ b/plugin/plugins/neko_roast/core/viewer_addressing.py
@@ -1,0 +1,193 @@
+"""Viewer address-name helpers for NEKO Live speech."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from .contracts_public import public_text
+from .viewer_preferences import safe_int
+
+
+_REGULAR_VIEWER_MIN_EVENTS = 5
+_POETIC_SUFFIX_ALIASES = (
+    "\u661f\u8fb0",
+    "\u661f\u6cb3",
+    "\u6708\u5149",
+    "\u665a\u98ce",
+    "\u6e05\u98ce",
+    "\u6e05\u97f5",
+    "\u843d\u96ea",
+    "\u82b1\u706b",
+    "\u5c0f\u96e8",
+    "\u6674\u5929",
+    "\u591c\u96e8",
+    "\u4e91\u6735",
+    "\u6d41\u8424",
+    "\u6625\u98ce",
+    "\u79cb\u6c34",
+)
+_SEPARATOR_RE = re.compile(r"[\s_\-|/\\\u4e28\u00b7\u30fb]+")
+_CJK_ALIAS_BLOCK_CHARS = set("\u4e0a\u4e0b\u524d\u540e\u5de6\u53f3\u4e2d\u4e00\u4e8c\u4e09\u56db\u4e94\u516d\u4e03\u516b\u4e5d\u5341\u96f6\u7684\u4e86\u7740\u8fc7\u662f\u6709\u6ca1\u4e0d\u8981\u6765\u53bb\u770b\u542c\u8bf4\u5403\u559d\u73a9\u505a\u7ed9\u628a\u88ab\u548c\u4e0e\u6216\u5c31\u90fd\u4e5f")
+_CJK_ALIAS_BLOCK_TERMS = {
+    "\u7528\u6237",
+    "\u89c2\u4f17",
+    "\u5ba2\u4eba",
+    "\u6280\u672f",
+    "\u6d4b\u8bd5",
+    "\u5403\u9c7c",
+    "\u559d\u6c34",
+    "\u59e5\u7237",
+}
+_CJK_ROLE_SUFFIXES = tuple("\u4eba\u5ba2\u54e5\u59d0\u7237\u7238\u5988\u4e3b\u8005\u5458")
+_CJK_NAME_SIGNAL_CHARS = set(
+    "\u6e05\u97f5\u971c\u98ce\u6708\u661f\u8fb0\u6cb3\u4e91\u96e8\u96ea\u82b1\u706b\u5149\u591c\u665a\u6625\u590f\u79cb\u51ac"
+    "\u68a6\u5f71\u58f0\u97f3\u8bd7\u6b4c\u8336\u7cd6\u751c\u9c7c\u732b\u72d0\u9e7f\u5154\u6843\u68a8\u67da\u8377\u7af9\u6885\u5170"
+    "\u6d45\u6df1\u5c0f\u767d\u84dd\u7eff\u7ea2\u7d2b\u91d1\u94f6\u7070\u6674\u6d41\u843d\u5bd2\u6696\u5b81\u5b89\u4e50"
+)
+_CJK_RE = re.compile(r"[\u4e00-\u9fff]+")
+_LATIN_WORD_RE = re.compile(r"[A-Za-z][A-Za-z0-9]*")
+_LATIN_ALIAS_BLOCK_TERMS = {
+    "admin",
+    "bot",
+    "channel",
+    "guest",
+    "live",
+    "official",
+    "test",
+    "user",
+    "viewer",
+}
+
+
+def viewer_address_name(nickname: Any, profile: Any | None = None) -> str:
+    """Return the natural spoken address for a viewer without mutating identity."""
+
+    raw = _safe_nickname(nickname)
+    if not raw:
+        return ""
+    if not _is_regular_viewer(profile):
+        return raw
+    return _short_nickname_alias(raw) or raw
+
+
+def _safe_nickname(value: Any) -> str:
+    text = public_text(value, max_len=32)
+    return " ".join(text.strip().split())[:24]
+
+
+def _is_regular_viewer(profile: Any | None) -> bool:
+    if profile is None:
+        return False
+    danmaku_count = safe_int(_get(profile, "danmaku_count"))
+    roast_count = safe_int(_get(profile, "roast_count"))
+    return danmaku_count + roast_count >= _REGULAR_VIEWER_MIN_EVENTS
+
+
+def _short_nickname_alias(nickname: str) -> str:
+    cleaned = nickname.strip()
+    parts = [part.strip() for part in _SEPARATOR_RE.split(cleaned) if part.strip()]
+    if len(parts) > 1:
+        for part in reversed(parts):
+            if _looks_like_initialism(part):
+                continue
+            alias = _alias_from_piece(part)
+            if alias:
+                return alias
+
+    cjk_runs = _cjk_runs(cleaned)
+    for run in reversed(cjk_runs):
+        alias = _natural_cjk_alias(run)
+        if alias:
+            return alias
+
+    compact = "".join(ch for ch in cleaned if ch.isalnum() or "\u4e00" <= ch <= "\u9fff")
+    if compact and not _is_cjk_name(compact) and not _looks_like_initialism(compact):
+        latin_alias = _latin_alias(cleaned)
+        if latin_alias:
+            return latin_alias
+    return ""
+
+
+def _has_visible_name_signal(text: str) -> bool:
+    dense = "".join(ch for ch in text if ch.isalnum() or "\u4e00" <= ch <= "\u9fff")
+    return len(dense) >= 2
+
+
+def _is_cjk_name(text: str) -> bool:
+    return bool(text) and all("\u4e00" <= ch <= "\u9fff" for ch in text)
+
+
+def _cjk_runs(text: str) -> list[str]:
+    return [match.group(0) for match in _CJK_RE.finditer(str(text or ""))]
+
+
+def _alias_from_piece(text: str) -> str:
+    piece = "".join(ch for ch in str(text or "").strip() if ch.isalnum() or "\u4e00" <= ch <= "\u9fff")
+    if not piece or not _has_visible_name_signal(piece):
+        return ""
+    if _is_cjk_name(piece):
+        if 2 <= len(piece) <= 3 and _is_natural_cjk_alias_candidate(piece):
+            return piece
+        return _natural_cjk_alias(piece)
+    cjk_runs = _cjk_runs(piece)
+    for run in reversed(cjk_runs):
+        alias = _natural_cjk_alias(run)
+        if alias:
+            return alias
+    latin_alias = _latin_alias(piece)
+    if latin_alias and not _looks_like_initialism(latin_alias):
+        return latin_alias
+    return ""
+
+
+def _looks_like_initialism(text: str) -> bool:
+    compact = "".join(ch for ch in str(text or "").strip() if ch.isalnum())
+    return 1 <= len(compact) <= 3 and compact.isascii() and compact.isalpha()
+
+
+def _latin_alias(text: str) -> str:
+    if _cjk_runs(text):
+        return ""
+    words = [word for word in _LATIN_WORD_RE.findall(str(text or "")) if _is_latin_alias_candidate(word)]
+    if not words:
+        return ""
+    return words[-1]
+
+
+def _is_latin_alias_candidate(text: str) -> bool:
+    word = str(text or "").strip()
+    if not 2 <= len(word) <= 16:
+        return False
+    if word.casefold() in _LATIN_ALIAS_BLOCK_TERMS:
+        return False
+    return any(ch.isalpha() for ch in word)
+
+
+def _natural_cjk_alias(text: str) -> str:
+    if not _is_cjk_name(text) or not 4 <= len(text) <= 10:
+        return ""
+    for candidate in (text[-2:], text[:2], text[-3:]):
+        if _is_natural_cjk_alias_candidate(candidate):
+            return candidate
+    return ""
+
+
+def _is_natural_cjk_alias_candidate(text: str) -> bool:
+    if not _is_cjk_name(text) or not 2 <= len(text) <= 3:
+        return False
+    if any(term in text for term in _CJK_ALIAS_BLOCK_TERMS):
+        return False
+    if any(ch in _CJK_ALIAS_BLOCK_CHARS for ch in text):
+        return False
+    if text.endswith(_CJK_ROLE_SUFFIXES):
+        return False
+    if not any(ch in _CJK_NAME_SIGNAL_CHARS for ch in text):
+        return False
+    return True
+
+
+def _get(value: Any, key: str) -> Any:
+    if isinstance(value, dict):
+        return value.get(key)
+    return getattr(value, key, None)

--- a/plugin/plugins/neko_roast/core/viewer_addressing.py
+++ b/plugin/plugins/neko_roast/core/viewer_addressing.py
@@ -10,23 +10,6 @@ from .viewer_preferences import safe_int
 
 
 _REGULAR_VIEWER_MIN_EVENTS = 5
-_POETIC_SUFFIX_ALIASES = (
-    "\u661f\u8fb0",
-    "\u661f\u6cb3",
-    "\u6708\u5149",
-    "\u665a\u98ce",
-    "\u6e05\u98ce",
-    "\u6e05\u97f5",
-    "\u843d\u96ea",
-    "\u82b1\u706b",
-    "\u5c0f\u96e8",
-    "\u6674\u5929",
-    "\u591c\u96e8",
-    "\u4e91\u6735",
-    "\u6d41\u8424",
-    "\u6625\u98ce",
-    "\u79cb\u6c34",
-)
 _SEPARATOR_RE = re.compile(r"[\s_\-|/\\\u4e28\u00b7\u30fb]+")
 _CJK_ALIAS_BLOCK_CHARS = set("\u4e0a\u4e0b\u524d\u540e\u5de6\u53f3\u4e2d\u4e00\u4e8c\u4e09\u56db\u4e94\u516d\u4e03\u516b\u4e5d\u5341\u96f6\u7684\u4e86\u7740\u8fc7\u662f\u6709\u6ca1\u4e0d\u8981\u6765\u53bb\u770b\u542c\u8bf4\u5403\u559d\u73a9\u505a\u7ed9\u628a\u88ab\u548c\u4e0e\u6216\u5c31\u90fd\u4e5f")
 _CJK_ALIAS_BLOCK_TERMS = {

--- a/plugin/plugins/neko_roast/fixtures/demo_avatar.svg
+++ b/plugin/plugins/neko_roast/fixtures/demo_avatar.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" role="img" aria-label="Neko Roast demo avatar">
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" role="img" aria-label="NEKO Live demo avatar">
   <rect width="512" height="512" fill="#f7bed7"/>
   <rect x="48" y="48" width="416" height="416" rx="18" fill="#fff"/>
   <circle cx="256" cy="226" r="136" fill="#fff1f8" stroke="#7d536b" stroke-width="6"/>

--- a/plugin/plugins/neko_roast/modules/avatar_roast/__init__.py
+++ b/plugin/plugins/neko_roast/modules/avatar_roast/__init__.py
@@ -5,18 +5,30 @@ from __future__ import annotations
 from typing import Any
 
 from ...core.contracts import InteractionRequest, ViewerEvent, ViewerIdentity, ViewerProfile
+from ...core.live_host_theme import live_host_theme_block
+from ...core.meme_knowledge import meme_knowledge_metadata, render_meme_knowledge_block, retrieve_meme_knowledge
+from ...core.viewer_addressing import viewer_address_name
+from ...core.viewer_preferences import viewer_preference_prompt_block
 from .._base import BaseModule
+from .._prompt_context import (
+    anti_repeat_rules,
+    live_events_context_block,
+    live_output_quality_rules,
+    recent_context_block,
+    short_reply_rules,
+    sustained_charm_rules,
+    viewer_session_context_block,
+)
 
 
 class AvatarRoastModule(BaseModule):
     id = "avatar_roast"
-    title = "弹幕锐评"
+    title = "首次出场锐评"
     domain = "interaction"
 
     def config_schema(self) -> list[dict[str, Any]]:
-        # 弹幕锐评这个功能自己的参数（功能级，跟功能走；平台级如节奏/队列/急停在「设置」）。
-        # name 直接绑现有 RoastConfig 顶层字段（锐评是核心切片，参数本就是顶层）；
-        # 未来新功能模块用 config.<id>.* 命名空间，见 docs/ui-architecture.md。
+        # Module-level controls for first-appearance roasting. Platform-level
+        # controls such as pacing and pause stay in the Settings tab.
         return [
             {
                 "name": "roast_strength",
@@ -45,65 +57,276 @@ class AvatarRoastModule(BaseModule):
         profile: ViewerProfile,
     ) -> InteractionRequest:
         strength = self.ctx.config.roast_strength if self.ctx else "normal"
+        activity_level = self.ctx.config.activity_level if self.ctx else "standard"
+        metadata: dict[str, Any] = {}
+        if event.source == "idle_hosting":
+            recent_context = recent_context_block(self.ctx)
+            host_beat = event.raw.get("host_beat") if isinstance(event.raw, dict) else None
+            meme_entries = self._idle_hosting_meme_entries(host_beat)
+            prompt_text = self._build_idle_hosting_prompt(
+                event,
+                strength,
+                activity_level,
+                live_host_theme_block(self.ctx, kind="host"),
+                recent_context,
+                render_meme_knowledge_block(meme_entries),
+            )
+            metadata.update(meme_knowledge_metadata(meme_entries))
+        else:
+            prompt_text = self._build_prompt(
+                event,
+                identity,
+                profile,
+                strength,
+                live_host_theme_block(self.ctx, kind="reply"),
+                recent_context_block(self.ctx),
+                viewer_session_context_block(self.ctx, identity.uid),
+                viewer_preference_prompt_block(profile),
+                live_events_context_block(self.ctx, event),
+            )
         return InteractionRequest(
             event=event,
             identity=identity,
             profile=profile,
-            prompt_text=self._build_prompt(event, identity, strength),
+            prompt_text=prompt_text,
             live_mode=event.live_mode,
             strength=strength,
             dry_run=bool(self.ctx.config.dry_run) if self.ctx else False,
+            allow_avatar_image=event.source != "idle_hosting",
+            metadata=metadata,
         )
 
-    def _build_prompt(self, event: ViewerEvent, identity: ViewerIdentity, strength: str) -> str:
-        nickname = identity.nickname or identity.uid or "这位观众"
-        danmaku = (event.danmaku_text or "").strip()
-        avatar_line, avatar_rule = self._avatar_guidance(identity)
-        pace = (
-            "你在独播、由你撑全场，可以更主动鲜活，别冷场"
-            if event.live_mode == "solo_stream"
-            else "人猫同播、低打断，自然接一句就好"
-        )
-        strength_zh = {"gentle": "轻一点、偏宠溺", "sharp": "可以犀利", "normal": "适中"}.get(strength, "适中")
-
-        facts = [f"观众昵称：{nickname}（UID {identity.uid}）"]
-        if danmaku:
-            facts.append(f"刚发的弹幕：{danmaku}")
-        facts.append(f"头像：{avatar_line}")
-        if identity.pendant:
-            facts.append(f"头像挂件/装扮：{identity.pendant}")
-
+    def _build_idle_hosting_prompt(
+        self,
+        event: ViewerEvent,
+        strength: str,
+        activity_level: str = "standard",
+        host_theme_context: str = "",
+        recent_context: str = "",
+        meme_context: str = "",
+    ) -> str:
+        strength_hint = {
+            "gentle": "warm and soft",
+            "sharp": "playfully sharp, but still easy to answer",
+            "normal": "balanced and lightly playful",
+        }.get(strength, "balanced and lightly playful")
+        pacing_hint = {
+            "quiet": "Prefer a soft observation over a direct question.",
+            "active": "You may ask one specific, low-pressure question, but never as a numeric vote.",
+            "standard": "Use a balanced host beat: one small observation or one non-numeric danmaku cue.",
+        }.get(str(activity_level), "Use a balanced host beat: one small observation or one non-numeric danmaku cue.")
+        host_beat_block = self._idle_hosting_beat_block(event.raw.get("host_beat") if isinstance(event.raw, dict) else None)
+        facts = [
+            "scene: NEKO is the only host on stage in solo_stream",
+            "task: solo idle hosting",
+            "goal: sound like NEKO hosting the room, not a system filler",
+            f"tone: {strength_hint}",
+            f"pacing: {activity_level}",
+            f"pacing rule: {pacing_hint}",
+        ]
         rules = [
-            "自适应焦点：昵称和头像哪个更有梗就主打哪个；两个都有料就抓它们之间的反差或呼应；都平淡就拿这条弹幕、进场时机或当前直播节奏发挥，别硬尬夸。",
-            "抓一个具体细节切入并给个有依据的小判断，别泛泛说“好可爱”，别逐字复述上面的字段。",
-            avatar_rule,
-            "别和你最近几条锐评用同样的开头和句式。",
-            f"一句话，短、有包袱、能直接 TTS 播出；强度{strength_zh}；{pace}。",
-            "只输出这一句锐评本身，不要解释、不要加前后缀、不要复述这些规则。",
+            "Say exactly one short live-host line as NEKO.",
+            "Create one tiny live-room topic: a small observation, a light tease, or an easy question that a quiet viewer can answer.",
+            "Treat the idle gap as normal stage time; do not announce that the room is quiet, empty, cold, or waiting.",
+            "Do not start with filler like while we wait, since nobody is talking, or to warm things up.",
+            "Use the host beat material as direction, but make the final line sound natural.",
+            "If a meme hint is present, treat it as optional seasoning for the host beat, not as the reason to speak.",
+            "Do not change the host beat just to use a meme.",
+            "If a NEKO live column is provided, use it as the tiny host format without announcing a formal segment.",
+            "Add at most one low-pressure non-numeric danmaku cue: one concrete choice, tiny stance, or small playful prompt.",
+            "Use the host beat reply_affordance as the only reply cue; do not add a second question.",
+            "Do not ask viewers to type, drop, reply, vote, or press 1/2/3/4; use 'put it in danmaku' wording instead.",
+            "Use the host beat fun_axis as the line's purpose; do not drift into generic hosting.",
+            "Make it feel like a spontaneous host beat, with a little NEKO personality and no formal opening.",
+            "The final line must be a complete sentence; never end with an unfinished word or dangling choice.",
+            "Do not use punishment, public-shaming, trial, labor-camp, or real-person judgment language.",
+            "Do not say \u516c\u5f00\u793a\u4f17, \u52b3\u6539, \u5ba1\u5224, \u5904\u5211, or \u60e9\u7f5a.",
+            "Do not pretend a viewer sent a message.",
+            "Do not announce that nobody is talking or that the room is silent.",
+            "Do not use generic welcome slogans, direct interaction requests, or attendance-check lines.",
+            "Do not mention viewer absence, silence metrics, queues, timing controls, dry_run, or system state.",
+            "Do not invent or hard-code streamer relationship labels; use profile memory if available, otherwise avoid naming the streamer.",
+            "Do not mention owner, master, backstage human, carbon-based human, private chat, or pre-stream relationship memory.",
+            "Solo-stream agency: NEKO is the only on-stage host and must perform all hosting actions herself.",
+            "Never tell or ask an unseen streamer, operator, or current viewer to greet the room, warm up the stream, carry the chat, provide topics, or help NEKO host.",
+            "In solo_stream, 'you' means the viewers or room, never an unseen operator.",
+            "Output spoken live speech only; never include parenthesized stage directions, action narration, or roleplay asides.",
+            "Keep it natural, low-pressure, and specific enough to avoid template-hosting.",
+            *live_output_quality_rules(kind="host"),
+            *sustained_charm_rules(kind="host"),
+            *anti_repeat_rules(kind="host"),
+            *short_reply_rules(kind="host"),
+            "Output only the line NEKO should say.",
         ]
         return (
-            "【直播观众锐评】请按当前人设，对这位新观众即兴说一句直播锐评。\n"
+            "[NEKO Live solo idle hosting]\n"
             + "\n".join(facts)
-            + "\n\n要求：\n"
-            + "\n".join(f"- {r}" for r in rules)
+            + "\n\n"
+            + host_theme_context
+            + recent_context
+            + host_beat_block
+            + meme_context
+            + "\nRules:\n"
+            + "\n".join(f"- {rule}" for rule in rules)
+        )
+
+    @staticmethod
+    def _idle_hosting_beat_block(host_beat: object | None) -> str:
+        if not isinstance(host_beat, dict):
+            return ""
+        shape = str(host_beat.get("shape") or "").strip()
+        fun_axis = str(host_beat.get("fun_axis") or "").strip()
+        family = str(host_beat.get("family") or "").strip()
+        title = str(host_beat.get("title") or "").strip()
+        hint = str(host_beat.get("hint") or "").strip()
+        live_column = str(host_beat.get("live_column") or "").strip()
+        idle_stage = str(host_beat.get("idle_stage") or "").strip()
+        reply_affordance = str(host_beat.get("reply_affordance") or "").strip()
+        if not any((shape, fun_axis, family, title, hint, live_column, idle_stage, reply_affordance)):
+            return ""
+        lines = ["Host beat material:"]
+        if shape:
+            lines.append(f"- shape: {shape}")
+        if fun_axis:
+            lines.append(f"- fun_axis: {fun_axis}")
+        if family:
+            lines.append(f"- content_family: {family}")
+        if title:
+            lines.append(f"- title: {title}")
+        if hint:
+            lines.append(f"- hint: {hint}")
+        if live_column:
+            lines.append(f"- NEKO live column: {live_column}")
+        if idle_stage:
+            lines.append(f"- idle_stage: {idle_stage}")
+        if reply_affordance:
+            lines.append(f"- reply_affordance: {reply_affordance}")
+        return "\n" + "\n".join(lines) + "\n\n"
+
+    @staticmethod
+    def _idle_hosting_meme_entries(host_beat: object | None) -> list[Any]:
+        if not isinstance(host_beat, dict):
+            return []
+        query_parts = [
+            str(host_beat.get("meme_query") or ""),
+            str(host_beat.get("title") or ""),
+            str(host_beat.get("hint") or ""),
+            str(host_beat.get("live_column") or ""),
+            str(host_beat.get("reply_affordance") or ""),
+        ]
+        return retrieve_meme_knowledge(*query_parts, limit=1)
+
+    def _build_prompt(
+        self,
+        event: ViewerEvent,
+        identity: ViewerIdentity,
+        profile: ViewerProfile,
+        strength: str,
+        host_theme_context: str = "",
+        recent_context: str = "",
+        viewer_context: str = "",
+        viewer_preference_context: str = "",
+        danmaku_context: str = "",
+    ) -> str:
+        raw_nickname = identity.nickname or identity.uid or "this viewer"
+        nickname = viewer_address_name(raw_nickname, profile) or raw_nickname
+        danmaku = (event.danmaku_text or "").strip()
+        avatar_line, avatar_rule = self._avatar_guidance(identity)
+        mode_contract = self._mode_contract(event.live_mode)
+        pace = (
+            "solo_stream: NEKO is the only host on stage; answer the current danmaku first, then stop after one compact line."
+            if event.live_mode == "solo_stream"
+            else "co_stream: NEKO is a low-interrupt partner; catch one point, never direct the streamer/operator/current viewer to host for NEKO, and leave room for the human streamer."
+        )
+        strength_hint = {
+            "gentle": "soft and warm",
+            "sharp": "playfully sharp, but never hostile",
+            "normal": "natural, lightly playful, and concise",
+        }.get(strength, "natural, lightly playful, and concise")
+
+        facts = [f"viewer: {nickname} (UID {identity.uid})"]
+        if nickname != raw_nickname:
+            facts.append(f"viewer_full_nickname: {raw_nickname}")
+        facts.append(f"mode_contract: {mode_contract}")
+        if danmaku:
+            facts.append(f"current danmaku: {danmaku}")
+        facts.append(f"avatar: {avatar_line}")
+        if identity.pendant:
+            facts.append(f"avatar pendant / decoration: {identity.pendant}")
+
+        solo_danmaku_priority_rules = (
+            [
+                "solo_stream first-appearance priority: current danmaku first.",
+                "Use avatar and nickname only as accents after answering the current danmaku.",
+                "Do not turn a first appearance into a pure avatar or ID roast when the viewer sent a danmaku.",
+            ]
+            if event.live_mode == "solo_stream" and danmaku
+            else []
+        )
+        rules = [
+            "Adapt the focus: nickname, avatar, or current danmaku can be the hook; use whichever has the clearest live-room material.",
+            "If the viewer sent danmaku, answer that line first, then optionally add one tiny avatar or nickname accent.",
+            "If this is a delayed chance to roast because an earlier first-appearance roast did not actually reach NEKO, make it feel like spontaneous live banter; never say this is a makeup, retry, missed first roast, or system correction.",
+            "If the current danmaku asks NEKO to roast or evaluate the viewer/avatar/name, satisfy it directly with a natural witty line rather than announcing a delayed retry.",
+            "Treat UID as a routing identity, not default roast material; do not quote raw UID digits unless the nickname itself is missing or the viewer explicitly makes the ID relevant.",
+            "Make one evidence-based small judgment from a concrete detail; do not vaguely say cute, cool, abstract, or repeat the facts back.",
+            *solo_danmaku_priority_rules,
+            avatar_rule,
+            *short_reply_rules(),
+            "Do not use the same opening, sentence shape, punchline, or host beat as recent live replies.",
+            "Never invent pinyin initials, Latin initials, or all-letter abbreviations for a Chinese nickname; use preferred short Chinese address when present, otherwise use the full nickname.",
+            *anti_repeat_rules(),
+            "Current danmaku wins over any previous reply.",
+            "Do not invent or hard-code streamer relationship labels; use profile memory if available, otherwise avoid naming the streamer.",
+            "Do not mention owner, master, backstage human, carbon-based human, private chat, or pre-stream relationship memory.",
+            "In solo_stream, 'you' means the current viewer or room, never an unseen operator.",
+            "Output spoken live speech only; never include parenthesized stage directions, action narration, or roleplay asides.",
+            f"Tone: {strength_hint}. Pacing: {pace}",
+            *live_output_quality_rules(),
+            *sustained_charm_rules(),
+            "Output only NEKO's one-line first-appearance roast. No explanation, no prefix, no suffix, no rule recap.",
+        ]
+        return (
+            "[NEKO Live first-appearance roast]\n"
+            + "\n".join(facts)
+            + "\n\n"
+            + host_theme_context
+            + recent_context
+            + viewer_context
+            + viewer_preference_context
+            + danmaku_context
+            + "Rules:\n"
+            + "\n".join(f"- {rule}" for rule in rules)
+        )
+
+    @staticmethod
+    def _mode_contract(live_mode: str) -> str:
+        if live_mode == "solo_stream":
+            return (
+                "solo_stream first-appearance contract - NEKO is carrying the room alone; "
+                "make one compact host reaction, then stop."
+            )
+        return (
+            "co_stream first-appearance contract - NEKO is a low-interrupt partner; "
+            "do not steal the human streamer's host role, and do not direct the streamer/operator/current viewer to greet viewers, warm up the room, carry chat, provide topics, or help NEKO host."
         )
 
     @staticmethod
     def _avatar_guidance(identity: ViewerIdentity) -> tuple[str, str]:
-        """返回 (头像情况描述, 头像锐评规则)。看不到的一律禁止脑补。"""
+        """Return avatar facts and guidance. Never invent details for unseen avatars."""
         if not identity.avatar_vision_ok:
-            extra = "（疑似动图/特殊头像）" if identity.is_animated_avatar else ""
+            extra = " (animated or special avatar suspected)" if identity.is_animated_avatar else ""
             return (
-                f"没取到或识别不了{extra}",
-                "你看不到这张头像的画面，绝对不要脑补描述它；只能就“头像没换/会动/带挂件”这类事实或昵称发挥。",
+                f"not fetched or not visible{extra}",
+                "You cannot see this avatar image; never invent visual details. Only use the fact that the avatar was not available, may be animated, has a pendant, or use the nickname/current danmaku instead.",
             )
         if identity.is_default_avatar:
             return (
-                "B站默认头像（根本没换过）",
-                "这是默认头像、没有可锐评的画面，别假装看到了什么；从“懒得换头像”或昵称切入。",
+                "Bilibili default avatar",
+                "This is the default avatar; do not pretend to see specific visual details. You may tease the default-avatar choice or pivot to nickname/current danmaku.",
             )
-        kind = "会动的动图头像" if identity.is_animated_avatar else "能看到的头像图"
+        kind = "animated avatar image" if identity.is_animated_avatar else "visible avatar image"
         return (
-            f"{kind}（图片会一起发给你看）",
-            "你能看到这张头像，可以锐评它的具体内容；但只评你真看到的，别编。",
+            f"{kind} (image will be provided to the model)",
+            "You may roast concrete details that are actually visible in the avatar, but never invent details.",
         )

--- a/plugin/plugins/neko_roast/modules/bili_live_ingest/__init__.py
+++ b/plugin/plugins/neko_roast/modules/bili_live_ingest/__init__.py
@@ -12,6 +12,8 @@ from typing import Any
 from ...core.contracts import LiveEvent, LiveRoomStatus, ViewerEvent
 from .._base import BaseModule
 
+SUPPORT_EVENT_DEDUPE_SECONDS = 0.35
+
 
 class _ListenerLog:
     """把 DanmakuListener 的日志收敛到 audit：info/debug 丢弃（避免刷屏+隐私），warning/error 入 audit。"""
@@ -50,13 +52,22 @@ class BiliLiveIngestModule(BaseModule):
         self._lookup_buvid3_ttl: float = 6 * 3600.0
         self._room_status_cache: "dict[int, tuple[LiveRoomStatus, float]]" = {}
         self._room_status_ttl: float = 60.0
+        self._last_event_at: float = 0.0
+        self._last_event_type: str = ""
+        self._recent_support_event_keys: dict[str, float] = {}
 
     async def teardown(self) -> None:
         await self.stop_listening()
         await super().teardown()
 
     def status(self) -> dict[str, Any]:
-        return {"enabled": self.enabled, "listening": self.is_listening(), "room_id": self._room_id}
+        return {
+            "enabled": self.enabled,
+            "listening": self.is_listening(),
+            "room_id": self._room_id,
+            "last_event_at": self._last_event_at,
+            "last_event_type": self._last_event_type,
+        }
 
     def is_listening(self) -> bool:
         return self._listener is not None
@@ -86,6 +97,8 @@ class BiliLiveIngestModule(BaseModule):
             # 富模型 on_event（带 get_score 打分）→ live_events 中枢窗口择优；不再用轻量
             # on_danmaku 直连 pipeline，避免同一条弹幕被两条路各锐评一次。
             "on_event": self._on_live_event,
+            "on_gift": self._on_gift_event,
+            "on_sc": self._on_super_chat_event,
             "on_live": self._on_live,
             "on_preparing": self._on_preparing,
             "on_error": self._on_error,
@@ -135,6 +148,7 @@ class BiliLiveIngestModule(BaseModule):
     _CMD_TO_TYPE = {
         "DANMU_MSG": "danmaku",
         "SEND_GIFT": "gift",
+        "COMBO_SEND": "gift",
         "SUPER_CHAT_MESSAGE": "super_chat",
         "SUPER_CHAT_MESSAGE_JPN": "super_chat",
         "GUARD_BUY": "guard",
@@ -151,7 +165,9 @@ class BiliLiveIngestModule(BaseModule):
         """
         if not self.ctx:
             return
-        if event is not None and getattr(event, "room_id", 0) in (0, None):
+        if isinstance(event, dict) and event.get("room_id") in (0, None):
+            event["room_id"] = self._room_id
+        elif event is not None and getattr(event, "room_id", 0) in (0, None):
             try:
                 event.room_id = self._room_id
             except Exception as exc:
@@ -160,12 +176,38 @@ class BiliLiveIngestModule(BaseModule):
         if bus is None:
             return
         live_event = self._to_live_event(cmd, event)
+        if self._is_duplicate_support_event(live_event):
+            return
+        self._last_event_at = live_event.ts or time.time()
+        self._last_event_type = live_event.type
         bus.publish(live_event.type, live_event)
+
+    def _on_gift_event(self, event: Any) -> None:
+        """Fallback path for Bilibili's lightweight gift callback."""
+        self._on_live_event("SEND_GIFT", event)
+
+    def _on_super_chat_event(self, event: Any) -> None:
+        """Fallback path for Bilibili's lightweight Super Chat callback."""
+        self._on_live_event("SUPER_CHAT_MESSAGE", event)
 
     def _to_live_event(self, cmd: str, event: Any) -> LiveEvent:
         """把富模型 + 命令名包成统一信封。``raw`` 保留富模型，供需要完整字段（如
         ``get_score()``）的 handler（如 ``live_events`` 中枢）解包使用。"""
-        event_type = self._CMD_TO_TYPE.get(str(cmd), str(cmd).lower())
+        normalized_cmd = self._normalize_cmd(cmd)
+        event_type = self._CMD_TO_TYPE.get(normalized_cmd, normalized_cmd.lower())
+        if isinstance(event, dict):
+            payload = dict(event)
+            payload["event_type"] = event_type
+            payload["room_id"] = payload.get("room_id") or self._room_id
+            uid = str(payload.get("uid") or payload.get("user_id") or "").strip()
+            nickname = str(payload.get("nickname") or payload.get("user_name") or payload.get("uname") or "")
+            text = str(payload.get("danmaku_text") or payload.get("text") or payload.get("message") or "")
+            payload["uid"] = uid
+            payload["nickname"] = nickname
+            payload["danmaku_text"] = text
+            payload["event_label"] = self._event_label(event_type, text)
+            payload["raw_type"] = normalized_cmd
+            return LiveEvent(type=event_type, uid=uid, payload=payload, source="live", ts=time.time(), raw=payload)
         uid = str(getattr(event, "uid", "") or "").strip()
         nickname = str(getattr(event, "nickname", "") or "")
         text = str(getattr(event, "text", "") or "")
@@ -175,12 +217,75 @@ class BiliLiveIngestModule(BaseModule):
             "nickname": nickname,
             "text": text,
             "event_label": self._event_label(event_type, text),
-            "raw_type": str(cmd),
+            "raw_type": normalized_cmd,
             "guard_level": getattr(event, "guard_level", 0),
             "room_id": getattr(event, "room_id", 0) or self._room_id,
-            "cmd": str(cmd),
+            "cmd": normalized_cmd,
         }
         return LiveEvent(type=event_type, uid=uid, payload=payload, source="live", ts=time.time(), raw=event)
+
+    @staticmethod
+    def _normalize_cmd(cmd: Any) -> str:
+        return str(cmd or "").split(":", 1)[0].strip()
+
+    def _is_duplicate_support_event(self, live_event: LiveEvent) -> bool:
+        if live_event.type not in {"gift", "super_chat", "guard"}:
+            return False
+        now = float(live_event.ts or time.time())
+        expired = [
+            key
+            for key, seen_at in self._recent_support_event_keys.items()
+            if now - seen_at > SUPPORT_EVENT_DEDUPE_SECONDS
+        ]
+        for key in expired:
+            self._recent_support_event_keys.pop(key, None)
+        key = self._support_event_key(live_event)
+        if not key:
+            return False
+        last_seen = self._recent_support_event_keys.get(key)
+        self._recent_support_event_keys[key] = now
+        return last_seen is not None and (now - last_seen) <= SUPPORT_EVENT_DEDUPE_SECONDS
+
+    @staticmethod
+    def _support_event_key(live_event: LiveEvent) -> str:
+        raw = live_event.raw
+        payload = live_event.payload if isinstance(live_event.payload, dict) else {}
+        gift = getattr(raw, "gift", None) if raw is not None else None
+        command = BiliLiveIngestModule._normalize_cmd(
+            payload.get("raw_cmd") or payload.get("cmd") or payload.get("raw_type") or ""
+        )
+        uid = str(live_event.uid or payload.get("uid") or payload.get("user_id") or "")
+        if live_event.type == "super_chat":
+            text = str(
+                payload.get("danmaku_text")
+                or payload.get("text")
+                or payload.get("message")
+                or getattr(raw, "text", "")
+                or ""
+            )
+            return "|".join(part.strip()[:80] for part in (live_event.type, command, uid, text))
+        parts = [
+            live_event.type,
+            command,
+            uid,
+            str(
+                payload.get("gift_name")
+                or payload.get("giftName")
+                or getattr(gift, "gift_name", "")
+                or payload.get("danmaku_text")
+                or payload.get("text")
+                or ""
+            ),
+            str(payload.get("gift_count") or payload.get("num") or getattr(gift, "num", "") or ""),
+            str(
+                payload.get("gift_value")
+                or payload.get("total_coin")
+                or getattr(gift, "total_coin", "")
+                or getattr(gift, "price", "")
+                or ""
+            ),
+        ]
+        return "|".join(part.strip()[:80] for part in parts)
 
     @staticmethod
     def _event_label(event_type: str, text: str) -> str:
@@ -192,12 +297,28 @@ class BiliLiveIngestModule(BaseModule):
         return cleaned
 
     async def _on_live(self) -> None:
+        self._mark_room_live_status("live")
         if self.ctx is not None:
             self.ctx.audit.record("live_room_live", "live started", detail={"room_id": self._room_id})
 
     async def _on_preparing(self) -> None:
+        self._mark_room_live_status("offline")
         if self.ctx is not None:
             self.ctx.audit.record("live_room_preparing", "live ended", detail={"room_id": self._room_id})
+
+    def _mark_room_live_status(self, live_status: str) -> None:
+        if self.ctx is None:
+            return
+        context = getattr(self.ctx, "live_room_context", None)
+        if not isinstance(context, dict):
+            context = {}
+        context = dict(context)
+        context["platform"] = "bilibili"
+        if self._room_id > 0:
+            context["room_ref"] = str(self._room_id)
+            context["room_id"] = self._room_id
+        context["live_status"] = live_status
+        self.ctx.live_room_context = context
 
     async def _on_error(self, exc: Any) -> None:
         if self.ctx is not None:
@@ -217,6 +338,7 @@ class BiliLiveIngestModule(BaseModule):
             target_lanlan=target_lanlan,
             source="live_danmaku",
             live_mode=self.ctx.config.live_mode if self.ctx else "co_stream",
+            trace_id=str(payload.get("trace_id") or "").strip(),
             raw=dict(payload),
         )
 
@@ -376,3 +498,13 @@ class BiliLiveIngestModule(BaseModule):
         if status == 2:
             return "rounding"
         return "unknown"
+
+
+def _safe_non_negative_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return number if number > 0 else 0

--- a/plugin/plugins/neko_roast/modules/bili_live_ingest/__init__.py
+++ b/plugin/plugins/neko_roast/modules/bili_live_ingest/__init__.py
@@ -243,8 +243,10 @@ class BiliLiveIngestModule(BaseModule):
         if not key:
             return False
         last_seen = self._recent_support_event_keys.get(key)
+        if last_seen is not None and 0 <= now - last_seen <= SUPPORT_EVENT_DEDUPE_SECONDS:
+            return True
         self._recent_support_event_keys[key] = now
-        return last_seen is not None and (now - last_seen) <= SUPPORT_EVENT_DEDUPE_SECONDS
+        return False
 
     @staticmethod
     def _support_event_key(live_event: LiveEvent) -> str:

--- a/plugin/plugins/neko_roast/modules/bili_live_ingest/danmaku_core.py
+++ b/plugin/plugins/neko_roast/modules/bili_live_ingest/danmaku_core.py
@@ -155,7 +155,6 @@ class DanmakuListener:
         credential=None,
         logger=None,
         callbacks: Dict[str, Callable] = None,
-        danmaku_max_length: int = 20,  # 弹幕最大长度限制（B站限制 20 字符）
     ):
         self.room_id = room_id
         self.real_room_id: int = room_id  # 连接后更新为真实房间号（处理短号）
@@ -167,7 +166,6 @@ class DanmakuListener:
         self._ws = None
         self._heartbeat_task: Optional[asyncio.Task] = None
         self._buvid3_temp: str = ""  # 临时 buvid3，无凭据时从 B站首页获取
-        self._danmaku_max_length = max(1, min(100, danmaku_max_length))  # 限制范围 1-100
 
         # 连接状态
         self._connection_state = ConnectionState.DISCONNECTED
@@ -578,6 +576,16 @@ class DanmakuListener:
                     await self._emit("on_event", "SEND_GIFT", ld)
                 except Exception as e:
                     self._log(f"LiveDanmaku SEND_GIFT parse failed: {e}", "debug")
+                    await self._emit("on_event", "SEND_GIFT", {
+                        "uid": inner.get("uid", 0),
+                        "nickname": inner.get("uname", ""),
+                        "danmaku_text": f"gift {inner.get('giftName', 'gift')}",
+                        "gift_name": inner.get("giftName", "gift"),
+                        "gift_count": inner.get("num", 1),
+                        "gift_value": inner.get("total_coin", 0),
+                        "gift_coin_type": inner.get("coin_type", ""),
+                        "room_id": inner.get("room_id") or inner.get("ruid", 0),
+                    })
 
             elif cmd == "SUPER_CHAT_MESSAGE":
                 inner = data.get("data", {})
@@ -596,6 +604,14 @@ class DanmakuListener:
                     await self._emit("on_event", "SUPER_CHAT_MESSAGE", ld)
                 except Exception as e:
                     self._log(f"LiveDanmaku SUPER_CHAT_MESSAGE parse failed: {e}", "debug")
+                    await self._emit("on_event", "SUPER_CHAT_MESSAGE", {
+                        "uid": inner.get("uid", 0),
+                        "nickname": user_info.get("uname", ""),
+                        "danmaku_text": inner.get("message", "") or "Super Chat",
+                        "gift_name": "Super Chat",
+                        "gift_value": (int(inner.get("price") or 0) * 1000) if str(inner.get("price") or "0").isdigit() else 0,
+                        "room_id": inner.get("room_id", 0),
+                    })
 
             elif cmd == "INTERACT_WORD":
                 inner = data.get("data", {})
@@ -629,9 +645,111 @@ class DanmakuListener:
                         await self._emit("on_event", cmd, ld)
                 except Exception as e:
                     self._log(f"增强协议处理 {cmd} 异常: {e}", "debug")
+            else:
+                gift_payload = self._fallback_support_gift_payload(cmd, data)
+                if gift_payload:
+                    await self._emit("on_event", "SEND_GIFT", gift_payload)
 
         except Exception as e:
             self._log(f"分发消息 {cmd} 异常: {e}", "debug")
+
+    @staticmethod
+    def _fallback_support_gift_payload(cmd: str, data: dict):
+        """Recover trusted Bilibili support packets that use a newer/unknown cmd."""
+        if not isinstance(data, dict) or str(cmd or "").split(":", 1)[0] == "DANMU_MSG":
+            return None
+        inner = data.get("data")
+        if not isinstance(inner, dict):
+            return None
+        gift_info = inner.get("gift_info") or inner.get("giftInfo") or inner.get("gift") or {}
+        if not isinstance(gift_info, dict):
+            gift_info = {}
+        command = str(cmd or "").upper()
+        explicit_gift_command = "GIFT" in command
+        explicit_gift_fields = any(
+            key in inner
+            for key in ("gift_id", "giftId", "giftName", "gift_name", "gift_name_str", "giftNameStr")
+        )
+        nested_gift_fields = any(
+            key in gift_info
+            for key in ("gift_id", "giftId", "giftName", "gift_name", "gift_name_str", "giftNameStr")
+        )
+        support_hint = explicit_gift_command or explicit_gift_fields or nested_gift_fields
+        gift_name = DanmakuListener._first_text(
+            inner,
+            gift_info,
+            keys=("giftName", "gift_name", "gift_name_str", "giftNameStr"),
+        )
+        if not gift_name and explicit_gift_command:
+            gift_name = DanmakuListener._first_text(inner, gift_info, keys=("name",))
+        elif not gift_name and nested_gift_fields:
+            gift_name = DanmakuListener._first_text(gift_info, keys=("name",))
+        text_hint = DanmakuListener._first_text(
+            inner,
+            gift_info,
+            keys=("toast_msg", "toastMsg", "message", "msg", "copy_writing", "copyWriting", "text", "content"),
+        )
+        if not gift_name and support_hint and DanmakuListener._looks_like_fans_medal_text(text_hint):
+            gift_name = "fans medal"
+        if not gift_name or not support_hint:
+            return None
+        uid = DanmakuListener._first_int(inner, gift_info, keys=("uid", "user_id", "userId", "sender_uid", "senderUid"))
+        nickname = DanmakuListener._first_text(
+            inner,
+            gift_info,
+            keys=("uname", "user_name", "userName", "nickname", "name"),
+        )
+        count = DanmakuListener._first_int(inner, gift_info, keys=("num", "gift_num", "giftNum", "combo_num", "comboNum")) or 1
+        value = DanmakuListener._first_int(inner, gift_info, keys=("total_coin", "totalCoin", "price", "coin", "gold")) or 0
+        room_id = DanmakuListener._first_int(inner, data, keys=("room_id", "roomId", "roomid")) or 0
+        return {
+            "uid": uid,
+            "nickname": nickname,
+            "danmaku_text": f"gift {gift_name}",
+            "gift_name": gift_name,
+            "gift_count": count,
+            "gift_value": value,
+            "room_id": room_id,
+            "raw_cmd": str(cmd or ""),
+        }
+
+    @staticmethod
+    def _looks_like_fans_medal_text(text: str) -> bool:
+        cleaned = str(text or "")
+        if not cleaned:
+            return False
+        return (
+            ("粉丝团灯牌" in cleaned or "粉丝牌" in cleaned or "灯牌" in cleaned)
+            and ("赠送" in cleaned or "点亮" in cleaned or "投喂" in cleaned or "加入" in cleaned)
+        )
+
+    @staticmethod
+    def _first_text(*sources: dict, keys: tuple[str, ...]) -> str:
+        for source in sources:
+            if not isinstance(source, dict):
+                continue
+            for key in keys:
+                value = source.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+        return ""
+
+    @staticmethod
+    def _first_int(*sources: dict, keys: tuple[str, ...]) -> int:
+        for source in sources:
+            if not isinstance(source, dict):
+                continue
+            for key in keys:
+                value = source.get(key)
+                if isinstance(value, bool):
+                    continue
+                try:
+                    parsed = int(value)
+                except (TypeError, ValueError):
+                    continue
+                if parsed >= 0:
+                    return parsed
+        return 0
 
     # ── 增强协议指令处理器 ─────────────────────────────────────
 
@@ -891,7 +1009,7 @@ class DanmakuListener:
         real_room_id = await self._get_real_room_id(self.room_id)
         if self._stop_event.is_set():
             return
-        # 保存真实房间号供 send_danmaku 等接口使用
+        # 保存真实房间号供状态投影和后续协议请求使用
         self.real_room_id = real_room_id
 
         # 2. 获取所有服务器和 token
@@ -1001,91 +1119,6 @@ class DanmakuListener:
             if last_error:
                 self._log(f"所有 {len(servers)} 个服务器连接失败: {last_error}", "error")
                 raise last_error
-
-    async def send_danmaku(
-        self,
-        message: str,
-        room_id: int,
-        credential=None,
-        danmaku_max_length: int = 20,
-    ) -> dict:
-        """
-        发送弹幕到 B站直播间。
-
-        Args:
-            message: 弹幕文本
-            room_id: 直播间真实房间号
-            credential: _BiliCredential 实例（需要 bili_jct + SESSDATA）
-            danmaku_max_length: 弹幕最大长度限制（默认 20，B站限制 20 字符/秒）
-
-        Returns:
-            dict: {"success": bool, "message": str}
-        """
-        if not credential:
-            return {"success": False, "message": "未登录，无法发送弹幕"}
-
-        bili_jct = getattr(credential, "bili_jct", "")
-        sessdata = getattr(credential, "sessdata", "")
-        dedeuserid = getattr(credential, "dedeuserid", "")
-
-        if not bili_jct:
-            return {"success": False, "message": "缺少 bili_jct，无法发送弹幕"}
-
-        message = str(message).strip()
-        if not message:
-            return {"success": False, "message": "弹幕内容不能为空"}
-        max_len = danmaku_max_length or self._danmaku_max_length or 20
-        if len(message) > max_len:
-            message = message[:max_len]
-
-        try:
-            import aiohttp
-
-            url = "https://api.live.bilibili.com/msg/send"
-            headers = {
-                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-                "Referer": f"https://live.bilibili.com/{room_id}",
-                "Content-Type": "application/x-www-form-urlencoded",
-            }
-            cookies = {
-                "SESSDATA": sessdata,
-                "bili_jct": bili_jct,
-                "DedeUserID": dedeuserid,
-            }
-            # 过滤空值
-            cookies = {k: v for k, v in cookies.items() if v}
-
-            payload = {
-                "bubble": "0",
-                "msg": message,
-                "color": "16777215",
-                "mode": "1",
-                "fontsize": "25",
-                "rnd": int(time.time() * 1000000),
-                "roomid": room_id,
-                "csrf": bili_jct,
-                "csrf_token": bili_jct,
-            }
-
-            async with aiohttp.ClientSession(cookies=cookies, timeout=aiohttp.ClientTimeout(total=self._http_timeout)) as session:
-                async with session.post(
-                    url,
-                    data=payload,
-                    headers=headers,
-                    timeout=aiohttp.ClientTimeout(total=self._http_timeout),
-                ) as resp:
-                    data = await resp.json()
-                    code = data.get("code", -1)
-                    if code == 0:
-                        self._log(f"✅ 弹幕发送成功: {message[:30]}...")
-                        return {"success": True, "message": f"弹幕发送成功: {message}"}
-                    else:
-                        msg = data.get("message", "未知错误")
-                        self._log(f"❌ 弹幕发送失败: code={code} msg={msg}", "warning")
-                        return {"success": False, "message": f"发送失败: {msg} (code={code})"}
-        except Exception as e:
-            self._log(f"❌ 弹幕发送异常: {e}", "error")
-            return {"success": False, "message": f"发送异常: {e}"}
 
     async def stop(self):
         """断开连接（可在任意时刻安全调用，包括连接建立过程中）"""

--- a/plugin/plugins/neko_roast/modules/bili_live_ingest/danmaku_core.py
+++ b/plugin/plugins/neko_roast/modules/bili_live_ingest/danmaku_core.py
@@ -560,16 +560,6 @@ class DanmakuListener:
 
             elif cmd == "SEND_GIFT":
                 inner = data.get("data", {})
-                await self._emit("on_gift", {
-                    "user_name": inner.get("uname", "未知"),
-                    "user_id": inner.get("uid", 0),
-                    "gift_name": inner.get("giftName", "未知礼物"),
-                    "num": inner.get("num", 1),
-                    "coin_type": inner.get("coin_type", "silver"),
-                    "total_coin": inner.get("total_coin", 0),
-                    "price": inner.get("price", 0),
-                })
-
                 try:
                     from .livedanmaku import LiveDanmaku as _LD
                     ld = _LD.from_gift(data)
@@ -586,18 +576,19 @@ class DanmakuListener:
                         "gift_coin_type": inner.get("coin_type", ""),
                         "room_id": inner.get("room_id") or inner.get("ruid", 0),
                     })
+                await self._emit("on_gift", {
+                    "user_name": inner.get("uname", "未知"),
+                    "user_id": inner.get("uid", 0),
+                    "gift_name": inner.get("giftName", "未知礼物"),
+                    "num": inner.get("num", 1),
+                    "coin_type": inner.get("coin_type", "silver"),
+                    "total_coin": inner.get("total_coin", 0),
+                    "price": inner.get("price", 0),
+                })
 
             elif cmd == "SUPER_CHAT_MESSAGE":
                 inner = data.get("data", {})
                 user_info = inner.get("user_info", {})
-                await self._emit("on_sc", {
-                    "user_name": user_info.get("uname", "未知"),
-                    "user_id": inner.get("uid", 0),
-                    "message": inner.get("message", ""),
-                    "price": inner.get("price", 0),
-                    "start_time": inner.get("start_time", 0),
-                })
-
                 try:
                     from .livedanmaku import LiveDanmaku as _LD
                     ld = _LD.from_sc(data)
@@ -612,6 +603,13 @@ class DanmakuListener:
                         "gift_value": (int(inner.get("price") or 0) * 1000) if str(inner.get("price") or "0").isdigit() else 0,
                         "room_id": inner.get("room_id", 0),
                     })
+                await self._emit("on_sc", {
+                    "user_name": user_info.get("uname", "未知"),
+                    "user_id": inner.get("uid", 0),
+                    "message": inner.get("message", ""),
+                    "price": inner.get("price", 0),
+                    "start_time": inner.get("start_time", 0),
+                })
 
             elif cmd == "INTERACT_WORD":
                 inner = data.get("data", {})
@@ -666,6 +664,7 @@ class DanmakuListener:
             gift_info = {}
         command = str(cmd or "").upper()
         explicit_gift_command = "GIFT" in command
+        official_support_command = command in {"USER_TOAST_MSG"}
         explicit_gift_fields = any(
             key in inner
             for key in ("gift_id", "giftId", "giftName", "gift_name", "gift_name_str", "giftNameStr")
@@ -674,7 +673,26 @@ class DanmakuListener:
             key in gift_info
             for key in ("gift_id", "giftId", "giftName", "gift_name", "gift_name_str", "giftNameStr")
         )
-        support_hint = explicit_gift_command or explicit_gift_fields or nested_gift_fields
+        nested_gift_name_fields = any(
+            key in gift_info
+            for key in ("giftName", "gift_name", "gift_name_str", "giftNameStr")
+        )
+        text_hint = DanmakuListener._first_text(
+            inner,
+            gift_info,
+            keys=("toast_msg", "toastMsg", "message", "msg", "copy_writing", "copyWriting", "text", "content"),
+        )
+        if official_support_command and DanmakuListener._looks_like_fans_medal_activation_text(text_hint):
+            return None
+        support_hint = (
+            explicit_gift_command
+            or explicit_gift_fields
+            or (
+                official_support_command
+                and nested_gift_name_fields
+                and DanmakuListener._looks_like_gift_transfer_text(text_hint)
+            )
+        )
         gift_name = DanmakuListener._first_text(
             inner,
             gift_info,
@@ -684,11 +702,6 @@ class DanmakuListener:
             gift_name = DanmakuListener._first_text(inner, gift_info, keys=("name",))
         elif not gift_name and nested_gift_fields:
             gift_name = DanmakuListener._first_text(gift_info, keys=("name",))
-        text_hint = DanmakuListener._first_text(
-            inner,
-            gift_info,
-            keys=("toast_msg", "toastMsg", "message", "msg", "copy_writing", "copyWriting", "text", "content"),
-        )
         if not gift_name and support_hint and DanmakuListener._looks_like_fans_medal_text(text_hint):
             gift_name = "fans medal"
         if not gift_name or not support_hint:
@@ -722,6 +735,18 @@ class DanmakuListener:
             ("粉丝团灯牌" in cleaned or "粉丝牌" in cleaned or "灯牌" in cleaned)
             and ("赠送" in cleaned or "点亮" in cleaned or "投喂" in cleaned or "加入" in cleaned)
         )
+
+    @staticmethod
+    def _looks_like_fans_medal_activation_text(text: str) -> bool:
+        cleaned = str(text or "")
+        return DanmakuListener._looks_like_fans_medal_text(cleaned) and (
+            "成功" in cleaned or "点亮" in cleaned or "加入粉丝团" in cleaned
+        )
+
+    @staticmethod
+    def _looks_like_gift_transfer_text(text: str) -> bool:
+        cleaned = str(text or "")
+        return bool(cleaned) and any(marker in cleaned for marker in ("赠送", "投喂"))
 
     @staticmethod
     def _first_text(*sources: dict, keys: tuple[str, ...]) -> str:

--- a/plugin/plugins/neko_roast/modules/viewer_profile/__init__.py
+++ b/plugin/plugins/neko_roast/modules/viewer_profile/__init__.py
@@ -13,6 +13,13 @@ class ViewerProfileModule(BaseModule):
     async def upsert(self, identity: ViewerIdentity) -> ViewerProfile:
         return await self.ctx.viewer_store.upsert_identity(identity)
 
+    async def record_live_danmaku(
+        self,
+        identity: ViewerIdentity,
+        danmaku_text: str,
+    ) -> ViewerProfile:
+        return await self.ctx.viewer_store.record_live_danmaku(identity, danmaku_text)
+
     async def has_roasted(self, uid: str) -> bool:
         return await self.ctx.viewer_store.has_roasted(uid)
 

--- a/plugin/plugins/neko_roast/stores/viewer_store.py
+++ b/plugin/plugins/neko_roast/stores/viewer_store.py
@@ -148,7 +148,7 @@ class ViewerStore:
         profiles = await self._load_all()
         now = utc_now_iso()
         uid = _safe_profile_uid(identity.uid)
-        nickname = _safe_profile_text(identity.nickname) or uid
+        nickname = _safe_profile_text(identity.nickname)
         avatar_url = _safe_profile_text(identity.avatar_url)
         if not uid:
             return ViewerProfile(uid="", nickname=nickname, avatar_url=avatar_url)
@@ -177,7 +177,7 @@ class ViewerStore:
         else:
             profile = ViewerProfile(
                 uid=uid,
-                nickname=nickname,
+                nickname=nickname or uid,
                 avatar_url=avatar_url,
                 first_seen_at=now,
                 last_seen_at=now,
@@ -195,7 +195,7 @@ class ViewerStore:
             profiles = await self._load_all()
             now = utc_now_iso()
             uid = _safe_profile_uid(identity.uid)
-            nickname = _safe_profile_text(identity.nickname) or uid
+            nickname = _safe_profile_text(identity.nickname)
             avatar_url = _safe_profile_text(identity.avatar_url)
             if not uid:
                 return ViewerProfile(uid="", nickname=nickname, avatar_url=avatar_url)

--- a/plugin/plugins/neko_roast/stores/viewer_store.py
+++ b/plugin/plugins/neko_roast/stores/viewer_store.py
@@ -17,8 +17,11 @@ from pathlib import Path
 from typing import Any, Callable
 
 from ..core.contracts import ViewerIdentity, ViewerProfile, utc_now_iso
+from ..core.contracts_public import public_int, public_text
+from ..core.viewer_preferences import infer_viewer_preferences, merge_preference_counts, safe_preference_counts
 
 _STORE_FILE = "viewer_profiles.json"
+_MAX_PROFILE_TEXT = 240
 
 
 class ViewerStore:
@@ -144,29 +147,97 @@ class ViewerStore:
     async def _upsert_identity_locked(self, identity: ViewerIdentity) -> ViewerProfile:
         profiles = await self._load_all()
         now = utc_now_iso()
-        existing = profiles.get(identity.uid)
+        uid = _safe_profile_uid(identity.uid)
+        nickname = _safe_profile_text(identity.nickname) or uid
+        avatar_url = _safe_profile_text(identity.avatar_url)
+        if not uid:
+            return ViewerProfile(uid="", nickname=nickname, avatar_url=avatar_url)
+        existing = profiles.get(uid)
         if existing:
             profile = ViewerProfile(
-                uid=identity.uid,
-                nickname=identity.nickname or str(existing.get("nickname") or identity.uid),
-                avatar_url=identity.avatar_url or str(existing.get("avatar_url") or ""),
-                first_seen_at=str(existing.get("first_seen_at") or now),
+                uid=uid,
+                nickname=nickname or _safe_profile_text(existing.get("nickname")) or uid,
+                avatar_url=avatar_url or _safe_profile_text(existing.get("avatar_url")),
+                first_seen_at=_safe_profile_text(existing.get("first_seen_at")) or now,
                 last_seen_at=now,
-                roast_count=int(existing.get("roast_count") or 0),
-                last_roast_at=str(existing.get("last_roast_at") or ""),
-                last_result=str(existing.get("last_result") or ""),
+                roast_count=public_int(existing.get("roast_count"), default=0, minimum=0),
+                last_roast_at=_safe_profile_text(existing.get("last_roast_at")),
+                last_result=_safe_profile_text(existing.get("last_result")),
+                danmaku_count=public_int(existing.get("danmaku_count"), default=0, minimum=0),
+                preference_tags=safe_preference_counts(existing.get("preference_tags")),
+                favorite_topics=safe_preference_counts(existing.get("favorite_topics")),
+                running_jokes=safe_preference_counts(existing.get("running_jokes")),
+                interaction_style=_safe_profile_text(existing.get("interaction_style")),
+                response_preference=_safe_profile_text(existing.get("response_preference")),
+                last_interaction_summary=_safe_profile_text(existing.get("last_interaction_summary")),
+                impression_summary=_safe_profile_text(existing.get("impression_summary")),
+                avoid_guidance=_safe_profile_text(existing.get("avoid_guidance")),
+                last_interaction_at=_safe_profile_text(existing.get("last_interaction_at")),
             )
         else:
             profile = ViewerProfile(
-                uid=identity.uid,
-                nickname=identity.nickname or identity.uid,
-                avatar_url=identity.avatar_url,
+                uid=uid,
+                nickname=nickname,
+                avatar_url=avatar_url,
                 first_seen_at=now,
                 last_seen_at=now,
             )
-        profiles[identity.uid] = profile.to_dict()
+        profiles[uid] = profile.to_dict()
         await self._save_all(profiles)
         return profile
+
+    async def record_live_danmaku(
+        self,
+        identity: ViewerIdentity,
+        danmaku_text: str,
+    ) -> ViewerProfile:
+        async with self._lock:
+            profiles = await self._load_all()
+            now = utc_now_iso()
+            uid = _safe_profile_uid(identity.uid)
+            nickname = _safe_profile_text(identity.nickname) or uid
+            avatar_url = _safe_profile_text(identity.avatar_url)
+            if not uid:
+                return ViewerProfile(uid="", nickname=nickname, avatar_url=avatar_url)
+            item = dict(profiles.get(uid) or {})
+            inference = infer_viewer_preferences(danmaku_text)
+            profile = ViewerProfile(
+                uid=uid,
+                nickname=nickname or _safe_profile_text(item.get("nickname")) or uid,
+                avatar_url=avatar_url or _safe_profile_text(item.get("avatar_url")),
+                first_seen_at=_safe_profile_text(item.get("first_seen_at")) or now,
+                last_seen_at=now,
+                roast_count=public_int(item.get("roast_count"), default=0, minimum=0),
+                last_roast_at=_safe_profile_text(item.get("last_roast_at")),
+                last_result=_safe_profile_text(item.get("last_result")),
+                danmaku_count=public_int(item.get("danmaku_count"), default=0, minimum=0) + 1,
+                preference_tags=merge_preference_counts(
+                    item.get("preference_tags"),
+                    [str(tag) for tag in inference.get("tags", []) if str(tag).strip()],
+                ),
+                favorite_topics=merge_preference_counts(
+                    item.get("favorite_topics"),
+                    [str(tag) for tag in inference.get("favorite_topics", []) if str(tag).strip()],
+                ),
+                running_jokes=merge_preference_counts(
+                    item.get("running_jokes"),
+                    [str(tag) for tag in inference.get("running_jokes", []) if str(tag).strip()],
+                ),
+                interaction_style=_safe_profile_text(inference.get("interaction_style"))
+                or _safe_profile_text(item.get("interaction_style")),
+                response_preference=_safe_profile_text(inference.get("response_preference"))
+                or _safe_profile_text(item.get("response_preference")),
+                last_interaction_summary=_safe_profile_text(inference.get("summary"))
+                or _safe_profile_text(item.get("last_interaction_summary")),
+                impression_summary=_safe_profile_text(inference.get("impression_summary"))
+                or _safe_profile_text(item.get("impression_summary")),
+                avoid_guidance=_safe_profile_text(inference.get("avoid_guidance"))
+                or _safe_profile_text(item.get("avoid_guidance")),
+                last_interaction_at=now,
+            )
+            profiles[uid] = profile.to_dict()
+            await self._save_all(profiles)
+            return profile
 
     async def mark_roasted(self, uid: str, output: str) -> None:
         async with self._lock:
@@ -190,3 +261,14 @@ class ViewerStore:
         profiles = await self._load_all()
         ordered = sorted(profiles.values(), key=lambda item: str(item.get("last_seen_at") or ""), reverse=True)
         return [dict(item) for item in ordered[:limit]]
+
+
+def _safe_profile_uid(value: Any) -> str:
+    text = public_text(value, max_len=120)
+    if "[redacted]" in text:
+        return ""
+    return text
+
+
+def _safe_profile_text(value: Any) -> str:
+    return public_text(value, max_len=_MAX_PROFILE_TEXT)

--- a/plugin/plugins/neko_roast/tests/test_event_bus.py
+++ b/plugin/plugins/neko_roast/tests/test_event_bus.py
@@ -124,3 +124,41 @@ def test_super_chat_jpn_routes_to_super_chat_bus_key():
     assert live_event.type == "super_chat"
     assert live_event.uid == "42"
     assert live_event.payload["raw_type"] == "SUPER_CHAT_MESSAGE_JPN"
+
+
+def test_avatar_roast_module_imports_with_its_prompt_dependencies():
+    from plugin.plugins.neko_roast.modules.avatar_roast import AvatarRoastModule
+
+    assert AvatarRoastModule.id == "avatar_roast"
+
+
+def test_support_dedupe_keeps_send_gift_and_combo_send_distinct():
+    module = BiliLiveIngestModule()
+    common = {
+        "gift_name": "小心心",
+        "gift_count": 1,
+        "gift_value": 100,
+    }
+    send = LiveEvent(type="gift", uid="9", payload={**common, "cmd": "SEND_GIFT"}, ts=100.0)
+    combo = LiveEvent(type="gift", uid="9", payload={**common, "cmd": "COMBO_SEND"}, ts=100.1)
+    duplicate_combo = LiveEvent(type="gift", uid="9", payload={**common, "cmd": "COMBO_SEND"}, ts=100.2)
+
+    assert module._is_duplicate_support_event(send) is False
+    assert module._is_duplicate_support_event(combo) is False
+    assert module._is_duplicate_support_event(duplicate_combo) is True
+
+
+def test_support_dedupe_matches_lightweight_and_rich_super_chat():
+    module = BiliLiveIngestModule()
+    lightweight = module._to_live_event(
+        "SUPER_CHAT_MESSAGE",
+        {"user_id": 9, "user_name": "SCUser", "message": "hello", "price": 30},
+    )
+    rich = module._to_live_event(
+        "SUPER_CHAT_MESSAGE",
+        SimpleNamespace(uid=9, nickname="SCUser", text="hello", room_id=1),
+    )
+    rich.ts = lightweight.ts + 0.1
+
+    assert module._is_duplicate_support_event(lightweight) is False
+    assert module._is_duplicate_support_event(rich) is True

--- a/plugin/plugins/neko_roast/tests/test_event_bus.py
+++ b/plugin/plugins/neko_roast/tests/test_event_bus.py
@@ -162,3 +162,15 @@ def test_support_dedupe_matches_lightweight_and_rich_super_chat():
 
     assert module._is_duplicate_support_event(lightweight) is False
     assert module._is_duplicate_support_event(rich) is True
+
+
+def test_support_dedupe_duplicate_does_not_extend_window():
+    module = BiliLiveIngestModule()
+    payload = {"gift_name": "small heart", "gift_count": 1, "cmd": "SEND_GIFT"}
+    first = LiveEvent(type="gift", uid="9", payload=payload, ts=100.0)
+    duplicate = LiveEvent(type="gift", uid="9", payload=payload, ts=100.2)
+    after_window = LiveEvent(type="gift", uid="9", payload=payload, ts=100.4)
+
+    assert module._is_duplicate_support_event(first) is False
+    assert module._is_duplicate_support_event(duplicate) is True
+    assert module._is_duplicate_support_event(after_window) is False

--- a/plugin/plugins/neko_roast/tests/test_livedanmaku.py
+++ b/plugin/plugins/neko_roast/tests/test_livedanmaku.py
@@ -232,6 +232,34 @@ def test_preparing_marks_live_ended():
     assert seen == ["preparing"]
 
 
+def test_support_callbacks_publish_rich_event_before_lightweight_fallback():
+    for cmd, fallback_callback, payload in (
+        (
+            "SEND_GIFT",
+            "on_gift",
+            {"data": {"uid": 9, "uname": "GiftUser", "giftName": "Heart", "num": 1}},
+        ),
+        (
+            "SUPER_CHAT_MESSAGE",
+            "on_sc",
+            {"data": {"uid": 10, "user_info": {"uname": "SCUser"}, "message": "hi", "price": 30}},
+        ),
+    ):
+        seen: list[tuple[str, object]] = []
+        listener = DanmakuListener(
+            room_id=1,
+            callbacks={
+                "on_event": lambda _cmd, event: seen.append(("on_event", event)),
+                fallback_callback: lambda event, name=fallback_callback: seen.append((name, event)),
+            },
+        )
+
+        asyncio.run(listener._dispatch_message(cmd, {"cmd": cmd, **payload}))
+
+        assert [name for name, _event in seen] == ["on_event", fallback_callback]
+        assert isinstance(seen[0][1], LiveDanmaku)
+
+
 def test_enhanced_cmd_handler_table_keeps_static_handlers_callable():
     """Class-level enhanced handlers should stay callable from _CMD_HANDLERS."""
     handler = DanmakuListener._CMD_HANDLERS["SUPER_CHAT_MESSAGE_JPN"]
@@ -250,6 +278,12 @@ def test_fallback_support_gift_rejects_generic_medal_or_toast_packets():
 
     assert DanmakuListener._fallback_support_gift_payload("FANS_MEDAL_CHANGE", medal) is None
     assert DanmakuListener._fallback_support_gift_payload("ROOM_TOAST_MESSAGE", toast) is None
+
+
+def test_fallback_support_gift_rejects_user_toast_fans_medal_text():
+    toast = {"data": {"uid": 9, "toast_msg": "\u70b9\u4eae\u7c89\u4e1d\u724c"}}
+
+    assert DanmakuListener._fallback_support_gift_payload("USER_TOAST_MSG", toast) is None
 
 
 def test_fallback_support_gift_rejects_bare_nested_name():
@@ -274,6 +308,57 @@ def test_fallback_support_gift_rejects_generic_nested_id_and_name():
     }
 
     assert DanmakuListener._fallback_support_gift_payload("ROOM_RANK_UPDATE", packet) is None
+
+
+def test_fallback_support_gift_rejects_nested_gift_id_without_gift_evidence():
+    packet = {
+        "data": {
+            "uid": 9,
+            "gift_info": {"gift_id": 1, "name": "灯牌"},
+            "message": "点亮粉丝牌成功",
+        }
+    }
+
+    assert DanmakuListener._fallback_support_gift_payload("ROOM_RANK_UPDATE", packet) is None
+
+
+def test_fallback_support_gift_rejects_fans_medal_activation_toast():
+    packet = {
+        "data": {
+            "uid": 42,
+            "uname": "Viewer",
+            "toast_msg": "点亮粉丝牌成功",
+            "gift_info": {"gift_id": 1, "name": "灯牌"},
+        }
+    }
+
+    assert DanmakuListener._fallback_support_gift_payload("USER_TOAST_MSG", packet) is None
+
+
+def test_fallback_support_gift_rejects_generic_medal_name_even_with_transfer_text():
+    packet = {
+        "data": {
+            "uid": 42,
+            "uname": "Viewer",
+            "toast_msg": "赠送粉丝牌成功",
+            "gift_info": {"gift_id": 1, "name": "灯牌"},
+        }
+    }
+
+    assert DanmakuListener._fallback_support_gift_payload("USER_TOAST_MSG", packet) is None
+
+
+def test_fallback_support_gift_rejects_explicit_medal_gift_name():
+    packet = {
+        "data": {
+            "uid": 42,
+            "uname": "Viewer",
+            "toast_msg": "赠送粉丝牌成功",
+            "gift_info": {"gift_id": 1, "gift_name": "灯牌"},
+        }
+    }
+
+    assert DanmakuListener._fallback_support_gift_payload("USER_TOAST_MSG", packet) is None
 
 
 def test_fallback_support_gift_accepts_explicit_gift_evidence():

--- a/plugin/plugins/neko_roast/tests/test_livedanmaku.py
+++ b/plugin/plugins/neko_roast/tests/test_livedanmaku.py
@@ -244,6 +244,60 @@ def test_enhanced_cmd_handler_table_keeps_static_handlers_callable():
     assert ld.text == "hi"
 
 
+def test_fallback_support_gift_rejects_generic_medal_or_toast_packets():
+    medal = {"data": {"uid": 9, "name": "普通勋章", "message": "勋章升级"}}
+    toast = {"data": {"uid": 9, "name": "普通提示", "message": "欢迎回来"}}
+
+    assert DanmakuListener._fallback_support_gift_payload("FANS_MEDAL_CHANGE", medal) is None
+    assert DanmakuListener._fallback_support_gift_payload("ROOM_TOAST_MESSAGE", toast) is None
+
+
+def test_fallback_support_gift_rejects_bare_nested_name():
+    packet = {
+        "data": {
+            "uid": 9,
+            "gift": {"name": "灯牌"},
+            "message": "点亮粉丝牌成功",
+        }
+    }
+
+    assert DanmakuListener._fallback_support_gift_payload("ROOM_RANK_UPDATE", packet) is None
+
+
+def test_fallback_support_gift_rejects_generic_nested_id_and_name():
+    packet = {
+        "data": {
+            "uid": 9,
+            "gift_info": {"id": 1, "name": "灯牌"},
+            "message": "点亮粉丝牌成功",
+        }
+    }
+
+    assert DanmakuListener._fallback_support_gift_payload("ROOM_RANK_UPDATE", packet) is None
+
+
+def test_fallback_support_gift_accepts_explicit_gift_evidence():
+    payload = DanmakuListener._fallback_support_gift_payload(
+        "UNKNOWN_SUPPORT_PACKET",
+        {
+            "data": {
+                "uid": 9,
+                "uname": "GiftUser",
+                "gift_id": 42,
+                "gift_name": "小心心",
+                "num": 2,
+                "total_coin": 200,
+            }
+        },
+    )
+
+    assert payload is not None
+    assert payload["uid"] == 9
+    assert payload["gift_name"] == "小心心"
+    assert payload["gift_count"] == 2
+    assert payload["gift_value"] == 200
+
+
 def test_brotli_missing_uses_supplied_log_callback(monkeypatch):
     """Decompression logging must be scoped to the listener/callback, not module state."""
     monkeypatch.setitem(sys.modules, "brotli", None)

--- a/plugin/plugins/neko_roast/tests/test_runtime_active_engagement.py
+++ b/plugin/plugins/neko_roast/tests/test_runtime_active_engagement.py
@@ -14,10 +14,11 @@ from plugin.plugins.neko_roast.core.runtime_active_engagement import (
 class _Pipeline:
     def __init__(self) -> None:
         self.events = []
+        self.status = "pushed"
 
     async def handle_event(self, event):
         self.events.append(event)
-        return InteractionResult(accepted=True, status="pushed", event=event)
+        return InteractionResult(accepted=True, status=self.status, event=event)
 
 
 class _Audit:
@@ -93,4 +94,18 @@ async def test_maybe_trigger_active_engagement_records_attempt_after_success():
     assert result is not None
     assert result.status == "pushed"
     assert runtime._active_engagement_last_attempt_at == 100.0
+    assert len(runtime.pipeline.events) == 1
+
+
+@pytest.mark.asyncio
+async def test_dry_run_active_engagement_records_attempt_and_respects_interval():
+    runtime = _Runtime({"candidate": True, "eligible": True, "reason": "eligible"})
+    runtime.pipeline.status = "dry_run"
+
+    result = await maybe_trigger_active_engagement(runtime)
+
+    assert result is not None
+    assert result.status == "dry_run"
+    assert runtime._active_engagement_last_attempt_at == 100.0
+    assert await maybe_trigger_active_engagement(runtime) is None
     assert len(runtime.pipeline.events) == 1

--- a/plugin/plugins/neko_roast/tests/test_runtime_live_controls.py
+++ b/plugin/plugins/neko_roast/tests/test_runtime_live_controls.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from plugin.plugins.neko_roast.core.contracts import LiveRoomStatus
 from plugin.plugins.neko_roast.core.runtime import RoastRuntime
 from plugin.plugins.neko_roast.core.runtime_live_listener import stop_live_listener
 
@@ -48,6 +49,7 @@ class FakeIngest:
         self.stopped = 0
         self.room_id = 0
         self.start_result = True
+        self.lookup_status = LiveRoomStatus(room_id=123, ok=True, title="configured room", live_status="live")
 
     def is_listening(self) -> bool:
         return self.room_id > 0
@@ -71,12 +73,33 @@ class FakeIngest:
             self.stopped += 1
         self.room_id = 0
 
+    async def lookup_room_status(self, room_id: int) -> LiveRoomStatus:
+        return LiveRoomStatus(
+            room_id=room_id,
+            ok=self.lookup_status.ok,
+            title=self.lookup_status.title,
+            live_status=self.lookup_status.live_status,
+        )
+
 
 @pytest.fixture
 def runtime(tmp_path: Path) -> RoastRuntime:
     rt = RoastRuntime(Plugin(tmp_path))
     rt.bili_live_ingest = FakeIngest()
     return rt
+
+
+@pytest.mark.asyncio
+async def test_lookup_other_room_does_not_replace_configured_room_context(runtime: RoastRuntime) -> None:
+    await runtime.set_live_room(123)
+    configured_context = dict(runtime.live_room_context)
+    runtime.bili_live_ingest.lookup_status.title = "preview room"
+
+    result = await runtime.lookup_live_room(999)
+
+    assert result["room_ref"] == "999"
+    assert result["title"] == "preview room"
+    assert runtime.live_room_context == configured_context
 
 
 @pytest.mark.asyncio

--- a/plugin/plugins/neko_roast/tests/test_viewer_store.py
+++ b/plugin/plugins/neko_roast/tests/test_viewer_store.py
@@ -113,3 +113,23 @@ async def test_record_live_danmaku_persists_count_and_preferences(tmp_path):
     assert item["nickname"] == "新昵称"
     assert item["danmaku_count"] == 2
     assert item["preference_tags"].get("question", 0) >= 2
+
+
+@pytest.mark.asyncio
+async def test_upsert_identity_without_nickname_preserves_existing_nickname(tmp_path):
+    store = ViewerStore(_FakePlugin(tmp_path), audit=None)
+    await store.upsert_identity(ViewerIdentity(uid="42", nickname="known viewer"))
+
+    profile = await store.upsert_identity(ViewerIdentity(uid="42", nickname=""))
+
+    assert profile.nickname == "known viewer"
+
+
+@pytest.mark.asyncio
+async def test_record_live_danmaku_without_nickname_preserves_existing_nickname(tmp_path):
+    store = ViewerStore(_FakePlugin(tmp_path), audit=None)
+    await store.upsert_identity(ViewerIdentity(uid="42", nickname="known viewer"))
+
+    profile = await store.record_live_danmaku(ViewerIdentity(uid="42", nickname=""), "hello")
+
+    assert profile.nickname == "known viewer"

--- a/plugin/plugins/neko_roast/tests/test_viewer_store.py
+++ b/plugin/plugins/neko_roast/tests/test_viewer_store.py
@@ -95,3 +95,21 @@ async def test_mark_roasted_roundtrip(tmp_path):
     item = next(p for p in recent if p["uid"] == "7")
     assert item["roast_count"] == 1
     assert item["last_result"] == "锐评内容"
+
+
+@pytest.mark.asyncio
+async def test_record_live_danmaku_persists_count_and_preferences(tmp_path):
+    store = ViewerStore(_FakePlugin(tmp_path), audit=None)
+    identity = ViewerIdentity(uid="42", nickname="提问观众")
+
+    first = await store.record_live_danmaku(identity, "这个插件怎么配置？")
+    second = await store.record_live_danmaku(identity, "还有教程吗？")
+    await store.upsert_identity(ViewerIdentity(uid="42", nickname="新昵称"))
+
+    assert first.danmaku_count == 1
+    assert second.danmaku_count == 2
+    restarted = ViewerStore(_FakePlugin(tmp_path), audit=None)
+    item = next(profile for profile in await restarted.recent_profiles() if profile["uid"] == "42")
+    assert item["nickname"] == "新昵称"
+    assert item["danmaku_count"] == 2
+    assert item["preference_tags"].get("question", 0) >= 2


### PR DESCRIPTION
﻿## Summary
Stacked PR slice 7/26 for bringing the modular NEKO Live / neko_roast plugin changes into upstream main while keeping each review unit small.

## Scope
- Branch: $(System.Collections.Hashtable.head)
- Base / merge order: after $(System.Collections.Hashtable.base)
- Path boundary: only plugin/plugins/neko_roast/**

## Module Slice
Bilibili ingest, avatar roast boundary, viewer profile integration, and demo avatar fixture.

## Regression Report
Final stacked branch validation after CodeRabbit fixes:

`powershell
uv run pytest plugin/plugins/neko_roast/tests -q --maxfail=1
# 1059 passed, 1 warning

uv run python -m plugin.neko_plugin_cli.cli check plugin/plugins/neko_roast
# 0 errors, 6 warnings

git diff --check -- plugin/plugins/neko_roast
# clean
`

## Rollback / Degrade
Revert or close this PR before merging dependent stacked PRs. Merge order is numeric, from 01/26 through 26/26.

## Notes
Draft stacked PR. Review against its base branch to keep the changed-file set small.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 首次出场锐评新增“空闲上麦/节拍”模式，并通过直播样式锚点提升回答衔接连贯性。
  - 新增观众昵称自然称呼/地址识别。
  - 支持记录观众弹幕并持久化，自动累积偏好与互动次数。
- **改进**
  - 直播支持类事件（如礼物/醒目留言等）增加短时去重；弹幕事件解析与兜底增强。
  - dry_run 下的活跃互动记录行为更一致；资料文本清洗与长度限制更可靠。
- **测试**
  - 扩充事件去重、回调触发顺序、存储持久化与兜底解析等覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->