### PR TITLE
修复教程跳过或对抗退出后的遮罩残留与快捷键禁用问题

### DIFF
--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -2993,6 +2993,9 @@
         ) {
             return true;
         }
+        if (!isYuiGuideMessageForCurrentLifecycle(message)) {
+            return true;
+        }
         if (
             message.action !== 'yui_guide_tutorial_lifecycle_ended'
             && isYuiGuideLifecycleScopedAction(message.action)
@@ -3264,6 +3267,9 @@
                     yuiGuidePcOverlayLifecycleClosed
                     && isYuiGuideLifecycleScopedAction(message.action)
                 ) {
+                    return;
+                }
+                if (!isYuiGuideMessageForCurrentLifecycle(message)) {
                     return;
                 }
 
@@ -4250,6 +4256,18 @@
         yuiGuidePcOverlayLifecycleEpoch += 1;
         yuiGuidePcOverlayLifecycleClosed = true;
         yuiGuidePcOverlayLifecycleRunId = '';
+    }
+
+    function isYuiGuideMessageForCurrentLifecycle(message) {
+        if (!message || !isYuiGuideLifecycleScopedAction(message.action)) {
+            return true;
+        }
+        var runId = typeof message.tutorialRunId === 'string'
+            ? message.tutorialRunId
+            : '';
+        return !runId
+            || !yuiGuidePcOverlayLifecycleRunId
+            || runId === yuiGuidePcOverlayLifecycleRunId;
     }
 
     function resetYuiGuidePcOverlayRunForRetry() {
@@ -5494,6 +5512,9 @@
             return false;
         }
         var action = message.action || '';
+        if (!isYuiGuideMessageForCurrentLifecycle(message)) {
+            return false;
+        }
         var cursorOptions = Object.assign({}, message, {
             pcOverlayRunId: message.pcOverlayRunId || getYuiGuidePcOverlayRunIdFromMessage(message)
         });

--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -2984,6 +2984,15 @@
         if (!message || !message.action) {
             return false;
         }
+        if (isYuiGuideLifecycleStartAction(message.action)) {
+            openYuiGuidePcOverlayLifecycle(message);
+        }
+        if (
+            yuiGuidePcOverlayLifecycleClosed
+            && isYuiGuideLifecycleScopedAction(message.action)
+        ) {
+            return true;
+        }
         if (
             message.action !== 'yui_guide_tutorial_lifecycle_ended'
             && isYuiGuideLifecycleScopedAction(message.action)
@@ -3245,6 +3254,16 @@
                     && isDuplicateMessage(message.action, message.timestamp)
                 ) {
                     console.log('[BroadcastChannel] 跳过重复消息:', message.action);
+                    return;
+                }
+
+                if (isYuiGuideLifecycleStartAction(message.action)) {
+                    openYuiGuidePcOverlayLifecycle(message);
+                }
+                if (
+                    yuiGuidePcOverlayLifecycleClosed
+                    && isYuiGuideLifecycleScopedAction(message.action)
+                ) {
                     return;
                 }
 
@@ -3984,6 +4003,9 @@
     var yuiGuidePcOverlayReady = false;
     var yuiGuidePcOverlayRunIdOverride = '';
     var yuiGuidePcOverlayEndedRunId = '';
+    var yuiGuidePcOverlayLifecycleEpoch = 0;
+    var yuiGuidePcOverlayLifecycleClosed = false;
+    var yuiGuidePcOverlayLifecycleRunId = '';
     var yuiGuidePcOverlaySequence = 0;
     var yuiGuidePcOverlaySpotlights = [];
     var yuiGuidePcOverlayCursor = null;
@@ -4195,6 +4217,41 @@
         }
     }
 
+    function isYuiGuideLifecycleStartAction(action) {
+        return action === 'yui_guide_tutorial_lifecycle_started'
+            || action === 'yui_guide_tutorial_started'
+            || action === 'avatar_floating_guide_started';
+    }
+
+    function openYuiGuidePcOverlayLifecycle(message) {
+        var runId = message && typeof message.tutorialRunId === 'string'
+            ? message.tutorialRunId
+            : '';
+        if (
+            (runId && isYuiGuidePcOverlayRunEnded(runId))
+            || (yuiGuidePcOverlayLifecycleClosed && !runId)
+        ) {
+            return false;
+        }
+        if (
+            yuiGuidePcOverlayLifecycleEpoch === 0
+            || yuiGuidePcOverlayLifecycleClosed
+            || (runId && runId !== yuiGuidePcOverlayLifecycleRunId)
+        ) {
+            yuiGuidePcOverlayLifecycleEpoch += 1;
+        }
+        yuiGuidePcOverlayLifecycleClosed = false;
+        yuiGuidePcOverlayLifecycleRunId = runId || yuiGuidePcOverlayLifecycleRunId;
+        yuiGuidePcOverlayEndedRunId = '';
+        return true;
+    }
+
+    function closeYuiGuidePcOverlayLifecycle() {
+        yuiGuidePcOverlayLifecycleEpoch += 1;
+        yuiGuidePcOverlayLifecycleClosed = true;
+        yuiGuidePcOverlayLifecycleRunId = '';
+    }
+
     function resetYuiGuidePcOverlayRunForRetry() {
         yuiGuidePcOverlayActive = false;
         yuiGuidePcOverlayReady = false;
@@ -4205,9 +4262,15 @@
         } catch (_) {}
     }
 
-    function handleYuiGuidePcOverlayStaleResult(result, patch, attemptedRunId, retried) {
+    function handleYuiGuidePcOverlayStaleResult(result, patch, attemptedRunId, retried, attemptedLifecycleEpoch) {
         var isStaleResponse = !!(result && result.stale === true);
         var alreadyRetried = retried === true;
+        if (
+            yuiGuidePcOverlayLifecycleClosed
+            || attemptedLifecycleEpoch !== yuiGuidePcOverlayLifecycleEpoch
+        ) {
+            return;
+        }
         var attemptedCurrentRun = !!(attemptedRunId && attemptedRunId === yuiGuidePcOverlayRunIdOverride);
         var attemptedChatOwnedRun = isYuiGuideChatOwnedPcOverlayRunId(attemptedRunId);
         var storedCanonicalRunId = readStoredYuiGuidePcOverlayRunId();
@@ -4576,9 +4639,10 @@
 
     function sendYuiGuidePcOverlayPatch(patch, retried, options) {
         var host = getYuiGuidePcOverlayHost();
-        if (!host) {
+        if (!host || yuiGuidePcOverlayLifecycleClosed) {
             return false;
         }
+        var sendLifecycleEpoch = yuiGuidePcOverlayLifecycleEpoch;
         var sendOptions = options || {};
         if (isYuiGuidePcOverlayRunEnded(sendOptions.tutorialRunId)) {
             return false;
@@ -4607,8 +4671,20 @@
         if (!yuiGuidePcOverlayActive && sendOptions.skipBegin !== true && typeof host.begin === 'function') {
             try {
                 Promise.resolve(host.begin({ tutorialRunId: runId })).then(function (result) {
+                    if (
+                        yuiGuidePcOverlayLifecycleClosed
+                        || sendLifecycleEpoch !== yuiGuidePcOverlayLifecycleEpoch
+                    ) {
+                        return;
+                    }
                     if (result && result.stale === true) {
-                        handleYuiGuidePcOverlayStaleResult(result, patch, runId, retried === true);
+                        handleYuiGuidePcOverlayStaleResult(
+                            result,
+                            patch,
+                            runId,
+                            retried === true,
+                            sendLifecycleEpoch
+                        );
                         return;
                     }
                     if (result && result.ok === false) {
@@ -4616,6 +4692,9 @@
                         yuiGuidePcOverlayReady = false;
                     }
                 }).catch(function () {
+                    if (sendLifecycleEpoch !== yuiGuidePcOverlayLifecycleEpoch) {
+                        return;
+                    }
                     yuiGuidePcOverlayActive = false;
                     yuiGuidePcOverlayReady = false;
                 });
@@ -4630,8 +4709,20 @@
                 sequence: yuiGuidePcOverlaySequence,
                 payload: payload
             })).then(function (result) {
+                if (
+                    yuiGuidePcOverlayLifecycleClosed
+                    || sendLifecycleEpoch !== yuiGuidePcOverlayLifecycleEpoch
+                ) {
+                    return;
+                }
                 if (result && result.stale === true) {
-                    handleYuiGuidePcOverlayStaleResult(result, patch, runId, retried === true);
+                    handleYuiGuidePcOverlayStaleResult(
+                        result,
+                        patch,
+                        runId,
+                        retried === true,
+                        sendLifecycleEpoch
+                    );
                     return;
                 }
                 if (result && result.ok === false) {
@@ -4640,6 +4731,9 @@
                 }
                 yuiGuidePcOverlayReady = true;
             }).catch(function () {
+                if (sendLifecycleEpoch !== yuiGuidePcOverlayLifecycleEpoch) {
+                    return;
+                }
                 yuiGuidePcOverlayReady = false;
             });
             yuiGuidePcOverlayReady = true;
@@ -5393,6 +5487,9 @@
 
     function applyYuiGuideChatCursorRelay(message) {
         if (!message || typeof message !== 'object' || !isStandaloneChatPage() || !document.body) return false;
+        if (yuiGuidePcOverlayLifecycleClosed) {
+            return false;
+        }
         if (isYuiGuidePcOverlayRunEnded(message.tutorialRunId)) {
             return false;
         }
@@ -5433,6 +5530,7 @@
         if (endedRunId) {
             yuiGuidePcOverlayEndedRunId = endedRunId;
         }
+        closeYuiGuidePcOverlayLifecycle();
         yuiGuidePcOverlayActive = false;
         yuiGuidePcOverlayReady = false;
         yuiGuidePcOverlayRunIdOverride = '';

--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -4259,7 +4259,13 @@
     }
 
     function isYuiGuideMessageForCurrentLifecycle(message) {
-        if (!message || !isYuiGuideLifecycleScopedAction(message.action)) {
+        if (
+            !message
+            || (
+                message.action !== 'yui_guide_tutorial_lifecycle_ended'
+                && !isYuiGuideLifecycleScopedAction(message.action)
+            )
+        ) {
             return true;
         }
         var runId = typeof message.tutorialRunId === 'string'

--- a/static/tutorial/icebreaker/new-user-icebreaker.js
+++ b/static/tutorial/icebreaker/new-user-icebreaker.js
@@ -1495,8 +1495,7 @@
         if (!endState || endState.ended !== true) return false;
         if (endState.isAngryExit) return false;
         var outcome = String(endState.outcome || endState.rawReason || '');
-        if (outcome === 'destroy') return false;
-        if (outcome && outcome !== 'complete' && outcome !== 'skip') return false;
+        if (outcome !== 'complete') return false;
         var endedAt = Number(endState.endedAt || 0);
         if (endedAt && Date.now() - endedAt > TRIGGER_WINDOW_MS) return false;
         var day = String(endState.day || '');
@@ -1650,12 +1649,8 @@
         var normalizedDetail = detail && typeof detail === 'object' ? detail : {};
         var day = normalizedDetail.day;
         var outcome = '';
-        if (eventType === 'neko:avatar-floating-guide-skip') {
-            outcome = 'skip';
-        } else if (eventType === 'neko:avatar-floating-guide-complete') {
+        if (eventType === 'neko:avatar-floating-guide-complete') {
             outcome = 'complete';
-        } else if (eventType === 'neko:tutorial-skipped' && normalizedDetail.page === 'home') {
-            outcome = 'skip';
         } else if (eventType === 'neko:tutorial-completed' && normalizedDetail.page === 'home') {
             outcome = 'complete';
         }
@@ -1687,6 +1682,13 @@
         var detail = event && event.detail ? event.detail : {};
         var eventType = event && event.type ? String(event.type) : '';
         var endState = resolveLatestEndState(detail, eventType);
+        if (
+            !endState
+            || endState.isAngryExit === true
+            || String(endState.outcome || endState.rawReason || '') !== 'complete'
+        ) {
+            return;
+        }
         var pendingDay = markPendingStartFromEndState(endState);
         window.setTimeout(function () {
             attemptStartFromGuideEndState(endState, pendingDay);
@@ -1700,9 +1702,7 @@
     }
 
     window.addEventListener('neko:avatar-floating-guide-complete', handleGuideEndEvent);
-    window.addEventListener('neko:avatar-floating-guide-skip', handleGuideEndEvent);
     window.addEventListener('neko:tutorial-completed', handleGuideEndEvent);
-    window.addEventListener('neko:tutorial-skipped', handleGuideEndEvent);
     window.addEventListener('neko:day1-systray-intro-closed', function () {
         if (!pendingGuideEndState) return;
         attemptStartFromGuideEndState(pendingGuideEndState, String(pendingGuideEndState.day || ''));

--- a/static/tutorial/yui-guide/overlay.js
+++ b/static/tutorial/yui-guide/overlay.js
@@ -739,6 +739,12 @@
     class YuiGuideOverlay {
         constructor(doc) {
             this.document = doc || document;
+            const hostWindow = this.document && this.document.defaultView
+                ? this.document.defaultView
+                : window;
+            this.lifecycleEpoch = Number(
+                hostWindow && hostWindow.__NEKO_YUI_GUIDE_OVERLAY_LIFECYCLE_EPOCH__
+            ) || 0;
             this.root = null;
             this.stage = null;
             this.controlBanner = null;
@@ -942,7 +948,26 @@
             return this.overlayRenderer.shouldSuppressDom();
         }
 
+        isTutorialLifecycleCurrent() {
+            const hostWindow = this.document && this.document.defaultView
+                ? this.document.defaultView
+                : window;
+            const currentEpoch = Number(
+                hostWindow && hostWindow.__NEKO_YUI_GUIDE_OVERLAY_LIFECYCLE_EPOCH__
+            ) || 0;
+            return currentEpoch === this.lifecycleEpoch;
+        }
+
         ensureRoot() {
+            if (!this.isTutorialLifecycleCurrent()) {
+                const staleRoot = this.document.getElementById(ROOT_ID);
+                if (staleRoot && staleRoot.isConnected) {
+                    staleRoot.remove();
+                }
+                this.root = null;
+                this.stage = null;
+                return null;
+            }
             if (this.root && this.root.isConnected) {
                 return this.root;
             }
@@ -1183,7 +1208,7 @@
             if (!this.takingOverActive) {
                 return;
             }
-            this.ensureRoot();
+            if (!this.ensureRoot()) return;
             if (this.controlBannerEmphasisTimer) {
                 window.clearTimeout(this.controlBannerEmphasisTimer);
                 this.controlBannerEmphasisTimer = null;
@@ -1423,7 +1448,7 @@
                 return null;
             }
 
-            this.ensureRoot();
+            if (!this.ensureRoot()) return null;
             if (this.extraSpotlightEntries[normalizedIndex]) {
                 return this.extraSpotlightEntries[normalizedIndex];
             }
@@ -1461,7 +1486,7 @@
         }
 
         setExtraSpotlights(elements) {
-            this.ensureRoot();
+            if (!this.ensureRoot()) return;
             if (this.clearIfSpotlightSuppressed()) {
                 return;
             }
@@ -1471,7 +1496,7 @@
         }
 
         clearExtraSpotlights() {
-            this.ensureRoot();
+            if (!this.ensureRoot()) return;
             this.spotlightState.clearExtra();
             this.extraSpotlightEntries.forEach((entry) => {
                 if (!entry) {
@@ -1559,7 +1584,7 @@
                 return;
             }
 
-            this.ensureRoot();
+            if (!this.ensureRoot()) return;
 
             if (this.backdrop) {
                 this.syncBackdropViewport();
@@ -1625,7 +1650,7 @@
         }
 
         setTakingOver(active) {
-            this.ensureRoot();
+            if (!this.ensureRoot()) return;
             this.takingOverActive = active === true;
             if (!this.takingOverActive) {
                 if (this.controlBannerEmphasisTimer) {
@@ -1643,13 +1668,13 @@
         }
 
         setInteractionShieldSuppressed(active) {
-            this.ensureRoot();
+            if (!this.ensureRoot()) return;
             this.interactionShieldSuppressed = active === true;
             this.syncInteractionShield();
         }
 
         setTutorialInputShieldActive(active) {
-            this.ensureRoot();
+            if (!this.ensureRoot()) return;
             this.tutorialInputShieldActive = active === true;
             if (this.document.body) {
                 this.document.body.classList.toggle('yui-guide-input-shield-active', this.tutorialInputShieldActive);
@@ -1678,7 +1703,7 @@
         }
 
         setInteractionShieldEnabled(active) {
-            this.ensureRoot();
+            if (!this.ensureRoot()) return;
             if (!this.interactionShield) {
                 return;
             }
@@ -1696,7 +1721,7 @@
         }
 
         setAngry(active) {
-            this.ensureRoot();
+            if (!this.ensureRoot()) return;
             this.root.classList.toggle('is-angry', !!active);
             if (this.bubble) {
                 this.bubble.classList.toggle('is-angry', !!active);
@@ -1704,7 +1729,7 @@
         }
 
         clearBubblePlacement() {
-            this.ensureRoot();
+            if (!this.ensureRoot()) return;
 
             if (!this.bubble) {
                 return;
@@ -1728,7 +1753,7 @@
         }
 
         positionBubble(anchorRect, options) {
-            this.ensureRoot();
+            if (!this.ensureRoot()) return;
             this.clearBubblePlacement();
 
             const normalizedOptions = options || {};
@@ -1796,7 +1821,7 @@
         }
 
         showBubble(text, options) {
-            this.ensureRoot();
+            if (!this.ensureRoot()) return;
             this.ensureBubbleHeader();
 
             const normalizedOptions = options || {};
@@ -1824,7 +1849,7 @@
         }
 
         hideBubble() {
-            this.ensureRoot();
+            if (!this.ensureRoot()) return;
             this.bubble.hidden = true;
             this.bubble.classList.remove('is-visible');
             this.clearBubblePlacement();
@@ -1833,7 +1858,7 @@
         }
 
         showPluginPreview(items, options) {
-            this.ensureRoot();
+            if (!this.ensureRoot()) return;
 
             const previewItems = Array.isArray(items) && items.length > 0 ? items : [
                 'WebSearch',
@@ -1864,7 +1889,7 @@
         }
 
         hidePluginPreview() {
-            this.ensureRoot();
+            if (!this.ensureRoot()) return;
             this.preview.hidden = true;
             this.preview.classList.remove('is-visible');
             this.previewList.innerHTML = '';
@@ -1879,7 +1904,7 @@
         }
 
         setPersistentSpotlight(element) {
-            this.ensureRoot();
+            if (!this.ensureRoot()) return;
             if (this.clearIfSpotlightSuppressed()) {
                 return;
             }
@@ -1889,7 +1914,7 @@
         }
 
         activateSpotlight(element) {
-            this.ensureRoot();
+            if (!this.ensureRoot()) return;
             if (this.clearIfSpotlightSuppressed()) {
                 return;
             }
@@ -1899,7 +1924,7 @@
         }
 
         activateSecondarySpotlight(element) {
-            this.ensureRoot();
+            if (!this.ensureRoot()) return;
             if (this.clearIfSpotlightSuppressed()) {
                 return;
             }
@@ -1909,14 +1934,14 @@
         }
 
         clearActionSpotlight() {
-            this.ensureRoot();
+            if (!this.ensureRoot()) return;
             this.spotlightState.clearAction();
             this.refreshSpotlight();
             this.syncSpotlightTracking();
         }
 
         clearPersistentSpotlight() {
-            this.ensureRoot();
+            if (!this.ensureRoot()) return;
             this.spotlightState.clearPersistent();
             this.refreshSpotlight();
             this.syncSpotlightTracking();
@@ -1927,7 +1952,7 @@
                 options
                 && options.preservePcOverlaySpotlights === true
             );
-            this.ensureRoot();
+            if (!this.ensureRoot()) return;
             this.stopSpotlightTracking();
             this.spotlightState.clearAll();
             if (this.isPcOverlayActive() && !preservePcOverlaySpotlights) {
@@ -2017,7 +2042,7 @@
         }
 
         showCursorAt(x, y) {
-            this.ensureRoot();
+            if (!this.ensureRoot()) return;
             this.updateSuppressedCursorMotion();
             const previous = this.cursorPosition;
             const glideDurationMs = this.getSmoothCursorShowDurationMs(x, y);
@@ -2353,6 +2378,14 @@
             this.extraSpotlightElements = [];
             this.extraSpotlightEntries = [];
             this.highlightedElements = new Set();
+            const hostWindow = this.document && this.document.defaultView
+                ? this.document.defaultView
+                : window;
+            if (hostWindow) {
+                hostWindow.__NEKO_YUI_GUIDE_OVERLAY_LIFECYCLE_EPOCH__ = (
+                    Number(hostWindow.__NEKO_YUI_GUIDE_OVERLAY_LIFECYCLE_EPOCH__) || 0
+                ) + 1;
+            }
         }
     }
 

--- a/static/tutorial/yui-guide/overlay.js
+++ b/static/tutorial/yui-guide/overlay.js
@@ -960,10 +960,6 @@
 
         ensureRoot() {
             if (!this.isTutorialLifecycleCurrent()) {
-                const staleRoot = this.document.getElementById(ROOT_ID);
-                if (staleRoot && staleRoot.isConnected) {
-                    staleRoot.remove();
-                }
                 this.root = null;
                 this.stage = null;
                 return null;

--- a/static/tutorial/yui-guide/overlay.js
+++ b/static/tutorial/yui-guide/overlay.js
@@ -745,6 +745,7 @@
             this.lifecycleEpoch = Number(
                 hostWindow && hostWindow.__NEKO_YUI_GUIDE_OVERLAY_LIFECYCLE_EPOCH__
             ) || 0;
+            this.destroyed = false;
             this.root = null;
             this.stage = null;
             this.controlBanner = null;
@@ -2319,6 +2320,10 @@
         }
 
         destroy() {
+            if (this.destroyed) {
+                return;
+            }
+            this.destroyed = true;
             this.overlayRenderer.clear();
             this.document.body.classList.remove('yui-taking-over');
             this.document.body.classList.remove('yui-guide-input-shield-active');

--- a/static/yui-guide-common.test.cjs
+++ b/static/yui-guide-common.test.cjs
@@ -2163,7 +2163,8 @@ test('tutorial teardown removes DOM overlay residue and blocks late overlay recr
 
     assert.match(overlaySource, /this\.lifecycleEpoch = Number\([\s\S]*__NEKO_YUI_GUIDE_OVERLAY_LIFECYCLE_EPOCH__/);
     assert.match(overlaySource, /isTutorialLifecycleCurrent\(\) \{[\s\S]*return currentEpoch === this\.lifecycleEpoch;/);
-    assert.match(ensureRootBlock, /if \(!this\.isTutorialLifecycleCurrent\(\)\) \{[\s\S]*staleRoot\.remove\(\);[\s\S]*return null;/);
+    assert.match(ensureRootBlock, /if \(!this\.isTutorialLifecycleCurrent\(\)\) \{[\s\S]*this\.root = null;[\s\S]*return null;/);
+    assert.doesNotMatch(ensureRootBlock, /staleRoot|\.remove\(\)/);
     assert.match(destroyBlock, /__NEKO_YUI_GUIDE_OVERLAY_LIFECYCLE_EPOCH__[\s\S]*\+ 1;/);
     assert.doesNotMatch(overlaySource, /^\s*this\.ensureRoot\(\);/m);
     assert.match(overlaySource, /if \(!this\.ensureRoot\(\)\) return;/);
@@ -2836,6 +2837,7 @@ test('external chat ignores stale guide commands after lifecycle ended', () => {
     assert.match(lifecycleBlock, /yuiGuidePcOverlayLifecycleEpoch === 0/);
     assert.match(lifecycleBlock, /runId && runId !== yuiGuidePcOverlayLifecycleRunId/);
     assert.match(lifecycleBlock, /function closeYuiGuidePcOverlayLifecycle\(\) \{[\s\S]*yuiGuidePcOverlayLifecycleEpoch \+= 1;[\s\S]*yuiGuidePcOverlayLifecycleClosed = true;/);
+    assert.match(lifecycleBlock, /function isYuiGuideMessageForCurrentLifecycle\(message\) \{[\s\S]*runId === yuiGuidePcOverlayLifecycleRunId;/);
     assert.match(appInterpageSource, /case 'yui_guide_set_chat_input_locked':/);
     assert.match(appInterpageSource, /case 'yui_guide_set_chat_spotlight':/);
     assert.match(appInterpageSource, /case 'yui_guide_set_chat_cursor':/);
@@ -2854,6 +2856,7 @@ test('external chat ignores stale guide commands after lifecycle ended', () => {
     assert.match(rememberRunIdBlock, /storedRunId !== normalizedRunId[\s\S]*return storedRunId/);
     assert.match(relayHandlerBlock, /isYuiGuideLifecycleScopedAction\(message\.action\)/);
     assert.match(relayHandlerBlock, /yuiGuidePcOverlayLifecycleClosed[\s\S]*isYuiGuideLifecycleScopedAction\(message\.action\)[\s\S]*return true;/);
+    assert.match(relayHandlerBlock, /if \(!isYuiGuideMessageForCurrentLifecycle\(message\)\) \{\s*return true;/);
     assert.match(relayHandlerBlock, /isYuiGuidePcOverlayRunEnded\(message\.tutorialRunId\)/);
     assert.match(relayHandlerBlock, /clearYuiGuidePcOverlayBridgeState\('stale-after-lifecycle-ended', message\.tutorialRunId \|\| ''\);/);
     assert.match(relayHandlerBlock, /return true;\s*\}\s*if \(message\.tutorialRunId && message\.action !== 'yui_guide_tutorial_lifecycle_ended'\) \{/);
@@ -2865,8 +2868,10 @@ test('external chat ignores stale guide commands after lifecycle ended', () => {
     assert.match(sendPatchBlock, /if \(!runId \|\| isYuiGuidePcOverlayRunEnded\(runId\)\) \{/);
     assert.match(cursorRelayBlock, /if \(yuiGuidePcOverlayLifecycleClosed\) \{/);
     assert.match(cursorRelayBlock, /if \(isYuiGuidePcOverlayRunEnded\(message\.tutorialRunId\)\) \{/);
+    assert.match(cursorRelayBlock, /if \(!isYuiGuideMessageForCurrentLifecycle\(message\)\) \{/);
     assert.match(broadcastStaleGuardBlock, /isYuiGuideLifecycleScopedAction\(message\.action\)/);
     assert.match(broadcastStaleGuardBlock, /yuiGuidePcOverlayLifecycleClosed[\s\S]*isYuiGuideLifecycleScopedAction\(message\.action\)[\s\S]*return;/);
+    assert.match(broadcastStaleGuardBlock, /if \(!isYuiGuideMessageForCurrentLifecycle\(message\)\) \{\s*return;/);
     assert.match(broadcastStaleGuardBlock, /isYuiGuidePcOverlayRunEnded\(message\.tutorialRunId\)/);
     assert.match(broadcastStaleGuardBlock, /clearYuiGuidePcOverlayBridgeState\('stale-after-lifecycle-ended', message\.tutorialRunId \|\| ''\);/);
     assert.match(broadcastStaleGuardBlock, /return;/);

--- a/static/yui-guide-common.test.cjs
+++ b/static/yui-guide-common.test.cjs
@@ -2150,6 +2150,25 @@ test('director routes final teardown through performFullCleanup helper', () => {
     assert.doesNotMatch(destroyBlock, /this\.overlay\.hidePluginPreview\(\);\s*this\.overlay\.hideBubble\(\);\s*this\.overlay\.setAngry\(false\);\s*this\.setTutorialTakingOver\(false\);/);
 });
 
+test('tutorial teardown removes DOM overlay residue and blocks late overlay recreation', () => {
+    const overlaySource = fs.readFileSync(path.join(repoRoot, 'static', 'tutorial/yui-guide/overlay.js'), 'utf8');
+    const ensureRootBlock = overlaySource.split('        ensureRoot() {')[1].split(
+        '        syncControlBanner() {',
+        1
+    )[0];
+    const destroyBlock = overlaySource.split('        destroy() {')[1].split(
+        '    window.YuiGuideOverlay = YuiGuideOverlay;',
+        1
+    )[0];
+
+    assert.match(overlaySource, /this\.lifecycleEpoch = Number\([\s\S]*__NEKO_YUI_GUIDE_OVERLAY_LIFECYCLE_EPOCH__/);
+    assert.match(overlaySource, /isTutorialLifecycleCurrent\(\) \{[\s\S]*return currentEpoch === this\.lifecycleEpoch;/);
+    assert.match(ensureRootBlock, /if \(!this\.isTutorialLifecycleCurrent\(\)\) \{[\s\S]*staleRoot\.remove\(\);[\s\S]*return null;/);
+    assert.match(destroyBlock, /__NEKO_YUI_GUIDE_OVERLAY_LIFECYCLE_EPOCH__[\s\S]*\+ 1;/);
+    assert.doesNotMatch(overlaySource, /^\s*this\.ensureRoot\(\);/m);
+    assert.match(overlaySource, /if \(!this\.ensureRoot\(\)\) return;/);
+});
+
 test('director routes scene and chat stream timers through scoped resources', () => {
     const source = fs.readFileSync(path.join(repoRoot, 'static', 'tutorial/yui-guide/director.js'), 'utf8');
     const constructorBlock = source.split('    class YuiGuideDirector {')[1].split(
@@ -2796,14 +2815,32 @@ test('external chat ignores stale guide commands after lifecycle ended', () => {
         '                switch (event.data.action) {',
         1
     )[0];
+    const lifecycleBlock = appInterpageSource.split('    function isYuiGuideLifecycleStartAction(action) {')[1].split(
+        '    function resetYuiGuidePcOverlayRunForRetry() {',
+        1
+    )[0];
+    const staleResultBlock = appInterpageSource.split('    function handleYuiGuidePcOverlayStaleResult(')[1].split(
+        '    function resolveYuiGuidePcOverlayRunIdForSend(',
+        1
+    )[0];
 
     assert.match(appInterpageSource, /var yuiGuidePcOverlayEndedRunId = '';/);
+    assert.match(appInterpageSource, /var yuiGuidePcOverlayLifecycleEpoch = 0;/);
+    assert.match(appInterpageSource, /var yuiGuidePcOverlayLifecycleClosed = false;/);
+    assert.match(appInterpageSource, /var yuiGuidePcOverlayLifecycleRunId = '';/);
     assert.match(appInterpageSource, /function isYuiGuidePcOverlayRunEnded\(runId\) \{/);
     assert.match(appInterpageSource, /function isYuiGuideLifecycleScopedAction\(action\) \{/);
+    assert.match(lifecycleBlock, /function openYuiGuidePcOverlayLifecycle\(message\) \{/);
+    assert.match(lifecycleBlock, /runId && isYuiGuidePcOverlayRunEnded\(runId\)/);
+    assert.match(lifecycleBlock, /yuiGuidePcOverlayLifecycleClosed && !runId/);
+    assert.match(lifecycleBlock, /yuiGuidePcOverlayLifecycleEpoch === 0/);
+    assert.match(lifecycleBlock, /runId && runId !== yuiGuidePcOverlayLifecycleRunId/);
+    assert.match(lifecycleBlock, /function closeYuiGuidePcOverlayLifecycle\(\) \{[\s\S]*yuiGuidePcOverlayLifecycleEpoch \+= 1;[\s\S]*yuiGuidePcOverlayLifecycleClosed = true;/);
     assert.match(appInterpageSource, /case 'yui_guide_set_chat_input_locked':/);
     assert.match(appInterpageSource, /case 'yui_guide_set_chat_spotlight':/);
     assert.match(appInterpageSource, /case 'yui_guide_set_chat_cursor':/);
     assert.match(clearStateBlock, /yuiGuidePcOverlayEndedRunId = endedRunId;/);
+    assert.match(clearStateBlock, /closeYuiGuidePcOverlayLifecycle\(\);/);
     assert.match(getRunIdBlock, /isYuiGuidePcOverlayRunEnded\(yuiGuidePcOverlayRunIdOverride\)/);
     assert.match(appInterpageSource, /function readStoredYuiGuidePcOverlayRunId\(\) \{/);
     assert.match(appInterpageSource, /function syncYuiGuidePcOverlayRunIdFromStorage\(\) \{/);
@@ -2816,17 +2853,24 @@ test('external chat ignores stale guide commands after lifecycle ended', () => {
     assert.match(rememberRunIdBlock, /var storedRunId = readStoredYuiGuidePcOverlayRunId\(\);/);
     assert.match(rememberRunIdBlock, /storedRunId !== normalizedRunId[\s\S]*return storedRunId/);
     assert.match(relayHandlerBlock, /isYuiGuideLifecycleScopedAction\(message\.action\)/);
+    assert.match(relayHandlerBlock, /yuiGuidePcOverlayLifecycleClosed[\s\S]*isYuiGuideLifecycleScopedAction\(message\.action\)[\s\S]*return true;/);
     assert.match(relayHandlerBlock, /isYuiGuidePcOverlayRunEnded\(message\.tutorialRunId\)/);
     assert.match(relayHandlerBlock, /clearYuiGuidePcOverlayBridgeState\('stale-after-lifecycle-ended', message\.tutorialRunId \|\| ''\);/);
     assert.match(relayHandlerBlock, /return true;\s*\}\s*if \(message\.tutorialRunId && message\.action !== 'yui_guide_tutorial_lifecycle_ended'\) \{/);
+    assert.match(sendPatchBlock, /if \(!host \|\| yuiGuidePcOverlayLifecycleClosed\) \{/);
+    assert.match(sendPatchBlock, /var sendLifecycleEpoch = yuiGuidePcOverlayLifecycleEpoch;/);
+    assert.match(sendPatchBlock, /sendLifecycleEpoch !== yuiGuidePcOverlayLifecycleEpoch/);
     assert.match(sendPatchBlock, /if \(isYuiGuidePcOverlayRunEnded\(sendOptions\.tutorialRunId\)\) \{/);
     assert.match(sendPatchBlock, /resolveYuiGuidePcOverlayRunIdForSend\(/);
     assert.match(sendPatchBlock, /if \(!runId \|\| isYuiGuidePcOverlayRunEnded\(runId\)\) \{/);
+    assert.match(cursorRelayBlock, /if \(yuiGuidePcOverlayLifecycleClosed\) \{/);
     assert.match(cursorRelayBlock, /if \(isYuiGuidePcOverlayRunEnded\(message\.tutorialRunId\)\) \{/);
     assert.match(broadcastStaleGuardBlock, /isYuiGuideLifecycleScopedAction\(message\.action\)/);
+    assert.match(broadcastStaleGuardBlock, /yuiGuidePcOverlayLifecycleClosed[\s\S]*isYuiGuideLifecycleScopedAction\(message\.action\)[\s\S]*return;/);
     assert.match(broadcastStaleGuardBlock, /isYuiGuidePcOverlayRunEnded\(message\.tutorialRunId\)/);
     assert.match(broadcastStaleGuardBlock, /clearYuiGuidePcOverlayBridgeState\('stale-after-lifecycle-ended', message\.tutorialRunId \|\| ''\);/);
     assert.match(broadcastStaleGuardBlock, /return;/);
+    assert.match(staleResultBlock, /attemptedLifecycleEpoch !== yuiGuidePcOverlayLifecycleEpoch/);
 });
 
 test('external chat reuses tutorial PC overlay run id for capsule spotlight and cursor patches', () => {
@@ -2909,7 +2953,7 @@ test('PC overlay bridges rotate stale run ids and replay current state', () => {
 
     assert.match(externalBridgeBlock, /window\.localStorage\.removeItem\('yuiGuidePcOverlayRunId'\)/);
     assert.match(appInterpageSource, /function getExistingYuiGuidePcOverlayRunId\(\) \{/);
-    assert.match(externalBridgeBlock, /function handleYuiGuidePcOverlayStaleResult\(result, patch, attemptedRunId, retried\)/);
+    assert.match(externalBridgeBlock, /function handleYuiGuidePcOverlayStaleResult\(result, patch, attemptedRunId, retried, attemptedLifecycleEpoch\)/);
     assert.match(externalBridgeBlock, /var isStaleResponse = !!\(result && result\.stale === true\);/);
     assert.match(externalBridgeBlock, /var attemptedCurrentRun = !!\(attemptedRunId && attemptedRunId === yuiGuidePcOverlayRunIdOverride\);/);
     assert.match(externalBridgeBlock, /var attemptedChatOwnedRun = isYuiGuideChatOwnedPcOverlayRunId\(attemptedRunId\);/);

--- a/static/yui-guide-common.test.cjs
+++ b/static/yui-guide-common.test.cjs
@@ -2162,10 +2162,12 @@ test('tutorial teardown removes DOM overlay residue and blocks late overlay recr
     )[0];
 
     assert.match(overlaySource, /this\.lifecycleEpoch = Number\([\s\S]*__NEKO_YUI_GUIDE_OVERLAY_LIFECYCLE_EPOCH__/);
+    assert.match(overlaySource, /this\.destroyed = false;/);
     assert.match(overlaySource, /isTutorialLifecycleCurrent\(\) \{[\s\S]*return currentEpoch === this\.lifecycleEpoch;/);
     assert.match(ensureRootBlock, /if \(!this\.isTutorialLifecycleCurrent\(\)\) \{[\s\S]*this\.root = null;[\s\S]*return null;/);
     assert.doesNotMatch(ensureRootBlock, /staleRoot|\.remove\(\)/);
     assert.match(destroyBlock, /__NEKO_YUI_GUIDE_OVERLAY_LIFECYCLE_EPOCH__[\s\S]*\+ 1;/);
+    assert.match(destroyBlock, /if \(this\.destroyed\) \{\s*return;\s*\}[\s\S]*this\.destroyed = true;/);
     assert.doesNotMatch(overlaySource, /^\s*this\.ensureRoot\(\);/m);
     assert.match(overlaySource, /if \(!this\.ensureRoot\(\)\) return;/);
 });
@@ -2838,6 +2840,7 @@ test('external chat ignores stale guide commands after lifecycle ended', () => {
     assert.match(lifecycleBlock, /runId && runId !== yuiGuidePcOverlayLifecycleRunId/);
     assert.match(lifecycleBlock, /function closeYuiGuidePcOverlayLifecycle\(\) \{[\s\S]*yuiGuidePcOverlayLifecycleEpoch \+= 1;[\s\S]*yuiGuidePcOverlayLifecycleClosed = true;/);
     assert.match(lifecycleBlock, /function isYuiGuideMessageForCurrentLifecycle\(message\) \{[\s\S]*runId === yuiGuidePcOverlayLifecycleRunId;/);
+    assert.match(lifecycleBlock, /message\.action !== 'yui_guide_tutorial_lifecycle_ended'/);
     assert.match(appInterpageSource, /case 'yui_guide_set_chat_input_locked':/);
     assert.match(appInterpageSource, /case 'yui_guide_set_chat_spotlight':/);
     assert.match(appInterpageSource, /case 'yui_guide_set_chat_cursor':/);

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -6822,6 +6822,19 @@ def test_tutorial_skip_and_angry_exit_do_not_start_new_user_icebreaker(mock_page
                     reason: 'skip',
                 },
             }));
+            window.dispatchEvent(new CustomEvent('neko:tutorial-completed', {
+                detail: {
+                    page: 'home',
+                    day: 1,
+                    endState: {
+                        day: 1,
+                        ended: true,
+                        outcome: 'skip',
+                        rawReason: 'angry_exit',
+                        isAngryExit: true,
+                    },
+                },
+            }));
             await new Promise((resolve) => setTimeout(resolve, 700));
             return {
                 fetchCount: window.__icebreakerFetchCount,
@@ -6857,13 +6870,19 @@ def test_yui_overlay_lifecycle_epoch_blocks_late_dom_recreation(mock_page: Page)
             nextOverlay.showBubble('next tutorial');
             const recreatedByNextInstance = !!document.getElementById('yui-guide-overlay');
             const nextRoot = document.getElementById('yui-guide-overlay');
+            const nextEpoch = window.__NEKO_YUI_GUIDE_OVERLAY_LIFECYCLE_EPOCH__;
+            staleOverlay.destroy();
             staleOverlay.showBubble('older callback after next tutorial');
             const nextRootPreserved = document.getElementById('yui-guide-overlay') === nextRoot;
+            const nextContentPreserved = document.querySelector('.yui-guide-bubble-body')?.textContent === 'next tutorial';
+            const nextEpochPreserved = window.__NEKO_YUI_GUIDE_OVERLAY_LIFECYCLE_EPOCH__ === nextEpoch;
             return {
                 initiallyCreated,
                 recreatedByStaleInstance,
                 recreatedByNextInstance,
                 nextRootPreserved,
+                nextContentPreserved,
+                nextEpochPreserved,
             };
         }
         """
@@ -6874,6 +6893,8 @@ def test_yui_overlay_lifecycle_epoch_blocks_late_dom_recreation(mock_page: Page)
         "recreatedByStaleInstance": False,
         "recreatedByNextInstance": True,
         "nextRootPreserved": True,
+        "nextContentPreserved": True,
+        "nextEpochPreserved": True,
     }
 
 

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -6856,7 +6856,15 @@ def test_yui_overlay_lifecycle_epoch_blocks_late_dom_recreation(mock_page: Page)
             const nextOverlay = new window.YuiGuideOverlay(document);
             nextOverlay.showBubble('next tutorial');
             const recreatedByNextInstance = !!document.getElementById('yui-guide-overlay');
-            return { initiallyCreated, recreatedByStaleInstance, recreatedByNextInstance };
+            const nextRoot = document.getElementById('yui-guide-overlay');
+            staleOverlay.showBubble('older callback after next tutorial');
+            const nextRootPreserved = document.getElementById('yui-guide-overlay') === nextRoot;
+            return {
+                initiallyCreated,
+                recreatedByStaleInstance,
+                recreatedByNextInstance,
+                nextRootPreserved,
+            };
         }
         """
     )
@@ -6865,6 +6873,7 @@ def test_yui_overlay_lifecycle_epoch_blocks_late_dom_recreation(mock_page: Page)
         "initiallyCreated": True,
         "recreatedByStaleInstance": False,
         "recreatedByNextInstance": True,
+        "nextRootPreserved": True,
     }
 
 

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -6789,6 +6789,86 @@ def test_pc_overlay_suppresses_dom_cursor_on_first_show(mock_page: Page):
 
 
 @pytest.mark.frontend
+def test_tutorial_skip_and_angry_exit_do_not_start_new_user_icebreaker(mock_page: Page):
+    _bootstrap_page(
+        mock_page,
+        setup_js="window.__icebreakerFetchCount = 0;",
+        fetch_js="""
+            window.__icebreakerFetchCount += 1;
+            return jsonResponse({}, 200);
+        """,
+        script_names=("tutorial/icebreaker/new-user-icebreaker.js",),
+    )
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            window.dispatchEvent(new CustomEvent('neko:avatar-floating-guide-skip', {
+                detail: {
+                    day: 1,
+                    endState: {
+                        day: 1,
+                        ended: true,
+                        outcome: 'skip',
+                        rawReason: 'angry_exit',
+                        isAngryExit: true,
+                    },
+                },
+            }));
+            window.dispatchEvent(new CustomEvent('neko:tutorial-skipped', {
+                detail: {
+                    page: 'home',
+                    day: 1,
+                    reason: 'skip',
+                },
+            }));
+            await new Promise((resolve) => setTimeout(resolve, 700));
+            return {
+                fetchCount: window.__icebreakerFetchCount,
+                activeSession: window.newUserIcebreaker.getActiveSession(),
+            };
+        }
+        """
+    )
+
+    assert result == {"fetchCount": 0, "activeSession": None}
+
+
+@pytest.mark.frontend
+def test_yui_overlay_lifecycle_epoch_blocks_late_dom_recreation(mock_page: Page):
+    _bootstrap_page(
+        mock_page,
+        setup_js="window.isInTutorial = true;",
+        script_names=("tutorial/yui-guide/overlay.js",),
+    )
+
+    result = mock_page.evaluate(
+        """
+        () => {
+            const staleOverlay = new window.YuiGuideOverlay(document);
+            staleOverlay.showBubble('active tutorial');
+            const initiallyCreated = !!document.getElementById('yui-guide-overlay');
+
+            staleOverlay.destroy();
+            staleOverlay.showBubble('late callback');
+            const recreatedByStaleInstance = !!document.getElementById('yui-guide-overlay');
+
+            const nextOverlay = new window.YuiGuideOverlay(document);
+            nextOverlay.showBubble('next tutorial');
+            const recreatedByNextInstance = !!document.getElementById('yui-guide-overlay');
+            return { initiallyCreated, recreatedByStaleInstance, recreatedByNextInstance };
+        }
+        """
+    )
+
+    assert result == {
+        "initiallyCreated": True,
+        "recreatedByStaleInstance": False,
+        "recreatedByNextInstance": True,
+    }
+
+
+@pytest.mark.frontend
 def test_pc_overlay_move_with_existing_position_never_reveals_dom_cursor(
     mock_page: Page,
 ):

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -384,7 +384,7 @@ def test_icebreaker_runtime_wires_choice_prompt_and_project_tts():
     assert "expressionFile" not in runtime
     assert "resolveLatestEndState(detail, eventType)" in runtime
     assert "synthesizeEndStateFromEvent(eventType, normalizedDetail)" in runtime
-    assert "eventType === 'neko:tutorial-skipped'" in runtime
+    assert "eventType === 'neko:tutorial-skipped'" not in runtime
     assert "eventType === 'neko:tutorial-completed'" in runtime
     assert "normalizedDetail.day" in runtime
     assert "day = 1" not in runtime
@@ -925,6 +925,7 @@ def test_icebreaker_tutorial_end_events_start_from_explicit_event_state():
     body = match.group("body")
     assert "startFromEndState(resolveLatestEndState(detail, eventType))" not in body
     assert "var endState = resolveLatestEndState(detail, eventType);" in body
+    assert "String(endState.outcome || endState.rawReason || '') !== 'complete'" in body
     assert "var pendingDay = markPendingStartFromEndState(endState);" in body
     assert "attemptStartFromGuideEndState(endState, pendingDay)" in body
 
@@ -1030,13 +1031,14 @@ def test_home_tutorial_release_events_carry_current_avatar_round_end_state():
     assert "state.lastEndState" in reset_runtime
     assert "state.lastEndState" in runtime
 
-    generic_tutorial_branch = re.search(
-        r"eventType === 'neko:tutorial-skipped'.*?outcome = 'skip';",
-        runtime,
-        re.DOTALL,
-    )
-    assert generic_tutorial_branch is not None
-    assert "day = 1" not in generic_tutorial_branch.group(0)
+    assert "window.addEventListener('neko:avatar-floating-guide-skip', handleGuideEndEvent)" not in runtime
+    assert "window.addEventListener('neko:tutorial-skipped', handleGuideEndEvent)" not in runtime
+    can_start_block = runtime.split("function canStartFromEndState(endState, scripts)", 1)[1].split(
+        "function readPersistedAvatarGuideState",
+        1,
+    )[0]
+    assert "if (outcome !== 'complete') return false;" in can_start_block
+    assert "outcome !== 'skip'" not in can_start_block
 
 
 def test_avatar_floating_angry_exit_skip_event_preserves_raw_end_state():


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复教程跳过或对抗退出后的遮罩残留与快捷键禁用问题

## 测试 / Testing

手动跳过教程/触发对抗机制测试
并确保没有影响现有机制


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - 修复教程/PC 叠加层在销毁或切换后，旧指令、延迟结果或跨 Tab 转发内容仍更新界面/光标/补丁状态的问题，新增 epoch/关闭态/RunId 门控与陈旧过滤。
  - 加强新用户破冰：仅允许 `complete` 结束态继续后续启动，避免跳过或异常退出误触发新引导。

- **测试**
  - 新增/强化浏览器端与静态契约测试，覆盖叠加层销毁后阻止迟到 DOM 重建、以及非 `complete` 结束态不启动。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->