### PR TITLE
修复猫娘说话时重复解析回调导致头像道具图片闪烁的问题

### DIFF
--- a/frontend/react-neko-chat/src/message-schema.test.ts
+++ b/frontend/react-neko-chat/src/message-schema.test.ts
@@ -131,6 +131,16 @@ describe('message-schema', () => {
     expect(onAvatarInteraction).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps validated host callback identities stable across repeated prop parsing', () => {
+    const onAvatarToolStateChange = vi.fn();
+    const firstProps = parseChatWindowProps({ onAvatarToolStateChange });
+    const secondProps = parseChatWindowProps({ onAvatarToolStateChange });
+
+    expect(firstProps.onAvatarToolStateChange).toBe(secondProps.onAvatarToolStateChange);
+    expect(firstProps.onAvatarToolStateChange).not.toBe(onAvatarToolStateChange);
+    expect(() => secondProps.onAvatarToolStateChange?.({ active: 'yes' } as never)).toThrow(ZodError);
+  });
+
   it('rejects avatar interaction payloads with a non-avatar target', () => {
     const onAvatarInteraction = vi.fn();
     const props = parseChatWindowProps({ onAvatarInteraction });

--- a/frontend/react-neko-chat/src/message-schema.ts
+++ b/frontend/react-neko-chat/src/message-schema.ts
@@ -390,6 +390,41 @@ export function parseChatMessage(input: unknown): ChatMessage {
   return chatMessageSchema.parse(input);
 }
 
+const parsedCallbackCaches = new Map<string, WeakMap<object, unknown>>();
+
+function stabilizeParsedCallbackIdentities(
+  input: Record<string, unknown> | undefined,
+  parsed: ChatWindowSchemaProps,
+): ChatWindowSchemaProps {
+  if (!input) return parsed;
+
+  const parsedRecord = parsed as Record<string, unknown>;
+  Object.entries(input).forEach(([key, rawValue]) => {
+    const parsedValue = parsedRecord[key];
+    if (typeof rawValue !== 'function' || typeof parsedValue !== 'function') return;
+
+    let callbackCache = parsedCallbackCaches.get(key);
+    if (!callbackCache) {
+      callbackCache = new WeakMap<object, unknown>();
+      parsedCallbackCaches.set(key, callbackCache);
+    }
+
+    const cachedCallback = callbackCache.get(rawValue);
+    if (typeof cachedCallback === 'function') {
+      parsedRecord[key] = cachedCallback;
+      return;
+    }
+
+    // z.function() returns a new validating wrapper on every parse. Reuse that
+    // wrapper for the same host callback so ordinary message renders do not
+    // look like callback changes to React effects.
+    callbackCache.set(rawValue, parsedValue);
+  });
+
+  return parsed;
+}
+
 export function parseChatWindowProps<T extends Record<string, unknown> | undefined>(input: T) {
-  return chatWindowPropsSchema.parse(input ?? {}) as ChatWindowSchemaProps;
+  const parsed = chatWindowPropsSchema.parse(input ?? {}) as ChatWindowSchemaProps;
+  return stabilizeParsedCallbackIdentities(input, parsed);
 }


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复猫娘说话时重复解析回调导致头像道具图片闪烁的问题
同时解决部分同类问题,如教程期间猫爪与高亮框闪烁

## 测试 / Testing

手动使用头像道具道具功能测试


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化回调处理，确保重复解析相同回调时保持引用稳定。
  * 减少因回调引用变化导致的 React 副作用重复触发。
  * 保留对无效回调参数的校验，并正确抛出验证错误。

* **Tests**
  * 新增测试，验证回调引用稳定性及无效参数校验行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->