### PR TITLE
修复模型锁定状态下自动离开后，“请她回来”出现假锁定的问题；回来时统一清理各模型的锁定状态，并补充回归测试

### DIFF
--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -4879,20 +4879,12 @@
                 window.pngtuberManager.resetAllButtons();
             }
 
-            // 保存当前锁定状态，以便"请她回来"时恢复
-            // core.setLocked() 将值写入 manager.isLocked，因此从 manager 级别读取
+            // 判断当前 PNGTuber 是否激活，告别态只锁定正在使用的 2D 图片模型。
             const pngtuberContainerForState = document.getElementById('pngtuber-container');
             const isPngtuberActiveForState = (window.lanlan_config?.model_type || '').toLowerCase() === 'pngtuber'
                 && pngtuberContainerForState
                 && pngtuberContainerForState.style.display !== 'none'
                 && !pngtuberContainerForState.classList.contains('hidden');
-
-            window._savedLockState = {
-                live2d: window.live2dManager ? window.live2dManager.isLocked : false,
-                vrm: window.vrmManager ? window.vrmManager.isLocked : false,
-                mmd: window.mmdManager ? window.mmdManager.isLocked : false,
-                pngtuber: isPngtuberActiveForState && window.pngtuberManager ? window.pngtuberManager.isLocked : false
-            };
 
             // 设置锁定状态
             if (window.live2dManager && typeof window.live2dManager.setLocked === 'function') {
@@ -5513,8 +5505,7 @@
                     mmdLockIcon.style.opacity = '0';
                 }
             }
-            // 恢复"请她离开"之前的锁定状态（而非强制解锁）
-            const savedLock = window._savedLockState || { live2d: false, vrm: false, mmd: false };
+            // 回来后统一清理锁定状态，不回放离开前的锁定快照，避免 UI、拖拽和穿透状态分叉。
             const pngtuberLockIcon = document.getElementById('pngtuber-lock-icon');
             if (pngtuberLockIcon) {
                 pngtuberLockIcon.style.removeProperty('display');
@@ -5522,18 +5513,17 @@
                 pngtuberLockIcon.style.removeProperty('opacity');
             }
             if (window.live2dManager && typeof window.live2dManager.setLocked === 'function') {
-                window.live2dManager.setLocked(savedLock.live2d, { updateFloatingButtons: false });
+                window.live2dManager.setLocked(false, { updateFloatingButtons: false });
             }
             if (window.vrmManager && window.vrmManager.core && typeof window.vrmManager.core.setLocked === 'function') {
-                window.vrmManager.core.setLocked(savedLock.vrm);
+                window.vrmManager.core.setLocked(false);
             }
             if (window.mmdManager && window.mmdManager.core && typeof window.mmdManager.core.setLocked === 'function') {
-                window.mmdManager.core.setLocked(savedLock.mmd);
+                window.mmdManager.core.setLocked(false);
             }
-            if (isReturningToPngtuber && window.pngtuberManager && typeof window.pngtuberManager.setLocked === 'function') {
-                window.pngtuberManager.setLocked(savedLock.pngtuber, { updateFloatingButtons: false });
+            if (window.pngtuberManager && typeof window.pngtuberManager.setLocked === 'function') {
+                window.pngtuberManager.setLocked(false, { updateFloatingButtons: false });
             }
-            window._savedLockState = null;
 
             // 恢复浮动按钮系统
             const live2dFloatingButtons = document.getElementById('live2d-floating-buttons');

--- a/tests/unit/test_auto_goodbye_goodbye_return_contract.py
+++ b/tests/unit/test_auto_goodbye_goodbye_return_contract.py
@@ -74,3 +74,18 @@ def test_return_ball_keeps_handle_return_click_semantics():
     assert "action: 'start_session'" in return_session_block
     assert "action: 'goodbye_state'" in return_session_block
     assert "active: false" in return_session_block
+
+
+def test_return_clears_all_model_lock_state_instead_of_replaying_a_snapshot():
+    ui_source = _read(APP_UI_PATH)
+    handle_return_block = _between(
+        ui_source,
+        "const handleReturnClick = async (event) => {",
+        "window.addEventListener('live2d-return-click', handleReturnClick);",
+    )
+
+    assert "_savedLockState" not in ui_source
+    assert "window.live2dManager.setLocked(false, { updateFloatingButtons: false });" in handle_return_block
+    assert "window.vrmManager.core.setLocked(false);" in handle_return_block
+    assert "window.mmdManager.core.setLocked(false);" in handle_return_block
+    assert "window.pngtuberManager.setLocked(false, { updateFloatingButtons: false });" in handle_return_block


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复模型锁定状态下自动离开后，“请她回来”出现假锁定的问题

## 测试 / Testing

手动测试请她回来


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化“请她离开/请她回来”流程中的模型锁定处理。
  * 返回时统一解除 Live2D、VRM、MMD 和 PNGTuber 的锁定状态，不再恢复此前保存的锁定状态。
  * 统一清理 PNGTuber 的锁定显示，减少模型状态异常。

* **Tests**
  * 新增测试，验证返回流程会正确解除所有模型锁定。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->