### PR TITLE
新增截图会话状态通知，确保截图开始和结束时正确协调头像道具功能

### DIFF
--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -3321,6 +3321,14 @@
          */
         var _captureScreenshotDataUrlBusy = false;
 
+        function setScreenshotCaptureSessionActive(active) {
+            try {
+                window.dispatchEvent(new CustomEvent('neko:screenshot-capture-session', {
+                    detail: { active: active === true }
+                }));
+            } catch (e) { }
+        }
+
         mod.captureScreenshotDataUrl = async function captureScreenshotDataUrl() {
             if (_captureScreenshotDataUrlBusy) {
                 console.warn('[截图] 截图流程进行中，忽略重复请求');
@@ -3330,6 +3338,12 @@
             var acquiredStream = null;
             var isCachedStream = false;
             var captureType = null;
+            var screenshotCaptureSessionActive = false;
+
+            if (!U.isMobile()) {
+                screenshotCaptureSessionActive = true;
+                setScreenshotCaptureSessionActive(true);
+            }
 
             try {
                 var dataUrl = null;
@@ -3509,6 +3523,9 @@
                     }
                 }
             } finally {
+                if (screenshotCaptureSessionActive) {
+                    setScreenshotCaptureSessionActive(false);
+                }
                 _captureScreenshotDataUrlBusy = false;
                 if (!isCachedStream && acquiredStream instanceof MediaStream) {
                     try {

--- a/static/screenshot-avatar-tool-session.test.cjs
+++ b/static/screenshot-avatar-tool-session.test.cjs
@@ -1,0 +1,18 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const source = fs.readFileSync(path.join(__dirname, 'app-buttons.js'), 'utf8');
+
+test('desktop screenshot lifecycle brackets capture and crop with an avatar-tool suspension session', () => {
+    const start = source.indexOf('mod.captureScreenshotDataUrl = async function captureScreenshotDataUrl()');
+    const end = source.indexOf('window.captureScreenshotDataUrl = mod.captureScreenshotDataUrl', start);
+    assert.notEqual(start, -1);
+    assert.notEqual(end, -1);
+    const section = source.slice(start, end);
+
+    assert.match(source, /new CustomEvent\('neko:screenshot-capture-session'/);
+    assert.match(section, /if \(!U\.isMobile\(\)\) \{[\s\S]*?setScreenshotCaptureSessionActive\(true\);/);
+    assert.match(section, /finally \{[\s\S]*?setScreenshotCaptureSessionActive\(false\);[\s\S]*?_captureScreenshotDataUrlBusy = false;/);
+});


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

新增截图会话状态通知，确保截图开始和结束时正确协调头像道具功能

## 测试 / Testing

手动测试截图

## 另一边
[优化截图期间头像道具与系统光标的暂停恢复逻辑，减少卡顿和闪烁](https://github.com/Project-N-E-K-O/N.E.K.O.-PC/pull/312)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 桌面端截图过程中新增截图会话状态通知，便于相关界面在截图期间进行适配。
  * 截图完成或失败后会自动结束会话状态，不影响后续截图操作。

* **测试**
  * 增加桌面端截图会话生命周期的自动化验证，确保状态能够正确启用、关闭并恢复截图流程。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->