### PR TITLE
修复 LLM gateway 信号量超时测试在 CI 上的 flaky

### DIFF
--- a/plugin/tests/unit/plugins/test_galgame_llm_gateway_cache.py
+++ b/plugin/tests/unit/plugins/test_galgame_llm_gateway_cache.py
@@ -337,7 +337,7 @@ async def test_llm_gateway_semaphore_wait_is_bounded_by_call_timeout() -> None:
     gateway = LLMGateway(
         None,
         None,
-        _config(llm_max_in_flight=1, llm_call_timeout_seconds=0.2),
+        _config(llm_max_in_flight=1, llm_call_timeout_seconds=2.0),
         backend=backend,
     )
     first = asyncio.create_task(gateway.agent_reply({"prompt": "first"}))
@@ -361,7 +361,7 @@ async def test_llm_gateway_semaphore_wait_timeout_does_not_poison_provider() -> 
     gateway = LLMGateway(
         None,
         None,
-        _config(llm_max_in_flight=1, llm_call_timeout_seconds=0.2),
+        _config(llm_max_in_flight=1, llm_call_timeout_seconds=2.0),
         backend=backend,
     )
     first = asyncio.create_task(gateway.agent_reply({"prompt": "first"}))
@@ -371,7 +371,12 @@ async def test_llm_gateway_semaphore_wait_timeout_does_not_poison_provider() -> 
     try:
         second = await gateway.agent_reply({"prompt": "second"})
         backend.release.set()
-        first_result = await asyncio.wait_for(first, timeout=1.0)
+        first_result = await asyncio.wait_for(first, timeout=2.0)
+        # The 0.01s timeout above only exists to force the semaphore wait of
+        # "second" to expire while "first" holds the slot. Restore a wall-clock
+        # budget that a busy CI runner can meet before issuing "third"; the
+        # provider backoff state under test survives update_config.
+        gateway.update_config(_config(llm_max_in_flight=1, llm_call_timeout_seconds=2.0))
         third = await gateway.agent_reply({"prompt": "third"})
     finally:
         backend.release.set()


### PR DESCRIPTION
## 问题

`plugin/tests/unit/plugins/test_galgame_llm_gateway_cache.py::test_llm_gateway_semaphore_wait_timeout_does_not_poison_provider` 在 main 分支 CI（Plugin pytest, Windows）上间歇性失败，最近三次 main push 失败中占两次：

- [run 28963565962](https://github.com/Project-N-E-K-O/N.E.K.O/actions/runs/28963565962)（7/8）
- [run 29115482543](https://github.com/Project-N-E-K-O/N.E.K.O/actions/runs/29115482543)（7/10）

均挂在 `assert third["degraded"] is False`（实际为 True）。

## 根因

测试中途把 `llm_call_timeout_seconds` 压到 **0.01s**，目的是让第二个调用在 "first" 占着唯一信号量槽位时快速触发信号量等待超时。但第三个调用（验证 provider 未被超时毒化）发出时该配置仍然生效——整条链路（获取槽位 + backend 调用）只有 10ms 墙钟预算，在繁忙的共享 Windows runner 上仅事件循环调度就可能超时，于是 "third" 也被判降级，断言炸掉。本地快机器上几乎复现不了，属于典型的对 CI 机器速度假设过紧。

## 修复

- 第三个调用前用 `update_config` 把超时恢复到 2.0s。`update_config` 不会清 `_provider_backoff`（只有事件循环变更才清），所以测试意图不受影响：若第二次超时真的毒化了 provider，backoff 状态依然存在，断言照样能抓住。
- 两个信号量测试的初始 0.2s 预算同步放宽到 2.0s，消除 "first" 在极慢 runner 上的同类超时风险。该值只需保证 "first" 不超时，与被测行为无关。

## 验证

- 本地 `pytest plugin/tests/unit/plugins/test_galgame_llm_gateway_cache.py`：10 passed。
- 两个信号量测试重复运行 30 次：30/30 通过。
- 第二个调用的信号量超时断言不受影响：其超时由 "first" 持锁保证，机器越慢越必然超时，方向安全。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 提高 LLM 网关信号量等待相关测试的超时时间，增强在繁忙 CI 环境下的稳定性。
  * 优化测试注释，明确等待时间与重试状态的一致性要求。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->