### PR TITLE
修复telemetry surface标签失真并退役compact历史A/B实验

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -22,14 +22,12 @@ import compactChatStyles from './styles.css?raw';
 
 describe('App', () => {
   const COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY = 'neko.reactChatWindow.compactExportHistoryOpen';
-  const COMPACT_HISTORY_DEFAULT_EXPERIMENT_KEY = 'neko.experiment.compactHistoryDefault';
   const COMPACT_HISTORY_HEIGHT_STORAGE_KEY = 'neko.reactChatWindow.compactHistorySlotHeight';
   const COMPACT_INPUT_TOOL_WHEEL_INDEX_STORAGE_KEY = 'neko.reactChatWindow.compactInputToolWheelIndex';
   const DEFAULT_CHAT_EMPTY_STATE_FALLBACK = getChatEmptyStateFallback('en');
   const DEFAULT_CHAT_COMPANION_EMPTY_STATE_FALLBACK = getChatCompanionEmptyStateFallback('en');
   const LOCAL_STORAGE_KEYS_TO_RESET = [
     COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY,
-    COMPACT_HISTORY_DEFAULT_EXPERIMENT_KEY,
     COMPACT_HISTORY_HEIGHT_STORAGE_KEY,
     COMPACT_INPUT_TOOL_WHEEL_INDEX_STORAGE_KEY,
     ACTIVE_AVATAR_TOOLS_STORAGE_KEY,
@@ -39,8 +37,8 @@ describe('App', () => {
     LOCAL_STORAGE_KEYS_TO_RESET.forEach(key => {
       window.localStorage.removeItem(key);
     });
-    // 历史 UI 用例需要历史区默认展开：A/B 变体默认值现改为「教程完全结束后」才异步套用，测试里直接给一个
-    // 显式持久化「开」偏好，让历史区同步展开、与实验门控解耦（实验/门控行为另有专门用例覆盖）。
+    // 历史 UI 用例需要历史区默认展开：无偏好一律折叠（「历史首启默认」A/B 已退役），测试里直接给一个
+    // 显式持久化「开」偏好，让历史区同步展开（默认折叠行为另有专门用例覆盖）。
     window.localStorage.setItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY, 'true');
     delete window.__NEKO_REACT_CHAT_ASSET_VERSION__;
     delete (window as Window & { NekoGameSystem?: unknown }).NekoGameSystem;
@@ -658,70 +656,32 @@ describe('App', () => {
     }
   });
 
-  it('keeps compact history collapsed by default and only applies the open variant after the tutorial ends', () => {
+  it('keeps compact history collapsed by default, including after the tutorial ends (retired A/B stays retired)', () => {
     window.localStorage.removeItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY);
-    window.localStorage.setItem(COMPACT_HISTORY_DEFAULT_EXPERIMENT_KEY, 'open');
-    const message = parseChatMessage({
-      id: 'assistant-gate-1', role: 'assistant', author: 'Neko', time: '10:00', createdAt: 1,
-      blocks: [{ type: 'text', text: 'hi' }], status: 'sent',
-    });
-    const { container } = render(
-      <App chatSurfaceMode="compact" compactChatState="input" messages={[message]} />,
-    );
-    // 无显式偏好 → 初始折叠（即便 variant=open，也要等教程结束才展开）
-    expect(container.querySelector('.compact-export-history-anchor')).toBeNull();
-    // 教程完成 → 套用 open 变体 → 展开
-    act(() => {
-      window.dispatchEvent(new Event('neko:tutorial-completed'));
-    });
-    expect(container.querySelector('.compact-export-history-anchor')).not.toBeNull();
-  });
-
-  it('does not allocate the history experiment variant when starting on a full surface (keeps compact A/B clean)', () => {
-    window.localStorage.removeItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY);
-    window.localStorage.removeItem(COMPACT_HISTORY_DEFAULT_EXPERIMENT_KEY);
-    const message = parseChatMessage({
-      id: 'assistant-full-gate', role: 'assistant', author: 'Neko', time: '10:00', createdAt: 1,
-      blocks: [{ type: 'text', text: 'hi' }], status: 'sent',
-    });
-    render(<App chatSurfaceMode="full" messages={[message]} />);
-    act(() => {
-      window.dispatchEvent(new Event('neko:tutorial-completed'));
-    });
-    // full → FullChatSurface（CompactChatApp 不 mount），实验 effect 不跑：不分配 variant、不上报曝光，
-    // full-surface 用户没见过紧凑历史面板，不该进入 compact A/B 样本。
-    expect(window.localStorage.getItem(COMPACT_HISTORY_DEFAULT_EXPERIMENT_KEY)).toBeNull();
-  });
-
-  it('still reports the exposure when sessionStorage access throws (privacy mode)', () => {
-    window.localStorage.removeItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY);
-    window.localStorage.setItem(COMPACT_HISTORY_DEFAULT_EXPERIMENT_KEY, 'closed');
+    // 存量用户 localStorage 里可能残留已退役实验的 'open' 分组值——它不能再触发自动展开。
+    window.localStorage.setItem('neko.experiment.compactHistoryDefault', 'open');
     const telemetry = vi.fn(() => true);
     (window as unknown as { appTelemetry?: { counter: (n: string, v?: number, d?: Record<string, unknown>) => boolean } }).appTelemetry = { counter: telemetry };
-    // 只让 sessionStorage.getItem 抛（隐私浏览器/webview），localStorage 仍可读 cohort——
-    // 二者共享 Storage.prototype，按 this 区分。
-    const realGetItem = Storage.prototype.getItem;
-    const getItemSpy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(function (this: Storage, key: string) {
-      if (this === window.sessionStorage) throw new DOMException('denied', 'SecurityError');
-      return realGetItem.call(this, key);
-    });
     try {
       const message = parseChatMessage({
-        id: 'assistant-privacy-exposure', role: 'assistant', author: 'Neko', time: '10:00', createdAt: 1,
+        id: 'assistant-gate-1', role: 'assistant', author: 'Neko', time: '10:00', createdAt: 1,
         blocks: [{ type: 'text', text: 'hi' }], status: 'sent',
       });
-      render(<App chatSurfaceMode="compact" compactChatState="input" messages={[message]} />);
+      const { container } = render(
+        <App chatSurfaceMode="compact" compactChatState="input" messages={[message]} />,
+      );
+      // 无显式偏好 → 折叠
+      expect(container.querySelector('.compact-export-history-anchor')).toBeNull();
+      // 教程完成也不再套用任何变体：保持折叠、不上报曝光、不动残留分组值
       act(() => {
         window.dispatchEvent(new Event('neko:tutorial-completed'));
       });
-      // sessionStorage 去重读失败不能吞掉曝光：有 variant 的用户仍要发出 experiment_exposure。
-      expect(telemetry).toHaveBeenCalledWith('experiment_exposure', 1, expect.objectContaining({
-        experiment: 'compact_history_default',
-        variant: 'closed',
-      }));
+      expect(container.querySelector('.compact-export-history-anchor')).toBeNull();
+      expect(telemetry).not.toHaveBeenCalled();
+      expect(window.localStorage.getItem('neko.experiment.compactHistoryDefault')).toBe('open');
     } finally {
-      getItemSpy.mockRestore();
       delete (window as unknown as { appTelemetry?: unknown }).appTelemetry;
+      window.localStorage.removeItem('neko.experiment.compactHistoryDefault');
     }
   });
 

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -136,9 +136,9 @@ const COMPACT_SPEECH_FALLBACK_REVEAL_DELAY_MS = 700;
 const SPEECH_PLAYBACK_STATE_STORAGE_KEY = 'neko_speech_playback_state';
 const SPEECH_PLAYBACK_CHANNEL_NAME = 'neko_speech_playback_channel';
 const COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY = 'neko.reactChatWindow.compactExportHistoryOpen';
-const COMPACT_HISTORY_DEFAULT_EXPERIMENT_KEY = 'neko.experiment.compactHistoryDefault';
-// A/B 变体「套用」的兜底延迟：本次不跑教程的老用户在此延迟后若仍非教程态，就直接套用变体默认值。
-const COMPACT_HISTORY_EXPERIMENT_APPLY_FALLBACK_MS = 3000;
+// ⚠️ 'neko.experiment.compactHistoryDefault' 是已退役的「历史首启默认」A/B 分组 key（退役记录见
+// utils/token_tracker.py 的已退役实验清单）：存量用户 localStorage 里仍残留 'open'/'closed' 值，
+// 只停读写、不清理（保留取证窗口），勿把该 key 名挪作他用。
 const COMPACT_HISTORY_HEIGHT_STORAGE_KEY = 'neko.reactChatWindow.compactHistorySlotHeight';
 export const COMPACT_EXPORT_HISTORY_VISIBILITY_ANIMATION_MS = 560;
 const COMPACT_INPUT_TOOL_WHEEL_TOOL_ORDER = [
@@ -559,29 +559,10 @@ function readPersistedCompactExportHistoryOpen(): boolean {
   try {
     const persisted = window.localStorage?.getItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY);
     if (persisted !== null) return persisted === 'true';
-    // 无显式偏好：初始一律折叠。A/B 变体默认值（含 open 展开）改由「教程完全结束后 / 本次不跑教程的老
-    // 用户」的 effect 套用（见 applyCompactHistoryExperimentDefault）——避免教程进行中、或教程演示历史区
-    // 之前就先展开，与教学冲突。
+    // 无显式偏好：一律折叠（原「历史首启默认」A/B 已退役，closed 即最终默认；用户手动展开写入偏好后照旧恢复）。
     return false;
   } catch {
     return false;
-  }
-}
-
-// 读取（必要时分配）A/B「历史首启默认」变体：用户已有显式开/合偏好 → null（不在实验内）；否则读已分配
-// variant，没有则随机分配并持久化（稳定 cohort），返回 'open'|'closed'。
-function readCompactHistoryExperimentVariant(): 'open' | 'closed' | null {
-  if (typeof window === 'undefined') return null;
-  try {
-    if (window.localStorage?.getItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY) !== null) return null;
-    let variant = window.localStorage?.getItem(COMPACT_HISTORY_DEFAULT_EXPERIMENT_KEY);
-    if (variant !== 'open' && variant !== 'closed') {
-      variant = Math.random() < 0.5 ? 'open' : 'closed';
-      window.localStorage?.setItem(COMPACT_HISTORY_DEFAULT_EXPERIMENT_KEY, variant);
-    }
-    return variant === 'open' ? 'open' : 'closed';
-  } catch {
-    return null;
   }
 }
 
@@ -592,64 +573,6 @@ function persistCompactExportHistoryOpen(open: boolean) {
   } catch {
     // localStorage can be unavailable in restricted hosts; keep the in-memory state.
   }
-}
-
-// A/B「聊天历史首启默认」曝光上报。刻意从 readPersistedCompactExportHistoryOpen（useState
-// 初始化器/render 阶段）里抽出，挪到组件挂载后的 useEffect 调用：(1) telemetry 是带副作用的
-// fire-and-forget，不该在 render 阶段触发；(2) 上报走 appTelemetry→WS，挂载前 socket 多半未
-// OPEN，过早上报会被静默丢弃。仅在「用户无显式开/合偏好 + 已分配实验 variant」时上报。
-const COMPACT_HISTORY_EXPOSURE_REPORTED_SESSION_KEY = 'neko.experiment.compactHistoryDefault.exposureReported';
-// 返回 true = 「已处理完、无需重试」（成功上报 / 本会话已报过 / 不适用）；返回 false 仅当「该报但
-// appTelemetry 没投出去」(WS 未 OPEN)，调用方据此挂 socket open 重试。去重用 sessionStorage 而非
-// useRef（useRef 仅同实例有效，挡不住真实重挂载如 surface 切换）、也非 localStorage（那会「一生一次」
-// 丢后续会话曝光）；按会话粒度，跨真实重挂载 + StrictMode 双 effect 都只报一次。只有真正投出去才置
-// flag，避免「标记了却没报」永久丢曝光。
-// sessionStorage 去重是 best-effort：隐私浏览器/webview 里 localStorage 仍可能持久化 cohort，但
-// sessionStorage 访问会抛 SecurityError。读失败时必须当作「本会话还没报过」、让曝光照常投出去，
-// 绝不能把存储异常当成「已处理的曝光」——否则有 variant 的用户永远漏曝光、A/B 指标被低估（回应 Codex）。
-function readCompactHistoryExposureReportedThisSession(): boolean {
-  try {
-    return window.sessionStorage?.getItem(COMPACT_HISTORY_EXPOSURE_REPORTED_SESSION_KEY) === 'true';
-  } catch {
-    return false;
-  }
-}
-function markCompactHistoryExposureReportedThisSession(): void {
-  try {
-    window.sessionStorage?.setItem(COMPACT_HISTORY_EXPOSURE_REPORTED_SESSION_KEY, 'true');
-  } catch {
-    // 存不下就退化成「跨真实重挂载可能重复上报」，但不丢曝光——去重只是降噪。
-  }
-}
-function reportCompactHistoryExperimentExposure(): boolean {
-  if (typeof window === 'undefined') return true;
-  let variant: string | null = null;
-  try {
-    const persisted = window.localStorage?.getItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY);
-    if (persisted !== null) return true;
-    variant = window.localStorage?.getItem(COMPACT_HISTORY_DEFAULT_EXPERIMENT_KEY) ?? null;
-  } catch {
-    // localStorage 不可用 → 读不到 cohort、没有可上报的 variant，视为不适用。
-    return true;
-  }
-  if (variant !== 'open' && variant !== 'closed') return true;
-  if (readCompactHistoryExposureReportedThisSession()) return true;
-  let sent = false;
-  try {
-    // 必须走 counter 不是 event：event 只落本地 events.jsonl、不进 instrument.snapshot()，
-    // 永远到不了 TokenTracker 的远程上报通道（见 utils/instrument.py、utils/event_logger.py）。
-    // A/B 曝光要进远程指标必须用 counter，与 session_start / session_end 同范式。
-    sent = (window as unknown as { appTelemetry?: { counter?: (n: string, v?: number, d?: Record<string, unknown>) => boolean } })
-      .appTelemetry?.counter?.('experiment_exposure', 1, { experiment: 'compact_history_default', variant }) === true;
-  } catch {
-    // 投递本身抛错：留给调用方挂 socket open 重试。
-    return false;
-  }
-  if (sent) {
-    markCompactHistoryExposureReportedThisSession();
-    return true;
-  }
-  return false;
 }
 
 function readPersistedCompactHistorySlotHeight(): number | null {
@@ -1667,71 +1590,11 @@ function CompactChatApp({
   const [compactHistorySlotHeight, setCompactHistorySlotHeight] = useState<number | null>(readPersistedCompactHistorySlotHeight);
   const [compactHistoryResizeActive, setCompactHistoryResizeActive] = useState(false);
   const [compactHistoryResizeContentLocked, setCompactHistoryResizeContentLocked] = useState(false);
-  // 快照一次再复用：open/mounted 必须来自同一次持久化读取（readPersistedCompactExportHistoryOpen
-  // 无偏好时一律返回折叠；随机分组在 readCompactHistoryExperimentVariant 里、不在这条读取上）。
-  // 单读单源避免后续给初始化引入副作用时，两个 useState 各算一次导致 open/mounted 分裂初态。
+  // 快照一次再复用：open/mounted 必须来自同一次持久化读取，单读单源避免后续给初始化引入副作用时，
+  // 两个 useState 各算一次导致 open/mounted 分裂初态。无偏好一律折叠（「历史首启默认」A/B 已退役）。
   const [initialCompactExportHistoryOpen] = useState(readPersistedCompactExportHistoryOpen);
   const [compactExportHistoryOpen, setCompactExportHistoryOpen] = useState(initialCompactExportHistoryOpen);
   const [compactExportHistoryMounted, setCompactExportHistoryMounted] = useState(initialCompactExportHistoryOpen);
-  // A/B「历史首启默认」套用（含 open 展开 + 曝光上报）：初始一律折叠（见 readPersistedCompactExportHistoryOpen），
-  // 变体只在「教程完全结束（neko:tutorial-completed / -ended-without-completion）」或「本次不跑教程的老用户」
-  // 时套用——避免教程进行中 / 演示历史区前就展开，与教学冲突。surface 门控见下方 useEffect 开头。
-  // ref 保证整会话只套一次；曝光走 sessionStorage 去重（不可用则退化为 best-effort）+ WS 未就绪有界轮询重试。
-  const compactHistoryExperimentAppliedRef = useRef(false);
-  useEffect(() => {
-    // 仅 compact 才套用 + 计曝光：full 聊天页 / 宽屏 web index（无 surface 偏好）下用户没看到紧凑历史面板，
-    // 若只跳过 minimized，full-surface 用户 3s 兜底后会分配 variant + 上报曝光，污染 compact A/B 数据
-    // （回应 Codex）。从 full 切到 compact 时本 effect 因 deps=[chatSurfaceMode] 重跑、会正常套用。
-    if (chatSurfaceMode !== 'compact') return undefined;
-    const win = window as unknown as { isInTutorial?: boolean };
-    let exposureTimer: number | null = null;
-    let fallbackTimer = 0;
-    // 曝光重试独立于「套用」guard：已套用但本会话还没成功上报的，重新可见（minimized→compact）时要能继续
-    // 补报——否则首报失败后一旦最小化打断，曝光就永久漏掉、A/B 指标被低估。sessionStorage 保证只投一次。
-    const startExposureReporting = () => {
-      if (exposureTimer !== null) return;
-      if (reportCompactHistoryExperimentExposure()) return;
-      let tries = 0;
-      exposureTimer = window.setInterval(() => {
-        if (reportCompactHistoryExperimentExposure() || (tries += 1) >= 20) {
-          if (exposureTimer !== null) { window.clearInterval(exposureTimer); exposureTimer = null; }
-        }
-      }, 1000);
-    };
-    const applyExperimentDefault = () => {
-      if (!compactHistoryExperimentAppliedRef.current) {
-        const variant = readCompactHistoryExperimentVariant();
-        compactHistoryExperimentAppliedRef.current = true;
-        if (variant === 'open') {
-          // 用 openCompactExportHistory({persist:false}) 而非直接 set state：会清掉 close 留下的 560ms
-          // unmount 定时器（否则它会在展开后触发把 mounted 设回 false，留下 open=true 但面板不渲染），
-          // 且 persist:false 不把 A/B 自动展开写成用户偏好。
-          openCompactExportHistory({ persist: false });
-        }
-      }
-      startExposureReporting();
-    };
-    const onTutorialEnd = () => applyExperimentDefault();
-    // 教程结束的三种信号都要监听：完成 / 未完成结束 / 跳过——skip 路径只派发 neko:tutorial-skipped，
-    // 不发另外两个，否则跳过新手教程的用户永远等不到变体套用 + 曝光（回应 Codex）。
-    const tutorialEndEvents = ['neko:tutorial-completed', 'neko:tutorial-ended-without-completion', 'neko:tutorial-skipped'];
-    tutorialEndEvents.forEach((name) => window.addEventListener(name, onTutorialEnd));
-    if (compactHistoryExperimentAppliedRef.current) {
-      // 上次可见时已套用（过了教程/兜底），但曝光可能还没成功 → 重新可见时继续补报。
-      startExposureReporting();
-    } else if (win.isInTutorial !== true && !isGuideChatButtonLockActive()) {
-      // 本次不跑教程的老用户：教程启动会置 window.isInTutorial=true / body 加 guide-active 类。给它一点
-      // 时间，到时仍非教程态就直接套用；教程态则等上面的结束事件。
-      fallbackTimer = window.setTimeout(() => {
-        if (win.isInTutorial !== true && !isGuideChatButtonLockActive()) applyExperimentDefault();
-      }, COMPACT_HISTORY_EXPERIMENT_APPLY_FALLBACK_MS);
-    }
-    return () => {
-      tutorialEndEvents.forEach((name) => window.removeEventListener(name, onTutorialEnd));
-      if (fallbackTimer) window.clearTimeout(fallbackTimer);
-      if (exposureTimer !== null) window.clearInterval(exposureTimer);
-    };
-  }, [chatSurfaceMode]);
   const [compactExportHistoryClosingMessages, setCompactExportHistoryClosingMessages] = useState<ChatMessage[] | null>(null);
   const [compactExportControlsOpen, setCompactExportControlsOpen] = useState(false);
   const [compactExportPreviewOpen, setCompactExportPreviewOpen] = useState(false);
@@ -2155,7 +2018,7 @@ function CompactChatApp({
     if (!request || !request.id || request.id === lastCompactHistoryOpenRequestIdRef.current) return;
     lastCompactHistoryOpenRequestIdRef.current = request.id;
     if (request.open) {
-      // 教程演示历史区只临时展开，不写用户偏好（与 close 对称）——否则会覆盖 A/B 变体默认值。
+      // 教程演示历史区只临时展开，不写用户偏好（与 close 对称）——演示动作不该变成用户的持久化选择。
       openCompactExportHistory({ persist: false });
       return;
     }
@@ -2182,7 +2045,7 @@ function CompactChatApp({
     if (chatSurfaceMode === 'compact' && prev !== 'compact'
       && compactHistoryReopenAfterRestoreRef.current) {
       compactHistoryReopenAfterRestoreRef.current = false;
-      openCompactExportHistory({ persist: false }); // restore 重开不持久化：manual-open OPEN_KEY 本就 true（幂等），experiment-open 保持 null 不变成偏好
+      openCompactExportHistory({ persist: false }); // restore 重开不持久化：manual-open OPEN_KEY 本就 true（幂等），教程临时展开不变成偏好
     }
     // 方向性 reveal 擦除只在毛线球 minimized→compact 恢复时播（full→compact 不播）。~340ms 后复位。
     // useLayoutEffect 让首帧绘制前就挂 mask，消除 web 端首帧闪（壳侧有 opacity-0 门、Electron 看不出）。
@@ -2226,7 +2089,7 @@ function CompactChatApp({
       // 不渲染（受 isCompactSurface 门控），无副作用。正常折叠走 minimized→compact 重开、不到这里。
       if (compactHistoryReopenAfterRestoreRef.current) {
         compactHistoryReopenAfterRestoreRef.current = false;
-        openCompactExportHistory({ persist: false }); // restore 重开不持久化：manual-open OPEN_KEY 本就 true（幂等），experiment-open 保持 null 不变成偏好
+        openCompactExportHistory({ persist: false }); // restore 重开不持久化：manual-open OPEN_KEY 本就 true（幂等），教程临时展开不变成偏好
       }
     }, 600);
     return () => window.clearTimeout(t);
@@ -2242,7 +2105,7 @@ function CompactChatApp({
     setCompactCollapsing(false);
     if (compactHistoryReopenAfterRestoreRef.current) {
       compactHistoryReopenAfterRestoreRef.current = false;
-      openCompactExportHistory({ persist: false }); // restore 重开不持久化：manual-open OPEN_KEY 本就 true（幂等），experiment-open 保持 null 不变成偏好
+      openCompactExportHistory({ persist: false }); // restore 重开不持久化：manual-open OPEN_KEY 本就 true（幂等），教程临时展开不变成偏好
     }
   }, [compactMinimizeCancelSeq, openCompactExportHistory]);
   const handleCompactHistoryVisibilityToggle = useCallback(() => {

--- a/static/app-telemetry.js
+++ b/static/app-telemetry.js
@@ -25,7 +25,8 @@
 
     /**
      * 当前 surface 名 —— 区分三个上下文（记忆 feedback_chat_three_contexts）：
-     *   - chat_window: chat.html follower 窗口
+     *   - chat_window: chat.html 承载的聊天窗口（Electron /chat、web /chat_full、
+     *     dev 直开 chat.html 三种入口）
      *   - index_mobile: 手机/平板视图的 index.html
      *   - index_wide: 桌面宽屏 index.html
      * 调用方任何 counter/histogram/event 都会带上这个字段。
@@ -33,7 +34,11 @@
     function _surface() {
         try {
             var p = (window.location.pathname || '').toLowerCase();
-            if (p.indexOf('chat.html') >= 0) return 'chat_window';
+            var q = p.replace(/\/+$/, '');
+            // 生产 Electron 聊天窗口与 web full 页都是服务端路由（pages_router.py 用
+            // chat.html 双服务 /chat 与 /chat_full），pathname 不含 'chat.html'——此前
+            // 只认文件名，这两个入口全部落到兜底 'index_wide'，surface 分面失真。
+            if (p.indexOf('chat.html') >= 0 || q === '/chat' || q === '/chat_full') return 'chat_window';
         } catch (_) {}
         try {
             var ua = (navigator && navigator.userAgent) || '';

--- a/utils/token_tracker.py
+++ b/utils/token_tracker.py
@@ -430,6 +430,15 @@ _TELEMETRY_BRANCH_FILE = ".telemetry_branch"
 #     branch 正是本实验组的 install，在「判非法 → 重抽」时把仍停在 20s 的
 #     proactiveChatInterval 拉回控制组 15s（见 _rollback_retired_proactive_interval；
 #     重抽即天然幂等标记，不压制用户日后再手选 20s）。
+#   - "compact_history_default"（⚠️ 非本池分支：纯前端 localStorage 实验，仅在此留底。
+#     试 compact 聊天历史面板首启默认 open/closed，分组 key
+#     'neko.experiment.compactHistoryDefault'，曝光 counter 'experiment_exposure'）：
+#     2026-07 退役。数据不可用——Electron 多窗口下教程结束事件只在 Pet 窗口派发、到不了
+#     承载实验 effect 的 /chat 窗口，而教程锁 class 又会经 interpage 中继过去压制 3s
+#     兜底，套用/曝光退化为与教程启动时序的竞速（07-06 CN Steam 新用户覆盖率仅 54%，
+#     且曝光组显著偏活跃、带选择偏差）；另 06-29（#2078）前构建曝光走 event 通道上不了
+#     远程，历史口径断层。结论改为无偏好一律默认折叠（控制组行为），用户显式开/合偏好
+#     照旧生效。分组 key 只停读写、不清理存量残值（保留客户端取证窗口），勿复用该 key 名。
 _TELEMETRY_BRANCHES: tuple = ("main",)
 
 # 进程级缓存：keyed by str(config_dir)。写盘失败的环境下（只读 FS / 权限拒绝），


### PR DESCRIPTION
## 背景

排查 compact_history_default 实验曝光覆盖异常时确认了两个结构性问题：

1. **教程事件跨窗口死锁（实验数据不可用的主因）**：教程结束三事件（`neko:tutorial-completed/-ended-without-completion/-skipped`）只在 Pet 窗口（index.html 的 universal-manager.js）派发，永远到不了承载实验 effect 的 /chat 窗口；而教程锁 class 却会经 interpage 中继到 chat 窗口 body、压制 3s 兜底。实验变体套用/曝光退化为与教程启动时序的竞速，且教程未完成不写 hasSeen、下次启动锁窗重现。能完成曝光的用户群带明显选择偏差，实验读数不可用。
2. **surface 标签失真**：`_surface()` 只认 `chat.html` 文件名，生产 Electron 聊天窗口（/chat 路由）与 web full 页（/chat_full）全部落到兜底 `index_wide`，`chat_window` 标签生产不可达，surface 分面统计整体失真。
3. 另有历史口径断层：#2078 之前曝光走 event 通道，上不了远程。

## 改动

- **修复** `static/app-telemetry.js` `_surface()`：补 `/chat`、`/chat_full` 路由判定（容尾斜杠），surface 分面恢复三上下文语义。
- **退役** compact_history_default 实验：删除分配（`readCompactHistoryExperimentVariant`）、套用 effect、曝光上报全链路；无偏好一律默认折叠（控制组行为），用户显式开/合偏好照旧生效。死锁代码随实验退役一并消失。
- 分组 key `neko.experiment.compactHistoryDefault` 只停读写、**不清理存量残值**（保留客户端取证窗口），并在源码留注勿复用该 key 名。
- 退役结论按惯例留底 `utils/token_tracker.py` 已退役实验清单（标注非 .telemetry_branch 池、纯前端 localStorage 实验）。
- 测试：删实验用例，新增"退役后残留 'open' 分组值不再触发自动展开/曝光"回归用例。

## 验证

- react-neko-chat vitest 271/271 通过
- `npm run build`（tsc + vite）通过
- 全仓库 grep 确认实验引用仅剩留底注释与回归测试残值模拟

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能调整**
  - 紧凑历史区域在未设置用户偏好时默认保持折叠。
  - 继续支持根据用户保存的“展开/折叠”偏好恢复状态。
  - 教程完成后不再因已退役实验设置自动展开或触发相关曝光记录。

- **修复**
  - `/chat` 和 `/chat_full` 入口现可正确归类为聊天窗口，提升遥测数据准确性。

- **文档**
  - 补充已退役紧凑历史默认行为实验的说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->