### PR TITLE
test: 修正 goodbye 契约测试对 #2186 重构后缩进的断言

### DIFF
--- a/tests/unit/test_auto_goodbye_goodbye_return_contract.py
+++ b/tests/unit/test_auto_goodbye_goodbye_return_contract.py
@@ -29,7 +29,7 @@ def test_auto_goodbye_reuses_existing_goodbye_base_chain():
     assert "playModelGoodbyeExit(mmdContainer, savedGoodbyeRect)" in ui_source
     assert "playModelGoodbyeExit(vrmContainer, savedGoodbyeRect)" in ui_source
     assert "container.classList.add('minimized');" in ui_source
-    assert "resetSessionButton.disabled = false;\n                    resetSessionButton.click();" in ui_source
+    assert "resetSessionButton.disabled = false;\n                resetSessionButton.click();" in ui_source
 
     reset_block = _between(
         buttons_source,


### PR DESCRIPTION
## 改动概述 / Summary

`test_auto_goodbye_goodbye_return_contract.py` 第 32 行的空白敏感断言仍锚定 20 空格缩进的 `resetSessionButton.disabled = false; / resetSessionButton.click();` 代码段。#2186 把这段包进 `runGoodbyeResetClickIfActive` 后缩进变成 16 空格，断言未同步，该测试自此在 main 上一直红（CI path filter 没在那个 PR 上跑到它）。本 PR 只把断言更新为当前代码形态。

## 回归报告 / Regression Report

不适用（仅测试断言更新，不改产品代码）。

## 测试 / Testing

- `pytest tests/unit/test_auto_goodbye_goodbye_return_contract.py -q` → 3 passed（修前 1 failed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 更新自动告别流程的返回契约测试断言，使其与当前界面代码格式保持一致。
  * 未改变应用功能、用户体验或实际业务逻辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->