### PR TITLE
fix(characters): .nekocfg 导入 UnboundLocalError（补 imported_card_character_data 赋值）

### DIFF
--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -7148,6 +7148,7 @@ async def import_character_card(
                 return JSONResponse({'success': False, 'error': f'角色卡解析失败: {str(e)}'}, status_code=400)
             if not isinstance(character_data, dict):
                 return JSONResponse({'success': False, 'error': '角色卡数据格式无效'}, status_code=400)
+            imported_card_character_data = copy.deepcopy(character_data)
             character_data = _filter_mutable_catgirl_fields(character_data)
             character_name = str(character_data.get('档案名', '')).strip()
             character_data['档案名'] = character_name

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -7148,7 +7148,12 @@ async def import_character_card(
                 return JSONResponse({'success': False, 'error': f'角色卡解析失败: {str(e)}'}, status_code=400)
             if not isinstance(character_data, dict):
                 return JSONResponse({'success': False, 'error': '角色卡数据格式无效'}, status_code=400)
-            imported_card_character_data = copy.deepcopy(character_data)
+            # .nekocfg is settings-only by design (export strips _reserved and
+            # ships no model assets), so give the shared PNGTuber-restore tail
+            # an empty source instead of the raw card: a hand-crafted file
+            # carrying _reserved.avatar would otherwise restore image paths
+            # that were never extracted locally.
+            imported_card_character_data = {}
             character_data = _filter_mutable_catgirl_fields(character_data)
             character_name = str(character_data.get('档案名', '')).strip()
             character_data['档案名'] = character_name

--- a/tests/unit/test_import_card_nekocfg_regression.py
+++ b/tests/unit/test_import_card_nekocfg_regression.py
@@ -91,3 +91,49 @@ async def test_nekocfg_import_does_not_raise_unbound_local():
     config_manager.asave_characters.assert_awaited()
     saved_characters = config_manager.asave_characters.await_args.args[0]
     assert "测试猫娘" in saved_characters["猫娘"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_nekocfg_import_does_not_restore_pngtuber_avatar_config():
+    """.nekocfg ships no model assets: a hand-crafted file carrying
+    _reserved.avatar.pngtuber must not have that config restored (the image
+    paths it references were never extracted locally)."""
+    character = {
+        "档案名": "手工猫娘",
+        "昵称": "手工猫娘",
+        "_reserved": {
+            "avatar": {
+                "model_type": "pngtuber",
+                "pngtuber": {"idle": "pngtuber/nonexistent/idle.png"},
+            }
+        },
+    }
+    payload = _xor(json.dumps(character, ensure_ascii=False).encode("utf-8"))
+
+    config_manager = MagicMock()
+    config_manager.aload_characters = AsyncMock(return_value={"猫娘": {}})
+    config_manager.asave_characters = AsyncMock()
+    config_manager.ensure_card_faces_directory = MagicMock()
+    config_manager.card_face_meta_path = MagicMock(return_value="unused-meta-path")
+
+    with patch.object(characters_router, "get_config_manager", return_value=config_manager), \
+         patch.object(characters_router, "get_initialize_character_data", return_value=None), \
+         patch.object(
+             characters_router,
+             "_mark_new_character_greeting_pending_safe",
+             new=AsyncMock(return_value=(True, None)),
+         ), \
+         patch.object(characters_router, "_write_card_meta", new=MagicMock()):
+        response = await characters_router.import_character_card(
+            zip_file=_FakeUpload("card.nekocfg", payload),
+            card_image=None,
+        )
+
+    body = json.loads(bytes(response.body).decode("utf-8"))
+    assert body.get("success") is True, body
+    saved_characters = config_manager.asave_characters.await_args.args[0]
+    saved = saved_characters["猫娘"]["手工猫娘"]
+    avatar = (saved.get("_reserved") or {}).get("avatar") or {}
+    assert avatar.get("model_type") != "pngtuber", saved
+    assert "pngtuber" not in avatar, saved

--- a/tests/unit/test_import_card_nekocfg_regression.py
+++ b/tests/unit/test_import_card_nekocfg_regression.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression test: importing a `.nekocfg` card must not crash.
+
+The `.nekocfg` branch of ``import_character_card`` never assigned
+``imported_card_character_data``, while the shared tail of the handler passes
+it unconditionally to ``_restore_imported_pngtuber_avatar_config`` — so every
+`.nekocfg` import died with ``UnboundLocalError`` (the ZIP/PNG branches were
+fine because they assign it before use).
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from main_routers import characters_router
+
+
+XOR_KEY = b"NEKOCHARA2024"
+
+
+def _xor(data: bytes) -> bytes:
+    return bytes(data[i] ^ XOR_KEY[i % len(XOR_KEY)] for i in range(len(data)))
+
+
+class _FakeUpload:
+    def __init__(self, filename: str, payload: bytes):
+        self.filename = filename
+        self._buf = payload
+        self._pos = 0
+
+    async def read(self, size: int = -1) -> bytes:
+        if size is None or size < 0:
+            size = len(self._buf) - self._pos
+        chunk = self._buf[self._pos:self._pos + size]
+        self._pos += len(chunk)
+        return chunk
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_nekocfg_import_does_not_raise_unbound_local():
+    character = {
+        "档案名": "测试猫娘",
+        "昵称": "测试猫娘",
+        "性格": "温柔",
+    }
+    payload = _xor(json.dumps(character, ensure_ascii=False).encode("utf-8"))
+
+    config_manager = MagicMock()
+    config_manager.aload_characters = AsyncMock(return_value={"猫娘": {}})
+    config_manager.asave_characters = AsyncMock()
+    config_manager.ensure_card_faces_directory = MagicMock()
+    config_manager.card_face_meta_path = MagicMock(
+        side_effect=AssertionError("meta write should be mocked out")
+    )
+
+    with patch.object(characters_router, "get_config_manager", return_value=config_manager), \
+         patch.object(characters_router, "get_initialize_character_data", return_value=None), \
+         patch.object(
+             characters_router,
+             "_mark_new_character_greeting_pending_safe",
+             new=AsyncMock(return_value=(True, None)),
+         ), \
+         patch.object(characters_router, "_write_card_meta", new=MagicMock()):
+        config_manager.card_face_meta_path = MagicMock(return_value="unused-meta-path")
+        response = await characters_router.import_character_card(
+            zip_file=_FakeUpload("card.nekocfg", payload),
+            card_image=None,
+        )
+
+    body = json.loads(bytes(response.body).decode("utf-8"))
+    # Before the fix this raised UnboundLocalError('imported_card_character_data')
+    # instead of returning any response at all.
+    assert body.get("success") is True, body
+    config_manager.asave_characters.assert_awaited()
+    saved_characters = config_manager.asave_characters.await_args.args[0]
+    assert "测试猫娘" in saved_characters["猫娘"]

--- a/tests/unit/test_import_card_nekocfg_regression.py
+++ b/tests/unit/test_import_card_nekocfg_regression.py
@@ -66,9 +66,7 @@ async def test_nekocfg_import_does_not_raise_unbound_local():
     config_manager.aload_characters = AsyncMock(return_value={"猫娘": {}})
     config_manager.asave_characters = AsyncMock()
     config_manager.ensure_card_faces_directory = MagicMock()
-    config_manager.card_face_meta_path = MagicMock(
-        side_effect=AssertionError("meta write should be mocked out")
-    )
+    config_manager.card_face_meta_path = MagicMock(return_value="unused-meta-path")
 
     with patch.object(characters_router, "get_config_manager", return_value=config_manager), \
          patch.object(characters_router, "get_initialize_character_data", return_value=None), \
@@ -78,7 +76,6 @@ async def test_nekocfg_import_does_not_raise_unbound_local():
              new=AsyncMock(return_value=(True, None)),
          ), \
          patch.object(characters_router, "_write_card_meta", new=MagicMock()):
-        config_manager.card_face_meta_path = MagicMock(return_value="unused-meta-path")
         response = await characters_router.import_character_card(
             zip_file=_FakeUpload("card.nekocfg", payload),
             card_image=None,

--- a/tests/unit/test_import_card_nekocfg_regression.py
+++ b/tests/unit/test_import_card_nekocfg_regression.py
@@ -82,6 +82,7 @@ async def test_nekocfg_import_does_not_raise_unbound_local():
         )
 
     body = json.loads(bytes(response.body).decode("utf-8"))
+    assert response.status_code == 200, (response.status_code, body)
     # Before the fix this raised UnboundLocalError('imported_card_character_data')
     # instead of returning any response at all.
     assert body.get("success") is True, body
@@ -128,6 +129,7 @@ async def test_nekocfg_import_does_not_restore_pngtuber_avatar_config():
         )
 
     body = json.loads(bytes(response.body).decode("utf-8"))
+    assert response.status_code == 200, (response.status_code, body)
     assert body.get("success") is True, body
     saved_characters = config_manager.asave_characters.await_args.args[0]
     saved = saved_characters["猫娘"]["手工猫娘"]


### PR DESCRIPTION
修复 `.nekocfg` 设定文件导入必然以 `UnboundLocalError` 失败的问题（coderabbit 在 #2148 review 中发现，确认为 main 既有 bug，与拆包无关，故独立出 PR）。

## 回归报告

**原行为**：`import_character_card` 的 `.nekocfg` 分支从未给 `imported_card_character_data` 赋值，而 handler 共同尾部无条件把它传给 `_restore_imported_pngtuber_avatar_config` → 任何 `.nekocfg` 导入抛 `UnboundLocalError`，接口返回 500。ZIP/PNG 卡导入不受影响（两个分支各自有赋值）。

**修复**：与另两个分支对偶，在 `_filter_mutable_catgirl_fields` 之前 `copy.deepcopy` 原始数据（一行）。

**验证**：新增 `tests/unit/test_import_card_nekocfg_regression.py`，构造 XOR 混淆的 `.nekocfg` 上传直调 endpoint——撤销修复即复现 `UnboundLocalError`，修复后导入成功且角色写入 `characters.json`（红绿均已本地实跑确认）。

**潜在回归面**：仅 `.nekocfg` 导入路径新增一次 deepcopy；`imported_card_character_data` 的下游消费（PNGTuber 头像配置恢复）从「崩溃」变为「拿到卡内原始数据」，与 ZIP 加密卡（character.json.encrypted）路径行为一致。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 修复加密的 `.nekocfg` 角色卡导入过程中可能因未初始化而触发的异常，提高导入稳定性。
  * 确保 `.nekocfg`（设置-only）导入不会错误恢复/注入 `pngtuber` 头像模型相关配置，避免使用不应来源的数据。
* **测试**
  * 新增两项 `.nekocfg` 导入回归测试：验证不抛异常、且 `pngtuber` 恢复行为不会发生。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->