### PR TITLE
fix(steam): update-playtime 对 Infinity 输入返回 400 而非 500

### DIFF
--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -4079,7 +4079,9 @@ async def update_playtime(request: Request):
                 content={"success": False, "error": "seconds must be non-negative"},
                 status_code=400,
             )
-    except (ValueError, TypeError):
+    except (ValueError, TypeError, OverflowError):
+        # OverflowError: json.loads accepts bare Infinity/-Infinity, which
+        # int() cannot convert — treat it as invalid input, not a 500.
         return JSONResponse(
             content={"success": False, "error": "seconds must be a valid integer"},
             status_code=400,

--- a/tests/unit/test_steam_achievement_router.py
+++ b/tests/unit/test_steam_achievement_router.py
@@ -260,3 +260,26 @@ def test_update_playtime_rejects_negative_seconds(
 
     assert response.status_code == 400
     assert stats.set_stat_calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("raw_seconds", ["Infinity", "-Infinity", "NaN"])
+def test_update_playtime_rejects_non_finite_seconds(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    raw_seconds: str,
+) -> None:
+    """json.loads accepts bare Infinity/NaN; int() then raises OverflowError
+    (Infinity) or ValueError (NaN) — both must surface as 400, not 500."""
+    stats = _FakeUserStats()
+    steamworks = _FakeSteamworks(stats)
+    monkeypatch.setattr(system_router_module, "get_steamworks", lambda: steamworks)
+
+    response = client.post(
+        "/api/steam/update-playtime",
+        headers={**_auth_headers(), "Content-Type": "application/json"},
+        content=('{"seconds": %s}' % raw_seconds).encode("utf-8"),
+    )
+
+    assert response.status_code == 400
+    assert stats.set_stat_calls == []


### PR DESCRIPTION
修复 `/api/steam/update-playtime` 收到 `{"seconds": Infinity}` 时返回 500 的问题（coderabbit 在 #2148 review 中发现；该代码随 #2207 进入 main，与拆包 PR 无关，故独立修复）。

## 回归报告

**原行为**：`json.loads` 默认接受裸 `Infinity`/`-Infinity`/`NaN` 字面量；`int(inf)` 抛 `OverflowError`，原 `except (ValueError, TypeError)` 兜不住 → 接口 500。`NaN` 走 `ValueError` 本来就被兜住返回 400。

**修复**：except 元组补上 `OverflowError`（一行），非有限数值与其他非法输入一致返回 400 `"seconds must be a valid integer"`。

**验证**：`test_steam_achievement_router.py` 新增 parametrize 回归（Infinity/-Infinity/NaN 直发 raw JSON body）——撤销修复时 Infinity 两例复现 500，修复后 10/10 全绿，且断言不产生任何 `SetStatInt` 调用。

**潜在回归面**：仅 update_playtime 的输入校验分支，正常整数路径无改动。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 修复游玩时长更新接口对 `Infinity`、`-Infinity` 和 `NaN` 等非有限数值处理不当的问题。
  - 现在此类无效输入会返回 `400` 错误，避免触发服务器异常，也不会写入错误的进度统计数据。

- **Tests**
  - 新增相关场景测试，确保非有限数值被正确拒绝。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->