### PR TITLE
test(pngtuber): fix start_block slice anchoring to method definition

### DIFF
--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -140,7 +140,7 @@ def test_pngtuber_mouth_flap_does_not_restart_layered_motion_timeline():
         source.index("        startSpeakingMouthAnimation()")
     ]
     start_block = source[
-        source.index("startSpeakingMouthAnimation()"):
+        source.index("        startSpeakingMouthAnimation() {"):
         source.index("        stopSpeakingMouthAnimation()")
     ]
 
@@ -498,7 +498,7 @@ def test_pngtuber_talking_hop_moves_whole_avatar_while_speaking():
         source.index("        getActiveLayoutFields()")
     ]
     start_block = source[
-        source.index("startSpeakingMouthAnimation()"):
+        source.index("        startSpeakingMouthAnimation() {"):
         source.index("        stopSpeakingMouthAnimation()")
     ]
     lip_sync_block = source[


### PR DESCRIPTION
## 背景

`tests/unit/test_pngtuber_static_contracts.py::test_pngtuber_mouth_flap_does_not_restart_layered_motion_timeline` 在 clean `origin/main` 上就失败（`1 failed`），报 `assert "layeredAnimationStart = performance.now()" not in start_block`。这不是任何 PR 引入的，是 main 上测试自身的 bug。

## 根因

测试这样切 `start_block`：

```python
start_block = source[
    source.index("startSpeakingMouthAnimation()"):
    source.index("        stopSpeakingMouthAnimation()")
]
```

裸字符串 `"startSpeakingMouthAnimation()"`（无前导空格）的**第一个**匹配是 `static/pngtuber-core.js:363` 里 `resumeRendering()` 内的**调用** `this.startSpeakingMouthAnimation();`，远早于方法定义（`pngtuber-core.js:1777`）。于是 `start_block` 被撑大，跨进了 `startLayeredAnimationLoop()` 方法体——那里合法地含有唯一一处 `this.layeredAnimationStart = performance.now();`（`source.count(...) == 1` 依然成立），导致 `not in start_block` 误判失败。

## 修复

把起始锚点改成 8 空格缩进的方法定义字符串 `"        startSpeakingMouthAnimation() {"`，让切片只覆盖方法体（`pngtuber-core.js:1777-1789`）。结束锚点 `"        stopSpeakingMouthAnimation()"` 本就匹配方法定义，不受影响。

同一文件里的 `test_pngtuber_talking_hop_moves_whole_avatar_while_speaking` 有一模一样的潜在 bug（同样的裸锚点），只是碰巧因过大的切片恰好包含被断言的子串而没红。一并按同样方式修掉，让断言真正校验方法体。

## 验证

主仓库 venv，cwd=仓库根：

- 目标用例：`1 failed` → `1 passed`
- 整个文件：`19 passed`

纯测试文件改动，不改 `static/pngtuber-core.js` 运行时逻辑。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 优化嘴部动画和说话跳动相关逻辑的自动化测试定位，提升测试断言的准确性与稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->