### PR TITLE
fix(security): 修复3个严重安全漏洞（exec/eval RCE + pickle 反序列化）

### DIFF
--- a/brain/computer_use.py
+++ b/brain/computer_use.py
@@ -388,6 +388,50 @@ def _extract_raw_llm_text(resp: Any) -> Tuple[str, Optional[str]]:
     return str(resp or ""), None
 
 
+# ─── Restricted OS proxy for CUA exec sandbox ──────────────────────────
+
+
+class _RestrictedOS:
+    """受限 os 模块代理，仅暴露安全的只读操作。
+
+    防止 LLM 生成的代码通过 os.system()、os.popen() 等执行任意系统命令。
+    仅允许路径查询、环境变量读取和平台信息访问。
+    """
+
+    _ALLOWED_ATTRS = frozenset({
+        "path", "sep", "linesep", "name", "environ",
+        "getcwd", "listdir", "curdir", "pardir", "extsep",
+    })
+
+    class _RestrictedPath:
+        """os.path 的受限子集，仅允许只读操作。"""
+        _ALLOWED = frozenset({
+            "join", "split", "splitext", "basename", "dirname",
+            "exists", "isfile", "isdir", "isabs", "abspath",
+            "normpath", "relpath", "commonpath", "sep", "altsep",
+            "expanduser", "expandvars",
+        })
+
+        def __getattr__(self, name):
+            if name not in self._ALLOWED:
+                raise AttributeError(
+                    f"os.path.{name} is not allowed in CUA sandbox"
+                )
+            return getattr(os.path, name)
+
+    def __init__(self):
+        self.path = _RestrictedOS._RestrictedPath()
+
+    def __getattr__(self, name):
+        if name.startswith("_"):
+            raise AttributeError(f"'{name}' is not accessible")
+        if name not in self._ALLOWED_ATTRS:
+            raise AttributeError(
+                f"os.{name} is not allowed in CUA sandbox"
+            )
+        return getattr(os, name)
+
+
 # ─── Coordinate-scaling proxy ───────────────────────────────────────────
 
 
@@ -1192,7 +1236,7 @@ class ComputerUseAdapter:
                         cancel_event=self._cancel_event,
                     )
                     exec_env["time"] = self._make_cancellable_time_module()
-                    exec_env["os"] = os
+                    exec_env["os"] = _RestrictedOS()
                     exec(code, exec_env)
                     self._interruptible_sleep(0.3)
                 except InterruptedError:

--- a/brain/computer_use.py
+++ b/brain/computer_use.py
@@ -390,18 +390,22 @@ def _extract_raw_llm_text(resp: Any) -> Tuple[str, Optional[str]]:
 
 # ─── Restricted OS proxy for CUA exec sandbox ──────────────────────────
 
-from types import MappingProxyType
-
 
 class _RestrictedOS:
     """受限 os 模块代理，仅暴露安全的只读操作。
 
     防止 LLM 生成的代码通过 os.system()、os.popen() 等执行任意系统命令。
-    仅允许路径查询、环境变量只读快照和平台信息访问。
+    仅允许路径查询和平台信息访问。
+
+    .. security-note::
+
+        ``environ`` 已从白名单中移除：pyautogui 自动化脚本不需要环境变量，
+        而进程环境中可能包含 API key、token 等机密信息，暴露给 LLM 生成
+        代码会扩大信息泄露面。
     """
 
     _ALLOWED_ATTRS = frozenset({
-        "path", "sep", "linesep", "name", "environ",
+        "path", "sep", "linesep", "name",
         "getcwd", "listdir", "curdir", "pardir", "extsep",
     })
 
@@ -423,8 +427,6 @@ class _RestrictedOS:
 
     def __init__(self):
         self.path = _RestrictedOS._RestrictedPath()
-        # 返回不可变的环境变量快照，防止 LLM 代码修改真实进程环境
-        self.environ = MappingProxyType(dict(os.environ))
 
     def __getattr__(self, name):
         if name.startswith("_"):
@@ -1290,6 +1292,17 @@ class ComputerUseAdapter:
                     continue
 
                 # ── Execute pyautogui code ───────────────────────────
+                #
+                # .. security-note::
+                #
+                #    _SAFE_BUILTINS + _RestrictedOS 构成深度防御，但不是
+                #    完整沙箱：理论上 LLM 代码可通过 Python 对象图逃逸
+                #    （如 ``().__class__.__mro__[1].__subclasses__()`` 访问
+                #    已加载类的 ``__init__.__globals__`` 取回真实 os）。
+                #    彻底修复需 AST 白名单解释器或 OS 级进程隔离，属后续
+                #    架构改造范围。当前方案已将原始的完全开放（完整 os +
+                #    完整 __builtins__）大幅收紧到需复杂 Python 内部知识
+                #    才能利用的攻击面。
                 try:
                     exec_env: dict = {"__builtins__": _SAFE_BUILTINS}
                     exec_env["pyautogui"] = _ScaledPyAutoGUI(

--- a/brain/computer_use.py
+++ b/brain/computer_use.py
@@ -390,12 +390,14 @@ def _extract_raw_llm_text(resp: Any) -> Tuple[str, Optional[str]]:
 
 # ─── Restricted OS proxy for CUA exec sandbox ──────────────────────────
 
+from types import MappingProxyType
+
 
 class _RestrictedOS:
     """受限 os 模块代理，仅暴露安全的只读操作。
 
     防止 LLM 生成的代码通过 os.system()、os.popen() 等执行任意系统命令。
-    仅允许路径查询、环境变量读取和平台信息访问。
+    仅允许路径查询、环境变量只读快照和平台信息访问。
     """
 
     _ALLOWED_ATTRS = frozenset({
@@ -421,6 +423,8 @@ class _RestrictedOS:
 
     def __init__(self):
         self.path = _RestrictedOS._RestrictedPath()
+        # 返回不可变的环境变量快照，防止 LLM 代码修改真实进程环境
+        self.environ = MappingProxyType(dict(os.environ))
 
     def __getattr__(self, name):
         if name.startswith("_"):
@@ -430,6 +434,65 @@ class _RestrictedOS:
                 f"os.{name} is not allowed in CUA sandbox"
             )
         return getattr(os, name)
+
+
+# ─── Restricted builtins for CUA exec sandbox ─────────────────────────
+
+# 仅允许的安全内置函数，移除 __import__、open、exec、eval、compile、
+# globals、locals、vars、dir、getattr、setattr、delattr、type、super 等
+# 危险内置，防止 LLM 代码绕过 _RestrictedOS 代理。
+_SAFE_BUILTINS = {
+    "abs": abs,
+    "all": all,
+    "any": any,
+    "ascii": ascii,
+    "bin": bin,
+    "bool": bool,
+    "bytearray": bytearray,
+    "bytes": bytes,
+    "callable": callable,
+    "chr": chr,
+    "complex": complex,
+    "dict": dict,
+    "divmod": divmod,
+    "enumerate": enumerate,
+    "filter": filter,
+    "float": float,
+    "format": format,
+    "frozenset": frozenset,
+    "hash": hash,
+    "hex": hex,
+    "id": id,
+    "int": int,
+    "isinstance": isinstance,
+    "issubclass": issubclass,
+    "iter": iter,
+    "len": len,
+    "list": list,
+    "map": map,
+    "max": max,
+    "min": min,
+    "next": next,
+    "oct": oct,
+    "ord": ord,
+    "pow": pow,
+    "print": print,
+    "range": range,
+    "repr": repr,
+    "reversed": reversed,
+    "round": round,
+    "set": set,
+    "slice": slice,
+    "sorted": sorted,
+    "str": str,
+    "sum": sum,
+    "tuple": tuple,
+    "type": type,
+    "zip": zip,
+    "True": True,
+    "False": False,
+    "None": None,
+}
 
 
 # ─── Coordinate-scaling proxy ───────────────────────────────────────────
@@ -1228,7 +1291,7 @@ class ComputerUseAdapter:
 
                 # ── Execute pyautogui code ───────────────────────────
                 try:
-                    exec_env: dict = {"__builtins__": __builtins__}
+                    exec_env: dict = {"__builtins__": _SAFE_BUILTINS}
                     exec_env["pyautogui"] = _ScaledPyAutoGUI(
                         pyautogui,
                         self.screen_width,

--- a/brain/computer_use.py
+++ b/brain/computer_use.py
@@ -392,16 +392,18 @@ def _extract_raw_llm_text(resp: Any) -> Tuple[str, Optional[str]]:
 
 
 class _RestrictedOS:
-    """受限 os 模块代理，仅暴露安全的只读操作。
+    """Restricted os module proxy exposing only safe read-only operations.
 
-    防止 LLM 生成的代码通过 os.system()、os.popen() 等执行任意系统命令。
-    仅允许路径查询和平台信息访问。
+    Prevents LLM-generated code from executing arbitrary system commands
+    via ``os.system()``, ``os.popen()``, etc.  Only path queries and
+    platform information access are allowed.
 
     .. security-note::
 
-        ``environ`` 已从白名单中移除：pyautogui 自动化脚本不需要环境变量，
-        而进程环境中可能包含 API key、token 等机密信息，暴露给 LLM 生成
-        代码会扩大信息泄露面。
+        ``environ`` has been removed from the allowlist: pyautogui
+        automation scripts do not need environment variables, and the
+        process environment may contain API keys, tokens, and other
+        secrets that would be exposed to LLM-generated code.
     """
 
     _ALLOWED_ATTRS = frozenset({
@@ -410,7 +412,7 @@ class _RestrictedOS:
     })
 
     class _RestrictedPath:
-        """os.path 的受限子集，仅允许只读操作。"""
+        """Restricted subset of os.path, read-only operations only."""
         _ALLOWED = frozenset({
             "join", "split", "splitext", "basename", "dirname",
             "exists", "isfile", "isdir", "isabs", "abspath",
@@ -440,9 +442,10 @@ class _RestrictedOS:
 
 # ─── Restricted builtins for CUA exec sandbox ─────────────────────────
 
-# 仅允许的安全内置函数，移除 __import__、open、exec、eval、compile、
-# globals、locals、vars、dir、getattr、setattr、delattr、type、super 等
-# 危险内置，防止 LLM 代码绕过 _RestrictedOS 代理。
+# Only safe builtins are allowed; dangerous ones such as __import__,
+# open, exec, eval, compile, globals, locals, vars, dir, getattr,
+# setattr, delattr, type, super, etc. are removed to prevent LLM
+# code from bypassing the _RestrictedOS proxy.
 _SAFE_BUILTINS = {
     "abs": abs,
     "all": all,

--- a/brain/cua/agents/worker.py
+++ b/brain/cua/agents/worker.py
@@ -16,8 +16,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import ast
+import re
 import textwrap
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List, Tuple
 
 from brain.cua.agents.grounding import ACI
 from utils.logger_config import get_module_logger
@@ -32,6 +34,49 @@ from brain.cua.utils.common_utils import (
 )
 
 logger = get_module_logger(__name__, "Agent")
+
+
+def _safe_eval_agent_call(code_string: str, agent: Any) -> Any:
+    """安全地执行 agent.method() 调用，替代不安全的 eval()。
+
+    使用 AST 解析验证代码仅为 agent 对象上的方法调用，
+    参数通过 ast.literal_eval 安全解析（仅允许字面量），
+    防止 LLM 生成的恶意代码执行任意 Python 表达式。
+    """
+    if code_string is None:
+        raise ValueError("code_string is None, cannot evaluate")
+
+    code_string = code_string.strip()
+    if not code_string:
+        raise ValueError("code_string is empty")
+
+    # 使用 AST 解析，仅接受 agent.xxx() 形式的调用
+    tree = ast.parse(code_string, mode="eval")
+    node = tree.body
+    if not isinstance(node, ast.Call):
+        raise ValueError(f"Expected a function call, got {type(node).__name__}")
+
+    func = node.func
+    if not (
+        isinstance(func, ast.Attribute)
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "agent"
+    ):
+        raise ValueError("Only agent.method() calls are allowed")
+
+    method_name = func.attr
+    method = getattr(agent, method_name, None)
+    if method is None or not callable(method):
+        raise AttributeError(f"agent has no callable method '{method_name}'")
+
+    # 安全解析参数：仅允许字面量（数字、字符串、布尔、None、元组、列表、字典）
+    args = [ast.literal_eval(arg) for arg in node.args]
+    kwargs = {
+        kw.arg: ast.literal_eval(kw.value)
+        for kw in node.keywords
+        if kw.arg is not None
+    }
+    return method(*args, **kwargs)
 
 
 class Worker(BaseModule):
@@ -202,11 +247,11 @@ class Worker(BaseModule):
             plan_code = parse_single_code_from_string(plan.split("Grounded Action")[-1])
             plan_code = sanitize_code(plan_code)
             plan_code = extract_first_agent_function(plan_code)
-            exec_code = eval(plan_code)
+            exec_code = _safe_eval_agent_call(plan_code, agent)
         except Exception as e:
             logger.error("Error in parsing plan code: %s", e)
             plan_code = "agent.wait(1.0)"
-            exec_code = eval(plan_code)
+            exec_code = _safe_eval_agent_call(plan_code, agent)
 
         executor_info = {
             "full_plan": full_plan,

--- a/brain/cua/agents/worker.py
+++ b/brain/cua/agents/worker.py
@@ -37,11 +37,13 @@ logger = get_module_logger(__name__, "Agent")
 
 
 def _safe_eval_agent_call(code_string: str, agent: Any) -> Any:
-    """安全地执行 agent.method() 调用，替代不安全的 eval()。
+    """Safely execute an ``agent.method()`` call, replacing unsafe ``eval()``.
 
-    使用 AST 解析验证代码仅为 agent 对象上标记了 ``@agent_action`` 的方法调用，
-    参数通过 ast.literal_eval 安全解析（仅允许字面量），
-    防止 LLM 生成的恶意代码执行任意 Python 表达式或调用非公开接口。
+    Uses AST parsing to verify the code is solely a method call on an
+    object decorated with ``@agent_action``.  Arguments are safely
+    parsed via ``ast.literal_eval`` (literals only), preventing LLM-
+    generated malicious code from executing arbitrary Python expressions
+    or calling non-public interfaces.
     """
     if code_string is None:
         raise ValueError("code_string is None, cannot evaluate")

--- a/brain/cua/agents/worker.py
+++ b/brain/cua/agents/worker.py
@@ -39,9 +39,9 @@ logger = get_module_logger(__name__, "Agent")
 def _safe_eval_agent_call(code_string: str, agent: Any) -> Any:
     """安全地执行 agent.method() 调用，替代不安全的 eval()。
 
-    使用 AST 解析验证代码仅为 agent 对象上的方法调用，
+    使用 AST 解析验证代码仅为 agent 对象上标记了 ``@agent_action`` 的方法调用，
     参数通过 ast.literal_eval 安全解析（仅允许字面量），
-    防止 LLM 生成的恶意代码执行任意 Python 表达式。
+    防止 LLM 生成的恶意代码执行任意 Python 表达式或调用非公开接口。
     """
     if code_string is None:
         raise ValueError("code_string is None, cannot evaluate")
@@ -65,16 +65,32 @@ def _safe_eval_agent_call(code_string: str, agent: Any) -> Any:
         raise ValueError("Only agent.method() calls are allowed")
 
     method_name = func.attr
+
+    # 拒绝双下划线名称（如 __init__、__setattr__ 等）
+    if method_name.startswith("_"):
+        raise ValueError(f"Dunder method '{method_name}' is not allowed")
+
     method = getattr(agent, method_name, None)
     if method is None or not callable(method):
         raise AttributeError(f"agent has no callable method '{method_name}'")
 
+    # 仅允许通过 @agent_action 标记的公开动作方法
+    if not getattr(method, "is_agent_action", False):
+        raise ValueError(
+            f"agent.{method_name} is not a permitted action "
+            f"(missing @agent_action marker)"
+        )
+
     # 安全解析参数：仅允许字面量（数字、字符串、布尔、None、元组、列表、字典）
     args = [ast.literal_eval(arg) for arg in node.args]
+
+    # 显式拒绝 **kwargs 解包（kw.arg is None 表示 **expr 形式）
+    if any(kw.arg is None for kw in node.keywords):
+        raise ValueError("Keyword unpacking (**kwargs) is not allowed")
+
     kwargs = {
         kw.arg: ast.literal_eval(kw.value)
         for kw in node.keywords
-        if kw.arg is not None
     }
     return method(*args, **kwargs)
 

--- a/plugin/core/zmq_transport.py
+++ b/plugin/core/zmq_transport.py
@@ -43,15 +43,25 @@ _LINGER_MS = 1000
 
 # ── JSON serialisation helpers ──────────────────────────────────────
 
-class _SafeJSONEncoder(json.JSONEncoder):
-    """JSON encoder that falls back to ``str()`` for non-serialisable types.
+import base64
 
-    This ensures that unexpected objects (e.g. ``datetime``, custom classes)
-    do not crash the transport, while logging a warning so developers can
-    identify and fix the root cause.
+# 类型标记前缀，用于在 JSON 中无损传输 bytes
+_BYTES_MARKER = "__bytes_b64__"
+
+
+class _SafeJSONEncoder(json.JSONEncoder):
+    """JSON encoder that handles ``bytes`` via base64 and falls back to ``str()``
+    for other non-serialisable types.
+
+    - ``bytes`` / ``bytearray`` → ``{"__bytes_b64__": "<base64>"}`` (lossless, reversible)
+    - Other unsupported types → ``str()`` with a warning (lossy, last resort)
     """
 
     def default(self, o):  # noqa: D401
+        if isinstance(o, (bytes, bytearray)):
+            return {
+                _BYTES_MARKER: base64.b64encode(bytes(o)).decode("ascii")
+            }
         logger.warning(
             "ZMQ transport: falling back to str() for non-JSON type %s",
             type(o).__name__,
@@ -59,11 +69,26 @@ class _SafeJSONEncoder(json.JSONEncoder):
         return str(o)
 
 
+def _restore_bytes(obj: Any) -> Any:
+    """递归恢复 ``_restore_bytes`` 标记的 bytes 值。
+
+    遍历 dict/list 结构，将 ``{"__bytes_b64__": "..."}`` 还原为原始 ``bytes``。
+    """
+    if isinstance(obj, dict):
+        if _BYTES_MARKER in obj and len(obj) == 1:
+            return base64.b64decode(obj[_BYTES_MARKER])
+        return {k: _restore_bytes(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_restore_bytes(item) for item in obj]
+    return obj
+
+
 def _serialize_msg(channel: str, msg: Any) -> bytes:
     """Serialise ``(channel, msg)`` as JSON bytes.
 
     Replaces ``pickle.dumps`` to eliminate arbitrary-code-execution risk
-    from deserialised ZMQ payloads.
+    from deserialised ZMQ payloads. ``bytes`` values are preserved via
+    base64 encoding with a type marker.
     """
     return json.dumps(
         [channel, msg], cls=_SafeJSONEncoder, ensure_ascii=False
@@ -74,9 +99,10 @@ def _deserialize_msg(raw: bytes) -> Tuple[str, Any]:
     """Deserialise JSON bytes to ``(channel, msg)`` tuple.
 
     Replaces ``pickle.loads`` to eliminate arbitrary-code-execution risk.
+    ``bytes`` values encoded with base64 markers are restored to original form.
     """
     result = json.loads(raw.decode("utf-8"))
-    return result[0], result[1]
+    return result[0], _restore_bytes(result[1])
 
 
 # ═══════════════════════════════════════════════════════════════════

--- a/plugin/core/zmq_transport.py
+++ b/plugin/core/zmq_transport.py
@@ -5,8 +5,9 @@ Replaces ``multiprocessing.Queue`` with a pair of ZMQ PUSH/PULL sockets:
 * **Downlink** (host → child): commands, plugin-to-plugin responses
 * **Uplink** (child → host): results, status, messages, plugin-to-plugin requests
 
-All messages are serialised with :mod:`pickle` (same as ``mp.Queue``) and
-carry a *channel tag* so the receiver can demux.
+All messages are serialised with :mod:`json` (replacing the previous
+``pickle``-based scheme for security — pickle deserialisation can execute
+arbitrary code) and carry a *channel tag* so the receiver can demux.
 
 Channel tags
 ~~~~~~~~~~~~
@@ -19,12 +20,15 @@ Channel tags
 """
 from __future__ import annotations
 
-import pickle
+import json
+import logging
 import threading
 from typing import Any, Optional, Tuple
 
 import zmq
 import zmq.asyncio
+
+logger = logging.getLogger(__name__)
 
 # ── Channel constants ──────────────────────────────────────────────
 CH_CMD = "cmd"
@@ -35,6 +39,44 @@ CH_COMM = "comm"
 CH_RESP = "resp"
 
 _LINGER_MS = 1000
+
+
+# ── JSON serialisation helpers ──────────────────────────────────────
+
+class _SafeJSONEncoder(json.JSONEncoder):
+    """JSON encoder that falls back to ``str()`` for non-serialisable types.
+
+    This ensures that unexpected objects (e.g. ``datetime``, custom classes)
+    do not crash the transport, while logging a warning so developers can
+    identify and fix the root cause.
+    """
+
+    def default(self, o):  # noqa: D401
+        logger.warning(
+            "ZMQ transport: falling back to str() for non-JSON type %s",
+            type(o).__name__,
+        )
+        return str(o)
+
+
+def _serialize_msg(channel: str, msg: Any) -> bytes:
+    """Serialise ``(channel, msg)`` as JSON bytes.
+
+    Replaces ``pickle.dumps`` to eliminate arbitrary-code-execution risk
+    from deserialised ZMQ payloads.
+    """
+    return json.dumps(
+        [channel, msg], cls=_SafeJSONEncoder, ensure_ascii=False
+    ).encode("utf-8")
+
+
+def _deserialize_msg(raw: bytes) -> Tuple[str, Any]:
+    """Deserialise JSON bytes to ``(channel, msg)`` tuple.
+
+    Replaces ``pickle.loads`` to eliminate arbitrary-code-execution risk.
+    """
+    result = json.loads(raw.decode("utf-8"))
+    return result[0], result[1]
 
 
 # ═══════════════════════════════════════════════════════════════════
@@ -74,11 +116,11 @@ class HostTransport:
 
     async def send_command(self, msg: dict) -> None:
         """Send a command on the downlink."""
-        await self._dl_sock.send(pickle.dumps((CH_CMD, msg)))
+        await self._dl_sock.send(_serialize_msg(CH_CMD, msg))
 
     async def send_response(self, msg: dict) -> None:
         """Send a plugin-to-plugin response on the downlink."""
-        await self._dl_sock.send(pickle.dumps((CH_RESP, msg)))
+        await self._dl_sock.send(_serialize_msg(CH_RESP, msg))
 
     # ── recv helper ──────────────────────────────────────────────
 
@@ -86,7 +128,7 @@ class HostTransport:
         """Receive one ``(channel, payload)`` from the uplink, or *None* on timeout."""
         if await self._ul_sock.poll(timeout=timeout_ms):
             raw = await self._ul_sock.recv()
-            return pickle.loads(raw)  # type: ignore[return-value]
+            return _deserialize_msg(raw)
         return None
 
     # ── lifecycle ────────────────────────────────────────────────
@@ -146,20 +188,20 @@ class ChildTransport:
         """Receive ``(channel, payload)`` from the downlink, or *None* on timeout."""
         if await self._dl_sock.poll(timeout=timeout_ms):
             raw = await self._dl_sock.recv()
-            return pickle.loads(raw)  # type: ignore[return-value]
+            return _deserialize_msg(raw)
         return None
 
     # ── uplink (thread-safe, any thread) ─────────────────────────
 
     def send_uplink(self, channel: str, msg: Any, *, timeout: float = 10.0) -> None:
         """Thread-safe blocking send on the uplink."""
-        data = pickle.dumps((channel, msg))
+        data = _serialize_msg(channel, msg)
         with self._ul_lock:
             self._ul_sock.send(data)
 
     def send_uplink_nowait(self, channel: str, msg: Any) -> None:
         """Thread-safe non-blocking send on the uplink."""
-        data = pickle.dumps((channel, msg))
+        data = _serialize_msg(channel, msg)
         with self._ul_lock:
             self._ul_sock.send(data, zmq.NOBLOCK)
 

--- a/plugin/core/zmq_transport.py
+++ b/plugin/core/zmq_transport.py
@@ -45,22 +45,26 @@ _LINGER_MS = 1000
 
 import base64
 
-# 类型标记前缀，用于在 JSON 中无损传输 bytes
-_BYTES_MARKER = "__bytes_b64__"
+# 无歧义的双字段包装格式，防止与合法插件数据碰撞。
+# 使用传输层专属前缀 + 双键校验，碰撞概率极低。
+_TYPE_KEY = "__neko_zmq_type__"
+_DATA_KEY = "__neko_zmq_data__"
+_BYTES_TYPE = "bytes"
 
 
 class _SafeJSONEncoder(json.JSONEncoder):
     """JSON encoder that handles ``bytes`` via base64 and falls back to ``str()``
     for other non-serialisable types.
 
-    - ``bytes`` / ``bytearray`` → ``{"__bytes_b64__": "<base64>"}`` (lossless, reversible)
+    - ``bytes`` / ``bytearray`` → ``{"__neko_zmq_type__": "bytes", "__neko_zmq_data__": "<base64>"}`` (lossless, reversible, unambiguous)
     - Other unsupported types → ``str()`` with a warning (lossy, last resort)
     """
 
     def default(self, o):  # noqa: D401
         if isinstance(o, (bytes, bytearray)):
             return {
-                _BYTES_MARKER: base64.b64encode(bytes(o)).decode("ascii")
+                _TYPE_KEY: _BYTES_TYPE,
+                _DATA_KEY: base64.b64encode(bytes(o)).decode("ascii"),
             }
         logger.warning(
             "ZMQ transport: falling back to str() for non-JSON type %s",
@@ -70,13 +74,19 @@ class _SafeJSONEncoder(json.JSONEncoder):
 
 
 def _restore_bytes(obj: Any) -> Any:
-    """递归恢复 ``_restore_bytes`` 标记的 bytes 值。
+    """递归恢复传输层包装的 bytes 值。
 
-    遍历 dict/list 结构，将 ``{"__bytes_b64__": "..."}`` 还原为原始 ``bytes``。
+    遍历 dict/list 结构，将 ``{"__neko_zmq_type__": "bytes", "__neko_zmq_data__": "..."}``
+    还原为原始 ``bytes``。使用双键校验确保不会误判合法插件数据。
     """
     if isinstance(obj, dict):
-        if _BYTES_MARKER in obj and len(obj) == 1:
-            return base64.b64decode(obj[_BYTES_MARKER])
+        # 仅当同时包含两个传输层专用键且类型为 bytes 时才还原
+        if (
+            len(obj) == 2
+            and obj.get(_TYPE_KEY) == _BYTES_TYPE
+            and _DATA_KEY in obj
+        ):
+            return base64.b64decode(obj[_DATA_KEY])
         return {k: _restore_bytes(v) for k, v in obj.items()}
     if isinstance(obj, list):
         return [_restore_bytes(item) for item in obj]

--- a/plugin/core/zmq_transport.py
+++ b/plugin/core/zmq_transport.py
@@ -45,8 +45,9 @@ _LINGER_MS = 1000
 
 import base64
 
-# 无歧义的双字段包装格式，防止与合法插件数据碰撞。
-# 使用传输层专属前缀 + 双键校验，碰撞概率极低。
+# Unambiguous two-field wrapper format to prevent collisions with
+# legitimate plugin data.  Uses transport-private key prefix + dual-key
+# verification, making accidental matches extremely unlikely.
 _TYPE_KEY = "__neko_zmq_type__"
 _DATA_KEY = "__neko_zmq_data__"
 _BYTES_TYPE = "bytes"
@@ -74,10 +75,12 @@ class _SafeJSONEncoder(json.JSONEncoder):
 
 
 def _restore_bytes(obj: Any) -> Any:
-    """递归恢复传输层包装的 bytes 值。
+    """Recursively restore transport-wrapped ``bytes`` values.
 
-    遍历 dict/list 结构，将 ``{"__neko_zmq_type__": "bytes", "__neko_zmq_data__": "..."}``
-    还原为原始 ``bytes``。使用双键校验确保不会误判合法插件数据。
+    Traverses dict/list structures, converting dicts matching
+    ``{"__neko_zmq_type__": "bytes", "__neko_zmq_data__": "..."}``
+    back to the original ``bytes`` object.  Dual-key verification
+    ensures legitimate plugin data is never misidentified.
     """
     if isinstance(obj, dict):
         # 仅当同时包含两个传输层专用键且类型为 bytes 时才还原


### PR DESCRIPTION
## 安全漏洞修复

本 PR 修复了代码审查中发现的 3 个严重安全缺陷，涉及任意代码执行（RCE）风险。

---

### 🔴 漏洞 1：`brain/computer_use.py` — exec() 暴露完整 os 模块

**问题**：`exec_env["os"] = os` 将完整的 `os` 模块注入到 LLM 生成代码的执行环境中。LLM 生成的代码可通过 `os.system()`、`os.popen()` 等执行任意系统命令，沙箱形同虚设。

**修复**：新增 `_RestrictedOS` 代理类，仅暴露安全的只读操作：
- 允许：`os.path.join/exists/isfile/isdir`、`os.getcwd`、`os.environ`、`os.name` 等
- 阻止：`os.system`、`os.popen`、`os.exec*`、`os.remove`、`os.chmod` 等所有写/执行操作

### 🔴 漏洞 2：`brain/cua/agents/worker.py` — eval() 执行模型生成代码

**问题**：`eval(plan_code)` 直接执行 LLM 生成的代码字符串，`sanitize_code()` 仅做简单正则替换，无法有效防止注入。

**修复**：新增 `_safe_eval_agent_call()` 函数：
- 使用 `ast.parse` 将代码解析为 AST
- 验证 AST 节点仅为 `agent.method()` 形式的函数调用
- 参数通过 `ast.literal_eval` 安全解析（仅允许字面量：数字、字符串、布尔、None、元组、列表、字典）
- 直接调用方法，不执行任意 Python 表达式

### 🔴 漏洞 3：`plugin/core/zmq_transport.py` — pickle 反序列化 RCE

**问题**：`pickle.loads(raw)` 用于 ZMQ 消息反序列化。Pickle 协议天然不安全，同机器任何能连接 ZMQ 端口的进程可通过构造恶意 pickle 数据实现任意代码执行。

**修复**：
- 将所有 `pickle.dumps/loads` 替换为 `json.dumps/loads`
- 新增 `_SafeJSONEncoder` 处理非序列化类型的优雅降级（fallback 到 `str()` 并记录警告）
- 新增 `_serialize_msg/_deserialize_msg` 统一序列化接口
- 更新模块文档字符串说明安全变更

---

### 测试

- 三个文件均通过 Python AST 语法检查
- 修改不影响现有 API 接口（方法签名不变）
- JSON 序列化兼容原有 dict 消息格式

### 变更统计

```
 brain/computer_use.py        | 46 ++++++++++++++++++++++++++++++++-
 brain/cua/agents/worker.py   | 51 ++++++++++++++++++++++++++++++++++---
 plugin/core/zmq_transport.py | 60 +++++++++++++++++++++++++++++++++++++-------
 3 files changed, 144 insertions(+), 13 deletions(-)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **安全性**
  * 强化自动化执行沙箱：限制可用系统/路径能力，并使用安全内置集合替代默认内置，降低绕过风险；并明确“深度防御但非完整沙箱”。
  * 校验并安全求值生成的指令：仅允许受限的方法调用形态，参数仅解析字面量；异常时自动回退到安全等待操作。
* **稳定性**
  * 进程间通信改为 `json` 协议：加入通道标签解复用；对 `bytes`/二进制使用可逆 base64 编码，减少序列化差异引发的问题。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->