### PR TITLE
兼容 QwenPaw 2.0 健康检查与聊天接口，保留旧版协议支持，并修复流式响应解析

### DIFF
--- a/brain/openclaw_adapter.py
+++ b/brain/openclaw_adapter.py
@@ -231,9 +231,15 @@ class OpenClawAdapter:
                     (self.health_url, "legacy"),
                 )
                 response = None
-                checked_url = candidates[0][0]
+                response_url = candidates[0][0]
+                last_request_error: Optional[httpx.RequestError] = None
                 for checked_url, variant in candidates:
-                    response = client.get(checked_url)
+                    try:
+                        response = client.get(checked_url)
+                    except httpx.RequestError as exc:
+                        last_request_error = exc
+                        continue
+                    response_url = checked_url
                     if response.is_success:
                         if variant == "v2":
                             try:
@@ -251,12 +257,14 @@ class OpenClawAdapter:
                             "status_code": response.status_code,
                             "provider": "qwenpaw",
                         }
+                if response is None and last_request_error is not None:
+                    raise last_request_error
                 status_code = response.status_code if response is not None else 503
                 self.last_error = f"HTTP {status_code}"
                 return {
                     "enabled": True,
                     "ready": False,
-                    "reasons": [f"OpenClaw(QwenPaw) responded {status_code} ({checked_url})"],
+                    "reasons": [f"OpenClaw(QwenPaw) responded {status_code} ({response_url})"],
                     "status_code": status_code,
                     "provider": "qwenpaw",
                 }
@@ -747,6 +755,24 @@ class OpenClawAdapter:
             ],
         }
 
+    def _build_console_payload(
+        self,
+        *,
+        session_id: str,
+        user_id: str,
+        channel: str,
+        instruction: str,
+        attachments: Optional[list] = None,
+    ) -> Dict[str, Any]:
+        payload = self._build_process_payload(
+            session_id=session_id,
+            channel=channel,
+            instruction=instruction,
+            attachments=attachments,
+        )
+        payload["user_id"] = user_id
+        return payload
+
     async def run_instruction(
         self,
         instruction: str,
@@ -779,6 +805,13 @@ class OpenClawAdapter:
             instruction=instruction,
             attachments=attachments,
         )
+        console_payload = self._build_console_payload(
+            session_id=resolved_session_id,
+            user_id=sender,
+            channel=channel,
+            instruction=instruction,
+            attachments=attachments,
+        )
         timeout = httpx.Timeout(self.http_timeout, connect=min(10.0, self.http_timeout))
         try:
             async with httpx.AsyncClient(
@@ -792,7 +825,7 @@ class OpenClawAdapter:
 
                 if self.api_variant == "v2":
                     console_attempted = True
-                    console_response = await client.post(self.console_chat_url, json=responses_payload)
+                    console_response = await client.post(self.console_chat_url, json=console_payload)
                     if console_response.status_code not in (404, 405):
                         console_response.raise_for_status()
                         data = self._parse_process_sse_payload(console_response.text)
@@ -810,7 +843,7 @@ class OpenClawAdapter:
                             data = self._parse_process_sse_payload(process_response.text)
                             self.api_variant = "legacy"
                         elif not console_attempted:
-                            console_response = await client.post(self.console_chat_url, json=responses_payload)
+                            console_response = await client.post(self.console_chat_url, json=console_payload)
                             console_response.raise_for_status()
                             data = self._parse_process_sse_payload(console_response.text)
                             self.api_variant = "v2"

--- a/brain/openclaw_adapter.py
+++ b/brain/openclaw_adapter.py
@@ -251,9 +251,6 @@ class OpenClawAdapter:
                             "status_code": response.status_code,
                             "provider": "qwenpaw",
                         }
-                    if response.status_code not in (404, 405):
-                        break
-
                 status_code = response.status_code if response is not None else 503
                 self.last_error = f"HTTP {status_code}"
                 return {

--- a/brain/openclaw_adapter.py
+++ b/brain/openclaw_adapter.py
@@ -821,34 +821,42 @@ class OpenClawAdapter:
                 trust_env=False,
             ) as client:
                 data = None
-                console_attempted = False
+                console_candidate = (self.console_chat_url, console_payload, "sse", "v2")
+                legacy_candidates = (
+                    (self.responses_url, responses_payload, "json", "legacy"),
+                    (self.process_url, process_payload, "sse", "legacy"),
+                )
+                candidates = (
+                    (console_candidate, *legacy_candidates)
+                    if self.api_variant == "v2"
+                    else (*legacy_candidates, console_candidate)
+                )
+                last_response: Optional[httpx.Response] = None
+                last_request_error: Optional[httpx.RequestError] = None
 
-                if self.api_variant == "v2":
-                    console_attempted = True
-                    console_response = await client.post(self.console_chat_url, json=console_payload)
-                    if console_response.status_code not in (404, 405):
-                        console_response.raise_for_status()
-                        data = self._parse_process_sse_payload(console_response.text)
+                for url, payload, response_format, variant in candidates:
+                    try:
+                        response = await client.post(url, json=payload)
+                    except httpx.RequestError as exc:
+                        last_request_error = exc
+                        continue
+                    last_response = response
+                    if response.is_success:
+                        data = (
+                            response.json()
+                            if response_format == "json"
+                            else self._parse_process_sse_payload(response.text)
+                        )
+                        self.api_variant = variant
+                        break
+                    if response.status_code < 500 and response.status_code not in (404, 405):
+                        response.raise_for_status()
 
                 if data is None:
-                    response = await client.post(self.responses_url, json=responses_payload)
-                    if response.status_code not in (404, 405):
-                        response.raise_for_status()
-                        data = response.json()
-                        self.api_variant = "legacy"
-                    else:
-                        process_response = await client.post(self.process_url, json=process_payload)
-                        if process_response.status_code not in (404, 405):
-                            process_response.raise_for_status()
-                            data = self._parse_process_sse_payload(process_response.text)
-                            self.api_variant = "legacy"
-                        elif not console_attempted:
-                            console_response = await client.post(self.console_chat_url, json=console_payload)
-                            console_response.raise_for_status()
-                            data = self._parse_process_sse_payload(console_response.text)
-                            self.api_variant = "v2"
-                        else:
-                            process_response.raise_for_status()
+                    if last_response is not None:
+                        last_response.raise_for_status()
+                    if last_request_error is not None:
+                        raise last_request_error
         except httpx.TimeoutException:
             self.last_error = f"OpenClaw(QwenPaw) request timed out ({self.timeout}s)"
             return {"success": False, "error": self.last_error}

--- a/brain/openclaw_adapter.py
+++ b/brain/openclaw_adapter.py
@@ -18,8 +18,8 @@ OpenClaw Agent adapter.
 
 In this project, "OpenClaw" is the compatibility name for the external
 QwenPaw service. The adapter keeps the existing OpenClaw-facing interface
-for N.E.K.O, while the transport is implemented with QwenPaw's RESTful
-Responses-compatible API.
+for N.E.K.O, while supporting both QwenPaw's legacy Responses-compatible API
+and its v2 console streaming API.
 """
 
 from __future__ import annotations
@@ -47,6 +47,8 @@ QWENPAW_API_PREFIX = "/api/agent"
 QWENPAW_PROCESS_ENDPOINT_PATH = f"{QWENPAW_API_PREFIX}/process"
 QWENPAW_RESPONSES_ENDPOINT_PATH = f"{QWENPAW_API_PREFIX}/compatible-mode/v1/responses"
 QWENPAW_HEALTH_ENDPOINT_PATH = f"{QWENPAW_API_PREFIX}/health"
+QWENPAW_VERSION_ENDPOINT_PATH = "/api/version"
+QWENPAW_CONSOLE_CHAT_ENDPOINT_PATH = "/api/console/chat"
 OPENCLAW_SESSION_CACHE_FILE = "openclaw_sessions.json"
 MAGIC_COMMANDS = frozenset({"/clear", "/new", "/stop", "/daemon approve"})
 MAGIC_COMMAND_REACTIONS = {
@@ -93,6 +95,8 @@ def _resolve_qwenpaw_urls(raw_url: str) -> tuple[str, str, str, str]:
         QWENPAW_PROCESS_ENDPOINT_PATH,
         QWENPAW_RESPONSES_ENDPOINT_PATH,
         QWENPAW_HEALTH_ENDPOINT_PATH,
+        QWENPAW_CONSOLE_CHAT_ENDPOINT_PATH,
+        QWENPAW_VERSION_ENDPOINT_PATH,
         QWENPAW_API_PREFIX,
         "/api",
     ):
@@ -129,6 +133,9 @@ class OpenClawAdapter:
         self.process_url = f"{DEFAULT_OPENCLAW_URL}{QWENPAW_PROCESS_ENDPOINT_PATH}"
         self.responses_url = f"{DEFAULT_OPENCLAW_URL}{QWENPAW_RESPONSES_ENDPOINT_PATH}"
         self.health_url = f"{DEFAULT_OPENCLAW_URL}{QWENPAW_HEALTH_ENDPOINT_PATH}"
+        self.version_url = f"{DEFAULT_OPENCLAW_URL}{QWENPAW_VERSION_ENDPOINT_PATH}"
+        self.console_chat_url = f"{DEFAULT_OPENCLAW_URL}{QWENPAW_CONSOLE_CHAT_ENDPOINT_PATH}"
+        self.api_variant = "unknown"
         self.timeout = DEFAULT_TIMEOUT
         self.http_timeout = max(DEFAULT_TIMEOUT + 15.0, DEFAULT_TIMEOUT)
         self.auth_token = ""
@@ -157,6 +164,8 @@ class OpenClawAdapter:
             self.base_url, self.process_url, self.responses_url, self.health_url = _resolve_qwenpaw_urls(raw_url)
         else:
             self.base_url, self.process_url, self.responses_url, self.health_url = _resolve_qwenpaw_urls(DEFAULT_OPENCLAW_URL)
+        self.version_url = f"{self.base_url}{QWENPAW_VERSION_ENDPOINT_PATH}"
+        self.console_chat_url = f"{self.base_url}{QWENPAW_CONSOLE_CHAT_ENDPOINT_PATH}"
 
         self.timeout = _normalize_timeout(
             cfg.get(
@@ -214,22 +223,44 @@ class OpenClawAdapter:
                 proxy=None,
                 trust_env=False,
             ) as client:
-                response = client.get(self.health_url)
-                if response.is_success:
-                    self.last_error = None
-                    return {
-                        "enabled": True,
-                        "ready": True,
-                        "reasons": [f"OpenClaw(QwenPaw) reachable ({self.health_url})"],
-                        "status_code": response.status_code,
-                        "provider": "qwenpaw",
-                    }
-                self.last_error = f"HTTP {response.status_code}"
+                candidates = (
+                    (self.health_url, "legacy"),
+                    (self.version_url, "v2"),
+                ) if self.api_variant == "legacy" else (
+                    (self.version_url, "v2"),
+                    (self.health_url, "legacy"),
+                )
+                response = None
+                checked_url = candidates[0][0]
+                for checked_url, variant in candidates:
+                    response = client.get(checked_url)
+                    if response.is_success:
+                        if variant == "v2":
+                            try:
+                                version_payload = response.json()
+                            except Exception:
+                                version_payload = None
+                            if not isinstance(version_payload, dict) or not version_payload.get("version"):
+                                continue
+                        self.api_variant = variant
+                        self.last_error = None
+                        return {
+                            "enabled": True,
+                            "ready": True,
+                            "reasons": [f"OpenClaw(QwenPaw) reachable ({checked_url})"],
+                            "status_code": response.status_code,
+                            "provider": "qwenpaw",
+                        }
+                    if response.status_code not in (404, 405):
+                        break
+
+                status_code = response.status_code if response is not None else 503
+                self.last_error = f"HTTP {status_code}"
                 return {
                     "enabled": True,
                     "ready": False,
-                    "reasons": [f"OpenClaw(QwenPaw) responded {response.status_code} ({self.health_url})"],
-                    "status_code": response.status_code,
+                    "reasons": [f"OpenClaw(QwenPaw) responded {status_code} ({checked_url})"],
+                    "status_code": status_code,
                     "provider": "qwenpaw",
                 }
         except Exception as exc:
@@ -616,6 +647,7 @@ class OpenClawAdapter:
     @staticmethod
     def _parse_process_sse_payload(raw_text: str) -> Dict[str, Any]:
         latest: Dict[str, Any] = {}
+        latest_reply: Dict[str, Any] = {}
         for line in str(raw_text or "").splitlines():
             stripped = line.strip()
             if not stripped.startswith("data:"):
@@ -629,7 +661,13 @@ class OpenClawAdapter:
                 continue
             if isinstance(parsed, dict):
                 latest = parsed
-        return latest
+                if parsed.get("object") == "response":
+                    latest_reply = parsed
+                elif parsed.get("object") == "message":
+                    latest_reply = {"message": parsed}
+                elif any(key in parsed for key in ("output", "output_text", "message")):
+                    latest_reply = parsed
+        return latest_reply or latest
 
     def _build_responses_payload(
         self,
@@ -752,14 +790,35 @@ class OpenClawAdapter:
                 proxy=None,
                 trust_env=False,
             ) as client:
-                response = await client.post(self.responses_url, json=responses_payload)
-                if response.status_code in (404, 405):
-                    process_response = await client.post(self.process_url, json=process_payload)
-                    process_response.raise_for_status()
-                    data = self._parse_process_sse_payload(process_response.text)
-                else:
-                    response.raise_for_status()
-                    data = response.json()
+                data = None
+                console_attempted = False
+
+                if self.api_variant == "v2":
+                    console_attempted = True
+                    console_response = await client.post(self.console_chat_url, json=responses_payload)
+                    if console_response.status_code not in (404, 405):
+                        console_response.raise_for_status()
+                        data = self._parse_process_sse_payload(console_response.text)
+
+                if data is None:
+                    response = await client.post(self.responses_url, json=responses_payload)
+                    if response.status_code not in (404, 405):
+                        response.raise_for_status()
+                        data = response.json()
+                        self.api_variant = "legacy"
+                    else:
+                        process_response = await client.post(self.process_url, json=process_payload)
+                        if process_response.status_code not in (404, 405):
+                            process_response.raise_for_status()
+                            data = self._parse_process_sse_payload(process_response.text)
+                            self.api_variant = "legacy"
+                        elif not console_attempted:
+                            console_response = await client.post(self.console_chat_url, json=responses_payload)
+                            console_response.raise_for_status()
+                            data = self._parse_process_sse_payload(console_response.text)
+                            self.api_variant = "v2"
+                        else:
+                            process_response.raise_for_status()
         except httpx.TimeoutException:
             self.last_error = f"OpenClaw(QwenPaw) request timed out ({self.timeout}s)"
             return {"success": False, "error": self.last_error}

--- a/tests/unit/test_openclaw_adapter_protocol.py
+++ b/tests/unit/test_openclaw_adapter_protocol.py
@@ -68,6 +68,45 @@ def test_availability_falls_back_to_legacy_health_after_version_server_error(mon
     ]
 
 
+def test_availability_falls_back_after_version_transport_error(monkeypatch):
+    adapter = _adapter_for_protocol_test()
+    client = MagicMock()
+    client.get.side_effect = (
+        httpx.ConnectTimeout(
+            "version probe timed out",
+            request=httpx.Request("GET", adapter.version_url),
+        ),
+        httpx.Response(200, json={"status": "ok"}),
+    )
+    context = MagicMock()
+    context.__enter__.return_value = client
+    monkeypatch.setattr(httpx, "Client", MagicMock(return_value=context))
+
+    result = adapter.is_available()
+
+    assert result["ready"] is True
+    assert adapter.api_variant == "legacy"
+    assert client.get.call_count == 2
+
+
+def test_console_payload_uses_qwenpaw_runtime_content_types():
+    adapter = _adapter_for_protocol_test()
+
+    payload = adapter._build_console_payload(
+        session_id="stable-session",
+        user_id="user-a",
+        channel="console",
+        instruction="describe this image",
+        attachments=[{"url": "data:image/png;base64,abc"}],
+    )
+
+    assert payload["user_id"] == "user-a"
+    assert payload["input"][0]["content"] == [
+        {"type": "text", "text": "describe this image"},
+        {"type": "image", "image_url": "data:image/png;base64,abc"},
+    ]
+
+
 def test_sse_parser_keeps_completed_response_before_trailing_usage():
     payload = "\n".join(
         (

--- a/tests/unit/test_openclaw_adapter_protocol.py
+++ b/tests/unit/test_openclaw_adapter_protocol.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 import httpx
+import pytest
 
 from brain.openclaw_adapter import OpenClawAdapter, _resolve_qwenpaw_urls
 
@@ -15,6 +16,10 @@ def _adapter_for_protocol_test() -> OpenClawAdapter:
     adapter.console_chat_url = f"{adapter.base_url}/api/console/chat"
     adapter.api_variant = "unknown"
     adapter.auth_token = ""
+    adapter.default_sender_id = "neko_user"
+    adapter.default_channel = "console"
+    adapter.timeout = 300.0
+    adapter.http_timeout = 315.0
     adapter.last_error = None
     adapter.reload_config = lambda: None
     return adapter
@@ -104,6 +109,59 @@ def test_console_payload_uses_qwenpaw_runtime_content_types():
     assert payload["input"][0]["content"] == [
         {"type": "text", "text": "describe this image"},
         {"type": "image", "image_url": "data:image/png;base64,abc"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_v2_console_server_error_falls_back_to_legacy_process(monkeypatch):
+    adapter = _adapter_for_protocol_test()
+    adapter.api_variant = "v2"
+    responses = [
+        httpx.Response(
+            503,
+            request=httpx.Request("POST", adapter.console_chat_url),
+        ),
+        httpx.Response(
+            404,
+            request=httpx.Request("POST", adapter.responses_url),
+        ),
+        httpx.Response(
+            200,
+            text='data: {"object":"response","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"text","text":"legacy fallback"}]}]}\n\n',
+            request=httpx.Request("POST", adapter.process_url),
+        ),
+    ]
+
+    class FakeAsyncClient:
+        def __init__(self):
+            self.calls = []
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+        async def post(self, url, *, json):
+            self.calls.append((url, json))
+            return responses.pop(0)
+
+    client = FakeAsyncClient()
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **kwargs: client)
+
+    result = await adapter.run_instruction(
+        "do the task",
+        sender_id="user-a",
+        session_id="stable-session",
+    )
+
+    assert result["success"] is True
+    assert result["reply"] == "legacy fallback"
+    assert adapter.api_variant == "legacy"
+    assert [url for url, _ in client.calls] == [
+        adapter.console_chat_url,
+        adapter.responses_url,
+        adapter.process_url,
     ]
 
 

--- a/tests/unit/test_openclaw_adapter_protocol.py
+++ b/tests/unit/test_openclaw_adapter_protocol.py
@@ -1,0 +1,61 @@
+from unittest.mock import MagicMock
+
+import httpx
+
+from brain.openclaw_adapter import OpenClawAdapter, _resolve_qwenpaw_urls
+
+
+def _adapter_for_protocol_test() -> OpenClawAdapter:
+    adapter = object.__new__(OpenClawAdapter)
+    adapter.base_url = "http://127.0.0.1:8088"
+    adapter.process_url = f"{adapter.base_url}/api/agent/process"
+    adapter.responses_url = f"{adapter.base_url}/api/agent/compatible-mode/v1/responses"
+    adapter.health_url = f"{adapter.base_url}/api/agent/health"
+    adapter.version_url = f"{adapter.base_url}/api/version"
+    adapter.console_chat_url = f"{adapter.base_url}/api/console/chat"
+    adapter.api_variant = "unknown"
+    adapter.auth_token = ""
+    adapter.last_error = None
+    adapter.reload_config = lambda: None
+    return adapter
+
+
+def test_resolve_qwenpaw_url_accepts_v2_endpoint():
+    base_url, process_url, responses_url, health_url = _resolve_qwenpaw_urls(
+        "http://127.0.0.1:8088/api/console/chat"
+    )
+
+    assert base_url == "http://127.0.0.1:8088"
+    assert process_url == "http://127.0.0.1:8088/api/agent/process"
+    assert responses_url.endswith("/api/agent/compatible-mode/v1/responses")
+    assert health_url == "http://127.0.0.1:8088/api/agent/health"
+
+
+def test_availability_prefers_qwenpaw_v2_version_endpoint(monkeypatch):
+    adapter = _adapter_for_protocol_test()
+    response = httpx.Response(200, json={"version": "2.0.0"})
+    client = MagicMock()
+    client.get.return_value = response
+    context = MagicMock()
+    context.__enter__.return_value = client
+    monkeypatch.setattr(httpx, "Client", MagicMock(return_value=context))
+
+    result = adapter.is_available()
+
+    assert result["ready"] is True
+    assert adapter.api_variant == "v2"
+    client.get.assert_called_once_with("http://127.0.0.1:8088/api/version")
+
+
+def test_sse_parser_keeps_completed_response_before_trailing_usage():
+    payload = "\n".join(
+        (
+            'data: {"object":"response","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"text","text":"done"}]}]}',
+            'data: {"type":"turn_usage","usage":{"total_tokens":12}}',
+        )
+    )
+
+    parsed = OpenClawAdapter._parse_process_sse_payload(payload)
+
+    assert parsed["object"] == "response"
+    assert OpenClawAdapter._extract_reply_text(_adapter_for_protocol_test(), parsed) == "done"

--- a/tests/unit/test_openclaw_adapter_protocol.py
+++ b/tests/unit/test_openclaw_adapter_protocol.py
@@ -47,6 +47,27 @@ def test_availability_prefers_qwenpaw_v2_version_endpoint(monkeypatch):
     client.get.assert_called_once_with("http://127.0.0.1:8088/api/version")
 
 
+def test_availability_falls_back_to_legacy_health_after_version_server_error(monkeypatch):
+    adapter = _adapter_for_protocol_test()
+    client = MagicMock()
+    client.get.side_effect = (
+        httpx.Response(503, json={"detail": "not supported"}),
+        httpx.Response(200, json={"status": "ok"}),
+    )
+    context = MagicMock()
+    context.__enter__.return_value = client
+    monkeypatch.setattr(httpx, "Client", MagicMock(return_value=context))
+
+    result = adapter.is_available()
+
+    assert result["ready"] is True
+    assert adapter.api_variant == "legacy"
+    assert [call.args[0] for call in client.get.call_args_list] == [
+        "http://127.0.0.1:8088/api/version",
+        "http://127.0.0.1:8088/api/agent/health",
+    ]
+
+
 def test_sse_parser_keeps_completed_response_before_trailing_usage():
     payload = "\n".join(
         (


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

兼容 QwenPaw 2.0 健康检查与聊天接口，保留旧版协议支持，并修复流式响应解析

## 测试 / Testing

手动测试


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 扩展适配：支持 QwenPaw v2 版本端点与 v2 控制台流式接口，并兼容 Responses 兼容模式。
  * 初始化时补齐 v2 端点信息，自动识别并切换协议变体；控制台载荷按运行时内容类型生成（文本/图片）。
* **Bug 修复**
  * 流式 SSE 归一化与回复提取优化，确保 completed 回复在 trailing usage 后仍能正确保留。
  * 指令请求增加基于协议变体的回退策略，按顺序重试并在失败时可靠抛出/上报。
* **测试**
  * 新增协议层单元测试：URL 解析、v2 优先探测与回退（含服务端错误/传输异常）、控制台载荷映射与 SSE 场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->