### PR TITLE
refactor(main_logic): core.py 拆分为 core/ 包（阶段一：纯搬模块级代码）

### DIFF
--- a/main_logic/core/__init__.py
+++ b/main_logic/core/__init__.py
@@ -155,9 +155,21 @@ import httpx
 
 
 # Re-exports from the package submodules. Everything the old single-file
-# module defined at top level stays importable/patchable as
-# ``main_logic.core.<name>``. State-carrying objects (the notice queue/lock,
-# the ``_proactive_expected_sid`` ContextVar, ``_notified_legacy_voices``) are
+# module defined at top level stays importable as ``main_logic.core.<name>``.
+#
+# Rebind/monkeypatch semantics: rebinding a facade attribute only affects
+# consumers whose code lives in THIS module -- i.e. ``LLMSessionManager``,
+# which is why the class stays here and every historical
+# ``monkeypatch.setattr("main_logic.core.<attr>", ...)`` site keeps working.
+# Code moved into a submodule reads its own module globals, so to stub a
+# symbol as seen by a moved helper (e.g. ``_loc`` inside ``callback_render``),
+# patch that submodule directly -- same contract as
+# ``main_routers/system_router`` (#2148). No such patch site exists today
+# (the old module early-bound those names from ``config.prompts.prompts_sys``
+# anyway, so rebinding them on the source module never propagated either).
+#
+# State-carrying objects (the notice queue/lock, the
+# ``_proactive_expected_sid`` ContextVar, ``_notified_legacy_voices``) are
 # re-exported by reference; their single owner is the defining submodule.
 # ``notices._prominent_notice_seq`` is intentionally NOT re-exported: the
 # owner rebinds that int on every enqueue, so a facade snapshot would go

--- a/main_logic/core/__init__.py
+++ b/main_logic/core/__init__.py
@@ -11,11 +11,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 This is the main logic file, responsible for managing the entire conversation flow. When TTS is not selected, the Omni model's native speech output is used via the OpenAI-compatible interface.
 When TTS is selected, speech is synthesized through an extra TTS API. Note that the TTS API output is streamed and must interact with user input to implement interruption logic.
 The TTS part uses two queues; one would normally suffice, but Aliyun's TTS API callbacks only support synchronous functions, so a response queue was added to asynchronously send audio data to the frontend.
+
+Package layout (split from the former single-file ``main_logic/core.py``; the
+import path ``main_logic.core`` is unchanged):
+
+- ``_shared``: module-level constants, the package logger, and small pure
+  helpers shared across the package.
+- ``callback_render``: pure rendering helpers for agent-task callbacks and
+  voice-swap injection strings.
+- ``notices``: the prominent-notice buffer pool (single owner of the queue
+  state).
+- ``__init__``: ``LLMSessionManager`` itself, plus re-exports of every
+  top-level name of the old module so existing imports and test monkeypatches
+  (``main_logic.core.<attr>``) keep working unchanged -- the class's global
+  lookups read this module's namespace at call time, which is exactly what
+  tests patch.
 """
 import asyncio
 import contextvars
@@ -106,482 +120,6 @@ from config.prompts.prompts_memory import (
     RECALL_MEMORY_TOOL_FOUND_HEADER,
 )
 
-# Sentinel for `send_lanlan_response(request_id=...)` so we can tell apart
-# "caller didn't pass it (use shared field as fallback)" from "caller
-# explicitly passed None to mean 'no request id'". A normal default of
-# None collapses both into the same code path and would let recovery /
-# proactive paths accidentally bind their messages to a newer request_id.
-_REQUEST_ID_UNSET: Any = object()
-_MAGIC_COMMAND_IMAGE_DROP_REQUEST_MAX = 64
-_VOICE_PROACTIVE_ACK_GRACE_S = 0.05
-_TEXT_SESSION_INPUT_TYPES = frozenset({"text", "avatar_drop_image", "user_image"})
-_IMAGE_INPUT_TYPES = frozenset({"screen", "camera", "avatar_drop_image", "user_image"})
-_LIVE_VISION_STREAM_INPUT_TYPES = frozenset({"screen", "camera"})
-_CONTEXT_APPEND_DEDUP_TTL_SECONDS = 120.0
-_CONTEXT_APPEND_DEDUP_MAX_ENTRIES = 256
-_CONTEXT_APPEND_READY_FLUSH_MAX_PASSES = 8
-_CONTEXT_APPEND_DEFAULT_MAX_TOKENS = 1000
-_CONTEXT_APPEND_SOURCE_MAX_TOKENS = {
-    "game.icebreaker": 500,
-    "game.scripted": 1000,
-    "game.realtime_context": 1000,
-    "game.postgame": 1500,
-    "proactive.context": 1000,
-    "proactive.callback": 1000,
-    "topic.hook": 1000,
-    "topic.material": 1000,
-    "realtime.prime": 1000,
-}
-_CONTEXT_APPEND_BARE_PRIME_SOURCES = frozenset({
-    "game.realtime_context",
-    "game.postgame",
-})
-
-
-# 内部 item 渲染时的视觉标记。状态信息已在外层 SYSTEM_NOTIFICATION_TASK_ACTIVE
-# 表达，emoji 仅作快速视觉识别用。
-_STATUS_EMOJI = {
-    "completed": "✅",
-    "partial": "⚠️",
-    "blocked": "⚠️",
-    "failed": "❌",
-    "cancelled": "🚫",
-}
-
-_VOICE_ECHO_LOOKBACK_SECONDS = 20.0
-_VOICE_ECHO_LOOKBACK_CHARS = 1200
-_VOICE_ECHO_MIN_NORMALIZED_CHARS = 6
-_VOICE_ECHO_MIN_WINDOW_CHARS = 10
-_VOICE_ECHO_SIMILARITY_THRESHOLD = 0.88
-_VOICE_ECHO_NORMALIZE_RE = re.compile(r"[\W_]+", re.UNICODE)
-
-
-def _normalize_voice_echo_text(text: str) -> str:
-    return _VOICE_ECHO_NORMALIZE_RE.sub("", str(text or "").casefold())
-
-
-def _looks_like_recent_ai_echo(transcript: str, recent_ai_text: str) -> bool:
-    """Return True when STT text is probably the assistant's own recent audio.
-
-    This intentionally requires a close text match. Voice barge-in during AI
-    playback should keep flowing unless it resembles the AI text that was just
-    rendered/spoken.
-    """
-    transcript_norm = _normalize_voice_echo_text(transcript)
-    if len(transcript_norm) < _VOICE_ECHO_MIN_NORMALIZED_CHARS:
-        return False
-    recent_norm = _normalize_voice_echo_text(recent_ai_text)
-    if len(recent_norm) < _VOICE_ECHO_MIN_NORMALIZED_CHARS:
-        return False
-    if len(transcript_norm) > len(recent_norm):
-        return SequenceMatcher(None, transcript_norm, recent_norm).ratio() >= _VOICE_ECHO_SIMILARITY_THRESHOLD
-    if len(transcript_norm) < _VOICE_ECHO_MIN_WINDOW_CHARS:
-        return False
-    if transcript_norm in recent_norm:
-        return True
-
-    window_len = len(transcript_norm)
-    step = max(1, window_len // 3)
-    best = 0.0
-    last_start = len(recent_norm) - window_len
-    starts = list(range(0, last_start + 1, step))
-    if not starts or starts[-1] != last_start:
-        starts.append(last_start)
-    for start in starts:
-        candidate = recent_norm[start:start + window_len]
-        best = max(best, SequenceMatcher(None, transcript_norm, candidate).ratio())
-        if best >= _VOICE_ECHO_SIMILARITY_THRESHOLD:
-            return True
-    return False
-
-
-def _format_callback_source(cb: dict, lang: str) -> str:
-    """Render an agent_task_callback's source as user-facing text in ``lang``.
-
-    Reads ``cb["source_kind"]`` (one of SOURCE_DESCRIPTORS keys) and
-    ``cb["source_name"]`` (free-form string used as ``{name}`` slot). Falls
-    back to the ``unknown`` descriptor for missing/unrecognized kinds.
-    """
-    kind = (cb.get("source_kind") or "unknown").strip()
-    descriptor = SOURCE_DESCRIPTORS.get(kind) or SOURCE_DESCRIPTORS["unknown"]
-    name = (cb.get("source_name") or "").strip()
-    return _loc(descriptor, lang).format(name=name)
-
-
-def apply_role_placeholders(
-    text: str,
-    *,
-    lanlan_name: str = "",
-    master_name: str = "",
-) -> str:
-    """Substitute ``{MASTER_NAME}`` / ``{LANLAN_NAME}`` placeholders in
-    plugin-supplied text at the LLM-injection boundary.
-
-    Plugin authors don't know which ``LLMSessionManager`` (and therefore which
-    ``master_name`` / ``lanlan_name`` pair) the text will route to — that's a
-    host-side visibility decision. So the canonical contract is:
-
-        plugin writes ``"Report to {MASTER_NAME}…"`` →
-        host expands at the injection site, per session.
-
-    Uses ``str.replace`` rather than ``str.format`` so that other braces in
-    the text (JSON fragments, code snippets, user content containing stray
-    ``{``) don't raise ``KeyError``. Empty names short-circuit — the
-    placeholder is left in place rather than replaced with ``""``, on the
-    theory that the literal token is less misleading than an empty hole.
-
-    This is the SINGLE source of truth for the placeholder contract. New
-    plugin-text injection sites should funnel through this helper.
-    """
-    if not text:
-        return text
-    if isinstance(master_name, str) and master_name:
-        text = text.replace("{MASTER_NAME}", master_name)
-    if isinstance(lanlan_name, str) and lanlan_name:
-        text = text.replace("{LANLAN_NAME}", lanlan_name)
-    return text
-
-
-def _render_callback_inner_item(
-    cb: dict,
-    lang: str,
-    *,
-    lanlan_name: str = "",
-    master_name: str = "",
-) -> str:
-    """Render one callback as a single inline string for the LLM prompt.
-
-    Returns ``""`` when there is genuinely nothing to convey (both summary
-    and detail empty); the caller can then drop the line and rely on the
-    outer header alone to express that something happened.
-
-    Plugin-supplied ``summary``/``detail`` may contain ``{MASTER_NAME}`` /
-    ``{LANLAN_NAME}`` placeholders; see :func:`apply_role_placeholders`.
-    """
-    summary = apply_role_placeholders(
-        (cb.get("summary") or "").strip(),
-        lanlan_name=lanlan_name, master_name=master_name,
-    )
-    detail = apply_role_placeholders(
-        (cb.get("detail") or "").strip(),
-        lanlan_name=lanlan_name, master_name=master_name,
-    )
-    text = summary or detail
-    if not text:
-        return ""
-    status = cb.get("status") or "completed"
-    emoji = _STATUS_EMOJI.get(status, "•")
-    line = f"{emoji} {text}"
-    if summary and detail and detail != summary and len(detail) > len(summary):
-        label = _loc(RESULT_PARSER_PHRASES["detail_result"], lang)
-        line += f"\n{label}{detail}"
-    return line
-
-
-def _build_callback_instruction(
-    callbacks,
-    *,
-    lang: str,
-    lanlan_name: str,
-    master_name: str,
-    passive: bool = False,
-) -> str:
-    """Render a list of agent_task_callbacks into the LLM injection string.
-
-    Each callback carries an ``origin`` tag stamped by the host at the
-    EventBus → callback boundary:
-      - ``"task_result"`` — real task completion (agent_server._emit_task_result),
-        e.g. Computer Use / Browser Use / plugin entry / MCP tool result.
-      - ``"event"`` — plugin push_message stream (proactive_bridge),
-        e.g. danmaku / gift / external notification.
-
-    Plugin authors cannot set ``origin``; it is derived structurally from
-    which SDK method they called (``finish()`` vs ``push_message()``) by
-    way of the event_type the upstream producer emitted.
-
-    Two axes (origin × passive) pick one of four outer templates:
-
-    +--------------+----------------------+-----------------------------+
-    | origin       | active (proactive)   | passive                     |
-    +==============+======================+=============================+
-    | task_result  | TASK_ACTIVE          | TASK_PASSIVE                |
-    |              | ("done, report it")  | ("task result")             |
-    +--------------+----------------------+-----------------------------+
-    | event        | EVENT_ACTIVE         | EVENT_PASSIVE               |
-    |              | ("new msg, respond") | ("message")                 |
-    +--------------+----------------------+-----------------------------+
-
-    Unknown origin defaults to ``"event"`` + warning. Rationale: rather
-    have the AI naturally react than fabricate "I completed a task".
-
-    Callbacks are grouped by (passive, origin, status, source) so each
-    group can pick the right outer template and (for task_result+active)
-    slot in the right status/action phrases. Event templates ignore
-    status/action — the concept doesn't apply to passive event streams.
-    """
-    if not callbacks:
-        return ""
-    from collections import OrderedDict
-
-    grouped: "OrderedDict[tuple, list]" = OrderedDict()
-    for cb in callbacks:
-        # passive=True call = drain path; treat all as passive regardless
-        # of per-callback delivery_mode.
-        cb_passive = passive or (cb.get("delivery_mode") == "passive")
-        origin = cb.get("origin")
-        if origin not in ("task_result", "event"):
-            if origin:
-                logger.warning(
-                    "[callback_instruction] unknown origin=%r, falling back to 'event'; "
-                    "source=%s/%s",
-                    origin, cb.get("source_kind"), cb.get("source_name"),
-                )
-            origin = "event"
-        key = (
-            cb_passive,
-            origin,
-            cb.get("status") or "completed",
-            cb.get("source_kind") or "unknown",
-            (cb.get("source_name") or ""),
-        )
-        grouped.setdefault(key, []).append(cb)
-
-    parts: list[str] = []
-    for (cb_passive, origin, status, _src_kind, _src_name), cbs in grouped.items():
-        source_text = _format_callback_source(cbs[0], lang)
-        if origin == "task_result":
-            if cb_passive:
-                header = _loc(SYSTEM_NOTIFICATION_TASK_PASSIVE, lang).format(source=source_text)
-            else:
-                status_phrase = _loc(
-                    TASK_STATUS_PHRASES.get(status) or TASK_STATUS_PHRASES["completed"],
-                    lang,
-                )
-                action_phrase = _loc(
-                    TASK_ACTION_PHRASES.get(status) or TASK_ACTION_PHRASES["completed"],
-                    lang,
-                )
-                header = _loc(SYSTEM_NOTIFICATION_TASK_ACTIVE, lang).format(
-                    source=source_text,
-                    status_phrase=status_phrase,
-                    action_phrase=action_phrase,
-                    name=lanlan_name,
-                    master=master_name,
-                )
-        else:  # origin == "event"
-            if cb_passive:
-                header = _loc(SYSTEM_NOTIFICATION_EVENT_PASSIVE, lang).format(source=source_text)
-            else:
-                header = _loc(SYSTEM_NOTIFICATION_EVENT_ACTIVE, lang).format(
-                    source=source_text,
-                    name=lanlan_name,
-                    master=master_name,
-                )
-        items = [
-            _render_callback_inner_item(
-                cb, lang, lanlan_name=lanlan_name, master_name=master_name,
-            )
-            for cb in cbs
-        ]
-        items = [s for s in items if s]
-        if items:
-            parts.append(header + "\n".join(items))
-        else:
-            # No item text — outer header alone (e.g. "task X failed") still
-            # tells the AI that something happened. Strip trailing newline so
-            # the joined output is clean.
-            parts.append(header.rstrip())
-    rendered = "\n\n".join(parts)
-    # Total input budget: many callbacks accumulating must not blow up the turn.
-    from utils.tokenize import truncate_to_tokens
-    from config import AGENT_CALLBACK_TOTAL_MAX_TOKENS
-    return truncate_to_tokens(rendered, AGENT_CALLBACK_TOTAL_MAX_TOKENS)
-
-
-def _format_voice_swap_item(
-    entry: dict,
-    lang: str,
-    *,
-    lanlan_name: str = "",
-    master_name: str = "",
-) -> str:
-    """Render a single voice-mode pending_extra_replies entry to a bulleted
-    line for the hot-swap injection.
-
-    Priority: ``summary`` → ``detail`` → synthesized "{status_phrase} from
-    {source}[: error_message]" placeholder. The placeholder path matters for
-    failure callbacks whose body is empty — without it, header information
-    like "execution failed / from plugin X / Connection refused" would be
-    silently dropped (the voice-mode equivalent of the header-only branch in
-    ``_build_callback_instruction``).
-
-    Plugin-supplied ``summary``/``detail`` may contain ``{MASTER_NAME}`` /
-    ``{LANLAN_NAME}`` placeholders; see :func:`apply_role_placeholders`. The
-    synthesized placeholder fallback uses host-side localized phrases so it
-    needs no role substitution.
-
-    Returns ``""`` when the entry is genuinely empty (no body, no error, and
-    a benign ``completed`` status) — caller filters those out.
-    """
-    summary = apply_role_placeholders(
-        (entry.get("summary") or "").strip(),
-        lanlan_name=lanlan_name, master_name=master_name,
-    )
-    detail = apply_role_placeholders(
-        (entry.get("detail") or "").strip(),
-        lanlan_name=lanlan_name, master_name=master_name,
-    )
-    text = summary or detail
-    status = entry.get("status") or "completed"
-    emoji = _STATUS_EMOJI.get(status, "•")
-
-    if text:
-        return f"- {emoji} {text}"
-
-    # No body text — synthesize from header info so the failure status
-    # doesn't disappear silently.
-    error_message = (entry.get("error_message") or "").strip()
-    source_name = (entry.get("source_name") or "").strip()
-    if not error_message and not source_name and status == "completed":
-        # Truly nothing to convey; drop. (enqueue_agent_callback already
-        # filters these out, but be defensive against legacy entries.)
-        return ""
-
-    source_text = _format_callback_source(entry, lang)
-    status_phrase = _loc(
-        TASK_STATUS_PHRASES.get(status) or TASK_STATUS_PHRASES["completed"],
-        lang,
-    )
-    line = f"- {emoji} {source_text} {status_phrase}"
-    if error_message:
-        line += f"：{error_message}"
-    return line
-
-
-def _render_pending_extra_replies_by_origin(
-    entries,
-    *,
-    lang: str,
-    lanlan_name: str,
-    master_name: str,
-) -> str:
-    """Render voice-mode ``pending_extra_replies`` into the hot-swap injection
-    string, grouped by ``origin``.
-
-    Each entry should be a structured dict with at least ``origin``;
-    ``summary``/``detail``/``status``/``source_kind``/``source_name``/
-    ``error_message`` are consumed by :func:`_format_voice_swap_item`. Legacy
-    plain-string entries (pre-migration code paths) are tolerated and
-    treated as ``origin="event"`` event-stream content — the safer default,
-    since the "report the result of a previously executed task" framing on
-    what may actually be a push event is the bug this refactor fixes.
-
-    Returns a single string suitable for appending to ``final_prime_text``.
-    Order: task block first (if any), then event block — matches the original
-    single-block placement where everything followed the cache dump.
-    """
-    if not entries:
-        return ""
-
-    task_entries: list[dict] = []
-    event_entries: list[dict] = []
-    for entry in entries:
-        if isinstance(entry, dict):
-            normalized = dict(entry)
-            origin = normalized.get("origin")
-            if origin not in ("task_result", "event"):
-                normalized["origin"] = "event"  # fail-safe
-                origin = "event"
-            if origin == "task_result":
-                task_entries.append(normalized)
-            else:
-                event_entries.append(normalized)
-        elif isinstance(entry, str):
-            stripped = entry.strip()
-            if stripped:
-                event_entries.append({
-                    "origin": "event",
-                    "summary": stripped,
-                    "detail": "",
-                    "status": "completed",
-                    "source_kind": "unknown",
-                    "source_name": "",
-                    "error_message": "",
-                })
-
-    blocks: list[str] = []
-    if task_entries:
-        items = [
-            _format_voice_swap_item(e, lang, lanlan_name=lanlan_name, master_name=master_name)
-            for e in task_entries
-        ]
-        items = [s for s in items if s]
-        if items:
-            blocks.append(
-                _loc(CONTEXT_SUMMARY_TASK_HEADER, lang).format(name=lanlan_name, master=master_name)
-                + "\n".join(items)
-                + _loc(CONTEXT_SUMMARY_TASK_FOOTER, lang)
-            )
-    if event_entries:
-        items = [
-            _format_voice_swap_item(e, lang, lanlan_name=lanlan_name, master_name=master_name)
-            for e in event_entries
-        ]
-        items = [s for s in items if s]
-        if items:
-            blocks.append(
-                _loc(CONTEXT_SUMMARY_EVENT_HEADER, lang).format(name=lanlan_name, master=master_name)
-                + "\n".join(items)
-                + _loc(CONTEXT_SUMMARY_EVENT_FOOTER, lang)
-            )
-    rendered = "".join(blocks)
-    # Total input budget for the voice hot-swap injection (mirror of the
-    # text-mode cap in _build_callback_instruction). Backstop only — callers
-    # should pre-select within budget via _select_callbacks_within_token_budget
-    # so whole callbacks are never silently dropped after a successful ack.
-    from utils.tokenize import truncate_to_tokens
-    from config import AGENT_CALLBACK_TOTAL_MAX_TOKENS
-    return truncate_to_tokens(rendered, AGENT_CALLBACK_TOTAL_MAX_TOKENS)
-
-
-def _select_callbacks_within_token_budget(callbacks, total_budget):
-    """Greedily take the oldest prefix of ``callbacks`` whose cumulative
-    summary/detail token count stays within ``total_budget``.
-
-    Returns ``(selected, deferred)``. Always selects at least one item so the
-    queue makes forward progress (each item is already per-item capped at
-    enqueue). The point: a caller that acks + clears must ack/clear only the
-    *selected* items and re-queue ``deferred`` for the next turn — otherwise
-    callbacks beyond the cap would be acked as delivered but never reach the
-    model (see PR review)."""
-    from utils.tokenize import count_tokens
-    # Per-item overhead for the emoji/bullet, the per-group outer header, and the
-    # template wrapper that the renderer adds around the body. Over-counting is
-    # the SAFE direction: we select fewer, so the rendered instruction stays
-    # under budget and the builder's backstop truncation never cuts an already
-    # selected (and acked) callback.
-    _ITEM_OVERHEAD_TOKENS = 48
-    selected: list = []
-    used = 0
-    for i, cb in enumerate(callbacks):
-        if isinstance(cb, dict):
-            # Count every field the renderer may emit — body line (summary or
-            # detail) plus the error/source fallback line — not just summary.
-            t = (
-                count_tokens(cb.get("summary") or "")
-                + count_tokens(cb.get("detail") or "")
-                + count_tokens(cb.get("error_message") or "")
-                + count_tokens(cb.get("source_name") or "")
-                + _ITEM_OVERHEAD_TOKENS
-            )
-        else:
-            t = count_tokens(str(cb)) + _ITEM_OVERHEAD_TOKENS
-        if selected and used + t > total_budget:
-            return selected, list(callbacks[i:])
-        selected.append(cb)
-        used += t
-    return selected, []
-
 
 from config.prompts.prompts_avatar_interaction import (
     _normalize_avatar_interaction_payload,
@@ -615,241 +153,73 @@ import numpy as np
 import soxr
 import httpx
 
-# Setup logger for this module
-logger = get_module_logger(__name__, "Main")
 
-# 用户静默达到此阈值 → 后台 loop 主动 end_session，让下一条消息触发
-# start_session(new=False) 重新拉 /new_dialog 注入新鲜时间/长间隔提示/节日
-# 上下文，解决长挂机 session 上下文僵化（"猫娘还停留在前一晚"）的问题。
-# 周期检查间隔故意远小于阈值（粒度 ~1 min），避免静默 30:01 时还要再等
-# 一整轮。
-IDLE_SESSION_RESET_THRESHOLD_SECONDS = 1800
-IDLE_SESSION_RESET_CHECK_INTERVAL_SECONDS = 60
-
-# 前端文本会话 start_session 等 session_started 的硬超时（static/app-buttons.js
-# 的 setTimeout(..., 15000)）。start_session 去重路径等 in-flight 启动落定后给
-# 本请求补发 ack 时，等待上限绑到这个值：超过前端这个超时再补发 session_started
-# 已无意义（前端早已 reject 并发 end_session），故以它为有意义窗口的天然上界。
-FRONTEND_START_SESSION_TIMEOUT_SECONDS = 15.0
-
-# 跨模式重启时「等 in-flight 落定」的等待上限。必须明显短于前端超时：等完之后
-# 还要花几秒真正起目标模式会话（含最坏 ~12s 的 TTS 就绪等待），若把大半个 15s 都
-# 耗在等待上，重启发出的 session_started 会晚于前端 deadline，前端照样超时、甚至
-# reset 后才收到 ack 起孤儿会话（Codex P2）。取前端超时的一半，给重启留 ~7.5s 余量；
-# in-flight 没在这窗口内落定就放弃（回落 baseline：前端超时、无孤儿）。in-flight
-# （text）正常 1~3s 落定，远在窗口内。注：TTS 冷启动叠加 in-flight 贴线落定的双重
-# 最坏情形仍可能溢出 15s，此时由 start_session 末尾的连接/放弃校验与重启侧守卫兜底。
-CROSS_MODE_RESTART_WAIT_SECONDS = FRONTEND_START_SESSION_TIMEOUT_SECONDS / 2
-
-# 主动搭话（proactive）调用 prompt_ephemeral 时设置的 sid 期望值。
-# 目的：prompt_ephemeral 内部通过 on_text_delta=handle_text_data 回调 enqueue TTS，
-# 中间可能被用户输入抢占（user stream_text 清 queue + 换 current_speech_id）。
-# handle_text_data / handle_output_transcript 检查此 contextvar：若已设置且与
-# current_speech_id 不符，说明本路径生成的 chunk 已不属于当前轮次，必须丢弃
-# 以免 proactive 文本被错打上用户新 sid 混进用户回复 TTS。
-# contextvar 是 per-task 隔离，不会泄漏到用户 stream_text 所在的独立任务。
-_proactive_expected_sid: contextvars.ContextVar[str | None] = contextvars.ContextVar(
-    '_proactive_expected_sid', default=None,
+# Re-exports from the package submodules. Everything the old single-file
+# module defined at top level stays importable/patchable as
+# ``main_logic.core.<name>``. State-carrying objects (the notice queue/lock,
+# the ``_proactive_expected_sid`` ContextVar, ``_notified_legacy_voices``) are
+# re-exported by reference; their single owner is the defining submodule.
+# ``notices._prominent_notice_seq`` is intentionally NOT re-exported: the
+# owner rebinds that int on every enqueue, so a facade snapshot would go
+# stale immediately (no external reader exists).
+from ._shared import (  # noqa: F401
+    _REQUEST_ID_UNSET,
+    _MAGIC_COMMAND_IMAGE_DROP_REQUEST_MAX,
+    _VOICE_PROACTIVE_ACK_GRACE_S,
+    _TEXT_SESSION_INPUT_TYPES,
+    _IMAGE_INPUT_TYPES,
+    _LIVE_VISION_STREAM_INPUT_TYPES,
+    _CONTEXT_APPEND_DEDUP_TTL_SECONDS,
+    _CONTEXT_APPEND_DEDUP_MAX_ENTRIES,
+    _CONTEXT_APPEND_READY_FLUSH_MAX_PASSES,
+    _CONTEXT_APPEND_DEFAULT_MAX_TOKENS,
+    _CONTEXT_APPEND_SOURCE_MAX_TOKENS,
+    _CONTEXT_APPEND_BARE_PRIME_SOURCES,
+    _VOICE_ECHO_LOOKBACK_SECONDS,
+    _VOICE_ECHO_LOOKBACK_CHARS,
+    _VOICE_ECHO_MIN_NORMALIZED_CHARS,
+    _VOICE_ECHO_MIN_WINDOW_CHARS,
+    _VOICE_ECHO_SIMILARITY_THRESHOLD,
+    _VOICE_ECHO_NORMALIZE_RE,
+    _normalize_voice_echo_text,
+    _looks_like_recent_ai_echo,
+    logger,
+    IDLE_SESSION_RESET_THRESHOLD_SECONDS,
+    IDLE_SESSION_RESET_CHECK_INTERVAL_SECONDS,
+    FRONTEND_START_SESSION_TIMEOUT_SECONDS,
+    CROSS_MODE_RESTART_WAIT_SECONDS,
+    _proactive_expected_sid,
+    NO_RETRY_TTS_CODES,
+    IMMEDIATE_REPORT_TTS_CODES,
+    _STATIC_LOCALES_DIR,
+    _load_locale_messages,
+    _get_chat_locale_text,
+    _START_LLM_CONCURRENT_ABORTED,
+    ContextAppendResult,
+    _purge_closed_tool_calls,
 )
-
-# TTS 错误码：不可恢复，禁止 respawn（欠费 / API Key 无效）
-NO_RETRY_TTS_CODES = {'API_ARREARS', 'API_KEY_REJECTED', 'TTS_CONFIG_INVALID'}
-# TTS 错误码：立即上报前端，不受"第3次才通知"门槛限制（含配额——仍允许重试）
-IMMEDIATE_REPORT_TTS_CODES = NO_RETRY_TTS_CODES | {'API_QUOTA_TIME'}
-
-
-# ---------------------------------------------------------------------------
-# 重要通知缓冲池
-# 任何模块随时可以调用 enqueue_prominent_notice() 往池里推消息；
-# 前端通过 GET /api/pending-notices 拉取（返回通知列表和游标），
-# 用户全部确认后通过 POST /api/pending-notices/ack?cursor=N 只删除已展示的通知，
-# 避免 peek→ack 两次 HTTP 往返之间新入队的通知被静默清空（TOCTOU）。
-# ---------------------------------------------------------------------------
-_prominent_notice_queue: list[dict] = []
-_prominent_notice_lock = threading.Lock()
-_prominent_notice_seq: int = 0  # 单调递增，每条通知入队时分配
-_STATIC_LOCALES_DIR = Path(__file__).resolve().parents[1] / "static" / "locales"
-
-
-@lru_cache(maxsize=16)
-def _load_locale_messages(locale_code: str) -> dict:
-    try:
-        with (_STATIC_LOCALES_DIR / f"{locale_code}.json").open("r", encoding="utf-8") as f:
-            data = json.load(f)
-            return data if isinstance(data, dict) else {}
-    except Exception:
-        return {}
-
-
-def _get_chat_locale_text(language: str | None, key: str, fallback: str) -> str:
-    raw_lang = language or get_global_language()
-    try:
-        lang_full = normalize_language_code(raw_lang, format='full')
-    except Exception:
-        lang_full = raw_lang or 'en'
-    try:
-        lang_short = normalize_language_code(raw_lang, format='short')
-    except Exception:
-        lang_short = 'en'
-
-    candidates: list[str] = []
-    for candidate in (lang_full, lang_short, 'en', 'zh-CN'):
-        if candidate and candidate not in candidates:
-            candidates.append(candidate)
-
-    for locale_code in candidates:
-        cursor = _load_locale_messages(locale_code)
-        for part in ('chat', key):
-            if not isinstance(cursor, dict):
-                cursor = None
-                break
-            cursor = cursor.get(part)
-        if isinstance(cursor, str) and cursor.strip():
-            return cursor
-    return fallback
-
-
-def enqueue_prominent_notice(notice: "str | dict"):
-    """Put a prominent notice into the buffer pool, awaiting frontend pickup.
-    
-    Accepts a string (automatically wrapped as {"message": ...}) or a structured
-    dict (recommended fields: "code", "message", "message_en", "details").
-    """
-    global _prominent_notice_seq
-    if isinstance(notice, str):
-        item: dict = {"message": notice}
-    else:
-        item = dict(notice)
-    with _prominent_notice_lock:
-        _prominent_notice_seq += 1
-        item["_nid"] = _prominent_notice_seq
-        _prominent_notice_queue.append(item)
-
-
-def peek_prominent_notices() -> tuple[list[dict], int]:
-    """Return a snapshot of the buffer pool and the current cursor (for GET /pending-notices).
-
-    Returns (notices_without_internal_fields, cursor); cursor is the largest _nid in
-    this snapshot, and passing it to drain_prominent_notices(cursor) deletes exactly
-    the displayed items.
-    """
-    with _prominent_notice_lock:
-        items = list(_prominent_notice_queue)
-    cursor = items[-1]["_nid"] if items else 0
-    public = [{k: v for k, v in it.items() if k != "_nid"} for it in items]
-    return public, cursor
-
-
-def drain_prominent_notices(up_to_cursor: int) -> list[dict]:
-    """Delete notices with _nid <= up_to_cursor, keeping items enqueued afterwards.
-
-    Returns the list of deleted notices. Passing 0 or a negative number deletes nothing.
-    """
-    if up_to_cursor <= 0:
-        return []
-    with _prominent_notice_lock:
-        remaining = [it for it in _prominent_notice_queue if it.get("_nid", 0) > up_to_cursor]
-        drained = [it for it in _prominent_notice_queue if it.get("_nid", 0) <= up_to_cursor]
-        _prominent_notice_queue.clear()
-        _prominent_notice_queue.extend(remaining)
-    return drained
-
-
-# ---------------------------------------------------------------------------
-# CosyVoice 旧版音色通知去重（模块级，startup 和 LLMSessionManager 共享）
-# ---------------------------------------------------------------------------
-_notified_legacy_voices: set[str] = set()
-
-
-def enqueue_voice_migration_notice(legacy_names: list) -> None:
-    """Push the legacy CosyVoice voice notice after dedup. Called by both the main_server
-    startup path and LLMSessionManager, avoiding duplicate popups for the same character."""
-    global _notified_legacy_voices
-    if not legacy_names:
-        return
-    new_names = sorted(set(legacy_names) - _notified_legacy_voices)
-    if not new_names:
-        return
-    _notified_legacy_voices.update(new_names)
-    enqueue_prominent_notice({
-        "code": "notice.voiceMigration.legacyDetected",
-        "message": "检测到旧版 CosyVoice 音色可能已失效，建议重新克隆语音。",
-        "message_en": "Legacy CosyVoice voices detected that may no longer work. Consider re-cloning your voices.",
-        "details": {"voices": new_names},
-    })
-
-
-# Sentinel returned by start_llm_session when CAS detects a concurrent start
-# already promoted its own session.  Returning a sentinel (instead of raising)
-# keeps the loser out of the generic error path — that path calls cleanup()
-# without an expected_session guard and would otherwise tear down the winner's
-# session/websocket while also inflating session_start_failure_count.
-_START_LLM_CONCURRENT_ABORTED = object()
-
-
-@dataclass(frozen=True)
-class ContextAppendResult:
-    appended: bool
-    deduped: bool = False
-    targets: tuple[str, ...] = ()
-    reason: str | None = None
+from .callback_render import (  # noqa: F401
+    _STATUS_EMOJI,
+    _format_callback_source,
+    apply_role_placeholders,
+    _render_callback_inner_item,
+    _build_callback_instruction,
+    _format_voice_swap_item,
+    _render_pending_extra_replies_by_origin,
+    _select_callbacks_within_token_budget,
+)
+from .notices import (  # noqa: F401
+    _prominent_notice_queue,
+    _prominent_notice_lock,
+    enqueue_prominent_notice,
+    peek_prominent_notices,
+    drain_prominent_notices,
+    _notified_legacy_voices,
+    enqueue_voice_migration_notice,
+)
 
 
 # --- 一个带有定期上下文压缩+在线热切换的语音会话管理器 ---
-def _purge_closed_tool_calls(history: list, *, start: int = 0) -> int:
-    """Remove every CLOSED tool-call pair from the conversation history: an
-    assistant message (role=assistant, carrying tool_calls) plus the tool-result
-    messages immediately following it whose tool_call_id matches. Any
-    reasoning_content (the thinking model's chain, parked on that assistant
-    message for provider replay) is dropped together with it — deleting the
-    whole pair, NOT just the field, since a thinking endpoint rejects a
-    tool_calls turn whose reasoning_content went missing on replay.
-
-    Only assistant messages at index >= ``start`` are considered, so a Focus
-    exit scopes the purge to the episode's history suffix (recorded when Focus
-    was entered) and leaves closed tool calls from regular turns BEFORE Focus
-    began intact. ``start`` is clamped to [0, len].
-
-    "Closed" = every tool_call id on the assistant message is answered by a
-    following contiguous tool message. Unclosed calls (a call with no result —
-    an interrupted / in-flight turn) are kept so live state is never corrupted.
-    Plain Human / AI / System (BaseMessage) entries are never touched. Returns
-    the number of messages deleted.
-    """
-    if not history:
-        return 0
-    n = len(history)
-    start = max(0, min(int(start or 0), n))
-    remove: set[int] = set()
-    for i in range(start, n):
-        msg = history[i]
-        if not (isinstance(msg, dict) and msg.get("role") == "assistant"):
-            continue
-        tool_calls = msg.get("tool_calls") or []
-        if not tool_calls:
-            continue
-        call_ids = {tc.get("id") for tc in tool_calls if tc.get("id")}
-        if not call_ids:
-            continue
-        # execute 路径原子追加 assistant + 紧随其后的各 tool result，所以闭合的
-        # 结果消息是「连续」的；遇到非 tool 消息即停止该 assistant 的结果收集。
-        result_idx: list[int] = []
-        covered: set = set()
-        for j in range(i + 1, n):
-            rj = history[j]
-            if isinstance(rj, dict) and rj.get("role") == "tool":
-                result_idx.append(j)
-                covered.add(rj.get("tool_call_id"))
-            else:
-                break
-        if call_ids <= covered:  # 每个 call 都有结果 → 已闭合，整对删
-            remove.add(i)
-            remove.update(result_idx)
-    for idx in sorted(remove, reverse=True):
-        del history[idx]
-    return len(remove)
-
-
 class LLMSessionManager:
     def __init__(self, sync_message_queue, lanlan_name, lanlan_prompt):
         self.websocket = None

--- a/main_logic/core/_shared.py
+++ b/main_logic/core/_shared.py
@@ -1,0 +1,267 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared module-level constants and helpers for the ``main_logic.core`` package.
+
+Split out of the former single-file ``main_logic/core.py`` as a pure move (no
+behavior change). The package ``__init__`` re-exports every name defined here,
+so existing ``main_logic.core.<name>`` imports and test monkeypatches keep
+working unchanged.
+"""
+import contextvars
+import json
+import re
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from utils.language_utils import normalize_language_code, get_global_language
+from utils.logger_config import get_module_logger
+
+
+# Sentinel for `send_lanlan_response(request_id=...)` so we can tell apart
+# "caller didn't pass it (use shared field as fallback)" from "caller
+# explicitly passed None to mean 'no request id'". A normal default of
+# None collapses both into the same code path and would let recovery /
+# proactive paths accidentally bind their messages to a newer request_id.
+_REQUEST_ID_UNSET: Any = object()
+_MAGIC_COMMAND_IMAGE_DROP_REQUEST_MAX = 64
+_VOICE_PROACTIVE_ACK_GRACE_S = 0.05
+_TEXT_SESSION_INPUT_TYPES = frozenset({"text", "avatar_drop_image", "user_image"})
+_IMAGE_INPUT_TYPES = frozenset({"screen", "camera", "avatar_drop_image", "user_image"})
+_LIVE_VISION_STREAM_INPUT_TYPES = frozenset({"screen", "camera"})
+_CONTEXT_APPEND_DEDUP_TTL_SECONDS = 120.0
+_CONTEXT_APPEND_DEDUP_MAX_ENTRIES = 256
+_CONTEXT_APPEND_READY_FLUSH_MAX_PASSES = 8
+_CONTEXT_APPEND_DEFAULT_MAX_TOKENS = 1000
+_CONTEXT_APPEND_SOURCE_MAX_TOKENS = {
+    "game.icebreaker": 500,
+    "game.scripted": 1000,
+    "game.realtime_context": 1000,
+    "game.postgame": 1500,
+    "proactive.context": 1000,
+    "proactive.callback": 1000,
+    "topic.hook": 1000,
+    "topic.material": 1000,
+    "realtime.prime": 1000,
+}
+_CONTEXT_APPEND_BARE_PRIME_SOURCES = frozenset({
+    "game.realtime_context",
+    "game.postgame",
+})
+
+
+_VOICE_ECHO_LOOKBACK_SECONDS = 20.0
+_VOICE_ECHO_LOOKBACK_CHARS = 1200
+_VOICE_ECHO_MIN_NORMALIZED_CHARS = 6
+_VOICE_ECHO_MIN_WINDOW_CHARS = 10
+_VOICE_ECHO_SIMILARITY_THRESHOLD = 0.88
+_VOICE_ECHO_NORMALIZE_RE = re.compile(r"[\W_]+", re.UNICODE)
+
+
+def _normalize_voice_echo_text(text: str) -> str:
+    return _VOICE_ECHO_NORMALIZE_RE.sub("", str(text or "").casefold())
+
+
+def _looks_like_recent_ai_echo(transcript: str, recent_ai_text: str) -> bool:
+    """Return True when STT text is probably the assistant's own recent audio.
+
+    This intentionally requires a close text match. Voice barge-in during AI
+    playback should keep flowing unless it resembles the AI text that was just
+    rendered/spoken.
+    """
+    transcript_norm = _normalize_voice_echo_text(transcript)
+    if len(transcript_norm) < _VOICE_ECHO_MIN_NORMALIZED_CHARS:
+        return False
+    recent_norm = _normalize_voice_echo_text(recent_ai_text)
+    if len(recent_norm) < _VOICE_ECHO_MIN_NORMALIZED_CHARS:
+        return False
+    if len(transcript_norm) > len(recent_norm):
+        return SequenceMatcher(None, transcript_norm, recent_norm).ratio() >= _VOICE_ECHO_SIMILARITY_THRESHOLD
+    if len(transcript_norm) < _VOICE_ECHO_MIN_WINDOW_CHARS:
+        return False
+    if transcript_norm in recent_norm:
+        return True
+
+    window_len = len(transcript_norm)
+    step = max(1, window_len // 3)
+    best = 0.0
+    last_start = len(recent_norm) - window_len
+    starts = list(range(0, last_start + 1, step))
+    if not starts or starts[-1] != last_start:
+        starts.append(last_start)
+    for start in starts:
+        candidate = recent_norm[start:start + window_len]
+        best = max(best, SequenceMatcher(None, transcript_norm, candidate).ratio())
+        if best >= _VOICE_ECHO_SIMILARITY_THRESHOLD:
+            return True
+    return False
+
+
+# Logger for the whole package. Bound to the literal package name rather than
+# ``__name__`` so every submodule keeps logging under the exact pre-split
+# logger name "N.E.K.O.Main.main_logic.core" (tests and log routing key off it).
+logger = get_module_logger("main_logic.core", "Main")
+
+
+# 用户静默达到此阈值 → 后台 loop 主动 end_session，让下一条消息触发
+# start_session(new=False) 重新拉 /new_dialog 注入新鲜时间/长间隔提示/节日
+# 上下文，解决长挂机 session 上下文僵化（"猫娘还停留在前一晚"）的问题。
+# 周期检查间隔故意远小于阈值（粒度 ~1 min），避免静默 30:01 时还要再等
+# 一整轮。
+IDLE_SESSION_RESET_THRESHOLD_SECONDS = 1800
+IDLE_SESSION_RESET_CHECK_INTERVAL_SECONDS = 60
+
+# 前端文本会话 start_session 等 session_started 的硬超时（static/app-buttons.js
+# 的 setTimeout(..., 15000)）。start_session 去重路径等 in-flight 启动落定后给
+# 本请求补发 ack 时，等待上限绑到这个值：超过前端这个超时再补发 session_started
+# 已无意义（前端早已 reject 并发 end_session），故以它为有意义窗口的天然上界。
+FRONTEND_START_SESSION_TIMEOUT_SECONDS = 15.0
+
+# 跨模式重启时「等 in-flight 落定」的等待上限。必须明显短于前端超时：等完之后
+# 还要花几秒真正起目标模式会话（含最坏 ~12s 的 TTS 就绪等待），若把大半个 15s 都
+# 耗在等待上，重启发出的 session_started 会晚于前端 deadline，前端照样超时、甚至
+# reset 后才收到 ack 起孤儿会话（Codex P2）。取前端超时的一半，给重启留 ~7.5s 余量；
+# in-flight 没在这窗口内落定就放弃（回落 baseline：前端超时、无孤儿）。in-flight
+# （text）正常 1~3s 落定，远在窗口内。注：TTS 冷启动叠加 in-flight 贴线落定的双重
+# 最坏情形仍可能溢出 15s，此时由 start_session 末尾的连接/放弃校验与重启侧守卫兜底。
+CROSS_MODE_RESTART_WAIT_SECONDS = FRONTEND_START_SESSION_TIMEOUT_SECONDS / 2
+
+# 主动搭话（proactive）调用 prompt_ephemeral 时设置的 sid 期望值。
+# 目的：prompt_ephemeral 内部通过 on_text_delta=handle_text_data 回调 enqueue TTS，
+# 中间可能被用户输入抢占（user stream_text 清 queue + 换 current_speech_id）。
+# handle_text_data / handle_output_transcript 检查此 contextvar：若已设置且与
+# current_speech_id 不符，说明本路径生成的 chunk 已不属于当前轮次，必须丢弃
+# 以免 proactive 文本被错打上用户新 sid 混进用户回复 TTS。
+# contextvar 是 per-task 隔离，不会泄漏到用户 stream_text 所在的独立任务。
+_proactive_expected_sid: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    '_proactive_expected_sid', default=None,
+)
+
+# TTS 错误码：不可恢复，禁止 respawn（欠费 / API Key 无效）
+NO_RETRY_TTS_CODES = {'API_ARREARS', 'API_KEY_REJECTED', 'TTS_CONFIG_INVALID'}
+# TTS 错误码：立即上报前端，不受"第3次才通知"门槛限制（含配额——仍允许重试）
+IMMEDIATE_REPORT_TTS_CODES = NO_RETRY_TTS_CODES | {'API_QUOTA_TIME'}
+
+
+_STATIC_LOCALES_DIR = Path(__file__).resolve().parents[2] / "static" / "locales"
+
+
+@lru_cache(maxsize=16)
+def _load_locale_messages(locale_code: str) -> dict:
+    try:
+        with (_STATIC_LOCALES_DIR / f"{locale_code}.json").open("r", encoding="utf-8") as f:
+            data = json.load(f)
+            return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _get_chat_locale_text(language: str | None, key: str, fallback: str) -> str:
+    raw_lang = language or get_global_language()
+    try:
+        lang_full = normalize_language_code(raw_lang, format='full')
+    except Exception:
+        lang_full = raw_lang or 'en'
+    try:
+        lang_short = normalize_language_code(raw_lang, format='short')
+    except Exception:
+        lang_short = 'en'
+
+    candidates: list[str] = []
+    for candidate in (lang_full, lang_short, 'en', 'zh-CN'):
+        if candidate and candidate not in candidates:
+            candidates.append(candidate)
+
+    for locale_code in candidates:
+        cursor = _load_locale_messages(locale_code)
+        for part in ('chat', key):
+            if not isinstance(cursor, dict):
+                cursor = None
+                break
+            cursor = cursor.get(part)
+        if isinstance(cursor, str) and cursor.strip():
+            return cursor
+    return fallback
+
+
+# Sentinel returned by start_llm_session when CAS detects a concurrent start
+# already promoted its own session.  Returning a sentinel (instead of raising)
+# keeps the loser out of the generic error path — that path calls cleanup()
+# without an expected_session guard and would otherwise tear down the winner's
+# session/websocket while also inflating session_start_failure_count.
+_START_LLM_CONCURRENT_ABORTED = object()
+
+
+@dataclass(frozen=True)
+class ContextAppendResult:
+    appended: bool
+    deduped: bool = False
+    targets: tuple[str, ...] = ()
+    reason: str | None = None
+
+
+def _purge_closed_tool_calls(history: list, *, start: int = 0) -> int:
+    """Remove every CLOSED tool-call pair from the conversation history: an
+    assistant message (role=assistant, carrying tool_calls) plus the tool-result
+    messages immediately following it whose tool_call_id matches. Any
+    reasoning_content (the thinking model's chain, parked on that assistant
+    message for provider replay) is dropped together with it — deleting the
+    whole pair, NOT just the field, since a thinking endpoint rejects a
+    tool_calls turn whose reasoning_content went missing on replay.
+
+    Only assistant messages at index >= ``start`` are considered, so a Focus
+    exit scopes the purge to the episode's history suffix (recorded when Focus
+    was entered) and leaves closed tool calls from regular turns BEFORE Focus
+    began intact. ``start`` is clamped to [0, len].
+
+    "Closed" = every tool_call id on the assistant message is answered by a
+    following contiguous tool message. Unclosed calls (a call with no result —
+    an interrupted / in-flight turn) are kept so live state is never corrupted.
+    Plain Human / AI / System (BaseMessage) entries are never touched. Returns
+    the number of messages deleted.
+    """
+    if not history:
+        return 0
+    n = len(history)
+    start = max(0, min(int(start or 0), n))
+    remove: set[int] = set()
+    for i in range(start, n):
+        msg = history[i]
+        if not (isinstance(msg, dict) and msg.get("role") == "assistant"):
+            continue
+        tool_calls = msg.get("tool_calls") or []
+        if not tool_calls:
+            continue
+        call_ids = {tc.get("id") for tc in tool_calls if tc.get("id")}
+        if not call_ids:
+            continue
+        # execute 路径原子追加 assistant + 紧随其后的各 tool result，所以闭合的
+        # 结果消息是「连续」的；遇到非 tool 消息即停止该 assistant 的结果收集。
+        result_idx: list[int] = []
+        covered: set = set()
+        for j in range(i + 1, n):
+            rj = history[j]
+            if isinstance(rj, dict) and rj.get("role") == "tool":
+                result_idx.append(j)
+                covered.add(rj.get("tool_call_id"))
+            else:
+                break
+        if call_ids <= covered:  # 每个 call 都有结果 → 已闭合，整对删
+            remove.add(i)
+            remove.update(result_idx)
+    for idx in sorted(remove, reverse=True):
+        del history[idx]
+    return len(remove)

--- a/main_logic/core/callback_render.py
+++ b/main_logic/core/callback_render.py
@@ -1,0 +1,436 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Pure rendering helpers for agent-task callbacks and voice-swap injections.
+
+Split out of the former single-file ``main_logic/core.py`` as a pure move (no
+behavior change): these helpers render agent_task_callback payloads and
+voice-mode ``pending_extra_replies`` into LLM prompt strings. The package
+``__init__`` re-exports every name defined here, so existing
+``main_logic.core.<name>`` imports keep working (plugins import
+``apply_role_placeholders`` through that path).
+"""
+from config.prompts.prompts_sys import (
+    _loc,
+    SYSTEM_NOTIFICATION_TASK_ACTIVE,
+    SYSTEM_NOTIFICATION_TASK_PASSIVE,
+    SYSTEM_NOTIFICATION_EVENT_ACTIVE,
+    SYSTEM_NOTIFICATION_EVENT_PASSIVE,
+    SOURCE_DESCRIPTORS,
+    TASK_STATUS_PHRASES,
+    TASK_ACTION_PHRASES,
+    CONTEXT_SUMMARY_TASK_HEADER, CONTEXT_SUMMARY_TASK_FOOTER,
+    CONTEXT_SUMMARY_EVENT_HEADER, CONTEXT_SUMMARY_EVENT_FOOTER,
+    RESULT_PARSER_PHRASES,
+)
+
+from ._shared import logger
+
+
+# 内部 item 渲染时的视觉标记。状态信息已在外层 SYSTEM_NOTIFICATION_TASK_ACTIVE
+# 表达，emoji 仅作快速视觉识别用。
+_STATUS_EMOJI = {
+    "completed": "✅",
+    "partial": "⚠️",
+    "blocked": "⚠️",
+    "failed": "❌",
+    "cancelled": "🚫",
+}
+
+
+def _format_callback_source(cb: dict, lang: str) -> str:
+    """Render an agent_task_callback's source as user-facing text in ``lang``.
+
+    Reads ``cb["source_kind"]`` (one of SOURCE_DESCRIPTORS keys) and
+    ``cb["source_name"]`` (free-form string used as ``{name}`` slot). Falls
+    back to the ``unknown`` descriptor for missing/unrecognized kinds.
+    """
+    kind = (cb.get("source_kind") or "unknown").strip()
+    descriptor = SOURCE_DESCRIPTORS.get(kind) or SOURCE_DESCRIPTORS["unknown"]
+    name = (cb.get("source_name") or "").strip()
+    return _loc(descriptor, lang).format(name=name)
+
+
+def apply_role_placeholders(
+    text: str,
+    *,
+    lanlan_name: str = "",
+    master_name: str = "",
+) -> str:
+    """Substitute ``{MASTER_NAME}`` / ``{LANLAN_NAME}`` placeholders in
+    plugin-supplied text at the LLM-injection boundary.
+
+    Plugin authors don't know which ``LLMSessionManager`` (and therefore which
+    ``master_name`` / ``lanlan_name`` pair) the text will route to — that's a
+    host-side visibility decision. So the canonical contract is:
+
+        plugin writes ``"Report to {MASTER_NAME}…"`` →
+        host expands at the injection site, per session.
+
+    Uses ``str.replace`` rather than ``str.format`` so that other braces in
+    the text (JSON fragments, code snippets, user content containing stray
+    ``{``) don't raise ``KeyError``. Empty names short-circuit — the
+    placeholder is left in place rather than replaced with ``""``, on the
+    theory that the literal token is less misleading than an empty hole.
+
+    This is the SINGLE source of truth for the placeholder contract. New
+    plugin-text injection sites should funnel through this helper.
+    """
+    if not text:
+        return text
+    if isinstance(master_name, str) and master_name:
+        text = text.replace("{MASTER_NAME}", master_name)
+    if isinstance(lanlan_name, str) and lanlan_name:
+        text = text.replace("{LANLAN_NAME}", lanlan_name)
+    return text
+
+
+def _render_callback_inner_item(
+    cb: dict,
+    lang: str,
+    *,
+    lanlan_name: str = "",
+    master_name: str = "",
+) -> str:
+    """Render one callback as a single inline string for the LLM prompt.
+
+    Returns ``""`` when there is genuinely nothing to convey (both summary
+    and detail empty); the caller can then drop the line and rely on the
+    outer header alone to express that something happened.
+
+    Plugin-supplied ``summary``/``detail`` may contain ``{MASTER_NAME}`` /
+    ``{LANLAN_NAME}`` placeholders; see :func:`apply_role_placeholders`.
+    """
+    summary = apply_role_placeholders(
+        (cb.get("summary") or "").strip(),
+        lanlan_name=lanlan_name, master_name=master_name,
+    )
+    detail = apply_role_placeholders(
+        (cb.get("detail") or "").strip(),
+        lanlan_name=lanlan_name, master_name=master_name,
+    )
+    text = summary or detail
+    if not text:
+        return ""
+    status = cb.get("status") or "completed"
+    emoji = _STATUS_EMOJI.get(status, "•")
+    line = f"{emoji} {text}"
+    if summary and detail and detail != summary and len(detail) > len(summary):
+        label = _loc(RESULT_PARSER_PHRASES["detail_result"], lang)
+        line += f"\n{label}{detail}"
+    return line
+
+
+def _build_callback_instruction(
+    callbacks,
+    *,
+    lang: str,
+    lanlan_name: str,
+    master_name: str,
+    passive: bool = False,
+) -> str:
+    """Render a list of agent_task_callbacks into the LLM injection string.
+
+    Each callback carries an ``origin`` tag stamped by the host at the
+    EventBus → callback boundary:
+      - ``"task_result"`` — real task completion (agent_server._emit_task_result),
+        e.g. Computer Use / Browser Use / plugin entry / MCP tool result.
+      - ``"event"`` — plugin push_message stream (proactive_bridge),
+        e.g. danmaku / gift / external notification.
+
+    Plugin authors cannot set ``origin``; it is derived structurally from
+    which SDK method they called (``finish()`` vs ``push_message()``) by
+    way of the event_type the upstream producer emitted.
+
+    Two axes (origin × passive) pick one of four outer templates:
+
+    +--------------+----------------------+-----------------------------+
+    | origin       | active (proactive)   | passive                     |
+    +==============+======================+=============================+
+    | task_result  | TASK_ACTIVE          | TASK_PASSIVE                |
+    |              | ("done, report it")  | ("task result")             |
+    +--------------+----------------------+-----------------------------+
+    | event        | EVENT_ACTIVE         | EVENT_PASSIVE               |
+    |              | ("new msg, respond") | ("message")                 |
+    +--------------+----------------------+-----------------------------+
+
+    Unknown origin defaults to ``"event"`` + warning. Rationale: rather
+    have the AI naturally react than fabricate "I completed a task".
+
+    Callbacks are grouped by (passive, origin, status, source) so each
+    group can pick the right outer template and (for task_result+active)
+    slot in the right status/action phrases. Event templates ignore
+    status/action — the concept doesn't apply to passive event streams.
+    """
+    if not callbacks:
+        return ""
+    from collections import OrderedDict
+
+    grouped: "OrderedDict[tuple, list]" = OrderedDict()
+    for cb in callbacks:
+        # passive=True call = drain path; treat all as passive regardless
+        # of per-callback delivery_mode.
+        cb_passive = passive or (cb.get("delivery_mode") == "passive")
+        origin = cb.get("origin")
+        if origin not in ("task_result", "event"):
+            if origin:
+                logger.warning(
+                    "[callback_instruction] unknown origin=%r, falling back to 'event'; "
+                    "source=%s/%s",
+                    origin, cb.get("source_kind"), cb.get("source_name"),
+                )
+            origin = "event"
+        key = (
+            cb_passive,
+            origin,
+            cb.get("status") or "completed",
+            cb.get("source_kind") or "unknown",
+            (cb.get("source_name") or ""),
+        )
+        grouped.setdefault(key, []).append(cb)
+
+    parts: list[str] = []
+    for (cb_passive, origin, status, _src_kind, _src_name), cbs in grouped.items():
+        source_text = _format_callback_source(cbs[0], lang)
+        if origin == "task_result":
+            if cb_passive:
+                header = _loc(SYSTEM_NOTIFICATION_TASK_PASSIVE, lang).format(source=source_text)
+            else:
+                status_phrase = _loc(
+                    TASK_STATUS_PHRASES.get(status) or TASK_STATUS_PHRASES["completed"],
+                    lang,
+                )
+                action_phrase = _loc(
+                    TASK_ACTION_PHRASES.get(status) or TASK_ACTION_PHRASES["completed"],
+                    lang,
+                )
+                header = _loc(SYSTEM_NOTIFICATION_TASK_ACTIVE, lang).format(
+                    source=source_text,
+                    status_phrase=status_phrase,
+                    action_phrase=action_phrase,
+                    name=lanlan_name,
+                    master=master_name,
+                )
+        else:  # origin == "event"
+            if cb_passive:
+                header = _loc(SYSTEM_NOTIFICATION_EVENT_PASSIVE, lang).format(source=source_text)
+            else:
+                header = _loc(SYSTEM_NOTIFICATION_EVENT_ACTIVE, lang).format(
+                    source=source_text,
+                    name=lanlan_name,
+                    master=master_name,
+                )
+        items = [
+            _render_callback_inner_item(
+                cb, lang, lanlan_name=lanlan_name, master_name=master_name,
+            )
+            for cb in cbs
+        ]
+        items = [s for s in items if s]
+        if items:
+            parts.append(header + "\n".join(items))
+        else:
+            # No item text — outer header alone (e.g. "task X failed") still
+            # tells the AI that something happened. Strip trailing newline so
+            # the joined output is clean.
+            parts.append(header.rstrip())
+    rendered = "\n\n".join(parts)
+    # Total input budget: many callbacks accumulating must not blow up the turn.
+    from utils.tokenize import truncate_to_tokens
+    from config import AGENT_CALLBACK_TOTAL_MAX_TOKENS
+    return truncate_to_tokens(rendered, AGENT_CALLBACK_TOTAL_MAX_TOKENS)
+
+
+def _format_voice_swap_item(
+    entry: dict,
+    lang: str,
+    *,
+    lanlan_name: str = "",
+    master_name: str = "",
+) -> str:
+    """Render a single voice-mode pending_extra_replies entry to a bulleted
+    line for the hot-swap injection.
+
+    Priority: ``summary`` → ``detail`` → synthesized "{status_phrase} from
+    {source}[: error_message]" placeholder. The placeholder path matters for
+    failure callbacks whose body is empty — without it, header information
+    like "execution failed / from plugin X / Connection refused" would be
+    silently dropped (the voice-mode equivalent of the header-only branch in
+    ``_build_callback_instruction``).
+
+    Plugin-supplied ``summary``/``detail`` may contain ``{MASTER_NAME}`` /
+    ``{LANLAN_NAME}`` placeholders; see :func:`apply_role_placeholders`. The
+    synthesized placeholder fallback uses host-side localized phrases so it
+    needs no role substitution.
+
+    Returns ``""`` when the entry is genuinely empty (no body, no error, and
+    a benign ``completed`` status) — caller filters those out.
+    """
+    summary = apply_role_placeholders(
+        (entry.get("summary") or "").strip(),
+        lanlan_name=lanlan_name, master_name=master_name,
+    )
+    detail = apply_role_placeholders(
+        (entry.get("detail") or "").strip(),
+        lanlan_name=lanlan_name, master_name=master_name,
+    )
+    text = summary or detail
+    status = entry.get("status") or "completed"
+    emoji = _STATUS_EMOJI.get(status, "•")
+
+    if text:
+        return f"- {emoji} {text}"
+
+    # No body text — synthesize from header info so the failure status
+    # doesn't disappear silently.
+    error_message = (entry.get("error_message") or "").strip()
+    source_name = (entry.get("source_name") or "").strip()
+    if not error_message and not source_name and status == "completed":
+        # Truly nothing to convey; drop. (enqueue_agent_callback already
+        # filters these out, but be defensive against legacy entries.)
+        return ""
+
+    source_text = _format_callback_source(entry, lang)
+    status_phrase = _loc(
+        TASK_STATUS_PHRASES.get(status) or TASK_STATUS_PHRASES["completed"],
+        lang,
+    )
+    line = f"- {emoji} {source_text} {status_phrase}"
+    if error_message:
+        line += f"：{error_message}"
+    return line
+
+
+def _render_pending_extra_replies_by_origin(
+    entries,
+    *,
+    lang: str,
+    lanlan_name: str,
+    master_name: str,
+) -> str:
+    """Render voice-mode ``pending_extra_replies`` into the hot-swap injection
+    string, grouped by ``origin``.
+
+    Each entry should be a structured dict with at least ``origin``;
+    ``summary``/``detail``/``status``/``source_kind``/``source_name``/
+    ``error_message`` are consumed by :func:`_format_voice_swap_item`. Legacy
+    plain-string entries (pre-migration code paths) are tolerated and
+    treated as ``origin="event"`` event-stream content — the safer default,
+    since the "report the result of a previously executed task" framing on
+    what may actually be a push event is the bug this refactor fixes.
+
+    Returns a single string suitable for appending to ``final_prime_text``.
+    Order: task block first (if any), then event block — matches the original
+    single-block placement where everything followed the cache dump.
+    """
+    if not entries:
+        return ""
+
+    task_entries: list[dict] = []
+    event_entries: list[dict] = []
+    for entry in entries:
+        if isinstance(entry, dict):
+            normalized = dict(entry)
+            origin = normalized.get("origin")
+            if origin not in ("task_result", "event"):
+                normalized["origin"] = "event"  # fail-safe
+                origin = "event"
+            if origin == "task_result":
+                task_entries.append(normalized)
+            else:
+                event_entries.append(normalized)
+        elif isinstance(entry, str):
+            stripped = entry.strip()
+            if stripped:
+                event_entries.append({
+                    "origin": "event",
+                    "summary": stripped,
+                    "detail": "",
+                    "status": "completed",
+                    "source_kind": "unknown",
+                    "source_name": "",
+                    "error_message": "",
+                })
+
+    blocks: list[str] = []
+    if task_entries:
+        items = [
+            _format_voice_swap_item(e, lang, lanlan_name=lanlan_name, master_name=master_name)
+            for e in task_entries
+        ]
+        items = [s for s in items if s]
+        if items:
+            blocks.append(
+                _loc(CONTEXT_SUMMARY_TASK_HEADER, lang).format(name=lanlan_name, master=master_name)
+                + "\n".join(items)
+                + _loc(CONTEXT_SUMMARY_TASK_FOOTER, lang)
+            )
+    if event_entries:
+        items = [
+            _format_voice_swap_item(e, lang, lanlan_name=lanlan_name, master_name=master_name)
+            for e in event_entries
+        ]
+        items = [s for s in items if s]
+        if items:
+            blocks.append(
+                _loc(CONTEXT_SUMMARY_EVENT_HEADER, lang).format(name=lanlan_name, master=master_name)
+                + "\n".join(items)
+                + _loc(CONTEXT_SUMMARY_EVENT_FOOTER, lang)
+            )
+    rendered = "".join(blocks)
+    # Total input budget for the voice hot-swap injection (mirror of the
+    # text-mode cap in _build_callback_instruction). Backstop only — callers
+    # should pre-select within budget via _select_callbacks_within_token_budget
+    # so whole callbacks are never silently dropped after a successful ack.
+    from utils.tokenize import truncate_to_tokens
+    from config import AGENT_CALLBACK_TOTAL_MAX_TOKENS
+    return truncate_to_tokens(rendered, AGENT_CALLBACK_TOTAL_MAX_TOKENS)
+
+
+def _select_callbacks_within_token_budget(callbacks, total_budget):
+    """Greedily take the oldest prefix of ``callbacks`` whose cumulative
+    summary/detail token count stays within ``total_budget``.
+
+    Returns ``(selected, deferred)``. Always selects at least one item so the
+    queue makes forward progress (each item is already per-item capped at
+    enqueue). The point: a caller that acks + clears must ack/clear only the
+    *selected* items and re-queue ``deferred`` for the next turn — otherwise
+    callbacks beyond the cap would be acked as delivered but never reach the
+    model (see PR review)."""
+    from utils.tokenize import count_tokens
+    # Per-item overhead for the emoji/bullet, the per-group outer header, and the
+    # template wrapper that the renderer adds around the body. Over-counting is
+    # the SAFE direction: we select fewer, so the rendered instruction stays
+    # under budget and the builder's backstop truncation never cuts an already
+    # selected (and acked) callback.
+    _ITEM_OVERHEAD_TOKENS = 48
+    selected: list = []
+    used = 0
+    for i, cb in enumerate(callbacks):
+        if isinstance(cb, dict):
+            # Count every field the renderer may emit — body line (summary or
+            # detail) plus the error/source fallback line — not just summary.
+            t = (
+                count_tokens(cb.get("summary") or "")
+                + count_tokens(cb.get("detail") or "")
+                + count_tokens(cb.get("error_message") or "")
+                + count_tokens(cb.get("source_name") or "")
+                + _ITEM_OVERHEAD_TOKENS
+            )
+        else:
+            t = count_tokens(str(cb)) + _ITEM_OVERHEAD_TOKENS
+        if selected and used + t > total_budget:
+            return selected, list(callbacks[i:])
+        selected.append(cb)
+        used += t
+    return selected, []

--- a/main_logic/core/notices.py
+++ b/main_logic/core/notices.py
@@ -1,0 +1,105 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Prominent-notice buffer pool awaiting frontend pickup.
+
+Split out of the former single-file ``main_logic/core.py`` as a pure move (no
+behavior change). This module is the single owner of the queue state
+(``_prominent_notice_queue`` / ``_prominent_notice_lock`` /
+``_prominent_notice_seq``); the package ``__init__`` and
+``main_routers.system_router.status`` re-export / import the accessor
+functions, so every producer and consumer shares this one queue.
+"""
+import threading
+
+
+# ---------------------------------------------------------------------------
+# 重要通知缓冲池
+# 任何模块随时可以调用 enqueue_prominent_notice() 往池里推消息；
+# 前端通过 GET /api/pending-notices 拉取（返回通知列表和游标），
+# 用户全部确认后通过 POST /api/pending-notices/ack?cursor=N 只删除已展示的通知，
+# 避免 peek→ack 两次 HTTP 往返之间新入队的通知被静默清空（TOCTOU）。
+# ---------------------------------------------------------------------------
+_prominent_notice_queue: list[dict] = []
+_prominent_notice_lock = threading.Lock()
+_prominent_notice_seq: int = 0  # 单调递增，每条通知入队时分配
+
+
+def enqueue_prominent_notice(notice: "str | dict"):
+    """Put a prominent notice into the buffer pool, awaiting frontend pickup.
+    
+    Accepts a string (automatically wrapped as {"message": ...}) or a structured
+    dict (recommended fields: "code", "message", "message_en", "details").
+    """
+    global _prominent_notice_seq
+    if isinstance(notice, str):
+        item: dict = {"message": notice}
+    else:
+        item = dict(notice)
+    with _prominent_notice_lock:
+        _prominent_notice_seq += 1
+        item["_nid"] = _prominent_notice_seq
+        _prominent_notice_queue.append(item)
+
+
+def peek_prominent_notices() -> tuple[list[dict], int]:
+    """Return a snapshot of the buffer pool and the current cursor (for GET /pending-notices).
+
+    Returns (notices_without_internal_fields, cursor); cursor is the largest _nid in
+    this snapshot, and passing it to drain_prominent_notices(cursor) deletes exactly
+    the displayed items.
+    """
+    with _prominent_notice_lock:
+        items = list(_prominent_notice_queue)
+    cursor = items[-1]["_nid"] if items else 0
+    public = [{k: v for k, v in it.items() if k != "_nid"} for it in items]
+    return public, cursor
+
+
+def drain_prominent_notices(up_to_cursor: int) -> list[dict]:
+    """Delete notices with _nid <= up_to_cursor, keeping items enqueued afterwards.
+
+    Returns the list of deleted notices. Passing 0 or a negative number deletes nothing.
+    """
+    if up_to_cursor <= 0:
+        return []
+    with _prominent_notice_lock:
+        remaining = [it for it in _prominent_notice_queue if it.get("_nid", 0) > up_to_cursor]
+        drained = [it for it in _prominent_notice_queue if it.get("_nid", 0) <= up_to_cursor]
+        _prominent_notice_queue.clear()
+        _prominent_notice_queue.extend(remaining)
+    return drained
+
+
+# ---------------------------------------------------------------------------
+# CosyVoice 旧版音色通知去重（模块级，startup 和 LLMSessionManager 共享）
+# ---------------------------------------------------------------------------
+_notified_legacy_voices: set[str] = set()
+
+
+def enqueue_voice_migration_notice(legacy_names: list) -> None:
+    """Push the legacy CosyVoice voice notice after dedup. Called by both the main_server
+    startup path and LLMSessionManager, avoiding duplicate popups for the same character."""
+    global _notified_legacy_voices
+    if not legacy_names:
+        return
+    new_names = sorted(set(legacy_names) - _notified_legacy_voices)
+    if not new_names:
+        return
+    _notified_legacy_voices.update(new_names)
+    enqueue_prominent_notice({
+        "code": "notice.voiceMigration.legacyDetected",
+        "message": "检测到旧版 CosyVoice 音色可能已失效，建议重新克隆语音。",
+        "message_en": "Legacy CosyVoice voices detected that may no longer work. Consider re-cloning your voices.",
+        "details": {"voices": new_names},
+    })

--- a/tests/unit/test_avatar_drop_frontend_static.py
+++ b/tests/unit/test_avatar_drop_frontend_static.py
@@ -9,7 +9,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 APP_BUTTONS_PATH = REPO_ROOT / "static" / "app-buttons.js"
 APP_AUDIO_CAPTURE_PATH = REPO_ROOT / "static" / "app-audio-capture.js"
 APP_WEBSOCKET_PATH = REPO_ROOT / "static" / "app-websocket.js"
-CORE_PATH = REPO_ROOT / "main_logic" / "core.py"
+CORE_PACKAGE_PATH = REPO_ROOT / "main_logic" / "core"
 CROSS_SERVER_PATH = REPO_ROOT / "main_logic" / "cross_server.py"
 INDEX_TEMPLATE_PATH = REPO_ROOT / "templates" / "index.html"
 INTAKE_PATH = REPO_ROOT / "static" / "avatar-drop-intake.js"
@@ -21,6 +21,12 @@ WEBSOCKET_ROUTER_PATH = REPO_ROOT / "main_routers" / "websocket_router.py"
 
 def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
+
+
+def _read_package(path: Path) -> str:
+    """Concatenated source of every module in a package directory (the
+    ``main_logic.core`` package equivalent of the old single-file read)."""
+    return "\n".join(p.read_text(encoding="utf-8") for p in sorted(path.glob("*.py")))
 
 
 def _js_function_block(source: str, function_name: str) -> str:
@@ -216,7 +222,7 @@ def test_avatar_drop_scripts_and_backend_routes_are_wired():
 
 @pytest.mark.unit
 def test_avatar_drop_image_and_memory_override_are_routed_as_text_session_inputs():
-    core_source = _read(CORE_PATH)
+    core_source = _read_package(CORE_PACKAGE_PATH)
     cross_server_source = _read(CROSS_SERVER_PATH)
     offline_source = _read(OMNI_OFFLINE_PATH)
     websocket_source = _read(WEBSOCKET_ROUTER_PATH)

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -481,7 +481,10 @@ def test_icebreaker_route_is_finalized_when_renderer_websocket_disconnects():
 
 
 def test_icebreaker_context_reuses_existing_session_context_paths():
-    core = (ROOT / "main_logic" / "core.py").read_text(encoding="utf-8")
+    core = "\n".join(
+        p.read_text(encoding="utf-8")
+        for p in sorted((ROOT / "main_logic" / "core").glob("*.py"))
+    )
 
     assert "pending_icebreaker_context" not in core
     assert "_icebreaker_context_request_ids" not in core

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -1096,14 +1096,21 @@ def test_submit_proactive_callback_persists_when_goodbye_silent():
     ]
 
 
+def _read_core_package_source() -> str:
+    """Concatenated source of the ``main_logic.core`` package (the equivalent
+    of reading the former single-file ``main_logic/core.py``)."""
+    package_dir = os.path.join(os.path.dirname(__file__), "../../main_logic/core")
+    parts = []
+    for name in sorted(os.listdir(package_dir)):
+        if name.endswith(".py"):
+            with open(os.path.join(package_dir, name), encoding="utf-8") as fh:
+                parts.append(fh.read())
+    return "\n".join(parts)
+
+
 def test_start_session_success_path_clears_goodbye_silent_gate():
     """Static guard for the successful start_session branch unblocking proactive."""
-    with open(
-        os.path.join(os.path.dirname(__file__), "../../main_logic/core.py"),
-        encoding="utf-8",
-    ) as fh:
-        source = fh.read()
-    normalized_source = re.sub(r"\s+", " ", source)
+    normalized_source = re.sub(r"\s+", " ", _read_core_package_source())
     success_marker = "self._session_start_circuit_open = False"
     clear_marker = "if self.is_goodbye_silent(): self.set_goodbye_silent(False)"
     notify_marker = "await self.send_session_started(input_mode)"
@@ -1117,12 +1124,7 @@ def test_start_session_success_path_clears_goodbye_silent_gate():
 
 def test_start_session_seeds_topic_hooks_with_full_global_locale():
     """Topic hooks must keep zh-TW when start_session falls back to global language."""
-    with open(
-        os.path.join(os.path.dirname(__file__), "../../main_logic/core.py"),
-        encoding="utf-8",
-    ) as fh:
-        source = fh.read()
-    normalized_source = re.sub(r"\s+", " ", source)
+    normalized_source = re.sub(r"\s+", " ", _read_core_package_source())
 
     assert "topic_language_seed = normalize_language_code(get_global_language_full(), format='full')" in normalized_source
     assert "self.user_language = normalize_language_code(topic_language_seed, format='short')" in normalized_source


### PR DESCRIPTION
## 概要

上帝文件拆分路线图第一批第 2 刀。`main_logic/core.py`（10,420 行）拆为 `main_logic/core/` 包，import 路径 `main_logic.core` 保持不变，完全复用 #2148 的 system_router 门面模式。本刀只动模块级代码（~700 行）；`LLMSessionManager` 巨类（212 方法）本体原样不动，留待阶段二。

## 布局

| 文件 | 内容 |
|---|---|
| `core/_shared.py` | 模块级常量、包 logger、语音回声检测、locale 文案助手、`_proactive_expected_sid` ContextVar、`_purge_closed_tool_calls`、`ContextAppendResult` |
| `core/callback_render.py` | agent 回调/语音热切换注入的纯函数渲染族（`apply_role_placeholders`、`_build_callback_instruction`、`_render_pending_extra_replies_by_origin` 等） |
| `core/notices.py` | 重要通知缓冲池（队列/锁/序号三全局的唯一属主） |
| `core/__init__.py` | `LLMSessionManager` 类本体原样 + 全部旧顶层符号 re-export 门面 |

## 关键设计决策

**类刻意留在 `__init__.py`**（任务书预留的两个选项之一）：类方法的 `__globals__` 就是门面模块 dict，25+ 测试文件对 `main_logic.core.<attr>` 的 monkeypatch（`CROSS_MODE_RESTART_WAIT_SECONDS`、`is_livestream_active`、`aload_global_conversation_settings`、`dispatch_text_user_message`、`process_screen_data` 等）继续原样命中类内消费点，不存在 from-import 早绑定导致 patch 静默失效（测试假绿）的风险。已用运行时断言验证 `LLMSessionManager.__init__.__globals__ is vars(main_logic.core)`。

**通知队列单一属主**：`_prominent_notice_queue`/`_lock`/`_seq` 只在 `notices.py` 定义；门面按引用 re-export 函数与容器对象，`main_routers/system_router/status.py` 的 peek/drain 与所有 enqueue 方共享同一队列（已用双路径入队/排干实测）。`_prominent_notice_seq` 故意不 re-export：属主每次 enqueue 重绑该 int，门面快照必然过期；已核实全仓无外部读者。

**仅有的两处非纯搬编辑**（均为保持行为不变所需）：
- logger 显式绑定 `"main_logic.core"` 而非 `__name__`，保住测试断言的 `N.E.K.O.Main.main_logic.core` logger 名；
- `_STATIC_LOCALES_DIR` `parents[1]`→`parents[2]`（文件深了一层），已断言解析到真实 `static/locales`。

**测试侧适配**（第 2 个 commit）：4 个静态源码扫描测试按字面路径读 `main_logic/core.py`，改为读包内全部 `*.py` 拼接——负向断言（"某符号不得存在"）必须覆盖全包，正向/顺序断言的标记均只出现于单一子文件，语义不变。

## 回归报告

**改动性质**：纯代码搬移重构，零行为变化。模块级 ~700 行按职责移入三个子模块；类本体与全部原始 import 语句逐字节保留在 `__init__.py`（git 识别为 rename，相似度 94%）。

**验证方法与结果**：
1. **AST 符号对账**：脚本对比旧 core.py 全部 169 个顶层符号（含 import 绑定）与新包——每个 def/class/assign 在包内 AST 逐字等价（`ast.unparse` 相等），仅上述 2 处白名单编辑；每个符号（除 `_prominent_notice_seq`）可经门面访问。✅
2. **运行时冒烟**：`import main_logic.core` 成功；门面属性 parity（含 `core.time`/`core.re`/`core.json`/`core.TtsStreamNormalizer` 等测试直读的 import 名）；队列单属主身份/行为实测；logger 名、locales 目录、monkeypatch→类全局可见性逐项断言。✅
3. **单测全量对比基线**：`pytest tests/unit` 在本分支与 origin/main（f76b5e5f8）各跑一轮：两侧均为 **61 failed / 4995 passed / 14 skipped，失败集合逐条 diff 完全一致**（61 个为存量红，与本刀无关）。根目录 `tests/test_agent_rewrite_regression.py` + `tests/test_user_utterance_bus_publish.py` 两侧同为 10 failed / 156 passed。✅

**潜在回归面**：
- import 时序：子模块顶层 import（`utils.language_utils`、`config.prompts.prompts_sys` 等）均为旧文件本已存在的模块级 import，无新增传递依赖；import 冒烟未见环。
- 测试 monkeypatch 语义：已被上述第 2 项运行时断言与全量单测覆盖。
- 消费方：`system_router/status.py`（peek/drain）、`plugin/plugins/qq_auto_reply` 与 `wechat_integration`（`apply_role_placeholders`）、`app/main_server.py`（`from main_logic import core`）均走门面路径，属性 parity 已验证。
- 打包/分发：Nuitka 构建按 import 追踪，`main_logic.core` 包与旧模块同名同路径；无脚本按 `main_logic/core.py` 字面路径引用（全仓 grep 仅测试，已适配）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增重要通知缓冲池：支持入队、轮询查看（游标）、按游标清理，并增加语音迁移提示的去重。
  - 引入回调/语音模式渲染能力：占位符替换、分组渲染、事件/任务内容生成与 token 预算控制。
- **改进**
  - 将核心实现从单文件演进为包外观层（对外导入路径保持兼容），并集中整理共享常量/工具逻辑（含语音回显识别与本地化兜底）。
- **测试**
  - 更新静态源码读取方式，改为按 `main_logic/core/` 目录拼接校验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->