### PR TITLE
fix(cloudsave): 修复 POSIX cloud_apply.lock unlock→unlink inode 竞态

### DIFF
--- a/utils/cloudsave_runtime/fence.py
+++ b/utils/cloudsave_runtime/fence.py
@@ -183,10 +183,9 @@ def release_cloud_apply_lock(config_manager) -> None:
     except Exception:
         pass
     _cloud_apply_lock_file = None
-    try:
-        os.unlink(config_manager.local_state_dir / "cloud_apply.lock")
-    except Exception:
-        pass
+    # 刻意不 unlink 锁文件：unlock→unlink 窗口内其他进程可能 flock 旧 inode，
+    # 随后路径被换成新 inode 会出现双持有者。锁文件长期保留（local_state_dir
+    # 不进云存档，残留无害），acquire 每次 open("w") 复用同一路径即可。
 
 
 def _process_holds_cloud_apply_lock() -> bool:


### PR DESCRIPTION
## 背景

PR #2258 review 时 CodeRabbit 指出的 pre-existing 竞态，已验证成立（低概率）。按约定等拆包合并后单独修。

## 问题

`utils/cloudsave_runtime/fence.py` 的 `release_cloud_apply_lock` POSIX 分支在 `flock LOCK_UN` + `close` 之后 `os.unlink` 锁文件，存在双持有者窗口：

1. 进程 A unlock + close；
2. 进程 B 在 unlock→unlink 窗口内 `open` + `flock` **旧 inode** 成功；
3. A 随后 unlink 路径；
4. 进程 C `open("w")` 在同一路径创建**新 inode** 并 `flock` 成功；
5. B（旧 inode）与 C（新 inode）同时持锁。

## 修法

删掉 `release_cloud_apply_lock` 末尾的 `os.unlink` 块，锁文件长期保留，release 只做 unlock + close。原地留注释说明为什么刻意不删。

低风险依据：
- acquire 侧全部是 `LOCK_EX|LOCK_NB` 单次尝试，无重试循环，行为不受锁文件是否预先存在影响（`open(path, "w")` 复用同一路径）；
- `local_state_dir` 明确不进云存档（`utils/config_manager.py` 注释），残留几字节锁文件无害；
- 仅影响 POSIX 构建，Windows 走 `Global\` mutex 分支不受影响。

## 回归报告

- `uv run pytest tests/unit/test_cloudsave_runtime.py` → **72 passed**（含 `test_cloud_apply_fence_releases_lock_when_mode_restore_fails`，该测试断言 release 后可重新 acquire，不钉文件删除，修后仍绿）。
- 改动为纯删除 + 注释，无新增路径；Windows 分支零改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 优化云端应用锁的释放与重新获取流程，避免因锁文件被删除而产生并发问题。
  * 提升多进程操作期间锁机制的稳定性与可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->