### PR TITLE
fix(cloudsave): 加固三处路径拼接对不可信输入的根目录约束

### DIFF
--- a/main_routers/workshop_router/meta.py
+++ b/main_routers/workshop_router/meta.py
@@ -136,6 +136,16 @@ def _normalize_workshop_model_ref(raw_value: str) -> str:
     return str(raw_value or "").strip().replace("\\", "/")
 
 
+def _sanitize_workshop_ref_segments(segments: list[str]) -> list[str]:
+    # 工坊卡的 model 路径来自第三方物品内容，是跨信任边界输入。这里在摄入点
+    # 丢弃 '..'/'.'/盘符段，保证拼出的 model_ref 无法解析出 /workshop/{item_id}/ 之外。
+    return [
+        segment
+        for segment in segments
+        if segment and segment not in ("..", ".") and ":" not in segment
+    ]
+
+
 def _build_subscriber_workshop_model_ref(item_id: str | int, raw_model_ref: str) -> str:
     normalized_ref = _normalize_workshop_model_ref(raw_model_ref)
     normalized_item_id = str(item_id or "").strip()
@@ -145,14 +155,14 @@ def _build_subscriber_workshop_model_ref(item_id: str | int, raw_model_ref: str)
         parts = [segment for segment in normalized_ref.strip("/").split("/") if segment]
         # /workshop/{old_item_id}/...
         if parts and parts[0] == "workshop":
-            tail_parts = parts[2:] if len(parts) >= 2 else []
+            tail_parts = _sanitize_workshop_ref_segments(parts[2:] if len(parts) >= 2 else [])
             if tail_parts:
                 return f"/workshop/{normalized_item_id}/{'/'.join(tail_parts)}"
             return f"/workshop/{normalized_item_id}"
-    relative_ref = normalized_ref.strip("/")
-    if not relative_ref:
+    relative_parts = _sanitize_workshop_ref_segments(normalized_ref.split("/"))
+    if not relative_parts:
         return f"/workshop/{normalized_item_id}"
-    return f"/workshop/{normalized_item_id}/{relative_ref}"
+    return f"/workshop/{normalized_item_id}/{'/'.join(relative_parts)}"
 
 
 def _derive_workshop_model_binding(chara_data: dict) -> dict[str, str]:

--- a/tests/unit/test_cloudsave_runtime.py
+++ b/tests/unit/test_cloudsave_runtime.py
@@ -942,6 +942,47 @@ def test_local_cloudsave_round_trip_restores_runtime_truth(tmp_path):
     assert cloud_state["last_successful_import_at"]
 
 
+def _tamper_manifest_with_memory_key(cm, hostile_key: str, placement_relative_path: str) -> None:
+    placement_path = cm.cloudsave_dir / placement_relative_path
+    placement_path.parent.mkdir(parents=True, exist_ok=True)
+    placement_path.write_text("{}", encoding="utf-8")
+
+    manifest_path = Path(cm.cloudsave_manifest_path)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["files"][hostile_key] = {"sha256": "0" * 64, "size": 2}
+    # 攻击场景里 manifest 由存档作者产出，fingerprint 留空即可跳过一致性校验，
+    # 因此路径约束不能依赖 fingerprint 这道闸。
+    manifest["fingerprint"] = ""
+    atomic_write_json(manifest_path, manifest, ensure_ascii=False, indent=2)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("hostile_key", "placement_relative_path", "error_match"),
+    [
+        # parts 恰好三段的 '..' 穿越：character_name 解析成 '..'，
+        # runtime 目标会落到 memory_dir 的上一级
+        ("memory/../escape.json", "escape.json", "unsupported cloudsave memory path"),
+        # 白名单外的叶子文件名
+        ("memory/小满/evil.bin", "memory/小满/evil.bin", "unsupported cloudsave memory path"),
+        # 角色名过不了 audit（前导空格）
+        ("memory/ 小满/recent.json", "memory/ 小满/recent.json", "character name audit failed"),
+    ],
+)
+def test_import_rejects_hostile_memory_manifest_keys(tmp_path, hostile_key, placement_relative_path, error_match):
+    from utils.cloudsave_runtime import export_local_cloudsave_snapshot, import_local_cloudsave_snapshot
+
+    cm = _make_config_manager(tmp_path)
+    _write_runtime_state(cm)
+    export_local_cloudsave_snapshot(cm)
+    _tamper_manifest_with_memory_key(cm, hostile_key, placement_relative_path)
+
+    with pytest.raises(ValueError, match=error_match):
+        import_local_cloudsave_snapshot(cm)
+
+    assert not (Path(cm.memory_dir).parent / "escape.json").exists()
+
+
 @pytest.mark.unit
 def test_cloudsave_summary_marks_exported_character_as_matched(tmp_path):
     cm = _make_config_manager(tmp_path)

--- a/tests/unit/test_steam_cloud_bundle_i18n_names.py
+++ b/tests/unit/test_steam_cloud_bundle_i18n_names.py
@@ -712,6 +712,42 @@ def test_apply_bundle_rejects_archive_entries_outside_cloudsave_root(tmp_path):
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("hostile_key", ["../escaped.txt", "/abs/escaped.txt", "memory/../../escaped.txt"])
+def test_apply_bundle_rejects_manifest_file_keys_outside_stage_roots(hostile_key: str, tmp_path):
+    # zip 条目本身全部安全，恶意路径只藏在 manifest 的 files key 里——
+    # 复制源/替换目标的拼接必须独立于 zip 解压守卫完成根目录约束。
+    cm = _make_config_manager(tmp_path / "target")
+    bootstrap_local_cloudsave_environment(cm)
+
+    malicious_bytes = io.BytesIO()
+    with zipfile.ZipFile(malicious_bytes, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(
+            "manifest.json",
+            json.dumps(
+                {
+                    "fingerprint": "",
+                    "sequence_number": 1,
+                    "files": {hostile_key: {"sha256": "0" * 64, "size": 1}},
+                },
+                ensure_ascii=False,
+                indent=2,
+            ),
+        )
+
+    stage_root = tmp_path / "staging-root"
+    escaped_path = stage_root / "escaped.txt"
+    with patch("utils.steam_cloud_bundle.create_staging_workspace", return_value=stage_root):
+        with pytest.raises(ValueError, match="unsafe archive entry"):
+            _apply_bundle_to_local_cloudsave(
+                cm,
+                malicious_bytes.getvalue(),
+                {"manifest_fingerprint": ""},
+            )
+
+    assert not escaped_path.exists()
+
+
+@pytest.mark.unit
 def test_apply_bundle_does_not_touch_live_cloudsave_when_staging_copy_fails(tmp_path):
     source_cm = _make_config_manager(tmp_path / "source")
     target_cm = _make_config_manager(tmp_path / "target")

--- a/tests/unit/test_workshop_model_ref.py
+++ b/tests/unit/test_workshop_model_ref.py
@@ -1,0 +1,34 @@
+import pytest
+
+from main_routers.workshop_router.meta import _build_subscriber_workshop_model_ref
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("raw_model_ref", "expected"),
+    [
+        # 正常路径保持原有语义
+        ("example/example.model3.json", "/workshop/999/example/example.model3.json"),
+        ("/workshop/123/model/foo.model3.json", "/workshop/999/model/foo.model3.json"),
+        ("/workshop/123", "/workshop/999"),
+        ("", ""),
+        # 工坊卡是第三方内容，'..' 段在摄入点被剥掉，
+        # 拼出的 model_ref 无法解析出 /workshop/{item_id}/ 之外
+        ("../../secrets/config.json", "/workshop/999/secrets/config.json"),
+        ("/workshop/123/../../secrets/config.json", "/workshop/999/secrets/config.json"),
+        ("foo/../../../bar.model3.json", "/workshop/999/foo/bar.model3.json"),
+        ("..\\..\\evil.model3.json", "/workshop/999/evil.model3.json"),
+        ("..", "/workshop/999"),
+        # '.' 段与盘符段同样被剥掉
+        ("./model/foo.model3.json", "/workshop/999/model/foo.model3.json"),
+        ("C:/evil/foo.model3.json", "/workshop/999/evil/foo.model3.json"),
+    ],
+)
+def test_build_subscriber_workshop_model_ref_strips_traversal_segments(raw_model_ref: str, expected: str):
+    assert _build_subscriber_workshop_model_ref("999", raw_model_ref) == expected
+
+
+@pytest.mark.unit
+def test_build_subscriber_workshop_model_ref_without_item_id_returns_ref_unchanged():
+    # 没有 item_id 时不加前缀；调用方（sync_cards）在 item_id 为空时不会入库 avatar 绑定
+    assert _build_subscriber_workshop_model_ref("", "model/foo.model3.json") == "model/foo.model3.json"

--- a/utils/cloudsave_runtime/operations.py
+++ b/utils/cloudsave_runtime/operations.py
@@ -1018,13 +1018,28 @@ def import_local_cloudsave_snapshot(
         )
         runtime_targets[Path(config_manager.get_runtime_config_path("user_preferences.json"))] = preferences_stage_path
 
+        memory_entries: list[tuple[str, str, Path]] = []
         for relative_path, staged_path in staged_entries.items():
             if not relative_path.startswith("memory/"):
                 continue
             parts = Path(relative_path).parts
-            if len(parts) != 3:
+            # manifest key 是不可信输入：三段结构之外，还要挡住 '..'/'.' 段
+            # （"memory/../x" 的 parts 恰好三段）和白名单外的叶子文件名。
+            if (
+                len(parts) != 3
+                or Path(relative_path).is_absolute()
+                or any(part in ("..", ".") for part in parts)
+                or parts[2] not in MANAGED_MEMORY_FILENAMES
+            ):
                 raise ValueError(f"unsupported cloudsave memory path: {relative_path}")
             _, character_name, filename = parts
+            memory_entries.append((character_name, filename, staged_path))
+
+        memory_name_audit = audit_cloudsave_character_names(
+            sorted({character_name for character_name, _, _ in memory_entries})
+        )
+        _raise_for_name_audit(memory_name_audit, context="import memory")
+        for character_name, filename, staged_path in memory_entries:
             if character_name in tombstone_names:
                 continue
             runtime_targets[Path(config_manager.memory_dir) / character_name / filename] = staged_path

--- a/utils/steam_cloud_bundle.py
+++ b/utils/steam_cloud_bundle.py
@@ -300,10 +300,14 @@ def _apply_bundle_to_local_cloudsave(
     managed_relative_paths = {"manifest.json", *(str(path) for path in manifest_files.keys())}
     payload_relative_paths = sorted(path for path in managed_relative_paths if path != "manifest.json")
 
+    # manifest 里的 files key 与 zip 条目名同属不可信输入，staging 内的读写
+    # 拼接统一走 _resolve_safe_archive_target 约束在各自 stage 根内。
+    staged_source_paths: dict[str, Path] = {}
     for relative_path in managed_relative_paths:
-        staged_file = stage_cloudsave_root / relative_path
+        staged_file = _resolve_safe_archive_target(stage_cloudsave_root, relative_path)
         if not staged_file.is_file():
             raise FileNotFoundError(f"remote cloudsave bundle is missing {relative_path}")
+        staged_source_paths[relative_path] = staged_file
 
     if preserve_newer_local and _local_cloudsave_snapshot_is_newer_or_equal(config_manager, stage_manifest):
         return {
@@ -321,7 +325,10 @@ def _apply_bundle_to_local_cloudsave(
             operation="steam_remote_download",
             stage=f"apply_copy_start:{relative_path}",
         )
-        atomic_copy_file(stage_cloudsave_root / relative_path, stage_replacement_root / relative_path)
+        atomic_copy_file(
+            staged_source_paths[relative_path],
+            _resolve_safe_archive_target(stage_replacement_root, relative_path),
+        )
         assert_deadline_not_exceeded(
             deadline_monotonic,
             operation="steam_remote_download",


### PR DESCRIPTION
## 背景

PR #2258（cloudsave_runtime 拆包）review 时 CodeRabbit 报了两条路径逃逸（inline comments [3564252336](https://github.com/Project-N-E-K-O/N.E.K.O/pull/2258#discussion_r3564252336)、[3564252351](https://github.com/Project-N-E-K-O/N.E.K.O/pull/2258#discussion_r3564252351)），逐条验证结论：均为 pre-existing、自攻击级别（输入只能来自用户自己的 characters.json 或自己账号的 Steam Cloud 存档），但值得加固。本 PR 为独立加固，不含行为重构。

## 三处改动

### 1. workshop 摄入点剥 `..` 段（唯一跨信任边界的缝隙）

`main_routers/workshop_router/meta.py` 的 `_build_subscriber_workshop_model_ref` 给第三方工坊卡的 model 路径加 `/workshop/{item_id}/` 前缀时原样保留 `..` 段，恶意卡可让 model_ref 解析出 workshop_root。现在摄入点剥掉 `..`/`.`/含 `:`（盘符）段，两条拼接分支（`/workshop/` 前缀重写、裸相对路径）都过清洗。

**刻意不按 bot 建议在 `utils/cloudsave_runtime/bindings.py` 的 resolver 层强制 `_is_path_within`**：manual_external 绝对路径模型是一等公民来源，resolver 层 confinement 会把它从 ready 翻成 import_required、指纹清空，且 realpath 会破坏 Windows junction 场景；`tests/unit/test_cloudsave_runtime.py` 大量测试钉死了现有模糊解析结果。

### 2. `import_local_cloudsave_snapshot` 的 memory manifest key 约束

`utils/cloudsave_runtime/operations.py`：manifest key `"memory/../x"` 的 `Path.parts` 恰好 3 段可绕过 `len(parts) != 3` 检查，character_name 解析成 `..`，runtime 目标落到 memory_dir 上一级（单层逃逸，叶子文件名可控）。现在该循环：

- 拒绝含 `..`/`.` 段与绝对路径的 key；
- 叶子文件名必须 ∈ `MANAGED_MEMORY_FILENAMES` 白名单（导出侧只产生白名单文件，无兼容性影响）;
- 角色名统一过 `audit_cloudsave_character_names`（其 Windows 禁字符检查平台无关地挡住 `memory/C:/x` 这类盘符相对段）。

注意 manifest fingerprint 留空即可跳过一致性校验（`if manifest.get("fingerprint")`），所以路径约束不能依赖 fingerprint 这道闸——新增测试显式覆盖了这一点。

### 3. steam apply 侧统一 confinement（防御纵深）

`utils/steam_cloud_bundle.py` `_apply_bundle_to_local_cloudsave`：manifest `files` key 派生的 staging 读写拼接（存在性检查、复制源、替换目标）统一走 `_resolve_safe_archive_target` 约束在各自 stage 根内。当前实际已被 zip 解压侧 `_resolve_safe_archive_target` 守卫链防住，此改动让 manifest key 的约束独立于解压层成立。

## 回归报告

- **本地测试**：`tests/unit/test_cloudsave_runtime.py`（75 passed，含新增 3 个 hostile memory key 用例）、`tests/unit/test_steam_cloud_bundle_i18n_names.py`（含新增 3 个 hostile manifest files key 用例）、`tests/unit/test_workshop_model_ref.py`（新文件，12 用例钉住剥段行为与正常路径不变）、`tests/unit/test_cloudsave_autocloud.py`、`tests/unit/test_workshop_card_face_refresh.py`、`tests/unit/test_workshop_cloudsave_disabled.py`、`tests/unit/test_workshop_router_ugc_details.py`、`tests/unit/test_characters_router_model_settings.py`、`tests/unit/test_character_memory_regression.py` 全绿（合计 274 passed）。rebase 到 #2258 合并后的 main 之后复跑核心套 174 passed。
- **合法路径不受影响**：workshop 正常 model_ref（`example/foo.model3.json`、`/workshop/{id}/...`）拼接结果逐字节不变（有测试钉住）；cloudsave 导出→导入 roundtrip（`test_local_cloudsave_round_trip_restores_runtime_truth`、多语言角色名 roundtrip、bundle roundtrip）全部保持绿。
- **manual_external / bindings resolver 链路零改动**：`utils/cloudsave_runtime/bindings.py` 未触碰，模糊解析语义与指纹行为不变。
- **新增拒绝面**：memory manifest key 白名单外叶子文件名从「静默写入任意文件名」变为报错拒绝导入；恶意 key（`..` 段、audit 不通过的角色名）同样报错。合法导出的存档不会产生这类 key。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **安全性改进**
  * 加强云存档导入与 Steam 云端包应用过程中的路径校验，拦截目录穿越、绝对路径及非法文件名。
  * 防止恶意清单内容将文件写入预期目录之外。
  * 强化工坊模型引用的路径规范化，避免引用越界到指定工坊项目之外。
  * 增加角色名称和内存文件路径的合法性校验，发现异常时明确拒绝处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->