### PR TITLE
fix(agent_server): 修 #2265 review 确认的 4 处存量缺陷 + 2 处 nitpick 清理

### DIFF
--- a/app/agent_server/__init__.py
+++ b/app/agent_server/__init__.py
@@ -983,6 +983,12 @@ async def plugin_execute_direct(payload: Dict[str, Any]):
                 return
             info["result"] = res.result
             info["end_time"] = _now_iso()
+            # 兜底终态先行：下面 inner try 里 detail/delivery_mode 的解析若抛
+            # 异常会被 except 吞掉（只 debug 日志），没有这行 info["status"]
+            # 会永远停在 "running"，finally 的 task_update 只能把 running 广播
+            # 出去，HUD 卡片永久转圈。_plugin_terminal_status 算出精确终态后
+            # 会再覆盖。
+            info["status"] = "completed" if res.success else "failed"
             try:
                 run_data = res.result.get("run_data") if isinstance(res.result, dict) else None
                 run_error = res.result.get("run_error") if isinstance(res.result, dict) else None

--- a/app/agent_server/__init__.py
+++ b/app/agent_server/__init__.py
@@ -591,15 +591,16 @@ async def startup():
             # 注册无人格执行 Agent（允许失败 — 连通即可用）
             # manifest 中直接带 api_key + provider=openai，不依赖环境变量
             try:
-                print("[OpenFang DEBUG] Calling push_agent_manifest...")
                 agent_id = await adapter.push_agent_manifest()
-                print(f"[OpenFang DEBUG] push_agent_manifest returned: {agent_id}")
-                print(f"[OpenFang DEBUG] adapter._executor_agent_id = {adapter._executor_agent_id}")
+                # agent_id 是 daemon 返回的标识符（非用户/LLM 原文），可进 logger
+                logger.debug(
+                    "[OpenFang] push_agent_manifest returned: %s (executor_agent_id=%s)",
+                    agent_id, adapter._executor_agent_id,
+                )
             except Exception as e:
                 import traceback
                 logger.warning("[OpenFang] push_agent_manifest failed (non-fatal): %s", e)
-                print(f"[OpenFang DEBUG] push_agent_manifest EXCEPTION: {e}")
-                print(f"[OpenFang DEBUG] push_agent_manifest traceback:\n{traceback.format_exc()}")
+                logger.debug("[OpenFang] push_agent_manifest traceback:\n%s", traceback.format_exc())
                 agent_id = None
 
             # 只要 daemon 连通就标记 ready，不强制要求 agent 注册成功

--- a/app/agent_server/channels/mcp.py
+++ b/app/agent_server/channels/mcp.py
@@ -66,4 +66,7 @@ async def dispatch(
         except Exception as e:
             logger.warning(f"[TaskExecutor] Failed to notify main_server: {e}")
     else:
-        logger.error(f"[TaskExecutor] ❌ MCP task failed: {result.error}")
+        # error 可能含用户/LLM 原文，logger 只记元数据，原文走 print 兜底
+        # （与本包其他通道的 exception 处理约定一致）。
+        logger.error("[TaskExecutor] ❌ MCP task failed (error_len=%d)", len(str(result.error or "")))
+        print(f"[TaskExecutor] MCP task raw error: {result.error}")

--- a/app/agent_server/channels/openfang.py
+++ b/app/agent_server/channels/openfang.py
@@ -295,16 +295,16 @@ def _patch_usage(data: dict) -> None:
     if not isinstance(usage, dict):
         return
 
-    if "prompt_tokens" not in usage:
+    # ``.get(k) is None`` covers both a missing key and an explicit JSON null.
+    # Zero prompt/completion BEFORE computing total — with the old order,
+    # ``{"prompt_tokens": null}`` reached the addition below and raised
+    # TypeError, silently skipping the patch for that chunk.
+    if usage.get("prompt_tokens") is None:
         usage["prompt_tokens"] = 0
-    if "completion_tokens" not in usage:
+    if usage.get("completion_tokens") is None:
         usage["completion_tokens"] = 0
-    if "total_tokens" not in usage:
-        usage["total_tokens"] = usage.get("prompt_tokens", 0) + usage.get("completion_tokens", 0)
-
-    for k in ("prompt_tokens", "completion_tokens", "total_tokens"):
-        if usage.get(k) is None:
-            usage[k] = 0
+    if usage.get("total_tokens") is None:
+        usage["total_tokens"] = usage["prompt_tokens"] + usage["completion_tokens"]
 
 
 def _patch_malformed_tool_calls(data: dict) -> None:

--- a/app/agent_server/plugin_host.py
+++ b/app/agent_server/plugin_host.py
@@ -204,6 +204,11 @@ async def _start_embedded_user_plugin_server() -> None:
     started = await asyncio.to_thread(ready.wait, 10.0)
     if not started or startup_error or not getattr(server, "started", False):
         server.should_exit = True
+        # 清掉残留 handle（与 _stop_embedded_user_plugin_server 对称）：
+        # 否则函数顶部的 early-return 守卫会把死 server 当成「已在跑」，
+        # 后续任何重试路径都会静默 no-op。
+        _shared.Modules.user_plugin_http_server = None
+        _shared.Modules.user_plugin_http_task = None
         detail = str(startup_error[0]) if startup_error else "timeout or server not started"
         raise RuntimeError(f"embedded user plugin server failed: {detail}")
 

--- a/app/agent_server/plugin_host.py
+++ b/app/agent_server/plugin_host.py
@@ -204,12 +204,19 @@ async def _start_embedded_user_plugin_server() -> None:
     started = await asyncio.to_thread(ready.wait, 10.0)
     if not started or startup_error or not getattr(server, "started", False):
         server.should_exit = True
-        # 清掉残留 handle（与 _stop_embedded_user_plugin_server 对称）：
-        # 否则函数顶部的 early-return 守卫会把死 server 当成「已在跑」，
-        # 后续任何重试路径都会静默 no-op。
+        detail = str(startup_error[0]) if startup_error else "timeout or server not started"
+        # 超时路径上线程可能仍在 uvicorn 启动中途——丢 handle 前先有界
+        # join，让它观察到 should_exit 自行退出；仍存活则 force_exit
+        # 催停（镜像 _stop_embedded_user_plugin_server 的收尾语义），
+        # 避免孤儿线程占着端口跟后续重试抢 bind。
+        await asyncio.to_thread(t.join, 5.0)
+        if t.is_alive():
+            server.force_exit = True
+            logger.warning("[Agent] Embedded plugin server thread still alive after failed startup; forcing exit")
+        # 之后再清残留 handle：否则函数顶部的 early-return 守卫会把死
+        # server 当成「已在跑」，后续任何重试路径都会静默 no-op。
         _shared.Modules.user_plugin_http_server = None
         _shared.Modules.user_plugin_http_task = None
-        detail = str(startup_error[0]) if startup_error else "timeout or server not started"
         raise RuntimeError(f"embedded user plugin server failed: {detail}")
 
     logger.info("[Agent] Embedded user plugin server started on 127.0.0.1:%s (isolated thread)", USER_PLUGIN_SERVER_PORT)

--- a/app/agent_server/plugin_host.py
+++ b/app/agent_server/plugin_host.py
@@ -205,18 +205,20 @@ async def _start_embedded_user_plugin_server() -> None:
     if not started or startup_error or not getattr(server, "started", False):
         server.should_exit = True
         detail = str(startup_error[0]) if startup_error else "timeout or server not started"
-        # 超时路径上线程可能仍在 uvicorn 启动中途——丢 handle 前先有界
-        # join，让它观察到 should_exit 自行退出；仍存活则 force_exit
-        # 催停（镜像 _stop_embedded_user_plugin_server 的收尾语义），
-        # 避免孤儿线程占着端口跟后续重试抢 bind。
+        # 超时路径上线程可能仍在 uvicorn 启动中途。先有界 join 让它观察
+        # 到 should_exit 自行退出；仍存活则整体移交 _stop_embedded_user_
+        # plugin_server 收尾（join(10s) + force_exit 升级、由它清 handle）
+        # ——线程所有权保持到退出或强制收尾完成，孤儿线程不会占着端口
+        # 跟后续重试抢 bind。
         await asyncio.to_thread(t.join, 5.0)
         if t.is_alive():
-            server.force_exit = True
-            logger.warning("[Agent] Embedded plugin server thread still alive after failed startup; forcing exit")
-        # 之后再清残留 handle：否则函数顶部的 early-return 守卫会把死
-        # server 当成「已在跑」，后续任何重试路径都会静默 no-op。
-        _shared.Modules.user_plugin_http_server = None
-        _shared.Modules.user_plugin_http_task = None
+            logger.warning("[Agent] Embedded plugin server thread still alive after failed startup; delegating to stop path")
+            await _stop_embedded_user_plugin_server()
+        else:
+            # 线程已退——清残留 handle：否则函数顶部的 early-return 守卫
+            # 会把死 server 当成「已在跑」，后续任何重试路径都静默 no-op。
+            _shared.Modules.user_plugin_http_server = None
+            _shared.Modules.user_plugin_http_task = None
         raise RuntimeError(f"embedded user plugin server failed: {detail}")
 
     logger.info("[Agent] Embedded user plugin server started on 127.0.0.1:%s (isolated thread)", USER_PLUGIN_SERVER_PORT)

--- a/app/agent_server/registry.py
+++ b/app/agent_server/registry.py
@@ -43,7 +43,9 @@ _LEGACY_CORRECTION_PUBLIC_KEYS = {
 
 
 def _now_iso() -> str:
-    return datetime.utcnow().isoformat() + "Z"
+    # datetime.utcnow() is deprecated since Python 3.12; the tz-aware form
+    # yields the exact same string ("+00:00" swapped back to the legacy "Z").
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def _cleanup_task_registry() -> List[Dict[str, Any]]:

--- a/tests/unit/test_agent_server_hardening.py
+++ b/tests/unit/test_agent_server_hardening.py
@@ -1,0 +1,233 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for the agent_server hardening follow-up (post PR #2265).
+
+Covers the four pre-existing defects surfaced by review on the package split:
+1. ``_patch_usage`` raised TypeError on explicit JSON null token fields.
+2. ``plugin_execute_direct``'s ``_run_plugin`` left the registry entry stuck
+   at "running" when result parsing raised inside the inner try.
+3. ``_start_embedded_user_plugin_server`` left stale server/thread handles on
+   startup failure, turning later start attempts into silent no-ops.
+4. The MCP channel failure branch logged raw ``result.error`` text instead of
+   metadata-only logging (privacy convention).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# 1. _patch_usage: explicit nulls must not raise and must be zero-filled
+# ---------------------------------------------------------------------------
+
+
+def test_patch_usage_tolerates_explicit_null_token_fields():
+    from app.agent_server.channels.openfang import _patch_usage
+
+    data = {"usage": {"prompt_tokens": None, "completion_tokens": None}}
+    _patch_usage(data)
+    assert data["usage"] == {
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "total_tokens": 0,
+    }
+
+
+def test_patch_usage_recomputes_total_from_partial_nulls():
+    from app.agent_server.channels.openfang import _patch_usage
+
+    data = {"usage": {"prompt_tokens": 3, "completion_tokens": None, "total_tokens": None}}
+    _patch_usage(data)
+    assert data["usage"] == {
+        "prompt_tokens": 3,
+        "completion_tokens": 0,
+        "total_tokens": 3,
+    }
+
+
+def test_patch_usage_fills_missing_usage_object():
+    from app.agent_server.channels.openfang import _patch_usage
+
+    data = {"usage": None}
+    _patch_usage(data)
+    assert data["usage"] == {
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "total_tokens": 0,
+    }
+
+
+def test_patch_usage_keeps_existing_values():
+    from app.agent_server.channels.openfang import _patch_usage
+
+    data = {"usage": {"prompt_tokens": 5, "completion_tokens": 7}}
+    _patch_usage(data)
+    assert data["usage"] == {
+        "prompt_tokens": 5,
+        "completion_tokens": 7,
+        "total_tokens": 12,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 2. plugin_execute_direct: parse failure must not strand status="running"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_plugin_execute_direct_parse_failure_still_reaches_terminal_state(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from app import agent_server as srv
+
+    saved_registry = dict(srv.Modules.task_registry)
+    saved_handles = dict(srv.Modules.task_async_handles)
+    saved_executor = srv.Modules.task_executor
+    saved_analyzer = srv.Modules.analyzer_enabled
+    srv.Modules.task_registry.clear()
+    srv.Modules.task_async_handles.clear()
+
+    emitted: list[tuple[str, dict]] = []
+
+    async def _emit_main_event(event_type, lanlan_name, **payload):
+        emitted.append((event_type, payload))
+
+    async def _friendly_name(plugin_id):
+        return None
+
+    executor = MagicMock()
+    executor.execute_user_plugin_direct = AsyncMock(
+        return_value=SimpleNamespace(success=True, result={"run_data": {}}, error=None)
+    )
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("parse blew up")
+
+    try:
+        srv.Modules.task_executor = executor
+        srv.Modules.analyzer_enabled = True
+        monkeypatch.setitem(srv.Modules.agent_flags, "user_plugin_enabled", True)
+        monkeypatch.setattr(srv, "_emit_main_event", _emit_main_event)
+        monkeypatch.setattr(srv, "_get_plugin_friendly_name", _friendly_name)
+        # parse_plugin_result is resolved from the facade globals by _run_plugin
+        monkeypatch.setattr(srv, "parse_plugin_result", _boom)
+
+        resp = await srv.plugin_execute_direct({"plugin_id": "p1", "entry_id": "e1"})
+        task_id = resp["task_id"]
+        bg = srv.Modules.task_async_handles.get(task_id)
+        assert bg is not None
+        await bg
+
+        info = srv.Modules.task_registry[task_id]
+        # The whole point: parsing raised, yet the entry must not stay "running".
+        assert info["status"] == "completed"
+        terminal_updates = [
+            p["task"]
+            for t, p in emitted
+            if t == "task_update" and p.get("task", {}).get("end_time")
+        ]
+        assert terminal_updates and terminal_updates[-1]["status"] == "completed"
+    finally:
+        srv.Modules.task_registry.clear()
+        srv.Modules.task_registry.update(saved_registry)
+        srv.Modules.task_async_handles.clear()
+        srv.Modules.task_async_handles.update(saved_handles)
+        srv.Modules.task_executor = saved_executor
+        srv.Modules.analyzer_enabled = saved_analyzer
+
+
+# ---------------------------------------------------------------------------
+# 3. _start_embedded_user_plugin_server: failure must clear stale handles
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_embedded_plugin_server_start_failure_clears_handles(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from app.agent_server import plugin_host
+    from app.agent_server import _shared
+
+    M = _shared.Modules
+    saved = (M.user_plugin_http_server, M.user_plugin_http_task, M.user_plugin_app, M._plugin_server_loop)
+    M.user_plugin_http_server = None
+    M.user_plugin_http_task = None
+    # Pre-set the app so the real plugin http_app build is skipped.
+    M.user_plugin_app = MagicMock()
+
+    class _FakeServer:
+        def __init__(self, config):
+            self.config = config
+            self.started = False  # never comes up -> failure branch
+            self.should_exit = False
+            self.install_signal_handlers = lambda: None
+
+        async def serve(self):
+            return None
+
+    fake_uvicorn = types.SimpleNamespace(
+        Config=lambda *a, **k: SimpleNamespace(),
+        Server=_FakeServer,
+    )
+    monkeypatch.setitem(sys.modules, "uvicorn", fake_uvicorn)
+
+    try:
+        with pytest.raises(RuntimeError, match="embedded user plugin server failed"):
+            await plugin_host._start_embedded_user_plugin_server()
+        # The fix under test: stale handles must be cleared so a later start
+        # attempt is not silently swallowed by the top-of-function guard.
+        assert M.user_plugin_http_server is None
+        assert M.user_plugin_http_task is None
+    finally:
+        (
+            M.user_plugin_http_server,
+            M.user_plugin_http_task,
+            M.user_plugin_app,
+            M._plugin_server_loop,
+        ) = saved
+
+
+# ---------------------------------------------------------------------------
+# 4. MCP channel failure branch: metadata-only logging
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_dispatch_failure_logs_metadata_not_raw_error(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+):
+    from app.agent_server.channels import mcp as mcp_channel
+
+    fake_logger = MagicMock()
+    monkeypatch.setattr(mcp_channel, "logger", fake_logger)
+
+    result = SimpleNamespace(
+        success=False,
+        error="SECRET user text",
+        task_description="do things",
+        result=None,
+        task_id="t-mcp",
+        execution_method="mcp",
+    )
+    await mcp_channel.dispatch(
+        result,
+        messages=[],
+        lanlan_name="lanlan",
+        conversation_id=None,
+        trigger_user_msg_sig=None,
+    )
+
+    assert fake_logger.error.called
+    logged = " ".join(str(a) for call in fake_logger.error.call_args_list for a in call.args)
+    assert "SECRET user text" not in logged
+    assert "error_len" in logged
+    # Raw text still reaches the local print fallback.
+    assert "SECRET user text" in capsys.readouterr().out

--- a/tests/unit/test_agent_server_hardening.py
+++ b/tests/unit/test_agent_server_hardening.py
@@ -226,7 +226,9 @@ async def test_mcp_dispatch_failure_logs_metadata_not_raw_error(
     )
 
     assert fake_logger.error.called
-    logged = " ".join(str(a) for call in fake_logger.error.call_args_list for a in call.args)
+    # repr(call) covers positional AND keyword args, so a hypothetical
+    # ``logger.error(..., error=raw_text)`` cannot slip past the assertion.
+    logged = " ".join(repr(call) for call in fake_logger.error.call_args_list)
     assert "SECRET user text" not in logged
     assert "error_len" in logged
     # Raw text still reaches the local print fallback.


### PR DESCRIPTION
#2265（agent_server 包拆分，纯搬移）review 期间由 CodeRabbit/复核确认、因「拆分 PR 零行为变化」原则刻意不掺进拆分 diff 的存量缺陷，在此统一修掉。全部问题在 main 的原单体代码中同样存在（#2265 的 AST 等价证明覆盖）；各 review thread 已逐条对齐方案：[__init__](https://github.com/Project-N-E-K-O/N.E.K.O/pull/2265#discussion_r3564924919)、[mcp](https://github.com/Project-N-E-K-O/N.E.K.O/pull/2265#discussion_r3564924930)、[openfang](https://github.com/Project-N-E-K-O/N.E.K.O/pull/2265#discussion_r3564924934)、[plugin_host](https://github.com/Project-N-E-K-O/N.E.K.O/pull/2265#discussion_r3564924937)。

## 修复内容

**4 处确认缺陷**（commit 1）：

1. **`plugin_execute_direct._run_plugin` 任务卡 running**（`app/agent_server/__init__.py`）：executor 返回后，detail/delivery_mode 解析（`parse_plugin_result`/`_resolve_delivery_mode`/`_plugin_terminal_status`）若抛异常会被 inner `except` 吞掉（仅 debug 日志），`info["status"]` 停在 "running"，finally 的 task_update 只能广播 running，HUD 卡片永久转圈。修法＝解析前先写 `res.success` 推导的兜底终态，`_plugin_terminal_status` 算出精确值后照常覆盖（cancelled 守卫在写终态之前，语义不受影响）。
2. **MCP 通道失败分支 logger 泄漏原文**（`channels/mcp.py`）：`logger.error(f"... {result.error}")` 违背全包「logger 只记元数据、原文走 print 兜底」约定——改为 `error_len` + print。
3. **`_patch_usage` 显式 null 触发 TypeError**（`channels/openfang.py`）：None 归零循环排在 total 计算之后，`{"prompt_tokens": null}` 会走到 `None + None`（调用点 try/except 兜底不炸服务，但该 chunk 的 patch 静默失效）。修法＝`.get(k) is None` 统一覆盖缺失与显式 null、归零前移；total 为显式 null 时也重算（旧代码置 0，新代码得到正确和，属修复的一部分）。
4. **嵌入式插件服务器启动失败残留 handle**（`plugin_host.py`）：失败分支只 `should_exit` 就 raise，`Modules.user_plugin_http_server/_task` 仍指向死 server，顶部 early-return 守卫会把它当「已在跑」。修法＝失败分支清空两 handle（与 `_stop_embedded_user_plugin_server` 对称）。当前唯一调用点是 startup()（进程一次性），属防御性对称修补。

**2 处 nitpick 清理**（commit 2）：

- `registry._now_iso`：`datetime.utcnow()`（3.12 起弃用）→ `datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")`，输出串逐字符一致（已运行时断言验证）。
- `__init__` OpenFang `push_agent_manifest` 的 5 处 `[OpenFang DEBUG]` print → `logger.debug`（agent_id 是 daemon 返回的标识符、非用户/LLM 原文，可进 logger；traceback 同）。

## 回归报告

- 新增 `tests/unit/test_agent_server_hardening.py` 共 **7 个单测**，逐一锁住四处修复的语义：
  - `_patch_usage` ×4：全 null、部分 null 重算 total、缺 usage 对象补全、正常值不受扰动
  - `plugin_execute_direct`：monkeypatch `parse_plugin_result` 抛异常 → 断言注册表终态为 completed 且 finally 广播的 task_update 是终态而非 running
  - `_start_embedded_user_plugin_server`：fake uvicorn（不 bind 端口）走启动失败分支 → 断言两 handle 被清空
  - mcp dispatch 失败分支：断言 logger.error 参数含 `error_len` 且不含原文、print 兜底含原文
- agent 相关套件（runtime_intent + end_all_notify + voice_bridge + callback_instruction_origin + hardening）**73 passed**，全绿。
- 冒烟 `from app import agent_server; assert agent_server.app` ✅（rebase 到合并后的 main 之上验证）。
- `_now_iso` 新旧输出串运行时比对一致（`...Z` 结尾、无 `+00:00`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复插件直接执行在解析异常时任务状态可能一直停留在“运行中”的问题，确保进入完成/失败终态并回传终态时间。
  * 修复 OpenAI 兼容响应中 `usage` 缺失/为 null 时的令牌统计错误。
  * 插件嵌入式服务器启动失败后会清理陈旧句柄，避免后续重试被静默跳过。
  * 优化后台初始化与 MCP 失败日志输出，遵循隐私合规并保留关键信息。
* **Tests**
  * 新增硬化回归测试，覆盖令牌统计、任务终态、失败清理与日志合规场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->