### PR TITLE
fix(vrm): 修正 vrm-cursor-follow.js 两处与代码相反的 forwardSign 注释

### DIFF
--- a/static/vrm/vrm-cursor-follow.js
+++ b/static/vrm/vrm-cursor-follow.js
@@ -223,7 +223,7 @@ class CursorFollowController {
         this._tempEuler = null;
 
         // ── 模型前方向符号（由 _detectModelForward() 动态检测） ──
-        // VRM 0.x (worldZ>=0) → -1, VRM 1.0 (worldZ<0) → +1
+        // VRM 1.0 → -1, VRM 0.x → +1
         this._modelForwardZ = 1;
 
         // ── 事件处理器引用 ──
@@ -430,8 +430,8 @@ class CursorFollowController {
     //  辅助：检测模型实际前方向
     //  基于 VRM 模型版本（由 vrm-core.js detectVRMVersion 从 GLTF
     //  extensionsUsed / meta 属性检测），不依赖 scene 世界旋转：
-    //    VRM 1.0 → three-vrm 内部对 scene 做了 180° Y 翻转，forwardSign = +1
-    //    VRM 0.x → forwardSign = -1
+    //    VRM 1.0 → three-vrm 内部对 scene 做了 180° Y 翻转，forwardSign = -1
+    //    VRM 0.x → forwardSign = +1
     // ════════════════════════════════════════════════════════════════
     _detectModelForward() {
         const vrmVersion = this.manager?.core?.vrmVersion;

--- a/static/vrm/vrm-cursor-follow.js
+++ b/static/vrm/vrm-cursor-follow.js
@@ -748,7 +748,7 @@ class CursorFollowController {
                 dirWorld.normalize();
 
                 // modelForward / modelUp / modelRight
-                // 使用 _modelForwardZ 适配 VRM 0.x(-Z) 和 1.0(+Z) 的前方向差异
+                // 使用 _modelForwardZ 适配 VRM 0.x(+Z) 和 1.0(-Z) 的前方向差异
                 const modelForward = this._tempVec3B.set(0, 0, this._modelForwardZ).applyQuaternion(this._tempQuat);
                 const modelUp = this._tempVec3C.set(0, 1, 0).applyQuaternion(this._tempQuat);
                 const modelRight = this._tempVec3D.crossVectors(modelUp, modelForward).normalize();


### PR DESCRIPTION
## 背景

PR #2273 review 中 CodeRabbit 发现（已人工确认）：`static/vrm/vrm-cursor-follow.js` 有两处注释与实际代码相反。实际代码 `_detectModelForward()` 为 `this._modelForwardZ = (vrmVersion === '1.0') ? -1 : 1;`（VRM 1.0 → -1，VRM 0.x → +1，方法内行内注释正确），但：

- 构造函数 `_modelForwardZ` 初始化处注释写 "VRM 0.x → -1, VRM 1.0 → +1"（相反）
- `_detectModelForward()` 方法头注释写 "VRM 1.0 → forwardSign = +1；VRM 0.x → forwardSign = -1"（相反）

## 改动

把这两处注释改成与代码一致（照方法内行内注释的说法）。纯注释修正，不改任何代码逻辑。

## 验证

`node --test static/avatar-multiscreen-drag.test.cjs` 6/6 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 修正 VRM 版本对应模型前向方向符号的注释说明，使其与当前行为保持一致。
  * 未改变模型跟踪或运行逻辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->