### PR TITLE
fix(vrm/mmd): 模型加载并发串行化 + 恢复 VRM cleanupUI（#2273 review 后续）

### DIFF
--- a/static/mmd/mmd-core.js
+++ b/static/mmd/mmd-core.js
@@ -427,7 +427,7 @@ class MMDCore {
 
     // ═══════════════════ 模型加载 ═══════════════════
 
-    async loadModel(modelUrl, options = {}) {
+    async loadModel(modelUrl, options = {}, managerLoadToken = null) {
         const THREE = window.THREE;
         if (!THREE) {
             throw new Error('Three.js 库未加载，无法加载 MMD 模型');
@@ -437,9 +437,27 @@ class MMDCore {
             throw new Error(`MMD 模型路径无效: ${modelUrl}`);
         }
 
+        // 加载令牌由 mmd-manager.js 分配并传入；未传时回退读当前值（等价旧行为）。
+        // 必须在首个 await 之前确定：旧实现在模块导入 await 之后才读当前值，悬挂期间
+        // 若有新调用进入会误拿新调用的 token，使下方的取代检查失效（幽灵模型叠加）。
+        const loadToken = managerLoadToken !== null ? managerLoadToken : this.manager._activeLoadToken;
+
+        // 已被更新的加载取代（如失败回退路径迟到）：在触碰 currentModel 之前退出，
+        // 避免把新调用刚装好的模型 _clearModel 掉
+        if (this.manager._activeLoadToken !== loadToken) {
+            console.log('[MMD Core] 模型加载已被取代（进入时），跳过');
+            return null;
+        }
+
         const mmdModule = await this._getMMDModule();
         if (!mmdModule) {
             throw new Error('three-mmd 模块加载失败');
+        }
+
+        // 模块导入悬挂期间同样可能被取代：同上，先于 _clearModel 检查
+        if (this.manager._activeLoadToken !== loadToken) {
+            console.log('[MMD Core] 模型加载已被取代（模块导入后），跳过');
+            return null;
         }
 
         const { MMDLoader } = mmdModule;
@@ -476,9 +494,6 @@ class MMDCore {
         if (this.manager.currentModel) {
             this._clearModel();
         }
-
-        // 加载令牌由 mmd-manager.js 管理，此处仅读取当前值用于竞态检查
-        const loadToken = this.manager._activeLoadToken;
 
         try {
             // MMDLoader.load 返回 MMD 对象

--- a/static/mmd/mmd-manager.js
+++ b/static/mmd/mmd-manager.js
@@ -118,7 +118,7 @@ class MMDManager {
         const loadToken = this._activeLoadToken;
 
         try {
-            const modelInfo = await this.core.loadModel(modelPath, options);
+            const modelInfo = await this.core.loadModel(modelPath, options, loadToken);
 
             // 检查是否已被新的加载请求取代或已 dispose
             if (this._isDisposed || this._activeLoadToken !== loadToken) {
@@ -170,12 +170,19 @@ class MMDManager {
         } catch (error) {
             console.error('[MMD Manager] 模型加载失败:', error);
 
+            // 已被新的加载请求取代或已 dispose：不再回退，避免迟到的回退加载
+            // 清掉新请求装好的模型
+            if (this._isDisposed || this._activeLoadToken !== loadToken) {
+                console.log('[MMD Manager] 模型加载已被取代或已销毁，跳过回退');
+                return null;
+            }
+
             // 尝试回退到默认模型
             const defaultModelPath = MMDManager.DEFAULT_MODEL_PATH;
             if (modelPath !== defaultModelPath) {
                 console.warn('[MMD Manager] 模型加载失败，尝试回退到默认模型:', defaultModelPath);
                 try {
-                    const modelInfo = await this.core.loadModel(defaultModelPath, options);
+                    const modelInfo = await this.core.loadModel(defaultModelPath, options, loadToken);
 
                     if (this._isDisposed || this._activeLoadToken !== loadToken) {
                         console.log('[MMD Manager] 回退模型加载已被取代或已销毁');

--- a/static/vrm/vrm-core.js
+++ b/static/vrm/vrm-core.js
@@ -1002,7 +1002,18 @@ class VRMCore {
                 };
                 requestAnimationFrame(waitFrames);
             });
-            
+
+            // 加载竞态守卫（二道）：一道守卫之后经过了 applyVRM0 旋转 / 偏好 fetch / 3 帧等待
+            // 等 await，期间可能被更新的加载取代。这里是「最后一个 await 之后、任何共享 manager
+            // 写入（相机位姿 / enableFaceCamera / scene.add / currentModel）之前」的屏障——若不
+            // 在此拦截，被取代的旧加载会用它自己模型的存档相机覆写共享相机，把已经可见的新模型
+            // 顶到屏外（Codex P2）。此处到 scene.add / currentModel 全程再无 await，一道即可覆盖。
+            if (this.manager._activeLoadToken !== loadToken) {
+                console.log('[VRM Core] 模型加载已被取代（共享相机/入场前），跳过并释放资源');
+                await this._disposeAbandonedVRM(vrm);
+                return null;
+            }
+
             // 旋转设置统一在这里处理，确保只应用一次
             // 先通过检测器检测并修复方向，然后应用最终的旋转值
             const savedRotation = this.getEffectiveSavedRotation(preferences?.rotation, versionDefaultRotation);
@@ -1191,14 +1202,7 @@ class VRMCore {
                 throw new Error(errorMsg);
             }
 
-            // 加载竞态守卫（二道）：一道守卫之后到这里还有偏好 fetch / 3 帧等待等 await，
-            // 期间同样可能被取代；在把模型加入共享 scene、覆写 currentModel 之前再校验一次。
-            if (this.manager._activeLoadToken !== loadToken) {
-                console.log('[VRM Core] 模型加载已被取代（入场前），跳过并释放资源');
-                await this._disposeAbandonedVRM(vrm);
-                return null;
-            }
-
+            // 此处到 scene.add 之间无 await，二道守卫（3 帧等待后）已覆盖，无需重复校验。
             this.manager.scene.add(vrm.scene);
 
             // 优化材质设置（根据性能模式）

--- a/static/vrm/vrm-core.js
+++ b/static/vrm/vrm-core.js
@@ -715,12 +715,20 @@ class VRMCore {
         }
     }
 
-    async loadModel(modelUrl, options = {}) {
+    async loadModel(modelUrl, options = {}, managerLoadToken = null) {
         const THREE = window.THREE;
         if (!THREE) {
             const errorMsg = window.t ? window.t('vrm.error.threeNotLoadedForModel') : 'Three.js库未加载，无法加载VRM模型';
             throw new Error(errorMsg);
         }
+
+        // 加载令牌：由 vrm-manager._loadModelExclusive 在入口分配后传入；直接调用时
+        // 回退读当前值（等价旧行为）。core.loadModel 在多个 await（GLTF 网络加载、偏好
+        // fetch、3 帧等待）之间会 remove/dispose/add 共享 scene 并覆写 currentModel，
+        // manager 的串行队列在 dispose 后会被清空以保证活性，因此这些跨越 await 的共享
+        // 副作用必须自带 token 守卫，否则被取代的迟到加载会毁掉新会话已装好的模型。
+        // 与 mmd-core.loadModel 的 token 守卫对偶。
+        const loadToken = managerLoadToken !== null ? managerLoadToken : this.manager._activeLoadToken;
 
         if (!modelUrl || 
             modelUrl === 'undefined' || 
@@ -806,6 +814,16 @@ class VRMCore {
                 } else {
                     throw error;
                 }
+            }
+
+            // 加载竞态守卫（一道）：GLTF 网络加载 + 依赖导入是最长的 await；若在此期间被
+            // dispose 或新一轮 loadModel 取代（loadToken 失效），必须在触碰共享 scene/
+            // currentModel 之前退出——否则本次迟到的加载会把新会话已装好的模型 remove/
+            // disposeVRM 掉（幽灵模型损坏）。释放本次已加载但不再采用的 VRM 资源避免显存泄漏。
+            if (this.manager._activeLoadToken !== loadToken) {
+                console.log('[VRM Core] 模型加载已被取代（GLTF 加载后），跳过并释放资源');
+                await this._disposeAbandonedVRM(gltf.userData?.vrm);
+                return null;
             }
 
             if (this.manager.currentModel && this.manager.currentModel.vrm) {
@@ -1172,7 +1190,15 @@ class VRMCore {
                 const errorMsg = window.t ? window.t('vrm.error.sceneNotInitializedForAdd') : '场景未初始化。请先调用 initThreeJS() 初始化场景。';
                 throw new Error(errorMsg);
             }
-            
+
+            // 加载竞态守卫（二道）：一道守卫之后到这里还有偏好 fetch / 3 帧等待等 await，
+            // 期间同样可能被取代；在把模型加入共享 scene、覆写 currentModel 之前再校验一次。
+            if (this.manager._activeLoadToken !== loadToken) {
+                console.log('[VRM Core] 模型加载已被取代（入场前），跳过并释放资源');
+                await this._disposeAbandonedVRM(vrm);
+                return null;
+            }
+
             this.manager.scene.add(vrm.scene);
 
             // 优化材质设置（根据性能模式）
@@ -1222,6 +1248,24 @@ class VRMCore {
         } catch (error) {
             console.error('加载 VRM 模型失败:', error);
             throw error;
+        }
+    }
+
+    /**
+     * 释放一个「已加载完成但因 loadToken 失效不会被采用」的 VRM 资源。
+     * 用于 loadModel 的竞态守卫早退路径：此时 vrm 尚未写入 manager.currentModel，
+     * 不能走 disposeVRM（那依赖 currentModel），需就地 deepDispose 避免 GPU 显存泄漏。
+     */
+    async _disposeAbandonedVRM(vrm) {
+        if (!vrm || !vrm.scene) return;
+        try {
+            if (vrm.scene.parent) vrm.scene.parent.remove(vrm.scene);
+            const VRMUtils = await VRMCore._getVRMUtils();
+            if (VRMUtils && typeof VRMUtils.deepDispose === 'function') {
+                VRMUtils.deepDispose(vrm.scene);
+            }
+        } catch (e) {
+            console.warn('[VRM Core] 释放被取代的 VRM 资源失败:', e);
         }
     }
 

--- a/static/vrm/vrm-core.js
+++ b/static/vrm/vrm-core.js
@@ -722,7 +722,7 @@ class VRMCore {
             throw new Error(errorMsg);
         }
 
-        // 加载令牌：由 vrm-manager._loadModelExclusive 在入口分配后传入；直接调用时
+        // 加载令牌：由 vrm-manager._loadModelInternal 在入口分配后传入；直接调用时
         // 回退读当前值（等价旧行为）。core.loadModel 在多个 await（GLTF 网络加载、偏好
         // fetch、3 帧等待）之间会 remove/dispose/add 共享 scene 并覆写 currentModel，
         // manager 的串行队列在 dispose 后会被清空以保证活性，因此这些跨越 await 的共享

--- a/static/vrm/vrm-manager.js
+++ b/static/vrm/vrm-manager.js
@@ -53,7 +53,6 @@ class VRMManager {
         this._initThreePromise = null;
         this._isDisposed = false;
         this._activeLoadToken = 0;
-        this._loadModelChain = null;
         this._loadState = 'idle';
         this._isModelReadyForInteraction = false;
 
@@ -1000,31 +999,27 @@ class VRMManager {
     }
 
     async loadModel(modelUrl, options = {}) {
-        // 并发串行化：core.loadModel 内部在 移除旧模型/disposeVRM/scene.add/currentModel 赋值
-        // 之间有多个 await 悬挂点，两次调用交错执行会留下永不清理的幽灵模型，或让先发的
-        // 慢调用把后发调用已装好的新模型误销毁。loadToken 只能拦截收尾阶段，挡不住中途
-        // 副作用，因此在入口整体排队：token 入口分配（后到者胜），加载体依次独占执行，
-        // 排队期间被更新调用取代的直接跳过（连网络请求都不发起）。
+        // 并发正确性由 vrm-core.loadModel 的 token 守卫兜底，实现「后到者胜」：每次 loadModel
+        // 在入口同步 bump _activeLoadToken 取代前一轮；被取代的旧加载在 core 内触碰共享
+        // scene/currentModel 之前的守卫处 bail，不会交错改写共享状态或留下幽灵模型。
+        //
+        // 因此不再排串行队列：队列里每个 predecessor 在其 successor 入队时其实已被 token
+        // 取代，让新加载 await 它只是「空等一个已被自己取代的旧加载」——而 GLTFLoader.load
+        // 无超时/中止，慢或挂死的旧加载会无限期阻塞正常的 VRM→VRM 切换（Codex P2）。
+        // token-only 方案与 mmd-manager.loadModel 对偶；代价是快速连切时被取代的加载会各自
+        // 完成一次下载后才 bail（带宽浪费），换取活性，符合 MMD 既有取舍。
         const loadToken = ++this._activeLoadToken;
         this._loadState = 'preparing';
         this._isModelReadyForInteraction = false;
-        const previousLoad = this._loadModelChain || Promise.resolve();
-        const currentLoad = previousLoad
-            .catch(() => {})
-            .then(() => {
-                if (!this._isLoadTokenActive(loadToken)) return null;
-                return this._loadModelExclusive(modelUrl, options, loadToken);
-            });
-        // 队列指针吞掉异常，避免悬挂 rejected promise；调用方仍通过 currentLoad 收到原始异常
-        this._loadModelChain = currentLoad.then(() => undefined, () => undefined);
-        return currentLoad;
+        return this._loadModelInternal(modelUrl, options, loadToken);
     }
 
     /**
-     * loadModel 的实际加载体。只能经由 loadModel 的串行队列进入，保证同一时刻
-     * 至多一个实例在执行；loadToken 由 loadModel 在入口分配后传入。
+     * loadModel 的实际加载体。loadToken 由 loadModel 在入口分配后传入；同一时刻可能有
+     * 多个实例并发在跑（快速连切），但只有持 current token 的那个能穿过 core 的守卫改写
+     * 共享状态，被取代的实例在 core 返回 null 后一路空转到早退，不 clobber 胜出者的状态。
      */
-    async _loadModelExclusive(modelUrl, options, loadToken) {
+    async _loadModelInternal(modelUrl, options, loadToken) {
         this._loadState = 'preparing';
         this._isModelReadyForInteraction = false;
         // 新一轮加载：取消上一轮可能还在跑的 T-pose 回退重试，避免旧重试打断新模型动画
@@ -1049,7 +1044,8 @@ class VRMManager {
             if (canvas && container) {
                 const threeReady = await this.ensureThreeReady(canvasId, containerId);
                 if (!threeReady) {
-                    this._loadState = 'idle';
+                    // 仅当自己仍是当前加载时才复位状态，避免被取代的实例 clobber 胜出者
+                    if (this._isLoadTokenActive(loadToken)) this._loadState = 'idle';
                     return null;
                 }
             } else {
@@ -1070,7 +1066,8 @@ class VRMManager {
         // 加载模型
         const result = await this.core.loadModel(modelUrl, options, loadToken);
         if (!this._isLoadTokenActive(loadToken)) {
-            this._loadState = 'idle';
+            // 已被更新的加载取代：core 已在守卫处 bail 并释放本次资源，这里直接返回，
+            // 不写 _loadState——否则会 clobber 正在并发跑的胜出者的状态（无队列后新增约束）。
             return result;
         }
 
@@ -1441,14 +1438,9 @@ class VRMManager {
         console.log('[VRM Manager] 开始完整清理 VRM 资源...');
         this._isDisposed = true;
 
-        // Invalidate any in-flight loadModel() async callbacks
+        // 使在途的 loadModel 失效：bump token 后，被取代的旧 load 的 core.loadModel
+        // 恢复时会在守卫处 bail、不覆写新会话；无串行队列，无需清理队列指针。
         ++this._activeLoadToken;
-        // 清空串行队列指针：dispose 只 bump token 不足以让下一次会话的 loadModel
-        // 立即开始——若不清空，被取代的旧 load（其 core.loadModel 可能仍挂在无超时的
-        // GLTF 网络请求上）会作为 previousLoad 把 dispose 后的新 load 堵在队列后（活性）。
-        // 清空后新 load 的 previousLoad 退回 Promise.resolve() 直接开跑；旧 load 的 core
-        // 侧 token 守卫（vrm-core.loadModel）保证它恢复时不会覆写新会话的模型（安全）。
-        this._loadModelChain = null;
         this._loadState = 'idle';
         this._isModelReadyForInteraction = false;
 

--- a/static/vrm/vrm-manager.js
+++ b/static/vrm/vrm-manager.js
@@ -53,6 +53,7 @@ class VRMManager {
         this._initThreePromise = null;
         this._isDisposed = false;
         this._activeLoadToken = 0;
+        this._loadModelChain = null;
         this._loadState = 'idle';
         this._isModelReadyForInteraction = false;
 
@@ -999,7 +1000,31 @@ class VRMManager {
     }
 
     async loadModel(modelUrl, options = {}) {
+        // 并发串行化：core.loadModel 内部在 移除旧模型/disposeVRM/scene.add/currentModel 赋值
+        // 之间有多个 await 悬挂点，两次调用交错执行会留下永不清理的幽灵模型，或让先发的
+        // 慢调用把后发调用已装好的新模型误销毁。loadToken 只能拦截收尾阶段，挡不住中途
+        // 副作用，因此在入口整体排队：token 入口分配（后到者胜），加载体依次独占执行，
+        // 排队期间被更新调用取代的直接跳过（连网络请求都不发起）。
         const loadToken = ++this._activeLoadToken;
+        this._loadState = 'preparing';
+        this._isModelReadyForInteraction = false;
+        const previousLoad = this._loadModelChain || Promise.resolve();
+        const currentLoad = previousLoad
+            .catch(() => {})
+            .then(() => {
+                if (!this._isLoadTokenActive(loadToken)) return null;
+                return this._loadModelExclusive(modelUrl, options, loadToken);
+            });
+        // 队列指针吞掉异常，避免悬挂 rejected promise；调用方仍通过 currentLoad 收到原始异常
+        this._loadModelChain = currentLoad.then(() => undefined, () => undefined);
+        return currentLoad;
+    }
+
+    /**
+     * loadModel 的实际加载体。只能经由 loadModel 的串行队列进入，保证同一时刻
+     * 至多一个实例在执行；loadToken 由 loadModel 在入口分配后传入。
+     */
+    async _loadModelExclusive(modelUrl, options, loadToken) {
         this._loadState = 'preparing';
         this._isModelReadyForInteraction = false;
         // 新一轮加载：取消上一轮可能还在跑的 T-pose 回退重试，避免旧重试打断新模型动画

--- a/static/vrm/vrm-manager.js
+++ b/static/vrm/vrm-manager.js
@@ -1068,7 +1068,7 @@ class VRMManager {
         }
 
         // 加载模型
-        const result = await this.core.loadModel(modelUrl, options);
+        const result = await this.core.loadModel(modelUrl, options, loadToken);
         if (!this._isLoadTokenActive(loadToken)) {
             this._loadState = 'idle';
             return result;
@@ -1443,6 +1443,12 @@ class VRMManager {
 
         // Invalidate any in-flight loadModel() async callbacks
         ++this._activeLoadToken;
+        // 清空串行队列指针：dispose 只 bump token 不足以让下一次会话的 loadModel
+        // 立即开始——若不清空，被取代的旧 load（其 core.loadModel 可能仍挂在无超时的
+        // GLTF 网络请求上）会作为 previousLoad 把 dispose 后的新 load 堵在队列后（活性）。
+        // 清空后新 load 的 previousLoad 退回 Promise.resolve() 直接开跑；旧 load 的 core
+        // 侧 token 守卫（vrm-core.loadModel）保证它恢复时不会覆写新会话的模型（安全）。
+        this._loadModelChain = null;
         this._loadState = 'idle';
         this._isModelReadyForInteraction = false;
 

--- a/static/vrm/vrm-ui-buttons.js
+++ b/static/vrm/vrm-ui-buttons.js
@@ -981,6 +981,21 @@ VRMManager.prototype._addReturnButtonBreathingAnimation = function () {
 };
 
 /**
+ * 清理 VRM UI 资源（浮动按钮、锁图标、"请她回来"按钮及其 document 级拖拽监听）。
+ *
+ * 历史：旧版 cleanupUI 在 #510 合并 common-ui 时被整体移除，但 vrm-manager.dispose()、
+ * app-character.js、app-interpage.js 仍按约定调用它（typeof 守卫下静默跳过），导致
+ * _returnButtonDragHandlers 等 document 级监听在销毁路径上无人清理。这里恢复为委托
+ * mixin 的 cleanupFloatingButtons（覆盖 RAF 循环、按钮/锁图标/返回按钮 DOM、侧边面板、
+ * _uiWindowHandlers、_returnButtonDragHandlers），与 mmd-manager.cleanupUI 对偶。
+ */
+VRMManager.prototype.cleanupUI = function () {
+    if (typeof this.cleanupFloatingButtons === 'function') {
+        this.cleanupFloatingButtons();
+    }
+};
+
+/**
  * 将屏幕像素偏移量应用到 VRM 模型的世界坐标
  * 用于"请她回来"按钮被拖拽后，模型跟随出现在新位置
  */

--- a/tests/unit/test_avatar_model_load_race_static_contracts.py
+++ b/tests/unit/test_avatar_model_load_race_static_contracts.py
@@ -40,6 +40,53 @@ def test_vrm_load_model_is_serialized_with_entry_token():
     assert "++this._activeLoadToken" not in exclusive_body.split("async dispose()", 1)[0]
 
 
+def test_vrm_dispose_clears_load_queue_pointer():
+    # Codex P2：dispose 只 bump token 不清 _loadModelChain 时，被取代/挂死的旧 load
+    # 会作为 previousLoad 把 dispose 后的新 load 堵在队列后（活性 bug）。dispose 必须
+    # 在 bump token 后清空队列指针，新 load 的 previousLoad 才退回 Promise.resolve()。
+    source = (PROJECT_ROOT / "static/vrm/vrm-manager.js").read_text(encoding="utf-8")
+
+    dispose_body = source.split("async dispose()", 1)[1].split("\n    }\n", 1)[0]
+    assert "++this._activeLoadToken;" in dispose_body
+    assert "this._loadModelChain = null;" in dispose_body
+    # 清链必须紧跟在 token bump 之后（同一失效动作），不能漏在别处
+    assert dispose_body.index("++this._activeLoadToken;") < dispose_body.index("this._loadModelChain = null;")
+
+
+def test_vrm_core_load_is_token_guarded_across_dispose():
+    # 清链修活性会重新引入并发损坏：慢的旧 load A 恢复后 core.loadModel 无 token 守卫
+    # 会 remove/dispose/覆写新会话 B 的模型。core.loadModel 必须自带 token 守卫
+    # （与 mmd-core 对偶），manager 必须把 loadToken 传进去。
+    core_source = (PROJECT_ROOT / "static/vrm/vrm-core.js").read_text(encoding="utf-8")
+    manager_source = (PROJECT_ROOT / "static/vrm/vrm-manager.js").read_text(encoding="utf-8")
+
+    # core 接收 manager 分配的 token
+    assert "async loadModel(modelUrl, options = {}, managerLoadToken = null)" in core_source
+    assert "const loadToken = managerLoadToken !== null ? managerLoadToken : this.manager._activeLoadToken;" in core_source
+
+    load_section = core_source.split("async loadModel(modelUrl, options = {}, managerLoadToken = null)", 1)[1]
+    load_section = load_section.split("async disposeVRM(", 1)[0]
+
+    # 两道守卫：GLTF 加载后（触碰共享 scene/currentModel 前）与 scene.add 前
+    guard_count = load_section.count("this.manager._activeLoadToken !== loadToken")
+    assert guard_count >= 2, f"expected >=2 token guards in vrm-core.loadModel, found {guard_count}"
+
+    # 守卫必须在触碰共享状态之前：一道在 disposeVRM(old) 之前，二道在 scene.add 之前
+    first_guard = load_section.index("this.manager._activeLoadToken !== loadToken")
+    old_remove = load_section.index("await this.disposeVRM();")
+    scene_add = load_section.index("this.manager.scene.add(vrm.scene);")
+    second_guard = load_section.index("this.manager._activeLoadToken !== loadToken", first_guard + 1)
+    assert first_guard < old_remove, "first guard must precede old-model disposeVRM"
+    assert second_guard < scene_add, "second guard must precede scene.add of new model"
+
+    # 早退释放被取代的 VRM 资源（避免显存泄漏）
+    assert "async _disposeAbandonedVRM(vrm)" in core_source
+    assert load_section.count("this._disposeAbandonedVRM(") >= 2
+
+    # manager 把 loadToken 传进 core.loadModel
+    assert "const result = await this.core.loadModel(modelUrl, options, loadToken);" in manager_source
+
+
 def test_vrm_cleanup_ui_is_restored_and_delegates_to_mixin():
     ui_source = (PROJECT_ROOT / "static/vrm/vrm-ui-buttons.js").read_text(encoding="utf-8")
     manager_source = (PROJECT_ROOT / "static/vrm/vrm-manager.js").read_text(encoding="utf-8")

--- a/tests/unit/test_avatar_model_load_race_static_contracts.py
+++ b/tests/unit/test_avatar_model_load_race_static_contracts.py
@@ -85,17 +85,33 @@ def test_vrm_core_load_is_token_guarded_across_dispose():
     load_section = core_source.split("async loadModel(modelUrl, options = {}, managerLoadToken = null)", 1)[1]
     load_section = load_section.split("async disposeVRM(", 1)[0]
 
-    # 两道守卫：GLTF 加载后（触碰共享 scene/currentModel 前）与 scene.add 前
+    # 两道守卫：GLTF 加载后（触碰共享 scene/currentModel 前）与 3 帧等待后（共享相机写入前）
     guard_count = load_section.count("this.manager._activeLoadToken !== loadToken")
     assert guard_count >= 2, f"expected >=2 token guards in vrm-core.loadModel, found {guard_count}"
 
-    # 守卫必须在触碰共享状态之前：一道在 disposeVRM(old) 之前，二道在 scene.add 之前
+    # 守卫必须在触碰共享状态之前：
+    #   一道在 disposeVRM(old) 之前；
+    #   二道在「最后一个 await（3 帧等待）之后、任何共享 manager 写入之前」——
+    #   关键是必须先于共享相机/interaction 写入（Codex P2：否则被取代的旧加载会用自己的
+    #   存档相机覆写共享相机把可见的新模型顶到屏外），scene.add 随后无 await 一并覆盖。
     first_guard = load_section.index("this.manager._activeLoadToken !== loadToken")
     old_remove = load_section.index("await this.disposeVRM();")
+    frame_wait = load_section.index("await new Promise(resolve => {")
+    face_camera = load_section.index("this.manager.interaction.enableFaceCamera = false;")
+    camera_write = load_section.index("this.manager.camera.position.set(")
     scene_add = load_section.index("this.manager.scene.add(vrm.scene);")
     second_guard = load_section.index("this.manager._activeLoadToken !== loadToken", first_guard + 1)
     assert first_guard < old_remove, "first guard must precede old-model disposeVRM"
+    assert frame_wait < second_guard, "second guard must sit AFTER the 3-frame-wait await"
+    assert second_guard < face_camera, "second guard must precede shared enableFaceCamera write"
+    assert second_guard < camera_write, "second guard must precede shared camera.position write (Codex P2)"
     assert second_guard < scene_add, "second guard must precede scene.add of new model"
+
+    # 二道守卫之后到 scene.add 之间不得再插入 await（否则又暴露一个未守卫窗口）
+    between = load_section[second_guard:scene_add]
+    assert "await " not in between.replace("await this._disposeAbandonedVRM(vrm);", ""), (
+        "二道守卫与 scene.add 之间不应有额外 await（会重现未守卫的共享写入窗口）"
+    )
 
     # 早退释放被取代的 VRM 资源（避免显存泄漏）
     assert "async _disposeAbandonedVRM(vrm)" in core_source

--- a/tests/unit/test_avatar_model_load_race_static_contracts.py
+++ b/tests/unit/test_avatar_model_load_race_static_contracts.py
@@ -1,13 +1,18 @@
-"""Static contracts for avatar model-load race fixes (PR #2273 review follow-up).
+"""Static contracts for avatar model-load race fixes (PR #2273/#2276 review).
 
-Covers three fixes:
-1. VRM loadModel serialization: entry-allocated token + promise queue, so two
-   overlapping core.loadModel runs can no longer interleave remove/dispose/add
-   on the shared scene (ghost orphan model / newer model disposed by stale call).
-2. VRMManager.cleanupUI restored: it was dropped in #510 while dispose() /
+Covers:
+1. VRM loadModel concurrency = token-only "last writer wins" (NO serial queue).
+   Entry-allocated token supersedes prior loads; vrm-core.loadModel bails at its
+   token guards before touching shared scene/currentModel, so overlapping loads
+   cannot interleave remove/dispose/add. A queue was tried first but removed: it
+   made a replacement load await an already-superseded predecessor, so a slow/hung
+   GLTF (no timeout) blocked ordinary VRM->VRM switches (Codex P2). Mirrors MMD.
+2. vrm-core.loadModel token guards: managerLoadToken passed in + guarded before
+   old-model removal and before scene.add, with _disposeAbandonedVRM on bail.
+3. VRMManager.cleanupUI restored: dropped in #510 while dispose() /
    app-character.js / app-interpage.js kept calling it behind typeof guards,
    leaving _returnButtonDragHandlers document listeners uncleaned on teardown.
-3. MMD load token provenance: token must be captured before the first await in
+4. MMD load token provenance: token captured before the first await in
    mmd-core.loadModel and passed from the manager, otherwise a superseded call
    (e.g. the failure-fallback path) can pass the stale check and stack a ghost
    mesh, or _clearModel a newer call's freshly loaded model.
@@ -18,39 +23,52 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 
-def test_vrm_load_model_is_serialized_with_entry_token():
+def test_vrm_load_model_uses_entry_token_without_blocking_queue():
+    # 设计：token-only「后到者胜」，无串行队列（与 mmd-manager 对偶）。
+    # 队列会让新加载 await 一个已被自己取代的旧加载 → 慢/挂死的 GLTF（无超时）
+    # 无限期阻塞 VRM→VRM 切换（Codex P2）。并发正确性由 vrm-core 的 token 守卫兜底。
     source = (PROJECT_ROOT / "static/vrm/vrm-manager.js").read_text(encoding="utf-8")
 
-    # token 在入口同步分配（后到者胜），加载体经串行队列独占执行
+    # token 在入口同步分配（后到者胜），直接调用加载体，不经 promise 队列
     assert "const loadToken = ++this._activeLoadToken;" in source
-    assert "const previousLoad = this._loadModelChain || Promise.resolve();" in source
-    assert "return this._loadModelExclusive(modelUrl, options, loadToken);" in source
-    assert "async _loadModelExclusive(modelUrl, options, loadToken)" in source
+    assert "return this._loadModelInternal(modelUrl, options, loadToken);" in source
+    assert "async _loadModelInternal(modelUrl, options, loadToken)" in source
 
-    # 排队期间被更新调用取代的加载体必须整体跳过（连网络请求都不发起）
+    # 串行队列必须彻底移除：不得残留 _loadModelChain / previousLoad / 旧方法名
+    assert "_loadModelChain" not in source, "串行队列指针应已移除（会阻塞 VRM→VRM 切换）"
+    assert "previousLoad" not in source
+    assert "_loadModelExclusive" not in source
+
+    # loadModel 包装体必须极薄：bump token → 直接委派，中间不 await 任何前序加载
     wrapper = source.split("async loadModel(modelUrl, options = {})", 1)[1]
-    wrapper = wrapper.split("async _loadModelExclusive", 1)[0]
-    assert "if (!this._isLoadTokenActive(loadToken)) return null;" in wrapper
+    wrapper = wrapper.split("async _loadModelInternal", 1)[0]
+    assert "await this." not in wrapper, "loadModel 不得 await 前序加载（否则重现阻塞）"
+    assert ".then(" not in wrapper, "loadModel 不得挂 promise 链（否则重现阻塞队列）"
 
-    # 队列指针必须吞掉异常，避免下一次加载被上一次的 rejection 卡住
-    assert "this._loadModelChain = currentLoad.then(() => undefined, () => undefined);" in source
+    # 加载体内不得再自行分配 token（token 由入口分配后传入，用于守卫比对）
+    body = source.split("async _loadModelInternal", 1)[1].split("async dispose()", 1)[0]
+    assert "++this._activeLoadToken" not in body
 
-    # 加载体内不得再自行分配 token（否则队列的取代检查失效）
-    exclusive_body = source.split("async _loadModelExclusive", 1)[1]
-    assert "++this._activeLoadToken" not in exclusive_body.split("async dispose()", 1)[0]
+    # 被取代的实例在 core 返回后直接早退，不写 _loadState（避免 clobber 并发胜出者）
+    post_core = body.split(
+        "const result = await this.core.loadModel(modelUrl, options, loadToken);", 1
+    )[1]
+    superseded_branch = post_core.split(
+        "if (!this._isLoadTokenActive(loadToken)) {", 1
+    )[1].split("}", 1)[0]
+    assert "return result;" in superseded_branch
+    # 真实写入才有 this. 前缀（注释里提到 _loadState 不算）
+    assert "this._loadState" not in superseded_branch, "被取代分支不得写 _loadState（会 clobber 胜出者）"
 
 
-def test_vrm_dispose_clears_load_queue_pointer():
-    # Codex P2：dispose 只 bump token 不清 _loadModelChain 时，被取代/挂死的旧 load
-    # 会作为 previousLoad 把 dispose 后的新 load 堵在队列后（活性 bug）。dispose 必须
-    # 在 bump token 后清空队列指针，新 load 的 previousLoad 才退回 Promise.resolve()。
+def test_vrm_dispose_invalidates_without_blocking_queue():
+    # 无队列后 dispose 只需 bump token 使在途加载失效（旧 load 在 core 守卫处 bail），
+    # 不得引入任何会阻塞后续加载的队列指针。
     source = (PROJECT_ROOT / "static/vrm/vrm-manager.js").read_text(encoding="utf-8")
 
     dispose_body = source.split("async dispose()", 1)[1].split("\n    }\n", 1)[0]
     assert "++this._activeLoadToken;" in dispose_body
-    assert "this._loadModelChain = null;" in dispose_body
-    # 清链必须紧跟在 token bump 之后（同一失效动作），不能漏在别处
-    assert dispose_body.index("++this._activeLoadToken;") < dispose_body.index("this._loadModelChain = null;")
+    assert "_loadModelChain" not in dispose_body
 
 
 def test_vrm_core_load_is_token_guarded_across_dispose():

--- a/tests/unit/test_avatar_model_load_race_static_contracts.py
+++ b/tests/unit/test_avatar_model_load_race_static_contracts.py
@@ -1,0 +1,83 @@
+"""Static contracts for avatar model-load race fixes (PR #2273 review follow-up).
+
+Covers three fixes:
+1. VRM loadModel serialization: entry-allocated token + promise queue, so two
+   overlapping core.loadModel runs can no longer interleave remove/dispose/add
+   on the shared scene (ghost orphan model / newer model disposed by stale call).
+2. VRMManager.cleanupUI restored: it was dropped in #510 while dispose() /
+   app-character.js / app-interpage.js kept calling it behind typeof guards,
+   leaving _returnButtonDragHandlers document listeners uncleaned on teardown.
+3. MMD load token provenance: token must be captured before the first await in
+   mmd-core.loadModel and passed from the manager, otherwise a superseded call
+   (e.g. the failure-fallback path) can pass the stale check and stack a ghost
+   mesh, or _clearModel a newer call's freshly loaded model.
+"""
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_vrm_load_model_is_serialized_with_entry_token():
+    source = (PROJECT_ROOT / "static/vrm/vrm-manager.js").read_text(encoding="utf-8")
+
+    # token 在入口同步分配（后到者胜），加载体经串行队列独占执行
+    assert "const loadToken = ++this._activeLoadToken;" in source
+    assert "const previousLoad = this._loadModelChain || Promise.resolve();" in source
+    assert "return this._loadModelExclusive(modelUrl, options, loadToken);" in source
+    assert "async _loadModelExclusive(modelUrl, options, loadToken)" in source
+
+    # 排队期间被更新调用取代的加载体必须整体跳过（连网络请求都不发起）
+    wrapper = source.split("async loadModel(modelUrl, options = {})", 1)[1]
+    wrapper = wrapper.split("async _loadModelExclusive", 1)[0]
+    assert "if (!this._isLoadTokenActive(loadToken)) return null;" in wrapper
+
+    # 队列指针必须吞掉异常，避免下一次加载被上一次的 rejection 卡住
+    assert "this._loadModelChain = currentLoad.then(() => undefined, () => undefined);" in source
+
+    # 加载体内不得再自行分配 token（否则队列的取代检查失效）
+    exclusive_body = source.split("async _loadModelExclusive", 1)[1]
+    assert "++this._activeLoadToken" not in exclusive_body.split("async dispose()", 1)[0]
+
+
+def test_vrm_cleanup_ui_is_restored_and_delegates_to_mixin():
+    ui_source = (PROJECT_ROOT / "static/vrm/vrm-ui-buttons.js").read_text(encoding="utf-8")
+    manager_source = (PROJECT_ROOT / "static/vrm/vrm-manager.js").read_text(encoding="utf-8")
+
+    # cleanupUI 必须存在并委托 mixin 的 cleanupFloatingButtons
+    # （后者负责 _returnButtonDragHandlers / _uiWindowHandlers / RAF / DOM 的完整清理）
+    assert "VRMManager.prototype.cleanupUI = function () {" in ui_source
+    cleanup_body = ui_source.split("VRMManager.prototype.cleanupUI = function () {", 1)[1]
+    cleanup_body = cleanup_body.split("};", 1)[0]
+    assert "this.cleanupFloatingButtons();" in cleanup_body
+
+    # dispose() 侧的调用点保持存在（cleanupUI 恢复后不再是 dead call）
+    assert "this.cleanupUI();" in manager_source
+
+    # mixin 的 cleanupFloatingButtons 必须清理 return 按钮的 document 级拖拽监听
+    mixin_source = (PROJECT_ROOT / "static/avatar-ui-buttons.js").read_text(encoding="utf-8")
+    cleanup_section = mixin_source.split("ManagerPrototype.cleanupFloatingButtons = function() {", 1)[1]
+    assert "this._returnButtonDragHandlers = null;" in cleanup_section
+
+
+def test_mmd_load_token_captured_before_first_await_and_passed_from_manager():
+    core_source = (PROJECT_ROOT / "static/mmd/mmd-core.js").read_text(encoding="utf-8")
+    manager_source = (PROJECT_ROOT / "static/mmd/mmd-manager.js").read_text(encoding="utf-8")
+
+    # core 接收 manager 分配的 token，且在首个 await（模块导入）之前捕获
+    assert "async loadModel(modelUrl, options = {}, managerLoadToken = null)" in core_source
+    load_section = core_source.split("async loadModel(modelUrl, options = {}, managerLoadToken = null)", 1)[1]
+    token_capture = load_section.index("const loadToken = managerLoadToken !== null")
+    module_await = load_section.index("await this._getMMDModule()")
+    assert token_capture < module_await
+
+    # 取代检查必须先于 _clearModel，避免迟到的回退加载清掉新模型
+    clear_model = load_section.index("this._clearModel();")
+    assert load_section.index("this.manager._activeLoadToken !== loadToken") < clear_model
+
+    # manager 两条加载路径都要把 loadToken 传给 core，且失败回退前先检查是否已被取代
+    assert "await this.core.loadModel(modelPath, options, loadToken);" in manager_source
+    assert "await this.core.loadModel(defaultModelPath, options, loadToken);" in manager_source
+    fallback_guard = manager_source.index("跳过回退")
+    fallback_load = manager_source.index("await this.core.loadModel(defaultModelPath, options, loadToken);")
+    assert fallback_guard < fallback_load


### PR DESCRIPTION
## 背景

[PR #2273](https://github.com/Project-N-E-K-O/N.E.K.O/pull/2273)（vrm-* 搬入 static/vrm/ 的纯搬移）的 CodeRabbit review 对 `static/vrm/vrm-manager.js` 存量代码提出三条 Major 级生命周期/并发意见。逐条独立验证后：两条属实（修复），一条 by-design（驳回）。对照 mmd/live2d 同层模块做对偶性检查，MMD 侧发现同族窄窗口一并修复。

## 逐条结论

### (1) loadModel 未串行化 — ✅ 属实，已修

`core.loadModel` 在 移除旧模型/`disposeVRM`/`scene.add`/`currentModel` 赋值之间有多个 await 悬挂点（GLTF 网络加载、偏好 fetch、3 帧等待）。两次调用交错执行：
- 双方都过了对方的 dispose 点 → 两个模型都进 scene，旧 token 调用的模型成为**永不清理的幽灵**（VRAM 泄漏）；
- 先发慢调用迟到 → 把后发调用已装好的新模型 remove+dispose，**屏幕留空**。

旧 `loadToken` 只拦收尾阶段，挡不住中途副作用。Live2D 侧早有同类互斥（`_isLoadingModel`，注释明说防"重复模型叠加"），VRM 一直缺位。

**修复**：入口分配 token + promise 队列串行执行；排队期间被更新调用取代的整体跳过（实测连网络请求都不发起）。后到者胜语义与原 token 设计一致。

### (2) dispose 可被 initThreeJS 打断 — ❌ by-design，不改

`dispose()` 在 `await disposeVRM()` 后的 `if (!this._isDisposed) return` 是与 `initThreeJS` 的**协作交接**（代码注释明示）：打断只可能发生在复用路径——此时 scene/camera/renderer 均非空，`initThreeJS` 走 fast path 复用它们，dispose 中止清理恰恰是为了不摧毁新会话正在使用的资源；window 监听器同样被复用会话继续使用且注册处有去重，无泄漏。补齐清理反而引入 bug。

### (3) _returnButtonDragHandlers 泄漏 — ✅ 属实，根因比 bot 说的深

不止 dispose 漏清这一处：`VRMManager.cleanupUI` 整个在 #510（common-ui 合并）时被删除，但 `vrm-manager.dispose()`、`app-character.js:665`（注释还写着"关键修复"）、`app-interpage.js:330` 三处调用点一直靠 `typeof` 守卫**静默跳过**，interpage 路径 fall-through 到纯 DOM 删除、监听留存。

**修复**：恢复 `cleanupUI` 为委托 mixin `cleanupFloatingButtons`（覆盖 RAF 循环、按钮/锁图标/返回按钮 DOM、侧边面板、`_uiWindowHandlers`、`_returnButtonDragHandlers`），与 `mmd-manager.cleanupUI` 对偶。三处调用点自动恢复生效。

## 对偶性检查（mmd / live2d）

- **MMD**：`mmd-core.loadModel` 的竞态 token 在首个 await（模块导入）**之后**才读当前值，悬挂期间被新调用取代则检查失效（幽灵 mesh）；失败回退路径还会先 `_clearModel` 掉新调用已装好的模型再发现自己已被取代（屏幕留空）。改为 manager 显式传 `loadToken`，core 在触碰 `currentModel` 前两处早退，manager 回退前先查取代。cleanupUI MMD 本来就有，无此问题。
- **Live2D**：`_isLoadingModel` 互斥已防并发；无 dispose 全拆路径，跨前缀清理网兜底，不改。

## 回归报告

- 新增 [tests/unit/test_avatar_model_load_race_static_contracts.py](https://github.com/Project-N-E-K-O/N.E.K.O/blob/claude/compassionate-gauss-2db986/tests/unit/test_avatar_model_load_race_static_contracts.py)：3 条契约（VRM 串行化、cleanupUI 恢复、MMD token 时序）。
- 存量静态契约测试：涉及这 4 个 JS 文件的 8 个测试文件全部通过（107 passed）。
- 真实应用验证（main_server + 浏览器，实际加载 sensei.vrm / sister1.0.vrm）：
  - 连发两个 `loadModel`：被取代调用返回 null 且未发起网络请求；后发调用胜出（`currentModel` = sister1.0）；场景中恰好 1 个模型（无幽灵）；无控制台报错。
  - 顺序切换 sister→sensei：旧模型正常释放、新模型入场、待机动画播放。
  - `cleanupUI()` 实测：注册的 4 个 document 级拖拽监听、浮动按钮 DOM、`_uiWindowHandlers` 全部清空。
  - `dispose()` 全链路：scene/renderer/camera/currentModel 置空、动画循环取消、window 监听清空、无中断。
  - 说明：模型可见性收尾（`ready`/淡入）依赖真实 rAF 帧，无头后台 tab 被 Chrome 强节流无法驱动；该路径本次 diff 未触碰。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 后续修复（review 轮：Codex P2，commit 5e6226208）

Codex 对第一版串行队列提了一条 P2：`dispose()` 只 bump `_activeLoadToken`、不清 `_loadModelChain`，dispose 后新会话的 load 会被上一会话「被取代但仍挂在无超时 GLTF 网络请求上」的旧 load 堵在队列后（活性 bug）。3 路对抗验证确认属实，并暴露「光清链」的隐患——清链后慢的旧 load 恢复时无 token 防护会覆写新模型（并发损坏）。按对偶原则两侧都补：

1. `vrm-manager.dispose`：`++_activeLoadToken` 后清 `_loadModelChain = null`（修活性）。
2. `vrm-core.loadModel`：加 `managerLoadToken` + 两道 token 守卫（触碰共享 scene/currentModel 前、`scene.add` 前）+ `_disposeAbandonedVRM` 释放被取代的 VRM（修安全，与本 PR 的 mmd-core token 守卫对偶）。

未改：completeness-critic 的 P3（隐藏窗口 rAF 停摆卡稳定性等待）是既有帧驱动限制且自愈，改 `_waitForSceneStability` 会破坏 T-pose 防护，按风险收益不动。

验证：契约测试 +2 例（共 7 passed）；真实应用 dispose-mid-load 清链后 B 胜出无幽灵、失效 token 直调 core.loadModel 确定性 bail 返回 null 且 currentModel 不变。