### PR TITLE
ci(core): check_core_contracts.py 把 core 包结构契约封进 lint

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -12,19 +12,25 @@ permissions:
   contents: read
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Two parallel jobs — split for blast-radius clarity:
+# Five parallel jobs, split by concern so a failing check name points at a
+# category (expand it to see which step is red) instead of one giant title
+# enumerating every sub-check:
 #
-#   python-lint        → "the code itself is wrong" (semantic / async / leaks)
-#   python-conventions → "the project's architecture / i18n / API rules"
+#   Ruff                   → the ruff linter (its own deps: uv + ruff)
+#   Code safety            → runtime hazards in the backend (blocking-in-async,
+#                            banned imports, startup import cost)
+#   Prompts & i18n         → LLM-call discipline + localization/docstring rules
+#   API & layering         → HTTP/route + module-layer architecture rules
+#   Core package contracts → the main_logic/core mixin/facade structural gate
 #
-# When one fails, the failure name immediately tells you whether to look at the
-# code change itself or at how it intersects project conventions. Both jobs run
-# in parallel, both block merge, neither needs the other's setup.
+# All run in parallel, all block merge, each is independently re-runnable. Only
+# the diff-based steps (i18n-sync, docstring-cjk) need full history; the rest
+# run on a shallow checkout.
 # ─────────────────────────────────────────────────────────────────────────────
 
 jobs:
-  python-lint:
-    name: Python lint (ruff + async-blocking + no-loguru + no-tkinter + no-temperature + prompt-hygiene + llm-budget + startup-lazy-import)
+  ruff:
+    name: Ruff
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -39,13 +45,24 @@ jobs:
         uses: astral-sh/setup-uv@v4
 
       - name: Install ruff
-        # ruff is the only dev dep we need for the lint job; a full uv sync
-        # pulls heavy native extensions (playwright, numpy, etc.) that are
-        # unnecessary for static checks.
+        # ruff is the only dev dep we need; a full uv sync pulls heavy native
+        # extensions (playwright, numpy, etc.) unnecessary for static checks.
         run: uv tool install ruff==0.15.4
 
       - name: ruff check (incl. ASYNC210/220/221/222/251)
         run: ruff check .
+
+  code-safety:
+    name: Code safety
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
 
       - name: Forbid blocking calls in async def bodies
         # Custom AST checker, broader than ruff's ASYNC* rules:
@@ -88,6 +105,39 @@ jobs:
         # neko-guide.md for the rationale.
         run: python scripts/check_no_temperature.py
 
+      - name: Keep heavy SDKs off the startup import chain (lazy-import contract)
+        # Merged production mode imports the app tree serially before any port
+        # binds, so a module-scope `import openai` (etc.) slows EVERY launch,
+        # silently — reference incident: #1496 cut main_server import to ~0.6s,
+        # openai 2.x types growth quietly ate it back to ~2.1s within 6 weeks.
+        # Banned-at-module-scope list (openai/anthropic/bs4/bilibili_api/
+        # google.genai/translatepy/dashscope/...) lives in the script; the
+        # sanctioned pattern is in-function import + utils/module_warmup.py
+        # background pre-import after ready. `# noqa: STARTUP_LAZY_IMPORT`
+        # opts out with justification.
+        run: python scripts/check_startup_import_lazy.py
+
+  prompts-i18n:
+    name: Prompts & i18n
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # i18n-sync / docstring-cjk are diff-based and need full history to
+          # diff against the merge-base of origin/main. The other steps don't
+          # care, but fetch-depth: 0 has negligible cost on this repo.
+          #
+          # The checkout@v5 bump also fixes a credential-handling regression the
+          # old @v4 tripped against the runner's git 2.54 on the full-history
+          # fetch ("could not read Username", git exit 128).
+          fetch-depth: 0
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Enforce prompt-i18n conventions (inline-EN-only + multilang-in-config)
         # Two rules in one walker:
         #   - INLINE_PROMPT_NON_EN: any string at an LLM call site or in a
@@ -117,42 +167,6 @@ jobs:
         #     opt out with `# noqa: LLM_INPUT_BUDGET`.
         # See docs/design/llm-prompt-budget.md for the full contract.
         run: python scripts/check_llm_budget.py
-
-      - name: Keep heavy SDKs off the startup import chain (lazy-import contract)
-        # Merged production mode imports the app tree serially before any port
-        # binds, so a module-scope `import openai` (etc.) slows EVERY launch,
-        # silently — reference incident: #1496 cut main_server import to ~0.6s,
-        # openai 2.x types growth quietly ate it back to ~2.1s within 6 weeks.
-        # Banned-at-module-scope list (openai/anthropic/bs4/bilibili_api/
-        # google.genai/translatepy/dashscope/...) lives in the script; the
-        # sanctioned pattern is in-function import + utils/module_warmup.py
-        # background pre-import after ready. `# noqa: STARTUP_LAZY_IMPORT`
-        # opts out with justification.
-        run: python scripts/check_startup_import_lazy.py
-
-  python-conventions:
-    name: Python conventions (i18n-sync + docs + api-trailing-slash×2 + module-layering + docstring-cjk + core-contracts)
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          # i18n-sync needs full history to diff against the merge-base of
-          # origin/main. Other steps don't care, but fetch-depth: 0 has
-          # negligible cost on this repo.
-          #
-          # The checkout@v5 bump is the actual fix here: the old @v4 tripped a
-          # credential-handling regression against the runner's git 2.54 on the
-          # full-history fetch ("could not read Username", git exit 128), which
-          # broke this job on every PR. (fetch-tags has no effect under
-          # fetch-depth: 0 — checkout fetches tags regardless — so we don't set
-          # it; the fix is purely the version bump.)
-          fetch-depth: 0
-
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
 
       - name: Verify i18n locale files move in lockstep (PR-only)
         # Diff-based: when ANY static/locales/*.json or
@@ -186,27 +200,17 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: python scripts/check_docstring_no_cjk.py --base "origin/${BASE_REF}"
 
-      - name: Enforce main_logic/core structural contracts
-        # The LLMSessionManager mixin split (#2272) rests on contracts a
-        # comment cannot enforce: symbols that tests rebind on the
-        # main_logic.core facade must be read by manager/mixin code through
-        # the _core_facade late-binding object (a from-import snapshot lets
-        # isolation-style stubs go silently green while the real function
-        # runs), mixins hold methods only, method sets stay disjoint, and
-        # the facade keeps its layout. The patched-symbol set is harvested
-        # from tests/ by AST on every run, so new patch targets tighten the
-        # gate automatically. Not diff-based — cheap full check, runs on
-        # push and PR alike.
-        run: python scripts/check_core_contracts.py
+  api-layering:
+    name: API & layering
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
 
-      - name: Forbid relative-up markdown links inside docs/
-        # docs/ ships through VitePress with itself as the deploy root;
-        # any markdown link target starting with '..' resolves outside the
-        # site and breaks deploy. We've shipped this regression more than
-        # once — this check fails the build before the next attempt lands.
-        # Fix is to inline the path as code (`foo/bar.js`) instead of a
-        # link, or move the referenced content into docs/.
-        run: python scripts/check_docs_no_relative_paths.py
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
 
       - name: Forbid trailing-slash route paths on FastAPI decorators (backend)
         # Project convention: every backend HTTP/WebSocket endpoint is
@@ -242,3 +246,37 @@ jobs:
         # `python scripts/check_module_layering.py --show-layers` to print
         # the hierarchy. Companion unit test: tests/unit/test_module_layering.py.
         run: python scripts/check_module_layering.py
+
+      - name: Forbid relative-up markdown links inside docs/
+        # docs/ ships through VitePress with itself as the deploy root;
+        # any markdown link target starting with '..' resolves outside the
+        # site and breaks deploy. We've shipped this regression more than
+        # once — this check fails the build before the next attempt lands.
+        # Fix is to inline the path as code (`foo/bar.js`) instead of a
+        # link, or move the referenced content into docs/.
+        run: python scripts/check_docs_no_relative_paths.py
+
+  core-contracts:
+    name: Core package contracts
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Enforce main_logic/core structural contracts
+        # The LLMSessionManager mixin split (#2272) rests on contracts a
+        # comment cannot enforce: symbols that tests rebind on the
+        # main_logic.core facade must be read by manager/mixin code through
+        # the _core_facade late-binding object (a from-import snapshot lets
+        # isolation-style stubs go silently green while the real function
+        # runs), mixins hold methods only, method sets stay disjoint, and
+        # the facade keeps its layout. The patched-symbol set is harvested
+        # from tests/ by AST on every run, so new patch targets tighten the
+        # gate automatically. Not diff-based — cheap full check, runs on
+        # push and PR alike.
+        run: python scripts/check_core_contracts.py

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -131,7 +131,7 @@ jobs:
         run: python scripts/check_startup_import_lazy.py
 
   python-conventions:
-    name: Python conventions (i18n-sync + docs + api-trailing-slash×2 + module-layering + docstring-cjk)
+    name: Python conventions (i18n-sync + docs + api-trailing-slash×2 + module-layering + docstring-cjk + core-contracts)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -185,6 +185,19 @@ jobs:
           # Same zizmor template-injection indirection as the i18n-sync step.
           BASE_REF: ${{ github.base_ref }}
         run: python scripts/check_docstring_no_cjk.py --base "origin/${BASE_REF}"
+
+      - name: Enforce main_logic/core structural contracts
+        # The LLMSessionManager mixin split (#2272) rests on contracts a
+        # comment cannot enforce: symbols that tests rebind on the
+        # main_logic.core facade must be read by manager/mixin code through
+        # the _core_facade late-binding object (a from-import snapshot lets
+        # isolation-style stubs go silently green while the real function
+        # runs), mixins hold methods only, method sets stay disjoint, and
+        # the facade keeps its layout. The patched-symbol set is harvested
+        # from tests/ by AST on every run, so new patch targets tighten the
+        # gate automatically. Not diff-based — cheap full check, runs on
+        # push and PR alike.
+        run: python scripts/check_core_contracts.py
 
       - name: Forbid relative-up markdown links inside docs/
         # docs/ ships through VitePress with itself as the deploy root;

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -89,6 +89,7 @@ import argparse
 import ast
 import sys
 import symtable
+import tokenize
 from pathlib import Path
 
 FACADE_MODULE_ALIAS = "_core_facade"
@@ -109,7 +110,12 @@ class Violation:
 
 
 def parse(path: Path) -> ast.Module:
-    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    # Read BYTES, not text: ast.parse honors a PEP 263 coding cookie
+    # (gbk/shift-jis/latin-1) and strips a UTF-8 BOM. read_text(encoding="utf-8")
+    # would keep a BOM (→ SyntaxError) or raise UnicodeDecodeError on a non-UTF-8
+    # cookie — either one crashes the whole gate on a valid, importable file
+    # (BOM is realistic here: Windows + PowerShell `Out-File -Encoding utf8`).
+    return ast.parse(path.read_bytes(), filename=str(path))
 
 
 # --------------------------------------------------------------- tests scan
@@ -123,7 +129,9 @@ def collect_patch_targets(tests_dir: Path):
     for path in sorted(tests_dir.rglob("*.py")):
         try:
             tree = parse(path)
-        except SyntaxError:
+        except (SyntaxError, ValueError):
+            # Malformed/undecodable test file: skip its harvest rather than
+            # crash the gate (ValueError covers UnicodeDecodeError).
             continue
         aliases = set()        # names bound to the main_logic.core MODULE
         pkg_aliases = set()    # names bound to the main_logic PACKAGE (for ``ml.core``)
@@ -268,7 +276,11 @@ def module_level_import_bindings(tree: ast.Module):
 
 def global_read_names(path: Path) -> set[str]:
     """Names referenced as globals from any function scope in the module."""
-    table = symtable.symtable(path.read_text(encoding="utf-8"), str(path), "exec")
+    # tokenize.open honors the PEP 263 cookie / BOM (see parse()); symtable
+    # needs text, so decode through it rather than read_text(encoding="utf-8").
+    with tokenize.open(str(path)) as f:
+        source = f.read()
+    table = symtable.symtable(source, str(path), "exec")
     found: set[str] = set()
 
     def walk(tab):

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -16,10 +16,13 @@ CORE_PATCH_ROUTING
     fail loudly, but isolation-style stubs (blocking disk/network IO) go
     silently green while calling the real function. The patched-symbol set
     is harvested from ``tests/`` by AST on every run, so the contract
-    tightens automatically as tests grow. Function-local imports from the
-    OWNER module (e.g. ``from utils.preferences import ...`` inside a
-    method) are a different, deliberate late-binding pattern and stay
-    allowed: the facade patch never targeted them.
+    tightens automatically as tests grow. Attribute reads through some other
+    imported module (``import main_logic.agent_event_bus`` + ``main_logic.
+    agent_event_bus.<attr>(...)``) are rejected the same way — they follow
+    the owner module, not the facade. Function-local imports from the OWNER
+    module (e.g. ``from utils.preferences import ...`` inside a method) are
+    a different, deliberate late-binding pattern and stay allowed: the
+    facade patch never targeted them, before or after the split.
 
 CORE_PATCH_TARGET_EXISTS
     Every patched facade attribute must actually exist at the facade top
@@ -31,11 +34,14 @@ CORE_MIXIN_SHAPE
     one ``*Mixin`` class; the class body holds only a docstring and
     methods. Instance state has a single home (``LLMSessionManager.
     __init__``), and module-level state in a mixin would sit outside the
-    facade's rebind semantics entirely.
+    facade's rebind semantics entirely. Any core module that is neither a
+    mixin, ``manager.py`` nor a registered owner submodule is rejected —
+    adding a new owner module is a conscious edit to this check.
 
 CORE_MANAGER_SHAPE
-    ``manager.py`` holds exactly one class, ``LLMSessionManager``; its only
-    method is ``__init__`` (class-level constants are allowed). New
+    ``manager.py`` holds exactly one class, ``LLMSessionManager``, and its
+    top level holds nothing but docstring/imports/that class; the class's
+    only method is ``__init__`` (class-level constants are allowed). New
     behavior belongs in a domain mixin.
 
 CORE_MIXIN_DISJOINT
@@ -46,7 +52,8 @@ CORE_MIXIN_DISJOINT
 CORE_MIXIN_BASES
     The base list of ``LLMSessionManager`` is exactly the set of ``*Mixin``
     classes defined in the package — no orphan mixin module, no missing
-    base.
+    base, and every base must be a plain name (dotted/computed bases would
+    make the exact-set comparison silently incomplete).
 
 CORE_FACADE_LAYOUT
     ``__init__.py`` defines no class at top level, and its last statement
@@ -181,7 +188,9 @@ def global_read_names(path: Path) -> set[str]:
     found: set[str] = set()
 
     def walk(tab):
-        if tab.get_type() == "function":
+        # Class scopes matter too: method defaults, decorators and evaluated
+        # annotations resolve in the class scope at class-creation time.
+        if tab.get_type() in ("function", "class"):
             for sym in tab.get_symbols():
                 if sym.is_referenced() and sym.is_global():
                     found.add(sym.get_name())
@@ -190,6 +199,43 @@ def global_read_names(path: Path) -> set[str]:
 
     walk(table)
     return found
+
+
+def module_alias_paths(tree: ast.Module) -> dict[str, str]:
+    """Module objects bound at top level: {binding: dotted module path}.
+
+    Covers plain ``import a.b`` (binds ``a``; the full dotted chain is also
+    kept as a key so ``a.b.attr`` reads match), ``import a.b as c`` and the
+    facade form ``from main_logic import core [as alias]``.
+    """
+    out: dict[str, str] = {}
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for a in node.names:
+                if a.asname:
+                    out[a.asname] = a.name
+                else:
+                    root = a.name.split(".")[0]
+                    out.setdefault(root, root)
+                    out[a.name] = a.name
+        elif isinstance(node, ast.ImportFrom) and node.module == "main_logic" and node.level == 0:
+            for a in node.names:
+                if a.name == "core":
+                    out[a.asname or "core"] = "main_logic.core"
+    return out
+
+
+def attr_value_chain(node: ast.Attribute):
+    """Dotted string of an attribute node's value side, or None."""
+    parts = []
+    cur = node.value
+    while isinstance(cur, ast.Attribute):
+        parts.append(cur.attr)
+        cur = cur.value
+    if not isinstance(cur, ast.Name):
+        return None
+    parts.append(cur.id)
+    return ".".join(reversed(parts))
 
 
 def first_name_load_line(tree: ast.Module, name: str):
@@ -229,6 +275,14 @@ def run(root: Path) -> list[Violation]:
             if manager_class is None:
                 violations.append(Violation(path, 1, 0, "CORE_MANAGER_SHAPE",
                                             "manager.py must define exactly one class: LLMSessionManager"))
+            for i, node in enumerate(tree.body):
+                if i == 0 and isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant):
+                    continue  # module docstring
+                if isinstance(node, (ast.Import, ast.ImportFrom, ast.ClassDef)):
+                    continue
+                violations.append(Violation(path, node.lineno, node.col_offset, "CORE_MANAGER_SHAPE",
+                                            f"manager.py top level allows only docstring/imports/class, "
+                                            f"found {type(node).__name__}"))
             continue
         mixins = [c for c in classes if c.name.endswith("Mixin")]
         if mixins:
@@ -236,6 +290,12 @@ def run(root: Path) -> list[Violation]:
                 violations.append(Violation(path, classes[1].lineno, classes[1].col_offset, "CORE_MIXIN_SHAPE",
                                             f"{path.name} must define exactly one class (found {len(classes)})"))
             mixin_files[path] = mixins[0]
+        elif path.stem not in OWNER_SUBMODULES:
+            violations.append(Violation(path, 1, 0, "CORE_MIXIN_SHAPE",
+                                        f"unknown core module '{path.name}': every core module must either "
+                                        f"define one *Mixin class or be a registered owner submodule — add it "
+                                        f"to OWNER_SUBMODULES in scripts/check_core_contracts.py if it is a "
+                                        f"deliberate new owner module"))
 
     # -- CORE_MIXIN_SHAPE: top level and class body
     for path, klass in mixin_files.items():
@@ -287,6 +347,11 @@ def run(root: Path) -> list[Violation]:
 
     # -- CORE_MIXIN_BASES
     if manager_class is not None:
+        for b in manager_class.bases:
+            if not isinstance(b, ast.Name):
+                violations.append(Violation(manager_path, b.lineno, b.col_offset, "CORE_MIXIN_BASES",
+                                            f"non-Name base '{ast.unparse(b)}' — LLMSessionManager bases must "
+                                            f"be plain *Mixin names so this check can verify the exact set"))
         base_names = {b.id for b in manager_class.bases if isinstance(b, ast.Name)}
         mixin_names = {k.name for k in mixin_files.values()}
         for missing in sorted(mixin_names - base_names):
@@ -320,7 +385,8 @@ def run(root: Path) -> list[Violation]:
     module_info = {}
     for path in routing_files:
         tree = parse(path)
-        module_info[path] = (tree, module_level_import_bindings(tree), global_read_names(path))
+        module_info[path] = (tree, module_level_import_bindings(tree), global_read_names(path),
+                             module_alias_paths(tree))
 
     for attr, sites in sorted(targets.items()):
         strict_sites = [s for s in sites if not s[2]]
@@ -333,7 +399,7 @@ def run(root: Path) -> list[Violation]:
             continue
         if not strict_sites:
             continue  # raising=False negative guards need no routing
-        for path, (tree, imports, global_reads) in module_info.items():
+        for path, (tree, imports, global_reads, alias_paths) in module_info.items():
             if attr in imports:
                 violations.append(Violation(path, imports[attr], 0, "CORE_PATCH_ROUTING",
                                             f"'{attr}' is a test patch target on the facade but is "
@@ -347,6 +413,24 @@ def run(root: Path) -> list[Violation]:
                                             f"as a bare global — read it as {FACADE_MODULE_ALIAS}.{attr} so "
                                             f"monkeypatch.setattr(\"main_logic.core.{attr}\", ...) keeps "
                                             f"hitting this consumer"))
+            else:
+                # Attribute reads through some OTHER imported module
+                # (``import main_logic.agent_event_bus`` +
+                # ``main_logic.agent_event_bus.dispatch_text_user_message(...)``)
+                # dodge facade patches just like a from-import snapshot would.
+                # Reads through main_logic.core itself ARE the facade contract.
+                for node in ast.walk(tree):
+                    if isinstance(node, ast.Attribute) and node.attr == attr:
+                        chain = attr_value_chain(node)
+                        if chain is None:
+                            continue
+                        resolved = alias_paths.get(chain)
+                        if resolved is not None and resolved != "main_logic.core":
+                            violations.append(Violation(
+                                path, node.lineno, node.col_offset, "CORE_PATCH_ROUTING",
+                                f"'{attr}' is a test patch target on the facade but is read here "
+                                f"through module '{resolved}' — that read follows the owner module, "
+                                f"not the facade; read it as {FACADE_MODULE_ALIAS}.{attr} instead"))
     return violations
 
 

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -473,7 +473,9 @@ def run(root: Path) -> list[Violation]:
     #    *.py discovery below never scans, so its mixins/state escape every
     #    shape/routing check. Reject any subdirectory carrying Python modules.
     for sub in sorted(p for p in core_dir.iterdir() if p.is_dir() and p.name != "__pycache__"):
-        if any(sub.glob("*.py")):
+        # rglob, not glob: a nested tree (helpers/nested/mod.py) is still
+        # importable as main_logic.core.helpers.nested.mod and must be rejected.
+        if any(q for q in sub.rglob("*.py") if "__pycache__" not in q.parts):
             violations.append(Violation(sub / "__init__.py", 1, 0, "CORE_MIXIN_SHAPE",
                                         f"core subpackage '{sub.name}/' is not allowed — the core package is "
                                         f"flat so every module is covered by the contract checks; keep new "
@@ -492,6 +494,21 @@ def run(root: Path) -> list[Violation]:
             if manager_class is None:
                 violations.append(Violation(path, 1, 0, "CORE_MANAGER_SHAPE",
                                             "manager.py must define exactly one class: LLMSessionManager"))
+            else:
+                # A class decorator or metaclass runs at class creation and can
+                # inject/replace methods after the AST is counted — invisible to
+                # every body/base/import check below.
+                if manager_class.decorator_list:
+                    d = manager_class.decorator_list[0]
+                    violations.append(Violation(path, d.lineno, d.col_offset, "CORE_MANAGER_SHAPE",
+                                                "LLMSessionManager must not be decorated — a class decorator "
+                                                "can inject methods/state the shape checks cannot see"))
+                if manager_class.keywords:  # metaclass= or other class kwargs
+                    k = manager_class.keywords[0]
+                    violations.append(Violation(path, k.value.lineno, k.value.col_offset, "CORE_MANAGER_SHAPE",
+                                                f"LLMSessionManager must not set class keyword "
+                                                f"'{k.arg or '**kwargs'}' (metaclass/kwargs) — it can rewrite "
+                                                f"the class outside the mixin contract"))
             for i, node in enumerate(tree.body):
                 if i == 0 and isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant):
                     continue  # module docstring
@@ -558,6 +575,8 @@ def run(root: Path) -> list[Violation]:
     # -- CORE_MANAGER_SHAPE: class body is only docstring / class constants /
     #    __init__. Any other statement (extra method, nested class, class-level
     #    cache, executable logic) is behavior/state that belongs in a mixin.
+    mixin_method_names = {n.name for k in mixin_files.values() for n in k.body
+                          if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))}
     if manager_class is not None:
         methods = [n for n in manager_class.body if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))]
         for i, node in enumerate(manager_class.body):
@@ -567,16 +586,27 @@ def run(root: Path) -> list[Violation]:
                 # Class-level CONSTANTS are allowed, but a mutable container
                 # literal (``CACHE = {}``) is shared state across instances and
                 # a Call (``TOKEN = open_socket()``) runs behavior at import —
-                # both are the drift this contract prevents.
-                val = node.value
-                if isinstance(val, (ast.Dict, ast.List, ast.Set, ast.DictComp,
-                                    ast.ListComp, ast.SetComp, ast.Call)):
-                    kind = "a Call (import-time behavior)" if isinstance(val, ast.Call) \
+                # both are the drift this contract prevents. Recurse: a nested
+                # literal (``TOKEN = (open_socket(),)``) hides the same thing
+                # behind an immutable-looking outer Tuple.
+                MUTABLE = (ast.Dict, ast.List, ast.Set, ast.DictComp, ast.ListComp, ast.SetComp, ast.Call)
+                bad = next((s for s in ast.walk(node.value) if isinstance(s, MUTABLE)), None)
+                if bad is not None:
+                    kind = "a Call (import-time behavior)" if isinstance(bad, ast.Call) \
                         else "a mutable container (shared instance state)"
                     violations.append(Violation(manager_path, node.lineno, node.col_offset, "CORE_MANAGER_SHAPE",
-                                                f"manager class attribute is {kind} — only immutable class "
-                                                f"constants are allowed; move state into __init__ (per instance) "
-                                                f"or behavior into a mixin"))
+                                                f"manager class attribute is/contains {kind} — only immutable "
+                                                f"class constants are allowed; move state into __init__ (per "
+                                                f"instance) or behavior into a mixin"))
+                # A class attribute that shares a name with a mixin method wins
+                # attribute lookup and silently removes that method from the API.
+                targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+                for t in targets:
+                    if isinstance(t, ast.Name) and t.id in mixin_method_names:
+                        violations.append(Violation(manager_path, node.lineno, node.col_offset, "CORE_MANAGER_SHAPE",
+                                                    f"manager class attribute '{t.id}' shadows a mixin method of "
+                                                    f"the same name — it would win attribute lookup and drop the "
+                                                    f"method from LLMSessionManager's API"))
                 continue
             if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "__init__":
                 continue
@@ -643,21 +673,30 @@ def run(root: Path) -> list[Violation]:
         # would still pass. ``defining_stem`` comes from where the class was
         # discovered.
         defining_stem = {mklass.name: mpath.stem for mpath, mklass in mixin_files.items()}
-        relative_binds = {}  # bound name -> level-1 module it was imported from
+        # bound name -> (level-1 module, ORIGINAL imported symbol name). The
+        # original name matters: ``from .focus import OmniOfflineClient as
+        # FocusMixin`` is same-module but binds the WRONG class.
+        relative_binds = {}
         for node in parse(manager_path).body:
             if isinstance(node, ast.ImportFrom) and node.level == 1 and node.module:
                 for a in node.names:
-                    relative_binds[a.asname or a.name] = node.module
+                    relative_binds[a.asname or a.name] = (node.module, a.name)
         for name in sorted(base_names & mixin_names):
             want = defining_stem.get(name)
-            if relative_binds.get(name) != want:
+            if relative_binds.get(name) != (want, name):
                 got = relative_binds.get(name)
-                where = f"bound from '.{got}'" if got else "not bound via a level-1 core-local import"
+                if got is None:
+                    where = "not bound via a level-1 core-local import"
+                elif got[0] != want:
+                    where = f"bound from '.{got[0]}'"
+                else:
+                    where = f"bound to the different symbol '{got[1]}'"
                 violations.append(Violation(manager_path, manager_class.lineno, manager_class.col_offset,
                                             "CORE_MIXIN_BASES",
-                                            f"base {name} must be imported from its defining module "
-                                            f"(from .{want} import {name}) but is {where}; the MRO may be using "
-                                            f"a different/outside class while the package mixin is orphaned"))
+                                            f"base {name} must be imported as the class named {name} from its "
+                                            f"defining module (from .{want} import {name}) but is {where}; the "
+                                            f"MRO may be using a different/outside class while the package mixin "
+                                            f"is orphaned"))
 
     # -- CORE_FACADE_LAYOUT: the facade only re-exports — docstring + imports.
     #    A top-level function, assignment or executable statement would put
@@ -685,6 +724,15 @@ def run(root: Path) -> list[Violation]:
                                     "the last statement of __init__.py must be "
                                     "'from .manager import LLMSessionManager' so the facade namespace is "
                                     "fully populated before the class modules bind it"))
+    # An EARLIER ``.manager`` import (before the re-export block finishes) would
+    # import manager/mixins against a half-populated facade namespace, defeating
+    # the ordering contract — the manager import must appear only as the last line.
+    for node in init_tree.body[:-1]:
+        if isinstance(node, ast.ImportFrom) and node.level == 1 and node.module == "manager":
+            violations.append(Violation(init_path, node.lineno, node.col_offset, "CORE_FACADE_LAYOUT",
+                                        "'.manager' is imported before the end of __init__.py — it must appear "
+                                        "only as the final statement, after every re-export, or the mixins bind "
+                                        "the facade before it is fully populated"))
 
     # -- patch-target checks
     targets = collect_patch_targets(tests_dir)

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -125,19 +125,27 @@ def collect_patch_targets(tests_dir: Path):
             tree = parse(path)
         except SyntaxError:
             continue
-        aliases = set()      # names bound to the main_logic.core MODULE
-        pkg_aliases = set()  # names bound to the main_logic PACKAGE (for ``ml.core``)
+        aliases = set()        # names bound to the main_logic.core MODULE
+        pkg_aliases = set()    # names bound to the main_logic PACKAGE (for ``ml.core``)
+        patch_aliases = set()  # extra names meaning unittest.mock.patch
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):
                 for a in node.names:
                     if a.name == "main_logic.core" and a.asname:
-                        aliases.add(a.asname)
-                    elif a.name == "main_logic":
-                        pkg_aliases.add(a.asname or "main_logic")
-            elif isinstance(node, ast.ImportFrom) and node.module == "main_logic" and node.level == 0:
-                for a in node.names:
-                    if a.name == "core":
-                        aliases.add(a.asname or "core")
+                        aliases.add(a.asname)           # import main_logic.core as core_module
+                    elif a.name == "main_logic" and a.asname:
+                        pkg_aliases.add(a.asname)        # import main_logic as ml
+                    elif a.name == "main_logic" or a.name.startswith("main_logic."):
+                        pkg_aliases.add("main_logic")    # import main_logic[.core] → binds main_logic
+            elif isinstance(node, ast.ImportFrom) and node.level == 0:
+                if node.module == "main_logic":
+                    for a in node.names:
+                        if a.name == "core":
+                            aliases.add(a.asname or "core")
+                elif node.module in ("unittest.mock", "mock"):
+                    for a in node.names:
+                        if a.name == "patch" and a.asname:
+                            patch_aliases.add(a.asname)  # from unittest.mock import patch as mock_patch
 
         def is_core_ref(expr):
             if isinstance(expr, ast.Name) and expr.id in aliases:
@@ -146,17 +154,23 @@ def collect_patch_targets(tests_dir: Path):
             return (isinstance(expr, ast.Attribute) and expr.attr == "core"
                     and isinstance(expr.value, ast.Name) and expr.value.id in pkg_aliases)
 
+        def is_patch_ref(expr):  # a Name/Attribute referring to unittest.mock.patch
+            if isinstance(expr, ast.Name):
+                return expr.id == "patch" or expr.id in patch_aliases
+            return isinstance(expr, ast.Attribute) and expr.attr == "patch"
+
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
                 continue
             fn = node.func
             fname = fn.attr if isinstance(fn, ast.Attribute) else (fn.id if isinstance(fn, ast.Name) else "")
+            fbase = fn.value if isinstance(fn, ast.Attribute) else None
             kw = {k.arg: k.value for k in node.keywords if k.arg}
             # A patch that need not resolve to a real facade attribute:
             #   raising=False  (pytest monkeypatch negative guard)
             #   create=True    (unittest.mock.patch / patch.object absent-name guard)
-            # Both mean "the target may not exist", so exempt from routing and
-            # from the target-exists check alike.
+            # These waive the EXISTENCE requirement (target may be absent); they
+            # do NOT waive routing when the target does exist (see run()).
             exempt = ((isinstance(kw.get("raising"), ast.Constant) and kw["raising"].value is False)
                       or (isinstance(kw.get("create"), ast.Constant) and kw["create"].value is True))
             args = node.args
@@ -165,14 +179,28 @@ def collect_patch_targets(tests_dir: Path):
             # patch.object(target=..., attribute=...).
             first = args[0] if args else kw.get("target")
             second = args[1] if len(args) >= 2 else (kw.get("name") or kw.get("attribute"))
-            if fname in PATCH_CALL_NAMES and first is not None:
+            # monkeypatch.setattr/delattr, patch("...") and aliased patch("...")
+            is_str_patch = fname in PATCH_CALL_NAMES or (isinstance(fn, ast.Name) and fn.id in patch_aliases)
+            if is_str_patch and first is not None:
                 if isinstance(first, ast.Constant) and isinstance(first.value, str):
                     s = first.value
                     if s.startswith("main_logic.core.") and s.count(".") == 2:
                         add(s.rsplit(".", 1)[1], path, node, exempt)
-            if fname in (PATCH_CALL_NAMES | {"object"}) and first is not None and second is not None:
+            # object form: setattr(core_module, "X"), patch.object(core_module, "X")
+            is_obj_patch = fname in (PATCH_CALL_NAMES | {"object"}) or (fname == "object" and is_patch_ref(fbase))
+            if is_obj_patch and first is not None and second is not None:
                 if is_core_ref(first) and isinstance(second, ast.Constant) and isinstance(second.value, str):
                     add(second.value, path, node, exempt)
+            # patch.multiple("main_logic.core", X=..., Y=...) / (core_module, X=...)
+            if fname == "multiple" and is_patch_ref(fbase) and first is not None:
+                target_is_core = (
+                    (isinstance(first, ast.Constant) and first.value == "main_logic.core")
+                    or is_core_ref(first))
+                if target_is_core:
+                    reserved = {"spec", "spec_set", "create", "autospec", "new_callable", "target"}
+                    for k in node.keywords:
+                        if k.arg and k.arg not in reserved:
+                            add(k.arg, path, node, exempt)
     return targets
 
 
@@ -235,19 +263,39 @@ def global_read_names(path: Path) -> set[str]:
     return found
 
 
-def module_alias_paths(tree: ast.Module) -> dict[str, str]:
-    """Module objects bound at top level: {binding: dotted module path}.
+def _resolve_relative(pkg: str, level: int, module) -> str | None:
+    """Absolute dotted base for a relative import in package ``pkg``.
 
-    Covers plain ``import a.b`` (binds ``a``; the full dotted chain is also
-    kept as a key so ``a.b.attr`` reads match), ``import a.b as c`` and the
-    from-import module form ``from a import b [as c]`` (binds ``b``/``c`` to
-    ``a.b`` — e.g. ``from main_logic import agent_event_bus as bus`` or the
-    facade ``from main_logic import core as _core_facade``).
+    ``from . import x`` (level 1) in ``main_logic.core`` anchors at
+    ``main_logic.core``; ``from .. import x`` (level 2) at ``main_logic``.
+    Returns None if the level escapes the top of the tree.
+    """
+    parts = pkg.split(".") if pkg else []
+    keep = len(parts) - (level - 1)
+    if keep < 0:
+        return None
+    anchor = parts[:keep]
+    if module:
+        anchor = anchor + module.split(".")
+    return ".".join(anchor)
 
-    From-imports of plain symbols (``from x import a_function``) land here too,
-    but that is harmless: the routing scan only consults this map for reads
-    spelled ``<binding>.<patched_symbol>``, and a patched module-level symbol
-    is never an attribute of another imported symbol.
+
+def module_alias_paths(tree: ast.Module, pkg: str) -> dict[str, str]:
+    """Module/name bindings at top level → ABSOLUTE dotted path.
+
+    ``pkg`` is the importing module's package (``main_logic.core``) so relative
+    imports resolve to absolute paths and compare cleanly against
+    ``main_logic.core``. Covers ``import a.b`` (binds ``a``; full chain kept
+    too), ``import a.b as c``, package aliases (``import main_logic as ml`` →
+    ``ml`` → ``main_logic``, so ``ml.core`` resolves via prefix), and both
+    absolute and relative from-imports (``from main_logic import agent_event_bus
+    as bus`` / ``from .. import agent_event_bus as bus`` → the same owner
+    module; ``from main_logic import core as _core_facade`` → ``main_logic.core``).
+
+    From-imports of plain symbols land here too, but that is harmless: the
+    routing scan only consults this map for ``<binding>.<patched_symbol>``
+    reads, and a patched module-level symbol is never an attribute of another
+    imported symbol.
     """
     out: dict[str, str] = {}
     for node in tree.body:
@@ -259,13 +307,31 @@ def module_alias_paths(tree: ast.Module) -> dict[str, str]:
                     root = a.name.split(".")[0]
                     out.setdefault(root, root)
                     out[a.name] = a.name
-        elif isinstance(node, ast.ImportFrom) and node.module is not None:
-            base = "." * node.level + node.module
+        elif isinstance(node, ast.ImportFrom):
+            base = node.module if node.level == 0 else _resolve_relative(pkg, node.level, node.module)
+            if base is None:
+                continue
             for a in node.names:
                 if a.name == "*":
                     continue
                 out[a.asname or a.name] = f"{base}.{a.name}"
     return out
+
+
+def resolve_chain(chain: str, alias_paths: dict[str, str]) -> str | None:
+    """Resolve a dotted read chain to an absolute module path, or None.
+
+    Exact binding first (``bus`` → ``main_logic.agent_event_bus``); else
+    substitute a bound prefix (``ml.agent_event_bus`` where ``ml`` →
+    ``main_logic`` yields ``main_logic.agent_event_bus``).
+    """
+    if chain in alias_paths:
+        return alias_paths[chain]
+    parts = chain.split(".")
+    if parts[0] in alias_paths:
+        rest = parts[1:]
+        return ".".join([alias_paths[parts[0]], *rest]) if rest else alias_paths[parts[0]]
+    return None
 
 
 def dotted_node_path(node):
@@ -305,7 +371,7 @@ def owner_module_reads(tree: ast.Module, alias_paths: dict[str, str], attr: str)
             chain = dotted_node_path(node.args[0])
         if chain is None:
             continue
-        resolved = alias_paths.get(chain)
+        resolved = resolve_chain(chain, alias_paths)
         if resolved is not None and resolved != "main_logic.core":
             sites.append((node.lineno, node.col_offset, resolved))
     return sites
@@ -314,14 +380,15 @@ def owner_module_reads(tree: ast.Module, alias_paths: dict[str, str], attr: str)
 def def_time_facade_reads(tree: ast.Module, alias_paths: dict[str, str], attr: str):
     """(line, col) of facade reads of ``attr`` evaluated at class-creation.
 
-    Method defaults, decorators, evaluated annotations and class-level
-    constant values run ONCE at import time; a ``_core_facade.<attr>`` there
+    Class decorators, method decorators, defaults, evaluated annotations and
+    class-level constant values run ONCE at import time; a facade read there
+    (attribute ``_core_facade.<attr>`` or ``getattr(_core_facade, "<attr>")``)
     freezes the value, so later facade patches no longer reach it — the read
     must live in the method body.
     """
     sites = []
     for klass in (n for n in tree.body if isinstance(n, ast.ClassDef)):
-        def_time_nodes = []
+        def_time_nodes = list(klass.decorator_list)  # the class's own decorators
         for stmt in klass.body:
             if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 a = stmt.args
@@ -341,10 +408,15 @@ def def_time_facade_reads(tree: ast.Module, alias_paths: dict[str, str], attr: s
                     def_time_nodes.append(stmt.value)
         for sub in def_time_nodes:
             for node in ast.walk(sub):
+                chain = None
                 if isinstance(node, ast.Attribute) and node.attr == attr:
                     chain = attr_value_chain(node)
-                    if chain and alias_paths.get(chain) == "main_logic.core":
-                        sites.append((node.lineno, node.col_offset))
+                elif (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+                      and node.func.id == "getattr" and len(node.args) >= 2
+                      and isinstance(node.args[1], ast.Constant) and node.args[1].value == attr):
+                    chain = dotted_node_path(node.args[0])
+                if chain and resolve_chain(chain, alias_paths) == "main_logic.core":
+                    sites.append((node.lineno, node.col_offset))
     return sites
 
 
@@ -371,6 +443,16 @@ def run(root: Path) -> list[Violation]:
     violations: list[Violation] = []
     init_tree = parse(init_path)
     facade_names = facade_top_level_names(init_tree)
+
+    # -- the core package must stay flat: a subpackage would define classes the
+    #    *.py discovery below never scans, so its mixins/state escape every
+    #    shape/routing check. Reject any subdirectory carrying Python modules.
+    for sub in sorted(p for p in core_dir.iterdir() if p.is_dir() and p.name != "__pycache__"):
+        if any(sub.glob("*.py")):
+            violations.append(Violation(sub / "__init__.py", 1, 0, "CORE_MIXIN_SHAPE",
+                                        f"core subpackage '{sub.name}/' is not allowed — the core package is "
+                                        f"flat so every module is covered by the contract checks; keep new "
+                                        f"code in a top-level core/*.py mixin or owner submodule"))
 
     # -- discover mixin modules (any core/*.py defining a single *Mixin class)
     mixin_files: dict[Path, ast.ClassDef] = {}
@@ -477,6 +559,17 @@ def run(root: Path) -> list[Violation]:
 
     # -- CORE_MIXIN_BASES
     if manager_class is not None:
+        # Two files defining the same *Mixin name collapse in the set below and
+        # only one enters the real MRO; the other is silently orphaned.
+        by_name: dict[str, Path] = {}
+        for mpath, mklass in sorted(mixin_files.items()):
+            if mklass.name in by_name:
+                violations.append(Violation(mpath, mklass.lineno, mklass.col_offset, "CORE_MIXIN_BASES",
+                                            f"mixin class {mklass.name} is also defined in "
+                                            f"{by_name[mklass.name].name} — duplicate names collapse and only "
+                                            f"one enters the MRO; give each mixin a unique name"))
+            else:
+                by_name[mklass.name] = mpath
         for b in manager_class.bases:
             if not isinstance(b, ast.Name):
                 violations.append(Violation(manager_path, b.lineno, b.col_offset, "CORE_MIXIN_BASES",
@@ -498,25 +591,39 @@ def run(root: Path) -> list[Violation]:
         # (``from .focus import FocusMixin``). Without this, manager.py could
         # ``from elsewhere import FocusMixin`` and put the outside class in the
         # MRO while the package mixin sits orphaned but the set check passes.
-        relative_binds = {}
+        # Must be ``from .<sibling_module> import <Mixin>`` (level 1). A level-2+
+        # import (``from .. import ...``) escapes the core package and could bind
+        # an outside same-named class, so it does not count as core-local.
+        relative_binds = set()
         for node in parse(manager_path).body:
-            if isinstance(node, ast.ImportFrom) and node.level >= 1:
+            if isinstance(node, ast.ImportFrom) and node.level == 1 and node.module:
                 for a in node.names:
-                    relative_binds[a.asname or a.name] = node.module
+                    relative_binds.add(a.asname or a.name)
         for name in sorted(base_names & mixin_names):
             if name not in relative_binds:
                 violations.append(Violation(manager_path, manager_class.lineno, manager_class.col_offset,
                                             "CORE_MIXIN_BASES",
                                             f"base {name} matches a package mixin by name but is not bound via "
-                                            f"a package-relative import (from .<module> import {name}); the MRO "
-                                            f"may be using an outside class while the package mixin is orphaned"))
+                                            f"a core-local import (from .<module> import {name}); the MRO may be "
+                                            f"using an outside class while the package mixin is orphaned"))
 
-    # -- CORE_FACADE_LAYOUT
-    for node in init_tree.body:
+    # -- CORE_FACADE_LAYOUT: the facade only re-exports — docstring + imports.
+    #    A top-level function, assignment or executable statement would put
+    #    behavior/state in the facade (and, for a facade read of a patched
+    #    symbol, freeze it at import) — reject anything but docstring/imports.
+    for i, node in enumerate(init_tree.body):
+        if i == 0 and isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant):
+            continue  # module docstring
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            continue
         if isinstance(node, ast.ClassDef):
             violations.append(Violation(init_path, node.lineno, node.col_offset, "CORE_FACADE_LAYOUT",
                                         f"__init__.py must not define classes (found {node.name}) — the "
                                         f"facade only re-exports; the class lives in manager.py"))
+        else:
+            violations.append(Violation(init_path, node.lineno, node.col_offset, "CORE_FACADE_LAYOUT",
+                                        f"__init__.py top level allows only docstring/imports, found "
+                                        f"{type(node).__name__} — the facade only re-exports, no behavior/state"))
     last = init_tree.body[-1] if init_tree.body else None
     is_manager_import = (isinstance(last, ast.ImportFrom) and last.level == 1 and last.module == "manager"
                          and [a.name for a in last.names] == ["LLMSessionManager"]
@@ -533,11 +640,11 @@ def run(root: Path) -> list[Violation]:
     module_info = {}
     for path in routing_files:
         tree = parse(path)
+        pkg = ".".join(path.resolve().relative_to(root.resolve()).parts[:-1])
         module_info[path] = (tree, module_level_import_bindings(tree), global_read_names(path),
-                             module_alias_paths(tree))
+                             module_alias_paths(tree, pkg))
 
     for attr, sites in sorted(targets.items()):
-        strict_sites = [s for s in sites if not s[2]]
         if attr not in facade_names:
             for site_path, line, exempt in sites:
                 if not exempt:
@@ -546,8 +653,9 @@ def run(root: Path) -> list[Violation]:
                                                 f"no such name (typo? pass raising=False / create=True for "
                                                 f"intentional absent-name guards)"))
             continue
-        if not strict_sites:
-            continue  # only raising=False / create=True guards; no routing needed
+        # The attr exists on the facade, so every patch of it is real (a
+        # raising=False / create=True guard only waives the existence check,
+        # not the routing requirement) — route ALL consumers.
         for path, (tree, imports, global_reads, alias_paths) in module_info.items():
             if attr in imports:
                 violations.append(Violation(path, imports[attr], 0, "CORE_PATCH_ROUTING",

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -223,6 +223,25 @@ def facade_top_level_names(init_tree: ast.Module) -> set[str]:
     return names
 
 
+def facade_owner_modules(init_tree: ast.Module) -> dict[str, str]:
+    """{re-exported name: absolute owner module} from the facade's imports.
+
+    The facade lives at package ``main_logic.core``, so relative re-exports
+    (``from ._shared import CROSS_MODE_RESTART_WAIT_SECONDS``) resolve against
+    it. Used to match owner-module reads precisely (see ``owner_module_reads``).
+    """
+    out: dict[str, str] = {}
+    for node in init_tree.body:
+        if isinstance(node, ast.ImportFrom):
+            base = node.module if node.level == 0 else _resolve_relative("main_logic.core", node.level, node.module)
+            if not base:
+                continue
+            for a in node.names:
+                if a.name != "*":
+                    out[a.asname or a.name] = base
+    return out
+
+
 # ----------------------------------------------------------- module analysis
 def module_level_import_bindings(tree: ast.Module):
     """{name: lineno} bound or aliased by top-level import statements.
@@ -293,9 +312,9 @@ def module_alias_paths(tree: ast.Module, pkg: str) -> dict[str, str]:
     module; ``from main_logic import core as _core_facade`` → ``main_logic.core``).
 
     From-imports of plain symbols land here too, but that is harmless: the
-    routing scan only consults this map for ``<binding>.<patched_symbol>``
-    reads, and a patched module-level symbol is never an attribute of another
-    imported symbol.
+    routing scan (``owner_module_reads``) only flags a ``<binding>.<attr>`` read
+    when the binding resolves to the attr's ACTUAL owner module, so a plain
+    imported object with a coincidentally same-named method never matches.
     """
     out: dict[str, str] = {}
     for node in tree.body:
@@ -352,14 +371,20 @@ def attr_value_chain(node: ast.Attribute):
     return dotted_node_path(node.value)
 
 
-def owner_module_reads(tree: ast.Module, alias_paths: dict[str, str], attr: str):
-    """(line, col, module) for reads of ``attr`` through a non-facade module.
+def owner_module_reads(tree: ast.Module, alias_paths: dict[str, str], attr: str, owner: str | None):
+    """(line, col, module) for reads of ``attr`` through its OWNER module.
 
-    Both the attribute-chain form ``mod.attr`` and the string-getattr form
-    ``getattr(mod, "attr")`` follow the owner module rather than the facade,
-    so a facade monkeypatch misses them. Reads through main_logic.core itself
-    ARE the facade contract and are skipped.
+    The facade re-exports ``attr`` from ``owner`` (e.g. ``get_tts_worker`` from
+    ``main_logic.tts_client``); a monkeypatch of ``main_logic.core.<attr>``
+    rebinds only the facade copy, so a mixin that reads ``owner.<attr>`` (or
+    ``getattr(owner, "<attr>")``) sees the un-patched original. Matching the
+    SPECIFIC owner module — not just any non-facade module — avoids flagging a
+    coincidental same-named attribute on an unrelated object (a plain imported
+    object whose method happens to share the name). If ``owner`` is unknown
+    (attr not from-imported by the facade) nothing is flagged here.
     """
+    if not owner:
+        return []
     sites = []
     for node in ast.walk(tree):
         chain = None
@@ -371,9 +396,8 @@ def owner_module_reads(tree: ast.Module, alias_paths: dict[str, str], attr: str)
             chain = dotted_node_path(node.args[0])
         if chain is None:
             continue
-        resolved = resolve_chain(chain, alias_paths)
-        if resolved is not None and resolved != "main_logic.core":
-            sites.append((node.lineno, node.col_offset, resolved))
+        if resolve_chain(chain, alias_paths) == owner:
+            sites.append((node.lineno, node.col_offset, owner))
     return sites
 
 
@@ -443,6 +467,7 @@ def run(root: Path) -> list[Violation]:
     violations: list[Violation] = []
     init_tree = parse(init_path)
     facade_names = facade_top_level_names(init_tree)
+    facade_owners = facade_owner_modules(init_tree)
 
     # -- the core package must stay flat: a subpackage would define classes the
     #    *.py discovery below never scans, so its mixins/state escape every
@@ -489,6 +514,15 @@ def run(root: Path) -> list[Violation]:
                                             f"mixin class {mixins[0].name} must have an empty base list — a "
                                             f"base would smuggle behavior into LLMSessionManager's MRO "
                                             f"outside the mixin contract"))
+            # A class decorator runs at class creation and can inject/replace
+            # methods after the AST body is counted — invisible to DISJOINT and
+            # the manager-base checks. Mixins must be plain, undecorated bags.
+            if mixins[0].decorator_list:
+                d = mixins[0].decorator_list[0]
+                violations.append(Violation(path, d.lineno, d.col_offset, "CORE_MIXIN_SHAPE",
+                                            f"mixin class {mixins[0].name} must not be decorated — a class "
+                                            f"decorator can add methods/state into the MRO uncounted by the "
+                                            f"other checks"))
             mixin_files[path] = mixins[0]
         elif path.stem not in OWNER_SUBMODULES:
             violations.append(Violation(path, 1, 0, "CORE_MIXIN_SHAPE",
@@ -530,7 +564,20 @@ def run(root: Path) -> list[Violation]:
             if i == 0 and isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant):
                 continue  # class docstring
             if isinstance(node, (ast.Assign, ast.AnnAssign)):
-                continue  # class-level constants are allowed
+                # Class-level CONSTANTS are allowed, but a mutable container
+                # literal (``CACHE = {}``) is shared state across instances and
+                # a Call (``TOKEN = open_socket()``) runs behavior at import —
+                # both are the drift this contract prevents.
+                val = node.value
+                if isinstance(val, (ast.Dict, ast.List, ast.Set, ast.DictComp,
+                                    ast.ListComp, ast.SetComp, ast.Call)):
+                    kind = "a Call (import-time behavior)" if isinstance(val, ast.Call) \
+                        else "a mutable container (shared instance state)"
+                    violations.append(Violation(manager_path, node.lineno, node.col_offset, "CORE_MANAGER_SHAPE",
+                                                f"manager class attribute is {kind} — only immutable class "
+                                                f"constants are allowed; move state into __init__ (per instance) "
+                                                f"or behavior into a mixin"))
+                continue
             if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "__init__":
                 continue
             if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
@@ -586,26 +633,31 @@ def run(root: Path) -> list[Violation]:
             violations.append(Violation(manager_path, manager_class.lineno, manager_class.col_offset,
                                         "CORE_MIXIN_BASES",
                                         f"base {extra} has no *Mixin class defined in the package"))
-        # A base name matching a package mixin is not enough: the NAME must
-        # actually be bound to the package class via a relative import
-        # (``from .focus import FocusMixin``). Without this, manager.py could
-        # ``from elsewhere import FocusMixin`` and put the outside class in the
-        # MRO while the package mixin sits orphaned but the set check passes.
-        # Must be ``from .<sibling_module> import <Mixin>`` (level 1). A level-2+
-        # import (``from .. import ...``) escapes the core package and could bind
-        # an outside same-named class, so it does not count as core-local.
-        relative_binds = set()
+        # A base name matching a package mixin is not enough: the NAME must be
+        # bound to THE module that actually defines it, i.e.
+        # ``from .<defining_module> import <Mixin>`` (level 1, module == the
+        # mixin's own file stem). Binding the same name from any other sibling
+        # (``from ._shared import FocusMixin``) or a level-2+ import
+        # (``from .. import ...``) would put a different/outside class in the
+        # MRO while the real package mixin sits orphaned, yet the set check
+        # would still pass. ``defining_stem`` comes from where the class was
+        # discovered.
+        defining_stem = {mklass.name: mpath.stem for mpath, mklass in mixin_files.items()}
+        relative_binds = {}  # bound name -> level-1 module it was imported from
         for node in parse(manager_path).body:
             if isinstance(node, ast.ImportFrom) and node.level == 1 and node.module:
                 for a in node.names:
-                    relative_binds.add(a.asname or a.name)
+                    relative_binds[a.asname or a.name] = node.module
         for name in sorted(base_names & mixin_names):
-            if name not in relative_binds:
+            want = defining_stem.get(name)
+            if relative_binds.get(name) != want:
+                got = relative_binds.get(name)
+                where = f"bound from '.{got}'" if got else "not bound via a level-1 core-local import"
                 violations.append(Violation(manager_path, manager_class.lineno, manager_class.col_offset,
                                             "CORE_MIXIN_BASES",
-                                            f"base {name} matches a package mixin by name but is not bound via "
-                                            f"a core-local import (from .<module> import {name}); the MRO may be "
-                                            f"using an outside class while the package mixin is orphaned"))
+                                            f"base {name} must be imported from its defining module "
+                                            f"(from .{want} import {name}) but is {where}; the MRO may be using "
+                                            f"a different/outside class while the package mixin is orphaned"))
 
     # -- CORE_FACADE_LAYOUT: the facade only re-exports — docstring + imports.
     #    A top-level function, assignment or executable statement would put
@@ -675,7 +727,7 @@ def run(root: Path) -> list[Violation]:
             # "dispatch_...")``) — dodge facade patches the same way. Reads
             # through main_logic.core itself ARE the facade contract and are
             # skipped inside the helper.
-            for line, col, resolved in owner_module_reads(tree, alias_paths, attr):
+            for line, col, resolved in owner_module_reads(tree, alias_paths, attr, facade_owners.get(attr)):
                 violations.append(Violation(
                     path, line, col, "CORE_PATCH_ROUTING",
                     f"'{attr}' is a test patch target on the facade but is read here "

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -254,29 +254,37 @@ def attr_value_chain(node: ast.Attribute):
 def def_time_facade_reads(tree: ast.Module, alias_paths: dict[str, str], attr: str):
     """(line, col) of facade reads of ``attr`` evaluated at class-creation.
 
-    Method defaults, decorators and evaluated annotations run ONCE at import
-    time; a ``_core_facade.<attr>`` there freezes the value, so later facade
-    patches no longer reach it — the read must live in the method body.
+    Method defaults, decorators, evaluated annotations and class-level
+    constant values run ONCE at import time; a ``_core_facade.<attr>`` there
+    freezes the value, so later facade patches no longer reach it — the read
+    must live in the method body.
     """
     sites = []
     for klass in (n for n in tree.body if isinstance(n, ast.ClassDef)):
-        for meth in (n for n in klass.body if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))):
-            a = meth.args
-            sig_nodes = list(meth.decorator_list)
-            sig_nodes += [d for d in a.defaults if d is not None]
-            sig_nodes += [d for d in a.kw_defaults if d is not None]
-            for arg in (a.posonlyargs + a.args + a.kwonlyargs
-                        + ([a.vararg] if a.vararg else []) + ([a.kwarg] if a.kwarg else [])):
-                if arg.annotation is not None:
-                    sig_nodes.append(arg.annotation)
-            if meth.returns is not None:
-                sig_nodes.append(meth.returns)
-            for sub in sig_nodes:
-                for node in ast.walk(sub):
-                    if isinstance(node, ast.Attribute) and node.attr == attr:
-                        chain = attr_value_chain(node)
-                        if chain and alias_paths.get(chain) == "main_logic.core":
-                            sites.append((node.lineno, node.col_offset))
+        def_time_nodes = []
+        for stmt in klass.body:
+            if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                a = stmt.args
+                def_time_nodes += stmt.decorator_list
+                def_time_nodes += [d for d in a.defaults if d is not None]
+                def_time_nodes += [d for d in a.kw_defaults if d is not None]
+                for arg in (a.posonlyargs + a.args + a.kwonlyargs
+                            + ([a.vararg] if a.vararg else []) + ([a.kwarg] if a.kwarg else [])):
+                    if arg.annotation is not None:
+                        def_time_nodes.append(arg.annotation)
+                if stmt.returns is not None:
+                    def_time_nodes.append(stmt.returns)
+            elif isinstance(stmt, (ast.Assign, ast.AnnAssign)):
+                # Class-level constants (allowed in manager.py) evaluate at
+                # class creation too — a facade read there freezes the value.
+                if stmt.value is not None:
+                    def_time_nodes.append(stmt.value)
+        for sub in def_time_nodes:
+            for node in ast.walk(sub):
+                if isinstance(node, ast.Attribute) and node.attr == attr:
+                    chain = attr_value_chain(node)
+                    if chain and alias_paths.get(chain) == "main_logic.core":
+                        sites.append((node.lineno, node.col_offset))
     return sites
 
 
@@ -477,10 +485,10 @@ def run(root: Path) -> list[Violation]:
             for line, col in def_time_facade_reads(tree, alias_paths, attr):
                 violations.append(Violation(
                     path, line, col, "CORE_PATCH_ROUTING",
-                    f"'{attr}' is read from the facade inside a default/decorator/annotation — "
-                    f"that expression runs once at import and freezes the value, so facade "
-                    f"patches no longer reach it; move the {FACADE_MODULE_ALIAS}.{attr} read "
-                    f"into the method body"))
+                    f"'{attr}' is read from the facade inside a default/decorator/annotation/"
+                    f"class attribute — that expression runs once at import and freezes the "
+                    f"value, so facade patches no longer reach it; move the "
+                    f"{FACADE_MODULE_ALIAS}.{attr} read into the method body"))
     return violations
 
 

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -643,17 +643,40 @@ def run(root: Path) -> list[Violation]:
             violations.append(Violation(manager_path, manager_class.lineno, manager_class.col_offset,
                                         "CORE_MANAGER_SHAPE", "LLMSessionManager must define __init__ here"))
 
-    # -- CORE_MIXIN_DISJOINT
+    # -- CORE_MIXIN_DISJOINT: a method name defined in two DIFFERENT mixins is
+    #    an MRO shadowing bug. A property accessor group (@property + @x.setter
+    #    / @x.deleter) legitimately repeats the name WITHIN one mixin — Python
+    #    merges them into one descriptor — so count each name once per mixin.
+    def _is_property_accessor(fn):
+        for d in fn.decorator_list:
+            if isinstance(d, ast.Name) and d.id == "property":
+                return True
+            if isinstance(d, ast.Attribute) and d.attr in ("setter", "deleter", "getter"):
+                return True
+        return False
+
     seen: dict[str, str] = {}
     for path, klass in sorted(mixin_files.items()):
+        here = f"{path.name}:{klass.name}"
+        local: dict[str, ast.AST] = {}
         for node in klass.body:
-            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                if node.name in seen:
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if node.name in local:
+                # Same name twice in ONE mixin: fine only for a property group.
+                if not (_is_property_accessor(local[node.name]) and _is_property_accessor(node)):
                     violations.append(Violation(path, node.lineno, node.col_offset, "CORE_MIXIN_DISJOINT",
-                                                f"method '{node.name}' already defined in {seen[node.name]} — "
-                                                f"MRO would shadow one of them silently"))
-                else:
-                    seen[node.name] = f"{path.name}:{klass.name}"
+                                                f"method '{node.name}' is defined twice in {here} and is not a "
+                                                f"property accessor group — the second definition shadows the "
+                                                f"first"))
+                continue
+            local[node.name] = node
+            if node.name in seen:
+                violations.append(Violation(path, node.lineno, node.col_offset, "CORE_MIXIN_DISJOINT",
+                                            f"method '{node.name}' already defined in {seen[node.name]} — "
+                                            f"MRO would shadow one of them silently"))
+            else:
+                seen[node.name] = here
 
     # -- CORE_MIXIN_BASES
     if manager_class is not None:

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -16,35 +16,45 @@ CORE_PATCH_ROUTING
     fail loudly, but isolation-style stubs (blocking disk/network IO) go
     silently green while calling the real function. The patched-symbol set
     is harvested from ``tests/`` by AST on every run, so the contract
-    tightens automatically as tests grow. Attribute reads through some other
-    imported module (``import main_logic.agent_event_bus`` + ``main_logic.
-    agent_event_bus.<attr>(...)``) are rejected the same way — they follow
-    the owner module, not the facade. So are facade reads inside method
-    defaults/decorators/annotations: those evaluate once at import and
-    freeze the value. Function-local imports from the OWNER module (e.g.
-    ``from utils.preferences import ...`` inside a method) are a different,
+    tightens automatically as tests grow. Reads through some other imported
+    module — attribute chains (``import main_logic.agent_event_bus`` /
+    ``from main_logic import agent_event_bus as bus`` + ``bus.<attr>(...)``)
+    and string getattr (``getattr(bus, "<attr>")``) — are rejected the same
+    way: they follow the owner module, not the facade. So are facade reads
+    inside method defaults/decorators/annotations and class-level constant
+    values: those evaluate once at import and freeze the value.
+    Function-local imports from the OWNER module (e.g. ``from
+    utils.preferences import ...`` inside a method) are a different,
     deliberate late-binding pattern and stay allowed: the facade patch
     never targeted them, before or after the split.
 
+    The patch-target harvest recognizes both positional and keyword call
+    spellings, string (``"main_logic.core.X"``) and object
+    (``setattr(core_module, "X", ...)``) forms, and object targets reached
+    through a package alias (``import main_logic as ml`` -> ``ml.core``).
+
 CORE_PATCH_TARGET_EXISTS
     Every patched facade attribute must actually exist at the facade top
-    level (typo guard), unless the call passes ``raising=False`` (negative
-    guards intentionally patch absent names).
+    level (typo guard), unless the call passes ``raising=False`` or
+    ``create=True`` (intentional absent-name guards).
 
 CORE_MIXIN_SHAPE
     A mixin module's top level holds only a docstring, imports and exactly
     one ``*Mixin`` class; the class body holds only a docstring and
-    methods. Instance state has a single home (``LLMSessionManager.
-    __init__``), and module-level state in a mixin would sit outside the
-    facade's rebind semantics entirely. Any core module that is neither a
-    mixin, ``manager.py`` nor a registered owner submodule is rejected —
-    adding a new owner module is a conscious edit to this check.
+    methods, and the class has an empty base list (a base would pull
+    inherited behavior into the MRO uncounted). Instance state has a single
+    home (``LLMSessionManager.__init__``), and module-level state in a
+    mixin would sit outside the facade's rebind semantics entirely. Any
+    core module that is neither a mixin, ``manager.py`` nor a registered
+    owner submodule is rejected — adding a new owner module is a conscious
+    edit to this check.
 
 CORE_MANAGER_SHAPE
     ``manager.py`` holds exactly one class, ``LLMSessionManager``, and its
-    top level holds nothing but docstring/imports/that class; the class's
-    only method is ``__init__`` (class-level constants are allowed). New
-    behavior belongs in a domain mixin.
+    top level holds nothing but docstring/imports/that class; the class
+    body holds nothing but a docstring, class-level constants and
+    ``__init__``. Any other method, nested class or executable statement is
+    behavior/state that belongs in a domain mixin.
 
 CORE_MIXIN_DISJOINT
     No method name is defined by two mixin classes (or by both a mixin and
@@ -54,8 +64,10 @@ CORE_MIXIN_DISJOINT
 CORE_MIXIN_BASES
     The base list of ``LLMSessionManager`` is exactly the set of ``*Mixin``
     classes defined in the package — no orphan mixin module, no missing
-    base, and every base must be a plain name (dotted/computed bases would
-    make the exact-set comparison silently incomplete).
+    base, every base a plain name (dotted/computed bases would make the
+    exact-set comparison silently incomplete), and every base bound via a
+    package-relative import (``from .focus import FocusMixin``) so a
+    same-named class from outside the package cannot take the MRO slot.
 
 CORE_FACADE_LAYOUT
     ``__init__.py`` defines no class at top level, and its last statement
@@ -105,21 +117,24 @@ def collect_patch_targets(tests_dir: Path):
     """Return {attr: [(file, line, raising_false)]} for facade rebind sites."""
     targets: dict[str, list[tuple[Path, int, bool]]] = {}
 
-    def add(name, path, node, raising_false):
-        targets.setdefault(name, []).append((path, node.lineno, raising_false))
+    def add(name, path, node, exempt):
+        targets.setdefault(name, []).append((path, node.lineno, exempt))
 
     for path in sorted(tests_dir.rglob("*.py")):
         try:
             tree = parse(path)
         except SyntaxError:
             continue
-        aliases = set()
+        aliases = set()      # names bound to the main_logic.core MODULE
+        pkg_aliases = set()  # names bound to the main_logic PACKAGE (for ``ml.core``)
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):
                 for a in node.names:
                     if a.name == "main_logic.core" and a.asname:
                         aliases.add(a.asname)
-            elif isinstance(node, ast.ImportFrom) and node.module == "main_logic":
+                    elif a.name == "main_logic":
+                        pkg_aliases.add(a.asname or "main_logic")
+            elif isinstance(node, ast.ImportFrom) and node.module == "main_logic" and node.level == 0:
                 for a in node.names:
                     if a.name == "core":
                         aliases.add(a.asname or "core")
@@ -127,8 +142,9 @@ def collect_patch_targets(tests_dir: Path):
         def is_core_ref(expr):
             if isinstance(expr, ast.Name) and expr.id in aliases:
                 return True
+            # ``main_logic.core`` or ``<pkg-alias>.core`` (import main_logic as ml)
             return (isinstance(expr, ast.Attribute) and expr.attr == "core"
-                    and isinstance(expr.value, ast.Name) and expr.value.id == "main_logic")
+                    and isinstance(expr.value, ast.Name) and expr.value.id in pkg_aliases)
 
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
@@ -136,8 +152,13 @@ def collect_patch_targets(tests_dir: Path):
             fn = node.func
             fname = fn.attr if isinstance(fn, ast.Attribute) else (fn.id if isinstance(fn, ast.Name) else "")
             kw = {k.arg: k.value for k in node.keywords if k.arg}
-            raising_false = (isinstance(kw.get("raising"), ast.Constant)
-                             and kw["raising"].value is False)
+            # A patch that need not resolve to a real facade attribute:
+            #   raising=False  (pytest monkeypatch negative guard)
+            #   create=True    (unittest.mock.patch / patch.object absent-name guard)
+            # Both mean "the target may not exist", so exempt from routing and
+            # from the target-exists check alike.
+            exempt = ((isinstance(kw.get("raising"), ast.Constant) and kw["raising"].value is False)
+                      or (isinstance(kw.get("create"), ast.Constant) and kw["create"].value is True))
             args = node.args
             # Positional and keyword spellings are equivalent for these APIs:
             # setattr(target=..., name=...), patch(target=...),
@@ -148,10 +169,10 @@ def collect_patch_targets(tests_dir: Path):
                 if isinstance(first, ast.Constant) and isinstance(first.value, str):
                     s = first.value
                     if s.startswith("main_logic.core.") and s.count(".") == 2:
-                        add(s.rsplit(".", 1)[1], path, node, raising_false)
+                        add(s.rsplit(".", 1)[1], path, node, exempt)
             if fname in (PATCH_CALL_NAMES | {"object"}) and first is not None and second is not None:
                 if is_core_ref(first) and isinstance(second, ast.Constant) and isinstance(second.value, str):
-                    add(second.value, path, node, raising_false)
+                    add(second.value, path, node, exempt)
     return targets
 
 
@@ -219,7 +240,14 @@ def module_alias_paths(tree: ast.Module) -> dict[str, str]:
 
     Covers plain ``import a.b`` (binds ``a``; the full dotted chain is also
     kept as a key so ``a.b.attr`` reads match), ``import a.b as c`` and the
-    facade form ``from main_logic import core [as alias]``.
+    from-import module form ``from a import b [as c]`` (binds ``b``/``c`` to
+    ``a.b`` — e.g. ``from main_logic import agent_event_bus as bus`` or the
+    facade ``from main_logic import core as _core_facade``).
+
+    From-imports of plain symbols (``from x import a_function``) land here too,
+    but that is harmless: the routing scan only consults this map for reads
+    spelled ``<binding>.<patched_symbol>``, and a patched module-level symbol
+    is never an attribute of another imported symbol.
     """
     out: dict[str, str] = {}
     for node in tree.body:
@@ -231,17 +259,19 @@ def module_alias_paths(tree: ast.Module) -> dict[str, str]:
                     root = a.name.split(".")[0]
                     out.setdefault(root, root)
                     out[a.name] = a.name
-        elif isinstance(node, ast.ImportFrom) and node.module == "main_logic" and node.level == 0:
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            base = "." * node.level + node.module
             for a in node.names:
-                if a.name == "core":
-                    out[a.asname or "core"] = "main_logic.core"
+                if a.name == "*":
+                    continue
+                out[a.asname or a.name] = f"{base}.{a.name}"
     return out
 
 
-def attr_value_chain(node: ast.Attribute):
-    """Dotted string of an attribute node's value side, or None."""
+def dotted_node_path(node):
+    """Dotted string of a Name/Attribute node itself, or None."""
     parts = []
-    cur = node.value
+    cur = node
     while isinstance(cur, ast.Attribute):
         parts.append(cur.attr)
         cur = cur.value
@@ -249,6 +279,36 @@ def attr_value_chain(node: ast.Attribute):
         return None
     parts.append(cur.id)
     return ".".join(reversed(parts))
+
+
+def attr_value_chain(node: ast.Attribute):
+    """Dotted string of an attribute node's value side, or None."""
+    return dotted_node_path(node.value)
+
+
+def owner_module_reads(tree: ast.Module, alias_paths: dict[str, str], attr: str):
+    """(line, col, module) for reads of ``attr`` through a non-facade module.
+
+    Both the attribute-chain form ``mod.attr`` and the string-getattr form
+    ``getattr(mod, "attr")`` follow the owner module rather than the facade,
+    so a facade monkeypatch misses them. Reads through main_logic.core itself
+    ARE the facade contract and are skipped.
+    """
+    sites = []
+    for node in ast.walk(tree):
+        chain = None
+        if isinstance(node, ast.Attribute) and node.attr == attr:
+            chain = attr_value_chain(node)
+        elif (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+              and node.func.id == "getattr" and len(node.args) >= 2
+              and isinstance(node.args[1], ast.Constant) and node.args[1].value == attr):
+            chain = dotted_node_path(node.args[0])
+        if chain is None:
+            continue
+        resolved = alias_paths.get(chain)
+        if resolved is not None and resolved != "main_logic.core":
+            sites.append((node.lineno, node.col_offset, resolved))
+    return sites
 
 
 def def_time_facade_reads(tree: ast.Module, alias_paths: dict[str, str], attr: str):
@@ -339,6 +399,14 @@ def run(root: Path) -> list[Violation]:
             if len(classes) != 1:
                 violations.append(Violation(path, classes[1].lineno, classes[1].col_offset, "CORE_MIXIN_SHAPE",
                                             f"{path.name} must define exactly one class (found {len(classes)})"))
+            # A base on a mixin drags inherited methods/state into
+            # LLMSessionManager's MRO uncounted by CORE_MIXIN_DISJOINT/BASES.
+            if mixins[0].bases or mixins[0].keywords:
+                b = (mixins[0].bases or [kw.value for kw in mixins[0].keywords])[0]
+                violations.append(Violation(path, b.lineno, b.col_offset, "CORE_MIXIN_SHAPE",
+                                            f"mixin class {mixins[0].name} must have an empty base list — a "
+                                            f"base would smuggle behavior into LLMSessionManager's MRO "
+                                            f"outside the mixin contract"))
             mixin_files[path] = mixins[0]
         elif path.stem not in OWNER_SUBMODULES:
             violations.append(Violation(path, 1, 0, "CORE_MIXIN_SHAPE",
@@ -371,14 +439,26 @@ def run(root: Path) -> list[Violation]:
                                         f"mixin class body allows only docstring/methods, "
                                         f"found {type(node).__name__} — state belongs in manager.__init__"))
 
-    # -- CORE_MANAGER_SHAPE: only __init__ as a method
+    # -- CORE_MANAGER_SHAPE: class body is only docstring / class constants /
+    #    __init__. Any other statement (extra method, nested class, class-level
+    #    cache, executable logic) is behavior/state that belongs in a mixin.
     if manager_class is not None:
         methods = [n for n in manager_class.body if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))]
-        for m in methods:
-            if m.name != "__init__":
-                violations.append(Violation(manager_path, m.lineno, m.col_offset, "CORE_MANAGER_SHAPE",
-                                            f"manager class defines method '{m.name}' — behavior belongs "
+        for i, node in enumerate(manager_class.body):
+            if i == 0 and isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant):
+                continue  # class docstring
+            if isinstance(node, (ast.Assign, ast.AnnAssign)):
+                continue  # class-level constants are allowed
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "__init__":
+                continue
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                violations.append(Violation(manager_path, node.lineno, node.col_offset, "CORE_MANAGER_SHAPE",
+                                            f"manager class defines method '{node.name}' — behavior belongs "
                                             f"in a domain mixin; manager.py keeps only __init__"))
+            else:
+                violations.append(Violation(manager_path, node.lineno, node.col_offset, "CORE_MANAGER_SHAPE",
+                                            f"manager class body allows only docstring/constants/__init__, "
+                                            f"found {type(node).__name__} — state/behavior belongs in a mixin"))
         if not any(m.name == "__init__" for m in methods):
             violations.append(Violation(manager_path, manager_class.lineno, manager_class.col_offset,
                                         "CORE_MANAGER_SHAPE", "LLMSessionManager must define __init__ here"))
@@ -413,6 +493,23 @@ def run(root: Path) -> list[Violation]:
             violations.append(Violation(manager_path, manager_class.lineno, manager_class.col_offset,
                                         "CORE_MIXIN_BASES",
                                         f"base {extra} has no *Mixin class defined in the package"))
+        # A base name matching a package mixin is not enough: the NAME must
+        # actually be bound to the package class via a relative import
+        # (``from .focus import FocusMixin``). Without this, manager.py could
+        # ``from elsewhere import FocusMixin`` and put the outside class in the
+        # MRO while the package mixin sits orphaned but the set check passes.
+        relative_binds = {}
+        for node in parse(manager_path).body:
+            if isinstance(node, ast.ImportFrom) and node.level >= 1:
+                for a in node.names:
+                    relative_binds[a.asname or a.name] = node.module
+        for name in sorted(base_names & mixin_names):
+            if name not in relative_binds:
+                violations.append(Violation(manager_path, manager_class.lineno, manager_class.col_offset,
+                                            "CORE_MIXIN_BASES",
+                                            f"base {name} matches a package mixin by name but is not bound via "
+                                            f"a package-relative import (from .<module> import {name}); the MRO "
+                                            f"may be using an outside class while the package mixin is orphaned"))
 
     # -- CORE_FACADE_LAYOUT
     for node in init_tree.body:
@@ -442,14 +539,15 @@ def run(root: Path) -> list[Violation]:
     for attr, sites in sorted(targets.items()):
         strict_sites = [s for s in sites if not s[2]]
         if attr not in facade_names:
-            for site_path, line, raising_false in sites:
-                if not raising_false:
+            for site_path, line, exempt in sites:
+                if not exempt:
                     violations.append(Violation(site_path, line, 0, "CORE_PATCH_TARGET_EXISTS",
                                                 f"test patches main_logic.core.{attr} but the facade defines "
-                                                f"no such name (typo? pass raising=False for negative guards)"))
+                                                f"no such name (typo? pass raising=False / create=True for "
+                                                f"intentional absent-name guards)"))
             continue
         if not strict_sites:
-            continue  # raising=False negative guards need no routing
+            continue  # only raising=False / create=True guards; no routing needed
         for path, (tree, imports, global_reads, alias_paths) in module_info.items():
             if attr in imports:
                 violations.append(Violation(path, imports[attr], 0, "CORE_PATCH_ROUTING",
@@ -464,24 +562,17 @@ def run(root: Path) -> list[Violation]:
                                             f"as a bare global — read it as {FACADE_MODULE_ALIAS}.{attr} so "
                                             f"monkeypatch.setattr(\"main_logic.core.{attr}\", ...) keeps "
                                             f"hitting this consumer"))
-            else:
-                # Attribute reads through some OTHER imported module
-                # (``import main_logic.agent_event_bus`` +
-                # ``main_logic.agent_event_bus.dispatch_text_user_message(...)``)
-                # dodge facade patches just like a from-import snapshot would.
-                # Reads through main_logic.core itself ARE the facade contract.
-                for node in ast.walk(tree):
-                    if isinstance(node, ast.Attribute) and node.attr == attr:
-                        chain = attr_value_chain(node)
-                        if chain is None:
-                            continue
-                        resolved = alias_paths.get(chain)
-                        if resolved is not None and resolved != "main_logic.core":
-                            violations.append(Violation(
-                                path, node.lineno, node.col_offset, "CORE_PATCH_ROUTING",
-                                f"'{attr}' is a test patch target on the facade but is read here "
-                                f"through module '{resolved}' — that read follows the owner module, "
-                                f"not the facade; read it as {FACADE_MODULE_ALIAS}.{attr} instead"))
+            # Reads through some OTHER imported module — attribute chains
+            # (``bus.dispatch_...``) and string getattr (``getattr(bus,
+            # "dispatch_...")``) — dodge facade patches the same way. Reads
+            # through main_logic.core itself ARE the facade contract and are
+            # skipped inside the helper.
+            for line, col, resolved in owner_module_reads(tree, alias_paths, attr):
+                violations.append(Violation(
+                    path, line, col, "CORE_PATCH_ROUTING",
+                    f"'{attr}' is a test patch target on the facade but is read here "
+                    f"through module '{resolved}' — that read follows the owner module, "
+                    f"not the facade; read it as {FACADE_MODULE_ALIAS}.{attr} instead"))
             for line, col in def_time_facade_reads(tree, alias_paths, attr):
                 violations.append(Violation(
                     path, line, col, "CORE_PATCH_ROUTING",

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -194,8 +194,12 @@ def collect_patch_targets(tests_dir: Path):
                     s = first.value
                     if s.startswith("main_logic.core.") and s.count(".") == 2:
                         add(s.rsplit(".", 1)[1], path, node, exempt)
-            # object form: setattr(core_module, "X"), patch.object(core_module, "X")
-            is_obj_patch = fname in (PATCH_CALL_NAMES | {"object"}) or (fname == "object" and is_patch_ref(fbase))
+            # object form: setattr(core_module, "X"), patch.object(core_module, "X").
+            # ``.object`` counts only on a real patch receiver — do NOT fold
+            # "object" into the union or ``x.object(core_ref, "y")`` on any
+            # receiver would be mis-harvested (the is_patch_ref check would be
+            # dead code and could invent false patch targets).
+            is_obj_patch = fname in PATCH_CALL_NAMES or (fname == "object" and is_patch_ref(fbase))
             if is_obj_patch and first is not None and second is not None:
                 if is_core_ref(first) and isinstance(second, ast.Constant) and isinstance(second.value, str):
                     add(second.value, path, node, exempt)

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -649,15 +649,16 @@ def run(root: Path) -> list[Violation]:
 
     # -- CORE_MIXIN_DISJOINT: a method name defined in two DIFFERENT mixins is
     #    an MRO shadowing bug. A property group legitimately repeats the name
-    #    WITHIN one mixin — but a VALID group is exactly one @property getter
-    #    plus optional @x.setter/@x.deleter; two plain @property (or two plain
-    #    methods) are a real shadow (Python keeps only the last).
+    #    WITHIN one mixin, but a VALID group fills each of Python's three
+    #    property slots at most once: getter (@property / @x.getter), setter
+    #    (@x.setter), deleter (@x.deleter). Two of any slot — or any plain
+    #    method sharing the name — is a real shadow (Python keeps only the last).
     def _prop_role(fn):
         for d in fn.decorator_list:
             if isinstance(d, ast.Name) and d.id == "property":
                 return "getter"
-            if isinstance(d, ast.Attribute) and d.attr in ("setter", "deleter", "getter"):
-                return "accessor"
+            if isinstance(d, ast.Attribute) and d.attr in ("getter", "setter", "deleter"):
+                return d.attr
         return None  # a plain method
 
     seen: dict[str, str] = {}
@@ -670,13 +671,17 @@ def run(root: Path) -> list[Violation]:
         for name, defs in groups.items():
             if len(defs) > 1:
                 roles = [_prop_role(d) for d in defs]
-                if any(r is None for r in roles) or roles.count("getter") > 1:
+                valid_group = (all(r is not None for r in roles)
+                               and roles.count("getter") <= 1
+                               and roles.count("setter") <= 1
+                               and roles.count("deleter") <= 1)
+                if not valid_group:
                     last = defs[-1]
                     violations.append(Violation(path, last.lineno, last.col_offset, "CORE_MIXIN_DISJOINT",
                                                 f"method '{name}' is defined {len(defs)}× in {here} and is not a "
-                                                f"valid property group (one @property getter + optional "
-                                                f"@{name}.setter/.deleter) — a later definition shadows an "
-                                                f"earlier one"))
+                                                f"valid property group (at most one each of @property getter / "
+                                                f"@{name}.setter / @{name}.deleter) — a later definition shadows "
+                                                f"an earlier one"))
             if name in seen:
                 first = defs[0]
                 violations.append(Violation(path, first.lineno, first.col_offset, "CORE_MIXIN_DISJOINT",

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -223,14 +223,17 @@ def facade_top_level_names(init_tree: ast.Module) -> set[str]:
     return names
 
 
-def facade_owner_modules(init_tree: ast.Module) -> dict[str, str]:
-    """{re-exported name: absolute owner module} from the facade's imports.
+def facade_owner_modules(init_tree: ast.Module) -> dict[str, tuple[str, str]]:
+    """{facade name: (absolute owner module, ORIGINAL symbol name)}.
 
     The facade lives at package ``main_logic.core``, so relative re-exports
     (``from ._shared import CROSS_MODE_RESTART_WAIT_SECONDS``) resolve against
-    it. Used to match owner-module reads precisely (see ``owner_module_reads``).
+    it. The original name matters for aliased re-exports
+    (``from ...bus import dispatch_text_user_message as send_text`` → facade
+    name ``send_text`` but the owner attribute is ``dispatch_text_user_message``)
+    so ``owner_module_reads`` searches the owner for the RIGHT attribute.
     """
-    out: dict[str, str] = {}
+    out: dict[str, tuple[str, str]] = {}
     for node in init_tree.body:
         if isinstance(node, ast.ImportFrom):
             base = node.module if node.level == 0 else _resolve_relative("main_logic.core", node.level, node.module)
@@ -238,7 +241,7 @@ def facade_owner_modules(init_tree: ast.Module) -> dict[str, str]:
                 continue
             for a in node.names:
                 if a.name != "*":
-                    out[a.asname or a.name] = base
+                    out[a.asname or a.name] = (base, a.name)
     return out
 
 
@@ -371,28 +374,31 @@ def attr_value_chain(node: ast.Attribute):
     return dotted_node_path(node.value)
 
 
-def owner_module_reads(tree: ast.Module, alias_paths: dict[str, str], attr: str, owner: str | None):
-    """(line, col, module) for reads of ``attr`` through its OWNER module.
+def owner_module_reads(tree: ast.Module, alias_paths: dict[str, str], owner_info):
+    """(line, col, module) for reads of the owner attribute that a facade patch
+    would miss.
 
-    The facade re-exports ``attr`` from ``owner`` (e.g. ``get_tts_worker`` from
-    ``main_logic.tts_client``); a monkeypatch of ``main_logic.core.<attr>``
-    rebinds only the facade copy, so a mixin that reads ``owner.<attr>`` (or
-    ``getattr(owner, "<attr>")``) sees the un-patched original. Matching the
-    SPECIFIC owner module — not just any non-facade module — avoids flagging a
-    coincidental same-named attribute on an unrelated object (a plain imported
-    object whose method happens to share the name). If ``owner`` is unknown
-    (attr not from-imported by the facade) nothing is flagged here.
+    ``owner_info`` is ``(owner_module, original_name)``: the facade re-exports
+    the patched symbol from ``owner_module`` under ``original_name`` (which
+    differs from the facade name only for aliased re-exports). A monkeypatch of
+    ``main_logic.core.<facade_name>`` rebinds only the facade copy, so a mixin
+    that reads ``owner_module.original_name`` (or ``getattr(...)``) sees the
+    un-patched original. Matching the SPECIFIC owner module and its ORIGINAL
+    attribute name avoids flagging a coincidental same-named attribute on an
+    unrelated object. If ``owner_info`` is unknown (attr not from-imported by
+    the facade) nothing is flagged here.
     """
-    if not owner:
+    if not owner_info:
         return []
+    owner, name = owner_info
     sites = []
     for node in ast.walk(tree):
         chain = None
-        if isinstance(node, ast.Attribute) and node.attr == attr:
+        if isinstance(node, ast.Attribute) and node.attr == name:
             chain = attr_value_chain(node)
         elif (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
               and node.func.id == "getattr" and len(node.args) >= 2
-              and isinstance(node.args[1], ast.Constant) and node.args[1].value == attr):
+              and isinstance(node.args[1], ast.Constant) and node.args[1].value == name):
             chain = dotted_node_path(node.args[0])
         if chain is None:
             continue
@@ -584,16 +590,21 @@ def run(root: Path) -> list[Violation]:
                 continue  # class docstring
             if isinstance(node, (ast.Assign, ast.AnnAssign)):
                 # Class-level CONSTANTS are allowed, but a mutable container
-                # literal (``CACHE = {}``) is shared state across instances and
-                # a Call (``TOKEN = open_socket()``) runs behavior at import —
-                # both are the drift this contract prevents. Recurse: a nested
-                # literal (``TOKEN = (open_socket(),)``) hides the same thing
-                # behind an immutable-looking outer Tuple.
-                MUTABLE = (ast.Dict, ast.List, ast.Set, ast.DictComp, ast.ListComp, ast.SetComp, ast.Call)
-                bad = next((s for s in ast.walk(node.value) if isinstance(s, MUTABLE)), None)
+                # literal (``CACHE = {}``) is shared state, a Call
+                # (``TOKEN = open_socket()``) runs behavior at import, and a
+                # Lambda (``extra = lambda self: ...``) is a method in disguise
+                # — all drift this contract prevents. Recurse: a nested literal
+                # (``TOKEN = (open_socket(),)``) hides it behind an outer Tuple.
+                # ``node.value`` is None for an annotation-only attr (``x: int``)
+                # — nothing to evaluate, so it is fine.
+                MUTABLE = (ast.Dict, ast.List, ast.Set, ast.DictComp, ast.ListComp,
+                           ast.SetComp, ast.GeneratorExp, ast.Call, ast.Lambda)
+                bad = None if node.value is None else \
+                    next((s for s in ast.walk(node.value) if isinstance(s, MUTABLE)), None)
                 if bad is not None:
-                    kind = "a Call (import-time behavior)" if isinstance(bad, ast.Call) \
-                        else "a mutable container (shared instance state)"
+                    kind = ("a Call (import-time behavior)" if isinstance(bad, ast.Call)
+                            else "a lambda (a method in disguise)" if isinstance(bad, ast.Lambda)
+                            else "a mutable container (shared instance state)")
                     violations.append(Violation(manager_path, node.lineno, node.col_offset, "CORE_MANAGER_SHAPE",
                                                 f"manager class attribute is/contains {kind} — only immutable "
                                                 f"class constants are allowed; move state into __init__ (per "
@@ -775,7 +786,7 @@ def run(root: Path) -> list[Violation]:
             # "dispatch_...")``) — dodge facade patches the same way. Reads
             # through main_logic.core itself ARE the facade contract and are
             # skipped inside the helper.
-            for line, col, resolved in owner_module_reads(tree, alias_paths, attr, facade_owners.get(attr)):
+            for line, col, resolved in owner_module_reads(tree, alias_paths, facade_owners.get(attr)):
                 violations.append(Violation(
                     path, line, col, "CORE_PATCH_ROUTING",
                     f"'{attr}' is a test patch target on the facade but is read here "

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -619,15 +619,19 @@ def run(root: Path) -> list[Violation]:
                                                 f"manager class attribute is/contains {kind} — only immutable "
                                                 f"class constants are allowed; move state into __init__ (per "
                                                 f"instance) or behavior into a mixin"))
-                # A class attribute that shares a name with a mixin method wins
-                # attribute lookup and silently removes that method from the API.
+                # A class attribute that shares a name with a mixin method (or
+                # with the manager's own __init__) wins attribute lookup and
+                # silently removes/replaces it — ``__init__ = external`` after
+                # ``def __init__`` overwrites the initializer while the method
+                # count still passes.
                 targets = node.targets if isinstance(node, ast.Assign) else [node.target]
                 for t in targets:
-                    if isinstance(t, ast.Name) and t.id in mixin_method_names:
+                    if isinstance(t, ast.Name) and (t.id in mixin_method_names or t.id == "__init__"):
+                        what = "the manager's __init__" if t.id == "__init__" else "a mixin method"
                         violations.append(Violation(manager_path, node.lineno, node.col_offset, "CORE_MANAGER_SHAPE",
-                                                    f"manager class attribute '{t.id}' shadows a mixin method of "
-                                                    f"the same name — it would win attribute lookup and drop the "
-                                                    f"method from LLMSessionManager's API"))
+                                                    f"manager class attribute '{t.id}' shadows {what} of the same "
+                                                    f"name — it would win attribute lookup and drop/replace it in "
+                                                    f"LLMSessionManager's API"))
                 continue
             if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "__init__":
                 continue
@@ -644,39 +648,42 @@ def run(root: Path) -> list[Violation]:
                                         "CORE_MANAGER_SHAPE", "LLMSessionManager must define __init__ here"))
 
     # -- CORE_MIXIN_DISJOINT: a method name defined in two DIFFERENT mixins is
-    #    an MRO shadowing bug. A property accessor group (@property + @x.setter
-    #    / @x.deleter) legitimately repeats the name WITHIN one mixin — Python
-    #    merges them into one descriptor — so count each name once per mixin.
-    def _is_property_accessor(fn):
+    #    an MRO shadowing bug. A property group legitimately repeats the name
+    #    WITHIN one mixin — but a VALID group is exactly one @property getter
+    #    plus optional @x.setter/@x.deleter; two plain @property (or two plain
+    #    methods) are a real shadow (Python keeps only the last).
+    def _prop_role(fn):
         for d in fn.decorator_list:
             if isinstance(d, ast.Name) and d.id == "property":
-                return True
+                return "getter"
             if isinstance(d, ast.Attribute) and d.attr in ("setter", "deleter", "getter"):
-                return True
-        return False
+                return "accessor"
+        return None  # a plain method
 
     seen: dict[str, str] = {}
     for path, klass in sorted(mixin_files.items()):
         here = f"{path.name}:{klass.name}"
-        local: dict[str, ast.AST] = {}
+        groups: dict[str, list] = {}
         for node in klass.body:
-            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                continue
-            if node.name in local:
-                # Same name twice in ONE mixin: fine only for a property group.
-                if not (_is_property_accessor(local[node.name]) and _is_property_accessor(node)):
-                    violations.append(Violation(path, node.lineno, node.col_offset, "CORE_MIXIN_DISJOINT",
-                                                f"method '{node.name}' is defined twice in {here} and is not a "
-                                                f"property accessor group — the second definition shadows the "
-                                                f"first"))
-                continue
-            local[node.name] = node
-            if node.name in seen:
-                violations.append(Violation(path, node.lineno, node.col_offset, "CORE_MIXIN_DISJOINT",
-                                            f"method '{node.name}' already defined in {seen[node.name]} — "
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                groups.setdefault(node.name, []).append(node)
+        for name, defs in groups.items():
+            if len(defs) > 1:
+                roles = [_prop_role(d) for d in defs]
+                if any(r is None for r in roles) or roles.count("getter") > 1:
+                    last = defs[-1]
+                    violations.append(Violation(path, last.lineno, last.col_offset, "CORE_MIXIN_DISJOINT",
+                                                f"method '{name}' is defined {len(defs)}× in {here} and is not a "
+                                                f"valid property group (one @property getter + optional "
+                                                f"@{name}.setter/.deleter) — a later definition shadows an "
+                                                f"earlier one"))
+            if name in seen:
+                first = defs[0]
+                violations.append(Violation(path, first.lineno, first.col_offset, "CORE_MIXIN_DISJOINT",
+                                            f"method '{name}' already defined in {seen[name]} — "
                                             f"MRO would shadow one of them silently"))
             else:
-                seen[node.name] = here
+                seen[name] = here
 
     # -- CORE_MIXIN_BASES
     if manager_class is not None:

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -11,22 +11,25 @@ CORE_PATCH_ROUTING
     ``monkeypatch.setattr(core_module, "<attr>", ...)`` /
     ``patch.object(core_module, "<attr>", ...)`` (object form) must be read
     by manager/mixin code ONLY through the ``_core_facade`` late-binding
-    module object. A module-level from-import or a bare global read in a
-    mixin snapshots the value at import time: assertion-style stubs then
+    module object. A module-level from-import of the symbol's REAL binding —
+    ``from <owner_module> import <original_name>`` (the module the facade
+    re-exports it from) or ``from main_logic.core import <attr>`` (the facade
+    itself) — snapshots the value at import time: assertion-style stubs then
     fail loudly, but isolation-style stubs (blocking disk/network IO) go
-    silently green while calling the real function. The patched-symbol set
-    is harvested from ``tests/`` by AST on every run, so the contract
-    tightens automatically as tests grow. Reads through some other imported
-    module — attribute chains (``import main_logic.agent_event_bus`` /
-    ``from main_logic import agent_event_bus as bus`` + ``bus.<attr>(...)``)
-    and string getattr (``getattr(bus, "<attr>")``) — are rejected the same
-    way: they follow the owner module, not the facade. So are facade reads
-    inside method defaults/decorators/annotations and class-level constant
-    values: those evaluate once at import and freeze the value.
-    Function-local imports from the OWNER module (e.g. ``from
-    utils.preferences import ...`` inside a method) are a different,
-    deliberate late-binding pattern and stay allowed: the facade patch
-    never targeted them, before or after the split.
+    silently green while calling the real function. Matching is by SOURCE
+    MODULE + original name, so an unrelated ``from vendor import
+    get_tts_worker as vw`` (a different object that merely shares the name) is
+    NOT flagged. The patched-symbol set is harvested from ``tests/`` by AST
+    on every run, so the contract tightens automatically as tests grow. Reads
+    through the OWNER module — attribute chains (``import
+    main_logic.agent_event_bus`` / ``from main_logic import agent_event_bus
+    as bus`` + ``bus.<attr>(...)``) and string getattr (``getattr(bus,
+    "<attr>")``) — are rejected the same way. So are facade reads inside
+    method defaults/decorators/annotations and class-level constant values:
+    those evaluate once at import and freeze the value. Function-local imports
+    from the OWNER module (e.g. ``from utils.preferences import ...`` inside a
+    method) are a different, deliberate late-binding pattern and stay allowed:
+    the facade patch never targeted them, before or after the split.
 
     The patch-target harvest recognizes both positional and keyword call
     spellings, string (``"main_logic.core.X"``) and object
@@ -88,8 +91,6 @@ from __future__ import annotations
 import argparse
 import ast
 import sys
-import symtable
-import tokenize
 from pathlib import Path
 
 FACADE_MODULE_ALIAS = "_core_facade"
@@ -258,47 +259,35 @@ def facade_owner_modules(init_tree: ast.Module) -> dict[str, tuple[str, str]]:
 
 
 # ----------------------------------------------------------- module analysis
-def module_level_import_bindings(tree: ast.Module):
-    """{name: lineno} bound or aliased by top-level import statements.
+def facade_snapshot_imports(tree: ast.Module, pkg: str,
+                            facade_owners: dict[str, tuple[str, str]]) -> dict[str, int]:
+    """{facade attr: lineno} for module-level from-imports that SNAPSHOT the
+    facade's real symbol — a binding the facade patch will not reach.
 
-    For from-imports BOTH the original name and the alias are indexed:
-    ``from x import patched_symbol as _p`` still snapshots the patched
-    symbol, so the routing check must see it under its facade name.
+    A snapshot is ``from <owner_module> import <original_name> [as x]`` (the
+    real symbol, under any alias) or ``from main_logic.core import <attr>`` (the
+    facade's own copy, frozen at import). Crucially, matching is by SOURCE
+    MODULE + original name, not by name alone: an unrelated
+    ``from vendor import get_tts_worker as vw`` imports a DIFFERENT object and
+    must NOT be flagged (that was a false positive of the old name-only check).
     """
-    out = {}
+    by_owner = {(mod, orig): attr for attr, (mod, orig) in facade_owners.items()}
+    out: dict[str, int] = {}
     for node in tree.body:
-        if isinstance(node, ast.Import):
-            for a in node.names:
-                out[a.asname or a.name.split(".")[0]] = node.lineno
-        elif isinstance(node, ast.ImportFrom):
-            for a in node.names:
-                out.setdefault(a.name, node.lineno)
-                if a.asname:
-                    out.setdefault(a.asname, node.lineno)
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        src = node.module if node.level == 0 else _resolve_relative(pkg, node.level, node.module)
+        if not src:
+            continue
+        for a in node.names:
+            if a.name == "*":
+                continue
+            attr = by_owner.get((src, a.name))
+            if attr is not None:
+                out.setdefault(attr, node.lineno)          # from owner import orig_name
+            elif src == "main_logic.core" and a.name in facade_owners:
+                out.setdefault(a.name, node.lineno)         # from the facade itself
     return out
-
-
-def global_read_names(path: Path) -> set[str]:
-    """Names referenced as globals from any function scope in the module."""
-    # tokenize.open honors the PEP 263 cookie / BOM (see parse()); symtable
-    # needs text, so decode through it rather than read_text(encoding="utf-8").
-    with tokenize.open(str(path)) as f:
-        source = f.read()
-    table = symtable.symtable(source, str(path), "exec")
-    found: set[str] = set()
-
-    def walk(tab):
-        # Class scopes matter too: method defaults, decorators and evaluated
-        # annotations resolve in the class scope at class-creation time.
-        if tab.get_type() in ("function", "class"):
-            for sym in tab.get_symbols():
-                if sym.is_referenced() and sym.is_global():
-                    found.add(sym.get_name())
-        for child in tab.get_children():
-            walk(child)
-
-    walk(table)
-    return found
 
 
 def _resolve_relative(pkg: str, level: int, module) -> str | None:
@@ -464,13 +453,6 @@ def def_time_facade_reads(tree: ast.Module, alias_paths: dict[str, str], attr: s
                 if chain and resolve_chain(chain, alias_paths) == "main_logic.core":
                     sites.append((node.lineno, node.col_offset))
     return sites
-
-
-def first_name_load_line(tree: ast.Module, name: str):
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Name) and node.id == name and isinstance(node.ctx, ast.Load):
-            return node.lineno, node.col_offset
-    return 0, 0
 
 
 # ------------------------------------------------------------------- checks
@@ -768,7 +750,7 @@ def run(root: Path) -> list[Violation]:
     for path in routing_files:
         tree = parse(path)
         pkg = ".".join(path.resolve().relative_to(root.resolve()).parts[:-1])
-        module_info[path] = (tree, module_level_import_bindings(tree), global_read_names(path),
+        module_info[path] = (tree, facade_snapshot_imports(tree, pkg, facade_owners),
                              module_alias_paths(tree, pkg))
 
     for attr, sites in sorted(targets.items()):
@@ -783,20 +765,13 @@ def run(root: Path) -> list[Violation]:
         # The attr exists on the facade, so every patch of it is real (a
         # raising=False / create=True guard only waives the existence check,
         # not the routing requirement) — route ALL consumers.
-        for path, (tree, imports, global_reads, alias_paths) in module_info.items():
-            if attr in imports:
-                violations.append(Violation(path, imports[attr], 0, "CORE_PATCH_ROUTING",
-                                            f"'{attr}' is a test patch target on the facade but is "
-                                            f"from-imported here at module level — the import snapshots the "
-                                            f"value and facade patches no longer reach this module; read it "
-                                            f"as {FACADE_MODULE_ALIAS}.{attr} instead"))
-            elif attr in global_reads:
-                line, col = first_name_load_line(tree, attr)
-                violations.append(Violation(path, line, col, "CORE_PATCH_ROUTING",
-                                            f"'{attr}' is a test patch target on the facade but is read here "
-                                            f"as a bare global — read it as {FACADE_MODULE_ALIAS}.{attr} so "
-                                            f"monkeypatch.setattr(\"main_logic.core.{attr}\", ...) keeps "
-                                            f"hitting this consumer"))
+        for path, (tree, snapshot, alias_paths) in module_info.items():
+            if attr in snapshot:
+                violations.append(Violation(path, snapshot[attr], 0, "CORE_PATCH_ROUTING",
+                                            f"'{attr}' is a test patch target on the facade but its real symbol "
+                                            f"is from-imported here at module level — the import snapshots the "
+                                            f"pre-patch value and facade patches no longer reach this module; "
+                                            f"read it as {FACADE_MODULE_ALIAS}.{attr} instead"))
             # Reads through some OTHER imported module — attribute chains
             # (``bus.dispatch_...``) and string getattr (``getattr(bus,
             # "dispatch_...")``) — dodge facade patches the same way. Reads

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -19,10 +19,12 @@ CORE_PATCH_ROUTING
     tightens automatically as tests grow. Attribute reads through some other
     imported module (``import main_logic.agent_event_bus`` + ``main_logic.
     agent_event_bus.<attr>(...)``) are rejected the same way — they follow
-    the owner module, not the facade. Function-local imports from the OWNER
-    module (e.g. ``from utils.preferences import ...`` inside a method) are
-    a different, deliberate late-binding pattern and stay allowed: the
-    facade patch never targeted them, before or after the split.
+    the owner module, not the facade. So are facade reads inside method
+    defaults/decorators/annotations: those evaluate once at import and
+    freeze the value. Function-local imports from the OWNER module (e.g.
+    ``from utils.preferences import ...`` inside a method) are a different,
+    deliberate late-binding pattern and stay allowed: the facade patch
+    never targeted them, before or after the split.
 
 CORE_PATCH_TARGET_EXISTS
     Every patched facade attribute must actually exist at the facade top
@@ -133,19 +135,23 @@ def collect_patch_targets(tests_dir: Path):
                 continue
             fn = node.func
             fname = fn.attr if isinstance(fn, ast.Attribute) else (fn.id if isinstance(fn, ast.Name) else "")
-            raising_false = any(
-                kw.arg == "raising" and isinstance(kw.value, ast.Constant) and kw.value.value is False
-                for kw in node.keywords)
+            kw = {k.arg: k.value for k in node.keywords if k.arg}
+            raising_false = (isinstance(kw.get("raising"), ast.Constant)
+                             and kw["raising"].value is False)
             args = node.args
-            if fname in PATCH_CALL_NAMES and args:
-                first = args[0]
+            # Positional and keyword spellings are equivalent for these APIs:
+            # setattr(target=..., name=...), patch(target=...),
+            # patch.object(target=..., attribute=...).
+            first = args[0] if args else kw.get("target")
+            second = args[1] if len(args) >= 2 else (kw.get("name") or kw.get("attribute"))
+            if fname in PATCH_CALL_NAMES and first is not None:
                 if isinstance(first, ast.Constant) and isinstance(first.value, str):
                     s = first.value
                     if s.startswith("main_logic.core.") and s.count(".") == 2:
                         add(s.rsplit(".", 1)[1], path, node, raising_false)
-            if fname in (PATCH_CALL_NAMES | {"object"}) and len(args) >= 2:
-                if is_core_ref(args[0]) and isinstance(args[1], ast.Constant) and isinstance(args[1].value, str):
-                    add(args[1].value, path, node, raising_false)
+            if fname in (PATCH_CALL_NAMES | {"object"}) and first is not None and second is not None:
+                if is_core_ref(first) and isinstance(second, ast.Constant) and isinstance(second.value, str):
+                    add(second.value, path, node, raising_false)
     return targets
 
 
@@ -170,7 +176,12 @@ def facade_top_level_names(init_tree: ast.Module) -> set[str]:
 
 # ----------------------------------------------------------- module analysis
 def module_level_import_bindings(tree: ast.Module):
-    """{name: lineno} bound by top-level import statements."""
+    """{name: lineno} bound or aliased by top-level import statements.
+
+    For from-imports BOTH the original name and the alias are indexed:
+    ``from x import patched_symbol as _p`` still snapshots the patched
+    symbol, so the routing check must see it under its facade name.
+    """
     out = {}
     for node in tree.body:
         if isinstance(node, ast.Import):
@@ -178,7 +189,9 @@ def module_level_import_bindings(tree: ast.Module):
                 out[a.asname or a.name.split(".")[0]] = node.lineno
         elif isinstance(node, ast.ImportFrom):
             for a in node.names:
-                out[a.asname or a.name] = node.lineno
+                out.setdefault(a.name, node.lineno)
+                if a.asname:
+                    out.setdefault(a.asname, node.lineno)
     return out
 
 
@@ -236,6 +249,35 @@ def attr_value_chain(node: ast.Attribute):
         return None
     parts.append(cur.id)
     return ".".join(reversed(parts))
+
+
+def def_time_facade_reads(tree: ast.Module, alias_paths: dict[str, str], attr: str):
+    """(line, col) of facade reads of ``attr`` evaluated at class-creation.
+
+    Method defaults, decorators and evaluated annotations run ONCE at import
+    time; a ``_core_facade.<attr>`` there freezes the value, so later facade
+    patches no longer reach it — the read must live in the method body.
+    """
+    sites = []
+    for klass in (n for n in tree.body if isinstance(n, ast.ClassDef)):
+        for meth in (n for n in klass.body if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))):
+            a = meth.args
+            sig_nodes = list(meth.decorator_list)
+            sig_nodes += [d for d in a.defaults if d is not None]
+            sig_nodes += [d for d in a.kw_defaults if d is not None]
+            for arg in (a.posonlyargs + a.args + a.kwonlyargs
+                        + ([a.vararg] if a.vararg else []) + ([a.kwarg] if a.kwarg else [])):
+                if arg.annotation is not None:
+                    sig_nodes.append(arg.annotation)
+            if meth.returns is not None:
+                sig_nodes.append(meth.returns)
+            for sub in sig_nodes:
+                for node in ast.walk(sub):
+                    if isinstance(node, ast.Attribute) and node.attr == attr:
+                        chain = attr_value_chain(node)
+                        if chain and alias_paths.get(chain) == "main_logic.core":
+                            sites.append((node.lineno, node.col_offset))
+    return sites
 
 
 def first_name_load_line(tree: ast.Module, name: str):
@@ -372,7 +414,8 @@ def run(root: Path) -> list[Violation]:
                                         f"facade only re-exports; the class lives in manager.py"))
     last = init_tree.body[-1] if init_tree.body else None
     is_manager_import = (isinstance(last, ast.ImportFrom) and last.level == 1 and last.module == "manager"
-                         and [a.name for a in last.names] == ["LLMSessionManager"])
+                         and [a.name for a in last.names] == ["LLMSessionManager"]
+                         and last.names[0].asname is None)
     if not is_manager_import:
         violations.append(Violation(init_path, getattr(last, "lineno", 1), 0, "CORE_FACADE_LAYOUT",
                                     "the last statement of __init__.py must be "
@@ -431,6 +474,13 @@ def run(root: Path) -> list[Violation]:
                                 f"'{attr}' is a test patch target on the facade but is read here "
                                 f"through module '{resolved}' — that read follows the owner module, "
                                 f"not the facade; read it as {FACADE_MODULE_ALIAS}.{attr} instead"))
+            for line, col in def_time_facade_reads(tree, alias_paths, attr):
+                violations.append(Violation(
+                    path, line, col, "CORE_PATCH_ROUTING",
+                    f"'{attr}' is read from the facade inside a default/decorator/annotation — "
+                    f"that expression runs once at import and freezes the value, so facade "
+                    f"patches no longer reach it; move the {FACADE_MODULE_ALIAS}.{attr} read "
+                    f"into the method body"))
     return violations
 
 

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""Static gate: structural contracts of the ``main_logic/core`` package.
+
+The ``LLMSessionManager`` mixin split (#2272) rests on a set of contracts
+that comments alone cannot enforce. This check makes every one of them a
+CI failure:
+
+CORE_PATCH_ROUTING
+    Every facade symbol that any test rebinds via
+    ``monkeypatch.setattr("main_logic.core.<attr>", ...)`` (string form) or
+    ``monkeypatch.setattr(core_module, "<attr>", ...)`` /
+    ``patch.object(core_module, "<attr>", ...)`` (object form) must be read
+    by manager/mixin code ONLY through the ``_core_facade`` late-binding
+    module object. A module-level from-import or a bare global read in a
+    mixin snapshots the value at import time: assertion-style stubs then
+    fail loudly, but isolation-style stubs (blocking disk/network IO) go
+    silently green while calling the real function. The patched-symbol set
+    is harvested from ``tests/`` by AST on every run, so the contract
+    tightens automatically as tests grow. Function-local imports from the
+    OWNER module (e.g. ``from utils.preferences import ...`` inside a
+    method) are a different, deliberate late-binding pattern and stay
+    allowed: the facade patch never targeted them.
+
+CORE_PATCH_TARGET_EXISTS
+    Every patched facade attribute must actually exist at the facade top
+    level (typo guard), unless the call passes ``raising=False`` (negative
+    guards intentionally patch absent names).
+
+CORE_MIXIN_SHAPE
+    A mixin module's top level holds only a docstring, imports and exactly
+    one ``*Mixin`` class; the class body holds only a docstring and
+    methods. Instance state has a single home (``LLMSessionManager.
+    __init__``), and module-level state in a mixin would sit outside the
+    facade's rebind semantics entirely.
+
+CORE_MANAGER_SHAPE
+    ``manager.py`` holds exactly one class, ``LLMSessionManager``; its only
+    method is ``__init__`` (class-level constants are allowed). New
+    behavior belongs in a domain mixin.
+
+CORE_MIXIN_DISJOINT
+    No method name is defined by two mixin classes (or by both a mixin and
+    the manager class). Python would resolve the clash silently by MRO
+    order; this makes it a build failure instead.
+
+CORE_MIXIN_BASES
+    The base list of ``LLMSessionManager`` is exactly the set of ``*Mixin``
+    classes defined in the package — no orphan mixin module, no missing
+    base.
+
+CORE_FACADE_LAYOUT
+    ``__init__.py`` defines no class at top level, and its last statement
+    is ``from .manager import LLMSessionManager`` — the facade namespace
+    must be fully populated before the class modules bind it as
+    ``_core_facade``.
+
+Every violation prints as ``path:line:col  CODE  message``. Exit 1 on any
+violation, 0 otherwise, 2 when the expected layout itself is missing (this
+gate hard-fails rather than silently skipping when paths move — see the
+agent_server split postmortem).
+
+Usage:
+    python scripts/check_core_contracts.py [--root PATH]
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+import symtable
+from pathlib import Path
+
+FACADE_MODULE_ALIAS = "_core_facade"
+OWNER_SUBMODULES = {"_shared", "callback_render", "notices"}
+PATCH_CALL_NAMES = {"setattr", "patch", "delattr"}
+
+
+class Violation:
+    def __init__(self, path, line, col, code, message):
+        self.path, self.line, self.col, self.code, self.message = path, line, col, code, message
+
+    def render(self, root: Path) -> str:
+        try:
+            rel = self.path.resolve().relative_to(root.resolve())
+        except ValueError:
+            rel = self.path
+        return f"{rel}:{self.line}:{self.col}  {self.code}  {self.message}"
+
+
+def parse(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+# --------------------------------------------------------------- tests scan
+def collect_patch_targets(tests_dir: Path):
+    """Return {attr: [(file, line, raising_false)]} for facade rebind sites."""
+    targets: dict[str, list[tuple[Path, int, bool]]] = {}
+
+    def add(name, path, node, raising_false):
+        targets.setdefault(name, []).append((path, node.lineno, raising_false))
+
+    for path in sorted(tests_dir.rglob("*.py")):
+        try:
+            tree = parse(path)
+        except SyntaxError:
+            continue
+        aliases = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for a in node.names:
+                    if a.name == "main_logic.core" and a.asname:
+                        aliases.add(a.asname)
+            elif isinstance(node, ast.ImportFrom) and node.module == "main_logic":
+                for a in node.names:
+                    if a.name == "core":
+                        aliases.add(a.asname or "core")
+
+        def is_core_ref(expr):
+            if isinstance(expr, ast.Name) and expr.id in aliases:
+                return True
+            return (isinstance(expr, ast.Attribute) and expr.attr == "core"
+                    and isinstance(expr.value, ast.Name) and expr.value.id == "main_logic")
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            fn = node.func
+            fname = fn.attr if isinstance(fn, ast.Attribute) else (fn.id if isinstance(fn, ast.Name) else "")
+            raising_false = any(
+                kw.arg == "raising" and isinstance(kw.value, ast.Constant) and kw.value.value is False
+                for kw in node.keywords)
+            args = node.args
+            if fname in PATCH_CALL_NAMES and args:
+                first = args[0]
+                if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                    s = first.value
+                    if s.startswith("main_logic.core.") and s.count(".") == 2:
+                        add(s.rsplit(".", 1)[1], path, node, raising_false)
+            if fname in (PATCH_CALL_NAMES | {"object"}) and len(args) >= 2:
+                if is_core_ref(args[0]) and isinstance(args[1], ast.Constant) and isinstance(args[1].value, str):
+                    add(args[1].value, path, node, raising_false)
+    return targets
+
+
+# ------------------------------------------------------------ facade layout
+def facade_top_level_names(init_tree: ast.Module) -> set[str]:
+    names = set()
+    for node in init_tree.body:
+        if isinstance(node, ast.Import):
+            for a in node.names:
+                names.add(a.asname or a.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            for a in node.names:
+                names.add(a.asname or a.name)
+        elif isinstance(node, (ast.Assign, ast.AnnAssign)):
+            for t in (node.targets if isinstance(node, ast.Assign) else [node.target]):
+                if isinstance(t, ast.Name):
+                    names.add(t.id)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            names.add(node.name)
+    return names
+
+
+# ----------------------------------------------------------- module analysis
+def module_level_import_bindings(tree: ast.Module):
+    """{name: lineno} bound by top-level import statements."""
+    out = {}
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for a in node.names:
+                out[a.asname or a.name.split(".")[0]] = node.lineno
+        elif isinstance(node, ast.ImportFrom):
+            for a in node.names:
+                out[a.asname or a.name] = node.lineno
+    return out
+
+
+def global_read_names(path: Path) -> set[str]:
+    """Names referenced as globals from any function scope in the module."""
+    table = symtable.symtable(path.read_text(encoding="utf-8"), str(path), "exec")
+    found: set[str] = set()
+
+    def walk(tab):
+        if tab.get_type() == "function":
+            for sym in tab.get_symbols():
+                if sym.is_referenced() and sym.is_global():
+                    found.add(sym.get_name())
+        for child in tab.get_children():
+            walk(child)
+
+    walk(table)
+    return found
+
+
+def first_name_load_line(tree: ast.Module, name: str):
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name) and node.id == name and isinstance(node.ctx, ast.Load):
+            return node.lineno, node.col_offset
+    return 0, 0
+
+
+# ------------------------------------------------------------------- checks
+def run(root: Path) -> list[Violation]:
+    core_dir = root / "main_logic" / "core"
+    tests_dir = root / "tests"
+    init_path = core_dir / "__init__.py"
+    manager_path = core_dir / "manager.py"
+    for required in (core_dir, tests_dir, init_path, manager_path):
+        if not required.exists():
+            print(f"error: expected path missing: {required} — the core package layout moved; "
+                  f"update scripts/check_core_contracts.py instead of letting the gate go dark.",
+                  file=sys.stderr)
+            sys.exit(2)
+
+    violations: list[Violation] = []
+    init_tree = parse(init_path)
+    facade_names = facade_top_level_names(init_tree)
+
+    # -- discover mixin modules (any core/*.py defining a single *Mixin class)
+    mixin_files: dict[Path, ast.ClassDef] = {}
+    manager_class = None
+    for path in sorted(core_dir.glob("*.py")):
+        if path.name == "__init__.py":
+            continue
+        tree = parse(path)
+        classes = [n for n in tree.body if isinstance(n, ast.ClassDef)]
+        if path == manager_path:
+            manager_class = classes[0] if len(classes) == 1 and classes[0].name == "LLMSessionManager" else None
+            if manager_class is None:
+                violations.append(Violation(path, 1, 0, "CORE_MANAGER_SHAPE",
+                                            "manager.py must define exactly one class: LLMSessionManager"))
+            continue
+        mixins = [c for c in classes if c.name.endswith("Mixin")]
+        if mixins:
+            if len(classes) != 1:
+                violations.append(Violation(path, classes[1].lineno, classes[1].col_offset, "CORE_MIXIN_SHAPE",
+                                            f"{path.name} must define exactly one class (found {len(classes)})"))
+            mixin_files[path] = mixins[0]
+
+    # -- CORE_MIXIN_SHAPE: top level and class body
+    for path, klass in mixin_files.items():
+        tree = parse(path)
+        for i, node in enumerate(tree.body):
+            if i == 0 and isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant):
+                continue  # module docstring
+            if isinstance(node, (ast.Import, ast.ImportFrom, ast.ClassDef)):
+                continue
+            violations.append(Violation(path, node.lineno, node.col_offset, "CORE_MIXIN_SHAPE",
+                                        f"mixin module top level allows only docstring/imports/class, "
+                                        f"found {type(node).__name__}"))
+        for i, node in enumerate(klass.body):
+            if i == 0 and isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant):
+                continue  # class docstring
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if node.name == "__init__":
+                    violations.append(Violation(path, node.lineno, node.col_offset, "CORE_MIXIN_SHAPE",
+                                                "mixins must not define __init__ — instance state has a "
+                                                "single home in LLMSessionManager.__init__ (manager.py)"))
+                continue
+            violations.append(Violation(path, node.lineno, node.col_offset, "CORE_MIXIN_SHAPE",
+                                        f"mixin class body allows only docstring/methods, "
+                                        f"found {type(node).__name__} — state belongs in manager.__init__"))
+
+    # -- CORE_MANAGER_SHAPE: only __init__ as a method
+    if manager_class is not None:
+        methods = [n for n in manager_class.body if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))]
+        for m in methods:
+            if m.name != "__init__":
+                violations.append(Violation(manager_path, m.lineno, m.col_offset, "CORE_MANAGER_SHAPE",
+                                            f"manager class defines method '{m.name}' — behavior belongs "
+                                            f"in a domain mixin; manager.py keeps only __init__"))
+        if not any(m.name == "__init__" for m in methods):
+            violations.append(Violation(manager_path, manager_class.lineno, manager_class.col_offset,
+                                        "CORE_MANAGER_SHAPE", "LLMSessionManager must define __init__ here"))
+
+    # -- CORE_MIXIN_DISJOINT
+    seen: dict[str, str] = {}
+    for path, klass in sorted(mixin_files.items()):
+        for node in klass.body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if node.name in seen:
+                    violations.append(Violation(path, node.lineno, node.col_offset, "CORE_MIXIN_DISJOINT",
+                                                f"method '{node.name}' already defined in {seen[node.name]} — "
+                                                f"MRO would shadow one of them silently"))
+                else:
+                    seen[node.name] = f"{path.name}:{klass.name}"
+
+    # -- CORE_MIXIN_BASES
+    if manager_class is not None:
+        base_names = {b.id for b in manager_class.bases if isinstance(b, ast.Name)}
+        mixin_names = {k.name for k in mixin_files.values()}
+        for missing in sorted(mixin_names - base_names):
+            violations.append(Violation(manager_path, manager_class.lineno, manager_class.col_offset,
+                                        "CORE_MIXIN_BASES",
+                                        f"mixin class {missing} is defined in the package but is not a "
+                                        f"base of LLMSessionManager"))
+        for extra in sorted(base_names - mixin_names):
+            violations.append(Violation(manager_path, manager_class.lineno, manager_class.col_offset,
+                                        "CORE_MIXIN_BASES",
+                                        f"base {extra} has no *Mixin class defined in the package"))
+
+    # -- CORE_FACADE_LAYOUT
+    for node in init_tree.body:
+        if isinstance(node, ast.ClassDef):
+            violations.append(Violation(init_path, node.lineno, node.col_offset, "CORE_FACADE_LAYOUT",
+                                        f"__init__.py must not define classes (found {node.name}) — the "
+                                        f"facade only re-exports; the class lives in manager.py"))
+    last = init_tree.body[-1] if init_tree.body else None
+    is_manager_import = (isinstance(last, ast.ImportFrom) and last.level == 1 and last.module == "manager"
+                         and [a.name for a in last.names] == ["LLMSessionManager"])
+    if not is_manager_import:
+        violations.append(Violation(init_path, getattr(last, "lineno", 1), 0, "CORE_FACADE_LAYOUT",
+                                    "the last statement of __init__.py must be "
+                                    "'from .manager import LLMSessionManager' so the facade namespace is "
+                                    "fully populated before the class modules bind it"))
+
+    # -- patch-target checks
+    targets = collect_patch_targets(tests_dir)
+    routing_files = sorted(set(mixin_files) | {manager_path})
+    module_info = {}
+    for path in routing_files:
+        tree = parse(path)
+        module_info[path] = (tree, module_level_import_bindings(tree), global_read_names(path))
+
+    for attr, sites in sorted(targets.items()):
+        strict_sites = [s for s in sites if not s[2]]
+        if attr not in facade_names:
+            for site_path, line, raising_false in sites:
+                if not raising_false:
+                    violations.append(Violation(site_path, line, 0, "CORE_PATCH_TARGET_EXISTS",
+                                                f"test patches main_logic.core.{attr} but the facade defines "
+                                                f"no such name (typo? pass raising=False for negative guards)"))
+            continue
+        if not strict_sites:
+            continue  # raising=False negative guards need no routing
+        for path, (tree, imports, global_reads) in module_info.items():
+            if attr in imports:
+                violations.append(Violation(path, imports[attr], 0, "CORE_PATCH_ROUTING",
+                                            f"'{attr}' is a test patch target on the facade but is "
+                                            f"from-imported here at module level — the import snapshots the "
+                                            f"value and facade patches no longer reach this module; read it "
+                                            f"as {FACADE_MODULE_ALIAS}.{attr} instead"))
+            elif attr in global_reads:
+                line, col = first_name_load_line(tree, attr)
+                violations.append(Violation(path, line, col, "CORE_PATCH_ROUTING",
+                                            f"'{attr}' is a test patch target on the facade but is read here "
+                                            f"as a bare global — read it as {FACADE_MODULE_ALIAS}.{attr} so "
+                                            f"monkeypatch.setattr(\"main_logic.core.{attr}\", ...) keeps "
+                                            f"hitting this consumer"))
+    return violations
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--root", default=".", help="repository root (default: cwd)")
+    ap.add_argument("--list-targets", action="store_true",
+                    help="print the harvested facade patch-target set and exit")
+    args = ap.parse_args()
+    root = Path(args.root)
+
+    if args.list_targets:
+        for attr, sites in sorted(collect_patch_targets(root / "tests").items()):
+            files = sorted({p.name for p, _, _ in sites})
+            print(f"{attr:50s} {files}")
+        return 0
+
+    violations = run(root)
+    for v in violations:
+        print(v.render(root))
+    if violations:
+        print(f"\n{len(violations)} core-contract violation(s).", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -571,6 +571,18 @@ def run(root: Path) -> list[Violation]:
                     violations.append(Violation(path, node.lineno, node.col_offset, "CORE_MIXIN_SHAPE",
                                                 "mixins must not define __init__ — instance state has a "
                                                 "single home in LLMSessionManager.__init__ (manager.py)"))
+                # A mutable-container default (``def f(self, cache={})``) is
+                # allocated once at import and SHARED across every instance —
+                # the exact hidden mixin state this contract keeps out (same
+                # rationale as the module-level/class-body state rejections).
+                MUT = (ast.Dict, ast.List, ast.Set, ast.DictComp, ast.ListComp, ast.SetComp)
+                for dflt in [d for d in node.args.defaults if d] + [d for d in node.args.kw_defaults if d]:
+                    bad = next((s for s in ast.walk(dflt) if isinstance(s, MUT)), None)
+                    if bad is not None:
+                        violations.append(Violation(path, dflt.lineno, dflt.col_offset, "CORE_MIXIN_SHAPE",
+                                                    f"mixin method '{node.name}' has a mutable default argument "
+                                                    f"— it is allocated once at import and shared across all "
+                                                    f"instances; use None and build inside the method"))
                 continue
             violations.append(Violation(path, node.lineno, node.col_offset, "CORE_MIXIN_SHAPE",
                                         f"mixin class body allows only docstring/methods, "

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -623,8 +623,13 @@ def run(root: Path) -> list[Violation]:
                 # with the manager's own __init__) wins attribute lookup and
                 # silently removes/replaces it — ``__init__ = external`` after
                 # ``def __init__`` overwrites the initializer while the method
-                # count still passes.
-                targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+                # count still passes. An annotation-ONLY entry (``foo: int`` with
+                # no value) creates no attribute — only ``__annotations__`` — so
+                # it shadows nothing and is skipped.
+                if isinstance(node, ast.AnnAssign) and node.value is None:
+                    targets = []
+                else:
+                    targets = node.targets if isinstance(node, ast.Assign) else [node.target]
                 for t in targets:
                     if isinstance(t, ast.Name) and (t.id in mixin_method_names or t.id == "__init__"):
                         what = "the manager's __init__" if t.id == "__init__" else "a mixin method"

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -575,7 +575,11 @@ def run(root: Path) -> list[Violation]:
                 # allocated once at import and SHARED across every instance —
                 # the exact hidden mixin state this contract keeps out (same
                 # rationale as the module-level/class-body state rejections).
-                MUT = (ast.Dict, ast.List, ast.Set, ast.DictComp, ast.ListComp, ast.SetComp)
+                # GeneratorExp too: a generator default is a single-use iterator
+                # allocated once at import and shared, so a second instance sees
+                # it already exhausted — the same shared-state hazard.
+                MUT = (ast.Dict, ast.List, ast.Set, ast.DictComp, ast.ListComp,
+                       ast.SetComp, ast.GeneratorExp)
                 for dflt in [d for d in node.args.defaults if d] + [d for d in node.args.kw_defaults if d]:
                     bad = next((s for s in ast.walk(dflt) if isinstance(s, MUT)), None)
                     if bad is not None:


### PR DESCRIPTION
## 概要

**Stacked 在 #2272 上（base 为其分支，#2272 合并后自动 retarget 到 main）。** 回应 review 中的共识：mixin 拆分的 monkeypatch 契约只靠门面注释挡不住静默破坏，把 core 包全部重要契约一次封进 CI lint。

## 为什么注释不够

facade 晚绑定契约的破坏有两种形态：断言型 stub（fake 必须被调用）在作者写测试时就会红——注释够用；但**隔离型 stub**（挡磁盘/网络 IO 的替身）在 mixin 用 from-import 快照时会**静默假绿**——测试照过、真函数照跑。#2272 的实测就有两个这种形态（`get_tts_worker`、`publish_analyze_request_reliably`），当时靠全量失败集合 diff 才抓回来。

## 检查项（scripts/check_core_contracts.py）

| 违规码 | 契约 |
|---|---|
| `CORE_PATCH_ROUTING` | 测试在门面上 rebind 的符号，manager/mixin 里只能以 `_core_facade.<attr>` 读；模块级 from-import 与裸全局读都拒。**patch 目标集合每次运行从 tests/ AST 现采**（字符串/对象两形态、跨行安全），新 patch 目标自动收紧契约。函数级属主模块 import 经 symtable 判定为局部、合法放行（如 lifecycle 里的 `from utils.preferences import ...`） |
| `CORE_PATCH_TARGET_EXISTS` | patch 目标必须真实存在于门面（typo 守卫）；`raising=False` 负向守卫豁免 |
| `CORE_MIXIN_SHAPE` | mixin 模块顶层只允许 docstring/import/单类；类体只允许 docstring/方法；禁 `__init__`、禁模块级状态 |
| `CORE_MANAGER_SHAPE` | manager 类唯一方法是 `__init__`（类常量放行）；新行为进领域 mixin |
| `CORE_MIXIN_DISJOINT` | mixin 方法名两两不相交（MRO 静默遮蔽 → 构建失败） |
| `CORE_MIXIN_BASES` | 包内 `*Mixin` 类集合与 `LLMSessionManager` 基类表相等（不许孤儿 mixin/缺基类） |
| `CORE_FACADE_LAYOUT` | 门面无类定义；`from .manager import LLMSessionManager` 必须是文件最后一条语句 |

布局路径缺失时 **exit 2 硬失败**而非静默跳过（吸取 agent_server gate 脚本 DEFAULT_PATHS 静默丢覆盖的教训）。挂进 `analyze.yml` 的 `python-conventions` job；非 diff 制、push/PR 都跑、除 stdlib 零依赖。

## 验证

- 干净树 GREEN；采集到的 patch 目标集合与 #2272 人工 AST 普查结果逐一相同（11 严格 + 1 个 `raising=False`）。
- **10 例 sabotage 矩阵全过**（每例在隔离 scratch 副本上做单点破坏后跑 lint）：模块级 from-import patch 符号 → `CORE_PATCH_ROUTING` 红；裸全局读 → 同红；**模拟未来测试新增 patch 目标 `resolve_callback_delivery_ack` → lint 直指 proactive.py 的快照 import**（本 lint 的核心价值场景端到端成立）；typo 目标 → `CORE_PATCH_TARGET_EXISTS` 红且 `raising=False` 后消失；mixin 模块级赋值/定义 `__init__` → `CORE_MIXIN_SHAPE` 红；manager 加方法 → `CORE_MANAGER_SHAPE` 红；跨 mixin 重名方法 → `CORE_MIXIN_DISJOINT` 红；删基类 → `CORE_MIXIN_BASES` 红；manager import 上移 → `CORE_FACADE_LAYOUT` 红。
- 新脚本自身过 ruff（F 规则 + 项目 ASYNC 规则）与 docstring-CJK 守卫；`analyze.yml` YAML 解析通过，CI 同款调用本地 GREEN。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **持续集成**
  * 将静态检查重构为 5 个并行任务：Ruff、代码安全、Prompts & i18n、API 分层、核心包契约，并细化任务命名与步骤。
  * 新增“核心包结构与 facade 冻结读取”静态闸门：在 PR/推送时阻断违例，输出具体行列位置并返回错误码；支持列出目标检查项。
  * 调整懒加载导入检查归属，并在 Prompts & i18n 中为 i18n/diff 配置完整拉取；保留路由尾斜杠与层次约束检查，并微调部分步骤顺序。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->