### PR TITLE
fix(build): launcher.spec static 打包改整目录收录（修 static 整理系列的打包缺口）

### DIFF
--- a/specs/launcher.spec
+++ b/specs/launcher.spec
@@ -153,24 +153,12 @@ def add_data(src, dest):
     else:
         print(f"[Build] Warning: {src_path} not found, skipping")
 
-add_data('static/css', 'static/css')
-add_data('static/js', 'static/js')
-add_data('static/fonts', 'static/fonts')
-add_data('static/vrm', 'static/vrm')
-add_data('static/mao_pro', 'static/mao_pro')
-add_data('static/ziraitikuwa', 'static/ziraitikuwa') 
-add_data('static/libs', 'static/libs')
-add_data('static/icons', 'static/icons')
-add_data('static/assets', 'static/assets')
-add_data('static/locales', 'static/locales')
-add_data('static/neko', 'static/neko')
-add_data('static/kemomimi', 'static/kemomimi')
-add_data('static/default', 'static/default')
-add_data('static/*.js', 'static')
-add_data('static/*.html', 'static')
-add_data('static/*.json', 'static')
-add_data('static/*.ico', 'static')
-add_data('static/*.png', 'static')
+# static/ 整目录收录，与 Nuitka 链路（build-desktop.yml 的
+# --include-data-dir=static=static）语义对齐。此前是子目录白名单 +
+# 根级 glob，static/ 整理系列（#2268/#2271/#2275/#2277 等）把根级
+# *.js 搬进 live2d/ mmd/ avatar/ app/ 等子目录后白名单收不到，打包版
+# 会 404；白名单也一直缺 mmd/ tutorial/ react/ sounds/ 等既有目录。
+add_data('static', 'static')
 add_data('assets', 'assets')
 add_data('templates', 'templates')
 add_data('data/browser_use_prompts', 'data/browser_use_prompts')


### PR DESCRIPTION
## 概要

[#2277 的 Codex review](https://github.com/Project-N-E-K-O/N.E.K.O/pull/2277#discussion_r3565388447) 指出：`specs/launcher.spec`（PyInstaller 本地/备用打包路径）的静态资源收录是**子目录白名单 + 根级 `static/*.js` glob**，static/ 整理系列把根级 js 搬进子目录后全部收不到：

- `static/live2d/`（#2268）、`static/mmd/` 代码（#2271）、`static/avatar/`（#2275）、`static/app/`（#2277）都不在白名单，根级 glob 不递归 → PyInstaller 打包版这些脚本 404
- 白名单本来就缺 `static/mmd` 资产、`tutorial/`、`react/`、`sounds/`、`game/` 等既有目录（更早的存量缺口）
- `static/vrm` 恰好在白名单里，vrm 批（#2273）侥幸无恙

**修复**：13 行子目录白名单 + 5 行根级 glob 收敛为一条 `add_data('static', 'static')` 整目录收录，与桌面分发链路 `build-desktop.yml` 的 Nuitka `--include-data-dir=static=static` 语义完全对齐。后续 static/ 整理批次（app 2/2、散件批）不再需要同步此文件。

**为什么 CI 一直是绿的**：该 spec 不在 CI 分发链路（桌面版走 Nuitka 整目录收录），属被维护的本地打包路径（最近 #2175/#1855 都动过），所以缺口不体现在 CI。

**体积影响**：整目录收录会带进 `*.test.cjs`、`pngtuber-test/` 等开发文件——与 Nuitka 链路现状一致（它也整目录收），无新增劣化。

## 验证

- spec 为 Python 语法，`ast.parse` 通过
- `add_data` 目录分支为 `datas.append((src_path, dest))`，PyInstaller 对目录条目递归收录，语义等价于原白名单的并集 ∪ 缺失目录

🤖 Generated with [Claude Code](https://claude.com/claude-code)