### PR TITLE
fix: complete Anthropic provider compatibility

### DIFF
--- a/brain/browser_use_adapter.py
+++ b/brain/browser_use_adapter.py
@@ -512,7 +512,8 @@ class BrowserUseAdapter:
         api_cfg = self._config_manager.get_model_api_config("agent")
         model = api_cfg.get("model", "") or ""
         base_url = api_cfg.get("base_url", "") or ""
-        return f"{base_url}|{model}"
+        provider_type = str(api_cfg.get("provider_type") or "openai_compatible").strip().lower()
+        return f"{provider_type}|{base_url}|{model}"
 
     def _get_mode_order(self, api_sig: str) -> List[str]:
         with _API_MODE_CACHE_LOCK:
@@ -595,17 +596,40 @@ class BrowserUseAdapter:
         ))
 
     def _build_llm(self, mode: str = "schema") -> Any:
-        """Build a browser-use compatible ChatOpenAI instance.
+        """Build a browser-use client matching the configured wire protocol.
 
         For Gemini-compatible endpoints, strips parameters that the API
         rejects (``frequency_penalty``, ``seed``, ``service_tier``).
         A thin wrapper class is used so the constraint survives any
         internal copy / re-init performed by browser-use.
         """
-        from browser_use.llm import ChatOpenAI as BUChatOpenAI
+        from utils.llm_client import (
+            _is_anthropic_endpoint,
+            _is_kimi_code_anthropic_base_url,
+            _normalize_anthropic_sdk_base_url,
+        )
+
         api_cfg = self._config_manager.get_model_api_config("agent")
         base_url = api_cfg.get("base_url", "") or ""
         model = api_cfg.get("model", "") or ""
+        provider_type = str(api_cfg.get("provider_type") or "openai_compatible").strip().lower()
+
+        if _is_anthropic_endpoint(base_url, provider_type):
+            from browser_use.llm import ChatAnthropic as BUChatAnthropic
+
+            default_headers: Dict[str, str] = {}
+            if _is_kimi_code_anthropic_base_url(base_url):
+                default_headers["User-Agent"] = "claude-code/0.1.0"
+            return BUChatAnthropic(
+                model=model,
+                api_key=api_cfg.get("api_key"),
+                base_url=_normalize_anthropic_sdk_base_url(base_url),
+                temperature=0.0,
+                default_headers=default_headers or None,
+            )
+
+        from browser_use.llm import ChatOpenAI as BUChatOpenAI
+
         is_gemini = self._is_gemini_compatible_endpoint(base_url)
         kwargs: Dict[str, Any] = dict(
             model=model,

--- a/tests/unit/test_browser_use_adapter_anthropic.py
+++ b/tests/unit/test_browser_use_adapter_anthropic.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import browser_use.llm
+
+from brain.browser_use_adapter import BrowserUseAdapter
+
+
+class _ConfigManager:
+    def __init__(self, config: dict):
+        self._config = config
+
+    def get_model_api_config(self, _tier: str) -> dict:
+        return dict(self._config)
+
+
+def _adapter(config: dict) -> BrowserUseAdapter:
+    adapter = object.__new__(BrowserUseAdapter)
+    adapter._config_manager = _ConfigManager(config)
+    return adapter
+
+
+def test_build_llm_selects_anthropic_for_provider_type(monkeypatch):
+    captured = {}
+
+    def fake_anthropic(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(kind="anthropic")
+
+    def fail_openai(**_kwargs):
+        raise AssertionError("Anthropic provider must not use ChatOpenAI")
+
+    monkeypatch.setattr(browser_use.llm, "ChatAnthropic", fake_anthropic)
+    monkeypatch.setattr(browser_use.llm, "ChatOpenAI", fail_openai)
+
+    llm = _adapter({
+        "model": "proxy-claude",
+        "base_url": "https://anthropic-proxy.example/v1",
+        "api_key": "sk-test",
+        "provider_type": "anthropic",
+    })._build_llm()
+
+    assert llm.kind == "anthropic"
+    assert captured == {
+        "model": "proxy-claude",
+        "api_key": "sk-test",
+        "base_url": "https://anthropic-proxy.example/v1",
+        "temperature": 0.0,
+        "default_headers": None,
+    }
+
+
+def test_build_llm_normalizes_claude_and_adds_kimi_user_agent(monkeypatch):
+    calls = []
+
+    def fake_anthropic(**kwargs):
+        calls.append(kwargs)
+        return SimpleNamespace(kind="anthropic")
+
+    monkeypatch.setattr(browser_use.llm, "ChatAnthropic", fake_anthropic)
+
+    _adapter({
+        "model": "claude-sonnet-4-6",
+        "base_url": "https://api.anthropic.com/v1",
+        "api_key": "sk-claude",
+        "provider_type": "anthropic",
+    })._build_llm()
+    _adapter({
+        "model": "kimi-for-coding",
+        "base_url": "https://api.kimi.com/coding",
+        "api_key": "sk-kimi",
+        "provider_type": "anthropic",
+    })._build_llm()
+
+    assert calls[0]["base_url"] == "https://api.anthropic.com"
+    assert calls[0]["default_headers"] is None
+    assert calls[1]["base_url"] == "https://api.kimi.com/coding"
+    assert calls[1]["default_headers"] == {"User-Agent": "claude-code/0.1.0"}
+
+
+def test_build_llm_keeps_openai_path_and_protocol_in_signature(monkeypatch):
+    captured = {}
+
+    def fake_openai(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(kind="openai")
+
+    monkeypatch.setattr(browser_use.llm, "ChatOpenAI", fake_openai)
+    adapter = _adapter({
+        "model": "gpt-test",
+        "base_url": "https://openai-proxy.example/v1",
+        "api_key": "sk-test",
+        "provider_type": "openai_compatible",
+    })
+
+    assert adapter._build_llm().kind == "openai"
+    assert captured["dont_force_structured_output"] is False
+    assert adapter._current_api_signature() == (
+        "openai_compatible|https://openai-proxy.example/v1|gpt-test"
+    )

--- a/tests/unit/test_browser_use_adapter_anthropic.py
+++ b/tests/unit/test_browser_use_adapter_anthropic.py
@@ -87,15 +87,28 @@ def test_build_llm_keeps_openai_path_and_protocol_in_signature(monkeypatch):
         return SimpleNamespace(kind="openai")
 
     monkeypatch.setattr(browser_use.llm, "ChatOpenAI", fake_openai)
-    adapter = _adapter({
+    shared_config = {
         "model": "gpt-test",
         "base_url": "https://openai-proxy.example/v1",
         "api_key": "sk-test",
+    }
+    adapter = _adapter({
+        **shared_config,
         "provider_type": "openai_compatible",
+    })
+    anthropic_adapter = _adapter({
+        **shared_config,
+        "provider_type": "anthropic",
     })
 
     assert adapter._build_llm().kind == "openai"
     assert captured["dont_force_structured_output"] is False
-    assert adapter._current_api_signature() == (
+    openai_signature = adapter._current_api_signature()
+    anthropic_signature = anthropic_adapter._current_api_signature()
+    assert openai_signature == (
         "openai_compatible|https://openai-proxy.example/v1|gpt-test"
     )
+    assert anthropic_signature == (
+        "anthropic|https://openai-proxy.example/v1|gpt-test"
+    )
+    assert anthropic_signature != openai_signature

--- a/tests/unit/test_focus_mode.py
+++ b/tests/unit/test_focus_mode.py
@@ -749,7 +749,8 @@ async def test_inline_gate_user_setting_off_blocks_and_clears(monkeypatch):
 
 async def test_inline_gate_user_setting_default_on_allows(monkeypatch):
     # Setting absent ⇒ defaults to on, so the global flag alone governs entry.
-    _patch_charge(monkeypatch, enter=1.0)
+    keyword_full = config.FOCUS_SIGNAL_WEIGHTS["keyword"]
+    _patch_charge(monkeypatch, enter=max(0.0, keyword_full - 0.1))
     monkeypatch.setattr(config, "FOCUS_MODE_ENABLED", True)
     _stub_user_focus_setting(monkeypatch, enabled=None)  # key absent
     mgr = _bare_mgr()

--- a/tests/unit/test_llm_client_response_safety.py
+++ b/tests/unit/test_llm_client_response_safety.py
@@ -576,6 +576,51 @@ def test_anthropic_message_normalization_keeps_repeated_no_id_tool_calls():
     ]
 
 
+def test_anthropic_message_normalization_remaps_reused_ids_across_tool_rounds():
+    _system, messages = llm_client_module._normalize_messages_to_anthropic([
+        {"role": "user", "content": "start"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{
+                "id": "call_0",
+                "type": "function",
+                "function": {"name": "lookup", "arguments": "{\"q\":\"first\"}"},
+            }],
+        },
+        {"role": "tool", "tool_call_id": "call_0", "content": "first result"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{
+                "id": "call_0",
+                "type": "function",
+                "function": {"name": "lookup", "arguments": "{\"q\":\"second\"}"},
+            }],
+        },
+        {"role": "tool", "tool_call_id": "call_0", "content": "second result"},
+    ])
+
+    tool_uses = [
+        block
+        for message in messages
+        for block in message["content"]
+        if block.get("type") == "tool_use"
+    ]
+    tool_results = [
+        block
+        for message in messages
+        for block in message["content"]
+        if block.get("type") == "tool_result"
+    ]
+    assert [block["input"]["q"] for block in tool_uses] == ["first", "second"]
+    assert tool_uses[0]["id"] == "call_0"
+    assert tool_uses[1]["id"] != "call_0"
+    assert [block["tool_use_id"] for block in tool_results] == [
+        block["id"] for block in tool_uses
+    ]
+
+
 def test_anthropic_message_normalization_drops_unanswered_tool_use_before_user_turn():
     _system, messages = llm_client_module._normalize_messages_to_anthropic([
         {"role": "user", "content": "start"},

--- a/tests/unit/test_llm_client_response_safety.py
+++ b/tests/unit/test_llm_client_response_safety.py
@@ -503,6 +503,58 @@ def test_anthropic_message_normalization_keeps_pending_tool_use_across_assistant
     ]
 
 
+def test_anthropic_message_normalization_dedupes_tool_ids_across_assistant_turns():
+    _system, messages = llm_client_module._normalize_messages_to_anthropic([
+        {"role": "user", "content": "start"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{
+                "id": "call_dup",
+                "type": "function",
+                "function": {"name": "lookup", "arguments": "{}"},
+            }],
+        },
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{
+                "id": "call_dup",
+                "type": "function",
+                "function": {"name": "lookup", "arguments": "{}"},
+            }],
+        },
+        {"role": "tool", "tool_call_id": "call_dup", "content": "result"},
+    ])
+
+    tool_uses = [
+        block
+        for message in messages
+        for block in message["content"]
+        if block.get("type") == "tool_use"
+    ]
+    assert [block["id"] for block in tool_uses] == ["call_dup"]
+
+
+def test_anthropic_message_normalization_drops_unanswered_tool_use_before_user_turn():
+    _system, messages = llm_client_module._normalize_messages_to_anthropic([
+        {"role": "user", "content": "start"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{
+                "id": "call_unanswered",
+                "type": "function",
+                "function": {"name": "lookup", "arguments": "{}"},
+            }],
+        },
+        {"role": "user", "content": "skip that"},
+    ])
+
+    assert "tool_use" not in repr(messages)
+    assert messages[-1]["role"] == "user"
+
+
 def test_anthropic_message_normalization_downgrades_orphan_tool_result():
     _system, messages = llm_client_module._normalize_messages_to_anthropic([
         {"role": "user", "content": "start"},
@@ -604,9 +656,88 @@ async def test_chat_anthropic_stream_helper_does_not_forward_stream_kwarg(monkey
         chunks = [chunk async for chunk in client.astream([{"role": "user", "content": "hi"}])]
         assert [chunk.content for chunk in chunks] == ["ok", "", ""]
         assert chunks[1].finish_reason == "stop"
-        assert chunks[2].usage_metadata == {"input_tokens": 2, "output_tokens": 3}
+        assert chunks[2].usage_metadata == {
+            "input_tokens": 2,
+            "output_tokens": 3,
+            "prompt_tokens": 2,
+            "completion_tokens": 3,
+            "total_tokens": 5,
+        }
         assert "stream" not in captured
         assert captured["model"] == "kimi-for-coding"
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_chat_anthropic_stream_records_partial_usage_when_closed_early(monkeypatch):
+    recorded = []
+
+    class _Usage:
+        def model_dump(self):
+            return {"input_tokens": 4}
+
+    class _Message:
+        usage = _Usage()
+
+    class _MessageStart:
+        type = "message_start"
+        message = _Message()
+
+    class _TextDelta:
+        type = "text_delta"
+        text = "first"
+
+    class _TextEvent:
+        type = "content_block_delta"
+        delta = _TextDelta()
+
+    class _StreamContext:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        def __aiter__(self):
+            self._events = iter([_MessageStart(), _TextEvent()])
+            return self
+
+        async def __anext__(self):
+            try:
+                return next(self._events)
+            except StopIteration:
+                raise StopAsyncIteration
+
+    class _Messages:
+        def stream(self, **_kwargs):
+            return _StreamContext()
+
+    class _FakeAnthropic:
+        def __init__(self, **_kwargs):
+            self.messages = _Messages()
+
+        def close(self):
+            pass
+
+    class _FakeAsyncAnthropic(_FakeAnthropic):
+        async def close(self):
+            pass
+
+    monkeypatch.setattr(llm_client_module, "Anthropic", _FakeAnthropic)
+    monkeypatch.setattr(llm_client_module, "AsyncAnthropic", _FakeAsyncAnthropic)
+    monkeypatch.setattr(
+        llm_client_module,
+        "_record_anthropic_token_usage",
+        lambda model, usage: recorded.append((model, dict(usage))),
+    )
+
+    client = llm_client_module.ChatAnthropic(model="claude-test", api_key="sk-test")
+    stream = client.astream([{"role": "user", "content": "hi"}])
+    try:
+        assert (await anext(stream)).content == "first"
+        await stream.aclose()
+        assert recorded == [("claude-test", {"input_tokens": 4})]
     finally:
         await client.aclose()
 

--- a/tests/unit/test_llm_client_response_safety.py
+++ b/tests/unit/test_llm_client_response_safety.py
@@ -536,6 +536,46 @@ def test_anthropic_message_normalization_dedupes_tool_ids_across_assistant_turns
     assert [block["id"] for block in tool_uses] == ["call_dup"]
 
 
+def test_anthropic_message_normalization_keeps_repeated_no_id_tool_calls():
+    _system, messages = llm_client_module._normalize_messages_to_anthropic([
+        {"role": "user", "content": "start"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": "{\"q\":\"first\"}"},
+                },
+                {
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": "{\"q\":\"second\"}"},
+                },
+            ],
+        },
+        {"role": "tool", "name": "lookup", "content": "first result"},
+        {"role": "tool", "name": "lookup", "content": "second result"},
+    ])
+
+    tool_uses = [
+        block
+        for message in messages
+        for block in message["content"]
+        if block.get("type") == "tool_use"
+    ]
+    tool_results = [
+        block
+        for message in messages
+        for block in message["content"]
+        if block.get("type") == "tool_result"
+    ]
+    assert [block["input"]["q"] for block in tool_uses] == ["first", "second"]
+    assert len({block["id"] for block in tool_uses}) == 2
+    assert [block["tool_use_id"] for block in tool_results] == [
+        block["id"] for block in tool_uses
+    ]
+
+
 def test_anthropic_message_normalization_drops_unanswered_tool_use_before_user_turn():
     _system, messages = llm_client_module._normalize_messages_to_anthropic([
         {"role": "user", "content": "start"},

--- a/tests/unit/test_token_tracker_install_hooks_idempotent.py
+++ b/tests/unit/test_token_tracker_install_hooks_idempotent.py
@@ -137,15 +137,16 @@ def test_record_anthropic_usage_maps_messages_usage_fields():
             {
                 "input_tokens": 100,
                 "output_tokens": 25,
+                "cache_creation_input_tokens": 20,
                 "cache_read_input_tokens": 80,
             },
         )
 
     rec.assert_called_once_with(
         model="claude-test",
-        prompt_tokens=100,
+        prompt_tokens=200,
         completion_tokens=25,
-        total_tokens=125,
+        total_tokens=225,
         cached_tokens=80,
         call_type="conversation",
     )

--- a/utils/llm_client.py
+++ b/utils/llm_client.py
@@ -1403,6 +1403,7 @@ def _normalize_messages_to_anthropic(messages: Any) -> tuple[str, list[dict]]:
     system_parts: list[str] = []
     anthropic_messages: list[dict] = []
     pending_tool_use_ids: set[str] = set()
+    pending_source_tool_use_ids: dict[str, list[str]] = {}
     pending_fallback_tool_uses: list[tuple[str, str]] = []
     emitted_tool_use_ids: set[str] = set()
     fallback_tool_use_seq = 0
@@ -1425,7 +1426,11 @@ def _normalize_messages_to_anthropic(messages: Any) -> tuple[str, list[dict]]:
         if role == "tool":
             explicit_tool_use_id = msg.get("tool_call_id") or msg.get("id")
             if explicit_tool_use_id:
-                tool_use_id = str(explicit_tool_use_id)
+                source_tool_use_id = str(explicit_tool_use_id)
+                effective_ids = pending_source_tool_use_ids.get(source_tool_use_id) or []
+                tool_use_id = effective_ids.pop(0) if effective_ids else source_tool_use_id
+                if not effective_ids:
+                    pending_source_tool_use_ids.pop(source_tool_use_id, None)
             else:
                 result_name = str(msg.get("name") or "")
                 fallback_match = next(
@@ -1469,7 +1474,8 @@ def _normalize_messages_to_anthropic(messages: Any) -> tuple[str, list[dict]]:
             deduped_blocks: list[dict] = []
             for block in blocks:
                 if isinstance(block, dict) and block.get("type") == "tool_use":
-                    tool_use_id = str(block.get("id") or "")
+                    source_tool_use_id = str(block.get("id") or "")
+                    tool_use_id = source_tool_use_id
                     if not tool_use_id:
                         fallback_tool_use_seq += 1
                         tool_use_id = f"toolu_fallback_{fallback_tool_use_seq}"
@@ -1478,7 +1484,14 @@ def _normalize_messages_to_anthropic(messages: Any) -> tuple[str, list[dict]]:
                             (tool_use_id, str(block.get("name") or ""))
                         )
                     if tool_use_id in emitted_tool_use_ids:
-                        continue
+                        fallback_tool_use_seq += 1
+                        tool_use_id = f"toolu_fallback_{fallback_tool_use_seq}"
+                        block = {**block, "id": tool_use_id}
+                    if source_tool_use_id:
+                        pending_source_tool_use_ids.setdefault(
+                            source_tool_use_id,
+                            [],
+                        ).append(tool_use_id)
                     emitted_tool_use_ids.add(tool_use_id)
                     seen_tool_use_ids.add(tool_use_id)
                 deduped_blocks.append(block)
@@ -1498,11 +1511,21 @@ def _normalize_messages_to_anthropic(messages: Any) -> tuple[str, list[dict]]:
                     fallback_id=fallback_id,
                 )
                 converted_id = str(converted.get("id") or "") if converted else ""
-                if converted and converted_id and converted_id not in emitted_tool_use_ids:
+                if converted and converted_id:
+                    source_tool_use_id = str(raw_tool_call_id or "")
+                    if converted_id in emitted_tool_use_ids:
+                        fallback_tool_use_seq += 1
+                        converted_id = f"toolu_fallback_{fallback_tool_use_seq}"
+                        converted = {**converted, "id": converted_id}
                     blocks.append(converted)
                     emitted_tool_use_ids.add(converted_id)
                     seen_tool_use_ids.add(converted_id)
-                    if fallback_id:
+                    if source_tool_use_id:
+                        pending_source_tool_use_ids.setdefault(
+                            source_tool_use_id,
+                            [],
+                        ).append(converted_id)
+                    else:
                         pending_fallback_tool_uses.append(
                             (converted_id, str(converted.get("name") or ""))
                         )
@@ -1510,6 +1533,7 @@ def _normalize_messages_to_anthropic(messages: Any) -> tuple[str, list[dict]]:
         elif role == "user":
             _drop_unanswered_anthropic_tool_uses(anthropic_messages, pending_tool_use_ids)
             pending_tool_use_ids.clear()
+            pending_source_tool_use_ids.clear()
             pending_fallback_tool_uses.clear()
         anthropic_messages.append({"role": role, "content": blocks or [{"type": "text", "text": "..."}]})
 

--- a/utils/llm_client.py
+++ b/utils/llm_client.py
@@ -1093,6 +1093,24 @@ def _merge_anthropic_usage(target: dict[str, Any], usage: Any) -> None:
     target.update(_anthropic_usage_to_dict(usage))
 
 
+def _anthropic_usage_with_openai_aliases(usage: dict[str, Any]) -> dict[str, Any]:
+    """Expose Anthropic usage under both native and shared token field names."""
+    result = dict(usage)
+    prompt_tokens = sum(
+        int(result.get(key) or 0)
+        for key in (
+            "input_tokens",
+            "cache_creation_input_tokens",
+            "cache_read_input_tokens",
+        )
+    )
+    completion_tokens = int(result.get("output_tokens") or 0)
+    result.setdefault("prompt_tokens", prompt_tokens)
+    result.setdefault("completion_tokens", completion_tokens)
+    result.setdefault("total_tokens", prompt_tokens + completion_tokens)
+    return result
+
+
 def anthropic_retry_error_types() -> tuple[type[BaseException], ...]:
     """Return Anthropic SDK error classes that should follow the chat retry path."""
     global _ANTHROPIC_RETRY_EXCEPTION_TYPES
@@ -1200,14 +1218,25 @@ def _anthropic_text_from_blocks(blocks: list[dict]) -> str:
     return "\n".join(text_parts)
 
 
-def _anthropic_tool_use_ids_from_blocks(blocks: list[dict]) -> set[str]:
-    ids: set[str] = set()
-    for block in blocks:
-        if isinstance(block, dict) and block.get("type") == "tool_use":
-            raw_id = block.get("id")
-            if raw_id:
-                ids.add(str(raw_id))
-    return ids
+def _drop_unanswered_anthropic_tool_uses(messages: list[dict], tool_use_ids: set[str]) -> None:
+    """Remove tool_use blocks that have no matching tool_result in history."""
+    if not tool_use_ids:
+        return
+    for message in messages:
+        if message.get("role") != "assistant":
+            continue
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        message["content"] = [
+            block
+            for block in content
+            if not (
+                isinstance(block, dict)
+                and block.get("type") == "tool_use"
+                and str(block.get("id") or "") in tool_use_ids
+            )
+        ] or [{"type": "text", "text": "..."}]
 
 
 def _convert_openai_tool_call_to_anthropic(tool_call: Any) -> dict[str, Any] | None:
@@ -1360,6 +1389,7 @@ def _normalize_messages_to_anthropic(messages: Any) -> tuple[str, list[dict]]:
     system_parts: list[str] = []
     anthropic_messages: list[dict] = []
     pending_tool_use_ids: set[str] = set()
+    emitted_tool_use_ids: set[str] = set()
 
     for msg in normalized:
         role = msg.get("role", "")
@@ -1394,16 +1424,31 @@ def _normalize_messages_to_anthropic(messages: Any) -> tuple[str, list[dict]]:
             role = "user"
         blocks = _convert_openai_content_to_anthropic(content)
         if role == "assistant":
-            seen_tool_use_ids = _anthropic_tool_use_ids_from_blocks(blocks)
+            seen_tool_use_ids: set[str] = set()
+            deduped_blocks: list[dict] = []
+            for block in blocks:
+                if isinstance(block, dict) and block.get("type") == "tool_use":
+                    tool_use_id = str(block.get("id") or "")
+                    if not tool_use_id or tool_use_id in emitted_tool_use_ids:
+                        continue
+                    emitted_tool_use_ids.add(tool_use_id)
+                    seen_tool_use_ids.add(tool_use_id)
+                deduped_blocks.append(block)
+            blocks = deduped_blocks
             for tool_call in msg.get("tool_calls") or []:
                 converted = _convert_openai_tool_call_to_anthropic(tool_call)
-                if converted and converted.get("id") not in seen_tool_use_ids:
+                converted_id = str(converted.get("id") or "") if converted else ""
+                if converted and converted_id and converted_id not in emitted_tool_use_ids:
                     blocks.append(converted)
-                    seen_tool_use_ids.add(str(converted.get("id")))
+                    emitted_tool_use_ids.add(converted_id)
+                    seen_tool_use_ids.add(converted_id)
             pending_tool_use_ids |= seen_tool_use_ids
         elif role == "user":
-            pending_tool_use_ids = set()
+            _drop_unanswered_anthropic_tool_uses(anthropic_messages, pending_tool_use_ids)
+            pending_tool_use_ids.clear()
         anthropic_messages.append({"role": role, "content": blocks or [{"type": "text", "text": "..."}]})
+
+    _drop_unanswered_anthropic_tool_uses(anthropic_messages, pending_tool_use_ids)
 
     # Enforce strict user/assistant alternation.
     fixed: list[dict] = []
@@ -1657,69 +1702,73 @@ class ChatAnthropic:
         payload = self._build_payload_for_call(messages, overrides)
         stream = self._aclient.messages.stream(**payload)
         usage_dict: dict[str, Any] = {}
-        async with stream as response_stream:
-            async for event in response_stream:
-                event_type = getattr(event, "type", "")
-                if event_type == "message_start":
-                    message = getattr(event, "message", None)
-                    _merge_anthropic_usage(usage_dict, getattr(message, "usage", None))
-                elif event_type == "content_block_start":
-                    block = getattr(event, "content_block", None)
-                    if block and getattr(block, "type", "") == "tool_use":
-                        index = int(getattr(event, "index", 0) or 0)
-                        raw_input = getattr(block, "input", None)
-                        arguments = ""
-                        if raw_input:
-                            arguments = _json.dumps(raw_input, ensure_ascii=False)
-                        yield LLMStreamChunk(
-                            content="",
-                            tool_call_deltas=[{
-                                "index": index,
-                                "id": getattr(block, "id", "") or "",
-                                "type": "function",
-                                "function": {
-                                    "name": getattr(block, "name", "") or "",
-                                    "arguments": arguments,
-                                },
-                            }],
-                        )
-                elif event_type == "content_block_delta":
-                    delta = getattr(event, "delta", None)
-                    if delta and getattr(delta, "type", "") == "text_delta":
-                        text = getattr(delta, "text", "") or ""
-                        if text:
-                            yield LLMStreamChunk(content=text)
-                    elif delta and getattr(delta, "type", "") == "input_json_delta":
-                        partial_json = getattr(delta, "partial_json", "") or ""
-                        if partial_json:
+        try:
+            async with stream as response_stream:
+                async for event in response_stream:
+                    event_type = getattr(event, "type", "")
+                    if event_type == "message_start":
+                        message = getattr(event, "message", None)
+                        _merge_anthropic_usage(usage_dict, getattr(message, "usage", None))
+                    elif event_type == "content_block_start":
+                        block = getattr(event, "content_block", None)
+                        if block and getattr(block, "type", "") == "tool_use":
+                            index = int(getattr(event, "index", 0) or 0)
+                            raw_input = getattr(block, "input", None)
+                            arguments = ""
+                            if raw_input:
+                                arguments = _json.dumps(raw_input, ensure_ascii=False)
                             yield LLMStreamChunk(
                                 content="",
                                 tool_call_deltas=[{
-                                    "index": int(getattr(event, "index", 0) or 0),
-                                    "id": "",
+                                    "index": index,
+                                    "id": getattr(block, "id", "") or "",
                                     "type": "function",
-                                    "function": {"name": "", "arguments": partial_json},
+                                    "function": {
+                                        "name": getattr(block, "name", "") or "",
+                                        "arguments": arguments,
+                                    },
                                 }],
                             )
-                elif event_type == "message_delta":
-                    finish_reason = None
-                    delta = getattr(event, "delta", None)
-                    if delta:
-                        finish_reason = getattr(delta, "stop_reason", None)
-                    _merge_anthropic_usage(usage_dict, getattr(delta, "usage", None))
-                    _merge_anthropic_usage(usage_dict, getattr(event, "usage", None))
-                    if finish_reason:
-                        mapped_reason = _anthropic_stop_reason_to_finish_reason(finish_reason)
-                        yield LLMStreamChunk(content="", finish_reason=mapped_reason)
-                elif event_type == "message_stop":
-                    message = getattr(event, "message", None)
-                    _merge_anthropic_usage(usage_dict, getattr(message, "usage", None))
+                    elif event_type == "content_block_delta":
+                        delta = getattr(event, "delta", None)
+                        if delta and getattr(delta, "type", "") == "text_delta":
+                            text = getattr(delta, "text", "") or ""
+                            if text:
+                                yield LLMStreamChunk(content=text)
+                        elif delta and getattr(delta, "type", "") == "input_json_delta":
+                            partial_json = getattr(delta, "partial_json", "") or ""
+                            if partial_json:
+                                yield LLMStreamChunk(
+                                    content="",
+                                    tool_call_deltas=[{
+                                        "index": int(getattr(event, "index", 0) or 0),
+                                        "id": "",
+                                        "type": "function",
+                                        "function": {"name": "", "arguments": partial_json},
+                                    }],
+                                )
+                    elif event_type == "message_delta":
+                        finish_reason = None
+                        delta = getattr(event, "delta", None)
+                        if delta:
+                            finish_reason = getattr(delta, "stop_reason", None)
+                        _merge_anthropic_usage(usage_dict, getattr(delta, "usage", None))
+                        _merge_anthropic_usage(usage_dict, getattr(event, "usage", None))
+                        if finish_reason:
+                            mapped_reason = _anthropic_stop_reason_to_finish_reason(finish_reason)
+                            yield LLMStreamChunk(content="", finish_reason=mapped_reason)
+                    elif event_type == "message_stop":
+                        message = getattr(event, "message", None)
+                        _merge_anthropic_usage(usage_dict, getattr(message, "usage", None))
+        finally:
+            if usage_dict:
+                _record_anthropic_token_usage(self.model, usage_dict)
         if usage_dict:
-            _record_anthropic_token_usage(self.model, usage_dict)
+            shared_usage = _anthropic_usage_with_openai_aliases(usage_dict)
             yield LLMStreamChunk(
                 content="",
-                usage_metadata=usage_dict,
-                response_metadata={"token_usage": usage_dict},
+                usage_metadata=shared_usage,
+                response_metadata={"token_usage": shared_usage},
             )
 
     async def ainvoke_raw(self, messages: Any, **overrides: Any):

--- a/utils/llm_client.py
+++ b/utils/llm_client.py
@@ -1239,7 +1239,11 @@ def _drop_unanswered_anthropic_tool_uses(messages: list[dict], tool_use_ids: set
         ] or [{"type": "text", "text": "..."}]
 
 
-def _convert_openai_tool_call_to_anthropic(tool_call: Any) -> dict[str, Any] | None:
+def _convert_openai_tool_call_to_anthropic(
+    tool_call: Any,
+    *,
+    fallback_id: str | None = None,
+) -> dict[str, Any] | None:
     if not isinstance(tool_call, dict):
         tool_call = {
             "id": getattr(tool_call, "id", ""),
@@ -1266,7 +1270,7 @@ def _convert_openai_tool_call_to_anthropic(tool_call: Any) -> dict[str, Any] | N
         parsed_args = raw_args
     else:
         parsed_args = {}
-    tool_use_id = str(tool_call.get("id") or name)
+    tool_use_id = str(tool_call.get("id") or fallback_id or name)
     return {
         "type": "tool_use",
         "id": tool_use_id,
@@ -1357,15 +1361,25 @@ def _convert_openai_tool_choice_to_anthropic(tool_choice: Any) -> dict[str, Any]
     return None
 
 
-def _convert_openai_tool_result_to_anthropic(msg: dict) -> dict[str, Any]:
+def _convert_openai_tool_result_to_anthropic(
+    msg: dict,
+    *,
+    tool_use_id: str | None = None,
+) -> dict[str, Any]:
     blocks = _convert_openai_content_to_anthropic(msg.get("content"))
-    tool_use_id = str(msg.get("tool_call_id") or msg.get("id") or msg.get("name") or "tool_result")
+    resolved_tool_use_id = str(
+        tool_use_id
+        or msg.get("tool_call_id")
+        or msg.get("id")
+        or msg.get("name")
+        or "tool_result"
+    )
     content: str | list[dict] = _anthropic_text_from_blocks(blocks)
     if any(isinstance(block, dict) and block.get("type") != "text" for block in blocks):
         content = blocks
     return {
         "type": "tool_result",
-        "tool_use_id": tool_use_id,
+        "tool_use_id": resolved_tool_use_id,
         "content": content,
     }
 
@@ -1389,7 +1403,9 @@ def _normalize_messages_to_anthropic(messages: Any) -> tuple[str, list[dict]]:
     system_parts: list[str] = []
     anthropic_messages: list[dict] = []
     pending_tool_use_ids: set[str] = set()
+    pending_fallback_tool_uses: list[tuple[str, str]] = []
     emitted_tool_use_ids: set[str] = set()
+    fallback_tool_use_seq = 0
 
     for msg in normalized:
         role = msg.get("role", "")
@@ -1407,7 +1423,24 @@ def _normalize_messages_to_anthropic(messages: Any) -> tuple[str, list[dict]]:
                     system_parts.append(system_text)
             continue
         if role == "tool":
-            tool_use_id = str(msg.get("tool_call_id") or msg.get("id") or msg.get("name") or "tool_result")
+            explicit_tool_use_id = msg.get("tool_call_id") or msg.get("id")
+            if explicit_tool_use_id:
+                tool_use_id = str(explicit_tool_use_id)
+            else:
+                result_name = str(msg.get("name") or "")
+                fallback_match = next(
+                    (
+                        item
+                        for item in pending_fallback_tool_uses
+                        if not result_name or item[1] == result_name
+                    ),
+                    None,
+                )
+                tool_use_id = (
+                    fallback_match[0]
+                    if fallback_match
+                    else str(msg.get("name") or "tool_result")
+                )
             if tool_use_id not in pending_tool_use_ids:
                 anthropic_messages.append({
                     "role": "user",
@@ -1415,9 +1448,17 @@ def _normalize_messages_to_anthropic(messages: Any) -> tuple[str, list[dict]]:
                 })
                 continue
             pending_tool_use_ids.discard(tool_use_id)
+            pending_fallback_tool_uses = [
+                item for item in pending_fallback_tool_uses if item[0] != tool_use_id
+            ]
             anthropic_messages.append({
                 "role": "user",
-                "content": [_convert_openai_tool_result_to_anthropic(msg)],
+                "content": [
+                    _convert_openai_tool_result_to_anthropic(
+                        msg,
+                        tool_use_id=tool_use_id,
+                    )
+                ],
             })
             continue
         if role not in ("user", "assistant"):
@@ -1429,23 +1470,47 @@ def _normalize_messages_to_anthropic(messages: Any) -> tuple[str, list[dict]]:
             for block in blocks:
                 if isinstance(block, dict) and block.get("type") == "tool_use":
                     tool_use_id = str(block.get("id") or "")
-                    if not tool_use_id or tool_use_id in emitted_tool_use_ids:
+                    if not tool_use_id:
+                        fallback_tool_use_seq += 1
+                        tool_use_id = f"toolu_fallback_{fallback_tool_use_seq}"
+                        block = {**block, "id": tool_use_id}
+                        pending_fallback_tool_uses.append(
+                            (tool_use_id, str(block.get("name") or ""))
+                        )
+                    if tool_use_id in emitted_tool_use_ids:
                         continue
                     emitted_tool_use_ids.add(tool_use_id)
                     seen_tool_use_ids.add(tool_use_id)
                 deduped_blocks.append(block)
             blocks = deduped_blocks
             for tool_call in msg.get("tool_calls") or []:
-                converted = _convert_openai_tool_call_to_anthropic(tool_call)
+                raw_tool_call_id = (
+                    tool_call.get("id")
+                    if isinstance(tool_call, dict)
+                    else getattr(tool_call, "id", "")
+                )
+                fallback_id = None
+                if not raw_tool_call_id:
+                    fallback_tool_use_seq += 1
+                    fallback_id = f"toolu_fallback_{fallback_tool_use_seq}"
+                converted = _convert_openai_tool_call_to_anthropic(
+                    tool_call,
+                    fallback_id=fallback_id,
+                )
                 converted_id = str(converted.get("id") or "") if converted else ""
                 if converted and converted_id and converted_id not in emitted_tool_use_ids:
                     blocks.append(converted)
                     emitted_tool_use_ids.add(converted_id)
                     seen_tool_use_ids.add(converted_id)
+                    if fallback_id:
+                        pending_fallback_tool_uses.append(
+                            (converted_id, str(converted.get("name") or ""))
+                        )
             pending_tool_use_ids |= seen_tool_use_ids
         elif role == "user":
             _drop_unanswered_anthropic_tool_uses(anthropic_messages, pending_tool_use_ids)
             pending_tool_use_ids.clear()
+            pending_fallback_tool_uses.clear()
         anthropic_messages.append({"role": role, "content": blocks or [{"type": "text", "text": "..."}]})
 
     _drop_unanswered_anthropic_tool_uses(anthropic_messages, pending_tool_use_ids)

--- a/utils/token_tracker.py
+++ b/utils/token_tracker.py
@@ -2064,7 +2064,17 @@ def record_anthropic_usage(model: str, usage, call_type: str | None = None):
         usage_dict = _usage_to_dict(usage)
         if not usage_dict:
             return
-        prompt_tokens = int(usage_dict.get('input_tokens') or usage_dict.get('prompt_tokens') or 0)
+        if 'input_tokens' in usage_dict:
+            prompt_tokens = sum(
+                int(usage_dict.get(field) or 0)
+                for field in (
+                    'input_tokens',
+                    'cache_creation_input_tokens',
+                    'cache_read_input_tokens',
+                )
+            )
+        else:
+            prompt_tokens = int(usage_dict.get('prompt_tokens') or 0)
         completion_tokens = int(usage_dict.get('output_tokens') or usage_dict.get('completion_tokens') or 0)
         total_tokens = int(usage_dict.get('total_tokens') or (prompt_tokens + completion_tokens))
         cached_tokens = _extract_cached_tokens(usage_dict)


### PR DESCRIPTION
## Summary

- route BrowserUse through its native `ChatAnthropic` client for Anthropic providers, including Kimi Code headers and protocol-aware mode caching
- normalize Anthropic streaming usage for shared downstream consumers and persist partial usage when a stream closes early
- reject duplicate or unanswered Anthropic `tool_use` blocks before sending cross-provider history
- count Anthropic cache creation/read tokens in prompt totals
- fix the stale Focus default-setting test threshold and add focused regression coverage

## Root cause

Most of #1983 had already been addressed on `main`, but BrowserUse still unconditionally constructed an OpenAI-protocol client. The remaining Anthropic adapter also exposed native usage field names to consumers expecting OpenAI-style aliases, only recorded completed streams, and could retain invalid tool history across provider switches.

## Impact

Kimi Code, Claude, and custom Anthropic-compatible agent providers can now use BrowserUse without sending Chat Completions payloads to Messages endpoints. Token accounting and prompt-budget observations remain accurate with streaming and prompt caching, while malformed cross-provider tool history is sanitized instead of producing Anthropic 400 responses.

## Validation

- `uv run pytest tests/unit/test_browser_use_adapter_anthropic.py tests/unit/test_llm_client_response_safety.py tests/unit/test_token_tracker_install_hooks_idempotent.py tests/unit/test_agent_runtime_intent.py tests/unit/test_connectivity_endpoint.py tests/unit/test_galgame_router.py tests/unit/test_api_config_manager.py tests/unit/test_focus_mode.py -q` (`335 passed`)
- Ruff checks for all changed Python files
- `uv run python scripts/check_llm_budget.py`
- `uv run python scripts/check_i18n_sync.py`
- `node --check static/js/api_key_settings.js`
- `git diff --check`

Closes #1983


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 增强 Anthropic 及兼容端点支持：根据配置自动适配连接方式，并对地址/请求头进行规范化，提升跨提供方的一致性。
- **问题修复**
  - 优化工具调用消息处理：更好地处理跨轮未配对与重复的工具调用，确保 `tool_result` 能正确对应到对应的工具请求。
  - 改进用量统计：流式场景即使提前结束也能保留已获取的用量；包含缓存输入 token 时 `prompt_tokens/total_tokens` 等字段更准确。
- **测试**
  - 新增/补强多提供方相关单元测试，覆盖签名选择与工具/用量边界情况。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->