### PR TITLE
fix: preserve Live2D appearance parameter edits

### DIFF
--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -1345,6 +1345,30 @@
         }
     }
 
+    async function handleReloadModelParametersMessage(message) {
+        var manager = window.live2dManager;
+        if (!manager || typeof manager.reloadModelParameters !== 'function') {
+            await handleModelReload(message && message.lanlan_name);
+            return false;
+        }
+
+        try {
+            var result = await manager.reloadModelParameters({
+                model_name: message && message.model_name,
+                model_path: message && message.model_path
+            });
+            if (result && result.reason === 'model_mismatch') {
+                console.log('[Live2D] 忽略非当前模型的参数热刷新消息');
+                return false;
+            }
+            return !!(result && result.applied);
+        } catch (error) {
+            console.warn('[Live2D] 参数轻量热刷新失败，降级为完整模型重载:', error);
+            await handleModelReload(message && message.lanlan_name);
+            return false;
+        }
+    }
+
     /**
      * [HACK/WORKAROUND] 动态向已加载的 Live2D 模型实例注入动作组。
      * 注意：这里直接修改了 pixi-live2d-display SDK 的内部私有/只读数据结构。
@@ -3289,6 +3313,9 @@
                 switch (event.data.action) {
                     case 'reload_model':
                         await handleModelReload(event.data?.lanlan_name, event.data?.reloadOptions);
+                        break;
+                    case 'reload_model_parameters':
+                        await handleReloadModelParametersMessage(event.data);
                         break;
                     case 'catgirl_switched': {
                         // 兜底：character_card_manager 切角色后用 BroadcastChannel 通知主窗口热切换。
@@ -5772,7 +5799,11 @@
             return;
         }
 
-        if (event.data && (event.data.action === 'model_saved' || event.data.action === 'reload_model')) {
+        if (event.data && (
+            event.data.action === 'model_saved'
+            || event.data.action === 'reload_model'
+            || event.data.action === 'reload_model_parameters'
+        )) {
             // Deduplicate: same message arrives via both BC and postMessage
             if (
                 !shouldBypassYuiGuideMessageDedup(event.data.action, event.data)
@@ -5781,9 +5812,27 @@
                 console.log('[Model] 跳过重复 postMessage:', event.data.action);
                 return;
             }
+            if (event.data.action === 'reload_model_parameters') {
+                await handleReloadModelParametersMessage(event.data);
+                return;
+            }
             console.log('[Model] 通过 postMessage 收到模型重载通知');
             await handleModelReload(event.data?.lanlan_name, event.data?.reloadOptions);
         }
+    });
+
+    // 参数编辑器在 BroadcastChannel 不可用时使用 localStorage 触发跨窗口消息。
+    window.addEventListener('storage', async function (event) {
+        if (event.key !== 'nekopage_message' || !event.newValue) return;
+        var message;
+        try {
+            message = JSON.parse(event.newValue);
+        } catch (_) {
+            return;
+        }
+        if (!message || message.action !== 'reload_model_parameters') return;
+        if (isDuplicateMessage(message.action, message.timestamp)) return;
+        await handleReloadModelParametersMessage(message);
     });
 
     // 音色应用页的后备通道：没有 BroadcastChannel 时使用 postMessage 同步准备态

--- a/static/js/live2d_parameter_editor.js
+++ b/static/js/live2d_parameter_editor.js
@@ -1478,6 +1478,7 @@ if (saveBtn) {
             if (prefSuccess) {
                 markModelManagerNeedsSaveAfterParameterEdit(currentModelInfo);
                 sendMessageToMainPage('reload_model_parameters', {
+                    lanlan_name: getParameterEditorLanlanName(),
                     model_name: currentModelInfo.name,
                     model_path: currentModelInfo.path
                 });

--- a/static/js/live2d_parameter_editor.js
+++ b/static/js/live2d_parameter_editor.js
@@ -178,7 +178,9 @@ let currentModelInfo = null;
 let parameterInfo = null;
 let parameterGroups = {};
 let initialParameters = {};
-let currentParameters = {};
+// 独立编辑草稿：只由用户操作更新，避免 motion/物理/呼吸的瞬时值混入保存结果。
+let draftParameters = {};
+let draftParameterIndexes = {};
 
 // 加载序列号，用于防止异步加载乱序
 let loadSeq = 0;
@@ -512,9 +514,10 @@ try {
 }
 
 // 保留原有的简单发送函数（用于不需要确认的场景）
-function sendMessageToMainPage(action) {
+function sendMessageToMainPage(action, payload = {}) {
     try {
         const message = {
+            ...payload,
             action: action,
             timestamp: Date.now()
         };
@@ -638,18 +641,13 @@ function showStatus(message, duration = 0) {
 
 // 返回L2D设置界面
 backToMainBtn.addEventListener('click', () => {
-    // 在跳转前发送消息通知主页
-    sendMessageToMainPage('reload_model_parameters');
-    // 延迟一点确保消息发送
-    setTimeout(() => {
-        // 获取当前URL参数，保留lanlan_name等参数
-        const lanlanName = getParameterEditorLanlanName();
-        let targetUrl = '/model_manager';
-        if (lanlanName) {
-            targetUrl += `?lanlan_name=${encodeURIComponent(lanlanName)}`;
-        }
-        window.location.href = targetUrl;
-    }, 100);
+    // 获取当前URL参数，保留lanlan_name等参数
+    const lanlanName = getParameterEditorLanlanName();
+    let targetUrl = '/model_manager';
+    if (lanlanName) {
+        targetUrl += `?lanlan_name=${encodeURIComponent(lanlanName)}`;
+    }
+    window.location.href = targetUrl;
 });
 
 // 加载模型列表
@@ -896,6 +894,7 @@ async function loadModel(modelName) {
             dragEnabled: true,
             wheelEnabled: true,
             preferences: modelPreferences,
+            parameterEditingMode: true,
             skipCloseWindows: true  // 参数编辑器页面不需要关闭其他窗口
         });
         
@@ -929,6 +928,9 @@ function recordInitialParameters() {
 
     const coreModel = live2dModel.internalModel.coreModel;
     initialParameters = {};
+    draftParameters = {};
+    draftParameterIndexes = {};
+    const effectiveParameters = window.live2dManager?.effectiveModelParameters || {};
     const paramCount = coreModel.getParameterCount();
 
     for (let i = 0; i < paramCount; i++) {
@@ -941,6 +943,10 @@ function recordInitialParameters() {
             }
             const value = coreModel.getParameterValueByIndex(i);
             initialParameters[paramId] = value;
+            draftParameterIndexes[paramId] = i;
+            draftParameters[paramId] = Object.prototype.hasOwnProperty.call(effectiveParameters, paramId)
+                ? effectiveParameters[paramId]
+                : value;
         } catch (e) {
             console.warn(`记录参数 ${i} 失败:`, e);
         }
@@ -1275,7 +1281,7 @@ function displayParameters() {
                             slider.value = clampedValue;
                         }
                         input.value = clampedValue;
-                        currentParameters[paramId] = clampedValue;
+                        draftParameters[paramId] = clampedValue;
                     } catch (e) {
                         console.warn(`更新参数 ${paramId} 失败:`, e);
                     }
@@ -1385,6 +1391,7 @@ if (resetAllBtn) {
                 }
 
                 coreModel.setParameterValueByIndex(i, resetValue);
+                draftParameters[paramId] = resetValue;
             } catch (e) {
                 console.warn(`重置参数索引 ${i} 失败:`, e);
             }
@@ -1396,91 +1403,98 @@ if (resetAllBtn) {
     });
 }
 
+function buildParametersFromDraft(parameters, parameterIndexes, manager) {
+    const paramsToSave = {};
+    for (const [paramId, value] of Object.entries(parameters || {})) {
+        const index = parameterIndexes && parameterIndexes[paramId];
+        let isEyeBlinkParam = false;
+        try {
+            isEyeBlinkParam = manager && typeof manager._isEyeBlinkParamId === 'function'
+                && (manager._isEyeBlinkParamId(paramId) || manager._isEyeBlinkParamId(`param_${index}`));
+        } catch (_) {}
+        if (!isEyeBlinkParam && typeof value === 'number' && Number.isFinite(value)) {
+            paramsToSave[paramId] = value;
+        }
+    }
+    return paramsToSave;
+}
+
+async function persistParameterDraft(modelInfo, model, parameters, dependencies = {}) {
+    const fetchImpl = dependencies.fetchImpl || fetch;
+    const manager = dependencies.manager || window.live2dManager;
+    const position = { x: model.x, y: model.y };
+    const scale = { x: model.scale.x, y: model.scale.y };
+
+    let fileSuccess = false;
+    let fileError = null;
+    try {
+        const fileResponse = await fetchImpl(`/api/live2d/save_model_parameters/${encodeURIComponent(modelInfo.name)}`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ parameters })
+        });
+        const fileResult = await fileResponse.json();
+        fileSuccess = fileResponse.ok !== false && fileResult.success === true;
+        if (!fileSuccess) fileError = fileResult.error || `HTTP ${fileResponse.status}`;
+    } catch (error) {
+        fileError = error.message;
+    }
+
+    let prefSuccess = false;
+    let prefError = null;
+    try {
+        prefSuccess = await manager.saveUserPreferences(
+            modelInfo.path,
+            position,
+            scale,
+            parameters
+        );
+    } catch (error) {
+        prefError = error.message;
+    }
+
+    return { fileSuccess, fileError, prefSuccess, prefError };
+}
+
 if (saveBtn) {
     saveBtn.addEventListener('click', async () => {
         if (!currentModelInfo || !live2dModel) return;
 
         showStatus(t('live2d.parameterEditor.savingParameters', '正在保存参数...'));
 
-        const paramsToSave = {};
-        if (live2dModel.internalModel && live2dModel.internalModel.coreModel) {
-            const coreModel = live2dModel.internalModel.coreModel;
-            const paramCount = coreModel.getParameterCount();
-            const manager = window.live2dManager;
-            const isEyeBlinkParam = (paramId, index) => {
-                if (!manager || typeof manager._isEyeBlinkParamId !== 'function') return false;
-                try {
-                    return manager._isEyeBlinkParamId(paramId)
-                        || manager._isEyeBlinkParamId(`param_${index}`);
-                } catch (_) {
-                    return false;
-                }
-            };
-
-            for (let i = 0; i < paramCount; i++) {
-                try {
-                    let paramId = null;
-                    try {
-                        paramId = coreModel._parameterIds?.[i]
-                            ?? coreModel._model?.parameters?.ids?.[i]
-                            ?? (typeof coreModel.getParameterId === 'function' ? coreModel.getParameterId(i) : null);
-                    } catch (e) {
-                        paramId = `param_${i}`;
-                    }
-                    if (!paramId) {
-                        paramId = `param_${i}`;
-                    }
-                    if (isEyeBlinkParam(paramId, i)) {
-                        continue;
-                    }
-                    const value = coreModel.getParameterValueByIndex(i);
-                    paramsToSave[paramId] = value;
-                } catch (e) {
-                    console.warn(`收集参数 ${i} 失败:`, e);
-                }
-            }
-        }
+        const manager = window.live2dManager;
+        const paramsToSave = buildParametersFromDraft(draftParameters, draftParameterIndexes, manager);
 
         try {
-            // 同时保存到模型目录的parameters.json文件和用户偏好设置
-            const position = { x: live2dModel.x, y: live2dModel.y };
-            const scale = { x: live2dModel.scale.x, y: live2dModel.scale.y };
-
-            // 1. 保存到模型目录的parameters.json文件
-            const fileResponse = await fetch(`/api/live2d/save_model_parameters/${encodeURIComponent(currentModelInfo.name)}`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({
-                    parameters: paramsToSave
-                })
-            });
-
-            const fileResult = await fileResponse.json();
-
-            // 2. 同时保存到用户偏好设置（这样主页加载时也能读取到）
-            const prefSuccess = await window.live2dManager.saveUserPreferences(
-                currentModelInfo.path,
-                position,
-                scale,
-                paramsToSave
+            const { fileSuccess, fileError, prefSuccess, prefError } = await persistParameterDraft(
+                currentModelInfo,
+                live2dModel,
+                paramsToSave,
+                { manager }
             );
 
-            if (fileResult.success || prefSuccess) {
+            if (prefSuccess) {
                 markModelManagerNeedsSaveAfterParameterEdit(currentModelInfo);
-            }
+                sendMessageToMainPage('reload_model_parameters', {
+                    model_name: currentModelInfo.name,
+                    model_path: currentModelInfo.path
+                });
 
-            if (fileResult.success && prefSuccess) {
-                showStatus(t('live2d.parameterEditor.parametersSaved', '参数保存成功！'), 2000);
-                // 通知主页重新应用参数
-                sendMessageToMainPage('reload_model_parameters');
+                if (fileSuccess) {
+                    showStatus(t('live2d.parameterEditor.parametersSaved', '参数保存成功！'), 2000);
+                } else {
+                    showStatus(t(
+                        'live2d.parameterEditor.modelDirectoryMirrorSaveWarning',
+                        '参数已保存；模型目录兼容镜像写入失败'
+                    ), 3500);
+                    console.warn('模型目录 parameters.json 兼容镜像保存失败:', fileError);
+                }
             } else {
-                const errors = [];
-                if (!fileResult.success) errors.push(t('live2d.parameterEditor.modelDirectorySaveFailed', '模型目录文件保存失败'));
-                if (!prefSuccess) errors.push(t('live2d.parameterEditor.userPreferencesSaveFailed', '用户偏好设置保存失败'));
-                showStatus(t('live2d.parameterEditor.parametersSavePartialFailed', '参数保存部分失败: {{errors}}', { errors: errors.join(', ') }), 3000);
-                console.error('参数保存失败:', errors);
+                const message = t('live2d.parameterEditor.userPreferencesSaveFailed', '用户偏好设置保存失败');
+                showStatus(t('live2d.parameterEditor.parametersSaveFailed', '参数保存失败: {{error}}', { error: message }), 3000);
+                console.error('权威用户偏好保存失败:', { fileSuccess, fileError, prefError });
             }
         } catch (error) {
             showStatus(t('live2d.parameterEditor.parametersSaveFailed', '参数保存失败: {{error}}', { error: error.message }), 3000);

--- a/static/live2d/live2d-emotion.js
+++ b/static/live2d/live2d-emotion.js
@@ -168,21 +168,18 @@ Live2DManager.prototype.recordInitialParameters = function() {
 
 // 清除expression到默认状态（使用保存的初始参数）
 Live2DManager.prototype.clearExpression = function() {
-    // 取消正在进行的平滑过渡和手动表情覆盖
+    const activeExpressionParamIds = this._activeExpressionParamIds
+        && typeof this._activeExpressionParamIds.forEach === 'function'
+        ? new Set(Array.from(this._activeExpressionParamIds))
+        : null;
+    // 必须先保存受影响参数，再取消正在进行的平滑过渡和手动表情覆盖。
     this._cancelSmoothReset();
     this._removeManualExpressionOverride();
-    this._activeExpressionParamIds = null;
 
     try {
         if (!this.currentModel || !this.currentModel.internalModel || !this.currentModel.internalModel.coreModel) {
+            this._activeExpressionParamIds = null;
             console.warn('无法清除expression：模型未加载');
-            return;
-        }
-
-        // 检查初始参数是否存在，如果不存在则视为硬错误
-        if (!this.initialParameters || Object.keys(this.initialParameters).length === 0) {
-            console.error('严重错误：未找到初始参数记录！expression清除失败。');
-            console.error('请确保在模型加载完成后立即调用recordInitialParameters()初始化参数基准');
             return;
         }
 
@@ -195,41 +192,20 @@ Live2DManager.prototype.clearExpression = function() {
             }
         }
 
-        const coreModel = this.currentModel.internalModel.coreModel;
-        console.log(`开始重置expression到初始状态，共${Object.keys(this.initialParameters).length}个参数`);
-        
-        // 创建可折叠的参数重置详情日志（默认折叠状态）
-        console.groupCollapsed(`参数重置详情 (${Object.keys(this.initialParameters).length}个参数)`);
-        
-        // 重置所有记录的初始参数
-        for (const [paramId, initialValue] of Object.entries(this.initialParameters)) {
-            try {
-                if (paramId.startsWith('param_')) {
-                    // 如果是使用索引作为参数名的情况，提取索引
-                    const paramIndex = parseInt(paramId.substring(6));
-                    if (!isNaN(paramIndex)) {
-                        coreModel.setParameterValueByIndex(paramIndex, initialValue);
-                        console.log(`使用索引重置参数 ${paramId} (索引${paramIndex}) = ${initialValue}`);
-                    } else {
-                        console.warn(`无效的参数索引: ${paramId}`);
-                    }
-                } else {
-                    // 正常使用参数ID重置
-                    coreModel.setParameterValueById(paramId, initialValue);
-                    console.log(`重置参数 ${paramId} = ${initialValue}`);
-                }
-            } catch (e) {
-                console.warn(`重置参数 ${paramId} 失败:`, e);
-            }
+        this._activeExpressionParamIds = null;
+        if (activeExpressionParamIds && activeExpressionParamIds.size > 0) {
+            const resetCount = this._resetRecordedParameterIds(activeExpressionParamIds, {
+                preserveExpression: false
+            });
+            console.log(`expression已恢复${resetCount}个受影响参数到用户外观基准`);
+        } else {
+            const resetCount = this._resetParametersToInitialState({ preserveExpression: false });
+            console.log(`expression参数列表不可用，已降级恢复${resetCount}个参数到外观基准`);
         }
-        
-        // 结束可折叠日志组
-        console.groupEnd();
-        
-        console.log('expression已使用初始参数重置');
 
     } catch (error) {
         console.warn('expression重置失败:', error);
+        this._activeExpressionParamIds = null;
     }
 
     // 如存在常驻表情，清除后立即重放常驻，保证不被清掉

--- a/static/live2d/live2d-model.js
+++ b/static/live2d/live2d-model.js
@@ -275,7 +275,7 @@ Live2DManager.prototype._isRuntimeManagedAppearanceParam = function(paramId, res
     } catch (_) {}
 
     try {
-        if (typeof this.getPersistentExpressionParamIds === 'function') {
+        if (this._parameterEditingMode !== true && typeof this.getPersistentExpressionParamIds === 'function') {
             const persistentParamIds = this.getPersistentExpressionParamIds();
             if (ids.some(id => persistentParamIds.has(id))) return true;
         }
@@ -322,6 +322,98 @@ Live2DManager.prototype.mergeAppearanceBaselineParameters = function(model, para
         if (!Object.prototype.hasOwnProperty.call(parameters, paramId)) continue;
         mergeAppearanceParam(paramId, parameters[paramId]);
     }
+};
+
+Live2DManager.prototype._normalizeModelPreferencePath = function(modelPath) {
+    const path = modelPath && typeof modelPath === 'object' ? modelPath.url : modelPath;
+    return typeof path === 'string' ? path.split('#')[0].split('?')[0] : '';
+};
+
+Live2DManager.prototype._findModelPreference = function(preferences, modelPath) {
+    if (!Array.isArray(preferences)) return null;
+    const normalizedPath = this._normalizeModelPreferencePath(modelPath);
+    return preferences.find((preference) => (
+        preference && this._normalizeModelPreferencePath(preference.model_path) === normalizedPath
+    )) || null;
+};
+
+Live2DManager.prototype._mergeEffectiveModelParameters = function(modelDirectoryParameters, userPreferenceParameters) {
+    return {
+        ...(modelDirectoryParameters && typeof modelDirectoryParameters === 'object' ? modelDirectoryParameters : {}),
+        ...(userPreferenceParameters && typeof userPreferenceParameters === 'object' ? userPreferenceParameters : {})
+    };
+};
+
+Live2DManager.prototype._loadModelDirectoryParameters = async function(modelName) {
+    if (!modelName) return {};
+    const response = await fetch(`/api/live2d/load_model_parameters/${encodeURIComponent(modelName)}`);
+    if (response.ok === false) {
+        throw new Error(`加载模型目录参数失败: HTTP ${response.status}`);
+    }
+    const data = await response.json();
+    return data.success && data.parameters && typeof data.parameters === 'object'
+        ? data.parameters
+        : {};
+};
+
+Live2DManager.prototype._applyEffectiveModelParameters = function(model, modelDirectoryParameters, userPreferenceParameters) {
+    const effectiveParameters = this._mergeEffectiveModelParameters(
+        modelDirectoryParameters,
+        userPreferenceParameters
+    );
+    const hasEffectiveParameters = Object.keys(effectiveParameters).length > 0;
+
+    this.effectiveModelParameters = effectiveParameters;
+    this.savedModelParameters = hasEffectiveParameters ? effectiveParameters : null;
+    this._shouldApplySavedParams = hasEffectiveParameters && this._parameterEditingMode !== true;
+
+    if (hasEffectiveParameters) {
+        this.applyModelParameters(model, effectiveParameters);
+    }
+
+    // installMouthOverride 会捕获 savedModelParameters，参数变化后必须重新安装。
+    this.installMouthOverride();
+    return effectiveParameters;
+};
+
+Live2DManager.prototype.reloadModelParameters = async function(options = {}) {
+    const model = this.currentModel;
+    if (!model || !model.internalModel || !model.internalModel.coreModel) {
+        throw new Error('当前 Live2D 模型尚未就绪');
+    }
+
+    const requestedPath = this._normalizeModelPreferencePath(options.modelPath || options.model_path);
+    const currentPath = this._normalizeModelPreferencePath(this._lastLoadedModelPath);
+    const requestedName = String(options.modelName || options.model_name || '').trim();
+
+    if ((requestedPath && requestedPath !== currentPath)
+        || (!requestedPath && requestedName && requestedName !== this.modelName)) {
+        return { applied: false, reason: 'model_mismatch' };
+    }
+
+    let modelDirectoryParameters = {};
+    try {
+        modelDirectoryParameters = await this._loadModelDirectoryParameters(this.modelName);
+    } catch (error) {
+        console.warn('[Live2D] 热刷新模型目录参数失败，将继续使用用户偏好:', error);
+    }
+
+    const preferences = await this.loadUserPreferences();
+    if (this.currentModel !== model) {
+        return { applied: false, reason: 'model_mismatch' };
+    }
+    const preference = this._findModelPreference(preferences, this._lastLoadedModelPath);
+    if (!preference || !preference.parameters || typeof preference.parameters !== 'object') {
+        throw new Error('未找到当前模型的用户偏好参数');
+    }
+    const userPreferenceParameters = preference && preference.parameters;
+    const effectiveParameters = this._applyEffectiveModelParameters(
+        model,
+        modelDirectoryParameters,
+        userPreferenceParameters
+    );
+
+    return { applied: true, parameters: effectiveParameters };
 };
 
 // 加载模型
@@ -546,7 +638,9 @@ Live2DManager.prototype._resetDerivedModelMetadata = function() {
     this.fileReferences = null;
     this.emotionMapping = null;
     this.savedModelParameters = null;
+    this.effectiveModelParameters = {};
     this._shouldApplySavedParams = false;
+    this._parameterEditingMode = false;
     this.modelName = null;
     this.modelRootPath = null;
     this._eyeBlinkParams = null;
@@ -1567,6 +1661,7 @@ Live2DManager.prototype._playIdleMotion = async function(motionManager) {
 Live2DManager.prototype._configureLoadedModel = async function(model, modelPath, options, loadToken) {
     if (!this._isLoadTokenActive(loadToken)) return;
     this._modelLoadState = 'applying';
+    this._parameterEditingMode = options.parameterEditingMode === true;
 
     // 解析模型目录名与根路径，供资源解析使用
     try {
@@ -1843,44 +1938,41 @@ Live2DManager.prototype._configureLoadedModel = async function(model, modelPath,
         }
     }
     
-    // 加载并应用模型目录中的parameters.json文件（优先级最高）
-    // 先加载参数，然后再安装口型覆盖（这样coreModel.update就能访问到savedModelParameters）
-    if (this.modelName && model.internalModel && model.internalModel.coreModel) {
+    if (this._parameterEditingMode) {
+        this._clearIdleMotionLoopTimers();
         try {
-            const response = await fetch(`/api/live2d/load_model_parameters/${encodeURIComponent(this.modelName)}`);
-            // 【重要修复】Fetch 回来后，必须检查 Token！如果用户在此期间切了模型，直接中断！
-            if (!this._isLoadTokenActive(loadToken)) return;
-
-            const data = await response.json();
-            if (!this._isLoadTokenActive(loadToken)) return;
-
-            if (data.success && data.parameters && Object.keys(data.parameters).length > 0) {
-                // 保存参数到实例变量，供定时器定期应用
-                this.savedModelParameters = data.parameters;
-                this._shouldApplySavedParams = true;
-
-                // 立即应用一次
-                this.applyModelParameters(model, data.parameters);
-            } else {
-                // 如果没有参数文件，清空保存的参数
-                this.savedModelParameters = null;
-                this._shouldApplySavedParams = false;
+            const motionManager = model.internalModel?.motionManager;
+            if (motionManager && typeof motionManager.stopAllMotions === 'function') {
+                motionManager.stopAllMotions();
+            }
+            const expressionManager = motionManager?.expressionManager;
+            if (expressionManager && typeof expressionManager.stopAllExpressions === 'function') {
+                expressionManager.stopAllExpressions();
             }
         } catch (error) {
-            console.error('加载模型参数失败:', error);
-            this.savedModelParameters = null;
-            this._shouldApplySavedParams = false;
+            console.warn('[Live2D] 参数编辑模式停止 motion/expression 失败:', error);
         }
-    } else {
-        this.savedModelParameters = null;
-        this._shouldApplySavedParams = false;
+        this._activeExpressionParamIds = null;
+        this._clearActiveMotionParamIds();
     }
-    
-    // 重新安装口型覆盖（这也包括了用户保存参数的应用逻辑）
+
+    // 用户偏好是权威来源，模型目录 parameters.json 仅作为兼容镜像。
+    let modelDirectoryParameters = {};
+    if (this.modelName && model.internalModel && model.internalModel.coreModel) {
+        try {
+            modelDirectoryParameters = await this._loadModelDirectoryParameters(this.modelName);
+            // 【重要修复】Fetch 回来后，必须检查 Token！如果用户在此期间切了模型，直接中断！
+            if (!this._isLoadTokenActive(loadToken)) return;
+        } catch (error) {
+            console.error('加载模型参数失败:', error);
+        }
+    }
+
+    const userPreferenceParameters = options.preferences && options.preferences.parameters;
     try {
-        this.installMouthOverride();
+        this._applyEffectiveModelParameters(model, modelDirectoryParameters, userPreferenceParameters);
     } catch (e) {
-        console.error('安装口型覆盖失败:', e);
+        console.error('应用有效模型参数或安装口型覆盖失败:', e);
     }
     
     // 移除原本的 setInterval 定时器逻辑，改用 installMouthOverride 中的逐帧叠加逻辑
@@ -1893,14 +1985,6 @@ Live2DManager.prototype._configureLoadedModel = async function(model, modelPath,
         console.log('已启用参数叠加模式');
     }
     
-    // 在模型目录参数加载完成后，应用用户偏好参数（如果有）
-    // 此时所有异步操作（常驻表情、模型目录参数）都已完成，
-    // 可以安全地应用用户偏好参数而不需要使用 setTimeout 延迟
-    if (options.preferences && options.preferences.parameters && model.internalModel && model.internalModel.coreModel) {
-        this.applyModelParameters(model, options.preferences.parameters);
-        console.log('已应用用户偏好参数');
-    }
-
     // 确保 PIXI ticker 正在运行（防止从VRM切换后卡住）
     // 无条件调用 start()，因为它是幂等的（如果已在运行则不会有影响）
     if (this.pixi_app && this.pixi_app.ticker) {
@@ -1999,7 +2083,7 @@ Live2DManager.prototype._configureLoadedModel = async function(model, modelPath,
         }));
     } catch (_) {}
 
-    const suppressInitialIdle = options.suppressInitialIdle === true;
+    const suppressInitialIdle = options.suppressInitialIdle === true || this._parameterEditingMode;
 
     // 模型完全可见后播放 Idle 情绪（替代原来的独立 setTimeout）
     if (!suppressInitialIdle && (hasIdleInEmotionMapping || hasIdleInFileReferences)) {
@@ -2185,6 +2269,7 @@ Live2DManager.prototype.installMouthOverride = function() {
             .map(resolveSavedParamEntry)
             .filter(entry => entry && !isRuntimeManagedSavedParam(entry))
         : [];
+    const shouldApplyPersistentExpressions = this._parameterEditingMode !== true;
     const lookAtParamIndices = {};
     for (const id of ['ParamAngleX', 'ParamAngleY', 'ParamEyeBallX', 'ParamEyeBallY']) {
         try {
@@ -2407,7 +2492,7 @@ Live2DManager.prototype.installMouthOverride = function() {
                     }
                 }
                 // 2. 写入常驻表情参数（覆盖模式，优先级最高）
-                if (this.persistentExpressionParamsByName) {
+                if (shouldApplyPersistentExpressions && this.persistentExpressionParamsByName) {
                     for (const name in this.persistentExpressionParamsByName) {
                         const params = this.persistentExpressionParamsByName[name];
                         if (Array.isArray(params)) {
@@ -2483,7 +2568,7 @@ Live2DManager.prototype.installMouthOverride = function() {
 
             // 2. 写入常驻表情参数（跳过口型参数以避免覆盖lipsync）
             // 当点击效果正在淡入淡出时，跳过常驻表情写入以避免覆盖插值
-            if (this.persistentExpressionParamsByName && !this._clickFadeState) {
+            if (shouldApplyPersistentExpressions && this.persistentExpressionParamsByName && !this._clickFadeState) {
                 for (const name in this.persistentExpressionParamsByName) {
                     const params = this.persistentExpressionParamsByName[name];
                     if (Array.isArray(params)) {
@@ -2752,7 +2837,8 @@ Live2DManager.prototype.applyModelParameters = function(model, parameters) {
                 }
                 
                 // 跳过常驻表情已设置的参数（保护去水印等功能）
-                if (persistentParamIds.has(paramId) || persistentParamIds.has(resolvedParamId)) {
+                if (this._parameterEditingMode !== true
+                    && (persistentParamIds.has(paramId) || persistentParamIds.has(resolvedParamId))) {
                     continue;
                 }
                 

--- a/static/live2d/live2d-model.js
+++ b/static/live2d/live2d-model.js
@@ -1735,8 +1735,8 @@ Live2DManager.prototype._configureLoadedModel = async function(model, modelPath,
         this.pixi_app.view.style.opacity = '0';
     }
     
-    // 注意：用户偏好参数的应用延迟到模型目录参数加载完成后，
-    // 以确保正确的优先级顺序（模型目录参数 > 用户偏好参数）
+    // 注意：用户偏好参数会在模型目录参数加载完成后参与统一合并，
+    // 优先级顺序为：用户偏好参数 > 模型目录参数（用户偏好是权威来源）。
 
     // 添加到舞台
     this.pixi_app.stage.addChild(model);
@@ -1961,12 +1961,12 @@ Live2DManager.prototype._configureLoadedModel = async function(model, modelPath,
     if (this.modelName && model.internalModel && model.internalModel.coreModel) {
         try {
             modelDirectoryParameters = await this._loadModelDirectoryParameters(this.modelName);
-            // 【重要修复】Fetch 回来后，必须检查 Token！如果用户在此期间切了模型，直接中断！
-            if (!this._isLoadTokenActive(loadToken)) return;
         } catch (error) {
             console.error('加载模型参数失败:', error);
         }
     }
+    // 无论目录参数加载成功或失败，都必须阻止过期加载继续写入当前模型。
+    if (!this._isLoadTokenActive(loadToken)) return;
 
     const userPreferenceParameters = options.preferences && options.preferences.parameters;
     try {

--- a/tests/unit/test_live2d_parameter_persistence_static.py
+++ b/tests/unit/test_live2d_parameter_persistence_static.py
@@ -290,8 +290,24 @@ def test_parameter_save_treats_preferences_as_authoritative_and_sends_one_refres
     assert "if (prefSuccess)" in save_source
     assert "if (fileSuccess)" in save_source
     assert save_source.count("sendMessageToMainPage('reload_model_parameters'") == 1
+    assert "lanlan_name: getParameterEditorLanlanName()" in save_source
     assert "model_name: currentModelInfo.name" in save_source
     assert "model_path: currentModelInfo.path" in save_source
+
+
+def test_stale_load_token_is_checked_after_directory_parameter_failure():
+    source = LIVE2D_MODEL_PATH.read_text(encoding="utf-8")
+    configure_start = source.index("Live2DManager.prototype._configureLoadedModel")
+    configure_end = source.index("Live2DManager.prototype._applyTextureQuality", configure_start)
+    configure_source = source[configure_start:configure_end]
+
+    load_index = configure_source.index("await this._loadModelDirectoryParameters(this.modelName)")
+    catch_index = configure_source.index("console.error('加载模型参数失败:'", load_index)
+    token_index = configure_source.index("if (!this._isLoadTokenActive(loadToken)) return;", load_index)
+    apply_index = configure_source.index("this._applyEffectiveModelParameters(", load_index)
+
+    assert load_index < catch_index < token_index < apply_index
+    assert "模型目录参数 > 用户偏好参数" not in configure_source
 
 
 def test_file_save_failure_with_preference_success_survives_parameter_reload():

--- a/tests/unit/test_live2d_parameter_persistence_static.py
+++ b/tests/unit/test_live2d_parameter_persistence_static.py
@@ -1,0 +1,437 @@
+import json
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+LIVE2D_MODEL_PATH = PROJECT_ROOT / "static" / "live2d" / "live2d-model.js"
+LIVE2D_EMOTION_PATH = PROJECT_ROOT / "static" / "live2d" / "live2d-emotion.js"
+PARAMETER_EDITOR_PATH = PROJECT_ROOT / "static" / "js" / "live2d_parameter_editor.js"
+APP_INTERPAGE_PATH = PROJECT_ROOT / "static" / "app-interpage.js"
+MAO_PRO_MODEL_PATH = PROJECT_ROOT / "static" / "mao_pro" / "mao_pro.model3.json"
+
+
+def _run_node_harness(script: str) -> subprocess.CompletedProcess[str]:
+    node_executable = shutil.which("node")
+    if node_executable is None:
+        pytest.skip("node not found")
+    return subprocess.run(
+        [node_executable, "-"],
+        input=script,
+        text=True,
+        capture_output=True,
+        cwd=PROJECT_ROOT,
+        timeout=10,
+        check=False,
+    )
+
+
+def _manager_harness(body: str) -> str:
+    return textwrap.dedent(
+        f"""
+        const assert = require('node:assert');
+        const fs = require('node:fs');
+        const vm = require('node:vm');
+        const context = {{
+          console: {{ log() {{}}, warn() {{}}, error() {{}}, groupCollapsed() {{}}, groupEnd() {{}} }},
+          window: {{ LIPSYNC_PARAMS: ['ParamMouthOpenY', 'ParamMouthForm'] }},
+          Live2DManager: function Live2DManager() {{}},
+          fetch: async () => {{ throw new Error('unexpected fetch'); }},
+          performance: {{ now() {{ return 0; }} }},
+          setTimeout, clearTimeout, setInterval, clearInterval,
+        }};
+        context.global = context;
+        context.window.Live2DManager = context.Live2DManager;
+        vm.createContext(context);
+        vm.runInContext(fs.readFileSync({json.dumps(str(LIVE2D_MODEL_PATH))}, 'utf8'), context);
+        vm.runInContext(fs.readFileSync({json.dumps(str(LIVE2D_EMOTION_PATH))}, 'utf8'), context);
+        {body}
+        """
+    )
+
+
+def _extract_js_function(source: str, name: str) -> str:
+    start_candidates = [
+        source.find(f"function {name}"),
+        source.find(f"async function {name}"),
+    ]
+    start = min(candidate for candidate in start_candidates if candidate >= 0)
+    signature_end = source.index(")", start)
+    brace_start = source.index("{", signature_end)
+    depth = 0
+    for index in range(brace_start, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+    raise AssertionError(f"unterminated JavaScript function: {name}")
+
+
+def test_parameter_editor_mode_suppresses_idle_and_saved_parameter_overlay():
+    model_source = LIVE2D_MODEL_PATH.read_text(encoding="utf-8")
+    editor_source = PARAMETER_EDITOR_PATH.read_text(encoding="utf-8")
+    configure_start = model_source.index("Live2DManager.prototype._configureLoadedModel")
+    configure_end = model_source.index("Live2DManager.prototype._applyTextureQuality", configure_start)
+    configure_source = model_source[configure_start:configure_end]
+
+    assert "parameterEditingMode: true" in editor_source
+    assert "dragEnabled: true" in editor_source
+    assert "wheelEnabled: true" in editor_source
+    assert "options.suppressInitialIdle === true || this._parameterEditingMode" in model_source
+    assert "hasEffectiveParameters && this._parameterEditingMode !== true" in model_source
+    assert "shouldApplyPersistentExpressions = this._parameterEditingMode !== true" in model_source
+    assert "if (!suppressInitialIdle)" in model_source
+    assert "motionManager.stopAllMotions()" in configure_source
+    assert "expressionManager.stopAllExpressions()" in configure_source
+    assert configure_source.count("this._applyEffectiveModelParameters(") == 1
+
+
+def test_parameter_editor_saves_draft_instead_of_runtime_core_values():
+    source = PARAMETER_EDITOR_PATH.read_text(encoding="utf-8")
+    save_start = source.index("if (saveBtn) {\n    saveBtn.addEventListener")
+    save_source = source[save_start : source.index("// 初始化", save_start)]
+
+    assert "currentParameters" not in source
+    assert "draftParameters[paramId] = clampedValue" in source
+    assert "draftParameters[paramId] = resetValue" in source
+    assert "buildParametersFromDraft(draftParameters" in save_source
+    assert "coreModel.getParameterValueByIndex(i)" not in save_source
+
+    build_function = _extract_js_function(source, "buildParametersFromDraft")
+    script = textwrap.dedent(
+        f"""
+        const assert = require('node:assert');
+        {build_function}
+        const draft = {{ ParamAllColor1: 0.8, ParamAllColor2: 0.6 }};
+        const runtimeCoreValues = {{ ParamAllColor1: 0.8, ParamAllColor2: 0.6 }};
+        for (let frame = 0; frame < 30; frame += 1) {{
+          runtimeCoreValues.ParamAllColor1 = frame / 100;
+          runtimeCoreValues.ParamAllColor2 = 1 - frame / 100;
+        }}
+        const saved = buildParametersFromDraft(draft, {{ ParamAllColor1: 0, ParamAllColor2: 1 }}, {{
+          _isEyeBlinkParamId() {{ return false; }},
+        }});
+        assert.deepStrictEqual(saved, {{ ParamAllColor1: 0.8, ParamAllColor2: 0.6 }});
+        assert.notStrictEqual(saved.ParamAllColor1, runtimeCoreValues.ParamAllColor1);
+        """
+    )
+    result = _run_node_harness(script)
+    assert result.returncode == 0, result.stderr
+
+
+def test_user_preference_parameters_override_model_directory_parameters():
+    script = _manager_harness(
+        """
+        const manager = new context.Live2DManager();
+        const effective = manager._mergeEffectiveModelParameters(
+          { ParamAllColor1: 0.1, ParamAllColor2: 0.2, ParamHair: 0.3 },
+          { ParamAllColor1: 0.8, ParamAllColor2: 0.9 },
+        );
+        assert.deepStrictEqual(
+          JSON.parse(JSON.stringify(effective)),
+          { ParamAllColor1: 0.8, ParamAllColor2: 0.9, ParamHair: 0.3 },
+        );
+        """
+    )
+    result = _run_node_harness(script)
+    assert result.returncode == 0, result.stderr
+
+
+def test_effective_parameter_refresh_reinstalls_overlay_with_new_values():
+    script = _manager_harness(
+        """
+        const manager = new context.Live2DManager();
+        manager._parameterEditingMode = false;
+        manager.applyModelParameters = (_model, parameters) => {
+          manager.lastApplied = { ...parameters };
+        };
+        manager.installMouthOverride = () => {
+          manager.installedSnapshot = { ...(manager.savedModelParameters || {}) };
+          manager.installCount = (manager.installCount || 0) + 1;
+        };
+        const model = { internalModel: { coreModel: {} } };
+
+        manager._applyEffectiveModelParameters(model, { ParamAllColor1: 0.2 }, {});
+        manager._applyEffectiveModelParameters(model, { ParamAllColor1: 0.2 }, { ParamAllColor1: 0.8 });
+
+        assert.strictEqual(manager.lastApplied.ParamAllColor1, 0.8);
+        assert.strictEqual(manager.installedSnapshot.ParamAllColor1, 0.8);
+        assert.strictEqual(manager.installCount, 2);
+        assert.strictEqual(manager._shouldApplySavedParams, true);
+        """
+    )
+    result = _run_node_harness(script)
+    assert result.returncode == 0, result.stderr
+
+
+def test_editing_mode_effective_parameters_override_stopped_persistent_expression_values():
+    script = _manager_harness(
+        """
+        const ids = ['ParamAllColor1'];
+        const values = [0.2];
+        const coreModel = {
+          getParameterCount() { return 1; },
+          getParameterId(index) { return ids[index]; },
+          getParameterIndex(id) { return ids.indexOf(id); },
+          setParameterValueByIndex(index, value) { values[index] = value; },
+        };
+        const manager = new context.Live2DManager();
+        manager._parameterEditingMode = true;
+        manager.initialParameters = { ParamAllColor1: 0 };
+        manager.appearanceBaselineParameters = {};
+        manager.persistentExpressionParamsByName = {
+          resident: [{ Id: 'ParamAllColor1', Value: 0.2 }],
+        };
+        manager.installMouthOverride = () => {};
+        manager._applyEffectiveModelParameters(
+          { internalModel: { coreModel } },
+          { ParamAllColor1: 0.1 },
+          { ParamAllColor1: 0.8 },
+        );
+        assert.strictEqual(values[0], 0.8);
+        assert.strictEqual(manager.appearanceBaselineParameters.ParamAllColor1, 0.8);
+        assert.strictEqual(manager._shouldApplySavedParams, false);
+        """
+    )
+    result = _run_node_harness(script)
+    assert result.returncode == 0, result.stderr
+
+
+def test_editing_mode_overlay_does_not_overwrite_slider_value_across_frames():
+    script = _manager_harness(
+        """
+        const ids = ['ParamAllColor1'];
+        const values = [0.1];
+        const coreModel = {
+          getParameterCount() { return ids.length; },
+          getParameterId(index) { return ids[index]; },
+          getParameterIndex(id) { return ids.indexOf(id); },
+          getParameterValueByIndex(index) { return values[index]; },
+          getParameterDefaultValueByIndex() { return 0; },
+          setParameterValueByIndex(index, value) { values[index] = value; },
+          setParameterValueById(id, value) { values[ids.indexOf(id)] = value; },
+          update() {},
+        };
+        const motionManager = { state: { currentPriority: 0 }, update() {} };
+        const manager = new context.Live2DManager();
+        manager.currentModel = { deltaTime: 16.66, internalModel: { coreModel, motionManager } };
+        manager._parameterEditingMode = true;
+        manager.savedModelParameters = { ParamAllColor1: 0.1 };
+        manager._shouldApplySavedParams = false;
+        manager._mouseTrackingEnabled = true;
+        manager._autoEyeBlinkEnabled = false;
+        manager.mouthValue = 0;
+        manager.persistentExpressionParamsByName = {
+          resident: [{ Id: 'ParamAllColor1', Value: 0.2 }],
+        };
+
+        manager.installMouthOverride();
+        values[0] = 0.8;
+        for (let frame = 0; frame < 30; frame += 1) {
+          motionManager.update(0.016);
+          coreModel.update();
+        }
+        assert.strictEqual(values[0], 0.8);
+        """
+    )
+    result = _run_node_harness(script)
+    assert result.returncode == 0, result.stderr
+
+
+def test_clear_expression_restores_only_active_ids_to_appearance_baseline():
+    script = _manager_harness(
+        """
+        const ids = ['ParamAllColor1', 'ParamUnrelated'];
+        const values = [0.1, 0.7];
+        const coreModel = {
+          getParameterIndex(id) { return ids.indexOf(id); },
+          getParameterId(index) { return ids[index]; },
+          setParameterValueById(id, value) { values[ids.indexOf(id)] = value; },
+          setParameterValueByIndex(index, value) { values[index] = value; },
+        };
+        let stopped = 0;
+        let persistentReplayed = 0;
+        const manager = new context.Live2DManager();
+        manager.currentModel = { internalModel: { coreModel, motionManager: {
+          expressionManager: { stopAllExpressions() { stopped += 1; } },
+        } } };
+        manager.initialParameters = { ParamAllColor1: 0, ParamUnrelated: 0 };
+        manager.motionBaselineParameters = {};
+        manager.appearanceBaselineParameters = { ParamAllColor1: 0.8, ParamUnrelated: 0.4 };
+        manager._activeExpressionParamIds = new Set(['ParamAllColor1']);
+        manager._cancelSmoothReset = () => {};
+        manager._removeManualExpressionOverride = () => {};
+        manager.applyPersistentExpressionsNative = () => { persistentReplayed += 1; };
+
+        manager.clearExpression();
+
+        assert.strictEqual(values[0], 0.8);
+        assert.strictEqual(values[1], 0.7);
+        assert.strictEqual(stopped, 1);
+        assert.strictEqual(persistentReplayed, 1);
+        """
+    )
+    result = _run_node_harness(script)
+    assert result.returncode == 0, result.stderr
+
+
+def test_parameter_save_treats_preferences_as_authoritative_and_sends_one_refresh():
+    source = PARAMETER_EDITOR_PATH.read_text(encoding="utf-8")
+    save_start = source.index("if (saveBtn) {\n    saveBtn.addEventListener")
+    save_source = source[save_start : source.index("// 初始化", save_start)]
+
+    assert "if (prefSuccess)" in save_source
+    assert "if (fileSuccess)" in save_source
+    assert save_source.count("sendMessageToMainPage('reload_model_parameters'") == 1
+    assert "model_name: currentModelInfo.name" in save_source
+    assert "model_path: currentModelInfo.path" in save_source
+
+
+def test_file_save_failure_with_preference_success_survives_parameter_reload():
+    editor_source = PARAMETER_EDITOR_PATH.read_text(encoding="utf-8")
+    persist_function = _extract_js_function(editor_source, "persistParameterDraft")
+    script = _manager_harness(
+        f"""
+        vm.runInContext({json.dumps(persist_function)}, context);
+        (async () => {{
+          const modelPath = '/static/mao_pro/mao_pro.model3.json';
+          let storedPreference = null;
+          const values = [0];
+          const ids = ['ParamAllColor1'];
+          const coreModel = {{
+            getParameterCount() {{ return 1; }},
+            getParameterId(index) {{ return ids[index]; }},
+            getParameterIndex(id) {{ return ids.indexOf(id); }},
+            getParameterValueByIndex(index) {{ return values[index]; }},
+            setParameterValueByIndex(index, value) {{ values[index] = value; }},
+          }};
+          const model = {{ x: 10, y: 20, scale: {{ x: 1, y: 1 }}, internalModel: {{ coreModel }} }};
+          const manager = new context.Live2DManager();
+          manager.currentModel = model;
+          manager.modelName = 'mao_pro';
+          manager._lastLoadedModelPath = modelPath;
+          manager.initialParameters = {{ ParamAllColor1: 0 }};
+          manager.appearanceBaselineParameters = {{}};
+          manager.motionBaselineParameters = {{}};
+          manager._parameterEditingMode = false;
+          manager.getPersistentExpressionParamIds = () => new Set();
+          manager.saveUserPreferences = async (path, position, scale, parameters) => {{
+            storedPreference = {{ model_path: path, position, scale, parameters: {{ ...parameters }} }};
+            return true;
+          }};
+          manager._loadModelDirectoryParameters = async () => ({{ ParamAllColor1: 0.1 }});
+          manager.loadUserPreferences = async () => [storedPreference];
+          manager.installMouthOverride = () => {{
+            manager.installedSnapshot = {{ ...(manager.savedModelParameters || {{}}) }};
+          }};
+
+          const saveResult = await context.persistParameterDraft(
+            {{ name: 'mao_pro', path: modelPath }},
+            model,
+            {{ ParamAllColor1: 0.8 }},
+            {{
+              manager,
+              fetchImpl: async () => ({{
+                ok: false,
+                status: 403,
+                async json() {{ return {{ success: false, error: 'read-only' }}; }},
+              }}),
+            }},
+          );
+          assert.strictEqual(saveResult.fileSuccess, false);
+          assert.strictEqual(saveResult.prefSuccess, true);
+          assert.strictEqual(storedPreference.parameters.ParamAllColor1, 0.8);
+
+          const totalFailure = await context.persistParameterDraft(
+            {{ name: 'mao_pro', path: modelPath }},
+            model,
+            {{ ParamAllColor1: 0.9 }},
+            {{
+              manager: {{ saveUserPreferences: async () => false }},
+              fetchImpl: async () => {{ throw new Error('read-only'); }},
+            }},
+          );
+          assert.strictEqual(totalFailure.fileSuccess, false);
+          assert.strictEqual(totalFailure.prefSuccess, false);
+
+          values[0] = 0;
+          const reloadResult = await manager.reloadModelParameters({{
+            model_name: 'mao_pro',
+            model_path: modelPath,
+          }});
+          assert.strictEqual(reloadResult.applied, true);
+          assert.strictEqual(values[0], 0.8);
+          assert.strictEqual(manager.savedModelParameters.ParamAllColor1, 0.8);
+          assert.strictEqual(manager.appearanceBaselineParameters.ParamAllColor1, 0.8);
+          assert.strictEqual(manager.installedSnapshot.ParamAllColor1, 0.8);
+        }})().catch((error) => {{ console.error(error); process.exitCode = 1; }});
+        """
+    )
+    result = _run_node_harness(script)
+    assert result.returncode == 0, result.stderr
+
+
+def test_reload_model_parameters_is_received_on_all_cross_page_channels():
+    source = APP_INTERPAGE_PATH.read_text(encoding="utf-8")
+
+    assert "async function handleReloadModelParametersMessage" in source
+    assert "case 'reload_model_parameters':" in source
+    assert "event.data.action === 'reload_model_parameters'" in source
+    assert "event.key !== 'nekopage_message'" in source
+    assert "参数轻量热刷新失败，降级为完整模型重载" in source
+
+
+def test_all_mao_pro_motions_restore_saved_hair_colors_from_appearance_baseline():
+    model_config = json.loads(MAO_PRO_MODEL_PATH.read_text(encoding="utf-8"))
+    motion_files = {
+        motion["File"]
+        for motions in model_config["FileReferences"]["Motions"].values()
+        for motion in motions
+    }
+    assert len(motion_files) == 7
+
+    motion_paths = [MAO_PRO_MODEL_PATH.parent / relative_path for relative_path in sorted(motion_files)]
+    for motion_path in motion_paths:
+        motion = json.loads(motion_path.read_text(encoding="utf-8"))
+        parameter_ids = {
+            curve["Id"]
+            for curve in motion.get("Curves", [])
+            if curve.get("Target") == "Parameter"
+        }
+        assert {"ParamAllColor1", "ParamAllColor2"} <= parameter_ids, motion_path.name
+
+    script = _manager_harness(
+        f"""
+        const motionPaths = {json.dumps([str(path) for path in motion_paths])};
+        const ids = ['ParamAllColor1', 'ParamAllColor2'];
+        const values = [0, 0];
+        const coreModel = {{
+          getParameterIndex(id) {{ return ids.indexOf(id); }},
+          setParameterValueById(id, value) {{ values[ids.indexOf(id)] = value; }},
+        }};
+        const manager = new context.Live2DManager();
+        manager.currentModel = {{ internalModel: {{ coreModel }} }};
+        manager.initialParameters = {{ ParamAllColor1: 0, ParamAllColor2: 0 }};
+        manager.motionBaselineParameters = {{}};
+        manager.appearanceBaselineParameters = {{ ParamAllColor1: 0.8, ParamAllColor2: 0.6 }};
+
+        for (const motionPath of motionPaths) {{
+          const motion = JSON.parse(fs.readFileSync(motionPath, 'utf8'));
+          manager._trackActiveMotionParametersFromData(motion);
+          values[0] = 0;
+          values[1] = 0;
+          manager._resetActiveMotionParameters({{ preserveExpression: false }});
+          assert.strictEqual(values[0], 0.8, motionPath);
+          assert.strictEqual(values[1], 0.6, motionPath);
+        }}
+        """
+    )
+    result = _run_node_harness(script)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## 改动概述 / Summary  修复 Live2D 参数编辑器中外观参数（例如头发颜色）在对话触发表情或动作后被恢复为旧值的问题。  根因包括：编辑器保存时重新读取包含 motion、物理和呼吸瞬时状态的 `coreModel`；模型目录参数与用户偏好存在两套优先级不一致的数据源；保存参数及常驻表情在多个逐帧写入点覆盖滑块值；`clearExpression()` 会把全部参数恢复到模型原始基准。  本 PR：  - 为参数编辑器增加默认关闭的 `parameterEditingMode`，编辑期间停止 Idle、motion 和 expression，并禁用保存参数及常驻表情的逐帧覆盖。 - 使用独立 `draftParameters` 作为保存来源，滑块和重置操作同步更新草稿，保存阶段不再遍历运行时 `coreModel`。 - 统一以用户偏好覆盖模型目录 `parameters.json`，更新 `savedModelParameters`、外观基准并重新安装逐帧覆盖闭包。 - 让 expression 与 motion 清理只恢复实际受影响的参数到用户外观基准。 - 接通 `reload_model_parameters` 跨页轻量热刷新，并在失败时降级完整模型重载。 - 将用户偏好保存视为核心成功；只读安装目录导致兼容镜像写入失败时保留用户修改并显示警告。  用户影响：参数编辑器中保存的颜色等外观值，在对话、表情、动作、页面热刷新及只读安装目录场景下均保持稳定。普通主页加载行为由默认关闭的编辑模式隔离。 ## 展示 <img width=1359 height=934 alt=fb7283c6725931286e81fe0a7ee5c7b3 src=https://github.com/user-attachments/assets/e7447c8c-3108-4aea-aca4-1a325d2c5e57 />   ## 回归报告 / Regression Report  不适用：未修改 `app/`、`main_logic/`、`main_routers/` 或 `memory/` 下的 Python 文件。  ## 不拆分理由 / Why Not Split  不适用：本 PR 仅修改 4 个计入上限的前端源文件，并新增 1 个测试文件。  ## 测试 / Testing  - `uv run pytest tests/unit/test_live2d_interaction_static_contracts.py tests/unit/test_live2d_init_static_contracts.py tests/unit/test_master_emotion.py tests/unit/test_live2d_appearance_baseline_static.py tests/unit/test_live2d_parameter_persistence_static.py -q`：65 passed - `node --check`：`static/live2d/live2d-model.js`、`static/live2d/live2d-emotion.js`、`static/js/live2d_parameter_editor.js`、`static/app-interpage.js` 全部通过 - `git diff --check`：通过 - GitNexus `detect-changes --scope compare --base-ref main`：LOW，0 个受影响执行流程  新增回归覆盖包括：编辑模式不启动 Idle、等待多帧后草稿仍保存 0.8、旧保存值和常驻表情不覆盖滑块、用户偏好优先、只读目录保存降级、参数热刷新重装闭包、`clearExpression()` 保持外观基准，以及 `mao_pro` 全部 7 个 motion 的颜色恢复。   <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **新功能**
  * 参数编辑器新增独立草稿机制，并以有效参数作为回填来源。
  * 合并模型目录参数与用户偏好参数，按“偏好优先”应用；支持参数编辑模式。
  * 保存后支持轻量刷新主页模型参数；跨页路由新增 `reload_model_parameters` 分发与降级策略。

* **问题修复**
  * 清除表情时改为仅回滚受影响的活动参数到基线，并提供降级恢复路径。
  * 参数编辑模式下抑制初始待机/相关覆盖，提升编辑稳定性。

* **测试**
  * 新增静态打包参数持久化与跨页刷新覆盖用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->