### PR TITLE
fix(core): 修复热切换 final swap 僵尸化——外层取消被步骤1吞噬后无锁 promote 毒化并发会话

### DIFF
--- a/main_logic/core/lifecycle.py
+++ b/main_logic/core/lifecycle.py
@@ -1692,7 +1692,16 @@ class LifecycleMixin:
                         logger.debug(f"Final Swap Sequence: 超时中止时关闭 new_session 失败（可忽略）: {_e}")
                     raise RuntimeError("旧 listener 取消超时，热切换中止")
                 except asyncio.CancelledError:
-                    pass
+                    # 这里只允许吞"刚被 cancel 的旧 listener 抛回的取消回波"。
+                    # 外层对 final_swap_task 自身的取消（_reset_preparation_state /
+                    # end_session）在此 await 点抛的同样是 CancelledError：若一并吞掉，
+                    # swap 会活过取消（_wait_one 2s 超时后 final_swap_task 失去追踪），
+                    # 稍后无锁 promote self.session，毒化/覆盖新 start_session 的赢家。
+                    # cancelling() > 0 表示本任务有未确认的取消请求 —— re-raise 交给
+                    # 外层 CancelledError 处理器关闭 new_session 并重置状态。
+                    _swap_task = asyncio.current_task()
+                    if _swap_task is not None and _swap_task.cancelling() > 0:
+                        raise
                 except Exception as e:
                     logger.warning(f"Final Swap Sequence: Old task exited with error: {e}")
 
@@ -1703,10 +1712,38 @@ class LifecycleMixin:
                 except Exception as e:
                     logger.error(f"💥 Final Swap Sequence: Error closing old session: {e}")
 
+            # ── promote 前的协作取消检查点 ───────────────────────────────────────
+            # Python 3.11 的 asyncio.wait_for（步骤 1）以及部分 session.close()（步骤 2）
+            # 在外层取消恰好落在其内层 await 已完成之后时，会把该取消“正常返回”式吞掉
+            # —— except CancelledError 分支不触发，僵尸带着 cancelling()>0 继续走到 promote。
+            # 步骤 1 的 except 只能拦到 wait_for *抛出* 取消的路径，拦不到这条“被吞”的路径。
+            # 这里在真正改 self.session 之前补一次显式检查：只要本任务有未确认的取消请求，
+            # 就 re-raise 交给下面的 CancelledError 处理器关闭 new_session、重置状态。
+            # 对正常热切换零影响（无外层取消时 cancelling()==0）。
+            _swap_task = asyncio.current_task()
+            if _swap_task is not None and _swap_task.cancelling() > 0:
+                raise asyncio.CancelledError()
+
             # ── 步骤 3：promote 新 session ────────────────────────────────────────
             # 旧 listener 已停、旧 session 已关，现在切换 self.session；
             # 此后旧 task 的任何回调若再执行也已看不到旧 ws。
-            self.session = new_session
+            # 镜像启动侧的强 CAS（_start_session_start_llm 的持锁提升）：整段 swap
+            # 期间本函数从不改 self.session，正常路径它必然仍是入口快照的
+            # old_main_session；任何偏离都意味着并发 start/end_session 已接管会话
+            # （典型：swap 被取消但存活成僵尸后，新 start_session 已清场或已就位），
+            # 此时覆盖 self.session 会孤儿化赢家 —— 中止 swap 并关闭 new_session。
+            # 不回滚共享准备状态：它已属于接管方的新纪元，由接管方管理。
+            async with self.lock:
+                _promote_allowed = self.session is old_main_session
+                if _promote_allowed:
+                    self.session = new_session
+            if not _promote_allowed:
+                logger.warning("⚠️ Final Swap Sequence: promote 时 self.session 已被并发接管，中止 swap 并关闭 new_session")
+                try:
+                    await new_session.close()
+                except Exception as _e:
+                    logger.debug(f"Final Swap Sequence: 中止 promote 时关闭 new_session 失败（可忽略）: {_e}")
+                return
             self._require_context_append_current_delivery = True
             next_context_count_at_promote = len(self._snapshot_next_session_context_messages())
             await self._apply_pending_tts_route_after_swap()

--- a/tests/unit/test_hot_swap_cancellation.py
+++ b/tests/unit/test_hot_swap_cancellation.py
@@ -86,6 +86,8 @@ async def _drain_task(task):
     try:
         await task
     except (asyncio.CancelledError, Exception):
+        # Best-effort teardown: the task is being cancelled on purpose, so its
+        # cancellation (or any error surfacing as it unwinds) is expected and moot.
         pass
 
 
@@ -163,6 +165,9 @@ async def test_final_swap_swallowed_cancel_still_aborts_before_promote():
             try:
                 await asyncio.sleep(0)
             except asyncio.CancelledError:
+                # Swallow it on purpose — this IS the swallow being reproduced:
+                # the cancel is consumed here so _must_cancel clears while
+                # cancelling() stays 1, mimicking wait_for/close eating the cancel.
                 pass
 
     old_session = _SwallowExternalCancelOnClose("old")

--- a/tests/unit/test_hot_swap_cancellation.py
+++ b/tests/unit/test_hot_swap_cancellation.py
@@ -1,0 +1,258 @@
+"""Regression tests for final-swap cancellation and concurrent takeover.
+
+Covers the latent zombie-swap defect confirmed during PR #2272 review:
+step 1 of ``_perform_final_swap_sequence`` swallows ``CancelledError``
+intending to absorb the just-cancelled old listener's echo, but an external
+cancellation of ``final_swap_task`` itself surfaces the same exception type.
+If it survives to the unlocked promote, the swap poisons or overwrites the
+concurrent ``start_session`` winner. The fix combines three guards:
+
+- step 1's ``except CancelledError`` re-raises when ``cancelling() > 0``
+  (distinguishes the external cancel that *raises* from the listener echo);
+- a pre-promote checkpoint re-raises when ``cancelling() > 0`` even if
+  ``wait_for``/``close`` *swallowed* the cancel (Python 3.11 returns
+  ``fut.result()`` and clears ``_must_cancel`` without re-raising);
+- the promote itself is a locked CAS mirroring the start-side guard.
+"""
+import asyncio
+
+import pytest
+
+import main_logic.core as core_module
+
+
+class _FakeSession:
+    def __init__(self, name):
+        self.name = name
+        self.closed = False
+        self.prime_calls = []
+
+    async def prime_context(self, text, *, skipped=False):
+        self.prime_calls.append((text, skipped))
+
+    async def close(self):
+        self.closed = True
+
+    async def handle_messages(self):
+        await asyncio.Event().wait()
+
+
+async def _noop_async(*args, **kwargs):
+    return None
+
+
+def _make_swap_manager():
+    mgr = object.__new__(core_module.LLMSessionManager)
+    mgr.lanlan_name = "Lan"
+    mgr.master_name = "Master"
+    mgr.user_language = "zh"
+    mgr.lock = asyncio.Lock()
+    mgr.session = None
+    mgr.message_handler_task = None
+    mgr.pending_session = None
+    mgr.background_preparation_task = None
+    mgr.final_swap_task = None
+    mgr.pending_session_warmed_up_event = None
+    mgr.pending_session_final_prime_complete_event = None
+    mgr.pending_use_tts = None
+    mgr.is_hot_swap_imminent = False
+    mgr.is_active = False
+    mgr.is_preparing_new_session = False
+    mgr._require_context_append_current_delivery = False
+    mgr.summary_triggered_time = None
+    mgr.initial_cache_snapshot_len = 0
+    mgr.initial_next_session_context_snapshot_len = 0
+    mgr.message_cache_for_new_session = []
+    mgr.next_session_context_messages = []
+    mgr.pending_extra_replies = []
+    mgr.current_speech_id = None
+    mgr.send_status = _noop_async
+    # Peripheral post-step-3 actions are irrelevant here; collapse to no-ops.
+    mgr._apply_pending_tts_route_after_swap = _noop_async
+    mgr._sync_tools_to_active_session = _noop_async
+
+    async def _prime_late(*args, **kwargs):
+        return 0
+
+    mgr._prime_late_next_session_context_after_swap = _prime_late
+    mgr._flush_hot_swap_audio_cache = _noop_async
+    return mgr
+
+
+async def _drain_task(task):
+    if task is None or task.done():
+        return
+    task.cancel()
+    try:
+        await task
+    except (asyncio.CancelledError, Exception):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_final_swap_cancelled_at_step1_does_not_promote_zombie():
+    """A swap parked at step 1's wait_for(old listener) then cancelled by
+    _reset_preparation_state must not survive as a zombie: no promote, the
+    new_session gets closed, and no task reference leaks."""
+    mgr = _make_swap_manager()
+    old_session = _FakeSession("old")
+    new_session = _FakeSession("pending")
+    mgr.session = old_session
+    mgr.pending_session = new_session
+    mgr.is_hot_swap_imminent = True
+
+    listener_cancelled = asyncio.Event()
+
+    async def _stubborn_listener():
+        # Absorb the first cancel (models the old listener stuck in recv())
+        # so the swap parks on wait_for's await point waiting for it.
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            listener_cancelled.set()
+            await asyncio.Event().wait()
+            raise
+
+    mgr.message_handler_task = asyncio.create_task(_stubborn_listener())
+    await asyncio.sleep(0)
+
+    mgr.final_swap_task = asyncio.create_task(mgr._perform_final_swap_sequence())
+    swap_task = mgr.final_swap_task
+    # The old listener receiving cancel proves the swap reached step 1 and is
+    # parked on wait_for.
+    await asyncio.wait_for(listener_cancelled.wait(), timeout=5)
+    await asyncio.sleep(0)
+
+    try:
+        # Model a new start_session prelude cancelling the in-flight swap.
+        await asyncio.wait_for(
+            mgr._reset_preparation_state(clear_main_cache=True), timeout=5
+        )
+
+        # Outcome-focused: the swap terminated without promoting. We assert the
+        # observable results rather than swap_task.cancelled(), which couples to
+        # the exact way the outer handler winds the task down.
+        assert swap_task.done()
+        assert mgr.session is old_session, "zombie swap must not promote self.session"
+        assert new_session.closed, "the cancelled swap must close new_session (no ws leak)"
+        assert not old_session.closed, "cancel landed before step 2; old session is the takeover's to close"
+        assert mgr.final_swap_task is None, "final_swap_task reference must not leak"
+        assert mgr.is_hot_swap_imminent is False
+    finally:
+        await _drain_task(mgr.message_handler_task)
+
+
+@pytest.mark.asyncio
+async def test_final_swap_swallowed_cancel_still_aborts_before_promote():
+    """The pre-promote checkpoint: even when the external cancel is *swallowed*
+    by an await (Python 3.11 wait_for/close returns normally, clearing
+    _must_cancel while cancelling() stays > 0), the swap must still abort before
+    overwriting self.session. Without the checkpoint the CAS would wave the
+    zombie through, since self.session is still old_main_session at promote."""
+    mgr = _make_swap_manager()
+    new_session = _FakeSession("pending")
+
+    class _SwallowExternalCancelOnClose(_FakeSession):
+        async def close(self):
+            await super().close()
+            # Reproduce the 3.11 quirk deterministically: an external cancel
+            # arrives and is consumed by an inner await that eats it, leaving
+            # _must_cancel cleared but cancelling() == 1.
+            t = asyncio.current_task()
+            t.cancel()
+            try:
+                await asyncio.sleep(0)
+            except asyncio.CancelledError:
+                pass
+
+    old_session = _SwallowExternalCancelOnClose("old")
+    mgr.session = old_session
+    mgr.pending_session = new_session
+    mgr.is_hot_swap_imminent = True
+    mgr.message_handler_task = None  # old listener already gone; step 1 is skipped
+
+    # The checkpoint raises CancelledError, which the swap's own
+    # ``except CancelledError`` handler catches and cleans up after — so the
+    # coroutine returns normally rather than propagating.
+    await mgr._perform_final_swap_sequence()
+
+    assert mgr.session is old_session, "swallowed external cancel must still abort before promote"
+    assert new_session.closed, "aborted swap must close new_session"
+    assert mgr.is_hot_swap_imminent is False
+
+
+@pytest.mark.asyncio
+async def test_final_swap_promote_aborts_when_session_taken_over():
+    """Promote-side CAS: when self.session is taken over mid-swap (cleared or
+    replaced by a concurrent winner), the swap must abort and close its
+    new_session instead of overwriting the winner."""
+    mgr = _make_swap_manager()
+    winner_session = _FakeSession("winner")
+    winner_listener = object()
+    new_session = _FakeSession("pending")
+
+    class _TakeoverOnClose(_FakeSession):
+        async def close(self):
+            await super().close()
+            # Inside step 2's close() await window, a new start_session finishes
+            # its takeover.
+            mgr.session = winner_session
+            mgr.message_handler_task = winner_listener
+
+    old_session = _TakeoverOnClose("old")
+    mgr.session = old_session
+    mgr.pending_session = new_session
+    mgr.is_hot_swap_imminent = True
+    mgr.message_handler_task = None  # old listener already gone; step 1 is skipped
+
+    await mgr._perform_final_swap_sequence()
+
+    assert mgr.session is winner_session, "swap must not overwrite the concurrently promoted winner"
+    assert mgr.message_handler_task is winner_listener, "winner's listener must not be replaced"
+    assert new_session.closed, "aborting the promote must close new_session"
+    assert mgr.is_hot_swap_imminent is False
+
+
+@pytest.mark.asyncio
+async def test_final_swap_happy_path_still_promotes():
+    """An uninterfered hot swap still completes end to end: the old listener's
+    cancellation echo is swallowed (not re-raised), the old session closes, the
+    new session promotes, and step 4 starts a *fresh* listener."""
+    mgr = _make_swap_manager()
+    old_session = _FakeSession("old")
+    new_session = _FakeSession("pending")
+    mgr.session = old_session
+    mgr.pending_session = new_session
+    mgr.is_hot_swap_imminent = True
+
+    echo_raised = asyncio.Event()
+
+    async def _old_listener():
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            # Pin the echo path: step 1's wait_for must actually see the old
+            # listener's cancellation surface, otherwise (a)'s "swallow the
+            # echo" branch has zero coverage yet the test still passes.
+            echo_raised.set()
+            raise
+
+    old_listener_task = asyncio.create_task(_old_listener())
+    mgr.message_handler_task = old_listener_task
+    await asyncio.sleep(0)
+
+    try:
+        await mgr._perform_final_swap_sequence()
+
+        assert echo_raised.is_set(), "old listener's cancel echo must reach wait_for (echo-swallow branch coverage)"
+        assert mgr.session is new_session
+        assert old_session.closed
+        assert not new_session.closed
+        assert mgr.pending_session is None
+        assert mgr.is_hot_swap_imminent is False
+        assert mgr.message_handler_task is not None
+        assert mgr.message_handler_task is not old_listener_task, "step 4 must start a fresh listener, not keep the old one"
+        assert not mgr.message_handler_task.done(), "the fresh listener should be running"
+    finally:
+        await _drain_task(mgr.message_handler_task)
+        await _drain_task(old_listener_task)


### PR DESCRIPTION
## 背景

存量并发缺陷，PR #2272 review 期间深挖确认（**非该 PR 引入**，纯搬迁前的 `core/__init__.py` 已存在）。触及 race-tested 热切换链路，动手前已与维护者确认取舍（拍板 a+b，对抗审查追加 checkpoint）。#2272 相关 thread 有完整讨论存档。

## 根因

`main_logic/core/lifecycle.py` 的 `_perform_final_swap_sequence` 步骤 1：

```python
await asyncio.wait_for(old_main_message_handler_task, timeout=2.0)
...
except asyncio.CancelledError:
    pass   # ← 本意吞"旧 listener 被 cancel 抛回的取消回波"
```

外层对 `final_swap_task` 自身的取消（`start_session` 前奏的 `_reset_preparation_state` / `end_session`）在同一 `await` 点抛的**同样是 `CancelledError`**，被一并吞掉。`_reset_preparation_state` 的 `_wait_one` 只等 2s，超时即把 `self.final_swap_task` 置 `None` **丢失追踪**，僵尸 swap 存活并稍后无锁执行 `self.session = new_session`。

## 后果（两种时序）

1. **僵尸 promote 落在新 `start_session` 的 CAS 之前** → CAS 落败走 `_llm_concurrent_aborted` 分支不递减 guard。前端 15s 超时的 `end_session` 走 inactive-early 路径只重置计数器、**不清 `self.session`**；且无任何路径会在 `is_active=False` 时清掉非 `None` 的 `self.session`（retire 分支有 `is_active` 门禁，僵尸成功路径从不置 `is_active=True`）→ **每次重试 CAS 都重新输给同一毒化 session，每轮烧一条 LLM 连接，功能性 livelock 直到切角色/重启**。
2. **僵尸 promote 落在 CAS 之后** → 静默覆盖刚赢的 session 并替换其 listener，**孤儿化赢家**。

**触发条件合取**（低概率高危害）：热切换 swap 恰停在步骤 1（每次 audio 热切换必经，窗口 ms~2s）时来了新 `start_session`（模式切换/重连常落在 turn 边界，与热切换同源）；被吞取消后 swap 耗时 >2s（慢 ws close 握手/prime）；promote 落进新 start 数秒级 connect 窗口。

## 修复（三层）

- **(a)** 步骤 1 的 `except CancelledError` 在 `asyncio.current_task().cancelling() > 0` 时 `raise`，区分"旧 listener 回波"（吞）与"外层任务取消"（交给外层 `CancelledError` handler 关 `new_session`、重置状态）。
- **(b)** 步骤 3 promote 镜像启动侧（`_start_session_start_llm`）的**持锁强 CAS**：仅当 `self.session is old_main_session` 才赋值，否则中止 swap、关闭 `new_session`、`return`（不回滚接管方新纪元的共享准备状态，由接管方管理）。
- **(c)** promote 前**协作取消检查点**：Python 3.11 的 `asyncio.wait_for`（步骤 1）与部分 `session.close()`（步骤 2）在外层取消恰落于内层 `await` 完成之后时会把取消**"正常返回"式吞掉**（`except` 分支不触发但 `cancelling()>0` 保留），(a) 拦不到这条被吞路径。promote 前显式检查 `cancelling()>0` 再 `raise`。覆盖 `wait_for`/`close` 吞取消及 CAS 基线晚快照等同源变体。

> (c) 来自对本修复的对抗式多视角审查（asyncio 取消语义 / 锁序 / 状态机残留 / 测试有效性 / 回归风险），在项目实际解释器 3.11.13 上复现了 `wait_for` 吞取消语义后追加。

## 回归报告

- **新增测试** `tests/unit/test_hot_swap_cancellation.py`（4 例，全绿）：
  1. 停在步骤 1 被 `_reset_preparation_state` 取消 → 不 promote、`new_session` 关闭、`final_swap_task` 不泄漏；
  2. 被**吞掉**的外层取消（3.11 `wait_for`/`close` quirk，`_must_cancel` 已清但 `cancelling()>0`）仍在 promote 前中止；
  3. promote CAS 落败 → 关闭 `new_session` 不覆盖赢家、不替换其 listener；
  4. 正常热切换仍完整走通（旧 listener 回波被吞、旧 session 关、新 session promote、步骤 4 起**新** listener），并钉住"回波确实抛回 `wait_for`"的分支覆盖。
- **红绿验证**：未修复代码下 1/2/3 三个防御测试全红、happy path 绿；单独禁用 checkpoint（保留 a+b）仅"被吞取消"测试变红 → 证明 checkpoint **非冗余**。
- **全量回归**：同一 worktree `clean`（移走本改动）vs `fixed` 各跑一次 `tests/unit` 全量，**失败集合逐条一致**（61 存量红，与 #2272 回归报告基线吻合），`fixed` 多 4 passed（`5021→5025`），无新增/消失失败。
- **静态检查**：`ruff check` 改动文件全绿；`check_docstring_no_cjk.py --full` 改动文件零命中（新增 docstring 全英文）。

## 兼容性

修复只在 swap 被外层取消时生效（`cancelling()>0`），对正常热切换**零语义影响**。(a) 保留"回波吞掉"原行为；(b) 的 CAS 在正常路径 `self.session` 必然仍是 `old_main_session` 故照常 promote；(c) 正常路径 `cancelling()==0` 恒不触发。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 修复热切换过程中取消操作可能被忽略的问题，避免错误覆盖当前会话。
  - 修复并发启动与结束操作下可能产生僵尸会话或错误会话状态的问题。
  - 当并发操作已接管会话时，系统将安全终止当前切换并清理待处理会话。
  - 确保正常热切换流程仍能完成，并正确启动新的监听器。

- **Tests**
  - 增加取消、并发接管及正常切换场景的回归测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->