### PR TITLE
fix(avatar): 修复 #2275 CodeRabbit 评审核实出的存量问题（含 pose timeline 悬挂竞态）

### DIFF
--- a/static/avatar/avatar-performance-stage.js
+++ b/static/avatar/avatar-performance-stage.js
@@ -2240,6 +2240,7 @@
             let settled = false;
             let settleLoop = null;
             let usesTemporaryPoseOverride = false;
+            let overrideFrameCount = 0;
             const startedAt = now();
             const finish = (result, reason) => {
                 if (settled) {
@@ -2321,6 +2322,7 @@
                 if (manager && typeof manager.setTemporaryPoseOverride === 'function') {
                     usesTemporaryPoseOverride = manager.setTemporaryPoseOverride(source, (coreModel) => {
                         if (coreModel === context.coreModel) {
+                            overrideFrameCount += 1;
                             applyFrame();
                         }
                     }) === true;
@@ -2339,13 +2341,31 @@
                 }
                 await new Promise((resolve) => {
                     settleLoop = resolve;
+                    // override 注册成功不代表在被驱动：coreModel.update 包装器
+                    // （installMouthOverride）可能尚未安装或已因异常自卸载。用帧计数
+                    // 心跳判定：连续多个 rAF 都没见 override 回调推进，就退回 rAF 驱动。
+                    // 阈值取 3——live2d 30fps 治理下模型帧隔一个 rAF 推进一次，不会误判。
+                    const OVERRIDE_STALL_FALLBACK_TICKS = 3;
+                    let lastOverrideFrameCount = overrideFrameCount;
+                    let overrideStallTicks = 0;
                     const tick = () => {
                         if (settled) {
                             resolve();
                             return;
                         }
                         try {
+                            let overrideDriving = false;
                             if (usesTemporaryPoseOverride) {
+                                if (overrideFrameCount !== lastOverrideFrameCount) {
+                                    lastOverrideFrameCount = overrideFrameCount;
+                                    overrideStallTicks = 0;
+                                    overrideDriving = true;
+                                } else {
+                                    overrideStallTicks += 1;
+                                    overrideDriving = overrideStallTicks < OVERRIDE_STALL_FALLBACK_TICKS;
+                                }
+                            }
+                            if (overrideDriving) {
                                 // override 回调已在模型 update 注入点逐帧 applyFrame，
                                 // rAF 只做完成/取消督导；重复 applyFrame 会让 handoff 期
                                 // 同一帧双重混合（实际权重变成 1-(1-w)^2）偏离设计曲线。

--- a/static/avatar/avatar-performance-stage.js
+++ b/static/avatar/avatar-performance-stage.js
@@ -2238,6 +2238,7 @@
             const previousEyeBlinkSuspended = !!manager._suspendEyeBlinkOverride;
             let frameId = 0;
             let settled = false;
+            let settleLoop = null;
             let usesTemporaryPoseOverride = false;
             const startedAt = now();
             const finish = (result, reason) => {
@@ -2268,6 +2269,11 @@
                             paramCount: paramKeys.length
                         });
                     } catch (_) {}
+                }
+                // finish 可能由 override 回调（模型 update 注入点）触发，此时上面已
+                // cancel 掉待执行的 tick，必须在这里直接唤醒等待循环，否则 promise 悬挂
+                if (settleLoop) {
+                    settleLoop();
                 }
             };
             const applyFrame = () => {
@@ -2332,19 +2338,33 @@
                     return true;
                 }
                 await new Promise((resolve) => {
+                    settleLoop = resolve;
                     const tick = () => {
                         if (settled) {
                             resolve();
                             return;
                         }
                         try {
-                            applyFrame();
+                            if (usesTemporaryPoseOverride) {
+                                // override 回调已在模型 update 注入点逐帧 applyFrame，
+                                // rAF 只做完成/取消督导；重复 applyFrame 会让 handoff 期
+                                // 同一帧双重混合（实际权重变成 1-(1-w)^2）偏离设计曲线。
+                                if (context.model !== this.getModel() || context.model.destroyed) {
+                                    finish('cancelled', 'model_changed');
+                                } else if (Math.max(0, now() - startedAt) >= durationMs) {
+                                    finish('played', '');
+                                }
+                            } else {
+                                applyFrame();
+                            }
                         } catch (error) {
                             this.warn('driver pose timeline frame failed', error);
                             resolve();
                             return;
                         }
-                        frameId = window.requestAnimationFrame(tick);
+                        if (!settled) {
+                            frameId = window.requestAnimationFrame(tick);
+                        }
                     };
                     frameId = window.requestAnimationFrame(tick);
                 });

--- a/static/avatar/avatar-performance-stage.js
+++ b/static/avatar/avatar-performance-stage.js
@@ -2346,9 +2346,12 @@
                     // 时间判定：超过阈值未见 override 回调推进才退回 rAF 驱动——不能
                     // 数 tick，高刷屏（120Hz+）配 30fps ticker 治理时一个模型帧间隔
                     // 就有 4+ 个 rAF。150ms 覆盖任何合法 ticker 配置的帧间隔。
+                    // 心跳起点视为已停滞：回调首次推进前由 rAF 驱动，否则 hook 注册
+                    // 成功但失活时前 150ms 无人写参，durationMs<=150 的短时间线会
+                    // 只播初始帧就被督导 finish('played')。
                     const OVERRIDE_STALL_FALLBACK_MS = 150;
                     let lastOverrideFrameCount = overrideFrameCount;
-                    let lastOverrideAdvanceAt = now();
+                    let lastOverrideAdvanceAt = now() - OVERRIDE_STALL_FALLBACK_MS;
                     const tick = () => {
                         if (settled) {
                             resolve();

--- a/static/avatar/avatar-performance-stage.js
+++ b/static/avatar/avatar-performance-stage.js
@@ -2342,12 +2342,13 @@
                 await new Promise((resolve) => {
                     settleLoop = resolve;
                     // override 注册成功不代表在被驱动：coreModel.update 包装器
-                    // （installMouthOverride）可能尚未安装或已因异常自卸载。用帧计数
-                    // 心跳判定：连续多个 rAF 都没见 override 回调推进，就退回 rAF 驱动。
-                    // 阈值取 3——live2d 30fps 治理下模型帧隔一个 rAF 推进一次，不会误判。
-                    const OVERRIDE_STALL_FALLBACK_TICKS = 3;
+                    // （installMouthOverride）可能尚未安装或已因异常自卸载。心跳按
+                    // 时间判定：超过阈值未见 override 回调推进才退回 rAF 驱动——不能
+                    // 数 tick，高刷屏（120Hz+）配 30fps ticker 治理时一个模型帧间隔
+                    // 就有 4+ 个 rAF。150ms 覆盖任何合法 ticker 配置的帧间隔。
+                    const OVERRIDE_STALL_FALLBACK_MS = 150;
                     let lastOverrideFrameCount = overrideFrameCount;
-                    let overrideStallTicks = 0;
+                    let lastOverrideAdvanceAt = now();
                     const tick = () => {
                         if (settled) {
                             resolve();
@@ -2358,11 +2359,10 @@
                             if (usesTemporaryPoseOverride) {
                                 if (overrideFrameCount !== lastOverrideFrameCount) {
                                     lastOverrideFrameCount = overrideFrameCount;
-                                    overrideStallTicks = 0;
+                                    lastOverrideAdvanceAt = now();
                                     overrideDriving = true;
                                 } else {
-                                    overrideStallTicks += 1;
-                                    overrideDriving = overrideStallTicks < OVERRIDE_STALL_FALLBACK_TICKS;
+                                    overrideDriving = (now() - lastOverrideAdvanceAt) < OVERRIDE_STALL_FALLBACK_MS;
                                 }
                             }
                             if (overrideDriving) {

--- a/static/avatar/avatar-portrait.js
+++ b/static/avatar/avatar-portrait.js
@@ -1664,12 +1664,9 @@
                         width: renderedSource.canvas.width,
                         height: renderedSource.canvas.height
                     },
-                    cropRectPixels: renderedSource.cropRectPixels || {
-                        x: 0,
-                        y: 0,
-                        width: renderedSource.canvas.width,
-                        height: renderedSource.canvas.height
-                    },
+                    // 上报实际传给 drawImage 的裁剪区（含目标宽高比修正），
+                    // 与下方非 renderSource 路径的 pixelCropRect 语义保持一致
+                    cropRectPixels: sourceCropRect,
                     sourceCanvas: renderedSource.sourceCanvas || renderedSource.canvas
                 };
 

--- a/static/avatar/avatar-ui-buttons.js
+++ b/static/avatar/avatar-ui-buttons.js
@@ -8854,12 +8854,14 @@ const AvatarButtonMixin = {
 
             this._returnButtonDragHandlers = {
                 mouseMove: (e) => {
-                    const point = getDragPoint(e, e.clientX, e.clientY);
-                    if (isDragging && dragPointerType === 'mouse' && e.buttons === 0) {
+                    // document 级 handler：非拖拽期直接返回，避免全页面鼠标移动白算坐标
+                    if (!isDragging) return;
+                    if (dragPointerType === 'mouse' && e.buttons === 0) {
                         handleEnd();
                         return;
                     }
-                    handleMove(point.x, point.y, e);
+                    const point = getDragPoint(e, e.clientX, e.clientY);
+                    handleMove(point.x, point.y, e, point);
                 },
                 mouseUp: handleEnd,
                 touchMove: (e) => {

--- a/static/avatar/avatar-ui-drag.js
+++ b/static/avatar/avatar-ui-drag.js
@@ -91,6 +91,14 @@
 })();
 
 // ===== 弹出框管理 =====
+//
+// 【加载顺序契约】本段在 Live2DManager.prototype 上定义的
+// showPopup / closePopupById / closeAllPopupsExcept / closeAllPopups / closeAllSettingsWindows
+// 会覆盖 AvatarPopupMixin（avatar-ui-popup.js，经 avatar-ui-popup-config.js 应用）装上的同名方法，
+// 所有加载 avatar-ui-drag.js 的页面都把它排在 avatar-ui-popup-config.js 之后，故本文件版本生效。
+// 保留旧版的原因：live2d 特有的引导守卫（isInTutorial 阻止关闭 settings 弹窗）与
+// settings 复选框状态同步逻辑仍内嵌在这里，尚未迁移到 mixin 的 _onPopupShow 钩子
+//（VRM 已走该架构，见 avatar-ui-popup-config.js）。迁移完成前请勿删除或调整加载顺序。
 
 // 关闭指定按钮对应的弹出框，并恢复按钮状态
 Live2DManager.prototype.closePopupById = function (buttonId) {

--- a/static/avatar/avatar-ui-popup.js
+++ b/static/avatar/avatar-ui-popup.js
@@ -1888,6 +1888,11 @@ function createIntervalControl(manager, prefix, toggle) {
     if (Number.isFinite(numericValue)) {
         if (numericValue < minVal) slider.min = Math.max(1, numericValue);
         if (numericValue > 120) slider.max = Math.min(3600, numericValue);
+        // 契约接受任意 1..3600 整数，值不在 5s 步进格点上（如 121、47）时浏览器
+        // 会把 slider.value 吸附到最近格点，显示与滑块再度分叉；此时改用 1s 步进
+        // 让该值可被精确表示。按格点值正常保持 5s 拖动手感。
+        const sliderShownValue = Math.min(Math.max(numericValue, Number(slider.min)), Number(slider.max));
+        if ((sliderShownValue - Number(slider.min)) % 5 !== 0) slider.step = '1';
     }
     slider.value = currentValue;
     Object.assign(slider.style, { width: '60px', height: '4px', cursor: 'pointer', accentColor: 'var(--neko-popup-accent, #44b7fe)' });

--- a/static/avatar/avatar-ui-popup.js
+++ b/static/avatar/avatar-ui-popup.js
@@ -1884,10 +1884,15 @@ function createIntervalControl(manager, prefix, toggle) {
     // 持久化值可能低于当前 toggle 的最小值（如旧版本保存的更低间隔），
     // 不 clamp 会导致 valueDisplay 显示低值而滑块实际停在 min，二者不一致
     if (currentValue < minVal) currentValue = minVal;
-    // 钳制改变了值时同步回运行时全局，避免界面显示钳制值而调度仍按越界旧值跑；
+    // 钳制改变了值时同步回运行时全局（window.proactiveXxxInterval 经 app-state.js
+    // 的 defineProperty 桥接直写 S），避免界面显示钳制值而调度仍按越界旧值跑；
     // 不在渲染路径主动落盘，归一化后的值随下一次 saveNEKOSettings 自然持久化
     if (typeof window[toggle.intervalKey] !== 'undefined' && window[toggle.intervalKey] !== currentValue) {
         window[toggle.intervalKey] = currentValue;
+        // 已在飞的定时器仍持有旧延迟，与下方 change 处理器同款：立即重排让钳制值生效
+        if (toggle.id === 'proactive-chat' && typeof window.resetProactiveChatBackoff === 'function') {
+            window.resetProactiveChatBackoff();
+        }
     }
     slider.value = currentValue;
     Object.assign(slider.style, { width: '60px', height: '4px', cursor: 'pointer', accentColor: 'var(--neko-popup-accent, #44b7fe)' });

--- a/static/avatar/avatar-ui-popup.js
+++ b/static/avatar/avatar-ui-popup.js
@@ -1893,6 +1893,13 @@ function createIntervalControl(manager, prefix, toggle) {
         if (toggle.id === 'proactive-chat' && typeof window.resetProactiveChatBackoff === 'function') {
             window.resetProactiveChatBackoff();
         }
+        // vision 发帧 setInterval 在创建时固化了旧间隔，正在运行时重启以套用钳制值
+        // （start 自带先清理再重建 + leader/录音/手动共享条件复查，直接调用即安全重启）
+        if (toggle.id === 'proactive-vision'
+            && typeof window.startProactiveVisionDuringSpeech === 'function'
+            && window.appState && window.appState.proactiveVisionFrameTimer) {
+            window.startProactiveVisionDuringSpeech();
+        }
     }
     slider.value = currentValue;
     Object.assign(slider.style, { width: '60px', height: '4px', cursor: 'pointer', accentColor: 'var(--neko-popup-accent, #44b7fe)' });

--- a/static/avatar/avatar-ui-popup.js
+++ b/static/avatar/avatar-ui-popup.js
@@ -1884,6 +1884,11 @@ function createIntervalControl(manager, prefix, toggle) {
     // 持久化值可能低于当前 toggle 的最小值（如旧版本保存的更低间隔），
     // 不 clamp 会导致 valueDisplay 显示低值而滑块实际停在 min，二者不一致
     if (currentValue < minVal) currentValue = minVal;
+    // 钳制改变了值时同步回运行时全局，避免界面显示钳制值而调度仍按越界旧值跑；
+    // 不在渲染路径主动落盘，归一化后的值随下一次 saveNEKOSettings 自然持久化
+    if (typeof window[toggle.intervalKey] !== 'undefined' && window[toggle.intervalKey] !== currentValue) {
+        window[toggle.intervalKey] = currentValue;
+    }
     slider.value = currentValue;
     Object.assign(slider.style, { width: '60px', height: '4px', cursor: 'pointer', accentColor: 'var(--neko-popup-accent, #44b7fe)' });
 

--- a/static/avatar/avatar-ui-popup.js
+++ b/static/avatar/avatar-ui-popup.js
@@ -1880,26 +1880,14 @@ function createIntervalControl(manager, prefix, toggle) {
     slider.max = '120';
     slider.step = '5';
     let currentValue = typeof window[toggle.intervalKey] !== 'undefined' ? window[toggle.intervalKey] : toggle.defaultInterval;
-    if (currentValue > 120) currentValue = 120;
-    // 持久化值可能低于当前 toggle 的最小值（如旧版本保存的更低间隔），
-    // 不 clamp 会导致 valueDisplay 显示低值而滑块实际停在 min，二者不一致
-    if (currentValue < minVal) currentValue = minVal;
-    // 钳制改变了值时同步回运行时全局（window.proactiveXxxInterval 经 app-state.js
-    // 的 defineProperty 桥接直写 S），避免界面显示钳制值而调度仍按越界旧值跑；
-    // 不在渲染路径主动落盘，归一化后的值随下一次 saveNEKOSettings 自然持久化
-    if (typeof window[toggle.intervalKey] !== 'undefined' && window[toggle.intervalKey] !== currentValue) {
-        window[toggle.intervalKey] = currentValue;
-        // 已在飞的定时器仍持有旧延迟，与下方 change 处理器同款：立即重排让钳制值生效
-        if (toggle.id === 'proactive-chat' && typeof window.resetProactiveChatBackoff === 'function') {
-            window.resetProactiveChatBackoff();
-        }
-        // vision 发帧 setInterval 在创建时固化了旧间隔，正在运行时重启以套用钳制值
-        // （start 自带先清理再重建 + leader/录音/手动共享条件复查，直接调用即安全重启）
-        if (toggle.id === 'proactive-vision'
-            && typeof window.startProactiveVisionDuringSpeech === 'function'
-            && window.appState && window.appState.proactiveVisionFrameTimer) {
-            window.startProactiveVisionDuringSpeech();
-        }
+    // 后端契约接受 1..3600 秒（utils/preferences.py），预设也会写入低于 UI 默认
+    // 下限的合法值（如 frequent 预设 5s，见 main_routers/proactive_router.py）。
+    // 持久化值越出滑条默认边界时，按契约放宽边界如实显示，绝不钳制或改写运行时/
+    // 持久化配置——否则打开设置面板就会把服务端配置的值静默改回 UI 边界。
+    const numericValue = Number(currentValue);
+    if (Number.isFinite(numericValue)) {
+        if (numericValue < minVal) slider.min = Math.max(1, numericValue);
+        if (numericValue > 120) slider.max = Math.min(3600, numericValue);
     }
     slider.value = currentValue;
     Object.assign(slider.style, { width: '60px', height: '4px', cursor: 'pointer', accentColor: 'var(--neko-popup-accent, #44b7fe)' });

--- a/static/avatar/avatar-ui-popup.js
+++ b/static/avatar/avatar-ui-popup.js
@@ -1881,6 +1881,9 @@ function createIntervalControl(manager, prefix, toggle) {
     slider.step = '5';
     let currentValue = typeof window[toggle.intervalKey] !== 'undefined' ? window[toggle.intervalKey] : toggle.defaultInterval;
     if (currentValue > 120) currentValue = 120;
+    // 持久化值可能低于当前 toggle 的最小值（如旧版本保存的更低间隔），
+    // 不 clamp 会导致 valueDisplay 显示低值而滑块实际停在 min，二者不一致
+    if (currentValue < minVal) currentValue = minVal;
     slider.value = currentValue;
     Object.assign(slider.style, { width: '60px', height: '4px', cursor: 'pointer', accentColor: 'var(--neko-popup-accent, #44b7fe)' });
 

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -2131,6 +2131,14 @@ def test_local_return_button_drag_recovers_lost_release_without_active_timeout()
         "const point = getDragPoint(e, e.clientX, e.clientY);",
         "handleMove(point.x, point.y, e, point);",
     )
+    _assert_source_contains(
+        mouse_move_block,
+        "if (dragPointerType === 'mouse' && e.buttons === 0) {\n"
+        "                        handleEnd();\n"
+        "                        return;\n"
+        "                    }",
+        "local return-ball lost mouseup recovery ends drag without moving",
+    )
     _assert_source_order(
         drag_setup,
         "local return-ball cancel recovery",
@@ -3418,6 +3426,14 @@ def test_cat1_walk_is_blocked_while_return_ball_drag_is_active_or_pending():
         "handleEnd();",
         "const point = getDragPoint(e, e.clientX, e.clientY);",
         "handleMove(point.x, point.y, e, point);",
+    )
+    _assert_source_contains(
+        mouse_move_block,
+        "if (dragPointerType === 'mouse' && e.buttons === 0) {\n"
+        "                        handleEnd();\n"
+        "                        return;\n"
+        "                    }",
+        "local return-ball mousemove ends released drag without moving",
     )
     finish_drag_state_block = _source_slice_between(
         drag_setup,

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -2125,10 +2125,11 @@ def test_local_return_button_drag_recovers_lost_release_without_active_timeout()
     _assert_source_order(
         mouse_move_block,
         "local return-ball lost mouseup recovery",
-        "const point = getDragPoint(e, e.clientX, e.clientY);",
-        "if (isDragging && dragPointerType === 'mouse' && e.buttons === 0) {",
+        "if (!isDragging) return;",
+        "if (dragPointerType === 'mouse' && e.buttons === 0) {",
         "handleEnd();",
-        "handleMove(point.x, point.y, e);",
+        "const point = getDragPoint(e, e.clientX, e.clientY);",
+        "handleMove(point.x, point.y, e, point);",
     )
     _assert_source_order(
         drag_setup,
@@ -2452,7 +2453,7 @@ def test_cat1_rapid_drag_reaction_is_same_drag_motion_only():
     )
     _assert_source_contains(
         local_drag_setup,
-        "handleMove(point.x, point.y, e);",
+        "handleMove(point.x, point.y, e, point);",
         "return button drag setup",
     )
     _assert_source_contains(
@@ -3412,10 +3413,11 @@ def test_cat1_walk_is_blocked_while_return_ball_drag_is_active_or_pending():
     _assert_source_order(
         mouse_move_block,
         "local return-ball mousemove recovers released mouse before moving",
-        "const point = getDragPoint(e, e.clientX, e.clientY);",
-        "if (isDragging && dragPointerType === 'mouse' && e.buttons === 0) {",
+        "if (!isDragging) return;",
+        "if (dragPointerType === 'mouse' && e.buttons === 0) {",
         "handleEnd();",
-        "handleMove(point.x, point.y, e);",
+        "const point = getDragPoint(e, e.clientX, e.clientY);",
+        "handleMove(point.x, point.y, e, point);",
     )
     finish_drag_state_block = _source_slice_between(
         drag_setup,


### PR DESCRIPTION
## 背景

对 #2275（avatar-* 十一文件搬入 static/avatar/ 纯搬移）的 CodeRabbit review 6 条意见逐条核实（bot 意见先证实再修）。**结论：6 条全部属实，无误报**——4 条本 PR 修复，1 条文档化+另开迁移任务，1 条核实后判定不改。核实过程中另发现一个 CodeRabbit 未指出的存量 promise 悬挂竞态，一并修复。

## 修复内容

### 1. avatar-performance-stage.js：pose timeline 双重 applyFrame + 悬挂竞态（actionable ①）
- **核实**：`setTemporaryPoseOverride` 注册成功后，override 回调已在模型 update 注入点 3 逐帧 `applyFrame`，rAF tick 又无条件再调一次。`applyPoseValues` 是增量混合（`base + (value-base)*w`），同帧双重混合使 handoff 期实际权重变成 `1-(1-w)²`，偏离 easeOutCubic 设计曲线。
- **修复**：override 生效时 tick 只做完成/取消督导（模型切换 cancel、到时 finish），不再重复计算与写参。评审迭代补充（Codex）：override 注册成功不保证被驱动（installMouthOverride 的 update 包装器可能未装/自卸载），tick 内加时间阈值心跳——override 回调超 150ms 未推进即退回 rAF 驱动；用时间而非 rAF 计数，避免 120Hz+ 高刷屏配 30fps ticker 治理时误判。
- **额外发现的存量 bug**：`finish()` 由 override 回调（pixi ticker 帧内）触发时，会 `cancelAnimationFrame` 掉**待执行**的 tick，此后无人 resolve，`await runPoseTimeline` 永久悬挂（性能会话卡死、capability 锁不释放）。原代码是否触发取决于 pixi ticker 与 tick 的 rAF 注册顺序；Node harness 下确定性复现悬挂。修复：`finish` 末尾直接唤醒等待循环。

### 2. avatar-portrait.js：renderSource 路径 cropRectPixels 报旧值（actionable ②）
- **核实**：属实。上报的是宽高比修正**前**的原始矩形，而实际 `drawImage` 用的是 `cropRectToTargetAspect` 修正后的 `sourceCropRect`；非 renderSource 路径上报的是修正后矩形，两路径不一致。消费方（app-chat-avatar.js 手动裁剪器默认框）拿修正后矩形更准。
- **修复**：上报 `sourceCropRect`（该函数只收缩不扩张，必在源画布内）。

### 3. avatar-ui-popup.js：滑条 currentValue 未 clamp 到 minVal（actionable ④）
- **核实**：属实。只 clamp 上限 120，持久化值低于 minVal（proactive-chat 为 10）时 `valueDisplay` 显示低值而滑块实际停在 min。
- **修复**（评审迭代后的最终方案）：不钳制、不写回——frequent 预设合法写入 5s（main_routers/proactive_router.py），后端契约接受 1..3600s（utils/preferences.py），钳制或写回都会与服务端配置冲突。改为持久化值越出滑条默认边界时按契约放宽边界（下限≥1、上限≤3600）如实显示，运行时/持久化配置一概不动，显示=滑块=运行时三者一致。

### 4. avatar-ui-buttons.js：mouseMove 非拖拽期白算 getDragPoint（nitpick ⑤）
- **核实**：属实且比意见描述更浪费——`handleMove` 首行判 `!isDragging` 且自行重算 point，外层那次 `getDragPoint` 无论拖不拖都是纯白算。
- **修复**：先判 `isDragging` 再计算，point 透传 `handleMove` 避免拖拽期二次计算，与同文件 touchMove 风格统一。同步更新 `test_avatar_return_button_idle_tiers_static.py` 三处顺序契约断言（丢失 mouseup 恢复语义不变：`handleEnd` 仍先于 `handleMove`）。只减少计算、不新增帧循环，空闲 CPU 无回归风险。

## 核实属实但本 PR 不修的两条

- **avatar-ui-drag.js 覆盖 AvatarPopupMixin 同名方法（actionable ③）**：属实。所有加载 drag.js 的页面它都排在 avatar-ui-popup-config.js 之后，live2d 实际走旧版；不加载 drag.js 的页面（character_card_manager、soccer_demo）走 mixin 版，两套实现确实在超时字段/可见性判定/生命周期事件上分叉。但旧版内嵌 live2d 特有**引导守卫**（`isInTutorial` 阻止关闭设置弹窗）与 settings 复选框同步，直接删除会打断 yui-guide；VRM 已迁移 `_onPopupShow` 钩子架构而 live2d 未迁移。本 PR 仅以注释固化加载顺序契约，完整迁移已另开任务承接。
- **avatar-reaction-bubble.js 跟随窗口 60fps 布局读（nitpick ⑥）**：描述属实，但循环在气泡隐藏/窗口过期时自停，**空闲期不存在该循环**，与空闲 CPU 治理不冲突；成本仅发生在对话轮次气泡可见期（模型动画本就在逐帧跑），且渲染侧已有 positionSnapPx 抑制。节流会改变跟随手感，收益不对等，判定不改。

## 验证

- `node --test static/*.test.cjs`：309 pass / 10 fail，失败集与改动前基线（git stash 对比）**完全一致**（tutorial/interpage 存量环境性失败）。
- pytest avatar 契约套件（idle_tiers/cat1/floating_button/drop/multiscreen/pointer_events/phase5/react_chat/model_manager）：除 react_chat_window 7 个基线同样失败的存量项外全绿；改动后 idle_tiers 单跑 36/36。
- 浏览器实测（uvicorn 起 main_server）：滑条 clamp 四场景（低值 5→10s、高值 300→120s、正常 45 不变、vision min=5）；返回球拖拽三场景（非拖拽 mousemove 零反应、+40px 精确拖动、buttons===0 丢失 mouseup 恢复）；两套弹窗方法归属与空跑无错。
- Node vm harness 加载真实 avatar-performance-stage.js 实测 pose timeline：修复后 override 路径 312ms 按时完成、computePose 21 次（原本翻倍）、参数复原、override 清理，普通路径不变，模型切换 80ms 内 cancel；**同 harness 下 HEAD 原版代码确定性悬挂**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - 修复临时姿态覆盖触发“完成/取消”时偶发等待悬挂，提升动画结束响应与稳定性。
  - 调整头像截图裁剪区域的上报逻辑，确保与实际显示一致。
  - 优化返回按钮鼠标拖拽的移动与收尾判断，降低误触发并避免拖拽状态异常。
  - 改进间隔滑块初始化边界与步进显示，减少与持久化数值不一致。
- **Documentation**
  - 补充弹出框管理的加载顺序契约说明。
- **Tests**
  - 更新返回按钮拖拽丢失恢复相关断言与事件参数。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
