### PR TITLE
feat(agent): 主动搭话可触发 agent，每会话上限节流（默认关）

### DIFF
--- a/app/agent_server/__init__.py
+++ b/app/agent_server/__init__.py
@@ -118,6 +118,8 @@ from config import (  # noqa: F401  (tail entries keep facade parity with the ol
     ERROR_MESSAGE_MAX_CHARS,
     TASK_TRACKER_DETAIL_MAX_CHARS,
     TASK_TRACKER_INJECT_DETAIL_MAX_CHARS,
+    AGENT_PROACTIVE_ANALYZE_ENABLED,
+    AGENT_PROACTIVE_ANALYZE_MAX_PER_SESSION,
 )
 from utils.config_manager import get_config_manager
 from utils.tokenize import truncate_to_tokens as _tt
@@ -131,6 +133,7 @@ from .tracker import (  # noqa: F401
     _user_message_sender_id,
     _user_message_payload_text,
     _build_user_turn_fingerprint,
+    _build_assistant_turn_fingerprint,
     _build_analyze_event_fingerprint,
     _user_message_signature,
     _last_user_message_signature,
@@ -289,6 +292,48 @@ async def _handle_voice_transcript_request(event: Dict[str, Any]) -> None:
         )
 
 
+def _handle_proactive_analyze(messages, lanlan_name, lanlan_key, conversation_id) -> None:
+    """Throttled proactive-analyze path (opt-in via AGENT_PROACTIVE_ANALYZE_ENABLED).
+
+    A proactive turn has no new user input, so the ordinary user-turn dedupe
+    would drop it. Instead we let lanlan's self-initiated utterance trigger one
+    analyzer pass, bounded by three gates so it can never fire frequently:
+      * the master enable switch (off → never run);
+      * an assistant-text fingerprint (dedupe identical proactive utterances —
+        a re-sent proactive turn must not re-analyze);
+      * a per-session count cap (AGENT_PROACTIVE_ANALYZE_MAX_PER_SESSION), reset
+        on greeting_check. This is the anti-cheap-layer / cost ceiling: it counts
+        analyzer RUNS (incl. ones that dispatch no tool), so a session can spend
+        at most N proactive analyzer calls regardless of how chatty lanlan is.
+    """
+    if not bool(AGENT_PROACTIVE_ANALYZE_ENABLED):
+        logger.info("[AgentAnalyze] skip proactive: disabled (lanlan=%s)", lanlan_name)
+        return
+    # fp is None ⟺ no assistant utterance to analyze (the executor pulls the
+    # actual proactive intent text from the same assistant turn downstream).
+    fp = _build_assistant_turn_fingerprint(messages)
+    if fp is None:
+        logger.info("[AgentAnalyze] skip proactive: no assistant utterance (lanlan=%s)", lanlan_name)
+        return
+    if Modules.last_proactive_assistant_fingerprint.get(lanlan_key) == fp:
+        logger.info("[AgentAnalyze] skip proactive: duplicate proactive utterance (lanlan=%s)", lanlan_name)
+        return
+    cap = max(0, int(AGENT_PROACTIVE_ANALYZE_MAX_PER_SESSION))
+    used = int(Modules.proactive_analyze_count.get(lanlan_key, 0))
+    if used >= cap:
+        logger.info("[AgentAnalyze] skip proactive: per-session cap reached (%d/%d, lanlan=%s)", used, cap, lanlan_name)
+        return
+    # Reserve the slot + dedupe fp BEFORE dispatch so concurrent proactive events
+    # can't both pass the cap check.
+    Modules.proactive_analyze_count[lanlan_key] = used + 1
+    Modules.last_proactive_assistant_fingerprint[lanlan_key] = fp
+    logger.info("[AgentAnalyze] proactive analyze accepted (%d/%d, lanlan=%s)", used + 1, cap, lanlan_name)
+    _create_tracked_task(_background_analyze_and_plan(
+        messages, lanlan_name, conversation_id=conversation_id,
+        external_intent=None, proactive=True,
+    ))
+
+
 async def _on_session_event(event: Dict[str, Any]) -> None:
     event_type = (event or {}).get("event_type")
     if event_type == "agent_intent_restore_signal":
@@ -299,6 +344,19 @@ async def _on_session_event(event: Dict[str, Any]) -> None:
         # and plugin lifecycle startup during the cold-start window
         # before the user actually opens a session. The restore helper
         # has its own once-flag, so this is safe to spam.
+        # Reset the per-session proactive-analyze budget ONLY on a genuine new
+        # session (character switch or a real gap) — never on a refresh/reconnect
+        # or a concurrent second window, which also fire greeting_check. Otherwise
+        # a user could refresh/parallel-open to farm a fresh cap mid-conversation,
+        # defeating the per-session bound. ``new_session`` is decided by
+        # websocket_router (is_switch or >15s gap, AND sole active connection).
+        # Done BEFORE the restore await so a restore failure can't leave a genuine
+        # new session stuck on the old cap / fingerprint.
+        if (event or {}).get("new_session"):
+            _key = _normalize_lanlan_key((event or {}).get("lanlan_name"))
+            if _key:
+                Modules.proactive_analyze_count.pop(_key, None)
+                Modules.last_proactive_assistant_fingerprint.pop(_key, None)
         await _maybe_restore_agent_intent()
         return
     if event_type in {"voice_transcript_observed", "voice_transcript_request"}:
@@ -315,8 +373,17 @@ async def _on_session_event(event: Dict[str, Any]) -> None:
             logger.info("[AgentAnalyze] skip: analyzer disabled (master switch off)")
             return
         if isinstance(messages, list) and messages:
-            # Consume only new user turn. Assistant turn_end without new user input should be ignored.
             lanlan_key = _normalize_lanlan_key(lanlan_name)
+            conversation_id = event.get("conversation_id")
+            # Proactive (self-initiated, no fresh user input) turn: opt-in,
+            # separate throttled path. The ordinary user-turn dedupe below would
+            # always drop these (the latest user message is a stale prior turn,
+            # so its fingerprint matches), so proactive routing is mandatory, not
+            # an optimization.
+            if event.get("proactive"):
+                _handle_proactive_analyze(messages, lanlan_name, lanlan_key, conversation_id)
+                return
+            # Consume only new user turn. Assistant turn_end without new user input should be ignored.
             fp = _build_analyze_event_fingerprint(event)
             if fp is None:
                 logger.info("[AgentAnalyze] skip analyze: no user message found (trigger=%s lanlan=%s)", event.get("trigger"), lanlan_name)
@@ -330,7 +397,6 @@ async def _on_session_event(event: Dict[str, Any]) -> None:
             # - Cancelled tasks not emitting task_result callbacks
             # - Voice-mode hot-swap sending 'turn end agent_callback'
             Modules.last_user_turn_fingerprint[lanlan_key] = fp
-            conversation_id = event.get("conversation_id")
             # Cheap pre-gate hint from the input-time master-emotion call (rides
             # the analyze_request payload). Absent → None → the gate fails open.
             external_intent = event.get("external_intent")
@@ -340,7 +406,7 @@ async def _on_session_event(event: Dict[str, Any]) -> None:
             ))
 
 
-async def _background_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Optional[str], conversation_id: Optional[str] = None, external_intent: Optional[float] = None):
+async def _background_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Optional[str], conversation_id: Optional[str] = None, external_intent: Optional[float] = None, proactive: bool = False):
     """
     [Simplified] Uses DirectTaskExecutor to do everything in one step: analyze the conversation + decide the execution method + execute the task
     
@@ -366,10 +432,10 @@ async def _background_analyze_and_plan(messages: list[dict[str, Any]], lanlan_na
         Modules.analyze_lock = asyncio.Lock()
 
     async with Modules.analyze_lock:
-        await _do_analyze_and_plan(messages, lanlan_name, conversation_id=conversation_id, external_intent=external_intent)
+        await _do_analyze_and_plan(messages, lanlan_name, conversation_id=conversation_id, external_intent=external_intent, proactive=proactive)
 
 
-async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Optional[str], conversation_id: Optional[str] = None, external_intent: Optional[float] = None):
+async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Optional[str], conversation_id: Optional[str] = None, external_intent: Optional[float] = None, proactive: bool = False):
     """Inner implementation, always called under analyze_lock."""
     try:
         if not Modules.analyzer_enabled:
@@ -379,12 +445,15 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                     lanlan_name, len(messages), Modules.agent_flags, Modules.analyzer_enabled)
         # 在 inject 之前先把已被用户 UI 取消的 user turn 整段 redact，让 analyzer
         # 完全看不到那条请求；inject 阶段也会跳过 cancelled 任务的所有 record。
-        redacted_messages = _redact_cancelled_user_turns(messages, lanlan_name)
+        redacted_messages = _redact_cancelled_user_turns(messages, lanlan_name, preserve_trailing_assistant=proactive)
         # 单条 user 消息签名：派单时塞到 task info 里。取自 redacted_messages
         # 而非 raw —— analyzer 实际看到的最新 user 才是该任务的真触发者；
         # 正常场景下 raw-latest 是 first-time bypass、没被 redact，两个签名
         # 一致，区别仅在 raw-latest 已经被 redact 的边界 case。
-        trigger_user_msg_sig = _last_user_message_signature(redacted_messages)
+        # 主动搭话轮没有触发它的 user 消息：绝不把它绑到窗口里那条陈旧 user 签名上，
+        # 否则用户取消这条主动任务会误把那条旧 user turn 标记为 cancelled、下一轮被
+        # redact 掉。proactive → 不绑 user 触发签名。
+        trigger_user_msg_sig = None if proactive else _last_user_message_signature(redacted_messages)
         enriched_messages = _task_tracker.inject(redacted_messages, lanlan_name)
 
         # 一步完成：分析 + 执行
@@ -394,6 +463,7 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
             agent_flags=Modules.agent_flags,
             conversation_id=conversation_id,
             external_intent=external_intent,
+            proactive=proactive,
         )
 
         if result is None:
@@ -2619,6 +2689,8 @@ async def admin_control(payload: Dict[str, Any]):
 
         Modules.task_registry.clear()
         Modules.last_user_turn_fingerprint.clear()
+        Modules.proactive_analyze_count.clear()
+        Modules.last_proactive_assistant_fingerprint.clear()
         # Clear scheduling state
         Modules.computer_use_running = False
         Modules.active_computer_use_task_id = None

--- a/app/agent_server/__init__.py
+++ b/app/agent_server/__init__.py
@@ -530,6 +530,7 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                 lanlan_name=lanlan_name,
                 conversation_id=conversation_id,
                 trigger_user_msg_sig=trigger_user_msg_sig,
+                proactive=proactive,
             )
         elif result.execution_method == 'browser_use':
             await channels.browser_use.dispatch(

--- a/app/agent_server/_shared.py
+++ b/app/agent_server/_shared.py
@@ -112,6 +112,11 @@ class Modules:
     analyze_lock: Optional[asyncio.Lock] = None
     # Per-lanlan fingerprint of latest user-turn payload already consumed by analyzer
     last_user_turn_fingerprint: ClassVar[Dict[str, str]] = {}
+    # Proactive-analyze throttle state (opt-in feature, see AGENT_PROACTIVE_ANALYZE_*).
+    # Per-lanlan count of proactive analyses run this session (reset on greeting_check)
+    # and the last proactive assistant-turn fingerprint already consumed (dedupe).
+    proactive_analyze_count: ClassVar[Dict[str, int]] = {}
+    last_proactive_assistant_fingerprint: ClassVar[Dict[str, str]] = {}
     capability_cache: Dict[str, Dict[str, Any]] = {
         "computer_use": {"ready": False, "reason": "AGENT_PRECHECK_PENDING"},
         "browser_use": {"ready": False, "reason": "AGENT_PRECHECK_PENDING"},

--- a/app/agent_server/channels/openclaw.py
+++ b/app/agent_server/channels/openclaw.py
@@ -313,8 +313,16 @@ async def dispatch(
     lanlan_name,
     conversation_id,
     trigger_user_msg_sig,
+    proactive: bool = False,
 ) -> None:
-    """Handle an analyzer decision routed to the OpenClaw channel."""
+    """Handle an analyzer decision routed to the OpenClaw channel.
+
+    ``proactive`` marks a self-initiated turn (no triggering user). The sender
+    is forced to the default rather than resolved from the messages window,
+    since the "latest user" there is a stale prior turn — attributing the action
+    (or a proactive ``/stop``) to that user's persistent OpenClaw session would
+    be wrong in multi-user setups.
+    """
     if _shared.Modules.agent_flags.get("openclaw_enabled", False) and _shared.Modules.openclaw:
         nk_start = _now_iso()
         instruction = ""
@@ -332,7 +340,13 @@ async def dispatch(
         }
         if magic_command:
             task_params["magic_command"] = magic_command
-        nk_sender_id = _resolve_openclaw_sender_id(messages) or _shared.Modules.openclaw.default_sender_id
+        # Proactive tasks have no triggering user → force the default sender so a
+        # self-initiated action (or proactive /stop) never runs under the stale
+        # prior user's persistent OpenClaw session.
+        if proactive:
+            nk_sender_id = _shared.Modules.openclaw.default_sender_id
+        else:
+            nk_sender_id = _resolve_openclaw_sender_id(messages) or _shared.Modules.openclaw.default_sender_id
         if magic_command:
             if magic_command == "/stop":
                 cancelled_task_ids = await _cancel_openclaw_tasks_for_stop(

--- a/app/agent_server/tracker.py
+++ b/app/agent_server/tracker.py
@@ -472,13 +472,29 @@ def _redact_cancelled_user_turns(messages: list, lanlan_name: Optional[str], *, 
     if not cancelled_sigs:
         return messages
 
+    # Index of the last assistant message — preserved from redaction when
+    # ``preserve_trailing_assistant`` is set (the proactive utterance).
+    # Computed up front because it must be excluded from the first-time bypass
+    # count below: on a proactive turn this trailing assistant is lanlan's own
+    # new utterance, NOT a reply to any user, so counting it would let a
+    # cancelled user turn that produced no reply masquerade as "first-time"
+    # (trailing_assistant_count == 1) and escape redaction, leaking the
+    # cancelled request into the proactive assessment.
+    keep_assistant_idx = -1
+    if preserve_trailing_assistant:
+        for i in range(len(messages) - 1, -1, -1):
+            if isinstance(messages[i], dict) and messages[i].get("role") == "assistant":
+                keep_assistant_idx = i
+                break
+
     # Precompute trailing assistant counts so we can resolve "first-time"
-    # in one O(n) sweep instead of nested scans.
+    # in one O(n) sweep instead of nested scans. The preserved proactive
+    # utterance is skipped so it never counts as a user turn's triggering reply.
     trailing_assistant_count = [0] * len(messages)
     running = 0
     for idx in range(len(messages) - 1, -1, -1):
         m = messages[idx]
-        if isinstance(m, dict) and m.get("role") == "assistant":
+        if isinstance(m, dict) and m.get("role") == "assistant" and idx != keep_assistant_idx:
             running += 1
         trailing_assistant_count[idx] = running
 
@@ -497,15 +513,6 @@ def _redact_cancelled_user_turns(messages: list, lanlan_name: Optional[str], *, 
 
     if not redact_indices:
         return messages
-
-    # Index of the last assistant message — preserved from redaction when
-    # ``preserve_trailing_assistant`` is set (the proactive utterance).
-    keep_assistant_idx = -1
-    if preserve_trailing_assistant:
-        for i in range(len(messages) - 1, -1, -1):
-            if isinstance(messages[i], dict) and messages[i].get("role") == "assistant":
-                keep_assistant_idx = i
-                break
 
     redacted: list = []
     drop_until_next_user = False

--- a/app/agent_server/tracker.py
+++ b/app/agent_server/tracker.py
@@ -363,28 +363,29 @@ def _build_user_turn_fingerprint(messages: Any) -> Optional[str]:
 
 
 def _build_assistant_turn_fingerprint(messages: Any) -> Optional[str]:
-    """Build a stable fingerprint from assistant-role message texts only.
+    """Build a stable fingerprint from the LATEST assistant utterance only.
 
     Used by the proactive-analyze path to ensure each distinct proactive
     utterance is analyzed at most once (a re-sent / duplicate proactive
     ``turn end`` carries the same assistant text → same fingerprint → skip).
-    Mirrors ``_build_user_turn_fingerprint`` but on the assistant side, since a
-    proactive turn has no new user message to key on. Returns None when the
-    window has no assistant text.
+    Keyed to the last assistant message with text — the exact utterance the
+    executor pulls the proactive intent from downstream (``_format_messages``
+    with ``proactive=True`` also walks the window in reverse to that same line).
+    Hashing the whole assistant history instead would make the key
+    history-dependent: the same line re-sent after the window gained another
+    assistant record would hash differently, slip past the dedupe, and burn a
+    second budget slot / repeat the agent action. Returns None when the window
+    has no assistant text (also the "no assistant utterance" skip signal).
     """
     if not isinstance(messages, list):
         return None
-    parts: list[str] = []
-    for m in messages:
+    for m in reversed(messages):
         if not isinstance(m, dict) or str(m.get("role") or "").lower() != "assistant":
             continue
         text = str(m.get("text") or m.get("content") or "").strip()
         if text:
-            parts.append(text)
-    if not parts:
-        return None
-    payload_bytes = "\n".join(parts).encode("utf-8", errors="ignore")
-    return hashlib.sha256(payload_bytes).hexdigest()
+            return hashlib.sha256(text.encode("utf-8", errors="ignore")).hexdigest()
+    return None
 
 
 def _build_analyze_event_fingerprint(event: Dict[str, Any]) -> Optional[str]:

--- a/app/agent_server/tracker.py
+++ b/app/agent_server/tracker.py
@@ -474,12 +474,6 @@ def _redact_cancelled_user_turns(messages: list, lanlan_name: Optional[str], *, 
 
     # Index of the last assistant message — preserved from redaction when
     # ``preserve_trailing_assistant`` is set (the proactive utterance).
-    # Computed up front because it must be excluded from the first-time bypass
-    # count below: on a proactive turn this trailing assistant is lanlan's own
-    # new utterance, NOT a reply to any user, so counting it would let a
-    # cancelled user turn that produced no reply masquerade as "first-time"
-    # (trailing_assistant_count == 1) and escape redaction, leaking the
-    # cancelled request into the proactive assessment.
     keep_assistant_idx = -1
     if preserve_trailing_assistant:
         for i in range(len(messages) - 1, -1, -1):
@@ -488,13 +482,12 @@ def _redact_cancelled_user_turns(messages: list, lanlan_name: Optional[str], *, 
                 break
 
     # Precompute trailing assistant counts so we can resolve "first-time"
-    # in one O(n) sweep instead of nested scans. The preserved proactive
-    # utterance is skipped so it never counts as a user turn's triggering reply.
+    # in one O(n) sweep instead of nested scans.
     trailing_assistant_count = [0] * len(messages)
     running = 0
     for idx in range(len(messages) - 1, -1, -1):
         m = messages[idx]
-        if isinstance(m, dict) and m.get("role") == "assistant" and idx != keep_assistant_idx:
+        if isinstance(m, dict) and m.get("role") == "assistant":
             running += 1
         trailing_assistant_count[idx] = running
 
@@ -507,7 +500,16 @@ def _redact_cancelled_user_turns(messages: list, lanlan_name: Optional[str], *, 
             continue
         # Exactly one trailing assistant → first-time analyze pass for this
         # user msg → bypass cancel.
-        if trailing_assistant_count[idx] == 1:
+        #
+        # DISABLED entirely on a proactive turn (``preserve_trailing_assistant``):
+        # the first-time bypass exists for the case where the user *re-issued*
+        # input and that turn's own reply triggered this analyze pass. A proactive
+        # analyze pass is triggered by lanlan's own utterance, not by any user
+        # turn, so no cancelled user turn is "first-time" here — whether it has
+        # zero trailing replies ([U(cancelled), A]) or its own one reply
+        # ([U(cancelled), R, A]), it must be redacted. The proactive utterance is
+        # preserved separately via keep_assistant_idx below.
+        if not preserve_trailing_assistant and trailing_assistant_count[idx] == 1:
             continue
         redact_indices.add(idx)
 

--- a/app/agent_server/tracker.py
+++ b/app/agent_server/tracker.py
@@ -362,6 +362,31 @@ def _build_user_turn_fingerprint(messages: Any) -> Optional[str]:
     return hashlib.sha256(payload_bytes).hexdigest()
 
 
+def _build_assistant_turn_fingerprint(messages: Any) -> Optional[str]:
+    """Build a stable fingerprint from assistant-role message texts only.
+
+    Used by the proactive-analyze path to ensure each distinct proactive
+    utterance is analyzed at most once (a re-sent / duplicate proactive
+    ``turn end`` carries the same assistant text → same fingerprint → skip).
+    Mirrors ``_build_user_turn_fingerprint`` but on the assistant side, since a
+    proactive turn has no new user message to key on. Returns None when the
+    window has no assistant text.
+    """
+    if not isinstance(messages, list):
+        return None
+    parts: list[str] = []
+    for m in messages:
+        if not isinstance(m, dict) or str(m.get("role") or "").lower() != "assistant":
+            continue
+        text = str(m.get("text") or m.get("content") or "").strip()
+        if text:
+            parts.append(text)
+    if not parts:
+        return None
+    payload_bytes = "\n".join(parts).encode("utf-8", errors="ignore")
+    return hashlib.sha256(payload_bytes).hexdigest()
+
+
 def _build_analyze_event_fingerprint(event: Dict[str, Any]) -> Optional[str]:
     fp = _build_user_turn_fingerprint(event.get("messages", []))
     if fp is None:
@@ -403,8 +428,14 @@ REDACTED_USER_TURN_MARKER = (
 )
 
 
-def _redact_cancelled_user_turns(messages: list, lanlan_name: Optional[str]) -> list:
+def _redact_cancelled_user_turns(messages: list, lanlan_name: Optional[str], *, preserve_trailing_assistant: bool = False) -> list:
     """Return a messages copy with cancelled user turns removed.
+
+    ``preserve_trailing_assistant`` keeps the LAST assistant message out of the
+    redaction. On a proactive turn that message is lanlan's own utterance being
+    analyzed (no next-user boundary follows it), so it must survive even when it
+    trails a cancelled user — otherwise the proactive intent is stripped before
+    ``_format_messages`` and the turn spends a budget slot without dispatching.
 
     Rule: a user message matches the cancel set (its sig is in
     `cancelled_sigs`) → redact it **unless** it is a "first-time analyze"
@@ -466,6 +497,15 @@ def _redact_cancelled_user_turns(messages: list, lanlan_name: Optional[str]) -> 
     if not redact_indices:
         return messages
 
+    # Index of the last assistant message — preserved from redaction when
+    # ``preserve_trailing_assistant`` is set (the proactive utterance).
+    keep_assistant_idx = -1
+    if preserve_trailing_assistant:
+        for i in range(len(messages) - 1, -1, -1):
+            if isinstance(messages[i], dict) and messages[i].get("role") == "assistant":
+                keep_assistant_idx = i
+                break
+
     redacted: list = []
     drop_until_next_user = False
     for idx, m in enumerate(messages):
@@ -481,6 +521,10 @@ def _redact_cancelled_user_turns(messages: list, lanlan_name: Optional[str]) -> 
             # 只吞掉被取消任务产出的 assistant/tool 段；夹在中间的 system
             # 消息（session callback、context 注入等）跟取消请求无关，保留。
             if isinstance(m, dict) and m.get("role") in {"assistant", "tool"}:
+                # 主动搭话轮：那条被分析的主动台词（最后一条 assistant）必须留下，
+                # 否则下游 _format_messages 取不到主动意图、白白消耗一个预算名额。
+                if idx == keep_assistant_idx:
+                    redacted.append(m)
                 continue
         redacted.append(m)
     return redacted

--- a/brain/task_executor.py
+++ b/brain/task_executor.py
@@ -553,8 +553,15 @@ class DirectTaskExecutor:
         except RuntimeError:
             logger.debug("[Agent] No running event loop, skipping async LLM close")
 
-    def _format_messages(self, messages: List[Dict[str, str]]) -> str:
-        """Format conversation messages"""
+    def _format_messages(self, messages: List[Dict[str, str]], *, proactive: bool = False) -> str:
+        """Format conversation messages.
+
+        ``proactive`` marks a self-initiated turn with no new user request: the
+        ``LATEST_USER_REQUEST`` marker (which both the unified and plugin
+        assessors key on) is taken from lanlan's own latest utterance instead of
+        the stale prior user line, so the assessment is driven by the proactive
+        intent rather than the old request.
+        """
         def _extract_text(m: dict) -> str:
             return str(m.get('text') or m.get('content') or '').strip()
 
@@ -584,11 +591,20 @@ class DirectTaskExecutor:
             return ""
 
         latest_user_text = ""
-        for m in reversed(messages[-AGENT_HISTORY_TURNS:]):
-            if m.get('role') == 'user':
-                latest_user_text = _describe_user_message(_extract_text(m), _extract_attachments(m))
-                if latest_user_text:
-                    break
+        if proactive:
+            # Self-initiated turn → the actionable "request" is lanlan's own
+            # latest utterance, not the (stale) latest user line.
+            for m in reversed(messages[-AGENT_HISTORY_TURNS:]):
+                if str(m.get('role') or '').lower() == 'assistant':
+                    latest_user_text = _extract_text(m)
+                    if latest_user_text:
+                        break
+        else:
+            for m in reversed(messages[-AGENT_HISTORY_TURNS:]):
+                if m.get('role') == 'user':
+                    latest_user_text = _describe_user_message(_extract_text(m), _extract_attachments(m))
+                    if latest_user_text:
+                        break
         lines = []
         if latest_user_text:
             lines.append(f"LATEST_USER_REQUEST: {latest_user_text}")
@@ -1774,11 +1790,17 @@ class DirectTaskExecutor:
         conversation_id: Optional[str] = None,
         lang: str = "en",
         external_intent: Optional[float] = None,
+        proactive: bool = False,
     ) -> Optional[TaskResult]:
         """
         Assess each channel's feasibility and return a Decision (no execution).
         Plugin is judged separately; qwenpaw/openfang/browser/computer are merged into one LLM call.
         Actual execution is dispatched uniformly by agent_server.
+
+        ``proactive`` marks a self-initiated turn (lanlan spoke with no fresh user
+        input). There is no new user request, so the actionable intent is taken
+        from lanlan's own latest utterance instead of the (stale) latest user
+        line.
         """
         # Bind active character for {MASTER_NAME}/{LANLAN_NAME} substitution
         # in any LLM call made under this analyze_and_execute (assess_user_plugin
@@ -1795,6 +1817,7 @@ class DirectTaskExecutor:
                 conversation_id=conversation_id,
                 lang=lang,
                 external_intent=external_intent,
+                proactive=proactive,
             )
         finally:
             reset_active_character(char_token)
@@ -1866,6 +1889,7 @@ class DirectTaskExecutor:
         conversation_id: Optional[str] = None,
         lang: str = "en",
         external_intent: Optional[float] = None,
+        proactive: bool = False,
     ) -> Optional[TaskResult]:
         task_id = str(uuid.uuid4())
 
@@ -1887,8 +1911,10 @@ class DirectTaskExecutor:
             logger.debug("[TaskExecutor] All execution channels disabled, skipping")
             return None
 
-        # 格式化对话
-        conversation = self._format_messages(messages)
+        # 格式化对话。主动搭话轮把 LATEST_USER_REQUEST 设为猫娘自己最近这句主动
+        # 台词（而非上一轮旧用户请求），让 unified / plugin 两路评估都对着主动意图
+        # 跑——两者都从 conversation 的 LATEST_USER_REQUEST 取意图。
+        conversation = self._format_messages(messages, proactive=proactive)
         if not conversation.strip():
             return None
         latest_user_request = self._extract_latest_user_intent(conversation)
@@ -1955,9 +1981,16 @@ class DirectTaskExecutor:
                 logger.warning("[TaskExecutor] Failed to check QwenPaw: %s", e)
 
         # ── 魔法命令前置拦截（仅对 openclaw/qwenpaw）──────────────────────
-        user_intent, user_attachments = self._extract_latest_user_payload(messages)
-        if not user_intent:
-            user_intent = self._extract_latest_user_intent(conversation)
+        if proactive:
+            # 主动搭话轮：意图是猫娘自己最近这句主动台词（已写进 latest_user_request /
+            # conversation 的 LATEST_USER_REQUEST），无 user 附件。绝不拿窗口里那条陈旧
+            # user 消息去 classify_magic_intent——否则旧 user 的魔法命令会被重放，或
+            # OpenClaw 派单成旧 user 文本而非主动意图。
+            user_intent, user_attachments = latest_user_request, []
+        else:
+            user_intent, user_attachments = self._extract_latest_user_payload(messages)
+            if not user_intent:
+                user_intent = self._extract_latest_user_intent(conversation)
         if qwenpaw_available and self.openclaw and user_intent and not user_attachments:
             try:
                 magic_intent = await self.openclaw.classify_magic_intent(user_intent)

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1714,6 +1714,27 @@ AGENT_EXTERNAL_GATE_THRESHOLD = 0.2
   这 90% 的易判 case，模棱两可的全 fail-open 到准确的大评估。调高 = 更激进省钱但
   漏判风险上升。"""
 
+# ── 主动搭话触发 agent（降临层，默认关）─────────────────────────────────
+# 默认情况下 analyzer 只在「新 user 轮」跑（agent_server 按 user-turn 指纹去重，
+# assistant turn_end 无新用户输入就忽略）—— 这是 product thesis 的廉价层防护。
+# 打开下面开关后，主动搭话（猫娘自发开口）也能跑一次 analyzer，让她自己起意用
+# 工具/查信息（如「我帮你查下天气」），但严格按「每会话上限」节流，绝不频发。
+AGENT_PROACTIVE_ANALYZE_ENABLED = False
+"""主动搭话触发 agent 的总开关（默认关，实验性、显式开启）。
+- 关（默认）= 维持现状：主动搭话从不跑 analyzer，只有新 user 轮才分析。
+- 开 = 主动搭话轮也带 proactive 标过河，agent_server 走独立路径：assistant 台词
+  指纹去重 + 每会话计数上限（AGENT_PROACTIVE_ANALYZE_MAX_PER_SESSION）双重节流，
+  通过才跑一次 analyzer、把猫娘的主动台词当意图评估。
+- 上游：cross_server 在 had_user_input=False 的 turn_end 打 proactive 标；
+  agent_server 的 analyze handler 分叉。"""
+
+AGENT_PROACTIVE_ANALYZE_MAX_PER_SESSION = 2
+"""每个会话内主动搭话最多触发几次 analyzer（默认 2）。
+- 计的是「主动轮 analyzer 跑的次数」（含未派出工具的），所以同时是成本上界 ——
+  一个 session 最多 N 次主动 analyzer 调用，防频发/防廉价层污染。
+- 计数在 greeting_check（新会话起点）重置；end_all 清空。
+- 调大 = 主动能力更明显但成本/打扰风险上升；0 = 等价于关。"""
+
 PLUGIN_INPUT_DESC_MAX_TOKENS = 1000
 """_ensure_short_descriptions 输入的 plugin manifest description 上限。
 - 用途：生成 short_description 时把原始 description 截断后再送入 prompt
@@ -2558,6 +2579,8 @@ __all__ = [
     'AGENT_PLUGIN_FULL_MAX_TOKENS',
     'AGENT_EXTERNAL_GATE_ENABLED',
     'AGENT_EXTERNAL_GATE_THRESHOLD',
+    'AGENT_PROACTIVE_ANALYZE_ENABLED',
+    'AGENT_PROACTIVE_ANALYZE_MAX_PER_SESSION',
     'PLUGIN_INPUT_DESC_MAX_TOKENS',
     'COMPUTER_USE_MAX_TOKENS',
     'LLM_PING_MAX_TOKENS',

--- a/main_logic/agent_event_bus.py
+++ b/main_logic/agent_event_bus.py
@@ -482,6 +482,7 @@ async def publish_analyze_request_reliably(
     retries: int = 1,
     conversation_id: Optional[str] = None,
     external_intent: Optional[float] = None,
+    proactive: bool = False,
 ) -> bool:
     """Reliably publish analyze_request: carries event_id + ack, with short retries.
 
@@ -490,6 +491,10 @@ async def publish_analyze_request_reliably(
     payload so the agent can cheaply decide whether to skip its expensive
     assessment. ``None`` (reading unavailable / no usable signal) is omitted from
     the event → the agent gate fails open (runs the assessment).
+
+    ``proactive`` marks a self-initiated (no fresh user input) turn. The agent
+    routes these through a separate throttled path instead of the user-turn
+    dedupe; omitted (not set) for ordinary user turns.
     """
     event_id = uuid.uuid4().hex
     sent_at = time.perf_counter()
@@ -507,6 +512,10 @@ async def publish_analyze_request_reliably(
         # Only an optimization hint; omitted when None so the agent fails open.
         if external_intent is not None:
             event["external_intent"] = external_intent
+        # Self-initiated turn marker; omitted for ordinary user turns so the
+        # agent's user-turn path is byte-for-byte unchanged when disabled.
+        if proactive:
+            event["proactive"] = True
 
         loop = asyncio.get_running_loop()
         waiter: asyncio.Future = loop.create_future()

--- a/main_logic/cross_server.py
+++ b/main_logic/cross_server.py
@@ -59,8 +59,15 @@ emoji_pattern2 = re.compile("["
 emotion_pattern = re.compile('<(.*?)>')
 
 
-async def _publish_analyze_request_with_fallback(lanlan_name: str, trigger: str, messages: list[dict], *, conversation_id: str | None = None) -> bool:
-    """Publish analyze request via EventBus with ack/retry."""
+async def _publish_analyze_request_with_fallback(lanlan_name: str, trigger: str, messages: list[dict], *, conversation_id: str | None = None, had_user_input: bool = True) -> bool:
+    """Publish analyze request via EventBus with ack/retry.
+
+    ``had_user_input`` is False for a proactive turn (lanlan spoke with no fresh
+    user input). Such turns carry NO user-text gate hint (master-emotion never
+    re-ran, and the "latest user message" here is a stale prior turn) and are
+    marked ``proactive=True`` so the agent routes them through its throttled
+    proactive path instead of the user-turn dedupe (which would drop them).
+    """
     try:
         # Optional optimization hint: the cheap pre-gate signal the master-emotion
         # call produced at input-time, matched to THIS turn's latest user message.
@@ -68,23 +75,24 @@ async def _publish_analyze_request_with_fallback(lanlan_name: str, trigger: str,
         # lazy-import/read failure degrades to None (the agent gate then fails open
         # and runs its assessment). turn_end also never blocks on the emotion call,
         # so this only reads an already-cached value. Cache miss / disabled / stale
-        # (different turn) / no-signal → None.
+        # (different turn) / no-signal / proactive turn → None.
         external_intent = None
-        try:
-            from main_logic.activity.master_emotion import gate_signal_for
-            _latest_user_msg = next(
-                (m for m in reversed(messages) if isinstance(m, dict) and m.get("role") == "user"),
-                None,
-            )
-            # Skip the gate hint when the latest user turn carries attachments:
-            # the actionable intent may live in the image, which the text-only
-            # signal never saw → leave external_intent None so the agent fails open
-            # and assesses the turn (never drop an image-driven task).
-            if _latest_user_msg is not None and not _latest_user_msg.get("attachments"):
-                _latest_user_text = str(_latest_user_msg.get("content") or _latest_user_msg.get("text") or "")
-                external_intent = gate_signal_for(lanlan_name, _latest_user_text)
-        except Exception:
-            external_intent = None
+        if had_user_input:
+            try:
+                from main_logic.activity.master_emotion import gate_signal_for
+                _latest_user_msg = next(
+                    (m for m in reversed(messages) if isinstance(m, dict) and m.get("role") == "user"),
+                    None,
+                )
+                # Skip the gate hint when the latest user turn carries attachments:
+                # the actionable intent may live in the image, which the text-only
+                # signal never saw → leave external_intent None so the agent fails
+                # open and assesses the turn (never drop an image-driven task).
+                if _latest_user_msg is not None and not _latest_user_msg.get("attachments"):
+                    _latest_user_text = str(_latest_user_msg.get("content") or _latest_user_msg.get("text") or "")
+                    external_intent = gate_signal_for(lanlan_name, _latest_user_text)
+            except Exception:
+                external_intent = None
         sent = await publish_analyze_request_reliably(
             lanlan_name=lanlan_name,
             trigger=trigger,
@@ -93,6 +101,7 @@ async def _publish_analyze_request_with_fallback(lanlan_name: str, trigger: str,
             retries=1,
             conversation_id=conversation_id,
             external_intent=external_intent,
+            proactive=not had_user_input,
         )
         if sent:
             logger.debug(
@@ -1142,11 +1151,19 @@ async def run_sync_connector(
                                         if recent and has_user and latest_user_is_avatar_drop:
                                             logger.info(f"[{lanlan_name}] analyze_request skipped (avatar_drop turn_end), messages={len(recent)}")
                                         elif recent and not is_agent_callback_turn_end:
+                                            # had_user_input gates the proactive marking: a turn with no
+                                            # user text but WITH a fresh user image (screenshot/camera) is
+                                            # still a user turn — count its attachments as input so it is
+                                            # NOT mis-marked proactive (which, with the feature off, would
+                                            # drop the image task). Only a genuinely self-initiated turn
+                                            # (no text, no image) is proactive.
+                                            _turn_had_user_input = had_user_input_this_turn or bool(selected_pending_user_images)
                                             sent = await _publish_analyze_request_with_fallback(
                                                 lanlan_name=lanlan_name,
                                                 trigger="turn_end",
                                                 messages=recent,
                                                 conversation_id=uuid.uuid4().hex,
+                                                had_user_input=_turn_had_user_input,
                                             )
                                             if sent:
                                                 logger.debug(f"[{lanlan_name}] analyze_request dispatch success (turn_end), messages={len(recent)}")
@@ -1246,6 +1263,9 @@ async def run_sync_connector(
                                                 trigger="session_end",
                                                 messages=recent,
                                                 conversation_id=uuid.uuid4().hex,
+                                                # session_end is terminal — never treated as proactive
+                                                # (had_user_input defaults True), so it always takes the
+                                                # ordinary user-turn path.
                                             )
                                             if sent:
                                                 logger.info(f"[{lanlan_name}] analyze_request dispatch success (session_end), messages={len(recent)}")

--- a/main_routers/websocket_router.py
+++ b/main_routers/websocket_router.py
@@ -70,18 +70,24 @@ def _fire_task(coro):
     return task
 
 
-async def _publish_agent_intent_restore_signal(lanlan_name: str) -> None:
+async def _publish_agent_intent_restore_signal(lanlan_name: str, *, new_session: bool = False) -> None:
     """Tell agent_server (via ZMQ) that a real client session is alive,
     so it can restore persisted agent runtime intent (analyzer_enabled +
     5 sub flags). Agent-side once-flag means duplicate signals are cheap.
     Failures (e.g. agent_server not up yet) are swallowed silently —
     the next greeting_check will retry, and the user-facing UI doesn't
-    depend on this restore succeeding."""
+    depend on this restore succeeding.
+
+    ``new_session`` is True only for a genuine new greeting (character switch or
+    a real gap, NOT a refresh/reconnect within the 15s window). agent_server uses
+    it to reset the per-session proactive-analyze budget, so a refresh can't farm
+    a fresh budget mid-conversation."""
     try:
         from main_logic.agent_event_bus import publish_session_event
         await publish_session_event({
             "event_type": "agent_intent_restore_signal",
             "lanlan_name": lanlan_name,
+            "new_session": bool(new_session),
         })
     except Exception as exc:
         logger.debug("[Greeting] agent intent restore signal publish failed: %s", exc)
@@ -89,6 +95,10 @@ async def _publish_agent_intent_restore_signal(lanlan_name: str) -> None:
 
 # 每个角色的 WS 断开时间戳（epoch），用于区分"首次连接"与"刷新/重连"
 _ws_disconnect_time: dict[str, float] = {}
+# 每个角色当前活跃的 WS 连接数（pet + /chat_full 等可并存）。用于判定
+# greeting_check 是不是"真·新会话"：并发开第二个窗口时不能算新会话（否则会重置
+# 主动搭话预算被刷新/多窗口 farm）。单事件循环内 inc/dec 无 await 间隙，天然原子。
+_ws_active_count: dict[str, int] = {}
 
 # ---- Telemetry helpers ----
 
@@ -250,6 +260,9 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
     # try-else 链的情形（SystemExit / KeyboardInterrupt 都不走 else）。
     _ws_disconnect_reason = "unknown"
     try:
+        # 计入活跃连接（finally 必减）。greeting_check 判定真·新会话时据此排除
+        # 「并发开第二个窗口」的情形。
+        _ws_active_count[lanlan_name] = _ws_active_count.get(lanlan_name, 0) + 1
         while True:
             data = await websocket.receive_text()
             # 安全检查：如果角色已被重命名或删除，lanlan_name 可能不再存在
@@ -392,12 +405,23 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
             elif action == "greeting_check":
                 # 首次连接或切换角色时，前端请求检查是否需要主动搭话
                 # is_switch=true 时始终触发；否则检查上次断开距今是否 >15s（排除刷新/重连）
+                is_switch = message.get("is_switch", False)
+                greeting_reason = str(message.get("reason") or "").strip().lower()[:64]
+                last_disconnect = _ws_disconnect_time.get(lanlan_name, 0)
+                since_disconnect = time.time() - last_disconnect if last_disconnect else float('inf')
+                # 触发问候的判定（保持原行为）：切角色 或 距上次断开 >15s。
+                new_session = bool(is_switch or since_disconnect > 15)
+                # 重置主动搭话预算用的更严判定：在上面基础上还要求本连接是该角色唯一
+                # 活跃连接，排除「并发开第二个窗口」（无断开时间戳 → since_disconnect=inf
+                # 假成新会话 → 重置预算被多窗口 farm）。本连接已在 try 起始处计数，唯一
+                # 时为 1。问候判定不受此约束，避免改动既有问候行为。
+                budget_new_session = new_session and _ws_active_count.get(lanlan_name, 1) <= 1
                 #
                 # 顺便：这也是 agent_server 启动后第一个"用户实际进入会话"的信号 ——
                 # 我们用它来触发 agent runtime intent restore (analyzer_enabled +
                 # 5 个 sub flag 上次会话的开关状态)。restore 是 fire-and-forget 的
                 # ZMQ event，agent_server 端有 once-flag 保证只跑一次。
-                _fire_task(_publish_agent_intent_restore_signal(lanlan_name))
+                _fire_task(_publish_agent_intent_restore_signal(lanlan_name, new_session=budget_new_session))
                 # A freshly-connected window (notably the separate /chat_full
                 # window, which has its own ws and misses any earlier Focus
                 # enter) must land on the current edge-glow brightness — push the
@@ -409,11 +433,7 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
                     # session): the focus glow/indicator is non-essential and must
                     # never block or break greeting_check, so swallow and move on.
                     pass
-                is_switch = message.get("is_switch", False)
-                greeting_reason = str(message.get("reason") or "").strip().lower()[:64]
-                last_disconnect = _ws_disconnect_time.get(lanlan_name, 0)
-                since_disconnect = time.time() - last_disconnect if last_disconnect else float('inf')
-                if is_switch or since_disconnect > 15:
+                if new_session:
                     if await has_new_character_greeting_pending(_config_manager, lanlan_name):
                         logger.info(f"[{lanlan_name}] greeting_check: is_switch={is_switch} since_disconnect={since_disconnect:.1f}s reason={greeting_reason or '-'} → new character greeting")
                         _fire_task(session_manager[lanlan_name].trigger_new_character_greeting())
@@ -502,6 +522,8 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
         logger.info(f"Cleaning up WebSocket resources: {websocket.client}")
         # 记录 WS 断开时间，供下次连接时判断是否为"刷新/重连"
         _ws_disconnect_time[lanlan_name] = time.time()
+        # 释放活跃连接计数（与 try 起始处的 +1 对偶）
+        _ws_active_count[lanlan_name] = max(0, _ws_active_count.get(lanlan_name, 1) - 1)
         # 释放 capture_bridge 注册并 resolve 其所有 pending futures 为错误，
         # 让 /api/capture/health 立即返回 503。
         try:

--- a/tests/unit/test_proactive_agent_trigger.py
+++ b/tests/unit/test_proactive_agent_trigger.py
@@ -189,6 +189,28 @@ def test_redact_preserves_proactive_utterance(monkeypatch):
     assert _has_proactive(a._redact_cancelled_user_turns(msgs, "lan", preserve_trailing_assistant=True))
 
 
+def test_redact_cancelled_user_without_reply_before_proactive(monkeypatch):
+    # Codex P2: a cancelled user turn that produced NO assistant reply, followed
+    # by a proactive utterance. The trailing proactive assistant must not count as
+    # that user's "first-time" reply (trailing_assistant_count==1 bypass), else the
+    # cancelled request leaks into the proactive assessment. It must be redacted
+    # while the proactive utterance is still preserved.
+    user_msg = {"role": "user", "content": "取消了的旧请求（没产出回复）"}
+    msgs = [
+        user_msg,
+        {"role": "assistant", "content": "我帮你查下天气"},  # proactive utterance (only trailing assistant)
+    ]
+    sig = a._user_message_signature(user_msg)
+    monkeypatch.setattr(a._task_tracker, "get_cancelled_user_sigs", lambda ln: {sig})
+
+    out = a._redact_cancelled_user_turns(msgs, "lan", preserve_trailing_assistant=True)
+    # cancelled user text redacted (replaced by the system marker), not leaked
+    assert not any(m.get("role") == "user" and "取消了的旧请求" in str(m.get("content", "")) for m in out)
+    assert any(m.get("role") == "system" and m.get("content") == a.REDACTED_USER_TURN_MARKER for m in out)
+    # proactive utterance still survives for the downstream assessment
+    assert any(m.get("role") == "assistant" and "天气" in str(m.get("content", "")) for m in out)
+
+
 # ── executor uses the assistant utterance as LATEST_USER_REQUEST on proactive ─
 def test_executor_format_messages_proactive_intent():
     ex = DirectTaskExecutor(computer_use=object())

--- a/tests/unit/test_proactive_agent_trigger.py
+++ b/tests/unit/test_proactive_agent_trigger.py
@@ -1,0 +1,195 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the opt-in proactive-analyze path.
+
+A proactive (self-initiated, no fresh user input) turn would be dropped by the
+ordinary user-turn dedupe, so it is routed through a separate throttled path
+(``_handle_proactive_analyze``), bounded by the master switch, an assistant-text
+fingerprint, and a per-session count cap. lanlan's own latest utterance becomes
+the actionable intent for the assessment.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import app.agent_server as a
+from brain.task_executor import DirectTaskExecutor
+
+
+def _proactive_msgs(assistant_text: str):
+    # A proactive window: the latest user line is a STALE prior turn, the new
+    # content is lanlan's own assistant utterance.
+    return [
+        {"role": "user", "content": "之前那句旧闲聊"},
+        {"role": "assistant", "content": assistant_text},
+    ]
+
+
+def _patch_dispatch(monkeypatch):
+    """Replace the dispatch tail so no coroutine/loop is needed; capture calls."""
+    calls = []
+    monkeypatch.setattr(a, "_background_analyze_and_plan", lambda *args, **kw: ("BAP", kw))
+    monkeypatch.setattr(a, "_create_tracked_task", lambda x: calls.append(x))
+    return calls
+
+
+def _reset_state():
+    a.Modules.proactive_analyze_count.clear()
+    a.Modules.last_proactive_assistant_fingerprint.clear()
+
+
+# ── assistant-turn fingerprint ───────────────────────────────────────
+def test_assistant_fingerprint():
+    m1 = _proactive_msgs("我帮你查下天气")
+    m2 = _proactive_msgs("我帮你查下天气")
+    m3 = _proactive_msgs("我给你推首歌")
+    assert a._build_assistant_turn_fingerprint(m1) == a._build_assistant_turn_fingerprint(m2)
+    assert a._build_assistant_turn_fingerprint(m1) != a._build_assistant_turn_fingerprint(m3)
+    # no assistant text → None (also the "no assistant utterance" skip signal)
+    assert a._build_assistant_turn_fingerprint([{"role": "user", "content": "x"}]) is None
+    # role match is case-insensitive (consistent with the executor's intent extractor)
+    assert a._build_assistant_turn_fingerprint([{"role": "Assistant", "content": "hi"}]) is not None
+
+
+# ── _handle_proactive_analyze gating ─────────────────────────────────
+def test_proactive_disabled_does_not_dispatch(monkeypatch):
+    _reset_state()
+    calls = _patch_dispatch(monkeypatch)
+    monkeypatch.setattr(a, "AGENT_PROACTIVE_ANALYZE_ENABLED", False)  # default
+    a._handle_proactive_analyze(_proactive_msgs("我帮你查天气"), "lan", "lan", "c")
+    assert calls == []
+    assert a.Modules.proactive_analyze_count.get("lan", 0) == 0
+
+
+def test_proactive_enabled_dispatches_with_assistant_intent(monkeypatch):
+    _reset_state()
+    calls = _patch_dispatch(monkeypatch)
+    monkeypatch.setattr(a, "AGENT_PROACTIVE_ANALYZE_ENABLED", True)
+    monkeypatch.setattr(a, "AGENT_PROACTIVE_ANALYZE_MAX_PER_SESSION", 2)
+    a._handle_proactive_analyze(_proactive_msgs("我帮你查天气"), "lan", "lan", "c")
+    assert len(calls) == 1
+    # dispatched with proactive=True and no gate signal (fails open into assess)
+    _, kw = calls[0]
+    assert kw.get("proactive") is True and kw.get("external_intent") is None
+    assert a.Modules.proactive_analyze_count["lan"] == 1
+
+
+def test_proactive_no_assistant_text_skips(monkeypatch):
+    _reset_state()
+    calls = _patch_dispatch(monkeypatch)
+    monkeypatch.setattr(a, "AGENT_PROACTIVE_ANALYZE_ENABLED", True)
+    a._handle_proactive_analyze([{"role": "user", "content": "x"}], "lan", "lan", "c")
+    assert calls == []
+
+
+def test_proactive_duplicate_utterance_deduped(monkeypatch):
+    _reset_state()
+    calls = _patch_dispatch(monkeypatch)
+    monkeypatch.setattr(a, "AGENT_PROACTIVE_ANALYZE_ENABLED", True)
+    monkeypatch.setattr(a, "AGENT_PROACTIVE_ANALYZE_MAX_PER_SESSION", 5)
+    msgs = _proactive_msgs("我帮你查天气")
+    a._handle_proactive_analyze(msgs, "lan", "lan", "c")
+    a._handle_proactive_analyze(msgs, "lan", "lan", "c")  # identical → deduped
+    assert len(calls) == 1
+    assert a.Modules.proactive_analyze_count["lan"] == 1
+
+
+def test_proactive_per_session_cap(monkeypatch):
+    _reset_state()
+    calls = _patch_dispatch(monkeypatch)
+    monkeypatch.setattr(a, "AGENT_PROACTIVE_ANALYZE_ENABLED", True)
+    monkeypatch.setattr(a, "AGENT_PROACTIVE_ANALYZE_MAX_PER_SESSION", 2)
+    # distinct utterances each time so dedupe never blocks — only the cap does.
+    for i in range(4):
+        a._handle_proactive_analyze(_proactive_msgs(f"主动台词{i}"), "lan", "lan", "c")
+    assert len(calls) == 2  # capped at 2
+    assert a.Modules.proactive_analyze_count["lan"] == 2
+
+
+def test_proactive_cap_is_per_lanlan(monkeypatch):
+    _reset_state()
+    calls = _patch_dispatch(monkeypatch)
+    monkeypatch.setattr(a, "AGENT_PROACTIVE_ANALYZE_ENABLED", True)
+    monkeypatch.setattr(a, "AGENT_PROACTIVE_ANALYZE_MAX_PER_SESSION", 1)
+    a._handle_proactive_analyze(_proactive_msgs("A"), "lanA", "lanA", "c")
+    a._handle_proactive_analyze(_proactive_msgs("B"), "lanB", "lanB", "c")
+    assert len(calls) == 2  # each lanlan has its own budget
+    assert a.Modules.proactive_analyze_count["lanA"] == 1
+    assert a.Modules.proactive_analyze_count["lanB"] == 1
+
+
+# ── greeting_check resets the budget only on a genuine new session ───
+def test_genuine_new_session_resets_budget(monkeypatch):
+    _reset_state()
+    async def _noop():
+        return
+    monkeypatch.setattr(a, "_maybe_restore_agent_intent", _noop)
+    a.Modules.proactive_analyze_count["lan"] = 2
+    a.Modules.last_proactive_assistant_fingerprint["lan"] = "deadbeef"
+    asyncio.run(a._on_session_event({
+        "event_type": "agent_intent_restore_signal", "lanlan_name": "lan", "new_session": True,
+    }))
+    assert "lan" not in a.Modules.proactive_analyze_count
+    assert "lan" not in a.Modules.last_proactive_assistant_fingerprint
+
+
+def test_refresh_does_not_reset_budget(monkeypatch):
+    # A refresh/reconnect (new_session falsey) must NOT reset the budget — else a
+    # user could refresh to farm a fresh cap mid-conversation.
+    _reset_state()
+    async def _noop():
+        return
+    monkeypatch.setattr(a, "_maybe_restore_agent_intent", _noop)
+    a.Modules.proactive_analyze_count["lan"] = 2
+    asyncio.run(a._on_session_event({
+        "event_type": "agent_intent_restore_signal", "lanlan_name": "lan",  # no new_session
+    }))
+    assert a.Modules.proactive_analyze_count.get("lan") == 2
+
+
+# ── cancel redaction preserves the proactive utterance ──────────────
+def test_redact_preserves_proactive_utterance(monkeypatch):
+    user_msg = {"role": "user", "content": "取消了的旧请求"}
+    msgs = [
+        user_msg,
+        {"role": "assistant", "content": "旧任务回复"},
+        {"role": "assistant", "content": "我帮你查下天气"},  # proactive utterance (trailing)
+    ]
+    sig = a._user_message_signature(user_msg)
+    monkeypatch.setattr(a._task_tracker, "get_cancelled_user_sigs", lambda ln: {sig})
+
+    def _has_proactive(out):
+        return any(m.get("role") == "assistant" and "天气" in str(m.get("content", "")) for m in out)
+
+    # default: the trailing proactive assistant is dropped with the cancelled user
+    assert not _has_proactive(a._redact_cancelled_user_turns(msgs, "lan"))
+    # preserve_trailing_assistant: the proactive utterance survives
+    assert _has_proactive(a._redact_cancelled_user_turns(msgs, "lan", preserve_trailing_assistant=True))
+
+
+# ── executor uses the assistant utterance as LATEST_USER_REQUEST on proactive ─
+def test_executor_format_messages_proactive_intent():
+    ex = DirectTaskExecutor(computer_use=object())
+    msgs = [
+        {"role": "user", "content": "旧请求"},
+        {"role": "assistant", "content": "我帮你查下天气吧"},
+    ]
+    # proactive: LATEST_USER_REQUEST is lanlan's own utterance, not the old user line
+    conv_p = ex._format_messages(msgs, proactive=True)
+    assert "LATEST_USER_REQUEST: 我帮你查下天气吧" in conv_p
+    assert ex._extract_latest_user_intent(conv_p) == "我帮你查下天气吧"
+    # ordinary turn: LATEST_USER_REQUEST is the user line
+    conv_u = ex._format_messages(msgs, proactive=False)
+    assert "LATEST_USER_REQUEST: 旧请求" in conv_u

--- a/tests/unit/test_proactive_agent_trigger.py
+++ b/tests/unit/test_proactive_agent_trigger.py
@@ -61,6 +61,16 @@ def test_assistant_fingerprint():
     assert a._build_assistant_turn_fingerprint([{"role": "user", "content": "x"}]) is None
     # role match is case-insensitive (consistent with the executor's intent extractor)
     assert a._build_assistant_turn_fingerprint([{"role": "Assistant", "content": "hi"}]) is not None
+    # keyed to the LATEST assistant utterance only → history-independent: the same
+    # trailing line with different prior assistant records still dedupes (so a
+    # re-send after the window grew can't slip past the gate and burn a slot).
+    only = [{"role": "assistant", "content": "我帮你查下天气"}]
+    with_history = [
+        {"role": "assistant", "content": "更早的一句"},
+        {"role": "user", "content": "中间的用户话"},
+        {"role": "assistant", "content": "我帮你查下天气"},
+    ]
+    assert a._build_assistant_turn_fingerprint(only) == a._build_assistant_turn_fingerprint(with_history)
 
 
 # ── _handle_proactive_analyze gating ─────────────────────────────────

--- a/tests/unit/test_proactive_agent_trigger.py
+++ b/tests/unit/test_proactive_agent_trigger.py
@@ -240,6 +240,73 @@ def test_redact_cancelled_one_reply_turn_before_proactive(monkeypatch):
     assert any(m.get("role") == "user" and "取消了的旧请求" in str(m.get("content", "")) for m in kept)
 
 
+# ── proactive OpenClaw dispatch forces the default sender ────────────
+def test_proactive_openclaw_dispatch_uses_default_sender(monkeypatch):
+    # A proactive OpenClaw task has no triggering user; the latest user in the
+    # window is a stale prior turn. Its sender_id must NOT be used — otherwise a
+    # self-initiated action (or proactive /stop) runs under that user's
+    # persistent OpenClaw session in multi-user setups. Proactive → default sender.
+    from app.agent_server.channels import openclaw as oc
+
+    captured = {}
+
+    class _FakeOpenClaw:
+        default_sender_id = "DEFAULT_SENDER"
+
+        def normalize_magic_command(self, x):
+            return None  # non-magic path
+
+        def get_or_create_persistent_session_id(self, *, role_name, sender_id):
+            captured["sender_id"] = sender_id
+            return "sess-1"
+
+        async def run_instruction(self, *a, **kw):
+            return {"success": True, "reply": ""}
+
+    monkeypatch.setitem(oc._shared.Modules.agent_flags, "openclaw_enabled", True)
+    monkeypatch.setattr(oc._shared.Modules, "openclaw", _FakeOpenClaw())
+
+    async def _noop_emit(*a, **kw):
+        return None
+    monkeypatch.setattr(oc, "_emit_main_event", _noop_emit)
+    monkeypatch.setattr(oc, "_emit_task_result", _noop_emit)
+    monkeypatch.setattr(oc._task_tracker, "record_assigned", lambda *a, **kw: None)
+
+    class _Result:
+        task_id = "t1"
+        task_description = "查天气"
+        tool_args = {"instruction": "查一下天气"}
+
+    # messages carry a stale user with an explicit sender_id
+    msgs = [
+        {"role": "user", "content": "旧请求", "sender_id": "USER_A"},
+        {"role": "assistant", "content": "我帮你查下天气"},
+    ]
+
+    async def _drive():
+        await oc.dispatch(
+            _Result(), messages=msgs, lanlan_name="lan",
+            conversation_id="c", trigger_user_msg_sig=None, proactive=True,
+        )
+        await asyncio.sleep(0.02)  # let the spawned run_instruction task settle
+
+    asyncio.run(_drive())
+    assert captured.get("sender_id") == "DEFAULT_SENDER"
+
+    # sanity: a non-proactive dispatch DOES resolve the stale user's sender
+    captured.clear()
+
+    async def _drive_user():
+        await oc.dispatch(
+            _Result(), messages=msgs, lanlan_name="lan",
+            conversation_id="c", trigger_user_msg_sig=None, proactive=False,
+        )
+        await asyncio.sleep(0.02)
+
+    asyncio.run(_drive_user())
+    assert captured.get("sender_id") == "USER_A"
+
+
 # ── executor uses the assistant utterance as LATEST_USER_REQUEST on proactive ─
 def test_executor_format_messages_proactive_intent():
     ex = DirectTaskExecutor(computer_use=object())

--- a/tests/unit/test_proactive_agent_trigger.py
+++ b/tests/unit/test_proactive_agent_trigger.py
@@ -211,6 +211,35 @@ def test_redact_cancelled_user_without_reply_before_proactive(monkeypatch):
     assert any(m.get("role") == "assistant" and "天气" in str(m.get("content", "")) for m in out)
 
 
+def test_redact_cancelled_one_reply_turn_before_proactive(monkeypatch):
+    # Codex P2 follow-up: a cancelled user turn that DID produce its own reply,
+    # then a proactive turn. The first-time bypass (trailing_assistant_count==1)
+    # must NOT fire on a proactive analyze pass — the trigger is lanlan's own
+    # utterance, not a user re-issue — so the cancelled user AND its reply are
+    # redacted, while the proactive utterance is preserved.
+    user_msg = {"role": "user", "content": "取消了的旧请求"}
+    msgs = [
+        user_msg,
+        {"role": "assistant", "content": "旧任务回复"},   # its own reply R
+        {"role": "assistant", "content": "我帮你查下天气"},  # proactive utterance A
+    ]
+    sig = a._user_message_signature(user_msg)
+    monkeypatch.setattr(a._task_tracker, "get_cancelled_user_sigs", lambda ln: {sig})
+
+    out = a._redact_cancelled_user_turns(msgs, "lan", preserve_trailing_assistant=True)
+    # neither the cancelled user text nor its reply leak into the assessment
+    assert not any(m.get("role") == "user" and "取消了的旧请求" in str(m.get("content", "")) for m in out)
+    assert not any(m.get("role") == "assistant" and "旧任务回复" in str(m.get("content", "")) for m in out)
+    assert any(m.get("role") == "system" and m.get("content") == a.REDACTED_USER_TURN_MARKER for m in out)
+    # proactive utterance survives
+    assert any(m.get("role") == "assistant" and "天气" in str(m.get("content", "")) for m in out)
+    # sanity: the non-proactive default still applies the first-time bypass
+    # (single trailing assistant → user kept), i.e. behavior only changes on proactive
+    single = [user_msg, {"role": "assistant", "content": "刚刚的回复"}]
+    kept = a._redact_cancelled_user_turns(single, "lan")
+    assert any(m.get("role") == "user" and "取消了的旧请求" in str(m.get("content", "")) for m in kept)
+
+
 # ── executor uses the assistant utterance as LATEST_USER_REQUEST on proactive ─
 def test_executor_format_messages_proactive_intent():
     ex = DirectTaskExecutor(computer_use=object())


### PR DESCRIPTION
## 背景

把已关闭的 #1993 基于**最新 main** 重新实现。#1993 因落后 main 257 个 commit、且 `app/agent_server.py` 已被 #2265 拆成包 `app/agent_server/`，merge 变成完整重移植，故关闭重做。本 PR 是它的等价重实现（v2），端口全部改动到拆分后的包结构，并原样带过 #1993 经 **9 轮 Codex/CodeRabbit/Greptile review** 打磨过的全部修复。

本特性是 #1970 / #1990 的后续，建立在 #1990 落地的 `external_intent` 前置闸之上，**不碰该信号名**。

## 这是什么

默认情况下 analyzer 只在「新 user 轮」跑：`agent_server` 按 user-turn 指纹去重（`_build_user_turn_fingerprint` 只哈希 user 消息，主动搭话轮 user 消息没变→指纹命中→提前丢弃）。「assistant turn_end 无新用户输入就忽略」是 product thesis 的**廉价层防护**，by-design。

本 PR 在此之上加一条**可选、受控**的主动触发路径：打开总开关后，主动搭话（猫娘自发开口、无新用户输入的 turn）也能起意用 agent 工具/查信息（如「我帮你查下天气」），但**默认关、严格节流、绝不频发**。

## 三道闸（节流语义）

主动轮走独立路径 `_handle_proactive_analyze`，任一闸不过即跳过：

1. **总开关** `AGENT_PROACTIVE_ANALYZE_ENABLED`（默认 `False`）—— 关时主动轮从不跑 analyzer，行为与现状逐字节一致。
2. **assistant 台词指纹去重** —— 同一句主动台词（re-send / 重复 turn_end）指纹相同 → 只分析一次。`fp is None`（无 assistant 台词）也走此闸跳过。
3. **每会话计数上限** `AGENT_PROACTIVE_ANALYZE_MAX_PER_SESSION`（默认 `2`）—— 计的是「主动 analyzer 跑的次数」（含未派单的），所以是成本硬上界。计数在 `greeting_check` 的**真·新会话**重置，`end_all` 清空。名额与去重指纹在派单**前**占位，防并发主动事件同时过闸。

## 默认关的行为对比

| | 默认（关） | 开启后 |
|---|---|---|
| 新 user 轮 | 跑 analyzer（不变） | 跑 analyzer（不变） |
| 主动搭话轮 | 指纹命中被丢弃（不变） | 走 proactive 路径，三道闸通过才跑一次 |
| `analyze_request` event | 无 `proactive` 字段（payload 逐字节不变） | `had_user_input=False` 且无 fresh 图片时带 `proactive=True` |

关闭时事件 payload、user-turn 路径、指纹去重全部与主线一致。

## 移植的 reviewer 修复（都是真 bug）

- **image-only turn 计 user 输入**：turn 无 user 文本但有 fresh 用户图片仍是 user 轮，把 `selected_pending_user_images` 算进 `had_user_input`，否则默认关时图片任务被误判 proactive 吞掉。
- **proactive 不绑陈旧 user 签名**：`trigger_user_msg_sig = None if proactive`，否则取消主动任务会误 redact 旧 user 轮。
- **redaction 保留主动台词**：`preserve_trailing_assistant`，主动轮紧跟被取消 user 任务时不连带吞掉主动台词（白耗预算不派单）。
- **`_format_messages(proactive=True)`**：`LATEST_USER_REQUEST` 取最近 assistant 台词（unified + plugin 两路都从该 marker 取意图）；OpenClaw 魔法命令拦截也用主动意图，不重放旧 user 文本。
- **多窗口不 farm 预算**：`_ws_active_count` 计活跃连接，`budget_new_session` 要求唯一活跃连接才重置预算（问候判定不受此约束，行为不变）。
- **预算重置前置于 `restore await`**：restore 抛错不会让真·新会话卡在旧 cap / 指纹。
- assistant role 比较统一 `.lower()`（与下游意图抽取一致）；proactive 不送 gate 信号 → 自然 fail-open。

## 回归报告

改动触及 `app/agent_server/`、`main_logic/`、`main_routers/`、`brain/`、`config/`。默认关，主线路径行为不变。

**新增单测** `tests/unit/test_proactive_agent_trigger.py`（11 例，全绿）：assistant 指纹、启用/禁用/去重/每会话上限/per-lanlan、真新会话重置 vs 刷新不重置、redaction preserve、`_format_messages` 主动意图。

**回归验证**（主仓库 venv，cwd=worktree，全绿）：
- `tests/unit/test_proactive_agent_trigger.py` —— 11 passed
- `test_agent_external_gate` / `test_master_emotion` / `test_agent_runtime_intent` / `test_module_layering` —— 91 passed
- `test_agent_server_hardening` / `test_agent_server_voice_bridge` —— 13 passed
- `scripts/check_core_contracts.py` —— exit 0
- 导入健全性：`app.agent_server` / `main_logic.*` / `main_routers.websocket_router` / `brain.task_executor` / `config` 全部 import OK，新 config 常量与 facade 符号可访问。

蓝本来源：已关闭的 #1993（分支 `claude/proactive-agent-trigger`，9 轮 review 终态 `be42f8666`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
