### PR TITLE
fix(core): 热切换中止时已注入的 pending_extra_replies 塞回队首，不再净丢失

### DIFF
--- a/main_logic/core/_shared.py
+++ b/main_logic/core/_shared.py
@@ -204,6 +204,11 @@ def _get_chat_locale_text(language: str | None, key: str, fallback: str) -> str:
 # session/websocket while also inflating session_start_failure_count.
 _START_LLM_CONCURRENT_ABORTED = object()
 
+# 强引用兜底：事件循环只弱引用 task，分离的收尸 task（lifecycle 的 listener
+# 取消超时 fail-close 后等旧 listener 退出再关旧 session）若无人持有可能被
+# GC 掐死在半路。add + done_callback(discard) 模式。
+_ORPHAN_SESSION_REAPER_TASKS: set = set()
+
 
 @dataclass(frozen=True)
 class ContextAppendResult:

--- a/main_logic/core/lifecycle.py
+++ b/main_logic/core/lifecycle.py
@@ -1582,17 +1582,16 @@ class LifecycleMixin:
             logger.error(f"💥 Extra Reply: preparation trigger error: {e}")
 
     def _restore_undelivered_swap_extras(self, injected_extras: list) -> None:
-        """[Hot-swap related] Return injected-but-undelivered extras to the queue head.
+        """[Hot-swap related] Return removed-but-undelivered extras to the queue head.
 
-        ``_perform_final_swap_sequence`` removes the budget-selected extras
-        from ``pending_extra_replies`` right after priming them into the
-        pending session. When the swap later aborts on an exit where that
-        primed session is discarded (old-listener cancel timeout, promote CAS
-        loss, external cancellation, post-promote ws fail-close), the prime
-        went into a session that will never speak — semantically the same as
-        "never injected". Mirror the surviving ``_deferred`` entries (which
-        already stay queued across these aborts): put the selected ones back
-        at the queue head so the next hot-swap delivers them.
+        ``_perform_final_swap_sequence`` keeps ``pending_extra_replies``
+        untouched through the prime window and removes the budget-selected
+        entries only at promote success — so every pre-promote abort keeps the
+        queue intact and needs no restore. The one exit where removal has
+        already happened but the promoted session dies before speaking is the
+        post-promote ws-invalid fail-close: put the removed entries back at
+        the queue head so the next hot-swap delivers them, mirroring the
+        ``_deferred`` entries that stay queued across aborts.
         """
         if not injected_extras:
             return
@@ -1669,10 +1668,12 @@ class LifecycleMixin:
         try:
             new_session = None  # 提前初始化，确保 except 块安全访问（实际赋值在 PERFORM ACTUAL HOT SWAP 段）
             old_listener_cancel_timed_out = False  # 旧 listener 取消超时标志，供 except 块做 fail-close 决策
-            # 注入 pending_session 后从队列摘走的 _selected 快照。swap 在注入后
-            # 中止且被注入的 session 被丢弃时，各出口用它把条目塞回队列
-            # （_restore_undelivered_swap_extras），与存活的 _deferred 行为对齐。
-            _injected_extras: list = []
+            # 已注入 pending_session 的 _selected 条目引用（队列原地保留，promote
+            # 成功时才移除）；_removed_extras 是 promote 时真正移除掉的子集，仅
+            # 供 promote 后 ws 失效 fail-close 这一个出口塞回（那时移除已发生、
+            # 会话已死）。其余中止出口队列本来就没动，无需恢复。
+            _prime_selected_extras: list = []
+            _removed_extras: list = []
             next_session_context_messages = getattr(self, "next_session_context_messages", []) or []
             incremental_next_session_context = next_session_context_messages[
                 self.initial_next_session_context_snapshot_len:
@@ -1713,12 +1714,15 @@ class LifecycleMixin:
                     await self._reset_preparation_state(clear_main_cache=True)
                     self.is_hot_swap_imminent = False
                     return
-                # 仅在成功注入后才移除已选条目；失败时保留整队列等下一轮 hot-swap
-                # （否则 _selected 既没进模型又丢了）。over-budget 的 _deferred 留到下一轮。
-                # 同一不变量的后半段：此后任何"被注入的 session 最终没成为活跃会话"
-                # 的中止出口，都要把 _selected 塞回队列（见 _injected_extras 各恢复点）。
-                self.pending_extra_replies = _deferred
-                _injected_extras = _selected
+                # 注入成功后队列**原地不动**，只记住已选条目的对象引用；真正的
+                # 移除延迟到 promote 成功那一刻（"被注入的 session 成为活跃会话"）。
+                # 这样 prime→promote 窗口期内的并发移除方——语音主动投递成功清除
+                # （trigger_agent_callbacks 按 delivery_id 清双队列）、retraction
+                # purge、topic 语音封锁清扫、flood cap——都能正常命中队列里的条目，
+                # 不存在"被摘走的条目逃过清除、中止后又被塞回复活"的 TOCTOU 盲区；
+                # 而任何 promote 前的中止出口天然保留整个队列（与 _deferred 对齐），
+                # 无需恢复代码。over-budget 的 _deferred 留到下一轮。
+                _prime_selected_extras = _selected
             else:
                 _lang = normalize_language_code(self.user_language, format='short')
                 final_prime_text += _loc(CONTEXT_SUMMARY_READY, _lang).format(name=self.lanlan_name, master=self.master_name)
@@ -1821,10 +1825,25 @@ class LifecycleMixin:
                     await new_session.close()
                 except Exception as _e:
                     logger.debug(f"Final Swap Sequence: 中止 promote 时关闭 new_session 失败（可忽略）: {_e}")
-                # 已注入 new_session 的 _selected 随之作废，塞回队列交给
-                # 接管方纪元的下一次 hot-swap（_deferred 本来就会这样存活）。
-                self._restore_undelivered_swap_extras(_injected_extras)
+                # 队列没动过：已注入 new_session 的 _selected 仍在队列里，随
+                # 接管方纪元的下一次 hot-swap 照常投递（与 _deferred 一致）。
                 return
+            # promote 成功：被注入的 session 已成为活跃会话，注入内容必随其下一
+            # 轮回复送达——此刻才把 _selected 从队列移除。按对象身份移除：窗口期
+            # 内被并发路径（语音投递清除/retraction/清扫/cap）先行移除的条目在此
+            # 自然 no-op，不会误删同 id 重入队的新条目。_removed_extras 记录真正
+            # 移除的子集，供紧随其后的 ws 失效 fail-close 出口塞回。
+            if _prime_selected_extras:
+                _selected_obj_ids = {id(extra) for extra in _prime_selected_extras}
+                _removed_extras = [
+                    extra for extra in self.pending_extra_replies
+                    if id(extra) in _selected_obj_ids
+                ]
+                if _removed_extras:
+                    self.pending_extra_replies = [
+                        extra for extra in self.pending_extra_replies
+                        if id(extra) not in _selected_obj_ids
+                    ]
             self._require_context_append_current_delivery = True
             next_context_count_at_promote = len(self._snapshot_next_session_context_messages())
             await self._apply_pending_tts_route_after_swap()
@@ -1888,11 +1907,8 @@ class LifecycleMixin:
                     logger.debug(f"Final Swap Sequence: CancelledError 路径关闭 new_session 失败（可忽略）: {_e}")
             await self._cleanup_pending_session_resources()
             await self._reset_preparation_state(clear_main_cache=True)
-            # 被注入的 session 没有存活为当前会话 → 已注入的 _selected 永远不会
-            # 被念出，塞回队列等下一次 hot-swap。（若取消发生在 promote 之后且
-            # 会话存活，注入内容仍在其上下文里会随下一轮回复送达，不能塞回。）
-            if new_session is None or new_session is not self.session:
-                self._restore_undelivered_swap_extras(_injected_extras)
+            # 无需恢复队列：promote 前取消→队列没动过；promote 后取消→会话存活，
+            # 注入内容仍在其上下文里会随下一轮回复送达（移除是正确的终态）。
             if self.is_active and self.session and hasattr(self.session, 'handle_messages') and (not self.message_handler_task or self.message_handler_task.done()):
                 self.message_handler_task = asyncio.create_task(self.session.handle_messages())
 
@@ -1912,23 +1928,21 @@ class LifecycleMixin:
                 # 旧 listener 取消超时：旧 task 可能在本函数返回后才真正退出，
                 # 此时无法安全判断 task.done() 并补建 listener，会留下"活跃但无监听"状态。
                 # 直接 fail-close：清除会话状态让前端重连，优于让后续输入陷入僵局。
+                # （promote 前出口，队列没动过，_selected 仍在队列无需恢复。）
                 self.session = None
                 self.message_handler_task = None
                 self.is_active = False
-                # new_session 已在步骤1超时分支关闭，注入其中的 _selected 作废塞回。
-                self._restore_undelivered_swap_extras(_injected_extras)
                 return
             # 若 self.session 的 ws 已失效（promote 后 ws invalid），清除会话状态，
             # 防止 is_active=True + ws=None 让后续输入进入坏会话。
+            # 这是唯一"移除已发生（promote 时）且被注入的会话已死"的出口：把
+            # promote 时真正移除的 _removed_extras 塞回队首等下一次 hot-swap。
+            # promote 后会话存活的其他失败不塞回——注入内容仍在其上下文里会随
+            # 下一轮回复送达，塞回会造成双投。
             if self.session and isinstance(self.session, OmniRealtimeClient) and not self.session.ws:
                 self.session = None
                 self.is_active = False
-            # 放在 ws 失效 fail-close 之后判定：promote 成功但 ws 随即失效的出口
-            # （self.session 刚被清）同样属于"注入进了永远不开口的 session"。
-            # 反之 promote 后会话存活的失败（new_session is self.session），注入
-            # 内容仍在其上下文里会随下一轮回复送达，塞回会造成双投。
-            if new_session is None or new_session is not self.session:
-                self._restore_undelivered_swap_extras(_injected_extras)
+                self._restore_undelivered_swap_extras(_removed_extras)
             if self.is_active and self.session and hasattr(self.session, 'handle_messages') and (not self.message_handler_task or self.message_handler_task.done()):
                 self.message_handler_task = asyncio.create_task(self.session.handle_messages())
         finally:

--- a/main_logic/core/lifecycle.py
+++ b/main_logic/core/lifecycle.py
@@ -1582,17 +1582,25 @@ class LifecycleMixin:
         except Exception as e:
             logger.error(f"💥 Extra Reply: preparation trigger error: {e}")
 
-    def _restore_undelivered_swap_extras(self, injected_extras: list) -> None:
+    def _restore_undelivered_swap_extras(self, injected_extras: list, cb_backed_ids: set = None) -> None:
         """[Hot-swap related] Return removed-but-undelivered extras to the queue head.
 
         ``_perform_final_swap_sequence`` keeps ``pending_extra_replies``
         untouched through the prime window and removes the budget-selected
         entries only at promote success — so every pre-promote abort keeps the
-        queue intact and needs no restore. The one exit where removal has
-        already happened but the promoted session dies before speaking is the
-        post-promote ws-invalid fail-close: put the removed entries back at
-        the queue head so the next hot-swap delivers them, mirroring the
-        ``_deferred`` entries that stay queued across aborts.
+        queue intact and needs no restore. The exits where removal has already
+        happened but the promoted session dies before speaking (post-promote
+        ws-invalid fail-close, post-promote external cancellation) put the
+        removed entries back at the queue head so the next hot-swap delivers
+        them, mirroring the ``_deferred`` entries that stay queued across
+        aborts.
+
+        ``cb_backed_ids``: delivery ids whose paired callback was still in
+        ``pending_agent_callbacks`` at removal time. An id in this set whose
+        callback is GONE by restore time was consumed inside the window (a
+        successful voice delivery prunes both queues; the extras half no-ops
+        on checked-out entries) — restoring it would announce the callback a
+        second time on the next hot-swap, so it is dropped.
         """
         if not injected_extras:
             return
@@ -1624,12 +1632,22 @@ class LifecycleMixin:
             # topic/delivery._remove_callback_from_manager），所以排除 topic 即
             # 杜绝"窗口期内被撤回的条目经此复活"。若未来引入非 topic 的
             # retraction，这里必须改为可查询的撤回 ledger 而非 marker 复查。
+            # 窗口期消费检测：移除时有配对 cb、现在 cb 没了 ⇒ 被语音投递等
+            # 消费掉了，不塞回。extras-only 条目（移除时就无 cb）唯一投递者是
+            # hot-swap 本身，窗口内不可能被投递，放行。
+            current_cb_ids = {
+                cb.get("_callback_delivery_id")
+                for cb in (getattr(self, "pending_agent_callbacks", None) or [])
+                if isinstance(cb, dict) and cb.get("_callback_delivery_id")
+            }
+            consumed_ids = (cb_backed_ids or set()) - current_cb_ids
             restored = [
                 extra for extra in injected_extras
                 if not isinstance(extra, dict)
                 or (extra.get("source_kind") != "topic"
                     and extra.get("_callback_delivery_id") not in retracted_ids
-                    and extra.get("_callback_delivery_id") not in queued_ids)
+                    and extra.get("_callback_delivery_id") not in queued_ids
+                    and extra.get("_callback_delivery_id") not in consumed_ids)
             ]
             if not restored:
                 return
@@ -1677,10 +1695,13 @@ class LifecycleMixin:
             old_listener_cancel_timed_out = False  # 旧 listener 取消超时标志，供 except 块做 fail-close 决策
             # 已注入 pending_session 的 _selected 条目引用（队列原地保留，promote
             # 成功时才移除）；_removed_extras 是 promote 时真正移除掉的子集，仅
-            # 供 promote 后 ws 失效 fail-close 这一个出口塞回（那时移除已发生、
-            # 会话已死）。其余中止出口队列本来就没动，无需恢复。
+            # 供"移除已发生且被注入会话已死"的出口（ws 失效 fail-close、promote
+            # 后外部取消）塞回。其余中止出口队列本来就没动，无需恢复。
+            # _removed_cb_backed_ids：移除时配对 callback 仍在 pending_agent_callbacks
+            # 的 delivery_id——restore 用它识别"窗口期内被语音投递消费"的条目。
             _prime_selected_extras: list = []
             _removed_extras: list = []
+            _removed_cb_backed_ids: set = set()
             next_session_context_messages = getattr(self, "next_session_context_messages", []) or []
             incremental_next_session_context = next_session_context_messages[
                 self.initial_next_session_context_snapshot_len:
@@ -1851,6 +1872,20 @@ class LifecycleMixin:
                         extra for extra in self.pending_extra_replies
                         if id(extra) not in _selected_obj_ids
                     ]
+                    # 快照"此刻仍有配对 cb"的 delivery_id：restore 时该 id 的 cb
+                    # 若已消失，说明窗口期内被消费（语音投递成功会 prune 双队列，
+                    # extras 半边对已摘走条目 no-op），塞回会重复播报。
+                    _removed_ids = {
+                        extra.get("_callback_delivery_id")
+                        for extra in _removed_extras
+                        if isinstance(extra, dict) and extra.get("_callback_delivery_id")
+                    }
+                    _removed_cb_backed_ids = {
+                        cb.get("_callback_delivery_id")
+                        for cb in (getattr(self, "pending_agent_callbacks", None) or [])
+                        if isinstance(cb, dict)
+                        and cb.get("_callback_delivery_id") in _removed_ids
+                    }
             self._require_context_append_current_delivery = True
             next_context_count_at_promote = len(self._snapshot_next_session_context_messages())
             await self._apply_pending_tts_route_after_swap()
@@ -1926,7 +1961,7 @@ class LifecycleMixin:
             # promote 后取消→只可能来自外部 reset/end_session/新 start_session
             # prelude，它们随后都会关闭 promoted 会话，注入内容不会再投递——把
             # promote 时移除的条目塞回队首等下一次 hot-swap。
-            self._restore_undelivered_swap_extras(_removed_extras)
+            self._restore_undelivered_swap_extras(_removed_extras, _removed_cb_backed_ids)
             if self.is_active and self.session and hasattr(self.session, 'handle_messages') and (not self.message_handler_task or self.message_handler_task.done()):
                 self.message_handler_task = asyncio.create_task(self.session.handle_messages())
 
@@ -1982,7 +2017,7 @@ class LifecycleMixin:
             if self.session and isinstance(self.session, OmniRealtimeClient) and not self.session.ws:
                 self.session = None
                 self.is_active = False
-                self._restore_undelivered_swap_extras(_removed_extras)
+                self._restore_undelivered_swap_extras(_removed_extras, _removed_cb_backed_ids)
             if self.is_active and self.session and hasattr(self.session, 'handle_messages') and (not self.message_handler_task or self.message_handler_task.done()):
                 self.message_handler_task = asyncio.create_task(self.session.handle_messages())
         finally:

--- a/main_logic/core/lifecycle.py
+++ b/main_logic/core/lifecycle.py
@@ -1962,7 +1962,11 @@ class LifecycleMixin:
             # prelude，它们随后都会关闭 promoted 会话，注入内容不会再投递——把
             # promote 时移除的条目塞回队首等下一次 hot-swap。
             self._restore_undelivered_swap_extras(_removed_extras, _removed_cb_backed_ids)
-            if self.is_active and self.session and hasattr(self.session, 'handle_messages') and (not self.message_handler_task or self.message_handler_task.done()):
+            # post-promote 取消（_removed_extras 非空）不重启 listener：promoted
+            # 会话即将被 canceller 关闭，重启会让它在关闭前把已 prime 的内容
+            # 播出来，与刚塞回的队列形成双投；没有 listener，服务器响应不会被
+            # 消费播出。重启只服务 promote 前取消后"老会话失去 listener"的恢复。
+            if self.is_active and self.session and hasattr(self.session, 'handle_messages') and not _removed_extras and (not self.message_handler_task or self.message_handler_task.done()):
                 self.message_handler_task = asyncio.create_task(self.session.handle_messages())
 
         except Exception as e:

--- a/main_logic/core/lifecycle.py
+++ b/main_logic/core/lifecycle.py
@@ -1617,6 +1617,12 @@ class LifecycleMixin:
             # retracted_ids 看不见，塞回会绕过 _drop_pending_topic_hooks_for_voice
             # 的清扫在语音里复活被禁止的 hook；且 TopicHookPool 有自己的
             # ack/retry 簿记，丢掉 extra 不会丢内容。
+            # ⚠️前提：retraction 目前是 topic-hook 专属机制——DELIVERY_RETRACTED_KEY
+            # 的全部设置点都 gate 在 channel=="topic_hook" 或只从 topic 投递流可达
+            # （proactive.py 三处 + proactive_delivery.retract 唯一调用链
+            # topic/delivery._remove_callback_from_manager），所以排除 topic 即
+            # 杜绝"窗口期内被撤回的条目经此复活"。若未来引入非 topic 的
+            # retraction，这里必须改为可查询的撤回 ledger 而非 marker 复查。
             restored = [
                 extra for extra in injected_extras
                 if not isinstance(extra, dict)

--- a/main_logic/core/lifecycle.py
+++ b/main_logic/core/lifecycle.py
@@ -27,6 +27,7 @@ from websockets import exceptions as web_exceptions
 from fastapi import WebSocket
 from main_logic.omni_realtime_client import OmniRealtimeClient
 from main_logic.omni_offline_client import OmniOfflineClient, _is_safety_violation_signal
+from main_logic.proactive_delivery import DELIVERY_RETRACTED_KEY
 from utils.gptsovits_config import is_gsv_disabled_voice_id
 from config.prompts.prompts_sys import _loc, CONTEXT_SUMMARY_READY
 from utils.config_manager import _as_bool
@@ -291,7 +292,18 @@ class LifecycleMixin:
         # finish before we drop references, preventing races with newly created tasks.
         bg_task_ref = self.background_preparation_task
         swap_task_ref = self.final_swap_task if not from_final_swap else None
-        
+        # 自引用守卫：本清理常被 final_swap_task 自己调回（swap 的中止 handler、
+        # 入口守卫、prime 失败出口都没传 from_final_swap）。cancel 当前任务会在
+        # 下面 gather 悬挂点把 CancelledError 打回调用方 except 块，截断其后的
+        # 全部清理——生产拓扑实测 swap 各 fail-close / 恢复尾巴因此成死代码，
+        # 且 try 之前的入口守卫死在 reset 后会把 is_hot_swap_imminent 卡成 True。
+        # 当前任务一律不 cancel、不等待（等自己必死锁）。
+        _current_task = asyncio.current_task()
+        if bg_task_ref is _current_task:
+            bg_task_ref = None
+        if swap_task_ref is _current_task:
+            swap_task_ref = None
+
         tasks_to_await = []
         if bg_task_ref and not bg_task_ref.done():
             bg_task_ref.cancel()
@@ -1569,6 +1581,65 @@ class LifecycleMixin:
         except Exception as e:
             logger.error(f"💥 Extra Reply: preparation trigger error: {e}")
 
+    def _restore_undelivered_swap_extras(self, injected_extras: list) -> None:
+        """[Hot-swap related] Return injected-but-undelivered extras to the queue head.
+
+        ``_perform_final_swap_sequence`` removes the budget-selected extras
+        from ``pending_extra_replies`` right after priming them into the
+        pending session. When the swap later aborts on an exit where that
+        primed session is discarded (old-listener cancel timeout, promote CAS
+        loss, external cancellation, post-promote ws fail-close), the prime
+        went into a session that will never speak — semantically the same as
+        "never injected". Mirror the surviving ``_deferred`` entries (which
+        already stay queued across these aborts): put the selected ones back
+        at the queue head so the next hot-swap delivers them.
+        """
+        if not injected_extras:
+            return
+        try:
+            from config import AGENT_CALLBACK_QUEUE_MAX_ITEMS
+            # 窗口期内配对 callback 可能已被 retract：retraction 清扫只作用于
+            # 当时还在队列里的镜像条目，被摘走的 _selected 逃过了那一轮——
+            # 塞回前按 pending_agent_callbacks 里仍带 retracted 标记的 id 补删。
+            retracted_ids = {
+                cb.get("_callback_delivery_id")
+                for cb in (getattr(self, "pending_agent_callbacks", None) or [])
+                if isinstance(cb, dict)
+                and cb.get(DELIVERY_RETRACTED_KEY)
+                and cb.get("_callback_delivery_id")
+            }
+            queued_ids = {
+                extra.get("_callback_delivery_id")
+                for extra in self.pending_extra_replies
+                if isinstance(extra, dict) and extra.get("_callback_delivery_id")
+            }
+            # topic hook extras 一律不塞回：主线 retract 流（语音封锁清扫/ack 超时
+            # 撤回）是"打标记后同步 purge"，窗口期内发生时 marker 已消失、上面的
+            # retracted_ids 看不见，塞回会绕过 _drop_pending_topic_hooks_for_voice
+            # 的清扫在语音里复活被禁止的 hook；且 TopicHookPool 有自己的
+            # ack/retry 簿记，丢掉 extra 不会丢内容。
+            restored = [
+                extra for extra in injected_extras
+                if not isinstance(extra, dict)
+                or (extra.get("source_kind") != "topic"
+                    and extra.get("_callback_delivery_id") not in retracted_ids
+                    and extra.get("_callback_delivery_id") not in queued_ids)
+            ]
+            if not restored:
+                return
+            # 塞回队首保持原始相对顺序（_selected 本来就排在 _deferred 之前）。
+            self.pending_extra_replies = restored + self.pending_extra_replies
+            # flood guard 与 enqueue_agent_callback 对齐：drop-oldest。
+            if len(self.pending_extra_replies) > AGENT_CALLBACK_QUEUE_MAX_ITEMS:
+                self.pending_extra_replies = self.pending_extra_replies[-AGENT_CALLBACK_QUEUE_MAX_ITEMS:]
+            logger.info(
+                "Final Swap Sequence: %d undelivered extra replies restored to queue head after aborted swap",
+                len(restored),
+            )
+        except Exception as e:
+            # 塞回是尽力而为：绝不能让队列簿记反过来打断中止清理流程。
+            logger.warning(f"Final Swap Sequence: failed to restore undelivered extras: {e}")
+
     async def _perform_final_swap_sequence(self):
         """[Hot-swap related] Perform the final swap sequence"""
         logger.info("Final Swap Sequence: Starting...")
@@ -1598,6 +1669,10 @@ class LifecycleMixin:
         try:
             new_session = None  # 提前初始化，确保 except 块安全访问（实际赋值在 PERFORM ACTUAL HOT SWAP 段）
             old_listener_cancel_timed_out = False  # 旧 listener 取消超时标志，供 except 块做 fail-close 决策
+            # 注入 pending_session 后从队列摘走的 _selected 快照。swap 在注入后
+            # 中止且被注入的 session 被丢弃时，各出口用它把条目塞回队列
+            # （_restore_undelivered_swap_extras），与存活的 _deferred 行为对齐。
+            _injected_extras: list = []
             next_session_context_messages = getattr(self, "next_session_context_messages", []) or []
             incremental_next_session_context = next_session_context_messages[
                 self.initial_next_session_context_snapshot_len:
@@ -1640,7 +1715,10 @@ class LifecycleMixin:
                     return
                 # 仅在成功注入后才移除已选条目；失败时保留整队列等下一轮 hot-swap
                 # （否则 _selected 既没进模型又丢了）。over-budget 的 _deferred 留到下一轮。
+                # 同一不变量的后半段：此后任何"被注入的 session 最终没成为活跃会话"
+                # 的中止出口，都要把 _selected 塞回队列（见 _injected_extras 各恢复点）。
                 self.pending_extra_replies = _deferred
+                _injected_extras = _selected
             else:
                 _lang = normalize_language_code(self.user_language, format='short')
                 final_prime_text += _loc(CONTEXT_SUMMARY_READY, _lang).format(name=self.lanlan_name, master=self.master_name)
@@ -1743,6 +1821,9 @@ class LifecycleMixin:
                     await new_session.close()
                 except Exception as _e:
                     logger.debug(f"Final Swap Sequence: 中止 promote 时关闭 new_session 失败（可忽略）: {_e}")
+                # 已注入 new_session 的 _selected 随之作废，塞回队列交给
+                # 接管方纪元的下一次 hot-swap（_deferred 本来就会这样存活）。
+                self._restore_undelivered_swap_extras(_injected_extras)
                 return
             self._require_context_append_current_delivery = True
             next_context_count_at_promote = len(self._snapshot_next_session_context_messages())
@@ -1807,6 +1888,11 @@ class LifecycleMixin:
                     logger.debug(f"Final Swap Sequence: CancelledError 路径关闭 new_session 失败（可忽略）: {_e}")
             await self._cleanup_pending_session_resources()
             await self._reset_preparation_state(clear_main_cache=True)
+            # 被注入的 session 没有存活为当前会话 → 已注入的 _selected 永远不会
+            # 被念出，塞回队列等下一次 hot-swap。（若取消发生在 promote 之后且
+            # 会话存活，注入内容仍在其上下文里会随下一轮回复送达，不能塞回。）
+            if new_session is None or new_session is not self.session:
+                self._restore_undelivered_swap_extras(_injected_extras)
             if self.is_active and self.session and hasattr(self.session, 'handle_messages') and (not self.message_handler_task or self.message_handler_task.done()):
                 self.message_handler_task = asyncio.create_task(self.session.handle_messages())
 
@@ -1829,12 +1915,20 @@ class LifecycleMixin:
                 self.session = None
                 self.message_handler_task = None
                 self.is_active = False
+                # new_session 已在步骤1超时分支关闭，注入其中的 _selected 作废塞回。
+                self._restore_undelivered_swap_extras(_injected_extras)
                 return
             # 若 self.session 的 ws 已失效（promote 后 ws invalid），清除会话状态，
             # 防止 is_active=True + ws=None 让后续输入进入坏会话。
             if self.session and isinstance(self.session, OmniRealtimeClient) and not self.session.ws:
                 self.session = None
                 self.is_active = False
+            # 放在 ws 失效 fail-close 之后判定：promote 成功但 ws 随即失效的出口
+            # （self.session 刚被清）同样属于"注入进了永远不开口的 session"。
+            # 反之 promote 后会话存活的失败（new_session is self.session），注入
+            # 内容仍在其上下文里会随下一轮回复送达，塞回会造成双投。
+            if new_session is None or new_session is not self.session:
+                self._restore_undelivered_swap_extras(_injected_extras)
             if self.is_active and self.session and hasattr(self.session, 'handle_messages') and (not self.message_handler_task or self.message_handler_task.done()):
                 self.message_handler_task = asyncio.create_task(self.session.handle_messages())
         finally:

--- a/main_logic/core/lifecycle.py
+++ b/main_logic/core/lifecycle.py
@@ -1582,6 +1582,21 @@ class LifecycleMixin:
         except Exception as e:
             logger.error(f"💥 Extra Reply: preparation trigger error: {e}")
 
+    @staticmethod
+    def _swap_session_is_dead(session) -> bool:
+        """[Hot-swap related] Closed/unusable session detection for the swap
+        abort handlers: a dead session must be fail-closed instead of getting
+        a listener restarted on it. Realtime clients clear ``ws`` on close();
+        offline (text) clients clear ``llm`` on close().
+        """
+        if not session:
+            return False
+        if isinstance(session, OmniRealtimeClient):
+            return not session.ws
+        if isinstance(session, OmniOfflineClient):
+            return session.llm is None
+        return False
+
     def _restore_undelivered_swap_extras(self, injected_extras: list, cb_backed_ids: set = None) -> None:
         """[Hot-swap related] Return removed-but-undelivered extras to the queue head.
 
@@ -1949,12 +1964,12 @@ class LifecycleMixin:
                     logger.debug(f"Final Swap Sequence: CancelledError 路径关闭 new_session 失败（可忽略）: {_e}")
             await self._cleanup_pending_session_resources()
             await self._reset_preparation_state(clear_main_cache=True)
-            # 镜像 except Exception 的 ws 失效 fail-close：取消若落在旧会话已
-            # close() 之后（self.session 仍指向 ws 已被 close() 清空的旧会话）
-            # 或 promote 后 ws 失效，下面的重启只会给死会话建 listener——直接
-            # fail-close 让前端重连。（pending 生命周期错误触发 reset 的场景里
-            # 旧会话仍活着（ws 非空），重启行为保留。）
-            if self.session and isinstance(self.session, OmniRealtimeClient) and not self.session.ws:
+            # 镜像 except Exception 的死会话 fail-close：取消若落在旧会话已
+            # close() 之后（realtime 的 ws / 文本 offline 的 llm 已被 close()
+            # 清空）或 promote 后连接失效，下面的重启只会给死会话建 listener
+            # ——直接 fail-close 让前端重连。（pending 生命周期错误触发 reset
+            # 的场景里旧会话仍活着，重启行为保留。）
+            if self._swap_session_is_dead(self.session):
                 self.session = None
                 self.is_active = False
             # promote 前取消→队列没动过、_removed_extras 为空，此调用 no-op。
@@ -2012,13 +2027,14 @@ class LifecycleMixin:
                 self.message_handler_task = None
                 self.is_active = False
                 return
-            # 若 self.session 的 ws 已失效（promote 后 ws invalid），清除会话状态，
-            # 防止 is_active=True + ws=None 让后续输入进入坏会话。
-            # 这是唯一"移除已发生（promote 时）且被注入的会话已死"的出口：把
+            # 若 self.session 已死（promote 后 realtime ws 失效 / 文本 offline
+            # llm 被清、或取消落在旧会话 close 之后），清除会话状态，防止
+            # is_active=True + 死连接让后续输入进入坏会话。
+            # 这也是"移除已发生（promote 时）且被注入的会话已死"的出口：把
             # promote 时真正移除的 _removed_extras 塞回队首等下一次 hot-swap。
             # promote 后会话存活的其他失败不塞回——注入内容仍在其上下文里会随
             # 下一轮回复送达，塞回会造成双投。
-            if self.session and isinstance(self.session, OmniRealtimeClient) and not self.session.ws:
+            if self._swap_session_is_dead(self.session):
                 self.session = None
                 self.is_active = False
                 self._restore_undelivered_swap_extras(_removed_extras, _removed_cb_backed_ids)

--- a/main_logic/core/lifecycle.py
+++ b/main_logic/core/lifecycle.py
@@ -41,6 +41,7 @@ from ._shared import (
     IDLE_SESSION_RESET_CHECK_INTERVAL_SECONDS,
     FRONTEND_START_SESSION_TIMEOUT_SECONDS,
     _START_LLM_CONCURRENT_ABORTED,
+    _ORPHAN_SESSION_REAPER_TASKS,
 )
 from .callback_render import (
     _render_pending_extra_replies_by_origin,
@@ -1913,8 +1914,19 @@ class LifecycleMixin:
                     logger.debug(f"Final Swap Sequence: CancelledError 路径关闭 new_session 失败（可忽略）: {_e}")
             await self._cleanup_pending_session_resources()
             await self._reset_preparation_state(clear_main_cache=True)
-            # 无需恢复队列：promote 前取消→队列没动过；promote 后取消→会话存活，
-            # 注入内容仍在其上下文里会随下一轮回复送达（移除是正确的终态）。
+            # 镜像 except Exception 的 ws 失效 fail-close：取消若落在旧会话已
+            # close() 之后（self.session 仍指向 ws 已被 close() 清空的旧会话）
+            # 或 promote 后 ws 失效，下面的重启只会给死会话建 listener——直接
+            # fail-close 让前端重连。（pending 生命周期错误触发 reset 的场景里
+            # 旧会话仍活着（ws 非空），重启行为保留。）
+            if self.session and isinstance(self.session, OmniRealtimeClient) and not self.session.ws:
+                self.session = None
+                self.is_active = False
+            # promote 前取消→队列没动过、_removed_extras 为空，此调用 no-op。
+            # promote 后取消→只可能来自外部 reset/end_session/新 start_session
+            # prelude，它们随后都会关闭 promoted 会话，注入内容不会再投递——把
+            # promote 时移除的条目塞回队首等下一次 hot-swap。
+            self._restore_undelivered_swap_extras(_removed_extras)
             if self.is_active and self.session and hasattr(self.session, 'handle_messages') and (not self.message_handler_task or self.message_handler_task.done()):
                 self.message_handler_task = asyncio.create_task(self.session.handle_messages())
 
@@ -1935,6 +1947,28 @@ class LifecycleMixin:
                 # 此时无法安全判断 task.done() 并补建 listener，会留下"活跃但无监听"状态。
                 # 直接 fail-close：清除会话状态让前端重连，优于让后续输入陷入僵局。
                 # （promote 前出口，队列没动过，_selected 仍在队列无需恢复。）
+                # 旧 session 不能就地 close()（会与卡死的 recv() 并发冲突，见步骤1
+                # 注释），但裸清引用会泄漏 ws：挂分离收尸 task，等旧 listener 真正
+                # 退出后再 best-effort 关闭。listener 永不退出时与裸清引用等价
+                # （无回归），退出时 ws 得到回收。
+                _stuck_listener_task = old_main_message_handler_task
+                _orphan_old_session = old_main_session
+
+                async def _reap_old_session_after_listener_exit():
+                    if _stuck_listener_task is not None:
+                        try:
+                            await _stuck_listener_task
+                        except (asyncio.CancelledError, Exception):
+                            pass  # 收尸只关心"已退出"，退出方式无所谓
+                    if _orphan_old_session is not None:
+                        try:
+                            await _orphan_old_session.close()
+                        except Exception as _reap_err:
+                            logger.debug(f"Final Swap Sequence: 收尸关闭旧 session 失败（可忽略）: {_reap_err}")
+
+                _reaper = asyncio.create_task(_reap_old_session_after_listener_exit())
+                _ORPHAN_SESSION_REAPER_TASKS.add(_reaper)
+                _reaper.add_done_callback(_ORPHAN_SESSION_REAPER_TASKS.discard)
                 self.session = None
                 self.message_handler_task = None
                 self.is_active = False

--- a/tests/unit/test_hot_swap_cancellation.py
+++ b/tests/unit/test_hot_swap_cancellation.py
@@ -15,12 +15,18 @@ concurrent ``start_session`` winner. The fix combines three guards:
 - the promote itself is a locked CAS mirroring the start-side guard.
 
 Also covers the follow-up (greptile P1 on PR #2283): the budget-selected
-``pending_extra_replies`` entries are removed from the queue right after
-being primed into the pending session. Every abort exit where that primed
-session is discarded must restore them to the queue head — mirroring the
-``_deferred`` entries, which already survive those exits — while aborts
-where the promoted session survives must NOT restore (the primed context
-delivers on the next turn; restoring would double-deliver).
+``pending_extra_replies`` entries used to be removed from the queue right
+after being primed, so every abort exit that discarded the primed session
+lost them. The fix keeps the queue UNTOUCHED through the prime window and
+removes the selected entries (by object identity) only at promote success:
+pre-promote aborts keep the queue intact with zero restore code, concurrent
+removers (voice proactive delivery's success prune, retraction purge, the
+topic voice-block sweep, the flood cap) hit queue-resident entries normally
+— no checked-out-entry TOCTOU — and the one exit where removal has already
+happened but the promoted session dies unspoken (post-promote ws-invalid
+fail-close) restores the removed entries to the queue head. Aborts where
+the promoted session survives must NOT re-queue anything (the primed
+context delivers on the next turn; re-queueing would double-deliver).
 
 The restore tests run the swap in PRODUCTION topology (registered as
 ``mgr.final_swap_task``, exactly as turn.py creates it): the in-handler
@@ -336,15 +342,18 @@ async def _run_swap_as_final_swap_task(mgr):
     try:
         await asyncio.wait_for(task, timeout=10)
     except asyncio.CancelledError:
+        # A regressed self-cancel would end the task CANCELLED and re-raise
+        # here; swallow it so the caller's `assert not task.cancelled()` can
+        # report the regression instead of the test erroring out.
         pass
     return task
 
 
 @pytest.mark.asyncio
 async def test_final_swap_promote_cas_loss_restores_injected_extras():
-    """Promote CAS loss discards the primed session — the extras that were
-    removed from the queue and injected into it must come back, mirroring the
-    _deferred entries that already survive this exit."""
+    """Promote CAS loss discards the primed session — the selected extras
+    must remain queued for the takeover epoch's next hot-swap (the queue is
+    kept untouched through the prime window), mirroring _deferred."""
     mgr = _make_swap_manager()
     winner_session = _FakeSession("winner")
     new_session = _FakeSession("pending")
@@ -391,6 +400,10 @@ async def test_final_swap_swallowed_cancel_restores_injected_extras():
             try:
                 await asyncio.sleep(0)
             except asyncio.CancelledError:
+                # Swallow on purpose — this reproduces the 3.11 quirk where an
+                # inner await consumes the cancel (_must_cancel clears while
+                # cancelling() stays 1), so only the pre-promote checkpoint
+                # can catch it.
                 pass
 
     old_session = _SwallowExternalCancelOnClose("old")
@@ -458,9 +471,11 @@ async def test_final_swap_listener_cancel_timeout_restores_injected_extras():
 
 @pytest.mark.asyncio
 async def test_final_swap_post_promote_ws_invalid_restores_injected_extras():
-    """The 4th exit: promote succeeds but the new session's ws is already dead,
-    so the swap raises and fail-closes (session cleared). The primed session
-    never speaks — injected extras must be restored."""
+    """The 4th exit: promote succeeds (removal happens) but the new session's
+    ws is already dead, so the swap raises and fail-closes (session cleared).
+    The primed session never speaks — the promote-removed extras must be
+    restored; topic-hook extras are excluded from the restore (their
+    lifecycle belongs to the voice-block sweep / TopicHookPool retry)."""
     mgr = _make_swap_manager()
     old_session = _FakeSession("old")
     new_session = _make_fake_realtime_session("pending")
@@ -476,7 +491,9 @@ async def test_final_swap_post_promote_ws_invalid_restores_injected_extras():
     mgr._apply_pending_tts_route_after_swap = _kill_new_session_ws
 
     extra = _extra_entry("id-ws", "task W finished")
-    mgr.pending_extra_replies = [extra]
+    extra_topic = _extra_entry("id-ws-topic", "deep topic hook")
+    extra_topic["source_kind"] = "topic"
+    mgr.pending_extra_replies = [extra, extra_topic]
 
     swap_task = await _run_swap_as_final_swap_task(mgr)
 
@@ -485,7 +502,7 @@ async def test_final_swap_post_promote_ws_invalid_restores_injected_extras():
     assert mgr.session is None, "post-promote ws-invalid must fail-close the session"
     assert mgr.is_active is False
     assert mgr.pending_extra_replies == [extra], \
-        "post-promote ws-invalid abort must restore the injected extras"
+        "post-promote ws-invalid abort must restore the removed extras (topic excluded)"
 
 
 @pytest.mark.asyncio
@@ -520,9 +537,9 @@ async def test_final_swap_post_promote_failure_with_live_session_does_not_restor
 
 @pytest.mark.asyncio
 async def test_final_swap_restore_preserves_order_with_deferred_and_new_entries(monkeypatch):
-    """Restored _selected entries go to the queue HEAD: ahead of the _deferred
-    ones (which they originally preceded) and of entries enqueued during the
-    swap window."""
+    """After an abort the queue preserves original order: selected entries
+    stay in place at the head (never checked out), ahead of the deferred ones
+    and of entries enqueued during the swap window."""
     mgr = _make_swap_manager()
     winner_session = _FakeSession("winner")
     new_session = _FakeSession("pending")
@@ -558,10 +575,11 @@ async def test_final_swap_restore_preserves_order_with_deferred_and_new_entries(
 
 
 @pytest.mark.asyncio
-async def test_final_swap_restore_skips_extras_retracted_during_swap():
-    """An extra whose paired callback got retracted inside the swap window
-    escaped the retraction purge (it was already removed from the queue) —
-    the restore must re-check and drop it instead of resurrecting it."""
+async def test_final_swap_abort_leaves_retracted_extras_purgeable():
+    """A retraction landing inside the swap window must stay effective: the
+    selected entries remain queue-resident through the window (no checkout),
+    so the standard retraction purge still sees and removes them after the
+    abort — nothing escapes and nothing resurrects."""
     mgr = _make_swap_manager()
     winner_session = _FakeSession("winner")
     new_session = _FakeSession("pending")
@@ -588,44 +606,87 @@ async def test_final_swap_restore_skips_extras_retracted_during_swap():
     swap_task = await _run_swap_as_final_swap_task(mgr)
 
     assert not swap_task.cancelled()
+    # 中止后条目仍在队列（原地保留），常规 purge 照常清掉窗口期内 retract 的那条
+    mgr._purge_retracted_agent_callbacks()
     assert mgr.pending_extra_replies == [extra_kept], \
-        "restore must drop entries retracted during the swap window"
+        "a retraction inside the swap window must remain purgeable after the abort"
 
 
 @pytest.mark.asyncio
-async def test_final_swap_restore_drops_topic_hook_extras():
-    """Topic-hook extras are never restored: mainline retraction flows
-    (voice-block sweep, delivery-ack timeout) mark-and-purge synchronously, so
-    a retraction landing inside the swap window leaves no marker for the
-    restore to consult — resurrecting the entry would bypass
-    _drop_pending_topic_hooks_for_voice. TopicHookPool's own ack/retry
-    bookkeeping re-delivers the content, so dropping the extra loses nothing."""
+async def test_final_swap_abort_does_not_resurrect_concurrently_delivered_extra():
+    """greptile P1 on this PR: a voice proactive delivery completing inside
+    the swap window prunes the delivered extra from the queue by delivery_id.
+    Because selected entries stay queue-resident (no checkout), that prune
+    hits them normally and an aborted swap must NOT bring them back."""
     mgr = _make_swap_manager()
     winner_session = _FakeSession("winner")
     new_session = _FakeSession("pending")
 
-    extra_normal = _extra_entry("id-normal", "regular callback")
-    extra_topic = _extra_entry("id-topic", "deep topic hook")
-    extra_topic["source_kind"] = "topic"
+    extra_spoken = _extra_entry("id-spoken", "delivered by voice mid-swap")
+    extra_other = _extra_entry("id-other", "still pending")
 
-    class _TakeoverOnClose(_FakeSession):
+    class _VoiceDeliverThenTakeoverOnClose(_FakeSession):
         async def close(self):
             await super().close()
+            # 模拟 trigger_agent_callbacks 语音投递成功清除（按 delivery_id）
+            mgr.pending_extra_replies = [
+                e for e in mgr.pending_extra_replies
+                if e.get("_callback_delivery_id") != "id-spoken"
+            ]
             mgr.session = winner_session
             mgr.message_handler_task = object()
 
-    old_session = _TakeoverOnClose("old")
+    old_session = _VoiceDeliverThenTakeoverOnClose("old")
     mgr.session = old_session
     mgr.pending_session = new_session
     mgr.is_hot_swap_imminent = True
     mgr.message_handler_task = None
-    mgr.pending_extra_replies = [extra_normal, extra_topic]
+    mgr.pending_extra_replies = [extra_spoken, extra_other]
 
     swap_task = await _run_swap_as_final_swap_task(mgr)
 
     assert not swap_task.cancelled()
-    assert mgr.pending_extra_replies == [extra_normal], \
-        "topic-hook extras must be dropped on restore, not resurrected"
+    assert mgr.pending_extra_replies == [extra_other], \
+        "an extra delivered by voice during the swap window must not be resurrected"
+
+
+@pytest.mark.asyncio
+async def test_final_swap_ws_invalid_restore_excludes_concurrently_delivered_extra():
+    """The ws-invalid exit restores only what the promote actually removed:
+    an extra pruned by a concurrent voice delivery BEFORE promote is not in
+    the removed set and must stay gone even on the restore-carrying exit."""
+    mgr = _make_swap_manager()
+    old_session = _FakeSession("old")
+    new_session = _make_fake_realtime_session("pending")
+
+    extra_spoken = _extra_entry("id-spoken", "delivered by voice mid-swap")
+    extra_other = _extra_entry("id-other", "still pending")
+
+    async def _voice_deliver_on_old_close():
+        mgr.pending_extra_replies = [
+            e for e in mgr.pending_extra_replies
+            if e.get("_callback_delivery_id") != "id-spoken"
+        ]
+        old_session.closed = True
+
+    old_session.close = _voice_deliver_on_old_close
+    mgr.session = old_session
+    mgr.pending_session = new_session
+    mgr.is_hot_swap_imminent = True
+    mgr.message_handler_task = None
+
+    async def _kill_new_session_ws(*args, **kwargs):
+        mgr.session.ws = None
+
+    mgr._apply_pending_tts_route_after_swap = _kill_new_session_ws
+    mgr.pending_extra_replies = [extra_spoken, extra_other]
+
+    swap_task = await _run_swap_as_final_swap_task(mgr)
+
+    assert not swap_task.cancelled()
+    assert mgr.session is None
+    assert mgr.pending_extra_replies == [extra_other], \
+        "ws-invalid restore must re-queue only the promote-removed entries"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_hot_swap_cancellation.py
+++ b/tests/unit/test_hot_swap_cancellation.py
@@ -800,3 +800,52 @@ async def test_final_swap_post_promote_cancel_restores_removed_extras():
         "the handler leaves the promoted session for the canceller to close"
     assert mgr.pending_extra_replies == [extra], \
         "post-promote cancel must restore the promote-removed extras"
+
+
+@pytest.mark.asyncio
+async def test_final_swap_restore_excludes_extra_delivered_after_promote():
+    """greptile follow-up P1: a voice delivery can consume a callback AFTER
+    promote removed its extra (the delivery's extras prune no-ops on the
+    checked-out entry). The restore detects this via the paired callback
+    vanishing from pending_agent_callbacks inside the window and must not
+    re-queue the already-announced entry; an entry whose callback is still
+    pending restores normally."""
+    mgr = _make_swap_manager()
+    old_session = _FakeSession("old")
+    new_session = _FakeSession("pending")
+    mgr.session = old_session
+    mgr.pending_session = new_session
+    mgr.is_hot_swap_imminent = True
+    mgr.message_handler_task = None
+
+    extra_spoken = _extra_entry("id-spoken", "delivered by voice after promote")
+    extra_kept = _extra_entry("id-kept", "still undelivered")
+    mgr.pending_extra_replies = [extra_spoken, extra_kept]
+    mgr.pending_agent_callbacks = [
+        {"_callback_delivery_id": "id-spoken"},
+        {"_callback_delivery_id": "id-kept"},
+    ]
+
+    async def _voice_delivery_then_external_cancel(*args, **kwargs):
+        # 窗口期内语音投递成功消费 id-spoken：cb 侧被 prune；extras 侧因条目
+        # 已在 promote 时摘走而 no-op（正是被复活的那半边）。随后外部取消命中。
+        mgr.pending_agent_callbacks = [
+            cb for cb in mgr.pending_agent_callbacks
+            if cb.get("_callback_delivery_id") != "id-spoken"
+        ]
+        mgr.pending_extra_replies = [
+            e for e in mgr.pending_extra_replies
+            if e.get("_callback_delivery_id") != "id-spoken"
+        ]
+        t = asyncio.current_task()
+        t.cancel()
+        await asyncio.sleep(0)
+        return 0
+
+    mgr._prime_late_next_session_context_after_swap = _voice_delivery_then_external_cancel
+
+    swap_task = await _run_swap_as_final_swap_task(mgr)
+
+    assert mgr.session is new_session
+    assert mgr.pending_extra_replies == [extra_kept], \
+        "an extra whose callback was consumed inside the window must not be re-queued"

--- a/tests/unit/test_hot_swap_cancellation.py
+++ b/tests/unit/test_hot_swap_cancellation.py
@@ -13,12 +13,30 @@ concurrent ``start_session`` winner. The fix combines three guards:
   ``wait_for``/``close`` *swallowed* the cancel (Python 3.11 returns
   ``fut.result()`` and clears ``_must_cancel`` without re-raising);
 - the promote itself is a locked CAS mirroring the start-side guard.
+
+Also covers the follow-up (greptile P1 on PR #2283): the budget-selected
+``pending_extra_replies`` entries are removed from the queue right after
+being primed into the pending session. Every abort exit where that primed
+session is discarded must restore them to the queue head — mirroring the
+``_deferred`` entries, which already survive those exits — while aborts
+where the promoted session survives must NOT restore (the primed context
+delivers on the next turn; restoring would double-deliver).
+
+The restore tests run the swap in PRODUCTION topology (registered as
+``mgr.final_swap_task``, exactly as turn.py creates it): the in-handler
+``_reset_preparation_state`` calls used to snapshot-and-cancel that very
+task (self-cancel), killing every handler line after the reset — restores
+AND the pre-existing fail-closes — while direct-await tests stayed green.
+``_reset_preparation_state`` now excludes ``asyncio.current_task()`` from
+its cancel set; ``assert not swap_task.cancelled()`` pins that guard.
 """
 import asyncio
 
 import pytest
 
 import main_logic.core as core_module
+from main_logic.omni_realtime_client import OmniRealtimeClient
+from main_logic.proactive_delivery import DELIVERY_RETRACTED_KEY
 
 
 class _FakeSession:
@@ -261,3 +279,384 @@ async def test_final_swap_happy_path_still_promotes():
     finally:
         await _drain_task(mgr.message_handler_task)
         await _drain_task(old_listener_task)
+
+
+def _extra_entry(delivery_id, summary):
+    """A pending_extra_replies entry in the exact shape enqueue_agent_callback produces."""
+    return {
+        "_callback_delivery_id": delivery_id,
+        "origin": "event",
+        "summary": summary,
+        "detail": "",
+        "status": "completed",
+        "context_source": "proactive.callback",
+        "source_kind": "unknown",
+        "source_name": "",
+        "error_message": "",
+    }
+
+
+def _make_fake_realtime_session(name):
+    """A _FakeSession-alike that passes ``isinstance(x, OmniRealtimeClient)``.
+
+    Needed to reach the post-promote ws-invalid exit, which is gated on the
+    real client type. Bypasses ``__init__`` (no network) and shadows the
+    methods the swap sequence calls with instance-level fakes.
+    """
+    s = object.__new__(OmniRealtimeClient)
+    s.name = name
+    s.ws = object()  # truthy: passes the entry ws check
+    s._fatal_error_occurred = False
+    s.closed = False
+    s.prime_calls = []
+
+    async def _prime(text, *, skipped=False):
+        s.prime_calls.append((text, skipped))
+
+    async def _close():
+        s.closed = True
+
+    async def _handle():
+        await asyncio.Event().wait()
+
+    s.prime_context = _prime
+    s.close = _close
+    s.handle_messages = _handle
+    return s
+
+
+async def _run_swap_as_final_swap_task(mgr):
+    """Run the swap exactly as production does (turn.py): registered as
+    ``mgr.final_swap_task``. This is the topology where the in-handler
+    ``_reset_preparation_state`` used to self-cancel the running swap task,
+    killing every handler line after it (restores, fail-closes) — awaiting
+    the coroutine directly would silently skip that whole failure mode."""
+    mgr.final_swap_task = asyncio.create_task(mgr._perform_final_swap_sequence())
+    task = mgr.final_swap_task
+    try:
+        await asyncio.wait_for(task, timeout=10)
+    except asyncio.CancelledError:
+        pass
+    return task
+
+
+@pytest.mark.asyncio
+async def test_final_swap_promote_cas_loss_restores_injected_extras():
+    """Promote CAS loss discards the primed session — the extras that were
+    removed from the queue and injected into it must come back, mirroring the
+    _deferred entries that already survive this exit."""
+    mgr = _make_swap_manager()
+    winner_session = _FakeSession("winner")
+    new_session = _FakeSession("pending")
+
+    class _TakeoverOnClose(_FakeSession):
+        async def close(self):
+            await super().close()
+            mgr.session = winner_session
+            mgr.message_handler_task = object()
+
+    old_session = _TakeoverOnClose("old")
+    mgr.session = old_session
+    mgr.pending_session = new_session
+    mgr.is_hot_swap_imminent = True
+    mgr.message_handler_task = None
+
+    extra_a = _extra_entry("id-a", "task A finished")
+    extra_b = _extra_entry("id-b", "task B finished")
+    mgr.pending_extra_replies = [extra_a, extra_b]
+
+    swap_task = await _run_swap_as_final_swap_task(mgr)
+
+    assert not swap_task.cancelled(), "abort cleanup must not self-cancel the swap task"
+    assert mgr.session is winner_session
+    assert new_session.closed
+    assert new_session.prime_calls and new_session.prime_calls[0][1] is False, \
+        "extras must have actually been primed (skipped=False) before the abort"
+    assert mgr.pending_extra_replies == [extra_a, extra_b], \
+        "CAS-loss abort must restore the injected extras to the queue"
+
+
+@pytest.mark.asyncio
+async def test_final_swap_swallowed_cancel_restores_injected_extras():
+    """The pre-promote checkpoint exit (external cancel swallowed by an inner
+    await) also discards the primed session — injected extras must be restored."""
+    mgr = _make_swap_manager()
+    new_session = _FakeSession("pending")
+
+    class _SwallowExternalCancelOnClose(_FakeSession):
+        async def close(self):
+            await super().close()
+            t = asyncio.current_task()
+            t.cancel()
+            try:
+                await asyncio.sleep(0)
+            except asyncio.CancelledError:
+                pass
+
+    old_session = _SwallowExternalCancelOnClose("old")
+    mgr.session = old_session
+    mgr.pending_session = new_session
+    mgr.is_hot_swap_imminent = True
+    mgr.message_handler_task = None
+
+    extra = _extra_entry("id-cancel", "task C finished")
+    mgr.pending_extra_replies = [extra]
+
+    swap_task = await _run_swap_as_final_swap_task(mgr)
+
+    assert not swap_task.cancelled(), \
+        "the handler must survive its own cleanup (no reset self-cancel)"
+    assert new_session.prime_calls and new_session.prime_calls[0][1] is False
+    assert mgr.session is old_session
+    assert new_session.closed
+    assert mgr.pending_extra_replies == [extra], \
+        "cancelled swap must restore the injected extras to the queue"
+
+
+@pytest.mark.asyncio
+async def test_final_swap_listener_cancel_timeout_restores_injected_extras():
+    """Step 1's old-listener cancel timeout aborts via RuntimeError into the
+    fail-close path (session cleared). The primed session never speaks — the
+    injected extras must be restored before the early return."""
+    mgr = _make_swap_manager()
+    old_session = _FakeSession("old")
+    new_session = _FakeSession("pending")
+    mgr.session = old_session
+    mgr.pending_session = new_session
+    mgr.is_hot_swap_imminent = True
+    mgr.is_active = True
+
+    async def _stubborn_listener():
+        # Absorb the swap's cancel and keep hanging so its 2s wait_for times
+        # out; the second cancel (test teardown) is allowed through.
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            await asyncio.Event().wait()
+            raise
+
+    listener_task = asyncio.create_task(_stubborn_listener())
+    mgr.message_handler_task = listener_task
+    await asyncio.sleep(0)
+
+    extra = _extra_entry("id-timeout", "task T finished")
+    mgr.pending_extra_replies = [extra]
+
+    try:
+        swap_task = await _run_swap_as_final_swap_task(mgr)
+
+        assert not swap_task.cancelled(), \
+            "the handler must survive its own cleanup (no reset self-cancel)"
+        assert mgr.session is None, "listener-timeout abort fail-closes the session"
+        assert mgr.is_active is False
+        assert new_session.closed
+        assert mgr.pending_extra_replies == [extra], \
+            "listener-timeout abort must restore the injected extras to the queue"
+    finally:
+        await _drain_task(listener_task)
+
+
+@pytest.mark.asyncio
+async def test_final_swap_post_promote_ws_invalid_restores_injected_extras():
+    """The 4th exit: promote succeeds but the new session's ws is already dead,
+    so the swap raises and fail-closes (session cleared). The primed session
+    never speaks — injected extras must be restored."""
+    mgr = _make_swap_manager()
+    old_session = _FakeSession("old")
+    new_session = _make_fake_realtime_session("pending")
+    mgr.session = old_session
+    mgr.pending_session = new_session
+    mgr.is_hot_swap_imminent = True
+    mgr.message_handler_task = None
+
+    async def _kill_new_session_ws(*args, **kwargs):
+        # Models the server dropping the new connection inside the swap window.
+        mgr.session.ws = None
+
+    mgr._apply_pending_tts_route_after_swap = _kill_new_session_ws
+
+    extra = _extra_entry("id-ws", "task W finished")
+    mgr.pending_extra_replies = [extra]
+
+    swap_task = await _run_swap_as_final_swap_task(mgr)
+
+    assert not swap_task.cancelled(), \
+        "the handler must survive its own cleanup (no reset self-cancel)"
+    assert mgr.session is None, "post-promote ws-invalid must fail-close the session"
+    assert mgr.is_active is False
+    assert mgr.pending_extra_replies == [extra], \
+        "post-promote ws-invalid abort must restore the injected extras"
+
+
+@pytest.mark.asyncio
+async def test_final_swap_post_promote_failure_with_live_session_does_not_restore():
+    """Double-delivery guard: when a post-promote step fails but the promoted
+    session survives as self.session, the primed extras are already in its
+    context and will be spoken next turn — they must NOT be restored."""
+    mgr = _make_swap_manager()
+    old_session = _FakeSession("old")
+    new_session = _FakeSession("pending")
+    mgr.session = old_session
+    mgr.pending_session = new_session
+    mgr.is_hot_swap_imminent = True
+    mgr.message_handler_task = None
+
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("post-promote step failed")
+
+    mgr._prime_late_next_session_context_after_swap = _boom
+
+    extra = _extra_entry("id-live", "task L finished")
+    mgr.pending_extra_replies = [extra]
+
+    swap_task = await _run_swap_as_final_swap_task(mgr)
+
+    assert not swap_task.cancelled()
+    assert mgr.session is new_session, "session survives the post-promote failure"
+    assert not new_session.closed
+    assert mgr.pending_extra_replies == [], \
+        "extras already primed into the live session must not be re-queued"
+
+
+@pytest.mark.asyncio
+async def test_final_swap_restore_preserves_order_with_deferred_and_new_entries(monkeypatch):
+    """Restored _selected entries go to the queue HEAD: ahead of the _deferred
+    ones (which they originally preceded) and of entries enqueued during the
+    swap window."""
+    mgr = _make_swap_manager()
+    winner_session = _FakeSession("winner")
+    new_session = _FakeSession("pending")
+
+    extra_a = _extra_entry("id-1", "first")
+    extra_b = _extra_entry("id-2", "second")
+    extra_c = _extra_entry("id-3", "arrived mid-swap")
+
+    monkeypatch.setattr(
+        "main_logic.core.lifecycle._select_callbacks_within_token_budget",
+        lambda callbacks, budget: (callbacks[:1], list(callbacks[1:])),
+    )
+
+    class _TakeoverOnClose(_FakeSession):
+        async def close(self):
+            await super().close()
+            mgr.pending_extra_replies.append(extra_c)  # new arrival inside the swap window
+            mgr.session = winner_session
+            mgr.message_handler_task = object()
+
+    old_session = _TakeoverOnClose("old")
+    mgr.session = old_session
+    mgr.pending_session = new_session
+    mgr.is_hot_swap_imminent = True
+    mgr.message_handler_task = None
+    mgr.pending_extra_replies = [extra_a, extra_b]
+
+    swap_task = await _run_swap_as_final_swap_task(mgr)
+
+    assert not swap_task.cancelled()
+    assert mgr.pending_extra_replies == [extra_a, extra_b, extra_c], \
+        "restore must preserve original relative order: selected, deferred, new arrivals"
+
+
+@pytest.mark.asyncio
+async def test_final_swap_restore_skips_extras_retracted_during_swap():
+    """An extra whose paired callback got retracted inside the swap window
+    escaped the retraction purge (it was already removed from the queue) —
+    the restore must re-check and drop it instead of resurrecting it."""
+    mgr = _make_swap_manager()
+    winner_session = _FakeSession("winner")
+    new_session = _FakeSession("pending")
+
+    extra_kept = _extra_entry("id-kept", "still wanted")
+    extra_retracted = _extra_entry("id-retracted", "withdrawn mid-swap")
+
+    class _TakeoverOnClose(_FakeSession):
+        async def close(self):
+            await super().close()
+            mgr.pending_agent_callbacks = [
+                {"_callback_delivery_id": "id-retracted", DELIVERY_RETRACTED_KEY: True},
+            ]
+            mgr.session = winner_session
+            mgr.message_handler_task = object()
+
+    old_session = _TakeoverOnClose("old")
+    mgr.session = old_session
+    mgr.pending_session = new_session
+    mgr.is_hot_swap_imminent = True
+    mgr.message_handler_task = None
+    mgr.pending_extra_replies = [extra_kept, extra_retracted]
+
+    swap_task = await _run_swap_as_final_swap_task(mgr)
+
+    assert not swap_task.cancelled()
+    assert mgr.pending_extra_replies == [extra_kept], \
+        "restore must drop entries retracted during the swap window"
+
+
+@pytest.mark.asyncio
+async def test_final_swap_restore_drops_topic_hook_extras():
+    """Topic-hook extras are never restored: mainline retraction flows
+    (voice-block sweep, delivery-ack timeout) mark-and-purge synchronously, so
+    a retraction landing inside the swap window leaves no marker for the
+    restore to consult — resurrecting the entry would bypass
+    _drop_pending_topic_hooks_for_voice. TopicHookPool's own ack/retry
+    bookkeeping re-delivers the content, so dropping the extra loses nothing."""
+    mgr = _make_swap_manager()
+    winner_session = _FakeSession("winner")
+    new_session = _FakeSession("pending")
+
+    extra_normal = _extra_entry("id-normal", "regular callback")
+    extra_topic = _extra_entry("id-topic", "deep topic hook")
+    extra_topic["source_kind"] = "topic"
+
+    class _TakeoverOnClose(_FakeSession):
+        async def close(self):
+            await super().close()
+            mgr.session = winner_session
+            mgr.message_handler_task = object()
+
+    old_session = _TakeoverOnClose("old")
+    mgr.session = old_session
+    mgr.pending_session = new_session
+    mgr.is_hot_swap_imminent = True
+    mgr.message_handler_task = None
+    mgr.pending_extra_replies = [extra_normal, extra_topic]
+
+    swap_task = await _run_swap_as_final_swap_task(mgr)
+
+    assert not swap_task.cancelled()
+    assert mgr.pending_extra_replies == [extra_normal], \
+        "topic-hook extras must be dropped on restore, not resurrected"
+
+
+@pytest.mark.asyncio
+async def test_final_swap_happy_path_consumes_selected_keeps_deferred(monkeypatch):
+    """A successful swap must not restore anything: selected extras were
+    delivered into the promoted session, deferred ones stay for the next swap."""
+    mgr = _make_swap_manager()
+    old_session = _FakeSession("old")
+    new_session = _FakeSession("pending")
+    mgr.session = old_session
+    mgr.pending_session = new_session
+    mgr.is_hot_swap_imminent = True
+    mgr.is_active = True
+    mgr.message_handler_task = None
+
+    extra_sel = _extra_entry("id-sel", "goes into this swap")
+    extra_def = _extra_entry("id-def", "waits for the next swap")
+    mgr.pending_extra_replies = [extra_sel, extra_def]
+
+    monkeypatch.setattr(
+        "main_logic.core.lifecycle._select_callbacks_within_token_budget",
+        lambda callbacks, budget: (callbacks[:1], list(callbacks[1:])),
+    )
+
+    try:
+        swap_task = await _run_swap_as_final_swap_task(mgr)
+
+        assert not swap_task.cancelled()
+        assert mgr.session is new_session
+        assert new_session.prime_calls and new_session.prime_calls[0][1] is False
+        assert mgr.pending_extra_replies == [extra_def], \
+            "successful swap consumes selected extras and keeps only deferred ones"
+    finally:
+        await _drain_task(mgr.message_handler_task)

--- a/tests/unit/test_hot_swap_cancellation.py
+++ b/tests/unit/test_hot_swap_cancellation.py
@@ -780,6 +780,7 @@ async def test_final_swap_post_promote_cancel_restores_removed_extras():
     mgr.session = old_session
     mgr.pending_session = new_session
     mgr.is_hot_swap_imminent = True
+    mgr.is_active = True
     mgr.message_handler_task = None
 
     async def _cancelled_mid_post_promote(*args, **kwargs):
@@ -802,6 +803,10 @@ async def test_final_swap_post_promote_cancel_restores_removed_extras():
         "the handler leaves the promoted session for the canceller to close"
     assert mgr.pending_extra_replies == [extra], \
         "post-promote cancel must restore the promote-removed extras"
+    # 双投守卫：restore 之后不得给将死的 promoted 会话重启 listener——
+    # 没有 listener，服务器响应不会被消费播出，塞回的条目才是唯一投递路径。
+    assert mgr.message_handler_task is None, \
+        "no listener may be restarted on the about-to-close promoted session"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_hot_swap_cancellation.py
+++ b/tests/unit/test_hot_swap_cancellation.py
@@ -796,6 +796,8 @@ async def test_final_swap_post_promote_cancel_restores_removed_extras():
 
     swap_task = await _run_swap_as_final_swap_task(mgr)
 
+    assert not swap_task.cancelled(), \
+        "the handler absorbs the cancel and finishes its cleanup normally"
     assert mgr.session is new_session, \
         "the handler leaves the promoted session for the canceller to close"
     assert mgr.pending_extra_replies == [extra], \
@@ -846,6 +848,8 @@ async def test_final_swap_restore_excludes_extra_delivered_after_promote():
 
     swap_task = await _run_swap_as_final_swap_task(mgr)
 
+    assert not swap_task.cancelled(), \
+        "the handler absorbs the cancel and finishes its cleanup normally"
     assert mgr.session is new_session
     assert mgr.pending_extra_replies == [extra_kept], \
         "an extra whose callback was consumed inside the window must not be re-queued"

--- a/tests/unit/test_hot_swap_cancellation.py
+++ b/tests/unit/test_hot_swap_cancellation.py
@@ -320,7 +320,9 @@ def _make_fake_realtime_session(name):
         s.prime_calls.append((text, skipped))
 
     async def _close():
+        # Mirror the real client: close() clears the ws reference.
         s.closed = True
+        s.ws = None
 
     async def _handle():
         await asyncio.Event().wait()
@@ -482,6 +484,7 @@ async def test_final_swap_post_promote_ws_invalid_restores_injected_extras():
     mgr.session = old_session
     mgr.pending_session = new_session
     mgr.is_hot_swap_imminent = True
+    mgr.is_active = True  # fail-close 必须真的把它翻回 False，默认 False 会假绿
     mgr.message_handler_task = None
 
     async def _kill_new_session_ws(*args, **kwargs):
@@ -721,3 +724,79 @@ async def test_final_swap_happy_path_consumes_selected_keeps_deferred(monkeypatc
             "successful swap consumes selected extras and keeps only deferred ones"
     finally:
         await _drain_task(mgr.message_handler_task)
+
+
+@pytest.mark.asyncio
+async def test_final_swap_cancel_after_old_close_fail_closes_instead_of_restarting():
+    """Cancellation landing after step 2 closed the old session but before
+    promote leaves self.session pointing at a closed client (ws=None). The
+    CancelledError handler must fail-close instead of restarting a listener
+    on the dead session (coderabbit Major on this PR)."""
+    mgr = _make_swap_manager()
+    new_session = _FakeSession("pending")
+    old_session = _make_fake_realtime_session("old")
+
+    _orig_close = old_session.close
+
+    async def _close_then_swallowed_cancel():
+        # Step 2 closes the old session (ws cleared), then the external cancel
+        # arrives and is swallowed — the pre-promote checkpoint re-raises it.
+        await _orig_close()
+        t = asyncio.current_task()
+        t.cancel()
+        try:
+            await asyncio.sleep(0)
+        except asyncio.CancelledError:
+            # Swallow on purpose: reproduces the checkpoint-only cancel path.
+            pass
+
+    old_session.close = _close_then_swallowed_cancel
+    mgr.session = old_session
+    mgr.pending_session = new_session
+    mgr.is_hot_swap_imminent = True
+    mgr.is_active = True
+    mgr.message_handler_task = None
+
+    swap_task = await _run_swap_as_final_swap_task(mgr)
+
+    assert not swap_task.cancelled()
+    assert new_session.closed
+    assert mgr.session is None, \
+        "cancel after old close must fail-close, not keep the dead session"
+    assert mgr.is_active is False
+    assert mgr.message_handler_task is None, \
+        "no listener may be restarted on a closed session"
+
+
+@pytest.mark.asyncio
+async def test_final_swap_post_promote_cancel_restores_removed_extras():
+    """Cancellation after promote comes only from external reset/end_session/
+    start_session preludes, all of which close the promoted session next — the
+    primed content never delivers, so the promote-removed extras must go back
+    to the queue (coderabbit Major on this PR)."""
+    mgr = _make_swap_manager()
+    old_session = _FakeSession("old")
+    new_session = _FakeSession("pending")
+    mgr.session = old_session
+    mgr.pending_session = new_session
+    mgr.is_hot_swap_imminent = True
+    mgr.message_handler_task = None
+
+    async def _cancelled_mid_post_promote(*args, **kwargs):
+        # External cancel lands on the swap task during a post-promote await.
+        t = asyncio.current_task()
+        t.cancel()
+        await asyncio.sleep(0)
+        return 0
+
+    mgr._prime_late_next_session_context_after_swap = _cancelled_mid_post_promote
+
+    extra = _extra_entry("id-post-promote", "task P finished")
+    mgr.pending_extra_replies = [extra]
+
+    swap_task = await _run_swap_as_final_swap_task(mgr)
+
+    assert mgr.session is new_session, \
+        "the handler leaves the promoted session for the canceller to close"
+    assert mgr.pending_extra_replies == [extra], \
+        "post-promote cancel must restore the promote-removed extras"

--- a/tests/unit/test_hot_swap_cancellation.py
+++ b/tests/unit/test_hot_swap_cancellation.py
@@ -41,6 +41,7 @@ import asyncio
 import pytest
 
 import main_logic.core as core_module
+from main_logic.omni_offline_client import OmniOfflineClient
 from main_logic.omni_realtime_client import OmniRealtimeClient
 from main_logic.proactive_delivery import DELIVERY_RETRACTED_KEY
 
@@ -766,6 +767,46 @@ async def test_final_swap_cancel_after_old_close_fail_closes_instead_of_restarti
     assert mgr.is_active is False
     assert mgr.message_handler_task is None, \
         "no listener may be restarted on a closed session"
+
+
+@pytest.mark.asyncio
+async def test_final_swap_cancel_after_old_close_fail_closes_text_session_too():
+    """Same scenario for a TEXT session: OmniOfflineClient clears ``llm`` on
+    close() (it has no ws), so the dead-session fail-close must recognize it
+    instead of restarting its keep-alive listener on a closed client
+    (coderabbit follow-up on this PR)."""
+    mgr = _make_swap_manager()
+    new_session = _FakeSession("pending")
+
+    old_session = object.__new__(OmniOfflineClient)
+    old_session.llm = object()  # 活跃文本会话的标志；close 后被清空
+
+    async def _close_then_swallowed_cancel():
+        old_session.llm = None  # mirror OmniOfflineClient.close()
+        t = asyncio.current_task()
+        t.cancel()
+        try:
+            await asyncio.sleep(0)
+        except asyncio.CancelledError:
+            # Swallow on purpose: reproduces the checkpoint-only cancel path.
+            pass
+
+    old_session.close = _close_then_swallowed_cancel
+    mgr.session = old_session
+    mgr.pending_session = new_session
+    mgr.is_hot_swap_imminent = True
+    mgr.is_active = True
+    mgr.message_handler_task = None
+
+    swap_task = await _run_swap_as_final_swap_task(mgr)
+
+    assert not swap_task.cancelled()
+    assert new_session.closed
+    assert mgr.session is None, \
+        "a closed text session must be fail-closed, not kept as self.session"
+    assert mgr.is_active is False
+    assert mgr.message_handler_task is None, \
+        "no keep-alive listener may be restarted on a closed text session"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# 背景

greptile 在 PR #2283 提出的 P1：`_perform_final_swap_sequence` 在 prime 成功后把预算选中的 `_selected` 从 `pending_extra_replies` 摘走注入 `pending_session`，此后所有"注入成功但 swap 最终没 promote"的中止出口都会**净丢失**这些条目——被注入的 session 永远不开口，接管方 start_session 及各 reset 路径都不感知这批 agent 回调。

产品语义已拍板：**保留**。关键事实是同一批补充里没选上的 `_deferred` 在全部中止出口本来就存活、会照常被下一纪元的第一次 hot-swap 投递——现状不是"丢弃"语义而是"预算选择器选中谁谁死"，保留才让 `_selected` 与 `_deferred` 行为一致，也符合摘除点注释自己声明的不变量（"仅在成功注入后才移除，否则既没进模型又丢了"）。

# 修复内容

**1. 队列原地保留，promote 成功才移除（初版"摘走+中止塞回"经本 PR review 演进为此设计）**

prime 后 `pending_extra_replies` **原地不动**，只持有 `_selected` 的对象引用；promote 成功（被注入的 session 成为活跃会话，注入内容必随其下一轮回复送达）那一刻才按**对象身份**移除。由此：

- **promote 前的所有中止出口**（旧 listener 取消超时、CAS 落败、外部取消 re-raise）天然保留整个队列，与 `_deferred` 对齐，零恢复代码；
- **窗口期内的并发移除方全部正常命中队列条目**：语音主动投递成功清除（`trigger_agent_callbacks` 按 delivery_id 清双队列）、retraction purge、topic 语音封锁清扫、flood cap——不存在"被摘走的条目逃过清除、中止后又被复活"的 TOCTOU 盲区（greptile 在本 PR 的 P1 即此类）；
- 唯一保留塞回的出口是 **promote 后 ws 失效 fail-close**（移除已发生、会话已死）：`_restore_undelivered_swap_extras` 只塞回 promote 时真正移除的子集，带 retraction 复查、去重、flood cap（drop-oldest 与 enqueue 对齐）、topic extras 排除（其生命周期归语音封锁清扫与 TopicHookPool ack/retry 簿记）。窗口从秒级缩到 promote→ws 检查的微秒级；
- promote 后会话存活的失败不塞回——注入内容仍在其上下文，塞回会双投。

**2. `_reset_preparation_state` 自引用守卫（本 PR 对抗式审查揪出的前置 P1）**

生产里 swap 以 `self.final_swap_task` 运行（turn.py 创建）。swap 的中止 handler／入口守卫／prime 失败出口调 `_reset_preparation_state` 时没传 `from_final_swap=True`，reset 会 snapshot 并 cancel **正在运行的 swap 自己**，在 `gather` 悬挂点把 CancelledError 打回调用方 except 块——**reset 之后的所有行在生产拓扑全是死代码**：不止恢复逻辑，还包括 #2283 既有的 fail-close 尾巴（listener 超时后 `is_active` 卡 True 带着卡死 listener——正是 #2283 要防的"活跃但无监听"僵局）、ws 失效清理、listener 重启，以及 try 之前入口守卫死在 reset 后把 `is_hot_swap_imminent` 卡成 True 堵死后续热切换。修复：reset 对 `asyncio.current_task()` 一律不 cancel 不等待（等自己必死锁），一处修复所有现在与未来的调用点；外部调用方语义不变。

**3. 测试跑生产拓扑**

此前该文件测试直接 await 协程（`final_swap_task=None`），踩不到自杀路径而假绿。现在全部以 `mgr.final_swap_task = asyncio.create_task(...)` 运行（与 turn.py 完全一致），并以 `assert not swap_task.cancelled()` 钉死自引用守卫。

# 回归报告

- `tests/unit/test_hot_swap_cancellation.py`：**14/14 通过**（4 个 #2283 既有 + 10 个新增）。
- **负向验证 ①**：stash 掉 lifecycle.py 全部修复、只留测试，在 base 代码上 8 个测试红（4 出口保留、双投守卫、顺序、retraction、生产拓扑断言）——真回归测试非套套逻辑。
- **负向验证 ②**：在初版"摘走+塞回"设计上，两个并发投递 TOCTOU 测试（`test_final_swap_abort_does_not_resurrect_concurrently_delivered_extra`、`test_final_swap_ws_invalid_restore_excludes_concurrently_delivered_extra`）精确变红，其余 12 个双设计兼容——钉死 greptile 本 PR P1 的场景。
- 相关面：`test_callback_instruction_origin.py` + `test_proactive_sm_integration.py` + `test_topic_delivery.py` 共 **104 通过**。
- 全量 `tests/unit`：**5049 passed，64 failed 的失败集合与 base（b31c12c05）逐条一致**（存量红，涉及 yui_guide/tool_calling 等与本 diff 无关的文件），零新增失败。
- `scripts/check_core_contracts.py` 通过；`ruff check` 通过。
- 合并前经 9-agent 对抗式审查（3 lens 找 + 逐条反驳验证，6 confirmed 0 refuted）；第 2、3 点即审查实锤（含生产拓扑复现）后的修复；greptile 两条 P1 一条促成设计演进（见第 1 点）、一条按既有 flood 策略反驳（见 thread 回复）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进热切换最终切换的并发一致性：仅在成功后移除注入的额外回复，失败/取消/超时场景下按原顺序回滚，避免丢失、重复投递与错误恢复。
  * 优化 WebSocket 失效与监听器取消超时后的恢复时机，降低会话关闭与状态清理引发的不一致。
* **Tests**
  * 扩展热切换取消、失败、异常与并发投递的回归覆盖，增加更贴近生产的执行方式与可观察断言。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->