### PR TITLE
feat(voice): 重建非 Soniox ASR 的 Smart Turn v3 轮次检测基础设施

### DIFF
--- a/.github/workflows/build-desktop-linux.yml
+++ b/.github/workflows/build-desktop-linux.yml
@@ -194,6 +194,16 @@ jobs:
             --output-root data/embedding_models \
             --variant both
 
+      - name: Cache voice-turn model weights
+        uses: actions/cache@v4
+        with:
+          path: data/vad_models/*.onnx
+          key: voice-turn-models-${{ runner.os }}-silero-v6.2.1-smart-turn-v3.2-f766f81
+
+      - name: Prepare verified voice-turn assets
+        shell: bash
+        run: .venv/bin/python tools/voice_eval/prepare_voice_turn_assets.py
+
       # --- Warm tiktoken o200k_base cache for offline use (PR #929) ---
       # tiktoken downloads encoding blobs (~1.5 MB each) on first use into
       # TIKTOKEN_CACHE_DIR; without warming, the bundled app would either
@@ -264,6 +274,7 @@ jobs:
           if [ -d "data/embedding_models" ]; then
             NUITKA_OPTS="$NUITKA_OPTS --include-data-dir=data/embedding_models=data/embedding_models"
           fi
+          NUITKA_OPTS="$NUITKA_OPTS --include-data-dir=data/vad_models=data/vad_models"
           NUITKA_OPTS="$NUITKA_OPTS --include-data-dir=static=static"
           # 应用内 OpenClaw 引导文档 + 图片，由 agent_router 经 /api/agent/openclaw/guide/* 提供；
           # 是纯数据目录，--include-package 不带，漏了引导页内容/图片打包后 404。
@@ -386,6 +397,8 @@ jobs:
             echo "::error::data/tiktoken_cache empty in bundle (o200k_base would re-download at runtime)"
             missing=1
           fi
+          .venv/bin/python tools/voice_eval/prepare_voice_turn_assets.py \
+            --asset-dir dist/Xiao8/data/vad_models --offline || missing=1
           [ "$missing" -eq 0 ]
 
       # --- Generic dist invariant check ---

--- a/.github/workflows/build-desktop-linux.yml
+++ b/.github/workflows/build-desktop-linux.yml
@@ -202,7 +202,7 @@ jobs:
 
       - name: Prepare verified voice-turn assets
         shell: bash
-        run: .venv/bin/python tools/voice_eval/prepare_voice_turn_assets.py
+        run: uv run --no-sync python tools/voice_eval/prepare_voice_turn_assets.py
 
       # --- Warm tiktoken o200k_base cache for offline use (PR #929) ---
       # tiktoken downloads encoding blobs (~1.5 MB each) on first use into
@@ -397,7 +397,7 @@ jobs:
             echo "::error::data/tiktoken_cache empty in bundle (o200k_base would re-download at runtime)"
             missing=1
           fi
-          .venv/bin/python tools/voice_eval/prepare_voice_turn_assets.py \
+          uv run --no-sync python tools/voice_eval/prepare_voice_turn_assets.py \
             --asset-dir dist/Xiao8/data/vad_models --offline || missing=1
           [ "$missing" -eq 0 ]
 

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -236,12 +236,7 @@ jobs:
 
       - name: Prepare verified voice-turn assets
         shell: bash
-        run: |
-          VENV_PYTHON=".venv/bin/python"
-          if [ -f ".venv/Scripts/python.exe" ]; then
-            VENV_PYTHON=".venv/Scripts/python.exe"
-          fi
-          $VENV_PYTHON tools/voice_eval/prepare_voice_turn_assets.py
+        run: uv run --no-sync python tools/voice_eval/prepare_voice_turn_assets.py
 
       # --- Warm tiktoken o200k_base cache for offline use (PR #929) ---
       # tiktoken downloads encoding blobs (~1.5 MB each) on first use into
@@ -612,11 +607,7 @@ jobs:
             echo "::error::data/tiktoken_cache empty in bundle (o200k_base would re-download at runtime)"
             missing=1
           fi
-          VENV_PYTHON=".venv/bin/python"
-          if [ -f ".venv/Scripts/python.exe" ]; then
-            VENV_PYTHON=".venv/Scripts/python.exe"
-          fi
-          $VENV_PYTHON tools/voice_eval/prepare_voice_turn_assets.py \
+          uv run --no-sync python tools/voice_eval/prepare_voice_turn_assets.py \
             --asset-dir dist/Xiao8/data/vad_models --offline || missing=1
           [ "$missing" -eq 0 ]
 

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -228,6 +228,21 @@ jobs:
             --output-root data/embedding_models \
             --variant both
 
+      - name: Cache voice-turn model weights
+        uses: actions/cache@v4
+        with:
+          path: data/vad_models/*.onnx
+          key: voice-turn-models-${{ runner.os }}-silero-v6.2.1-smart-turn-v3.2-f766f81
+
+      - name: Prepare verified voice-turn assets
+        shell: bash
+        run: |
+          VENV_PYTHON=".venv/bin/python"
+          if [ -f ".venv/Scripts/python.exe" ]; then
+            VENV_PYTHON=".venv/Scripts/python.exe"
+          fi
+          $VENV_PYTHON tools/voice_eval/prepare_voice_turn_assets.py
+
       # --- Warm tiktoken o200k_base cache for offline use (PR #929) ---
       # tiktoken downloads encoding blobs (~1.5 MB each) on first use into
       # TIKTOKEN_CACHE_DIR; without warming, the bundled app would either
@@ -316,6 +331,7 @@ jobs:
           if [ -d "data/embedding_models" ]; then
             NUITKA_OPTS="$NUITKA_OPTS --include-data-dir=data/embedding_models=data/embedding_models"
           fi
+          NUITKA_OPTS="$NUITKA_OPTS --include-data-dir=data/vad_models=data/vad_models"
           NUITKA_OPTS="$NUITKA_OPTS --include-data-dir=static=static"
           # 应用内 OpenClaw 引导文档 + 图片，由 agent_router 经 /api/agent/openclaw/guide/* 提供；
           # 是纯数据目录，--include-package 不带，漏了引导页内容/图片打包后 404。
@@ -471,6 +487,7 @@ jobs:
           set NUITKA_OPTS=%NUITKA_OPTS% --include-data-dir=playwright_browsers=playwright_browsers
           if exist "data\tiktoken_cache" set NUITKA_OPTS=%NUITKA_OPTS% --include-data-dir=data/tiktoken_cache=data/tiktoken_cache
           if exist "data\embedding_models" set NUITKA_OPTS=%NUITKA_OPTS% --include-data-dir=data/embedding_models=data/embedding_models
+          set NUITKA_OPTS=%NUITKA_OPTS% --include-data-dir=data/vad_models=data/vad_models
           set NUITKA_OPTS=%NUITKA_OPTS% --include-data-dir=static=static
           rem 应用内 OpenClaw 引导文档 + 图片，由 agent_router 经 /api/agent/openclaw/guide/* 提供；
           rem 纯数据目录，漏了引导页内容/图片打包后 404。
@@ -595,6 +612,12 @@ jobs:
             echo "::error::data/tiktoken_cache empty in bundle (o200k_base would re-download at runtime)"
             missing=1
           fi
+          VENV_PYTHON=".venv/bin/python"
+          if [ -f ".venv/Scripts/python.exe" ]; then
+            VENV_PYTHON=".venv/Scripts/python.exe"
+          fi
+          $VENV_PYTHON tools/voice_eval/prepare_voice_turn_assets.py \
+            --asset-dir dist/Xiao8/data/vad_models --offline || missing=1
           [ "$missing" -eq 0 ]
 
       # --- Generic dist invariant check ---

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,15 @@ tests/test_inputs/
 *.log
 /logs/
 /data/
+# Voice-turn assets are prepared from a pinned, checksummed manifest. Keep the
+# manifest/notices reviewable while preventing downloaded weights or stray data
+# from being added accidentally.
+!/data/
+/data/*
+!/data/vad_models/
+/data/vad_models/*
+!/data/vad_models/manifest.json
+!/data/vad_models/THIRD_PARTY_NOTICES.md
 debug_audio/*
 # Binaries (but keep our committed Windows tools listed explicitly if needed)
 *.exe

--- a/data/vad_models/THIRD_PARTY_NOTICES.md
+++ b/data/vad_models/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,55 @@
+# Voice-turn model notices
+
+The ONNX weights prepared into this directory are third-party assets. Their
+fixed source revisions and SHA-256 digests are recorded in `manifest.json`.
+
+## Silero VAD v6.2.1
+
+Copyright (c) 2020-present Silero Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## Pipecat Smart Turn v3.2 CPU
+
+Copyright (c) 2024-2025, Daily
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Upstream license references:
+
+- https://github.com/snakers4/silero-vad/blob/v6.2.1/LICENSE
+- https://github.com/pipecat-ai/smart-turn/blob/main/LICENSE

--- a/data/vad_models/manifest.json
+++ b/data/vad_models/manifest.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "assets": [
+    {
+      "filename": "silero_vad.onnx",
+      "version": "v6.2.1",
+      "source": "https://raw.githubusercontent.com/snakers4/silero-vad/v6.2.1/src/silero_vad/data/silero_vad.onnx",
+      "license": "MIT",
+      "sha256": "1a153a22f4509e292a94e67d6f9b85e8deb25b4988682b7e174c65279d8788e3",
+      "input_contract": "input:float32[batch,576],state:float32[2,batch,128],sr:int64[]",
+      "output_contract": "probability:float32[batch,1],state:float32[2,batch,128]"
+    },
+    {
+      "filename": "smart_turn_v3.onnx",
+      "version": "v3.2-cpu@f766f81d3cfdf7737ac64aad813d91bbfd56bf93",
+      "source": "https://huggingface.co/pipecat-ai/smart-turn-v3/resolve/f766f81d3cfdf7737ac64aad813d91bbfd56bf93/smart-turn-v3.2-cpu.onnx?download=true",
+      "license": "BSD-2-Clause",
+      "sha256": "2bb026316b14a660486a75b1733cd3fbab8c2fd0314dc9af7be49f8cca967e4f",
+      "input_contract": "input_features:float32[batch,80,800]",
+      "output_contract": "probability:float32[batch,1]"
+    }
+  ]
+}

--- a/docs/design/smart-turn-v3-provider-neutral.md
+++ b/docs/design/smart-turn-v3-provider-neutral.md
@@ -35,7 +35,7 @@ statistics.
 licenses, and SHA-256 digests. Run:
 
 ```text
-python tools/voice_eval/prepare_voice_turn_assets.py
+uv run python tools/voice_eval/prepare_voice_turn_assets.py
 ```
 
 The runtime is lazy and disabled by default. Concurrent loads are

--- a/docs/design/smart-turn-v3-provider-neutral.md
+++ b/docs/design/smart-turn-v3-provider-neutral.md
@@ -1,0 +1,66 @@
+# Smart Turn v3 provider-neutral backend
+
+This backend supersedes the implementation approach in PR #2187. It is built
+from the current package-based `main` layout and intentionally does not connect
+to Omni Realtime, Core, an ASR provider, or a user-visible setting.
+
+## Endpoint authority
+
+- A provider with an authoritative semantic endpoint (for example Soniox
+  `<end>`) must not construct or call Smart Turn.
+- An ASR provider without that capability may use common VAD to find a
+  candidate pause and ask Smart Turn for `COMPLETE` or `INCOMPLETE`.
+- Provider buffer commit, hard timeout, maximum turn duration, and manual
+  commit remain responsibilities of the future ASR Controller.
+
+VAD emits only speech start, resumed speech, and candidate pause events. It is
+also suitable for barge-in and connection lifecycle gating, but it never emits
+`TURN_COMPLETE` or `FORCE_COMMIT`.
+
+## Audio contract
+
+The package accepts a continuous stream of signed 16-bit little-endian, mono,
+16 kHz PCM. It does not resample. Callers with 48 kHz capture must use the
+project's stateful streaming resampler before this boundary; independently
+resampling each capture chunk can create endpoint artifacts.
+
+Smart Turn receives at most the trailing eight seconds. Short inputs are
+left-padded. Whisper-compatible preprocessing is implemented with NumPy and is
+golden-tested against the reviewed 80-bin mel bank and synthetic feature
+statistics.
+
+## Assets and lifecycle
+
+`data/vad_models/manifest.json` pins model revisions, authoritative URLs,
+licenses, and SHA-256 digests. Run:
+
+```text
+python tools/voice_eval/prepare_voice_turn_assets.py
+```
+
+The runtime is lazy and disabled by default. Concurrent loads are
+single-flight. Missing/corrupt assets produce `UNAVAILABLE`, which is distinct
+from a semantic `INCOMPLETE` result. Repeated inference failures open a
+per-instance circuit breaker; constructing a new instance permits recovery.
+
+## Current verification
+
+- Hermetic unit/concurrency/build-contract tests cover buffer bounds, model
+  lifecycle, Silero state/context, stale results, candidate coalescing, close,
+  asset SHA checks, and the Soniox-like capability path.
+- The pinned real models load successfully. One second of synthetic silence
+  stays below Silero speech probability 0.05. Smart Turn golden outputs are
+  checked for silence and a synthetic tone.
+- On the Windows development machine, Smart Turn with two CPU threads and the
+  CPU memory arena disabled measured about 26 ms P95 after warm-up. This is a
+  local inference measurement, not ASR/network latency.
+
+## Accuracy gate and known limitation
+
+Synthetic fixtures validate the implementation contract, not conversational
+accuracy. No product-quality claim is made for Chinese, English, or Japanese.
+Before enabling the backend, maintainers must run
+`tools/voice_eval/evaluate_smart_turn_v3.py` on an authorized labelled set that
+includes sentence-internal pauses, hesitation followed by continuation,
+complete turns, keyboard noise, and barge-in. The report always includes all
+four confusion-matrix cells and per-sample probabilities.

--- a/main_logic/voice_turn/__init__.py
+++ b/main_logic/voice_turn/__init__.py
@@ -1,0 +1,32 @@
+"""Provider-neutral voice turn detection primitives.
+
+This package deliberately has no ASR provider, Core, or Omni dependencies.
+Smart Turn is an optional semantic endpoint helper for ASR providers that do
+not already expose an authoritative semantic endpoint.
+"""
+
+from .audio_buffer import Pcm16RingBuffer
+from .contracts import (
+    AsrTurnCapabilities,
+    EvaluationStatus,
+    SmartTurnConfig,
+    SpeechActivityEvent,
+    TurnDecision,
+    TurnDetector,
+    TurnEvaluation,
+    build_turn_detector_if_required,
+    requires_external_turn_detector,
+)
+
+__all__ = [
+    "AsrTurnCapabilities",
+    "EvaluationStatus",
+    "Pcm16RingBuffer",
+    "SmartTurnConfig",
+    "SpeechActivityEvent",
+    "TurnDecision",
+    "TurnDetector",
+    "TurnEvaluation",
+    "build_turn_detector_if_required",
+    "requires_external_turn_detector",
+]

--- a/main_logic/voice_turn/asset_manifest.py
+++ b/main_logic/voice_turn/asset_manifest.py
@@ -1,0 +1,135 @@
+"""Auditable resolution and SHA-256 verification for voice-turn assets."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+MANIFEST_FILENAME = "manifest.json"
+DEFAULT_ASSET_DIR_NAME = "vad_models"
+
+
+class AssetManifestError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class AssetSpec:
+    filename: str
+    version: str
+    source: str
+    license: str
+    sha256: str
+    input_contract: str
+    output_contract: str
+
+    @classmethod
+    def from_mapping(cls, value: dict[str, Any]) -> "AssetSpec":
+        required = {field for field in cls.__dataclass_fields__}
+        missing = sorted(required - value.keys())
+        if missing:
+            raise AssetManifestError(f"asset is missing fields: {', '.join(missing)}")
+        spec = cls(**{key: str(value[key]) for key in required})
+        if Path(spec.filename).name != spec.filename:
+            raise AssetManifestError("asset filename must not contain a path")
+        if len(spec.sha256) != 64 or any(c not in "0123456789abcdefABCDEF" for c in spec.sha256):
+            raise AssetManifestError(f"invalid sha256 for {spec.filename}")
+        return spec
+
+
+@dataclass(frozen=True, slots=True)
+class AssetManifest:
+    schema_version: int
+    assets: tuple[AssetSpec, ...]
+
+    def asset(self, filename: str) -> AssetSpec:
+        for spec in self.assets:
+            if spec.filename == filename:
+                return spec
+        raise AssetManifestError(f"asset is not declared: {filename}")
+
+
+def load_manifest(directory: Path) -> AssetManifest:
+    manifest_path = directory / MANIFEST_FILENAME
+    try:
+        raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AssetManifestError(f"cannot read {manifest_path}: {exc}") from exc
+    if not isinstance(raw, dict) or raw.get("schema_version") != 1:
+        raise AssetManifestError("unsupported or missing manifest schema_version")
+    values = raw.get("assets")
+    if not isinstance(values, list) or not values:
+        raise AssetManifestError("manifest assets must be a non-empty list")
+    assets = tuple(AssetSpec.from_mapping(value) for value in values if isinstance(value, dict))
+    if len(assets) != len(values):
+        raise AssetManifestError("every asset entry must be an object")
+    names = [asset.filename for asset in assets]
+    if len(names) != len(set(names)):
+        raise AssetManifestError("manifest contains duplicate asset filenames")
+    return AssetManifest(schema_version=1, assets=assets)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError as exc:
+        raise AssetManifestError(f"cannot read asset {path}: {exc}") from exc
+    return digest.hexdigest()
+
+
+def verify_asset(directory: Path, spec: AssetSpec) -> Path:
+    path = directory / spec.filename
+    if not path.is_file() or path.stat().st_size == 0:
+        raise AssetManifestError(f"asset is missing or empty: {path}")
+    actual = sha256_file(path)
+    if actual.lower() != spec.sha256.lower():
+        raise AssetManifestError(
+            f"asset SHA-256 mismatch for {spec.filename}: expected {spec.sha256}, got {actual}"
+        )
+    return path
+
+
+def candidate_asset_dirs(override: Path | None = None) -> tuple[Path, ...]:
+    """Return override, frozen-app, and source-tree locations in priority order."""
+
+    candidates: list[Path] = []
+    if override is not None:
+        candidates.append(override)
+    meipass = getattr(sys, "_MEIPASS", None)
+    if meipass:
+        candidates.append(Path(meipass) / "data" / DEFAULT_ASSET_DIR_NAME)
+    if getattr(sys, "frozen", False) or "__compiled__" in globals():
+        candidates.append(Path(sys.executable).resolve().parent / "data" / DEFAULT_ASSET_DIR_NAME)
+    candidates.append(Path(__file__).resolve().parents[2] / "data" / DEFAULT_ASSET_DIR_NAME)
+    unique: list[Path] = []
+    for path in candidates:
+        normalized = path.resolve()
+        if normalized not in unique:
+            unique.append(normalized)
+    return tuple(unique)
+
+
+def resolve_verified_assets(
+    required_filenames: Iterable[str], override: Path | None = None
+) -> tuple[Path, AssetManifest, dict[str, Path]]:
+    failures: list[str] = []
+    for directory in candidate_asset_dirs(override):
+        try:
+            manifest = load_manifest(directory)
+            paths = {
+                filename: verify_asset(directory, manifest.asset(filename))
+                for filename in required_filenames
+            }
+            return directory, manifest, paths
+        except AssetManifestError as exc:
+            failures.append(str(exc))
+    reason = "; ".join(failures) if failures else "no candidate directories"
+    raise AssetManifestError(f"no verified voice-turn asset directory: {reason}")

--- a/main_logic/voice_turn/asset_manifest.py
+++ b/main_logic/voice_turn/asset_manifest.py
@@ -120,13 +120,14 @@ def candidate_asset_dirs(override: Path | None = None) -> tuple[Path, ...]:
 def resolve_verified_assets(
     required_filenames: Iterable[str], override: Path | None = None
 ) -> tuple[Path, AssetManifest, dict[str, Path]]:
+    required = tuple(required_filenames)
     failures: list[str] = []
     for directory in candidate_asset_dirs(override):
         try:
             manifest = load_manifest(directory)
             paths = {
                 filename: verify_asset(directory, manifest.asset(filename))
-                for filename in required_filenames
+                for filename in required
             }
             return directory, manifest, paths
         except AssetManifestError as exc:

--- a/main_logic/voice_turn/audio_buffer.py
+++ b/main_logic/voice_turn/audio_buffer.py
@@ -1,0 +1,74 @@
+"""Bounded buffering for already-normalized 16 kHz mono PCM16 audio."""
+
+from __future__ import annotations
+
+from collections import deque
+from threading import Lock
+
+import numpy as np
+
+
+class Pcm16RingBuffer:
+    """A chunked, bounded ring that copies only when a snapshot is requested."""
+
+    SAMPLE_RATE = 16_000
+    SAMPLE_WIDTH_BYTES = 2
+
+    def __init__(self, max_seconds: float = 8.0) -> None:
+        if max_seconds <= 0:
+            raise ValueError("max_seconds must be positive")
+        self._capacity_bytes = int(max_seconds * self.SAMPLE_RATE) * self.SAMPLE_WIDTH_BYTES
+        self._chunks: deque[bytes] = deque()
+        self._size_bytes = 0
+        self._lock = Lock()
+
+    @property
+    def capacity_samples(self) -> int:
+        return self._capacity_bytes // self.SAMPLE_WIDTH_BYTES
+
+    @property
+    def sample_count(self) -> int:
+        with self._lock:
+            return self._size_bytes // self.SAMPLE_WIDTH_BYTES
+
+    def append(self, pcm16_le: bytes | bytearray | memoryview) -> None:
+        chunk = bytes(pcm16_le)
+        if len(chunk) % self.SAMPLE_WIDTH_BYTES:
+            raise ValueError("PCM16 input must contain complete little-endian samples")
+        if not chunk:
+            return
+        with self._lock:
+            if len(chunk) >= self._capacity_bytes:
+                self._chunks.clear()
+                self._chunks.append(chunk[-self._capacity_bytes :])
+                self._size_bytes = self._capacity_bytes
+                return
+            self._chunks.append(chunk)
+            self._size_bytes += len(chunk)
+            overflow = self._size_bytes - self._capacity_bytes
+            while overflow > 0:
+                oldest = self._chunks[0]
+                if len(oldest) <= overflow:
+                    self._chunks.popleft()
+                    self._size_bytes -= len(oldest)
+                    overflow -= len(oldest)
+                    continue
+                trim = overflow + (overflow % self.SAMPLE_WIDTH_BYTES)
+                self._chunks[0] = oldest[trim:]
+                self._size_bytes -= trim
+                overflow = 0
+
+    def snapshot_bytes(self) -> bytes:
+        with self._lock:
+            return b"".join(self._chunks)
+
+    def snapshot_float32(self) -> np.ndarray:
+        pcm = self.snapshot_bytes()
+        if not pcm:
+            return np.empty(0, dtype=np.float32)
+        return np.frombuffer(pcm, dtype="<i2").astype(np.float32) / 32768.0
+
+    def reset(self) -> None:
+        with self._lock:
+            self._chunks.clear()
+            self._size_bytes = 0

--- a/main_logic/voice_turn/contracts.py
+++ b/main_logic/voice_turn/contracts.py
@@ -1,0 +1,116 @@
+"""Stable contracts for provider-neutral semantic turn detection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from collections.abc import Callable
+from typing import Protocol, runtime_checkable
+
+
+class TurnDecision(Enum):
+    """A semantic judgment only; timeout and provider commits live elsewhere."""
+
+    INCOMPLETE = "incomplete"
+    COMPLETE = "complete"
+
+
+class EvaluationStatus(Enum):
+    """Execution status kept separate from the semantic decision."""
+
+    OK = "ok"
+    UNAVAILABLE = "unavailable"
+    ERROR = "error"
+    STALE = "stale"
+
+
+class SpeechActivityEvent(Enum):
+    """Cheap VAD events; none of these commits an ASR turn."""
+
+    NONE = "none"
+    SPEECH_STARTED = "speech_started"
+    CANDIDATE_PAUSE = "candidate_pause"
+    SPEECH_RESUMED = "speech_resumed"
+
+
+@dataclass(frozen=True, slots=True)
+class TurnEvaluation:
+    status: EvaluationStatus
+    decision: TurnDecision | None
+    probability: float | None
+    generation: int
+    activity_seq: int
+    reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.status is EvaluationStatus.OK:
+            if self.decision is None or self.probability is None:
+                raise ValueError("OK evaluations require a decision and probability")
+            if not 0.0 <= self.probability <= 1.0:
+                raise ValueError("probability must be within [0, 1]")
+        elif self.decision is not None or self.probability is not None:
+            raise ValueError("non-OK evaluations must not carry a semantic result")
+
+
+@runtime_checkable
+class TurnDetector(Protocol):
+    """Contract consumed by the future ASR Controller."""
+
+    async def on_speech_started(self) -> None: ...
+
+    async def evaluate(self, audio_tail: bytes) -> TurnEvaluation: ...
+
+    async def reset(self) -> None: ...
+
+    async def close(self) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class AsrTurnCapabilities:
+    """Only the capability needed to choose an endpoint authority."""
+
+    semantic_endpoint: bool
+
+
+def requires_external_turn_detector(capabilities: AsrTurnCapabilities) -> bool:
+    """Return false for Soniox-like providers with authoritative endpoints."""
+
+    return not capabilities.semantic_endpoint
+
+
+def build_turn_detector_if_required(
+    capabilities: AsrTurnCapabilities, factory: Callable[[], TurnDetector]
+) -> TurnDetector | None:
+    """Construct only for providers without an authoritative semantic endpoint."""
+
+    if not requires_external_turn_detector(capabilities):
+        return None
+    return factory()
+
+
+@dataclass(frozen=True, slots=True)
+class SmartTurnConfig:
+    """Internal defaults; this PR does not expose a user-facing setting."""
+
+    enabled: bool = False
+    evaluation_threshold: float = 0.5
+    candidate_silence_ms: int = 300
+    onset_probability: float = 0.5
+    offset_probability: float = 0.35
+    minimum_speech_ms: int = 200
+    max_audio_seconds: int = 8
+    inference_error_limit: int = 3
+
+    def __post_init__(self) -> None:
+        for name in ("evaluation_threshold", "onset_probability", "offset_probability"):
+            value = getattr(self, name)
+            if not 0.0 <= value <= 1.0:
+                raise ValueError(f"{name} must be within [0, 1]")
+        if self.offset_probability >= self.onset_probability:
+            raise ValueError("offset_probability must be below onset_probability")
+        if self.candidate_silence_ms <= 0 or self.minimum_speech_ms <= 0:
+            raise ValueError("speech and silence durations must be positive")
+        if self.max_audio_seconds <= 0:
+            raise ValueError("max_audio_seconds must be positive")
+        if self.inference_error_limit <= 0:
+            raise ValueError("inference_error_limit must be positive")

--- a/main_logic/voice_turn/coordinator.py
+++ b/main_logic/voice_turn/coordinator.py
@@ -1,0 +1,204 @@
+"""Async Smart Turn coordination with stale-result and coalescing guards."""
+
+from __future__ import annotations
+
+import asyncio
+from enum import Enum
+from typing import Protocol
+
+import numpy as np
+
+from .audio_buffer import Pcm16RingBuffer
+from .contracts import (
+    EvaluationStatus,
+    SmartTurnConfig,
+    SpeechActivityEvent,
+    TurnDecision,
+    TurnEvaluation,
+)
+from .onnx_runtime import RuntimeInferenceError, RuntimeUnavailableError
+
+
+class ProbabilityPredictor(Protocol):
+    def load(self) -> bool: ...
+
+    def predict_probability(self, audio: np.ndarray) -> float: ...
+
+    def close(self) -> None: ...
+
+
+class CoordinatorState(Enum):
+    IDLE = "idle"
+    SPEECH_ACTIVE = "speech_active"
+    PAUSE_CANDIDATE = "pause_candidate"
+    EVALUATING = "evaluating"
+    WAIT_CONTINUATION = "wait_continuation"
+    CLOSED = "closed"
+
+
+class TurnCoordinator:
+    """Own model evaluation state, but never commit a provider buffer."""
+
+    def __init__(self, predictor: ProbabilityPredictor, config: SmartTurnConfig) -> None:
+        self._predictor = predictor
+        self._config = config
+        self._buffer = Pcm16RingBuffer(config.max_audio_seconds)
+        self._generation = 0
+        self._activity_seq = 0
+        self._request_seq = 0
+        self._latest_request = 0
+        self._state = CoordinatorState.IDLE
+        self._closed = False
+        self._state_lock = asyncio.Lock()
+        self._evaluation_lock = asyncio.Lock()
+
+    @property
+    def generation(self) -> int:
+        return self._generation
+
+    @property
+    def activity_seq(self) -> int:
+        return self._activity_seq
+
+    @property
+    def state(self) -> CoordinatorState:
+        return self._state
+
+    def push_audio(self, pcm16_le: bytes) -> None:
+        if self._closed:
+            return
+        self._buffer.append(pcm16_le)
+
+    async def on_activity_event(self, event: SpeechActivityEvent) -> None:
+        if event is SpeechActivityEvent.NONE or self._closed:
+            return
+        async with self._state_lock:
+            if self._closed:
+                return
+            if event in (SpeechActivityEvent.SPEECH_STARTED, SpeechActivityEvent.SPEECH_RESUMED):
+                self._activity_seq += 1
+                self._state = CoordinatorState.SPEECH_ACTIVE
+            elif event is SpeechActivityEvent.CANDIDATE_PAUSE:
+                self._state = CoordinatorState.PAUSE_CANDIDATE
+
+    async def on_speech_started(self) -> None:
+        await self.on_activity_event(SpeechActivityEvent.SPEECH_STARTED)
+
+    async def evaluate_buffered(self) -> TurnEvaluation:
+        return await self.evaluate(self._buffer.snapshot_bytes())
+
+    async def evaluate(self, audio_tail: bytes) -> TurnEvaluation:
+        if len(audio_tail) % 2:
+            raise ValueError("Smart Turn input must contain complete PCM16 samples")
+        async with self._state_lock:
+            self._request_seq += 1
+            request = self._request_seq
+            self._latest_request = request
+            generation = self._generation
+            activity_seq = self._activity_seq
+            if self._closed:
+                return self._non_ok(
+                    EvaluationStatus.STALE, generation, activity_seq, "coordinator_closed"
+                )
+
+        async with self._evaluation_lock:
+            async with self._state_lock:
+                if request != self._latest_request:
+                    return self._non_ok(
+                        EvaluationStatus.STALE, generation, activity_seq, "candidate_superseded"
+                    )
+                if generation != self._generation or activity_seq != self._activity_seq:
+                    return self._non_ok(
+                        EvaluationStatus.STALE, generation, activity_seq, "activity_changed"
+                    )
+                self._state = CoordinatorState.EVALUATING
+
+            if not audio_tail:
+                result = self._non_ok(
+                    EvaluationStatus.UNAVAILABLE, generation, activity_seq, "empty_audio"
+                )
+            else:
+                try:
+                    loaded = await asyncio.to_thread(self._predictor.load)
+                    if not loaded:
+                        result = self._non_ok(
+                            EvaluationStatus.UNAVAILABLE,
+                            generation,
+                            activity_seq,
+                            "model_unavailable",
+                        )
+                    else:
+                        audio = np.frombuffer(audio_tail, dtype="<i2").astype(np.float32) / 32768.0
+                        probability = await asyncio.to_thread(
+                            self._predictor.predict_probability, audio
+                        )
+                        decision = (
+                            TurnDecision.COMPLETE
+                            if probability >= self._config.evaluation_threshold
+                            else TurnDecision.INCOMPLETE
+                        )
+                        result = TurnEvaluation(
+                            EvaluationStatus.OK,
+                            decision,
+                            probability,
+                            generation,
+                            activity_seq,
+                        )
+                except RuntimeUnavailableError as exc:
+                    result = self._non_ok(
+                        EvaluationStatus.UNAVAILABLE, generation, activity_seq, str(exc)
+                    )
+                except (RuntimeInferenceError, Exception) as exc:
+                    result = self._non_ok(
+                        EvaluationStatus.ERROR,
+                        generation,
+                        activity_seq,
+                        f"{type(exc).__name__}:{exc}",
+                    )
+
+            async with self._state_lock:
+                if (
+                    self._closed
+                    or request != self._latest_request
+                    or generation != self._generation
+                    or activity_seq != self._activity_seq
+                ):
+                    return self._non_ok(
+                        EvaluationStatus.STALE, generation, activity_seq, "result_became_stale"
+                    )
+                self._state = (
+                    CoordinatorState.WAIT_CONTINUATION
+                    if result.status is EvaluationStatus.OK
+                    and result.decision is TurnDecision.INCOMPLETE
+                    else CoordinatorState.PAUSE_CANDIDATE
+                )
+                return result
+
+    async def reset(self) -> None:
+        async with self._state_lock:
+            if self._closed:
+                return
+            self._generation += 1
+            self._latest_request = self._request_seq + 1
+            self._state = CoordinatorState.IDLE
+            self._buffer.reset()
+
+    async def close(self) -> None:
+        async with self._state_lock:
+            if self._closed:
+                return
+            self._closed = True
+            self._generation += 1
+            self._latest_request = self._request_seq + 1
+            self._state = CoordinatorState.CLOSED
+            self._buffer.reset()
+        # Drain the single inference lane before releasing the session. The
+        # generation change above already guarantees any late result is stale.
+        async with self._evaluation_lock:
+            await asyncio.to_thread(self._predictor.close)
+
+    @staticmethod
+    def _non_ok(
+        status: EvaluationStatus, generation: int, activity_seq: int, reason: str
+    ) -> TurnEvaluation:
+        return TurnEvaluation(status, None, None, generation, activity_seq, reason)

--- a/main_logic/voice_turn/onnx_runtime.py
+++ b/main_logic/voice_turn/onnx_runtime.py
@@ -1,0 +1,152 @@
+"""Shared lifecycle for small, CPU-only ONNX voice-turn models."""
+
+from __future__ import annotations
+
+from enum import Enum
+from pathlib import Path
+from threading import Lock
+from typing import Any
+
+from .asset_manifest import AssetManifestError, resolve_verified_assets
+
+
+class RuntimeState(Enum):
+    UNLOADED = "unloaded"
+    LOADING = "loading"
+    READY = "ready"
+    DEGRADED = "degraded"
+    UNAVAILABLE = "unavailable"
+    CLOSED = "closed"
+
+
+class RuntimeUnavailableError(RuntimeError):
+    pass
+
+
+class RuntimeInferenceError(RuntimeError):
+    pass
+
+
+class OnnxModelRuntime:
+    """Lazy, single-flight ONNX lifecycle with a per-instance circuit breaker."""
+
+    asset_filenames: tuple[str, ...] = ()
+
+    def __init__(
+        self,
+        *,
+        enabled: bool = False,
+        asset_dir: Path | None = None,
+        intra_op_threads: int = 1,
+        inference_error_limit: int = 3,
+        enable_cpu_mem_arena: bool = False,
+    ) -> None:
+        if intra_op_threads <= 0:
+            raise ValueError("intra_op_threads must be positive")
+        if inference_error_limit <= 0:
+            raise ValueError("inference_error_limit must be positive")
+        self._enabled = enabled
+        self._asset_dir = asset_dir
+        self._intra_op_threads = intra_op_threads
+        self._inference_error_limit = inference_error_limit
+        self._enable_cpu_mem_arena = enable_cpu_mem_arena
+        self._state = RuntimeState.UNLOADED if enabled else RuntimeState.UNAVAILABLE
+        self._reason = None if enabled else "disabled_by_config"
+        self._session: Any | None = None
+        self._load_lock = Lock()
+        self._inference_lock = Lock()
+        self._consecutive_errors = 0
+
+    @property
+    def state(self) -> RuntimeState:
+        return self._state
+
+    @property
+    def unavailable_reason(self) -> str | None:
+        return self._reason
+
+    @property
+    def is_ready(self) -> bool:
+        return self._state in (RuntimeState.READY, RuntimeState.DEGRADED)
+
+    def load(self) -> bool:
+        """Load once; concurrent callers share the same attempt."""
+
+        if self.is_ready:
+            return True
+        if self._state in (RuntimeState.UNAVAILABLE, RuntimeState.CLOSED):
+            return False
+        with self._load_lock:
+            if self.is_ready:
+                return True
+            if self._state in (RuntimeState.UNAVAILABLE, RuntimeState.CLOSED):
+                return False
+            self._state = RuntimeState.LOADING
+            try:
+                _, manifest, paths = resolve_verified_assets(
+                    self.asset_filenames, override=self._asset_dir
+                )
+                import onnxruntime as ort
+
+                self._load_verified(paths, manifest, ort)
+            except (AssetManifestError, ImportError) as exc:
+                self._mark_unavailable(type(exc).__name__.lower())
+                return False
+            except Exception as exc:  # model/session failures are contained
+                self._mark_unavailable(f"load_error:{type(exc).__name__}")
+                return False
+            self._state = RuntimeState.READY
+            self._reason = None
+            return True
+
+    def _make_session(self, model_path: Path, ort: Any) -> Any:
+        options = ort.SessionOptions()
+        options.execution_mode = ort.ExecutionMode.ORT_SEQUENTIAL
+        options.intra_op_num_threads = self._intra_op_threads
+        options.inter_op_num_threads = 1
+        options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
+        options.enable_cpu_mem_arena = self._enable_cpu_mem_arena
+        return ort.InferenceSession(
+            str(model_path),
+            sess_options=options,
+            providers=["CPUExecutionProvider"],
+        )
+
+    def _load_verified(self, paths: dict[str, Path], manifest: Any, ort: Any) -> None:
+        raise NotImplementedError
+
+    def _run_session(self, output_names: Any, inputs: dict[str, Any]) -> Any:
+        if not self.is_ready or self._session is None:
+            raise RuntimeUnavailableError(self._reason or self._state.value)
+        try:
+            with self._inference_lock:
+                session = self._session
+                if session is None:
+                    raise RuntimeUnavailableError("runtime_closed")
+                outputs = session.run(output_names, inputs)
+        except RuntimeUnavailableError:
+            raise
+        except Exception as exc:
+            self._consecutive_errors += 1
+            if self._consecutive_errors >= self._inference_error_limit:
+                self._mark_unavailable(f"inference_circuit_open:{type(exc).__name__}")
+            else:
+                self._state = RuntimeState.DEGRADED
+                self._reason = f"inference_error:{type(exc).__name__}"
+            raise RuntimeInferenceError(str(exc)) from exc
+        self._consecutive_errors = 0
+        self._state = RuntimeState.READY
+        self._reason = None
+        return outputs
+
+    def _mark_unavailable(self, reason: str) -> None:
+        self._session = None
+        self._state = RuntimeState.UNAVAILABLE
+        self._reason = reason
+
+    def close(self) -> None:
+        with self._load_lock:
+            with self._inference_lock:
+                self._session = None
+                self._state = RuntimeState.CLOSED
+                self._reason = "closed"

--- a/main_logic/voice_turn/onnx_runtime.py
+++ b/main_logic/voice_turn/onnx_runtime.py
@@ -118,26 +118,26 @@ class OnnxModelRuntime:
     def _run_session(self, output_names: Any, inputs: dict[str, Any]) -> Any:
         if not self.is_ready or self._session is None:
             raise RuntimeUnavailableError(self._reason or self._state.value)
-        try:
-            with self._inference_lock:
+        with self._inference_lock:
+            try:
                 session = self._session
                 if session is None:
                     raise RuntimeUnavailableError("runtime_closed")
                 outputs = session.run(output_names, inputs)
-        except RuntimeUnavailableError:
-            raise
-        except Exception as exc:
-            self._consecutive_errors += 1
-            if self._consecutive_errors >= self._inference_error_limit:
-                self._mark_unavailable(f"inference_circuit_open:{type(exc).__name__}")
-            else:
-                self._state = RuntimeState.DEGRADED
-                self._reason = f"inference_error:{type(exc).__name__}"
-            raise RuntimeInferenceError(str(exc)) from exc
-        self._consecutive_errors = 0
-        self._state = RuntimeState.READY
-        self._reason = None
-        return outputs
+            except RuntimeUnavailableError:
+                raise
+            except Exception as exc:
+                self._consecutive_errors += 1
+                if self._consecutive_errors >= self._inference_error_limit:
+                    self._mark_unavailable(f"inference_circuit_open:{type(exc).__name__}")
+                else:
+                    self._state = RuntimeState.DEGRADED
+                    self._reason = f"inference_error:{type(exc).__name__}"
+                raise RuntimeInferenceError(str(exc)) from exc
+            self._consecutive_errors = 0
+            self._state = RuntimeState.READY
+            self._reason = None
+            return outputs
 
     def _mark_unavailable(self, reason: str) -> None:
         self._session = None

--- a/main_logic/voice_turn/silero_vad.py
+++ b/main_logic/voice_turn/silero_vad.py
@@ -1,0 +1,113 @@
+"""Streaming Silero VAD and provider-neutral speech activity gating."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from threading import Lock
+from typing import Any, Iterable
+
+import numpy as np
+
+from .contracts import SmartTurnConfig, SpeechActivityEvent
+from .onnx_runtime import OnnxModelRuntime
+
+
+class SileroVad(OnnxModelRuntime):
+    """Silero v5/v6 ONNX wrapper for continuous 16 kHz PCM16 streams."""
+
+    asset_filenames = ("silero_vad.onnx",)
+    SAMPLE_RATE = 16_000
+    WINDOW_SAMPLES = 512
+    CONTEXT_SAMPLES = 64
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._sample_rate = np.asarray(self.SAMPLE_RATE, dtype=np.int64)
+        self._stream_lock = Lock()
+        self.reset_stream()
+
+    def _load_verified(self, paths: dict[str, Path], manifest: Any, ort: Any) -> None:
+        self._session = self._make_session(paths["silero_vad.onnx"], ort)
+
+    def reset_stream(self) -> None:
+        with getattr(self, "_stream_lock", Lock()):
+            self._lstm_state = np.zeros((2, 1, 128), dtype=np.float32)
+            self._context = np.zeros(self.CONTEXT_SAMPLES, dtype=np.float32)
+            self._pending = np.empty(0, dtype=np.float32)
+
+    def process_pcm16(self, pcm16_le: bytes) -> list[float]:
+        if len(pcm16_le) % 2:
+            raise ValueError("Silero input must contain complete PCM16 samples")
+        if not pcm16_le or not self.is_ready:
+            return []
+        samples = np.frombuffer(pcm16_le, dtype="<i2").astype(np.float32) / 32768.0
+        probabilities: list[float] = []
+        with self._stream_lock:
+            self._pending = np.concatenate((self._pending, samples))
+            while self._pending.size >= self.WINDOW_SAMPLES:
+                window = self._pending[: self.WINDOW_SAMPLES]
+                self._pending = self._pending[self.WINDOW_SAMPLES :]
+                model_input = np.concatenate((self._context, window))[None].astype(np.float32)
+                outputs = self._run_session(
+                    None,
+                    {
+                        "input": model_input,
+                        "state": self._lstm_state,
+                        "sr": self._sample_rate,
+                    },
+                )
+                probability = float(np.asarray(outputs[0]).reshape(-1)[0])
+                if not 0.0 <= probability <= 1.0:
+                    raise ValueError("Silero returned a probability outside [0, 1]")
+                self._lstm_state = np.asarray(outputs[1], dtype=np.float32)
+                self._context = window[-self.CONTEXT_SAMPLES :].copy()
+                probabilities.append(probability)
+        return probabilities
+
+
+class SileroActivityGate:
+    """Map Silero probabilities to activity events without committing a turn."""
+
+    def __init__(self, vad: SileroVad, config: SmartTurnConfig) -> None:
+        self._vad = vad
+        self._config = config
+        window_ms = 1000 * SileroVad.WINDOW_SAMPLES / SileroVad.SAMPLE_RATE
+        self._minimum_speech_windows = max(1, round(config.minimum_speech_ms / window_ms))
+        self._candidate_silence_windows = max(1, round(config.candidate_silence_ms / window_ms))
+        self.reset()
+
+    def reset(self) -> None:
+        self._vad.reset_stream()
+        self._speech_windows = 0
+        self._silence_windows = 0
+        self._speech_confirmed = False
+        self._candidate_emitted = False
+
+    def feed(self, pcm16_le: bytes) -> SpeechActivityEvent:
+        return self.process_probabilities(self._vad.process_pcm16(pcm16_le))
+
+    def process_probabilities(self, probabilities: Iterable[float]) -> SpeechActivityEvent:
+        event = SpeechActivityEvent.NONE
+        for probability in probabilities:
+            if probability >= self._config.onset_probability:
+                was_paused = self._candidate_emitted
+                self._speech_windows += 1
+                self._silence_windows = 0
+                self._candidate_emitted = False
+                if not self._speech_confirmed and self._speech_windows >= self._minimum_speech_windows:
+                    self._speech_confirmed = True
+                    event = SpeechActivityEvent.SPEECH_STARTED
+                elif self._speech_confirmed and was_paused:
+                    event = SpeechActivityEvent.SPEECH_RESUMED
+            elif probability < self._config.offset_probability:
+                if not self._speech_confirmed:
+                    self._speech_windows = 0
+                    continue
+                self._silence_windows += 1
+                if (
+                    not self._candidate_emitted
+                    and self._silence_windows >= self._candidate_silence_windows
+                ):
+                    self._candidate_emitted = True
+                    event = SpeechActivityEvent.CANDIDATE_PAUSE
+        return event

--- a/main_logic/voice_turn/silero_vad.py
+++ b/main_logic/voice_turn/silero_vad.py
@@ -48,7 +48,9 @@ class SileroVad(OnnxModelRuntime):
             while self._pending.size >= self.WINDOW_SAMPLES:
                 window = self._pending[: self.WINDOW_SAMPLES]
                 self._pending = self._pending[self.WINDOW_SAMPLES :]
-                model_input = np.concatenate((self._context, window))[None].astype(np.float32)
+                model_input = np.concatenate((self._context, window))[None].astype(
+                    np.float32
+                )
                 outputs = self._run_session(
                     None,
                     {
@@ -88,22 +90,27 @@ class SileroActivityGate:
         self._speech_confirmed = False
         self._candidate_emitted = False
 
-    def feed(self, pcm16_le: bytes) -> SpeechActivityEvent:
+    def feed(self, pcm16_le: bytes) -> tuple[SpeechActivityEvent, ...]:
         return self.process_probabilities(self._vad.process_pcm16(pcm16_le))
 
-    def process_probabilities(self, probabilities: Iterable[float]) -> SpeechActivityEvent:
-        event = SpeechActivityEvent.NONE
+    def process_probabilities(
+        self, probabilities: Iterable[float]
+    ) -> tuple[SpeechActivityEvent, ...]:
+        events: list[SpeechActivityEvent] = []
         for probability in probabilities:
             if probability >= self._config.onset_probability:
                 was_paused = self._candidate_emitted
                 self._speech_windows += 1
                 self._silence_windows = 0
                 self._candidate_emitted = False
-                if not self._speech_confirmed and self._speech_windows >= self._minimum_speech_windows:
+                if (
+                    not self._speech_confirmed
+                    and self._speech_windows >= self._minimum_speech_windows
+                ):
                     self._speech_confirmed = True
-                    event = SpeechActivityEvent.SPEECH_STARTED
+                    events.append(SpeechActivityEvent.SPEECH_STARTED)
                 elif self._speech_confirmed and was_paused:
-                    event = SpeechActivityEvent.SPEECH_RESUMED
+                    events.append(SpeechActivityEvent.SPEECH_RESUMED)
             elif probability < self._config.offset_probability:
                 if not self._speech_confirmed:
                     self._speech_windows = 0
@@ -114,5 +121,5 @@ class SileroActivityGate:
                     and self._silence_windows >= self._candidate_silence_windows
                 ):
                     self._candidate_emitted = True
-                    event = SpeechActivityEvent.CANDIDATE_PAUSE
-        return event
+                    events.append(SpeechActivityEvent.CANDIDATE_PAUSE)
+        return tuple(events)

--- a/main_logic/voice_turn/silero_vad.py
+++ b/main_logic/voice_turn/silero_vad.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from pathlib import Path
 from threading import Lock
 from typing import Any, Iterable
@@ -72,8 +73,12 @@ class SileroActivityGate:
         self._vad = vad
         self._config = config
         window_ms = 1000 * SileroVad.WINDOW_SAMPLES / SileroVad.SAMPLE_RATE
-        self._minimum_speech_windows = max(1, round(config.minimum_speech_ms / window_ms))
-        self._candidate_silence_windows = max(1, round(config.candidate_silence_ms / window_ms))
+        self._minimum_speech_windows = max(
+            1, math.ceil(config.minimum_speech_ms / window_ms)
+        )
+        self._candidate_silence_windows = max(
+            1, math.ceil(config.candidate_silence_ms / window_ms)
+        )
         self.reset()
 
     def reset(self) -> None:

--- a/main_logic/voice_turn/smart_turn_v3.py
+++ b/main_logic/voice_turn/smart_turn_v3.py
@@ -1,0 +1,40 @@
+"""Smart Turn v3.2 CPU ONNX semantic endpoint runtime."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from .onnx_runtime import OnnxModelRuntime, RuntimeInferenceError
+from .whisper_features import WhisperFeatureExtractor
+
+
+class SmartTurnV3(OnnxModelRuntime):
+    asset_filenames = ("smart_turn_v3.onnx",)
+
+    def __init__(self, **kwargs: Any) -> None:
+        # Two CPU threads met the <=30 ms local inference target on the Windows
+        # reference machine without enabling the higher-RSS CPU arena.
+        kwargs.setdefault("intra_op_threads", 2)
+        super().__init__(**kwargs)
+        self._features = WhisperFeatureExtractor()
+        self._input_name = "input_features"
+
+    def _load_verified(self, paths: dict[str, Path], manifest: Any, ort: Any) -> None:
+        self._session = self._make_session(paths["smart_turn_v3.onnx"], ort)
+        inputs = self._session.get_inputs()
+        if len(inputs) != 1:
+            raise ValueError("Smart Turn model must expose exactly one input")
+        self._input_name = inputs[0].name
+
+    def predict_probability(self, audio: np.ndarray) -> float:
+        if np.asarray(audio).size == 0:
+            raise ValueError("Smart Turn requires non-empty audio")
+        features = self._features.extract(np.asarray(audio))[None].astype(np.float32)
+        outputs = self._run_session(None, {self._input_name: features})
+        probability = float(np.asarray(outputs[0]).reshape(-1)[0])
+        if not np.isfinite(probability) or not 0.0 <= probability <= 1.0:
+            raise RuntimeInferenceError("Smart Turn returned an invalid probability")
+        return probability

--- a/main_logic/voice_turn/whisper_features.py
+++ b/main_logic/voice_turn/whisper_features.py
@@ -1,0 +1,86 @@
+"""Numpy-only Whisper log-mel preprocessing used by Smart Turn v3."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def _hertz_to_mel(frequencies: np.ndarray) -> np.ndarray:
+    frequencies = np.asarray(frequencies, dtype=np.float64)
+    min_log_hertz = 1000.0
+    min_log_mel = 15.0
+    logstep = np.log(6.4) / 27.0
+    mels = frequencies / (200.0 / 3.0)
+    return np.where(
+        frequencies >= min_log_hertz,
+        min_log_mel + np.log(np.maximum(frequencies, min_log_hertz) / min_log_hertz) / logstep,
+        mels,
+    )
+
+
+def _mel_to_hertz(mels: np.ndarray) -> np.ndarray:
+    mels = np.asarray(mels, dtype=np.float64)
+    min_log_hertz = 1000.0
+    min_log_mel = 15.0
+    logstep = np.log(6.4) / 27.0
+    frequencies = (200.0 / 3.0) * mels
+    return np.where(
+        mels >= min_log_mel,
+        min_log_hertz * np.exp(logstep * (mels - min_log_mel)),
+        frequencies,
+    )
+
+
+def whisper_mel_filter_bank() -> np.ndarray:
+    """Return the Slaney-normalized 201x80 bank used by Whisper."""
+
+    fft_frequencies = np.linspace(0.0, 8000.0, 201)
+    mel_min, mel_max = _hertz_to_mel(np.asarray([0.0, 8000.0]))
+    filter_frequencies = _mel_to_hertz(np.linspace(mel_min, mel_max, 82))
+    filter_diff = np.diff(filter_frequencies)
+    slopes = filter_frequencies[None, :] - fft_frequencies[:, None]
+    down = -slopes[:, :-2] / filter_diff[:-1]
+    up = slopes[:, 2:] / filter_diff[1:]
+    filters = np.maximum(0.0, np.minimum(down, up))
+    filters *= (2.0 / (filter_frequencies[2:82] - filter_frequencies[:80]))[None, :]
+    return filters
+
+
+class WhisperFeatureExtractor:
+    SAMPLE_RATE = 16_000
+    MAX_SAMPLES = 8 * SAMPLE_RATE
+    N_FFT = 400
+    HOP_LENGTH = 160
+    N_FRAMES = 800
+
+    def __init__(self) -> None:
+        self._mel_filters = whisper_mel_filter_bank()
+        indices = np.arange(self.N_FFT, dtype=np.float64)
+        self._window = 0.5 - 0.5 * np.cos(2 * np.pi * indices / self.N_FFT)
+        padded_samples = self.MAX_SAMPLES + self.N_FFT
+        full_frames = 1 + (padded_samples - self.N_FFT) // self.HOP_LENGTH
+        self._frame_indices = (
+            np.arange(self.N_FFT)[None, :]
+            + self.HOP_LENGTH * np.arange(full_frames)[:, None]
+        )
+
+    def extract(self, audio: np.ndarray) -> np.ndarray:
+        """Return `[80, 800]` float32 features for the trailing 8 seconds."""
+
+        values = np.asarray(audio)
+        if values.ndim != 1:
+            raise ValueError("Smart Turn audio must be mono")
+        if values.size > self.MAX_SAMPLES:
+            values = values[-self.MAX_SAMPLES :]
+        elif values.size < self.MAX_SAMPLES:
+            values = np.pad(values, (self.MAX_SAMPLES - values.size, 0))
+        values = values.astype(np.float64)
+        values = (values - values.mean()) / np.sqrt(values.var() + 1e-7)
+        centered = np.pad(values, (self.N_FFT // 2, self.N_FFT // 2), mode="reflect")
+        frames = centered[self._frame_indices] * self._window[None, :]
+        spectrum = np.fft.rfft(frames, n=self.N_FFT, axis=1)
+        power = (spectrum.real**2 + spectrum.imag**2).T
+        mel_spectrum = self._mel_filters.T @ power
+        log_spectrum = np.log10(np.clip(mel_spectrum, 1e-10, None))[:, :-1]
+        log_spectrum = np.maximum(log_spectrum, log_spectrum.max() - 8.0)
+        return ((log_spectrum + 4.0) / 4.0).astype(np.float32)

--- a/specs/launcher.spec
+++ b/specs/launcher.spec
@@ -168,6 +168,7 @@ add_data('data/browser_use_prompts', 'data/browser_use_prompts')
 # packaging; for local source builds add_data warns and skips silently.
 add_data('data/tiktoken_cache', 'data/tiktoken_cache')
 add_data('data/embedding_models', 'data/embedding_models')
+add_data('data/vad_models', 'data/vad_models')
 add_data('steam_appid.txt', '.')
 
 # 添加 Steam 相关的 DLL 和库文件（源文件位于 steamworks/，打包后放在根目录）

--- a/tests/unit/voice_turn/__init__.py
+++ b/tests/unit/voice_turn/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the provider-neutral voice-turn package."""

--- a/tests/unit/voice_turn/test_asset_manifest.py
+++ b/tests/unit/voice_turn/test_asset_manifest.py
@@ -3,6 +3,7 @@ import json
 
 import pytest
 
+from main_logic.voice_turn import asset_manifest
 from main_logic.voice_turn.asset_manifest import (
     AssetManifestError,
     load_manifest,
@@ -51,3 +52,20 @@ def test_manifest_rejects_path_traversal_filename(tmp_path):
     (tmp_path / "manifest.json").write_text(json.dumps(raw), encoding="utf-8")
     with pytest.raises(AssetManifestError, match="must not contain a path"):
         load_manifest(tmp_path)
+
+
+def test_generator_required_filenames_survive_candidate_fallback(monkeypatch, tmp_path):
+    invalid = tmp_path / "invalid"
+    valid = tmp_path / "valid"
+    invalid.mkdir()
+    valid.mkdir()
+    content = b"model"
+    _write_manifest(invalid, digest=hashlib.sha256(content).hexdigest())
+    (valid / "model.onnx").write_bytes(content)
+    _write_manifest(valid, digest=hashlib.sha256(content).hexdigest())
+    monkeypatch.setattr(asset_manifest, "candidate_asset_dirs", lambda override: (invalid, valid))
+
+    required = (filename for filename in ("model.onnx",))
+    directory, _, paths = resolve_verified_assets(required)
+    assert directory == valid
+    assert paths == {"model.onnx": valid / "model.onnx"}

--- a/tests/unit/voice_turn/test_asset_manifest.py
+++ b/tests/unit/voice_turn/test_asset_manifest.py
@@ -1,0 +1,53 @@
+import hashlib
+import json
+
+import pytest
+
+from main_logic.voice_turn.asset_manifest import (
+    AssetManifestError,
+    load_manifest,
+    resolve_verified_assets,
+    verify_asset,
+)
+
+
+def _write_manifest(directory, *, digest):
+    payload = {
+        "schema_version": 1,
+        "assets": [
+            {
+                "filename": "model.onnx",
+                "version": "test",
+                "source": "https://example.test/model.onnx",
+                "license": "BSD-2-Clause",
+                "sha256": digest,
+                "input_contract": "float32[1]",
+                "output_contract": "probability[1]",
+            }
+        ],
+    }
+    (directory / "manifest.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_manifest_verifies_declared_asset(tmp_path):
+    content = b"model"
+    (tmp_path / "model.onnx").write_bytes(content)
+    _write_manifest(tmp_path, digest=hashlib.sha256(content).hexdigest())
+    manifest = load_manifest(tmp_path)
+    assert verify_asset(tmp_path, manifest.asset("model.onnx")).name == "model.onnx"
+
+
+def test_manifest_rejects_sha_mismatch(tmp_path):
+    (tmp_path / "model.onnx").write_bytes(b"corrupt")
+    _write_manifest(tmp_path, digest="0" * 64)
+    with pytest.raises(AssetManifestError, match="SHA-256 mismatch"):
+        resolve_verified_assets(["model.onnx"], override=tmp_path)
+
+
+def test_manifest_rejects_path_traversal_filename(tmp_path):
+    _write_manifest(tmp_path, digest="0" * 64)
+    raw = json.loads((tmp_path / "manifest.json").read_text(encoding="utf-8"))
+    raw["assets"][0]["filename"] = "../model.onnx"
+    (tmp_path / "manifest.json").write_text(json.dumps(raw), encoding="utf-8")
+    with pytest.raises(AssetManifestError, match="must not contain a path"):
+        load_manifest(tmp_path)

--- a/tests/unit/voice_turn/test_audio_buffer.py
+++ b/tests/unit/voice_turn/test_audio_buffer.py
@@ -1,0 +1,36 @@
+import numpy as np
+import pytest
+
+from main_logic.voice_turn.audio_buffer import Pcm16RingBuffer
+
+
+def _pcm(values):
+    return np.asarray(values, dtype="<i2").tobytes()
+
+
+def test_ring_buffer_preserves_order_and_trims_oldest_samples():
+    buffer = Pcm16RingBuffer(max_seconds=4 / 16_000)
+    buffer.append(_pcm([1, 2, 3]))
+    buffer.append(_pcm([4, 5, 6]))
+    assert np.frombuffer(buffer.snapshot_bytes(), dtype="<i2").tolist() == [3, 4, 5, 6]
+
+
+def test_chunk_larger_than_capacity_keeps_only_tail():
+    buffer = Pcm16RingBuffer(max_seconds=3 / 16_000)
+    buffer.append(_pcm([10, 20, 30, 40]))
+    assert np.frombuffer(buffer.snapshot_bytes(), dtype="<i2").tolist() == [20, 30, 40]
+
+
+def test_snapshot_is_independent_from_reset():
+    buffer = Pcm16RingBuffer(max_seconds=1)
+    buffer.append(_pcm([100, -100]))
+    snapshot = buffer.snapshot_float32()
+    buffer.reset()
+    assert snapshot.tolist() == pytest.approx([100 / 32768, -100 / 32768])
+    assert buffer.sample_count == 0
+
+
+def test_rejects_partial_pcm16_sample():
+    buffer = Pcm16RingBuffer()
+    with pytest.raises(ValueError):
+        buffer.append(b"\x01")

--- a/tests/unit/voice_turn/test_build_contracts.py
+++ b/tests/unit/voice_turn/test_build_contracts.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_pyinstaller_bundles_voice_turn_assets():
+    spec = (ROOT / "specs" / "launcher.spec").read_text(encoding="utf-8")
+    assert "add_data('data/vad_models', 'data/vad_models')" in spec
+
+
+def test_nuitka_workflows_prepare_bundle_and_verify_voice_turn_assets():
+    for relative in (
+        ".github/workflows/build-desktop.yml",
+        ".github/workflows/build-desktop-linux.yml",
+    ):
+        workflow = (ROOT / relative).read_text(encoding="utf-8")
+        assert "tools/voice_eval/prepare_voice_turn_assets.py" in workflow
+        assert "--include-data-dir=data/vad_models=data/vad_models" in workflow
+        assert "--asset-dir dist/Xiao8/data/vad_models --offline" in workflow

--- a/tests/unit/voice_turn/test_contracts.py
+++ b/tests/unit/voice_turn/test_contracts.py
@@ -1,0 +1,53 @@
+import pytest
+from unittest.mock import Mock
+
+from main_logic.voice_turn.contracts import (
+    AsrTurnCapabilities,
+    EvaluationStatus,
+    SmartTurnConfig,
+    TurnDecision,
+    TurnEvaluation,
+    build_turn_detector_if_required,
+    requires_external_turn_detector,
+)
+
+
+def test_semantic_endpoint_provider_does_not_require_smart_turn():
+    assert requires_external_turn_detector(AsrTurnCapabilities(semantic_endpoint=True)) is False
+    assert requires_external_turn_detector(AsrTurnCapabilities(semantic_endpoint=False)) is True
+
+
+def test_semantic_endpoint_provider_never_constructs_smart_turn_runtime():
+    factory = Mock()
+    detector = build_turn_detector_if_required(
+        AsrTurnCapabilities(semantic_endpoint=True), factory
+    )
+    assert detector is None
+    factory.assert_not_called()
+
+
+def test_unavailable_is_not_an_incomplete_decision():
+    evaluation = TurnEvaluation(
+        status=EvaluationStatus.UNAVAILABLE,
+        decision=None,
+        probability=None,
+        generation=1,
+        activity_seq=2,
+        reason="model_missing",
+    )
+    assert evaluation.decision is not TurnDecision.INCOMPLETE
+
+
+def test_ok_evaluation_requires_probability_and_decision():
+    with pytest.raises(ValueError):
+        TurnEvaluation(EvaluationStatus.OK, TurnDecision.COMPLETE, None, 0, 0)
+
+
+def test_non_ok_evaluation_rejects_probability():
+    with pytest.raises(ValueError):
+        TurnEvaluation(EvaluationStatus.ERROR, None, 0.4, 0, 0)
+
+
+def test_config_rejects_missing_vad_hysteresis():
+    with pytest.raises(ValueError):
+        SmartTurnConfig(onset_probability=0.4, offset_probability=0.4)

--- a/tests/unit/voice_turn/test_coordinator.py
+++ b/tests/unit/voice_turn/test_coordinator.py
@@ -60,12 +60,22 @@ class _BlockingPredictor(_Predictor):
         super().__init__()
         self.started = threading.Event()
         self.release = threading.Event()
+        self._active_lock = threading.Lock()
+        self._active_calls = 0
+        self.max_active_calls = 0
 
     def predict_probability(self, audio):
-        self.calls += 1
+        with self._active_lock:
+            self.calls += 1
+            self._active_calls += 1
+            self.max_active_calls = max(self.max_active_calls, self._active_calls)
         self.started.set()
-        assert self.release.wait(timeout=5)
-        return self.probability
+        try:
+            assert self.release.wait(timeout=5)
+            return self.probability
+        finally:
+            with self._active_lock:
+                self._active_calls -= 1
 
 
 @pytest.mark.asyncio
@@ -93,6 +103,7 @@ async def test_latest_candidate_coalesces_without_parallel_inference():
     assert first_result.status is EvaluationStatus.STALE
     assert second_result.status is EvaluationStatus.OK
     assert predictor.calls == 2
+    assert predictor.max_active_calls == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/voice_turn/test_coordinator.py
+++ b/tests/unit/voice_turn/test_coordinator.py
@@ -1,0 +1,109 @@
+import asyncio
+import threading
+
+import numpy as np
+import pytest
+
+from main_logic.voice_turn.contracts import (
+    EvaluationStatus,
+    SmartTurnConfig,
+    SpeechActivityEvent,
+    TurnDecision,
+)
+from main_logic.voice_turn.coordinator import CoordinatorState, TurnCoordinator
+
+
+def _pcm(sample_count=512):
+    return np.ones(sample_count, dtype=np.int16).tobytes()
+
+
+class _Predictor:
+    def __init__(self, probability=0.8, *, available=True):
+        self.probability = probability
+        self.available = available
+        self.calls = 0
+        self.closed = False
+
+    def load(self):
+        return self.available
+
+    def predict_probability(self, audio):
+        self.calls += 1
+        return self.probability
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_complete_and_incomplete_are_semantic_only():
+    complete = TurnCoordinator(_Predictor(0.5), SmartTurnConfig(enabled=True))
+    result = await complete.evaluate(_pcm())
+    assert (result.status, result.decision) == (EvaluationStatus.OK, TurnDecision.COMPLETE)
+
+    incomplete = TurnCoordinator(_Predictor(0.49), SmartTurnConfig(enabled=True))
+    result = await incomplete.evaluate(_pcm())
+    assert result.decision is TurnDecision.INCOMPLETE
+    assert incomplete.state is CoordinatorState.WAIT_CONTINUATION
+
+
+@pytest.mark.asyncio
+async def test_unavailable_is_not_converted_to_incomplete():
+    coordinator = TurnCoordinator(_Predictor(available=False), SmartTurnConfig(enabled=True))
+    result = await coordinator.evaluate(_pcm())
+    assert result.status is EvaluationStatus.UNAVAILABLE
+    assert result.decision is None
+
+
+class _BlockingPredictor(_Predictor):
+    def __init__(self):
+        super().__init__()
+        self.started = threading.Event()
+        self.release = threading.Event()
+
+    def predict_probability(self, audio):
+        self.calls += 1
+        self.started.set()
+        assert self.release.wait(timeout=5)
+        return self.probability
+
+
+@pytest.mark.asyncio
+async def test_resumed_speech_makes_inflight_result_stale():
+    predictor = _BlockingPredictor()
+    coordinator = TurnCoordinator(predictor, SmartTurnConfig(enabled=True))
+    task = asyncio.create_task(coordinator.evaluate(_pcm()))
+    await asyncio.to_thread(predictor.started.wait, 2)
+    await coordinator.on_activity_event(SpeechActivityEvent.SPEECH_RESUMED)
+    predictor.release.set()
+    result = await task
+    assert result.status is EvaluationStatus.STALE
+
+
+@pytest.mark.asyncio
+async def test_latest_candidate_coalesces_without_parallel_inference():
+    predictor = _BlockingPredictor()
+    coordinator = TurnCoordinator(predictor, SmartTurnConfig(enabled=True))
+    first = asyncio.create_task(coordinator.evaluate(_pcm(256)))
+    await asyncio.to_thread(predictor.started.wait, 2)
+    second = asyncio.create_task(coordinator.evaluate(_pcm(512)))
+    await asyncio.sleep(0)
+    predictor.release.set()
+    first_result, second_result = await asyncio.gather(first, second)
+    assert first_result.status is EvaluationStatus.STALE
+    assert second_result.status is EvaluationStatus.OK
+    assert predictor.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_close_invalidates_late_result_and_releases_runtime():
+    predictor = _BlockingPredictor()
+    coordinator = TurnCoordinator(predictor, SmartTurnConfig(enabled=True))
+    task = asyncio.create_task(coordinator.evaluate(_pcm()))
+    await asyncio.to_thread(predictor.started.wait, 2)
+    close_task = asyncio.create_task(coordinator.close())
+    predictor.release.set()
+    result, _ = await asyncio.gather(task, close_task)
+    assert result.status is EvaluationStatus.STALE
+    assert coordinator.state is CoordinatorState.CLOSED
+    assert predictor.closed is True

--- a/tests/unit/voice_turn/test_coordinator.py
+++ b/tests/unit/voice_turn/test_coordinator.py
@@ -107,3 +107,46 @@ async def test_close_invalidates_late_result_and_releases_runtime():
     assert result.status is EvaluationStatus.STALE
     assert coordinator.state is CoordinatorState.CLOSED
     assert predictor.closed is True
+
+
+@pytest.mark.asyncio
+async def test_reset_during_inflight_evaluation_is_stale():
+    predictor = _BlockingPredictor()
+    coordinator = TurnCoordinator(predictor, SmartTurnConfig(enabled=True))
+    task = asyncio.create_task(coordinator.evaluate(_pcm()))
+    await asyncio.to_thread(predictor.started.wait, 2)
+    await coordinator.reset()
+    predictor.release.set()
+    result = await task
+    assert result.status is EvaluationStatus.STALE
+    assert coordinator.generation == 1
+    assert coordinator.state is CoordinatorState.IDLE
+
+
+@pytest.mark.asyncio
+async def test_empty_audio_is_unavailable_not_incomplete():
+    coordinator = TurnCoordinator(_Predictor(), SmartTurnConfig(enabled=True))
+    result = await coordinator.evaluate(b"")
+    assert result.status is EvaluationStatus.UNAVAILABLE
+    assert result.decision is None
+
+
+@pytest.mark.asyncio
+async def test_buffered_audio_evaluation_uses_bounded_buffer():
+    predictor = _Predictor(0.8)
+    coordinator = TurnCoordinator(predictor, SmartTurnConfig(enabled=True))
+    coordinator.push_audio(_pcm())
+    result = await coordinator.evaluate_buffered()
+    assert result.status is EvaluationStatus.OK
+    assert result.decision is TurnDecision.COMPLETE
+    assert predictor.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_close_is_idempotent():
+    predictor = _Predictor()
+    coordinator = TurnCoordinator(predictor, SmartTurnConfig(enabled=True))
+    await coordinator.close()
+    await coordinator.close()
+    assert coordinator.state is CoordinatorState.CLOSED
+    assert predictor.closed is True

--- a/tests/unit/voice_turn/test_evaluation_tool.py
+++ b/tests/unit/voice_turn/test_evaluation_tool.py
@@ -1,0 +1,49 @@
+import json
+import wave
+
+import numpy as np
+import pytest
+
+from tools.voice_eval.evaluate_smart_turn_v3 import evaluate_cases, load_cases
+
+
+def _wav(path, samples):
+    with wave.open(str(path), "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(16_000)
+        wav_file.writeframes(np.asarray(samples, dtype="<i2").tobytes())
+
+
+class _Predictor:
+    def __init__(self, probabilities):
+        self.probabilities = iter(probabilities)
+
+    def predict_probability(self, audio):
+        return next(self.probabilities)
+
+
+def test_evaluation_reports_all_four_confusion_cells(tmp_path):
+    labels = []
+    for index, expected in enumerate(("complete", "complete", "incomplete", "incomplete")):
+        name = f"case-{index}.wav"
+        _wav(tmp_path / name, [index])
+        labels.append(json.dumps({"path": name, "expected": expected, "language": "zh"}))
+    labels_path = tmp_path / "labels.jsonl"
+    labels_path.write_text("\n".join(labels), encoding="utf-8")
+    report = evaluate_cases(
+        load_cases(tmp_path, labels_path), _Predictor([0.9, 0.1, 0.9, 0.1])
+    )
+    assert report["confusion_matrix"] == {
+        "true_complete": 1,
+        "false_incomplete": 1,
+        "false_complete": 1,
+        "true_incomplete": 1,
+    }
+
+
+def test_labels_cannot_escape_fixture_directory(tmp_path):
+    labels = tmp_path / "labels.jsonl"
+    labels.write_text(json.dumps({"path": "../outside.wav", "expected": "complete"}))
+    with pytest.raises(ValueError, match="escapes"):
+        load_cases(tmp_path, labels)

--- a/tests/unit/voice_turn/test_onnx_runtime.py
+++ b/tests/unit/voice_turn/test_onnx_runtime.py
@@ -1,0 +1,54 @@
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+from main_logic.voice_turn import onnx_runtime
+from main_logic.voice_turn.onnx_runtime import OnnxModelRuntime, RuntimeState
+
+
+class _Runtime(OnnxModelRuntime):
+    asset_filenames = ("model.onnx",)
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.loads = 0
+        self._count_lock = threading.Lock()
+
+    def _load_verified(self, paths, manifest, ort):
+        with self._count_lock:
+            self.loads += 1
+        time.sleep(0.02)
+        self._session = object()
+
+
+def test_runtime_is_disabled_by_default():
+    runtime = _Runtime()
+    assert runtime.load() is False
+    assert runtime.state is RuntimeState.UNAVAILABLE
+    assert runtime.unavailable_reason == "disabled_by_config"
+
+
+def test_concurrent_load_is_single_flight(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        onnx_runtime,
+        "resolve_verified_assets",
+        lambda filenames, override: (tmp_path, object(), {"model.onnx": tmp_path / "model.onnx"}),
+    )
+    runtime = _Runtime(enabled=True)
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        assert all(pool.map(lambda _: runtime.load(), range(8)))
+    assert runtime.loads == 1
+    assert runtime.state is RuntimeState.READY
+
+
+def test_close_is_terminal(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        onnx_runtime,
+        "resolve_verified_assets",
+        lambda filenames, override: (tmp_path, object(), {"model.onnx": tmp_path / "model.onnx"}),
+    )
+    runtime = _Runtime(enabled=True)
+    assert runtime.load()
+    runtime.close()
+    assert runtime.state is RuntimeState.CLOSED
+    assert runtime.load() is False

--- a/tests/unit/voice_turn/test_onnx_runtime.py
+++ b/tests/unit/voice_turn/test_onnx_runtime.py
@@ -2,8 +2,15 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 
+import pytest
+
 from main_logic.voice_turn import onnx_runtime
-from main_logic.voice_turn.onnx_runtime import OnnxModelRuntime, RuntimeState
+from main_logic.voice_turn.asset_manifest import AssetManifestError
+from main_logic.voice_turn.onnx_runtime import (
+    OnnxModelRuntime,
+    RuntimeInferenceError,
+    RuntimeState,
+)
 
 
 class _Runtime(OnnxModelRuntime):
@@ -52,3 +59,50 @@ def test_close_is_terminal(monkeypatch, tmp_path):
     runtime.close()
     assert runtime.state is RuntimeState.CLOSED
     assert runtime.load() is False
+
+
+def test_missing_assets_make_runtime_unavailable(monkeypatch):
+    def fail_resolve(filenames, override):
+        raise AssetManifestError("missing model")
+
+    monkeypatch.setattr(onnx_runtime, "resolve_verified_assets", fail_resolve)
+    runtime = _Runtime(enabled=True)
+    assert runtime.load() is False
+    assert runtime.state is RuntimeState.UNAVAILABLE
+    assert runtime.unavailable_reason == "assetmanifesterror"
+
+
+class _FailingSession:
+    def run(self, output_names, inputs):
+        raise RuntimeError("inference failed")
+
+
+def test_inference_errors_open_circuit_breaker():
+    runtime = _Runtime(enabled=True, inference_error_limit=3)
+    runtime._session = _FailingSession()
+    runtime._state = RuntimeState.READY
+
+    for expected_state in (RuntimeState.DEGRADED, RuntimeState.DEGRADED):
+        with pytest.raises(RuntimeInferenceError):
+            runtime._run_session(None, {})
+        assert runtime.state is expected_state
+
+    with pytest.raises(RuntimeInferenceError):
+        runtime._run_session(None, {})
+    assert runtime.state is RuntimeState.UNAVAILABLE
+    assert runtime.unavailable_reason == "inference_circuit_open:RuntimeError"
+
+
+def test_successful_inference_clears_degraded_state():
+    class SuccessfulSession:
+        def run(self, output_names, inputs):
+            return ["ok"]
+
+    runtime = _Runtime(enabled=True)
+    runtime._session = SuccessfulSession()
+    runtime._state = RuntimeState.DEGRADED
+    runtime._reason = "previous_error"
+    runtime._consecutive_errors = 1
+    assert runtime._run_session(None, {}) == ["ok"]
+    assert runtime.state is RuntimeState.READY
+    assert runtime.unavailable_reason is None

--- a/tests/unit/voice_turn/test_onnx_runtime.py
+++ b/tests/unit/voice_turn/test_onnx_runtime.py
@@ -106,3 +106,61 @@ def test_successful_inference_clears_degraded_state():
     assert runtime._run_session(None, {}) == ["ok"]
     assert runtime.state is RuntimeState.READY
     assert runtime.unavailable_reason is None
+
+
+class _CoordinatedInferenceLock:
+    """Force the old lock-outside-bookkeeping race deterministically."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self.failure_released = threading.Event()
+        self.success_finished = threading.Event()
+        self.runtime = None
+
+    def __enter__(self):
+        self._lock.acquire()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self._lock.release()
+        if exc_type is not None:
+            self.failure_released.set()
+            if self.runtime.state is RuntimeState.READY:
+                assert self.success_finished.wait(timeout=5)
+
+
+class _MixedSession:
+    def run(self, output_names, inputs):
+        if inputs["fail"]:
+            raise RuntimeError("first inference failed")
+        return ["ok"]
+
+
+def test_failed_then_successful_concurrent_inference_finishes_ready():
+    runtime = _Runtime(enabled=True, inference_error_limit=3)
+    runtime._session = _MixedSession()
+    runtime._state = RuntimeState.READY
+    coordinated_lock = _CoordinatedInferenceLock()
+    coordinated_lock.runtime = runtime
+    runtime._inference_lock = coordinated_lock
+
+    def fail():
+        with pytest.raises(RuntimeInferenceError):
+            runtime._run_session(None, {"fail": True})
+
+    def succeed():
+        try:
+            assert runtime._run_session(None, {"fail": False}) == ["ok"]
+        finally:
+            coordinated_lock.success_finished.set()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        failed = pool.submit(fail)
+        assert coordinated_lock.failure_released.wait(timeout=5)
+        succeeded = pool.submit(succeed)
+        failed.result(timeout=5)
+        succeeded.result(timeout=5)
+
+    assert runtime.state is RuntimeState.READY
+    assert runtime.unavailable_reason is None
+    assert runtime._session is not None

--- a/tests/unit/voice_turn/test_prepare_assets.py
+++ b/tests/unit/voice_turn/test_prepare_assets.py
@@ -51,3 +51,16 @@ def test_source_cache_is_verified_before_install(tmp_path):
     _manifest(output, "https://example.invalid/model", "0" * 64)
     with pytest.raises(AssetManifestError, match="cache SHA-256 mismatch"):
         prepare_assets(output, source_cache=cache)
+
+
+def test_download_sha_mismatch_removes_partial_file(tmp_path):
+    source = tmp_path / "source.bin"
+    source.write_bytes(b"corrupt model")
+    output = tmp_path / "output"
+    output.mkdir()
+    _manifest(output, source.as_uri(), "0" * 64)
+
+    with pytest.raises(AssetManifestError, match="download SHA-256 mismatch"):
+        prepare_assets(output)
+    assert not (output / "model.onnx").exists()
+    assert not (output / "model.onnx.part").exists()

--- a/tests/unit/voice_turn/test_prepare_assets.py
+++ b/tests/unit/voice_turn/test_prepare_assets.py
@@ -1,0 +1,53 @@
+import hashlib
+import json
+
+import pytest
+
+from main_logic.voice_turn.asset_manifest import AssetManifestError
+from tools.voice_eval.prepare_voice_turn_assets import prepare_assets
+
+
+def _manifest(directory, source, digest):
+    payload = {
+        "schema_version": 1,
+        "assets": [
+            {
+                "filename": "model.onnx",
+                "version": "test",
+                "source": source,
+                "license": "MIT",
+                "sha256": digest,
+                "input_contract": "test",
+                "output_contract": "test",
+            }
+        ],
+    }
+    (directory / "manifest.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_prepare_assets_downloads_and_atomically_verifies(tmp_path):
+    source = tmp_path / "source.bin"
+    source.write_bytes(b"reviewed model")
+    output = tmp_path / "output"
+    output.mkdir()
+    _manifest(output, source.as_uri(), hashlib.sha256(source.read_bytes()).hexdigest())
+    paths = prepare_assets(output)
+    assert paths[0].read_bytes() == b"reviewed model"
+    assert not (output / "model.onnx.part").exists()
+
+
+def test_offline_mode_rejects_missing_asset(tmp_path):
+    _manifest(tmp_path, "https://example.invalid/model", "0" * 64)
+    with pytest.raises(AssetManifestError):
+        prepare_assets(tmp_path, offline=True)
+
+
+def test_source_cache_is_verified_before_install(tmp_path):
+    output = tmp_path / "output"
+    cache = tmp_path / "cache"
+    output.mkdir()
+    cache.mkdir()
+    (cache / "model.onnx").write_bytes(b"wrong")
+    _manifest(output, "https://example.invalid/model", "0" * 64)
+    with pytest.raises(AssetManifestError, match="cache SHA-256 mismatch"):
+        prepare_assets(output, source_cache=cache)

--- a/tests/unit/voice_turn/test_real_models.py
+++ b/tests/unit/voice_turn/test_real_models.py
@@ -1,0 +1,40 @@
+"""Opt-in checks against the pinned ONNX assets prepared from manifest.json."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from main_logic.voice_turn.asset_manifest import AssetManifestError, resolve_verified_assets
+from main_logic.voice_turn.silero_vad import SileroVad
+from main_logic.voice_turn.smart_turn_v3 import SmartTurnV3
+
+
+try:
+    _ASSET_DIR, _, _ = resolve_verified_assets(("silero_vad.onnx", "smart_turn_v3.onnx"))
+except AssetManifestError:
+    _ASSET_DIR = None
+
+needs_models = pytest.mark.skipif(_ASSET_DIR is None, reason="run prepare_voice_turn_assets.py")
+
+
+@needs_models
+def test_real_silero_model_rejects_one_second_of_silence():
+    runtime = SileroVad(enabled=True, asset_dir=Path(_ASSET_DIR))
+    assert runtime.load()
+    probabilities = runtime.process_pcm16(np.zeros(16_000, dtype=np.int16).tobytes())
+    assert len(probabilities) == 31
+    assert max(probabilities) < 0.05
+    runtime.close()
+
+
+@needs_models
+def test_real_smart_turn_model_matches_reviewed_golden_outputs():
+    runtime = SmartTurnV3(enabled=True, asset_dir=Path(_ASSET_DIR))
+    assert runtime.load()
+    silence = np.zeros(32_000, dtype=np.float32)
+    samples = np.arange(32_000)
+    tone = (0.1 * np.sin(2 * np.pi * 220 * samples / 16_000)).astype(np.float32)
+    assert runtime.predict_probability(silence) == pytest.approx(0.9870367, abs=1e-4)
+    assert runtime.predict_probability(tone) == pytest.approx(0.05968675, abs=1e-4)
+    runtime.close()

--- a/tests/unit/voice_turn/test_silero_vad.py
+++ b/tests/unit/voice_turn/test_silero_vad.py
@@ -1,0 +1,62 @@
+import numpy as np
+import pytest
+
+from main_logic.voice_turn.contracts import SmartTurnConfig, SpeechActivityEvent
+from main_logic.voice_turn.onnx_runtime import RuntimeState
+from main_logic.voice_turn.silero_vad import SileroActivityGate, SileroVad
+
+
+class _Session:
+    def __init__(self):
+        self.inputs = []
+
+    def run(self, output_names, inputs):
+        self.inputs.append({key: np.asarray(value).copy() for key, value in inputs.items()})
+        state = inputs["state"] + 1
+        return [np.asarray([[0.9]], dtype=np.float32), state]
+
+
+def _ready_vad():
+    vad = SileroVad(enabled=True)
+    vad._session = _Session()
+    vad._state = RuntimeState.READY
+    return vad
+
+
+def test_silero_preserves_context_and_lstm_state_across_windows():
+    vad = _ready_vad()
+    values = np.arange(1024, dtype=np.int16)
+    assert vad.process_pcm16(values.tobytes()) == pytest.approx([0.9, 0.9])
+    first, second = vad._session.inputs
+    assert first["input"].shape == (1, 576)
+    assert np.all(first["input"][0, :64] == 0)
+    assert np.allclose(second["input"][0, :64], values[448:512] / 32768.0)
+    assert np.all(second["state"] == 1)
+
+
+def test_silero_reset_clears_context_state_and_pending_audio():
+    vad = _ready_vad()
+    vad.process_pcm16(np.ones(700, dtype=np.int16).tobytes())
+    vad.reset_stream()
+    assert not vad._pending.size
+    assert np.all(vad._context == 0)
+    assert np.all(vad._lstm_state == 0)
+
+
+class _NoopVad:
+    def reset_stream(self):
+        pass
+
+
+def test_activity_gate_emits_pause_once_and_resume_without_force_commit():
+    config = SmartTurnConfig(
+        enabled=True,
+        minimum_speech_ms=32,
+        candidate_silence_ms=32,
+    )
+    gate = SileroActivityGate(_NoopVad(), config)
+    assert gate.process_probabilities([0.9]) is SpeechActivityEvent.SPEECH_STARTED
+    assert gate.process_probabilities([0.1]) is SpeechActivityEvent.CANDIDATE_PAUSE
+    assert gate.process_probabilities([0.1] * 100) is SpeechActivityEvent.NONE
+    assert gate.process_probabilities([0.9]) is SpeechActivityEvent.SPEECH_RESUMED
+    assert {event.value for event in SpeechActivityEvent}.isdisjoint({"force_end", "turn_complete"})

--- a/tests/unit/voice_turn/test_silero_vad.py
+++ b/tests/unit/voice_turn/test_silero_vad.py
@@ -11,7 +11,9 @@ class _Session:
         self.inputs = []
 
     def run(self, output_names, inputs):
-        self.inputs.append({key: np.asarray(value).copy() for key, value in inputs.items()})
+        self.inputs.append(
+            {key: np.asarray(value).copy() for key, value in inputs.items()}
+        )
         state = inputs["state"] + 1
         return [np.asarray([[0.9]], dtype=np.float32), state]
 
@@ -48,6 +50,11 @@ class _NoopVad:
         pass
 
 
+class _BatchVad(_NoopVad):
+    def process_pcm16(self, pcm16_le):
+        return [0.9, 0.1]
+
+
 def test_activity_gate_emits_pause_once_and_resume_without_force_commit():
     config = SmartTurnConfig(
         enabled=True,
@@ -55,16 +62,46 @@ def test_activity_gate_emits_pause_once_and_resume_without_force_commit():
         candidate_silence_ms=32,
     )
     gate = SileroActivityGate(_NoopVad(), config)
-    assert gate.process_probabilities([0.9]) is SpeechActivityEvent.SPEECH_STARTED
-    assert gate.process_probabilities([0.1]) is SpeechActivityEvent.CANDIDATE_PAUSE
-    assert gate.process_probabilities([0.1] * 100) is SpeechActivityEvent.NONE
-    assert gate.process_probabilities([0.9]) is SpeechActivityEvent.SPEECH_RESUMED
-    assert {event.value for event in SpeechActivityEvent}.isdisjoint({"force_end", "turn_complete"})
+    assert gate.process_probabilities([0.9]) == (SpeechActivityEvent.SPEECH_STARTED,)
+    assert gate.process_probabilities([0.1]) == (SpeechActivityEvent.CANDIDATE_PAUSE,)
+    assert gate.process_probabilities([0.1] * 100) == ()
+    assert gate.process_probabilities([0.9]) == (SpeechActivityEvent.SPEECH_RESUMED,)
+    assert {event.value for event in SpeechActivityEvent}.isdisjoint(
+        {"force_end", "turn_complete"}
+    )
 
 
 def test_activity_gate_duration_thresholds_never_round_down():
     gate = SileroActivityGate(_NoopVad(), SmartTurnConfig(enabled=True))
-    assert gate.process_probabilities([0.9] * 6) is SpeechActivityEvent.NONE
-    assert gate.process_probabilities([0.9]) is SpeechActivityEvent.SPEECH_STARTED
-    assert gate.process_probabilities([0.1] * 9) is SpeechActivityEvent.NONE
-    assert gate.process_probabilities([0.1]) is SpeechActivityEvent.CANDIDATE_PAUSE
+    assert gate.process_probabilities([0.9] * 6) == ()
+    assert gate.process_probabilities([0.9]) == (SpeechActivityEvent.SPEECH_STARTED,)
+    assert gate.process_probabilities([0.1] * 9) == ()
+    assert gate.process_probabilities([0.1]) == (SpeechActivityEvent.CANDIDATE_PAUSE,)
+
+
+def test_activity_gate_preserves_all_ordered_events_from_one_batch():
+    config = SmartTurnConfig(
+        enabled=True,
+        minimum_speech_ms=32,
+        candidate_silence_ms=32,
+    )
+    gate = SileroActivityGate(_NoopVad(), config)
+
+    assert gate.process_probabilities([0.9, 0.1]) == (
+        SpeechActivityEvent.SPEECH_STARTED,
+        SpeechActivityEvent.CANDIDATE_PAUSE,
+    )
+
+
+def test_activity_gate_feed_preserves_ordered_events_from_vad_batch():
+    config = SmartTurnConfig(
+        enabled=True,
+        minimum_speech_ms=32,
+        candidate_silence_ms=32,
+    )
+    gate = SileroActivityGate(_BatchVad(), config)
+
+    assert gate.feed(b"pcm") == (
+        SpeechActivityEvent.SPEECH_STARTED,
+        SpeechActivityEvent.CANDIDATE_PAUSE,
+    )

--- a/tests/unit/voice_turn/test_silero_vad.py
+++ b/tests/unit/voice_turn/test_silero_vad.py
@@ -60,3 +60,11 @@ def test_activity_gate_emits_pause_once_and_resume_without_force_commit():
     assert gate.process_probabilities([0.1] * 100) is SpeechActivityEvent.NONE
     assert gate.process_probabilities([0.9]) is SpeechActivityEvent.SPEECH_RESUMED
     assert {event.value for event in SpeechActivityEvent}.isdisjoint({"force_end", "turn_complete"})
+
+
+def test_activity_gate_duration_thresholds_never_round_down():
+    gate = SileroActivityGate(_NoopVad(), SmartTurnConfig(enabled=True))
+    assert gate.process_probabilities([0.9] * 6) is SpeechActivityEvent.NONE
+    assert gate.process_probabilities([0.9]) is SpeechActivityEvent.SPEECH_STARTED
+    assert gate.process_probabilities([0.1] * 9) is SpeechActivityEvent.NONE
+    assert gate.process_probabilities([0.1]) is SpeechActivityEvent.CANDIDATE_PAUSE

--- a/tests/unit/voice_turn/test_silero_vad.py
+++ b/tests/unit/voice_turn/test_silero_vad.py
@@ -72,7 +72,14 @@ def test_activity_gate_emits_pause_once_and_resume_without_force_commit():
 
 
 def test_activity_gate_duration_thresholds_never_round_down():
-    gate = SileroActivityGate(_NoopVad(), SmartTurnConfig(enabled=True))
+    gate = SileroActivityGate(
+        _NoopVad(),
+        SmartTurnConfig(
+            enabled=True,
+            minimum_speech_ms=200,
+            candidate_silence_ms=300,
+        ),
+    )
     assert gate.process_probabilities([0.9] * 6) == ()
     assert gate.process_probabilities([0.9]) == (SpeechActivityEvent.SPEECH_STARTED,)
     assert gate.process_probabilities([0.1] * 9) == ()

--- a/tests/unit/voice_turn/test_smart_turn_v3.py
+++ b/tests/unit/voice_turn/test_smart_turn_v3.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pytest
+
+from main_logic.voice_turn.onnx_runtime import RuntimeInferenceError, RuntimeState
+from main_logic.voice_turn.smart_turn_v3 import SmartTurnV3
+
+
+class _Session:
+    def __init__(self, output):
+        self.output = output
+        self.seen = None
+
+    def run(self, output_names, inputs):
+        self.seen = inputs
+        return [np.asarray([[self.output]], dtype=np.float32)]
+
+
+def _runtime(output):
+    runtime = SmartTurnV3(enabled=True)
+    runtime._session = _Session(output)
+    runtime._state = RuntimeState.READY
+    return runtime
+
+
+def test_predict_uses_expected_feature_contract():
+    runtime = _runtime(0.75)
+    probability = runtime.predict_probability(np.zeros(16_000, dtype=np.float32))
+    assert probability == pytest.approx(0.75)
+    assert runtime._session.seen["input_features"].shape == (1, 80, 800)
+    assert runtime._session.seen["input_features"].dtype == np.float32
+
+
+@pytest.mark.parametrize("output", [-0.1, 1.1, float("nan")])
+def test_predict_rejects_invalid_model_probability(output):
+    runtime = _runtime(output)
+    with pytest.raises(RuntimeInferenceError):
+        runtime.predict_probability(np.zeros(16_000, dtype=np.float32))

--- a/tests/unit/voice_turn/test_whisper_features.py
+++ b/tests/unit/voice_turn/test_whisper_features.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+from main_logic.voice_turn.whisper_features import (
+    WhisperFeatureExtractor,
+    whisper_mel_filter_bank,
+)
+
+
+def test_mel_filter_bank_matches_reviewed_whisper_reference_values():
+    filters = whisper_mel_filter_bank()
+    assert filters.shape == (201, 80)
+    np.testing.assert_allclose(filters.sum(), 1.9990242, atol=1e-7)
+
+
+def test_features_have_golden_statistics_for_synthetic_tone():
+    samples = np.arange(16_000)
+    tone = (0.1 * np.sin(2 * np.pi * 440 * samples / 16_000)).astype(np.float32)
+    features = WhisperFeatureExtractor().extract(tone)
+    assert features.shape == (80, 800)
+    assert features.dtype == np.float32
+    np.testing.assert_allclose(
+        [features.sum(), features.mean(), features.std(), features.min(), features.max()],
+        [-6148.0396, -0.096063115, 0.15449585, -0.11026861, 1.8897314],
+        rtol=1e-5,
+        atol=1e-5,
+    )
+
+
+def test_long_audio_keeps_trailing_eight_seconds():
+    extractor = WhisperFeatureExtractor()
+    tail = np.linspace(-0.2, 0.2, extractor.MAX_SAMPLES, dtype=np.float32)
+    prefix = np.ones(1234, dtype=np.float32)
+    np.testing.assert_array_equal(extractor.extract(np.concatenate((prefix, tail))), extractor.extract(tail))

--- a/tools/voice_eval/evaluate_smart_turn_v3.py
+++ b/tools/voice_eval/evaluate_smart_turn_v3.py
@@ -1,0 +1,165 @@
+"""Evaluate Smart Turn v3 on an authorized JSONL-labelled WAV fixture set."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+import time
+import wave
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Protocol
+
+import numpy as np
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from main_logic.voice_turn.smart_turn_v3 import SmartTurnV3  # noqa: E402
+
+
+@dataclass(frozen=True, slots=True)
+class EvaluationCase:
+    path: Path
+    expected_complete: bool
+    language: str | None = None
+    category: str | None = None
+
+
+@dataclass(slots=True)
+class ConfusionMatrix:
+    true_complete: int = 0
+    false_incomplete: int = 0
+    false_complete: int = 0
+    true_incomplete: int = 0
+
+    def add(self, *, expected: bool, predicted: bool) -> None:
+        if expected and predicted:
+            self.true_complete += 1
+        elif expected:
+            self.false_incomplete += 1
+        elif predicted:
+            self.false_complete += 1
+        else:
+            self.true_incomplete += 1
+
+
+class Predictor(Protocol):
+    def predict_probability(self, audio: np.ndarray) -> float: ...
+
+
+def load_cases(fixture_dir: Path, labels_path: Path) -> list[EvaluationCase]:
+    root = fixture_dir.resolve()
+    cases: list[EvaluationCase] = []
+    for line_number, line in enumerate(labels_path.read_text(encoding="utf-8").splitlines(), 1):
+        if not line.strip():
+            continue
+        value = json.loads(line)
+        relative = Path(value["path"])
+        path = (root / relative).resolve()
+        if root not in path.parents:
+            raise ValueError(f"line {line_number}: fixture path escapes fixture directory")
+        expected = value.get("expected")
+        if expected not in ("complete", "incomplete"):
+            raise ValueError(f"line {line_number}: expected must be complete or incomplete")
+        cases.append(
+            EvaluationCase(
+                path=path,
+                expected_complete=expected == "complete",
+                language=value.get("language"),
+                category=value.get("category"),
+            )
+        )
+    if not cases:
+        raise ValueError("labels file contains no evaluation cases")
+    return cases
+
+
+def read_pcm16_wav(path: Path) -> np.ndarray:
+    with wave.open(str(path), "rb") as wav_file:
+        if wav_file.getnchannels() != 1:
+            raise ValueError(f"{path}: expected mono WAV")
+        if wav_file.getframerate() != 16_000:
+            raise ValueError(f"{path}: expected 16000 Hz WAV")
+        if wav_file.getsampwidth() != 2:
+            raise ValueError(f"{path}: expected signed PCM16 WAV")
+        pcm = wav_file.readframes(wav_file.getnframes())
+    return np.frombuffer(pcm, dtype="<i2").astype(np.float32) / 32768.0
+
+
+def evaluate_cases(
+    cases: list[EvaluationCase], predictor: Predictor, *, threshold: float = 0.5
+) -> dict[str, object]:
+    if not 0.0 <= threshold <= 1.0:
+        raise ValueError("threshold must be within [0, 1]")
+    matrix = ConfusionMatrix()
+    latencies_ms: list[float] = []
+    results: list[dict[str, object]] = []
+    for case in cases:
+        audio = read_pcm16_wav(case.path)
+        started = time.perf_counter()
+        probability = predictor.predict_probability(audio)
+        latency_ms = (time.perf_counter() - started) * 1000
+        predicted = probability >= threshold
+        matrix.add(expected=case.expected_complete, predicted=predicted)
+        latencies_ms.append(latency_ms)
+        results.append(
+            {
+                "path": case.path.name,
+                "language": case.language,
+                "category": case.category,
+                "expected": "complete" if case.expected_complete else "incomplete",
+                "predicted": "complete" if predicted else "incomplete",
+                "probability": probability,
+                "latency_ms": latency_ms,
+            }
+        )
+    ordered = sorted(latencies_ms)
+
+    def percentile(fraction: float) -> float:
+        index = round((len(ordered) - 1) * fraction)
+        return ordered[index]
+
+    return {
+        "threshold": threshold,
+        "case_count": len(cases),
+        "confusion_matrix": asdict(matrix),
+        "latency_ms": {
+            "median": statistics.median(latencies_ms),
+            "p95": percentile(0.95),
+            "p99": percentile(0.99),
+        },
+        "results": results,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture-dir", required=True, type=Path)
+    parser.add_argument("--labels", required=True, type=Path)
+    parser.add_argument("--asset-dir", type=Path, default=PROJECT_ROOT / "data" / "vad_models")
+    parser.add_argument("--threshold", type=float, default=0.5)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+    runtime = SmartTurnV3(enabled=True, asset_dir=args.asset_dir.resolve())
+    if not runtime.load():
+        parser.error(f"Smart Turn runtime unavailable: {runtime.unavailable_reason}")
+    try:
+        report = evaluate_cases(
+            load_cases(args.fixture_dir, args.labels), runtime, threshold=args.threshold
+        )
+    finally:
+        runtime.close()
+    rendered = json.dumps(report, ensure_ascii=False, indent=2)
+    if args.output:
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+    print(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/voice_eval/prepare_voice_turn_assets.py
+++ b/tools/voice_eval/prepare_voice_turn_assets.py
@@ -1,0 +1,128 @@
+"""Prepare pinned Smart Turn/Silero assets and verify every byte before use."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import shutil
+import sys
+import time
+import urllib.request
+from urllib.error import URLError
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from main_logic.voice_turn.asset_manifest import (  # noqa: E402
+    AssetManifestError,
+    load_manifest,
+    verify_asset,
+)
+
+
+def _download_verified(source: str, destination: Path, expected_sha256: str) -> None:
+    temporary = destination.with_suffix(destination.suffix + ".part")
+    digest = hashlib.sha256()
+    request = urllib.request.Request(source, headers={"User-Agent": "NEKO-asset-preparer/1"})
+    last_error: Exception | None = None
+    for attempt in range(3):
+        digest = hashlib.sha256()
+        try:
+            with urllib.request.urlopen(request, timeout=60) as response, temporary.open(
+                "wb"
+            ) as output:
+                while chunk := response.read(1024 * 1024):
+                    digest.update(chunk)
+                    output.write(chunk)
+            actual = digest.hexdigest()
+            if actual.lower() != expected_sha256.lower():
+                raise AssetManifestError(
+                    f"download SHA-256 mismatch for {destination.name}: "
+                    f"expected {expected_sha256}, got {actual}"
+                )
+            os.replace(temporary, destination)
+            return
+        except AssetManifestError:
+            raise
+        except (OSError, TimeoutError, URLError) as exc:
+            last_error = exc
+            temporary.unlink(missing_ok=True)
+            if attempt < 2:
+                time.sleep(1 << attempt)
+    raise AssetManifestError(f"cannot download {destination.name}: {last_error}") from last_error
+
+
+def _copy_verified(source: Path, destination: Path, expected_sha256: str) -> None:
+    temporary = destination.with_suffix(destination.suffix + ".part")
+    try:
+        shutil.copyfile(source, temporary)
+        actual = hashlib.sha256(temporary.read_bytes()).hexdigest()
+        if actual.lower() != expected_sha256.lower():
+            raise AssetManifestError(
+                f"cache SHA-256 mismatch for {destination.name}: expected {expected_sha256}, got {actual}"
+            )
+        os.replace(temporary, destination)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def prepare_assets(
+    directory: Path, *, offline: bool = False, source_cache: Path | None = None
+) -> list[Path]:
+    manifest = load_manifest(directory)
+    prepared: list[Path] = []
+    directory.mkdir(parents=True, exist_ok=True)
+    for spec in manifest.assets:
+        try:
+            prepared.append(verify_asset(directory, spec))
+            continue
+        except AssetManifestError:
+            if offline:
+                raise
+        cached = source_cache / spec.filename if source_cache is not None else None
+        if cached is not None and cached.is_file():
+            _copy_verified(cached, directory / spec.filename, spec.sha256)
+        else:
+            _download_verified(spec.source, directory / spec.filename, spec.sha256)
+        prepared.append(verify_asset(directory, spec))
+    return prepared
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--asset-dir",
+        type=Path,
+        default=PROJECT_ROOT / "data" / "vad_models",
+        help="directory containing manifest.json and prepared assets",
+    )
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="verify existing assets without making network requests",
+    )
+    parser.add_argument(
+        "--source-cache",
+        type=Path,
+        help="optional directory of pre-fetched files; every file is still SHA-256 verified",
+    )
+    args = parser.parse_args(argv)
+    try:
+        paths = prepare_assets(
+            args.asset_dir.resolve(),
+            offline=args.offline,
+            source_cache=args.source_cache.resolve() if args.source_cache else None,
+        )
+    except AssetManifestError as exc:
+        parser.error(str(exc))
+    for path in paths:
+        print(f"verified {path.name}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/voice_eval/prepare_voice_turn_assets.py
+++ b/tools/voice_eval/prepare_voice_turn_assets.py
@@ -47,6 +47,7 @@ def _download_verified(source: str, destination: Path, expected_sha256: str) -> 
             os.replace(temporary, destination)
             return
         except AssetManifestError:
+            temporary.unlink(missing_ok=True)
             raise
         except (OSError, TimeoutError, URLError) as exc:
             last_error = exc


### PR DESCRIPTION
替代 #2187。

## 改动概述

#2187 基于旧的 Core/Config Router 单文件结构，并把本地轮次检测直接耦合进 Omni Realtime；在 #2148 完成包结构重构、语音方案明确区分 Soniox 与非 Soniox ASR 后，继续修改旧分支会把目录迁移、职责重构和 review 修复混在同一历史中。

本 PR 从最新 `main` 重新实现 provider-neutral 的语音轮次检测基础设施：定义稳定的 `COMPLETE / INCOMPLETE` 契约，加入有界 16 kHz PCM16 音频缓冲、Silero VAD、Whisper-compatible 特征、复用项目现有 `onnxruntime` 依赖的 Smart Turn v3.2 ONNX 推理封装，以及带 generation/activity sequence 防护的异步 coordinator。模型通过固定 revision、许可证与 SHA-256 manifest 准备，并进入 Windows/Linux/PyInstaller 分发链路。

具备权威语义 endpoint 的 provider 不构造 Smart Turn runtime；因此 Soniox 后续继续以自身 `<end>` 为准。非 Soniox ASR 可以在公共 VAD 发现候选停顿后消费本模块的语义判断。

## 回归报告 / Regression Report

修改前，仓库主线没有可供独立 ASR Controller 复用的本地语义断句模块；#2187 的实现依赖旧目录、直接操作 Omni provider buffer，并把 VAD、Smart Turn、hard commit 与 provider 生命周期集中在单文件中，无法直接合入当前架构。

修改后，VAD 只负责 speech start、speech resumed 与 candidate pause；Smart Turn 只返回语义完整与否，不包含 provider commit 或 force commit。模型不可用、推理错误和过期结果分别表示为 `UNAVAILABLE / ERROR / STALE`，不会伪装成 `INCOMPLETE`。异步推理通过单通道执行并丢弃 resumed speech、reset 或 close 之后返回的旧结果。

新增语音轮次专项、并发、真实模型、资产与构建契约回归；相关回归共 131 项通过，新增运行时代码覆盖率 90.29%。固定 Silero 与 Smart Turn 权重已完成真实 ONNX 加载、输入输出契约及离线 SHA 校验。GitNexus 相对最新主线评估为 low risk，未命中现有执行流程。

请重点 review 公共契约是否足以支持后续 ASR Controller、coordinator 的 stale-result/close 边界、Silero 跨窗口状态，以及模型资产在桌面分发中的生命周期。

## 风险与边界

本 PR 默认关闭，不接入 Soniox WebSocket、Qwen/Step/GLM 等 ASR provider，不修改 Core 会话、Omni Realtime、前端设置或八语言 locale，也不实现 provider commit、hard timeout、最大 turn 时长和 `FORCE_COMMIT`。这些策略属于后续 ASR Controller。

当前真实模型验证证明实现契约和运行时行为正确，但合成样本不能代表对话准确率；在中文句中停顿、犹豫后继续、英语/日语停顿、键盘噪声与 barge-in 数据完成评测前，不宣称产品可用，也不向普通用户暴露开关。

主要回归风险集中在模型资源缺失或损坏、打包产物漏带权重、并发评估晚到，以及上游误把非 OK 状态当作语义判断。本 PR 分别通过 manifest/SHA 校验、构建产物离线验证、generation/activity guard 和类型契约限制这些风险。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增与语音服务商无关的语音轮次检测能力（开始、候选暂停、恢复/完成及不可用状态）。
  * 引入 Smart Turn v3.2 与 Silero VAD 的 CPU-only ONNX 推断，并增加 Whisper 对数梅尔特征预处理。
  * 提供有界 PCM16 环形缓冲与轮次协调/评估流程。
* **构建与发布**
  * 桌面端构建新增 voice-turn 离线资产准备与缓存；打包与“离线资产校验”失败将阻止构建通过。
  * 强化资产清单与 SHA-256 校验，并调整数据打包/忽略策略仅保留必要说明。
* **文档**
  * 新增 Smart Turn v3 provider-neutral 方案设计与第三方许可说明。
* **测试**
  * 新增/扩展 voice-turn 相关单元与集成测试（含离线准备脚本、清单校验、缓冲/协调整体逻辑）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->