### PR TITLE
feat(agent): enable proactive analysis by default

### DIFF
--- a/app/agent_server/__init__.py
+++ b/app/agent_server/__init__.py
@@ -293,7 +293,7 @@ async def _handle_voice_transcript_request(event: Dict[str, Any]) -> None:
 
 
 def _handle_proactive_analyze(messages, lanlan_name, lanlan_key, conversation_id) -> None:
-    """Throttled proactive-analyze path (opt-in via AGENT_PROACTIVE_ANALYZE_ENABLED).
+    """Throttled proactive-analyze path controlled by AGENT_PROACTIVE_ANALYZE_ENABLED.
 
     A proactive turn has no new user input, so the ordinary user-turn dedupe
     would drop it. Instead we let lanlan's self-initiated utterance trigger one

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1714,17 +1714,18 @@ AGENT_EXTERNAL_GATE_THRESHOLD = 0.2
   这 90% 的易判 case，模棱两可的全 fail-open 到准确的大评估。调高 = 更激进省钱但
   漏判风险上升。"""
 
-# ── 主动搭话触发 agent（降临层，默认关）─────────────────────────────────
-# 默认情况下 analyzer 只在「新 user 轮」跑（agent_server 按 user-turn 指纹去重，
-# assistant turn_end 无新用户输入就忽略）—— 这是 product thesis 的廉价层防护。
-# 打开下面开关后，主动搭话（猫娘自发开口）也能跑一次 analyzer，让她自己起意用
+# ── 主动搭话触发 agent（降临层，默认开）─────────────────────────────────
+# Agent 总开关开启时，主动搭话（猫娘自发开口）也能跑一次 analyzer，让她自己起意用
 # 工具/查信息（如「我帮你查下天气」），但严格按「每会话上限」节流，绝不频发。
-AGENT_PROACTIVE_ANALYZE_ENABLED = False
-"""主动搭话触发 agent 的总开关（默认关，实验性、显式开启）。
-- 关（默认）= 维持现状：主动搭话从不跑 analyzer，只有新 user 轮才分析。
-- 开 = 主动搭话轮也带 proactive 标过河，agent_server 走独立路径：assistant 台词
+# Agent 总开关关闭时，analyze_request 会在进入主动路径前被硬拦截，不分析也不
+# 派单。
+AGENT_PROACTIVE_ANALYZE_ENABLED = True
+"""主动搭话触发 agent 的总开关（默认开）。
+- 关 = 主动搭话从不跑 analyzer，只有新 user 轮才分析。
+- 开（默认）= 主动搭话轮也带 proactive 标过河，agent_server 走独立路径：assistant 台词
   指纹去重 + 每会话计数上限（AGENT_PROACTIVE_ANALYZE_MAX_PER_SESSION）双重节流，
   通过才跑一次 analyzer、把猫娘的主动台词当意图评估。
+- Agent 总开关是更高优先级的硬闸；用户未开启 Agent 时不会分析或派单。
 - 上游：cross_server 在 had_user_input=False 的 turn_end 打 proactive 标；
   agent_server 的 analyze handler 分叉。"""
 

--- a/tests/unit/test_proactive_agent_trigger.py
+++ b/tests/unit/test_proactive_agent_trigger.py
@@ -74,13 +74,39 @@ def test_assistant_fingerprint():
 
 
 # ── _handle_proactive_analyze gating ─────────────────────────────────
+def test_proactive_enabled_by_default():
+    assert a.AGENT_PROACTIVE_ANALYZE_ENABLED is True
+
+
 def test_proactive_disabled_does_not_dispatch(monkeypatch):
     _reset_state()
     calls = _patch_dispatch(monkeypatch)
-    monkeypatch.setattr(a, "AGENT_PROACTIVE_ANALYZE_ENABLED", False)  # default
+    monkeypatch.setattr(a, "AGENT_PROACTIVE_ANALYZE_ENABLED", False)
     a._handle_proactive_analyze(_proactive_msgs("我帮你查天气"), "lan", "lan", "c")
     assert calls == []
     assert a.Modules.proactive_analyze_count.get("lan", 0) == 0
+
+
+def test_agent_master_disabled_blocks_proactive_dispatch(monkeypatch):
+    """The proactive feature must never bypass the user-facing Agent master switch."""
+    calls = []
+    monkeypatch.setattr(a.Modules, "analyzer_enabled", False)
+    monkeypatch.setattr(a, "AGENT_PROACTIVE_ANALYZE_ENABLED", True)
+    monkeypatch.setattr(
+        a,
+        "_handle_proactive_analyze",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    asyncio.run(a._on_session_event({
+        "event_type": "analyze_request",
+        "messages": _proactive_msgs("我帮你查天气"),
+        "lanlan_name": "lan",
+        "conversation_id": "c",
+        "proactive": True,
+    }))
+
+    assert calls == []
 
 
 def test_proactive_enabled_dispatches_with_assistant_intent(monkeypatch):


### PR DESCRIPTION
## 改动概述 / Summary

- 在 #2289 已落地完整节流和安全闸后，将主动 Agent 分析改为默认开启。
- 保持用户侧 Agent 总开关为更高优先级硬闸。
- 新增默认值与“总开关关闭时主动事件不可进入处理器”的回归测试。

## 回归报告 / Regression Report

- **改动内容**：`AGENT_PROACTIVE_ANALYZE_ENABLED` 默认值由 `False` 改为 `True`，同步更新配置说明；新增两条主动分析开关测试。
- **理由 / 必要性**：#2289 为降低首次落地风险而默认关闭该能力。其指纹去重、每会话上限和派单隔离现已合入主线，本 PR 按产品计划正式启用。
- **改动前后**：改动前即使用户已开启 Agent，猫娘无新用户输入的主动搭话也不会进入 analyzer；改动后这类主动轮默认可进入受控路径，每会话仍最多分析 2 次。用户未开启 Agent 时，事件仍在主动 handler 之前被总开关拦截，不分析、不派单。
- **潜在回归点**：影响 `analyze_request` 的 proactive 分支和配置默认值。通过专门测试验证默认开启、独立功能开关关闭仍不派单、Agent 总开关关闭时不进入主动 handler；并回归 Agent external gate、runtime intent、server hardening 与模块分层。

## 不拆分理由 / Why Not Split

不适用：仅修改 3 个文件，配置启用与对应回归测试属于同一原子变更。

## 测试 / Testing

- `uv run pytest tests/unit/test_proactive_agent_trigger.py -q` — 16 passed
- `uv run pytest tests/unit/test_agent_external_gate.py tests/unit/test_agent_runtime_intent.py tests/unit/test_agent_server_hardening.py tests/unit/test_module_layering.py -q` — 60 passed
- `uv run python scripts/check_core_contracts.py` — passed
- `git diff --check` — passed