### PR TITLE
feat: add VRM jukebox seek synchronization

### DIFF
--- a/main_routers/jukebox_router.py
+++ b/main_routers/jukebox_router.py
@@ -51,6 +51,7 @@ from utils.logger_config import get_module_logger
 
 router = APIRouter(prefix="/api/jukebox", tags=["jukebox"])
 logger = get_module_logger(__name__, "Main")
+BUILTIN_JUKEBOX_DIR = Path(__file__).parent.parent / "static" / "jukebox"
 
 # 文件上传常量
 MAX_FILE_SIZE = 1 * 1024 * 1024 * 1024  # 1GB (单个歌曲/动画文件)
@@ -60,6 +61,16 @@ CHUNK_SIZE = 1024 * 1024  # 1MB chunks
 # 允许的文件扩展名
 ALLOWED_AUDIO_EXTENSIONS = {'.mp3', '.wav', '.ogg', '.flac'}
 ALLOWED_ACTION_EXTENSIONS = {'.vmd', '.bvh', '.fbx', '.vrma'}
+JUKEBOX_MEDIA_TYPES = {
+    '.mp3': 'audio/mpeg',
+    '.wav': 'audio/wav',
+    '.ogg': 'audio/ogg',
+    '.flac': 'audio/flac',
+    '.vmd': 'application/octet-stream',
+    '.bvh': 'application/octet-stream',
+    '.fbx': 'application/octet-stream',
+    '.vrma': 'application/octet-stream'
+}
 
 def check_file_size(file: UploadFile, max_size: int) -> int:
     """Check file size; returns the size in bytes, raising an exception if the limit is exceeded."""
@@ -88,6 +99,58 @@ def cleanup_temp_path(path: str):
             shutil.rmtree(p, ignore_errors=True)
     except Exception as e:
         logger.warning(f"清理临时路径失败 {path}: {e}")
+
+
+def _resolve_child_path(root: Path, relative_path: str) -> Path:
+    target_path = (root / relative_path).resolve()
+    root_path = root.resolve()
+    try:
+        target_path.relative_to(root_path)
+    except ValueError:
+        raise HTTPException(403, "访问被拒绝")
+    return target_path
+
+
+def _get_flat_builtin_jukebox_path(file_path: str) -> Optional[Path]:
+    path = Path(file_path)
+    if len(path.parts) != 2 or path.parts[0] not in {"songs", "actions"}:
+        return None
+    return _resolve_child_path(BUILTIN_JUKEBOX_DIR, path.name)
+
+
+def resolve_jukebox_file_path(file_path: str) -> Path:
+    """Resolve a jukebox file path from user storage or bundled resources."""
+    config_mgr = get_config_manager()
+    jukebox_config = JukeboxConfig(config_mgr)
+
+    # 去除前导斜杠，防止路径解析问题
+    file_path = file_path.lstrip('/')
+
+    # 处理 /static/jukebox/ 前缀（自带资源的特殊路径）
+    if file_path.startswith('static/jukebox/'):
+        file_path = file_path.replace('static/jukebox/', '', 1)
+
+    full_path = _resolve_child_path(jukebox_config.jukebox_dir, file_path)
+
+    # 优先使用用户文档目录的文件
+    if full_path.exists() and full_path.is_file():
+        return full_path
+
+    # 如果用户目录不存在，尝试从软件自带目录获取；Steam 包历史资源是平铺结构。
+    builtin_candidates = [_resolve_child_path(BUILTIN_JUKEBOX_DIR, file_path)]
+    flat_builtin_path = _get_flat_builtin_jukebox_path(file_path)
+    if flat_builtin_path is not None:
+        builtin_candidates.append(flat_builtin_path)
+
+    for builtin_path in builtin_candidates:
+        if builtin_path.exists() and builtin_path.is_file():
+            return builtin_path
+
+    raise HTTPException(404, "文件不存在")
+
+
+def get_jukebox_media_type(target_path: Path) -> str:
+    return JUKEBOX_MEDIA_TYPES.get(target_path.suffix.lower(), 'application/octet-stream')
 
 
 def validate_extract_path(file_path: str, extract_dir: Path) -> Path:
@@ -1401,61 +1464,8 @@ async def get_file(file_path: str):
     file_path: relative path, e.g. songs/song_001.mp3 or actions/action_001.vmd
     Prefers the user documents directory; falls back to the bundled directory if absent.
     """
-    config_mgr = get_config_manager()
-    jukebox_config = JukeboxConfig(config_mgr)
-    
-    # 去除前导斜杠，防止路径解析问题
-    file_path = file_path.lstrip('/')
-    
-    # 处理 /static/jukebox/ 前缀（自带资源的特殊路径）
-    if file_path.startswith('static/jukebox/'):
-        file_path = file_path.replace('static/jukebox/', '', 1)
-    
-    # 安全检查：确保路径在 jukebox 目录内
-    full_path = (jukebox_config.jukebox_dir / file_path).resolve()
-    jukebox_root = jukebox_config.jukebox_dir.resolve()
-    
-    # 防止目录遍历攻击
-    try:
-        full_path.relative_to(jukebox_root)
-    except ValueError:
-        raise HTTPException(403, "访问被拒绝")
-    
-    # 优先使用用户文档目录的文件
-    if full_path.exists() and full_path.is_file():
-        target_path = full_path
-    else:
-        # 如果用户目录不存在，尝试从软件自带目录获取
-        builtin_path = Path(__file__).parent.parent / "static" / "jukebox" / file_path
-        builtin_path = builtin_path.resolve()
-        builtin_root = (Path(__file__).parent.parent / "static" / "jukebox").resolve()
-        
-        # 安全检查
-        try:
-            builtin_path.relative_to(builtin_root)
-        except ValueError:
-            raise HTTPException(403, "访问被拒绝")
-        
-        if not builtin_path.exists() or not builtin_path.is_file():
-            raise HTTPException(404, "文件不存在")
-        
-        target_path = builtin_path
-    
-    # 根据扩展名确定媒体类型
-    ext = target_path.suffix.lower()
-    media_types = {
-        '.mp3': 'audio/mpeg',
-        '.wav': 'audio/wav',
-        '.ogg': 'audio/ogg',
-        '.flac': 'audio/flac',
-        '.vmd': 'application/octet-stream',
-        '.bvh': 'application/octet-stream',
-        '.fbx': 'application/octet-stream',
-        '.vrma': 'application/octet-stream'
-    }
-    media_type = media_types.get(ext, 'application/octet-stream')
-    
-    return FileResponse(target_path, media_type=media_type)
+    target_path = resolve_jukebox_file_path(file_path)
+    return FileResponse(target_path, media_type=get_jukebox_media_type(target_path))
 
 
 @router.post("/import")

--- a/main_routers/jukebox_router.py
+++ b/main_routers/jukebox_router.py
@@ -29,6 +29,7 @@ enforced by ``scripts/check_api_trailing_slash.py``.
 """
 
 import asyncio
+import copy
 import json
 import hashlib
 import re
@@ -70,6 +71,9 @@ JUKEBOX_MEDIA_TYPES = {
     '.bvh': 'application/octet-stream',
     '.fbx': 'application/octet-stream',
     '.vrma': 'application/octet-stream'
+}
+BUILTIN_BINDING_OFFSET_MIGRATIONS = {
+    ("song_001", "action_003"): {0},
 }
 
 def check_file_size(file: UploadFile, max_size: int) -> int:
@@ -319,7 +323,10 @@ class JukeboxConfig:
 
         # 融合绑定关系：自带绑定 + 用户绑定（用户绑定优先）
         # 先加载程序内自带的绑定（从用户文档或从软件自带配置）
-        user_builtin_bindings = user_config.get("builtinBindings", {})
+        user_builtin_bindings = self._migrate_builtin_bindings(
+            user_config.get("builtinBindings", {}),
+            builtin_bindings,
+        )
         merged_bindings = {**builtin_bindings, **user_builtin_bindings}
         # 再合并用户绑定（覆盖自带绑定）
         merged_bindings = {**merged_bindings, **user_config.get("bindings", {})}
@@ -347,6 +354,23 @@ class JukeboxConfig:
             "bindings": merged_bindings,
             "md5Index": merged_md5_index
         }
+
+    @staticmethod
+    def _migrate_builtin_bindings(user_builtin_bindings: dict, builtin_bindings: dict) -> dict:
+        migrated_bindings = copy.deepcopy(user_builtin_bindings)
+        for (song_id, action_id), old_offsets in BUILTIN_BINDING_OFFSET_MIGRATIONS.items():
+            song_bindings = migrated_bindings.get(song_id)
+            if not isinstance(song_bindings, dict):
+                continue
+            binding = song_bindings.get(action_id)
+            bundled_binding = builtin_bindings.get(song_id, {}).get(action_id)
+            if not isinstance(binding, dict) or not isinstance(bundled_binding, dict):
+                continue
+            current_offset = binding.get("offset")
+            bundled_offset = bundled_binding.get("offset")
+            if current_offset in old_offsets and bundled_offset not in old_offsets:
+                binding["offset"] = bundled_offset
+        return migrated_bindings
 
     def _load_builtin_resource_defaults(self) -> tuple[dict, dict]:
         """Load bundled song/action defaults used to detect real user overrides."""

--- a/static/jukebox/Jukebox.js
+++ b/static/jukebox/Jukebox.js
@@ -7805,18 +7805,11 @@ window.Jukebox = {
             ...actions[actionId]
           })); // 过滤掉不存在或已隐藏的动画
         
-        // 处理音频路径：自带资源使用 /static/jukebox/ 前缀
-        let audioPath = song.audio || '';
-        if (song.isBuiltin && audioPath && !audioPath.startsWith('/static/')) {
-          // 将 songs/xxx.mp3 转换为 /static/jukebox/xxx.mp3
-          audioPath = '/static/jukebox/' + audioPath.replace(/^songs\//, '');
-        }
-        
         return {
           id: id,
           name: song.name || '未知',
           artist: song.artist || '未知',
-          audio: audioPath,
+          audio: song.audio || '',
           vmd: song.vmd || '',
           duration: song.duration || 0,
           visible: song.visible !== false, // 默认可见
@@ -7835,6 +7828,16 @@ window.Jukebox = {
       console.error('[Jukebox]', window.t('Jukebox.loadFailed', '加载歌曲列表失败'), error);
       Jukebox.showError(window.t('Jukebox.loadFailed', '加载歌曲列表失败') + ': ' + error.message);
     }
+  },
+
+  resolveJukeboxFileUrl: function(filePath) {
+    const rawPath = String(filePath || '').trim();
+    if (!rawPath) return '';
+    if (/^(?:https?:|data:|blob:)/i.test(rawPath)) return rawPath;
+    if (rawPath.startsWith('/api/') || rawPath.startsWith('/static/') || rawPath.startsWith('/user_')) {
+      return rawPath;
+    }
+    return '/api/jukebox/file' + '/' + rawPath.replace(/^\/+/, '');
   },
   
   renderList: function() {
@@ -8114,15 +8117,7 @@ window.Jukebox = {
       // 根据模型类型播放对应格式的动画
       const action = Jukebox.getActionForModel(song);
       if (action) {
-        // 处理动画路径：自带资源直接用 /static/ 路径，用户上传的走 API
-        let actionFilePath = action.file || '';
-        let actionUrl;
-        if (action.isBuiltin && actionFilePath && !actionFilePath.startsWith('/static/')) {
-          // 将 actions/xxx.vmd 转换为 /static/jukebox/xxx.vmd
-          actionUrl = '/static/jukebox/' + actionFilePath.replace(/^actions\//, '');
-        } else {
-          actionUrl = `/api/jukebox/file/${actionFilePath}`;
-        }
+        const actionUrl = Jukebox.resolveJukeboxFileUrl(action.file || '');
         console.log('[Jukebox] 播放动画:', action.name, '格式:', action.format || 'vmd', '路径:', actionUrl);
 
         const modelType = Jukebox.getModelType();
@@ -8165,8 +8160,7 @@ window.Jukebox = {
     
     console.log('[Jukebox]', window.t('Jukebox.useAPlayer', '使用APlayer播放音频文件'));
     
-    // 将相对路径转换为API路径
-    const audioUrl = `/api/jukebox/file/${song.audio}`;
+    const audioUrl = Jukebox.resolveJukeboxFileUrl(song.audio);
     
     player.list.add([{
       name: song.name,
@@ -8733,6 +8727,59 @@ window.Jukebox = {
     Jukebox._updateProgressDisplayFromSlider();
   },
 
+  getAnimationTimeForMusicTime: function(musicTime, offset) {
+    const song = Jukebox.State.currentSong;
+    const action = song ? Jukebox.getActionForModel(song) : null;
+    const fps = Jukebox.getAnimationFps(action);
+    const frameOffset = Number.isFinite(Number(offset)) ? Number(offset) : Jukebox.getCurrentOffset();
+    const animFrame = (Number(musicTime) || 0) * fps + frameOffset;
+    return Math.max(0, animFrame / fps);
+  },
+
+  _seekMmdAnimationToTime: function(animTime, requireClip) {
+    const anim = window.mmdManager?.animationModule;
+    if (!anim || !anim.mixer || (requireClip && !anim.currentClip)) return false;
+
+    anim.mixer.setTime(animTime);
+    const mesh = window.mmdManager.currentModel?.mesh;
+    if (typeof anim._restoreBones === 'function') anim._restoreBones(mesh);
+    if (anim.mixer.update) anim.mixer.update(0);
+    if (typeof anim._saveBones === 'function') anim._saveBones(mesh);
+    if (mesh) mesh.updateMatrixWorld(true);
+    if (anim.ikSolver) anim.ikSolver.update();
+    if (anim.grantSolver) anim.grantSolver.update();
+    return true;
+  },
+
+  _seekVrmAnimationToTime: function(animTime) {
+    const manager = window.vrmManager;
+    if (manager && typeof manager.seekVRMAAnimation === 'function') {
+      return manager.seekVRMAAnimation(animTime);
+    }
+    const anim = manager?.animationModule || manager?.animation;
+    if (anim && typeof anim.seekTo === 'function') {
+      return anim.seekTo(animTime);
+    }
+    console.warn('[Jukebox] VRM动画同步入口不可用，跳过 seek:', animTime);
+    return false;
+  },
+
+  syncCurrentAnimationToTime: function(animTime, options = {}) {
+    if (window.__NEKO_JUKEBOX_STANDALONE__) return false;
+
+    const modelType = Jukebox.getModelType();
+    if (modelType === 'mmd' || modelType === 'live3d') {
+      return Jukebox._seekMmdAnimationToTime(animTime, options.requireClipForMmd === true);
+    }
+    if (modelType === 'vrm') {
+      return Jukebox._seekVrmAnimationToTime(animTime);
+    }
+    if (modelType === 'fbx') {
+      console.log('[Jukebox] FBX动画同步:', animTime);
+    }
+    return false;
+  },
+
   _onProgressChange: function() {
     const slider = document.getElementById('jukebox-progress-slider');
     if (!slider) {
@@ -8752,28 +8799,11 @@ window.Jukebox = {
     // 同步音频
     player.seek(seekTime);
 
-    // 同步 VMD 动画（考虑 offset）—— 独立窗口无法直接操作动画模块
-    if (!window.__NEKO_JUKEBOX_STANDALONE__) {
-      const song = Jukebox.State.currentSong;
-      const action = song ? Jukebox.getActionForModel(song) : null;
-      const fps = Jukebox.getAnimationFps(action);
-      const offset = Jukebox.getCurrentOffset();
-      const animFrame = seekTime * fps + offset;
-      const animTime = Math.max(0, animFrame / fps);
-
-      const anim = window.mmdManager?.animationModule;
-      if (anim && anim.mixer && anim.currentClip) {
-        anim.mixer.setTime(animTime);
-        // 手动执行一帧更新让姿态同步
-        anim._restoreBones(window.mmdManager.currentModel?.mesh);
-        anim.mixer.update(0);
-        anim._saveBones(window.mmdManager.currentModel?.mesh);
-        const mesh = window.mmdManager.currentModel?.mesh;
-        if (mesh) mesh.updateMatrixWorld(true);
-        if (anim.ikSolver) anim.ikSolver.update();
-        if (anim.grantSolver) anim.grantSolver.update();
-      }
-    }
+    // 同步动画（考虑 offset）—— 独立窗口无法直接操作动画模块
+    Jukebox.syncCurrentAnimationToTime(
+      Jukebox.getAnimationTimeForMusicTime(seekTime),
+      { requireClipForMmd: true }
+    );
 
     Jukebox.State.isSeeking = false;
     Jukebox._updateProgressDisplay();
@@ -8986,35 +9016,12 @@ window.Jukebox = {
     // 独立窗口模式：校准需要直接访问动画模块，无法通过 IPC 操作
     if (window.__NEKO_JUKEBOX_STANDALONE__) return;
 
-    const song = Jukebox.State.currentSong;
-    const action = Jukebox.getActionForModel(song);
-    const fps = Jukebox.getAnimationFps(action);
-
     const player = Jukebox.getPlayer();
     if (!player || !player.audio) return;
 
     const musicTime = player.audio.currentTime;
-    const animFrame = musicTime * fps + offset;
-    const animTime = Math.max(0, animFrame / fps);
-
-    // 根据模型类型同步动画
-    const modelType = Jukebox.getModelType();
-    if (modelType === 'mmd' || modelType === 'live3d') {
-      const anim = window.mmdManager?.animationModule;
-      if (anim && anim.mixer) {
-        anim.mixer.setTime(animTime);
-        // 手动更新一帧确保同步
-        if (anim.mixer.update) {
-          anim.mixer.update(0);
-        }
-      }
-    } else if (modelType === 'vrm') {
-      // VRM动画同步（如果有相关API）
-      console.log('[Jukebox] VRM动画同步:', animTime, 'FPS:', fps);
-    } else if (modelType === 'fbx') {
-      // FBX动画同步
-      console.log('[Jukebox] FBX动画同步:', animTime, 'FPS:', fps);
-    }
+    const animTime = Jukebox.getAnimationTimeForMusicTime(musicTime, offset);
+    Jukebox.syncCurrentAnimationToTime(animTime);
   },
 
   // 根据模型类型获取对应格式的动画

--- a/static/jukebox/Jukebox.js
+++ b/static/jukebox/Jukebox.js
@@ -8933,9 +8933,11 @@ window.Jukebox = {
     const action = Jukebox.getActionForModel(song);
     if (!action) return 0;
 
-    // 从绑定关系中获取offset (从 SongActionManager.data 中获取)
-    const binding = Jukebox.SongActionManager.data.bindings?.[song.id]?.[action.id];
-    return binding?.offset || 0;
+    // 当前会话编辑过的值优先；普通播放路径未打开管理器时回退到 loadSongs 已加载的配置。
+    const managerBinding = Jukebox.SongActionManager.data.bindings?.[song.id]?.[action.id];
+    const configBinding = Jukebox.State.config?.bindings?.[song.id]?.[action.id];
+    const offset = managerBinding?.offset ?? configBinding?.offset ?? 0;
+    return Number.isFinite(Number(offset)) ? Number(offset) : 0;
   },
 
   // 更新校准显示值

--- a/static/jukebox/Jukebox.js
+++ b/static/jukebox/Jukebox.js
@@ -7834,6 +7834,9 @@ window.Jukebox = {
     const rawPath = String(filePath || '').trim();
     if (!rawPath) return '';
     if (/^(?:https?:|data:|blob:)/i.test(rawPath)) return rawPath;
+    if (/^\/?static\/jukebox\//.test(rawPath)) {
+      return '/api/jukebox/file/' + rawPath.replace(/^\/?static\/jukebox\//, '');
+    }
     if (rawPath.startsWith('/api/') || rawPath.startsWith('/static/') || rawPath.startsWith('/user_')) {
       return rawPath;
     }
@@ -8753,12 +8756,13 @@ window.Jukebox = {
 
   _seekVrmAnimationToTime: function(animTime) {
     const manager = window.vrmManager;
+    const seekOptions = { paused: Jukebox.State.isPaused === true };
     if (manager && typeof manager.seekVRMAAnimation === 'function') {
-      return manager.seekVRMAAnimation(animTime);
+      return manager.seekVRMAAnimation(animTime, seekOptions);
     }
     const anim = manager?.animationModule || manager?.animation;
     if (anim && typeof anim.seekTo === 'function') {
-      return anim.seekTo(animTime);
+      return anim.seekTo(animTime, seekOptions);
     }
     console.warn('[Jukebox] VRM动画同步入口不可用，跳过 seek:', animTime);
     return false;

--- a/static/jukebox/songs.json
+++ b/static/jukebox/songs.json
@@ -74,7 +74,7 @@
         "offset": 13
       },
       "action_003": {
-        "offset": 0
+        "offset": 6
       }
     },
     "song_002": {

--- a/static/vrm/vrm-animation.js
+++ b/static/vrm/vrm-animation.js
@@ -140,35 +140,7 @@ class VRMAnimation {
 
         if (this.vrmaIsPlaying && this.vrmaMixer) {
             this.vrmaMixer.update(updateDelta);
-
-            const vrm = this.manager.currentModel?.vrm;
-            if (vrm?.scene) {
-                // 检查 scene 是否变化，如果变化则重建缓存（防止僵尸引用）
-                if (this._cachedSceneUuid !== vrm.scene.uuid) {
-                    this._cacheSkinnedMeshes(vrm);
-                }
-
-                if (vrm.humanoid) {
-                    const vrmVersion = this._detectVRMVersion(vrm);
-                    if (vrmVersion === '1.0' && vrm.humanoid.autoUpdateHumanBones) {
-                        vrm.humanoid.update();
-                    } else if (vrmVersion === '0.0') {
-                        const mixerRoot = this.vrmaMixer.getRoot();
-                        const normalizedRoot = vrm.humanoid?._normalizedHumanBones?.root;
-                        if (normalizedRoot && mixerRoot === normalizedRoot) {
-                            if (vrm.humanoid.autoUpdateHumanBones !== undefined) {
-                                vrm.humanoid.update();
-                            }
-                        }
-                    }
-                }
-                vrm.scene.updateMatrixWorld(true);
-                this._skinnedMeshes.forEach(mesh => {
-                    if (mesh.skeleton) {
-                        mesh.skeleton.update();
-                    }
-                });
-            }
+            this._refreshPoseAfterMixerUpdate();
         }
         if (this.lipSyncActive && this.analyser) {
             this._updateLipSync(updateDelta);
@@ -181,6 +153,58 @@ class VRMAnimation {
                 this.manager.interaction.updateModelBoundsCache();
             }
         }
+    }
+
+    _refreshPoseAfterMixerUpdate(updateSkeletonHelper = false) {
+        const vrm = this.manager.currentModel?.vrm;
+        if (!vrm?.scene) return;
+
+        if (this._cachedSceneUuid !== vrm.scene.uuid) {
+            this._cacheSkinnedMeshes(vrm);
+        }
+
+        if (vrm.humanoid) {
+            const vrmVersion = this._detectVRMVersion(vrm);
+            if (vrmVersion === '1.0' && vrm.humanoid.autoUpdateHumanBones) {
+                vrm.humanoid.update();
+            } else if (vrmVersion === '0.0') {
+                const mixerRoot = this.vrmaMixer?.getRoot?.();
+                const normalizedRoot = vrm.humanoid?._normalizedHumanBones?.root;
+                if (normalizedRoot && mixerRoot === normalizedRoot) {
+                    if (vrm.humanoid.autoUpdateHumanBones !== undefined) {
+                        vrm.humanoid.update();
+                    }
+                }
+            }
+        }
+
+        vrm.scene.updateMatrixWorld(true);
+        this._skinnedMeshes.forEach(mesh => {
+            if (mesh.skeleton) {
+                mesh.skeleton.update();
+            }
+        });
+
+        if (updateSkeletonHelper && this.debug) this._updateSkeletonHelper();
+    }
+
+    seekTo(timeSeconds) {
+        const targetTime = Number(timeSeconds);
+        if (!Number.isFinite(targetTime) || !this.vrmaMixer || !this.currentAction) {
+            return false;
+        }
+
+        const wasPaused = this.currentAction.paused === true;
+        const seekTime = Math.max(0, targetTime);
+        try {
+            this.currentAction.paused = false;
+            this.currentAction.time = seekTime;
+            this.vrmaMixer.update(0);
+            this._refreshPoseAfterMixerUpdate(true);
+        } finally {
+            this.currentAction.paused = wasPaused;
+        }
+        return true;
     }
 
     async _initLoader() {
@@ -549,21 +573,7 @@ class VRMAnimation {
 
         this.vrmaMixer.update(0.001);
 
-        if (vrm.scene) {
-            // 检查 scene 是否变化，如果变化则重建缓存（防止僵尸引用）
-            if (this._cachedSceneUuid !== vrm.scene.uuid) {
-                this._cacheSkinnedMeshes(vrm);
-            }
-
-            vrm.scene.updateMatrixWorld(true);
-            this._skinnedMeshes.forEach(mesh => {
-                if (mesh.skeleton) {
-                    mesh.skeleton.update();
-                }
-            });
-        }
-
-        if (this.debug) this._updateSkeletonHelper();
+        this._refreshPoseAfterMixerUpdate(true);
     }
 
     /**

--- a/static/vrm/vrm-animation.js
+++ b/static/vrm/vrm-animation.js
@@ -188,13 +188,15 @@ class VRMAnimation {
         if (updateSkeletonHelper && this.debug) this._updateSkeletonHelper();
     }
 
-    seekTo(timeSeconds) {
+    seekTo(timeSeconds, options = {}) {
         const targetTime = Number(timeSeconds);
         if (!Number.isFinite(targetTime) || !this.vrmaMixer || !this.currentAction) {
             return false;
         }
 
-        const wasPaused = this.currentAction.paused === true;
+        const nextPaused = typeof options?.paused === 'boolean'
+            ? options.paused
+            : this.currentAction.paused === true;
         const seekTime = Math.max(0, targetTime);
         try {
             this.currentAction.paused = false;
@@ -202,7 +204,7 @@ class VRMAnimation {
             this.vrmaMixer.update(0);
             this._refreshPoseAfterMixerUpdate(true);
         } finally {
-            this.currentAction.paused = wasPaused;
+            this.currentAction.paused = nextPaused;
         }
         return true;
     }

--- a/static/vrm/vrm-manager.js
+++ b/static/vrm/vrm-manager.js
@@ -1338,6 +1338,12 @@ class VRMManager {
         if (this.animation) return this.animation.playVRMAAnimation(url, opts);
     }
 
+    seekVRMAAnimation(timeSeconds) {
+        if (this.animation && typeof this.animation.seekTo === 'function') {
+            return this.animation.seekTo(timeSeconds);
+        }
+        return false;
+    }
 
     stopVRMAAnimation() {
         if (this.animation) this.animation.stopVRMAAnimation();

--- a/static/vrm/vrm-manager.js
+++ b/static/vrm/vrm-manager.js
@@ -1338,9 +1338,9 @@ class VRMManager {
         if (this.animation) return this.animation.playVRMAAnimation(url, opts);
     }
 
-    seekVRMAAnimation(timeSeconds) {
+    seekVRMAAnimation(timeSeconds, options) {
         if (this.animation && typeof this.animation.seekTo === 'function') {
-            return this.animation.seekTo(timeSeconds);
+            return this.animation.seekTo(timeSeconds, options);
         }
         return false;
     }

--- a/tests/frontend/test_jukebox_playback_modes.py
+++ b/tests/frontend/test_jukebox_playback_modes.py
@@ -528,7 +528,9 @@ def test_jukebox_builtin_paths_keep_resource_directories(mock_page: Page):
           return {
             audio: song.audio,
             playerUrls,
-            vrmaCalls
+            vrmaCalls,
+            legacyStaticVrma: J.resolveJukeboxFileUrl('/static/jukebox/actions/song_001.vrma'),
+            legacyFlatVrma: J.resolveJukeboxFileUrl('static/jukebox/song_001.vrma')
           };
         }
         """
@@ -538,6 +540,8 @@ def test_jukebox_builtin_paths_keep_resource_directories(mock_page: Page):
         "audio": "songs/song_001.mp3",
         "playerUrls": ["/api/jukebox/file/songs/song_001.mp3"],
         "vrmaCalls": ["/api/jukebox/file/actions/song_001.vrma"],
+        "legacyStaticVrma": "/api/jukebox/file/actions/song_001.vrma",
+        "legacyFlatVrma": "/api/jukebox/file/song_001.vrma",
     }
 
 
@@ -575,8 +579,8 @@ def test_jukebox_vrm_progress_seek_and_calibration_sync_animation(mock_page: Pag
             }
           };
           window.vrmManager = {
-            seekVRMAAnimation(time) {
-              vrmSeekCalls.push(time);
+            seekVRMAAnimation(time, options) {
+              vrmSeekCalls.push({ time, paused: options && options.paused });
               return true;
             }
           };
@@ -600,7 +604,10 @@ def test_jukebox_vrm_progress_seek_and_calibration_sync_animation(mock_page: Pag
 
     assert result == {
         "audioSeekCalls": [50],
-        "vrmSeekCalls": [50.5, 11.5],
+        "vrmSeekCalls": [
+            {"time": 50.5, "paused": False},
+            {"time": 11.5, "paused": False},
+        ],
         "afterProgressChange": {
             "audioCurrentTime": 50,
             "isSeeking": False,
@@ -649,9 +656,11 @@ def test_vrm_animation_seek_preserves_paused_state_and_refreshes_pose(mock_page:
           anim.currentAction = { time: 0, paused: true };
 
           const ok = anim.seekTo(3.25);
+          const okPlaying = anim.seekTo(1.5, { paused: false });
 
           return {
             ok,
+            okPlaying,
             actionTime: anim.currentAction.time,
             actionPaused: anim.currentAction.paused,
             cachedMeshes: anim._skinnedMeshes.length,
@@ -663,10 +672,18 @@ def test_vrm_animation_seek_preserves_paused_state_and_refreshes_pose(mock_page:
 
     assert result == {
         "ok": True,
-        "actionTime": 3.25,
-        "actionPaused": True,
+        "okPlaying": True,
+        "actionTime": 1.5,
+        "actionPaused": False,
         "cachedMeshes": 1,
-        "events": ["mixer:0", "matrix:true", "skeleton"],
+        "events": [
+            "mixer:0",
+            "matrix:true",
+            "skeleton",
+            "mixer:0",
+            "matrix:true",
+            "skeleton",
+        ],
     }
 
 

--- a/tests/frontend/test_jukebox_playback_modes.py
+++ b/tests/frontend/test_jukebox_playback_modes.py
@@ -9,6 +9,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 JUKEBOX_SCRIPT = (REPO_ROOT / "static" / "jukebox" / "Jukebox.js").read_text(encoding="utf-8")
 JUKEBOX_LOADER_SCRIPT = (REPO_ROOT / "static" / "jukebox" / "jukebox-loader.js").read_text(encoding="utf-8")
 JUKEBOX_TEMPLATE = (REPO_ROOT / "templates" / "jukebox.html").read_text(encoding="utf-8")
+VRM_ANIMATION_SCRIPT = (REPO_ROOT / "static" / "vrm" / "vrm-animation.js").read_text(encoding="utf-8")
 
 HARNESS_HTML = """
 <!DOCTYPE html>
@@ -457,6 +458,216 @@ def test_jukebox_volume_wheel_adjusts_volume_without_scrolling_container(mock_pa
     assert result["upDispatchResult"] is False
     assert result["downDispatchResult"] is False
     assert result["containerWheelCount"] == 0
+
+
+@pytest.mark.frontend
+def test_jukebox_builtin_paths_keep_resource_directories(mock_page: Page):
+    setup_jukebox_page(mock_page)
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+          const J = window.Jukebox;
+          const playerUrls = [];
+          const vrmaCalls = [];
+
+          window.fetch = async (url) => {
+            if (url === '/api/jukebox/config') {
+              return {
+                ok: true,
+                json: async () => ({
+                  configRevision: 'rev-builtin-paths',
+                  songs: {
+                    song_001: {
+                      name: '桃源恋歌',
+                      artist: 'GARNiDELiA',
+                      audio: 'songs/song_001.mp3',
+                      visible: true,
+                      isBuiltin: true,
+                      defaultAction: 'action_001'
+                    }
+                  },
+                  actions: {
+                    action_001: {
+                      name: '桃源恋歌',
+                      file: 'actions/song_001.vrma',
+                      format: 'vrma',
+                      visible: true,
+                      isBuiltin: true
+                    }
+                  },
+                  bindings: {
+                    song_001: { action_001: { offset: 0 } }
+                  }
+                })
+              };
+            }
+            throw new Error(`unexpected fetch ${url}`);
+          };
+
+          await J.loadSongs();
+          const song = J.State.songs[0];
+
+          J.getModelType = () => 'vrm';
+          J.stopPlayback = () => {};
+          J.playVRMA = async (url) => { vrmaCalls.push(url); };
+          J.getPlayer = () => ({
+            list: {
+              clear() {},
+              add(items) {
+                playerUrls.push(...items.map(item => item.url));
+              }
+            },
+            options: {},
+            on() {},
+            play() {}
+          });
+
+          await J.playSong('song_001');
+
+          return {
+            audio: song.audio,
+            playerUrls,
+            vrmaCalls
+          };
+        }
+        """
+    )
+
+    assert result == {
+        "audio": "songs/song_001.mp3",
+        "playerUrls": ["/api/jukebox/file/songs/song_001.mp3"],
+        "vrmaCalls": ["/api/jukebox/file/actions/song_001.vrma"],
+    }
+
+
+@pytest.mark.frontend
+def test_jukebox_vrm_progress_seek_and_calibration_sync_animation(mock_page: Page):
+    setup_jukebox_page(mock_page)
+
+    result = mock_page.evaluate(
+        """
+        () => {
+          const J = window.Jukebox;
+          const audioSeekCalls = [];
+          const vrmSeekCalls = [];
+          const audio = { duration: 100, currentTime: 20 };
+
+          J.getModelType = () => 'vrm';
+          J.State.currentSong = {
+            id: 'song-vrm',
+            name: 'VRM Song',
+            boundActions: [{ id: 'action-vrma', name: 'Dance', format: 'vrma', fps: 60 }],
+            defaultAction: 'action-vrma'
+          };
+          J.SongActionManager.data = {
+            bindings: {
+              'song-vrm': {
+                'action-vrma': { offset: 30 }
+              }
+            }
+          };
+          J.State.player = {
+            audio,
+            seek(time) {
+              audio.currentTime = time;
+              audioSeekCalls.push(time);
+            }
+          };
+          window.vrmManager = {
+            seekVRMAAnimation(time) {
+              vrmSeekCalls.push(time);
+              return true;
+            }
+          };
+
+          const slider = document.getElementById('jukebox-progress-slider');
+          slider.value = '50';
+          J._onProgressChange();
+          const afterProgressChange = {
+            audioCurrentTime: audio.currentTime,
+            isSeeking: J.State.isSeeking,
+            timeText: document.getElementById('jukebox-time-current').textContent
+          };
+
+          audio.currentTime = 12;
+          J.syncAnimationToOffset(-30);
+
+          return { audioSeekCalls, vrmSeekCalls, afterProgressChange };
+        }
+        """
+    )
+
+    assert result == {
+        "audioSeekCalls": [50],
+        "vrmSeekCalls": [50.5, 11.5],
+        "afterProgressChange": {
+            "audioCurrentTime": 50,
+            "isSeeking": False,
+            "timeText": "0:50",
+        },
+    }
+
+
+@pytest.mark.frontend
+def test_vrm_animation_seek_preserves_paused_state_and_refreshes_pose(mock_page: Page):
+    mock_page.set_content("<html><body></body></html>")
+    mock_page.evaluate("() => { window.THREE = {}; }")
+    mock_page.add_script_tag(content=VRM_ANIMATION_SCRIPT)
+
+    result = mock_page.evaluate(
+        """
+        () => {
+          const events = [];
+          const skinnedMesh = {
+            isSkinnedMesh: true,
+            skeleton: {
+              update() {
+                events.push('skeleton');
+              }
+            }
+          };
+          const scene = {
+            uuid: 'scene-a',
+            traverse(callback) {
+              callback(skinnedMesh);
+            },
+            updateMatrixWorld(force) {
+              events.push(`matrix:${force}`);
+            }
+          };
+          const manager = { currentModel: { vrm: { scene } } };
+          const anim = new window.VRMAnimation(manager);
+          anim.vrmaMixer = {
+            update(delta) {
+              events.push(`mixer:${delta}`);
+            },
+            getRoot() {
+              return scene;
+            }
+          };
+          anim.currentAction = { time: 0, paused: true };
+
+          const ok = anim.seekTo(3.25);
+
+          return {
+            ok,
+            actionTime: anim.currentAction.time,
+            actionPaused: anim.currentAction.paused,
+            cachedMeshes: anim._skinnedMeshes.length,
+            events
+          };
+        }
+        """
+    )
+
+    assert result == {
+        "ok": True,
+        "actionTime": 3.25,
+        "actionPaused": True,
+        "cachedMeshes": 1,
+        "events": ["mixer:0", "matrix:true", "skeleton"],
+    }
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_jukebox_playback_modes.py
+++ b/tests/frontend/test_jukebox_playback_modes.py
@@ -715,11 +715,13 @@ def test_vrm_animation_seek_preserves_paused_state_and_refreshes_pose(mock_page:
           anim.currentAction = { time: 0, paused: true };
 
           const ok = anim.seekTo(3.25);
+          const pausedAfterFirstSeek = anim.currentAction.paused;
           const okPlaying = anim.seekTo(1.5, { paused: false });
 
           return {
             ok,
             okPlaying,
+            pausedAfterFirstSeek,
             actionTime: anim.currentAction.time,
             actionPaused: anim.currentAction.paused,
             cachedMeshes: anim._skinnedMeshes.length,
@@ -732,6 +734,7 @@ def test_vrm_animation_seek_preserves_paused_state_and_refreshes_pose(mock_page:
     assert result == {
         "ok": True,
         "okPlaying": True,
+        "pausedAfterFirstSeek": True,
         "actionTime": 1.5,
         "actionPaused": False,
         "cachedMeshes": 1,

--- a/tests/frontend/test_jukebox_playback_modes.py
+++ b/tests/frontend/test_jukebox_playback_modes.py
@@ -617,6 +617,65 @@ def test_jukebox_vrm_progress_seek_and_calibration_sync_animation(mock_page: Pag
 
 
 @pytest.mark.frontend
+def test_jukebox_progress_seek_uses_loaded_config_offset_before_manager_load(mock_page: Page):
+    setup_jukebox_page(mock_page)
+
+    result = mock_page.evaluate(
+        """
+        () => {
+          const J = window.Jukebox;
+          const vrmSeekCalls = [];
+          const audio = { duration: 100, currentTime: 0 };
+
+          J.getModelType = () => 'vrm';
+          J.State.config = {
+            bindings: {
+              'song-vrm': {
+                'action-vrma': { offset: 6 }
+              }
+            }
+          };
+          J.State.currentSong = {
+            id: 'song-vrm',
+            name: 'VRM Song',
+            boundActions: [{ id: 'action-vrma', name: 'Dance', format: 'vrma', fps: 60 }],
+            defaultAction: 'action-vrma'
+          };
+          J.SongActionManager.data = { bindings: {} };
+          J.State.player = {
+            audio,
+            seek(time) {
+              audio.currentTime = time;
+            }
+          };
+          window.vrmManager = {
+            seekVRMAAnimation(time, options) {
+              vrmSeekCalls.push({ time, paused: options && options.paused });
+              return true;
+            }
+          };
+
+          const slider = document.getElementById('jukebox-progress-slider');
+          slider.value = '50';
+          J._onProgressChange();
+
+          return {
+            currentOffset: J.getCurrentOffset(),
+            audioCurrentTime: audio.currentTime,
+            vrmSeekCalls
+          };
+        }
+        """
+    )
+
+    assert result == {
+        "currentOffset": 6,
+        "audioCurrentTime": 50,
+        "vrmSeekCalls": [{"time": 50.1, "paused": False}],
+    }
+
+
+@pytest.mark.frontend
 def test_vrm_animation_seek_preserves_paused_state_and_refreshes_pose(mock_page: Page):
     mock_page.set_content("<html><body></body></html>")
     mock_page.evaluate("() => { window.THREE = {}; }")

--- a/tests/unit/test_jukebox_batch_delete.py
+++ b/tests/unit/test_jukebox_batch_delete.py
@@ -69,6 +69,41 @@ def test_config_summary_revision_is_stable_and_changes_with_songs():
     assert changed["visibleSongCount"] == 2
 
 
+def test_resolve_jukebox_file_prefers_user_storage_then_bundled_layouts(monkeypatch, tmp_path):
+    jukebox_dir = tmp_path / "jukebox"
+    user_songs_dir = jukebox_dir / "songs"
+    user_songs_dir.mkdir(parents=True)
+    user_song = user_songs_dir / "song_001.mp3"
+    user_song.write_bytes(b"user")
+
+    builtin_dir = tmp_path / "static" / "jukebox"
+    builtin_songs_dir = builtin_dir / "songs"
+    builtin_actions_dir = builtin_dir / "actions"
+    builtin_songs_dir.mkdir(parents=True)
+    builtin_actions_dir.mkdir(parents=True)
+    nested_song = builtin_songs_dir / "song_002.mp3"
+    nested_song.write_bytes(b"nested")
+    flat_song = builtin_dir / "song_003.mp3"
+    flat_song.write_bytes(b"flat-song")
+    flat_action = builtin_dir / "song_001.vrma"
+    flat_action.write_bytes(b"flat-action")
+
+    fake = _FakeJukeboxConfig(
+        {"version": "1.0", "songs": {}, "actions": {}, "bindings": {}},
+        jukebox_dir,
+    )
+    _install_fake_config(monkeypatch, fake)
+    monkeypatch.setattr(jukebox_router, "BUILTIN_JUKEBOX_DIR", builtin_dir)
+
+    assert jukebox_router.resolve_jukebox_file_path("songs/song_001.mp3") == user_song
+    assert jukebox_router.resolve_jukebox_file_path("songs/song_002.mp3") == nested_song
+    assert jukebox_router.resolve_jukebox_file_path("songs/song_003.mp3") == flat_song
+    assert jukebox_router.resolve_jukebox_file_path("actions/song_001.vrma") == flat_action
+    with pytest.raises(HTTPException) as exc_info:
+        jukebox_router.resolve_jukebox_file_path("../song_003.mp3")
+    assert exc_info.value.status_code == 403
+
+
 def test_save_builtin_overrides_omits_unchanged_defaults(tmp_path):
     config = _make_save_config(
         tmp_path,

--- a/tests/unit/test_jukebox_batch_delete.py
+++ b/tests/unit/test_jukebox_batch_delete.py
@@ -35,6 +35,13 @@ def _make_save_config(tmp_path, data, builtin_songs, builtin_actions):
     return config
 
 
+def _load_config_with_user_data(tmp_path, user_data):
+    config = object.__new__(jukebox_router.JukeboxConfig)
+    config.config_file = tmp_path / "config.json"
+    config.config_file.write_text(json.dumps(user_data), encoding="utf-8")
+    return config._load_config()
+
+
 def test_config_summary_revision_is_stable_and_changes_with_songs():
     data = {
         "version": "1.0",
@@ -102,6 +109,34 @@ def test_resolve_jukebox_file_prefers_user_storage_then_bundled_layouts(monkeypa
     with pytest.raises(HTTPException) as exc_info:
         jukebox_router.resolve_jukebox_file_path("../song_003.mp3")
     assert exc_info.value.status_code == 403
+
+
+def test_builtin_vrma_offset_migration_updates_only_old_default(tmp_path):
+    migrated = _load_config_with_user_data(
+        tmp_path,
+        {
+            "version": "1.0",
+            "builtinBindings": {
+                "song_001": {
+                    "action_003": {"offset": 0},
+                },
+            },
+        },
+    )
+    preserved = _load_config_with_user_data(
+        tmp_path,
+        {
+            "version": "1.0",
+            "builtinBindings": {
+                "song_001": {
+                    "action_003": {"offset": 9},
+                },
+            },
+        },
+    )
+
+    assert migrated["bindings"]["song_001"]["action_003"]["offset"] == 6
+    assert preserved["bindings"]["song_001"]["action_003"]["offset"] == 9
 
 
 def test_save_builtin_overrides_omits_unchanged_defaults(tmp_path):


### PR DESCRIPTION
## 改动概述 / Summary

- Add VRMA seek support so VRM jukebox playback can stay aligned when users drag progress or adjust calibration.
- Preserve logical jukebox media paths and resolve them through the file API with user-storage, bundled nested, and Steam flat bundled fallbacks.
- Update the bundled `song_001` VRMA calibration offset and migrate existing saved builtin configs that still have the old default offset.
- Handle legacy `/static/jukebox/...` references through the file resolver and keep VRMA seek paused only when the jukebox is actually paused by the user.
- Read saved offsets from the config loaded by `loadSongs()` before the manager panel is opened, while keeping current-session manager edits as the priority source.

## Why

The project ships builtin jukebox songs and animations as usable resources. The MMD path already had progress seeking and calibration offset alignment, but the VRM/VRMA path did not yet have the matching playback synchronization capability. That missing feature meant the provided music and VRMA actions could not be reliably lined up during playback.

This PR adds the missing VRM jukebox synchronization behavior so builtin VRMA actions can be calibrated and kept in sync with music, matching the expectation for project-provided jukebox resources.

It also keeps the media path model explicit: song/action entries remain logical `songs/...` and `actions/...` references, while the backend resolves them against user files, bundled nested files, and the legacy flat Steam package layout.

## 回归报告 / Regression Report

- Changed `main_routers/jukebox_router.py` to resolve jukebox media paths through a single safe resolver. It accepts logical `songs/...` and `actions/...` paths, rejects path traversal, and searches user storage first, bundled nested static media second, and the legacy flat Steam bundled layout last.
- Added a guarded builtin binding migration for `song_001/action_003`: existing saved configs that still have the old default offset `0` are migrated to the current bundled offset, while user-adjusted values are preserved.
- This is necessary because project-provided jukebox media can exist in different layouts depending on whether the app is running from the development/user directory or the Steam package. The frontend should not hard-code `/static/jukebox/...` URLs for builtin entries because that bypasses user-storage priority and fails when action files are stored under `actions/`.
- Before this change, builtin VRMA entries could request `/static/jukebox/song_001.vrma` and fail in layouts where the action is actually under `actions/song_001.vrma`; existing user configs could also keep the stale builtin offset; normal playback could ignore saved offsets before the manager panel was opened. After this change, jukebox media goes through `/api/jukebox/file/...`, supported storage layouts are resolved safely, old default builtin offsets are upgraded without overwriting user calibration, and playback reads offsets from the already loaded config.
- Potential regression points are jukebox audio/action file serving, path traversal rejection, existing saved builtin binding merge behavior, offset reads during normal playback, and existing batch-delete route behavior in the same router module. These were covered by targeted resolver/migration/offset tests, existing batch-delete tests, frontend playback-mode tests, syntax checks, and a local backend HTTP range-response check for both mp3 and vrma media.

## 不拆分理由 / Why Not Split

不适用。The counted file set is below the split threshold, and the backend resolver, frontend media URL handling, VRM seek entry point, bundled offset/migration, config offset fallback, and tests are one user-visible jukebox synchronization capability.

## 测试 / Testing

- `node --check static/jukebox/Jukebox.js`
- `node --check static/vrm/vrm-animation.js`
- `node --check static/vrm/vrm-manager.js`
- `uv run --no-sync --project D:\AI\N.E.K.O\N.E.K.O python -m py_compile main_routers/jukebox_router.py`
- `uv run --no-sync --project D:\AI\N.E.K.O\N.E.K.O python -m pytest tests/unit/test_jukebox_batch_delete.py::test_resolve_jukebox_file_prefers_user_storage_then_bundled_layouts tests/unit/test_jukebox_batch_delete.py::test_builtin_vrma_offset_migration_updates_only_old_default tests/frontend/test_jukebox_playback_modes.py::test_jukebox_builtin_paths_keep_resource_directories tests/frontend/test_jukebox_playback_modes.py::test_jukebox_vrm_progress_seek_and_calibration_sync_animation tests/frontend/test_jukebox_playback_modes.py::test_vrm_animation_seek_preserves_paused_state_and_refreshes_pose -q` -> `5 passed, 2 warnings`
- `uv run --no-sync --project D:\AI\N.E.K.O\N.E.K.O python -m pytest tests/frontend/test_jukebox_playback_modes.py::test_jukebox_vrm_progress_seek_and_calibration_sync_animation tests/frontend/test_jukebox_playback_modes.py::test_jukebox_progress_seek_uses_loaded_config_offset_before_manager_load -q` -> `2 passed`
- `uv run --no-sync --project D:\AI\N.E.K.O\N.E.K.O python -m pytest tests/frontend/test_jukebox_playback_modes.py -q` -> `41 passed`
- `uv run --no-sync --project D:\AI\N.E.K.O\N.E.K.O python -m pytest tests/unit/test_jukebox_batch_delete.py -q` -> `21 passed, 2 warnings`
- `uv run --no-sync --project D:\AI\N.E.K.O\N.E.K.O python -m pytest tests/frontend/test_jukebox_standalone_cursor.py tests/frontend/test_jukebox_playback_modes.py tests/frontend/test_jukebox_standalone.py tests/frontend/test_jukebox_manager_standalone.py tests/unit/test_jukebox_batch_delete.py -q` -> `98 passed, 1 skipped, 2 warnings`
- Restarted the backend from the worktree and checked `/api/jukebox/file/songs/song_001.mp3` and `/api/jukebox/file/actions/song_001.vrma` return HTTP 206 range responses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持更稳定地加载和播放内置及用户自定义的音乐、动作资源。
  * 新增 VRM 动画精准跳转与音频进度同步，拖动进度条时保持一致。
  * 支持多种媒体格式，并兼容历史资源目录结构。

* **改进**
  * 优先使用用户资源，缺失时自动回退到内置资源。
  * 增强资源路径安全校验，阻止非法路径访问。
  * 自动迁移旧版内置动作偏移配置，减少升级后的播放偏差。

* **测试**
  * 新增播放、路径解析、进度同步及动画跳转的自动化测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->