### PR TITLE
feat:enhance plugin autostart

### DIFF
--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -39,7 +39,10 @@ except ImportError:  # pragma: no cover
 from plugin._types.events import EventHandler, EventMeta, EVENT_META_ATTR
 from plugin._types.version import SDK_VERSION
 from plugin.server.infrastructure.config_resolver import resolve_plugin_config_from_path
-from plugin.server.infrastructure.runtime_overrides import get_runtime_override
+from plugin.server.infrastructure.runtime_overrides import (
+    get_runtime_auto_start_override,
+    get_runtime_override,
+)
 from plugin.core.state import state
 from plugin.core.entry_points import normalize_plugin_entry_point
 from plugin._types.models import PluginMeta, PluginAuthor, PluginDependency
@@ -1099,6 +1102,16 @@ def _parse_single_plugin_config(
             override,
         )
         enabled_val = override
+
+    auto_start_override = get_runtime_auto_start_override(str(pid))
+    if auto_start_override is not None and auto_start_override != auto_start_val:
+        logger.info(
+            "Plugin {} runtime_auto_start overridden by user preference: {} -> {}",
+            pid,
+            auto_start_val,
+            auto_start_override,
+        )
+        auto_start_val = auto_start_override
 
     if not enabled_val:
         logger.info(

--- a/plugin/server/application/plugins/lifecycle_service.py
+++ b/plugin/server/application/plugins/lifecycle_service.py
@@ -41,7 +41,10 @@ from plugin.server.domain.errors import ServerDomainError
 from plugin.server.application.plugins.registry_service import PluginRegistryService
 from plugin.server.infrastructure.config_resolver import resolve_plugin_config_from_path
 from plugin.server.infrastructure.runtime_overrides import (
+    RuntimeOverridePersistenceError,
     clear_runtime_override,
+    get_runtime_auto_start_override,
+    get_runtime_override,
     set_runtime_override,
 )
 from plugin.server.messaging.lifecycle_events import emit_lifecycle_event
@@ -53,6 +56,7 @@ from plugin.settings import (
     PLUGIN_CONFIG_ROOTS,
     PLUGIN_SHUTDOWN_TIMEOUT,
     PLUGIN_STARTUP_TIMEOUT,
+    PLUGIN_SYNC_AUTO_START_ON_TOGGLE,
 )
 from plugin.utils import parse_bool_config
 
@@ -60,6 +64,36 @@ logger = get_logger("server.application.plugins.lifecycle")
 _PLUGIN_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
 _PLUGIN_STARTUP_TIMEOUT_MAX = 300.0
 plugin_registry_service = PluginRegistryService()
+
+
+def _persist_user_runtime_intent(
+    plugin_id: str,
+    enabled: bool,
+    *,
+    runtime_state_changed: bool = False,
+) -> None:
+    try:
+        set_runtime_override(
+            plugin_id,
+            enabled,
+            auto_start=enabled if PLUGIN_SYNC_AUTO_START_ON_TOGGLE else None,
+        )
+    except RuntimeOverridePersistenceError as exc:
+        raise ServerDomainError(
+            code="PLUGIN_RUNTIME_PREFERENCE_PERSIST_FAILED",
+            message="PLUGIN_RUNTIME_PREFERENCE_PERSIST_FAILED",
+            status_code=500,
+            details={
+                "plugin_id": plugin_id,
+                "enabled": enabled,
+                "auto_start": (
+                    enabled if PLUGIN_SYNC_AUTO_START_ON_TOGGLE else None
+                ),
+                "error_type": type(exc).__name__,
+                "runtime_state_changed": runtime_state_changed,
+            },
+            log_level="error",
+        ) from exc
 
 
 @runtime_checkable
@@ -583,7 +617,12 @@ class PluginLifecycleService:
         if isinstance(existing_host_obj, PluginHostContract):
             if existing_host_obj.is_alive():
                 if persist_user_intent:
-                    await asyncio.to_thread(set_runtime_override, current_plugin_id, True)
+                    await asyncio.to_thread(
+                        _persist_user_runtime_intent,
+                        current_plugin_id,
+                        True,
+                        runtime_state_changed=False,
+                    )
                 _emit_lifecycle_event(event_type="plugin_start_skipped", plugin_id=current_plugin_id)
                 return {
                     "success": True,
@@ -604,7 +643,12 @@ class PluginLifecycleService:
             )
 
         if persist_user_intent:
-            await asyncio.to_thread(set_runtime_override, current_plugin_id, True)
+            await asyncio.to_thread(
+                _persist_user_runtime_intent,
+                current_plugin_id,
+                True,
+                runtime_state_changed=False,
+            )
 
         if refresh_registry:
             try:
@@ -733,6 +777,18 @@ class PluginLifecycleService:
                         runtime_cfg.get("startup_failure"),
                         plugin_id=current_plugin_id,
                     )
+            enabled_override = await asyncio.to_thread(
+                get_runtime_override,
+                current_plugin_id,
+            )
+            if enabled_override is not None:
+                enabled_value = enabled_override
+            auto_start_override = await asyncio.to_thread(
+                get_runtime_auto_start_override,
+                current_plugin_id,
+            )
+            if auto_start_override is not None:
+                auto_start_value = auto_start_override
             if not enabled_value:
                 raise _to_domain_error(
                     code="PLUGIN_DISABLED",
@@ -928,7 +984,12 @@ class PluginLifecycleService:
             registered_plugin_id = current_plugin_id
 
             if persist_user_intent:
-                await asyncio.to_thread(set_runtime_override, current_plugin_id, True)
+                await asyncio.to_thread(
+                    _persist_user_runtime_intent,
+                    current_plugin_id,
+                    True,
+                    runtime_state_changed=True,
+                )
             _emit_lifecycle_event(event_type="plugin_started", plugin_id=current_plugin_id)
             response: dict[str, object] = {
                 "success": True,
@@ -1050,7 +1111,12 @@ class PluginLifecycleService:
                     str(exc),
                 )
             if persist_user_intent:
-                await asyncio.to_thread(set_runtime_override, plugin_id, False)
+                await asyncio.to_thread(
+                    _persist_user_runtime_intent,
+                    plugin_id,
+                    False,
+                    runtime_state_changed=True,
+                )
             _emit_lifecycle_event(event_type="plugin_stopped", plugin_id=plugin_id)
             return {
                 "success": True,

--- a/plugin/server/application/plugins/lifecycle_service.py
+++ b/plugin/server/application/plugins/lifecycle_service.py
@@ -45,6 +45,7 @@ from plugin.server.infrastructure.runtime_overrides import (
     clear_runtime_override,
     get_runtime_auto_start_override,
     get_runtime_override,
+    migrate_runtime_override,
     set_runtime_override,
 )
 from plugin.server.messaging.lifecycle_events import emit_lifecycle_event
@@ -70,14 +71,24 @@ def _persist_user_runtime_intent(
     plugin_id: str,
     enabled: bool,
     *,
+    previous_plugin_ids: tuple[str, ...] = (),
     runtime_state_changed: bool = False,
 ) -> None:
     try:
-        set_runtime_override(
-            plugin_id,
-            enabled,
-            auto_start=enabled if PLUGIN_SYNC_AUTO_START_ON_TOGGLE else None,
-        )
+        auto_start = enabled if PLUGIN_SYNC_AUTO_START_ON_TOGGLE else None
+        if previous_plugin_ids:
+            migrate_runtime_override(
+                previous_plugin_ids,
+                plugin_id,
+                enabled,
+                auto_start=auto_start,
+            )
+        else:
+            set_runtime_override(
+                plugin_id,
+                enabled,
+                auto_start=auto_start,
+            )
     except RuntimeOverridePersistenceError as exc:
         raise ServerDomainError(
             code="PLUGIN_RUNTIME_PREFERENCE_PERSIST_FAILED",
@@ -94,6 +105,46 @@ def _persist_user_runtime_intent(
             },
             log_level="error",
         ) from exc
+
+
+def _mark_preference_persistence_failure(
+    response: dict[str, object],
+    error: ServerDomainError,
+) -> None:
+    details = error.details if isinstance(error.details, dict) else {}
+    response["partial_success"] = True
+    response["preference_persisted"] = False
+    response["preference_error"] = {
+        "code": error.code,
+        "error_type": str(details.get("error_type", "RuntimeOverridePersistenceError")),
+    }
+    response["runtime_state_changed"] = bool(details.get("runtime_state_changed", False))
+
+
+async def _persist_changed_runtime_intent(
+    response: dict[str, object],
+    plugin_id: str,
+    enabled: bool,
+    *,
+    previous_plugin_ids: tuple[str, ...] = (),
+) -> None:
+    try:
+        await asyncio.to_thread(
+            _persist_user_runtime_intent,
+            plugin_id,
+            enabled,
+            previous_plugin_ids=previous_plugin_ids,
+            runtime_state_changed=True,
+        )
+        response["preference_persisted"] = True
+    except ServerDomainError as exc:
+        logger.error(
+            "plugin runtime state changed but user preference could not be persisted: plugin_id={}, enabled={}, err_type={}",
+            plugin_id,
+            enabled,
+            type(exc).__name__,
+        )
+        _mark_preference_persistence_failure(response, exc)
 
 
 @runtime_checkable
@@ -612,6 +663,7 @@ class PluginLifecycleService:
         start_time = time_module.perf_counter()
         original_plugin_id = plugin_id
         current_plugin_id = plugin_id
+        resolved_plugin_ids = [plugin_id]
 
         existing_host_obj = await asyncio.to_thread(_get_plugin_host_sync, current_plugin_id)
         if isinstance(existing_host_obj, PluginHostContract):
@@ -642,19 +694,13 @@ class PluginLifecycleService:
                 error_type="PluginFrozen",
             )
 
-        if persist_user_intent:
-            await asyncio.to_thread(
-                _persist_user_runtime_intent,
-                current_plugin_id,
-                True,
-                runtime_state_changed=False,
-            )
-
         if refresh_registry:
             try:
                 refresh_payload = await plugin_registry_service.refresh_plugin(current_plugin_id)
                 refreshed_plugin_id = refresh_payload.get("plugin_id")
                 if isinstance(refreshed_plugin_id, str) and refreshed_plugin_id:
+                    if refreshed_plugin_id != current_plugin_id:
+                        resolved_plugin_ids.append(refreshed_plugin_id)
                     current_plugin_id = refreshed_plugin_id
             except ServerDomainError as exc:
                 if exc.code == "PLUGIN_CONFIG_NOT_FOUND":
@@ -789,6 +835,14 @@ class PluginLifecycleService:
             )
             if auto_start_override is not None:
                 auto_start_value = auto_start_override
+            if persist_user_intent:
+                # An explicit start request is the new enabled intent. Apply it
+                # in-memory for this attempt, but do not persist until startup
+                # succeeds; otherwise validation/start failures become durable
+                # auto-start preferences.
+                enabled_value = True
+                if PLUGIN_SYNC_AUTO_START_ON_TOGGLE:
+                    auto_start_value = True
             if not enabled_value:
                 raise _to_domain_error(
                     code="PLUGIN_DISABLED",
@@ -983,13 +1037,6 @@ class PluginLifecycleService:
             await asyncio.to_thread(_register_or_replace_host_sync, current_plugin_id, host_obj)
             registered_plugin_id = current_plugin_id
 
-            if persist_user_intent:
-                await asyncio.to_thread(
-                    _persist_user_runtime_intent,
-                    current_plugin_id,
-                    True,
-                    runtime_state_changed=True,
-                )
             _emit_lifecycle_event(event_type="plugin_started", plugin_id=current_plugin_id)
             response: dict[str, object] = {
                 "success": True,
@@ -1012,6 +1059,18 @@ class PluginLifecycleService:
                         f"Plugin started successfully (renamed from '{original_plugin_id}' to "
                         f"'{current_plugin_id}' due to ID conflict)"
                     )
+            if persist_user_intent:
+                stale_plugin_ids = tuple(
+                    plugin_id
+                    for plugin_id in resolved_plugin_ids
+                    if plugin_id != current_plugin_id
+                )
+                await _persist_changed_runtime_intent(
+                    response,
+                    current_plugin_id,
+                    True,
+                    previous_plugin_ids=stale_plugin_ids,
+                )
             return response
         except ServerDomainError:
             if host_obj is not None:
@@ -1110,19 +1169,19 @@ class PluginLifecycleService:
                     type(exc).__name__,
                     str(exc),
                 )
-            if persist_user_intent:
-                await asyncio.to_thread(
-                    _persist_user_runtime_intent,
-                    plugin_id,
-                    False,
-                    runtime_state_changed=True,
-                )
             _emit_lifecycle_event(event_type="plugin_stopped", plugin_id=plugin_id)
-            return {
+            response: dict[str, object] = {
                 "success": True,
                 "plugin_id": plugin_id,
                 "message": "Plugin stopped successfully",
             }
+            if persist_user_intent:
+                await _persist_changed_runtime_intent(
+                    response,
+                    plugin_id,
+                    False,
+                )
+            return response
         except PluginError as exc:
             logger.error(
                 "stop_plugin failed with PluginError: plugin_id={}, err_type={}, err={}",

--- a/plugin/server/infrastructure/runtime_overrides.py
+++ b/plugin/server/infrastructure/runtime_overrides.py
@@ -11,9 +11,9 @@ next registry scan the override is layered on top of the manifest's default so
 the user's choice survives restarts.
 
 Only entries the user actually toggled are stored; the file is intentionally
-small and append-only sparse so that re-installing or upgrading a plugin still
-inherits its manifest default unless the user already had an explicit
-preference.
+small and sparse so that re-installing or upgrading a plugin still inherits
+its manifest defaults unless the user already had an explicit preference.
+Legacy boolean entries remain valid and represent an ``enabled`` override only.
 """
 
 from __future__ import annotations
@@ -28,52 +28,99 @@ logger = get_logger("server.infrastructure.runtime_overrides")
 OVERRIDES_FILENAME = "plugin_runtime_overrides.json"
 
 _cache_lock = threading.Lock()
-_cache: dict[str, bool] | None = None
+RuntimeOverride = bool | dict[str, bool]
+
+_cache: dict[str, RuntimeOverride] | None = None
 
 
-def _coerce_overrides(raw: object) -> dict[str, bool]:
+class RuntimeOverridePersistenceError(OSError):
+    """Base error for durable runtime-preference storage failures."""
+
+
+class RuntimeOverrideReadError(RuntimeOverridePersistenceError):
+    """The persisted runtime preferences could not be read safely."""
+
+
+class RuntimeOverrideWriteError(RuntimeOverridePersistenceError):
+    """Runtime preferences could not be committed to durable storage."""
+
+
+def _coerce_overrides(raw: object) -> dict[str, RuntimeOverride]:
     if not isinstance(raw, Mapping):
-        return {}
-    result: dict[str, bool] = {}
+        raise RuntimeOverrideReadError(
+            f"{OVERRIDES_FILENAME} must contain a JSON object"
+        )
+    result: dict[str, RuntimeOverride] = {}
     for key, value in raw.items():
-        if isinstance(key, str) and isinstance(value, bool):
+        if not isinstance(key, str):
+            raise RuntimeOverrideReadError(
+                f"{OVERRIDES_FILENAME} contains an invalid plugin id"
+            )
+        if isinstance(value, bool):
             result[key] = value
+            continue
+        if isinstance(value, Mapping):
+            unknown_fields = set(value) - {"enabled", "auto_start"}
+            invalid_fields = {
+                field
+                for field in ("enabled", "auto_start")
+                if field in value and not isinstance(value[field], bool)
+            }
+            if unknown_fields or invalid_fields or not value:
+                raise RuntimeOverrideReadError(
+                    f"{OVERRIDES_FILENAME} contains invalid fields for plugin {key!r}"
+                )
+            normalized = {
+                field: field_value
+                for field in ("enabled", "auto_start")
+                if isinstance((field_value := value.get(field)), bool)
+            }
+            result[key] = normalized
+            continue
+        raise RuntimeOverrideReadError(
+            f"{OVERRIDES_FILENAME} contains an invalid entry for plugin {key!r}"
+        )
     return result
 
 
-def _load_from_disk() -> dict[str, bool]:
+def _load_from_disk() -> dict[str, RuntimeOverride]:
     try:
         from utils.config_manager import get_config_manager
 
         cm = get_config_manager()
-        raw = cm.load_json_config(OVERRIDES_FILENAME, default_value={})
+        raw = cm.load_json_config(OVERRIDES_FILENAME)
     except FileNotFoundError:
         return {}
     except Exception as exc:
-        logger.warning(
+        logger.error(
             "Failed to load plugin runtime overrides from {}: {}",
             OVERRIDES_FILENAME,
             exc,
         )
-        return {}
+        raise RuntimeOverrideReadError(
+            f"Failed to load plugin runtime overrides from {OVERRIDES_FILENAME}"
+        ) from exc
     return _coerce_overrides(raw)
 
 
-def _save_to_disk(overrides: dict[str, bool]) -> None:
+def _save_to_disk(overrides: dict[str, RuntimeOverride]) -> None:
     try:
         from utils.config_manager import get_config_manager
 
         cm = get_config_manager()
         cm.save_json_config(OVERRIDES_FILENAME, dict(overrides))
     except Exception as exc:
-        logger.warning(
+        logger.error(
             "Failed to persist plugin runtime overrides to {}: {}",
             OVERRIDES_FILENAME,
             exc,
         )
+        raise RuntimeOverrideWriteError(
+            f"Failed to persist plugin runtime overrides to {OVERRIDES_FILENAME}"
+        ) from exc
 
 
-def load_runtime_overrides() -> dict[str, bool]:
+def load_runtime_overrides() -> dict[str, RuntimeOverride]:
     """Return a snapshot of the persisted overrides; loads on first access."""
     global _cache
     with _cache_lock:
@@ -86,11 +133,37 @@ def get_runtime_override(plugin_id: str) -> bool | None:
     """Return the persisted override for ``plugin_id`` or ``None`` if unset."""
     if not plugin_id:
         return None
-    return load_runtime_overrides().get(plugin_id)
+    override = load_runtime_overrides().get(plugin_id)
+    if isinstance(override, bool):
+        return override
+    if isinstance(override, Mapping):
+        enabled = override.get("enabled")
+        return enabled if isinstance(enabled, bool) else None
+    return None
 
 
-def set_runtime_override(plugin_id: str, enabled: bool) -> None:
-    """Persist ``enabled`` as the user's override for ``plugin_id``.
+def get_runtime_auto_start_override(plugin_id: str) -> bool | None:
+    """Return the user's auto-start preference, if one was persisted."""
+    if not plugin_id:
+        return None
+    override = load_runtime_overrides().get(plugin_id)
+    if not isinstance(override, Mapping):
+        return None
+    auto_start = override.get("auto_start")
+    return auto_start if isinstance(auto_start, bool) else None
+
+
+def set_runtime_override(
+    plugin_id: str,
+    enabled: bool,
+    *,
+    auto_start: bool | None = None,
+) -> None:
+    """Persist user runtime preferences for ``plugin_id``.
+
+    ``enabled`` is always updated. When ``auto_start`` is omitted, an existing
+    auto-start preference is preserved; when provided, both fields are stored
+    together.
 
     The disk write happens while ``_cache_lock`` is still held so that two
     concurrent toggles cannot race and overwrite each other with stale
@@ -102,10 +175,22 @@ def set_runtime_override(plugin_id: str, enabled: bool) -> None:
     with _cache_lock:
         if _cache is None:
             _cache = _load_from_disk()
-        if _cache.get(plugin_id) == enabled:
+        new_value: RuntimeOverride
+        if auto_start is None:
+            existing = _cache.get(plugin_id)
+            if isinstance(existing, Mapping):
+                new_value = dict(existing)
+                new_value["enabled"] = enabled
+            else:
+                new_value = enabled
+        else:
+            new_value = {"enabled": enabled, "auto_start": auto_start}
+        if _cache.get(plugin_id) == new_value:
             return
-        _cache[plugin_id] = enabled
-        _save_to_disk(dict(_cache))
+        candidate = dict(_cache)
+        candidate[plugin_id] = new_value
+        _save_to_disk(candidate)
+        _cache = candidate
 
 
 def clear_runtime_override(plugin_id: str) -> None:
@@ -122,8 +207,10 @@ def clear_runtime_override(plugin_id: str) -> None:
             _cache = _load_from_disk()
         if plugin_id not in _cache:
             return
-        _cache.pop(plugin_id, None)
-        _save_to_disk(dict(_cache))
+        candidate = dict(_cache)
+        candidate.pop(plugin_id, None)
+        _save_to_disk(candidate)
+        _cache = candidate
 
 
 def reset_cache_for_testing() -> None:

--- a/plugin/server/infrastructure/runtime_overrides.py
+++ b/plugin/server/infrastructure/runtime_overrides.py
@@ -19,7 +19,7 @@ Legacy boolean entries remain valid and represent an ``enabled`` override only.
 from __future__ import annotations
 
 import threading
-from typing import Mapping
+from typing import Iterable, Mapping
 
 from plugin.logging_config import get_logger
 
@@ -31,6 +31,7 @@ _cache_lock = threading.Lock()
 RuntimeOverride = bool | dict[str, bool]
 
 _cache: dict[str, RuntimeOverride] | None = None
+_cache_write_blocked_by_invalid_content = False
 
 
 class RuntimeOverridePersistenceError(OSError):
@@ -45,17 +46,23 @@ class RuntimeOverrideWriteError(RuntimeOverridePersistenceError):
     """Runtime preferences could not be committed to durable storage."""
 
 
-def _coerce_overrides(raw: object) -> dict[str, RuntimeOverride]:
+def _coerce_overrides_with_status(
+    raw: object,
+) -> tuple[dict[str, RuntimeOverride], bool]:
     if not isinstance(raw, Mapping):
         raise RuntimeOverrideReadError(
             f"{OVERRIDES_FILENAME} must contain a JSON object"
         )
     result: dict[str, RuntimeOverride] = {}
+    invalid_content_found = False
     for key, value in raw.items():
         if not isinstance(key, str):
-            raise RuntimeOverrideReadError(
-                f"{OVERRIDES_FILENAME} contains an invalid plugin id"
+            invalid_content_found = True
+            logger.warning(
+                "Ignoring runtime override with invalid plugin id in {}",
+                OVERRIDES_FILENAME,
             )
+            continue
         if isinstance(value, bool):
             result[key] = value
             continue
@@ -66,30 +73,61 @@ def _coerce_overrides(raw: object) -> dict[str, RuntimeOverride]:
                 for field in ("enabled", "auto_start")
                 if field in value and not isinstance(value[field], bool)
             }
-            if unknown_fields or invalid_fields or not value:
-                raise RuntimeOverrideReadError(
-                    f"{OVERRIDES_FILENAME} contains invalid fields for plugin {key!r}"
+            if unknown_fields:
+                invalid_content_found = True
+                logger.warning(
+                    "Ignoring unknown runtime override fields for plugin {} in {}: {}",
+                    key,
+                    OVERRIDES_FILENAME,
+                    sorted(str(field) for field in unknown_fields),
                 )
+            if invalid_fields:
+                invalid_content_found = True
+                logger.warning(
+                    "Ignoring runtime override entry with invalid fields for plugin {} in {}: {}",
+                    key,
+                    OVERRIDES_FILENAME,
+                    sorted(invalid_fields),
+                )
+                continue
             normalized = {
                 field: field_value
                 for field in ("enabled", "auto_start")
                 if isinstance((field_value := value.get(field)), bool)
             }
-            result[key] = normalized
+            if normalized:
+                result[key] = normalized
+            else:
+                invalid_content_found = True
+                logger.warning(
+                    "Ignoring invalid runtime override entry for plugin {} in {}",
+                    key,
+                    OVERRIDES_FILENAME,
+                )
             continue
-        raise RuntimeOverrideReadError(
-            f"{OVERRIDES_FILENAME} contains an invalid entry for plugin {key!r}"
+        invalid_content_found = True
+        logger.warning(
+            "Ignoring invalid runtime override entry for plugin {} in {}",
+            key,
+            OVERRIDES_FILENAME,
         )
+    return result, invalid_content_found
+
+
+def _coerce_overrides(raw: object) -> dict[str, RuntimeOverride]:
+    result, _invalid_content_found = _coerce_overrides_with_status(raw)
     return result
 
 
 def _load_from_disk() -> dict[str, RuntimeOverride]:
+    global _cache_write_blocked_by_invalid_content
     try:
         from utils.config_manager import get_config_manager
 
         cm = get_config_manager()
         raw = cm.load_json_config(OVERRIDES_FILENAME)
     except FileNotFoundError:
+        _cache_write_blocked_by_invalid_content = False
         return {}
     except Exception as exc:
         logger.error(
@@ -100,7 +138,16 @@ def _load_from_disk() -> dict[str, RuntimeOverride]:
         raise RuntimeOverrideReadError(
             f"Failed to load plugin runtime overrides from {OVERRIDES_FILENAME}"
         ) from exc
-    return _coerce_overrides(raw)
+    overrides, invalid_content_found = _coerce_overrides_with_status(raw)
+    _cache_write_blocked_by_invalid_content = invalid_content_found
+    return overrides
+
+
+def _ensure_cache_can_be_written() -> None:
+    if _cache_write_blocked_by_invalid_content:
+        raise RuntimeOverrideWriteError(
+            f"Refusing to overwrite {OVERRIDES_FILENAME} because it contains invalid content"
+        )
 
 
 def _save_to_disk(overrides: dict[str, RuntimeOverride]) -> None:
@@ -126,14 +173,33 @@ def load_runtime_overrides() -> dict[str, RuntimeOverride]:
     with _cache_lock:
         if _cache is None:
             _cache = _load_from_disk()
-        return dict(_cache)
+        return {
+            plugin_id: dict(override) if isinstance(override, Mapping) else override
+            for plugin_id, override in _cache.items()
+        }
+
+
+def _get_runtime_override_entry(plugin_id: str) -> RuntimeOverride | None:
+    if not plugin_id:
+        return None
+    try:
+        return load_runtime_overrides().get(plugin_id)
+    except RuntimeOverrideReadError as exc:
+        # Runtime preferences are an optional layer over the manifest. A damaged
+        # preferences file must not make every plugin undiscoverable or prevent a
+        # direct/autostart attempt from falling back to manifest defaults. Writes
+        # remain strict, so a later toggle cannot silently overwrite that file.
+        logger.warning(
+            "Ignoring unreadable plugin runtime overrides for plugin {}: {}",
+            plugin_id,
+            exc,
+        )
+        return None
 
 
 def get_runtime_override(plugin_id: str) -> bool | None:
     """Return the persisted override for ``plugin_id`` or ``None`` if unset."""
-    if not plugin_id:
-        return None
-    override = load_runtime_overrides().get(plugin_id)
+    override = _get_runtime_override_entry(plugin_id)
     if isinstance(override, bool):
         return override
     if isinstance(override, Mapping):
@@ -144,9 +210,7 @@ def get_runtime_override(plugin_id: str) -> bool | None:
 
 def get_runtime_auto_start_override(plugin_id: str) -> bool | None:
     """Return the user's auto-start preference, if one was persisted."""
-    if not plugin_id:
-        return None
-    override = load_runtime_overrides().get(plugin_id)
+    override = _get_runtime_override_entry(plugin_id)
     if not isinstance(override, Mapping):
         return None
     auto_start = override.get("auto_start")
@@ -189,6 +253,66 @@ def set_runtime_override(
             return
         candidate = dict(_cache)
         candidate[plugin_id] = new_value
+        _ensure_cache_can_be_written()
+        _save_to_disk(candidate)
+        _cache = candidate
+
+
+def migrate_runtime_override(
+    stale_plugin_ids: Iterable[str],
+    target_plugin_id: str,
+    enabled: bool,
+    *,
+    auto_start: bool | None = None,
+) -> None:
+    """Migrate and update a preference after runtime plugin-ID resolution.
+
+    All stale-ID removals and the target update are committed in one disk write
+    while holding ``_cache_lock``. This covers multi-stage ID resolution, such as
+    a registry refresh followed by a load-time conflict rename.
+    """
+    if not target_plugin_id:
+        return
+    stale_ids = tuple(
+        dict.fromkeys(
+            plugin_id
+            for plugin_id in stale_plugin_ids
+            if plugin_id and plugin_id != target_plugin_id
+        )
+    )
+    if not stale_ids:
+        set_runtime_override(target_plugin_id, enabled, auto_start=auto_start)
+        return
+
+    global _cache
+    with _cache_lock:
+        if _cache is None:
+            _cache = _load_from_disk()
+
+        existing = next(
+            (
+                _cache[plugin_id]
+                for plugin_id in reversed(stale_ids)
+                if plugin_id in _cache
+            ),
+            _cache.get(target_plugin_id),
+        )
+        if auto_start is None:
+            if isinstance(existing, Mapping):
+                new_value: RuntimeOverride = dict(existing)
+                new_value["enabled"] = enabled
+            else:
+                new_value = enabled
+        else:
+            new_value = {"enabled": enabled, "auto_start": auto_start}
+
+        candidate = dict(_cache)
+        for plugin_id in stale_ids:
+            candidate.pop(plugin_id, None)
+        candidate[target_plugin_id] = new_value
+        if candidate == _cache:
+            return
+        _ensure_cache_can_be_written()
         _save_to_disk(candidate)
         _cache = candidate
 
@@ -209,12 +333,14 @@ def clear_runtime_override(plugin_id: str) -> None:
             return
         candidate = dict(_cache)
         candidate.pop(plugin_id, None)
+        _ensure_cache_can_be_written()
         _save_to_disk(candidate)
         _cache = candidate
 
 
 def reset_cache_for_testing() -> None:
     """Reset in-memory cache; intended for tests that swap the underlying store."""
-    global _cache
+    global _cache, _cache_write_blocked_by_invalid_content
     with _cache_lock:
         _cache = None
+        _cache_write_blocked_by_invalid_content = False

--- a/plugin/settings.py
+++ b/plugin/settings.py
@@ -209,6 +209,15 @@ PLUGIN_TRIGGER_TIMEOUT = _get_float_env("NEKO_PLUGIN_TRIGGER_TIMEOUT", 10.0)
 # Env: NEKO_PLUGIN_STARTUP_TIMEOUT, default=10.0
 PLUGIN_STARTUP_TIMEOUT = _get_float_env("NEKO_PLUGIN_STARTUP_TIMEOUT", 10.0)
 
+# Keep the next-launch auto-start preference in sync with explicit user
+# start/stop actions from the plugin manager. Internal lifecycle operations do
+# not persist user intent and therefore do not change auto-start.
+# Env: NEKO_PLUGIN_SYNC_AUTO_START_ON_TOGGLE, default=True
+PLUGIN_SYNC_AUTO_START_ON_TOGGLE = _get_bool_env(
+    "NEKO_PLUGIN_SYNC_AUTO_START_ON_TOGGLE",
+    True,
+)
+
 # 单个插件优雅关闭的超时时间
 # Env: NEKO_PLUGIN_SHUTDOWN_TIMEOUT, default=1.5
 # 用于 ``host.shutdown``，超过后会进入更激进的终止流程。

--- a/plugin/tests/unit/server/test_plugin_registry_service.py
+++ b/plugin/tests/unit/server/test_plugin_registry_service.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from plugin.server.application.plugins import registry_service as module
+from plugin.server.infrastructure import runtime_overrides
 
 
 pytestmark = pytest.mark.plugin_unit
@@ -184,6 +185,37 @@ async def test_refresh_registry_syncs_metadata_and_marks_missing_running_plugin(
         with module.state.acquire_plugin_hosts_write_lock():
             module.state.plugin_hosts.clear()
             module.state.plugin_hosts.update(hosts_backup)
+        with module.state._snapshot_cache_lock:
+            module.state._snapshot_cache = cache_backup
+
+
+@pytest.mark.asyncio
+async def test_refresh_registry_applies_user_auto_start_override(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = _write_plugin_fixture(tmp_path, "remembered_plugin")
+    plugins_backup = copy.deepcopy(module.state.plugins)
+    cache_backup = copy.deepcopy(module.state._snapshot_cache)
+
+    try:
+        runtime_overrides.set_runtime_override(
+            "remembered_plugin",
+            True,
+            auto_start=True,
+        )
+        monkeypatch.setattr(module, "PLUGIN_CONFIG_ROOTS", (root,))
+
+        await module.PluginRegistryService().refresh_registry()
+
+        with module.state.acquire_plugins_read_lock():
+            plugin_meta = dict(module.state.plugins["remembered_plugin"])
+        assert plugin_meta["runtime_enabled"] is True
+        assert plugin_meta["runtime_auto_start"] is True
+    finally:
+        with module.state.acquire_plugins_write_lock():
+            module.state.plugins.clear()
+            module.state.plugins.update(plugins_backup)
         with module.state._snapshot_cache_lock:
             module.state._snapshot_cache = cache_backup
 

--- a/plugin/tests/unit/server/test_plugin_registry_service.py
+++ b/plugin/tests/unit/server/test_plugin_registry_service.py
@@ -221,6 +221,56 @@ async def test_refresh_registry_applies_user_auto_start_override(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "load_overrides",
+    [
+        lambda: (_ for _ in ()).throw(
+            runtime_overrides.RuntimeOverrideReadError("invalid json")
+        ),
+        lambda: runtime_overrides._coerce_overrides(
+            {
+                "manifest_plugin": {
+                    "enabled": False,
+                    "auto_start": "yes",
+                }
+            }
+        ),
+    ],
+    ids=("unreadable-file", "invalid-plugin-entry"),
+)
+async def test_refresh_registry_uses_manifest_defaults_when_overrides_are_invalid(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    load_overrides,
+) -> None:
+    root = _write_plugin_fixture(tmp_path, "manifest_plugin")
+    plugins_backup = copy.deepcopy(module.state.plugins)
+    cache_backup = copy.deepcopy(module.state._snapshot_cache)
+
+    monkeypatch.setattr(
+        runtime_overrides,
+        "_load_from_disk",
+        load_overrides,
+    )
+    runtime_overrides.reset_cache_for_testing()
+    monkeypatch.setattr(module, "PLUGIN_CONFIG_ROOTS", (root,))
+
+    try:
+        await module.PluginRegistryService().refresh_registry()
+
+        with module.state.acquire_plugins_read_lock():
+            plugin_meta = dict(module.state.plugins["manifest_plugin"])
+        assert plugin_meta["runtime_enabled"] is True
+        assert plugin_meta["runtime_auto_start"] is False
+    finally:
+        with module.state.acquire_plugins_write_lock():
+            module.state.plugins.clear()
+            module.state.plugins.update(plugins_backup)
+        with module.state._snapshot_cache_lock:
+            module.state._snapshot_cache = cache_backup
+
+
+@pytest.mark.asyncio
 async def test_refresh_plugin_returns_updated_status_for_existing_plugin(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/plugin/tests/unit/server/test_plugins_lifecycle_service.py
+++ b/plugin/tests/unit/server/test_plugins_lifecycle_service.py
@@ -116,6 +116,49 @@ def test_get_plugin_config_path_returns_none_for_missing_file(monkeypatch: pytes
 
 
 @pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_start_plugin_already_running_reports_preference_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "running_plugin" / "plugin.toml"
+    host = _FakeProcessHost(
+        plugin_id="running_plugin",
+        entry_point="tests.fake:Plugin",
+        config_path=config_path,
+    )
+    hosts_backup = dict(module.state.plugin_hosts)
+
+    monkeypatch.setattr(
+        module,
+        "set_runtime_override",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            runtime_overrides_module.RuntimeOverrideWriteError("disk full")
+        ),
+    )
+
+    try:
+        with module.state.acquire_plugin_hosts_write_lock():
+            module.state.plugin_hosts.clear()
+            module.state.plugin_hosts["running_plugin"] = host
+
+        with pytest.raises(ServerDomainError) as exc_info:
+            await module.PluginLifecycleService().start_plugin(
+                "running_plugin",
+                persist_user_intent=True,
+            )
+
+        assert exc_info.value.code == "PLUGIN_RUNTIME_PREFERENCE_PERSIST_FAILED"
+        assert exc_info.value.details["runtime_state_changed"] is False
+        with module.state.acquire_plugin_hosts_read_lock():
+            assert module.state.plugin_hosts["running_plugin"] is host
+    finally:
+        with module.state.acquire_plugin_hosts_write_lock():
+            module.state.plugin_hosts.clear()
+            module.state.plugin_hosts.update(hosts_backup)
+
+
+@pytest.mark.plugin_unit
 def test_parse_single_plugin_config_warns_on_directory_id_mismatch(
     tmp_path: Path,
 ) -> None:
@@ -311,10 +354,22 @@ async def test_start_plugin_refreshes_registry_before_loading(
 
 @pytest.mark.plugin_unit
 @pytest.mark.asyncio
-async def test_start_plugin_persist_user_intent_sets_effective_auto_start_before_refresh(
+@pytest.mark.parametrize(
+    ("persist_fails", "refreshed_plugin_id", "resolved_plugin_id"),
+    [
+        (False, "demo_plugin", "demo_plugin"),
+        (True, "demo_plugin", "demo_plugin"),
+        (False, "refreshed_plugin", "resolved_plugin"),
+    ],
+    ids=("success", "persistence-failure", "multi-stage-id-resolution"),
+)
+async def test_start_plugin_persists_intent_after_success_and_migrates_resolved_ids(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     _isolate_runtime_overrides: dict,
+    persist_fails: bool,
+    refreshed_plugin_id: str,
+    resolved_plugin_id: str,
 ) -> None:
     config_path = tmp_path / "demo_plugin" / "plugin.toml"
     config_path.parent.mkdir(parents=True)
@@ -339,12 +394,12 @@ async def test_start_plugin_persist_user_intent_sets_effective_auto_start_before
     async def _refresh_plugin(plugin_id: str) -> dict[str, object]:
         seen["override_at_refresh"] = runtime_overrides_module.get_runtime_override(plugin_id)
         with module.state.acquire_plugins_write_lock():
-            module.state.plugins[plugin_id] = {
-                "id": plugin_id,
+            module.state.plugins[refreshed_plugin_id] = {
+                "id": refreshed_plugin_id,
                 "runtime_enabled": True,
                 "runtime_auto_start": True,
             }
-        return {"success": True, "plugin_id": plugin_id}
+        return {"success": True, "plugin_id": refreshed_plugin_id}
 
     async def _list_extension_configs_for_host(_plugin_id: str) -> list[dict[str, str]]:
         return []
@@ -360,7 +415,7 @@ async def test_start_plugin_persist_user_intent_sets_effective_auto_start_before
             "warnings": [],
         },
     )
-    monkeypatch.setattr(module, "_resolve_plugin_id_conflict", lambda *args, **kwargs: args[0])
+    monkeypatch.setattr(module, "_resolve_plugin_id_conflict", lambda *args, **kwargs: resolved_plugin_id)
     monkeypatch.setattr(module, "_find_missing_python_requirements", lambda *args, **kwargs: [])
     monkeypatch.setattr(module, "PluginProcessHost", _FakeProcessHost)
     monkeypatch.setattr(module, "_import_plugin_module", lambda *args, **kwargs: SimpleNamespace(Plugin=type("Plugin", (), {})))
@@ -377,16 +432,45 @@ async def test_start_plugin_persist_user_intent_sets_effective_auto_start_before
             module.state.plugin_hosts.clear()
 
         runtime_overrides_module.set_runtime_override("demo_plugin", False)
+        if refreshed_plugin_id != "demo_plugin":
+            runtime_overrides_module.set_runtime_override(
+                refreshed_plugin_id,
+                False,
+                auto_start=False,
+            )
+
+        if persist_fails:
+            def _fail_persist(*_args, **_kwargs) -> None:
+                raise ServerDomainError(
+                    code="PLUGIN_RUNTIME_PREFERENCE_PERSIST_FAILED",
+                    message="PLUGIN_RUNTIME_PREFERENCE_PERSIST_FAILED",
+                    status_code=500,
+                    details={
+                        "error_type": "RuntimeOverrideWriteError",
+                        "runtime_state_changed": True,
+                    },
+                )
+
+            monkeypatch.setattr(module, "_persist_user_runtime_intent", _fail_persist)
 
         response = await module.PluginLifecycleService().start_plugin("demo_plugin", persist_user_intent=True)
 
         assert response["success"] is True
-        assert seen["override_at_refresh"] is True
-        assert _isolate_runtime_overrides == {
-            "demo_plugin": {"enabled": True, "auto_start": True},
-        }
-        with module.state.acquire_plugins_read_lock():
-            assert module.state.plugins["demo_plugin"]["runtime_auto_start"] is True
+        assert seen["override_at_refresh"] is False
+        if persist_fails:
+            assert _isolate_runtime_overrides == {"demo_plugin": False}
+            assert response["partial_success"] is True
+            assert response["preference_persisted"] is False
+            assert response["runtime_state_changed"] is True
+        else:
+            assert _isolate_runtime_overrides == {
+                resolved_plugin_id: {"enabled": True, "auto_start": True},
+            }
+            assert response["preference_persisted"] is True
+        assert response["plugin_id"] == resolved_plugin_id
+        if resolved_plugin_id == "demo_plugin":
+            with module.state.acquire_plugins_read_lock():
+                assert module.state.plugins["demo_plugin"]["runtime_auto_start"] is True
     finally:
         with module.state.acquire_plugins_write_lock():
             module.state.plugins.clear()
@@ -396,6 +480,71 @@ async def test_start_plugin_persist_user_intent_sets_effective_auto_start_before
             module.state.plugin_hosts.update(hosts_backup)
         with module.state._snapshot_cache_lock:
             module.state._snapshot_cache = cache_backup
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_start_plugin_refresh_failure_does_not_persist_user_intent(
+    monkeypatch: pytest.MonkeyPatch,
+    _isolate_runtime_overrides: dict,
+) -> None:
+    runtime_overrides_module.set_runtime_override(
+        "failed_plugin",
+        False,
+        auto_start=False,
+    )
+
+    async def _fail_refresh(_plugin_id: str) -> dict[str, object]:
+        raise ServerDomainError(
+            code="PLUGIN_REGISTRY_CONFLICT",
+            message="conflict",
+            status_code=409,
+        )
+
+    monkeypatch.setattr(module.plugin_registry_service, "refresh_plugin", _fail_refresh)
+
+    with pytest.raises(ServerDomainError) as exc_info:
+        await module.PluginLifecycleService().start_plugin(
+            "failed_plugin",
+            persist_user_intent=True,
+        )
+
+    assert exc_info.value.code == "PLUGIN_REGISTRY_CONFLICT"
+    assert _isolate_runtime_overrides == {
+        "failed_plugin": {"enabled": False, "auto_start": False},
+    }
+
+
+@pytest.mark.plugin_unit
+def test_persist_user_runtime_intent_migrates_resolved_plugin_preferences(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[tuple[str, ...], str, bool, bool | None]] = []
+
+    monkeypatch.setattr(module, "PLUGIN_SYNC_AUTO_START_ON_TOGGLE", True)
+    monkeypatch.setattr(
+        module,
+        "migrate_runtime_override",
+        lambda sources, target, enabled, *, auto_start=None: calls.append(
+            (tuple(sources), target, enabled, auto_start)
+        ),
+    )
+
+    module._persist_user_runtime_intent(
+        "renamed_plugin",
+        True,
+        previous_plugin_ids=("original_plugin", "intermediate_plugin"),
+        runtime_state_changed=True,
+    )
+
+    assert calls == [
+        (
+            ("original_plugin", "intermediate_plugin"),
+            "renamed_plugin",
+            True,
+            True,
+        )
+    ]
 
 
 @pytest.mark.plugin_unit
@@ -2510,7 +2659,7 @@ async def test_stop_plugin_can_leave_auto_start_unchanged_when_sync_is_disabled(
 
 @pytest.mark.plugin_unit
 @pytest.mark.asyncio
-async def test_stop_plugin_reports_preference_write_failure_after_stopping(
+async def test_stop_plugin_returns_partial_success_on_preference_write_failure(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -2534,15 +2683,19 @@ async def test_stop_plugin_reports_preference_write_failure_after_stopping(
             ),
         )
 
-        with pytest.raises(ServerDomainError) as exc_info:
-            await module.PluginLifecycleService().stop_plugin(
-                "demo_plugin",
-                persist_user_intent=True,
-            )
+        response = await module.PluginLifecycleService().stop_plugin(
+            "demo_plugin",
+            persist_user_intent=True,
+        )
 
-        assert exc_info.value.code == "PLUGIN_RUNTIME_PREFERENCE_PERSIST_FAILED"
-        assert exc_info.value.details["enabled"] is False
-        assert exc_info.value.details["runtime_state_changed"] is True
+        assert response["success"] is True
+        assert response["partial_success"] is True
+        assert response["preference_persisted"] is False
+        assert response["runtime_state_changed"] is True
+        assert response["preference_error"] == {
+            "code": "PLUGIN_RUNTIME_PREFERENCE_PERSIST_FAILED",
+            "error_type": "RuntimeOverrideWriteError",
+        }
         with module.state.acquire_plugin_hosts_read_lock():
             assert "demo_plugin" not in module.state.plugin_hosts
     finally:

--- a/plugin/tests/unit/server/test_plugins_lifecycle_service.py
+++ b/plugin/tests/unit/server/test_plugins_lifecycle_service.py
@@ -311,7 +311,7 @@ async def test_start_plugin_refreshes_registry_before_loading(
 
 @pytest.mark.plugin_unit
 @pytest.mark.asyncio
-async def test_start_plugin_persist_user_intent_clears_stop_override_before_refresh(
+async def test_start_plugin_persist_user_intent_sets_effective_auto_start_before_refresh(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     _isolate_runtime_overrides: dict,
@@ -328,7 +328,7 @@ async def test_start_plugin_persist_user_intent_clears_stop_override_before_refr
                 "",
                 "[plugin_runtime]",
                 "enabled = true",
-                "auto_start = true",
+                "auto_start = false",
             ]
         ),
         encoding="utf-8",
@@ -338,6 +338,12 @@ async def test_start_plugin_persist_user_intent_clears_stop_override_before_refr
 
     async def _refresh_plugin(plugin_id: str) -> dict[str, object]:
         seen["override_at_refresh"] = runtime_overrides_module.get_runtime_override(plugin_id)
+        with module.state.acquire_plugins_write_lock():
+            module.state.plugins[plugin_id] = {
+                "id": plugin_id,
+                "runtime_enabled": True,
+                "runtime_auto_start": True,
+            }
         return {"success": True, "plugin_id": plugin_id}
 
     async def _list_extension_configs_for_host(_plugin_id: str) -> list[dict[str, str]]:
@@ -376,7 +382,11 @@ async def test_start_plugin_persist_user_intent_clears_stop_override_before_refr
 
         assert response["success"] is True
         assert seen["override_at_refresh"] is True
-        assert _isolate_runtime_overrides == {"demo_plugin": True}
+        assert _isolate_runtime_overrides == {
+            "demo_plugin": {"enabled": True, "auto_start": True},
+        }
+        with module.state.acquire_plugins_read_lock():
+            assert module.state.plugins["demo_plugin"]["runtime_auto_start"] is True
     finally:
         with module.state.acquire_plugins_write_lock():
             module.state.plugins.clear()
@@ -2392,8 +2402,11 @@ async def test_stop_plugin_persist_user_intent_writes_runtime_override(
 
         service = module.PluginLifecycleService()
         await service.stop_plugin("demo_plugin", persist_user_intent=True)
-        assert _isolate_runtime_overrides == {"demo_plugin": False}
+        assert _isolate_runtime_overrides == {
+            "demo_plugin": {"enabled": False, "auto_start": False},
+        }
         assert runtime_overrides_module.get_runtime_override("demo_plugin") is False
+        assert runtime_overrides_module.get_runtime_auto_start_override("demo_plugin") is False
     finally:
         with module.state.acquire_plugins_write_lock():
             module.state.plugins.clear()
@@ -2433,6 +2446,105 @@ async def test_stop_plugin_internal_call_does_not_touch_override(
         await service.stop_plugin("demo_plugin")
         assert _isolate_runtime_overrides == {"demo_plugin": True}
         assert runtime_overrides_module.get_runtime_override("demo_plugin") is True
+    finally:
+        with module.state.acquire_plugins_write_lock():
+            module.state.plugins.clear()
+            module.state.plugins.update(plugins_backup)
+        with module.state.acquire_plugin_hosts_write_lock():
+            module.state.plugin_hosts.clear()
+            module.state.plugin_hosts.update(hosts_backup)
+        with module.state.acquire_event_handlers_write_lock():
+            module.state.event_handlers.clear()
+            module.state.event_handlers.update(handlers_backup)
+        with module.state._snapshot_cache_lock:
+            module.state._snapshot_cache = cache_backup
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_stop_plugin_can_leave_auto_start_unchanged_when_sync_is_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _isolate_runtime_overrides: dict,
+) -> None:
+    config_path = tmp_path / "demo_plugin" / "plugin.toml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text("[plugin]\nid='demo_plugin'\n", encoding="utf-8")
+
+    plugins_backup = copy.deepcopy(module.state.plugins)
+    hosts_backup = dict(module.state.plugin_hosts)
+    handlers_backup = dict(module.state.event_handlers)
+    cache_backup = copy.deepcopy(module.state._snapshot_cache)
+
+    try:
+        _seed_running_plugin("demo_plugin", config_path)
+        runtime_overrides_module.set_runtime_override(
+            "demo_plugin",
+            True,
+            auto_start=True,
+        )
+        monkeypatch.setattr(module, "PLUGIN_SYNC_AUTO_START_ON_TOGGLE", False)
+        monkeypatch.setattr(module, "emit_lifecycle_event", lambda event: None)
+
+        await module.PluginLifecycleService().stop_plugin(
+            "demo_plugin",
+            persist_user_intent=True,
+        )
+
+        assert _isolate_runtime_overrides == {
+            "demo_plugin": {"enabled": False, "auto_start": True},
+        }
+    finally:
+        with module.state.acquire_plugins_write_lock():
+            module.state.plugins.clear()
+            module.state.plugins.update(plugins_backup)
+        with module.state.acquire_plugin_hosts_write_lock():
+            module.state.plugin_hosts.clear()
+            module.state.plugin_hosts.update(hosts_backup)
+        with module.state.acquire_event_handlers_write_lock():
+            module.state.event_handlers.clear()
+            module.state.event_handlers.update(handlers_backup)
+        with module.state._snapshot_cache_lock:
+            module.state._snapshot_cache = cache_backup
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_stop_plugin_reports_preference_write_failure_after_stopping(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "demo_plugin" / "plugin.toml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text("[plugin]\nid='demo_plugin'\n", encoding="utf-8")
+
+    plugins_backup = copy.deepcopy(module.state.plugins)
+    hosts_backup = dict(module.state.plugin_hosts)
+    handlers_backup = dict(module.state.event_handlers)
+    cache_backup = copy.deepcopy(module.state._snapshot_cache)
+
+    try:
+        _seed_running_plugin("demo_plugin", config_path)
+        monkeypatch.setattr(module, "emit_lifecycle_event", lambda event: None)
+        monkeypatch.setattr(
+            module,
+            "set_runtime_override",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                runtime_overrides_module.RuntimeOverrideWriteError("disk full")
+            ),
+        )
+
+        with pytest.raises(ServerDomainError) as exc_info:
+            await module.PluginLifecycleService().stop_plugin(
+                "demo_plugin",
+                persist_user_intent=True,
+            )
+
+        assert exc_info.value.code == "PLUGIN_RUNTIME_PREFERENCE_PERSIST_FAILED"
+        assert exc_info.value.details["enabled"] is False
+        assert exc_info.value.details["runtime_state_changed"] is True
+        with module.state.acquire_plugin_hosts_read_lock():
+            assert "demo_plugin" not in module.state.plugin_hosts
     finally:
         with module.state.acquire_plugins_write_lock():
             module.state.plugins.clear()

--- a/plugin/tests/unit/server/test_runtime_overrides.py
+++ b/plugin/tests/unit/server/test_runtime_overrides.py
@@ -84,12 +84,17 @@ def test_runtime_overrides_ignore_blank_plugin_id(_isolate_runtime_overrides):
 
 
 @pytest.mark.plugin_unit
-def test_coerce_overrides_rejects_invalid_entries():
-    with pytest.raises(ro.RuntimeOverrideReadError, match="invalid entry"):
-        ro._coerce_overrides({"good": True, "bad": "yes"})
-
-    with pytest.raises(ro.RuntimeOverrideReadError, match="invalid fields"):
-        ro._coerce_overrides({"bad": {"enabled": "yes"}})
+def test_coerce_overrides_skips_invalid_entries_and_keeps_valid_entries():
+    assert ro._coerce_overrides(
+        {
+            "good": True,
+            "bad_entry": "yes",
+            "bad_fields": {"enabled": "yes"},
+            "mixed": {"enabled": False, "auto_start": "yes", "legacy": True},
+        }
+    ) == {
+        "good": True,
+    }
 
 
 @pytest.mark.plugin_unit
@@ -146,6 +151,91 @@ def test_runtime_override_read_error_is_not_treated_as_empty_or_cached(monkeypat
 
     monkeypatch.setattr(ro, "_load_from_disk", lambda: {"recovered": True})
     assert ro.load_runtime_overrides() == {"recovered": True}
+
+
+@pytest.mark.plugin_unit
+def test_runtime_override_getters_fall_back_when_file_is_unreadable(monkeypatch):
+    monkeypatch.setattr(
+        ro,
+        "_load_from_disk",
+        lambda: (_ for _ in ()).throw(ro.RuntimeOverrideReadError("invalid json")),
+    )
+    ro.reset_cache_for_testing()
+
+    assert ro.get_runtime_override("demo") is None
+    assert ro.get_runtime_auto_start_override("demo") is None
+
+
+@pytest.mark.plugin_unit
+def test_tolerated_invalid_entries_cannot_be_silently_overwritten(monkeypatch):
+    saved: list[dict[str, ro.RuntimeOverride]] = []
+
+    class _ConfigManager:
+        def load_json_config(self, _filename):
+            return {
+                "valid": True,
+                "invalid": "yes",
+                "partially_invalid": {"enabled": False, "auto_start": "yes"},
+            }
+
+        def save_json_config(self, _filename, overrides):
+            saved.append(dict(overrides))
+
+    monkeypatch.setattr(config_manager_module, "get_config_manager", lambda: _ConfigManager())
+    monkeypatch.setattr(ro, "_load_from_disk", _ORIGINAL_LOAD_FROM_DISK)
+    ro.reset_cache_for_testing()
+
+    assert ro.get_runtime_override("valid") is True
+    assert ro.get_runtime_override("invalid") is None
+    assert ro.get_runtime_override("partially_invalid") is None
+    assert ro.get_runtime_auto_start_override("partially_invalid") is None
+    with pytest.raises(ro.RuntimeOverrideWriteError, match="invalid content"):
+        ro.set_runtime_override("valid", False)
+    assert saved == []
+
+
+@pytest.mark.plugin_unit
+def test_load_runtime_overrides_returns_independent_nested_snapshot(
+    _isolate_runtime_overrides,
+):
+    ro.set_runtime_override("demo", True, auto_start=True)
+
+    snapshot = ro.load_runtime_overrides()
+    assert isinstance(snapshot["demo"], dict)
+    snapshot["demo"]["auto_start"] = False
+
+    assert ro.load_runtime_overrides() == {
+        "demo": {"enabled": True, "auto_start": True},
+    }
+
+
+@pytest.mark.plugin_unit
+def test_migrate_runtime_override_commits_all_source_removals_and_target_update_once(
+    _isolate_runtime_overrides,
+    monkeypatch,
+):
+    ro.set_runtime_override("original", False, auto_start=False)
+    ro.set_runtime_override("intermediate", False, auto_start=False)
+    saved: list[dict[str, ro.RuntimeOverride]] = []
+    original_save = ro._save_to_disk
+
+    def _spy_save(overrides):
+        saved.append(dict(overrides))
+        original_save(overrides)
+
+    monkeypatch.setattr(ro, "_save_to_disk", _spy_save)
+
+    ro.migrate_runtime_override(
+        ("original", "intermediate"),
+        "renamed",
+        True,
+        auto_start=True,
+    )
+
+    assert saved == [{"renamed": {"enabled": True, "auto_start": True}}]
+    assert ro.load_runtime_overrides() == {
+        "renamed": {"enabled": True, "auto_start": True},
+    }
 
 
 @pytest.mark.plugin_unit

--- a/plugin/tests/unit/server/test_runtime_overrides.py
+++ b/plugin/tests/unit/server/test_runtime_overrides.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import pytest
+import utils.config_manager as config_manager_module
 
 from plugin.server.infrastructure import runtime_overrides as ro
+
+_ORIGINAL_LOAD_FROM_DISK = ro._load_from_disk
 
 
 @pytest.mark.plugin_unit
@@ -19,6 +22,34 @@ def test_runtime_overrides_set_load_clear_roundtrip(_isolate_runtime_overrides):
     ro.clear_runtime_override("alpha")
     assert ro.load_runtime_overrides() == {"beta": True}
     assert ro.get_runtime_override("alpha") is None
+
+
+@pytest.mark.plugin_unit
+def test_runtime_overrides_persist_auto_start_alongside_enabled(_isolate_runtime_overrides):
+    ro.set_runtime_override("alpha", True, auto_start=True)
+
+    assert ro.load_runtime_overrides() == {
+        "alpha": {"enabled": True, "auto_start": True},
+    }
+    assert ro.get_runtime_override("alpha") is True
+    assert ro.get_runtime_auto_start_override("alpha") is True
+
+    ro.set_runtime_override("alpha", False, auto_start=False)
+
+    assert ro.load_runtime_overrides() == {
+        "alpha": {"enabled": False, "auto_start": False},
+    }
+    assert ro.get_runtime_override("alpha") is False
+    assert ro.get_runtime_auto_start_override("alpha") is False
+
+
+@pytest.mark.plugin_unit
+def test_runtime_overrides_keep_legacy_boolean_entries_compatible(monkeypatch):
+    monkeypatch.setattr(ro, "_load_from_disk", lambda: {"legacy": False})
+    ro.reset_cache_for_testing()
+
+    assert ro.get_runtime_override("legacy") is False
+    assert ro.get_runtime_auto_start_override("legacy") is None
 
 
 @pytest.mark.plugin_unit
@@ -53,16 +84,20 @@ def test_runtime_overrides_ignore_blank_plugin_id(_isolate_runtime_overrides):
 
 
 @pytest.mark.plugin_unit
-def test_coerce_overrides_drops_invalid_entries():
-    """Non-bool / non-string entries from disk are silently dropped."""
-    coerced = ro._coerce_overrides({"good": True, "bad": "yes", 42: True, "neg": False})
-    assert coerced == {"good": True, "neg": False}
+def test_coerce_overrides_rejects_invalid_entries():
+    with pytest.raises(ro.RuntimeOverrideReadError, match="invalid entry"):
+        ro._coerce_overrides({"good": True, "bad": "yes"})
+
+    with pytest.raises(ro.RuntimeOverrideReadError, match="invalid fields"):
+        ro._coerce_overrides({"bad": {"enabled": "yes"}})
 
 
 @pytest.mark.plugin_unit
 def test_coerce_overrides_handles_non_mapping():
-    assert ro._coerce_overrides([1, 2, 3]) == {}
-    assert ro._coerce_overrides(None) == {}
+    with pytest.raises(ro.RuntimeOverrideReadError, match="JSON object"):
+        ro._coerce_overrides([1, 2, 3])
+    with pytest.raises(ro.RuntimeOverrideReadError, match="JSON object"):
+        ro._coerce_overrides(None)
 
 
 @pytest.mark.plugin_unit
@@ -94,3 +129,40 @@ def test_set_runtime_override_holds_cache_lock_during_disk_write(
     ro.clear_runtime_override("alpha")
 
     assert lock_held_during_save == [True, True]
+
+
+@pytest.mark.plugin_unit
+def test_runtime_override_read_error_is_not_treated_as_empty_or_cached(monkeypatch):
+    class _ConfigManager:
+        def load_json_config(self, _filename):
+            raise ValueError("invalid json")
+
+    monkeypatch.setattr(config_manager_module, "get_config_manager", lambda: _ConfigManager())
+    monkeypatch.setattr(ro, "_load_from_disk", _ORIGINAL_LOAD_FROM_DISK)
+    ro.reset_cache_for_testing()
+
+    with pytest.raises(ro.RuntimeOverrideReadError, match="Failed to load"):
+        ro.load_runtime_overrides()
+
+    monkeypatch.setattr(ro, "_load_from_disk", lambda: {"recovered": True})
+    assert ro.load_runtime_overrides() == {"recovered": True}
+
+
+@pytest.mark.plugin_unit
+def test_runtime_override_write_error_does_not_commit_cache(
+    _isolate_runtime_overrides,
+    monkeypatch,
+):
+    ro.set_runtime_override("alpha", True, auto_start=True)
+
+    def _fail_save(_overrides):
+        raise ro.RuntimeOverrideWriteError("disk full")
+
+    monkeypatch.setattr(ro, "_save_to_disk", _fail_save)
+
+    with pytest.raises(ro.RuntimeOverrideWriteError, match="disk full"):
+        ro.set_runtime_override("alpha", False, auto_start=False)
+
+    assert ro.load_runtime_overrides() == {
+        "alpha": {"enabled": True, "auto_start": True},
+    }


### PR DESCRIPTION
## 改动概述 / Summary

增强了插件系统默认的自启动规则，现在用户手动启动/关闭插件，会保存到自启动，下次启动时这些插件可以自启动。

## 回归报告 / Regression Report

不适用

## 不拆分理由 / Why Not Split

不适用

## 测试 / Testing

plugin/tests/unit/server/test_plugin_registry_service.py
plugin/tests/unit/server/test_plugins_lifecycle_service.py
plugin/tests/unit/server/test_runtime_overrides.py
手动测试过了，应该没问题。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 运行时偏好可分别持久化插件“启用状态”和“自动启动”设置。
  * 启动/停止时可记录用户意图；刷新注册表后按偏好继续生效，并在插件解析/重命名场景下迁移对应偏好。
  * 新增配置：切换启停时是否同步更新自动启动偏好。
  * 兼容并读取旧版仅包含启用状态的偏好数据。
* **错误修复**
  * 运行时覆盖文件的读取/校验更严格：无效内容会被跳过并回退到默认偏好。
  * 偏好落盘失败时提供更明确的部分成功/状态回传，避免静默失效。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->