### PR TITLE
fix(build): repair PyInstaller plugin SDK packaging

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -12,6 +12,8 @@ on:
       - 'plugin/**'
       - 'static/avatar/avatar-ui-buttons.js'
       - 'tests/unit/test_avatar_return_button_idle_tiers_static.py'
+      - 'tests/unit/test_plugin_sdk_packaging.py'
+      - 'specs/launcher.spec'
       - '.github/workflows/plugin-tests.yml'
       # Dependency changes alter the plugin test/runtime environment (e.g.
       # removing a dev dep plugin/tests needs) — without these a deps-only
@@ -24,6 +26,8 @@ on:
       - 'plugin/**'
       - 'static/avatar/avatar-ui-buttons.js'
       - 'tests/unit/test_avatar_return_button_idle_tiers_static.py'
+      - 'tests/unit/test_plugin_sdk_packaging.py'
+      - 'specs/launcher.spec'
       - '.github/workflows/plugin-tests.yml'
       - 'pyproject.toml'
       - 'uv.lock'
@@ -63,7 +67,7 @@ jobs:
 
       - name: Install dependencies
         # Plain `uv sync` = main deps + dev group (pytest, pytest-asyncio,
-        # hypothesis). The galgame group (rapidocr + cv2, ~130 MB) is NOT
+        # hypothesis, PyInstaller). The galgame group (rapidocr + cv2, ~130 MB) is NOT
         # installed — the plugin degrades its OCR backend gracefully and the
         # affected tests mock or skip that cohort.
         run: uv sync
@@ -75,8 +79,11 @@ jobs:
         # collected too.
         run: uv run pytest plugin/tests -q
 
-      - name: Run avatar static contract tests
+      - name: Run repository contract tests
         # Keep this in a separate pytest process so plugin/tests continues to
-        # use its own pytest.ini while repo-root static contracts are still
-        # covered by CI.
-        run: uv run pytest tests/unit/test_avatar_return_button_idle_tiers_static.py -q
+        # use its own pytest.ini while repo-root contracts are still covered.
+        run: >
+          uv run pytest
+          tests/unit/test_avatar_return_button_idle_tiers_static.py
+          tests/unit/test_plugin_sdk_packaging.py
+          -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,7 @@ override-dependencies = [
 dev = [
     "hypothesis>=6.100",
     "nest-asyncio>=1.6.0",
+    "pyinstaller==6.12.0",
     "pytest>=9.0.2",
     "pytest-asyncio>=1.3.0",
     "pytest-cov>=7.1.0",

--- a/specs/launcher.spec
+++ b/specs/launcher.spec
@@ -2,12 +2,14 @@
 import sys
 import os
 import platform
-from PyInstaller.utils.hooks import collect_all
+from PyInstaller.utils.hooks import collect_all, collect_submodules
 from PyInstaller.building.build_main import Tree
 
 # 获取 spec 文件所在目录和项目根目录
 SPEC_DIR = os.path.dirname(os.path.abspath(SPEC))
 PROJECT_ROOT = os.path.dirname(SPEC_DIR)
+VERSION_INFO_PATH = os.path.join(PROJECT_ROOT, 'version_info.txt')
+ICON_PATH = os.path.join(PROJECT_ROOT, 'assets', 'icon.ico')
 
 # 切换到项目根目录，以便所有路径都是相对于根目录
 original_dir = os.getcwd()
@@ -21,6 +23,7 @@ print(f"[Build] Working from: {os.getcwd()}")
 datas = []
 binaries = []
 hiddenimports = []
+hiddenimports += collect_submodules('plugin.sdk')
 
 # 收集关键包的所有内容（根据实际 import 检查）
 critical_packages = [
@@ -345,11 +348,6 @@ hiddenimports += [
     'plugin.core.state',
     'plugin.runtime',
     'plugin.sdk',
-    'plugin.sdk.base',
-    'plugin.sdk.decorators',
-    'plugin.sdk.events',
-    'plugin.sdk.logger',
-    'plugin.sdk.version',
     'plugin.server',
     'plugin.server.exceptions',
     'plugin.server.lifecycle',
@@ -391,8 +389,9 @@ exe = EXE(
     target_arch=platform.machine() if sys.platform == 'darwin' else None,  # 自动检测 macOS 架构 (arm64/x86_64)
     codesign_identity=None,
     entitlements_file=None,
-    icon='assets/icon.ico' if sys.platform == 'win32' else None,  # macOS 暂不使用图标
-    version='version_info.txt' if sys.platform == 'win32' else None,  # 添加版本信息减少误报
+    icon=ICON_PATH if sys.platform == 'win32' else None,  # macOS 暂不使用图标
+    version=VERSION_INFO_PATH if sys.platform == 'win32' and os.path.isfile(VERSION_INFO_PATH) else None,
+    # 本地 version_info.txt 未生成时保持可构建；仅跳过 Windows 版本资源。
 )
 
 # 使用 COLLECT 创建目录模式分发包

--- a/specs/launcher.spec
+++ b/specs/launcher.spec
@@ -23,7 +23,7 @@ print(f"[Build] Working from: {os.getcwd()}")
 datas = []
 binaries = []
 hiddenimports = []
-hiddenimports += collect_submodules('plugin.sdk')
+hiddenimports += collect_submodules('plugin.sdk', on_error='raise')
 
 # 收集关键包的所有内容（根据实际 import 检查）
 critical_packages = [

--- a/tests/unit/test_plugin_sdk_packaging.py
+++ b/tests/unit/test_plugin_sdk_packaging.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 import importlib.util
 from pathlib import Path
 
@@ -15,10 +16,25 @@ REMOVED_ROOT_SDK_MODULES = (
 )
 
 
+def _sdk_module_names() -> list[str]:
+    module_names: set[str] = set()
+    for source_path in (ROOT / "plugin" / "sdk").rglob("*.py"):
+        module_parts = source_path.relative_to(ROOT).with_suffix("").parts
+        if module_parts[-1] == "__init__":
+            module_parts = module_parts[:-1]
+        module_names.add(".".join(module_parts))
+    return sorted(module_names)
+
+
+def test_current_sdk_modules_are_importable() -> None:
+    for module_name in _sdk_module_names():
+        importlib.import_module(module_name)
+
+
 def test_launcher_collects_current_plugin_sdk_tree() -> None:
     spec = (ROOT / "specs" / "launcher.spec").read_text(encoding="utf-8")
 
-    assert "collect_submodules('plugin.sdk')" in spec
+    assert "collect_submodules('plugin.sdk', on_error='raise')" in spec
     for removed_module in REMOVED_ROOT_SDK_MODULES:
         assert f"'{removed_module}'" not in spec
 
@@ -29,6 +45,11 @@ def test_launcher_uses_project_root_for_windows_resources() -> None:
     assert "VERSION_INFO_PATH = os.path.join(PROJECT_ROOT, 'version_info.txt')" in spec
     assert "os.path.isfile(VERSION_INFO_PATH)" in spec
     assert "ICON_PATH = os.path.join(PROJECT_ROOT, 'assets', 'icon.ico')" in spec
+    assert "icon=ICON_PATH if sys.platform == 'win32' else None" in spec
+    assert (
+        "version=VERSION_INFO_PATH if sys.platform == 'win32' and "
+        "os.path.isfile(VERSION_INFO_PATH) else None"
+    ) in spec
 
 
 def test_removed_root_sdk_modules_are_not_importable() -> None:

--- a/tests/unit/test_plugin_sdk_packaging.py
+++ b/tests/unit/test_plugin_sdk_packaging.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
 REMOVED_ROOT_SDK_MODULES = (
     "plugin.sdk.base",
     "plugin.sdk.decorators",
@@ -9,6 +13,22 @@ REMOVED_ROOT_SDK_MODULES = (
     "plugin.sdk.version",
     "plugin.sdk.extension",
 )
+
+
+def test_launcher_collects_current_plugin_sdk_tree() -> None:
+    spec = (ROOT / "specs" / "launcher.spec").read_text(encoding="utf-8")
+
+    assert "collect_submodules('plugin.sdk')" in spec
+    for removed_module in REMOVED_ROOT_SDK_MODULES:
+        assert f"'{removed_module}'" not in spec
+
+
+def test_launcher_uses_project_root_for_windows_resources() -> None:
+    spec = (ROOT / "specs" / "launcher.spec").read_text(encoding="utf-8")
+
+    assert "VERSION_INFO_PATH = os.path.join(PROJECT_ROOT, 'version_info.txt')" in spec
+    assert "os.path.isfile(VERSION_INFO_PATH)" in spec
+    assert "ICON_PATH = os.path.join(PROJECT_ROOT, 'assets', 'icon.ico')" in spec
 
 
 def test_removed_root_sdk_modules_are_not_importable() -> None:

--- a/tests/unit/test_plugin_sdk_packaging.py
+++ b/tests/unit/test_plugin_sdk_packaging.py
@@ -4,6 +4,8 @@ import importlib
 import importlib.util
 from pathlib import Path
 
+from PyInstaller.utils.hooks import collect_submodules
+
 
 ROOT = Path(__file__).resolve().parents[2]
 REMOVED_ROOT_SDK_MODULES = (
@@ -29,6 +31,12 @@ def _sdk_module_names() -> list[str]:
 def test_current_sdk_modules_are_importable() -> None:
     for module_name in _sdk_module_names():
         importlib.import_module(module_name)
+
+
+def test_pyinstaller_collects_complete_sdk_tree() -> None:
+    assert sorted(collect_submodules("plugin.sdk", on_error="raise")) == (
+        _sdk_module_names()
+    )
 
 
 def test_launcher_collects_current_plugin_sdk_tree() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -76,6 +76,15 @@ wheels = [
 ]
 
 [[package]]
+name = "altgraph"
+version = "0.17.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/f8/97fdf103f38fed6792a1601dbc16cc8aac56e7459a9fff08c812d8ae177a/altgraph-0.17.5.tar.gz", hash = "sha256:c87b395dd12fabde9c99573a9749d67da8d29ef9de0125c7f536699b4a9bc9e7", size = 48428, upload-time = "2025-11-21T20:35:50.583Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/ba/000a1996d4308bc65120167c21241a3b205464a2e0b58deda26ae8ac21d1/altgraph-0.17.5-py2.py3-none-any.whl", hash = "sha256:f3a22400bce1b0c701683820ac4f3b159cd301acab067c51c653e06961600597", size = 21228, upload-time = "2025-11-21T20:35:49.444Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1237,6 +1246,18 @@ wheels = [
 ]
 
 [[package]]
+name = "macholib"
+version = "1.16.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph", marker = "sys_platform == 'darwin'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/d1/a9f36f8ecdf0fb7c9b1e78c8d7af12b8c8754e74851ac7b94a8305540fc7/macholib-1.16.4-py2.py3-none-any.whl", hash = "sha256:da1a3fa8266e30f0ce7e97c6a54eefaae8edd1e5f86f3eb8b95457cae90265ea", size = 38117, upload-time = "2025-11-22T08:28:36.939Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1453,6 +1474,7 @@ dependencies = [
 dev = [
     { name = "hypothesis" },
     { name = "nest-asyncio" },
+    { name = "pyinstaller" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -1525,6 +1547,7 @@ requires-dist = [
 dev = [
     { name = "hypothesis", specifier = ">=6.100" },
     { name = "nest-asyncio", specifier = ">=1.6.0" },
+    { name = "pyinstaller", specifier = "==6.12.0" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
@@ -1664,6 +1687,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pefile"
+version = "2023.2.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/c5/3b3c62223f72e2360737fd2a57c30e5b2adecd85e70276879609a7403334/pefile-2023.2.7.tar.gz", hash = "sha256:82e6114004b3d6911c77c3953e3838654b04511b8b66e8583db70c65998017dc", size = 74854, upload-time = "2023-02-07T12:23:55.958Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/26/d0ad8b448476d0a1e8d3ea5622dc77b916db84c6aa3cb1e1c0965af948fc/pefile-2023.2.7-py3-none-any.whl", hash = "sha256:da185cd2af68c08a6cd4481f7325ed600a88f6a813bad9dea07ab3ef73d8d8d6", size = 71791, upload-time = "2023-02-07T12:28:36.678Z" },
 ]
 
 [[package]]
@@ -2009,6 +2041,46 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyinstaller"
+version = "6.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+    { name = "macholib", marker = "sys_platform == 'darwin'" },
+    { name = "packaging" },
+    { name = "pefile", marker = "sys_platform == 'win32'" },
+    { name = "pyinstaller-hooks-contrib" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/c0/001e86a13f9f6104613f198721c72d377fa1fc2a09550cfe1ac9a1d12406/pyinstaller-6.12.0.tar.gz", hash = "sha256:1834797be48ce1b26015af68bdeb3c61a6c7500136f04e0fc65e468115dec777", size = 4267132, upload-time = "2025-02-08T22:19:18.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/73/b897a3fda99a14130111abdb978d63da14cbc9932497b5e5064c5fe28187/pyinstaller-6.12.0-py3-none-macosx_10_13_universal2.whl", hash = "sha256:68f1e4cecf88a6272063977fa2a2c69ad37cf568e5901769d7206d0314c74f47", size = 997954, upload-time = "2025-02-08T22:18:09.438Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/bc/0929ed6aca3c5ff3f20f8cfd4f2f7e90f18c9465440e0d151d56d8170851/pyinstaller-6.12.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:fea76fc9b55ffa730fcf90beb897cce4399938460b0b6f40507fbebfc752c753", size = 714097, upload-time = "2025-02-08T22:18:14.476Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/9a/422d5eb04132e4a4735ca9099a53511324ff7d387b80231fe8dbd67bf322/pyinstaller-6.12.0-py3-none-manylinux2014_i686.whl", hash = "sha256:dac8a27988dbc33cdc34f2046803258bc3f6829de24de52745a5daa22bdba0f1", size = 724471, upload-time = "2025-02-08T22:18:19.117Z" },
+    { url = "https://files.pythonhosted.org/packages/64/1c/5028ba2e09f5b57f6792e9d88e888725224f8f016a07666e48664f6a9fcf/pyinstaller-6.12.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:83c7f3bde9871b4a6aa71c66a96e8ba5c21668ce711ed97f510b9382d10aac6c", size = 722753, upload-time = "2025-02-08T22:18:23.173Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d9/e7742caf4c4dc07d13e355ad2c14c7844c9bb2e66dea4f3386b4644bd106/pyinstaller-6.12.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:a69818815c6e0711c727edc30680cb1f81c691b59de35db81a2d9e0ae26a9ef1", size = 720906, upload-time = "2025-02-08T22:18:27.881Z" },
+    { url = "https://files.pythonhosted.org/packages/80/2b/14404f2dc95d1ec94d08879c62a76d5f26a176fab99fb023c2c70d2ff500/pyinstaller-6.12.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a2abf5fde31a8b38b6df7939bcef8ac1d0c51e97e25317ce3555cd675259750f", size = 716959, upload-time = "2025-02-08T22:18:33.707Z" },
+    { url = "https://files.pythonhosted.org/packages/11/a6/5c3a233cf19aa6d4caacf62f7ee1c728486cc20b73f5817be17485d7b7ff/pyinstaller-6.12.0-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:8e92e9873a616547bbabbb5a3a9843d5f2ab40c3d8b26810acdf0fe257bee4cf", size = 719414, upload-time = "2025-02-08T22:18:39.097Z" },
+    { url = "https://files.pythonhosted.org/packages/24/57/069d35236806b281a3331ef00ff94e43f3b91e4b36350de8b40b4baf9fd3/pyinstaller-6.12.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:aefe502d55c9cf6aeaed7feba80b5f8491ce43f8f2b5fe2d9aadca3ee5a05bc4", size = 715903, upload-time = "2025-02-08T22:18:43.899Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/5f/857de8798836f9d16a620bd0a7c8899bba05b5fda7b3b4432762f148a86d/pyinstaller-6.12.0-py3-none-win32.whl", hash = "sha256:138856a5a503bb69c066377e0a22671b0db063e9cc14d5cf5c798a53561200d3", size = 1290980, upload-time = "2025-02-08T22:18:49.954Z" },
+    { url = "https://files.pythonhosted.org/packages/99/6e/d7d76d4d15f6351f1f942256633b795eec3d6c691d985869df1bf319cd9d/pyinstaller-6.12.0-py3-none-win_amd64.whl", hash = "sha256:0e62d3906309248409f215b386f33afec845214e69cc0f296b93222b26a88f43", size = 1348786, upload-time = "2025-02-08T22:18:56.166Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c2/298ad6a3aa2cacb55cbc1f845068dc1e4a6c966082ffa0e19c69084cbc42/pyinstaller-6.12.0-py3-none-win_arm64.whl", hash = "sha256:0c271896a3a168f4f91827145702543db9c5427f4c7372a6df8c75925a3ac18a", size = 1289617, upload-time = "2025-02-08T22:19:02.162Z" },
+]
+
+[[package]]
+name = "pyinstaller-hooks-contrib"
+version = "2026.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/5b/c9fe0db5e83ee1c39b2258fa21d23b15e1a60786b6c5990ee5074ead8bb6/pyinstaller_hooks_contrib-2026.6.tar.gz", hash = "sha256:bef5002c32f4f50bd55b005da12cff64eca8783e7eaf86a06a62410164bab725", size = 173354, upload-time = "2026-06-08T22:37:16.152Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/31/f2d7343d8ed5f7c4678377886f6ce533e6eaaa131b252ce950114c2a7efa/pyinstaller_hooks_contrib-2026.6-py3-none-any.whl", hash = "sha256:fd13b8ac126b35361175edacd41a0d97080b75dd5f4b594ecefefff969509dd3", size = 457159, upload-time = "2026-06-08T22:37:14.722Z" },
 ]
 
 [[package]]
@@ -4582,6 +4654,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
 name = "pywinauto"
 version = "0.6.9"
 source = { registry = "https://pypi.org/simple" }
@@ -4926,6 +5007,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ec/bb/e69e5e628d43f118e0af4fc063c20058faa8635c95a1296764acc8167e27/screeninfo-0.8.1.tar.gz", hash = "sha256:9983076bcc7e34402a1a9e4d7dabf3729411fd2abb3f3b4be7eba73519cd2ed1", size = 10666, upload-time = "2022-09-09T11:35:23.419Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6e/bf/c5205d480307bef660e56544b9e3d7ff687da776abb30c9cb3f330887570/screeninfo-0.8.1-py3-none-any.whl", hash = "sha256:e97d6b173856edcfa3bd282f81deb528188aff14b11ec3e195584e7641be733c", size = 12907, upload-time = "2022-09-09T11:35:21.351Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "83.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 改动概述 / Summary

修复 `specs/launcher.spec` 在插件 SDK v0.9 收敛后的 PyInstaller 打包行为：

- 使用 `collect_submodules('plugin.sdk')` 收集当前真实 SDK 树，替代已经不存在的 root SDK 模块白名单。
- 移除 `plugin.sdk.base/decorators/events/logger/version` 等 stale hiddenimports。
- 将 Windows 图标路径锚定到仓库根目录，避免被错误解析为 `specs/assets/icon.ico`。
- 根目录未生成 ignored 的 `version_info.txt` 时跳过版本资源，而不是让干净 worktree 构建直接失败。
- 补充包装契约测试，锁定当前 SDK 收集方式、已删除模块不可导入，以及 Windows 资源路径语义。

GitHub Actions 和正式桌面发布仍使用 Nuitka；Nuitka 已通过 `--include-package=plugin` 覆盖当前 SDK 树，本 PR 不修改 Nuitka。PyInstaller 目前是文档保留的本地/备用构建路径，本机 ignored 的 `build.bat -> build.py -> specs/launcher.spec` 是现有调用方。

## 根因 / Root Cause

`launcher.spec` 手写了早已删除的 SDK root 模块，同时没有跟随当前 `plugin.sdk.plugin/adapter/shared` 树自动演进。其 Windows 图标和版本资源又使用 spec-relative 字符串路径，PyInstaller 会从 `specs/` 解析，导致干净构建分别在 `specs/version_info.txt` 和 `specs/assets/icon.ico` 失败。

## 回归报告 / Regression Report

不适用。本 PR 只修改备用 PyInstaller 构建档案和对应单元测试，不改变运行时代码、GitHub Actions 或 Nuitka 正式分发链路。

## 测试 / Testing

- `uv run pytest tests/unit/test_plugin_sdk_packaging.py -q` → 3 passed。
- PyInstaller 6.12 hook smoke：收集 56 个 `plugin.sdk` 模块；关键 Plugin/Adapter/Shared 模块存在，6 个已删除入口均不存在。
- `uv run --group galgame python -m PyInstaller specs/launcher.spec --noconfirm ...` → Windows onedir 构建成功。
- 对生成的 `projectneko_server.exe` 递归检查 PyInstaller archive：
  - `plugin.sdk.plugin.base`、`plugin.sdk.adapter.neko_adapter`、`plugin.sdk.shared.core.context` 存在。
  - 已删除的 root SDK/Extension 模块均不存在。
- `git diff --check` 通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 优化 Windows 应用打包：自动收集插件 SDK 的全部子模块，减少因模块遗漏导致的构建问题。
  * 改进图标与版本资源路径处理：当版本信息文件不存在时不再触发构建失败。
* **Tests**
  * 新增打包规范与插件模块可导入性的自动化校验，确保当前插件 SDK 模块可被正常导入并与打包配置一致。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->