### PR TITLE
refactor(memory): split embedding internals

### DIFF
--- a/memory/_embeddings/__init__.py
+++ b/memory/_embeddings/__init__.py
@@ -1,0 +1,6 @@
+"""Internal building blocks for :mod:`memory.embeddings`.
+
+The public compatibility surface intentionally remains in ``memory.embeddings``.
+These modules separate implementation responsibilities without asking callers to
+depend on a new package layout.
+"""

--- a/memory/_embeddings/hardware.py
+++ b/memory/_embeddings/hardware.py
@@ -1,0 +1,80 @@
+"""Hardware capability snapshots and pure runtime-selection policies."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class HardwareCapabilities:
+    """The hardware facts consumed while selecting an embedding profile."""
+
+    ram_gb: float | None
+    has_vnni: bool
+    vnni_absence_confirmed: bool
+    has_avx2: bool
+    avx2_absence_confirmed: bool
+
+
+def detect_capabilities(
+    detect_ram: Callable[[], float | None],
+    detect_vnni: Callable[[], tuple[bool, bool]],
+    detect_avx2: Callable[[], tuple[bool, bool]],
+) -> HardwareCapabilities:
+    """Collect capability probes behind an injectable compatibility bridge."""
+    ram_gb = detect_ram()
+    has_vnni, vnni_confirmed = detect_vnni()
+    has_avx2, avx2_confirmed = detect_avx2()
+    return HardwareCapabilities(
+        ram_gb=ram_gb,
+        has_vnni=has_vnni,
+        vnni_absence_confirmed=vnni_confirmed,
+        has_avx2=has_avx2,
+        avx2_absence_confirmed=avx2_confirmed,
+    )
+
+
+def resolve_dim_for_ram(ram_gb: float | None, min_ram_gb: float) -> int | None:
+    """Choose the default Matryoshka dimension for installed RAM."""
+    if ram_gb is None or ram_gb < min_ram_gb:
+        return None
+    if ram_gb < 8:
+        return 64
+    if ram_gb < 16:
+        return 128
+    return 256
+
+
+def auto_int8_or_none(
+    has_vnni: bool,
+    vnni_absence_confirmed: bool,
+    has_avx2: bool,
+    avx2_absence_confirmed: bool,
+) -> str | None:
+    """Select int8 unless both supported SIMD paths are confirmed absent."""
+    if has_vnni or not vnni_absence_confirmed:
+        return "int8"
+    if has_avx2 or not avx2_absence_confirmed:
+        return "int8"
+    return None
+
+
+def resolve_quantization(
+    value: str | None,
+    has_vnni: bool,
+    *,
+    vnni_absence_confirmed: bool,
+    has_avx2: bool,
+    avx2_absence_confirmed: bool,
+) -> str | None:
+    """Resolve the configured quantization without performing any I/O."""
+    if value == "fp32":
+        return "fp32"
+    if value == "auto" or value is None or value not in ("int8", "fp32"):
+        return auto_int8_or_none(
+            has_vnni,
+            vnni_absence_confirmed,
+            has_avx2,
+            avx2_absence_confirmed,
+        )
+    return "int8"

--- a/memory/_embeddings/lifecycle.py
+++ b/memory/_embeddings/lifecycle.py
@@ -1,0 +1,18 @@
+"""Small, dependency-free helpers for the EmbeddingService singleton."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TypeVar
+
+
+T = TypeVar("T")
+
+
+def get_or_create(current: T | None, factory: Callable[[], T]) -> T:
+    """Return ``current`` or lazily construct the process service."""
+    return current if current is not None else factory()
+
+
+def reset_for_tests() -> None:
+    """Return the empty singleton state used by the public test hook."""
+    return None

--- a/memory/_embeddings/profiles.py
+++ b/memory/_embeddings/profiles.py
@@ -1,0 +1,78 @@
+"""Embedding model-profile validation and directory selection."""
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Callable, Iterable
+
+
+def is_nonempty_file(path: str) -> bool:
+    """Return whether ``path`` is a regular, non-empty file."""
+    try:
+        return os.path.isfile(path) and os.path.getsize(path) > 0
+    except OSError:
+        return False
+
+
+def profile_exists(model_dir: str, profile_id: str) -> bool:
+    return os.path.isdir(os.path.join(model_dir, profile_id))
+
+
+def profile_is_complete(
+    model_dir: str,
+    profile_id: str,
+    quantization: str | None = None,
+    *,
+    file_check: Callable[[str], bool] = is_nonempty_file,
+) -> bool:
+    """Validate the tokenizer and complete ONNX external-data pair."""
+    profile_dir = os.path.join(model_dir, profile_id)
+    if not os.path.isdir(profile_dir):
+        return False
+    if not file_check(os.path.join(profile_dir, "tokenizer.json")):
+        return False
+    stem = "model.onnx" if quantization == "fp32" else "model_quantized.onnx"
+    model_path = os.path.join(profile_dir, "onnx", stem)
+    return file_check(model_path) and file_check(model_path + "_data")
+
+
+def bundled_model_dirs(
+    module_file: str,
+    model_dir_name: str,
+    *,
+    sys_module=sys,
+    compiled: bool = False,
+) -> list[str]:
+    """Return de-duplicated source and frozen-build asset roots."""
+    roots: list[str] = []
+    if hasattr(sys_module, "_MEIPASS"):
+        roots.append(str(sys_module._MEIPASS))
+    if getattr(sys_module, "frozen", False) or compiled:
+        roots.append(os.path.dirname(os.path.abspath(sys_module.executable)))
+    roots.append(os.path.dirname(os.path.dirname(os.path.abspath(module_file))))
+
+    seen: set[str] = set()
+    result: list[str] = []
+    for root in roots:
+        path = os.path.abspath(os.path.join(root, "data", model_dir_name))
+        if path not in seen:
+            seen.add(path)
+            result.append(path)
+    return result
+
+
+def select_model_dir(
+    app_docs_model_dir: str,
+    profile_id: str,
+    quantization: str | None,
+    bundled_dirs: Iterable[str],
+    *,
+    completeness_check: Callable[[str, str, str | None], bool],
+) -> str:
+    """Prefer a complete app-data profile, then a complete bundle."""
+    if completeness_check(app_docs_model_dir, profile_id, quantization):
+        return app_docs_model_dir
+    for bundled_dir in bundled_dirs:
+        if completeness_check(bundled_dir, profile_id, quantization):
+            return bundled_dir
+    return app_docs_model_dir

--- a/memory/_embeddings/schema.py
+++ b/memory/_embeddings/schema.py
@@ -1,0 +1,164 @@
+"""Embedding persistence schema and vector codec helpers."""
+from __future__ import annotations
+
+import base64
+import hashlib
+import re
+from typing import Any
+
+
+_MODEL_ID_DIM_RE = re.compile(r"-(\d+)d-(?:int8|fp32)(?:-mlen\d+)?$")
+
+
+def encode_vector_fp16(vector) -> str:
+    """Encode a float vector as strict base64-wrapped fp16 bytes."""
+    import numpy as np
+
+    arr = np.asarray(vector, dtype=np.float16).ravel()
+    return base64.b64encode(arr.tobytes()).decode("ascii")
+
+
+def decode_vector_fp16(encoded: str):
+    """Decode base64 fp16 storage into a finite numpy fp32 array."""
+    import numpy as np
+
+    try:
+        raw = base64.b64decode(encoded, validate=True)
+    except Exception:  # noqa: BLE001 - corrupt cache is treated as missing
+        return None
+    if len(raw) % 2 != 0:
+        return None
+    decoded = np.frombuffer(raw, dtype=np.float16).astype(np.float32)
+    if decoded.size == 0:
+        return decoded
+    if not np.isfinite(decoded).all():
+        return None
+    return decoded
+
+
+def decode_embedding(embedding: Any, *, decode_string=None):
+    """Normalize persisted and legacy embedding values to numpy fp32."""
+    if embedding is None:
+        return None
+    import numpy as np
+
+    if isinstance(embedding, np.ndarray):
+        if embedding.size == 0:
+            return None
+        return embedding.astype(np.float32, copy=False)
+    if isinstance(embedding, str):
+        if not embedding:
+            return None
+        decoder = decode_vector_fp16 if decode_string is None else decode_string
+        return decoder(embedding)
+    if isinstance(embedding, (list, tuple)):
+        if not embedding:
+            return None
+        try:
+            return np.asarray(embedding, dtype=np.float32)
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def parse_dim_from_model_id(model_id: str | None) -> int | None:
+    """Extract the trailing embedding dimension from a canonical model id."""
+    if not model_id or not isinstance(model_id, str):
+        return None
+    match = _MODEL_ID_DIM_RE.search(model_id)
+    if not match:
+        return None
+    try:
+        return int(match.group(1))
+    except (TypeError, ValueError):
+        return None
+
+
+def embedding_text_sha256(text: str) -> str:
+    """Return the stable full-text fingerprint used by embedding caches."""
+    return hashlib.sha256((text or "").encode("utf-8")).hexdigest()
+
+
+def build_model_id(
+    profile: str,
+    dim: int,
+    quantization: str,
+    max_length: int | None = None,
+) -> str:
+    """Build the canonical embedding-space identity."""
+    base = f"{profile}-{dim}d-{quantization}"
+    if max_length is None:
+        return base
+    return f"{base}-mlen{max_length}"
+
+
+def cosine_similarity(a, b, *, decoder=None) -> float:
+    """Dot product for the service's L2-normalized vectors."""
+    decode = decode_embedding if decoder is None else decoder
+    av = decode(a)
+    bv = decode(b)
+    if av is None or bv is None:
+        return 0.0
+    if av.size == 0 or bv.size == 0 or av.size != bv.size:
+        return 0.0
+    import numpy as np
+    return float(np.dot(av, bv))
+
+
+def is_cached_embedding_valid(
+    entry: dict,
+    current_text: str,
+    current_model_id: str | None,
+    *,
+    hash_text=None,
+    decode_string=None,
+    parse_dim=None,
+) -> bool:
+    """Check all embedding cache fingerprints and the decoded dimension."""
+    if not isinstance(entry, dict):
+        return False
+    embedding = entry.get("embedding")
+    if not isinstance(embedding, str) or not embedding:
+        return False
+    if current_model_id is None:
+        return False
+    if entry.get("embedding_model_id") != current_model_id:
+        return False
+    hasher = embedding_text_sha256 if hash_text is None else hash_text
+    if entry.get("embedding_text_sha256") != hasher(current_text):
+        return False
+    decoder = decode_vector_fp16 if decode_string is None else decode_string
+    vector = decoder(embedding)
+    if vector is None or vector.size == 0:
+        return False
+    dim_parser = parse_dim_from_model_id if parse_dim is None else parse_dim
+    expected_dim = dim_parser(current_model_id)
+    return expected_dim is None or vector.size == expected_dim
+
+
+def clear_embedding_fields(entry: dict) -> None:
+    """Atomically invalidate the persisted embedding triple."""
+    if not isinstance(entry, dict):
+        return
+    entry["embedding"] = None
+    entry["embedding_text_sha256"] = None
+    entry["embedding_model_id"] = None
+
+
+def stamp_embedding_fields(
+    entry: dict,
+    vector,
+    text: str,
+    model_id: str,
+    *,
+    encoder=None,
+    hash_text=None,
+) -> None:
+    """Persist a vector and its two cache fingerprints on an entry."""
+    if not isinstance(entry, dict):
+        return
+    encode = encode_vector_fp16 if encoder is None else encoder
+    hasher = embedding_text_sha256 if hash_text is None else hash_text
+    entry["embedding"] = encode(vector)
+    entry["embedding_text_sha256"] = hasher(text)
+    entry["embedding_model_id"] = model_id

--- a/memory/embeddings.py
+++ b/memory/embeddings.py
@@ -59,15 +59,30 @@ match the current text + service ``model_id()`` — same pattern as the
 from __future__ import annotations
 
 import asyncio
-import base64
 import enum
-import hashlib
 import logging
 import os
 import platform
 import re
 import sys
 from typing import Any
+
+from ._embeddings import lifecycle as _service_lifecycle
+from ._embeddings import hardware as _hardware
+from ._embeddings import profiles as _profiles
+from ._embeddings.schema import (
+    _MODEL_ID_DIM_RE,
+    build_model_id,
+    clear_embedding_fields,
+    cosine_similarity as _cosine_similarity_impl,
+    decode_embedding as _decode_embedding_impl,
+    decode_vector_fp16 as _decode_vector_fp16,
+    embedding_text_sha256 as _embedding_text_sha256,
+    encode_vector_fp16 as _encode_vector_fp16,
+    is_cached_embedding_valid as _is_cached_embedding_valid_impl,
+    parse_dim_from_model_id,
+    stamp_embedding_fields as _stamp_embedding_fields_impl,
+)
 
 # 走 get_module_logger(..., "Memory") 把本模块日志归到 N.E.K.O.Memory.*，
 # 否则 ``logging.getLogger(__name__)`` 产生的 ``memory.embeddings`` logger
@@ -185,135 +200,7 @@ class _DisableReason(enum.Enum):
     INFERENCE_ERROR = "inference_raised"
 
 
-# ── helpers ──────────────────────────────────────────────────────────
-
-
-def _encode_vector_fp16(vector) -> str:
-    """Encode a float vector as ``base64(fp16_bytes)``.
-
-    Accepts list/tuple/numpy. fp16 has dynamic range up to ±65504, so
-    L2-normalized vectors (per-axis magnitudes < 1) can never overflow
-    on cast — we don't need a per-vector scale prefix the way int8
-    quantization would.
-    """
-    import numpy as np
-    arr = np.asarray(vector, dtype=np.float16).ravel()
-    return base64.b64encode(arr.tobytes()).decode("ascii")
-
-
-def _decode_vector_fp16(encoded: str):
-    """Inverse of :func:`_encode_vector_fp16`. Returns a numpy fp32 array.
-
-    Returns None on any decoding failure — corrupt cache fields fall
-    through to the "no embedding" path rather than raising up into the
-    retrieval/dedup loops.
-
-    Strict-validate the base64 payload (``validate=True``): the looser
-    setting silently skips non-alphabet bytes, letting a garbage-suffix
-    payload decode to plausible-but-wrong values. Reject odd-length
-    raw buffers (fp16 must align to 2 bytes — odd length means
-    truncation or corruption) and any non-finite element after cast
-    (NaN / ±Inf would otherwise propagate through every dot product
-    the decoded vector touches).
-    """
-    import numpy as np
-    try:
-        raw = base64.b64decode(encoded, validate=True)
-    except Exception:  # noqa: BLE001 — malformed base64 → treat as missing
-        return None
-    if len(raw) % 2 != 0:
-        return None
-    decoded = np.frombuffer(raw, dtype=np.float16).astype(np.float32)
-    if decoded.size == 0:
-        return decoded
-    if not np.isfinite(decoded).all():
-        return None
-    return decoded
-
-
-def decode_embedding(emb: Any):
-    """Public helper: turn a persisted ``embedding`` field into a numpy
-    fp32 array, regardless of whether the row carries the new base64
-    form, a legacy ``list[float]``, an already-decoded numpy array, or
-    None / empty.
-
-    Returns None when the field is missing or unreadable. Used by
-    cosine helpers and by recall's batched dot-product path.
-    """
-    if emb is None:
-        return None
-    import numpy as np
-    if isinstance(emb, np.ndarray):
-        if emb.size == 0:
-            return None
-        return emb.astype(np.float32, copy=False)
-    if isinstance(emb, str):
-        if not emb:
-            return None
-        return _decode_vector_fp16(emb)
-    if isinstance(emb, (list, tuple)):
-        if not emb:
-            return None
-        try:
-            return np.asarray(emb, dtype=np.float32)
-        except (TypeError, ValueError):
-            return None
-    return None
-
-
-# Anchor on the trailing ``-<dim>d-<quant>`` form emitted by
-# :func:`build_model_id` (e.g. ``local-text-retrieval-v1-256d-int8``).
-# Anchoring at end-of-string + a known quantization keyword guards
-# against profile names that happen to contain their own ``-Nd-``
-# segment (e.g. an upstream profile like ``model-384d-v2``); without
-# the anchor, ``re.search`` would pick the *first* match (384) rather
-# than the actual runtime dim (256), and is_cached_embedding_valid
-# would reject every freshly stamped vector forever (size mismatch),
-# pinning the worker into an infinite re-embed loop. Codex review
-# PR #1147.
-#
-# ``-mlen<N>`` 后缀(PR #1585):tokenizer 截断长度是 embedding 输入空间的
-# 一部分 —— 同一段 2K-token 文本在 max_length=8192 下喂全量、在
-# max_length=1024 下只喂前缀,得到的向量在同一模型下也不可比。把 mlen
-# 编进 model_id,降 max_length 时旧 cache 自动失效,worker 重新 embed,
-# 避免不同 token 输入空间的向量混用做 cosine。后缀可选(``mlen<N>?``)是
-# 为了向后兼容已经在用户磁盘上的老 cache id —— 它们解析 dim 仍然成功,
-# 在 is_cached_embedding_valid 里会因为 model_id 字符串比较失败被识别
-# 为 stale,然后被 worker 重新 stamp 上带 mlen 的新 id。
-_MODEL_ID_DIM_RE = re.compile(r"-(\d+)d-(?:int8|fp32)(?:-mlen\d+)?$")
-
-
-def parse_dim_from_model_id(model_id: str | None) -> int | None:
-    """Extract the embedding dimension from a model_id, or None if the
-    id can't be parsed.
-
-    ``embedding_model_id`` is built by :func:`build_model_id` and always
-    has the shape ``<profile>-<dim>d-<quant>`` where ``quant`` is a
-    fixed enum (``int8`` / ``fp32``). The regex anchors on that
-    trailing form so a profile name that itself contains ``-Nd-``
-    can't shadow the runtime dim segment.
-    """
-    if not model_id or not isinstance(model_id, str):
-        return None
-    m = _MODEL_ID_DIM_RE.search(model_id)
-    if not m:
-        return None
-    try:
-        return int(m.group(1))
-    except (TypeError, ValueError):
-        return None
-
-
-def _embedding_text_sha256(text: str) -> str:
-    """Stable fingerprint used for ``embedding_text_sha256`` cache keys.
-
-    Same scheme as ``token_count_text_sha256`` — utf-8 then full sha256.
-    Truncation lives at consumer sites only; we keep the full hex so a
-    future migration to a longer prefix doesn't require recomputing all
-    cached values.
-    """
-    return hashlib.sha256((text or "").encode("utf-8")).hexdigest()
-
+# ── hardware probes ─────────────────────────────────────────────────
 
 def detect_total_ram_gb() -> float | None:
     """Return total system RAM in GiB or None on detection failure.
@@ -874,26 +761,6 @@ def detect_avx2_details() -> tuple[bool, bool]:
     return False, False
 
 
-def resolve_dim_for_ram(ram_gb: float | None) -> int | None:
-    """Pick a Matryoshka dim from detected RAM. None ⇒ disabled.
-
-    The bands match the design contract in the PR description — they're
-    not a hard performance cliff, but a conservative budget that leaves
-    headroom for the rest of the app (LLM client, websocket pool, TTS
-    buffers, frontend renderer if collocated).
-
-    ≥ 16 GB → 256. Higher Matryoshka levels (512/768) are reserved for
-    opt-in overrides until we have enough latency data from real installs.
-    """
-    if ram_gb is None or ram_gb < DEFAULT_VECTORS_MIN_RAM_GB:
-        return None
-    if ram_gb < 8:
-        return 64
-    if ram_gb < 16:
-        return 128
-    return 256
-
-
 def _coerce_dim(value, ram_gb: float | None) -> int | None:
     """Resolve a config value to an integer dim, or None if disabled.
 
@@ -920,28 +787,63 @@ def _coerce_dim(value, ram_gb: float | None) -> int | None:
     return as_int
 
 
+# Compatibility facade. Keep these names in this module because tests and
+# downstream integrations monkeypatch them directly.
+def decode_embedding(embedding: Any):
+    return _decode_embedding_impl(embedding, decode_string=_decode_vector_fp16)
+
+
+def cosine_similarity(a, b) -> float:
+    return _cosine_similarity_impl(a, b, decoder=decode_embedding)
+
+
+def is_cached_embedding_valid(
+    entry: dict,
+    current_text: str,
+    current_model_id: str | None,
+) -> bool:
+    return _is_cached_embedding_valid_impl(
+        entry,
+        current_text,
+        current_model_id,
+        hash_text=_embedding_text_sha256,
+        decode_string=_decode_vector_fp16,
+        parse_dim=parse_dim_from_model_id,
+    )
+
+
+def stamp_embedding_fields(
+    entry: dict,
+    vector,
+    text: str,
+    model_id: str,
+) -> None:
+    _stamp_embedding_fields_impl(
+        entry,
+        vector,
+        text,
+        model_id,
+        encoder=_encode_vector_fp16,
+        hash_text=_embedding_text_sha256,
+    )
+
+
+def resolve_dim_for_ram(ram_gb: float | None) -> int | None:
+    return _hardware.resolve_dim_for_ram(ram_gb, DEFAULT_VECTORS_MIN_RAM_GB)
+
+
 def _auto_int8_or_none(
     has_vnni: bool,
     vnni_absence_confirmed: bool,
     has_avx2: bool,
     avx2_absence_confirmed: bool,
 ) -> str | None:
-    """``auto`` policy core: pick ``int8`` when *any* usable int8 SIMD path
-    exists, else ``None`` (disable).
-
-    Tiers:
-      1. AVX-VNNI present → int8 (fast path).
-      2. VNNI inconclusive → int8 (optimistic, unchanged from before).
-      3. VNNI confirmed absent, but AVX2 present → int8 (slow-but-fine —
-         Haswell 2013+ / Zen+; covers the bulk of pre-2021 desktops).
-      4. VNNI confirmed absent, AVX2 inconclusive → int8 (optimistic).
-      5. VNNI *and* AVX2 both confirmed absent → None (SSE-only; too slow).
-    """
-    if has_vnni or not vnni_absence_confirmed:
-        return "int8"
-    if has_avx2 or not avx2_absence_confirmed:
-        return "int8"
-    return None
+    return _hardware.auto_int8_or_none(
+        has_vnni,
+        vnni_absence_confirmed,
+        has_avx2,
+        avx2_absence_confirmed,
+    )
 
 
 def _resolve_quantization(
@@ -952,136 +854,49 @@ def _resolve_quantization(
     has_avx2: bool = True,
     avx2_absence_confirmed: bool = False,
 ) -> str | None:
-    """Map ``\"auto\"`` / ``\"int8\"`` / ``\"fp32\"`` onto a loadable variant.
-
-    Returns ``\"int8\"``, ``\"fp32\"``, or ``None``. ``None`` means local
-    embeddings are off — for ``auto``, only when the CPU has *neither* AVX-VNNI
-    nor AVX2 (both confirmed). Explicit ``\"fp32\"`` always loads the FP32 ONNX
-    when files exist.
-
-    Explicit ``\"int8\"`` is always honoured (with a warning when no VNNI fast
-    path) so operators can force INT8 even on SSE-only CPUs if they accept the
-    cost. ``has_avx2`` defaults True so the historical 3-arg call sites keep the
-    old (VNNI-only) behaviour until they pass the AVX2 detection through.
-    """
-    if value == "fp32":
-        return "fp32"
-    if value == "auto" or value is None or value not in ("int8", "fp32"):
-        return _auto_int8_or_none(
-            has_vnni, vnni_absence_confirmed, has_avx2, avx2_absence_confirmed,
-        )
-    # value == "int8" (forced)
-    if not has_vnni:
+    resolved = _hardware.resolve_quantization(
+        value,
+        has_vnni,
+        vnni_absence_confirmed=vnni_absence_confirmed,
+        has_avx2=has_avx2,
+        avx2_absence_confirmed=avx2_absence_confirmed,
+    )
+    if value == "int8" and not has_vnni:
         logger.warning(
             "EmbeddingService: int8 requested but AVX-VNNI not detected "
             "(avx2=%s) — expect slower inference (AVX2 kernel or SSE fallback)",
             has_avx2,
         )
-    return "int8"
-
-
-def build_model_id(
-    profile: str, dim: int, quantization: str, max_length: int | None = None,
-) -> str:
-    """Return the canonical id used in ``embedding_model_id`` cache fields.
-
-    Format: ``<profile>-<dim>d-<quant>`` or ``<profile>-<dim>d-<quant>-mlen<N>``
-    (e.g. ``local-text-retrieval-v1-128d-int8-mlen1024``).
-    A change to any axis flips the id, which invalidates cached
-    embeddings on the next read — same idea as ``tokenizer_identity``.
-
-    ``max_length`` is the tokenizer truncation length — Codex pointed out on PR
-    #1585 that the same long text fed into ONNX under max_length=8192 vs
-    max_length=1024 yields entirely different token sequences, hence different
-    vector spaces; leaving it out of the id would make stale caches "look valid"
-    after an upgrade, silently skewing recall quality when cosine-compared against
-    new queries. None falls back to the old mlen-less format — only for legacy call
-    sites (e.g. old test fixtures that don't pass max_length); real service paths
-    always pass it.
-    """
-    base = f"{profile}-{dim}d-{quantization}"
-    if max_length is None:
-        return base
-    return f"{base}-mlen{max_length}"
+    return resolved
 
 
 def _profile_exists(model_dir: str, profile_id: str) -> bool:
-    return os.path.isdir(os.path.join(model_dir, profile_id))
+    return _profiles.profile_exists(model_dir, profile_id)
 
 
 def _is_nonempty_file(path: str) -> bool:
-    """File present AND >0 bytes. Zero-byte residue from an interrupted
-    download passes plain ``isfile`` but trips the loader downstream — we
-    treat it as missing so the bundled fallback still kicks in."""
-    try:
-        return os.path.isfile(path) and os.path.getsize(path) > 0
-    except OSError:
-        return False
+    return _profiles.is_nonempty_file(path)
 
 
 def _profile_is_complete(
-    model_dir: str, profile_id: str, quantization: str | None = None,
+    model_dir: str,
+    profile_id: str,
+    quantization: str | None = None,
 ) -> bool:
-    """A profile dir is usable only if it has a non-empty tokenizer plus
-    a full (model + onnx_data sidecar) variant the runtime can actually
-    load.
-
-    ``quantization`` lets callers narrow the variant requirement to the
-    one ``_load_session_blocking`` will actually open. With ``None``, only
-    the shipped INT8 variant is considered complete — so a legacy fp32-only
-    app-data tree does not mask a good bundled int8 profile. Pass ``None``
-    only when the runtime quantization is not yet pinned to a single file.
-
-    Why stricter than ``_profile_exists``: a half-downloaded or partially
-    deleted app-data profile would otherwise satisfy the existence check,
-    short-circuit the bundled fallback, and then trip
-    ``NO_MODEL_FILE`` at session load — leaving the user with vectors
-    sticky-disabled even though the bundle on disk is fine.
-    """
-    profile_dir = os.path.join(model_dir, profile_id)
-    if not os.path.isdir(profile_dir):
-        return False
-    if not _is_nonempty_file(os.path.join(profile_dir, "tokenizer.json")):
-        return False
-    if quantization == "int8":
-        stems: tuple[str, ...] = ("model_quantized.onnx",)
-    elif quantization == "fp32":
-        stems = ("model.onnx",)
-    else:
-        # Only the INT8 bundle is shipped; fp32 ONNX is optional / omitted.
-        stems = ("model_quantized.onnx",)
-    for stem in stems:
-        model_path = os.path.join(profile_dir, "onnx", stem)
-        sidecar_path = model_path + "_data"
-        if _is_nonempty_file(model_path) and _is_nonempty_file(sidecar_path):
-            return True
-    return False
+    return _profiles.profile_is_complete(
+        model_dir,
+        profile_id,
+        quantization,
+        file_check=_is_nonempty_file,
+    )
 
 
 def _bundled_model_dirs() -> list[str]:
-    """Candidate roots for build-time packaged embedding assets.
-
-    Developers and CI place model files under
-    ``data/embedding_models/<profile_id>/...``. In source runs this is
-    relative to the repo root; in PyInstaller/Nuitka builds it lives next
-    to the bundled launcher resources.
-    """
-    roots: list[str] = []
-    if hasattr(sys, "_MEIPASS"):
-        roots.append(str(sys._MEIPASS))
-    if getattr(sys, "frozen", False) or "__compiled__" in globals():
-        roots.append(os.path.dirname(os.path.abspath(sys.executable)))
-    roots.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
-    seen: set[str] = set()
-    model_dirs: list[str] = []
-    for root in roots:
-        path = os.path.join(root, "data", DEFAULT_VECTORS_MODEL_DIR_NAME)
-        norm = os.path.abspath(path)
-        if norm not in seen:
-            seen.add(norm)
-            model_dirs.append(norm)
-    return model_dirs
+    return _profiles.bundled_model_dirs(
+        __file__,
+        DEFAULT_VECTORS_MODEL_DIR_NAME,
+        compiled="__compiled__" in globals(),
+    )
 
 
 def _select_model_dir(
@@ -1089,22 +904,13 @@ def _select_model_dir(
     profile_id: str,
     quantization: str | None = None,
 ) -> str:
-    """Prefer user-managed app-data models, otherwise use bundled assets.
-
-    A half-downloaded app-data profile, or one that only has the
-    *other* quantization variant from what the runtime resolved to, is
-    treated as broken (see ``_profile_is_complete``) and we fall back to
-    bundled — otherwise the presence-only check would prefer the broken
-    dir and sticky-disable vectors at load even though the bundle is
-    fine. Callers should pass the resolved ``quantization`` so the
-    variant check matches what ``_load_session_blocking`` will open.
-    """
-    if _profile_is_complete(app_docs_model_dir, profile_id, quantization):
-        return app_docs_model_dir
-    for bundled_dir in _bundled_model_dirs():
-        if _profile_is_complete(bundled_dir, profile_id, quantization):
-            return bundled_dir
-    return app_docs_model_dir
+    return _profiles.select_model_dir(
+        app_docs_model_dir,
+        profile_id,
+        quantization,
+        _bundled_model_dirs(),
+        completeness_check=_profile_is_complete,
+    )
 
 
 # ── service ──────────────────────────────────────────────────────────
@@ -1153,7 +959,23 @@ class EmbeddingService:
         # Resolved at construction so ``model_id()`` can return early
         # even before the session loads — callers reading
         # embedding_model_id at write time need a stable id.
-        self._ram_gb = ram_gb if ram_gb is not None else detect_total_ram_gb()
+        capabilities = None
+        if ram_gb is None and has_vnni is None and has_avx2 is None:
+            capabilities = _hardware.detect_capabilities(
+                detect_total_ram_gb,
+                detect_avx_vnni_details,
+                detect_avx2_details,
+            )
+            ram_gb = capabilities.ram_gb
+            has_vnni = capabilities.has_vnni
+            vnni_absence_confirmed = capabilities.vnni_absence_confirmed
+            has_avx2 = capabilities.has_avx2
+            avx2_absence_confirmed = capabilities.avx2_absence_confirmed
+        self._ram_gb = (
+            capabilities.ram_gb
+            if capabilities is not None
+            else ram_gb if ram_gb is not None else detect_total_ram_gb()
+        )
         if has_vnni is not None:
             self._has_vnni = has_vnni
             self._vnni_absence_confirmed = (
@@ -1599,8 +1421,7 @@ def get_embedding_service() -> EmbeddingService:
     sampling), so we don't bother short-circuiting on the lock outside.
     """
     global _SERVICE
-    if _SERVICE is None:
-        _SERVICE = _build_default_service()
+    _SERVICE = _service_lifecycle.get_or_create(_SERVICE, _build_default_service)
     return _SERVICE
 
 
@@ -1612,7 +1433,7 @@ def reset_embedding_service_for_tests() -> None:
     detection can verify the warning is emitted on its synthetic boot.
     """
     global _SERVICE, _VNNI_DECISION_LOGGED
-    _SERVICE = None
+    _SERVICE = _service_lifecycle.reset_for_tests()
     _VNNI_DECISION_LOGGED = False
 
 
@@ -1691,117 +1512,3 @@ def _build_default_service() -> EmbeddingService:
         has_avx2=has_avx2,
         avx2_absence_confirmed=avx2_absence_confirmed,
     )
-
-
-# ── cosine helpers (numpy-free for callers that only need scoring) ────
-
-
-def cosine_similarity(a, b) -> float:
-    """Cosine similarity between two unit-norm vectors.
-
-    Both ``embed()`` outputs are L2-normalized, so this is a straight
-    dot product — no division required. Accepts the canonical base64
-    form, legacy ``list[float]``, or an already-decoded numpy array;
-    decodes lazily so the per-pair API stays compatible with tests and
-    fact-dedup's single-pair callsite. For hot loops over thousands of
-    candidates, prefer building a stacked matrix once via
-    :func:`decode_embedding` and using ``M @ q`` — the recall path does
-    that.
-
-    Out-of-band inputs (None, empty, dim mismatch, malformed base64)
-    return 0.0 rather than raising; retrieval and dedup are happier
-    ranking around an unrankable candidate than crashing because one
-    entry was missing its embedding.
-    """
-    av = decode_embedding(a)
-    bv = decode_embedding(b)
-    if av is None or bv is None:
-        return 0.0
-    if av.size == 0 or bv.size == 0 or av.size != bv.size:
-        return 0.0
-    import numpy as np
-    return float(np.dot(av, bv))
-
-
-def is_cached_embedding_valid(
-    entry: dict, current_text: str, current_model_id: str | None,
-) -> bool:
-    """Decide whether the persisted embedding on ``entry`` is still good.
-
-    Match contract (mirrors ``token_count`` cache in persona.py):
-      * embedding field is a non-empty base64 string (canonical form
-        emitted by :func:`stamp_embedding_fields`)
-      * the payload actually decodes (corrupt base64 → invalid)
-      * decoded length matches the dim encoded in the running
-        ``model_id`` — guards against truncated payloads and against
-        a wrong-quantization payload sneaking through under the right
-        model_id string
-      * sha256 of ``current_text`` matches stored ``embedding_text_sha256``
-      * ``embedding_model_id`` matches the running service's id
-
-    Legacy ``list[float]`` payloads are intentionally treated as invalid
-    so the warmup worker re-stamps them in the new compact form. The
-    one-time CPU cost is bounded (small N at migration time) and avoids
-    carrying two on-disk shapes forward indefinitely.
-
-    Without the decode + dim check, a corrupt cache row would pass the
-    typeof guard, never get re-stamped by the worker (it keeps
-    "validating"), and silently fall through to the unembedded pool in
-    every recall — a permanent retrieval-quality regression for that
-    entry (Codex review on PR #1147).
-
-    Any mismatch → False, callers should clear the embedding fields and
-    re-enqueue the entry for the warmup worker.
-    """
-    if not isinstance(entry, dict):
-        return False
-    emb = entry.get("embedding")
-    if not isinstance(emb, str) or not emb:
-        return False
-    if current_model_id is None:
-        return False
-    if entry.get("embedding_model_id") != current_model_id:
-        return False
-    if entry.get("embedding_text_sha256") != _embedding_text_sha256(current_text):
-        return False
-    decoded = _decode_vector_fp16(emb)
-    if decoded is None or decoded.size == 0:
-        return False
-    expected_dim = parse_dim_from_model_id(current_model_id)
-    if expected_dim is not None and decoded.size != expected_dim:
-        return False
-    return True
-
-
-def clear_embedding_fields(entry: dict) -> None:
-    """In-place wipe of the embedding cache. Call from any path that
-    rewrites ``entry['text']`` so the next render/recall sees a clean
-    cache miss instead of a stale vector tied to the old text."""
-    if not isinstance(entry, dict):
-        return
-    entry["embedding"] = None
-    entry["embedding_text_sha256"] = None
-    entry["embedding_model_id"] = None
-
-
-def stamp_embedding_fields(
-    entry: dict, vector, text: str, model_id: str,
-) -> None:
-    """In-place write of an embedding triple onto an entry.
-
-    Stamping all three fields together (vector + text-sha + model-id)
-    in one helper prevents the half-written state where ``embedding`` is
-    set but the fingerprints aren't, which would otherwise look like a
-    legacy entry on the next read and trigger a recompute.
-
-    The vector is encoded to the canonical base64 fp16 form before
-    storage (see :func:`_encode_vector_fp16`). Callers pass the raw
-    fp32 list returned by :meth:`EmbeddingService.embed` — this helper
-    owns the on-disk encoding so the rest of the pipeline never sees
-    it.
-    """
-    if not isinstance(entry, dict):
-        return
-    entry["embedding"] = _encode_vector_fp16(vector)
-    entry["embedding_text_sha256"] = _embedding_text_sha256(text)
-    entry["embedding_model_id"] = model_id

--- a/memory/embeddings.py
+++ b/memory/embeddings.py
@@ -71,7 +71,6 @@ from ._embeddings import lifecycle as _service_lifecycle
 from ._embeddings import hardware as _hardware
 from ._embeddings import profiles as _profiles
 from ._embeddings.schema import (
-    _MODEL_ID_DIM_RE,
     build_model_id,
     clear_embedding_fields,
     cosine_similarity as _cosine_similarity_impl,

--- a/tests/unit/test_embedding_internal_modules.py
+++ b/tests/unit/test_embedding_internal_modules.py
@@ -1,0 +1,89 @@
+"""Contract tests for the internal ``memory._embeddings`` split."""
+from __future__ import annotations
+
+from memory import embeddings
+from memory._embeddings import hardware, lifecycle, profiles, schema
+
+
+def test_public_schema_facade_keeps_callable_identity():
+    assert embeddings.build_model_id is schema.build_model_id
+    assert embeddings.clear_embedding_fields is schema.clear_embedding_fields
+
+
+def test_schema_facade_keeps_dynamic_private_helper_monkeypatch(monkeypatch):
+    monkeypatch.setattr(embeddings, "_decode_vector_fp16", lambda _value: "sentinel")
+    assert embeddings.decode_embedding("encoded") == "sentinel"
+
+
+def test_hardware_capability_snapshot_uses_injected_probes():
+    capabilities = hardware.detect_capabilities(
+        lambda: 12.0,
+        lambda: (False, True),
+        lambda: (True, True),
+    )
+    assert capabilities == hardware.HardwareCapabilities(
+        ram_gb=12.0,
+        has_vnni=False,
+        vnni_absence_confirmed=True,
+        has_avx2=True,
+        avx2_absence_confirmed=True,
+    )
+
+
+def test_service_default_detection_still_uses_facade_monkeypatches(monkeypatch):
+    monkeypatch.setattr(embeddings, "detect_total_ram_gb", lambda: 12.0)
+    monkeypatch.setattr(
+        embeddings, "detect_avx_vnni_details", lambda: (False, True),
+    )
+    monkeypatch.setattr(embeddings, "detect_avx2_details", lambda: (True, True))
+    monkeypatch.setattr(embeddings, "_cpu_is_blocklisted", lambda: False)
+
+    service = embeddings.EmbeddingService(model_dir="/nonexistent")
+
+    assert service.dim() == 128
+    assert service.is_disabled() is False
+
+
+def test_profile_facade_preserves_file_check_monkeypatch(tmp_path, monkeypatch):
+    profile_dir = tmp_path / "p" / "onnx"
+    profile_dir.mkdir(parents=True)
+    checked: list[str] = []
+
+    def fake_check(path: str) -> bool:
+        checked.append(path)
+        return True
+
+    monkeypatch.setattr(embeddings, "_is_nonempty_file", fake_check)
+    assert embeddings._profile_is_complete(str(tmp_path), "p", "int8")
+    assert len(checked) == 3
+
+
+def test_profile_selection_prefers_complete_bundle(tmp_path):
+    app_dir = tmp_path / "app"
+    bundled_dir = tmp_path / "bundle"
+
+    def complete(root: str, _profile: str, _quantization: str | None) -> bool:
+        return root == str(bundled_dir)
+
+    assert profiles.select_model_dir(
+        str(app_dir),
+        "p",
+        "int8",
+        [str(bundled_dir)],
+        completeness_check=complete,
+    ) == str(bundled_dir)
+
+
+def test_lifecycle_get_or_create_is_lazy_and_stable():
+    calls = 0
+
+    def factory():
+        nonlocal calls
+        calls += 1
+        return object()
+
+    first = lifecycle.get_or_create(None, factory)
+    second = lifecycle.get_or_create(first, factory)
+    assert second is first
+    assert calls == 1
+    assert lifecycle.reset_for_tests() is None


### PR DESCRIPTION
## 改动说明

- 新增 `memory._embeddings.schema`，承接向量 fp16/base64 编解码、model id 与 cache schema。
- 新增 `memory._embeddings.hardware`，承接硬件能力快照及维度/量化选择策略。
- 新增 `memory._embeddings.profiles`，承接模型 profile 完整性校验与目录选择。
- 新增 `memory._embeddings.lifecycle`，承接 `EmbeddingService` singleton 的 lazy create/reset。
- `memory.embeddings` 继续作为兼容 facade；CPU blocklist、文件探测、codec 私有 helper 与 singleton factory 的动态 monkeypatch 路径保留。

## 必要性

`memory/embeddings.py` 同时承担持久化格式、硬件策略、模型目录选择和服务生命周期，职责耦合且难以独立验证。本次按内部职责拆分，同时避免调用方迁移和运行格式变化。

## 前后表现

- 拆分前：上述职责集中在单文件，测试需通过同一模块覆盖全部路径。
- 拆分后：内部职责可单独测试；调用方仍使用 `memory.embeddings`，既有顶层 API、singleton、模型 id、embedding 存储格式及 fallback 行为保持不变。

## 回归报告

- `uv run ruff check memory/embeddings.py memory/_embeddings tests/unit/test_embedding_internal_modules.py`：通过。
- embedding 针对性测试及 recall/refine/reflection 回归共 155 项：`155 passed`。
- import smoke：通过。
- 对比 `origin/main` 顶层 surface：原有 40 个 callable/class 均仍可从 `memory.embeddings` 访问。
- 新增契约测试覆盖 facade 私有 helper monkeypatch、硬件 probe callback、profile file-check monkeypatch、singleton lazy/reset。

## 潜在回归点

- facade 与内部模块之间的 callback 桥接若未来被改成静态绑定，可能破坏测试/集成的 monkeypatch 行为。
- model profile 完整性与量化选择必须继续保持当前回退顺序。
- embedding schema 与 model id 属于磁盘兼容契约，后续修改需同步 cache invalidation 测试。
