### PR TITLE
fix(build): honor plugin packaging rules in Nuitka

### DIFF
--- a/.github/workflows/build-desktop-linux.yml
+++ b/.github/workflows/build-desktop-linux.yml
@@ -113,6 +113,11 @@ jobs:
           uv sync --group galgame
           uv pip install --python .venv nuitka ordered-set zstandard
 
+      - name: Prepare filtered built-in plugins for Nuitka
+        shell: bash
+        run: |
+          .venv/bin/python scripts/prepare_nuitka_plugins.py prepare
+
       # --- Generate runtime config files (not tracked in git) ---
       - name: Generate default config files
         shell: bash
@@ -254,9 +259,8 @@ jobs:
           else
             echo "[WARNING] frontend/plugin-manager/dist missing; /ui will be empty in bundle."
           fi
-          if [ -d "plugin/plugins" ]; then
-            NUITKA_OPTS="$NUITKA_OPTS --include-data-dir=plugin/plugins=plugin/plugins"
-          fi
+          # Built-in plugin data is installed from the filtered stage after
+          # compilation. Nuitka intentionally refuses to treat .py as data.
           NUITKA_OPTS="$NUITKA_OPTS --include-data-dir=playwright_browsers=playwright_browsers"
           if [ -d "data/tiktoken_cache" ]; then
             NUITKA_OPTS="$NUITKA_OPTS --include-data-dir=data/tiktoken_cache=data/tiktoken_cache"
@@ -277,6 +281,8 @@ jobs:
           NUITKA_OPTS="$NUITKA_OPTS --include-package=websockets"
           NUITKA_OPTS="$NUITKA_OPTS --include-package=app"
           NUITKA_OPTS="$NUITKA_OPTS --include-package=config"
+          # The generated launcher carries selective --nofollow-import-to
+          # directives derived from each plugin's [tool.neko.build] rules.
           NUITKA_OPTS="$NUITKA_OPTS --include-package=plugin"
           NUITKA_OPTS="$NUITKA_OPTS --include-package=brain"
           NUITKA_OPTS="$NUITKA_OPTS --include-package=main_logic"
@@ -310,7 +316,6 @@ jobs:
           NUITKA_OPTS="$NUITKA_OPTS --include-package-data=bilibili_api"
 
           # Exclusions
-          NUITKA_OPTS="$NUITKA_OPTS --nofollow-import-to=plugin.plugins"
           NUITKA_OPTS="$NUITKA_OPTS --nofollow-import-to=audiolab"
           NUITKA_OPTS="$NUITKA_OPTS --nofollow-import-to=pyrnnoise"
           NUITKA_OPTS="$NUITKA_OPTS --nofollow-import-to=matplotlib"
@@ -341,15 +346,17 @@ jobs:
           echo "$NUITKA_OPTS" | tr ' ' '\n'
           echo "======================"
 
-          .venv/bin/python -m nuitka $NUITKA_OPTS launcher.py
+          .venv/bin/python -m nuitka $NUITKA_OPTS build_nuitka_launcher.py
 
       # --- Rename Nuitka output directory ---
       - name: Rename build output
         shell: bash
         run: |
-          if [ -d "dist/launcher.dist" ]; then
-            mv dist/launcher.dist dist/Xiao8
+          if [ -d "dist/build_nuitka_launcher.dist" ]; then
+            mv dist/build_nuitka_launcher.dist dist/Xiao8
           fi
+          .venv/bin/python scripts/prepare_nuitka_plugins.py install \
+            --destination-dir dist/Xiao8/plugin/plugins
           echo "=== Build output ==="
           ls -la dist/Xiao8/ || echo "dist/Xiao8 not found!"
 
@@ -397,7 +404,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          .venv/bin/python scripts/check_nuitka_dist.py dist/Xiao8
+          .venv/bin/python scripts/check_nuitka_dist.py dist/Xiao8 --plugin-stage build/nuitka-plugins
 
       - name: Upload Python backend artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-desktop-linux.yml
+++ b/.github/workflows/build-desktop-linux.yml
@@ -316,6 +316,9 @@ jobs:
           NUITKA_OPTS="$NUITKA_OPTS --include-package-data=bilibili_api"
 
           # Exclusions
+          # galgame_plugin/training is offline-only model-training code and is
+          # not governed by a top-level plugin [tool.neko.build] rule.
+          NUITKA_OPTS="$NUITKA_OPTS --nofollow-import-to=plugin.plugins.galgame_plugin.training"
           NUITKA_OPTS="$NUITKA_OPTS --nofollow-import-to=audiolab"
           NUITKA_OPTS="$NUITKA_OPTS --nofollow-import-to=pyrnnoise"
           NUITKA_OPTS="$NUITKA_OPTS --nofollow-import-to=matplotlib"

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -121,6 +121,15 @@ jobs:
           uv sync --group galgame
           uv pip install --python .venv nuitka ordered-set zstandard
 
+      - name: Prepare filtered built-in plugins for Nuitka
+        shell: bash
+        run: |
+          VENV_PYTHON=".venv/bin/python"
+          if [ -f ".venv/Scripts/python.exe" ]; then
+            VENV_PYTHON=".venv/Scripts/python.exe"
+          fi
+          "$VENV_PYTHON" scripts/prepare_nuitka_plugins.py prepare
+
       # --- Generate runtime config files (not tracked in git) ---
       - name: Generate default config files
         shell: bash
@@ -302,9 +311,8 @@ jobs:
           else
             echo "[WARNING] frontend/plugin-manager/dist missing; /ui will be empty in bundle."
           fi
-          if [ -d "plugin/plugins" ]; then
-            NUITKA_OPTS="$NUITKA_OPTS --include-data-dir=plugin/plugins=plugin/plugins"
-          fi
+          # Built-in plugin data is installed from the filtered stage after
+          # compilation. Nuitka intentionally refuses to treat .py as data.
           # macOS: skip bundling playwright_browsers (Chromium .app path has spaces
           # that break Nuitka's xattr call; browser will download on first run)
           if [[ "$RUNNER_OS" != "macOS" ]]; then
@@ -329,13 +337,9 @@ jobs:
           NUITKA_OPTS="$NUITKA_OPTS --include-package=websockets"
           NUITKA_OPTS="$NUITKA_OPTS --include-package=app"
           NUITKA_OPTS="$NUITKA_OPTS --include-package=config"
+          # The generated launcher carries selective --nofollow-import-to
+          # directives derived from each plugin's [tool.neko.build] rules.
           NUITKA_OPTS="$NUITKA_OPTS --include-package=plugin"
-          # Built-in plugins are imported at runtime via their dotted entry path
-          # (plugin.plugins.<name>:Class in each plugin.toml), so they must be
-          # compiled into the binary. Shipping them only via --include-data-dir
-          # drops the .py (Nuitka treats it as code) and every built-in plugin
-          # fails to import. Kept in sync with build_nuitka.bat.
-          NUITKA_OPTS="$NUITKA_OPTS --include-package=plugin.plugins"
           NUITKA_OPTS="$NUITKA_OPTS --include-package=brain"
           NUITKA_OPTS="$NUITKA_OPTS --include-package=main_logic"
           NUITKA_OPTS="$NUITKA_OPTS --include-package=main_routers"
@@ -438,7 +442,7 @@ jobs:
           echo "$NUITKA_OPTS" | tr ' ' '\n'
           echo "======================"
 
-          .venv/bin/python -m nuitka $NUITKA_OPTS launcher.py
+          .venv/bin/python -m nuitka $NUITKA_OPTS build_nuitka_launcher.py
 
       - name: Build with Nuitka (Windows)
         if: runner.os == 'Windows'
@@ -467,7 +471,7 @@ jobs:
           set NUITKA_OPTS=%NUITKA_OPTS% --include-data-dir=data/browser_use_prompts=data/browser_use_prompts
           if not exist "frontend\plugin-manager\dist" echo [WARNING] frontend\plugin-manager\dist missing; /ui will be empty in bundle.
           if exist "frontend\plugin-manager\dist" set NUITKA_OPTS=%NUITKA_OPTS% --include-data-dir=frontend/plugin-manager/dist=frontend/plugin-manager/dist
-          if exist "plugin\plugins" set NUITKA_OPTS=%NUITKA_OPTS% --include-data-dir=plugin/plugins=plugin/plugins
+          rem Built-in plugin payload is copied from the filtered stage after Nuitka.
           set NUITKA_OPTS=%NUITKA_OPTS% --include-data-dir=playwright_browsers=playwright_browsers
           if exist "data\tiktoken_cache" set NUITKA_OPTS=%NUITKA_OPTS% --include-data-dir=data/tiktoken_cache=data/tiktoken_cache
           if exist "data\embedding_models" set NUITKA_OPTS=%NUITKA_OPTS% --include-data-dir=data/embedding_models=data/embedding_models
@@ -482,12 +486,10 @@ jobs:
           set NUITKA_OPTS=%NUITKA_OPTS% --include-package=websockets
           set NUITKA_OPTS=%NUITKA_OPTS% --include-package=app
           set NUITKA_OPTS=%NUITKA_OPTS% --include-package=config
+          rem The generated launcher excludes Python modules filtered by each
+          rem plugin's [tool.neko.build] rules while --include-package compiles
+          rem the remaining dynamically imported built-in modules.
           set NUITKA_OPTS=%NUITKA_OPTS% --include-package=plugin
-          rem Built-in plugins are imported at runtime via their dotted entry path
-          rem (plugin.plugins.[name]:Class in plugin.toml), so they must be compiled
-          rem into the binary; --include-data-dir alone drops the .py. Synced with
-          rem build_nuitka.bat. training/ is offline-only (torch) so carve it out.
-          set NUITKA_OPTS=%NUITKA_OPTS% --include-package=plugin.plugins
           set NUITKA_OPTS=%NUITKA_OPTS% --nofollow-import-to=plugin.plugins.galgame_plugin.training
           set NUITKA_OPTS=%NUITKA_OPTS% --include-package=brain
           set NUITKA_OPTS=%NUITKA_OPTS% --include-package=main_logic
@@ -544,14 +546,14 @@ jobs:
           set NUITKA_OPTS=%NUITKA_OPTS% --windows-console-mode=force
           set NUITKA_OPTS=%NUITKA_OPTS% --assume-yes-for-downloads
 
-          .venv\Scripts\python.exe -m nuitka %NUITKA_OPTS% launcher.py
+          .venv\Scripts\python.exe -m nuitka %NUITKA_OPTS% build_nuitka_launcher.py
 
       # --- Rename Nuitka output directory ---
       - name: Rename build output
         shell: bash
         run: |
-          if [ -d "dist/launcher.dist" ]; then
-            mv dist/launcher.dist dist/Xiao8
+          if [ -d "dist/build_nuitka_launcher.dist" ]; then
+            mv dist/build_nuitka_launcher.dist dist/Xiao8
           fi
           # macOS: playwright_browsers was excluded from Nuitka (xattr bug with
           # spaces in .app paths), copy it manually into the output directory
@@ -559,6 +561,12 @@ jobs:
             cp -R playwright_browsers dist/Xiao8/playwright_browsers
             echo "Copied playwright_browsers into dist/Xiao8/"
           fi
+          VENV_PYTHON=".venv/bin/python"
+          if [ -f ".venv/Scripts/python.exe" ]; then
+            VENV_PYTHON=".venv/Scripts/python.exe"
+          fi
+          "$VENV_PYTHON" scripts/prepare_nuitka_plugins.py install \
+            --destination-dir dist/Xiao8/plugin/plugins
           echo "=== Build output ==="
           ls -la dist/Xiao8/ || echo "dist/Xiao8 not found!"
 
@@ -607,9 +615,9 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "$RUNNER_OS" == "Windows" ]]; then
-            .venv/Scripts/python.exe scripts/check_nuitka_dist.py dist/Xiao8
+            .venv/Scripts/python.exe scripts/check_nuitka_dist.py dist/Xiao8 --plugin-stage build/nuitka-plugins
           else
-            .venv/bin/python scripts/check_nuitka_dist.py dist/Xiao8
+            .venv/bin/python scripts/check_nuitka_dist.py dist/Xiao8 --plugin-stage build/nuitka-plugins
           fi
 
       - name: Upload Python backend artifact

--- a/docs/contributing/nuitka-packaging.md
+++ b/docs/contributing/nuitka-packaging.md
@@ -39,19 +39,31 @@ default suffix filter. For everything else, prefer
 `--include-package=<dotted.name>` so Nuitka compiles the modules into the
 binary.
 
-## Rule 3: New directories require synced updates in build script + CI
+## Rule 3: Built-in plugins must go through the shared staging step
 
-Two independent build configurations exist:
+Two build entrypoints exist:
 
 - `build_nuitka.bat` — local maintainer script, **gitignored** (contains
   signing paths, machine-specific settings).
 - `.github/workflows/build-desktop.yml` — CI build for Linux/macOS/Windows
   release artifacts.
 
-If you add a directory that needs to ship in the bundle, you must update
-**both**. After the Nuitka build, the CI workflow runs
-`scripts/check_nuitka_dist.py` to verify critical assets exist; register new
-required assets there too.
+Both must run `scripts/prepare_nuitka_plugins.py prepare` before Nuitka and
+compile the generated `build_nuitka_launcher.py`. The helper applies every
+plugin's `[tool.neko.build]` rules to a shared staging directory and emits
+selective `--nofollow-import-to` directives for Python modules excluded by
+those same rules. After Nuitka finishes, `prepare_nuitka_plugins.py install`
+replaces `dist/Xiao8/plugin/plugins` with the filtered runtime payload.
+
+Do not add `--include-data-dir=plugin/plugins=plugin/plugins` back to either
+build: it bypasses the plugin rules and still drops `.py` files. Do not add a
+blanket `--nofollow-import-to=plugin.plugins` either, because built-in plugins
+are dynamically imported and must be compiled.
+
+The CI workflow then runs `scripts/check_nuitka_dist.py --plugin-stage ...` to
+verify that the installed plugin tree matches the filtered stage byte for
+byte. New non-plugin assets still require explicit updates in both build
+entrypoints and in the required-asset checker.
 
 ## Rule 4: Don't run the bundled exe casually for diagnosis
 
@@ -78,8 +90,9 @@ The historical neko-plugin-cli bug (PR #1115, "rename neko-plugin-cli
 it. We now have three layers:
 
 1. **Build-time check** — `scripts/check_nuitka_dist.py` runs in CI after
-   Nuitka, verifying the dist root contains every critical directory and
-   that each built-in plugin has its `plugin.toml`.
+   Nuitka, verifying the dist root contains every critical directory, every
+   built-in plugin has its `plugin.toml`, and the installed plugin payload
+   exactly matches the filtered stage.
 2. **Source-level lint** — `tests/unit/test_no_hyphen_python_packages.py`
    fails at PR time if any tracked directory with a hyphen name contains
    `.py` files.

--- a/scripts/check_nuitka_dist.py
+++ b/scripts/check_nuitka_dist.py
@@ -42,6 +42,7 @@ packaging into Electron.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import sys
 from pathlib import Path
 
@@ -114,8 +115,56 @@ def _check_plugin_tomls(dist_root: Path) -> list[str]:
         issues.append(f"no plugin subdirectories under {_PLUGIN_TOML_REQUIRED_PARENT}/")
         return issues
     for sub in plugin_subdirs:
+        if sub.name.startswith("_"):
+            continue
         if not (sub / "plugin.toml").is_file():
             issues.append(f"plugin missing plugin.toml: {sub.relative_to(dist_root).as_posix()}")
+    return issues
+
+
+def _file_digest(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file_obj:
+        for chunk in iter(lambda: file_obj.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _check_plugin_stage(dist_root: Path, stage_root: Path) -> list[str]:
+    """Require the installed plugin payload to exactly match the filtered stage."""
+
+    installed_root = dist_root / _PLUGIN_TOML_REQUIRED_PARENT
+    if not stage_root.is_dir():
+        return [f"plugin stage does not exist: {stage_root}"]
+    if not installed_root.is_dir():
+        return []  # The regular required-asset check reports this more clearly.
+
+    staged_files = {
+        path.relative_to(stage_root).as_posix(): path
+        for path in stage_root.rglob("*")
+        if path.is_file()
+    }
+    installed_files = {
+        path.relative_to(installed_root).as_posix(): path
+        for path in installed_root.rglob("*")
+        if path.is_file()
+    }
+
+    issues: list[str] = []
+    missing = sorted(staged_files.keys() - installed_files.keys())
+    unexpected = sorted(installed_files.keys() - staged_files.keys())
+    if missing:
+        issues.append(f"plugin payload missing {len(missing)} staged file(s): {missing[:5]}")
+    if unexpected:
+        issues.append(f"plugin payload contains {len(unexpected)} unstaged file(s): {unexpected[:5]}")
+
+    mismatched = [
+        relative
+        for relative in sorted(staged_files.keys() & installed_files.keys())
+        if _file_digest(staged_files[relative]) != _file_digest(installed_files[relative])
+    ]
+    if mismatched:
+        issues.append(f"plugin payload changed after staging ({len(mismatched)} file(s)): {mismatched[:5]}")
     return issues
 
 
@@ -126,6 +175,14 @@ def main(argv: list[str] | None = None) -> int:
         nargs="?",
         default="dist/Xiao8",
         help="Path to Nuitka standalone dist root (default: dist/Xiao8)",
+    )
+    parser.add_argument(
+        "--plugin-stage",
+        type=Path,
+        help=(
+            "Filtered built-in plugin stage produced by prepare_nuitka_plugins.py; "
+            "when provided, the installed plugin payload must match it exactly"
+        ),
     )
     args = parser.parse_args(argv)
 
@@ -141,6 +198,8 @@ def main(argv: list[str] | None = None) -> int:
             issues.append(problem)
 
     issues.extend(_check_plugin_tomls(dist_root))
+    if args.plugin_stage is not None:
+        issues.extend(_check_plugin_stage(dist_root, args.plugin_stage.resolve()))
 
     if issues:
         print(f"[FAIL] Nuitka dist verification failed for {dist_root}:", file=sys.stderr)

--- a/scripts/prepare_nuitka_plugins.py
+++ b/scripts/prepare_nuitka_plugins.py
@@ -260,13 +260,26 @@ def install_plugins(*, stage_dir: Path, destination_dir: Path) -> None:
         raise ValueError("plugin stage and destination must not contain each other")
 
     temporary_dir = destination_dir.with_name(destination_dir.name + ".staging")
+    backup_dir = destination_dir.with_name(destination_dir.name + ".old")
+    if backup_dir.exists():
+        if destination_dir.exists():
+            shutil.rmtree(backup_dir)
+        else:
+            backup_dir.replace(destination_dir)
     if temporary_dir.exists():
         shutil.rmtree(temporary_dir)
     temporary_dir.parent.mkdir(parents=True, exist_ok=True)
     shutil.copytree(stage_dir, temporary_dir)
     if destination_dir.exists():
-        shutil.rmtree(destination_dir)
-    temporary_dir.replace(destination_dir)
+        destination_dir.replace(backup_dir)
+    try:
+        temporary_dir.replace(destination_dir)
+    except BaseException:
+        if backup_dir.exists() and not destination_dir.exists():
+            backup_dir.replace(destination_dir)
+        raise
+    if backup_dir.exists():
+        shutil.rmtree(backup_dir)
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/scripts/prepare_nuitka_plugins.py
+++ b/scripts/prepare_nuitka_plugins.py
@@ -131,15 +131,6 @@ def _remove_private_runtime_artifacts(stage_dir: Path) -> list[str]:
             removed.append(path.relative_to(stage_dir).as_posix())
             path.unlink()
 
-    napcat_dir = stage_dir / "qq_auto_reply" / "NapCat.Shell"
-    if napcat_dir.exists():
-        removed.extend(
-            path.relative_to(stage_dir).as_posix()
-            for path in napcat_dir.rglob("*")
-            if path.is_file()
-        )
-        shutil.rmtree(napcat_dir)
-        napcat_dir.mkdir(parents=True, exist_ok=True)
     return removed
 
 

--- a/scripts/prepare_nuitka_plugins.py
+++ b/scripts/prepare_nuitka_plugins.py
@@ -1,0 +1,314 @@
+"""Prepare built-in plugins for Nuitka using each plugin's build rules.
+
+Nuitka deliberately does not copy Python source files as data.  Built-in
+plugins are also imported dynamically, so the desktop build has two separate
+requirements:
+
+* compile only Python modules allowed by ``[tool.neko.build]``;
+* copy the complete filtered runtime payload (including source files used by
+  subprocess/``spec_from_file_location`` entrypoints) into the standalone
+  distribution.
+
+``prepare`` creates that filtered payload and a generated launcher containing
+Nuitka project directives for Python modules excluded by the same rules.
+``install`` atomically replaces ``dist/.../plugin/plugins`` with the staged
+payload after Nuitka finishes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+from plugin.core.python_dependencies import load_pyproject_toml
+from plugin.neko_plugin_cli.core.build_rules import BuildRuleSet, load_build_rules, should_skip_path
+
+
+DEFAULT_STAGE_DIR = Path("build/nuitka-plugins")
+DEFAULT_GENERATED_LAUNCHER = Path("build_nuitka_launcher.py")
+_PRIVATE_SUFFIXES = {".db", ".log"}
+
+
+@dataclass(frozen=True, slots=True)
+class PrepareResult:
+    stage_dir: Path
+    generated_launcher: Path
+    plugin_dirs: tuple[str, ...]
+    staged_files: tuple[str, ...]
+    excluded_paths: tuple[str, ...]
+    excluded_modules: tuple[str, ...]
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _safe_clean_directory(path: Path, *, project_root: Path) -> None:
+    resolved = path.resolve()
+    root = project_root.resolve()
+    if resolved == root or not _is_relative_to(resolved, root):
+        raise ValueError(f"refusing to clean path outside project root: {resolved}")
+    if resolved.exists():
+        shutil.rmtree(resolved)
+    resolved.mkdir(parents=True, exist_ok=True)
+
+
+def _module_name(plugin_dir_name: str, relative_path: Path, *, is_dir: bool) -> str | None:
+    parts = ["plugin", "plugins", plugin_dir_name, *relative_path.parts]
+    if not is_dir:
+        if relative_path.suffix != ".py":
+            return None
+        parts[-1] = relative_path.stem
+        if parts[-1] == "__init__":
+            parts.pop()
+    if not parts or not all(part.isidentifier() for part in parts):
+        return None
+    return ".".join(parts)
+
+
+def _copy_plugin_tree(
+    source_dir: Path,
+    destination_dir: Path,
+    *,
+    rules: BuildRuleSet,
+) -> tuple[list[str], list[str], set[str]]:
+    staged_files: list[str] = []
+    excluded_paths: list[str] = []
+    excluded_modules: set[str] = set()
+    plugin_dir_name = source_dir.name
+
+    for current, dir_names, file_names in os.walk(source_dir, topdown=True):
+        current_path = Path(current)
+        relative_current = current_path.relative_to(source_dir)
+
+        kept_dirs: list[str] = []
+        for dir_name in sorted(dir_names):
+            relative = relative_current / dir_name
+            if should_skip_path(relative, is_dir=True, rules=rules):
+                excluded_paths.append(relative.as_posix() + "/")
+                module = _module_name(plugin_dir_name, relative, is_dir=True)
+                if module is not None:
+                    excluded_modules.add(module)
+                continue
+            kept_dirs.append(dir_name)
+            (destination_dir / relative).mkdir(parents=True, exist_ok=True)
+        dir_names[:] = kept_dirs
+
+        for file_name in sorted(file_names):
+            relative = relative_current / file_name
+            source_path = source_dir / relative
+            if should_skip_path(relative, is_dir=False, rules=rules):
+                excluded_paths.append(relative.as_posix())
+                module = _module_name(plugin_dir_name, relative, is_dir=False)
+                if module is not None:
+                    excluded_modules.add(module)
+                continue
+            destination_path = destination_dir / relative
+            destination_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source_path, destination_path)
+            staged_files.append(relative.as_posix())
+
+    return staged_files, excluded_paths, excluded_modules
+
+
+def _remove_private_runtime_artifacts(stage_dir: Path) -> list[str]:
+    """Preserve the existing desktop-build privacy cleanup in the stage itself."""
+
+    removed: list[str] = []
+    for path in sorted(stage_dir.rglob("*"), reverse=True):
+        if path.is_dir() and path.name == "__pycache__":
+            removed.append(path.relative_to(stage_dir).as_posix() + "/")
+            shutil.rmtree(path)
+        elif path.is_file() and path.suffix.lower() in _PRIVATE_SUFFIXES:
+            removed.append(path.relative_to(stage_dir).as_posix())
+            path.unlink()
+
+    napcat_dir = stage_dir / "qq_auto_reply" / "NapCat.Shell"
+    if napcat_dir.exists():
+        removed.extend(
+            path.relative_to(stage_dir).as_posix()
+            for path in napcat_dir.rglob("*")
+            if path.is_file()
+        )
+        shutil.rmtree(napcat_dir)
+        napcat_dir.mkdir(parents=True, exist_ok=True)
+    return removed
+
+
+def _write_generated_launcher(
+    source_launcher: Path,
+    generated_launcher: Path,
+    *,
+    excluded_modules: set[str],
+) -> None:
+    source_text = source_launcher.read_text(encoding="utf-8-sig")
+    directives = [
+        "# Generated by scripts/prepare_nuitka_plugins.py; do not edit.",
+        *(
+            f"# nuitka-project: --nofollow-import-to={module}"
+            for module in sorted(excluded_modules)
+        ),
+        "",
+    ]
+    generated_launcher.parent.mkdir(parents=True, exist_ok=True)
+    generated_launcher.write_text("\n".join(directives) + source_text, encoding="utf-8", newline="\n")
+
+
+def prepare_plugins(
+    *,
+    project_root: Path,
+    plugins_root: Path,
+    stage_dir: Path,
+    source_launcher: Path,
+    generated_launcher: Path,
+) -> PrepareResult:
+    project_root = project_root.resolve()
+    plugins_root = (project_root / plugins_root).resolve() if not plugins_root.is_absolute() else plugins_root.resolve()
+    stage_dir = (project_root / stage_dir).resolve() if not stage_dir.is_absolute() else stage_dir.resolve()
+    source_launcher = (
+        (project_root / source_launcher).resolve()
+        if not source_launcher.is_absolute()
+        else source_launcher.resolve()
+    )
+    generated_launcher = (
+        (project_root / generated_launcher).resolve()
+        if not generated_launcher.is_absolute()
+        else generated_launcher.resolve()
+    )
+
+    if not plugins_root.is_dir():
+        raise FileNotFoundError(f"built-in plugins directory not found: {plugins_root}")
+    if not source_launcher.is_file():
+        raise FileNotFoundError(f"launcher not found: {source_launcher}")
+    if _is_relative_to(stage_dir, plugins_root) or _is_relative_to(plugins_root, stage_dir):
+        raise ValueError("stage directory and plugin source directory must not contain each other")
+
+    _safe_clean_directory(stage_dir, project_root=project_root)
+
+    plugin_dirs: list[str] = []
+    staged_files: list[str] = []
+    excluded_paths: list[str] = []
+    excluded_modules: set[str] = set()
+
+    for source_file in sorted(path for path in plugins_root.iterdir() if path.is_file()):
+        shutil.copy2(source_file, stage_dir / source_file.name)
+
+    for source_dir in sorted(path for path in plugins_root.iterdir() if path.is_dir()):
+        plugin_dirs.append(source_dir.name)
+        destination_dir = stage_dir / source_dir.name
+        destination_dir.mkdir(parents=True, exist_ok=True)
+        rules = load_build_rules(load_pyproject_toml(source_dir))
+        copied, excluded, modules = _copy_plugin_tree(source_dir, destination_dir, rules=rules)
+        staged_files.extend(f"{source_dir.name}/{item}" for item in copied)
+        excluded_paths.extend(f"{source_dir.name}/{item}" for item in excluded)
+        excluded_modules.update(modules)
+
+    excluded_paths.extend(_remove_private_runtime_artifacts(stage_dir))
+    staged_files = sorted(
+        path.relative_to(stage_dir).as_posix()
+        for path in stage_dir.rglob("*")
+        if path.is_file()
+    )
+    _write_generated_launcher(
+        source_launcher,
+        generated_launcher,
+        excluded_modules=excluded_modules,
+    )
+
+    manifest = {
+        "schema_version": 1,
+        "plugins_root": plugins_root.relative_to(project_root).as_posix(),
+        "stage_dir": stage_dir.relative_to(project_root).as_posix(),
+        "plugin_dirs": plugin_dirs,
+        "staged_files": staged_files,
+        "excluded_paths": sorted(excluded_paths),
+        "excluded_modules": sorted(excluded_modules),
+    }
+    (stage_dir.parent / "nuitka-plugin-stage.json").write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+    return PrepareResult(
+        stage_dir=stage_dir,
+        generated_launcher=generated_launcher,
+        plugin_dirs=tuple(plugin_dirs),
+        staged_files=tuple(staged_files),
+        excluded_paths=tuple(sorted(excluded_paths)),
+        excluded_modules=tuple(sorted(excluded_modules)),
+    )
+
+
+def install_plugins(*, stage_dir: Path, destination_dir: Path) -> None:
+    stage_dir = stage_dir.resolve()
+    destination_dir = destination_dir.resolve()
+    if not stage_dir.is_dir():
+        raise FileNotFoundError(f"Nuitka plugin stage not found: {stage_dir}")
+    if (
+        stage_dir == destination_dir
+        or _is_relative_to(stage_dir, destination_dir)
+        or _is_relative_to(destination_dir, stage_dir)
+    ):
+        raise ValueError("plugin stage and destination must not contain each other")
+
+    temporary_dir = destination_dir.with_name(destination_dir.name + ".staging")
+    if temporary_dir.exists():
+        shutil.rmtree(temporary_dir)
+    temporary_dir.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(stage_dir, temporary_dir)
+    if destination_dir.exists():
+        shutil.rmtree(destination_dir)
+    temporary_dir.replace(destination_dir)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    prepare_parser = subparsers.add_parser("prepare", help="stage plugins and generate launcher")
+    prepare_parser.add_argument("--project-root", type=Path, default=Path("."))
+    prepare_parser.add_argument("--plugins-root", type=Path, default=Path("plugin/plugins"))
+    prepare_parser.add_argument("--stage-dir", type=Path, default=DEFAULT_STAGE_DIR)
+    prepare_parser.add_argument("--source-launcher", type=Path, default=Path("launcher.py"))
+    prepare_parser.add_argument("--output-launcher", type=Path, default=DEFAULT_GENERATED_LAUNCHER)
+
+    install_parser = subparsers.add_parser("install", help="install staged plugins into a Nuitka dist")
+    install_parser.add_argument("--stage-dir", type=Path, default=DEFAULT_STAGE_DIR)
+    install_parser.add_argument("--destination-dir", type=Path, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    if args.command == "prepare":
+        result = prepare_plugins(
+            project_root=args.project_root,
+            plugins_root=args.plugins_root,
+            stage_dir=args.stage_dir,
+            source_launcher=args.source_launcher,
+            generated_launcher=args.output_launcher,
+        )
+        print(
+            f"Prepared {len(result.plugin_dirs)} built-in plugin directories with "
+            f"{len(result.staged_files)} files; excluded {len(result.excluded_paths)} paths."
+        )
+        print(f"Plugin stage: {result.stage_dir}")
+        print(f"Generated launcher: {result.generated_launcher}")
+        return 0
+
+    install_plugins(stage_dir=args.stage_dir, destination_dir=args.destination_dir)
+    print(f"Installed staged built-in plugins into {args.destination_dir.resolve()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/prepare_nuitka_plugins.py
+++ b/scripts/prepare_nuitka_plugins.py
@@ -21,8 +21,16 @@ import argparse
 import json
 import os
 import shutil
+import sys
 from dataclasses import dataclass
 from pathlib import Path
+
+# Direct execution (``python scripts/prepare_nuitka_plugins.py``) puts only
+# ``scripts/`` on sys.path.  Add the repository root before importing the
+# local plugin package; both desktop workflows intentionally use this form.
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPOSITORY_ROOT))
 
 from plugin.core.python_dependencies import load_pyproject_toml
 from plugin.neko_plugin_cli.core.build_rules import BuildRuleSet, load_build_rules, should_skip_path

--- a/tests/unit/test_prepare_nuitka_plugins.py
+++ b/tests/unit/test_prepare_nuitka_plugins.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
+import subprocess
+import sys
 
 from scripts.check_nuitka_dist import _check_plugin_stage, _check_plugin_tomls
 from scripts.prepare_nuitka_plugins import install_plugins, prepare_plugins
@@ -154,3 +157,23 @@ def test_desktop_workflows_use_filtered_plugin_stage() -> None:
         assert "--plugin-stage build/nuitka-plugins" in workflow
         assert "--include-data-dir=plugin/plugins=plugin/plugins" not in workflow
         assert 'NUITKA_OPTS="$NUITKA_OPTS --nofollow-import-to=plugin.plugins"' not in workflow
+        assert "--nofollow-import-to=plugin.plugins.galgame_plugin.training" in workflow
+
+
+def test_prepare_helper_is_directly_executable_without_pythonpath(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    helper = repo_root / "scripts" / "prepare_nuitka_plugins.py"
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+
+    completed = subprocess.run(
+        [sys.executable, str(helper), "--help"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "stage plugins and generate launcher" in completed.stdout

--- a/tests/unit/test_prepare_nuitka_plugins.py
+++ b/tests/unit/test_prepare_nuitka_plugins.py
@@ -103,6 +103,24 @@ def test_prepare_keeps_shared_plugin_runtime_directory(tmp_path: Path) -> None:
     assert (result.stage_dir / "_shared" / "helper.py").is_file()
 
 
+def test_prepare_preserves_allowed_bundled_napcat_launcher(tmp_path: Path) -> None:
+    project_root = tmp_path / "repo"
+    _write(project_root / "launcher.py", "pass\n")
+    plugin_dir = project_root / "plugin" / "plugins" / "qq_auto_reply"
+    _write(plugin_dir / "plugin.toml", '[plugin]\nid = "qq_auto_reply"\n')
+    _write(plugin_dir / "NapCat.Shell" / "launcher.bat", "@echo off\n")
+
+    result = prepare_plugins(
+        project_root=project_root,
+        plugins_root=Path("plugin/plugins"),
+        stage_dir=Path("build/nuitka-plugins"),
+        source_launcher=Path("launcher.py"),
+        generated_launcher=Path("build_nuitka_launcher.py"),
+    )
+
+    assert (result.stage_dir / "qq_auto_reply" / "NapCat.Shell" / "launcher.bat").is_file()
+
+
 def test_dist_check_matches_stage_and_allows_shared_directory(tmp_path: Path) -> None:
     stage = tmp_path / "stage"
     dist_root = tmp_path / "dist"

--- a/tests/unit/test_prepare_nuitka_plugins.py
+++ b/tests/unit/test_prepare_nuitka_plugins.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.check_nuitka_dist import _check_plugin_stage, _check_plugin_tomls
+from scripts.prepare_nuitka_plugins import install_plugins, prepare_plugins
+
+
+def _write(path: Path, content: str = "runtime\n") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_prepare_and_install_plugins_apply_neko_build_rules(tmp_path: Path) -> None:
+    project_root = tmp_path / "repo"
+    plugin_dir = project_root / "plugin" / "plugins" / "demo_plugin"
+    _write(project_root / "launcher.py", "print('launcher')\n")
+    _write(plugin_dir / "plugin.toml", '[plugin]\nid = "demo_plugin"\n')
+    _write(
+        plugin_dir / "pyproject.toml",
+        "\n".join(
+            [
+                "[project]",
+                'name = "demo-plugin"',
+                'version = "0.1.0"',
+                "dependencies = []",
+                "",
+                "[tool.neko.build]",
+                'exclude_dirs = ["tests", "local_logs"]',
+                'exclude_files = ["README.md"]',
+                'exclude = ["*.tmp"]',
+                "",
+            ]
+        ),
+    )
+    _write(plugin_dir / "__init__.py")
+    _write(plugin_dir / "runtime.py")
+    _write(plugin_dir / "data layer" / "worker.py")
+    _write(plugin_dir / "tests" / "__init__.py")
+    _write(plugin_dir / "tests" / "test_runtime.py")
+    _write(plugin_dir / "local_logs" / "private.txt")
+    _write(plugin_dir / "README.md")
+    _write(plugin_dir / "scratch.tmp")
+    _write(plugin_dir / "store.db")
+    _write(plugin_dir / "runtime.log")
+
+    result = prepare_plugins(
+        project_root=project_root,
+        plugins_root=Path("plugin/plugins"),
+        stage_dir=Path("build/nuitka-plugins"),
+        source_launcher=Path("launcher.py"),
+        generated_launcher=Path("build_nuitka_launcher.py"),
+    )
+
+    stage_plugin = result.stage_dir / "demo_plugin"
+    assert (stage_plugin / "runtime.py").is_file()
+    assert (stage_plugin / "data layer" / "worker.py").is_file()
+    assert not (stage_plugin / "tests").exists()
+    assert not (stage_plugin / "local_logs").exists()
+    assert not (stage_plugin / "README.md").exists()
+    assert not (stage_plugin / "scratch.tmp").exists()
+    assert not (stage_plugin / "store.db").exists()
+    assert not (stage_plugin / "runtime.log").exists()
+
+    generated = result.generated_launcher.read_text(encoding="utf-8")
+    assert "--nofollow-import-to=plugin.plugins.demo_plugin.tests" in generated
+    assert "plugin.plugins.demo_plugin.data layer" not in generated
+    assert generated.endswith("print('launcher')\n")
+
+    manifest = json.loads(
+        (result.stage_dir.parent / "nuitka-plugin-stage.json").read_text(encoding="utf-8")
+    )
+    assert "demo_plugin/tests/" in manifest["excluded_paths"]
+    assert "plugin.plugins.demo_plugin.tests" in manifest["excluded_modules"]
+
+    destination = project_root / "dist" / "Xiao8" / "plugin" / "plugins"
+    _write(destination / "stale_plugin" / "plugin.toml")
+    install_plugins(stage_dir=result.stage_dir, destination_dir=destination)
+
+    assert not (destination / "stale_plugin").exists()
+    assert (destination / "demo_plugin" / "runtime.py").is_file()
+    assert not (destination / ".nuitka-stage.json").exists()
+
+
+def test_prepare_keeps_shared_plugin_runtime_directory(tmp_path: Path) -> None:
+    project_root = tmp_path / "repo"
+    _write(project_root / "launcher.py", "pass\n")
+    _write(project_root / "plugin" / "plugins" / "__init__.py")
+    _write(project_root / "plugin" / "plugins" / "_shared" / "__init__.py")
+    _write(project_root / "plugin" / "plugins" / "_shared" / "helper.py")
+
+    result = prepare_plugins(
+        project_root=project_root,
+        plugins_root=Path("plugin/plugins"),
+        stage_dir=Path("build/nuitka-plugins"),
+        source_launcher=Path("launcher.py"),
+        generated_launcher=Path("build_nuitka_launcher.py"),
+    )
+
+    assert result.plugin_dirs == ("_shared",)
+    assert (result.stage_dir / "__init__.py").is_file()
+    assert (result.stage_dir / "_shared" / "helper.py").is_file()
+
+
+def test_dist_check_matches_stage_and_allows_shared_directory(tmp_path: Path) -> None:
+    stage = tmp_path / "stage"
+    dist_root = tmp_path / "dist"
+    installed = dist_root / "plugin" / "plugins"
+    _write(stage / "demo" / "plugin.toml")
+    _write(stage / "demo" / "runtime.py")
+    _write(stage / "_shared" / "helper.py")
+    install_plugins(stage_dir=stage, destination_dir=installed)
+
+    assert _check_plugin_tomls(dist_root) == []
+    assert _check_plugin_stage(dist_root, stage) == []
+
+    _write(installed / "demo" / "README.md")
+    issues = _check_plugin_stage(dist_root, stage)
+    assert len(issues) == 1
+    assert "unstaged file" in issues[0]
+
+
+def test_desktop_workflows_use_filtered_plugin_stage() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    workflow_paths = (
+        repo_root / ".github" / "workflows" / "build-desktop.yml",
+        repo_root / ".github" / "workflows" / "build-desktop-linux.yml",
+    )
+
+    for workflow_path in workflow_paths:
+        workflow = workflow_path.read_text(encoding="utf-8")
+        assert "scripts/prepare_nuitka_plugins.py prepare" in workflow
+        assert "build_nuitka_launcher.py" in workflow
+        assert "scripts/prepare_nuitka_plugins.py install" in workflow
+        assert "--plugin-stage build/nuitka-plugins" in workflow
+        assert "--include-data-dir=plugin/plugins=plugin/plugins" not in workflow
+        assert 'NUITKA_OPTS="$NUITKA_OPTS --nofollow-import-to=plugin.plugins"' not in workflow

--- a/tests/unit/test_prepare_nuitka_plugins.py
+++ b/tests/unit/test_prepare_nuitka_plugins.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import subprocess
 import sys
 
+import pytest
+
 from scripts.check_nuitka_dist import _check_plugin_stage, _check_plugin_tomls
 from scripts.prepare_nuitka_plugins import install_plugins, prepare_plugins
 
@@ -142,6 +144,30 @@ def test_dist_check_matches_stage_and_allows_shared_directory(tmp_path: Path) ->
     assert "unstaged file" in issues[0]
 
 
+def test_install_plugins_restores_previous_payload_when_replace_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stage = tmp_path / "stage"
+    destination = tmp_path / "dist" / "plugin" / "plugins"
+    _write(stage / "demo" / "new.py", "new")
+    _write(destination / "demo" / "old.py", "old")
+    temporary = destination.with_name(destination.name + ".staging")
+    original_replace = Path.replace
+
+    def fail_new_payload(path: Path, target: Path) -> Path:
+        if path == temporary:
+            raise OSError("simulated interrupted replacement")
+        return original_replace(path, target)
+
+    monkeypatch.setattr(Path, "replace", fail_new_payload)
+
+    with pytest.raises(OSError, match="simulated interrupted replacement"):
+        install_plugins(stage_dir=stage, destination_dir=destination)
+
+    assert (destination / "demo" / "old.py").read_text(encoding="utf-8") == "old"
+    assert not (destination / "demo" / "new.py").exists()
+
+
 def test_desktop_workflows_use_filtered_plugin_stage() -> None:
     repo_root = Path(__file__).resolve().parents[2]
     workflow_paths = (
@@ -151,12 +177,14 @@ def test_desktop_workflows_use_filtered_plugin_stage() -> None:
 
     for workflow_path in workflow_paths:
         workflow = workflow_path.read_text(encoding="utf-8")
+        workflow_lines = {line.strip() for line in workflow.splitlines()}
         assert "scripts/prepare_nuitka_plugins.py prepare" in workflow
         assert "build_nuitka_launcher.py" in workflow
         assert "scripts/prepare_nuitka_plugins.py install" in workflow
         assert "--plugin-stage build/nuitka-plugins" in workflow
         assert "--include-data-dir=plugin/plugins=plugin/plugins" not in workflow
         assert 'NUITKA_OPTS="$NUITKA_OPTS --nofollow-import-to=plugin.plugins"' not in workflow
+        assert "set NUITKA_OPTS=%NUITKA_OPTS% --nofollow-import-to=plugin.plugins" not in workflow_lines
         assert "--nofollow-import-to=plugin.plugins.galgame_plugin.training" in workflow
 
 


### PR DESCRIPTION
## Summary

- stage built-in plugins with each plugin's `[tool.neko.build]` rules before Nuitka compilation
- generate selective Nuitka exclusions for filtered Python modules while preserving raw runtime scripts
- install the filtered stage into desktop artifacts and verify the final plugin tree byte-for-byte
- apply the same path to the cross-platform and Linux-only GitHub Actions workflows

## Why

The desktop builds previously copied `plugin/plugins` wholesale as data and recursively compiled `plugin.plugins`. That bypassed plugin-specific build exclusions, shipped development/runtime artifacts, and could not preserve Python files that plugins load from paths at runtime because Nuitka does not treat `.py` as data.

The shared staging step now makes local and CI builds consume the same plugin packaging contract as `neko-plugin build`.

## Validation

- `uv run --no-sync pytest tests/unit/test_prepare_nuitka_plugins.py plugin/tests/unit/test_neko_plugin_cli_public.py plugin/tests/unit/test_neko_plugin_cli_deps.py -q` (`44 passed`)
- `uv run --no-sync ruff check scripts/prepare_nuitka_plugins.py scripts/check_nuitka_dist.py tests/unit/test_prepare_nuitka_plugins.py`
- parsed both desktop workflow YAML files with PyYAML
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化桌面版打包流程，确保内置插件按构建规则筛选并正确安装。
  * 增强发布包校验，自动比对插件文件的完整性与内容一致性。
  * 改进插件导入处理，减少不必要的内容并提升打包可靠性。

* **文档**
  * 更新 Nuitka 打包指南，补充插件筛选、安装及验证要求。

* **测试**
  * 新增插件筛选、安装、校验及桌面构建流程测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->