### PR TITLE
新增启动默认猫咪形态处理，启动后自动进入离开状态

### DIFF
--- a/static/app/app-auto-goodbye.js
+++ b/static/app/app-auto-goodbye.js
@@ -705,23 +705,47 @@
         );
     }
 
+    function cancelStartupDefaultCatRequest(markApplied) {
+        if (state.startupDefaultCatTimerId) {
+            window.clearTimeout(state.startupDefaultCatTimerId);
+            state.startupDefaultCatTimerId = 0;
+        }
+        state.startupDefaultCatRequested = false;
+        state.startupDefaultCatAttempts = 0;
+        if (markApplied === true) state.startupDefaultCatApplied = true;
+    }
+
+    function scheduleStartupDefaultCatRetry() {
+        state.startupDefaultCatTimerId = window.setTimeout(
+            applyStartupDefaultCat,
+            STARTUP_DEFAULT_CAT_RETRY_MS
+        );
+    }
+
     function applyStartupDefaultCat() {
         state.startupDefaultCatTimerId = 0;
         if (!state.startupDefaultCatRequested || state.startupDefaultCatApplied) return;
+        // The startup event can arrive before the storage-location barrier is released.
+        // Do not spend the avatar-readiness retry budget while app startup is still blocked.
+        if (!state.started) {
+            scheduleStartupDefaultCatRetry();
+            return;
+        }
         if (isGoodbyeActive()) {
-            state.startupDefaultCatApplied = true;
+            cancelStartupDefaultCatRequest(true);
             return;
         }
         if (!hasCoreInfrastructure() || !hasStartupDefaultCatTarget()) {
             state.startupDefaultCatAttempts += 1;
             if (state.startupDefaultCatAttempts < STARTUP_DEFAULT_CAT_MAX_ATTEMPTS) {
-                state.startupDefaultCatTimerId = window.setTimeout(
-                    applyStartupDefaultCat,
-                    STARTUP_DEFAULT_CAT_RETRY_MS
-                );
+                scheduleStartupDefaultCatRetry();
+            } else {
+                // Let a later startup-form signal start a fresh readiness attempt.
+                cancelStartupDefaultCatRequest(false);
             }
             return;
         }
+        state.startupDefaultCatRequested = false;
         state.startupDefaultCatApplied = true;
         window.dispatchEvent(new CustomEvent('live2d-goodbye-click', {
             detail: {
@@ -835,6 +859,10 @@
 
         window.addEventListener('live2d-goodbye-click', (event) => {
             const detail = event && event.detail && typeof event.detail === 'object' ? event.detail : {};
+            if (detail.startupDefaultForm !== 'cat' && state.startupDefaultCatRequested) {
+                // A manual goodbye is a newer user choice; never let a delayed startup retry override it.
+                cancelStartupDefaultCatRequest(true);
+            }
             clearConversationGrace();
             // 记录"变成猫咪"的时刻与入口，供变回时按猫咪停留时长触发专属问候。
             // goodbye-click 只在真正进入猫咪态时派发（手动按钮 / 自动 idle-timeout），
@@ -859,6 +887,8 @@
         });
 
         const handleReturn = () => {
+            // Returning is an explicit user override of any startup request still waiting for avatar readiness.
+            cancelStartupDefaultCatRequest(true);
             // 变回猫娘前，按"作为猫咪待了多久 + 此刻所处 tier（清醒/打盹/熟睡）"
             // 请求一次专属问候。tier 必须在 setVisualTier(NONE) 清空之前读取。
             syncGoodbyeSilentState(false, 'return-click');

--- a/static/app/app-auto-goodbye.js
+++ b/static/app/app-auto-goodbye.js
@@ -7,6 +7,8 @@
     const CONVERSATION_GRACE_MS = 15 * 1000;
     const TICK_INTERVAL_MS = 500;
     const CAT3_DRAG_RELEASES_BEFORE_CAT2 = 2;
+    const STARTUP_DEFAULT_CAT_RETRY_MS = 200;
+    const STARTUP_DEFAULT_CAT_MAX_ATTEMPTS = 300;
 
     const TIER_NONE = 'none';
     const TIER_CAT1 = 'cat1';
@@ -69,6 +71,10 @@
         // 用户「自动变猫」开关：true=启用自动变猫（默认）。禁用时 getIdleBlockReasons 持续上报
         // 'user-disabled'，从而挡掉自动 idle 变猫；不影响已处猫态或手动请离开。init 时从 localStorage 读取。
         autoCatEnabled: true,
+        startupDefaultCatRequested: false,
+        startupDefaultCatApplied: false,
+        startupDefaultCatAttempts: 0,
+        startupDefaultCatTimerId: 0,
     };
 
     function nowMs() {
@@ -693,10 +699,54 @@
         return true;
     }
 
+    function hasStartupDefaultCatTarget() {
+        return !!document.querySelector(
+            '#live2d-btn-goodbye, #vrm-btn-goodbye, #mmd-btn-goodbye, #pngtuber-btn-goodbye'
+        );
+    }
+
+    function applyStartupDefaultCat() {
+        state.startupDefaultCatTimerId = 0;
+        if (!state.startupDefaultCatRequested || state.startupDefaultCatApplied) return;
+        if (isGoodbyeActive()) {
+            state.startupDefaultCatApplied = true;
+            return;
+        }
+        if (!hasCoreInfrastructure() || !hasStartupDefaultCatTarget()) {
+            state.startupDefaultCatAttempts += 1;
+            if (state.startupDefaultCatAttempts < STARTUP_DEFAULT_CAT_MAX_ATTEMPTS) {
+                state.startupDefaultCatTimerId = window.setTimeout(
+                    applyStartupDefaultCat,
+                    STARTUP_DEFAULT_CAT_RETRY_MS
+                );
+            }
+            return;
+        }
+        state.startupDefaultCatApplied = true;
+        window.dispatchEvent(new CustomEvent('live2d-goodbye-click', {
+            detail: {
+                startupDefaultForm: 'cat',
+                source: 'startup-default-form',
+                reason: 'startup-default-cat',
+            },
+        }));
+    }
+
+    function requestStartupDefaultCat() {
+        if (state.startupDefaultCatRequested || state.startupDefaultCatApplied) return;
+        state.startupDefaultCatRequested = true;
+        state.startupDefaultCatAttempts = 0;
+        applyStartupDefaultCat();
+    }
+
     function clearTimers(reason) {
         if (state.timerId) {
             window.clearInterval(state.timerId);
             state.timerId = 0;
+        }
+        if (state.startupDefaultCatTimerId) {
+            window.clearTimeout(state.startupDefaultCatTimerId);
+            state.startupDefaultCatTimerId = 0;
         }
         if (typeof reason === 'string' && reason) {
             state.lastReason = reason;
@@ -778,6 +828,10 @@
             }
             noteUserInteraction(source);
         });
+        window.addEventListener('neko:startup-default-form', (event) => {
+            const detail = event && event.detail && typeof event.detail === 'object' ? event.detail : {};
+            if (detail.form === 'cat') requestStartupDefaultCat();
+        });
 
         window.addEventListener('live2d-goodbye-click', (event) => {
             const detail = event && event.detail && typeof event.detail === 'object' ? event.detail : {};
@@ -792,11 +846,12 @@
                 state.lastReason = typeof detail.reason === 'string' ? detail.reason : 'idle-timeout';
                 syncVisualTierFromCurrentState('goodbye-event');
             } else {
+                const isStartupDefaultCat = detail.startupDefaultForm === 'cat';
                 state.autoGoodbyeTriggered = false;
-                state.lastReason = 'manual-goodbye';
+                state.lastReason = isStartupDefaultCat ? 'startup-default-cat' : 'manual-goodbye';
                 clearDragTierMemory();
                 setVisualTier(TIER_CAT1, {
-                    source: 'manual-goodbye',
+                    source: isStartupDefaultCat ? 'startup-default-form' : 'manual-goodbye',
                     reason: state.lastReason,
                 });
             }

--- a/tests/unit/test_startup_default_cat_static.py
+++ b/tests/unit/test_startup_default_cat_static.py
@@ -16,6 +16,16 @@ def test_startup_default_cat_waits_for_avatar_then_uses_the_existing_goodbye_flo
     assert "startupDefaultForm: 'cat'" in source
 
 
+def test_startup_default_cat_retry_is_deferred_and_user_actions_cancel_it():
+    source = APP_AUTO_GOODBYE.read_text(encoding="utf-8")
+
+    assert "if (!state.started)" in source
+    assert "cancelStartupDefaultCatRequest(false);" in source
+    assert "detail.startupDefaultForm !== 'cat' && state.startupDefaultCatRequested" in source
+    assert "const handleReturn = () => {\n            // Returning" in source
+    assert "cancelStartupDefaultCatRequest(true);" in source
+
+
 def test_startup_default_cat_is_cat1_and_has_a_distinct_silence_reason():
     source = APP_AUTO_GOODBYE.read_text(encoding="utf-8")
 

--- a/tests/unit/test_startup_default_cat_static.py
+++ b/tests/unit/test_startup_default_cat_static.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+APP_AUTO_GOODBYE = PROJECT_ROOT / "static" / "app" / "app-auto-goodbye.js"
+
+
+def test_startup_default_cat_waits_for_avatar_then_uses_the_existing_goodbye_flow():
+    source = APP_AUTO_GOODBYE.read_text(encoding="utf-8")
+
+    assert "window.addEventListener('neko:startup-default-form'" in source
+    assert "if (detail.form === 'cat') requestStartupDefaultCat();" in source
+    assert "STARTUP_DEFAULT_CAT_MAX_ATTEMPTS = 300" in source
+    assert "#live2d-btn-goodbye, #vrm-btn-goodbye, #mmd-btn-goodbye, #pngtuber-btn-goodbye" in source
+    assert "window.dispatchEvent(new CustomEvent('live2d-goodbye-click'" in source
+    assert "startupDefaultForm: 'cat'" in source
+
+
+def test_startup_default_cat_is_cat1_and_has_a_distinct_silence_reason():
+    source = APP_AUTO_GOODBYE.read_text(encoding="utf-8")
+
+    assert "const isStartupDefaultCat = detail.startupDefaultForm === 'cat';" in source
+    assert "state.lastReason = isStartupDefaultCat ? 'startup-default-cat' : 'manual-goodbye';" in source
+    assert "source: isStartupDefaultCat ? 'startup-default-form' : 'manual-goodbye'" in source
+    assert "setVisualTier(TIER_CAT1" in source


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

新增启动默认猫咪形态处理，启动后自动进入离开状态
[默认开启猫咪模式的选项
](https://github.com/Project-N-E-K-O/N.E.K.O/issues/2086#issuecomment-4949345863)

## 测试 / Testing

手动测试默认猫咪形态功能

## 另一边

[新增托盘启动默认形态设置，并实现猫咪模式下的聊天框定位后最小化及呼吸球锁定](https://github.com/Project-N-E-K-O/N.E.K.O.-PC/pull/334)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 启动时默认表单选择“猫”时，将自动触发对应的猫咪告别效果。
  * 在页面组件尚未准备就绪时自动重试，准备完成后仅应用一次。
  * 区分启动默认猫咪与手动告别操作，分别应用对应的视觉效果。

* **测试**
  * 新增启动默认猫咪流程、重试机制及视觉效果的自动化验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->