### PR TITLE
fix(plugin): sanitize and harden web search result parsing

### DIFF
--- a/plugin/plugins/web_search/__init__.py
+++ b/plugin/plugins/web_search/__init__.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any, Dict, List, Optional
 
 from plugin.sdk.plugin import (
@@ -167,10 +168,19 @@ class WebSearchPlugin(NekoPluginBase):
         self._country: Optional[str] = None
         self._is_cn: bool = False
         self._client: Optional[httpx.AsyncClient] = None
+        self._client_loop: Optional[asyncio.AbstractEventLoop] = None
 
     def _get_client(self) -> httpx.AsyncClient:
-        if self._client is None or self._client.is_closed:
+        # 宿主对 startup / 命令循环 / shutdown 分别 asyncio.run()（plugin/core/host.py），
+        # 连接池绑定在创建它的循环上：只在同一循环内复用，循环切换时丢弃重建
+        loop = asyncio.get_running_loop()
+        if (
+            self._client is None
+            or self._client.is_closed
+            or self._client_loop is not loop
+        ):
             self._client = httpx.AsyncClient(follow_redirects=True)
+            self._client_loop = loop
         return self._client
 
     @lifecycle(id="startup")
@@ -191,8 +201,15 @@ class WebSearchPlugin(NekoPluginBase):
 
     @lifecycle(id="shutdown")
     async def shutdown(self, **_):
-        if self._client is not None and not self._client.is_closed:
-            await self._client.aclose()
+        client, self._client = self._client, None
+        self._client_loop = None
+        if client is not None and not client.is_closed:
+            try:
+                await client.aclose()
+            except Exception:
+                # shutdown 运行在新的事件循环里，跨循环关闭旧连接池可能报错；
+                # 进程即将退出，尽力关闭即可
+                pass
         self.logger.info("WebSearch shutdown")
         return Ok({"status": "shutdown"})
 

--- a/plugin/plugins/web_search/__init__.py
+++ b/plugin/plugins/web_search/__init__.py
@@ -139,6 +139,8 @@ async def _search_baidu(
         try:
             await client.get(_BAIDU_HOME_URL, headers=headers, timeout=timeout)
         except httpx.HTTPError:
+            # Cookie 预热失败不阻断搜索本身：没拿到 Cookie 时大概率命中
+            # 安全验证页，由下方 is_baidu_blocked 显式报错，无需在此处理
             pass
 
     resp = await client.get(

--- a/plugin/plugins/web_search/__init__.py
+++ b/plugin/plugins/web_search/__init__.py
@@ -300,9 +300,13 @@ class WebSearchPlugin(NekoPluginBase):
 
         try:
             results = await self._do_text_search(query, max_r, timeout)
+        except SearchBlockedError as e:
+            return Err(SdkError(str(e)))
         except Exception as e:
+            # 异常文本可能带完整请求 URL（含 wd= 查询词），只回传类型名，
+            # 细节留在本地文件日志里
             self.logger.exception("Search failed (query_len={})", len(query))
-            return Err(SdkError(f"搜索失败: {e}"))
+            return Err(SdkError(f"搜索失败: {type(e).__name__}"))
 
         summary = self._build_summary(query, results)
         self.logger.info(
@@ -349,8 +353,11 @@ class WebSearchPlugin(NekoPluginBase):
 
         try:
             results = await self._do_text_search(query, max_r, timeout)
+        except SearchBlockedError as e:
+            return Err(SdkError(str(e)))
         except Exception as e:
-            return Err(SdkError(f"搜索失败: {e}"))
+            self.logger.exception("Search failed (query_len={})", len(query))
+            return Err(SdkError(f"搜索失败: {type(e).__name__}"))
 
         return Ok({
             "query": query,

--- a/plugin/plugins/web_search/__init__.py
+++ b/plugin/plugins/web_search/__init__.py
@@ -5,13 +5,12 @@
 - 中国大陆 → Baidu
 - 海外 → DuckDuckGo HTML 抓取
 全部基于 httpx + BeautifulSoup，不依赖任何第三方搜索库。
+解析与文本清洗逻辑在 _parsing.py（纯函数，可单测）。
 """
 
 from __future__ import annotations
 
-import re
 from typing import Any, Dict, List, Optional
-from urllib.parse import unquote
 
 from plugin.sdk.plugin import (
     NekoPluginBase,
@@ -24,7 +23,15 @@ from plugin.sdk.plugin import (
 )
 
 import httpx
-from bs4 import BeautifulSoup  # type: ignore[import-untyped]
+
+from ._parsing import (
+    SearchBlockedError,
+    decode_html,
+    is_baidu_blocked,
+    parse_baidu_html,
+    parse_ddg_html,
+    parse_ddg_lite_html,
+)
 
 _UA = (
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
@@ -34,6 +41,7 @@ _UA = (
 
 _DDG_HTML_URL = "https://html.duckduckgo.com/html/"
 _DDG_LITE_URL = "https://lite.duckduckgo.com/lite/"
+_BAIDU_HOME_URL = "https://www.baidu.com/"
 _BAIDU_SEARCH_URL = "https://www.baidu.com/s"
 _GEOIP_URL = "http://ip-api.com/json/?fields=countryCode"
 
@@ -63,130 +71,56 @@ async def _detect_country(timeout: float = 4.0) -> Optional[str]:
 
 
 # ---------------------------------------------------------------------------
-# DuckDuckGo HTML scraping (international)
+# Fetchers (shared client: keeps cookies + connection reuse across searches)
 # ---------------------------------------------------------------------------
 
-def _extract_real_url(href: str) -> str:
-    if "uddg=" in href:
-        match = re.search(r"uddg=([^&]+)", href)
-        if match:
-            return unquote(match.group(1))
-    return href
-
-
-def _is_ddg_ad_url(url: str) -> bool:
-    return "duckduckgo.com/y.js" in url or "ad_provider=" in url
-
-
-async def _search_ddg_html(
-    query: str,
-    max_results: int = 8,
-    region: str = "wt-wt",
-    timeout: float = 15.0,
-) -> List[Dict[str, str]]:
-    headers = {
+def _ddg_headers() -> Dict[str, str]:
+    return {
         "User-Agent": _UA,
         "Accept": "text/html,application/xhtml+xml",
         "Accept-Language": "en-US,en;q=0.9",
         "Referer": "https://duckduckgo.com/",
     }
-    data = {"q": query, "kl": region}
-
-    async with httpx.AsyncClient(
-        timeout=timeout,
-        follow_redirects=True,
-        headers=headers,
-    ) as client:
-        resp = await client.post(_DDG_HTML_URL, data=data)
-        resp.raise_for_status()
-
-    soup = BeautifulSoup(resp.text, "html.parser")
-    results: List[Dict[str, str]] = []
-
-    for link_tag in soup.select("a.result__a"):
-        parent = link_tag.find_parent("div", class_=re.compile(r"result--ad"))
-        if parent:
-            continue
-
-        title = link_tag.get_text(strip=True)
-        href = link_tag.get("href", "")
-        real_url = _extract_real_url(str(href))
-        if not real_url or not title:
-            continue
-        if _is_ddg_ad_url(real_url):
-            continue
-
-        snippet_tag = link_tag.find_parent("div", class_="result")
-        snippet = ""
-        if snippet_tag:
-            sn = snippet_tag.select_one("a.result__snippet")
-            if sn:
-                snippet = sn.get_text(strip=True)
-
-        results.append({"title": title, "url": real_url, "snippet": snippet})
-        if len(results) >= max_results:
-            break
-
-    return results
 
 
-async def _search_ddg_lite(
+async def _search_ddg_html(
+    client: httpx.AsyncClient,
     query: str,
     max_results: int = 8,
     region: str = "wt-wt",
     timeout: float = 15.0,
 ) -> List[Dict[str, str]]:
-    headers = {
-        "User-Agent": _UA,
-        "Accept": "text/html",
-        "Accept-Language": "en-US,en;q=0.9",
-    }
-    data = {"q": query, "kl": region}
-
-    async with httpx.AsyncClient(
+    resp = await client.post(
+        _DDG_HTML_URL,
+        data={"q": query, "kl": region},
+        headers=_ddg_headers(),
         timeout=timeout,
-        follow_redirects=True,
-        headers=headers,
-    ) as client:
-        resp = await client.post(_DDG_LITE_URL, data=data)
-        resp.raise_for_status()
-
-    soup = BeautifulSoup(resp.text, "html.parser")
-    results: List[Dict[str, str]] = []
-
-    for row in soup.find_all("tr"):
-        link = row.find("a", href=True)
-        if not link:
-            continue
-        href = str(link.get("href", ""))
-        if not href.startswith("http"):
-            continue
-
-        title = link.get_text(strip=True)
-        real_url = _extract_real_url(href)
-        if _is_ddg_ad_url(real_url):
-            continue
-
-        snippet_td = row.find_next_sibling("tr")
-        snippet = ""
-        if snippet_td:
-            snippet_cell = snippet_td.find("td", class_="result-snippet")
-            if snippet_cell:
-                snippet = snippet_cell.get_text(strip=True)
-
-        if title and real_url:
-            results.append({"title": title, "url": real_url, "snippet": snippet})
-        if len(results) >= max_results:
-            break
-
-    return results
+    )
+    resp.raise_for_status()
+    html = decode_html(resp.content, resp.headers.get("content-type", ""))
+    return parse_ddg_html(html, max_results)
 
 
-# ---------------------------------------------------------------------------
-# Baidu scraping (China mainland)
-# ---------------------------------------------------------------------------
+async def _search_ddg_lite(
+    client: httpx.AsyncClient,
+    query: str,
+    max_results: int = 8,
+    region: str = "wt-wt",
+    timeout: float = 15.0,
+) -> List[Dict[str, str]]:
+    resp = await client.post(
+        _DDG_LITE_URL,
+        data={"q": query, "kl": region},
+        headers=_ddg_headers(),
+        timeout=timeout,
+    )
+    resp.raise_for_status()
+    html = decode_html(resp.content, resp.headers.get("content-type", ""))
+    return parse_ddg_lite_html(html, max_results)
+
 
 async def _search_baidu(
+    client: httpx.AsyncClient,
     query: str,
     max_results: int = 8,
     timeout: float = 15.0,
@@ -195,46 +129,27 @@ async def _search_baidu(
         "User-Agent": _UA,
         "Accept": "text/html,application/xhtml+xml",
         "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
-        "Referer": "https://www.baidu.com/",
+        "Referer": _BAIDU_HOME_URL,
     }
-    params = {"wd": query, "rn": str(min(max_results, 50))}
+    params = {"wd": query, "rn": str(min(max_results, 50)), "ie": "utf-8"}
 
-    async with httpx.AsyncClient(
-        timeout=timeout,
-        follow_redirects=True,
-        headers=headers,
-    ) as client:
-        resp = await client.get(_BAIDU_SEARCH_URL, params=params)
-        resp.raise_for_status()
+    # 无 BAIDUID Cookie 的裸请求几乎必中"百度安全验证"页，先访问首页领 Cookie
+    if not any(c.name == "BAIDUID" for c in client.cookies.jar):
+        try:
+            await client.get(_BAIDU_HOME_URL, headers=headers, timeout=timeout)
+        except httpx.HTTPError:
+            pass
 
-    soup = BeautifulSoup(resp.text, "html.parser")
-    results: List[Dict[str, str]] = []
+    resp = await client.get(
+        _BAIDU_SEARCH_URL, params=params, headers=headers, timeout=timeout
+    )
+    resp.raise_for_status()
 
-    for item in soup.select("div.result, div.c-container"):
-        link = item.find("a", href=True)
-        if not link:
-            continue
-        title = link.get_text(strip=True)
-        href = str(link.get("href", ""))
-        if not title or not href:
-            continue
-
-        snippet = ""
-        for sel in ("div.c-abstract", "span.content-right_8Zs40", "div.c-span-last"):
-            sn = item.select_one(sel)
-            if sn:
-                snippet = sn.get_text(strip=True)
-                break
-        if not snippet:
-            abs_tag = item.find("div", class_=re.compile(r"abstract|summary|desc"))
-            if abs_tag:
-                snippet = abs_tag.get_text(strip=True)
-
-        results.append({"title": title, "url": href, "snippet": snippet})
-        if len(results) >= max_results:
-            break
-
-    return results
+    html = decode_html(resp.content, resp.headers.get("content-type", ""))
+    # 被拦截时会 302 到 wappass.baidu.com 验证码页
+    if "wappass.baidu.com" in str(resp.url) or is_baidu_blocked(html):
+        raise SearchBlockedError("百度返回安全验证页（反爬拦截），请稍后重试")
+    return parse_baidu_html(html, max_results)
 
 
 # ---------------------------------------------------------------------------
@@ -251,6 +166,12 @@ class WebSearchPlugin(NekoPluginBase):
         self._cfg: Dict[str, Any] = {}
         self._country: Optional[str] = None
         self._is_cn: bool = False
+        self._client: Optional[httpx.AsyncClient] = None
+
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(follow_redirects=True)
+        return self._client
 
     @lifecycle(id="startup")
     async def startup(self, **_):
@@ -270,6 +191,8 @@ class WebSearchPlugin(NekoPluginBase):
 
     @lifecycle(id="shutdown")
     async def shutdown(self, **_):
+        if self._client is not None and not self._client.is_closed:
+            await self._client.aclose()
         self.logger.info("WebSearch shutdown")
         return Ok({"status": "shutdown"})
 
@@ -293,15 +216,16 @@ class WebSearchPlugin(NekoPluginBase):
         max_results: int,
         timeout: float,
     ) -> List[Dict[str, str]]:
+        client = self._get_client()
         if self._is_cn:
-            return await _search_baidu(query, max_results, timeout)
+            return await _search_baidu(client, query, max_results, timeout)
 
         try:
-            return await _search_ddg_html(query, max_results, timeout=timeout)
+            return await _search_ddg_html(client, query, max_results, timeout=timeout)
         except Exception as e:
             self.logger.warning("DDG html failed, trying lite: {}", e)
 
-        return await _search_ddg_lite(query, max_results, timeout=timeout)
+        return await _search_ddg_lite(client, query, max_results, timeout=timeout)
 
     @staticmethod
     def _build_summary(query: str, results: List[Dict[str, str]]) -> str:
@@ -350,24 +274,24 @@ class WebSearchPlugin(NekoPluginBase):
         max_r = max(3, max_r)
         timeout = defs["timeout"]
 
-        self.logger.info("Searching: query={!r} max={} engine={}", query, max_r, "baidu" if self._is_cn else "duckduckgo")
+        # query / titles / snippets / summary 含外部网页内容 + 用户搜索词，
+        # 任何输出渠道（logger/stdout）都只记录长度与条数
+        self.logger.info(
+            "Searching: query_len={} max={} engine={}",
+            len(query), max_r, "baidu" if self._is_cn else "duckduckgo",
+        )
 
         try:
             results = await self._do_text_search(query, max_r, timeout)
         except Exception as e:
-            self.logger.exception("Search failed for query={!r}", query)
+            self.logger.exception("Search failed (query_len={})", len(query))
             return Err(SdkError(f"搜索失败: {e}"))
 
         summary = self._build_summary(query, results)
-        # query / titles / snippets / summary 含外部网页内容 + 用户搜索词，不写 logger
-        self.logger.info("Search returned {} results (query_len={})", len(results), len(query or ""))
-        print(f"[WebSearch] query: {query!r}")
-        for i, r in enumerate(results, 1):
-            print(
-                f"  [{i}] title={r.get('title', '')!r}  snippet={r.get('snippet', '')!r}  url={r.get('url', '')!r}"
-            )
-        self.logger.info("Summary sent to LLM (summary_len={})", len(summary or ""))
-        print(f"[WebSearch] Summary sent to LLM:\n{summary}")
+        self.logger.info(
+            "Search returned {} results (query_len={}, summary_len={})",
+            len(results), len(query), len(summary),
+        )
         return Ok({
             "query": query,
             "count": len(results),

--- a/plugin/plugins/web_search/_parsing.py
+++ b/plugin/plugins/web_search/_parsing.py
@@ -150,7 +150,10 @@ def parse_ddg_lite_html(html: str, max_results: int = 8) -> List[Dict[str, str]]
         if link is None:
             continue
         href = str(link.get("href", ""))
-        if not href.startswith("http"):
+        # Lite 端点的跳转链接可能是协议相对形式（//duckduckgo.com/l/?uddg=...）
+        if href.startswith("//"):
+            href = "https:" + href
+        if not href.startswith(("http://", "https://")):
             continue
 
         title = sanitize_text(link.get_text(strip=True))

--- a/plugin/plugins/web_search/_parsing.py
+++ b/plugin/plugins/web_search/_parsing.py
@@ -99,7 +99,15 @@ def extract_real_url(href: str) -> str:
 
 
 def is_ddg_ad_url(url: str) -> bool:
-    return "duckduckgo.com/y.js" in url or "ad_provider=" in url
+    # 广告以 duckduckgo.com/y.js 跳转包装标记；不能看目标 URL 里是否含
+    # ad_provider= 之类的参数——正常结果自己的查询串也可能带同名参数
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return True
+    host = (parsed.hostname or "").lower()
+    is_ddg_host = host == "duckduckgo.com" or host.endswith(".duckduckgo.com")
+    return is_ddg_host and parsed.path == "/y.js"
 
 
 def parse_ddg_html(html: str, max_results: int = 8) -> List[Dict[str, str]]:

--- a/plugin/plugins/web_search/_parsing.py
+++ b/plugin/plugins/web_search/_parsing.py
@@ -75,11 +75,13 @@ def decode_html(content: bytes, content_type: str = "") -> str:
 
 
 def is_http_url(url: str) -> bool:
+    # 校验 hostname 而不是 netloc："https://@"、"http://:80" 这类残缺 URL
+    # 的 netloc 非空但 hostname 为 None
     try:
         parsed = urlparse(url)
+        return parsed.scheme in ("http", "https") and bool(parsed.hostname)
     except ValueError:
         return False
-    return parsed.scheme in ("http", "https") and bool(parsed.netloc)
 
 
 def _clip(text: str, limit: int) -> str:

--- a/plugin/plugins/web_search/_parsing.py
+++ b/plugin/plugins/web_search/_parsing.py
@@ -1,0 +1,222 @@
+"""
+web_search 插件的解析层：纯函数、不依赖 SDK 和网络，便于单元测试。
+
+安全约束：
+- 所有进入 LLM/TTS 的文本（标题/摘要）必须先过 sanitize_text —— 外部网页内容不可信，
+  Baidu 页面文本节点里混有 iconfont 私有区字符（如 U+E687），编码错位时还会出现
+  U+FFFD，零宽/bidi 控制符则可能被用来做注入混淆。
+- 结果 URL 只接受 http(s) 绝对地址，拒绝 javascript:/相对链接（相关搜索词等站内跳转）。
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from typing import Dict, List
+from urllib.parse import unquote, urlparse
+
+from bs4 import BeautifulSoup  # type: ignore[import-untyped]
+
+MAX_TITLE_LEN = 200
+MAX_SNIPPET_LEN = 320
+
+_WS_RE = re.compile(r"\s+")
+_HEADER_CHARSET_RE = re.compile(r"charset\s*=\s*[\"']?\s*([A-Za-z0-9_\-]+)", re.I)
+_META_CHARSET_RE = re.compile(
+    rb"<meta[^>]{0,120}?charset\s*=\s*[\"']?\s*([A-Za-z0-9_\-]+)", re.I
+)
+# gb2312/gbk 解码器会在合法页面的少数扩展字符上报错，统一升级到超集 gb18030
+_ENCODING_ALIASES = {"gb2312": "gb18030", "gbk": "gb18030"}
+
+
+class SearchBlockedError(RuntimeError):
+    """搜索引擎返回了反爬验证页，而不是结果页。"""
+
+
+def sanitize_text(text: str) -> str:
+    """清洗不可信网页文本：去掉控制/格式/私有区/代理区字符与 U+FFFD，压缩空白。"""
+    if not text:
+        return ""
+    kept: List[str] = []
+    for ch in text:
+        if ch.isspace():
+            kept.append(" ")
+            continue
+        if ord(ch) == 0xFFFD:
+            continue
+        # Cc/Cf/Co/Cs：控制、格式（含零宽与 bidi 覆盖符）、私有区（iconfont）、代理区
+        if unicodedata.category(ch) in ("Cc", "Cf", "Co", "Cs"):
+            continue
+        kept.append(ch)
+    return _WS_RE.sub(" ", "".join(kept)).strip()
+
+
+def decode_html(content: bytes, content_type: str = "") -> str:
+    """按 响应头 charset → 页面 meta → utf-8 → gb18030 的顺序严格解码。
+
+    Baidu 存在响应头缺 charset 或与实际字节编码不符的情况，直接信任默认 utf-8
+    会把 GBK 页面解成一串 U+FFFD。严格模式逐个候选尝试，全失败才 replace 兜底。
+    """
+    candidates: List[str] = []
+    m = _HEADER_CHARSET_RE.search(content_type or "")
+    if m:
+        candidates.append(m.group(1))
+    m = _META_CHARSET_RE.search(content[:4096])
+    if m:
+        candidates.append(m.group(1).decode("ascii", errors="ignore"))
+    candidates.extend(["utf-8", "gb18030"])
+    for enc in candidates:
+        enc = _ENCODING_ALIASES.get(enc.lower(), enc)
+        try:
+            return content.decode(enc)
+        except (UnicodeDecodeError, LookupError):
+            continue
+    return content.decode("utf-8", errors="replace")
+
+
+def is_http_url(url: str) -> bool:
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return False
+    return parsed.scheme in ("http", "https") and bool(parsed.netloc)
+
+
+def _clip(text: str, limit: int) -> str:
+    return text if len(text) <= limit else text[:limit].rstrip() + "…"
+
+
+# ---------------------------------------------------------------------------
+# DuckDuckGo
+# ---------------------------------------------------------------------------
+
+def extract_real_url(href: str) -> str:
+    if "uddg=" in href:
+        match = re.search(r"uddg=([^&]+)", href)
+        if match:
+            return unquote(match.group(1))
+    return href
+
+
+def is_ddg_ad_url(url: str) -> bool:
+    return "duckduckgo.com/y.js" in url or "ad_provider=" in url
+
+
+def parse_ddg_html(html: str, max_results: int = 8) -> List[Dict[str, str]]:
+    soup = BeautifulSoup(html, "html.parser")
+    results: List[Dict[str, str]] = []
+
+    for link_tag in soup.select("a.result__a"):
+        if link_tag.find_parent("div", class_=re.compile(r"result--ad")):
+            continue
+
+        title = sanitize_text(link_tag.get_text(strip=True))
+        real_url = extract_real_url(str(link_tag.get("href", "")))
+        if not title or not is_http_url(real_url) or is_ddg_ad_url(real_url):
+            continue
+
+        snippet = ""
+        parent = link_tag.find_parent("div", class_="result")
+        if parent is not None:
+            sn = parent.select_one("a.result__snippet")
+            if sn is not None:
+                snippet = sanitize_text(sn.get_text(strip=True))
+
+        results.append({
+            "title": _clip(title, MAX_TITLE_LEN),
+            "url": real_url,
+            "snippet": _clip(snippet, MAX_SNIPPET_LEN),
+        })
+        if len(results) >= max_results:
+            break
+
+    return results
+
+
+def parse_ddg_lite_html(html: str, max_results: int = 8) -> List[Dict[str, str]]:
+    soup = BeautifulSoup(html, "html.parser")
+    results: List[Dict[str, str]] = []
+
+    for row in soup.find_all("tr"):
+        link = row.find("a", href=True)
+        if link is None:
+            continue
+        href = str(link.get("href", ""))
+        if not href.startswith("http"):
+            continue
+
+        title = sanitize_text(link.get_text(strip=True))
+        real_url = extract_real_url(href)
+        if not title or not is_http_url(real_url) or is_ddg_ad_url(real_url):
+            continue
+
+        snippet = ""
+        next_row = row.find_next_sibling("tr")
+        if next_row is not None:
+            cell = next_row.find("td", class_="result-snippet")
+            if cell is not None:
+                snippet = sanitize_text(cell.get_text(strip=True))
+
+        results.append({
+            "title": _clip(title, MAX_TITLE_LEN),
+            "url": real_url,
+            "snippet": _clip(snippet, MAX_SNIPPET_LEN),
+        })
+        if len(results) >= max_results:
+            break
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Baidu
+# ---------------------------------------------------------------------------
+
+def is_baidu_blocked(html: str) -> bool:
+    head = html[:5000]
+    return "百度安全验证" in head or "wappass.baidu.com" in head
+
+
+def parse_baidu_html(html: str, max_results: int = 8) -> List[Dict[str, str]]:
+    soup = BeautifulSoup(html, "html.parser")
+    results: List[Dict[str, str]] = []
+    seen_urls: set = set()
+
+    for item in soup.select("div.result, div.c-container"):
+        # 商业推广容器带 data-tuiguang 属性
+        if item.has_attr("data-tuiguang"):
+            continue
+
+        # 标题只认 h3 下的链接：容器里第一个 <a> 可能是卡片子链接（如天气卡的
+        # "查看40天预报"）或相关搜索词，不是结果标题
+        title_link = item.select_one("h3 a[href]")
+        if title_link is None:
+            continue
+
+        title = sanitize_text(title_link.get_text(strip=True))
+        href = str(title_link.get("href", "")).strip()
+        if not title or not is_http_url(href) or href in seen_urls:
+            continue
+        seen_urls.add(href)
+
+        snippet = ""
+        # content-right 类名带 CSS-module 哈希后缀（如 content-right_8Zs40），用前缀匹配
+        for sel in ("div.c-abstract", "span[class*='content-right']", "div.c-span-last"):
+            sn = item.select_one(sel)
+            if sn is not None:
+                snippet = sanitize_text(sn.get_text(strip=True))
+                break
+        if not snippet:
+            abs_tag = item.find("div", class_=re.compile(r"abstract|summary|desc"))
+            if abs_tag is not None:
+                snippet = sanitize_text(abs_tag.get_text(strip=True))
+
+        results.append({
+            "title": _clip(title, MAX_TITLE_LEN),
+            "url": href,
+            "snippet": _clip(snippet, MAX_SNIPPET_LEN),
+        })
+        if len(results) >= max_results:
+            break
+
+    return results

--- a/plugin/tests/unit/plugins/test_web_search_parsing.py
+++ b/plugin/tests/unit/plugins/test_web_search_parsing.py
@@ -230,8 +230,9 @@ def test_ddg_ad_filter_only_matches_yjs_wrapper() -> None:
 
 _DDG_LITE_HTML = f"""
 <html><body><table>
-  <tr><td><a href="https://duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fa">Result{_REPL} One</a></td></tr>
+  <tr><td><a href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fa">Result{_REPL} One</a></td></tr>
   <tr><td class="result-snippet">Snippet{_RLO} text</td></tr>
+  <tr><td><a href="https://duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fb">Result Two</a></td></tr>
   <tr><td><a href="/local/nav">站内导航</a></td></tr>
 </table></body></html>
 """
@@ -239,7 +240,9 @@ _DDG_LITE_HTML = f"""
 
 def test_parse_ddg_lite_sanitizes_and_skips_relative() -> None:
     results = p.parse_ddg_lite_html(_DDG_LITE_HTML, max_results=10)
-    assert len(results) == 1
-    assert results[0]["title"] == "Result One"
-    assert results[0]["url"] == "https://example.com/a"
+    # 协议相对（//duckduckgo.com/...）与绝对跳转链接都被解包，站内相对链接被拒
+    assert [(r["title"], r["url"]) for r in results] == [
+        ("Result One", "https://example.com/a"),
+        ("Result Two", "https://example.com/b"),
+    ]
     assert results[0]["snippet"] == "Snippet text"

--- a/plugin/tests/unit/plugins/test_web_search_parsing.py
+++ b/plugin/tests/unit/plugins/test_web_search_parsing.py
@@ -198,7 +198,14 @@ _DDG_HTML = f"""
   </div>
   <div class="result result--ad">
     <div class="links_main result__body">
-      <a class="result__a" href="//duckduckgo.com/y.js?ad_provider=x">Buy Now</a>
+      <a class="result__a" href="https://duckduckgo.com/y.js?ad_provider=x">Buy Now</a>
+    </div>
+  </div>
+  <!-- 正常结果：目标 URL 自己的查询串带 ad_provider= 参数，不能被当广告误杀 -->
+  <div class="result results_links web-result">
+    <div class="links_main result__body">
+      <a class="result__a"
+         href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fshop.example.com%2Fp%3Fad_provider%3Dbing&amp;rut=def">Shop Landing</a>
     </div>
   </div>
 </body></html>
@@ -207,10 +214,18 @@ _DDG_HTML = f"""
 
 def test_parse_ddg_html_decodes_uddg_and_sanitizes() -> None:
     results = p.parse_ddg_html(_DDG_HTML, max_results=10)
-    assert len(results) == 1
-    assert results[0]["title"] == "Project NEKO Official"
+    assert [r["title"] for r in results] == ["Project NEKO Official", "Shop Landing"]
     assert results[0]["url"] == "https://www.example.com/neko"
     assert results[0]["snippet"] == "A virtual desktop companion."
+    assert results[1]["url"] == "https://shop.example.com/p?ad_provider=bing"
+
+
+def test_ddg_ad_filter_only_matches_yjs_wrapper() -> None:
+    assert p.is_ddg_ad_url("https://duckduckgo.com/y.js?ad_provider=bing&u3=x")
+    assert p.is_ddg_ad_url("//duckduckgo.com/y.js?ad_provider=x")
+    # 目标 URL 带同名参数、或路径里碰巧含 y.js 字样的，都不是广告
+    assert not p.is_ddg_ad_url("https://shop.example.com/p?ad_provider=bing")
+    assert not p.is_ddg_ad_url("https://example.com/duckduckgo.com/y.js")
 
 
 _DDG_LITE_HTML = f"""

--- a/plugin/tests/unit/plugins/test_web_search_parsing.py
+++ b/plugin/tests/unit/plugins/test_web_search_parsing.py
@@ -1,0 +1,230 @@
+"""web_search 插件解析层测试。
+
+覆盖用户报告的三类问题：
+1. 非法字符——Baidu 页面里的 iconfont 私有区字符、编码错位产生的 U+FFFD、
+   零宽/bidi 控制符进入 LLM/TTS 被读出乱码；
+2. 解析瑕疵——容器里第一个 <a> 是卡片子链接/相关搜索词，被当成结果标题；
+3. 不安全——javascript:/相对链接原样返回、反爬验证页被静默解析成 0 条。
+
+不可见/私有区字符一律用 \\u 转义书写，避免源码里出现肉眼不可见的字面量。
+"""
+from __future__ import annotations
+
+import pytest
+
+from plugin.plugins.web_search import _parsing as p
+
+pytestmark = pytest.mark.plugin_unit
+
+_PUA = "\ue687"      # Baidu iconfont 私有区字符（实测页面中出现）
+_ZWSP = "\u200b"     # 零宽空格
+_RLO = "\u202e"      # bidi 右到左覆盖符
+_REPL = "\ufffd"     # U+FFFD replacement character
+
+
+# ---------------------------------------------------------------------------
+# sanitize_text
+# ---------------------------------------------------------------------------
+
+def test_sanitize_strips_pua_and_invisible_chars() -> None:
+    dirty = f"上海天气{_ZWSP}预报{_RLO}今日\x07实况{_REPL}{_PUA}"
+    assert p.sanitize_text(dirty) == "上海天气预报今日实况"
+
+
+def test_sanitize_collapses_whitespace_variants() -> None:
+    assert p.sanitize_text("多云\xa0转晴\n\t 33/28℃ ") == "多云 转晴 33/28℃"
+
+
+def test_sanitize_preserves_normal_text_and_emoji() -> None:
+    assert p.sanitize_text("NEKO 🐱 v2.0 发布!") == "NEKO 🐱 v2.0 发布!"
+
+
+def test_sanitize_empty() -> None:
+    assert p.sanitize_text("") == ""
+
+
+# ---------------------------------------------------------------------------
+# decode_html
+# ---------------------------------------------------------------------------
+
+def test_decode_gbk_bytes_mislabeled_as_utf8_header() -> None:
+    # 实测过 Baidu 会用 charset=utf-8 的响应头下发 GBK 字节，
+    # 严格解码失败后应回退 gb18030 而不是产出一串 U+FFFD
+    raw = "<html><body>查看40天预报</body></html>".encode("gbk")
+    text = p.decode_html(raw, "text/html;charset=utf-8")
+    assert "查看40天预报" in text
+    assert _REPL not in text
+
+
+def test_decode_bare_content_type_defaults_utf8() -> None:
+    raw = "<html><body>上海天气</body></html>".encode("utf-8")
+    assert "上海天气" in p.decode_html(raw, "text/html")
+
+
+def test_decode_honors_meta_gb2312_upgraded_to_gb18030() -> None:
+    raw = (
+        b'<html><head><meta http-equiv="content-type" '
+        b'content="text/html;charset=gb2312"></head><body>'
+        + "天气预报".encode("gbk")
+        + b"</body></html>"
+    )
+    assert "天气预报" in p.decode_html(raw, "text/html")
+
+
+# ---------------------------------------------------------------------------
+# is_http_url
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("url", [
+    "http://www.baidu.com/link?url=abc",
+    "https://example.com/path?q=1",
+])
+def test_is_http_url_accepts_http_absolute(url: str) -> None:
+    assert p.is_http_url(url)
+
+
+@pytest.mark.parametrize("url", [
+    "/s?wd=%E4%BB%8A%E5%A4%A9&rn=8",   # 相关搜索的站内相对链接
+    "javascript:void(0)",
+    "ftp://example.com/x",
+    "",
+    "http://",                          # 无 netloc
+])
+def test_is_http_url_rejects_unsafe(url: str) -> None:
+    assert not p.is_http_url(url)
+
+
+# ---------------------------------------------------------------------------
+# parse_baidu_html
+# ---------------------------------------------------------------------------
+
+_BAIDU_HTML = f"""
+<html><body><div id="content_left">
+
+  <!-- 正常结果：标题带 em 高亮和 iconfont 字符，摘要带零宽字符 -->
+  <div class="result c-container">
+    <h3 class="t"><a href="http://www.baidu.com/link?url=AAA">上海<em>天气</em>预报{_PUA}</a></h3>
+    <div class="c-abstract">今日{_ZWSP}多云&nbsp;33/28℃</div>
+  </div>
+
+  <!-- 卡片：第一个 a 是子链接且无 h3 —— 整个容器应被跳过 -->
+  <div class="c-container">
+    <a href="http://www.baidu.com/link?url=SUB">查看40天预报</a>
+    <span>61%</span>
+  </div>
+
+  <!-- 相关搜索：有 h3 但 href 是站内相对链接 —— 应被拒绝 -->
+  <div class="c-container">
+    <h3><a href="/s?wd=%E4%BB%8A%E5%A4%A9&rn=8">今天上海的气温是多少</a></h3>
+  </div>
+
+  <!-- javascript 伪协议 —— 应被拒绝 -->
+  <div class="c-container">
+    <h3><a href="javascript:void(0)">点击展开更多结果</a></h3>
+  </div>
+
+  <!-- 商业推广 —— 应被跳过 -->
+  <div class="c-container" data-tuiguang="1">
+    <h3><a href="http://www.baidu.com/link?url=ADS">买天气仪器上XX商城</a></h3>
+  </div>
+
+  <!-- 新版模板：content-right 带 CSS-module 哈希后缀 -->
+  <div class="result c-container">
+    <h3><a href="http://www.baidu.com/link?url=BBB">中国天气网上海站</a></h3>
+    <span class="content-right_XYZ99">权威发布{_PUA}上海天气预警</span>
+  </div>
+
+  <!-- 与第一条重复的 URL —— 应被去重 -->
+  <div class="result c-container">
+    <h3><a href="http://www.baidu.com/link?url=AAA">上海天气预报（重复）</a></h3>
+  </div>
+
+</div></body></html>
+"""
+
+
+def test_parse_baidu_picks_h3_titles_only() -> None:
+    results = p.parse_baidu_html(_BAIDU_HTML, max_results=10)
+    titles = [r["title"] for r in results]
+    assert titles == ["上海天气预报", "中国天气网上海站"]
+
+
+def test_parse_baidu_sanitizes_title_and_snippet() -> None:
+    results = p.parse_baidu_html(_BAIDU_HTML, max_results=10)
+    # PUA 字符被清掉、零宽空格被清掉、&nbsp; 归一为普通空格
+    assert results[0]["title"] == "上海天气预报"
+    assert results[0]["snippet"] == "今日多云 33/28℃"
+    # content-right 哈希类名命中且清洗生效
+    assert results[1]["snippet"] == "权威发布上海天气预警"
+
+
+def test_parse_baidu_urls_are_absolute_http() -> None:
+    results = p.parse_baidu_html(_BAIDU_HTML, max_results=10)
+    assert all(r["url"].startswith("http") for r in results)
+    joined = " ".join(r["title"] + r["url"] for r in results)
+    assert "javascript" not in joined
+    assert "查看40天预报" not in joined       # 卡片子链接没被当成结果
+    assert "今天上海的气温是多少" not in joined  # 相关搜索词没被当成结果
+    assert "XX商城" not in joined             # 推广容器被跳过
+
+
+def test_parse_baidu_respects_max_results() -> None:
+    assert len(p.parse_baidu_html(_BAIDU_HTML, max_results=1)) == 1
+
+
+def test_baidu_blocked_page_detected_not_silently_empty() -> None:
+    verify_page = (
+        '<!DOCTYPE html><html lang="zh-CN"><head><meta charset="utf-8">'
+        "<title>百度安全验证</title></head><body>...</body></html>"
+    )
+    assert p.is_baidu_blocked(verify_page)
+    assert not p.is_baidu_blocked(_BAIDU_HTML)
+
+
+# ---------------------------------------------------------------------------
+# parse_ddg_html / parse_ddg_lite_html
+# ---------------------------------------------------------------------------
+
+_DDG_HTML = f"""
+<html><body>
+  <div class="result results_links web-result">
+    <div class="links_main result__body">
+      <h2 class="result__title">
+        <a class="result__a"
+           href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fwww.example.com%2Fneko&amp;rut=abc">Project{_ZWSP} NEKO Official</a>
+      </h2>
+      <a class="result__snippet">A virtual desktop companion.</a>
+    </div>
+  </div>
+  <div class="result result--ad">
+    <div class="links_main result__body">
+      <a class="result__a" href="//duckduckgo.com/y.js?ad_provider=x">Buy Now</a>
+    </div>
+  </div>
+</body></html>
+"""
+
+
+def test_parse_ddg_html_decodes_uddg_and_sanitizes() -> None:
+    results = p.parse_ddg_html(_DDG_HTML, max_results=10)
+    assert len(results) == 1
+    assert results[0]["title"] == "Project NEKO Official"
+    assert results[0]["url"] == "https://www.example.com/neko"
+    assert results[0]["snippet"] == "A virtual desktop companion."
+
+
+_DDG_LITE_HTML = f"""
+<html><body><table>
+  <tr><td><a href="https://duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fa">Result{_REPL} One</a></td></tr>
+  <tr><td class="result-snippet">Snippet{_RLO} text</td></tr>
+  <tr><td><a href="/local/nav">站内导航</a></td></tr>
+</table></body></html>
+"""
+
+
+def test_parse_ddg_lite_sanitizes_and_skips_relative() -> None:
+    results = p.parse_ddg_lite_html(_DDG_LITE_HTML, max_results=10)
+    assert len(results) == 1
+    assert results[0]["title"] == "Result One"
+    assert results[0]["url"] == "https://example.com/a"
+    assert results[0]["snippet"] == "Snippet text"

--- a/plugin/tests/unit/plugins/test_web_search_parsing.py
+++ b/plugin/tests/unit/plugins/test_web_search_parsing.py
@@ -160,7 +160,7 @@ def test_parse_baidu_sanitizes_title_and_snippet() -> None:
 
 def test_parse_baidu_urls_are_absolute_http() -> None:
     results = p.parse_baidu_html(_BAIDU_HTML, max_results=10)
-    assert all(r["url"].startswith("http") for r in results)
+    assert all(r["url"].startswith(("http://", "https://")) for r in results)
     joined = " ".join(r["title"] + r["url"] for r in results)
     assert "javascript" not in joined
     assert "查看40天预报" not in joined       # 卡片子链接没被当成结果

--- a/plugin/tests/unit/plugins/test_web_search_parsing.py
+++ b/plugin/tests/unit/plugins/test_web_search_parsing.py
@@ -89,6 +89,9 @@ def test_is_http_url_accepts_http_absolute(url: str) -> None:
     "ftp://example.com/x",
     "",
     "http://",                          # 无 netloc
+    "https://@",                        # netloc 非空但 hostname 为 None
+    "http://:80",                       # 同上，只有端口
+    "http://[",                         # 非法 IPv6，urlparse 抛 ValueError
 ])
 def test_is_http_url_rejects_unsafe(url: str) -> None:
     assert not p.is_http_url(url)

--- a/tests/unit/test_baidu_search.py
+++ b/tests/unit/test_baidu_search.py
@@ -1,0 +1,75 @@
+"""Tests for Baidu search parsing in utils/web_scraper.py。
+
+对齐 web_search 插件侧的修复（plugin/plugins/web_search/_parsing.py）：
+- 标题只认 h3 下的链接，不再取容器里第一个 <a>（卡片子链接/相关搜索词误报）；
+- javascript: 等伪协议被拒绝；
+- 标题/摘要清洗 iconfont 私有区字符、零宽字符、U+FFFD 等非法字符。
+
+不可见/私有区字符一律用 \\u 转义书写，避免源码里出现肉眼不可见的字面量。
+"""
+import pytest
+
+from utils.web_scraper import parse_baidu_results, _sanitize_search_text
+
+_PUA = "\ue687"   # Baidu iconfont 私有区字符（实测页面中出现）
+_ZWSP = "\u200b"  # 零宽空格
+_REPL = "\ufffd"  # replacement character
+
+_BAIDU_HTML = f"""
+<html><body><div id="content_left">
+
+  <!-- 正常结果：标题带 em 高亮和 iconfont 字符，摘要带零宽字符 -->
+  <div class="result c-container">
+    <h3 class="t"><a href="http://www.baidu.com/link?url=AAA">上海<em>气象</em>预报站{_PUA}</a></h3>
+    <span class="content-right_XYZ99">今日{_ZWSP}多云&nbsp;33/28℃{_REPL}</span>
+  </div>
+
+  <!-- 卡片：第一个 a 是子链接且无 h3 —— 修复前会被当成标题 -->
+  <div class="c-container">
+    <a href="http://www.baidu.com/link?url=SUB">查看40天预报详情页</a>
+    <span>61%</span>
+  </div>
+
+  <!-- javascript 伪协议 —— 应被拒绝 -->
+  <div class="c-container">
+    <h3><a href="javascript:void(0)">点击展开更多结果内容</a></h3>
+  </div>
+
+  <div class="result c-container">
+    <h3><a href="http://www.baidu.com/link?url=BBB">中国天气网权威预警发布</a></h3>
+  </div>
+
+</div></body></html>
+"""
+
+
+@pytest.mark.unit
+def test_sanitize_search_text_strips_illegal_chars():
+    assert _sanitize_search_text(f"上海{_ZWSP}天气{_PUA}预报{_REPL}") == "上海天气预报"
+    assert _sanitize_search_text("多云\xa0转晴\n 33℃ ") == "多云 转晴 33℃"
+    assert _sanitize_search_text("") == ""
+
+
+@pytest.mark.unit
+def test_parse_baidu_takes_h3_titles_and_sanitizes():
+    results = parse_baidu_results(_BAIDU_HTML, limit=10)
+
+    titles = [r['title'] for r in results]
+    assert titles == ['上海气象预报站', '中国天气网权威预警发布']
+    # 摘要清洗：零宽/U+FFFD 被清掉，&nbsp; 归一为普通空格
+    assert results[0]['abstract'] == '今日多云 33/28℃'
+
+
+@pytest.mark.unit
+def test_parse_baidu_rejects_unsafe_links():
+    results = parse_baidu_results(_BAIDU_HTML, limit=10)
+
+    joined = ' '.join(r['title'] + r['url'] for r in results)
+    assert 'javascript' not in joined
+    assert '查看40天预报详情页' not in joined  # 卡片子链接不再被当成结果标题
+    assert all(r['url'].startswith('http') for r in results)
+
+
+@pytest.mark.unit
+def test_parse_baidu_empty_html_returns_empty_list():
+    assert parse_baidu_results('<html><body>no results</body></html>', limit=5) == []

--- a/tests/unit/test_baidu_search.py
+++ b/tests/unit/test_baidu_search.py
@@ -80,5 +80,22 @@ def test_parse_baidu_rejects_unsafe_links():
 
 
 @pytest.mark.unit
+def test_parse_baidu_scans_past_rejected_containers():
+    # 大量相关搜索容器排在前面时，不能因预截断漏掉后面的有效结果
+    junk = ''.join(
+        f'<div class="c-container"><h3><a href="/s?wd=related{i}">相关搜索推荐词条目{i}</a></h3></div>'
+        for i in range(10)
+    )
+    html = (
+        f'<html><body><div id="content_left">{junk}'
+        '<div class="result c-container">'
+        '<h3><a href="http://www.baidu.com/link?url=REAL">真实结果标题条目在后面</a></h3>'
+        '</div></div></body></html>'
+    )
+    results = parse_baidu_results(html, limit=3)
+    assert [r['title'] for r in results] == ['真实结果标题条目在后面']
+
+
+@pytest.mark.unit
 def test_parse_baidu_empty_html_returns_empty_list():
     assert parse_baidu_results('<html><body>no results</body></html>', limit=5) == []

--- a/tests/unit/test_baidu_search.py
+++ b/tests/unit/test_baidu_search.py
@@ -97,5 +97,21 @@ def test_parse_baidu_scans_past_rejected_containers():
 
 
 @pytest.mark.unit
+def test_parse_baidu_h3_fallback_scans_past_rejected_links():
+    # 兜底 h3 路径（无 c-container）同样不能因预截断漏掉排在后面的有效链接
+    junk = ''.join(
+        f'<h3><a href="/s?wd=related{i}">相关搜索推荐词条目{i}</a></h3>'
+        for i in range(10)
+    )
+    html = (
+        f'<html><body>{junk}'
+        '<h3><a href="http://www.baidu.com/link?url=REAL">兜底路径真实结果标题</a></h3>'
+        '</body></html>'
+    )
+    results = parse_baidu_results(html, limit=3)
+    assert [r['title'] for r in results] == ['兜底路径真实结果标题']
+
+
+@pytest.mark.unit
 def test_parse_baidu_empty_html_returns_empty_list():
     assert parse_baidu_results('<html><body>no results</body></html>', limit=5) == []

--- a/tests/unit/test_baidu_search.py
+++ b/tests/unit/test_baidu_search.py
@@ -76,7 +76,7 @@ def test_parse_baidu_rejects_unsafe_links():
     assert 'javascript' not in joined
     assert '查看40天预报详情页' not in joined  # 卡片子链接不再被当成结果标题
     assert '今天上海的气温是多少度' not in joined  # 相关搜索的站内相对链接被拒绝
-    assert all(r['url'].startswith('http') for r in results)
+    assert all(r['url'].startswith(('http://', 'https://')) for r in results)
 
 
 @pytest.mark.unit

--- a/tests/unit/test_baidu_search.py
+++ b/tests/unit/test_baidu_search.py
@@ -38,6 +38,11 @@ _BAIDU_HTML = f"""
     <h3><a href="javascript:void(0)">点击展开更多结果内容</a></h3>
   </div>
 
+  <!-- 相关搜索：站内相对链接 —— 不能被 urljoin 洗白成结果 -->
+  <div class="c-container">
+    <h3><a href="/s?wd=%E4%BB%8A%E5%A4%A9&rn=8">今天上海的气温是多少度</a></h3>
+  </div>
+
   <div class="result c-container">
     <h3><a href="http://www.baidu.com/link?url=BBB">中国天气网权威预警发布</a></h3>
   </div>
@@ -70,6 +75,7 @@ def test_parse_baidu_rejects_unsafe_links():
     joined = ' '.join(r['title'] + r['url'] for r in results)
     assert 'javascript' not in joined
     assert '查看40天预报详情页' not in joined  # 卡片子链接不再被当成结果标题
+    assert '今天上海的气温是多少度' not in joined  # 相关搜索的站内相对链接被拒绝
     assert all(r['url'].startswith('http') for r in results)
 
 

--- a/tests/unit/test_baidu_search.py
+++ b/tests/unit/test_baidu_search.py
@@ -1,11 +1,14 @@
-"""Tests for Baidu search parsing in utils/web_scraper.py。
+"""Tests for Baidu search parsing in utils/web_scraper.py.
 
-对齐 web_search 插件侧的修复（plugin/plugins/web_search/_parsing.py）：
-- 标题只认 h3 下的链接，不再取容器里第一个 <a>（卡片子链接/相关搜索词误报）；
-- javascript: 等伪协议被拒绝；
-- 标题/摘要清洗 iconfont 私有区字符、零宽字符、U+FFFD 等非法字符。
+Mirrors the web_search plugin fixes (plugin/plugins/web_search/_parsing.py):
+- titles come only from links under h3, no longer the first <a> in the
+  container (card sub-links / related-search suggestions were misreported);
+- javascript: and other pseudo-scheme links are rejected;
+- titles/abstracts are sanitized of iconfont private-use glyphs, zero-width
+  characters, U+FFFD and other illegal characters.
 
-不可见/私有区字符一律用 \\u 转义书写，避免源码里出现肉眼不可见的字面量。
+Invisible/private-use characters are written as \\u escapes only, so no
+naked-eye-invisible literals appear in the source.
 """
 import pytest
 

--- a/tests/unit/test_baidu_search.py
+++ b/tests/unit/test_baidu_search.py
@@ -47,6 +47,11 @@ _BAIDU_HTML = f"""
     <h3><a href="http://www.baidu.com/link?url=BBB">中国天气网权威预警发布</a></h3>
   </div>
 
+  <!-- 与第一条重复的 URL —— 应被去重 -->
+  <div class="result c-container">
+    <h3><a href="http://www.baidu.com/link?url=AAA">上海气象预报站副本条目</a></h3>
+  </div>
+
 </div></body></html>
 """
 
@@ -94,6 +99,20 @@ def test_parse_baidu_scans_past_rejected_containers():
     )
     results = parse_baidu_results(html, limit=3)
     assert [r['title'] for r in results] == ['真实结果标题条目在后面']
+
+
+@pytest.mark.unit
+def test_parse_baidu_h3_fallback_filters_ads_and_dupes():
+    # 兜底 h3 路径与主循环同口径：广告关键词过滤 + URL 去重
+    html = (
+        '<html><body>'
+        '<h3><a href="http://www.baidu.com/link?url=AD">广告推广的天气站点标题</a></h3>'
+        '<h3><a href="http://www.baidu.com/link?url=DUP">正常结果标题条目甲</a></h3>'
+        '<h3><a href="http://www.baidu.com/link?url=DUP">正常结果标题条目乙</a></h3>'
+        '</body></html>'
+    )
+    results = parse_baidu_results(html, limit=5)
+    assert [r['title'] for r in results] == ['正常结果标题条目甲']
 
 
 @pytest.mark.unit

--- a/tests/unit/test_duckduckgo_search.py
+++ b/tests/unit/test_duckduckgo_search.py
@@ -87,6 +87,34 @@ def test_parse_empty_html_returns_empty_list():
 
 
 @pytest.mark.unit
+def test_parse_scans_past_rejected_results():
+    # 被拒绝的条目（无效 uddg 目标）排在前面时，不能因预截断漏掉后面的有效结果
+    junk = ''.join(
+        f'''
+        <div class="result results_links web-result">
+          <div class="links_main result__body">
+            <h2 class="result__title">
+              <a class="result__a" href="//duckduckgo.com/l/?uddg=javascript%3Avoid({i})">Broken Entry {i}</a>
+            </h2>
+          </div>
+        </div>
+        '''
+        for i in range(10)
+    )
+    html = junk + '''
+    <div class="result results_links web-result">
+      <div class="links_main result__body">
+        <h2 class="result__title">
+          <a class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fvalid">Valid Trailing Result</a>
+        </h2>
+      </div>
+    </div>
+    '''
+    results = parse_duckduckgo_results(html, limit=3)
+    assert [r['title'] for r in results] == ['Valid Trailing Result']
+
+
+@pytest.mark.unit
 def test_parse_skips_results_without_usable_url():
     # uddg 包着非 http 目标（javascript:）→ 整条丢弃，不以空 URL 占用结果位
     html = '''

--- a/tests/unit/test_duckduckgo_search.py
+++ b/tests/unit/test_duckduckgo_search.py
@@ -84,3 +84,19 @@ def test_parse_respects_limit():
 @pytest.mark.unit
 def test_parse_empty_html_returns_empty_list():
     assert parse_duckduckgo_results('<html><body>no results</body></html>', limit=5) == []
+
+
+@pytest.mark.unit
+def test_parse_skips_results_without_usable_url():
+    # uddg 包着非 http 目标（javascript:）→ 整条丢弃，不以空 URL 占用结果位
+    html = '''
+    <div class="result results_links web-result">
+      <div class="links_main result__body">
+        <h2 class="result__title">
+          <a class="result__a" href="//duckduckgo.com/l/?uddg=javascript%3Aalert(1)&amp;rut=x">Malicious Entry</a>
+        </h2>
+        <a class="result__snippet">Should never surface.</a>
+      </div>
+    </div>
+    '''
+    assert parse_duckduckgo_results(html, limit=5) == []

--- a/tests/unit/test_duckduckgo_search.py
+++ b/tests/unit/test_duckduckgo_search.py
@@ -116,7 +116,8 @@ def test_parse_scans_past_rejected_results():
 
 @pytest.mark.unit
 def test_parse_skips_results_without_usable_url():
-    # uddg 包着非 http 目标（javascript:）→ 整条丢弃，不以空 URL 占用结果位
+    # uddg 包着非 http 目标（javascript:）或残缺目标（裸 "https://"）
+    # → 整条丢弃，不以空/无效 URL 占用结果位
     html = '''
     <div class="result results_links web-result">
       <div class="links_main result__body">
@@ -124,6 +125,13 @@ def test_parse_skips_results_without_usable_url():
           <a class="result__a" href="//duckduckgo.com/l/?uddg=javascript%3Aalert(1)&amp;rut=x">Malicious Entry</a>
         </h2>
         <a class="result__snippet">Should never surface.</a>
+      </div>
+    </div>
+    <div class="result results_links web-result">
+      <div class="links_main result__body">
+        <h2 class="result__title">
+          <a class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2F&amp;rut=y">Truncated Target</a>
+        </h2>
       </div>
     </div>
     '''

--- a/utils/web_scraper.py
+++ b/utils/web_scraper.py
@@ -1843,8 +1843,9 @@ def parse_baidu_results(html_content: str, limit: int = 5) -> List[Dict[str, str
         from bs4 import BeautifulSoup
         soup = BeautifulSoup(html_content, 'lxml')
 
-        # 提取搜索结果容器
-        containers = soup.find_all('div', class_=lambda x: x and 'c-container' in x, limit=limit * 2)
+        # 提取搜索结果容器。不预截断列表：相关搜索/卡片等会被拒绝的容器可能
+        # 排在有效结果前面，靠下方 len(results) >= limit 提前退出即可
+        containers = soup.find_all('div', class_=lambda x: x and 'c-container' in x)
         
         for container in containers:
             # 标题只认 h3 下的链接：容器里第一个 <a> 可能是卡片子链接

--- a/utils/web_scraper.py
+++ b/utils/web_scraper.py
@@ -1844,7 +1844,8 @@ def parse_baidu_results(html_content: str, limit: int = 5) -> List[Dict[str, str
         Search result list; each result contains title, abstract, url
     """
     results = []
-    
+    seen_urls = set()
+
     try:
         from bs4 import BeautifulSoup
         soup = BeautifulSoup(html_content, 'lxml')
@@ -1866,6 +1867,8 @@ def parse_baidu_results(html_content: str, limit: int = 5) -> List[Dict[str, str
                     if not href.startswith(('http://', 'https://')):
                         continue
                     url = href
+                    if url in seen_urls:
+                        continue
 
                     # 提取摘要
                     abstract = ""
@@ -1874,6 +1877,7 @@ def parse_baidu_results(html_content: str, limit: int = 5) -> List[Dict[str, str
                         abstract = _sanitize_search_text(content_span.get_text(strip=True))[:200]
 
                     if not any(skip in title.lower() for skip in ['百度', '广告', 'javascript']):
+                        seen_urls.add(url)
                         results.append({
                             'title': title,
                             'abstract': abstract,
@@ -1890,12 +1894,17 @@ def parse_baidu_results(html_content: str, limit: int = 5) -> List[Dict[str, str
                 if link:
                     title = _sanitize_search_text(link.get_text(strip=True))
                     if title and 5 < len(title) < 200:
-                        # 与主循环同口径：只接受 http(s) 绝对地址
+                        # 与主循环同口径：http(s) 校验、广告关键词过滤、URL 去重
                         href = link.get('href', '')
                         if not href.startswith(('http://', 'https://')):
                             continue
                         url = href
+                        if url in seen_urls:
+                            continue
+                        if any(skip in title.lower() for skip in ['百度', '广告', 'javascript']):
+                            continue
 
+                        seen_urls.add(url)
                         results.append({
                             'title': title,
                             'abstract': '',

--- a/utils/web_scraper.py
+++ b/utils/web_scraper.py
@@ -1696,10 +1696,11 @@ def parse_duckduckgo_results(html_content: str, limit: int = 5) -> List[Dict[str
         from bs4 import BeautifulSoup
         soup = BeautifulSoup(html_content, 'lxml')
 
-        # html.duckduckgo.com 每条结果是 div.result（正常结果还带 web-result）
+        # html.duckduckgo.com 每条结果是 div.result（正常结果还带 web-result）。
+        # 不预截断：广告/无效 URL 的条目可能排在前面，靠下方攒够 limit 提前退出
         result_divs = soup.find_all('div', class_='result')
 
-        for div in result_divs[:limit * 2]:
+        for div in result_divs:
             # 跳过广告（class 含 result--ad / results_links_deep 之外的 ad 变体）
             cls = div.get('class') or []
             if any('ad' in c for c in cls):
@@ -1876,10 +1877,10 @@ def parse_baidu_results(html_content: str, limit: int = 5) -> List[Dict[str, str
                         if len(results) >= limit:
                             break
         
-        # 如果没找到结果，尝试提取 h3 标题
+        # 如果没找到结果，尝试提取 h3 标题。同样不预截断：被拒绝的
+        # 相关搜索类 h3 可能排在前面，攒够 limit 条再退出
         if not results:
-            h3_links = soup.find_all('h3')
-            for h3 in h3_links[:limit]:
+            for h3 in soup.find_all('h3'):
                 link = h3.find('a')
                 if link:
                     title = _sanitize_search_text(link.get_text(strip=True))
@@ -1895,6 +1896,8 @@ def parse_baidu_results(html_content: str, limit: int = 5) -> List[Dict[str, str
                             'abstract': '',
                             'url': url
                         })
+                        if len(results) >= limit:
+                            break
         
         logger.info(f"解析到 {len(results)} 条百度搜索结果")
         return results[:limit]

--- a/utils/web_scraper.py
+++ b/utils/web_scraper.py
@@ -26,6 +26,7 @@ import httpx
 from utils.external_http_client import get_external_http_client
 import random
 import re
+import unicodedata
 import platform
 from typing import TYPE_CHECKING, Dict, List, Any, Optional, Union
 from urllib.parse import quote
@@ -1651,6 +1652,30 @@ async def search_duckduckgo(query: str, limit: int = 10) -> Dict[str, Any]:
         }
 
 
+_SEARCH_TEXT_WS_RE = re.compile(r"\s+")
+
+
+def _sanitize_search_text(text: str) -> str:
+    """清洗不可信搜索结果文本：去掉控制/格式/私有区/代理区字符与 U+FFFD，压缩空白。
+
+    Baidu 页面文本节点里混有 iconfont 私有区字符（如 U+E687），编码错位时还会出现
+    U+FFFD，零宽/bidi 控制符可能被用来做注入混淆——这些都不应进入 LLM/TTS。
+    """
+    if not text:
+        return ""
+    kept = []
+    for ch in text:
+        if ch.isspace():
+            kept.append(" ")
+            continue
+        if ord(ch) == 0xFFFD:
+            continue
+        if unicodedata.category(ch) in ("Cc", "Cf", "Co", "Cs"):
+            continue
+        kept.append(ch)
+    return _SEARCH_TEXT_WS_RE.sub(" ", "".join(kept)).strip()
+
+
 def parse_duckduckgo_results(html_content: str, limit: int = 5) -> List[Dict[str, str]]:
     """
     Parse a DuckDuckGo HTML-endpoint search results page
@@ -1682,7 +1707,7 @@ def parse_duckduckgo_results(html_content: str, limit: int = 5) -> List[Dict[str
             if not link:
                 continue
 
-            title = link.get_text(strip=True)
+            title = _sanitize_search_text(link.get_text(strip=True))
             if not title or not (3 < len(title) < 200):
                 continue
 
@@ -1699,12 +1724,15 @@ def parse_duckduckgo_results(html_content: str, limit: int = 5) -> List[Dict[str
                     url = qs.get('uddg', [''])[0]
                 elif href.startswith('http'):
                     url = href
+            # 只接受 http(s) 绝对地址（uddg 里也可能包着 javascript: 之类）
+            if url and not url.startswith(('http://', 'https://')):
+                url = ''
 
             # 摘要片段
             abstract = ''
             snippet = div.find(class_='result__snippet')
             if snippet:
-                abstract = snippet.get_text(strip=True)[:200]
+                abstract = _sanitize_search_text(snippet.get_text(strip=True))[:200]
 
             results.append({
                 'title': title,
@@ -1817,10 +1845,11 @@ def parse_baidu_results(html_content: str, limit: int = 5) -> List[Dict[str, str
         containers = soup.find_all('div', class_=lambda x: x and 'c-container' in x, limit=limit * 2)
         
         for container in containers:
-            # 提取标题和链接
-            link = container.find('a')
+            # 标题只认 h3 下的链接：容器里第一个 <a> 可能是卡片子链接
+            # （如天气卡的"查看40天预报"）或相关搜索词，不是结果标题
+            link = container.select_one('h3 a[href]')
             if link:
-                title = link.get_text(strip=True)
+                title = _sanitize_search_text(link.get_text(strip=True))
                 if title and 5 < len(title) < 200:
                     # 提取 URL（处理相对和绝对 URL）
                     href = link.get('href', '')
@@ -1829,13 +1858,16 @@ def parse_baidu_results(html_content: str, limit: int = 5) -> List[Dict[str, str
                         url = urljoin('https://www.baidu.com', href)
                     else:
                         url = ''
-                    
+                    # 只接受 http(s) 跳转，拒绝 javascript: 等伪协议
+                    if url and not url.startswith(('http://', 'https://')):
+                        continue
+
                     # 提取摘要
                     abstract = ""
                     content_span = container.find('span', class_=lambda x: x and 'content-right' in x)
                     if content_span:
-                        abstract = content_span.get_text(strip=True)[:200]
-                    
+                        abstract = _sanitize_search_text(content_span.get_text(strip=True))[:200]
+
                     if not any(skip in title.lower() for skip in ['百度', '广告', 'javascript']):
                         results.append({
                             'title': title,
@@ -1851,7 +1883,7 @@ def parse_baidu_results(html_content: str, limit: int = 5) -> List[Dict[str, str
             for h3 in h3_links[:limit]:
                 link = h3.find('a')
                 if link:
-                    title = link.get_text(strip=True)
+                    title = _sanitize_search_text(link.get_text(strip=True))
                     if title and 5 < len(title) < 200:
                         # 提取 URL
                         href = link.get('href', '')
@@ -1864,7 +1896,9 @@ def parse_baidu_results(html_content: str, limit: int = 5) -> List[Dict[str, str
                                 url = href
                         else:
                             url = ''
-                        
+                        if url and not url.startswith(('http://', 'https://')):
+                            continue
+
                         results.append({
                             'title': title,
                             'abstract': '',

--- a/utils/web_scraper.py
+++ b/utils/web_scraper.py
@@ -1656,10 +1656,12 @@ _SEARCH_TEXT_WS_RE = re.compile(r"\s+")
 
 
 def _sanitize_search_text(text: str) -> str:
-    """清洗不可信搜索结果文本：去掉控制/格式/私有区/代理区字符与 U+FFFD，压缩空白。
+    """Sanitize untrusted search-result text: drop control/format/private-use/
+    surrogate characters and U+FFFD, and normalize whitespace.
 
-    Baidu 页面文本节点里混有 iconfont 私有区字符（如 U+E687），编码错位时还会出现
-    U+FFFD，零宽/bidi 控制符可能被用来做注入混淆——这些都不应进入 LLM/TTS。
+    Baidu pages mix iconfont private-use glyphs (e.g. U+E687) into text nodes,
+    mis-decoded pages yield U+FFFD, and zero-width/bidi controls can be abused
+    for injection obfuscation — none of these should reach the LLM/TTS.
     """
     if not text:
         return ""

--- a/utils/web_scraper.py
+++ b/utils/web_scraper.py
@@ -1727,9 +1727,14 @@ def parse_duckduckgo_results(html_content: str, limit: int = 5) -> List[Dict[str
                     url = qs.get('uddg', [''])[0]
                 elif href.startswith('http'):
                     url = href
-            # 只接受 http(s) 绝对地址（uddg 里也可能包着 javascript: 之类），
-            # 没有可用目标地址的整条跳过，不以空 URL 占用结果位
-            if not url.startswith(('http://', 'https://')):
+            # 只接受带真实主机名的 http(s) 绝对地址（uddg 里可能包着
+            # javascript: 或 "https://" 这种残缺目标），无效的整条跳过
+            try:
+                parsed_target = urlparse(url)
+                url_ok = parsed_target.scheme in ('http', 'https') and bool(parsed_target.hostname)
+            except ValueError:
+                url_ok = False
+            if not url_ok:
                 continue
 
             # 摘要片段

--- a/utils/web_scraper.py
+++ b/utils/web_scraper.py
@@ -1726,9 +1726,10 @@ def parse_duckduckgo_results(html_content: str, limit: int = 5) -> List[Dict[str
                     url = qs.get('uddg', [''])[0]
                 elif href.startswith('http'):
                     url = href
-            # 只接受 http(s) 绝对地址（uddg 里也可能包着 javascript: 之类）
-            if url and not url.startswith(('http://', 'https://')):
-                url = ''
+            # 只接受 http(s) 绝对地址（uddg 里也可能包着 javascript: 之类），
+            # 没有可用目标地址的整条跳过，不以空 URL 占用结果位
+            if not url.startswith(('http://', 'https://')):
+                continue
 
             # 摘要片段
             abstract = ''
@@ -1839,7 +1840,6 @@ def parse_baidu_results(html_content: str, limit: int = 5) -> List[Dict[str, str
     results = []
     
     try:
-        from urllib.parse import urljoin
         from bs4 import BeautifulSoup
         soup = BeautifulSoup(html_content, 'lxml')
 
@@ -1853,16 +1853,12 @@ def parse_baidu_results(html_content: str, limit: int = 5) -> List[Dict[str, str
             if link:
                 title = _sanitize_search_text(link.get_text(strip=True))
                 if title and 5 < len(title) < 200:
-                    # 提取 URL（处理相对和绝对 URL）
+                    # 只接受 http(s) 绝对地址：相关搜索等站内相对链接（/s?wd=...）
+                    # 和 javascript: 伪协议都不是搜索结果，不能 urljoin 洗白
                     href = link.get('href', '')
-                    if href:
-                        # urljoin 能够自动处理绝对URL、相对URL以及以 '/' 开头的根URL
-                        url = urljoin('https://www.baidu.com', href)
-                    else:
-                        url = ''
-                    # 只接受 http(s) 跳转，拒绝 javascript: 等伪协议
-                    if url and not url.startswith(('http://', 'https://')):
+                    if not href.startswith(('http://', 'https://')):
                         continue
+                    url = href
 
                     # 提取摘要
                     abstract = ""
@@ -1887,19 +1883,11 @@ def parse_baidu_results(html_content: str, limit: int = 5) -> List[Dict[str, str
                 if link:
                     title = _sanitize_search_text(link.get_text(strip=True))
                     if title and 5 < len(title) < 200:
-                        # 提取 URL
+                        # 与主循环同口径：只接受 http(s) 绝对地址
                         href = link.get('href', '')
-                        if href:
-                            if href.startswith('/'):
-                                url = urljoin('https://www.baidu.com', href)
-                            elif not href.startswith('http'):
-                                url = urljoin('https://www.baidu.com/', href)
-                            else:
-                                url = href
-                        else:
-                            url = ''
-                        if url and not url.startswith(('http://', 'https://')):
+                        if not href.startswith(('http://', 'https://')):
                             continue
+                        url = href
 
                         results.append({
                             'title': title,


### PR DESCRIPTION
## 问题

web_search 插件对搜索结果的解析有瑕疵且不安全，用户反馈 AI 有时会读出非法字符，尤其在百度上：

1. **非法字符进入 LLM/TTS**：百度页面文本节点里混有 iconfont 私有区字符（实测页面扫到 U+E687/U+E613/U+E619/U+E662）；`resp.text` 在响应头缺 charset 或 charset 与实际字节不符时按 UTF-8 硬解 GBK 页面，产出成串的 U+FFFD；零宽/bidi 控制符原样透传。三者都不做任何清洗直接拼进 summary。
2. **解析抓错内容**：`item.find("a", href=True)` 取容器第一个 `<a>`，把天气卡片的子链接（"查看40天预报"+摘要"61%"）和相关搜索推荐词当成结果；`span.content-right_8Zs40` 这类带 CSS-module 哈希的选择器一改版就失效。
3. **不安全**：结果 URL 不做 scheme 校验（`javascript:`、站内相对链接原样返回）；每次搜索新建无 Cookie 的 client，实测第二次请求起 100% 命中"百度安全验证"反爬页且被静默解析成 0 条；`print()` 直接把网页原文打到 stdout，Windows 管道编码为 ANSI 代码页时遇到 emoji/PUA 抛 `UnicodeEncodeError` 使整次搜索失败（且与上一行"不写 logger"的隐私注释自相矛盾）。

## 修复

**新增 `plugin/plugins/web_search/_parsing.py`**（纯函数解析层，不依赖 SDK，参照 lifekit `_routing.py` 的组织方式）：

- `sanitize_text()`：清掉 Cc/Cf/Co/Cs 类别字符（控制、零宽、bidi 覆盖、iconfont 私有区）与 U+FFFD，空白归一。
- `decode_html()`：按 响应头 charset → 页面 meta 嗅探 → utf-8 → gb18030 顺序严格解码，gb2312/gbk 升级为超集 gb18030，全部失败才 replace 兜底。
- `is_http_url()`：结果 URL 只接受 http(s) 绝对地址。
- `parse_baidu_html()`：标题只认 `h3 a[href]`；跳过 `data-tuiguang` 推广容器；URL 去重；`span[class*='content-right']` 前缀匹配替代哈希类名；标题/摘要截断。
- `is_baidu_blocked()` + `SearchBlockedError`：识别"百度安全验证"/wappass 反爬页，显式报错而非静默 0 条。
- DDG html/lite 解析同步接入 sanitize 与 URL 校验。

**`__init__.py`**：

- 插件持有共享 `httpx.AsyncClient`（shutdown 时关闭）：Cookie 与连接跨搜索复用；百度搜索前若无 BAIDUID 先访问首页领 Cookie，请求带 `ie=utf-8`。
- 删除全部 `print()`；logger 只记录 query/summary 的长度与条数，符合既有隐私注释的意图。

**`utils/web_scraper.py`**（主服务侧同款问题，最小修复）：

- `parse_baidu_results()`：标题只认 `h3 a[href]`（不再取容器第一个 `<a>`），拒绝非 http(s) 跳转。
- `parse_baidu_results()` / `parse_duckduckgo_results()`：标题/摘要接入 `_sanitize_search_text()`。

## 验证

- 新增 21 个单测（`plugin/tests/unit/plugins/test_web_search_parsing.py`、`tests/unit/test_baidu_search.py`），连同既有 `tests/unit/test_duckduckgo_search.py` 全部通过；不可见字符用例一律以 `\u` 转义书写。
- 真实网络端到端：DDG 返回 5 条全部清洗合格、URL 均为 http(s)；百度反爬页正确抛出 `SearchBlockedError`（本机 IP 已被 302 到 wappass 验证码页，恰好覆盖该路径）。
- 编码回退用实测样本验证：`charset=utf-8` 响应头 + GBK 字节 → gb18030 正确解码，无 U+FFFD。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改进**
  - 优化百度与 DuckDuckGo 搜索流程：在被拦截时能识别并给出一致的失败提示，海外搜索失败后自动回退到备用方案。
  - 强化网页编码识别与文本清洗：清理异常字符与多余空白，提升标题/摘要可读性。
  - 更严格的结果筛选：过滤广告、无效/不安全链接，限制结果数量并去重，避免展示不可靠信息。
  - 改进错误处理与日志表现，减少控制台噪音并统一返回口径。
- **测试**
  - 新增与扩展解析与清洗相关单元测试，覆盖常见异常场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->