### PR TITLE
统一 Live2D 参数正式 ID，迁移旧参数数据，并修复模型默认值重置及参数意外串改问题

### DIFF
--- a/static/js/live2d_parameter_editor.js
+++ b/static/js/live2d_parameter_editor.js
@@ -1015,12 +1015,15 @@ function getParameterRange(coreModel, index) {
         console.warn('Error getting parameter range:', e);
     }
 
-    // Validate values
+    // Validate values. Keep whether the default came from the model separate
+    // from the numeric UI fallback so reset-all never treats an invented zero
+    // as a declared model default.
     if (typeof min !== 'number' || isNaN(min)) min = -1;
     if (typeof max !== 'number' || isNaN(max)) max = 1;
-    if (defaultVal === undefined || typeof defaultVal !== 'number' || isNaN(defaultVal)) defaultVal = 0;
+    const hasDefault = typeof defaultVal === 'number' && Number.isFinite(defaultVal);
+    if (!hasDefault) defaultVal = 0;
 
-    return { min, max, default: defaultVal };
+    return { min, max, default: defaultVal, hasDefault };
 }
 
 // 更新参数UI值（不重新渲染列表）
@@ -1391,9 +1394,11 @@ if (resetAllBtn) {
                 let resetValue = parameter.defaultValue;
                 if (typeof resetValue !== 'number' || !Number.isFinite(resetValue)) {
                     const range = getParameterRange(coreModel, parameter.index);
-                    resetValue = range.default;
+                    if (range.hasDefault === true) resetValue = range.default;
                 }
                 if (typeof resetValue !== 'number' || !Number.isFinite(resetValue)) {
+                    // Unknown wrappers cannot expose the .moc3 default. Keep
+                    // the loaded value instead of fabricating a destructive 0.
                     resetValue = initialParameters[parameter.key];
                 }
                 if (typeof resetValue !== 'number' || !Number.isFinite(resetValue)) continue;

--- a/static/js/live2d_parameter_editor.js
+++ b/static/js/live2d_parameter_editor.js
@@ -181,6 +181,8 @@ let initialParameters = {};
 // 独立编辑草稿：只由用户操作更新，避免 motion/物理/呼吸的瞬时值混入保存结果。
 let draftParameters = {};
 let draftParameterIndexes = {};
+let parameterCatalog = [];
+let parameterCatalogByIndex = new Map();
 
 // 加载序列号，用于防止异步加载乱序
 let loadSeq = 0;
@@ -927,28 +929,39 @@ function recordInitialParameters() {
     }
 
     const coreModel = live2dModel.internalModel.coreModel;
+    const manager = window.live2dManager;
     initialParameters = {};
     draftParameters = {};
     draftParameterIndexes = {};
-    const effectiveParameters = window.live2dManager?.effectiveModelParameters || {};
-    const paramCount = coreModel.getParameterCount();
+    parameterCatalog = manager && typeof manager._buildModelParameterCatalog === 'function'
+        ? manager._buildModelParameterCatalog(coreModel)
+        : [];
+    if (parameterCatalog.length === 0) {
+        const paramCount = coreModel.getParameterCount();
+        parameterCatalog = Array.from({ length: paramCount }, (_, index) => ({
+            index,
+            id: '',
+            key: `param_${index}`,
+            defaultValue: undefined
+        }));
+    }
+    parameterCatalogByIndex = new Map(parameterCatalog.map(entry => [entry.index, entry]));
 
-    for (let i = 0; i < paramCount; i++) {
+    const rawEffectiveParameters = manager?.effectiveModelParameters || {};
+    const effectiveParameters = manager && typeof manager._normalizeModelParameters === 'function'
+        ? manager._normalizeModelParameters(coreModel, rawEffectiveParameters)
+        : rawEffectiveParameters;
+
+    for (const parameter of parameterCatalog) {
         try {
-            let paramId = null;
-            try {
-                paramId = coreModel.getParameterId(i);
-            } catch (e) {
-                paramId = `param_${i}`;
-            }
-            const value = coreModel.getParameterValueByIndex(i);
-            initialParameters[paramId] = value;
-            draftParameterIndexes[paramId] = i;
-            draftParameters[paramId] = Object.prototype.hasOwnProperty.call(effectiveParameters, paramId)
-                ? effectiveParameters[paramId]
+            const value = coreModel.getParameterValueByIndex(parameter.index);
+            initialParameters[parameter.key] = value;
+            draftParameterIndexes[parameter.key] = parameter.index;
+            draftParameters[parameter.key] = Object.prototype.hasOwnProperty.call(effectiveParameters, parameter.key)
+                ? effectiveParameters[parameter.key]
                 : value;
         } catch (e) {
-            console.warn(`记录参数 ${i} 失败:`, e);
+            console.warn(`记录参数 ${parameter.index} 失败:`, e);
         }
     }
 }
@@ -1081,8 +1094,9 @@ function displayParameters() {
             try {
                 const idx = coreModel.getParameterIndex(param.id);
                 if (idx >= 0) {
+                    const parameter = parameterCatalogByIndex.get(idx);
                     groupedParams[groupName].push({
-                        id: param.id,
+                        id: parameter?.key || param.id,
                         name: getParameterChineseName(param.name), // 使用中文名称
                         index: idx
                     });
@@ -1093,18 +1107,10 @@ function displayParameters() {
         }
     } else {
         // 如果没有参数信息，从模型读取所有参数
-        const paramCount = coreModel.getParameterCount();
-        for (let i = 0; i < paramCount; i++) {
+        for (const parameter of parameterCatalog) {
             try {
-                let paramId = null;
-                let paramName = null;
-                try {
-                    paramId = coreModel.getParameterId(i);
-                    paramName = paramId; // 如果没有名称，使用ID
-                } catch (e) {
-                    paramId = `param_${i}`;
-                    paramName = paramId;
-                }
+                const paramId = parameter.key;
+                const paramName = parameter.id || parameter.key;
 
                 // 只显示重要参数
                 if (!isParameterImportant(paramId, paramName)) {
@@ -1118,10 +1124,10 @@ function displayParameters() {
                 groupedParams[groupName].push({
                     id: paramId,
                     name: getParameterChineseName(paramName), // 转换为中文名称
-                    index: i
+                    index: parameter.index
                 });
             } catch (e) {
-                console.warn(`处理参数 ${i} 失败:`, e);
+                console.warn(`处理参数 ${parameter.index} 失败:`, e);
             }
         }
     }
@@ -1368,32 +1374,35 @@ if (resetAllBtn) {
         if (!live2dModel || !live2dModel.internalModel || !live2dModel.internalModel.coreModel) return;
 
         const coreModel = live2dModel.internalModel.coreModel;
-        const paramCount = coreModel.getParameterCount();
+        const manager = window.live2dManager;
+        const catalog = parameterCatalog.length > 0
+            ? parameterCatalog
+            : (manager && typeof manager._buildModelParameterCatalog === 'function'
+                ? manager._buildModelParameterCatalog(coreModel)
+                : []);
 
-        // 将所有参数重置为加载时的初始值
-        for (let i = 0; i < paramCount; i++) {
+        // 全量重建草稿，避免保留任何历史别名或本次会话中的旧键。
+        draftParameters = {};
+        draftParameterIndexes = {};
+
+        // 重置为模型在 .moc3 中声明的真正默认值，而不是页面加载时的外观。
+        for (const parameter of catalog) {
             try {
-                let paramId = null;
-                try {
-                    paramId = coreModel.getParameterId(i);
-                } catch (e) {
-                    paramId = `param_${i}`;
-                }
-
-                let resetValue = 0;
-                // 优先使用加载时记录的初始值
-                if (initialParameters && initialParameters[paramId] !== undefined) {
-                    resetValue = initialParameters[paramId];
-                } else {
-                    // 降级到使用模型定义的默认值
-                    const range = getParameterRange(coreModel, i);
+                let resetValue = parameter.defaultValue;
+                if (typeof resetValue !== 'number' || !Number.isFinite(resetValue)) {
+                    const range = getParameterRange(coreModel, parameter.index);
                     resetValue = range.default;
                 }
+                if (typeof resetValue !== 'number' || !Number.isFinite(resetValue)) {
+                    resetValue = initialParameters[parameter.key];
+                }
+                if (typeof resetValue !== 'number' || !Number.isFinite(resetValue)) continue;
 
-                coreModel.setParameterValueByIndex(i, resetValue);
-                draftParameters[paramId] = resetValue;
+                coreModel.setParameterValueByIndex(parameter.index, resetValue);
+                draftParameters[parameter.key] = resetValue;
+                draftParameterIndexes[parameter.key] = parameter.index;
             } catch (e) {
-                console.warn(`重置参数索引 ${i} 失败:`, e);
+                console.warn(`重置参数索引 ${parameter.index} 失败:`, e);
             }
         }
 
@@ -1403,10 +1412,18 @@ if (resetAllBtn) {
     });
 }
 
-function buildParametersFromDraft(parameters, parameterIndexes, manager) {
+function buildParametersFromDraft(parameters, parameterIndexes, manager, coreModel) {
+    const normalizedParameters = manager
+        && coreModel
+        && typeof manager._normalizeModelParameters === 'function'
+        ? manager._normalizeModelParameters(coreModel, parameters)
+        : parameters;
     const paramsToSave = {};
-    for (const [paramId, value] of Object.entries(parameters || {})) {
-        const index = parameterIndexes && parameterIndexes[paramId];
+    for (const [paramId, value] of Object.entries(normalizedParameters || {})) {
+        let index = parameterIndexes && parameterIndexes[paramId];
+        if (manager && coreModel && typeof manager._resolveModelParameterKey === 'function') {
+            index = manager._resolveModelParameterKey(coreModel, paramId)?.idx ?? index;
+        }
         let isEyeBlinkParam = false;
         try {
             isEyeBlinkParam = manager && typeof manager._isEyeBlinkParamId === 'function'
@@ -1465,7 +1482,13 @@ if (saveBtn) {
         showStatus(t('live2d.parameterEditor.savingParameters', '正在保存参数...'));
 
         const manager = window.live2dManager;
-        const paramsToSave = buildParametersFromDraft(draftParameters, draftParameterIndexes, manager);
+        const coreModel = live2dModel.internalModel?.coreModel;
+        const paramsToSave = buildParametersFromDraft(
+            draftParameters,
+            draftParameterIndexes,
+            manager,
+            coreModel
+        );
 
         try {
             const { fileSuccess, fileError, prefSuccess, prefError } = await persistParameterDraft(

--- a/static/live2d/live2d-init.js
+++ b/static/live2d/live2d-init.js
@@ -721,10 +721,11 @@ async function _initLive2DModelInner() {
                 isMobile: typeof window.isMobileWidth === 'function' ? window.isMobileWidth() : (window.innerWidth <= 768),
                 // 在常驻表情应用完成后应用参数（事件驱动，替代不可靠的 setTimeout）
                 onResidentExpressionApplied: (model) => {
-                    if (modelPreferences && modelPreferences.parameters &&
+                    const effectiveParameters = window.live2dManager.effectiveModelParameters;
+                    if (effectiveParameters && Object.keys(effectiveParameters).length > 0 &&
                         model && model.internalModel && model.internalModel.coreModel) {
-                        window.live2dManager.applyModelParameters(model, modelPreferences.parameters);
-                        console.log('[Live2D Init] 在常驻表情应用后已重新应用用户偏好参数');
+                        window.live2dManager.applyModelParameters(model, effectiveParameters);
+                        console.log('[Live2D Init] 在常驻表情应用后已重新应用规范化有效参数');
                     }
                 },
                 // 模型完全就绪后恢复待机动作（延迟 500ms 确保模型完全稳定）

--- a/static/live2d/live2d-model.js
+++ b/static/live2d/live2d-model.js
@@ -205,6 +205,88 @@ Live2DManager.prototype.removeModel = async function(options = {}) {
     }
 };
 
+Live2DManager.prototype._stringifyCoreParameterId = function(paramId) {
+    if (paramId === undefined || paramId === null) return '';
+    if (typeof paramId === 'string') return paramId;
+    try {
+        if (typeof paramId.getString === 'function') {
+            const value = paramId.getString();
+            if (typeof value === 'string') return value;
+            if (value && typeof value.s === 'string') return value.s;
+            if (value !== undefined && value !== null) return String(value);
+        }
+    } catch (_) {}
+    try {
+        const value = String(paramId);
+        return value && value !== '[object Object]' ? value : '';
+    } catch (_) {
+        return '';
+    }
+};
+
+// Cubism 2/3/4/5 wrappers expose parameter IDs through different fields.
+// Keep the compatibility lookup in one place so editor/load/save paths never
+// invent different keys for the same parameter index.
+Live2DManager.prototype._getCoreParameterId = function(coreModel, index) {
+    if (!coreModel || !Number.isInteger(index) || index < 0) return '';
+
+    const candidates = [];
+    try { candidates.push(coreModel._parameterIds?.[index]); } catch (_) {}
+    try { candidates.push(coreModel._model?.parameters?.ids?.[index]); } catch (_) {}
+    try { candidates.push(coreModel.model?.parameters?.ids?.[index]); } catch (_) {}
+    try { candidates.push(coreModel.parameters?.ids?.[index]); } catch (_) {}
+    try {
+        if (typeof coreModel.getParameterId === 'function') {
+            candidates.push(coreModel.getParameterId(index));
+        }
+    } catch (_) {}
+
+    for (const candidate of candidates) {
+        const id = this._stringifyCoreParameterId(candidate);
+        if (id) return id;
+    }
+    return '';
+};
+
+Live2DManager.prototype._getCoreParameterDefaultValue = function(coreModel, index) {
+    if (!coreModel || !Number.isInteger(index) || index < 0) return undefined;
+    return this._readParameterValueByIndex(
+        coreModel,
+        index,
+        [
+            'getParameterDefaultValueByIndex',
+            'getParameterDefaultValue',
+            'getParamDefaultValue',
+            'getParamDefault'
+        ],
+        ['defaultValues', 'defaults', '_parameterDefaultValues'],
+        undefined
+    );
+};
+
+Live2DManager.prototype._buildModelParameterCatalog = function(coreModel) {
+    if (!coreModel || typeof coreModel.getParameterCount !== 'function') return [];
+
+    const catalog = [];
+    const usedKeys = new Set();
+    const parameterCount = coreModel.getParameterCount();
+    for (let index = 0; index < parameterCount; index++) {
+        const id = this._getCoreParameterId(coreModel, index);
+        let key = id || `param_${index}`;
+        // Model parameter IDs should be unique. Preserve every parameter even
+        // for malformed models by falling back to its stable runtime index.
+        if (usedKeys.has(key)) key = `param_${index}`;
+        usedKeys.add(key);
+        catalog.push({
+            index,
+            id: id || '',
+            key,
+            defaultValue: this._getCoreParameterDefaultValue(coreModel, index)
+        });
+    }
+    return catalog;
+};
+
 Live2DManager.prototype._resolveModelParameterKey = function(coreModel, paramId) {
     if (!coreModel || paramId === undefined || paramId === null) return null;
 
@@ -221,15 +303,11 @@ Live2DManager.prototype._resolveModelParameterKey = function(coreModel, paramId)
             : Number.POSITIVE_INFINITY;
         if (parsedIndex >= 0 && parsedIndex < parameterCount) {
             idx = parsedIndex;
-            try {
-                if (typeof coreModel.getParameterId === 'function') {
-                    const id = coreModel.getParameterId(idx);
-                    if (id) {
-                        resolvedId = id;
-                        hasResolvedId = true;
-                    }
-                }
-            } catch (_) {}
+            const id = this._getCoreParameterId(coreModel, idx);
+            if (id) {
+                resolvedId = id;
+                hasResolvedId = true;
+            }
         }
     } else {
         try {
@@ -242,6 +320,39 @@ Live2DManager.prototype._resolveModelParameterKey = function(coreModel, paramId)
     }
 
     return idx >= 0 ? { idx, resolvedId, hasResolvedId, isIndexKey } : null;
+};
+
+// Lazy migration for legacy parameter dictionaries. Both official Cubism IDs
+// and historical param_N aliases are accepted, but each runtime index emits
+// exactly one canonical key. Official IDs always outrank legacy aliases;
+// entries of the same kind retain the historical last-write-wins behavior.
+Live2DManager.prototype._normalizeModelParameters = function(coreModel, parameters) {
+    if (!coreModel || !parameters || typeof parameters !== 'object') return {};
+
+    const catalogByIndex = new Map(
+        this._buildModelParameterCatalog(coreModel).map(parameter => [parameter.index, parameter])
+    );
+    const normalizedByIndex = new Map();
+    for (const [paramId, value] of Object.entries(parameters)) {
+        if (typeof value !== 'number' || !Number.isFinite(value)) continue;
+        const resolved = this._resolveModelParameterKey(coreModel, paramId);
+        if (!resolved) continue;
+        const canonicalKey = catalogByIndex.get(resolved.idx)?.key
+            || (resolved.hasResolvedId && resolved.resolvedId
+                ? String(resolved.resolvedId)
+                : `param_${resolved.idx}`);
+        const priority = resolved.isIndexKey ? 0 : 1;
+        const existing = normalizedByIndex.get(resolved.idx);
+        if (!existing || priority >= existing.priority) {
+            normalizedByIndex.set(resolved.idx, { key: canonicalKey, value, priority });
+        }
+    }
+
+    const normalized = {};
+    for (const { key, value } of normalizedByIndex.values()) {
+        normalized[key] = value;
+    }
+    return normalized;
 };
 
 Live2DManager.prototype._isRuntimeManagedAppearanceParam = function(paramId, resolvedParamId, coreModel) {
@@ -337,10 +448,16 @@ Live2DManager.prototype._findModelPreference = function(preferences, modelPath) 
     )) || null;
 };
 
-Live2DManager.prototype._mergeEffectiveModelParameters = function(modelDirectoryParameters, userPreferenceParameters) {
+Live2DManager.prototype._mergeEffectiveModelParameters = function(modelDirectoryParameters, userPreferenceParameters, coreModel) {
+    const directoryParameters = coreModel
+        ? this._normalizeModelParameters(coreModel, modelDirectoryParameters)
+        : (modelDirectoryParameters && typeof modelDirectoryParameters === 'object' ? modelDirectoryParameters : {});
+    const preferenceParameters = coreModel
+        ? this._normalizeModelParameters(coreModel, userPreferenceParameters)
+        : (userPreferenceParameters && typeof userPreferenceParameters === 'object' ? userPreferenceParameters : {});
     return {
-        ...(modelDirectoryParameters && typeof modelDirectoryParameters === 'object' ? modelDirectoryParameters : {}),
-        ...(userPreferenceParameters && typeof userPreferenceParameters === 'object' ? userPreferenceParameters : {})
+        ...directoryParameters,
+        ...preferenceParameters
     };
 };
 
@@ -357,9 +474,11 @@ Live2DManager.prototype._loadModelDirectoryParameters = async function(modelName
 };
 
 Live2DManager.prototype._applyEffectiveModelParameters = function(model, modelDirectoryParameters, userPreferenceParameters) {
+    const coreModel = model?.internalModel?.coreModel;
     const effectiveParameters = this._mergeEffectiveModelParameters(
         modelDirectoryParameters,
-        userPreferenceParameters
+        userPreferenceParameters,
+        coreModel
     );
     const hasEffectiveParameters = Object.keys(effectiveParameters).length > 0;
 

--- a/static/live2d/live2d-model.js
+++ b/static/live2d/live2d-model.js
@@ -322,10 +322,10 @@ Live2DManager.prototype._resolveModelParameterKey = function(coreModel, paramId)
     return idx >= 0 ? { idx, resolvedId, hasResolvedId, isIndexKey } : null;
 };
 
-// Lazy migration for legacy parameter dictionaries. Both official Cubism IDs
-// and historical param_N aliases are accepted, but each runtime index emits
-// exactly one canonical key. Official IDs always outrank legacy aliases;
-// entries of the same kind retain the historical last-write-wins behavior.
+// Lazy migration for legacy parameter dictionaries. Historical param_N keys
+// have no parameter identity, so they are only safe when the runtime cannot
+// expose an official ID for that index. Once an official ID is available,
+// discard the ambiguous alias instead of guessing across model revisions.
 Live2DManager.prototype._normalizeModelParameters = function(coreModel, parameters) {
     if (!coreModel || !parameters || typeof parameters !== 'object') return {};
 
@@ -337,7 +337,9 @@ Live2DManager.prototype._normalizeModelParameters = function(coreModel, paramete
         if (typeof value !== 'number' || !Number.isFinite(value)) continue;
         const resolved = this._resolveModelParameterKey(coreModel, paramId);
         if (!resolved) continue;
-        const canonicalKey = catalogByIndex.get(resolved.idx)?.key
+        const catalogEntry = catalogByIndex.get(resolved.idx);
+        if (resolved.isIndexKey && catalogEntry?.id) continue;
+        const canonicalKey = catalogEntry?.key
             || (resolved.hasResolvedId && resolved.resolvedId
                 ? String(resolved.resolvedId)
                 : `param_${resolved.idx}`);

--- a/tests/unit/test_live2d_init_static_contracts.py
+++ b/tests/unit/test_live2d_init_static_contracts.py
@@ -15,3 +15,14 @@ def test_live2d_init_respects_model_manager_pngtuber_mode():
     assert "String(window._modelManagerCurrentAvatarType || '').toLowerCase()" in guard_block
     assert "modelManagerAvatarType === 'pngtuber'" in guard_block
     assert guard_block.index("modelManagerAvatarType === 'pngtuber'") < guard_block.index("(window.lanlan_config?.model_type || '').toLowerCase() === 'pngtuber'")
+
+
+def test_resident_expression_callback_reapplies_normalized_effective_parameters():
+    source = LIVE2D_INIT_PATH.read_text(encoding="utf-8")
+    callback_start = source.index("onResidentExpressionApplied: (model) =>")
+    callback_end = source.index("onModelReady: (model) =>", callback_start)
+    callback_source = source[callback_start:callback_end]
+
+    assert "window.live2dManager.effectiveModelParameters" in callback_source
+    assert "applyModelParameters(model, effectiveParameters)" in callback_source
+    assert "applyModelParameters(model, modelPreferences.parameters)" not in callback_source

--- a/tests/unit/test_live2d_parameter_persistence_static.py
+++ b/tests/unit/test_live2d_parameter_persistence_static.py
@@ -227,6 +227,17 @@ def test_legacy_index_aliases_are_normalized_and_user_preferences_remain_authori
         );
         assert.strictEqual(Object.keys(normalized).some((key) => key.startsWith('param_')), false);
 
+        // An index-only value cannot be tied safely to an official parameter
+        // after a model revision may have reordered its parameter table.
+        const ambiguousLegacyOnly = manager._normalizeModelParameters(
+          coreModel,
+          { param_0: 5.42, param_1: 4.57 },
+        );
+        assert.deepStrictEqual(
+          JSON.parse(JSON.stringify(ambiguousLegacyOnly)),
+          {},
+        );
+
         // Official IDs are authoritative regardless of JSON insertion order.
         const reverseOrdered = manager._normalizeModelParameters(
           coreModel,

--- a/tests/unit/test_live2d_parameter_persistence_static.py
+++ b/tests/unit/test_live2d_parameter_persistence_static.py
@@ -100,8 +100,9 @@ def test_parameter_editor_saves_draft_instead_of_runtime_core_values():
 
     assert "currentParameters" not in source
     assert "draftParameters[paramId] = clampedValue" in source
-    assert "draftParameters[paramId] = resetValue" in source
-    assert "buildParametersFromDraft(draftParameters" in save_source
+    assert "draftParameters[parameter.key] = resetValue" in source
+    assert "buildParametersFromDraft(" in save_source
+    assert "draftParameters," in save_source
     assert "coreModel.getParameterValueByIndex(i)" not in save_source
 
     build_function = _extract_js_function(source, "buildParametersFromDraft")
@@ -144,6 +145,183 @@ def test_user_preference_parameters_override_model_directory_parameters():
     assert result.returncode == 0, result.stderr
 
 
+def test_cubism4_parameter_catalog_uses_official_ids_and_model_defaults():
+    script = _manager_harness(
+        """
+        const manager = new context.Live2DManager();
+        const ids = [
+          { getString() { return { s: 'ParamHair_Color1' }; } },
+          'ParamClothes_Color1',
+        ];
+        const coreModel = {
+          _parameterIds: ids,
+          parameters: { defaultValues: [0.25, 0.5] },
+          getParameterCount() { return ids.length; },
+          getParameterIndex(id) {
+            return ['ParamHair_Color1', 'ParamClothes_Color1'].indexOf(id);
+          },
+        };
+
+        const catalog = manager._buildModelParameterCatalog(coreModel);
+        assert.deepStrictEqual(
+          JSON.parse(JSON.stringify(catalog)),
+          [
+            { index: 0, id: 'ParamHair_Color1', key: 'ParamHair_Color1', defaultValue: 0.25 },
+            { index: 1, id: 'ParamClothes_Color1', key: 'ParamClothes_Color1', defaultValue: 0.5 },
+          ],
+        );
+        """
+    )
+    result = _run_node_harness(script)
+    assert result.returncode == 0, result.stderr
+
+
+def test_parameter_catalog_reuses_all_supported_default_value_sources():
+    script = _manager_harness(
+        """
+        const manager = new context.Live2DManager();
+        const ids = ['ParamFromGetter', 'ParamFromArray'];
+        const coreModel = {
+          _parameterIds: ids,
+          defaults: [undefined, '0.75'],
+          getParameterCount() { return ids.length; },
+          getParameterIndex(id) { return ids.indexOf(id); },
+          getParamDefault(index) { return index === 0 ? '0.25' : Number.NaN; },
+        };
+
+        const catalog = manager._buildModelParameterCatalog(coreModel);
+        assert.deepStrictEqual(
+          JSON.parse(JSON.stringify(catalog)),
+          [
+            { index: 0, id: 'ParamFromGetter', key: 'ParamFromGetter', defaultValue: 0.25 },
+            { index: 1, id: 'ParamFromArray', key: 'ParamFromArray', defaultValue: 0.75 },
+          ],
+        );
+        """
+    )
+    result = _run_node_harness(script)
+    assert result.returncode == 0, result.stderr
+
+
+def test_legacy_index_aliases_are_normalized_and_user_preferences_remain_authoritative():
+    script = _manager_harness(
+        """
+        const manager = new context.Live2DManager();
+        const ids = ['ParamHair_Color1', 'ParamClothes_Color1', 'ParamBangs_Hairstyle'];
+        const coreModel = {
+          _model: { parameters: { ids, defaultValues: [0, 0, 0] } },
+          getParameterCount() { return ids.length; },
+          getParameterIndex(id) { return ids.indexOf(id); },
+        };
+
+        const legacy = {
+          param_0: 5.42,
+          param_1: 4.57,
+          ParamHair_Color1: 0,
+          ParamClothes_Color1: 0,
+        };
+        const normalized = manager._normalizeModelParameters(coreModel, legacy);
+        assert.deepStrictEqual(
+          JSON.parse(JSON.stringify(normalized)),
+          { ParamHair_Color1: 0, ParamClothes_Color1: 0 },
+        );
+        assert.strictEqual(Object.keys(normalized).some((key) => key.startsWith('param_')), false);
+
+        // Official IDs are authoritative regardless of JSON insertion order.
+        const reverseOrdered = manager._normalizeModelParameters(
+          coreModel,
+          { ParamHair_Color1: 0, param_0: 5.42 },
+        );
+        assert.deepStrictEqual(
+          JSON.parse(JSON.stringify(reverseOrdered)),
+          { ParamHair_Color1: 0 },
+        );
+
+        // Normalize each source before merging so aliases and official IDs
+        // cannot both survive in the effective parameter dictionary.
+        const effective = manager._mergeEffectiveModelParameters(
+          { ParamHair_Color1: 0.1, param_0: 0.2, ParamClothes_Color1: 0.3 },
+          {},
+          coreModel,
+        );
+        assert.deepStrictEqual(
+          JSON.parse(JSON.stringify(effective)),
+          { ParamHair_Color1: 0.1, ParamClothes_Color1: 0.3 },
+        );
+
+        const preferenceOverride = manager._mergeEffectiveModelParameters(
+          { ParamHair_Color1: 0.1, ParamClothes_Color1: 0.3 },
+          { param_0: 0.7, ParamHair_Color1: 0.8 },
+          coreModel,
+        );
+        assert.deepStrictEqual(
+          JSON.parse(JSON.stringify(preferenceOverride)),
+          { ParamHair_Color1: 0.8, ParamClothes_Color1: 0.3 },
+        );
+
+        // Editing one unrelated parameter must preserve the normalized
+        // appearance values and must not re-emit legacy aliases.
+        const draft = { ...normalized, ParamBangs_Hairstyle: 1 };
+        const saved = manager._normalizeModelParameters(coreModel, draft);
+        assert.deepStrictEqual(
+          JSON.parse(JSON.stringify(saved)),
+          {
+            ParamHair_Color1: 0,
+            ParamClothes_Color1: 0,
+            ParamBangs_Hairstyle: 1,
+          },
+        );
+        """
+    )
+    result = _run_node_harness(script)
+    assert result.returncode == 0, result.stderr
+
+
+def test_parameter_catalog_keeps_stable_index_fallback_when_model_ids_are_unavailable():
+    script = _manager_harness(
+        """
+        const manager = new context.Live2DManager();
+        const coreModel = {
+          parameters: { defaultValues: [0.2, -0.5] },
+          getParameterCount() { return 2; },
+          getParameterIndex() { return -1; },
+        };
+
+        const catalog = manager._buildModelParameterCatalog(coreModel);
+        assert.deepStrictEqual(
+          JSON.parse(JSON.stringify(catalog)),
+          [
+            { index: 0, id: '', key: 'param_0', defaultValue: 0.2 },
+            { index: 1, id: '', key: 'param_1', defaultValue: -0.5 },
+          ],
+        );
+        assert.deepStrictEqual(
+          JSON.parse(JSON.stringify(manager._normalizeModelParameters(coreModel, { param_0: 0.7, param_1: -0.1 }))),
+          { param_0: 0.7, param_1: -0.1 },
+        );
+        """
+    )
+    result = _run_node_harness(script)
+    assert result.returncode == 0, result.stderr
+
+
+def test_parameter_editor_initializes_and_resets_through_canonical_catalog():
+    source = PARAMETER_EDITOR_PATH.read_text(encoding="utf-8")
+    record_start = source.index("function recordInitialParameters()")
+    record_end = source.index("// 获取参数的范围和默认值", record_start)
+    record_source = source[record_start:record_end]
+    reset_start = source.index("if (resetAllBtn) {")
+    reset_end = source.index("function buildParametersFromDraft", reset_start)
+    reset_source = source[reset_start:reset_end]
+
+    assert "manager._buildModelParameterCatalog(coreModel)" in record_source
+    assert "manager._normalizeModelParameters(coreModel, rawEffectiveParameters)" in record_source
+    assert "coreModel.getParameterId(i)" not in record_source
+    assert "draftParameters = {};" in reset_source
+    assert "resetValue = parameter.defaultValue" in reset_source
+    assert "initialParameters[paramId]" not in reset_source
+
+
 def test_effective_parameter_refresh_reinstalls_overlay_with_new_values():
     script = _manager_harness(
         """
@@ -156,7 +334,12 @@ def test_effective_parameter_refresh_reinstalls_overlay_with_new_values():
           manager.installedSnapshot = { ...(manager.savedModelParameters || {}) };
           manager.installCount = (manager.installCount || 0) + 1;
         };
-        const model = { internalModel: { coreModel: {} } };
+        const ids = ['ParamAllColor1'];
+        const model = { internalModel: { coreModel: {
+          _parameterIds: ids,
+          getParameterCount() { return ids.length; },
+          getParameterIndex(id) { return ids.indexOf(id); },
+        } } };
 
         manager._applyEffectiveModelParameters(model, { ParamAllColor1: 0.2 }, {});
         manager._applyEffectiveModelParameters(model, { ParamAllColor1: 0.2 }, { ParamAllColor1: 0.8 });

--- a/tests/unit/test_live2d_parameter_persistence_static.py
+++ b/tests/unit/test_live2d_parameter_persistence_static.py
@@ -319,7 +319,39 @@ def test_parameter_editor_initializes_and_resets_through_canonical_catalog():
     assert "coreModel.getParameterId(i)" not in record_source
     assert "draftParameters = {};" in reset_source
     assert "resetValue = parameter.defaultValue" in reset_source
+    assert "range.hasDefault === true" in reset_source
     assert "initialParameters[paramId]" not in reset_source
+
+
+def test_parameter_range_marks_synthetic_zero_as_not_a_model_default():
+    source = PARAMETER_EDITOR_PATH.read_text(encoding="utf-8")
+    get_range_function = _extract_js_function(source, "getParameterRange")
+    script = textwrap.dedent(
+        f"""
+        const assert = require('node:assert');
+        {get_range_function}
+
+        const unknownDefault = getParameterRange({{}}, 0);
+        assert.deepStrictEqual(
+          unknownDefault,
+          {{ min: -1, max: 1, default: 0, hasDefault: false }},
+        );
+
+        const declaredDefault = getParameterRange({{
+          parameters: {{
+            minimumValues: [-2],
+            maximumValues: [3],
+            defaultValues: [1.25],
+          }},
+        }}, 0);
+        assert.deepStrictEqual(
+          declaredDefault,
+          {{ min: -2, max: 3, default: 1.25, hasDefault: true }},
+        );
+        """
+    )
+    result = _run_node_harness(script)
+    assert result.returncode == 0, result.stderr
 
 
 def test_effective_parameter_refresh_reinstalls_overlay_with_new_values():


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

统一 Live2D 参数正式 ID，迁移旧参数数据，并修复模型默认值重置及参数意外串改问题

## 测试 / Testing

手动重置捏脸对比前后差异


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 优化 Live2D 参数目录管理，支持更稳定的官方参数 ID 与索引识别。
  - 参数编辑器的初始化、保存和全部重置流程现可保持参数值一致性。
  - 支持从模型默认值等多种来源恢复参数，并在缺少参数 ID 时使用稳定的索引标识。

- **问题修复**
  - 修复用户参数偏好与模型参数合并时的映射和覆盖异常。
  - 修复参数编辑器保存草稿时可能读取运行时参数值的问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->