### PR TITLE
fix(static): 延迟绑定 interpage relay listeners

### DIFF
--- a/scripts/check_static_app_part_keys.cjs
+++ b/scripts/check_static_app_part_keys.cjs
@@ -1,13 +1,57 @@
 'use strict';
 
 const assert = require('node:assert/strict');
-const childProcess = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
 const vm = require('node:vm');
 
 
 const repoRoot = path.resolve(__dirname, '..');
+
+// Snapshot of the public keys published by the three monoliths immediately
+// before they were split. Keep this contract independent of git history so the
+// check remains runnable after the deleted source files reach main.
+const expectedPublicKeys = {
+    reactChatWindowHost: [
+        'appendMessage', 'clearChoicePromptBySource', 'clearGuideMessages',
+        'clearIcebreakerChoicePrompt', 'clearMessages', 'clearPendingRollbackDraft',
+        'closeWindow', 'cycleChatSurfaceMode', 'deactivateToolCursor', 'ensureBundleLoaded',
+        'getChatSurfaceMode', 'getState', 'handleMiniGameInviteResolved',
+        'isGalgameModeEnabled', 'isMounted', 'openWindow', 'prepareCompactHistoryDropSubmit',
+        'refreshGalgameOptions', 'removeMessage', 'rollbackLastDraft', 'rotateCompactToolWheel',
+        'setAvatarToolMenuOpen', 'setChatSurfaceMode', 'setChoicePrompt',
+        'setCompactChatState', 'setCompactHistoryOpen', 'setCompactToolFanOpen',
+        'setCompactToolWheelIndex', 'setComposerAttachments', 'setComposerHidden',
+        'setGalgameModeEnabled', 'setGoodbyeComposerHidden', 'setHomeTutorialInputLocked',
+        'setHomeTutorialInteractionLocked', 'setIcebreakerChoicePrompt', 'setMessages',
+        'setMiniGameInvitePrompt', 'setNewUserIcebreakerPrompt', 'setOnAvatarInteraction',
+        'setOnAvatarToolStateChange', 'setOnComposerImportImage', 'setOnComposerRemoveAttachment',
+        'setOnComposerScreenshot', 'setOnComposerSubmit', 'setOnMessageAction',
+        'setTranslateEnabled', 'setViewProps', 'syncGoodbyeComposerHidden',
+        'triggerComposerScreenshot', 'updateMessage',
+    ],
+    appUi: [
+        'completeGoodbyeResourceSuspend', 'ensureHiddenElements', 'hideLive2d',
+        'hideVoicePreparingToast', 'initFinalUiGuards', 'initFloatingButtonListeners',
+        'restoreGoodbyeResourceSuspend', 'showCurrentModel', 'showLive2d',
+        'showProminentNotice', 'showReadyToSpeakToast', 'showStatusToast', 'showSurveyModal',
+        'showVoicePreparingToast', 'syncFloatingMicButtonState', 'syncFloatingScreenButtonState',
+    ],
+    appInterpage: [
+        'applyGoodbyeChatComposerHidden', 'applyTutorialChatIdentityOverride',
+        'applyVoiceComposerHiddenFromActive', 'cleanupLive2DOverlayUI', 'cleanupMMDOverlayUI',
+        'cleanupPNGTuberOverlayUI', 'cleanupVRMOverlayUI',
+        'consumePendingVoiceChatComposerHiddenMessage', 'handleGoodbyeChatComposerHiddenMessage',
+        'handleHideMainUI', 'handleMemoryEdited', 'handleModelReload', 'handleShowMainUI',
+        'handleVoiceChatComposerHiddenMessage', 'isMainUIHiddenByModelManager',
+        'isVoiceConfigSwitching', 'nekoBroadcastChannel', 'postGoodbyeChatComposerHiddenElectron',
+        'postGoodbyeChatComposerHiddenState', 'postIcebreakerBridgeEvent',
+        'postIcebreakerChoiceSelected', 'postIcebreakerFreeTextSubmitted',
+        'postVoiceChatComposerHiddenElectron', 'requestGoodbyeChatComposerHiddenState',
+        'resetToDefaultModel', 'shouldKeepVoiceComposerHidden', 'syncVoiceChatComposerHidden',
+        'waitForVoiceConfigSwitchReady',
+    ],
+};
 
 
 function createElement() {
@@ -46,7 +90,10 @@ function createContext(options = {}) {
         getElementById() { return null; },
         querySelector() { return null; },
         querySelectorAll() { return []; },
-        addEventListener(type, handler) { listeners.set(`document:${type}`, handler); },
+        addEventListener(type, handler) {
+            const key = `document:${type}`;
+            listeners.set(key, [...(listeners.get(key) || []), handler]);
+        },
         removeEventListener() {},
     };
     const localStorage = {
@@ -72,7 +119,9 @@ function createContext(options = {}) {
         screenX: 0,
         screenY: 0,
         console: quietConsole,
-        addEventListener(type, handler) { listeners.set(type, handler); },
+        addEventListener(type, handler) {
+            listeners.set(type, [...(listeners.get(type) || []), handler]);
+        },
         removeEventListener() {},
         dispatchEvent() { return true; },
         setTimeout() { return 1; },
@@ -118,16 +167,7 @@ function createContext(options = {}) {
         requestAnimationFrame: window.requestAnimationFrame,
         cancelAnimationFrame: window.cancelAnimationFrame,
     };
-    return { context, window };
-}
-
-
-function baselineSource(relativePath) {
-    return childProcess.execFileSync(
-        'git',
-        ['show', `origin/main:${relativePath.replaceAll('\\', '/')}`],
-        { cwd: repoRoot, encoding: 'utf8' },
-    );
+    return { context, window, listeners };
 }
 
 
@@ -156,9 +196,11 @@ function runParts(relativeDir, options) {
 }
 
 
-function checkInterpageBroadcastBindingOrder() {
-    const { context, window } = createContext();
+function checkInterpageEventBindingOrder() {
+    const { context, window, listeners } = createContext();
     const channels = [];
+    let relayedCustomEventHandler;
+    let relayedWindowMessageHandler;
     class BroadcastChannel {
         constructor(name) {
             this.name = name;
@@ -174,35 +216,51 @@ function checkInterpageBroadcastBindingOrder() {
     const paths = partPaths('static/app/app-interpage');
     for (const partPath of paths) {
         vm.runInNewContext(fs.readFileSync(partPath, 'utf8'), context, { filename: partPath });
+        if (path.basename(partPath) === 'cross-window-broadcast-and-bridge.js') {
+            relayedCustomEventHandler = window.__appInterpageParts.handleYuiGuideRelayedCustomEvent;
+            relayedWindowMessageHandler = window.__appInterpageParts.handleYuiGuideRelayedWindowMessage;
+            assert.ok(
+                !(listeners.get('neko:tutorial-overlay-relay') || []).includes(relayedCustomEventHandler),
+                'tutorial overlay relay bound before later helpers loaded',
+            );
+            assert.ok(
+                !(listeners.get('message') || []).includes(relayedWindowMessageHandler),
+                'tutorial window message relay bound before later helpers loaded',
+            );
+        }
         if (path.basename(partPath) === 'guide-message-relay.js') {
             assert.equal(channels.length, 1);
             assert.equal(channels[0].onmessage, null, 'BroadcastChannel bound before later helpers loaded');
         }
     }
     assert.equal(typeof channels[0].onmessage, 'function', 'final part did not bind BroadcastChannel');
+    assert.ok(
+        (listeners.get('neko:tutorial-overlay-relay') || []).includes(relayedCustomEventHandler),
+        'final part did not bind tutorial overlay relay',
+    );
+    assert.ok(
+        (listeners.get('message') || []).includes(relayedWindowMessageHandler),
+        'final part did not bind tutorial window message relay',
+    );
     assert.equal(window.__appInterpageParts, undefined, 'internal namespace leaked after final assembly');
-    process.stdout.write('appInterpage: BroadcastChannel binding deferred until final part\n');
+    process.stdout.write('appInterpage: cross-window event bindings deferred until final part\n');
 }
 
 
 for (const contract of [
     {
-        oldPath: 'static/app/app-' + 'react-chat-window' + '.js',
         partDir: 'static/app/app-react-chat-window',
         publicName: 'reactChatWindowHost',
     },
-    { oldPath: 'static/app/app-' + 'ui' + '.js', partDir: 'static/app/app-ui', publicName: 'appUi' },
+    { partDir: 'static/app/app-ui', publicName: 'appUi' },
     {
-        oldPath: 'static/app/app-' + 'interpage' + '.js',
         partDir: 'static/app/app-interpage',
         publicName: 'appInterpage',
     },
 ]) {
-    const baselineWindow = runSource(baselineSource(contract.oldPath), contract.oldPath);
     const partWindow = runParts(contract.partDir);
-    const baselineKeys = Object.keys(baselineWindow[contract.publicName] || {}).sort();
     const partKeys = Object.keys(partWindow[contract.publicName] || {}).sort();
-    assert.deepEqual(partKeys, baselineKeys, `${contract.publicName} key set changed`);
+    assert.deepEqual(partKeys, expectedPublicKeys[contract.publicName], `${contract.publicName} key set changed`);
     process.stdout.write(`${contract.publicName}: ${partKeys.length} keys match\n`);
 }
 
@@ -220,4 +278,4 @@ for (const scenario of [
     process.stdout.write(`${scenario.label}: React host state/render scheduling smoke passed\n`);
 }
 
-checkInterpageBroadcastBindingOrder();
+checkInterpageEventBindingOrder();

--- a/static/app/app-interpage/cross-window-broadcast-and-bridge.js
+++ b/static/app/app-interpage/cross-window-broadcast-and-bridge.js
@@ -893,7 +893,7 @@
         }
     }
 
-    I.yuiGuideInterpageResources.addEventListener(window, 'neko:tutorial-overlay-relay', function (event) {
+    I.handleYuiGuideRelayedCustomEvent = function handleYuiGuideRelayedCustomEvent(event) {
         var message = event && event.detail;
         if (
             message
@@ -903,9 +903,9 @@
             return;
         }
         handleYuiGuideRelayedMessage(message);
-    });
+    };
 
-    I.yuiGuideInterpageResources.addEventListener(window, 'message', function (event) {
+    I.handleYuiGuideRelayedWindowMessage = function handleYuiGuideRelayedWindowMessage(event) {
         var data = event && event.data;
         if (!data || data.__nekoTutorialOverlayRelay !== true) {
             return;
@@ -922,7 +922,7 @@
             return;
         }
         handleYuiGuideRelayedMessage(message);
-    });
+    };
 
     I.yuiGuideInterpageResources.addEventListener(window, 'storage', handleIcebreakerStorageBridgeEvent);
     I.yuiGuideInterpageResources.addEventListener(window, 'storage', handleYuiGuideChatBridgeStorageEvent);

--- a/static/app/app-interpage/listeners-and-api.js
+++ b/static/app/app-interpage/listeners-and-api.js
@@ -18,12 +18,22 @@
     window.appInterpage = window.appInterpage || {};
     const I = window.__appInterpageParts || (window.__appInterpageParts = {});
 
-    // The former single IIFE could not receive a BroadcastChannel event until
+    // The former single IIFE could not receive cross-window relay events until
     // all hoisted lifecycle helpers were ready. Bind only in the final part to
     // preserve that ordering across parser-blocking external scripts.
     if (I.nekoBroadcastChannel && typeof I.handleNekoBroadcastMessage === 'function') {
         I.nekoBroadcastChannel.onmessage = I.handleNekoBroadcastMessage;
     }
+    I.yuiGuideInterpageResources.addEventListener(
+        window,
+        'neko:tutorial-overlay-relay',
+        I.handleYuiGuideRelayedCustomEvent
+    );
+    I.yuiGuideInterpageResources.addEventListener(
+        window,
+        'message',
+        I.handleYuiGuideRelayedWindowMessage
+    );
 
     function cleanupAppInterpageTransientResources() {
         I.clearYuiGuideChatFlushTimer();

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -1392,6 +1392,19 @@ def test_interpage_defers_broadcast_binding_until_all_parts_are_loaded():
     assert "I.nekoBroadcastChannel.onmessage = I.handleNekoBroadcastMessage;" in final_part
 
 
+def test_interpage_defers_tutorial_relay_listeners_until_all_parts_are_loaded():
+    root = Path(__file__).resolve().parents[2] / "static" / "app" / "app-interpage"
+    bridge_part = (root / "cross-window-broadcast-and-bridge.js").read_text(encoding="utf-8")
+    final_part = (root / "listeners-and-api.js").read_text(encoding="utf-8")
+
+    assert "I.handleYuiGuideRelayedCustomEvent = function" in bridge_part
+    assert "I.handleYuiGuideRelayedWindowMessage = function" in bridge_part
+    assert bridge_part.count("I.handleYuiGuideRelayedCustomEvent") == 1
+    assert bridge_part.count("I.handleYuiGuideRelayedWindowMessage") == 1
+    assert "I.handleYuiGuideRelayedCustomEvent" in final_part
+    assert "I.handleYuiGuideRelayedWindowMessage" in final_part
+
+
 def test_new_user_icebreaker_choice_prompt_dispatches_host_event():
     react_host = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
     choice_block = react_host.split("function handleChoiceSelect(option, source)", 1)[1].split(


### PR DESCRIPTION
## Summary
- defer the tutorial overlay relay and window message listeners until the final app-interpage part, after lifecycle helpers are loaded
- extend the Node harness to prove the BroadcastChannel and both relay handlers remain unbound during partial loading and bind in the final part
- replace the post-merge-broken origin/main monolith lookup with fixed public-key snapshots from the pre-split files

## Validation
- all 18 semantic part files pass node --check
- node scripts/check_static_app_part_keys.cjs passes: 50/16/28 public keys, wide/narrow/chat-hidden scenarios, and staged interpage event binding
- targeted relay/static tests: 3 passed
- full test_react_chat_window_static.py run: 81 passed; the only failure is the known gitignored React IIFE bundle missing from a clean worktree
- no numeric part filenames and no references to the removed monolith paths
- no browser used

Follow-up to #2317 after it was merged before the final review race fix landed.