### PR TITLE
新增与 TTS 对偶的 Phase 1 实时 ASR 接口骨架

### DIFF
--- a/docs/design/asr-client-phase1.md
+++ b/docs/design/asr-client-phase1.md
@@ -1,0 +1,78 @@
+# Phase 1 ASR client
+
+Phase 1 冻结一条只负责“实时 PCM 输入、整轮文本输出”的公共链路：
+
+```text
+玩家麦克风 PCM
+  -> RealtimeAsrSession
+  -> Core 对应的 ASR worker
+  -> final 文本
+  -> on_input_transcript(text)
+```
+
+实现按现有 `tts_client` 的职责分层组织为公共入口、公共基础层、唯一注册表和 workers。ASR 本身使用 asyncio 长连接；一次 `commit` 只结束当前 utterance，不关闭 Session。
+
+## 公共接口
+
+`main_logic.asr_client` 只稳定导出：
+
+- `AsrSessionConfig`
+- `RealtimeAsrSession`
+- `create_asr_session`
+
+worker 解析器是包内实现。调用方不得直接实例化 provider worker，也不得依赖内部 command/event 类型。
+
+```python
+from main_logic.asr_client import AsrSessionConfig, create_asr_session
+
+
+async def on_transcript(text: str) -> None:
+    print(text)
+
+
+async def on_error(message: str) -> None:
+    print(message)
+
+
+session = create_asr_session(
+    core_type="qwen",
+    config=AsrSessionConfig(
+        language="zh-CN",
+        input_sample_rate_hz=48_000,
+        endpointing_mode="manual",
+    ),
+    on_input_transcript=on_transcript,
+    on_connection_error=on_error,
+)
+
+await session.connect()
+await session.stream_audio(pcm16le_chunk, sample_rate_hz=48_000)
+await session.signal_user_activity_end()
+await session.close()
+```
+
+Phase 1 联调前需要在进程环境中显式设置：
+
+```text
+ASR_PROVIDER=dummy
+```
+
+dummy 不进入持久化 Core 配置和设置 UI，也不会成为未实现 Core 的自动 fallback。
+
+## 已冻结的行为
+
+- 生产 ASR 跟随 `core_type` 路由；一个 Session 只使用一个 worker，不跨供应商 fallback。
+- 默认 `endpointing_mode="manual"`。该模式下 `signal_user_activity_end()` 发送 `commit`；`provider` 模式下该方法为 no-op，由供应商 VAD 断句。
+- 公共输入固定为单声道 PCM16LE，支持 16 kHz 和 48 kHz。公共层将 48 kHz 流式转换为 16 kHz；一个 Session 首包锁定输入采样率。
+- 空音频块是 no-op；非空音频必须为偶数字节，单块最多一秒。
+- 只有首个有效、非空 `final` 调用 `on_input_transcript()`。`partial`、重复 final、冲突 final 以及 clear/close 后到达的旧 final 都不进入业务回调。
+- 内部事件用 `generation + buffer_epoch + utterance_id` 关联，不能按 transcript 文本去重。
+- callback 串行执行；业务 callback 失败不破坏 provider receive loop。
+- worker `error` 终止当前 Session，只报告一次连接错误，不自动重连。恢复时由调用方创建新 Session。
+- `close()` 幂等；可预知的未知 Core、未实现 backend、blocked backend 和配置错误在 `create_asr_session()` 阶段同步失败。
+
+## Phase 1 边界
+
+本阶段只提供 `asr_client` 公共骨架、唯一路由表和 dummy worker，不接入真实 ASR 供应商，不修改小游戏、`game_router`、`websocket_router.py`、现有 `streaming.py`、`OmniRealtimeClient`、普通语音链路或生产开关。
+
+本阶段也不实现 Smart Turn、VAD、RNNoise、声纹、节流、LLM 回复、TTS、工具调用、上下文事件或独立 ASR 云服务。后续真实服务通过新增 worker 实现相同的 request/response 合同，不改变上述公共调用方式。

--- a/docs/design/asr-client-phase1.md
+++ b/docs/design/asr-client-phase1.md
@@ -62,7 +62,7 @@ dummy 不进入持久化 Core 配置和设置 UI，也不会成为未实现 Core
 ## 已冻结的行为
 
 - 生产 ASR 跟随 `core_type` 路由；一个 Session 只使用一个 worker，不跨供应商 fallback。
-- 默认 `endpointing_mode="manual"`。该模式下 `signal_user_activity_end()` 发送 `commit`；`provider` 模式下该方法为 no-op，由供应商 VAD 断句。
+- 默认 `endpointing_mode="manual"`。该模式下 `signal_user_activity_end()` 发送 `commit`；`provider` 模式下不发送 `commit`，只刷新本地 48 kHz 流式重采样器的尾部音频，最终断句仍由供应商 VAD 决定。
 - 公共输入固定为单声道 PCM16LE，支持 16 kHz 和 48 kHz。公共层将 48 kHz 流式转换为 16 kHz；一个 Session 首包锁定输入采样率。
 - 空音频块是 no-op；非空音频必须为偶数字节，单块最多一秒。
 - 只有首个有效、非空 `final` 调用 `on_input_transcript()`。`partial`、重复 final、冲突 final 以及 clear/close 后到达的旧 final 都不进入业务回调。

--- a/main_logic/asr_client/__init__.py
+++ b/main_logic/asr_client/__init__.py
@@ -1,0 +1,109 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Stable public entry point for realtime speech recognition sessions."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Awaitable, Callable
+
+from ._infra import (
+    AsrSessionConfig,
+    RealtimeAsrSession,
+    AsrWorkerFn as _AsrWorkerFn,
+    _RealtimeAsrSessionImpl,
+)
+from ._registry_meta import (
+    ASR_PROVIDER_REGISTRY as _ASR_PROVIDER_REGISTRY,
+    CORE_ASR_ROUTES as _CORE_ASR_ROUTES,
+)
+from .workers.dummy import dummy_asr_worker as _dummy_asr_worker
+
+
+__all__ = [
+    "AsrSessionConfig",
+    "RealtimeAsrSession",
+    "create_asr_session",
+]
+
+
+_IMPLEMENTED_WORKERS: dict[str, _AsrWorkerFn] = {
+    "dummy": _dummy_asr_worker,
+}
+
+
+def _get_asr_worker(core_type: str) -> tuple[_AsrWorkerFn, str | None, str]:
+    """Resolve one worker without exposing provider internals to callers."""
+
+    core_key = str(core_type or "").strip().lower()
+    provider_key = _CORE_ASR_ROUTES.get(core_key)
+    if provider_key is None:
+        raise RuntimeError(f"ASR_UNKNOWN_CORE: {core_key or '<empty>'}")
+
+    provider_override = os.getenv("ASR_PROVIDER", "").strip().lower()
+    if provider_override:
+        if provider_override != "dummy":
+            raise RuntimeError(
+                "ASR_INVALID_CONFIG: ASR_PROVIDER only supports the development "
+                "value 'dummy' in Phase 1"
+            )
+        provider_key = "dummy"
+
+    meta = _ASR_PROVIDER_REGISTRY[provider_key]
+    if meta.implementation_status == "blocked_backend":
+        raise RuntimeError(f"ASR_BACKEND_BLOCKED: {core_key}")
+    if meta.implementation_status == "blocked_credentials":
+        raise RuntimeError(f"ASR_CREDENTIALS_MISSING: {provider_key}")
+    if meta.implementation_status != "implemented":
+        raise RuntimeError(f"ASR_BACKEND_NOT_IMPLEMENTED: {core_key}")
+
+    worker_fn = _IMPLEMENTED_WORKERS.get(provider_key)
+    if worker_fn is None:
+        raise RuntimeError(f"ASR_BACKEND_NOT_IMPLEMENTED: {core_key}")
+
+    # Dummy deliberately receives an empty key. Real workers added in later
+    # phases must resolve their own provider-specific credentials here rather
+    # than borrowing another provider's key as a fallback.
+    return worker_fn, "", provider_key
+
+
+def create_asr_session(
+    core_type: str,
+    *,
+    config: AsrSessionConfig | None = None,
+    on_input_transcript: Callable[[str], Awaitable[None]],
+    on_connection_error: Callable[[str], Awaitable[None]],
+    on_status_message: Callable[[str], Awaitable[None]] | None = None,
+) -> RealtimeAsrSession:
+    """Create an isolated ASR session or fail fast for unsupported routes."""
+
+    if config is not None and not isinstance(config, AsrSessionConfig):
+        raise TypeError("ASR_INVALID_CONFIG: config must be AsrSessionConfig")
+    session_config = config if config is not None else AsrSessionConfig()
+    worker_fn, api_key_override, provider_key = _get_asr_worker(core_type)
+
+    if provider_key == "dummy" and session_config.endpointing_mode != "manual":
+        raise RuntimeError(
+            "ASR_INVALID_CONFIG: dummy requires endpointing_mode='manual'"
+        )
+
+    return _RealtimeAsrSessionImpl(
+        worker_fn=worker_fn,
+        api_key=api_key_override or "",
+        config=session_config,
+        on_input_transcript=on_input_transcript,
+        on_connection_error=on_connection_error,
+        on_status_message=on_status_message,
+    )

--- a/main_logic/asr_client/_infra.py
+++ b/main_logic/asr_client/_infra.py
@@ -1,0 +1,762 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared contracts and lifecycle machinery for realtime ASR workers."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass, replace
+from enum import Enum
+from typing import Any, Literal, Protocol, TypeAlias, runtime_checkable
+
+import numpy as np
+import soxr
+
+
+logger = logging.getLogger(__name__)
+
+_READY_TIMEOUT_SECONDS = 10.0
+_CALLBACK_DRAIN_TIMEOUT_SECONDS = 5.0
+_WORKER_CLOSE_TIMEOUT_SECONDS = 5.0
+_REQUEST_QUEUE_SIZE = 64
+_RESPONSE_QUEUE_SIZE = 128
+_CALLBACK_QUEUE_SIZE = 64
+
+_LANGUAGE_RE = re.compile(r"^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$")
+_OMNI_ONLY_FIELDS = frozenset(
+    {
+        "audio",
+        "beta_fields",
+        "enable_search",
+        "input_audio_format",
+        "input_audio_noise_reduction",
+        "input_audio_transcription",
+        "instructions",
+        "language_code",
+        "modalities",
+        "model",
+        "output_audio_format",
+        "output_modalities",
+        "repetition_penalty",
+        "session",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "turn_detection",
+        "type",
+        "voice",
+    }
+)
+
+_RequestKind: TypeAlias = Literal["audio", "commit", "clear", "shutdown"]
+_EventKind: TypeAlias = Literal["ready", "partial", "final", "error", "closed"]
+
+
+@dataclass(frozen=True, slots=True)
+class AsrSessionConfig:
+    """Provider-neutral ASR settings frozen when the worker connects."""
+
+    language: str = "zh"
+    input_sample_rate_hz: Literal[16000, 48000] = 16000
+    endpointing_mode: Literal["provider", "manual"] = "manual"
+
+    def __post_init__(self) -> None:
+        language = str(self.language).strip()
+        if language.lower() == "auto":
+            normalized_language = "auto"
+        elif not _LANGUAGE_RE.fullmatch(language):
+            raise ValueError("ASR_INVALID_CONFIG: invalid language")
+        else:
+            parts = language.split("-")
+            normalized_parts = [parts[0].lower()]
+            for part in parts[1:]:
+                if len(part) == 2 and part.isalpha():
+                    normalized_parts.append(part.upper())
+                elif len(part) == 4 and part.isalpha():
+                    normalized_parts.append(part.title())
+                else:
+                    normalized_parts.append(part)
+            normalized_language = "-".join(normalized_parts)
+
+        if self.input_sample_rate_hz not in (16000, 48000):
+            raise ValueError(
+                "ASR_INVALID_CONFIG: input_sample_rate_hz must be 16000 or 48000"
+            )
+        if self.endpointing_mode not in ("provider", "manual"):
+            raise ValueError(
+                "ASR_INVALID_CONFIG: endpointing_mode must be 'provider' or 'manual'"
+            )
+        object.__setattr__(self, "language", normalized_language)
+
+
+@runtime_checkable
+class RealtimeAsrSession(Protocol):
+    """Stable session surface used by audio-producing callers."""
+
+    @property
+    def is_ready(self) -> bool: ...
+
+    async def connect(
+        self,
+        instructions: str = "",
+        native_audio: bool = False,
+    ) -> None: ...
+
+    async def update_session(self, config: Mapping[str, Any]) -> None: ...
+
+    async def stream_audio(
+        self,
+        audio_chunk: bytes,
+        *,
+        sample_rate_hz: int | None = None,
+    ) -> None: ...
+
+    async def signal_user_activity_end(self) -> None: ...
+
+    async def clear_audio_buffer(self) -> None: ...
+
+    async def close(self) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class _AsrWorkerRequest:
+    """One normalized command sent from a session to its selected worker."""
+
+    kind: _RequestKind
+    generation: int
+    buffer_epoch: int = 0
+    utterance_id: int | None = None
+    audio: bytes = b""
+
+
+@dataclass(frozen=True, slots=True)
+class _AsrWorkerEvent:
+    """One provider-neutral event returned by an ASR worker."""
+
+    kind: _EventKind
+    generation: int
+    buffer_epoch: int = 0
+    utterance_id: int | None = None
+    text: str = ""
+    error_code: str = ""
+    error_message: str = ""
+
+
+AsrWorkerFn: TypeAlias = Callable[
+    [
+        asyncio.Queue[_AsrWorkerRequest],
+        asyncio.Queue[_AsrWorkerEvent],
+        str,
+        AsrSessionConfig,
+    ],
+    Awaitable[None],
+]
+
+
+class _SessionState(Enum):
+    NEW = "new"
+    CONNECTING = "connecting"
+    READY = "ready"
+    CLOSING = "closing"
+    CLOSED = "closed"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True, slots=True)
+class _CallbackItem:
+    text: str
+
+
+class _RealtimeAsrSessionImpl:
+    """Default asyncio session implementation shared by all ASR workers."""
+
+    def __init__(
+        self,
+        *,
+        worker_fn: AsrWorkerFn,
+        api_key: str,
+        config: AsrSessionConfig,
+        on_input_transcript: Callable[[str], Awaitable[None]],
+        on_connection_error: Callable[[str], Awaitable[None]],
+        on_status_message: Callable[[str], Awaitable[None]] | None = None,
+    ) -> None:
+        if not isinstance(config, AsrSessionConfig):
+            raise TypeError("ASR_INVALID_CONFIG: config must be AsrSessionConfig")
+        if not callable(worker_fn):
+            raise TypeError("ASR_INVALID_CONFIG: worker_fn must be callable")
+        if not callable(on_input_transcript) or not callable(on_connection_error):
+            raise TypeError("ASR_INVALID_CONFIG: callbacks must be callable")
+        if on_status_message is not None and not callable(on_status_message):
+            raise TypeError("ASR_INVALID_CONFIG: status callback must be callable")
+
+        self._worker_fn = worker_fn
+        self._api_key = api_key
+        self._config = config
+        self._on_input_transcript = on_input_transcript
+        self._on_connection_error = on_connection_error
+        self._on_status_message = on_status_message
+
+        self._state = _SessionState.NEW
+        self._generation = 0
+        self._buffer_epoch = 0
+        self._utterance_id = 1
+        self._utterance_has_audio = False
+        self._input_sample_rate_hz: int | None = None
+        self._resampler: soxr.ResampleStream | None = None
+        self._final_keys: set[tuple[int, int, int]] = set()
+
+        self._request_queue: asyncio.Queue[_AsrWorkerRequest] | None = None
+        self._response_queue: asyncio.Queue[_AsrWorkerEvent] | None = None
+        self._callback_queue: asyncio.Queue[_CallbackItem] | None = None
+        self._worker_task: asyncio.Task[None] | None = None
+        self._response_task: asyncio.Task[None] | None = None
+        self._callback_task: asyncio.Task[None] | None = None
+        self._close_task: asyncio.Task[None] | None = None
+        self._ready_future: asyncio.Future[None] | None = None
+
+        self._operation_lock = asyncio.Lock()
+        self._connect_lock = asyncio.Lock()
+        self._closing_event = asyncio.Event()
+        self._connection_error_reported = False
+
+    @property
+    def is_ready(self) -> bool:
+        return self._state is _SessionState.READY
+
+    async def connect(
+        self,
+        instructions: str = "",
+        native_audio: bool = False,
+    ) -> None:
+        # Compatibility-only Omni arguments deliberately never reach a worker.
+        _ = (instructions, native_audio)
+        async with self._connect_lock:
+            if self._state is _SessionState.READY:
+                return
+            if self._state is not _SessionState.NEW:
+                raise RuntimeError(
+                    f"ASR_SESSION_NOT_READY: cannot connect a {self._state.value} session"
+                )
+
+            self._state = _SessionState.CONNECTING
+            self._request_queue = asyncio.Queue(maxsize=_REQUEST_QUEUE_SIZE)
+            self._response_queue = asyncio.Queue(maxsize=_RESPONSE_QUEUE_SIZE)
+            self._callback_queue = asyncio.Queue(maxsize=_CALLBACK_QUEUE_SIZE)
+            self._ready_future = asyncio.get_running_loop().create_future()
+            self._callback_task = asyncio.create_task(
+                self._dispatch_callbacks(), name="asr-callback-dispatch"
+            )
+            self._response_task = asyncio.create_task(
+                self._consume_responses(), name="asr-response-consumer"
+            )
+            self._worker_task = asyncio.create_task(
+                self._run_worker(), name="asr-worker"
+            )
+
+            await self._emit_status("ASR_CONNECTING")
+            try:
+                await asyncio.wait_for(
+                    asyncio.shield(self._ready_future),
+                    timeout=_READY_TIMEOUT_SECONDS,
+                )
+            except asyncio.TimeoutError as exc:
+                if self._ready_future is not None and not self._ready_future.done():
+                    self._ready_future.cancel()
+                await self._fail(
+                    "ASR_CONNECT_TIMEOUT",
+                    "worker did not become ready within 10 seconds",
+                )
+                raise RuntimeError(
+                    "ASR_CONNECT_TIMEOUT: worker did not become ready within 10 seconds"
+                ) from exc
+            except Exception:
+                if self._state in (_SessionState.CLOSING, _SessionState.CLOSED):
+                    raise
+                if self._state is not _SessionState.FAILED:
+                    await self._fail("ASR_WORKER_FAILED", "worker failed during connect")
+                raise
+
+            worker_task = self._worker_task
+            if self._state is not _SessionState.READY or worker_task is None:
+                raise RuntimeError("ASR_WORKER_FAILED: worker exited during connect")
+            if worker_task.done():
+                await self._fail(
+                    "ASR_WORKER_FAILED",
+                    "worker exited immediately after becoming ready",
+                )
+                raise RuntimeError("ASR_WORKER_FAILED: worker exited during connect")
+
+    async def update_session(self, config: Mapping[str, Any]) -> None:
+        if not isinstance(config, Mapping):
+            raise TypeError("ASR_INVALID_CONFIG: session update must be a mapping")
+
+        unknown_fields = set(config) - {
+            "language",
+            "input_sample_rate_hz",
+            "endpointing_mode",
+        } - _OMNI_ONLY_FIELDS
+        if unknown_fields:
+            names = ", ".join(sorted(map(str, unknown_fields)))
+            raise ValueError(f"ASR_INVALID_CONFIG: unknown session field(s): {names}")
+
+        updates = {
+            key: config[key]
+            for key in ("language", "input_sample_rate_hz", "endpointing_mode")
+            if key in config
+        }
+        if not updates:
+            return
+        if self._state is not _SessionState.NEW:
+            raise RuntimeError("ASR_SESSION_CONFIG_LOCKED: session is already connecting")
+        self._config = replace(self._config, **updates)
+
+    async def stream_audio(
+        self,
+        audio_chunk: bytes,
+        *,
+        sample_rate_hz: int | None = None,
+    ) -> None:
+        if not isinstance(audio_chunk, bytes):
+            raise TypeError("ASR_INVALID_PCM: audio_chunk must be bytes")
+        if not audio_chunk:
+            return
+
+        async with self._operation_lock:
+            if self._state is not _SessionState.READY:
+                raise RuntimeError("ASR_SESSION_NOT_READY: session is not ready")
+            if len(audio_chunk) % 2:
+                raise ValueError("ASR_INVALID_PCM: PCM16LE data has an odd byte length")
+
+            effective_rate = (
+                sample_rate_hz
+                if sample_rate_hz is not None
+                else self._config.input_sample_rate_hz
+            )
+            if effective_rate not in (16000, 48000):
+                raise ValueError("ASR_INVALID_CONFIG: sample rate must be 16000 or 48000")
+            if len(audio_chunk) > effective_rate * 2:
+                raise ValueError(
+                    "ASR_AUDIO_CHUNK_TOO_LARGE: one chunk may contain at most one second"
+                )
+            if self._input_sample_rate_hz is None:
+                self._input_sample_rate_hz = effective_rate
+                self._resampler = self._make_resampler()
+            elif effective_rate != self._input_sample_rate_hz:
+                raise ValueError(
+                    "ASR_SAMPLE_RATE_CHANGED: a session cannot mix input sample rates"
+                )
+
+            normalized_audio = self._convert_audio(audio_chunk)
+            if normalized_audio:
+                await self._enqueue_request(
+                    _AsrWorkerRequest(
+                        kind="audio",
+                        generation=self._generation,
+                        buffer_epoch=self._buffer_epoch,
+                        utterance_id=self._utterance_id,
+                        audio=normalized_audio,
+                    )
+                )
+            # Even if soxr is still buffering, valid input belongs to this turn.
+            self._utterance_has_audio = True
+
+    async def signal_user_activity_end(self) -> None:
+        async with self._operation_lock:
+            if self._state is not _SessionState.READY:
+                raise RuntimeError("ASR_SESSION_NOT_READY: session is not ready")
+            if self._config.endpointing_mode == "provider":
+                return
+            if not self._utterance_has_audio:
+                return
+
+            tail = self._flush_resampler()
+            if tail:
+                await self._enqueue_request(
+                    _AsrWorkerRequest(
+                        kind="audio",
+                        generation=self._generation,
+                        buffer_epoch=self._buffer_epoch,
+                        utterance_id=self._utterance_id,
+                        audio=tail,
+                    )
+                )
+            await self._enqueue_request(
+                _AsrWorkerRequest(
+                    kind="commit",
+                    generation=self._generation,
+                    buffer_epoch=self._buffer_epoch,
+                    utterance_id=self._utterance_id,
+                )
+            )
+            self._utterance_id += 1
+            self._utterance_has_audio = False
+            self._reset_resampler()
+
+    async def clear_audio_buffer(self) -> None:
+        async with self._operation_lock:
+            if self._state is not _SessionState.READY:
+                raise RuntimeError("ASR_SESSION_NOT_READY: session is not ready")
+            self._buffer_epoch += 1
+            self._utterance_id += 1
+            self._utterance_has_audio = False
+            self._reset_resampler()
+            await self._enqueue_request(
+                _AsrWorkerRequest(
+                    kind="clear",
+                    generation=self._generation,
+                    buffer_epoch=self._buffer_epoch,
+                    utterance_id=self._utterance_id,
+                )
+            )
+
+    async def close(self) -> None:
+        if self._state is _SessionState.CLOSED:
+            return
+
+        close_task = self._close_task
+        if close_task is None:
+            # The state transition is synchronous so cancellation cannot leave
+            # a READY session with a permanently-set closing event. Shielding
+            # lets cleanup continue if the caller cancels its own wait.
+            self._closing_event.set()
+            self._state = _SessionState.CLOSING
+            self._generation += 1
+            if self._ready_future is not None and not self._ready_future.done():
+                self._ready_future.set_exception(
+                    RuntimeError("ASR_SESSION_NOT_READY: session was closed")
+                )
+            close_task = asyncio.create_task(
+                self._close_impl(), name="asr-session-close"
+            )
+            self._close_task = close_task
+
+        await asyncio.shield(close_task)
+
+    async def _close_impl(self) -> None:
+        async with self._operation_lock:
+            self._utterance_has_audio = False
+            self._reset_resampler()
+
+            if self._request_queue is not None:
+                request = _AsrWorkerRequest(
+                    kind="shutdown",
+                    generation=self._generation,
+                    buffer_epoch=self._buffer_epoch,
+                    utterance_id=self._utterance_id,
+                )
+                try:
+                    await asyncio.wait_for(
+                        self._request_queue.put(request),
+                        timeout=_WORKER_CLOSE_TIMEOUT_SECONDS,
+                    )
+                except asyncio.TimeoutError:
+                    logger.warning("ASR shutdown command timed out")
+
+            if self._worker_task is not None and not self._worker_task.done():
+                try:
+                    await asyncio.wait_for(
+                        asyncio.shield(self._worker_task),
+                        timeout=_WORKER_CLOSE_TIMEOUT_SECONDS,
+                    )
+                except (asyncio.TimeoutError, asyncio.CancelledError):
+                    self._worker_task.cancel()
+
+            if self._callback_queue is not None:
+                try:
+                    await asyncio.wait_for(
+                        self._callback_queue.join(),
+                        timeout=_CALLBACK_DRAIN_TIMEOUT_SECONDS,
+                    )
+                except asyncio.TimeoutError:
+                    logger.warning("ASR callback drain timed out")
+
+            await self._shutdown()
+            self._state = _SessionState.CLOSED
+            await self._emit_status("ASR_CLOSED")
+
+    async def _run_worker(self) -> None:
+        assert self._request_queue is not None
+        assert self._response_queue is not None
+        try:
+            await self._worker_fn(
+                self._request_queue,
+                self._response_queue,
+                self._api_key,
+                self._config,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            await self._response_queue.put(
+                _AsrWorkerEvent(
+                    kind="error",
+                    generation=self._generation,
+                    buffer_epoch=self._buffer_epoch,
+                    utterance_id=self._utterance_id,
+                    error_code="ASR_WORKER_FAILED",
+                    error_message="worker raised an unexpected exception",
+                )
+            )
+        else:
+            # Workers normally emit ``closed`` themselves. This synthetic
+            # event makes an accidental bare return terminal as well; a
+            # duplicate closed event during shutdown is harmless.
+            await self._response_queue.put(
+                _AsrWorkerEvent(kind="closed", generation=self._generation)
+            )
+
+    async def _consume_responses(self) -> None:
+        assert self._response_queue is not None
+        while True:
+            event = await self._response_queue.get()
+            try:
+                should_stop = await self._handle_event(event)
+            finally:
+                self._response_queue.task_done()
+            if should_stop:
+                return
+
+    async def _dispatch_callbacks(self) -> None:
+        assert self._callback_queue is not None
+        while True:
+            item = await self._callback_queue.get()
+            try:
+                await self._on_input_transcript(item.text)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("ASR transcript callback failed")
+            finally:
+                self._callback_queue.task_done()
+
+    async def _handle_event(self, event: _AsrWorkerEvent) -> bool:
+        if not isinstance(event, _AsrWorkerEvent):
+            await self._fail("ASR_WORKER_FAILED", "worker returned an invalid event")
+            return True
+
+        if event.kind == "ready":
+            if (
+                self._state is not _SessionState.CONNECTING
+                or event.generation != self._generation
+            ):
+                return False
+            self._state = _SessionState.READY
+            if self._ready_future is not None and not self._ready_future.done():
+                self._ready_future.set_result(None)
+            await self._emit_status("ASR_READY")
+            return False
+
+        if event.generation != self._generation:
+            return False
+        if event.kind == "partial":
+            return False
+        if event.kind == "final":
+            if (
+                event.buffer_epoch != self._buffer_epoch
+                or event.utterance_id is None
+            ):
+                return False
+            text = event.text.strip()
+            if not text:
+                return False
+            key = (event.generation, event.buffer_epoch, event.utterance_id)
+            if key in self._final_keys:
+                logger.warning("ASR worker returned a duplicate or conflicting final")
+                return False
+            self._final_keys.add(key)
+            assert self._callback_queue is not None
+            await self._callback_queue.put(_CallbackItem(text=text))
+            if (
+                self._config.endpointing_mode == "provider"
+                and event.utterance_id == self._utterance_id
+            ):
+                self._utterance_id += 1
+                self._utterance_has_audio = False
+                self._reset_resampler()
+            return False
+        if event.kind == "error":
+            if (
+                event.utterance_id is not None
+                and event.buffer_epoch != self._buffer_epoch
+            ):
+                return False
+            await self._fail(
+                event.error_code or "ASR_WORKER_FAILED",
+                event.error_message or "worker reported a provider error",
+            )
+            return True
+        if event.kind == "closed":
+            if self._state is _SessionState.CLOSING:
+                return True
+            await self._fail("ASR_WORKER_FAILED", "worker closed unexpectedly")
+            return True
+
+        await self._fail("ASR_WORKER_FAILED", "worker returned an unknown event")
+        return True
+
+    async def _fail(self, error_code: str, message: str) -> None:
+        if self._state in (_SessionState.FAILED, _SessionState.CLOSED):
+            return
+        self._state = _SessionState.FAILED
+        self._generation += 1
+        self._closing_event.set()
+        safe_code = (
+            error_code
+            if re.fullmatch(r"ASR_[A-Z0-9_]+", error_code or "")
+            else "ASR_WORKER_FAILED"
+        )
+        safe_message = self._sanitize_error(message)
+        error = f"{safe_code}: {safe_message}"
+        if self._ready_future is not None and not self._ready_future.done():
+            self._ready_future.set_exception(RuntimeError(error))
+        if self._worker_task is not None and self._worker_task is not asyncio.current_task():
+            self._worker_task.cancel()
+        try:
+            await self._emit_connection_error_once(error)
+        finally:
+            if self._callback_queue is not None:
+                try:
+                    await asyncio.wait_for(
+                        self._callback_queue.join(),
+                        timeout=_CALLBACK_DRAIN_TIMEOUT_SECONDS,
+                    )
+                except asyncio.TimeoutError:
+                    logger.warning("ASR callback drain timed out after failure")
+            await self._shutdown()
+
+    async def _enqueue_request(self, request: _AsrWorkerRequest) -> None:
+        worker_task = self._worker_task
+        if (
+            self._state is not _SessionState.READY
+            or self._request_queue is None
+            or self._closing_event.is_set()
+            or worker_task is None
+            or worker_task.done()
+        ):
+            raise RuntimeError("ASR_SESSION_NOT_READY: session is not ready")
+        put_task = asyncio.create_task(self._request_queue.put(request))
+        closing_task = asyncio.create_task(self._closing_event.wait())
+        watched: set[asyncio.Task[Any]] = {put_task, closing_task, worker_task}
+        done, _ = await asyncio.wait(watched, return_when=asyncio.FIRST_COMPLETED)
+        if put_task in done and worker_task not in done and closing_task not in done:
+            closing_task.cancel()
+            await asyncio.gather(closing_task, return_exceptions=True)
+            await put_task
+            return
+        put_task.cancel()
+        closing_task.cancel()
+        await asyncio.gather(put_task, closing_task, return_exceptions=True)
+        raise RuntimeError("ASR_SESSION_NOT_READY: worker is no longer running")
+
+    def _make_resampler(self) -> soxr.ResampleStream | None:
+        if self._input_sample_rate_hz != 48000:
+            return None
+        return soxr.ResampleStream(
+            48000,
+            16000,
+            1,
+            dtype="float32",
+            quality="HQ",
+        )
+
+    def _convert_audio(self, audio_chunk: bytes) -> bytes:
+        if self._resampler is None:
+            return audio_chunk
+        samples = np.frombuffer(audio_chunk, dtype="<i2").astype(np.float32)
+        samples /= 32768.0
+        output = self._resampler.resample_chunk(samples)
+        if len(output) == 0:
+            return b""
+        return (
+            (output * 32768.0)
+            .clip(-32768, 32767)
+            .astype("<i2")
+            .tobytes()
+        )
+
+    def _flush_resampler(self) -> bytes:
+        if self._resampler is None:
+            return b""
+        output = self._resampler.resample_chunk(
+            np.empty(0, dtype=np.float32),
+            last=True,
+        )
+        if len(output) == 0:
+            return b""
+        return (
+            (output * 32768.0)
+            .clip(-32768, 32767)
+            .astype("<i2")
+            .tobytes()
+        )
+
+    def _reset_resampler(self) -> None:
+        if self._resampler is not None:
+            self._resampler.clear()
+        self._resampler = self._make_resampler()
+
+    async def _emit_status(self, status: str) -> None:
+        if self._on_status_message is None:
+            return
+        try:
+            await self._on_status_message(status)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("ASR status callback failed")
+
+    async def _emit_connection_error_once(self, error: str) -> None:
+        if self._connection_error_reported:
+            return
+        self._connection_error_reported = True
+        try:
+            await self._on_connection_error(error)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("ASR connection error callback failed")
+
+    async def _shutdown(self) -> None:
+        current = asyncio.current_task()
+        tasks = [
+            task
+            for task in (
+                self._worker_task,
+                self._response_task,
+                self._callback_task,
+            )
+            if task is not None and task is not current and not task.done()
+        ]
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    def _validate_language(self, language: str) -> str:
+        # Kept as a private seam for future worker-specific language mapping.
+        return AsrSessionConfig(language=language).language
+
+    def _sanitize_error(self, message: str) -> str:
+        safe = str(message or "worker failed")
+        if self._api_key:
+            safe = safe.replace(self._api_key, "[REDACTED]")
+        safe = re.sub(r"(?i)bearer\s+[A-Za-z0-9._~+/-]+=*", "Bearer [REDACTED]", safe)
+        safe = re.sub(r"([?&](?:api_?key|token|key)=)[^&\s]+", r"\1[REDACTED]", safe)
+        safe = re.sub(r"https?://[^\s?#]+[?][^\s]+", "[REDACTED_URL]", safe)
+        safe = " ".join(safe.split())
+        return safe[:300] or "worker failed"

--- a/main_logic/asr_client/_infra.py
+++ b/main_logic/asr_client/_infra.py
@@ -65,6 +65,7 @@ _OMNI_ONLY_FIELDS = frozenset(
 
 _RequestKind: TypeAlias = Literal["audio", "commit", "clear", "shutdown"]
 _EventKind: TypeAlias = Literal["ready", "partial", "final", "error", "closed"]
+_UtteranceKey: TypeAlias = tuple[int, int, int]
 
 
 @dataclass(frozen=True, slots=True)
@@ -218,7 +219,9 @@ class _RealtimeAsrSessionImpl:
         self._utterance_has_audio = False
         self._input_sample_rate_hz: int | None = None
         self._resampler: soxr.ResampleStream | None = None
-        self._final_keys: set[tuple[int, int, int]] = set()
+        self._active_utterance_keys: set[_UtteranceKey] = set()
+        self._committed_utterance_keys: set[_UtteranceKey] = set()
+        self._final_keys: set[_UtteranceKey] = set()
 
         self._request_queue: asyncio.Queue[_AsrWorkerRequest] | None = None
         self._response_queue: asyncio.Queue[_AsrWorkerEvent] | None = None
@@ -226,12 +229,14 @@ class _RealtimeAsrSessionImpl:
         self._worker_task: asyncio.Task[None] | None = None
         self._response_task: asyncio.Task[None] | None = None
         self._callback_task: asyncio.Task[None] | None = None
+        self._callback_close_waiter: asyncio.Task[Any] | None = None
         self._close_task: asyncio.Task[None] | None = None
         self._ready_future: asyncio.Future[None] | None = None
 
         self._operation_lock = asyncio.Lock()
         self._connect_lock = asyncio.Lock()
         self._closing_event = asyncio.Event()
+        self._callback_close_event = asyncio.Event()
         self._connection_error_reported = False
 
     @property
@@ -414,6 +419,9 @@ class _RealtimeAsrSessionImpl:
             self._buffer_epoch += 1
             self._utterance_id += 1
             self._utterance_has_audio = False
+            self._active_utterance_keys.clear()
+            self._committed_utterance_keys.clear()
+            self._final_keys.clear()
             self._reset_resampler()
             await self._enqueue_request(
                 _AsrWorkerRequest(
@@ -425,6 +433,11 @@ class _RealtimeAsrSessionImpl:
             )
 
     async def close(self) -> None:
+        current = asyncio.current_task()
+        if current is self._callback_task:
+            self._callback_close_waiter = current
+            self._callback_close_event.set()
+
         if self._state is _SessionState.CLOSED:
             return
 
@@ -450,6 +463,9 @@ class _RealtimeAsrSessionImpl:
     async def _close_impl(self) -> None:
         async with self._operation_lock:
             self._utterance_has_audio = False
+            self._active_utterance_keys.clear()
+            self._committed_utterance_keys.clear()
+            self._final_keys.clear()
             self._reset_resampler()
 
             if self._request_queue is not None:
@@ -477,13 +493,21 @@ class _RealtimeAsrSessionImpl:
                     self._worker_task.cancel()
 
             if self._callback_queue is not None:
-                try:
-                    await asyncio.wait_for(
-                        self._callback_queue.join(),
-                        timeout=_CALLBACK_DRAIN_TIMEOUT_SECONDS,
-                    )
-                except asyncio.TimeoutError:
+                drain_task = asyncio.create_task(self._callback_queue.join())
+                callback_close_task = asyncio.create_task(
+                    self._callback_close_event.wait()
+                )
+                done, pending = await asyncio.wait(
+                    {drain_task, callback_close_task},
+                    timeout=_CALLBACK_DRAIN_TIMEOUT_SECONDS,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if not done:
                     logger.warning("ASR callback drain timed out")
+                for task in pending:
+                    task.cancel()
+                if pending:
+                    await asyncio.gather(*pending, return_exceptions=True)
 
             await self._shutdown()
             self._state = _SessionState.CLOSED
@@ -502,6 +526,12 @@ class _RealtimeAsrSessionImpl:
         except asyncio.CancelledError:
             raise
         except Exception:
+            if self._state in (
+                _SessionState.CLOSING,
+                _SessionState.CLOSED,
+                _SessionState.FAILED,
+            ):
+                return
             await self._response_queue.put(
                 _AsrWorkerEvent(
                     kind="error",
@@ -543,6 +573,8 @@ class _RealtimeAsrSessionImpl:
                 logger.exception("ASR transcript callback failed")
             finally:
                 self._callback_queue.task_done()
+            if self._state is _SessionState.CLOSED:
+                return
 
     async def _handle_event(self, event: _AsrWorkerEvent) -> bool:
         if not isinstance(event, _AsrWorkerEvent):
@@ -566,28 +598,46 @@ class _RealtimeAsrSessionImpl:
         if event.kind == "partial":
             return False
         if event.kind == "final":
-            if (
-                event.buffer_epoch != self._buffer_epoch
-                or event.utterance_id is None
-            ):
+            if event.utterance_id is None:
                 return False
             text = event.text.strip()
             if not text:
                 return False
             key = (event.generation, event.buffer_epoch, event.utterance_id)
-            if key in self._final_keys:
-                logger.warning("ASR worker returned a duplicate or conflicting final")
-                return False
-            self._final_keys.add(key)
+            async with self._operation_lock:
+                if (
+                    self._state is not _SessionState.READY
+                    or event.generation != self._generation
+                    or event.buffer_epoch != self._buffer_epoch
+                ):
+                    return False
+                if key in self._final_keys:
+                    logger.warning(
+                        "ASR worker returned a duplicate or conflicting final"
+                    )
+                    return False
+                valid_keys = (
+                    self._active_utterance_keys
+                    if self._config.endpointing_mode == "provider"
+                    else self._committed_utterance_keys
+                )
+                if key not in valid_keys:
+                    logger.warning(
+                        "ASR worker returned a final for an inactive utterance"
+                    )
+                    return False
+                self._final_keys.add(key)
+                self._active_utterance_keys.discard(key)
+                self._committed_utterance_keys.discard(key)
+                if (
+                    self._config.endpointing_mode == "provider"
+                    and event.utterance_id == self._utterance_id
+                ):
+                    self._utterance_id += 1
+                    self._utterance_has_audio = False
+                    self._reset_resampler()
             assert self._callback_queue is not None
             await self._callback_queue.put(_CallbackItem(text=text))
-            if (
-                self._config.endpointing_mode == "provider"
-                and event.utterance_id == self._utterance_id
-            ):
-                self._utterance_id += 1
-                self._utterance_has_audio = False
-                self._reset_resampler()
             return False
         if event.kind == "error":
             if (
@@ -615,6 +665,9 @@ class _RealtimeAsrSessionImpl:
         self._state = _SessionState.FAILED
         self._generation += 1
         self._closing_event.set()
+        self._active_utterance_keys.clear()
+        self._committed_utterance_keys.clear()
+        self._final_keys.clear()
         safe_code = (
             error_code
             if re.fullmatch(r"ASR_[A-Z0-9_]+", error_code or "")
@@ -649,18 +702,63 @@ class _RealtimeAsrSessionImpl:
             or worker_task.done()
         ):
             raise RuntimeError("ASR_SESSION_NOT_READY: session is not ready")
+
+        key: _UtteranceKey | None = None
+        added_active = False
+        added_committed = False
+        if request.utterance_id is not None and request.kind in ("audio", "commit"):
+            key = (
+                request.generation,
+                request.buffer_epoch,
+                request.utterance_id,
+            )
+            if request.kind == "audio" and key not in self._active_utterance_keys:
+                self._active_utterance_keys.add(key)
+                added_active = True
+            if request.kind == "commit" and key not in self._committed_utterance_keys:
+                self._committed_utterance_keys.add(key)
+                added_committed = True
+
         put_task = asyncio.create_task(self._request_queue.put(request))
         closing_task = asyncio.create_task(self._closing_event.wait())
         watched: set[asyncio.Task[Any]] = {put_task, closing_task, worker_task}
-        done, _ = await asyncio.wait(watched, return_when=asyncio.FIRST_COMPLETED)
-        if put_task in done and worker_task not in done and closing_task not in done:
+        try:
+            done, _ = await asyncio.wait(watched, return_when=asyncio.FIRST_COMPLETED)
+        except BaseException:
+            put_task.cancel()
+            closing_task.cancel()
+            await asyncio.gather(put_task, closing_task, return_exceptions=True)
+            if key is not None:
+                if added_active:
+                    self._active_utterance_keys.discard(key)
+                if added_committed:
+                    self._committed_utterance_keys.discard(key)
+            raise
+
+        if put_task in done:
+            try:
+                await put_task
+            except BaseException:
+                closing_task.cancel()
+                await asyncio.gather(closing_task, return_exceptions=True)
+                if key is not None:
+                    if added_active:
+                        self._active_utterance_keys.discard(key)
+                    if added_committed:
+                        self._committed_utterance_keys.discard(key)
+                raise
             closing_task.cancel()
             await asyncio.gather(closing_task, return_exceptions=True)
-            await put_task
             return
+
         put_task.cancel()
         closing_task.cancel()
         await asyncio.gather(put_task, closing_task, return_exceptions=True)
+        if key is not None:
+            if added_active:
+                self._active_utterance_keys.discard(key)
+            if added_committed:
+                self._committed_utterance_keys.discard(key)
         raise RuntimeError("ASR_SESSION_NOT_READY: worker is no longer running")
 
     def _make_resampler(self) -> soxr.ResampleStream | None:
@@ -740,7 +838,12 @@ class _RealtimeAsrSessionImpl:
                 self._response_task,
                 self._callback_task,
             )
-            if task is not None and task is not current and not task.done()
+            if (
+                task is not None
+                and task is not current
+                and task is not self._callback_close_waiter
+                and not task.done()
+            )
         ]
         for task in tasks:
             task.cancel()

--- a/main_logic/asr_client/_infra.py
+++ b/main_logic/asr_client/_infra.py
@@ -384,8 +384,6 @@ class _RealtimeAsrSessionImpl:
         async with self._operation_lock:
             if self._state is not _SessionState.READY:
                 raise RuntimeError("ASR_SESSION_NOT_READY: session is not ready")
-            if self._config.endpointing_mode == "provider":
-                return
             if not self._utterance_has_audio:
                 return
 
@@ -400,6 +398,12 @@ class _RealtimeAsrSessionImpl:
                         audio=tail,
                     )
                 )
+            if self._config.endpointing_mode == "provider":
+                # Provider endpointing still needs a local activity boundary
+                # to drain soxr's buffered 48 kHz tail. It deliberately does
+                # not send a commit or advance the provider utterance key.
+                self._reset_resampler()
+                return
             await self._enqueue_request(
                 _AsrWorkerRequest(
                     kind="commit",

--- a/main_logic/asr_client/_registry_meta.py
+++ b/main_logic/asr_client/_registry_meta.py
@@ -1,0 +1,105 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Single source of truth for Core-to-ASR routing and provider metadata."""
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+AsrProviderCategory = Literal["dummy", "ws_streaming", "segmented_request"]
+AsrImplementationStatus = Literal[
+    "implemented",
+    "planned",
+    "blocked_credentials",
+    "blocked_backend",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class AsrProviderMeta:
+    """Architectural metadata for one ASR provider implementation."""
+
+    provider_key: str
+    category: AsrProviderCategory
+    canonical_sample_rate_hz: int
+    implementation_status: AsrImplementationStatus
+
+
+# Business code must route through this table rather than scattering
+# ``if core_type == ...`` branches. qwen and qwen_intl intentionally share one
+# worker implementation; their regional endpoint/credential differences belong
+# to the future Alibaba worker.
+CORE_ASR_ROUTES: dict[str, str] = {
+    "qwen": "alibaba",
+    "qwen_intl": "alibaba",
+    "openai": "openai",
+    "step": "step",
+    "grok": "grok",
+    "glm": "glm",
+    "gemini": "gemini",
+    "free": "free",
+}
+
+
+ASR_PROVIDER_REGISTRY: dict[str, AsrProviderMeta] = {
+    "dummy": AsrProviderMeta(
+        provider_key="dummy",
+        category="dummy",
+        canonical_sample_rate_hz=16_000,
+        implementation_status="implemented",
+    ),
+    "alibaba": AsrProviderMeta(
+        provider_key="alibaba",
+        category="ws_streaming",
+        canonical_sample_rate_hz=16_000,
+        implementation_status="planned",
+    ),
+    "openai": AsrProviderMeta(
+        provider_key="openai",
+        category="ws_streaming",
+        canonical_sample_rate_hz=16_000,
+        implementation_status="planned",
+    ),
+    "step": AsrProviderMeta(
+        provider_key="step",
+        category="ws_streaming",
+        canonical_sample_rate_hz=16_000,
+        implementation_status="planned",
+    ),
+    "grok": AsrProviderMeta(
+        provider_key="grok",
+        category="ws_streaming",
+        canonical_sample_rate_hz=16_000,
+        implementation_status="planned",
+    ),
+    "glm": AsrProviderMeta(
+        provider_key="glm",
+        category="segmented_request",
+        canonical_sample_rate_hz=16_000,
+        implementation_status="planned",
+    ),
+    "gemini": AsrProviderMeta(
+        provider_key="gemini",
+        category="segmented_request",
+        canonical_sample_rate_hz=16_000,
+        implementation_status="planned",
+    ),
+    "free": AsrProviderMeta(
+        provider_key="free",
+        category="segmented_request",
+        canonical_sample_rate_hz=16_000,
+        implementation_status="blocked_backend",
+    ),
+}

--- a/main_logic/asr_client/workers/__init__.py
+++ b/main_logic/asr_client/workers/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ASR worker implementations, one provider per module."""

--- a/main_logic/asr_client/workers/dummy.py
+++ b/main_logic/asr_client/workers/dummy.py
@@ -1,0 +1,177 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Local-only ASR worker used to exercise the public session contract."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from .._infra import AsrSessionConfig, _AsrWorkerEvent, _AsrWorkerRequest
+
+_DEFAULT_TRANSCRIPT = "测试识别文本"
+_DEFAULT_DELAY_MS = 500
+_MAX_DELAY_MS = 10_000
+_ASR_DUMMY_VALID_MODES = frozenset({"normal", "duplicate", "delayed", "error"})
+
+
+async def _emit_later(
+    response_queue: asyncio.Queue[_AsrWorkerEvent],
+    event: _AsrWorkerEvent,
+    delay_seconds: float,
+) -> None:
+    """Emit a response later without blocking the worker command loop."""
+
+    await asyncio.sleep(delay_seconds)
+    await response_queue.put(event)
+
+
+async def dummy_asr_worker(
+    request_queue: asyncio.Queue[_AsrWorkerRequest],
+    response_queue: asyncio.Queue[_AsrWorkerEvent],
+    api_key: str,
+    config: AsrSessionConfig,
+) -> None:
+    """Run a deterministic ASR worker for local integration testing."""
+
+    # The dummy must accept the same signature as real workers, but it never
+    # reads credentials or provider-specific configuration.
+    _ = (api_key, config)
+    last_generation = 0
+    closed_sent = False
+    buffered_frame_counts: dict[tuple[int, int, int | None], int] = {}
+    pending_emissions: set[asyncio.Task[None]] = set()
+
+    try:
+        transcript = os.getenv("ASR_DUMMY_TRANSCRIPT", _DEFAULT_TRANSCRIPT)
+        mode = os.getenv("ASR_DUMMY_MODE", "normal").strip().lower()
+        delay_raw = os.getenv("ASR_DUMMY_DELAY_MS", str(_DEFAULT_DELAY_MS)).strip()
+
+        try:
+            delay_ms = int(delay_raw)
+        except ValueError:
+            delay_ms = -1
+
+        if mode not in _ASR_DUMMY_VALID_MODES or not 0 <= delay_ms <= _MAX_DELAY_MS:
+            await response_queue.put(
+                _AsrWorkerEvent(
+                    kind="error",
+                    generation=last_generation,
+                    error_code="ASR_DUMMY_INVALID_CONFIG",
+                    error_message="dummy worker configuration is invalid",
+                )
+            )
+            return
+
+        await response_queue.put(
+            _AsrWorkerEvent(kind="ready", generation=last_generation)
+        )
+
+        while True:
+            request = await request_queue.get()
+            last_generation = request.generation
+
+            if request.kind == "audio":
+                key = (
+                    request.generation,
+                    request.buffer_epoch,
+                    request.utterance_id,
+                )
+                buffered_frame_counts[key] = buffered_frame_counts.get(key, 0) + 1
+                continue
+
+            if request.kind == "clear":
+                buffered_frame_counts.clear()
+                continue
+
+            if request.kind == "shutdown":
+                buffered_frame_counts.clear()
+                await response_queue.put(
+                    _AsrWorkerEvent(kind="closed", generation=request.generation)
+                )
+                closed_sent = True
+                break
+
+            if request.kind != "commit":
+                await response_queue.put(
+                    _AsrWorkerEvent(
+                        kind="error",
+                        generation=request.generation,
+                        buffer_epoch=request.buffer_epoch,
+                        utterance_id=request.utterance_id,
+                        error_code="ASR_DUMMY_PROTOCOL_ERROR",
+                        error_message="dummy worker received an unsupported command",
+                    )
+                )
+                return
+
+            key = (
+                request.generation,
+                request.buffer_epoch,
+                request.utterance_id,
+            )
+            has_audio = buffered_frame_counts.pop(key, 0) > 0
+            if not has_audio:
+                continue
+
+            if mode == "error":
+                await response_queue.put(
+                    _AsrWorkerEvent(
+                        kind="error",
+                        generation=request.generation,
+                        buffer_epoch=request.buffer_epoch,
+                        utterance_id=request.utterance_id,
+                        error_code="ASR_DUMMY_ERROR",
+                        error_message="simulated provider failure",
+                    )
+                )
+                return
+
+            final_event = _AsrWorkerEvent(
+                kind="final",
+                generation=request.generation,
+                buffer_epoch=request.buffer_epoch,
+                utterance_id=request.utterance_id,
+                text=transcript,
+            )
+            if mode == "delayed":
+                task = asyncio.create_task(
+                    _emit_later(response_queue, final_event, delay_ms / 1000)
+                )
+                pending_emissions.add(task)
+                task.add_done_callback(pending_emissions.discard)
+                continue
+
+            await response_queue.put(final_event)
+            if mode == "duplicate":
+                await response_queue.put(final_event)
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        await response_queue.put(
+            _AsrWorkerEvent(
+                kind="error",
+                generation=last_generation,
+                error_code="ASR_DUMMY_WORKER_FAILED",
+                error_message="dummy worker failed",
+            )
+        )
+    finally:
+        if not closed_sent:
+            await response_queue.put(
+                _AsrWorkerEvent(kind="closed", generation=last_generation)
+            )
+        if pending_emissions:
+            await asyncio.gather(*pending_emissions, return_exceptions=True)

--- a/main_logic/asr_client/workers/dummy.py
+++ b/main_logic/asr_client/workers/dummy.py
@@ -169,9 +169,11 @@ async def dummy_asr_worker(
             )
         )
     finally:
+        for task in tuple(pending_emissions):
+            task.cancel()
+        if pending_emissions:
+            await asyncio.gather(*pending_emissions, return_exceptions=True)
         if not closed_sent:
             await response_queue.put(
                 _AsrWorkerEvent(kind="closed", generation=last_generation)
             )
-        if pending_emissions:
-            await asyncio.gather(*pending_emissions, return_exceptions=True)

--- a/tests/unit/test_asr_client.py
+++ b/tests/unit/test_asr_client.py
@@ -634,3 +634,223 @@ async def test_dummy_does_not_retain_pcm_requests(monkeypatch):
             _AsrWorkerRequest(kind="shutdown", generation=1)
         )
         await asyncio.wait_for(worker_task, 1)
+
+
+async def test_dummy_close_cancels_long_delayed_final(monkeypatch):
+    monkeypatch.setenv("ASR_PROVIDER", "dummy")
+    monkeypatch.setenv("ASR_DUMMY_MODE", "delayed")
+    monkeypatch.setenv("ASR_DUMMY_DELAY_MS", "10000")
+    transcripts: asyncio.Queue[str] = asyncio.Queue()
+    errors = AsyncMock()
+    session = create_asr_session(
+        "qwen",
+        on_input_transcript=transcripts.put,
+        on_connection_error=errors,
+    )
+
+    await session.connect()
+    await session.stream_audio(b"\x00\x00" * 160)
+    await session.signal_user_activity_end()
+    await asyncio.wait_for(session.close(), 1)
+
+    assert transcripts.empty()
+    errors.assert_not_awaited()
+
+
+async def test_transcript_callback_can_close_session(monkeypatch):
+    monkeypatch.setenv("ASR_PROVIDER", "dummy")
+    monkeypatch.setenv("ASR_DUMMY_MODE", "normal")
+    callback_returned = asyncio.Event()
+    errors = AsyncMock()
+    session = None
+
+    async def close_from_callback(text):
+        assert text
+        assert session is not None
+        await session.close()
+        callback_returned.set()
+
+    session = create_asr_session(
+        "qwen",
+        on_input_transcript=close_from_callback,
+        on_connection_error=errors,
+    )
+    await session.connect()
+    await session.stream_audio(b"\x00\x00" * 160)
+    await session.signal_user_activity_end()
+
+    await asyncio.wait_for(callback_returned.wait(), 1)
+    assert session.is_ready is False
+    assert session._callback_task is not None
+    await asyncio.wait_for(asyncio.shield(session._callback_task), 1)
+    await session.close()
+    errors.assert_not_awaited()
+
+
+async def test_manual_mode_accepts_only_committed_utterance_finals():
+    async def eager_final_worker(request_queue, response_queue, api_key, config):
+        del api_key, config
+        await response_queue.put(_AsrWorkerEvent(kind="ready", generation=0))
+        while True:
+            request = await request_queue.get()
+            common = {
+                "generation": request.generation,
+                "buffer_epoch": request.buffer_epoch,
+                "utterance_id": request.utterance_id,
+            }
+            if request.kind == "audio":
+                await response_queue.put(
+                    _AsrWorkerEvent(kind="final", text="uncommitted", **common)
+                )
+                await response_queue.put(
+                    _AsrWorkerEvent(
+                        kind="final",
+                        text="arbitrary",
+                        generation=request.generation,
+                        buffer_epoch=request.buffer_epoch,
+                        utterance_id=(request.utterance_id or 0) + 100,
+                    )
+                )
+            elif request.kind == "commit":
+                await response_queue.put(
+                    _AsrWorkerEvent(kind="final", text="committed", **common)
+                )
+            elif request.kind == "shutdown":
+                await response_queue.put(
+                    _AsrWorkerEvent(kind="closed", generation=request.generation)
+                )
+                return
+
+    transcripts: asyncio.Queue[str] = asyncio.Queue()
+    session = _RealtimeAsrSessionImpl(
+        worker_fn=eager_final_worker,
+        api_key="",
+        config=AsrSessionConfig(),
+        on_input_transcript=transcripts.put,
+        on_connection_error=AsyncMock(),
+    )
+    await session.connect()
+    await session.stream_audio(b"\x00\x00" * 160)
+    await asyncio.sleep(0.05)
+    assert transcripts.empty()
+
+    await session.signal_user_activity_end()
+    assert await asyncio.wait_for(transcripts.get(), 1) == "committed"
+    await session.close()
+
+
+async def test_provider_final_waits_for_in_flight_audio_enqueue():
+    first_audio_received = asyncio.Event()
+    release_final = asyncio.Event()
+
+    async def racing_provider_worker(request_queue, response_queue, api_key, config):
+        del api_key, config
+        first_request = None
+        await response_queue.put(_AsrWorkerEvent(kind="ready", generation=0))
+        while True:
+            request = await request_queue.get()
+            if request.kind == "audio" and first_request is None:
+                first_request = request
+                first_audio_received.set()
+                await release_final.wait()
+                await response_queue.put(
+                    _AsrWorkerEvent(
+                        kind="final",
+                        generation=request.generation,
+                        buffer_epoch=request.buffer_epoch,
+                        utterance_id=request.utterance_id,
+                        text="provider final",
+                    )
+                )
+                await asyncio.sleep(0)
+            elif request.kind == "shutdown":
+                await response_queue.put(
+                    _AsrWorkerEvent(kind="closed", generation=request.generation)
+                )
+                return
+
+    callback_states: asyncio.Queue[bool] = asyncio.Queue()
+    blocked_producer: asyncio.Task[None] | None = None
+
+    async def capture_enqueue_state(text):
+        assert text == "provider final"
+        assert blocked_producer is not None
+        await callback_states.put(blocked_producer.done())
+
+    session = _RealtimeAsrSessionImpl(
+        worker_fn=racing_provider_worker,
+        api_key="",
+        config=AsrSessionConfig(endpointing_mode="provider"),
+        on_input_transcript=capture_enqueue_state,
+        on_connection_error=AsyncMock(),
+    )
+    await session.connect()
+    await session.stream_audio(b"\x00\x00")
+    await asyncio.wait_for(first_audio_received.wait(), 1)
+    for _ in range(asr_infra._REQUEST_QUEUE_SIZE):
+        await session.stream_audio(b"\x00\x00")
+
+    blocked_producer = asyncio.create_task(session.stream_audio(b"\x00\x00"))
+    await asyncio.sleep(0)
+    assert blocked_producer.done() is False
+    release_final.set()
+
+    assert await asyncio.wait_for(callback_states.get(), 1) is True
+    await asyncio.wait_for(blocked_producer, 1)
+    await session.close()
+
+
+async def test_delivered_request_wins_over_simultaneous_worker_exit():
+    release_worker = asyncio.Event()
+
+    async def exiting_worker(request_queue, response_queue, api_key, config):
+        del request_queue, api_key, config
+        await response_queue.put(_AsrWorkerEvent(kind="ready", generation=0))
+        await release_worker.wait()
+
+    errors: asyncio.Queue[str] = asyncio.Queue()
+    delivered: list[_AsrWorkerRequest] = []
+    session = _RealtimeAsrSessionImpl(
+        worker_fn=exiting_worker,
+        api_key="",
+        config=AsrSessionConfig(),
+        on_input_transcript=AsyncMock(),
+        on_connection_error=errors.put,
+    )
+    await session.connect()
+
+    class DeliveringQueue:
+        async def put(self, request):
+            delivered.append(request)
+            release_worker.set()
+
+    session._request_queue = DeliveringQueue()  # type: ignore[assignment]
+    await session.stream_audio(b"\x00\x00")
+
+    assert [request.kind for request in delivered] == ["audio"]
+    assert (await asyncio.wait_for(errors.get(), 1)).startswith("ASR_WORKER_FAILED:")
+    await session.close()
+
+
+async def test_worker_exception_during_close_is_not_reported():
+    async def shutdown_error_worker(request_queue, response_queue, api_key, config):
+        del api_key, config
+        await response_queue.put(_AsrWorkerEvent(kind="ready", generation=0))
+        while True:
+            request = await request_queue.get()
+            if request.kind == "shutdown":
+                raise RuntimeError("shutdown failed")
+
+    errors = AsyncMock()
+    session = _RealtimeAsrSessionImpl(
+        worker_fn=shutdown_error_worker,
+        api_key="",
+        config=AsrSessionConfig(),
+        on_input_transcript=AsyncMock(),
+        on_connection_error=errors,
+    )
+    await session.connect()
+    await asyncio.wait_for(session.close(), 1)
+
+    assert session.is_ready is False
+    errors.assert_not_awaited()

--- a/tests/unit/test_asr_client.py
+++ b/tests/unit/test_asr_client.py
@@ -414,19 +414,46 @@ async def test_update_session_is_locked_after_connect(monkeypatch):
 
 
 async def test_provider_mode_does_not_commit():
+    observed_requests: list[tuple[str, int]] = []
+
+    async def capture_provider_worker(request_queue, response_queue, api_key, config):
+        del api_key, config
+        await response_queue.put(_AsrWorkerEvent(kind="ready", generation=0))
+        while True:
+            request = await request_queue.get()
+            try:
+                observed_requests.append((request.kind, len(request.audio)))
+                if request.kind == "shutdown":
+                    await response_queue.put(
+                        _AsrWorkerEvent(kind="closed", generation=request.generation)
+                    )
+                    return
+            finally:
+                request_queue.task_done()
+
     transcripts: asyncio.Queue[str] = asyncio.Queue()
+    errors = AsyncMock()
     session = _RealtimeAsrSessionImpl(
-        worker_fn=_scripted_worker,
-        api_key="provider",
-        config=AsrSessionConfig(endpointing_mode="provider"),
+        worker_fn=capture_provider_worker,
+        api_key="",
+        config=AsrSessionConfig(
+            input_sample_rate_hz=48_000,
+            endpointing_mode="provider",
+        ),
         on_input_transcript=transcripts.put,
-        on_connection_error=AsyncMock(),
+        on_connection_error=errors,
     )
     await session.connect()
-    await session.stream_audio(b"\x00\x00" * 160)
+    await session.stream_audio(b"\x00\x00" * 480)
     await session.signal_user_activity_end()
-    await asyncio.sleep(0.05)
+
+    assert session._request_queue is not None
+    await asyncio.wait_for(session._request_queue.join(), 1)
+    audio_requests = [size for kind, size in observed_requests if kind == "audio"]
+    assert sum(audio_requests) == 160 * 2
+    assert all(kind != "commit" for kind, _ in observed_requests)
     assert transcripts.empty()
+    errors.assert_not_awaited()
     await session.close()
 
 
@@ -688,6 +715,8 @@ async def test_transcript_callback_can_close_session(monkeypatch):
 
 
 async def test_manual_mode_accepts_only_committed_utterance_finals():
+    uncommitted_finals_emitted = asyncio.Event()
+
     async def eager_final_worker(request_queue, response_queue, api_key, config):
         del api_key, config
         await response_queue.put(_AsrWorkerEvent(kind="ready", generation=0))
@@ -711,6 +740,7 @@ async def test_manual_mode_accepts_only_committed_utterance_finals():
                         utterance_id=(request.utterance_id or 0) + 100,
                     )
                 )
+                uncommitted_finals_emitted.set()
             elif request.kind == "commit":
                 await response_queue.put(
                     _AsrWorkerEvent(kind="final", text="committed", **common)
@@ -722,17 +752,21 @@ async def test_manual_mode_accepts_only_committed_utterance_finals():
                 return
 
     transcripts: asyncio.Queue[str] = asyncio.Queue()
+    errors = AsyncMock()
     session = _RealtimeAsrSessionImpl(
         worker_fn=eager_final_worker,
         api_key="",
         config=AsrSessionConfig(),
         on_input_transcript=transcripts.put,
-        on_connection_error=AsyncMock(),
+        on_connection_error=errors,
     )
     await session.connect()
     await session.stream_audio(b"\x00\x00" * 160)
-    await asyncio.sleep(0.05)
+    await asyncio.wait_for(uncommitted_finals_emitted.wait(), 1)
+    assert session._response_queue is not None
+    await asyncio.wait_for(session._response_queue.join(), 1)
     assert transcripts.empty()
+    errors.assert_not_awaited()
 
     await session.signal_user_activity_end()
     assert await asyncio.wait_for(transcripts.get(), 1) == "committed"

--- a/tests/unit/test_asr_client.py
+++ b/tests/unit/test_asr_client.py
@@ -1,0 +1,636 @@
+from __future__ import annotations
+
+import asyncio
+import gc
+import weakref
+from unittest.mock import AsyncMock
+
+import pytest
+
+import main_logic.asr_client as asr_client
+import main_logic.asr_client._infra as asr_infra
+from main_logic.asr_client import AsrSessionConfig, create_asr_session
+from main_logic.asr_client._infra import (
+    _AsrWorkerEvent,
+    _AsrWorkerRequest,
+    _RealtimeAsrSessionImpl,
+)
+from main_logic.asr_client.workers.dummy import dummy_asr_worker
+
+
+async def _scripted_worker(request_queue, response_queue, api_key, config):
+    del config
+    await response_queue.put(_AsrWorkerEvent(kind="ready", generation=0))
+    while True:
+        request = await request_queue.get()
+        if request.kind == "commit":
+            if api_key == "events":
+                common = {
+                    "generation": request.generation,
+                    "buffer_epoch": request.buffer_epoch,
+                    "utterance_id": request.utterance_id,
+                }
+                await response_queue.put(
+                    _AsrWorkerEvent(kind="partial", text="draft", **common)
+                )
+                await response_queue.put(
+                    _AsrWorkerEvent(kind="final", text="   ", **common)
+                )
+                await response_queue.put(
+                    _AsrWorkerEvent(kind="final", text=" first ", **common)
+                )
+                await response_queue.put(
+                    _AsrWorkerEvent(kind="final", text="conflict", **common)
+                )
+            elif api_key == "error":
+                await response_queue.put(
+                    _AsrWorkerEvent(
+                        kind="error",
+                        generation=request.generation,
+                        buffer_epoch=request.buffer_epoch,
+                        utterance_id=request.utterance_id,
+                        error_code="ASR_WORKER_FAILED",
+                        error_message="provider rejected Authorization: Bearer sk-secret",
+                    )
+                )
+            elif api_key == "provider":
+                await response_queue.put(
+                    _AsrWorkerEvent(
+                        kind="final",
+                        generation=request.generation,
+                        buffer_epoch=request.buffer_epoch,
+                        utterance_id=request.utterance_id,
+                        text="unexpected commit",
+                    )
+                )
+        elif request.kind == "shutdown":
+            await response_queue.put(
+                _AsrWorkerEvent(kind="closed", generation=request.generation)
+            )
+            return
+
+
+async def _delayed_error_worker(request_queue, response_queue, api_key, config):
+    del api_key, config
+    pending = set()
+    await response_queue.put(_AsrWorkerEvent(kind="ready", generation=0))
+    try:
+        while True:
+            request = await request_queue.get()
+            if request.kind == "commit":
+                async def emit_error(committed_request=request):
+                    await asyncio.sleep(0.02)
+                    await response_queue.put(
+                        _AsrWorkerEvent(
+                            kind="error",
+                            generation=committed_request.generation,
+                            buffer_epoch=committed_request.buffer_epoch,
+                            utterance_id=committed_request.utterance_id,
+                            error_code="ASR_WORKER_FAILED",
+                            error_message="stale utterance failure",
+                        )
+                    )
+
+                task = asyncio.create_task(emit_error())
+                pending.add(task)
+                task.add_done_callback(pending.discard)
+            elif request.kind == "shutdown":
+                await response_queue.put(
+                    _AsrWorkerEvent(kind="closed", generation=request.generation)
+                )
+                return
+    finally:
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+
+
+async def _non_consuming_worker(request_queue, response_queue, api_key, config):
+    del request_queue, api_key, config
+    await response_queue.put(_AsrWorkerEvent(kind="ready", generation=0))
+    await asyncio.Event().wait()
+
+
+async def _wrong_generation_ready_worker(
+    request_queue, response_queue, api_key, config
+):
+    del request_queue, api_key, config
+    await response_queue.put(_AsrWorkerEvent(kind="ready", generation=99))
+    await asyncio.Event().wait()
+
+
+def test_public_exports_are_frozen():
+    assert asr_client.__all__ == [
+        "AsrSessionConfig",
+        "RealtimeAsrSession",
+        "create_asr_session",
+    ]
+    assert not hasattr(asr_client, "get_asr_worker")
+    assert not hasattr(asr_client, "AsrWorkerFn")
+    assert not hasattr(asr_client, "ASR_PROVIDER_REGISTRY")
+    assert not hasattr(asr_client, "CORE_ASR_ROUTES")
+    assert not hasattr(asr_client, "dummy_asr_worker")
+
+
+def test_routes_fail_synchronously_without_dummy(monkeypatch):
+    monkeypatch.delenv("ASR_PROVIDER", raising=False)
+    callback = AsyncMock()
+
+    with pytest.raises(RuntimeError, match="ASR_UNKNOWN_CORE"):
+        create_asr_session(
+            "unknown",
+            on_input_transcript=callback,
+            on_connection_error=callback,
+        )
+    with pytest.raises(RuntimeError, match="ASR_BACKEND_NOT_IMPLEMENTED"):
+        create_asr_session(
+            "qwen",
+            on_input_transcript=callback,
+            on_connection_error=callback,
+        )
+    with pytest.raises(RuntimeError, match="ASR_BACKEND_BLOCKED"):
+        create_asr_session(
+            "free",
+            on_input_transcript=callback,
+            on_connection_error=callback,
+        )
+
+
+def test_dummy_requires_explicit_override_and_manual_mode(monkeypatch):
+    callback = AsyncMock()
+    monkeypatch.setenv("ASR_PROVIDER", "soniox")
+    with pytest.raises(RuntimeError, match="ASR_INVALID_CONFIG"):
+        create_asr_session(
+            "qwen",
+            on_input_transcript=callback,
+            on_connection_error=callback,
+        )
+    with pytest.raises(TypeError, match="ASR_INVALID_CONFIG"):
+        create_asr_session(
+            "qwen",
+            config={"endpointing_mode": "manual"},
+            on_input_transcript=callback,
+            on_connection_error=callback,
+        )
+
+    monkeypatch.setenv("ASR_PROVIDER", "dummy")
+    session = create_asr_session(
+        "qwen",
+        on_input_transcript=callback,
+        on_connection_error=callback,
+    )
+    assert session is not None
+    with pytest.raises(RuntimeError, match="ASR_INVALID_CONFIG"):
+        create_asr_session(
+            "qwen",
+            config=AsrSessionConfig(endpointing_mode="provider"),
+            on_input_transcript=callback,
+            on_connection_error=callback,
+        )
+
+
+async def test_connect_ready_status_and_idempotent_close(monkeypatch):
+    monkeypatch.setenv("ASR_PROVIDER", "dummy")
+    statuses: asyncio.Queue[str] = asyncio.Queue()
+    session = create_asr_session(
+        "qwen",
+        on_input_transcript=AsyncMock(),
+        on_connection_error=AsyncMock(),
+        on_status_message=statuses.put,
+    )
+
+    await session.connect()
+    await session.connect()
+    assert session.is_ready is True
+    assert await asyncio.wait_for(statuses.get(), 1) == "ASR_CONNECTING"
+    assert await asyncio.wait_for(statuses.get(), 1) == "ASR_READY"
+
+    await session.close()
+    await session.close()
+    assert session.is_ready is False
+    assert await asyncio.wait_for(statuses.get(), 1) == "ASR_CLOSED"
+    assert statuses.empty()
+
+
+async def test_dummy_handles_multiple_utterances(monkeypatch):
+    monkeypatch.setenv("ASR_PROVIDER", "dummy")
+    monkeypatch.setenv("ASR_DUMMY_TRANSCRIPT", "测试识别文本")
+    transcripts: asyncio.Queue[str] = asyncio.Queue()
+    session = create_asr_session(
+        "qwen",
+        on_input_transcript=transcripts.put,
+        on_connection_error=AsyncMock(),
+    )
+    await session.connect()
+    await session.signal_user_activity_end()
+    await asyncio.sleep(0)
+    assert transcripts.empty()
+
+    for _ in range(2):
+        await session.stream_audio(b"\x00\x00" * 160, sample_rate_hz=16_000)
+        await session.signal_user_activity_end()
+
+    assert await asyncio.wait_for(transcripts.get(), 1) == "测试识别文本"
+    assert await asyncio.wait_for(transcripts.get(), 1) == "测试识别文本"
+    assert session.is_ready is True
+    await session.close()
+
+
+async def test_pcm_16k_and_48k_are_accepted_and_rate_is_locked(monkeypatch):
+    monkeypatch.setenv("ASR_PROVIDER", "dummy")
+    for sample_rate, sample_count in ((16_000, 320), (48_000, 960)):
+        transcripts: asyncio.Queue[str] = asyncio.Queue()
+        session = create_asr_session(
+            "qwen",
+            config=AsrSessionConfig(input_sample_rate_hz=sample_rate),
+            on_input_transcript=transcripts.put,
+            on_connection_error=AsyncMock(),
+        )
+        await session.connect()
+        await session.stream_audio(b"\x00\x00" * sample_count)
+        with pytest.raises((RuntimeError, ValueError), match="ASR_SAMPLE_RATE_CHANGED"):
+            await session.stream_audio(
+                b"\x00\x00" * 16,
+                sample_rate_hz=48_000 if sample_rate == 16_000 else 16_000,
+            )
+        await session.signal_user_activity_end()
+        assert await asyncio.wait_for(transcripts.get(), 1)
+        await session.close()
+
+
+async def test_48k_pcm_is_resampled_to_16k_before_worker():
+    normalized_sizes: asyncio.Queue[int] = asyncio.Queue()
+
+    async def capture_worker(request_queue, response_queue, api_key, config):
+        del api_key, config
+        chunks = []
+        await response_queue.put(_AsrWorkerEvent(kind="ready", generation=0))
+        while True:
+            request = await request_queue.get()
+            if request.kind == "audio":
+                chunks.append(request.audio)
+            elif request.kind == "commit":
+                await normalized_sizes.put(sum(map(len, chunks)))
+            elif request.kind == "shutdown":
+                await response_queue.put(
+                    _AsrWorkerEvent(kind="closed", generation=request.generation)
+                )
+                return
+
+    session = _RealtimeAsrSessionImpl(
+        worker_fn=capture_worker,
+        api_key="",
+        config=AsrSessionConfig(input_sample_rate_hz=48_000),
+        on_input_transcript=AsyncMock(),
+        on_connection_error=AsyncMock(),
+    )
+    await session.connect()
+    await session.stream_audio(b"\x00\x00" * 48_000)
+    await session.signal_user_activity_end()
+    assert await asyncio.wait_for(normalized_sizes.get(), 1) == 16_000 * 2
+    await session.close()
+
+
+async def test_pcm_validation_and_empty_chunk(monkeypatch):
+    monkeypatch.setenv("ASR_PROVIDER", "dummy")
+    session = create_asr_session(
+        "qwen",
+        on_input_transcript=AsyncMock(),
+        on_connection_error=AsyncMock(),
+    )
+    await session.connect()
+    await session.stream_audio(b"")
+    with pytest.raises((RuntimeError, ValueError), match="ASR_INVALID_PCM"):
+        await session.stream_audio(b"\x00")
+    with pytest.raises((RuntimeError, ValueError), match="ASR_AUDIO_CHUNK_TOO_LARGE"):
+        await session.stream_audio(b"\x00\x00" * 16_001, sample_rate_hz=16_000)
+    await session.close()
+
+
+async def test_duplicate_final_is_delivered_once(monkeypatch):
+    monkeypatch.setenv("ASR_PROVIDER", "dummy")
+    monkeypatch.setenv("ASR_DUMMY_MODE", "duplicate")
+    transcripts: asyncio.Queue[str] = asyncio.Queue()
+    session = create_asr_session(
+        "qwen",
+        on_input_transcript=transcripts.put,
+        on_connection_error=AsyncMock(),
+    )
+    await session.connect()
+    await session.stream_audio(b"\x00\x00" * 160)
+    await session.signal_user_activity_end()
+    assert await asyncio.wait_for(transcripts.get(), 1)
+    await asyncio.sleep(0.05)
+    assert transcripts.empty()
+    await session.close()
+
+
+async def test_delayed_final_is_dropped_after_clear_and_close(monkeypatch):
+    monkeypatch.setenv("ASR_PROVIDER", "dummy")
+    monkeypatch.setenv("ASR_DUMMY_MODE", "delayed")
+    monkeypatch.setenv("ASR_DUMMY_DELAY_MS", "50")
+    transcripts: asyncio.Queue[str] = asyncio.Queue()
+    session = create_asr_session(
+        "qwen",
+        on_input_transcript=transcripts.put,
+        on_connection_error=AsyncMock(),
+    )
+    await session.connect()
+    await session.stream_audio(b"\x00\x00" * 160)
+    await session.signal_user_activity_end()
+    await session.clear_audio_buffer()
+    await asyncio.sleep(0.1)
+    assert transcripts.empty()
+
+    await session.stream_audio(b"\x00\x00" * 160)
+    await session.signal_user_activity_end()
+    await session.close()
+    await asyncio.sleep(0.1)
+    assert transcripts.empty()
+
+
+async def test_callback_failure_does_not_break_session(monkeypatch):
+    monkeypatch.setenv("ASR_PROVIDER", "dummy")
+    callback_started: asyncio.Queue[str] = asyncio.Queue()
+
+    async def failing_callback(text):
+        await callback_started.put(text)
+        raise RuntimeError("downstream failure")
+
+    session = create_asr_session(
+        "qwen",
+        on_input_transcript=failing_callback,
+        on_connection_error=AsyncMock(),
+    )
+    await session.connect()
+    for _ in range(2):
+        await session.stream_audio(b"\x00\x00" * 160)
+        await session.signal_user_activity_end()
+        assert await asyncio.wait_for(callback_started.get(), 1)
+    assert session.is_ready is True
+    await session.close()
+
+
+async def test_worker_error_is_terminal_reported_once_and_sanitized():
+    errors: asyncio.Queue[str] = asyncio.Queue()
+    session = _RealtimeAsrSessionImpl(
+        worker_fn=_scripted_worker,
+        api_key="error",
+        config=AsrSessionConfig(),
+        on_input_transcript=AsyncMock(),
+        on_connection_error=errors.put,
+    )
+    await session.connect()
+    await session.stream_audio(b"\x00\x00" * 160)
+    await session.signal_user_activity_end()
+    message = await asyncio.wait_for(errors.get(), 1)
+    assert message.startswith("ASR_WORKER_FAILED:")
+    assert "sk-secret" not in message
+    assert session.is_ready is False
+    with pytest.raises(RuntimeError, match="ASR_SESSION_NOT_READY"):
+        await session.stream_audio(b"\x00\x00")
+    await asyncio.sleep(0.05)
+    assert errors.empty()
+    assert session._worker_task is not None and session._worker_task.done()
+    assert session._response_task is not None and session._response_task.done()
+    assert session._callback_task is not None and session._callback_task.done()
+    await session.close()
+
+
+async def test_update_session_is_locked_after_connect(monkeypatch):
+    monkeypatch.setenv("ASR_PROVIDER", "dummy")
+    session = create_asr_session(
+        "qwen",
+        on_input_transcript=AsyncMock(),
+        on_connection_error=AsyncMock(),
+    )
+    await session.update_session({"language": "en-US", "instructions": "ignored"})
+    with pytest.raises((RuntimeError, ValueError), match="ASR_INVALID_CONFIG"):
+        await session.update_session({"unknown_asr_field": True})
+    await session.connect()
+    await session.update_session({"instructions": "ignored", "tools": []})
+    with pytest.raises(RuntimeError, match="ASR_SESSION_CONFIG_LOCKED"):
+        await session.update_session({"language": "ja"})
+    await session.close()
+
+
+async def test_provider_mode_does_not_commit():
+    transcripts: asyncio.Queue[str] = asyncio.Queue()
+    session = _RealtimeAsrSessionImpl(
+        worker_fn=_scripted_worker,
+        api_key="provider",
+        config=AsrSessionConfig(endpointing_mode="provider"),
+        on_input_transcript=transcripts.put,
+        on_connection_error=AsyncMock(),
+    )
+    await session.connect()
+    await session.stream_audio(b"\x00\x00" * 160)
+    await session.signal_user_activity_end()
+    await asyncio.sleep(0.05)
+    assert transcripts.empty()
+    await session.close()
+
+
+async def test_partial_empty_duplicate_and_conflicting_finals_are_filtered():
+    transcripts: asyncio.Queue[str] = asyncio.Queue()
+    session = _RealtimeAsrSessionImpl(
+        worker_fn=_scripted_worker,
+        api_key="events",
+        config=AsrSessionConfig(),
+        on_input_transcript=transcripts.put,
+        on_connection_error=AsyncMock(),
+    )
+    await session.connect()
+    await session.stream_audio(b"\x00\x00" * 160)
+    await session.signal_user_activity_end()
+    assert await asyncio.wait_for(transcripts.get(), 1) == "first"
+    await asyncio.sleep(0.05)
+    assert transcripts.empty()
+    await session.close()
+
+
+async def test_stale_utterance_error_is_dropped_after_clear():
+    errors: asyncio.Queue[str] = asyncio.Queue()
+    session = _RealtimeAsrSessionImpl(
+        worker_fn=_delayed_error_worker,
+        api_key="",
+        config=AsrSessionConfig(),
+        on_input_transcript=AsyncMock(),
+        on_connection_error=errors.put,
+    )
+    await session.connect()
+    await session.stream_audio(b"\x00\x00" * 160)
+    await session.signal_user_activity_end()
+    await session.clear_audio_buffer()
+    await asyncio.sleep(0.05)
+    assert errors.empty()
+    assert session.is_ready is True
+    await session.close()
+
+
+async def test_close_unblocks_request_backpressure(monkeypatch):
+    monkeypatch.setattr(asr_infra, "_WORKER_CLOSE_TIMEOUT_SECONDS", 0.02)
+    session = _RealtimeAsrSessionImpl(
+        worker_fn=_non_consuming_worker,
+        api_key="",
+        config=AsrSessionConfig(),
+        on_input_transcript=AsyncMock(),
+        on_connection_error=AsyncMock(),
+    )
+    await session.connect()
+    for _ in range(asr_infra._REQUEST_QUEUE_SIZE):
+        await session.stream_audio(b"\x00\x00")
+
+    blocked_producer = asyncio.create_task(session.stream_audio(b"\x00\x00"))
+    await asyncio.sleep(0)
+    assert blocked_producer.done() is False
+    await asyncio.wait_for(session.close(), 1)
+    with pytest.raises(RuntimeError, match="ASR_SESSION_NOT_READY"):
+        await blocked_producer
+
+
+async def test_invalid_ready_generation_times_out(monkeypatch):
+    monkeypatch.setattr(asr_infra, "_READY_TIMEOUT_SECONDS", 0.02)
+    errors: asyncio.Queue[str] = asyncio.Queue()
+    session = _RealtimeAsrSessionImpl(
+        worker_fn=_wrong_generation_ready_worker,
+        api_key="",
+        config=AsrSessionConfig(),
+        on_input_transcript=AsyncMock(),
+        on_connection_error=errors.put,
+    )
+    with pytest.raises(RuntimeError, match="ASR_CONNECT_TIMEOUT"):
+        await session.connect()
+    assert (await asyncio.wait_for(errors.get(), 1)).startswith("ASR_CONNECT_TIMEOUT:")
+    await session.close()
+
+
+async def test_worker_normal_exit_is_terminal():
+    release_worker = asyncio.Event()
+    errors: asyncio.Queue[str] = asyncio.Queue()
+
+    async def exiting_worker(request_queue, response_queue, api_key, config):
+        del request_queue, api_key, config
+        await response_queue.put(_AsrWorkerEvent(kind="ready", generation=0))
+        await release_worker.wait()
+
+    session = _RealtimeAsrSessionImpl(
+        worker_fn=exiting_worker,
+        api_key="",
+        config=AsrSessionConfig(),
+        on_input_transcript=AsyncMock(),
+        on_connection_error=errors.put,
+    )
+    await session.connect()
+    release_worker.set()
+    message = await asyncio.wait_for(errors.get(), 1)
+    assert message == "ASR_WORKER_FAILED: worker closed unexpectedly"
+    assert session._response_task is not None
+    await asyncio.wait_for(asyncio.shield(session._response_task), 1)
+    assert session.is_ready is False
+    assert session._worker_task is not None and session._worker_task.done()
+    assert session._response_task.done()
+    assert session._callback_task is not None and session._callback_task.done()
+    await session.close()
+
+    async def immediately_exiting_worker(
+        request_queue, response_queue, api_key, config
+    ):
+        del request_queue, api_key, config
+        await response_queue.put(_AsrWorkerEvent(kind="ready", generation=0))
+
+    immediate_errors: asyncio.Queue[str] = asyncio.Queue()
+    immediate_session = _RealtimeAsrSessionImpl(
+        worker_fn=immediately_exiting_worker,
+        api_key="",
+        config=AsrSessionConfig(),
+        on_input_transcript=AsyncMock(),
+        on_connection_error=immediate_errors.put,
+    )
+    with pytest.raises(RuntimeError, match="ASR_WORKER_FAILED"):
+        await immediate_session.connect()
+    assert (await asyncio.wait_for(immediate_errors.get(), 1)).startswith(
+        "ASR_WORKER_FAILED:"
+    )
+    assert immediate_session.is_ready is False
+    await immediate_session.close()
+
+
+async def test_cancelled_close_still_finishes_cleanup():
+    session = _RealtimeAsrSessionImpl(
+        worker_fn=_scripted_worker,
+        api_key="",
+        config=AsrSessionConfig(),
+        on_input_transcript=AsyncMock(),
+        on_connection_error=AsyncMock(),
+    )
+    await session.connect()
+    await session._operation_lock.acquire()
+    try:
+        close_waiter = asyncio.create_task(session.close())
+        await asyncio.sleep(0)
+        assert session.is_ready is False
+        close_waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await close_waiter
+    finally:
+        session._operation_lock.release()
+
+    await asyncio.wait_for(session.close(), 1)
+    assert session.is_ready is False
+    assert session._worker_task is not None and session._worker_task.done()
+    assert session._response_task is not None and session._response_task.done()
+    assert session._callback_task is not None and session._callback_task.done()
+
+
+async def test_dummy_does_not_retain_pcm_requests(monkeypatch):
+    class Payload:
+        pass
+
+    monkeypatch.setenv("ASR_DUMMY_MODE", "normal")
+    request_queue: asyncio.Queue[_AsrWorkerRequest] = asyncio.Queue()
+    events: asyncio.Queue[_AsrWorkerEvent] = asyncio.Queue()
+    worker_task = asyncio.create_task(
+        dummy_asr_worker(
+            request_queue,
+            events,
+            "",
+            AsrSessionConfig(),
+        )
+    )
+    ready = await asyncio.wait_for(events.get(), 1)
+    assert ready.kind == "ready"
+
+    first_payload = Payload()
+    first_payload_ref = weakref.ref(first_payload)
+    first_request = _AsrWorkerRequest(
+        kind="audio",
+        generation=0,
+        buffer_epoch=0,
+        utterance_id=1,
+        audio=first_payload,  # type: ignore[arg-type]
+    )
+    second_request = _AsrWorkerRequest(
+        kind="audio",
+        generation=0,
+        buffer_epoch=0,
+        utterance_id=1,
+        audio=Payload(),  # type: ignore[arg-type]
+    )
+
+    try:
+        await request_queue.put(first_request)
+        await request_queue.put(second_request)
+        for _ in range(20):
+            if request_queue.empty():
+                break
+            await asyncio.sleep(0)
+        assert request_queue.empty()
+        await asyncio.sleep(0)
+        del first_request, first_payload
+        gc.collect()
+        assert first_payload_ref() is None
+    finally:
+        await request_queue.put(
+            _AsrWorkerRequest(kind="shutdown", generation=1)
+        )
+        await asyncio.wait_for(worker_task, 1)


### PR DESCRIPTION
## 改动概述

小游戏后续需要从成本较高的 Omni Realtime STT 迁移到独立 ASR，但仓库目前没有可供调用方稳定依赖的 ASR 合同。本 PR 先交付与现有 `tts_client` 职责对偶的 Phase 1 骨架，让小游戏团队能够基于固定接口并行接入，而不提前绑定尚未确认的真实供应商。

实现采用“公共入口、公共基础层、唯一注册表、workers”四层结构：

- `main_logic.asr_client` 只稳定导出配置、Session Protocol 和创建入口，调用方不能绕过 Session 直接操作 worker。
- Core 到 ASR provider 的规划集中在唯一注册表；未实现或被阻塞的 Core 同步失败，不允许跨供应商静默 fallback。
- Session 使用有界 `asyncio.Queue` 管理请求、响应和业务回调，统一处理 PCM 校验、48 kHz 到 16 kHz 流式重采样、生命周期和背压。
- 内部事件通过 `generation + buffer_epoch + utterance_id` 关联，隔离 clear/close 后的迟到事件，并按关联键去重 final。
- Phase 1 仅提供显式启用的 dummy worker，用于验证多轮提交、重复/延迟 final、供应商错误和关闭路径；默认采用手动断句，确保无 VAD 的联调环境能够产出 final。

## 回归报告 / Regression Report

### 改动内容与必要性

本 PR 仅新增独立的 `main_logic/asr_client` 包、对应专项测试和设计说明，没有修改小游戏、Omni Realtime、普通语音链路或生产设置。该公共底座是后续小游戏替换 Omni STT、接入第一批流式 ASR worker，以及继续扩展 Smart Turn 的共同前置条件。

### 前后表现

- 改动前：仓库没有独立 ASR Session 合同，小游戏若要获得实时转写只能直接依赖现有 Omni Realtime 链路。
- 改动后：调用方可以通过统一入口创建长连接 ASR Session，并以相同方法完成连接、流式送入 PCM、提交当前 utterance、清空缓冲和关闭；开发环境可显式使用 dummy 联调。
- 未实现的真实 provider 仍会明确拒绝创建，不会因为新增骨架而改变任何现有生产路由。
- worker 裸退出、provider error、回调异常和关闭协程取消均会进入确定的终止与回收路径，避免假 READY、后台任务遗留或半关闭状态。

### 潜在回归点

- 后续调用方必须只依赖三个稳定公共导出，不能依赖内部队列、事件或 provider 状态。
- 单个 Session 首个非空音频包会锁定 16 kHz 或 48 kHz 输入采样率；混用采样率会明确失败。
- `endpointing_mode="provider"` 下，`signal_user_activity_end()` 不主动发送 commit；Phase 1 dummy 因此只允许 manual 模式。
- `ASR_PROVIDER=dummy` 是进程级开发覆盖，只能显式设置，不进入持久化配置或设置 UI。

## 风险与边界

本轮不接入任何真实 ASR 供应商，不修改小游戏和现有 Omni 调用，也不实现 Smart Turn、VAD、RNNoise、声纹、节流、生产开关、LLM 回复、TTS 或工具调用。当前新增代码没有生产调用方，主要风险集中在后续接入方绕过公共入口或误把规划状态当作已实现状态。

后续真实供应商应只在 `workers/` 下实现相同的 request/response 合同；Smart Turn 和统一节流能力按后续阶段动态接入，不改变本次冻结的小游戏公共接口。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增实时 ASR 会话公共接口：支持连接就绪、推送音频流、按 utterance 提交、清空缓冲与幂等关闭。
  - 支持基于核心类型路由并提供本地 dummy worker，用于联调与协议验证；冻结 Phase 1 会话行为与端点/提交语义约束。
- **Bug Fixes**
  - 细化事件与转录回调触发规则：重复/冲突/过期 final 过滤，回调异常不影响会话接收循环。
  - 强化错误路径处理与错误信息脱敏；worker 异常退出会终止当前会话且不自动重连。
- **测试**
  - 新增并完善覆盖会话全生命周期、音频校验/重采样、dummy 行为与并发容错的单元测试。
- **文档**
  - 新增 Phase 1 ASR 客户端设计文档，明确接口/调用契约与联调边界条件。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->