### PR TITLE
game_agent_minecraft: 降话痨/止派发环/加忙碌感知（rebase 到 main）

### DIFF
--- a/plugin/plugins/game_agent_minecraft/README.md
+++ b/plugin/plugins/game_agent_minecraft/README.md
@@ -16,6 +16,13 @@ agent server 与本插件通过单一 WebSocket 连接通信，JSON 帧格式：
 | ← agent | `task_finished` | `{"type": "task_finished", "status": "ok", "text": "...", "task_id": "<uuid>"}` |
 | ← agent | `agent_status` | informational, ignored by callbacks |
 
+`task_finished` 的 `status` 是一个字符串，插件**容忍任意取值**（当作不透明
+串透传，不做枚举校验，未知值不会崩）。agent 目前会发这些：`ok`（真正完成）、
+`interrupted`（被打断）、`superseded`（被更新的任务顶替而中止——中性的"没跑完"，
+与 `interrupted` 同类，**不算失败**）、`failed`（真正执行失败）、`timeout`。
+插件据此给对话 LLM 分档措辞：`ok`→成功、`interrupted`/`superseded`→中性"换/停"、
+其余→失败。**约定**：失败绝不能报成 `ok`（否则猫娘会把翻车当成功叙述）。
+
 `task_id` 是**可选的**显式关联字段。插件每次发 `task` 帧都会带一个新生成
 的 UUID；agent 如果在对应的 `task_finished` 帧里把这个 UUID 原样回传，插件
 就用 ID 严格匹配 pending 任务，跳过 FIFO 的 stale-frame 启发式。**不回传
@@ -49,9 +56,10 @@ agent 端启动方式由你自己决定（一般是 `node minecraft-agent/index.
 | `ws_url` | `ws://localhost:48909` | agent server WebSocket 地址 |
 | `reconnect_interval_seconds` | `5.0` | WS 断开后等待多久重连 |
 | `task_timeout_seconds` | `120.0` | `minecraft_task` 单次调用最长等待 agent 完成的秒数；超时返回 `{status: "timeout"}` 给 LLM。默认 120s 给 mine/craft 类多步动作留余量（实测 60–90s 较常见）；先前 25s 默认在挖矿场景下普遍误超时 |
-| `system_prompt_interval_seconds` | `5.0` | 自动 nudge 循环的最小间隔；不影响 `main_server` 自身的对话节奏控制 |
+| `system_prompt_interval_seconds` | `15.0` | 自动 nudge 循环的最小间隔（节流，降低对话密度）；不影响 `main_server` 自身的对话节奏控制 |
 | `skip_system_prompt_if_busy` | `true` | 任务进行中跳过 nudge，避免堆叠 |
-| `stream_screenshots_to_llm` | `true` | 收到 agent 截图就立即 push 到模型视觉上下文（`ai_behavior="read"`） |
+| `stream_screenshots_to_llm` | `true` | 收到 agent 截图就 push 到模型视觉上下文（`ai_behavior="read"`），按下面的最小间隔节流 |
+| `screenshot_stream_min_interval_seconds` | `6.0` | 内联截图流 push 的最小间隔（节流，防止按 agent ~1Hz 速率灌爆模型视觉上下文）；窗口内的帧折叠为最新一张 |
 | `screenshot_cache_size` | `3` | 内存里保留的最近 N 张截图，nudge 时一并发出 |
 
 ## LLM 工具：`minecraft_task`
@@ -76,10 +84,16 @@ agent 端启动方式由你自己决定（一般是 `node minecraft-agent/index.
 | 形态 | 时机 |
 |------|------|
 | `{"status": "ok", "query": "..."}` | agent 正常完成 |
+| `{"status": "failed", "query": "...", "text": "..."}` | agent 报告任务真正执行失败 |
+| `{"status": "superseded", "query": "...", "text": "..."}` | agent 因更新的任务顶替而中止本任务（中性非完成，与 `interrupted` 同类，不算失败） |
 | `{"status": "timeout", "query": "...", "reason": "..."}` | `task_timeout_seconds` 内 agent 未完成 |
 | `{"status": "interrupted", "query": "...", "reason": "..."}` | 被新任务（`overwrite=True`）抢占 |
 | `{"result": "busy", "currently_executing": "...", "hint": "..."}` | 已有任务在跑且 `overwrite=False`，新任务被拒 |
 | `{"output": {"error": "..."}, "is_error": true, "error": "AGENT_DISCONNECTED"}` | agent server 当前不可达 |
+
+> `status` 直接透传 agent 的原值：`ok`/`interrupted` 之外，agent 现也可能发
+> `failed`/`superseded`。插件对 `interrupted`、`superseded` 用中性"没跑完"措辞，
+> 对 `failed`（及 `timeout`、断连）用失败措辞，只有 `ok` 判成功。
 
 ## 自动 nudge 循环
 

--- a/plugin/plugins/game_agent_minecraft/__init__.py
+++ b/plugin/plugins/game_agent_minecraft/__init__.py
@@ -40,7 +40,7 @@ from plugin.sdk.plugin import (
 )
 
 from . import prompts
-from .service import GameAgentService
+from .service import GameAgentService, text_signals_blocked
 
 # JSON Schema reused by the @llm_tool decorator below. Pulled into a
 # module-level constant so the plugin's introspection (status entry,
@@ -73,6 +73,15 @@ MINECRAFT_TASK_DESCRIPTION = (
     "(cue). "
     "Do not infer or claim results from the task text itself — only from "
     "actually-observed cues and screenshots.\n\n"
+    "CRITICAL — never parrot the game's own logs. The Minecraft feed you see is "
+    "the agent's internal telemetry: function-call lines (goToCoordinates(...), "
+    "attackEntity(...)), '!commands', 'admin movement request', and coordinates it "
+    "picked itself. NEVER copy any of that into a task — echoing a log line back "
+    "as a task creates a dispatch loop. A task must come from the user's actual "
+    "spoken request or a genuine decision of your own, written as a plain-language "
+    "goal (e.g. 'mine straight down 3 blocks then place 1 block below you'), never "
+    "the game's raw command syntax or a coordinate you only saw in a log. If the "
+    "user asked for a specific thing, do THAT — not whatever the log happens to say.\n\n"
     "Use this tool when the user asks the character to do something in "
     "the game, or when continuing an in-game activity that needs another "
     "concrete step. Do NOT use it for chat, status questions, or "
@@ -466,11 +475,21 @@ class GameAgentMinecraftPlugin(NekoPluginBase):
         # dialog LLM can paraphrase. The "received status string" stays
         # the surface text the LLM sees; routing logic below still keys
         # off the original ``ok`` / ``受阻`` sentinel values via the
-        # same-language label, so the three-way branch survives
+        # same-language label, so the status branches below survive
         # localization without growing brittle "if any locale of 受阻"
         # checks.
         blocked_label = prompts.t("STATUS_LABEL_BLOCKED", lang=self._lang)
-        if status == "AGENT_DISCONNECTED" or "not connected" in detail.lower():
+        # Gate the "not connected" text sniff on an actual error envelope.
+        # The genuine transport failure already arrives as
+        # status=="AGENT_DISCONNECTED" (is_error path above), so the substring
+        # is only a belt-and-suspenders for error results whose text says
+        # "not connected". Firing it on ANY detail containing that phrase
+        # would hijack a legitimate completion (e.g. status="ok",
+        # text="the lever is not connected to the piston") — or a new
+        # interrupted/superseded frame — into the disconnect bucket.
+        if status == "AGENT_DISCONNECTED" or (
+            result.get("is_error") and "not connected" in detail.lower()
+        ):
             status = prompts.t("STATUS_LABEL_DISCONNECTED", lang=self._lang)
             detail = prompts.t("STATUS_DETAIL_DISCONNECTED", lang=self._lang)
         # mc-agent quirk: chat-loop returns ``status="ok"`` even when the
@@ -480,23 +499,10 @@ class GameAgentMinecraftPlugin(NekoPluginBase):
         # "结果 ok" + "find player not found" and concludes "task done"
         # (cf. user-reported "她以为找博士成功了，没改用真 username"
         # bug). Surface the blocked-ness explicitly so she has to plan
-        # around it.
-        elif status.lower() == "ok" and detail:
-            blocked_markers = (
-                "obstacle", "obstructed", "not found", "could not", "couldn't",
-                "unable", "failed", "no path", "blocked", "missing",
-                "cannot", "can't",
-                # status=ok 但实际没目标 / 要更多信息也算受阻：mc-agent 对
-                # 「过来」「跟着我」这类缺玩家名/坐标的指令会回 status=ok +
-                # "Target unavailable. Please provide the exact player name or
-                # coordinates."，旧标记词表漏了 unavailable，导致被当成功 →
-                # 猫娘叙述「我来啦」其实化身没动。
-                "unavailable", "please provide", "provide the exact",
-                "no target", "target not",
-            )
-            d_lower = detail.lower()
-            if any(m in d_lower for m in blocked_markers):
-                status = blocked_label
+        # around it. Marker list is shared with the retroactive cue via
+        # ``text_signals_blocked`` so the two can't drift apart.
+        elif status.strip().lower() == "ok" and text_signals_blocked(detail):
+            status = blocked_label
 
         inv = result.get("inventory")
         inv_line = ""
@@ -513,17 +519,35 @@ class GameAgentMinecraftPlugin(NekoPluginBase):
         elif isinstance(inv, dict):
             inv_line = prompts.t("COMPLETION_INV_CURRENT_EMPTY", lang=self._lang)
 
-        # Three-way: actual success ("ok", case-insensitive), rebadged
-        # success-but-blocked (status == blocked_label), or anything
-        # else (disconnect, timeout, interrupted, error, "unknown",
-        # arbitrary is_error strings). The else branch previously cue'd
-        # everything that wasn't 受阻 as "做完 ... 派下一步" which told
-        # the dialog LLM the action succeeded when it actually
-        # disconnected / timed out / crashed — Codex review on PR
-        # #1395 caught this. Whitelist "ok" as success instead of
-        # trying to enumerate every failure.
+        # Four-way: actual success ("ok", case-insensitive), rebadged
+        # success-but-blocked (status == blocked_label), neutral
+        # interrupted/superseded (task stopped short but nothing went
+        # wrong), or genuine failure (disconnect, timeout, "failed",
+        # error, "unknown", arbitrary is_error strings). The catch-all
+        # branch previously cue'd everything that wasn't 受阻 as "做完 ...
+        # 派下一步" which told the dialog LLM the action succeeded when it
+        # actually disconnected / timed out / crashed — Codex review on
+        # PR #1395 caught this, so we whitelist "ok" as success instead
+        # of enumerating every failure. ``interrupted`` (our overwrite/
+        # shutdown/bounce verdict) and ``superseded`` (mc-agent's "a newer
+        # task replaced this") are carved out of the failure bucket: they
+        # are non-completions, not failures, and narrating them as
+        # "没做成——想清楚原因" is wrong (there's no cause; she just moved on).
+        # Normalize once for the buckets: tolerate case + stray whitespace
+        # from mc-agent (e.g. "ok " / " SUPERSEDED" must still classify).
+        # ``is_blocked`` keeps the exact-label compare — blocked_label is a
+        # localized display string set by the rewrite above, never padded.
+        status_lc = status.strip().lower()
         is_blocked = status == blocked_label
-        is_success = status.lower() == "ok"
+        is_success = status_lc == "ok"
+        is_interrupted = status_lc in ("interrupted", "superseded")
+        # [NO-SWITCH-CUE] interrupted/superseded means a newer task already
+        # replaced this one — the LLM (or user) did that on purpose and knows.
+        # Reporting "your task got switched (re-dispatch if you want)" just makes
+        # it fire another minecraft_task → the observed task-switch retry storm.
+        # Emit nothing; the fresh task's own cues/screenshots carry the story.
+        if is_interrupted:
+            return ""
         if is_blocked:
             head_verb = prompts.t("HEAD_VERB_BLOCKED", lang=self._lang)
         elif is_success:

--- a/plugin/plugins/game_agent_minecraft/client.py
+++ b/plugin/plugins/game_agent_minecraft/client.py
@@ -29,6 +29,7 @@ OnScreenshot = Callable[[str, str], Awaitable[None]]  # (base64_payload, encodin
 OnTaskFinished = Callable[[dict[str, Any]], Awaitable[None]]
 OnAlert = Callable[[dict[str, Any]], Awaitable[None]]
 OnInventory = Callable[[dict[str, Any]], Awaitable[None]]
+OnBotStatus = Callable[[dict[str, Any]], Awaitable[None]]  # bot_status_nl frame
 
 
 class GameAgentClient:
@@ -49,6 +50,7 @@ class GameAgentClient:
         on_task_finished: Optional[OnTaskFinished] = None,
         on_alert: Optional[OnAlert] = None,
         on_inventory: Optional[OnInventory] = None,
+        on_bot_status: Optional[OnBotStatus] = None,
         reconnect_interval: float = 5.0,
         logger: Any = None,
     ):
@@ -58,6 +60,7 @@ class GameAgentClient:
         self.on_task_finished = on_task_finished
         self.on_alert = on_alert
         self.on_inventory = on_inventory
+        self.on_bot_status = on_bot_status
         self.reconnect_interval = reconnect_interval
         # Plugin SDK injects a per-plugin loguru logger; fall back to a
         # noop when running outside that environment (unit tests).
@@ -248,6 +251,14 @@ class GameAgentClient:
                         # and wakes any pending ``query_inventory`` calls.
                         await self.on_inventory(data)
 
+                    elif msg_type == "bot_status_nl" and self.on_bot_status is not None:
+                        # Natural-language activity status (🎯[按指令]/🤖[自主] +
+                        # skill/kind). The service uses it to know whether the
+                        # mc-agent is actively executing, so the autonomous
+                        # nudge loop stops telling her to dispatch a new task
+                        # while the agent is already mid-action.
+                        await self.on_bot_status(data)
+
                     elif msg_type == "agent_status":
                         # Informational status — the original integration
                         # logged this at debug. Keep parity.
@@ -312,4 +323,5 @@ __all__ = [
     "OnTaskFinished",
     "OnAlert",
     "OnInventory",
+    "OnBotStatus",
 ]

--- a/plugin/plugins/game_agent_minecraft/plugin.toml
+++ b/plugin/plugins/game_agent_minecraft/plugin.toml
@@ -52,7 +52,9 @@ task_timeout_seconds = 120.0
 # when there's no pending task. The LLM sees a "GAME_SYSTEM" prompt with
 # accumulated logs and is asked to either issue the next minecraft_task or
 # provide voice commentary.
-system_prompt_interval_seconds = 5.0
+system_prompt_interval_seconds = 15.0   # [THROTTLE] was 5.0
+# [THROTTLE] cap inline screenshot stream (was implicit 1.0s → ~60/min)
+screenshot_stream_min_interval_seconds = 6.0
 
 # Skip a system-prompt nudge if a tool call is already pending — the LLM is
 # busy and an extra prompt would just queue up.

--- a/plugin/plugins/game_agent_minecraft/prompts.py
+++ b/plugin/plugins/game_agent_minecraft/prompts.py
@@ -526,6 +526,20 @@ PROMPTS: Dict[str, Dict[str, str]] = {
         "es": "La tarea anterior que enviaste (\"{task_text}\") en realidad terminó (resultado: {status}).",
         "pt": "A tarefa anterior que você enviou (\"{task_text}\") na real terminou (resultado: {status}).",
     },
+    "RETROACTIVE_HEADER_ENDED": {
+        # Used when the late frame's status is NOT a genuine completion
+        # (interrupted / superseded / failed / timeout). The plain
+        # RETROACTIVE_HEADER asserts "actually finished", which would
+        # contradict the status and re-tell 猫娘 a completion that never
+        # happened. {task_text} = the earlier task, {status} = final status.
+        "zh": "你之前派出去的「{task_text}」已经结束了，但没真正跑完（结果 {status}）。",
+        "en": "The earlier task you dispatched (\"{task_text}\") has since ended, but didn't actually complete (result: {status}).",
+        "ja": "前に送った「{task_text}」、もう終わったけど実際には完了しなかった（結果: {status}）。",
+        "ko": "전에 보낸 \"{task_text}\", 이제 끝났는데 실제로 완료되진 않았어 (결과: {status}).",
+        "ru": "Та задача, которую ты раньше отправил(а) («{task_text}»), уже завершилась, но по-настоящему не выполнена (результат: {status}).",
+        "es": "La tarea anterior que enviaste (\"{task_text}\") ya terminó, pero en realidad no se completó (resultado: {status}).",
+        "pt": "A tarefa anterior que você enviou (\"{task_text}\") já encerrou, mas na real não foi concluída (resultado: {status}).",
+    },
     "RETROACTIVE_INVENTORY_LINE": {
         # {snippet} = item list
         "zh": "现在背包：{snippet}",

--- a/plugin/plugins/game_agent_minecraft/service.py
+++ b/plugin/plugins/game_agent_minecraft/service.py
@@ -47,6 +47,55 @@ from .client import GameAgentClient
 # LLM — we don't want VT100 noise in the model's context window.
 _ANSI_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
 
+# [ANTI-PARROT] mc-agent emits internal action/telemetry logs that contain
+# executable command syntax — function calls like ``goToCoordinates(118,64,-115,1)``
+# or ``attackEntity(spider)``, ``!command`` prefixes, and "admin movement request"
+# lines. Forwarded verbatim to the dialog LLM, these get copied back as new
+# minecraft_task dispatches (observed: Neko spamming goToCoordinates/attackEntity
+# instead of the user's actual request), a self-reinforcing loop. These lines are
+# internal mechanics, not narration the character should see, so we drop them
+# before they ever reach the dialog LLM (both inline push and the nudge digest).
+_INJECTION_LOG_RE = re.compile(
+    r"""(?xi)
+      [A-Za-z_][A-Za-z0-9_]*\([^)]*\)   # function-call syntax: goToCoordinates(...), attackEntity(...)
+    | (?:^|\s)![A-Za-z_]\w*             # !command prefix
+    | admin\s+movement                  # "admin movement request"
+    | latest\s+admin                    # "Continuing with latest admin ... request"
+    | forced\s+interrupt                # stack-kick / interrupt mechanics
+    | kicking\s+the\s+stack
+    | pinned\s+\d+\s*min                # "Pinned 15min+ — ..."
+    """
+)
+
+# English "the action was actually blocked" markers. mc-agent's chat-loop
+# sometimes returns status="ok" while the real in-game action was blocked
+# (target not found, no path, missing tool, needs more info…), burying the
+# failure in the free-text feedback. Both the live completion cue
+# (``_format_completion_cue`` in the facade) and the retroactive cue
+# (``_push_retroactive_completion_cue`` below) sniff these so a blocked
+# action is never narrated as a success (user-reported "她以为找博士成功了"
+# bug). Kept in ONE place so the two consumers can't drift apart.
+_BLOCKED_TEXT_MARKERS = (
+    "obstacle", "obstructed", "not found", "could not", "couldn't",
+    "unable", "failed", "no path", "blocked", "missing",
+    "cannot", "can't",
+    # status=ok 但缺目标 / 要更多信息也算受阻：mc-agent 对「过来」「跟着我」
+    # 这类缺玩家名/坐标的指令会回 status=ok + "Target unavailable. Please
+    # provide the exact player name or coordinates."
+    "unavailable", "please provide", "provide the exact",
+    "no target", "target not",
+)
+
+
+def text_signals_blocked(text: str) -> bool:
+    """True when free-text feedback indicates the action was actually
+    blocked / unsuccessful despite a status that claims otherwise. Shared
+    by the live and retroactive completion cues (see ``_BLOCKED_TEXT_MARKERS``)."""
+    if not text:
+        return False
+    low = text.lower()
+    return any(m in low for m in _BLOCKED_TEXT_MARKERS)
+
 
 @dataclass
 class PendingTask:
@@ -104,7 +153,7 @@ class GameAgentService:
         self._ws_url: str = "ws://localhost:48909"
         self._reconnect_interval: float = 5.0
         self._task_timeout: float = 90.0
-        self._system_prompt_interval: float = 5.0
+        self._system_prompt_interval: float = 15.0
         self._skip_when_busy: bool = True
         self._stream_screenshots: bool = True
         self._screenshot_cache_size: int = 3
@@ -182,6 +231,20 @@ class GameAgentService:
         # dialog LLM always gets present-state, not minutes-old cache.
         self._last_inventory: Dict[str, int] = {}
         self._last_inventory_at: float = 0.0
+        # [INV-DEDUP] snapshot of the inventory we last SURFACED to the dialog
+        # (in a nudge/cue). The bag line is only re-stated when this changes, so
+        # she stops robotically reciting the same inventory every nudge. None =
+        # never surfaced yet (first mention always allowed).
+        self._last_pushed_inventory: Optional[tuple] = None
+        # [AGENT-BUSY] mc-agent's self-reported activity, parsed from its
+        # bot_status_nl frames. When it's actively executing (a skill/command),
+        # the autonomous nudge loop must NOT tell her to dispatch a new task —
+        # that interrupts what the agent is already doing. Refreshed per frame;
+        # treated as stale (idle) after ``_agent_busy_ttl`` with no update.
+        self._agent_busy: bool = False
+        self._agent_busy_at: float = 0.0
+        self._agent_activity: str = ""
+        self._agent_busy_ttl: float = 60.0
         # On-demand inventory refresh plumbing. ``_inventory_waiters`` are
         # asyncio.Futures that resolve when the next ``inventory`` frame
         # lands; multiple concurrent ``query_inventory`` calls can all
@@ -222,10 +285,19 @@ class GameAgentService:
         # ``_inline_log_min_interval`` is the minimum spacing between
         # consecutive inline pushes; bursts within that window are batched
         # and delivered as one combined push when the window expires.
-        self._inline_log_min_interval: float = 1.5
+        self._inline_log_min_interval: float = 12.0  # [THROTTLE] was 1.5
         self._last_inline_log_time: float = 0.0
         self._inline_log_pending: list[str] = []
         self._inline_log_flush_task: Optional[asyncio.Task] = None
+        # [DEDUP] mc-agent repeats identical status lines (e.g. "Nightfall —
+        # securing till dawn", "Picking up item!") every few seconds while it's
+        # stuck in a loop. Without dedup each one becomes a push and the dialog
+        # LLM re-narrates the same thing forever. Suppress a log line that was
+        # already seen within this window; refresh its timestamp on every
+        # repeat so a persistently-looping line stays muted after being said
+        # once, and only resurfaces once it's been quiet for the full window.
+        self._log_dedup_window: float = 120.0
+        self._recent_log_times: dict[str, float] = {}
 
         # Pacing state for inline screenshot push. mc-agent broadcasts at
         # 1Hz (configurable on its side via NEKO_AGENT_SCREENSHOT_INTERVAL_MS).
@@ -236,7 +308,7 @@ class GameAgentService:
         # collapsed (we keep only the latest pending and deliver it when
         # the window opens, so the dialog LLM always sees the most recent
         # visual rather than a stale one).
-        self._screenshot_stream_min_interval: float = 1.0
+        self._screenshot_stream_min_interval: float = 6.0  # [THROTTLE] was 1.0
         self._last_screenshot_push_time: float = 0.0
         self._pending_screenshot: Optional[tuple[bytes, str]] = None
         self._screenshot_flush_task: Optional[asyncio.Task] = None
@@ -310,14 +382,14 @@ class GameAgentService:
         # ``{status: "timeout"}`` shape — the LLM would see the cancel
         # error path instead of the clean timeout result.
         self._task_timeout = max(1.0, min(295.0, _f("task_timeout_seconds", 90.0)))
-        self._system_prompt_interval = max(1.0, _f("system_prompt_interval_seconds", 5.0))
+        self._system_prompt_interval = max(1.0, _f("system_prompt_interval_seconds", 15.0))
         self._skip_when_busy = _b("skip_system_prompt_if_busy", True)
         self._stream_screenshots = _b("stream_screenshots_to_llm", True)
         # Floor at 0.2s (i.e. 5 fps cap) — below that we're letting the
         # dialog LLM's context burn at the wire rate of mc-agent and the
         # rate-limit ceases to function as a throttle.
         self._screenshot_stream_min_interval = max(
-            0.2, _f("screenshot_stream_min_interval_seconds", 1.0)
+            0.2, _f("screenshot_stream_min_interval_seconds", 6.0)
         )
         size = max(1, _i("screenshot_cache_size", 3))
         self._screenshot_cache_size = size
@@ -384,6 +456,7 @@ class GameAgentService:
             on_task_finished=self._on_task_finished,
             on_alert=self._on_alert,
             on_inventory=self._on_inventory,
+            on_bot_status=self._on_bot_status,
             reconnect_interval=self._reconnect_interval,
             logger=self.logger,
         )
@@ -494,6 +567,12 @@ class GameAgentService:
         # 清空 = "回到 inv_at==0 未知"分支，由下一个 task_finished 重建。
         self._last_inventory = {}
         self._last_inventory_at = 0.0
+        # New session may be a different world — let its first inventory and
+        # activity surface fresh instead of being deduped against the old one.
+        self._last_pushed_inventory = None
+        self._mark_agent_idle()
+        self._agent_busy_at = 0.0
+        self._agent_activity = ""
         # ``_dispatched_history`` belongs to the just-ended session too —
         # next session's task_id space is independent, holding onto these
         # would only cause spurious "retroactive completion" cues if a
@@ -587,6 +666,73 @@ class GameAgentService:
         for w in waiters:
             if not w.done():
                 w.set_result(None)
+
+    async def _on_bot_status(self, data: Dict[str, Any]) -> None:
+        """Track the mc-agent's activity from a ``bot_status_nl`` frame.
+
+        The agent tags its status text with 🎯[按指令] (executing a dispatched
+        command) or 🤖[自主] (doing its own autonomous thing), and carries a
+        ``skill``/``kind`` when it's mid-action. We collapse that to a single
+        ``_agent_busy`` flag: busy unless it explicitly says it's idle/thinking
+        (or reports no skill and no kind). The autonomous nudge loop reads this
+        so it won't tell her to dispatch a fresh task over a running one.
+        """
+        text = str(data.get("text") or "")
+        skill = data.get("skill")
+        kind = data.get("kind")
+        idle_markers = ("空闲", "在想下一步", "空閒", "idle", "thinking", "nothing to do")
+        is_idle = ((not skill) and (not kind)) or any(m in text for m in idle_markers)
+        # [BUSY-RACE] Re-arm the busy latch only when the frame correlates to real
+        # ongoing work: a pending dispatched task, or an explicitly autonomous
+        # (自主) frame. The agent tags each status 🎯[按指令] (a DISPATCHED command)
+        # or 🤖[自主] (autonomous). With no pending task AND no 自主 tag, a busy
+        # frame is either a stale trailing report of the just-finished dispatch
+        # (按指令) or an untagged frame we can't attribute — so we do NOT re-arm.
+        # Conservative on purpose: a wrong "not busy" costs at most one extra
+        # nudge, but a wrong "busy" strands recovery for the full TTL while the
+        # agent is idle. (A precise call on untagged frames would need the mc-agent
+        # to stamp bot_status_nl with a run-id/seq — a protocol change on that
+        # side, out of scope here.)
+        if (not is_idle) and self._pending is None:
+            autonomous_tag = ("自主" in text) or ("🤖" in text)
+            if not autonomous_tag:
+                return
+        self._agent_busy = not is_idle
+        self._agent_busy_at = time.time()
+        self._agent_activity = text[:120]
+
+    def _mc_agent_busy(self) -> bool:
+        """True when the mc-agent recently reported it's actively executing.
+        Fresh within ``_agent_busy_ttl`` — a stale flag (no bot_status_nl for a
+        while) is treated as not-busy so the loop can resume nudging."""
+        return bool(self._agent_busy) and (time.time() - self._agent_busy_at) < self._agent_busy_ttl
+
+    def _mark_agent_idle(self) -> None:
+        """Drop the busy latch on a task-terminal path. Centralized so every
+        terminal clears it uniformly; ``_on_bot_status`` then won't re-arm from an
+        uncorrelated (no pending, non-autonomous) post-terminal frame."""
+        self._agent_busy = False
+
+    def _inventory_section_if_changed(self, top_n: int = 20) -> Optional[str]:
+        """Return the localized bag line ONLY when the inventory changed since
+        we last surfaced it, so the dialog LLM stops reciting the same bag every
+        nudge (the "有点人机" complaint). Returns ``None`` to omit the line."""
+        inv = self._last_inventory
+        if inv:
+            snapshot = tuple(sorted(
+                (str(k), int(v)) for k, v in inv.items() if int(v) > 0
+            ))
+            if snapshot == self._last_pushed_inventory:
+                return None
+            self._last_pushed_inventory = snapshot
+            items = sorted(inv.items(), key=lambda kv: -kv[1])
+            inv_str = "、".join(f"{n}×{c}" for n, c in items[:top_n])
+            return prompts.t("BAG_LINE", lang=self._lang, items=inv_str)
+        # inventory known-empty: mention "empty" once, only on the transition.
+        if self._last_inventory_at > 0 and self._last_pushed_inventory != ():
+            self._last_pushed_inventory = ()
+            return prompts.t("BAG_EMPTY_LINE", lang=self._lang)
+        return None
 
     def current_task_text(self) -> Optional[str]:
         """Return the text of the currently-pending task, or ``None`` if idle.
@@ -694,6 +840,7 @@ class GameAgentService:
                 if self._pending is my_pending:
                     self._pending = None
                     self._task_finished = True
+                    self._mark_agent_idle()  # [BUSY] local terminal — drop stale latch
             return {
                 "output": {
                     "error": "plugin is not started yet",
@@ -730,6 +877,7 @@ class GameAgentService:
                 if self._pending is my_pending:
                     self._pending = None
                     self._task_finished = True
+                    self._mark_agent_idle()  # [BUSY] local terminal — drop stale latch
                     # Send failure is functionally "task ended" from the
                     # autonomous loop's perspective — anchor so the
                     # keep_going nudge can prod the dialog LLM to retry
@@ -758,6 +906,7 @@ class GameAgentService:
                     # falls completely silent until the user prods her.
                     self._task_finished = True
                     self._last_task_finished_at = time.time()
+                    self._mark_agent_idle()  # [BUSY] local terminal — drop stale latch
             self._log_info("task timed out: {}", task[:80])
             return {
                 "status": "timeout",
@@ -865,6 +1014,10 @@ class GameAgentService:
                 ai_behavior="read",
                 parts=[{"type": "text", "text": text}],
                 priority=4,
+                # [COALESCE] agent narration is superseding — while the dialog
+                # LLM is busy, older queued log pushes collapse so it only ever
+                # reads the LATEST one, not a backlog it would recite in order.
+                coalesce_key="mc_log",
             )
         except Exception as exc:
             self._log_error(
@@ -928,6 +1081,10 @@ class GameAgentService:
                 ai_behavior="read",
                 parts=[{"type": "image", "data": img_bytes, "mime": mime}],
                 priority=3,
+                # [COALESCE] older frames are obsolete the moment a newer one
+                # exists — collapse queued screenshots so the LLM only sees the
+                # freshest view.
+                coalesce_key="mc_screenshot",
             )
         except Exception as exc:
             self._log_error(
@@ -943,16 +1100,12 @@ class GameAgentService:
         text_strip = text.strip() if isinstance(text, str) else ""
         if not text_strip:
             return
-        self._log_cache.append(text_strip)
-
-        # Inline push to the dialog LLM, rate-limited. The 5s autonomous
-        # nudge loop is still authoritative for "burst the full state
-        # alongside screenshots when nothing else is happening"; this
-        # inline path is for "agent just said something, get it in front
-        # of the dialog LLM now so it can weave into ongoing conversation
-        # without 5s of staleness".
-        self._schedule_inline_log_push(text_strip)
-
+        # [CONTROL-LOG] Agent state transitions (task-ended latch, "action
+        # selection" reset, connection-bounce → wake pending) must run on EVERY
+        # frame, ahead of the anti-parrot/dedup early-returns below. Otherwise a
+        # repeated control log — e.g. a second "Connection lost and re-established."
+        # inside the dedup window — would be dropped before it could wake a
+        # pending task, stranding the handler until ``task_timeout_seconds``.
         # The original integration sniffed log strings to track agent
         # state because some agent server implementations emit logs
         # before / instead of explicit ``task_finished`` frames. Keep
@@ -966,6 +1119,7 @@ class GameAgentService:
         if "task run ended" in text_strip:
             if self._pending is None:
                 self._task_finished = True
+                self._mark_agent_idle()  # [BUSY] local terminal — drop stale latch
         elif "action selection" in text_strip:
             # Setting False unconditionally is safe — at worst it
             # confirms what's already true (a task is in flight).
@@ -980,6 +1134,11 @@ class GameAgentService:
             # surprises us with a late frame for a known task after the
             # bounce, the retroactive cue path will still surface it.
             async with self._pending_lock:
+                # [BUSY] a bounce wiped the agent's queue — any prior busy
+                # bot_status_nl is stale; clear the latch (both branches) so the
+                # recovery keep-going nudge this path anchors isn't suppressed for
+                # the full _agent_busy_ttl, matching the task_finished/timeout paths.
+                self._mark_agent_idle()
                 pending = self._pending
                 if pending is None:
                     self._task_finished = True
@@ -998,6 +1157,37 @@ class GameAgentService:
                     # interrupted cue with no follow-up to push her into
                     # a new dispatch.
                     self._last_task_finished_at = time.time()
+        # [ANTI-PARROT] drop internal command/telemetry lines entirely (no cache,
+        # no push) so the dialog LLM never sees command syntax it would echo back
+        # as a task. This is what stops the goToCoordinates/attackEntity dispatch
+        # loop that was overriding the user's actual request.
+        if _INJECTION_LOG_RE.search(text_strip):
+            self._log_debug("[anti-parrot] dropped injection-shaped log: {}", text_strip[:80])
+            return
+        # [DEDUP] drop a line already seen within the dedup window so the
+        # dialog LLM doesn't re-narrate the mc-agent's repeated status spam.
+        # Refresh-on-hit keeps a persistently-looping line muted; prune the
+        # map when it grows so it can't leak memory over a long session.
+        _now = time.time()
+        _seen_at = self._recent_log_times.get(text_strip)
+        if _seen_at is not None and (_now - _seen_at) < self._log_dedup_window:
+            self._recent_log_times[text_strip] = _now
+            return
+        self._recent_log_times[text_strip] = _now
+        if len(self._recent_log_times) > 256:
+            _cutoff = _now - self._log_dedup_window
+            self._recent_log_times = {
+                k: v for k, v in self._recent_log_times.items() if v >= _cutoff
+            }
+        self._log_cache.append(text_strip)
+
+        # Inline push to the dialog LLM, rate-limited. The 5s autonomous
+        # nudge loop is still authoritative for "burst the full state
+        # alongside screenshots when nothing else is happening"; this
+        # inline path is for "agent just said something, get it in front
+        # of the dialog LLM now so it can weave into ongoing conversation
+        # without 5s of staleness".
+        self._schedule_inline_log_push(text_strip)
 
     def _normalize_screenshot_bytes(self, img_bytes: bytes, src_mime: str) -> tuple[bytes, str]:
         """Downscale + re-encode to JPEG under a *raw-bytes budget* so the pushed
@@ -1227,22 +1417,48 @@ class GameAgentService:
         return prompts.t("CAUSE_JOIN_SEP", lang=self._lang).join(parts)
 
     def _push_retroactive_completion_cue(self, info: Dict[str, Any]) -> None:
-        """Tell the dialog LLM that a previously-dispatched task (one she
-        explicitly overwrote, or that timed out on this side but kept
-        running on mc-agent) actually finished. Without this, she'd keep
-        narrating "I'm doing X" or fall silent — both are wrong, the
-        action really completed and she needs to know.
+        """Tell the dialog LLM the fate of a previously-dispatched task she's
+        no longer waiting on (one she explicitly overwrote, or that timed out
+        on this side but kept running on mc-agent). Without this she'd keep
+        narrating "I'm doing X" or fall silent — both wrong once the task has
+        reached a terminal state on mc-agent. The header honestly reflects
+        that state: a genuine completion says "actually finished"; a
+        non-completion (interrupted/superseded/failed/timeout, or status=ok
+        whose text signals it was blocked) says "ended without completing" so
+        she never narrates a phantom success.
         """
         task_text = str(
             info.get("task_text")
             or prompts.t("PLACEHOLDER_UNKNOWN", lang=self._lang)
         )
         status = str(info.get("status") or "ok")
+        # [NO-SWITCH-CUE] same as the live cue: a late interrupted/superseded
+        # frame is a task the LLM already replaced on purpose. Re-surfacing it
+        # only nudges another dispatch (the retry storm). Drop it silently.
+        if status.strip().lower() in ("interrupted", "superseded"):
+            self._log_debug("[no-switch-cue] skipping retroactive cue for status={}", status)
+            return
         text = str(info.get("text") or "").strip()
         inv = info.get("inventory")
 
+        # Only assert "actually finished" when the late frame reports a
+        # genuine completion. Two ways it can fail to be genuine:
+        #   1. an explicit non-completion status — mc-agent now distinguishes
+        #      ``interrupted`` / ``superseded`` / ``failed`` / ``timeout``;
+        #   2. status=="ok" but the free-text feedback signals the action was
+        #      actually blocked (target not found, no path…) — the same
+        #      status=ok-but-really-blocked quirk the live completion cue
+        #      re-labels (see ``text_signals_blocked``). Without this second
+        #      check the retroactive cue would say "其实跑完了（结果 ok）" while
+        #      its own feedback line shows "could not find path" — re-telling
+        #      猫娘 a success that never happened.
+        # ``.strip().lower()`` so a whitespace-padded "ok " still reads as ok.
+        is_genuine_ok = (
+            status.strip().lower() == "ok" and not text_signals_blocked(text)
+        )
+        header_key = "RETROACTIVE_HEADER" if is_genuine_ok else "RETROACTIVE_HEADER_ENDED"
         sections = [prompts.t(
-            "RETROACTIVE_HEADER", lang=self._lang,
+            header_key, lang=self._lang,
             task_text=task_text[:100], status=status,
         )]
         if text:
@@ -1286,6 +1502,24 @@ class GameAgentService:
         text = str(
             data.get("text") or data.get("data") or data.get("message") or ""
         )
+        # [ANTI-PARROT] a completion's free-text can carry the same mc-agent
+        # command/telemetry syntax the _on_log filter drops (e.g. "Finished
+        # goToCoordinates(118,64,-115,1)"). This ``text`` feeds both _log_cache
+        # (→ RECENT_EVENTS_BLOCK) and the completion / retroactive cue, so scrub
+        # the command syntax here at its single derivation point before any
+        # model-visible sink sees it — otherwise the dialog LLM re-dispatches the
+        # raw command. Scrub only the matched command syntax (``sub``, don't blank
+        # the whole line): a status="ok" completion whose text ALSO explains a
+        # block ("Failed goToCoordinates(...): could not find path") must keep the
+        # "could not find path" signal so ``text_signals_blocked`` still fires and
+        # the blocked action isn't relabeled a success.
+        if text and _INJECTION_LOG_RE.search(text):
+            scrubbed = _INJECTION_LOG_RE.sub("", text).strip()
+            self._log_debug(
+                "[anti-parrot] scrubbed command syntax from completion text: {!r} -> {!r}",
+                text[:80], scrubbed[:80],
+            )
+            text = scrubbed
         status = str(data.get("status") or "ok")
         # Optional explicit correlation: agents that opt in echo back
         # the ``task_id`` we sent on the matching ``task`` frame.
@@ -1378,6 +1612,13 @@ class GameAgentService:
                 pending.event.set()
                 self._task_finished = True
                 self._last_task_finished_at = time.time()
+                # [BUSY] a dispatched task just reached a terminal frame — the
+                # agent is no longer mid-action on it. Clear the busy flag now so
+                # the keep-going nudge isn't suppressed for the full
+                # ``_agent_busy_ttl`` while the agent sits idle awaiting the next
+                # dispatch; a fresh bot_status_nl re-arms it if the agent starts
+                # something on its own.
+                self._mark_agent_idle()
             elif bucket == "fifo":
                 # Legacy agent without task_id echo: pending exists, so
                 # treat this as its completion.
@@ -1396,6 +1637,9 @@ class GameAgentService:
                 pending.event.set()
                 self._task_finished = True
                 self._last_task_finished_at = time.time()
+                # [BUSY] see the "current" branch — clear the busy flag on a
+                # completed dispatch so the nudge loop can resume promptly.
+                self._mark_agent_idle()
             elif bucket == "retroactive":
                 # A previously-dispatched task (now no longer pending)
                 # actually finished — emit a cue so the dialog LLM
@@ -1410,10 +1654,15 @@ class GameAgentService:
                 # Don't touch ``_task_finished`` — current pending is
                 # genuinely still running.
             else:  # "unknown" or "stray"
-                # No pending and no known dispatch → drift. Update the
-                # nudge gate so the autonomous loop knows agent is idle.
+                # No pending and no known dispatch → drift (e.g. an autonomous
+                # task_finished). Mark idle so the nudge loop resumes, and clear
+                # the busy latch too: a terminal frame proves the agent reached
+                # idle, so the recovery/keep-going nudge shouldn't be suppressed
+                # for the full _agent_busy_ttl. A fresh bot_status_nl re-arms it
+                # if the agent starts something new.
                 if pending is None:
                     self._task_finished = True
+                    self._mark_agent_idle()  # [BUSY] terminal frame — drop stale latch
 
         # Emit the retroactive cue outside the lock.
         if retroactive is not None:
@@ -1467,10 +1716,10 @@ class GameAgentService:
         # keep_going now fires whenever idle, forever, paced by the cooldown.
         # (User present/absent gating is main_server's proactive SM job, not the
         # plugin's; the plugin only paces wake-ups.)
-        _IN_PROGRESS_AFTER = 8.0
-        _IN_PROGRESS_COOLDOWN = 8.0
-        _KEEP_GOING_AFTER = 8.0
-        _KEEP_GOING_COOLDOWN = 10.0
+        _IN_PROGRESS_AFTER = 30.0      # [THROTTLE] was 8.0
+        _IN_PROGRESS_COOLDOWN = 30.0   # [THROTTLE] was 8.0
+        _KEEP_GOING_AFTER = 30.0       # [THROTTLE] was 8.0
+        _KEEP_GOING_COOLDOWN = 45.0    # [THROTTLE] was 10.0
 
         self._log_debug(
             "system_prompt_loop started (in_progress={}/{}, keep_going={}/{}, "
@@ -1511,6 +1760,7 @@ class GameAgentService:
                     self._task_finished
                     and self._pending is None
                     and self._last_task_finished_at > 0
+                    and not self._mc_agent_busy()  # [BUSY] agent is executing on its own — don't tell her to dispatch
                 ):
                     since_finish = now - self._last_task_finished_at
                     since_last_keep = now - self._last_keep_going_nudge_at
@@ -1580,10 +1830,9 @@ class GameAgentService:
             "IN_PROGRESS_HEADER", lang=self._lang,
             pending_text=pending_text[:120], elapsed=f"{elapsed:.0f}",
         )]
-        if self._last_inventory:
-            items = sorted(self._last_inventory.items(), key=lambda kv: -kv[1])
-            inv_str = "、".join(f"{n}×{c}" for n, c in items[:15])
-            sections.append(prompts.t("BAG_LINE", lang=self._lang, items=inv_str))
+        inv_line = self._inventory_section_if_changed(top_n=15)
+        if inv_line:
+            sections.append(inv_line)
         sections.append(prompts.t("IN_PROGRESS_FOLLOWUP", lang=self._lang))
         body_text = prompts.t("CUE_PREFIX_IN_PROGRESS", lang=self._lang) + "\n" + "\n".join(sections)
         parts.append({"type": "text", "text": body_text})
@@ -1613,12 +1862,9 @@ class GameAgentService:
         it can ground its next decision.
         """
         sections: list[str] = []
-        if self._last_inventory:
-            items = sorted(self._last_inventory.items(), key=lambda kv: -kv[1])
-            inv_str = "、".join(f"{n}×{c}" for n, c in items[:20])
-            sections.append(prompts.t("BAG_LINE", lang=self._lang, items=inv_str))
-        elif self._last_inventory_at > 0:
-            sections.append(prompts.t("BAG_EMPTY_LINE", lang=self._lang))
+        inv_line = self._inventory_section_if_changed(top_n=20)
+        if inv_line:
+            sections.append(inv_line)
         sections.append(prompts.t("KEEP_GOING_BODY", lang=self._lang))
         body_text = prompts.t("CUE_PREFIX_IDLE", lang=self._lang) + "\n" + "\n".join(sections)
         parts: list[Dict[str, Any]] = [{"type": "text", "text": body_text}]
@@ -1653,12 +1899,9 @@ class GameAgentService:
         # Inventory line first — it's the closest thing to ground truth
         # we have, and the dialog LLM should know it before narrating
         # anything that depends on owned items.
-        if self._last_inventory:
-            items = sorted(self._last_inventory.items(), key=lambda kv: -kv[1])
-            inv_str = "、".join(f"{n}×{c}" for n, c in items[:20])
-            sections.append(prompts.t("BAG_LINE", lang=self._lang, items=inv_str))
-        elif self._last_inventory_at > 0:
-            sections.append(prompts.t("BAG_EMPTY_LINE", lang=self._lang))
+        inv_line = self._inventory_section_if_changed(top_n=20)
+        if inv_line:
+            sections.append(inv_line)
         if self._pending is not None:
             sections.append(prompts.t(
                 "CURRENT_TASK_LINE", lang=self._lang,
@@ -1668,7 +1911,11 @@ class GameAgentService:
             sections.append(prompts.t(
                 "RECENT_EVENTS_BLOCK", lang=self._lang, log_text=log_text,
             ))
-        if self._task_finished:
+        # [BUSY] The mc-agent's own activity counts as busy too: in autonomous
+        # play the plugin has no _pending task, so without this it would always
+        # look idle and keep telling her to dispatch. Use the BUSY body (narrate
+        # / stay quiet) whenever the agent is actively executing.
+        if self._task_finished and not self._mc_agent_busy():
             sections.append(prompts.t("SYSTEM_PROMPT_IDLE_BODY", lang=self._lang))
         else:
             sections.append(prompts.t("SYSTEM_PROMPT_BUSY_BODY", lang=self._lang))
@@ -1778,4 +2025,4 @@ class GameAgentService:
                 pass  # log emission itself failed — see comment above
 
 
-__all__ = ["GameAgentService", "PendingTask"]
+__all__ = ["GameAgentService", "PendingTask", "text_signals_blocked"]

--- a/plugin/plugins/game_agent_minecraft/smoke_local.py
+++ b/plugin/plugins/game_agent_minecraft/smoke_local.py
@@ -235,7 +235,10 @@ async def run(
         print(f"[smoke] ← result after {elapsed:.1f}s: {result}")
 
         status = result.get("status") if isinstance(result, dict) else None
-        rc = 0 if status in ("ok", "timeout", "interrupted") else 1
+        # ``superseded`` is mc-agent's "a newer task replaced this one" —
+        # a neutral non-completion, same class as ``interrupted``, not a
+        # failure. ``failed`` (genuine failure) still maps to rc=1.
+        rc = 0 if status in ("ok", "timeout", "interrupted", "superseded") else 1
         # ``timeout`` is a clean structured outcome (LLM-visible) — keep
         # exit 0 so CI doesn't read it as a hard failure; the elapsed
         # time + the printed result are enough for a human reader.

--- a/tests/unit/test_game_agent_minecraft_plugin.py
+++ b/tests/unit/test_game_agent_minecraft_plugin.py
@@ -1329,3 +1329,500 @@ def test_prompts_t_falls_back_to_english_on_missing_locale():
     en = prompts.t('TASK_NOT_CONNECTED', lang='en')
     assert out == en
 
+
+# ---------------------------------------------------------------------------
+# Status vocab tolerance — mc-agent now emits ``failed`` / ``superseded``
+# alongside ``ok`` / ``interrupted``. The plugin must tolerate every value
+# (no crash — status is an opaque string everywhere) AND frame the new ones
+# correctly: ``superseded`` is a non-completion, NOT a failure, and a late
+# non-completion frame must not be narrated as "actually finished".
+# ---------------------------------------------------------------------------
+
+
+def _make_facade(lang: str = "en"):
+    """Build just enough of the plugin facade to exercise
+    ``_format_completion_cue`` without the SDK ctx / WebSocket. That method
+    only reads ``self._lang`` + module-level prompts, so bypass __init__
+    (same object.__new__ trick used elsewhere in the suite for handler-only
+    methods)."""
+    from plugin.plugins.game_agent_minecraft import GameAgentMinecraftPlugin
+
+    facade = object.__new__(GameAgentMinecraftPlugin)
+    facade._lang = lang
+    return facade
+
+
+# " superseded " padded exercises the .strip() normalization; SUPERSEDED the
+# .lower(). Both must classify into the interrupted bucket, which [NO-SWITCH-CUE]
+# suppresses entirely (see _format_completion_cue's ``if is_interrupted``).
+@pytest.mark.parametrize(
+    "status", ["superseded", "interrupted", "SUPERSEDED", " superseded "]
+)
+def test_completion_cue_interrupted_is_suppressed(status):
+    """``interrupted`` / ``superseded`` is a task the LLM (or user) already
+    replaced on purpose — [NO-SWITCH-CUE] emits no completion cue at all so it
+    can't nudge another dispatch (the observed task-switch retry storm). The
+    case/whitespace variants must still land in that suppressed bucket."""
+    facade = _make_facade("en")
+    cue = facade._format_completion_cue({"status": status, "query": "mine 10 logs"})
+
+    assert cue == ""
+
+
+@pytest.mark.parametrize("status", ["failed", "FAILED"])
+def test_completion_cue_failed_still_reads_as_failure(status):
+    """Regression guard: ``failed`` must stay in the genuine-failure bucket
+    (it's not swept into the neutral interrupted carve-out); case-insensitive."""
+    from plugin.plugins.game_agent_minecraft import prompts
+
+    facade = _make_facade("en")
+    cue = facade._format_completion_cue(
+        {"status": status, "query": "reach the village"}
+    )
+
+    assert prompts.t("HEAD_VERB_FAILED", lang="en") in cue
+    assert prompts.t("COMPLETION_FOLLOWUP_FAILED", lang="en") in cue
+
+
+# "OK"/"ok " pin the .strip().lower() normalization for the success branch —
+# a case- or whitespace-sensitive regression would mislabel a success as failure.
+@pytest.mark.parametrize("status", ["ok", "OK", "ok "])
+def test_completion_cue_ok_still_reads_as_success(status):
+    """Regression guard: the new interrupted branch must not disturb the
+    success path (no detail → no blocked-marker rewrite)."""
+    from plugin.plugins.game_agent_minecraft import prompts
+
+    facade = _make_facade("en")
+    cue = facade._format_completion_cue({"status": status, "query": "place a torch"})
+
+    assert prompts.t("HEAD_VERB_SUCCESS", lang="en") in cue
+    assert prompts.t("COMPLETION_FOLLOWUP_SUCCESS", lang="en") in cue
+
+
+def test_completion_cue_ok_but_blocked_text_reads_as_blocked():
+    """status='ok' whose feedback text signals a blocked action (mc-agent's
+    'ok but really stuck' quirk) must be re-labeled blocked, not success —
+    guards the shared ``text_signals_blocked`` marker detection."""
+    from plugin.plugins.game_agent_minecraft import prompts
+
+    facade = _make_facade("en")
+    cue = facade._format_completion_cue(
+        {"status": "ok", "query": "walk to 博士", "text": "could not find path to 博士"}
+    )
+
+    assert prompts.t("HEAD_VERB_BLOCKED", lang="en") in cue
+    assert prompts.t("COMPLETION_FOLLOWUP_BLOCKED", lang="en") in cue
+    assert prompts.t("COMPLETION_FOLLOWUP_SUCCESS", lang="en") not in cue
+
+
+# ``failed`` / ``timeout`` are genuine non-completions the plugin still narrates
+# (honestly, via the 'ended without completing' header). ``interrupted`` /
+# ``superseded`` are handled separately below — [NO-SWITCH-CUE] drops them.
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["failed", "timeout"])
+async def test_retroactive_cue_non_completion_does_not_claim_finished(status):
+    """A late ``task_finished`` for an overwritten/abandoned task whose
+    status is a non-completion must use the honest 'ended without completing'
+    header — never RETROACTIVE_HEADER's 'actually finished', which would
+    fabricate a success the character would then narrate."""
+    from plugin.plugins.game_agent_minecraft import prompts
+
+    service, push_calls = _make_service()
+    service.set_lang("en")
+    # A task the plugin already moved on from, still tracked in history.
+    service._remember_dispatched("hist-1", "build a cobblestone wall")
+    service._seen_task_id_echo = True  # modern agent that echoes task_id
+
+    await service._on_task_finished(
+        {"status": status, "task_id": "hist-1", "text": "stopped partway"}
+    )
+
+    blob = "\n".join(
+        p.get("text") or ""
+        for call in push_calls
+        for p in (call.get("parts") or [])
+    )
+    # Cue fired (task_text is interpolated raw, stable across locales).
+    assert "build a cobblestone wall" in blob
+    ended = prompts.t(
+        "RETROACTIVE_HEADER_ENDED", lang="en",
+        task_text="build a cobblestone wall", status=status,
+    )
+    finished = prompts.t(
+        "RETROACTIVE_HEADER", lang="en",
+        task_text="build a cobblestone wall", status=status,
+    )
+    assert ended in blob
+    assert finished not in blob
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["superseded", "interrupted"])
+async def test_retroactive_cue_interrupted_superseded_is_suppressed(status):
+    """[NO-SWITCH-CUE]: a late ``interrupted`` / ``superseded`` frame is a task
+    the LLM already replaced on purpose. Re-surfacing it retroactively only
+    nudges another dispatch (the retry storm), so no cue fires at all — the
+    task text is never surfaced."""
+    service, push_calls = _make_service()
+    service.set_lang("en")
+    service._remember_dispatched("hist-1", "build a cobblestone wall")
+    service._seen_task_id_echo = True
+
+    await service._on_task_finished(
+        {"status": status, "task_id": "hist-1", "text": "stopped partway"}
+    )
+
+    blob = "\n".join(
+        p.get("text") or ""
+        for call in push_calls
+        for p in (call.get("parts") or [])
+    )
+    assert "build a cobblestone wall" not in blob
+
+
+@pytest.mark.asyncio
+async def test_retroactive_cue_ok_still_claims_finished():
+    """Regression guard: a genuine late completion (``ok``) keeps the
+    'actually finished' header — the whole reason the retroactive cue
+    exists is to tell the character the action she gave up on really did complete."""
+    from plugin.plugins.game_agent_minecraft import prompts
+
+    service, push_calls = _make_service()
+    service.set_lang("en")
+    service._remember_dispatched("hist-2", "smelt 8 iron")
+    service._seen_task_id_echo = True
+
+    await service._on_task_finished(
+        {"status": "ok", "task_id": "hist-2", "text": "done late"}
+    )
+
+    blob = "\n".join(
+        p.get("text") or ""
+        for call in push_calls
+        for p in (call.get("parts") or [])
+    )
+    finished = prompts.t(
+        "RETROACTIVE_HEADER", lang="en",
+        task_text="smelt 8 iron", status="ok",
+    )
+    ended = prompts.t(
+        "RETROACTIVE_HEADER_ENDED", lang="en",
+        task_text="smelt 8 iron", status="ok",
+    )
+    assert finished in blob
+    assert ended not in blob
+
+
+@pytest.mark.asyncio
+async def test_retroactive_cue_ok_but_blocked_text_does_not_claim_finished():
+    """A late status='ok' frame whose text signals a blocked action must NOT
+    assert 'actually finished' — the same 'ok but really stuck' quirk the live
+    completion cue guards. Otherwise the cue says 'it actually finished' while its
+    own feedback line shows 'could not find path'."""
+    from plugin.plugins.game_agent_minecraft import prompts
+
+    service, push_calls = _make_service()
+    service.set_lang("en")
+    service._remember_dispatched("hist-3", "walk to 博士")
+    service._seen_task_id_echo = True
+
+    await service._on_task_finished(
+        {"status": "ok", "task_id": "hist-3", "text": "could not find path to 博士"}
+    )
+
+    blob = "\n".join(
+        p.get("text") or ""
+        for call in push_calls
+        for p in (call.get("parts") or [])
+    )
+    ended = prompts.t(
+        "RETROACTIVE_HEADER_ENDED", lang="en",
+        task_text="walk to 博士", status="ok",
+    )
+    finished = prompts.t(
+        "RETROACTIVE_HEADER", lang="en",
+        task_text="walk to 博士", status="ok",
+    )
+    assert ended in blob
+    assert finished not in blob
+
+
+@pytest.mark.asyncio
+async def test_busy_flag_cleared_on_dispatched_task_completion():
+    """[BUSY] A dispatched task's terminal ``task_finished`` must clear the
+    ``_agent_busy`` flag set by an earlier bot_status_nl. Without this the
+    keep-going nudge stays suppressed for the full ``_agent_busy_ttl`` while
+    the agent sits idle after completing, leaving a silent avatar for ~1min."""
+    import time
+    from plugin.plugins.game_agent_minecraft.service import PendingTask
+
+    service, _ = _make_service()
+    service._seen_task_id_echo = True
+    service._pending = PendingTask(
+        task_text="mine 10 logs", event=asyncio.Event(),
+        start_time=0.0, task_id="t1",
+    )
+    # An in-flight bot_status_nl reported the agent busy; no later frame arrives.
+    service._agent_busy = True
+    service._agent_busy_at = time.time()
+
+    await service._on_task_finished({"status": "ok", "task_id": "t1"})
+
+    assert service._pending is None
+    assert service._agent_busy is False
+    assert service._mc_agent_busy() is False
+
+
+@pytest.mark.asyncio
+async def test_connection_bounce_wakes_pending_even_when_deduped():
+    """[CONTROL-LOG] A repeated 'Connection lost and re-established.' inside the
+    dedup window must still wake a pending task with the interrupted verdict.
+    The control-log state handling runs before the dedup early-return, so a
+    second reconnect during a pending task isn't dropped — otherwise the handler
+    would sit until ``task_timeout_seconds``."""
+    import time
+    from plugin.plugins.game_agent_minecraft.service import PendingTask
+
+    service, _ = _make_service()
+    pending = PendingTask(
+        task_text="dig straight down", event=asyncio.Event(),
+        start_time=0.0, task_id="t2",
+    )
+    service._pending = pending
+    # Same control log already seen moments ago → the dedup gate would drop it
+    # if state handling ran after the dedup return.
+    service._recent_log_times["Connection lost and re-established."] = time.time()
+
+    await service._on_log("Connection lost and re-established.")
+
+    assert service._pending is None
+    assert pending.result.get("status") == "interrupted"
+    assert pending.event.is_set()
+
+
+@pytest.mark.asyncio
+async def test_busy_flag_cleared_on_task_timeout():
+    """[BUSY] A dispatched task that ends via the local timeout path (no
+    task_finished ever arrives) must also clear _agent_busy — otherwise the
+    keep-going nudge stays suppressed for the full TTL after the timeout."""
+    import time
+
+    service, _ = _make_service()
+    service.configure({"task_timeout_seconds": 30.0})
+    service._client = _FakeClient()
+    service._task_timeout = 0.05  # force the timeout path fast
+    service._agent_busy = True
+    service._agent_busy_at = time.time()
+
+    out = await service.execute_minecraft_task(task="mine forever")
+
+    assert out["status"] == "timeout"
+    assert service._agent_busy is False
+    assert service._mc_agent_busy() is False
+
+
+@pytest.mark.asyncio
+async def test_busy_flag_cleared_on_connection_bounce():
+    """[BUSY] A connection bounce ends the pending task via _on_log and anchors
+    the recovery keep-going nudge — it must also clear _agent_busy, or that
+    nudge stays suppressed for the full TTL after the bounce."""
+    import time
+    from plugin.plugins.game_agent_minecraft.service import PendingTask
+
+    service, _ = _make_service()
+    service._pending = PendingTask(
+        task_text="build a wall", event=asyncio.Event(),
+        start_time=0.0, task_id="t3",
+    )
+    service._agent_busy = True
+    service._agent_busy_at = time.time()
+
+    await service._on_log("Connection lost and re-established.")
+
+    assert service._pending is None
+    assert service._agent_busy is False
+    assert service._mc_agent_busy() is False
+
+
+@pytest.mark.asyncio
+async def test_completion_text_with_command_syntax_is_filtered():
+    """[ANTI-PARROT] A task_finished whose free-text carries mc-agent command
+    syntax (goToCoordinates(...) etc.) must not reach _log_cache /
+    RECENT_EVENTS_BLOCK or the completion payload — the _on_log anti-parrot
+    filter only covers log frames, so completion text is sanitized at its
+    derivation point too, else the dialog LLM re-dispatches the raw command."""
+    from plugin.plugins.game_agent_minecraft.service import PendingTask
+
+    service, _ = _make_service()
+    service._seen_task_id_echo = True
+    pending = PendingTask(
+        task_text="go mine", event=asyncio.Event(), start_time=0.0, task_id="t4",
+    )
+    service._pending = pending
+
+    await service._on_task_finished(
+        {"status": "ok", "task_id": "t4",
+         "text": "Finished goToCoordinates(118,64,-115,1)"}
+    )
+
+    # Task still resolved as a success...
+    assert pending.result.get("status") == "ok"
+    assert pending.event.is_set()
+    # ...but the command-syntax text never reaches model-visible sinks.
+    assert all("goToCoordinates" not in ln for ln in service._log_cache)
+    assert "goToCoordinates" not in (pending.result.get("text") or "")
+
+
+@pytest.mark.asyncio
+async def test_completion_ok_with_command_syntax_keeps_block_signal():
+    """[ANTI-PARROT] Scrubbing command syntax must NOT strip a co-located block
+    signal: a status='ok' completion whose text is
+    'Failed goToCoordinates(...): could not find path' must keep 'could not find
+    path' so text_signals_blocked still fires (else the blocked action reads as a
+    success), while the command syntax is still removed."""
+    from plugin.plugins.game_agent_minecraft.service import (
+        PendingTask,
+        text_signals_blocked,
+    )
+
+    service, _ = _make_service()
+    service._seen_task_id_echo = True
+    pending = PendingTask(
+        task_text="walk to base", event=asyncio.Event(), start_time=0.0, task_id="t5",
+    )
+    service._pending = pending
+
+    await service._on_task_finished(
+        {"status": "ok", "task_id": "t5",
+         "text": "Failed goToCoordinates(1,2,3): could not find path"}
+    )
+
+    out_text = pending.result.get("text") or ""
+    assert "goToCoordinates" not in out_text        # command syntax scrubbed
+    assert "could not find path" in out_text          # block signal preserved
+    assert text_signals_blocked(out_text)             # → blocked, not success
+
+
+@pytest.mark.asyncio
+async def test_busy_flag_cleared_on_task_run_ended_log_when_idle():
+    """[BUSY] The 'task run ended' terminal log (no pending) marks the service
+    finished — it must also clear _agent_busy, matching the other terminal
+    paths, or the keep-going nudge stays suppressed for the full TTL."""
+    import time
+
+    service, _ = _make_service()
+    service._agent_busy = True
+    service._agent_busy_at = time.time()
+    assert service._pending is None
+
+    await service._on_log("task run ended")
+
+    assert service._task_finished is True
+    assert service._agent_busy is False
+    assert service._mc_agent_busy() is False
+
+
+@pytest.mark.asyncio
+async def test_busy_flag_cleared_on_stray_task_finished_when_idle():
+    """[BUSY] An autonomous/stray task_finished (no pending, no known id) marks
+    the service idle — it must also clear _agent_busy, or the recovery keep-going
+    nudge is suppressed for the full TTL after an autonomous completion."""
+    import time
+
+    service, _ = _make_service()
+    service._agent_busy = True
+    service._agent_busy_at = time.time()
+    assert service._pending is None
+
+    await service._on_task_finished(
+        {"status": "ok", "text": "did an autonomous thing"}
+    )
+
+    assert service._task_finished is True
+    assert service._agent_busy is False
+    assert service._mc_agent_busy() is False
+
+
+@pytest.mark.asyncio
+async def test_stale_bot_status_does_not_rearm_busy_after_terminal():
+    """[BUSY-RACE] A busy bot_status_nl that lags a completion (arrives within the
+    re-arm grace after a terminal marked idle) must NOT re-arm _agent_busy — else
+    recovery stalls for the full TTL while the agent is already idle."""
+    service, _ = _make_service()
+    service._seen_task_id_echo = True
+    service._pending = None
+
+    await service._on_task_finished({"status": "ok", "text": "done"})
+    assert service._agent_busy is False
+
+    # Untagged busy status lagging the completion — no tag, no pending → the
+    # conservative policy does not re-arm it.
+    await service._on_bot_status({"text": "mining", "skill": "mine", "kind": "cmd"})
+
+    assert service._agent_busy is False
+    assert service._mc_agent_busy() is False
+
+
+@pytest.mark.asyncio
+async def test_untagged_busy_rearms_while_task_pending():
+    """A busy bot_status_nl re-arms _agent_busy while a dispatched task is pending
+    — the pending task is the correlation, even for an untagged frame."""
+    from plugin.plugins.game_agent_minecraft.service import PendingTask
+
+    service, _ = _make_service()
+    service._pending = PendingTask(
+        task_text="mine ore", event=asyncio.Event(), start_time=0.0, task_id="tp",
+    )
+
+    await service._on_bot_status({"text": "working", "skill": "mine", "kind": "cmd"})
+
+    assert service._agent_busy is True
+    assert service._mc_agent_busy() is True
+
+
+@pytest.mark.asyncio
+async def test_stale_dispatched_status_does_not_rearm_when_idle():
+    """A dispatched-command status frame with no pending task is a stale trailing
+    report of the just-finished dispatch — it must not re-arm busy, regardless of
+    arrival time (a content correlation, not a timing guess)."""
+    service, _ = _make_service()
+    service._pending = None
+    service._agent_busy = False
+
+    await service._on_bot_status(
+        {"text": "🎯[按指令] goToCoordinates", "skill": "goto", "kind": "cmd"}
+    )
+
+    assert service._agent_busy is False
+    assert service._mc_agent_busy() is False
+
+
+@pytest.mark.asyncio
+async def test_untagged_busy_does_not_rearm_when_idle():
+    """[BUSY-RACE] An untagged busy bot_status_nl with no pending task can't be
+    correlated to real work (stale or unattributable) — the conservative policy
+    does not re-arm busy at any delay, so recovery isn't stranded for the TTL."""
+    service, _ = _make_service()
+    service._pending = None
+    service._agent_busy = False
+
+    await service._on_bot_status({"text": "still going", "skill": "mine", "kind": "cmd"})
+
+    assert service._agent_busy is False
+    assert service._mc_agent_busy() is False
+
+
+@pytest.mark.asyncio
+async def test_autonomous_status_rearms_busy_without_pending():
+    """An autonomous status frame reflects genuine ongoing activity — it re-arms
+    busy even with no pending task (autonomy is its own correlation)."""
+    service, _ = _make_service()
+    service._pending = None
+    service._agent_busy = False
+
+    await service._on_bot_status(
+        {"text": "🤖[自主] exploring", "skill": "explore", "kind": "auto"}
+    )
+
+    assert service._agent_busy is True
+


### PR DESCRIPTION
## 这个 PR 做什么

Minecraft 游戏代理插件（`game_agent_minecraft`）的对话密度 + 正确性调优，来自实机测试。原提交对着旧 main、落后 144 个 commit；本 PR 已 **rebase 到最新 main**，干净应用（改动文件与 main 无重叠，插件依赖的 SDK push `coalesce_key`/`priority` 参数在 main 上仍支持）。

### 主要改动
- **节流**：inline-log 1.5s→12s、截图流 1s→12s、系统提示 nudge 5s→30s、in-progress 8s→30s、keep-going 10s→45s。
- **去重**：120s 窗口内丢掉重复的 mc-agent 日志行（消除 "Nightfall…" / "Picking up item!" 刷屏）。
- **合并（coalesce）**：inline 日志 + 截图 push 加 coalesce key（`mc_log` / `mc_screenshot`），对话 LLM 只读最新一条，不再念一整串积压。
- **背包变化门控**：背包行只在库存真变了才播，不再每次 nudge 机械复述。
- **忙碌感知**：解析之前被忽略的 `bot_status_nl` → `_agent_busy`；agent 自己在执行时不再催「派新任务」。
- **防复读**：进 LLM 前过滤 mc-agent 内部指令/遥测日志（`goToCoordinates(...)`、`attackEntity(...)`、`!命令`、admin movement、stack-kick），避免被当成任务回声派发；并在 `minecraft_task` 描述里加规则强化。
- **不发切换提示**：抑制 interrupted/superseded 的完成提示（实时 + 追溯），它原本催「重新派」，引发任务切换风暴。
- **状态分档**：ok / 受阻 / interrupted·superseded（中性非完成）/ failed·timeout·断连（失败）四分档，docs + prompts + tests 同步。

### rebase 时做的清理（相对原提交）
1. `plugin.toml` `auto_start` 恢复 `false`（原提交为跑监控临时置 true）。
2. 删掉根目录 `_monitor/`（WS 日志诊断代理 + 其 `.gitignore`）——纯 dev 工具，不进 main。
3. 回滚 `config/prompts/prompts_chara.py` 里给全局人设加的「主要说中文」（超出插件范围 + 对非中文部署是 i18n 回归）。
4. 修复原提交自带的 6 个红测试：原提交的 **[NO-SWITCH-CUE]** 决定（interrupted/superseded 的完成提示直接 `return ""` / 追溯提示提前 return）与它自己的测试断言相矛盾。按 test-only 把测试改成断言抑制行为（interrupted/superseded 不发任何 cue；failed/timeout 仍走诚实的 “ended without completing” 追溯头）。

### 已知遗留（可另起 follow-up）
`_format_completion_cue` 里 `if is_interrupted: return ""` 之后还留着两个走不到的 `elif is_interrupted:` 分支（以及只被它们引用的 `HEAD_VERB_INTERRUPTED` / `COMPLETION_FOLLOWUP_INTERRUPTED` prompt 键）。为保持本 PR test-only、不牵动其它已通过的测试，暂未删；要清可另开 PR。

## 测试
主仓库 venv 跑 `tests/unit/test_game_agent_minecraft_plugin.py`：**56 passed**。
未触发 PR 回归报告闸门（没动 `app`/`main_logic`/`main_routers`/`memory`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化 Minecraft 任务状态处理，准确区分成功、失败、超时、中断及未完成等结果，避免将失败误报为成功。
  * 增加机器人活动状态反馈，并改善忙碌状态与任务结束后的状态恢复。
  * 过滤重复日志、内部命令和无效回显，减少信息刷屏。
  * 优化库存、日志及截图推送，降低重复通知并提升信息时效性。
  * 调整系统提示和截图推送频率，改善交互体验。
  * 补充多语言任务结束提示，并完善相关状态场景的测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->