### PR TITLE
feat(proactive): passive(read) 投递支持 coalesce_key 去重

### DIFF
--- a/app/main_server/character_runtime.py
+++ b/app/main_server/character_runtime.py
@@ -729,7 +729,9 @@ async def _handle_agent_event(event: dict):
                     if delivery_mode == "passive":
                         # Passive cues keep the direct enqueue-only path:
                         # they must NOT interrupt; the next user turn drains
-                        # them. The pacing manager only governs proactive.
+                        # them. The pacing manager only governs proactive, but
+                        # enqueue_agent_callback still honors coalesce_key so a
+                        # passive stream can dedup queued snapshots by key.
                         mgr.enqueue_agent_callback(callback)
                         logger.info(
                             "[EventBus] %s enqueued callback (passive); next user turn will carry it",

--- a/main_logic/core/lifecycle.py
+++ b/main_logic/core/lifecycle.py
@@ -1742,6 +1742,19 @@ class LifecycleMixin:
                 _selected, _deferred = _select_callbacks_within_token_budget(
                     list(self.pending_extra_replies), AGENT_CALLBACK_TOTAL_MAX_TOKENS
                 )
+                # Pull-model staleness guard (same contract as the voice/text
+                # delivery points): drop extras whose coalesce_key has a newer
+                # submission — the push-side eviction removes queue entries but
+                # cannot reach text already baked into final_prime_text, so the
+                # check must run here, synchronously between select and render
+                # (no await in between; a newer cue landing during the prime
+                # await below is an accepted residual window). Stale extras are
+                # NOT added to _deferred: their newer same-key mirror is (or will
+                # be) queued in their place.
+                _selected = [
+                    e for e in _selected
+                    if not self._coalesce_entry_is_stale(e)
+                ]
                 final_prime_text += _render_pending_extra_replies_by_origin(
                     _selected,
                     lang=_lang,

--- a/main_logic/core/proactive.py
+++ b/main_logic/core/proactive.py
@@ -1676,6 +1676,44 @@ class ProactiveMixin:
             # ``pending_extra_replies`` intact, so the queues legitimately
             # drift apart across user turns.
             delivery_id = callback.setdefault("_callback_delivery_id", uuid4().hex)
+            # Coalescing is OPT-IN and channel-agnostic: when a callback carries
+            # a non-empty ``coalesce_key``, the newest cue collapses any already
+            # queued cue that set the SAME key — mirroring
+            # ``ProactiveDeliveryManager.submit``'s dedup for the proactive path.
+            # Passive/read cues never reach that manager (they take this direct
+            # enqueue-only path so they don't interrupt), so without this a rapid
+            # ``ai_behavior="read"`` stream reusing one key would pile up stale
+            # snapshots, bounded only by the drop-oldest flood guard below. An
+            # empty key never coalesces, so no existing producer regresses. Both
+            # queues (and any delivery-ack future) must stay consistent: match on
+            # ``pending_agent_callbacks``, then evict the mirror rows by
+            # ``_callback_delivery_id`` (the two queues drift, so positional
+            # trimming is unreliable).
+            new_key = str(callback.get("coalesce_key") or "").strip()
+            if new_key:
+                superseded_ids: set[str] = set()
+                surviving: list[dict] = []
+                for _cb in self.pending_agent_callbacks:
+                    if str(_cb.get("coalesce_key") or "").strip() == new_key:
+                        resolve_callback_delivery_ack(_cb, False)
+                        _did = _cb.get("_callback_delivery_id")
+                        if _did:
+                            superseded_ids.add(_did)
+                    else:
+                        surviving.append(_cb)
+                if len(surviving) != len(self.pending_agent_callbacks):
+                    logger.debug(
+                        "[%s] coalesced %d queued callback(s) on key=%r (enqueue path)",
+                        self.lanlan_name,
+                        len(self.pending_agent_callbacks) - len(surviving),
+                        new_key,
+                    )
+                    self.pending_agent_callbacks = surviving
+                    if superseded_ids:
+                        self.pending_extra_replies = [
+                            _extra for _extra in self.pending_extra_replies
+                            if _extra.get("_callback_delivery_id") not in superseded_ids
+                        ]
             self.pending_agent_callbacks.append(callback)
             self.pending_extra_replies.append({
                 "_callback_delivery_id": delivery_id,

--- a/main_logic/core/proactive.py
+++ b/main_logic/core/proactive.py
@@ -1216,6 +1216,13 @@ class ProactiveMixin:
         "don't interrupt" promise is unchanged.
         """
         if self.is_goodbye_silent():
+            # goodbye_silent bypasses the manager, which is where the
+            # coalesce_key would normally be applied. The enqueue path reads the
+            # key off the callback dict, so carry the arg onto it here — else a
+            # same-key proactive stream deferred during goodbye_silent would not
+            # collapse.
+            if coalesce_key:
+                callback["coalesce_key"] = coalesce_key
             self.enqueue_agent_callback(callback)
             logger.debug(
                 "[%s] goodbye_silent queued proactive callback for later delivery",
@@ -1691,32 +1698,50 @@ class ProactiveMixin:
             # trimming is unreliable).
             new_key = str(callback.get("coalesce_key") or "").strip()
             if new_key:
-                superseded_ids: set[str] = set()
+                dropped = 0
                 surviving: list[dict] = []
                 for _cb in self.pending_agent_callbacks:
                     if str(_cb.get("coalesce_key") or "").strip() == new_key:
                         resolve_callback_delivery_ack(_cb, False)
-                        _did = _cb.get("_callback_delivery_id")
-                        if _did:
-                            superseded_ids.add(_did)
+                        # Mark retracted, don't just drop: trigger_agent_callbacks
+                        # snapshots pending_agent_callbacks into a local
+                        # voice_snapshot BEFORE its await (media stream /
+                        # inject_text_and_request_response) and re-filters that
+                        # snapshot only by DELIVERY_RETRACTED_KEY. A same-key cue
+                        # arriving mid-delivery must set the flag or the captured
+                        # old cue is still spoken even though its ack was already
+                        # resolved False — mirroring ProactiveDeliveryManager's
+                        # retract() and the other mid-delivery removal paths.
+                        _cb[DELIVERY_RETRACTED_KEY] = True
+                        dropped += 1
                     else:
                         surviving.append(_cb)
-                if len(surviving) != len(self.pending_agent_callbacks):
+                if dropped:
                     logger.debug(
                         "[%s] coalesced %d queued callback(s) on key=%r (enqueue path)",
-                        self.lanlan_name,
-                        len(self.pending_agent_callbacks) - len(surviving),
-                        new_key,
+                        self.lanlan_name, dropped, new_key,
                     )
                     self.pending_agent_callbacks = surviving
-                    if superseded_ids:
-                        self.pending_extra_replies = [
-                            _extra for _extra in self.pending_extra_replies
-                            if _extra.get("_callback_delivery_id") not in superseded_ids
-                        ]
+                # Evict voice mirrors by KEY, covering the extras-only orphan:
+                # drain_agent_callbacks_for_llm clears pending_agent_callbacks on
+                # a text user turn but keeps the paired pending_extra_replies for
+                # the hot-swap path, so a superseded cue can survive as an
+                # extras-only entry whose callback half is already gone —
+                # id-matching would miss it. Matching the stamped coalesce_key
+                # collapses both the paired and the orphaned voice mirrors.
+                if self.pending_extra_replies:
+                    kept_extras = [
+                        _extra for _extra in self.pending_extra_replies
+                        if str(_extra.get("coalesce_key") or "").strip() != new_key
+                    ]
+                    if len(kept_extras) != len(self.pending_extra_replies):
+                        self.pending_extra_replies = kept_extras
             self.pending_agent_callbacks.append(callback)
             self.pending_extra_replies.append({
                 "_callback_delivery_id": delivery_id,
+                # Stamp the coalesce_key so a later same-key cue can evict this
+                # voice mirror even after its callback half is drained.
+                "coalesce_key": new_key,
                 "origin": origin,
                 "summary": summary,
                 "detail": detail,

--- a/main_logic/core/proactive.py
+++ b/main_logic/core/proactive.py
@@ -21,7 +21,7 @@ Method-only mixin: every instance attribute is assigned in
 
 import asyncio
 import time
-from typing import Optional
+from typing import Any, Optional
 from main_logic.omni_realtime_client import OmniRealtimeClient
 from main_logic.omni_offline_client import OmniOfflineClient
 from utils.llm_client import AIMessage
@@ -674,6 +674,12 @@ class ProactiveMixin:
                     )
                     self._schedule_proactive_retry(self.proactive_manager.min_gap_s)
                     return False
+                # Pull-model staleness: a newer same-coalesce_key cue may have
+                # been submitted during the media await above (possibly still
+                # held by the manager, so the enqueue-time push scan never saw
+                # this snapshot). Retract the superseded cues so the re-filter
+                # below drops them and the purge sweeps both queues.
+                self._retract_stale_coalesced(voice_snapshot)
                 voice_snapshot[:] = [
                     cb for cb in voice_snapshot
                     if not cb.get(DELIVERY_RETRACTED_KEY)
@@ -896,6 +902,11 @@ class ProactiveMixin:
                 # gate closure that lands during the CLAIM/PHASE2 awaits in between.
                 if self._retract_unavailable_topic_hook_snapshots(callbacks_snapshot):
                     logger.info("[%s] trigger_agent_callbacks: topic hook dropped before claim — delivery gate closed mid-delivery", self.lanlan_name)
+                # Pull-model staleness (1/2, cheap early-out): the snapshot was
+                # checked OUT of pending_agent_callbacks before the claim awaits,
+                # so a newer same-coalesce_key cue enqueued meanwhile could not
+                # retract it via the push-side queue scan.
+                self._retract_stale_coalesced(callbacks_snapshot)
                 self._purge_retracted_agent_callback_extras(callbacks_snapshot)
                 active_callbacks = [
                     cb for cb in callbacks_snapshot
@@ -953,6 +964,10 @@ class ProactiveMixin:
             # still prompt the old text session.
             if self._retract_unavailable_topic_hook_snapshots(active_callbacks):
                 logger.info("[%s] trigger_agent_callbacks: topic hook dropped at prompt — delivery gate closed mid-delivery", self.lanlan_name)
+            # Pull-model staleness (2/2, authoritative — immediately before
+            # prompt_ephemeral): catches a newer same-coalesce_key cue that
+            # landed during the CLAIM/PHASE2 awaits above.
+            self._retract_stale_coalesced(active_callbacks)
             self._purge_retracted_agent_callback_extras(active_callbacks)
             active_callbacks = [
                 cb for cb in active_callbacks
@@ -1209,6 +1224,63 @@ class ProactiveMixin:
         self._coalesce_seq_counter = seq
         return seq
 
+    def _note_coalesce_submission(self, key: str, seq: int) -> None:
+        """Record the latest submission seq seen for a coalesce_key.
+
+        This map is the pull-model source of truth for staleness: enqueue-time
+        (push) retraction can only reach cues sitting in the LIVE queues, while
+        a cue checked out into a local delivery snapshot (voice_snapshot, the
+        text callbacks_snapshot, a hot-swap prime selection) is invisible to
+        that scan across its await boundaries. Delivery points therefore ask
+        ``_coalesce_entry_is_stale`` / ``_retract_stale_coalesced`` right
+        before actually sending, which needs the freshest seq per key recorded
+        HERE at both submission sites — including manager submit time, so a
+        newer cue still held by ProactiveDeliveryManager already marks older
+        same-key cues stale. Lazily initialised like ``_coalesce_seq_counter``."""
+        latest = getattr(self, "_coalesce_latest", None)
+        if latest is None:
+            latest = self._coalesce_latest = {}
+        if seq > latest.get(key, -1):
+            latest[key] = seq
+
+    def _coalesce_entry_is_stale(self, entry: Any) -> bool:
+        """True when ``entry``'s coalesce_key has a NEWER recorded submission.
+
+        Works for both callback dicts and their pending_extra_replies mirrors
+        (both carry ``coalesce_key`` + ``_coalesce_submit_seq``). Non-dict
+        (legacy plain-string extras), unkeyed, or unstamped entries are never
+        stale — coalescing stays strictly opt-in."""
+        if not isinstance(entry, dict):
+            return False
+        key = str(entry.get("coalesce_key") or "").strip()
+        seq = entry.get("_coalesce_submit_seq")
+        if not key or not isinstance(seq, int):
+            return False
+        latest = getattr(self, "_coalesce_latest", {}).get(key)
+        return isinstance(latest, int) and latest > seq
+
+    def _retract_stale_coalesced(self, callbacks: list) -> bool:
+        """Pull-model staleness sweep for a delivery-point snapshot.
+
+        Marks every same-key-superseded callback retracted (ack False), so the
+        existing ``DELIVERY_RETRACTED_KEY`` re-filters at each delivery point
+        drop it — exactly like the other mid-delivery removal paths. Returns
+        True when anything was retracted."""
+        retracted = False
+        for cb in callbacks:
+            if not isinstance(cb, dict) or cb.get(DELIVERY_RETRACTED_KEY):
+                continue
+            if self._coalesce_entry_is_stale(cb):
+                resolve_callback_delivery_ack(cb, False)
+                cb[DELIVERY_RETRACTED_KEY] = True
+                retracted = True
+        if retracted:
+            logger.info(
+                "[%s] retracted stale coalesced callback(s) at delivery point",
+                self.lanlan_name,
+            )
+        return retracted
+
     def submit_proactive_callback(
         self,
         callback: dict,
@@ -1233,8 +1305,15 @@ class ProactiveMixin:
         # release of an older respond cue from a newer direct-queued read cue.
         if coalesce_key:
             callback["coalesce_key"] = coalesce_key
-        if str(callback.get("coalesce_key") or "").strip():
+        _key = str(callback.get("coalesce_key") or "").strip()
+        if _key:
             callback.setdefault("_coalesce_submit_seq", self._next_coalesce_seq())
+            # Bump the latest-seq map AT SUBMIT TIME (not only at enqueue): a
+            # newer cue may sit in ProactiveDeliveryManager through a whole
+            # playback window before reaching enqueue, and the pull-model
+            # delivery guards must already see older same-key cues as stale
+            # during exactly that window.
+            self._note_coalesce_submission(_key, callback["_coalesce_submit_seq"])
         if self.is_goodbye_silent():
             self.enqueue_agent_callback(callback)
             logger.debug(
@@ -1281,6 +1360,15 @@ class ProactiveMixin:
             return
         for callback in callbacks:
             self.enqueue_agent_callback(callback)
+        # enqueue-time coalescing may retract a released cue on the spot (an
+        # older manager-held respond cue losing to a newer same-key cue that was
+        # direct-queued while it waited out playback). If the WHOLE batch died
+        # that way, nothing below will emit a playback/text signal — free the
+        # manager's inflight slot now (mirrors the pre-enqueue empty check
+        # above) instead of stalling the next cue until the inflight timeout.
+        if all(cb.get(DELIVERY_RETRACTED_KEY) for cb in callbacks):
+            self.proactive_manager.release_inflight_noop()
+            return
         # NOTE: images carried by these cues (push_message media_parts for
         # ai_behavior="respond") are streamed at the ACTUAL delivery point
         # inside trigger_agent_callbacks via _stream_cb_media — NOT here. That
@@ -1716,8 +1804,13 @@ class ProactiveMixin:
                 if not isinstance(new_seq, int):
                     new_seq = self._next_coalesce_seq()
                     callback["_coalesce_submit_seq"] = new_seq
+                # Feed the pull-model staleness map: delivery-point guards
+                # (_retract_stale_coalesced / _coalesce_entry_is_stale) compare
+                # in-flight snapshot entries against this latest seq.
+                self._note_coalesce_submission(new_key, new_seq)
                 incoming_superseded = False
                 dropped = 0
+                superseded_ids: set = set()
                 surviving: list[dict] = []
                 for _cb in self.pending_agent_callbacks:
                     # isinstance guard: the queue should hold dicts, but never let
@@ -1745,6 +1838,9 @@ class ProactiveMixin:
                         resolve_callback_delivery_ack(_cb, False)
                         _cb[DELIVERY_RETRACTED_KEY] = True
                         dropped += 1
+                        _did = _cb.get("_callback_delivery_id")
+                        if _did:
+                            superseded_ids.add(_did)
                 if dropped:
                     logger.debug(
                         "[%s] coalesced %d queued callback(s) on key=%r seq=%d (enqueue path)",
@@ -1762,8 +1858,16 @@ class ProactiveMixin:
                 if self.pending_extra_replies:
                     kept_extras: list = []
                     for _extra in self.pending_extra_replies:
-                        if not (isinstance(_extra, dict)
-                                and str(_extra.get("coalesce_key") or "").strip() == new_key):
+                        if not isinstance(_extra, dict):
+                            kept_extras.append(_extra)
+                            continue
+                        # A mirror paired with a just-retracted callback is
+                        # evicted by delivery_id even when it predates the
+                        # coalesce_key stamp (legacy mirror shape) — key-only
+                        # matching would orphan it for the hot-swap path.
+                        if _extra.get("_callback_delivery_id") in superseded_ids:
+                            continue
+                        if str(_extra.get("coalesce_key") or "").strip() != new_key:
                             kept_extras.append(_extra)
                             continue
                         _ex_seq = _extra.get("_coalesce_submit_seq")
@@ -1852,6 +1956,11 @@ class ProactiveMixin:
                 "[%s] drain_agent_callbacks_for_llm: topic hook dropped before passive drain — delivery gate closed",
                 self.lanlan_name,
             )
+        # Pull-model staleness: uniform with the voice/text/hot-swap delivery
+        # points — a cue restored from a failed proactive attempt (or any path
+        # that re-appends without the push-side scan) must not deliver once a
+        # newer same-coalesce_key cue exists.
+        self._retract_stale_coalesced(candidate_callbacks)
         self._purge_retracted_agent_callback_extras(candidate_callbacks)
         self._purge_retracted_agent_callbacks()
         active_callbacks = [

--- a/main_logic/core/proactive.py
+++ b/main_logic/core/proactive.py
@@ -1200,6 +1200,15 @@ class ProactiveMixin:
         except Exception:
             return None
 
+    def _next_coalesce_seq(self) -> int:
+        """Monotonic per-manager submission counter shared by the manager-held
+        (submit_proactive_callback) and direct-enqueue (enqueue_agent_callback)
+        coalescing paths, so same-key newest-wins is consistent across both.
+        Lazily initialised — the core mixins have no single __init__."""
+        seq = getattr(self, "_coalesce_seq_counter", 0) + 1
+        self._coalesce_seq_counter = seq
+        return seq
+
     def submit_proactive_callback(
         self,
         callback: dict,
@@ -1215,14 +1224,18 @@ class ProactiveMixin:
         their existing direct enqueue-only path so ``delivery="passive"``'s
         "don't interrupt" promise is unchanged.
         """
+        # Persist the coalesce_key + a monotonic submission seq onto the callback
+        # up front so it survives the manager→enqueue handoff (the manager stores
+        # the key on its cue, not the callback dict) and both delivery paths order
+        # by the same clock. Without the writeback a manager-released respond cue
+        # reaches enqueue with an empty key and skips coalescing ("Manager key is
+        # lost"); without the seq the enqueue path cannot tell a late manager
+        # release of an older respond cue from a newer direct-queued read cue.
+        if coalesce_key:
+            callback["coalesce_key"] = coalesce_key
+        if str(callback.get("coalesce_key") or "").strip():
+            callback.setdefault("_coalesce_submit_seq", self._next_coalesce_seq())
         if self.is_goodbye_silent():
-            # goodbye_silent bypasses the manager, which is where the
-            # coalesce_key would normally be applied. The enqueue path reads the
-            # key off the callback dict, so carry the arg onto it here — else a
-            # same-key proactive stream deferred during goodbye_silent would not
-            # collapse.
-            if coalesce_key:
-                callback["coalesce_key"] = coalesce_key
             self.enqueue_agent_callback(callback)
             logger.debug(
                 "[%s] goodbye_silent queued proactive callback for later delivery",
@@ -1691,57 +1704,91 @@ class ProactiveMixin:
             # enqueue-only path so they don't interrupt), so without this a rapid
             # ``ai_behavior="read"`` stream reusing one key would pile up stale
             # snapshots, bounded only by the drop-oldest flood guard below. An
-            # empty key never coalesces, so no existing producer regresses. Both
-            # queues (and any delivery-ack future) must stay consistent: match on
-            # ``pending_agent_callbacks``, then evict the mirror rows by
-            # ``_callback_delivery_id`` (the two queues drift, so positional
-            # trimming is unreliable).
+            # empty key never coalesces, so no existing producer regresses.
             new_key = str(callback.get("coalesce_key") or "").strip()
             if new_key:
+                # Submission-order stamp: cues carry a monotonic seq assigned at
+                # submit_proactive_callback (manager-held respond cues) or here
+                # (direct read cues), so newest-wins holds ACROSS the manager and
+                # enqueue paths. A manager release of an OLDER respond cue must not
+                # overwrite a newer direct-queued read cue sharing the key.
+                new_seq = callback.get("_coalesce_submit_seq")
+                if not isinstance(new_seq, int):
+                    new_seq = self._next_coalesce_seq()
+                    callback["_coalesce_submit_seq"] = new_seq
+                incoming_superseded = False
                 dropped = 0
                 surviving: list[dict] = []
                 for _cb in self.pending_agent_callbacks:
-                    if str(_cb.get("coalesce_key") or "").strip() == new_key:
-                        resolve_callback_delivery_ack(_cb, False)
-                        # Mark retracted, don't just drop: trigger_agent_callbacks
+                    # isinstance guard: the queue should hold dicts, but never let
+                    # a malformed entry raise here (the broad except below would
+                    # silently drop the whole enqueue and lose this callback).
+                    if not (isinstance(_cb, dict)
+                            and str(_cb.get("coalesce_key") or "").strip() == new_key):
+                        surviving.append(_cb)
+                        continue
+                    _old_seq = _cb.get("_coalesce_submit_seq")
+                    _old_seq = _old_seq if isinstance(_old_seq, int) else -1
+                    if _old_seq > new_seq:
+                        # A newer same-key cue is already queued → the incoming one
+                        # (an older manager-released respond) loses; keep the queued.
+                        incoming_superseded = True
+                        surviving.append(_cb)
+                    else:
+                        # Incoming is newer → retract the older queued cue. Mark
+                        # retracted, don't just drop: trigger_agent_callbacks
                         # snapshots pending_agent_callbacks into a local
-                        # voice_snapshot BEFORE its await (media stream /
-                        # inject_text_and_request_response) and re-filters that
-                        # snapshot only by DELIVERY_RETRACTED_KEY. A same-key cue
-                        # arriving mid-delivery must set the flag or the captured
-                        # old cue is still spoken even though its ack was already
-                        # resolved False — mirroring ProactiveDeliveryManager's
-                        # retract() and the other mid-delivery removal paths.
+                        # voice_snapshot BEFORE its await and re-filters it only by
+                        # DELIVERY_RETRACTED_KEY, so an in-flight cue must carry the
+                        # flag or it is still spoken even though its ack was resolved
+                        # False. Mirrors retract() / _drop_pending_topic_hooks_for_voice.
+                        resolve_callback_delivery_ack(_cb, False)
                         _cb[DELIVERY_RETRACTED_KEY] = True
                         dropped += 1
-                    else:
-                        surviving.append(_cb)
                 if dropped:
                     logger.debug(
-                        "[%s] coalesced %d queued callback(s) on key=%r (enqueue path)",
-                        self.lanlan_name, dropped, new_key,
+                        "[%s] coalesced %d queued callback(s) on key=%r seq=%d (enqueue path)",
+                        self.lanlan_name, dropped, new_key, new_seq,
                     )
                     self.pending_agent_callbacks = surviving
-                # Evict voice mirrors by KEY, covering the extras-only orphan:
-                # drain_agent_callbacks_for_llm clears pending_agent_callbacks on
-                # a text user turn but keeps the paired pending_extra_replies for
+                # Evict OLDER same-key voice mirrors by key, covering the extras-only
+                # orphan: drain_agent_callbacks_for_llm clears pending_agent_callbacks
+                # on a text user turn but keeps the paired pending_extra_replies for
                 # the hot-swap path, so a superseded cue can survive as an
-                # extras-only entry whose callback half is already gone —
-                # id-matching would miss it. Matching the stamped coalesce_key
-                # collapses both the paired and the orphaned voice mirrors.
+                # extras-only entry whose callback half is gone — id-matching misses
+                # it. The isinstance guard also skips legacy plain-string extras that
+                # _render_pending_extra_replies_by_origin tolerates (calling .get()
+                # on a str would raise into the broad except and lose the enqueue).
                 if self.pending_extra_replies:
-                    kept_extras = [
-                        _extra for _extra in self.pending_extra_replies
-                        if str(_extra.get("coalesce_key") or "").strip() != new_key
-                    ]
+                    kept_extras: list = []
+                    for _extra in self.pending_extra_replies:
+                        if not (isinstance(_extra, dict)
+                                and str(_extra.get("coalesce_key") or "").strip() == new_key):
+                            kept_extras.append(_extra)
+                            continue
+                        _ex_seq = _extra.get("_coalesce_submit_seq")
+                        _ex_seq = _ex_seq if isinstance(_ex_seq, int) else -1
+                        if _ex_seq > new_seq:
+                            # A newer snapshot already mirrored → incoming loses.
+                            incoming_superseded = True
+                            kept_extras.append(_extra)
+                        # else: drop the older mirror
                     if len(kept_extras) != len(self.pending_extra_replies):
                         self.pending_extra_replies = kept_extras
+                if incoming_superseded:
+                    # A newer same-key cue already won on both queues; don't enqueue
+                    # this stale one (ack it False so any waiter unblocks).
+                    resolve_callback_delivery_ack(callback, False)
+                    callback[DELIVERY_RETRACTED_KEY] = True
+                    return
             self.pending_agent_callbacks.append(callback)
             self.pending_extra_replies.append({
                 "_callback_delivery_id": delivery_id,
-                # Stamp the coalesce_key so a later same-key cue can evict this
-                # voice mirror even after its callback half is drained.
+                # Stamp the coalesce_key + submission seq so a later same-key cue
+                # can evict this voice mirror even after its callback half is
+                # drained, and only when the incoming cue is actually newer.
                 "coalesce_key": new_key,
+                "_coalesce_submit_seq": callback.get("_coalesce_submit_seq"),
                 "origin": origin,
                 "summary": summary,
                 "detail": detail,

--- a/plugin/sdk/shared/core/push_message_schema.py
+++ b/plugin/sdk/shared/core/push_message_schema.py
@@ -376,10 +376,12 @@ def translate_push_message(
         "schema": SCHEMA_VERSION,
         "source": source,
         "priority": priority,
-        # Optional coalescing key for ProactiveDeliveryManager (OPT-IN):
-        # queued proactive cues sharing the SAME explicit key collapse to the
-        # newest. Empty → never coalesce (unique per cue). Set distinct keys
-        # per cue CATEGORY so distinct important cues don't drop each other.
+        # Optional coalescing key (OPT-IN): queued cues sharing the SAME
+        # explicit key collapse to the newest, on BOTH delivery paths — the
+        # ProactiveDeliveryManager (ai_behavior="respond") and the direct
+        # enqueue-only queue (ai_behavior="read"). Empty → never coalesce
+        # (unique per cue). Set distinct keys per cue CATEGORY so distinct
+        # important cues don't drop each other.
         "coalesce_key": coalesce_key if isinstance(coalesce_key, str) else "",
         "visibility": final_visibility,
         "ai_behavior": final_ai_behavior,

--- a/tests/unit/test_proactive_delivery.py
+++ b/tests/unit/test_proactive_delivery.py
@@ -14,6 +14,7 @@ import pytest
 import main_logic.core as core_module
 from main_logic.proactive_delivery import (
     DELIVERY_ACK_FUTURE_KEY,
+    DELIVERY_RETRACTED_KEY,
     ProactiveDeliveryManager,
     effective_priority,
 )
@@ -331,3 +332,30 @@ def test_enqueue_coalesce_resolves_superseded_ack_false():
     mgr.enqueue_agent_callback(_passive_cb("new", coalesce_key="k"))
     assert fut.done() and fut.result is False
     assert [c["summary"] for c in mgr.pending_agent_callbacks] == ["new"]
+
+
+def test_enqueue_coalesce_marks_superseded_retracted():
+    # A superseded cue must be FLAGGED retracted, not merely dropped: a voice
+    # delivery already in flight snapshots pending_agent_callbacks before its
+    # await and re-filters that snapshot only by DELIVERY_RETRACTED_KEY. Without
+    # the flag the captured stale cue is still spoken even though its ack was
+    # resolved False.
+    mgr = _make_session_mgr()
+    old = _passive_cb("old", coalesce_key="k")
+    mgr.enqueue_agent_callback(old)
+    mgr.enqueue_agent_callback(_passive_cb("new", coalesce_key="k"))
+    assert old.get(DELIVERY_RETRACTED_KEY) is True
+    assert [c["summary"] for c in mgr.pending_agent_callbacks] == ["new"]
+
+
+def test_enqueue_coalesce_evicts_drained_extras_orphan():
+    # After a text user turn, drain_agent_callbacks_for_llm clears the callback
+    # side but KEEPS the paired voice mirror in pending_extra_replies. A later
+    # same-key cue has no callback half to match by id, so eviction must be by
+    # the stamped coalesce_key — otherwise hot-swap injects BOTH snapshots.
+    mgr = _make_session_mgr()
+    mgr.enqueue_agent_callback(_passive_cb("old snapshot", coalesce_key="gs"))
+    mgr.pending_agent_callbacks.clear()  # simulate drain (callback side only)
+    assert [r["summary"] for r in mgr.pending_extra_replies] == ["old snapshot"]
+    mgr.enqueue_agent_callback(_passive_cb("new snapshot", coalesce_key="gs"))
+    assert [r["summary"] for r in mgr.pending_extra_replies] == ["new snapshot"]

--- a/tests/unit/test_proactive_delivery.py
+++ b/tests/unit/test_proactive_delivery.py
@@ -348,6 +348,41 @@ def test_enqueue_coalesce_marks_superseded_retracted():
     assert [c["summary"] for c in mgr.pending_agent_callbacks] == ["new"]
 
 
+def test_enqueue_coalesce_older_manager_release_loses_to_newer_read():
+    # Cross-path newest-wins: a respond cue held in ProactiveDeliveryManager
+    # (submission seq stamped at submit_proactive_callback) that is RELEASED into
+    # enqueue AFTER a newer same-key read cue was direct-queued must NOT overwrite
+    # the newer read cue. The submission seq lets enqueue tell the late manager
+    # release from a genuinely newer cue.
+    mgr = _make_session_mgr()
+    # A respond cue stamped early, then held by the manager during playback.
+    respond = _passive_cb("respond held", coalesce_key="k")
+    respond["_coalesce_submit_seq"] = 1
+    # A newer read cue enqueued directly gets a later seq.
+    mgr._coalesce_seq_counter = 5  # next direct-enqueue seq = 6 > 1
+    mgr.enqueue_agent_callback(_passive_cb("newer read", coalesce_key="k"))
+    # The manager now releases the OLDER respond cue into the same queue.
+    mgr.enqueue_agent_callback(respond)
+    # Newer read cue survives; the stale respond is dropped AND retracted (so any
+    # in-flight snapshot that captured it discards it too).
+    assert [c["summary"] for c in mgr.pending_agent_callbacks] == ["newer read"]
+    assert respond.get(DELIVERY_RETRACTED_KEY) is True
+
+
+def test_enqueue_coalesce_guards_legacy_string_extra():
+    # pending_extra_replies may hold a legacy plain-string entry that the render
+    # path tolerates. A keyed enqueue must not raise on it (the broad except in
+    # enqueue_agent_callback would otherwise swallow the error and silently drop
+    # the new callback).
+    mgr = _make_session_mgr()
+    mgr.pending_extra_replies.append("legacy plain string")  # non-dict entry
+    mgr.enqueue_agent_callback(_passive_cb("fresh", coalesce_key="k"))
+    assert "fresh" in [
+        c["summary"] for c in mgr.pending_agent_callbacks
+    ]  # new callback survived, not swallowed
+    assert "legacy plain string" in mgr.pending_extra_replies  # legacy left intact
+
+
 def test_enqueue_coalesce_evicts_drained_extras_orphan():
     # After a text user turn, drain_agent_callbacks_for_llm clears the callback
     # side but KEEPS the paired voice mirror in pending_extra_replies. A later

--- a/tests/unit/test_proactive_delivery.py
+++ b/tests/unit/test_proactive_delivery.py
@@ -455,6 +455,35 @@ async def test_deliver_batch_releases_inflight_when_all_superseded():
     assert [c["summary"] for c in mgr.pending_agent_callbacks] == ["newer read"]
 
 
+def test_drain_skips_read_superseded_by_manager_held_respond():
+    # Codex scenario: a newer respond cue is submitted and PARKED in the
+    # delivery manager (playback / min-gap keeps it from releasing). If the
+    # user's next text turn arrives first, the passive drain must already see
+    # the older same-key read cue as stale — the submit-time bump of
+    # _coalesce_latest plus the drain-point pull check cover the window where
+    # release-time coalescing has not run yet.
+    mgr = _make_session_mgr()
+    old = _passive_cb("stale read", coalesce_key="k")
+    fut = _FakeAckFuture()
+    old[DELIVERY_ACK_FUTURE_KEY] = fut
+    mgr.enqueue_agent_callback(old)
+
+    class _MgrStub:  # manager holds the newer cue; never releases in this test
+        def submit(self, cb, **kw):
+            pass
+
+    mgr.proactive_manager = _MgrStub()
+    mgr.is_goodbye_silent = lambda: False
+    core_module.LLMSessionManager.submit_proactive_callback(
+        mgr, {"status": "completed", "summary": "newer respond"},
+        priority=1, coalesce_key="k",
+    )
+    out = core_module.LLMSessionManager.drain_agent_callbacks_for_llm(mgr)
+    assert out == ""                      # stale read NOT injected
+    assert fut.done() and fut.result is False
+    assert mgr.pending_agent_callbacks == []  # purged, not redelivered later
+
+
 def test_enqueue_coalesce_evicts_legacy_mirror_by_delivery_id():
     # A mirror created before the coalesce_key stamp existed (legacy shape,
     # paired by _callback_delivery_id only) must still be evicted when its

--- a/tests/unit/test_proactive_delivery.py
+++ b/tests/unit/test_proactive_delivery.py
@@ -11,6 +11,7 @@ import asyncio
 
 import pytest
 
+import main_logic.core as core_module
 from main_logic.proactive_delivery import (
     DELIVERY_ACK_FUTURE_KEY,
     ProactiveDeliveryManager,
@@ -238,3 +239,95 @@ async def test_stale_cue_dropped_by_ttl():
     mgr.on_playback_end()
     await _settle()
     assert delivered == []          # dropped as stale, never spoken
+
+
+# ── enqueue_agent_callback path (passive / ai_behavior="read") ────────────────
+# The ProactiveDeliveryManager above only governs proactive ("respond") cues.
+# Passive/read cues bypass it and land directly in pending_agent_callbacks; the
+# same OPT-IN coalesce_key semantics apply there so a rapid read-stream can
+# dedup queued snapshots by key instead of piling up until the flood guard.
+
+
+class _FakeAckFuture:
+    """Minimal delivery-ack future stand-in (no event loop needed)."""
+
+    def __init__(self):
+        self._done = False
+        self.result = None
+
+    def done(self):
+        return self._done
+
+    def set_result(self, value):
+        self._done = True
+        self.result = value
+
+
+def _make_session_mgr():
+    mgr = core_module.LLMSessionManager.__new__(core_module.LLMSessionManager)
+    mgr.lanlan_name = "Test"
+    mgr.pending_agent_callbacks = []
+    mgr.pending_extra_replies = []
+    # Identity normalizer: isolate the per-source token-budget path, which is
+    # irrelevant to coalescing and pulls in config/budget dependencies.
+    mgr._normalize_context_text_for_source = lambda _src, text: text
+    return mgr
+
+
+def _passive_cb(summary, *, coalesce_key="", **extra):
+    cb = {
+        "event": "agent_task_callback",
+        "origin": "event",
+        "summary": summary,
+        "detail": summary,
+        "status": "completed",
+        "coalesce_key": coalesce_key,
+    }
+    cb.update(extra)
+    return cb
+
+
+def test_enqueue_coalesce_same_key_newest_replaces():
+    # Same explicit key → newest collapses the older queued cue, on BOTH the
+    # LLM-inject queue and its voice-mode mirror (which drift, so the mirror is
+    # evicted by delivery_id, not by position).
+    mgr = _make_session_mgr()
+    mgr.enqueue_agent_callback(_passive_cb("old snapshot", coalesce_key="gamestate"))
+    mgr.enqueue_agent_callback(_passive_cb("new snapshot", coalesce_key="gamestate"))
+    assert [c["summary"] for c in mgr.pending_agent_callbacks] == ["new snapshot"]
+    assert [r["summary"] for r in mgr.pending_extra_replies] == ["new snapshot"]
+
+
+def test_enqueue_coalesce_empty_key_never_collapses():
+    # Unset / explicit-empty key never coalesces — the non-regression guarantee
+    # for read-cues that didn't opt in.
+    mgr = _make_session_mgr()
+    mgr.enqueue_agent_callback(_passive_cb("a"))                    # no key
+    mgr.enqueue_agent_callback(_passive_cb("b"))                    # no key
+    mgr.enqueue_agent_callback(_passive_cb("c", coalesce_key=""))   # explicit empty
+    assert [c["summary"] for c in mgr.pending_agent_callbacks] == ["a", "b", "c"]
+    assert len(mgr.pending_extra_replies) == 3
+
+
+def test_enqueue_coalesce_distinct_keys_independent():
+    # Only the matching key collapses; a different key is untouched.
+    mgr = _make_session_mgr()
+    mgr.enqueue_agent_callback(_passive_cb("x1", coalesce_key="x"))
+    mgr.enqueue_agent_callback(_passive_cb("y1", coalesce_key="y"))
+    mgr.enqueue_agent_callback(_passive_cb("x2", coalesce_key="x"))
+    assert [c["summary"] for c in mgr.pending_agent_callbacks] == ["y1", "x2"]
+    assert [r["summary"] for r in mgr.pending_extra_replies] == ["y1", "x2"]
+
+
+def test_enqueue_coalesce_resolves_superseded_ack_false():
+    # A superseded cue's delivery-ack future resolves False immediately so a
+    # waiter unblocks instead of stalling until timeout (parity with the
+    # manager path).
+    mgr = _make_session_mgr()
+    fut = _FakeAckFuture()
+    old = _passive_cb("old", coalesce_key="k")
+    old[DELIVERY_ACK_FUTURE_KEY] = fut
+    mgr.enqueue_agent_callback(old)
+    mgr.enqueue_agent_callback(_passive_cb("new", coalesce_key="k"))
+    assert fut.done() and fut.result is False
+    assert [c["summary"] for c in mgr.pending_agent_callbacks] == ["new"]

--- a/tests/unit/test_proactive_delivery.py
+++ b/tests/unit/test_proactive_delivery.py
@@ -369,6 +369,108 @@ def test_enqueue_coalesce_older_manager_release_loses_to_newer_read():
     assert respond.get(DELIVERY_RETRACTED_KEY) is True
 
 
+def test_pull_model_retracts_checked_out_snapshot():
+    # PULL model: a cue checked OUT of pending_agent_callbacks into a local
+    # delivery snapshot is invisible to the enqueue-time push scan. When a
+    # newer same-key cue arrives (bumping _coalesce_latest), the delivery point
+    # calls _retract_stale_coalesced on its snapshot and the stale cue must be
+    # retracted there — acked False and flagged — instead of being delivered.
+    mgr = _make_session_mgr()
+    old = _passive_cb("checked out", coalesce_key="k")
+    mgr.enqueue_agent_callback(old)
+    snapshot = list(mgr.pending_agent_callbacks)
+    mgr.pending_agent_callbacks.clear()  # simulate checkout (text delivery path)
+    # Newer same-key cue arrives while the old one is in-flight.
+    mgr.enqueue_agent_callback(_passive_cb("newer", coalesce_key="k"))
+    fut = _FakeAckFuture()
+    snapshot[0][DELIVERY_ACK_FUTURE_KEY] = fut
+    assert mgr._retract_stale_coalesced(snapshot) is True
+    assert snapshot[0].get(DELIVERY_RETRACTED_KEY) is True
+    assert fut.done() and fut.result is False
+    # The newer cue is NOT stale (it holds the latest seq itself).
+    assert mgr._retract_stale_coalesced(list(mgr.pending_agent_callbacks)) is False
+
+
+def test_pull_model_manager_held_window():
+    # The staleness map is bumped at SUBMIT time (submit_proactive_callback),
+    # not only at enqueue — so an older direct-queued cue is already stale
+    # while the newer respond cue is still held by the delivery manager.
+    mgr = _make_session_mgr()
+    old = _passive_cb("old read", coalesce_key="k")
+    mgr.enqueue_agent_callback(old)
+    # Newer respond cue submitted; manager holds it (we stub the manager).
+    class _MgrStub:
+        def submit(self, cb, **kw):
+            pass
+    mgr.proactive_manager = _MgrStub()
+    mgr.is_goodbye_silent = lambda: False
+    newer = {"status": "completed", "summary": "respond held"}
+    core_module.LLMSessionManager.submit_proactive_callback(
+        mgr, newer, priority=1, coalesce_key="k",
+    )
+    # The old cue must now test stale even though the newer one never enqueued.
+    assert mgr._coalesce_entry_is_stale(old) is True
+    assert mgr._coalesce_entry_is_stale(newer) is False
+
+
+def test_pull_model_stale_extra_is_detected():
+    # _coalesce_entry_is_stale works on pending_extra_replies mirrors too (the
+    # hot-swap prime guard filters its selection with it). Legacy plain-string
+    # extras are never stale.
+    mgr = _make_session_mgr()
+    mgr.enqueue_agent_callback(_passive_cb("old", coalesce_key="k"))
+    old_extra = mgr.pending_extra_replies[0]
+    mgr.enqueue_agent_callback(_passive_cb("new", coalesce_key="k"))
+    assert mgr._coalesce_entry_is_stale(old_extra) is True
+    assert mgr._coalesce_entry_is_stale(mgr.pending_extra_replies[-1]) is False
+    assert mgr._coalesce_entry_is_stale("legacy plain string") is False
+
+
+async def test_deliver_batch_releases_inflight_when_all_superseded():
+    # An older manager-released respond cue that loses to a newer same-key
+    # direct cue during enqueue produces an all-retracted batch; the release
+    # hook must free the manager's inflight slot instead of stalling until the
+    # inflight timeout (and must not fire a trigger for nothing).
+    mgr = _make_session_mgr()
+    released = []
+    class _MgrStub:
+        def release_inflight_noop(self):
+            released.append(True)
+    mgr.proactive_manager = _MgrStub()
+    triggered = []
+    async def _fake_trigger():
+        triggered.append(True)
+        return True
+    mgr.trigger_agent_callbacks = _fake_trigger
+    mgr._topic_hook_release_allowed = lambda cb: True
+    # Newer same-key cue already direct-queued with a higher seq.
+    mgr._coalesce_seq_counter = 5
+    mgr.enqueue_agent_callback(_passive_cb("newer read", coalesce_key="k"))
+    # Manager releases the OLDER respond cue (stamped seq=1 at submit time).
+    stale = _passive_cb("older respond", coalesce_key="k")
+    stale["_coalesce_submit_seq"] = 1
+    await core_module.LLMSessionManager._deliver_proactive_batch(mgr, [stale])
+    assert released == [True]   # inflight slot freed immediately
+    assert triggered == []      # no pointless trigger for an empty batch
+    assert [c["summary"] for c in mgr.pending_agent_callbacks] == ["newer read"]
+
+
+def test_enqueue_coalesce_evicts_legacy_mirror_by_delivery_id():
+    # A mirror created before the coalesce_key stamp existed (legacy shape,
+    # paired by _callback_delivery_id only) must still be evicted when its
+    # callback half is retracted by a same-key enqueue — key-only matching
+    # would orphan it for the hot-swap path.
+    mgr = _make_session_mgr()
+    old = _passive_cb("old", coalesce_key="k")
+    mgr.enqueue_agent_callback(old)
+    # Strip the key/seq stamps from the mirror to simulate the legacy shape.
+    legacy_mirror = mgr.pending_extra_replies[0]
+    legacy_mirror.pop("coalesce_key", None)
+    legacy_mirror.pop("_coalesce_submit_seq", None)
+    mgr.enqueue_agent_callback(_passive_cb("new", coalesce_key="k"))
+    assert [r["summary"] for r in mgr.pending_extra_replies] == ["new"]
+
+
 def test_enqueue_coalesce_guards_legacy_string_extra():
     # pending_extra_replies may hold a legacy plain-string entry that the render
     # path tolerates. A keyed enqueue must not raise on it (the broad except in

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -1082,12 +1082,14 @@ def test_submit_proactive_callback_persists_when_goodbye_silent():
     assert mgr.pending_agent_callbacks == [cb]
     assert cb["_callback_delivery_id"]
     # goodbye_silent bypasses the manager, so the coalesce_key arg is carried
-    # onto the callback dict for the enqueue path's coalescing.
+    # onto the callback dict (plus a submission seq) for the enqueue path.
     assert cb["coalesce_key"] == "same-source"
+    assert isinstance(cb["_coalesce_submit_seq"], int)
     assert mgr.pending_extra_replies == [
         {
             "_callback_delivery_id": cb["_callback_delivery_id"],
             "coalesce_key": "same-source",
+            "_coalesce_submit_seq": cb["_coalesce_submit_seq"],
             "origin": "event",
             "summary": "queued",
             "detail": "",

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -1081,9 +1081,13 @@ def test_submit_proactive_callback_persists_when_goodbye_silent():
     mgr.proactive_manager.submit.assert_not_called()
     assert mgr.pending_agent_callbacks == [cb]
     assert cb["_callback_delivery_id"]
+    # goodbye_silent bypasses the manager, so the coalesce_key arg is carried
+    # onto the callback dict for the enqueue path's coalescing.
+    assert cb["coalesce_key"] == "same-source"
     assert mgr.pending_extra_replies == [
         {
             "_callback_delivery_id": cb["_callback_delivery_id"],
+            "coalesce_key": "same-source",
             "origin": "event",
             "summary": "queued",
             "detail": "",


### PR DESCRIPTION
## 背景 / 问题

插件 `push_message` 的 `coalesce_key`（同 key 的排队 cue 新替旧）此前**只对 `ai_behavior="respond"` 生效**。合并逻辑只长在 [`ProactiveDeliveryManager.submit`](main_logic/proactive_delivery.py) 里，而这个 pacing manager 按设计只放行 proactive 类。

`ai_behavior="read"`（passive）在 [`character_runtime.py`](app/main_server/character_runtime.py) 的分叉处走 `mgr.enqueue_agent_callback(callback)` 直投队列、**绕过 manager**，`coalesce_key` 一路运到 callback dict 上却从没被消费。后果：用 `read` 每隔几秒 push「当前状态」这类高频流，即便带同一个 `coalesce_key`，旧快照也会在 `pending_agent_callbacks` 堆积，仅靠 `AGENT_CALLBACK_QUEUE_MAX_ITEMS` 的 drop-oldest 防洪兜底，不按 key 去重。

`coalesce_key` 本就是 opt-in（不设 key → 永不合并），所以让 passive 也认这个字段，对不设 key 的既有插件行为零影响。

## 改动（三轮迭代后的最终架构）

**拉模型（pull-model）staleness**，取代最初「enqueue 时扫队列」的推模型——推模型追不到已 checkout 进局部快照/选集的引用（voice_snapshot、text callbacks_snapshot、hot-swap prime 选集），每个消费点都要单独打补丁；拉模型一次收口：

- **`main_logic/core/proactive.py`**（核心）：
  - 中心 `_coalesce_latest[key→seq]` 映射 + 单调 `_coalesce_submit_seq`，在两个提交位点（`submit_proactive_callback` / `enqueue_agent_callback`）bump——newest-wins 跨 manager/enqueue 两条路成立，manager 持有期新 cue 也已把旧 cue 判老。
  - 四个投递点发送前做 stale-by-key 判定并 retract（ack=False + `DELIVERY_RETRACTED_KEY`）：voice inject 重过滤、text 两道 re-gate、passive drain、（lifecycle）hot-swap prime。
  - enqueue 保留 push 侧同步去重（常见路径立即收敛队列），双向：更旧的入队者撤回自己。
  - `_deliver_proactive_batch` 整批被 supersede 时立即 `release_inflight_noop`。
  - extras 镜像按 `_callback_delivery_id` 补充清除 legacy 形态（无 key 戳）镜像；`isinstance` guard 容忍 legacy 纯字符串 extras。
- **`main_logic/core/lifecycle.py`**：hot-swap prime 在 select→render 原子区过滤 stale extras。
- **`plugin/sdk/shared/core/push_message_schema.py`** / **`app/main_server/character_runtime.py`**：注释同步。
- **`tests/unit/test_proactive_delivery.py`**：+11 个 enqueue/拉模型测试。

## 回归报告

### 改动内容
`coalesce_key` 语义扩展到 passive(read) 投递路径，并将 staleness 判定重构为拉模型：中心 `_coalesce_latest[key→seq]` 映射记录每 key 最新提交序号，四个投递点（voice inject / text prompt / passive drain / hot-swap prime）发送前查询并撤回被 supersede 的 cue。

### 理由 / 必要性
去重语义此前被 pacing manager 独占，passive 绕过 manager 就丢了去重能力。三轮 review（codex/greptile）证明推模型在每个 async 快照边界都要重复打补丁（voice snapshot、text checkout、hot-swap prime、manager 释放序），拉模型让每条 cue 在自己的投递点自证新鲜度，一个机制覆盖全部消费点。

### 前后行为对比
- **前**：`read` + 相同 `coalesce_key` → 每条都进队列堆到防洪上限，下一轮全部注入；respond/read 混用同 key 时 manager 晚释放的旧 cue 会反杀新 cue。
- **后**：同 key 只留提交序最新的一条，跨 manager/enqueue、跨 in-flight 快照一致；不设 key（或空 key）行为完全不变（非回归保证，`__uniq` sentinel 语义照旧）。

### 潜在回归
- **不设 key 的既有插件**：零影响——staleness 判定对无 key/无 seq 条目恒 False，全部路径先判 opt-in。
- **proactive 主路径**：新增判定都在既有 `DELIVERY_RETRACTED_KEY` 过滤链之前插入，等价于既有 retract 机制多一个触发源；批全 superseded 时 inflight 立即释放（新增测试锁定）。
- **hot-swap**：select→render 间的过滤在无 await 原子区内，不引入新竞态；prime await 期间落地的新 cue 为已接受的残余窗口（文本已进 session，物理不可撤回）。
- **legacy 数据**：纯字符串 extras、无 key 戳镜像均有 isinstance/id 兜底（各有测试）。
- **已知边界（by-design 不修）**：read 已即时流式的**图片**不随 coalesce 撤回——voice 模式帧已上线不可撤回；text 模式修复需 EventBus 感知 session 类型或重构 drain 契约，收益不匹配。`coalesce_key` 撤回的是文本载荷。

### 验证
- 新增 11 个测试：同 key 顶替（双队列一致）、空 key 不合并、异 key 独立、ack=False、retracted 标记、drained 孤儿镜像、跨路 newest-wins、checked-out 快照 retract、manager 持有窗口 staleness、批全 superseded 释放 inflight、legacy 镜像/字符串 guard——全绿。
- 回归套件 **251 passed / 0 fail**：`test_proactive_delivery`、`proactive_sm_integration`、`topic_delivery`、`hot_swap_cancellation`、`passthrough_to_chat_bubble`、`callback_instruction_origin`、`role_placeholder_substitution`、`core_game_route_memory_contract`、`plugin_push_message_models`。
- `check_core_contracts.py` / `ruff` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 引入可选合并键（coalesce_key），对相同类型的待处理回调执行“同键仅保留最新”的队列合并。
  * 被替换的旧回调会被立即更新为未交付状态，避免过期内容继续发送。

* **改进**
  * 在语音/文本交付与热切换“最终交换序列”的注入阶段，增加基于合并键的陈旧条目剔除，减少窗口期误注入。
  * 若整批被 supersede，提前释放占用名额，避免卡住。

* **测试**
  * 扩展覆盖同键替换、空键不合并、不同键独立、确认状态与跨路径 newest-wins 等场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->