### PR TITLE
接入第一批独立流式 ASR 供应商

### DIFF
--- a/docs/design/asr-client-phase1.md
+++ b/docs/design/asr-client-phase1.md
@@ -65,7 +65,7 @@ dummy 不进入持久化 Core 配置和设置 UI，也不会成为未实现 Core
 - 公共断句语义只有 `manual` 与 `provider`。`manual` 下 `signal_user_activity_end()` 发送 `commit`；`provider` 下不发送 `commit`，只刷新本地 48 kHz 流式重采样器尾部，最终断句由供应商决定。`server_vad`、`endpointing` 等厂商字段只存在于 worker 内部。
 - 默认模式跟随 Core 路由：`qwen`、`qwen_intl`、`openai`、`step` 使用 `manual`，`grok` 使用 `provider`。小游戏不需要按厂商选择模式。
 - `endpointing_mode` 在 Session 创建时冻结，不能通过 `update_session()` 动态切换。
-- 公共输入固定为单声道 PCM16LE，支持 16 kHz 和 48 kHz。公共层将 48 kHz 流式转换为 16 kHz；一个 Session 首包锁定输入采样率。
+- 公共输入固定为单声道 PCM16LE，支持 16 kHz 和 48 kHz。公共层将 48 kHz 流式转换为 worker 统一接收的 16 kHz；OpenAI worker 再将 16 kHz 转为其接口要求的 24 kHz。一个 Session 首包锁定输入采样率。
 - 空音频块是 no-op；非空音频必须为偶数字节，单块最多一秒。
 - 每个 utterance 只有首个有效、非空 `final` 调用 `on_input_transcript()`。即使供应商乱序返回多个 final，业务回调仍按 commit/语音开始顺序交付。`partial`、重复 final、冲突 final 以及 clear/close 后到达的旧 final 都不进入业务回调。
 - 内部事件用 `generation + buffer_epoch + utterance_id` 关联，不能按 transcript 文本去重。

--- a/docs/design/asr-client-phase1.md
+++ b/docs/design/asr-client-phase1.md
@@ -62,7 +62,7 @@ dummy 不进入持久化 Core 配置和设置 UI，也不会成为未实现 Core
 ## 已冻结的行为
 
 - 生产 ASR 跟随 `core_type` 路由；一个 Session 只使用一个 worker，不跨供应商 fallback。
-- 默认 `endpointing_mode="manual"`。该模式下 `signal_user_activity_end()` 发送 `commit`；`provider` 模式下不发送 `commit`，只刷新本地 48 kHz 流式重采样器的尾部音频，最终断句仍由供应商 VAD 决定。
+- 默认 `endpointing_mode="manual"`。该模式下 `signal_user_activity_end()` 发送 `commit`；`server_vad` 模式下不发送 `commit`，只刷新本地 48 kHz 流式重采样器的尾部音频，最终断句仍由供应商 VAD 决定。
 - 公共输入固定为单声道 PCM16LE，支持 16 kHz 和 48 kHz。公共层将 48 kHz 流式转换为 16 kHz；一个 Session 首包锁定输入采样率。
 - 空音频块是 no-op；非空音频必须为偶数字节，单块最多一秒。
 - 只有首个有效、非空 `final` 调用 `on_input_transcript()`。`partial`、重复 final、冲突 final 以及 clear/close 后到达的旧 final 都不进入业务回调。

--- a/docs/design/asr-client-phase1.md
+++ b/docs/design/asr-client-phase1.md
@@ -1,4 +1,4 @@
-# Phase 1 ASR client
+# Phase 1/2 ASR client
 
 Phase 1 冻结一条只负责“实时 PCM 输入、整轮文本输出”的公共链路：
 
@@ -51,7 +51,7 @@ await session.signal_user_activity_end()
 await session.close()
 ```
 
-Phase 1 联调前需要在进程环境中显式设置：
+仅联调公共骨架时，可在进程环境中显式设置：
 
 ```text
 ASR_PROVIDER=dummy
@@ -62,17 +62,21 @@ dummy 不进入持久化 Core 配置和设置 UI，也不会成为未实现 Core
 ## 已冻结的行为
 
 - 生产 ASR 跟随 `core_type` 路由；一个 Session 只使用一个 worker，不跨供应商 fallback。
-- 默认 `endpointing_mode="manual"`。该模式下 `signal_user_activity_end()` 发送 `commit`；`server_vad` 模式下不发送 `commit`，只刷新本地 48 kHz 流式重采样器的尾部音频，最终断句仍由供应商 VAD 决定。
+- 公共断句语义只有 `manual` 与 `provider`。`manual` 下 `signal_user_activity_end()` 发送 `commit`；`provider` 下不发送 `commit`，只刷新本地 48 kHz 流式重采样器尾部，最终断句由供应商决定。`server_vad`、`endpointing` 等厂商字段只存在于 worker 内部。
+- 默认模式跟随 Core 路由：`qwen`、`qwen_intl`、`openai`、`step` 使用 `manual`，`grok` 使用 `provider`。小游戏不需要按厂商选择模式。
+- `endpointing_mode` 在 Session 创建时冻结，不能通过 `update_session()` 动态切换。
 - 公共输入固定为单声道 PCM16LE，支持 16 kHz 和 48 kHz。公共层将 48 kHz 流式转换为 16 kHz；一个 Session 首包锁定输入采样率。
 - 空音频块是 no-op；非空音频必须为偶数字节，单块最多一秒。
-- 只有首个有效、非空 `final` 调用 `on_input_transcript()`。`partial`、重复 final、冲突 final 以及 clear/close 后到达的旧 final 都不进入业务回调。
+- 每个 utterance 只有首个有效、非空 `final` 调用 `on_input_transcript()`。即使供应商乱序返回多个 final，业务回调仍按 commit/语音开始顺序交付。`partial`、重复 final、冲突 final 以及 clear/close 后到达的旧 final 都不进入业务回调。
 - 内部事件用 `generation + buffer_epoch + utterance_id` 关联，不能按 transcript 文本去重。
 - callback 串行执行；业务 callback 失败不破坏 provider receive loop。
 - worker `error` 终止当前 Session，只报告一次连接错误，不自动重连。恢复时由调用方创建新 Session。
 - `close()` 幂等；可预知的未知 Core、未实现 backend、blocked backend 和配置错误在 `create_asr_session()` 阶段同步失败。
 
-## Phase 1 边界
+## 当前边界
 
-本阶段只提供 `asr_client` 公共骨架、唯一路由表和 dummy worker，不接入真实 ASR 供应商，不修改小游戏、`game_router`、`websocket_router.py`、现有 `streaming.py`、`OmniRealtimeClient`、普通语音链路或生产开关。
+当前已提供公共骨架、唯一路由表、dummy worker，以及 Qwen、OpenAI、Step、Grok 的 WSS worker。真实 worker 在完成凭据联调和 WSS smoke 前保持 `blocked_credentials`，不会被生产 Factory 创建；smoke 脚本只用于逐个供应商验收。
+
+本阶段不修改小游戏、`game_router`、`websocket_router.py`、现有 `streaming.py`、`OmniRealtimeClient`、普通语音链路或生产开关。
 
 本阶段也不实现 Smart Turn、VAD、RNNoise、声纹、节流、LLM 回复、TTS、工具调用、上下文事件或独立 ASR 云服务。后续真实服务通过新增 worker 实现相同的 request/response 合同，不改变上述公共调用方式。

--- a/main_logic/asr_client/__init__.py
+++ b/main_logic/asr_client/__init__.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Awaitable, Callable
+from functools import partial
 
 from ._infra import (
     AsrSessionConfig,
@@ -28,8 +29,13 @@ from ._infra import (
 from ._registry_meta import (
     ASR_PROVIDER_REGISTRY as _ASR_PROVIDER_REGISTRY,
     CORE_ASR_ROUTES as _CORE_ASR_ROUTES,
+    AsrEndpointingMode as _AsrEndpointingMode,
 )
 from .workers.dummy import dummy_asr_worker as _dummy_asr_worker
+from .workers.grok import grok_asr_worker as _grok_asr_worker
+from .workers.openai import openai_asr_worker as _openai_asr_worker
+from .workers.qwen import qwen_asr_worker as _qwen_asr_worker
+from .workers.step import step_asr_worker as _step_asr_worker
 
 
 __all__ = [
@@ -41,15 +47,22 @@ __all__ = [
 
 _IMPLEMENTED_WORKERS: dict[str, _AsrWorkerFn] = {
     "dummy": _dummy_asr_worker,
+    "qwen": _qwen_asr_worker,
+    "openai": _openai_asr_worker,
+    "step": _step_asr_worker,
+    "grok": _grok_asr_worker,
 }
 
 
-def _get_asr_worker(core_type: str) -> tuple[_AsrWorkerFn, str | None, str]:
+def _get_asr_worker(
+    core_type: str,
+    endpointing_mode: _AsrEndpointingMode = "manual",
+) -> tuple[_AsrWorkerFn, str | None, str]:
     """Resolve one worker without exposing provider internals to callers."""
 
     core_key = str(core_type or "").strip().lower()
-    provider_key = _CORE_ASR_ROUTES.get(core_key)
-    if provider_key is None:
+    route = _CORE_ASR_ROUTES.get(core_key)
+    if route is None:
         raise RuntimeError(f"ASR_UNKNOWN_CORE: {core_key or '<empty>'}")
 
     provider_override = os.getenv("ASR_PROVIDER", "").strip().lower()
@@ -57,11 +70,18 @@ def _get_asr_worker(core_type: str) -> tuple[_AsrWorkerFn, str | None, str]:
         if provider_override != "dummy":
             raise RuntimeError(
                 "ASR_INVALID_CONFIG: ASR_PROVIDER only supports the development "
-                "value 'dummy' in Phase 1"
+                "value 'dummy'"
             )
         provider_key = "dummy"
+    else:
+        provider_key = route.provider_key
 
     meta = _ASR_PROVIDER_REGISTRY[provider_key]
+    if endpointing_mode not in meta.supported_endpointing_modes:
+        raise RuntimeError(
+            "ASR_ENDPOINTING_NOT_SUPPORTED: "
+            f"{provider_key} does not support {endpointing_mode}"
+        )
     if meta.implementation_status == "blocked_backend":
         raise RuntimeError(f"ASR_BACKEND_BLOCKED: {core_key}")
     if meta.implementation_status == "blocked_credentials":
@@ -73,10 +93,25 @@ def _get_asr_worker(core_type: str) -> tuple[_AsrWorkerFn, str | None, str]:
     if worker_fn is None:
         raise RuntimeError(f"ASR_BACKEND_NOT_IMPLEMENTED: {core_key}")
 
-    # Dummy deliberately receives an empty key. Real workers added in later
-    # phases must resolve their own provider-specific credentials here rather
-    # than borrowing another provider's key as a fallback.
-    return worker_fn, "", provider_key
+    if provider_key == "dummy":
+        return worker_fn, "", provider_key
+
+    # ConfigManager owns the only permitted provider-specific credential
+    # fallback: a matching Core may supply CORE_API_KEY through its matching
+    # ASSIST_API_KEY_* slot. No audio/TTS/other-provider key is consulted here.
+    from utils.config_manager import get_config_manager
+
+    try:
+        core_config = get_config_manager().get_core_config() or {}
+    except Exception:
+        raise RuntimeError(f"ASR_CREDENTIALS_MISSING: {provider_key}") from None
+    api_key = str(core_config.get(route.credential_field) or "").strip()
+    if not api_key:
+        raise RuntimeError(f"ASR_CREDENTIALS_MISSING: {provider_key}")
+
+    if provider_key == "qwen":
+        worker_fn = partial(worker_fn, region=route.region or "cn")  # type: ignore[assignment]
+    return worker_fn, api_key, provider_key
 
 
 def create_asr_session(
@@ -92,12 +127,10 @@ def create_asr_session(
     if config is not None and not isinstance(config, AsrSessionConfig):
         raise TypeError("ASR_INVALID_CONFIG: config must be AsrSessionConfig")
     session_config = config if config is not None else AsrSessionConfig()
-    worker_fn, api_key_override, provider_key = _get_asr_worker(core_type)
-
-    if provider_key == "dummy" and session_config.endpointing_mode != "manual":
-        raise RuntimeError(
-            "ASR_INVALID_CONFIG: dummy requires endpointing_mode='manual'"
-        )
+    worker_fn, api_key_override, provider_key = _get_asr_worker(
+        core_type,
+        session_config.endpointing_mode,
+    )
 
     return _RealtimeAsrSessionImpl(
         worker_fn=worker_fn,

--- a/main_logic/asr_client/__init__.py
+++ b/main_logic/asr_client/__init__.py
@@ -54,6 +54,16 @@ _IMPLEMENTED_WORKERS: dict[str, _AsrWorkerFn] = {
 }
 
 
+def _get_default_endpointing_mode(core_type: str) -> _AsrEndpointingMode:
+    core_key = str(core_type or "").strip().lower()
+    route = _CORE_ASR_ROUTES.get(core_key)
+    if route is None:
+        raise RuntimeError(f"ASR_UNKNOWN_CORE: {core_key or '<empty>'}")
+    if os.getenv("ASR_PROVIDER", "").strip().lower() == "dummy":
+        return "manual"
+    return route.default_endpointing_mode
+
+
 def _get_asr_worker(
     core_type: str,
     endpointing_mode: _AsrEndpointingMode = "manual",
@@ -126,7 +136,11 @@ def create_asr_session(
 
     if config is not None and not isinstance(config, AsrSessionConfig):
         raise TypeError("ASR_INVALID_CONFIG: config must be AsrSessionConfig")
-    session_config = config if config is not None else AsrSessionConfig()
+    session_config = (
+        config
+        if config is not None
+        else AsrSessionConfig(endpointing_mode=_get_default_endpointing_mode(core_type))
+    )
     worker_fn, api_key_override, provider_key = _get_asr_worker(
         core_type,
         session_config.endpointing_mode,

--- a/main_logic/asr_client/_infra.py
+++ b/main_logic/asr_client/_infra.py
@@ -64,7 +64,14 @@ _OMNI_ONLY_FIELDS = frozenset(
 )
 
 _RequestKind: TypeAlias = Literal["audio", "commit", "clear", "shutdown"]
-_EventKind: TypeAlias = Literal["ready", "partial", "final", "error", "closed"]
+_EventKind: TypeAlias = Literal[
+    "ready",
+    "utterance_started",
+    "partial",
+    "final",
+    "error",
+    "closed",
+]
 _UtteranceKey: TypeAlias = tuple[int, int, int]
 
 
@@ -74,7 +81,7 @@ class AsrSessionConfig:
 
     language: str = "zh"
     input_sample_rate_hz: Literal[16000, 48000] = 16000
-    endpointing_mode: Literal["provider", "manual"] = "manual"
+    endpointing_mode: Literal["manual", "server_vad"] = "manual"
 
     def __post_init__(self) -> None:
         language = str(self.language).strip()
@@ -98,9 +105,9 @@ class AsrSessionConfig:
             raise ValueError(
                 "ASR_INVALID_CONFIG: input_sample_rate_hz must be 16000 or 48000"
             )
-        if self.endpointing_mode not in ("provider", "manual"):
+        if self.endpointing_mode not in ("manual", "server_vad"):
             raise ValueError(
-                "ASR_INVALID_CONFIG: endpointing_mode must be 'provider' or 'manual'"
+                "ASR_INVALID_CONFIG: endpointing_mode must be 'manual' or 'server_vad'"
             )
         object.__setattr__(self, "language", normalized_language)
 
@@ -293,7 +300,9 @@ class _RealtimeAsrSessionImpl:
                 if self._state in (_SessionState.CLOSING, _SessionState.CLOSED):
                     raise
                 if self._state is not _SessionState.FAILED:
-                    await self._fail("ASR_WORKER_FAILED", "worker failed during connect")
+                    await self._fail(
+                        "ASR_WORKER_FAILED", "worker failed during connect"
+                    )
                 raise
 
             worker_task = self._worker_task
@@ -310,11 +319,15 @@ class _RealtimeAsrSessionImpl:
         if not isinstance(config, Mapping):
             raise TypeError("ASR_INVALID_CONFIG: session update must be a mapping")
 
-        unknown_fields = set(config) - {
-            "language",
-            "input_sample_rate_hz",
-            "endpointing_mode",
-        } - _OMNI_ONLY_FIELDS
+        unknown_fields = (
+            set(config)
+            - {
+                "language",
+                "input_sample_rate_hz",
+                "endpointing_mode",
+            }
+            - _OMNI_ONLY_FIELDS
+        )
         if unknown_fields:
             names = ", ".join(sorted(map(str, unknown_fields)))
             raise ValueError(f"ASR_INVALID_CONFIG: unknown session field(s): {names}")
@@ -327,7 +340,9 @@ class _RealtimeAsrSessionImpl:
         if not updates:
             return
         if self._state is not _SessionState.NEW:
-            raise RuntimeError("ASR_SESSION_CONFIG_LOCKED: session is already connecting")
+            raise RuntimeError(
+                "ASR_SESSION_CONFIG_LOCKED: session is already connecting"
+            )
         self._config = replace(self._config, **updates)
 
     async def stream_audio(
@@ -353,7 +368,9 @@ class _RealtimeAsrSessionImpl:
                 else self._config.input_sample_rate_hz
             )
             if effective_rate not in (16000, 48000):
-                raise ValueError("ASR_INVALID_CONFIG: sample rate must be 16000 or 48000")
+                raise ValueError(
+                    "ASR_INVALID_CONFIG: sample rate must be 16000 or 48000"
+                )
             if len(audio_chunk) > effective_rate * 2:
                 raise ValueError(
                     "ASR_AUDIO_CHUNK_TOO_LARGE: one chunk may contain at most one second"
@@ -398,10 +415,11 @@ class _RealtimeAsrSessionImpl:
                         audio=tail,
                     )
                 )
-            if self._config.endpointing_mode == "provider":
-                # Provider endpointing still needs a local activity boundary
+            if self._config.endpointing_mode == "server_vad":
+                # Server VAD still needs a local activity boundary
                 # to drain soxr's buffered 48 kHz tail. It deliberately does
-                # not send a commit or advance the provider utterance key.
+                # not send a commit or advance a worker-owned utterance ID.
+                self._utterance_has_audio = False
                 self._reset_resampler()
                 return
             await self._enqueue_request(
@@ -599,6 +617,25 @@ class _RealtimeAsrSessionImpl:
 
         if event.generation != self._generation:
             return False
+        if event.kind == "utterance_started":
+            if (
+                self._config.endpointing_mode != "server_vad"
+                or event.utterance_id is None
+            ):
+                return False
+            key = (event.generation, event.buffer_epoch, event.utterance_id)
+            async with self._operation_lock:
+                if (
+                    self._state is not _SessionState.READY
+                    or event.generation != self._generation
+                    or event.buffer_epoch != self._buffer_epoch
+                ):
+                    return False
+                # Repeated provider speech-start notifications for one item
+                # are idempotent. The worker owns provider-item -> internal-ID
+                # mapping, so no provider identifier leaks into this layer.
+                self._active_utterance_keys.add(key)
+            return False
         if event.kind == "partial":
             return False
         if event.kind == "final":
@@ -622,7 +659,7 @@ class _RealtimeAsrSessionImpl:
                     return False
                 valid_keys = (
                     self._active_utterance_keys
-                    if self._config.endpointing_mode == "provider"
+                    if self._config.endpointing_mode == "server_vad"
                     else self._committed_utterance_keys
                 )
                 if key not in valid_keys:
@@ -633,13 +670,6 @@ class _RealtimeAsrSessionImpl:
                 self._final_keys.add(key)
                 self._active_utterance_keys.discard(key)
                 self._committed_utterance_keys.discard(key)
-                if (
-                    self._config.endpointing_mode == "provider"
-                    and event.utterance_id == self._utterance_id
-                ):
-                    self._utterance_id += 1
-                    self._utterance_has_audio = False
-                    self._reset_resampler()
             assert self._callback_queue is not None
             await self._callback_queue.put(_CallbackItem(text=text))
             return False
@@ -681,7 +711,10 @@ class _RealtimeAsrSessionImpl:
         error = f"{safe_code}: {safe_message}"
         if self._ready_future is not None and not self._ready_future.done():
             self._ready_future.set_exception(RuntimeError(error))
-        if self._worker_task is not None and self._worker_task is not asyncio.current_task():
+        if (
+            self._worker_task is not None
+            and self._worker_task is not asyncio.current_task()
+        ):
             self._worker_task.cancel()
         try:
             await self._emit_connection_error_once(error)
@@ -716,7 +749,11 @@ class _RealtimeAsrSessionImpl:
                 request.buffer_epoch,
                 request.utterance_id,
             )
-            if request.kind == "audio" and key not in self._active_utterance_keys:
+            if (
+                self._config.endpointing_mode == "manual"
+                and request.kind == "audio"
+                and key not in self._active_utterance_keys
+            ):
                 self._active_utterance_keys.add(key)
                 added_active = True
             if request.kind == "commit" and key not in self._committed_utterance_keys:
@@ -784,12 +821,7 @@ class _RealtimeAsrSessionImpl:
         output = self._resampler.resample_chunk(samples)
         if len(output) == 0:
             return b""
-        return (
-            (output * 32768.0)
-            .clip(-32768, 32767)
-            .astype("<i2")
-            .tobytes()
-        )
+        return (output * 32768.0).clip(-32768, 32767).astype("<i2").tobytes()
 
     def _flush_resampler(self) -> bytes:
         if self._resampler is None:
@@ -800,12 +832,7 @@ class _RealtimeAsrSessionImpl:
         )
         if len(output) == 0:
             return b""
-        return (
-            (output * 32768.0)
-            .clip(-32768, 32767)
-            .astype("<i2")
-            .tobytes()
-        )
+        return (output * 32768.0).clip(-32768, 32767).astype("<i2").tobytes()
 
     def _reset_resampler(self) -> None:
         if self._resampler is not None:

--- a/main_logic/asr_client/_infra.py
+++ b/main_logic/asr_client/_infra.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+from collections import deque
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, replace
 from enum import Enum
@@ -81,7 +82,7 @@ class AsrSessionConfig:
 
     language: str = "zh"
     input_sample_rate_hz: Literal[16000, 48000] = 16000
-    endpointing_mode: Literal["manual", "server_vad"] = "manual"
+    endpointing_mode: Literal["manual", "provider"] = "manual"
 
     def __post_init__(self) -> None:
         language = str(self.language).strip()
@@ -105,9 +106,9 @@ class AsrSessionConfig:
             raise ValueError(
                 "ASR_INVALID_CONFIG: input_sample_rate_hz must be 16000 or 48000"
             )
-        if self.endpointing_mode not in ("manual", "server_vad"):
+        if self.endpointing_mode not in ("manual", "provider"):
             raise ValueError(
-                "ASR_INVALID_CONFIG: endpointing_mode must be 'manual' or 'server_vad'"
+                "ASR_INVALID_CONFIG: endpointing_mode must be 'manual' or 'provider'"
             )
         object.__setattr__(self, "language", normalized_language)
 
@@ -228,7 +229,8 @@ class _RealtimeAsrSessionImpl:
         self._resampler: soxr.ResampleStream | None = None
         self._active_utterance_keys: set[_UtteranceKey] = set()
         self._committed_utterance_keys: set[_UtteranceKey] = set()
-        self._final_keys: set[_UtteranceKey] = set()
+        self._utterance_order: deque[_UtteranceKey] = deque()
+        self._pending_finals: dict[_UtteranceKey, str] = {}
 
         self._request_queue: asyncio.Queue[_AsrWorkerRequest] | None = None
         self._response_queue: asyncio.Queue[_AsrWorkerEvent] | None = None
@@ -324,7 +326,6 @@ class _RealtimeAsrSessionImpl:
             - {
                 "language",
                 "input_sample_rate_hz",
-                "endpointing_mode",
             }
             - _OMNI_ONLY_FIELDS
         )
@@ -334,7 +335,7 @@ class _RealtimeAsrSessionImpl:
 
         updates = {
             key: config[key]
-            for key in ("language", "input_sample_rate_hz", "endpointing_mode")
+            for key in ("language", "input_sample_rate_hz")
             if key in config
         }
         if not updates:
@@ -415,8 +416,8 @@ class _RealtimeAsrSessionImpl:
                         audio=tail,
                     )
                 )
-            if self._config.endpointing_mode == "server_vad":
-                # Server VAD still needs a local activity boundary
+            if self._config.endpointing_mode == "provider":
+                # Provider endpointing still needs a local activity boundary
                 # to drain soxr's buffered 48 kHz tail. It deliberately does
                 # not send a commit or advance a worker-owned utterance ID.
                 self._utterance_has_audio = False
@@ -443,7 +444,8 @@ class _RealtimeAsrSessionImpl:
             self._utterance_has_audio = False
             self._active_utterance_keys.clear()
             self._committed_utterance_keys.clear()
-            self._final_keys.clear()
+            self._utterance_order.clear()
+            self._pending_finals.clear()
             self._reset_resampler()
             await self._enqueue_request(
                 _AsrWorkerRequest(
@@ -487,7 +489,8 @@ class _RealtimeAsrSessionImpl:
             self._utterance_has_audio = False
             self._active_utterance_keys.clear()
             self._committed_utterance_keys.clear()
-            self._final_keys.clear()
+            self._utterance_order.clear()
+            self._pending_finals.clear()
             self._reset_resampler()
 
             if self._request_queue is not None:
@@ -619,7 +622,7 @@ class _RealtimeAsrSessionImpl:
             return False
         if event.kind == "utterance_started":
             if (
-                self._config.endpointing_mode != "server_vad"
+                self._config.endpointing_mode != "provider"
                 or event.utterance_id is None
             ):
                 return False
@@ -634,7 +637,9 @@ class _RealtimeAsrSessionImpl:
                 # Repeated provider speech-start notifications for one item
                 # are idempotent. The worker owns provider-item -> internal-ID
                 # mapping, so no provider identifier leaks into this layer.
-                self._active_utterance_keys.add(key)
+                if key not in self._active_utterance_keys:
+                    self._active_utterance_keys.add(key)
+                    self._utterance_order.append(key)
             return False
         if event.kind == "partial":
             return False
@@ -652,14 +657,14 @@ class _RealtimeAsrSessionImpl:
                     or event.buffer_epoch != self._buffer_epoch
                 ):
                     return False
-                if key in self._final_keys:
+                if key in self._pending_finals:
                     logger.warning(
                         "ASR worker returned a duplicate or conflicting final"
                     )
                     return False
                 valid_keys = (
                     self._active_utterance_keys
-                    if self._config.endpointing_mode == "server_vad"
+                    if self._config.endpointing_mode == "provider"
                     else self._committed_utterance_keys
                 )
                 if key not in valid_keys:
@@ -667,11 +672,19 @@ class _RealtimeAsrSessionImpl:
                         "ASR worker returned a final for an inactive utterance"
                     )
                     return False
-                self._final_keys.add(key)
-                self._active_utterance_keys.discard(key)
-                self._committed_utterance_keys.discard(key)
+                self._pending_finals[key] = text
+                ready_texts: list[str] = []
+                while (
+                    self._utterance_order
+                    and self._utterance_order[0] in self._pending_finals
+                ):
+                    ready_key = self._utterance_order.popleft()
+                    ready_texts.append(self._pending_finals.pop(ready_key))
+                    self._active_utterance_keys.discard(ready_key)
+                    self._committed_utterance_keys.discard(ready_key)
             assert self._callback_queue is not None
-            await self._callback_queue.put(_CallbackItem(text=text))
+            for ready_text in ready_texts:
+                await self._callback_queue.put(_CallbackItem(text=ready_text))
             return False
         if event.kind == "error":
             if (
@@ -701,7 +714,8 @@ class _RealtimeAsrSessionImpl:
         self._closing_event.set()
         self._active_utterance_keys.clear()
         self._committed_utterance_keys.clear()
-        self._final_keys.clear()
+        self._utterance_order.clear()
+        self._pending_finals.clear()
         safe_code = (
             error_code
             if re.fullmatch(r"ASR_[A-Z0-9_]+", error_code or "")
@@ -743,6 +757,7 @@ class _RealtimeAsrSessionImpl:
         key: _UtteranceKey | None = None
         added_active = False
         added_committed = False
+        added_order = False
         if request.utterance_id is not None and request.kind in ("audio", "commit"):
             key = (
                 request.generation,
@@ -759,6 +774,8 @@ class _RealtimeAsrSessionImpl:
             if request.kind == "commit" and key not in self._committed_utterance_keys:
                 self._committed_utterance_keys.add(key)
                 added_committed = True
+                self._utterance_order.append(key)
+                added_order = True
 
         put_task = asyncio.create_task(self._request_queue.put(request))
         closing_task = asyncio.create_task(self._closing_event.wait())
@@ -774,6 +791,11 @@ class _RealtimeAsrSessionImpl:
                     self._active_utterance_keys.discard(key)
                 if added_committed:
                     self._committed_utterance_keys.discard(key)
+                if added_order:
+                    try:
+                        self._utterance_order.remove(key)
+                    except ValueError:
+                        pass
             raise
 
         if put_task in done:
@@ -787,6 +809,11 @@ class _RealtimeAsrSessionImpl:
                         self._active_utterance_keys.discard(key)
                     if added_committed:
                         self._committed_utterance_keys.discard(key)
+                    if added_order:
+                        try:
+                            self._utterance_order.remove(key)
+                        except ValueError:
+                            pass
                 raise
             closing_task.cancel()
             await asyncio.gather(closing_task, return_exceptions=True)
@@ -800,6 +827,11 @@ class _RealtimeAsrSessionImpl:
                 self._active_utterance_keys.discard(key)
             if added_committed:
                 self._committed_utterance_keys.discard(key)
+            if added_order:
+                try:
+                    self._utterance_order.remove(key)
+                except ValueError:
+                    pass
         raise RuntimeError("ASR_SESSION_NOT_READY: worker is no longer running")
 
     def _make_resampler(self) -> soxr.ResampleStream | None:

--- a/main_logic/asr_client/_infra.py
+++ b/main_logic/asr_client/_infra.py
@@ -288,6 +288,11 @@ class _RealtimeAsrSessionImpl:
                     asyncio.shield(self._ready_future),
                     timeout=_READY_TIMEOUT_SECONDS,
                 )
+            except asyncio.CancelledError:
+                if self._ready_future is not None and not self._ready_future.done():
+                    self._ready_future.cancel()
+                await self.close()
+                raise
             except asyncio.TimeoutError as exc:
                 if self._ready_future is not None and not self._ready_future.done():
                     self._ready_future.cancel()
@@ -647,8 +652,6 @@ class _RealtimeAsrSessionImpl:
             if event.utterance_id is None:
                 return False
             text = event.text.strip()
-            if not text:
-                return False
             key = (event.generation, event.buffer_epoch, event.utterance_id)
             async with self._operation_lock:
                 if (
@@ -684,7 +687,8 @@ class _RealtimeAsrSessionImpl:
                     self._committed_utterance_keys.discard(ready_key)
             assert self._callback_queue is not None
             for ready_text in ready_texts:
-                await self._callback_queue.put(_CallbackItem(text=ready_text))
+                if ready_text:
+                    await self._callback_queue.put(_CallbackItem(text=ready_text))
             return False
         if event.kind == "error":
             if (

--- a/main_logic/asr_client/_registry_meta.py
+++ b/main_logic/asr_client/_registry_meta.py
@@ -19,7 +19,7 @@ from typing import Literal
 
 
 AsrProviderCategory = Literal["dummy", "ws_streaming", "segmented_request"]
-AsrEndpointingMode = Literal["manual", "server_vad"]
+AsrEndpointingMode = Literal["manual", "provider"]
 AsrImplementationStatus = Literal[
     "implemented",
     "planned",
@@ -35,6 +35,7 @@ class AsrCoreRoute:
     provider_key: str
     credential_field: str
     region: Literal["cn", "intl"] | None = None
+    default_endpointing_mode: AsrEndpointingMode = "manual"
 
 
 @dataclass(frozen=True, slots=True)
@@ -74,6 +75,7 @@ CORE_ASR_ROUTES: dict[str, AsrCoreRoute] = {
     "grok": AsrCoreRoute(
         provider_key="grok",
         credential_field="ASSIST_API_KEY_GROK",
+        default_endpointing_mode="provider",
     ),
     "glm": AsrCoreRoute(
         provider_key="glm",
@@ -103,7 +105,7 @@ ASR_PROVIDER_REGISTRY: dict[str, AsrProviderMeta] = {
         category="ws_streaming",
         worker_input_sample_rate_hz=16_000,
         wire_sample_rate_hz=16_000,
-        supported_endpointing_modes=frozenset({"manual", "server_vad"}),
+        supported_endpointing_modes=frozenset({"manual", "provider"}),
         implementation_status="blocked_credentials",
     ),
     "openai": AsrProviderMeta(
@@ -119,7 +121,7 @@ ASR_PROVIDER_REGISTRY: dict[str, AsrProviderMeta] = {
         category="ws_streaming",
         worker_input_sample_rate_hz=16_000,
         wire_sample_rate_hz=16_000,
-        supported_endpointing_modes=frozenset({"manual", "server_vad"}),
+        supported_endpointing_modes=frozenset({"manual", "provider"}),
         implementation_status="blocked_credentials",
     ),
     "grok": AsrProviderMeta(
@@ -127,7 +129,7 @@ ASR_PROVIDER_REGISTRY: dict[str, AsrProviderMeta] = {
         category="ws_streaming",
         worker_input_sample_rate_hz=16_000,
         wire_sample_rate_hz=16_000,
-        supported_endpointing_modes=frozenset({"server_vad"}),
+        supported_endpointing_modes=frozenset({"provider"}),
         implementation_status="blocked_credentials",
     ),
     "glm": AsrProviderMeta(

--- a/main_logic/asr_client/_registry_meta.py
+++ b/main_logic/asr_client/_registry_meta.py
@@ -19,6 +19,7 @@ from typing import Literal
 
 
 AsrProviderCategory = Literal["dummy", "ws_streaming", "segmented_request"]
+AsrEndpointingMode = Literal["manual", "server_vad"]
 AsrImplementationStatus = Literal[
     "implemented",
     "planned",
@@ -28,28 +29,63 @@ AsrImplementationStatus = Literal[
 
 
 @dataclass(frozen=True, slots=True)
+class AsrCoreRoute:
+    """Bind one Core to its ASR provider, credential slot, and region."""
+
+    provider_key: str
+    credential_field: str
+    region: Literal["cn", "intl"] | None = None
+
+
+@dataclass(frozen=True, slots=True)
 class AsrProviderMeta:
     """Architectural metadata for one ASR provider implementation."""
 
     provider_key: str
     category: AsrProviderCategory
-    canonical_sample_rate_hz: int
+    worker_input_sample_rate_hz: int
+    wire_sample_rate_hz: int
+    supported_endpointing_modes: frozenset[AsrEndpointingMode]
     implementation_status: AsrImplementationStatus
 
 
 # Business code must route through this table rather than scattering
-# ``if core_type == ...`` branches. qwen and qwen_intl intentionally share one
-# worker implementation; their regional endpoint/credential differences belong
-# to the future Alibaba worker.
-CORE_ASR_ROUTES: dict[str, str] = {
-    "qwen": "alibaba",
-    "qwen_intl": "alibaba",
-    "openai": "openai",
-    "step": "step",
-    "grok": "grok",
-    "glm": "glm",
-    "gemini": "gemini",
-    "free": "free",
+# ``if core_type == ...`` branches. qwen and qwen_intl intentionally share
+# workers/qwen.py while keeping region and credential selection explicit.
+CORE_ASR_ROUTES: dict[str, AsrCoreRoute] = {
+    "qwen": AsrCoreRoute(
+        provider_key="qwen",
+        credential_field="ASSIST_API_KEY_QWEN",
+        region="cn",
+    ),
+    "qwen_intl": AsrCoreRoute(
+        provider_key="qwen",
+        credential_field="ASSIST_API_KEY_QWEN_INTL",
+        region="intl",
+    ),
+    "openai": AsrCoreRoute(
+        provider_key="openai",
+        credential_field="ASSIST_API_KEY_OPENAI",
+    ),
+    "step": AsrCoreRoute(
+        provider_key="step",
+        credential_field="ASSIST_API_KEY_STEP",
+    ),
+    "grok": AsrCoreRoute(
+        provider_key="grok",
+        credential_field="ASSIST_API_KEY_GROK",
+    ),
+    "glm": AsrCoreRoute(
+        provider_key="glm",
+        credential_field="ASSIST_API_KEY_GLM",
+    ),
+    "gemini": AsrCoreRoute(
+        provider_key="gemini",
+        credential_field="ASSIST_API_KEY_GEMINI",
+    ),
+    # The free backend is blocked before credential resolution. An empty field
+    # makes it impossible to accidentally borrow AUDIO_API_KEY in the future.
+    "free": AsrCoreRoute(provider_key="free", credential_field=""),
 }
 
 
@@ -57,49 +93,65 @@ ASR_PROVIDER_REGISTRY: dict[str, AsrProviderMeta] = {
     "dummy": AsrProviderMeta(
         provider_key="dummy",
         category="dummy",
-        canonical_sample_rate_hz=16_000,
+        worker_input_sample_rate_hz=16_000,
+        wire_sample_rate_hz=16_000,
+        supported_endpointing_modes=frozenset({"manual"}),
         implementation_status="implemented",
     ),
-    "alibaba": AsrProviderMeta(
-        provider_key="alibaba",
+    "qwen": AsrProviderMeta(
+        provider_key="qwen",
         category="ws_streaming",
-        canonical_sample_rate_hz=16_000,
-        implementation_status="planned",
+        worker_input_sample_rate_hz=16_000,
+        wire_sample_rate_hz=16_000,
+        supported_endpointing_modes=frozenset({"manual", "server_vad"}),
+        implementation_status="blocked_credentials",
     ),
     "openai": AsrProviderMeta(
         provider_key="openai",
         category="ws_streaming",
-        canonical_sample_rate_hz=16_000,
-        implementation_status="planned",
+        worker_input_sample_rate_hz=16_000,
+        wire_sample_rate_hz=24_000,
+        supported_endpointing_modes=frozenset({"manual"}),
+        implementation_status="blocked_credentials",
     ),
     "step": AsrProviderMeta(
         provider_key="step",
         category="ws_streaming",
-        canonical_sample_rate_hz=16_000,
-        implementation_status="planned",
+        worker_input_sample_rate_hz=16_000,
+        wire_sample_rate_hz=16_000,
+        supported_endpointing_modes=frozenset({"manual", "server_vad"}),
+        implementation_status="blocked_credentials",
     ),
     "grok": AsrProviderMeta(
         provider_key="grok",
         category="ws_streaming",
-        canonical_sample_rate_hz=16_000,
-        implementation_status="planned",
+        worker_input_sample_rate_hz=16_000,
+        wire_sample_rate_hz=16_000,
+        supported_endpointing_modes=frozenset({"server_vad"}),
+        implementation_status="blocked_credentials",
     ),
     "glm": AsrProviderMeta(
         provider_key="glm",
         category="segmented_request",
-        canonical_sample_rate_hz=16_000,
+        worker_input_sample_rate_hz=16_000,
+        wire_sample_rate_hz=16_000,
+        supported_endpointing_modes=frozenset({"manual"}),
         implementation_status="planned",
     ),
     "gemini": AsrProviderMeta(
         provider_key="gemini",
         category="segmented_request",
-        canonical_sample_rate_hz=16_000,
+        worker_input_sample_rate_hz=16_000,
+        wire_sample_rate_hz=16_000,
+        supported_endpointing_modes=frozenset({"manual"}),
         implementation_status="planned",
     ),
     "free": AsrProviderMeta(
         provider_key="free",
         category="segmented_request",
-        canonical_sample_rate_hz=16_000,
+        worker_input_sample_rate_hz=16_000,
+        wire_sample_rate_hz=16_000,
+        supported_endpointing_modes=frozenset({"manual"}),
         implementation_status="blocked_backend",
     ),
 }

--- a/main_logic/asr_client/workers/grok.py
+++ b/main_logic/asr_client/workers/grok.py
@@ -374,7 +374,7 @@ async def grok_asr_worker(
         return action
 
     try:
-        if config.endpointing_mode not in {"manual", "server_vad"}:
+        if config.endpointing_mode not in {"manual", "provider"}:
             await _emit_error(
                 "ASR_ENDPOINTING_NOT_SUPPORTED",
                 "xAI endpointing mode is unsupported",
@@ -387,6 +387,10 @@ async def grok_asr_worker(
             "encoding": "pcm",
             "interim_results": "true",
         }
+        if config.endpointing_mode == "provider":
+            # Pin xAI's documented default so provider behavior cannot drift
+            # silently if the upstream default changes.
+            query["endpointing"] = 10
         if language is not None:
             query["language"] = language
         url = f"{_GROK_STT_URL}?{urlencode(query)}"

--- a/main_logic/asr_client/workers/grok.py
+++ b/main_logic/asr_client/workers/grok.py
@@ -1,0 +1,443 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""xAI Grok streaming speech-to-text worker."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections import deque
+from typing import Any, Literal
+from urllib.parse import urlencode
+
+import websockets
+
+from .._infra import AsrSessionConfig, _AsrWorkerEvent, _AsrWorkerRequest
+
+
+_GROK_STT_URL = "wss://api.x.ai/v1/stt"
+_CLOSE_TIMEOUT_SECONDS = 0.5
+_SHUTDOWN_TIMEOUT_SECONDS = 3.0
+
+_UtteranceKey = tuple[int, int, int | None]
+_ConnectionAction = Literal["reconnect", "shutdown", "failed"]
+
+
+def _normalize_grok_language(language: str) -> str | None:
+    normalized = language.strip().lower()
+    if normalized == "auto":
+        return None
+    if normalized in {"zh", "zh-cn"}:
+        return "zh"
+    if normalized in {"en", "en-us"}:
+        return "en"
+    raise ValueError("ASR_LANGUAGE_NOT_SUPPORTED: xAI language is unsupported")
+
+
+def _grok_is_auth_rejection(exc: BaseException) -> bool:
+    response = getattr(exc, "response", None)
+    status_code = getattr(response, "status_code", None)
+    if status_code is None:
+        status_code = getattr(exc, "status_code", None)
+    return status_code in {401, 403}
+
+
+async def grok_asr_worker(
+    request_queue: asyncio.Queue[_AsrWorkerRequest],
+    response_queue: asyncio.Queue[_AsrWorkerEvent],
+    api_key: str,
+    config: AsrSessionConfig,
+) -> None:
+    """Stream raw 16 kHz PCM to xAI's dedicated STT WebSocket."""
+
+    last_generation = 0
+    failure_sent = False
+    ready_sent = False
+    shutdown_requested = asyncio.Event()
+    websocket = None
+
+    async def _emit_error(error_code: str, error_message: str) -> None:
+        nonlocal failure_sent
+        if failure_sent:
+            return
+        failure_sent = True
+        await response_queue.put(
+            _AsrWorkerEvent(
+                kind="error",
+                generation=last_generation,
+                error_code=error_code,
+                error_message=error_message,
+            )
+        )
+
+    async def _connect_ready(url: str):
+        connection = await websockets.connect(
+            url,
+            additional_headers={"Authorization": f"Bearer {api_key}"},
+            close_timeout=_CLOSE_TIMEOUT_SECONDS,
+        )
+        try:
+            while True:
+                message = await connection.recv()
+                if isinstance(message, bytes):
+                    await _emit_error(
+                        "ASR_GROK_PROTOCOL_ERROR",
+                        "xAI returned an unexpected binary event",
+                    )
+                    await connection.close()
+                    return None
+                try:
+                    event = json.loads(message)
+                except (TypeError, json.JSONDecodeError):
+                    await _emit_error(
+                        "ASR_GROK_PROTOCOL_ERROR",
+                        "xAI returned an invalid event",
+                    )
+                    await connection.close()
+                    return None
+                if not isinstance(event, dict):
+                    continue
+                event_type = event.get("type")
+                if event_type == "transcript.created":
+                    return connection
+                if event_type == "error":
+                    await _emit_error(
+                        "ASR_GROK_ERROR",
+                        "xAI streaming transcription failed",
+                    )
+                    await connection.close()
+                    return None
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            try:
+                await connection.close()
+            except Exception:
+                pass
+            raise
+
+    async def _run_connection(connection) -> _ConnectionAction:
+        nonlocal last_generation
+
+        latest_audio_key: _UtteranceKey | None = None
+        pending_manual_commits: deque[_UtteranceKey] = deque()
+        manual_locked_segments: dict[_UtteranceKey, list[str]] = {}
+        active_server_key: _UtteranceKey | None = None
+        next_server_utterance_id: int | None = None
+        intentional_close = asyncio.Event()
+
+        async def _receive_events() -> None:
+            nonlocal active_server_key, next_server_utterance_id
+            try:
+                async for message in connection:
+                    if isinstance(message, bytes):
+                        await _emit_error(
+                            "ASR_GROK_PROTOCOL_ERROR",
+                            "xAI returned an unexpected binary event",
+                        )
+                        return
+                    try:
+                        event = json.loads(message)
+                    except (TypeError, json.JSONDecodeError):
+                        await _emit_error(
+                            "ASR_GROK_PROTOCOL_ERROR",
+                            "xAI returned an invalid event",
+                        )
+                        return
+                    if not isinstance(event, dict):
+                        continue
+
+                    event_type = event.get("type")
+                    if event_type == "error":
+                        await _emit_error(
+                            "ASR_GROK_ERROR",
+                            "xAI streaming transcription failed",
+                        )
+                        return
+                    if event_type == "transcript.done":
+                        return
+                    if event_type != "transcript.partial":
+                        continue
+
+                    text = event.get("text", "")
+                    if not isinstance(text, str):
+                        text = ""
+                    is_final = event.get("is_final") is True
+                    speech_final = event.get("speech_final") is True
+
+                    if config.endpointing_mode == "manual":
+                        key = (
+                            pending_manual_commits[0]
+                            if pending_manual_commits
+                            else latest_audio_key
+                        )
+                        if key is None:
+                            continue
+                        if is_final and speech_final:
+                            if pending_manual_commits:
+                                final_key = pending_manual_commits.popleft()
+                                segments = manual_locked_segments.pop(final_key, [])
+                                segments.append(text)
+                                await response_queue.put(
+                                    _AsrWorkerEvent(
+                                        kind="final",
+                                        generation=final_key[0],
+                                        buffer_epoch=final_key[1],
+                                        utterance_id=final_key[2],
+                                        text="".join(segments),
+                                    )
+                                )
+                            else:
+                                # Natural endpointing can race ahead of a PTT
+                                # commit. Keep every locked segment as partial;
+                                # the public commit still sends ``finalize`` so
+                                # later speech cannot be lost or overwritten.
+                                segments = manual_locked_segments.setdefault(key, [])
+                                segments.append(text)
+                                await response_queue.put(
+                                    _AsrWorkerEvent(
+                                        kind="partial",
+                                        generation=key[0],
+                                        buffer_epoch=key[1],
+                                        utterance_id=key[2],
+                                        text="".join(segments),
+                                    )
+                                )
+                            continue
+                        # Both mutable interim results and locked chunks
+                        # (is_final=true, speech_final=false) remain partial.
+                        await response_queue.put(
+                            _AsrWorkerEvent(
+                                kind="partial",
+                                generation=key[0],
+                                buffer_epoch=key[1],
+                                utterance_id=key[2],
+                                text="".join(
+                                    [*manual_locked_segments.get(key, []), text]
+                                ),
+                            )
+                        )
+                        continue
+
+                    if active_server_key is None:
+                        if latest_audio_key is None:
+                            continue
+                        if next_server_utterance_id is None:
+                            next_server_utterance_id = latest_audio_key[2] or 1
+                        active_server_key = (
+                            latest_audio_key[0],
+                            latest_audio_key[1],
+                            next_server_utterance_id,
+                        )
+                        next_server_utterance_id += 1
+                        await response_queue.put(
+                            _AsrWorkerEvent(
+                                kind="utterance_started",
+                                generation=active_server_key[0],
+                                buffer_epoch=active_server_key[1],
+                                utterance_id=active_server_key[2],
+                            )
+                        )
+
+                    key = active_server_key
+                    kind = "final" if is_final and speech_final else "partial"
+                    await response_queue.put(
+                        _AsrWorkerEvent(
+                            kind=kind,
+                            generation=key[0],
+                            buffer_epoch=key[1],
+                            utterance_id=key[2],
+                            text=text,
+                        )
+                    )
+                    if kind == "final":
+                        active_server_key = None
+            except asyncio.CancelledError:
+                raise
+            except websockets.exceptions.ConnectionClosed:
+                pass
+            except Exception:
+                await _emit_error(
+                    "ASR_GROK_WORKER_FAILED",
+                    "xAI streaming transcription failed",
+                )
+                return
+
+            if (
+                not intentional_close.is_set()
+                and not shutdown_requested.is_set()
+                and not failure_sent
+            ):
+                await _emit_error(
+                    "ASR_GROK_DISCONNECTED",
+                    "xAI streaming transcription disconnected unexpectedly",
+                )
+
+        async def _send_requests() -> _ConnectionAction:
+            nonlocal latest_audio_key, last_generation
+            while True:
+                request = await request_queue.get()
+                try:
+                    last_generation = request.generation
+                    key = (
+                        request.generation,
+                        request.buffer_epoch,
+                        request.utterance_id,
+                    )
+
+                    if request.kind == "audio":
+                        latest_audio_key = key
+                        if request.audio:
+                            await connection.send(request.audio)
+                        continue
+
+                    if request.kind == "commit":
+                        if config.endpointing_mode != "manual":
+                            await _emit_error(
+                                "ASR_GROK_PROTOCOL_ERROR",
+                                "xAI server VAD received an unexpected commit",
+                            )
+                            return "failed"
+                        pending_manual_commits.append(key)
+                        await connection.send(json.dumps({"type": "finalize"}))
+                        continue
+
+                    if request.kind == "clear":
+                        # xAI STT has no native clear. Reconnect to the same
+                        # provider, and don't consume later queued audio until the
+                        # new transcript.created handshake completes.
+                        intentional_close.set()
+                        return "reconnect"
+
+                    if request.kind == "shutdown":
+                        shutdown_requested.set()
+                        await connection.send(json.dumps({"type": "audio.done"}))
+                        return "shutdown"
+
+                    await _emit_error(
+                        "ASR_GROK_PROTOCOL_ERROR",
+                        "xAI worker received an unsupported command",
+                    )
+                    return "failed"
+                finally:
+                    request_queue.task_done()
+
+        receiver_task = asyncio.create_task(_receive_events(), name="grok-asr-receiver")
+        sender_task = asyncio.create_task(_send_requests(), name="grok-asr-sender")
+        done, _ = await asyncio.wait(
+            {sender_task, receiver_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+
+        action = await sender_task if sender_task in done else None
+        if receiver_task in done:
+            await receiver_task
+            if action is not None:
+                return action
+            if not sender_task.done():
+                sender_task.cancel()
+                await asyncio.gather(sender_task, return_exceptions=True)
+            return "failed"
+
+        assert action is not None
+        if action == "shutdown":
+            try:
+                await asyncio.wait_for(
+                    asyncio.shield(receiver_task),
+                    timeout=_SHUTDOWN_TIMEOUT_SECONDS,
+                )
+            except asyncio.TimeoutError:
+                receiver_task.cancel()
+                await asyncio.gather(receiver_task, return_exceptions=True)
+            return action
+
+        intentional_close.set()
+        try:
+            await connection.close()
+        except Exception:
+            pass
+        if not receiver_task.done():
+            receiver_task.cancel()
+        await asyncio.gather(receiver_task, return_exceptions=True)
+        return action
+
+    try:
+        if config.endpointing_mode not in {"manual", "server_vad"}:
+            await _emit_error(
+                "ASR_ENDPOINTING_NOT_SUPPORTED",
+                "xAI endpointing mode is unsupported",
+            )
+            return
+
+        language = _normalize_grok_language(config.language)
+        query: dict[str, Any] = {
+            "sample_rate": 16_000,
+            "encoding": "pcm",
+            "interim_results": "true",
+        }
+        if language is not None:
+            query["language"] = language
+        url = f"{_GROK_STT_URL}?{urlencode(query)}"
+
+        while True:
+            websocket = await _connect_ready(url)
+            if websocket is None:
+                return
+            if not ready_sent:
+                ready_sent = True
+                await response_queue.put(
+                    _AsrWorkerEvent(kind="ready", generation=last_generation)
+                )
+
+            action = await _run_connection(websocket)
+            try:
+                await websocket.close()
+            except Exception:
+                pass
+            websocket = None
+
+            if action == "reconnect":
+                continue
+            return
+    except asyncio.CancelledError:
+        raise
+    except ValueError as exc:
+        await _emit_error(
+            "ASR_LANGUAGE_NOT_SUPPORTED",
+            str(exc).partition(": ")[2] or "xAI language is unsupported",
+        )
+    except Exception as exc:
+        await _emit_error(
+            (
+                "ASR_CREDENTIALS_REJECTED"
+                if _grok_is_auth_rejection(exc)
+                else "ASR_GROK_WORKER_FAILED"
+            ),
+            (
+                "xAI credentials were rejected"
+                if _grok_is_auth_rejection(exc)
+                else "xAI streaming transcription failed"
+            ),
+        )
+    finally:
+        shutdown_requested.set()
+        if websocket is not None:
+            try:
+                await websocket.close()
+            except Exception:
+                pass
+        await response_queue.put(
+            _AsrWorkerEvent(kind="closed", generation=last_generation)
+        )

--- a/main_logic/asr_client/workers/openai.py
+++ b/main_logic/asr_client/workers/openai.py
@@ -1,0 +1,401 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OpenAI transcription-only Realtime ASR worker."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from collections import deque
+from typing import Any
+
+import numpy as np
+import soxr
+import websockets
+
+from .._infra import AsrSessionConfig, _AsrWorkerEvent, _AsrWorkerRequest
+
+
+_OPENAI_REALTIME_URL = "wss://api.openai.com/v1/realtime?model=gpt-realtime-whisper"
+_OPENAI_MODEL = "gpt-realtime-whisper"
+_CLOSE_TIMEOUT_SECONDS = 0.5
+
+_UtteranceKey = tuple[int, int, int | None]
+
+
+def _normalize_openai_language(language: str) -> str | None:
+    normalized = language.strip().lower()
+    if normalized == "auto":
+        return None
+    if normalized in {"zh", "zh-cn"}:
+        return "zh"
+    if normalized in {"en", "en-us"}:
+        return "en"
+    raise ValueError("ASR_LANGUAGE_NOT_SUPPORTED: OpenAI language is unsupported")
+
+
+def _openai_is_auth_rejection(exc: BaseException) -> bool:
+    response = getattr(exc, "response", None)
+    status_code = getattr(response, "status_code", None)
+    if status_code is None:
+        status_code = getattr(exc, "status_code", None)
+    return status_code in {401, 403}
+
+
+def _resample_pcm_16k_to_24k(
+    resampler: soxr.ResampleStream,
+    audio: bytes,
+    *,
+    last: bool = False,
+) -> bytes:
+    if audio:
+        samples = np.frombuffer(audio, dtype="<i2").astype(np.float32)
+        samples /= 32768.0
+    else:
+        samples = np.empty(0, dtype=np.float32)
+    output = resampler.resample_chunk(samples, last=last)
+    if len(output) == 0:
+        return b""
+    return (output * 32768.0).clip(-32768, 32767).astype("<i2").tobytes()
+
+
+async def openai_asr_worker(
+    request_queue: asyncio.Queue[_AsrWorkerRequest],
+    response_queue: asyncio.Queue[_AsrWorkerEvent],
+    api_key: str,
+    config: AsrSessionConfig,
+) -> None:
+    """Stream 16 kHz worker PCM into OpenAI's 24 kHz transcription session."""
+
+    last_generation = 0
+    closed_sent = False
+    failure_sent = False
+    ready_sent = False
+    shutdown_requested = asyncio.Event()
+    receiver_task: asyncio.Task[None] | None = None
+    sender_task: asyncio.Task[None] | None = None
+    websocket = None
+
+    pending_commits: deque[_UtteranceKey] = deque()
+    item_keys: dict[str, _UtteranceKey] = {}
+    resampler = soxr.ResampleStream(
+        16_000,
+        24_000,
+        1,
+        dtype="float32",
+        quality="HQ",
+    )
+
+    async def _emit_error(error_code: str, error_message: str) -> None:
+        nonlocal failure_sent
+        if failure_sent:
+            return
+        failure_sent = True
+        await response_queue.put(
+            _AsrWorkerEvent(
+                kind="error",
+                generation=last_generation,
+                error_code=error_code,
+                error_message=error_message,
+            )
+        )
+
+    async def _handle_transcript_event(event: dict[str, Any]) -> None:
+        item_id = event.get("item_id")
+        if not isinstance(item_id, str) or not item_id:
+            return
+        key = item_keys.get(item_id)
+        if key is None:
+            # input_audio_buffer.committed is ordered before transcript events.
+            # An unknown ID therefore belongs to an item invalidated by clear.
+            return
+        generation, buffer_epoch, utterance_id = key
+        event_type = event.get("type")
+        if event_type == "conversation.item.input_audio_transcription.delta":
+            text = event.get("delta", "")
+            if isinstance(text, str):
+                await response_queue.put(
+                    _AsrWorkerEvent(
+                        kind="partial",
+                        generation=generation,
+                        buffer_epoch=buffer_epoch,
+                        utterance_id=utterance_id,
+                        text=text,
+                    )
+                )
+            return
+        if event_type == "conversation.item.input_audio_transcription.completed":
+            text = event.get("transcript", "")
+            if isinstance(text, str):
+                await response_queue.put(
+                    _AsrWorkerEvent(
+                        kind="final",
+                        generation=generation,
+                        buffer_epoch=buffer_epoch,
+                        utterance_id=utterance_id,
+                        text=text,
+                    )
+                )
+            item_keys.pop(item_id, None)
+
+    async def _receive_events(ready_event: asyncio.Event) -> None:
+        nonlocal ready_sent
+        try:
+            async for message in websocket:
+                if isinstance(message, bytes):
+                    await _emit_error(
+                        "ASR_OPENAI_PROTOCOL_ERROR",
+                        "OpenAI returned an unexpected binary event",
+                    )
+                    return
+                try:
+                    event = json.loads(message)
+                except (TypeError, json.JSONDecodeError):
+                    await _emit_error(
+                        "ASR_OPENAI_PROTOCOL_ERROR",
+                        "OpenAI returned an invalid event",
+                    )
+                    return
+                if not isinstance(event, dict):
+                    continue
+
+                event_type = event.get("type")
+                if event_type == "session.updated":
+                    if not ready_sent:
+                        ready_sent = True
+                        ready_event.set()
+                        await response_queue.put(
+                            _AsrWorkerEvent(kind="ready", generation=last_generation)
+                        )
+                    continue
+                if event_type == "input_audio_buffer.committed":
+                    item_id = event.get("item_id")
+                    if isinstance(item_id, str) and item_id and pending_commits:
+                        item_keys[item_id] = pending_commits.popleft()
+                    continue
+                if event_type in {
+                    "conversation.item.input_audio_transcription.delta",
+                    "conversation.item.input_audio_transcription.completed",
+                }:
+                    await _handle_transcript_event(event)
+                    continue
+                if event_type == "error":
+                    await _emit_error(
+                        "ASR_OPENAI_ERROR",
+                        "OpenAI realtime transcription failed",
+                    )
+                    return
+        except asyncio.CancelledError:
+            raise
+        except websockets.exceptions.ConnectionClosed:
+            pass
+        except Exception:
+            await _emit_error(
+                "ASR_OPENAI_WORKER_FAILED",
+                "OpenAI realtime transcription failed",
+            )
+            return
+
+        if not shutdown_requested.is_set() and not failure_sent:
+            await _emit_error(
+                "ASR_OPENAI_DISCONNECTED",
+                "OpenAI realtime transcription disconnected unexpectedly",
+            )
+
+    async def _send_requests() -> None:
+        nonlocal last_generation, resampler
+        while True:
+            request = await request_queue.get()
+            try:
+                last_generation = request.generation
+
+                if request.kind == "audio":
+                    wire_audio = _resample_pcm_16k_to_24k(resampler, request.audio)
+                    if wire_audio:
+                        await websocket.send(
+                            json.dumps(
+                                {
+                                    "type": "input_audio_buffer.append",
+                                    "audio": base64.b64encode(wire_audio).decode(
+                                        "ascii"
+                                    ),
+                                }
+                            )
+                        )
+                    continue
+
+                if request.kind == "commit":
+                    tail = _resample_pcm_16k_to_24k(resampler, b"", last=True)
+                    if tail:
+                        await websocket.send(
+                            json.dumps(
+                                {
+                                    "type": "input_audio_buffer.append",
+                                    "audio": base64.b64encode(tail).decode("ascii"),
+                                }
+                            )
+                        )
+                    pending_commits.append(
+                        (
+                            request.generation,
+                            request.buffer_epoch,
+                            request.utterance_id,
+                        )
+                    )
+                    await websocket.send(
+                        json.dumps({"type": "input_audio_buffer.commit"})
+                    )
+                    resampler = soxr.ResampleStream(
+                        16_000,
+                        24_000,
+                        1,
+                        dtype="float32",
+                        quality="HQ",
+                    )
+                    continue
+
+                if request.kind == "clear":
+                    # Keep already-sent commit keys in FIFO order. Their late
+                    # acknowledgements must consume the old epoch keys instead
+                    # of stealing a post-clear key; Session drops old finals.
+                    item_keys.clear()
+                    resampler.clear()
+                    resampler = soxr.ResampleStream(
+                        16_000,
+                        24_000,
+                        1,
+                        dtype="float32",
+                        quality="HQ",
+                    )
+                    await websocket.send(
+                        json.dumps({"type": "input_audio_buffer.clear"})
+                    )
+                    continue
+
+                if request.kind == "shutdown":
+                    shutdown_requested.set()
+                    await websocket.close()
+                    return
+
+                await _emit_error(
+                    "ASR_OPENAI_PROTOCOL_ERROR",
+                    "OpenAI worker received an unsupported command",
+                )
+                return
+            finally:
+                request_queue.task_done()
+
+    try:
+        if config.endpointing_mode != "manual":
+            await _emit_error(
+                "ASR_ENDPOINTING_NOT_SUPPORTED",
+                "OpenAI realtime transcription only supports manual endpointing",
+            )
+            return
+
+        language = _normalize_openai_language(config.language)
+        transcription: dict[str, Any] = {"model": _OPENAI_MODEL}
+        if language is not None:
+            transcription["language"] = language
+        session_update = {
+            "type": "session.update",
+            "session": {
+                "type": "transcription",
+                "audio": {
+                    "input": {
+                        "format": {"type": "audio/pcm", "rate": 24_000},
+                        "transcription": transcription,
+                        "turn_detection": None,
+                    }
+                },
+            },
+        }
+
+        websocket = await websockets.connect(
+            _OPENAI_REALTIME_URL,
+            additional_headers={"Authorization": f"Bearer {api_key}"},
+            close_timeout=_CLOSE_TIMEOUT_SECONDS,
+        )
+        ready_event = asyncio.Event()
+        receiver_task = asyncio.create_task(
+            _receive_events(ready_event), name="openai-asr-receiver"
+        )
+        await websocket.send(json.dumps(session_update))
+
+        ready_wait_task = asyncio.create_task(ready_event.wait())
+        done, _ = await asyncio.wait(
+            {ready_wait_task, receiver_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if ready_wait_task not in done:
+            ready_wait_task.cancel()
+            await asyncio.gather(ready_wait_task, return_exceptions=True)
+            await receiver_task
+            return
+
+        await ready_wait_task
+        sender_task = asyncio.create_task(_send_requests(), name="openai-asr-sender")
+        done, pending = await asyncio.wait(
+            {sender_task, receiver_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for task in done:
+            await task
+        if pending:
+            if shutdown_requested.is_set():
+                await asyncio.gather(*pending, return_exceptions=True)
+            else:
+                for task in pending:
+                    task.cancel()
+                await asyncio.gather(*pending, return_exceptions=True)
+    except asyncio.CancelledError:
+        raise
+    except ValueError as exc:
+        await _emit_error(
+            "ASR_LANGUAGE_NOT_SUPPORTED",
+            str(exc).partition(": ")[2] or "OpenAI language is unsupported",
+        )
+    except Exception as exc:
+        await _emit_error(
+            (
+                "ASR_CREDENTIALS_REJECTED"
+                if _openai_is_auth_rejection(exc)
+                else "ASR_OPENAI_WORKER_FAILED"
+            ),
+            (
+                "OpenAI credentials were rejected"
+                if _openai_is_auth_rejection(exc)
+                else "OpenAI realtime transcription failed"
+            ),
+        )
+    finally:
+        shutdown_requested.set()
+        for task in (sender_task, receiver_task):
+            if task is not None and not task.done():
+                task.cancel()
+        tasks = [task for task in (sender_task, receiver_task) if task is not None]
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        if websocket is not None:
+            try:
+                await websocket.close()
+            except Exception:
+                pass
+        if not closed_sent:
+            await response_queue.put(
+                _AsrWorkerEvent(kind="closed", generation=last_generation)
+            )
+            closed_sent = True

--- a/main_logic/asr_client/workers/openai.py
+++ b/main_logic/asr_client/workers/openai.py
@@ -192,6 +192,15 @@ async def openai_asr_worker(
                 }:
                     await _handle_transcript_event(event)
                     continue
+                if event_type == "conversation.item.input_audio_transcription.failed":
+                    item_id = event.get("item_id")
+                    if isinstance(item_id, str):
+                        item_keys.pop(item_id, None)
+                    await _emit_error(
+                        "ASR_OPENAI_TRANSCRIPTION_FAILED",
+                        "OpenAI failed to transcribe a committed audio item",
+                    )
+                    return
                 if event_type == "error":
                     await _emit_error(
                         "ASR_OPENAI_ERROR",

--- a/main_logic/asr_client/workers/openai.py
+++ b/main_logic/asr_client/workers/openai.py
@@ -29,7 +29,7 @@ import websockets
 from .._infra import AsrSessionConfig, _AsrWorkerEvent, _AsrWorkerRequest
 
 
-_OPENAI_REALTIME_URL = "wss://api.openai.com/v1/realtime?model=gpt-realtime-whisper"
+_OPENAI_REALTIME_URL = "wss://api.openai.com/v1/realtime?intent=transcription"
 _OPENAI_MODEL = "gpt-realtime-whisper"
 _CLOSE_TIMEOUT_SECONDS = 0.5
 

--- a/main_logic/asr_client/workers/qwen.py
+++ b/main_logic/asr_client/workers/qwen.py
@@ -118,7 +118,7 @@ def _qwen_session_update(
 ) -> dict[str, Any]:
     if config.endpointing_mode == "manual":
         turn_detection: dict[str, str] | None = None
-    elif config.endpointing_mode == "server_vad":
+    elif config.endpointing_mode == "provider":
         turn_detection = {"type": "server_vad"}
     else:
         raise ValueError("unsupported Qwen ASR endpointing mode")
@@ -367,7 +367,7 @@ async def _qwen_receiver(
                 continue
 
             if event_type == "input_audio_buffer.speech_started":
-                if config.endpointing_mode != "server_vad":
+                if config.endpointing_mode != "provider":
                     continue
                 item_id = str(event.get("item_id") or "")
                 if not item_id or item_id in state.item_keys:

--- a/main_logic/asr_client/workers/qwen.py
+++ b/main_logic/asr_client/workers/qwen.py
@@ -359,9 +359,10 @@ async def _qwen_receiver(
                 if not state.pending_manual_commits:
                     continue
                 if item_id:
-                    state.item_keys.setdefault(
-                        item_id, state.pending_manual_commits.popleft()
-                    )
+                    if item_id not in state.item_keys:
+                        state.item_keys[item_id] = (
+                            state.pending_manual_commits.popleft()
+                        )
                 elif state.legacy_manual_key is None:
                     state.legacy_manual_key = state.pending_manual_commits[0]
                 continue

--- a/main_logic/asr_client/workers/qwen.py
+++ b/main_logic/asr_client/workers/qwen.py
@@ -1,0 +1,689 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Qwen-ASR Realtime worker for the China and international regions."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import uuid
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any, TypeAlias
+
+import websockets
+from websockets.exceptions import ConnectionClosed
+
+from .._infra import AsrSessionConfig, _AsrWorkerEvent, _AsrWorkerRequest
+
+_QWEN_MODEL = "qwen3-asr-flash-realtime"
+_QWEN_CN_URL = f"wss://dashscope.aliyuncs.com/api-ws/v1/realtime?model={_QWEN_MODEL}"
+_QWEN_INTL_URL = (
+    f"wss://dashscope-intl.aliyuncs.com/api-ws/v1/realtime?model={_QWEN_MODEL}"
+)
+_QWEN_FINISH_TIMEOUT_SECONDS = 3.0
+_QWEN_SUPPORTED_LANGUAGES = frozenset(
+    {
+        "ar",
+        "cs",
+        "da",
+        "de",
+        "en",
+        "es",
+        "fi",
+        "fil",
+        "fr",
+        "hi",
+        "id",
+        "is",
+        "it",
+        "ja",
+        "ko",
+        "ms",
+        "no",
+        "pl",
+        "pt",
+        "ru",
+        "sv",
+        "th",
+        "tr",
+        "uk",
+        "vi",
+        "yue",
+        "zh",
+    }
+)
+
+_ItemKey: TypeAlias = tuple[int, int, int]
+
+
+@dataclass(slots=True)
+class _QwenConnectionState:
+    generation: int
+    buffer_epoch: int
+    next_utterance_id: int
+    emit_ready: bool
+    item_keys: dict[str, _ItemKey] = field(default_factory=dict)
+    pending_manual_commits: deque[_ItemKey] = field(default_factory=deque)
+    configured: asyncio.Event = field(default_factory=asyncio.Event)
+    finish_received: asyncio.Event = field(default_factory=asyncio.Event)
+    intentional_close: asyncio.Event = field(default_factory=asyncio.Event)
+    error_sent: asyncio.Event = field(default_factory=asyncio.Event)
+    closed_sent: asyncio.Event = field(default_factory=asyncio.Event)
+    last_utterance_id: int | None = None
+    # Legacy DashScope domains can omit the documented ``item_id`` fields.
+    # Their manual stream is ordered, so retain the head commit until final.
+    legacy_manual_key: _ItemKey | None = None
+    shutdown_request: _AsrWorkerRequest | None = None
+
+
+def _qwen_event_id() -> str:
+    return f"event_{uuid.uuid4().hex}"
+
+
+def _qwen_language_code(language: str) -> str | None:
+    normalized = language.strip().lower()
+    if normalized == "auto":
+        return None
+    code = normalized.split("-", 1)[0]
+    if code not in _QWEN_SUPPORTED_LANGUAGES:
+        raise ValueError("unsupported Qwen ASR language")
+    return code
+
+
+def _qwen_is_auth_rejection(exc: BaseException) -> bool:
+    response = getattr(exc, "response", None)
+    status_code = getattr(response, "status_code", None)
+    if status_code is None:
+        status_code = getattr(exc, "status_code", None)
+    return status_code in {401, 403}
+
+
+def _qwen_session_update(
+    config: AsrSessionConfig,
+    language: str | None,
+) -> dict[str, Any]:
+    if config.endpointing_mode == "manual":
+        turn_detection: dict[str, str] | None = None
+    elif config.endpointing_mode == "server_vad":
+        turn_detection = {"type": "server_vad"}
+    else:
+        raise ValueError("unsupported Qwen ASR endpointing mode")
+
+    transcription: dict[str, str] = {}
+    if language is not None:
+        transcription["language"] = language
+    return {
+        "event_id": _qwen_event_id(),
+        "type": "session.update",
+        "session": {
+            "modalities": ["text"],
+            "input_audio_format": "pcm",
+            "sample_rate": 16000,
+            "input_audio_transcription": transcription,
+            "turn_detection": turn_detection,
+        },
+    }
+
+
+async def _emit_qwen_error_once(
+    response_queue: asyncio.Queue[_AsrWorkerEvent],
+    state: _QwenConnectionState,
+    error_code: str,
+    error_message: str,
+    *,
+    item_key: _ItemKey | None = None,
+) -> None:
+    if state.error_sent.is_set():
+        return
+    state.error_sent.set()
+    generation, buffer_epoch, utterance_id = item_key or (
+        state.generation,
+        state.buffer_epoch,
+        state.last_utterance_id,
+    )
+    await response_queue.put(
+        _AsrWorkerEvent(
+            kind="error",
+            generation=generation,
+            buffer_epoch=buffer_epoch,
+            utterance_id=utterance_id,
+            error_code=error_code,
+            error_message=error_message,
+        )
+    )
+
+
+async def _qwen_sender(
+    ws: Any,
+    request_queue: asyncio.Queue[_AsrWorkerRequest],
+    response_queue: asyncio.Queue[_AsrWorkerEvent],
+    config: AsrSessionConfig,
+    state: _QwenConnectionState,
+) -> tuple[str, _AsrWorkerRequest | None]:
+    await state.configured.wait()
+    try:
+        while True:
+            request = await request_queue.get()
+            try:
+                if request.kind == "audio":
+                    state.last_utterance_id = request.utterance_id
+                    await ws.send(
+                        json.dumps(
+                            {
+                                "event_id": _qwen_event_id(),
+                                "type": "input_audio_buffer.append",
+                                "audio": base64.b64encode(request.audio).decode(
+                                    "ascii"
+                                ),
+                            }
+                        )
+                    )
+                    continue
+
+                if request.kind == "commit":
+                    if config.endpointing_mode != "manual":
+                        await _emit_qwen_error_once(
+                            response_queue,
+                            state,
+                            "ASR_QWEN_PROTOCOL_ERROR",
+                            "Qwen ASR received commit while server VAD is active",
+                        )
+                        return "error", request
+                    if request.utterance_id is None:
+                        await _emit_qwen_error_once(
+                            response_queue,
+                            state,
+                            "ASR_QWEN_PROTOCOL_ERROR",
+                            "Qwen ASR commit is missing an utterance identifier",
+                        )
+                        return "error", request
+                    key = (
+                        request.generation,
+                        request.buffer_epoch,
+                        request.utterance_id,
+                    )
+                    state.pending_manual_commits.append(key)
+                    await ws.send(
+                        json.dumps(
+                            {
+                                "event_id": _qwen_event_id(),
+                                "type": "input_audio_buffer.commit",
+                            }
+                        )
+                    )
+                    continue
+
+                if request.kind == "clear":
+                    state.intentional_close.set()
+                    try:
+                        await ws.close()
+                    except Exception:
+                        pass
+                    return "clear", request
+
+                if request.kind == "shutdown":
+                    state.shutdown_request = request
+                    await ws.send(
+                        json.dumps(
+                            {
+                                "event_id": _qwen_event_id(),
+                                "type": "session.finish",
+                            }
+                        )
+                    )
+                    try:
+                        await asyncio.wait_for(
+                            state.finish_received.wait(),
+                            timeout=_QWEN_FINISH_TIMEOUT_SECONDS,
+                        )
+                    except asyncio.TimeoutError:
+                        if not state.closed_sent.is_set():
+                            state.closed_sent.set()
+                            await response_queue.put(
+                                _AsrWorkerEvent(
+                                    kind="closed",
+                                    generation=request.generation,
+                                    buffer_epoch=request.buffer_epoch,
+                                    utterance_id=request.utterance_id,
+                                )
+                            )
+                    state.intentional_close.set()
+                    try:
+                        await ws.close()
+                    except Exception:
+                        pass
+                    return "shutdown", request
+
+                await _emit_qwen_error_once(
+                    response_queue,
+                    state,
+                    "ASR_QWEN_PROTOCOL_ERROR",
+                    "Qwen ASR received an unsupported command",
+                )
+                return "error", request
+            finally:
+                request_queue.task_done()
+    except asyncio.CancelledError:
+        raise
+    except ConnectionClosed:
+        if not state.intentional_close.is_set():
+            await _emit_qwen_error_once(
+                response_queue,
+                state,
+                "ASR_QWEN_CONNECTION_CLOSED",
+                "Qwen ASR connection closed unexpectedly",
+            )
+        return "error", None
+    except Exception:
+        await _emit_qwen_error_once(
+            response_queue,
+            state,
+            "ASR_QWEN_WORKER_FAILED",
+            "Qwen ASR sender failed",
+        )
+        return "error", None
+
+
+async def _qwen_receiver(
+    ws: Any,
+    response_queue: asyncio.Queue[_AsrWorkerEvent],
+    config: AsrSessionConfig,
+    state: _QwenConnectionState,
+) -> str:
+    try:
+        async for raw_message in ws:
+            try:
+                event = json.loads(raw_message)
+            except (TypeError, ValueError):
+                await _emit_qwen_error_once(
+                    response_queue,
+                    state,
+                    "ASR_QWEN_PROTOCOL_ERROR",
+                    "Qwen ASR returned an invalid event",
+                )
+                return "error"
+
+            event_type = event.get("type")
+            if event_type == "session.updated":
+                if not state.configured.is_set():
+                    state.configured.set()
+                    if state.emit_ready:
+                        await response_queue.put(
+                            _AsrWorkerEvent(
+                                kind="ready",
+                                generation=state.generation,
+                                buffer_epoch=state.buffer_epoch,
+                            )
+                        )
+                continue
+
+            if event_type in (
+                "error",
+                "conversation.item.input_audio_transcription.failed",
+            ):
+                if state.intentional_close.is_set():
+                    return "closed"
+                item_id = str(event.get("item_id") or "")
+                await _emit_qwen_error_once(
+                    response_queue,
+                    state,
+                    "ASR_QWEN_PROVIDER_ERROR",
+                    "Qwen ASR provider reported an error",
+                    item_key=(
+                        state.item_keys.get(item_id)
+                        if item_id
+                        else state.legacy_manual_key
+                    ),
+                )
+                return "error"
+
+            if event_type == "conversation.item.created":
+                if config.endpointing_mode != "manual":
+                    continue
+                item = event.get("item")
+                item_id = str(item.get("id") or "") if isinstance(item, dict) else ""
+                if not state.pending_manual_commits:
+                    continue
+                if item_id:
+                    state.item_keys.setdefault(
+                        item_id, state.pending_manual_commits.popleft()
+                    )
+                elif state.legacy_manual_key is None:
+                    state.legacy_manual_key = state.pending_manual_commits[0]
+                continue
+
+            if event_type == "input_audio_buffer.speech_started":
+                if config.endpointing_mode != "server_vad":
+                    continue
+                item_id = str(event.get("item_id") or "")
+                if not item_id or item_id in state.item_keys:
+                    continue
+                key = (
+                    state.generation,
+                    state.buffer_epoch,
+                    state.next_utterance_id,
+                )
+                state.next_utterance_id += 1
+                state.last_utterance_id = key[2]
+                state.item_keys[item_id] = key
+                await response_queue.put(
+                    _AsrWorkerEvent(
+                        kind="utterance_started",
+                        generation=key[0],
+                        buffer_epoch=key[1],
+                        utterance_id=key[2],
+                    )
+                )
+                continue
+
+            if event_type == "input_audio_buffer.committed":
+                item_id = str(event.get("item_id") or "")
+                if (
+                    config.endpointing_mode == "manual"
+                    and item_id
+                    and item_id not in state.item_keys
+                    and state.pending_manual_commits
+                ):
+                    state.item_keys[item_id] = state.pending_manual_commits.popleft()
+                elif (
+                    config.endpointing_mode == "manual"
+                    and not item_id
+                    and state.legacy_manual_key is None
+                    and state.pending_manual_commits
+                ):
+                    state.legacy_manual_key = state.pending_manual_commits[0]
+                continue
+
+            if event_type == "conversation.item.input_audio_transcription.text":
+                item_id = str(event.get("item_id") or "")
+                key = (
+                    state.item_keys.get(item_id) if item_id else state.legacy_manual_key
+                )
+                if key is not None:
+                    text = str(event.get("text") or "") + str(event.get("stash") or "")
+                    await response_queue.put(
+                        _AsrWorkerEvent(
+                            kind="partial",
+                            generation=key[0],
+                            buffer_epoch=key[1],
+                            utterance_id=key[2],
+                            text=text,
+                        )
+                    )
+                continue
+
+            if event_type == "conversation.item.input_audio_transcription.completed":
+                item_id = str(event.get("item_id") or "")
+                key = (
+                    state.item_keys.pop(item_id, None)
+                    if item_id
+                    else state.legacy_manual_key
+                )
+                if key is not None:
+                    await response_queue.put(
+                        _AsrWorkerEvent(
+                            kind="final",
+                            generation=key[0],
+                            buffer_epoch=key[1],
+                            utterance_id=key[2],
+                            text=str(event.get("transcript") or ""),
+                        )
+                    )
+                    if not item_id:
+                        state.legacy_manual_key = None
+                        if (
+                            state.pending_manual_commits
+                            and state.pending_manual_commits[0] == key
+                        ):
+                            state.pending_manual_commits.popleft()
+                continue
+
+            if event_type == "session.finished":
+                state.finish_received.set()
+                if not state.closed_sent.is_set():
+                    state.closed_sent.set()
+                    request = state.shutdown_request
+                    await response_queue.put(
+                        _AsrWorkerEvent(
+                            kind="closed",
+                            generation=(
+                                request.generation if request else state.generation
+                            ),
+                            buffer_epoch=(
+                                request.buffer_epoch if request else state.buffer_epoch
+                            ),
+                            utterance_id=(
+                                request.utterance_id
+                                if request
+                                else state.last_utterance_id
+                            ),
+                        )
+                    )
+                return "closed"
+
+        if not state.intentional_close.is_set() and not state.closed_sent.is_set():
+            await _emit_qwen_error_once(
+                response_queue,
+                state,
+                "ASR_QWEN_CONNECTION_CLOSED",
+                "Qwen ASR connection closed unexpectedly",
+            )
+            return "error"
+        return "closed"
+    except asyncio.CancelledError:
+        raise
+    except ConnectionClosed:
+        if not state.intentional_close.is_set() and not state.closed_sent.is_set():
+            await _emit_qwen_error_once(
+                response_queue,
+                state,
+                "ASR_QWEN_CONNECTION_CLOSED",
+                "Qwen ASR connection closed unexpectedly",
+            )
+            return "error"
+        return "closed"
+    except Exception:
+        if state.intentional_close.is_set():
+            return "closed"
+        await _emit_qwen_error_once(
+            response_queue,
+            state,
+            "ASR_QWEN_WORKER_FAILED",
+            "Qwen ASR receiver failed",
+        )
+        return "error"
+
+
+async def qwen_asr_worker(
+    request_queue: asyncio.Queue[_AsrWorkerRequest],
+    response_queue: asyncio.Queue[_AsrWorkerEvent],
+    api_key: str,
+    config: AsrSessionConfig,
+    *,
+    region: str = "cn",
+) -> None:
+    """Stream normalized PCM to Qwen-ASR and normalize provider events."""
+
+    generation = 0
+    buffer_epoch = 0
+    next_utterance_id = 1
+    first_connection = True
+    closed_sent = False
+    active_state: _QwenConnectionState | None = None
+
+    try:
+        if region not in ("cn", "intl"):
+            raise ValueError("unsupported Qwen ASR region")
+        if not api_key:
+            raise PermissionError("Qwen ASR credentials are missing")
+        language = _qwen_language_code(config.language)
+        session_update = _qwen_session_update(config, language)
+        url = _QWEN_CN_URL if region == "cn" else _QWEN_INTL_URL
+
+        while True:
+            state = _QwenConnectionState(
+                generation=generation,
+                buffer_epoch=buffer_epoch,
+                next_utterance_id=next_utterance_id,
+                emit_ready=first_connection,
+            )
+            active_state = state
+            ws: Any | None = None
+            sender_task: asyncio.Task[tuple[str, _AsrWorkerRequest | None]] | None = (
+                None
+            )
+            receiver_task: asyncio.Task[str] | None = None
+            outcome = "error"
+            outcome_request: _AsrWorkerRequest | None = None
+            try:
+                ws = await websockets.connect(
+                    url,
+                    additional_headers={"Authorization": f"Bearer {api_key}"},
+                    close_timeout=0.5,
+                )
+                receiver_task = asyncio.create_task(
+                    _qwen_receiver(ws, response_queue, config, state),
+                    name="qwen-asr-receiver",
+                )
+                await ws.send(json.dumps(session_update))
+                sender_task = asyncio.create_task(
+                    _qwen_sender(
+                        ws,
+                        request_queue,
+                        response_queue,
+                        config,
+                        state,
+                    ),
+                    name="qwen-asr-sender",
+                )
+                done, pending = await asyncio.wait(
+                    {sender_task, receiver_task},
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if sender_task in done:
+                    outcome, outcome_request = await sender_task
+                if (
+                    receiver_task in done
+                    and state.intentional_close.is_set()
+                    and sender_task not in done
+                ):
+                    try:
+                        outcome, outcome_request = await asyncio.wait_for(
+                            asyncio.shield(sender_task), timeout=1.0
+                        )
+                    except asyncio.TimeoutError:
+                        pass
+                if receiver_task in done:
+                    receiver_outcome = await receiver_task
+                    if receiver_outcome == "error":
+                        outcome = "error"
+                    elif receiver_outcome == "closed" and outcome != "clear":
+                        outcome = "shutdown"
+                for task in pending:
+                    task.cancel()
+                if pending:
+                    await asyncio.gather(*pending, return_exceptions=True)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                await _emit_qwen_error_once(
+                    response_queue,
+                    state,
+                    (
+                        "ASR_CREDENTIALS_REJECTED"
+                        if _qwen_is_auth_rejection(exc)
+                        else "ASR_QWEN_CONNECTION_FAILED"
+                    ),
+                    (
+                        "Qwen ASR credentials were rejected"
+                        if _qwen_is_auth_rejection(exc)
+                        else "Qwen ASR connection or session setup failed"
+                    ),
+                )
+                outcome = "error"
+            finally:
+                for task in (sender_task, receiver_task):
+                    if task is not None and not task.done():
+                        task.cancel()
+                pending_tasks = [
+                    task
+                    for task in (sender_task, receiver_task)
+                    if task is not None and not task.done()
+                ]
+                if pending_tasks:
+                    await asyncio.gather(*pending_tasks, return_exceptions=True)
+                if ws is not None:
+                    state.intentional_close.set()
+                    try:
+                        await ws.close()
+                    except Exception:
+                        pass
+
+            closed_sent = state.closed_sent.is_set()
+            if outcome == "clear" and outcome_request is not None:
+                generation = outcome_request.generation
+                buffer_epoch = outcome_request.buffer_epoch
+                next_utterance_id = outcome_request.utterance_id or 1
+                first_connection = False
+                continue
+            if outcome_request is not None:
+                generation = outcome_request.generation
+                buffer_epoch = outcome_request.buffer_epoch
+                next_utterance_id = outcome_request.utterance_id or next_utterance_id
+            return
+    except asyncio.CancelledError:
+        raise
+    except PermissionError:
+        await response_queue.put(
+            _AsrWorkerEvent(
+                kind="error",
+                generation=generation,
+                buffer_epoch=buffer_epoch,
+                error_code="ASR_CREDENTIALS_MISSING",
+                error_message="Qwen ASR credentials are missing",
+            )
+        )
+    except ValueError as exc:
+        message = str(exc)
+        code = (
+            "ASR_LANGUAGE_NOT_SUPPORTED"
+            if "language" in message
+            else "ASR_INVALID_CONFIG"
+        )
+        await response_queue.put(
+            _AsrWorkerEvent(
+                kind="error",
+                generation=generation,
+                buffer_epoch=buffer_epoch,
+                error_code=code,
+                error_message="Qwen ASR configuration is not supported",
+            )
+        )
+    finally:
+        if active_state is not None:
+            closed_sent = closed_sent or active_state.closed_sent.is_set()
+        if not closed_sent:
+            await response_queue.put(
+                _AsrWorkerEvent(
+                    kind="closed",
+                    generation=generation,
+                    buffer_epoch=buffer_epoch,
+                    utterance_id=(
+                        active_state.last_utterance_id if active_state else None
+                    ),
+                )
+            )

--- a/main_logic/asr_client/workers/step.py
+++ b/main_logic/asr_client/workers/step.py
@@ -1,0 +1,571 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""StepFun bidirectional streaming ASR worker."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import uuid
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any, TypeAlias
+
+import websockets
+from websockets.exceptions import ConnectionClosed
+
+from .._infra import AsrSessionConfig, _AsrWorkerEvent, _AsrWorkerRequest
+
+_STEP_URL = "wss://api.stepfun.com/v1/realtime/asr/stream"
+_STEP_MODEL = "stepaudio-2.5-asr-stream"
+_STEP_SUPPORTED_LANGUAGES = frozenset({"en", "zh"})
+
+_ItemKey: TypeAlias = tuple[int, int, int]
+
+
+@dataclass(slots=True)
+class _StepConnectionState:
+    generation: int
+    buffer_epoch: int
+    next_utterance_id: int
+    emit_ready: bool
+    item_keys: dict[str, _ItemKey] = field(default_factory=dict)
+    pending_manual_commits: deque[_ItemKey] = field(default_factory=deque)
+    configured: asyncio.Event = field(default_factory=asyncio.Event)
+    intentional_close: asyncio.Event = field(default_factory=asyncio.Event)
+    error_sent: asyncio.Event = field(default_factory=asyncio.Event)
+    closed_sent: asyncio.Event = field(default_factory=asyncio.Event)
+    last_utterance_id: int | None = None
+
+
+def _step_event_id() -> str:
+    return f"event_{uuid.uuid4().hex}"
+
+
+def _step_language_code(language: str) -> str | None:
+    normalized = language.strip().lower()
+    if normalized == "auto":
+        return None
+    code = normalized.split("-", 1)[0]
+    if code not in _STEP_SUPPORTED_LANGUAGES:
+        raise ValueError("unsupported Step ASR language")
+    return code
+
+
+def _step_is_auth_rejection(exc: BaseException) -> bool:
+    response = getattr(exc, "response", None)
+    status_code = getattr(response, "status_code", None)
+    if status_code is None:
+        status_code = getattr(exc, "status_code", None)
+    return status_code in {401, 403}
+
+
+def _step_session_update(
+    config: AsrSessionConfig,
+    language: str | None,
+) -> dict[str, Any]:
+    if config.endpointing_mode not in ("manual", "server_vad"):
+        raise ValueError("unsupported Step ASR endpointing mode")
+
+    transcription: dict[str, Any] = {
+        "model": _STEP_MODEL,
+        "full_rerun_on_commit": True,
+        "enable_timestamp_align": False,
+    }
+    if language is not None:
+        transcription["language"] = language
+    audio_input: dict[str, Any] = {
+        "format": {
+            "type": "pcm",
+            "codec": "pcm_s16le",
+            "rate": 16000,
+            "bits": 16,
+            "channel": 1,
+        },
+        "transcription": transcription,
+    }
+    if config.endpointing_mode == "server_vad":
+        audio_input["turn_detection"] = {"type": "server_vad"}
+    return {
+        "event_id": _step_event_id(),
+        "type": "session.update",
+        "session": {"audio": {"input": audio_input}},
+    }
+
+
+async def _emit_step_error_once(
+    response_queue: asyncio.Queue[_AsrWorkerEvent],
+    state: _StepConnectionState,
+    error_code: str,
+    error_message: str,
+    *,
+    item_key: _ItemKey | None = None,
+) -> None:
+    if state.error_sent.is_set():
+        return
+    state.error_sent.set()
+    generation, buffer_epoch, utterance_id = item_key or (
+        state.generation,
+        state.buffer_epoch,
+        state.last_utterance_id,
+    )
+    await response_queue.put(
+        _AsrWorkerEvent(
+            kind="error",
+            generation=generation,
+            buffer_epoch=buffer_epoch,
+            utterance_id=utterance_id,
+            error_code=error_code,
+            error_message=error_message,
+        )
+    )
+
+
+async def _step_sender(
+    ws: Any,
+    request_queue: asyncio.Queue[_AsrWorkerRequest],
+    response_queue: asyncio.Queue[_AsrWorkerEvent],
+    config: AsrSessionConfig,
+    state: _StepConnectionState,
+) -> tuple[str, _AsrWorkerRequest | None]:
+    await state.configured.wait()
+    try:
+        while True:
+            request = await request_queue.get()
+            try:
+                if request.kind == "audio":
+                    state.last_utterance_id = request.utterance_id
+                    # The configured container and codec are raw PCM16LE. The
+                    # official field is Base64 text; no WAV header is added.
+                    await ws.send(
+                        json.dumps(
+                            {
+                                "event_id": _step_event_id(),
+                                "type": "input_audio_buffer.append",
+                                "audio": base64.b64encode(request.audio).decode(
+                                    "ascii"
+                                ),
+                            }
+                        )
+                    )
+                    continue
+
+                if request.kind == "commit":
+                    if config.endpointing_mode != "manual":
+                        await _emit_step_error_once(
+                            response_queue,
+                            state,
+                            "ASR_STEP_PROTOCOL_ERROR",
+                            "Step ASR received commit while server VAD is active",
+                        )
+                        return "error", request
+                    if request.utterance_id is None:
+                        await _emit_step_error_once(
+                            response_queue,
+                            state,
+                            "ASR_STEP_PROTOCOL_ERROR",
+                            "Step ASR commit is missing an utterance identifier",
+                        )
+                        return "error", request
+                    key = (
+                        request.generation,
+                        request.buffer_epoch,
+                        request.utterance_id,
+                    )
+                    state.pending_manual_commits.append(key)
+                    await ws.send(
+                        json.dumps(
+                            {
+                                "event_id": _step_event_id(),
+                                "type": "input_audio_buffer.commit",
+                            }
+                        )
+                    )
+                    continue
+
+                if request.kind == "clear":
+                    state.intentional_close.set()
+                    try:
+                        await ws.close()
+                    except Exception:
+                        pass
+                    return "clear", request
+
+                if request.kind == "shutdown":
+                    state.intentional_close.set()
+                    if not state.closed_sent.is_set():
+                        state.closed_sent.set()
+                        await response_queue.put(
+                            _AsrWorkerEvent(
+                                kind="closed",
+                                generation=request.generation,
+                                buffer_epoch=request.buffer_epoch,
+                                utterance_id=request.utterance_id,
+                            )
+                        )
+                    try:
+                        await ws.close()
+                    except Exception:
+                        pass
+                    return "shutdown", request
+
+                await _emit_step_error_once(
+                    response_queue,
+                    state,
+                    "ASR_STEP_PROTOCOL_ERROR",
+                    "Step ASR received an unsupported command",
+                )
+                return "error", request
+            finally:
+                request_queue.task_done()
+    except asyncio.CancelledError:
+        raise
+    except ConnectionClosed:
+        if not state.intentional_close.is_set():
+            await _emit_step_error_once(
+                response_queue,
+                state,
+                "ASR_STEP_CONNECTION_CLOSED",
+                "Step ASR connection closed unexpectedly",
+            )
+        return "error", None
+    except Exception:
+        await _emit_step_error_once(
+            response_queue,
+            state,
+            "ASR_STEP_WORKER_FAILED",
+            "Step ASR sender failed",
+        )
+        return "error", None
+
+
+async def _step_receiver(
+    ws: Any,
+    response_queue: asyncio.Queue[_AsrWorkerEvent],
+    config: AsrSessionConfig,
+    state: _StepConnectionState,
+) -> str:
+    try:
+        async for raw_message in ws:
+            try:
+                event = json.loads(raw_message)
+            except (TypeError, ValueError):
+                await _emit_step_error_once(
+                    response_queue,
+                    state,
+                    "ASR_STEP_PROTOCOL_ERROR",
+                    "Step ASR returned an invalid event",
+                )
+                return "error"
+
+            event_type = event.get("type")
+            if event_type == "session.updated":
+                if not state.configured.is_set():
+                    state.configured.set()
+                    if state.emit_ready:
+                        await response_queue.put(
+                            _AsrWorkerEvent(
+                                kind="ready",
+                                generation=state.generation,
+                                buffer_epoch=state.buffer_epoch,
+                            )
+                        )
+                continue
+
+            if event_type == "error":
+                if state.intentional_close.is_set():
+                    return "closed"
+                item_id = str(event.get("item_id") or "")
+                await _emit_step_error_once(
+                    response_queue,
+                    state,
+                    "ASR_STEP_PROVIDER_ERROR",
+                    "Step ASR provider reported an error",
+                    item_key=state.item_keys.get(item_id),
+                )
+                return "error"
+
+            if event_type == "input_audio_buffer.speech_started":
+                if config.endpointing_mode != "server_vad":
+                    continue
+                item_id = str(event.get("item_id") or "")
+                if not item_id or item_id in state.item_keys:
+                    continue
+                key = (
+                    state.generation,
+                    state.buffer_epoch,
+                    state.next_utterance_id,
+                )
+                state.next_utterance_id += 1
+                state.last_utterance_id = key[2]
+                state.item_keys[item_id] = key
+                await response_queue.put(
+                    _AsrWorkerEvent(
+                        kind="utterance_started",
+                        generation=key[0],
+                        buffer_epoch=key[1],
+                        utterance_id=key[2],
+                    )
+                )
+                continue
+
+            if event_type == "input_audio_buffer.committed":
+                item_id = str(event.get("item_id") or "")
+                if (
+                    config.endpointing_mode == "manual"
+                    and item_id
+                    and item_id not in state.item_keys
+                    and state.pending_manual_commits
+                ):
+                    state.item_keys[item_id] = state.pending_manual_commits.popleft()
+                continue
+
+            if event_type == "conversation.item.input_audio_transcription.delta":
+                item_id = str(event.get("item_id") or "")
+                key = state.item_keys.get(item_id)
+                if key is not None:
+                    await response_queue.put(
+                        _AsrWorkerEvent(
+                            kind="partial",
+                            generation=key[0],
+                            buffer_epoch=key[1],
+                            utterance_id=key[2],
+                            text=str(event.get("text") or ""),
+                        )
+                    )
+                continue
+
+            if event_type == "conversation.item.input_audio_transcription.completed":
+                item_id = str(event.get("item_id") or "")
+                key = state.item_keys.pop(item_id, None)
+                if key is not None:
+                    await response_queue.put(
+                        _AsrWorkerEvent(
+                            kind="final",
+                            generation=key[0],
+                            buffer_epoch=key[1],
+                            utterance_id=key[2],
+                            text=str(event.get("transcript") or ""),
+                        )
+                    )
+                continue
+
+        if not state.intentional_close.is_set():
+            await _emit_step_error_once(
+                response_queue,
+                state,
+                "ASR_STEP_CONNECTION_CLOSED",
+                "Step ASR connection closed unexpectedly",
+            )
+            return "error"
+        return "closed"
+    except asyncio.CancelledError:
+        raise
+    except ConnectionClosed:
+        if not state.intentional_close.is_set():
+            await _emit_step_error_once(
+                response_queue,
+                state,
+                "ASR_STEP_CONNECTION_CLOSED",
+                "Step ASR connection closed unexpectedly",
+            )
+            return "error"
+        return "closed"
+    except Exception:
+        if state.intentional_close.is_set():
+            return "closed"
+        await _emit_step_error_once(
+            response_queue,
+            state,
+            "ASR_STEP_WORKER_FAILED",
+            "Step ASR receiver failed",
+        )
+        return "error"
+
+
+async def step_asr_worker(
+    request_queue: asyncio.Queue[_AsrWorkerRequest],
+    response_queue: asyncio.Queue[_AsrWorkerEvent],
+    api_key: str,
+    config: AsrSessionConfig,
+) -> None:
+    """Stream normalized PCM to StepFun and normalize provider events."""
+
+    generation = 0
+    buffer_epoch = 0
+    next_utterance_id = 1
+    first_connection = True
+    closed_sent = False
+    active_state: _StepConnectionState | None = None
+
+    try:
+        if not api_key:
+            raise PermissionError("Step ASR credentials are missing")
+        language = _step_language_code(config.language)
+        session_update = _step_session_update(config, language)
+
+        while True:
+            state = _StepConnectionState(
+                generation=generation,
+                buffer_epoch=buffer_epoch,
+                next_utterance_id=next_utterance_id,
+                emit_ready=first_connection,
+            )
+            active_state = state
+            ws: Any | None = None
+            sender_task: asyncio.Task[tuple[str, _AsrWorkerRequest | None]] | None = (
+                None
+            )
+            receiver_task: asyncio.Task[str] | None = None
+            outcome = "error"
+            outcome_request: _AsrWorkerRequest | None = None
+            try:
+                ws = await websockets.connect(
+                    _STEP_URL,
+                    additional_headers={"Authorization": f"Bearer {api_key}"},
+                    close_timeout=0.5,
+                )
+                receiver_task = asyncio.create_task(
+                    _step_receiver(ws, response_queue, config, state),
+                    name="step-asr-receiver",
+                )
+                await ws.send(json.dumps(session_update))
+                sender_task = asyncio.create_task(
+                    _step_sender(
+                        ws,
+                        request_queue,
+                        response_queue,
+                        config,
+                        state,
+                    ),
+                    name="step-asr-sender",
+                )
+                done, pending = await asyncio.wait(
+                    {sender_task, receiver_task},
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if sender_task in done:
+                    outcome, outcome_request = await sender_task
+                if (
+                    receiver_task in done
+                    and state.intentional_close.is_set()
+                    and sender_task not in done
+                ):
+                    try:
+                        outcome, outcome_request = await asyncio.wait_for(
+                            asyncio.shield(sender_task), timeout=1.0
+                        )
+                    except asyncio.TimeoutError:
+                        pass
+                if receiver_task in done:
+                    receiver_outcome = await receiver_task
+                    if receiver_outcome == "error":
+                        outcome = "error"
+                for task in pending:
+                    if not task.done():
+                        task.cancel()
+                if pending:
+                    await asyncio.gather(*pending, return_exceptions=True)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                await _emit_step_error_once(
+                    response_queue,
+                    state,
+                    (
+                        "ASR_CREDENTIALS_REJECTED"
+                        if _step_is_auth_rejection(exc)
+                        else "ASR_STEP_CONNECTION_FAILED"
+                    ),
+                    (
+                        "Step ASR credentials were rejected"
+                        if _step_is_auth_rejection(exc)
+                        else "Step ASR connection or session setup failed"
+                    ),
+                )
+                outcome = "error"
+            finally:
+                for task in (sender_task, receiver_task):
+                    if task is not None and not task.done():
+                        task.cancel()
+                pending_tasks = [
+                    task
+                    for task in (sender_task, receiver_task)
+                    if task is not None and not task.done()
+                ]
+                if pending_tasks:
+                    await asyncio.gather(*pending_tasks, return_exceptions=True)
+                if ws is not None:
+                    state.intentional_close.set()
+                    try:
+                        await ws.close()
+                    except Exception:
+                        pass
+
+            closed_sent = state.closed_sent.is_set()
+            if outcome == "clear" and outcome_request is not None:
+                generation = outcome_request.generation
+                buffer_epoch = outcome_request.buffer_epoch
+                next_utterance_id = outcome_request.utterance_id or 1
+                first_connection = False
+                continue
+            if outcome_request is not None:
+                generation = outcome_request.generation
+                buffer_epoch = outcome_request.buffer_epoch
+                next_utterance_id = outcome_request.utterance_id or next_utterance_id
+            return
+    except asyncio.CancelledError:
+        raise
+    except PermissionError:
+        await response_queue.put(
+            _AsrWorkerEvent(
+                kind="error",
+                generation=generation,
+                buffer_epoch=buffer_epoch,
+                error_code="ASR_CREDENTIALS_MISSING",
+                error_message="Step ASR credentials are missing",
+            )
+        )
+    except ValueError as exc:
+        message = str(exc)
+        code = (
+            "ASR_LANGUAGE_NOT_SUPPORTED"
+            if "language" in message
+            else "ASR_INVALID_CONFIG"
+        )
+        await response_queue.put(
+            _AsrWorkerEvent(
+                kind="error",
+                generation=generation,
+                buffer_epoch=buffer_epoch,
+                error_code=code,
+                error_message="Step ASR configuration is not supported",
+            )
+        )
+    finally:
+        if active_state is not None:
+            closed_sent = closed_sent or active_state.closed_sent.is_set()
+        if not closed_sent:
+            await response_queue.put(
+                _AsrWorkerEvent(
+                    kind="closed",
+                    generation=generation,
+                    buffer_epoch=buffer_epoch,
+                    utterance_id=(
+                        active_state.last_utterance_id if active_state else None
+                    ),
+                )
+            )

--- a/main_logic/asr_client/workers/step.py
+++ b/main_logic/asr_client/workers/step.py
@@ -44,11 +44,38 @@ class _StepConnectionState:
     emit_ready: bool
     item_keys: dict[str, _ItemKey] = field(default_factory=dict)
     pending_manual_commits: deque[_ItemKey] = field(default_factory=deque)
+    unbound_manual_item_ids: deque[str] = field(default_factory=deque)
+    unbound_manual_item_id_set: set[str] = field(default_factory=set)
     configured: asyncio.Event = field(default_factory=asyncio.Event)
     intentional_close: asyncio.Event = field(default_factory=asyncio.Event)
     error_sent: asyncio.Event = field(default_factory=asyncio.Event)
     closed_sent: asyncio.Event = field(default_factory=asyncio.Event)
     last_utterance_id: int | None = None
+
+
+def _step_bind_pending_manual_items(state: _StepConnectionState) -> None:
+    while state.pending_manual_commits and state.unbound_manual_item_ids:
+        item_id = state.unbound_manual_item_ids.popleft()
+        if item_id not in state.unbound_manual_item_id_set:
+            continue
+        state.unbound_manual_item_id_set.remove(item_id)
+        if item_id in state.item_keys:
+            continue
+        state.item_keys[item_id] = state.pending_manual_commits.popleft()
+
+
+def _step_manual_item_key(
+    state: _StepConnectionState,
+    item_id: str,
+) -> _ItemKey | None:
+    key = state.item_keys.get(item_id)
+    if key is not None:
+        return key
+    if item_id not in state.unbound_manual_item_id_set:
+        state.unbound_manual_item_ids.append(item_id)
+        state.unbound_manual_item_id_set.add(item_id)
+    _step_bind_pending_manual_items(state)
+    return state.item_keys.get(item_id)
 
 
 def _step_event_id() -> str:
@@ -186,6 +213,7 @@ async def _step_sender(
                         request.utterance_id,
                     )
                     state.pending_manual_commits.append(key)
+                    _step_bind_pending_manual_items(state)
                     await ws.send(
                         json.dumps(
                             {
@@ -323,19 +351,16 @@ async def _step_receiver(
                 continue
 
             if event_type == "input_audio_buffer.committed":
-                item_id = str(event.get("item_id") or "")
-                if (
-                    config.endpointing_mode == "manual"
-                    and item_id
-                    and item_id not in state.item_keys
-                    and state.pending_manual_commits
-                ):
-                    state.item_keys[item_id] = state.pending_manual_commits.popleft()
+                # Step assigns this event to the committed audio item. Its
+                # transcription events use a different item_id, so manual
+                # utterances are bound when a transcription event arrives.
                 continue
 
             if event_type == "conversation.item.input_audio_transcription.delta":
                 item_id = str(event.get("item_id") or "")
                 key = state.item_keys.get(item_id)
+                if key is None and item_id and config.endpointing_mode == "manual":
+                    key = _step_manual_item_key(state, item_id)
                 if key is not None:
                     await response_queue.put(
                         _AsrWorkerEvent(
@@ -350,8 +375,11 @@ async def _step_receiver(
 
             if event_type == "conversation.item.input_audio_transcription.completed":
                 item_id = str(event.get("item_id") or "")
-                key = state.item_keys.pop(item_id, None)
+                key = state.item_keys.get(item_id)
+                if key is None and item_id and config.endpointing_mode == "manual":
+                    key = _step_manual_item_key(state, item_id)
                 if key is not None:
+                    state.item_keys.pop(item_id, None)
                     await response_queue.put(
                         _AsrWorkerEvent(
                             kind="final",

--- a/main_logic/asr_client/workers/step.py
+++ b/main_logic/asr_client/workers/step.py
@@ -216,17 +216,27 @@ async def _step_sender(
                         request.utterance_id,
                     )
                     if state.pending_manual_commits:
-                        await _emit_step_error_once(
-                            response_queue,
-                            state,
-                            "ASR_STEP_PROTOCOL_ERROR",
-                            (
-                                "Step ASR previous commit has no transcription item; "
-                                "rejecting a new commit to prevent utterance mis-correlation"
-                            ),
-                            item_key=key,
+                        # Keep receiving the already-committed turn. Only the
+                        # overlapping uncommitted buffer is discarded, and an
+                        # empty terminal final retires its local FIFO slot.
+                        await ws.send(
+                            json.dumps(
+                                {
+                                    "event_id": _step_event_id(),
+                                    "type": "input_audio_buffer.clear",
+                                }
+                            )
                         )
-                        return "error", request
+                        await response_queue.put(
+                            _AsrWorkerEvent(
+                                kind="final",
+                                generation=key[0],
+                                buffer_epoch=key[1],
+                                utterance_id=key[2],
+                                text="",
+                            )
+                        )
+                        continue
                     state.pending_manual_commits.append(key)
                     _step_bind_pending_manual_items(state)
                     await ws.send(

--- a/main_logic/asr_client/workers/step.py
+++ b/main_logic/asr_client/workers/step.py
@@ -46,6 +46,7 @@ class _StepConnectionState:
     pending_manual_commits: deque[_ItemKey] = field(default_factory=deque)
     unbound_manual_item_ids: deque[str] = field(default_factory=deque)
     unbound_manual_item_id_set: set[str] = field(default_factory=set)
+    completed_manual_item_ids: set[str] = field(default_factory=set)
     configured: asyncio.Event = field(default_factory=asyncio.Event)
     intentional_close: asyncio.Event = field(default_factory=asyncio.Event)
     error_sent: asyncio.Event = field(default_factory=asyncio.Event)
@@ -68,6 +69,8 @@ def _step_manual_item_key(
     state: _StepConnectionState,
     item_id: str,
 ) -> _ItemKey | None:
+    if item_id in state.completed_manual_item_ids:
+        return None
     key = state.item_keys.get(item_id)
     if key is not None:
         return key
@@ -391,6 +394,8 @@ async def _step_receiver(
                 if key is None and item_id and config.endpointing_mode == "manual":
                     key = _step_manual_item_key(state, item_id)
                 if key is not None:
+                    if config.endpointing_mode == "manual":
+                        state.completed_manual_item_ids.add(item_id)
                     state.item_keys.pop(item_id, None)
                     await response_queue.put(
                         _AsrWorkerEvent(

--- a/main_logic/asr_client/workers/step.py
+++ b/main_logic/asr_client/workers/step.py
@@ -77,7 +77,7 @@ def _step_session_update(
     config: AsrSessionConfig,
     language: str | None,
 ) -> dict[str, Any]:
-    if config.endpointing_mode not in ("manual", "server_vad"):
+    if config.endpointing_mode not in ("manual", "provider"):
         raise ValueError("unsupported Step ASR endpointing mode")
 
     transcription: dict[str, Any] = {
@@ -97,7 +97,7 @@ def _step_session_update(
         },
         "transcription": transcription,
     }
-    if config.endpointing_mode == "server_vad":
+    if config.endpointing_mode == "provider":
         audio_input["turn_detection"] = {"type": "server_vad"}
     return {
         "event_id": _step_event_id(),
@@ -299,7 +299,7 @@ async def _step_receiver(
                 return "error"
 
             if event_type == "input_audio_buffer.speech_started":
-                if config.endpointing_mode != "server_vad":
+                if config.endpointing_mode != "provider":
                     continue
                 item_id = str(event.get("item_id") or "")
                 if not item_id or item_id in state.item_keys:

--- a/main_logic/asr_client/workers/step.py
+++ b/main_logic/asr_client/workers/step.py
@@ -212,6 +212,18 @@ async def _step_sender(
                         request.buffer_epoch,
                         request.utterance_id,
                     )
+                    if state.pending_manual_commits:
+                        await _emit_step_error_once(
+                            response_queue,
+                            state,
+                            "ASR_STEP_PROTOCOL_ERROR",
+                            (
+                                "Step ASR previous commit has no transcription item; "
+                                "rejecting a new commit to prevent utterance mis-correlation"
+                            ),
+                            item_key=key,
+                        )
+                        return "error", request
                     state.pending_manual_commits.append(key)
                     _step_bind_pending_manual_items(state)
                     await ws.send(

--- a/scripts/asr_realtime_smoke.py
+++ b/scripts/asr_realtime_smoke.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python
+# -- coding: utf-8 --
+"""Exercise one Phase 2 realtime ASR worker with PCM16 mono WAV turns.
+
+This is deliberately an opt-in development probe.  It bypasses the registry's
+``blocked_credentials`` gate so a provider can be verified before its registry
+status is promoted to ``implemented``.  The production factory remains the
+only supported application entry point.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import time
+import wave
+from collections.abc import Awaitable, Callable
+from dataclasses import asdict, dataclass, field
+from functools import partial
+from pathlib import Path
+from typing import Any
+
+from main_logic.asr_client._infra import (
+    AsrSessionConfig,
+    AsrWorkerFn,
+    _AsrWorkerEvent,
+    _RealtimeAsrSessionImpl,
+)
+
+
+_CREDENTIAL_FIELDS = {
+    "qwen": "ASSIST_API_KEY_QWEN",
+    "qwen_intl": "ASSIST_API_KEY_QWEN_INTL",
+    "openai": "ASSIST_API_KEY_OPENAI",
+    "step": "ASSIST_API_KEY_STEP",
+    "grok": "ASSIST_API_KEY_GROK",
+}
+
+_AUTH_FAILURE_CODES = {
+    "ASR_CREDENTIALS_MISSING",
+    "ASR_CREDENTIALS_REJECTED",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class _AudioTurn:
+    path: Path
+    pcm: bytes
+    sample_rate_hz: int
+    duration_s: float
+
+
+@dataclass(slots=True)
+class SmokeResult:
+    provider: str
+    endpointing_mode: str
+    ok: bool = False
+    expected_auth_failure: bool = False
+    auth_failure_observed: bool = False
+    audio_sample_rates_hz: list[int] = field(default_factory=list)
+    turns_requested: int = 0
+    business_finals: int = 0
+    ready_ms: float | None = None
+    first_partial_ms: float | None = None
+    final_ms: list[float] = field(default_factory=list)
+    close_ms: float | None = None
+    statuses: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    transcripts: list[str] | None = None
+
+
+@dataclass(slots=True)
+class _Observation:
+    started_at: float
+    first_partial_at: float | None = None
+    final_at: list[float] = field(default_factory=list)
+
+
+class _ResponseQueueObserver:
+    """Observe event timing without logging event payloads or credentials."""
+
+    def __init__(
+        self,
+        target: asyncio.Queue[_AsrWorkerEvent],
+        observation: _Observation,
+    ) -> None:
+        self._target = target
+        self._observation = observation
+
+    async def put(self, event: _AsrWorkerEvent) -> None:
+        now = time.perf_counter()
+        if event.kind == "partial" and self._observation.first_partial_at is None:
+            self._observation.first_partial_at = now
+        elif event.kind == "final":
+            self._observation.final_at.append(now)
+        await self._target.put(event)
+
+    def put_nowait(self, event: _AsrWorkerEvent) -> None:
+        now = time.perf_counter()
+        if event.kind == "partial" and self._observation.first_partial_at is None:
+            self._observation.first_partial_at = now
+        elif event.kind == "final":
+            self._observation.final_at.append(now)
+        self._target.put_nowait(event)
+
+
+def _read_wav_pcm16(path: Path) -> _AudioTurn:
+    with wave.open(str(path), "rb") as wav_file:
+        channels = wav_file.getnchannels()
+        sample_width = wav_file.getsampwidth()
+        sample_rate_hz = wav_file.getframerate()
+        frames = wav_file.getnframes()
+        pcm = wav_file.readframes(frames)
+
+    if channels != 1:
+        raise ValueError(f"{path}: expected mono WAV, got {channels} channels")
+    if sample_width != 2:
+        raise ValueError(f"{path}: expected PCM16 WAV")
+    if sample_rate_hz not in (16_000, 48_000):
+        raise ValueError(f"{path}: expected 16000 or 48000 Hz WAV")
+    if not pcm:
+        raise ValueError(f"{path}: audio is empty")
+    return _AudioTurn(
+        path=path,
+        pcm=pcm,
+        sample_rate_hz=sample_rate_hz,
+        duration_s=frames / sample_rate_hz,
+    )
+
+
+def _resolve_provider(provider: str) -> AsrWorkerFn:
+    if provider in {"qwen", "qwen_intl"}:
+        from main_logic.asr_client.workers.qwen import qwen_asr_worker
+
+        region = "intl" if provider == "qwen_intl" else "cn"
+        return partial(qwen_asr_worker, region=region)
+    if provider == "openai":
+        from main_logic.asr_client.workers.openai import openai_asr_worker
+
+        return openai_asr_worker
+    if provider == "step":
+        from main_logic.asr_client.workers.step import step_asr_worker
+
+        return step_asr_worker
+    if provider == "grok":
+        from main_logic.asr_client.workers.grok import grok_asr_worker
+
+        return grok_asr_worker
+    raise ValueError(f"unknown provider: {provider}")
+
+
+def _resolve_api_key(provider: str, override_env: str) -> str:
+    field_name = _CREDENTIAL_FIELDS[provider]
+    env_name = override_env.strip() or field_name
+    api_key = os.getenv(env_name, "").strip()
+    if api_key:
+        return api_key
+
+    from utils.config_manager import get_config_manager
+
+    core_config = get_config_manager().get_core_config() or {}
+    api_key = str(core_config.get(field_name) or "").strip()
+    if not api_key:
+        raise RuntimeError(f"ASR_CREDENTIALS_MISSING: {field_name}")
+    return api_key
+
+
+def _observe_worker(
+    worker_fn: AsrWorkerFn,
+    observation: _Observation,
+) -> AsrWorkerFn:
+    async def observed_worker(
+        request_queue: asyncio.Queue[Any],
+        response_queue: asyncio.Queue[_AsrWorkerEvent],
+        api_key: str,
+        config: AsrSessionConfig,
+    ) -> None:
+        observer = _ResponseQueueObserver(response_queue, observation)
+        await worker_fn(request_queue, observer, api_key, config)  # type: ignore[arg-type]
+
+    return observed_worker
+
+
+async def _stream_turn(
+    session: _RealtimeAsrSessionImpl,
+    turn: _AudioTurn,
+    *,
+    chunk_ms: int,
+    endpointing_mode: str,
+    realtime: bool,
+    vad_silence_ms: int,
+) -> None:
+    bytes_per_frame = 2
+    chunk_bytes = max(
+        bytes_per_frame,
+        turn.sample_rate_hz * bytes_per_frame * chunk_ms // 1000,
+    )
+    chunk_bytes -= chunk_bytes % bytes_per_frame
+    for offset in range(0, len(turn.pcm), chunk_bytes):
+        chunk = turn.pcm[offset : offset + chunk_bytes]
+        await session.stream_audio(chunk, sample_rate_hz=turn.sample_rate_hz)
+        if realtime:
+            await asyncio.sleep(len(chunk) / bytes_per_frame / turn.sample_rate_hz)
+    if endpointing_mode == "server_vad" and vad_silence_ms:
+        silence = bytes(turn.sample_rate_hz * bytes_per_frame * vad_silence_ms // 1000)
+        for offset in range(0, len(silence), chunk_bytes):
+            chunk = silence[offset : offset + chunk_bytes]
+            await session.stream_audio(chunk, sample_rate_hz=turn.sample_rate_hz)
+            if realtime:
+                await asyncio.sleep(len(chunk) / bytes_per_frame / turn.sample_rate_hz)
+    await session.signal_user_activity_end()
+
+
+async def _wait_for_final_count(
+    event: asyncio.Event,
+    transcripts: list[str],
+    expected: int,
+    timeout_s: float,
+) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout_s
+    while len(transcripts) < expected:
+        remaining = deadline - asyncio.get_running_loop().time()
+        if remaining <= 0:
+            raise TimeoutError(f"timed out waiting for final {expected}")
+        event.clear()
+        if len(transcripts) >= expected:
+            break
+        await asyncio.wait_for(event.wait(), timeout=remaining)
+
+
+async def _run_provider_smoke(args: argparse.Namespace) -> SmokeResult:
+    turns = [_read_wav_pcm16(path) for path in args.audio]
+    result = SmokeResult(
+        provider=args.provider,
+        endpointing_mode=args.endpointing_mode,
+        expected_auth_failure=bool(args.invalid_credential),
+        audio_sample_rates_hz=[turn.sample_rate_hz for turn in turns],
+        turns_requested=len(turns),
+        transcripts=[] if args.show_transcripts else None,
+    )
+    api_key = (
+        "invalid-asr-smoke-key"
+        if args.invalid_credential
+        else _resolve_api_key(args.provider, args.api_key_env)
+    )
+    observation = _Observation(started_at=time.perf_counter())
+    worker_fn = _observe_worker(_resolve_provider(args.provider), observation)
+    final_event = asyncio.Event()
+    transcripts: list[str] = []
+
+    async def on_transcript(text: str) -> None:
+        transcripts.append(text)
+        final_event.set()
+
+    async def on_error(error: str) -> None:
+        result.errors.append(error)
+
+    async def on_status(status: str) -> None:
+        result.statuses.append(status)
+
+    session = _RealtimeAsrSessionImpl(
+        worker_fn=worker_fn,
+        api_key=api_key,
+        config=AsrSessionConfig(
+            language=args.language,
+            input_sample_rate_hz=turns[0].sample_rate_hz,
+            endpointing_mode=args.endpointing_mode,
+        ),
+        on_input_transcript=on_transcript,
+        on_connection_error=on_error,
+        on_status_message=on_status,
+    )
+
+    connected_at: float | None = None
+    close_started: float | None = None
+    try:
+        await session.connect()
+        connected_at = time.perf_counter()
+        result.ready_ms = (connected_at - observation.started_at) * 1000
+        if args.invalid_credential:
+            raise RuntimeError("invalid credential unexpectedly reached ASR_READY")
+
+        if not args.skip_clear:
+            await session.clear_audio_buffer()
+
+        for index, turn in enumerate(turns, start=1):
+            await _stream_turn(
+                session,
+                turn,
+                chunk_ms=args.chunk_ms,
+                endpointing_mode=args.endpointing_mode,
+                realtime=not args.no_realtime,
+                vad_silence_ms=args.vad_silence_ms,
+            )
+            await _wait_for_final_count(
+                final_event,
+                transcripts,
+                index,
+                args.timeout_s,
+            )
+            if not session.is_ready:
+                raise RuntimeError("commit or provider endpointing closed the session")
+
+        if result.errors:
+            raise RuntimeError(result.errors[-1])
+        result.ok = len(transcripts) == len(turns)
+    except Exception as exc:
+        if args.invalid_credential:
+            if session.is_ready:
+                result.errors.append("ASR_INVALID_CREDENTIAL_ACCEPTED")
+            elif not result.errors:
+                safe_error = str(exc).strip() or type(exc).__name__
+                result.errors.append(safe_error[:300])
+        else:
+            safe_error = str(exc).strip() or type(exc).__name__
+            if safe_error not in result.errors:
+                result.errors.append(safe_error[:300])
+    finally:
+        close_started = time.perf_counter()
+        try:
+            await session.close()
+            await session.close()
+        except Exception as exc:
+            safe_error = str(exc).strip() or type(exc).__name__
+            if safe_error not in result.errors:
+                result.errors.append(safe_error[:300])
+            result.ok = False
+        result.close_ms = (time.perf_counter() - close_started) * 1000
+
+    result.business_finals = len(transcripts)
+    if result.transcripts is not None:
+        result.transcripts.extend(transcripts)
+    if observation.first_partial_at is not None:
+        result.first_partial_ms = (
+            observation.first_partial_at - observation.started_at
+        ) * 1000
+    result.final_ms = [
+        (timestamp - observation.started_at) * 1000
+        for timestamp in observation.final_at
+    ]
+    if args.invalid_credential:
+        error_codes = {error.partition(":")[0] for error in result.errors}
+        result.auth_failure_observed = bool(error_codes & _AUTH_FAILURE_CODES)
+        result.ok = result.auth_failure_observed and error_codes <= _AUTH_FAILURE_CODES
+    else:
+        if len(result.final_ms) != len(transcripts):
+            result.errors.append(
+                "worker final count did not match business callback count"
+            )
+        if result.errors:
+            result.ok = False
+    return result
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "provider",
+        choices=sorted(_CREDENTIAL_FIELDS),
+        help="Phase 2 Core/provider route to probe.",
+    )
+    parser.add_argument(
+        "audio",
+        nargs="+",
+        type=Path,
+        help="One or more mono PCM16 WAV turns at 16 kHz or 48 kHz.",
+    )
+    parser.add_argument(
+        "--endpointing-mode",
+        choices=("manual", "server_vad"),
+        default="manual",
+    )
+    parser.add_argument("--language", default="zh")
+    parser.add_argument("--api-key-env", default="")
+    parser.add_argument("--chunk-ms", type=int, default=100)
+    parser.add_argument(
+        "--vad-silence-ms",
+        type=int,
+        default=1000,
+        help="Silence appended to each server_vad turn so the provider can finalize.",
+    )
+    parser.add_argument("--timeout-s", type=float, default=30.0)
+    parser.add_argument("--no-realtime", action="store_true")
+    parser.add_argument("--skip-clear", action="store_true")
+    parser.add_argument("--invalid-credential", action="store_true")
+    parser.add_argument("--show-transcripts", action="store_true")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    if args.chunk_ms <= 0:
+        parser.error("--chunk-ms must be positive")
+    if args.timeout_s <= 0:
+        parser.error("--timeout-s must be positive")
+    if args.vad_silence_ms < 0:
+        parser.error("--vad-silence-ms must not be negative")
+    if args.endpointing_mode == "server_vad" and args.provider == "openai":
+        parser.error("OpenAI Phase 2 only supports manual endpointing")
+    return args
+
+
+async def main_async() -> int:
+    args = parse_args()
+    result = await _run_provider_smoke(args)
+    payload = json.dumps(asdict(result), ensure_ascii=False, indent=2)
+    if args.output is None:
+        print(payload)
+    else:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload + "\n", encoding="utf-8")
+        print(f"Wrote {args.output}")
+    return 0 if result.ok else 1
+
+
+def main() -> int:
+    return asyncio.run(main_async())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/asr_realtime_smoke.py
+++ b/scripts/asr_realtime_smoke.py
@@ -28,6 +28,7 @@ from main_logic.asr_client._infra import (
     _AsrWorkerEvent,
     _RealtimeAsrSessionImpl,
 )
+from main_logic.asr_client._registry_meta import ASR_PROVIDER_REGISTRY
 
 
 _CREDENTIAL_FIELDS = {
@@ -203,7 +204,7 @@ async def _stream_turn(
         await session.stream_audio(chunk, sample_rate_hz=turn.sample_rate_hz)
         if realtime:
             await asyncio.sleep(len(chunk) / bytes_per_frame / turn.sample_rate_hz)
-    if endpointing_mode == "server_vad" and vad_silence_ms:
+    if endpointing_mode == "provider" and vad_silence_ms:
         silence = bytes(turn.sample_rate_hz * bytes_per_frame * vad_silence_ms // 1000)
         for offset in range(0, len(silence), chunk_bytes):
             chunk = silence[offset : offset + chunk_bytes]
@@ -321,7 +322,6 @@ async def _run_provider_smoke(args: argparse.Namespace) -> SmokeResult:
         close_started = time.perf_counter()
         try:
             await session.close()
-            await session.close()
         except Exception as exc:
             safe_error = str(exc).strip() or type(exc).__name__
             if safe_error not in result.errors:
@@ -369,8 +369,9 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--endpointing-mode",
-        choices=("manual", "server_vad"),
-        default="manual",
+        choices=("manual", "provider"),
+        default=None,
+        help="Defaults to a supported provider mode (Grok uses provider; others manual).",
     )
     parser.add_argument("--language", default="zh")
     parser.add_argument("--api-key-env", default="")
@@ -379,7 +380,7 @@ def parse_args() -> argparse.Namespace:
         "--vad-silence-ms",
         type=int,
         default=1000,
-        help="Silence appended to each server_vad turn so the provider can finalize.",
+        help="Silence appended to each provider-endpointed turn so it can finalize.",
     )
     parser.add_argument("--timeout-s", type=float, default=30.0)
     parser.add_argument("--no-realtime", action="store_true")
@@ -394,8 +395,15 @@ def parse_args() -> argparse.Namespace:
         parser.error("--timeout-s must be positive")
     if args.vad_silence_ms < 0:
         parser.error("--vad-silence-ms must not be negative")
-    if args.endpointing_mode == "server_vad" and args.provider == "openai":
-        parser.error("OpenAI Phase 2 only supports manual endpointing")
+    supported_modes = ASR_PROVIDER_REGISTRY[
+        "qwen" if args.provider == "qwen_intl" else args.provider
+    ].supported_endpointing_modes
+    if args.endpointing_mode is None:
+        args.endpointing_mode = "manual" if "manual" in supported_modes else "provider"
+    if args.endpointing_mode not in supported_modes:
+        parser.error(
+            f"{args.provider} does not support {args.endpointing_mode} endpointing"
+        )
     return args
 
 

--- a/tests/unit/test_asr_client.py
+++ b/tests/unit/test_asr_client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import gc
 import weakref
+from dataclasses import replace
 from unittest.mock import AsyncMock
 
 import pytest
@@ -14,6 +15,10 @@ from main_logic.asr_client._infra import (
     _AsrWorkerEvent,
     _AsrWorkerRequest,
     _RealtimeAsrSessionImpl,
+)
+from main_logic.asr_client._registry_meta import (
+    ASR_PROVIDER_REGISTRY,
+    CORE_ASR_ROUTES,
 )
 from main_logic.asr_client.workers.dummy import dummy_asr_worker
 
@@ -78,6 +83,7 @@ async def _delayed_error_worker(request_queue, response_queue, api_key, config):
         while True:
             request = await request_queue.get()
             if request.kind == "commit":
+
                 async def emit_error(committed_request=request):
                     await asyncio.sleep(0.02)
                     await response_queue.put(
@@ -141,7 +147,7 @@ def test_routes_fail_synchronously_without_dummy(monkeypatch):
             on_input_transcript=callback,
             on_connection_error=callback,
         )
-    with pytest.raises(RuntimeError, match="ASR_BACKEND_NOT_IMPLEMENTED"):
+    with pytest.raises(RuntimeError, match="ASR_CREDENTIALS_MISSING"):
         create_asr_session(
             "qwen",
             on_input_transcript=callback,
@@ -179,13 +185,97 @@ def test_dummy_requires_explicit_override_and_manual_mode(monkeypatch):
         on_connection_error=callback,
     )
     assert session is not None
-    with pytest.raises(RuntimeError, match="ASR_INVALID_CONFIG"):
+    with pytest.raises(RuntimeError, match="ASR_ENDPOINTING_NOT_SUPPORTED"):
         create_asr_session(
             "qwen",
-            config=AsrSessionConfig(endpointing_mode="provider"),
+            config=AsrSessionConfig(endpointing_mode="server_vad"),
             on_input_transcript=callback,
             on_connection_error=callback,
         )
+
+
+def test_phase2_registry_routes_and_capabilities():
+    assert set(asr_client._IMPLEMENTED_WORKERS) == {
+        "dummy",
+        "qwen",
+        "openai",
+        "step",
+        "grok",
+    }
+    assert CORE_ASR_ROUTES["qwen"].provider_key == "qwen"
+    assert CORE_ASR_ROUTES["qwen"].credential_field == "ASSIST_API_KEY_QWEN"
+    assert CORE_ASR_ROUTES["qwen"].region == "cn"
+    assert CORE_ASR_ROUTES["qwen_intl"].credential_field == ("ASSIST_API_KEY_QWEN_INTL")
+    assert CORE_ASR_ROUTES["qwen_intl"].region == "intl"
+    assert CORE_ASR_ROUTES["openai"].credential_field == "ASSIST_API_KEY_OPENAI"
+    assert CORE_ASR_ROUTES["step"].credential_field == "ASSIST_API_KEY_STEP"
+    assert CORE_ASR_ROUTES["grok"].credential_field == "ASSIST_API_KEY_GROK"
+
+    assert ASR_PROVIDER_REGISTRY["qwen"].supported_endpointing_modes == {
+        "manual",
+        "server_vad",
+    }
+    assert ASR_PROVIDER_REGISTRY["openai"].wire_sample_rate_hz == 24_000
+    assert ASR_PROVIDER_REGISTRY["openai"].supported_endpointing_modes == {"manual"}
+    assert ASR_PROVIDER_REGISTRY["grok"].supported_endpointing_modes == {"server_vad"}
+    for provider_key in ("qwen", "openai", "step", "grok"):
+        assert (
+            ASR_PROVIDER_REGISTRY[provider_key].implementation_status
+            == "blocked_credentials"
+        )
+
+
+def test_phase2_factory_resolves_credentials_and_qwen_region(monkeypatch):
+    import utils.config_manager as config_manager
+
+    class FakeConfigManager:
+        def get_core_config(self):
+            return {
+                "ASSIST_API_KEY_QWEN": "qwen-cn-key",
+                "ASSIST_API_KEY_QWEN_INTL": "qwen-intl-key",
+                "AUDIO_API_KEY": "must-not-be-used",
+            }
+
+    monkeypatch.delenv("ASR_PROVIDER", raising=False)
+    monkeypatch.setattr(
+        config_manager,
+        "get_config_manager",
+        lambda: FakeConfigManager(),
+    )
+    monkeypatch.setitem(
+        ASR_PROVIDER_REGISTRY,
+        "qwen",
+        replace(
+            ASR_PROVIDER_REGISTRY["qwen"],
+            implementation_status="implemented",
+        ),
+    )
+
+    cn_worker, cn_key, cn_provider = asr_client._get_asr_worker("qwen")
+    intl_worker, intl_key, intl_provider = asr_client._get_asr_worker("qwen_intl")
+    assert (cn_key, cn_provider) == ("qwen-cn-key", "qwen")
+    assert (intl_key, intl_provider) == ("qwen-intl-key", "qwen")
+    assert cn_worker.keywords == {"region": "cn"}
+    assert intl_worker.keywords == {"region": "intl"}
+
+    with pytest.raises(RuntimeError, match="ASR_ENDPOINTING_NOT_SUPPORTED"):
+        asr_client._get_asr_worker("openai", "server_vad")
+
+    class AudioOnlyConfigManager:
+        def get_core_config(self):
+            return {
+                "AUDIO_API_KEY": "audio-key",
+                "TTS_API_KEY": "tts-key",
+                "ASSIST_API_KEY_OPENAI": "another-provider-key",
+            }
+
+    monkeypatch.setattr(
+        config_manager,
+        "get_config_manager",
+        lambda: AudioOnlyConfigManager(),
+    )
+    with pytest.raises(RuntimeError, match="ASR_CREDENTIALS_MISSING"):
+        asr_client._get_asr_worker("qwen")
 
 
 async def test_connect_ready_status_and_idempotent_close(monkeypatch):
@@ -438,7 +528,7 @@ async def test_provider_mode_does_not_commit():
         api_key="",
         config=AsrSessionConfig(
             input_sample_rate_hz=48_000,
-            endpointing_mode="provider",
+            endpointing_mode="server_vad",
         ),
         on_input_transcript=transcripts.put,
         on_connection_error=errors,
@@ -454,6 +544,105 @@ async def test_provider_mode_does_not_commit():
     assert all(kind != "commit" for kind, _ in observed_requests)
     assert transcripts.empty()
     errors.assert_not_awaited()
+    await session.close()
+
+
+async def test_server_vad_started_is_idempotent_and_finals_can_arrive_out_of_order():
+    observed_kinds: list[str] = []
+
+    async def server_vad_worker(request_queue, response_queue, api_key, config):
+        del api_key, config
+        audio_requests = []
+        await response_queue.put(_AsrWorkerEvent(kind="ready", generation=0))
+        while True:
+            request = await request_queue.get()
+            try:
+                observed_kinds.append(request.kind)
+                if request.kind == "audio":
+                    audio_requests.append(request)
+                    if len(audio_requests) == 2:
+                        common = {
+                            "generation": request.generation,
+                            "buffer_epoch": request.buffer_epoch,
+                        }
+                        await response_queue.put(
+                            _AsrWorkerEvent(
+                                kind="utterance_started",
+                                utterance_id=10,
+                                **common,
+                            )
+                        )
+                        # A repeated provider speech-start notification is
+                        # idempotent and must not create another turn.
+                        await response_queue.put(
+                            _AsrWorkerEvent(
+                                kind="utterance_started",
+                                utterance_id=10,
+                                **common,
+                            )
+                        )
+                        await response_queue.put(
+                            _AsrWorkerEvent(
+                                kind="utterance_started",
+                                utterance_id=11,
+                                **common,
+                            )
+                        )
+                        # Turn 2 may complete before turn 1.
+                        await response_queue.put(
+                            _AsrWorkerEvent(
+                                kind="final",
+                                utterance_id=11,
+                                text="second",
+                                **common,
+                            )
+                        )
+                        await response_queue.put(
+                            _AsrWorkerEvent(
+                                kind="final",
+                                utterance_id=10,
+                                text="first",
+                                **common,
+                            )
+                        )
+                        await response_queue.put(
+                            _AsrWorkerEvent(
+                                kind="final",
+                                utterance_id=10,
+                                text="duplicate",
+                                **common,
+                            )
+                        )
+                elif request.kind == "shutdown":
+                    await response_queue.put(
+                        _AsrWorkerEvent(
+                            kind="closed",
+                            generation=request.generation,
+                        )
+                    )
+                    return
+            finally:
+                request_queue.task_done()
+
+    transcripts: asyncio.Queue[str] = asyncio.Queue()
+    session = _RealtimeAsrSessionImpl(
+        worker_fn=server_vad_worker,
+        api_key="",
+        config=AsrSessionConfig(endpointing_mode="server_vad"),
+        on_input_transcript=transcripts.put,
+        on_connection_error=AsyncMock(),
+    )
+    await session.connect()
+    await session.stream_audio(b"\x00\x00" * 160)
+    await session.stream_audio(b"\x00\x00" * 160)
+    await session.signal_user_activity_end()
+
+    assert await asyncio.wait_for(transcripts.get(), 1) == "second"
+    assert await asyncio.wait_for(transcripts.get(), 1) == "first"
+    await asyncio.sleep(0.05)
+    assert transcripts.empty()
+    assert "commit" not in observed_kinds
+    assert session._utterance_id == 1
     await session.close()
 
 
@@ -657,9 +846,7 @@ async def test_dummy_does_not_retain_pcm_requests(monkeypatch):
         gc.collect()
         assert first_payload_ref() is None
     finally:
-        await request_queue.put(
-            _AsrWorkerRequest(kind="shutdown", generation=1)
-        )
+        await request_queue.put(_AsrWorkerRequest(kind="shutdown", generation=1))
         await asyncio.wait_for(worker_task, 1)
 
 
@@ -789,6 +976,14 @@ async def test_provider_final_waits_for_in_flight_audio_enqueue():
                 await release_final.wait()
                 await response_queue.put(
                     _AsrWorkerEvent(
+                        kind="utterance_started",
+                        generation=request.generation,
+                        buffer_epoch=request.buffer_epoch,
+                        utterance_id=request.utterance_id,
+                    )
+                )
+                await response_queue.put(
+                    _AsrWorkerEvent(
                         kind="final",
                         generation=request.generation,
                         buffer_epoch=request.buffer_epoch,
@@ -814,7 +1009,7 @@ async def test_provider_final_waits_for_in_flight_audio_enqueue():
     session = _RealtimeAsrSessionImpl(
         worker_fn=racing_provider_worker,
         api_key="",
-        config=AsrSessionConfig(endpointing_mode="provider"),
+        config=AsrSessionConfig(endpointing_mode="server_vad"),
         on_input_transcript=capture_enqueue_state,
         on_connection_error=AsyncMock(),
     )

--- a/tests/unit/test_asr_client.py
+++ b/tests/unit/test_asr_client.py
@@ -188,7 +188,7 @@ def test_dummy_requires_explicit_override_and_manual_mode(monkeypatch):
     with pytest.raises(RuntimeError, match="ASR_ENDPOINTING_NOT_SUPPORTED"):
         create_asr_session(
             "qwen",
-            config=AsrSessionConfig(endpointing_mode="server_vad"),
+            config=AsrSessionConfig(endpointing_mode="provider"),
             on_input_transcript=callback,
             on_connection_error=callback,
         )
@@ -205,24 +205,55 @@ def test_phase2_registry_routes_and_capabilities():
     assert CORE_ASR_ROUTES["qwen"].provider_key == "qwen"
     assert CORE_ASR_ROUTES["qwen"].credential_field == "ASSIST_API_KEY_QWEN"
     assert CORE_ASR_ROUTES["qwen"].region == "cn"
+    assert CORE_ASR_ROUTES["qwen"].default_endpointing_mode == "manual"
     assert CORE_ASR_ROUTES["qwen_intl"].credential_field == ("ASSIST_API_KEY_QWEN_INTL")
     assert CORE_ASR_ROUTES["qwen_intl"].region == "intl"
     assert CORE_ASR_ROUTES["openai"].credential_field == "ASSIST_API_KEY_OPENAI"
     assert CORE_ASR_ROUTES["step"].credential_field == "ASSIST_API_KEY_STEP"
     assert CORE_ASR_ROUTES["grok"].credential_field == "ASSIST_API_KEY_GROK"
+    assert CORE_ASR_ROUTES["grok"].default_endpointing_mode == "provider"
 
     assert ASR_PROVIDER_REGISTRY["qwen"].supported_endpointing_modes == {
         "manual",
-        "server_vad",
+        "provider",
     }
     assert ASR_PROVIDER_REGISTRY["openai"].wire_sample_rate_hz == 24_000
     assert ASR_PROVIDER_REGISTRY["openai"].supported_endpointing_modes == {"manual"}
-    assert ASR_PROVIDER_REGISTRY["grok"].supported_endpointing_modes == {"server_vad"}
+    assert ASR_PROVIDER_REGISTRY["grok"].supported_endpointing_modes == {"provider"}
     for provider_key in ("qwen", "openai", "step", "grok"):
         assert (
             ASR_PROVIDER_REGISTRY[provider_key].implementation_status
             == "blocked_credentials"
         )
+
+
+def test_endpointing_contract_is_provider_neutral_and_route_defaulted(monkeypatch):
+    callback = AsyncMock()
+    observed_modes: list[tuple[str, str]] = []
+
+    def fake_get_asr_worker(core_type, endpointing_mode="manual"):
+        observed_modes.append((core_type, endpointing_mode))
+        return dummy_asr_worker, "", "dummy"
+
+    monkeypatch.delenv("ASR_PROVIDER", raising=False)
+    monkeypatch.setattr(asr_client, "_get_asr_worker", fake_get_asr_worker)
+
+    grok_session = create_asr_session(
+        "grok",
+        on_input_transcript=callback,
+        on_connection_error=callback,
+    )
+    qwen_session = create_asr_session(
+        "qwen",
+        on_input_transcript=callback,
+        on_connection_error=callback,
+    )
+
+    assert grok_session._config.endpointing_mode == "provider"
+    assert qwen_session._config.endpointing_mode == "manual"
+    assert observed_modes == [("grok", "provider"), ("qwen", "manual")]
+    with pytest.raises(ValueError, match="manual.*provider"):
+        AsrSessionConfig(endpointing_mode="server_vad")
 
 
 def test_phase2_factory_resolves_credentials_and_qwen_region(monkeypatch):
@@ -259,7 +290,7 @@ def test_phase2_factory_resolves_credentials_and_qwen_region(monkeypatch):
     assert intl_worker.keywords == {"region": "intl"}
 
     with pytest.raises(RuntimeError, match="ASR_ENDPOINTING_NOT_SUPPORTED"):
-        asr_client._get_asr_worker("openai", "server_vad")
+        asr_client._get_asr_worker("openai", "provider")
 
     class AudioOnlyConfigManager:
         def get_core_config(self):
@@ -494,6 +525,8 @@ async def test_update_session_is_locked_after_connect(monkeypatch):
         on_connection_error=AsyncMock(),
     )
     await session.update_session({"language": "en-US", "instructions": "ignored"})
+    with pytest.raises(ValueError, match="unknown session field"):
+        await session.update_session({"endpointing_mode": "provider"})
     with pytest.raises((RuntimeError, ValueError), match="ASR_INVALID_CONFIG"):
         await session.update_session({"unknown_asr_field": True})
     await session.connect()
@@ -528,7 +561,7 @@ async def test_provider_mode_does_not_commit():
         api_key="",
         config=AsrSessionConfig(
             input_sample_rate_hz=48_000,
-            endpointing_mode="server_vad",
+            endpointing_mode="provider",
         ),
         on_input_transcript=transcripts.put,
         on_connection_error=errors,
@@ -547,7 +580,7 @@ async def test_provider_mode_does_not_commit():
     await session.close()
 
 
-async def test_server_vad_started_is_idempotent_and_finals_can_arrive_out_of_order():
+async def test_provider_started_is_idempotent_and_finals_are_delivered_in_order():
     observed_kinds: list[str] = []
 
     async def server_vad_worker(request_queue, response_queue, api_key, config):
@@ -628,7 +661,7 @@ async def test_server_vad_started_is_idempotent_and_finals_can_arrive_out_of_ord
     session = _RealtimeAsrSessionImpl(
         worker_fn=server_vad_worker,
         api_key="",
-        config=AsrSessionConfig(endpointing_mode="server_vad"),
+        config=AsrSessionConfig(endpointing_mode="provider"),
         on_input_transcript=transcripts.put,
         on_connection_error=AsyncMock(),
     )
@@ -637,12 +670,62 @@ async def test_server_vad_started_is_idempotent_and_finals_can_arrive_out_of_ord
     await session.stream_audio(b"\x00\x00" * 160)
     await session.signal_user_activity_end()
 
-    assert await asyncio.wait_for(transcripts.get(), 1) == "second"
     assert await asyncio.wait_for(transcripts.get(), 1) == "first"
+    assert await asyncio.wait_for(transcripts.get(), 1) == "second"
     await asyncio.sleep(0.05)
     assert transcripts.empty()
     assert "commit" not in observed_kinds
     assert session._utterance_id == 1
+    await session.close()
+
+
+async def test_manual_finals_are_delivered_in_commit_order():
+    async def out_of_order_worker(request_queue, response_queue, api_key, config):
+        del api_key, config
+        commits = []
+        await response_queue.put(_AsrWorkerEvent(kind="ready", generation=0))
+        while True:
+            request = await request_queue.get()
+            try:
+                if request.kind == "commit":
+                    commits.append(request)
+                    if len(commits) == 2:
+                        for item, text in (
+                            (commits[1], "second"),
+                            (commits[0], "first"),
+                        ):
+                            await response_queue.put(
+                                _AsrWorkerEvent(
+                                    kind="final",
+                                    generation=item.generation,
+                                    buffer_epoch=item.buffer_epoch,
+                                    utterance_id=item.utterance_id,
+                                    text=text,
+                                )
+                            )
+                elif request.kind == "shutdown":
+                    await response_queue.put(
+                        _AsrWorkerEvent(kind="closed", generation=request.generation)
+                    )
+                    return
+            finally:
+                request_queue.task_done()
+
+    transcripts: asyncio.Queue[str] = asyncio.Queue()
+    session = _RealtimeAsrSessionImpl(
+        worker_fn=out_of_order_worker,
+        api_key="",
+        config=AsrSessionConfig(endpointing_mode="manual"),
+        on_input_transcript=transcripts.put,
+        on_connection_error=AsyncMock(),
+    )
+    await session.connect()
+    for _ in range(2):
+        await session.stream_audio(b"\x00\x00" * 160)
+        await session.signal_user_activity_end()
+
+    assert await asyncio.wait_for(transcripts.get(), 1) == "first"
+    assert await asyncio.wait_for(transcripts.get(), 1) == "second"
     await session.close()
 
 
@@ -1009,7 +1092,7 @@ async def test_provider_final_waits_for_in_flight_audio_enqueue():
     session = _RealtimeAsrSessionImpl(
         worker_fn=racing_provider_worker,
         api_key="",
-        config=AsrSessionConfig(endpointing_mode="server_vad"),
+        config=AsrSessionConfig(endpointing_mode="provider"),
         on_input_transcript=capture_enqueue_state,
         on_connection_error=AsyncMock(),
     )

--- a/tests/unit/test_asr_client.py
+++ b/tests/unit/test_asr_client.py
@@ -38,15 +38,17 @@ async def _scripted_worker(request_queue, response_queue, api_key, config):
                 await response_queue.put(
                     _AsrWorkerEvent(kind="partial", text="draft", **common)
                 )
-                await response_queue.put(
-                    _AsrWorkerEvent(kind="final", text="   ", **common)
-                )
-                await response_queue.put(
-                    _AsrWorkerEvent(kind="final", text=" first ", **common)
-                )
-                await response_queue.put(
-                    _AsrWorkerEvent(kind="final", text="conflict", **common)
-                )
+                if request.utterance_id == 1:
+                    await response_queue.put(
+                        _AsrWorkerEvent(kind="final", text="   ", **common)
+                    )
+                    await response_queue.put(
+                        _AsrWorkerEvent(kind="final", text="conflict", **common)
+                    )
+                else:
+                    await response_queue.put(
+                        _AsrWorkerEvent(kind="final", text=" second ", **common)
+                    )
             elif api_key == "error":
                 await response_queue.put(
                     _AsrWorkerEvent(
@@ -729,7 +731,7 @@ async def test_manual_finals_are_delivered_in_commit_order():
     await session.close()
 
 
-async def test_partial_empty_duplicate_and_conflicting_finals_are_filtered():
+async def test_empty_final_retires_utterance_without_blocking_later_final():
     transcripts: asyncio.Queue[str] = asyncio.Queue()
     session = _RealtimeAsrSessionImpl(
         worker_fn=_scripted_worker,
@@ -741,10 +743,49 @@ async def test_partial_empty_duplicate_and_conflicting_finals_are_filtered():
     await session.connect()
     await session.stream_audio(b"\x00\x00" * 160)
     await session.signal_user_activity_end()
-    assert await asyncio.wait_for(transcripts.get(), 1) == "first"
     await asyncio.sleep(0.05)
     assert transcripts.empty()
+    await session.stream_audio(b"\x00\x00" * 160)
+    await session.signal_user_activity_end()
+    assert await asyncio.wait_for(transcripts.get(), 1) == "second"
     await session.close()
+
+
+async def test_cancelled_connect_closes_worker_and_dispatch_tasks():
+    async def never_ready_worker(request_queue, response_queue, api_key, config):
+        del api_key, config
+        while True:
+            request = await request_queue.get()
+            try:
+                if request.kind == "shutdown":
+                    await response_queue.put(
+                        _AsrWorkerEvent(kind="closed", generation=request.generation)
+                    )
+                    return
+            finally:
+                request_queue.task_done()
+
+    on_error = AsyncMock()
+    session = _RealtimeAsrSessionImpl(
+        worker_fn=never_ready_worker,
+        api_key="",
+        config=AsrSessionConfig(),
+        on_input_transcript=AsyncMock(),
+        on_connection_error=on_error,
+    )
+    connect_task = asyncio.create_task(session.connect())
+    while session._worker_task is None:
+        await asyncio.sleep(0)
+
+    connect_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await connect_task
+
+    assert session.is_ready is False
+    assert session._worker_task.done()
+    assert session._response_task is not None and session._response_task.done()
+    assert session._callback_task is not None and session._callback_task.done()
+    on_error.assert_not_awaited()
 
 
 async def test_stale_utterance_error_is_dropped_after_clear():

--- a/tests/unit/test_asr_workers.py
+++ b/tests/unit/test_asr_workers.py
@@ -538,7 +538,7 @@ async def test_step_manual_uses_transcription_item_id_not_committed_item_id(
         await _stop_worker(task, requests, responses, utterance_id=8)
 
 
-async def test_step_manual_rejects_commit_when_previous_item_is_unbound(
+async def test_step_manual_rejects_overlap_without_dropping_previous_final(
     monkeypatch,
 ) -> None:
     async def on_send(ws: _FakeWebSocket, payload: str | bytes) -> None:
@@ -574,22 +574,48 @@ async def test_step_manual_rejects_commit_when_previous_item_is_unbound(
     )
     await requests.put(_AsrWorkerRequest(kind="commit", generation=0, utterance_id=2))
 
-    error = await _next_event(responses, "error")
-    assert (error.error_code, error.utterance_id) == (
-        "ASR_STEP_PROTOCOL_ERROR",
-        2,
+    rejected = await _next_event(responses, "final")
+    assert (rejected.utterance_id, rejected.text) == (2, "")
+    assert not task.done()
+    await websocket.server_send(
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "item_id": "step-1",
+            "transcript": "first",
+        }
     )
-    assert (await _next_event(responses, "closed")).kind == "closed"
-    await asyncio.wait_for(task, 1)
-    assert responses.empty()
+    first = await _next_event(responses, "final")
+    assert (first.utterance_id, first.text) == (1, "first")
+
+    await requests.put(_AsrWorkerRequest(kind="commit", generation=0, utterance_id=3))
+    await _wait_until(
+        lambda: (
+            sum(
+                isinstance(payload, str)
+                and json.loads(payload).get("type") == "input_audio_buffer.commit"
+                for payload in websocket.sent
+            )
+            == 2
+        )
+    )
+    await websocket.server_send(
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "item_id": "step-3",
+            "transcript": "third",
+        }
+    )
+    third = await _next_event(responses, "final")
+    assert (third.utterance_id, third.text) == (3, "third")
     assert (
         sum(
             isinstance(payload, str)
-            and json.loads(payload).get("type") == "input_audio_buffer.commit"
+            and json.loads(payload).get("type") == "input_audio_buffer.clear"
             for payload in websocket.sent
         )
         == 1
     )
+    await _stop_worker(task, requests, responses, utterance_id=4)
 
 
 async def test_step_duplicate_final_does_not_consume_next_commit(monkeypatch) -> None:

--- a/tests/unit/test_asr_workers.py
+++ b/tests/unit/test_asr_workers.py
@@ -529,7 +529,7 @@ async def test_openai_transcription_resampling_and_out_of_order_finals(
     assert (first.utterance_id, first.text) == (1, "first")
 
     url, kwargs = connector.calls[0]
-    assert "model=gpt-realtime-whisper" in url
+    assert url == "wss://api.openai.com/v1/realtime?intent=transcription"
     assert kwargs["additional_headers"] == {"Authorization": "Bearer openai-key"}
     messages = [json.loads(payload) for payload in websocket.sent]
     session = messages[0]["session"]

--- a/tests/unit/test_asr_workers.py
+++ b/tests/unit/test_asr_workers.py
@@ -674,6 +674,48 @@ async def test_openai_native_clear_and_mode_rejection(monkeypatch) -> None:
     assert len(connector.calls) == 1
 
 
+async def test_openai_transcription_failure_is_terminal(monkeypatch) -> None:
+    async def on_send(ws: _FakeWebSocket, payload: str | bytes) -> None:
+        assert isinstance(payload, str)
+        message = json.loads(payload)
+        if message["type"] == "session.update":
+            await ws.server_send({"type": "session.updated"})
+        elif message["type"] == "input_audio_buffer.commit":
+            await ws.server_send(
+                {"type": "input_audio_buffer.committed", "item_id": "failed-item"}
+            )
+            await ws.server_send(
+                {
+                    "type": "conversation.item.input_audio_transcription.failed",
+                    "item_id": "failed-item",
+                }
+            )
+
+    websocket = _FakeWebSocket(on_send=on_send)
+    connector = _FakeConnector(websocket)
+    monkeypatch.setattr(openai.websockets, "connect", connector)
+    requests: asyncio.Queue[_AsrWorkerRequest] = asyncio.Queue()
+    responses: asyncio.Queue[_AsrWorkerEvent] = asyncio.Queue()
+    task = asyncio.create_task(
+        openai.openai_asr_worker(requests, responses, "key", AsrSessionConfig())
+    )
+    await _next_event(responses, "ready")
+    await requests.put(
+        _AsrWorkerRequest(
+            kind="audio",
+            generation=0,
+            utterance_id=1,
+            audio=b"\0\0" * 100,
+        )
+    )
+    await requests.put(_AsrWorkerRequest(kind="commit", generation=0, utterance_id=1))
+
+    error = await _next_event(responses, "error")
+    assert error.error_code == "ASR_OPENAI_TRANSCRIPTION_FAILED"
+    await _next_event(responses, "closed")
+    await asyncio.wait_for(task, 1)
+
+
 async def test_openai_clear_keeps_old_commit_tombstone(monkeypatch) -> None:
     commit_count = 0
 

--- a/tests/unit/test_asr_workers.py
+++ b/tests/unit/test_asr_workers.py
@@ -1,0 +1,953 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from collections.abc import Awaitable, Callable
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from main_logic.asr_client._infra import (
+    AsrSessionConfig,
+    _AsrWorkerEvent,
+    _AsrWorkerRequest,
+)
+from main_logic.asr_client.workers import grok, openai, qwen, step
+
+
+_END = object()
+
+
+class _FakeWebSocket:
+    def __init__(
+        self,
+        *,
+        initial: list[dict[str, Any]] | None = None,
+        on_send: Callable[["_FakeWebSocket", str | bytes], Awaitable[None]]
+        | None = None,
+    ) -> None:
+        self.incoming: asyncio.Queue[str | object] = asyncio.Queue()
+        self.sent: list[str | bytes] = []
+        self.closed = False
+        self.on_send = on_send
+        for event in initial or []:
+            self.incoming.put_nowait(json.dumps(event))
+
+    async def send(self, payload: str | bytes) -> None:
+        if self.closed:
+            raise RuntimeError("fake websocket is closed")
+        self.sent.append(payload)
+        if self.on_send is not None:
+            await self.on_send(self, payload)
+
+    async def recv(self) -> str:
+        message = await self.incoming.get()
+        if message is _END:
+            raise RuntimeError("fake websocket closed before ready")
+        assert isinstance(message, str)
+        return message
+
+    def __aiter__(self) -> _FakeWebSocket:
+        return self
+
+    async def __anext__(self) -> str:
+        message = await self.incoming.get()
+        if message is _END:
+            raise StopAsyncIteration
+        assert isinstance(message, str)
+        return message
+
+    async def server_send(self, event: dict[str, Any]) -> None:
+        await self.incoming.put(json.dumps(event))
+
+    async def server_end(self) -> None:
+        await self.incoming.put(_END)
+
+    async def close(self) -> None:
+        if self.closed:
+            return
+        self.closed = True
+        await self.incoming.put(_END)
+
+
+class _FakeConnector:
+    def __init__(self, *websockets: _FakeWebSocket) -> None:
+        self.websockets = list(websockets)
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def __call__(self, url: str, **kwargs: Any) -> _FakeWebSocket:
+        self.calls.append((url, kwargs))
+        if not self.websockets:
+            raise AssertionError("unexpected extra WebSocket connection")
+        return self.websockets.pop(0)
+
+
+async def _next_event(
+    queue: asyncio.Queue[_AsrWorkerEvent],
+    kind: str | None = None,
+    *,
+    timeout: float = 1.0,
+) -> _AsrWorkerEvent:
+    while True:
+        event = await asyncio.wait_for(queue.get(), timeout)
+        queue.task_done()
+        if kind is None or event.kind == kind:
+            return event
+
+
+async def _wait_until(
+    predicate: Callable[[], bool],
+    *,
+    timeout: float = 1.0,
+) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while not predicate():
+        if asyncio.get_running_loop().time() >= deadline:
+            raise TimeoutError("condition was not reached")
+        await asyncio.sleep(0)
+
+
+async def _stop_worker(
+    task: asyncio.Task[None],
+    requests: asyncio.Queue[_AsrWorkerRequest],
+    responses: asyncio.Queue[_AsrWorkerEvent],
+    *,
+    generation: int = 0,
+    buffer_epoch: int = 0,
+    utterance_id: int = 1,
+) -> _AsrWorkerEvent:
+    await requests.put(
+        _AsrWorkerRequest(
+            kind="shutdown",
+            generation=generation,
+            buffer_epoch=buffer_epoch,
+            utterance_id=utterance_id,
+        )
+    )
+    closed = await _next_event(responses, "closed")
+    await asyncio.wait_for(task, 1)
+    await asyncio.wait_for(requests.join(), 1)
+    return closed
+
+
+@pytest.mark.parametrize(
+    ("region", "domain", "legacy_without_item_ids"),
+    [
+        ("cn", "dashscope.aliyuncs.com", True),
+        ("intl", "dashscope-intl.aliyuncs.com", False),
+    ],
+)
+async def test_qwen_manual_regions_payload_and_final(
+    monkeypatch,
+    region: str,
+    domain: str,
+    legacy_without_item_ids: bool,
+) -> None:
+    commit_count = 0
+
+    async def on_send(ws: _FakeWebSocket, payload: str | bytes) -> None:
+        nonlocal commit_count
+        assert isinstance(payload, str)
+        message = json.loads(payload)
+        if message["type"] == "session.update":
+            await ws.server_send({"type": "session.updated"})
+        elif message["type"] == "input_audio_buffer.commit":
+            commit_count += 1
+            item_id = f"qwen-{commit_count}"
+            if legacy_without_item_ids:
+                await ws.server_send(
+                    {
+                        "type": "conversation.item.created",
+                        "item": {
+                            "type": "message",
+                            "role": "user",
+                            "content": [{"type": "input_audio"}],
+                        },
+                    }
+                )
+                await ws.server_send({"type": "input_audio_buffer.committed"})
+            else:
+                await ws.server_send(
+                    {"type": "input_audio_buffer.committed", "item_id": item_id}
+                )
+            await ws.server_send(
+                {
+                    "type": "conversation.item.input_audio_transcription.text",
+                    "text": "你",
+                    "stash": "好",
+                    **({} if legacy_without_item_ids else {"item_id": item_id}),
+                }
+            )
+            await ws.server_send(
+                {
+                    "type": "conversation.item.input_audio_transcription.completed",
+                    "transcript": "你好",
+                    **({} if legacy_without_item_ids else {"item_id": item_id}),
+                }
+            )
+        elif message["type"] == "session.finish":
+            await ws.server_send({"type": "session.finished"})
+
+    websocket = _FakeWebSocket(on_send=on_send)
+    connector = _FakeConnector(websocket)
+    monkeypatch.setattr(qwen.websockets, "connect", connector)
+    requests: asyncio.Queue[_AsrWorkerRequest] = asyncio.Queue()
+    responses: asyncio.Queue[_AsrWorkerEvent] = asyncio.Queue()
+    task = asyncio.create_task(
+        qwen.qwen_asr_worker(
+            requests,
+            responses,
+            "secret-qwen-key",
+            AsrSessionConfig(language="zh-CN"),
+            region=region,
+        )
+    )
+
+    assert (await _next_event(responses, "ready")).generation == 0
+    pcm = b"\x01\x02" * 320
+    await requests.put(
+        _AsrWorkerRequest(kind="audio", generation=0, utterance_id=1, audio=pcm)
+    )
+    await requests.put(_AsrWorkerRequest(kind="commit", generation=0, utterance_id=1))
+
+    partial = await _next_event(responses, "partial")
+    final = await _next_event(responses, "final")
+    assert (partial.text, final.text, final.utterance_id) == ("你好", "你好", 1)
+    assert not task.done(), "commit must keep the provider connection open"
+
+    url, kwargs = connector.calls[0]
+    assert urlparse(url).hostname == domain
+    assert parse_qs(urlparse(url).query)["model"] == ["qwen3-asr-flash-realtime"]
+    assert kwargs["additional_headers"] == {"Authorization": "Bearer secret-qwen-key"}
+    messages = [json.loads(payload) for payload in websocket.sent]
+    session = next(
+        message for message in messages if message["type"] == "session.update"
+    )
+    assert session["session"]["sample_rate"] == 16_000
+    assert session["session"]["turn_detection"] is None
+    append = next(
+        message
+        for message in messages
+        if message["type"] == "input_audio_buffer.append"
+    )
+    assert base64.b64decode(append["audio"]) == pcm
+
+    await _stop_worker(task, requests, responses)
+
+
+async def test_qwen_server_vad_maps_items_and_reconnects_on_clear(monkeypatch) -> None:
+    async def on_send(ws: _FakeWebSocket, payload: str | bytes) -> None:
+        if isinstance(payload, str):
+            message = json.loads(payload)
+            if message["type"] == "session.update":
+                await ws.server_send({"type": "session.updated"})
+            elif message["type"] == "session.finish":
+                await ws.server_send({"type": "session.finished"})
+
+    first = _FakeWebSocket(on_send=on_send)
+    second = _FakeWebSocket(on_send=on_send)
+    connector = _FakeConnector(first, second)
+    monkeypatch.setattr(qwen.websockets, "connect", connector)
+    requests: asyncio.Queue[_AsrWorkerRequest] = asyncio.Queue()
+    responses: asyncio.Queue[_AsrWorkerEvent] = asyncio.Queue()
+    task = asyncio.create_task(
+        qwen.qwen_asr_worker(
+            requests,
+            responses,
+            "key",
+            AsrSessionConfig(endpointing_mode="server_vad"),
+        )
+    )
+    await _next_event(responses, "ready")
+    await requests.put(
+        _AsrWorkerRequest(
+            kind="audio", generation=0, buffer_epoch=0, utterance_id=1, audio=b"\0\0"
+        )
+    )
+    await first.server_send(
+        {"type": "input_audio_buffer.speech_started", "item_id": "one"}
+    )
+    await first.server_send(
+        {"type": "input_audio_buffer.speech_started", "item_id": "one"}
+    )
+    await first.server_send(
+        {"type": "input_audio_buffer.speech_started", "item_id": "two"}
+    )
+    started_one = await _next_event(responses, "utterance_started")
+    started_two = await _next_event(responses, "utterance_started")
+    assert (started_one.utterance_id, started_two.utterance_id) == (1, 2)
+
+    for item_id, text in (("two", "second"), ("one", "first")):
+        await first.server_send(
+            {
+                "type": "conversation.item.input_audio_transcription.completed",
+                "item_id": item_id,
+                "transcript": text,
+            }
+        )
+    final_two = await _next_event(responses, "final")
+    final_one = await _next_event(responses, "final")
+    assert (final_two.utterance_id, final_two.text) == (2, "second")
+    assert (final_one.utterance_id, final_one.text) == (1, "first")
+
+    await requests.put(
+        _AsrWorkerRequest(kind="clear", generation=0, buffer_epoch=1, utterance_id=3)
+    )
+    await requests.put(
+        _AsrWorkerRequest(
+            kind="audio",
+            generation=0,
+            buffer_epoch=1,
+            utterance_id=3,
+            audio=b"\x03\x04",
+        )
+    )
+    await _wait_until(lambda: len(connector.calls) == 2)
+    await _wait_until(
+        lambda: any(
+            isinstance(payload, str)
+            and json.loads(payload).get("type") == "input_audio_buffer.append"
+            for payload in second.sent
+        )
+    )
+    assert len(connector.calls) == 2
+    await _stop_worker(
+        task,
+        requests,
+        responses,
+        buffer_epoch=1,
+        utterance_id=3,
+    )
+
+
+async def test_step_manual_payload_and_cumulative_partial(monkeypatch) -> None:
+    async def on_send(ws: _FakeWebSocket, payload: str | bytes) -> None:
+        assert isinstance(payload, str)
+        message = json.loads(payload)
+        if message["type"] == "session.update":
+            await ws.server_send({"type": "session.updated"})
+        elif message["type"] == "input_audio_buffer.commit":
+            await ws.server_send(
+                {"type": "input_audio_buffer.committed", "item_id": "step-1"}
+            )
+            await ws.server_send(
+                {
+                    "type": "conversation.item.input_audio_transcription.delta",
+                    "item_id": "step-1",
+                    "text": "你好，请问",
+                    "stash": "退款",
+                }
+            )
+            await ws.server_send(
+                {
+                    "type": "conversation.item.input_audio_transcription.completed",
+                    "item_id": "step-1",
+                    "transcript": "你好，请问退款流程",
+                }
+            )
+
+    websocket = _FakeWebSocket(on_send=on_send)
+    connector = _FakeConnector(websocket)
+    monkeypatch.setattr(step.websockets, "connect", connector)
+    requests: asyncio.Queue[_AsrWorkerRequest] = asyncio.Queue()
+    responses: asyncio.Queue[_AsrWorkerEvent] = asyncio.Queue()
+    task = asyncio.create_task(
+        step.step_asr_worker(
+            requests,
+            responses,
+            "step-key",
+            AsrSessionConfig(language="zh-CN"),
+        )
+    )
+    await _next_event(responses, "ready")
+    pcm = b"\x11\x22" * 160
+    await requests.put(
+        _AsrWorkerRequest(kind="audio", generation=0, utterance_id=1, audio=pcm)
+    )
+    await requests.put(_AsrWorkerRequest(kind="commit", generation=0, utterance_id=1))
+    partial = await _next_event(responses, "partial")
+    final = await _next_event(responses, "final")
+    assert partial.text == "你好，请问"
+    assert final.text == "你好，请问退款流程"
+    assert not task.done()
+
+    url, kwargs = connector.calls[0]
+    assert url == "wss://api.stepfun.com/v1/realtime/asr/stream"
+    assert kwargs["additional_headers"] == {"Authorization": "Bearer step-key"}
+    messages = [json.loads(payload) for payload in websocket.sent]
+    session = messages[0]["session"]["audio"]["input"]
+    assert session["format"] == {
+        "type": "pcm",
+        "codec": "pcm_s16le",
+        "rate": 16_000,
+        "bits": 16,
+        "channel": 1,
+    }
+    assert session["transcription"]["model"] == "stepaudio-2.5-asr-stream"
+    assert "turn_detection" not in session
+    append = next(
+        message
+        for message in messages
+        if message["type"] == "input_audio_buffer.append"
+    )
+    assert base64.b64decode(append["audio"]) == pcm
+    await _stop_worker(task, requests, responses)
+
+
+async def test_step_server_vad_maps_utterances_and_reconnects(monkeypatch) -> None:
+    async def on_send(ws: _FakeWebSocket, payload: str | bytes) -> None:
+        if isinstance(payload, str) and json.loads(payload)["type"] == "session.update":
+            await ws.server_send({"type": "session.updated"})
+
+    first = _FakeWebSocket(on_send=on_send)
+    second = _FakeWebSocket(on_send=on_send)
+    connector = _FakeConnector(first, second)
+    monkeypatch.setattr(step.websockets, "connect", connector)
+    requests: asyncio.Queue[_AsrWorkerRequest] = asyncio.Queue()
+    responses: asyncio.Queue[_AsrWorkerEvent] = asyncio.Queue()
+    task = asyncio.create_task(
+        step.step_asr_worker(
+            requests,
+            responses,
+            "key",
+            AsrSessionConfig(endpointing_mode="server_vad"),
+        )
+    )
+    await _next_event(responses, "ready")
+    await requests.put(
+        _AsrWorkerRequest(kind="audio", generation=0, utterance_id=1, audio=b"\0\0")
+    )
+    await first.server_send(
+        {"type": "input_audio_buffer.speech_started", "item_id": "step-vad"}
+    )
+    await first.server_send(
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "item_id": "step-vad",
+            "transcript": "done",
+        }
+    )
+    assert (await _next_event(responses, "utterance_started")).utterance_id == 1
+    assert (await _next_event(responses, "final")).text == "done"
+
+    await requests.put(
+        _AsrWorkerRequest(kind="clear", generation=0, buffer_epoch=1, utterance_id=2)
+    )
+    await requests.put(
+        _AsrWorkerRequest(
+            kind="audio",
+            generation=0,
+            buffer_epoch=1,
+            utterance_id=2,
+            audio=b"\x01\x02",
+        )
+    )
+    await _wait_until(lambda: len(connector.calls) == 2)
+    await _wait_until(
+        lambda: any(
+            isinstance(payload, str)
+            and json.loads(payload).get("type") == "input_audio_buffer.append"
+            for payload in second.sent
+        )
+    )
+    await _stop_worker(
+        task,
+        requests,
+        responses,
+        buffer_epoch=1,
+        utterance_id=2,
+    )
+
+
+async def test_openai_transcription_resampling_and_out_of_order_finals(
+    monkeypatch,
+) -> None:
+    commit_count = 0
+
+    async def on_send(ws: _FakeWebSocket, payload: str | bytes) -> None:
+        nonlocal commit_count
+        assert isinstance(payload, str)
+        message = json.loads(payload)
+        if message["type"] == "session.update":
+            await ws.server_send({"type": "session.updated"})
+        elif message["type"] == "input_audio_buffer.commit":
+            commit_count += 1
+            await ws.server_send(
+                {
+                    "type": "input_audio_buffer.committed",
+                    "item_id": f"openai-{commit_count}",
+                }
+            )
+
+    websocket = _FakeWebSocket(on_send=on_send)
+    connector = _FakeConnector(websocket)
+    monkeypatch.setattr(openai.websockets, "connect", connector)
+    requests: asyncio.Queue[_AsrWorkerRequest] = asyncio.Queue()
+    responses: asyncio.Queue[_AsrWorkerEvent] = asyncio.Queue()
+    task = asyncio.create_task(
+        openai.openai_asr_worker(
+            requests,
+            responses,
+            "openai-key",
+            AsrSessionConfig(language="en-US"),
+        )
+    )
+    await _next_event(responses, "ready")
+    pcm = b"\x01\x00" * 1_600
+    for utterance_id in (1, 2):
+        await requests.put(
+            _AsrWorkerRequest(
+                kind="audio",
+                generation=0,
+                utterance_id=utterance_id,
+                audio=pcm,
+            )
+        )
+        await requests.put(
+            _AsrWorkerRequest(kind="commit", generation=0, utterance_id=utterance_id)
+        )
+    await _wait_until(lambda: commit_count == 2)
+    await websocket.server_send(
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "item_id": "openai-2",
+            "transcript": "second",
+        }
+    )
+    await websocket.server_send(
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "item_id": "openai-1",
+            "transcript": "first",
+        }
+    )
+    second = await _next_event(responses, "final")
+    first = await _next_event(responses, "final")
+    assert (second.utterance_id, second.text) == (2, "second")
+    assert (first.utterance_id, first.text) == (1, "first")
+
+    url, kwargs = connector.calls[0]
+    assert "model=gpt-realtime-whisper" in url
+    assert kwargs["additional_headers"] == {"Authorization": "Bearer openai-key"}
+    messages = [json.loads(payload) for payload in websocket.sent]
+    session = messages[0]["session"]
+    assert session["type"] == "transcription"
+    audio_input = session["audio"]["input"]
+    assert audio_input["format"] == {"type": "audio/pcm", "rate": 24_000}
+    assert audio_input["transcription"]["model"] == "gpt-realtime-whisper"
+    assert audio_input["turn_detection"] is None
+    assert "response.create" not in {message["type"] for message in messages}
+    wire_audio = b"".join(
+        base64.b64decode(message["audio"])
+        for message in messages
+        if message["type"] == "input_audio_buffer.append"
+    )
+    assert len(wire_audio) > len(pcm) * 2
+    assert len(wire_audio) < len(pcm) * 4
+    await _stop_worker(task, requests, responses, utterance_id=3)
+
+
+async def test_openai_native_clear_and_mode_rejection(monkeypatch) -> None:
+    async def on_send(ws: _FakeWebSocket, payload: str | bytes) -> None:
+        if isinstance(payload, str) and json.loads(payload)["type"] == "session.update":
+            await ws.server_send({"type": "session.updated"})
+
+    websocket = _FakeWebSocket(on_send=on_send)
+    connector = _FakeConnector(websocket)
+    monkeypatch.setattr(openai.websockets, "connect", connector)
+    requests: asyncio.Queue[_AsrWorkerRequest] = asyncio.Queue()
+    responses: asyncio.Queue[_AsrWorkerEvent] = asyncio.Queue()
+    task = asyncio.create_task(
+        openai.openai_asr_worker(requests, responses, "key", AsrSessionConfig())
+    )
+    await _next_event(responses, "ready")
+    await requests.put(
+        _AsrWorkerRequest(kind="clear", generation=0, buffer_epoch=1, utterance_id=2)
+    )
+    await _wait_until(
+        lambda: any(
+            isinstance(payload, str)
+            and json.loads(payload).get("type") == "input_audio_buffer.clear"
+            for payload in websocket.sent
+        )
+    )
+    assert len(connector.calls) == 1
+    await _stop_worker(
+        task,
+        requests,
+        responses,
+        buffer_epoch=1,
+        utterance_id=2,
+    )
+
+    rejected_requests: asyncio.Queue[_AsrWorkerRequest] = asyncio.Queue()
+    rejected_responses: asyncio.Queue[_AsrWorkerEvent] = asyncio.Queue()
+    rejected = asyncio.create_task(
+        openai.openai_asr_worker(
+            rejected_requests,
+            rejected_responses,
+            "key",
+            AsrSessionConfig(endpointing_mode="server_vad"),
+        )
+    )
+    error = await _next_event(rejected_responses, "error")
+    assert error.error_code == "ASR_ENDPOINTING_NOT_SUPPORTED"
+    await _next_event(rejected_responses, "closed")
+    await asyncio.wait_for(rejected, 1)
+    assert len(connector.calls) == 1
+
+
+async def test_openai_clear_keeps_old_commit_tombstone(monkeypatch) -> None:
+    commit_count = 0
+
+    async def on_send(ws: _FakeWebSocket, payload: str | bytes) -> None:
+        nonlocal commit_count
+        assert isinstance(payload, str)
+        message = json.loads(payload)
+        if message["type"] == "session.update":
+            await ws.server_send({"type": "session.updated"})
+        elif message["type"] == "input_audio_buffer.commit":
+            commit_count += 1
+
+    websocket = _FakeWebSocket(on_send=on_send)
+    connector = _FakeConnector(websocket)
+    monkeypatch.setattr(openai.websockets, "connect", connector)
+    requests: asyncio.Queue[_AsrWorkerRequest] = asyncio.Queue()
+    responses: asyncio.Queue[_AsrWorkerEvent] = asyncio.Queue()
+    task = asyncio.create_task(
+        openai.openai_asr_worker(requests, responses, "key", AsrSessionConfig())
+    )
+    await _next_event(responses, "ready")
+
+    await requests.put(
+        _AsrWorkerRequest(
+            kind="audio",
+            generation=0,
+            buffer_epoch=0,
+            utterance_id=1,
+            audio=b"\0\0" * 100,
+        )
+    )
+    await requests.put(
+        _AsrWorkerRequest(kind="commit", generation=0, buffer_epoch=0, utterance_id=1)
+    )
+    await _wait_until(lambda: commit_count == 1)
+    await requests.put(
+        _AsrWorkerRequest(kind="clear", generation=0, buffer_epoch=1, utterance_id=2)
+    )
+    await requests.put(
+        _AsrWorkerRequest(
+            kind="audio",
+            generation=0,
+            buffer_epoch=1,
+            utterance_id=2,
+            audio=b"\1\1" * 100,
+        )
+    )
+    await requests.put(
+        _AsrWorkerRequest(kind="commit", generation=0, buffer_epoch=1, utterance_id=2)
+    )
+    await _wait_until(lambda: commit_count == 2)
+
+    for item_id, transcript in (("old", "old final"), ("new", "new final")):
+        await websocket.server_send(
+            {"type": "input_audio_buffer.committed", "item_id": item_id}
+        )
+        await websocket.server_send(
+            {
+                "type": "conversation.item.input_audio_transcription.completed",
+                "item_id": item_id,
+                "transcript": transcript,
+            }
+        )
+    old_final = await _next_event(responses, "final")
+    new_final = await _next_event(responses, "final")
+    assert (
+        old_final.buffer_epoch,
+        old_final.utterance_id,
+        old_final.text,
+    ) == (0, 1, "old final")
+    assert (
+        new_final.buffer_epoch,
+        new_final.utterance_id,
+        new_final.text,
+    ) == (1, 2, "new final")
+    await _stop_worker(
+        task,
+        requests,
+        responses,
+        buffer_epoch=1,
+        utterance_id=3,
+    )
+
+
+async def test_grok_manual_binary_finalize_and_shutdown(monkeypatch) -> None:
+    async def on_send(ws: _FakeWebSocket, payload: str | bytes) -> None:
+        if not isinstance(payload, str):
+            return
+        message = json.loads(payload)
+        if message["type"] == "finalize":
+            await ws.server_send(
+                {
+                    "type": "transcript.partial",
+                    "text": "manual final",
+                    "is_final": True,
+                    "speech_final": True,
+                }
+            )
+        elif message["type"] == "audio.done":
+            await ws.server_send({"type": "transcript.done", "duration": 1.0})
+
+    websocket = _FakeWebSocket(
+        initial=[{"type": "transcript.created"}],
+        on_send=on_send,
+    )
+    connector = _FakeConnector(websocket)
+    monkeypatch.setattr(grok.websockets, "connect", connector)
+    requests: asyncio.Queue[_AsrWorkerRequest] = asyncio.Queue()
+    responses: asyncio.Queue[_AsrWorkerEvent] = asyncio.Queue()
+    task = asyncio.create_task(
+        grok.grok_asr_worker(
+            requests,
+            responses,
+            "grok-key",
+            AsrSessionConfig(language="zh-CN"),
+        )
+    )
+    await _next_event(responses, "ready")
+    pcm = b"\x12\x34" * 160
+    await requests.put(
+        _AsrWorkerRequest(kind="audio", generation=0, utterance_id=1, audio=pcm)
+    )
+    await requests.put(_AsrWorkerRequest(kind="commit", generation=0, utterance_id=1))
+    final = await _next_event(responses, "final")
+    assert (final.utterance_id, final.text) == (1, "manual final")
+    assert not task.done()
+
+    url, kwargs = connector.calls[0]
+    query = parse_qs(urlparse(url).query)
+    assert urlparse(url).path == "/v1/stt"
+    assert query == {
+        "sample_rate": ["16000"],
+        "encoding": ["pcm"],
+        "interim_results": ["true"],
+        "language": ["zh"],
+    }
+    assert "smart_turn" not in query
+    assert kwargs["additional_headers"] == {"Authorization": "Bearer grok-key"}
+    assert pcm in websocket.sent
+    assert {
+        json.loads(payload)["type"]
+        for payload in websocket.sent
+        if isinstance(payload, str)
+    } == {"finalize"}
+    await _stop_worker(task, requests, responses)
+    assert any(
+        isinstance(payload, str) and json.loads(payload)["type"] == "audio.done"
+        for payload in websocket.sent
+    )
+
+
+async def test_grok_manual_preserves_natural_segments_before_commit(
+    monkeypatch,
+) -> None:
+    async def on_send(ws: _FakeWebSocket, payload: str | bytes) -> None:
+        if not isinstance(payload, str):
+            return
+        message = json.loads(payload)
+        if message["type"] == "finalize":
+            await ws.server_send(
+                {
+                    "type": "transcript.partial",
+                    "text": "后半段",
+                    "is_final": True,
+                    "speech_final": True,
+                }
+            )
+        elif message["type"] == "audio.done":
+            await ws.server_send({"type": "transcript.done", "duration": 1.0})
+
+    websocket = _FakeWebSocket(
+        initial=[{"type": "transcript.created"}], on_send=on_send
+    )
+    connector = _FakeConnector(websocket)
+    monkeypatch.setattr(grok.websockets, "connect", connector)
+    requests: asyncio.Queue[_AsrWorkerRequest] = asyncio.Queue()
+    responses: asyncio.Queue[_AsrWorkerEvent] = asyncio.Queue()
+    task = asyncio.create_task(
+        grok.grok_asr_worker(requests, responses, "key", AsrSessionConfig())
+    )
+    await _next_event(responses, "ready")
+    await requests.put(
+        _AsrWorkerRequest(kind="audio", generation=0, utterance_id=1, audio=b"\0\0")
+    )
+    await _wait_until(lambda: b"\0\0" in websocket.sent)
+    await websocket.server_send(
+        {
+            "type": "transcript.partial",
+            "text": "前半段",
+            "is_final": True,
+            "speech_final": True,
+        }
+    )
+    assert (await _next_event(responses, "partial")).text == "前半段"
+
+    await requests.put(
+        _AsrWorkerRequest(kind="audio", generation=0, utterance_id=1, audio=b"\1\1")
+    )
+    await requests.put(_AsrWorkerRequest(kind="commit", generation=0, utterance_id=1))
+    final = await _next_event(responses, "final")
+    assert final.text == "前半段后半段"
+    assert any(
+        isinstance(payload, str) and json.loads(payload)["type"] == "finalize"
+        for payload in websocket.sent
+    )
+    await _stop_worker(task, requests, responses)
+
+
+async def test_grok_server_vad_three_states_and_clear_reconnect(monkeypatch) -> None:
+    async def on_send(ws: _FakeWebSocket, payload: str | bytes) -> None:
+        if isinstance(payload, str) and json.loads(payload)["type"] == "audio.done":
+            await ws.server_send({"type": "transcript.done", "duration": 1.0})
+
+    first = _FakeWebSocket(initial=[{"type": "transcript.created"}], on_send=on_send)
+    second = _FakeWebSocket(initial=[{"type": "transcript.created"}], on_send=on_send)
+    connector = _FakeConnector(first, second)
+    monkeypatch.setattr(grok.websockets, "connect", connector)
+    requests: asyncio.Queue[_AsrWorkerRequest] = asyncio.Queue()
+    responses: asyncio.Queue[_AsrWorkerEvent] = asyncio.Queue()
+    task = asyncio.create_task(
+        grok.grok_asr_worker(
+            requests,
+            responses,
+            "key",
+            AsrSessionConfig(endpointing_mode="server_vad"),
+        )
+    )
+    await _next_event(responses, "ready")
+    await requests.put(
+        _AsrWorkerRequest(kind="audio", generation=0, utterance_id=1, audio=b"\0\0")
+    )
+    await _wait_until(lambda: any(isinstance(item, bytes) for item in first.sent))
+    for text, is_final, speech_final in (
+        ("mutable", False, False),
+        ("locked", True, False),
+        ("utterance", True, True),
+    ):
+        await first.server_send(
+            {
+                "type": "transcript.partial",
+                "text": text,
+                "is_final": is_final,
+                "speech_final": speech_final,
+            }
+        )
+    started = await _next_event(responses, "utterance_started")
+    mutable = await _next_event(responses, "partial")
+    locked = await _next_event(responses, "partial")
+    final = await _next_event(responses, "final")
+    assert started.utterance_id == 1
+    assert (mutable.text, locked.text, final.text) == (
+        "mutable",
+        "locked",
+        "utterance",
+    )
+
+    await requests.put(
+        _AsrWorkerRequest(kind="clear", generation=0, buffer_epoch=1, utterance_id=2)
+    )
+    await requests.put(
+        _AsrWorkerRequest(
+            kind="audio",
+            generation=0,
+            buffer_epoch=1,
+            utterance_id=2,
+            audio=b"\x56\x78",
+        )
+    )
+    await _wait_until(lambda: len(connector.calls) == 2)
+    await _wait_until(lambda: b"\x56\x78" in second.sent)
+    await _stop_worker(
+        task,
+        requests,
+        responses,
+        buffer_epoch=1,
+        utterance_id=2,
+    )
+
+
+@pytest.mark.parametrize(
+    ("module", "worker"),
+    [
+        (qwen, qwen.qwen_asr_worker),
+        (step, step.step_asr_worker),
+        (openai, openai.openai_asr_worker),
+        (grok, grok.grok_asr_worker),
+    ],
+)
+async def test_workers_reject_unsupported_languages_without_connecting(
+    monkeypatch,
+    module,
+    worker,
+) -> None:
+    connect_calls = 0
+
+    async def unexpected_connect(*args, **kwargs):
+        nonlocal connect_calls
+        connect_calls += 1
+        raise AssertionError("language validation must precede network access")
+
+    monkeypatch.setattr(module.websockets, "connect", unexpected_connect)
+    requests: asyncio.Queue[_AsrWorkerRequest] = asyncio.Queue()
+    responses: asyncio.Queue[_AsrWorkerEvent] = asyncio.Queue()
+    await worker(
+        requests,
+        responses,
+        "key",
+        AsrSessionConfig(language="eo"),
+    )
+    error = await _next_event(responses, "error")
+    assert error.error_code == "ASR_LANGUAGE_NOT_SUPPORTED"
+    assert (await _next_event(responses, "closed")).kind == "closed"
+    assert connect_calls == 0
+
+
+async def test_workers_report_unexpected_disconnect(monkeypatch) -> None:
+    async def on_send(ws: _FakeWebSocket, payload: str | bytes) -> None:
+        if isinstance(payload, str) and json.loads(payload)["type"] == "session.update":
+            await ws.server_send({"type": "session.updated"})
+
+    websocket = _FakeWebSocket(on_send=on_send)
+    connector = _FakeConnector(websocket)
+    monkeypatch.setattr(openai.websockets, "connect", connector)
+    requests: asyncio.Queue[_AsrWorkerRequest] = asyncio.Queue()
+    responses: asyncio.Queue[_AsrWorkerEvent] = asyncio.Queue()
+    task = asyncio.create_task(
+        openai.openai_asr_worker(requests, responses, "key", AsrSessionConfig())
+    )
+    await _next_event(responses, "ready")
+    await websocket.server_end()
+    error = await _next_event(responses, "error")
+    assert error.error_code == "ASR_OPENAI_DISCONNECTED"
+    await _next_event(responses, "closed")
+    await asyncio.wait_for(task, 1)
+
+
+def test_auth_rejection_classification() -> None:
+    class Response:
+        status_code = 401
+
+    error = RuntimeError("must not be inspected or logged")
+    error.response = Response()  # type: ignore[attr-defined]
+    assert qwen._qwen_is_auth_rejection(error)
+    assert step._step_is_auth_rejection(error)
+    assert openai._openai_is_auth_rejection(error)
+    assert grok._grok_is_auth_rejection(error)
+
+    ordinary_error = RuntimeError("network failure")
+    assert not qwen._qwen_is_auth_rejection(ordinary_error)
+    assert not step._step_is_auth_rejection(ordinary_error)
+    assert not openai._openai_is_auth_rejection(ordinary_error)
+    assert not grok._grok_is_auth_rejection(ordinary_error)

--- a/tests/unit/test_asr_workers.py
+++ b/tests/unit/test_asr_workers.py
@@ -471,6 +471,60 @@ async def test_step_manual_uses_transcription_item_id_not_committed_item_id(
         await _stop_worker(task, requests, responses, utterance_id=8)
 
 
+async def test_step_manual_rejects_commit_when_previous_item_is_unbound(
+    monkeypatch,
+) -> None:
+    async def on_send(ws: _FakeWebSocket, payload: str | bytes) -> None:
+        assert isinstance(payload, str)
+        message = json.loads(payload)
+        if message["type"] == "session.update":
+            await ws.server_send({"type": "session.updated"})
+
+    websocket = _FakeWebSocket(on_send=on_send)
+    monkeypatch.setattr(step.websockets, "connect", _FakeConnector(websocket))
+    requests: asyncio.Queue[_AsrWorkerRequest] = asyncio.Queue()
+    responses: asyncio.Queue[_AsrWorkerEvent] = asyncio.Queue()
+    task = asyncio.create_task(
+        step.step_asr_worker(
+            requests,
+            responses,
+            "step-key",
+            AsrSessionConfig(endpointing_mode="manual"),
+        )
+    )
+    await _next_event(responses, "ready")
+
+    await requests.put(_AsrWorkerRequest(kind="commit", generation=0, utterance_id=1))
+    await _wait_until(
+        lambda: (
+            sum(
+                isinstance(payload, str)
+                and json.loads(payload).get("type") == "input_audio_buffer.commit"
+                for payload in websocket.sent
+            )
+            == 1
+        )
+    )
+    await requests.put(_AsrWorkerRequest(kind="commit", generation=0, utterance_id=2))
+
+    error = await _next_event(responses, "error")
+    assert (error.error_code, error.utterance_id) == (
+        "ASR_STEP_PROTOCOL_ERROR",
+        2,
+    )
+    assert (await _next_event(responses, "closed")).kind == "closed"
+    await asyncio.wait_for(task, 1)
+    assert responses.empty()
+    assert (
+        sum(
+            isinstance(payload, str)
+            and json.loads(payload).get("type") == "input_audio_buffer.commit"
+            for payload in websocket.sent
+        )
+        == 1
+    )
+
+
 async def test_step_server_vad_maps_utterances_and_reconnects(monkeypatch) -> None:
     async def on_send(ws: _FakeWebSocket, payload: str | bytes) -> None:
         if isinstance(payload, str) and json.loads(payload)["type"] == "session.update":

--- a/tests/unit/test_asr_workers.py
+++ b/tests/unit/test_asr_workers.py
@@ -237,6 +237,73 @@ async def test_qwen_manual_regions_payload_and_final(
     await _stop_worker(task, requests, responses)
 
 
+async def test_qwen_duplicate_item_created_does_not_consume_next_commit(
+    monkeypatch,
+) -> None:
+    async def on_send(ws: _FakeWebSocket, payload: str | bytes) -> None:
+        assert isinstance(payload, str)
+        message = json.loads(payload)
+        if message["type"] == "session.update":
+            await ws.server_send({"type": "session.updated"})
+        elif message["type"] == "session.finish":
+            await ws.server_send({"type": "session.finished"})
+
+    websocket = _FakeWebSocket(on_send=on_send)
+    monkeypatch.setattr(qwen.websockets, "connect", _FakeConnector(websocket))
+    requests: asyncio.Queue[_AsrWorkerRequest] = asyncio.Queue()
+    responses: asyncio.Queue[_AsrWorkerEvent] = asyncio.Queue()
+    task = asyncio.create_task(
+        qwen.qwen_asr_worker(requests, responses, "key", AsrSessionConfig())
+    )
+    await _next_event(responses, "ready")
+
+    await requests.put(_AsrWorkerRequest(kind="commit", generation=0, utterance_id=1))
+    await _wait_until(
+        lambda: (
+            sum(
+                isinstance(payload, str)
+                and json.loads(payload).get("type") == "input_audio_buffer.commit"
+                for payload in websocket.sent
+            )
+            == 1
+        )
+    )
+    await websocket.server_send(
+        {"type": "input_audio_buffer.committed", "item_id": "qwen-1"}
+    )
+    await requests.put(_AsrWorkerRequest(kind="commit", generation=0, utterance_id=2))
+    await _wait_until(
+        lambda: (
+            sum(
+                isinstance(payload, str)
+                and json.loads(payload).get("type") == "input_audio_buffer.commit"
+                for payload in websocket.sent
+            )
+            == 2
+        )
+    )
+    await websocket.server_send(
+        {"type": "conversation.item.created", "item": {"id": "qwen-1"}}
+    )
+    await websocket.server_send(
+        {"type": "input_audio_buffer.committed", "item_id": "qwen-2"}
+    )
+    for item_id, transcript in (("qwen-1", "first"), ("qwen-2", "second")):
+        await websocket.server_send(
+            {
+                "type": "conversation.item.input_audio_transcription.completed",
+                "item_id": item_id,
+                "transcript": transcript,
+            }
+        )
+
+    first = await _next_event(responses, "final")
+    second = await _next_event(responses, "final")
+    assert (first.utterance_id, first.text) == (1, "first")
+    assert (second.utterance_id, second.text) == (2, "second")
+    await _stop_worker(task, requests, responses, utterance_id=3)
+
+
 async def test_qwen_server_vad_maps_items_and_reconnects_on_clear(monkeypatch) -> None:
     async def on_send(ws: _FakeWebSocket, payload: str | bytes) -> None:
         if isinstance(payload, str):
@@ -523,6 +590,73 @@ async def test_step_manual_rejects_commit_when_previous_item_is_unbound(
         )
         == 1
     )
+
+
+async def test_step_duplicate_final_does_not_consume_next_commit(monkeypatch) -> None:
+    async def on_send(ws: _FakeWebSocket, payload: str | bytes) -> None:
+        assert isinstance(payload, str)
+        if json.loads(payload)["type"] == "session.update":
+            await ws.server_send({"type": "session.updated"})
+
+    websocket = _FakeWebSocket(on_send=on_send)
+    monkeypatch.setattr(step.websockets, "connect", _FakeConnector(websocket))
+    requests: asyncio.Queue[_AsrWorkerRequest] = asyncio.Queue()
+    responses: asyncio.Queue[_AsrWorkerEvent] = asyncio.Queue()
+    task = asyncio.create_task(
+        step.step_asr_worker(requests, responses, "key", AsrSessionConfig())
+    )
+    await _next_event(responses, "ready")
+
+    await requests.put(_AsrWorkerRequest(kind="commit", generation=0, utterance_id=1))
+    await _wait_until(
+        lambda: (
+            sum(
+                isinstance(payload, str)
+                and json.loads(payload).get("type") == "input_audio_buffer.commit"
+                for payload in websocket.sent
+            )
+            == 1
+        )
+    )
+    await websocket.server_send(
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "item_id": "step-1",
+            "transcript": "first",
+        }
+    )
+    first = await _next_event(responses, "final")
+    assert (first.utterance_id, first.text) == (1, "first")
+
+    await requests.put(_AsrWorkerRequest(kind="commit", generation=0, utterance_id=2))
+    await _wait_until(
+        lambda: (
+            sum(
+                isinstance(payload, str)
+                and json.loads(payload).get("type") == "input_audio_buffer.commit"
+                for payload in websocket.sent
+            )
+            == 2
+        )
+    )
+    await websocket.server_send(
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "item_id": "step-1",
+            "transcript": "duplicate",
+        }
+    )
+    await websocket.server_send(
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "item_id": "step-2",
+            "transcript": "second",
+        }
+    )
+    second = await _next_event(responses, "final")
+    assert (second.utterance_id, second.text) == (2, "second")
+    assert responses.empty()
+    await _stop_worker(task, requests, responses, utterance_id=3)
 
 
 async def test_step_server_vad_maps_utterances_and_reconnects(monkeypatch) -> None:

--- a/tests/unit/test_asr_workers.py
+++ b/tests/unit/test_asr_workers.py
@@ -109,6 +109,14 @@ async def _wait_until(
         await asyncio.sleep(0)
 
 
+def _count_ws_messages(sent: list[str | bytes], message_type: str) -> int:
+    return sum(
+        1
+        for payload in sent
+        if isinstance(payload, str) and json.loads(payload).get("type") == message_type
+    )
+
+
 async def _stop_worker(
     task: asyncio.Task[None],
     requests: asyncio.Queue[_AsrWorkerRequest],
@@ -259,28 +267,14 @@ async def test_qwen_duplicate_item_created_does_not_consume_next_commit(
 
     await requests.put(_AsrWorkerRequest(kind="commit", generation=0, utterance_id=1))
     await _wait_until(
-        lambda: (
-            sum(
-                isinstance(payload, str)
-                and json.loads(payload).get("type") == "input_audio_buffer.commit"
-                for payload in websocket.sent
-            )
-            == 1
-        )
+        lambda: _count_ws_messages(websocket.sent, "input_audio_buffer.commit") == 1
     )
     await websocket.server_send(
         {"type": "input_audio_buffer.committed", "item_id": "qwen-1"}
     )
     await requests.put(_AsrWorkerRequest(kind="commit", generation=0, utterance_id=2))
     await _wait_until(
-        lambda: (
-            sum(
-                isinstance(payload, str)
-                and json.loads(payload).get("type") == "input_audio_buffer.commit"
-                for payload in websocket.sent
-            )
-            == 2
-        )
+        lambda: _count_ws_messages(websocket.sent, "input_audio_buffer.commit") == 2
     )
     await websocket.server_send(
         {"type": "conversation.item.created", "item": {"id": "qwen-1"}}
@@ -563,14 +557,7 @@ async def test_step_manual_rejects_overlap_without_dropping_previous_final(
 
     await requests.put(_AsrWorkerRequest(kind="commit", generation=0, utterance_id=1))
     await _wait_until(
-        lambda: (
-            sum(
-                isinstance(payload, str)
-                and json.loads(payload).get("type") == "input_audio_buffer.commit"
-                for payload in websocket.sent
-            )
-            == 1
-        )
+        lambda: _count_ws_messages(websocket.sent, "input_audio_buffer.commit") == 1
     )
     await requests.put(_AsrWorkerRequest(kind="commit", generation=0, utterance_id=2))
 
@@ -589,14 +576,7 @@ async def test_step_manual_rejects_overlap_without_dropping_previous_final(
 
     await requests.put(_AsrWorkerRequest(kind="commit", generation=0, utterance_id=3))
     await _wait_until(
-        lambda: (
-            sum(
-                isinstance(payload, str)
-                and json.loads(payload).get("type") == "input_audio_buffer.commit"
-                for payload in websocket.sent
-            )
-            == 2
-        )
+        lambda: _count_ws_messages(websocket.sent, "input_audio_buffer.commit") == 2
     )
     await websocket.server_send(
         {
@@ -607,14 +587,7 @@ async def test_step_manual_rejects_overlap_without_dropping_previous_final(
     )
     third = await _next_event(responses, "final")
     assert (third.utterance_id, third.text) == (3, "third")
-    assert (
-        sum(
-            isinstance(payload, str)
-            and json.loads(payload).get("type") == "input_audio_buffer.clear"
-            for payload in websocket.sent
-        )
-        == 1
-    )
+    assert _count_ws_messages(websocket.sent, "input_audio_buffer.clear") == 1
     await _stop_worker(task, requests, responses, utterance_id=4)
 
 
@@ -635,14 +608,7 @@ async def test_step_duplicate_final_does_not_consume_next_commit(monkeypatch) ->
 
     await requests.put(_AsrWorkerRequest(kind="commit", generation=0, utterance_id=1))
     await _wait_until(
-        lambda: (
-            sum(
-                isinstance(payload, str)
-                and json.loads(payload).get("type") == "input_audio_buffer.commit"
-                for payload in websocket.sent
-            )
-            == 1
-        )
+        lambda: _count_ws_messages(websocket.sent, "input_audio_buffer.commit") == 1
     )
     await websocket.server_send(
         {
@@ -656,14 +622,7 @@ async def test_step_duplicate_final_does_not_consume_next_commit(monkeypatch) ->
 
     await requests.put(_AsrWorkerRequest(kind="commit", generation=0, utterance_id=2))
     await _wait_until(
-        lambda: (
-            sum(
-                isinstance(payload, str)
-                and json.loads(payload).get("type") == "input_audio_buffer.commit"
-                for payload in websocket.sent
-            )
-            == 2
-        )
+        lambda: _count_ws_messages(websocket.sent, "input_audio_buffer.commit") == 2
     )
     await websocket.server_send(
         {

--- a/tests/unit/test_asr_workers.py
+++ b/tests/unit/test_asr_workers.py
@@ -396,6 +396,81 @@ async def test_step_manual_payload_and_cumulative_partial(monkeypatch) -> None:
     await _stop_worker(task, requests, responses)
 
 
+async def test_step_manual_uses_transcription_item_id_not_committed_item_id(
+    monkeypatch,
+) -> None:
+    async def on_send(ws: _FakeWebSocket, payload: str | bytes) -> None:
+        assert isinstance(payload, str)
+        message = json.loads(payload)
+        if message["type"] == "session.update":
+            await ws.server_send({"type": "session.updated"})
+        elif message["type"] == "input_audio_buffer.append":
+            await ws.server_send(
+                {
+                    "type": "conversation.item.created",
+                    "item": {"id": "step-audio-item"},
+                }
+            )
+            await ws.server_send(
+                {
+                    "type": "conversation.item.created",
+                    "item": {"id": "step-transcription-item"},
+                }
+            )
+            await ws.server_send(
+                {
+                    "type": "conversation.item.input_audio_transcription.delta",
+                    "item_id": "step-transcription-item",
+                    "text": "hello",
+                }
+            )
+        elif message["type"] == "input_audio_buffer.commit":
+            await ws.server_send(
+                {
+                    "type": "input_audio_buffer.committed",
+                    "item_id": "step-audio-item",
+                }
+            )
+            await ws.server_send(
+                {
+                    "type": "conversation.item.input_audio_transcription.completed",
+                    "item_id": "step-transcription-item",
+                    "transcript": "hello step",
+                }
+            )
+
+    websocket = _FakeWebSocket(on_send=on_send)
+    connector = _FakeConnector(websocket)
+    monkeypatch.setattr(step.websockets, "connect", connector)
+    requests: asyncio.Queue[_AsrWorkerRequest] = asyncio.Queue()
+    responses: asyncio.Queue[_AsrWorkerEvent] = asyncio.Queue()
+    task = asyncio.create_task(
+        step.step_asr_worker(
+            requests,
+            responses,
+            "step-key",
+            AsrSessionConfig(language="en", endpointing_mode="manual"),
+        )
+    )
+    await _next_event(responses, "ready")
+    try:
+        await requests.put(
+            _AsrWorkerRequest(
+                kind="audio",
+                generation=0,
+                utterance_id=7,
+                audio=b"\x11\x22" * 160,
+            )
+        )
+        await requests.put(
+            _AsrWorkerRequest(kind="commit", generation=0, utterance_id=7)
+        )
+        final = await _next_event(responses, "final")
+        assert (final.utterance_id, final.text) == (7, "hello step")
+    finally:
+        await _stop_worker(task, requests, responses, utterance_id=8)
+
+
 async def test_step_server_vad_maps_utterances_and_reconnects(monkeypatch) -> None:
     async def on_send(ws: _FakeWebSocket, payload: str | bytes) -> None:
         if isinstance(payload, str) and json.loads(payload)["type"] == "session.update":

--- a/tests/unit/test_asr_workers.py
+++ b/tests/unit/test_asr_workers.py
@@ -257,7 +257,7 @@ async def test_qwen_server_vad_maps_items_and_reconnects_on_clear(monkeypatch) -
             requests,
             responses,
             "key",
-            AsrSessionConfig(endpointing_mode="server_vad"),
+            AsrSessionConfig(endpointing_mode="provider"),
         )
     )
     await _next_event(responses, "ready")
@@ -412,7 +412,7 @@ async def test_step_server_vad_maps_utterances_and_reconnects(monkeypatch) -> No
             requests,
             responses,
             "key",
-            AsrSessionConfig(endpointing_mode="server_vad"),
+            AsrSessionConfig(endpointing_mode="provider"),
         )
     )
     await _next_event(responses, "ready")
@@ -589,7 +589,7 @@ async def test_openai_native_clear_and_mode_rejection(monkeypatch) -> None:
             rejected_requests,
             rejected_responses,
             "key",
-            AsrSessionConfig(endpointing_mode="server_vad"),
+            AsrSessionConfig(endpointing_mode="provider"),
         )
     )
     error = await _next_event(rejected_responses, "error")
@@ -823,10 +823,12 @@ async def test_grok_server_vad_three_states_and_clear_reconnect(monkeypatch) -> 
             requests,
             responses,
             "key",
-            AsrSessionConfig(endpointing_mode="server_vad"),
+            AsrSessionConfig(endpointing_mode="provider"),
         )
     )
     await _next_event(responses, "ready")
+    query = parse_qs(urlparse(connector.calls[0][0]).query)
+    assert query["endpointing"] == ["10"]
     await requests.put(
         _AsrWorkerRequest(kind="audio", generation=0, utterance_id=1, audio=b"\0\0")
     )
@@ -914,6 +916,93 @@ async def test_workers_reject_unsupported_languages_without_connecting(
     assert connect_calls == 0
 
 
+@pytest.mark.parametrize(
+    ("worker", "expected_code"),
+    [
+        (qwen.qwen_asr_worker, "ASR_INVALID_CONFIG"),
+        (step.step_asr_worker, "ASR_INVALID_CONFIG"),
+        (grok.grok_asr_worker, "ASR_ENDPOINTING_NOT_SUPPORTED"),
+    ],
+)
+async def test_workers_reject_unknown_endpointing_before_connect(
+    worker,
+    expected_code,
+) -> None:
+    config = AsrSessionConfig()
+    object.__setattr__(config, "endpointing_mode", "vendor_private_mode")
+    requests: asyncio.Queue[_AsrWorkerRequest] = asyncio.Queue()
+    responses: asyncio.Queue[_AsrWorkerEvent] = asyncio.Queue()
+
+    await worker(requests, responses, "key", config)
+
+    assert (await _next_event(responses, "error")).error_code == expected_code
+    assert (await _next_event(responses, "closed")).kind == "closed"
+
+
+@pytest.mark.parametrize("worker", [qwen.qwen_asr_worker, step.step_asr_worker])
+async def test_workers_report_missing_credentials_without_connecting(worker) -> None:
+    requests: asyncio.Queue[_AsrWorkerRequest] = asyncio.Queue()
+    responses: asyncio.Queue[_AsrWorkerEvent] = asyncio.Queue()
+
+    await worker(requests, responses, "", AsrSessionConfig())
+
+    assert (await _next_event(responses, "error")).error_code == (
+        "ASR_CREDENTIALS_MISSING"
+    )
+    assert (await _next_event(responses, "closed")).kind == "closed"
+
+
+async def test_qwen_rejects_unknown_region_without_connecting() -> None:
+    requests: asyncio.Queue[_AsrWorkerRequest] = asyncio.Queue()
+    responses: asyncio.Queue[_AsrWorkerEvent] = asyncio.Queue()
+
+    await qwen.qwen_asr_worker(
+        requests,
+        responses,
+        "key",
+        AsrSessionConfig(),
+        region="unknown",
+    )
+
+    assert (await _next_event(responses, "error")).error_code == "ASR_INVALID_CONFIG"
+    assert (await _next_event(responses, "closed")).kind == "closed"
+
+
+@pytest.mark.parametrize(
+    ("module", "worker", "expected_code"),
+    [
+        (qwen, qwen.qwen_asr_worker, "ASR_QWEN_PROTOCOL_ERROR"),
+        (step, step.step_asr_worker, "ASR_STEP_PROTOCOL_ERROR"),
+    ],
+)
+async def test_provider_endpointing_rejects_manual_commit(
+    monkeypatch,
+    module,
+    worker,
+    expected_code,
+) -> None:
+    async def on_send(ws: _FakeWebSocket, payload: str | bytes) -> None:
+        if isinstance(payload, str) and json.loads(payload)["type"] == "session.update":
+            await ws.server_send({"type": "session.updated"})
+
+    websocket = _FakeWebSocket(on_send=on_send)
+    monkeypatch.setattr(module.websockets, "connect", _FakeConnector(websocket))
+    requests: asyncio.Queue[_AsrWorkerRequest] = asyncio.Queue()
+    responses: asyncio.Queue[_AsrWorkerEvent] = asyncio.Queue()
+    task = asyncio.create_task(
+        worker(
+            requests, responses, "key", AsrSessionConfig(endpointing_mode="provider")
+        )
+    )
+    await _next_event(responses, "ready")
+
+    await requests.put(_AsrWorkerRequest(kind="commit", generation=0, utterance_id=1))
+
+    assert (await _next_event(responses, "error")).error_code == expected_code
+    assert (await _next_event(responses, "closed")).kind == "closed"
+    await asyncio.wait_for(task, 1)
+
+
 async def test_workers_report_unexpected_disconnect(monkeypatch) -> None:
     async def on_send(ws: _FakeWebSocket, payload: str | bytes) -> None:
         if isinstance(payload, str) and json.loads(payload)["type"] == "session.update":
@@ -951,3 +1040,10 @@ def test_auth_rejection_classification() -> None:
     assert not step._step_is_auth_rejection(ordinary_error)
     assert not openai._openai_is_auth_rejection(ordinary_error)
     assert not grok._grok_is_auth_rejection(ordinary_error)
+
+
+def test_workers_preserve_provider_auto_language_detection() -> None:
+    assert qwen._qwen_language_code("auto") is None
+    assert step._step_language_code("auto") is None
+    assert openai._normalize_openai_language("auto") is None
+    assert grok._normalize_grok_language("auto") is None


### PR DESCRIPTION
## 改动概述 / Summary

本 PR 交付 Phase 1 独立实时 ASR 客户端，为后续小游戏用独立语音转文本替换成本较高的 Omni Realtime 提供统一接口。

- 新增公共会话接口：`AsrSessionConfig`、`RealtimeAsrSession` 和 `create_asr_session`。
- 在统一接口后接入 dummy、Qwen、OpenAI、StepFun 和 Grok worker。
- 输入支持 16 kHz 或 48 kHz、单声道 PCM16LE，供应商所需采样率由内部统一转换。
- 明确 `manual` 与 `provider` 两种断句模式，以及 `clear`、重连、关闭后的迟到事件抑制规则。
- 本 PR 不修改 Core 回复生成、小游戏实现、普通语音链路，也不接入 Smart Turn、VAD、RNNoise、声纹节流或 Soniox。

## 回归报告 / Regression Report

- **改了什么：** 新增独立实时 ASR Session 层、供应商注册信息、各供应商 worker、实时烟测工具，以及覆盖会话生命周期、断句、重采样、事件关联和过期结果抑制的单元测试。
- **修改理由：** 小游戏后续需要一个不依赖 Omni Realtime 的稳定语音转文本协议。Qwen、OpenAI、StepFun 等供应商的 WSS 协议差异应封装在统一 ASR 接口之后，避免调用方分别适配。
- **修改前：** 代码中没有可复用的独立 ASR 客户端契约。调用方只能依赖 Core/Omni Realtime 语音链路，或者自行实现各供应商协议。
- **修改后：** 调用方可通过同一 ASR Session API 持续发送 PCM 音频，并接收 partial/final 文本回调。`manual` 模式由 `commit()` 划定本轮话语边界；`provider` 模式允许供应商断句并产生 final。通过 generation、buffer epoch 和 utterance 关联，抑制已清空、已重连或已替换任务的迟到事件。
- **潜在回归点：** 各供应商 WebSocket 事件格式和断句行为；final 重复或迟到；clear/重连生命周期；16/48 kHz 转换及重采样尾帧；回调顺序和关闭行为。上述链路已通过针对性单元测试覆盖。
- **真实接口验证：** 当前 Qwen、OpenAI Transcription WebSocket 和 StepFun 已使用仅注入进程环境变量的密钥完成实时烟测。Qwen Intl 因供应商权限问题暂停；未验证或未支持的供应商不会被静默选为可发布实现。
- **兼容边界：** 本 PR 仅增加供后续消费者使用的独立 ASR 客户端，不改变现有 Core Session、普通语音链路、小游戏代码和 Omni Realtime 行为。

## 不拆分理由 / Why Not Split

本 PR 未触发仓库的文件数量拆分门槛。公共接口、基础设施、供应商 worker、测试和烟测工具共同构成一个可独立审查、可独立验收的 Phase 1 ASR 客户端切片，因此保持在同一个 PR 中。

## 测试 / Testing

- `python -m pytest tests/unit/test_asr_client.py tests/unit/test_asr_workers.py`
- 59 项测试通过。
- ASR 相关代码覆盖率：80.23%。
- `ruff check` 通过。
- `ruff format --check` 通过。
- Qwen、OpenAI 和 StepFun 的真实 WSS 烟测通过，密钥仅通过进程环境变量提供，未写入仓库。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 提供统一实时 ASR 会话入口：支持连接、会话更新、PCM16LE 音频流式发送、用户活动提交、清空缓冲与幂等关闭，并提供转写与连接错误回调。
  * 引入 `manual` 与 `provider` 两种端点模式（创建时冻结），新增 Dummy、Qwen、OpenAI、StepFun、Grok 后端实时转写能力，并按场景标准化错误分类。
* **文档**
  * 新增 Phase 1 ASR 客户端公共链路与行为契约说明。
* **测试**
  * 扩充会话协定与各后端 worker 单元测试；新增实时冒烟脚本用于逐后端验收与超时/鉴权验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->