### PR TITLE
修复 API 切换刷新后弹幕模式翻译框透明背景及临时布局状态丢失的问题

### DIFF
--- a/static/subtitle/subtitle-window.js
+++ b/static/subtitle/subtitle-window.js
@@ -630,17 +630,48 @@
 
     function applyDanmakuModeTemporaryState(session) {
         if (!session || !session.active) return;
-        var nextState = SubtitleShared.updateSettings({
-            subtitlePanelLocked: true,
-            subtitleInteractionPassthrough: true,
-            subtitleOpacity: 0
-        }, {
+        var currentState = SubtitleShared.getSettings();
+        var restoreBounds = !!session.lastPanelBounds &&
+            !samePanelBounds(currentState.subtitlePanelBounds, session.lastPanelBounds);
+        var restoreLock = currentState.subtitlePanelLocked !== true ||
+            currentState.subtitleInteractionPassthrough !== true;
+        var restoreOpacity = currentState.subtitleOpacity !== 0;
+        if (!restoreBounds && !restoreLock && !restoreOpacity) {
+            return currentState;
+        }
+
+        var patch = {};
+        if (restoreBounds) {
+            patch.subtitlePanelBounds = session.lastPanelBounds;
+        }
+        if (restoreLock) {
+            patch.subtitlePanelLocked = true;
+            patch.subtitleInteractionPassthrough = true;
+        }
+        if (restoreOpacity) {
+            patch.subtitleOpacity = 0;
+        }
+        var nextState = SubtitleShared.updateSettings(patch, {
             persist: false,
-            source: 'subtitle-danmaku-enter'
+            source: 'subtitle-danmaku-maintain'
         });
-        propagateDanmakuModeLock(true, nextState);
-        propagateDanmakuModeOpacity(0, nextState);
+        if (restoreBounds) {
+            propagateSubtitleSetting({
+                type: 'bounds',
+                value: session.lastPanelBounds,
+                patch: { subtitlePanelBounds: session.lastPanelBounds },
+                transient: true,
+                state: nextState
+            });
+        }
+        if (restoreLock) {
+            propagateDanmakuModeLock(true, nextState);
+        }
+        if (restoreOpacity) {
+            propagateDanmakuModeOpacity(0, nextState);
+        }
         updateNativeInteractionPassthrough();
+        return nextState;
     }
 
     function applyDanmakuModeAvatarBounds(session, payload) {
@@ -669,6 +700,8 @@
             layout.panelBounds,
             { host: 'window' }
         );
+        var panelBoundsChanged = !samePanelBounds(session.lastPanelBounds, layout.panelBounds);
+        session.lastPanelBounds = layout.panelBounds;
         var nextState = SubtitleShared.updateSettings({
             subtitlePanelBounds: layout.panelBounds,
             subtitlePanelLocked: true,
@@ -677,8 +710,7 @@
             persist: false,
             source: 'subtitle-danmaku-avatar-layout'
         });
-        if (!samePanelBounds(session.lastPanelBounds, layout.panelBounds)) {
-            session.lastPanelBounds = layout.panelBounds;
+        if (panelBoundsChanged) {
             propagateSubtitleSetting({
                 type: 'bounds',
                 value: layout.panelBounds,
@@ -775,7 +807,12 @@
         function setActive(nextActive) {
             nextActive = !!nextActive;
             var active = !!(danmakuModeSession && danmakuModeSession.active);
-            if (active === nextActive) return;
+            if (active === nextActive) {
+                if (active) {
+                    applyDanmakuModeTemporaryState(danmakuModeSession);
+                }
+                return;
+            }
             if (nextActive) {
                 startDanmakuModeSession();
             } else {

--- a/static/subtitle/subtitle.js
+++ b/static/subtitle/subtitle.js
@@ -383,6 +383,35 @@ function attachWebDanmakuModeLayout(controller) {
         scheduleLayout(true);
     }
 
+    function maintainDanmakuTemporaryState() {
+        if (!active || destroyed) return;
+        var state = SubtitleShared.getSettings();
+        var layoutMatches = !lastVisualLayout || sameWebDanmakuLayout({
+            subtitlePanelBounds: state.subtitlePanelBounds,
+            subtitlePanelPosition: state.subtitlePanelPosition
+        }, lastVisualLayout);
+        if (state.subtitlePanelLocked === true &&
+            state.subtitleInteractionPassthrough === true &&
+            state.subtitleOpacity === 0 &&
+            layoutMatches) {
+            return;
+        }
+
+        var patch = {
+            subtitlePanelLocked: true,
+            subtitleInteractionPassthrough: true,
+            subtitleOpacity: 0
+        };
+        if (lastVisualLayout) {
+            patch.subtitlePanelBounds = lastVisualLayout.subtitlePanelBounds;
+            patch.subtitlePanelPosition = lastVisualLayout.subtitlePanelPosition;
+        }
+        SubtitleShared.updateSettings(patch, {
+            persist: false,
+            source: 'subtitle-web-danmaku-maintain'
+        });
+    }
+
     function start() {
         if (active || destroyed || !isWebSubtitleDanmakuHost()) return;
         active = true;
@@ -399,14 +428,7 @@ function attachWebDanmakuModeLayout(controller) {
             display.style.transition = 'none';
             display.style.willChange = 'left, top, width, height';
         }
-        SubtitleShared.updateSettings({
-            subtitlePanelLocked: true,
-            subtitleInteractionPassthrough: true,
-            subtitleOpacity: 0
-        }, {
-            persist: false,
-            source: 'subtitle-web-danmaku-enter'
-        });
+        maintainDanmakuTemporaryState();
         window.addEventListener('resize', onViewportChanged);
         window.addEventListener('scroll', onViewportChanged, true);
         scheduleLayout(true);
@@ -438,6 +460,7 @@ function attachWebDanmakuModeLayout(controller) {
     var unsubscribe = SubtitleShared.subscribeSettings(function(state) {
         if (state && state.subtitleDanmakuMode) {
             start();
+            maintainDanmakuTemporaryState();
         } else {
             stop();
         }

--- a/tests/frontend/test_subtitle_incremental.py
+++ b/tests/frontend/test_subtitle_incremental.py
@@ -315,6 +315,16 @@ def test_subtitle_window_danmaku_mode_tracks_avatar_head_and_restores(mock_page:
                 },
             });
             await new Promise((resolve) => setTimeout(resolve, 0));
+            window.dispatchEvent(new CustomEvent('neko-subtitle-state-sync', {
+                detail: {
+                    opacity: 72,
+                    bounds: { width: 655, height: 109 },
+                    locked: false,
+                    interactionPassthrough: false,
+                    danmakuMode: true,
+                },
+            }));
+            await new Promise((resolve) => setTimeout(resolve, 0));
             const afterOn = {
                 subscriptions: window.__avatarBoundsSubscriptions.slice(),
                 settings: shared.getSettings(),
@@ -322,6 +332,7 @@ def test_subtitle_window_danmaku_mode_tracks_avatar_head_and_restores(mock_page:
                 calls: window.__subtitleSetBoundsCalls.slice(),
                 changes: window.__subtitleSettingsChanges.slice(),
                 panelState: display.dataset.subtitlePanelState || '',
+                backgroundOpacity: display.dataset.subtitleBackgroundOpacity || '',
                 panelHidden: panel.classList.contains('hidden'),
                 closeCount: window.__subtitleSettingsCloseCount,
             };
@@ -352,6 +363,7 @@ def test_subtitle_window_danmaku_mode_tracks_avatar_head_and_restores(mock_page:
     assert result["afterOn"]["settings"]["subtitlePanelBounds"] == {"width": 228, "height": 76}
     assert result["afterOn"]["nativeBounds"] == {"x": 780, "y": 244, "width": 240, "height": 88}
     assert result["afterOn"]["panelState"] == "clean"
+    assert result["afterOn"]["backgroundOpacity"] == "0"
     assert result["afterOn"]["panelHidden"] is True
     assert result["afterOn"]["closeCount"] == 1
     assert {"type": "lock", "value": True, "transient": True} in result["afterOn"]["changes"]
@@ -728,6 +740,22 @@ def test_web_subtitle_danmaku_mode_tracks_avatar_head_and_restores(mock_page: Pa
             const panel = document.getElementById('subtitle-settings-panel');
             shared.updateSettings({ subtitleDanmakuMode: true }, { source: 'test-enable-web-danmaku' });
             await new Promise((resolve) => setTimeout(resolve, 150));
+            shared.updateSettings({
+                subtitlePanelBounds: { width: 655, height: 109 },
+                subtitlePanelPosition: {
+                    left: 300,
+                    top: 500,
+                    coordinateSpace: 'viewport',
+                },
+                subtitlePanelLocked: false,
+                subtitleInteractionPassthrough: false,
+                subtitleOpacity: 72,
+                subtitleDanmakuMode: true,
+            }, {
+                persist: false,
+                source: 'test-settings-refresh',
+            });
+            await new Promise((resolve) => setTimeout(resolve, 50));
             const afterOn = {
                 settings: shared.getSettings(),
                 style: {
@@ -737,6 +765,7 @@ def test_web_subtitle_danmaku_mode_tracks_avatar_head_and_restores(mock_page: Pa
                     height: display.style.height,
                 },
                 panelState: display.dataset.subtitlePanelState || '',
+                backgroundOpacity: display.dataset.subtitleBackgroundOpacity || '',
                 panelHidden: panel.classList.contains('hidden'),
                 storage: {
                     bounds: JSON.parse(window.localStorage.getItem('subtitlePanelBounds')),
@@ -791,6 +820,7 @@ def test_web_subtitle_danmaku_mode_tracks_avatar_head_and_restores(mock_page: Pa
         "height": "76px",
     }
     assert result["afterOn"]["panelState"] == "clean"
+    assert result["afterOn"]["backgroundOpacity"] == "0"
     assert result["afterOn"]["panelHidden"] is True
     assert result["afterOn"]["storage"] == {
         "bounds": {"width": 655, "height": 109},


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复 API 切换刷新后弹幕模式翻译框透明背景及临时布局状态丢失的问题

## 测试 / Testing

手动保存API测试翻译框


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化字幕弹幕模式下的面板状态同步，减少重复更新。
  * 修复模式切换后面板边界、锁定状态、交互穿透及透明度未及时恢复或同步的问题。
  * 改善窗口端与网页端的字幕状态一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->