### PR TITLE
fix(workshop): import legacy character cards with dotted names

### DIFF
--- a/main_routers/workshop_router/meta.py
+++ b/main_routers/workshop_router/meta.py
@@ -77,8 +77,13 @@ def _remove_deleted_character_tombstones(config_mgr, character_names: list[str])
     if not target_names:
         return []
 
-    session_removed_names = sorted(name for name in target_names if name in _session_deleted_names)
-    _session_deleted_names.difference_update(target_names)
+    target_casefolds = {name.casefold() for name in target_names}
+    session_removed_names = sorted(
+        name
+        for name in _session_deleted_names
+        if name.casefold() in target_casefolds
+    )
+    _session_deleted_names.difference_update(session_removed_names)
 
     if is_cloudsave_disabled():
         return session_removed_names
@@ -93,7 +98,7 @@ def _remove_deleted_character_tombstones(config_mgr, character_names: list[str])
             remaining_entries.append(entry)
             continue
         character_name = str(entry.get("character_name") or "").strip()
-        if character_name in target_names:
+        if character_name.casefold() in target_casefolds:
             removed_names.append(character_name)
             continue
         remaining_entries.append(entry)

--- a/main_routers/workshop_router/sync_cards.py
+++ b/main_routers/workshop_router/sync_cards.py
@@ -53,6 +53,19 @@ _ugc_sync_lock = asyncio.Lock()
 
 # ─── 创意工坊角色卡同步 ────────────────────────────────────────────────
 
+def _find_casefold_conflict_name(existing_names, candidate_name: str) -> str | None:
+    candidate = str(candidate_name or "").strip()
+    if not candidate:
+        return None
+    candidate_casefold = candidate.casefold()
+    for existing_name in existing_names:
+        normalized_existing = str(existing_name or "").strip()
+        if not normalized_existing or normalized_existing == candidate:
+            continue
+        if normalized_existing.casefold() == candidate_casefold:
+            return normalized_existing
+    return None
+
 async def sync_workshop_character_cards(
     target_item_id: str | int | None = None,
     restore_deleted: bool = False,
@@ -281,6 +294,19 @@ async def sync_workshop_character_cards(
                                         item_id,
                                     )
                                     continue
+                            conflict_name = _find_casefold_conflict_name(
+                                characters.get('猫娘', {}).keys(),
+                                chara_name,
+                            )
+                            if conflict_name is not None:
+                                skipped_count += 1
+                                logger.warning(
+                                    "sync_workshop_character_cards: 跳过大小写折叠冲突角色 '%s'（与 '%s' 共用 casefold，物品 %s）",
+                                    chara_name,
+                                    conflict_name,
+                                    item_id,
+                                )
+                                continue
                             chara_file_stem = Path(chara_file_path).name[:-11]
                             preview_image_path = find_preview_image_in_folder(
                                 installed_folder,
@@ -484,9 +510,14 @@ async def sync_workshop_character_cards(
                     skipped_due_to_race_count = 0
                     for pending_name, pending_payload in pending_added_catgirls.items():
                         pending_name_is_deleted = pending_name in latest_deleted_character_names
+                        conflict_name = _find_casefold_conflict_name(
+                            latest_catgirls.keys(),
+                            pending_name,
+                        )
                         if (
                             (pending_name_is_deleted and not restore_deleted)
                             or pending_name in latest_catgirls
+                            or conflict_name is not None
                         ):
                             skipped_due_to_race_count += 1
                             if pending_name in latest_catgirls:
@@ -500,6 +531,12 @@ async def sync_workshop_character_cards(
                                     )
                                 ):
                                     confirmed_recoverable_existing_names.add(pending_name)
+                            elif conflict_name is not None:
+                                logger.warning(
+                                    "sync_workshop_character_cards: 保存前跳过大小写折叠冲突角色 '%s'（与 '%s' 共用 casefold）",
+                                    pending_name,
+                                    conflict_name,
+                                )
                             continue
                         latest_catgirls[pending_name] = pending_payload
                         actually_added_count += 1

--- a/main_routers/workshop_router/sync_cards.py
+++ b/main_routers/workshop_router/sync_cards.py
@@ -295,7 +295,7 @@ async def sync_workshop_character_cards(
                                     )
                                     continue
                             conflict_name = _find_casefold_conflict_name(
-                                characters.get('猫娘', {}).keys(),
+                                characters['猫娘'].keys(),
                                 chara_name,
                             )
                             if conflict_name is not None:

--- a/main_routers/workshop_router/sync_cards.py
+++ b/main_routers/workshop_router/sync_cards.py
@@ -313,6 +313,7 @@ async def sync_workshop_character_cards(
                                 chara_name,
                             )
                             if conflict_name is not None:
+                                _append_unique(existing_character_names, conflict_name)
                                 skipped_count += 1
                                 logger.warning(
                                     "sync_workshop_character_cards: 跳过大小写折叠冲突角色 '%s'（与 '%s' 共用 casefold，物品 %s）",
@@ -556,6 +557,7 @@ async def sync_workshop_character_cards(
                                         pending_restore_tombstone_names[pending_name]
                                     )
                             elif conflict_name is not None:
+                                _append_unique(existing_character_names, conflict_name)
                                 logger.warning(
                                     "sync_workshop_character_cards: 保存前跳过大小写折叠冲突角色 '%s'（与 '%s' 共用 casefold）",
                                     pending_name,

--- a/main_routers/workshop_router/sync_cards.py
+++ b/main_routers/workshop_router/sync_cards.py
@@ -314,6 +314,17 @@ async def sync_workshop_character_cards(
                             )
                             if conflict_name is not None:
                                 _append_unique(existing_character_names, conflict_name)
+                                if (
+                                    restore_deleted
+                                    and chara_name in pending_restore_tombstone_names
+                                    and _is_matching_workshop_character(
+                                        characters['猫娘'].get(conflict_name) or {},
+                                        item_id,
+                                    )
+                                ):
+                                    confirmed_recoverable_existing_names[conflict_name] = (
+                                        pending_restore_tombstone_names[chara_name]
+                                    )
                                 skipped_count += 1
                                 logger.warning(
                                     "sync_workshop_character_cards: 跳过大小写折叠冲突角色 '%s'（与 '%s' 共用 casefold，物品 %s）",
@@ -558,6 +569,17 @@ async def sync_workshop_character_cards(
                                     )
                             elif conflict_name is not None:
                                 _append_unique(existing_character_names, conflict_name)
+                                if (
+                                    restore_deleted
+                                    and pending_name in pending_restore_tombstone_names
+                                    and _is_matching_workshop_character(
+                                        latest_catgirls.get(conflict_name) or {},
+                                        pending_item_ids.get(pending_name, ""),
+                                    )
+                                ):
+                                    confirmed_recoverable_existing_names[conflict_name] = (
+                                        pending_restore_tombstone_names[pending_name]
+                                    )
                                 logger.warning(
                                     "sync_workshop_character_cards: 保存前跳过大小写折叠冲突角色 '%s'（与 '%s' 共用 casefold）",
                                     pending_name,

--- a/main_routers/workshop_router/sync_cards.py
+++ b/main_routers/workshop_router/sync_cards.py
@@ -234,7 +234,7 @@ async def sync_workshop_character_cards(
             pending_added_catgirls = {}
             pending_card_face_writes = {}
             pending_item_ids = {}
-            pending_restore_tombstone_names: set[str] = set()
+            pending_restore_tombstone_names: dict[str, str] = {}
             confirmed_recoverable_existing_names: set[str] = set()
             
             # 2. 遍历所有已安装的物品
@@ -293,7 +293,7 @@ async def sync_workshop_character_cards(
                             if deleted_name is not None:
                                 _append_unique(deleted_character_names_seen, chara_name)
                                 if restore_deleted:
-                                    pending_restore_tombstone_names.add(chara_name)
+                                    pending_restore_tombstone_names[chara_name] = deleted_name
                                 else:
                                     skipped_count += 1
                                     logger.info(
@@ -339,7 +339,9 @@ async def sync_workshop_character_cards(
                                 existing_data = characters['猫娘'].get(chara_name) or {}
                                 existing_matches_item = _is_matching_workshop_character(existing_data, item_id)
                                 if existing_matches_item and restore_deleted and chara_name in pending_restore_tombstone_names:
-                                    confirmed_recoverable_existing_names.add(chara_name)
+                                    confirmed_recoverable_existing_names.add(
+                                        pending_restore_tombstone_names[chara_name]
+                                    )
                                 if existing_matches_item:
                                     try:
                                         blocked_result = _abort_if_write_fence_active(
@@ -544,7 +546,9 @@ async def sync_workshop_character_cards(
                                         pending_item_ids.get(pending_name, ""),
                                     )
                                 ):
-                                    confirmed_recoverable_existing_names.add(pending_name)
+                                    confirmed_recoverable_existing_names.add(
+                                        pending_restore_tombstone_names[pending_name]
+                                    )
                             elif conflict_name is not None:
                                 logger.warning(
                                     "sync_workshop_character_cards: 保存前跳过大小写折叠冲突角色 '%s'（与 '%s' 共用 casefold）",
@@ -579,7 +583,8 @@ async def sync_workshop_character_cards(
 
                     if restore_deleted and actually_added_names:
                         restored_candidates = [
-                            name for name in actually_added_names
+                            pending_restore_tombstone_names[name]
+                            for name in actually_added_names
                             if name in pending_restore_tombstone_names
                         ]
                         if restored_candidates:

--- a/main_routers/workshop_router/sync_cards.py
+++ b/main_routers/workshop_router/sync_cards.py
@@ -282,7 +282,15 @@ async def sync_workshop_character_cards(
                                 continue
                             _append_unique(found_character_names, chara_name)
 
-                            if chara_name in deleted_character_names:
+                            deleted_name = (
+                                chara_name
+                                if chara_name in deleted_character_names
+                                else _find_casefold_conflict_name(
+                                    deleted_character_names,
+                                    chara_name,
+                                )
+                            )
+                            if deleted_name is not None:
                                 _append_unique(deleted_character_names_seen, chara_name)
                                 if restore_deleted:
                                     pending_restore_tombstone_names.add(chara_name)
@@ -509,7 +517,13 @@ async def sync_workshop_character_cards(
                     actually_added_count = 0
                     skipped_due_to_race_count = 0
                     for pending_name, pending_payload in pending_added_catgirls.items():
-                        pending_name_is_deleted = pending_name in latest_deleted_character_names
+                        pending_name_is_deleted = (
+                            pending_name in latest_deleted_character_names
+                            or _find_casefold_conflict_name(
+                                latest_deleted_character_names,
+                                pending_name,
+                            ) is not None
+                        )
                         conflict_name = _find_casefold_conflict_name(
                             latest_catgirls.keys(),
                             pending_name,

--- a/main_routers/workshop_router/sync_cards.py
+++ b/main_routers/workshop_router/sync_cards.py
@@ -251,6 +251,11 @@ async def sync_workshop_character_cards(
                                 continue
                             name_validation = validate_character_name(
                                 chara_name_raw,
+                                # Workshop 中仍有严格命名规则启用前发布的角色卡（例如
+                                # ``N.E.K.O``）。嵌入式点号本身是安全的，现有角色路径、
+                                # memory 与 cloudsave 也已兼容；这里只放宽点号，统一校验仍会
+                                # 拒绝 ``..``、尾随点号、路径分隔符和其它危险名称。
+                                allow_dots=True,
                                 max_units=PROFILE_NAME_MAX_UNITS,
                             )
                             chara_name = name_validation.normalized

--- a/main_routers/workshop_router/sync_cards.py
+++ b/main_routers/workshop_router/sync_cards.py
@@ -184,8 +184,10 @@ async def sync_workshop_character_cards(
         async def _clear_restored_existing_tombstones():
             nonlocal error_count
             restored_existing_candidates = [
-                name for name in confirmed_recoverable_existing_names
-                if name not in restored_deleted_names
+                tombstone_name
+                for character_name, tombstone_name
+                in confirmed_recoverable_existing_names.items()
+                if character_name not in restored_deleted_names
             ]
             if not restored_existing_candidates:
                 return None
@@ -202,8 +204,12 @@ async def sync_workshop_character_cards(
                     config_mgr,
                     restored_existing_candidates,
                 )
-                for removed_name in removed_names:
-                    _append_unique(restored_deleted_names, removed_name)
+                removed_casefolds = {name.casefold() for name in removed_names}
+                for character_name, tombstone_name in (
+                    confirmed_recoverable_existing_names.items()
+                ):
+                    if tombstone_name.casefold() in removed_casefolds:
+                        _append_unique(restored_deleted_names, character_name)
                 if removed_names:
                     logger.info(
                         "sync_workshop_character_cards: 已移除已存在恢复角色的 tombstone: %s",
@@ -235,7 +241,7 @@ async def sync_workshop_character_cards(
             pending_card_face_writes = {}
             pending_item_ids = {}
             pending_restore_tombstone_names: dict[str, str] = {}
-            confirmed_recoverable_existing_names: set[str] = set()
+            confirmed_recoverable_existing_names: dict[str, str] = {}
             
             # 2. 遍历所有已安装的物品
             for item in subscribed_items:
@@ -339,7 +345,7 @@ async def sync_workshop_character_cards(
                                 existing_data = characters['猫娘'].get(chara_name) or {}
                                 existing_matches_item = _is_matching_workshop_character(existing_data, item_id)
                                 if existing_matches_item and restore_deleted and chara_name in pending_restore_tombstone_names:
-                                    confirmed_recoverable_existing_names.add(
+                                    confirmed_recoverable_existing_names[chara_name] = (
                                         pending_restore_tombstone_names[chara_name]
                                     )
                                 if existing_matches_item:
@@ -546,7 +552,7 @@ async def sync_workshop_character_cards(
                                         pending_item_ids.get(pending_name, ""),
                                     )
                                 ):
-                                    confirmed_recoverable_existing_names.add(
+                                    confirmed_recoverable_existing_names[pending_name] = (
                                         pending_restore_tombstone_names[pending_name]
                                     )
                             elif conflict_name is not None:
@@ -582,20 +588,29 @@ async def sync_workshop_character_cards(
                         _append_unique(added_character_names, added_name)
 
                     if restore_deleted and actually_added_names:
-                        restored_candidates = [
-                            pending_restore_tombstone_names[name]
+                        restored_candidates = {
+                            name: pending_restore_tombstone_names[name]
                             for name in actually_added_names
                             if name in pending_restore_tombstone_names
-                        ]
+                        }
                         if restored_candidates:
                             try:
                                 removed_names = await asyncio.to_thread(
                                     _remove_deleted_character_tombstones,
                                     config_mgr,
-                                    restored_candidates,
+                                    list(restored_candidates.values()),
                                 )
-                                for removed_name in removed_names:
-                                    _append_unique(restored_deleted_names, removed_name)
+                                removed_casefolds = {
+                                    name.casefold() for name in removed_names
+                                }
+                                for character_name, tombstone_name in (
+                                    restored_candidates.items()
+                                ):
+                                    if tombstone_name.casefold() in removed_casefolds:
+                                        _append_unique(
+                                            restored_deleted_names,
+                                            character_name,
+                                        )
                                 if removed_names:
                                     logger.info(
                                         "sync_workshop_character_cards: 已移除手动恢复角色的 tombstone: %s",

--- a/tests/unit/test_character_memory_regression.py
+++ b/tests/unit/test_character_memory_regression.py
@@ -1305,8 +1305,11 @@ async def test_workshop_sync_skips_casefold_conflicting_dotted_names():
             assert len(current_catgirls) == len(
                 {name.casefold() for name in current_catgirls}
             )
-            assert {"N.E.K.O", "n.e.k.o"} & set(current_catgirls)
-            assert not {"N.E.K.O", "n.e.k.o"} <= set(current_catgirls)
+            imported_names = {"N.E.K.O", "n.e.k.o"} & set(current_catgirls)
+            assert len(imported_names) == 1
+            assert sync_result["existing_character_names"] == [
+                next(iter(imported_names))
+            ]
 
 
 @pytest.mark.unit

--- a/tests/unit/test_character_memory_regression.py
+++ b/tests/unit/test_character_memory_regression.py
@@ -1243,6 +1243,74 @@ async def test_deleted_workshop_character_is_not_restored_by_startup_sync():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_workshop_sync_skips_casefold_conflicting_dotted_names():
+    with TemporaryDirectory() as td:
+        cm = _make_config_manager(Path(td))
+        bootstrap_local_cloudsave_environment(cm)
+
+        async def _noop_init():
+            return None
+
+        async def _noop_any(*args, **kwargs):
+            return None
+
+        with patch("utils.config_manager._config_manager", cm):
+            init_shared_state(
+                role_state={},
+                steamworks=None,
+                templates=None,
+                config_manager=cm,
+                logger=None,
+                initialize_character_data=_noop_init,
+                switch_current_catgirl_fast=_noop_any,
+                init_one_catgirl=_noop_any,
+                remove_one_catgirl=_noop_any,
+            )
+
+            workshop_router_module = reload_module("main_routers.workshop_router.sync_cards")
+            installed_folder = Path(td) / "casefold_conflict_workshop_item"
+            installed_folder.mkdir(parents=True, exist_ok=True)
+
+            for filename, payload in {
+                "upper.chara.json": {"档案名": "N.E.K.O", "昵称": "历史点号角色"},
+                "lower.chara.json": {"档案名": "n.e.k.o", "昵称": "大小写冲突角色"},
+            }.items():
+                (installed_folder / filename).write_text(
+                    json.dumps(payload, ensure_ascii=False, indent=2),
+                    encoding="utf-8",
+                )
+
+            with patch.object(
+                workshop_router_module,
+                "get_subscribed_workshop_items",
+                AsyncMock(
+                    return_value={
+                        "success": True,
+                        "items": [
+                            {
+                                "publishedFileId": "123456",
+                                "installedFolder": str(installed_folder),
+                            }
+                        ],
+                    }
+                ),
+            ):
+                sync_result = await workshop_router_module.sync_workshop_character_cards(
+                    target_item_id="123456",
+                )
+
+            assert sync_result["added"] == 1
+            assert sync_result["skipped"] >= 1
+            current_catgirls = cm.load_characters().get("猫娘", {})
+            assert sorted(name.casefold() for name in current_catgirls) == sorted(
+                {name.casefold() for name in current_catgirls}
+            )
+            assert {"N.E.K.O", "n.e.k.o"} & set(current_catgirls)
+            assert not {"N.E.K.O", "n.e.k.o"} <= set(current_catgirls)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_delete_catgirl_skips_tombstone_state_when_cloudsave_local_state_is_unavailable(monkeypatch):
     with TemporaryDirectory() as td:
         cm = _make_config_manager(Path(td))

--- a/tests/unit/test_character_memory_regression.py
+++ b/tests/unit/test_character_memory_regression.py
@@ -1492,10 +1492,7 @@ async def test_manual_workshop_character_sync_restores_deleted_character_and_cle
 
             assert sync_result["added"] == 1
             assert sync_result["added_character_names"] == [restored_name]
-            assert set(sync_result["restored_deleted_names"]) == {
-                deleted_name,
-                deleted_alias,
-            }
+            assert sync_result["restored_deleted_names"] == [restored_name]
             current_characters = cm.load_characters()
             assert restored_name in current_characters.get("猫娘", {})
             tombstones = cm.load_character_tombstones_state().get("tombstones") or []

--- a/tests/unit/test_character_memory_regression.py
+++ b/tests/unit/test_character_memory_regression.py
@@ -1163,7 +1163,7 @@ async def test_workshop_sync_imports_legacy_dotted_name_but_rejects_unsafe_names
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_deleted_workshop_character_is_not_restored_by_startup_sync():
+async def test_deleted_workshop_character_casefold_variant_is_not_restored_by_startup_sync():
     with TemporaryDirectory() as td:
         cm = _make_config_manager(Path(td))
         bootstrap_local_cloudsave_environment(cm)
@@ -1192,7 +1192,7 @@ async def test_deleted_workshop_character_is_not_restored_by_startup_sync():
 
             characters = cm.load_characters()
             initial_name = next(iter(characters.get("猫娘", {})))
-            characters["猫娘"]["工坊角色"] = {"昵称": "会复活吗"}
+            characters["猫娘"]["N.E.K.O"] = {"昵称": "会复活吗"}
             cm.save_characters(characters, bypass_write_fence=True)
 
             fake_response = type(
@@ -1206,14 +1206,14 @@ async def test_deleted_workshop_character_is_not_restored_by_startup_sync():
             fake_client.post.return_value = fake_response
 
             with patch("main_routers.characters_router.notify.httpx.AsyncClient", return_value=fake_client):
-                delete_result = await characters_router_module.delete_catgirl("工坊角色")
+                delete_result = await characters_router_module.delete_catgirl("N.E.K.O")
             assert delete_result["success"] is True
-            assert "工坊角色" not in cm.load_characters().get("猫娘", {})
+            assert "N.E.K.O" not in cm.load_characters().get("猫娘", {})
 
             installed_folder = Path(td) / "mock_workshop_item"
             installed_folder.mkdir(parents=True, exist_ok=True)
             (installed_folder / "角色卡.chara.json").write_text(
-                json.dumps({"档案名": "工坊角色", "昵称": "来自工坊"}, ensure_ascii=False, indent=2),
+                json.dumps({"档案名": "n.e.k.o", "昵称": "来自工坊"}, ensure_ascii=False, indent=2),
                 encoding="utf-8",
             )
 
@@ -1237,7 +1237,7 @@ async def test_deleted_workshop_character_is_not_restored_by_startup_sync():
             assert sync_result["added"] == 0
             assert sync_result["skipped"] >= 1
             current_characters = cm.load_characters()
-            assert "工坊角色" not in current_characters.get("猫娘", {})
+            assert "n.e.k.o" not in current_characters.get("猫娘", {})
             assert current_characters["当前猫娘"] == initial_name
 
 

--- a/tests/unit/test_character_memory_regression.py
+++ b/tests/unit/test_character_memory_regression.py
@@ -1537,9 +1537,10 @@ async def test_manual_workshop_character_sync_clears_tombstone_for_existing_char
 
             workshop_router_module = reload_module("main_routers.workshop_router.sync_cards")
 
-            restored_name = "已存在但有墓碑角色"
+            existing_name = "N.E.K.O"
+            restored_name = "n.e.k.o"
             characters = cm.load_characters()
-            characters.setdefault("猫娘", {})[restored_name] = {
+            characters.setdefault("猫娘", {})[existing_name] = {
                 "昵称": "已存在",
                 "_reserved": {
                     "character_origin": {
@@ -1588,8 +1589,11 @@ async def test_manual_workshop_character_sync_clears_tombstone_for_existing_char
                 )
 
             assert sync_result["added"] == 0
-            assert sync_result["existing_character_names"] == [restored_name]
-            assert sync_result["restored_deleted_names"] == [restored_name]
+            assert sync_result["existing_character_names"] == [existing_name]
+            assert sync_result["restored_deleted_names"] == [existing_name]
+            current_characters = cm.load_characters().get("猫娘", {})
+            assert existing_name in current_characters
+            assert restored_name not in current_characters
             tombstones = cm.load_character_tombstones_state().get("tombstones") or []
             assert not any(entry.get("character_name") == restored_name for entry in tombstones)
 

--- a/tests/unit/test_character_memory_regression.py
+++ b/tests/unit/test_character_memory_regression.py
@@ -1440,7 +1440,8 @@ async def test_manual_workshop_character_sync_restores_deleted_character_and_cle
             workshop_router_module = reload_module("main_routers.workshop_router.sync_cards")
 
             deleted_name = "N.E.K.O"
-            restored_name = "n.e.k.o"
+            deleted_alias = "n.e.k.o"
+            restored_name = "N.e.k.o"
             cm.save_character_tombstones_state({
                 "version": cm.CHARACTER_TOMBSTONES_STATE_VERSION,
                 "tombstones": [
@@ -1448,7 +1449,12 @@ async def test_manual_workshop_character_sync_restores_deleted_character_and_cle
                         "character_name": deleted_name,
                         "deleted_at": "2026-05-25T00:00:00Z",
                         "sequence_number": 1,
-                    }
+                    },
+                    {
+                        "character_name": deleted_alias,
+                        "deleted_at": "2026-05-25T00:00:01Z",
+                        "sequence_number": 2,
+                    },
                 ],
             })
 
@@ -1486,11 +1492,18 @@ async def test_manual_workshop_character_sync_restores_deleted_character_and_cle
 
             assert sync_result["added"] == 1
             assert sync_result["added_character_names"] == [restored_name]
-            assert sync_result["restored_deleted_names"] == [deleted_name]
+            assert set(sync_result["restored_deleted_names"]) == {
+                deleted_name,
+                deleted_alias,
+            }
             current_characters = cm.load_characters()
             assert restored_name in current_characters.get("猫娘", {})
             tombstones = cm.load_character_tombstones_state().get("tombstones") or []
-            assert not any(entry.get("character_name") == deleted_name for entry in tombstones)
+            assert not any(
+                str(entry.get("character_name") or "").casefold()
+                == restored_name.casefold()
+                for entry in tombstones
+            )
 
             assert second_result["added"] == 0
             assert second_result["existing_character_names"] == [restored_name]

--- a/tests/unit/test_character_memory_regression.py
+++ b/tests/unit/test_character_memory_regression.py
@@ -1439,7 +1439,8 @@ async def test_manual_workshop_character_sync_restores_deleted_character_and_cle
 
             workshop_router_module = reload_module("main_routers.workshop_router.sync_cards")
 
-            deleted_name = "手动恢复工坊角色"
+            deleted_name = "N.E.K.O"
+            restored_name = "n.e.k.o"
             cm.save_character_tombstones_state({
                 "version": cm.CHARACTER_TOMBSTONES_STATE_VERSION,
                 "tombstones": [
@@ -1454,7 +1455,7 @@ async def test_manual_workshop_character_sync_restores_deleted_character_and_cle
             installed_folder = Path(td) / "mock_workshop_manual_restore_item"
             installed_folder.mkdir(parents=True, exist_ok=True)
             (installed_folder / "角色卡.chara.json").write_text(
-                json.dumps({"档案名": deleted_name, "昵称": "来自手动恢复"}, ensure_ascii=False, indent=2),
+                json.dumps({"档案名": restored_name, "昵称": "来自手动恢复"}, ensure_ascii=False, indent=2),
                 encoding="utf-8",
             )
 
@@ -1484,15 +1485,15 @@ async def test_manual_workshop_character_sync_restores_deleted_character_and_cle
                 )
 
             assert sync_result["added"] == 1
-            assert sync_result["added_character_names"] == [deleted_name]
+            assert sync_result["added_character_names"] == [restored_name]
             assert sync_result["restored_deleted_names"] == [deleted_name]
             current_characters = cm.load_characters()
-            assert deleted_name in current_characters.get("猫娘", {})
+            assert restored_name in current_characters.get("猫娘", {})
             tombstones = cm.load_character_tombstones_state().get("tombstones") or []
             assert not any(entry.get("character_name") == deleted_name for entry in tombstones)
 
             assert second_result["added"] == 0
-            assert second_result["existing_character_names"] == [deleted_name]
+            assert second_result["existing_character_names"] == [restored_name]
 
 
 @pytest.mark.unit

--- a/tests/unit/test_character_memory_regression.py
+++ b/tests/unit/test_character_memory_regression.py
@@ -1092,6 +1092,77 @@ async def test_rename_catgirl_maintenance_error_preserves_original_exception_typ
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_workshop_sync_imports_legacy_dotted_name_but_rejects_unsafe_names():
+    with TemporaryDirectory() as td:
+        cm = _make_config_manager(Path(td))
+        bootstrap_local_cloudsave_environment(cm)
+
+        async def _noop_init():
+            return None
+
+        async def _noop_any(*args, **kwargs):
+            return None
+
+        with patch("utils.config_manager._config_manager", cm):
+            init_shared_state(
+                role_state={},
+                steamworks=None,
+                templates=None,
+                config_manager=cm,
+                logger=None,
+                initialize_character_data=_noop_init,
+                switch_current_catgirl_fast=_noop_any,
+                init_one_catgirl=_noop_any,
+                remove_one_catgirl=_noop_any,
+            )
+
+            workshop_router_module = reload_module("main_routers.workshop_router.sync_cards")
+            installed_folder = Path(td) / "legacy_dotted_name_workshop_item"
+            installed_folder.mkdir(parents=True, exist_ok=True)
+
+            card_payloads = {
+                "legacy.chara.json": {"档案名": "N.E.K.O", "昵称": "历史点号角色"},
+                "traversal.chara.json": {"档案名": "..", "昵称": "路径穿越"},
+                "trailing-dot.chara.json": {"档案名": "角色.", "昵称": "尾随点号"},
+                "separator.chara.json": {"档案名": "角色/子目录", "昵称": "路径分隔符"},
+            }
+            for filename, payload in card_payloads.items():
+                (installed_folder / filename).write_text(
+                    json.dumps(payload, ensure_ascii=False, indent=2),
+                    encoding="utf-8",
+                )
+
+            with patch.object(
+                workshop_router_module,
+                "get_subscribed_workshop_items",
+                AsyncMock(
+                    return_value={
+                        "success": True,
+                        "items": [
+                            {
+                                "publishedFileId": "123456",
+                                "installedFolder": str(installed_folder),
+                            }
+                        ],
+                    }
+                ),
+            ):
+                sync_result = await workshop_router_module.sync_workshop_character_cards(
+                    target_item_id="123456",
+                )
+
+            assert sync_result["added"] == 1
+            assert sync_result["found_character_names"] == ["N.E.K.O"]
+            assert sync_result["added_character_names"] == ["N.E.K.O"]
+            current_catgirls = cm.load_characters().get("猫娘", {})
+            assert "N.E.K.O" in current_catgirls
+            assert ".." not in current_catgirls
+            assert "角色." not in current_catgirls
+            assert "角色/子目录" not in current_catgirls
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_deleted_workshop_character_is_not_restored_by_startup_sync():
     with TemporaryDirectory() as td:
         cm = _make_config_manager(Path(td))

--- a/tests/unit/test_character_memory_regression.py
+++ b/tests/unit/test_character_memory_regression.py
@@ -1302,7 +1302,7 @@ async def test_workshop_sync_skips_casefold_conflicting_dotted_names():
             assert sync_result["added"] == 1
             assert sync_result["skipped"] >= 1
             current_catgirls = cm.load_characters().get("猫娘", {})
-            assert sorted(name.casefold() for name in current_catgirls) == sorted(
+            assert len(current_catgirls) == len(
                 {name.casefold() for name in current_catgirls}
             )
             assert {"N.E.K.O", "n.e.k.o"} & set(current_catgirls)


### PR DESCRIPTION
## 改动概述 / Summary

- Workshop 导入兼容 N.E.K.O 这类路径安全、带嵌入式点号的历史角色名。
- 继续拒绝路径穿越、尾随点号、路径分隔符和其他危险名称。
- 新增回归测试，同时覆盖历史兼容名称与危险名称拒绝路径。

## 回归报告 / Regression Report

- 改动内容：Workshop 角色卡同步调用统一角色名校验时启用历史点号兼容；新建/重命名角色的严格命名规则不变。
- 理由与必要性：严格角色名校验启用前发布的 Workshop 卡可包含 N.E.K.O 等名称。现有角色、memory 和 cloudsave 链路已经支持这类路径安全名称，但 Workshop 同步此前以 contains_dot 直接丢弃，导致换机后无法重新导入。
- 改动前：Steamworks 查询、下载和目录挂载均成功，但角色卡被判为非法并跳过；单物品加入进一步误报未找到可导入角色卡。
- 改动后：嵌入式点号名称可以导入；统一校验仍拒绝 ..、尾随点号、路径分隔符、Windows 危险名称和其他非法字符。
- 潜在回归点：Workshop 自动同步、单物品手动加入、删除 tombstone 恢复、保存并发、封面回填，以及角色导入后的 memory/cloudsave 路径。已运行完整角色/Workshop 同步回归和其余 Workshop 模块测试，共 94 项通过。

## 不拆分理由 / Why Not Split

不适用：本 PR 仅修改 1 个生产代码文件并增加 1 个对应回归测试，属于同一兼容性修复。

## 测试 / Testing

- uv run pytest tests/unit/test_character_memory_regression.py -q：60 passed
- uv run pytest tests/unit/test_workshop_router_ugc_details.py tests/unit/test_workshop_card_face_refresh.py tests/unit/test_workshop_model_ref.py tests/unit/test_workshop_cloudsave_disabled.py -q：34 passed
- git diff --check

本 PR 处理 Issue 中的 Steam Workshop 角色卡导入部分；macOS 屏幕读取问题不在本次范围内。

Refs Project-N-E-K-O/N.E.K.O#2315

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **功能改进**
  - 工坊同步支持包含安全点号的传统角色名（如 `N.E.K.O`），并继续拦截危险点号或路径分隔符等不安全命名。
  - 现在会按不区分大小写的“折叠规则”检测仅大小写不同的冲突，必要时跳过并给出跳过原因。
  - 手动恢复已删除角色时，相关记录的清理也将按同一折叠规则执行，避免错误恢复或残留冲突。
- **测试**
  - 新增/更新工坊同步的回归用例，覆盖旧点号命名、安全校验、冲突跳过与 tombstone 清理/恢复语义。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->