### PR TITLE
fix: correct soccer VRM0 fixed-camera facing

### DIFF
--- a/static/vrm/vrm-interaction.js
+++ b/static/vrm/vrm-interaction.js
@@ -645,6 +645,9 @@ class VRMInteraction {
         // 2. 计算目标角度
         // VRM 默认朝向 +Z，atan2(x, z) 对应 Y 轴旋转
         let targetAngle = Math.atan2(dx, dz);
+        if (this.manager.__soccerFixedCameraNormalizeYaw) {
+            targetAngle += Math.PI;
+        }
 
         // 3. 平滑插值处理角度突变
         const currentAngle = model.rotation.y;

--- a/templates/soccer_demo.html
+++ b/templates/soccer_demo.html
@@ -648,6 +648,22 @@
     );
   }
 
+  function syncSoccerVrmCameraTarget(manager, lookY, dist) {
+    const THREE = window.THREE;
+    const cam = manager?.camera;
+    if (!THREE || !cam || !manager) return null;
+    const cameraTarget = new THREE.Vector3(0, lookY, 0);
+    cam.position.set(0, lookY, dist);
+    cam.lookAt(cameraTarget);
+    cam.updateProjectionMatrix();
+    manager._cameraTarget = cameraTarget;
+    if (manager.controls) {
+      manager.controls.target.copy(cameraTarget);
+      manager.controls.update();
+    }
+    return cameraTarget;
+  }
+
   function fitVrmManagerCamera(manager, containerId, label = 'VRM') {
     const THREE = window.THREE;
     const vrm = manager?.currentModel?.vrm;
@@ -675,15 +691,7 @@
     const visibleH = h * 1.15;
     const dist = visibleH / (2 * Math.tan(fovRad / 2));
     const lookY = visibleH / 2;
-    const cameraTarget = new THREE.Vector3(0, lookY, 0);
-    cam.position.set(0, lookY, dist);
-    cam.lookAt(cameraTarget);
-    cam.updateProjectionMatrix();
-    manager._cameraTarget = cameraTarget;
-    if (manager.controls) {
-      manager.controls.target.copy(cameraTarget);
-      manager.controls.update();
-    }
+    syncSoccerVrmCameraTarget(manager, lookY, dist);
     console.log(`[soccer_demo] fit ${label}: h=`, h.toFixed(2), 'w=', w.toFixed(2), 'dist=', dist.toFixed(2));
   }
 
@@ -2957,15 +2965,7 @@
     const visibleH = h * 1.15;
     const dist = visibleH / (2 * Math.tan(fovRad / 2));
     const lookY = visibleH / 2;
-    const cameraTarget = new THREE.Vector3(0, lookY, 0);
-    cam.position.set(0, lookY, dist);
-    cam.lookAt(cameraTarget);
-    cam.updateProjectionMatrix();
-    window.vrmManager._cameraTarget = cameraTarget;
-    if (window.vrmManager.controls) {
-      window.vrmManager.controls.target.copy(cameraTarget);
-      window.vrmManager.controls.update();
-    }
+    syncSoccerVrmCameraTarget(window.vrmManager, lookY, dist);
     emitEvent('player-avatar-changed', { type, path });
   }
 

--- a/templates/soccer_demo.html
+++ b/templates/soccer_demo.html
@@ -675,10 +675,115 @@
     const visibleH = h * 1.15;
     const dist = visibleH / (2 * Math.tan(fovRad / 2));
     const lookY = visibleH / 2;
+    const cameraTarget = new THREE.Vector3(0, lookY, 0);
     cam.position.set(0, lookY, dist);
-    cam.lookAt(0, lookY, 0);
+    cam.lookAt(cameraTarget);
     cam.updateProjectionMatrix();
+    manager._cameraTarget = cameraTarget;
+    if (manager.controls) {
+      manager.controls.target.copy(cameraTarget);
+      manager.controls.update();
+    }
     console.log(`[soccer_demo] fit ${label}: h=`, h.toFixed(2), 'w=', w.toFixed(2), 'dist=', dist.toFixed(2));
+  }
+
+  function isSoccerVrm0(gltf, vrm) {
+    const exts = gltf?.parser?.json?.extensionsUsed || [];
+    if (exts.includes('VRMC_vrm')) return false;
+    if (exts.includes('VRM')) return true;
+    const metaVersion = vrm?.meta?.metaVersion || vrm?.meta?.vrmVersion;
+    return typeof metaVersion === 'string' && metaVersion.startsWith('0');
+  }
+
+  function getSoccerVrmBoneNode(vrm, boneName) {
+    const humanoid = vrm?.humanoid;
+    if (!humanoid) return null;
+    try {
+      if (typeof humanoid.getRawBoneNode === 'function') {
+        const raw = humanoid.getRawBoneNode(boneName);
+        if (raw) return raw;
+      }
+      if (typeof humanoid.getNormalizedBoneNode === 'function') {
+        const normalized = humanoid.getNormalizedBoneNode(boneName);
+        if (normalized) return normalized;
+      }
+    } catch (_) {}
+    return humanoid.humanBones?.[boneName]?.node || null;
+  }
+
+  function countSoccerVrmReversedBonePairs(vrm) {
+    const THREE = window.THREE;
+    if (!THREE || !vrm?.scene) return { reversed: 0, checked: 0 };
+    const pairs = [
+      ['leftEye', 'rightEye'],
+      ['leftUpperArm', 'rightUpperArm'],
+      ['leftLowerArm', 'rightLowerArm'],
+      ['leftHand', 'rightHand'],
+    ];
+    const leftPos = new THREE.Vector3();
+    const rightPos = new THREE.Vector3();
+    let reversed = 0;
+    let checked = 0;
+    vrm.scene.updateMatrixWorld(true);
+    for (const [leftName, rightName] of pairs) {
+      const left = getSoccerVrmBoneNode(vrm, leftName);
+      const right = getSoccerVrmBoneNode(vrm, rightName);
+      if (!left || !right) continue;
+      left.getWorldPosition(leftPos);
+      right.getWorldPosition(rightPos);
+      if (!Number.isFinite(leftPos.x) || !Number.isFinite(rightPos.x)) continue;
+      if (Math.abs(leftPos.x - rightPos.x) < 0.001) continue;
+      checked += 1;
+      if (leftPos.x < rightPos.x) reversed += 1;
+    }
+    return { reversed, checked };
+  }
+
+  function sampleSoccerVrmHeadFaceZ(vrm) {
+    const THREE = window.THREE;
+    if (!THREE || !vrm?.scene) return null;
+    const namePattern = /(head|face|eye|eyeline|eyelash|hitomi|sirome|头|脸|眼|眉|睫|瞳)/i;
+    const point = new THREE.Vector3();
+    let positive = 0;
+    let negative = 0;
+    vrm.scene.updateMatrixWorld(true);
+    vrm.scene.traverse(object => {
+      if (!object?.isMesh || !object.geometry?.attributes?.position) return;
+      const materialNames = Array.isArray(object.material)
+        ? object.material.map(m => m?.name || '').join(' ')
+        : (object.material?.name || '');
+      const label = `${object.name || ''} ${materialNames}`;
+      if (!namePattern.test(label)) return;
+      const pos = object.geometry.attributes.position;
+      const step = Math.max(1, Math.floor(pos.count / 1200));
+      for (let i = 0; i < pos.count; i += step) {
+        point.fromBufferAttribute(pos, i);
+        object.localToWorld(point);
+        if (point.z > 0.001) positive += 1;
+        else if (point.z < -0.001) negative += 1;
+      }
+    });
+    return positive + negative > 0 ? { positive, negative } : null;
+  }
+
+  function shouldNormalizeSoccerVrm0FixedCameraYaw(gltf, vrm) {
+    if (!isSoccerVrm0(gltf, vrm)) return false;
+    const bonePairs = countSoccerVrmReversedBonePairs(vrm);
+    if (bonePairs.reversed >= 2) return true;
+    const headFaceZ = sampleSoccerVrmHeadFaceZ(vrm);
+    return bonePairs.reversed === 1 &&
+      !!headFaceZ &&
+      headFaceZ.negative > headFaceZ.positive * 1.25;
+  }
+
+  function applySoccerVrm0FixedCameraFacingFix(gltf, vrm, manager) {
+    const shouldNormalizeYaw = shouldNormalizeSoccerVrm0FixedCameraYaw(gltf, vrm);
+    if (manager) manager.__soccerFixedCameraNormalizeYaw = shouldNormalizeYaw;
+    if (shouldNormalizeYaw && vrm?.scene?.rotation) {
+      vrm.scene.rotation.y = Math.PI;
+      vrm.scene.updateMatrixWorld?.(true);
+    }
+    return shouldNormalizeYaw;
   }
 
   window.__SoccerLoadVrmIntoManager = async function loadVrmIntoManager(manager, path, {
@@ -702,6 +807,7 @@
     const gltf = await new Promise((res, rej) => loader.load(path, res, null, rej));
     const vrm = gltf.userData.vrm;
     if (!vrm) throw new Error(`${label}: loaded file is not a valid VRM`);
+    applySoccerVrm0FixedCameraFacingFix(gltf, vrm, manager);
 
     if (manager.currentModel?.vrm?.scene) {
       const oldScene = manager.currentModel.vrm.scene;
@@ -2823,6 +2929,7 @@
     const gltf = await new Promise((res, rej) => loader.load(path, res, null, rej));
     const vrm = gltf.userData.vrm;
     if (!vrm) throw new Error('not a valid VRM: ' + path);
+    applySoccerVrm0FixedCameraFacingFix(gltf, vrm, window.vrmManager);
     if (window.vrmManager.currentModel?.vrm?.scene) {
       const oldScene = window.vrmManager.currentModel.vrm.scene;
       window.vrmManager.scene.remove(oldScene);
@@ -2850,9 +2957,15 @@
     const visibleH = h * 1.15;
     const dist = visibleH / (2 * Math.tan(fovRad / 2));
     const lookY = visibleH / 2;
+    const cameraTarget = new THREE.Vector3(0, lookY, 0);
     cam.position.set(0, lookY, dist);
-    cam.lookAt(0, lookY, 0);
+    cam.lookAt(cameraTarget);
     cam.updateProjectionMatrix();
+    window.vrmManager._cameraTarget = cameraTarget;
+    if (window.vrmManager.controls) {
+      window.vrmManager.controls.target.copy(cameraTarget);
+      window.vrmManager.controls.update();
+    }
     emitEvent('player-avatar-changed', { type, path });
   }
 

--- a/tests/unit/test_soccer_vrm_orientation_static_contracts.py
+++ b/tests/unit/test_soccer_vrm_orientation_static_contracts.py
@@ -26,19 +26,28 @@ def test_soccer_vrm0_fixed_camera_facing_fix_uses_bone_and_head_evidence():
 def test_soccer_vrm0_fixed_camera_facing_fix_runs_on_both_soccer_load_paths():
     source = (PROJECT_ROOT / "templates/soccer_demo.html").read_text(encoding="utf-8")
 
+    assert "function syncSoccerVrmCameraTarget(manager, lookY, dist)" in source
+    assert "manager.controls.target.copy(cameraTarget);" in source
+
+    fit_section = source.split("function fitVrmManagerCamera", 1)[1].split(
+        "function isSoccerVrm0",
+        1,
+    )[0]
+    assert "syncSoccerVrmCameraTarget(manager, lookY, dist);" in fit_section
+
     helper_section = source.split(
         "window.__SoccerLoadVrmIntoManager = async function loadVrmIntoManager",
         1,
-    )[1].split("if (manager.currentModel?.vrm?.scene)", 1)[0]
+    )[1].split("return vrm;", 1)[0]
     assert "applySoccerVrm0FixedCameraFacingFix(gltf, vrm, manager);" in helper_section
+    assert "fitVrmManagerCamera(manager, containerId, label);" in helper_section
 
     player_section = source.split(
         "async function setPlayerAvatar({ type, path } = {})",
         1,
     )[1].split("emitEvent('player-avatar-changed'", 1)[0]
     assert "applySoccerVrm0FixedCameraFacingFix(gltf, vrm, window.vrmManager);" in player_section
-    assert "manager.controls.target.copy(cameraTarget);" in source
-    assert "window.vrmManager.controls.target.copy(cameraTarget);" in player_section
+    assert "syncSoccerVrmCameraTarget(window.vrmManager, lookY, dist);" in player_section
 
 
 def test_soccer_vrm0_fixed_camera_facing_fix_keeps_yaw_offset_alive():

--- a/tests/unit/test_soccer_vrm_orientation_static_contracts.py
+++ b/tests/unit/test_soccer_vrm_orientation_static_contracts.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_soccer_vrm0_fixed_camera_facing_fix_is_scoped_to_vrm0():
+    source = (PROJECT_ROOT / "templates/soccer_demo.html").read_text(encoding="utf-8")
+
+    assert "function isSoccerVrm0(gltf, vrm)" in source
+    assert "if (exts.includes('VRMC_vrm')) return false;" in source
+    assert "if (exts.includes('VRM')) return true;" in source
+    assert "function shouldNormalizeSoccerVrm0FixedCameraYaw(gltf, vrm)" in source
+
+
+def test_soccer_vrm0_fixed_camera_facing_fix_uses_bone_and_head_evidence():
+    source = (PROJECT_ROOT / "templates/soccer_demo.html").read_text(encoding="utf-8")
+
+    assert "function countSoccerVrmReversedBonePairs(vrm)" in source
+    assert "['leftEye', 'rightEye']" in source
+    assert "['leftUpperArm', 'rightUpperArm']" in source
+    assert "function sampleSoccerVrmHeadFaceZ(vrm)" in source
+    assert "headFaceZ.negative > headFaceZ.positive * 1.25" in source
+
+
+def test_soccer_vrm0_fixed_camera_facing_fix_runs_on_both_soccer_load_paths():
+    source = (PROJECT_ROOT / "templates/soccer_demo.html").read_text(encoding="utf-8")
+
+    helper_section = source.split(
+        "window.__SoccerLoadVrmIntoManager = async function loadVrmIntoManager",
+        1,
+    )[1].split("if (manager.currentModel?.vrm?.scene)", 1)[0]
+    assert "applySoccerVrm0FixedCameraFacingFix(gltf, vrm, manager);" in helper_section
+
+    player_section = source.split(
+        "async function setPlayerAvatar({ type, path } = {})",
+        1,
+    )[1].split("emitEvent('player-avatar-changed'", 1)[0]
+    assert "applySoccerVrm0FixedCameraFacingFix(gltf, vrm, window.vrmManager);" in player_section
+    assert "manager.controls.target.copy(cameraTarget);" in source
+    assert "window.vrmManager.controls.target.copy(cameraTarget);" in player_section
+
+
+def test_soccer_vrm0_fixed_camera_facing_fix_keeps_yaw_offset_alive():
+    soccer_source = (PROJECT_ROOT / "templates/soccer_demo.html").read_text(encoding="utf-8")
+    interaction_source = (PROJECT_ROOT / "static/vrm/vrm-interaction.js").read_text(encoding="utf-8")
+
+    assert "manager.__soccerFixedCameraNormalizeYaw = shouldNormalizeYaw;" in soccer_source
+    assert "vrm.scene.rotation.y = Math.PI;" in soccer_source
+    assert "if (this.manager.__soccerFixedCameraNormalizeYaw)" in interaction_source
+    assert "targetAngle += Math.PI;" in interaction_source


### PR DESCRIPTION
## Summary
- Fix soccer demo VRM0 avatars that can face away from the fixed camera.
- Detect suspect VRM0 models from version metadata, reversed humanoid bone pairs, and head/face mesh Z distribution.
- Keep the fixed camera on the default side, apply a PI yaw correction only for suspect VRM0 models, and keep the face-camera loop aligned with that correction.
- Sync the soccer VRM camera target with OrbitControls so the next controls update does not restore a stale look target.

## Test plan
- `node --check static/vrm/vrm-interaction.js`
- `git diff --check`
- `uv run --no-sync --project D:\AI\N.E.K.O\N.E.K.O python -m pytest tests/unit/test_soccer_vrm_orientation_static_contracts.py -q --confcutdir=tests/unit`
- Local soccer demo verification with the known affected VRM0 avatar confirmed the avatar faces the fixed camera after the yaw correction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 为足球 VRM v0 增加固定相机朝向识别与自动修正。
  * 加强模型加载后的相机朝向拟合：使用显式目标向量更新视线，并同步缓存与控制器目标。
  * 玩家头像切换后同样应用朝向修正，保持视角一致。
* **Bug 修复**
  * 修正 VRM v0 在归一化偏航补偿下的朝向偏转表现。
* **测试**
  * 新增针对足球 VRM v0 朝向修正逻辑与多加载路径的静态契约单元测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->