### PR TITLE
修复网页端关闭翻译框后状态未持久化的问题

### DIFF
--- a/static/subtitle/subtitle.js
+++ b/static/subtitle/subtitle.js
@@ -1278,7 +1278,12 @@ function initSubtitleHostUi() {
         host: 'web',
         onClose: function() {
             if (window.subtitleBridge && typeof window.subtitleBridge.setSubtitleEnabled === 'function') {
-                window.subtitleBridge.setSubtitleEnabled(false);
+                window.subtitleBridge.setSubtitleEnabled(false, {
+                    source: 'subtitle-ui-close'
+                });
+            }
+            if (window.appSettings && typeof window.appSettings.saveSettings === 'function') {
+                window.appSettings.saveSettings();
             }
         },
         onLanguageChange: function(lang) {

--- a/tests/frontend/test_subtitle_incremental.py
+++ b/tests/frontend/test_subtitle_incremental.py
@@ -2877,6 +2877,70 @@ def test_subtitle_panel_close_fallback_updates_state_before_propagating(
 
 
 @pytest.mark.frontend
+def test_web_subtitle_panel_close_persists_app_settings(mock_page: Page):
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-web-host",
+        """
+        <div id="subtitle-display" class="show" data-subtitle-panel-state="clean">
+            <div id="subtitle-scroll"><span id="subtitle-text">Translated text.</span></div>
+            <div id="subtitle-panel-controls" aria-hidden="true">
+                <button type="button" id="subtitle-close-btn"></button>
+            </div>
+            <div id="subtitle-settings-panel" class="hidden"></div>
+        </div>
+        """,
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.localStorage.setItem('subtitleEnabled', 'true');
+            window.localStorage.setItem('userLanguage', 'en');
+            window.appState = { subtitleEnabled: true };
+            window.__subtitleSaveSettingsCalls = 0;
+            window.__savedSubtitleEnabled = null;
+            window.appSettings = {
+                saveSettings: () => {
+                    window.__subtitleSaveSettingsCalls += 1;
+                    window.__savedSubtitleEnabled = window.appState.subtitleEnabled;
+                },
+            };
+        }
+        """
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle/subtitle-shared.js"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle/subtitle.js"))
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            initSubtitleHostUi();
+            document.getElementById('subtitle-close-btn').click();
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const display = document.getElementById('subtitle-display');
+            return {
+                saveSettingsCalls: window.__subtitleSaveSettingsCalls,
+                savedEnabled: window.__savedSubtitleEnabled,
+                enabled: window.nekoSubtitleShared.getSettings().subtitleEnabled,
+                storedEnabled: window.localStorage.getItem('subtitleEnabled'),
+                appStateEnabled: window.appState.subtitleEnabled,
+                isHidden: display.classList.contains('hidden'),
+            };
+        }
+        """
+    )
+
+    assert result == {
+        "saveSettingsCalls": 1,
+        "savedEnabled": False,
+        "enabled": False,
+        "storedEnabled": "false",
+        "appStateEnabled": False,
+        "isHidden": True,
+    }
+
+
+@pytest.mark.frontend
 def test_react_translate_button_tracks_external_subtitle_enabled_changes(
     mock_page: Page,
 ):


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复网页端关闭翻译框后状态未持久化的问题

桌面端在另一侧： [修复 Electron 翻译窗关闭状态未同步保存的问题](https://github.com/Project-N-E-K-O/N.E.K.O.-PC/pull/340)

## 测试 / Testing

手动关闭翻译框刷新测试


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能改进**
  * 关闭字幕面板时，字幕状态会正确关闭并自动保存当前设置。
  * 关闭后字幕显示会立即隐藏，设置状态与本地存储保持同步。

* **测试**
  * 新增字幕面板关闭及设置持久化的自动化测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->