### PR TITLE
fix: restore macOS pyautogui diagnostics

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -281,7 +281,14 @@ jobs:
         if: runner.os != 'Windows'
         shell: bash
         run: |
-          NUITKA_OPTS="--standalone"
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            # PyObjC Foundation/AppKit refuse Nuitka's plain standalone mode.
+            # Keep the backend as a background app bundle; the packaging step
+            # below adds a stable bin/projectneko_server wrapper for Electron.
+            NUITKA_OPTS="--mode=app --macos-app-mode=background"
+          else
+            NUITKA_OPTS="--standalone"
+          fi
           NUITKA_OPTS="$NUITKA_OPTS --output-dir=dist"
           NUITKA_OPTS="$NUITKA_OPTS --output-filename=projectneko_server"
 
@@ -394,12 +401,6 @@ jobs:
           NUITKA_OPTS="$NUITKA_OPTS --nofollow-import-to=pyrnnoise"
           NUITKA_OPTS="$NUITKA_OPTS --nofollow-import-to=matplotlib"
           NUITKA_OPTS="$NUITKA_OPTS --nofollow-import-to=pytest"
-
-          # macOS: keep PyObjC bridge modules in the frozen app. Both
-          # brain/computer_use.py and /api/screenshot import pyautogui, and on
-          # macOS pyautogui imports Quartz/AppKit during module import. Excluding
-          # those bridge modules makes the packaged app fail at import time and
-          # surface a false "pyautogui not installed" error.
 
           # Plugin & CI flags
           NUITKA_OPTS="$NUITKA_OPTS --enable-plugin=dill-compat"
@@ -548,21 +549,36 @@ jobs:
       - name: Rename build output
         shell: bash
         run: |
-          if [ -d "dist/build_nuitka_launcher.dist" ]; then
+          if [[ "$RUNNER_OS" == "macOS" && -d "dist/build_nuitka_launcher.app" ]]; then
+            mkdir -p dist/Xiao8
+            mv dist/build_nuitka_launcher.app dist/Xiao8/projectneko_server.app
+            {
+              echo '#!/bin/sh'
+              echo 'SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)'
+              echo 'exec "$SCRIPT_DIR/projectneko_server.app/Contents/MacOS/projectneko_server" "$@"'
+            } > dist/Xiao8/projectneko_server
+            chmod +x dist/Xiao8/projectneko_server
+            RUNTIME_DIR="dist/Xiao8/projectneko_server.app/Contents/MacOS"
+          elif [ -d "dist/build_nuitka_launcher.dist" ]; then
             mv dist/build_nuitka_launcher.dist dist/Xiao8
+            RUNTIME_DIR="dist/Xiao8"
+          else
+            echo "::error::Nuitka output directory not found"
+            exit 1
           fi
+          echo "NEKO_NUITKA_RUNTIME_DIR=$RUNTIME_DIR" >> "$GITHUB_ENV"
           # macOS: playwright_browsers was excluded from Nuitka (xattr bug with
           # spaces in .app paths), copy it manually into the output directory
           if [[ "$RUNNER_OS" == "macOS" && -d "playwright_browsers" ]]; then
-            cp -R playwright_browsers dist/Xiao8/playwright_browsers
-            echo "Copied playwright_browsers into dist/Xiao8/"
+            cp -R playwright_browsers "$RUNTIME_DIR/playwright_browsers"
+            echo "Copied playwright_browsers into $RUNTIME_DIR/"
           fi
           VENV_PYTHON=".venv/bin/python"
           if [ -f ".venv/Scripts/python.exe" ]; then
             VENV_PYTHON=".venv/Scripts/python.exe"
           fi
           "$VENV_PYTHON" scripts/prepare_nuitka_plugins.py install \
-            --destination-dir dist/Xiao8/plugin/plugins
+            --destination-dir "$RUNTIME_DIR/plugin/plugins"
           echo "=== Build output ==="
           ls -la dist/Xiao8/ || echo "dist/Xiao8 not found!"
 
@@ -577,8 +593,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ ! -d "dist/Xiao8" ]; then
-            echo "::error::dist/Xiao8 not found, cannot verify"
+          if [ ! -d "$NEKO_NUITKA_RUNTIME_DIR" ]; then
+            echo "::error::$NEKO_NUITKA_RUNTIME_DIR not found, cannot verify"
             exit 1
           fi
           embedding_required=(
@@ -590,12 +606,12 @@ jobs:
           )
           missing=0
           for rel in "${embedding_required[@]}"; do
-            if [ ! -s "dist/Xiao8/data/embedding_models/$EMBEDDING_MODEL_PROFILE_ID/$rel" ]; then
+            if [ ! -s "$NEKO_NUITKA_RUNTIME_DIR/data/embedding_models/$EMBEDDING_MODEL_PROFILE_ID/$rel" ]; then
               echo "::error::missing or empty bundled embedding asset: $rel"
               missing=1
             fi
           done
-          if ! ls dist/Xiao8/data/tiktoken_cache/ 2>/dev/null | grep -q .; then
+          if ! ls "$NEKO_NUITKA_RUNTIME_DIR/data/tiktoken_cache/" 2>/dev/null | grep -q .; then
             echo "::error::data/tiktoken_cache empty in bundle (o200k_base would re-download at runtime)"
             missing=1
           fi
@@ -613,7 +629,7 @@ jobs:
           if [[ "$RUNNER_OS" == "Windows" ]]; then
             .venv/Scripts/python.exe scripts/check_nuitka_dist.py dist/Xiao8 --plugin-stage build/nuitka-plugins
           else
-            .venv/bin/python scripts/check_nuitka_dist.py dist/Xiao8 --plugin-stage build/nuitka-plugins
+            .venv/bin/python scripts/check_nuitka_dist.py "$NEKO_NUITKA_RUNTIME_DIR" --plugin-stage build/nuitka-plugins
           fi
 
       - name: Upload Python backend artifact

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -395,15 +395,11 @@ jobs:
           NUITKA_OPTS="$NUITKA_OPTS --nofollow-import-to=matplotlib"
           NUITKA_OPTS="$NUITKA_OPTS --nofollow-import-to=pytest"
 
-          # macOS: exclude pyobjc frameworks (Foundation requires --mode=app)
-          if [[ "$RUNNER_OS" == "macOS" ]]; then
-            NUITKA_OPTS="$NUITKA_OPTS --nofollow-import-to=Foundation"
-            NUITKA_OPTS="$NUITKA_OPTS --nofollow-import-to=AppKit"
-            NUITKA_OPTS="$NUITKA_OPTS --nofollow-import-to=objc"
-            NUITKA_OPTS="$NUITKA_OPTS --nofollow-import-to=PyObjCTools"
-            NUITKA_OPTS="$NUITKA_OPTS --nofollow-import-to=CoreFoundation"
-            NUITKA_OPTS="$NUITKA_OPTS --nofollow-import-to=Quartz"
-          fi
+          # macOS: keep PyObjC bridge modules in the frozen app. Both
+          # brain/computer_use.py and /api/screenshot import pyautogui, and on
+          # macOS pyautogui imports Quartz/AppKit during module import. Excluding
+          # those bridge modules makes the packaged app fail at import time and
+          # surface a false "pyautogui not installed" error.
 
           # Plugin & CI flags
           NUITKA_OPTS="$NUITKA_OPTS --enable-plugin=dill-compat"

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -632,6 +632,18 @@ jobs:
             .venv/bin/python scripts/check_nuitka_dist.py "$NEKO_NUITKA_RUNTIME_DIR" --plugin-stage build/nuitka-plugins
           fi
 
+      # Nuitka signs macOS app bundles when it creates them. The steps above
+      # then add Playwright and plugin payloads inside the bundle, invalidating
+      # that seal. Restore a valid ad-hoc signature for the backend artifact;
+      # electron-builder applies the configured distribution identity later.
+      - name: Re-sign macOS backend after post-processing
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          codesign --force --deep --sign - dist/Xiao8/projectneko_server.app
+          codesign --verify --deep --strict dist/Xiao8/projectneko_server.app
+
       - name: Upload Python backend artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -697,7 +697,12 @@ jobs:
 
       - name: Make server binary executable (Unix)
         if: runner.os != 'Windows'
-        run: chmod +x electron-app/bin/projectneko_server
+        shell: bash
+        run: |
+          chmod +x electron-app/bin/projectneko_server
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            chmod +x electron-app/bin/projectneko_server.app/Contents/MacOS/projectneko_server
+          fi
 
       # --- Cache Electron binary to avoid download failures ---
       - name: Cache Electron binary

--- a/app/agent_server/_shared.py
+++ b/app/agent_server/_shared.py
@@ -176,6 +176,10 @@ def _set_capability(name: str, ready: bool, reason: str = "") -> None:
             return "AGENT_KEY_NOT_CONFIGURED"
         if "endpoint not configured" in lower or "api 未配置" in lower:
             return "AGENT_ENDPOINT_NOT_CONFIGURED"
+        if "pyautogui" in lower and ("pyobjc" in lower or "quartz" in lower or "appkit" in lower or "corefoundation" in lower or "pyobjctools" in lower):
+            return "AGENT_PYAUTOGUI_MACOS_PYOBJC_MISSING"
+        if "pyautogui" in lower and ("import failed" in lower or "导入失败" in text):
+            return "AGENT_PYAUTOGUI_IMPORT_FAILED"
         if "pyautogui" in lower and ("not installed" in lower or "未安装" in text):
             return "AGENT_PYAUTOGUI_NOT_INSTALLED"
         if "browser-use" in lower and ("not installed" in lower or "未安装" in text):

--- a/app/agent_server/_shared.py
+++ b/app/agent_server/_shared.py
@@ -176,10 +176,6 @@ def _set_capability(name: str, ready: bool, reason: str = "") -> None:
             return "AGENT_KEY_NOT_CONFIGURED"
         if "endpoint not configured" in lower or "api 未配置" in lower:
             return "AGENT_ENDPOINT_NOT_CONFIGURED"
-        if "pyautogui" in lower and ("pyobjc" in lower or "quartz" in lower or "appkit" in lower or "corefoundation" in lower or "pyobjctools" in lower):
-            return "AGENT_PYAUTOGUI_MACOS_PYOBJC_MISSING"
-        if "pyautogui" in lower and ("import failed" in lower or "导入失败" in text):
-            return "AGENT_PYAUTOGUI_IMPORT_FAILED"
         if "pyautogui" in lower and ("not installed" in lower or "未安装" in text):
             return "AGENT_PYAUTOGUI_NOT_INSTALLED"
         if "browser-use" in lower and ("not installed" in lower or "未安装" in text):

--- a/brain/computer_use.py
+++ b/brain/computer_use.py
@@ -36,6 +36,10 @@ from config import get_agent_extra_body, COMPUTER_USE_MAX_TOKENS, LLM_PING_MAX_T
 from utils.config_manager import get_config_manager
 from utils.llm_client import create_chat_llm, ChatOpenAI
 from utils.logger_config import get_module_logger
+from utils.pyautogui_diagnostics import (
+    classify_pyautogui_import_error,
+    format_pyautogui_import_error,
+)
 from utils.token_tracker import set_call_type
 from utils.screenshot_utils import compress_screenshot
 
@@ -75,18 +79,10 @@ def _load_pyautogui():
 
 
 def _pyautogui_unavailable_reason() -> str:
-    text = str(_PYAUTOGUI_IMPORT_ERROR or "").lower()
-    if any(token in text for token in (
-        "displayconnectionerror",
-        "can't connect to display",
-        "cannot connect to display",
-        "authorization required",
-        "no authorization protocol",
-        "display",
-        "xlib",
-    )):
-        return "AGENT_PYAUTOGUI_DISPLAY_UNAVAILABLE"
-    return "AGENT_PYAUTOGUI_NOT_INSTALLED"
+    return classify_pyautogui_import_error(
+        _PYAUTOGUI_IMPORT_ERROR,
+        platform_name=platform.system(),
+    )
 
 
 _load_pyautogui()
@@ -691,7 +687,10 @@ class ComputerUseAdapter:
         try:
             pyautogui_module = _load_pyautogui()
             if pyautogui_module is None:
-                self.last_error = f"pyautogui unavailable: {_pyautogui_unavailable_reason()}"
+                self.last_error = format_pyautogui_import_error(
+                    _PYAUTOGUI_IMPORT_ERROR,
+                    platform_name=platform.system(),
+                )
                 return
 
             self.screen_width, self.screen_height = pyautogui_module.size()

--- a/brain/computer_use.py
+++ b/brain/computer_use.py
@@ -38,7 +38,6 @@ from utils.llm_client import create_chat_llm, ChatOpenAI
 from utils.logger_config import get_module_logger
 from utils.pyautogui_diagnostics import (
     classify_pyautogui_import_error,
-    format_pyautogui_import_error,
 )
 from utils.token_tracker import set_call_type
 from utils.screenshot_utils import compress_screenshot
@@ -687,10 +686,7 @@ class ComputerUseAdapter:
         try:
             pyautogui_module = _load_pyautogui()
             if pyautogui_module is None:
-                self.last_error = format_pyautogui_import_error(
-                    _PYAUTOGUI_IMPORT_ERROR,
-                    platform_name=platform.system(),
-                )
+                self.last_error = _pyautogui_unavailable_reason()
                 return
 
             self.screen_width, self.screen_height = pyautogui_module.size()

--- a/main_routers/system_router/screenshot.py
+++ b/main_routers/system_router/screenshot.py
@@ -38,6 +38,7 @@ import tempfile
 from fastapi import Request
 from fastapi.responses import JSONResponse
 from PIL import Image
+from utils.pyautogui_diagnostics import format_pyautogui_import_error
 from utils.screenshot_utils import (
     compress_screenshot,
     COMPRESS_TARGET_HEIGHT,
@@ -138,8 +139,10 @@ async def backend_screenshot(request: Request):
 
     try:
         import pyautogui
-    except ImportError:
-        return _json_no_store_response({"success": False, "error": "pyautogui not installed"}, status_code=501)
+    except Exception as exc:
+        error_message = format_pyautogui_import_error(exc, platform_name=sys.platform)
+        logger.error(f"后端截图初始化失败: {error_message}")
+        return _json_no_store_response({"success": False, "error": error_message}, status_code=501)
 
     try:
         def _capture_rgb_screenshot():

--- a/main_routers/system_router/screenshot.py
+++ b/main_routers/system_router/screenshot.py
@@ -38,7 +38,7 @@ import tempfile
 from fastapi import Request
 from fastapi.responses import JSONResponse
 from PIL import Image
-from utils.pyautogui_diagnostics import format_pyautogui_import_error
+from utils.pyautogui_diagnostics import classify_pyautogui_import_error
 from utils.screenshot_utils import (
     compress_screenshot,
     COMPRESS_TARGET_HEIGHT,
@@ -140,9 +140,20 @@ async def backend_screenshot(request: Request):
     try:
         import pyautogui
     except Exception as exc:
-        error_message = format_pyautogui_import_error(exc, platform_name=sys.platform)
-        logger.error(f"后端截图初始化失败: {error_message}")
-        return _json_no_store_response({"success": False, "error": error_message}, status_code=501)
+        reason = classify_pyautogui_import_error(exc, platform_name=sys.platform)
+        logger.error(
+            "后端截图初始化失败: reason=%s, error_type=%s",
+            reason,
+            type(exc).__name__,
+        )
+        return _json_no_store_response(
+            {
+                "success": False,
+                "error": "pyautogui unavailable",
+                "reason": reason,
+            },
+            status_code=501,
+        )
 
     try:
         def _capture_rgb_screenshot():

--- a/static/app/app-screen.js
+++ b/static/app/app-screen.js
@@ -537,25 +537,40 @@
     /**
      * 后端截图兜底：当前端所有屏幕捕获 API 均失败时，请求后端用 pyautogui 截取本机屏幕。
      * 安全限制：仅当页面来自 localhost / 127.0.0.1 / 0.0.0.0 时才调用。
-     * @returns {Promise<{dataUrl: string|null, status: number|null}>}
+     * @returns {Promise<{dataUrl: string|null, status: number|null, error: string|null}>}
      */
     async function fetchBackendScreenshot() {
         var h = window.location.hostname;
         if (h !== 'localhost' && h !== '127.0.0.1' && h !== '0.0.0.0') {
-            return { dataUrl: null, status: null };
+            return { dataUrl: null, status: null, error: null };
         }
         try {
             var resp = await secureLocalScreenshotFetch('/api/screenshot', { method: 'POST' });
-            if (!resp.ok) return { dataUrl: null, status: resp.status };
-            var json = await resp.json();
+            var json = null;
+            try {
+                json = await resp.json();
+            } catch (_) {
+                json = null;
+            }
+            if (!resp.ok) {
+                return {
+                    dataUrl: null,
+                    status: resp.status,
+                    error: (json && json.error) ? json.error : null
+                };
+            }
             if (json.success && json.data) {
                 console.log('[截图] 后端 pyautogui 截图成功,', json.size, 'bytes');
-                return { dataUrl: json.data, status: 200 };
+                return { dataUrl: json.data, status: 200, error: null };
             }
-            return { dataUrl: null, status: resp.status };
+            return {
+                dataUrl: null,
+                status: resp.status,
+                error: (json && json.error) ? json.error : null
+            };
         } catch (e) {
             console.warn('[截图] 后端截图请求失败:', e);
-            return { dataUrl: null, status: null };
+            return { dataUrl: null, status: null, error: e && e.message ? e.message : null };
         }
     }
     mod.fetchBackendScreenshot = fetchBackendScreenshot;
@@ -980,7 +995,7 @@
                 var result = await fetchBackendScreenshot();
                 var backendTest = result.dataUrl;
                 if (!backendTest) {
-                    throw new Error('所有屏幕捕获方式均失败（含后端兜底）');
+                    throw new Error(result.error || '所有屏幕捕获方式均失败（含后端兜底）');
                 }
                 if (await stopLiveVisionStreamIfBlocked('screen')) {
                     return;

--- a/static/app/app-screen.js
+++ b/static/app/app-screen.js
@@ -559,7 +559,7 @@
                     reason: (json && json.reason) ? json.reason : null
                 };
             }
-            if (json.success && json.data) {
+            if (json && json.success && json.data) {
                 console.log('[截图] 后端 pyautogui 截图成功,', json.size, 'bytes');
                 return { dataUrl: json.data, status: 200, reason: null };
             }

--- a/static/app/app-screen.js
+++ b/static/app/app-screen.js
@@ -537,12 +537,12 @@
     /**
      * 后端截图兜底：当前端所有屏幕捕获 API 均失败时，请求后端用 pyautogui 截取本机屏幕。
      * 安全限制：仅当页面来自 localhost / 127.0.0.1 / 0.0.0.0 时才调用。
-     * @returns {Promise<{dataUrl: string|null, status: number|null, error: string|null}>}
+     * @returns {Promise<{dataUrl: string|null, status: number|null, reason: string|null}>}
      */
     async function fetchBackendScreenshot() {
         var h = window.location.hostname;
         if (h !== 'localhost' && h !== '127.0.0.1' && h !== '0.0.0.0') {
-            return { dataUrl: null, status: null, error: null };
+            return { dataUrl: null, status: null, reason: null };
         }
         try {
             var resp = await secureLocalScreenshotFetch('/api/screenshot', { method: 'POST' });
@@ -556,24 +556,40 @@
                 return {
                     dataUrl: null,
                     status: resp.status,
-                    error: (json && json.error) ? json.error : null
+                    reason: (json && json.reason) ? json.reason : null
                 };
             }
             if (json.success && json.data) {
                 console.log('[截图] 后端 pyautogui 截图成功,', json.size, 'bytes');
-                return { dataUrl: json.data, status: 200, error: null };
+                return { dataUrl: json.data, status: 200, reason: null };
             }
             return {
                 dataUrl: null,
                 status: resp.status,
-                error: (json && json.error) ? json.error : null
+                reason: (json && json.reason) ? json.reason : null
             };
         } catch (e) {
             console.warn('[截图] 后端截图请求失败:', e);
-            return { dataUrl: null, status: null, error: e && e.message ? e.message : null };
+            return { dataUrl: null, status: null, reason: null };
         }
     }
     mod.fetchBackendScreenshot = fetchBackendScreenshot;
+
+    function translateBackendScreenshotReason(reason) {
+        var supportedReasons = {
+            AGENT_PYAUTOGUI_NOT_INSTALLED: true,
+            AGENT_PYAUTOGUI_DISPLAY_UNAVAILABLE: true,
+            AGENT_PYAUTOGUI_MACOS_PYOBJC_MISSING: true,
+            AGENT_PYAUTOGUI_IMPORT_FAILED: true
+        };
+        if (!supportedReasons[reason]) return '';
+        var key = 'agent.precheck.' + reason;
+        if (typeof window.t === 'function') {
+            var translated = window.t(key);
+            if (translated && translated !== key) return translated;
+        }
+        return reason;
+    }
 
     /**
      * 后端系统原生交互截图：触发操作系统级的全桌面框选截图。
@@ -995,7 +1011,10 @@
                 var result = await fetchBackendScreenshot();
                 var backendTest = result.dataUrl;
                 if (!backendTest) {
-                    throw new Error(result.error || '所有屏幕捕获方式均失败（含后端兜底）');
+                    throw new Error(
+                        translateBackendScreenshotReason(result.reason)
+                        || (window.t ? window.t('console.screenShareFailed') : '所有屏幕捕获方式均失败（含后端兜底）')
+                    );
                 }
                 if (await stopLiveVisionStreamIfBlocked('screen')) {
                     return;

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -2716,6 +2716,8 @@
             "AGENT_ENDPOINT_NOT_CONFIGURED": "Agent API not configured",
             "AGENT_PYAUTOGUI_NOT_INSTALLED": "pyautogui not installed",
             "AGENT_PYAUTOGUI_DISPLAY_UNAVAILABLE": "Desktop display session unavailable",
+            "AGENT_PYAUTOGUI_MACOS_PYOBJC_MISSING": "macOS PyAutoGUI bridge unavailable (PyObjC/Quartz/AppKit missing)",
+            "AGENT_PYAUTOGUI_IMPORT_FAILED": "pyautogui import failed",
             "AGENT_BROWSER_USE_NOT_INSTALLED": "browser-use not installed",
             "AGENT_CU_MODULE_NOT_LOADED": "Computer Use module not loaded",
             "AGENT_BU_MODULE_NOT_LOADED": "Browser Use module not loaded",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -2716,6 +2716,8 @@
             "AGENT_ENDPOINT_NOT_CONFIGURED": "API del agente no configurada",
             "AGENT_PYAUTOGUI_NOT_INSTALLED": "pyautogui no instalado",
             "AGENT_PYAUTOGUI_DISPLAY_UNAVAILABLE": "Sesión de pantalla de escritorio no disponible",
+            "AGENT_PYAUTOGUI_MACOS_PYOBJC_MISSING": "Puente de PyAutoGUI en macOS no disponible (faltan PyObjC/Quartz/AppKit)",
+            "AGENT_PYAUTOGUI_IMPORT_FAILED": "Error al importar pyautogui",
             "AGENT_BROWSER_USE_NOT_INSTALLED": "uso del navegador no instalado",
             "AGENT_CU_MODULE_NOT_LOADED": "módulo Computer Use no cargado",
             "AGENT_BU_MODULE_NOT_LOADED": "módulo Browser Use no cargado",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -2716,6 +2716,8 @@
             "AGENT_ENDPOINT_NOT_CONFIGURED": "Agent API が設定されていません",
             "AGENT_PYAUTOGUI_NOT_INSTALLED": "pyautogui がインストールされていません",
             "AGENT_PYAUTOGUI_DISPLAY_UNAVAILABLE": "デスクトップ表示セッションにアクセスできません",
+            "AGENT_PYAUTOGUI_MACOS_PYOBJC_MISSING": "macOS の PyAutoGUI ブリッジが利用できません（PyObjC/Quartz/AppKit が不足しています）",
+            "AGENT_PYAUTOGUI_IMPORT_FAILED": "pyautogui のインポートに失敗しました",
             "AGENT_BROWSER_USE_NOT_INSTALLED": "browser-use がインストールされていません",
             "AGENT_CU_MODULE_NOT_LOADED": "Computer Use モジュールが読み込まれていません",
             "AGENT_BU_MODULE_NOT_LOADED": "Browser Use モジュールが読み込まれていません",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -2716,6 +2716,8 @@
             "AGENT_ENDPOINT_NOT_CONFIGURED": "Agent API가 구성되지 않았습니다",
             "AGENT_PYAUTOGUI_NOT_INSTALLED": "pyautogui가 설치되지 않았습니다",
             "AGENT_PYAUTOGUI_DISPLAY_UNAVAILABLE": "데스크톱 표시 세션에 접근할 수 없습니다",
+            "AGENT_PYAUTOGUI_MACOS_PYOBJC_MISSING": "macOS PyAutoGUI 브리지 사용 불가 (PyObjC/Quartz/AppKit 누락)",
+            "AGENT_PYAUTOGUI_IMPORT_FAILED": "pyautogui 가져오기에 실패했습니다",
             "AGENT_BROWSER_USE_NOT_INSTALLED": "browser-use가 설치되지 않았습니다",
             "AGENT_CU_MODULE_NOT_LOADED": "Computer Use 모듈이 로드되지 않았습니다",
             "AGENT_BU_MODULE_NOT_LOADED": "Browser Use 모듈이 로드되지 않았습니다",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -2716,6 +2716,8 @@
             "AGENT_ENDPOINT_NOT_CONFIGURED": "API do agente não configurada",
             "AGENT_PYAUTOGUI_NOT_INSTALLED": "pyautogui não instalado",
             "AGENT_PYAUTOGUI_DISPLAY_UNAVAILABLE": "Sessão de exibição da área de trabalho indisponível",
+            "AGENT_PYAUTOGUI_MACOS_PYOBJC_MISSING": "Ponte do PyAutoGUI no macOS indisponível (faltando PyObjC/Quartz/AppKit)",
+            "AGENT_PYAUTOGUI_IMPORT_FAILED": "Falha ao importar pyautogui",
             "AGENT_BROWSER_USE_NOT_INSTALLED": "uso do navegador não instalado",
             "AGENT_CU_MODULE_NOT_LOADED": "módulo Computer Use não carregado",
             "AGENT_BU_MODULE_NOT_LOADED": "módulo Browser Use não carregado",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -2716,6 +2716,8 @@
             "AGENT_ENDPOINT_NOT_CONFIGURED": "Agent API не настроен",
             "AGENT_PYAUTOGUI_NOT_INSTALLED": "pyautogui не установлен",
             "AGENT_PYAUTOGUI_DISPLAY_UNAVAILABLE": "Сеанс рабочего стола недоступен",
+            "AGENT_PYAUTOGUI_MACOS_PYOBJC_MISSING": "Мост PyAutoGUI для macOS недоступен (отсутствуют PyObjC/Quartz/AppKit)",
+            "AGENT_PYAUTOGUI_IMPORT_FAILED": "Не удалось импортировать pyautogui",
             "AGENT_BROWSER_USE_NOT_INSTALLED": "browser-use не установлен",
             "AGENT_CU_MODULE_NOT_LOADED": "модуль Computer Use не загружен",
             "AGENT_BU_MODULE_NOT_LOADED": "модуль Browser Use не загружен",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -2716,6 +2716,8 @@
             "AGENT_ENDPOINT_NOT_CONFIGURED": "Agent API 未配置",
             "AGENT_PYAUTOGUI_NOT_INSTALLED": "pyautogui 未安装",
             "AGENT_PYAUTOGUI_DISPLAY_UNAVAILABLE": "桌面显示会话不可访问",
+            "AGENT_PYAUTOGUI_MACOS_PYOBJC_MISSING": "macOS 的 PyAutoGUI 桥接模块不可用（缺少 PyObjC/Quartz/AppKit）",
+            "AGENT_PYAUTOGUI_IMPORT_FAILED": "pyautogui 导入失败",
             "AGENT_BROWSER_USE_NOT_INSTALLED": "browser-use 未安装",
             "AGENT_CU_MODULE_NOT_LOADED": "Computer Use 模块未加载",
             "AGENT_BU_MODULE_NOT_LOADED": "Browser Use 模块未加载",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -2716,6 +2716,8 @@
             "AGENT_ENDPOINT_NOT_CONFIGURED": "Agent API 未配置",
             "AGENT_PYAUTOGUI_NOT_INSTALLED": "pyautogui 未安裝",
             "AGENT_PYAUTOGUI_DISPLAY_UNAVAILABLE": "桌面顯示工作階段無法存取",
+            "AGENT_PYAUTOGUI_MACOS_PYOBJC_MISSING": "macOS 的 PyAutoGUI 橋接模組不可用（缺少 PyObjC/Quartz/AppKit）",
+            "AGENT_PYAUTOGUI_IMPORT_FAILED": "pyautogui 匯入失敗",
             "AGENT_BROWSER_USE_NOT_INSTALLED": "browser-use 未安裝",
             "AGENT_CU_MODULE_NOT_LOADED": "Computer Use 模組未載入",
             "AGENT_BU_MODULE_NOT_LOADED": "Browser Use 模組未載入",

--- a/tests/unit/test_agent_runtime_intent.py
+++ b/tests/unit/test_agent_runtime_intent.py
@@ -187,6 +187,32 @@ def test_pyautogui_display_error_is_not_reported_as_missing(monkeypatch: pytest.
     assert cu_module._pyautogui_unavailable_reason() == "AGENT_PYAUTOGUI_DISPLAY_UNAVAILABLE"
 
 
+def test_pyautogui_macos_pyobjc_error_has_dedicated_reason(monkeypatch: pytest.MonkeyPatch):
+    from brain import computer_use as cu_module
+
+    monkeypatch.setattr(cu_module, "pyautogui", None)
+    monkeypatch.setattr(
+        cu_module,
+        "_PYAUTOGUI_IMPORT_ERROR",
+        AssertionError("You must first install pyobjc-core and pyobjc"),
+    )
+
+    assert cu_module._pyautogui_unavailable_reason() == "AGENT_PYAUTOGUI_MACOS_PYOBJC_MISSING"
+
+
+def test_pyautogui_generic_import_failure_is_not_reported_as_missing(monkeypatch: pytest.MonkeyPatch):
+    from brain import computer_use as cu_module
+
+    monkeypatch.setattr(cu_module, "pyautogui", None)
+    monkeypatch.setattr(
+        cu_module,
+        "_PYAUTOGUI_IMPORT_ERROR",
+        RuntimeError("dlopen failed while importing pyautogui backend"),
+    )
+
+    assert cu_module._pyautogui_unavailable_reason() == "AGENT_PYAUTOGUI_IMPORT_FAILED"
+
+
 def test_pyautogui_lazy_import_can_recover_after_initial_failure(monkeypatch: pytest.MonkeyPatch):
     from brain import computer_use as cu_module
 

--- a/tests/unit/test_app_screen_screenshot_fallback_static.py
+++ b/tests/unit/test_app_screen_screenshot_fallback_static.py
@@ -17,5 +17,6 @@ def test_backend_screenshot_reason_is_localized_without_exposing_raw_error():
     assert "json.reason" in fallback
     assert "json.error" not in fallback
     assert "e && e.message" not in fallback
+    assert "if (json && json.success && json.data)" in fallback
     assert "translateBackendScreenshotReason(result.reason)" in source
     assert "'agent.precheck.' + reason" in source

--- a/tests/unit/test_app_screen_screenshot_fallback_static.py
+++ b/tests/unit/test_app_screen_screenshot_fallback_static.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import pytest
+
+
+APP_SCREEN_JS = Path(__file__).resolve().parents[2] / "static" / "app" / "app-screen.js"
+
+
+@pytest.mark.unit
+def test_backend_screenshot_reason_is_localized_without_exposing_raw_error():
+    source = APP_SCREEN_JS.read_text(encoding="utf-8")
+    fallback = source.split("async function fetchBackendScreenshot()", 1)[1].split(
+        "mod.fetchBackendScreenshot = fetchBackendScreenshot;",
+        1,
+    )[0]
+
+    assert "json.reason" in fallback
+    assert "json.error" not in fallback
+    assert "e && e.message" not in fallback
+    assert "translateBackendScreenshotReason(result.reason)" in source
+    assert "'agent.precheck.' + reason" in source

--- a/tests/unit/test_nuitka_macos_bundle_contract.py
+++ b/tests/unit/test_nuitka_macos_bundle_contract.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+import pytest
+
+
+WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "build-desktop.yml"
+
+
+@pytest.mark.unit
+def test_macos_pyobjc_build_uses_background_app_with_electron_wrapper():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'NUITKA_OPTS="--mode=app --macos-app-mode=background"' in workflow
+    assert "dist/build_nuitka_launcher.app" in workflow
+    assert "dist/Xiao8/projectneko_server.app" in workflow
+    assert 'projectneko_server.app/Contents/MacOS/projectneko_server' in workflow
+    assert 'NEKO_NUITKA_RUNTIME_DIR=$RUNTIME_DIR' in workflow
+
+
+@pytest.mark.unit
+def test_macos_build_no_longer_excludes_pyobjc_bridge_modules():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    for module in (
+        "Foundation",
+        "AppKit",
+        "objc",
+        "PyObjCTools",
+        "CoreFoundation",
+        "Quartz",
+    ):
+        assert f"--nofollow-import-to={module}" not in workflow

--- a/tests/unit/test_nuitka_macos_bundle_contract.py
+++ b/tests/unit/test_nuitka_macos_bundle_contract.py
@@ -18,6 +18,15 @@ def test_macos_pyobjc_build_uses_background_app_with_electron_wrapper():
         "chmod +x electron-app/bin/projectneko_server.app/Contents/MacOS/"
         "projectneko_server"
     ) in workflow
+    assert "Re-sign macOS backend after post-processing" in workflow
+    assert (
+        "codesign --force --deep --sign - "
+        "dist/Xiao8/projectneko_server.app"
+    ) in workflow
+    assert (
+        "codesign --verify --deep --strict "
+        "dist/Xiao8/projectneko_server.app"
+    ) in workflow
     assert 'NEKO_NUITKA_RUNTIME_DIR=$RUNTIME_DIR' in workflow
 
 

--- a/tests/unit/test_nuitka_macos_bundle_contract.py
+++ b/tests/unit/test_nuitka_macos_bundle_contract.py
@@ -14,6 +14,10 @@ def test_macos_pyobjc_build_uses_background_app_with_electron_wrapper():
     assert "dist/build_nuitka_launcher.app" in workflow
     assert "dist/Xiao8/projectneko_server.app" in workflow
     assert 'projectneko_server.app/Contents/MacOS/projectneko_server' in workflow
+    assert (
+        "chmod +x electron-app/bin/projectneko_server.app/Contents/MacOS/"
+        "projectneko_server"
+    ) in workflow
     assert 'NEKO_NUITKA_RUNTIME_DIR=$RUNTIME_DIR' in workflow
 
 

--- a/tests/unit/test_system_screenshot_router.py
+++ b/tests/unit/test_system_screenshot_router.py
@@ -1,3 +1,4 @@
+import builtins
 from unittest.mock import patch
 from types import SimpleNamespace
 
@@ -123,6 +124,30 @@ def test_backend_screenshot_rejects_missing_csrf_headers():
     assert payload["success"] is False
     assert payload["error_code"] == "csrf_validation_failed"
     assert response.headers["Cache-Control"] == "no-store, no-cache, must-revalidate, max-age=0"
+
+
+@pytest.mark.unit
+def test_backend_screenshot_surfaces_macos_pyobjc_import_error(monkeypatch):
+    monkeypatch.setattr(system_router_module, "_is_loopback_request", lambda _request: True)
+    monkeypatch.setattr(system_router_module.sys, "platform", "darwin")
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "pyautogui":
+            raise AssertionError("You must first install pyobjc-core and pyobjc")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with _build_client() as client:
+        response = client.post(SCREENSHOT_ENDPOINT, headers=_local_headers())
+
+    assert response.status_code == 501
+    payload = response.json()
+    assert payload["success"] is False
+    assert "PyObjC/Quartz/AppKit" in payload["error"]
+    assert "pyobjc-core and pyobjc" in payload["error"]
 
 
 @pytest.mark.unit
@@ -387,4 +412,3 @@ def test_interactive_screenshot_returns_cropped_image_data(monkeypatch):
     assert payload["size"] > 0
     assert payload["data"].startswith("data:image/jpeg;base64,")
     assert response.headers["Cache-Control"] == "no-store, no-cache, must-revalidate, max-age=0"
-

--- a/tests/unit/test_system_screenshot_router.py
+++ b/tests/unit/test_system_screenshot_router.py
@@ -127,7 +127,7 @@ def test_backend_screenshot_rejects_missing_csrf_headers():
 
 
 @pytest.mark.unit
-def test_backend_screenshot_surfaces_macos_pyobjc_import_error(monkeypatch):
+def test_backend_screenshot_returns_safe_macos_pyobjc_reason(monkeypatch):
     monkeypatch.setattr(system_router_module, "_is_loopback_request", lambda _request: True)
     monkeypatch.setattr(system_router_module.sys, "platform", "darwin")
 
@@ -146,8 +146,35 @@ def test_backend_screenshot_surfaces_macos_pyobjc_import_error(monkeypatch):
     assert response.status_code == 501
     payload = response.json()
     assert payload["success"] is False
-    assert "PyObjC/Quartz/AppKit" in payload["error"]
-    assert "pyobjc-core and pyobjc" in payload["error"]
+    assert payload["error"] == "pyautogui unavailable"
+    assert payload["reason"] == "AGENT_PYAUTOGUI_MACOS_PYOBJC_MISSING"
+    assert "pyobjc-core and pyobjc" not in str(payload)
+
+
+@pytest.mark.unit
+def test_backend_screenshot_does_not_expose_raw_import_details(monkeypatch):
+    monkeypatch.setattr(system_router_module, "_is_loopback_request", lambda _request: True)
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "pyautogui":
+            raise RuntimeError("dlopen(/Users/alice/private/libbackend.dylib) failed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with _build_client() as client:
+        response = client.post(SCREENSHOT_ENDPOINT, headers=_local_headers())
+
+    assert response.status_code == 501
+    payload = response.json()
+    assert payload == {
+        "success": False,
+        "error": "pyautogui unavailable",
+        "reason": "AGENT_PYAUTOGUI_IMPORT_FAILED",
+    }
+    assert "/Users/alice" not in response.text
 
 
 @pytest.mark.unit

--- a/utils/pyautogui_diagnostics.py
+++ b/utils/pyautogui_diagnostics.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Optional
+
+
+_DISPLAY_UNAVAILABLE_TOKENS = (
+    "displayconnectionerror",
+    "can't connect to display",
+    "cannot connect to display",
+    "authorization required",
+    "no authorization protocol",
+    "display",
+    "xlib",
+)
+
+_MACOS_PYOBJC_MISSING_TOKENS = (
+    "you must first install pyobjc-core and pyobjc",
+    "pyobjc-core",
+    "pyobjc",
+    "quartz",
+    "appkit",
+    "corefoundation",
+    "pyobjctools",
+)
+
+_MACOS_PYOBJC_MODULE_NAMES = frozenset({
+    "appkit",
+    "quartz",
+    "corefoundation",
+    "foundation",
+    "objc",
+    "pyobjctools",
+})
+
+
+def classify_pyautogui_import_error(
+    exc: BaseException | None,
+    *,
+    platform_name: Optional[str] = None,
+) -> str:
+    text = str(exc or "").strip()
+    lower = text.lower()
+    lower_platform = str(platform_name or "").lower()
+
+    if isinstance(exc, ModuleNotFoundError):
+        missing_name = str(getattr(exc, "name", "") or "").lower()
+        if missing_name == "pyautogui" or "no module named 'pyautogui'" in lower or 'no module named "pyautogui"' in lower:
+            return "AGENT_PYAUTOGUI_NOT_INSTALLED"
+        if lower_platform == "darwin" and missing_name in _MACOS_PYOBJC_MODULE_NAMES:
+            return "AGENT_PYAUTOGUI_MACOS_PYOBJC_MISSING"
+
+    if any(token in lower for token in _DISPLAY_UNAVAILABLE_TOKENS):
+        return "AGENT_PYAUTOGUI_DISPLAY_UNAVAILABLE"
+
+    if any(token in lower for token in _MACOS_PYOBJC_MISSING_TOKENS):
+        return "AGENT_PYAUTOGUI_MACOS_PYOBJC_MISSING"
+
+    if "no module named" in lower and "pyautogui" in lower:
+        return "AGENT_PYAUTOGUI_NOT_INSTALLED"
+
+    return "AGENT_PYAUTOGUI_IMPORT_FAILED"
+
+
+def format_pyautogui_import_error(
+    exc: BaseException | None,
+    *,
+    platform_name: Optional[str] = None,
+) -> str:
+    reason = classify_pyautogui_import_error(exc, platform_name=platform_name)
+    text = str(exc or "").strip()
+
+    if reason == "AGENT_PYAUTOGUI_NOT_INSTALLED":
+        return "pyautogui not installed"
+
+    if reason == "AGENT_PYAUTOGUI_DISPLAY_UNAVAILABLE":
+        return text or "desktop display session unavailable"
+
+    if reason == "AGENT_PYAUTOGUI_MACOS_PYOBJC_MISSING":
+        prefix = "pyautogui macOS bridge unavailable (PyObjC/Quartz/AppKit missing from the environment or packaged app)"
+        return f"{prefix}: {text}" if text else prefix
+
+    if text:
+        return f"pyautogui import failed: {text}"
+    return "pyautogui import failed"

--- a/utils/pyautogui_diagnostics.py
+++ b/utils/pyautogui_diagnostics.py
@@ -59,26 +59,3 @@ def classify_pyautogui_import_error(
         return "AGENT_PYAUTOGUI_NOT_INSTALLED"
 
     return "AGENT_PYAUTOGUI_IMPORT_FAILED"
-
-
-def format_pyautogui_import_error(
-    exc: BaseException | None,
-    *,
-    platform_name: Optional[str] = None,
-) -> str:
-    reason = classify_pyautogui_import_error(exc, platform_name=platform_name)
-    text = str(exc or "").strip()
-
-    if reason == "AGENT_PYAUTOGUI_NOT_INSTALLED":
-        return "pyautogui not installed"
-
-    if reason == "AGENT_PYAUTOGUI_DISPLAY_UNAVAILABLE":
-        return text or "desktop display session unavailable"
-
-    if reason == "AGENT_PYAUTOGUI_MACOS_PYOBJC_MISSING":
-        prefix = "pyautogui macOS bridge unavailable (PyObjC/Quartz/AppKit missing from the environment or packaged app)"
-        return f"{prefix}: {text}" if text else prefix
-
-    if text:
-        return f"pyautogui import failed: {text}"
-    return "pyautogui import failed"


### PR DESCRIPTION
## 改动概述 / Summary

- 在 macOS 上将 Nuitka 后端改为 background app bundle，使 PyObjC 的 Foundation、AppKit、Quartz 等桥接模块可被合法打包；artifact 根目录保留 `projectneko_server` wrapper，兼容 Electron 现有启动路径。
- 统一分类 `pyautogui` 导入失败，区分未安装、桌面会话不可用、macOS PyObjC bridge 缺失和通用导入失败。
- 后端截图接口仅返回稳定 reason code，不向浏览器或持久化日志暴露原始异常、本机路径等环境细节；前端通过现有 `agent.precheck.*` key 本地化展示。
- 补充 macOS 打包、后端安全错误协议、前端本地化以及 lazy import 恢复路径的回归测试。

## Issue

- Refs #2329

## 回归报告 / Regression Report

- **改动内容**：`main_routers/system_router/screenshot.py` 的 PyAutoGUI 导入失败响应由原始字符串改为稳定 reason code；Computer Use 复用相同分类器；macOS Nuitka 由普通 standalone 改为 background app bundle，并在 artifact 根提供兼容 Electron 的启动 wrapper。
- **理由 / 必要性**：原构建显式排除 PyObjC bridge，导致 Electron 分发包内 `pyautogui` 无法导入并被误报为“未安装”；直接取消排除又会触发 Nuitka 的 `Foundation requires --mode=app` 致命错误，因此必须使用 app bundle。原始异常可能包含本机绝对路径或环境信息，也不能直接透传到浏览器。
- **改动前后**：改动前 macOS 分发包缺少 Quartz/AppKit，且截图 fallback 将多类导入异常统一成未安装；最初版本的修复还会把原始异常以英文透传给 UI。改动后 PyObjC 位于合法的 background `.app` 内，Electron 仍启动 `bin/projectneko_server`，错误通过稳定 code 映射到 8 个 locale 文案。
- **潜在回归点与验证**：重点覆盖 Electron artifact 路径、Nuitka 数据/插件安装目录、截图 API 协议、Computer Use 预检和 i18n。用 Nuitka 4.1.3 最小构建确认普通 standalone 会因 Foundation 失败，而 app mode 产物可从 `Contents/MacOS/projectneko_server` 直接启动、导入 PyObjC 并读取屏幕尺寸；相关单测、Ruff、JS 语法、YAML 与 locale 一致性检查均通过。完整 Electron 签名分发构建仍交由 macOS CI 验证。

## 不拆分理由 / Why Not Split

不适用：计入上限的文件数不超过 20；打包模式、后端 reason code 与前端本地化共同构成同一条 macOS PyAutoGUI 修复链路。

## 测试 / Testing

- [x] `uv run pytest tests/unit/test_system_screenshot_router.py tests/unit/test_agent_runtime_intent.py tests/unit/test_app_screen_screenshot_fallback_static.py tests/unit/test_nuitka_macos_bundle_contract.py -q`（80 passed）
- [x] `uv run pytest tests/unit/test_prepare_nuitka_plugins.py -q`（7 passed）
- [x] `uv run pytest tests/unit/test_i18n_locale_keys.py -q`（6 passed）
- [x] `uv run ruff check app/agent_server/_shared.py brain/computer_use.py main_routers/system_router/screenshot.py utils/pyautogui_diagnostics.py tests/unit/test_system_screenshot_router.py tests/unit/test_app_screen_screenshot_fallback_static.py tests/unit/test_nuitka_macos_bundle_contract.py`
- [x] `uv run python -m py_compile utils/pyautogui_diagnostics.py brain/computer_use.py main_routers/system_router/screenshot.py`
- [x] `node --check static/app/app-screen.js`
- [x] 8 个 `static/locales/*.json` key 集合一致，新增 reason code 全部存在
- [x] `.github/workflows/build-desktop.yml` YAML 解析通过
- [x] Nuitka 4.1.3 最小 macOS app-mode 产物运行验证通过
- [ ] 完整 macOS Electron 构建与签名（由 CI 验证）

> 注：`scripts/check_i18n.py --strict` 的跨 locale key 集合检查通过；脚本仍报告 3 个本 PR 未涉及、且在所有 locale 中均缺失的既有 Jukebox key。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 屏幕共享/截图失败提示更细化：后端返回 `reason`，前端本地化翻译并用于轮询兜底提示。
  * 新增运行前预检文案（多语言）：macOS 缺少 PyAutoGUI 桥接依赖、以及 `pyautogui` 导入失败。
* **问题修复**
  * 前端对截图接口返回/JSON 解析更健壮；错误不再暴露原始异常细节或敏感路径。
* **构建/打包**
  * macOS Nuitka 打包运行契约调整为后台模式，并重签名修复签名状态；离线资源改从运行时目录读取。
* **测试**
  * 补充 `pyautogui` 不可用原因分类、前端本地化与 macOS 打包配置的校验用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->