### PR TITLE
fix(tutorial): 修复新手教程形态恢复竞态

### DIFF
--- a/static/app/app-auto-goodbye.js
+++ b/static/app/app-auto-goodbye.js
@@ -715,6 +715,14 @@
         if (markApplied === true) state.startupDefaultCatApplied = true;
     }
 
+    function consumeStartupDefaultCatRequest() {
+        if (!state.startupDefaultCatRequested) return false;
+        // 教程恢复会自行重放同一个猫咪业务入口；先消费启动请求并清掉重试定时器，
+        // 避免教程锁释放后旧重试与恢复链各派发一次猫咪切换。
+        cancelStartupDefaultCatRequest(true);
+        return true;
+    }
+
     function scheduleStartupDefaultCatRetry() {
         state.startupDefaultCatTimerId = window.setTimeout(
             applyStartupDefaultCat,
@@ -977,6 +985,7 @@
         setAutoCatEnabled: setAutoCatEnabled,
         isAutoCatEnabled: isAutoCatEnabled,
         clearTimers: clearTimers,
+        consumeStartupDefaultCatRequest: consumeStartupDefaultCatRequest,
         getState: getState,
     };
 

--- a/static/app/app-auto-goodbye.js
+++ b/static/app/app-auto-goodbye.js
@@ -731,6 +731,15 @@
             scheduleStartupDefaultCatRetry();
             return;
         }
+        if (
+            isTutorialGuardActive()
+            || window.isNekoHomeTutorialPending === true
+            || window.isInTutorial === true
+        ) {
+            // 教程直启时页面上出现的是临时 YUI 模型按钮；继续等待，不能把启动默认猫咪请求消费在教程模型上。
+            scheduleStartupDefaultCatRetry();
+            return;
+        }
         if (isGoodbyeActive()) {
             cancelStartupDefaultCatRequest(true);
             return;
@@ -793,6 +802,8 @@
             lastSuppressionChangedAt: state.lastSuppressionChangedAt,
             conversationGraceUntil: state.conversationGraceUntil,
             lastConversationSource: state.lastConversationSource,
+            // 教程管理器需要区分“用户选择普通模型”和“PC 默认猫咪请求尚未执行”的冷启动状态。
+            startupDefaultCatRequested: state.startupDefaultCatRequested,
             thresholdsMs: {
                 cat1: AUTO_GOODBYE_MS,
                 cat2: CAT2_MS,

--- a/static/app/app-interpage/cross-window-broadcast-and-bridge.js
+++ b/static/app/app-interpage/cross-window-broadcast-and-bridge.js
@@ -729,6 +729,18 @@
                 I.applyYuiGuideCompactChatFixedLayout(message.fixed === true);
                 return true;
             }
+            case 'yui_guide_prepare_compact_chat': {
+                if (!I.isStandaloneChatPage()) return true;
+                // 原生 relay 与 BroadcastChannel 共用同一准备函数，保证两条传输路径行为一致。
+                I.prepareYuiGuideCompactChatSurface(message);
+                return true;
+            }
+            case 'yui_guide_restore_compact_chat': {
+                if (!I.isStandaloneChatPage()) return true;
+                // 形态恢复留在胶囊窗口执行，避免主页猜测 Electron 的真实折叠状态。
+                I.restoreYuiGuideCompactChatSurface(message);
+                return true;
+            }
             case 'yui_guide_set_chat_spotlight': {
                 if (!I.isStandaloneChatPage() || !document.body) return true;
                 I.ensureYuiGuideExternalChatExpanded();
@@ -873,6 +885,14 @@
                     detail: {
                         timestamp: message.timestamp || Date.now()
                     }
+                }));
+                return true;
+            }
+            case 'yui_guide_compact_chat_ready': {
+                if (I.isStandaloneChatPage()) return true;
+                // 主页只接受当前 requestId 的回执，重启教程时不会误用上一轮迟到消息。
+                window.dispatchEvent(new CustomEvent('neko:yui-guide:compact-chat-ready', {
+                    detail: message
                 }));
                 return true;
             }

--- a/static/app/app-interpage/guide-message-relay.js
+++ b/static/app/app-interpage/guide-message-relay.js
@@ -269,6 +269,18 @@
                         I.applyYuiGuideCompactChatFixedLayout(event.data.fixed === true);
                         break;
                     }
+                    case 'yui_guide_prepare_compact_chat': {
+                        if (!I.isStandaloneChatPage()) break;
+                        // 固定教程布局前先完成原生毛球到胶囊的展开，并把启动前形态回传给主页。
+                        I.prepareYuiGuideCompactChatSurface(event.data);
+                        break;
+                    }
+                    case 'yui_guide_restore_compact_chat': {
+                        if (!I.isStandaloneChatPage()) break;
+                        // 教程结束后的形态恢复必须由胶囊窗口执行，主页没有原生窗口状态。
+                        I.restoreYuiGuideCompactChatSurface(event.data);
+                        break;
+                    }
                     case 'yui_guide_set_chat_cursor':
                     case 'yui_guide_drag_chat_cursor':
                     case 'yui_guide_arc_chat_cursor': {
@@ -322,6 +334,14 @@
                             detail: {
                                 timestamp: event.data.timestamp || Date.now()
                             }
+                        }));
+                        break;
+                    }
+                    case 'yui_guide_compact_chat_ready': {
+                        if (I.isStandaloneChatPage()) break;
+                        // requestId 由本轮教程生成，主页据此忽略上一轮迟到的展开回执。
+                        window.dispatchEvent(new CustomEvent('neko:yui-guide:compact-chat-ready', {
+                            detail: event.data
                         }));
                         break;
                     }
@@ -580,6 +600,90 @@
             return false;
         }
     }
+
+    I.prepareYuiGuideCompactChatSurface = function prepareYuiGuideCompactChatSurface(message) {
+        var requestId = message && message.requestId ? String(message.requestId) : '';
+        if (!requestId) return false;
+
+        var host = getReactChatWindowHost();
+        var nativeBridge = window.nekoChatWindow || null;
+        var hostMode = host && typeof host.getChatSurfaceMode === 'function'
+            ? host.getChatSurfaceMode()
+            : '';
+        var wasCollapsed = hostMode === 'minimized'
+            || !!(nativeBridge && typeof nativeBridge.isCollapsed === 'function' && nativeBridge.isCollapsed());
+
+        // 同一请求可能同时经 BroadcastChannel 与原生 relay 到达；只启动一次原生动画，
+        // 否则第二次调用会把正在展开的 surface 当成新的教程状态。
+        if (I.yuiGuideCompactChatPrepareRequestId === requestId) {
+            return true;
+        }
+        I.yuiGuideCompactChatPrepareRequestId = requestId;
+
+        var nativePreparation = null;
+        if (nativeBridge && typeof nativeBridge.prepareExpandedForTutorial === 'function') {
+            try {
+                nativePreparation = nativeBridge.prepareExpandedForTutorial();
+            } catch (error) {
+                console.warn('[YuiGuide] Failed to prepare native compact chat surface:', error);
+            }
+        } else if (nativeBridge && typeof nativeBridge.ensureExpandedForTutorial === 'function') {
+            try {
+                nativeBridge.ensureExpandedForTutorial();
+            } catch (_) {}
+        }
+
+        // 浏览器和旧版桌面桥仍需同步 React 自己的 minimized 状态；新版桌面桥会在
+        // 原生展开完成后再次把 host 对齐到 compact，因此这一步是幂等的。
+        I.ensureYuiGuideExternalChatExpanded();
+
+        Promise.resolve(nativePreparation).then(function (result) {
+            var nativeResult = result && typeof result === 'object' ? result : {};
+            I.postYuiGuideMessageToPet('yui_guide_compact_chat_ready', {
+                requestId: requestId,
+                ready: nativeResult.ready !== false,
+                wasCollapsed: nativeResult.wasCollapsed === true || wasCollapsed,
+                timestamp: Date.now()
+            });
+        }).catch(function (error) {
+            console.warn('[YuiGuide] Native compact chat preparation failed:', error);
+            I.postYuiGuideMessageToPet('yui_guide_compact_chat_ready', {
+                requestId: requestId,
+                ready: false,
+                wasCollapsed: wasCollapsed,
+                timestamp: Date.now()
+            });
+        });
+        return true;
+    };
+
+    I.restoreYuiGuideCompactChatSurface = function restoreYuiGuideCompactChatSurface(message) {
+        if (!message || message.wasCollapsed !== true) return false;
+        var requestId = message.requestId ? String(message.requestId) : '';
+        if (requestId && I.yuiGuideCompactChatRestoreRequestId === requestId) {
+            return true;
+        }
+        // BroadcastChannel 与原生 relay 可能各送一次；恢复动画同样只允许启动一次。
+        I.yuiGuideCompactChatRestoreRequestId = requestId;
+
+        var nativeBridge = window.nekoChatWindow || null;
+        if (nativeBridge && typeof nativeBridge.restoreCollapsedAfterTutorial === 'function') {
+            try {
+                nativeBridge.restoreCollapsedAfterTutorial();
+                return true;
+            } catch (error) {
+                console.warn('[YuiGuide] Failed to restore native collapsed chat surface:', error);
+            }
+        }
+
+        var host = getReactChatWindowHost();
+        if (host && typeof host.setChatSurfaceMode === 'function') {
+            // 旧版桌面桥及浏览器环境没有原生恢复 API，仍通过现有 surface 状态机折叠。
+            host.setChatSurfaceMode('minimized');
+            return true;
+        }
+        return false;
+    };
 
     function relayYuiGuideChatCommand(data) {
         var detail = data && typeof data === 'object' ? Object.assign({}, data) : {};

--- a/static/app/app-interpage/guide-message-relay.js
+++ b/static/app/app-interpage/guide-message-relay.js
@@ -666,6 +666,11 @@
     I.restoreYuiGuideCompactChatSurface = function restoreYuiGuideCompactChatSurface(message) {
         if (!message || message.wasCollapsed !== true) return false;
         var requestId = message.requestId ? String(message.requestId) : '';
+        // restore 必须属于当前最近一次 prepare；快速重启教程时，旧 run 的迟到恢复
+        // 不能把新教程刚展开的胶囊重新折叠。新版恢复消息始终携带 requestId。
+        if (!requestId || I.yuiGuideCompactChatPrepareRequestId !== requestId) {
+            return false;
+        }
         if (requestId && I.yuiGuideCompactChatRestoreRequestId === requestId) {
             return true;
         }

--- a/static/app/app-interpage/guide-message-relay.js
+++ b/static/app/app-interpage/guide-message-relay.js
@@ -625,12 +625,18 @@
             try {
                 nativePreparation = nativeBridge.prepareExpandedForTutorial();
             } catch (error) {
+                // 同步调用失败与 Promise reject 语义一致，必须显式回执失败，
+                // 否则 null 会被后续 Promise.resolve 当成成功准备完成。
+                nativePreparation = { ready: false };
                 console.warn('[YuiGuide] Failed to prepare native compact chat surface:', error);
             }
         } else if (nativeBridge && typeof nativeBridge.ensureExpandedForTutorial === 'function') {
             try {
                 nativeBridge.ensureExpandedForTutorial();
-            } catch (_) {}
+            } catch (_) {
+                // 旧桥接同步失败时同样不能向教程误报胶囊已经准备完成。
+                nativePreparation = { ready: false };
+            }
         }
 
         // 浏览器和旧版桌面桥仍需同步 React 自己的 minimized 状态；新版桌面桥会在

--- a/static/app/app-interpage/guide-message-relay.js
+++ b/static/app/app-interpage/guide-message-relay.js
@@ -619,6 +619,9 @@
             return true;
         }
         I.yuiGuideCompactChatPrepareRequestId = requestId;
+        // 主页超时后已无法收到 ready 回执；按 request 保存真实初始形态，后续取消请求
+        // 才能只恢复原本的毛球，而不把原本展开的胶囊错误折叠。
+        I.yuiGuideCompactChatPrepareWasCollapsed = wasCollapsed;
 
         var nativePreparation = null;
         if (nativeBridge && typeof nativeBridge.prepareExpandedForTutorial === 'function') {
@@ -664,13 +667,20 @@
     };
 
     I.restoreYuiGuideCompactChatSurface = function restoreYuiGuideCompactChatSurface(message) {
-        if (!message || message.wasCollapsed !== true) return false;
+        if (!message) return false;
         var requestId = message.requestId ? String(message.requestId) : '';
         // restore 必须属于当前最近一次 prepare；快速重启教程时，旧 run 的迟到恢复
         // 不能把新教程刚展开的胶囊重新折叠。新版恢复消息始终携带 requestId。
         if (!requestId || I.yuiGuideCompactChatPrepareRequestId !== requestId) {
             return false;
         }
+        var shouldRestoreCollapsed = message.wasCollapsed === true;
+        if (message.restoreFromPrepareSnapshot === true) {
+            // 超时恢复只信任当前 prepare 在聊天窗捕获的真实状态；主页的未知状态不能
+            // 保守地当成毛球，否则原本展开的胶囊也会被错误折叠。
+            shouldRestoreCollapsed = I.yuiGuideCompactChatPrepareWasCollapsed === true;
+        }
+        if (!shouldRestoreCollapsed) return false;
         if (requestId && I.yuiGuideCompactChatRestoreRequestId === requestId) {
             return true;
         }

--- a/static/app/app-interpage/guide-message-relay.js
+++ b/static/app/app-interpage/guide-message-relay.js
@@ -587,6 +587,10 @@
         return window.reactChatWindowHost || null;
     }
 
+    var YUI_GUIDE_COMPACT_CHAT_HOST_RETRY_DELAY_MS = 50;
+    // 主页面等待 ready 的上限是 4.5 秒；最多重试 4 秒，为明确失败回执预留传输时间。
+    var YUI_GUIDE_COMPACT_CHAT_HOST_RETRY_LIMIT = 80;
+
     I.ensureYuiGuideExternalChatExpanded = function ensureYuiGuideExternalChatExpanded() {
         var host = getReactChatWindowHost();
         if (!host || typeof host.openWindow !== 'function') {
@@ -601,24 +605,69 @@
         }
     }
 
-    I.prepareYuiGuideCompactChatSurface = function prepareYuiGuideCompactChatSurface(message) {
+    I.prepareYuiGuideCompactChatSurface = function prepareYuiGuideCompactChatSurface(message, hostRetryAttempt) {
         var requestId = message && message.requestId ? String(message.requestId) : '';
         if (!requestId) return false;
 
+        var retryAttempt = Number.isFinite(Number(hostRetryAttempt))
+            ? Math.max(0, Number(hostRetryAttempt))
+            : 0;
+        if (retryAttempt > 0) {
+            if (
+                I.yuiGuideCompactChatPrepareRequestId !== requestId
+                || I.yuiGuidePcOverlayLifecycleClosed
+                || !I.isYuiGuideMessageForCurrentLifecycle(message)
+            ) {
+                // 新教程、结束消息或新 requestId 已接管时，旧 host 重试不得再展开聊天窗。
+                return false;
+            }
+        } else if (I.yuiGuideCompactChatPrepareRequestId === requestId) {
+            // 同一请求可能同时经 BroadcastChannel 与原生 relay 到达；只保留一条准备/重试链。
+            return true;
+        } else {
+            I.yuiGuideCompactChatPrepareRequestId = requestId;
+            // host 尚未安装时无法读取折叠态；先清空旧请求快照，准备成功后再记录真实状态。
+            I.yuiGuideCompactChatPrepareWasCollapsed = false;
+        }
+
         var host = getReactChatWindowHost();
         var nativeBridge = window.nekoChatWindow || null;
+        var hasNativePreparation = !!(
+            nativeBridge
+            && (
+                typeof nativeBridge.prepareExpandedForTutorial === 'function'
+                || typeof nativeBridge.ensureExpandedForTutorial === 'function'
+            )
+        );
+        var hasReadyHost = !!(
+            host
+            && typeof host.openWindow === 'function'
+            && typeof host.getChatSurfaceMode === 'function'
+        );
+        if (!hasNativePreparation && !hasReadyHost) {
+            if (retryAttempt < YUI_GUIDE_COMPACT_CHAT_HOST_RETRY_LIMIT) {
+                // /chat 会先加载 interpage relay、后安装 React host；在主页面握手超时内等待，
+                // 不能把“host 尚未安装”当成胶囊已经展开。
+                I.yuiGuideInterpageResources.setTimeout(function () {
+                    I.prepareYuiGuideCompactChatSurface(message, retryAttempt + 1);
+                }, YUI_GUIDE_COMPACT_CHAT_HOST_RETRY_DELAY_MS);
+                return true;
+            }
+            I.postYuiGuideMessageToPet('yui_guide_compact_chat_ready', {
+                requestId: requestId,
+                ready: false,
+                wasCollapsed: false,
+                timestamp: Date.now()
+            });
+            return false;
+        }
+
         var hostMode = host && typeof host.getChatSurfaceMode === 'function'
             ? host.getChatSurfaceMode()
             : '';
         var wasCollapsed = hostMode === 'minimized'
             || !!(nativeBridge && typeof nativeBridge.isCollapsed === 'function' && nativeBridge.isCollapsed());
 
-        // 同一请求可能同时经 BroadcastChannel 与原生 relay 到达；只启动一次原生动画，
-        // 否则第二次调用会把正在展开的 surface 当成新的教程状态。
-        if (I.yuiGuideCompactChatPrepareRequestId === requestId) {
-            return true;
-        }
-        I.yuiGuideCompactChatPrepareRequestId = requestId;
         // 主页超时后已无法收到 ready 回执；按 request 保存真实初始形态，后续取消请求
         // 才能只恢复原本的毛球，而不把原本展开的胶囊错误折叠。
         I.yuiGuideCompactChatPrepareWasCollapsed = wasCollapsed;
@@ -644,7 +693,17 @@
 
         // 浏览器和旧版桌面桥仍需同步 React 自己的 minimized 状态；新版桌面桥会在
         // 原生展开完成后再次把 host 对齐到 compact，因此这一步是幂等的。
-        I.ensureYuiGuideExternalChatExpanded();
+        var hostExpanded = I.ensureYuiGuideExternalChatExpanded();
+        if (!hasNativePreparation && !hostExpanded) {
+            // host 已安装但同步展开失败时必须明确回执失败，不能让 null 被当成成功。
+            I.postYuiGuideMessageToPet('yui_guide_compact_chat_ready', {
+                requestId: requestId,
+                ready: false,
+                wasCollapsed: wasCollapsed,
+                timestamp: Date.now()
+            });
+            return false;
+        }
 
         Promise.resolve(nativePreparation).then(function (result) {
             var nativeResult = result && typeof result === 'object' ? result : {};

--- a/static/app/app-interpage/guide-overlay.js
+++ b/static/app/app-interpage/guide-overlay.js
@@ -221,6 +221,9 @@
 
     I.isYuiGuideLifecycleScopedAction = function isYuiGuideLifecycleScopedAction(action) {
         switch (action) {
+            // 教程准备会改写当前胶囊快照；必须和后续 fixed-layout 一样绑定当前 run，
+            // 否则快速重启时迟到的旧 prepare 会覆盖新教程的恢复身份。
+            case 'yui_guide_prepare_compact_chat':
             case 'yui_guide_set_chat_buttons_disabled':
             case 'yui_guide_set_chat_input_locked':
             case 'yui_guide_set_compact_chat_fixed_layout':

--- a/static/app/app-ui/surface-floating-controls.js
+++ b/static/app/app-ui/surface-floating-controls.js
@@ -78,7 +78,7 @@
         });
 
         // 睡觉按钮（请她离开）
-        window.addEventListener('live2d-goodbye-click', () => {
+        window.addEventListener('live2d-goodbye-click', (event) => {
             const goodbyeTransitionToken = I.reserveNekoModelCatTransition('model-to-cat');
             if (!goodbyeTransitionToken) {
                 console.log('[App] 模型/猫切换进行中，忽略本次请她离开点击');
@@ -86,7 +86,21 @@
             }
             // 第零步：在任何状态变更之前立即捕获模型位置。
             // return-ball 会出现在这个位置；后续 return 时也以它作为模型位移基准。
-            const savedModelRect = I.getActiveModelTransitionRect();
+            const requestedRestoreRect = event && event.detail && event.detail.restoreSavedGoodbyeRect;
+            // 教程结束恢复猫咪态时，用户模型刚被临时重载到教程站位；必须沿用教程前
+            // 猫咪/返回按钮锚点，不能把临时模型位置误存成新的猫咪位置。
+            const savedModelRect = requestedRestoreRect
+                && Number.isFinite(Number(requestedRestoreRect.left))
+                && Number.isFinite(Number(requestedRestoreRect.top))
+                && Number(requestedRestoreRect.width) > 0
+                && Number(requestedRestoreRect.height) > 0
+                ? {
+                    left: Number(requestedRestoreRect.left),
+                    top: Number(requestedRestoreRect.top),
+                    width: Number(requestedRestoreRect.width),
+                    height: Number(requestedRestoreRect.height)
+                }
+                : I.getActiveModelTransitionRect();
 
             // 按钮位置只作为模型 bounds 不可用时的兜底。
             // 其他 handler（VRM/MMD goodbyeHandler）可能先于此处执行并隐藏按钮容器，

--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -1426,9 +1426,24 @@ class UniversalTutorialManager {
 
     prepareYuiGuideCompactChatForTutorial() {
         const requestId = `tutorial-compact-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        let tutorialRunId = '';
+        try {
+            tutorialRunId = window.localStorage
+                ? (window.localStorage.getItem('yuiGuidePcOverlayRunId') || '')
+                : '';
+            if (!tutorialRunId) {
+                // prepare 早于 lifecycle-start relay，必须在排队前给本轮生成稳定 runId；
+                // PC 才能让迟到的旧 lifecycle-ended 只清理旧教程请求。
+                tutorialRunId = 'yui-guide-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2);
+                if (window.localStorage) {
+                    window.localStorage.setItem('yuiGuidePcOverlayRunId', tutorialRunId);
+                }
+            }
+        } catch (_) {}
         const message = {
             action: 'yui_guide_prepare_compact_chat',
             requestId: requestId,
+            tutorialRunId: tutorialRunId,
             reason: 'avatar-floating-guide-start',
             timestamp: Date.now()
         };
@@ -3361,6 +3376,27 @@ class UniversalTutorialManager {
         }
     }
 
+    consumePendingStartupDefaultCatRestoreRequest() {
+        const snapshot = this._avatarFloatingModelLockSnapshot;
+        if (
+            !snapshot
+            || snapshot.goodbyeActive !== true
+            || !snapshot.goodbyeMeta
+            || snapshot.goodbyeMeta.reason !== 'startup-default-cat'
+        ) {
+            return false;
+        }
+        try {
+            const autoGoodbye = window.nekoAutoGoodbye;
+            if (autoGoodbye && typeof autoGoodbye.consumeStartupDefaultCatRequest === 'function') {
+                return autoGoodbye.consumeStartupDefaultCatRequest() === true;
+            }
+        } catch (error) {
+            console.warn('[Tutorial] 消费待恢复的启动默认猫咪请求失败:', error);
+        }
+        return false;
+    }
+
     applyTutorialChatIdentityOverride(detail) {
         const payload = detail || {};
         if (window.appInterpage && typeof window.appInterpage.applyTutorialChatIdentityOverride === 'function') {
@@ -4258,6 +4294,9 @@ class UniversalTutorialManager {
         this.cachedValidSteps = null;
         this.lifecycleStateStore.resetEndReason();
         this.currentTutorialStartSource = 'auto';
+
+        // 在解除教程全局锁前消费启动默认猫咪重试；后续模型恢复链会按快照只重放一次猫咪形态。
+        this.consumePendingStartupDefaultCatRestoreRequest();
 
         // 清除全局引导标记
         window.isInTutorial = false;

--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -1461,6 +1461,23 @@ class UniversalTutorialManager {
             }, YUI_GUIDE_COMPACT_CHAT_PREPARE_TIMEOUT_MS);
             window.addEventListener('neko:yui-guide:compact-chat-ready', handleReady);
 
+            const localHost = window.reactChatWindowHost || null;
+            const hasNativeChatRelay = !!(
+                window.nekoTutorialOverlay
+                && typeof window.nekoTutorialOverlay.relayToChat === 'function'
+            );
+            if (!hasNativeChatRelay && localHost && typeof localHost.openWindow === 'function') {
+                // 单窗口浏览器也可能创建 BroadcastChannel，但没有独立 /chat 页面负责回执；
+                // 此时直接准备当前页的 React chat host，避免等待一个永远不会出现的回执。
+                const wasCollapsed = !!(
+                    typeof localHost.getChatSurfaceMode === 'function'
+                    && localHost.getChatSurfaceMode() === 'minimized'
+                );
+                localHost.openWindow();
+                finish(true, { wasCollapsed: wasCollapsed });
+                return;
+            }
+
             let posted = false;
             const channel = window.appInterpage && window.appInterpage.nekoBroadcastChannel;
             if (channel && typeof channel.postMessage === 'function') {
@@ -1484,14 +1501,13 @@ class UniversalTutorialManager {
             }
             if (!posted) {
                 // 没有独立聊天窗的浏览器环境无需等待原生 carrier；本地 React 窗口沿用原行为。
-                const host = window.reactChatWindowHost || null;
                 const wasCollapsed = !!(
-                    host
-                    && typeof host.getChatSurfaceMode === 'function'
-                    && host.getChatSurfaceMode() === 'minimized'
+                    localHost
+                    && typeof localHost.getChatSurfaceMode === 'function'
+                    && localHost.getChatSurfaceMode() === 'minimized'
                 );
-                if (host && typeof host.openWindow === 'function') {
-                    host.openWindow();
+                if (localHost && typeof localHost.openWindow === 'function') {
+                    localHost.openWindow();
                 }
                 finish(true, { wasCollapsed: wasCollapsed });
             }

--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -3402,11 +3402,38 @@ class UniversalTutorialManager {
 
     consumePendingStartupDefaultCatRestoreRequest() {
         const snapshot = this._avatarFloatingModelLockSnapshot;
+        if (!snapshot) {
+            return false;
+        }
+        let startupDefaultCatPending = false;
+        try {
+            const autoGoodbye = window.nekoAutoGoodbye;
+            const currentState = autoGoodbye && typeof autoGoodbye.getState === 'function'
+                ? autoGoodbye.getState()
+                : null;
+            startupDefaultCatPending = !!(
+                currentState && currentState.startupDefaultCatRequested === true
+            );
+            if (startupDefaultCatPending && snapshot.goodbyeActive !== true) {
+                // 默认猫咪事件可能晚于首次快照；在解除教程锁前读取实时 pending 状态，
+                // 仅当原快照不是猫咪态时升级业务形态，保留既有猫咪层级及教程前交互/位置。
+                snapshot.goodbyeActive = true;
+                snapshot.goodbyeMeta = {
+                    autoGoodbye: currentState.autoGoodbyeTriggered === true,
+                    reason: 'startup-default-cat',
+                    visualTier: currentState.visualTier || ''
+                };
+            }
+        } catch (error) {
+            console.warn('[Tutorial] 刷新待恢复的启动默认猫咪状态失败:', error);
+        }
         if (
-            !snapshot
-            || snapshot.goodbyeActive !== true
-            || !snapshot.goodbyeMeta
-            || snapshot.goodbyeMeta.reason !== 'startup-default-cat'
+            !startupDefaultCatPending
+            && (
+                snapshot.goodbyeActive !== true
+                || !snapshot.goodbyeMeta
+                || snapshot.goodbyeMeta.reason !== 'startup-default-cat'
+            )
         ) {
             return false;
         }

--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -3692,6 +3692,17 @@ class UniversalTutorialManager {
             // 必须先让 PC 原生窗口完成毛球→胶囊，再开启固定布局；反过来会让固定锁
             // 与展开请求竞争，表现为教程仍显示毛球或胶囊位置闪烁。
             const compactChatReady = await this.prepareYuiGuideCompactChatForTutorial();
+            if (
+                this._tutorialEndHandled
+                || this._isDestroyed
+                || !this.isTutorialRunning
+                || window.isInTutorial !== true
+            ) {
+                // skip/远程结束可能发生在 prepare 等待期间；迟到回执刚写入的形态快照
+                // 仍需补恢复，但不能再走 catch 重复 teardown，更不能继续固定布局并启动 director。
+                this.restoreYuiGuideCompactChatSurface('tutorial-start-cancelled-after-prepare');
+                return false;
+            }
             if (!compactChatReady) {
                 throw new Error('tutorial_compact_chat_not_ready');
             }

--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -3676,6 +3676,10 @@ class UniversalTutorialManager {
         this.lockBodyScroll();
 
         try {
+            // prepare 已绑定当前教程生命周期；重启教程时聊天桥仍处于上一轮 closed 状态，
+            // 必须先只打开本轮 PC/chat lifecycle，否则 prepare 会被当作迟到消息丢弃。
+            // 用户可见的 tutorial-started 事件仍等胶囊准备成功后再发，避免失败启动被记录为已开始。
+            this.relayYuiGuideTutorialLifecycleStarted('home', source);
             // 必须先让 PC 原生窗口完成毛球→胶囊，再开启固定布局；反过来会让固定锁
             // 与展开请求竞争，表现为教程仍显示毛球或胶囊位置闪烁。
             const compactChatReady = await this.prepareYuiGuideCompactChatForTutorial();
@@ -3687,7 +3691,7 @@ class UniversalTutorialManager {
             }
             this.syncYuiGuideCompactChatFixedLayout(true, 'avatar-floating-guide-start');
             this._tutorialModelPrefix = 'live2d';
-            this.emitTutorialStarted('home', source);
+            this.emitTutorialStarted('home', source, { lifecycleAlreadyStarted: true });
             if (directTutorialBoot) {
                 this.claimDirectAvatarFloatingTutorialBoot(round, source);
             }
@@ -3930,9 +3934,12 @@ class UniversalTutorialManager {
         this._teardownTutorialUI();
     }
 
-    emitTutorialStarted(page = this.currentPage, source = this.currentTutorialStartSource) {
+    emitTutorialStarted(page = this.currentPage, source = this.currentTutorialStartSource, options = {}) {
         this.clearStartupGreetingRelease('tutorial-started');
-        this.relayYuiGuideTutorialLifecycleStarted(page, source);
+        // 胶囊准备链可能已提前打开当前 lifecycle；避免向 chat/pet 重复发送开始消息。
+        if (options.lifecycleAlreadyStarted !== true) {
+            this.relayYuiGuideTutorialLifecycleStarted(page, source);
+        }
         this.syncPcSystemCursorHidden(true, 'tutorial-started');
         window.dispatchEvent(new CustomEvent('neko:tutorial-started', {
             detail: {

--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -1308,11 +1308,6 @@ class UniversalTutorialManager {
     }
 
     ensurePcTutorialGlobalOverlayStarted(reason = 'tutorial-started') {
-        const overlay = window.nekoTutorialOverlay;
-        if (!overlay || typeof overlay.begin !== 'function') {
-            return '';
-        }
-
         let tutorialRunId = '';
         try {
             tutorialRunId = window.localStorage
@@ -1326,6 +1321,13 @@ class UniversalTutorialManager {
                     window.localStorage.setItem('yuiGuidePcOverlayRunId', tutorialRunId);
                 }
             } catch (_) {}
+        }
+
+        const overlay = window.nekoTutorialOverlay;
+        if (!overlay || typeof overlay.begin !== 'function') {
+            // 纯 BroadcastChannel 页面同样需要稳定 runId，才能在上一轮 closed 后
+            // 用 lifecycle-start 重新打开独立聊天页，并过滤迟到的旧教程消息。
+            return tutorialRunId;
         }
 
         try {
@@ -1361,6 +1363,17 @@ class UniversalTutorialManager {
             tutorialRunId: tutorialRunId,
             timestamp: Date.now()
         };
+
+        const channel = window.appInterpage && window.appInterpage.nekoBroadcastChannel;
+        if (channel && typeof channel.postMessage === 'function') {
+            try {
+                // 浏览器独立聊天页没有原生 overlay relay；必须通过同一 BroadcastChannel
+                // 先打开本轮 lifecycle，随后发送的 prepare 才不会被 closed guard 丢弃。
+                channel.postMessage(startedMessage);
+            } catch (error) {
+                console.warn('[Tutorial] 广播 Yui Guide 生命周期开始到独立聊天窗失败:', error);
+            }
+        }
 
         try {
             if (
@@ -3369,10 +3382,12 @@ class UniversalTutorialManager {
             // 让可见形态、锁定状态、返回按钮和 PC 命中区由同一业务链路一致重建。
             window.dispatchEvent(new CustomEvent('live2d-goodbye-click', { detail: restoreDetail }));
             if (
-                goodbyeMeta.visualTier
+                ['cat1', 'cat2', 'cat3'].includes(goodbyeMeta.visualTier)
                 && window.nekoAutoGoodbye
                 && typeof window.nekoAutoGoodbye.setVisualTier === 'function'
             ) {
+                // startup-default-cat 的 pending 快照可能仍是 none；goodbye 事件已经建立 cat1，
+                // 这里只回放真实保存过的猫咪层级，不能再用 none 把刚恢复的猫咪视觉清空。
                 window.nekoAutoGoodbye.setVisualTier(goodbyeMeta.visualTier, {
                     source: 'tutorial-state-restore',
                     reason: restoreDetail.reason

--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -32,6 +32,8 @@ const AVATAR_FLOATING_GUIDE_USAGE_STORAGE_KEY = 'neko_avatar_floating_guide_usag
 const AVATAR_FLOATING_GUIDE_ROUND_COUNT = 7;
 const YUI_GUIDE_CHAT_BRIDGE_QUEUE_KEY = 'neko_yui_guide_chat_bridge_queue_v1';
 const STARTUP_GREETING_RELEASE_EVENT = 'neko:startup-greeting-release';
+// PC 端最长可能先等折叠动画结束再展开；这里额外留出跨窗口转发余量，但不让教程无限等待。
+const YUI_GUIDE_COMPACT_CHAT_PREPARE_TIMEOUT_MS = 4500;
 
 function getTutorialStorageKeyForPage(pageKey) {
     return TUTORIAL_STORAGE_KEY_PREFIX + (pageKey === 'home' ? 'home_yui_v1' : pageKey);
@@ -491,6 +493,8 @@ class UniversalTutorialManager {
         this.currentStep = 0;
         this._tutorialLive2dRenderActivationToken = 0;
         this._avatarFloatingModelLockSnapshot = null;
+        // 记录教程强制展开前是否为毛球，所有结束路径都用它恢复原形态。
+        this._avatarFloatingChatSurfaceSnapshot = null;
         this.cachedValidSteps = null;
         this._pendingI18nStart = false;
         this.pendingTutorialStartSource = null;
@@ -1224,6 +1228,8 @@ class UniversalTutorialManager {
         const director = this.yuiGuideDirector;
         this.syncPcSystemCursorHidden(false, rawReason);
         this.clearYuiGuideCompactChatFixedLayout(rawReason);
+        // 恢复请求必须先于 lifecycle-ended 发出；聊天窗关闭本轮生命周期后会拒绝迟到的教程命令。
+        this.restoreYuiGuideCompactChatSurface(rawReason);
 
         try {
             this.notifyYuiGuideTutorialEnd(rawReason);
@@ -1416,6 +1422,124 @@ class UniversalTutorialManager {
                 console.warn('[Tutorial] 原生转发胶囊聊天框固定布局失败:', error);
             }
         }
+    }
+
+    prepareYuiGuideCompactChatForTutorial() {
+        const requestId = `tutorial-compact-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        const message = {
+            action: 'yui_guide_prepare_compact_chat',
+            requestId: requestId,
+            reason: 'avatar-floating-guide-start',
+            timestamp: Date.now()
+        };
+
+        return new Promise((resolve) => {
+            let settled = false;
+            const finish = (ready, detail) => {
+                if (settled) return;
+                settled = true;
+                window.removeEventListener('neko:yui-guide:compact-chat-ready', handleReady);
+                window.clearTimeout(timeoutId);
+                const response = detail && typeof detail === 'object' ? detail : {};
+                // 只在握手完成后保存启动前形态；上一轮迟到回执不能覆盖本轮恢复目标。
+                this._avatarFloatingChatSurfaceSnapshot = {
+                    requestId: requestId,
+                    wasCollapsed: response.wasCollapsed === true
+                };
+                resolve(ready === true);
+            };
+            const handleReady = (event) => {
+                const detail = event && event.detail && typeof event.detail === 'object'
+                    ? event.detail
+                    : {};
+                if (detail.requestId !== requestId) return;
+                finish(detail.ready !== false, detail);
+            };
+            const timeoutId = window.setTimeout(() => {
+                console.warn('[Tutorial] 等待胶囊聊天框原生展开超时，取消本轮教程启动');
+                finish(false, {});
+            }, YUI_GUIDE_COMPACT_CHAT_PREPARE_TIMEOUT_MS);
+            window.addEventListener('neko:yui-guide:compact-chat-ready', handleReady);
+
+            let posted = false;
+            const channel = window.appInterpage && window.appInterpage.nekoBroadcastChannel;
+            if (channel && typeof channel.postMessage === 'function') {
+                try {
+                    channel.postMessage(message);
+                    posted = true;
+                } catch (error) {
+                    console.warn('[Tutorial] 广播胶囊聊天框准备请求失败:', error);
+                }
+            }
+            if (
+                window.nekoTutorialOverlay
+                && typeof window.nekoTutorialOverlay.relayToChat === 'function'
+            ) {
+                try {
+                    window.nekoTutorialOverlay.relayToChat(message);
+                    posted = true;
+                } catch (error) {
+                    console.warn('[Tutorial] 原生转发胶囊聊天框准备请求失败:', error);
+                }
+            }
+            if (!posted) {
+                // 没有独立聊天窗的浏览器环境无需等待原生 carrier；本地 React 窗口沿用原行为。
+                const host = window.reactChatWindowHost || null;
+                const wasCollapsed = !!(
+                    host
+                    && typeof host.getChatSurfaceMode === 'function'
+                    && host.getChatSurfaceMode() === 'minimized'
+                );
+                if (host && typeof host.openWindow === 'function') {
+                    host.openWindow();
+                }
+                finish(true, { wasCollapsed: wasCollapsed });
+            }
+        });
+    }
+
+    restoreYuiGuideCompactChatSurface(reason = 'tutorial-ended') {
+        const snapshot = this._avatarFloatingChatSurfaceSnapshot;
+        this._avatarFloatingChatSurfaceSnapshot = null;
+        if (!snapshot || snapshot.wasCollapsed !== true) return false;
+
+        const message = {
+            action: 'yui_guide_restore_compact_chat',
+            requestId: snapshot.requestId,
+            wasCollapsed: true,
+            reason: reason,
+            timestamp: Date.now()
+        };
+        let posted = false;
+        const channel = window.appInterpage && window.appInterpage.nekoBroadcastChannel;
+        if (channel && typeof channel.postMessage === 'function') {
+            try {
+                channel.postMessage(message);
+                posted = true;
+            } catch (error) {
+                console.warn('[Tutorial] 广播胶囊聊天框形态恢复失败:', error);
+            }
+        }
+        if (
+            window.nekoTutorialOverlay
+            && typeof window.nekoTutorialOverlay.relayToChat === 'function'
+        ) {
+            try {
+                window.nekoTutorialOverlay.relayToChat(message);
+                posted = true;
+            } catch (error) {
+                console.warn('[Tutorial] 原生转发胶囊聊天框形态恢复失败:', error);
+            }
+        }
+        if (!posted) {
+            const host = window.reactChatWindowHost || null;
+            if (host && typeof host.setChatSurfaceMode === 'function') {
+                // 浏览器内嵌聊天窗没有跨窗口接收端，直接通过同一 surface 状态机恢复毛球。
+                host.setChatSurfaceMode('minimized');
+                return true;
+            }
+        }
+        return posted;
     }
 
     clearPcTutorialGlobalOverlay(reason = 'destroy') {
@@ -3022,6 +3146,12 @@ class UniversalTutorialManager {
         if (this._avatarFloatingModelLockSnapshot) {
             return;
         }
+        let autoGoodbyeState = null;
+        try {
+            autoGoodbyeState = window.nekoAutoGoodbye && typeof window.nekoAutoGoodbye.getState === 'function'
+                ? window.nekoAutoGoodbye.getState()
+                : null;
+        } catch (_) {}
         const readLocked = (manager, fallback) => {
             if (manager && typeof manager.isLocked !== 'undefined') {
                 return !!manager.isLocked;
@@ -3035,6 +3165,9 @@ class UniversalTutorialManager {
             const element = document.getElementById(elementId);
             return element ? element.style.pointerEvents : '';
         };
+        const startupDefaultCatPending = !!(
+            autoGoodbyeState && autoGoodbyeState.startupDefaultCatRequested === true
+        );
         this._avatarFloatingModelLockSnapshot = {
             live2d: readLocked(window.live2dManager),
             vrm: readLocked(window.vrmManager, window.vrmManager && window.vrmManager.interaction),
@@ -3050,6 +3183,32 @@ class UniversalTutorialManager {
                 pngtuberCanvas: readPointerEvents('pngtuber-canvas'),
                 pngtuberContainer: readPointerEvents('pngtuber-container')
             },
+            // 猫咪/告别态是业务形态，不能只靠 pointer-events 快照推断；模型重载会清掉 manager 标志。
+            goodbyeActive: !!(
+                (window.live2dManager && window.live2dManager._goodbyeClicked)
+                || (window.vrmManager && window.vrmManager._goodbyeClicked)
+                || (window.mmdManager && window.mmdManager._goodbyeClicked)
+                // 冷启动直进教程时 manager 标志可能尚未建立，auto-goodbye 的视觉层级仍是可靠业务状态。
+                || (autoGoodbyeState && autoGoodbyeState.visualTier && autoGoodbyeState.visualTier !== 'none')
+                // PC 冷启动直进教程会跳过用户模型；此时“默认猫咪”只有待执行请求，还没有可见猫咪态。
+                || startupDefaultCatPending
+            ),
+            goodbyeMeta: autoGoodbyeState && typeof autoGoodbyeState === 'object'
+                ? {
+                    autoGoodbye: autoGoodbyeState.autoGoodbyeTriggered === true,
+                    // 待执行的启动默认形态是明确的产品状态，优先于尚未进入猫咪态时的 started 等临时原因。
+                    reason: startupDefaultCatPending ? 'startup-default-cat' : (autoGoodbyeState.lastReason || ''),
+                    visualTier: autoGoodbyeState.visualTier || ''
+                }
+                : null,
+            goodbyeRect: window._savedGoodbyeRect
+                ? {
+                    left: Number(window._savedGoodbyeRect.left),
+                    top: Number(window._savedGoodbyeRect.top),
+                    width: Number(window._savedGoodbyeRect.width),
+                    height: Number(window._savedGoodbyeRect.height)
+                }
+                : null,
             reason
         };
     }
@@ -3071,6 +3230,11 @@ class UniversalTutorialManager {
     restoreAvatarFloatingModelInteractionState(reason = 'tutorial-ended') {
         const snapshot = this._avatarFloatingModelLockSnapshot;
         if (!snapshot) {
+            return;
+        }
+        if (reason === 'teardown-early' && snapshot.goodbyeActive === true) {
+            // 猫咪态的锁定属性属于隐藏模型；必须等用户模型重载完成并重新进入猫咪态，
+            // 不能提前把 pointer-events:none 套到仍在退场的教程模型上。
             return;
         }
         try {
@@ -3136,6 +3300,47 @@ class UniversalTutorialManager {
             restoreAvatarPointerEvents(element, elementId, snapshotPointerEvents, hasSnapshotPointerEvents);
         });
         if (reason === 'tutorial-avatar-restored') {
+            this._avatarFloatingModelLockSnapshot = null;
+        }
+    }
+
+    restoreAvatarFloatingModelStateAfterTutorial() {
+        const snapshot = this._avatarFloatingModelLockSnapshot;
+        if (!snapshot || snapshot.goodbyeActive !== true) {
+            this.restoreAvatarFloatingModelInteractionState('tutorial-avatar-restored');
+            return false;
+        }
+
+        const goodbyeMeta = snapshot.goodbyeMeta || {};
+        const restoreDetail = {
+            source: 'tutorial-state-restore',
+            reason: goodbyeMeta.reason || 'tutorial-state-restore',
+            // 重新进入猫咪态时保留教程前的返回按钮锚点，不使用教程临时模型站位。
+            restoreSavedGoodbyeRect: snapshot.goodbyeRect || null
+        };
+        if (goodbyeMeta.autoGoodbye === true) {
+            restoreDetail.autoGoodbye = true;
+        } else if (goodbyeMeta.reason === 'startup-default-cat') {
+            restoreDetail.startupDefaultForm = 'cat';
+        }
+
+        try {
+            // 模型重载只恢复角色资源，不会恢复猫咪/告别表现；重新走既有 goodbye 入口，
+            // 让可见形态、锁定状态、返回按钮和 PC 命中区由同一业务链路一致重建。
+            window.dispatchEvent(new CustomEvent('live2d-goodbye-click', { detail: restoreDetail }));
+            if (
+                goodbyeMeta.visualTier
+                && window.nekoAutoGoodbye
+                && typeof window.nekoAutoGoodbye.setVisualTier === 'function'
+            ) {
+                window.nekoAutoGoodbye.setVisualTier(goodbyeMeta.visualTier, {
+                    source: 'tutorial-state-restore',
+                    reason: restoreDetail.reason
+                });
+            }
+            return true;
+        } finally {
+            // 业务形态已接管交互恢复，不能再把旧 DOM 的 pointer-events 快照重复应用到新模型。
             this._avatarFloatingModelLockSnapshot = null;
         }
     }
@@ -3417,17 +3622,24 @@ class UniversalTutorialManager {
         this.isTutorialRunning = true;
         window.isInTutorial = true;
         this.lockBodyScroll();
-        if (document.body) {
-            document.body.classList.add('yui-guide-compact-chat-fixed');
-        }
-        this.syncYuiGuideCompactChatFixedLayout(true, 'avatar-floating-guide-start');
-        this._tutorialModelPrefix = 'live2d';
-        this.emitTutorialStarted('home', source);
-        if (directTutorialBoot) {
-            this.claimDirectAvatarFloatingTutorialBoot(round, source);
-        }
 
         try {
+            // 必须先让 PC 原生窗口完成毛球→胶囊，再开启固定布局；反过来会让固定锁
+            // 与展开请求竞争，表现为教程仍显示毛球或胶囊位置闪烁。
+            const compactChatReady = await this.prepareYuiGuideCompactChatForTutorial();
+            if (!compactChatReady) {
+                throw new Error('tutorial_compact_chat_not_ready');
+            }
+            if (document.body) {
+                document.body.classList.add('yui-guide-compact-chat-fixed');
+            }
+            this.syncYuiGuideCompactChatFixedLayout(true, 'avatar-floating-guide-start');
+            this._tutorialModelPrefix = 'live2d';
+            this.emitTutorialStarted('home', source);
+            if (directTutorialBoot) {
+                this.claimDirectAvatarFloatingTutorialBoot(round, source);
+            }
+
             const director = this.ensureYuiGuideDirector();
             if (!director || typeof director.playAvatarFloatingRound !== 'function') {
                 throw new Error('avatar_floating_director_unavailable');
@@ -4040,7 +4252,8 @@ class UniversalTutorialManager {
         const teardownPromise = Promise.resolve()
             .then(() => this.restoreTutorialAvatarOverride())
             .then(() => this.clearTutorialYuiLive2dRuntimeResidue('tutorial-avatar-restored'))
-            .then(() => this.restoreAvatarFloatingModelInteractionState('tutorial-avatar-restored'))
+            // 用户模型恢复后再按教程前的业务形态恢复；猫咪态不能只回放旧 DOM 的点击穿透属性。
+            .then(() => this.restoreAvatarFloatingModelStateAfterTutorial())
             .catch(error => {
                 console.warn('[Tutorial] 拆除引导时恢复头像失败:', error);
             })

--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -3742,6 +3742,11 @@ class UniversalTutorialManager {
         this.lockBodyScroll();
 
         try {
+            if (directTutorialBoot) {
+                // 自动 round 已预留后，预测状态可能不再阻止用户模型初始化；必须在任何新的 await
+                // 之前建立 direct-boot claim，覆盖胶囊 prepare 等待窗口，避免用户模型盖住教程模型。
+                this.claimDirectAvatarFloatingTutorialBoot(round, source);
+            }
             // prepare 已绑定当前教程生命周期；重启教程时聊天桥仍处于上一轮 closed 状态，
             // 必须先只打开本轮 PC/chat lifecycle，否则 prepare 会被当作迟到消息丢弃。
             // 用户可见的 tutorial-started 事件仍等胶囊准备成功后再发，避免失败启动被记录为已开始。
@@ -3758,6 +3763,14 @@ class UniversalTutorialManager {
                 // skip/远程结束可能发生在 prepare 等待期间；迟到回执刚写入的形态快照
                 // 仍需补恢复，但不能再走 catch 重复 teardown，更不能继续固定布局并启动 director。
                 this.restoreYuiGuideCompactChatSurface('tutorial-start-cancelled-after-prepare');
+                if (directTutorialBoot) {
+                    // teardown 已接管取消流程；这里只释放提前建立的 claim，并保留已跳过模型标记，
+                    // 让调用方既有的 result=false recovery 在拆除后恢复用户模型。
+                    this.releaseDirectAvatarFloatingTutorialBoot('avatar-floating-start-cancelled', {
+                        keepUserModelBootSkipped: true,
+                        suppressPrediction: true
+                    });
+                }
                 return false;
             }
             if (!compactChatReady) {
@@ -3769,9 +3782,6 @@ class UniversalTutorialManager {
             this.syncYuiGuideCompactChatFixedLayout(true, 'avatar-floating-guide-start');
             this._tutorialModelPrefix = 'live2d';
             this.emitTutorialStarted('home', source, { lifecycleAlreadyStarted: true });
-            if (directTutorialBoot) {
-                this.claimDirectAvatarFloatingTutorialBoot(round, source);
-            }
 
             const director = this.ensureYuiGuideDirector();
             if (!director || typeof director.playAvatarFloatingRound !== 'function') {

--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -1432,8 +1432,8 @@ class UniversalTutorialManager {
                 ? (window.localStorage.getItem('yuiGuidePcOverlayRunId') || '')
                 : '';
             if (!tutorialRunId) {
-                // prepare 早于 lifecycle-start relay，必须在排队前给本轮生成稳定 runId；
-                // PC 才能让迟到的旧 lifecycle-ended 只清理旧教程请求。
+                // 正常入口会复用 lifecycle-start 创建的 runId；独立调用或旧入口缺失时仍需
+                // 在排队前补一个稳定 id，让迟到的旧 lifecycle-ended 只清理旧教程请求。
                 tutorialRunId = 'yui-guide-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2);
                 if (window.localStorage) {
                     window.localStorage.setItem('yuiGuidePcOverlayRunId', tutorialRunId);
@@ -1450,6 +1450,7 @@ class UniversalTutorialManager {
 
         return new Promise((resolve) => {
             let settled = false;
+            let posted = false;
             const finish = (ready, detail) => {
                 if (settled) return;
                 settled = true;
@@ -1459,7 +1460,10 @@ class UniversalTutorialManager {
                 // 只在握手完成后保存启动前形态；上一轮迟到回执不能覆盖本轮恢复目标。
                 this._avatarFloatingChatSurfaceSnapshot = {
                     requestId: requestId,
-                    wasCollapsed: response.wasCollapsed === true
+                    wasCollapsed: response.wasCollapsed === true,
+                    // 超时只说明主页没收到回执；聊天窗可能已保存真实形态并仍在异步展开。
+                    // teardown 通过同一 requestId 请求它按自己的 prepare 快照恢复，避免主页猜测。
+                    restoreFromPrepareSnapshot: response.restoreFromPrepareSnapshot === true
                 };
                 resolve(ready === true);
             };
@@ -1472,7 +1476,7 @@ class UniversalTutorialManager {
             };
             const timeoutId = window.setTimeout(() => {
                 console.warn('[Tutorial] 等待胶囊聊天框原生展开超时，取消本轮教程启动');
-                finish(false, {});
+                finish(false, { restoreFromPrepareSnapshot: posted });
             }, YUI_GUIDE_COMPACT_CHAT_PREPARE_TIMEOUT_MS);
             window.addEventListener('neko:yui-guide:compact-chat-ready', handleReady);
 
@@ -1493,7 +1497,6 @@ class UniversalTutorialManager {
                 return;
             }
 
-            let posted = false;
             const channel = window.appInterpage && window.appInterpage.nekoBroadcastChannel;
             if (channel && typeof channel.postMessage === 'function') {
                 try {
@@ -1532,12 +1535,17 @@ class UniversalTutorialManager {
     restoreYuiGuideCompactChatSurface(reason = 'tutorial-ended') {
         const snapshot = this._avatarFloatingChatSurfaceSnapshot;
         this._avatarFloatingChatSurfaceSnapshot = null;
-        if (!snapshot || snapshot.wasCollapsed !== true) return false;
+        if (!snapshot || (
+            snapshot.wasCollapsed !== true
+            && snapshot.restoreFromPrepareSnapshot !== true
+        )) return false;
 
         const message = {
             action: 'yui_guide_restore_compact_chat',
             requestId: snapshot.requestId,
-            wasCollapsed: true,
+            wasCollapsed: snapshot.wasCollapsed === true,
+            // prepare 超时后由聊天窗使用同 request 的本地快照决定是否需要折叠。
+            restoreFromPrepareSnapshot: snapshot.restoreFromPrepareSnapshot === true,
             reason: reason,
             timestamp: Date.now()
         };
@@ -1562,10 +1570,11 @@ class UniversalTutorialManager {
                 console.warn('[Tutorial] 原生转发胶囊聊天框形态恢复失败:', error);
             }
         }
-        if (!posted) {
+        if (!posted && snapshot.wasCollapsed === true) {
             const host = window.reactChatWindowHost || null;
             if (host && typeof host.setChatSurfaceMode === 'function') {
-                // 浏览器内嵌聊天窗没有跨窗口接收端，直接通过同一 surface 状态机恢复毛球。
+                // 只有明确回执过毛球状态才能走本地 fallback；超时未知状态必须由
+                // 保存过 prepare 快照的独立聊天窗判断，主页不能猜测并强制折叠。
                 host.setChatSurfaceMode('minimized');
                 return true;
             }

--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -1474,6 +1474,9 @@ class UniversalTutorialManager {
                 this._avatarFloatingChatSurfaceSnapshot = {
                     requestId: requestId,
                     wasCollapsed: response.wasCollapsed === true,
+                    // 浏览器主页可能同时准备本地 host 并广播给独立 /chat；恢复时必须区分两者，
+                    // 不能因 BroadcastChannel 已发送就跳过本地毛球形态的恢复。
+                    localHostPrepared: response.localHostPrepared === true,
                     // 超时只说明主页没收到回执；聊天窗可能已保存真实形态并仍在异步展开。
                     // teardown 通过同一 requestId 请求它按自己的 prepare 快照恢复，避免主页猜测。
                     restoreFromPrepareSnapshot: response.restoreFromPrepareSnapshot === true
@@ -1493,6 +1496,18 @@ class UniversalTutorialManager {
             }, YUI_GUIDE_COMPACT_CHAT_PREPARE_TIMEOUT_MS);
             window.addEventListener('neko:yui-guide:compact-chat-ready', handleReady);
 
+            const channel = window.appInterpage && window.appInterpage.nekoBroadcastChannel;
+            if (channel && typeof channel.postMessage === 'function') {
+                try {
+                    // BroadcastChannel 是否有接收端无法从主页判断；先发送给可能存在的独立 /chat，
+                    // 再由下方本地 fallback 决定是否需要等待回执。
+                    channel.postMessage(message);
+                    posted = true;
+                } catch (error) {
+                    console.warn('[Tutorial] 广播胶囊聊天框准备请求失败:', error);
+                }
+            }
+
             const localHost = window.reactChatWindowHost || null;
             const hasNativeChatRelay = !!(
                 window.nekoTutorialOverlay
@@ -1506,19 +1521,16 @@ class UniversalTutorialManager {
                     && localHost.getChatSurfaceMode() === 'minimized'
                 );
                 localHost.openWindow();
-                finish(true, { wasCollapsed: wasCollapsed });
+                finish(true, {
+                    wasCollapsed: wasCollapsed,
+                    localHostPrepared: true,
+                    // 若独立 /chat 实际存在，它已按同 requestId 保存自己的折叠快照；
+                    // teardown 仍要广播恢复，但单窗口页面不等待一个不存在的回执。
+                    restoreFromPrepareSnapshot: posted
+                });
                 return;
             }
 
-            const channel = window.appInterpage && window.appInterpage.nekoBroadcastChannel;
-            if (channel && typeof channel.postMessage === 'function') {
-                try {
-                    channel.postMessage(message);
-                    posted = true;
-                } catch (error) {
-                    console.warn('[Tutorial] 广播胶囊聊天框准备请求失败:', error);
-                }
-            }
             if (
                 window.nekoTutorialOverlay
                 && typeof window.nekoTutorialOverlay.relayToChat === 'function'
@@ -1583,11 +1595,14 @@ class UniversalTutorialManager {
                 console.warn('[Tutorial] 原生转发胶囊聊天框形态恢复失败:', error);
             }
         }
-        if (!posted && snapshot.wasCollapsed === true) {
+        if (
+            snapshot.wasCollapsed === true
+            && (snapshot.localHostPrepared === true || !posted)
+        ) {
             const host = window.reactChatWindowHost || null;
             if (host && typeof host.setChatSurfaceMode === 'function') {
-                // 只有明确回执过毛球状态才能走本地 fallback；超时未知状态必须由
-                // 保存过 prepare 快照的独立聊天窗判断，主页不能猜测并强制折叠。
+                // 只恢复明确由主页准备过、或完全没有 carrier 的本地毛球；外部回执/超时
+                // 仍由保存过 prepare 快照的独立聊天窗判断，主页不能猜测并强制折叠。
                 host.setChatSurfaceMode('minimized');
                 return true;
             }

--- a/static/yui-guide-common.test.cjs
+++ b/static/yui-guide-common.test.cjs
@@ -2623,7 +2623,11 @@ test('tutorial skip button reuses the manager tutorial end lifecycle', () => {
     assert.match(managerSource, /modelType === 'live3d'/);
     assert.match(managerSource, /live3d_sub_type/);
     assert.match(teardownBlock, /this\.restoreAvatarFloatingModelInteractionState\('teardown-early'\);/);
-    assert.match(teardownBlock, /\.then\(\(\) => this\.restoreAvatarFloatingModelInteractionState\('tutorial-avatar-restored'\)\)/);
+    // 最终恢复必须先判断猫咪业务形态，不能把旧 DOM 的穿透样式直接应用到重载后的模型。
+    assert.match(teardownBlock, /\.then\(\(\) => this\.restoreAvatarFloatingModelStateAfterTutorial\(\)\)/);
+    assert.match(managerSource, /goodbyeActive:/);
+    assert.match(avatarInteractionRestoreBlock, /window\.dispatchEvent\(new CustomEvent\('live2d-goodbye-click'/);
+    assert.match(avatarInteractionRestoreBlock, /this\._avatarFloatingModelLockSnapshot = null;/);
     assert.doesNotMatch(routerBlock, /requestAvatarFloatingGuideCooperativeEnd\(finalReason\)/);
     assert.match(routerBlock, /return director\.tutorialManager\.requestTutorialEnd\(finalReason\);/);
     assert.match(routerBlock, /return director\.tutorialManager\.requestTutorialDestroy\(finalReason\);/);

--- a/static/yui-guide-common.test.cjs
+++ b/static/yui-guide-common.test.cjs
@@ -345,7 +345,7 @@ test('common helper creates a PC overlay run id before tutorial lifecycle start'
 
 test('tutorial start activates PC lifecycle before hiding the system cursor', () => {
     const managerSource = fs.readFileSync(path.join(repoRoot, 'static', 'tutorial/core/universal-manager.js'), 'utf8');
-    const emitBlock = managerSource.split('    emitTutorialStarted(page = this.currentPage, source = this.currentTutorialStartSource) {')[1].split(
+    const emitBlock = managerSource.split('    emitTutorialStarted(page = this.currentPage, source = this.currentTutorialStartSource, options = {}) {')[1].split(
         '    logPromptFlow',
         1
     )[0];

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -1961,6 +1961,16 @@ def test_avatar_floating_direct_tutorial_boot_uses_manager_recheck_and_user_mode
     assert "await this.waitForTutorialModelHostReady()" in start_round_block
     assert "await this.waitForFloatingButtons()" in start_round_block
     assert "this.claimDirectAvatarFloatingTutorialBoot(round, source);" in start_round_block
+    # round 预留会改变预测结果；direct-boot claim 必须覆盖胶囊 prepare 的异步等待窗口。
+    assert start_round_block.index("this.claimDirectAvatarFloatingTutorialBoot(round, source);") < start_round_block.index(
+        "await this.prepareYuiGuideCompactChatForTutorial()"
+    )
+    # prepare 期间取消时释放提前 claim，但保留已跳过用户模型的恢复标记。
+    cancellation_release_index = start_round_block.index(
+        "this.releaseDirectAvatarFloatingTutorialBoot('avatar-floating-start-cancelled', {"
+    )
+    assert "keepUserModelBootSkipped: true" in start_round_block[cancellation_release_index:]
+    assert "suppressPrediction: true" in start_round_block[cancellation_release_index:]
     assert "skipSourceModelFade: directTutorialBoot" in start_round_block
     assert "clearDirectAvatarFloatingTutorialLoading" not in start_round_block
     assert "await this.recoverUserModelAfterDirectTutorialBootFailure('avatar-floating-start-failed')" in start_round_block

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -1514,13 +1514,14 @@ def test_home_yui_guide_avatar_override_does_not_persist_tutorial_model():
     assert avatar_interaction_restore_block.index("const isActiveAvatarContainer = elementId === `${activePrefix}-container`;") < avatar_interaction_restore_block.index("if (hasSnapshotPointerEvents && snapshotPointerEvents) {")
     assert "this.restoreAvatarFloatingModelInteractionState('teardown-early');" in tutorial_source
     assert ".then(() => this.clearTutorialYuiLive2dRuntimeResidue('tutorial-avatar-restored'))" in tutorial_source
-    assert ".then(() => this.restoreAvatarFloatingModelInteractionState('tutorial-avatar-restored'))" in tutorial_source
+    # 最终恢复统一按业务形态分流：普通模型回放交互快照，猫咪态重走 goodbye 链路。
+    assert ".then(() => this.restoreAvatarFloatingModelStateAfterTutorial())" in tutorial_source
     assert tutorial_source.index(".then(() => this.restoreTutorialAvatarOverride())") < tutorial_source.index(
         ".then(() => this.clearTutorialYuiLive2dRuntimeResidue('tutorial-avatar-restored'))"
     )
     assert tutorial_source.index(
         ".then(() => this.clearTutorialYuiLive2dRuntimeResidue('tutorial-avatar-restored'))"
-    ) < tutorial_source.index(".then(() => this.restoreAvatarFloatingModelInteractionState('tutorial-avatar-restored'))")
+    ) < tutorial_source.index(".then(() => this.restoreAvatarFloatingModelStateAfterTutorial())")
     assert "async clearTutorialYuiLive2dRuntimeResidue(reason = '')" in tutorial_source
     assert "this.isCurrentRuntimeModelLive2d()" in tutorial_source
     assert "await manager.removeModel({ skipCloseWindows: true });" in tutorial_source
@@ -1983,7 +1984,8 @@ def test_avatar_floating_direct_tutorial_boot_uses_manager_recheck_and_user_mode
     )[0]
     assert "this.dispatchAvatarFloatingTutorialInputRestored(" in tutorial_source
     assert "neko:yui-guide:tutorial-input-restored" in tutorial_source
-    assert teardown_block.index("this.restoreAvatarFloatingModelInteractionState('tutorial-avatar-restored')") < teardown_block.index(
+    # 输入区域刷新必须发生在模型身份和猫咪/普通业务形态都恢复完成之后。
+    assert teardown_block.index("this.restoreAvatarFloatingModelStateAfterTutorial()") < teardown_block.index(
         "this.dispatchAvatarFloatingTutorialInputRestored("
     )
 

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -1969,8 +1969,10 @@ def test_avatar_floating_direct_tutorial_boot_uses_manager_recheck_and_user_mode
     cancellation_release_index = start_round_block.index(
         "this.releaseDirectAvatarFloatingTutorialBoot('avatar-floating-start-cancelled', {"
     )
-    assert "keepUserModelBootSkipped: true" in start_round_block[cancellation_release_index:]
-    assert "suppressPrediction: true" in start_round_block[cancellation_release_index:]
+    # 只检查取消分支的当前 release 调用，避免误命中后续正常 teardown 的同名参数。
+    cancellation_release_block = start_round_block[cancellation_release_index:].split("});", 1)[0]
+    assert "keepUserModelBootSkipped: true" in cancellation_release_block
+    assert "suppressPrediction: true" in cancellation_release_block
     assert "skipSourceModelFade: directTutorialBoot" in start_round_block
     assert "clearDirectAvatarFloatingTutorialLoading" not in start_round_block
     assert "await this.recoverUserModelAfterDirectTutorialBootFailure('avatar-floating-start-failed')" in start_round_block

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -1379,6 +1379,8 @@ def test_yui_guide_compact_chat_fixed_layout_is_bridged_to_standalone_chat_body(
     assert "case 'yui_guide_set_compact_chat_fixed_layout':" in broadcast_block
     assert "applyYuiGuideCompactChatFixedLayout(event.data.fixed === true);" in broadcast_block
     assert "case 'yui_guide_set_compact_chat_fixed_layout':" in scoped_block
+    # prepare 会建立本轮教程的胶囊恢复快照，也必须拒绝旧 run 的迟到消息。
+    assert "case 'yui_guide_prepare_compact_chat':" in scoped_block
     assert "applyYuiGuideCompactChatFixedLayout(false);" in cleanup_block
 
 

--- a/tests/unit/test_startup_default_cat_static.py
+++ b/tests/unit/test_startup_default_cat_static.py
@@ -1,3 +1,7 @@
+import json
+import shutil
+import subprocess
+import textwrap
 from pathlib import Path
 
 
@@ -20,6 +24,8 @@ def test_startup_default_cat_retry_is_deferred_and_user_actions_cancel_it():
     source = APP_AUTO_GOODBYE.read_text(encoding="utf-8")
 
     assert "if (!state.started)" in source
+    assert "isTutorialGuardActive()" in source
+    assert "window.isNekoHomeTutorialPending === true" in source
     assert "cancelStartupDefaultCatRequest(false);" in source
     assert "detail.startupDefaultForm !== 'cat' && state.startupDefaultCatRequested" in source
     assert "const handleReturn = () => {\n            // Returning" in source
@@ -33,3 +39,78 @@ def test_startup_default_cat_is_cat1_and_has_a_distinct_silence_reason():
     assert "state.lastReason = isStartupDefaultCat ? 'startup-default-cat' : 'manual-goodbye';" in source
     assert "source: isStartupDefaultCat ? 'startup-default-form' : 'manual-goodbye'" in source
     assert "setVisualTier(TIER_CAT1" in source
+
+
+def test_startup_default_cat_request_survives_tutorial_and_runs_after_unlock():
+    node = shutil.which("node")
+    if not node:
+        raise AssertionError("node is required to run startup default cat harness")
+
+    # 复现 PC 冷启动直进教程：默认猫咪信号先到，但教程临时 YUI 按钮已经存在。
+    script = textwrap.dedent(
+        f"""
+        const fs = require('node:fs');
+        const vm = require('node:vm');
+        const source = fs.readFileSync({json.dumps(str(APP_AUTO_GOODBYE))}, 'utf8');
+        const listeners = new Map();
+        const timers = [];
+        const goodbyeEvents = [];
+        class CustomEvent {{
+          constructor(type, init = {{}}) {{ this.type = type; this.detail = init.detail; }}
+        }}
+        const window = {{
+          location: {{ pathname: '/' }},
+          appConst: {{}},
+          appState: {{ socket: {{ readyState: 0, send() {{}} }} }},
+          live2dManager: {{ _goodbyeClicked: false }},
+          vrmManager: {{ _goodbyeClicked: false }},
+          mmdManager: {{ _goodbyeClicked: false }},
+          isInTutorial: true,
+          isNekoHomeTutorialPending: true,
+          addEventListener(type, handler) {{
+            if (!listeners.has(type)) listeners.set(type, []);
+            listeners.get(type).push(handler);
+          }},
+          dispatchEvent(event) {{
+            for (const handler of listeners.get(event.type) || []) handler(event);
+          }},
+          setTimeout(handler) {{ timers.push(handler); return timers.length; }},
+          clearTimeout() {{}},
+          setInterval() {{ return 1; }},
+          clearInterval() {{}},
+          waitForStorageLocationStartupBarrier() {{ return Promise.resolve(); }},
+        }};
+        const tutorialButton = {{}};
+        const document = {{
+          readyState: 'complete',
+          body: {{ classList: {{ contains() {{ return false; }} }} }},
+          addEventListener() {{}},
+          getElementById(id) {{ return id === 'resetSessionButton' ? {{}} : null; }},
+          querySelector(selector) {{ return selector.includes('#live2d-btn-goodbye') ? tutorialButton : null; }},
+        }};
+        window.document = document;
+        window.addEventListener('live2d-goodbye-click', (event) => {{
+          goodbyeEvents.push(event.detail);
+          window.live2dManager._goodbyeClicked = true;
+        }});
+        vm.runInNewContext(source, {{ window, document, CustomEvent, WebSocket: {{ OPEN: 1 }}, console, Date, Math, Promise, Set }});
+
+        Promise.resolve().then(() => Promise.resolve()).then(() => {{
+          window.dispatchEvent(new CustomEvent('neko:startup-default-form', {{ detail: {{ form: 'cat' }} }}));
+          if (goodbyeEvents.length !== 0) throw new Error('tutorial consumed startup cat request');
+          if (window.nekoAutoGoodbye.getState().startupDefaultCatRequested !== true) {{
+            throw new Error('startup cat request was not kept pending');
+          }}
+          window.isInTutorial = false;
+          window.isNekoHomeTutorialPending = false;
+          const retry = timers.shift();
+          if (typeof retry !== 'function') throw new Error('missing deferred retry');
+          retry();
+          if (goodbyeEvents.length !== 1 || goodbyeEvents[0].startupDefaultForm !== 'cat') {{
+            throw new Error('startup cat request did not run after tutorial unlock');
+          }}
+        }}).catch((error) => {{ console.error(error); process.exitCode = 1; }});
+        """
+    )
+    result = subprocess.run([node, "-e", script], capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stderr or result.stdout

--- a/tests/unit/test_startup_default_cat_static.py
+++ b/tests/unit/test_startup_default_cat_static.py
@@ -30,6 +30,8 @@ def test_startup_default_cat_retry_is_deferred_and_user_actions_cancel_it():
     assert "detail.startupDefaultForm !== 'cat' && state.startupDefaultCatRequested" in source
     assert "const handleReturn = () => {\n            // Returning" in source
     assert "cancelStartupDefaultCatRequest(true);" in source
+    assert "function consumeStartupDefaultCatRequest()" in source
+    assert "consumeStartupDefaultCatRequest: consumeStartupDefaultCatRequest" in source
 
 
 def test_startup_default_cat_is_cat1_and_has_a_distinct_silence_reason():

--- a/tests/unit/test_universal_tutorial_manager_static.py
+++ b/tests/unit/test_universal_tutorial_manager_static.py
@@ -924,6 +924,15 @@ def test_avatar_floating_guide_restores_goodbye_business_state_after_model_reloa
         "    applyTutorialChatIdentityOverride(detail) {",
         1,
     )[0]
+    # 默认猫咪事件可能晚于首个快照；teardown 必须在解锁前按实时状态升级原始快照。
+    assert "currentState.startupDefaultCatRequested === true" in consume_block
+    assert "startupDefaultCatPending && snapshot.goodbyeActive !== true" in consume_block
+    assert consume_block.index("snapshot.goodbyeActive = true") < consume_block.index(
+        "snapshot.goodbyeMeta.reason !== 'startup-default-cat'"
+    )
+    assert "reason: 'startup-default-cat'" in consume_block
+    # 原快照已是猫咪态时保留其层级，但实时 pending 仍必须进入消费链。
+    assert "!startupDefaultCatPending" in consume_block
     assert "snapshot.goodbyeMeta.reason !== 'startup-default-cat'" in consume_block
     assert "autoGoodbye.consumeStartupDefaultCatRequest()" in consume_block
     assert teardown_block.index("this.consumePendingStartupDefaultCatRestoreRequest()") < teardown_block.index(

--- a/tests/unit/test_universal_tutorial_manager_static.py
+++ b/tests/unit/test_universal_tutorial_manager_static.py
@@ -29,6 +29,7 @@ FLOATING_GUIDE_RESET_PATH = (
 CHARACTER_PERSONALITY_ONBOARDING_PATH = (
     Path(__file__).resolve().parents[2] / "static" / "js/character_personality_onboarding.js"
 )
+APP_INTERPAGE_PARTS_PATH = Path(__file__).resolve().parents[2] / "static" / "app" / "app-interpage"
 
 
 def _read_manager() -> str:
@@ -818,6 +819,75 @@ def test_avatar_floating_guide_lifecycle_toggles_compact_chat_fixed_layout_class
     assert "this.syncYuiGuideCompactChatFixedLayout(false, reason)" in clear_method_block
     assert "action: 'yui_guide_set_compact_chat_fixed_layout'" in source
     assert "window.nekoTutorialOverlay.relayToChat(message)" in source
+
+
+def test_avatar_floating_guide_waits_for_compact_chat_before_fixing_layout_and_restores_ball():
+    source = _read_manager()
+    start_round_block = source.split("    async startAvatarFloatingGuideRound(day, options = {}) {", 1)[1].split(
+        "            const director = this.ensureYuiGuideDirector();",
+        1,
+    )[0]
+    lifecycle_block = source.split("    clearAllTutorialLifecycles(reason = 'destroy') {", 1)[1].split(
+        "    normalizeTutorialEndRawReason(reason) {",
+        1,
+    )[0]
+
+    # 原生毛球必须先展开并回执，随后才允许教程固定胶囊位置。
+    assert start_round_block.index("await this.prepareYuiGuideCompactChatForTutorial()") < start_round_block.index(
+        "this.syncYuiGuideCompactChatFixedLayout(true, 'avatar-floating-guide-start')"
+    )
+    assert "action: 'yui_guide_prepare_compact_chat'" in source
+    assert "neko:yui-guide:compact-chat-ready" in source
+    assert "wasCollapsed: response.wasCollapsed === true" in source
+    # 所有结束方式都经过 clearAllTutorialLifecycles，因此形态恢复不能只挂在 skip 或 complete 分支。
+    assert lifecycle_block.index("this.clearYuiGuideCompactChatFixedLayout(rawReason)") < lifecycle_block.index(
+        "this.restoreYuiGuideCompactChatSurface(rawReason)"
+    )
+    assert "action: 'yui_guide_restore_compact_chat'" in source
+
+
+def test_avatar_floating_guide_restores_goodbye_business_state_after_model_reload():
+    source = _read_manager()
+    repo_root = Path(__file__).resolve().parents[2]
+    app_ui_source = read_js_parts(repo_root / "static/app/app-ui")
+    teardown_block = source.split("    _teardownTutorialUI() {", 1)[1].split(
+        "    /**\n     * 恢复所有在引导中修改过的元素",
+        1,
+    )[0]
+    restore_state_block = source.split("    restoreAvatarFloatingModelStateAfterTutorial() {", 1)[1].split(
+        "    applyTutorialChatIdentityOverride(detail) {",
+        1,
+    )[0]
+
+    # 用户模型先恢复，随后才重新进入教程前的猫咪形态，避免点击穿透状态套到普通模型上。
+    assert teardown_block.index("this.restoreTutorialAvatarOverride()") < teardown_block.index(
+        "this.restoreAvatarFloatingModelStateAfterTutorial()"
+    )
+    assert "snapshot.goodbyeActive !== true" in restore_state_block
+    # 直启教程没有用户模型可供读取，待执行的 PC 默认猫咪请求也必须成为恢复目标。
+    assert "autoGoodbyeState.startupDefaultCatRequested === true" in source
+    assert "startupDefaultCatPending ? 'startup-default-cat'" in source
+    assert "new CustomEvent('live2d-goodbye-click'" in restore_state_block
+    assert "restoreSavedGoodbyeRect: snapshot.goodbyeRect || null" in restore_state_block
+    assert "this._avatarFloatingModelLockSnapshot = null" in restore_state_block
+    assert "const requestedRestoreRect = event && event.detail && event.detail.restoreSavedGoodbyeRect" in app_ui_source
+
+
+def test_external_chat_prepares_native_capsule_and_restores_previous_ball_state():
+    source = (APP_INTERPAGE_PARTS_PATH / "guide-message-relay.js").read_text(encoding="utf-8")
+    native_relay_source = (APP_INTERPAGE_PARTS_PATH / "cross-window-broadcast-and-bridge.js").read_text(
+        encoding="utf-8"
+    )
+
+    # 两种跨窗口传输路径必须落到同一实现，重复 relay 也只能启动一次原生展开动画。
+    assert "case 'yui_guide_prepare_compact_chat':" in source
+    assert "case 'yui_guide_prepare_compact_chat':" in native_relay_source
+    assert "I.yuiGuideCompactChatPrepareRequestId === requestId" in source
+    assert "nativeBridge.prepareExpandedForTutorial()" in source
+    assert "I.postYuiGuideMessageToPet('yui_guide_compact_chat_ready'" in source
+    # 只有教程前确实是毛球时才折叠，普通胶囊用户结束教程后保持胶囊。
+    assert "if (!message || message.wasCollapsed !== true) return false" in source
+    assert "nativeBridge.restoreCollapsedAfterTutorial()" in source
 
 
 def test_electron_shortcut_bridges_are_blocked_during_tutorial():

--- a/tests/unit/test_universal_tutorial_manager_static.py
+++ b/tests/unit/test_universal_tutorial_manager_static.py
@@ -953,6 +953,18 @@ def test_external_chat_prepares_native_capsule_and_restores_previous_ball_state(
     native_relay_source = (APP_INTERPAGE_PARTS_PATH / "cross-window-broadcast-and-bridge.js").read_text(
         encoding="utf-8"
     )
+    prepare_surface_block = source.split(
+        "I.prepareYuiGuideCompactChatSurface = function prepareYuiGuideCompactChatSurface",
+        1,
+    )[1].split("I.restoreYuiGuideCompactChatSurface = function restoreYuiGuideCompactChatSurface", 1)[0]
+    host_wait_block = prepare_surface_block.split("if (!hasNativePreparation && !hasReadyHost)", 1)[1].split(
+        "var hostMode",
+        1,
+    )[0]
+    host_expand_failure_block = prepare_surface_block.split(
+        "if (!hasNativePreparation && !hostExpanded)",
+        1,
+    )[1].split("Promise.resolve(nativePreparation)", 1)[0]
 
     # 两种跨窗口传输路径必须落到同一实现，重复 relay 也只能启动一次原生展开动画。
     assert "case 'yui_guide_prepare_compact_chat':" in source
@@ -960,6 +972,14 @@ def test_external_chat_prepares_native_capsule_and_restores_previous_ball_state(
     assert "I.yuiGuideCompactChatPrepareRequestId === requestId" in source
     assert "I.yuiGuideCompactChatPrepareRequestId !== requestId" in source
     assert "I.yuiGuideCompactChatPrepareWasCollapsed = wasCollapsed" in source
+    # /chat 的 relay 早于 React host 加载；无原生 prepare 时必须等待 host 方法，不能误报 ready。
+    assert "YUI_GUIDE_COMPACT_CHAT_HOST_RETRY_LIMIT = 80" in source
+    assert "typeof host.openWindow === 'function'" in source
+    assert "typeof host.getChatSurfaceMode === 'function'" in source
+    assert "I.prepareYuiGuideCompactChatSurface(message, retryAttempt + 1)" in source
+    assert "I.yuiGuidePcOverlayLifecycleClosed" in source
+    assert "ready: false" in host_wait_block
+    assert "ready: false" in host_expand_failure_block
     assert "nativeBridge.prepareExpandedForTutorial()" in source
     assert "I.postYuiGuideMessageToPet('yui_guide_compact_chat_ready'" in source
     # 新旧原生桥同步抛错时都必须回执失败，不能让 null 被当成准备成功。

--- a/tests/unit/test_universal_tutorial_manager_static.py
+++ b/tests/unit/test_universal_tutorial_manager_static.py
@@ -495,11 +495,12 @@ def test_universal_tutorial_manager_resets_and_delays_startup_greeting_release()
 
     assert "clearStartupGreetingRelease(reason = 'tutorial-started')" in source
     assert "delete window.__NEKO_STARTUP_GREETING_RELEASED__;" in source
-    emit_block = source.split("    emitTutorialStarted(page = this.currentPage, source = this.currentTutorialStartSource) {", 1)[1].split(
+    emit_block = source.split("    emitTutorialStarted(page = this.currentPage, source = this.currentTutorialStartSource, options = {}) {", 1)[1].split(
         "    /**",
         1,
     )[0]
     assert "this.clearStartupGreetingRelease('tutorial-started');" in emit_block
+    assert "options.lifecycleAlreadyStarted !== true" in emit_block
     assert "this.relayYuiGuideTutorialLifecycleStarted(page, source);" in emit_block
     assert emit_block.index("this.clearStartupGreetingRelease('tutorial-started');") < emit_block.index(
         "this.relayYuiGuideTutorialLifecycleStarted(page, source);"
@@ -832,9 +833,15 @@ def test_avatar_floating_guide_waits_for_compact_chat_before_fixing_layout_and_r
         1,
     )[0]
 
-    # 原生毛球必须先展开并回执，随后才允许教程固定胶囊位置。
+    # 重启教程时聊天桥仍是 closed；只提前打开本轮 lifecycle，用户可见 started 仍等准备成功。
+    assert start_round_block.index("this.relayYuiGuideTutorialLifecycleStarted('home', source)") < start_round_block.index(
+        "await this.prepareYuiGuideCompactChatForTutorial()"
+    )
     assert start_round_block.index("await this.prepareYuiGuideCompactChatForTutorial()") < start_round_block.index(
         "this.syncYuiGuideCompactChatFixedLayout(true, 'avatar-floating-guide-start')"
+    )
+    assert start_round_block.index("this.syncYuiGuideCompactChatFixedLayout(true, 'avatar-floating-guide-start')") < start_round_block.index(
+        "this.emitTutorialStarted('home', source, { lifecycleAlreadyStarted: true })"
     )
     assert "action: 'yui_guide_prepare_compact_chat'" in source
     assert "tutorialRunId: tutorialRunId" in source

--- a/tests/unit/test_universal_tutorial_manager_static.py
+++ b/tests/unit/test_universal_tutorial_manager_static.py
@@ -880,15 +880,20 @@ def test_avatar_floating_guide_waits_for_compact_chat_before_fixing_layout_and_r
         "    clearPcTutorialGlobalOverlay(reason = 'destroy') {",
         1,
     )[0]
-    # 单窗口浏览器虽然有 BroadcastChannel，却没有独立聊天页回执；必须先走本地 host。
+    # 主页无法判断 BroadcastChannel 是否有独立 /chat 接收端：先广播，再立即走本地 host，
+    # 既不能漏掉外部 prepare，也不能让单窗口浏览器等待不存在的回执。
     assert "const hasNativeChatRelay" in prepare_block
-    assert prepare_block.index("if (!hasNativeChatRelay") < prepare_block.index("channel.postMessage(message)")
+    assert prepare_block.index("channel.postMessage(message)") < prepare_block.index("if (!hasNativeChatRelay")
+    assert "localHostPrepared: true" in prepare_block
+    assert "restoreFromPrepareSnapshot: posted" in prepare_block
+    # BroadcastChannel 与本地 host 同时准备时，两边都必须按各自快照恢复启动前形态。
+    assert "localHostPrepared: response.localHostPrepared === true" in prepare_block
+    assert "snapshot.localHostPrepared === true || !posted" in restore_block
     # 原生请求超时后不能猜用户原本是毛球；交给聊天窗按同 request 的 prepare 快照恢复。
     assert "finish(false, { restoreFromPrepareSnapshot: posted })" in prepare_block
     assert "restoreFromPrepareSnapshot: response.restoreFromPrepareSnapshot === true" in prepare_block
     assert "snapshot.restoreFromPrepareSnapshot !== true" in restore_block
     assert "restoreFromPrepareSnapshot: snapshot.restoreFromPrepareSnapshot === true" in restore_block
-    assert "if (!posted && snapshot.wasCollapsed === true)" in restore_block
     # 所有结束方式都经过 clearAllTutorialLifecycles，因此形态恢复不能只挂在 skip 或 complete 分支。
     assert lifecycle_block.index("this.clearYuiGuideCompactChatFixedLayout(rawReason)") < lifecycle_block.index(
         "this.restoreYuiGuideCompactChatSurface(rawReason)"

--- a/tests/unit/test_universal_tutorial_manager_static.py
+++ b/tests/unit/test_universal_tutorial_manager_static.py
@@ -837,6 +837,7 @@ def test_avatar_floating_guide_waits_for_compact_chat_before_fixing_layout_and_r
         "this.syncYuiGuideCompactChatFixedLayout(true, 'avatar-floating-guide-start')"
     )
     assert "action: 'yui_guide_prepare_compact_chat'" in source
+    assert "tutorialRunId: tutorialRunId" in source
     assert "neko:yui-guide:compact-chat-ready" in source
     assert "wasCollapsed: response.wasCollapsed === true" in source
     prepare_block = source.split("    prepareYuiGuideCompactChatForTutorial() {", 1)[1].split(
@@ -875,6 +876,15 @@ def test_avatar_floating_guide_restores_goodbye_business_state_after_model_reloa
     assert "autoGoodbyeState.startupDefaultCatRequested === true" in source
     assert "startupDefaultCatPending ? 'startup-default-cat'" in source
     assert "new CustomEvent('live2d-goodbye-click'" in restore_state_block
+    consume_block = source.split("    consumePendingStartupDefaultCatRestoreRequest() {", 1)[1].split(
+        "    applyTutorialChatIdentityOverride(detail) {",
+        1,
+    )[0]
+    assert "snapshot.goodbyeMeta.reason !== 'startup-default-cat'" in consume_block
+    assert "autoGoodbye.consumeStartupDefaultCatRequest()" in consume_block
+    assert teardown_block.index("this.consumePendingStartupDefaultCatRestoreRequest()") < teardown_block.index(
+        "window.isInTutorial = false"
+    )
     assert "restoreSavedGoodbyeRect: snapshot.goodbyeRect || null" in restore_state_block
     assert "this._avatarFloatingModelLockSnapshot = null" in restore_state_block
     assert "const requestedRestoreRect = event && event.detail && event.detail.restoreSavedGoodbyeRect" in app_ui_source

--- a/tests/unit/test_universal_tutorial_manager_static.py
+++ b/tests/unit/test_universal_tutorial_manager_static.py
@@ -519,6 +519,19 @@ def test_universal_tutorial_manager_resets_and_delays_startup_greeting_release()
     assert lifecycle_started_block.index(
         "this.ensurePcTutorialGlobalOverlayStarted('tutorial-lifecycle-started')"
     ) < lifecycle_started_block.index("const startedMessage = {")
+    # 没有原生 overlay 的浏览器独立聊天页也必须收到带稳定 runId 的 lifecycle-start。
+    overlay_start_block = source.split(
+        "    ensurePcTutorialGlobalOverlayStarted(reason = 'tutorial-started') {",
+        1,
+    )[1].split(
+        "    relayYuiGuideTutorialLifecycleStarted(page, source) {",
+        1,
+    )[0]
+    assert overlay_start_block.index("if (!tutorialRunId) {") < overlay_start_block.index(
+        "if (!overlay || typeof overlay.begin !== 'function')"
+    )
+    assert "return tutorialRunId;" in overlay_start_block
+    assert "channel.postMessage(startedMessage)" in lifecycle_started_block
 
     end_block = source.split("    onTutorialEnd() {", 1)[1].split(
         "    restoreYuiGuideChatInputState",
@@ -905,6 +918,8 @@ def test_avatar_floating_guide_restores_goodbye_business_state_after_model_reloa
     assert "autoGoodbyeState.startupDefaultCatRequested === true" in source
     assert "startupDefaultCatPending ? 'startup-default-cat'" in source
     assert "new CustomEvent('live2d-goodbye-click'" in restore_state_block
+    # pending 启动猫咪快照的 visualTier 可能是 none；只允许回放真实猫咪层级。
+    assert "['cat1', 'cat2', 'cat3'].includes(goodbyeMeta.visualTier)" in restore_state_block
     consume_block = source.split("    consumePendingStartupDefaultCatRestoreRequest() {", 1)[1].split(
         "    applyTutorialChatIdentityOverride(detail) {",
         1,

--- a/tests/unit/test_universal_tutorial_manager_static.py
+++ b/tests/unit/test_universal_tutorial_manager_static.py
@@ -851,9 +851,19 @@ def test_avatar_floating_guide_waits_for_compact_chat_before_fixing_layout_and_r
         "    restoreYuiGuideCompactChatSurface(reason = 'tutorial-ended') {",
         1,
     )[0]
+    restore_block = source.split("    restoreYuiGuideCompactChatSurface(reason = 'tutorial-ended') {", 1)[1].split(
+        "    clearPcTutorialGlobalOverlay(reason = 'destroy') {",
+        1,
+    )[0]
     # 单窗口浏览器虽然有 BroadcastChannel，却没有独立聊天页回执；必须先走本地 host。
     assert "const hasNativeChatRelay" in prepare_block
     assert prepare_block.index("if (!hasNativeChatRelay") < prepare_block.index("channel.postMessage(message)")
+    # 原生请求超时后不能猜用户原本是毛球；交给聊天窗按同 request 的 prepare 快照恢复。
+    assert "finish(false, { restoreFromPrepareSnapshot: posted })" in prepare_block
+    assert "restoreFromPrepareSnapshot: response.restoreFromPrepareSnapshot === true" in prepare_block
+    assert "snapshot.restoreFromPrepareSnapshot !== true" in restore_block
+    assert "restoreFromPrepareSnapshot: snapshot.restoreFromPrepareSnapshot === true" in restore_block
+    assert "if (!posted && snapshot.wasCollapsed === true)" in restore_block
     # 所有结束方式都经过 clearAllTutorialLifecycles，因此形态恢复不能只挂在 skip 或 complete 分支。
     assert lifecycle_block.index("this.clearYuiGuideCompactChatFixedLayout(rawReason)") < lifecycle_block.index(
         "this.restoreYuiGuideCompactChatSurface(rawReason)"
@@ -908,12 +918,15 @@ def test_external_chat_prepares_native_capsule_and_restores_previous_ball_state(
     assert "case 'yui_guide_prepare_compact_chat':" in native_relay_source
     assert "I.yuiGuideCompactChatPrepareRequestId === requestId" in source
     assert "I.yuiGuideCompactChatPrepareRequestId !== requestId" in source
+    assert "I.yuiGuideCompactChatPrepareWasCollapsed = wasCollapsed" in source
     assert "nativeBridge.prepareExpandedForTutorial()" in source
     assert "I.postYuiGuideMessageToPet('yui_guide_compact_chat_ready'" in source
     # 新旧原生桥同步抛错时都必须回执失败，不能让 null 被当成准备成功。
     assert source.count("nativePreparation = { ready: false };") == 2
-    # 只有教程前确实是毛球时才折叠，普通胶囊用户结束教程后保持胶囊。
-    assert "if (!message || message.wasCollapsed !== true) return false" in source
+    # 明确回执或同 request 的本地 prepare 快照确认是毛球时才折叠，原本胶囊保持不变。
+    assert "if (!shouldRestoreCollapsed) return false" in source
+    assert "message.restoreFromPrepareSnapshot === true" in source
+    assert "I.yuiGuideCompactChatPrepareWasCollapsed === true" in source
     assert "nativeBridge.restoreCollapsedAfterTutorial()" in source
 
 

--- a/tests/unit/test_universal_tutorial_manager_static.py
+++ b/tests/unit/test_universal_tutorial_manager_static.py
@@ -839,6 +839,13 @@ def test_avatar_floating_guide_waits_for_compact_chat_before_fixing_layout_and_r
     assert "action: 'yui_guide_prepare_compact_chat'" in source
     assert "neko:yui-guide:compact-chat-ready" in source
     assert "wasCollapsed: response.wasCollapsed === true" in source
+    prepare_block = source.split("    prepareYuiGuideCompactChatForTutorial() {", 1)[1].split(
+        "    restoreYuiGuideCompactChatSurface(reason = 'tutorial-ended') {",
+        1,
+    )[0]
+    # 单窗口浏览器虽然有 BroadcastChannel，却没有独立聊天页回执；必须先走本地 host。
+    assert "const hasNativeChatRelay" in prepare_block
+    assert prepare_block.index("if (!hasNativeChatRelay") < prepare_block.index("channel.postMessage(message)")
     # 所有结束方式都经过 clearAllTutorialLifecycles，因此形态恢复不能只挂在 skip 或 complete 分支。
     assert lifecycle_block.index("this.clearYuiGuideCompactChatFixedLayout(rawReason)") < lifecycle_block.index(
         "this.restoreYuiGuideCompactChatSurface(rawReason)"
@@ -885,6 +892,8 @@ def test_external_chat_prepares_native_capsule_and_restores_previous_ball_state(
     assert "I.yuiGuideCompactChatPrepareRequestId === requestId" in source
     assert "nativeBridge.prepareExpandedForTutorial()" in source
     assert "I.postYuiGuideMessageToPet('yui_guide_compact_chat_ready'" in source
+    # 新旧原生桥同步抛错时都必须回执失败，不能让 null 被当成准备成功。
+    assert source.count("nativePreparation = { ready: false };") == 2
     # 只有教程前确实是毛球时才折叠，普通胶囊用户结束教程后保持胶囊。
     assert "if (!message || message.wasCollapsed !== true) return false" in source
     assert "nativeBridge.restoreCollapsedAfterTutorial()" in source

--- a/tests/unit/test_universal_tutorial_manager_static.py
+++ b/tests/unit/test_universal_tutorial_manager_static.py
@@ -837,6 +837,18 @@ def test_avatar_floating_guide_waits_for_compact_chat_before_fixing_layout_and_r
     assert start_round_block.index("this.relayYuiGuideTutorialLifecycleStarted('home', source)") < start_round_block.index(
         "await this.prepareYuiGuideCompactChatForTutorial()"
     )
+    # prepare 等待期间允许 skip/远程结束；回执回来后只能恢复形态，不能复活已拆除的教程。
+    prepare_ready_index = start_round_block.index("await this.prepareYuiGuideCompactChatForTutorial()")
+    cancellation_index = start_round_block.index("this._tutorialEndHandled", prepare_ready_index)
+    fixed_layout_index = start_round_block.index(
+        "this.syncYuiGuideCompactChatFixedLayout(true, 'avatar-floating-guide-start')"
+    )
+    assert prepare_ready_index < cancellation_index < fixed_layout_index
+    assert "this._isDestroyed" in start_round_block[cancellation_index:fixed_layout_index]
+    assert "!this.isTutorialRunning" in start_round_block[cancellation_index:fixed_layout_index]
+    assert "window.isInTutorial !== true" in start_round_block[cancellation_index:fixed_layout_index]
+    assert "this.restoreYuiGuideCompactChatSurface('tutorial-start-cancelled-after-prepare')" in start_round_block
+    assert "return false;" in start_round_block[cancellation_index:fixed_layout_index]
     assert start_round_block.index("await this.prepareYuiGuideCompactChatForTutorial()") < start_round_block.index(
         "this.syncYuiGuideCompactChatFixedLayout(true, 'avatar-floating-guide-start')"
     )

--- a/tests/unit/test_universal_tutorial_manager_static.py
+++ b/tests/unit/test_universal_tutorial_manager_static.py
@@ -900,6 +900,7 @@ def test_external_chat_prepares_native_capsule_and_restores_previous_ball_state(
     assert "case 'yui_guide_prepare_compact_chat':" in source
     assert "case 'yui_guide_prepare_compact_chat':" in native_relay_source
     assert "I.yuiGuideCompactChatPrepareRequestId === requestId" in source
+    assert "I.yuiGuideCompactChatPrepareRequestId !== requestId" in source
     assert "nativeBridge.prepareExpandedForTutorial()" in source
     assert "I.postYuiGuideMessageToPet('yui_guide_compact_chat_ready'" in source
     # 新旧原生桥同步抛错时都必须回执失败，不能让 null 被当成准备成功。

--- a/tests/unit/test_yui_guide_director_static.py
+++ b/tests/unit/test_yui_guide_director_static.py
@@ -466,7 +466,7 @@ def test_avatar_floating_guides_hide_real_cursor_during_takeover_and_show_banner
         "this.ensurePcTutorialGlobalOverlayStarted('tutorial-lifecycle-started')"
     ) < lifecycle_started_block.index("const startedMessage = {")
     emit_started_block = manager_source.split(
-        "    emitTutorialStarted(page = this.currentPage, source = this.currentTutorialStartSource) {",
+        "    emitTutorialStarted(page = this.currentPage, source = this.currentTutorialStartSource, options = {}) {",
         1,
     )[1].split(
         "    showSkipButton() {",


### PR DESCRIPTION
## 改动概述 / Summary

修复桌面端重启新手教程时，毛球/胶囊输入框与猫咪形态恢复存在的跨窗口竞态。

- 教程开始前先等待 PC 原生聊天窗口完成毛球到胶囊的展开，再启用教程固定布局。
- 记录教程前的聊天形态、猫咪业务状态和位置锚点，在完成、跳过或异常结束后统一恢复。
- 冷启动默认猫咪请求遇到教程接管时继续等待，避免请求被临时 YUI 模型提前消费。
- 增加 requestId 回执与双通道去重，避免迟到消息或重复 relay 启动第二次动画。

根因是网页教程状态、独立 Chat 页面和 Electron 原生窗口此前各自异步切换：教程只确认 React 状态，没有等待原生 surface 稳定；结束时又只恢复模型交互属性，没有恢复猫咪/告别业务形态，导致不同启动时序下出现形态丢失、位置闪烁或恢复错误。

## 回归报告 / Regression Report

### static/app

- 改动内容：增加教程胶囊准备/恢复消息、ready 回执、requestId 去重，并让冷启动默认猫咪请求在教程接管期间保持待执行。
- 理由 / 必要性：static/app 是网页端跨窗口消息和猫咪业务状态的实际承载层；如果只改教程管理器，独立 Chat 窗口仍无法确认 Electron 原生毛球是否真正展开，也无法在结束后恢复启动前形态。
- 改动前后：改动前教程可能在原生窗口仍为毛球或正在展开时锁定胶囊位置；改动后必须收到当前请求的原生 ready 回执才进入固定布局，结束时仅在教程前为毛球的情况下恢复毛球。
- 潜在回归点：跨窗口广播、独立 Chat 初始化、启动默认猫咪、自动告别和猫咪位置锚点。通过双通道去重、超时失败收口、语法检查、静态契约测试和真实重启教程循环验证。

### static/tutorial

- 改动内容：保存聊天形态与猫咪业务快照，统一所有教程结束路径的恢复顺序，并在恢复用户模型后重新进入教程前的猫咪状态。
- 理由 / 必要性：教程会临时加载 YUI 模型，单纯回放 pointer-events 无法重建猫咪返回按钮、视觉层级和原位置；恢复必须发生在用户模型重载之后。
- 改动前后：改动前跳过或结束教程后可能停留在普通模型、错误穿透或错误锚点；改动后先恢复用户模型，再恢复猫咪/普通模型业务形态，最后通知 PC 刷新输入区域。
- 潜在回归点：教程完成、跳过、异常销毁、冷启动直进教程以及 Live2D 浮动按钮重建。新增静态回归覆盖恢复顺序、默认猫咪待执行状态和原位置锚点。

### main_logic

未修改。该问题位于前端教程与桌面窗口协作层，不需要改变会话主逻辑。

### memory

未修改。该问题不涉及记忆读写、检索或持久化链路。

## 不拆分理由 / Why Not Split

不适用。计入限制的文件数量不超过 20；网页端消息、教程恢复和配套测试属于同一条原子修复链路。

## 测试 / Testing

- git diff --check 通过。
- 5 个修改 JavaScript 文件的 node --check 通过。
- 33 项与本次改动直接相关的 Node/Pytest 回归通过。
- 连续 4 轮“重启教程 → 跳过 → 观察猫咪恢复”运行时验证均恢复成功，约 0.9 秒完成既有过渡动画。
- 两个历史大集合测试仍包含与本次改动无关的既有失败；已在干净 HEAD 快照运行同一命令确认失败集合一致，本次新增及修改断言单独运行通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增紧凑聊天教程 prepare/restore 跨页握手：仅在独立聊天页执行，并通过回执完成还原链路。
  * 新增“启动默认猫咪”外部消费能力：教程期间保留请求，解锁后按时且避免重复触发。
* **Bug 修复**
  * “请她离开”过渡锚点：优先使用回执/事件中的保存矩形，校验失败则回退默认计算；同时优化教程结束/取消/重放时的恢复时序与状态竞争。
* **测试**
  * 更新并扩展紧凑聊天、启动默认猫咪保留/延迟执行、跨页中继与恢复顺序的回归/单元用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->