### PR TITLE
Docker运行环境补全，Nginx反代针对性优化

### DIFF
--- a/.github/workflows/docker-multi-arch.yml
+++ b/.github/workflows/docker-multi-arch.yml
@@ -43,7 +43,7 @@ concurrency:
 
 env:
   REGISTRY_GHCR: ghcr.io
-  IMAGE_NAME: project-n-e-k-o/n.e.k.o
+  IMAGE_NAME: ${{ github.repository }}
   # Embedding model pin (kept identical to .github/workflows/build-desktop.yml and
   # docker/Dockerfile{,.full} ARG defaults). The weights are pre-fetched on the
   # native runner and cached so the Docker build never hits huggingface.co — see

--- a/.github/workflows/docker-multi-arch.yml
+++ b/.github/workflows/docker-multi-arch.yml
@@ -43,7 +43,6 @@ concurrency:
 
 env:
   REGISTRY_GHCR: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
   # Embedding model pin (kept identical to .github/workflows/build-desktop.yml and
   # docker/Dockerfile{,.full} ARG defaults). The weights are pre-fetched on the
   # native runner and cached so the Docker build never hits huggingface.co — see
@@ -60,8 +59,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       image_version: ${{ steps.version_calc.outputs.VERSION }}
-      skip_dockerhub: ${{ steps.calc_skip.outputs.SKIP_DOCKERHUB }}
+      skip_dockerhub: $steps.calc_skip.outputs.SKIP_DOCKERHUB }}
       is_main_commit: ${{ steps.calc_is_main.outputs.IS_MAIN_COMMIT }}
+      image_name: ${{ steps.lowercase_image.outputs.IMAGE_NAME }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -138,6 +138,13 @@ jobs:
             echo "版本号为自动生成: $VERSION"
           fi
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Compute lowercase image name
+        id: lowercase_image
+        run: |
+          IMAGE_NAME="${GITHUB_REPOSITORY,,}"
+          echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_OUTPUT
+          echo "✅ Image name (lowercase): $IMAGE_NAME"
 
   # ============================================================================
   # Job 2: Build and push STANDARD version (parallel with full version)
@@ -235,7 +242,7 @@ jobs:
         id: meta_ghcr
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY_GHCR }}/${{ needs.calculate-version.outputs.image_name }}
           flavor: |
             suffix=-${{ matrix.platform }}
           tags: |
@@ -254,7 +261,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME }}
+            ${{ env.REGISTRY_GHCR }}/${{ needs.calculate-version.outputs.image_name }}
             ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o
           flavor: |
             suffix=-${{ matrix.platform }}
@@ -364,7 +371,7 @@ jobs:
         id: meta_ghcr
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY_GHCR }}/${{ needs.calculate-version.outputs.image_name }}
           flavor: |
             suffix=-${{ matrix.platform }}
           tags: |
@@ -383,7 +390,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME }}
+            ${{ env.REGISTRY_GHCR }}/${{ needs.calculate-version.outputs.image_name }}
             ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o
           flavor: |
             suffix=-${{ matrix.platform }}
@@ -457,9 +464,9 @@ jobs:
           VERSION=${{ needs.calculate-version.outputs.image_version }}
 
           docker buildx imagetools create \
-            -t ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard \
-            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard-linux-amd64 \
-            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard-linux-arm64
+            -t ghcr.io/${{ needs.calculate-version.outputs.image_name }}:${VERSION}-standard \
+            ghcr.io/${{ needs.calculate-version.outputs.image_name }}:${VERSION}-standard-linux-amd64 \
+            ghcr.io/${{ needs.calculate-version.outputs.image_name }}:${VERSION}-standard-linux-arm64
 
       - name: Create and push multi-arch manifest for standard version (DockerHub)
         if: needs.build-standard.outputs.skipped != 'true' && needs.calculate-version.outputs.skip_dockerhub != 'true' && steps.check_dockerhub.outputs.has_credentials == 'true'
@@ -476,9 +483,9 @@ jobs:
           VERSION=${{ needs.calculate-version.outputs.image_version }}
 
           docker buildx imagetools create \
-            -t ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-full \
-            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-full-linux-amd64 \
-            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-full-linux-arm64
+            -t ghcr.io/${{ needs.calculate-version.outputs.image_name }}:${VERSION}-full \
+            ghcr.io/${{ needs.calculate-version.outputs.image_name }}:${VERSION}-full-linux-amd64 \
+            ghcr.io/${{ needs.calculate-version.outputs.image_name }}:${VERSION}-full-linux-arm64
 
       - name: Create and push multi-arch manifest for full version (DockerHub)
         if: needs.calculate-version.outputs.skip_dockerhub != 'true' && steps.check_dockerhub.outputs.has_credentials == 'true'
@@ -497,9 +504,9 @@ jobs:
 
           # GHCR - ci-standard (without hash)
           docker buildx imagetools create \
-            -t ghcr.io/${{ env.IMAGE_NAME }}:ci-standard \
-            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard-linux-amd64 \
-            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard-linux-arm64
+            -t ghcr.io/${{ needs.calculate-version.outputs.image_name }}:ci-standard \
+            ghcr.io/${{ needs.calculate-version.outputs.image_name }}:${VERSION}-standard-linux-amd64 \
+            ghcr.io/${{ needs.calculate-version.outputs.image_name }}:${VERSION}-standard-linux-arm64
 
       - name: Create and push CI short tags - full (GHCR)
         if: needs.calculate-version.outputs.is_main_commit == 'true'
@@ -508,9 +515,9 @@ jobs:
 
           # GHCR - ci-full (without hash)
           docker buildx imagetools create \
-            -t ghcr.io/${{ env.IMAGE_NAME }}:ci-full \
-            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-full-linux-amd64 \
-            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-full-linux-arm64
+            -t ghcr.io/${{ needs.calculate-version.outputs.image_name }}:ci-full \
+            ghcr.io/${{ needs.calculate-version.outputs.image_name }}:${VERSION}-full-linux-amd64 \
+            ghcr.io/${{ needs.calculate-version.outputs.image_name }}:${VERSION}-full-linux-arm64
 
       - name: Create and push CI short tags - standard (DockerHub)
         if: needs.calculate-version.outputs.is_main_commit == 'true' && needs.build-standard.outputs.skipped != 'true' && needs.calculate-version.outputs.skip_dockerhub != 'true' && steps.check_dockerhub.outputs.has_credentials == 'true'
@@ -541,9 +548,9 @@ jobs:
 
           # GHCR - pr-ci-standard (without PR number)
           docker buildx imagetools create \
-            -t ghcr.io/${{ env.IMAGE_NAME }}:pr-ci-standard \
-            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard-linux-amd64 \
-            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard-linux-arm64
+            -t ghcr.io/${{ needs.calculate-version.outputs.image_name }}:pr-ci-standard \
+            ghcr.io/${{ needs.calculate-version.outputs.image_name }}:${VERSION}-standard-linux-amd64 \
+            ghcr.io/${{ needs.calculate-version.outputs.image_name }}:${VERSION}-standard-linux-arm64
 
       - name: Create and push PR short tags - full (GHCR)
         if: github.event_name == 'pull_request'
@@ -552,9 +559,9 @@ jobs:
 
           # GHCR - pr-ci-full (without PR number)
           docker buildx imagetools create \
-            -t ghcr.io/${{ env.IMAGE_NAME }}:pr-ci-full \
-            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-full-linux-amd64 \
-            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-full-linux-arm64
+            -t ghcr.io/${{ needs.calculate-version.outputs.image_name }}:pr-ci-full \
+            ghcr.io/${{ needs.calculate-version.outputs.image_name }}:${VERSION}-full-linux-amd64 \
+            ghcr.io/${{ needs.calculate-version.outputs.image_name }}:${VERSION}-full-linux-arm64
 
       - name: Create and push latest manifests - standard (GHCR)
         if: github.event_name != 'pull_request' && needs.calculate-version.outputs.is_main_commit != 'true' && needs.build-standard.outputs.skipped != 'true'
@@ -563,15 +570,15 @@ jobs:
 
           # GHCR - latest (traditional alias pointing to standard)
           docker buildx imagetools create \
-            -t ghcr.io/${{ env.IMAGE_NAME }}:latest \
-            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard-linux-amd64 \
-            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard-linux-arm64
+            -t ghcr.io/${{ needs.calculate-version.outputs.image_name }}:latest \
+            ghcr.io/${{ needs.calculate-version.outputs.image_name }}:${VERSION}-standard-linux-amd64 \
+            ghcr.io/${{ needs.calculate-version.outputs.image_name }}:${VERSION}-standard-linux-arm64
 
           # GHCR - latest-standard
           docker buildx imagetools create \
-            -t ghcr.io/${{ env.IMAGE_NAME }}:latest-standard \
-            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard-linux-amd64 \
-            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard-linux-arm64
+            -t ghcr.io/${{ needs.calculate-version.outputs.image_name }}:latest-standard \
+            ghcr.io/${{ needs.calculate-version.outputs.image_name }}:${VERSION}-standard-linux-amd64 \
+            ghcr.io/${{ needs.calculate-version.outputs.image_name }}:${VERSION}-standard-linux-arm64
 
       - name: Create and push latest manifests - full (GHCR)
         if: github.event_name != 'pull_request' && needs.calculate-version.outputs.is_main_commit != 'true'
@@ -580,9 +587,9 @@ jobs:
 
           # GHCR - latest-full
           docker buildx imagetools create \
-            -t ghcr.io/${{ env.IMAGE_NAME }}:latest-full \
-            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-full-linux-amd64 \
-            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-full-linux-arm64
+            -t ghcr.io/${{ needs.calculate-version.outputs.image_name }}:latest-full \
+            ghcr.io/${{ needs.calculate-version.outputs.image_name }}:${VERSION}-full-linux-amd64 \
+            ghcr.io/${{ needs.calculate-version.outputs.image_name }}:${VERSION}-full-linux-arm64
 
       - name: Create and push latest manifests - standard (DockerHub)
         if: github.event_name != 'pull_request' && needs.calculate-version.outputs.is_main_commit != 'true' && needs.build-standard.outputs.skipped != 'true' && needs.calculate-version.outputs.skip_dockerhub != 'true' && steps.check_dockerhub.outputs.has_credentials == 'true'

--- a/.github/workflows/docker-multi-arch.yml
+++ b/.github/workflows/docker-multi-arch.yml
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       image_version: ${{ steps.version_calc.outputs.VERSION }}
-      skip_dockerhub: $steps.calc_skip.outputs.SKIP_DOCKERHUB }}
+      skip_dockerhub: ${{ steps.calc_skip.outputs.SKIP_DOCKERHUB }}
       is_main_commit: ${{ steps.calc_is_main.outputs.IS_MAIN_COMMIT }}
       image_name: ${{ steps.lowercase_image.outputs.IMAGE_NAME }}
     steps:

--- a/.github/workflows/docker-multi-arch.yml
+++ b/.github/workflows/docker-multi-arch.yml
@@ -145,7 +145,8 @@ jobs:
   build-standard:
     needs: calculate-version
     # 仅在上游仓库运行：fork 上的 push / workflow_dispatch 用其 GITHUB_TOKEN 无法写入上游 GHCR namespace，会必然失败
-    if: github.repository == 'Project-N-E-K-O/N.E.K.O' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+    # 手动触发 (workflow_dispatch) 时跳过仓库检查，允许 fork 构建
+    if: (github.event_name == 'workflow_dispatch' || github.repository == 'Project-N-E-K-O/N.E.K.O') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -289,8 +290,8 @@ jobs:
   # ============================================================================
   build-full:
     needs: calculate-version
-    # 仅在上游仓库运行：fork 上的 push / workflow_dispatch 用其 GITHUB_TOKEN 无法写入上游 GHCR namespace，会必然失败
-    if: github.repository == 'Project-N-E-K-O/N.E.K.O' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+    # 手动触发 (workflow_dispatch) 时跳过仓库检查，允许 fork 构建
+    if: (github.event_name == 'workflow_dispatch' || github.repository == 'Project-N-E-K-O/N.E.K.O') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -417,7 +418,8 @@ jobs:
   # ============================================================================
   create-manifests:
     needs: [calculate-version, build-standard, build-full]
-    if: github.repository == 'Project-N-E-K-O/N.E.K.O' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && always() && needs.build-full.result == 'success'
+    # 手动触发 (workflow_dispatch) 时跳过仓库检查，允许 fork 构建
+    if: (github.event_name == 'workflow_dispatch' || github.repository == 'Project-N-E-K-O/N.E.K.O') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && always() && needs.build-full.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/README.MD
+++ b/README.MD
@@ -127,7 +127,7 @@ services:
     volumes:
       - ./N.E.K.O:/root/Documents/N.E.K.O
       - ./logs:/app/logs
-      - ./ssl:/root/ssl
+      - ./ssl:/home/neko/ssl
     networks:
       - neko-network
 networks:
@@ -162,7 +162,7 @@ docker run -d \
   -p 48912:443 \
   -v "${NEKO_BASE_PATH}/N.E.K.O:/root/Documents/N.E.K.O" \
   -v "${NEKO_BASE_PATH}/logs:/app/logs" \
-  -v "${NEKO_BASE_PATH}/ssl:/root/ssl" \
+  -v "${NEKO_BASE_PATH}/ssl:/home/neko/ssl" \
   --network neko-network \
   docker.gh-proxy.org/ghcr.io/project-n-e-k-o/n.e.k.o:latest
 ```
@@ -230,7 +230,7 @@ docker-compose up -d
 
 ##### 查看证书信息
 ```bash
-docker exec neko openssl x509 -in /root/ssl/N.E.K.O.crt -noout -text
+docker exec neko openssl x509 -in /home/neko/ssl/N.E.K.O.crt -noout -text
 ```
 </details>
 

--- a/app/agent_server/plugin_host.py
+++ b/app/agent_server/plugin_host.py
@@ -167,6 +167,8 @@ async def _start_embedded_user_plugin_server() -> None:
         log_config=None,
         backlog=4096,
         timeout_keep_alive=30,
+        proxy_headers=True,
+        forwarded_allow_ips="*",
     )
     server = uvicorn.Server(config)
     server.install_signal_handlers = lambda: None

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,31 +34,26 @@ RUN npm ci && npm run build-only
 WORKDIR /src/frontend/react-neko-chat
 RUN npm ci && npm run build
 
-# --- Stage 2: Build OpenFang (Rust A2A agent daemon) ---
-FROM rust:1-slim-bookworm AS openfang-builder
+# --- Stage 2: Download OpenFang (pre-built Rust A2A agent daemon binary) ---
+FROM alpine:latest AS openfang-downloader
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
-WORKDIR /build
-
-# 安装编译 OpenFang 所需的系统依赖
-RUN apt-get update && apt-get install -y pkg-config libssl-dev perl make git && rm -rf /var/lib/apt/lists/*
-
-# 配置 Rust crates.io 镜像（国内构建加速）
-RUN mkdir -p /root/.cargo && \
-    printf '[source.crates-io]\nreplace-with = "rsproxy-sparse"\n[source.rsproxy-sparse]\nregistry = "sparse+https://rsproxy.cn/crates.io/"\n' > /root/.cargo/config.toml
+ARG TARGETARCH
 
 # 可覆盖 OpenFang 版本标签（默认 v0.6.9）
 ARG OPENFANG_TAG=v0.6.9
 
-# 编译优化
-ENV CARGO_PROFILE_RELEASE_LTO=true \
-    CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1
-
-RUN if [ -n "$HTTP_PROXY" ]; then export http_proxy=$HTTP_PROXY; fi; \
+# 根据 Docker 架构映射到 Rust target triple，下载对应预编译二进制
+RUN apk add --no-cache curl ca-certificates && \
+    case "$TARGETARCH" in \
+      amd64) triple="x86_64-unknown-linux-gnu" ;; \
+      arm64) triple="aarch64-unknown-linux-gnu" ;; \
+      *) echo "Unsupported arch: $TARGETARCH"; exit 1 ;; \
+    esac && \
+    if [ -n "$HTTP_PROXY" ]; then export http_proxy=$HTTP_PROXY; fi; \
     if [ -n "$HTTPS_PROXY" ]; then export https_proxy=$HTTPS_PROXY; fi; \
-    git clone --depth 1 --branch ${OPENFANG_TAG} https://github.com/RightNow-AI/openfang.git . && \
-    cargo build --release --bin openfang && \
-    cp /build/target/release/openfang /usr/local/bin/openfang
+    curl -fsSL "https://github.com/RightNow-AI/openfang/releases/download/${OPENFANG_TAG}/openfang-${triple}.tar.gz" | tar xz -C /usr/local/bin openfang && \
+    chmod +x /usr/local/bin/openfang
 
 # --- Stage 3: Runtime ---
 FROM debian:bookworm
@@ -185,7 +180,7 @@ COPY --from=frontend-builder /src/frontend/plugin-manager/dist /app/frontend/plu
 COPY --from=frontend-builder /src/static/react/neko-chat /app/static/react/neko-chat
 
 # 7b. Copy OpenFang binary (Rust A2A agent daemon)
-COPY --from=openfang-builder /usr/local/bin/openfang /usr/local/bin/openfang
+COPY --from=openfang-downloader /usr/local/bin/openfang /usr/local/bin/openfang
 
 # 7c. Extract yui-origin Live2D model (assets/yui-origin.tar.gz → static/yui-origin/)
 RUN cd /app && tar -xzmf assets/yui-origin.tar.gz -C static/ && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -112,9 +112,9 @@ RUN groupadd -r nginx && \
     mkdir -p /var/log/nginx /var/cache/nginx && \
     chown -R nginx:nginx /var/log/nginx /var/cache/nginx && \
     groupadd -r neko && \
-    useradd -r -g neko -d /app -s /bin/bash neko && \
-    mkdir -p /app/logs /app/N.E.K.O /root/ssl /opt/ms-playwright && \
-    chown -R neko:neko /app /opt/ms-playwright
+    useradd -r -g neko -d /home/neko -s /bin/bash neko && \
+    mkdir -p /home/neko /app/logs /app/N.E.K.O /home/neko/ssl /opt/ms-playwright && \
+    chown -R neko:neko /home/neko /app /opt/ms-playwright
 
 # 3. Create Python symlinks
 RUN ln -sf /usr/bin/python3.11 /usr/bin/python3 && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,33 @@ RUN npm ci && npm run build-only
 WORKDIR /src/frontend/react-neko-chat
 RUN npm ci && npm run build
 
-# --- Stage 2: Runtime ---
+# --- Stage 2: Build OpenFang (Rust A2A agent daemon) ---
+FROM rust:1-slim-bookworm AS openfang-builder
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+WORKDIR /build
+
+# 安装编译 OpenFang 所需的系统依赖
+RUN apt-get update && apt-get install -y pkg-config libssl-dev perl make git && rm -rf /var/lib/apt/lists/*
+
+# 配置 Rust crates.io 镜像（国内构建加速）
+RUN mkdir -p /root/.cargo && \
+    printf '[source.crates-io]\nreplace-with = "rsproxy-sparse"\n[source.rsproxy-sparse]\nregistry = "sparse+https://rsproxy.cn/crates.io/"\n' > /root/.cargo/config.toml
+
+# 可覆盖 OpenFang 版本标签（默认 v0.6.9）
+ARG OPENFANG_TAG=v0.6.9
+
+# 编译优化
+ENV CARGO_PROFILE_RELEASE_LTO=true \
+    CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1
+
+RUN if [ -n "$HTTP_PROXY" ]; then export http_proxy=$HTTP_PROXY; fi; \
+    if [ -n "$HTTPS_PROXY" ]; then export https_proxy=$HTTPS_PROXY; fi; \
+    git clone --depth 1 --branch ${OPENFANG_TAG} https://github.com/RightNow-AI/openfang.git . && \
+    cargo build --release --bin openfang && \
+    cp /build/target/release/openfang /usr/local/bin/openfang
+
+# --- Stage 3: Runtime ---
 FROM debian:bookworm
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
@@ -158,7 +184,10 @@ RUN cd /app && \
 COPY --from=frontend-builder /src/frontend/plugin-manager/dist /app/frontend/plugin-manager/dist
 COPY --from=frontend-builder /src/static/react/neko-chat /app/static/react/neko-chat
 
-# 7b. Extract yui-origin Live2D model (assets/yui-origin.tar.gz → static/yui-origin/)
+# 7b. Copy OpenFang binary (Rust A2A agent daemon)
+COPY --from=openfang-builder /usr/local/bin/openfang /usr/local/bin/openfang
+
+# 7c. Extract yui-origin Live2D model (assets/yui-origin.tar.gz → static/yui-origin/)
 RUN cd /app && tar -xzmf assets/yui-origin.tar.gz -C static/ && \
     test -f static/yui-origin/yui-origin.moc3
 

--- a/docker/Dockerfile.full
+++ b/docker/Dockerfile.full
@@ -35,12 +35,38 @@ RUN npm ci && npm run build-only
 WORKDIR /src/frontend/react-neko-chat
 RUN npm ci && npm run build
 
-# --- Stage 2: Runtime ---
+# --- Stage 2: Build OpenFang (Rust A2A agent daemon) ---
+FROM rust:1-slim-bookworm AS openfang-builder
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+WORKDIR /build
+
+# 安装编译 OpenFang 所需的系统依赖
+RUN apt-get update && apt-get install -y pkg-config libssl-dev perl make git && rm -rf /var/lib/apt/lists/*
+
+# 配置 Rust crates.io 镜像（国内构建加速）
+RUN mkdir -p /root/.cargo && \
+    printf '[source.crates-io]\nreplace-with = "rsproxy-sparse"\n[source.rsproxy-sparse]\nregistry = "sparse+https://rsproxy.cn/crates.io/"\n' > /root/.cargo/config.toml
+
+# 可覆盖 OpenFang 版本标签（默认 v0.6.9）
+ARG OPENFANG_TAG=v0.6.9
+
+# 编译优化
+ENV CARGO_PROFILE_RELEASE_LTO=true \
+    CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1
+
+RUN if [ -n "$HTTP_PROXY" ]; then export http_proxy=$HTTP_PROXY; fi; \
+    if [ -n "$HTTPS_PROXY" ]; then export https_proxy=$HTTPS_PROXY; fi; \
+    git clone --depth 1 --branch ${OPENFANG_TAG} https://github.com/RightNow-AI/openfang.git . && \
+    cargo build --release --bin openfang && \
+    cp /build/target/release/openfang /usr/local/bin/openfang
+
+# --- Stage 3: Runtime ---
 FROM debian:bookworm
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 
-# 设置环境变量
+# Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 # Per-request HTTP timeout for uv downloads (default 30s). Bumped because the
@@ -227,7 +253,10 @@ RUN cd /app && \
 COPY --from=frontend-builder /src/frontend/plugin-manager/dist /app/frontend/plugin-manager/dist
 COPY --from=frontend-builder /src/static/react/neko-chat /app/static/react/neko-chat
 
-# 7b. 解压 yui-origin Live2D 模型（assets/yui-origin.tar.gz → static/yui-origin/）
+# 7b. 复制 OpenFang 二进制（Rust A2A agent daemon）
+COPY --from=openfang-builder /usr/local/bin/openfang /usr/local/bin/openfang
+
+# 7c. 解压 yui-origin Live2D 模型（assets/yui-origin.tar.gz → static/yui-origin/）
 #     dev 用 build_frontend.{sh,bat} 解压；docker 路径绕过那两个脚本，单独解压一次
 RUN cd /app && tar -xzmf assets/yui-origin.tar.gz -C static/ && \
     test -f static/yui-origin/yui-origin.moc3

--- a/docker/Dockerfile.full
+++ b/docker/Dockerfile.full
@@ -35,31 +35,26 @@ RUN npm ci && npm run build-only
 WORKDIR /src/frontend/react-neko-chat
 RUN npm ci && npm run build
 
-# --- Stage 2: Build OpenFang (Rust A2A agent daemon) ---
-FROM rust:1-slim-bookworm AS openfang-builder
+# --- Stage 2: Download OpenFang (pre-built Rust A2A agent daemon binary) ---
+FROM alpine:latest AS openfang-downloader
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
-WORKDIR /build
-
-# 安装编译 OpenFang 所需的系统依赖
-RUN apt-get update && apt-get install -y pkg-config libssl-dev perl make git && rm -rf /var/lib/apt/lists/*
-
-# 配置 Rust crates.io 镜像（国内构建加速）
-RUN mkdir -p /root/.cargo && \
-    printf '[source.crates-io]\nreplace-with = "rsproxy-sparse"\n[source.rsproxy-sparse]\nregistry = "sparse+https://rsproxy.cn/crates.io/"\n' > /root/.cargo/config.toml
+ARG TARGETARCH
 
 # 可覆盖 OpenFang 版本标签（默认 v0.6.9）
 ARG OPENFANG_TAG=v0.6.9
 
-# 编译优化
-ENV CARGO_PROFILE_RELEASE_LTO=true \
-    CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1
-
-RUN if [ -n "$HTTP_PROXY" ]; then export http_proxy=$HTTP_PROXY; fi; \
+# 根据 Docker 架构映射到 Rust target triple，下载对应预编译二进制
+RUN apk add --no-cache curl ca-certificates && \
+    case "$TARGETARCH" in \
+      amd64) triple="x86_64-unknown-linux-gnu" ;; \
+      arm64) triple="aarch64-unknown-linux-gnu" ;; \
+      *) echo "Unsupported arch: $TARGETARCH"; exit 1 ;; \
+    esac && \
+    if [ -n "$HTTP_PROXY" ]; then export http_proxy=$HTTP_PROXY; fi; \
     if [ -n "$HTTPS_PROXY" ]; then export https_proxy=$HTTPS_PROXY; fi; \
-    git clone --depth 1 --branch ${OPENFANG_TAG} https://github.com/RightNow-AI/openfang.git . && \
-    cargo build --release --bin openfang && \
-    cp /build/target/release/openfang /usr/local/bin/openfang
+    curl -fsSL "https://github.com/RightNow-AI/openfang/releases/download/${OPENFANG_TAG}/openfang-${triple}.tar.gz" | tar xz -C /usr/local/bin openfang && \
+    chmod +x /usr/local/bin/openfang
 
 # --- Stage 3: Runtime ---
 FROM debian:bookworm
@@ -254,7 +249,7 @@ COPY --from=frontend-builder /src/frontend/plugin-manager/dist /app/frontend/plu
 COPY --from=frontend-builder /src/static/react/neko-chat /app/static/react/neko-chat
 
 # 7b. 复制 OpenFang 二进制（Rust A2A agent daemon）
-COPY --from=openfang-builder /usr/local/bin/openfang /usr/local/bin/openfang
+COPY --from=openfang-downloader /usr/local/bin/openfang /usr/local/bin/openfang
 
 # 7c. 解压 yui-origin Live2D 模型（assets/yui-origin.tar.gz → static/yui-origin/）
 #     dev 用 build_frontend.{sh,bat} 解压；docker 路径绕过那两个脚本，单独解压一次

--- a/docker/Dockerfile.full
+++ b/docker/Dockerfile.full
@@ -183,9 +183,9 @@ RUN groupadd -r nginx && \
     mkdir -p /var/log/nginx /var/cache/nginx && \
     chown -R nginx:nginx /var/log/nginx /var/cache/nginx && \
     groupadd -r neko && \
-    useradd -r -g neko -d /app -s /bin/bash neko && \
-    mkdir -p /app/logs /app/N.E.K.O /root/ssl /opt/ms-playwright && \
-    chown -R neko:neko /app /opt/ms-playwright
+    useradd -r -g neko -d /home/neko -s /bin/bash neko && \
+    mkdir -p /home/neko /app/logs /app/N.E.K.O /home/neko/ssl /opt/ms-playwright && \
+    chown -R neko:neko /home/neko /app /opt/ms-playwright
 
 # 3. 创建 Python 符号链接
 RUN ln -sf /usr/bin/python3.11 /usr/bin/python3 && \

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -50,13 +50,13 @@ services:
     # 卷挂载配置
     volumes:
       # 1. 持久化配置目录（XDG_DATA_HOME 规范路径）
-      - ./N.E.K.O:/app/.local/share/N.E.K.O
+      - ./N.E.K.O:/home/neko/.local/share/N.E.K.O
 
       # 2. 日志目录
       - ./logs:/app/logs
 
       # 3. SSL证书目录
-      - ./ssl:/root/ssl
+      - ./ssl:/home/neko/ssl
 
     # 环境变量
     environment:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -49,8 +49,8 @@ services:
 
     # 卷挂载配置
     volumes:
-      # 1. 持久化配置目录
-      - ./N.E.K.O:/root/Documents/N.E.K.O
+      # 1. 持久化配置目录（XDG_DATA_HOME 规范路径）
+      - ./N.E.K.O:/app/.local/share/N.E.K.O
 
       # 2. 日志目录
       - ./logs:/app/logs
@@ -58,9 +58,24 @@ services:
       # 3. SSL证书目录
       - ./ssl:/root/ssl
 
+    # 环境变量
+    environment:
+      # OpenFang A2A 监听端口（容器内部使用 127.0.0.1，无需对外暴露）
+      - OPENFANG_PORT=50051
+
     # 网络配置
     networks:
       - neko-network
+
+  # ============================================================================
+  # OpenFang（专属桌面）— Rust A2A agent daemon
+  # 已编译至 neko-main 容器镜像中（openfang-builder 构建阶段）
+  # 自动在容器内以 127.0.0.1:50051 启动，无需额外服务配置
+  # 若需从宿主机访问 OpenFang Web 控制台，取消下面注释暴露端口：
+  # ports:
+  #   - "4200:4200"
+  # 并设置环境变量 OPENFANG_LISTEN=0.0.0.0:4200
+  # ============================================================================
 
 # 网络定义
 networks:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -553,7 +553,24 @@ server {
     client_max_body_size 0;
 
     # 代理到用户插件服务 (Plugin Server, 内嵌于 agent_server 进程)
-    location ~ ^/(ws/|ui|plugins|plugin/|available|server/|logs/|metrics|runs|packages) {
+    location ~ ^/(ui|plugins|plugin/|available|server/|logs/|metrics|runs|packages) {
+        proxy_pass http://127.0.0.1:48916;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host \$http_host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+        proxy_set_header X-Forwarded-Host \$host;
+        
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 86400;
+    }
+
+    # 插件 WebSocket 路径 → 插件服务器 (48916)
+    location ~ ^/ws/(run|admin|logs) {
         proxy_pass http://127.0.0.1:48916;
         proxy_http_version 1.1;
         proxy_set_header Upgrade \$http_upgrade;
@@ -656,7 +673,24 @@ server {
     client_max_body_size 0;
 
     # 代理到用户插件服务 (Plugin Server, 内嵌于 agent_server 进程)
-    location ~ ^/(ws/|ui|plugins|plugin/|available|server/|logs/|metrics|runs|packages) {
+    location ~ ^/(ui|plugins|plugin/|available|server/|logs/|metrics|runs|packages) {
+        proxy_pass http://127.0.0.1:48916;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host \$http_host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+        proxy_set_header X-Forwarded-Host \$host;
+        
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 86400;
+    }
+
+    # 插件 WebSocket 路径 → 插件服务器 (48916)
+    location ~ ^/ws/(run|admin|logs) {
         proxy_pass http://127.0.0.1:48916;
         proxy_http_version 1.1;
         proxy_set_header Upgrade \$http_upgrade;

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -549,6 +549,23 @@ server {
     # 取消客户端请求体大小限制
     client_max_body_size 0;
 
+    # 代理到用户插件服务 (Plugin Server, 内嵌于 agent_server 进程)
+    location ~ ^/(ws/|ui|plugins|plugin/|available|server/|logs/|metrics|runs|packages) {
+        proxy_pass http://127.0.0.1:48916;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host \$http_host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+        proxy_set_header X-Forwarded-Host \$host;
+        
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 86400;
+    }
+    
     # 代理到N.E.K.O主服务
     location / {
         proxy_pass http://127.0.0.1:${NEKO_MAIN_SERVER_PORT};
@@ -634,6 +651,23 @@ server {
     # 取消客户端请求体大小限制
     client_max_body_size 0;
 
+    # 代理到用户插件服务 (Plugin Server, 内嵌于 agent_server 进程)
+    location ~ ^/(ws/|ui|plugins|plugin/|available|server/|logs/|metrics|runs|packages) {
+        proxy_pass http://127.0.0.1:48916;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host \$http_host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+        proxy_set_header X-Forwarded-Host \$host;
+        
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 86400;
+    }
+    
     # 代理到N.E.K.O主服务
     location / {
         proxy_pass http://127.0.0.1:${NEKO_MAIN_SERVER_PORT};
@@ -873,6 +907,12 @@ setup_dependencies() {
         fi
     fi
     
+    # uv sync 以 root 运行，生成的文件归 root；服务以 neko 用户运行，须修正权限
+    echo "🔧 Fixing .venv permissions for neko user..."
+    chown -R neko:neko /app/.venv 2>/dev/null || echo "⚠️ Could not chown .venv (non-fatal)"
+    # 同时确保文档和模板目录可被 neko 读取（用于 OpenClaw 指南等静态内容）
+    chown -R neko:neko /app/docs /app/templates /app/static 2>/dev/null || echo "⚠️ Could not chown doc/template/static dirs (non-fatal)"
+    
     echo "✅ Dependencies installed successfully"
     
     # 安装 Playwright 浏览器（用于 browser_use 自动化）
@@ -888,6 +928,8 @@ setup_dependencies() {
         # 尝试安装 Chromium，失败时不中断启动
         if uv run --no-sync python -m playwright install chromium --with-deps 2>&1; then
             echo "✅ Playwright Chromium installed successfully"
+            echo "🔧 Fixing Playwright browser permissions for neko user..."
+            chown -R neko:neko "${PLAYWRIGHT_BROWSERS_PATH:-/opt/ms-playwright}" 2>/dev/null || echo "⚠️ Could not chown Playwright browsers (non-fatal)"
         else
             echo "⚠️ Playwright Chromium installation failed (will retry on next start)"
             echo "   Browser automation features may not work until Playwright is installed"
@@ -896,6 +938,54 @@ setup_dependencies() {
 }
 
 # 7. 服务启动优化
+# ── OpenFang (Rust A2A agent daemon) ──────────────────────────
+start_openfang_daemon() {
+    if ! command -v openfang &>/dev/null; then
+        echo "⚠️ OpenFang binary not found, skipping OpenFang daemon"
+        return 0
+    fi
+    echo "🚀 Starting OpenFang A2A daemon..."
+    cd /app
+
+    # OpenFang 工作目录（neko 用户的 home = /app → ~/.openfang = /app/.openfang）
+    local OF_HOME="/app/.openfang"
+    local OF_CONFIG="$OF_HOME/config.toml"
+
+    if [ ! -f "$OF_CONFIG" ]; then
+        echo "   Initializing OpenFang workspace..."
+        runuser -u neko -- openfang init 2>&1 || {
+            echo "⚠️ OpenFang init failed (non-critical)"
+        }
+    fi
+
+    # 确保 A2A 协议已启用（N.E.K.O 通过 A2A 接口与 OpenFang 通信）
+    if [ -f "$OF_CONFIG" ]; then
+        if ! grep -q '^\s*\[a2a\]' "$OF_CONFIG" 2>/dev/null; then
+            echo "   Enabling A2A protocol in OpenFang config..."
+            printf '\n[a2a]\nenabled = true\n' >> "$OF_CONFIG"
+        fi
+    fi
+
+    echo "   Starting openfang daemon (API listen: 127.0.0.1:50051)..."
+    OPENFANG_LISTEN=127.0.0.1:50051 runuser -u neko -- openfang start &
+    local of_pid=$!
+    PIDS+=("$of_pid")
+    echo "     OpenFang daemon PID: $of_pid"
+
+    # 等待健康检查
+    local of_retries=15
+    while [ $of_retries -gt 0 ]; do
+        if curl -sf http://127.0.0.1:50051/api/health >/dev/null 2>&1; then
+            echo "✅ OpenFang daemon is healthy"
+            return 0
+        fi
+        sleep 2
+        of_retries=$((of_retries - 1))
+    done
+    echo "⚠️ OpenFang health check timed out (continuing anyway)"
+    return 0
+}
+
 start_services() {
     echo "🚀 Starting N.E.K.O. services..."
     cd /app
@@ -1044,6 +1134,9 @@ main() {
     setup_configuration
     setup_dependencies
     setup_nginx_proxy
+    
+    # 启动 OpenFang A2A 守护进程（编译在镜像中的 Rust 二进制）
+    start_openfang_daemon
     
     # 启动N.E.K.O服务
     if ! start_services; then

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -553,7 +553,7 @@ server {
     client_max_body_size 0;
 
     # 代理到用户插件服务 (Plugin Server, 内嵌于 agent_server 进程)
-    location ~ ^/(ui|plugins|plugin/|available|server/|logs/|metrics|runs|packages) {
+    location ~ ^/(ui|plugins?|plugin/|available|server/|logs/|metrics|runs|packages|plugin-cli/|market/|health|market-bridge/) {
         proxy_pass http://127.0.0.1:48916;
         proxy_http_version 1.1;
         proxy_set_header Upgrade \$http_upgrade;
@@ -570,7 +570,7 @@ server {
     }
 
     # 插件 WebSocket 路径 → 插件服务器 (48916)
-    location ~ ^/ws/(run|admin|logs) {
+    location ~ ^/ws/(run|admin|logs)(/|$) {
         proxy_pass http://127.0.0.1:48916;
         proxy_http_version 1.1;
         proxy_set_header Upgrade \$http_upgrade;
@@ -673,7 +673,7 @@ server {
     client_max_body_size 0;
 
     # 代理到用户插件服务 (Plugin Server, 内嵌于 agent_server 进程)
-    location ~ ^/(ui|plugins|plugin/|available|server/|logs/|metrics|runs|packages) {
+    location ~ ^/(ui|plugins?|plugin/|available|server/|logs/|metrics|runs|packages|plugin-cli/|market/|health|market-bridge/) {
         proxy_pass http://127.0.0.1:48916;
         proxy_http_version 1.1;
         proxy_set_header Upgrade \$http_upgrade;
@@ -690,7 +690,7 @@ server {
     }
 
     # 插件 WebSocket 路径 → 插件服务器 (48916)
-    location ~ ^/ws/(run|admin|logs) {
+    location ~ ^/ws/(run|admin|logs)(/|$) {
         proxy_pass http://127.0.0.1:48916;
         proxy_http_version 1.1;
         proxy_set_header Upgrade \$http_upgrade;
@@ -995,12 +995,11 @@ start_openfang_daemon() {
         runuser -u neko -- openfang init 2>&1 || {
             echo "⚠️ OpenFang init failed (non-critical)"
         }
-    fi
-
-    # 清除预装 agent（默认用 Groq 但用户无 key → 刷 heartbeat WARN）
-    if [ -d "$OF_HOME/agents" ]; then
-        echo "   Removing pre-installed agents (no Groq API key configured)..."
-        rm -rf "$OF_HOME/agents"
+        # 首次初始化时清除预装 agent（默认用 Groq 但用户无 key → 刷 heartbeat WARN）
+        if [ -d "$OF_HOME/agents" ]; then
+            echo "   Removing pre-installed agents (no Groq API key configured)..."
+            rm -rf "$OF_HOME/agents"
+        fi
     fi
 
     # 确保 A2A 协议已启用（N.E.K.O 通过 A2A 接口与 OpenFang 通信）
@@ -1011,8 +1010,9 @@ start_openfang_daemon() {
         fi
     fi
 
-    echo "   Starting openfang daemon (API listen: 127.0.0.1:50051)..."
-    OPENFANG_LISTEN=127.0.0.1:50051 runuser -u neko -- openfang start &
+    local OF_PORT="${OPENFANG_PORT:-50051}"
+    echo "   Starting openfang daemon (API listen: 127.0.0.1:${OF_PORT})..."
+    OPENFANG_LISTEN="127.0.0.1:${OF_PORT}" runuser -u neko -- openfang start &
     local of_pid=$!
     PIDS+=("$of_pid")
     echo "     OpenFang daemon PID: $of_pid"
@@ -1020,7 +1020,7 @@ start_openfang_daemon() {
     # 等待健康检查
     local of_retries=15
     while [ $of_retries -gt 0 ]; do
-        if curl -sf http://127.0.0.1:50051/api/health >/dev/null 2>&1; then
+        if curl -sf "http://127.0.0.1:${OF_PORT}/api/health" >/dev/null 2>&1; then
             echo "✅ OpenFang daemon is healthy"
             return 0
         fi

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -13,6 +13,9 @@ export SSL_DOMAIN=${SSL_DOMAIN:-project-neko.online}
 export SSL_DAYS=${SSL_DAYS:-365000}  # 1000年
 export NGINX_AUTO_RELOAD=${NGINX_AUTO_RELOAD:-1}  # 是否启用自动重载，默认启用
 
+# Docker 容器内 Nginx 作为反向代理前置，强制启用 uvicorn proxy_headers
+export NEKO_BEHIND_PROXY=true
+
 # 1. 信号处理优化
 setup_signal_handlers() {
     trap 'echo "🛑 Received shutdown signal"; nginx -s stop 2>/dev/null || true; for pid in "${PIDS[@]}"; do kill -TERM "$pid" 2>/dev/null || true; done; [ -n "$RELOADER_PID" ] && kill -TERM "$RELOADER_PID" 2>/dev/null || true; wait; exit 0' TERM INT
@@ -669,12 +672,45 @@ server {
     }
     
     # 代理到N.E.K.O主服务
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384;
+    
+    # 设置HSTS头（增强安全性）
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    
+    server_name _;
+    
+    # 禁用默认的Nginx版本显示
+    server_tokens off;
+    
+    # 取消客户端请求体大小限制
+    client_max_body_size 0;
+
+    # 代理到用户插件服务 (Plugin Server, 内嵌于 agent_server 进程)
+    location ~ ^/(ws/|ui|plugins|plugin/|available|server/|logs/|metrics|runs|packages) {
+        proxy_pass http://127.0.0.1:48916;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host \$http_host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+        proxy_set_header X-Forwarded-Host \$host;
+        
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 86400;
+    }
+    
+    # 代理到N.E.K.O主服务
     location / {
         proxy_pass http://127.0.0.1:${NEKO_MAIN_SERVER_PORT};
         proxy_set_header Host \$http_host;
         proxy_set_header X-Real-IP \$remote_addr;
         proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto \$scheme;
+        proxy_set_header X-Forwarded-Host \$host;
         
         # WebSocket支持
         proxy_http_version 1.1;

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -576,6 +576,7 @@ server {
         proxy_set_header X-Real-IP \$remote_addr;
         proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto \$scheme;
+        proxy_set_header X-Forwarded-Host \$host;
         
         # WebSocket支持
         proxy_http_version 1.1;
@@ -640,38 +641,6 @@ server {
     ssl_certificate $cert_file;
     ssl_certificate_key $key_file;
     ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_prefer_server_ciphers on;
-    ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384;
-    
-    # 设置HSTS头（增强安全性）
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    
-    server_name _;
-    
-    # 禁用默认的Nginx版本显示
-    server_tokens off;
-    
-    # 取消客户端请求体大小限制
-    client_max_body_size 0;
-
-    # 代理到用户插件服务 (Plugin Server, 内嵌于 agent_server 进程)
-    location ~ ^/(ws/|ui|plugins|plugin/|available|server/|logs/|metrics|runs|packages) {
-        proxy_pass http://127.0.0.1:48916;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade \$http_upgrade;
-        proxy_set_header Connection "upgrade";
-        proxy_set_header Host \$http_host;
-        proxy_set_header X-Real-IP \$remote_addr;
-        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto \$scheme;
-        proxy_set_header X-Forwarded-Host \$host;
-        
-        proxy_connect_timeout 60s;
-        proxy_send_timeout 60s;
-        proxy_read_timeout 86400;
-    }
-    
-    # 代理到N.E.K.O主服务
     ssl_prefer_server_ciphers on;
     ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384;
     

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -439,10 +439,10 @@ setup_nginx_proxy() {
     
     # 生成SSL证书和密钥（如果不存在）
     echo "🔐 Setting up SSL certificates..."
-    mkdir -p /root/ssl
+    mkdir -p /home/neko/ssl
     
-    local cert_file="/root/ssl/N.E.K.O.crt"
-    local key_file="/root/ssl/N.E.K.O.key"
+    local cert_file="/home/neko/ssl/N.E.K.O.crt"
+    local key_file="/home/neko/ssl/N.E.K.O.key"
     
     # 如果证书或密钥不存在，直接生成新的
     if [ ! -f "$cert_file" ] || [ ! -f "$key_file" ]; then
@@ -759,8 +759,8 @@ start_nginx_reloader() {
     # 记录初始配置文件的修改时间
     local nginx_conf="/etc/nginx/nginx.conf"
     local site_conf="/etc/nginx/conf.d/neko-proxy.conf"
-    local ssl_cert="/root/ssl/N.E.K.O.crt"
-    local ssl_key="/root/ssl/N.E.K.O.key"
+    local ssl_cert="/home/neko/ssl/N.E.K.O.crt"
+    local ssl_key="/home/neko/ssl/N.E.K.O.key"
     
     local last_conf_time=$(stat -c %Y "$nginx_conf" "$site_conf" 2>/dev/null)
     local last_ssl_time=""
@@ -952,8 +952,8 @@ start_openfang_daemon() {
     echo "🚀 Starting OpenFang A2A daemon..."
     cd /app
 
-    # OpenFang 工作目录（neko 用户的 home = /app → ~/.openfang = /app/.openfang）
-    local OF_HOME="/app/.openfang"
+    # OpenFang 工作目录（~neko/.openfang）
+    local OF_HOME="/home/neko/.openfang"
     local OF_CONFIG="$OF_HOME/config.toml"
 
     if [ ! -f "$OF_CONFIG" ]; then
@@ -961,6 +961,12 @@ start_openfang_daemon() {
         runuser -u neko -- openfang init 2>&1 || {
             echo "⚠️ OpenFang init failed (non-critical)"
         }
+    fi
+
+    # 清除预装 agent（默认用 Groq 但用户无 key → 刷 heartbeat WARN）
+    if [ -d "$OF_HOME/agents" ]; then
+        echo "   Removing pre-installed agents (no Groq API key configured)..."
+        rm -rf "$OF_HOME/agents"
     fi
 
     # 确保 A2A 协议已启用（N.E.K.O 通过 A2A 接口与 OpenFang 通信）
@@ -1141,8 +1147,8 @@ main() {
     setup_nginx_proxy
     
     # 确保数据目录对 neko 用户可写（Docker volume 可能以 root 创建）
-    mkdir -p /app/.local/share/N.E.K.O
-    chown -R neko:neko /app/.local/share/N.E.K.O
+    mkdir -p /home/neko/.local/share/N.E.K.O
+    chown -R neko:neko /home/neko/.local/share/N.E.K.O
     
     # 启动 OpenFang A2A 守护进程（编译在镜像中的 Rust 二进制）
     start_openfang_daemon

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1140,6 +1140,10 @@ main() {
     setup_dependencies
     setup_nginx_proxy
     
+    # 确保数据目录对 neko 用户可写（Docker volume 可能以 root 创建）
+    mkdir -p /app/.local/share/N.E.K.O
+    chown -R neko:neko /app/.local/share/N.E.K.O
+    
     # 启动 OpenFang A2A 守护进程（编译在镜像中的 Rust 二进制）
     start_openfang_daemon
     

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -119,7 +119,7 @@ services:
       - "48911:80"   # HTTP port
       - "48912:443"  # HTTPS port
     volumes:
-      - ./N.E.K.O:/root/Documents/N.E.K.O
+      - ./N.E.K.O:/app/.local/share/N.E.K.O
       - ./logs:/app/logs
       - ./ssl:/root/ssl
     networks:
@@ -154,7 +154,7 @@ docker run -d \
   --restart unless-stopped \
   -p 48911:80 \
   -p 48912:443 \
-  -v "${NEKO_BASE_PATH}/N.E.K.O:/root/Documents/N.E.K.O" \
+  -v "${NEKO_BASE_PATH}/N.E.K.O:/app/.local/share/N.E.K.O" \
   -v "${NEKO_BASE_PATH}/logs:/app/logs" \
   -v "${NEKO_BASE_PATH}/ssl:/root/ssl" \
   --network neko-network \

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -119,9 +119,9 @@ services:
       - "48911:80"   # HTTP port
       - "48912:443"  # HTTPS port
     volumes:
-      - ./N.E.K.O:/app/.local/share/N.E.K.O
+      - ./N.E.K.O:/home/neko/.local/share/N.E.K.O
       - ./logs:/app/logs
-      - ./ssl:/root/ssl
+      - ./ssl:/home/neko/ssl
     networks:
       - neko-network
 networks:
@@ -154,9 +154,9 @@ docker run -d \
   --restart unless-stopped \
   -p 48911:80 \
   -p 48912:443 \
-  -v "${NEKO_BASE_PATH}/N.E.K.O:/app/.local/share/N.E.K.O" \
+  -v "${NEKO_BASE_PATH}/N.E.K.O:/home/neko/.local/share/N.E.K.O" \
   -v "${NEKO_BASE_PATH}/logs:/app/logs" \
-  -v "${NEKO_BASE_PATH}/ssl:/root/ssl" \
+  -v "${NEKO_BASE_PATH}/ssl:/home/neko/ssl" \
   --network neko-network \
   docker.gh-proxy.org/ghcr.io/project-n-e-k-o/n.e.k.o:latest
 ```
@@ -224,7 +224,7 @@ The container automatically validates SSL certificates on startup:
 
 ##### View Certificate Info
 ```bash
-docker exec neko openssl x509 -in /root/ssl/N.E.K.O.crt -noout -text
+docker exec neko openssl x509 -in /home/neko/ssl/N.E.K.O.crt -noout -text
 ```
 </details>
 

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -119,7 +119,7 @@ services:
       - "48911:80"   # HTTPポート
       - "48912:443"  # HTTPSポート
     volumes:
-      - ./N.E.K.O:/root/Documents/N.E.K.O
+      - ./N.E.K.O:/app/.local/share/N.E.K.O
       - ./logs:/app/logs
       - ./ssl:/root/ssl
     networks:
@@ -154,7 +154,7 @@ docker run -d \
   --restart unless-stopped \
   -p 48911:80 \
   -p 48912:443 \
-  -v "${NEKO_BASE_PATH}/N.E.K.O:/root/Documents/N.E.K.O" \
+  -v "${NEKO_BASE_PATH}/N.E.K.O:/app/.local/share/N.E.K.O" \
   -v "${NEKO_BASE_PATH}/logs:/app/logs" \
   -v "${NEKO_BASE_PATH}/ssl:/root/ssl" \
   --network neko-network \

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -119,9 +119,9 @@ services:
       - "48911:80"   # HTTPポート
       - "48912:443"  # HTTPSポート
     volumes:
-      - ./N.E.K.O:/app/.local/share/N.E.K.O
+      - ./N.E.K.O:/home/neko/.local/share/N.E.K.O
       - ./logs:/app/logs
-      - ./ssl:/root/ssl
+      - ./ssl:/home/neko/ssl
     networks:
       - neko-network
 networks:
@@ -154,9 +154,9 @@ docker run -d \
   --restart unless-stopped \
   -p 48911:80 \
   -p 48912:443 \
-  -v "${NEKO_BASE_PATH}/N.E.K.O:/app/.local/share/N.E.K.O" \
+  -v "${NEKO_BASE_PATH}/N.E.K.O:/home/neko/.local/share/N.E.K.O" \
   -v "${NEKO_BASE_PATH}/logs:/app/logs" \
-  -v "${NEKO_BASE_PATH}/ssl:/root/ssl" \
+  -v "${NEKO_BASE_PATH}/ssl:/home/neko/ssl" \
   --network neko-network \
   docker.gh-proxy.org/ghcr.io/project-n-e-k-o/n.e.k.o:latest
 ```
@@ -216,7 +216,7 @@ docker-compose up -d
 
 ##### 証明書情報の確認
 ```bash
-docker exec neko openssl x509 -in /root/ssl/N.E.K.O.crt -noout -text
+docker exec neko openssl x509 -in /home/neko/ssl/N.E.K.O.crt -noout -text
 ```
 </details>
 

--- a/docs/README_ru.md
+++ b/docs/README_ru.md
@@ -119,7 +119,7 @@ services:
       - "48911:80"   # HTTP порт
       - "48912:443"  # HTTPS порт
     volumes:
-      - ./N.E.K.O:/root/Documents/N.E.K.O
+      - ./N.E.K.O:/app/.local/share/N.E.K.O
       - ./logs:/app/logs
       - ./ssl:/root/ssl
     networks:
@@ -154,7 +154,7 @@ docker run -d \
   --restart unless-stopped \
   -p 48911:80 \
   -p 48912:443 \
-  -v "${NEKO_BASE_PATH}/N.E.K.O:/root/Documents/N.E.K.O" \
+  -v "${NEKO_BASE_PATH}/N.E.K.O:/app/.local/share/N.E.K.O" \
   -v "${NEKO_BASE_PATH}/logs:/app/logs" \
   -v "${NEKO_BASE_PATH}/ssl:/root/ssl" \
   --network neko-network \

--- a/docs/README_ru.md
+++ b/docs/README_ru.md
@@ -119,9 +119,9 @@ services:
       - "48911:80"   # HTTP порт
       - "48912:443"  # HTTPS порт
     volumes:
-      - ./N.E.K.O:/app/.local/share/N.E.K.O
+      - ./N.E.K.O:/home/neko/.local/share/N.E.K.O
       - ./logs:/app/logs
-      - ./ssl:/root/ssl
+      - ./ssl:/home/neko/ssl
     networks:
       - neko-network
 networks:
@@ -154,9 +154,9 @@ docker run -d \
   --restart unless-stopped \
   -p 48911:80 \
   -p 48912:443 \
-  -v "${NEKO_BASE_PATH}/N.E.K.O:/app/.local/share/N.E.K.O" \
+  -v "${NEKO_BASE_PATH}/N.E.K.O:/home/neko/.local/share/N.E.K.O" \
   -v "${NEKO_BASE_PATH}/logs:/app/logs" \
-  -v "${NEKO_BASE_PATH}/ssl:/root/ssl" \
+  -v "${NEKO_BASE_PATH}/ssl:/home/neko/ssl" \
   --network neko-network \
   docker.gh-proxy.org/ghcr.io/project-n-e-k-o/n.e.k.o:latest
 ```
@@ -216,7 +216,7 @@ docker-compose up -d
 
 ##### Просмотр информации о сертификате
 ```bash
-docker exec neko openssl x509 -in /root/ssl/N.E.K.O.crt -noout -text
+docker exec neko openssl x509 -in /home/neko/ssl/N.E.K.O.crt -noout -text
 ```
 </details>
 

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -32,9 +32,9 @@ services:
       - "48911:80"    # HTTP
       - "48912:443"   # HTTPS
     volumes:
-      - ./N.E.K.O:/app/.local/share/N.E.K.O
+      - ./N.E.K.O:/home/neko/.local/share/N.E.K.O
       - ./logs:/app/logs
-      - ./ssl:/root/ssl
+      - ./ssl:/home/neko/ssl
     networks:
       - neko-network
 
@@ -74,9 +74,9 @@ The Docker container includes Nginx as a reverse proxy:
 
 | Mount | Container path | Purpose |
 |-------|----------------|---------|
-| `./N.E.K.O` | `/app/.local/share/N.E.K.O` | Config, characters, memories |
+| `./N.E.K.O` | `/home/neko/.local/share/N.E.K.O` | Config, characters, memories |
 | `./logs` | `/app/logs` | Application logs |
-| `./ssl` | `/root/ssl` | SSL certificates |
+| `./ssl` | `/home/neko/ssl` | SSL certificates |
 
 ## Provider quick start
 
@@ -108,7 +108,7 @@ docker logs neko
 docker exec -it neko bash
 
 # Check config
-docker exec neko cat /app/.local/share/N.E.K.O/core_config.json
+docker exec neko cat /home/neko/.local/share/N.E.K.O/core_config.json
 
 # Check environment
 docker exec neko env | grep NEKO_

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -32,7 +32,7 @@ services:
       - "48911:80"    # HTTP
       - "48912:443"   # HTTPS
     volumes:
-      - ./N.E.K.O:/root/Documents/N.E.K.O
+      - ./N.E.K.O:/app/.local/share/N.E.K.O
       - ./logs:/app/logs
       - ./ssl:/root/ssl
     networks:
@@ -74,7 +74,7 @@ The Docker container includes Nginx as a reverse proxy:
 
 | Mount | Container path | Purpose |
 |-------|----------------|---------|
-| `./N.E.K.O` | `/root/Documents/N.E.K.O` | Config, characters, memories |
+| `./N.E.K.O` | `/app/.local/share/N.E.K.O` | Config, characters, memories |
 | `./logs` | `/app/logs` | Application logs |
 | `./ssl` | `/root/ssl` | SSL certificates |
 
@@ -108,7 +108,7 @@ docker logs neko
 docker exec -it neko bash
 
 # Check config
-docker exec neko cat /root/Documents/N.E.K.O/core_config.json
+docker exec neko cat /app/.local/share/N.E.K.O/core_config.json
 
 # Check environment
 docker exec neko env | grep NEKO_

--- a/docs/ja/deployment/docker.md
+++ b/docs/ja/deployment/docker.md
@@ -32,7 +32,7 @@ services:
       - "48911:80"    # HTTP
       - "48912:443"   # HTTPS
     volumes:
-      - ./N.E.K.O:/root/Documents/N.E.K.O
+      - ./N.E.K.O:/app/.local/share/N.E.K.O
       - ./logs:/app/logs
       - ./ssl:/root/ssl
     networks:
@@ -74,7 +74,7 @@ Docker コンテナにはリバースプロキシとして Nginx が含まれて
 
 | マウント | コンテナパス | 用途 |
 |-------|----------------|---------|
-| `./N.E.K.O` | `/root/Documents/N.E.K.O` | 設定、キャラクター、メモリ |
+| `./N.E.K.O` | `/app/.local/share/N.E.K.O` | 設定、キャラクター、メモリ |
 | `./logs` | `/app/logs` | アプリケーションログ |
 | `./ssl` | `/root/ssl` | SSL 証明書 |
 
@@ -108,7 +108,7 @@ docker logs neko
 docker exec -it neko bash
 
 # 設定を確認
-docker exec neko cat /root/Documents/N.E.K.O/core_config.json
+docker exec neko cat /app/.local/share/N.E.K.O/core_config.json
 
 # 環境変数を確認
 docker exec neko env | grep NEKO_

--- a/docs/ja/deployment/docker.md
+++ b/docs/ja/deployment/docker.md
@@ -32,9 +32,9 @@ services:
       - "48911:80"    # HTTP
       - "48912:443"   # HTTPS
     volumes:
-      - ./N.E.K.O:/app/.local/share/N.E.K.O
+      - ./N.E.K.O:/home/neko/.local/share/N.E.K.O
       - ./logs:/app/logs
-      - ./ssl:/root/ssl
+      - ./ssl:/home/neko/ssl
     networks:
       - neko-network
 
@@ -74,9 +74,9 @@ Docker コンテナにはリバースプロキシとして Nginx が含まれて
 
 | マウント | コンテナパス | 用途 |
 |-------|----------------|---------|
-| `./N.E.K.O` | `/app/.local/share/N.E.K.O` | 設定、キャラクター、メモリ |
+| `./N.E.K.O` | `/home/neko/.local/share/N.E.K.O` | 設定、キャラクター、メモリ |
 | `./logs` | `/app/logs` | アプリケーションログ |
-| `./ssl` | `/root/ssl` | SSL 証明書 |
+| `./ssl` | `/home/neko/ssl` | SSL 証明書 |
 
 ## プロバイダークイックスタート
 
@@ -108,7 +108,7 @@ docker logs neko
 docker exec -it neko bash
 
 # 設定を確認
-docker exec neko cat /app/.local/share/N.E.K.O/core_config.json
+docker exec neko cat /home/neko/.local/share/N.E.K.O/core_config.json
 
 # 環境変数を確認
 docker exec neko env | grep NEKO_

--- a/docs/zh-CN/deployment/docker.md
+++ b/docs/zh-CN/deployment/docker.md
@@ -32,9 +32,9 @@ services:
       - "48911:80"    # HTTP
       - "48912:443"   # HTTPS
     volumes:
-      - ./N.E.K.O:/app/.local/share/N.E.K.O
+      - ./N.E.K.O:/home/neko/.local/share/N.E.K.O
       - ./logs:/app/logs
-      - ./ssl:/root/ssl
+      - ./ssl:/home/neko/ssl
     networks:
       - neko-network
 
@@ -74,9 +74,9 @@ Docker 容器内置 Nginx 作为反向代理：
 
 | 挂载 | 容器路径 | 用途 |
 |------|----------|------|
-| `./N.E.K.O` | `/app/.local/share/N.E.K.O` | 配置、角色、记忆 |
+| `./N.E.K.O` | `/home/neko/.local/share/N.E.K.O` | 配置、角色、记忆 |
 | `./logs` | `/app/logs` | 应用日志 |
-| `./ssl` | `/root/ssl` | SSL 证书 |
+| `./ssl` | `/home/neko/ssl` | SSL 证书 |
 
 ## 服务商快速配置
 
@@ -108,7 +108,7 @@ docker logs neko
 docker exec -it neko bash
 
 # Check config
-docker exec neko cat /app/.local/share/N.E.K.O/core_config.json
+docker exec neko cat /home/neko/.local/share/N.E.K.O/core_config.json
 
 # Check environment
 docker exec neko env | grep NEKO_

--- a/docs/zh-CN/deployment/docker.md
+++ b/docs/zh-CN/deployment/docker.md
@@ -32,7 +32,7 @@ services:
       - "48911:80"    # HTTP
       - "48912:443"   # HTTPS
     volumes:
-      - ./N.E.K.O:/root/Documents/N.E.K.O
+      - ./N.E.K.O:/app/.local/share/N.E.K.O
       - ./logs:/app/logs
       - ./ssl:/root/ssl
     networks:
@@ -74,7 +74,7 @@ Docker 容器内置 Nginx 作为反向代理：
 
 | 挂载 | 容器路径 | 用途 |
 |------|----------|------|
-| `./N.E.K.O` | `/root/Documents/N.E.K.O` | 配置、角色、记忆 |
+| `./N.E.K.O` | `/app/.local/share/N.E.K.O` | 配置、角色、记忆 |
 | `./logs` | `/app/logs` | 应用日志 |
 | `./ssl` | `/root/ssl` | SSL 证书 |
 
@@ -108,7 +108,7 @@ docker logs neko
 docker exec -it neko bash
 
 # Check config
-docker exec neko cat /root/Documents/N.E.K.O/core_config.json
+docker exec neko cat /app/.local/share/N.E.K.O/core_config.json
 
 # Check environment
 docker exec neko env | grep NEKO_

--- a/main_routers/agent_router.py
+++ b/main_routers/agent_router.py
@@ -28,6 +28,7 @@ See ``main_routers/characters_router.py`` docstring or
 enforced by ``scripts/check_api_trailing_slash.py``.
 """
 
+import os
 import time
 import uuid
 from pathlib import Path
@@ -455,8 +456,14 @@ async def proxy_mcp_availability():
 
 @router.get('/user_plugin/dashboard')
 async def redirect_plugin_dashboard(request: Request):
-    user_plugin_base = await _resolve_user_plugin_base()
-    target_url = f"{user_plugin_base}/ui"
+    # Docker 部署（位于 Nginx 反向代理后方）：使用相对路径 /ui，
+    # 由 Nginx 代理到插件服务（48916），避免返回容器内部 127.0.0.1
+    behind_proxy = os.environ.get("NEKO_BEHIND_PROXY", "").strip().lower() in ("1", "true", "yes")
+    if behind_proxy:
+        target_url = "/ui"
+    else:
+        user_plugin_base = await _resolve_user_plugin_base()
+        target_url = f"{user_plugin_base}/ui"
     query_params: dict[str, str] = {}
     if "v" in request.query_params:
         v = request.query_params["v"].strip()

--- a/main_routers/system_router/_shared.py
+++ b/main_routers/system_router/_shared.py
@@ -25,7 +25,7 @@ import sys
 import ipaddress
 import secrets
 from typing import Any
-from urllib.parse import urlsplit
+from urllib.parse import urlparse, urlsplit
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse, Response
 from ..shared_state import get_config_manager

--- a/main_routers/system_router/_shared.py
+++ b/main_routers/system_router/_shared.py
@@ -177,6 +177,17 @@ def _validate_local_mutation_request(
     if has_valid_csrf and has_valid_origin:
         return None
 
+    # 端口无关的 hostname 降级匹配：Docker 端口映射下内部端口（如 48911）
+    # 与浏览器 Origin 端口（如 1081）不一致，CSRF token 有效时放宽检查
+    if has_valid_csrf and request_origin:
+        parsed_origin = urlparse(request_origin)
+        origin_host = parsed_origin.hostname
+        if origin_host:
+            for allowed in allowed_origins:
+                parsed_allowed = urlparse(allowed)
+                if parsed_allowed.hostname == origin_host:
+                    return None
+
     logger.warning(
         "Rejected local mutation request due to failed CSRF/origin validation: "
         "method=%r path=%r origin=%r allowed_origins=%r has_csrf=%s referer=%r",


### PR DESCRIPTION
## 改动概述 / Summary

本 PR 累计 10 个提交，主要围绕 **Docker 部署体验优化** 和 **反向代理场景适配**：

1. **Docker 基础设施重构**（`cb2d6b7`、`e1c64c8`、`e9c5d69`）：统一容器内用户主目录路径为 `/home/neko`，修复 data 目录权限问题，并集成 OpenFang A2A 服务。
2. **反向代理/NGINX 适配**（`45d0b7e`、`bd65ef1`、`1182415`、`c040532`）：补全 Nginx 代理头配置；为插件跳转链接添加 `NEKO_BEHIND_PROXY` 环境变量支持，返回相对路径 `/ui` 而非容器内部地址；放宽 Docker 端口映射下 CSRF origin 校验（仅比较 hostname 忽略端口）；为 uvicorn 启用 `proxy_headers=True` 以正确获取客户端 IP。
3. **CI/CD 改进**（`904b762`、`a11ef57`、`042405c`）：优化多架构 Docker 镜像构建流程，允许 fork 仓库手动触发构建，修复镜像名变量引用问题。

---

## 回归报告 / Regression Report

本 PR 触碰了 `app/` 下的 `app/agent_server/plugin_host.py`，按要求逐项说明：

| 改动项 | 文件 | 改动内容 | 必要性 | 改动前后对比 | 潜在回归点 |
|--------|------|---------|--------|-------------|-----------|
| **uvicorn proxy headers** | [plugin_host.py](file:///c:/Users/HINS/Documents/Trae/N.E.K.O/N.E.K.O/app/agent_server/plugin_host.py) | 新增 `proxy_headers=True` 和 `forwarded_allow_ips="*"` | 反向代理部署下，Nginx 转发的请求需要 uvicorn 信任 `X-Forwarded-*` 头才能正确记录客户端 IP | 改动前：`request.client.host` 始终为 Nginx 容器 IP（如 172.x.x.x）；改动后：正确传递真实客户端 IP | 反向代理配置不当可能导致 IP 伪造，需确保 Nginx 正确覆写这些头 |
| **CSRF origin 放宽** | [system_router/_shared.py](file:///c:/Users/HINS/Documents/Trae/N.E.K.O/N.E.K.O/main_routers/system_router/_shared.py#L189-L196) | 当 CSRF token 有效时，仅比较 hostname 忽略端口 | Docker 端口映射下内部端口（48911）与外部映射端口（如 1081）不一致导致 CSRF 校验失败 | 改动前：origin `http://localhost:1081` 不匹配 `http://localhost:48911` 被拒绝；改动后：hostname 均为 `localhost` 即通过 | 攻击者如果拿到有效 CSRF token，可从同 hostname 不同端口发起请求——但 token 本身已绑定会话，风险可控 |
| **插件跳转相对路径** | [agent_router.py](file:///c:/Users/HINS/Documents/Trae/N.E.K.O/N.E.K.O/main_routers/agent_router.py#L459-L467) | 当 `NEKO_BEHIND_PROXY=true` 时返回 `/ui` 而非拼接容器内部地址 | 反向代理下，容器内 127.0.0.1:48916 对浏览器不可达 | 改动前：302 跳转到 `http://127.0.0.1:48916/ui` 浏览器无法访问；改动后：返回 `/ui` 由 Nginx 代理到插件服务 | 非反向代理场景下若误设环境变量会跳转到错误路径，需确保仅 Docker 部署时设置该变量 |

**验证方式**：通过 Docker Compose 工作流实际部署测试，验证了：
- 插件面板跳转正常
- WebSocket 连接正常（ws 路径从通用 proxy 中拆分）
- 多架构镜像构建通过（amd64 + arm64）

---

## 不拆分理由 / Why Not Split

不适用。计入上限的改动文件共 15 个（≤ 20），无需强制拆分。

---

## 测试 / Testing

验证是通过 Docker CI 工作流实际部署测试，涵盖：
- Docker Compose 完整部署链路
- 多架构镜像构建（amd64 / arm64）
- 反向代理场景下的插件跳转、CSRF 校验、WebSocket 连接
- 数据目录权限与用户主目录路径统一

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 镜像现已自动下载并启动 OpenFang 服务（并在容器内完成初始化）。
  - 增强反向代理适配：插件页面与相关 WebSocket 连接可正常访问；支持在代理场景下调整跳转路径与头部处理。
- **错误修复**
  - 跨端口访问时的安全校验更宽容，减少合法请求被误拒绝。
- **文档**
  - 更新多语言 Docker 部署指南：统一数据与 SSL 证书容器内挂载路径为 `/home/neko/...`，并同步调整排查/查看命令。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->