### PR TITLE
chore: add reproducible runtime memory baseline

### DIFF
--- a/docs/benchmarks/runtime-memory-baseline-2026-07-15.md
+++ b/docs/benchmarks/runtime-memory-baseline-2026-07-15.md
@@ -3,7 +3,7 @@
 This document is the reproducible **before** baseline for runtime-memory work in
 Xiao8. Measurements were collected from commit
 `5ca2f416db2e09b4628b395c51a108ead7fc13a4` (`origin/main` on 2026-07-15) with
-[`scripts/runtime_memory_baseline.py`](../../scripts/runtime_memory_baseline.py).
+`scripts/runtime_memory_baseline.py`.
 
 ## Scope and interpretation
 
@@ -137,8 +137,8 @@ state, with a material temporary Python allocation peak.
 
 ### browser-use and Playwright
 
-The measured transition launches a real headed Chromium against `about:blank`
-with no network navigation.
+The measured transition launches a real Chromium process in headed mode against
+`about:blank` with no network navigation.
 
 | Checkpoint | Python RSS / USS | Chromium RSS / USS | traced current / peak |
 | --- | ---: | ---: | ---: |

--- a/docs/benchmarks/runtime-memory-baseline-2026-07-15.md
+++ b/docs/benchmarks/runtime-memory-baseline-2026-07-15.md
@@ -1,0 +1,223 @@
+# Runtime memory baseline (2026-07-15)
+
+This document is the reproducible **before** baseline for runtime-memory work in
+Xiao8. Measurements were collected from commit
+`5ca2f416db2e09b4628b395c51a108ead7fc13a4` (`origin/main` on 2026-07-15) with
+[`scripts/runtime_memory_baseline.py`](../../scripts/runtime_memory_baseline.py).
+
+## Scope and interpretation
+
+- `psutil` samples the complete process tree every 250 ms. A checkpoint is the
+  median of a three-second window after the transition has settled.
+- RSS includes shared and memory-mapped resident pages. It is useful for peak
+  pressure, but adding RSS across processes can double-count shared pages.
+- USS is memory unique to a process and is the primary comparison metric here.
+- `tracemalloc` runs inside the feature-scenario Python process with 10 frames.
+  It cannot attach to an already running child process. `USS - traced current`
+  is therefore only an attribution aid: it includes the interpreter, native
+  extensions, allocator slack, mappings, and any untraced Python allocation.
+- Stack runs use actual launcher, server, Electron, and Chromium processes.
+  Scenario runs isolate one lazy transition in one Python process.
+- Values are MiB. Except for the three-run development cold-start baseline,
+  results are one run with multiple samples per checkpoint. They should be
+  compared with the same scenario and host rather than treated as universal
+  constants.
+
+## Test environment
+
+| Item | Value |
+| --- | --- |
+| OS | Windows build 26100 (`Windows-10-10.0.26100-SP0`) |
+| CPU / memory | Intel Core Ultra 7 265KF, 20 logical CPUs, 63.625 GiB RAM |
+| Python | 3.11.13, always launched through `uv run` |
+| psutil / onnxruntime / NumPy | 7.2.2 / 1.25.0 / 1.26.4 |
+| tokenizers / rapidocr-onnxruntime | 0.22.2 / 1.4.4 |
+| browser-use / Playwright | 0.11.9 / 1.58.0 |
+| Embedding model | `jinaai/jina-embeddings-v5-text-nano-retrieval`, revision `ac5d898c8d382b17167c33e5c8af644a3519b47d`, quantized ONNX profile, 256 dimensions |
+| Embedding files | tokenizer 16.41 MiB, ONNX 0.13 MiB, external data 235.56 MiB |
+| OCR models | PP-OCRv4 mobile detector 4.53 MiB, recognizer 10.35 MiB, classifier 0.56 MiB |
+| Electron sample | Packaged N.E.K.O 0.8.3 attached to the measured backend; runtime reported Electron 41.7.1 |
+
+The new worktree did not have enough free disk space to create a second full
+environment. This run used `uv run --project <main-checkout> --no-sync` against
+an existing Python 3.11.13 environment after verifying that the current and
+main-checkout `uv.lock` files had the same SHA-256. Imports of Xiao8 code still
+resolved from this worktree. A normal rerun should use `uv sync --locked
+--group galgame` in the target worktree first.
+
+## Before baseline
+
+The split below is the primary hand-off for optimization tasks. `Python` does
+not include the small `uv` wrapper, which is shown as part of the total.
+
+| Checkpoint | Python RSS / USS | Electron main RSS / USS | Chromium children RSS / USS | Whole measured tree RSS / USS |
+| --- | ---: | ---: | ---: | ---: |
+| Development cold READY, three-server mode, median of 3 | 722.8 / 546.7 | - | - | 742.7 / 552.8 |
+| Merged-server cold READY | 402.8 / 339.6 | - | - | 422.5 / 345.7 |
+| First chat complete, three-server mode | 810.3 / 630.3 | - | - | 830.0 / 636.4 |
+| Embedding READY | 194.2 / 163.4 | - | - | 194.2 / 163.4 |
+| OCR constructed and first blank-image inference complete | 308.2 / 271.0 | - | - | 308.2 / 271.0 |
+| browser-use + headed Playwright started | 233.8 / 214.5 | - | 420.3 / 121.8 (7) | 654.1 / 336.3 |
+| Packaged Electron attached to merged backend | 410.3 / 346.8 | 233.3 / 107.9 | 1165.0 / 611.6 (6) | 1951.0 / 1110.5 |
+
+The last row also contains 122.6 / 38.1 MiB of packaged-app helpers
+(OpenFang, PowerShell, and console host) and a 19.6 / 6.1 MiB `uv` wrapper.
+The Electron subtotal (main plus Chromium children) is 1398.3 / 719.5 MiB.
+The packaged binary was not rebuilt from the Xiao8 commit above, so use this
+row for component attribution and distribution-shaped comparisons, not as a
+source-to-binary regression gate.
+
+### Cold start
+
+Three-server mode (`NEKO_MERGED=0`) reached all three ports in 13.797 seconds
+on the first cold-cache run and 7.182 / 6.863 seconds on two warm-cache repeats.
+After an eight-second settle, its three whole-tree READY checkpoints were:
+
+| Run | RSS | USS |
+| --- | ---: | ---: |
+| 1 | 749.3 | 559.1 |
+| 2 | 742.7 | 552.8 |
+| 3 | 741.8 | 552.0 |
+
+The first run's Python services were launcher 65.8 / 33.1, memory server
+126.7 / 88.1, main server 339.3 / 285.2, and agent server 193.7 / 146.2 MiB,
+plus a 4.1 / 0.4 MiB Python stub. Merged mode (`NEKO_MERGED=1`) was 422.5 /
+345.7 MiB for the whole tree. On this host, merging saved about 320.2 MiB RSS
+and 207.1 MiB USS versus the three-run median.
+
+### First chat
+
+A fixed synthetic prompt completed in 1.954 seconds. The benchmark JSON retains
+only message types, counts, timing, and status codes; it does not retain prompt
+or response text.
+
+| Transition | Whole tree RSS delta | Whole tree USS delta |
+| --- | ---: | ---: |
+| READY to first chat complete | +88.2 | +84.4 |
+
+The memory server accounted for +78.7 / +75.9 MiB of that change, and the main
+server for +9.3 / +8.3 MiB. Agent and launcher changes were negligible. Thus
+the first-turn lazy allocation is concentrated in the memory service. Finer
+Python-versus-native attribution would require starting `tracemalloc` inside
+that child service; an external sampler cannot provide it.
+
+The launcher overrode the attempted isolated storage root during this run and
+used the selected existing character store. The synthetic turn was therefore
+persisted by normal application behavior. No automatic cleanup was performed.
+Startup also ran the application's ordinary memory-maintenance path. A rerun
+that must be side-effect-free needs a launcher-supported, verified isolated
+storage configuration before sending the chat request.
+
+### Embedding READY
+
+| Checkpoint | RSS | USS | traced current / peak | USS - traced current |
+| --- | ---: | ---: | ---: | ---: |
+| Minimal Python | 30.7 | 18.0 | 0.0 / 0.1 | 18.0 |
+| Embedding imports | 106.5 | 91.0 | 23.9 / 24.0 | 67.1 |
+| Model READY | 194.2 | 163.4 | 31.6 / 31.7 | 131.8 |
+| First inference | 322.7 | 165.6 | 31.7 / 31.7 | 134.0 |
+
+Imports to READY added +87.7 / +72.5 MiB RSS/USS, but only +7.8 MiB of
+current traced allocations. READY to first inference added +128.6 MiB RSS but
+only +2.2 MiB USS and almost no traced heap, consistent with file-backed/shared
+model pages becoming resident rather than a large unique Python allocation.
+
+### OCR enabled
+
+| Checkpoint | RSS | USS | traced current / peak | USS - traced current |
+| --- | ---: | ---: | ---: | ---: |
+| Minimal Python | 31.0 | 18.3 | 0.0 / 0.1 | 18.2 |
+| OCR imports | 201.9 | 184.0 | 40.8 / 40.8 | 143.3 |
+| Runtime + first blank-image inference | 308.2 | 271.0 | 53.2 / 102.8 | 217.9 |
+
+Imports to enabled runtime added +106.2 / +87.0 MiB RSS/USS. Current traced
+heap grew by only +12.4 MiB, while the trace peak reached 102.8 MiB during
+initialization. The persistent increase is primarily untraced/native runtime
+state, with a material temporary Python allocation peak.
+
+### browser-use and Playwright
+
+The measured transition launches a real headed Chromium against `about:blank`
+with no network navigation.
+
+| Checkpoint | Python RSS / USS | Chromium RSS / USS | traced current / peak |
+| --- | ---: | ---: | ---: |
+| Minimal Python | 30.7 / 18.1 | - | 0.0 / 0.1 |
+| browser-use imported | 187.6 / 171.1 | - | 35.8 / 35.9 |
+| Playwright started | 233.8 / 214.5 | 420.3 / 121.8 (7) | 46.8 / 46.8 |
+
+At Playwright READY, Python's `USS - traced current` was about 167.9 MiB. The
+browser transition from imports added 165.2 MiB total USS: about 43.4 MiB in
+Python and 121.8 MiB across Chromium. A headless comparison was also measured
+at 668.2 / 350.4 MiB total with 434.4 / 136.0 MiB in Chromium; it is close
+enough that headed/headless should be kept consistent within a regression run.
+
+## Attribution and optimization order
+
+1. **Electron renderers are the largest unique component in the measured full
+   stack.** Six Chromium children used 611.6 MiB USS; Electron main added 107.9
+   MiB. Renderer/window lifetime and count deserve measurement before broad
+   Python object rewrites.
+2. **Duplicated Python server state is the next clear structural cost.** Merged
+   mode reduced the READY baseline by 207.1 MiB USS on this host.
+3. **First-chat growth belongs mainly to the memory server.** Its +75.9 MiB USS
+   explains 90% of the whole-tree first-turn USS delta.
+4. **browser-use has both a heavy import footprint and a browser-process
+   footprint.** Importing it added about 152.9 MiB Python USS from the minimal
+   process; starting Chromium added another 165.2 MiB total USS.
+5. **OCR and embedding READY are mostly not traced Python heap.** Persistent
+   optimization should target ONNX Runtime sessions, model mappings, provider
+   lifetime, and buffers. OCR initialization also has a temporary traced peak.
+6. **RSS-only conclusions can be misleading.** Embedding's first inference is
+   the clearest example: +128.6 MiB RSS with only +2.2 MiB USS.
+
+## Reproduction
+
+Create a clean environment and make sure the required local models and browser
+binary are already installed. All Python entry points must remain under `uv
+run`.
+
+```powershell
+uv sync --locked --group galgame
+
+uv run python scripts/runtime_memory_baseline.py --output embedding.json scenario embedding --embedding-root data/embedding_models
+uv run python scripts/runtime_memory_baseline.py --output ocr.json scenario ocr
+uv run python scripts/runtime_memory_baseline.py --output browser-headed.json scenario browser-use --headed
+
+uv run python scripts/runtime_memory_baseline.py --output cold-multi.json stack `
+  --backend-command 'uv|run|python|launcher.py' `
+  --env NEKO_MERGED=0 --settle 8
+
+uv run python scripts/runtime_memory_baseline.py --output cold-merged.json stack `
+  --backend-command 'uv|run|python|launcher.py' `
+  --env NEKO_MERGED=1 --settle 8
+```
+
+Electron can be added with `--electron-command '<absolute-path-to-exe>'` and
+`--electron-cwd '<distribution-directory>'`. The synthetic first-chat probe is
+enabled with `--synthetic-chat --chat-character '<character>'`; it invokes the
+configured provider and may persist data, so verify storage isolation first.
+
+Run each comparison at least three times on the same host, use checkpoint
+medians, and preserve both RSS and USS. Do not commit the generated JSON or
+subprocess logs. Stack logs can contain application data even though the JSON
+does not, and should be deleted after extracting aggregate measurements.
+
+## Regression gates for follow-up tasks
+
+Use these stable comparisons rather than a single absolute RSS value:
+
+- three-server READY whole-tree median: **742.7 / 552.8 MiB** RSS/USS;
+- merged READY whole tree: **422.5 / 345.7 MiB**;
+- first chat whole-tree delta: **+88.2 / +84.4 MiB**;
+- embedding imports to READY: **+87.7 / +72.5 MiB**, traced current **+7.8 MiB**;
+- OCR imports to enabled: **+106.2 / +87.0 MiB**, traced current **+12.4 MiB**;
+- browser-use imports to Playwright READY: **+466.5 / +165.2 MiB** total,
+  including **420.3 / 121.8 MiB** in Chromium;
+- merged backend plus packaged Electron: **1951.0 / 1110.5 MiB** whole tree,
+  with Electron main plus children at **1398.3 / 719.5 MiB**.
+
+For any optimization, report the same checkpoint, process-category split,
+Python traced current/peak when available, and host/build provenance. A change
+that lowers RSS but not USS may only change residency rather than durable
+unique memory.

--- a/docs/benchmarks/runtime-memory-baseline-2026-07-15.md
+++ b/docs/benchmarks/runtime-memory-baseline-2026-07-15.md
@@ -54,7 +54,7 @@ not include the small `uv` wrapper, which is shown as part of the total.
 | --- | ---: | ---: | ---: | ---: |
 | Development cold READY, three-server mode, median of 3 | 722.8 / 546.7 | - | - | 742.7 / 552.8 |
 | Merged-server cold READY | 402.8 / 339.6 | - | - | 422.5 / 345.7 |
-| First chat complete, three-server mode | 810.3 / 630.3 | - | - | 830.0 / 636.4 |
+| First chat after session teardown, three-server mode | 810.3 / 630.3 | - | - | 830.0 / 636.4 |
 | Embedding READY | 194.2 / 163.4 | - | - | 194.2 / 163.4 |
 | OCR constructed and first blank-image inference complete | 308.2 / 271.0 | - | - | 308.2 / 271.0 |
 | browser-use + headed Playwright started | 233.8 / 214.5 | - | 420.3 / 121.8 (7) | 654.1 / 336.3 |
@@ -93,13 +93,20 @@ or response text.
 
 | Transition | Whole tree RSS delta | Whole tree USS delta |
 | --- | ---: | ---: |
-| READY to first chat complete | +88.2 | +84.4 |
+| READY to first chat after session teardown | +88.2 | +84.4 |
 
 The memory server accounted for +78.7 / +75.9 MiB of that change, and the main
 server for +9.3 / +8.3 MiB. Agent and launcher changes were negligible. Thus
 the first-turn lazy allocation is concentrated in the memory service. Finer
 Python-versus-native attribution would require starting `tracemalloc` inside
 that child service; an external sampler cannot provide it.
+
+The original run sent `end_session` before this checkpoint, so the number is a
+conservative after-teardown baseline rather than the retained memory of a live
+text session. The probe now records `first_chat_complete_live` before sending
+`end_session`. A replacement live-session number requires a rerun with verified
+isolated storage; it was not repeated here because the launcher had already
+ignored the attempted isolated root and persisted the synthetic turn.
 
 The launcher overrode the attempted isolated storage root during this run and
 used the selected existing character store. The synthetic turn was therefore
@@ -209,7 +216,8 @@ Use these stable comparisons rather than a single absolute RSS value:
 
 - three-server READY whole-tree median: **742.7 / 552.8 MiB** RSS/USS;
 - merged READY whole tree: **422.5 / 345.7 MiB**;
-- first chat whole-tree delta: **+88.2 / +84.4 MiB**;
+- legacy first-chat after-teardown delta: **+88.2 / +84.4 MiB**; do not compare
+  this with the probe's new `first_chat_complete_live` checkpoint;
 - embedding imports to READY: **+87.7 / +72.5 MiB**, traced current **+7.8 MiB**;
 - OCR imports to enabled: **+106.2 / +87.0 MiB**, traced current **+12.4 MiB**;
 - browser-use imports to Playwright READY: **+466.5 / +165.2 MiB** total,

--- a/scripts/runtime_memory_baseline.py
+++ b/scripts/runtime_memory_baseline.py
@@ -24,15 +24,15 @@ import platform
 import socket
 import statistics
 import subprocess
-import sys
 import time
 import tracemalloc
 import urllib.parse
 import urllib.request
 import uuid
 from collections import Counter
+from contextlib import suppress
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Callable, Iterable
 
 import psutil
 
@@ -161,7 +161,11 @@ def _series_summary(samples: list[dict[str, Any]]) -> dict[str, Any]:
         ]
         uss_values: list[float] = []
         for sample in samples:
-            uss_mib = sample["categories"].get(name, {}).get("uss_mib")
+            category = sample["categories"].get(name)
+            if category is None:
+                uss_values.append(0.0)
+                continue
+            uss_mib = category.get("uss_mib")
             if uss_mib is not None:
                 uss_values.append(float(uss_mib))
         count_values = [
@@ -486,17 +490,14 @@ def _terminate_process_trees(
             except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
                 continue
     target_list = list(targets.values())
+    # Teardown is best-effort because processes can exit between discovery and action.
     for target in reversed(target_list):
-        try:
+        with suppress(psutil.AccessDenied, psutil.NoSuchProcess, OSError):
             target.terminate()
-        except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
-            pass
     _, alive = psutil.wait_procs(target_list, timeout=timeout)
     for target in alive:
-        try:
+        with suppress(psutil.AccessDenied, psutil.NoSuchProcess, OSError):
             target.kill()
-        except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
-            pass
 
 
 async def _run_synthetic_chat(
@@ -505,6 +506,7 @@ async def _run_synthetic_chat(
     character: str,
     prompt: str,
     timeout: float,
+    after_turn: Callable[[], None] | None = None,
 ) -> dict[str, Any]:
     import websockets
 
@@ -578,14 +580,19 @@ async def _run_synthetic_chat(
             if (
                 message_type == "system"
                 and str(message.get("data") or "").startswith("turn end")
-                and message.get("request_id") in (None, request_id)
+                and message.get("request_id") == request_id
             ):
                 break
 
-        await websocket.send(json.dumps({"action": "end_session"}))
+        turn_elapsed_s = round(time.perf_counter() - started_at, 3)
+        try:
+            if after_turn is not None:
+                await asyncio.to_thread(after_turn)
+        finally:
+            await websocket.send(json.dumps({"action": "end_session"}))
 
     return {
-        "elapsed_s": round(time.perf_counter() - started_at, 3),
+        "elapsed_s": turn_elapsed_s,
         "message_type_counts": dict(sorted(counts.items())),
         "status_code_counts": dict(sorted(status_codes.items())),
         "request_id_prefix": "memory-baseline-",
@@ -728,22 +735,25 @@ def _stack(args: argparse.Namespace) -> dict[str, Any]:
 
         chat_result = None
         if args.synthetic_chat:
+            def _record_live_first_chat() -> None:
+                time.sleep(args.settle)
+                checkpoints.append(
+                    _sample_window(
+                        "first_chat_complete_live",
+                        roots,
+                        seconds=args.window,
+                        interval=args.interval,
+                        observed_processes=observed_processes,
+                    )
+                )
+
             chat_result = asyncio.run(
                 _run_synthetic_chat(
                     port=ports[0],
                     character=args.chat_character,
                     prompt=args.chat_prompt,
                     timeout=args.chat_timeout,
-                )
-            )
-            time.sleep(args.settle)
-            checkpoints.append(
-                _sample_window(
-                    "first_chat_complete",
-                    roots,
-                    seconds=args.window,
-                    interval=args.interval,
-                    observed_processes=observed_processes,
+                    after_turn=_record_live_first_chat,
                 )
             )
 

--- a/scripts/runtime_memory_baseline.py
+++ b/scripts/runtime_memory_baseline.py
@@ -1,0 +1,744 @@
+#!/usr/bin/env python3
+"""Collect reproducible runtime-memory checkpoints for N.E.K.O.
+
+The probe deliberately keeps two measurement scopes separate:
+
+* ``stack`` samples real child processes with psutil. It is suitable for the
+  launcher, Electron, and their descendants.
+* ``scenario`` runs one lazy feature transition in this process so tracemalloc
+  can distinguish traced Python allocations from total process USS.
+
+The JSON output never includes command lines, environment variables, API
+payloads, or response text. Synthetic chat runs retain only message types and
+status codes. ``stack`` subprocess logs can contain application data, so treat
+them as sensitive diagnostics and remove them after extracting aggregate data.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import platform
+import socket
+import statistics
+import subprocess
+import sys
+import time
+import tracemalloc
+import urllib.parse
+import urllib.request
+import uuid
+from collections import Counter
+from pathlib import Path
+from typing import Any, Iterable
+
+import psutil
+
+
+MIB = 1024 * 1024
+DEFAULT_SAMPLE_INTERVAL = 0.25
+
+
+def _mib(value: int | float | None) -> float | None:
+    if value is None:
+        return None
+    return round(float(value) / MIB, 3)
+
+
+def _process_category(process: psutil.Process) -> str:
+    try:
+        name = process.name().lower()
+    except (psutil.Error, OSError):
+        return "unknown"
+
+    try:
+        command = [str(item).lower() for item in process.cmdline()]
+    except (psutil.Error, OSError):
+        command = []
+
+    if "electron" in name or name == "n.e.k.o.exe":
+        if any(item.startswith("--type=") for item in command):
+            return "electron_chromium_child"
+        return "electron_main"
+    if "chrome" in name or "chromium" in name:
+        return "chromium"
+    if "python" in name:
+        return "python"
+    if name in {"uv.exe", "uv"}:
+        return "uv_wrapper"
+    if "node" in name:
+        return "node"
+    return "other"
+
+
+def _process_row(process: psutil.Process) -> dict[str, Any] | None:
+    try:
+        basic = process.memory_info()
+        try:
+            full = process.memory_full_info()
+            uss = getattr(full, "uss", None)
+        except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
+            uss = None
+        return {
+            "pid": process.pid,
+            "ppid": process.ppid(),
+            "name": process.name(),
+            "category": _process_category(process),
+            "rss_mib": _mib(basic.rss),
+            "uss_mib": _mib(uss),
+        }
+    except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
+        return None
+
+
+def _tree_processes(root_pids: Iterable[int]) -> list[psutil.Process]:
+    found: dict[int, psutil.Process] = {}
+    for pid in root_pids:
+        try:
+            root = psutil.Process(pid)
+            found[root.pid] = root
+            for child in root.children(recursive=True):
+                found[child.pid] = child
+        except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
+            continue
+    return list(found.values())
+
+
+def _sample(root_pids: Iterable[int]) -> dict[str, Any]:
+    rows = [row for process in _tree_processes(root_pids) if (row := _process_row(process))]
+    categories: dict[str, dict[str, float | int | None]] = {}
+    for row in rows:
+        entry = categories.setdefault(
+            row["category"],
+            {"count": 0, "rss_mib": 0.0, "uss_mib": 0.0, "uss_processes": 0},
+        )
+        entry["count"] = int(entry["count"]) + 1
+        entry["rss_mib"] = float(entry["rss_mib"]) + float(row["rss_mib"] or 0.0)
+        if row["uss_mib"] is not None:
+            entry["uss_mib"] = float(entry["uss_mib"]) + float(row["uss_mib"])
+            entry["uss_processes"] = int(entry["uss_processes"]) + 1
+
+    total_rss = sum(float(row["rss_mib"] or 0.0) for row in rows)
+    total_uss_values = [float(row["uss_mib"]) for row in rows if row["uss_mib"] is not None]
+    return {
+        "elapsed_s": round(time.perf_counter(), 6),
+        "categories": categories,
+        "total": {
+            "count": len(rows),
+            "rss_mib": round(total_rss, 3),
+            "uss_mib": round(sum(total_uss_values), 3) if total_uss_values else None,
+            "uss_processes": len(total_uss_values),
+        },
+        "processes": rows,
+    }
+
+
+def _series_summary(samples: list[dict[str, Any]]) -> dict[str, Any]:
+    category_names = sorted(
+        {name for sample in samples for name in sample.get("categories", {})}
+    )
+    categories: dict[str, dict[str, float | int | None]] = {}
+    for name in category_names:
+        rss_values = [
+            float(sample["categories"].get(name, {}).get("rss_mib", 0.0))
+            for sample in samples
+        ]
+        uss_values = [
+            float(sample["categories"].get(name, {}).get("uss_mib", 0.0))
+            for sample in samples
+        ]
+        count_values = [
+            int(sample["categories"].get(name, {}).get("count", 0))
+            for sample in samples
+        ]
+        categories[name] = {
+            "median_count": int(statistics.median(count_values)),
+            "max_count": max(count_values),
+            "median_rss_mib": round(statistics.median(rss_values), 3),
+            "peak_rss_mib": round(max(rss_values), 3),
+            "median_uss_mib": round(statistics.median(uss_values), 3),
+            "peak_uss_mib": round(max(uss_values), 3),
+        }
+
+    total_rss = [float(sample["total"]["rss_mib"] or 0.0) for sample in samples]
+    total_uss = [
+        float(sample["total"]["uss_mib"] or 0.0)
+        for sample in samples
+        if sample["total"]["uss_mib"] is not None
+    ]
+    return {
+        "sample_count": len(samples),
+        "categories": categories,
+        "total": {
+            "median_rss_mib": round(statistics.median(total_rss), 3) if total_rss else 0.0,
+            "peak_rss_mib": round(max(total_rss), 3) if total_rss else 0.0,
+            "median_uss_mib": round(statistics.median(total_uss), 3) if total_uss else None,
+            "peak_uss_mib": round(max(total_uss), 3) if total_uss else None,
+        },
+        "last_processes": samples[-1]["processes"] if samples else [],
+    }
+
+
+def _sample_window(
+    label: str,
+    root_pids: Iterable[int],
+    *,
+    seconds: float,
+    interval: float,
+    traced_python_pid: int | None = None,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + max(seconds, 0.0)
+    samples: list[dict[str, Any]] = []
+    while True:
+        samples.append(_sample(root_pids))
+        if time.monotonic() >= deadline:
+            break
+        time.sleep(interval)
+
+    result = {"label": label, **_series_summary(samples)}
+    if traced_python_pid is not None and tracemalloc.is_tracing():
+        current, peak = tracemalloc.get_traced_memory()
+        traced_uss = None
+        for row in result["last_processes"]:
+            if row["pid"] == traced_python_pid:
+                traced_uss = row["uss_mib"]
+                break
+        current_mib = _mib(current)
+        result["tracemalloc"] = {
+            "pid": traced_python_pid,
+            "current_mib": current_mib,
+            "peak_mib": _mib(peak),
+            "uss_minus_traced_current_mib": (
+                round(float(traced_uss) - float(current_mib), 3)
+                if traced_uss is not None and current_mib is not None
+                else None
+            ),
+        }
+    return result
+
+
+def _metadata() -> dict[str, Any]:
+    try:
+        commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], text=True, stderr=subprocess.DEVNULL
+        ).strip()
+    except (OSError, subprocess.SubprocessError):
+        commit = ""
+    return {
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        "git_commit": commit,
+        "python": platform.python_version(),
+        "platform": platform.platform(),
+        "logical_cpu_count": psutil.cpu_count(),
+        "ram_gib": round(psutil.virtual_memory().total / (1024**3), 3),
+        "sample_interval_s": DEFAULT_SAMPLE_INTERVAL,
+    }
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(path.resolve())
+
+
+async def _embedding_scenario(args: argparse.Namespace) -> dict[str, Any]:
+    checkpoints = [
+        _sample_window(
+            "python_baseline",
+            [os.getpid()],
+            seconds=args.window,
+            interval=args.interval,
+            traced_python_pid=os.getpid(),
+        )
+    ]
+
+    from config import (
+        VECTORS_EMBEDDING_DIM,
+        VECTORS_MIN_RAM_GB,
+        VECTORS_MODEL_PROFILE_ID,
+        VECTORS_QUANTIZATION,
+    )
+    from memory.embeddings import EmbeddingService
+
+    checkpoints.append(
+        _sample_window(
+            "embedding_imported",
+            [os.getpid()],
+            seconds=args.window,
+            interval=args.interval,
+            traced_python_pid=os.getpid(),
+        )
+    )
+    service = EmbeddingService(
+        model_dir=str(Path(args.embedding_root).resolve()),
+        enabled=True,
+        embedding_dim_setting=VECTORS_EMBEDDING_DIM,
+        quantization_setting=VECTORS_QUANTIZATION,
+        min_ram_gb=VECTORS_MIN_RAM_GB,
+        profile_id=VECTORS_MODEL_PROFILE_ID,
+    )
+    ready = await service.request_load()
+    if not ready:
+        raise RuntimeError(f"embedding service did not become READY: {service.disable_reason()}")
+    checkpoints.append(
+        _sample_window(
+            "embedding_ready",
+            [os.getpid()],
+            seconds=args.window,
+            interval=args.interval,
+            traced_python_pid=os.getpid(),
+        )
+    )
+    vector = await service.embed("N.E.K.O runtime memory baseline")
+    checkpoints.append(
+        _sample_window(
+            "embedding_first_inference",
+            [os.getpid()],
+            seconds=args.window,
+            interval=args.interval,
+            traced_python_pid=os.getpid(),
+        )
+    )
+    return {
+        "scenario": "embedding",
+        "embedding": {
+            "ready": ready,
+            "model_id": service.model_id(),
+            "model_root": str(Path(args.embedding_root).resolve()),
+            "vector_dimensions": len(vector or []),
+        },
+        "checkpoints": checkpoints,
+    }
+
+
+async def _ocr_scenario(args: argparse.Namespace) -> dict[str, Any]:
+    checkpoints = [
+        _sample_window(
+            "python_baseline",
+            [os.getpid()],
+            seconds=args.window,
+            interval=args.interval,
+            traced_python_pid=os.getpid(),
+        )
+    ]
+    from PIL import Image
+    from plugin.plugins._shared.rapidocr.rapidocr_support import (
+        DEFAULT_RAPIDOCR_ENGINE_TYPE,
+        DEFAULT_RAPIDOCR_LANG_TYPE,
+        DEFAULT_RAPIDOCR_MODEL_TYPE,
+        DEFAULT_RAPIDOCR_OCR_VERSION,
+    )
+    from plugin.plugins.galgame_plugin.ocr_rapidocr_backend import RapidOcrBackend
+
+    backend = RapidOcrBackend(
+        install_target_dir_raw="",
+        engine_type=DEFAULT_RAPIDOCR_ENGINE_TYPE,
+        lang_type=DEFAULT_RAPIDOCR_LANG_TYPE,
+        model_type=DEFAULT_RAPIDOCR_MODEL_TYPE,
+        ocr_version=DEFAULT_RAPIDOCR_OCR_VERSION,
+    )
+    available = backend.is_available()
+    checkpoints.append(
+        _sample_window(
+            "ocr_imported",
+            [os.getpid()],
+            seconds=args.window,
+            interval=args.interval,
+            traced_python_pid=os.getpid(),
+        )
+    )
+    if not available:
+        raise RuntimeError("RapidOCR backend is not available")
+    text = backend.extract_text(Image.new("RGB", (640, 360), "white"))
+    checkpoints.append(
+        _sample_window(
+            "ocr_ready_after_first_inference",
+            [os.getpid()],
+            seconds=args.window,
+            interval=args.interval,
+            traced_python_pid=os.getpid(),
+        )
+    )
+    return {
+        "scenario": "ocr",
+        "ocr": {"available": available, "synthetic_text_length": len(text)},
+        "checkpoints": checkpoints,
+    }
+
+
+async def _browser_scenario(args: argparse.Namespace) -> dict[str, Any]:
+    checkpoints = [
+        _sample_window(
+            "python_baseline",
+            [os.getpid()],
+            seconds=args.window,
+            interval=args.interval,
+            traced_python_pid=os.getpid(),
+        )
+    ]
+    from brain.browser_use_adapter import BrowserUseAdapter
+
+    adapter = BrowserUseAdapter(headless=not args.headed)
+    checkpoints.append(
+        _sample_window(
+            "browser_use_imported",
+            [os.getpid()],
+            seconds=args.window,
+            interval=args.interval,
+            traced_python_pid=os.getpid(),
+        )
+    )
+    session = await adapter._get_browser_session()
+    await session.start()
+    adapter._session_ever_started = True
+    try:
+        checkpoints.append(
+            _sample_window(
+                "browser_use_playwright_started",
+                [os.getpid()],
+                seconds=args.window,
+                interval=args.interval,
+                traced_python_pid=os.getpid(),
+            )
+        )
+    finally:
+        await adapter.close()
+    return {
+        "scenario": "browser_use",
+        "browser": {"headless": not args.headed},
+        "checkpoints": checkpoints,
+    }
+
+
+def _ports_ready(ports: list[int]) -> bool:
+    for port in ports:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.25):
+                pass
+        except OSError:
+            return False
+    return True
+
+
+def _terminate_process_tree(process: subprocess.Popen[Any], timeout: float = 12.0) -> None:
+    try:
+        root = psutil.Process(process.pid)
+        targets = root.children(recursive=True)
+        targets.append(root)
+    except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
+        targets = []
+    for target in reversed(targets):
+        try:
+            target.terminate()
+        except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
+            pass
+    _, alive = psutil.wait_procs(targets, timeout=timeout)
+    for target in alive:
+        try:
+            target.kill()
+        except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
+            pass
+
+
+async def _run_synthetic_chat(
+    *,
+    port: int,
+    character: str,
+    prompt: str,
+    timeout: float,
+) -> dict[str, Any]:
+    import websockets
+
+    if not character:
+        def _read_current_character() -> dict[str, Any]:
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{port}/api/characters/current_catgirl", timeout=5
+            ) as response:
+                return json.loads(response.read().decode("utf-8"))
+
+        current = await asyncio.to_thread(_read_current_character)
+        character = str(current.get("current_catgirl") or "").strip()
+    if not character:
+        raise RuntimeError("no character available for synthetic chat")
+
+    request_id = f"memory-baseline-{uuid.uuid4().hex}"
+    uri = f"ws://127.0.0.1:{port}/ws/{urllib.parse.quote(character, safe='')}"
+    counts: Counter[str] = Counter()
+    status_codes: Counter[str] = Counter()
+    started_at = time.perf_counter()
+    async with websockets.connect(uri, max_size=32 * MIB) as websocket:
+        await websocket.send(
+            json.dumps(
+                {
+                    "action": "start_session",
+                    "input_type": "text",
+                    "new_session": True,
+                    "language": "en",
+                }
+            )
+        )
+        while True:
+            raw = await asyncio.wait_for(websocket.recv(), timeout=timeout)
+            message = json.loads(raw)
+            message_type = str(message.get("type") or "unknown")
+            counts[message_type] += 1
+            if message_type == "status":
+                try:
+                    status = json.loads(message.get("message") or "{}")
+                except (TypeError, json.JSONDecodeError):
+                    status = {}
+                code = str(status.get("code") or "unknown")
+                status_codes[code] += 1
+            if message_type == "session_failed":
+                raise RuntimeError("synthetic chat session failed")
+            if message_type == "session_started":
+                break
+
+        await websocket.send(
+            json.dumps(
+                {
+                    "action": "stream_data",
+                    "input_type": "text",
+                    "data": prompt,
+                    "request_id": request_id,
+                    "source": "runtime_memory_baseline",
+                }
+            )
+        )
+        while True:
+            raw = await asyncio.wait_for(websocket.recv(), timeout=timeout)
+            message = json.loads(raw)
+            message_type = str(message.get("type") or "unknown")
+            counts[message_type] += 1
+            if message_type == "status":
+                try:
+                    status = json.loads(message.get("message") or "{}")
+                except (TypeError, json.JSONDecodeError):
+                    status = {}
+                status_codes[str(status.get("code") or "unknown")] += 1
+            if (
+                message_type == "system"
+                and str(message.get("data") or "").startswith("turn end")
+                and message.get("request_id") in (None, request_id)
+            ):
+                break
+
+        await websocket.send(json.dumps({"action": "end_session"}))
+
+    return {
+        "character": character,
+        "elapsed_s": round(time.perf_counter() - started_at, 3),
+        "message_type_counts": dict(sorted(counts.items())),
+        "status_code_counts": dict(sorted(status_codes.items())),
+        "request_id_prefix": "memory-baseline-",
+        "prompt_recorded": False,
+    }
+
+
+def _decode_command(raw: str) -> list[str]:
+    try:
+        command = json.loads(raw)
+    except json.JSONDecodeError:
+        command = raw.split("|")
+    if not isinstance(command, list) or not command or not all(isinstance(item, str) for item in command):
+        raise ValueError("command must be a JSON array or a pipe-delimited string")
+    return command
+
+
+def _parse_env(items: list[str]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for item in items:
+        key, separator, value = item.partition("=")
+        if not separator or not key:
+            raise ValueError(f"invalid environment override: {item!r}")
+        result[key] = value
+    return result
+
+
+def _spawn(
+    command: list[str],
+    *,
+    cwd: str,
+    env: dict[str, str],
+    log_path: Path,
+) -> tuple[subprocess.Popen[Any], Any]:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_file = log_path.open("w", encoding="utf-8", errors="replace")
+    process = subprocess.Popen(
+        command,
+        cwd=cwd,
+        env=env,
+        stdin=subprocess.DEVNULL,
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
+        text=True,
+        creationflags=(subprocess.CREATE_NEW_PROCESS_GROUP if os.name == "nt" else 0),
+    )
+    return process, log_file
+
+
+def _stack(args: argparse.Namespace) -> dict[str, Any]:
+    output = Path(args.output).resolve()
+    env = os.environ.copy()
+    env.update(_parse_env(args.env))
+    backend_command = _decode_command(args.backend_command)
+    electron_command = _decode_command(args.electron_command) if args.electron_command else None
+    ports = [int(item) for item in args.ports.split(",") if item.strip()]
+    processes: list[tuple[str, subprocess.Popen[Any], Any]] = []
+    checkpoints: list[dict[str, Any]] = []
+    startup_samples: list[dict[str, Any]] = []
+    roots: list[int] = []
+    started_at = time.perf_counter()
+    ports_ready_elapsed_s: float | None = None
+
+    try:
+        backend, backend_log = _spawn(
+            backend_command,
+            cwd=args.backend_cwd,
+            env=env,
+            log_path=output.with_suffix(".backend.log"),
+        )
+        processes.append(("backend", backend, backend_log))
+        roots.append(backend.pid)
+        deadline = time.monotonic() + args.timeout
+        while not _ports_ready(ports):
+            startup_samples.append(_sample(roots))
+            if backend.poll() is not None:
+                raise RuntimeError(f"backend exited before ready with code {backend.returncode}")
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"ports did not become ready: {ports}")
+            time.sleep(args.interval)
+        ports_ready_elapsed_s = time.perf_counter() - started_at
+        startup_samples.append(_sample(roots))
+        time.sleep(args.settle)
+        checkpoints.append(
+            _sample_window(
+                "cold_start_ready",
+                roots,
+                seconds=args.window,
+                interval=args.interval,
+            )
+        )
+
+        if electron_command is not None:
+            electron, electron_log = _spawn(
+                electron_command,
+                cwd=args.electron_cwd,
+                env=env,
+                log_path=output.with_suffix(".electron.log"),
+            )
+            processes.append(("electron", electron, electron_log))
+            roots.append(electron.pid)
+            time.sleep(args.electron_settle)
+            if electron.poll() is not None:
+                raise RuntimeError(f"Electron exited early with code {electron.returncode}")
+            checkpoints.append(
+                _sample_window(
+                    "electron_attached",
+                    roots,
+                    seconds=args.window,
+                    interval=args.interval,
+                )
+            )
+
+        chat_result = None
+        if args.synthetic_chat:
+            chat_result = asyncio.run(
+                _run_synthetic_chat(
+                    port=ports[0],
+                    character=args.chat_character,
+                    prompt=args.chat_prompt,
+                    timeout=args.chat_timeout,
+                )
+            )
+            time.sleep(args.settle)
+            checkpoints.append(
+                _sample_window(
+                    "first_chat_complete",
+                    roots,
+                    seconds=args.window,
+                    interval=args.interval,
+                )
+            )
+
+        return {
+            "scenario": "stack",
+            "ports_ready_elapsed_s": round(ports_ready_elapsed_s, 3),
+            "measurement_elapsed_s": round(time.perf_counter() - started_at, 3),
+            "ports": ports,
+            "startup_window": _series_summary(startup_samples),
+            "checkpoints": checkpoints,
+            "synthetic_chat": chat_result,
+            "logs": {
+                "backend": str(output.with_suffix(".backend.log")),
+                "electron": str(output.with_suffix(".electron.log")) if electron_command else None,
+            },
+        }
+    finally:
+        for _name, process, _log_file in reversed(processes):
+            _terminate_process_tree(process)
+        for _name, _process, log_file in processes:
+            log_file.close()
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", required=True, help="JSON output path")
+    parser.add_argument("--interval", type=float, default=DEFAULT_SAMPLE_INTERVAL)
+    parser.add_argument("--window", type=float, default=3.0)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    scenario = subparsers.add_parser("scenario", help="Run an in-process lazy feature scenario")
+    scenario.add_argument("name", choices=("embedding", "ocr", "browser-use"))
+    scenario.add_argument("--embedding-root", default="data/embedding_models")
+    scenario.add_argument("--headed", action="store_true")
+
+    stack = subparsers.add_parser("stack", help="Measure a launcher/Electron process tree")
+    stack.add_argument(
+        "--backend-command",
+        required=True,
+        help="JSON array or a pipe-delimited command",
+    )
+    stack.add_argument("--backend-cwd", default=str(Path.cwd()))
+    stack.add_argument("--electron-command", help="JSON array or a pipe-delimited command")
+    stack.add_argument("--electron-cwd", default=str(Path.cwd()))
+    stack.add_argument("--ports", default="48911,48912,48915")
+    stack.add_argument("--env", action="append", default=[], metavar="NAME=VALUE")
+    stack.add_argument("--timeout", type=float, default=150.0)
+    stack.add_argument("--settle", type=float, default=5.0)
+    stack.add_argument("--electron-settle", type=float, default=12.0)
+    stack.add_argument("--synthetic-chat", action="store_true")
+    stack.add_argument("--chat-character", default="")
+    stack.add_argument(
+        "--chat-prompt",
+        default="Reply with exactly OK. This is a runtime memory benchmark.",
+    )
+    stack.add_argument("--chat-timeout", type=float, default=90.0)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    if args.interval <= 0 or args.window < 0:
+        raise SystemExit("--interval must be positive and --window cannot be negative")
+
+    if args.command == "scenario":
+        tracemalloc.start(10)
+        if args.name == "embedding":
+            result = asyncio.run(_embedding_scenario(args))
+        elif args.name == "ocr":
+            result = asyncio.run(_ocr_scenario(args))
+        else:
+            result = asyncio.run(_browser_scenario(args))
+    else:
+        result = _stack(args)
+
+    payload = {"metadata": _metadata(), **result}
+    _write_json(Path(args.output), payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/runtime_memory_baseline.py
+++ b/scripts/runtime_memory_baseline.py
@@ -130,6 +130,9 @@ def _sample(
         if row["uss_mib"] is not None:
             entry["uss_mib"] = float(entry["uss_mib"]) + float(row["uss_mib"])
             entry["uss_processes"] = int(entry["uss_processes"]) + 1
+    for entry in categories.values():
+        if entry["uss_processes"] == 0:
+            entry["uss_mib"] = None
 
     total_rss = sum(float(row["rss_mib"] or 0.0) for row in rows)
     total_uss_values = [float(row["uss_mib"]) for row in rows if row["uss_mib"] is not None]
@@ -156,10 +159,11 @@ def _series_summary(samples: list[dict[str, Any]]) -> dict[str, Any]:
             float(sample["categories"].get(name, {}).get("rss_mib", 0.0))
             for sample in samples
         ]
-        uss_values = [
-            float(sample["categories"].get(name, {}).get("uss_mib", 0.0))
-            for sample in samples
-        ]
+        uss_values: list[float] = []
+        for sample in samples:
+            uss_mib = sample["categories"].get(name, {}).get("uss_mib")
+            if uss_mib is not None:
+                uss_values.append(float(uss_mib))
         count_values = [
             int(sample["categories"].get(name, {}).get("count", 0))
             for sample in samples
@@ -169,8 +173,10 @@ def _series_summary(samples: list[dict[str, Any]]) -> dict[str, Any]:
             "max_count": max(count_values),
             "median_rss_mib": round(statistics.median(rss_values), 3),
             "peak_rss_mib": round(max(rss_values), 3),
-            "median_uss_mib": round(statistics.median(uss_values), 3),
-            "peak_uss_mib": round(max(uss_values), 3),
+            "median_uss_mib": round(statistics.median(uss_values), 3)
+            if uss_values
+            else None,
+            "peak_uss_mib": round(max(uss_values), 3) if uss_values else None,
         }
 
     total_rss = [float(sample["total"]["rss_mib"] or 0.0) for sample in samples]
@@ -304,6 +310,10 @@ async def _embedding_scenario(args: argparse.Namespace) -> dict[str, Any]:
         )
     )
     vector = await service.embed("N.E.K.O runtime memory baseline")
+    if vector is None:
+        raise RuntimeError(
+            f"embedding inference failed after READY: {service.disable_reason()}"
+        )
     checkpoints.append(
         _sample_window(
             "embedding_first_inference",
@@ -319,7 +329,7 @@ async def _embedding_scenario(args: argparse.Namespace) -> dict[str, Any]:
             "ready": ready,
             "model_id": service.model_id(),
             "model_root": str(Path(args.embedding_root).resolve()),
-            "vector_dimensions": len(vector or []),
+            "vector_dimensions": len(vector),
         },
         "checkpoints": checkpoints,
     }
@@ -403,9 +413,9 @@ async def _browser_scenario(args: argparse.Namespace) -> dict[str, Any]:
         )
     )
     session = await adapter._get_browser_session()
-    await session.start()
-    adapter._session_ever_started = True
     try:
+        await session.start()
+        adapter._session_ever_started = True
         checkpoints.append(
             _sample_window(
                 "browser_use_playwright_started",
@@ -575,7 +585,6 @@ async def _run_synthetic_chat(
         await websocket.send(json.dumps({"action": "end_session"}))
 
     return {
-        "character": character,
         "elapsed_s": round(time.perf_counter() - started_at, 3),
         "message_type_counts": dict(sorted(counts.items())),
         "status_code_counts": dict(sorted(status_codes.items())),

--- a/scripts/runtime_memory_baseline.py
+++ b/scripts/runtime_memory_baseline.py
@@ -106,8 +106,19 @@ def _tree_processes(root_pids: Iterable[int]) -> list[psutil.Process]:
     return list(found.values())
 
 
-def _sample(root_pids: Iterable[int]) -> dict[str, Any]:
-    rows = [row for process in _tree_processes(root_pids) if (row := _process_row(process))]
+def _sample(
+    root_pids: Iterable[int],
+    *,
+    observed_processes: dict[tuple[int, float], psutil.Process] | None = None,
+) -> dict[str, Any]:
+    processes = _tree_processes(root_pids)
+    if observed_processes is not None:
+        for process in processes:
+            try:
+                observed_processes[(process.pid, process.create_time())] = process
+            except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
+                continue
+    rows = [row for process in processes if (row := _process_row(process))]
     categories: dict[str, dict[str, float | int | None]] = {}
     for row in rows:
         entry = categories.setdefault(
@@ -188,11 +199,12 @@ def _sample_window(
     seconds: float,
     interval: float,
     traced_python_pid: int | None = None,
+    observed_processes: dict[tuple[int, float], psutil.Process] | None = None,
 ) -> dict[str, Any]:
     deadline = time.monotonic() + max(seconds, 0.0)
     samples: list[dict[str, Any]] = []
     while True:
-        samples.append(_sample(root_pids))
+        samples.append(_sample(root_pids, observed_processes=observed_processes))
         if time.monotonic() >= deadline:
             break
         time.sleep(interval)
@@ -422,19 +434,54 @@ def _ports_ready(ports: list[int]) -> bool:
     return True
 
 
-def _terminate_process_tree(process: subprocess.Popen[Any], timeout: float = 12.0) -> None:
-    try:
-        root = psutil.Process(process.pid)
-        targets = root.children(recursive=True)
-        targets.append(root)
-    except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
-        targets = []
-    for target in reversed(targets):
+def _assert_ports_available(ports: list[int]) -> None:
+    busy: list[int] = []
+    for port in ports:
+        probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            if hasattr(socket, "SO_EXCLUSIVEADDRUSE"):
+                probe.setsockopt(socket.SOL_SOCKET, socket.SO_EXCLUSIVEADDRUSE, 1)
+            probe.bind(("127.0.0.1", port))
+        except OSError:
+            busy.append(port)
+        finally:
+            probe.close()
+    if busy:
+        raise RuntimeError(
+            "benchmark ports must be free before startup; refusing launcher "
+            f"fallback because it would invalidate readiness attribution: {busy}"
+        )
+
+
+def _terminate_process_trees(
+    processes: Iterable[subprocess.Popen[Any]],
+    observed_processes: Iterable[psutil.Process],
+    timeout: float = 12.0,
+) -> None:
+    targets: dict[tuple[int, float], psutil.Process] = {}
+    for target in observed_processes:
+        try:
+            targets[(target.pid, target.create_time())] = target
+        except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
+            continue
+    for process in processes:
+        try:
+            root = psutil.Process(process.pid)
+            current = [root, *root.children(recursive=True)]
+        except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
+            continue
+        for target in current:
+            try:
+                targets[(target.pid, target.create_time())] = target
+            except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
+                continue
+    target_list = list(targets.values())
+    for target in reversed(target_list):
         try:
             target.terminate()
         except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
             pass
-    _, alive = psutil.wait_procs(targets, timeout=timeout)
+    _, alive = psutil.wait_procs(target_list, timeout=timeout)
     for target in alive:
         try:
             target.kill()
@@ -541,10 +588,31 @@ def _decode_command(raw: str) -> list[str]:
     try:
         command = json.loads(raw)
     except json.JSONDecodeError:
-        command = raw.split("|")
-    if not isinstance(command, list) or not command or not all(isinstance(item, str) for item in command):
+        command = [item.strip() for item in raw.split("|")]
+    if (
+        not isinstance(command, list)
+        or not command
+        or not all(isinstance(item, str) and item for item in command)
+    ):
         raise ValueError("command must be a JSON array or a pipe-delimited string")
     return command
+
+
+def _decode_ports(raw: str) -> list[int]:
+    items = [item.strip() for item in raw.split(",")]
+    if not items or any(not item for item in items):
+        raise ValueError("--ports must be a comma-separated list of port numbers")
+    try:
+        ports = [int(item) for item in items]
+    except ValueError as exc:
+        raise ValueError(
+            "--ports must be a comma-separated list of port numbers"
+        ) from exc
+    if any(port < 1 or port > 65535 for port in ports):
+        raise ValueError("--ports values must be between 1 and 65535")
+    if len(set(ports)) != len(ports):
+        raise ValueError("--ports values must be unique")
+    return ports
 
 
 def _parse_env(items: list[str]) -> dict[str, str]:
@@ -585,11 +653,13 @@ def _stack(args: argparse.Namespace) -> dict[str, Any]:
     env.update(_parse_env(args.env))
     backend_command = _decode_command(args.backend_command)
     electron_command = _decode_command(args.electron_command) if args.electron_command else None
-    ports = [int(item) for item in args.ports.split(",") if item.strip()]
+    ports = _decode_ports(args.ports)
+    _assert_ports_available(ports)
     processes: list[tuple[str, subprocess.Popen[Any], Any]] = []
     checkpoints: list[dict[str, Any]] = []
     startup_samples: list[dict[str, Any]] = []
     roots: list[int] = []
+    observed_processes: dict[tuple[int, float], psutil.Process] = {}
     started_at = time.perf_counter()
     ports_ready_elapsed_s: float | None = None
 
@@ -604,14 +674,16 @@ def _stack(args: argparse.Namespace) -> dict[str, Any]:
         roots.append(backend.pid)
         deadline = time.monotonic() + args.timeout
         while not _ports_ready(ports):
-            startup_samples.append(_sample(roots))
+            startup_samples.append(
+                _sample(roots, observed_processes=observed_processes)
+            )
             if backend.poll() is not None:
                 raise RuntimeError(f"backend exited before ready with code {backend.returncode}")
             if time.monotonic() >= deadline:
                 raise TimeoutError(f"ports did not become ready: {ports}")
             time.sleep(args.interval)
         ports_ready_elapsed_s = time.perf_counter() - started_at
-        startup_samples.append(_sample(roots))
+        startup_samples.append(_sample(roots, observed_processes=observed_processes))
         time.sleep(args.settle)
         checkpoints.append(
             _sample_window(
@@ -619,6 +691,7 @@ def _stack(args: argparse.Namespace) -> dict[str, Any]:
                 roots,
                 seconds=args.window,
                 interval=args.interval,
+                observed_processes=observed_processes,
             )
         )
 
@@ -640,6 +713,7 @@ def _stack(args: argparse.Namespace) -> dict[str, Any]:
                     roots,
                     seconds=args.window,
                     interval=args.interval,
+                    observed_processes=observed_processes,
                 )
             )
 
@@ -660,6 +734,7 @@ def _stack(args: argparse.Namespace) -> dict[str, Any]:
                     roots,
                     seconds=args.window,
                     interval=args.interval,
+                    observed_processes=observed_processes,
                 )
             )
 
@@ -677,8 +752,10 @@ def _stack(args: argparse.Namespace) -> dict[str, Any]:
             },
         }
     finally:
-        for _name, process, _log_file in reversed(processes):
-            _terminate_process_tree(process)
+        _terminate_process_trees(
+            (process for _name, process, _log_file in processes),
+            observed_processes.values(),
+        )
         for _name, _process, log_file in processes:
             log_file.close()
 


### PR DESCRIPTION
## Summary

- add a reusable `psutil` + `tracemalloc` runtime-memory probe
- measure launcher/server, Electron, and Chromium process trees with RSS/USS splits
- document cold start, first chat, embedding READY, OCR, and browser-use/Playwright before baselines
- provide reproducible PowerShell commands and regression gates for follow-up optimization work

## Baseline highlights

- three-server READY: 742.7 / 552.8 MiB RSS/USS
- merged-server READY: 422.5 / 345.7 MiB
- first-chat delta: +88.2 / +84.4 MiB
- headed browser-use + Playwright: 654.1 / 336.3 MiB total
- merged backend + packaged Electron: 1951.0 / 1110.5 MiB total

The report also separates traced Python allocations from native, mapped-model, and child-process memory. Generated JSON and subprocess logs are intentionally not committed.

## Validation

- `python -m py_compile` through `uv run` during script development
- `ruff check` through `uv run` during script development
- `git diff --cached --check`
- live benchmark runs for every documented scenario on Windows

## Notes

The packaged Electron binary was measured for component attribution but was not rebuilt from this Xiao8 commit; the report calls out that provenance limitation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 新增运行时内存基线记录，涵盖启动、聊天、Embedding、OCR、浏览器等阶段。
  * 补充 RSS、USS 等指标说明、环境信息、结果对比及复现实验步骤。
  * 提供后续性能优化的稳定回归门槛与注意事项。

* **工具**
  * 新增可重复运行的内存采集工具，支持多种运行场景并输出结构化测量结果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->