### PR TITLE
feat(memory): add batched time-index reads

### DIFF
--- a/memory/timeindex.py
+++ b/memory/timeindex.py
@@ -19,12 +19,24 @@ from memory.stop_names import collect_stop_names, strip_stop_names
 from utils.cloudsave_runtime import MaintenanceModeError, assert_cloudsave_writable
 from utils.config_manager import get_config_manager
 from utils.logger_config import get_module_logger
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncIterator, Generator, Iterator
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 import asyncio
 import os
 
 logger = get_module_logger(__name__, "Memory")
+
+
+def _next_readonly_batch(
+    stream: Generator[list[tuple[object, object, object]], None, None],
+) -> tuple[bool, list[tuple[object, object, object]] | None]:
+    """Return a non-StopIteration marker suitable for asyncio futures."""
+    try:
+        return False, next(stream)
+    except StopIteration:
+        return True, None
+
 
 class TimeIndexedMemory:
     def __init__(self, recent_history_manager):
@@ -470,6 +482,63 @@ class TimeIndexedMemory:
         next_cursor = (raw_rows[-1][0], int(raw_rows[-1][1]))
         return rows, next_cursor
 
+    def _has_indexed_timeframe_order(
+        self,
+        lanlan_name: str,
+        start_time,
+        end_time,
+    ) -> bool:
+        """Return whether SQLite can satisfy the keyset order without sorting."""
+        table_name = self._validate_table_name(TIME_ORIGINAL_TABLE_NAME)
+        sql = (
+            f"EXPLAIN QUERY PLAN SELECT timestamp, rowid FROM {table_name} "
+            "WHERE timestamp BETWEEN :start_time AND :end_time "
+            "ORDER BY timestamp ASC, rowid ASC LIMIT 1"
+        )
+        try:
+            with self.engines[lanlan_name].connect() as conn:
+                plan = conn.execute(
+                    text(sql),
+                    {"start_time": start_time, "end_time": end_time},
+                ).fetchall()
+        except Exception as exc:
+            logger.debug(
+                "[TimeIndexedMemory] 无法检查时间索引，改用单查询流式读取: %s",
+                exc,
+            )
+            return False
+        return not any(
+            "USE TEMP B-TREE FOR ORDER BY" in str(row[-1]).upper() for row in plan
+        )
+
+    def _iter_readonly_timeframe_stream(
+        self,
+        lanlan_name: str,
+        start_time,
+        end_time,
+        *,
+        batch_size: int,
+        limit_rows: int | None,
+    ) -> Generator[list[tuple[object, object, object]], None, None]:
+        """Fetch bounded batches from one ordered read-only query."""
+        table_name = self._validate_table_name(TIME_ORIGINAL_TABLE_NAME)
+        sql = (
+            f"SELECT timestamp, session_id, message FROM {table_name} "
+            "WHERE timestamp BETWEEN :start_time AND :end_time "
+            "ORDER BY timestamp ASC, rowid ASC"
+        )
+        params: dict = {"start_time": start_time, "end_time": end_time}
+        if limit_rows is not None and limit_rows > 0:
+            sql += " LIMIT :limit_rows"
+            params["limit_rows"] = int(limit_rows)
+        with self.engines[lanlan_name].connect() as conn:
+            result = conn.execute(text(sql), params)
+            while True:
+                raw_rows = result.fetchmany(batch_size)
+                if not raw_rows:
+                    return
+                yield [(row[0], row[1], row[2]) for row in raw_rows]
+
     def iter_original_by_timeframe_batches(
         self,
         lanlan_name: str,
@@ -481,11 +550,13 @@ class TimeIndexedMemory:
     ) -> Iterator[list[tuple[object, object, object]]]:
         """Yield bounded raw-conversation batches in stable chronological order.
 
-        Unlike ``retrieve_original_by_timeframe``, this interface never keeps a
-        live SQLAlchemy connection attached to the yielded iterator: every
-        keyset page opens, consumes, and closes its connection before the batch
-        reaches the caller. ``limit_rows`` is a total cap across all batches;
-        non-positive values retain the list API's historical "no LIMIT" meaning.
+        Indexed databases close their connection before each keyset page is
+        yielded. A read-only legacy database without that index uses one
+        streaming cursor, avoiding a full scan and sort per page. The async
+        path confines that cursor to one worker and only returns materialized
+        batches across the thread boundary.
+        ``limit_rows`` is a total cap across all batches; non-positive values
+        retain the list API's historical "no LIMIT" meaning.
         """
         if batch_size <= 0:
             raise ValueError("batch_size must be greater than zero")
@@ -494,6 +565,23 @@ class TimeIndexedMemory:
                 return
         except MaintenanceModeError as exc:
             logger.debug(f"[TimeIndexedMemory] 维护态跳过分批读取 {lanlan_name} 的历史对话: {exc}")
+            return
+
+        if not self._has_indexed_timeframe_order(lanlan_name, start_time, end_time):
+            stream = self._iter_readonly_timeframe_stream(
+                lanlan_name,
+                start_time,
+                end_time,
+                batch_size=batch_size,
+                limit_rows=limit_rows,
+            )
+            try:
+                yield from stream
+            except Exception as exc:
+                logger.warning(f"[TimeIndexedMemory] 单查询流式读取原始对话失败: {exc}")
+                raise
+            finally:
+                stream.close()
             return
 
         remaining = int(limit_rows) if limit_rows is not None and limit_rows > 0 else None
@@ -540,6 +628,46 @@ class TimeIndexedMemory:
                 return
         except MaintenanceModeError as exc:
             logger.debug(f"[TimeIndexedMemory] 维护态跳过异步分批读取 {lanlan_name} 的历史对话: {exc}")
+            return
+
+        indexed = await asyncio.to_thread(
+            self._has_indexed_timeframe_order,
+            lanlan_name,
+            start_time,
+            end_time,
+        )
+        if not indexed:
+            stream = self._iter_readonly_timeframe_stream(
+                lanlan_name,
+                start_time,
+                end_time,
+                batch_size=batch_size,
+                limit_rows=limit_rows,
+            )
+            executor = ThreadPoolExecutor(
+                max_workers=1,
+                thread_name_prefix="time-index-read",
+            )
+            loop = asyncio.get_running_loop()
+            try:
+                while True:
+                    done, rows = await loop.run_in_executor(
+                        executor,
+                        _next_readonly_batch,
+                        stream,
+                    )
+                    if done:
+                        return
+                    if rows is not None:
+                        yield rows
+            except Exception as exc:
+                logger.warning(f"[TimeIndexedMemory] 异步单查询流式读取原始对话失败: {exc}")
+                raise
+            finally:
+                try:
+                    await loop.run_in_executor(executor, stream.close)
+                finally:
+                    executor.shutdown(wait=True)
             return
 
         remaining = int(limit_rows) if limit_rows is not None and limit_rows > 0 else None

--- a/memory/timeindex.py
+++ b/memory/timeindex.py
@@ -19,6 +19,7 @@ from memory.stop_names import collect_stop_names, strip_stop_names
 from utils.cloudsave_runtime import MaintenanceModeError, assert_cloudsave_writable
 from utils.config_manager import get_config_manager
 from utils.logger_config import get_module_logger
+from collections.abc import AsyncIterator, Iterator
 from datetime import datetime
 import asyncio
 import os
@@ -419,6 +420,141 @@ class TimeIndexedMemory:
         return await asyncio.to_thread(
             self.retrieve_original_by_timeframe, lanlan_name, start_time, end_time, limit_rows
         )
+
+    def _fetch_original_timeframe_page(
+        self,
+        lanlan_name: str,
+        start_time,
+        end_time,
+        *,
+        page_size: int,
+        cursor: tuple[object, int] | None,
+    ) -> tuple[list[tuple[object, object, object]], tuple[object, int] | None]:
+        """Fetch one stable keyset page and close its connection before returning."""
+        table_name = self._validate_table_name(TIME_ORIGINAL_TABLE_NAME)
+        sql = (
+            f"SELECT timestamp, rowid, session_id, message FROM {table_name} "
+            f"WHERE timestamp BETWEEN :start_time AND :end_time"
+        )
+        params: dict = {
+            "start_time": start_time,
+            "end_time": end_time,
+            "page_size": page_size,
+        }
+        if cursor is not None:
+            sql += (
+                " AND (timestamp > :cursor_timestamp "
+                "OR (timestamp = :cursor_timestamp AND rowid > :cursor_rowid))"
+            )
+            params["cursor_timestamp"], params["cursor_rowid"] = cursor
+        sql += " ORDER BY timestamp ASC, rowid ASC LIMIT :page_size"
+
+        # The connection and Result stay entirely inside this call. In
+        # particular, async callers run this whole method in ``to_thread`` and
+        # only receive the materialized, bounded page after ``__exit__``.
+        with self.engines[lanlan_name].connect() as conn:
+            result = conn.execute(text(sql), params)
+            raw_rows = result.fetchmany(page_size)
+
+        if not raw_rows:
+            return [], None
+        rows = [(row[0], row[2], row[3]) for row in raw_rows]
+        next_cursor = (raw_rows[-1][0], int(raw_rows[-1][1]))
+        return rows, next_cursor
+
+    def iter_original_by_timeframe_batches(
+        self,
+        lanlan_name: str,
+        start_time,
+        end_time,
+        *,
+        batch_size: int = 256,
+        limit_rows: int | None = None,
+    ) -> Iterator[list[tuple[object, object, object]]]:
+        """Yield bounded raw-conversation batches in stable chronological order.
+
+        Unlike ``retrieve_original_by_timeframe``, this interface never keeps a
+        live SQLAlchemy connection attached to the yielded iterator: every
+        keyset page opens, consumes, and closes its connection before the batch
+        reaches the caller. ``limit_rows`` is a total cap across all batches;
+        non-positive values retain the list API's historical "no LIMIT" meaning.
+        """
+        if batch_size <= 0:
+            raise ValueError("batch_size must be greater than zero")
+        try:
+            if not self._ensure_engine_exists(lanlan_name, readonly=True):
+                return
+        except MaintenanceModeError as exc:
+            logger.debug(f"[TimeIndexedMemory] 维护态跳过分批读取 {lanlan_name} 的历史对话: {exc}")
+            return
+
+        remaining = int(limit_rows) if limit_rows is not None and limit_rows > 0 else None
+        cursor: tuple[object, int] | None = None
+        while remaining is None or remaining > 0:
+            page_size = batch_size if remaining is None else min(batch_size, remaining)
+            try:
+                rows, cursor = self._fetch_original_timeframe_page(
+                    lanlan_name,
+                    start_time,
+                    end_time,
+                    page_size=page_size,
+                    cursor=cursor,
+                )
+            except Exception as exc:
+                logger.warning(f"[TimeIndexedMemory] 分批读取原始对话失败: {exc}")
+                return
+            if not rows:
+                return
+            if remaining is not None:
+                remaining -= len(rows)
+            yield rows
+
+    async def aiter_original_by_timeframe_batches(
+        self,
+        lanlan_name: str,
+        start_time,
+        end_time,
+        *,
+        batch_size: int = 256,
+        limit_rows: int | None = None,
+    ) -> AsyncIterator[list[tuple[object, object, object]]]:
+        """Async batch iterator whose SQLite work is fully contained in workers."""
+        if batch_size <= 0:
+            raise ValueError("batch_size must be greater than zero")
+        try:
+            ready = await asyncio.to_thread(
+                self._ensure_engine_exists,
+                lanlan_name,
+                None,
+                True,
+            )
+            if not ready:
+                return
+        except MaintenanceModeError as exc:
+            logger.debug(f"[TimeIndexedMemory] 维护态跳过异步分批读取 {lanlan_name} 的历史对话: {exc}")
+            return
+
+        remaining = int(limit_rows) if limit_rows is not None and limit_rows > 0 else None
+        cursor: tuple[object, int] | None = None
+        while remaining is None or remaining > 0:
+            page_size = batch_size if remaining is None else min(batch_size, remaining)
+            try:
+                rows, cursor = await asyncio.to_thread(
+                    self._fetch_original_timeframe_page,
+                    lanlan_name,
+                    start_time,
+                    end_time,
+                    page_size=page_size,
+                    cursor=cursor,
+                )
+            except Exception as exc:
+                logger.warning(f"[TimeIndexedMemory] 异步分批读取原始对话失败: {exc}")
+                return
+            if not rows:
+                return
+            if remaining is not None:
+                remaining -= len(rows)
+            yield rows
 
     # ── FTS5 事实索引 ─────────────────────────────────────────────
 

--- a/memory/timeindex.py
+++ b/memory/timeindex.py
@@ -274,7 +274,7 @@ class TimeIndexedMemory:
                     logger.error(f"[TimeIndexedMemory] 表 {table} 未能成功创建喵！")
 
     def _check_and_migrate_schema(self, engine, lanlan_name: str) -> None:
-        """Check and backfill the timestamp column table by table; each table handled independently so they can't affect each other."""
+        """Backfill timestamp columns and their read indexes table by table."""
         migration_errors = []
         for table_name in [TIME_ORIGINAL_TABLE_NAME, TIME_COMPRESSED_TABLE_NAME]:
             table = self._validate_table_name(table_name)
@@ -284,8 +284,16 @@ class TimeIndexedMemory:
                     columns = [row[1] for row in result.fetchall()]
                     if 'timestamp' not in columns:
                         conn.execute(text(f"ALTER TABLE {table} ADD COLUMN timestamp DATETIME"))
-                        conn.commit()
                         logger.info(f"[TimeIndexedMemory] 已为 {lanlan_name} 的表 {table} 补齐 timestamp 列")
+                    # SQLite secondary indexes carry rowid as their implicit
+                    # tie-breaker, matching ORDER BY timestamp, rowid in the
+                    # paginated reader without requiring a redundant column.
+                    index_name = f"idx_{table}_timestamp"
+                    conn.execute(text(
+                        f"CREATE INDEX IF NOT EXISTS {index_name} "
+                        f"ON {table}(timestamp)"
+                    ))
+                    conn.commit()
             except Exception as exc:
                 logger.exception(f"[TimeIndexedMemory] 迁移 {lanlan_name} 表 {table} 失败")
                 migration_errors.append(f"{table}: {exc}")
@@ -502,7 +510,7 @@ class TimeIndexedMemory:
                 )
             except Exception as exc:
                 logger.warning(f"[TimeIndexedMemory] 分批读取原始对话失败: {exc}")
-                return
+                raise
             if not rows:
                 return
             if remaining is not None:
@@ -549,7 +557,7 @@ class TimeIndexedMemory:
                 )
             except Exception as exc:
                 logger.warning(f"[TimeIndexedMemory] 异步分批读取原始对话失败: {exc}")
-                return
+                raise
             if not rows:
                 return
             if remaining is not None:

--- a/tests/testbench/pipeline/conversation_corpus.py
+++ b/tests/testbench/pipeline/conversation_corpus.py
@@ -53,6 +53,10 @@ _WIDE_END = datetime.max
 # table into memory at once. Aggregator/attribution can override.
 _DEFAULT_LIMIT_ROWS = 5000
 
+# Keep the widest "read every turn" path from holding both the complete raw
+# SQLAlchemy row list and the normalized trace list at the same time.
+_TIME_INDEX_BATCH_SIZE = 256
+
 
 def _normalize_role(raw_type: Any) -> str:
     """Map LangChain message ``type`` to the trace graph's role vocabulary."""
@@ -222,25 +226,32 @@ def load_time_indexed_turns(
         # recent_history_manager is unused on the readonly retrieve path; None
         # keeps construction cheap and side-effect free.
         tm = TimeIndexedMemory(None)  # type: ignore[arg-type]
-        rows = tm.retrieve_original_by_timeframe(
-            character, _WIDE_START, _WIDE_END, limit_rows=limit_rows,
-        )
-        for idx, row in enumerate(rows):
-            try:
-                ts_raw, session_id, message_raw = row[0], row[1], row[2]
-            except (IndexError, TypeError):
-                continue
-            role, content = _parse_db_message(message_raw)
-            if not content.strip():
-                continue
-            turns.append({
-                "id": _db_turn_id(session_id, idx),
-                "ts": _normalize_ts(ts_raw),
-                "session_id": str(session_id) if session_id is not None else None,
-                "role": role,
-                "content": content,
-                "origin": "time_indexed_db",
-            })
+        row_index = 0
+        for batch in tm.iter_original_by_timeframe_batches(
+            character,
+            _WIDE_START,
+            _WIDE_END,
+            batch_size=_TIME_INDEX_BATCH_SIZE,
+            limit_rows=limit_rows,
+        ):
+            for row in batch:
+                idx = row_index
+                row_index += 1
+                try:
+                    ts_raw, session_id, message_raw = row[0], row[1], row[2]
+                except (IndexError, TypeError):
+                    continue
+                role, content = _parse_db_message(message_raw)
+                if not content.strip():
+                    continue
+                turns.append({
+                    "id": _db_turn_id(session_id, idx),
+                    "ts": _normalize_ts(ts_raw),
+                    "session_id": str(session_id) if session_id is not None else None,
+                    "role": role,
+                    "content": content,
+                    "origin": "time_indexed_db",
+                })
     except Exception as exc:  # noqa: BLE001 — soft error, never crash the graph
         warnings.append(
             f"time_indexed.db 读取失败 ({type(exc).__name__}): {exc}"

--- a/tests/testbench/pipeline/conversation_corpus.py
+++ b/tests/testbench/pipeline/conversation_corpus.py
@@ -253,6 +253,10 @@ def load_time_indexed_turns(
                     "origin": "time_indexed_db",
                 })
     except Exception as exc:  # noqa: BLE001 — soft error, never crash the graph
+        # A later batch may fail after earlier rows were normalized. Preserve
+        # the previous one-shot reader's all-or-empty contract rather than
+        # exposing an incomplete archive as a valid corpus prefix.
+        turns.clear()
         warnings.append(
             f"time_indexed.db 读取失败 ({type(exc).__name__}): {exc}"
         )

--- a/tests/unit/test_timeindex_batched_read.py
+++ b/tests/unit/test_timeindex_batched_read.py
@@ -254,7 +254,7 @@ def test_connection_is_closed_before_yield_and_fetchmany_is_bounded(timeindex_mo
     assert tracker["exits"] == 1
 
 
-def test_fetch_exception_is_soft_and_still_closes_connection(timeindex_module):
+def test_fetch_exception_propagates_and_still_closes_connection(timeindex_module):
     tracker = {"active": 0, "exits": 0, "threads": []}
     manager = _fake_manager(
         timeindex_module,
@@ -262,16 +262,35 @@ def test_fetch_exception_is_soft_and_still_closes_connection(timeindex_module):
         tracker,
     )
 
-    assert (
+    with pytest.raises(RuntimeError, match="read failed"):
         list(
             manager.iter_original_by_timeframe_batches(
                 "cat", _START, _END, batch_size=8
             )
         )
-        == []
-    )
     assert tracker["active"] == 0
     assert tracker["exits"] == 1
+
+
+def test_later_page_exception_marks_partial_iteration_failed(timeindex_module):
+    tracker = {"active": 0, "exits": 0, "threads": []}
+    manager = _fake_manager(
+        timeindex_module,
+        [
+            _FakeResult([("2026-01-01 00:00:00.000000", 1, "session", "message")]),
+            _FakeResult(error=RuntimeError("later page failed")),
+        ],
+        tracker,
+    )
+
+    iterator = manager.iter_original_by_timeframe_batches(
+        "cat", _START, _END, batch_size=1
+    )
+    assert next(iterator) == [("2026-01-01 00:00:00.000000", "session", "message")]
+    with pytest.raises(RuntimeError, match="later page failed"):
+        next(iterator)
+    assert tracker["active"] == 0
+    assert tracker["exits"] == 2
 
 
 @pytest.mark.asyncio
@@ -303,13 +322,39 @@ async def test_async_batches_finish_worker_connection_before_crossing_thread(
     await iterator.aclose()
 
 
+@pytest.mark.asyncio
+async def test_async_later_page_exception_propagates_after_closing_connection(
+    timeindex_module,
+):
+    tracker = {"active": 0, "exits": 0, "threads": []}
+    manager = _fake_manager(
+        timeindex_module,
+        [
+            _FakeResult([("2026-01-01 00:00:00.000000", 1, "session", "message")]),
+            _FakeResult(error=RuntimeError("async later page failed")),
+        ],
+        tracker,
+    )
+
+    iterator = manager.aiter_original_by_timeframe_batches(
+        "cat", _START, _END, batch_size=1
+    )
+    assert await anext(iterator) == [
+        ("2026-01-01 00:00:00.000000", "session", "message")
+    ]
+    with pytest.raises(RuntimeError, match="async later page failed"):
+        await anext(iterator)
+    assert tracker["active"] == 0
+    assert tracker["exits"] == 2
+
+
 def test_wide_corpus_reader_consumes_batches_and_still_cleans_up(
     timeindex_module,
     tmp_path,
     monkeypatch,
 ):
     logger_module = types.ModuleType("tests.testbench.logger")
-    logger_module.python_logger = lambda: _NullLogger()
+    logger_module.python_logger = _NullLogger
     monkeypatch.setitem(sys.modules, "tests.testbench.logger", logger_module)
 
     calls: dict = {"cleanup": 0}
@@ -338,6 +383,8 @@ def test_wide_corpus_reader_consumes_batches_and_still_cleans_up(
                 ("2026-01-01", "s0", '{"type":"human","data":{"content":"hello"}}'),
                 ("2026-01-02", "s1", '{"type":"ai","data":{"content":""}}'),
             ]
+            if calls.get("fail_after_first"):
+                raise RuntimeError("later page failed")
             yield [
                 ("2026-01-03", "s2", '{"type":"ai","data":{"content":"world"}}'),
             ]
@@ -372,6 +419,43 @@ def test_wide_corpus_reader_consumes_batches_and_still_cleans_up(
     assert calls["args"][0] == "cat"
     assert calls["args"][3:] == (module._TIME_INDEX_BATCH_SIZE, 3)
     assert calls["cleanup"] == 1
+
+    calls["fail_after_first"] = True
+    turns, warnings, present = module.load_time_indexed_turns("cat", limit_rows=3)
+    assert present is True
+    assert turns == []
+    assert len(warnings) == 1
+    assert "later page failed" in warnings[0]
+    assert calls["cleanup"] == 2
+
+
+def test_schema_migration_adds_timestamp_indexes(timeindex_module, tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'migration.db'}")
+    tables = [_TABLE, "time_indexed_compressed"]
+    try:
+        with engine.begin() as conn:
+            for table in tables:
+                conn.execute(
+                    text(f"CREATE TABLE {table} (session_id TEXT, message TEXT)")
+                )
+
+        manager = timeindex_module.TimeIndexedMemory.__new__(
+            timeindex_module.TimeIndexedMemory
+        )
+        manager._check_and_migrate_schema(engine, "cat")
+
+        with engine.connect() as conn:
+            for table in tables:
+                columns = {
+                    row[1] for row in conn.execute(text(f"PRAGMA table_info({table})"))
+                }
+                indexes = {
+                    row[1] for row in conn.execute(text(f"PRAGMA index_list({table})"))
+                }
+                assert "timestamp" in columns
+                assert f"idx_{table}_timestamp" in indexes
+    finally:
+        engine.dispose()
 
 
 def test_batched_read_reduces_python_peak_memory(timeindex_module, tmp_path):

--- a/tests/unit/test_timeindex_batched_read.py
+++ b/tests/unit/test_timeindex_batched_read.py
@@ -9,7 +9,7 @@ import types
 from pathlib import Path
 
 import pytest
-from sqlalchemy import create_engine, text
+from sqlalchemy import create_engine, event, text
 
 
 _START = "0001-01-01 00:00:00.000000"
@@ -92,7 +92,7 @@ def timeindex_module():
                 sys.modules[name] = old_module
 
 
-def _create_manager(timeindex_module, tmp_path, rows):
+def _create_manager(timeindex_module, tmp_path, rows, *, indexed=True):
     engine = create_engine(f"sqlite:///{tmp_path / 'time-index.db'}")
     with engine.begin() as conn:
         conn.execute(
@@ -101,9 +101,10 @@ def _create_manager(timeindex_module, tmp_path, rows):
                 "session_id TEXT, message TEXT, timestamp DATETIME)"
             )
         )
-        conn.execute(
-            text(f"CREATE INDEX idx_{_TABLE}_timestamp ON {_TABLE}(timestamp)")
-        )
+        if indexed:
+            conn.execute(
+                text(f"CREATE INDEX idx_{_TABLE}_timestamp ON {_TABLE}(timestamp)")
+            )
         if rows:
             conn.execute(
                 text(
@@ -154,6 +155,7 @@ def test_batches_preserve_order_limit_and_legacy_list_api(timeindex_module, tmp_
     ]
     manager, engine = _create_manager(timeindex_module, tmp_path, rows)
     try:
+        assert manager._has_indexed_timeframe_order("cat", _START, _END) is True
         legacy_rows = manager.retrieve_original_by_timeframe(
             "cat", _START, _END, limit_rows=3
         )
@@ -171,6 +173,182 @@ def test_batches_preserve_order_limit_and_legacy_list_api(timeindex_module, tmp_
             "same-b",
             "late",
         ]
+    finally:
+        engine.dispose()
+
+
+def test_unindexed_readonly_database_uses_one_streaming_query_without_writes(
+    timeindex_module,
+    tmp_path,
+):
+    rows = [
+        {
+            "session_id": "late",
+            "message": "3",
+            "timestamp": "2026-01-02 00:00:00.000000",
+        },
+        {
+            "session_id": "same-a",
+            "message": "1",
+            "timestamp": "2026-01-01 00:00:00.000000",
+        },
+        {
+            "session_id": "same-b",
+            "message": "2",
+            "timestamp": "2026-01-01 00:00:00.000000",
+        },
+        {
+            "session_id": "excluded",
+            "message": "4",
+            "timestamp": "2026-01-03 00:00:00.000000",
+        },
+    ]
+    manager, engine = _create_manager(
+        timeindex_module,
+        tmp_path,
+        rows,
+        indexed=False,
+    )
+    tracker = {"active": 0, "checkouts": 0, "checkins": 0}
+    read_queries: list[tuple[str, int]] = []
+
+    def on_checkout(*_args):
+        tracker["active"] += 1
+        tracker["checkouts"] += 1
+
+    def on_checkin(*_args):
+        tracker["active"] -= 1
+        tracker["checkins"] += 1
+
+    def on_execute(_conn, _cursor, statement, *_args):
+        if statement.startswith("SELECT timestamp, session_id, message"):
+            read_queries.append((statement, threading.get_ident()))
+
+    event.listen(engine, "checkout", on_checkout)
+    event.listen(engine, "checkin", on_checkin)
+    event.listen(engine, "before_cursor_execute", on_execute)
+    try:
+        assert manager._has_indexed_timeframe_order("cat", _START, _END) is False
+        batches = list(
+            manager.iter_original_by_timeframe_batches(
+                "cat",
+                _START,
+                _END,
+                batch_size=1,
+                limit_rows=3,
+            )
+        )
+        assert [row[1] for row in _flatten(batches)] == [
+            "same-a",
+            "same-b",
+            "late",
+        ]
+        assert len(read_queries) == 1
+        assert "LIMIT" in read_queries[0][0]
+        assert tracker["active"] == 0
+        assert tracker["checkouts"] == tracker["checkins"]
+
+        with engine.connect() as conn:
+            indexes = list(conn.execute(text(f"PRAGMA index_list({_TABLE})")))
+        assert indexes == []
+    finally:
+        engine.dispose()
+
+
+def test_unindexed_stream_closes_worker_connection_when_consumer_stops_early(
+    timeindex_module,
+    tmp_path,
+):
+    rows = [
+        {
+            "session_id": f"session-{idx}",
+            "message": str(idx),
+            "timestamp": f"2026-01-01 00:00:{idx:02d}.000000",
+        }
+        for idx in range(20)
+    ]
+    manager, engine = _create_manager(
+        timeindex_module,
+        tmp_path,
+        rows,
+        indexed=False,
+    )
+    tracker = {"active": 0, "checkouts": 0, "checkins": 0}
+
+    def on_checkout(*_args):
+        tracker["active"] += 1
+        tracker["checkouts"] += 1
+
+    def on_checkin(*_args):
+        tracker["active"] -= 1
+        tracker["checkins"] += 1
+
+    event.listen(engine, "checkout", on_checkout)
+    event.listen(engine, "checkin", on_checkin)
+    try:
+        iterator = manager.iter_original_by_timeframe_batches(
+            "cat", _START, _END, batch_size=1
+        )
+        assert len(next(iterator)) == 1
+        iterator.close()
+
+        assert tracker["active"] == 0
+        assert tracker["checkouts"] == tracker["checkins"]
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_async_unindexed_stream_keeps_sqlite_in_worker_and_closes(
+    timeindex_module,
+    tmp_path,
+):
+    rows = [
+        {
+            "session_id": f"session-{idx}",
+            "message": str(idx),
+            "timestamp": f"2026-01-01 00:00:0{idx}.000000",
+        }
+        for idx in range(3)
+    ]
+    manager, engine = _create_manager(
+        timeindex_module,
+        tmp_path,
+        rows,
+        indexed=False,
+    )
+    tracker = {"active": 0, "checkouts": 0, "checkins": 0}
+    query_threads: list[int] = []
+
+    def on_checkout(*_args):
+        tracker["active"] += 1
+        tracker["checkouts"] += 1
+
+    def on_checkin(*_args):
+        tracker["active"] -= 1
+        tracker["checkins"] += 1
+
+    def on_execute(_conn, _cursor, statement, *_args):
+        if statement.startswith("SELECT timestamp, session_id, message"):
+            query_threads.append(threading.get_ident())
+
+    event.listen(engine, "checkout", on_checkout)
+    event.listen(engine, "checkin", on_checkin)
+    event.listen(engine, "before_cursor_execute", on_execute)
+    event_loop_thread = threading.get_ident()
+    try:
+        batches = [
+            batch
+            async for batch in manager.aiter_original_by_timeframe_batches(
+                "cat", _START, _END, batch_size=1, limit_rows=2
+            )
+        ]
+
+        assert [row[1] for row in _flatten(batches)] == ["session-0", "session-1"]
+        assert len(query_threads) == 1
+        assert query_threads[0] != event_loop_thread
+        assert tracker["active"] == 0
+        assert tracker["checkouts"] == tracker["checkins"]
     finally:
         engine.dispose()
 
@@ -200,6 +378,17 @@ class _FakeResult:
         return self.rows
 
 
+class _FailingStreamResult:
+    def __init__(self):
+        self.calls = 0
+
+    def fetchmany(self, _size):
+        self.calls += 1
+        if self.calls == 1:
+            return [("2026-01-01 00:00:00.000000", "session", "message")]
+        raise RuntimeError("stream failed")
+
+
 class _FakeConnection:
     def __init__(self, result, tracker):
         self.result = result
@@ -227,12 +416,13 @@ class _FakeEngine:
         return _FakeConnection(next(self.results), self.tracker)
 
 
-def _fake_manager(timeindex_module, results, tracker):
+def _fake_manager(timeindex_module, results, tracker, *, indexed=True):
     manager = timeindex_module.TimeIndexedMemory.__new__(
         timeindex_module.TimeIndexedMemory
     )
     manager.engines = {"cat": _FakeEngine(results, tracker)}
     manager._ensure_engine_exists = lambda _name, db_path=None, readonly=False: True
+    manager._has_indexed_timeframe_order = lambda *_args, **_kwargs: indexed
     return manager
 
 
@@ -291,6 +481,27 @@ def test_later_page_exception_marks_partial_iteration_failed(timeindex_module):
         next(iterator)
     assert tracker["active"] == 0
     assert tracker["exits"] == 2
+
+
+def test_unindexed_stream_exception_propagates_and_closes_connection(timeindex_module):
+    tracker = {"active": 0, "exits": 0, "threads": []}
+    manager = _fake_manager(
+        timeindex_module,
+        [_FailingStreamResult()],
+        tracker,
+        indexed=False,
+    )
+
+    iterator = manager.iter_original_by_timeframe_batches(
+        "cat", _START, _END, batch_size=1
+    )
+    assert next(iterator) == [
+        ("2026-01-01 00:00:00.000000", "session", "message")
+    ]
+    with pytest.raises(RuntimeError, match="stream failed"):
+        next(iterator)
+    assert tracker["active"] == 0
+    assert tracker["exits"] == 1
 
 
 @pytest.mark.asyncio
@@ -458,7 +669,12 @@ def test_schema_migration_adds_timestamp_indexes(timeindex_module, tmp_path):
         engine.dispose()
 
 
-def test_batched_read_reduces_python_peak_memory(timeindex_module, tmp_path):
+@pytest.mark.parametrize("indexed", [True, False], ids=["indexed", "readonly-legacy"])
+def test_batched_read_reduces_python_peak_memory(
+    timeindex_module,
+    tmp_path,
+    indexed,
+):
     payload = "x" * 4096
     row_count = 2500
     rows = [
@@ -469,7 +685,12 @@ def test_batched_read_reduces_python_peak_memory(timeindex_module, tmp_path):
         }
         for idx in range(row_count)
     ]
-    manager, engine = _create_manager(timeindex_module, tmp_path, rows)
+    manager, engine = _create_manager(
+        timeindex_module,
+        tmp_path,
+        rows,
+        indexed=indexed,
+    )
     try:
         gc.collect()
         tracemalloc.start()

--- a/tests/unit/test_timeindex_batched_read.py
+++ b/tests/unit/test_timeindex_batched_read.py
@@ -1,0 +1,416 @@
+from __future__ import annotations
+
+import gc
+import importlib.util
+import sys
+import threading
+import tracemalloc
+import types
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, text
+
+
+_START = "0001-01-01 00:00:00.000000"
+_END = "9999-12-31 23:59:59.999999"
+_TABLE = "time_indexed_original"
+
+
+class _NullLogger:
+    def __getattr__(self, _name):
+        return lambda *_args, **_kwargs: None
+
+
+@pytest.fixture(scope="module")
+def timeindex_module():
+    """Load timeindex in isolation so this focused test has no app bootstrap."""
+    stubs: dict[str, types.ModuleType] = {}
+
+    utils = types.ModuleType("utils")
+    utils.__path__ = []  # type: ignore[attr-defined]
+    stubs["utils"] = utils
+
+    llm_client = types.ModuleType("utils.llm_client")
+
+    class _History:
+        _engine_cache: dict = {}
+
+    llm_client.SQLChatMessageHistory = _History
+    llm_client.SystemMessage = object
+    stubs["utils.llm_client"] = llm_client
+
+    cloudsave = types.ModuleType("utils.cloudsave_runtime")
+
+    class _MaintenanceModeError(RuntimeError):
+        pass
+
+    cloudsave.MaintenanceModeError = _MaintenanceModeError
+    cloudsave.assert_cloudsave_writable = lambda *_args, **_kwargs: None
+    stubs["utils.cloudsave_runtime"] = cloudsave
+
+    config_manager = types.ModuleType("utils.config_manager")
+    config_manager.get_config_manager = lambda *_args, **_kwargs: None
+    stubs["utils.config_manager"] = config_manager
+
+    logger_config = types.ModuleType("utils.logger_config")
+    logger_config.get_module_logger = lambda *_args, **_kwargs: _NullLogger()
+    stubs["utils.logger_config"] = logger_config
+
+    config = types.ModuleType("config")
+    config.TIME_ORIGINAL_TABLE_NAME = _TABLE
+    config.TIME_COMPRESSED_TABLE_NAME = "time_indexed_compressed"
+    stubs["config"] = config
+
+    memory = types.ModuleType("memory")
+    memory.__path__ = []  # type: ignore[attr-defined]
+    memory.ensure_character_dir = lambda *_args, **_kwargs: ""
+    stubs["memory"] = memory
+
+    stop_names = types.ModuleType("memory.stop_names")
+    stop_names.collect_stop_names = lambda *_args, **_kwargs: set()
+    stop_names.strip_stop_names = lambda content, _names: content
+    stubs["memory.stop_names"] = stop_names
+
+    previous = {name: sys.modules.get(name) for name in stubs}
+    sys.modules.update(stubs)
+    module_name = "_timeindex_batched_read_under_test"
+    module_path = Path(__file__).parents[2] / "memory" / "timeindex.py"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        sys.modules.pop(module_name, None)
+        for name, old_module in previous.items():
+            if old_module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = old_module
+
+
+def _create_manager(timeindex_module, tmp_path, rows):
+    engine = create_engine(f"sqlite:///{tmp_path / 'time-index.db'}")
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                f"CREATE TABLE {_TABLE} ("
+                "session_id TEXT, message TEXT, timestamp DATETIME)"
+            )
+        )
+        conn.execute(
+            text(f"CREATE INDEX idx_{_TABLE}_timestamp ON {_TABLE}(timestamp)")
+        )
+        if rows:
+            conn.execute(
+                text(
+                    f"INSERT INTO {_TABLE}(session_id, message, timestamp) "
+                    "VALUES (:session_id, :message, :timestamp)"
+                ),
+                rows,
+            )
+
+    manager = timeindex_module.TimeIndexedMemory.__new__(
+        timeindex_module.TimeIndexedMemory
+    )
+    manager.engines = {"cat": engine}
+    manager.db_paths = {}
+    manager._engine_readonly_flags = {}
+    manager._writable_bootstrapped = set()
+    manager.recent_history_manager = None
+    manager._ensure_engine_exists = lambda _name, db_path=None, readonly=False: True
+    return manager, engine
+
+
+def _flatten(batches):
+    return [row for batch in batches for row in batch]
+
+
+def test_batches_preserve_order_limit_and_legacy_list_api(timeindex_module, tmp_path):
+    rows = [
+        {
+            "session_id": "late",
+            "message": "4",
+            "timestamp": "2026-01-02 00:00:00.000000",
+        },
+        {
+            "session_id": "same-a",
+            "message": "1",
+            "timestamp": "2026-01-01 00:00:00.000000",
+        },
+        {
+            "session_id": "same-b",
+            "message": "2",
+            "timestamp": "2026-01-01 00:00:00.000000",
+        },
+        {
+            "session_id": "latest",
+            "message": "5",
+            "timestamp": "2026-01-03 00:00:00.000000",
+        },
+    ]
+    manager, engine = _create_manager(timeindex_module, tmp_path, rows)
+    try:
+        legacy_rows = manager.retrieve_original_by_timeframe(
+            "cat", _START, _END, limit_rows=3
+        )
+        assert isinstance(legacy_rows, list)
+        assert [row[1] for row in legacy_rows] == ["same-a", "same-b", "late"]
+
+        batches = list(
+            manager.iter_original_by_timeframe_batches(
+                "cat", _START, _END, batch_size=1, limit_rows=3
+            )
+        )
+        assert [len(batch) for batch in batches] == [1, 1, 1]
+        assert [row[1] for row in _flatten(batches)] == [
+            "same-a",
+            "same-b",
+            "late",
+        ]
+    finally:
+        engine.dispose()
+
+
+def test_batch_size_must_be_positive(timeindex_module):
+    manager = timeindex_module.TimeIndexedMemory.__new__(
+        timeindex_module.TimeIndexedMemory
+    )
+    with pytest.raises(ValueError, match="batch_size"):
+        list(
+            manager.iter_original_by_timeframe_batches(
+                "cat", _START, _END, batch_size=0
+            )
+        )
+
+
+class _FakeResult:
+    def __init__(self, rows=None, error=None):
+        self.rows = rows or []
+        self.error = error
+        self.fetch_sizes: list[int] = []
+
+    def fetchmany(self, size):
+        self.fetch_sizes.append(size)
+        if self.error is not None:
+            raise self.error
+        return self.rows
+
+
+class _FakeConnection:
+    def __init__(self, result, tracker):
+        self.result = result
+        self.tracker = tracker
+
+    def __enter__(self):
+        self.tracker["active"] += 1
+        self.tracker["threads"].append(threading.get_ident())
+        return self
+
+    def __exit__(self, *_args):
+        self.tracker["active"] -= 1
+        self.tracker["exits"] += 1
+
+    def execute(self, *_args, **_kwargs):
+        return self.result
+
+
+class _FakeEngine:
+    def __init__(self, results, tracker):
+        self.results = iter(results)
+        self.tracker = tracker
+
+    def connect(self):
+        return _FakeConnection(next(self.results), self.tracker)
+
+
+def _fake_manager(timeindex_module, results, tracker):
+    manager = timeindex_module.TimeIndexedMemory.__new__(
+        timeindex_module.TimeIndexedMemory
+    )
+    manager.engines = {"cat": _FakeEngine(results, tracker)}
+    manager._ensure_engine_exists = lambda _name, db_path=None, readonly=False: True
+    return manager
+
+
+def test_connection_is_closed_before_yield_and_fetchmany_is_bounded(timeindex_module):
+    tracker = {"active": 0, "exits": 0, "threads": []}
+    first_result = _FakeResult(
+        [
+            ("2026-01-01 00:00:00.000000", 1, "session", "message"),
+        ]
+    )
+    manager = _fake_manager(timeindex_module, [first_result], tracker)
+
+    iterator = manager.iter_original_by_timeframe_batches(
+        "cat", _START, _END, batch_size=7, limit_rows=1
+    )
+    assert next(iterator) == [("2026-01-01 00:00:00.000000", "session", "message")]
+    assert first_result.fetch_sizes == [1]
+    assert tracker["active"] == 0
+    assert tracker["exits"] == 1
+
+
+def test_fetch_exception_is_soft_and_still_closes_connection(timeindex_module):
+    tracker = {"active": 0, "exits": 0, "threads": []}
+    manager = _fake_manager(
+        timeindex_module,
+        [_FakeResult(error=RuntimeError("read failed"))],
+        tracker,
+    )
+
+    assert (
+        list(
+            manager.iter_original_by_timeframe_batches(
+                "cat", _START, _END, batch_size=8
+            )
+        )
+        == []
+    )
+    assert tracker["active"] == 0
+    assert tracker["exits"] == 1
+
+
+@pytest.mark.asyncio
+async def test_async_batches_finish_worker_connection_before_crossing_thread(
+    timeindex_module,
+):
+    tracker = {"active": 0, "exits": 0, "threads": []}
+    manager = _fake_manager(
+        timeindex_module,
+        [
+            _FakeResult(
+                [
+                    ("2026-01-01 00:00:00.000000", 1, "session", "message"),
+                ]
+            )
+        ],
+        tracker,
+    )
+    event_loop_thread = threading.get_ident()
+
+    iterator = manager.aiter_original_by_timeframe_batches(
+        "cat", _START, _END, batch_size=1, limit_rows=1
+    )
+    batch = await anext(iterator)
+    assert batch == [("2026-01-01 00:00:00.000000", "session", "message")]
+    assert tracker["threads"] and tracker["threads"][0] != event_loop_thread
+    assert tracker["active"] == 0
+    assert tracker["exits"] == 1
+    await iterator.aclose()
+
+
+def test_wide_corpus_reader_consumes_batches_and_still_cleans_up(
+    timeindex_module,
+    tmp_path,
+    monkeypatch,
+):
+    logger_module = types.ModuleType("tests.testbench.logger")
+    logger_module.python_logger = lambda: _NullLogger()
+    monkeypatch.setitem(sys.modules, "tests.testbench.logger", logger_module)
+
+    calls: dict = {"cleanup": 0}
+
+    class _FakeTimeIndexedMemory:
+        def __init__(self, _recent_history_manager):
+            pass
+
+        def iter_original_by_timeframe_batches(
+            self,
+            character,
+            start_time,
+            end_time,
+            *,
+            batch_size,
+            limit_rows,
+        ):
+            calls["args"] = (
+                character,
+                start_time,
+                end_time,
+                batch_size,
+                limit_rows,
+            )
+            yield [
+                ("2026-01-01", "s0", '{"type":"human","data":{"content":"hello"}}'),
+                ("2026-01-02", "s1", '{"type":"ai","data":{"content":""}}'),
+            ]
+            yield [
+                ("2026-01-03", "s2", '{"type":"ai","data":{"content":"world"}}'),
+            ]
+
+        def cleanup(self):
+            calls["cleanup"] += 1
+
+    fake_timeindex = types.ModuleType("memory.timeindex")
+    fake_timeindex.TimeIndexedMemory = _FakeTimeIndexedMemory
+    monkeypatch.setitem(sys.modules, "memory.timeindex", fake_timeindex)
+
+    module_name = "_conversation_corpus_batched_read_under_test"
+    module_path = (
+        Path(__file__).parents[1] / "testbench" / "pipeline" / "conversation_corpus.py"
+    )
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    character_dir = tmp_path / "cat"
+    character_dir.mkdir()
+    (character_dir / "time_indexed.db").touch()
+    monkeypatch.setattr(module, "_character_memory_dir", lambda _name: character_dir)
+
+    turns, warnings, present = module.load_time_indexed_turns("cat", limit_rows=3)
+
+    assert present is True
+    assert warnings == []
+    assert [turn["content"] for turn in turns] == ["hello", "world"]
+    assert turns[1]["id"] == module._db_turn_id("s2", 2)
+    assert calls["args"][0] == "cat"
+    assert calls["args"][3:] == (module._TIME_INDEX_BATCH_SIZE, 3)
+    assert calls["cleanup"] == 1
+
+
+def test_batched_read_reduces_python_peak_memory(timeindex_module, tmp_path):
+    payload = "x" * 4096
+    row_count = 2500
+    rows = [
+        {
+            "session_id": f"session-{idx}",
+            "message": payload,
+            "timestamp": f"2026-01-01 00:{idx // 60:02d}:{idx % 60:02d}.{idx:06d}",
+        }
+        for idx in range(row_count)
+    ]
+    manager, engine = _create_manager(timeindex_module, tmp_path, rows)
+    try:
+        gc.collect()
+        tracemalloc.start()
+        legacy_rows = manager.retrieve_original_by_timeframe("cat", _START, _END)
+        _, legacy_peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        assert len(legacy_rows) == row_count
+        del legacy_rows
+
+        gc.collect()
+        tracemalloc.start()
+        streamed_count = 0
+        for batch in manager.iter_original_by_timeframe_batches(
+            "cat", _START, _END, batch_size=64
+        ):
+            streamed_count += len(batch)
+        _, batched_peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+
+        assert streamed_count == row_count
+        assert batched_peak < legacy_peak * 0.5, (
+            f"expected batched peak < 50% of list peak, got "
+            f"{batched_peak=} {legacy_peak=}"
+        )
+    finally:
+        if tracemalloc.is_tracing():
+            tracemalloc.stop()
+        engine.dispose()


### PR DESCRIPTION
## 改动概述 / Summary

- 为 time-indexed conversation history 增加同步和异步分批读取接口。
- 使用 `(timestamp, rowid)` keyset pagination；每页在把 batch 交给调用方前关闭 SQLAlchemy connection。
- 保持现有 list API 兼容，异步路径不会经 `asyncio.to_thread` 返回绑定活动 connection 的 generator。
- 只迁移 testbench 的 `read every turn` 大窗口；短周期 signal window、已有 SQL LIMIT 的 rebuttal/Path B 与 FTS 查询保持不变。

## 回归报告 / Regression Report

- **改动了什么：** `memory/timeindex.py` 新增同步/异步 batch iterator，`conversation_corpus.py` 改为逐批规范化宽窗口历史。
- **理由 / 必要性：** 原实现对宽时间窗调用 `fetchall()`，构建 corpus 时会同时持有完整 raw SQL row list 与最终 normalized `turns` list，抬高峰值内存。
- **改动前后的表现对比：** 现有 list API 行为不变；新路径按 256 行分批，使用 `(timestamp, rowid)` 保证同 timestamp 跨批次时顺序稳定、无重复和遗漏。2,500 × 4 KiB SQLite 合成测量中，SQL reader 层 Python 峰值从 11,079,025 B 降至 613,146 B（下降 94.5%）。端到端仍保留最终 `turns` list，因此进程级收益会低于该上限。
- **潜在回归点与验证：** 重点覆盖 chronological order、同 timestamp 翻页、总 limit、异常软失败、connection 关闭、async worker thread 边界、corpus cleanup 与峰值内存。小 LIMIT 和 FTS 调用方未迁移，避免改变 prompt/cursor 语义。

## 不拆分理由 / Why Not Split

不适用：计入上限的文件数不超过 20；实现、唯一宽窗口调用方和对应测试属于同一原子变更。

## 测试 / Testing

- `uv run ... pytest --confcutdir=tests/unit ... tests/unit/test_timeindex_batched_read.py` — 7 passed
- `uv run ... ruff check memory/timeindex.py tests/testbench/pipeline/conversation_corpus.py tests/unit/test_timeindex_batched_read.py` — passed
- `git diff --check` — passed
