### PR TITLE
feat: make natural expression history deterministic and repeat-aware

### DIFF
--- a/config/prompts/prompts_slop.py
+++ b/config/prompts/prompts_slop.py
@@ -45,10 +45,10 @@ import re
 # should intentionally re-key deterministic prompt-side replacements.
 SLOP_RULESET_VERSION = 1
 
-# The third eligible occurrence of a rule is the first one rewritten. This is
+# The second eligible occurrence of a rule is the first one rewritten. This is
 # deliberately an engine constant, not a user setting: the existing Natural
 # Speech switch remains the only product control.
-SLOP_REPEAT_THRESHOLD = 3
+SLOP_REPEAT_THRESHOLD = 2
 
 
 SLOP_RULES: dict[str, list[dict]] = {

--- a/config/prompts/prompts_slop.py
+++ b/config/prompts/prompts_slop.py
@@ -26,7 +26,7 @@ Rule schema::
         "id":      "ZH_001",          # stable, unique across all languages
         "name":    "heart pounding",  # short English label (for logs / management UI)
         "find":    r"...",            # a Python ``re`` pattern (NOT JavaScript)
-        "replace": ["...", ...],      # pool; one entry is chosen at random per match
+        "replace": ["...", ...],      # pool; one entry is chosen deterministically per match
         "flags":   re.IGNORECASE,     # optional; omitted when no flags are needed
     }
 
@@ -39,6 +39,16 @@ This table is curated. Patterns are kept specific (matching the full stock
 collocation, not a single common word) so they do not fire on ordinary prose.
 """
 import re
+
+
+# Bump this whenever rule matching or replacement pools change in a way that
+# should intentionally re-key deterministic prompt-side replacements.
+SLOP_RULESET_VERSION = 1
+
+# The third eligible occurrence of a rule is the first one rewritten. This is
+# deliberately an engine constant, not a user setting: the existing Natural
+# Speech switch remains the only product control.
+SLOP_REPEAT_THRESHOLD = 3
 
 
 SLOP_RULES: dict[str, list[dict]] = {

--- a/tests/unit/test_slop_filter.py
+++ b/tests/unit/test_slop_filter.py
@@ -9,7 +9,7 @@ model stops imitating its own stock phrases. Two hard invariants this file pins:
 2. **assistant-only** — system instructions and the user's own words pass through
    verbatim; only the cat's past turns are rewritten.
 
-Plus: the third eligible match is the first rewrite, replacement choice is stable
+Plus: the second eligible match is the first rewrite, replacement choice is stable
 across calls and history appends, protected technical regions are skipped,
 malformed rules can never break a turn, ``dry_run`` is side-effect-free, and all
 three provider paths use the same engine.
@@ -179,31 +179,25 @@ def test_no_assistant_turn_returns_same_list():
     assert sf.apply_slop_reduction(msgs, "zz", rules=_RULES) is msgs
 
 
-def test_default_threshold_keeps_first_two_and_rewrites_third():
+def test_default_threshold_keeps_first_and_rewrites_second():
     msgs = [
         _assistant_dict("他的心脏疯狂跳动"),
         _assistant_dict("她的心脏疯狂跳动"),
-        _assistant_dict("他的心脏疯狂跳动"),
     ]
 
     out = sf.apply_slop_reduction(msgs, "zz", rules=[_HEART])
 
     assert out[0]["content"] == "他的心脏疯狂跳动"
-    assert out[1]["content"] == "她的心脏疯狂跳动"
-    assert out[2]["content"] == "他的胸口闷闷地一沉"
+    assert out[1]["content"] == "她的胸口闷闷地一沉"
 
 
 def test_below_threshold_is_a_true_noop():
-    msgs = [
-        _assistant_dict("他的心脏疯狂跳动"),
-        _assistant_dict("她的心脏疯狂跳动"),
-    ]
+    msgs = [_assistant_dict("他的心脏疯狂跳动")]
 
     out = sf.apply_slop_reduction(msgs, "zz", rules=[_HEART])
 
     assert out is msgs
     assert out[0] is msgs[0]
-    assert out[1] is msgs[1]
 
 
 def test_multiple_hits_in_one_message_count_in_text_order():
@@ -211,7 +205,7 @@ def test_multiple_hits_in_one_message_count_in_text_order():
 
     out = sf.apply_slop_reduction([_assistant_dict("X X X X")], "zz", rules=[rule])
 
-    assert out[0]["content"] == "X X R R"
+    assert out[0]["content"] == "X R R R"
 
 
 def test_replacement_pool_is_fully_deterministic_across_calls():
@@ -279,7 +273,7 @@ def test_code_inline_code_and_urls_are_not_counted_or_rewritten():
     out = sf.apply_slop_reduction([_assistant_dict(text)], "zz", rules=[rule])
 
     assert out[0]["content"] == (
-        "slop `slop` https://example.test/slop\n```text\nslop\n```\nslop fixed fixed"
+        "slop `slop` https://example.test/slop\n```text\nslop\n```\nfixed fixed fixed"
     )
 
 
@@ -387,7 +381,7 @@ def test_params_applies_slop_only_when_contextvar_armed(monkeypatch):
     assert p_on["messages"][0]["content"] == "你是只猫娘"
     assert p_on["messages"][1]["content"] == "他的心脏疯狂跳动"
     assert p_on["messages"][2]["content"] == "继续"
-    assert p_on["messages"][3]["content"] == "她的心脏疯狂跳动"
+    assert p_on["messages"][3]["content"] == "她的胸口闷闷地一沉"
     assert p_on["messages"][5]["content"] == "他的胸口闷闷地一沉"
 
 
@@ -434,7 +428,7 @@ def test_anthropic_payload_uses_same_repeat_aware_engine(monkeypatch):
     ]
     assert assistant_texts == [
         "他的心脏疯狂跳动",
-        "她的心脏疯狂跳动",
+        "她的胸口闷闷地一沉",
         "他的胸口闷闷地一沉",
     ]
 
@@ -461,7 +455,7 @@ def test_genai_path_uses_same_repeat_aware_engine(monkeypatch):
         reset_dialog_slop_lang(token)
 
     assert out[1].content == "他的心脏疯狂跳动"
-    assert out[3].content == "她的心脏疯狂跳动"
+    assert out[3].content == "她的胸口闷闷地一沉"
     assert out[5].content == "他的胸口闷闷地一沉"
 
 
@@ -478,7 +472,7 @@ def test_all_static_rules_are_valid():
     assert isinstance(rules_by_lang, dict) and rules_by_lang
     assert set(rules_by_lang) == {"zh", "en", "ja", "ko", "ru", "es", "pt"}
     assert prompts_slop.SLOP_RULESET_VERSION >= 1
-    assert prompts_slop.SLOP_REPEAT_THRESHOLD == 3
+    assert prompts_slop.SLOP_REPEAT_THRESHOLD == 2
 
     seen_ids = set()
     cjk_langs = {"zh", "ja"}

--- a/tests/unit/test_slop_filter.py
+++ b/tests/unit/test_slop_filter.py
@@ -9,13 +9,13 @@ model stops imitating its own stock phrases. Two hard invariants this file pins:
 2. **assistant-only** — system instructions and the user's own words pass through
    verbatim; only the cat's past turns are rewritten.
 
-Plus: malformed rules can never break a turn, ``dry_run`` is side-effect-free,
-unknown languages are a no-op, and the ``_dialog_slop_lang`` context var actually
-routes through ``ChatOpenAI._params``.
+Plus: the third eligible match is the first rewrite, replacement choice is stable
+across calls and history appends, protected technical regions are skipped,
+malformed rules can never break a turn, ``dry_run`` is side-effect-free, and all
+three provider paths use the same engine.
 """
-from __future__ import annotations
 
-import random
+from __future__ import annotations
 
 import pytest
 
@@ -53,32 +53,45 @@ def _assistant_dict(text):
 # assistant-only + backref
 # ---------------------------------------------------------------------------
 
+
 def test_rewrites_assistant_dict_and_preserves_backref():
     msgs = [_assistant_dict("他的心脏疯狂跳动，久久不能平静。")]
-    out = sf.apply_slop_reduction(msgs, "zz", rules=_RULES)
+    out = sf.apply_slop_reduction(msgs, "zz", rules=_RULES, repeat_threshold=1)
     assert out[0]["content"] == "他的胸口闷闷地一沉，久久不能平静。"
 
 
 def test_user_and_system_messages_untouched():
     msgs = [
-        {"role": "system", "content": "他的心脏疯狂跳动"},   # instruction — must NOT change
-        {"role": "user", "content": "他的心脏疯狂跳动"},     # user's words — must NOT change
-        _assistant_dict("他的心脏疯狂跳动"),                 # assistant — should change
+        {
+            "role": "system",
+            "content": "他的心脏疯狂跳动",
+        },  # instruction — must NOT change
+        {
+            "role": "user",
+            "content": "他的心脏疯狂跳动",
+        },  # user's words — must NOT change
+        {
+            "role": "tool",
+            "content": "他的心脏疯狂跳动",
+        },  # tool output — must NOT change
+        _assistant_dict("他的心脏疯狂跳动"),  # assistant — should change
     ]
-    out = sf.apply_slop_reduction(msgs, "zz", rules=_RULES)
+    out = sf.apply_slop_reduction(msgs, "zz", rules=_RULES, repeat_threshold=1)
     assert out[0]["content"] == "他的心脏疯狂跳动"
     assert out[1]["content"] == "他的心脏疯狂跳动"
-    assert out[2]["content"] == "他的胸口闷闷地一沉"
+    assert out[2]["content"] == "他的心脏疯狂跳动"
+    assert out[3]["content"] == "他的胸口闷闷地一沉"
 
 
 # ---------------------------------------------------------------------------
 # promptOnly: no mutation of inputs
 # ---------------------------------------------------------------------------
 
+
 def test_input_list_and_dicts_not_mutated():
     original = _assistant_dict("嘴角勾起一抹弧度")
     msgs = [original]
-    out = sf.apply_slop_reduction(msgs, "zz", rules=_RULES)
+    out = sf.apply_slop_reduction(msgs, "zz", rules=_RULES, repeat_threshold=1)
     # The original dict object is untouched; a new one is returned.
     assert original["content"] == "嘴角勾起一抹弧度"
     assert out is not msgs
@@ -88,11 +101,11 @@ def test_input_list_and_dicts_not_mutated():
 
 def test_basemessage_object_cloned_not_mutated():
     original = AIMessage(content="嘴角勾起一抹弧度")
-    out = sf.apply_slop_reduction([original], "zz", rules=_RULES)
-    assert original.content == "嘴角勾起一抹弧度"      # original object intact
+    out = sf.apply_slop_reduction([original], "zz", rules=_RULES, repeat_threshold=1)
+    assert original.content == "嘴角勾起一抹弧度"  # original object intact
     assert out[0] is not original
     assert out[0].content == "神色柔和下来"
-    assert out[0].type == "ai"                        # clone keeps the role
+    assert out[0].type == "ai"  # clone keeps the role
 
 
 def test_humanmessage_object_passes_through_same_identity():
@@ -105,6 +118,7 @@ def test_humanmessage_object_passes_through_same_identity():
 # multimodal content (list of parts)
 # ---------------------------------------------------------------------------
 
+
 def test_multimodal_text_part_rewritten_image_part_kept():
     msg = {
         "role": "assistant",
@@ -113,7 +127,7 @@ def test_multimodal_text_part_rewritten_image_part_kept():
             {"type": "image_url", "image_url": {"url": "data:..."}},
         ],
     }
-    out = sf.apply_slop_reduction([msg], "zz", rules=_RULES)
+    out = sf.apply_slop_reduction([msg], "zz", rules=_RULES, repeat_threshold=1)
     assert out[0]["content"][0]["text"] == "神色柔和下来"
     assert out[0]["content"][1] == msg["content"][1]  # image part untouched
 
@@ -122,11 +136,12 @@ def test_multimodal_text_part_rewritten_image_part_kept():
 # robustness: a malformed rule can never break the turn
 # ---------------------------------------------------------------------------
 
+
 def test_uncompilable_rule_is_skipped():
     bad = {"id": "ZZ_BAD", "name": "broken", "find": r"(unbalanced", "replace": ["x"]}
     msgs = [_assistant_dict("他的心脏疯狂跳动")]
     # The good rule still applies; the broken one is silently skipped.
-    out = sf.apply_slop_reduction(msgs, "zz", rules=[bad, _HEART])
+    out = sf.apply_slop_reduction(msgs, "zz", rules=[bad, _HEART], repeat_threshold=1)
     assert out[0]["content"] == "他的胸口闷闷地一沉"
 
 
@@ -134,7 +149,9 @@ def test_replacement_with_bad_backref_falls_back_to_literal():
     # \2 has no group 2 in the pattern → expand fails → literal template used,
     # never a crash.
     rule = {"id": "ZZ_X", "name": "x", "find": r"心脏", "replace": [r"胸口\2"]}
-    out = sf.apply_slop_reduction([_assistant_dict("心脏")], "zz", rules=[rule])
+    out = sf.apply_slop_reduction(
+        [_assistant_dict("心脏")], "zz", rules=[rule], repeat_threshold=1
+    )
     assert out[0]["content"] == r"胸口\2"
 
 
@@ -142,9 +159,12 @@ def test_replacement_with_bad_backref_falls_back_to_literal():
 # dry_run + no-op paths
 # ---------------------------------------------------------------------------
 
+
 def test_dry_run_returns_original_unchanged():
     msgs = [_assistant_dict("他的心脏疯狂跳动")]
-    out = sf.apply_slop_reduction(msgs, "zz", rules=_RULES, dry_run=True)
+    out = sf.apply_slop_reduction(
+        msgs, "zz", rules=_RULES, repeat_threshold=1, dry_run=True
+    )
     assert out is msgs
     assert out[0]["content"] == "他的心脏疯狂跳动"
 
@@ -159,18 +179,149 @@ def test_no_assistant_turn_returns_same_list():
     assert sf.apply_slop_reduction(msgs, "zz", rules=_RULES) is msgs
 
 
-def test_each_occurrence_picks_independently_from_pool():
-    rule = {"id": "ZZ_P", "name": "pool", "find": r"X", "replace": ["a", "b"]}
-    msgs = [_assistant_dict("X" * 200)]
-    rng = random.Random(1234)
-    out = sf.apply_slop_reduction(msgs, "zz", rules=[rule], rng=rng)
-    body = out[0]["content"]
-    assert set(body) == {"a", "b"}  # both pool entries appear across occurrences
+def test_default_threshold_keeps_first_two_and_rewrites_third():
+    msgs = [
+        _assistant_dict("他的心脏疯狂跳动"),
+        _assistant_dict("她的心脏疯狂跳动"),
+        _assistant_dict("他的心脏疯狂跳动"),
+    ]
+
+    out = sf.apply_slop_reduction(msgs, "zz", rules=[_HEART])
+
+    assert out[0]["content"] == "他的心脏疯狂跳动"
+    assert out[1]["content"] == "她的心脏疯狂跳动"
+    assert out[2]["content"] == "他的胸口闷闷地一沉"
+
+
+def test_below_threshold_is_a_true_noop():
+    msgs = [
+        _assistant_dict("他的心脏疯狂跳动"),
+        _assistant_dict("她的心脏疯狂跳动"),
+    ]
+
+    out = sf.apply_slop_reduction(msgs, "zz", rules=[_HEART])
+
+    assert out is msgs
+    assert out[0] is msgs[0]
+    assert out[1] is msgs[1]
+
+
+def test_multiple_hits_in_one_message_count_in_text_order():
+    rule = {"id": "ZZ_X", "name": "x", "find": r"X", "replace": ["R"]}
+
+    out = sf.apply_slop_reduction([_assistant_dict("X X X X")], "zz", rules=[rule])
+
+    assert out[0]["content"] == "X X R R"
+
+
+def test_replacement_pool_is_fully_deterministic_across_calls():
+    rule = {
+        "id": "ZZ_P",
+        "name": "pool",
+        "find": r"X",
+        "replace": ["alpha", "beta", "gamma"],
+    }
+    msgs = [_assistant_dict("X X X X X X")]
+
+    outputs = {
+        sf.apply_slop_reduction(msgs, "zz", rules=[rule])[0]["content"]
+        for _ in range(20)
+    }
+
+    assert len(outputs) == 1
+
+
+def test_deterministic_choice_is_stable_across_wire_content_shapes():
+    rule = {
+        "id": "ZZ_P",
+        "name": "pool",
+        "find": r"X",
+        "replace": ["alpha", "beta", "gamma"],
+    }
+    plain = [_assistant_dict("X") for _ in range(3)]
+    blocked = [
+        {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "X"}],
+        }
+        for _ in range(3)
+    ]
+
+    plain_out = sf.apply_slop_reduction(plain, "zz", rules=[rule])
+    blocked_out = sf.apply_slop_reduction(blocked, "zz", rules=[rule])
+
+    assert plain_out[2]["content"] == blocked_out[2]["content"][0]["text"]
+
+
+def test_appending_history_does_not_change_existing_replacements():
+    rule = {
+        "id": "ZZ_P",
+        "name": "pool",
+        "find": r"X",
+        "replace": ["alpha", "beta", "gamma"],
+    }
+    original = [_assistant_dict("X") for _ in range(5)]
+    before = sf.apply_slop_reduction(original, "zz", rules=[rule])
+
+    extended = original + [{"role": "user", "content": "next"}, _assistant_dict("X")]
+    after = sf.apply_slop_reduction(extended, "zz", rules=[rule])
+
+    assert [message["content"] for message in after[:5]] == [
+        message["content"] for message in before
+    ]
+    assert after[-1]["content"] != "X"
+
+
+def test_code_inline_code_and_urls_are_not_counted_or_rewritten():
+    rule = {"id": "ZZ_P", "name": "pool", "find": r"slop", "replace": ["fixed"]}
+    text = "slop `slop` https://example.test/slop\n```text\nslop\n```\nslop slop slop"
+
+    out = sf.apply_slop_reduction([_assistant_dict(text)], "zz", rules=[rule])
+
+    assert out[0]["content"] == (
+        "slop `slop` https://example.test/slop\n```text\nslop\n```\nslop fixed fixed"
+    )
+
+
+def test_overlapping_matches_use_rule_order_on_original_text():
+    first = {"id": "ZZ_A", "name": "ab", "find": r"AB", "replace": ["first"]}
+    second = {"id": "ZZ_B", "name": "bc", "find": r"BC", "replace": ["second"]}
+
+    out = sf.apply_slop_reduction(
+        [_assistant_dict("ABC")],
+        "zz",
+        rules=[first, second],
+        repeat_threshold=1,
+    )
+    reversed_out = sf.apply_slop_reduction(
+        [_assistant_dict("ABC")],
+        "zz",
+        rules=[second, first],
+        repeat_threshold=1,
+    )
+
+    assert out[0]["content"] == "firstC"
+    assert reversed_out[0]["content"] == "Asecond"
+
+
+def test_replacements_do_not_cascade_into_later_rules():
+    x_to_y = {"id": "ZZ_X", "name": "x", "find": r"X", "replace": ["Y"]}
+    y_to_z = {"id": "ZZ_Y", "name": "y", "find": r"Y", "replace": ["Z"]}
+
+    out = sf.apply_slop_reduction(
+        [_assistant_dict("X")],
+        "zz",
+        rules=[x_to_y, y_to_z],
+        repeat_threshold=1,
+    )
+
+    assert out[0]["content"] == "Y"
 
 
 # ---------------------------------------------------------------------------
 # gating helper: resolve_dialog_slop_lang
 # ---------------------------------------------------------------------------
+
 
 def test_resolve_dialog_slop_lang_off_when_switch_disabled(monkeypatch):
     monkeypatch.setattr(sf, "is_slop_filter_enabled", lambda: False)
@@ -179,7 +330,9 @@ def test_resolve_dialog_slop_lang_off_when_switch_disabled(monkeypatch):
 
 def test_resolve_dialog_slop_lang_short_code_when_enabled(monkeypatch):
     monkeypatch.setattr(sf, "is_slop_filter_enabled", lambda: True)
-    monkeypatch.setattr(sf, "get_rules_for_language", lambda lang: [_HEART] if lang == "zh" else [])
+    monkeypatch.setattr(
+        sf, "get_rules_for_language", lambda lang: [_HEART] if lang == "zh" else []
+    )
     assert sf.resolve_dialog_slop_lang(lambda: "zh-CN") == "zh"
     assert sf.resolve_dialog_slop_lang(lambda: "ko-KR") is None  # no rules → skip
     assert sf.resolve_dialog_slop_lang(lambda: None) is None
@@ -189,8 +342,10 @@ def test_resolve_dialog_slop_lang_short_code_when_enabled(monkeypatch):
 # llm_client wiring: the context var actually routes through _params
 # ---------------------------------------------------------------------------
 
+
 def _bare_chat_openai(model="m", base_url="https://example.test"):
     from utils.llm_client import ChatOpenAI
+
     obj = ChatOpenAI.__new__(ChatOpenAI)
     obj.model = model
     obj.base_url = base_url
@@ -205,11 +360,17 @@ def _bare_chat_openai(model="m", base_url="https://example.test"):
 
 
 def test_params_applies_slop_only_when_contextvar_armed(monkeypatch):
-    monkeypatch.setattr(sf, "get_rules_for_language", lambda lang: _RULES if lang == "zz" else [])
+    monkeypatch.setattr(
+        sf, "get_rules_for_language", lambda lang: _RULES if lang == "zz" else []
+    )
 
     client = _bare_chat_openai()
     msgs = [
         SystemMessage(content="你是只猫娘"),
+        AIMessage(content="他的心脏疯狂跳动"),
+        HumanMessage(content="继续"),
+        AIMessage(content="她的心脏疯狂跳动"),
+        HumanMessage(content="继续"),
         AIMessage(content="他的心脏疯狂跳动"),
     ]
 
@@ -224,12 +385,90 @@ def test_params_applies_slop_only_when_contextvar_armed(monkeypatch):
     finally:
         reset_dialog_slop_lang(token)
     assert p_on["messages"][0]["content"] == "你是只猫娘"
-    assert p_on["messages"][1]["content"] == "他的胸口闷闷地一沉"
+    assert p_on["messages"][1]["content"] == "他的心脏疯狂跳动"
+    assert p_on["messages"][2]["content"] == "继续"
+    assert p_on["messages"][3]["content"] == "她的心脏疯狂跳动"
+    assert p_on["messages"][5]["content"] == "他的胸口闷闷地一沉"
+
+
+def _bare_chat_anthropic():
+    from utils.llm_client import ChatAnthropic
+
+    obj = ChatAnthropic.__new__(ChatAnthropic)
+    obj.model = "m"
+    obj._max_tokens = 128
+    obj.temperature = None
+    obj.extra_body = {}
+    obj.tools = None
+    obj.tool_choice = None
+    return obj
+
+
+def test_anthropic_payload_uses_same_repeat_aware_engine(monkeypatch):
+    monkeypatch.setattr(
+        sf, "get_rules_for_language", lambda lang: _RULES if lang == "zz" else []
+    )
+    client = _bare_chat_anthropic()
+    msgs = [
+        SystemMessage(content="system"),
+        HumanMessage(content="start"),
+        AIMessage(content="他的心脏疯狂跳动"),
+        HumanMessage(content="继续"),
+        AIMessage(content="她的心脏疯狂跳动"),
+        HumanMessage(content="继续"),
+        AIMessage(content="他的心脏疯狂跳动"),
+    ]
+
+    token = set_dialog_slop_lang("zz")
+    try:
+        payload = client._build_payload(msgs)
+    finally:
+        reset_dialog_slop_lang(token)
+
+    assistant_texts = [
+        part["text"]
+        for message in payload["messages"]
+        if message["role"] == "assistant"
+        for part in message["content"]
+        if part.get("type") == "text"
+    ]
+    assert assistant_texts == [
+        "他的心脏疯狂跳动",
+        "她的心脏疯狂跳动",
+        "他的胸口闷闷地一沉",
+    ]
+
+
+def test_genai_path_uses_same_repeat_aware_engine(monkeypatch):
+    from main_logic.omni_offline_client import _slop_reduced_for_genai
+
+    monkeypatch.setattr(
+        sf, "get_rules_for_language", lambda lang: _RULES if lang == "zz" else []
+    )
+    msgs = [
+        SystemMessage(content="system"),
+        AIMessage(content="他的心脏疯狂跳动"),
+        HumanMessage(content="继续"),
+        AIMessage(content="她的心脏疯狂跳动"),
+        HumanMessage(content="继续"),
+        AIMessage(content="他的心脏疯狂跳动"),
+    ]
+
+    token = set_dialog_slop_lang("zz")
+    try:
+        out = _slop_reduced_for_genai(msgs)
+    finally:
+        reset_dialog_slop_lang(token)
+
+    assert out[1].content == "他的心脏疯狂跳动"
+    assert out[3].content == "她的心脏疯狂跳动"
+    assert out[5].content == "他的胸口闷闷地一沉"
 
 
 # ---------------------------------------------------------------------------
 # real rule tables compile + are well-formed (runs once assembled)
 # ---------------------------------------------------------------------------
+
 
 def test_all_static_rules_are_valid():
     import re
@@ -237,6 +476,9 @@ def test_all_static_rules_are_valid():
     prompts_slop = pytest.importorskip("config.prompts.prompts_slop")
     rules_by_lang = prompts_slop.SLOP_RULES
     assert isinstance(rules_by_lang, dict) and rules_by_lang
+    assert set(rules_by_lang) == {"zh", "en", "ja", "ko", "ru", "es", "pt"}
+    assert prompts_slop.SLOP_RULESET_VERSION >= 1
+    assert prompts_slop.SLOP_REPEAT_THRESHOLD == 3
 
     seen_ids = set()
     cjk_langs = {"zh", "ja"}
@@ -257,13 +499,17 @@ def test_all_static_rules_are_valid():
                 assert r"\b" not in rule["find"], f"{rid}: \\b in a CJK pattern"
 
             pool = rule.get("replace")
-            assert isinstance(pool, list) and len(pool) >= 5, f"{rid}: thin replace pool"
+            assert isinstance(pool, list) and len(pool) >= 5, (
+                f"{rid}: thin replace pool"
+            )
 
             # Every backref a pool entry uses must exist as a capture group.
             ngroups = compiled.groups
             for entry in pool:
                 for ref in re.findall(r"\\(\d+)", entry):
-                    assert int(ref) <= ngroups, f"{rid}: \\{ref} but only {ngroups} groups"
+                    assert int(ref) <= ngroups, (
+                        f"{rid}: \\{ref} but only {ngroups} groups"
+                    )
                 # zh replacements must stay gender-neutral: the subject is
                 # carried by a backref (\1), never a hardcoded 他/她, so a
                 # male/1st/2nd-person turn is never misgendered in the rewrite.
@@ -277,9 +523,14 @@ def test_all_static_rules_are_valid():
 # in-flight tool-call turns are left alone (prefix the user already saw)
 # ---------------------------------------------------------------------------
 
+
 def test_openai_tool_call_prefix_not_rewritten():
     msgs = [
-        {"role": "assistant", "content": "他的心脏疯狂跳动", "tool_calls": [{"id": "c1"}]},
+        {
+            "role": "assistant",
+            "content": "他的心脏疯狂跳动",
+            "tool_calls": [{"id": "c1"}],
+        },
     ]
     out = sf.apply_slop_reduction(msgs, "zz", rules=_RULES)
     assert out is msgs  # untouched → same list identity (no rewrite happened)
@@ -303,11 +554,14 @@ def test_anthropic_tool_use_block_turn_not_rewritten():
 # Traditional Chinese is skipped (shared zh rules are Simplified)
 # ---------------------------------------------------------------------------
 
+
 def test_resolve_dialog_slop_lang_skips_traditional_chinese(monkeypatch):
     monkeypatch.setattr(sf, "is_slop_filter_enabled", lambda: True)
-    monkeypatch.setattr(sf, "get_rules_for_language", lambda lang: [_HEART] if lang == "zh" else [])
-    assert sf.resolve_dialog_slop_lang(lambda: "zh-CN") == "zh"     # Simplified → apply
-    assert sf.resolve_dialog_slop_lang(lambda: "zh-TW") is None     # Traditional → skip
+    monkeypatch.setattr(
+        sf, "get_rules_for_language", lambda lang: [_HEART] if lang == "zh" else []
+    )
+    assert sf.resolve_dialog_slop_lang(lambda: "zh-CN") == "zh"  # Simplified → apply
+    assert sf.resolve_dialog_slop_lang(lambda: "zh-TW") is None  # Traditional → skip
     assert sf.resolve_dialog_slop_lang(lambda: "zh-Hant") is None
 
 
@@ -315,6 +569,7 @@ def test_resolve_dialog_slop_lang_skips_traditional_chinese(monkeypatch):
 # dialog-slop is suspended around tool handlers so a nested LLM call the handler
 # makes (plugin / agent) is treated as a non-dialog call → no-op
 # ---------------------------------------------------------------------------
+
 
 def test_suspend_dialog_slop_hides_lang_from_nested_tool_calls():
     import asyncio
@@ -344,6 +599,7 @@ def test_suspend_dialog_slop_hides_lang_from_nested_tool_calls():
 
     async def _peek():
         from utils.llm_client import peek_dialog_slop_lang as _p
+
         return _p()
 
     asyncio.run(_run())

--- a/utils/slop_filter.py
+++ b/utils/slop_filter.py
@@ -37,6 +37,15 @@ System instructions and user messages pass through untouched, so prompt
 contracts and the user's own words are never altered. The realtime (voice) path
 does not flow through here and is out of scope by construction.
 
+Repeat and stability semantics
+------------------------------
+Matches are counted per rule over the original assistant history in chronological
+message / text-part / match order. The first two eligible occurrences remain
+verbatim; the third and later occurrences are rewritten. Replacement selection is
+derived from stable rule and match coordinates rather than global randomness, so
+repeating a request or appending later history cannot reshuffle older rewrites.
+Fenced code, inline code, and URLs are excluded from both counting and rewriting.
+
 Rule format (see ``config/prompts/prompts_slop.py``)
 ----------------------------------------------------
 Each language maps to a list of rule dicts::
@@ -45,7 +54,7 @@ Each language maps to a list of rule dicts::
         "id": "ZH_003",
         "name": "heart pounding",
         "find": r"...",            # a Python ``re`` pattern (NOT JS)
-        "replace": ["...", ...],   # pool; one is picked at random per match
+        "replace": ["...", ...],   # pool; one is picked deterministically per match
         "flags": 0,                # optional ``re`` flags (default 0)
     }
 
@@ -54,10 +63,11 @@ capture groups from ``find`` through to the replacement, e.g. preserving the
 pronoun. Substitution uses :meth:`re.Match.expand`, so the syntax is exactly
 what ``re.sub`` accepts as a template string.
 """
+
 from __future__ import annotations
 
+import hashlib
 import os
-import random
 import re
 from typing import Any, Callable, Iterable, Optional
 
@@ -94,10 +104,12 @@ class _CompiledRuleCache:
             return value
         try:
             compiled: Optional[re.Pattern[str]] = re.compile(pattern, flags)
-        except re.error as exc:
+        except (re.error, TypeError, ValueError) as exc:
             # Bad pattern from a curated or learned rule — log the pattern (it is
             # author-supplied, not conversation content) once and poison the key.
-            logger.warning("slop rule failed to compile, skipping: %r (%s)", pattern, exc)
+            logger.warning(
+                "slop rule failed to compile, skipping: %r (%s)", pattern, exc
+            )
             compiled = None
         if len(self._cache) >= self._max_size:
             # Evict the oldest entry.
@@ -128,6 +140,21 @@ def get_rules_for_language(lang: str) -> list[dict]:
         logger.warning("slop rules unavailable: %s", exc)
         return []
     return SLOP_RULES.get(lang, [])
+
+
+def _get_ruleset_config() -> tuple[int, int]:
+    """Return the deterministic rule version and built-in repeat threshold."""
+    try:
+        from config.prompts.prompts_slop import (
+            SLOP_REPEAT_THRESHOLD,
+            SLOP_RULESET_VERSION,
+        )
+
+        return int(SLOP_RULESET_VERSION), max(1, int(SLOP_REPEAT_THRESHOLD))
+    except Exception:
+        # Keep prompt construction available even if a partially-upgraded rule
+        # module is imported during development.
+        return 1, 3
 
 
 # ────────────────────────────────────────────────────────────────
@@ -166,57 +193,311 @@ def _is_tool_turn(m: Any) -> bool:
     return False
 
 
+_URL_RE = re.compile(r"(?:https?://|www\.)[^\s<>()]+", re.IGNORECASE)
+
+
+def _fenced_code_spans(text: str) -> list[tuple[int, int]]:
+    """Return Markdown fenced-code spans, including an unclosed final fence."""
+    spans: list[tuple[int, int]] = []
+    fence_start: Optional[int] = None
+    fence_char = ""
+    fence_len = 0
+    offset = 0
+    for line in text.splitlines(keepends=True):
+        stripped = line.lstrip(" \t")
+        indent = len(line) - len(stripped)
+        if indent <= 3:
+            if fence_start is None:
+                opening = re.match(r"(`{3,}|~{3,})", stripped)
+                if opening:
+                    marker = opening.group(1)
+                    fence_start = offset
+                    fence_char = marker[0]
+                    fence_len = len(marker)
+            else:
+                closing = re.match(
+                    rf"{re.escape(fence_char)}{{{fence_len},}}[ \t]*(?:\r?\n)?\Z",
+                    stripped,
+                )
+                if closing:
+                    spans.append((fence_start, offset + len(line)))
+                    fence_start = None
+                    fence_char = ""
+                    fence_len = 0
+        offset += len(line)
+    if fence_start is not None:
+        spans.append((fence_start, len(text)))
+    return spans
+
+
+def _inline_code_spans(
+    text: str,
+    fenced_spans: list[tuple[int, int]],
+) -> list[tuple[int, int]]:
+    """Return same-line backtick code spans outside fenced blocks.
+
+    An unclosed backtick run protects the rest of its line. That conservative
+    fallback is preferable to rewriting a technical fragment that merely has
+    malformed Markdown.
+    """
+    spans: list[tuple[int, int]] = []
+    index = 0
+    fence_index = 0
+    while index < len(text):
+        while fence_index < len(fenced_spans) and fenced_spans[fence_index][1] <= index:
+            fence_index += 1
+        if (
+            fence_index < len(fenced_spans)
+            and fenced_spans[fence_index][0] <= index < fenced_spans[fence_index][1]
+        ):
+            index = fenced_spans[fence_index][1]
+            continue
+        if text[index] != "`":
+            index += 1
+            continue
+
+        run_end = index + 1
+        while run_end < len(text) and text[run_end] == "`":
+            run_end += 1
+        delimiter = text[index:run_end]
+        newline = text.find("\n", run_end)
+        line_end = len(text) if newline < 0 else newline
+        closing = text.find(delimiter, run_end, line_end)
+        end = line_end if closing < 0 else closing + len(delimiter)
+        spans.append((index, end))
+        index = max(end, run_end)
+    return spans
+
+
+def _protected_spans(text: str) -> list[tuple[int, int]]:
+    """Return merged spans for fenced code, inline code, and URLs."""
+    fenced = _fenced_code_spans(text)
+    spans = fenced + _inline_code_spans(text, fenced)
+    spans.extend(match.span() for match in _URL_RE.finditer(text))
+    if not spans:
+        return []
+    merged: list[tuple[int, int]] = []
+    for start, end in sorted(spans):
+        if not merged or start > merged[-1][1]:
+            merged.append((start, end))
+        elif end > merged[-1][1]:
+            merged[-1] = (merged[-1][0], end)
+    return merged
+
+
+def _overlaps_spans(
+    start: int,
+    end: int,
+    spans: Iterable[tuple[int, int]],
+) -> bool:
+    return any(
+        start < protected_end and protected_start < end
+        for protected_start, protected_end in spans
+    )
+
+
+def _prepare_rules(
+    rules: Iterable[dict],
+) -> list[tuple[int, str, tuple[str, ...], re.Pattern[str]]]:
+    """Compile and validate rules without allowing one bad entry to escape."""
+    prepared: list[tuple[int, str, tuple[str, ...], re.Pattern[str]]] = []
+    for order, rule in enumerate(rules):
+        try:
+            pattern = rule.get("find")
+            raw_pool = rule.get("replace")
+            if not isinstance(pattern, str) or not pattern:
+                continue
+            if not isinstance(raw_pool, (list, tuple)):
+                continue
+            pool = tuple(item for item in raw_pool if isinstance(item, str))
+            if not pool:
+                continue
+            flags = int(rule.get("flags", 0) or 0)
+            compiled = _RULE_CACHE.get(pattern, flags)
+            if compiled is None:
+                continue
+            rule_id = str(rule.get("id") or pattern)
+            prepared.append((order, rule_id, pool, compiled))
+        except Exception as exc:
+            logger.debug(
+                "slop rule %s could not be prepared: %s",
+                rule.get("id") if isinstance(rule, dict) else None,
+                exc,
+            )
+    return prepared
+
+
+def _stable_pool_choice(
+    pool: tuple[str, ...],
+    *,
+    ruleset_version: int,
+    lang: str,
+    rule_id: str,
+    rule_order: int,
+    message_index: int,
+    part_index: int,
+    occurrence: int,
+    match: "re.Match[str]",
+    original_text_fingerprint: str,
+) -> str:
+    """Choose a replacement without process-global or call-order state.
+
+    The locator is prefix-stable: appending later history leaves every existing
+    message index, text-part index, match span, and occurrence ordinal intact.
+    """
+    digest = hashlib.blake2b(digest_size=8, person=b"NEKO-slop-v1")
+    components: tuple[Any, ...] = (
+        ruleset_version,
+        lang,
+        rule_id,
+        rule_order,
+        message_index,
+        part_index,
+        occurrence,
+        match.start(),
+        match.end(),
+        match.group(0),
+        original_text_fingerprint,
+    )
+    for component in components:
+        encoded = str(component).encode("utf-8", "surrogatepass")
+        digest.update(len(encoded).to_bytes(8, "big"))
+        digest.update(encoded)
+    index = int.from_bytes(digest.digest(), "big") % len(pool)
+    return pool[index]
+
+
 def _rewrite_text(
     text: str,
-    rules: Iterable[dict],
-    rng: random.Random,
+    prepared_rules: Iterable[tuple[int, str, tuple[str, ...], re.Pattern[str]]],
+    *,
+    lang: str,
+    ruleset_version: int,
+    repeat_threshold: int,
+    message_index: int,
+    part_index: int,
+    occurrence_counts: dict[int, int],
     counters: dict[str, int],
 ) -> str:
-    """Apply every rule to ``text`` in order. Each rule is isolated in its own
-    try/except so one malformed rule can never break the dialog turn."""
-    out = text
-    for rule in rules:
-        pattern = rule.get("find")
-        pool = rule.get("replace")
-        if not pattern or not pool:
-            continue
-        compiled = _RULE_CACHE.get(pattern, int(rule.get("flags", 0) or 0))
-        if compiled is None:
-            continue
+    """Count on original text, then rewrite stable non-overlapping candidates.
 
-        def _replacer(match: "re.Match[str]") -> str:
-            template = rng.choice(pool)
-            try:
-                return match.expand(template)
-            except (re.error, IndexError):
-                # Backref to a group the pattern didn't capture, or a stray
-                # escape in the pool entry — fall back to the literal template.
-                return template
-
+    Counts are independent per rule and therefore unaffected by replacements
+    from earlier rules. If rewrite spans overlap, the earlier rule in the table
+    wins; accepted replacements are finally applied right-to-left to preserve
+    every original match coordinate.
+    """
+    protected = _protected_spans(text)
+    text_fingerprint = hashlib.blake2b(
+        text.encode("utf-8", "surrogatepass"),
+        digest_size=16,
+        person=b"NEKO-slop-text",
+    ).hexdigest()
+    candidates: list[tuple[int, int, int, str, str]] = []
+    for order, rule_id, pool, compiled in prepared_rules:
         try:
-            new_out, n = compiled.subn(_replacer, out)
+            for match in compiled.finditer(text):
+                start, end = match.span()
+                if start == end or _overlaps_spans(start, end, protected):
+                    continue
+                occurrence = occurrence_counts.get(order, 0) + 1
+                occurrence_counts[order] = occurrence
+                if occurrence < repeat_threshold:
+                    continue
+                template = _stable_pool_choice(
+                    pool,
+                    ruleset_version=ruleset_version,
+                    lang=lang,
+                    rule_id=rule_id,
+                    rule_order=order,
+                    message_index=message_index,
+                    part_index=part_index,
+                    occurrence=occurrence,
+                    match=match,
+                    original_text_fingerprint=text_fingerprint,
+                )
+                try:
+                    replacement = match.expand(template)
+                except Exception:
+                    # Preserve the previous fail-soft contract for a bad
+                    # backreference or escape in one pool entry.
+                    replacement = template
+                candidates.append((order, start, end, replacement, rule_id))
         except Exception as exc:
-            logger.debug("slop rule %s errored at apply time: %s", rule.get("id"), exc)
+            logger.debug("slop rule %s errored at apply time: %s", rule_id, exc)
+
+    accepted: list[tuple[int, int, int, str, str]] = []
+    for candidate in sorted(candidates, key=lambda item: (item[0], item[1], item[2])):
+        _, start, end, _, _ = candidate
+        if any(
+            start < kept_end and kept_start < end
+            for _, kept_start, kept_end, _, _ in accepted
+        ):
             continue
-        if n:
-            counters[rule.get("id") or pattern] = counters.get(rule.get("id") or pattern, 0) + n
-            out = new_out
+        accepted.append(candidate)
+    if not accepted:
+        return text
+
+    out = text
+    for _, start, end, replacement, rule_id in sorted(
+        accepted,
+        key=lambda item: item[1],
+        reverse=True,
+    ):
+        out = out[:start] + replacement + out[end:]
+        counters[rule_id] = counters.get(rule_id, 0) + 1
     return out
 
 
-def _rewrite_content(content: Any, rules, rng, counters) -> Any:
-    """Rewrite a message's ``content`` field, handling both a plain string and
-    the multimodal list-of-parts shape (only ``text`` parts are touched)."""
+def _rewrite_content(
+    content: Any,
+    prepared_rules,
+    *,
+    lang: str,
+    ruleset_version: int,
+    repeat_threshold: int,
+    message_index: int,
+    occurrence_counts: dict[int, int],
+    counters: dict[str, int],
+) -> Any:
+    """Rewrite plain or multimodal text while retaining non-text part identity."""
     if isinstance(content, str):
-        return _rewrite_text(content, rules, rng, counters)
+        return _rewrite_text(
+            content,
+            prepared_rules,
+            lang=lang,
+            ruleset_version=ruleset_version,
+            repeat_threshold=repeat_threshold,
+            message_index=message_index,
+            part_index=0,
+            occurrence_counts=occurrence_counts,
+            counters=counters,
+        )
     if isinstance(content, list):
         new_parts = []
+        changed = False
+        text_part_index = 0
         for part in content:
             if isinstance(part, dict) and isinstance(part.get("text"), str):
-                new_parts.append({**part, "text": _rewrite_text(part["text"], rules, rng, counters)})
+                new_text = _rewrite_text(
+                    part["text"],
+                    prepared_rules,
+                    lang=lang,
+                    ruleset_version=ruleset_version,
+                    repeat_threshold=repeat_threshold,
+                    message_index=message_index,
+                    part_index=text_part_index,
+                    occurrence_counts=occurrence_counts,
+                    counters=counters,
+                )
+                text_part_index += 1
+                if new_text != part["text"]:
+                    new_parts.append({**part, "text": new_text})
+                    changed = True
+                else:
+                    new_parts.append(part)
             else:
                 new_parts.append(part)
-        return new_parts
+        return new_parts if changed else content
     return content
 
 
@@ -225,7 +506,8 @@ def apply_slop_reduction(
     lang: str,
     *,
     rules: Optional[list[dict]] = None,
-    rng: Optional[random.Random] = None,
+    ruleset_version: Optional[int] = None,
+    repeat_threshold: Optional[int] = None,
     dry_run: bool = False,
 ) -> list:
     """Return a NEW message list with AI-writing clichés rewritten in the
@@ -236,7 +518,9 @@ def apply_slop_reduction(
         messages: the history list (``BaseMessage`` objects and/or dicts).
         lang: short language code selecting the rule set (``zh``/``en``/...).
         rules: override rule set (defaults to ``get_rules_for_language(lang)``).
-        rng: inject a seeded ``random.Random`` for deterministic tests.
+        ruleset_version: stable version mixed into replacement selection.
+        repeat_threshold: first occurrence ordinal eligible for replacement;
+            defaults to the built-in value (3) and is not a user setting.
         dry_run: count + log what *would* change but return ``messages`` as-is.
 
     Returns ``messages`` unchanged (same object) when there is nothing to do —
@@ -245,11 +529,23 @@ def apply_slop_reduction(
     rules = rules if rules is not None else get_rules_for_language(lang)
     if not rules:
         return messages
-    rng = rng or random
+    default_ruleset_version, default_repeat_threshold = _get_ruleset_config()
+    ruleset_version = (
+        default_ruleset_version if ruleset_version is None else int(ruleset_version)
+    )
+    repeat_threshold = max(
+        1,
+        default_repeat_threshold if repeat_threshold is None else int(repeat_threshold),
+    )
+    prepared_rules = _prepare_rules(rules)
+    if not prepared_rules:
+        return messages
     counters: dict[str, int] = {}
+    occurrence_counts: dict[int, int] = {}
 
     out: list = []
     changed = False
+    assistant_message_index = 0
     for m in messages:
         # Rewrite only completed plain assistant turns. System instructions and
         # the user's own words pass through; an in-flight assistant+tool_calls
@@ -258,10 +554,21 @@ def apply_slop_reduction(
         if not _is_assistant_message(m) or _is_tool_turn(m):
             out.append(m)
             continue
+        message_index = assistant_message_index
+        assistant_message_index += 1
         if isinstance(m, dict):
             content = m.get("content")
-            new_content = _rewrite_content(content, rules, rng, counters)
-            if new_content is not content:
+            new_content = _rewrite_content(
+                content,
+                prepared_rules,
+                lang=lang,
+                ruleset_version=ruleset_version,
+                repeat_threshold=repeat_threshold,
+                message_index=message_index,
+                occurrence_counts=occurrence_counts,
+                counters=counters,
+            )
+            if new_content != content:
                 out.append({**m, "content": new_content})
                 changed = True
             else:
@@ -272,8 +579,17 @@ def apply_slop_reduction(
             # succeeds, so the log never reports replacements that were dropped
             # because the message object could not be safely cloned.
             scratch: dict[str, int] = {}
-            new_content = _rewrite_content(content, rules, rng, scratch)
-            if new_content is not content:
+            new_content = _rewrite_content(
+                content,
+                prepared_rules,
+                lang=lang,
+                ruleset_version=ruleset_version,
+                repeat_threshold=repeat_threshold,
+                message_index=message_index,
+                occurrence_counts=occurrence_counts,
+                counters=scratch,
+            )
+            if new_content != content:
                 # Defensive copy of the message object — never mutate the one
                 # that lives in the persisted history.
                 clone = _clone_message(m, new_content)
@@ -337,6 +653,7 @@ def _resolve_short_lang(raw: Optional[str]) -> str:
         return ""
     try:
         from utils.language_utils import normalize_language_code
+
         return normalize_language_code(raw, format="short") or ""
     except Exception:
         return ""
@@ -351,6 +668,7 @@ def _is_traditional_chinese(raw: Optional[str]) -> bool:
         return False
     try:
         from utils.language_utils import normalize_language_code
+
         return (normalize_language_code(raw, format="full") or "") == "zh-TW"
     except Exception:
         return False
@@ -363,6 +681,7 @@ def is_slop_filter_enabled() -> bool:
     leaves the feature on (its rewrites are reversible and low-risk)."""
     try:
         from utils.preferences import load_global_conversation_settings
+
         return bool(load_global_conversation_settings().get("slopFilterEnabled", True))
     except Exception:
         return True

--- a/utils/slop_filter.py
+++ b/utils/slop_filter.py
@@ -154,7 +154,7 @@ def _get_ruleset_config() -> tuple[int, int]:
     except Exception:
         # Keep prompt construction available even if a partially-upgraded rule
         # module is imported during development.
-        return 1, 3
+        return 1, 2
 
 
 # ────────────────────────────────────────────────────────────────
@@ -520,7 +520,7 @@ def apply_slop_reduction(
         rules: override rule set (defaults to ``get_rules_for_language(lang)``).
         ruleset_version: stable version mixed into replacement selection.
         repeat_threshold: first occurrence ordinal eligible for replacement;
-            defaults to the built-in value (3) and is not a user setting.
+            defaults to the built-in value (2) and is not a user setting.
         dry_run: count + log what *would* change but return ``messages`` as-is.
 
     Returns ``messages`` unchanged (same object) when there is nothing to do —


### PR DESCRIPTION
## Summary

- make Natural Speech history rewrites deterministic with a versioned, stable match locator instead of process-global randomness
- count rule matches on the original assistant history and keep the first eligible occurrence unchanged; rewrite the second and later occurrences
- exclude fenced code, inline code, and URLs from both repeat counting and rewriting
- keep overlap handling stable: rule-table order wins, and replacement output never cascades into later rule matching
- retain the existing promptOnly boundary and the existing Natural Speech switch across OpenAI, Anthropic, and native GenAI paths

## Behavior

The repeat threshold is fixed at **2** for this stage: occurrence 1 remains verbatim, while occurrence 2 and later are eligible for replacement. This intentionally differs from the research baseline of 3 after review: one occurrence still preserves legitimate contextual phrasing, while the second establishes actual repetition and intervenes early enough to avoid reinforcing the pattern in later generations.

Replacement selection is keyed by the ruleset version, language, rule identity/order, assistant message/text-part location, occurrence ordinal, original match span, and original text fingerprint. Repeating the same request produces byte-identical model-side history, and appending later history does not reshuffle older replacements.

The switch still does **not** post-process the current visible response and does not modify persisted conversation history. It only changes the assistant-history copy sent back to the model, so it can indirectly influence later generations through what the model sees in context.

The existing seven rule packs remain in place. Traditional Chinese remains explicitly skipped rather than receiving mechanically converted Simplified Chinese rules. Runtime LLM-generated regex rules and Regex Navigator remain out of scope for the later PR3.

## Validation

- `uv run pytest tests/unit/test_slop_filter.py -q` — 30 passed
- `uv run pytest tests/unit/test_slop_filter.py tests/unit/test_llm_client_response_safety.py tests/unit/test_proactive_sm_integration.py tests/unit/test_tool_calling.py -q` — 200 passed
- `uv run ruff check .`
- `uv run python -m py_compile config/prompts/prompts_slop.py utils/slop_filter.py tests/unit/test_slop_filter.py`
- `uv run python scripts/check_prompt_hygiene.py`
- `uv run python scripts/check_i18n_sync.py --base origin/main`
- `uv run python scripts/check_docstring_no_cjk.py --base origin/main`
- `uv run python scripts/check_no_temperature.py`
- `uv run python scripts/check_startup_import_lazy.py`
- `uv run python scripts/check_async_blocking.py`
- `git diff --check`
