### PR TITLE
perf(topic): reduce TopicTurnSignal overhead with slots

### DIFF
--- a/main_logic/topic/signals.py
+++ b/main_logic/topic/signals.py
@@ -134,7 +134,7 @@ def _format_age(age_s: float, labels: Mapping[str, str]) -> str:
     return labels["hours_ago"].format(value=int(age_s / 3600))
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class TopicTurnSignal:
     actor: str
     text: str

--- a/main_logic/topic/signals.py
+++ b/main_logic/topic/signals.py
@@ -134,7 +134,7 @@ def _format_age(age_s: float, labels: Mapping[str, str]) -> str:
     return labels["hours_ago"].format(value=int(age_s / 3600))
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, weakref_slot=True)
 class TopicTurnSignal:
     actor: str
     text: str

--- a/tests/unit/test_topic_signals.py
+++ b/tests/unit/test_topic_signals.py
@@ -1,13 +1,15 @@
 import json
 import time
+import weakref
 
 from main_logic.topic.signals import TopicSignalStore, TopicTurnSignal
 
 
-def test_topic_turn_signal_uses_slots_for_the_bounded_rolling_window():
+def test_topic_turn_signal_uses_slots_and_preserves_weakrefs():
     signal = TopicTurnSignal(actor="user", text="hello", timestamp=1.0)
 
     assert not hasattr(signal, "__dict__")
+    assert weakref.ref(signal)() is signal
 
 
 def test_topic_signal_store_keeps_filler_chat_below_ready_even_after_many_turns():

--- a/tests/unit/test_topic_signals.py
+++ b/tests/unit/test_topic_signals.py
@@ -1,7 +1,13 @@
 import json
 import time
 
-from main_logic.topic.signals import TopicSignalStore
+from main_logic.topic.signals import TopicSignalStore, TopicTurnSignal
+
+
+def test_topic_turn_signal_uses_slots_for_the_bounded_rolling_window():
+    signal = TopicTurnSignal(actor="user", text="hello", timestamp=1.0)
+
+    assert not hasattr(signal, "__dict__")
 
 
 def test_topic_signal_store_keeps_filler_chat_below_ready_even_after_many_turns():


### PR DESCRIPTION
## 改动概述 / Summary

- 为 `TopicTurnSignal` 添加 `slots=True`，并用 `weakref_slot=True` 保留原有弱引用能力
- 增加回归测试，确保这个有界滚动窗口中的值对象不再携带实例 `__dict__`，同时仍可被 `weakref.ref()` 引用
- 审计但不改动其余候选 dataclass：低常驻实例量或兼容性风险不足以支撑 slots 改造

## 回归报告 / Regression Report

- **改动了什么：** 仅调整 `main_logic/topic/signals.py` 中 `TopicTurnSignal` 的 dataclass 布局，并在 `tests/unit/test_topic_signals.py` 增加 slots 与 weakref 兼容断言。
- **理由 / 必要性：** `TopicSignalStore` 会为每个角色常驻保存最多 60 条 turn signal。该类型字段固定，未发现动态属性、weakref、子类或实例 monkeypatch 用法，是本次审计中唯一同时满足兼容性和批量常驻条件的候选。由于该类型从 `main_logic.topic` 导出，follow-up 保守保留了此前的弱引用能力。
- **改动前后的表现：** 业务行为、构造参数、冻结语义、弱引用能力和持久化格式保持不变；CPython 3.11 下 shallow `getsizeof` 从 152 B 降到 64 B，50,000 实例等布局 `tracemalloc` 对比约节省 32 B/实例，即单角色 60 条满窗口约 1.88 KiB。
- **潜在回归点与验证：** 风险集中在对象属性访问、弱引用、滚动窗口保留、格式化和持久化重载。初始改动的 `test_topic_signals.py` 8 项与 `test_topic_pipeline.py` 67 项均通过；follow-up 新增 weakref 断言后，GitHub Actions `Analyze` 全部 jobs 与 PR report gate 通过。

`MasterEmotionReading`、`FocusScore`、`FocusThresholds` 和 `_FocusDecision` 保持不变，因为它们每会话仅一个或每轮短暂存在。`SessionStateMachine` 保持不变，因为其每会话仅一个，且现有测试会在实例级 monkeypatch `fire`。

## 不拆分理由 / Why Not Split

不适用：计入上限的改动文件仅 1 个，另有 1 个对应测试文件。

## 测试 / Testing

- `uv run --no-sync python -m pytest --noconftest tests/unit/test_topic_signals.py -q` — 8 passed（初始 slots 改动）
- `uv run --no-sync python -m pytest --noconftest tests/unit/test_topic_pipeline.py -q` — 67 passed（初始 slots 改动）
- `uv run --no-sync ruff check main_logic/topic/signals.py tests/unit/test_topic_signals.py` — passed
- GitHub Actions `Analyze`（Ruff、API & layering、Code safety、Core package contracts、Prompts & i18n）— passed on `605047ad`
- PR report gate — passed on `605047ad`

测试环境：Windows，CPython 3.11.13。