### PR TITLE
perf(audio): reduce silence and RNNoise buffer memory

### DIFF
--- a/benchmarks/audio_memory_benchmark.py
+++ b/benchmarks/audio_memory_benchmark.py
@@ -1,0 +1,410 @@
+# -*- coding: utf-8 -*-
+"""Measure peak allocations and numeric drift for audio memory changes.
+
+Run with::
+
+    uv run --no-sync python benchmarks/audio_memory_benchmark.py
+
+The legacy helpers intentionally mirror the pre-optimization implementations so
+the benchmark remains useful after the production paths change.
+"""
+
+from __future__ import annotations
+
+import gc
+import hashlib
+import io
+import json
+import math
+from pathlib import Path
+import sys
+import time
+import tracemalloc
+import wave
+from typing import Callable
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from utils.audio_processor import AudioProcessor
+from utils.audio_silence_remover import (
+    SilenceAnalysisResult,
+    SilenceSegment,
+    _samples_to_float,
+    trim_silence,
+)
+
+
+def _legacy_samples_to_float(data: bytes, sample_width: int) -> np.ndarray:
+    if sample_width == 1:
+        arr = np.frombuffer(data, dtype=np.uint8).astype(np.float64)
+        return (arr - 128.0) / 128.0
+    if sample_width == 2:
+        arr = np.frombuffer(data, dtype=np.int16).astype(np.float64)
+        return arr / 32768.0
+    if sample_width == 3:
+        raw = np.frombuffer(data, dtype=np.uint8).reshape(-1, 3)
+        i32 = (
+            raw[:, 0].astype(np.int32)
+            | (raw[:, 1].astype(np.int32) << 8)
+            | (raw[:, 2].astype(np.int32) << 16)
+        )
+        i32[i32 >= 0x800000] -= 0x1000000
+        return i32.astype(np.float64) / 8388608.0
+    if sample_width == 4:
+        arr = np.frombuffer(data, dtype=np.int32).astype(np.float64)
+        return arr / 2147483648.0
+    raise ValueError(sample_width)
+
+
+def _candidate_samples_to_float32(data: bytes, sample_width: int) -> np.ndarray:
+    if sample_width == 1:
+        arr = np.frombuffer(data, dtype=np.uint8).astype(np.float32)
+        return (arr - np.float32(128.0)) / np.float32(128.0)
+    if sample_width == 2:
+        arr = np.frombuffer(data, dtype=np.int16).astype(np.float32)
+        return arr / np.float32(32768.0)
+    if sample_width == 3:
+        raw = np.frombuffer(data, dtype=np.uint8).reshape(-1, 3)
+        i32 = (
+            raw[:, 0].astype(np.int32)
+            | (raw[:, 1].astype(np.int32) << 8)
+            | (raw[:, 2].astype(np.int32) << 16)
+        )
+        i32[i32 >= 0x800000] -= 0x1000000
+        return i32.astype(np.float32) / np.float32(8388608.0)
+    if sample_width == 4:
+        arr = np.frombuffer(data, dtype=np.int32).astype(np.float32)
+        return arr / np.float32(2147483648.0)
+    raise ValueError(sample_width)
+
+
+def _legacy_float_to_samples(arr: np.ndarray, sample_width: int) -> bytes:
+    arr = np.clip(arr, -1.0, 1.0)
+    if sample_width == 1:
+        return ((arr * 128.0) + 128.0).astype(np.uint8).tobytes()
+    if sample_width == 2:
+        return (arr * 32768.0).astype(np.int16).tobytes()
+    if sample_width == 3:
+        i32 = np.clip(arr * 8388608.0, -8388608, 8388607).astype(np.int32)
+        u32 = i32.view(np.uint32)
+        raw = np.empty((len(u32), 3), dtype=np.uint8)
+        raw[:, 0] = u32 & 0xFF
+        raw[:, 1] = (u32 >> 8) & 0xFF
+        raw[:, 2] = (u32 >> 16) & 0xFF
+        return raw.tobytes()
+    if sample_width == 4:
+        return (arr * 2147483648.0).astype(np.int32).tobytes()
+    raise ValueError(sample_width)
+
+
+def _rms_dbfs(samples: np.ndarray) -> float:
+    if len(samples) == 0:
+        return -100.0
+    rms = np.sqrt(np.mean(samples**2))
+    if rms < 1e-10:
+        return -100.0
+    return 20.0 * math.log10(rms)
+
+
+def _pcm_bytes(values: np.ndarray, sample_width: int) -> bytes:
+    if sample_width == 1:
+        return values.astype(np.uint8).tobytes()
+    if sample_width == 2:
+        return values.astype(np.int16).tobytes()
+    if sample_width == 3:
+        i32 = values.astype(np.int32)
+        u32 = i32.view(np.uint32)
+        raw = np.empty((len(u32), 3), dtype=np.uint8)
+        raw[:, 0] = u32 & 0xFF
+        raw[:, 1] = (u32 >> 8) & 0xFF
+        raw[:, 2] = (u32 >> 16) & 0xFF
+        return raw.tobytes()
+    if sample_width == 4:
+        return values.astype(np.int32).tobytes()
+    raise ValueError(sample_width)
+
+
+def _numeric_error_benchmark() -> dict[str, dict[str, float | int]]:
+    rng = np.random.default_rng(20260715)
+    ranges = {
+        1: (0, 256, np.uint16),
+        2: (-32768, 32768, np.int32),
+        3: (-8388608, 8388608, np.int32),
+        4: (-2147483648, 2147483648, np.int64),
+    }
+    results: dict[str, dict[str, float | int]] = {}
+    for sample_width, (low, high, dtype) in ranges.items():
+        values = rng.integers(low, high, size=480 * 100, dtype=dtype)
+        data = _pcm_bytes(values, sample_width)
+        reference = _legacy_samples_to_float(data, sample_width)
+        candidate = _candidate_samples_to_float32(data, sample_width)
+        production = _samples_to_float(data, sample_width)
+        db_errors = []
+        for start in range(0, len(reference), 480):
+            ref_db = _rms_dbfs(reference[start : start + 480])
+            cand_db = _rms_dbfs(candidate[start : start + 480])
+            db_errors.append(abs(ref_db - cand_db))
+
+        threshold_errors = []
+        decision_mismatches = 0
+        phase = np.arange(480, dtype=np.float64) * (2.0 * np.pi * 7.0 / 480.0)
+        for level_dbfs in np.linspace(-40.1, -39.9, 201):
+            peak = math.sqrt(2.0) * (10.0 ** (level_dbfs / 20.0))
+            threshold_pcm = _legacy_float_to_samples(np.sin(phase) * peak, sample_width)
+            threshold_reference = _legacy_samples_to_float(threshold_pcm, sample_width)
+            threshold_candidate = _candidate_samples_to_float32(
+                threshold_pcm, sample_width
+            )
+            ref_db = _rms_dbfs(threshold_reference)
+            cand_db = _rms_dbfs(threshold_candidate)
+            threshold_errors.append(abs(ref_db - cand_db))
+            decision_mismatches += (ref_db < -40.0) != (cand_db < -40.0)
+        results[str(sample_width)] = {
+            "candidate_max_sample_error": float(
+                np.max(np.abs(reference - candidate.astype(np.float64)))
+            ),
+            "candidate_max_dbfs_error": float(max(db_errors)),
+            "candidate_near_threshold_max_dbfs_error": float(max(threshold_errors)),
+            "candidate_threshold_mismatches": decision_mismatches,
+            "production_dtype_bits": int(production.dtype.itemsize * 8),
+            "production_max_sample_error": float(
+                np.max(np.abs(reference - production.astype(np.float64)))
+            ),
+        }
+    return results
+
+
+def _make_trim_fixture(duration_s: int = 30) -> tuple[bytes, SilenceAnalysisResult]:
+    sample_rate = 48000
+    channels = 2
+    sample_width = 4
+    sample_count = duration_s * sample_rate * channels
+    samples = np.arange(sample_count, dtype=np.int32)
+    wav_buf = io.BytesIO()
+    with wave.open(wav_buf, "wb") as wf:
+        wf.setnchannels(channels)
+        wf.setsampwidth(sample_width)
+        wf.setframerate(sample_rate)
+        wf.writeframes(samples.tobytes())
+    segments = [
+        SilenceSegment(start_ms=5000.0, end_ms=7000.0),
+        SilenceSegment(start_ms=14000.0, end_ms=16000.0),
+        SilenceSegment(start_ms=23000.0, end_ms=25000.0),
+    ]
+    analysis = SilenceAnalysisResult(
+        original_duration_ms=duration_s * 1000.0,
+        silence_segments=segments,
+        total_silence_ms=6000.0,
+        removable_silence_ms=5400.0,
+        estimated_duration_ms=duration_s * 1000.0 - 5400.0,
+        sample_rate=sample_rate,
+        sample_width=sample_width,
+        channels=channels,
+    )
+    return wav_buf.getvalue(), analysis
+
+
+def _legacy_trim(audio_data: bytes, analysis: SilenceAnalysisResult) -> bytes:
+    with wave.open(io.BytesIO(audio_data), "rb") as wf:
+        sample_rate = wf.getframerate()
+        sample_width = wf.getsampwidth()
+        channels = wf.getnchannels()
+        raw_data = wf.readframes(wf.getnframes())
+    float_samples = _legacy_samples_to_float(raw_data, sample_width).reshape(-1, channels)
+    retain_half = int(sample_rate * 0.1)
+    result_parts: list[np.ndarray] = []
+    prev_end = 0
+    for segment in analysis.silence_segments:
+        segment_start = int(segment.start_ms * sample_rate / 1000.0)
+        segment_end = int(segment.end_ms * sample_rate / 1000.0)
+        cut_start = segment_start + retain_half
+        cut_end = segment_end - retain_half
+        if cut_start >= cut_end:
+            continue
+        if cut_start > prev_end:
+            result_parts.append(float_samples[prev_end:cut_start])
+        prev_end = cut_end
+    if prev_end < len(float_samples):
+        result_parts.append(float_samples[prev_end:])
+    final_samples = np.concatenate(result_parts, axis=0)
+    pcm_data = _legacy_float_to_samples(final_samples.reshape(-1), sample_width)
+    output = io.BytesIO()
+    with wave.open(output, "wb") as wf:
+        wf.setnchannels(channels)
+        wf.setsampwidth(sample_width)
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm_data)
+    return output.getvalue()
+
+
+def _analysis_scratch(
+    audio_data: bytes,
+    converter: Callable[[bytes, int], np.ndarray],
+) -> bytes:
+    with wave.open(io.BytesIO(audio_data), "rb") as wf:
+        channels = wf.getnchannels()
+        sample_width = wf.getsampwidth()
+        raw_data = wf.readframes(wf.getnframes())
+    samples = converter(raw_data, sample_width)
+    mono = samples.reshape(-1, channels).mean(axis=1)
+    return repr(_rms_dbfs(mono[:480])).encode("ascii")
+
+
+class _IdentityDenoiser:
+    def process_frame(self, frame: np.ndarray) -> tuple[np.ndarray, float]:
+        return frame.copy(), 0.1
+
+
+class _LegacyRnnoiseProcessor:
+    frame_size = 480
+    sample_rate = 48000
+
+    def __init__(self) -> None:
+        self.frame_buffer = np.array([], dtype=np.int16)
+        self.denoiser = _IdentityDenoiser()
+
+    def process(self, audio: np.ndarray) -> np.ndarray:
+        self.frame_buffer = np.concatenate([self.frame_buffer, audio])
+        if len(self.frame_buffer) > self.sample_rate:
+            self.frame_buffer = self.frame_buffer[-self.sample_rate :]
+        output_frames = []
+        while len(self.frame_buffer) >= self.frame_size:
+            frame = self.frame_buffer[: self.frame_size]
+            self.frame_buffer = self.frame_buffer[self.frame_size :]
+            denoised, _ = self.denoiser.process_frame(frame)
+            output_frames.append(denoised)
+        if output_frames:
+            return np.concatenate(output_frames)
+        return np.array([], dtype=np.int16)
+
+
+def _current_rnnoise_processor() -> AudioProcessor:
+    processor = AudioProcessor.__new__(AudioProcessor)
+    processor._denoiser = _IdentityDenoiser()
+    processor._frame_buffer = np.empty(processor.RNNOISE_FRAME_SIZE, dtype=np.int16)
+    processor._frame_buffer_size = 0
+    processor._last_speech_prob = 0.0
+    processor._last_speech_time = time.time()
+    return processor
+
+
+def _run_rnnoise(
+    processor: object,
+    chunks: list[np.ndarray],
+    method: Callable[[object, np.ndarray], np.ndarray],
+) -> bytes:
+    output = io.BytesIO()
+    for chunk in chunks:
+        output.write(method(processor, chunk).tobytes())
+    return output.getvalue()
+
+
+def _measure_peak(call: Callable[[], bytes]) -> tuple[int, bytes]:
+    gc.collect()
+    tracemalloc.start()
+    try:
+        result = call()
+        peak = tracemalloc.get_traced_memory()[1]
+    finally:
+        tracemalloc.stop()
+    return peak, result
+
+
+def _retained_array_bytes(array: np.ndarray) -> int:
+    root = array
+    while isinstance(root.base, np.ndarray):
+        root = root.base
+    return int(root.nbytes)
+
+
+def _memory_benchmark() -> dict[str, dict[str, int | bool | float]]:
+    audio_data, analysis = _make_trim_fixture()
+    legacy_analysis_peak, _ = _measure_peak(
+        lambda: _analysis_scratch(audio_data, _legacy_samples_to_float)
+    )
+    current_analysis_peak, _ = _measure_peak(
+        lambda: _analysis_scratch(audio_data, _samples_to_float)
+    )
+    legacy_trim_peak, legacy_trim_output = _measure_peak(
+        lambda: _legacy_trim(audio_data, analysis)
+    )
+    current_trim_peak, current_trim_output = _measure_peak(
+        lambda: trim_silence(io.BytesIO(audio_data), analysis).audio_data
+    )
+
+    rng = np.random.default_rng(20260715)
+    burst = [rng.integers(-32768, 32768, size=48000, dtype=np.int16)]
+    stream_data = rng.integers(-32768, 32768, size=48000, dtype=np.int16)
+    stream = [stream_data[start : start + 512] for start in range(0, len(stream_data), 512)]
+
+    results: dict[str, dict[str, int | bool | float]] = {
+        "analysis_scratch_30s_stereo_48k_s32": {
+            "legacy_peak_bytes": legacy_analysis_peak,
+            "current_peak_bytes": current_analysis_peak,
+            "peak_reduction_percent": 100.0
+            * (legacy_analysis_peak - current_analysis_peak)
+            / legacy_analysis_peak,
+        },
+        "trim_30s_stereo_48k_s32": {
+            "legacy_peak_bytes": legacy_trim_peak,
+            "current_peak_bytes": current_trim_peak,
+            "peak_reduction_percent": 100.0
+            * (legacy_trim_peak - current_trim_peak)
+            / legacy_trim_peak,
+            "output_bytes_equal": legacy_trim_output == current_trim_output,
+            "output_md5_equal": hashlib.md5(legacy_trim_output).digest()
+            == hashlib.md5(current_trim_output).digest(),
+        }
+    }
+    for name, chunks in (("rnnoise_1s_burst", burst), ("rnnoise_512_sample_stream", stream)):
+        legacy_peak, legacy_output = _measure_peak(
+            lambda chunks=chunks: _run_rnnoise(
+                _LegacyRnnoiseProcessor(), chunks, _LegacyRnnoiseProcessor.process
+            )
+        )
+        current_peak, current_output = _measure_peak(
+            lambda chunks=chunks: _run_rnnoise(
+                _current_rnnoise_processor(), chunks, AudioProcessor._process_with_rnnoise
+            )
+        )
+        legacy_retained = _LegacyRnnoiseProcessor()
+        _run_rnnoise(legacy_retained, chunks, _LegacyRnnoiseProcessor.process)
+        current_retained = _current_rnnoise_processor()
+        _run_rnnoise(current_retained, chunks, AudioProcessor._process_with_rnnoise)
+        results[name] = {
+            "legacy_peak_bytes": legacy_peak,
+            "current_peak_bytes": current_peak,
+            "peak_reduction_percent": 100.0 * (legacy_peak - current_peak) / legacy_peak,
+            "output_bytes_equal": legacy_output == current_output,
+            "legacy_retained_buffer_bytes": _retained_array_bytes(
+                legacy_retained.frame_buffer
+            ),
+            "current_retained_buffer_bytes": _retained_array_bytes(
+                current_retained._frame_buffer
+            ),
+            "legacy_concatenate_calls": len(chunks) * 2,
+            "current_concatenate_calls": 0,
+        }
+    return results
+
+
+def main() -> None:
+    print(
+        json.dumps(
+            {
+                "numeric_float32_candidate": _numeric_error_benchmark(),
+                "memory": _memory_benchmark(),
+            },
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_audio_memory_optimization.py
+++ b/tests/unit/test_audio_memory_optimization.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for the low-allocation audio paths."""
+
+from __future__ import annotations
+
+import io
+import math
+import time
+import wave
+
+import numpy as np
+import pytest
+
+from utils.audio_processor import AudioProcessor
+from utils.audio_silence_remover import (
+    SilenceAnalysisResult,
+    SilenceSegment,
+    _samples_to_float,
+    _rms_dbfs,
+    trim_silence,
+)
+
+
+class _IdentityDenoiser:
+    def process_frame(self, frame: np.ndarray) -> tuple[np.ndarray, float]:
+        return frame.copy(), 0.1
+
+
+def _processor() -> AudioProcessor:
+    processor = AudioProcessor.__new__(AudioProcessor)
+    processor._denoiser = _IdentityDenoiser()
+    processor._frame_buffer = np.empty(processor.RNNOISE_FRAME_SIZE, dtype=np.int16)
+    processor._frame_buffer_size = 0
+    processor._last_speech_prob = 0.0
+    processor._last_speech_time = time.time()
+    return processor
+
+
+@pytest.mark.parametrize(
+    ("sample_width", "dtype", "values"),
+    [
+        (1, np.uint8, [0, 1, 127, 128, 254, 255]),
+        (2, np.int16, [-32768, -1, 0, 1, 32767]),
+        (4, np.int32, [-2147483648, -1, 0, 1, 2147483647]),
+    ],
+)
+def test_samples_to_float_uses_float32_with_bounded_error(
+    sample_width: int,
+    dtype: np.dtype,
+    values: list[int],
+) -> None:
+    pcm = np.asarray(values, dtype=dtype).tobytes()
+    result = _samples_to_float(pcm, sample_width)
+
+    assert result.dtype == np.float32
+    reference = np.asarray(values, dtype=np.float64)
+    if sample_width == 1:
+        reference = (reference - 128.0) / 128.0
+    else:
+        reference /= float(1 << (sample_width * 8 - 1))
+    np.testing.assert_allclose(result, reference, rtol=0.0, atol=3e-8)
+
+
+@pytest.mark.parametrize("level_dbfs", [-40.1, -40.01, -39.99, -39.9])
+def test_float32_rms_preserves_near_threshold_decisions(level_dbfs: float) -> None:
+    phase = np.arange(480, dtype=np.float64) * (2.0 * np.pi * 7.0 / 480.0)
+    peak = math.sqrt(2.0) * (10.0 ** (level_dbfs / 20.0))
+    pcm = (np.sin(phase) * peak * 2147483648.0).astype(np.int32).tobytes()
+    reference = np.frombuffer(pcm, dtype=np.int32).astype(np.float64) / 2147483648.0
+    candidate = _samples_to_float(pcm, 4)
+
+    assert (_rms_dbfs(reference) < -40.0) == (_rms_dbfs(candidate) < -40.0)
+
+
+def test_trim_silence_copies_original_s32_pcm_frames_exactly() -> None:
+    sample_rate = 1000
+    channels = 2
+    frames = np.arange(2000, dtype=np.int64).reshape(1000, channels)
+    frames[0] = np.iinfo(np.int32).min
+    frames[-1] = np.iinfo(np.int32).max
+    frames = frames.astype(np.int32)
+    source_pcm = frames.tobytes()
+    source = io.BytesIO()
+    with wave.open(source, "wb") as wf:
+        wf.setnchannels(channels)
+        wf.setsampwidth(4)
+        wf.setframerate(sample_rate)
+        wf.writeframes(source_pcm)
+
+    analysis = SilenceAnalysisResult(
+        original_duration_ms=1000.0,
+        silence_segments=[SilenceSegment(start_ms=200.0, end_ms=800.0)],
+        sample_rate=sample_rate,
+        sample_width=4,
+        channels=channels,
+    )
+    result = trim_silence(io.BytesIO(source.getvalue()), analysis)
+
+    with wave.open(io.BytesIO(result.audio_data), "rb") as wf:
+        output_pcm = wf.readframes(wf.getnframes())
+        assert wf.getsampwidth() == 4
+        assert wf.getnchannels() == channels
+    assert output_pcm == frames[np.r_[0:300, 700:1000]].tobytes()
+    assert result.trimmed_duration_ms == pytest.approx(600.0)
+
+
+def test_rnnoise_fixed_buffer_preserves_chunk_boundaries() -> None:
+    processor = _processor()
+    first = np.arange(100, dtype=np.int16)
+    second = np.arange(100, 600, dtype=np.int16)
+
+    assert processor._process_with_rnnoise(first).size == 0
+    output = processor._process_with_rnnoise(second)
+
+    np.testing.assert_array_equal(output, np.arange(480, dtype=np.int16))
+    assert processor._frame_buffer_size == 120
+    np.testing.assert_array_equal(
+        processor._frame_buffer[: processor._frame_buffer_size],
+        np.arange(480, 600, dtype=np.int16),
+    )
+
+
+def test_rnnoise_one_second_burst_is_byte_exact() -> None:
+    processor = _processor()
+    audio = np.arange(processor.RNNOISE_SAMPLE_RATE, dtype=np.int16)
+
+    output = processor._process_with_rnnoise(audio)
+
+    np.testing.assert_array_equal(output, audio)
+    assert processor._frame_buffer_size == 0
+
+
+def test_rnnoise_overflow_keeps_latest_one_second() -> None:
+    processor = _processor()
+    pending = np.full(100, -123, dtype=np.int16)
+    assert processor._process_with_rnnoise(pending).size == 0
+    audio = np.arange(processor.RNNOISE_SAMPLE_RATE, dtype=np.int16)
+
+    output = processor._process_with_rnnoise(audio)
+
+    np.testing.assert_array_equal(output, audio)
+    assert processor._frame_buffer_size == 0

--- a/tests/unit/test_audio_memory_optimization.py
+++ b/tests/unit/test_audio_memory_optimization.py
@@ -17,6 +17,8 @@ from utils.audio_silence_remover import (
     SilenceSegment,
     _samples_to_float,
     _rms_dbfs,
+    _float_to_samples,
+    detect_silence,
     trim_silence,
 )
 
@@ -70,6 +72,30 @@ def test_float32_rms_preserves_near_threshold_decisions(level_dbfs: float) -> No
     candidate = _samples_to_float(pcm, 4)
 
     assert (_rms_dbfs(reference) < -40.0) == (_rms_dbfs(candidate) < -40.0)
+
+
+def test_s32_positive_full_scale_roundtrip() -> None:
+    pcm = np.asarray([np.iinfo(np.int32).max], dtype=np.int32).tobytes()
+
+    assert _float_to_samples(_samples_to_float(pcm, 4), 4) == pcm
+
+
+def test_detect_silence_rechecks_adversarial_threshold_frame() -> None:
+    low = 21474836
+    frame = np.asarray([low] * 249 + [low + 1] * 231, dtype=np.int32)
+    frame_pcm = frame.tobytes()
+    float32_dbfs = _rms_dbfs(_samples_to_float(frame_pcm, 4))
+    float64_dbfs = _rms_dbfs(_samples_to_float(frame_pcm, 4, dtype=np.float64))
+    assert float32_dbfs < -40.0 < float64_dbfs
+
+    source = io.BytesIO()
+    with wave.open(source, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(4)
+        wf.setframerate(48000)
+        wf.writeframes(np.tile(frame, 20).tobytes())
+
+    assert detect_silence(io.BytesIO(source.getvalue())).silence_segments == []
 
 
 def test_trim_silence_copies_original_s32_pcm_frames_exactly() -> None:

--- a/utils/audio_processor.py
+++ b/utils/audio_processor.py
@@ -259,8 +259,10 @@ class AudioProcessor:
         self._denoiser = None
         self._init_denoiser()
         
-        # Buffer for incomplete frames (int16 for pyrnnoise)
-        self._frame_buffer = np.array([], dtype=np.int16)
+        # Fixed-capacity pending buffer. A processed call can leave at most one
+        # incomplete RNNoise frame, so a growing/ring buffer is unnecessary.
+        self._frame_buffer = np.empty(self.RNNOISE_FRAME_SIZE, dtype=np.int16)
+        self._frame_buffer_size = 0
         
         # Track voice activity for auto-reset
         self._last_speech_prob = 0.0
@@ -389,36 +391,68 @@ class AudioProcessor:
         Returns:
             Denoised int16 numpy array
         """
-        # Add to frame buffer (int16)
-        self._frame_buffer = np.concatenate([self._frame_buffer, audio])
-        
-        # Limit buffer size to prevent memory issues (max 1 seconds of audio)
-        max_buffer_samples = 1 * self.RNNOISE_SAMPLE_RATE
-        if len(self._frame_buffer) > max_buffer_samples:
-            self._frame_buffer = self._frame_buffer[-max_buffer_samples:]
-        
-        output_frames = []
-        while len(self._frame_buffer) >= self.RNNOISE_FRAME_SIZE:
-            frame = self._frame_buffer[:self.RNNOISE_FRAME_SIZE]
-            self._frame_buffer = self._frame_buffer[self.RNNOISE_FRAME_SIZE:]
-            
+        pending_size = self._frame_buffer_size
+        max_buffer_samples = self.RNNOISE_SAMPLE_RATE
+
+        # Preserve the previous one-second overflow policy without first
+        # concatenating the pending samples and the new chunk.
+        drop_samples = pending_size + len(audio) - max_buffer_samples
+        if drop_samples > 0:
+            if drop_samples < pending_size:
+                retained = pending_size - drop_samples
+                self._frame_buffer[:retained] = self._frame_buffer[
+                    drop_samples:pending_size
+                ].copy()
+                pending_size = retained
+            else:
+                audio = audio[drop_samples - pending_size :]
+                pending_size = 0
+
+        frame_count = (pending_size + len(audio)) // self.RNNOISE_FRAME_SIZE
+        if frame_count == 0:
+            self._frame_buffer[pending_size : pending_size + len(audio)] = audio
+            self._frame_buffer_size = pending_size + len(audio)
+            return np.empty(0, dtype=np.int16)
+
+        output = np.empty(frame_count * self.RNNOISE_FRAME_SIZE, dtype=np.int16)
+        input_offset = 0
+        output_offset = 0
+
+        def process_frame(frame: np.ndarray) -> None:
+            nonlocal output_offset
             try:
                 denoised, prob = self._denoiser.process_frame(frame)
                 self._last_speech_prob = prob
                 if prob > 0.2:
                     self._last_speech_time = time.time()
-                output_frames.append(denoised)
+                output[output_offset : output_offset + self.RNNOISE_FRAME_SIZE] = denoised
             except Exception as e:
                 logger.error(f"❌ RNNoise processing error: {e}")
-                output_frames.append(frame)
-        
-        if output_frames:
-            return np.concatenate(output_frames)
-        return np.array([], dtype=np.int16)
+                output[output_offset : output_offset + self.RNNOISE_FRAME_SIZE] = frame
+            output_offset += self.RNNOISE_FRAME_SIZE
+
+        if pending_size:
+            needed = self.RNNOISE_FRAME_SIZE - pending_size
+            self._frame_buffer[pending_size:] = audio[:needed]
+            input_offset = needed
+            process_frame(self._frame_buffer)
+            self._frame_buffer.fill(0)
+
+        while input_offset + self.RNNOISE_FRAME_SIZE <= len(audio):
+            frame = audio[input_offset : input_offset + self.RNNOISE_FRAME_SIZE]
+            process_frame(frame)
+            input_offset += self.RNNOISE_FRAME_SIZE
+
+        remaining = len(audio) - input_offset
+        if remaining:
+            self._frame_buffer[:remaining] = audio[input_offset:]
+        self._frame_buffer_size = remaining
+        return output
     
     def _reset_internal_state(self) -> None:
         """Reset RNNoise internal state without full reinitialization."""
-        self._frame_buffer = np.array([], dtype=np.int16)
+        self._frame_buffer.fill(0)
+        self._frame_buffer_size = 0
         self._last_speech_prob = 0.0
         # Reset AGC gain state
         self._agc_gain = 1.0
@@ -505,7 +539,8 @@ class AudioProcessor:
         if enabled and self._denoiser is None:
             self._init_denoiser()
         if prev != enabled:
-            self._frame_buffer = np.array([], dtype=np.int16)
+            self._frame_buffer.fill(0)
+            self._frame_buffer_size = 0
             self._agc_gain = 1.0
         logger.info(f"🎤 Noise reduction {'enabled' if enabled else 'disabled'}")
     

--- a/utils/audio_silence_remover.py
+++ b/utils/audio_silence_remover.py
@@ -96,15 +96,15 @@ CancelledError = SilenceRemovalCancelledError
 
 
 def _samples_to_float(data: bytes, sample_width: int) -> np.ndarray:
-    """Convert raw PCM bytes to a float64 numpy array (range -1.0 ~ 1.0)"""
+    """Convert raw PCM bytes to a float32 numpy array (range -1.0 ~ 1.0)."""
     if sample_width == 1:
         # 8-bit unsigned
-        arr = np.frombuffer(data, dtype=np.uint8).astype(np.float64)
-        arr = (arr - 128.0) / 128.0
+        arr = np.frombuffer(data, dtype=np.uint8).astype(np.float32)
+        arr = (arr - np.float32(128.0)) / np.float32(128.0)
     elif sample_width == 2:
         # 16-bit signed
-        arr = np.frombuffer(data, dtype=np.int16).astype(np.float64)
-        arr = arr / 32768.0
+        arr = np.frombuffer(data, dtype=np.int16).astype(np.float32)
+        arr = arr / np.float32(32768.0)
     elif sample_width == 3:
         # 24-bit signed – numpy 向量化解码
         n_samples = len(data) // 3
@@ -115,18 +115,18 @@ def _samples_to_float(data: bytes, sample_width: int) -> np.ndarray:
                | (raw[:, 2].astype(np.int32) << 16))
         # 符号扩展: 如果最高位 (bit 23) 为 1，扩展为负数
         i32[i32 >= 0x800000] -= 0x1000000
-        arr = i32.astype(np.float64) / 8388608.0
+        arr = i32.astype(np.float32) / np.float32(8388608.0)
     elif sample_width == 4:
         # 32-bit signed
-        arr = np.frombuffer(data, dtype=np.int32).astype(np.float64)
-        arr = arr / 2147483648.0
+        arr = np.frombuffer(data, dtype=np.int32).astype(np.float32)
+        arr = arr / np.float32(2147483648.0)
     else:
         raise ValueError(f"不支持的采样宽度: {sample_width} bytes")
     return arr
 
 
 def _float_to_samples(arr: np.ndarray, sample_width: int) -> bytes:
-    """Convert a float64 numpy array (-1.0 ~ 1.0) back to raw PCM bytes"""
+    """Convert a floating-point numpy array (-1.0 ~ 1.0) to raw PCM bytes."""
     arr = np.clip(arr, -1.0, 1.0)
     if sample_width == 1:
         out = ((arr * 128.0) + 128.0).astype(np.uint8)
@@ -324,14 +324,6 @@ def trim_silence(
         n_frames = wf.getnframes()
         raw_data = wf.readframes(n_frames)
 
-    float_samples = _samples_to_float(raw_data, sample_width)
-
-    # 对于多声道，reshape 为 (n_frames, channels)
-    if channels > 1:
-        float_samples = float_samples.reshape(-1, channels)
-    else:
-        float_samples = float_samples.reshape(-1, 1)
-
     # 每侧保留的采样数
     retain_half_samples = int(sample_rate * (RETAINED_SILENCE_MS / 2) / 1000.0)
 
@@ -340,66 +332,55 @@ def trim_silence(
 
     # 按顺序遍历音频，对每段静音只保留首尾各 retain_half，移除正中间部分
     total_segs = len(analysis.silence_segments)
-    result_parts: list[np.ndarray] = []
     prev_end = 0  # 上一次拷贝到的样本位置
-
-    for idx, seg in enumerate(analysis.silence_segments):
-        if cancel_check and cancel_check():
-            raise SilenceRemovalCancelledError("裁剪处理已被用户取消")
-
-        seg_start = int(seg.start_ms * sample_rate / 1000.0)
-        seg_end = int(seg.end_ms * sample_rate / 1000.0)
-
-        # 计算中心裁剪区域
-        cut_start = seg_start + retain_half_samples  # 前半保留结束点
-        cut_end = seg_end - retain_half_samples       # 后半保留起始点
-
-        if cut_start >= cut_end:
-            # 静音段不足以裁剪（≤ RETAINED_SILENCE_MS），保留完整静音
-            continue
-
-        # 拷贝: 从 prev_end 到 cut_start（包含语音 + 静音前半段保留）
-        if cut_start > prev_end:
-            result_parts.append(float_samples[prev_end:cut_start])
-
-        # 跳过中间部分 [cut_start, cut_end)
-        prev_end = cut_end
-
-        # 进度回调
-        if progress_callback:
-            pct = int(((idx + 1) / total_segs) * 100)
-            progress_callback(min(pct, 100))
-
-    # 拷贝最后一段静音之后的剩余音频
-    total_samples_per_channel = float_samples.shape[0]
-    if prev_end < total_samples_per_channel:
-        result_parts.append(float_samples[prev_end:total_samples_per_channel])
-
-    if not result_parts:
-        # 极端情况：没有任何内容需要保留（理论上不会发生）
-        result_parts.append(float_samples[:0])  # 空数组，保持 shape 兼容
-
-    # 拼接所有段
-    final_samples = np.concatenate(result_parts, axis=0)
-
-    # reshape 回一维 (多声道交错)
-    final_flat = final_samples.reshape(-1)
-
-    # 转回 PCM bytes
-    pcm_data = _float_to_samples(final_flat, sample_width)
-
-    # 写入 WAV
+    kept_frames = 0
+    frame_width = sample_width * channels
+    raw_view = memoryview(raw_data)
     output_buf = io.BytesIO()
     with wave.open(output_buf, 'wb') as out_wf:
         out_wf.setnchannels(channels)
         out_wf.setsampwidth(sample_width)
         out_wf.setframerate(sample_rate)
-        out_wf.writeframes(pcm_data)
+
+        for idx, seg in enumerate(analysis.silence_segments):
+            if cancel_check and cancel_check():
+                raise SilenceRemovalCancelledError("裁剪处理已被用户取消")
+
+            seg_start = int(seg.start_ms * sample_rate / 1000.0)
+            seg_end = int(seg.end_ms * sample_rate / 1000.0)
+
+            # 计算中心裁剪区域
+            cut_start = seg_start + retain_half_samples  # 前半保留结束点
+            cut_end = seg_end - retain_half_samples       # 后半保留起始点
+
+            if cut_start >= cut_end:
+                # 静音段不足以裁剪（≤ RETAINED_SILENCE_MS），保留完整静音
+                continue
+
+            # 直接写入原始 PCM 帧，避免浮点往返和整段 concatenate。
+            if cut_start > prev_end:
+                out_wf.writeframesraw(
+                    raw_view[prev_end * frame_width : cut_start * frame_width]
+                )
+                kept_frames += cut_start - prev_end
+
+            # 跳过中间部分 [cut_start, cut_end)
+            prev_end = cut_end
+
+            # 进度回调
+            if progress_callback:
+                pct = int(((idx + 1) / total_segs) * 100)
+                progress_callback(min(pct, 100))
+
+        # 拷贝最后一段静音之后的剩余音频
+        if prev_end < n_frames:
+            out_wf.writeframesraw(raw_view[prev_end * frame_width :])
+            kept_frames += n_frames - prev_end
 
     output_data = output_buf.getvalue()
     md5 = hashlib.md5(output_data).hexdigest()
 
-    trimmed_duration_ms = (final_samples.shape[0] / sample_rate) * 1000.0
+    trimmed_duration_ms = (kept_frames / sample_rate) * 1000.0
 
     if progress_callback:
         progress_callback(100)

--- a/utils/audio_silence_remover.py
+++ b/utils/audio_silence_remover.py
@@ -45,6 +45,7 @@ SILENCE_THRESHOLD_DBFS = -40.0  # 静音阈值 (dBFS)
 MIN_SILENCE_DURATION_MS = 200   # 最小静音持续时间 (ms)
 RETAINED_SILENCE_MS = 200       # 每段静音裁剪后保留的时长 (ms)
 RMS_FRAME_DURATION_MS = 10      # RMS 计算帧长 (ms)
+RMS_FLOAT32_RECHECK_MARGIN_DB = 1e-4  # 阈值附近用 float64 复核，保持边界语义
 
 
 @dataclass
@@ -95,16 +96,21 @@ class SilenceRemovalCancelledError(Exception):
 CancelledError = SilenceRemovalCancelledError
 
 
-def _samples_to_float(data: bytes, sample_width: int) -> np.ndarray:
-    """Convert raw PCM bytes to a float32 numpy array (range -1.0 ~ 1.0)."""
+def _samples_to_float(
+    data: bytes | memoryview,
+    sample_width: int,
+    dtype=np.float32,
+) -> np.ndarray:
+    """Convert raw PCM bytes to a floating array (range -1.0 ~ 1.0)."""
+    float_dtype = np.dtype(dtype)
     if sample_width == 1:
         # 8-bit unsigned
-        arr = np.frombuffer(data, dtype=np.uint8).astype(np.float32)
-        arr = (arr - np.float32(128.0)) / np.float32(128.0)
+        arr = np.frombuffer(data, dtype=np.uint8).astype(float_dtype)
+        arr = (arr - float_dtype.type(128.0)) / float_dtype.type(128.0)
     elif sample_width == 2:
         # 16-bit signed
-        arr = np.frombuffer(data, dtype=np.int16).astype(np.float32)
-        arr = arr / np.float32(32768.0)
+        arr = np.frombuffer(data, dtype=np.int16).astype(float_dtype)
+        arr = arr / float_dtype.type(32768.0)
     elif sample_width == 3:
         # 24-bit signed – numpy 向量化解码
         n_samples = len(data) // 3
@@ -115,11 +121,11 @@ def _samples_to_float(data: bytes, sample_width: int) -> np.ndarray:
                | (raw[:, 2].astype(np.int32) << 16))
         # 符号扩展: 如果最高位 (bit 23) 为 1，扩展为负数
         i32[i32 >= 0x800000] -= 0x1000000
-        arr = i32.astype(np.float32) / np.float32(8388608.0)
+        arr = i32.astype(float_dtype) / float_dtype.type(8388608.0)
     elif sample_width == 4:
         # 32-bit signed
-        arr = np.frombuffer(data, dtype=np.int32).astype(np.float32)
-        arr = arr / np.float32(2147483648.0)
+        arr = np.frombuffer(data, dtype=np.int32).astype(float_dtype)
+        arr = arr / float_dtype.type(2147483648.0)
     else:
         raise ValueError(f"不支持的采样宽度: {sample_width} bytes")
     return arr
@@ -145,7 +151,10 @@ def _float_to_samples(arr: np.ndarray, sample_width: int) -> bytes:
         raw[:, 2] = (u32 >> 16) & 0xFF
         return raw.tobytes()
     elif sample_width == 4:
-        out = (arr * 2147483648.0).astype(np.int32)
+        # float32 rounds the valid s32 maximum to 1.0. Scale in float64 and
+        # clamp before casting so +2147483647 never wraps to -2147483648.
+        scaled = arr.astype(np.float64, copy=False) * 2147483648.0
+        out = np.clip(scaled, -2147483648.0, 2147483647.0).astype(np.int32)
         return out.tobytes()
     else:
         raise ValueError(f"不支持的采样宽度: {sample_width} bytes")
@@ -155,7 +164,7 @@ def _rms_dbfs(samples: np.ndarray) -> float:
     """Compute the RMS value (dBFS) of one frame of samples"""
     if len(samples) == 0:
         return -100.0
-    rms = np.sqrt(np.mean(samples ** 2))
+    rms = np.sqrt(np.mean(np.square(samples, dtype=np.float64)))
     if rms < 1e-10:
         return -100.0
     return 20.0 * math.log10(rms)
@@ -191,8 +200,10 @@ def detect_silence(
 
     duration_ms = (n_frames / sample_rate) * 1000.0
 
-    # 转为 float
+    # 主分析数组使用 float32；只有落在阈值极近处的帧才按原始 PCM
+    # 以 float64 复核，从而保留旧实现的严格边界分类。
     float_samples = _samples_to_float(raw_data, sample_width)
+    raw_view = memoryview(raw_data)
 
     # 如果是多声道，取平均作为单声道进行分析
     if channels > 1:
@@ -219,6 +230,17 @@ def detect_silence(
         frame_data = float_samples_mono[start_idx:end_idx]
 
         rms = _rms_dbfs(frame_data)
+        if abs(rms - threshold_dbfs) <= RMS_FLOAT32_RECHECK_MARGIN_DB:
+            raw_start = start_idx * channels * sample_width
+            raw_end = end_idx * channels * sample_width
+            precise_samples = _samples_to_float(
+                raw_view[raw_start:raw_end],
+                sample_width,
+                dtype=np.float64,
+            )
+            if channels > 1:
+                precise_samples = precise_samples.reshape(-1, channels).mean(axis=1)
+            rms = _rms_dbfs(precise_samples)
 
         if rms < threshold_dbfs:
             if not in_silence:


### PR DESCRIPTION
## Summary

- use `float32` scratch arrays for silence detection
- trim silence by copying original PCM frames directly instead of converting and concatenating whole-file float arrays
- replace RNNoise's growing frame buffer and repeated concatenations with a fixed 480-sample pending buffer and preallocated output
- add reproducible memory/numeric-error benchmarks and focused regression coverage

## Why

The silence-removal path materialized full-size `float64` arrays and another concatenated output array. The RNNoise path also concatenated pending input and per-frame output on every call, retaining the backing allocation after burst-sized chunks. These allocations increased peak and retained memory without changing the audio contract.

## Impact

- silence-analysis scratch peak: 57.60 MB -> 34.56 MB (-40.00%)
- 30s stereo/48k/s32 trim peak: 100.69 MB -> 20.97 MB (-79.17%)
- RNNoise 1s burst peak: 302.3 KB -> 194.2 KB (-35.76%)
- RNNoise burst retained buffer: 96,000 bytes -> 960 bytes
- benchmark output remains byte-identical; float32 detection error stayed below 9.3e-7 dB with zero threshold mismatches in the tested -40.1 to -39.9 dBFS range

## Validation

- `uv run --no-sync python -m pytest --confcutdir=tests/unit -p no:cacheprovider tests/unit/test_audio_memory_optimization.py tests/unit/test_audio_silence_remover.py tests/unit/test_audio_silence_integration.py -q` (77 passed)
- `uv run --no-sync python -m pytest --confcutdir=tests/unit -p no:cacheprovider tests/unit/test_voice_session.py -q` (46 passed, 3 skipped)
- real native RNNoise 480-sample smoke test passed
- `uv run --no-sync python -m ruff check ...`
- `git diff --check`