### PR TITLE
perf: optimize heavy dependency lifecycle

### DIFF
--- a/app/agent_server/_shared.py
+++ b/app/agent_server/_shared.py
@@ -94,9 +94,9 @@ class Modules:
     # subprocess.  Keep construction/teardown serialized so on-demand callers
     # cannot create duplicate adapters or race a disable/shutdown close.
     browser_use_init_lock: Optional[asyncio.Lock] = None
-    # Explicit disables close BrowserUse in the background so the flag request
-    # stays responsive. Re-enables await this task before reporting ready.
-    browser_use_close_task: Optional[asyncio.Task] = None
+    # Monotonic intent generation. A background close may finish after a quick
+    # re-enable, but must not overwrite the newer ready capability state.
+    browser_use_lifecycle_seq: int = 0
     # OpenClaw/QwenPaw is an external service. Enabling keeps the user's intent
     # while a bounded background probe waits for the external health endpoint.
     openclaw_enable_task: Optional[asyncio.Task] = None

--- a/app/agent_server/_shared.py
+++ b/app/agent_server/_shared.py
@@ -94,6 +94,9 @@ class Modules:
     # subprocess.  Keep construction/teardown serialized so on-demand callers
     # cannot create duplicate adapters or race a disable/shutdown close.
     browser_use_init_lock: Optional[asyncio.Lock] = None
+    # Explicit disables close BrowserUse in the background so the flag request
+    # stays responsive. Re-enables await this task before reporting ready.
+    browser_use_close_task: Optional[asyncio.Task] = None
     # OpenClaw/QwenPaw is an external service. Enabling keeps the user's intent
     # while a bounded background probe waits for the external health endpoint.
     openclaw_enable_task: Optional[asyncio.Task] = None

--- a/app/agent_server/_shared.py
+++ b/app/agent_server/_shared.py
@@ -90,6 +90,10 @@ class Modules:
     # (mirrors computer-use exclusivity, implemented as a lock instead of a
     # scheduler loop). Lazily created on the running event loop.
     browser_use_dispatch_lock: Optional[asyncio.Lock] = None
+    # BrowserUse imports a sizeable dependency graph and may own a Chromium
+    # subprocess.  Keep construction/teardown serialized so on-demand callers
+    # cannot create duplicate adapters or race a disable/shutdown close.
+    browser_use_init_lock: Optional[asyncio.Lock] = None
     # OpenClaw/QwenPaw is an external service. Enabling keeps the user's intent
     # while a bounded background probe waits for the external health endpoint.
     openclaw_enable_task: Optional[asyncio.Task] = None

--- a/app/agent_server/api_routes.py
+++ b/app/agent_server/api_routes.py
@@ -81,6 +81,7 @@ from .api_shared import (  # noqa: F401
     _ensure_plugin_lifecycle_started,
     _ensure_plugin_lifecycle_stopped,
     _ensure_browser_use_adapter,
+    _wait_for_browser_use_adapter_close,
     _extract_tool_intent_as_text,
     _fire_agent_llm_connectivity_check,
     _fire_user_plugin_capability_check,
@@ -541,6 +542,7 @@ async def set_agent_flags(payload: Dict[str, Any]):
     changed = False
     old_flags = dict(Modules.agent_flags)
     old_analyzer_enabled = bool(Modules.analyzer_enabled)
+    browser_use_close_reason: Optional[str] = None
     of = (payload or {}).get("openfang_enabled")
     # Agent LLM gate fail (endpoint/key not configured) blocks **only** the
     # four LLM-dependent sub flags. ``user_plugin_enabled`` runs entirely on
@@ -558,6 +560,7 @@ async def set_agent_flags(payload: Dict[str, Any]):
         Modules.agent_flags["openclaw_enabled"] = False
         Modules.agent_flags["openfang_enabled"] = False
         first_reason = (gate.get('reasons') or ['AGENT_ENDPOINT_NOT_CONFIGURED'])[0]
+        browser_use_close_reason = first_reason
         _set_capability("computer_use", False, first_reason)
         _set_capability("browser_use", False, first_reason)
         _set_capability("openclaw", False, first_reason)
@@ -605,6 +608,7 @@ async def set_agent_flags(payload: Dict[str, Any]):
     # 2.5. Handle Browser Use Flag with Capability Check
     if isinstance(bf, bool):
         if bf:
+            await _wait_for_browser_use_adapter_close()
             dependency_ready, dependency_error = _browser_use_dependency_status()
             if not dependency_ready:
                 Modules.agent_flags["browser_use_enabled"] = False
@@ -625,7 +629,17 @@ async def set_agent_flags(payload: Dict[str, Any]):
         old_flags.get("browser_use_enabled", False)
         and not Modules.agent_flags.get("browser_use_enabled", False)
     ):
-        _create_tracked_task(_close_browser_use_adapter())
+        close_task = _create_tracked_task(
+            _close_browser_use_adapter(capability_reason=browser_use_close_reason)
+        )
+        if close_task is not None:
+            Modules.browser_use_close_task = close_task
+
+            def _clear_browser_use_close_task(done_task):
+                if Modules.browser_use_close_task is done_task:
+                    Modules.browser_use_close_task = None
+
+            close_task.add_done_callback(_clear_browser_use_close_task)
 
     if isinstance(uf, bool):
         if uf:  # Attempting to enable UserPlugin — non-blocking (like CUA)

--- a/app/agent_server/api_routes.py
+++ b/app/agent_server/api_routes.py
@@ -81,7 +81,6 @@ from .api_shared import (  # noqa: F401
     _ensure_plugin_lifecycle_started,
     _ensure_plugin_lifecycle_stopped,
     _ensure_browser_use_adapter,
-    _wait_for_browser_use_adapter_close,
     _extract_tool_intent_as_text,
     _fire_agent_llm_connectivity_check,
     _fire_user_plugin_capability_check,
@@ -543,6 +542,10 @@ async def set_agent_flags(payload: Dict[str, Any]):
     old_flags = dict(Modules.agent_flags)
     old_analyzer_enabled = bool(Modules.analyzer_enabled)
     browser_use_close_reason: Optional[str] = None
+    browser_use_lifecycle_seq = Modules.browser_use_lifecycle_seq
+    if isinstance(bf, bool):
+        Modules.browser_use_lifecycle_seq += 1
+        browser_use_lifecycle_seq = Modules.browser_use_lifecycle_seq
     of = (payload or {}).get("openfang_enabled")
     # Agent LLM gate fail (endpoint/key not configured) blocks **only** the
     # four LLM-dependent sub flags. ``user_plugin_enabled`` runs entirely on
@@ -554,6 +557,9 @@ async def set_agent_flags(payload: Dict[str, Any]):
     # nullifying them, then fall through to the per-flag handling so uf still
     # processes normally.
     if gate.get("ready") is not True and any(x is True for x in (cf, bf, nf, of)):
+        if not isinstance(bf, bool) and old_flags.get("browser_use_enabled", False):
+            Modules.browser_use_lifecycle_seq += 1
+            browser_use_lifecycle_seq = Modules.browser_use_lifecycle_seq
         _cancel_openclaw_enable_probe()
         Modules.agent_flags["computer_use_enabled"] = False
         Modules.agent_flags["browser_use_enabled"] = False
@@ -608,7 +614,6 @@ async def set_agent_flags(payload: Dict[str, Any]):
     # 2.5. Handle Browser Use Flag with Capability Check
     if isinstance(bf, bool):
         if bf:
-            await _wait_for_browser_use_adapter_close()
             dependency_ready, dependency_error = _browser_use_dependency_status()
             if not dependency_ready:
                 Modules.agent_flags["browser_use_enabled"] = False
@@ -629,17 +634,12 @@ async def set_agent_flags(payload: Dict[str, Any]):
         old_flags.get("browser_use_enabled", False)
         and not Modules.agent_flags.get("browser_use_enabled", False)
     ):
-        close_task = _create_tracked_task(
-            _close_browser_use_adapter(capability_reason=browser_use_close_reason)
+        _create_tracked_task(
+            _close_browser_use_adapter(
+                capability_reason=browser_use_close_reason,
+                expected_lifecycle_seq=browser_use_lifecycle_seq,
+            )
         )
-        if close_task is not None:
-            Modules.browser_use_close_task = close_task
-
-            def _clear_browser_use_close_task(done_task):
-                if Modules.browser_use_close_task is done_task:
-                    Modules.browser_use_close_task = None
-
-            close_task.add_done_callback(_clear_browser_use_close_task)
 
     if isinstance(uf, bool):
         if uf:  # Attempting to enable UserPlugin — non-blocking (like CUA)
@@ -1255,9 +1255,6 @@ async def computer_use_run(payload: Dict[str, Any]):
 
 @app.post("/browser_use/run")
 async def browser_use_run(payload: Dict[str, Any]):
-    adapter = await _ensure_browser_use_adapter()
-    if adapter is None:
-        raise HTTPException(503, "BrowserUse not ready")
     instruction = (payload or {}).get("instruction", "").strip()
     if not instruction:
         raise HTTPException(400, "instruction required")
@@ -1269,6 +1266,9 @@ async def browser_use_run(payload: Dict[str, Any]):
 
     async def _locked_run():
         async with Modules.browser_use_dispatch_lock:
+            adapter = await _ensure_browser_use_adapter()
+            if adapter is None:
+                raise HTTPException(503, "BrowserUse not ready")
             return await adapter.run_instruction(instruction)
 
     # Run as a tracked background task so end_all can cancel a wedged direct
@@ -1285,6 +1285,8 @@ async def browser_use_run(payload: Dict[str, Any]):
             return JSONResponse(content={"success": False, "error": "cancelled by end_all"}, status_code=500)
         # The HTTP request itself was cancelled — don't leak the inner task.
         run_task.cancel()
+        raise
+    except HTTPException:
         raise
     except Exception as e:
         return JSONResponse(content={"success": False, "error": str(e)}, status_code=500)
@@ -1469,6 +1471,10 @@ async def admin_control(payload: Dict[str, Any]):
                     pass
         except Exception as e:
             logger.warning(f"[Agent] Error cleaning browser-use agents during end_all: {e}")
+        # A disable-triggered close is itself tracked above and may have been
+        # cancelled by this drain. Retry teardown after dispatches quiesce so
+        # keep-alive Chromium cannot survive end_all.
+        await _close_browser_use_adapter(update_capability=False)
         Modules.active_browser_use_task_id = None
         # Cancel any in-flight openfang tasks
         try:

--- a/app/agent_server/api_routes.py
+++ b/app/agent_server/api_routes.py
@@ -1241,7 +1241,8 @@ async def computer_use_run(payload: Dict[str, Any]):
 
 @app.post("/browser_use/run")
 async def browser_use_run(payload: Dict[str, Any]):
-    if not await _ensure_browser_use_adapter():
+    adapter = await _ensure_browser_use_adapter()
+    if adapter is None:
         raise HTTPException(503, "BrowserUse not ready")
     instruction = (payload or {}).get("instruction", "").strip()
     if not instruction:
@@ -1254,7 +1255,7 @@ async def browser_use_run(payload: Dict[str, Any]):
 
     async def _locked_run():
         async with Modules.browser_use_dispatch_lock:
-            return await Modules.browser_use.run_instruction(instruction)
+            return await adapter.run_instruction(instruction)
 
     # Run as a tracked background task so end_all can cancel a wedged direct
     # run (otherwise it would survive end_all still holding the mutex).

--- a/app/agent_server/api_routes.py
+++ b/app/agent_server/api_routes.py
@@ -70,6 +70,7 @@ from .api_shared import (  # noqa: F401
     _collect_active_openclaw_task_ids,
     _collect_agent_status_snapshot,
     _collect_existing_task_descriptions,
+    _close_browser_use_adapter,
     _computer_use_scheduler_loop,
     _create_tracked_task,
     _default_openclaw_task_description,
@@ -78,6 +79,7 @@ from .api_shared import (  # noqa: F401
     _emit_task_result,
     _ensure_plugin_lifecycle_started,
     _ensure_plugin_lifecycle_stopped,
+    _ensure_browser_use_adapter,
     _extract_tool_intent_as_text,
     _fire_agent_llm_connectivity_check,
     _fire_user_plugin_capability_check,
@@ -602,7 +604,7 @@ async def set_agent_flags(payload: Dict[str, Any]):
     # 2.5. Handle Browser Use Flag with Capability Check
     if isinstance(bf, bool):
         if bf:
-            bu = getattr(Modules, "browser_use", None)
+            bu = await _ensure_browser_use_adapter()
             if not bu:
                 Modules.agent_flags["browser_use_enabled"] = False
                 Modules.notification = json.dumps({"code": "AGENT_BU_MODULE_NOT_LOADED"})
@@ -618,6 +620,14 @@ async def set_agent_flags(payload: Dict[str, Any]):
                 _set_capability("browser_use", True, "")
         else:
             Modules.agent_flags["browser_use_enabled"] = False
+
+    # Explicit disable and automatic gate demotion both release the heavy
+    # browser-use graph and any keep-alive Chromium subprocess immediately.
+    if bf is False or (
+        old_flags.get("browser_use_enabled", False)
+        and not Modules.agent_flags.get("browser_use_enabled", False)
+    ):
+        await _close_browser_use_adapter()
 
     if isinstance(uf, bool):
         if uf:  # Attempting to enable UserPlugin — non-blocking (like CUA)
@@ -1186,7 +1196,7 @@ async def browser_use_availability():
     gate = _check_agent_api_gate()
     if gate.get("ready") is not True:
         return {"ready": False, "reasons": gate.get("reasons", ["Agent API 未配置"])}
-    bu = Modules.browser_use
+    bu = await _ensure_browser_use_adapter()
     if not bu:
         raise HTTPException(503, "BrowserUse not ready")
     if not getattr(bu, "_ready_import", False):
@@ -1235,7 +1245,7 @@ async def computer_use_run(payload: Dict[str, Any]):
 
 @app.post("/browser_use/run")
 async def browser_use_run(payload: Dict[str, Any]):
-    if not Modules.browser_use:
+    if not await _ensure_browser_use_adapter():
         raise HTTPException(503, "BrowserUse not ready")
     instruction = (payload or {}).get("instruction", "").strip()
     if not instruction:

--- a/app/agent_server/api_routes.py
+++ b/app/agent_server/api_routes.py
@@ -60,6 +60,7 @@ from .api_shared import (  # noqa: F401
     _LEGACY_CORRECTION_PUBLIC_KEYS,
     _agent_flags_snapshot,
     _bind_deferred_task,
+    _browser_use_dependency_status,
     _build_analyze_event_fingerprint,
     _build_assistant_turn_fingerprint,
     _build_user_turn_fingerprint,
@@ -604,13 +605,10 @@ async def set_agent_flags(payload: Dict[str, Any]):
     # 2.5. Handle Browser Use Flag with Capability Check
     if isinstance(bf, bool):
         if bf:
-            bu = await _ensure_browser_use_adapter()
-            if not bu:
+            dependency_ready, dependency_error = _browser_use_dependency_status()
+            if not dependency_ready:
                 Modules.agent_flags["browser_use_enabled"] = False
-                Modules.notification = json.dumps({"code": "AGENT_BU_MODULE_NOT_LOADED"})
-            elif not getattr(bu, "_ready_import", False):
-                Modules.agent_flags["browser_use_enabled"] = False
-                Modules.notification = json.dumps({"code": "AGENT_BU_NOT_INSTALLED", "details": {"error": str(bu.last_error)}})
+                Modules.notification = json.dumps({"code": "AGENT_BU_NOT_INSTALLED", "details": {"error": dependency_error}})
             elif not getattr(Modules.computer_use, "init_ok", False):
                 Modules.agent_flags["browser_use_enabled"] = True
                 Modules.notification = json.dumps({"code": "AGENT_BU_ENABLED_CHECKING"})
@@ -1196,11 +1194,9 @@ async def browser_use_availability():
     gate = _check_agent_api_gate()
     if gate.get("ready") is not True:
         return {"ready": False, "reasons": gate.get("reasons", ["Agent API 未配置"])}
-    bu = await _ensure_browser_use_adapter()
-    if not bu:
-        raise HTTPException(503, "BrowserUse not ready")
-    if not getattr(bu, "_ready_import", False):
-        reason = f"browser-use not installed: {bu.last_error}"
+    dependency_ready, dependency_error = _browser_use_dependency_status()
+    if not dependency_ready:
+        reason = f"browser-use not installed: {dependency_error}"
         _set_capability("browser_use", False, reason)
         return {"enabled": True, "ready": False, "reasons": [reason], "provider": "browser-use"}
     # LLM connectivity — reuse the shared agent-LLM check
@@ -1211,7 +1207,7 @@ async def browser_use_availability():
     reasons = []
     if not llm_ok:
         reasons.append(cua.last_error if cua and cua.last_error else "Agent LLM not connected")
-    ready = llm_ok and getattr(bu, "_ready_import", False)
+    ready = llm_ok and dependency_ready
     _set_capability("browser_use", ready, reasons[0] if reasons else "")
     return {"enabled": True, "ready": ready, "reasons": reasons, "provider": "browser-use"}
 

--- a/app/agent_server/api_routes.py
+++ b/app/agent_server/api_routes.py
@@ -625,7 +625,7 @@ async def set_agent_flags(payload: Dict[str, Any]):
         old_flags.get("browser_use_enabled", False)
         and not Modules.agent_flags.get("browser_use_enabled", False)
     ):
-        await _close_browser_use_adapter()
+        _create_tracked_task(_close_browser_use_adapter())
 
     if isinstance(uf, bool):
         if uf:  # Attempting to enable UserPlugin — non-blocking (like CUA)

--- a/app/agent_server/api_runtime.py
+++ b/app/agent_server/api_runtime.py
@@ -70,6 +70,7 @@ from .api_shared import (  # noqa: F401
     _collect_active_openclaw_task_ids,
     _collect_agent_status_snapshot,
     _collect_existing_task_descriptions,
+    _close_browser_use_adapter,
     _computer_use_scheduler_loop,
     _create_tracked_task,
     _default_openclaw_task_description,
@@ -532,24 +533,6 @@ async def startup():
     Modules.throttled_logger = ThrottledLogger(logger, interval=30.0)
     _rewire_computer_use_dependents()
 
-    async def _init_browser_use_background():
-        try:
-            bu = await asyncio.to_thread(BrowserUseAdapter)
-            Modules.browser_use = bu
-            Modules.task_executor.browser_use = bu
-            logger.info("[Agent] BrowserUseAdapter ready (background init)")
-            # fire-and-forget capability 刷新：check_connectivity 可能因网络不稳
-            # 走到几十秒级的重试，绝不能把 OpenFang 初始化链 gate 在它上面。
-            # queue=True：这是"BU 刚就绪"这种状态变化触发，不能被启动期 LLM probe
-            # 持锁时的早退路径吞掉，否则 browser_use capability 会停在 PENDING。
-            _refresh_task = asyncio.create_task(
-                _fire_agent_llm_connectivity_check(queue=True)
-            )
-            Modules._persistent_tasks.add(_refresh_task)
-            _refresh_task.add_done_callback(Modules._persistent_tasks.discard)
-        except Exception as exc:
-            logger.error("[Agent] BrowserUseAdapter background init failed: %s", exc)
-
     try:
         await _start_embedded_user_plugin_server()
     except Exception as e:
@@ -622,16 +605,12 @@ async def startup():
             logger.error("[OpenFang] background init failed: %s", exc)
             _set_capability("openfang", False, str(exc))
 
-    # BrowserUse 与 OpenFang 都涉及较重的初始化（CPU 密集模块加载 / 进程连通性轮询），
-    # 放在同一个后台任务里串行执行，避免两者并发时启动期 CPU 双峰。LLM connectivity
-    # probe 是轻量 HTTP，独立 task 与这条串行链并行。
-    async def _init_heavy_adapters_serial():
-        await _init_browser_use_background()
-        await _init_openfang_background()
-
-    _heavy_adapters_task = asyncio.create_task(_init_heavy_adapters_serial())
-    Modules._persistent_tasks.add(_heavy_adapters_task)
-    _heavy_adapters_task.add_done_callback(Modules._persistent_tasks.discard)
+    # BrowserUse stays unloaded until its toggle, availability endpoint, or
+    # direct run is requested.  OpenFang remains an independent background
+    # connectivity task because Electron owns that external daemon lifecycle.
+    _openfang_task = asyncio.create_task(_init_openfang_background())
+    Modules._persistent_tasks.add(_openfang_task)
+    _openfang_task.add_done_callback(Modules._persistent_tasks.discard)
 
     # Both CUA and BrowserUse share the agent LLM — default to "not connected"
     # and probe in background.  The single check updates both capability caches.
@@ -849,6 +828,11 @@ async def shutdown():
             logger.warning("[Agent] ⚠️ 部分后台任务取消超时")
     Modules._persistent_tasks.clear()
     Modules._background_tasks.clear()
+
+    # BrowserSession.keep_alive keeps Chromium running between tasks; closing
+    # the adapter is therefore required at service shutdown, not just task
+    # cancellation, to reap the browser subprocess tree.
+    await _close_browser_use_adapter()
 
     cu = Modules.computer_use
     if cu is not None and hasattr(cu, "wait_for_completion"):

--- a/app/agent_server/api_runtime.py
+++ b/app/agent_server/api_runtime.py
@@ -77,6 +77,7 @@ from .api_shared import (  # noqa: F401
     _emit_agent_status_update,
     _emit_main_event,
     _emit_task_result,
+    _ensure_browser_use_adapter,
     _ensure_plugin_lifecycle_started,
     _ensure_plugin_lifecycle_stopped,
     _extract_tool_intent_as_text,
@@ -382,6 +383,17 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
         if not Modules.analyzer_enabled:
             logger.info("[TaskExecutor] Skipping analysis: analyzer disabled (master switch off)")
             return
+        if Modules.agent_flags.get("browser_use_enabled", False):
+            browser_use = await _ensure_browser_use_adapter()
+            if browser_use is None or not getattr(browser_use, "_ready_import", False):
+                Modules.agent_flags["browser_use_enabled"] = False
+                reason = str(getattr(browser_use, "last_error", "") or "AGENT_BU_MODULE_NOT_LOADED")
+                _set_capability("browser_use", False, reason)
+                Modules.notification = json.dumps(
+                    {"code": "AGENT_BU_NOT_INSTALLED", "details": {"error": reason}}
+                )
+                _bump_state_revision()
+                await _emit_agent_status_update(lanlan_name=lanlan_name)
         logger.info("[AgentAnalyze] background analyze start: lanlan=%s messages=%d flags=%s analyzer_enabled=%s",
                     lanlan_name, len(messages), Modules.agent_flags, Modules.analyzer_enabled)
         # 在 inject 之前先把已被用户 UI 取消的 user turn 整段 redact，让 analyzer

--- a/app/agent_server/api_shared.py
+++ b/app/agent_server/api_shared.py
@@ -147,6 +147,9 @@ from .plugin_host import (  # noqa: F401
     _fire_user_plugin_capability_check,
 )
 from .capabilities import (  # noqa: F401
+    _close_browser_use_adapter,
+    _ensure_browser_use_adapter,
+    _rewire_browser_use_dependents,
     _rewire_computer_use_dependents,
     _try_refresh_computer_use_adapter,
     _llm_check_lock,

--- a/app/agent_server/api_shared.py
+++ b/app/agent_server/api_shared.py
@@ -147,6 +147,7 @@ from .plugin_host import (  # noqa: F401
     _fire_user_plugin_capability_check,
 )
 from .capabilities import (  # noqa: F401
+    _browser_use_dependency_status,
     _close_browser_use_adapter,
     _ensure_browser_use_adapter,
     _rewire_browser_use_dependents,

--- a/app/agent_server/api_shared.py
+++ b/app/agent_server/api_shared.py
@@ -150,7 +150,6 @@ from .capabilities import (  # noqa: F401
     _browser_use_dependency_status,
     _close_browser_use_adapter,
     _ensure_browser_use_adapter,
-    _wait_for_browser_use_adapter_close,
     _rewire_browser_use_dependents,
     _rewire_computer_use_dependents,
     _try_refresh_computer_use_adapter,

--- a/app/agent_server/api_shared.py
+++ b/app/agent_server/api_shared.py
@@ -150,6 +150,7 @@ from .capabilities import (  # noqa: F401
     _browser_use_dependency_status,
     _close_browser_use_adapter,
     _ensure_browser_use_adapter,
+    _wait_for_browser_use_adapter_close,
     _rewire_browser_use_dependents,
     _rewire_computer_use_dependents,
     _try_refresh_computer_use_adapter,

--- a/app/agent_server/capabilities.py
+++ b/app/agent_server/capabilities.py
@@ -66,10 +66,6 @@ def _browser_use_dependency_status() -> tuple[bool, str]:
 
 async def _ensure_browser_use_adapter():
     """Build the heavy BrowserUse adapter only when the feature is requested."""
-    current = _shared.Modules.browser_use
-    if current is not None:
-        return current
-
     if _shared.Modules.browser_use_init_lock is None:
         _shared.Modules.browser_use_init_lock = asyncio.Lock()
 
@@ -81,6 +77,10 @@ async def _ensure_browser_use_adapter():
             current = await asyncio.to_thread(BrowserUseAdapter)
         except Exception as exc:
             logger.error("[Agent] BrowserUseAdapter on-demand init failed: %s", exc)
+            _set_capability("browser_use", False, "AGENT_BU_MODULE_NOT_LOADED")
+            return None
+
+        if not getattr(current, "_ready_import", False):
             _set_capability("browser_use", False, "AGENT_BU_MODULE_NOT_LOADED")
             return None
 

--- a/app/agent_server/capabilities.py
+++ b/app/agent_server/capabilities.py
@@ -25,6 +25,7 @@ through the facade at call time.
 
 import json
 import asyncio
+import importlib.util
 from typing import Dict, Any, Optional, Tuple
 
 from . import _shared
@@ -46,8 +47,21 @@ def _rewire_browser_use_dependents() -> None:
         executor = _shared.Modules.task_executor
         if executor is not None and hasattr(executor, "browser_use"):
             executor.browser_use = _shared.Modules.browser_use
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug("[Agent] BrowserUse dependent rewire failed: %s", exc)
+
+
+def _browser_use_dependency_status() -> tuple[bool, str]:
+    """Check BrowserUse installation without importing its heavy module graph."""
+    current = _shared.Modules.browser_use
+    if current is not None:
+        ready = bool(getattr(current, "_ready_import", False))
+        return ready, "" if ready else str(getattr(current, "last_error", "") or "")
+    try:
+        installed = importlib.util.find_spec("browser_use") is not None
+    except Exception as exc:
+        return False, str(exc)
+    return installed, "" if installed else "browser-use package not found"
 
 
 async def _ensure_browser_use_adapter():

--- a/app/agent_server/capabilities.py
+++ b/app/agent_server/capabilities.py
@@ -90,18 +90,6 @@ async def _ensure_browser_use_adapter():
         return current
 
 
-async def _wait_for_browser_use_adapter_close() -> None:
-    """Wait for a disable-triggered close without cancelling it with the caller."""
-    task = _shared.Modules.browser_use_close_task
-    if task is None:
-        return
-    try:
-        await asyncio.shield(task)
-    except asyncio.CancelledError:
-        if not task.cancelled():
-            raise
-
-
 def _set_unloaded_browser_use_capability(capability_reason: Optional[str]) -> None:
     if capability_reason is not None:
         _set_capability("browser_use", False, capability_reason)
@@ -113,30 +101,51 @@ def _set_unloaded_browser_use_capability(capability_reason: Optional[str]) -> No
 async def _close_browser_use_adapter(
     *,
     capability_reason: Optional[str] = None,
+    expected_lifecycle_seq: Optional[int] = None,
+    update_capability: bool = True,
 ) -> None:
     """Close Chromium/browser-use resources and detach the singleton adapter."""
+    if _shared.Modules.browser_use_dispatch_lock is None:
+        _shared.Modules.browser_use_dispatch_lock = asyncio.Lock()
     if _shared.Modules.browser_use_init_lock is None:
         _shared.Modules.browser_use_init_lock = asyncio.Lock()
 
-    async with _shared.Modules.browser_use_init_lock:
-        current = _shared.Modules.browser_use
-        if current is None:
-            _rewire_browser_use_dependents()
-            _set_unloaded_browser_use_capability(capability_reason)
-            return
-        cancelled = False
-        try:
-            await current.close()
-        except asyncio.CancelledError:
-            cancelled = True
-            raise
-        except Exception as exc:
-            logger.warning("[Agent] BrowserUseAdapter close failed: %s", exc)
-        finally:
-            if not cancelled:
-                _shared.Modules.browser_use = None
+    # Lock order is dispatch -> init everywhere that needs both. This drains
+    # an active run before releasing the shared BrowserSession/Chromium graph.
+    async with _shared.Modules.browser_use_dispatch_lock:
+        async with _shared.Modules.browser_use_init_lock:
+            current = _shared.Modules.browser_use
+            if current is None:
                 _rewire_browser_use_dependents()
-                _set_unloaded_browser_use_capability(capability_reason)
+                if (
+                    update_capability
+                    and (
+                        expected_lifecycle_seq is None
+                        or _shared.Modules.browser_use_lifecycle_seq == expected_lifecycle_seq
+                    )
+                ):
+                    _set_unloaded_browser_use_capability(capability_reason)
+                return
+            cancelled = False
+            try:
+                await current.close()
+            except asyncio.CancelledError:
+                cancelled = True
+                raise
+            except Exception as exc:
+                logger.warning("[Agent] BrowserUseAdapter close failed: %s", exc)
+            finally:
+                if not cancelled:
+                    _shared.Modules.browser_use = None
+                    _rewire_browser_use_dependents()
+                    if (
+                        update_capability
+                        and (
+                            expected_lifecycle_seq is None
+                            or _shared.Modules.browser_use_lifecycle_seq == expected_lifecycle_seq
+                        )
+                    ):
+                        _set_unloaded_browser_use_capability(capability_reason)
 
 def _rewire_computer_use_dependents() -> None:
     """Keep task_executor in sync after computer_use adapter refresh."""

--- a/app/agent_server/capabilities.py
+++ b/app/agent_server/capabilities.py
@@ -104,14 +104,19 @@ async def _close_browser_use_adapter(
             _rewire_browser_use_dependents()
             _set_capability("browser_use", False, capability_reason)
             return
+        cancelled = False
         try:
             await current.close()
+        except asyncio.CancelledError:
+            cancelled = True
+            raise
         except Exception as exc:
             logger.warning("[Agent] BrowserUseAdapter close failed: %s", exc)
         finally:
-            _shared.Modules.browser_use = None
-            _rewire_browser_use_dependents()
-            _set_capability("browser_use", False, capability_reason)
+            if not cancelled:
+                _shared.Modules.browser_use = None
+                _rewire_browser_use_dependents()
+                _set_capability("browser_use", False, capability_reason)
 
 def _rewire_computer_use_dependents() -> None:
     """Keep task_executor in sync after computer_use adapter refresh."""

--- a/app/agent_server/capabilities.py
+++ b/app/agent_server/capabilities.py
@@ -30,6 +30,7 @@ from typing import Dict, Any, Optional, Tuple
 from . import _shared
 from ._shared import (
     logger,
+    BrowserUseAdapter,
     ComputerUseAdapter,
     ThrottledLogger,
     _set_capability,
@@ -37,6 +38,66 @@ from ._shared import (
 )
 from .registry import _cleanup_task_registry, _now_iso
 from .results import _emit_main_event
+
+
+def _rewire_browser_use_dependents() -> None:
+    """Keep task_executor in sync after BrowserUse lifecycle changes."""
+    try:
+        executor = _shared.Modules.task_executor
+        if executor is not None and hasattr(executor, "browser_use"):
+            executor.browser_use = _shared.Modules.browser_use
+    except Exception:
+        pass
+
+
+async def _ensure_browser_use_adapter():
+    """Build the heavy BrowserUse adapter only when the feature is requested."""
+    current = _shared.Modules.browser_use
+    if current is not None:
+        return current
+
+    if _shared.Modules.browser_use_init_lock is None:
+        _shared.Modules.browser_use_init_lock = asyncio.Lock()
+
+    async with _shared.Modules.browser_use_init_lock:
+        current = _shared.Modules.browser_use
+        if current is not None:
+            return current
+        try:
+            current = await asyncio.to_thread(BrowserUseAdapter)
+        except Exception as exc:
+            logger.error("[Agent] BrowserUseAdapter on-demand init failed: %s", exc)
+            _set_capability("browser_use", False, "AGENT_BU_MODULE_NOT_LOADED")
+            return None
+
+        _shared.Modules.browser_use = current
+        _rewire_browser_use_dependents()
+        logger.info("[Agent] BrowserUseAdapter ready (on-demand init)")
+        return current
+
+
+async def _close_browser_use_adapter(
+    *,
+    capability_reason: str = "AGENT_BU_MODULE_NOT_LOADED",
+) -> None:
+    """Close Chromium/browser-use resources and detach the singleton adapter."""
+    if _shared.Modules.browser_use_init_lock is None:
+        _shared.Modules.browser_use_init_lock = asyncio.Lock()
+
+    async with _shared.Modules.browser_use_init_lock:
+        current = _shared.Modules.browser_use
+        if current is None:
+            _rewire_browser_use_dependents()
+            _set_capability("browser_use", False, capability_reason)
+            return
+        try:
+            await current.close()
+        except Exception as exc:
+            logger.warning("[Agent] BrowserUseAdapter close failed: %s", exc)
+        finally:
+            _shared.Modules.browser_use = None
+            _rewire_browser_use_dependents()
+            _set_capability("browser_use", False, capability_reason)
 
 def _rewire_computer_use_dependents() -> None:
     """Keep task_executor in sync after computer_use adapter refresh."""
@@ -164,6 +225,7 @@ async def _fire_agent_llm_connectivity_check(*, queue: bool = False) -> None:
                 if _shared.Modules.agent_flags.get("browser_use_enabled"):
                     _shared.Modules.agent_flags["browser_use_enabled"] = False
                     _shared.Modules.notification = json.dumps({"code": "AGENT_AUTO_DISABLED_BROWSER", "details": {"reason_code": reason}})
+                    await _close_browser_use_adapter(capability_reason=reason)
 
             _bump_state_revision()
             await _emit_agent_status_update()
@@ -180,6 +242,7 @@ async def _fire_agent_llm_connectivity_check(*, queue: bool = False) -> None:
                 _shared.Modules.agent_flags["computer_use_enabled"] = False
             if _shared.Modules.agent_flags.get("browser_use_enabled"):
                 _shared.Modules.agent_flags["browser_use_enabled"] = False
+                await _close_browser_use_adapter(capability_reason="AGENT_LLM_UNREACHABLE")
             _shared.Modules.notification = json.dumps({"code": "AGENT_LLM_CHECK_ERROR"})
             _bump_state_revision()
             await _emit_agent_status_update()

--- a/app/agent_server/capabilities.py
+++ b/app/agent_server/capabilities.py
@@ -224,15 +224,19 @@ async def _fire_agent_llm_connectivity_check(*, queue: bool = False) -> None:
             reason = "" if ok else (probe_reason or "AGENT_LLM_UNREACHABLE")
             _set_capability("computer_use", ok, reason)
             bu = _shared.Modules.browser_use
-            if bu is None:
-                _set_capability("browser_use", False, "AGENT_BU_MODULE_NOT_LOADED")
+            if not ok:
+                _set_capability("browser_use", False, reason)
+            elif bu is None:
+                dependency_ready, dependency_error = _browser_use_dependency_status()
+                _set_capability(
+                    "browser_use",
+                    dependency_ready,
+                    "" if dependency_ready else dependency_error,
+                )
+            elif not getattr(bu, "_ready_import", False):
+                _set_capability("browser_use", False, "AGENT_BROWSER_USE_NOT_INSTALLED")
             else:
-                if not ok:
-                    _set_capability("browser_use", False, reason)
-                elif not getattr(bu, "_ready_import", False):
-                    _set_capability("browser_use", False, "AGENT_BROWSER_USE_NOT_INSTALLED")
-                else:
-                    _set_capability("browser_use", True, "")
+                _set_capability("browser_use", True, "")
 
             if ok:
                 logger.info("[Agent] Agent-LLM connectivity check passed")

--- a/app/agent_server/capabilities.py
+++ b/app/agent_server/capabilities.py
@@ -90,9 +90,29 @@ async def _ensure_browser_use_adapter():
         return current
 
 
+async def _wait_for_browser_use_adapter_close() -> None:
+    """Wait for a disable-triggered close without cancelling it with the caller."""
+    task = _shared.Modules.browser_use_close_task
+    if task is None:
+        return
+    try:
+        await asyncio.shield(task)
+    except asyncio.CancelledError:
+        if not task.cancelled():
+            raise
+
+
+def _set_unloaded_browser_use_capability(capability_reason: Optional[str]) -> None:
+    if capability_reason is not None:
+        _set_capability("browser_use", False, capability_reason)
+        return
+    dependency_ready, dependency_error = _browser_use_dependency_status()
+    _set_capability("browser_use", dependency_ready, dependency_error)
+
+
 async def _close_browser_use_adapter(
     *,
-    capability_reason: str = "AGENT_BU_MODULE_NOT_LOADED",
+    capability_reason: Optional[str] = None,
 ) -> None:
     """Close Chromium/browser-use resources and detach the singleton adapter."""
     if _shared.Modules.browser_use_init_lock is None:
@@ -102,7 +122,7 @@ async def _close_browser_use_adapter(
         current = _shared.Modules.browser_use
         if current is None:
             _rewire_browser_use_dependents()
-            _set_capability("browser_use", False, capability_reason)
+            _set_unloaded_browser_use_capability(capability_reason)
             return
         cancelled = False
         try:
@@ -116,7 +136,7 @@ async def _close_browser_use_adapter(
             if not cancelled:
                 _shared.Modules.browser_use = None
                 _rewire_browser_use_dependents()
-                _set_capability("browser_use", False, capability_reason)
+                _set_unloaded_browser_use_capability(capability_reason)
 
 def _rewire_computer_use_dependents() -> None:
     """Keep task_executor in sync after computer_use adapter refresh."""

--- a/app/agent_server/channels/browser_use.py
+++ b/app/agent_server/channels/browser_use.py
@@ -101,10 +101,15 @@ async def dispatch(
                     # disabled browser_use while this task waited for
                     # the slot (mirrors the computer-use scheduler's
                     # disabled-drop path).
-                    if not _shared.Modules.analyzer_enabled or not _shared.Modules.agent_flags.get("browser_use_enabled", False):
+                    adapter = _shared.Modules.browser_use
+                    if (
+                        not _shared.Modules.analyzer_enabled
+                        or not _shared.Modules.agent_flags.get("browser_use_enabled", False)
+                        or adapter is None
+                    ):
                         bu_info["status"] = "cancelled"
                         bu_info["end_time"] = _now_iso()
-                        bu_info["error"] = "browser_use disabled before dispatch"
+                        bu_info["error"] = "browser_use unavailable before dispatch"
                         # Close out the record_assigned entry; otherwise
                         # the tracker keeps showing [ASSIGNED] and later
                         # analyzer passes treat the same user request as
@@ -112,7 +117,7 @@ async def dispatch(
                         _task_tracker.record_completed(
                             lanlan_name, task_id=bu_task_id, method="browser_use",
                             desc=result.task_description or "",
-                            detail="browser_use disabled before dispatch",
+                            detail="browser_use unavailable before dispatch",
                             success=False, cancelled=True,
                             trigger_user_fingerprint=trigger_user_msg_sig,
                         )
@@ -139,7 +144,7 @@ async def dispatch(
                         )
                     except Exception as e:
                         logger.debug("[BrowserUse] emit task_update(running) failed: task_id=%s error=%s", bu_task_id, e)
-                    bres = await _shared.Modules.browser_use.run_instruction(
+                    bres = await adapter.run_instruction(
                         result.task_description,
                         session_id=bu_session.session_id,
                     )

--- a/app/main_server/preload.py
+++ b/app/main_server/preload.py
@@ -23,14 +23,14 @@ logger = runtime.logger
 
 
 async def _background_preload():
-    """Preload audio processing modules in the background
+    """Preload translation libraries, dashscope, and httpx in the background.
 
     Note: no Event-based synchronization is needed, because Python's import lock
-    automatically waits for the first import to finish. If the user clicks voice
-    before preloading completes, the second import simply blocks until ready.
+    automatically waits for the first import to finish. A concurrent first use
+    simply blocks until the corresponding import is ready.
     """
     try:
-        logger.info("🔄 后台预加载音频处理模块...")
+        logger.info("🔄 后台预加载翻译与网络模块...")
         # 在线程池中执行同步导入（避免阻塞事件循环）
         import concurrent.futures
 
@@ -38,7 +38,7 @@ async def _background_preload():
         with concurrent.futures.ThreadPoolExecutor() as pool:
             await loop.run_in_executor(pool, _sync_preload_modules)
     except Exception as e:
-        logger.warning(f"⚠️ 音频处理模块预加载失败（不影响使用）: {e}")
+        logger.warning(f"⚠️ 翻译与网络模块预加载失败（不影响使用）: {e}")
 
 
 def _sync_preload_modules():

--- a/app/main_server/preload.py
+++ b/app/main_server/preload.py
@@ -52,7 +52,6 @@ def _sync_preload_modules():
     - aiohttp: via tts_client.py
 
     Lazily imported modules that genuinely need preloading:
-    - pyrnnoise.rnnoise: lazily loaded in audio_processor.py via _get_rnnoise()
     - dashscope: imported only inside the cosyvoice_vc_tts_worker function in tts_client.py
     - googletrans/translatepy: translation libraries lazily imported in language_utils.py
     - translation_service: the translation service (TranslationService) in language_utils.py
@@ -87,21 +86,7 @@ def _sync_preload_modules():
     except Exception as e:
         logger.debug(f"⚠️ 翻译服务预加载失败（不影响使用）: {e}")
 
-    # 3. pyrnnoise (音频降噪 - 延迟加载，可能较慢)
-    try:
-        from utils.audio_processor import _get_rnnoise, _LiteDenoiser
-
-        rnnoise_mod = _get_rnnoise()
-        if rnnoise_mod:
-            _warmup = _LiteDenoiser(rnnoise_mod)
-            del _warmup
-            logger.debug("  ✓ pyrnnoise loaded and warmed up")
-        else:
-            logger.debug("  ✗ pyrnnoise not available")
-    except Exception as e:
-        logger.debug(f"  ✗ pyrnnoise: {e}")
-
-    # 4. dashscope (阿里云 CosyVoice TTS SDK - 仅在使用自定义音色时需要)
+    # 3. dashscope (阿里云 CosyVoice TTS SDK - 仅在使用自定义音色时需要)
     try:
         import dashscope  # noqa: F401
 
@@ -109,26 +94,7 @@ def _sync_preload_modules():
     except Exception as e:
         logger.debug(f"  ✗ dashscope: {e}")
 
-    # 5. AudioProcessor 预热（numpy buffer + soxr resampler 初始化）
-    try:
-        from utils.audio_processor import AudioProcessor
-        import numpy as np
-
-        # 创建临时实例预热 numpy/soxr
-        _warmup_processor = AudioProcessor(
-            input_sample_rate=48000,
-            output_sample_rate=16000,
-            noise_reduce_enabled=False,  # 不需要 RNNoise，前面已预热
-        )
-        # 模拟处理一小块音频，预热 numpy 和 soxr 的 JIT
-        _dummy_audio = np.zeros(480, dtype=np.int16).tobytes()
-        _ = _warmup_processor.process_chunk(_dummy_audio)
-        del _warmup_processor, _dummy_audio
-        logger.debug("  ✓ AudioProcessor warmed up")
-    except Exception as e:
-        logger.debug(f"  ✗ AudioProcessor warmup: {e}")
-
-    # 6. httpx SSL 上下文预热（首次创建 AsyncClient 会初始化 SSL）
+    # 4. httpx SSL 上下文预热（首次创建 AsyncClient 会初始化 SSL）
     try:
         import httpx
         import asyncio

--- a/app/memory_server/runtime.py
+++ b/app/memory_server/runtime.py
@@ -744,6 +744,14 @@ async def shutdown_event_handler():
         shutdown_coros.append(_await_worker_stop())
     if shutdown_coros:
         await asyncio.gather(*shutdown_coros)
+    # The worker is stopped before releasing the process-scoped singleton, so
+    # no background inference can retain or race the ONNX/tokenizer instances.
+    try:
+        from memory.embeddings import release_embedding_service
+
+        release_embedding_service()
+    except Exception as e:
+        logger.warning("[Memory] embedding service release 失败: %s", e)
     logger.info("Memory server已关闭")
 
 
@@ -759,4 +767,3 @@ async def reload_config():
     except Exception as e:
         logger.error(f"重新加载配置时出错: {e}", exc_info=True)
         return {"status": "error", "message": str(e)}
-

--- a/app/memory_server/runtime.py
+++ b/app/memory_server/runtime.py
@@ -749,7 +749,7 @@ async def shutdown_event_handler():
     try:
         from memory.embeddings import release_embedding_service
 
-        release_embedding_service()
+        await release_embedding_service()
     except Exception as e:
         logger.warning("[Memory] embedding service release 失败: %s", e)
     logger.info("Memory server已关闭")

--- a/main_logic/core/lifecycle.py
+++ b/main_logic/core/lifecycle.py
@@ -1264,7 +1264,7 @@ class LifecycleMixin:
             # Apply user's noise reduction preference to the AudioProcessor
             nr_enabled = (await _core_facade.aload_global_conversation_settings()).get('noiseReductionEnabled', True)
             if hasattr(new_session, '_audio_processor') and new_session._audio_processor:
-                new_session._audio_processor.set_enabled(nr_enabled)
+                await new_session.set_audio_noise_reduction_enabled(nr_enabled)
 
         # Bind guarded callbacks BEFORE connect — connect() can invoke
         # on_connection_error during the handshake, and without the guard
@@ -1516,7 +1516,7 @@ class LifecycleMixin:
                 # Apply user's noise reduction preference to the AudioProcessor
                 nr_enabled = (await _core_facade.aload_global_conversation_settings()).get('noiseReductionEnabled', True)
                 if hasattr(self.pending_session, '_audio_processor') and self.pending_session._audio_processor:
-                    self.pending_session._audio_processor.set_enabled(nr_enabled)
+                    await self.pending_session.set_audio_noise_reduction_enabled(nr_enabled)
                 logger.info("🔄 热切换准备: 创建语音模式 OmniRealtimeClient")
             
             initial_prompt = await self._build_initial_prompt()

--- a/main_logic/core/lifecycle.py
+++ b/main_logic/core/lifecycle.py
@@ -1240,6 +1240,7 @@ class LifecycleMixin:
             new_session.on_thinking_active = self._make_thinking_active_callback(new_session)
         else:
             realtime_config = self._config_manager.get_model_api_config('realtime')
+            nr_enabled = (await _core_facade.aload_global_conversation_settings()).get('noiseReductionEnabled', True)
             new_session = OmniRealtimeClient(
                 base_url=realtime_config.get('base_url', ''),
                 api_key=realtime_config['api_key'],
@@ -1260,9 +1261,9 @@ class LifecycleMixin:
                 on_tool_call=self._on_tool_call,
                 tool_definitions=_initial_tool_defs,
                 livestream_mode=self._is_livestream_active(),
+                noise_reduction_enabled=nr_enabled,
             )
             # Apply user's noise reduction preference to the AudioProcessor
-            nr_enabled = (await _core_facade.aload_global_conversation_settings()).get('noiseReductionEnabled', True)
             if hasattr(new_session, '_audio_processor') and new_session._audio_processor:
                 await new_session.set_audio_noise_reduction_enabled(nr_enabled)
 
@@ -1492,6 +1493,7 @@ class LifecycleMixin:
             else:
                 # 语音模式：使用 OmniRealtimeClient
                 realtime_config = self._config_manager.get_model_api_config('realtime')
+                nr_enabled = (await _core_facade.aload_global_conversation_settings()).get('noiseReductionEnabled', True)
                 self.pending_session = OmniRealtimeClient(
                     base_url=realtime_config.get('base_url', ''),
                     api_key=realtime_config['api_key'],
@@ -1512,9 +1514,9 @@ class LifecycleMixin:
                     on_tool_call=self._on_tool_call,
                     tool_definitions=_pending_tool_defs,
                     livestream_mode=self._is_livestream_active(),
+                    noise_reduction_enabled=nr_enabled,
                 )
                 # Apply user's noise reduction preference to the AudioProcessor
-                nr_enabled = (await _core_facade.aload_global_conversation_settings()).get('noiseReductionEnabled', True)
                 if hasattr(self.pending_session, '_audio_processor') and self.pending_session._audio_processor:
                     await self.pending_session.set_audio_noise_reduction_enabled(nr_enabled)
                 logger.info("🔄 热切换准备: 创建语音模式 OmniRealtimeClient")

--- a/main_logic/omni_realtime_client/_audio.py
+++ b/main_logic/omni_realtime_client/_audio.py
@@ -87,6 +87,8 @@ class _AudioMixin:
                 logger.error(f"Error saving debug audio: {exc}")
             try:
                 processor.close()
+            except Exception as exc:
+                logger.error(f"Error closing audio processor: {exc}")
             finally:
                 self._audio_processor = None
 

--- a/main_logic/omni_realtime_client/_audio.py
+++ b/main_logic/omni_realtime_client/_audio.py
@@ -62,18 +62,33 @@ class _AudioMixin:
         Asynchronously process audio chunk using RNNoise in a separate thread.
         This prevents blocking the main event loop during heavy calculation.
         """
-        if self._audio_processor is None:
-            return audio_chunk
-
         async with self._audio_processing_lock:
+            processor = self._audio_processor
+            if processor is None:
+                return audio_chunk
             # Use run_in_executor to offload heavy processing
             # None = use default ThreadPoolExecutor
             loop = asyncio.get_running_loop()
             return await loop.run_in_executor(
-                None, 
-                self._audio_processor.process_chunk, 
-                audio_chunk
+                None,
+                processor.process_chunk,
+                audio_chunk,
             )
+
+    async def _close_audio_processor(self) -> None:
+        """Quiesce executor processing before releasing RNNoise/soxr state."""
+        async with self._audio_processing_lock:
+            processor = self._audio_processor
+            if processor is None:
+                return
+            try:
+                processor.save_debug_audio()
+            except Exception as exc:
+                logger.error(f"Error saving debug audio: {exc}")
+            try:
+                processor.close()
+            finally:
+                self._audio_processor = None
 
     async def _check_silence_timeout(self):
         """Periodically check whether the silence timeout has been exceeded; if so, trigger the timeout callback"""

--- a/main_logic/omni_realtime_client/_audio.py
+++ b/main_logic/omni_realtime_client/_audio.py
@@ -98,7 +98,10 @@ class _AudioMixin:
             self._noise_reduction_enabled = enabled
             processor = self._audio_processor
             if processor is not None:
-                processor.set_enabled(enabled)
+                try:
+                    processor.set_enabled(enabled)
+                except Exception as exc:
+                    logger.error(f"Error toggling audio noise reduction: {exc}")
 
     async def _close_audio_processor(self) -> None:
         """Quiesce executor processing before releasing RNNoise/soxr state."""

--- a/main_logic/omni_realtime_client/_audio.py
+++ b/main_logic/omni_realtime_client/_audio.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
+
 from ._shared import (
     asyncio,
     logger,
@@ -65,15 +67,30 @@ class _AudioMixin:
         async with self._audio_processing_lock:
             processor = self._audio_processor
             if processor is None:
-                return audio_chunk
-            # Use run_in_executor to offload heavy processing
-            # None = use default ThreadPoolExecutor
-            loop = asyncio.get_running_loop()
-            return await loop.run_in_executor(
-                None,
-                processor.process_chunk,
-                audio_chunk,
+                # The caller selected the 48 kHz RNNoise path before awaiting
+                # this lock. Returning that original frame would make it look
+                # like processed 16 kHz PCM after a concurrent close.
+                return b""
+            worker = asyncio.create_task(
+                asyncio.to_thread(processor.process_chunk, audio_chunk)
             )
+            try:
+                return await asyncio.shield(worker)
+            except asyncio.CancelledError:
+                # A native RNNoise call keeps running after cancellation. Keep
+                # the lifecycle lock until it exits so close/toggle cannot
+                # destroy or mutate the processor underneath that call.
+                while not worker.done():
+                    try:
+                        await asyncio.shield(worker)
+                    except asyncio.CancelledError:
+                        continue
+                    except Exception:
+                        break
+                if worker.done() and not worker.cancelled():
+                    with contextlib.suppress(Exception):
+                        worker.result()
+                raise
 
     async def set_audio_noise_reduction_enabled(self, enabled: bool) -> None:
         """Apply a live denoiser toggle after active processing quiesces."""

--- a/main_logic/omni_realtime_client/_audio.py
+++ b/main_logic/omni_realtime_client/_audio.py
@@ -78,6 +78,7 @@ class _AudioMixin:
     async def set_audio_noise_reduction_enabled(self, enabled: bool) -> None:
         """Apply a live denoiser toggle after active processing quiesces."""
         async with self._audio_processing_lock:
+            self._noise_reduction_enabled = enabled
             processor = self._audio_processor
             if processor is not None:
                 processor.set_enabled(enabled)

--- a/main_logic/omni_realtime_client/_audio.py
+++ b/main_logic/omni_realtime_client/_audio.py
@@ -75,6 +75,13 @@ class _AudioMixin:
                 audio_chunk,
             )
 
+    async def set_audio_noise_reduction_enabled(self, enabled: bool) -> None:
+        """Apply a live denoiser toggle after active processing quiesces."""
+        async with self._audio_processing_lock:
+            processor = self._audio_processor
+            if processor is not None:
+                processor.set_enabled(enabled)
+
     async def _close_audio_processor(self) -> None:
         """Quiesce executor processing before releasing RNNoise/soxr state."""
         async with self._audio_processing_lock:

--- a/main_logic/omni_realtime_client/_client.py
+++ b/main_logic/omni_realtime_client/_client.py
@@ -186,12 +186,7 @@ class OmniRealtimeClient(_ToolingMixin, _AudioMixin, _TransportMixin, _ResponseM
         # Auto-resets after 2 seconds of no speech to prevent state drift
         # Input: 48kHz from PC, 16kHz from mobile
         # Output: 16kHz for API
-        self._audio_processor = AudioProcessor(
-            input_sample_rate=48000,
-            output_sample_rate=16000,
-            noise_reduce_enabled=True,  # RNNoise noise reduction + VAD
-            on_silence_reset=self._on_silence_reset  # 静音重置时发送 input_audio_buffer.clear
-        )
+        self._audio_processor = self._create_audio_processor()
 
         # ── Uplink (client→provider) sample rate ──────────────────────
         # 内部管线一律 16kHz（RNNoise 降采样到 16k、移动端原生 16k、主动
@@ -367,6 +362,15 @@ class OmniRealtimeClient(_ToolingMixin, _AudioMixin, _TransportMixin, _ResponseM
         # signal_user_activity_end) could content-match a lingering — already
         # succeeded — proactive handler and wrongly re-enqueue its cb.
         self._proactive_inject_awaiting_outcome = False
+
+    def _create_audio_processor(self) -> AudioProcessor:
+        """Create session-owned audio state, including native RNNoise state."""
+        return AudioProcessor(
+            input_sample_rate=48000,
+            output_sample_rate=16000,
+            noise_reduce_enabled=True,
+            on_silence_reset=self._on_silence_reset,
+        )
 
     def _fire_task(self, coro):
         """Create a background task with GC protection."""

--- a/main_logic/omni_realtime_client/_client.py
+++ b/main_logic/omni_realtime_client/_client.py
@@ -186,6 +186,7 @@ class OmniRealtimeClient(_ToolingMixin, _AudioMixin, _TransportMixin, _ResponseM
         # Auto-resets after 2 seconds of no speech to prevent state drift
         # Input: 48kHz from PC, 16kHz from mobile
         # Output: 16kHz for API
+        self._noise_reduction_enabled = True
         self._audio_processor = self._create_audio_processor()
 
         # ── Uplink (client→provider) sample rate ──────────────────────
@@ -368,7 +369,7 @@ class OmniRealtimeClient(_ToolingMixin, _AudioMixin, _TransportMixin, _ResponseM
         return AudioProcessor(
             input_sample_rate=48000,
             output_sample_rate=16000,
-            noise_reduce_enabled=True,
+            noise_reduce_enabled=self._noise_reduction_enabled,
             on_silence_reset=self._on_silence_reset,
         )
 

--- a/main_logic/omni_realtime_client/_client.py
+++ b/main_logic/omni_realtime_client/_client.py
@@ -99,6 +99,7 @@ class OmniRealtimeClient(_ToolingMixin, _AudioMixin, _TransportMixin, _ResponseM
         on_tool_call: Optional[OnToolCallCallback] = None,
         tool_definitions: Optional[List[ToolDefinition]] = None,
         livestream_mode: bool = False,
+        noise_reduction_enabled: bool = True,
     ):
         self.base_url = base_url
         self.api_key = api_key
@@ -186,7 +187,7 @@ class OmniRealtimeClient(_ToolingMixin, _AudioMixin, _TransportMixin, _ResponseM
         # Auto-resets after 2 seconds of no speech to prevent state drift
         # Input: 48kHz from PC, 16kHz from mobile
         # Output: 16kHz for API
-        self._noise_reduction_enabled = True
+        self._noise_reduction_enabled = noise_reduction_enabled
         self._audio_processor = self._create_audio_processor()
 
         # ── Uplink (client→provider) sample rate ──────────────────────

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -57,6 +57,11 @@ class _TransportMixin:
         # provider branch so it covers both Gemini and the WS providers.
         self._recent_tool_call_times = []
 
+        # ``close()`` releases RNNoise/soxr state. The client object is reused
+        # across sessions, so recreate that session-owned processor on demand.
+        if self._audio_processor is None:
+            self._audio_processor = self._create_audio_processor()
+
         # Gemini uses google-genai SDK, not raw WebSocket
         if self._is_gemini:
             await self._connect_gemini(instructions, native_audio)
@@ -1209,9 +1214,12 @@ class _TransportMixin:
             except Exception as e:
                 logger.error(f"Error saving debug audio: {e}")
 
-        # 重置音频处理器状态
+        # 会话结束后显式释放 RNNoise 原生 state 和 soxr 流式缓冲。
         if self._audio_processor is not None:
-            self._audio_processor.reset()
+            try:
+                self._audio_processor.close()
+            finally:
+                self._audio_processor = None
 
         # Gemini uses different cleanup
         if self._is_gemini:

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -514,12 +514,18 @@ class _TransportMixin:
         # Client-side speech detection (only when no server VAD — server events handle it in handle_messages)
         # use_rnnoise_path is true only for 48kHz input when AudioProcessor exists;
         # for 16kHz/mobile input RNNoise doesn't run, so fall back to RMS.
-        _rnnoise_vad_live = use_rnnoise_path and self._audio_processor.noise_reduce_enabled and self._audio_processor._denoiser is not None
+        audio_processor = self._audio_processor
+        use_rnnoise_path = use_rnnoise_path and audio_processor is not None
+        _rnnoise_vad_live = (
+            use_rnnoise_path
+            and audio_processor.noise_reduce_enabled
+            and audio_processor._denoiser is not None
+        )
         self._rnnoise_vad_active = _rnnoise_vad_live
         if not self._has_server_vad:
             if _rnnoise_vad_live:
                 # Priority 2: RNNoise speech probability with sustained threshold
-                if self._audio_processor.speech_probability > 0.4:
+                if audio_processor.speech_probability > 0.4:
                     # B: 单帧 RNNoise 判定为语音就立即打点，独立于 sustain。
                     # _client_vad_active 仍需 500ms sustain，_user_recent_activity
                     # 只看"最近是否发声"，fudge guard 用它兜住首 500ms 和停顿缝隙。
@@ -1207,19 +1213,9 @@ class _TransportMixin:
         self._user_recent_activity_time = 0.0
         self._ai_recent_activity_time = 0.0
 
-        # 保存 debug 音频（RNNoise 处理前后的对比音频）
-        if self._audio_processor is not None:
-            try:
-                self._audio_processor.save_debug_audio()
-            except Exception as e:
-                logger.error(f"Error saving debug audio: {e}")
-
-        # 会话结束后显式释放 RNNoise 原生 state 和 soxr 流式缓冲。
-        if self._audio_processor is not None:
-            try:
-                self._audio_processor.close()
-            finally:
-                self._audio_processor = None
+        # Wait for any executor-owned chunk to finish before releasing the
+        # session's RNNoise native state and soxr streaming buffers.
+        await self._close_audio_processor()
 
         # Gemini uses different cleanup
         if self._is_gemini:

--- a/main_routers/config_router/preferences.py
+++ b/main_routers/config_router/preferences.py
@@ -27,7 +27,7 @@ from utils.preferences import aload_user_preferences, update_model_preferences, 
 from utils.cloudsave_runtime import MaintenanceModeError
 
 
-def _apply_noise_reduction_to_active_sessions(enabled: bool):
+async def _apply_noise_reduction_to_active_sessions(enabled: bool):
     """Apply noise reduction toggle to all active voice sessions immediately."""
     from main_logic.omni_realtime_client import OmniRealtimeClient
     try:
@@ -37,9 +37,7 @@ def _apply_noise_reduction_to_active_sessions(enabled: bool):
                 continue
             if not isinstance(mgr.session, OmniRealtimeClient):
                 continue
-            ap = getattr(mgr.session, '_audio_processor', None)
-            if ap is not None:
-                ap.set_enabled(enabled)
+            await mgr.session.set_audio_noise_reduction_enabled(enabled)
     except Exception as e:
         logger.warning(f"Failed to apply noise reduction to active sessions: {e}")
 
@@ -167,7 +165,7 @@ async def save_conversation_settings(request: Request):
             return {"success": False, "error": "保存失败"}
 
         if 'noiseReductionEnabled' in data:
-            _apply_noise_reduction_to_active_sessions(data['noiseReductionEnabled'])
+            await _apply_noise_reduction_to_active_sessions(data['noiseReductionEnabled'])
 
         return {"success": True, "message": "对话设置已保存"}
     except MaintenanceModeError:

--- a/memory/embeddings.py
+++ b/memory/embeddings.py
@@ -1116,7 +1116,7 @@ class EmbeddingService:
                     return self.is_available()
                 self._state = EmbeddingState.LOADING
                 try:
-                    await asyncio.to_thread(self._load_session_blocking)
+                    await self._run_blocking(self._load_session_blocking)
                 except _DisabledError as e:
                     if not self._closing:
                         self._mark_disabled(e.reason)
@@ -1164,7 +1164,7 @@ class EmbeddingService:
             if not self.is_available():
                 return None
             try:
-                vectors = await asyncio.to_thread(self._infer_blocking, [text])
+                vectors = await self._run_blocking(self._infer_blocking, [text])
             except Exception as e:  # noqa: BLE001 — sticky inference failure
                 if not self._closing:
                     logger.warning(
@@ -1200,7 +1200,7 @@ class EmbeddingService:
             if not active_texts:
                 return result
             try:
-                vectors = await asyncio.to_thread(self._infer_blocking, active_texts)
+                vectors = await self._run_blocking(self._infer_blocking, active_texts)
             except Exception as e:  # noqa: BLE001
                 if not self._closing:
                     logger.warning(
@@ -1229,6 +1229,31 @@ class EmbeddingService:
             self._active_operations -= 1
             if self._active_operations == 0:
                 self._lifecycle_condition.notify_all()
+
+    @staticmethod
+    async def _run_blocking(func, *args):
+        """Keep cancellation from outliving a native worker-thread call."""
+        worker = asyncio.create_task(asyncio.to_thread(func, *args))
+        try:
+            return await asyncio.shield(worker)
+        except asyncio.CancelledError:
+            # ``to_thread`` cannot stop a running native call.  Do not let the
+            # caller's lifecycle lease unwind until that call has actually
+            # exited, otherwise close() could clear or recreate its owners
+            # while ONNX Runtime is still using them.
+            while not worker.done():
+                try:
+                    await asyncio.shield(worker)
+                except asyncio.CancelledError:
+                    continue
+                except Exception:
+                    break
+            if worker.done() and not worker.cancelled():
+                try:
+                    worker.result()
+                except Exception:
+                    pass
+            raise
 
     # ── internal: session load / inference ───────────────────────────
 

--- a/memory/embeddings.py
+++ b/memory/embeddings.py
@@ -929,9 +929,9 @@ class EmbeddingService:
          the safe "no embedding" answer for the rest of the process
 
     Thread/coroutine safety: ``request_load()`` is idempotent under
-    concurrent callers thanks to the asyncio.Lock; embedding calls are
-    naturally serialized through ``asyncio.to_thread`` and the
-    onnxruntime session itself releases the GIL during inference.
+    concurrent callers thanks to the asyncio.Lock. Embedding calls may run
+    concurrently; lifecycle leases let shutdown drain them before releasing
+    the ONNX session and tokenizer.
     """
 
     def __init__(
@@ -1016,6 +1016,9 @@ class EmbeddingService:
         self._session = None
         self._tokenizer = None
         self._load_lock = asyncio.Lock()
+        self._lifecycle_condition = asyncio.Condition()
+        self._active_operations = 0
+        self._closing = False
 
         # Decide initial disable conditions (all but model file presence,
         # which we check at load time so a deferred download path can
@@ -1100,41 +1103,54 @@ class EmbeddingService:
         On any failure, transitions to DISABLED and returns False — the
         service stays off for the lifetime of the process.
         """
-        if self._state is EmbeddingState.CLOSED:
+        if not await self._begin_operation():
             return False
-        if self._state in (EmbeddingState.READY, EmbeddingState.DISABLED):
-            return self.is_available()
-
-        async with self._load_lock:
-            if self._state is EmbeddingState.CLOSED:
-                return False
+        try:
             if self._state in (EmbeddingState.READY, EmbeddingState.DISABLED):
                 return self.is_available()
-            self._state = EmbeddingState.LOADING
-            try:
-                await asyncio.to_thread(self._load_session_blocking)
-            except _DisabledError as e:
-                self._mark_disabled(e.reason)
-                return False
-            except Exception as e:  # noqa: BLE001 — any load failure → off
-                logger.warning(
-                    "EmbeddingService: load failed (%s: %s); vectors disabled",
-                    type(e).__name__, e,
-                )
-                self._mark_disabled(_DisableReason.LOAD_ERROR)
-                return False
-            self._state = EmbeddingState.READY
-            logger.info(
-                "EmbeddingService: ready (model_id=%s, ram=%.1fGB, vnni=%s, avx2=%s)",
-                self.model_id(), self._ram_gb or 0.0, self._has_vnni, self._has_avx2,
-            )
-            return True
 
-    def close(self) -> None:
-        """Drop the native ONNX session/tokenizer references at process shutdown."""
-        self._session = None
-        self._tokenizer = None
-        self._state = EmbeddingState.CLOSED
+            async with self._load_lock:
+                if self._closing or self._state is EmbeddingState.CLOSED:
+                    return False
+                if self._state in (EmbeddingState.READY, EmbeddingState.DISABLED):
+                    return self.is_available()
+                self._state = EmbeddingState.LOADING
+                try:
+                    await asyncio.to_thread(self._load_session_blocking)
+                except _DisabledError as e:
+                    if not self._closing:
+                        self._mark_disabled(e.reason)
+                    return False
+                except Exception as e:  # noqa: BLE001 — any load failure → off
+                    if not self._closing:
+                        logger.warning(
+                            "EmbeddingService: load failed (%s: %s); vectors disabled",
+                            type(e).__name__, e,
+                        )
+                        self._mark_disabled(_DisableReason.LOAD_ERROR)
+                    return False
+                if self._closing or self._state is EmbeddingState.CLOSED:
+                    return False
+                self._state = EmbeddingState.READY
+                logger.info(
+                    "EmbeddingService: ready (model_id=%s, ram=%.1fGB, vnni=%s, avx2=%s)",
+                    self.model_id(), self._ram_gb or 0.0, self._has_vnni, self._has_avx2,
+                )
+                return True
+        finally:
+            await self._end_operation()
+
+    async def close(self) -> None:
+        """Quiesce requests, then drop the native session/tokenizer references."""
+        async with self._lifecycle_condition:
+            if self._state is EmbeddingState.CLOSED:
+                return
+            self._closing = True
+            while self._active_operations:
+                await self._lifecycle_condition.wait()
+            self._session = None
+            self._tokenizer = None
+            self._state = EmbeddingState.CLOSED
 
     async def embed(self, text: str) -> list[float] | None:
         """Single-text embedding. Returns None when not READY — caller
@@ -1142,18 +1158,24 @@ class EmbeddingService:
         this query."""
         if not text:
             return None
-        if not self.is_available():
+        if not await self._begin_operation():
             return None
         try:
-            vectors = await asyncio.to_thread(self._infer_blocking, [text])
-        except Exception as e:  # noqa: BLE001 — sticky inference failure
-            logger.warning(
-                "EmbeddingService: inference failed (%s: %s); vectors disabled",
-                type(e).__name__, e,
-            )
-            self._mark_disabled(_DisableReason.INFERENCE_ERROR)
-            return None
-        return vectors[0] if vectors else None
+            if not self.is_available():
+                return None
+            try:
+                vectors = await asyncio.to_thread(self._infer_blocking, [text])
+            except Exception as e:  # noqa: BLE001 — sticky inference failure
+                if not self._closing:
+                    logger.warning(
+                        "EmbeddingService: inference failed (%s: %s); vectors disabled",
+                        type(e).__name__, e,
+                    )
+                    self._mark_disabled(_DisableReason.INFERENCE_ERROR)
+                return None
+            return vectors[0] if vectors else None
+        finally:
+            await self._end_operation()
 
     async def embed_batch(self, texts: list[str]) -> list[list[float] | None]:
         """Batch embedding. Empty / None inputs and not-ready service
@@ -1162,30 +1184,51 @@ class EmbeddingService:
         if not texts:
             return []
         result: list[list[float] | None] = [None] * len(texts)
-        if not self.is_available():
-            return result
-        # Filter out empty entries before inference but preserve
-        # positional alignment in the output via index mapping.
-        active_idx: list[int] = []
-        active_texts: list[str] = []
-        for i, t in enumerate(texts):
-            if t:
-                active_idx.append(i)
-                active_texts.append(t)
-        if not active_texts:
+        if not await self._begin_operation():
             return result
         try:
-            vectors = await asyncio.to_thread(self._infer_blocking, active_texts)
-        except Exception as e:  # noqa: BLE001
-            logger.warning(
-                "EmbeddingService: batch inference failed (%s: %s); vectors disabled",
-                type(e).__name__, e,
-            )
-            self._mark_disabled(_DisableReason.INFERENCE_ERROR)
+            if not self.is_available():
+                return result
+            # Filter out empty entries before inference but preserve
+            # positional alignment in the output via index mapping.
+            active_idx: list[int] = []
+            active_texts: list[str] = []
+            for i, t in enumerate(texts):
+                if t:
+                    active_idx.append(i)
+                    active_texts.append(t)
+            if not active_texts:
+                return result
+            try:
+                vectors = await asyncio.to_thread(self._infer_blocking, active_texts)
+            except Exception as e:  # noqa: BLE001
+                if not self._closing:
+                    logger.warning(
+                        "EmbeddingService: batch inference failed (%s: %s); vectors disabled",
+                        type(e).__name__, e,
+                    )
+                    self._mark_disabled(_DisableReason.INFERENCE_ERROR)
+                return result
+            for slot, vec in zip(active_idx, vectors):
+                result[slot] = vec
             return result
-        for slot, vec in zip(active_idx, vectors):
-            result[slot] = vec
-        return result
+        finally:
+            await self._end_operation()
+
+    async def _begin_operation(self) -> bool:
+        """Register a request unless shutdown has started."""
+        async with self._lifecycle_condition:
+            if self._closing or self._state is EmbeddingState.CLOSED:
+                return False
+            self._active_operations += 1
+            return True
+
+    async def _end_operation(self) -> None:
+        """Release a request lease and wake a waiting shutdown."""
+        async with self._lifecycle_condition:
+            self._active_operations -= 1
+            if self._active_operations == 0:
+                self._lifecycle_condition.notify_all()
 
     # ── internal: session load / inference ───────────────────────────
 
@@ -1447,13 +1490,14 @@ def reset_embedding_service_for_tests() -> None:
     _VNNI_DECISION_LOGGED = False
 
 
-def release_embedding_service() -> None:
+async def release_embedding_service() -> None:
     """Release the process singleton and its native session references."""
     global _SERVICE
     service = _SERVICE
-    _SERVICE = None
     if service is not None:
-        service.close()
+        await service.close()
+    if _SERVICE is service:
+        _SERVICE = None
 
 
 def _build_default_service() -> EmbeddingService:

--- a/memory/embeddings.py
+++ b/memory/embeddings.py
@@ -159,6 +159,7 @@ class EmbeddingState(enum.Enum):
     LOADING = "loading"
     READY = "ready"
     DISABLED = "disabled"
+    CLOSED = "closed"
 
 
 class _DisableReason(enum.Enum):
@@ -1099,10 +1100,14 @@ class EmbeddingService:
         On any failure, transitions to DISABLED and returns False — the
         service stays off for the lifetime of the process.
         """
+        if self._state is EmbeddingState.CLOSED:
+            return False
         if self._state in (EmbeddingState.READY, EmbeddingState.DISABLED):
             return self.is_available()
 
         async with self._load_lock:
+            if self._state is EmbeddingState.CLOSED:
+                return False
             if self._state in (EmbeddingState.READY, EmbeddingState.DISABLED):
                 return self.is_available()
             self._state = EmbeddingState.LOADING
@@ -1124,6 +1129,12 @@ class EmbeddingService:
                 self.model_id(), self._ram_gb or 0.0, self._has_vnni, self._has_avx2,
             )
             return True
+
+    def close(self) -> None:
+        """Drop the native ONNX session/tokenizer references at process shutdown."""
+        self._session = None
+        self._tokenizer = None
+        self._state = EmbeddingState.CLOSED
 
     async def embed(self, text: str) -> list[float] | None:
         """Single-text embedding. Returns None when not READY — caller
@@ -1434,6 +1445,15 @@ def reset_embedding_service_for_tests() -> None:
     global _SERVICE, _VNNI_DECISION_LOGGED
     _SERVICE = _service_lifecycle.reset_for_tests()
     _VNNI_DECISION_LOGGED = False
+
+
+def release_embedding_service() -> None:
+    """Release the process singleton and its native session references."""
+    global _SERVICE
+    service = _SERVICE
+    _SERVICE = None
+    if service is not None:
+        service.close()
 
 
 def _build_default_service() -> EmbeddingService:

--- a/memory/embeddings.py
+++ b/memory/embeddings.py
@@ -59,6 +59,7 @@ match the current text + service ``model_id()`` — same pattern as the
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import enum
 import logging
 import os
@@ -1249,10 +1250,10 @@ class EmbeddingService:
                 except Exception:
                     break
             if worker.done() and not worker.cancelled():
-                try:
+                # Preserve the caller's cancellation; the worker failure is
+                # secondary and has already been observed by the await above.
+                with contextlib.suppress(Exception):
                     worker.result()
-                except Exception:
-                    pass
             raise
 
     # ── internal: session load / inference ───────────────────────────

--- a/plugin/plugins/_shared/rapidocr/ocr_rapidocr_backend.py
+++ b/plugin/plugins/_shared/rapidocr/ocr_rapidocr_backend.py
@@ -107,8 +107,8 @@ class RapidOcrBackend:
                         plugin_id=self._plugin_id,
                     )
                     _store_rapidocr_runtime_cache(key, runtime, now=now)
+                _acquire_rapidocr_runtime_cache(key)
             self._runtime = runtime
-            _acquire_rapidocr_runtime_cache(key)
             self._runtime_cache_acquired = True
             self._runtime_last_used_at = now
             return runtime

--- a/plugin/plugins/_shared/rapidocr/ocr_rapidocr_backend.py
+++ b/plugin/plugins/_shared/rapidocr/ocr_rapidocr_backend.py
@@ -9,8 +9,10 @@ from .ocr_runtime_types import (
     _RAPIDOCR_INFERENCE_LOCK,
     _RAPIDOCR_RUNTIME_CACHE_LOCK,
     _RAPIDOCR_RUNTIME_IDLE_TTL_SECONDS,
+    _acquire_rapidocr_runtime_cache,
     _get_rapidocr_runtime_cache,
     _prepare_ocr_image,
+    _release_rapidocr_runtime_cache,
     _rapidocr_lines_from_output,
     _rapidocr_runtime_cache_key,
     _rapidocr_text_from_output,
@@ -44,9 +46,11 @@ class RapidOcrBackend:
         self._runtime_lock = threading.Lock()
         self._runtime_cache_key: tuple[str, str, str, str, str, str] | None = None
         self._runtime_last_used_at = 0.0
+        self._runtime_cache_acquired = False
         self._warmup_started = False
         self._warmup_completed = False
         self._warmup_error = ""
+        self._closed = False
 
     def is_available(self) -> bool:
         inspection = inspect_rapidocr_installation(
@@ -70,6 +74,8 @@ class RapidOcrBackend:
             plugin_id=self._plugin_id,
         )
         with self._runtime_lock:
+            if self._closed:
+                raise RuntimeError("RapidOCR backend is closed")
             if (
                 self._runtime is not None
                 and self._runtime_cache_key == key
@@ -80,6 +86,13 @@ class RapidOcrBackend:
                     _store_rapidocr_runtime_cache(key, self._runtime, now=now)
                 return self._runtime
 
+            if self._runtime_cache_acquired and self._runtime_cache_key is not None:
+                _release_rapidocr_runtime_cache(
+                    self._runtime_cache_key,
+                    runtime=self._runtime,
+                    owner_acquired=True,
+                )
+                self._runtime_cache_acquired = False
             self._runtime = None
             self._runtime_cache_key = key
             with _RAPIDOCR_RUNTIME_CACHE_LOCK:
@@ -95,11 +108,13 @@ class RapidOcrBackend:
                     )
                     _store_rapidocr_runtime_cache(key, runtime, now=now)
             self._runtime = runtime
+            _acquire_rapidocr_runtime_cache(key)
+            self._runtime_cache_acquired = True
             self._runtime_last_used_at = now
             return runtime
 
     def warmup_async(self, logger: Any | None = None) -> None:
-        if self._warmup_started or self._warmup_completed:
+        if self._closed or self._warmup_started or self._warmup_completed:
             return
         self._warmup_started = True
 
@@ -121,6 +136,25 @@ class RapidOcrBackend:
                         pass
 
         threading.Thread(target=_warmup, name="shared-rapidocr-warmup", daemon=True).start()
+
+    def close(self) -> None:
+        """Release Python references that own RapidOCR's native ONNX sessions."""
+        with self._runtime_lock:
+            if self._closed:
+                return
+            self._closed = True
+            runtime = self._runtime
+            key = self._runtime_cache_key
+            self._runtime = None
+            self._runtime_cache_key = None
+            self._runtime_last_used_at = 0.0
+            if key is not None:
+                _release_rapidocr_runtime_cache(
+                    key,
+                    runtime=runtime,
+                    owner_acquired=self._runtime_cache_acquired,
+                )
+            self._runtime_cache_acquired = False
 
     def extract_text(self, image: Any) -> str:
         import numpy as np

--- a/plugin/plugins/_shared/rapidocr/ocr_runtime_types.py
+++ b/plugin/plugins/_shared/rapidocr/ocr_runtime_types.py
@@ -12,6 +12,7 @@ _LOGGER = logging.getLogger(__name__)
 _RAPIDOCR_RUNTIME_IDLE_TTL_SECONDS = 300.0
 _RAPIDOCR_RUNTIME_CACHE_LOCK = threading.RLock()
 _RAPIDOCR_RUNTIME_CACHE: dict[tuple[str, str, str, str, str, str], tuple[Any, float]] = {}
+_RAPIDOCR_RUNTIME_CACHE_OWNERS: dict[tuple[str, str, str, str, str, str], int] = {}
 _RAPIDOCR_INFERENCE_LOCK = threading.Lock()
 
 _OCR_PREPARE_UPSCALE_SOURCE_LONG_EDGE = 900
@@ -99,10 +100,14 @@ def _prune_rapidocr_runtime_cache(now: float) -> None:
         stale_keys = [
             key
             for key, (_runtime, last_used_at) in _RAPIDOCR_RUNTIME_CACHE.items()
-            if now - float(last_used_at or 0.0) >= _RAPIDOCR_RUNTIME_IDLE_TTL_SECONDS
+            if (
+                now - float(last_used_at or 0.0) >= _RAPIDOCR_RUNTIME_IDLE_TTL_SECONDS
+                and _RAPIDOCR_RUNTIME_CACHE_OWNERS.get(key, 0) <= 0
+            )
         ]
         for key in stale_keys:
             _RAPIDOCR_RUNTIME_CACHE.pop(key, None)
+            _RAPIDOCR_RUNTIME_CACHE_OWNERS.pop(key, None)
 
 
 def _get_rapidocr_runtime_cache(
@@ -113,10 +118,15 @@ def _get_rapidocr_runtime_cache(
     with _RAPIDOCR_RUNTIME_CACHE_LOCK:
         cached = _RAPIDOCR_RUNTIME_CACHE.get(key)
         if cached is None:
+            _RAPIDOCR_RUNTIME_CACHE_OWNERS.pop(key, None)
             return None
         runtime, last_used_at = cached
-        if now - float(last_used_at or 0.0) >= _RAPIDOCR_RUNTIME_IDLE_TTL_SECONDS:
+        if (
+            now - float(last_used_at or 0.0) >= _RAPIDOCR_RUNTIME_IDLE_TTL_SECONDS
+            and _RAPIDOCR_RUNTIME_CACHE_OWNERS.get(key, 0) <= 0
+        ):
             _RAPIDOCR_RUNTIME_CACHE.pop(key, None)
+            _RAPIDOCR_RUNTIME_CACHE_OWNERS.pop(key, None)
             return None
         _RAPIDOCR_RUNTIME_CACHE[key] = (runtime, now)
         return runtime
@@ -130,7 +140,43 @@ def _store_rapidocr_runtime_cache(
 ) -> None:
     with _RAPIDOCR_RUNTIME_CACHE_LOCK:
         _prune_rapidocr_runtime_cache(now)
+        if key not in _RAPIDOCR_RUNTIME_CACHE:
+            _RAPIDOCR_RUNTIME_CACHE_OWNERS[key] = 0
         _RAPIDOCR_RUNTIME_CACHE[key] = (runtime, now)
+
+
+def _acquire_rapidocr_runtime_cache(
+    key: tuple[str, str, str, str, str, str],
+) -> None:
+    with _RAPIDOCR_RUNTIME_CACHE_LOCK:
+        _RAPIDOCR_RUNTIME_CACHE_OWNERS[key] = (
+            _RAPIDOCR_RUNTIME_CACHE_OWNERS.get(key, 0) + 1
+        )
+
+
+def _release_rapidocr_runtime_cache(
+    key: tuple[str, str, str, str, str, str],
+    *,
+    runtime: Any | None = None,
+    owner_acquired: bool = False,
+) -> bool:
+    """Drop a cached native runtime when its owning backend is closed."""
+    with _RAPIDOCR_RUNTIME_CACHE_LOCK:
+        cached = _RAPIDOCR_RUNTIME_CACHE.get(key)
+        if cached is None:
+            return False
+        if runtime is not None and cached[0] is not runtime:
+            return False
+        if owner_acquired:
+            remaining = max(0, _RAPIDOCR_RUNTIME_CACHE_OWNERS.get(key, 0) - 1)
+            if remaining:
+                _RAPIDOCR_RUNTIME_CACHE_OWNERS[key] = remaining
+                return False
+            _RAPIDOCR_RUNTIME_CACHE_OWNERS.pop(key, None)
+        else:
+            _RAPIDOCR_RUNTIME_CACHE_OWNERS.pop(key, None)
+        _RAPIDOCR_RUNTIME_CACHE.pop(key, None)
+        return True
 
 
 def _prepare_ocr_image(image: Any, *, apply_filters: bool = True) -> Any:
@@ -389,9 +435,11 @@ __all__ = [
     "_RAPIDOCR_RUNTIME_CACHE_LOCK",
     "_RAPIDOCR_RUNTIME_IDLE_TTL_SECONDS",
     "_RapidOcrToken",
+    "_acquire_rapidocr_runtime_cache",
     "_get_rapidocr_runtime_cache",
     "_join_ocr_segments",
     "_prepare_ocr_image",
+    "_release_rapidocr_runtime_cache",
     "_rapidocr_lines_from_output",
     "_rapidocr_points",
     "_rapidocr_runtime_cache_key",

--- a/plugin/plugins/galgame_plugin/core/vision/vision_classifier.py
+++ b/plugin/plugins/galgame_plugin/core/vision/vision_classifier.py
@@ -99,6 +99,13 @@ class VisionScreenClassifier:
             self._input_name = str(inputs[0].name)
         return True
 
+    def close(self) -> None:
+        """Release the classifier and loader references to native sessions."""
+        with self._session_lock:
+            self._session = None
+            self._input_name = ""
+        self._loader.close()
+
     def classify(self, image: VisionInput) -> dict[str, Any] | None:
         self.last_error = ""
         with self._session_lock:

--- a/plugin/plugins/galgame_plugin/core/vision/vision_model_loader.py
+++ b/plugin/plugins/galgame_plugin/core/vision/vision_model_loader.py
@@ -103,6 +103,11 @@ class VisionModelLoader:
             self._sessions.pop(model_name, None)
         return self.load(model_name)
 
+    def close(self) -> None:
+        """Release cached ONNX sessions owned by this loader."""
+        with self._lock:
+            self._sessions.clear()
+
     def _session_options(self) -> Any:
         if ort is None:
             return None

--- a/plugin/plugins/galgame_plugin/ocr_manager_poll.py
+++ b/plugin/plugins/galgame_plugin/ocr_manager_poll.py
@@ -211,6 +211,12 @@ class PollMixin:
     async def shutdown(self) -> None:
         self._stop_foreground_advance_monitor()
         self._shutdown_capture_worker()
+        self._release_rapidocr_backend()
+        classifier = self.vision_classifier
+        self.vision_classifier = None
+        close_classifier = getattr(classifier, "close", None)
+        if callable(close_classifier):
+            close_classifier()
         if self._writer.session_id:
             self._writer.end_session(ts=utc_now_iso(self._time_fn()))
             self._ocr_lang_detector.reset(clear_switch_time=True)

--- a/plugin/plugins/galgame_plugin/ocr_manager_text.py
+++ b/plugin/plugins/galgame_plugin/ocr_manager_text.py
@@ -312,18 +312,15 @@ class TextMixin:
         return backend
 
 
-    def _start_rapidocr_warmup_if_configured(self) -> None:
-        if self._custom_ocr_backend or not bool(self._config.rapidocr_enabled):
+    def _release_rapidocr_backend(self) -> None:
+        backend = self._rapidocr_backend_cache
+        self._rapidocr_backend_cache = None
+        self._rapidocr_backend_cache_key = None
+        if backend is None:
             return
-        selection = self._configured_backend_selection()
-        if selection not in {"auto", "rapidocr"}:
-            return
-        self._rapidocr_backend_for_config().warmup_async(self._logger)
-        if self._writer.bridge_root != self._config.bridge_root:
-            self._writer = OcrReaderBridgeWriter(
-                bridge_root=self._config.bridge_root,
-                time_fn=self._time_fn,
-            )
+        close = getattr(backend, "close", None)
+        if callable(close):
+            close()
 
 
     def _line_changed_repeat_threshold(self) -> int:

--- a/plugin/plugins/galgame_plugin/ocr_manager_text.py
+++ b/plugin/plugins/galgame_plugin/ocr_manager_text.py
@@ -406,8 +406,7 @@ class TextMixin:
         self._backend_plan_cache_key = None
         self._backend_plan_cache_at = 0.0
         self._backend_plan_cache = None
-        self._rapidocr_backend_cache_key = None
-        self._rapidocr_backend_cache = None
+        self._release_rapidocr_backend()
         self._ocr_lang_detector.reset()
         callback = self._rapidocr_lang_changed_callback
         if callable(callback):

--- a/plugin/plugins/galgame_plugin/ocr_rapidocr_backend.py
+++ b/plugin/plugins/galgame_plugin/ocr_rapidocr_backend.py
@@ -9,8 +9,10 @@ from .ocr_runtime_types import (
     _RAPIDOCR_INFERENCE_LOCK,
     _RAPIDOCR_RUNTIME_CACHE_LOCK,
     _RAPIDOCR_RUNTIME_IDLE_TTL_SECONDS,
+    _acquire_rapidocr_runtime_cache,
     _get_rapidocr_runtime_cache,
     _prepare_ocr_image,
+    _release_rapidocr_runtime_cache,
     _rapidocr_lines_from_output,
     _rapidocr_runtime_cache_key,
     _rapidocr_text_from_output,
@@ -42,9 +44,11 @@ class RapidOcrBackend:
         self._runtime_lock = threading.Lock()
         self._runtime_cache_key: tuple[str, str, str, str, str] | None = None
         self._runtime_last_used_at = 0.0
+        self._runtime_cache_acquired = False
         self._warmup_started = False
         self._warmup_completed = False
         self._warmup_error = ""
+        self._closed = False
 
     def is_available(self) -> bool:
         inspection = inspect_rapidocr_installation(
@@ -67,6 +71,8 @@ class RapidOcrBackend:
             ocr_version=self._ocr_version,
         )
         with self._runtime_lock:
+            if self._closed:
+                raise RuntimeError("RapidOCR backend is closed")
             if (
                 self._runtime is not None
                 and self._runtime_cache_key == key
@@ -77,6 +83,13 @@ class RapidOcrBackend:
                     _store_rapidocr_runtime_cache(key, self._runtime, now=now)
                 return self._runtime
 
+            if self._runtime_cache_acquired and self._runtime_cache_key is not None:
+                _release_rapidocr_runtime_cache(
+                    self._runtime_cache_key,
+                    runtime=self._runtime,
+                    owner_acquired=True,
+                )
+                self._runtime_cache_acquired = False
             self._runtime = None
             self._runtime_cache_key = key
             with _RAPIDOCR_RUNTIME_CACHE_LOCK:
@@ -92,11 +105,13 @@ class RapidOcrBackend:
                     )
                     _store_rapidocr_runtime_cache(key, runtime, now=now)
             self._runtime = runtime
+            _acquire_rapidocr_runtime_cache(key)
+            self._runtime_cache_acquired = True
             self._runtime_last_used_at = now
             return runtime
 
     def warmup_async(self, logger: Any | None = None) -> None:
-        if self._warmup_started or self._warmup_completed:
+        if self._closed or self._warmup_started or self._warmup_completed:
             return
         self._warmup_started = True
 
@@ -118,6 +133,25 @@ class RapidOcrBackend:
                         pass
 
         threading.Thread(target=_warmup, name="galgame-rapidocr-warmup", daemon=True).start()
+
+    def close(self) -> None:
+        """Release Python references that own RapidOCR's native ONNX sessions."""
+        with self._runtime_lock:
+            if self._closed:
+                return
+            self._closed = True
+            runtime = self._runtime
+            key = self._runtime_cache_key
+            self._runtime = None
+            self._runtime_cache_key = None
+            self._runtime_last_used_at = 0.0
+            if key is not None:
+                _release_rapidocr_runtime_cache(
+                    key,
+                    runtime=runtime,
+                    owner_acquired=self._runtime_cache_acquired,
+                )
+            self._runtime_cache_acquired = False
 
     def extract_text(self, image: Any) -> str:
         import numpy as np

--- a/plugin/plugins/galgame_plugin/ocr_rapidocr_backend.py
+++ b/plugin/plugins/galgame_plugin/ocr_rapidocr_backend.py
@@ -104,8 +104,8 @@ class RapidOcrBackend:
                         plugin_id="galgame_plugin",
                     )
                     _store_rapidocr_runtime_cache(key, runtime, now=now)
+                _acquire_rapidocr_runtime_cache(key)
             self._runtime = runtime
-            _acquire_rapidocr_runtime_cache(key)
             self._runtime_cache_acquired = True
             self._runtime_last_used_at = now
             return runtime

--- a/plugin/plugins/galgame_plugin/ocr_reader.py
+++ b/plugin/plugins/galgame_plugin/ocr_reader.py
@@ -305,7 +305,6 @@ class OcrReaderManager(
         ] = []
         self._window_inventory_cache_at = 0.0
         self._window_inventory_cache: list[DetectedGameWindow] = []
-        self._start_rapidocr_warmup_if_configured()
 
     def _initialize_vision_classifier(self) -> None:
         self.vision_classifier = None
@@ -378,6 +377,12 @@ class OcrReaderManager(
         return (repo_root / path).resolve()
 
     def close(self) -> None:
+        self._release_rapidocr_backend()
+        classifier = self.vision_classifier
+        self.vision_classifier = None
+        close_classifier = getattr(classifier, "close", None)
+        if callable(close_classifier):
+            close_classifier()
         try:
             self._stop_foreground_advance_monitor(join_timeout=1.0)
         except Exception as exc:
@@ -451,6 +456,10 @@ class OcrReaderManager(
         self._config = config
         self._runtime.enabled = config.ocr_reader_enabled
         if old_vision_key != self._vision_classifier_config_key(config):
+            classifier = self.vision_classifier
+            close_classifier = getattr(classifier, "close", None)
+            if callable(close_classifier):
+                close_classifier()
             self._initialize_vision_classifier()
         if not bool(config.llm_vision_enabled):
             self._clear_vision_snapshot()
@@ -461,8 +470,7 @@ class OcrReaderManager(
             self._backend_plan_cache_key = None
             self._backend_plan_cache_at = 0.0
             self._backend_plan_cache = None
-            self._rapidocr_backend_cache_key = None
-            self._rapidocr_backend_cache = None
+            self._release_rapidocr_backend()
             self._ocr_lang_detector.reset(clear_switch_time=True)
         elif old_auto_detect_lang != bool(getattr(config, "rapidocr_auto_detect_lang", False)):
             self._ocr_lang_detector.reset(clear_switch_time=True)
@@ -482,7 +490,11 @@ class OcrReaderManager(
             self.start_foreground_advance_monitor()
         else:
             self._stop_foreground_advance_monitor()
-        self._start_rapidocr_warmup_if_configured()
+        if self._writer.bridge_root != config.bridge_root:
+            self._writer = OcrReaderBridgeWriter(
+                bridge_root=config.bridge_root,
+                time_fn=self._time_fn,
+            )
 
     def update_advance_speed(self, advance_speed: str) -> None:
         normalized = str(advance_speed or "").strip().lower()

--- a/plugin/plugins/galgame_plugin/ocr_runtime_types.py
+++ b/plugin/plugins/galgame_plugin/ocr_runtime_types.py
@@ -212,6 +212,7 @@ __all__ = [
     "_RAPIDOCR_RUNTIME_IDLE_TTL_SECONDS",
     "_RapidOcrToken",
     "_RuntimeFieldProxy",
+    "_acquire_rapidocr_runtime_cache",
     "_SCENE_CHANGE_COOLDOWN_SECONDS",
     "_SCREEN_AWARENESS_LATENCY_MODES",
     "_SCREEN_AWARENESS_LATENCY_MODE_AGGRESSIVE",
@@ -262,6 +263,7 @@ __all__ = [
     "_float_or_zero",
     "_frame_choice_bounds_metadata",
     "_get_rapidocr_runtime_cache",
+    "_release_rapidocr_runtime_cache",
     "_join_ocr_segments",
     "_looks_like_dialogue_line",
     "_looks_like_english_overlay_label",
@@ -362,6 +364,7 @@ _WINDOW_SCAN_CACHE_TTL_SECONDS = 5.0
 _RAPIDOCR_RUNTIME_IDLE_TTL_SECONDS = 300.0
 _RAPIDOCR_RUNTIME_CACHE_LOCK = threading.RLock()
 _RAPIDOCR_RUNTIME_CACHE: dict[tuple[str, str, str, str, str], tuple[Any, float]] = {}
+_RAPIDOCR_RUNTIME_CACHE_OWNERS: dict[tuple[str, str, str, str, str], int] = {}
 _RAPIDOCR_INFERENCE_LOCK = threading.Lock()
 _OCR_PREPARE_UPSCALE_SOURCE_LONG_EDGE = 900
 _OCR_PREPARE_TARGET_LONG_EDGE = 1400
@@ -458,10 +461,14 @@ def _prune_rapidocr_runtime_cache(now: float) -> None:
         stale_keys = [
             key
             for key, (_runtime, last_used_at) in _RAPIDOCR_RUNTIME_CACHE.items()
-            if now - float(last_used_at or 0.0) >= _RAPIDOCR_RUNTIME_IDLE_TTL_SECONDS
+            if (
+                now - float(last_used_at or 0.0) >= _RAPIDOCR_RUNTIME_IDLE_TTL_SECONDS
+                and _RAPIDOCR_RUNTIME_CACHE_OWNERS.get(key, 0) <= 0
+            )
         ]
         for key in stale_keys:
             _RAPIDOCR_RUNTIME_CACHE.pop(key, None)
+            _RAPIDOCR_RUNTIME_CACHE_OWNERS.pop(key, None)
 
 
 def _get_rapidocr_runtime_cache(
@@ -472,10 +479,15 @@ def _get_rapidocr_runtime_cache(
     with _RAPIDOCR_RUNTIME_CACHE_LOCK:
         cached = _RAPIDOCR_RUNTIME_CACHE.get(key)
         if cached is None:
+            _RAPIDOCR_RUNTIME_CACHE_OWNERS.pop(key, None)
             return None
         runtime, last_used_at = cached
-        if now - float(last_used_at or 0.0) >= _RAPIDOCR_RUNTIME_IDLE_TTL_SECONDS:
+        if (
+            now - float(last_used_at or 0.0) >= _RAPIDOCR_RUNTIME_IDLE_TTL_SECONDS
+            and _RAPIDOCR_RUNTIME_CACHE_OWNERS.get(key, 0) <= 0
+        ):
             _RAPIDOCR_RUNTIME_CACHE.pop(key, None)
+            _RAPIDOCR_RUNTIME_CACHE_OWNERS.pop(key, None)
             return None
         _RAPIDOCR_RUNTIME_CACHE[key] = (runtime, now)
         return runtime
@@ -489,7 +501,43 @@ def _store_rapidocr_runtime_cache(
 ) -> None:
     with _RAPIDOCR_RUNTIME_CACHE_LOCK:
         _prune_rapidocr_runtime_cache(now)
+        if key not in _RAPIDOCR_RUNTIME_CACHE:
+            _RAPIDOCR_RUNTIME_CACHE_OWNERS[key] = 0
         _RAPIDOCR_RUNTIME_CACHE[key] = (runtime, now)
+
+
+def _acquire_rapidocr_runtime_cache(
+    key: tuple[str, str, str, str, str],
+) -> None:
+    with _RAPIDOCR_RUNTIME_CACHE_LOCK:
+        _RAPIDOCR_RUNTIME_CACHE_OWNERS[key] = (
+            _RAPIDOCR_RUNTIME_CACHE_OWNERS.get(key, 0) + 1
+        )
+
+
+def _release_rapidocr_runtime_cache(
+    key: tuple[str, str, str, str, str],
+    *,
+    runtime: Any | None = None,
+    owner_acquired: bool = False,
+) -> bool:
+    """Drop a cached native runtime when its owning backend is closed."""
+    with _RAPIDOCR_RUNTIME_CACHE_LOCK:
+        cached = _RAPIDOCR_RUNTIME_CACHE.get(key)
+        if cached is None:
+            return False
+        if runtime is not None and cached[0] is not runtime:
+            return False
+        if owner_acquired:
+            remaining = max(0, _RAPIDOCR_RUNTIME_CACHE_OWNERS.get(key, 0) - 1)
+            if remaining:
+                _RAPIDOCR_RUNTIME_CACHE_OWNERS[key] = remaining
+                return False
+            _RAPIDOCR_RUNTIME_CACHE_OWNERS.pop(key, None)
+        else:
+            _RAPIDOCR_RUNTIME_CACHE_OWNERS.pop(key, None)
+        _RAPIDOCR_RUNTIME_CACHE.pop(key, None)
+        return True
 
 
 def _aihong_choice_boxes(

--- a/plugin/plugins/study_companion/study_ocr_pipeline.py
+++ b/plugin/plugins/study_companion/study_ocr_pipeline.py
@@ -8,6 +8,7 @@ import importlib
 import importlib.util
 import subprocess
 import sys
+from threading import RLock
 import time
 from typing import Any
 
@@ -114,6 +115,9 @@ class StudyOcrPipeline:
         self._latest_vision_snapshot: dict[str, Any] = {}
         self._latest_vision_image_base64 = ""
         self._last_thumbnail_phash = ""
+        self._lifecycle_lock = RLock()
+        self._closed = False
+        self._retired_executors: list[ThreadPoolExecutor] = []
         self._executor: ThreadPoolExecutor | None = ThreadPoolExecutor(
             max_workers=2, thread_name_prefix="study-ocr"
         )
@@ -123,26 +127,35 @@ class StudyOcrPipeline:
             )
 
     def update_config(self, config: StudyConfig) -> None:
-        self._release_owned_ocr_backend()
-        self._config = config
-        self._capture_backend = None
-        self._last_thumbnail_phash = ""
-        self._clear_vision_snapshot()
+        with self._lifecycle_lock:
+            self._release_owned_ocr_backend()
+            self._config = config
+            self._capture_backend = None
+            self._last_thumbnail_phash = ""
+            self._clear_vision_snapshot()
 
     def close(self) -> None:
+        with self._lifecycle_lock:
+            if self._closed:
+                return
+            self._closed = True
+            executors = self._retired_executors
+            self._retired_executors = []
+            executor = self._executor
+            self._executor = None
+            if executor is not None:
+                executors.append(executor)
+        for executor in executors:
+            executor.shutdown(wait=True)
         self._release_owned_ocr_backend()
-        executor = self._executor
-        if executor is None:
-            return
-        executor.shutdown(wait=False)
-        self._executor = None
 
     def _release_owned_ocr_backend(self) -> None:
-        if not self._owns_ocr_backend:
-            return
-        backend = self._ocr_backend
-        self._ocr_backend = None
-        self._owns_ocr_backend = True
+        with self._lifecycle_lock:
+            if not self._owns_ocr_backend:
+                return
+            backend = self._ocr_backend
+            self._ocr_backend = None
+            self._owns_ocr_backend = True
         if backend is None:
             return
         close = getattr(backend, "close", None)
@@ -150,22 +163,27 @@ class StudyOcrPipeline:
             close()
 
     def _retire_executor(self, executor: ThreadPoolExecutor) -> None:
-        if self._executor is not executor:
-            return
-        shutdown = getattr(executor, "shutdown", None)
-        if callable(shutdown):
-            try:
-                shutdown(wait=False)
-            except Exception:
-                pass
-        self._executor = None
+        with self._lifecycle_lock:
+            if self._executor is not executor:
+                return
+            shutdown = getattr(executor, "shutdown", None)
+            if callable(shutdown):
+                try:
+                    shutdown(wait=False)
+                except Exception:
+                    pass
+            self._retired_executors.append(executor)
+            self._executor = None
 
     def _require_executor(self) -> ThreadPoolExecutor:
-        if self._executor is None:
-            self._executor = ThreadPoolExecutor(
-                max_workers=2, thread_name_prefix="study-ocr"
-            )
-        return self._executor
+        with self._lifecycle_lock:
+            if self._closed:
+                raise RuntimeError("study OCR pipeline is closed")
+            if self._executor is None:
+                self._executor = ThreadPoolExecutor(
+                    max_workers=2, thread_name_prefix="study-ocr"
+                )
+            return self._executor
 
     def snapshot_from_image(self, image: Any, *, backend_name: str = "") -> OcrSnapshot:
         if image is None:
@@ -635,31 +653,34 @@ class StudyOcrPipeline:
             return rendered
 
     def _resolve_ocr_backend(self) -> Any:
-        if self._ocr_backend is not None:
+        with self._lifecycle_lock:
+            if self._closed:
+                raise RuntimeError("study OCR pipeline is closed")
+            if self._ocr_backend is not None:
+                return self._ocr_backend
+            selection = str(self._config.ocr_backend_selection or "rapidocr").strip().lower()
+            if selection == "tesseract":
+                from .tesseract_support import TesseractOcrBackend
+
+                self._ocr_backend = TesseractOcrBackend(
+                    tesseract_path=self._config.ocr_tesseract_path,
+                    install_target_dir_raw=self._config.ocr_install_target_dir,
+                    languages=self._config.ocr_languages,
+                )
+                self._owns_ocr_backend = True
+            else:
+                from plugin.plugins._shared.rapidocr.ocr_backends import RapidOcrBackend
+
+                self._ocr_backend = RapidOcrBackend(
+                    install_target_dir_raw=self._config.rapidocr_install_target_dir,
+                    engine_type=self._config.rapidocr_engine_type,
+                    lang_type=self._config.rapidocr_lang_type,
+                    model_type=self._config.rapidocr_model_type,
+                    ocr_version=self._config.rapidocr_ocr_version,
+                    plugin_id="study_companion",
+                )
+                self._owns_ocr_backend = True
             return self._ocr_backend
-        selection = str(self._config.ocr_backend_selection or "rapidocr").strip().lower()
-        if selection == "tesseract":
-            from .tesseract_support import TesseractOcrBackend
-
-            self._ocr_backend = TesseractOcrBackend(
-                tesseract_path=self._config.ocr_tesseract_path,
-                install_target_dir_raw=self._config.ocr_install_target_dir,
-                languages=self._config.ocr_languages,
-            )
-            self._owns_ocr_backend = True
-        else:
-            from plugin.plugins._shared.rapidocr.ocr_backends import RapidOcrBackend
-
-            self._ocr_backend = RapidOcrBackend(
-                install_target_dir_raw=self._config.rapidocr_install_target_dir,
-                engine_type=self._config.rapidocr_engine_type,
-                lang_type=self._config.rapidocr_lang_type,
-                model_type=self._config.rapidocr_model_type,
-                ocr_version=self._config.rapidocr_ocr_version,
-                plugin_id="study_companion",
-            )
-            self._owns_ocr_backend = True
-        return self._ocr_backend
 
     def _resolve_capture_backend(self) -> Any:
         if self._capture_backend is not None:

--- a/plugin/plugins/study_companion/study_ocr_pipeline.py
+++ b/plugin/plugins/study_companion/study_ocr_pipeline.py
@@ -170,8 +170,10 @@ class StudyOcrPipeline:
             if callable(shutdown):
                 try:
                     shutdown(wait=False)
-                except Exception:
-                    pass
+                except Exception as exc:
+                    self._logger.warning(
+                        f"study OCR executor retirement shutdown failed: {exc}"
+                    )
             self._retired_executors.append(executor)
             self._executor = None
 

--- a/plugin/plugins/study_companion/study_ocr_pipeline.py
+++ b/plugin/plugins/study_companion/study_ocr_pipeline.py
@@ -138,11 +138,12 @@ class StudyOcrPipeline:
         self._executor = None
 
     def _release_owned_ocr_backend(self) -> None:
+        if not self._owns_ocr_backend:
+            return
         backend = self._ocr_backend
-        owns_backend = self._owns_ocr_backend
         self._ocr_backend = None
         self._owns_ocr_backend = True
-        if not owns_backend or backend is None:
+        if backend is None:
             return
         close = getattr(backend, "close", None)
         if callable(close):

--- a/plugin/plugins/study_companion/study_ocr_pipeline.py
+++ b/plugin/plugins/study_companion/study_ocr_pipeline.py
@@ -4,18 +4,14 @@ import base64
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 import io
+import importlib
+import importlib.util
 import subprocess
 import sys
 import time
 from typing import Any
 
 from PIL import Image
-
-try:
-    import imagehash
-except ImportError:
-    imagehash = None
-
 from .models import (
     ActivitySnapshot,
     OCR_SNIPPET_MAX_CHARS,
@@ -24,6 +20,25 @@ from .models import (
     utc_now_iso,
 )
 from .screen_classifier import classify_app_from_title, classify_screen_from_ocr
+
+_IMAGEHASH_UNLOADED = object()
+imagehash: Any = _IMAGEHASH_UNLOADED
+
+
+def _get_imagehash() -> Any | None:
+    global imagehash
+    if imagehash is _IMAGEHASH_UNLOADED:
+        try:
+            imagehash = importlib.import_module("imagehash")
+        except ImportError:
+            imagehash = None
+    return imagehash
+
+
+def _imagehash_is_available() -> bool:
+    if imagehash is not _IMAGEHASH_UNLOADED:
+        return imagehash is not None
+    return importlib.util.find_spec("imagehash") is not None
 
 CAPTURE_BACKEND_AUTO = "auto"
 CAPTURE_BACKEND_DXCAM = "dxcam"
@@ -94,6 +109,7 @@ class StudyOcrPipeline:
         self._logger = logger
         self._config = config
         self._ocr_backend = ocr_backend
+        self._owns_ocr_backend = ocr_backend is None
         self._capture_backend = capture_backend
         self._latest_vision_snapshot: dict[str, Any] = {}
         self._latest_vision_image_base64 = ""
@@ -101,24 +117,36 @@ class StudyOcrPipeline:
         self._executor: ThreadPoolExecutor | None = ThreadPoolExecutor(
             max_workers=2, thread_name_prefix="study-ocr"
         )
-        if imagehash is None:
+        if not _imagehash_is_available():
             self._logger.warning(
                 "study OCR content-change detection disabled: imagehash is unavailable"
             )
 
     def update_config(self, config: StudyConfig) -> None:
+        self._release_owned_ocr_backend()
         self._config = config
-        self._ocr_backend = None
         self._capture_backend = None
         self._last_thumbnail_phash = ""
         self._clear_vision_snapshot()
 
     def close(self) -> None:
+        self._release_owned_ocr_backend()
         executor = self._executor
         if executor is None:
             return
         executor.shutdown(wait=False)
         self._executor = None
+
+    def _release_owned_ocr_backend(self) -> None:
+        backend = self._ocr_backend
+        owns_backend = self._owns_ocr_backend
+        self._ocr_backend = None
+        self._owns_ocr_backend = True
+        if not owns_backend or backend is None:
+            return
+        close = getattr(backend, "close", None)
+        if callable(close):
+            close()
 
     def _retire_executor(self, executor: ThreadPoolExecutor) -> None:
         if self._executor is not executor:
@@ -388,9 +416,10 @@ class StudyOcrPipeline:
 
     @staticmethod
     def _calculate_thumbnail_phash(image: Image.Image) -> str | None:
-        if imagehash is None:
+        imagehash_module = _get_imagehash()
+        if imagehash_module is None:
             return None
-        return str(imagehash.phash(image, hash_size=8))
+        return str(imagehash_module.phash(image, hash_size=8))
 
     def _has_content_change(self, thumbnail_phash: str) -> bool:
         previous = str(self._last_thumbnail_phash or "").strip()
@@ -616,6 +645,7 @@ class StudyOcrPipeline:
                 install_target_dir_raw=self._config.ocr_install_target_dir,
                 languages=self._config.ocr_languages,
             )
+            self._owns_ocr_backend = True
         else:
             from plugin.plugins._shared.rapidocr.ocr_backends import RapidOcrBackend
 
@@ -627,6 +657,7 @@ class StudyOcrPipeline:
                 ocr_version=self._config.rapidocr_ocr_version,
                 plugin_id="study_companion",
             )
+            self._owns_ocr_backend = True
         return self._ocr_backend
 
     def _resolve_capture_backend(self) -> Any:

--- a/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
+++ b/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
@@ -5106,7 +5106,7 @@ def test_build_config_defaults_ocr_languages_to_chi_sim_jpn_eng(tmp_path: Path) 
     )
 
 
-def test_ocr_reader_manager_initializes_with_rapidocr_warmup_enabled(
+def test_ocr_reader_manager_defers_rapidocr_until_first_ocr(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -5127,7 +5127,8 @@ def test_ocr_reader_manager_initializes_with_rapidocr_warmup_enabled(
     )
 
     assert manager._writer.bridge_root == bridge_root
-    assert warmup_calls
+    assert warmup_calls == []
+    assert manager._rapidocr_backend_cache is None
 
 
 @pytest.mark.asyncio
@@ -5343,8 +5344,50 @@ def test_rapidocr_runtime_cache_reuses_loaded_runtime(
         assert first._ensure_runtime() is runtime
         assert second._ensure_runtime() is runtime
         assert len(load_calls) == 1
+        first.close()
+        assert galgame_ocr_reader._RAPIDOCR_RUNTIME_CACHE[cache_key][0] is runtime
+        second.close()
+        assert cache_key not in galgame_ocr_reader._RAPIDOCR_RUNTIME_CACHE
     finally:
         galgame_ocr_reader._RAPIDOCR_RUNTIME_CACHE.pop(cache_key, None)
+
+
+def test_rapidocr_backend_close_releases_cached_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_target_dir = str(tmp_path / "RapidOCR")
+    runtime = object()
+    monkeypatch.setattr(
+        galgame_ocr_rapidocr_backend,
+        "load_rapidocr_runtime",
+        lambda **_kwargs: (runtime, {}),
+    )
+    backend = galgame_ocr_reader.RapidOcrBackend(
+        install_target_dir_raw=install_target_dir,
+        engine_type="onnxruntime",
+        lang_type="ch",
+        model_type="mobile",
+        ocr_version="PP-OCRv5",
+    )
+    cache_key = (
+        install_target_dir,
+        "onnxruntime",
+        "ch",
+        "mobile",
+        "PP-OCRv5",
+    )
+
+    assert backend._ensure_runtime() is runtime
+    assert galgame_ocr_reader._RAPIDOCR_RUNTIME_CACHE[cache_key][0] is runtime
+
+    backend.close()
+    backend.close()
+
+    assert cache_key not in galgame_ocr_reader._RAPIDOCR_RUNTIME_CACHE
+    assert backend._runtime is None
+    with pytest.raises(RuntimeError, match="closed"):
+        backend._ensure_runtime()
 
 
 def test_rapidocr_runtime_cache_reloads_after_idle_timeout(

--- a/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
+++ b/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
@@ -5685,6 +5685,11 @@ def test_rapidocr_auto_lang_switches_when_rapidocr_active(
         rapidocr_lang_changed_callback=persisted.append,
     )
     manager._ocr_lang_detector = _OcrLangDetector(window_size=3, confirm_streak=2)
+    backend_close_calls: list[bool] = []
+    manager._rapidocr_backend_cache_key = manager._rapidocr_cache_key()
+    manager._rapidocr_backend_cache = SimpleNamespace(
+        close=lambda: backend_close_calls.append(True)
+    )
     monkeypatch.setattr(
         galgame_ocr_reader,
         "inspect_rapidocr_installation",
@@ -5709,6 +5714,8 @@ def test_rapidocr_auto_lang_switches_when_rapidocr_active(
     assert manager._config.rapidocr_lang_type == "korean"
     assert manager._config.rapidocr_auto_detect_last_lang == "korean"
     assert persisted == ["korean"]
+    assert backend_close_calls == [True]
+    assert manager._rapidocr_backend_cache is None
 
 
 def test_rapidocr_auto_lang_does_not_override_manual_disable_during_inspection(

--- a/plugin/tests/unit/plugins/test_galgame_rapidocr_support.py
+++ b/plugin/tests/unit/plugins/test_galgame_rapidocr_support.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 from contextlib import nullcontext
 from pathlib import Path
+import threading
 from types import SimpleNamespace
 
 import httpx
 import pytest
 
-from plugin.plugins._shared.rapidocr import rapidocr_support
+from plugin.plugins._shared.rapidocr import ocr_rapidocr_backend, rapidocr_support
 from plugin.plugins._shared.rapidocr.ocr_rapidocr_backend import RapidOcrBackend
 from plugin.plugins._shared.rapidocr.ocr_runtime_types import (
     _RAPIDOCR_RUNTIME_CACHE,
@@ -132,6 +133,85 @@ def test_shared_rapidocr_backend_close_releases_plugin_scoped_runtime(
     second.close()
 
     assert key not in _RAPIDOCR_RUNTIME_CACHE
+
+
+def test_shared_rapidocr_cache_acquire_is_atomic_with_lookup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = object()
+    install_target_dir = str(tmp_path / "RapidOCR")
+    monkeypatch.setattr(
+        ocr_rapidocr_backend,
+        "load_rapidocr_runtime",
+        lambda **_kwargs: (runtime, {}),
+    )
+    first = RapidOcrBackend(
+        install_target_dir_raw=install_target_dir,
+        engine_type="onnxruntime",
+        lang_type="ch",
+        model_type="mobile",
+        ocr_version="PP-OCRv5",
+        plugin_id="study_companion",
+    )
+    second = RapidOcrBackend(
+        install_target_dir_raw=install_target_dir,
+        engine_type="onnxruntime",
+        lang_type="ch",
+        model_type="mobile",
+        ocr_version="PP-OCRv5",
+        plugin_id="study_companion",
+    )
+    key = _rapidocr_runtime_cache_key(
+        install_target_dir_raw=install_target_dir,
+        engine_type="onnxruntime",
+        lang_type="ch",
+        model_type="mobile",
+        ocr_version="PP-OCRv5",
+        plugin_id="study_companion",
+    )
+    assert first._ensure_runtime() is runtime
+
+    acquire_started = threading.Event()
+    release_acquire = threading.Event()
+    close_completed = threading.Event()
+    result: list[object] = []
+    real_acquire = ocr_rapidocr_backend._acquire_rapidocr_runtime_cache
+
+    def _blocking_acquire(cache_key) -> None:
+        acquire_started.set()
+        assert release_acquire.wait(timeout=2.0)
+        real_acquire(cache_key)
+
+    monkeypatch.setattr(
+        ocr_rapidocr_backend,
+        "_acquire_rapidocr_runtime_cache",
+        _blocking_acquire,
+    )
+    ensure_thread = threading.Thread(target=lambda: result.append(second._ensure_runtime()))
+
+    def _close_first() -> None:
+        first.close()
+        close_completed.set()
+
+    close_thread = threading.Thread(target=_close_first)
+    try:
+        ensure_thread.start()
+        assert acquire_started.wait(timeout=2.0)
+        close_thread.start()
+        assert not close_completed.wait(timeout=0.2)
+        release_acquire.set()
+        ensure_thread.join(timeout=2.0)
+        close_thread.join(timeout=2.0)
+
+        assert result == [runtime]
+        assert close_completed.is_set()
+        assert _RAPIDOCR_RUNTIME_CACHE[key][0] is runtime
+    finally:
+        release_acquire.set()
+        ensure_thread.join(timeout=2.0)
+        close_thread.join(timeout=2.0)
+        second.close()
 
 
 def test_default_rapidocr_install_target_rejects_path_traversal_plugin_id(

--- a/plugin/tests/unit/plugins/test_galgame_rapidocr_support.py
+++ b/plugin/tests/unit/plugins/test_galgame_rapidocr_support.py
@@ -8,7 +8,11 @@ import httpx
 import pytest
 
 from plugin.plugins._shared.rapidocr import rapidocr_support
-from plugin.plugins._shared.rapidocr.ocr_runtime_types import _rapidocr_runtime_cache_key
+from plugin.plugins._shared.rapidocr.ocr_rapidocr_backend import RapidOcrBackend
+from plugin.plugins._shared.rapidocr.ocr_runtime_types import (
+    _RAPIDOCR_RUNTIME_CACHE,
+    _rapidocr_runtime_cache_key,
+)
 
 
 pytestmark = pytest.mark.plugin_unit
@@ -80,6 +84,54 @@ def test_shared_rapidocr_runtime_cache_key_includes_plugin_id() -> None:
         "PP-OCRv5",
     )
     assert other_key != study_key
+
+
+def test_shared_rapidocr_backend_close_releases_plugin_scoped_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = object()
+    install_target_dir = str(tmp_path / "RapidOCR")
+    monkeypatch.setattr(
+        "plugin.plugins._shared.rapidocr.ocr_rapidocr_backend.load_rapidocr_runtime",
+        lambda **_kwargs: (runtime, {}),
+    )
+    backend = RapidOcrBackend(
+        install_target_dir_raw=install_target_dir,
+        engine_type="onnxruntime",
+        lang_type="ch",
+        model_type="mobile",
+        ocr_version="PP-OCRv5",
+        plugin_id="study_companion",
+    )
+    second = RapidOcrBackend(
+        install_target_dir_raw=install_target_dir,
+        engine_type="onnxruntime",
+        lang_type="ch",
+        model_type="mobile",
+        ocr_version="PP-OCRv5",
+        plugin_id="study_companion",
+    )
+    key = _rapidocr_runtime_cache_key(
+        install_target_dir_raw=install_target_dir,
+        engine_type="onnxruntime",
+        lang_type="ch",
+        model_type="mobile",
+        ocr_version="PP-OCRv5",
+        plugin_id="study_companion",
+    )
+
+    assert backend._ensure_runtime() is runtime
+    assert second._ensure_runtime() is runtime
+    assert _RAPIDOCR_RUNTIME_CACHE[key][0] is runtime
+
+    backend.close()
+
+    assert _RAPIDOCR_RUNTIME_CACHE[key][0] is runtime
+
+    second.close()
+
+    assert key not in _RAPIDOCR_RUNTIME_CACHE
 
 
 def test_default_rapidocr_install_target_rejects_path_traversal_plugin_id(

--- a/plugin/tests/unit/plugins/test_galgame_vision_classifier.py
+++ b/plugin/tests/unit/plugins/test_galgame_vision_classifier.py
@@ -160,6 +160,10 @@ def test_vision_model_loader_caches_and_reloads_sessions(tmp_path, monkeypatch) 
     assert reloaded is not first
     assert created == [str(model_path), str(model_path)]
 
+    loader.close()
+
+    assert loader._sessions == {}
+
 
 def test_vision_model_loader_rejects_path_traversal_model_names(tmp_path, monkeypatch) -> None:
     class _FakeOrt:

--- a/plugin/tests/unit/plugins/test_study_companion_study_ocr_pipeline.py
+++ b/plugin/tests/unit/plugins/test_study_companion_study_ocr_pipeline.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from concurrent.futures import Future
+import subprocess
+import sys
 from types import SimpleNamespace
 from typing import Any
 
@@ -189,6 +191,20 @@ def test_ocr_pipeline_imagehash_module_import_is_optional(
     assert StudyOcrPipeline._calculate_thumbnail_phash(
         Image.new("RGB", (16, 16), "white")
     ) is None
+
+
+def test_study_plugin_registration_import_does_not_load_numpy() -> None:
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; import plugin.plugins.study_companion; "
+                "raise SystemExit(1 if 'numpy' in sys.modules else 0)"
+            ),
+        ],
+        check=True,
+    )
 
 
 def test_ocr_pipeline_capture_lightweight_allows_missing_imagehash(
@@ -415,6 +431,33 @@ def test_ocr_pipeline_reuses_executor_and_closes_it(
 
     assert len(created) == 1
     assert created[0].shutdown_calls == 1
+
+
+def test_ocr_pipeline_close_releases_only_owned_backend() -> None:
+    class _ClosableBackend:
+        def __init__(self) -> None:
+            self.close_calls = 0
+
+        def close(self) -> None:
+            self.close_calls += 1
+
+    external = _ClosableBackend()
+    external_pipeline = StudyOcrPipeline(
+        logger=_Logger(),
+        config=StudyConfig(),
+        ocr_backend=external,
+    )
+    external_pipeline.close()
+    assert external.close_calls == 0
+
+    owned = _ClosableBackend()
+    owned_pipeline = StudyOcrPipeline(logger=_Logger(), config=StudyConfig())
+    owned_pipeline._ocr_backend = owned
+    owned_pipeline._owns_ocr_backend = True
+    owned_pipeline.close()
+    owned_pipeline.close()
+
+    assert owned.close_calls == 1
 
 
 def test_ocr_pipeline_capture_lightweight_content_change_and_failure_paths() -> None:

--- a/plugin/tests/unit/plugins/test_study_companion_study_ocr_pipeline.py
+++ b/plugin/tests/unit/plugins/test_study_companion_study_ocr_pipeline.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from concurrent.futures import Future
 import subprocess
 import sys
+import threading
 from types import SimpleNamespace
 from typing import Any
 
@@ -403,7 +404,7 @@ def test_ocr_pipeline_reuses_executor_and_closes_it(
 
     class _FakeExecutor:
         def __init__(self, *args: Any, **kwargs: Any) -> None:
-            self.shutdown_calls = 0
+            self.shutdown_waits: list[bool] = []
             created.append(self)
 
         def submit(self, fn, /, *args: Any, **kwargs: Any):  # noqa: ANN001
@@ -415,7 +416,7 @@ def test_ocr_pipeline_reuses_executor_and_closes_it(
             return future
 
         def shutdown(self, *, wait: bool = True) -> None:
-            self.shutdown_calls += 1
+            self.shutdown_waits.append(wait)
 
     monkeypatch.setattr(pipeline_module, "ThreadPoolExecutor", _FakeExecutor)
     pipeline = StudyOcrPipeline(
@@ -432,7 +433,61 @@ def test_ocr_pipeline_reuses_executor_and_closes_it(
     pipeline.close()
 
     assert len(created) == 1
-    assert created[0].shutdown_calls == 1
+    assert created[0].shutdown_waits == [True]
+
+
+def test_ocr_pipeline_close_drains_work_before_releasing_owned_backend() -> None:
+    image = Image.new("RGB", (800, 600), "white")
+    extraction_started = threading.Event()
+    release_extraction = threading.Event()
+
+    class _ClosableBackend(_Backend):
+        def __init__(self) -> None:
+            super().__init__("Question: text")
+            self.close_calls = 0
+
+        def extract_text(self, image: Any) -> Any:
+            extraction_started.set()
+            assert release_extraction.wait(timeout=2.0)
+            return super().extract_text(image)
+
+        def close(self) -> None:
+            self.close_calls += 1
+
+    backend = _ClosableBackend()
+    pipeline = StudyOcrPipeline(
+        logger=_Logger(),
+        config=StudyConfig(
+            awareness=AwarenessConfig(classify_mode="ocr_text", image_max_bytes=80_000)
+        ),
+        ocr_backend=backend,
+        capture_backend=_Capture(image),
+    )
+    pipeline._owns_ocr_backend = True
+    capture_thread = threading.Thread(
+        target=pipeline.capture_lightweight,
+        kwargs={"target": {"hwnd": 1, "title": "Quiz"}},
+    )
+    capture_thread.start()
+    assert extraction_started.wait(timeout=2.0)
+
+    close_thread = threading.Thread(target=pipeline.close)
+    close_thread.start()
+    close_thread.join(timeout=0.05)
+
+    assert close_thread.is_alive()
+    assert backend.close_calls == 0
+
+    release_extraction.set()
+    capture_thread.join(timeout=2.0)
+    close_thread.join(timeout=2.0)
+
+    assert not capture_thread.is_alive()
+    assert not close_thread.is_alive()
+    assert backend.close_calls == 1
+    assert pipeline._ocr_backend is None
+    with pytest.raises(RuntimeError, match="pipeline is closed"):
+        pipeline._resolve_ocr_backend()
 
 
 def test_ocr_pipeline_close_releases_only_owned_backend() -> None:

--- a/plugin/tests/unit/plugins/test_study_companion_study_ocr_pipeline.py
+++ b/plugin/tests/unit/plugins/test_study_companion_study_ocr_pipeline.py
@@ -83,10 +83,11 @@ def test_ocr_pipeline_normalizes_strings_dicts_objects_and_join_fallback(
 
 def test_ocr_pipeline_capture_target_uses_profile_and_resets_backends_on_config_update() -> None:
     capture = _Capture("frame")
+    backend = _Backend([{"text": "hello"}, {"text": "world"}])
     pipeline = StudyOcrPipeline(
         logger=_Logger(),
         config=StudyConfig(ocr_left_inset_ratio=0.2, ocr_capture_backend=CAPTURE_BACKEND_DXCAM),
-        ocr_backend=_Backend([{"text": "hello"}, {"text": "world"}]),
+        ocr_backend=backend,
         capture_backend=capture,
     )
 
@@ -96,7 +97,8 @@ def test_ocr_pipeline_capture_target_uses_profile_and_resets_backends_on_config_
     assert snapshot.status == "ok"
     assert "hello" in snapshot.text
     assert capture.calls[0][1].left_inset_ratio == 0.2
-    assert pipeline._ocr_backend is None
+    assert pipeline._ocr_backend is backend
+    assert pipeline._owns_ocr_backend is False
     assert pipeline._capture_backend is None
 
 

--- a/tests/unit/test_agent_browser_lifecycle.py
+++ b/tests/unit/test_agent_browser_lifecycle.py
@@ -113,7 +113,8 @@ async def test_browser_use_disable_schedules_close_outside_flag_request(
         assert close_calls == []
         assert len(scheduled) == 1
 
-        await scheduled[0]
+        task_result = await scheduled[0]
+        assert task_result is None
         assert close_calls == [True]
     finally:
         modules.agent_flags.clear()
@@ -134,6 +135,7 @@ async def test_browser_use_adapter_is_single_flight_and_explicitly_closed(
 
     class _FakeAdapter:
         def __init__(self) -> None:
+            self._ready_import = True
             self.close_calls = 0
             created.append(self)
 
@@ -163,6 +165,81 @@ async def test_browser_use_adapter_is_single_flight_and_explicitly_closed(
     finally:
         modules.browser_use = original_adapter
         modules.task_executor = original_executor
+        modules.browser_use_init_lock = original_lock
+        modules.capability_cache["browser_use"] = original_capability
+
+
+@pytest.mark.asyncio
+async def test_browser_use_failed_import_is_not_cached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modules = capabilities._shared.Modules
+    original_adapter = modules.browser_use
+    original_lock = modules.browser_use_init_lock
+    original_capability = dict(modules.capability_cache["browser_use"])
+    created = []
+
+    class _FailedAdapter:
+        def __init__(self) -> None:
+            self._ready_import = False
+            self.last_error = "browser-use import failed"
+            created.append(self)
+
+    monkeypatch.setattr(capabilities, "BrowserUseAdapter", _FailedAdapter)
+    modules.browser_use = None
+    modules.browser_use_init_lock = None
+    try:
+        assert await capabilities._ensure_browser_use_adapter() is None
+        assert await capabilities._ensure_browser_use_adapter() is None
+        assert modules.browser_use is None
+        assert len(created) == 2
+        assert modules.capability_cache["browser_use"]["reason"] == "AGENT_BU_MODULE_NOT_LOADED"
+    finally:
+        modules.browser_use = original_adapter
+        modules.browser_use_init_lock = original_lock
+        modules.capability_cache["browser_use"] = original_capability
+
+
+@pytest.mark.asyncio
+async def test_browser_use_ensure_waits_for_teardown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modules = capabilities._shared.Modules
+    original_adapter = modules.browser_use
+    original_lock = modules.browser_use_init_lock
+    original_capability = dict(modules.capability_cache["browser_use"])
+    close_started = asyncio.Event()
+    release_close = asyncio.Event()
+    created = []
+
+    class _FakeAdapter:
+        def __init__(self) -> None:
+            self._ready_import = True
+            created.append(self)
+
+        async def close(self) -> None:
+            close_started.set()
+            await release_close.wait()
+
+    closing_adapter = _FakeAdapter()
+    monkeypatch.setattr(capabilities, "BrowserUseAdapter", _FakeAdapter)
+    modules.browser_use = closing_adapter
+    modules.browser_use_init_lock = None
+    try:
+        close_task = asyncio.create_task(capabilities._close_browser_use_adapter())
+        await close_started.wait()
+        ensure_task = asyncio.create_task(capabilities._ensure_browser_use_adapter())
+        await asyncio.sleep(0)
+
+        assert not ensure_task.done()
+        release_close.set()
+        assert await close_task is None
+        replacement = await ensure_task
+        assert replacement is created[1]
+        assert replacement is not closing_adapter
+    finally:
+        release_close.set()
+        modules.browser_use = original_adapter
         modules.browser_use_init_lock = original_lock
         modules.capability_cache["browser_use"] = original_capability
 

--- a/tests/unit/test_agent_browser_lifecycle.py
+++ b/tests/unit/test_agent_browser_lifecycle.py
@@ -10,9 +10,72 @@ from brain.browser_use_adapter import BrowserUseAdapter
 
 
 capabilities = importlib.import_module("app.agent_server.capabilities")
+api_routes = importlib.import_module("app.agent_server.api_routes")
 
 
 pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_browser_use_availability_does_not_construct_adapter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modules = capabilities._shared.Modules
+    original_computer_use = modules.computer_use
+    original_capability = dict(modules.capability_cache["browser_use"])
+
+    async def _unexpected_init():
+        raise AssertionError("availability polling must not construct BrowserUseAdapter")
+
+    monkeypatch.setattr(api_routes, "_check_agent_api_gate", lambda: {"ready": True})
+    monkeypatch.setattr(api_routes, "_browser_use_dependency_status", lambda: (True, ""))
+    monkeypatch.setattr(api_routes, "_ensure_browser_use_adapter", _unexpected_init)
+    modules.computer_use = SimpleNamespace(init_ok=True, last_error=None)
+    try:
+        status = await api_routes.browser_use_availability()
+
+        assert status["ready"] is True
+        assert status["provider"] == "browser-use"
+    finally:
+        modules.computer_use = original_computer_use
+        modules.capability_cache["browser_use"] = original_capability
+
+
+@pytest.mark.asyncio
+async def test_browser_use_enable_returns_without_constructing_adapter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modules = capabilities._shared.Modules
+    original_computer_use = modules.computer_use
+    original_flags = dict(modules.agent_flags)
+    original_notification = modules.notification
+    original_capability = dict(modules.capability_cache["browser_use"])
+
+    async def _unexpected_init():
+        raise AssertionError("the short flag request must not construct BrowserUseAdapter")
+
+    async def _ignore_status_update(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(api_routes, "_check_agent_api_gate", lambda: {"ready": True})
+    monkeypatch.setattr(api_routes, "_browser_use_dependency_status", lambda: (True, ""))
+    monkeypatch.setattr(api_routes, "_ensure_browser_use_adapter", _unexpected_init)
+    monkeypatch.setattr(api_routes, "_emit_agent_status_update", _ignore_status_update)
+    modules.computer_use = SimpleNamespace(init_ok=True, last_error=None)
+    modules.agent_flags["browser_use_enabled"] = False
+    try:
+        result = await api_routes.set_agent_flags(
+            {"browser_use_enabled": True, "_persist_intent": False}
+        )
+
+        assert result["success"] is True
+        assert modules.agent_flags["browser_use_enabled"] is True
+    finally:
+        modules.computer_use = original_computer_use
+        modules.agent_flags.clear()
+        modules.agent_flags.update(original_flags)
+        modules.notification = original_notification
+        modules.capability_cache["browser_use"] = original_capability
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_agent_browser_lifecycle.py
+++ b/tests/unit/test_agent_browser_lifecycle.py
@@ -79,6 +79,49 @@ async def test_browser_use_enable_returns_without_constructing_adapter(
 
 
 @pytest.mark.asyncio
+async def test_browser_use_disable_schedules_close_outside_flag_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modules = capabilities._shared.Modules
+    original_flags = dict(modules.agent_flags)
+    original_notification = modules.notification
+    scheduled = []
+    close_calls = []
+
+    async def _close_adapter():
+        close_calls.append(True)
+
+    async def _ignore_status_update(*_args, **_kwargs):
+        return None
+
+    def _capture_task(coro):
+        scheduled.append(coro)
+        return None
+
+    monkeypatch.setattr(api_routes, "_check_agent_api_gate", lambda: {"ready": True})
+    monkeypatch.setattr(api_routes, "_close_browser_use_adapter", _close_adapter)
+    monkeypatch.setattr(api_routes, "_create_tracked_task", _capture_task)
+    monkeypatch.setattr(api_routes, "_emit_agent_status_update", _ignore_status_update)
+    modules.agent_flags["browser_use_enabled"] = True
+    try:
+        result = await api_routes.set_agent_flags(
+            {"browser_use_enabled": False, "_persist_intent": False}
+        )
+
+        assert result["success"] is True
+        assert modules.agent_flags["browser_use_enabled"] is False
+        assert close_calls == []
+        assert len(scheduled) == 1
+
+        await scheduled[0]
+        assert close_calls == [True]
+    finally:
+        modules.agent_flags.clear()
+        modules.agent_flags.update(original_flags)
+        modules.notification = original_notification
+
+
+@pytest.mark.asyncio
 async def test_browser_use_adapter_is_single_flight_and_explicitly_closed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_agent_browser_lifecycle.py
+++ b/tests/unit/test_agent_browser_lifecycle.py
@@ -269,8 +269,9 @@ async def test_cancelled_browser_use_close_keeps_adapter_for_shutdown_retry() ->
         close_task = asyncio.create_task(capabilities._close_browser_use_adapter())
         await close_started.wait()
         close_task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await close_task
+        cancelled_result = await asyncio.gather(close_task, return_exceptions=True)
+        assert len(cancelled_result) == 1
+        assert isinstance(cancelled_result[0], asyncio.CancelledError)
 
         assert modules.browser_use is adapter
         release_close.set()

--- a/tests/unit/test_agent_browser_lifecycle.py
+++ b/tests/unit/test_agent_browser_lifecycle.py
@@ -245,6 +245,46 @@ async def test_browser_use_ensure_waits_for_teardown(
 
 
 @pytest.mark.asyncio
+async def test_cancelled_browser_use_close_keeps_adapter_for_shutdown_retry() -> None:
+    modules = capabilities._shared.Modules
+    original_adapter = modules.browser_use
+    original_lock = modules.browser_use_init_lock
+    original_capability = dict(modules.capability_cache["browser_use"])
+    close_started = asyncio.Event()
+    release_close = asyncio.Event()
+
+    class _Adapter:
+        def __init__(self) -> None:
+            self.close_calls = 0
+
+        async def close(self) -> None:
+            self.close_calls += 1
+            close_started.set()
+            await release_close.wait()
+
+    adapter = _Adapter()
+    modules.browser_use = adapter
+    modules.browser_use_init_lock = None
+    try:
+        close_task = asyncio.create_task(capabilities._close_browser_use_adapter())
+        await close_started.wait()
+        close_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await close_task
+
+        assert modules.browser_use is adapter
+        release_close.set()
+        assert await capabilities._close_browser_use_adapter() is None
+        assert adapter.close_calls == 2
+        assert modules.browser_use is None
+    finally:
+        release_close.set()
+        modules.browser_use = original_adapter
+        modules.browser_use_init_lock = original_lock
+        modules.capability_cache["browser_use"] = original_capability
+
+
+@pytest.mark.asyncio
 async def test_browser_adapter_close_stops_keep_alive_session() -> None:
     class _Session:
         def __init__(self) -> None:

--- a/tests/unit/test_agent_browser_lifecycle.py
+++ b/tests/unit/test_agent_browser_lifecycle.py
@@ -216,14 +216,53 @@ async def test_browser_use_normal_close_preserves_dependency_capability(
 
 
 @pytest.mark.asyncio
+async def test_browser_use_close_waits_for_active_dispatch() -> None:
+    modules = capabilities._shared.Modules
+    original_adapter = modules.browser_use
+    original_dispatch_lock = modules.browser_use_dispatch_lock
+    original_init_lock = modules.browser_use_init_lock
+    original_capability = dict(modules.capability_cache["browser_use"])
+    close_called = asyncio.Event()
+
+    class _Adapter:
+        async def close(self) -> None:
+            close_called.set()
+
+    dispatch_lock = asyncio.Lock()
+    await dispatch_lock.acquire()
+    modules.browser_use = _Adapter()
+    modules.browser_use_dispatch_lock = dispatch_lock
+    modules.browser_use_init_lock = None
+    try:
+        close_task = asyncio.create_task(capabilities._close_browser_use_adapter())
+        await asyncio.sleep(0)
+
+        assert not close_called.is_set()
+        assert not close_task.done()
+
+        dispatch_lock.release()
+        assert await close_task is None
+        assert close_called.is_set()
+        assert modules.browser_use is None
+    finally:
+        if dispatch_lock.locked():
+            dispatch_lock.release()
+        modules.browser_use = original_adapter
+        modules.browser_use_dispatch_lock = original_dispatch_lock
+        modules.browser_use_init_lock = original_init_lock
+        modules.capability_cache["browser_use"] = original_capability
+
+
+@pytest.mark.asyncio
 async def test_browser_use_reenable_stays_ready_after_pending_close(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     modules = capabilities._shared.Modules
     original_adapter = modules.browser_use
     original_computer_use = modules.computer_use
-    original_lock = modules.browser_use_init_lock
-    original_close_task = modules.browser_use_close_task
+    original_init_lock = modules.browser_use_init_lock
+    original_dispatch_lock = modules.browser_use_dispatch_lock
+    original_lifecycle_seq = modules.browser_use_lifecycle_seq
     original_flags = dict(modules.agent_flags)
     original_notification = modules.notification
     original_capability = dict(modules.capability_cache["browser_use"])
@@ -254,6 +293,7 @@ async def test_browser_use_reenable_stays_ready_after_pending_close(
     modules.browser_use = _Adapter()
     modules.computer_use = SimpleNamespace(init_ok=True, last_error=None)
     modules.browser_use_init_lock = None
+    modules.browser_use_dispatch_lock = None
     modules.agent_flags["browser_use_enabled"] = True
     try:
         await api_routes.set_agent_flags(
@@ -266,11 +306,12 @@ async def test_browser_use_reenable_stays_ready_after_pending_close(
                 {"browser_use_enabled": True, "_persist_intent": False}
             )
         )
-        await asyncio.sleep(0)
-        assert not enable_task.done()
+        result = await asyncio.wait_for(enable_task, timeout=0.2)
+        assert result["success"] is True
+        assert modules.agent_flags["browser_use_enabled"] is True
+        assert modules.capability_cache["browser_use"] == {"ready": True, "reason": ""}
 
         release_close.set()
-        await enable_task
         await asyncio.gather(*tasks)
 
         assert modules.browser_use is None
@@ -282,8 +323,9 @@ async def test_browser_use_reenable_stays_ready_after_pending_close(
             await asyncio.gather(*tasks, return_exceptions=True)
         modules.browser_use = original_adapter
         modules.computer_use = original_computer_use
-        modules.browser_use_init_lock = original_lock
-        modules.browser_use_close_task = original_close_task
+        modules.browser_use_init_lock = original_init_lock
+        modules.browser_use_dispatch_lock = original_dispatch_lock
+        modules.browser_use_lifecycle_seq = original_lifecycle_seq
         modules.agent_flags.clear()
         modules.agent_flags.update(original_flags)
         modules.notification = original_notification

--- a/tests/unit/test_agent_browser_lifecycle.py
+++ b/tests/unit/test_agent_browser_lifecycle.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import asyncio
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+from brain.browser_use_adapter import BrowserUseAdapter
+
+
+capabilities = importlib.import_module("app.agent_server.capabilities")
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_browser_use_adapter_is_single_flight_and_explicitly_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modules = capabilities._shared.Modules
+    original_adapter = modules.browser_use
+    original_executor = modules.task_executor
+    original_lock = modules.browser_use_init_lock
+    original_capability = dict(modules.capability_cache["browser_use"])
+    created = []
+
+    class _FakeAdapter:
+        def __init__(self) -> None:
+            self.close_calls = 0
+            created.append(self)
+
+        async def close(self) -> None:
+            self.close_calls += 1
+
+    monkeypatch.setattr(capabilities, "BrowserUseAdapter", _FakeAdapter)
+    modules.browser_use = None
+    modules.browser_use_init_lock = None
+    modules.task_executor = SimpleNamespace(browser_use=None)
+    try:
+        first, second = await asyncio.gather(
+            capabilities._ensure_browser_use_adapter(),
+            capabilities._ensure_browser_use_adapter(),
+        )
+
+        assert first is second
+        assert created == [first]
+        assert modules.task_executor.browser_use is first
+
+        await capabilities._close_browser_use_adapter()
+        await capabilities._close_browser_use_adapter()
+
+        assert first.close_calls == 1
+        assert modules.browser_use is None
+        assert modules.task_executor.browser_use is None
+    finally:
+        modules.browser_use = original_adapter
+        modules.task_executor = original_executor
+        modules.browser_use_init_lock = original_lock
+        modules.capability_cache["browser_use"] = original_capability
+
+
+@pytest.mark.asyncio
+async def test_browser_adapter_close_stops_keep_alive_session() -> None:
+    class _Session:
+        def __init__(self) -> None:
+            self.stop_calls = 0
+
+        async def stop(self) -> None:
+            self.stop_calls += 1
+
+    adapter = object.__new__(BrowserUseAdapter)
+    session = _Session()
+    adapter._overlay_task = None
+    adapter._browser_session = session
+    adapter._session_ever_started = True
+    adapter._agents = {"session": object()}
+
+    await adapter.close()
+
+    assert session.stop_calls == 1
+    assert adapter._browser_session is None
+    assert adapter._session_ever_started is False
+    assert adapter._agents == {}

--- a/tests/unit/test_agent_browser_lifecycle.py
+++ b/tests/unit/test_agent_browser_lifecycle.py
@@ -79,6 +79,72 @@ async def test_browser_use_enable_returns_without_constructing_adapter(
 
 
 @pytest.mark.asyncio
+async def test_llm_probe_keeps_unloaded_browser_use_ready_when_dependencies_exist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modules = capabilities._shared.Modules
+    original_computer_use = modules.computer_use
+    original_browser_use = modules.browser_use
+    original_capability = dict(modules.capability_cache["browser_use"])
+
+    class _ComputerUse:
+        @staticmethod
+        def check_connectivity():
+            return True, ""
+
+    async def _ignore_status_update(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(capabilities, "_browser_use_dependency_status", lambda: (True, ""))
+    monkeypatch.setattr(capabilities, "_emit_agent_status_update", _ignore_status_update)
+    modules.computer_use = _ComputerUse()
+    modules.browser_use = None
+    try:
+        await capabilities._fire_agent_llm_connectivity_check()
+
+        assert modules.capability_cache["browser_use"]["ready"] is True
+        assert modules.capability_cache["browser_use"]["reason"] == ""
+    finally:
+        modules.computer_use = original_computer_use
+        modules.browser_use = original_browser_use
+        modules.capability_cache["browser_use"] = original_capability
+
+
+@pytest.mark.asyncio
+async def test_direct_browser_run_keeps_adapter_returned_by_initializer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modules = capabilities._shared.Modules
+    original_adapter = modules.browser_use
+    original_lock = modules.browser_use_dispatch_lock
+    calls: list[str] = []
+
+    class _Adapter:
+        async def run_instruction(self, instruction: str):
+            calls.append(instruction)
+            return {"success": True}
+
+    adapter = _Adapter()
+
+    async def _ensure_adapter():
+        # Simulate an asynchronous disable clearing the process singleton
+        # after initialization but before the dispatch coroutine runs.
+        modules.browser_use = None
+        return adapter
+
+    monkeypatch.setattr(api_routes, "_ensure_browser_use_adapter", _ensure_adapter)
+    modules.browser_use_dispatch_lock = None
+    try:
+        result = await api_routes.browser_use_run({"instruction": "open example"})
+
+        assert result["success"] is True
+        assert calls == ["open example"]
+    finally:
+        modules.browser_use = original_adapter
+        modules.browser_use_dispatch_lock = original_lock
+
+
+@pytest.mark.asyncio
 async def test_browser_use_disable_schedules_close_outside_flag_request(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_agent_browser_lifecycle.py
+++ b/tests/unit/test_agent_browser_lifecycle.py
@@ -154,7 +154,7 @@ async def test_browser_use_disable_schedules_close_outside_flag_request(
     scheduled = []
     close_calls = []
 
-    async def _close_adapter():
+    async def _close_adapter(**_kwargs):
         close_calls.append(True)
 
     async def _ignore_status_update(*_args, **_kwargs):
@@ -186,6 +186,108 @@ async def test_browser_use_disable_schedules_close_outside_flag_request(
         modules.agent_flags.clear()
         modules.agent_flags.update(original_flags)
         modules.notification = original_notification
+
+
+@pytest.mark.asyncio
+async def test_browser_use_normal_close_preserves_dependency_capability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modules = capabilities._shared.Modules
+    original_adapter = modules.browser_use
+    original_lock = modules.browser_use_init_lock
+    original_capability = dict(modules.capability_cache["browser_use"])
+
+    class _Adapter:
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(capabilities, "_browser_use_dependency_status", lambda: (True, ""))
+    modules.browser_use = _Adapter()
+    modules.browser_use_init_lock = None
+    try:
+        await capabilities._close_browser_use_adapter()
+
+        assert modules.browser_use is None
+        assert modules.capability_cache["browser_use"] == {"ready": True, "reason": ""}
+    finally:
+        modules.browser_use = original_adapter
+        modules.browser_use_init_lock = original_lock
+        modules.capability_cache["browser_use"] = original_capability
+
+
+@pytest.mark.asyncio
+async def test_browser_use_reenable_stays_ready_after_pending_close(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modules = capabilities._shared.Modules
+    original_adapter = modules.browser_use
+    original_computer_use = modules.computer_use
+    original_lock = modules.browser_use_init_lock
+    original_close_task = modules.browser_use_close_task
+    original_flags = dict(modules.agent_flags)
+    original_notification = modules.notification
+    original_capability = dict(modules.capability_cache["browser_use"])
+    close_started = asyncio.Event()
+    release_close = asyncio.Event()
+    tasks: list[asyncio.Task] = []
+
+    class _Adapter:
+        _ready_import = True
+
+        async def close(self) -> None:
+            close_started.set()
+            await release_close.wait()
+
+    async def _ignore_status_update(*_args, **_kwargs):
+        return None
+
+    def _capture_task(coro):
+        task = asyncio.create_task(coro)
+        tasks.append(task)
+        return task
+
+    monkeypatch.setattr(api_routes, "_check_agent_api_gate", lambda: {"ready": True})
+    monkeypatch.setattr(api_routes, "_browser_use_dependency_status", lambda: (True, ""))
+    monkeypatch.setattr(capabilities, "_browser_use_dependency_status", lambda: (True, ""))
+    monkeypatch.setattr(api_routes, "_create_tracked_task", _capture_task)
+    monkeypatch.setattr(api_routes, "_emit_agent_status_update", _ignore_status_update)
+    modules.browser_use = _Adapter()
+    modules.computer_use = SimpleNamespace(init_ok=True, last_error=None)
+    modules.browser_use_init_lock = None
+    modules.agent_flags["browser_use_enabled"] = True
+    try:
+        await api_routes.set_agent_flags(
+            {"browser_use_enabled": False, "_persist_intent": False}
+        )
+        await close_started.wait()
+
+        enable_task = asyncio.create_task(
+            api_routes.set_agent_flags(
+                {"browser_use_enabled": True, "_persist_intent": False}
+            )
+        )
+        await asyncio.sleep(0)
+        assert not enable_task.done()
+
+        release_close.set()
+        await enable_task
+        await asyncio.gather(*tasks)
+
+        assert modules.browser_use is None
+        assert modules.agent_flags["browser_use_enabled"] is True
+        assert modules.capability_cache["browser_use"] == {"ready": True, "reason": ""}
+    finally:
+        release_close.set()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        modules.browser_use = original_adapter
+        modules.computer_use = original_computer_use
+        modules.browser_use_init_lock = original_lock
+        modules.browser_use_close_task = original_close_task
+        modules.agent_flags.clear()
+        modules.agent_flags.update(original_flags)
+        modules.notification = original_notification
+        modules.capability_cache["browser_use"] = original_capability
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_agent_end_all_notify.py
+++ b/tests/unit/test_agent_end_all_notify.py
@@ -171,3 +171,32 @@ def test_end_all_cancels_orphan_dispatch_handles(srv):
         assert orphan.cancelled()
 
     asyncio.run(_scenario())
+
+
+def test_end_all_retries_browser_close_after_cancelling_tracked_teardown(
+    srv, monkeypatch: pytest.MonkeyPatch,
+):
+    M = srv.Modules
+    teardown_cancelled = asyncio.Event()
+    retried = AsyncMock()
+    monkeypatch.setattr(srv, "_close_browser_use_adapter", retried)
+
+    async def _pending_teardown():
+        try:
+            await asyncio.sleep(3600)
+        finally:
+            teardown_cancelled.set()
+
+    async def _scenario():
+        pending = asyncio.create_task(_pending_teardown())
+        M._background_tasks.add(pending)
+        await asyncio.sleep(0)
+
+        result = await srv.admin_control({"action": "end_all"})
+
+        assert result["success"] is True
+        assert pending.cancelled()
+        assert teardown_cancelled.is_set()
+        retried.assert_awaited_once_with(update_capability=False)
+
+    asyncio.run(_scenario())

--- a/tests/unit/test_audio_processor_lifecycle.py
+++ b/tests/unit/test_audio_processor_lifecycle.py
@@ -122,6 +122,41 @@ async def test_audio_close_waits_for_executor_chunk_processing() -> None:
 
 
 @pytest.mark.asyncio
+async def test_live_noise_reduction_toggle_waits_for_chunk_processing() -> None:
+    processing_started = threading.Event()
+    release_processing = threading.Event()
+
+    class _Processor:
+        def __init__(self) -> None:
+            self.enabled_calls: list[bool] = []
+
+        def process_chunk(self, audio_chunk: bytes) -> bytes:
+            processing_started.set()
+            assert release_processing.wait(timeout=2.0)
+            return audio_chunk
+
+        def set_enabled(self, enabled: bool) -> None:
+            self.enabled_calls.append(enabled)
+
+    client = object.__new__(OmniRealtimeClient)
+    processor = _Processor()
+    client._audio_processor = processor
+    client._audio_processing_lock = asyncio.Lock()
+
+    process_task = asyncio.create_task(client.process_audio_chunk_async(b"chunk"))
+    assert await asyncio.to_thread(processing_started.wait, 2.0)
+    toggle_task = asyncio.create_task(client.set_audio_noise_reduction_enabled(False))
+    await asyncio.sleep(0)
+
+    assert processor.enabled_calls == []
+    release_processing.set()
+
+    assert await process_task == b"chunk"
+    assert await toggle_task is None
+    assert processor.enabled_calls == [False]
+
+
+@pytest.mark.asyncio
 async def test_audio_close_failure_does_not_escape_cleanup() -> None:
     class _Processor:
         def save_debug_audio(self) -> None:

--- a/tests/unit/test_audio_processor_lifecycle.py
+++ b/tests/unit/test_audio_processor_lifecycle.py
@@ -182,6 +182,27 @@ def test_recreated_audio_processor_preserves_noise_reduction_preference(
     assert created[0]["noise_reduce_enabled"] is False
 
 
+def test_initial_audio_processor_honors_noise_reduction_preference(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created: list[dict[str, object]] = []
+
+    def _create_processor(**kwargs):
+        created.append(kwargs)
+        return object()
+
+    monkeypatch.setattr(client_module, "AudioProcessor", _create_processor)
+
+    client = OmniRealtimeClient(
+        base_url="",
+        api_key="",
+        noise_reduction_enabled=False,
+    )
+
+    assert client._noise_reduction_enabled is False
+    assert created[0]["noise_reduce_enabled"] is False
+
+
 @pytest.mark.asyncio
 async def test_audio_close_failure_does_not_escape_cleanup() -> None:
     class _Processor:

--- a/tests/unit/test_audio_processor_lifecycle.py
+++ b/tests/unit/test_audio_processor_lifecycle.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import numpy as np
+
+from utils.audio_processor import AudioProcessor, _LiteDenoiser
+
+
+class _FakeRnnoise:
+    def __init__(self) -> None:
+        self.destroyed: list[object] = []
+
+    def create(self) -> object:
+        return object()
+
+    def destroy(self, state: object) -> None:
+        self.destroyed.append(state)
+
+
+def test_lite_denoiser_close_destroys_native_state_once() -> None:
+    library = _FakeRnnoise()
+    denoiser = _LiteDenoiser(library)
+    state = denoiser._state
+
+    denoiser.close()
+    denoiser.close()
+
+    assert library.destroyed == [state]
+    assert denoiser._state is None
+
+
+def test_audio_processor_close_releases_owned_buffers_and_denoiser() -> None:
+    class _Denoiser:
+        def __init__(self) -> None:
+            self.close_calls = 0
+
+        def close(self) -> None:
+            self.close_calls += 1
+
+    processor = object.__new__(AudioProcessor)
+    denoiser = _Denoiser()
+    processor._denoiser = denoiser
+    processor._downsample_resampler = object()
+    processor._frame_buffer = np.ones(4, dtype=np.int16)
+    processor._debug_audio_before = [np.ones(1, dtype=np.int16)]
+    processor._debug_audio_after = [np.ones(1, dtype=np.int16)]
+
+    processor.close()
+    processor.close()
+
+    assert denoiser.close_calls == 1
+    assert processor._denoiser is None
+    assert processor._downsample_resampler is None
+    assert processor._frame_buffer.size == 0
+    assert processor._debug_audio_before == []
+    assert processor._debug_audio_after == []
+
+
+def test_disabling_noise_reduction_releases_native_denoiser() -> None:
+    class _Denoiser:
+        def __init__(self) -> None:
+            self.close_calls = 0
+
+        def close(self) -> None:
+            self.close_calls += 1
+
+    processor = object.__new__(AudioProcessor)
+    denoiser = _Denoiser()
+    processor.noise_reduce_enabled = True
+    processor._denoiser = denoiser
+    processor._frame_buffer = np.ones(4, dtype=np.int16)
+    processor._agc_gain = 2.0
+
+    processor.set_enabled(False)
+
+    assert denoiser.close_calls == 1
+    assert processor._denoiser is None
+    assert processor._frame_buffer.size == 0

--- a/tests/unit/test_audio_processor_lifecycle.py
+++ b/tests/unit/test_audio_processor_lifecycle.py
@@ -171,7 +171,7 @@ async def test_cancelled_audio_processing_keeps_lock_until_worker_finishes() -> 
 
     release_processing.set()
     with pytest.raises(asyncio.CancelledError):
-        await process_task
+        _ = await process_task
     assert await close_task is None
     assert processor.close_calls == 1
     assert client._audio_processor is None

--- a/tests/unit/test_audio_processor_lifecycle.py
+++ b/tests/unit/test_audio_processor_lifecycle.py
@@ -116,6 +116,23 @@ async def test_audio_close_waits_for_executor_chunk_processing() -> None:
     release_processing.set()
 
     assert await process_task == b"chunk"
-    await close_task
+    assert await close_task is None
     assert processor.close_calls == 1
+    assert client._audio_processor is None
+
+
+@pytest.mark.asyncio
+async def test_audio_close_failure_does_not_escape_cleanup() -> None:
+    class _Processor:
+        def save_debug_audio(self) -> None:
+            return None
+
+        def close(self) -> None:
+            raise RuntimeError("native close failed")
+
+    client = object.__new__(OmniRealtimeClient)
+    client._audio_processor = _Processor()
+    client._audio_processing_lock = asyncio.Lock()
+
+    assert await client._close_audio_processor() is None
     assert client._audio_processor is None

--- a/tests/unit/test_audio_processor_lifecycle.py
+++ b/tests/unit/test_audio_processor_lifecycle.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
-import numpy as np
+import asyncio
+import threading
 
+import numpy as np
+import pytest
+
+from main_logic.omni_realtime_client import OmniRealtimeClient
 from utils.audio_processor import AudioProcessor, _LiteDenoiser
 
 
@@ -75,3 +80,42 @@ def test_disabling_noise_reduction_releases_native_denoiser() -> None:
     assert denoiser.close_calls == 1
     assert processor._denoiser is None
     assert processor._frame_buffer.size == 0
+
+
+@pytest.mark.asyncio
+async def test_audio_close_waits_for_executor_chunk_processing() -> None:
+    processing_started = threading.Event()
+    release_processing = threading.Event()
+
+    class _Processor:
+        def __init__(self) -> None:
+            self.close_calls = 0
+
+        def process_chunk(self, audio_chunk: bytes) -> bytes:
+            processing_started.set()
+            assert release_processing.wait(timeout=2.0)
+            return audio_chunk
+
+        def save_debug_audio(self) -> None:
+            return None
+
+        def close(self) -> None:
+            self.close_calls += 1
+
+    client = object.__new__(OmniRealtimeClient)
+    processor = _Processor()
+    client._audio_processor = processor
+    client._audio_processing_lock = asyncio.Lock()
+
+    process_task = asyncio.create_task(client.process_audio_chunk_async(b"chunk"))
+    assert await asyncio.to_thread(processing_started.wait, 2.0)
+    close_task = asyncio.create_task(client._close_audio_processor())
+    await asyncio.sleep(0)
+
+    assert processor.close_calls == 0
+    release_processing.set()
+
+    assert await process_task == b"chunk"
+    await close_task
+    assert processor.close_calls == 1
+    assert client._audio_processor is None

--- a/tests/unit/test_audio_processor_lifecycle.py
+++ b/tests/unit/test_audio_processor_lifecycle.py
@@ -127,6 +127,57 @@ async def test_audio_close_waits_for_executor_chunk_processing() -> None:
 
 
 @pytest.mark.asyncio
+async def test_audio_processing_drops_frame_after_processor_close() -> None:
+    client = object.__new__(OmniRealtimeClient)
+    client._audio_processor = None
+    client._audio_processing_lock = asyncio.Lock()
+
+    assert await client.process_audio_chunk_async(b"48khz-frame") == b""
+
+
+@pytest.mark.asyncio
+async def test_cancelled_audio_processing_keeps_lock_until_worker_finishes() -> None:
+    processing_started = threading.Event()
+    release_processing = threading.Event()
+
+    class _Processor:
+        def __init__(self) -> None:
+            self.close_calls = 0
+
+        def process_chunk(self, audio_chunk: bytes) -> bytes:
+            processing_started.set()
+            assert release_processing.wait(timeout=2.0)
+            return audio_chunk
+
+        def save_debug_audio(self) -> None:
+            return None
+
+        def close(self) -> None:
+            self.close_calls += 1
+
+    client = object.__new__(OmniRealtimeClient)
+    processor = _Processor()
+    client._audio_processor = processor
+    client._audio_processing_lock = asyncio.Lock()
+
+    process_task = asyncio.create_task(client.process_audio_chunk_async(b"chunk"))
+    assert await asyncio.to_thread(processing_started.wait, 2.0)
+    process_task.cancel()
+    close_task = asyncio.create_task(client._close_audio_processor())
+    await asyncio.sleep(0)
+
+    assert processor.close_calls == 0
+    assert not close_task.done()
+
+    release_processing.set()
+    with pytest.raises(asyncio.CancelledError):
+        await process_task
+    assert await close_task is None
+    assert processor.close_calls == 1
+    assert client._audio_processor is None
+
+
+@pytest.mark.asyncio
 async def test_live_noise_reduction_toggle_waits_for_chunk_processing() -> None:
     processing_started = threading.Event()
     release_processing = threading.Event()

--- a/tests/unit/test_audio_processor_lifecycle.py
+++ b/tests/unit/test_audio_processor_lifecycle.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import importlib
 import threading
 
 import numpy as np
@@ -8,6 +9,9 @@ import pytest
 
 from main_logic.omni_realtime_client import OmniRealtimeClient
 from utils.audio_processor import AudioProcessor, _LiteDenoiser
+
+
+client_module = importlib.import_module("main_logic.omni_realtime_client._client")
 
 
 class _FakeRnnoise:
@@ -104,6 +108,7 @@ async def test_audio_close_waits_for_executor_chunk_processing() -> None:
 
     client = object.__new__(OmniRealtimeClient)
     processor = _Processor()
+    client._noise_reduction_enabled = True
     client._audio_processor = processor
     client._audio_processing_lock = asyncio.Lock()
 
@@ -154,6 +159,27 @@ async def test_live_noise_reduction_toggle_waits_for_chunk_processing() -> None:
     assert await process_task == b"chunk"
     assert await toggle_task is None
     assert processor.enabled_calls == [False]
+    assert client._noise_reduction_enabled is False
+
+
+def test_recreated_audio_processor_preserves_noise_reduction_preference(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created: list[dict[str, object]] = []
+
+    def _create_processor(**kwargs):
+        created.append(kwargs)
+        return object()
+
+    monkeypatch.setattr(client_module, "AudioProcessor", _create_processor)
+    client = object.__new__(OmniRealtimeClient)
+    client._noise_reduction_enabled = False
+    client._on_silence_reset = lambda: None
+
+    processor = client._create_audio_processor()
+
+    assert processor is not None
+    assert created[0]["noise_reduce_enabled"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_audio_processor_lifecycle.py
+++ b/tests/unit/test_audio_processor_lifecycle.py
@@ -213,6 +213,21 @@ async def test_live_noise_reduction_toggle_waits_for_chunk_processing() -> None:
     assert client._noise_reduction_enabled is False
 
 
+@pytest.mark.asyncio
+async def test_audio_toggle_failure_does_not_escape_session_setup() -> None:
+    class _Processor:
+        def set_enabled(self, enabled: bool) -> None:
+            raise RuntimeError("native close failed")
+
+    client = object.__new__(OmniRealtimeClient)
+    client._noise_reduction_enabled = True
+    client._audio_processor = _Processor()
+    client._audio_processing_lock = asyncio.Lock()
+
+    assert await client.set_audio_noise_reduction_enabled(False) is None
+    assert client._noise_reduction_enabled is False
+
+
 def test_recreated_audio_processor_preserves_noise_reduction_preference(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_embedding_token_budget.py
+++ b/tests/unit/test_embedding_token_budget.py
@@ -147,14 +147,18 @@ async def test_embedding_close_waits_for_inflight_inference(
     svc._infer_blocking = _blocking_inference
     embed_task = asyncio.create_task(svc.embed("hello"))
     assert await asyncio.to_thread(inference_started.wait, 2.0)
+    embed_task.cancel()
+    await asyncio.sleep(0)
     close_task = asyncio.create_task(svc.close())
     await asyncio.sleep(0)
 
     assert svc._closing is True
+    assert svc._active_operations == 1
     assert not close_task.done()
     release_inference.set()
 
-    assert await embed_task == [1.0]
+    cancelled_result = await asyncio.gather(embed_task, return_exceptions=True)
+    assert isinstance(cancelled_result[0], asyncio.CancelledError)
     assert await close_task is None
     assert svc._session is None
     assert svc._tokenizer is None
@@ -179,13 +183,18 @@ async def test_embedding_load_cannot_publish_after_close_starts(
     svc._load_session_blocking = _blocking_load
     load_task = asyncio.create_task(svc.request_load())
     assert await asyncio.to_thread(load_started.wait, 2.0)
+    load_task.cancel()
+    await asyncio.sleep(0)
     close_task = asyncio.create_task(svc.close())
     await asyncio.sleep(0)
 
     assert svc._closing is True
+    assert svc._active_operations == 1
+    assert not close_task.done()
     release_load.set()
 
-    assert await load_task is False
+    cancelled_result = await asyncio.gather(load_task, return_exceptions=True)
+    assert isinstance(cancelled_result[0], asyncio.CancelledError)
     assert await close_task is None
     assert svc._session is None
     assert svc._tokenizer is None

--- a/tests/unit/test_embedding_token_budget.py
+++ b/tests/unit/test_embedding_token_budget.py
@@ -20,6 +20,7 @@ Test goals:
 from __future__ import annotations
 
 import asyncio
+import threading
 import types
 
 import pytest
@@ -92,6 +93,10 @@ def service_with_fake_session(monkeypatch):
     svc._session = fake_sess
     svc._tokenizer = object()  # 占位,只要不是 None 就行(不会被调到)
     svc._dim = None  # 不做 Matryoshka 截断
+    svc._load_lock = asyncio.Lock()
+    svc._lifecycle_condition = asyncio.Condition()
+    svc._active_operations = 0
+    svc._closing = False
     return svc, fake_sess, embeddings
 
 
@@ -117,12 +122,74 @@ def test_embedding_service_close_releases_native_owners(service_with_fake_sessio
     svc, _session, embeddings_mod = service_with_fake_session
     svc._state = embeddings_mod.EmbeddingState.READY
 
-    svc.close()
+    asyncio.run(svc.close())
 
     assert svc._session is None
     assert svc._tokenizer is None
     assert svc._state is embeddings_mod.EmbeddingState.CLOSED
     assert asyncio.run(svc.request_load()) is False
+
+
+@pytest.mark.asyncio
+async def test_embedding_close_waits_for_inflight_inference(
+    service_with_fake_session,
+) -> None:
+    svc, _session, embeddings_mod = service_with_fake_session
+    inference_started = threading.Event()
+    release_inference = threading.Event()
+    svc._state = embeddings_mod.EmbeddingState.READY
+
+    def _blocking_inference(_texts):
+        inference_started.set()
+        assert release_inference.wait(timeout=2.0)
+        return [[1.0]]
+
+    svc._infer_blocking = _blocking_inference
+    embed_task = asyncio.create_task(svc.embed("hello"))
+    assert await asyncio.to_thread(inference_started.wait, 2.0)
+    close_task = asyncio.create_task(svc.close())
+    await asyncio.sleep(0)
+
+    assert svc._closing is True
+    assert not close_task.done()
+    release_inference.set()
+
+    assert await embed_task == [1.0]
+    assert await close_task is None
+    assert svc._session is None
+    assert svc._tokenizer is None
+    assert svc._state is embeddings_mod.EmbeddingState.CLOSED
+
+
+@pytest.mark.asyncio
+async def test_embedding_load_cannot_publish_after_close_starts(
+    service_with_fake_session,
+) -> None:
+    svc, _session, embeddings_mod = service_with_fake_session
+    load_started = threading.Event()
+    release_load = threading.Event()
+    svc._state = embeddings_mod.EmbeddingState.INIT
+
+    def _blocking_load() -> None:
+        load_started.set()
+        assert release_load.wait(timeout=2.0)
+        svc._session = object()
+        svc._tokenizer = object()
+
+    svc._load_session_blocking = _blocking_load
+    load_task = asyncio.create_task(svc.request_load())
+    assert await asyncio.to_thread(load_started.wait, 2.0)
+    close_task = asyncio.create_task(svc.close())
+    await asyncio.sleep(0)
+
+    assert svc._closing is True
+    release_load.set()
+
+    assert await load_task is False
+    assert await close_task is None
+    assert svc._session is None
+    assert svc._tokenizer is None
+    assert svc._state is embeddings_mod.EmbeddingState.CLOSED
 
 
 def test_short_batch_runs_in_single_bucket(service_with_fake_session):

--- a/tests/unit/test_embedding_token_budget.py
+++ b/tests/unit/test_embedding_token_budget.py
@@ -19,6 +19,7 @@ Test goals:
 """
 from __future__ import annotations
 
+import asyncio
 import types
 
 import pytest
@@ -110,6 +111,18 @@ def _run_with_lengths(svc, fake_sess, embeddings_mod, lengths):
     # texts 列表只起占位作用,长度跟 encoded 对齐就行
     texts = ["x"] * len(lengths)
     return svc._infer_blocking(texts)
+
+
+def test_embedding_service_close_releases_native_owners(service_with_fake_session):
+    svc, _session, embeddings_mod = service_with_fake_session
+    svc._state = embeddings_mod.EmbeddingState.READY
+
+    svc.close()
+
+    assert svc._session is None
+    assert svc._tokenizer is None
+    assert svc._state is embeddings_mod.EmbeddingState.CLOSED
+    assert asyncio.run(svc.request_load()) is False
 
 
 def test_short_batch_runs_in_single_bucket(service_with_fake_session):

--- a/utils/audio_processor.py
+++ b/utils/audio_processor.py
@@ -29,6 +29,8 @@ Important: RNNoise's GRU state drifts while processing background noise,
 and must be reset once end of speech is detected.
 """
 
+from contextlib import suppress
+
 import numpy as np
 from typing import Optional
 from utils.logger_config import get_module_logger
@@ -192,10 +194,10 @@ class _LiteDenoiser:
             self._lib.destroy(state)
 
     def __del__(self):
-        try:
+        # Finalization may run during interpreter teardown; never let native
+        # cleanup errors escape or depend on the logging subsystem still existing.
+        with suppress(Exception):
             self.close()
-        except Exception:
-            pass
 
 
 class AudioProcessor:

--- a/utils/audio_processor.py
+++ b/utils/audio_processor.py
@@ -184,15 +184,18 @@ class _LiteDenoiser:
         if old_state:
             self._lib.destroy(old_state)
 
+    def close(self) -> None:
+        """Destroy the owned native RNNoise state exactly once."""
+        state = self._state
+        self._state = None
+        if state:
+            self._lib.destroy(state)
+
     def __del__(self):
-        lib = getattr(self, "_lib", None)
-        state = getattr(self, "_state", None)
-        if lib is not None and state:
-            try:
-                lib.destroy(state)
-            except Exception:
-                pass
-            self._state = None
+        try:
+            self.close()
+        except Exception:
+            pass
 
 
 class AudioProcessor:
@@ -446,6 +449,19 @@ class AudioProcessor:
         self._reset_internal_state()
         self._last_speech_time = time.time()
         logger.info("🔄 AudioProcessor state reset (external call)")
+
+    def close(self) -> None:
+        """Release native denoiser and streaming-buffer resources."""
+        denoiser = self._denoiser
+        self._denoiser = None
+        if denoiser is not None:
+            close = getattr(denoiser, "close", None)
+            if callable(close):
+                close()
+        self._downsample_resampler = None
+        self._frame_buffer = np.array([], dtype=np.int16)
+        self._debug_audio_before.clear()
+        self._debug_audio_after.clear()
     
     def request_reset(self) -> None:
         """Request a reset on the next process_chunk call."""
@@ -504,6 +520,9 @@ class AudioProcessor:
         self.noise_reduce_enabled = enabled
         if enabled and self._denoiser is None:
             self._init_denoiser()
+        elif not enabled and self._denoiser is not None:
+            self._denoiser.close()
+            self._denoiser = None
         if prev != enabled:
             self._frame_buffer = np.array([], dtype=np.int16)
             self._agc_gain = 1.0


### PR DESCRIPTION
## 改动概述 / Summary

- Lazy-load `browser-use` behind a single-flight initializer and explicitly stop its keep-alive BrowserSession/Chromium process tree on disable, capability demotion, or shutdown.
- Remove eager RapidOCR warmup, share ONNX-backed runtimes by ownership, and release cached runtimes when the last plugin owner closes.
- Add explicit close paths for Galgame vision ONNX sessions, embedding services, RNNoise state, and soxr streams.
- Keep Study Companion registration scans lightweight by deferring `imagehash`/NumPy import until OCR use.
- Preserve the existing Electron and web-server routes and plugin contracts; no frontend or i18n behavior changed.

## 回归报告 / Regression Report

### 改动与必要性

Optional features were imported or constructed during registration/startup, while several native sessions and child processes had no owner-driven shutdown path. This kept Python modules, ONNX/native allocations, and Chromium subprocess RSS resident after the feature or plugin was inactive.

This PR connects the complete lifecycle—registration/startup, first use, reconfiguration/disable, and shutdown—for browser-use, RapidOCR, embedding/tokenizer, Galgame vision, Study OCR, and audio-native resources.

### 改动前后

| Dependency | Before | After |
| --- | --- | --- |
| browser-use / Playwright / Chromium | Adapter constructed at agent startup; keep-alive browser could outlive capability use | Constructed on first use with single-flight initialization; explicit close stops the session and force-cleans owned Chromium descendants |
| RapidOCR / ONNX Runtime | Optional warmup could create sessions early; cache lifetime was TTL-only | No eager warmup; per-runtime owner accounting evicts the cache on last close |
| Galgame vision ONNX | Session cache had no explicit plugin shutdown path | Classifier/loader close clears cached sessions during reconfigure and shutdown |
| embeddings / tokenizers | Model loading was already lazy, but the service singleton had no terminal release | Lazy behavior retained; memory-server shutdown releases tokenizer/session references |
| Study Companion NumPy / imagehash | Registration import loaded the optional image stack | Imports occur only when OCR hashing is used; owned OCR backends close explicitly |
| NumPy / soxr / RNNoise | Core audio NumPy remains process-wide; denoiser/resampler native state could remain attached | Core NumPy contract is unchanged; session-owned RNNoise and soxr resources close on disable/disconnect |
| Playwright child processes | BrowserSession shutdown was not tied to every disable/demotion path | All explicit lifecycle exits close the adapter and clean owned child processes |

Observed baseline probes showed browser-use import at about +23.47 MiB RSS and adapter construction at a further +39.19 MiB; Study Companion import loaded NumPy/imagehash at about +72.04 MiB. The patch removes those eager construction/import paths. Embedding construction remained lazy for ONNX Runtime/tokenizers in the baseline probe.

### 潜在回归点与覆盖

- Agent capability enable/disable/demotion and shutdown could race adapter creation; covered by concurrent single-flight and idempotent-close tests.
- Browser keep-alive shutdown could leave Chromium descendants; covered by BrowserSession close-path tests.
- RapidOCR cache ownership could release too early or remain resident; covered in both shared and Galgame backends, including last-owner eviction.
- Audio reconnect/disable could reuse destroyed RNNoise/soxr state; covered by explicit close, disable, and recreation tests.
- Embedding, Study OCR, and Galgame vision could access a released session; covered by release/recreation and lazy-import tests.
- Electron and web routes are unchanged; the modifications are server/plugin lifecycle-only and retain existing public plugin interfaces.

## 不拆分理由 / Why Not Split

The change is one lifecycle contract spanning eager discovery, first-use construction, ownership, reconfiguration, and terminal shutdown. Splitting creation-side and release-side changes would temporarily leave resources either uninitialized or unreclaimable, and would make the memory comparison misleading. RapidOCR also requires symmetric changes in the shared and Galgame backends to preserve the project's provider/plugin duality rule. The counted file total is driven by those paired implementations plus their owner call sites; the tests validate the lifecycle as one end-to-end unit.

## 测试 / Testing

- `uv run --active --no-sync pytest -q tests/unit/test_agent_browser_lifecycle.py tests/unit/test_audio_processor_lifecycle.py tests/unit/test_embedding_token_budget.py plugin/tests/unit/plugins/test_galgame_rapidocr_support.py plugin/tests/unit/plugins/test_galgame_vision_classifier.py plugin/tests/unit/plugins/test_study_companion_study_ocr_pipeline.py plugin/tests/unit/plugins/test_galgame_ocr_reader.py`
  - 306 passed
- `git diff --cached --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 浏览器能力现已按需启用，并进行依赖就绪探测；支持可用性检查、运行前拦截与更安全的关闭/重启。
  * 音频噪声抑制开关改为实时异步生效。
  * OCR 与相关图像哈希/运行时能力改为按需加载，降低预热负担。
* **问题修复**
  * 修复多组件在并发、重连与退出清理中的竞态与资源泄漏（浏览器、嵌入服务、音频处理器、RapidOCR/视觉加载会话）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->