### PR TITLE
feat(slop): add offline natural-expression candidate miner

### DIFF
--- a/docs/contributing/natural-expression-candidate-miner.md
+++ b/docs/contributing/natural-expression-candidate-miner.md
@@ -70,6 +70,9 @@ opposite sides of `。`, `！`, `？`, `，`, or related punctuation.
 
 Fenced code, inline code, URLs, numeric-only material, and obvious placeholder
 templates are excluded. System and user content never enters candidate counts.
+Coverage is checked against complete punctuation-bounded assistant fragments in
+memory, so a runtime pattern longer than an individual n-gram can still be
+recognized. Those source fragments are never written to the review artifact.
 
 ## Review artifact
 

--- a/docs/contributing/natural-expression-candidate-miner.md
+++ b/docs/contributing/natural-expression-candidate-miner.md
@@ -1,0 +1,120 @@
+# Natural-expression candidate miner
+
+`scripts/natural_expression_candidate_miner.py` is a maintainer-only, offline
+discovery tool. It counts repeated assistant phrases in a local corpus that a
+maintainer explicitly names and writes **pending review candidates**. It does not
+generate regular expressions, replacements, or runtime rules.
+
+The repository's user-facing conversation export is not a stable machine-readable
+message corpus for this purpose, so the miner uses the deliberately small JSONL
+contract below rather than depending on an internal database or UI export shape.
+
+## Input contract
+
+Pass one local JSONL file with `--input`. Each non-empty line must be one JSON
+object with:
+
+- `role`: required string. Only the exact value `assistant` is analyzed; all
+  other roles are validated and ignored.
+- `content`: required string.
+- `lang`: required on assistant records unless `--language` is supplied.
+- `conversation_id`: optional string. It is accepted only to make separately
+  exported conversations easier to combine; it is never copied to the output.
+
+Supported language tags are `en`, `es`, `pt`, `ru`, `ja`, `ko`, `zh`, `zh-CN`,
+and `zh-TW`, plus common locale aliases such as `pt-BR`, `ja-JP`, and `ko-KR`.
+`--language` overrides every record's `lang`. There is no automatic language
+detection or guessing.
+
+Synthetic example:
+
+```jsonl
+{"role":"system","content":"Synthetic instruction","lang":"en","conversation_id":"demo-a"}
+{"role":"user","content":"Synthetic question","lang":"en","conversation_id":"demo-a"}
+{"role":"assistant","content":"A quiet lantern lit the path.","lang":"en","conversation_id":"demo-a"}
+```
+
+The tool never scans a directory, database, default chat-history location, or
+user profile. Prepare the JSONL file yourself and pass its exact path.
+
+## Run it
+
+All project Python commands use `uv run`:
+
+```bash
+uv run python scripts/natural_expression_candidate_miner.py \
+  --input C:/maintainer/corpora/synthetic-or-consented.jsonl \
+  --output C:/maintainer/review/natural-expression-candidates.json
+```
+
+Useful controls:
+
+- `--threshold 3`: minimum total occurrences. The default starts at three.
+- `--word-ngram-min` / `--word-ngram-max`: Unicode word n-grams for English,
+  Spanish, Portuguese, and Russian. Defaults to 2–5 words.
+- `--cjk-ngram-min` / `--cjk-ngram-max`: character-fragment n-grams for Chinese
+  and Japanese, plus the character side of Korean's hybrid strategy. Defaults
+  to 4–8 characters.
+- `--min-length`: minimum non-space character length.
+- `--exclude-covered`: omit candidates already matched by a current curated
+  `SLOP_RULES` pattern. Without this flag they remain visible with
+  `covered_by_rule_ids` for review.
+- `--debug-candidates`: explicitly print candidate phrases. This can expose
+  assistant text and is off by default.
+
+Korean uses both Unicode word n-grams and Hangul character fragments: normal
+space-delimited prose benefits from word boundaries, while repeated compounds
+and onomatopoeia can still be discovered without a morphological analyzer.
+CJK punctuation creates hard boundaries, so candidates never join text from
+opposite sides of `。`, `！`, `？`, `，`, or related punctuation.
+
+Fenced code, inline code, URLs, numeric-only material, and obvious placeholder
+templates are excluded. System and user content never enters candidate counts.
+
+## Review artifact
+
+The output is deterministic JSON with no timestamp or random identifier. Given
+identical input bytes, arguments, and rule-table version, repeated runs produce
+identical output bytes. Candidates are stably sorted by language, message count,
+occurrence count, and phrase.
+
+Each candidate contains only:
+
+```json
+{
+  "covered_by_rule_ids": [],
+  "language": "en",
+  "message_count": 3,
+  "normalized_phrase": "a quiet lantern",
+  "occurrence_count": 4,
+  "phrase": "A quiet lantern",
+  "status": "pending"
+}
+```
+
+The top-level `schema_version` is
+`natural-expression-candidates/v1`, and the artifact shape is intentionally
+incompatible with the runtime rule schema. It has no `find`, `replace`, or
+activation field and cannot be loaded by `utils.slop_filter`.
+
+Default terminal output contains only input/output paths, aggregate counts, and
+language names. Candidate phrases are written only to the explicit output file.
+That file can contain fragments of assistant replies and must be handled with the
+same care as conversation data. It intentionally contains no full context, user
+content, system content, or conversation identifiers.
+
+## Manual review and promotion
+
+1. Review each pending phrase for false positives, genre-specific language, and
+   whether repetition across messages is actually undesirable.
+2. Check `covered_by_rule_ids`; an already covered phrase normally needs no new
+   runtime rule.
+3. Reject, merge, or refine candidates manually outside this artifact.
+4. In a separate maintainer change, manually add a curated, language-specific
+   pattern and deterministic replacement pool to
+   `config/prompts/prompts_slop.py`, with focused synthetic tests.
+
+The miner never writes `config/prompts/prompts_slop.py`, never turns a candidate
+into a regex, never calls an LLM or third-party API, never learns during runtime,
+and never enables a rule. Promotion is always an explicit human maintenance
+decision.

--- a/docs/contributing/natural-expression-candidate-miner.md
+++ b/docs/contributing/natural-expression-candidate-miner.md
@@ -70,9 +70,12 @@ opposite sides of `。`, `！`, `？`, `，`, or related punctuation.
 
 Fenced code, inline code, URLs, numeric-only material, and obvious placeholder
 templates are excluded. System and user content never enters candidate counts.
-Coverage is checked against complete punctuation-bounded assistant fragments in
-memory, so a runtime pattern longer than an individual n-gram can still be
-recognized. Those source fragments are never written to the review artifact.
+Coverage checks run curated patterns against the original assistant message so
+runtime punctuation, normalization, and line boundaries are preserved; matches
+overlapping runtime-protected code or URLs are ignored. Original message context
+is retained only in memory and is never written to the report.
+Candidate spans are compared with complete runtime matches, so a pattern longer
+than an individual n-gram can still be recognized.
 
 ## Review artifact
 

--- a/docs/contributing/natural-expression-candidate-miner.md
+++ b/docs/contributing/natural-expression-candidate-miner.md
@@ -56,9 +56,9 @@ Useful controls:
   and Japanese, plus the character side of Korean's hybrid strategy. Defaults
   to 4–8 characters.
 - `--min-length`: minimum non-space character length.
-- `--exclude-covered`: omit candidates already matched by a current curated
-  `SLOP_RULES` pattern. Without this flag they remain visible with
-  `covered_by_rule_ids` for review.
+- `--exclude-covered`: omit a candidate only when every mined occurrence falls
+  inside a current curated `SLOP_RULES` match. Partially covered candidates stay
+  visible with `covered_by_rule_ids` for review.
 - `--debug-candidates`: explicitly print candidate phrases. This can expose
   assistant text and is off by default.
 
@@ -110,8 +110,9 @@ content, system content, or conversation identifiers.
 
 1. Review each pending phrase for false positives, genre-specific language, and
    whether repetition across messages is actually undesirable.
-2. Check `covered_by_rule_ids`; an already covered phrase normally needs no new
-   runtime rule.
+2. Check `covered_by_rule_ids`; it records rules covering at least one
+   occurrence. A partially covered phrase remains pending, while a fully covered
+   phrase normally needs no new runtime rule.
 3. Reject, merge, or refine candidates manually outside this artifact.
 4. In a separate maintainer change, manually add a curated, language-specific
    pattern and deterministic replacement pool to

--- a/scripts/natural_expression_candidate_miner.py
+++ b/scripts/natural_expression_candidate_miner.py
@@ -441,10 +441,20 @@ def _message_candidates(
         return
     if language == "ko":
         # Korean prose is normally space-delimited, but repeated compounds and
-        # onomatopoeia often are not. Keep both families and make their output
-        # distinguishable through spaces in word candidates.
-        yield from _word_candidates(message.content, config)
-        yield from _character_candidates(message.content, config, _is_hangul)
+        # onomatopoeia often are not. Keep both families, but do not count an
+        # identical single-token occurrence once in each strategy.
+        word_candidates = list(_word_candidates(message.content, config))
+        overlapping_word_counts = Counter(
+            (normalized, coverage_text)
+            for normalized, _, coverage_text in word_candidates
+        )
+        yield from word_candidates
+        for candidate in _character_candidates(message.content, config, _is_hangul):
+            overlap_key = (candidate[0], candidate[2])
+            if overlapping_word_counts[overlap_key]:
+                overlapping_word_counts[overlap_key] -= 1
+                continue
+            yield candidate
         return
     raise CandidateMinerError(f"unsupported normalized language: {language}")
 
@@ -615,6 +625,7 @@ def write_report(output_path: Path, report: Mapping[str, object]) -> None:
             try:
                 Path(temporary_name).unlink(missing_ok=True)
             except OSError:
+                # Do not mask the primary report write failure with cleanup failure.
                 pass
         raise CandidateMinerError(
             f"unable to write output file: {output_path}"

--- a/scripts/natural_expression_candidate_miner.py
+++ b/scripts/natural_expression_candidate_miner.py
@@ -1,0 +1,715 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Mine deterministic natural-expression candidates from explicit JSONL input.
+
+This is a maintainer-only offline analysis tool. It never discovers input files,
+calls a model or network service, edits the runtime rule table, or activates a
+candidate. Its output is a review artifact whose schema is intentionally
+incompatible with ``config.prompts.prompts_slop.SLOP_RULES``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import tempfile
+import unicodedata
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator, Mapping, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+SCHEMA_VERSION = "natural-expression-candidates/v1"
+ARTIFACT_TYPE = "maintainer_review_candidates"
+DEFAULT_THRESHOLD = 3
+DEFAULT_WORD_NGRAM_MIN = 2
+DEFAULT_WORD_NGRAM_MAX = 5
+DEFAULT_CJK_NGRAM_MIN = 4
+DEFAULT_CJK_NGRAM_MAX = 8
+DEFAULT_MIN_LENGTH = 4
+
+_LANGUAGE_ALIASES = {
+    "en": "en",
+    "en-us": "en",
+    "en-gb": "en",
+    "es": "es",
+    "es-es": "es",
+    "es-mx": "es",
+    "pt": "pt",
+    "pt-br": "pt",
+    "pt-pt": "pt",
+    "ru": "ru",
+    "ru-ru": "ru",
+    "ja": "ja",
+    "ja-jp": "ja",
+    "ko": "ko",
+    "ko-kr": "ko",
+    "zh": "zh",
+    "zh-cn": "zh-CN",
+    "zh-hans": "zh-CN",
+    "zh-tw": "zh-TW",
+    "zh-hant": "zh-TW",
+}
+_WHITESPACE_LANGUAGES = frozenset({"en", "es", "pt", "ru"})
+_WORD_RE = re.compile(r"[^\W_]+(?:[\u2019'][^\W_]+)*", re.UNICODE)
+_TEXT_BOUNDARY_RE = re.compile(r"[\r\n.!?。！？；;:：,，、]+")
+_URL_RE = re.compile(r"(?:https?://|www\.)[^\s<>()]+", re.IGNORECASE)
+_TEMPLATE_RE = re.compile(
+    r"\{\{[^{}\r\n]*\}\}|\$\{[^{}\r\n]*\}|<%[^%\r\n]*%>|"
+    r"<[^<>\r\n]{1,80}>|\[[A-Z][A-Z0-9_-]{1,63}\]"
+)
+
+
+class CandidateMinerError(ValueError):
+    """A safe, content-free error suitable for CLI output."""
+
+
+@dataclass(frozen=True)
+class MiningConfig:
+    """Deterministic mining parameters recorded in the output artifact."""
+
+    threshold: int = DEFAULT_THRESHOLD
+    word_ngram_min: int = DEFAULT_WORD_NGRAM_MIN
+    word_ngram_max: int = DEFAULT_WORD_NGRAM_MAX
+    cjk_ngram_min: int = DEFAULT_CJK_NGRAM_MIN
+    cjk_ngram_max: int = DEFAULT_CJK_NGRAM_MAX
+    min_length: int = DEFAULT_MIN_LENGTH
+    exclude_covered: bool = False
+
+    def validate(self) -> None:
+        for name in (
+            "threshold",
+            "word_ngram_min",
+            "word_ngram_max",
+            "cjk_ngram_min",
+            "cjk_ngram_max",
+            "min_length",
+        ):
+            if getattr(self, name) < 1:
+                raise CandidateMinerError(f"{name} must be at least 1")
+        if self.word_ngram_min > self.word_ngram_max:
+            raise CandidateMinerError("word_ngram_min cannot exceed word_ngram_max")
+        if self.cjk_ngram_min > self.cjk_ngram_max:
+            raise CandidateMinerError("cjk_ngram_min cannot exceed cjk_ngram_max")
+
+
+@dataclass(frozen=True)
+class SourceMessage:
+    """The only source data retained during mining."""
+
+    language: str
+    content: str
+    source_line: int
+
+
+@dataclass
+class _CandidateStats:
+    occurrence_count: int
+    source_lines: set[int]
+    phrases: set[str]
+
+
+def normalize_language(raw: str) -> str:
+    """Normalize an explicit locale tag without guessing from message text."""
+    if not isinstance(raw, str) or not raw.strip():
+        raise CandidateMinerError("language must be a non-empty string")
+    normalized = raw.strip().replace("_", "-").casefold()
+    try:
+        return _LANGUAGE_ALIASES[normalized]
+    except KeyError as exc:
+        supported = ", ".join(sorted(set(_LANGUAGE_ALIASES.values())))
+        raise CandidateMinerError(
+            f"unsupported language tag; supported languages: {supported}"
+        ) from exc
+
+
+def read_jsonl(
+    input_path: Path,
+    *,
+    language_override: str | None = None,
+) -> tuple[list[SourceMessage], int]:
+    """Read the documented JSONL contract and retain assistant text only."""
+    if not input_path.is_file():
+        raise CandidateMinerError(f"input file does not exist: {input_path}")
+    override = normalize_language(language_override) if language_override else None
+    messages: list[SourceMessage] = []
+    record_count = 0
+
+    try:
+        handle = input_path.open("r", encoding="utf-8-sig", newline="")
+    except OSError as exc:
+        raise CandidateMinerError(f"unable to open input file: {input_path}") from exc
+
+    with handle:
+        for line_number, raw_line in enumerate(handle, start=1):
+            if not raw_line.strip():
+                continue
+            try:
+                record = json.loads(raw_line)
+            except json.JSONDecodeError as exc:
+                raise CandidateMinerError(f"line {line_number}: invalid JSON") from exc
+            if not isinstance(record, dict):
+                raise CandidateMinerError(
+                    f"line {line_number}: each JSONL record must be an object"
+                )
+            record_count += 1
+
+            role = record.get("role")
+            content = record.get("content")
+            if not isinstance(role, str) or not role:
+                raise CandidateMinerError(
+                    f"line {line_number}: role must be a non-empty string"
+                )
+            if not isinstance(content, str):
+                raise CandidateMinerError(
+                    f"line {line_number}: content must be a string"
+                )
+            conversation_id = record.get("conversation_id")
+            if conversation_id is not None and not isinstance(conversation_id, str):
+                raise CandidateMinerError(
+                    f"line {line_number}: conversation_id must be a string when present"
+                )
+            if role != "assistant":
+                continue
+
+            raw_language = override or record.get("lang")
+            if raw_language is None:
+                raise CandidateMinerError(
+                    f"line {line_number}: assistant records require lang or --language"
+                )
+            language = override or normalize_language(raw_language)
+            messages.append(
+                SourceMessage(
+                    language=language,
+                    content=content,
+                    source_line=line_number,
+                )
+            )
+
+    return messages, record_count
+
+
+def _fenced_code_spans(text: str) -> list[tuple[int, int]]:
+    """Return Markdown fenced-code spans, including an unclosed final fence."""
+    spans: list[tuple[int, int]] = []
+    fence_start: int | None = None
+    fence_char = ""
+    fence_len = 0
+    offset = 0
+    for line in text.splitlines(keepends=True):
+        stripped = line.lstrip(" \t")
+        indent = len(line) - len(stripped)
+        if indent <= 3:
+            if fence_start is None:
+                opening = re.match(r"(`{3,}|~{3,})", stripped)
+                if opening:
+                    marker = opening.group(1)
+                    fence_start = offset
+                    fence_char = marker[0]
+                    fence_len = len(marker)
+            else:
+                closing = re.match(
+                    rf"{re.escape(fence_char)}{{{fence_len},}}[ \t]*(?:\r?\n)?\Z",
+                    stripped,
+                )
+                if closing:
+                    spans.append((fence_start, offset + len(line)))
+                    fence_start = None
+                    fence_char = ""
+                    fence_len = 0
+        offset += len(line)
+    if fence_start is not None:
+        spans.append((fence_start, len(text)))
+    return spans
+
+
+def _inline_code_spans(
+    text: str,
+    fenced_spans: Sequence[tuple[int, int]],
+) -> list[tuple[int, int]]:
+    """Return same-line backtick spans outside fenced blocks."""
+    spans: list[tuple[int, int]] = []
+    index = 0
+    fence_index = 0
+    while index < len(text):
+        while fence_index < len(fenced_spans) and fenced_spans[fence_index][1] <= index:
+            fence_index += 1
+        if (
+            fence_index < len(fenced_spans)
+            and fenced_spans[fence_index][0] <= index < fenced_spans[fence_index][1]
+        ):
+            index = fenced_spans[fence_index][1]
+            continue
+        if text[index] != "`":
+            index += 1
+            continue
+
+        run_end = index + 1
+        while run_end < len(text) and text[run_end] == "`":
+            run_end += 1
+        delimiter = text[index:run_end]
+        newline = text.find("\n", run_end)
+        line_end = len(text) if newline < 0 else newline
+        closing = text.find(delimiter, run_end, line_end)
+        end = line_end if closing < 0 else closing + len(delimiter)
+        spans.append((index, end))
+        index = max(end, run_end)
+    return spans
+
+
+def _protected_spans(text: str) -> list[tuple[int, int]]:
+    """Return merged spans for code, URLs, and obvious template placeholders."""
+    fenced = _fenced_code_spans(text)
+    spans = fenced + _inline_code_spans(text, fenced)
+    spans.extend(match.span() for match in _URL_RE.finditer(text))
+    spans.extend(match.span() for match in _TEMPLATE_RE.finditer(text))
+    if not spans:
+        return []
+
+    merged: list[tuple[int, int]] = []
+    for start, end in sorted(spans):
+        if not merged or start > merged[-1][1]:
+            merged.append((start, end))
+        elif end > merged[-1][1]:
+            merged[-1] = (merged[-1][0], end)
+    return merged
+
+
+def _unprotected_segments(text: str) -> Iterator[str]:
+    """Yield text outside protected spans without bridging across a removed span."""
+    cursor = 0
+    for start, end in _protected_spans(text):
+        if cursor < start:
+            yield text[cursor:start]
+        cursor = end
+    if cursor < len(text):
+        yield text[cursor:]
+
+
+def _bounded_ngrams(
+    values: Sequence[str],
+    minimum: int,
+    maximum: int,
+) -> Iterator[tuple[str, ...]]:
+    upper = min(maximum, len(values))
+    for size in range(minimum, upper + 1):
+        for start in range(0, len(values) - size + 1):
+            yield tuple(values[start : start + size])
+
+
+def _is_meaningful(value: str, min_length: int) -> bool:
+    compact = "".join(value.split())
+    return len(compact) >= min_length and any(char.isalpha() for char in compact)
+
+
+def _word_candidates(text: str, config: MiningConfig) -> Iterator[tuple[str, str]]:
+    for unprotected in _unprotected_segments(text):
+        for segment in _TEXT_BOUNDARY_RE.split(unprotected):
+            token_run: list[str] = []
+            for match in _WORD_RE.finditer(segment):
+                token = unicodedata.normalize("NFKC", match.group(0))
+                if not any(char.isalpha() for char in token):
+                    yield from _word_run_candidates(token_run, config)
+                    token_run = []
+                    continue
+                token_run.append(token)
+            yield from _word_run_candidates(token_run, config)
+
+
+def _word_run_candidates(
+    token_run: Sequence[str],
+    config: MiningConfig,
+) -> Iterator[tuple[str, str]]:
+    for gram in _bounded_ngrams(
+        token_run,
+        config.word_ngram_min,
+        config.word_ngram_max,
+    ):
+        phrase = " ".join(gram)
+        normalized = " ".join(token.casefold() for token in gram)
+        if _is_meaningful(normalized, config.min_length):
+            yield normalized, phrase
+
+
+def _is_han(char: str) -> bool:
+    codepoint = ord(char)
+    return (
+        0x3400 <= codepoint <= 0x4DBF
+        or 0x4E00 <= codepoint <= 0x9FFF
+        or 0xF900 <= codepoint <= 0xFAFF
+        or 0x20000 <= codepoint <= 0x3134F
+    )
+
+
+def _is_japanese(char: str) -> bool:
+    codepoint = ord(char)
+    return (
+        _is_han(char)
+        or 0x3040 <= codepoint <= 0x30FF
+        or 0x31F0 <= codepoint <= 0x31FF
+        or 0xFF66 <= codepoint <= 0xFF9D
+    )
+
+
+def _is_hangul(char: str) -> bool:
+    codepoint = ord(char)
+    return (
+        0x1100 <= codepoint <= 0x11FF
+        or 0x3130 <= codepoint <= 0x318F
+        or 0xA960 <= codepoint <= 0xA97F
+        or 0xAC00 <= codepoint <= 0xD7AF
+        or 0xD7B0 <= codepoint <= 0xD7FF
+    )
+
+
+def _script_runs(text: str, predicate) -> Iterator[str]:
+    run: list[str] = []
+    for char in unicodedata.normalize("NFKC", text):
+        if predicate(char):
+            run.append(char)
+        elif run:
+            yield "".join(run)
+            run = []
+    if run:
+        yield "".join(run)
+
+
+def _character_candidates(
+    text: str,
+    config: MiningConfig,
+    predicate,
+) -> Iterator[tuple[str, str]]:
+    for unprotected in _unprotected_segments(text):
+        for run in _script_runs(unprotected, predicate):
+            characters = list(run)
+            for gram in _bounded_ngrams(
+                characters,
+                config.cjk_ngram_min,
+                config.cjk_ngram_max,
+            ):
+                phrase = "".join(gram)
+                normalized = phrase.casefold()
+                if _is_meaningful(normalized, config.min_length):
+                    yield normalized, phrase
+
+
+def _message_candidates(
+    message: SourceMessage,
+    config: MiningConfig,
+) -> Iterator[tuple[str, str]]:
+    language = message.language
+    if language in _WHITESPACE_LANGUAGES:
+        yield from _word_candidates(message.content, config)
+        return
+    if language.startswith("zh"):
+        yield from _character_candidates(message.content, config, _is_han)
+        return
+    if language == "ja":
+        yield from _character_candidates(message.content, config, _is_japanese)
+        return
+    if language == "ko":
+        # Korean prose is normally space-delimited, but repeated compounds and
+        # onomatopoeia often are not. Keep both families and make their output
+        # distinguishable through spaces in word candidates.
+        yield from _word_candidates(message.content, config)
+        yield from _character_candidates(message.content, config, _is_hangul)
+        return
+    raise CandidateMinerError(f"unsupported normalized language: {language}")
+
+
+def _coverage_language(language: str) -> str:
+    return "zh" if language.startswith("zh") else language
+
+
+def _covered_rule_ids(
+    language: str,
+    phrases: Iterable[str],
+    rules_by_language: Mapping[str, Sequence[Mapping[str, object]]],
+) -> list[str]:
+    covered: set[str] = set()
+    for rule in rules_by_language.get(_coverage_language(language), ()):
+        rule_id = rule.get("id")
+        pattern = rule.get("find")
+        flags = rule.get("flags", 0)
+        if not isinstance(rule_id, str) or not isinstance(pattern, str):
+            continue
+        try:
+            compiled = re.compile(pattern, int(flags))
+        except (re.error, TypeError, ValueError) as exc:
+            raise CandidateMinerError(
+                f"existing rule {rule_id} has an invalid pattern"
+            ) from exc
+        if any(compiled.search(phrase) for phrase in phrases):
+            covered.add(rule_id)
+    return sorted(covered)
+
+
+def load_current_rules() -> Mapping[str, Sequence[Mapping[str, object]]]:
+    """Load the curated runtime table for read-only coverage analysis."""
+    try:
+        from config.prompts.prompts_slop import SLOP_RULES
+    except Exception as exc:
+        raise CandidateMinerError("unable to load current SLOP_RULES") from exc
+    return SLOP_RULES
+
+
+def build_report(
+    messages: Sequence[SourceMessage],
+    *,
+    input_record_count: int,
+    config: MiningConfig,
+    rules_by_language: Mapping[str, Sequence[Mapping[str, object]]] | None = None,
+) -> dict[str, object]:
+    """Build a deterministic, review-only candidate report."""
+    config.validate()
+    current_rules = (
+        load_current_rules() if rules_by_language is None else rules_by_language
+    )
+    stats: dict[tuple[str, str], _CandidateStats] = {}
+
+    for message in messages:
+        for normalized, phrase in _message_candidates(message, config):
+            key = (message.language, normalized)
+            candidate_stats = stats.get(key)
+            if candidate_stats is None:
+                candidate_stats = _CandidateStats(0, set(), set())
+                stats[key] = candidate_stats
+            candidate_stats.occurrence_count += 1
+            candidate_stats.source_lines.add(message.source_line)
+            candidate_stats.phrases.add(phrase)
+
+    candidates: list[dict[str, object]] = []
+    for (language, normalized), candidate_stats in stats.items():
+        if candidate_stats.occurrence_count < config.threshold:
+            continue
+        covered_by = _covered_rule_ids(
+            language,
+            sorted(candidate_stats.phrases),
+            current_rules,
+        )
+        if config.exclude_covered and covered_by:
+            continue
+        candidates.append(
+            {
+                "covered_by_rule_ids": covered_by,
+                "language": language,
+                "message_count": len(candidate_stats.source_lines),
+                "normalized_phrase": normalized,
+                "occurrence_count": candidate_stats.occurrence_count,
+                "phrase": min(
+                    candidate_stats.phrases, key=lambda item: (item.casefold(), item)
+                ),
+                "status": "pending",
+            }
+        )
+
+    candidates.sort(
+        key=lambda item: (
+            item["language"],
+            -item["message_count"],
+            -item["occurrence_count"],
+            item["normalized_phrase"],
+            item["phrase"],
+        )
+    )
+    language_counts = Counter(message.language for message in messages)
+
+    return {
+        "artifact_type": ARTIFACT_TYPE,
+        "candidates": candidates,
+        "parameters": {
+            "cjk_ngram_range": [config.cjk_ngram_min, config.cjk_ngram_max],
+            "exclude_covered": config.exclude_covered,
+            "min_length": config.min_length,
+            "occurrence_threshold": config.threshold,
+            "word_ngram_range": [config.word_ngram_min, config.word_ngram_max],
+        },
+        "schema_version": SCHEMA_VERSION,
+        "summary": {
+            "assistant_message_count": len(messages),
+            "candidate_count": len(candidates),
+            "input_record_count": input_record_count,
+            "language_counts": dict(sorted(language_counts.items())),
+            "languages": sorted(language_counts),
+        },
+    }
+
+
+def serialize_report(report: Mapping[str, object]) -> str:
+    """Serialize with stable key ordering and a single trailing newline."""
+    return (
+        json.dumps(
+            report,
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+
+
+def write_report(output_path: Path, report: Mapping[str, object]) -> None:
+    """Atomically write a report using stable LF newlines."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            newline="\n",
+            dir=output_path.parent,
+            prefix=f".{output_path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temporary_name = handle.name
+            handle.write(serialize_report(report))
+        os.replace(temporary_name, output_path)
+    except OSError as exc:
+        if temporary_name:
+            try:
+                Path(temporary_name).unlink(missing_ok=True)
+            except OSError:
+                pass
+        raise CandidateMinerError(
+            f"unable to write output file: {output_path}"
+        ) from exc
+
+
+def _positive_int(raw: str) -> int:
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be an integer") from exc
+    if value < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return value
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Mine pending natural-expression candidates from an explicitly provided "
+            "local JSONL file. No rules are generated, modified, or activated."
+        )
+    )
+    parser.add_argument("--input", required=True, type=Path, help="input JSONL file")
+    parser.add_argument("--output", required=True, type=Path, help="review JSON file")
+    parser.add_argument(
+        "--language",
+        help="explicit language/locale for every assistant record; overrides record lang",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=_positive_int,
+        default=DEFAULT_THRESHOLD,
+        help=f"minimum occurrence count (default: {DEFAULT_THRESHOLD})",
+    )
+    parser.add_argument(
+        "--word-ngram-min",
+        type=_positive_int,
+        default=DEFAULT_WORD_NGRAM_MIN,
+    )
+    parser.add_argument(
+        "--word-ngram-max",
+        type=_positive_int,
+        default=DEFAULT_WORD_NGRAM_MAX,
+    )
+    parser.add_argument(
+        "--cjk-ngram-min",
+        type=_positive_int,
+        default=DEFAULT_CJK_NGRAM_MIN,
+    )
+    parser.add_argument(
+        "--cjk-ngram-max",
+        type=_positive_int,
+        default=DEFAULT_CJK_NGRAM_MAX,
+    )
+    parser.add_argument(
+        "--min-length",
+        type=_positive_int,
+        default=DEFAULT_MIN_LENGTH,
+        help=f"minimum non-space character length (default: {DEFAULT_MIN_LENGTH})",
+    )
+    parser.add_argument(
+        "--exclude-covered",
+        action="store_true",
+        help="omit candidates matched by a current curated SLOP_RULES pattern",
+    )
+    parser.add_argument(
+        "--debug-candidates",
+        action="store_true",
+        help="explicitly print candidate phrases; may expose assistant text",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    input_path = args.input.resolve()
+    output_path = args.output.resolve()
+    if input_path == output_path:
+        parser.error("--input and --output must be different files")
+
+    config = MiningConfig(
+        threshold=args.threshold,
+        word_ngram_min=args.word_ngram_min,
+        word_ngram_max=args.word_ngram_max,
+        cjk_ngram_min=args.cjk_ngram_min,
+        cjk_ngram_max=args.cjk_ngram_max,
+        min_length=args.min_length,
+        exclude_covered=args.exclude_covered,
+    )
+    try:
+        messages, record_count = read_jsonl(
+            input_path,
+            language_override=args.language,
+        )
+        report = build_report(
+            messages,
+            input_record_count=record_count,
+            config=config,
+        )
+        write_report(output_path, report)
+    except CandidateMinerError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    summary = report["summary"]
+    languages = ", ".join(summary["languages"]) or "none"
+    print(f"input: {input_path}")
+    print(f"output: {output_path}")
+    print(
+        "assistant_messages="
+        f"{summary['assistant_message_count']} candidates={summary['candidate_count']} "
+        f"languages={languages}"
+    )
+    if args.debug_candidates:
+        for candidate in report["candidates"]:
+            print(f"[debug candidate] {candidate['language']}: {candidate['phrase']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/natural_expression_candidate_miner.py
+++ b/scripts/natural_expression_candidate_miner.py
@@ -438,7 +438,7 @@ def _message_candidates(
 
 
 def _coverage_language(language: str) -> str:
-    return "zh" if language.startswith("zh") else language
+    return "zh" if language in {"zh", "zh-CN"} else language
 
 
 def _covered_rule_ids(

--- a/scripts/natural_expression_candidate_miner.py
+++ b/scripts/natural_expression_candidate_miner.py
@@ -127,6 +127,7 @@ class _CandidateStats:
     occurrence_count: int
     source_lines: set[int]
     phrases: set[str]
+    coverage_texts: set[str]
 
 
 def normalize_language(raw: str) -> str:
@@ -322,24 +323,33 @@ def _is_meaningful(value: str, min_length: int) -> bool:
     return len(compact) >= min_length and any(char.isalpha() for char in compact)
 
 
-def _word_candidates(text: str, config: MiningConfig) -> Iterator[tuple[str, str]]:
+def _word_candidates(
+    text: str,
+    config: MiningConfig,
+) -> Iterator[tuple[str, str, str]]:
     for unprotected in _unprotected_segments(text):
         for segment in _TEXT_BOUNDARY_RE.split(unprotected):
+            normalized_segment = unicodedata.normalize("NFKC", segment)
             token_run: list[str] = []
-            for match in _WORD_RE.finditer(segment):
-                token = unicodedata.normalize("NFKC", match.group(0))
+            for match in _WORD_RE.finditer(normalized_segment):
+                token = match.group(0)
                 if not any(char.isalpha() for char in token):
-                    yield from _word_run_candidates(token_run, config)
+                    yield from _word_run_candidates(
+                        token_run,
+                        config,
+                        normalized_segment,
+                    )
                     token_run = []
                     continue
                 token_run.append(token)
-            yield from _word_run_candidates(token_run, config)
+            yield from _word_run_candidates(token_run, config, normalized_segment)
 
 
 def _word_run_candidates(
     token_run: Sequence[str],
     config: MiningConfig,
-) -> Iterator[tuple[str, str]]:
+    coverage_text: str,
+) -> Iterator[tuple[str, str, str]]:
     for gram in _bounded_ngrams(
         token_run,
         config.word_ngram_min,
@@ -348,7 +358,7 @@ def _word_run_candidates(
         phrase = " ".join(gram)
         normalized = " ".join(token.casefold() for token in gram)
         if _is_meaningful(normalized, config.min_length):
-            yield normalized, phrase
+            yield normalized, phrase, coverage_text
 
 
 def _is_han(char: str) -> bool:
@@ -398,25 +408,27 @@ def _character_candidates(
     text: str,
     config: MiningConfig,
     predicate,
-) -> Iterator[tuple[str, str]]:
+) -> Iterator[tuple[str, str, str]]:
     for unprotected in _unprotected_segments(text):
-        for run in _script_runs(unprotected, predicate):
-            characters = list(run)
-            for gram in _bounded_ngrams(
-                characters,
-                config.cjk_ngram_min,
-                config.cjk_ngram_max,
-            ):
-                phrase = "".join(gram)
-                normalized = phrase.casefold()
-                if _is_meaningful(normalized, config.min_length):
-                    yield normalized, phrase
+        for segment in _TEXT_BOUNDARY_RE.split(unprotected):
+            coverage_text = unicodedata.normalize("NFKC", segment)
+            for run in _script_runs(coverage_text, predicate):
+                characters = list(run)
+                for gram in _bounded_ngrams(
+                    characters,
+                    config.cjk_ngram_min,
+                    config.cjk_ngram_max,
+                ):
+                    phrase = "".join(gram)
+                    normalized = phrase.casefold()
+                    if _is_meaningful(normalized, config.min_length):
+                        yield normalized, phrase, coverage_text
 
 
 def _message_candidates(
     message: SourceMessage,
     config: MiningConfig,
-) -> Iterator[tuple[str, str]]:
+) -> Iterator[tuple[str, str, str]]:
     language = message.language
     if language in _WHITESPACE_LANGUAGES:
         yield from _word_candidates(message.content, config)
@@ -444,9 +456,13 @@ def _coverage_language(language: str) -> str:
 def _covered_rule_ids(
     language: str,
     phrases: Iterable[str],
+    coverage_texts: Iterable[str],
     rules_by_language: Mapping[str, Sequence[Mapping[str, object]]],
 ) -> list[str]:
     covered: set[str] = set()
+    normalized_phrases = {
+        unicodedata.normalize("NFKC", phrase).casefold() for phrase in phrases
+    }
     for rule in rules_by_language.get(_coverage_language(language), ()):
         rule_id = rule.get("id")
         pattern = rule.get("find")
@@ -459,8 +475,15 @@ def _covered_rule_ids(
             raise CandidateMinerError(
                 f"existing rule {rule_id} has an invalid pattern"
             ) from exc
-        if any(compiled.search(phrase) for phrase in phrases):
-            covered.add(rule_id)
+        for coverage_text in coverage_texts:
+            if any(
+                normalized_phrase
+                in unicodedata.normalize("NFKC", match.group(0)).casefold()
+                for match in compiled.finditer(coverage_text)
+                for normalized_phrase in normalized_phrases
+            ):
+                covered.add(rule_id)
+                break
     return sorted(covered)
 
 
@@ -488,15 +511,16 @@ def build_report(
     stats: dict[tuple[str, str], _CandidateStats] = {}
 
     for message in messages:
-        for normalized, phrase in _message_candidates(message, config):
+        for normalized, phrase, coverage_text in _message_candidates(message, config):
             key = (message.language, normalized)
             candidate_stats = stats.get(key)
             if candidate_stats is None:
-                candidate_stats = _CandidateStats(0, set(), set())
+                candidate_stats = _CandidateStats(0, set(), set(), set())
                 stats[key] = candidate_stats
             candidate_stats.occurrence_count += 1
             candidate_stats.source_lines.add(message.source_line)
             candidate_stats.phrases.add(phrase)
+            candidate_stats.coverage_texts.add(coverage_text)
 
     candidates: list[dict[str, object]] = []
     for (language, normalized), candidate_stats in stats.items():
@@ -505,6 +529,7 @@ def build_report(
         covered_by = _covered_rule_ids(
             language,
             sorted(candidate_stats.phrases),
+            sorted(candidate_stats.coverage_texts),
             current_rules,
         )
         if config.exclude_covered and covered_by:

--- a/scripts/natural_expression_candidate_miner.py
+++ b/scripts/natural_expression_candidate_miner.py
@@ -33,7 +33,7 @@ import unicodedata
 from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Iterator, Mapping, Sequence
+from typing import Iterator, Mapping, Sequence, TypeVar
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(REPO_ROOT) not in sys.path:
@@ -122,12 +122,21 @@ class SourceMessage:
     source_line: int
 
 
+@dataclass(frozen=True)
+class _CandidateOccurrence:
+    normalized: str
+    phrase: str
+    coverage_text: str
+    start: int
+    end: int
+
+
 @dataclass
 class _CandidateStats:
     occurrence_count: int
     source_lines: set[int]
     phrases: set[str]
-    coverage_texts: set[str]
+    occurrences: list[_CandidateOccurrence]
 
 
 def normalize_language(raw: str) -> str:
@@ -307,11 +316,14 @@ def _unprotected_segments(text: str) -> Iterator[str]:
         yield text[cursor:]
 
 
+_T = TypeVar("_T")
+
+
 def _bounded_ngrams(
-    values: Sequence[str],
+    values: Sequence[_T],
     minimum: int,
     maximum: int,
-) -> Iterator[tuple[str, ...]]:
+) -> Iterator[tuple[_T, ...]]:
     upper = min(maximum, len(values))
     for size in range(minimum, upper + 1):
         for start in range(0, len(values) - size + 1):
@@ -326,11 +338,11 @@ def _is_meaningful(value: str, min_length: int) -> bool:
 def _word_candidates(
     text: str,
     config: MiningConfig,
-) -> Iterator[tuple[str, str, str]]:
+) -> Iterator[_CandidateOccurrence]:
     for unprotected in _unprotected_segments(text):
         for segment in _TEXT_BOUNDARY_RE.split(unprotected):
             normalized_segment = unicodedata.normalize("NFKC", segment)
-            token_run: list[str] = []
+            token_run: list[tuple[str, int, int]] = []
             for match in _WORD_RE.finditer(normalized_segment):
                 token = match.group(0)
                 if not any(char.isalpha() for char in token):
@@ -341,24 +353,30 @@ def _word_candidates(
                     )
                     token_run = []
                     continue
-                token_run.append(token)
+                token_run.append((token, match.start(), match.end()))
             yield from _word_run_candidates(token_run, config, normalized_segment)
 
 
 def _word_run_candidates(
-    token_run: Sequence[str],
+    token_run: Sequence[tuple[str, int, int]],
     config: MiningConfig,
     coverage_text: str,
-) -> Iterator[tuple[str, str, str]]:
+) -> Iterator[_CandidateOccurrence]:
     for gram in _bounded_ngrams(
         token_run,
         config.word_ngram_min,
         config.word_ngram_max,
     ):
-        phrase = " ".join(gram)
-        normalized = " ".join(token.casefold() for token in gram)
+        phrase = " ".join(token for token, _, _ in gram)
+        normalized = " ".join(token.casefold() for token, _, _ in gram)
         if _is_meaningful(normalized, config.min_length):
-            yield normalized, phrase, coverage_text
+            yield _CandidateOccurrence(
+                normalized=normalized,
+                phrase=phrase,
+                coverage_text=coverage_text,
+                start=gram[0][1],
+                end=gram[-1][2],
+            )
 
 
 def _is_han(char: str) -> bool:
@@ -375,6 +393,9 @@ def _is_japanese(char: str) -> bool:
     codepoint = ord(char)
     return (
         _is_han(char)
+        or codepoint == 0x3005
+        or 0x3031 <= codepoint <= 0x3035
+        or codepoint == 0x303B
         or 0x3040 <= codepoint <= 0x30FF
         or 0x31F0 <= codepoint <= 0x31FF
         or 0xFF66 <= codepoint <= 0xFF9D
@@ -392,43 +413,51 @@ def _is_hangul(char: str) -> bool:
     )
 
 
-def _script_runs(text: str, predicate) -> Iterator[str]:
+def _script_runs(text: str, predicate) -> Iterator[tuple[str, int]]:
     run: list[str] = []
-    for char in unicodedata.normalize("NFKC", text):
+    run_start = 0
+    for index, char in enumerate(text):
         if predicate(char):
+            if not run:
+                run_start = index
             run.append(char)
         elif run:
-            yield "".join(run)
+            yield "".join(run), run_start
             run = []
     if run:
-        yield "".join(run)
+        yield "".join(run), run_start
 
 
 def _character_candidates(
     text: str,
     config: MiningConfig,
     predicate,
-) -> Iterator[tuple[str, str, str]]:
+) -> Iterator[_CandidateOccurrence]:
     for unprotected in _unprotected_segments(text):
         for segment in _TEXT_BOUNDARY_RE.split(unprotected):
             coverage_text = unicodedata.normalize("NFKC", segment)
-            for run in _script_runs(coverage_text, predicate):
+            for run, run_start in _script_runs(coverage_text, predicate):
                 characters = list(run)
-                for gram in _bounded_ngrams(
-                    characters,
-                    config.cjk_ngram_min,
-                    config.cjk_ngram_max,
-                ):
-                    phrase = "".join(gram)
-                    normalized = phrase.casefold()
-                    if _is_meaningful(normalized, config.min_length):
-                        yield normalized, phrase, coverage_text
+                upper = min(config.cjk_ngram_max, len(characters))
+                for size in range(config.cjk_ngram_min, upper + 1):
+                    for start in range(0, len(characters) - size + 1):
+                        gram = characters[start : start + size]
+                        phrase = "".join(gram)
+                        normalized = phrase.casefold()
+                        if _is_meaningful(normalized, config.min_length):
+                            yield _CandidateOccurrence(
+                                normalized=normalized,
+                                phrase=phrase,
+                                coverage_text=coverage_text,
+                                start=run_start + start,
+                                end=run_start + start + size,
+                            )
 
 
 def _message_candidates(
     message: SourceMessage,
     config: MiningConfig,
-) -> Iterator[tuple[str, str, str]]:
+) -> Iterator[_CandidateOccurrence]:
     language = message.language
     if language in _WHITESPACE_LANGUAGES:
         yield from _word_candidates(message.content, config)
@@ -445,12 +474,22 @@ def _message_candidates(
         # identical single-token occurrence once in each strategy.
         word_candidates = list(_word_candidates(message.content, config))
         overlapping_word_counts = Counter(
-            (normalized, coverage_text)
-            for normalized, _, coverage_text in word_candidates
+            (
+                candidate.normalized,
+                candidate.coverage_text,
+                candidate.start,
+                candidate.end,
+            )
+            for candidate in word_candidates
         )
         yield from word_candidates
         for candidate in _character_candidates(message.content, config, _is_hangul):
-            overlap_key = (candidate[0], candidate[2])
+            overlap_key = (
+                candidate.normalized,
+                candidate.coverage_text,
+                candidate.start,
+                candidate.end,
+            )
             if overlapping_word_counts[overlap_key]:
                 overlapping_word_counts[overlap_key] -= 1
                 continue
@@ -463,16 +502,13 @@ def _coverage_language(language: str) -> str:
     return "zh" if language in {"zh", "zh-CN"} else language
 
 
-def _covered_rule_ids(
+def _coverage_result(
     language: str,
-    phrases: Iterable[str],
-    coverage_texts: Iterable[str],
+    occurrences: Sequence[_CandidateOccurrence],
     rules_by_language: Mapping[str, Sequence[Mapping[str, object]]],
-) -> list[str]:
+) -> tuple[list[str], bool]:
+    compiled_rules: list[tuple[str, re.Pattern[str]]] = []
     covered: set[str] = set()
-    normalized_phrases = {
-        unicodedata.normalize("NFKC", phrase).casefold() for phrase in phrases
-    }
     for rule in rules_by_language.get(_coverage_language(language), ()):
         rule_id = rule.get("id")
         pattern = rule.get("find")
@@ -485,16 +521,21 @@ def _covered_rule_ids(
             raise CandidateMinerError(
                 f"existing rule {rule_id} has an invalid pattern"
             ) from exc
-        for coverage_text in coverage_texts:
+        compiled_rules.append((rule_id, compiled))
+
+    all_occurrences_covered = bool(occurrences)
+    for occurrence in occurrences:
+        occurrence_covered = False
+        for rule_id, compiled in compiled_rules:
             if any(
-                normalized_phrase
-                in unicodedata.normalize("NFKC", match.group(0)).casefold()
-                for match in compiled.finditer(coverage_text)
-                for normalized_phrase in normalized_phrases
+                match.start() <= occurrence.start and occurrence.end <= match.end()
+                for match in compiled.finditer(occurrence.coverage_text)
             ):
                 covered.add(rule_id)
-                break
-    return sorted(covered)
+                occurrence_covered = True
+        if not occurrence_covered:
+            all_occurrences_covered = False
+    return sorted(covered), all_occurrences_covered
 
 
 def load_current_rules() -> Mapping[str, Sequence[Mapping[str, object]]]:
@@ -521,28 +562,27 @@ def build_report(
     stats: dict[tuple[str, str], _CandidateStats] = {}
 
     for message in messages:
-        for normalized, phrase, coverage_text in _message_candidates(message, config):
-            key = (message.language, normalized)
+        for occurrence in _message_candidates(message, config):
+            key = (message.language, occurrence.normalized)
             candidate_stats = stats.get(key)
             if candidate_stats is None:
-                candidate_stats = _CandidateStats(0, set(), set(), set())
+                candidate_stats = _CandidateStats(0, set(), set(), [])
                 stats[key] = candidate_stats
             candidate_stats.occurrence_count += 1
             candidate_stats.source_lines.add(message.source_line)
-            candidate_stats.phrases.add(phrase)
-            candidate_stats.coverage_texts.add(coverage_text)
+            candidate_stats.phrases.add(occurrence.phrase)
+            candidate_stats.occurrences.append(occurrence)
 
     candidates: list[dict[str, object]] = []
     for (language, normalized), candidate_stats in stats.items():
         if candidate_stats.occurrence_count < config.threshold:
             continue
-        covered_by = _covered_rule_ids(
+        covered_by, all_occurrences_covered = _coverage_result(
             language,
-            sorted(candidate_stats.phrases),
-            sorted(candidate_stats.coverage_texts),
+            candidate_stats.occurrences,
             current_rules,
         )
-        if config.exclude_covered and covered_by:
+        if config.exclude_covered and all_occurrences_covered:
             continue
         candidates.append(
             {

--- a/scripts/natural_expression_candidate_miner.py
+++ b/scripts/natural_expression_candidate_miner.py
@@ -71,7 +71,6 @@ _LANGUAGE_ALIASES = {
     "zh-hant": "zh-TW",
 }
 _WHITESPACE_LANGUAGES = frozenset({"en", "es", "pt", "ru"})
-_WORD_RE = re.compile(r"[^\W_]+(?:[\u2019'][^\W_]+)*", re.UNICODE)
 _TEXT_BOUNDARY_RE = re.compile(r"[\r\n.!?。！？；;:：,，、]+")
 _URL_RE = re.compile(r"(?:https?://|www\.)[^\s<>()]+", re.IGNORECASE)
 _TEMPLATE_RE = re.compile(
@@ -289,10 +288,20 @@ def _inline_code_spans(
 
 def _protected_spans(text: str) -> list[tuple[int, int]]:
     """Return merged spans for code, URLs, and obvious template placeholders."""
+    spans = _runtime_protected_spans(text)
+    spans.extend(match.span() for match in _TEMPLATE_RE.finditer(text))
+    return _merge_spans(spans)
+
+
+def _runtime_protected_spans(text: str) -> list[tuple[int, int]]:
+    """Mirror the runtime filter's fenced-code, inline-code, and URL spans."""
     fenced = _fenced_code_spans(text)
     spans = fenced + _inline_code_spans(text, fenced)
     spans.extend(match.span() for match in _URL_RE.finditer(text))
-    spans.extend(match.span() for match in _TEMPLATE_RE.finditer(text))
+    return _merge_spans(spans)
+
+
+def _merge_spans(spans: Sequence[tuple[int, int]]) -> list[tuple[int, int]]:
     if not spans:
         return []
 
@@ -305,15 +314,26 @@ def _protected_spans(text: str) -> list[tuple[int, int]]:
     return merged
 
 
-def _unprotected_segments(text: str) -> Iterator[str]:
-    """Yield text outside protected spans without bridging across a removed span."""
+def _unprotected_segments(text: str) -> Iterator[tuple[str, int]]:
+    """Yield text and offsets outside protected spans without bridging them."""
     cursor = 0
     for start, end in _protected_spans(text):
         if cursor < start:
-            yield text[cursor:start]
+            yield text[cursor:start], cursor
         cursor = end
     if cursor < len(text):
-        yield text[cursor:]
+        yield text[cursor:], cursor
+
+
+def _text_segments(text: str, base_offset: int) -> Iterator[tuple[str, int]]:
+    """Yield punctuation-bounded mining segments with original-text offsets."""
+    cursor = 0
+    for match in _TEXT_BOUNDARY_RE.finditer(text):
+        if cursor < match.start():
+            yield text[cursor : match.start()], base_offset + cursor
+        cursor = match.end()
+    if cursor < len(text):
+        yield text[cursor:], base_offset + cursor
 
 
 _T = TypeVar("_T")
@@ -335,26 +355,53 @@ def _is_meaningful(value: str, min_length: int) -> bool:
     return len(compact) >= min_length and any(char.isalpha() for char in compact)
 
 
+def _word_tokens(text: str) -> Iterator[tuple[str, int, int]]:
+    """Yield NFKC-normalized word tokens with spans in the original text."""
+    index = 0
+    while index < len(text):
+        if not text[index].isalnum() or text[index] == "_":
+            index += 1
+            continue
+        start = index
+        index += 1
+        while index < len(text):
+            char = text[index]
+            if char.isalnum() and char != "_":
+                index += 1
+                continue
+            if unicodedata.category(char).startswith("M"):
+                index += 1
+                continue
+            if (
+                char in {"'", "\u2019"}
+                and index + 1 < len(text)
+                and text[index + 1].isalnum()
+                and text[index + 1] != "_"
+            ):
+                index += 1
+                continue
+            break
+        yield unicodedata.normalize("NFKC", text[start:index]), start, index
+
+
 def _word_candidates(
     text: str,
     config: MiningConfig,
 ) -> Iterator[_CandidateOccurrence]:
-    for unprotected in _unprotected_segments(text):
-        for segment in _TEXT_BOUNDARY_RE.split(unprotected):
-            normalized_segment = unicodedata.normalize("NFKC", segment)
+    for unprotected, unprotected_start in _unprotected_segments(text):
+        for segment, segment_start in _text_segments(unprotected, unprotected_start):
             token_run: list[tuple[str, int, int]] = []
-            for match in _WORD_RE.finditer(normalized_segment):
-                token = match.group(0)
+            for token, start, end in _word_tokens(segment):
                 if not any(char.isalpha() for char in token):
                     yield from _word_run_candidates(
                         token_run,
                         config,
-                        normalized_segment,
+                        text,
                     )
                     token_run = []
                     continue
-                token_run.append((token, match.start(), match.end()))
-            yield from _word_run_candidates(token_run, config, normalized_segment)
+                token_run.append((token, segment_start + start, segment_start + end))
+            yield from _word_run_candidates(token_run, config, text)
 
 
 def _word_run_candidates(
@@ -413,19 +460,48 @@ def _is_hangul(char: str) -> bool:
     )
 
 
-def _script_runs(text: str, predicate) -> Iterator[tuple[str, int]]:
-    run: list[str] = []
-    run_start = 0
-    for index, char in enumerate(text):
+def _is_hangul_jamo(char: str) -> bool:
+    codepoint = ord(char)
+    return (
+        0x1100 <= codepoint <= 0x11FF
+        or 0x3130 <= codepoint <= 0x318F
+        or 0xA960 <= codepoint <= 0xA97F
+        or 0xD7B0 <= codepoint <= 0xD7FF
+    )
+
+
+def _normalized_characters(text: str) -> Iterator[tuple[str, int, int]]:
+    """Yield normalized characters mapped to their original source spans."""
+    index = 0
+    while index < len(text):
+        start = index
+        index += 1
+        if _is_hangul_jamo(text[start]):
+            while index < len(text) and _is_hangul_jamo(text[index]):
+                index += 1
+        while index < len(text) and (
+            unicodedata.category(text[index]).startswith("M")
+            or text[index] in {"\uff9e", "\uff9f"}
+        ):
+            index += 1
+        normalized = unicodedata.normalize("NFKC", text[start:index])
+        for char in normalized:
+            yield char, start, index
+
+
+def _script_runs(
+    text: str,
+    predicate,
+) -> Iterator[list[tuple[str, int, int]]]:
+    run: list[tuple[str, int, int]] = []
+    for char, start, end in _normalized_characters(text):
         if predicate(char):
-            if not run:
-                run_start = index
-            run.append(char)
+            run.append((char, start, end))
         elif run:
-            yield "".join(run), run_start
+            yield run
             run = []
     if run:
-        yield "".join(run), run_start
+        yield run
 
 
 def _character_candidates(
@@ -433,24 +509,22 @@ def _character_candidates(
     config: MiningConfig,
     predicate,
 ) -> Iterator[_CandidateOccurrence]:
-    for unprotected in _unprotected_segments(text):
-        for segment in _TEXT_BOUNDARY_RE.split(unprotected):
-            coverage_text = unicodedata.normalize("NFKC", segment)
-            for run, run_start in _script_runs(coverage_text, predicate):
-                characters = list(run)
-                upper = min(config.cjk_ngram_max, len(characters))
+    for unprotected, unprotected_start in _unprotected_segments(text):
+        for segment, segment_start in _text_segments(unprotected, unprotected_start):
+            for run in _script_runs(segment, predicate):
+                upper = min(config.cjk_ngram_max, len(run))
                 for size in range(config.cjk_ngram_min, upper + 1):
-                    for start in range(0, len(characters) - size + 1):
-                        gram = characters[start : start + size]
-                        phrase = "".join(gram)
+                    for start in range(0, len(run) - size + 1):
+                        gram = run[start : start + size]
+                        phrase = "".join(char for char, _, _ in gram)
                         normalized = phrase.casefold()
                         if _is_meaningful(normalized, config.min_length):
                             yield _CandidateOccurrence(
                                 normalized=normalized,
                                 phrase=phrase,
-                                coverage_text=coverage_text,
-                                start=run_start + start,
-                                end=run_start + start + size,
+                                coverage_text=text,
+                                start=segment_start + gram[0][1],
+                                end=segment_start + gram[-1][2],
                             )
 
 
@@ -508,6 +582,8 @@ def _coverage_result(
     rules_by_language: Mapping[str, Sequence[Mapping[str, object]]],
 ) -> tuple[list[str], bool]:
     compiled_rules: list[tuple[str, re.Pattern[str]]] = []
+    protected_cache: dict[str, list[tuple[int, int]]] = {}
+    match_cache: dict[tuple[str, int], tuple[tuple[int, int], ...]] = {}
     covered: set[str] = set()
     for rule in rules_by_language.get(_coverage_language(language), ()):
         rule_id = rule.get("id")
@@ -526,10 +602,27 @@ def _coverage_result(
     all_occurrences_covered = bool(occurrences)
     for occurrence in occurrences:
         occurrence_covered = False
-        for rule_id, compiled in compiled_rules:
+        protected = protected_cache.get(occurrence.coverage_text)
+        if protected is None:
+            protected = _runtime_protected_spans(occurrence.coverage_text)
+            protected_cache[occurrence.coverage_text] = protected
+        for rule_index, (rule_id, compiled) in enumerate(compiled_rules):
+            cache_key = (occurrence.coverage_text, rule_index)
+            match_spans = match_cache.get(cache_key)
+            if match_spans is None:
+                match_spans = tuple(
+                    (match.start(), match.end())
+                    for match in compiled.finditer(occurrence.coverage_text)
+                    if match.start() != match.end()
+                    and not any(
+                        match.start() < protected_end and match.end() > protected_start
+                        for protected_start, protected_end in protected
+                    )
+                )
+                match_cache[cache_key] = match_spans
             if any(
-                match.start() <= occurrence.start and occurrence.end <= match.end()
-                for match in compiled.finditer(occurrence.coverage_text)
+                start <= occurrence.start and occurrence.end <= end
+                for start, end in match_spans
             ):
                 covered.add(rule_id)
                 occurrence_covered = True

--- a/tests/unit/test_natural_expression_candidate_miner.py
+++ b/tests/unit/test_natural_expression_candidate_miner.py
@@ -188,6 +188,38 @@ def test_korean_uses_word_and_hangul_character_strategies():
     assert _candidate(report, "두근두근")["occurrence_count"] == 3
 
 
+def test_korean_single_token_is_not_double_counted_across_strategies():
+    messages = [miner.SourceMessage("ko", "두근두근", index) for index in range(1, 3)]
+    config = _config(
+        threshold=1,
+        word_ngram_min=1,
+        word_ngram_max=1,
+    )
+
+    report = miner.build_report(
+        messages,
+        input_record_count=2,
+        config=config,
+        rules_by_language={},
+    )
+
+    candidate = _candidate(report, "두근두근")
+    assert candidate["occurrence_count"] == 2
+    assert candidate["message_count"] == 2
+
+    below_threshold = miner.build_report(
+        messages,
+        input_record_count=2,
+        config=_config(
+            threshold=3,
+            word_ngram_min=1,
+            word_ngram_max=1,
+        ),
+        rules_by_language={},
+    )
+    assert below_threshold["candidates"] == []
+
+
 def test_code_urls_and_template_noise_are_protected():
     text = (
         "`hidden phrase` https://example.test/hidden-phrase\n"

--- a/tests/unit/test_natural_expression_candidate_miner.py
+++ b/tests/unit/test_natural_expression_candidate_miner.py
@@ -122,6 +122,23 @@ def test_unicode_word_ngrams_by_language(language, phrase, normalized):
     assert _candidate(report, normalized)["occurrence_count"] == 3
 
 
+def test_word_tokenization_normalizes_decomposed_accents_before_counting():
+    messages = [
+        miner.SourceMessage("pt", "café tranquilo", 1),
+        miner.SourceMessage("pt", "cafe\u0301 tranquilo", 2),
+        miner.SourceMessage("pt", "cafe\u0301 tranquilo", 3),
+    ]
+
+    report = miner.build_report(
+        messages,
+        input_record_count=3,
+        config=_config(),
+        rules_by_language={},
+    )
+
+    assert _candidate(report, "café tranquilo")["occurrence_count"] == 3
+
+
 @pytest.mark.parametrize(
     ("language", "phrase"),
     [
@@ -274,6 +291,25 @@ def test_traditional_chinese_is_not_covered_by_simplified_runtime_rules():
     )
 
     assert _candidate(report, phrase)["covered_by_rule_ids"] == []
+
+
+def test_cjk_coverage_checks_the_complete_matched_collocation():
+    phrase = "嘴角微微勾起一抹笑意"
+    messages = [miner.SourceMessage("zh-CN", phrase, index) for index in range(1, 4)]
+
+    report = miner.build_report(
+        messages,
+        input_record_count=3,
+        config=_config(),
+    )
+    assert _candidate(report, "嘴角微微")["covered_by_rule_ids"] == ["ZH_002"]
+
+    excluded = miner.build_report(
+        messages,
+        input_record_count=3,
+        config=_config(exclude_covered=True),
+    )
+    assert excluded["candidates"] == []
 
 
 def test_output_schema_is_pending_and_not_a_runtime_rule_schema():

--- a/tests/unit/test_natural_expression_candidate_miner.py
+++ b/tests/unit/test_natural_expression_candidate_miner.py
@@ -333,6 +333,112 @@ def test_partially_covered_candidate_is_annotated_but_not_excluded():
     assert candidate["occurrence_count"] == 4
 
 
+def test_word_coverage_uses_original_sentence_delimiters():
+    text = "Он смотрел. Словно само время замерло"
+    messages = [miner.SourceMessage("ru", text, index) for index in range(1, 4)]
+    rules = {
+        "ru": [
+            {
+                "id": "RU_011",
+                "find": (
+                    r"(^|[.!?…]\s)(?:Словно|Будто)\s+(?:само\s+)?"
+                    r"время\s+(?:замерло|остановилось|застыло)\b"
+                ),
+            }
+        ]
+    }
+
+    report = miner.build_report(
+        messages,
+        input_record_count=3,
+        config=_config(
+            word_ngram_min=4,
+            word_ngram_max=4,
+            exclude_covered=True,
+        ),
+        rules_by_language=rules,
+    )
+
+    assert report["candidates"] == []
+
+
+def test_cjk_coverage_uses_original_punctuation_context():
+    text = "张了张嘴，欲言又止"
+    messages = [miner.SourceMessage("zh-CN", text, index) for index in range(1, 4)]
+
+    report = miner.build_report(
+        messages,
+        input_record_count=3,
+        config=_config(),
+    )
+
+    assert _candidate(report, "张了张嘴")["covered_by_rule_ids"] == ["ZH_026"]
+    assert _candidate(report, "欲言又止")["covered_by_rule_ids"] == ["ZH_026"]
+
+    excluded = miner.build_report(
+        messages,
+        input_record_count=3,
+        config=_config(exclude_covered=True),
+    )
+    assert excluded["candidates"] == []
+
+
+def test_coverage_does_not_normalize_original_runtime_text():
+    text = "aguanto\u0301 el aliento"
+    messages = [miner.SourceMessage("es", text, index) for index in range(1, 4)]
+    rules = {
+        "es": [
+            {
+                "id": "ES_002",
+                "find": r"\b(?:contuvo|aguant[oó]) el aliento\b",
+            }
+        ]
+    }
+
+    report = miner.build_report(
+        messages,
+        input_record_count=3,
+        config=_config(
+            word_ngram_min=3,
+            word_ngram_max=3,
+            exclude_covered=True,
+        ),
+        rules_by_language=rules,
+    )
+
+    assert _candidate(report, "aguantó el aliento")["covered_by_rule_ids"] == []
+
+
+def test_coverage_preserves_protected_suffixes_in_original_text():
+    text = "A beat of silence passed `token`"
+    messages = [miner.SourceMessage("en", text, index) for index in range(1, 4)]
+    rules = {
+        "en": [
+            {
+                "id": "EN_023",
+                "find": (
+                    r"\b(?:[Aa]\s+)?(?:beat|moment)\s+of\s+silence\s+"
+                    r"(?:passed|hung|stretched|fell|followed|settled)"
+                    r"(?=\s*[.,;:!?]|\s*$)"
+                ),
+            }
+        ]
+    }
+
+    report = miner.build_report(
+        messages,
+        input_record_count=3,
+        config=_config(
+            word_ngram_min=5,
+            word_ngram_max=5,
+            exclude_covered=True,
+        ),
+        rules_by_language=rules,
+    )
+
+    assert _candidate(report, "a beat of silence passed")["covered_by_rule_ids"] == []
+
+
 def test_coverage_reads_the_real_curated_rule_table():
     messages = [
         miner.SourceMessage("en", "She smiled warmly", index) for index in range(1, 4)

--- a/tests/unit/test_natural_expression_candidate_miner.py
+++ b/tests/unit/test_natural_expression_candidate_miner.py
@@ -257,6 +257,25 @@ def test_coverage_reads_the_real_curated_rule_table():
     assert _candidate(report, "she smiled warmly")["covered_by_rule_ids"] == ["EN_004"]
 
 
+def test_traditional_chinese_is_not_covered_by_simplified_runtime_rules():
+    phrase = "嘴角微微上揚"
+    messages = [miner.SourceMessage("zh-TW", phrase, index) for index in range(1, 4)]
+    rules = {"zh": [{"id": "ZH_TEST", "find": phrase}]}
+
+    report = miner.build_report(
+        messages,
+        input_record_count=3,
+        config=_config(
+            cjk_ngram_min=len(phrase),
+            cjk_ngram_max=len(phrase),
+            exclude_covered=True,
+        ),
+        rules_by_language=rules,
+    )
+
+    assert _candidate(report, phrase)["covered_by_rule_ids"] == []
+
+
 def test_output_schema_is_pending_and_not_a_runtime_rule_schema():
     messages = [
         miner.SourceMessage("en", "quiet lantern", index) for index in range(1, 4)

--- a/tests/unit/test_natural_expression_candidate_miner.py
+++ b/tests/unit/test_natural_expression_candidate_miner.py
@@ -171,6 +171,20 @@ def test_cjk_character_ngrams_split_at_punctuation(language, phrase):
     )
 
 
+def test_japanese_iteration_marks_remain_in_script_runs():
+    phrase = "時々微笑む"
+    messages = [miner.SourceMessage("ja", phrase, index) for index in range(1, 4)]
+
+    report = miner.build_report(
+        messages,
+        input_record_count=3,
+        config=_config(cjk_ngram_min=len(phrase), cjk_ngram_max=len(phrase)),
+        rules_by_language={},
+    )
+
+    assert _candidate(report, phrase)["occurrence_count"] == 3
+
+
 def test_korean_uses_word_and_hangul_character_strategies():
     messages = [
         miner.SourceMessage("ko", "조용한 달빛. 두근두근.", index)
@@ -290,6 +304,33 @@ def test_current_rule_coverage_is_read_only_and_can_be_excluded():
         rules_by_language=rules,
     )
     assert excluded["candidates"] == []
+
+
+def test_partially_covered_candidate_is_annotated_but_not_excluded():
+    messages = [
+        miner.SourceMessage("en", "smiled warmly", index) for index in range(1, 4)
+    ]
+    messages.append(miner.SourceMessage("en", "She smiled warmly", 4))
+    rules = {
+        "en": [
+            {
+                "id": "EN_004",
+                "find": r"\b(he|she|they|I|you)\s+smiled\s+(?:warmly|softly)\b",
+                "flags": re.IGNORECASE,
+            }
+        ]
+    }
+
+    report = miner.build_report(
+        messages,
+        input_record_count=4,
+        config=_config(exclude_covered=True),
+        rules_by_language=rules,
+    )
+
+    candidate = _candidate(report, "smiled warmly")
+    assert candidate["covered_by_rule_ids"] == ["EN_004"]
+    assert candidate["occurrence_count"] == 4
 
 
 def test_coverage_reads_the_real_curated_rule_table():

--- a/tests/unit/test_natural_expression_candidate_miner.py
+++ b/tests/unit/test_natural_expression_candidate_miner.py
@@ -1,0 +1,362 @@
+"""Synthetic tests for the maintainer-only candidate miner."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from scripts import natural_expression_candidate_miner as miner
+
+
+def _config(**overrides) -> miner.MiningConfig:
+    values = {
+        "threshold": 3,
+        "word_ngram_min": 2,
+        "word_ngram_max": 2,
+        "cjk_ngram_min": 4,
+        "cjk_ngram_max": 4,
+        "min_length": 1,
+        "exclude_covered": False,
+    }
+    values.update(overrides)
+    return miner.MiningConfig(**values)
+
+
+def _candidate(report, normalized_phrase: str):
+    return next(
+        candidate
+        for candidate in report["candidates"]
+        if candidate["normalized_phrase"] == normalized_phrase
+    )
+
+
+def test_assistant_only_counts_occurrences_and_distinct_messages(tmp_path: Path):
+    input_path = tmp_path / "synthetic.jsonl"
+    records = [
+        {
+            "role": "system",
+            "content": "Soft silver rain Soft silver rain",
+            "lang": "en",
+        },
+        {"role": "user", "content": "Soft silver rain Soft silver rain", "lang": "en"},
+        {
+            "role": "assistant",
+            "content": "Soft silver rain. Soft silver rain.",
+            "lang": "en",
+        },
+        {"role": "assistant", "content": "Soft silver rain.", "lang": "en"},
+    ]
+    input_path.write_text(
+        "\n".join(json.dumps(record) for record in records) + "\n",
+        encoding="utf-8",
+    )
+
+    messages, record_count = miner.read_jsonl(input_path)
+    report = miner.build_report(
+        messages,
+        input_record_count=record_count,
+        config=_config(word_ngram_min=3, word_ngram_max=3),
+        rules_by_language={},
+    )
+
+    candidate = _candidate(report, "soft silver rain")
+    assert candidate["occurrence_count"] == 3
+    assert candidate["message_count"] == 2
+    assert report["summary"]["assistant_message_count"] == 2
+    assert report["summary"]["input_record_count"] == 4
+
+
+def test_explicit_language_overrides_missing_or_unknown_record_language(tmp_path: Path):
+    input_path = tmp_path / "override.jsonl"
+    records = [
+        {"role": "assistant", "content": "quiet lantern"},
+        {"role": "assistant", "content": "quiet lantern", "lang": "unknown"},
+        {"role": "assistant", "content": "quiet lantern", "lang": "ja"},
+    ]
+    input_path.write_text(
+        "\n".join(json.dumps(record) for record in records) + "\n",
+        encoding="utf-8",
+    )
+
+    messages, record_count = miner.read_jsonl(input_path, language_override="en-US")
+    report = miner.build_report(
+        messages,
+        input_record_count=record_count,
+        config=_config(),
+        rules_by_language={},
+    )
+
+    assert [message.language for message in messages] == ["en", "en", "en"]
+    assert _candidate(report, "quiet lantern")["occurrence_count"] == 3
+
+
+@pytest.mark.parametrize(
+    ("language", "phrase", "normalized"),
+    [
+        ("en", "Gentle Moonlight", "gentle moonlight"),
+        ("es", "brisa cálida", "brisa cálida"),
+        ("pt-BR", "Coração tranquilo", "coração tranquilo"),
+        ("ru", "Тихий свет", "тихий свет"),
+    ],
+)
+def test_unicode_word_ngrams_by_language(language, phrase, normalized):
+    messages = [
+        miner.SourceMessage(
+            language=miner.normalize_language(language),
+            content=phrase,
+            source_line=index,
+        )
+        for index in range(1, 4)
+    ]
+
+    report = miner.build_report(
+        messages,
+        input_record_count=3,
+        config=_config(),
+        rules_by_language={},
+    )
+
+    assert _candidate(report, normalized)["occurrence_count"] == 3
+
+
+@pytest.mark.parametrize(
+    ("language", "phrase"),
+    [
+        ("zh-CN", "嘴角微微上扬"),
+        ("zh-TW", "嘴角微微上揚"),
+        ("ja", "静かな月明かり"),
+    ],
+)
+def test_cjk_character_ngrams_split_at_punctuation(language, phrase):
+    size = len(phrase)
+    config = _config(cjk_ngram_min=size, cjk_ngram_max=size)
+    messages = [
+        miner.SourceMessage(language, f"{phrase}。{phrase}！", 1),
+        miner.SourceMessage(language, phrase, 2),
+    ]
+
+    report = miner.build_report(
+        messages,
+        input_record_count=2,
+        config=config,
+        rules_by_language={},
+    )
+
+    candidate = _candidate(report, phrase)
+    assert candidate["occurrence_count"] == 3
+    assert candidate["message_count"] == 2
+    assert all(
+        "。" not in item["phrase"] and "！" not in item["phrase"]
+        for item in report["candidates"]
+    )
+
+
+def test_korean_uses_word_and_hangul_character_strategies():
+    messages = [
+        miner.SourceMessage("ko", "조용한 달빛. 두근두근.", index)
+        for index in range(1, 4)
+    ]
+
+    report = miner.build_report(
+        messages,
+        input_record_count=3,
+        config=_config(),
+        rules_by_language={},
+    )
+
+    assert _candidate(report, "조용한 달빛")["occurrence_count"] == 3
+    assert _candidate(report, "두근두근")["occurrence_count"] == 3
+
+
+def test_code_urls_and_template_noise_are_protected():
+    text = (
+        "`hidden phrase` https://example.test/hidden-phrase\n"
+        "```text\nhidden phrase\n```\n"
+        "{{hidden phrase}} <HIDDEN_PHRASE>\n"
+        "visible phrase"
+    )
+    messages = [miner.SourceMessage("en", text, index) for index in range(1, 4)]
+
+    report = miner.build_report(
+        messages,
+        input_record_count=3,
+        config=_config(),
+        rules_by_language={},
+    )
+
+    normalized = {candidate["normalized_phrase"] for candidate in report["candidates"]}
+    assert "visible phrase" in normalized
+    assert "hidden phrase" not in normalized
+
+
+def test_threshold_filters_below_minimum_occurrence_count():
+    messages = [
+        miner.SourceMessage("en", "quiet lantern", 1),
+        miner.SourceMessage("en", "quiet lantern", 2),
+    ]
+
+    report = miner.build_report(
+        messages,
+        input_record_count=2,
+        config=_config(threshold=3),
+        rules_by_language={},
+    )
+
+    assert report["candidates"] == []
+
+
+def test_current_rule_coverage_is_read_only_and_can_be_excluded():
+    messages = [
+        miner.SourceMessage("en", "She smiled warmly", index) for index in range(1, 4)
+    ]
+    rules = {
+        "en": [
+            {
+                "id": "EN_004",
+                "find": r"\b(he|she|they|I|you)\s+smiled\s+(?:warmly|softly)\b",
+                "flags": re.IGNORECASE,
+            }
+        ]
+    }
+
+    report = miner.build_report(
+        messages,
+        input_record_count=3,
+        config=_config(word_ngram_min=3, word_ngram_max=3),
+        rules_by_language=rules,
+    )
+    assert _candidate(report, "she smiled warmly")["covered_by_rule_ids"] == ["EN_004"]
+
+    excluded = miner.build_report(
+        messages,
+        input_record_count=3,
+        config=_config(
+            word_ngram_min=3,
+            word_ngram_max=3,
+            exclude_covered=True,
+        ),
+        rules_by_language=rules,
+    )
+    assert excluded["candidates"] == []
+
+
+def test_coverage_reads_the_real_curated_rule_table():
+    messages = [
+        miner.SourceMessage("en", "She smiled warmly", index) for index in range(1, 4)
+    ]
+
+    report = miner.build_report(
+        messages,
+        input_record_count=3,
+        config=_config(word_ngram_min=3, word_ngram_max=3),
+    )
+
+    assert _candidate(report, "she smiled warmly")["covered_by_rule_ids"] == ["EN_004"]
+
+
+def test_output_schema_is_pending_and_not_a_runtime_rule_schema():
+    messages = [
+        miner.SourceMessage("en", "quiet lantern", index) for index in range(1, 4)
+    ]
+
+    report = miner.build_report(
+        messages,
+        input_record_count=3,
+        config=_config(),
+        rules_by_language={},
+    )
+    candidate = _candidate(report, "quiet lantern")
+
+    assert report["schema_version"] == "natural-expression-candidates/v1"
+    assert report["artifact_type"] == "maintainer_review_candidates"
+    assert candidate["status"] == "pending"
+    assert set(candidate) == {
+        "covered_by_rule_ids",
+        "language",
+        "message_count",
+        "normalized_phrase",
+        "occurrence_count",
+        "phrase",
+        "status",
+    }
+    assert "find" not in candidate and "replace" not in candidate
+    assert "context" not in candidate and "conversation_id" not in candidate
+
+
+def test_serialized_output_is_byte_deterministic(tmp_path: Path):
+    messages = [
+        miner.SourceMessage("en", "quiet lantern", index) for index in range(1, 4)
+    ]
+    report = miner.build_report(
+        messages,
+        input_record_count=3,
+        config=_config(),
+        rules_by_language={},
+    )
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+
+    miner.write_report(first, report)
+    miner.write_report(second, report)
+
+    assert first.read_bytes() == second.read_bytes()
+
+
+@pytest.mark.parametrize(
+    ("line", "error_fragment"),
+    [
+        ("not-json\n", "invalid JSON"),
+        (json.dumps(["not", "an", "object"]) + "\n", "must be an object"),
+        (
+            json.dumps({"role": "assistant", "content": ["not text"], "lang": "en"})
+            + "\n",
+            "content must be a string",
+        ),
+        (json.dumps({"role": "assistant", "content": "hello"}) + "\n", "require lang"),
+    ],
+)
+def test_bad_input_reports_line_without_echoing_content(
+    tmp_path: Path, line, error_fragment
+):
+    input_path = tmp_path / "bad.jsonl"
+    input_path.write_text(line, encoding="utf-8")
+
+    with pytest.raises(miner.CandidateMinerError, match=error_fragment) as exc_info:
+        miner.read_jsonl(input_path)
+
+    assert "line 1" in str(exc_info.value)
+    assert "hello" not in str(exc_info.value)
+
+
+def test_cli_default_stdout_does_not_print_candidate_text(tmp_path: Path, capsys):
+    input_path = tmp_path / "input.jsonl"
+    output_path = tmp_path / "review.json"
+    records = [
+        {"role": "assistant", "content": "private synthetic phrase", "lang": "en"}
+        for _ in range(3)
+    ]
+    input_path.write_text(
+        "\n".join(json.dumps(record) for record in records) + "\n",
+        encoding="utf-8",
+    )
+
+    return_code = miner.main(
+        [
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--word-ngram-min",
+            "3",
+            "--word-ngram-max",
+            "3",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert return_code == 0
+    assert "private synthetic phrase" not in captured.out
+    assert "private synthetic phrase" in output_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- add a maintainer-only JSONL CLI for deterministic offline natural-expression candidate discovery
- count Unicode word n-grams for space-delimited languages, character fragments for Chinese/Japanese, and word + Hangul fragments for Korean
- exclude code, URLs, numeric-only content, and template noise; analyze only `role=assistant`
- annotate candidates with read-only `SLOP_RULES` coverage and emit a review-only pending schema
- document the input contract, privacy boundary, and manual review/promotion workflow

## Product and privacy boundary

This is an offline maintainer tool, not a user feature. It reads only the exact local JSONL file passed with `--input`; it does not scan user directories, databases, or default chat history. It makes no LLM, network, or third-party API calls.

The tool does not change the runtime rewrite engine, generate regexes or replacements, write `config/prompts/prompts_slop.py`, learn at runtime, or activate candidates. The output schema is intentionally incompatible with `SLOP_RULES` and every candidate is `status=pending`. Promotion remains a separate manual maintainer action.

Default terminal output contains only paths, aggregate counts, and language names. Candidate phrases are written only to the explicitly selected output file, which may contain assistant-text fragments and must be handled as conversation data. System/user content, full contexts, and conversation IDs are never emitted. Raw phrase printing requires explicit `--debug-candidates` opt-in.

This branch is based on current `main`, including #2352, and keeps PR3's offline discovery responsibility separate from the deterministic runtime rewrite path.

## Validation

- `uv run pytest tests/unit/test_natural_expression_candidate_miner.py tests/unit/test_slop_filter.py -q` — 51 passed
- `uv run ruff check scripts/natural_expression_candidate_miner.py tests/unit/test_natural_expression_candidate_miner.py`
- `uv run ruff check --select F,E9,I scripts/natural_expression_candidate_miner.py tests/unit/test_natural_expression_candidate_miner.py`
- `uv run ruff format --check scripts/natural_expression_candidate_miner.py tests/unit/test_natural_expression_candidate_miner.py`
- `uv run python scripts/check_docstring_no_cjk.py scripts/natural_expression_candidate_miner.py tests/unit/test_natural_expression_candidate_miner.py`
- `uv run python scripts/check_no_loguru.py scripts/natural_expression_candidate_miner.py`
- `git diff origin/main...HEAD --check`
