### PR TITLE
fix(testbench): 归档事实纳入记忆溯源，修 D4「引用已删除事实」误报

### DIFF
--- a/tests/testbench/pipeline/memory_lineage.py
+++ b/tests/testbench/pipeline/memory_lineage.py
@@ -132,6 +132,15 @@ def build_lineage_snapshot(
     mem = _memory_dir(character)
 
     facts = _read_json(mem / "facts.json", expect=list, warnings=file_warnings)
+    # A fact absorbed into a reflection is *moved* out of facts.json into
+    # facts_archive.json (main-program memory lifecycle), yet the reflection
+    # keeps citing its original ``source_fact_ids``. Without the archive the
+    # graph can't draw the reflection<-fact edge, and the overview's D4 check
+    # mislabels every such citation as "referencing a deleted fact" (a P29
+    # false positive). Loaded here; only the referenced subset is materialised
+    # (lane 2.5) — never the whole archive.
+    facts_archive = _read_json(
+        mem / "facts_archive.json", expect=list, warnings=file_warnings)
     reflections = _read_json(
         mem / "reflections.json", expect=list, warnings=file_warnings)
     persona = _read_json(mem / "persona.json", expect=dict, warnings=file_warnings)
@@ -158,12 +167,14 @@ def build_lineage_snapshot(
         nodes.append(node)
 
     # ── lane 2: facts ──
+    active_fact_ids: set[str] = set()
     for f in facts:
         if not isinstance(f, dict):
             continue
         fid = f.get("id")
         if not fid:
             continue
+        active_fact_ids.add(str(fid))
         _add_node({
             "id": str(fid),
             "type": "fact",
@@ -180,6 +191,53 @@ def build_lineage_snapshot(
             },
             "warnings": [],
         })
+
+    # ── lane 2.5: archived facts a reflection still references ──
+    # Materialise ONLY the archived facts an existing reflection cites (not the
+    # whole archive: a heavy character archives hundreds, and an un-referenced
+    # archived fact adds no lineage while burning the node budget). These nodes
+    # carry a distinct ``fact_archived`` type + ``archived`` status so the
+    # reflection<-fact edge below resolves and D4 sees the fact as present,
+    # while every fact-quality/count metric keyed on ``type == "fact"``
+    # automatically excludes them. Placed before lane 3 so the edge pass finds
+    # them in ``node_ids``.
+    referenced_fact_ids: set[str] = set()
+    for r in reflections:
+        if not isinstance(r, dict):
+            continue
+        for x in (r.get("source_fact_ids") or []):
+            if x:
+                referenced_fact_ids.add(str(x))
+    need_archived = referenced_fact_ids - active_fact_ids
+    archived_fact_count = 0
+    if need_archived:
+        for f in facts_archive:
+            if not isinstance(f, dict):
+                continue
+            fid = f.get("id")
+            if not fid:
+                continue
+            fid = str(fid)
+            if fid not in need_archived or fid in node_ids:
+                continue
+            archived_fact_count += 1
+            _add_node({
+                "id": fid,
+                "type": "fact_archived",
+                "lane": LANE_FACT,
+                "label": _truncate(f.get("text", "")),
+                "status": "archived",
+                "entity": f.get("entity"),
+                "created_at": f.get("created_at"),
+                "meta": {
+                    "text": f.get("text", ""),
+                    "importance": f.get("importance"),
+                    "tags": f.get("tags") or [],
+                    "absorbed": True,
+                    "archived": True,
+                },
+                "warnings": [],
+            })
 
     # ── lane 3: reflections (+ fact -> reflection edges) ──
     for r in reflections:
@@ -354,6 +412,7 @@ def build_lineage_snapshot(
             "messages": message_count,
             "recent_memos": recent_memo_count,
             "facts": sum(1 for n in nodes if n["type"] == "fact"),
+            "facts_archived": archived_fact_count,
             "reflections": sum(1 for n in nodes if n["type"] == "reflection"),
             "persona": persona_count,
             "corrections": correction_count,

--- a/tests/testbench/pipeline/memory_overview.py
+++ b/tests/testbench/pipeline/memory_overview.py
@@ -343,10 +343,18 @@ def build_overview(character: str) -> dict[str, Any]:
             ))
 
     # ── D. Structural orphans (stage=structure, no embeddings needed) ────────
+    # ``facts`` is active-only (type == "fact"). Facts a reflection cites that
+    # were absorbed-then-archived arrive from lineage as ``fact_archived``
+    # nodes. Referential-integrity checks (D1 orphan / D4 dangling) must treat
+    # those as *present* — an archived fact is not a deleted one — so they key
+    # on ``existing_fact_ids``. Fact-quality/count checks (D3/H1/zombie/
+    # composition) stay active-only and keep using ``fact_ids``.
     fact_ids = {f["id"] for f in facts}
+    archived_fact_ids = {n["id"] for n in nodes if n.get("type") == "fact_archived"}
+    existing_fact_ids = fact_ids | archived_fact_ids
     refl_orphans = [r for r in refls
                     if not [fid for fid in ((r.get("meta") or {}).get("source_fact_ids") or [])
-                            if fid in fact_ids]]
+                            if fid in existing_fact_ids]]
     if refl_orphans:
         findings.append(_finding(
             "D1", "structure", "structure", "warn",
@@ -398,17 +406,20 @@ def build_overview(character: str) -> dict[str, Any]:
                       for f in dangling[:MAX_EXAMPLES]],
         ))
     # D4 — dangling source references: a reflection's declared ``source_fact_ids``
-    # cite facts that no longer exist (hard-deleted, not merely ``absorbed`` —
-    # absorbed facts are kept with a flag). A referential-integrity problem:
-    # deleting a fact should also clean up reflections that reference it, so a
-    # later node never points at a vanished one. Distinct from D1 ("no valid
-    # source at all"); D4 also catches the partial case where only SOME declared
-    # sources were deleted. Purely structural — runs without embeddings.
+    # cite facts that exist in neither the active pool nor the archive, i.e. are
+    # truly hard-deleted. Absorbed facts are *moved* into facts_archive.json (not
+    # kept in facts.json with a flag), so lineage materialises the referenced
+    # archived ones as ``fact_archived`` nodes and ``existing_fact_ids`` counts
+    # them as present — only genuinely vanished ids remain "gone". A referential-
+    # integrity problem: deleting a fact should also clean up reflections that
+    # reference it, so a later node never points at a vanished one. Distinct from
+    # D1 ("no valid source at all"); D4 also catches the partial case where only
+    # SOME declared sources were deleted. Purely structural — no embeddings.
     dangling_refl: list[dict[str, Any]] = []
     total_dangling_refs = 0
     for r in refls:
         declared = [str(x) for x in ((r.get("meta") or {}).get("source_fact_ids") or []) if x]
-        gone = [fid for fid in declared if fid not in fact_ids]
+        gone = [fid for fid in declared if fid not in existing_fact_ids]
         if gone:
             total_dangling_refs += len(gone)
             dangling_refl.append({
@@ -567,6 +578,7 @@ def build_overview(character: str) -> dict[str, Any]:
             "messages": counts.get("messages", 0),
             "recent_memos": counts.get("recent_memos", 0),
             "facts": len(facts),
+            "facts_archived": len(archived_fact_ids),
             "reflections": total_refl,
             "persona": len(personas),
             "corrections": len(corrections),

--- a/tests/testbench/pipeline/memory_overview.py
+++ b/tests/testbench/pipeline/memory_overview.py
@@ -504,7 +504,12 @@ def build_overview(character: str) -> dict[str, Any]:
         ))
     # F5 extract yield uses the TRUE conversation turn count (lineage messages
     # are node-budget-truncated — blueprint §3.1.1). Derive it from meta.
-    structural = len(facts) + total_refl + len(personas) + len(corrections)
+    # ``node_budget.total`` counts archived facts too (they are structural nodes
+    # materialised for referenced sources), so they MUST be subtracted here as
+    # well — otherwise each leaks into convo_total, inflating convo_turns and
+    # deflating extract_yield.
+    structural = (len(facts) + len(archived_fact_ids) + total_refl
+                  + len(personas) + len(corrections))
     convo_total = max(0, int((lmeta.get("node_budget", {}) or {}).get("total", 0)) - structural)
     extract_yield = _ratio(len(facts), convo_total)
 

--- a/tests/testbench/smoke/p39_memory_overview_smoke.py
+++ b/tests/testbench/smoke/p39_memory_overview_smoke.py
@@ -32,6 +32,11 @@ O8 — **errors**: no session → 404; no character → 409 NoCharacterSelected.
 O9 — **LLM endpoints degrade, never 500**: ai_report → method 'unavailable'
      with an actionable warning when no memory model is configured; contradictions
      → 200, method in {llm, unavailable, none}, candidates returned.
+O10 — **archived source fact is present, not deleted**: a reflection citing a
+     fact that was absorbed then moved to facts_archive.json must NOT trip D4 (it
+     materialises as a ``fact_archived`` lineage node in the fact lane with a live
+     reflection<-fact edge); only a citation to an id in neither pool stays D4.
+     Active fact count / composition stay unpolluted by archived facts.
 
 Environment isolation mirrors p37_embedding_space_smoke.py.
 
@@ -222,6 +227,36 @@ def _seed_rich_memory() -> None:
     ])
 
 
+def _seed_archived_memory() -> None:
+    """A reflection that cites an absorbed-then-archived fact + one truly gone.
+
+    ``fact_arch`` lives in facts_archive.json (moved there when absorbed), still
+    cited by ``ref_ok``; ``fact_gone_forever`` exists nowhere. D4 must flag ONLY
+    the latter, and the archived one must materialise as a ``fact_archived`` node
+    with a live reflection<-fact edge (P29 dangling-source false-positive fix).
+    """
+    mem = _mem_dir()
+    _write_json(mem / "facts.json", [
+        {"id": "fact_active", "text": "主人喜欢深夜写代码", "entity": "master",
+         "importance": 5, "created_at": _RECENT},
+    ])
+    _write_json(mem / "facts_archive.json", [
+        {"id": "fact_arch", "text": "主人常喝美式咖啡", "entity": "master",
+         "importance": 6, "absorbed": True, "created_at": _OLD},
+        # An archived fact NO reflection cites — must stay unmaterialised.
+        {"id": "fact_arch_unused", "text": "无人引用的归档事实", "entity": "master",
+         "importance": 4, "absorbed": True, "created_at": _OLD},
+    ])
+    _write_json(mem / "reflections.json", [
+        {"id": "ref_ok", "text": "主人偏好黑咖啡且爱夜里工作", "entity": "master",
+         "status": "promoted",
+         "source_fact_ids": ["fact_active", "fact_arch"], "created_at": _RECENT},
+        {"id": "ref_dangling", "text": "引用真删事实的反思", "entity": "master",
+         "status": "pending",
+         "source_fact_ids": ["fact_gone_forever"], "created_at": _RECENT},
+    ])
+
+
 def _codes(findings: list[dict]) -> dict[str, dict]:
     return {f["code"]: f for f in findings}
 
@@ -400,6 +435,68 @@ def check_o9_llm_degrade(client) -> list[str]:
     return errors
 
 
+def check_o10_archived_facts(client) -> list[str]:
+    """O10 — an archived (absorbed) source fact is 'present', not 'deleted'.
+
+    Regression for the P29 dangling-source false positive: a reflection citing a
+    fact that was absorbed then moved to facts_archive.json must NOT trip D4, and
+    the archived fact must appear as a ``fact_archived`` lineage node (same lane
+    as active facts) with a live reflection<-fact edge. Only a citation to an id
+    that exists in neither pool (``fact_gone_forever``) stays a D4 dangling ref.
+    """
+    errors: list[str] = []
+    try:
+        _delete_session(client)
+        _create_session(client, "o_archived")
+        _seed_archived_memory()
+
+        # ── lineage: archived fact materialised + edge, active count unpolluted.
+        r = client.get("/api/memory/lineage")
+        _check(r.status_code == 200, "O10.lin_status", f"{r.status_code} {r.text[:160]}")
+        lin = r.json()
+        nodes = {n["id"]: n for n in lin["nodes"]}
+        _check("fact_arch" in nodes, "O10.arch_node", f"nodes={list(nodes)}")
+        _check(nodes["fact_arch"]["type"] == "fact_archived", "O10.arch_type",
+               f"{nodes['fact_arch'].get('type')}")
+        _check(nodes["fact_arch"]["lane"] == nodes["fact_active"]["lane"],
+               "O10.arch_lane", "archived fact must share the fact lane")
+        # Only referenced archived facts are materialised (budget discipline).
+        _check("fact_arch_unused" not in nodes, "O10.arch_unused_skipped",
+               "un-referenced archived fact must NOT be materialised")
+        edge_set = {(e["source"], e["target"]) for e in lin["edges"]}
+        _check(("fact_arch", "ref_ok") in edge_set, "O10.arch_edge",
+               "reflection<-archived-fact edge missing")
+        counts = lin["meta"]["counts"]
+        _check(counts.get("facts_archived") == 1, "O10.arch_count", f"{counts}")
+        _check(counts.get("facts") == 1, "O10.active_unpolluted", f"{counts}")
+
+        # ── overview: ref_ok not dangling; only ref_dangling trips D4.
+        r = client.get("/api/memory/overview")
+        _check(r.status_code == 200, "O10.ov_status", f"{r.status_code} {r.text[:160]}")
+        body = r.json()
+        comp = body["cards"]["composition"]
+        _check(comp.get("facts") == 1, "O10.comp_facts", f"{comp}")
+        _check(comp.get("facts_archived") == 1, "O10.comp_archived", f"{comp}")
+        c = _codes(body["findings"])
+        _check("D4" in c, "O10.D4_present", f"expected D4 for the真删 ref; codes={list(c)}")
+        _check(c["D4"]["data"]["dangling_refs"] == 1, "O10.D4_only_real",
+               f"only fact_gone_forever should dangle: {c['D4']['data']}")
+        d4_ids = {ex.get("id") for ex in c["D4"].get("examples", [])}
+        _check("ref_dangling" in d4_ids, "O10.D4_keeps_real", f"{d4_ids}")
+        _check("ref_ok" not in d4_ids, "O10.D4_excludes_archived", f"{d4_ids}")
+        # D1 orphan: ref_ok has valid sources (one active + one archived).
+        if "D1" in c:
+            d1_ids = {ex.get("id") for ex in c["D1"].get("examples", [])}
+            _check("ref_ok" not in d1_ids, "O10.D1_excludes_archived_sourced",
+                   f"{d1_ids}")
+    except _AssertFail as exc:
+        errors.append(str(exc))
+    except Exception as exc:  # noqa: BLE001
+        import traceback
+        errors.append(f"[O10.crash] {type(exc).__name__}: {exc}\n{traceback.format_exc()}")
+    return errors
+
+
 # ── Orchestration ───────────────────────────────────────────────────────
 
 
@@ -436,6 +533,8 @@ def main() -> int:
                      check_o8_errors(client))
     total += _report("O9 — LLM endpoints degrade, never 500",
                      check_o9_llm_degrade(client))
+    total += _report("O10 — archived source fact is present, not deleted (D4 fix)",
+                     check_o10_archived_facts(client))
 
     _delete_session(client)
 

--- a/tests/testbench/smoke/p39_memory_overview_smoke.py
+++ b/tests/testbench/smoke/p39_memory_overview_smoke.py
@@ -477,6 +477,10 @@ def check_o10_archived_facts(client) -> list[str]:
         comp = body["cards"]["composition"]
         _check(comp.get("facts") == 1, "O10.comp_facts", f"{comp}")
         _check(comp.get("facts_archived") == 1, "O10.comp_archived", f"{comp}")
+        # Archived facts are structural nodes, not conversation turns: they must
+        # NOT leak into convo_turns (no conversation seeded here → must be 0).
+        _check(comp.get("convo_turns") == 0, "O10.convo_unpolluted",
+               f"archived facts inflated convo_turns: {comp}")
         c = _codes(body["findings"])
         _check("D4" in c, "O10.D4_present", f"expected D4 for the真删 ref; codes={list(c)}")
         _check(c["D4"]["data"]["dangling_refs"] == 1, "O10.D4_only_real",

--- a/tests/testbench/static/core/i18n.js
+++ b/tests/testbench/static/core/i18n.js
@@ -264,7 +264,9 @@ export const I18N = {
         cards: {
           composition: {
             head: '记忆构成',
-            fmt: (c) => `事实 ${c.facts} · 反思 ${c.reflections} · 人设 ${c.persona} · `
+            fmt: (c) => `事实 ${c.facts}`
+              + (c.facts_archived ? ` (+${c.facts_archived} 归档)` : '')
+              + ` · 反思 ${c.reflections} · 人设 ${c.persona} · `
               + `纠正 ${c.corrections} · 对话 ${c.convo_turns} 回合`,
           },
           coverage: {
@@ -459,6 +461,7 @@ export const I18N = {
         message: '对话',
         recent_memo: 'recent 摘要',
         fact: '事实',
+        fact_archived: '事实(归档)',
         reflection: '反思',
         persona_entry: '人设',
         correction: '矛盾待裁决',
@@ -483,7 +486,9 @@ export const I18N = {
         dashed: '虚线 · 启发式推断',
       },
       counts_fmt: (c) =>
-        `对话 ${c.messages} · 摘要 ${c.recent_memos} · 事实 ${c.facts} · 反思 ${c.reflections} · 人设 ${c.persona} · 矛盾 ${c.corrections}`,
+        `对话 ${c.messages} · 摘要 ${c.recent_memos} · 事实 ${c.facts}`
+        + (c.facts_archived ? ` (+${c.facts_archived} 归档)` : '')
+        + ` · 反思 ${c.reflections} · 人设 ${c.persona} · 矛盾 ${c.corrections}`,
       budget_fmt: (shown, total) =>
         `已显示 ${shown} / ${total} 个节点 (其余按节点预算省略)`,
       sources: {

--- a/tests/testbench/static/testbench.css
+++ b/tests/testbench/static/testbench.css
@@ -6322,6 +6322,16 @@ button.is-dirty {
 .mtrace-node-status { fill: var(--text-tertiary); font-size: 9.5px; }
 .mtrace-node--fact .mtrace-node-box { stroke: var(--ok); }
 .mtrace-node--fact .mtrace-node-type { fill: var(--ok); }
+/* Archived fact: absorbed into a reflection and moved to facts_archive.json.
+   Same fact colour family but dashed + de-emphasised — it reads as "off the
+   active pool, materialised only to complete a reflection's source chain". */
+.mtrace-node--fact_archived .mtrace-node-box {
+  stroke: var(--ok);
+  stroke-dasharray: 4 3;
+  opacity: 0.7;
+}
+.mtrace-node--fact_archived .mtrace-node-type { fill: var(--ok); opacity: 0.85; }
+.mtrace-node--fact_archived .mtrace-node-label { fill: var(--text-secondary); }
 .mtrace-node--reflection .mtrace-node-type { fill: var(--link); }
 .mtrace-node--persona_entry .mtrace-node-type { fill: var(--accent); }
 .mtrace-node--correction .mtrace-node-box { stroke: var(--err); stroke-dasharray: 4 3; }


### PR DESCRIPTION
## 背景 / 症状

在 testbench「记忆系统分析 → 系统概况」里以真实角色**悠怡**为分析对象时，自动发现里报了一条**红色·严重**：

> 引用了已删除的事实 —— 有 15 条反思的来源声明，共引用了 288 处不存在(被删除)的事实。

## 根因

这 288 处 fact **没有被删除**，而是被反思**吸收(absorbed)后归档**了：主程序的记忆生命周期会把被反思消化的 fact 从 `facts.json` **移入** `facts_archive.json`（标 `absorbed:true`），而反思仍在 `source_fact_ids` 里引用其**原始 id**。

testbench 的溯源加载层(`memory_lineage.py`)此前**只加载活跃 `facts.json`**，从不读归档，于是：

- **溯源图断链**：画不出「反思 ← 归档事实」的边（连边逻辑 `if fid in node_ids` 找不到归档节点）。
- **系统概况 D4 误报**：`memory_overview.py` 把「反思引用了不在活跃池的 id」一律判成「引用了已删除的事实」，288 ≥ 10 触发 `bad`(严重)。D4 注释原本写的是 "not merely absorbed — absorbed facts are kept with a flag"，但该前提与主程序「搬到 archive 文件」的实际行为不符——这就是 bug 根。

用悠怡真实数据核对：**288 处 dangling 全部落在 `facts_archive.json`，两处都查不到(真删)的为 0**。

## 方案（方案 B：溯源图也加载归档）

- **lineage**：按需**物化**「被反思引用且不在活跃池」的归档事实为独立 `fact_archived` 节点（同 fact 泳道、`archived` 状态），放在 reflection 连边之前。只捞被引用的（不是整份 archive，悠怡 493 条只需 285 条），守住节点预算；未被引用的归档事实不物化。`counts` 增加 `facts_archived`。
- **overview**：D1/D4 的引用完整性判断改用「活跃 ∪ 归档」的 `existing_fact_ids`，只有两处都查不到的 id 才算真删。**活跃事实的计数/质量诊断(H1/D3/zombie/absorb_rate/composition.facts)仍只看活跃事实，不被归档污染**（composition 另加独立的 `facts_archived`）。
- **前端**：`fact_archived` 节点在溯源图淡显(虚线边框+降透明度)、类型文案「事实(归档)」；溯源 counts 条与概览「记忆构成」按需展示「(+N 归档)」。testbench 仅 `zh-CN` 单 locale，无多语言联动。

## 回归报告

| 验证 | 结果 |
|---|---|
| 悠怡真实沙盒端到端 | `facts:92 / facts_archived:285`，反思→归档边 **288 条全部接上**，**D4 从 288 → 0**，D1 误报消失，`composition.facts` 仍为 92(未污染) |
| `p39_memory_overview_smoke`（新增 O10 + 原有 D4 真删 case） | **PASS** |
| `p32_memory_lineage_smoke` | **PASS** |
| `p00_static_gate_smoke`（py_compile 98/98 + import 53/53） | **PASS** |
| `ruff` / `check_docstring_no_cjk` | **PASS** |
| 前端(浏览器)记忆溯源图 | 归档节点渲染为「事实(归档)/archived」并与活跃事实一起连线汇入反思；counts 条显示「事实 2 (+2 归档)」；未引用归档事实不物化 |

### 行为变化说明

归档事实属结构性真因果，无条件纳入 structural 节点（先于对话节点预算）。对**重角色**（如悠怡，2337 轮对话）而言，加入 285 条归档事实后结构节点会占满默认 400 预算，**对话级节点被截断**（`node_budget.truncated=true` 会提示）——这是「结构因果 > 对话材料」的有意取舍。

## 影响面

仅 `tests/testbench/`（记忆分析测试台）。不触及主程序 `app/main_logic/main_routers/memory` 运行路径。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 记忆溯源图新增归档事实节点，保留其与反思之间的关联。
  - 记忆概览与溯源统计新增归档事实数量展示。
  - 归档事实采用低强调视觉样式，便于与当前事实区分。

- **问题修复**
  - 引用已归档事实的反思不再被误判为来源缺失或悬空引用。
  - 仅真正不存在的事实来源会触发相关告警。

- **测试**
  - 新增归档事实溯源、统计及异常引用场景验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->