### PR TITLE
修复弹幕模式下大模型及屏幕边缘场景的字幕框定位、内容错位和窗口恢复竞态

### DIFF
--- a/static/subtitle/subtitle-window.js
+++ b/static/subtitle/subtitle-window.js
@@ -21,14 +21,26 @@
     var DANMAKU_MODE_VERTICAL_OFFSET_RATIO = 0.5;
     var DANMAKU_MODE_SWITCH_MASK_SETTLE_MS = 140;
     var DANMAKU_MODE_SWITCH_MASK_MAX_MS = 900;
+    var DANMAKU_NATIVE_BOUNDS_SNAPSHOT_TIMEOUT_MS = 500;
+    // Used only by the one-shot fallback for older preload bridges whose
+    // setBounds() does not return the main process restore acknowledgement.
+    var DANMAKU_NATIVE_BOUNDS_TOLERANCE = 2;
     var activeNativeResizeState = null;
     var danmakuModeSession = null;
+    var danmakuModeStoppingSession = null;
     var danmakuModeSessionSerial = 0;
     var danmakuModeSwitchMaskSerial = 0;
 
     if (!SubtitleShared) {
         console.error('[SubtitleWindow] subtitle-shared.js 未加载');
         return;
+    }
+
+    function isDanmakuNativeBoundsManaged() {
+        return !!((danmakuModeSession && danmakuModeSession.active) ||
+            (danmakuModeStoppingSession &&
+                danmakuModeStoppingSession.ended &&
+                !danmakuModeStoppingSession.stopCompleted));
     }
 
     function isNativeWindowResizing(refs) {
@@ -69,7 +81,8 @@
         }
 
         function setWindowSizeOnce() {
-            if (nativeResizing || !api || typeof api.setSize !== 'function') return;
+            if (nativeResizing || isDanmakuNativeBoundsManaged() ||
+                !api || typeof api.setSize !== 'function') return;
             var inlineSettingsHeight = getInlineSettingsHeightReserve();
             var payload = {
                 width: bounds.width + DESKTOP_WINDOW_EDGE_INSET * 2,
@@ -206,6 +219,11 @@
         var refs = subtitleWindowController && subtitleWindowController.refs;
         var rects = [];
         if (!refs || !refs.display || refs.display.classList.contains('hidden')) return rects;
+        if (danmakuModeStoppingSession &&
+            danmakuModeStoppingSession.ended &&
+            !danmakuModeStoppingSession.stopCompleted) {
+            return rects;
+        }
         var state = SubtitleShared.getSettings();
 
         if (!state.subtitleInteractionPassthrough && !state.subtitlePanelLocked) {
@@ -265,7 +283,7 @@
 
     function shouldIgnoreAtPoint(point, bounds) {
         var pagePoint = cursorPointToPagePoint(point, bounds);
-        if (!pagePoint) return false;
+        if (!pagePoint) return true;
         var width = bounds && Number.isFinite(Number(bounds.width)) ? Number(bounds.width) : window.innerWidth;
         var height = bounds && Number.isFinite(Number(bounds.height)) ? Number(bounds.height) : window.innerHeight;
         if (pagePoint.x < 0 || pagePoint.y < 0 || pagePoint.x >= width || pagePoint.y >= height) {
@@ -378,10 +396,11 @@
             setNativeInteractionIgnored(shouldIgnoreAtPoint(values[1], values[0]));
             scheduleInteractionPoll(computeNextInteractionPollDelay(values[0], values[1]));
         }).catch(function() {
-            setNativeInteractionIgnored(false);
             if (shouldUseNativePassthrough()) {
+                setNativeInteractionIgnored(true);
                 scheduleInteractionPoll(INTERACTION_PASSTHROUGH_POLL_MS);
             } else {
+                setNativeInteractionIgnored(false);
                 stopInteractionPoll();
             }
         }).finally(function() {
@@ -467,36 +486,194 @@
         return Math.round(Math.max(min, Math.min(max, value)));
     }
 
-    function calculateDanmakuModeLayout(payload) {
+    function normalizeWorkArea(workArea) {
+        if (!workArea || typeof workArea !== 'object') return null;
+        var x = Number(workArea.x);
+        var y = Number(workArea.y);
+        var width = Number(workArea.width);
+        var height = Number(workArea.height);
+        if (!isFinite(x) || !isFinite(y) || !isFinite(width) || !isFinite(height) ||
+            width <= 0 || height <= 0) {
+            return null;
+        }
+        return { x: x, y: y, width: width, height: height };
+    }
+
+    function getVisibleAvatarBounds(avatar, workArea) {
+        if (!avatar) return null;
+        if (!workArea) {
+            return {
+                left: avatar.left,
+                top: avatar.top,
+                right: avatar.left + avatar.width,
+                bottom: avatar.top + avatar.height,
+                width: avatar.width,
+                height: avatar.height,
+                centerX: avatar.left + avatar.width / 2
+            };
+        }
+        var left = Math.max(avatar.left, workArea.x);
+        var top = Math.max(avatar.top, workArea.y);
+        var right = Math.min(avatar.left + avatar.width, workArea.x + workArea.width);
+        var bottom = Math.min(avatar.top + avatar.height, workArea.y + workArea.height);
+        if (right <= left || bottom <= top) return null;
+        return {
+            left: left,
+            top: top,
+            right: right,
+            bottom: bottom,
+            width: right - left,
+            height: bottom - top,
+            centerX: left + (right - left) / 2
+        };
+    }
+
+    function resolveDanmakuModePanelPosition(layout, nativeBounds) {
+        var carrier = cloneNativeBounds(nativeBounds);
+        if (!layout || !layout.panelBounds || !layout.panelScreenPosition || !carrier) return null;
+        var maxLeft = carrier.width - layout.panelBounds.width - DESKTOP_WINDOW_EDGE_INSET;
+        var maxTop = carrier.height - layout.panelBounds.height - DESKTOP_WINDOW_EDGE_INSET;
+        if (maxLeft < DESKTOP_WINDOW_EDGE_INSET || maxTop < DESKTOP_WINDOW_EDGE_INSET) return null;
+        return {
+            left: clampToRange(
+                layout.panelScreenPosition.left - carrier.x,
+                DESKTOP_WINDOW_EDGE_INSET,
+                maxLeft
+            ),
+            top: clampToRange(
+                layout.panelScreenPosition.top - carrier.y,
+                DESKTOP_WINDOW_EDGE_INSET,
+                maxTop
+            )
+        };
+    }
+
+    function calculateDanmakuModeLayout(payload, snapshotPanelBounds, snapshotNativeBounds) {
         var normalized = normalizeAvatarBoundsPayload(payload);
         if (!normalized) return null;
         var avatar = normalized.bounds;
-        var panelWidth = Math.max(DESKTOP_MIN_PANEL_WIDTH, Math.round(avatar.width));
-        var basePanelHeight = panelWidth / 2;
-        var panelHeight = Math.max(DESKTOP_MIN_PANEL_HEIGHT, Math.round(basePanelHeight * 2 / 3));
-        var panelLeft = avatar.centerX - panelWidth / 2;
-        var panelTop = avatar.top - panelHeight - DANMAKU_MODE_HEAD_GAP +
-            panelHeight * DANMAKU_MODE_VERTICAL_OFFSET_RATIO;
-        var workArea = normalized.workArea;
+        var normalPanelBounds = SubtitleShared.getPanelBounds(snapshotPanelBounds);
+        var normalNativeBounds = cloneNativeBounds(snapshotNativeBounds);
+        var workArea = normalizeWorkArea(normalized.workArea);
+        var visibleAvatar = getVisibleAvatarBounds(avatar, workArea);
+        if (!normalNativeBounds || !visibleAvatar) return null;
+        // Keep the entry BrowserWindow as a stable, bounded transparent carrier.
+        // Near an edge the smaller panel can then move inside that carrier instead of
+        // being stranded at its default left/bottom inset.
+        var carrierWidth = normalNativeBounds.width;
+        var carrierHeight = normalNativeBounds.height;
         if (workArea) {
-            var workLeft = Number(workArea.x);
-            var workTop = Number(workArea.y);
-            var workWidth = Number(workArea.width);
-            var workHeight = Number(workArea.height);
-            if (isFinite(workLeft) && isFinite(workTop) && isFinite(workWidth) && isFinite(workHeight)) {
-                panelLeft = clampToRange(panelLeft, workLeft, workLeft + workWidth - panelWidth);
-                panelTop = clampToRange(panelTop, workTop, workTop + workHeight - panelHeight);
-            }
+            carrierWidth = Math.min(carrierWidth, Math.floor(workArea.width));
+            carrierHeight = Math.min(carrierHeight, Math.floor(workArea.height));
         }
-        return {
+        var maxPanelWidth = Math.min(
+            normalPanelBounds.width,
+            carrierWidth - DESKTOP_WINDOW_EDGE_INSET * 2
+        );
+        var maxPanelHeight = Math.min(
+            normalPanelBounds.height,
+            carrierHeight - DESKTOP_WINDOW_EDGE_INSET * 2
+        );
+        // A native window smaller than the supported panel minimum cannot be laid out
+        // safely. Keep the current bounds instead of creating an oversized/off-screen
+        // surface on an invalid or extremely small work area.
+        if (maxPanelWidth < DESKTOP_MIN_PANEL_WIDTH || maxPanelHeight < DESKTOP_MIN_PANEL_HEIGHT) {
+            return null;
+        }
+        var panelWidth = Math.min(
+            maxPanelWidth,
+            Math.max(DESKTOP_MIN_PANEL_WIDTH, Math.round(visibleAvatar.width))
+        );
+        var basePanelHeight = panelWidth / 2;
+        var panelHeight = Math.min(
+            maxPanelHeight,
+            Math.max(DESKTOP_MIN_PANEL_HEIGHT, Math.round(basePanelHeight * 2 / 3))
+        );
+        var panelLeft = visibleAvatar.centerX - panelWidth / 2;
+        var panelTop = visibleAvatar.top - panelHeight - DANMAKU_MODE_HEAD_GAP +
+            panelHeight * DANMAKU_MODE_VERTICAL_OFFSET_RATIO;
+        var nativeLeft = panelLeft - DESKTOP_WINDOW_EDGE_INSET;
+        var nativeTop = panelTop - DESKTOP_WINDOW_EDGE_INSET;
+        if (workArea) {
+            nativeLeft = clampToRange(
+                nativeLeft,
+                workArea.x,
+                workArea.x + workArea.width - carrierWidth
+            );
+            nativeTop = clampToRange(
+                nativeTop,
+                workArea.y,
+                workArea.y + workArea.height - carrierHeight
+            );
+        }
+        var layout = {
             panelBounds: { width: panelWidth, height: panelHeight },
+            panelScreenPosition: {
+                left: Math.round(panelLeft),
+                top: Math.round(panelTop)
+            },
             nativeBounds: {
-                x: Math.round(panelLeft - DESKTOP_WINDOW_EDGE_INSET),
-                y: Math.round(panelTop - DESKTOP_WINDOW_EDGE_INSET),
-                width: panelWidth + DESKTOP_WINDOW_EDGE_INSET * 2,
-                height: panelHeight + DESKTOP_WINDOW_EDGE_INSET * 2
+                x: Math.round(nativeLeft),
+                y: Math.round(nativeTop),
+                width: carrierWidth,
+                height: carrierHeight
             }
         };
+        layout.panelPosition = resolveDanmakuModePanelPosition(layout, layout.nativeBounds);
+        return layout.panelPosition ? layout : null;
+    }
+
+    function clearDanmakuModePanelPosition() {
+        var display = getSubtitleDisplayElement();
+        if (!display) return;
+        display.style.removeProperty('left');
+        display.style.removeProperty('top');
+        display.style.removeProperty('bottom');
+    }
+
+    function normalizeDanmakuModePanelRegion(region, carrier) {
+        var nativeBounds = cloneNativeBounds(carrier);
+        if (!region || typeof region !== 'object' || !nativeBounds) return null;
+        var left = Number(region.x);
+        var top = Number(region.y);
+        var width = Math.round(Number(region.width));
+        var height = Math.round(Number(region.height));
+        if (!isFinite(left) || !isFinite(top) ||
+            !isFinite(width) || !isFinite(height) ||
+            width < DESKTOP_MIN_PANEL_WIDTH || height < DESKTOP_MIN_PANEL_HEIGHT) {
+            return null;
+        }
+        var maxLeft = nativeBounds.width - width - DESKTOP_WINDOW_EDGE_INSET;
+        var maxTop = nativeBounds.height - height - DESKTOP_WINDOW_EDGE_INSET;
+        if (maxLeft < DESKTOP_WINDOW_EDGE_INSET || maxTop < DESKTOP_WINDOW_EDGE_INSET) return null;
+        return {
+            x: clampToRange(left, DESKTOP_WINDOW_EDGE_INSET, maxLeft),
+            y: clampToRange(top, DESKTOP_WINDOW_EDGE_INSET, maxTop),
+            width: width,
+            height: height
+        };
+    }
+
+    function applyDanmakuModePanelLayout(layout, actualNativeBounds, actualPanelRegion) {
+        var display = getSubtitleDisplayElement();
+        if (!display || !layout) return null;
+        var carrier = actualNativeBounds || layout.nativeBounds;
+        var region = normalizeDanmakuModePanelRegion(actualPanelRegion, carrier);
+        var panelBounds = region
+            ? { width: region.width, height: region.height }
+            : layout.panelBounds;
+        var position = region
+            ? { left: region.x, top: region.y }
+            : resolveDanmakuModePanelPosition(layout, carrier);
+        if (!position) {
+            clearDanmakuModePanelPosition();
+            return null;
+        }
+        SubtitleShared.applySubtitlePanelBounds(display, panelBounds, { host: 'window' });
+        display.style.left = position.left + 'px';
+        display.style.top = position.top + 'px';
+        display.style.bottom = 'auto';
+        return panelBounds;
     }
 
     function createDanmakuModeSnapshot() {
@@ -511,6 +688,52 @@
         };
     }
 
+    function resolveDanmakuModeEntryBounds(session, api) {
+        var settled = false;
+
+        function settle(bounds) {
+            if (settled || !session || session.id !== danmakuModeSessionSerial) return;
+            settled = true;
+            if (session.entryBoundsTimer) {
+                clearTimeout(session.entryBoundsTimer);
+                session.entryBoundsTimer = null;
+            }
+            session.snapshot.nativeBoundsResolved = true;
+            session.snapshot.nativeBounds = cloneNativeBounds(bounds);
+            if (session.snapshot.nativeBounds &&
+                session.pendingAvatarBoundsPayload &&
+                session.active && danmakuModeSession === session) {
+                var pendingPayload = session.pendingAvatarBoundsPayload;
+                session.pendingAvatarBoundsPayload = null;
+                applyDanmakuModeAvatarBounds(session, pendingPayload);
+            } else if (!session.snapshot.nativeBounds) {
+                session.pendingAvatarBoundsPayload = null;
+            }
+            if (session.ended && session.restoreNativeWhenReady && !danmakuModeSession) {
+                completeDanmakuModeStop(session);
+            } else if (session.active && danmakuModeSession === session && !session.snapshot.nativeBounds) {
+                releaseDanmakuModeSwitchMask(session, DANMAKU_MODE_SWITCH_MASK_SETTLE_MS);
+            }
+        }
+
+        session.entryBoundsTimer = setTimeout(function() {
+            settle(null);
+        }, DANMAKU_NATIVE_BOUNDS_SNAPSHOT_TIMEOUT_MS);
+        var entryBoundsResult;
+        try {
+            // Start the snapshot request before temporary passthrough enables its
+            // cursor poll; otherwise that poll can consume a delayed test/bridge
+            // response and let the first avatar sample race ahead of the snapshot.
+            entryBoundsResult = api.getBounds();
+        } catch (_err) {
+            settle(null);
+            return;
+        }
+        Promise.resolve(entryBoundsResult).then(settle).catch(function() {
+            settle(null);
+        });
+    }
+
     function createDanmakuModeSession() {
         var api = window.nekoSubtitle;
         var session = {
@@ -520,38 +743,22 @@
             switchMaskId: 0,
             switchMaskTimer: null,
             nativeBoundsRestored: false,
+            nativeBoundsRestorePromise: null,
             restoreNativeWhenReady: false,
+            stopCompleted: false,
+            restartWhenRestored: false,
+            retryRestoreWhenSettled: false,
+            transientBoundsRequested: false,
+            boundsApplyPromise: null,
+            entryBoundsTimer: null,
             avatarBoundsCleanup: null,
             lastPanelBounds: null,
+            layoutSerial: 0,
             pendingAvatarBoundsPayload: null,
             snapshot: createDanmakuModeSnapshot()
         };
         danmakuModeSession = session;
-        if (api && typeof api.getBounds === 'function') {
-            Promise.resolve(api.getBounds()).then(function(bounds) {
-                if (session.id !== danmakuModeSessionSerial) return;
-                session.snapshot.nativeBoundsResolved = true;
-                session.snapshot.nativeBounds = cloneNativeBounds(bounds);
-                if (session.pendingAvatarBoundsPayload && session.active && danmakuModeSession === session) {
-                    var pendingPayload = session.pendingAvatarBoundsPayload;
-                    session.pendingAvatarBoundsPayload = null;
-                    applyDanmakuModeAvatarBounds(session, pendingPayload);
-                }
-                if (session.ended && session.restoreNativeWhenReady && !danmakuModeSession) {
-                    restoreDanmakuModeNativeBounds(session);
-                    releaseDanmakuModeSwitchMask(session, DANMAKU_MODE_SWITCH_MASK_SETTLE_MS);
-                }
-            }).catch(function() {
-                if (session.id !== danmakuModeSessionSerial) return;
-                session.snapshot.nativeBoundsResolved = true;
-                session.pendingAvatarBoundsPayload = null;
-                if (session.ended && session.restoreNativeWhenReady && !danmakuModeSession) {
-                    releaseDanmakuModeSwitchMask(session, DANMAKU_MODE_SWITCH_MASK_SETTLE_MS);
-                } else if (session.active && danmakuModeSession === session) {
-                    releaseDanmakuModeSwitchMask(session, DANMAKU_MODE_SWITCH_MASK_SETTLE_MS);
-                }
-            });
-        }
+        resolveDanmakuModeEntryBounds(session, api);
         return session;
     }
 
@@ -595,13 +802,72 @@
         }, delay);
     }
 
+    function sameNativeBounds(a, b) {
+        var left = cloneNativeBounds(a);
+        var right = cloneNativeBounds(b);
+        if (!left || !right) return false;
+        return Math.abs(left.x - right.x) <= DANMAKU_NATIVE_BOUNDS_TOLERANCE &&
+            Math.abs(left.y - right.y) <= DANMAKU_NATIVE_BOUNDS_TOLERANCE &&
+            Math.abs(left.width - right.width) <= DANMAKU_NATIVE_BOUNDS_TOLERANCE &&
+            Math.abs(left.height - right.height) <= DANMAKU_NATIVE_BOUNDS_TOLERANCE;
+    }
+
     function restoreDanmakuModeNativeBounds(session) {
         var api = window.nekoSubtitle;
-        if (!session || session.nativeBoundsRestored) return;
+        if (!session) return Promise.resolve(false);
+        if (session.nativeBoundsRestored) return Promise.resolve(true);
+        if (session.nativeBoundsRestorePromise) return session.nativeBoundsRestorePromise;
         var bounds = session.snapshot && session.snapshot.nativeBounds;
-        if (!bounds || !api || typeof api.setBounds !== 'function') return;
-        session.nativeBoundsRestored = true;
-        api.setBounds(bounds.x, bounds.y, bounds.width, bounds.height);
+        if (!bounds || !api || typeof api.setBounds !== 'function' || typeof api.getBounds !== 'function') {
+            return Promise.resolve(false);
+        }
+        var setBoundsResult;
+        try {
+            setBoundsResult = api.setBounds(bounds.x, bounds.y, bounds.width, bounds.height, {
+                transient: true,
+                sessionId: session.id,
+                restore: true
+            });
+        } catch (_err) {
+            return Promise.resolve(false);
+        }
+        var restoreResult;
+        if (setBoundsResult && typeof setBoundsResult.then === 'function') {
+            // New preload contract: the main process resolves only after its native
+            // retry loop has verified the actual (possibly work-area-clamped) frame.
+            restoreResult = Promise.resolve(setBoundsResult).then(function(result) {
+                if (!result || result.ok !== true) return false;
+                return true;
+            }).catch(function() {
+                return false;
+            });
+        } else {
+            // Compatibility with older preload bridges. Their fire-and-forget IPC has
+            // no acknowledgement, so perform one asynchronous observation only; native
+            // retry ownership remains in the main process.
+            restoreResult = Promise.resolve().then(function() {
+                return api.getBounds();
+            }).then(function(currentBounds) {
+                if (!sameNativeBounds(currentBounds, bounds)) return false;
+                return true;
+            }).catch(function() {
+                return false;
+            });
+        }
+        var restorePromise = restoreResult.then(function(restored) {
+            var verified = !!restored &&
+                session.id === danmakuModeSessionSerial &&
+                !danmakuModeSession;
+            session.nativeBoundsRestored = verified;
+            if (!verified && session.nativeBoundsRestorePromise === restorePromise) {
+                // Stay fail-closed, but allow a later explicit toggle to recover
+                // after a lifecycle-owned hide/show restore has succeeded.
+                session.nativeBoundsRestorePromise = null;
+            }
+            return verified;
+        });
+        session.nativeBoundsRestorePromise = restorePromise;
+        return restorePromise;
     }
 
     function propagateDanmakuModeLock(locked, state) {
@@ -674,36 +940,22 @@
         return nextState;
     }
 
-    function applyDanmakuModeAvatarBounds(session, payload) {
-        var api = window.nekoSubtitle;
-        if (!api || typeof api.setBounds !== 'function') return;
-        if (!session || !session.active || danmakuModeSession !== session) return;
-        if (!SubtitleShared.getSettings().subtitleDanmakuMode) return;
-        if (!session.snapshot.nativeBoundsResolved) {
-            session.pendingAvatarBoundsPayload = payload;
-            return;
+    function commitDanmakuModeLayout(session, layout, actualNativeBounds, actualPanelRegion) {
+        if (!session || !layout ||
+            !session.active || danmakuModeSession !== session ||
+            !SubtitleShared.getSettings().subtitleDanmakuMode) {
+            return false;
         }
-        if (!session.snapshot.nativeBounds) {
-            releaseDanmakuModeSwitchMask(session, DANMAKU_MODE_SWITCH_MASK_SETTLE_MS);
-            return;
-        }
-        var layout = calculateDanmakuModeLayout(payload);
-        if (!layout) return;
-        api.setBounds(
-            layout.nativeBounds.x,
-            layout.nativeBounds.y,
-            layout.nativeBounds.width,
-            layout.nativeBounds.height
+        var appliedPanelBounds = applyDanmakuModePanelLayout(
+            layout,
+            actualNativeBounds,
+            actualPanelRegion
         );
-        SubtitleShared.applySubtitlePanelBounds(
-            subtitleWindowController.refs.display,
-            layout.panelBounds,
-            { host: 'window' }
-        );
-        var panelBoundsChanged = !samePanelBounds(session.lastPanelBounds, layout.panelBounds);
-        session.lastPanelBounds = layout.panelBounds;
+        if (!appliedPanelBounds) return false;
+        var panelBoundsChanged = !samePanelBounds(session.lastPanelBounds, appliedPanelBounds);
+        session.lastPanelBounds = appliedPanelBounds;
         var nextState = SubtitleShared.updateSettings({
-            subtitlePanelBounds: layout.panelBounds,
+            subtitlePanelBounds: appliedPanelBounds,
             subtitlePanelLocked: true,
             subtitleInteractionPassthrough: true
         }, {
@@ -713,8 +965,8 @@
         if (panelBoundsChanged) {
             propagateSubtitleSetting({
                 type: 'bounds',
-                value: layout.panelBounds,
-                patch: { subtitlePanelBounds: layout.panelBounds },
+                value: appliedPanelBounds,
+                patch: { subtitlePanelBounds: appliedPanelBounds },
                 transient: true,
                 state: nextState
             });
@@ -722,10 +974,129 @@
         syncExternalSettingsWindow();
         updateNativeInteractionPassthrough();
         releaseDanmakuModeSwitchMask(session, DANMAKU_MODE_SWITCH_MASK_SETTLE_MS);
+        return true;
+    }
+
+    function getVerifiedDanmakuModeBounds(result) {
+        if (!result || result.cancelled === true) return null;
+        if (result.ok !== true && result.reason !== 'verification-failed') return null;
+        var nativeBounds = cloneNativeBounds(result.bounds);
+        if (!nativeBounds) return null;
+        return {
+            nativeBounds: nativeBounds,
+            panelRegion: result.panelRegion || null
+        };
+    }
+
+    function finishDanmakuModeBoundsApply(session) {
+        if (!session) return;
+        session.boundsApplyPromise = null;
+        if (session.active && danmakuModeSession === session) {
+            var pendingPayload = session.pendingAvatarBoundsPayload;
+            session.pendingAvatarBoundsPayload = null;
+            if (pendingPayload) {
+                applyDanmakuModeAvatarBounds(session, pendingPayload);
+            }
+            return;
+        }
+        session.pendingAvatarBoundsPayload = null;
+        if (session.ended && session.snapshot.nativeBoundsResolved) {
+            completeDanmakuModeStop(session);
+        }
+    }
+
+    function applyDanmakuModeAvatarBounds(session, payload) {
+        var api = window.nekoSubtitle;
+        if (!api || typeof api.setBounds !== 'function') {
+            clearDanmakuModePanelPosition();
+            return;
+        }
+        if (!session || !session.active || danmakuModeSession !== session) {
+            if (!danmakuModeSession) clearDanmakuModePanelPosition();
+            return;
+        }
+        if (!SubtitleShared.getSettings().subtitleDanmakuMode) {
+            clearDanmakuModePanelPosition();
+            return;
+        }
+        var layoutSerial = ++session.layoutSerial;
+        if (!session.snapshot.nativeBoundsResolved) {
+            session.pendingAvatarBoundsPayload = payload;
+            return;
+        }
+        if (!session.snapshot.nativeBounds) {
+            clearDanmakuModePanelPosition();
+            releaseDanmakuModeSwitchMask(session, DANMAKU_MODE_SWITCH_MASK_SETTLE_MS);
+            return;
+        }
+        if (session.boundsApplyPromise) {
+            // Avatar zoom/drag can produce many samples while Electron is still
+            // verifying one transparent-window move. Keep only the newest sample.
+            session.pendingAvatarBoundsPayload = payload;
+            return;
+        }
+        var layout = calculateDanmakuModeLayout(
+            payload,
+            session.snapshot.panelBounds,
+            session.snapshot.nativeBounds
+        );
+        if (!layout) {
+            clearDanmakuModePanelPosition();
+            return;
+        }
+        var setBoundsResult;
+        try {
+            // Main may already have captured a transient snapshot even when invoke
+            // later rejects, so every dispatched request owns a matching restore.
+            session.transientBoundsRequested = true;
+            setBoundsResult = api.setBounds(
+                layout.nativeBounds.x,
+                layout.nativeBounds.y,
+                layout.nativeBounds.width,
+                layout.nativeBounds.height,
+                {
+                    transient: true,
+                    sessionId: session.id,
+                    panelScreenBounds: {
+                        x: layout.panelScreenPosition.left,
+                        y: layout.panelScreenPosition.top,
+                        width: layout.panelBounds.width,
+                        height: layout.panelBounds.height
+                    }
+                }
+            );
+        } catch (_err) {
+            clearDanmakuModePanelPosition();
+            releaseDanmakuModeSwitchMask(session, DANMAKU_MODE_SWITCH_MASK_SETTLE_MS);
+            return;
+        }
+        if (setBoundsResult && typeof setBoundsResult.then === 'function') {
+            session.boundsApplyPromise = Promise.resolve(setBoundsResult).then(function(result) {
+                var verified = getVerifiedDanmakuModeBounds(result);
+                if (!verified) return false;
+                if (!session.active || danmakuModeSession !== session ||
+                    layoutSerial !== session.layoutSerial) return false;
+                return commitDanmakuModeLayout(
+                    session,
+                    layout,
+                    verified.nativeBounds,
+                    verified.panelRegion
+                );
+            }).catch(function() {
+                return false;
+            }).then(function(result) {
+                finishDanmakuModeBoundsApply(session);
+                return result;
+            });
+            return;
+        }
+        // Compatibility with older preload bridges whose setBounds is fire-and-forget.
+        commitDanmakuModeLayout(session, layout, layout.nativeBounds);
     }
 
     function restoreDanmakuModeSettings(session) {
         var snapshot = session && session.snapshot;
+        clearDanmakuModePanelPosition();
         if (!snapshot) return;
         var nextState = SubtitleShared.updateSettings({
             subtitlePanelBounds: snapshot.panelBounds,
@@ -747,6 +1118,57 @@
         propagateDanmakuModeOpacity(snapshot.opacity, nextState);
     }
 
+    function finalizeDanmakuModeStop(session) {
+        if (!session || session.stopCompleted) return;
+        if (session.id !== danmakuModeSessionSerial || danmakuModeSession) return;
+        session.stopCompleted = true;
+        restoreDanmakuModeSettings(session);
+        syncExternalSettingsWindow();
+        releaseDanmakuModeSwitchMask(session, DANMAKU_MODE_SWITCH_MASK_SETTLE_MS);
+        var shouldRestart = session.restartWhenRestored === true &&
+            !!SubtitleShared.getSettings().subtitleDanmakuMode;
+        if (danmakuModeStoppingSession === session) {
+            danmakuModeStoppingSession = null;
+        }
+        updateNativeInteractionPassthrough();
+        if (shouldRestart) {
+            startDanmakuModeSession();
+        }
+    }
+
+    function completeDanmakuModeStop(session) {
+        if (!session || !session.ended || session.stopCompleted) return;
+        if (session.boundsApplyPromise) {
+            session.restoreNativeWhenReady = true;
+            return;
+        }
+        session.restoreNativeWhenReady = false;
+        if (!session.transientBoundsRequested) {
+            // The entry snapshot failed/timed out, or the session ended before an
+            // avatar layout was applied. No transient native frame needs restoring.
+            finalizeDanmakuModeStop(session);
+            return;
+        }
+        if (!session.snapshot.nativeBounds) {
+            releaseDanmakuModeSwitchMask(session, DANMAKU_MODE_SWITCH_MASK_SETTLE_MS);
+            return;
+        }
+        restoreDanmakuModeNativeBounds(session).then(function(restored) {
+            if (restored) {
+                finalizeDanmakuModeStop(session);
+            } else {
+                // Fail closed: keep passthrough/lock enabled if the native frame could
+                // not be verified at its safe size. This avoids an interactive giant
+                // transparent window blocking the desktop.
+                releaseDanmakuModeSwitchMask(session, DANMAKU_MODE_SWITCH_MASK_SETTLE_MS);
+                if (session.retryRestoreWhenSettled) {
+                    session.retryRestoreWhenSettled = false;
+                    completeDanmakuModeStop(session);
+                }
+            }
+        });
+    }
+
     function stopDanmakuModeSession(session) {
         var api = window.nekoSubtitle;
         if (!session || session.ended) return;
@@ -756,6 +1178,9 @@
         }
         session.active = false;
         session.ended = true;
+        session.layoutSerial += 1;
+        session.pendingAvatarBoundsPayload = null;
+        clearDanmakuModePanelPosition();
         if (api && typeof api.subscribeAvatarBounds === 'function') {
             api.subscribeAvatarBounds(false);
         }
@@ -763,28 +1188,34 @@
             session.avatarBoundsCleanup();
             session.avatarBoundsCleanup = null;
         }
-        restoreDanmakuModeSettings(session);
-        if (session.snapshot.nativeBounds) {
-            restoreDanmakuModeNativeBounds(session);
-            releaseDanmakuModeSwitchMask(session, DANMAKU_MODE_SWITCH_MASK_SETTLE_MS);
-        } else {
-            session.restoreNativeWhenReady = !session.snapshot.nativeBoundsResolved;
-        }
         if (danmakuModeSession === session) {
             danmakuModeSession = null;
         }
-        if (!session.restoreNativeWhenReady && !session.snapshot.nativeBounds) {
-            releaseDanmakuModeSwitchMask(session, DANMAKU_MODE_SWITCH_MASK_SETTLE_MS);
+        danmakuModeStoppingSession = session;
+        // Keep the native window click-through until its original frame has actually
+        // been observed. Restoring normal interaction before this point can turn a
+        // stale full-display transparent frame into an input blocker.
+        stopInteractionPoll();
+        setNativeInteractionIgnored(true);
+        if (session.snapshot.nativeBoundsResolved) {
+            completeDanmakuModeStop(session);
+        } else {
+            session.restoreNativeWhenReady = true;
         }
         syncExternalSettingsWindow();
-        updateNativeInteractionPassthrough();
     }
 
     function startDanmakuModeSession() {
         var api = window.nekoSubtitle;
-        if (!api || typeof api.subscribeAvatarBounds !== 'function' || typeof api.onAvatarBounds !== 'function') {
+        if (danmakuModeStoppingSession ||
+            !api ||
+            typeof api.getBounds !== 'function' ||
+            typeof api.setBounds !== 'function' ||
+            typeof api.subscribeAvatarBounds !== 'function' ||
+            typeof api.onAvatarBounds !== 'function') {
             return null;
         }
+        clearDanmakuModePanelPosition();
         var session = createDanmakuModeSession();
         beginDanmakuModeSwitchMask(session);
         if (subtitleWindowController && typeof subtitleWindowController.closeSettingsForExternalInteraction === 'function') {
@@ -800,12 +1231,26 @@
 
     function attachDanmakuModeLayout() {
         var api = window.nekoSubtitle;
-        if (!api || typeof api.subscribeAvatarBounds !== 'function' || typeof api.onAvatarBounds !== 'function') {
+        if (!api ||
+            typeof api.getBounds !== 'function' ||
+            typeof api.setBounds !== 'function' ||
+            typeof api.subscribeAvatarBounds !== 'function' ||
+            typeof api.onAvatarBounds !== 'function') {
             return function() {};
         }
 
         function setActive(nextActive) {
             nextActive = !!nextActive;
+            if (danmakuModeStoppingSession) {
+                danmakuModeStoppingSession.restartWhenRestored = nextActive;
+                if (danmakuModeStoppingSession.nativeBoundsRestorePromise) {
+                    danmakuModeStoppingSession.retryRestoreWhenSettled = true;
+                } else if (
+                    danmakuModeStoppingSession.snapshot.nativeBoundsResolved) {
+                    completeDanmakuModeStop(danmakuModeStoppingSession);
+                }
+                return;
+            }
             var active = !!(danmakuModeSession && danmakuModeSession.active);
             if (active === nextActive) {
                 if (active) {
@@ -827,6 +1272,7 @@
         return function detachDanmakuModeLayout() {
             unsubscribe();
             stopDanmakuModeSession(danmakuModeSession);
+            clearDanmakuModePanelPosition();
         };
     }
 

--- a/static/subtitle/subtitle-window.js
+++ b/static/subtitle/subtitle-window.js
@@ -836,8 +836,12 @@
             // New preload contract: the main process resolves only after its native
             // retry loop has verified the actual (possibly work-area-clamped) frame.
             restoreResult = Promise.resolve(setBoundsResult).then(function(result) {
-                if (!result || result.ok !== true) return false;
-                return true;
+                if (!result) return false;
+                if (result.ok === true) return true;
+                return result.ok === false &&
+                    result.cancelled !== true &&
+                    result.reason === 'verification-failed' &&
+                    result.safeToReveal === true;
             }).catch(function() {
                 return false;
             });
@@ -988,7 +992,7 @@
         };
     }
 
-    function finishDanmakuModeBoundsApply(session) {
+    function finishDanmakuModeBoundsApply(session, committed) {
         if (!session) return;
         session.boundsApplyPromise = null;
         if (session.active && danmakuModeSession === session) {
@@ -996,6 +1000,11 @@
             session.pendingAvatarBoundsPayload = null;
             if (pendingPayload) {
                 applyDanmakuModeAvatarBounds(session, pendingPayload);
+                return;
+            }
+            if (committed !== true) {
+                clearDanmakuModePanelPosition();
+                releaseDanmakuModeSwitchMask(session, DANMAKU_MODE_SWITCH_MASK_SETTLE_MS);
             }
             return;
         }
@@ -1042,6 +1051,7 @@
         );
         if (!layout) {
             clearDanmakuModePanelPosition();
+            releaseDanmakuModeSwitchMask(session, DANMAKU_MODE_SWITCH_MASK_SETTLE_MS);
             return;
         }
         var setBoundsResult;
@@ -1085,13 +1095,16 @@
             }).catch(function() {
                 return false;
             }).then(function(result) {
-                finishDanmakuModeBoundsApply(session);
+                finishDanmakuModeBoundsApply(session, result);
                 return result;
             });
             return;
         }
         // Compatibility with older preload bridges whose setBounds is fire-and-forget.
-        commitDanmakuModeLayout(session, layout, layout.nativeBounds);
+        if (!commitDanmakuModeLayout(session, layout, layout.nativeBounds)) {
+            clearDanmakuModePanelPosition();
+            releaseDanmakuModeSwitchMask(session, DANMAKU_MODE_SWITCH_MASK_SETTLE_MS);
+        }
     }
 
     function restoreDanmakuModeSettings(session) {

--- a/tests/frontend/test_subtitle_incremental.py
+++ b/tests/frontend/test_subtitle_incremental.py
@@ -255,6 +255,13 @@ def test_subtitle_window_danmaku_mode_tracks_avatar_head_and_restores(mock_page:
             window.localStorage.setItem('subtitleOpacity', '72');
             window.__subtitleNativeBounds = { x: 100, y: 300, width: 667, height: 121 };
             window.__subtitleSetBoundsCalls = [];
+            window.__subtitleSetBoundsOptions = [];
+            window.__subtitleSetSizeCalls = [];
+            window.__delaySubtitleRestoreUntilMainRetry = true;
+            window.__dropSubtitleRestore = false;
+            window.__holdNextSubtitleRestore = false;
+            window.__resolveHeldSubtitleRestore = null;
+            window.__subtitleMainRetryApplied = false;
             window.__subtitleSettingsChanges = [];
             window.__subtitleSettingsCloseCount = 0;
             window.__avatarBoundsSubscriptions = [];
@@ -264,12 +271,42 @@ def test_subtitle_window_danmaku_mode_tracks_avatar_head_and_restores(mock_page:
                 disableInteraction: () => {},
                 getCursorPoint: () => Promise.resolve({ screenX: 0, screenY: 0 }),
                 getBounds: () => Promise.resolve({ ...window.__subtitleNativeBounds }),
-                setBounds: (x, y, w, h) => {
+                setBounds: (x, y, w, h, options) => {
                     const next = { x, y, width: w, height: h };
                     window.__subtitleSetBoundsCalls.push(next);
+                    window.__subtitleSetBoundsOptions.push(options || null);
+                    if (options && options.restore && window.__dropSubtitleRestore) {
+                        return;
+                    }
+                    if (options && options.restore && window.__holdNextSubtitleRestore) {
+                        window.__holdNextSubtitleRestore = false;
+                        return new Promise((resolve) => {
+                            window.__resolveHeldSubtitleRestore = () => {
+                                window.__subtitleNativeBounds = next;
+                                resolve({ ok: true, bounds: next });
+                            };
+                        });
+                    }
+                    if (options && options.restore && window.__delaySubtitleRestoreUntilMainRetry) {
+                        window.__delaySubtitleRestoreUntilMainRetry = false;
+                        // The new preload resolves only after main has verified its
+                        // work-area-clamped native result. Its coordinates may differ
+                        // from the renderer's raw entry snapshot.
+                        return new Promise((resolve) => setTimeout(() => {
+                            const verified = {
+                                x: next.x + 12,
+                                y: next.y - 6,
+                                width: next.width,
+                                height: next.height,
+                            };
+                            window.__subtitleNativeBounds = verified;
+                            window.__subtitleMainRetryApplied = true;
+                            resolve({ ok: true, bounds: verified });
+                        }, 560));
+                    }
                     window.__subtitleNativeBounds = next;
                 },
-                setSize: () => {},
+                setSize: (...args) => window.__subtitleSetSizeCalls.push(args),
                 changeSettings: (change) => window.__subtitleSettingsChanges.push(change),
                 updateSettingsWindow: () => {},
                 openSettings: () => {},
@@ -297,6 +334,7 @@ def test_subtitle_window_danmaku_mode_tracks_avatar_head_and_restores(mock_page:
             const panel = document.getElementById('subtitle-settings-panel');
             document.getElementById('subtitle-settings-btn').click();
             await new Promise((resolve) => setTimeout(resolve, 0));
+            const setSizeCountBeforeDanmaku = window.__subtitleSetSizeCalls.length;
             shared.updateSettings({ subtitleDanmakuMode: true }, { source: 'test-enable-danmaku' });
             await new Promise((resolve) => setTimeout(resolve, 0));
             window.__avatarBoundsHandler({
@@ -330,38 +368,208 @@ def test_subtitle_window_danmaku_mode_tracks_avatar_head_and_restores(mock_page:
                 settings: shared.getSettings(),
                 nativeBounds: window.__subtitleNativeBounds,
                 calls: window.__subtitleSetBoundsCalls.slice(),
+                setBoundsOptions: window.__subtitleSetBoundsOptions.slice(),
                 changes: window.__subtitleSettingsChanges.slice(),
                 panelState: display.dataset.subtitlePanelState || '',
                 backgroundOpacity: display.dataset.subtitleBackgroundOpacity || '',
                 panelHidden: panel.classList.contains('hidden'),
                 closeCount: window.__subtitleSettingsCloseCount,
             };
+            window.dispatchEvent(new Event('resize'));
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const setSizeCountAfterDanmakuResize = window.__subtitleSetSizeCalls.length;
+            window.__avatarBoundsHandler({
+                bounds: {
+                    left: -5000,
+                    top: -400,
+                    width: 2548,
+                    height: 3897,
+                    centerX: -3726,
+                    centerY: 1548.5,
+                },
+                display: {
+                    workArea: { x: -2560, y: 0, width: 2560, height: 1392 },
+                },
+            });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const afterHugeAvatar = {
+                settings: shared.getSettings(),
+                nativeBounds: { ...window.__subtitleNativeBounds },
+            };
+            window.__avatarBoundsHandler({
+                bounds: {
+                    left: -3000,
+                    top: -800,
+                    width: 2548,
+                    height: 3897,
+                    centerX: -1726,
+                    centerY: 1148.5,
+                },
+                display: {
+                    workArea: { x: -500, y: -300, width: 500, height: 300 },
+                },
+            });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const afterSmallNegativeWorkArea = {
+                settings: shared.getSettings(),
+                nativeBounds: { ...window.__subtitleNativeBounds },
+            };
             document.getElementById('subtitle-settings-btn').click();
             await new Promise((resolve) => setTimeout(resolve, 0));
             shared.updateSettings({ subtitleDanmakuMode: false }, { source: 'test-disable-danmaku' });
+            window.dispatchEvent(new Event('resize'));
             await new Promise((resolve) => setTimeout(resolve, 0));
+            const setSizeCountDuringRestore = window.__subtitleSetSizeCalls.length;
+            await new Promise((resolve) => setTimeout(resolve, 300));
+            const whileRestorePending = {
+                settings: shared.getSettings(),
+                nativeBounds: { ...window.__subtitleNativeBounds },
+                restoreRequestCount: window.__subtitleSetBoundsOptions.filter(
+                    (options) => options && options.restore
+                ).length,
+                mainRetryApplied: window.__subtitleMainRetryApplied,
+            };
+            shared.updateSettings({ subtitleDanmakuMode: true }, { source: 'test-queue-danmaku-on' });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            shared.updateSettings({ subtitleDanmakuMode: false }, { source: 'test-cancel-queued-danmaku' });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const afterRapidRetoggle = {
+                subscriptions: window.__avatarBoundsSubscriptions.slice(),
+                sessionIds: window.__subtitleSetBoundsOptions
+                    .filter((options) => options && options.transient)
+                    .map((options) => options.sessionId),
+                settings: shared.getSettings(),
+            };
+            await new Promise((resolve) => setTimeout(resolve, 400));
             const afterOff = {
                 subscriptions: window.__avatarBoundsSubscriptions.slice(),
                 settings: shared.getSettings(),
                 nativeBounds: window.__subtitleNativeBounds,
                 calls: window.__subtitleSetBoundsCalls.slice(),
+                setBoundsOptions: window.__subtitleSetBoundsOptions.slice(),
                 changes: window.__subtitleSettingsChanges.slice(),
+                mainRetryApplied: window.__subtitleMainRetryApplied,
                 panelState: display.dataset.subtitlePanelState || '',
                 panelHidden: panel.classList.contains('hidden'),
                 closeCount: window.__subtitleSettingsCloseCount,
             };
-            return { afterOn, afterOff };
+            window.__holdNextSubtitleRestore = true;
+            shared.updateSettings({ subtitleDanmakuMode: true }, { source: 'test-enable-queued-restart' });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            window.__avatarBoundsHandler({
+                bounds: {
+                    left: 800,
+                    top: 300,
+                    width: 200,
+                    height: 400,
+                    centerX: 900,
+                    centerY: 500,
+                },
+                display: {
+                    workArea: { x: 0, y: 0, width: 1920, height: 1080 },
+                },
+            });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            shared.updateSettings({ subtitleDanmakuMode: false }, { source: 'test-stop-before-queued-restart' });
+            shared.updateSettings({ subtitleDanmakuMode: true }, { source: 'test-queue-restart' });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const whileRestartQueued = {
+                subscriptions: window.__avatarBoundsSubscriptions.slice(),
+                settings: shared.getSettings(),
+                handlerDetached: window.__avatarBoundsHandler === null,
+            };
+            window.__resolveHeldSubtitleRestore();
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const afterQueuedRestart = {
+                subscriptions: window.__avatarBoundsSubscriptions.slice(),
+                settings: shared.getSettings(),
+                handlerAttached: typeof window.__avatarBoundsHandler === 'function',
+            };
+            window.__avatarBoundsHandler({
+                bounds: {
+                    left: 800,
+                    top: 300,
+                    width: 200,
+                    height: 400,
+                    centerX: 900,
+                    centerY: 500,
+                },
+                display: {
+                    workArea: { x: 0, y: 0, width: 1920, height: 1080 },
+                },
+            });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            shared.updateSettings({ subtitleDanmakuMode: false }, { source: 'test-stop-queued-restart' });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const afterLegacyFallback = {
+                settings: shared.getSettings(),
+                nativeBounds: { ...window.__subtitleNativeBounds },
+                restoreRequestCount: window.__subtitleSetBoundsOptions.filter(
+                    (options) => options && options.restore && options.sessionId === 3
+                ).length,
+            };
+            window.__dropSubtitleRestore = true;
+            shared.updateSettings({ subtitleDanmakuMode: true }, { source: 'test-enable-danmaku-drop' });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            window.__avatarBoundsHandler({
+                bounds: {
+                    left: 800,
+                    top: 300,
+                    width: 200,
+                    height: 400,
+                    centerX: 900,
+                    centerY: 500,
+                },
+                display: {
+                    workArea: { x: 0, y: 0, width: 1920, height: 1080 },
+                },
+            });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            shared.updateSettings({ subtitleDanmakuMode: false }, { source: 'test-disable-danmaku-drop' });
+            await new Promise((resolve) => setTimeout(resolve, 700));
+            const afterDroppedRestore = {
+                settings: shared.getSettings(),
+                nativeBounds: { ...window.__subtitleNativeBounds },
+                restoreRequestCount: window.__subtitleSetBoundsOptions.filter(
+                    (options) => options && options.restore && options.sessionId === 4
+                ).length,
+            };
+            return {
+                afterOn,
+                afterHugeAvatar,
+                afterSmallNegativeWorkArea,
+                whileRestorePending,
+                afterRapidRetoggle,
+                afterOff,
+                whileRestartQueued,
+                afterQueuedRestart,
+                afterLegacyFallback,
+                afterDroppedRestore,
+                setSizeCountBeforeDanmaku,
+                setSizeCountAfterDanmakuResize,
+                setSizeCountDuringRestore,
+            };
         }
         """
     )
 
     assert result["afterOn"]["subscriptions"] == [True]
+    assert result["setSizeCountAfterDanmakuResize"] == result["setSizeCountBeforeDanmaku"]
+    assert result["setSizeCountDuringRestore"] == result["setSizeCountBeforeDanmaku"]
     assert result["afterOn"]["settings"]["subtitleDanmakuMode"] is True
     assert result["afterOn"]["settings"]["subtitlePanelLocked"] is True
     assert result["afterOn"]["settings"]["subtitleInteractionPassthrough"] is True
     assert result["afterOn"]["settings"]["subtitleOpacity"] == 0
     assert result["afterOn"]["settings"]["subtitlePanelBounds"] == {"width": 228, "height": 76}
-    assert result["afterOn"]["nativeBounds"] == {"x": 780, "y": 244, "width": 240, "height": 88}
+    assert result["afterOn"]["nativeBounds"] == {"x": 780, "y": 244, "width": 667, "height": 121}
+    assert result["afterOn"]["setBoundsOptions"] == [
+        {
+            "transient": True,
+            "sessionId": 1,
+            "panelScreenBounds": {"x": 786, "y": 250, "width": 228, "height": 76},
+        }
+    ]
     assert result["afterOn"]["panelState"] == "clean"
     assert result["afterOn"]["backgroundOpacity"] == "0"
     assert result["afterOn"]["panelHidden"] is True
@@ -374,13 +582,62 @@ def test_subtitle_window_danmaku_mode_tracks_avatar_head_and_restores(mock_page:
         "transient": True,
     } in result["afterOn"]["changes"]
 
+    # Even when the model bounds grow far beyond a secondary display, the
+    # transient native surface never grows beyond the normal pre-danmaku panel.
+    assert result["afterHugeAvatar"]["settings"]["subtitlePanelBounds"] == {
+        "width": 228,
+        "height": 76,
+    }
+    assert result["afterHugeAvatar"]["nativeBounds"] == {
+        "x": -2560,
+        "y": 0,
+        "width": 667,
+        "height": 121,
+    }
+    # The native outer frame, including its transparent inset, is also capped
+    # and clamped inside a negative-origin work area.
+    assert result["afterSmallNegativeWorkArea"]["settings"]["subtitlePanelBounds"] == {
+        "width": 228,
+        "height": 76,
+    }
+    assert result["afterSmallNegativeWorkArea"]["nativeBounds"] == {
+        "x": -500,
+        "y": -300,
+        "width": 500,
+        "height": 121,
+    }
+
     assert result["afterOff"]["subscriptions"] == [True, False]
+    assert result["whileRestorePending"]["settings"]["subtitlePanelLocked"] is True
+    assert result["whileRestorePending"]["settings"]["subtitleInteractionPassthrough"] is True
+    assert result["whileRestorePending"]["settings"]["subtitleOpacity"] == 0
+    assert result["whileRestorePending"]["nativeBounds"] == {
+        "x": -500,
+        "y": -300,
+        "width": 500,
+        "height": 121,
+    }
+    assert result["whileRestorePending"]["restoreRequestCount"] == 1
+    assert result["whileRestorePending"]["mainRetryApplied"] is False
+    assert result["afterRapidRetoggle"]["subscriptions"] == [True, False]
+    assert result["afterRapidRetoggle"]["settings"]["subtitleDanmakuMode"] is False
+    assert set(result["afterRapidRetoggle"]["sessionIds"]) == {1}
     assert result["afterOff"]["settings"]["subtitleDanmakuMode"] is False
     assert result["afterOff"]["settings"]["subtitlePanelLocked"] is False
     assert result["afterOff"]["settings"]["subtitleInteractionPassthrough"] is False
     assert result["afterOff"]["settings"]["subtitleOpacity"] == 72
     assert result["afterOff"]["settings"]["subtitlePanelBounds"] == {"width": 655, "height": 109}
-    assert result["afterOff"]["nativeBounds"] == {"x": 100, "y": 300, "width": 667, "height": 121}
+    assert result["afterOff"]["nativeBounds"] == {"x": 112, "y": 294, "width": 667, "height": 121}
+    assert result["afterOff"]["mainRetryApplied"] is True
+    assert result["afterOff"]["setBoundsOptions"][-1] == {
+        "transient": True,
+        "sessionId": 1,
+        "restore": True,
+    }
+    assert sum(
+        1 for options in result["afterOff"]["setBoundsOptions"]
+        if options and options.get("restore")
+    ) == 1
     assert result["afterOff"]["panelState"] == "clean"
     assert result["afterOff"]["panelHidden"] is True
     assert result["afterOff"]["closeCount"] == 2
@@ -391,6 +648,687 @@ def test_subtitle_window_danmaku_mode_tracks_avatar_head_and_restores(mock_page:
         "value": {"width": 655, "height": 109},
         "transient": True,
     } in result["afterOff"]["changes"]
+
+    assert result["whileRestartQueued"]["subscriptions"] == [True, False, True, False]
+    assert result["whileRestartQueued"]["settings"]["subtitleDanmakuMode"] is True
+    assert result["whileRestartQueued"]["handlerDetached"] is True
+    assert result["afterQueuedRestart"]["subscriptions"] == [True, False, True, False, True]
+    assert result["afterQueuedRestart"]["settings"]["subtitleDanmakuMode"] is True
+    assert result["afterQueuedRestart"]["handlerAttached"] is True
+    assert result["afterLegacyFallback"]["settings"]["subtitleDanmakuMode"] is False
+    assert result["afterLegacyFallback"]["settings"]["subtitlePanelLocked"] is False
+    assert result["afterLegacyFallback"]["settings"]["subtitleOpacity"] == 72
+    assert result["afterLegacyFallback"]["nativeBounds"] == {
+        "x": 112,
+        "y": 294,
+        "width": 667,
+        "height": 121,
+    }
+    assert result["afterLegacyFallback"]["restoreRequestCount"] == 1
+
+    # If the single restore IPC never takes effect, renderer verification must
+    # not keep invalidating main-process retries. It fails closed after the final
+    # observation while still issuing exactly one restore request for the session.
+    assert result["afterDroppedRestore"]["settings"]["subtitleDanmakuMode"] is False
+    assert result["afterDroppedRestore"]["settings"]["subtitlePanelLocked"] is True
+    assert result["afterDroppedRestore"]["settings"]["subtitleInteractionPassthrough"] is True
+    assert result["afterDroppedRestore"]["settings"]["subtitleOpacity"] == 0
+    assert result["afterDroppedRestore"]["nativeBounds"] == {
+        "x": 780,
+        "y": 244,
+        "width": 667,
+        "height": 121,
+    }
+    assert result["afterDroppedRestore"]["restoreRequestCount"] == 1
+
+
+@pytest.mark.frontend
+def test_subtitle_window_danmaku_layout_fits_entry_native_viewport(mock_page: Page):
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-window-host",
+        """
+        <div id="subtitle-display" data-subtitle-panel-state="clean">
+            <div id="subtitle-scroll"><span id="subtitle-text">Translated text.</span></div>
+            <div id="subtitle-panel-controls" aria-hidden="true"></div>
+            <div id="subtitle-settings-panel" class="hidden"></div>
+        </div>
+        """,
+        path="/subtitle-window-danmaku-entry-viewport-harness",
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            // Reproduce a stale saved panel that is wider/taller than the real
+            // BrowserWindow carrier observed when danmaku mode starts.
+            window.localStorage.setItem(
+                'subtitlePanelBounds',
+                JSON.stringify({ width: 655, height: 109 })
+            );
+            window.localStorage.setItem('subtitlePanelLocked', 'false');
+            window.localStorage.setItem('subtitleInteractionPassthrough', 'false');
+            window.__subtitleNativeBounds = { x: 198, y: 12, width: 272, height: 98 };
+            window.__subtitleSetBoundsCalls = [];
+            window.__avatarBoundsHandler = null;
+            window.nekoSubtitle = {
+                enableInteraction: () => {},
+                disableInteraction: () => {},
+                getCursorPoint: () => Promise.resolve({ screenX: 0, screenY: 0 }),
+                getBounds: () => Promise.resolve({ ...window.__subtitleNativeBounds }),
+                setBounds: (x, y, width, height) => {
+                    const next = { x, y, width, height };
+                    window.__subtitleSetBoundsCalls.push(next);
+                    window.__subtitleNativeBounds = next;
+                },
+                setSize: () => {},
+                changeSettings: () => {},
+                updateSettingsWindow: () => {},
+                subscribeAvatarBounds: () => {},
+                onAvatarBounds: (handler) => {
+                    window.__avatarBoundsHandler = handler;
+                    return () => { window.__avatarBoundsHandler = null; };
+                },
+            };
+        }
+        """
+    )
+    mock_page.add_style_tag(path=str(PROJECT_ROOT / "static/css/subtitle.css"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle/subtitle-shared.js"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle/subtitle-window.js"))
+    mock_page.evaluate("() => document.dispatchEvent(new Event('DOMContentLoaded'))")
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            const shared = window.nekoSubtitleShared;
+            shared.updateSettings({ subtitleDanmakuMode: true }, { source: 'test-enable-danmaku' });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            window.__avatarBoundsHandler({
+                bounds: {
+                    left: -1100,
+                    top: -500,
+                    width: 2548,
+                    height: 3897,
+                    centerX: 174,
+                    centerY: 1448.5,
+                },
+                display: {
+                    workArea: { x: 0, y: 0, width: 1920, height: 1080 },
+                },
+            });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const display = document.getElementById('subtitle-display');
+            return {
+                settings: shared.getSettings(),
+                nativeBounds: { ...window.__subtitleNativeBounds },
+                requestedBounds: window.__subtitleSetBoundsCalls.at(-1),
+                renderedPanel: {
+                    width: Number(display.dataset.subtitlePanelWidth),
+                    height: Number(display.dataset.subtitlePanelHeight),
+                    styleWidth: display.style.width,
+                    styleHeight: display.style.height,
+                },
+            };
+        }
+        """
+    )
+
+    # Main caps transient requests to the 272x98 entry carrier. Renderer layout
+    # must independently use the same 6px inset on every edge.
+    assert result["settings"]["subtitlePanelBounds"] == {"width": 260, "height": 86}
+    assert result["requestedBounds"]["width"] == 272
+    assert result["requestedBounds"]["height"] == 98
+    assert result["nativeBounds"]["width"] == 272
+    assert result["nativeBounds"]["height"] == 98
+    assert result["renderedPanel"] == {
+        "width": 260,
+        "height": 86,
+        "styleWidth": "260px",
+        "styleHeight": "86px",
+    }
+
+
+@pytest.mark.frontend
+def test_subtitle_window_danmaku_anchors_to_visible_avatar_inside_carrier(mock_page: Page):
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-window-host",
+        """
+        <div id="subtitle-display" data-subtitle-panel-state="clean">
+            <div id="subtitle-scroll"><span id="subtitle-text">Translated text.</span></div>
+            <div id="subtitle-panel-controls" aria-hidden="true"></div>
+            <div id="subtitle-settings-panel" class="hidden"></div>
+        </div>
+        """,
+        path="/subtitle-window-danmaku-visible-avatar-harness",
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.localStorage.setItem(
+                'subtitlePanelBounds',
+                JSON.stringify({ width: 692, height: 254 })
+            );
+            window.localStorage.setItem('subtitlePanelLocked', 'false');
+            window.localStorage.setItem('subtitleInteractionPassthrough', 'false');
+            window.__subtitleNativeBounds = { x: -704, y: 105, width: 704, height: 266 };
+            window.__subtitleSetBoundsCalls = [];
+            window.__avatarBoundsHandler = null;
+            window.nekoSubtitle = {
+                enableInteraction: () => {},
+                disableInteraction: () => {},
+                getCursorPoint: () => Promise.resolve({ screenX: 0, screenY: 0 }),
+                getBounds: () => Promise.resolve({ ...window.__subtitleNativeBounds }),
+                setBounds: (x, y, width, height) => {
+                    const next = { x, y, width, height };
+                    window.__subtitleSetBoundsCalls.push(next);
+                    window.__subtitleNativeBounds = next;
+                },
+                setSize: () => {},
+                changeSettings: () => {},
+                updateSettingsWindow: () => {},
+                subscribeAvatarBounds: () => {},
+                onAvatarBounds: (handler) => {
+                    window.__avatarBoundsHandler = handler;
+                    return () => { window.__avatarBoundsHandler = null; };
+                },
+            };
+        }
+        """
+    )
+    mock_page.add_style_tag(path=str(PROJECT_ROOT / "static/css/subtitle.css"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle/subtitle-shared.js"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle/subtitle-window.js"))
+    mock_page.evaluate("() => document.dispatchEvent(new Event('DOMContentLoaded'))")
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const shared = window.nekoSubtitleShared;
+            const display = document.getElementById('subtitle-display');
+            const snapshot = () => ({
+                settings: shared.getSettings(),
+                nativeBounds: { ...window.__subtitleNativeBounds },
+                style: {
+                    left: display.style.left,
+                    top: display.style.top,
+                    bottom: display.style.bottom,
+                },
+            });
+            const workArea = { x: -2560, y: 0, width: 2560, height: 1392 };
+            shared.updateSettings({ subtitleDanmakuMode: true }, { source: 'test-enable-danmaku' });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            // Matches the reported right-edge shape: the raw model centre is already
+            // outside the negative-origin monitor, while a narrow slice remains visible.
+            window.__avatarBoundsHandler({
+                bounds: { left: -180, top: 192, width: 500, height: 1000, centerX: 70 },
+                display: { workArea },
+            });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const rightEdge = snapshot();
+
+            // Mirror the same geometry at the left edge of the secondary display.
+            window.__avatarBoundsHandler({
+                bounds: { left: -2800, top: 192, width: 500, height: 1000, centerX: -2550 },
+                display: { workArea },
+            });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const leftEdge = snapshot();
+
+            // A model with no visible intersection cannot provide a valid anchor.
+            window.__avatarBoundsHandler({
+                bounds: { left: 100, top: 192, width: 500, height: 1000, centerX: 350 },
+                display: { workArea },
+            });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const invalid = snapshot();
+
+            shared.updateSettings({ subtitleDanmakuMode: false }, { source: 'test-disable-danmaku' });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const afterOff = snapshot();
+            return { rightEdge, leftEdge, invalid, afterOff };
+        }
+        """
+    )
+
+    assert result["rightEdge"]["nativeBounds"] == {
+        "x": -704,
+        "y": 136,
+        "width": 704,
+        "height": 266,
+    }
+    assert result["rightEdge"]["settings"]["subtitlePanelBounds"] == {
+        "width": 228,
+        "height": 76,
+    }
+    assert result["rightEdge"]["style"] == {
+        "left": "470px",
+        "top": "6px",
+        "bottom": "auto",
+    }
+    right_panel_center = -704 + 470 + 228 / 2
+    assert right_panel_center == -120
+    assert abs(right_panel_center - (-90)) == 30
+
+    assert result["leftEdge"]["nativeBounds"] == {
+        "x": -2560,
+        "y": 131,
+        "width": 704,
+        "height": 266,
+    }
+    assert result["leftEdge"]["settings"]["subtitlePanelBounds"] == {
+        "width": 260,
+        "height": 87,
+    }
+    assert result["leftEdge"]["style"] == {
+        "left": "6px",
+        "top": "6px",
+        "bottom": "auto",
+    }
+    assert result["invalid"]["style"] == {"left": "", "top": "", "bottom": ""}
+    assert result["afterOff"]["style"] == {"left": "", "top": "", "bottom": ""}
+
+
+@pytest.mark.frontend
+def test_subtitle_window_danmaku_coalesces_pending_apply_and_restores_after_ack(
+    mock_page: Page,
+):
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-window-host",
+        """
+        <div id="subtitle-display" data-subtitle-panel-state="clean">
+            <div id="subtitle-scroll"><span id="subtitle-text">Translated text.</span></div>
+            <div id="subtitle-panel-controls" aria-hidden="true"></div>
+            <div id="subtitle-settings-panel" class="hidden"></div>
+        </div>
+        """,
+        path="/subtitle-window-danmaku-pending-apply-harness",
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.localStorage.setItem(
+                'subtitlePanelBounds',
+                JSON.stringify({ width: 288, height: 88 })
+            );
+            window.localStorage.setItem('subtitlePanelLocked', 'false');
+            window.localStorage.setItem('subtitleInteractionPassthrough', 'false');
+            window.localStorage.setItem('subtitleOpacity', '65');
+            window.__subtitleNativeBounds = { x: 10, y: 20, width: 300, height: 100 };
+            window.__subtitleSetBoundsCalls = [];
+            window.__pendingSubtitleApplies = [];
+            window.__pendingSubtitleRestores = [];
+            window.__avatarBoundsSubscriptions = [];
+            window.__avatarBoundsHandler = null;
+            window.__resolveNextSubtitleApply = (xOffset, panelRegion) => {
+                const pending = window.__pendingSubtitleApplies.shift();
+                if (!pending) throw new Error('No pending subtitle apply');
+                const actual = {
+                    ...pending.bounds,
+                    x: pending.bounds.x + Number(xOffset || 0),
+                };
+                window.__subtitleNativeBounds = actual;
+                const acknowledgement = {
+                    ok: true,
+                    bounds: actual,
+                    sessionId: pending.options.sessionId,
+                };
+                const summary = { requested: pending.bounds, actual };
+                if (panelRegion) {
+                    acknowledgement.panelRegion = { ...panelRegion };
+                    summary.panelRegion = { ...panelRegion };
+                }
+                pending.resolve(acknowledgement);
+                return summary;
+            };
+            window.__resolveNextSubtitleRestore = (succeeded) => {
+                const pending = window.__pendingSubtitleRestores.shift();
+                if (!pending) throw new Error('No pending subtitle restore');
+                const ok = succeeded !== false;
+                if (ok) window.__subtitleNativeBounds = pending.bounds;
+                pending.resolve({
+                    ok,
+                    bounds: { ...window.__subtitleNativeBounds },
+                    sessionId: pending.options.sessionId,
+                });
+            };
+            window.nekoSubtitle = {
+                enableInteraction: () => {},
+                disableInteraction: () => {},
+                getCursorPoint: () => Promise.resolve({ screenX: 0, screenY: 0 }),
+                getBounds: () => Promise.resolve({ ...window.__subtitleNativeBounds }),
+                setBounds: (x, y, width, height, options) => {
+                    const bounds = { x, y, width, height };
+                    const call = { bounds, options: options || null };
+                    window.__subtitleSetBoundsCalls.push(call);
+                    return new Promise((resolve) => {
+                        const pending = { bounds, options: options || {}, resolve };
+                        if (options && options.restore) {
+                            window.__pendingSubtitleRestores.push(pending);
+                        } else {
+                            window.__pendingSubtitleApplies.push(pending);
+                        }
+                    });
+                },
+                setSize: () => {},
+                changeSettings: () => {},
+                updateSettingsWindow: () => {},
+                subscribeAvatarBounds: (active) => {
+                    window.__avatarBoundsSubscriptions.push(!!active);
+                },
+                onAvatarBounds: (handler) => {
+                    window.__avatarBoundsHandler = handler;
+                    return () => { window.__avatarBoundsHandler = null; };
+                },
+            };
+        }
+        """
+    )
+    mock_page.add_style_tag(path=str(PROJECT_ROOT / "static/css/subtitle.css"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle/subtitle-shared.js"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle/subtitle-window.js"))
+    mock_page.evaluate("() => document.dispatchEvent(new Event('DOMContentLoaded'))")
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            const flush = async () => {
+                await Promise.resolve();
+                await new Promise((resolve) => setTimeout(resolve, 0));
+            };
+            const shared = window.nekoSubtitleShared;
+            const display = document.getElementById('subtitle-display');
+            const workArea = { x: 0, y: 0, width: 2000, height: 1000 };
+            const emitAvatar = (centerX) => {
+                window.__avatarBoundsHandler({
+                    bounds: {
+                        left: centerX - 100,
+                        top: 300,
+                        width: 200,
+                        height: 400,
+                        centerX,
+                    },
+                    display: { workArea },
+                });
+            };
+            const snapshot = () => ({
+                calls: window.__subtitleSetBoundsCalls.map((call) => ({
+                    bounds: { ...call.bounds },
+                    options: call.options ? { ...call.options } : null,
+                })),
+                pendingApplies: window.__pendingSubtitleApplies.length,
+                pendingRestores: window.__pendingSubtitleRestores.length,
+                nativeBounds: { ...window.__subtitleNativeBounds },
+                settings: shared.getSettings(),
+                style: {
+                    left: display.style.left,
+                    top: display.style.top,
+                    bottom: display.style.bottom,
+                },
+                handlerAttached: typeof window.__avatarBoundsHandler === 'function',
+            });
+
+            await flush();
+            shared.updateSettings({ subtitleDanmakuMode: true }, {
+                source: 'test-enable-danmaku',
+            });
+            await flush();
+            emitAvatar(400);
+            emitAvatar(600);
+            emitAvatar(800);
+            await flush();
+            const beforeFirstAck = snapshot();
+
+            const firstAck = window.__resolveNextSubtitleApply(-20);
+            await flush();
+            await flush();
+            const afterFirstAck = snapshot();
+
+            const latestAck = window.__resolveNextSubtitleApply(-30, {
+                x: 41,
+                y: 7,
+                width: 228,
+                height: 76,
+            });
+            await flush();
+            await flush();
+            const afterLatestAck = snapshot();
+
+            emitAvatar(1000);
+            emitAvatar(1200);
+            shared.updateSettings({ subtitleDanmakuMode: false }, {
+                source: 'test-disable-danmaku-while-apply-pending',
+            });
+            await flush();
+            const whileStoppedApplyPending = snapshot();
+
+            const stoppedApplyAck = window.__resolveNextSubtitleApply(-40);
+            await flush();
+            await flush();
+            const afterStoppedApplyAck = snapshot();
+
+            // Queue the requested restart while session 1's first restore is still
+            // pending; no second toggle will be sent after this point.
+            shared.updateSettings({ subtitleDanmakuMode: true }, {
+                source: 'test-queue-danmaku-while-restore-pending',
+            });
+            await flush();
+            await flush();
+            const whileFirstRestorePending = snapshot();
+
+            // Main's lifecycle path may complete a trusted restore even when the
+            // renderer's in-flight invoke eventually reports failure.
+            window.__subtitleNativeBounds = { x: 10, y: 20, width: 300, height: 100 };
+            window.__resolveNextSubtitleRestore(false);
+            await flush();
+            await flush();
+            const afterFailedRestoreRetry = snapshot();
+
+            window.__resolveNextSubtitleRestore(true);
+            await flush();
+            await flush();
+            const afterRecoveredRestart = snapshot();
+            return {
+                beforeFirstAck,
+                firstAck,
+                afterFirstAck,
+                latestAck,
+                afterLatestAck,
+                whileStoppedApplyPending,
+                stoppedApplyAck,
+                afterStoppedApplyAck,
+                whileFirstRestorePending,
+                afterFailedRestoreRetry,
+                afterRecoveredRestart,
+                subscriptions: window.__avatarBoundsSubscriptions.slice(),
+            };
+        }
+        """
+    )
+
+    # While A is in flight, B is overwritten by C and no speculative DOM layout
+    # is committed before main confirms the actual native frame.
+    assert [
+        call["bounds"]["x"] for call in result["beforeFirstAck"]["calls"]
+    ] == [280]
+    assert result["beforeFirstAck"]["pendingApplies"] == 1
+    assert result["beforeFirstAck"]["pendingRestores"] == 0
+    assert result["beforeFirstAck"]["calls"][0]["options"] == {
+        "transient": True,
+        "sessionId": 1,
+        "panelScreenBounds": {"x": 286, "y": 250, "width": 228, "height": 76},
+    }
+    assert result["beforeFirstAck"]["settings"]["subtitlePanelBounds"] == {
+        "width": 288,
+        "height": 88,
+    }
+    assert result["beforeFirstAck"]["style"] == {
+        "left": "",
+        "top": "",
+        "bottom": "",
+    }
+
+    # A became stale while it was pending, so its acknowledgement is not rendered;
+    # only the latest queued sample C is then dispatched (B would be x=480).
+    assert result["firstAck"] == {
+        "requested": {"x": 280, "y": 244, "width": 300, "height": 100},
+        "actual": {"x": 260, "y": 244, "width": 300, "height": 100},
+    }
+    assert [
+        call["bounds"]["x"] for call in result["afterFirstAck"]["calls"]
+    ] == [280, 680]
+    assert result["afterFirstAck"]["calls"][1]["options"] == {
+        "transient": True,
+        "sessionId": 1,
+        "panelScreenBounds": {"x": 686, "y": 250, "width": 228, "height": 76},
+    }
+    assert result["afterFirstAck"]["pendingApplies"] == 1
+    assert result["afterFirstAck"]["settings"]["subtitlePanelBounds"] == {
+        "width": 288,
+        "height": 88,
+    }
+    assert result["afterFirstAck"]["style"] == {
+        "left": "",
+        "top": "",
+        "bottom": "",
+    }
+
+    # C is still current when its acknowledgement arrives, so the renderer commits
+    # main's explicit panel region instead of recomputing the fallback left=36.
+    assert result["latestAck"] == {
+        "requested": {"x": 680, "y": 244, "width": 300, "height": 100},
+        "actual": {"x": 650, "y": 244, "width": 300, "height": 100},
+        "panelRegion": {"x": 41, "y": 7, "width": 228, "height": 76},
+    }
+    assert [
+        call["bounds"]["x"] for call in result["afterLatestAck"]["calls"]
+    ] == [280, 680]
+    assert result["afterLatestAck"]["pendingApplies"] == 0
+    assert result["afterLatestAck"]["settings"]["subtitlePanelBounds"] == {
+        "width": 228,
+        "height": 76,
+    }
+    assert result["afterLatestAck"]["style"] == {
+        "left": "41px",
+        "top": "7px",
+        "bottom": "auto",
+    }
+
+    # D starts another apply and E replaces it as the queued latest sample. Stopping
+    # must drop E and not race restore against D's still-unverified native move.
+    assert [
+        call["bounds"]["x"]
+        for call in result["whileStoppedApplyPending"]["calls"]
+    ] == [280, 680, 880]
+    assert result["whileStoppedApplyPending"]["pendingApplies"] == 1
+    assert result["whileStoppedApplyPending"]["pendingRestores"] == 0
+    assert result["whileStoppedApplyPending"]["calls"][2]["options"] == {
+        "transient": True,
+        "sessionId": 1,
+        "panelScreenBounds": {"x": 886, "y": 250, "width": 228, "height": 76},
+    }
+    assert result["whileStoppedApplyPending"]["style"] == {
+        "left": "",
+        "top": "",
+        "bottom": "",
+    }
+
+    assert result["stoppedApplyAck"] == {
+        "requested": {"x": 880, "y": 244, "width": 300, "height": 100},
+        "actual": {"x": 840, "y": 244, "width": 300, "height": 100},
+    }
+    assert [
+        call["bounds"]["x"]
+        for call in result["afterStoppedApplyAck"]["calls"]
+    ] == [280, 680, 880, 10]
+    assert result["afterStoppedApplyAck"]["pendingApplies"] == 0
+    assert result["afterStoppedApplyAck"]["pendingRestores"] == 1
+    assert result["afterStoppedApplyAck"]["calls"][-1]["options"] == {
+        "transient": True,
+        "sessionId": 1,
+        "restore": True,
+    }
+
+    # The on toggle is queued while restore 1 is pending. The old transient carrier
+    # remains fail-closed and session 2 must not start ahead of restore settlement.
+    assert result["whileFirstRestorePending"]["nativeBounds"] == {
+        "x": 840,
+        "y": 244,
+        "width": 300,
+        "height": 100,
+    }
+    assert (
+        result["whileFirstRestorePending"]["settings"]["subtitleDanmakuMode"]
+        is True
+    )
+    assert result["whileFirstRestorePending"]["settings"]["subtitlePanelBounds"] == {
+        "width": 228,
+        "height": 76,
+    }
+    assert result["whileFirstRestorePending"]["settings"]["subtitlePanelLocked"] is True
+    assert (
+        result["whileFirstRestorePending"]["settings"]["subtitleInteractionPassthrough"]
+        is True
+    )
+    assert result["whileFirstRestorePending"]["settings"]["subtitleOpacity"] == 0
+    assert result["whileFirstRestorePending"]["handlerAttached"] is False
+    assert result["whileFirstRestorePending"]["pendingRestores"] == 1
+    assert len([
+        call
+        for call in result["whileFirstRestorePending"]["calls"]
+        if call["options"] and call["options"].get("restore")
+    ]) == 1
+
+    # Restore 1 reports failure after that queued toggle. The renderer automatically
+    # consumes the queued retry and issues restore 2 without another settings change.
+    retry_restore_calls = [
+        call
+        for call in result["afterFailedRestoreRetry"]["calls"]
+        if call["options"] and call["options"].get("restore")
+    ]
+    assert len(retry_restore_calls) == 2
+    assert [call["options"]["sessionId"] for call in retry_restore_calls] == [1, 1]
+    assert result["afterFailedRestoreRetry"]["pendingRestores"] == 1
+    assert result["afterFailedRestoreRetry"]["handlerAttached"] is False
+    assert (
+        result["afterFailedRestoreRetry"]["settings"]["subtitleDanmakuMode"]
+        is True
+    )
+    assert result["afterFailedRestoreRetry"]["settings"]["subtitlePanelLocked"] is True
+    assert (
+        result["afterFailedRestoreRetry"]["settings"]["subtitleInteractionPassthrough"]
+        is True
+    )
+
+    assert result["afterRecoveredRestart"]["nativeBounds"] == {
+        "x": 10,
+        "y": 20,
+        "width": 300,
+        "height": 100,
+    }
+    assert result["afterRecoveredRestart"]["pendingRestores"] == 0
+    assert result["afterRecoveredRestart"]["settings"]["subtitleDanmakuMode"] is True
+    assert result["afterRecoveredRestart"]["settings"]["subtitlePanelBounds"] == {
+        "width": 288,
+        "height": 88,
+    }
+    assert result["afterRecoveredRestart"]["settings"]["subtitlePanelLocked"] is True
+    assert (
+        result["afterRecoveredRestart"]["settings"]["subtitleInteractionPassthrough"]
+        is True
+    )
+    assert result["afterRecoveredRestart"]["settings"]["subtitleOpacity"] == 0
+    assert result["afterRecoveredRestart"]["handlerAttached"] is True
+    assert result["afterRecoveredRestart"]["style"] == {
+        "left": "",
+        "top": "",
+        "bottom": "",
+    }
+    assert result["subscriptions"] == [True, False, True]
 
 
 @pytest.mark.frontend
@@ -432,12 +1370,18 @@ def test_subtitle_window_danmaku_mode_restores_delayed_native_bounds(mock_page: 
             window.__avatarBoundsSubscriptions = [];
             window.__avatarBoundsHandler = null;
             window.__resolveSubtitleBounds = [];
+            window.__delayInitialSubtitleBounds = true;
+            window.__interactionEvents = [];
             window.nekoSubtitle = {
-                enableInteraction: () => {},
-                disableInteraction: () => {},
+                enableInteraction: () => window.__interactionEvents.push('enable'),
+                disableInteraction: () => window.__interactionEvents.push('disable'),
                 getCursorPoint: () => Promise.resolve({ screenX: 0, screenY: 0 }),
                 getBounds: () => {
                     const captured = { ...window.__subtitleNativeBounds };
+                    if (!window.__delayInitialSubtitleBounds) {
+                        return Promise.resolve(captured);
+                    }
+                    window.__delayInitialSubtitleBounds = false;
                     return new Promise((resolve) => {
                         window.__resolveSubtitleBounds.push(() => resolve(captured));
                     });
@@ -445,6 +1389,7 @@ def test_subtitle_window_danmaku_mode_restores_delayed_native_bounds(mock_page: 
                 setBounds: (x, y, w, h) => {
                     const next = { x, y, width: w, height: h };
                     window.__subtitleSetBoundsCalls.push(next);
+                    window.__interactionEvents.push('setBounds');
                     window.__subtitleNativeBounds = next;
                 },
                 setSize: () => {},
@@ -507,6 +1452,7 @@ def test_subtitle_window_danmaku_mode_restores_delayed_native_bounds(mock_page: 
                         pointerEvents: style.pointerEvents,
                     };
                 })(),
+                interactionEvents: window.__interactionEvents.slice(),
             };
             window.__resolveSubtitleBounds.forEach((resolve) => resolve());
             await new Promise((resolve) => setTimeout(resolve, 0));
@@ -517,6 +1463,7 @@ def test_subtitle_window_danmaku_mode_restores_delayed_native_bounds(mock_page: 
                 setBoundsCalls: window.__subtitleSetBoundsCalls.slice(),
                 subscriptions: window.__avatarBoundsSubscriptions.slice(),
                 mask: document.getElementById('subtitle-display').dataset.subtitleDanmakuSwitching || '',
+                interactionEvents: window.__interactionEvents.slice(),
             };
             await new Promise((resolve) => setTimeout(resolve, 170));
             const afterNativeBoundsSettled = {
@@ -537,8 +1484,9 @@ def test_subtitle_window_danmaku_mode_restores_delayed_native_bounds(mock_page: 
     assert result["whileOn"]["mask"] == "true"
 
     assert result["afterOffBeforeBounds"]["settings"]["subtitleDanmakuMode"] is False
-    assert result["afterOffBeforeBounds"]["settings"]["subtitlePanelLocked"] is False
-    assert result["afterOffBeforeBounds"]["settings"]["subtitleOpacity"] == 64
+    assert result["afterOffBeforeBounds"]["settings"]["subtitlePanelLocked"] is True
+    assert result["afterOffBeforeBounds"]["settings"]["subtitleInteractionPassthrough"] is True
+    assert result["afterOffBeforeBounds"]["settings"]["subtitleOpacity"] == 0
     assert result["afterOffBeforeBounds"]["nativeBounds"] == {"x": 70, "y": 260, "width": 612, "height": 102}
     assert result["afterOffBeforeBounds"]["handlerDetached"] is True
     assert result["afterOffBeforeBounds"]["mask"] == "true"
@@ -547,18 +1495,27 @@ def test_subtitle_window_danmaku_mode_restores_delayed_native_bounds(mock_page: 
         "visibility": "hidden",
         "pointerEvents": "none",
     }
+    assert "enable" not in result["afterOffBeforeBounds"]["interactionEvents"]
 
     assert result["afterNativeBoundsImmediate"]["settings"]["subtitlePanelBounds"] == {"width": 600, "height": 90}
     assert result["afterNativeBoundsImmediate"]["nativeBounds"] == {"x": 70, "y": 260, "width": 612, "height": 102}
+    assert result["afterNativeBoundsImmediate"]["setBoundsCalls"] == []
     assert result["afterNativeBoundsImmediate"]["subscriptions"] == [True, False]
     assert result["afterNativeBoundsImmediate"]["mask"] == "true"
+    restore_events = result["afterNativeBoundsImmediate"]["interactionEvents"]
+    assert "setBounds" not in restore_events
+    assert "enable" in restore_events
     assert result["afterNativeBoundsSettled"]["nativeBounds"] == {"x": 70, "y": 260, "width": 612, "height": 102}
     assert result["afterNativeBoundsSettled"]["subscriptions"] == [True, False]
     assert result["afterNativeBoundsSettled"]["mask"] == ""
 
 
 @pytest.mark.frontend
-def test_subtitle_window_danmaku_mode_does_not_move_when_native_bounds_fail(mock_page: Page):
+@pytest.mark.parametrize("entry_bounds_mode", ["reject", "hang"])
+def test_subtitle_window_danmaku_mode_does_not_move_when_native_bounds_fail(
+    mock_page: Page,
+    entry_bounds_mode: str,
+):
     _open_subtitle_harness(
         mock_page,
         "subtitle-window-host",
@@ -574,7 +1531,8 @@ def test_subtitle_window_danmaku_mode_does_not_move_when_native_bounds_fail(mock
     )
     mock_page.evaluate(
         """
-        () => {
+        (entryBoundsMode) => {
+            window.__entryBoundsMode = entryBoundsMode;
             window.localStorage.setItem('subtitlePanelBounds', JSON.stringify({ width: 600, height: 90 }));
             window.localStorage.setItem('subtitlePanelLocked', 'false');
             window.localStorage.setItem('subtitleInteractionPassthrough', 'false');
@@ -587,7 +1545,9 @@ def test_subtitle_window_danmaku_mode_does_not_move_when_native_bounds_fail(mock
                 enableInteraction: () => {},
                 disableInteraction: () => {},
                 getCursorPoint: () => Promise.resolve({ screenX: 0, screenY: 0 }),
-                getBounds: () => Promise.reject(new Error('bounds unavailable')),
+                getBounds: () => entryBoundsMode === 'hang'
+                    ? new Promise(() => {})
+                    : Promise.reject(new Error('bounds unavailable')),
                 setBounds: (x, y, w, h) => {
                     const next = { x, y, width: w, height: h };
                     window.__subtitleSetBoundsCalls.push(next);
@@ -605,7 +1565,8 @@ def test_subtitle_window_danmaku_mode_does_not_move_when_native_bounds_fail(mock
                 },
             };
         }
-        """
+        """,
+        entry_bounds_mode,
     )
     mock_page.add_style_tag(path=str(PROJECT_ROOT / "static/css/subtitle.css"))
     mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle/subtitle-shared.js"))
@@ -632,7 +1593,10 @@ def test_subtitle_window_danmaku_mode_does_not_move_when_native_bounds_fail(mock
                 mask: display.dataset.subtitleDanmakuSwitching || '',
             };
             shared.updateSettings({ subtitleDanmakuMode: false }, { source: 'test-disable-danmaku' });
-            await new Promise((resolve) => setTimeout(resolve, 170));
+            await new Promise((resolve) => setTimeout(
+                resolve,
+                window.__entryBoundsMode === 'hang' ? 520 : 170
+            ));
             return {
                 whileOn,
                 afterOff: {
@@ -653,7 +1617,7 @@ def test_subtitle_window_danmaku_mode_does_not_move_when_native_bounds_fail(mock
     assert result["whileOn"]["settings"]["subtitleOpacity"] == 0
     assert result["whileOn"]["nativeBounds"] == {"x": 70, "y": 260, "width": 612, "height": 102}
     assert result["whileOn"]["calls"] == []
-    assert result["whileOn"]["mask"] == ""
+    assert result["whileOn"]["mask"] == ("true" if entry_bounds_mode == "hang" else "")
 
     assert result["afterOff"]["settings"]["subtitleDanmakuMode"] is False
     assert result["afterOff"]["settings"]["subtitlePanelLocked"] is False
@@ -663,6 +1627,73 @@ def test_subtitle_window_danmaku_mode_does_not_move_when_native_bounds_fail(mock
     assert result["afterOff"]["subscriptions"] == [True, False]
     assert result["afterOff"]["handlerDetached"] is True
     assert result["afterOff"]["mask"] == ""
+
+
+@pytest.mark.frontend
+def test_subtitle_window_danmaku_mode_requires_complete_native_bounds_bridge(
+    mock_page: Page,
+):
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-window-host",
+        """
+        <div id="subtitle-display" data-subtitle-panel-state="clean">
+            <div id="subtitle-scroll"><span id="subtitle-text">Translated text.</span></div>
+            <div id="subtitle-panel-controls" aria-hidden="true"></div>
+            <div id="subtitle-settings-panel" class="hidden"></div>
+        </div>
+        """,
+        path="/subtitle-window-danmaku-incomplete-bridge-harness",
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.localStorage.setItem('subtitlePanelLocked', 'false');
+            window.localStorage.setItem('subtitleInteractionPassthrough', 'false');
+            window.localStorage.setItem('subtitleOpacity', '64');
+            window.__avatarBoundsSubscriptions = [];
+            window.__avatarBoundsHandler = null;
+            window.nekoSubtitle = {
+                enableInteraction: () => {},
+                disableInteraction: () => {},
+                getCursorPoint: () => Promise.resolve({ screenX: 0, screenY: 0 }),
+                setSize: () => {},
+                changeSettings: () => {},
+                updateSettingsWindow: () => {},
+                subscribeAvatarBounds: (active) => window.__avatarBoundsSubscriptions.push(!!active),
+                onAvatarBounds: (handler) => {
+                    window.__avatarBoundsHandler = handler;
+                    return () => { window.__avatarBoundsHandler = null; };
+                },
+            };
+        }
+        """
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle/subtitle-shared.js"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle/subtitle-window.js"))
+    mock_page.evaluate("() => document.dispatchEvent(new Event('DOMContentLoaded'))")
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            const shared = window.nekoSubtitleShared;
+            shared.updateSettings({ subtitleDanmakuMode: true }, { source: 'test-incomplete-bridge' });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            return {
+                settings: shared.getSettings(),
+                subscriptions: window.__avatarBoundsSubscriptions.slice(),
+                handlerAttached: typeof window.__avatarBoundsHandler === 'function',
+            };
+        }
+        """
+    )
+
+    assert result["settings"]["subtitleDanmakuMode"] is True
+    assert result["settings"]["subtitlePanelLocked"] is False
+    assert result["settings"]["subtitleInteractionPassthrough"] is False
+    assert result["settings"]["subtitleOpacity"] == 64
+    assert result["subscriptions"] == []
+    assert result["handlerAttached"] is False
 
 
 @pytest.mark.frontend
@@ -8027,6 +9058,72 @@ def test_subtitle_window_native_passthrough_toggles_by_cursor_position(
     assert result["afterTransparentArea"] == ["disable"]
     assert result["afterText"] == ["disable"]
     assert result["afterTransparentAgain"] == ["disable"]
+    assert result["afterDisabled"] == ["disable", "enable"]
+
+
+@pytest.mark.frontend
+def test_subtitle_window_native_passthrough_fails_closed_without_cursor_bounds(
+    mock_page: Page,
+):
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-window-host",
+        """
+        <div id="subtitle-display" data-subtitle-panel-state="clean">
+            <div id="subtitle-scroll"><span id="subtitle-text">Translated subtitle.</span></div>
+            <div id="subtitle-settings-panel" class="hidden"></div>
+        </div>
+        """,
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.__subtitleInteractionCalls = [];
+            window.__boundsAvailable = false;
+            window.nekoSubtitle = {
+                getBounds: () => window.__boundsAvailable
+                    ? Promise.resolve({ x: 100, y: 120, width: 360, height: 80 })
+                    : Promise.reject(new Error('bounds unavailable')),
+                getCursorPoint: () => Promise.resolve(null),
+                enableInteraction: () => window.__subtitleInteractionCalls.push('enable'),
+                disableInteraction: () => window.__subtitleInteractionCalls.push('disable'),
+                setSize: () => {},
+                changeSettings: () => {},
+            };
+            window.localStorage.setItem('subtitleInteractionPassthrough', 'true');
+            window.localStorage.setItem('subtitlePanelLocked', 'true');
+        }
+        """
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle/subtitle-shared.js"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle/subtitle-window.js"))
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            document.dispatchEvent(new Event('DOMContentLoaded'));
+            await new Promise((resolve) => setTimeout(resolve, 40));
+            const afterRejectedBounds = window.__subtitleInteractionCalls.slice();
+            window.__boundsAvailable = true;
+            window.dispatchEvent(new Event('focus'));
+            await new Promise((resolve) => setTimeout(resolve, 40));
+            const afterMissingCursor = window.__subtitleInteractionCalls.slice();
+            window.nekoSubtitleShared.updateSettings({
+                subtitleInteractionPassthrough: false,
+                subtitlePanelLocked: false,
+            }, { source: 'test-disable-passthrough' });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            return {
+                afterRejectedBounds,
+                afterMissingCursor,
+                afterDisabled: window.__subtitleInteractionCalls.slice(),
+            };
+        }
+        """
+    )
+
+    assert result["afterRejectedBounds"] == ["disable"]
+    assert result["afterMissingCursor"] == ["disable"]
     assert result["afterDisabled"] == ["disable", "enable"]
 
 

--- a/tests/frontend/test_subtitle_incremental.py
+++ b/tests/frontend/test_subtitle_incremental.py
@@ -933,6 +933,335 @@ def test_subtitle_window_danmaku_anchors_to_visible_avatar_inside_carrier(mock_p
 
 
 @pytest.mark.frontend
+@pytest.mark.parametrize("failure_mode", ["invalid-layout", "rejected-ack"])
+def test_subtitle_window_danmaku_failed_first_layout_releases_switch_mask(
+    mock_page: Page,
+    failure_mode: str,
+):
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-window-host",
+        """
+        <div id="subtitle-display" data-subtitle-panel-state="clean">
+            <div id="subtitle-scroll"><span id="subtitle-text">Translated text.</span></div>
+            <div id="subtitle-panel-controls" aria-hidden="true"></div>
+            <div id="subtitle-settings-panel" class="hidden"></div>
+        </div>
+        """,
+        path=f"/subtitle-window-danmaku-first-layout-{failure_mode}-harness",
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.localStorage.setItem(
+                'subtitlePanelBounds',
+                JSON.stringify({ width: 288, height: 88 })
+            );
+            window.localStorage.setItem('subtitlePanelLocked', 'false');
+            window.localStorage.setItem('subtitleInteractionPassthrough', 'false');
+            window.localStorage.setItem('subtitleOpacity', '65');
+            window.__subtitleNativeBounds = { x: 10, y: 20, width: 300, height: 100 };
+            window.__subtitleSetBoundsCalls = [];
+            window.__pendingSubtitleApplyRejections = [];
+            window.__avatarBoundsHandler = null;
+            window.nekoSubtitle = {
+                enableInteraction: () => {},
+                disableInteraction: () => {},
+                getCursorPoint: () => Promise.resolve({ screenX: 0, screenY: 0 }),
+                getBounds: () => Promise.resolve({ ...window.__subtitleNativeBounds }),
+                setBounds: (x, y, width, height, options) => {
+                    window.__subtitleSetBoundsCalls.push({
+                        bounds: { x, y, width, height },
+                        options: options || null,
+                    });
+                    return new Promise((_resolve, reject) => {
+                        window.__pendingSubtitleApplyRejections.push(reject);
+                    });
+                },
+                setSize: () => {},
+                changeSettings: () => {},
+                updateSettingsWindow: () => {},
+                subscribeAvatarBounds: () => {},
+                onAvatarBounds: (handler) => {
+                    window.__avatarBoundsHandler = handler;
+                    return () => { window.__avatarBoundsHandler = null; };
+                },
+            };
+        }
+        """
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle/subtitle-shared.js"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle/subtitle-window.js"))
+    mock_page.evaluate("() => document.dispatchEvent(new Event('DOMContentLoaded'))")
+
+    result = mock_page.evaluate(
+        """
+        async (failureMode) => {
+            const flush = async () => {
+                await Promise.resolve();
+                await new Promise((resolve) => setTimeout(resolve, 0));
+            };
+            const shared = window.nekoSubtitleShared;
+            const display = document.getElementById('subtitle-display');
+            const snapshot = () => ({
+                calls: window.__subtitleSetBoundsCalls.map((call) => ({
+                    bounds: { ...call.bounds },
+                    options: call.options ? { ...call.options } : null,
+                })),
+                pendingRejections: window.__pendingSubtitleApplyRejections.length,
+                mask: display.dataset.subtitleDanmakuSwitching || '',
+                style: {
+                    left: display.style.left,
+                    top: display.style.top,
+                    bottom: display.style.bottom,
+                },
+            });
+
+            await flush();
+            shared.updateSettings({ subtitleDanmakuMode: true }, {
+                source: 'test-enable-danmaku',
+            });
+            await flush();
+            await flush();
+            display.style.left = '42px';
+            display.style.top = '9px';
+            display.style.bottom = 'auto';
+            const beforeFailure = snapshot();
+
+            const validBounds = failureMode === 'rejected-ack';
+            window.__avatarBoundsHandler({
+                bounds: {
+                    left: 300,
+                    top: 300,
+                    width: validBounds ? 200 : 0,
+                    height: 400,
+                    centerX: 400,
+                },
+                display: { workArea: { x: 0, y: 0, width: 1600, height: 900 } },
+            });
+            await flush();
+            if (failureMode === 'rejected-ack') {
+                const reject = window.__pendingSubtitleApplyRejections.shift();
+                reject(new Error('setBounds rejected'));
+                await flush();
+                await flush();
+            }
+            const afterFailure = snapshot();
+            await new Promise((resolve) => setTimeout(resolve, 170));
+            const afterMaskSettle = snapshot();
+            return { beforeFailure, afterFailure, afterMaskSettle };
+        }
+        """,
+        failure_mode,
+    )
+
+    assert result["beforeFailure"]["mask"] == "true"
+    assert result["beforeFailure"]["style"] == {
+        "left": "42px",
+        "top": "9px",
+        "bottom": "auto",
+    }
+    assert len(result["afterFailure"]["calls"]) == (
+        1 if failure_mode == "rejected-ack" else 0
+    )
+    assert result["afterFailure"]["pendingRejections"] == 0
+    assert result["afterFailure"]["mask"] == "true"
+    assert result["afterFailure"]["style"] == {
+        "left": "",
+        "top": "",
+        "bottom": "",
+    }
+    assert result["afterMaskSettle"]["mask"] == ""
+
+
+@pytest.mark.frontend
+@pytest.mark.parametrize(
+    ("case_name", "restore_result", "should_restore"),
+    [
+        (
+            "safe-terminal",
+            {
+                "ok": False,
+                "reason": "verification-failed",
+                "safeToReveal": True,
+                "bounds": {"x": 10, "y": 20, "width": 300, "height": 100},
+            },
+            True,
+        ),
+        (
+            "unsafe-terminal",
+            {
+                "ok": False,
+                "reason": "verification-failed",
+                "safeToReveal": False,
+                "bounds": {"x": 10, "y": 20, "width": 300, "height": 100},
+            },
+            False,
+        ),
+        (
+            "wrong-reason",
+            {
+                "ok": False,
+                "reason": "restore-failed",
+                "safeToReveal": True,
+                "bounds": {"x": 10, "y": 20, "width": 300, "height": 100},
+            },
+            False,
+        ),
+        (
+            "cancelled-safe-terminal",
+            {
+                "ok": False,
+                "cancelled": True,
+                "reason": "verification-failed",
+                "safeToReveal": True,
+                "bounds": {"x": 10, "y": 20, "width": 300, "height": 100},
+            },
+            False,
+        ),
+    ],
+)
+def test_subtitle_window_danmaku_restore_only_reveals_explicit_safe_terminal(
+    mock_page: Page,
+    case_name: str,
+    restore_result: dict,
+    should_restore: bool,
+):
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-window-host",
+        """
+        <div id="subtitle-display" data-subtitle-panel-state="clean">
+            <div id="subtitle-scroll"><span id="subtitle-text">Translated text.</span></div>
+            <div id="subtitle-panel-controls" aria-hidden="true"></div>
+            <div id="subtitle-settings-panel" class="hidden"></div>
+        </div>
+        """,
+        path=f"/subtitle-window-danmaku-safe-restore-{case_name}-harness",
+    )
+    mock_page.evaluate(
+        """
+        (restoreResult) => {
+            window.localStorage.setItem(
+                'subtitlePanelBounds',
+                JSON.stringify({ width: 288, height: 88 })
+            );
+            window.localStorage.setItem('subtitlePanelLocked', 'false');
+            window.localStorage.setItem('subtitleInteractionPassthrough', 'false');
+            window.localStorage.setItem('subtitleOpacity', '65');
+            window.__subtitleNativeBounds = { x: 10, y: 20, width: 300, height: 100 };
+            window.__subtitleRestoreResult = restoreResult;
+            window.__subtitleSetBoundsOptions = [];
+            window.__subtitleSettingsChanges = [];
+            window.__avatarBoundsHandler = null;
+            window.nekoSubtitle = {
+                enableInteraction: () => {},
+                disableInteraction: () => {},
+                getCursorPoint: () => Promise.resolve({ screenX: 0, screenY: 0 }),
+                getBounds: () => Promise.resolve({ ...window.__subtitleNativeBounds }),
+                setBounds: (x, y, width, height, options) => {
+                    const next = { x, y, width, height };
+                    window.__subtitleSetBoundsOptions.push(options || null);
+                    if (options && options.restore) {
+                        window.__subtitleNativeBounds = {
+                            ...window.__subtitleRestoreResult.bounds,
+                        };
+                        return Promise.resolve({
+                            ...window.__subtitleRestoreResult,
+                            sessionId: options.sessionId,
+                        });
+                    }
+                    window.__subtitleNativeBounds = next;
+                    return Promise.resolve({
+                        ok: true,
+                        bounds: next,
+                        sessionId: options && options.sessionId,
+                    });
+                },
+                setSize: () => {},
+                changeSettings: (change) => window.__subtitleSettingsChanges.push(change),
+                updateSettingsWindow: () => {},
+                subscribeAvatarBounds: () => {},
+                onAvatarBounds: (handler) => {
+                    window.__avatarBoundsHandler = handler;
+                    return () => { window.__avatarBoundsHandler = null; };
+                },
+            };
+        }
+        """,
+        restore_result,
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle/subtitle-shared.js"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle/subtitle-window.js"))
+    mock_page.evaluate("() => document.dispatchEvent(new Event('DOMContentLoaded'))")
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            const flush = async () => {
+                await Promise.resolve();
+                await new Promise((resolve) => setTimeout(resolve, 0));
+            };
+            const shared = window.nekoSubtitleShared;
+            await flush();
+            shared.updateSettings({ subtitleDanmakuMode: true }, {
+                source: 'test-enable-danmaku',
+            });
+            await flush();
+            await flush();
+            window.__avatarBoundsHandler({
+                bounds: {
+                    left: 300,
+                    top: 300,
+                    width: 200,
+                    height: 400,
+                    centerX: 400,
+                },
+                display: { workArea: { x: 0, y: 0, width: 1600, height: 900 } },
+            });
+            await flush();
+            await flush();
+            const whileOn = shared.getSettings();
+            shared.updateSettings({ subtitleDanmakuMode: false }, {
+                source: 'test-disable-danmaku',
+            });
+            await flush();
+            await flush();
+            return {
+                whileOn,
+                afterOff: shared.getSettings(),
+                nativeBounds: { ...window.__subtitleNativeBounds },
+                restoreOptions: window.__subtitleSetBoundsOptions.filter(
+                    (options) => options && options.restore
+                ),
+                changes: window.__subtitleSettingsChanges.slice(),
+            };
+        }
+        """
+    )
+
+    assert result["whileOn"]["subtitlePanelLocked"] is True
+    assert result["whileOn"]["subtitleInteractionPassthrough"] is True
+    assert result["whileOn"]["subtitleOpacity"] == 0
+    assert result["nativeBounds"] == {"x": 10, "y": 20, "width": 300, "height": 100}
+    assert result["restoreOptions"] == [
+        {"transient": True, "sessionId": 1, "restore": True}
+    ]
+    assert result["afterOff"]["subtitleDanmakuMode"] is False
+    assert result["afterOff"]["subtitlePanelLocked"] is (not should_restore)
+    assert result["afterOff"]["subtitleInteractionPassthrough"] is (
+        not should_restore
+    )
+    assert result["afterOff"]["subtitleOpacity"] == (65 if should_restore else 0)
+    restored_lock_changes = [
+        change
+        for change in result["changes"]
+        if change.get("type") == "lock" and change.get("value") is False
+    ]
+    assert bool(restored_lock_changes) is should_restore
+
+
+@pytest.mark.frontend
 def test_subtitle_window_danmaku_coalesces_pending_apply_and_restores_after_ack(
     mock_page: Page,
 ):
@@ -1069,6 +1398,7 @@ def test_subtitle_window_danmaku_coalesces_pending_apply_and_restores_after_ack(
                     top: display.style.top,
                     bottom: display.style.bottom,
                 },
+                mask: display.dataset.subtitleDanmakuSwitching || '',
                 handlerAttached: typeof window.__avatarBoundsHandler === 'function',
             });
 
@@ -1087,6 +1417,8 @@ def test_subtitle_window_danmaku_coalesces_pending_apply_and_restores_after_ack(
             await flush();
             await flush();
             const afterFirstAck = snapshot();
+            await new Promise((resolve) => setTimeout(resolve, 170));
+            const afterStaleAckSettleDelay = snapshot();
 
             const latestAck = window.__resolveNextSubtitleApply(-30, {
                 x: 41,
@@ -1136,6 +1468,7 @@ def test_subtitle_window_danmaku_coalesces_pending_apply_and_restores_after_ack(
                 beforeFirstAck,
                 firstAck,
                 afterFirstAck,
+                afterStaleAckSettleDelay,
                 latestAck,
                 afterLatestAck,
                 whileStoppedApplyPending,
@@ -1157,6 +1490,7 @@ def test_subtitle_window_danmaku_coalesces_pending_apply_and_restores_after_ack(
     ] == [280]
     assert result["beforeFirstAck"]["pendingApplies"] == 1
     assert result["beforeFirstAck"]["pendingRestores"] == 0
+    assert result["beforeFirstAck"]["mask"] == "true"
     assert result["beforeFirstAck"]["calls"][0]["options"] == {
         "transient": True,
         "sessionId": 1,
@@ -1187,6 +1521,7 @@ def test_subtitle_window_danmaku_coalesces_pending_apply_and_restores_after_ack(
         "panelScreenBounds": {"x": 686, "y": 250, "width": 228, "height": 76},
     }
     assert result["afterFirstAck"]["pendingApplies"] == 1
+    assert result["afterFirstAck"]["mask"] == "true"
     assert result["afterFirstAck"]["settings"]["subtitlePanelBounds"] == {
         "width": 288,
         "height": 88,
@@ -1196,6 +1531,8 @@ def test_subtitle_window_danmaku_coalesces_pending_apply_and_restores_after_ack(
         "top": "",
         "bottom": "",
     }
+    assert result["afterStaleAckSettleDelay"]["pendingApplies"] == 1
+    assert result["afterStaleAckSettleDelay"]["mask"] == "true"
 
     # C is still current when its acknowledgement arrives, so the renderer commits
     # main's explicit panel region instead of recomputing the fallback left=36.


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复弹幕模式下大模型及屏幕边缘场景的字幕框定位、内容错位和窗口恢复竞态
### 具体问题表现
缩放模型时弹幕模式翻译框会出现错位、闪现、消失等等问题

## 测试 / Testing

手动测试放大缩小模型观察翻译框

## 另一侧
[增加字幕窗口临时边界与面板区域校验，修复透明窗口跨屏及隐藏恢复异常](https://github.com/Project-N-E-K-O/N.E.K.O.-PC/pull/346)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 改进弹幕模式原生窗口 bounds 的托管/停止过渡判断，跳过不应进行的尺寸设定，减少切换错位。
  * 重构弹幕布局计算与应用：基于稳定载体窗口进行面板定位与覆盖式更新；无法获得有效位置时会清理面板样式。
  * 升级 bounds 恢复与验证：引入快照超时与结果校验，失败时保持“fail-closed”策略，避免异常移动。

* **可靠性**
  * 强化弹幕模式启动/停止/挂接/分离收尾，串行化 setBounds→验证→提交流程，并处理停止中会话分流与重试分支。
  * 改善交互穿透判定：在缺失 cursor/原生轮询失败等场景下更严格禁用与时序控制，确保行为一致。

* **测试**
  * 扩展字幕与原生桥接并发/异常场景用例，覆盖延迟恢复、失败拒绝/挂起、订阅缺失与交互 fail-closed 断言。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->