### PR TITLE
fix(screenshot): stop pin failures from triggering recapture

### DIFF
--- a/static/app/app-buttons.js
+++ b/static/app/app-buttons.js
@@ -3137,13 +3137,24 @@
 
         function isDesktopRegionCaptureUnavailable(errorLike) {
             if (!errorLike) return false;
-            var code = errorLike.code || '';
+            var code = String(errorLike.code || '').trim();
+            if (!code) {
+                var exactValue = String(
+                    errorLike.message || errorLike.error || errorLike.reason || ''
+                ).trim();
+                if (/^[A-Z][A-Z0-9_]+$/.test(exactValue)) {
+                    code = exactValue;
+                }
+            }
             if (code === 'ENOSYS' || code === 'UNSUPPORTED_API' || code === 'SCREEN_CAPTURE_UNAVAILABLE') return true;
             var message = String(errorLike.message || errorLike.error || errorLike.reason || '').toLowerCase();
-            return message.indexOf('not implemented') !== -1
-                || message.indexOf('not supported') !== -1
-                || message.indexOf('unsupported') !== -1
-                || message.indexOf('unavailable') !== -1;
+            // 仅保留旧壳曾经返回的完整短语。能力级错误（例如
+            // SCREENSHOT_PIN_*）即使包含 unsupported，也必须终止本次操作，
+            // 不能回退到第二轮截图并把编辑器本身抓进画面。
+            return message === 'not implemented'
+                || message === 'not supported'
+                || message === 'unsupported'
+                || message === 'unavailable';
         }
 
         function normalizeDesktopRegionCaptureResult(raw) {
@@ -3158,7 +3169,9 @@
                 return {
                     success: false,
                     error: raw.error || raw.message || 'DESKTOP_REGION_CAPTURE_FAILED',
-                    code: raw.code || null
+                    code: raw.code || null,
+                    capability: raw.capability || null,
+                    retryable: raw.retryable === true
                 };
             }
             if (raw.pinned) {
@@ -3231,7 +3244,11 @@
                     console.info('[截图] 桌面框选接口声明不可用，回退到内置裁剪:', regionMethod.name);
                     return null;
                 }
-                throw new Error(normalized.error || 'DESKTOP_REGION_CAPTURE_FAILED');
+                var terminalError = new Error(normalized.error || 'DESKTOP_REGION_CAPTURE_FAILED');
+                terminalError.code = normalized.code || null;
+                terminalError.capability = normalized.capability || null;
+                terminalError.retryable = normalized.retryable === true;
+                throw terminalError;
             }
 
             console.log('[截图] 桌面框选捕获成功:', regionMethod.name, (normalized.width || 0) + 'x' + (normalized.height || 0));

--- a/static/app/app-buttons.js
+++ b/static/app/app-buttons.js
@@ -3147,7 +3147,7 @@
                 }
             }
             if (code === 'ENOSYS' || code === 'UNSUPPORTED_API' || code === 'SCREEN_CAPTURE_UNAVAILABLE') return true;
-            var message = String(errorLike.message || errorLike.error || errorLike.reason || '').toLowerCase();
+            var message = String(errorLike.message || errorLike.error || errorLike.reason || '').toLowerCase().trim();
             // 仅保留旧壳曾经返回的完整短语。能力级错误（例如
             // SCREENSHOT_PIN_*）即使包含 unsupported，也必须终止本次操作，
             // 不能回退到第二轮截图并把编辑器本身抓进画面。

--- a/tests/unit/test_desktop_screenshot_overlay_static.py
+++ b/tests/unit/test_desktop_screenshot_overlay_static.py
@@ -80,6 +80,7 @@ def test_desktop_pin_failures_never_trigger_a_second_screenshot_fallback():
     )[1].split("async function recaptureWithoutNeko()", 1)[0]
 
     assert "message.indexOf('unsupported')" not in unavailable_block
+    assert ".toLowerCase().trim()" in unavailable_block
     assert "message === 'unsupported'" in unavailable_block
     assert "terminalError.capability = normalized.capability || null" in direct_capture_block
     assert direct_capture_block.index("if (isDesktopRegionCaptureUnavailable(normalized))") < direct_capture_block.index(

--- a/tests/unit/test_desktop_screenshot_overlay_static.py
+++ b/tests/unit/test_desktop_screenshot_overlay_static.py
@@ -69,6 +69,24 @@ def test_successful_desktop_pin_is_not_reported_as_cancelled():
     )
 
 
+def test_desktop_pin_failures_never_trigger_a_second_screenshot_fallback():
+    unavailable_block = APP_BUTTONS.split(
+        "function isDesktopRegionCaptureUnavailable(errorLike)",
+        1,
+    )[1].split("function normalizeDesktopRegionCaptureResult(raw)", 1)[0]
+    direct_capture_block = APP_BUTTONS.split(
+        "async function captureDesktopRegionDirectly()",
+        1,
+    )[1].split("async function recaptureWithoutNeko()", 1)[0]
+
+    assert "message.indexOf('unsupported')" not in unavailable_block
+    assert "message === 'unsupported'" in unavailable_block
+    assert "terminalError.capability = normalized.capability || null" in direct_capture_block
+    assert direct_capture_block.index("if (isDesktopRegionCaptureUnavailable(normalized))") < direct_capture_block.index(
+        "throw terminalError"
+    )
+
+
 def test_react_chat_marks_screenshot_capability_ready_after_binding_the_button():
     button_index = APP_BUTTONS.index(
         "screenshotButton.addEventListener('click', mod.captureScreenshotToPendingList);"


### PR DESCRIPTION
## 关联

- 配套 PC 修复：Project-N-E-K-O/N.E.K.O.-PC#345
- 基于已合并的截图贴图前端功能 #2335。

## 修改内容

- 只有明确的 API 不可用错误码和旧壳完整短语才允许回退内置截图链路。
- 不再用包含 `unsupported` / `unavailable` 的宽泛子串判断能力是否缺失。
- 保留 PC 返回的 `code`、`capability` 和 `retryable` 字段。
- 贴图能力级失败作为终止错误返回，不再触发第二轮截图。

## 根因

PC 贴图失败时会返回 `SCREENSHOT_PIN_*` 能力级错误。前端旧判断只要错误文本包含 `unsupported` 或 `unavailable` 就视为“桌面截图 API 不存在”，随后回退到旧截图链路。

这会重新发起一次系统截图/portal 授权，并可能把仍在桌面的贴图或截图编辑层再次抓入画面。

## 用户影响

- 贴图失败不会再次弹出屏幕共享选择器。
- 不会因为错误回退而把截图编辑层或贴图重新截入画面。
- 真正不支持桌面框选 API 的旧 Electron 壳仍可使用原有回退路径。

## 验证

- `uv run pytest -q tests/unit/test_desktop_screenshot_overlay_static.py`：8/8 通过。
- `uv run ruff check tests/unit/test_desktop_screenshot_overlay_static.py`：通过。
- `node --check static/app/app-buttons.js`：通过。

## 范围

- 只修改桌面截图失败分类和对应静态契约测试。
- 不修改成功贴图、用户取消、普通截图和上传图片流程。
- 无 i18n 字符串变更。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 优化桌面区域截图“不可用”判断：当缺少错误码时从错误信息中提取规范化错误码，并将“unsupported/not supported”等识别改为更精确的匹配方式，降低误判回退。
  - 完善桌面框选失败的错误信息透传：补齐错误码、能力状态，并携带是否可重试信息。
  - 终止错误处理：失败流程不再使用通用异常，而是按状态构造终止错误，避免在明确不可用时触发二次截图回退。
- **测试**
  - 新增覆盖场景：验证当能力为 `unsupported` 时不会触发二次截图回退。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->