### PR TITLE
fix: harden runtime memory lifecycle teardown

### DIFF
--- a/docs/benchmarks/runtime-memory-soak-2026-07-15.md
+++ b/docs/benchmarks/runtime-memory-soak-2026-07-15.md
@@ -4,15 +4,15 @@
 
 A two-hour, 204-cycle lifecycle soak on commit
 `715cab7fa8143aaf6cce92b8645e8cbdebf7e467` did **not** find a retained
-Python owner, child process, thread, handle, ONNX mapping, or monotonically
-unrecoverable working set that establishes a product leak.
+RapidOCR owner, child process, thread, handle, growing ONNX mapping count, or
+monotonically unrecoverable working set that establishes a product leak.
 
 The run did find two distinct effects:
 
 1. Repeated ONNX/browser construction raises the process allocator/working-set
    high-water mark in steps. Large 20-50 MiB drops also occur later, while
-   Python owners are already zero. Treat the elevated RSS/USS as native
-   allocator retention, not proof of a live session leak.
+   observed RapidOCR owners are already zero. Treat the elevated RSS/USS as
+   native allocator retention, not proof of a live session leak.
 2. The merged audio lifecycle had one deterministic integration bug:
    `AudioProcessor.set_enabled(False)` closed RNNoise but retained the fixed
    frame buffer, contradicting the lifecycle regression. Releasing it without
@@ -66,8 +66,9 @@ resolved from this worktree. The run lasted 7,203.426 seconds and exited zero.
 
 ## Formal two-hour run
 
-All five executable workloads completed in all 204 cycles. Chat was explicitly
-reported as skipped in all 204 cycles.
+All five executable workloads completed in all 204 cycles. Every audio result
+recorded `native_denoiser=true`, and every plugin result recorded
+`triggered=true`. Chat was explicitly reported as skipped in all 204 cycles.
 
 | Released checkpoint | USS average (MiB) | USS min-max (MiB) | traced current average (MiB) | handles min-max | threads min-max |
 | --- | ---: | ---: | ---: | ---: | ---: |
@@ -90,8 +91,6 @@ Examples of real recovery:
 
 Released resource invariants across all 204 cycles:
 
-- embedding session refs: min/max 0/0;
-- embedding tokenizer refs: min/max 0/0;
 - RapidOCR cache entries: min/max 0/0;
 - RapidOCR owners: min/max 0/0;
 - Chromium children: min/max 0/0;
@@ -100,8 +99,16 @@ Released resource invariants across all 204 cycles:
 - threads: first/last 69/65, range 62-71;
 - handles: first/last 839/843, range 835-843.
 
-The two stable ONNX mappings remain after Python owners reach zero. They are
-DLL/model residency, not evidence that an `InferenceSession` is still owned.
+The formal run's embedding session/tokenizer counters are not used as release
+evidence: that revision inspected only the application singleton while the
+probe created direct `EmbeddingService` instances. The probe now weakly
+registers direct services, so future active checkpoints observe their session
+and tokenizer while released checkpoints can verify that the objects and
+references disappeared.
+
+The two stable ONNX mappings remain after the explicit embedding close and
+RapidOCR owner release. They are DLL/model residency, not evidence that an
+`InferenceSession` is still owned.
 
 Tracemalloc current grew 96.312 -> 105.793 MiB (+9.481 MiB). This run retained
 7.66 MiB of aggregate JSON in memory so it could atomically rewrite the report
@@ -111,6 +118,14 @@ aggregates remain) and exposes `--retain-process-rows` only for investigations
 that need every PID at every checkpoint.
 
 ## Controls
+
+### Embedding owner instrumentation, post-review
+
+A fresh one-cycle embedding control using the revised weak registry recorded
+one service, one session, and one tokenizer at the active checkpoint, followed
+by 0/0/0 at both the feature-released and all-released checkpoints. The ONNX
+map count remained at two after release, directly separating released Python
+owners from stable runtime mappings.
 
 ### OCR-only, fresh process
 
@@ -174,6 +189,10 @@ Coverage includes time-index batching, topic signals, audio memory and
 lifecycle, embedding lifecycle, browser lifecycle, agent shutdown, RapidOCR,
 vision, study OCR, and the soak analyzer.
 
+The post-review lifecycle/measurement slice also passes 22 tests, including
+unknown-metric preservation, direct embedding owner tracking, workload success
+gates, and the isolated chat backend PID contract.
+
 ## Re-run
 
 From a Python 3.11 environment:
@@ -187,5 +206,6 @@ uv run python -m scripts.runtime_memory_soak `
 ```
 
 `--duration-hours` accepts values up to 8. Chat remains disabled unless an
-operator passes `--chat-port` for a separately started backend whose storage
-isolation has already been verified.
+operator passes both `--chat-port` and `--chat-pid` for a separately started
+backend whose storage isolation has already been verified. Chat checkpoints
+sample that backend PID and its descendants rather than the soak driver.

--- a/docs/benchmarks/runtime-memory-soak-2026-07-15.md
+++ b/docs/benchmarks/runtime-memory-soak-2026-07-15.md
@@ -1,0 +1,191 @@
+# Runtime lifecycle soak after PRs #2350/#2351/#2353/#2354/#2355
+
+## Result
+
+A two-hour, 204-cycle lifecycle soak on commit
+`715cab7fa8143aaf6cce92b8645e8cbdebf7e467` did **not** find a retained
+Python owner, child process, thread, handle, ONNX mapping, or monotonically
+unrecoverable working set that establishes a product leak.
+
+The run did find two distinct effects:
+
+1. Repeated ONNX/browser construction raises the process allocator/working-set
+   high-water mark in steps. Large 20-50 MiB drops also occur later, while
+   Python owners are already zero. Treat the elevated RSS/USS as native
+   allocator retention, not proof of a live session leak.
+2. The merged audio lifecycle had one deterministic integration bug:
+   `AudioProcessor.set_enabled(False)` closed RNNoise but retained the fixed
+   frame buffer, contradicting the lifecycle regression. Releasing it without
+   a matching enable path would then break processing. The branch now releases
+   the buffer on disable and symmetrically recreates it on enable.
+
+No other product code was changed.
+
+## Scope and privacy
+
+Every workload used explicit synthetic input:
+
+- audio: deterministic generated PCM16 ramp;
+- embedding: a fixed synthetic sentence;
+- RapidOCR: a generated blank 640x360 image;
+- browser-use: local headless Playwright startup/close without an LLM task;
+- plugin reload: the repository's synthetic dynamic-entry fixture process;
+- chat: **skipped** because no backend with verified isolated storage was
+  available. The earlier baseline documents that an unisolated synthetic chat
+  can persist into the selected character store, so this soak did not risk it.
+
+The aggregate JSON records process/resource counts, status codes, and exception
+types only. It does not record prompts, responses, command lines, environment
+variables, microphone data, or API payloads.
+
+## Method
+
+The probe extends `scripts/runtime_memory_baseline.py` and adds
+`scripts/runtime_memory_soak.py`. Each cycle performs:
+
+1. `AudioProcessor` create, synthetic processing, disable/enable twice, close.
+2. `EmbeddingService` load, one synthetic inference, close.
+3. `RapidOcrBackend` acquire, one blank-image inference, close/release owner.
+4. `BrowserUseAdapter` and Playwright start, close, verify descendants exit.
+5. Synthetic plugin host start, dynamic entry trigger, shutdown.
+6. GC plus a released checkpoint after every feature and after the whole cycle.
+
+Samples include the full process tree and aggregate:
+
+- RSS and USS;
+- process, thread, and Windows handle counts;
+- Chromium child count;
+- ONNX-related memory map count and resident bytes;
+- embedding session/tokenizer references;
+- RapidOCR cache entries and owner counts;
+- tracemalloc current/peak and top final growth sites.
+
+The formal command ran through `uv run` with Python 3.11.13 from the existing
+main-checkout environment and the model files from that checkout. Imports still
+resolved from this worktree. The run lasted 7,203.426 seconds and exited zero.
+
+## Formal two-hour run
+
+All five executable workloads completed in all 204 cycles. Chat was explicitly
+reported as skipped in all 204 cycles.
+
+| Released checkpoint | USS average (MiB) | USS min-max (MiB) | traced current average (MiB) | handles min-max | threads min-max |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Cycles 1-10 | 492.493 | 436.539-534.211 | 96.607 | 836-841 | 63-71 |
+| Cycles 41-50 | 608.143 | 604.727-610.977 | 98.546 | 837-839 | 63-63 |
+| Cycles 91-100 | 623.264 | 620.613-624.953 | 100.865 | 837-843 | 63-65 |
+| Cycles 141-150 | 645.685 | 625.219-650.981 | 103.161 | 841-843 | 64-65 |
+| Cycles 195-204 | 657.287 | 656.496-657.813 | 105.592 | 841-843 | 64-65 |
+
+The first/last released samples were 436.539/657.391 MiB USS and
+500.488/720.719 MiB RSS. The maximum released USS was 658.281 MiB. A naive
+whole-run regression is about +54.1 MiB USS/hour, but it is not a leak rate:
+the series contains cold imports, allocator warm-up steps, diagnostic result
+retention, and multiple large recoveries.
+
+Examples of real recovery:
+
+- cycle 50 to 51: 610.977 -> 588.605 MiB USS (-22.372 MiB);
+- cycle 142 to 143: 650.680 -> 625.219 MiB USS (-25.461 MiB).
+
+Released resource invariants across all 204 cycles:
+
+- embedding session refs: min/max 0/0;
+- embedding tokenizer refs: min/max 0/0;
+- RapidOCR cache entries: min/max 0/0;
+- RapidOCR owners: min/max 0/0;
+- Chromium children: min/max 0/0;
+- ONNX maps: min/max 2/2;
+- ONNX mapped RSS: min/max 16.430/16.430 MiB;
+- threads: first/last 69/65, range 62-71;
+- handles: first/last 839/843, range 835-843.
+
+The two stable ONNX mappings remain after Python owners reach zero. They are
+DLL/model residency, not evidence that an `InferenceSession` is still owned.
+
+Tracemalloc current grew 96.312 -> 105.793 MiB (+9.481 MiB). This run retained
+7.66 MiB of aggregate JSON in memory so it could atomically rewrite the report
+after each cycle; several of the largest final growth sites are the sampler's
+own retained rows. The soak script now drops per-PID rows by default (category
+aggregates remain) and exposes `--retain-process-rows` only for investigations
+that need every PID at every checkpoint.
+
+## Controls
+
+### OCR-only, fresh process
+
+Thirty cycles completed in 114.676 seconds.
+
+| Cycles | USS average (MiB) | USS min-max (MiB) | traced current average (MiB) |
+| --- | ---: | ---: | ---: |
+| 1-5 | 240.938 | 237.352-242.934 | 52.347 |
+| 11-15 | 247.569 | 245.297-253.410 | 52.446 |
+| 26-30 | 256.714 | 255.387-258.074 | 52.588 |
+
+The last cycle was 255.570 MiB USS. Tracemalloc grew only 0.286 MiB, handles
+grew by 2, threads ended unchanged at 39, maps stayed at 2/16.430 MiB, and all
+RapidOCR cache/owner counts were zero after release. The final window is a
+plateau with small recoveries rather than a fixed per-cycle loss.
+
+### Audio + embedding + browser-use + plugin, no OCR
+
+Twenty cycles completed in 149.676 seconds. Released USS ranged from 365.215 to
+490.101 MiB and ended at 438.375 MiB. Cycle 19 to 20 alone recovered 51.726 MiB.
+Tracemalloc grew 0.895 MiB; handles ended one lower and threads five lower.
+
+Embedding close was the transition that sometimes caused a 45-53 MiB recovery,
+while browser and plugin release returned to the same level. This independently
+shows native allocator/working-set changes outside RapidOCR as well.
+
+### Harness-only
+
+Fifty measurement-only cycles completed in 6.060 seconds. USS grew
+16.730 -> 19.633 MiB (+2.903 MiB), tracemalloc current grew 0.177 MiB, and
+handles grew by 2. This is diagnostic self-retention and is not application
+workload memory. The new default compact checkpoint format reduces this effect
+for future 2-8 hour runs.
+
+## Audio lifecycle fix
+
+The merged regression test expected disabling noise reduction to release both
+the native denoiser and its owned frame buffer. The fixed-buffer optimization
+from #2354 instead only filled the buffer with zeroes, so the #2355 release
+contract failed.
+
+The minimal symmetric fix is:
+
+- disable: close RNNoise, clear the reference, release the frame buffer;
+- enable: initialize RNNoise and recreate the fixed 480-sample buffer before
+  processing;
+- preserve the existing AGC and pending-buffer reset semantics.
+
+A regression now enables from the released state and processes one synthetic
+480-sample frame, preventing a one-sided lifecycle fix.
+
+## Validation
+
+The focused merged-PR and diagnostic suite passes:
+
+```text
+377 passed, 5 pre-existing deprecation warnings in 7.44s
+```
+
+Coverage includes time-index batching, topic signals, audio memory and
+lifecycle, embedding lifecycle, browser lifecycle, agent shutdown, RapidOCR,
+vision, study OCR, and the soak analyzer.
+
+## Re-run
+
+From a Python 3.11 environment:
+
+```powershell
+uv run python -m scripts.runtime_memory_soak `
+  --output soak-2h.json `
+  --duration-hours 2 `
+  --cycle-pause 20 `
+  --embedding-root data/embedding_models
+```
+
+`--duration-hours` accepts values up to 8. Chat remains disabled unless an
+operator passes `--chat-port` for a separately started backend whose storage
+isolation has already been verified.

--- a/scripts/runtime_memory_baseline.py
+++ b/scripts/runtime_memory_baseline.py
@@ -31,6 +31,7 @@ import tracemalloc
 import urllib.parse
 import urllib.request
 import uuid
+import weakref
 from collections import Counter
 from contextlib import suppress
 from pathlib import Path
@@ -41,6 +42,7 @@ import psutil
 
 MIB = 1024 * 1024
 DEFAULT_SAMPLE_INTERVAL = 0.25
+_PROBED_EMBEDDING_SERVICES: weakref.WeakSet[Any] = weakref.WeakSet()
 
 
 def _mib(value: int | float | None) -> float | None:
@@ -94,8 +96,8 @@ def _process_row(process: psutil.Process) -> dict[str, Any] | None:
         except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
             handle_count = None
 
-        onnx_map_count = 0
-        onnx_mapped_rss = 0
+        onnx_map_count: int | None = 0
+        onnx_mapped_rss: int | None = 0
         try:
             for memory_map in process.memory_maps(grouped=True):
                 path = str(getattr(memory_map, "path", "") or "").lower()
@@ -109,7 +111,9 @@ def _process_row(process: psutil.Process) -> dict[str, Any] | None:
             OSError,
             NotImplementedError,
         ):
-            pass
+            # Preserve an unknown result when maps are unsupported or inaccessible.
+            onnx_map_count = None
+            onnx_mapped_rss = None
         return {
             "pid": process.pid,
             "ppid": process.ppid(),
@@ -166,7 +170,9 @@ def _sample(
                 "handles": 0,
                 "handle_processes": 0,
                 "onnx_map_count": 0,
+                "onnx_map_processes": 0,
                 "onnx_mapped_rss_mib": 0.0,
+                "onnx_mapped_rss_processes": 0,
             },
         )
         entry["count"] = int(entry["count"]) + 1
@@ -180,12 +186,18 @@ def _sample(
         if row["handles"] is not None:
             entry["handles"] = int(entry["handles"]) + int(row["handles"])
             entry["handle_processes"] = int(entry["handle_processes"]) + 1
-        entry["onnx_map_count"] = int(entry["onnx_map_count"]) + int(
-            row["onnx_map_count"] or 0
-        )
-        entry["onnx_mapped_rss_mib"] = float(entry["onnx_mapped_rss_mib"]) + float(
-            row["onnx_mapped_rss_mib"] or 0.0
-        )
+        if row["onnx_map_count"] is not None:
+            entry["onnx_map_count"] = int(entry["onnx_map_count"]) + int(
+                row["onnx_map_count"]
+            )
+            entry["onnx_map_processes"] = int(entry["onnx_map_processes"]) + 1
+        if row["onnx_mapped_rss_mib"] is not None:
+            entry["onnx_mapped_rss_mib"] = float(entry["onnx_mapped_rss_mib"]) + float(
+                row["onnx_mapped_rss_mib"]
+            )
+            entry["onnx_mapped_rss_processes"] = (
+                int(entry["onnx_mapped_rss_processes"]) + 1
+            )
     for entry in categories.values():
         if entry["uss_processes"] == 0:
             entry["uss_mib"] = None
@@ -193,6 +205,10 @@ def _sample(
             entry["threads"] = None
         if entry["handle_processes"] == 0:
             entry["handles"] = None
+        if entry["onnx_map_processes"] == 0:
+            entry["onnx_map_count"] = None
+        if entry["onnx_mapped_rss_processes"] == 0:
+            entry["onnx_mapped_rss_mib"] = None
 
     total_rss = sum(float(row["rss_mib"] or 0.0) for row in rows)
     total_uss_values = [
@@ -200,6 +216,14 @@ def _sample(
     ]
     total_threads = [int(row["threads"]) for row in rows if row["threads"] is not None]
     total_handles = [int(row["handles"]) for row in rows if row["handles"] is not None]
+    total_onnx_maps = [
+        int(row["onnx_map_count"]) for row in rows if row["onnx_map_count"] is not None
+    ]
+    total_onnx_rss = [
+        float(row["onnx_mapped_rss_mib"])
+        for row in rows
+        if row["onnx_mapped_rss_mib"] is not None
+    ]
     return {
         "elapsed_s": round(time.perf_counter(), 6),
         "categories": categories,
@@ -212,10 +236,12 @@ def _sample(
             "thread_processes": len(total_threads),
             "handles": sum(total_handles) if total_handles else None,
             "handle_processes": len(total_handles),
-            "onnx_map_count": sum(int(row["onnx_map_count"] or 0) for row in rows),
-            "onnx_mapped_rss_mib": round(
-                sum(float(row["onnx_mapped_rss_mib"] or 0.0) for row in rows), 3
-            ),
+            "onnx_map_count": sum(total_onnx_maps) if total_onnx_maps else None,
+            "onnx_map_processes": len(total_onnx_maps),
+            "onnx_mapped_rss_mib": round(sum(total_onnx_rss), 3)
+            if total_onnx_rss
+            else None,
+            "onnx_mapped_rss_processes": len(total_onnx_rss),
         },
         "processes": rows,
     }
@@ -245,20 +271,26 @@ def _series_summary(samples: list[dict[str, Any]]) -> dict[str, Any]:
             for sample in samples
         ]
         thread_values = [
-            int(sample["categories"].get(name, {}).get("threads") or 0)
+            int(value)
             for sample in samples
+            if (value := sample["categories"].get(name, {}).get("threads")) is not None
         ]
         handle_values = [
-            int(sample["categories"].get(name, {}).get("handles") or 0)
+            int(value)
             for sample in samples
+            if (value := sample["categories"].get(name, {}).get("handles")) is not None
         ]
         onnx_map_values = [
-            int(sample["categories"].get(name, {}).get("onnx_map_count") or 0)
+            int(value)
             for sample in samples
+            if (value := sample["categories"].get(name, {}).get("onnx_map_count"))
+            is not None
         ]
         onnx_rss_values = [
-            float(sample["categories"].get(name, {}).get("onnx_mapped_rss_mib") or 0.0)
+            float(value)
             for sample in samples
+            if (value := sample["categories"].get(name, {}).get("onnx_mapped_rss_mib"))
+            is not None
         ]
         categories[name] = {
             "median_count": int(statistics.median(count_values)),
@@ -269,14 +301,24 @@ def _series_summary(samples: list[dict[str, Any]]) -> dict[str, Any]:
             if uss_values
             else None,
             "peak_uss_mib": round(max(uss_values), 3) if uss_values else None,
-            "median_threads": round(statistics.median(thread_values), 3),
-            "max_threads": max(thread_values),
-            "median_handles": round(statistics.median(handle_values), 3),
-            "max_handles": max(handle_values),
-            "median_onnx_map_count": round(statistics.median(onnx_map_values), 3),
-            "max_onnx_map_count": max(onnx_map_values),
-            "median_onnx_mapped_rss_mib": round(statistics.median(onnx_rss_values), 3),
-            "peak_onnx_mapped_rss_mib": round(max(onnx_rss_values), 3),
+            "median_threads": round(statistics.median(thread_values), 3)
+            if thread_values
+            else None,
+            "max_threads": max(thread_values) if thread_values else None,
+            "median_handles": round(statistics.median(handle_values), 3)
+            if handle_values
+            else None,
+            "max_handles": max(handle_values) if handle_values else None,
+            "median_onnx_map_count": round(statistics.median(onnx_map_values), 3)
+            if onnx_map_values
+            else None,
+            "max_onnx_map_count": max(onnx_map_values) if onnx_map_values else None,
+            "median_onnx_mapped_rss_mib": round(statistics.median(onnx_rss_values), 3)
+            if onnx_rss_values
+            else None,
+            "peak_onnx_mapped_rss_mib": round(max(onnx_rss_values), 3)
+            if onnx_rss_values
+            else None,
         }
 
     total_rss = [float(sample["total"]["rss_mib"] or 0.0) for sample in samples]
@@ -285,13 +327,25 @@ def _series_summary(samples: list[dict[str, Any]]) -> dict[str, Any]:
         for sample in samples
         if sample["total"]["uss_mib"] is not None
     ]
-    total_threads = [int(sample["total"].get("threads") or 0) for sample in samples]
-    total_handles = [int(sample["total"].get("handles") or 0) for sample in samples]
+    total_threads = [
+        int(value)
+        for sample in samples
+        if (value := sample["total"].get("threads")) is not None
+    ]
+    total_handles = [
+        int(value)
+        for sample in samples
+        if (value := sample["total"].get("handles")) is not None
+    ]
     total_onnx_maps = [
-        int(sample["total"].get("onnx_map_count") or 0) for sample in samples
+        int(value)
+        for sample in samples
+        if (value := sample["total"].get("onnx_map_count")) is not None
     ]
     total_onnx_rss = [
-        float(sample["total"].get("onnx_mapped_rss_mib") or 0.0) for sample in samples
+        float(value)
+        for sample in samples
+        if (value := sample["total"].get("onnx_mapped_rss_mib")) is not None
     ]
     return {
         "sample_count": len(samples),
@@ -315,14 +369,14 @@ def _series_summary(samples: list[dict[str, Any]]) -> dict[str, Any]:
             "max_handles": max(total_handles) if total_handles else None,
             "median_onnx_map_count": round(statistics.median(total_onnx_maps), 3)
             if total_onnx_maps
-            else 0,
-            "max_onnx_map_count": max(total_onnx_maps) if total_onnx_maps else 0,
+            else None,
+            "max_onnx_map_count": max(total_onnx_maps) if total_onnx_maps else None,
             "median_onnx_mapped_rss_mib": round(statistics.median(total_onnx_rss), 3)
             if total_onnx_rss
-            else 0.0,
+            else None,
             "peak_onnx_mapped_rss_mib": round(max(total_onnx_rss), 3)
             if total_onnx_rss
-            else 0.0,
+            else None,
         },
         "last_processes": samples[-1]["processes"] if samples else [],
     }
@@ -367,6 +421,11 @@ def _sample_window(
     return result
 
 
+def _register_embedding_service(service: Any) -> None:
+    """Track direct probe services without extending their lifetime."""
+    _PROBED_EMBEDDING_SERVICES.add(service)
+
+
 def _runtime_resource_counts() -> dict[str, Any]:
     """Return reference counts for heavy runtimes without importing them.
 
@@ -382,17 +441,19 @@ def _runtime_resource_counts() -> dict[str, Any]:
         "rapidocr_cache_owners": 0,
     }
 
+    services = list(_PROBED_EMBEDDING_SERVICES)
     embeddings = sys.modules.get("memory.embeddings")
     if embeddings is not None:
         service = getattr(embeddings, "_SERVICE", None)
-        if service is not None:
-            result["embedding_service_instances"] = 1
-            result["embedding_session_refs"] = int(
-                getattr(service, "_session", None) is not None
-            )
-            result["embedding_tokenizer_refs"] = int(
-                getattr(service, "_tokenizer", None) is not None
-            )
+        if service is not None and all(service is not item for item in services):
+            services.append(service)
+    result["embedding_service_instances"] = len(services)
+    result["embedding_session_refs"] = sum(
+        int(getattr(service, "_session", None) is not None) for service in services
+    )
+    result["embedding_tokenizer_refs"] = sum(
+        int(getattr(service, "_tokenizer", None) is not None) for service in services
+    )
 
     seen_caches: set[int] = set()
     for module_name in (
@@ -421,15 +482,17 @@ def _in_process_checkpoint(
     seconds: float,
     interval: float,
     collect: bool = False,
+    root_pids: Iterable[int] | None = None,
 ) -> dict[str, Any]:
     if collect:
         gc.collect()
+    sample_root_pids = list(root_pids) if root_pids is not None else [os.getpid()]
     checkpoint = _sample_window(
         label,
-        [os.getpid()],
+        sample_root_pids,
         seconds=seconds,
         interval=interval,
-        traced_python_pid=os.getpid(),
+        traced_python_pid=os.getpid() if os.getpid() in sample_root_pids else None,
     )
     checkpoint["captured_perf_counter"] = round(time.perf_counter(), 6)
     checkpoint["resources"] = _runtime_resource_counts()
@@ -494,6 +557,7 @@ async def _embedding_scenario(args: argparse.Namespace) -> dict[str, Any]:
         min_ram_gb=VECTORS_MIN_RAM_GB,
         profile_id=VECTORS_MODEL_PROFILE_ID,
     )
+    _register_embedding_service(service)
     ready = await service.request_load()
     if not ready:
         raise RuntimeError(

--- a/scripts/runtime_memory_baseline.py
+++ b/scripts/runtime_memory_baseline.py
@@ -518,6 +518,7 @@ async def _embedding_scenario(args: argparse.Namespace) -> dict[str, Any]:
             interval=args.interval,
         )
     )
+    model_id = service.model_id()
     await service.close()
     vector_dimensions = len(vector)
     del vector, service
@@ -533,7 +534,7 @@ async def _embedding_scenario(args: argparse.Namespace) -> dict[str, Any]:
         "scenario": "embedding",
         "embedding": {
             "ready": ready,
-            "model_id": service.model_id(),
+            "model_id": model_id,
             "model_root": str(Path(args.embedding_root).resolve()),
             "vector_dimensions": vector_dimensions,
         },

--- a/scripts/runtime_memory_baseline.py
+++ b/scripts/runtime_memory_baseline.py
@@ -18,12 +18,14 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import gc
 import json
 import os
 import platform
 import socket
 import statistics
 import subprocess
+import sys
 import time
 import tracemalloc
 import urllib.parse
@@ -81,6 +83,33 @@ def _process_row(process: psutil.Process) -> dict[str, Any] | None:
             uss = getattr(full, "uss", None)
         except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
             uss = None
+        try:
+            thread_count = process.num_threads()
+        except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
+            thread_count = None
+        try:
+            handle_count = (
+                process.num_handles() if hasattr(process, "num_handles") else None
+            )
+        except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
+            handle_count = None
+
+        onnx_map_count = 0
+        onnx_mapped_rss = 0
+        try:
+            for memory_map in process.memory_maps(grouped=True):
+                path = str(getattr(memory_map, "path", "") or "").lower()
+                if "onnxruntime" not in path and not path.endswith(".onnx"):
+                    continue
+                onnx_map_count += 1
+                onnx_mapped_rss += int(getattr(memory_map, "rss", 0) or 0)
+        except (
+            psutil.AccessDenied,
+            psutil.NoSuchProcess,
+            OSError,
+            NotImplementedError,
+        ):
+            pass
         return {
             "pid": process.pid,
             "ppid": process.ppid(),
@@ -88,6 +117,10 @@ def _process_row(process: psutil.Process) -> dict[str, Any] | None:
             "category": _process_category(process),
             "rss_mib": _mib(basic.rss),
             "uss_mib": _mib(uss),
+            "threads": thread_count,
+            "handles": handle_count,
+            "onnx_map_count": onnx_map_count,
+            "onnx_mapped_rss_mib": _mib(onnx_mapped_rss),
         }
     except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
         return None
@@ -123,19 +156,50 @@ def _sample(
     for row in rows:
         entry = categories.setdefault(
             row["category"],
-            {"count": 0, "rss_mib": 0.0, "uss_mib": 0.0, "uss_processes": 0},
+            {
+                "count": 0,
+                "rss_mib": 0.0,
+                "uss_mib": 0.0,
+                "uss_processes": 0,
+                "threads": 0,
+                "thread_processes": 0,
+                "handles": 0,
+                "handle_processes": 0,
+                "onnx_map_count": 0,
+                "onnx_mapped_rss_mib": 0.0,
+            },
         )
         entry["count"] = int(entry["count"]) + 1
         entry["rss_mib"] = float(entry["rss_mib"]) + float(row["rss_mib"] or 0.0)
         if row["uss_mib"] is not None:
             entry["uss_mib"] = float(entry["uss_mib"]) + float(row["uss_mib"])
             entry["uss_processes"] = int(entry["uss_processes"]) + 1
+        if row["threads"] is not None:
+            entry["threads"] = int(entry["threads"]) + int(row["threads"])
+            entry["thread_processes"] = int(entry["thread_processes"]) + 1
+        if row["handles"] is not None:
+            entry["handles"] = int(entry["handles"]) + int(row["handles"])
+            entry["handle_processes"] = int(entry["handle_processes"]) + 1
+        entry["onnx_map_count"] = int(entry["onnx_map_count"]) + int(
+            row["onnx_map_count"] or 0
+        )
+        entry["onnx_mapped_rss_mib"] = float(entry["onnx_mapped_rss_mib"]) + float(
+            row["onnx_mapped_rss_mib"] or 0.0
+        )
     for entry in categories.values():
         if entry["uss_processes"] == 0:
             entry["uss_mib"] = None
+        if entry["thread_processes"] == 0:
+            entry["threads"] = None
+        if entry["handle_processes"] == 0:
+            entry["handles"] = None
 
     total_rss = sum(float(row["rss_mib"] or 0.0) for row in rows)
-    total_uss_values = [float(row["uss_mib"]) for row in rows if row["uss_mib"] is not None]
+    total_uss_values = [
+        float(row["uss_mib"]) for row in rows if row["uss_mib"] is not None
+    ]
+    total_threads = [int(row["threads"]) for row in rows if row["threads"] is not None]
+    total_handles = [int(row["handles"]) for row in rows if row["handles"] is not None]
     return {
         "elapsed_s": round(time.perf_counter(), 6),
         "categories": categories,
@@ -144,6 +208,14 @@ def _sample(
             "rss_mib": round(total_rss, 3),
             "uss_mib": round(sum(total_uss_values), 3) if total_uss_values else None,
             "uss_processes": len(total_uss_values),
+            "threads": sum(total_threads) if total_threads else None,
+            "thread_processes": len(total_threads),
+            "handles": sum(total_handles) if total_handles else None,
+            "handle_processes": len(total_handles),
+            "onnx_map_count": sum(int(row["onnx_map_count"] or 0) for row in rows),
+            "onnx_mapped_rss_mib": round(
+                sum(float(row["onnx_mapped_rss_mib"] or 0.0) for row in rows), 3
+            ),
         },
         "processes": rows,
     }
@@ -172,6 +244,22 @@ def _series_summary(samples: list[dict[str, Any]]) -> dict[str, Any]:
             int(sample["categories"].get(name, {}).get("count", 0))
             for sample in samples
         ]
+        thread_values = [
+            int(sample["categories"].get(name, {}).get("threads") or 0)
+            for sample in samples
+        ]
+        handle_values = [
+            int(sample["categories"].get(name, {}).get("handles") or 0)
+            for sample in samples
+        ]
+        onnx_map_values = [
+            int(sample["categories"].get(name, {}).get("onnx_map_count") or 0)
+            for sample in samples
+        ]
+        onnx_rss_values = [
+            float(sample["categories"].get(name, {}).get("onnx_mapped_rss_mib") or 0.0)
+            for sample in samples
+        ]
         categories[name] = {
             "median_count": int(statistics.median(count_values)),
             "max_count": max(count_values),
@@ -181,6 +269,14 @@ def _series_summary(samples: list[dict[str, Any]]) -> dict[str, Any]:
             if uss_values
             else None,
             "peak_uss_mib": round(max(uss_values), 3) if uss_values else None,
+            "median_threads": round(statistics.median(thread_values), 3),
+            "max_threads": max(thread_values),
+            "median_handles": round(statistics.median(handle_values), 3),
+            "max_handles": max(handle_values),
+            "median_onnx_map_count": round(statistics.median(onnx_map_values), 3),
+            "max_onnx_map_count": max(onnx_map_values),
+            "median_onnx_mapped_rss_mib": round(statistics.median(onnx_rss_values), 3),
+            "peak_onnx_mapped_rss_mib": round(max(onnx_rss_values), 3),
         }
 
     total_rss = [float(sample["total"]["rss_mib"] or 0.0) for sample in samples]
@@ -189,14 +285,44 @@ def _series_summary(samples: list[dict[str, Any]]) -> dict[str, Any]:
         for sample in samples
         if sample["total"]["uss_mib"] is not None
     ]
+    total_threads = [int(sample["total"].get("threads") or 0) for sample in samples]
+    total_handles = [int(sample["total"].get("handles") or 0) for sample in samples]
+    total_onnx_maps = [
+        int(sample["total"].get("onnx_map_count") or 0) for sample in samples
+    ]
+    total_onnx_rss = [
+        float(sample["total"].get("onnx_mapped_rss_mib") or 0.0) for sample in samples
+    ]
     return {
         "sample_count": len(samples),
         "categories": categories,
         "total": {
-            "median_rss_mib": round(statistics.median(total_rss), 3) if total_rss else 0.0,
+            "median_rss_mib": round(statistics.median(total_rss), 3)
+            if total_rss
+            else 0.0,
             "peak_rss_mib": round(max(total_rss), 3) if total_rss else 0.0,
-            "median_uss_mib": round(statistics.median(total_uss), 3) if total_uss else None,
+            "median_uss_mib": round(statistics.median(total_uss), 3)
+            if total_uss
+            else None,
             "peak_uss_mib": round(max(total_uss), 3) if total_uss else None,
+            "median_threads": round(statistics.median(total_threads), 3)
+            if total_threads
+            else None,
+            "max_threads": max(total_threads) if total_threads else None,
+            "median_handles": round(statistics.median(total_handles), 3)
+            if total_handles
+            else None,
+            "max_handles": max(total_handles) if total_handles else None,
+            "median_onnx_map_count": round(statistics.median(total_onnx_maps), 3)
+            if total_onnx_maps
+            else 0,
+            "max_onnx_map_count": max(total_onnx_maps) if total_onnx_maps else 0,
+            "median_onnx_mapped_rss_mib": round(statistics.median(total_onnx_rss), 3)
+            if total_onnx_rss
+            else 0.0,
+            "peak_onnx_mapped_rss_mib": round(max(total_onnx_rss), 3)
+            if total_onnx_rss
+            else 0.0,
         },
         "last_processes": samples[-1]["processes"] if samples else [],
     }
@@ -241,6 +367,76 @@ def _sample_window(
     return result
 
 
+def _runtime_resource_counts() -> dict[str, Any]:
+    """Return reference counts for heavy runtimes without importing them.
+
+    The process sampler reports mapped ONNX files and Chromium descendants.
+    These counters complement it with the owners that are visible in Python so
+    a released owner can be distinguished from a still-referenced model.
+    """
+    result: dict[str, Any] = {
+        "embedding_service_instances": 0,
+        "embedding_session_refs": 0,
+        "embedding_tokenizer_refs": 0,
+        "rapidocr_cache_entries": 0,
+        "rapidocr_cache_owners": 0,
+    }
+
+    embeddings = sys.modules.get("memory.embeddings")
+    if embeddings is not None:
+        service = getattr(embeddings, "_SERVICE", None)
+        if service is not None:
+            result["embedding_service_instances"] = 1
+            result["embedding_session_refs"] = int(
+                getattr(service, "_session", None) is not None
+            )
+            result["embedding_tokenizer_refs"] = int(
+                getattr(service, "_tokenizer", None) is not None
+            )
+
+    seen_caches: set[int] = set()
+    for module_name in (
+        "plugin.plugins._shared.rapidocr.ocr_runtime_types",
+        "plugin.plugins.galgame_plugin.ocr_runtime_types",
+    ):
+        runtime_types = sys.modules.get(module_name)
+        if runtime_types is None:
+            continue
+        cache = getattr(runtime_types, "_RAPIDOCR_RUNTIME_CACHE", None)
+        owners = getattr(runtime_types, "_RAPIDOCR_RUNTIME_CACHE_OWNERS", None)
+        if not isinstance(cache, dict) or id(cache) in seen_caches:
+            continue
+        seen_caches.add(id(cache))
+        result["rapidocr_cache_entries"] += len(cache)
+        if isinstance(owners, dict):
+            result["rapidocr_cache_owners"] += sum(
+                max(0, int(value or 0)) for value in owners.values()
+            )
+    return result
+
+
+def _in_process_checkpoint(
+    label: str,
+    *,
+    seconds: float,
+    interval: float,
+    collect: bool = False,
+) -> dict[str, Any]:
+    if collect:
+        gc.collect()
+    checkpoint = _sample_window(
+        label,
+        [os.getpid()],
+        seconds=seconds,
+        interval=interval,
+        traced_python_pid=os.getpid(),
+    )
+    checkpoint["captured_perf_counter"] = round(time.perf_counter(), 6)
+    checkpoint["resources"] = _runtime_resource_counts()
+    checkpoint["gc_counts"] = list(gc.get_count())
+    return checkpoint
+
+
 def _metadata() -> dict[str, Any]:
     try:
         commit = subprocess.check_output(
@@ -259,20 +455,19 @@ def _metadata() -> dict[str, Any]:
     }
 
 
-def _write_json(path: Path, payload: dict[str, Any]) -> None:
+def _write_json(path: Path, payload: dict[str, Any], *, announce: bool = True) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
-    print(path.resolve())
+    if announce:
+        print(path.resolve())
 
 
 async def _embedding_scenario(args: argparse.Namespace) -> dict[str, Any]:
     checkpoints = [
-        _sample_window(
+        _in_process_checkpoint(
             "python_baseline",
-            [os.getpid()],
             seconds=args.window,
             interval=args.interval,
-            traced_python_pid=os.getpid(),
         )
     ]
 
@@ -285,12 +480,10 @@ async def _embedding_scenario(args: argparse.Namespace) -> dict[str, Any]:
     from memory.embeddings import EmbeddingService
 
     checkpoints.append(
-        _sample_window(
+        _in_process_checkpoint(
             "embedding_imported",
-            [os.getpid()],
             seconds=args.window,
             interval=args.interval,
-            traced_python_pid=os.getpid(),
         )
     )
     service = EmbeddingService(
@@ -303,14 +496,14 @@ async def _embedding_scenario(args: argparse.Namespace) -> dict[str, Any]:
     )
     ready = await service.request_load()
     if not ready:
-        raise RuntimeError(f"embedding service did not become READY: {service.disable_reason()}")
+        raise RuntimeError(
+            f"embedding service did not become READY: {service.disable_reason()}"
+        )
     checkpoints.append(
-        _sample_window(
+        _in_process_checkpoint(
             "embedding_ready",
-            [os.getpid()],
             seconds=args.window,
             interval=args.interval,
-            traced_python_pid=os.getpid(),
         )
     )
     vector = await service.embed("N.E.K.O runtime memory baseline")
@@ -319,12 +512,21 @@ async def _embedding_scenario(args: argparse.Namespace) -> dict[str, Any]:
             f"embedding inference failed after READY: {service.disable_reason()}"
         )
     checkpoints.append(
-        _sample_window(
+        _in_process_checkpoint(
             "embedding_first_inference",
-            [os.getpid()],
             seconds=args.window,
             interval=args.interval,
-            traced_python_pid=os.getpid(),
+        )
+    )
+    await service.close()
+    vector_dimensions = len(vector)
+    del vector, service
+    checkpoints.append(
+        _in_process_checkpoint(
+            "embedding_released",
+            seconds=args.window,
+            interval=args.interval,
+            collect=True,
         )
     )
     return {
@@ -333,7 +535,7 @@ async def _embedding_scenario(args: argparse.Namespace) -> dict[str, Any]:
             "ready": ready,
             "model_id": service.model_id(),
             "model_root": str(Path(args.embedding_root).resolve()),
-            "vector_dimensions": len(vector),
+            "vector_dimensions": vector_dimensions,
         },
         "checkpoints": checkpoints,
     }
@@ -341,12 +543,10 @@ async def _embedding_scenario(args: argparse.Namespace) -> dict[str, Any]:
 
 async def _ocr_scenario(args: argparse.Namespace) -> dict[str, Any]:
     checkpoints = [
-        _sample_window(
+        _in_process_checkpoint(
             "python_baseline",
-            [os.getpid()],
             seconds=args.window,
             interval=args.interval,
-            traced_python_pid=os.getpid(),
         )
     ]
     from PIL import Image
@@ -367,53 +567,56 @@ async def _ocr_scenario(args: argparse.Namespace) -> dict[str, Any]:
     )
     available = backend.is_available()
     checkpoints.append(
-        _sample_window(
+        _in_process_checkpoint(
             "ocr_imported",
-            [os.getpid()],
             seconds=args.window,
             interval=args.interval,
-            traced_python_pid=os.getpid(),
         )
     )
     if not available:
         raise RuntimeError("RapidOCR backend is not available")
     text = backend.extract_text(Image.new("RGB", (640, 360), "white"))
     checkpoints.append(
-        _sample_window(
+        _in_process_checkpoint(
             "ocr_ready_after_first_inference",
-            [os.getpid()],
             seconds=args.window,
             interval=args.interval,
-            traced_python_pid=os.getpid(),
+        )
+    )
+    synthetic_text_length = len(text)
+    backend.close()
+    del text, backend
+    checkpoints.append(
+        _in_process_checkpoint(
+            "ocr_released",
+            seconds=args.window,
+            interval=args.interval,
+            collect=True,
         )
     )
     return {
         "scenario": "ocr",
-        "ocr": {"available": available, "synthetic_text_length": len(text)},
+        "ocr": {"available": available, "synthetic_text_length": synthetic_text_length},
         "checkpoints": checkpoints,
     }
 
 
 async def _browser_scenario(args: argparse.Namespace) -> dict[str, Any]:
     checkpoints = [
-        _sample_window(
+        _in_process_checkpoint(
             "python_baseline",
-            [os.getpid()],
             seconds=args.window,
             interval=args.interval,
-            traced_python_pid=os.getpid(),
         )
     ]
     from brain.browser_use_adapter import BrowserUseAdapter
 
     adapter = BrowserUseAdapter(headless=not args.headed)
     checkpoints.append(
-        _sample_window(
+        _in_process_checkpoint(
             "browser_use_imported",
-            [os.getpid()],
             seconds=args.window,
             interval=args.interval,
-            traced_python_pid=os.getpid(),
         )
     )
     session = await adapter._get_browser_session()
@@ -421,16 +624,23 @@ async def _browser_scenario(args: argparse.Namespace) -> dict[str, Any]:
         await session.start()
         adapter._session_ever_started = True
         checkpoints.append(
-            _sample_window(
+            _in_process_checkpoint(
                 "browser_use_playwright_started",
-                [os.getpid()],
                 seconds=args.window,
                 interval=args.interval,
-                traced_python_pid=os.getpid(),
             )
         )
     finally:
         await adapter.close()
+    del session, adapter
+    checkpoints.append(
+        _in_process_checkpoint(
+            "browser_use_released",
+            seconds=args.window,
+            interval=args.interval,
+            collect=True,
+        )
+    )
     return {
         "scenario": "browser_use",
         "browser": {"headless": not args.headed},
@@ -511,6 +721,7 @@ async def _run_synthetic_chat(
     import websockets
 
     if not character:
+
         def _read_current_character() -> dict[str, Any]:
             with urllib.request.urlopen(
                 f"http://127.0.0.1:{port}/api/characters/current_catgirl", timeout=5
@@ -668,7 +879,9 @@ def _stack(args: argparse.Namespace) -> dict[str, Any]:
     env = os.environ.copy()
     env.update(_parse_env(args.env))
     backend_command = _decode_command(args.backend_command)
-    electron_command = _decode_command(args.electron_command) if args.electron_command else None
+    electron_command = (
+        _decode_command(args.electron_command) if args.electron_command else None
+    )
     ports = _decode_ports(args.ports)
     _assert_ports_available(ports)
     processes: list[tuple[str, subprocess.Popen[Any], Any]] = []
@@ -694,7 +907,9 @@ def _stack(args: argparse.Namespace) -> dict[str, Any]:
                 _sample(roots, observed_processes=observed_processes)
             )
             if backend.poll() is not None:
-                raise RuntimeError(f"backend exited before ready with code {backend.returncode}")
+                raise RuntimeError(
+                    f"backend exited before ready with code {backend.returncode}"
+                )
             if time.monotonic() >= deadline:
                 raise TimeoutError(f"ports did not become ready: {ports}")
             time.sleep(args.interval)
@@ -722,7 +937,9 @@ def _stack(args: argparse.Namespace) -> dict[str, Any]:
             roots.append(electron.pid)
             time.sleep(args.electron_settle)
             if electron.poll() is not None:
-                raise RuntimeError(f"Electron exited early with code {electron.returncode}")
+                raise RuntimeError(
+                    f"Electron exited early with code {electron.returncode}"
+                )
             checkpoints.append(
                 _sample_window(
                     "electron_attached",
@@ -735,6 +952,7 @@ def _stack(args: argparse.Namespace) -> dict[str, Any]:
 
         chat_result = None
         if args.synthetic_chat:
+
             def _record_live_first_chat() -> None:
                 time.sleep(args.settle)
                 checkpoints.append(
@@ -767,7 +985,9 @@ def _stack(args: argparse.Namespace) -> dict[str, Any]:
             "synthetic_chat": chat_result,
             "logs": {
                 "backend": str(output.with_suffix(".backend.log")),
-                "electron": str(output.with_suffix(".electron.log")) if electron_command else None,
+                "electron": str(output.with_suffix(".electron.log"))
+                if electron_command
+                else None,
             },
         }
     finally:
@@ -786,19 +1006,25 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--window", type=float, default=3.0)
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    scenario = subparsers.add_parser("scenario", help="Run an in-process lazy feature scenario")
+    scenario = subparsers.add_parser(
+        "scenario", help="Run an in-process lazy feature scenario"
+    )
     scenario.add_argument("name", choices=("embedding", "ocr", "browser-use"))
     scenario.add_argument("--embedding-root", default="data/embedding_models")
     scenario.add_argument("--headed", action="store_true")
 
-    stack = subparsers.add_parser("stack", help="Measure a launcher/Electron process tree")
+    stack = subparsers.add_parser(
+        "stack", help="Measure a launcher/Electron process tree"
+    )
     stack.add_argument(
         "--backend-command",
         required=True,
         help="JSON array or a pipe-delimited command",
     )
     stack.add_argument("--backend-cwd", default=str(Path.cwd()))
-    stack.add_argument("--electron-command", help="JSON array or a pipe-delimited command")
+    stack.add_argument(
+        "--electron-command", help="JSON array or a pipe-delimited command"
+    )
     stack.add_argument("--electron-cwd", default=str(Path.cwd()))
     stack.add_argument("--ports", default="48911,48912,48915")
     stack.add_argument("--env", action="append", default=[], metavar="NAME=VALUE")

--- a/scripts/runtime_memory_soak.py
+++ b/scripts/runtime_memory_soak.py
@@ -14,7 +14,6 @@ import argparse
 import asyncio
 import contextlib
 import gc
-import os
 import statistics
 import time
 import tracemalloc
@@ -25,6 +24,7 @@ from scripts.runtime_memory_baseline import (
     MIB,
     _in_process_checkpoint,
     _metadata,
+    _register_embedding_service,
     _run_synthetic_chat,
     _write_json,
 )
@@ -51,12 +51,14 @@ def _checkpoint(
     label: str,
     *,
     collect: bool = False,
+    root_pids: list[int] | None = None,
 ) -> dict[str, Any]:
     checkpoint = _in_process_checkpoint(
         label,
         seconds=args.window,
         interval=args.interval,
         collect=collect,
+        root_pids=root_pids,
     )
     if not args.retain_process_rows:
         checkpoint.pop("last_processes", None)
@@ -93,6 +95,8 @@ async def _audio_cycle(args: argparse.Namespace, cycle: int) -> dict[str, Any]:
     native_denoiser = processor._denoiser is not None
     output_bytes = 0
     try:
+        if not native_denoiser:
+            raise FeatureUnavailable("native_denoiser_unavailable")
         for _ in range(2):
             output_bytes += len(processor.process_chunk(synthetic_pcm))
             processor.set_enabled(False)
@@ -133,6 +137,7 @@ async def _embedding_cycle(args: argparse.Namespace, cycle: int) -> dict[str, An
         min_ram_gb=VECTORS_MIN_RAM_GB,
         profile_id=VECTORS_MODEL_PROFILE_ID,
     )
+    _register_embedding_service(service)
     vector: list[float] | None = None
     try:
         if not await service.request_load():
@@ -236,6 +241,8 @@ async def _plugin_cycle(args: argparse.Namespace, cycle: int) -> dict[str, Any]:
         )
         result = await host.trigger("late_entry", {}, timeout=args.plugin_timeout)
         triggered = isinstance(result, dict) and result.get("ok") is True
+        if not triggered:
+            raise RuntimeError("synthetic_plugin_trigger_failed")
         active = _checkpoint(args, f"cycle_{cycle:04d}_plugin_reload_active")
     finally:
         with contextlib.suppress(Exception):
@@ -254,10 +261,18 @@ async def _plugin_cycle(args: argparse.Namespace, cycle: int) -> dict[str, Any]:
 async def _chat_cycle(args: argparse.Namespace, cycle: int) -> dict[str, Any]:
     if args.chat_port <= 0:
         raise FeatureUnavailable("verified_isolated_chat_endpoint_not_configured")
+    if args.chat_pid <= 0:
+        raise FeatureUnavailable("verified_isolated_chat_backend_pid_not_configured")
     checkpoints: list[dict[str, Any]] = []
 
     def _record_live_session() -> None:
-        checkpoints.append(_checkpoint(args, f"cycle_{cycle:04d}_chat_active"))
+        checkpoints.append(
+            _checkpoint(
+                args,
+                f"cycle_{cycle:04d}_chat_active",
+                root_pids=[args.chat_pid],
+            )
+        )
 
     result = await _run_synthetic_chat(
         port=args.chat_port,
@@ -266,8 +281,15 @@ async def _chat_cycle(args: argparse.Namespace, cycle: int) -> dict[str, Any]:
         timeout=args.chat_timeout,
         after_turn=_record_live_session,
     )
+    if args.cooldown:
+        await asyncio.sleep(args.cooldown)
     checkpoints.append(
-        await _released_checkpoint(args, f"cycle_{cycle:04d}_chat_released")
+        _checkpoint(
+            args,
+            f"cycle_{cycle:04d}_chat_released",
+            collect=True,
+            root_pids=[args.chat_pid],
+        )
     )
     return {
         "status": "completed",
@@ -593,6 +615,12 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--plugin-timeout", type=float, default=5.0)
     parser.add_argument("--chat-port", type=int, default=0)
+    parser.add_argument(
+        "--chat-pid",
+        type=int,
+        default=0,
+        help="PID of the verified isolated chat backend sampled with its descendants",
+    )
     parser.add_argument("--chat-character", default="")
     parser.add_argument("--chat-timeout", type=float, default=90.0)
     parser.add_argument(

--- a/scripts/runtime_memory_soak.py
+++ b/scripts/runtime_memory_soak.py
@@ -1,0 +1,630 @@
+#!/usr/bin/env python3
+"""Run repeatable 2-8 hour lifecycle soak probes for N.E.K.O.
+
+All workload inputs are deterministic synthetic data. The JSON contains only
+aggregate process/resource measurements, status codes, and exception types; it
+never records prompts, responses, command lines, environment variables, or API
+payloads. Chat is opt-in because it must target a separately started backend
+whose storage isolation has already been verified by the operator.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import gc
+import os
+import statistics
+import time
+import tracemalloc
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+
+from scripts.runtime_memory_baseline import (
+    MIB,
+    _in_process_checkpoint,
+    _metadata,
+    _run_synthetic_chat,
+    _write_json,
+)
+
+
+SYNTHETIC_EMBEDDING_TEXT = "Synthetic runtime lifecycle probe."
+SYNTHETIC_CHAT_PROMPT = "Reply with exactly OK. This is a synthetic soak probe."
+FEATURE_NAMES = (
+    "audio",
+    "embedding",
+    "ocr",
+    "browser-use",
+    "plugin-reload",
+    "chat",
+)
+
+
+class FeatureUnavailable(RuntimeError):
+    """A feature cannot run in the current environment."""
+
+
+def _checkpoint(
+    args: argparse.Namespace,
+    label: str,
+    *,
+    collect: bool = False,
+) -> dict[str, Any]:
+    checkpoint = _in_process_checkpoint(
+        label,
+        seconds=args.window,
+        interval=args.interval,
+        collect=collect,
+    )
+    if not args.retain_process_rows:
+        checkpoint.pop("last_processes", None)
+    return checkpoint
+
+
+async def _released_checkpoint(
+    args: argparse.Namespace,
+    label: str,
+) -> dict[str, Any]:
+    if args.cooldown:
+        await asyncio.sleep(args.cooldown)
+    return _checkpoint(args, label, collect=True)
+
+
+async def _audio_cycle(args: argparse.Namespace, cycle: int) -> dict[str, Any]:
+    import numpy as np
+
+    from utils.audio_processor import AudioProcessor
+
+    # Fixed PCM ramp: no microphone input or conversation audio is read.
+    synthetic_pcm = (
+        ((np.arange(480 * args.audio_chunks, dtype=np.int32) % 2048) - 1024)
+        .astype(np.int16)
+        .tobytes()
+    )
+    processor = AudioProcessor(
+        input_sample_rate=48_000,
+        output_sample_rate=16_000,
+        noise_reduce_enabled=True,
+        agc_enabled=True,
+        limiter_enabled=True,
+    )
+    native_denoiser = processor._denoiser is not None
+    output_bytes = 0
+    try:
+        for _ in range(2):
+            output_bytes += len(processor.process_chunk(synthetic_pcm))
+            processor.set_enabled(False)
+            processor.set_enabled(True)
+        active = _checkpoint(args, f"cycle_{cycle:04d}_audio_active")
+    finally:
+        processor.close()
+    del processor, synthetic_pcm
+    released = await _released_checkpoint(args, f"cycle_{cycle:04d}_audio_released")
+    return {
+        "status": "completed",
+        "details": {
+            "synthetic_input": True,
+            "native_denoiser": native_denoiser,
+            "output_bytes": output_bytes,
+        },
+        "checkpoints": [active, released],
+    }
+
+
+async def _embedding_cycle(args: argparse.Namespace, cycle: int) -> dict[str, Any]:
+    from config import (
+        VECTORS_EMBEDDING_DIM,
+        VECTORS_MIN_RAM_GB,
+        VECTORS_MODEL_PROFILE_ID,
+        VECTORS_QUANTIZATION,
+    )
+    from memory.embeddings import EmbeddingService
+
+    model_root = Path(args.embedding_root).resolve()
+    if not model_root.is_dir():
+        raise FeatureUnavailable("embedding_model_root_missing")
+    service = EmbeddingService(
+        model_dir=str(model_root),
+        enabled=True,
+        embedding_dim_setting=VECTORS_EMBEDDING_DIM,
+        quantization_setting=VECTORS_QUANTIZATION,
+        min_ram_gb=VECTORS_MIN_RAM_GB,
+        profile_id=VECTORS_MODEL_PROFILE_ID,
+    )
+    vector: list[float] | None = None
+    try:
+        if not await service.request_load():
+            reason = service.disable_reason() or "embedding_load_unavailable"
+            raise FeatureUnavailable(reason)
+        vector = await service.embed(SYNTHETIC_EMBEDDING_TEXT)
+        if vector is None:
+            raise RuntimeError("embedding_inference_returned_none")
+        active = _checkpoint(args, f"cycle_{cycle:04d}_embedding_active")
+    finally:
+        await service.close()
+    dimensions = len(vector) if vector is not None else 0
+    del vector, service
+    released = await _released_checkpoint(args, f"cycle_{cycle:04d}_embedding_released")
+    return {
+        "status": "completed",
+        "details": {"synthetic_input": True, "vector_dimensions": dimensions},
+        "checkpoints": [active, released],
+    }
+
+
+async def _ocr_cycle(args: argparse.Namespace, cycle: int) -> dict[str, Any]:
+    from PIL import Image
+    from plugin.plugins._shared.rapidocr.rapidocr_support import (
+        DEFAULT_RAPIDOCR_ENGINE_TYPE,
+        DEFAULT_RAPIDOCR_LANG_TYPE,
+        DEFAULT_RAPIDOCR_MODEL_TYPE,
+        DEFAULT_RAPIDOCR_OCR_VERSION,
+    )
+    from plugin.plugins.galgame_plugin.ocr_rapidocr_backend import RapidOcrBackend
+
+    backend = RapidOcrBackend(
+        install_target_dir_raw="",
+        engine_type=DEFAULT_RAPIDOCR_ENGINE_TYPE,
+        lang_type=DEFAULT_RAPIDOCR_LANG_TYPE,
+        model_type=DEFAULT_RAPIDOCR_MODEL_TYPE,
+        ocr_version=DEFAULT_RAPIDOCR_OCR_VERSION,
+    )
+    text = ""
+    try:
+        if not backend.is_available():
+            raise FeatureUnavailable("rapidocr_unavailable")
+        text = backend.extract_text(Image.new("RGB", (640, 360), "white"))
+        active = _checkpoint(args, f"cycle_{cycle:04d}_ocr_active")
+    finally:
+        backend.close()
+    synthetic_text_length = len(text)
+    del text, backend
+    released = await _released_checkpoint(args, f"cycle_{cycle:04d}_ocr_released")
+    return {
+        "status": "completed",
+        "details": {
+            "synthetic_input": True,
+            "synthetic_text_length": synthetic_text_length,
+        },
+        "checkpoints": [active, released],
+    }
+
+
+async def _browser_cycle(args: argparse.Namespace, cycle: int) -> dict[str, Any]:
+    from brain.browser_use_adapter import BrowserUseAdapter
+
+    adapter = BrowserUseAdapter(headless=not args.headed)
+    if not adapter._ready_import:
+        raise FeatureUnavailable("browser_use_import_unavailable")
+    session = await adapter._get_browser_session()
+    try:
+        await session.start()
+        adapter._session_ever_started = True
+        active = _checkpoint(args, f"cycle_{cycle:04d}_browser_use_active")
+    finally:
+        await adapter.close()
+    del session, adapter
+    released = await _released_checkpoint(
+        args, f"cycle_{cycle:04d}_browser_use_released"
+    )
+    return {
+        "status": "completed",
+        "details": {"headless": not args.headed},
+        "checkpoints": [active, released],
+    }
+
+
+async def _plugin_cycle(args: argparse.Namespace, cycle: int) -> dict[str, Any]:
+    from plugin.core.host import PluginProcessHost
+
+    config_path = Path(args.plugin_config).resolve()
+    if not config_path.is_file():
+        raise FeatureUnavailable("synthetic_plugin_config_missing")
+    host = PluginProcessHost(
+        plugin_id="runtime_memory_soak_fixture",
+        entry_point=args.plugin_entry,
+        config_path=config_path,
+    )
+    triggered = False
+    try:
+        await host.start(
+            message_target_queue=asyncio.Queue(),
+            startup_timeout=args.plugin_timeout,
+            startup_failure="fail",
+        )
+        result = await host.trigger("late_entry", {}, timeout=args.plugin_timeout)
+        triggered = isinstance(result, dict) and result.get("ok") is True
+        active = _checkpoint(args, f"cycle_{cycle:04d}_plugin_reload_active")
+    finally:
+        with contextlib.suppress(Exception):
+            await host.shutdown(timeout=args.plugin_timeout)
+    del host
+    released = await _released_checkpoint(
+        args, f"cycle_{cycle:04d}_plugin_reload_released"
+    )
+    return {
+        "status": "completed",
+        "details": {"synthetic_plugin": True, "triggered": triggered},
+        "checkpoints": [active, released],
+    }
+
+
+async def _chat_cycle(args: argparse.Namespace, cycle: int) -> dict[str, Any]:
+    if args.chat_port <= 0:
+        raise FeatureUnavailable("verified_isolated_chat_endpoint_not_configured")
+    checkpoints: list[dict[str, Any]] = []
+
+    def _record_live_session() -> None:
+        checkpoints.append(_checkpoint(args, f"cycle_{cycle:04d}_chat_active"))
+
+    result = await _run_synthetic_chat(
+        port=args.chat_port,
+        character=args.chat_character,
+        prompt=SYNTHETIC_CHAT_PROMPT,
+        timeout=args.chat_timeout,
+        after_turn=_record_live_session,
+    )
+    checkpoints.append(
+        await _released_checkpoint(args, f"cycle_{cycle:04d}_chat_released")
+    )
+    return {
+        "status": "completed",
+        "details": result,
+        "checkpoints": checkpoints,
+    }
+
+
+FEATURE_RUNNERS: dict[
+    str, Callable[[argparse.Namespace, int], Awaitable[dict[str, Any]]]
+] = {
+    "audio": _audio_cycle,
+    "embedding": _embedding_cycle,
+    "ocr": _ocr_cycle,
+    "browser-use": _browser_cycle,
+    "plugin-reload": _plugin_cycle,
+    "chat": _chat_cycle,
+}
+
+
+def _parse_features(raw: str) -> list[str]:
+    features: list[str] = []
+    for item in raw.split(","):
+        name = item.strip().lower()
+        if not name:
+            continue
+        if name not in FEATURE_RUNNERS:
+            raise argparse.ArgumentTypeError(
+                f"unknown feature {name!r}; choose from {', '.join(FEATURE_NAMES)}"
+            )
+        if name not in features:
+            features.append(name)
+    if not features:
+        raise argparse.ArgumentTypeError("at least one feature is required")
+    return features
+
+
+def _slope_per_hour(points: list[tuple[float, float]]) -> float | None:
+    if len(points) < 2:
+        return None
+    xs = [point[0] for point in points]
+    ys = [point[1] for point in points]
+    x_mean = statistics.fmean(xs)
+    y_mean = statistics.fmean(ys)
+    denominator = sum((value - x_mean) ** 2 for value in xs)
+    if denominator <= 0:
+        return None
+    slope_per_second = (
+        sum((x - x_mean) * (y - y_mean) for x, y in zip(xs, ys)) / denominator
+    )
+    return round(slope_per_second * 3600.0, 3)
+
+
+def _series(points: list[tuple[float, float]]) -> dict[str, Any]:
+    if not points:
+        return {"samples": 0}
+    values = [value for _elapsed, value in points]
+    return {
+        "samples": len(values),
+        "first": round(values[0], 3),
+        "last": round(values[-1], 3),
+        "delta": round(values[-1] - values[0], 3),
+        "min": round(min(values), 3),
+        "max": round(max(values), 3),
+        "slope_per_hour": _slope_per_hour(points),
+    }
+
+
+def _released_checkpoints(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    released: list[dict[str, Any]] = []
+    for cycle in payload.get("cycles", []):
+        cycle_checkpoint = cycle.get("released_checkpoint")
+        if isinstance(cycle_checkpoint, dict):
+            released.append(cycle_checkpoint)
+    return released
+
+
+def _feature_released_checkpoints(
+    payload: dict[str, Any], feature: str
+) -> list[dict[str, Any]]:
+    released: list[dict[str, Any]] = []
+    for cycle in payload.get("cycles", []):
+        result = cycle.get("features", {}).get(feature, {})
+        for checkpoint in result.get("checkpoints", []):
+            if str(checkpoint.get("label", "")).endswith("_released"):
+                released.append(checkpoint)
+    return released
+
+
+def _checkpoint_series(
+    checkpoints: list[dict[str, Any]], start_perf: float
+) -> tuple[dict[str, dict[str, Any]], dict[str, Any]]:
+    metrics: dict[str, list[tuple[float, float]]] = {
+        "rss_mib": [],
+        "uss_mib": [],
+        "threads": [],
+        "handles": [],
+        "onnx_map_count": [],
+        "onnx_mapped_rss_mib": [],
+        "traced_current_mib": [],
+        "traced_peak_mib": [],
+        "chromium_processes": [],
+    }
+    latest_resources: dict[str, Any] = {}
+    for checkpoint in checkpoints:
+        elapsed = float(checkpoint.get("captured_perf_counter", 0.0)) - start_perf
+        total = checkpoint.get("total", {})
+        traced = checkpoint.get("tracemalloc", {})
+        chromium = checkpoint.get("categories", {}).get("chromium", {})
+        values = {
+            "rss_mib": total.get("median_rss_mib"),
+            "uss_mib": total.get("median_uss_mib"),
+            "threads": total.get("median_threads"),
+            "handles": total.get("median_handles"),
+            "onnx_map_count": total.get("median_onnx_map_count"),
+            "onnx_mapped_rss_mib": total.get("median_onnx_mapped_rss_mib"),
+            "traced_current_mib": traced.get("current_mib"),
+            "traced_peak_mib": traced.get("peak_mib"),
+            "chromium_processes": chromium.get("median_count", 0),
+        }
+        for name, value in values.items():
+            if value is not None:
+                metrics[name].append((elapsed, float(value)))
+        latest_resources = checkpoint.get("resources", latest_resources)
+    return {name: _series(points) for name, points in metrics.items()}, latest_resources
+
+
+def _trend_analysis(payload: dict[str, Any]) -> dict[str, Any]:
+    start_perf = float(payload.get("started_perf_counter", 0.0))
+    series, latest_resources = _checkpoint_series(
+        _released_checkpoints(payload), start_perf
+    )
+    feature_series = {
+        feature: _checkpoint_series(
+            _feature_released_checkpoints(payload, feature), start_perf
+        )[0]
+        for feature in payload.get("contract", {}).get("features", [])
+    }
+    signals: list[str] = []
+    uss = series["uss_mib"]
+    traced = series["traced_current_mib"]
+    handles = series["handles"]
+    threads = series["threads"]
+    chromium = series["chromium_processes"]
+    onnx_maps = series["onnx_map_count"]
+    if chromium.get("last", 0) > 0:
+        signals.append("chromium_children_remain_after_release")
+    if latest_resources.get("rapidocr_cache_owners", 0) > 0:
+        signals.append("rapidocr_owner_remains_after_release")
+    if latest_resources.get("embedding_session_refs", 0) > 0:
+        signals.append("embedding_session_reference_remains_after_release")
+    if int(uss.get("samples", 0)) >= 5:
+        uss_slope = float(uss.get("slope_per_hour") or 0.0)
+        traced_slope = float(traced.get("slope_per_hour") or 0.0)
+        if uss_slope >= 16.0 and traced_slope >= 8.0:
+            signals.append("sustained_python_and_process_growth_review_required")
+        elif uss_slope >= 16.0 and abs(traced_slope) < 8.0:
+            signals.append("native_or_allocator_retention_review_required")
+    if float(handles.get("delta") or 0.0) >= 32:
+        signals.append("handle_growth_review_required")
+    if float(threads.get("delta") or 0.0) >= 4:
+        signals.append("thread_growth_review_required")
+    if onnx_maps.get("last", 0) > 0 and not any(
+        latest_resources.get(name, 0)
+        for name in ("embedding_session_refs", "rapidocr_cache_owners")
+    ):
+        signals.append("onnx_dll_or_model_mapping_residency_without_python_owner")
+    return {
+        "released_series": series,
+        "feature_released_series": feature_series,
+        "latest_resource_counts": latest_resources,
+        "heuristic_signals": signals,
+        "interpretation": (
+            "Signals are triage hints only. Confirm a leak from sustained USS/resource "
+            "growth across many released cycles; RSS-only growth can be allocator or mapping residency."
+        ),
+    }
+
+
+def _allocation_growth(
+    before: tracemalloc.Snapshot,
+    after: tracemalloc.Snapshot,
+    *,
+    limit: int = 20,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    root = Path.cwd().resolve()
+    for stat in after.compare_to(before, "lineno")[:limit]:
+        frame = stat.traceback[0]
+        path = Path(frame.filename)
+        try:
+            display_path = str(path.resolve().relative_to(root))
+        except (OSError, ValueError):
+            display_path = path.name
+        rows.append(
+            {
+                "file": display_path,
+                "line": frame.lineno,
+                "size_diff_mib": round(stat.size_diff / MIB, 6),
+                "count_diff": stat.count_diff,
+            }
+        )
+    return rows
+
+
+def _persist(output: Path, payload: dict[str, Any]) -> None:
+    temporary = output.with_suffix(output.suffix + ".tmp")
+    _write_json(temporary, payload, announce=False)
+    temporary.replace(output)
+
+
+async def _run_soak(args: argparse.Namespace) -> dict[str, Any]:
+    output = Path(args.output).resolve()
+    started_perf = time.perf_counter()
+    deadline = started_perf + args.duration_hours * 3600.0
+    payload: dict[str, Any] = {
+        "metadata": _metadata(),
+        "scenario": "soak",
+        "started_perf_counter": started_perf,
+        "contract": {
+            "duration_hours": args.duration_hours,
+            "max_cycles": args.cycles,
+            "features": args.features,
+            "synthetic_inputs_only": True,
+            "chat_requires_verified_isolated_endpoint": True,
+            "raw_payloads_recorded": False,
+        },
+        "cycles": [],
+        "disabled_features": {},
+        "completed_cycles": 0,
+    }
+    disabled: dict[str, str] = {}
+    before = tracemalloc.take_snapshot()
+    cycle = 0
+    try:
+        while time.perf_counter() < deadline and (
+            args.cycles <= 0 or cycle < args.cycles
+        ):
+            cycle += 1
+            cycle_result: dict[str, Any] = {
+                "cycle": cycle,
+                "started_elapsed_s": round(time.perf_counter() - started_perf, 3),
+                "features": {},
+            }
+            for feature in args.features:
+                if feature in disabled:
+                    cycle_result["features"][feature] = {
+                        "status": "skipped",
+                        "reason": disabled[feature],
+                        "checkpoints": [],
+                    }
+                    continue
+                runner = FEATURE_RUNNERS[feature]
+                try:
+                    cycle_result["features"][feature] = await runner(args, cycle)
+                except FeatureUnavailable as exc:
+                    reason = str(exc)[:160] or "feature_unavailable"
+                    disabled[feature] = reason
+                    cycle_result["features"][feature] = {
+                        "status": "skipped",
+                        "reason": reason,
+                        "checkpoints": [],
+                    }
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:  # noqa: BLE001 - preserve soak after one feature failure
+                    cycle_result["features"][feature] = {
+                        "status": "error",
+                        "error_type": type(exc).__name__,
+                        "checkpoints": [],
+                    }
+            cycle_result["released_checkpoint"] = await _released_checkpoint(
+                args, f"cycle_{cycle:04d}_all_released"
+            )
+            cycle_result["elapsed_s"] = round(time.perf_counter() - started_perf, 3)
+            payload["cycles"].append(cycle_result)
+            payload["completed_cycles"] = cycle
+            payload["disabled_features"] = dict(disabled)
+            payload["analysis"] = _trend_analysis(payload)
+            _persist(output, payload)
+            summary = cycle_result["released_checkpoint"]["total"]
+            print(
+                f"cycle={cycle} elapsed_s={cycle_result['elapsed_s']} "
+                f"rss_mib={summary.get('median_rss_mib')} "
+                f"uss_mib={summary.get('median_uss_mib')}",
+                flush=True,
+            )
+            if args.cycle_pause and time.perf_counter() < deadline:
+                await asyncio.sleep(args.cycle_pause)
+    finally:
+        gc.collect()
+        after = tracemalloc.take_snapshot()
+        payload["completed_elapsed_s"] = round(time.perf_counter() - started_perf, 3)
+        payload["disabled_features"] = dict(disabled)
+        payload["analysis"] = _trend_analysis(payload)
+        payload["tracemalloc_top_growth"] = _allocation_growth(before, after)
+        _persist(output, payload)
+    return payload
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", required=True, help="Aggregate JSON output path")
+    parser.add_argument("--duration-hours", type=float, default=2.0)
+    parser.add_argument(
+        "--cycles", type=int, default=0, help="Optional cycle cap; 0 is unlimited"
+    )
+    parser.add_argument("--features", type=_parse_features, default=list(FEATURE_NAMES))
+    parser.add_argument("--interval", type=float, default=0.5)
+    parser.add_argument("--window", type=float, default=0.5)
+    parser.add_argument("--cooldown", type=float, default=1.0)
+    parser.add_argument("--cycle-pause", type=float, default=0.0)
+    parser.add_argument("--embedding-root", default="data/embedding_models")
+    parser.add_argument("--audio-chunks", type=int, default=20)
+    parser.add_argument("--headed", action="store_true")
+    parser.add_argument(
+        "--plugin-config",
+        default="plugin/tests/fixtures/neko_plugin_cli/plugins/simple_plugin/plugin.toml",
+    )
+    parser.add_argument(
+        "--plugin-entry",
+        default="tests.fixtures.plugin_test_dynamic_entry_fixture:DynamicEntryFixturePlugin",
+    )
+    parser.add_argument("--plugin-timeout", type=float, default=5.0)
+    parser.add_argument("--chat-port", type=int, default=0)
+    parser.add_argument("--chat-character", default="")
+    parser.add_argument("--chat-timeout", type=float, default=90.0)
+    parser.add_argument(
+        "--retain-process-rows",
+        action="store_true",
+        help="Keep per-PID rows at every checkpoint (larger and self-retaining)",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    if args.duration_hours <= 0 or args.duration_hours > 8:
+        raise SystemExit("--duration-hours must be greater than 0 and no more than 8")
+    if args.cycles < 0:
+        raise SystemExit("--cycles cannot be negative")
+    if (
+        args.interval <= 0
+        or args.window < 0
+        or args.cooldown < 0
+        or args.cycle_pause < 0
+    ):
+        raise SystemExit(
+            "interval must be positive; window/cooldown/pause cannot be negative"
+        )
+    if args.audio_chunks < 1 or args.plugin_timeout <= 0:
+        raise SystemExit("--audio-chunks and --plugin-timeout must be positive")
+    tracemalloc.start(10)
+    asyncio.run(_run_soak(args))
+    print(Path(args.output).resolve())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_audio_processor_lifecycle.py
+++ b/tests/unit/test_audio_processor_lifecycle.py
@@ -86,6 +86,35 @@ def test_disabling_noise_reduction_releases_native_denoiser() -> None:
     assert processor._frame_buffer.size == 0
 
 
+def test_reenabling_noise_reduction_recreates_frame_buffer(monkeypatch) -> None:
+    class _Denoiser:
+        def process_frame(self, frame: np.ndarray) -> tuple[np.ndarray, float]:
+            return frame.copy(), 0.0
+
+        def close(self) -> None:
+            return None
+
+    processor = AudioProcessor(
+        input_sample_rate=48_000,
+        output_sample_rate=48_000,
+        noise_reduce_enabled=False,
+        agc_enabled=False,
+        limiter_enabled=False,
+    )
+    monkeypatch.setattr(
+        processor,
+        "_init_denoiser",
+        lambda: setattr(processor, "_denoiser", _Denoiser()),
+    )
+
+    processor.set_enabled(True)
+    output = processor.process_chunk(np.zeros(480, dtype=np.int16).tobytes())
+
+    assert processor._frame_buffer.size == processor.RNNOISE_FRAME_SIZE
+    assert len(output) == 480 * np.dtype(np.int16).itemsize
+    processor.close()
+
+
 @pytest.mark.asyncio
 async def test_audio_close_waits_for_executor_chunk_processing() -> None:
     processing_started = threading.Event()

--- a/tests/unit/test_runtime_memory_soak.py
+++ b/tests/unit/test_runtime_memory_soak.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
 import os
+import sys
+from types import ModuleType, SimpleNamespace
 
 import psutil
 import pytest
 
-from scripts.runtime_memory_baseline import _process_row, _series_summary
+from scripts import runtime_memory_baseline
+from scripts.runtime_memory_baseline import (
+    _embedding_scenario,
+    _process_row,
+    _series_summary,
+)
 from scripts.runtime_memory_soak import (
     _parse_features,
     _slope_per_hour,
@@ -79,6 +86,56 @@ def test_series_summary_aggregates_resource_high_water_marks() -> None:
     assert summary["total"]["max_onnx_map_count"] == 3
     assert summary["total"]["peak_onnx_mapped_rss_mib"] == 13.0
     assert summary["categories"]["python"]["max_threads"] == 5
+
+
+@pytest.mark.asyncio
+async def test_embedding_scenario_captures_model_id_before_close(monkeypatch) -> None:
+    instances = []
+
+    class _EmbeddingService:
+        def __init__(self, **_kwargs) -> None:
+            self.closed = False
+            instances.append(self)
+
+        async def request_load(self) -> bool:
+            return True
+
+        async def embed(self, _text: str) -> list[float]:
+            return [0.1, 0.2, 0.3]
+
+        def model_id(self) -> str:
+            if self.closed:
+                raise RuntimeError("model_id accessed after close")
+            return "synthetic-3d"
+
+        def disable_reason(self) -> str:
+            return ""
+
+        async def close(self) -> None:
+            self.closed = True
+
+    embeddings = ModuleType("memory.embeddings")
+    embeddings.EmbeddingService = _EmbeddingService
+    monkeypatch.setitem(sys.modules, "memory.embeddings", embeddings)
+    monkeypatch.setattr(
+        runtime_memory_baseline,
+        "_in_process_checkpoint",
+        lambda label, **_kwargs: {"label": label},
+    )
+
+    result = await _embedding_scenario(
+        SimpleNamespace(embedding_root="synthetic-model-root", window=0, interval=0)
+    )
+
+    assert result["embedding"] == {
+        "ready": True,
+        "model_id": "synthetic-3d",
+        "model_root": str(
+            runtime_memory_baseline.Path("synthetic-model-root").resolve()
+        ),
+        "vector_dimensions": 3,
+    }
+    assert instances[0].closed is True
 
 
 def test_parse_features_deduplicates_and_rejects_unknown_names() -> None:

--- a/tests/unit/test_runtime_memory_soak.py
+++ b/tests/unit/test_runtime_memory_soak.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import argparse
+import gc
 import os
 import sys
 from types import ModuleType, SimpleNamespace
@@ -11,10 +13,16 @@ from scripts import runtime_memory_baseline
 from scripts.runtime_memory_baseline import (
     _embedding_scenario,
     _process_row,
+    _register_embedding_service,
+    _runtime_resource_counts,
     _series_summary,
 )
 from scripts.runtime_memory_soak import (
+    FeatureUnavailable,
+    _audio_cycle,
+    _chat_cycle,
     _parse_features,
+    _plugin_cycle,
     _slope_per_hour,
     _trend_analysis,
 )
@@ -27,8 +35,10 @@ def test_process_row_records_threads_handles_and_onnx_maps() -> None:
     assert row["threads"] is not None
     assert row["threads"] >= 1
     assert "handles" in row
-    assert row["onnx_map_count"] >= 0
-    assert row["onnx_mapped_rss_mib"] >= 0
+    if row["onnx_map_count"] is not None:
+        assert row["onnx_map_count"] >= 0
+    if row["onnx_mapped_rss_mib"] is not None:
+        assert row["onnx_mapped_rss_mib"] >= 0
 
 
 def test_series_summary_aggregates_resource_high_water_marks() -> None:
@@ -52,6 +62,28 @@ def test_series_summary_aggregates_resource_high_water_marks() -> None:
                 "handles": 20,
                 "onnx_map_count": 2,
                 "onnx_mapped_rss_mib": 12.0,
+            },
+            "processes": [],
+        },
+        {
+            "categories": {
+                "python": {
+                    "count": 1,
+                    "rss_mib": 105.0,
+                    "uss_mib": 82.0,
+                    "threads": None,
+                    "handles": None,
+                    "onnx_map_count": None,
+                    "onnx_mapped_rss_mib": None,
+                }
+            },
+            "total": {
+                "rss_mib": 105.0,
+                "uss_mib": 82.0,
+                "threads": None,
+                "handles": None,
+                "onnx_map_count": None,
+                "onnx_mapped_rss_mib": None,
             },
             "processes": [],
         },
@@ -84,6 +116,7 @@ def test_series_summary_aggregates_resource_high_water_marks() -> None:
     assert summary["total"]["max_threads"] == 5
     assert summary["total"]["max_handles"] == 24
     assert summary["total"]["max_onnx_map_count"] == 3
+    assert summary["total"]["median_onnx_map_count"] == 2.5
     assert summary["total"]["peak_onnx_mapped_rss_mib"] == 13.0
     assert summary["categories"]["python"]["max_threads"] == 5
 
@@ -138,9 +171,103 @@ async def test_embedding_scenario_captures_model_id_before_close(monkeypatch) ->
     assert instances[0].closed is True
 
 
+def test_runtime_resource_counts_tracks_direct_embedding_services() -> None:
+    class _Service:
+        _session = object()
+        _tokenizer = object()
+
+    gc.collect()
+    baseline = _runtime_resource_counts()
+    service = _Service()
+    _register_embedding_service(service)
+
+    active = _runtime_resource_counts()
+    assert active["embedding_service_instances"] == (
+        baseline["embedding_service_instances"] + 1
+    )
+    assert active["embedding_session_refs"] == baseline["embedding_session_refs"] + 1
+    assert active["embedding_tokenizer_refs"] == (
+        baseline["embedding_tokenizer_refs"] + 1
+    )
+
+    del service
+    gc.collect()
+    assert _runtime_resource_counts() == baseline
+
+
+@pytest.mark.asyncio
+async def test_audio_cycle_skips_when_native_denoiser_is_unavailable(
+    monkeypatch,
+) -> None:
+    instances = []
+
+    class _AudioProcessor:
+        def __init__(self, **_kwargs) -> None:
+            self._denoiser = None
+            self.closed = False
+            instances.append(self)
+
+        def close(self) -> None:
+            self.closed = True
+
+    audio_processor = ModuleType("utils.audio_processor")
+    audio_processor.AudioProcessor = _AudioProcessor
+    monkeypatch.setitem(sys.modules, "utils.audio_processor", audio_processor)
+
+    with pytest.raises(FeatureUnavailable, match="native_denoiser_unavailable"):
+        await _audio_cycle(SimpleNamespace(audio_chunks=1), 1)
+
+    assert instances[0].closed is True
+
+
+@pytest.mark.asyncio
+async def test_plugin_cycle_rejects_unsuccessful_trigger(monkeypatch, tmp_path) -> None:
+    instances = []
+
+    class _PluginProcessHost:
+        def __init__(self, **_kwargs) -> None:
+            self.shutdown_called = False
+            instances.append(self)
+
+        async def start(self, **_kwargs) -> None:
+            return None
+
+        async def trigger(self, *_args, **_kwargs) -> dict[str, bool]:
+            return {"ok": False}
+
+        async def shutdown(self, **_kwargs) -> None:
+            self.shutdown_called = True
+
+    host_module = ModuleType("plugin.core.host")
+    host_module.PluginProcessHost = _PluginProcessHost
+    monkeypatch.setitem(sys.modules, "plugin.core.host", host_module)
+    config_path = tmp_path / "plugin.toml"
+    config_path.write_text("[plugin]\nname='synthetic'\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="synthetic_plugin_trigger_failed"):
+        await _plugin_cycle(
+            SimpleNamespace(
+                plugin_config=str(config_path),
+                plugin_entry="synthetic:Plugin",
+                plugin_timeout=1.0,
+            ),
+            1,
+        )
+
+    assert instances[0].shutdown_called is True
+
+
+@pytest.mark.asyncio
+async def test_chat_cycle_requires_backend_pid_for_resource_sampling() -> None:
+    with pytest.raises(
+        FeatureUnavailable, match="verified_isolated_chat_backend_pid_not_configured"
+    ):
+        await _chat_cycle(SimpleNamespace(chat_port=48911, chat_pid=0), 1)
+
+
 def test_parse_features_deduplicates_and_rejects_unknown_names() -> None:
     assert _parse_features("audio,ocr,audio") == ["audio", "ocr"]
-    with pytest.raises(Exception, match="unknown feature"):
+    with pytest.raises(argparse.ArgumentTypeError, match="unknown feature"):
         _parse_features("audio,private-input")
 
 

--- a/tests/unit/test_runtime_memory_soak.py
+++ b/tests/unit/test_runtime_memory_soak.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import os
+
+import psutil
+import pytest
+
+from scripts.runtime_memory_baseline import _process_row, _series_summary
+from scripts.runtime_memory_soak import (
+    _parse_features,
+    _slope_per_hour,
+    _trend_analysis,
+)
+
+
+def test_process_row_records_threads_handles_and_onnx_maps() -> None:
+    row = _process_row(psutil.Process(os.getpid()))
+
+    assert row is not None
+    assert row["threads"] is not None
+    assert row["threads"] >= 1
+    assert "handles" in row
+    assert row["onnx_map_count"] >= 0
+    assert row["onnx_mapped_rss_mib"] >= 0
+
+
+def test_series_summary_aggregates_resource_high_water_marks() -> None:
+    samples = [
+        {
+            "categories": {
+                "python": {
+                    "count": 1,
+                    "rss_mib": 100.0,
+                    "uss_mib": 80.0,
+                    "threads": 4,
+                    "handles": 20,
+                    "onnx_map_count": 2,
+                    "onnx_mapped_rss_mib": 12.0,
+                }
+            },
+            "total": {
+                "rss_mib": 100.0,
+                "uss_mib": 80.0,
+                "threads": 4,
+                "handles": 20,
+                "onnx_map_count": 2,
+                "onnx_mapped_rss_mib": 12.0,
+            },
+            "processes": [],
+        },
+        {
+            "categories": {
+                "python": {
+                    "count": 1,
+                    "rss_mib": 110.0,
+                    "uss_mib": 85.0,
+                    "threads": 5,
+                    "handles": 24,
+                    "onnx_map_count": 3,
+                    "onnx_mapped_rss_mib": 13.0,
+                }
+            },
+            "total": {
+                "rss_mib": 110.0,
+                "uss_mib": 85.0,
+                "threads": 5,
+                "handles": 24,
+                "onnx_map_count": 3,
+                "onnx_mapped_rss_mib": 13.0,
+            },
+            "processes": [],
+        },
+    ]
+
+    summary = _series_summary(samples)
+
+    assert summary["total"]["max_threads"] == 5
+    assert summary["total"]["max_handles"] == 24
+    assert summary["total"]["max_onnx_map_count"] == 3
+    assert summary["total"]["peak_onnx_mapped_rss_mib"] == 13.0
+    assert summary["categories"]["python"]["max_threads"] == 5
+
+
+def test_parse_features_deduplicates_and_rejects_unknown_names() -> None:
+    assert _parse_features("audio,ocr,audio") == ["audio", "ocr"]
+    with pytest.raises(Exception, match="unknown feature"):
+        _parse_features("audio,private-input")
+
+
+def test_slope_per_hour_uses_elapsed_seconds() -> None:
+    assert _slope_per_hour([(0.0, 10.0), (1800.0, 18.0), (3600.0, 26.0)]) == 16.0
+
+
+def test_trend_analysis_distinguishes_native_growth_from_traced_heap() -> None:
+    start = 10_000.0
+    cycles = []
+    for index in range(5):
+        cycles.append(
+            {
+                "features": {},
+                "released_checkpoint": {
+                    "label": f"cycle_{index + 1:04d}_all_released",
+                    "captured_perf_counter": start + index * 900.0,
+                    "total": {
+                        "median_rss_mib": 200.0 + index * 8.0,
+                        "median_uss_mib": 150.0 + index * 6.0,
+                        "median_threads": 8,
+                        "median_handles": 100,
+                        "median_onnx_map_count": 1,
+                        "median_onnx_mapped_rss_mib": 20.0,
+                    },
+                    "tracemalloc": {
+                        "current_mib": 40.0 + index * 0.2,
+                        "peak_mib": 60.0,
+                    },
+                    "categories": {},
+                    "resources": {
+                        "embedding_session_refs": 0,
+                        "rapidocr_cache_owners": 0,
+                    },
+                },
+            }
+        )
+
+    analysis = _trend_analysis({"started_perf_counter": start, "cycles": cycles})
+
+    assert analysis["released_series"]["uss_mib"]["slope_per_hour"] == 24.0
+    assert analysis["released_series"]["traced_current_mib"]["slope_per_hour"] == 0.8
+    assert (
+        "native_or_allocator_retention_review_required" in analysis["heuristic_signals"]
+    )
+    assert (
+        "onnx_dll_or_model_mapping_residency_without_python_owner"
+        in analysis["heuristic_signals"]
+    )

--- a/utils/audio_processor.py
+++ b/utils/audio_processor.py
@@ -554,13 +554,22 @@ class AudioProcessor:
         """Enable or disable noise reduction."""
         prev = self.noise_reduce_enabled
         self.noise_reduce_enabled = enabled
-        if enabled and self._denoiser is None:
-            self._init_denoiser()
-        elif not enabled and self._denoiser is not None:
-            self._denoiser.close()
-            self._denoiser = None
+        if enabled:
+            if self._denoiser is None:
+                self._init_denoiser()
+            if (
+                self._denoiser is not None
+                and self._frame_buffer.size != self.RNNOISE_FRAME_SIZE
+            ):
+                self._frame_buffer = np.empty(self.RNNOISE_FRAME_SIZE, dtype=np.int16)
+        else:
+            if self._denoiser is not None:
+                self._denoiser.close()
+                self._denoiser = None
+            self._frame_buffer = np.array([], dtype=np.int16)
         if prev != enabled:
-            self._frame_buffer.fill(0)
+            if self._frame_buffer.size:
+                self._frame_buffer.fill(0)
             self._frame_buffer_size = 0
             self._agc_gain = 1.0
         logger.info(f"🎤 Noise reduction {'enabled' if enabled else 'disabled'}")


### PR DESCRIPTION
## Summary

- add a repeatable 2–8 hour runtime lifecycle soak covering audio, embedding, RapidOCR, BrowserUse/Playwright, and synthetic plugin reloads
- extend the existing runtime memory baseline with RSS/USS, thread/handle, Chromium, ONNX mapping, owner-count, and tracemalloc checkpoints
- release the RNNoise fixed frame buffer when noise reduction is disabled and recreate it symmetrically when re-enabled
- document the two-hour run, controls, resource invariants, and interpretation

## Findings

The formal run completed 204 cycles over 7,203 seconds. Released checkpoints kept embedding and RapidOCR owners at zero, Chromium descendants at zero, and ONNX mappings stable at 2 / 16.43 MiB. Threads and handles remained bounded, with later 20–52 MiB USS recoveries. The observed RSS/USS high-water behavior is consistent with native allocator/model working-set retention rather than a retained application session.

Chat cycles remain opt-in and were skipped because no backend with verified isolated storage was available; all executed workloads used deterministic synthetic data.

The soak exposed one deterministic lifecycle issue: disabling RNNoise closed the native denoiser but retained its fixed frame buffer. The fix releases that buffer and ensures re-enable recreates it before processing.

## Validation

- `377 passed` across the focused merged-PR and diagnostic suite
- `17 passed` for the final soak/audio lifecycle slice after rebasing onto latest `main`
- Ruff checks passed
- `py_compile` and `git diff --check` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 修复重新启用降噪后音频帧缓冲区未正确重建的问题，提升音频处理稳定性。
  - 优化关闭与重新开启降噪时的资源清理和恢复行为。

- **测试**
  - 增加音频生命周期及运行时资源监测相关测试，覆盖多种功能场景。

- **文档与工具**
  - 新增可重复执行的运行时内存浸泡检测工具及基准验收文档，支持分析长时间运行期间的资源变化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->