### PR TITLE
feat: add regional YouTube proactive feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ memory/store/*
 utils/cache/
 config/api.py
 config/*.json
+config/*_key.key
 !config/api_providers.json
 env/*
 lanlan_frd.exe

--- a/main_routers/cookies_login_router.py
+++ b/main_routers/cookies_login_router.py
@@ -97,10 +97,10 @@ class CookieSubmit(BaseModel):
 def validate_platform_fields(platform: str, cookies: Dict[str, str]):
     """Unified sanity validation of core fields for each platform."""
     if platform == "youtube":
-        if not (cookies.get("SAPISID") or cookies.get("__Secure-3PAPISID")):
+        if not cookies.get("SAPISID"):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="格式错误：未检测到核心字段 SAPISID 或 __Secure-3PAPISID"
+                detail="格式错误：未检测到必需字段 SAPISID"
             )
         return
 

--- a/main_routers/cookies_login_router.py
+++ b/main_routers/cookies_login_router.py
@@ -96,6 +96,14 @@ class CookieSubmit(BaseModel):
 
 def validate_platform_fields(platform: str, cookies: Dict[str, str]):
     """Unified sanity validation of core fields for each platform."""
+    if platform == "youtube":
+        if not (cookies.get("SAPISID") or cookies.get("__Secure-3PAPISID")):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="格式错误：未检测到核心字段 SAPISID 或 __Secure-3PAPISID"
+            )
+        return
+
     platform_validations = {
         "netease": ["MUSIC_U"],
         "bilibili": ["SESSDATA"],

--- a/main_routers/cookies_login_router.py
+++ b/main_routers/cookies_login_router.py
@@ -129,7 +129,12 @@ def validate_platform_fields(platform: str, cookies: Dict[str, str]):
 @router.get("/page", response_class=HTMLResponse, summary="凭证管理可视化后台入口")
 async def render_auth_page(request: Request):
     """Credential management page (local access only)."""
-    return templates.TemplateResponse("cookies_login.html", {"request": request})
+    from config import APP_VERSION
+
+    return templates.TemplateResponse("cookies_login.html", {
+        "request": request,
+        "static_asset_version": APP_VERSION,
+    })
 
 # ============ 3. API 核心功能 ============
 

--- a/main_routers/pages_router.py
+++ b/main_routers/pages_router.py
@@ -371,7 +371,10 @@ async def memory_browser(request: Request):
 async def cookies_login_page(request: Request):
     """Media credential acquisition page."""
     templates = get_templates()
-    return templates.TemplateResponse('templates/cookies_login.html', {"request": request})
+    return templates.TemplateResponse('templates/cookies_login.html', {
+        "request": request,
+        **_static_assets_ctx(),
+    })
 
 
 

--- a/main_routers/system_router/proactive_content.py
+++ b/main_routers/system_router/proactive_content.py
@@ -56,10 +56,10 @@ def _log_video_content(lanlan_name: str, video_content: dict):
                 for title in titles:
                     print(f"  - {title}")
         else:
-            posts = video_data.get('posts', [])
-            titles = [post.get('title', '') for post in posts[:5]]
+            videos = video_data.get('videos', [])
+            titles = [video.get('title', '') for video in videos[:5]]
             if titles:
-                print(f"[{lanlan_name}] 成功获取Reddit热门帖子:")
+                print(f"[{lanlan_name}] 成功获取YouTube视频:")
                 for title in titles:
                     print(f"  - {title}")
 

--- a/main_routers/system_router/proactive_content.py
+++ b/main_routers/system_router/proactive_content.py
@@ -48,20 +48,13 @@ def _log_video_content(lanlan_name: str, video_content: dict):
     region = video_content.get('region', 'china')
     video_data = video_content.get('video', {})
     if video_data.get('success'):
-        if region == 'china':
-            videos = video_data.get('videos', [])
-            titles = [video.get('title', '') for video in videos[:5]]
-            if titles:
-                print(f"[{lanlan_name}] 成功获取B站视频:")
-                for title in titles:
-                    print(f"  - {title}")
-        else:
-            videos = video_data.get('videos', [])
-            titles = [video.get('title', '') for video in videos[:5]]
-            if titles:
-                print(f"[{lanlan_name}] 成功获取YouTube视频:")
-                for title in titles:
-                    print(f"  - {title}")
+        videos = video_data.get('videos', [])
+        titles = [video.get('title', '') for video in videos[:5]]
+        if titles:
+            source = "B站视频" if region == 'china' else "YouTube视频"
+            print(f"[{lanlan_name}] 成功获取{source}:")
+            for title in titles:
+                print(f"  - {title}")
 
 
 def _log_trending_content(lanlan_name: str, trending_content: dict):

--- a/main_routers/system_router/proactive_parsing.py
+++ b/main_routers/system_router/proactive_parsing.py
@@ -52,7 +52,8 @@ def _extract_links_from_raw(mode: str, raw_data: dict) -> list[dict]:
                 title = item.get('title', '')
                 url = item.get('url', '')
                 if title and url:
-                    links.append({'title': title, 'url': url, 'source': 'B站' if raw_data.get('region', 'china') == 'china' else 'Reddit'})
+                    default_source = 'B站' if raw_data.get('region', 'china') == 'china' else 'YouTube'
+                    links.append({'title': title, 'url': url, 'source': item.get('source') or default_source})
         
         elif mode == 'home':
             bilibili = raw_data.get('bilibili', {})

--- a/static/app-proactive.test.cjs
+++ b/static/app-proactive.test.cjs
@@ -36,3 +36,15 @@ test('proactive scheduler re-arms after new-user icebreaker suppression', () => 
     const activeBlock = source.slice(activeStart, activeEnd);
     assert.match(activeBlock, /getNewUserIcebreakerBlockingRetryMs\(\) \|\| getNewUserIcebreakerRetryDelayMs\(\)/);
 });
+
+test('youtube login does not enable the unrelated personal dynamics mode', () => {
+    assert.match(
+        source,
+        /new Set\(\['bilibili', 'douyin', 'kuaishou', 'weibo', 'reddit', 'twitter'\]\)/
+    );
+    const personalPlatformStart = source.indexOf('async function getAvailablePersonalPlatforms()');
+    const personalPlatformEnd = source.indexOf('mod.getAvailablePersonalPlatforms', personalPlatformStart);
+    const personalPlatformBlock = source.slice(personalPlatformStart, personalPlatformEnd);
+    assert.match(personalPlatformBlock, /personalFeedPlatforms\.has\(platform\) && info\.has_cookies/);
+    assert.doesNotMatch(personalPlatformBlock, /personalFeedPlatforms[^;]*youtube/);
+});

--- a/static/app/app-proactive.js
+++ b/static/app/app-proactive.js
@@ -933,12 +933,13 @@
 
             var result = await response.json();
             var availablePlatforms = [];
+            var personalFeedPlatforms = new Set(['bilibili', 'douyin', 'kuaishou', 'weibo', 'reddit', 'twitter']);
 
             if (result.success && result.data) {
                 for (var _ref of Object.entries(result.data)) {
                     var platform = _ref[0];
                     var info = _ref[1];
-                    if (platform !== 'platforms' && info.has_cookies) {
+                    if (personalFeedPlatforms.has(platform) && info.has_cookies) {
                         availablePlatforms.push(platform);
                     }
                 }
@@ -1073,7 +1074,7 @@
                 availableModes.push('news');
             }
 
-            // 视频搭话：使用B站首页视频
+            // 视频搭话：中文地区使用 B站，非中文地区使用 YouTube 首页 Feed
             if (S.proactiveVideoChatEnabled && S.proactiveChatEnabled) {
                 availableModes.push('video');
             }

--- a/static/js/cookies_login.js
+++ b/static/js/cookies_login.js
@@ -34,10 +34,10 @@ const PLATFORM_CONFIG_DATA = {
         nameKey: 'cookiesLogin.youtube',
         theme: '#ff0000',
         instructionKey: 'cookiesLogin.instructions.youtube',
-        fields: [
-            { key: 'SAPISID', labelKey: 'cookiesLogin.fields.SAPISID.label', descKey: 'cookiesLogin.fields.SAPISID.desc', required: false },
-            { key: '__Secure-3PAPISID', labelKey: 'cookiesLogin.fields.secure3PAPISID.label', descKey: 'cookiesLogin.fields.secure3PAPISID.desc', required: false }
-        ]
+        cookieStringMode: true,
+        cookieStringLabelKey: 'cookiesLogin.fields.youtubeCookie.label',
+        cookieStringDescKey: 'cookiesLogin.fields.youtubeCookie.desc',
+        fields: []
     },
     'douyin': {
         name: '抖音', 
@@ -186,7 +186,9 @@ function initPlatformConfig() {
             // 如果字典里有 instructionKey，直接用字典的（字典通常自带了网址）
             // 如果字典没有，则使用这里的模板，并填入 m.weibo.cn 或 翻译后的平台名
             instruction: data.instructionKey ? safeT(data.instructionKey, `<b>目标：</b> 请前往 <b>${targetDisplay}</b> 获取这些 Cookies。`) : '',
-            
+            cookieStringMode: data.cookieStringMode === true,
+            cookieStringLabel: data.cookieStringLabelKey ? safeT(data.cookieStringLabelKey, '完整 Cookie') : '',
+            cookieStringDesc: data.cookieStringDescKey ? safeT(data.cookieStringDescKey, '粘贴 Request Headers 中完整的 Cookie 值') : '',
             fields: data.fields.map(field => ({
                 key: field.key,
                 mapKey: field.mapKey,
@@ -637,11 +639,28 @@ function switchTab(platformKey, btnElement, isReRender = false) {
         }
 
         const placeholderBase = safeT('cookiesLogin.pasteHere', '在此粘贴');
-        // 渲染动态 Cookies 配置字段
-        fieldsContainer.innerHTML = config.fields.map((f, index) => {
-            const inputId = `input-${f.mapKey || f.key}`;
+        if (config.cookieStringMode) {
+            fieldsContainer.innerHTML = `
+            <div class="field-group">
+                <label for="input-cookie-string">
+                    <span>${DOMPurify.sanitize(config.cookieStringLabel)} <span class="req-star">*</span></span>
+                    <span class="desc">${DOMPurify.sanitize(config.cookieStringDesc)}</span>
+                </label>
+                <textarea id="input-cookie-string"
+                          rows="6"
+                          autocomplete="off"
+                          autocapitalize="off"
+                          spellcheck="false"
+                          class="credential-input"></textarea>
+            </div>`;
+            const cookieInput = document.getElementById('input-cookie-string');
+            if (cookieInput) cookieInput.placeholder = `${placeholderBase} Cookie...`;
+        } else {
+            // 渲染动态 Cookies 配置字段
+            fieldsContainer.innerHTML = config.fields.map((f, index) => {
+                const inputId = `input-${f.mapKey || f.key}`;
 
-            return `
+                return `
             <div class="field-group">
                 <label for="${inputId}">
                     <span>${DOMPurify.sanitize(f.label)} ${f.required ? '<span class="req-star">*</span>' : ''}</span>
@@ -652,15 +671,16 @@ function switchTab(platformKey, btnElement, isReRender = false) {
                        autocomplete="off" 
                        class="credential-input">
             </div>
-        `}).join('');
+            `}).join('');
 
-         fieldsContainer.querySelectorAll('.credential-input').forEach((inputEl) => {
-            const idx = Number(inputEl.getAttribute('data-field-index'));
-            const field = config.fields[idx];
-            if (field) {
-                inputEl.placeholder = `${placeholderBase} ${field.key}...`;
-            }
-        });
+            fieldsContainer.querySelectorAll('.credential-input').forEach((inputEl) => {
+                const idx = Number(inputEl.getAttribute('data-field-index'));
+                const field = config.fields[idx];
+                if (field) {
+                    inputEl.placeholder = `${placeholderBase} ${field.key}...`;
+                }
+            });
+        }
         
         if (isReRender) {
             Object.entries(existingValues).forEach(([id, preservedValue]) => {
@@ -681,52 +701,67 @@ function switchTab(platformKey, btnElement, isReRender = false) {
 // 提交当前平台的 Cookies 配置
 async function submitCurrentCookie() {
     const config = PLATFORM_CONFIG[currentPlatform];
-    const cookiePairs = [];
-    // 遍历配置字段，收集 Cookies 配置
-    for (const f of config.fields) {
-        const fieldId = `input-${f.mapKey || f.key}`;
-        const inputEl = document.getElementById(fieldId);
-        const rawVal = inputEl ? inputEl.value : '';
-        const val = rawVal;
-        // 检查必填项
-        if (f.required && !rawVal.trim()) {
-            const message = safeT('cookiesLogin.requiredField', '请填写必填项: {{fieldName}}').replace('{{fieldName}}', f.label);
+    let cookieString = '';
+
+    if (config.cookieStringMode) {
+        const cookieInput = document.getElementById('input-cookie-string');
+        const rawCookieString = cookieInput ? cookieInput.value : '';
+        cookieString = rawCookieString.trim();
+        if (!cookieString) {
+            const message = safeT('cookiesLogin.requiredField', '请填写必填项: {{fieldName}}')
+                .replace('{{fieldName}}', config.cookieStringLabel);
             showAlert(false, message);
-            inputEl?.focus();
+            cookieInput?.focus();
             return;
         }
-        // 过滤非法字符
-        if (rawVal !== '') {
-            let sanitizedVal = rawVal;
-            if (/[\r\n\t<>'";]/.test(sanitizedVal)) {
-                sanitizedVal = sanitizedVal.replace(/[\r\n\t]/g, '').replace(/[<>'"]/g, '').replace(/;/g, '');
-                const message = safeT('cookiesLogin.invalidChars', '{{fieldName}} 包含非法字符，已自动过滤').replace('{{fieldName}}', f.label);
+    } else {
+        const cookiePairs = [];
+        // 遍历配置字段，收集 Cookies 配置
+        for (const f of config.fields) {
+            const fieldId = `input-${f.mapKey || f.key}`;
+            const inputEl = document.getElementById(fieldId);
+            const rawVal = inputEl ? inputEl.value : '';
+            // 检查必填项
+            if (f.required && !rawVal.trim()) {
+                const message = safeT('cookiesLogin.requiredField', '请填写必填项: {{fieldName}}').replace('{{fieldName}}', f.label);
                 showAlert(false, message);
+                inputEl?.focus();
+                return;
             }
-            // 检查是否有首尾空格
-            const prevVal = sanitizedVal;
-            sanitizedVal = sanitizedVal.trim();
-            if (sanitizedVal !== prevVal) {
-                const message = safeT('cookiesLogin.whitespaceTrimmed', '{{fieldName}} 已自动去除首尾空格').replace('{{fieldName}}', f.label);
-                showAlert(false, message);
-            }
-            if (!sanitizedVal) {
-                if (f.required) {
-                    const message = safeT('cookiesLogin.requiredField', '请填写必填项: {{fieldName}}')
-                        .replace('{{fieldName}}', f.label);
+            // 过滤非法字符
+            if (rawVal !== '') {
+                let sanitizedVal = rawVal;
+                if (/[\r\n\t<>'";]/.test(sanitizedVal)) {
+                    sanitizedVal = sanitizedVal.replace(/[\r\n\t]/g, '').replace(/[<>'"]/g, '').replace(/;/g, '');
+                    const message = safeT('cookiesLogin.invalidChars', '{{fieldName}} 包含非法字符，已自动过滤').replace('{{fieldName}}', f.label);
                     showAlert(false, message);
-                    inputEl?.focus();
-                    return;
                 }
-                continue;
+                // 检查是否有首尾空格
+                const prevVal = sanitizedVal;
+                sanitizedVal = sanitizedVal.trim();
+                if (sanitizedVal !== prevVal) {
+                    const message = safeT('cookiesLogin.whitespaceTrimmed', '{{fieldName}} 已自动去除首尾空格').replace('{{fieldName}}', f.label);
+                    showAlert(false, message);
+                }
+                if (!sanitizedVal) {
+                    if (f.required) {
+                        const message = safeT('cookiesLogin.requiredField', '请填写必填项: {{fieldName}}')
+                            .replace('{{fieldName}}', f.label);
+                        showAlert(false, message);
+                        inputEl?.focus();
+                        return;
+                    }
+                    continue;
+                }
+                cookiePairs.push(`${f.key}=${sanitizedVal}`);
             }
-            cookiePairs.push(`${f.key}=${sanitizedVal}`);
         }
-    }
-    // 检查是否有 Cookies 配置
-    if (cookiePairs.length === 0) {
-        showAlert(false, safeT('cookiesLogin.noCookies', '请先配置 Cookies'));
-        return;
+        // 检查是否有 Cookies 配置
+        if (cookiePairs.length === 0) {
+            showAlert(false, safeT('cookiesLogin.noCookies', '请先配置 Cookies'));
+            return;
+        }
+        cookieString = cookiePairs.join('; ');
     }
     const submitBtn = document.getElementById('submit-btn');
     const submitText = document.getElementById('submit-text');
@@ -742,7 +777,7 @@ async function submitCurrentCookie() {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
                 platform: currentPlatform,
-                cookie_string: cookiePairs.join('; '),
+                cookie_string: cookieString,
                 encrypt: encryptToggle ? encryptToggle.checked : false
             })
         });

--- a/static/js/cookies_login.js
+++ b/static/js/cookies_login.js
@@ -29,6 +29,16 @@ const PLATFORM_CONFIG_DATA = {
             { key: 'buvid3', labelKey: 'cookiesLogin.fields.buvid3.label', descKey: 'cookiesLogin.fields.buvid3.desc', required: false }
         ]
     },
+    'youtube': {
+        name: 'YouTube',
+        nameKey: 'cookiesLogin.youtube',
+        theme: '#ff0000',
+        instructionKey: 'cookiesLogin.instructions.youtube',
+        fields: [
+            { key: 'SAPISID', labelKey: 'cookiesLogin.fields.SAPISID.label', descKey: 'cookiesLogin.fields.SAPISID.desc', required: false },
+            { key: '__Secure-3PAPISID', labelKey: 'cookiesLogin.fields.secure3PAPISID.label', descKey: 'cookiesLogin.fields.secure3PAPISID.desc', required: false }
+        ]
+    },
     'douyin': {
         name: '抖音', 
         nameKey: 'cookiesLogin.douyin', 

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -3748,6 +3748,7 @@
         "thisPlatform": "this platform",
         "instructions": {
             "bilibili": "<b>Target:</b> Go to <b>bilibili.com</b> to fetch these cookies.",
+            "youtube": "<b>Target:</b> Sign in at <b>youtube.com</b> and fetch either SAPISID or __Secure-3PAPISID.",
             "douyin": "<b>Target:</b> Go to <b>douyin.com</b> to fetch these cookies.",
             "kuaishou": "<b>Target:</b> Go to <b>kuaishou.com</b> to fetch these cookies.",
             "weibo": "<b>Target:</b> Go to <b>weibo.com</b> to fetch these cookies.",
@@ -3764,6 +3765,14 @@
             "step4": "Find <span class=\"highlight-text\">Cookies</span> on the left sidebar, click the domain, and copy the required values on the right."
         },
         "fields": {
+            "SAPISID": {
+                "label": "SAPISID",
+                "desc": "Google session credential (provide this or __Secure-3PAPISID)"
+            },
+            "secure3PAPISID": {
+                "label": "__Secure-3PAPISID",
+                "desc": "Secure Google session credential (provide this or SAPISID)"
+            },
             "SESSDATA": {
                 "label": "SESSDATA",
                 "desc": "Core identity credential (Required)"

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -3748,7 +3748,7 @@
         "thisPlatform": "this platform",
         "instructions": {
             "bilibili": "<b>Target:</b> Go to <b>bilibili.com</b> to fetch these cookies.",
-            "youtube": "<b>Target:</b> Sign in at <b>youtube.com</b> and fetch either SAPISID or __Secure-3PAPISID.",
+            "youtube": "<b>1. Get the Cookie</b><br>In a browser signed in to YouTube:<br>1. Open <b>youtube.com</b><br>2. Press F12 → Network<br>3. Refresh the page and select a <code>youtubei/v1/browse</code> request<br>4. Copy the complete Cookie value from Request Headers",
             "douyin": "<b>Target:</b> Go to <b>douyin.com</b> to fetch these cookies.",
             "kuaishou": "<b>Target:</b> Go to <b>kuaishou.com</b> to fetch these cookies.",
             "weibo": "<b>Target:</b> Go to <b>weibo.com</b> to fetch these cookies.",
@@ -3765,13 +3765,9 @@
             "step4": "Find <span class=\"highlight-text\">Cookies</span> on the left sidebar, click the domain, and copy the required values on the right."
         },
         "fields": {
-            "SAPISID": {
-                "label": "SAPISID",
-                "desc": "Google session credential (provide this or __Secure-3PAPISID)"
-            },
-            "secure3PAPISID": {
-                "label": "__Secure-3PAPISID",
-                "desc": "Secure Google session credential (provide this or SAPISID)"
+            "youtubeCookie": {
+                "label": "Complete Cookie",
+                "desc": "Paste the complete Cookie value from Request Headers (must include SAPISID)"
             },
             "SESSDATA": {
                 "label": "SESSDATA",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -3720,6 +3720,7 @@
         "title": "N.E.K.O Credential Control Center",
         "header": "Credential Acquisition Center",
         "bilibili": "Bilibili",
+        "youtube": "YouTube",
         "douyin": "Douyin",
         "kuaishou": "Kuaishou",
         "weibo": "Weibo",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -3748,7 +3748,7 @@
         "thisPlatform": "esta plataforma",
         "instructions": {
             "bilibili": "<b>Destino:</b> Vaya a <b>bilibili.com</b> para buscar estas cookies.",
-            "youtube": "<b>Destino:</b> Inicie sesión en <b>youtube.com</b> y obtenga SAPISID o __Secure-3PAPISID.",
+            "youtube": "<b>1. Obtén la Cookie</b><br>En un navegador con la sesión de YouTube iniciada:<br>1. Abre <b>youtube.com</b><br>2. Pulsa F12 → Network<br>3. Actualiza la página y selecciona una solicitud <code>youtubei/v1/browse</code><br>4. Copia el valor completo de Cookie desde Request Headers",
             "douyin": "<b>Destino:</b> Vaya a <b>douyin.com</b> para buscar estas cookies.",
             "kuaishou": "<b>Destino:</b> Vaya a <b>kuaishou.com</b> para buscar estas cookies.",
             "weibo": "<b>Destino:</b> Vaya a <b>weibo.com</b> para buscar estas cookies.",
@@ -3765,13 +3765,9 @@
             "step4": "Busque <span class=\"highlight-text\">Cookies</span> en la barra lateral izquierda, haga clic en el dominio y copie los valores requeridos a la derecha."
         },
         "fields": {
-            "SAPISID": {
-                "label": "SAPISID",
-                "desc": "Credencial de sesión de Google (indique esta o __Secure-3PAPISID)"
-            },
-            "secure3PAPISID": {
-                "label": "__Secure-3PAPISID",
-                "desc": "Credencial segura de sesión de Google (indique esta o SAPISID)"
+            "youtubeCookie": {
+                "label": "Cookie completa",
+                "desc": "Pega el valor completo de Cookie de Request Headers (debe incluir SAPISID)"
             },
             "SESSDATA": {
                 "label": "DATOSESSDATA",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -3720,6 +3720,7 @@
         "title": "Centro de control de credenciales N.E.K.O",
         "header": "Centro de adquisición de credenciales",
         "bilibili": "Bilibili",
+        "youtube": "YouTube",
         "douyin": "Douyin",
         "kuaishou": "Kuaishou",
         "weibo": "Weibo",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -3748,6 +3748,7 @@
         "thisPlatform": "esta plataforma",
         "instructions": {
             "bilibili": "<b>Destino:</b> Vaya a <b>bilibili.com</b> para buscar estas cookies.",
+            "youtube": "<b>Destino:</b> Inicie sesión en <b>youtube.com</b> y obtenga SAPISID o __Secure-3PAPISID.",
             "douyin": "<b>Destino:</b> Vaya a <b>douyin.com</b> para buscar estas cookies.",
             "kuaishou": "<b>Destino:</b> Vaya a <b>kuaishou.com</b> para buscar estas cookies.",
             "weibo": "<b>Destino:</b> Vaya a <b>weibo.com</b> para buscar estas cookies.",
@@ -3764,6 +3765,14 @@
             "step4": "Busque <span class=\"highlight-text\">Cookies</span> en la barra lateral izquierda, haga clic en el dominio y copie los valores requeridos a la derecha."
         },
         "fields": {
+            "SAPISID": {
+                "label": "SAPISID",
+                "desc": "Credencial de sesión de Google (indique esta o __Secure-3PAPISID)"
+            },
+            "secure3PAPISID": {
+                "label": "__Secure-3PAPISID",
+                "desc": "Credencial segura de sesión de Google (indique esta o SAPISID)"
+            },
             "SESSDATA": {
                 "label": "DATOSESSDATA",
                 "desc": "Credencial de identidad principal (obligatoria)"

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -3748,6 +3748,7 @@
         "thisPlatform": "このプラットフォーム",
         "instructions": {
             "bilibili": "<b>対象：</b> <b>bilibili.com</b> にアクセスして Cookie を取得してください。",
+            "youtube": "<b>対象：</b> <b>youtube.com</b> にログインし、SAPISID または __Secure-3PAPISID を取得してください。",
             "douyin": "<b>対象：</b> <b>douyin.com</b> にアクセスして Cookie を取得してください。",
             "kuaishou": "<b>対象：</b> <b>kuaishou.com</b> にアクセスして Cookie を取得してください。",
             "weibo": "<b>対象：</b> <b>weibo.com</b> にアクセスして Cookie を取得してください。",
@@ -3764,6 +3765,14 @@
             "step4": "左側の <span class=\"highlight-text\">Cookies</span> を展開し、ドメインをクリックして右側にある必要な値をコピーします。"
         },
         "fields": {
+            "SAPISID": {
+                "label": "SAPISID",
+                "desc": "Google セッションクレデンシャル（これか __Secure-3PAPISID のどちらかを入力）"
+            },
+            "secure3PAPISID": {
+                "label": "__Secure-3PAPISID",
+                "desc": "セキュアな Google セッションクレデンシャル（これか SAPISID のどちらかを入力）"
+            },
             "SESSDATA": {
                 "label": "SESSDATA",
                 "desc": "コアIDクレデンシャル (必須)"

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -3748,7 +3748,7 @@
         "thisPlatform": "このプラットフォーム",
         "instructions": {
             "bilibili": "<b>対象：</b> <b>bilibili.com</b> にアクセスして Cookie を取得してください。",
-            "youtube": "<b>対象：</b> <b>youtube.com</b> にログインし、SAPISID または __Secure-3PAPISID を取得してください。",
+            "youtube": "<b>1. Cookie を取得</b><br>YouTube にログイン済みのブラウザで：<br>1. <b>youtube.com</b> を開く<br>2. F12 → Network を押す<br>3. ページを更新し、<code>youtubei/v1/browse</code> リクエストを選択する<br>4. Request Headers から完全な Cookie 値をコピーする",
             "douyin": "<b>対象：</b> <b>douyin.com</b> にアクセスして Cookie を取得してください。",
             "kuaishou": "<b>対象：</b> <b>kuaishou.com</b> にアクセスして Cookie を取得してください。",
             "weibo": "<b>対象：</b> <b>weibo.com</b> にアクセスして Cookie を取得してください。",
@@ -3765,13 +3765,9 @@
             "step4": "左側の <span class=\"highlight-text\">Cookies</span> を展開し、ドメインをクリックして右側にある必要な値をコピーします。"
         },
         "fields": {
-            "SAPISID": {
-                "label": "SAPISID",
-                "desc": "Google セッションクレデンシャル（これか __Secure-3PAPISID のどちらかを入力）"
-            },
-            "secure3PAPISID": {
-                "label": "__Secure-3PAPISID",
-                "desc": "セキュアな Google セッションクレデンシャル（これか SAPISID のどちらかを入力）"
+            "youtubeCookie": {
+                "label": "完全な Cookie",
+                "desc": "Request Headers の Cookie 値全体を貼り付けてください（SAPISID 必須）"
             },
             "SESSDATA": {
                 "label": "SESSDATA",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -3720,6 +3720,7 @@
         "title": "N.E.K.O クレデンシャル制御センター",
         "header": "クレデンシャル取得センター",
         "bilibili": "ビリビリ (Bilibili)",
+        "youtube": "YouTube",
         "douyin": "抖音 (Douyin)",
         "kuaishou": "快手 (Kuaishou)",
         "weibo": "微博 (Weibo)",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -3748,6 +3748,7 @@
         "thisPlatform": "이 플랫폼",
         "instructions": {
             "bilibili": "<b>대상:</b> <b>bilibili.com</b>에 접속하여 해당 쿠키를 가져오세요.",
+            "youtube": "<b>대상:</b> <b>youtube.com</b>에 로그인한 뒤 SAPISID 또는 __Secure-3PAPISID를 가져오세요.",
             "douyin": "<b>대상:</b> <b>douyin.com</b>에 접속하여 해당 쿠키를 가져오세요.",
             "kuaishou": "<b>대상:</b> <b>kuaishou.com</b>에 접속하여 해당 쿠키를 가져오세요.",
             "weibo": "<b>대상:</b> <b>weibo.com</b>에 접속하여 해당 쿠키를 가져오세요.",
@@ -3764,6 +3765,14 @@
             "step4": "왼쪽 사이드바에서 <span class=\"highlight-text\">Cookies</span>를 찾아 도메인을 클릭한 후, 오른쪽에서 필요한 값을 복사합니다."
         },
         "fields": {
+            "SAPISID": {
+                "label": "SAPISID",
+                "desc": "Google 세션 자격 증명 (__Secure-3PAPISID와 둘 중 하나 입력)"
+            },
+            "secure3PAPISID": {
+                "label": "__Secure-3PAPISID",
+                "desc": "보안 Google 세션 자격 증명 (SAPISID와 둘 중 하나 입력)"
+            },
             "SESSDATA": {
                 "label": "SESSDATA",
                 "desc": "핵심 신분 자격 증명 (필수)"

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -3748,7 +3748,7 @@
         "thisPlatform": "이 플랫폼",
         "instructions": {
             "bilibili": "<b>대상:</b> <b>bilibili.com</b>에 접속하여 해당 쿠키를 가져오세요.",
-            "youtube": "<b>대상:</b> <b>youtube.com</b>에 로그인한 뒤 SAPISID 또는 __Secure-3PAPISID를 가져오세요.",
+            "youtube": "<b>1. Cookie 가져오기</b><br>YouTube에 로그인된 브라우저에서:<br>1. <b>youtube.com</b> 열기<br>2. F12 → Network 누르기<br>3. 페이지를 새로고침하고 <code>youtubei/v1/browse</code> 요청 선택<br>4. Request Headers에서 전체 Cookie 값 복사",
             "douyin": "<b>대상:</b> <b>douyin.com</b>에 접속하여 해당 쿠키를 가져오세요.",
             "kuaishou": "<b>대상:</b> <b>kuaishou.com</b>에 접속하여 해당 쿠키를 가져오세요.",
             "weibo": "<b>대상:</b> <b>weibo.com</b>에 접속하여 해당 쿠키를 가져오세요.",
@@ -3765,13 +3765,9 @@
             "step4": "왼쪽 사이드바에서 <span class=\"highlight-text\">Cookies</span>를 찾아 도메인을 클릭한 후, 오른쪽에서 필요한 값을 복사합니다."
         },
         "fields": {
-            "SAPISID": {
-                "label": "SAPISID",
-                "desc": "Google 세션 자격 증명 (__Secure-3PAPISID와 둘 중 하나 입력)"
-            },
-            "secure3PAPISID": {
-                "label": "__Secure-3PAPISID",
-                "desc": "보안 Google 세션 자격 증명 (SAPISID와 둘 중 하나 입력)"
+            "youtubeCookie": {
+                "label": "전체 Cookie",
+                "desc": "Request Headers의 전체 Cookie 값을 붙여넣으세요(SAPISID 필수)"
             },
             "SESSDATA": {
                 "label": "SESSDATA",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -3720,6 +3720,7 @@
         "title": "N.E.K.O 자격 증명 제어 센터",
         "header": "자격 증명 획득 센터",
         "bilibili": "빌리빌리 (Bilibili)",
+        "youtube": "YouTube",
         "douyin": "도인 (Douyin)",
         "kuaishou": "쾌수 (Kuaishou)",
         "weibo": "위보 (Weibo)",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -3748,6 +3748,7 @@
         "thisPlatform": "esta plataforma",
         "instructions": {
             "bilibili": "<b>Target:</b> Vá para <b>bilibili.com</b> para buscar esses cookies.",
+            "youtube": "<b>Destino:</b> Entre em <b>youtube.com</b> e obtenha SAPISID ou __Secure-3PAPISID.",
             "douyin": "<b>Target:</b> Vá para <b>douyin.com</b> para buscar esses cookies.",
             "kuaishou": "<b>Target:</b> Vá para <b>kuaishou.com</b> para buscar esses cookies.",
             "weibo": "<b>Target:</b> Vá para <b>weibo.com</b> para buscar esses cookies.",
@@ -3764,6 +3765,14 @@
             "step4": "Encontre <span class=\"highlight-text\">Cookies</span> na barra lateral esquerda, clique no domínio e copie os valores necessários à direita."
         },
         "fields": {
+            "SAPISID": {
+                "label": "SAPISID",
+                "desc": "Credencial de sessão do Google (informe esta ou __Secure-3PAPISID)"
+            },
+            "secure3PAPISID": {
+                "label": "__Secure-3PAPISID",
+                "desc": "Credencial segura de sessão do Google (informe esta ou SAPISID)"
+            },
             "SESSDATA": {
                 "label": "SESSDATA",
                 "desc": "Credencial de identidade principal (obrigatório)"

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -3720,6 +3720,7 @@
         "title": "Centro de controle de credenciais NEKO",
         "header": "Centro de aquisição de credenciais",
         "bilibili": "Bilíbili",
+        "youtube": "YouTube",
         "douyin": "Douyin",
         "kuaishou": "Kuaishou",
         "weibo": "Weibo",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -3748,7 +3748,7 @@
         "thisPlatform": "esta plataforma",
         "instructions": {
             "bilibili": "<b>Target:</b> Vá para <b>bilibili.com</b> para buscar esses cookies.",
-            "youtube": "<b>Destino:</b> Entre em <b>youtube.com</b> e obtenha SAPISID ou __Secure-3PAPISID.",
+            "youtube": "<b>1. Obtenha o Cookie</b><br>Em um navegador conectado ao YouTube:<br>1. Abra <b>youtube.com</b><br>2. Pressione F12 → Network<br>3. Atualize a página e selecione uma solicitação <code>youtubei/v1/browse</code><br>4. Copie o valor completo do Cookie em Request Headers",
             "douyin": "<b>Target:</b> Vá para <b>douyin.com</b> para buscar esses cookies.",
             "kuaishou": "<b>Target:</b> Vá para <b>kuaishou.com</b> para buscar esses cookies.",
             "weibo": "<b>Target:</b> Vá para <b>weibo.com</b> para buscar esses cookies.",
@@ -3765,13 +3765,9 @@
             "step4": "Encontre <span class=\"highlight-text\">Cookies</span> na barra lateral esquerda, clique no domínio e copie os valores necessários à direita."
         },
         "fields": {
-            "SAPISID": {
-                "label": "SAPISID",
-                "desc": "Credencial de sessão do Google (informe esta ou __Secure-3PAPISID)"
-            },
-            "secure3PAPISID": {
-                "label": "__Secure-3PAPISID",
-                "desc": "Credencial segura de sessão do Google (informe esta ou SAPISID)"
+            "youtubeCookie": {
+                "label": "Cookie completo",
+                "desc": "Cole o valor completo do Cookie em Request Headers (deve incluir SAPISID)"
             },
             "SESSDATA": {
                 "label": "SESSDATA",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -3720,6 +3720,7 @@
         "title": "Центр управления учетными данными N.E.K.O",
         "header": "Центр получения учетных данных",
         "bilibili": "Bilibili",
+        "youtube": "YouTube",
         "douyin": "Douyin",
         "kuaishou": "Kuaishou",
         "weibo": "Weibo",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -3748,6 +3748,7 @@
         "thisPlatform": "Эта платформа",
         "instructions": {
             "bilibili": "<b>Цель:</b> Перейдите на <b>bilibili.com</b>, чтобы получить эти файлы cookie.",
+            "youtube": "<b>Цель:</b> Войдите на <b>youtube.com</b> и получите SAPISID или __Secure-3PAPISID.",
             "douyin": "<b>Цель:</b> Перейдите на <b>douyin.com</b>, чтобы получить эти файлы cookie.",
             "kuaishou": "<b>Цель:</b> Перейдите на <b>kuaishou.com</b>, чтобы получить эти файлы cookie.",
             "weibo": "<b>Цель:</b> Перейдите на <b>weibo.com</b>, чтобы получить эти файлы cookie.",
@@ -3764,6 +3765,14 @@
             "step4": "Найдите <span class=\"highlight-text\">Cookies</span> на левой боковой панели, нажмите на домен и скопируйте нужные значения справа."
         },
         "fields": {
+            "SAPISID": {
+                "label": "SAPISID",
+                "desc": "Учетные данные сессии Google (укажите это поле или __Secure-3PAPISID)"
+            },
+            "secure3PAPISID": {
+                "label": "__Secure-3PAPISID",
+                "desc": "Защищенные учетные данные сессии Google (укажите это поле или SAPISID)"
+            },
             "SESSDATA": {
                 "label": "SESSDATA",
                 "desc": "Основные учетные данные личности (Обязательно)"

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -3748,7 +3748,7 @@
         "thisPlatform": "Эта платформа",
         "instructions": {
             "bilibili": "<b>Цель:</b> Перейдите на <b>bilibili.com</b>, чтобы получить эти файлы cookie.",
-            "youtube": "<b>Цель:</b> Войдите на <b>youtube.com</b> и получите SAPISID или __Secure-3PAPISID.",
+            "youtube": "<b>1. Получите Cookie</b><br>В браузере, где выполнен вход в YouTube:<br>1. Откройте <b>youtube.com</b><br>2. Нажмите F12 → Network<br>3. Обновите страницу и выберите запрос <code>youtubei/v1/browse</code><br>4. Скопируйте полное значение Cookie из Request Headers",
             "douyin": "<b>Цель:</b> Перейдите на <b>douyin.com</b>, чтобы получить эти файлы cookie.",
             "kuaishou": "<b>Цель:</b> Перейдите на <b>kuaishou.com</b>, чтобы получить эти файлы cookie.",
             "weibo": "<b>Цель:</b> Перейдите на <b>weibo.com</b>, чтобы получить эти файлы cookie.",
@@ -3765,13 +3765,9 @@
             "step4": "Найдите <span class=\"highlight-text\">Cookies</span> на левой боковой панели, нажмите на домен и скопируйте нужные значения справа."
         },
         "fields": {
-            "SAPISID": {
-                "label": "SAPISID",
-                "desc": "Учетные данные сессии Google (укажите это поле или __Secure-3PAPISID)"
-            },
-            "secure3PAPISID": {
-                "label": "__Secure-3PAPISID",
-                "desc": "Защищенные учетные данные сессии Google (укажите это поле или SAPISID)"
+            "youtubeCookie": {
+                "label": "Полный Cookie",
+                "desc": "Вставьте полное значение Cookie из Request Headers (должно содержать SAPISID)"
             },
             "SESSDATA": {
                 "label": "SESSDATA",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -3748,6 +3748,7 @@
         "thisPlatform": "此平台",
         "instructions": {
             "bilibili": "<b>目标：</b>请前往 <b>bilibili.com</b>获取这些 Cookies。",
+            "youtube": "<b>目标：</b> 请登录 <b>youtube.com</b>，获取 SAPISID 或 __Secure-3PAPISID。",
             "douyin": "<b>目标：</b> 请前往 <b>douyin.com</b> 获取这些 Cookies。",
             "kuaishou": "<b>目标：</b> 请前往 <b>kuaishou.com</b> 获取这些 Cookies。",
             "weibo": "<b>目标：</b> 请前往 <b>weibo.com</b> 获取这些 Cookies。",
@@ -3764,6 +3765,14 @@
             "step4": "在左侧找到 <span class=\"highlight-text\">Cookies</span>，点击域名后在右侧复制对应的值。"
         },
         "fields": {
+            "SAPISID": {
+                "label": "SAPISID",
+                "desc": "Google 会话凭证（与 __Secure-3PAPISID 二选一）"
+            },
+            "secure3PAPISID": {
+                "label": "__Secure-3PAPISID",
+                "desc": "Google 安全会话凭证（与 SAPISID 二选一）"
+            },
             "SESSDATA": {
                 "label": "SESSDATA",
                 "desc": "核心身份凭证 (必填)"

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -3720,6 +3720,7 @@
         "title": "N.E.K.O 凭证控制中心",
         "header": "凭证获取中心",
         "bilibili": "Bilibili",
+        "youtube": "YouTube",
         "douyin": "抖音",
         "kuaishou": "快手",
         "weibo": "微博",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -3748,7 +3748,7 @@
         "thisPlatform": "此平台",
         "instructions": {
             "bilibili": "<b>目标：</b>请前往 <b>bilibili.com</b>获取这些 Cookies。",
-            "youtube": "<b>目标：</b> 请登录 <b>youtube.com</b>，获取 SAPISID 或 __Secure-3PAPISID。",
+            "youtube": "<b>1. 获取 Cookie</b><br>在已登录 YouTube 的浏览器中：<br>1. 打开 <b>youtube.com</b><br>2. 按 F12 → Network<br>3. 刷新页面，选择一个 <code>youtubei/v1/browse</code> 请求<br>4. 在 Request Headers 中复制完整的 Cookie 值",
             "douyin": "<b>目标：</b> 请前往 <b>douyin.com</b> 获取这些 Cookies。",
             "kuaishou": "<b>目标：</b> 请前往 <b>kuaishou.com</b> 获取这些 Cookies。",
             "weibo": "<b>目标：</b> 请前往 <b>weibo.com</b> 获取这些 Cookies。",
@@ -3765,13 +3765,9 @@
             "step4": "在左侧找到 <span class=\"highlight-text\">Cookies</span>，点击域名后在右侧复制对应的值。"
         },
         "fields": {
-            "SAPISID": {
-                "label": "SAPISID",
-                "desc": "Google 会话凭证（与 __Secure-3PAPISID 二选一）"
-            },
-            "secure3PAPISID": {
-                "label": "__Secure-3PAPISID",
-                "desc": "Google 安全会话凭证（与 SAPISID 二选一）"
+            "youtubeCookie": {
+                "label": "完整 Cookie",
+                "desc": "粘贴 Request Headers 中完整的 Cookie 值（必须包含 SAPISID）"
             },
             "SESSDATA": {
                 "label": "SESSDATA",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -3748,6 +3748,7 @@
         "thisPlatform": "該平台",
         "instructions": {
             "bilibili": "<b>目標：</b> 請前往 <b>bilibili.com</b> 獲取這些 Cookies。",
+            "youtube": "<b>目標：</b> 請登入 <b>youtube.com</b>，取得 SAPISID 或 __Secure-3PAPISID。",
             "douyin": "<b>目標：</b> 請前往 <b>douyin.com</b> 獲取這些 Cookies。",
             "kuaishou": "<b>目標：</b> 請前往 <b>kuaishou.com</b> 獲取這些 Cookies。",
             "weibo": "<b>目標：</b> 請前往 <b>weibo.com</b> 獲取這些 Cookies。",
@@ -3764,6 +3765,14 @@
             "step4": "在左側找到 <span class=\"highlight-text\">Cookies</span>，點擊網域後在右側複製對應的值。"
         },
         "fields": {
+            "SAPISID": {
+                "label": "SAPISID",
+                "desc": "Google 工作階段憑證（與 __Secure-3PAPISID 二選一）"
+            },
+            "secure3PAPISID": {
+                "label": "__Secure-3PAPISID",
+                "desc": "Google 安全工作階段憑證（與 SAPISID 二選一）"
+            },
             "SESSDATA": {
                 "label": "SESSDATA",
                 "desc": "核心身份憑證 (必填)"

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -3720,6 +3720,7 @@
         "title": "N.E.K.O 憑證控制中心",
         "header": "憑證取得中心",
         "bilibili": "嗶哩嗶哩",
+        "youtube": "YouTube",
         "douyin": "抖音",
         "kuaishou": "快手",
         "weibo": "微博",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -3748,7 +3748,7 @@
         "thisPlatform": "該平台",
         "instructions": {
             "bilibili": "<b>目標：</b> 請前往 <b>bilibili.com</b> 獲取這些 Cookies。",
-            "youtube": "<b>目標：</b> 請登入 <b>youtube.com</b>，取得 SAPISID 或 __Secure-3PAPISID。",
+            "youtube": "<b>1. 取得 Cookie</b><br>在已登入 YouTube 的瀏覽器中：<br>1. 開啟 <b>youtube.com</b><br>2. 按 F12 → Network<br>3. 重新整理頁面，選擇一個 <code>youtubei/v1/browse</code> 請求<br>4. 在 Request Headers 中複製完整的 Cookie 值",
             "douyin": "<b>目標：</b> 請前往 <b>douyin.com</b> 獲取這些 Cookies。",
             "kuaishou": "<b>目標：</b> 請前往 <b>kuaishou.com</b> 獲取這些 Cookies。",
             "weibo": "<b>目標：</b> 請前往 <b>weibo.com</b> 獲取這些 Cookies。",
@@ -3765,13 +3765,9 @@
             "step4": "在左側找到 <span class=\"highlight-text\">Cookies</span>，點擊網域後在右側複製對應的值。"
         },
         "fields": {
-            "SAPISID": {
-                "label": "SAPISID",
-                "desc": "Google 工作階段憑證（與 __Secure-3PAPISID 二選一）"
-            },
-            "secure3PAPISID": {
-                "label": "__Secure-3PAPISID",
-                "desc": "Google 安全工作階段憑證（與 SAPISID 二選一）"
+            "youtubeCookie": {
+                "label": "完整 Cookie",
+                "desc": "貼上 Request Headers 中完整的 Cookie 值（必須包含 SAPISID）"
             },
             "SESSDATA": {
                 "label": "SESSDATA",

--- a/templates/cookies_login.html
+++ b/templates/cookies_login.html
@@ -504,6 +504,7 @@
         <div class="tabs">
             <button class="tab-btn active" onclick="switchTab('netease', this)" data-i18n="cookiesLogin.netease">网易云音乐</button>
             <button class="tab-btn" onclick="switchTab('bilibili', this)" data-i18n="cookiesLogin.bilibili">Bilibili</button>
+            <button class="tab-btn" onclick="switchTab('youtube', this)" data-i18n="cookiesLogin.youtube">YouTube</button>
             <button class="tab-btn" onclick="switchTab('douyin', this)" data-i18n="cookiesLogin.douyin">抖音</button>
             <button class="tab-btn" onclick="switchTab('kuaishou', this)" data-i18n="cookiesLogin.kuaishou">快手</button>
             <button class="tab-btn" onclick="switchTab('weibo', this)" data-i18n="cookiesLogin.weibo">微博</button>
@@ -561,6 +562,6 @@
     </div>
 
     </div>
-    <script src="/static/js/cookies_login.js?v=2.2"></script>
+    <script src="/static/js/cookies_login.js?v=2.3"></script>
 </body>
 </html>

--- a/templates/cookies_login.html
+++ b/templates/cookies_login.html
@@ -562,6 +562,6 @@
     </div>
 
     </div>
-    <script src="/static/js/cookies_login.js?v=2.3"></script>
+    <script src="/static/js/cookies_login.js?v={{ static_asset_version | default('0') }}"></script>
 </body>
 </html>

--- a/templates/cookies_login.html
+++ b/templates/cookies_login.html
@@ -118,13 +118,16 @@
 
         .field-group { margin-bottom: 16px; display: flex; flex-direction: column; gap: 8px;}
         .field-group label { font-weight: 600; font-size: 14px; color: #334155; display: flex; justify-content: space-between; }
-        .field-group input { 
+        .field-group input,
+        .field-group textarea {
             width: 100%; padding: 12px 14px; 
             border: 2px solid #e2e8f0; border-radius: 10px; 
             font-family: monospace; font-size: 14px; 
             transition: all 0.2s; -webkit-appearance: none; appearance: none; /* 去除 iOS 默认圆角 */
         }
-        .field-group input:focus { outline: none; border-color: var(--primary); box-shadow: 0 0 0 3px var(--primary-shadow); }
+        .field-group textarea { resize: vertical; min-height: 130px; line-height: 1.5; }
+        .field-group input:focus,
+        .field-group textarea:focus { outline: none; border-color: var(--primary); box-shadow: 0 0 0 3px var(--primary-shadow); }
         
         .submit-btn { 
             width: 100%; padding: 14px; margin-top: 10px; 
@@ -194,7 +197,8 @@
             .tutorial-steps { grid-template-columns: 1fr; gap: 8px; }
 
             /* 5. 输入框体验优化 */
-            .field-group input { 
+            .field-group input,
+            .field-group textarea {
                 font-size: 16px; /* 关键：防止 iOS 缩放 */ 
                 padding: 14px; /* 更大的点击区域 */
             }
@@ -268,13 +272,15 @@
         box-shadow: inset 0 -3px 0 var(--primary);
     }
 
-    [data-theme="dark"] .field-group input {
+    [data-theme="dark"] .field-group input,
+    [data-theme="dark"] .field-group textarea {
         background: var(--input-bg);
         border-color: var(--input-border);
         color: var(--text);
     }
 
-    [data-theme="dark"] .field-group input:focus {
+    [data-theme="dark"] .field-group input:focus,
+    [data-theme="dark"] .field-group textarea:focus {
         border-color: var(--primary);
         box-shadow: 0 0 0 3px var(--primary-shadow);
     }

--- a/tests/unit/test_language_env_override.py
+++ b/tests/unit/test_language_env_override.py
@@ -1,0 +1,55 @@
+import pytest
+
+from utils import language_utils
+
+
+@pytest.fixture(autouse=True)
+def reset_language_cache():
+    language_utils.reset_global_language()
+    yield
+    language_utils.reset_global_language()
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_short", "expected_full"),
+    [
+        ("en", "en", "en"),
+        ("en-US", "en", "en"),
+        ("english", "en", "en"),
+        ("ja-JP", "ja", "ja"),
+    ],
+)
+def test_language_env_overrides_steam_and_system(
+    monkeypatch, value, expected_short, expected_full
+):
+    monkeypatch.setenv("NEKO_LANGUAGE", value)
+    monkeypatch.setattr(language_utils, "_get_steam_language", lambda: "zh")
+    monkeypatch.setattr(language_utils, "_get_system_language", lambda: "zh")
+
+    assert language_utils.initialize_global_language() == expected_short
+    assert language_utils.get_global_language_full() == expected_full
+
+
+def test_language_env_survives_late_steam_refresh(monkeypatch):
+    monkeypatch.setenv("NEKO_LANGUAGE", "en")
+
+    assert language_utils.initialize_global_language() == "en"
+    assert language_utils.refresh_global_language("schinese") is False
+    assert language_utils.get_global_language() == "en"
+    assert language_utils.get_global_language_full() == "en"
+
+
+def test_language_and_region_overrides_are_independent(monkeypatch):
+    monkeypatch.setenv("NEKO_LANGUAGE", "en")
+    monkeypatch.setenv("NEKO_IS_CHINA_REGION", "false")
+
+    assert language_utils.get_global_language() == "en"
+    assert language_utils.get_global_region() == "non-china"
+
+
+def test_invalid_language_env_falls_back_to_detected_language(monkeypatch):
+    monkeypatch.setenv("NEKO_LANGUAGE", "not-a-language")
+    monkeypatch.setattr(language_utils, "_get_steam_language", lambda: None)
+    monkeypatch.setattr(language_utils, "_get_system_language", lambda: "zh")
+
+    assert language_utils.initialize_global_language() == "zh"

--- a/tests/unit/test_language_region_override.py
+++ b/tests/unit/test_language_region_override.py
@@ -1,0 +1,36 @@
+import pytest
+
+from utils import language_utils
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on"])
+def test_region_env_truthy_forces_china(monkeypatch, value):
+    monkeypatch.setenv("NEKO_IS_CHINA_REGION", value)
+    monkeypatch.setattr(language_utils.locale, "getlocale", lambda: ("English_United States", "1252"))
+
+    assert language_utils._is_china_region() is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "FALSE", "no", "off"])
+def test_region_env_falsy_forces_non_china(monkeypatch, value):
+    monkeypatch.setenv("NEKO_IS_CHINA_REGION", value)
+    monkeypatch.setattr(language_utils.locale, "getlocale", lambda: ("Chinese (Simplified)_China", "936"))
+
+    assert language_utils._is_china_region() is False
+
+
+def test_invalid_region_env_falls_back_to_locale(monkeypatch):
+    monkeypatch.setenv("NEKO_IS_CHINA_REGION", "unexpected")
+    monkeypatch.setattr(language_utils.locale, "getlocale", lambda: ("Chinese (Simplified)_China", "936"))
+
+    assert language_utils._is_china_region() is True
+
+
+def test_region_env_populates_public_region_cache(monkeypatch):
+    monkeypatch.setenv("NEKO_IS_CHINA_REGION", "false")
+    language_utils.reset_global_language()
+    try:
+        assert language_utils.get_global_region() == "non-china"
+        assert language_utils.is_china_region() is False
+    finally:
+        language_utils.reset_global_language()

--- a/tests/unit/test_language_region_override.py
+++ b/tests/unit/test_language_region_override.py
@@ -3,6 +3,13 @@ import pytest
 from utils import language_utils
 
 
+@pytest.fixture(autouse=True)
+def reset_language_cache():
+    language_utils.reset_global_language()
+    yield
+    language_utils.reset_global_language()
+
+
 @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on"])
 def test_region_env_truthy_forces_china(monkeypatch, value):
     monkeypatch.setenv("NEKO_IS_CHINA_REGION", value)
@@ -28,9 +35,5 @@ def test_invalid_region_env_falls_back_to_locale(monkeypatch):
 
 def test_region_env_populates_public_region_cache(monkeypatch):
     monkeypatch.setenv("NEKO_IS_CHINA_REGION", "false")
-    language_utils.reset_global_language()
-    try:
-        assert language_utils.get_global_region() == "non-china"
-        assert language_utils.is_china_region() is False
-    finally:
-        language_utils.reset_global_language()
+    assert language_utils.get_global_region() == "non-china"
+    assert language_utils.is_china_region() is False

--- a/tests/unit/test_youtube_feed.py
+++ b/tests/unit/test_youtube_feed.py
@@ -1,8 +1,11 @@
 import hashlib
+import json
+from pathlib import Path
 
 import httpx
 import pytest
 
+from main_routers.system_router.proactive_content import _log_video_content
 from main_routers.system_router.proactive_parsing import _extract_links_from_raw
 from utils import cookies_login
 from utils.web_scraper import trending_content
@@ -150,15 +153,19 @@ async def test_fetch_youtube_home_feed_falls_back_when_home_is_empty(monkeypatch
     class FakeClient:
         def __init__(self):
             self.post_urls = []
+            self.get_kwargs = None
+            self.post_kwargs = []
 
-        async def get(self, *_args, **_kwargs):
+        async def get(self, *_args, **kwargs):
+            self.get_kwargs = kwargs
             return FakeResponse(text=(
                 '<script>ytcfg.set({"INNERTUBE_API_KEY":"api-key",'
                 '"INNERTUBE_CONTEXT":{"client":{"clientVersion":"1.2.3"}}});</script>'
             ))
 
-        async def post(self, url, **_kwargs):
+        async def post(self, url, **kwargs):
             self.post_urls.append(url)
+            self.post_kwargs.append(kwargs)
             if url.endswith("/browse"):
                 return FakeResponse(payload={"richGridRenderer": {"contents": []}})
             return FakeResponse(payload={
@@ -171,6 +178,7 @@ async def test_fetch_youtube_home_feed_falls_back_when_home_is_empty(monkeypatch
     client = FakeClient()
     monkeypatch.setattr(youtube_feed, "_get_platform_cookies", lambda _platform: {})
     monkeypatch.setattr(youtube_feed, "get_external_http_client", lambda: client)
+    monkeypatch.setattr(youtube_feed, "get_global_language_full", lambda: "ja")
 
     result = await youtube_feed.fetch_youtube_home_feed(limit=5)
 
@@ -178,6 +186,200 @@ async def test_fetch_youtube_home_feed_falls_back_when_home_is_empty(monkeypatch
     assert result["feed_kind"] == "public_discovery"
     assert result["videos"][0]["video_id"] == "fallback123"
     assert client.post_urls[-1].endswith("/search")
+    assert client.get_kwargs["headers"]["Accept-Language"].startswith("ja-JP")
+    assert client.post_kwargs[-1]["json"]["query"] == "話題の動画"
+
+
+@pytest.mark.asyncio
+async def test_authenticated_feed_uses_and_closes_isolated_client(monkeypatch):
+    class FakeResponse:
+        def __init__(self, *, text="", payload=None):
+            self.text = text
+            self._payload = payload
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    class FakeClient:
+        def __init__(self):
+            self.closed = False
+            self.cookies = type("CookieJar", (), {"clear": lambda self: None})()
+            self.post_headers = []
+
+        async def get(self, *_args, **_kwargs):
+            return FakeResponse(text=(
+                '<script>ytcfg.set({"INNERTUBE_API_KEY":"api-key",'
+                '"INNERTUBE_CONTEXT":{"client":{"clientVersion":"1.2.3"}}});</script>'
+            ))
+
+        async def post(self, _url, **kwargs):
+            self.post_headers.append(kwargs["headers"])
+            return FakeResponse(payload={
+                "videoRenderer": {
+                    "videoId": "private123",
+                    "title": {"simpleText": "Personalized recommendation"},
+                }
+            })
+
+        async def aclose(self):
+            self.closed = True
+
+    client = FakeClient()
+    monkeypatch.setattr(
+        youtube_feed,
+        "_get_platform_cookies",
+        lambda _platform: {"SAPISID": "secret"},
+    )
+    monkeypatch.setattr(youtube_feed.httpx, "AsyncClient", lambda **_kwargs: client)
+    monkeypatch.setattr(
+        youtube_feed,
+        "get_external_http_client",
+        lambda: pytest.fail("credentialed requests must not use the shared client"),
+    )
+
+    result = await youtube_feed.fetch_youtube_home_feed(limit=5)
+
+    assert result["success"] is True
+    assert result["authenticated"] is True
+    assert "Authorization" in client.post_headers[0]
+    assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_expired_credentials_retry_anonymous_home(monkeypatch):
+    class FakeCookieJar:
+        def __init__(self):
+            self.clear_count = 0
+
+        def clear(self):
+            self.clear_count += 1
+
+    class FakeResponse:
+        def __init__(self, *, status_code=200, text="", payload=None):
+            self.status_code = status_code
+            self.text = text
+            self._payload = payload
+
+        def raise_for_status(self):
+            if self.status_code in {401, 403}:
+                request = httpx.Request("POST", "https://www.youtube.com/youtubei/v1/browse")
+                response = httpx.Response(self.status_code, request=request)
+                raise httpx.HTTPStatusError(
+                    "authentication failed", request=request, response=response
+                )
+
+        def json(self):
+            return self._payload
+
+    class FakeClient:
+        def __init__(self):
+            self.cookies = FakeCookieJar()
+            self.post_headers = []
+
+        async def get(self, *_args, **_kwargs):
+            return FakeResponse(text=(
+                '<script>ytcfg.set({"INNERTUBE_API_KEY":"api-key",'
+                '"INNERTUBE_CONTEXT":{"client":{"clientVersion":"1.2.3"}}});</script>'
+            ))
+
+        async def post(self, _url, **kwargs):
+            self.post_headers.append(kwargs["headers"])
+            if len(self.post_headers) == 1:
+                return FakeResponse(status_code=401)
+            return FakeResponse(payload={
+                "videoRenderer": {
+                    "videoId": "anonymous123",
+                    "title": {"simpleText": "Anonymous recommendation"},
+                }
+            })
+
+        async def aclose(self):
+            return None
+
+    client = FakeClient()
+    monkeypatch.setattr(
+        youtube_feed,
+        "_get_platform_cookies",
+        lambda _platform: {"SAPISID": "expired"},
+    )
+    monkeypatch.setattr(youtube_feed.httpx, "AsyncClient", lambda **_kwargs: client)
+
+    result = await youtube_feed.fetch_youtube_home_feed(limit=5)
+
+    assert result["success"] is True
+    assert result["authenticated"] is False
+    assert len(client.post_headers) == 2
+    assert "Authorization" in client.post_headers[0]
+    assert "Authorization" not in client.post_headers[1]
+    assert "SAPISID" not in client.post_headers[1]["Cookie"]
+    assert client.cookies.clear_count == 1
+
+
+@pytest.mark.asyncio
+async def test_authenticated_empty_home_uses_anonymous_public_discovery(monkeypatch):
+    class FakeCookieJar:
+        def __init__(self):
+            self.clear_count = 0
+
+        def clear(self):
+            self.clear_count += 1
+
+    class FakeResponse:
+        def __init__(self, *, text="", payload=None):
+            self.text = text
+            self._payload = payload
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    class FakeClient:
+        def __init__(self):
+            self.cookies = FakeCookieJar()
+            self.posts = []
+
+        async def get(self, *_args, **_kwargs):
+            return FakeResponse(text=(
+                '<script>ytcfg.set({"INNERTUBE_API_KEY":"api-key",'
+                '"INNERTUBE_CONTEXT":{"client":{"clientVersion":"1.2.3"}}});</script>'
+            ))
+
+        async def post(self, url, **kwargs):
+            self.posts.append((url, kwargs))
+            if url.endswith("/browse"):
+                return FakeResponse(payload={"richGridRenderer": {"contents": []}})
+            return FakeResponse(payload={
+                "videoRenderer": {
+                    "videoId": "public123",
+                    "title": {"simpleText": "Public discovery"},
+                }
+            })
+
+        async def aclose(self):
+            return None
+
+    client = FakeClient()
+    monkeypatch.setattr(
+        youtube_feed,
+        "_get_platform_cookies",
+        lambda _platform: {"SAPISID": "secret"},
+    )
+    monkeypatch.setattr(youtube_feed.httpx, "AsyncClient", lambda **_kwargs: client)
+
+    result = await youtube_feed.fetch_youtube_home_feed(limit=5)
+
+    assert result["success"] is True
+    assert result["feed_kind"] == "public_discovery"
+    assert result["authenticated"] is False
+    search_headers = client.posts[-1][1]["headers"]
+    assert "Authorization" not in search_headers
+    assert "SAPISID" not in search_headers["Cookie"]
+    assert client.cookies.clear_count == 1
 
 
 @pytest.mark.asyncio
@@ -257,3 +459,30 @@ def test_youtube_cookie_validation_accepts_either_sapisid_variant():
     assert cookies_login.validate_cookies("youtube", {"SAPISID": "a"}) is True
     assert cookies_login.validate_cookies("youtube", {"__Secure-3PAPISID": "b"}) is True
     assert cookies_login.validate_cookies("youtube", {"SID": "c"}) is False
+
+
+def test_youtube_cookie_i18n_contract_is_complete_for_all_locales():
+    locale_dir = Path(__file__).parents[2] / "static" / "locales"
+    for locale_path in locale_dir.glob("*.json"):
+        payload = json.loads(locale_path.read_text(encoding="utf-8"))
+        cookies_login_i18n = payload["cookiesLogin"]
+        assert cookies_login_i18n["instructions"]["youtube"]
+        assert cookies_login_i18n["fields"]["SAPISID"]["label"]
+        assert cookies_login_i18n["fields"]["SAPISID"]["desc"]
+        assert cookies_login_i18n["fields"]["secure3PAPISID"]["label"]
+        assert cookies_login_i18n["fields"]["secure3PAPISID"]["desc"]
+
+
+def test_non_china_video_log_reports_youtube_payload(capsys):
+    _log_video_content("YUI", {
+        "region": "non-china",
+        "video": {
+            "success": True,
+            "videos": [{"title": "A YouTube recommendation"}],
+        },
+    })
+
+    output = capsys.readouterr().out
+    assert "成功获取YouTube视频" in output
+    assert "A YouTube recommendation" in output
+    assert "Reddit" not in output

--- a/tests/unit/test_youtube_feed.py
+++ b/tests/unit/test_youtube_feed.py
@@ -1,0 +1,259 @@
+import hashlib
+
+import httpx
+import pytest
+
+from main_routers.system_router.proactive_parsing import _extract_links_from_raw
+from utils import cookies_login
+from utils.web_scraper import trending_content
+from utils.web_scraper import youtube_feed
+
+
+def test_extract_ytcfg_merges_bootstrap_objects():
+    html = """
+    <script>ytcfg.set({"INNERTUBE_API_KEY":"key-1"});</script>
+    <script>ytcfg.set( {"INNERTUBE_CONTEXT":{"client":{"clientVersion":"1.2.3"}}} );</script>
+    """
+
+    config = youtube_feed._extract_ytcfg(html)
+
+    assert config["INNERTUBE_API_KEY"] == "key-1"
+    assert config["INNERTUBE_CONTEXT"]["client"]["clientVersion"] == "1.2.3"
+
+
+def test_build_sapisid_authorization_supports_secure_cookie_fallback():
+    expected_digest = hashlib.sha1(
+        b"123456 secret https://www.youtube.com"
+    ).hexdigest()
+
+    authorization = youtube_feed._build_sapisid_authorization(
+        {"__Secure-3PAPISID": "secret"}, now=123456
+    )
+
+    assert authorization == f"SAPISIDHASH 123456_{expected_digest}"
+
+
+def test_extract_videos_supports_classic_and_lockup_renderers():
+    payload = {
+        "contents": [
+            {
+                "videoRenderer": {
+                    "videoId": "classic123",
+                    "title": {"runs": [{"text": "Classic video"}]},
+                    "ownerText": {"runs": [{"text": "Creator A"}]},
+                    "viewCountText": {"simpleText": "12K views"},
+                    "publishedTimeText": {"simpleText": "2 hours ago"},
+                    "thumbnail": {"thumbnails": [{"url": "https://img/classic.jpg"}]},
+                }
+            },
+            {
+                "lockupViewModel": {
+                    "contentId": "lockup456",
+                    "contentType": "LOCKUP_CONTENT_TYPE_VIDEO",
+                    "metadata": {
+                        "lockupMetadataViewModel": {
+                            "title": {"content": "Lockup video"},
+                            "metadata": {
+                                "contentMetadataViewModel": {
+                                    "metadataRows": [
+                                        {
+                                            "metadataParts": [
+                                                {"text": {"content": "Creator B"}},
+                                                {"text": {"content": "34K views"}},
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                        }
+                    },
+                    "contentImage": {
+                        "thumbnailViewModel": {
+                            "image": {"sources": [{"url": "https://img/lockup.jpg"}]}
+                        }
+                    },
+                }
+            },
+        ]
+    }
+
+    videos = youtube_feed._extract_videos(payload, 10)
+
+    assert [video["video_id"] for video in videos] == ["classic123", "lockup456"]
+    assert videos[0]["author"] == "Creator A"
+    assert videos[1]["author"] == "Creator B"
+    assert videos[1]["source"] == "YouTube"
+
+
+@pytest.mark.asyncio
+async def test_fetch_youtube_home_feed_uses_anonymous_browse(monkeypatch):
+    class FakeResponse:
+        def __init__(self, *, text="", payload=None):
+            self.text = text
+            self._payload = payload
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    class FakeClient:
+        def __init__(self):
+            self.post_kwargs = None
+
+        async def get(self, *_args, **_kwargs):
+            return FakeResponse(
+                text=(
+                    '<script>ytcfg.set({"INNERTUBE_API_KEY":"api-key",'
+                    '"INNERTUBE_CONTEXT":{"client":{"clientVersion":"1.2.3",'
+                    '"visitorData":"visitor"}}});</script>'
+                )
+            )
+
+        async def post(self, *_args, **kwargs):
+            self.post_kwargs = kwargs
+            return FakeResponse(payload={
+                "videoRenderer": {
+                    "videoId": "video123",
+                    "title": {"simpleText": "Home recommendation"},
+                }
+            })
+
+    client = FakeClient()
+    monkeypatch.setattr(youtube_feed, "_get_platform_cookies", lambda _platform: {})
+    monkeypatch.setattr(youtube_feed, "get_external_http_client", lambda: client)
+
+    result = await youtube_feed.fetch_youtube_home_feed(limit=5)
+
+    assert result["success"] is True
+    assert result["feed_kind"] == "home"
+    assert result["authenticated"] is False
+    assert result["videos"][0]["url"] == "https://www.youtube.com/watch?v=video123"
+    assert client.post_kwargs["json"]["browseId"] == "FEwhat_to_watch"
+    assert "Authorization" not in client.post_kwargs["headers"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_youtube_home_feed_falls_back_when_home_is_empty(monkeypatch):
+    class FakeResponse:
+        def __init__(self, *, text="", payload=None):
+            self.text = text
+            self._payload = payload
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    class FakeClient:
+        def __init__(self):
+            self.post_urls = []
+
+        async def get(self, *_args, **_kwargs):
+            return FakeResponse(text=(
+                '<script>ytcfg.set({"INNERTUBE_API_KEY":"api-key",'
+                '"INNERTUBE_CONTEXT":{"client":{"clientVersion":"1.2.3"}}});</script>'
+            ))
+
+        async def post(self, url, **_kwargs):
+            self.post_urls.append(url)
+            if url.endswith("/browse"):
+                return FakeResponse(payload={"richGridRenderer": {"contents": []}})
+            return FakeResponse(payload={
+                "videoRenderer": {
+                    "videoId": "fallback123",
+                    "title": {"simpleText": "Public discovery video"},
+                }
+            })
+
+    client = FakeClient()
+    monkeypatch.setattr(youtube_feed, "_get_platform_cookies", lambda _platform: {})
+    monkeypatch.setattr(youtube_feed, "get_external_http_client", lambda: client)
+
+    result = await youtube_feed.fetch_youtube_home_feed(limit=5)
+
+    assert result["success"] is True
+    assert result["feed_kind"] == "public_discovery"
+    assert result["videos"][0]["video_id"] == "fallback123"
+    assert client.post_urls[-1].endswith("/search")
+
+
+@pytest.mark.asyncio
+async def test_fetch_youtube_home_feed_formats_empty_timeout_error(monkeypatch):
+    class TimeoutClient:
+        async def get(self, *_args, **_kwargs):
+            raise httpx.ConnectTimeout("")
+
+    monkeypatch.setattr(youtube_feed, "_get_platform_cookies", lambda _platform: {})
+    monkeypatch.setattr(youtube_feed, "get_external_http_client", TimeoutClient)
+
+    result = await youtube_feed.fetch_youtube_home_feed(limit=5)
+
+    assert result["success"] is False
+    assert result["error"].startswith("ConnectTimeout:")
+    assert "代理" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_video_region_route_uses_youtube_outside_china(monkeypatch):
+    async def fake_youtube(limit):
+        return {"success": True, "source": "youtube", "videos": [{"title": str(limit)}]}
+
+    monkeypatch.setattr(trending_content, "is_china_region", lambda: False)
+    monkeypatch.setattr(trending_content, "fetch_youtube_home_feed", fake_youtube)
+
+    result = await trending_content.fetch_video_content(limit=7)
+
+    assert result["region"] == "non-china"
+    assert result["video"]["source"] == "youtube"
+    assert result["video"]["videos"][0]["title"] == "7"
+
+
+@pytest.mark.asyncio
+async def test_video_region_route_always_propagates_failure_error(monkeypatch):
+    async def fake_youtube(_limit):
+        return {"success": False, "source": "youtube", "videos": []}
+
+    monkeypatch.setattr(trending_content, "is_china_region", lambda: False)
+    monkeypatch.setattr(trending_content, "fetch_youtube_home_feed", fake_youtube)
+
+    result = await trending_content.fetch_video_content(limit=7)
+
+    assert result["success"] is False
+    assert result["error"] == "youtube 获取失败（无错误详情）"
+
+
+def test_youtube_video_format_and_source_links():
+    raw = {
+        "success": True,
+        "region": "non-china",
+        "video": {
+            "success": True,
+            "videos": [{
+                "title": "A useful video",
+                "author": "Creator",
+                "view_count": "1K views",
+                "url": "https://www.youtube.com/watch?v=abc",
+                "source": "YouTube",
+            }],
+        },
+    }
+
+    formatted = trending_content.format_video_content(raw)
+    links = _extract_links_from_raw("video", raw)
+
+    assert "【YouTube 推荐】" in formatted
+    assert "Creator | 1K views" in formatted
+    assert links == [{
+        "title": "A useful video",
+        "url": "https://www.youtube.com/watch?v=abc",
+        "source": "YouTube",
+    }]
+
+
+def test_youtube_cookie_validation_accepts_either_sapisid_variant():
+    assert cookies_login.validate_cookies("youtube", {"SAPISID": "a"}) is True
+    assert cookies_login.validate_cookies("youtube", {"__Secure-3PAPISID": "b"}) is True
+    assert cookies_login.validate_cookies("youtube", {"SID": "c"}) is False

--- a/tests/unit/test_youtube_feed.py
+++ b/tests/unit/test_youtube_feed.py
@@ -473,16 +473,28 @@ def test_youtube_cookie_i18n_contract_is_complete_for_all_locales():
         assert cookies_login_i18n["fields"]["secure3PAPISID"]["desc"]
 
 
-def test_non_china_video_log_reports_youtube_payload(capsys):
+@pytest.mark.parametrize(
+    ("region", "source"),
+    [("china", "B站视频"), ("non-china", "YouTube视频")],
+)
+def test_video_log_reports_region_source(capsys, region, source):
     _log_video_content("YUI", {
-        "region": "non-china",
+        "region": region,
         "video": {
             "success": True,
-            "videos": [{"title": "A YouTube recommendation"}],
+            "videos": [{"title": "A video recommendation"}],
         },
     })
 
     output = capsys.readouterr().out
-    assert "成功获取YouTube视频" in output
-    assert "A YouTube recommendation" in output
-    assert "Reddit" not in output
+    assert f"成功获取{source}" in output
+    assert "A video recommendation" in output
+
+
+def test_video_log_stays_silent_without_titles(capsys):
+    _log_video_content("YUI", {
+        "region": "non-china",
+        "video": {"success": True, "videos": []},
+    })
+
+    assert capsys.readouterr().out == ""

--- a/tests/unit/test_youtube_feed.py
+++ b/tests/unit/test_youtube_feed.py
@@ -1,10 +1,13 @@
 import hashlib
 import json
+import logging
 from pathlib import Path
 
 import httpx
 import pytest
+from fastapi import HTTPException
 
+from main_routers.cookies_login_router import validate_platform_fields
 from main_routers.system_router.proactive_content import _log_video_content
 from main_routers.system_router.proactive_parsing import _extract_links_from_raw
 from utils import cookies_login
@@ -24,13 +27,17 @@ def test_extract_ytcfg_merges_bootstrap_objects():
     assert config["INNERTUBE_CONTEXT"]["client"]["clientVersion"] == "1.2.3"
 
 
-def test_build_sapisid_authorization_supports_secure_cookie_fallback():
+def test_build_sapisid_authorization_requires_real_sapisid():
+    assert youtube_feed._build_sapisid_authorization(
+        {"__Secure-3PAPISID": "secret"}, now=123456
+    ) == ""
+
     expected_digest = hashlib.sha1(
         b"123456 secret https://www.youtube.com"
     ).hexdigest()
 
     authorization = youtube_feed._build_sapisid_authorization(
-        {"__Secure-3PAPISID": "secret"}, now=123456
+        {"SAPISID": "secret"}, now=123456
     )
 
     assert authorization == f"SAPISIDHASH 123456_{expected_digest}"
@@ -191,7 +198,9 @@ async def test_fetch_youtube_home_feed_falls_back_when_home_is_empty(monkeypatch
 
 
 @pytest.mark.asyncio
-async def test_authenticated_feed_uses_and_closes_isolated_client(monkeypatch):
+async def test_authenticated_feed_uses_and_closes_isolated_client(monkeypatch, caplog):
+    caplog.set_level(logging.INFO)
+
     class FakeResponse:
         def __init__(self, *, text="", payload=None):
             self.text = text
@@ -218,6 +227,9 @@ async def test_authenticated_feed_uses_and_closes_isolated_client(monkeypatch):
         async def post(self, _url, **kwargs):
             self.post_headers.append(kwargs["headers"])
             return FakeResponse(payload={
+                "responseContext": {
+                    "mainAppWebResponseContext": {"loggedOut": False}
+                },
                 "videoRenderer": {
                     "videoId": "private123",
                     "title": {"simpleText": "Personalized recommendation"},
@@ -246,6 +258,63 @@ async def test_authenticated_feed_uses_and_closes_isolated_client(monkeypatch):
     assert result["authenticated"] is True
     assert "Authorization" in client.post_headers[0]
     assert client.closed is True
+    assert "feed_kind=home" in caplog.text
+    assert "auth_requested=True" in caplog.text
+    assert "auth_confirmed=True" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_logged_out_response_is_not_reported_as_authenticated(monkeypatch, caplog):
+    caplog.set_level(logging.INFO)
+
+    class FakeResponse:
+        def __init__(self, *, text="", payload=None):
+            self.text = text
+            self._payload = payload
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    class FakeClient:
+        def __init__(self):
+            self.cookies = type("CookieJar", (), {"clear": lambda self: None})()
+
+        async def get(self, *_args, **_kwargs):
+            return FakeResponse(text=(
+                '<script>ytcfg.set({"INNERTUBE_API_KEY":"api-key",'
+                '"INNERTUBE_CONTEXT":{"client":{"clientVersion":"1.2.3"}}});</script>'
+            ))
+
+        async def post(self, _url, **_kwargs):
+            return FakeResponse(payload={
+                "responseContext": {
+                    "mainAppWebResponseContext": {"loggedOut": True}
+                },
+                "videoRenderer": {
+                    "videoId": "public123",
+                    "title": {"simpleText": "Public recommendation"},
+                },
+            })
+
+        async def aclose(self):
+            return None
+
+    monkeypatch.setattr(
+        youtube_feed,
+        "_get_platform_cookies",
+        lambda _platform: {"SAPISID": "secret"},
+    )
+    monkeypatch.setattr(youtube_feed.httpx, "AsyncClient", lambda **_kwargs: FakeClient())
+
+    result = await youtube_feed.fetch_youtube_home_feed(limit=5)
+
+    assert result["success"] is True
+    assert result["authenticated"] is False
+    assert "auth_requested=True" in caplog.text
+    assert "auth_confirmed=False" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -319,7 +388,9 @@ async def test_expired_credentials_retry_anonymous_home(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_authenticated_empty_home_uses_anonymous_public_discovery(monkeypatch):
+async def test_authenticated_empty_home_uses_anonymous_public_discovery(monkeypatch, caplog):
+    caplog.set_level(logging.INFO)
+
     class FakeCookieJar:
         def __init__(self):
             self.clear_count = 0
@@ -380,6 +451,8 @@ async def test_authenticated_empty_home_uses_anonymous_public_discovery(monkeypa
     assert "Authorization" not in search_headers
     assert "SAPISID" not in search_headers["Cookie"]
     assert client.cookies.clear_count == 1
+    assert "切换匿名 public_discovery" in caplog.text
+    assert "feed_kind=public_discovery" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -455,10 +528,30 @@ def test_youtube_video_format_and_source_links():
     }]
 
 
-def test_youtube_cookie_validation_accepts_either_sapisid_variant():
+def test_youtube_cookie_validation_requires_sapisid():
     assert cookies_login.validate_cookies("youtube", {"SAPISID": "a"}) is True
-    assert cookies_login.validate_cookies("youtube", {"__Secure-3PAPISID": "b"}) is True
+    assert cookies_login.validate_cookies("youtube", {"__Secure-3PAPISID": "b"}) is False
     assert cookies_login.validate_cookies("youtube", {"SID": "c"}) is False
+
+
+def test_youtube_cookie_route_validation_requires_sapisid():
+    validate_platform_fields("youtube", {"SAPISID": "a"})
+
+    with pytest.raises(HTTPException, match="SAPISID"):
+        validate_platform_fields("youtube", {"__Secure-3PAPISID": "b"})
+
+
+def test_youtube_cookie_form_accepts_complete_cookie_string():
+    source = (
+        Path(__file__).parents[2] / "static" / "js" / "cookies_login.js"
+    ).read_text(encoding="utf-8")
+
+    youtube_config = source.split("'youtube': {", 1)[1].split("'douyin': {", 1)[0]
+    assert "cookieStringMode: true" in youtube_config
+    assert "{ key: 'SAPISID'" not in youtube_config
+    assert "id=\"input-cookie-string\"" in source
+    assert "cookieString = rawCookieString.trim()" in source
+    assert "cookie_string: cookieString" in source
 
 
 def test_youtube_cookie_i18n_contract_is_complete_for_all_locales():
@@ -467,10 +560,16 @@ def test_youtube_cookie_i18n_contract_is_complete_for_all_locales():
         payload = json.loads(locale_path.read_text(encoding="utf-8"))
         cookies_login_i18n = payload["cookiesLogin"]
         assert cookies_login_i18n["instructions"]["youtube"]
-        assert cookies_login_i18n["fields"]["SAPISID"]["label"]
-        assert cookies_login_i18n["fields"]["SAPISID"]["desc"]
-        assert cookies_login_i18n["fields"]["secure3PAPISID"]["label"]
-        assert cookies_login_i18n["fields"]["secure3PAPISID"]["desc"]
+        assert cookies_login_i18n["fields"]["youtubeCookie"]["label"]
+        assert cookies_login_i18n["fields"]["youtubeCookie"]["desc"]
+
+    zh_instruction = json.loads(
+        (locale_dir / "zh-CN.json").read_text(encoding="utf-8")
+    )["cookiesLogin"]["instructions"]["youtube"]
+    assert "1. 获取 Cookie" in zh_instruction
+    assert "F12 → Network" in zh_instruction
+    assert "youtubei/v1/browse" in zh_instruction
+    assert "Request Headers 中复制完整的 Cookie 值" in zh_instruction
 
 
 @pytest.mark.parametrize(

--- a/utils/cookies_login.py
+++ b/utils/cookies_login.py
@@ -72,8 +72,8 @@ def mask_string(s: str) -> str:
 def validate_cookies(platform: str, cookies: Dict[str, str]) -> bool:
     """Core credential integrity check, preventing incomplete cookies from causing account anomalies or risk control"""
     if platform == 'youtube':
-        if not (cookies.get('SAPISID') or cookies.get('__Secure-3PAPISID')):
-            logger.warning("⚠️ 安全拦截：YouTube Cookie 缺少 SAPISID 或 __Secure-3PAPISID！")
+        if not cookies.get('SAPISID'):
+            logger.warning("⚠️ 安全拦截：YouTube Cookie 缺少 SAPISID！")
             return False
         return True
 
@@ -353,7 +353,7 @@ def get_twitter_cookies(_method: str = "manual") -> Optional[Dict[str, str]]:
 
 def get_youtube_cookies(_method: str = "manual") -> Optional[Dict[str, str]]:
     print("\n" + "-" * 40)
-    print("【YouTube 手动导入】(需包含 SAPISID 或 __Secure-3PAPISID 字段)")
+    print("【YouTube 手动导入】(必须包含 SAPISID 字段)")
     cookie_string = input("👉 请粘贴 Cookie: ").strip()
     print("\033[F\033[K" + "👉 请粘贴 Cookie: [已接收，已脱敏掩码]")
     cookies = parse_cookie_string(cookie_string)

--- a/utils/cookies_login.py
+++ b/utils/cookies_login.py
@@ -49,7 +49,8 @@ COOKIE_FILES = {
     "kuaishou": CONFIG_DIR / 'kuaishou_cookies.json', 
     'weibo': CONFIG_DIR / 'weibo_cookies.json',
     'reddit': CONFIG_DIR / 'reddit_cookies.json',
-    'twitter': CONFIG_DIR / 'twitter_cookies.json'
+    'twitter': CONFIG_DIR / 'twitter_cookies.json',
+    'youtube': CONFIG_DIR / 'youtube_cookies.json'
 }
 
 class LoginStatus:
@@ -70,6 +71,12 @@ def mask_string(s: str) -> str:
 
 def validate_cookies(platform: str, cookies: Dict[str, str]) -> bool:
     """Core credential integrity check, preventing incomplete cookies from causing account anomalies or risk control"""
+    if platform == 'youtube':
+        if not (cookies.get('SAPISID') or cookies.get('__Secure-3PAPISID')):
+            logger.warning("⚠️ 安全拦截：YouTube Cookie 缺少 SAPISID 或 __Secure-3PAPISID！")
+            return False
+        return True
+
     required_keys = {
         'netease': ['MUSIC_U'],
         'bilibili': ['SESSDATA'],
@@ -344,6 +351,16 @@ def get_twitter_cookies(_method: str = "manual") -> Optional[Dict[str, str]]:
         save_cookies_to_file('twitter', cookies)  # noqa: ASYNC_BLOCK — CLI-only path; outer fn already blocks on input()
     return cookies
 
+def get_youtube_cookies(_method: str = "manual") -> Optional[Dict[str, str]]:
+    print("\n" + "-" * 40)
+    print("【YouTube 手动导入】(需包含 SAPISID 或 __Secure-3PAPISID 字段)")
+    cookie_string = input("👉 请粘贴 Cookie: ").strip()
+    print("\033[F\033[K" + "👉 请粘贴 Cookie: [已接收，已脱敏掩码]")
+    cookies = parse_cookie_string(cookie_string)
+    if cookies:
+        save_cookies_to_file('youtube', cookies)
+    return cookies
+
 def get_netease_cookies(_method: str = "manual") -> Optional[Dict[str, str]]:
     print("\n" + "-" * 40)
     print("【网易云音乐手动导入】(需包含 MUSIC_U 字段)")
@@ -366,7 +383,8 @@ class PlatformLoginManager:
             "kuaishou": {'name': '快手', 'methods': ['manual'], 'func': get_kuaishou_cookies},
             'weibo': {'name': '微博', 'methods': ['manual'], 'func': get_weibo_cookies},
             'reddit': {'name': 'Reddit', 'methods': ['manual'], 'func': get_reddit_cookies},
-            'twitter': {'name': 'Twitter/X', 'methods': ['manual'], 'func': get_twitter_cookies}
+            'twitter': {'name': 'Twitter/X', 'methods': ['manual'], 'func': get_twitter_cookies},
+            'youtube': {'name': 'YouTube', 'methods': ['manual'], 'func': get_youtube_cookies}
         }
     
     def login_platform(self, platform: str, method: str) -> Optional[Dict[str, str]]:

--- a/utils/language_utils.py
+++ b/utils/language_utils.py
@@ -52,6 +52,20 @@ _global_language_initialized = False
 _global_region: Optional[str] = None  # 'china' 或 'non-china'
 
 
+def _get_language_env_override() -> Optional[str]:
+    """Return a validated ``NEKO_LANGUAGE`` override, or ``None`` for auto detection."""
+    language_override = os.environ.get('NEKO_LANGUAGE', '').strip()
+    if not language_override:
+        return None
+    if is_supported_language_code(language_override):
+        return language_override
+    logger.warning(
+        "NEKO_LANGUAGE=%r 无效，支持 zh/en/ja/ko/ru/es/pt 及对应完整语言代码；回退自动语言检测",
+        language_override,
+    )
+    return None
+
+
 def _matches_lang_code(lang_lower: str, code: str, aliases: Optional[set] = None) -> bool:
     """Check whether a language string matches the given language code; supports exact codes, locale suffixes (`xx-XX`/`xx_XX`) and explicit aliases.
 
@@ -105,10 +119,26 @@ def is_supported_language_code(raw: Any) -> bool:
 def _is_china_region() -> bool:
     """
     Decide whether the current system is in the Chinese region
+
+    ``NEKO_IS_CHINA_REGION`` can explicitly override auto detection:
+    truthy values (1/true/yes/on) force the Chinese region, while falsy
+    values (0/false/no/off) force the non-Chinese region. An unset, empty,
+    or invalid value falls back to locale-based detection.
     
     Returns:
         True for the Chinese region, False otherwise
     """
+    region_override = os.environ.get('NEKO_IS_CHINA_REGION', '').strip().lower()
+    if region_override in {'1', 'true', 'yes', 'on'}:
+        return True
+    if region_override in {'0', 'false', 'no', 'off'}:
+        return False
+    if region_override:
+        logger.warning(
+            "NEKO_IS_CHINA_REGION=%r 无效，支持 1/true/yes/on 或 0/false/no/off；回退系统区域检测",
+            region_override,
+        )
+
     try:
         system_locale = locale.getlocale()[0]
         if system_locale:
@@ -269,6 +299,19 @@ def initialize_global_language() -> str:
         else:
             _global_region = 'non-china'
         logger.info(f"系统区域判断: {_global_region}")
+
+        # 显式环境变量覆盖优先于 Steam 和系统语言，主要用于启动/集成测试。
+        language_override = _get_language_env_override()
+        if language_override:
+            _global_language = normalize_language_code(language_override, format='short')
+            _global_language_full = normalize_language_code(language_override, format='full')
+            _global_language_initialized = True
+            logger.info(
+                "全局语言已由 NEKO_LANGUAGE 强制设置为: %s (full: %s)",
+                _global_language,
+                _global_language_full,
+            )
+            return _global_language
         
         # 优先级1：尝试从 Steam 获取
         steam_lang = _get_steam_language()
@@ -383,6 +426,12 @@ def refresh_global_language(language: str) -> bool:
         argument is invalid.
     """
     global _global_language, _global_language_full, _global_region, _global_language_initialized
+
+    # NEKO_LANGUAGE 是进程级强制覆盖；前端冷启动随后读取到 Steam 语言时，
+    # 不允许该晚到值把显式环境配置覆盖回去。
+    language_override = _get_language_env_override()
+    if language_override:
+        language = language_override
 
     if not language:
         return False

--- a/utils/web_scraper/__init__.py
+++ b/utils/web_scraper/__init__.py
@@ -60,6 +60,7 @@ from .trending_content import (
     _fetch_weibo_trending_fallback,
     _format_bilibili_videos,
     _format_reddit_posts,
+    _format_youtube_videos,
     _format_score,
     _format_twitter_trending,
     _format_weibo_trending,
@@ -74,6 +75,7 @@ from .trending_content import (
     format_trending_content,
     format_video_content,
 )
+from .youtube_feed import fetch_youtube_home_feed
 from .window_context import (
     _SEARCH_TEXT_WS_RE,
     _sanitize_search_text,

--- a/utils/web_scraper/trending_content.py
+++ b/utils/web_scraper/trending_content.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
 
 from ._shared import get_random_user_agent, is_china_region, logger
 from .platform_helpers import _get_bilibili_credential, _get_platform_cookies
+from .youtube_feed import fetch_youtube_home_feed
 
 async def fetch_bilibili_trending(limit: int = 30) -> Dict[str, Any]:
     """
@@ -719,8 +720,9 @@ async def _fetch_content_by_region(
                 content_key: result
             }
         
-        if not result.get('success') and result.get('error'):
-            response['error'] = result.get('error')
+        if not result.get('success'):
+            source = result.get('source') or content_key
+            response['error'] = result.get('error') or f'{source} 获取失败（无错误详情）'
         return response
             
     except Exception as e:
@@ -735,7 +737,7 @@ async def fetch_video_content(limit: int = 10) -> Dict[str, Any]:
     Fetch video content based on the user's region
     
     Chinese region: Bilibili homepage videos
-    non-Chinese region: Reddit hot posts
+    non-Chinese region: YouTube Home Feed
     
     Args:
         limit: maximum amount of content
@@ -745,11 +747,11 @@ async def fetch_video_content(limit: int = 10) -> Dict[str, Any]:
     """
     return await _fetch_content_by_region(
         china_fetch_func=fetch_bilibili_trending,
-        non_china_fetch_func=fetch_reddit_popular,
+        non_china_fetch_func=fetch_youtube_home_feed,
         limit=limit,
         content_key='video',
         china_log_msg="检测到中文区域，获取B站视频内容",
-        non_china_log_msg="检测到非中文区域，获取Reddit热门内容"
+        non_china_log_msg="检测到非中文区域，获取 YouTube 首页 Feed"
     )
 
 async def fetch_news_content(limit: int = 10) -> Dict[str, Any]:
@@ -786,6 +788,22 @@ def _format_bilibili_videos(videos: List[Dict], limit: int = 5) -> List[str]:
         output_lines.append(f"   UP主: {author}")
         if rcmd_reason:
             output_lines.append(f"   推荐理由: {rcmd_reason}")
+    output_lines.append("")
+    return output_lines
+
+def _format_youtube_videos(videos: List[Dict], limit: int = 5) -> List[str]:
+    """Format YouTube Home Feed videos."""
+    output_lines = ["【YouTube 推荐】"]
+    for i, video in enumerate(videos[:limit], 1):
+        title = video.get('title', '')
+        author = video.get('author', '')
+        view_count = video.get('view_count', '')
+        published_text = video.get('published_text', '')
+
+        output_lines.append(f"{i}. {title}")
+        details = [detail for detail in (author, view_count, published_text) if detail]
+        if details:
+            output_lines.append(f"   {' | '.join(details)}")
     output_lines.append("")
     return output_lines
 
@@ -883,7 +901,7 @@ def format_video_content(video_content: Dict[str, Any]) -> str:
     
     Formats automatically by region:
     - Chinese region: Bilibili video content
-    - non-Chinese region: Reddit post content
+    - non-Chinese region: YouTube Home Feed
     
     Args:
         video_content: result returned by fetch_video_content
@@ -902,10 +920,10 @@ def format_video_content(video_content: Dict[str, Any]) -> str:
         return "暂时无法获取视频推荐内容"
     else:
         if video_data.get('success'):
-            posts = video_data.get('posts', [])
-            output_lines = _format_reddit_posts(posts)
+            videos = video_data.get('videos', [])
+            output_lines = _format_youtube_videos(videos)
             return "\n".join(output_lines)
-        return "Unable to fetch trending posts at the moment"
+        return "Unable to fetch YouTube recommendations at the moment"
 
 def format_news_content(news_content: Dict[str, Any]) -> str:
     """

--- a/utils/web_scraper/youtube_feed.py
+++ b/utils/web_scraper/youtube_feed.py
@@ -32,6 +32,7 @@ from typing import Any, Iterator
 import httpx
 
 from utils.external_http_client import get_external_http_client
+from utils.language_utils import get_global_language_full
 
 from ._shared import get_random_user_agent, logger
 from .platform_helpers import _get_platform_cookies
@@ -39,9 +40,19 @@ from .platform_helpers import _get_platform_cookies
 
 _YOUTUBE_ORIGIN = "https://www.youtube.com"
 _HOME_BROWSE_ID = "FEwhat_to_watch"
-_ANONYMOUS_DISCOVERY_QUERY = "trending videos"
 _DEFAULT_CLIENT_NAME = "1"  # WEB
 _DEFAULT_CLIENT_VERSION = "2.20250710.01.00"
+_AUTH_HEADER_NAMES = {"Authorization", "X-Goog-AuthUser", "X-Origin"}
+_LANGUAGE_SETTINGS = {
+    "zh": ("zh-CN,zh;q=0.9,en;q=0.8", "热门视频"),
+    "zh-TW": ("zh-TW,zh;q=0.9,en;q=0.8", "熱門影片"),
+    "en": ("en-US,en;q=0.9", "trending videos"),
+    "ja": ("ja-JP,ja;q=0.9,en;q=0.8", "話題の動画"),
+    "ko": ("ko-KR,ko;q=0.9,en;q=0.8", "인기 동영상"),
+    "ru": ("ru-RU,ru;q=0.9,en;q=0.8", "популярные видео"),
+    "es": ("es-ES,es;q=0.9,en;q=0.8", "videos populares"),
+    "pt": ("pt-BR,pt;q=0.9,en;q=0.8", "vídeos em alta"),
+}
 
 
 def _format_fetch_error(exc: Exception) -> str:
@@ -228,16 +239,49 @@ def _cookie_header(cookies: dict[str, str]) -> str:
     return "; ".join(f"{key}={value}" for key, value in values.items())
 
 
+def _request_language_settings() -> tuple[str, str]:
+    """Return the YouTube request locale and localized discovery query."""
+    language = get_global_language_full()
+    if language == "zh-TW":
+        return _LANGUAGE_SETTINGS["zh-TW"]
+    short_language = language.split("-", 1)[0]
+    return _LANGUAGE_SETTINGS.get(short_language, _LANGUAGE_SETTINGS["en"])
+
+
+def _without_authentication(headers: dict[str, str]) -> dict[str, str]:
+    """Build headers for a genuinely anonymous retry or discovery request."""
+    anonymous_headers = {
+        key: value for key, value in headers.items() if key not in _AUTH_HEADER_NAMES
+    }
+    anonymous_headers["Cookie"] = _cookie_header({})
+    return anonymous_headers
+
+
 async def fetch_youtube_home_feed(limit: int = 30) -> dict[str, Any]:
     """Fetch YouTube's anonymous or signed-in homepage recommendations."""
+    client: httpx.AsyncClient | None = None
+    owns_client = False
     try:
         cookies = await asyncio.to_thread(_get_platform_cookies, "youtube")
         cookie_header = _cookie_header(cookies)
         user_agent = get_random_user_agent()
-        client = get_external_http_client()
+        accept_language, discovery_query = _request_language_settings()
+
+        # Credentialed requests must not use the process-wide shared client:
+        # httpx persists response Set-Cookie values in the client jar, which
+        # would keep deleted or changed account state alive across later calls.
+        if cookies:
+            client = httpx.AsyncClient(
+                timeout=15.0,
+                trust_env=True,
+                follow_redirects=True,
+            )
+            owns_client = True
+        else:
+            client = get_external_http_client()
 
         bootstrap_headers = {
-            "Accept-Language": "en-US,en;q=0.9",
+            "Accept-Language": accept_language,
             "Cookie": cookie_header,
             "User-Agent": user_agent,
         }
@@ -274,14 +318,34 @@ async def fetch_youtube_home_feed(limit: int = 30) -> dict[str, Any]:
                 "X-Origin": _YOUTUBE_ORIGIN,
             })
 
+        browse_url = f"{_YOUTUBE_ORIGIN}/youtubei/v1/browse"
+        browse_params = {"prettyPrint": "false", "key": api_key}
+        browse_payload = {"context": context, "browseId": _HOME_BROWSE_ID}
         response = await client.post(
-            f"{_YOUTUBE_ORIGIN}/youtubei/v1/browse",
-            params={"prettyPrint": "false", "key": api_key},
+            browse_url,
+            params=browse_params,
             headers=headers,
-            json={"context": context, "browseId": _HOME_BROWSE_ID},
+            json=browse_payload,
             timeout=15.0,
         )
-        response.raise_for_status()
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            status_code = exc.response.status_code
+            if not authorization or status_code not in {401, 403}:
+                raise
+            logger.info("YouTube 登录凭证失效，回退匿名首页 Feed")
+            client.cookies.clear()
+            headers = _without_authentication(headers)
+            authorization = ""
+            response = await client.post(
+                browse_url,
+                params=browse_params,
+                headers=headers,
+                json=browse_payload,
+                timeout=15.0,
+            )
+            response.raise_for_status()
         videos = _extract_videos(response.json(), max(1, limit))
         feed_kind = "home"
 
@@ -290,11 +354,15 @@ async def fetch_youtube_home_feed(limit: int = 30) -> dict[str, Any]:
         # public search keeps the non-login video source useful while preserving
         # the real Home Feed whenever YouTube supplies one.
         if not videos:
+            if authorization:
+                client.cookies.clear()
+                headers = _without_authentication(headers)
+                authorization = ""
             discovery_response = await client.post(
                 f"{_YOUTUBE_ORIGIN}/youtubei/v1/search",
                 params={"prettyPrint": "false", "key": api_key},
                 headers=headers,
-                json={"context": context, "query": _ANONYMOUS_DISCOVERY_QUERY},
+                json={"context": context, "query": discovery_query},
                 timeout=15.0,
             )
             discovery_response.raise_for_status()
@@ -322,3 +390,9 @@ async def fetch_youtube_home_feed(limit: int = 30) -> dict[str, Any]:
             "videos": [],
             "error": error,
         }
+    finally:
+        if owns_client and client is not None:
+            try:
+                await client.aclose()
+            except Exception:
+                logger.debug("关闭 YouTube 独立 HTTP 客户端失败", exc_info=True)

--- a/utils/web_scraper/youtube_feed.py
+++ b/utils/web_scraper/youtube_feed.py
@@ -225,7 +225,7 @@ def _extract_videos(payload: dict[str, Any], limit: int) -> list[dict[str, Any]]
 
 
 def _build_sapisid_authorization(cookies: dict[str, str], now: int | None = None) -> str:
-    sapisid = cookies.get("SAPISID") or cookies.get("__Secure-3PAPISID") or ""
+    sapisid = cookies.get("SAPISID") or ""
     if not sapisid:
         return ""
     timestamp = int(time.time()) if now is None else now
@@ -257,12 +257,39 @@ def _without_authentication(headers: dict[str, str]) -> dict[str, str]:
     return anonymous_headers
 
 
+def _youtube_confirms_authentication(
+    payload: dict[str, Any],
+    bootstrap_config: dict[str, Any],
+    *,
+    auth_sent: bool,
+) -> bool:
+    """Return true only when YouTube explicitly reports a signed-in session."""
+    if not auth_sent:
+        return False
+
+    response_context = payload.get("responseContext", {})
+    if isinstance(response_context, dict):
+        web_context = response_context.get("mainAppWebResponseContext", {})
+        if isinstance(web_context, dict):
+            logged_out = web_context.get("loggedOut")
+            if isinstance(logged_out, bool):
+                return not logged_out
+
+    logged_in = bootstrap_config.get("LOGGED_IN")
+    return logged_in if isinstance(logged_in, bool) else False
+
+
 async def fetch_youtube_home_feed(limit: int = 30) -> dict[str, Any]:
     """Fetch YouTube's anonymous or signed-in homepage recommendations."""
     client: httpx.AsyncClient | None = None
     owns_client = False
     try:
         cookies = await asyncio.to_thread(_get_platform_cookies, "youtube")
+        logger.info(
+            "YouTube 凭证状态: cookie_count=%d, sapisid_present=%s",
+            len(cookies),
+            bool(cookies.get("SAPISID")),
+        )
         cookie_header = _cookie_header(cookies)
         user_agent = get_random_user_agent()
         accept_language, discovery_query = _request_language_settings()
@@ -311,6 +338,7 @@ async def fetch_youtube_home_feed(limit: int = 30) -> dict[str, Any]:
             headers["X-Goog-Visitor-Id"] = str(visitor_data)
 
         authorization = _build_sapisid_authorization(cookies)
+        auth_requested = bool(authorization)
         if authorization:
             headers.update({
                 "Authorization": authorization,
@@ -334,7 +362,10 @@ async def fetch_youtube_home_feed(limit: int = 30) -> dict[str, Any]:
             status_code = exc.response.status_code
             if not authorization or status_code not in {401, 403}:
                 raise
-            logger.info("YouTube 登录凭证失效，回退匿名首页 Feed")
+            logger.warning(
+                "YouTube 登录认证被拒绝(status=%d)，重试匿名首页 Feed",
+                status_code,
+            )
             client.cookies.clear()
             headers = _without_authentication(headers)
             authorization = ""
@@ -346,7 +377,13 @@ async def fetch_youtube_home_feed(limit: int = 30) -> dict[str, Any]:
                 timeout=15.0,
             )
             response.raise_for_status()
-        videos = _extract_videos(response.json(), max(1, limit))
+        browse_data = response.json()
+        authenticated = _youtube_confirms_authentication(
+            browse_data,
+            config,
+            auth_sent=bool(authorization),
+        )
+        videos = _extract_videos(browse_data, max(1, limit))
         feed_kind = "home"
 
         # YouTube currently returns an intentionally empty Home tab for some
@@ -354,10 +391,17 @@ async def fetch_youtube_home_feed(limit: int = 30) -> dict[str, Any]:
         # public search keeps the non-login video source useful while preserving
         # the real Home Feed whenever YouTube supplies one.
         if not videos:
+            logger.warning(
+                "YouTube Home Feed 未返回可解析视频，切换匿名 public_discovery: "
+                "auth_requested=%s, auth_confirmed=%s",
+                auth_requested,
+                authenticated,
+            )
             if authorization:
                 client.cookies.clear()
                 headers = _without_authentication(headers)
                 authorization = ""
+            authenticated = False
             discovery_response = await client.post(
                 f"{_YOUTUBE_ORIGIN}/youtubei/v1/search",
                 params={"prettyPrint": "false", "key": api_key},
@@ -372,11 +416,20 @@ async def fetch_youtube_home_feed(limit: int = 30) -> dict[str, Any]:
         if not videos:
             raise ValueError("YouTube returned no Home Feed or public discovery videos")
 
+        logger.info(
+            "YouTube Feed 获取成功: feed_kind=%s, auth_requested=%s, "
+            "auth_confirmed=%s, videos=%d",
+            feed_kind,
+            auth_requested,
+            authenticated,
+            len(videos),
+        )
+
         return {
             "success": True,
             "source": "youtube",
             "feed_kind": feed_kind,
-            "authenticated": bool(authorization),
+            "authenticated": authenticated,
             "videos": videos,
         }
     except Exception as exc:

--- a/utils/web_scraper/youtube_feed.py
+++ b/utils/web_scraper/youtube_feed.py
@@ -1,0 +1,324 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""YouTube Home Feed fetcher backed by the web Innertube API.
+
+This mirrors the small part of youtubei.js that N.E.K.O. needs: bootstrap the
+web client configuration from youtube.com, then browse ``FEwhat_to_watch``.
+Stored YouTube cookies are optional.  When SAPISID-compatible credentials are
+present the request carries SAPISIDHASH and returns the signed-in home feed;
+otherwise YouTube's anonymous home feed is used, with public discovery as a
+fallback when YouTube intentionally leaves the signed-out Home tab empty.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import time
+from typing import Any, Iterator
+
+import httpx
+
+from utils.external_http_client import get_external_http_client
+
+from ._shared import get_random_user_agent, logger
+from .platform_helpers import _get_platform_cookies
+
+
+_YOUTUBE_ORIGIN = "https://www.youtube.com"
+_HOME_BROWSE_ID = "FEwhat_to_watch"
+_ANONYMOUS_DISCOVERY_QUERY = "trending videos"
+_DEFAULT_CLIENT_NAME = "1"  # WEB
+_DEFAULT_CLIENT_VERSION = "2.20250710.01.00"
+
+
+def _format_fetch_error(exc: Exception) -> str:
+    """Return a useful error even when httpx exceptions have an empty message."""
+    error_name = type(exc).__name__
+    detail = str(exc).strip()
+    if detail:
+        return f"{error_name}: {detail}"
+    if isinstance(exc, httpx.TimeoutException):
+        return (
+            f"{error_name}: 连接 YouTube 超时，请检查 HTTPS_PROXY/ALL_PROXY "
+            "或桌面端系统代理设置"
+        )
+    if isinstance(exc, httpx.ConnectError):
+        return f"{error_name}: 无法连接 YouTube，请检查网络或代理设置"
+    return error_name
+
+
+def _extract_ytcfg(html: str) -> dict[str, Any]:
+    """Merge JSON objects passed to ``ytcfg.set(...)`` in the bootstrap page."""
+    config: dict[str, Any] = {}
+    decoder = json.JSONDecoder()
+    marker = "ytcfg.set("
+    cursor = 0
+
+    while True:
+        marker_index = html.find(marker, cursor)
+        if marker_index < 0:
+            break
+        value_index = marker_index + len(marker)
+        while value_index < len(html) and html[value_index].isspace():
+            value_index += 1
+        try:
+            value, consumed = decoder.raw_decode(html[value_index:])
+            if isinstance(value, dict):
+                config.update(value)
+            cursor = value_index + consumed
+        except (json.JSONDecodeError, ValueError):
+            cursor = value_index + 1
+
+    return config
+
+
+def _text(value: Any) -> str:
+    if not isinstance(value, dict):
+        return ""
+    simple = value.get("simpleText")
+    if isinstance(simple, str):
+        return simple.strip()
+    runs = value.get("runs")
+    if isinstance(runs, list):
+        return "".join(
+            run.get("text", "") for run in runs if isinstance(run, dict)
+        ).strip()
+    content = value.get("content")
+    return content.strip() if isinstance(content, str) else ""
+
+
+def _thumbnail_sources(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, dict):
+        return []
+    sources = value.get("thumbnails") or value.get("sources")
+    if isinstance(sources, list):
+        return [source for source in sources if isinstance(source, dict) and source.get("url")]
+    for child in value.values():
+        found = _thumbnail_sources(child)
+        if found:
+            return found
+    return []
+
+
+def _walk_renderers(value: Any) -> Iterator[tuple[str, dict[str, Any]]]:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key in {
+                "videoRenderer",
+                "gridVideoRenderer",
+                "compactVideoRenderer",
+                "reelItemRenderer",
+                "lockupViewModel",
+            } and isinstance(child, dict):
+                yield key, child
+            yield from _walk_renderers(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk_renderers(child)
+
+
+def _parse_classic_renderer(renderer: dict[str, Any], *, is_short: bool = False) -> dict[str, Any] | None:
+    video_id = renderer.get("videoId")
+    if not isinstance(video_id, str) or not video_id:
+        return None
+
+    title = _text(renderer.get("title")) or _text(renderer.get("headline"))
+    if not title:
+        return None
+
+    thumbnails = _thumbnail_sources(renderer.get("thumbnail", {}))
+    return {
+        "video_id": video_id,
+        "title": title,
+        "author": _text(renderer.get("ownerText")) or _text(renderer.get("longBylineText")),
+        "url": f"{_YOUTUBE_ORIGIN}/watch?v={video_id}",
+        "duration": _text(renderer.get("lengthText")),
+        "view_count": _text(renderer.get("viewCountText")) or _text(renderer.get("shortViewCountText")),
+        "published_text": _text(renderer.get("publishedTimeText")),
+        "thumbnail": thumbnails[-1].get("url", "") if thumbnails else "",
+        "thumbnails": thumbnails,
+        "rcmd_reason": _text(renderer.get("reelWatchEndpoint", {}).get("overlay", {})),
+        "source": "YouTube",
+        "is_short": is_short,
+    }
+
+
+def _parse_lockup_view_model(renderer: dict[str, Any]) -> dict[str, Any] | None:
+    """Parse the newer Polymer lockup representation used by YouTube Home."""
+    video_id = renderer.get("contentId")
+    content_type = renderer.get("contentType", "")
+    if not isinstance(video_id, str) or not video_id or "VIDEO" not in str(content_type):
+        return None
+
+    metadata = renderer.get("metadata", {}).get("lockupMetadataViewModel", {})
+    title = _text(metadata.get("title"))
+    if not title:
+        return None
+
+    metadata_texts: list[str] = []
+    rows = metadata.get("metadata", {}).get("contentMetadataViewModel", {}).get("metadataRows", [])
+    for row in rows if isinstance(rows, list) else []:
+        parts = row.get("metadataParts", []) if isinstance(row, dict) else []
+        for part in parts if isinstance(parts, list) else []:
+            part_text = _text(part.get("text", {})) if isinstance(part, dict) else ""
+            if part_text:
+                metadata_texts.append(part_text)
+
+    thumbnails = _thumbnail_sources(renderer.get("contentImage", {}))
+    return {
+        "video_id": video_id,
+        "title": title,
+        "author": metadata_texts[0] if metadata_texts else "",
+        "url": f"{_YOUTUBE_ORIGIN}/watch?v={video_id}",
+        "duration": "",
+        "view_count": metadata_texts[1] if len(metadata_texts) > 1 else "",
+        "published_text": metadata_texts[2] if len(metadata_texts) > 2 else "",
+        "thumbnail": thumbnails[-1].get("url", "") if thumbnails else "",
+        "thumbnails": thumbnails,
+        "rcmd_reason": "",
+        "source": "YouTube",
+        "is_short": False,
+    }
+
+
+def _extract_videos(payload: dict[str, Any], limit: int) -> list[dict[str, Any]]:
+    videos: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    for renderer_name, renderer in _walk_renderers(payload):
+        if renderer_name == "lockupViewModel":
+            video = _parse_lockup_view_model(renderer)
+        else:
+            video = _parse_classic_renderer(renderer, is_short=renderer_name == "reelItemRenderer")
+        if not video or video["video_id"] in seen:
+            continue
+        seen.add(video["video_id"])
+        videos.append(video)
+        if len(videos) >= limit:
+            break
+
+    return videos
+
+
+def _build_sapisid_authorization(cookies: dict[str, str], now: int | None = None) -> str:
+    sapisid = cookies.get("SAPISID") or cookies.get("__Secure-3PAPISID") or ""
+    if not sapisid:
+        return ""
+    timestamp = int(time.time()) if now is None else now
+    digest = hashlib.sha1(f"{timestamp} {sapisid} {_YOUTUBE_ORIGIN}".encode("utf-8")).hexdigest()
+    return f"SAPISIDHASH {timestamp}_{digest}"
+
+
+def _cookie_header(cookies: dict[str, str]) -> str:
+    values = dict(cookies)
+    values.setdefault("CONSENT", "YES+cb.20210328-17-p0.en+FX+")
+    return "; ".join(f"{key}={value}" for key, value in values.items())
+
+
+async def fetch_youtube_home_feed(limit: int = 30) -> dict[str, Any]:
+    """Fetch YouTube's anonymous or signed-in homepage recommendations."""
+    try:
+        cookies = await asyncio.to_thread(_get_platform_cookies, "youtube")
+        cookie_header = _cookie_header(cookies)
+        user_agent = get_random_user_agent()
+        client = get_external_http_client()
+
+        bootstrap_headers = {
+            "Accept-Language": "en-US,en;q=0.9",
+            "Cookie": cookie_header,
+            "User-Agent": user_agent,
+        }
+        bootstrap = await client.get(_YOUTUBE_ORIGIN, headers=bootstrap_headers, timeout=12.0)
+        bootstrap.raise_for_status()
+        config = _extract_ytcfg(bootstrap.text)
+
+        api_key = config.get("INNERTUBE_API_KEY")
+        context = config.get("INNERTUBE_CONTEXT")
+        if not isinstance(api_key, str) or not api_key or not isinstance(context, dict):
+            raise ValueError("YouTube bootstrap page did not expose Innertube configuration")
+
+        client_config = context.get("client", {}) if isinstance(context.get("client"), dict) else {}
+        client_name = str(config.get("INNERTUBE_CONTEXT_CLIENT_NAME") or _DEFAULT_CLIENT_NAME)
+        client_version = str(client_config.get("clientVersion") or _DEFAULT_CLIENT_VERSION)
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "Cookie": cookie_header,
+            "Origin": _YOUTUBE_ORIGIN,
+            "User-Agent": user_agent,
+            "X-YouTube-Client-Name": client_name,
+            "X-YouTube-Client-Version": client_version,
+        }
+        visitor_data = client_config.get("visitorData") or config.get("VISITOR_DATA")
+        if visitor_data:
+            headers["X-Goog-Visitor-Id"] = str(visitor_data)
+
+        authorization = _build_sapisid_authorization(cookies)
+        if authorization:
+            headers.update({
+                "Authorization": authorization,
+                "X-Goog-AuthUser": "0",
+                "X-Origin": _YOUTUBE_ORIGIN,
+            })
+
+        response = await client.post(
+            f"{_YOUTUBE_ORIGIN}/youtubei/v1/browse",
+            params={"prettyPrint": "false", "key": api_key},
+            headers=headers,
+            json={"context": context, "browseId": _HOME_BROWSE_ID},
+            timeout=15.0,
+        )
+        response.raise_for_status()
+        videos = _extract_videos(response.json(), max(1, limit))
+        feed_kind = "home"
+
+        # YouTube currently returns an intentionally empty Home tab for some
+        # signed-out users (and for accounts with watch history disabled).  A
+        # public search keeps the non-login video source useful while preserving
+        # the real Home Feed whenever YouTube supplies one.
+        if not videos:
+            discovery_response = await client.post(
+                f"{_YOUTUBE_ORIGIN}/youtubei/v1/search",
+                params={"prettyPrint": "false", "key": api_key},
+                headers=headers,
+                json={"context": context, "query": _ANONYMOUS_DISCOVERY_QUERY},
+                timeout=15.0,
+            )
+            discovery_response.raise_for_status()
+            videos = _extract_videos(discovery_response.json(), max(1, limit))
+            feed_kind = "public_discovery"
+
+        if not videos:
+            raise ValueError("YouTube returned no Home Feed or public discovery videos")
+
+        return {
+            "success": True,
+            "source": "youtube",
+            "feed_kind": feed_kind,
+            "authenticated": bool(authorization),
+            "videos": videos,
+        }
+    except Exception as exc:
+        error = _format_fetch_error(exc)
+        logger.warning(f"获取 YouTube 首页 Feed 失败: {error}")
+        return {
+            "success": False,
+            "source": "youtube",
+            "feed_kind": "unavailable",
+            "authenticated": False,
+            "videos": [],
+            "error": error,
+        }


### PR DESCRIPTION
## 改动概述 / Summary

- 为非中文区域接入基于 Web Innertube 的 YouTube 首页 Feed，支持登录态个性化推荐和非登录态公共内容回退，无需静态 YouTube API Key。
- 视频分类按地区选择内容源：中国区域继续使用 B 站，非中国区域使用 YouTube。
- 增加 `NEKO_IS_CHINA_REGION` 和 `NEKO_LANGUAGE` 环境变量，便于部署和本地测试时覆盖地区、语言自动检测。
- 将 YouTube 纳入现有 Cookie 凭证管理页面、校验、加密存储和多语言文案，并补充主动搭话链接来源处理。
- 忽略运行时生成的 `config/*_key.key` Cookie 加密密钥，避免本地密钥进入版本控制。

<img width="800" height="689" alt="42ec398d8344df0769889143ebf83a4f" src="https://github.com/user-attachments/assets/909b9904-cf63-4730-85fc-2cc84745b856" />

## 回归报告 / Regression Report

不适用。本 PR 未修改 `app/`、`main_logic/` 或 `memory/` 下的 Python 文件。

## 不拆分理由 / Why Not Split

不适用。扣除新增文件、i18n locale 文件和测试文件后，计入上限的改动文件数不超过 20。

## 测试 / Testing

- `python -m pytest -p no:cacheprovider tests/unit/test_youtube_feed.py tests/unit/test_language_region_override.py tests/unit/test_language_env_override.py -q`：29 passed。
- `python -m ruff check --no-cache ...`：通过。
- `node --test static/app-proactive.test.cjs`：2 passed。
- 手动使用 `NEKO_IS_CHINA_REGION=false` 和终端代理启动，确认能够加载加密的 YouTube 凭证并获取首页 Feed。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 增加 YouTube Cookie 登录支持：支持手动导入/保存，并在 Cookie 登录界面提供多语言指引与“整段 Cookie”输入方式（要求包含 SAPISID）。
  * 非中国区域的视频推荐切换到 YouTube 首页 Feed：解析失败时回退到公开发现，并更新来源标注。
* **变更**
  * 个人动态可用平台筛选改为白名单限定，YouTube 不再影响无关的个人动态模式。
* **问题修复**
  * 强化 YouTube 相关校验、Cookie 提交与抓取/日志错误描述；模板静态资源版本号改为动态注入。
* **测试**
  * 新增 YouTube 抓取/鉴权/格式化、以及语言环境覆盖与区域判断相关单元测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->