### PR TITLE
fix(tutorial): 修复跨窗口新手引导竞态与状态恢复

### DIFF
--- a/static/app/app-interpage/cross-window-broadcast-and-bridge.js
+++ b/static/app/app-interpage/cross-window-broadcast-and-bridge.js
@@ -773,14 +773,16 @@
                     pcOverlayRunId: I.getYuiGuidePcOverlayRunIdFromMessage(message),
                     timestamp: I.getYuiGuideBridgeMessageTimestamp(message)
                 };
-                I.applyYuiGuideChatCursor(cursorKind, cursorOptions);
+                var cursorApplied = I.applyYuiGuideChatCursor(cursorKind, cursorOptions);
                 // applyYuiGuideChatCursor owns the request generation. Capture its resulting token so
                 // the post-expansion retry remains current until a newer cursor command supersedes it.
                 var cursorRequestToken = I.yuiGuideChatCursorRequestToken;
-                var retryCursorOptions = Object.assign({}, cursorOptions, {
-                    effect: '',
-                    effectDurationMs: 0
-                });
+                var retryCursorOptions = cursorApplied
+                    ? Object.assign({}, cursorOptions, {
+                        effect: '',
+                        effectDurationMs: 0
+                    })
+                    : cursorOptions;
                 if (expandedForCursor && cursorOptions.freezePoint !== true) {
                     window.setTimeout(function () {
                         if (cursorRequestToken !== I.yuiGuideChatCursorRequestToken) {

--- a/static/app/app-interpage/cross-window-broadcast-and-bridge.js
+++ b/static/app/app-interpage/cross-window-broadcast-and-bridge.js
@@ -777,7 +777,7 @@
                 // applyYuiGuideChatCursor owns the request generation. Capture its resulting token so
                 // the post-expansion retry remains current until a newer cursor command supersedes it.
                 var cursorRequestToken = I.yuiGuideChatCursorRequestToken;
-                var retryCursorOptions = cursorApplied
+                var retryCursorOptions = cursorApplied && cursorOptions.effect === 'click'
                     ? Object.assign({}, cursorOptions, {
                         effect: '',
                         effectDurationMs: 0

--- a/static/app/app-interpage/cross-window-broadcast-and-bridge.js
+++ b/static/app/app-interpage/cross-window-broadcast-and-bridge.js
@@ -756,7 +756,6 @@
             case 'yui_guide_set_chat_cursor': {
                 if (!I.isStandaloneChatPage() || !document.body) return true;
                 var expandedForCursor = I.ensureYuiGuideExternalChatExpanded();
-                var cursorRequestToken = ++I.yuiGuideChatCursorRequestToken;
                 var cursorKind = message.kind || '';
                 var cursorOptions = {
                     effect: message.effect || '',
@@ -775,12 +774,19 @@
                     timestamp: I.getYuiGuideBridgeMessageTimestamp(message)
                 };
                 I.applyYuiGuideChatCursor(cursorKind, cursorOptions);
+                // applyYuiGuideChatCursor owns the request generation. Capture its resulting token so
+                // the post-expansion retry remains current until a newer cursor command supersedes it.
+                var cursorRequestToken = I.yuiGuideChatCursorRequestToken;
+                var retryCursorOptions = Object.assign({}, cursorOptions, {
+                    effect: '',
+                    effectDurationMs: 0
+                });
                 if (expandedForCursor && cursorOptions.freezePoint !== true) {
                     window.setTimeout(function () {
                         if (cursorRequestToken !== I.yuiGuideChatCursorRequestToken) {
                             return;
                         }
-                        I.applyYuiGuideChatCursor(cursorKind, cursorOptions);
+                        I.applyYuiGuideChatCursor(cursorKind, retryCursorOptions);
                     }, 720);
                 }
                 return true;

--- a/static/app/app-interpage/guide-overlay.js
+++ b/static/app/app-interpage/guide-overlay.js
@@ -22,6 +22,7 @@
     I.YUI_GUIDE_EXTERNAL_CHAT_CURSOR_SCREEN_POINT_KEY = 'neko_yui_guide_external_chat_cursor_screen_point_v1';
     var YUI_GUIDE_PC_OVERLAY_SEQUENCE_KEY = 'yuiGuidePcOverlaySequence';
     var YUI_GUIDE_PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES = 3;
+    var YUI_GUIDE_PC_OVERLAY_MAX_TOTAL_SAME_RUN_STALE_RETRIES = 6;
     var YUI_GUIDE_PC_OVERLAY_DEFERRED_RECONCILIATION_DELAY_MS = 48;
     I.yuiGuidePcOverlayActive = false;
     I.yuiGuidePcOverlayReady = false;
@@ -316,11 +317,22 @@
         }
     }
 
+    function readStoredYuiGuidePcOverlaySequence() {
+        try {
+            return Math.max(
+                0,
+                Math.floor(Number(window.localStorage.getItem(YUI_GUIDE_PC_OVERLAY_SEQUENCE_KEY)) || 0)
+            );
+        } catch (_) {
+            return 0;
+        }
+    }
+
     function scheduleYuiGuidePcOverlayDeferredReconciliation(
-        patch,
         attemptedRunId,
         retryCount,
-        attemptedLifecycleEpoch
+        attemptedLifecycleEpoch,
+        attemptedSequence
     ) {
         clearYuiGuidePcOverlayDeferredReconciliation();
         yuiGuidePcOverlayDeferredReconciliationTimer = window.setTimeout(function () {
@@ -328,10 +340,11 @@
             if (
                 I.yuiGuidePcOverlayLifecycleClosed
                 || attemptedLifecycleEpoch !== yuiGuidePcOverlayLifecycleEpoch
+                || readStoredYuiGuidePcOverlaySequence() > attemptedSequence
             ) {
                 return;
             }
-            I.sendYuiGuidePcOverlayPatch(patch || {}, retryCount, {
+            I.sendYuiGuidePcOverlayPatch({}, retryCount + 1, {
                 tutorialRunId: attemptedRunId
             });
         }, YUI_GUIDE_PC_OVERLAY_DEFERRED_RECONCILIATION_DELAY_MS);
@@ -389,12 +402,12 @@
                 I.sendYuiGuidePcOverlayPatch(patch || {}, retryCount + 1, {
                     tutorialRunId: attemptedRunId
                 });
-            } else if (retryCount === YUI_GUIDE_PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES) {
+            } else if (retryCount < YUI_GUIDE_PC_OVERLAY_MAX_TOTAL_SAME_RUN_STALE_RETRIES) {
                 scheduleYuiGuidePcOverlayDeferredReconciliation(
-                    patch,
                     attemptedRunId,
                     retryCount,
-                    attemptedLifecycleEpoch
+                    attemptedLifecycleEpoch,
+                    attemptedSequence
                 );
             }
             return;
@@ -441,15 +454,7 @@
     function nextYuiGuidePcOverlaySequence(minimumSequence) {
         var wallSequence = Date.now() * 1000;
         var sequenceFloor = Math.max(0, Math.floor(Number(minimumSequence) || 0));
-        var storedSequence = 0;
-        try {
-            storedSequence = Math.max(
-                0,
-                Math.floor(Number(window.localStorage.getItem(YUI_GUIDE_PC_OVERLAY_SEQUENCE_KEY)) || 0)
-            );
-        } catch (_) {
-            storedSequence = 0;
-        }
+        var storedSequence = readStoredYuiGuidePcOverlaySequence();
 
         yuiGuidePcOverlaySequence = Math.max(
             yuiGuidePcOverlaySequence + 1,

--- a/static/app/app-interpage/guide-overlay.js
+++ b/static/app/app-interpage/guide-overlay.js
@@ -21,6 +21,7 @@
     I.yuiGuideChatSpotlightTimer = 0;
     I.YUI_GUIDE_EXTERNAL_CHAT_CURSOR_SCREEN_POINT_KEY = 'neko_yui_guide_external_chat_cursor_screen_point_v1';
     var YUI_GUIDE_PC_OVERLAY_SEQUENCE_KEY = 'yuiGuidePcOverlaySequence';
+    var YUI_GUIDE_PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES = 3;
     I.yuiGuidePcOverlayActive = false;
     I.yuiGuidePcOverlayReady = false;
     I.yuiGuidePcOverlayRunIdOverride = '';
@@ -307,7 +308,7 @@
 
     function handleYuiGuidePcOverlayStaleResult(result, patch, attemptedRunId, retried, attemptedLifecycleEpoch) {
         var isStaleResponse = !!(result && result.stale === true);
-        var alreadyRetried = retried === true;
+        var retryCount = Math.max(0, Math.floor(Number(retried) || 0));
         if (
             I.yuiGuidePcOverlayLifecycleClosed
             || attemptedLifecycleEpoch !== yuiGuidePcOverlayLifecycleEpoch
@@ -326,7 +327,7 @@
 
         if (
             isStaleResponse
-            && !alreadyRetried
+            && retryCount < YUI_GUIDE_PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES
             && result.reason === 'stale-sequence'
             && result.activeTutorialRunId === attemptedRunId
             && (
@@ -335,29 +336,29 @@
             )
         ) {
             yuiGuidePcOverlaySequence = nextYuiGuidePcOverlaySequence(result.activeSequence);
-            I.sendYuiGuidePcOverlayPatch(patch || {}, true, {
+            I.sendYuiGuidePcOverlayPatch(patch || {}, retryCount + 1, {
                 tutorialRunId: attemptedRunId
             });
             return;
         }
 
-        if (!isStaleResponse || alreadyRetried || !attemptedRunId) {
+        if (!isStaleResponse || retryCount > 0 || !attemptedRunId) {
             return;
         }
         if (attemptedCanonicalRun) {
             if (syncYuiGuidePcOverlayRunIdFromStorage()) {
-                I.sendYuiGuidePcOverlayPatch(patch || {}, true);
+                I.sendYuiGuidePcOverlayPatch(patch || {}, retryCount + 1);
                 return;
             }
         } else if (!attemptedCurrentRun || !attemptedChatOwnedRun) {
             return;
         }
         if (syncYuiGuidePcOverlayRunIdFromStorage()) {
-            I.sendYuiGuidePcOverlayPatch(patch || {}, true);
+            I.sendYuiGuidePcOverlayPatch(patch || {}, retryCount + 1);
             return;
         }
         resetYuiGuidePcOverlayRunForRetry();
-        I.sendYuiGuidePcOverlayPatch(patch || {}, true);
+        I.sendYuiGuidePcOverlayPatch(patch || {}, retryCount + 1);
     }
 
     function resolveYuiGuidePcOverlayRunIdForSend(requestedRunId, allowCreateRun) {
@@ -776,7 +777,7 @@
                         result,
                         patch,
                         runId,
-                        retried === true,
+                        retried,
                         sendLifecycleEpoch
                     );
                     return;

--- a/static/app/app-interpage/guide-overlay.js
+++ b/static/app/app-interpage/guide-overlay.js
@@ -329,6 +329,10 @@
             && !alreadyRetried
             && result.reason === 'stale-sequence'
             && result.activeTutorialRunId === attemptedRunId
+            && (
+                attemptedCanonicalRun
+                || (attemptedCurrentRun && attemptedChatOwnedRun)
+            )
         ) {
             yuiGuidePcOverlaySequence = nextYuiGuidePcOverlaySequence(result.activeSequence);
             I.sendYuiGuidePcOverlayPatch(patch || {}, true, {
@@ -736,13 +740,7 @@
                         return;
                     }
                     if (result && result.stale === true) {
-                        handleYuiGuidePcOverlayStaleResult(
-                            result,
-                            patch,
-                            runId,
-                            retried === true,
-                            sendLifecycleEpoch
-                        );
+                        // The paired update carries the state and owns stale retries.
                         return;
                     }
                     if (result && result.ok === false) {

--- a/static/app/app-interpage/guide-overlay.js
+++ b/static/app/app-interpage/guide-overlay.js
@@ -324,6 +324,19 @@
             && !attemptedChatOwnedRun
         );
 
+        if (
+            isStaleResponse
+            && !alreadyRetried
+            && result.reason === 'stale-sequence'
+            && result.activeTutorialRunId === attemptedRunId
+        ) {
+            yuiGuidePcOverlaySequence = nextYuiGuidePcOverlaySequence(result.activeSequence);
+            I.sendYuiGuidePcOverlayPatch(patch || {}, true, {
+                tutorialRunId: attemptedRunId
+            });
+            return;
+        }
+
         if (!isStaleResponse || alreadyRetried || !attemptedRunId) {
             return;
         }
@@ -362,8 +375,9 @@
             : getYuiGuidePcOverlayRunId();
     }
 
-    function nextYuiGuidePcOverlaySequence() {
+    function nextYuiGuidePcOverlaySequence(minimumSequence) {
         var wallSequence = Date.now() * 1000;
+        var sequenceFloor = Math.max(0, Math.floor(Number(minimumSequence) || 0));
         var storedSequence = 0;
         try {
             storedSequence = Math.max(
@@ -377,6 +391,7 @@
         yuiGuidePcOverlaySequence = Math.max(
             yuiGuidePcOverlaySequence + 1,
             storedSequence + 1,
+            sequenceFloor + 1,
             wallSequence
         );
         try {

--- a/static/app/app-interpage/guide-overlay.js
+++ b/static/app/app-interpage/guide-overlay.js
@@ -331,7 +331,7 @@
             ) {
                 return;
             }
-            I.sendYuiGuidePcOverlayPatch(patch || {}, retryCount + 1, {
+            I.sendYuiGuidePcOverlayPatch(patch || {}, retryCount, {
                 tutorialRunId: attemptedRunId
             });
         }, YUI_GUIDE_PC_OVERLAY_DEFERRED_RECONCILIATION_DELAY_MS);
@@ -354,6 +354,15 @@
         ) {
             return;
         }
+        var activeSequence = Math.max(0, Math.floor(Number(result && result.activeSequence) || 0));
+        if (
+            isStaleResponse
+            && result.reason === 'stale-sequence'
+            && result.activeTutorialRunId === attemptedRunId
+            && activeSequence > attemptedSequence
+        ) {
+            return;
+        }
         var attemptedCurrentRun = !!(attemptedRunId && attemptedRunId === I.yuiGuidePcOverlayRunIdOverride);
         var attemptedChatOwnedRun = isYuiGuideChatOwnedPcOverlayRunId(attemptedRunId);
         var storedCanonicalRunId = readStoredYuiGuidePcOverlayRunId();
@@ -367,6 +376,7 @@
             isStaleResponse
             && result.reason === 'stale-sequence'
             && result.activeTutorialRunId === attemptedRunId
+            && activeSequence === attemptedSequence
             && (
                 attemptedCanonicalRun
                 || (attemptedCurrentRun && attemptedChatOwnedRun)

--- a/static/app/app-interpage/guide-overlay.js
+++ b/static/app/app-interpage/guide-overlay.js
@@ -22,7 +22,7 @@
     I.YUI_GUIDE_EXTERNAL_CHAT_CURSOR_SCREEN_POINT_KEY = 'neko_yui_guide_external_chat_cursor_screen_point_v1';
     var YUI_GUIDE_PC_OVERLAY_SEQUENCE_KEY = 'yuiGuidePcOverlaySequence';
     var YUI_GUIDE_PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES = 3;
-    var YUI_GUIDE_PC_OVERLAY_MAX_TOTAL_SAME_RUN_STALE_RETRIES = 6;
+    var YUI_GUIDE_PC_OVERLAY_MAX_TOTAL_STALE_RETRIES = 6;
     var YUI_GUIDE_PC_OVERLAY_DEFERRED_RECONCILIATION_DELAY_MS = 48;
     I.yuiGuidePcOverlayActive = false;
     I.yuiGuidePcOverlayReady = false;
@@ -402,7 +402,30 @@
                 I.sendYuiGuidePcOverlayPatch(patch || {}, retryCount + 1, {
                     tutorialRunId: attemptedRunId
                 });
-            } else if (retryCount < YUI_GUIDE_PC_OVERLAY_MAX_TOTAL_SAME_RUN_STALE_RETRIES) {
+            } else if (retryCount < YUI_GUIDE_PC_OVERLAY_MAX_TOTAL_STALE_RETRIES) {
+                scheduleYuiGuidePcOverlayDeferredReconciliation(
+                    attemptedRunId,
+                    retryCount,
+                    attemptedLifecycleEpoch,
+                    attemptedSequence
+                );
+            }
+            return;
+        }
+
+        var attemptedOwnedRun = !!(
+            attemptedCanonicalRun
+            || (attemptedCurrentRun && attemptedChatOwnedRun)
+        );
+        var isDifferentRunStale = !!(
+            isStaleResponse
+            && result.activeTutorialRunId
+            && result.activeTutorialRunId !== attemptedRunId
+        );
+        if (isDifferentRunStale && retryCount > 0) {
+            if (attemptedOwnedRun && retryCount < YUI_GUIDE_PC_OVERLAY_MAX_TOTAL_STALE_RETRIES) {
+                I.yuiGuidePcOverlayActive = false;
+                I.yuiGuidePcOverlayReady = false;
                 scheduleYuiGuidePcOverlayDeferredReconciliation(
                     attemptedRunId,
                     retryCount,

--- a/static/app/app-interpage/guide-overlay.js
+++ b/static/app/app-interpage/guide-overlay.js
@@ -22,6 +22,7 @@
     I.YUI_GUIDE_EXTERNAL_CHAT_CURSOR_SCREEN_POINT_KEY = 'neko_yui_guide_external_chat_cursor_screen_point_v1';
     var YUI_GUIDE_PC_OVERLAY_SEQUENCE_KEY = 'yuiGuidePcOverlaySequence';
     var YUI_GUIDE_PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES = 3;
+    var YUI_GUIDE_PC_OVERLAY_DEFERRED_RECONCILIATION_DELAY_MS = 48;
     I.yuiGuidePcOverlayActive = false;
     I.yuiGuidePcOverlayReady = false;
     I.yuiGuidePcOverlayRunIdOverride = '';
@@ -30,6 +31,7 @@
     I.yuiGuidePcOverlayLifecycleClosed = false;
     var yuiGuidePcOverlayLifecycleRunId = '';
     var yuiGuidePcOverlaySequence = 0;
+    var yuiGuidePcOverlayDeferredReconciliationTimer = 0;
     I.yuiGuidePcOverlaySpotlights = [];
     I.yuiGuidePcOverlayCursor = null;
     I.yuiGuideChatSpotlightLastPcKind = '';
@@ -273,6 +275,7 @@
     }
 
     I.closeYuiGuidePcOverlayLifecycle = function closeYuiGuidePcOverlayLifecycle() {
+        clearYuiGuidePcOverlayDeferredReconciliation();
         yuiGuidePcOverlayLifecycleEpoch += 1;
         I.yuiGuidePcOverlayLifecycleClosed = true;
         yuiGuidePcOverlayLifecycleRunId = '';
@@ -306,12 +309,48 @@
         } catch (_) {}
     }
 
-    function handleYuiGuidePcOverlayStaleResult(result, patch, attemptedRunId, retried, attemptedLifecycleEpoch) {
+    function clearYuiGuidePcOverlayDeferredReconciliation() {
+        if (yuiGuidePcOverlayDeferredReconciliationTimer) {
+            window.clearTimeout(yuiGuidePcOverlayDeferredReconciliationTimer);
+            yuiGuidePcOverlayDeferredReconciliationTimer = 0;
+        }
+    }
+
+    function scheduleYuiGuidePcOverlayDeferredReconciliation(
+        patch,
+        attemptedRunId,
+        retryCount,
+        attemptedLifecycleEpoch
+    ) {
+        clearYuiGuidePcOverlayDeferredReconciliation();
+        yuiGuidePcOverlayDeferredReconciliationTimer = window.setTimeout(function () {
+            yuiGuidePcOverlayDeferredReconciliationTimer = 0;
+            if (
+                I.yuiGuidePcOverlayLifecycleClosed
+                || attemptedLifecycleEpoch !== yuiGuidePcOverlayLifecycleEpoch
+            ) {
+                return;
+            }
+            I.sendYuiGuidePcOverlayPatch(patch || {}, retryCount + 1, {
+                tutorialRunId: attemptedRunId
+            });
+        }, YUI_GUIDE_PC_OVERLAY_DEFERRED_RECONCILIATION_DELAY_MS);
+    }
+
+    function handleYuiGuidePcOverlayStaleResult(
+        result,
+        patch,
+        attemptedRunId,
+        retried,
+        attemptedLifecycleEpoch,
+        attemptedSequence
+    ) {
         var isStaleResponse = !!(result && result.stale === true);
         var retryCount = Math.max(0, Math.floor(Number(retried) || 0));
         if (
             I.yuiGuidePcOverlayLifecycleClosed
             || attemptedLifecycleEpoch !== yuiGuidePcOverlayLifecycleEpoch
+            || attemptedSequence !== yuiGuidePcOverlaySequence
         ) {
             return;
         }
@@ -324,21 +363,30 @@
             && attemptedRunId === storedCanonicalRunId
             && !attemptedChatOwnedRun
         );
-
-        if (
+        var isSameRunSequenceStale = !!(
             isStaleResponse
-            && retryCount < YUI_GUIDE_PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES
             && result.reason === 'stale-sequence'
             && result.activeTutorialRunId === attemptedRunId
             && (
                 attemptedCanonicalRun
                 || (attemptedCurrentRun && attemptedChatOwnedRun)
             )
-        ) {
-            yuiGuidePcOverlaySequence = nextYuiGuidePcOverlaySequence(result.activeSequence);
-            I.sendYuiGuidePcOverlayPatch(patch || {}, retryCount + 1, {
-                tutorialRunId: attemptedRunId
-            });
+        );
+
+        if (isSameRunSequenceStale) {
+            if (retryCount < YUI_GUIDE_PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES) {
+                yuiGuidePcOverlaySequence = nextYuiGuidePcOverlaySequence(result.activeSequence);
+                I.sendYuiGuidePcOverlayPatch(patch || {}, retryCount + 1, {
+                    tutorialRunId: attemptedRunId
+                });
+            } else if (retryCount === YUI_GUIDE_PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES) {
+                scheduleYuiGuidePcOverlayDeferredReconciliation(
+                    patch,
+                    attemptedRunId,
+                    retryCount,
+                    attemptedLifecycleEpoch
+                );
+            }
             return;
         }
 
@@ -705,6 +753,10 @@
         if (!host || I.yuiGuidePcOverlayLifecycleClosed) {
             return false;
         }
+        var retryCount = Math.max(0, Math.floor(Number(retried) || 0));
+        if (retryCount === 0) {
+            clearYuiGuidePcOverlayDeferredReconciliation();
+        }
         var sendLifecycleEpoch = yuiGuidePcOverlayLifecycleEpoch;
         var sendOptions = options || {};
         if (I.isYuiGuidePcOverlayRunEnded(sendOptions.tutorialRunId)) {
@@ -759,11 +811,12 @@
             } catch (_) {}
         }
         yuiGuidePcOverlaySequence = nextYuiGuidePcOverlaySequence();
+        var updateSequence = yuiGuidePcOverlaySequence;
         try {
             Promise.resolve(host.update({
                 tutorialRunId: runId,
                 sceneId: 'external-chat',
-                sequence: yuiGuidePcOverlaySequence,
+                sequence: updateSequence,
                 payload: payload
             })).then(function (result) {
                 if (
@@ -777,8 +830,9 @@
                         result,
                         patch,
                         runId,
-                        retried,
-                        sendLifecycleEpoch
+                        retryCount,
+                        sendLifecycleEpoch,
+                        updateSequence
                     );
                     return;
                 }

--- a/static/app/app-react-chat-window/bootstrap-state-and-geometry.js
+++ b/static/app/app-react-chat-window/bootstrap-state-and-geometry.js
@@ -310,7 +310,10 @@ I.BUNDLE_SRC = '/static/react/neko-chat/neko-chat-window.iife.js';
     // 高最小高度 / 窗口最小高度 CSS 不再撑住空白输入区。
     // body class 切换、change 事件 payload 都走这个 helper，避免逻辑分叉。
     I.getEffectiveComposerHidden = function getEffectiveComposerHidden() {
-        return !!(I.state.composerHidden || I.state.goodbyeComposerHidden);
+        return !!(
+            !I.state.homeTutorialInputLocked
+            && (I.state.composerHidden || I.state.goodbyeComposerHidden)
+        );
     }
 
     I.getNekoGoodbyeModeActive = function getNekoGoodbyeModeActive() {

--- a/static/app/app-react-chat-window/bootstrap-state-and-geometry.js
+++ b/static/app/app-react-chat-window/bootstrap-state-and-geometry.js
@@ -72,6 +72,7 @@ I.BUNDLE_SRC = '/static/react/neko-chat/neko-chat-window.iife.js';
     I.savedExpandedShellPosition = null; // last known full-surface desktop position
     I.lastRestorableChatSurfaceMode = 'compact';
     I.tutorialChatRequestSeq = 0;
+    I.homeTutorialCompactChatStateSnapshot = null;
     I._sortKeySeq = 0; // monotonically increasing sortKey counter
     var COMPACT_CHAT_STATES = ['default', 'options', 'input'];
     // The active compact↔minimized cycle. `full` is intentionally NOT here: it is

--- a/static/app/app-react-chat-window/message-bundle-actions-and-prompts.js
+++ b/static/app/app-react-chat-window/message-bundle-actions-and-prompts.js
@@ -1837,6 +1837,7 @@
         if (I.state.homeTutorialInputLocked === next) {
             return;
         }
+        var previousAttachmentsVisible = I.getEffectiveComposerAttachmentsVisible();
         if (next && I.getCurrentCompactChatState() === 'input') {
             I.resetCompactChatState();
         }
@@ -1849,6 +1850,7 @@
             compactInputLocked: next,
             composerDisabled: !!I.state.homeTutorialInteractionLocked
         });
+        I.syncComposerAttachmentsVisibility(previousAttachmentsVisible);
         syncTutorialGalgameSuppression();
         I.renderWindow();
     }

--- a/static/app/app-react-chat-window/message-bundle-actions-and-prompts.js
+++ b/static/app/app-react-chat-window/message-bundle-actions-and-prompts.js
@@ -1821,6 +1821,9 @@
             I.resetCompactChatState();
         }
         I.state.homeTutorialInteractionLocked = next;
+        if (!next && !I.state.homeTutorialInputLocked) {
+            I.restoreHomeTutorialCompactChatState(true);
+        }
         I.state.viewProps = Object.assign({}, I.ensureViewProps(), {
             compactChatState: I.getCurrentCompactChatState(),
             composerDisabled: !!next
@@ -1838,6 +1841,9 @@
             I.resetCompactChatState();
         }
         I.state.homeTutorialInputLocked = next;
+        if (!next && !I.state.homeTutorialInteractionLocked) {
+            I.restoreHomeTutorialCompactChatState(true);
+        }
         I.state.viewProps = Object.assign({}, I.ensureViewProps(), {
             compactChatState: I.getCurrentCompactChatState(),
             compactInputLocked: next,

--- a/static/app/app-react-chat-window/minimize-and-idle-dock.js
+++ b/static/app/app-react-chat-window/minimize-and-idle-dock.js
@@ -1061,6 +1061,9 @@
     }
 
     I.setAvatarToolMenuOpen = function setAvatarToolMenuOpen(open, reason) {
+        if (open === true && I.getCurrentChatSurfaceMode() === 'compact') {
+            I.state.compactChatState = 'input';
+        }
         I.setViewProps({
             avatarToolMenuOpenRequest: {
                 id: nextTutorialChatRequestId('avatar-tool-menu'),
@@ -1072,6 +1075,9 @@
     }
 
     I.setCompactToolFanOpen = function setCompactToolFanOpen(open, reason) {
+        if (open === true && I.getCurrentChatSurfaceMode() === 'compact') {
+            I.state.compactChatState = 'input';
+        }
         I.setViewProps({
             compactToolFanOpenRequest: {
                 id: nextTutorialChatRequestId('compact-tool-fan'),

--- a/static/app/app-react-chat-window/minimize-and-idle-dock.js
+++ b/static/app/app-react-chat-window/minimize-and-idle-dock.js
@@ -1060,9 +1060,52 @@
         return prefix + '-' + Date.now() + '-' + I.tutorialChatRequestSeq;
     }
 
+    function isHomeTutorialCompactOverrideActive() {
+        return !!(I.state.homeTutorialInputLocked || I.state.homeTutorialInteractionLocked);
+    }
+
+    I.captureHomeTutorialCompactChatState = function captureHomeTutorialCompactChatState() {
+        if (I.homeTutorialCompactChatStateSnapshot === null) {
+            I.homeTutorialCompactChatStateSnapshot = I.getCurrentCompactChatState();
+        }
+    };
+
+    I.restoreHomeTutorialCompactChatState = function restoreHomeTutorialCompactChatState(releaseSnapshot) {
+        if (I.homeTutorialCompactChatStateSnapshot === null) {
+            return false;
+        }
+        I.state.compactChatState = I.normalizeCompactChatState(I.homeTutorialCompactChatStateSnapshot);
+        if (releaseSnapshot === true) {
+            I.homeTutorialCompactChatStateSnapshot = null;
+        }
+        return true;
+    };
+
+    function restoreHomeTutorialCompactStateAfterToolClose(closingTool) {
+        if (!isHomeTutorialCompactOverrideActive()) {
+            return false;
+        }
+        var props = I.ensureViewProps();
+        var avatarMenuOpen = closingTool !== 'avatar-menu'
+            && props.avatarToolMenuOpenRequest
+            && props.avatarToolMenuOpenRequest.open === true;
+        var compactFanOpen = closingTool !== 'compact-fan'
+            && props.compactToolFanOpenRequest
+            && props.compactToolFanOpenRequest.open === true;
+        if (avatarMenuOpen || compactFanOpen) {
+            return false;
+        }
+        return I.restoreHomeTutorialCompactChatState(false);
+    }
+
     I.setAvatarToolMenuOpen = function setAvatarToolMenuOpen(open, reason) {
         if (open === true && I.getCurrentChatSurfaceMode() === 'compact') {
+            if (isHomeTutorialCompactOverrideActive()) {
+                I.captureHomeTutorialCompactChatState();
+            }
             I.state.compactChatState = 'input';
+        } else if (open !== true) {
+            restoreHomeTutorialCompactStateAfterToolClose('avatar-menu');
         }
         I.setViewProps({
             avatarToolMenuOpenRequest: {
@@ -1076,7 +1119,12 @@
 
     I.setCompactToolFanOpen = function setCompactToolFanOpen(open, reason) {
         if (open === true && I.getCurrentChatSurfaceMode() === 'compact') {
+            if (isHomeTutorialCompactOverrideActive()) {
+                I.captureHomeTutorialCompactChatState();
+            }
             I.state.compactChatState = 'input';
+        } else if (open !== true) {
+            restoreHomeTutorialCompactStateAfterToolClose('compact-fan');
         }
         I.setViewProps({
             compactToolFanOpenRequest: {

--- a/static/tutorial/avatar/reload-controller.js
+++ b/static/tutorial/avatar/reload-controller.js
@@ -180,8 +180,16 @@
                 };
                 this.override.currentName = currentName;
                 this.override.snapshotPayload = snapshotPayload;
-                this.override.proactiveSnapshot = snapshotProactiveState();
-                applyProactiveState(buildDisabledProactiveState());
+                const featureController = window.NekoHomeTutorialFeatureController;
+                const proactiveManagedByTutorialLifecycle = !!(
+                    featureController
+                    && typeof featureController.isActive === 'function'
+                    && featureController.isActive()
+                );
+                if (!proactiveManagedByTutorialLifecycle) {
+                    this.override.proactiveSnapshot = snapshotProactiveState();
+                    applyProactiveState(buildDisabledProactiveState());
+                }
 
                 if (!skipSourceModelFade) {
                     await Promise.resolve(this.fadeOutCurrentModel({

--- a/static/tutorial/yui-guide/overlay.js
+++ b/static/tutorial/yui-guide/overlay.js
@@ -12,6 +12,7 @@
     const SMOOTH_CURSOR_SHOW_DURATION_MS = 560;
     const PC_OVERLAY_SEQUENCE_STORAGE_KEY = 'yuiGuidePcOverlaySequence';
     const PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES = 3;
+    const PC_OVERLAY_MAX_TOTAL_SAME_RUN_STALE_RETRIES = 6;
     const PC_OVERLAY_DEFERRED_RECONCILIATION_DELAY_MS = 48;
     const CONTROL_BANNER_TEXT_KEY = 'tutorial.yuiGuide.controlBanner';
     const CONTROL_BANNER_FALLBACK_TEXT = 'The catgirl is controlling the mouse';
@@ -148,18 +149,21 @@
         };
         const syncRunIdFromStorage = () => adoptRunId(readStoredRunId());
 
-        const nextSequence = (minimumSequence) => {
-            const wallSequence = Date.now() * 1000;
-            const sequenceFloor = Math.max(0, Math.floor(Number(minimumSequence) || 0));
-            let storedSequence = 0;
+        const readStoredSequence = () => {
             try {
-                storedSequence = Math.max(
+                return Math.max(
                     0,
                     Math.floor(Number(window.localStorage.getItem(PC_OVERLAY_SEQUENCE_STORAGE_KEY)) || 0)
                 );
             } catch (_) {
-                storedSequence = 0;
+                return 0;
             }
+        };
+
+        const nextSequence = (minimumSequence) => {
+            const wallSequence = Date.now() * 1000;
+            const sequenceFloor = Math.max(0, Math.floor(Number(minimumSequence) || 0));
+            const storedSequence = readStoredSequence();
 
             sequence = Math.max(sequence + 1, storedSequence + 1, sequenceFloor + 1, wallSequence);
             try {
@@ -174,14 +178,14 @@
                 deferredReconciliationTimer = 0;
             }
         };
-        const scheduleDeferredReconciliation = (retryCount) => {
+        const scheduleDeferredReconciliation = (retryCount, attemptedSequence) => {
             clearDeferredReconciliation();
             deferredReconciliationTimer = window.setTimeout(() => {
                 deferredReconciliationTimer = 0;
-                if (cleared) {
+                if (cleared || readStoredSequence() > attemptedSequence) {
                     return;
                 }
-                send({}, true, retryCount);
+                send({}, true, retryCount + 1);
             }, PC_OVERLAY_DEFERRED_RECONCILIATION_DELAY_MS);
         };
 
@@ -213,8 +217,8 @@
                 if (retryCount < PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES) {
                     sequence = nextSequence(result.activeSequence);
                     send(patch, true, retryCount + 1);
-                } else if (retryCount === PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES) {
-                    scheduleDeferredReconciliation(retryCount);
+                } else if (retryCount < PC_OVERLAY_MAX_TOTAL_SAME_RUN_STALE_RETRIES) {
+                    scheduleDeferredReconciliation(retryCount, attemptedSequence);
                 }
                 return;
             }
@@ -256,8 +260,8 @@
                 if (retryCount < PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES) {
                     sequence = nextSequence(result.activeSequence);
                     sendCursorOnly(cursor, retryCount + 1);
-                } else if (retryCount === PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES) {
-                    scheduleDeferredReconciliation(retryCount);
+                } else if (retryCount < PC_OVERLAY_MAX_TOTAL_SAME_RUN_STALE_RETRIES) {
+                    scheduleDeferredReconciliation(retryCount, attemptedSequence);
                 }
                 return;
             }

--- a/static/tutorial/yui-guide/overlay.js
+++ b/static/tutorial/yui-guide/overlay.js
@@ -176,7 +176,7 @@
                 && attemptedRunId === runId
             ) {
                 sequence = nextSequence(result.activeSequence);
-                send(patch, force, true);
+                send(patch, true, true);
                 return;
             }
             if (!result || result.stale !== true || retried || cleared || attemptedRunId !== runId) {
@@ -495,11 +495,10 @@
             lastKey = key;
             if (!active) {
                 active = true;
-                const beginRunId = runId;
                 try {
                     Promise.resolve(host.begin({ tutorialRunId: runId })).then((result) => {
                         if (result && result.stale === true) {
-                            handleStaleResult(result, patch, force, retried === true, beginRunId);
+                            // The paired update carries the state and owns stale retries.
                             return;
                         }
                         if (result && result.ok === false) {

--- a/static/tutorial/yui-guide/overlay.js
+++ b/static/tutorial/yui-guide/overlay.js
@@ -555,11 +555,10 @@
             const payload = completeStateStore.applyPatch({ cursor: cursor });
             if (!active) {
                 active = true;
-                const beginRunId = runId;
                 try {
                     Promise.resolve(host.begin({ tutorialRunId: runId })).then((result) => {
                         if (result && result.stale === true) {
-                            handleCursorOnlyStaleResult(result, cursor, retried === true, beginRunId);
+                            // The paired cursor update carries the state and owns stale retries.
                             return;
                         }
                         if (result && result.ok === false) {

--- a/static/tutorial/yui-guide/overlay.js
+++ b/static/tutorial/yui-guide/overlay.js
@@ -11,6 +11,7 @@
     const DEFAULT_CURSOR_CLICK_VISIBLE_MS = 420;
     const SMOOTH_CURSOR_SHOW_DURATION_MS = 560;
     const PC_OVERLAY_SEQUENCE_STORAGE_KEY = 'yuiGuidePcOverlaySequence';
+    const PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES = 3;
     const CONTROL_BANNER_TEXT_KEY = 'tutorial.yuiGuide.controlBanner';
     const CONTROL_BANNER_FALLBACK_TEXT = 'The catgirl is controlling the mouse';
     const CONTROL_BANNER_INTERRUPT_EMPHASIS_MS = 2000;
@@ -166,52 +167,54 @@
         };
 
         const handleStaleResult = (result, patch, force, retried, attemptedRunId) => {
+            const retryCount = Math.max(0, Math.floor(Number(retried) || 0));
             if (
                 result
                 && result.stale === true
                 && result.reason === 'stale-sequence'
                 && result.activeTutorialRunId === attemptedRunId
-                && !retried
+                && retryCount < PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES
                 && !cleared
                 && attemptedRunId === runId
             ) {
                 sequence = nextSequence(result.activeSequence);
-                send(patch, true, true);
+                send(patch, true, retryCount + 1);
                 return;
             }
-            if (!result || result.stale !== true || retried || cleared || attemptedRunId !== runId) {
+            if (!result || result.stale !== true || retryCount > 0 || cleared || attemptedRunId !== runId) {
                 return;
             }
             if (syncRunIdFromStorage()) {
-                send(patch, force, true);
+                send(patch, force, retryCount + 1);
                 return;
             }
             rotateRunId();
-            send(patch, force, true);
+            send(patch, force, retryCount + 1);
         };
         const handleCursorOnlyStaleResult = (result, cursor, retried, attemptedRunId) => {
+            const retryCount = Math.max(0, Math.floor(Number(retried) || 0));
             if (
                 result
                 && result.stale === true
                 && result.reason === 'stale-sequence'
                 && result.activeTutorialRunId === attemptedRunId
-                && !retried
+                && retryCount < PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES
                 && !cleared
                 && attemptedRunId === runId
             ) {
                 sequence = nextSequence(result.activeSequence);
-                sendCursorOnly(cursor, true);
+                sendCursorOnly(cursor, retryCount + 1);
                 return;
             }
-            if (!result || result.stale !== true || retried || cleared || attemptedRunId !== runId) {
+            if (!result || result.stale !== true || retryCount > 0 || cleared || attemptedRunId !== runId) {
                 return;
             }
             if (syncRunIdFromStorage()) {
-                sendCursorOnly(cursor, true);
+                sendCursorOnly(cursor, retryCount + 1);
                 return;
             }
             rotateRunId();
-            sendCursorOnly(cursor, true);
+            sendCursorOnly(cursor, retryCount + 1);
         };
 
         const getAssetUrl = (assetPath) => {
@@ -526,7 +529,7 @@
                     payload: payload
                 })).then((result) => {
                     if (result && result.stale === true) {
-                        handleStaleResult(result, patch, force, retried === true, updateRunId);
+                        handleStaleResult(result, patch, force, retried, updateRunId);
                         return;
                     }
                     if (result && result.ok === false) {
@@ -586,7 +589,7 @@
                     payload: payload
                 })).then((result) => {
                     if (result && result.stale === true) {
-                        handleCursorOnlyStaleResult(result, cursor, retried === true, updateRunId);
+                        handleCursorOnlyStaleResult(result, cursor, retried, updateRunId);
                         return;
                     }
                     if (result && result.ok === false) {

--- a/static/tutorial/yui-guide/overlay.js
+++ b/static/tutorial/yui-guide/overlay.js
@@ -12,6 +12,7 @@
     const SMOOTH_CURSOR_SHOW_DURATION_MS = 560;
     const PC_OVERLAY_SEQUENCE_STORAGE_KEY = 'yuiGuidePcOverlaySequence';
     const PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES = 3;
+    const PC_OVERLAY_DEFERRED_RECONCILIATION_DELAY_MS = 48;
     const CONTROL_BANNER_TEXT_KEY = 'tutorial.yuiGuide.controlBanner';
     const CONTROL_BANNER_FALLBACK_TEXT = 'The catgirl is controlling the mouse';
     const CONTROL_BANNER_INTERRUPT_EMPHASIS_MS = 2000;
@@ -112,6 +113,7 @@
         let remoteReady = false;
         let failed = false;
         let lastKey = '';
+        let deferredReconciliationTimer = 0;
         const createCompleteStateStore = OverlayRendererApi.createPcOverlayCompleteStateStore
             || (window.TutorialOverlayRenderer && window.TutorialOverlayRenderer.createPcOverlayCompleteStateStore);
         if (typeof createCompleteStateStore !== 'function') {
@@ -166,19 +168,43 @@
             return sequence;
         };
 
-        const handleStaleResult = (result, patch, force, retried, attemptedRunId) => {
+        const clearDeferredReconciliation = () => {
+            if (deferredReconciliationTimer) {
+                window.clearTimeout(deferredReconciliationTimer);
+                deferredReconciliationTimer = 0;
+            }
+        };
+        const scheduleDeferredReconciliation = (retryCount) => {
+            clearDeferredReconciliation();
+            deferredReconciliationTimer = window.setTimeout(() => {
+                deferredReconciliationTimer = 0;
+                if (cleared) {
+                    return;
+                }
+                send({}, true, retryCount + 1);
+            }, PC_OVERLAY_DEFERRED_RECONCILIATION_DELAY_MS);
+        };
+
+        const handleStaleResult = (result, patch, force, retried, attemptedRunId, attemptedSequence) => {
             const retryCount = Math.max(0, Math.floor(Number(retried) || 0));
-            if (
+            if (attemptedSequence !== sequence) {
+                return;
+            }
+            const isSameRunSequenceStale = !!(
                 result
                 && result.stale === true
                 && result.reason === 'stale-sequence'
                 && result.activeTutorialRunId === attemptedRunId
-                && retryCount < PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES
                 && !cleared
                 && attemptedRunId === runId
-            ) {
-                sequence = nextSequence(result.activeSequence);
-                send(patch, true, retryCount + 1);
+            );
+            if (isSameRunSequenceStale) {
+                if (retryCount < PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES) {
+                    sequence = nextSequence(result.activeSequence);
+                    send(patch, true, retryCount + 1);
+                } else if (retryCount === PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES) {
+                    scheduleDeferredReconciliation(retryCount);
+                }
                 return;
             }
             if (!result || result.stale !== true || retryCount > 0 || cleared || attemptedRunId !== runId) {
@@ -191,19 +217,26 @@
             rotateRunId();
             send(patch, force, retryCount + 1);
         };
-        const handleCursorOnlyStaleResult = (result, cursor, retried, attemptedRunId) => {
+        const handleCursorOnlyStaleResult = (result, cursor, retried, attemptedRunId, attemptedSequence) => {
             const retryCount = Math.max(0, Math.floor(Number(retried) || 0));
-            if (
+            if (attemptedSequence !== sequence) {
+                return;
+            }
+            const isSameRunSequenceStale = !!(
                 result
                 && result.stale === true
                 && result.reason === 'stale-sequence'
                 && result.activeTutorialRunId === attemptedRunId
-                && retryCount < PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES
                 && !cleared
                 && attemptedRunId === runId
-            ) {
-                sequence = nextSequence(result.activeSequence);
-                sendCursorOnly(cursor, retryCount + 1);
+            );
+            if (isSameRunSequenceStale) {
+                if (retryCount < PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES) {
+                    sequence = nextSequence(result.activeSequence);
+                    sendCursorOnly(cursor, retryCount + 1);
+                } else if (retryCount === PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES) {
+                    scheduleDeferredReconciliation(retryCount);
+                }
                 return;
             }
             if (!result || result.stale !== true || retryCount > 0 || cleared || attemptedRunId !== runId) {
@@ -489,6 +522,10 @@
             if (cleared) {
                 return;
             }
+            const retryCount = Math.max(0, Math.floor(Number(retried) || 0));
+            if (retryCount === 0) {
+                clearDeferredReconciliation();
+            }
             syncRunIdFromStorage();
             const payload = completeStateStore.applyPatch(patch || {});
             const key = JSON.stringify(payload || {});
@@ -520,16 +557,17 @@
                 }
             }
             sequence = nextSequence();
+            const updateSequence = sequence;
             const updateRunId = runId;
             try {
                 Promise.resolve(host.update({
                     tutorialRunId: runId,
                     sceneId: doc && doc.body ? (doc.body.getAttribute('data-yui-guide-scene') || '') : '',
-                    sequence: sequence,
+                    sequence: updateSequence,
                     payload: payload
                 })).then((result) => {
                     if (result && result.stale === true) {
-                        handleStaleResult(result, patch, force, retried, updateRunId);
+                        handleStaleResult(result, patch, force, retryCount, updateRunId, updateSequence);
                         return;
                     }
                     if (result && result.ok === false) {
@@ -553,6 +591,10 @@
         const sendCursorOnly = (cursor, retried) => {
             if (cleared || !cursor) {
                 return;
+            }
+            const retryCount = Math.max(0, Math.floor(Number(retried) || 0));
+            if (retryCount === 0) {
+                clearDeferredReconciliation();
             }
             syncRunIdFromStorage();
             const payload = completeStateStore.applyPatch({ cursor: cursor });
@@ -580,16 +622,17 @@
                 }
             }
             sequence = nextSequence();
+            const updateSequence = sequence;
             const updateRunId = runId;
             try {
                 Promise.resolve(host.update({
                     tutorialRunId: runId,
                     sceneId: doc && doc.body ? (doc.body.getAttribute('data-yui-guide-scene') || '') : '',
-                    sequence: sequence,
+                    sequence: updateSequence,
                     payload: payload
                 })).then((result) => {
                     if (result && result.stale === true) {
-                        handleCursorOnlyStaleResult(result, cursor, retried, updateRunId);
+                        handleCursorOnlyStaleResult(result, cursor, retryCount, updateRunId, updateSequence);
                         return;
                     }
                     if (result && result.ok === false) {
@@ -705,6 +748,7 @@
                 }, durationMs + 900);
             },
             clear() {
+                clearDeferredReconciliation();
                 active = false;
                 cleared = true;
                 lastKey = '';

--- a/static/tutorial/yui-guide/overlay.js
+++ b/static/tutorial/yui-guide/overlay.js
@@ -181,7 +181,7 @@
                 if (cleared) {
                     return;
                 }
-                send({}, true, retryCount + 1);
+                send({}, true, retryCount);
             }, PC_OVERLAY_DEFERRED_RECONCILIATION_DELAY_MS);
         };
 
@@ -190,11 +190,22 @@
             if (attemptedSequence !== sequence) {
                 return;
             }
+            const activeSequence = Math.max(0, Math.floor(Number(result && result.activeSequence) || 0));
+            if (
+                result
+                && result.stale === true
+                && result.reason === 'stale-sequence'
+                && result.activeTutorialRunId === attemptedRunId
+                && activeSequence > attemptedSequence
+            ) {
+                return;
+            }
             const isSameRunSequenceStale = !!(
                 result
                 && result.stale === true
                 && result.reason === 'stale-sequence'
                 && result.activeTutorialRunId === attemptedRunId
+                && activeSequence === attemptedSequence
                 && !cleared
                 && attemptedRunId === runId
             );
@@ -222,11 +233,22 @@
             if (attemptedSequence !== sequence) {
                 return;
             }
+            const activeSequence = Math.max(0, Math.floor(Number(result && result.activeSequence) || 0));
+            if (
+                result
+                && result.stale === true
+                && result.reason === 'stale-sequence'
+                && result.activeTutorialRunId === attemptedRunId
+                && activeSequence > attemptedSequence
+            ) {
+                return;
+            }
             const isSameRunSequenceStale = !!(
                 result
                 && result.stale === true
                 && result.reason === 'stale-sequence'
                 && result.activeTutorialRunId === attemptedRunId
+                && activeSequence === attemptedSequence
                 && !cleared
                 && attemptedRunId === runId
             );

--- a/static/tutorial/yui-guide/overlay.js
+++ b/static/tutorial/yui-guide/overlay.js
@@ -145,8 +145,9 @@
         };
         const syncRunIdFromStorage = () => adoptRunId(readStoredRunId());
 
-        const nextSequence = () => {
+        const nextSequence = (minimumSequence) => {
             const wallSequence = Date.now() * 1000;
+            const sequenceFloor = Math.max(0, Math.floor(Number(minimumSequence) || 0));
             let storedSequence = 0;
             try {
                 storedSequence = Math.max(
@@ -157,7 +158,7 @@
                 storedSequence = 0;
             }
 
-            sequence = Math.max(sequence + 1, storedSequence + 1, wallSequence);
+            sequence = Math.max(sequence + 1, storedSequence + 1, sequenceFloor + 1, wallSequence);
             try {
                 window.localStorage.setItem(PC_OVERLAY_SEQUENCE_STORAGE_KEY, String(sequence));
             } catch (_) {}
@@ -165,6 +166,19 @@
         };
 
         const handleStaleResult = (result, patch, force, retried, attemptedRunId) => {
+            if (
+                result
+                && result.stale === true
+                && result.reason === 'stale-sequence'
+                && result.activeTutorialRunId === attemptedRunId
+                && !retried
+                && !cleared
+                && attemptedRunId === runId
+            ) {
+                sequence = nextSequence(result.activeSequence);
+                send(patch, force, true);
+                return;
+            }
             if (!result || result.stale !== true || retried || cleared || attemptedRunId !== runId) {
                 return;
             }
@@ -176,6 +190,19 @@
             send(patch, force, true);
         };
         const handleCursorOnlyStaleResult = (result, cursor, retried, attemptedRunId) => {
+            if (
+                result
+                && result.stale === true
+                && result.reason === 'stale-sequence'
+                && result.activeTutorialRunId === attemptedRunId
+                && !retried
+                && !cleared
+                && attemptedRunId === runId
+            ) {
+                sequence = nextSequence(result.activeSequence);
+                sendCursorOnly(cursor, true);
+                return;
+            }
             if (!result || result.stale !== true || retried || cleared || attemptedRunId !== runId) {
                 return;
             }

--- a/static/yui-guide-avatar-reload-controller.test.cjs
+++ b/static/yui-guide-avatar-reload-controller.test.cjs
@@ -165,6 +165,62 @@ test('tutorial avatar reload snapshots proactive chat when override starts, not 
     assert.equal(window.scheduleCalls, 1);
 });
 
+test('tutorial avatar reload does not overwrite proactive state restored by the tutorial lifecycle', async () => {
+    const window = loadReloadControllerWindow();
+    window.proactiveChatEnabled = false;
+    window.appState.proactiveChatEnabled = false;
+    window.proactiveVisionChatEnabled = false;
+    window.appState.proactiveVisionChatEnabled = false;
+    window.NekoHomeTutorialFeatureController = {
+        isActive() {
+            return true;
+        }
+    };
+
+    const host = {
+        constructor: {
+            detectModelPrefix() {
+                return 'live2d';
+            }
+        }
+    };
+    const controller = window.TutorialAvatarReloadController.createController({
+        host,
+        timeoutMs: 200,
+        resolveCurrentName: () => Promise.resolve('LanLan'),
+        fetchCharacters: () => Promise.resolve({
+            '猫娘': {
+                LanLan: {
+                    model_type: 'live2d',
+                    live2d: 'lanlan'
+                }
+            }
+        }),
+        buildSnapshotPayload: () => ({ model_type: 'live2d', live2d: 'lanlan' }),
+        reloadModel: () => Promise.resolve(),
+        setPreparing: () => {},
+        revealPrepared: () => {},
+        applyIdentityOverride: () => {},
+        clearViewportWatcher: () => {}
+    });
+
+    await controller.beginOverride();
+
+    // Skip/angry-exit tears down the feature controller before the model restore.
+    window.proactiveChatEnabled = true;
+    window.appState.proactiveChatEnabled = true;
+    window.proactiveVisionChatEnabled = true;
+    window.appState.proactiveVisionChatEnabled = true;
+    window.NekoHomeTutorialFeatureController = null;
+
+    await controller.restoreOverride();
+
+    assert.equal(window.proactiveChatEnabled, true);
+    assert.equal(window.appState.proactiveChatEnabled, true);
+    assert.equal(window.proactiveVisionChatEnabled, true);
+    assert.equal(window.appState.proactiveVisionChatEnabled, true);
+});
+
 test('tutorial avatar reload can keep prepared model hidden for intro performance reveal', async () => {
     const window = loadReloadControllerWindow();
     const reloadCalls = [];

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -8060,7 +8060,25 @@ def test_pc_overlay_cursor_only_bounds_repeated_same_run_stale_retries(mock_page
                 await new Promise((resolve) => setTimeout(resolve, 80));
             }
             if (window.__pcOverlayUpdates[5]) {
-                window.__pcOverlayUpdateResolvers[5]({ ok: true });
+                const deferredRetry = window.__pcOverlayUpdates[5];
+                window.__pcOverlayUpdateResolvers[5]({
+                    ok: false,
+                    stale: true,
+                    reason: 'stale-sequence',
+                    activeTutorialRunId: deferredRetry.tutorialRunId,
+                    activeSequence: deferredRetry.sequence,
+                });
+                await new Promise((resolve) => setTimeout(resolve, 80));
+            }
+            if (window.__pcOverlayUpdates[6]) {
+                const finalDeferredRetry = window.__pcOverlayUpdates[6];
+                window.__pcOverlayUpdateResolvers[6]({
+                    ok: false,
+                    stale: true,
+                    reason: 'stale-sequence',
+                    activeTutorialRunId: finalDeferredRetry.tutorialRunId,
+                    activeSequence: finalDeferredRetry.sequence,
+                });
                 await new Promise((resolve) => setTimeout(resolve, 80));
             }
             return {
@@ -8072,13 +8090,71 @@ def test_pc_overlay_cursor_only_bounds_repeated_same_run_stale_retries(mock_page
     )
 
     assert result["beforeDeferredRetry"] == 4
-    assert len(result["updates"]) == 6
+    assert len(result["updates"]) == 7
     assert all(update["tutorialRunId"] == "cursor-retry-run" for update in result["updates"])
     assert result["updates"][1]["sequence"] > result["updates"][0]["sequence"]
     assert result["updates"][2]["sequence"] > result["updates"][1]["sequence"]
     assert result["updates"][3]["sequence"] > result["updates"][2]["sequence"]
     assert result["updates"][4]["sequence"] > result["updates"][3]["sequence"]
     assert result["updates"][5]["sequence"] > result["updates"][4]["sequence"]
+    assert result["updates"][6]["sequence"] > result["updates"][5]["sequence"]
+
+
+@pytest.mark.frontend
+def test_pc_overlay_deferred_retry_yields_to_newer_shared_sequence(mock_page: Page):
+    _bootstrap_page(
+        mock_page,
+        setup_js="""
+            window.history.pushState({}, '', '/');
+            window.localStorage.setItem('yuiGuidePcOverlayRunId', 'cursor-shared-sequence-run');
+            window.__pcOverlayUpdates = [];
+            window.__pcOverlayUpdateResolvers = [];
+            window.nekoTutorialOverlay = {
+                getWindowMetricsSync: () => ({
+                    bounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    contentBounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    zoomFactor: 1,
+                }),
+                begin: () => Promise.resolve({ ok: true }),
+                update: (payload) => {
+                    window.__pcOverlayUpdates.push(payload);
+                    return new Promise((resolve) => window.__pcOverlayUpdateResolvers.push(resolve));
+                },
+                clear: () => Promise.resolve({ ok: true }),
+            };
+        """,
+        script_names=("tutorial/yui-guide/overlay.js",),
+    )
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            const overlay = new window.YuiGuideOverlay(document);
+            overlay.pcOverlayBridge.moveCursorOnlyTo(240, 180, 0, 'click', 420);
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            for (let index = 0; index < 4; index += 1) {
+                const update = window.__pcOverlayUpdates[index];
+                window.__pcOverlayUpdateResolvers[index]({
+                    ok: false,
+                    stale: true,
+                    reason: 'stale-sequence',
+                    activeTutorialRunId: update.tutorialRunId,
+                    activeSequence: update.sequence,
+                });
+                await new Promise((resolve) => setTimeout(resolve, 0));
+            }
+            const latestRetry = window.__pcOverlayUpdates[3];
+            window.localStorage.setItem(
+                'yuiGuidePcOverlaySequence',
+                String(latestRetry.sequence + 1000),
+            );
+            await new Promise((resolve) => setTimeout(resolve, 80));
+            return window.__pcOverlayUpdates;
+        }
+        """
+    )
+
+    assert len(result) == 4
 
 
 @pytest.mark.frontend
@@ -8248,7 +8324,25 @@ def test_external_chat_reconciles_a_second_same_run_stale_response(mock_page: Pa
                 await new Promise((resolve) => setTimeout(resolve, 80));
             }
             if (window.__externalChatOverlayUpdates[5]) {
-                window.__externalChatUpdateResolvers[5]({ ok: true });
+                const deferredRetry = window.__externalChatOverlayUpdates[5];
+                window.__externalChatUpdateResolvers[5]({
+                    ok: false,
+                    stale: true,
+                    reason: 'stale-sequence',
+                    activeTutorialRunId: deferredRetry.tutorialRunId,
+                    activeSequence: deferredRetry.sequence,
+                });
+                await new Promise((resolve) => setTimeout(resolve, 80));
+            }
+            if (window.__externalChatOverlayUpdates[6]) {
+                const finalDeferredRetry = window.__externalChatOverlayUpdates[6];
+                window.__externalChatUpdateResolvers[6]({
+                    ok: false,
+                    stale: true,
+                    reason: 'stale-sequence',
+                    activeTutorialRunId: finalDeferredRetry.tutorialRunId,
+                    activeSequence: finalDeferredRetry.sequence,
+                });
                 await new Promise((resolve) => setTimeout(resolve, 80));
             }
             return {
@@ -8260,13 +8354,90 @@ def test_external_chat_reconciles_a_second_same_run_stale_response(mock_page: Pa
     )
 
     assert result["beforeDeferredRetry"] == 4
-    assert len(result["updates"]) == 6
+    assert len(result["updates"]) == 7
     assert all(update["tutorialRunId"] == "external-retry-run" for update in result["updates"])
     assert result["updates"][1]["sequence"] > result["updates"][0]["sequence"]
     assert result["updates"][2]["sequence"] > result["updates"][1]["sequence"]
     assert result["updates"][3]["sequence"] > result["updates"][2]["sequence"]
     assert result["updates"][4]["sequence"] > result["updates"][3]["sequence"]
     assert result["updates"][5]["sequence"] > result["updates"][4]["sequence"]
+    assert result["updates"][6]["sequence"] > result["updates"][5]["sequence"]
+    assert "effect" not in result["updates"][4]["payload"]["cursor"]
+
+
+@pytest.mark.frontend
+def test_external_chat_deferred_retry_yields_to_newer_shared_sequence(mock_page: Page):
+    _bootstrap_page(
+        mock_page,
+        setup_js="""
+            window.history.pushState({}, '', '/chat');
+            window.localStorage.setItem('yuiGuidePcOverlayRunId', 'external-shared-sequence-run');
+            window.__externalChatOverlayUpdates = [];
+            window.__externalChatUpdateResolvers = [];
+            window.nekoTutorialOverlay = {
+                getWindowMetricsSync: () => ({
+                    bounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    contentBounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    zoomFactor: 1,
+                }),
+                begin: () => Promise.resolve({ ok: true }),
+                update: (payload) => {
+                    window.__externalChatOverlayUpdates.push(payload);
+                    return new Promise((resolve) => window.__externalChatUpdateResolvers.push(resolve));
+                },
+                clear: () => Promise.resolve({ ok: true }),
+            };
+            document.body.innerHTML = `
+                <div id="react-chat-window-root">
+                    <button
+                        class="send-button-circle compact-input-tool-toggle"
+                        style="position:fixed; left:100px; top:200px; width:42px; height:42px;"
+                    ></button>
+                </div>
+            `;
+        """,
+        script_names=("app/app-interpage",),
+    )
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            window.postMessage({
+                __nekoTutorialOverlayRelay: true,
+                payload: {
+                    action: 'yui_guide_set_chat_cursor',
+                    kind: 'tool-toggle',
+                    effect: 'click',
+                    effectDurationMs: 420,
+                    durationMs: 0,
+                    timestamp: Date.now(),
+                    tutorialRunId: 'external-shared-sequence-run',
+                },
+            }, '*');
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            for (let index = 0; index < 4; index += 1) {
+                const update = window.__externalChatOverlayUpdates[index];
+                window.__externalChatUpdateResolvers[index]({
+                    ok: false,
+                    stale: true,
+                    reason: 'stale-sequence',
+                    activeTutorialRunId: update.tutorialRunId,
+                    activeSequence: update.sequence,
+                });
+                await new Promise((resolve) => setTimeout(resolve, 0));
+            }
+            const latestRetry = window.__externalChatOverlayUpdates[3];
+            window.localStorage.setItem(
+                'yuiGuidePcOverlaySequence',
+                String(latestRetry.sequence + 1000),
+            );
+            await new Promise((resolve) => setTimeout(resolve, 80));
+            return window.__externalChatOverlayUpdates;
+        }
+        """
+    )
+
+    assert len(result) == 4
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -8362,7 +8362,98 @@ def test_external_chat_reconciles_a_second_same_run_stale_response(mock_page: Pa
     assert result["updates"][4]["sequence"] > result["updates"][3]["sequence"]
     assert result["updates"][5]["sequence"] > result["updates"][4]["sequence"]
     assert result["updates"][6]["sequence"] > result["updates"][5]["sequence"]
-    assert "effect" not in result["updates"][4]["payload"]["cursor"]
+    assert all(
+        "effect" not in update["payload"]["cursor"]
+        for update in result["updates"][4:]
+    )
+
+
+@pytest.mark.frontend
+def test_external_chat_bounds_repeated_different_run_stale_reconciliation(mock_page: Page):
+    _bootstrap_page(
+        mock_page,
+        setup_js="""
+            window.history.pushState({}, '', '/chat');
+            window.localStorage.setItem('yuiGuidePcOverlayRunId', 'external-different-run');
+            window.__externalChatOverlayBegins = [];
+            window.__externalChatOverlayUpdates = [];
+            window.__externalChatUpdateResolvers = [];
+            window.nekoTutorialOverlay = {
+                getWindowMetricsSync: () => ({
+                    bounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    contentBounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    zoomFactor: 1,
+                }),
+                begin: (payload) => {
+                    window.__externalChatOverlayBegins.push(payload);
+                    return Promise.resolve({ ok: true });
+                },
+                update: (payload) => {
+                    window.__externalChatOverlayUpdates.push(payload);
+                    return new Promise((resolve) => window.__externalChatUpdateResolvers.push(resolve));
+                },
+                clear: () => Promise.resolve({ ok: true }),
+            };
+            document.body.innerHTML = `
+                <div id="react-chat-window-root">
+                    <button
+                        class="send-button-circle compact-input-tool-toggle"
+                        style="position:fixed; left:100px; top:200px; width:42px; height:42px;"
+                    ></button>
+                </div>
+            `;
+        """,
+        script_names=("app/app-interpage",),
+    )
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            window.postMessage({
+                __nekoTutorialOverlayRelay: true,
+                payload: {
+                    action: 'yui_guide_set_chat_cursor',
+                    kind: 'tool-toggle',
+                    effect: 'click',
+                    effectDurationMs: 420,
+                    durationMs: 0,
+                    timestamp: Date.now(),
+                    tutorialRunId: 'external-different-run',
+                },
+            }, '*');
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            for (let index = 0; index < 7; index += 1) {
+                const update = window.__externalChatOverlayUpdates[index];
+                if (!update) {
+                    break;
+                }
+                window.__externalChatUpdateResolvers[index]({
+                    ok: false,
+                    stale: true,
+                    reason: 'stale-run',
+                    activeTutorialRunId: 'paired-active-run',
+                    activeSequence: update.sequence,
+                });
+                await new Promise((resolve) => setTimeout(resolve, 80));
+            }
+            return {
+                begins: window.__externalChatOverlayBegins,
+                updates: window.__externalChatOverlayUpdates,
+            };
+        }
+        """
+    )
+
+    assert len(result["updates"]) == 7
+    assert result["updates"][0]["tutorialRunId"] == "external-different-run"
+    retry_run_ids = {update["tutorialRunId"] for update in result["updates"][1:]}
+    assert len(retry_run_ids) == 1
+    assert next(iter(retry_run_ids)).startswith("yui-guide-chat-")
+    assert len(result["begins"]) == 7
+    assert all(
+        "effect" not in update["payload"]["cursor"]
+        for update in result["updates"][2:]
+    )
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -2640,12 +2640,16 @@ def test_home_tutorial_input_lock_temporarily_reveals_hidden_compact_tools(
             host.setChatSurfaceMode('compact');
             host.setComposerHidden(true);
             host.setGoodbyeComposerHidden(true, 'pre-tutorial-goodbye');
+            host.setCompactChatState('options');
 
             host.setHomeTutorialInputLocked(true, 'avatar-floating-guide-day2');
             const hiddenDuringTutorial = window.__lastReactChatProps.composerHidden;
             host.setCompactToolFanOpen(true, 'avatar-floating-guide-open-tool-fan');
             const stateDuringTutorial = host.getState();
             const propsDuringTutorial = window.__lastReactChatProps;
+            host.setCompactToolFanOpen(false, 'avatar-floating-guide-close-tool-fan');
+            const compactChatStateAfterFanClose = host.getState().compactChatState;
+            host.setCompactToolFanOpen(true, 'avatar-floating-guide-reopen-tool-fan');
 
             host.setHomeTutorialInputLocked(false, 'avatar-floating-guide-day2-complete');
 
@@ -2653,6 +2657,8 @@ def test_home_tutorial_input_lock_temporarily_reveals_hidden_compact_tools(
                 hiddenDuringTutorial,
                 compactChatState: stateDuringTutorial.compactChatState,
                 fanOpen: propsDuringTutorial.compactToolFanOpenRequest.open,
+                compactChatStateAfterFanClose,
+                compactChatStateAfterTutorial: host.getState().compactChatState,
                 hiddenAfterTutorial: window.__lastReactChatProps.composerHidden,
                 composerHiddenRequestedAfterTutorial: host.getState().composerHiddenRequested,
                 goodbyeComposerHiddenAfterTutorial: host.getState().goodbyeComposerHidden,
@@ -2665,6 +2671,8 @@ def test_home_tutorial_input_lock_temporarily_reveals_hidden_compact_tools(
         "hiddenDuringTutorial": False,
         "compactChatState": "input",
         "fanOpen": True,
+        "compactChatStateAfterFanClose": "options",
+        "compactChatStateAfterTutorial": "options",
         "hiddenAfterTutorial": True,
         "composerHiddenRequestedAfterTutorial": True,
         "goodbyeComposerHiddenAfterTutorial": True,
@@ -7682,6 +7690,55 @@ def test_pc_overlay_begin_stale_response_does_not_duplicate_update(mock_page: Pa
 
 
 @pytest.mark.frontend
+def test_pc_overlay_cursor_only_begin_stale_response_does_not_duplicate_update(mock_page: Page):
+    _bootstrap_page(
+        mock_page,
+        setup_js="""
+            window.history.pushState({}, '', '/');
+            window.localStorage.setItem('yuiGuidePcOverlayRunId', 'cursor-only-begin-stale-run');
+            window.__pcOverlayUpdates = [];
+            window.__pcOverlayBeginResolvers = [];
+            window.nekoTutorialOverlay = {
+                getWindowMetricsSync: () => ({
+                    bounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    contentBounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    zoomFactor: 1,
+                }),
+                begin: () => new Promise((resolve) => window.__pcOverlayBeginResolvers.push(resolve)),
+                update: (payload) => {
+                    window.__pcOverlayUpdates.push(payload);
+                    return new Promise(() => {});
+                },
+                clear: () => Promise.resolve({ ok: true }),
+            };
+        """,
+        script_names=("tutorial/yui-guide/overlay.js",),
+    )
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            const overlay = new window.YuiGuideOverlay(document);
+            overlay.pcOverlayBridge.moveCursorOnlyTo(240, 180, 0, 'click', 420);
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const first = window.__pcOverlayUpdates[0];
+            window.__pcOverlayBeginResolvers[0]({
+                ok: false,
+                stale: true,
+                reason: 'stale-sequence',
+                activeTutorialRunId: first.tutorialRunId,
+                activeSequence: first.sequence,
+            });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            return window.__pcOverlayUpdates.length;
+        }
+        """
+    )
+
+    assert result == 1
+
+
+@pytest.mark.frontend
 def test_pc_overlay_stale_update_retry_bypasses_ready_state_dedupe(mock_page: Page):
     _bootstrap_page(
         mock_page,
@@ -7733,12 +7790,19 @@ def test_pc_overlay_stale_update_retry_bypasses_ready_state_dedupe(mock_page: Pa
                 activeSequence: staleUpdate.sequence,
             });
             await new Promise((resolve) => setTimeout(resolve, 0));
-            return window.__pcOverlayUpdates.length;
+            return {
+                updates: window.__pcOverlayUpdates.length,
+                activeSequence: staleUpdate.sequence,
+                retry: window.__pcOverlayUpdates[2],
+            };
         }
         """
     )
 
-    assert result == 3
+    assert result["updates"] == 3
+    assert result["retry"]["tutorialRunId"] == "dedupe-run"
+    # Sequence also respects the persisted and wall-clock floors, so the contract is strictly newer.
+    assert result["retry"]["sequence"] > result["activeSequence"]
 
 
 @pytest.mark.frontend
@@ -7876,15 +7940,26 @@ def test_external_chat_ignores_late_stale_response_from_replaced_run(mock_page: 
                 activeSequence: oldUpdate.sequence,
             });
             await new Promise((resolve) => setTimeout(resolve, 0));
+            const afterLateResponse = window.__externalChatOverlayUpdates.length;
+            const previousNewRunUpdate = window.__externalChatOverlayUpdates.find(
+                (update) => update.tutorialRunId === 'new-run'
+            );
+            relayCursor('new-run', Date.now() + 2);
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const latestNewRunUpdate = window.__externalChatOverlayUpdates.at(-1);
             return {
                 beforeLateResponse,
-                afterLateResponse: window.__externalChatOverlayUpdates.length,
+                afterLateResponse,
+                previousNewRunUpdate,
+                latestNewRunUpdate,
             };
         }
         """
     )
 
     assert result["afterLateResponse"] == result["beforeLateResponse"]
+    assert result["latestNewRunUpdate"]["tutorialRunId"] == "new-run"
+    assert result["latestNewRunUpdate"]["sequence"] > result["previousNewRunUpdate"]["sequence"]
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -6412,6 +6412,73 @@ def test_externalized_chat_cursor_retries_position_without_replaying_click(mock_
 
 
 @pytest.mark.frontend
+def test_externalized_chat_cursor_preserves_click_when_first_placement_fails(mock_page: Page):
+    _bootstrap_page(
+        mock_page,
+        setup_js="""
+            window.history.pushState({}, '', '/chat');
+            window.__externalChatOverlayUpdates = [];
+            window.nekoTutorialOverlay = {
+                getWindowMetricsSync: () => ({
+                    bounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    contentBounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    zoomFactor: 1,
+                }),
+                update: (payload) => {
+                    window.__externalChatOverlayUpdates.push(payload);
+                    return Promise.resolve({ ok: true });
+                },
+                begin: () => Promise.resolve({ ok: true }),
+                clear: () => Promise.resolve({ ok: true }),
+            };
+            window.localStorage.setItem('yuiGuidePcOverlayRunId', 'test-run');
+            document.body.innerHTML = '<div id="react-chat-window-root"></div>';
+            window.reactChatWindowHost = {
+                openWindow: () => {
+                    window.setTimeout(() => {
+                        document.getElementById('react-chat-window-root').innerHTML = `
+                            <button
+                                class="send-button-circle compact-input-tool-toggle"
+                                style="position:fixed; left:500px; top:200px; width:42px; height:42px;"
+                            ></button>
+                        `;
+                    }, 100);
+                },
+            };
+        """,
+        script_names=("app/app-interpage",),
+    )
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            window.postMessage({
+                __nekoTutorialOverlayRelay: true,
+                payload: {
+                    action: 'yui_guide_set_chat_cursor',
+                    kind: 'tool-toggle',
+                    effect: 'click',
+                    effectDurationMs: 420,
+                    durationMs: 0,
+                    timestamp: Date.now(),
+                    tutorialRunId: 'test-run',
+                },
+            }, '*');
+            await new Promise((resolve) => setTimeout(resolve, 850));
+            return window.__externalChatOverlayUpdates
+                .map((update) => update && update.payload && update.payload.cursor)
+                .filter((cursor) => cursor && cursor.visible === true);
+        }
+        """
+    )
+
+    assert len(result) == 1
+    assert result[0]["x"] == 521
+    assert result[0]["effect"] == "click"
+    assert result[0]["effectDurationMs"] == 420
+
+
+@pytest.mark.frontend
 def test_externalized_chat_cursor_anchor_reports_after_pc_move_duration(
     mock_page: Page,
 ):
@@ -7556,6 +7623,268 @@ def test_externalized_chat_capsule_input_spotlight_uses_capsule_body_rect_withou
     assert spotlight["id"] == "external-chat-capsule-input"
     assert spotlight["x"] == 692
     assert spotlight["width"] == 446
+
+
+@pytest.mark.frontend
+def test_pc_overlay_begin_stale_response_does_not_duplicate_update(mock_page: Page):
+    _bootstrap_page(
+        mock_page,
+        setup_js="""
+            window.history.pushState({}, '', '/');
+            window.localStorage.setItem('yuiGuidePcOverlayRunId', 'begin-stale-run');
+            window.__pcOverlayBegins = [];
+            window.__pcOverlayUpdates = [];
+            window.__pcOverlayBeginResolvers = [];
+            window.nekoTutorialOverlay = {
+                getWindowMetricsSync: () => ({
+                    bounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    contentBounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    zoomFactor: 1,
+                }),
+                begin: (payload) => {
+                    window.__pcOverlayBegins.push(payload);
+                    return new Promise((resolve) => window.__pcOverlayBeginResolvers.push(resolve));
+                },
+                update: (payload) => {
+                    window.__pcOverlayUpdates.push(payload);
+                    return new Promise(() => {});
+                },
+                clear: () => Promise.resolve({ ok: true }),
+            };
+        """,
+        script_names=("tutorial/yui-guide/overlay.js",),
+    )
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            const overlay = new window.YuiGuideOverlay(document);
+            overlay.pcOverlayBridge.setSpotlights([{
+                kind: 'input',
+                rect: { left: 100, top: 120, width: 240, height: 56, radius: 18 },
+            }]);
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const first = window.__pcOverlayUpdates[0];
+            window.__pcOverlayBeginResolvers[0]({
+                ok: false,
+                stale: true,
+                reason: 'stale-sequence',
+                activeTutorialRunId: first.tutorialRunId,
+                activeSequence: first.sequence,
+            });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            return window.__pcOverlayUpdates.length;
+        }
+        """
+    )
+
+    assert result == 1
+
+
+@pytest.mark.frontend
+def test_pc_overlay_stale_update_retry_bypasses_ready_state_dedupe(mock_page: Page):
+    _bootstrap_page(
+        mock_page,
+        setup_js="""
+            window.history.pushState({}, '', '/');
+            window.localStorage.setItem('yuiGuidePcOverlayRunId', 'dedupe-run');
+            window.__pcOverlayUpdates = [];
+            window.__pcOverlayUpdateResolvers = [];
+            window.nekoTutorialOverlay = {
+                getWindowMetricsSync: () => ({
+                    bounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    contentBounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    zoomFactor: 1,
+                }),
+                begin: () => Promise.resolve({ ok: true }),
+                update: (payload) => {
+                    window.__pcOverlayUpdates.push(payload);
+                    if (window.__pcOverlayUpdates.length === 1) {
+                        return Promise.resolve({ ok: true });
+                    }
+                    return new Promise((resolve) => window.__pcOverlayUpdateResolvers.push(resolve));
+                },
+                clear: () => Promise.resolve({ ok: true }),
+            };
+        """,
+        script_names=("tutorial/yui-guide/overlay.js",),
+    )
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            const overlay = new window.YuiGuideOverlay(document);
+            overlay.pcOverlayBridge.setSpotlights([{
+                kind: 'input',
+                rect: { left: 100, top: 120, width: 240, height: 56, radius: 18 },
+            }]);
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            overlay.pcOverlayBridge.setSpotlights([{
+                kind: 'input',
+                rect: { left: 420, top: 220, width: 240, height: 56, radius: 18 },
+            }]);
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const staleUpdate = window.__pcOverlayUpdates[1];
+            window.__pcOverlayUpdateResolvers[0]({
+                ok: false,
+                stale: true,
+                reason: 'stale-sequence',
+                activeTutorialRunId: staleUpdate.tutorialRunId,
+                activeSequence: staleUpdate.sequence,
+            });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            return window.__pcOverlayUpdates.length;
+        }
+        """
+    )
+
+    assert result == 3
+
+
+@pytest.mark.frontend
+def test_external_chat_begin_stale_response_does_not_duplicate_update(mock_page: Page):
+    _bootstrap_page(
+        mock_page,
+        setup_js="""
+            window.history.pushState({}, '', '/chat');
+            window.localStorage.setItem('yuiGuidePcOverlayRunId', 'external-begin-run');
+            window.__externalChatOverlayUpdates = [];
+            window.__externalChatBeginResolvers = [];
+            window.nekoTutorialOverlay = {
+                getWindowMetricsSync: () => ({
+                    bounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    contentBounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    zoomFactor: 1,
+                }),
+                begin: () => new Promise((resolve) => window.__externalChatBeginResolvers.push(resolve)),
+                update: (payload) => {
+                    window.__externalChatOverlayUpdates.push(payload);
+                    return new Promise(() => {});
+                },
+                clear: () => Promise.resolve({ ok: true }),
+            };
+            document.body.innerHTML = `
+                <div id="react-chat-window-root">
+                    <button
+                        class="send-button-circle compact-input-tool-toggle"
+                        style="position:fixed; left:100px; top:200px; width:42px; height:42px;"
+                    ></button>
+                </div>
+            `;
+        """,
+        script_names=("app/app-interpage",),
+    )
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            window.postMessage({
+                __nekoTutorialOverlayRelay: true,
+                payload: {
+                    action: 'yui_guide_set_chat_cursor',
+                    kind: 'tool-toggle',
+                    effect: 'click',
+                    effectDurationMs: 420,
+                    durationMs: 0,
+                    timestamp: Date.now(),
+                    tutorialRunId: 'external-begin-run',
+                },
+            }, '*');
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const first = window.__externalChatOverlayUpdates[0];
+            window.__externalChatBeginResolvers[0]({
+                ok: false,
+                stale: true,
+                reason: 'stale-sequence',
+                activeTutorialRunId: first.tutorialRunId,
+                activeSequence: first.sequence,
+            });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            return window.__externalChatOverlayUpdates.length;
+        }
+        """
+    )
+
+    assert result == 1
+
+
+@pytest.mark.frontend
+def test_external_chat_ignores_late_stale_response_from_replaced_run(mock_page: Page):
+    _bootstrap_page(
+        mock_page,
+        setup_js="""
+            window.history.pushState({}, '', '/chat');
+            window.localStorage.setItem('yuiGuidePcOverlayRunId', 'old-run');
+            window.__externalChatOverlayUpdates = [];
+            window.__externalChatUpdateResolvers = {};
+            window.nekoTutorialOverlay = {
+                getWindowMetricsSync: () => ({
+                    bounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    contentBounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    zoomFactor: 1,
+                }),
+                begin: () => Promise.resolve({ ok: true }),
+                update: (payload) => {
+                    window.__externalChatOverlayUpdates.push(payload);
+                    return new Promise((resolve) => {
+                        window.__externalChatUpdateResolvers[payload.tutorialRunId] = resolve;
+                    });
+                },
+                clear: () => Promise.resolve({ ok: true }),
+            };
+            document.body.innerHTML = `
+                <div id="react-chat-window-root">
+                    <button
+                        class="send-button-circle compact-input-tool-toggle"
+                        style="position:fixed; left:100px; top:200px; width:42px; height:42px;"
+                    ></button>
+                </div>
+            `;
+        """,
+        script_names=("app/app-interpage",),
+    )
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            const relayCursor = (runId, timestamp) => window.postMessage({
+                __nekoTutorialOverlayRelay: true,
+                payload: {
+                    action: 'yui_guide_set_chat_cursor',
+                    kind: 'tool-toggle',
+                    effect: 'click',
+                    effectDurationMs: 420,
+                    durationMs: 0,
+                    timestamp,
+                    tutorialRunId: runId,
+                },
+            }, '*');
+            relayCursor('old-run', Date.now());
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            window.localStorage.setItem('yuiGuidePcOverlayRunId', 'new-run');
+            relayCursor('new-run', Date.now() + 1);
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const beforeLateResponse = window.__externalChatOverlayUpdates.length;
+            const oldUpdate = window.__externalChatOverlayUpdates.find(
+                (update) => update.tutorialRunId === 'old-run'
+            );
+            window.__externalChatUpdateResolvers['old-run']({
+                ok: false,
+                stale: true,
+                reason: 'stale-sequence',
+                activeTutorialRunId: 'old-run',
+                activeSequence: oldUpdate.sequence,
+            });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            return {
+                beforeLateResponse,
+                afterLateResponse: window.__externalChatOverlayUpdates.length,
+            };
+        }
+        """
+    )
+
+    assert result["afterLateResponse"] == result["beforeLateResponse"]
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -7790,19 +7790,111 @@ def test_pc_overlay_stale_update_retry_bypasses_ready_state_dedupe(mock_page: Pa
                 activeSequence: staleUpdate.sequence,
             });
             await new Promise((resolve) => setTimeout(resolve, 0));
+            const firstRetry = window.__pcOverlayUpdates[2];
+            window.__pcOverlayUpdateResolvers[1]({
+                ok: false,
+                stale: true,
+                reason: 'stale-sequence',
+                activeTutorialRunId: firstRetry.tutorialRunId,
+                activeSequence: firstRetry.sequence,
+            });
+            await new Promise((resolve) => setTimeout(resolve, 0));
             return {
                 updates: window.__pcOverlayUpdates.length,
                 activeSequence: staleUpdate.sequence,
-                retry: window.__pcOverlayUpdates[2],
+                firstRetry,
+                secondRetry: window.__pcOverlayUpdates[3],
             };
         }
         """
     )
 
-    assert result["updates"] == 3
-    assert result["retry"]["tutorialRunId"] == "dedupe-run"
+    assert result["updates"] == 4
+    assert result["firstRetry"]["tutorialRunId"] == "dedupe-run"
+    assert result["secondRetry"]["tutorialRunId"] == "dedupe-run"
     # Sequence also respects the persisted and wall-clock floors, so the contract is strictly newer.
-    assert result["retry"]["sequence"] > result["activeSequence"]
+    assert result["firstRetry"]["sequence"] > result["activeSequence"]
+    assert result["secondRetry"]["sequence"] > result["firstRetry"]["sequence"]
+
+
+@pytest.mark.frontend
+def test_pc_overlay_cursor_only_bounds_repeated_same_run_stale_retries(mock_page: Page):
+    _bootstrap_page(
+        mock_page,
+        setup_js="""
+            window.history.pushState({}, '', '/');
+            window.localStorage.setItem('yuiGuidePcOverlayRunId', 'cursor-retry-run');
+            window.__pcOverlayUpdates = [];
+            window.__pcOverlayUpdateResolvers = [];
+            window.nekoTutorialOverlay = {
+                getWindowMetricsSync: () => ({
+                    bounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    contentBounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    zoomFactor: 1,
+                }),
+                begin: () => Promise.resolve({ ok: true }),
+                update: (payload) => {
+                    window.__pcOverlayUpdates.push(payload);
+                    return new Promise((resolve) => window.__pcOverlayUpdateResolvers.push(resolve));
+                },
+                clear: () => Promise.resolve({ ok: true }),
+            };
+        """,
+        script_names=("tutorial/yui-guide/overlay.js",),
+    )
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            const overlay = new window.YuiGuideOverlay(document);
+            overlay.pcOverlayBridge.moveCursorOnlyTo(240, 180, 0, 'click', 420);
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const first = window.__pcOverlayUpdates[0];
+            window.__pcOverlayUpdateResolvers[0]({
+                ok: false,
+                stale: true,
+                reason: 'stale-sequence',
+                activeTutorialRunId: first.tutorialRunId,
+                activeSequence: first.sequence,
+            });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const firstRetry = window.__pcOverlayUpdates[1];
+            window.__pcOverlayUpdateResolvers[1]({
+                ok: false,
+                stale: true,
+                reason: 'stale-sequence',
+                activeTutorialRunId: firstRetry.tutorialRunId,
+                activeSequence: firstRetry.sequence,
+            });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const secondRetry = window.__pcOverlayUpdates[2];
+            window.__pcOverlayUpdateResolvers[2]({
+                ok: false,
+                stale: true,
+                reason: 'stale-sequence',
+                activeTutorialRunId: secondRetry.tutorialRunId,
+                activeSequence: secondRetry.sequence,
+            });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const finalRetry = window.__pcOverlayUpdates[3];
+            window.__pcOverlayUpdateResolvers[3]({
+                ok: false,
+                stale: true,
+                reason: 'stale-sequence',
+                activeTutorialRunId: finalRetry.tutorialRunId,
+                activeSequence: finalRetry.sequence,
+            });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            return window.__pcOverlayUpdates;
+        }
+        """
+    )
+
+    assert len(result) == 4
+    assert all(update["tutorialRunId"] == "cursor-retry-run" for update in result)
+    assert result[1]["sequence"] > result[0]["sequence"]
+    assert result[2]["sequence"] > result[1]["sequence"]
+    assert result[3]["sequence"] > result[2]["sequence"]
 
 
 @pytest.mark.frontend
@@ -7870,6 +7962,85 @@ def test_external_chat_begin_stale_response_does_not_duplicate_update(mock_page:
     )
 
     assert result == 1
+
+
+@pytest.mark.frontend
+def test_external_chat_reconciles_a_second_same_run_stale_response(mock_page: Page):
+    _bootstrap_page(
+        mock_page,
+        setup_js="""
+            window.history.pushState({}, '', '/chat');
+            window.localStorage.setItem('yuiGuidePcOverlayRunId', 'external-retry-run');
+            window.__externalChatOverlayUpdates = [];
+            window.__externalChatUpdateResolvers = [];
+            window.nekoTutorialOverlay = {
+                getWindowMetricsSync: () => ({
+                    bounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    contentBounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    zoomFactor: 1,
+                }),
+                begin: () => Promise.resolve({ ok: true }),
+                update: (payload) => {
+                    window.__externalChatOverlayUpdates.push(payload);
+                    return new Promise((resolve) => window.__externalChatUpdateResolvers.push(resolve));
+                },
+                clear: () => Promise.resolve({ ok: true }),
+            };
+            document.body.innerHTML = `
+                <div id="react-chat-window-root">
+                    <button
+                        class="send-button-circle compact-input-tool-toggle"
+                        style="position:fixed; left:100px; top:200px; width:42px; height:42px;"
+                    ></button>
+                </div>
+            `;
+        """,
+        script_names=("app/app-interpage",),
+    )
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            window.postMessage({
+                __nekoTutorialOverlayRelay: true,
+                payload: {
+                    action: 'yui_guide_set_chat_cursor',
+                    kind: 'tool-toggle',
+                    effect: 'click',
+                    effectDurationMs: 420,
+                    durationMs: 0,
+                    timestamp: Date.now(),
+                    tutorialRunId: 'external-retry-run',
+                },
+            }, '*');
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const first = window.__externalChatOverlayUpdates[0];
+            window.__externalChatUpdateResolvers[0]({
+                ok: false,
+                stale: true,
+                reason: 'stale-sequence',
+                activeTutorialRunId: first.tutorialRunId,
+                activeSequence: first.sequence,
+            });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const firstRetry = window.__externalChatOverlayUpdates[1];
+            window.__externalChatUpdateResolvers[1]({
+                ok: false,
+                stale: true,
+                reason: 'stale-sequence',
+                activeTutorialRunId: firstRetry.tutorialRunId,
+                activeSequence: firstRetry.sequence,
+            });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            return window.__externalChatOverlayUpdates;
+        }
+        """
+    )
+
+    assert len(result) == 3
+    assert all(update["tutorialRunId"] == "external-retry-run" for update in result)
+    assert result[1]["sequence"] > result[0]["sequence"]
+    assert result[2]["sequence"] > result[1]["sequence"]
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -2637,13 +2637,22 @@ def test_home_tutorial_input_lock_temporarily_reveals_hidden_compact_tools(
         """
         async () => {
             const host = window.reactChatWindowHost;
+            const attachmentVisibilityEvents = [];
+            window.addEventListener('react-chat-window:composer-attachments-change', (event) => {
+                attachmentVisibilityEvents.push(event.detail && event.detail.hasAttachments);
+            });
             host.setChatSurfaceMode('compact');
             host.setComposerHidden(true);
             host.setGoodbyeComposerHidden(true, 'pre-tutorial-goodbye');
+            host.setComposerAttachments([{
+                id: 'pre-tutorial-attachment',
+                url: 'data:image/png;base64,AA==',
+            }]);
             host.setCompactChatState('options');
 
             host.setHomeTutorialInputLocked(true, 'avatar-floating-guide-day2');
             const hiddenDuringTutorial = window.__lastReactChatProps.composerHidden;
+            const attachmentsVisibleDuringTutorial = document.body.classList.contains('composer-has-attachments');
             host.setCompactToolFanOpen(true, 'avatar-floating-guide-open-tool-fan');
             const stateDuringTutorial = host.getState();
             const propsDuringTutorial = window.__lastReactChatProps;
@@ -2660,6 +2669,9 @@ def test_home_tutorial_input_lock_temporarily_reveals_hidden_compact_tools(
                 compactChatStateAfterFanClose,
                 compactChatStateAfterTutorial: host.getState().compactChatState,
                 hiddenAfterTutorial: window.__lastReactChatProps.composerHidden,
+                attachmentsVisibleDuringTutorial,
+                attachmentsVisibleAfterTutorial: document.body.classList.contains('composer-has-attachments'),
+                attachmentVisibilityEvents,
                 composerHiddenRequestedAfterTutorial: host.getState().composerHiddenRequested,
                 goodbyeComposerHiddenAfterTutorial: host.getState().goodbyeComposerHidden,
             };
@@ -2674,6 +2686,9 @@ def test_home_tutorial_input_lock_temporarily_reveals_hidden_compact_tools(
         "compactChatStateAfterFanClose": "options",
         "compactChatStateAfterTutorial": "options",
         "hiddenAfterTutorial": True,
+        "attachmentsVisibleDuringTutorial": True,
+        "attachmentsVisibleAfterTutorial": False,
+        "attachmentVisibilityEvents": [True, False],
         "composerHiddenRequestedAfterTutorial": True,
         "goodbyeComposerHiddenAfterTutorial": True,
     }
@@ -7903,6 +7918,67 @@ def test_pc_overlay_ignores_late_same_run_stale_responses_from_older_requests(
 
 
 @pytest.mark.frontend
+@pytest.mark.parametrize("cursor_only", [False, True], ids=["complete-state", "cursor-only"])
+def test_pc_overlay_ignores_same_run_stale_response_superseded_by_other_bridge(
+    mock_page: Page,
+    cursor_only: bool,
+):
+    _bootstrap_page(
+        mock_page,
+        setup_js="""
+            window.history.pushState({}, '', '/');
+            window.localStorage.setItem('yuiGuidePcOverlayRunId', 'shared-run');
+            window.__pcOverlayUpdates = [];
+            window.__pcOverlayUpdateResolvers = [];
+            window.nekoTutorialOverlay = {
+                getWindowMetricsSync: () => ({
+                    bounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    contentBounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    zoomFactor: 1,
+                }),
+                begin: () => Promise.resolve({ ok: true }),
+                update: (payload) => {
+                    window.__pcOverlayUpdates.push(payload);
+                    return new Promise((resolve) => window.__pcOverlayUpdateResolvers.push(resolve));
+                },
+                clear: () => Promise.resolve({ ok: true }),
+            };
+        """,
+        script_names=("tutorial/yui-guide/overlay.js",),
+    )
+
+    result = mock_page.evaluate(
+        """
+        async (cursorOnly) => {
+            const overlay = new window.YuiGuideOverlay(document);
+            if (cursorOnly) {
+                overlay.pcOverlayBridge.moveCursorOnlyTo(420, 220, 0, 'click', 420);
+            } else {
+                overlay.pcOverlayBridge.setSpotlights([{
+                    kind: 'input',
+                    rect: { left: 100, top: 120, width: 240, height: 56, radius: 18 },
+                }]);
+            }
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const update = window.__pcOverlayUpdates[0];
+            window.__pcOverlayUpdateResolvers[0]({
+                ok: false,
+                stale: true,
+                reason: 'stale-sequence',
+                activeTutorialRunId: update.tutorialRunId,
+                activeSequence: update.sequence + 1000,
+            });
+            await new Promise((resolve) => setTimeout(resolve, 80));
+            return window.__pcOverlayUpdates;
+        }
+        """,
+        cursor_only,
+    )
+
+    assert len(result) == 1
+
+
+@pytest.mark.frontend
 def test_pc_overlay_cursor_only_bounds_repeated_same_run_stale_retries(mock_page: Page):
     _bootstrap_page(
         mock_page,
@@ -7983,6 +8059,10 @@ def test_pc_overlay_cursor_only_bounds_repeated_same_run_stale_retries(mock_page
                 });
                 await new Promise((resolve) => setTimeout(resolve, 80));
             }
+            if (window.__pcOverlayUpdates[5]) {
+                window.__pcOverlayUpdateResolvers[5]({ ok: true });
+                await new Promise((resolve) => setTimeout(resolve, 80));
+            }
             return {
                 beforeDeferredRetry,
                 updates: window.__pcOverlayUpdates,
@@ -7992,12 +8072,13 @@ def test_pc_overlay_cursor_only_bounds_repeated_same_run_stale_retries(mock_page
     )
 
     assert result["beforeDeferredRetry"] == 4
-    assert len(result["updates"]) == 5
+    assert len(result["updates"]) == 6
     assert all(update["tutorialRunId"] == "cursor-retry-run" for update in result["updates"])
     assert result["updates"][1]["sequence"] > result["updates"][0]["sequence"]
     assert result["updates"][2]["sequence"] > result["updates"][1]["sequence"]
     assert result["updates"][3]["sequence"] > result["updates"][2]["sequence"]
     assert result["updates"][4]["sequence"] > result["updates"][3]["sequence"]
+    assert result["updates"][5]["sequence"] > result["updates"][4]["sequence"]
 
 
 @pytest.mark.frontend
@@ -8166,6 +8247,10 @@ def test_external_chat_reconciles_a_second_same_run_stale_response(mock_page: Pa
                 });
                 await new Promise((resolve) => setTimeout(resolve, 80));
             }
+            if (window.__externalChatOverlayUpdates[5]) {
+                window.__externalChatUpdateResolvers[5]({ ok: true });
+                await new Promise((resolve) => setTimeout(resolve, 80));
+            }
             return {
                 beforeDeferredRetry,
                 updates: window.__externalChatOverlayUpdates,
@@ -8175,12 +8260,13 @@ def test_external_chat_reconciles_a_second_same_run_stale_response(mock_page: Pa
     )
 
     assert result["beforeDeferredRetry"] == 4
-    assert len(result["updates"]) == 5
+    assert len(result["updates"]) == 6
     assert all(update["tutorialRunId"] == "external-retry-run" for update in result["updates"])
     assert result["updates"][1]["sequence"] > result["updates"][0]["sequence"]
     assert result["updates"][2]["sequence"] > result["updates"][1]["sequence"]
     assert result["updates"][3]["sequence"] > result["updates"][2]["sequence"]
     assert result["updates"][4]["sequence"] > result["updates"][3]["sequence"]
+    assert result["updates"][5]["sequence"] > result["updates"][4]["sequence"]
 
 
 @pytest.mark.frontend
@@ -8254,6 +8340,75 @@ def test_external_chat_ignores_late_same_run_stale_response_from_older_request(
 
     assert len(result) == 2
     assert result[1]["payload"]["cursor"]["effect"] == "wobble"
+
+
+@pytest.mark.frontend
+def test_external_chat_ignores_same_run_stale_response_superseded_by_other_bridge(
+    mock_page: Page,
+):
+    _bootstrap_page(
+        mock_page,
+        setup_js="""
+            window.history.pushState({}, '', '/chat');
+            window.localStorage.setItem('yuiGuidePcOverlayRunId', 'external-shared-run');
+            window.__externalChatOverlayUpdates = [];
+            window.__externalChatUpdateResolvers = [];
+            window.nekoTutorialOverlay = {
+                getWindowMetricsSync: () => ({
+                    bounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    contentBounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    zoomFactor: 1,
+                }),
+                begin: () => Promise.resolve({ ok: true }),
+                update: (payload) => {
+                    window.__externalChatOverlayUpdates.push(payload);
+                    return new Promise((resolve) => window.__externalChatUpdateResolvers.push(resolve));
+                },
+                clear: () => Promise.resolve({ ok: true }),
+            };
+            document.body.innerHTML = `
+                <div id="react-chat-window-root">
+                    <button
+                        class="send-button-circle compact-input-tool-toggle"
+                        style="position:fixed; left:100px; top:200px; width:42px; height:42px;"
+                    ></button>
+                </div>
+            `;
+        """,
+        script_names=("app/app-interpage",),
+    )
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            window.postMessage({
+                __nekoTutorialOverlayRelay: true,
+                payload: {
+                    action: 'yui_guide_set_chat_cursor',
+                    kind: 'tool-toggle',
+                    effect: 'click',
+                    effectDurationMs: 420,
+                    durationMs: 0,
+                    timestamp: Date.now(),
+                    tutorialRunId: 'external-shared-run',
+                },
+            }, '*');
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const update = window.__externalChatOverlayUpdates[0];
+            window.__externalChatUpdateResolvers[0]({
+                ok: false,
+                stale: true,
+                reason: 'stale-sequence',
+                activeTutorialRunId: update.tutorialRunId,
+                activeSequence: update.sequence + 1000,
+            });
+            await new Promise((resolve) => setTimeout(resolve, 80));
+            return window.__externalChatOverlayUpdates;
+        }
+        """
+    )
+
+    assert len(result) == 1
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -6041,6 +6041,9 @@ def test_externalized_chat_cursor_reports_anchor_back_to_home(mock_page: Page):
             const updates = [];
             window.__externalChatAnchorRelays = relays;
             window.__externalChatOverlayUpdates = updates;
+            window.reactChatWindowHost = {
+                openWindow: () => {},
+            };
             window.nekoTutorialOverlay = {
                 getWindowMetricsSync: () => ({
                     bounds: { x: 100, y: 50, width: 1200, height: 800 },
@@ -6077,11 +6080,9 @@ def test_externalized_chat_cursor_reports_anchor_back_to_home(mock_page: Page):
                     tutorialRunId: 'test-run',
                 },
             }, '*');
-            await new Promise((resolve) => setTimeout(resolve, 80));
-            const raw = window.localStorage.getItem('neko_yui_guide_external_chat_cursor_screen_point_v1');
+            await new Promise((resolve) => setTimeout(resolve, 780));
             return {
                 relays: window.__externalChatAnchorRelays,
-                stored: raw ? JSON.parse(raw) : null,
                 updates: window.__externalChatOverlayUpdates,
             };
         }
@@ -6096,13 +6097,9 @@ def test_externalized_chat_cursor_reports_anchor_back_to_home(mock_page: Page):
     assert anchorRelays[-1]["x"] == 820
     assert anchorRelays[-1]["y"] == 530
     assert anchorRelays[-1]["kind"] == "window"
-    assert anchorRelays[-1]["effect"] == ""
-    assert anchorRelays[-1]["effectDurationMs"] == 0
+    assert anchorRelays[-1]["effect"] == "wobble"
+    assert anchorRelays[-1]["effectDurationMs"] == 2000
     assert anchorRelays[-1]["source"] == "external-chat"
-    assert result["stored"]["x"] == 820
-    assert result["stored"]["y"] == 530
-    assert result["stored"]["effect"] == ""
-    assert result["stored"]["effectDurationMs"] == 0
     assert any(
         update.get("payload", {}).get("cursor", {}).get("visible") is True
         and update["payload"]["cursor"]["x"] == 820
@@ -6111,6 +6108,14 @@ def test_externalized_chat_cursor_reports_anchor_back_to_home(mock_page: Page):
         and update["payload"]["cursor"].get("effectDurationMs") == 2000
         for update in result["updates"]
     )
+    cursor_updates = [
+        update["payload"]["cursor"]
+        for update in result["updates"]
+        if update.get("payload", {}).get("cursor")
+    ]
+    assert cursor_updates
+    assert cursor_updates[-1].get("effect") == "wobble"
+    assert cursor_updates[-1].get("effectDurationMs") == 2000
 
 
 @pytest.mark.frontend
@@ -7818,6 +7823,86 @@ def test_pc_overlay_stale_update_retry_bypasses_ready_state_dedupe(mock_page: Pa
 
 
 @pytest.mark.frontend
+def test_pc_overlay_ignores_late_same_run_stale_responses_from_older_requests(
+    mock_page: Page,
+):
+    _bootstrap_page(
+        mock_page,
+        setup_js="""
+            window.history.pushState({}, '', '/');
+            window.localStorage.setItem('yuiGuidePcOverlayRunId', 'same-run');
+            window.__pcOverlayUpdates = [];
+            window.__pcOverlayUpdateResolvers = [];
+            window.nekoTutorialOverlay = {
+                getWindowMetricsSync: () => ({
+                    bounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    contentBounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    zoomFactor: 1,
+                }),
+                begin: () => Promise.resolve({ ok: true }),
+                update: (payload) => {
+                    window.__pcOverlayUpdates.push(payload);
+                    return new Promise((resolve) => window.__pcOverlayUpdateResolvers.push(resolve));
+                },
+                clear: () => Promise.resolve({ ok: true }),
+            };
+        """,
+        script_names=("tutorial/yui-guide/overlay.js",),
+    )
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            const overlay = new window.YuiGuideOverlay(document);
+            overlay.pcOverlayBridge.setSpotlights([{
+                kind: 'input',
+                rect: { left: 100, top: 120, width: 240, height: 56, radius: 18 },
+            }]);
+            overlay.pcOverlayBridge.moveCursorOnlyTo(420, 220, 0, 'click', 420);
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const newerCursorUpdate = window.__pcOverlayUpdates[1];
+            window.__pcOverlayUpdateResolvers[1]({ ok: true });
+            window.__pcOverlayUpdateResolvers[0]({
+                ok: false,
+                stale: true,
+                reason: 'stale-sequence',
+                activeTutorialRunId: newerCursorUpdate.tutorialRunId,
+                activeSequence: newerCursorUpdate.sequence,
+            });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const updatesAfterOlderSpotlightResponse = window.__pcOverlayUpdates.length;
+
+            overlay.pcOverlayBridge.moveCursorOnlyTo(520, 320, 0, 'click', 420);
+            overlay.pcOverlayBridge.setSpotlights([{
+                kind: 'window',
+                rect: { left: 300, top: 260, width: 360, height: 180, radius: 24 },
+            }]);
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const newerSpotlightUpdate = window.__pcOverlayUpdates[3];
+            window.__pcOverlayUpdateResolvers[3]({ ok: true });
+            window.__pcOverlayUpdateResolvers[2]({
+                ok: false,
+                stale: true,
+                reason: 'stale-sequence',
+                activeTutorialRunId: newerSpotlightUpdate.tutorialRunId,
+                activeSequence: newerSpotlightUpdate.sequence,
+            });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            return {
+                updatesAfterOlderSpotlightResponse,
+                updates: window.__pcOverlayUpdates,
+            };
+        }
+        """
+    )
+
+    assert result["updatesAfterOlderSpotlightResponse"] == 2
+    assert len(result["updates"]) == 4
+    assert result["updates"][1]["payload"]["cursor"]["x"] == 420
+    assert result["updates"][3]["payload"]["spotlights"][0]["kind"] == "window"
+
+
+@pytest.mark.frontend
 def test_pc_overlay_cursor_only_bounds_repeated_same_run_stale_retries(mock_page: Page):
     _bootstrap_page(
         mock_page,
@@ -7885,16 +7970,34 @@ def test_pc_overlay_cursor_only_bounds_repeated_same_run_stale_retries(mock_page
                 activeSequence: finalRetry.sequence,
             });
             await new Promise((resolve) => setTimeout(resolve, 0));
-            return window.__pcOverlayUpdates;
+            const beforeDeferredRetry = window.__pcOverlayUpdates.length;
+            await new Promise((resolve) => setTimeout(resolve, 80));
+            if (window.__pcOverlayUpdates[4]) {
+                const deferredRetry = window.__pcOverlayUpdates[4];
+                window.__pcOverlayUpdateResolvers[4]({
+                    ok: false,
+                    stale: true,
+                    reason: 'stale-sequence',
+                    activeTutorialRunId: deferredRetry.tutorialRunId,
+                    activeSequence: deferredRetry.sequence,
+                });
+                await new Promise((resolve) => setTimeout(resolve, 80));
+            }
+            return {
+                beforeDeferredRetry,
+                updates: window.__pcOverlayUpdates,
+            };
         }
         """
     )
 
-    assert len(result) == 4
-    assert all(update["tutorialRunId"] == "cursor-retry-run" for update in result)
-    assert result[1]["sequence"] > result[0]["sequence"]
-    assert result[2]["sequence"] > result[1]["sequence"]
-    assert result[3]["sequence"] > result[2]["sequence"]
+    assert result["beforeDeferredRetry"] == 4
+    assert len(result["updates"]) == 5
+    assert all(update["tutorialRunId"] == "cursor-retry-run" for update in result["updates"])
+    assert result["updates"][1]["sequence"] > result["updates"][0]["sequence"]
+    assert result["updates"][2]["sequence"] > result["updates"][1]["sequence"]
+    assert result["updates"][3]["sequence"] > result["updates"][2]["sequence"]
+    assert result["updates"][4]["sequence"] > result["updates"][3]["sequence"]
 
 
 @pytest.mark.frontend
@@ -8032,15 +8135,125 @@ def test_external_chat_reconciles_a_second_same_run_stale_response(mock_page: Pa
                 activeSequence: firstRetry.sequence,
             });
             await new Promise((resolve) => setTimeout(resolve, 0));
+            const secondRetry = window.__externalChatOverlayUpdates[2];
+            window.__externalChatUpdateResolvers[2]({
+                ok: false,
+                stale: true,
+                reason: 'stale-sequence',
+                activeTutorialRunId: secondRetry.tutorialRunId,
+                activeSequence: secondRetry.sequence,
+            });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const finalRetry = window.__externalChatOverlayUpdates[3];
+            window.__externalChatUpdateResolvers[3]({
+                ok: false,
+                stale: true,
+                reason: 'stale-sequence',
+                activeTutorialRunId: finalRetry.tutorialRunId,
+                activeSequence: finalRetry.sequence,
+            });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const beforeDeferredRetry = window.__externalChatOverlayUpdates.length;
+            await new Promise((resolve) => setTimeout(resolve, 80));
+            if (window.__externalChatOverlayUpdates[4]) {
+                const deferredRetry = window.__externalChatOverlayUpdates[4];
+                window.__externalChatUpdateResolvers[4]({
+                    ok: false,
+                    stale: true,
+                    reason: 'stale-sequence',
+                    activeTutorialRunId: deferredRetry.tutorialRunId,
+                    activeSequence: deferredRetry.sequence,
+                });
+                await new Promise((resolve) => setTimeout(resolve, 80));
+            }
+            return {
+                beforeDeferredRetry,
+                updates: window.__externalChatOverlayUpdates,
+            };
+        }
+        """
+    )
+
+    assert result["beforeDeferredRetry"] == 4
+    assert len(result["updates"]) == 5
+    assert all(update["tutorialRunId"] == "external-retry-run" for update in result["updates"])
+    assert result["updates"][1]["sequence"] > result["updates"][0]["sequence"]
+    assert result["updates"][2]["sequence"] > result["updates"][1]["sequence"]
+    assert result["updates"][3]["sequence"] > result["updates"][2]["sequence"]
+    assert result["updates"][4]["sequence"] > result["updates"][3]["sequence"]
+
+
+@pytest.mark.frontend
+def test_external_chat_ignores_late_same_run_stale_response_from_older_request(
+    mock_page: Page,
+):
+    _bootstrap_page(
+        mock_page,
+        setup_js="""
+            window.history.pushState({}, '', '/chat');
+            window.localStorage.setItem('yuiGuidePcOverlayRunId', 'external-same-run');
+            window.__externalChatOverlayUpdates = [];
+            window.__externalChatUpdateResolvers = [];
+            window.nekoTutorialOverlay = {
+                getWindowMetricsSync: () => ({
+                    bounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    contentBounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    zoomFactor: 1,
+                }),
+                begin: () => Promise.resolve({ ok: true }),
+                update: (payload) => {
+                    window.__externalChatOverlayUpdates.push(payload);
+                    return new Promise((resolve) => window.__externalChatUpdateResolvers.push(resolve));
+                },
+                clear: () => Promise.resolve({ ok: true }),
+            };
+            document.body.innerHTML = `
+                <div id="react-chat-window-root">
+                    <button
+                        class="send-button-circle compact-input-tool-toggle"
+                        style="position:fixed; left:100px; top:200px; width:42px; height:42px;"
+                    ></button>
+                </div>
+            `;
+        """,
+        script_names=("app/app-interpage",),
+    )
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            const relayCursor = (effect, timestamp) => window.postMessage({
+                __nekoTutorialOverlayRelay: true,
+                payload: {
+                    action: 'yui_guide_set_chat_cursor',
+                    kind: 'tool-toggle',
+                    effect,
+                    effectDurationMs: 420,
+                    durationMs: 0,
+                    timestamp,
+                    tutorialRunId: 'external-same-run',
+                },
+            }, '*');
+            relayCursor('click', Date.now());
+            relayCursor('wobble', Date.now() + 1);
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const newerUpdate = window.__externalChatOverlayUpdates[1];
+            window.__externalChatUpdateResolvers[1]({ ok: true });
+            window.__externalChatUpdateResolvers[0]({
+                ok: false,
+                stale: true,
+                reason: 'stale-sequence',
+                activeTutorialRunId: newerUpdate.tutorialRunId,
+                activeSequence: newerUpdate.sequence,
+            });
+            await new Promise((resolve) => setTimeout(resolve, 0));
             return window.__externalChatOverlayUpdates;
         }
         """
     )
 
-    assert len(result) == 3
-    assert all(update["tutorialRunId"] == "external-retry-run" for update in result)
-    assert result[1]["sequence"] > result[0]["sequence"]
-    assert result[2]["sequence"] > result[1]["sequence"]
+    assert len(result) == 2
+    assert result[1]["payload"]["cursor"]["effect"] == "wobble"
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -2600,6 +2600,78 @@ def test_home_tutorial_input_lock_suppresses_galgame_options_without_tutorial_ev
 
 
 @pytest.mark.frontend
+def test_home_tutorial_input_lock_temporarily_reveals_hidden_compact_tools(
+    mock_page: Page,
+):
+    _bootstrap_page(
+        mock_page,
+        setup_js="""
+            document.body.innerHTML = `
+                <div id="react-chat-window-overlay" hidden>
+                    <div id="react-chat-window-shell">
+                        <div id="react-chat-window-drag-handle"></div>
+                        <div id="react-chat-window-root"></div>
+                    </div>
+                </div>
+            `;
+            window.NekoChatWindow = {
+                mount: (_root, props) => {
+                    window.__lastReactChatProps = props;
+                },
+            };
+        """,
+        script_names=("app/app-react-chat-window",),
+    )
+
+    mock_page.evaluate(
+        """
+        async () => {
+            await window.reactChatWindowHost.ensureBundleLoaded();
+            window.reactChatWindowHost.openWindow();
+        }
+        """
+    )
+    mock_page.wait_for_function("() => !!window.__lastReactChatProps", timeout=5000)
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            const host = window.reactChatWindowHost;
+            host.setChatSurfaceMode('compact');
+            host.setComposerHidden(true);
+            host.setGoodbyeComposerHidden(true, 'pre-tutorial-goodbye');
+
+            host.setHomeTutorialInputLocked(true, 'avatar-floating-guide-day2');
+            const hiddenDuringTutorial = window.__lastReactChatProps.composerHidden;
+            host.setCompactToolFanOpen(true, 'avatar-floating-guide-open-tool-fan');
+            const stateDuringTutorial = host.getState();
+            const propsDuringTutorial = window.__lastReactChatProps;
+
+            host.setHomeTutorialInputLocked(false, 'avatar-floating-guide-day2-complete');
+
+            return {
+                hiddenDuringTutorial,
+                compactChatState: stateDuringTutorial.compactChatState,
+                fanOpen: propsDuringTutorial.compactToolFanOpenRequest.open,
+                hiddenAfterTutorial: window.__lastReactChatProps.composerHidden,
+                composerHiddenRequestedAfterTutorial: host.getState().composerHiddenRequested,
+                goodbyeComposerHiddenAfterTutorial: host.getState().goodbyeComposerHidden,
+            };
+        }
+        """
+    )
+
+    assert result == {
+        "hiddenDuringTutorial": False,
+        "compactChatState": "input",
+        "fanOpen": True,
+        "hiddenAfterTutorial": True,
+        "composerHiddenRequestedAfterTutorial": True,
+        "goodbyeComposerHiddenAfterTutorial": True,
+    }
+
+
+@pytest.mark.frontend
 def test_home_tutorial_feature_controller_restores_live_galgame_state_after_legacy_listener(
     mock_page: Page,
 ):
@@ -6264,6 +6336,79 @@ def test_externalized_chat_cursor_explicit_duration_overrides_handoff_speed(
     assert result["y"] == 471
     assert result["effect"] == "move"
     assert result["durationMs"] == 1480
+
+
+@pytest.mark.frontend
+def test_externalized_chat_cursor_retries_position_without_replaying_click(mock_page: Page):
+    _bootstrap_page(
+        mock_page,
+        setup_js="""
+            window.history.pushState({}, '', '/chat');
+            window.__externalChatOverlayUpdates = [];
+            window.nekoTutorialOverlay = {
+                getWindowMetricsSync: () => ({
+                    bounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    contentBounds: { x: 0, y: 0, width: 1200, height: 800 },
+                    zoomFactor: 1,
+                }),
+                update: (payload) => {
+                    window.__externalChatOverlayUpdates.push(payload);
+                    return Promise.resolve({ ok: true });
+                },
+                begin: () => Promise.resolve({ ok: true }),
+                clear: () => Promise.resolve({ ok: true }),
+            };
+            window.localStorage.setItem('yuiGuidePcOverlayRunId', 'test-run');
+            document.body.innerHTML = `
+                <div id="react-chat-window-root">
+                    <button
+                        id="tutorial-tool-toggle"
+                        class="send-button-circle compact-input-tool-toggle"
+                        style="position:fixed; left:100px; top:200px; width:42px; height:42px;"
+                    ></button>
+                </div>
+            `;
+            window.reactChatWindowHost = {
+                openWindow: () => {
+                    window.setTimeout(() => {
+                        document.getElementById('tutorial-tool-toggle').style.left = '500px';
+                    }, 100);
+                },
+            };
+        """,
+        script_names=("app/app-interpage",),
+    )
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            window.postMessage({
+                __nekoTutorialOverlayRelay: true,
+                payload: {
+                    action: 'yui_guide_set_chat_cursor',
+                    kind: 'tool-toggle',
+                    effect: 'click',
+                    effectDurationMs: 420,
+                    durationMs: 0,
+                    timestamp: Date.now(),
+                    tutorialRunId: 'test-run',
+                },
+            }, '*');
+            await new Promise((resolve) => setTimeout(resolve, 850));
+            return window.__externalChatOverlayUpdates
+                .map((update) => update && update.payload && update.payload.cursor)
+                .filter((cursor) => cursor && cursor.visible === true);
+        }
+        """
+    )
+
+    assert len(result) >= 2
+    assert result[0]["x"] == 121
+    assert result[0]["effect"] == "click"
+    assert result[0]["effectDurationMs"] == 420
+    assert result[-1]["x"] == 521
+    assert result[-1]["effect"] == ""
+    assert result[-1]["effectDurationMs"] == 0
 
 
 @pytest.mark.frontend

--- a/tests/unit/test_avatar_floating_day1_round_contracts.py
+++ b/tests/unit/test_avatar_floating_day1_round_contracts.py
@@ -788,7 +788,8 @@ def test_pc_overlay_resistance_cursor_uses_cursor_only_patch_without_touching_sp
 
     assert "const payload = completeStateStore.applyPatch({ cursor: cursor });" in cursor_only_block
     assert "const payload = { cursor: cursor };" not in cursor_only_block
-    assert "handleCursorOnlyStaleResult(result, cursor, retried === true, beginRunId);" in cursor_only_block
+    assert "handleCursorOnlyStaleResult(result, cursor, retried === true, updateRunId);" in cursor_only_block
+    assert "handleCursorOnlyStaleResult(result, cursor, retried === true, beginRunId);" not in cursor_only_block
     assert "result && result.ok === false" in cursor_only_block
     assert "moveCursorOnlyTo(x, y, durationMs, effect, effectDurationMs)" in overlay_source
     assert "normalizedOptions.forcePcOverlay === true" in move_cursor_block

--- a/tests/unit/test_avatar_floating_day1_round_contracts.py
+++ b/tests/unit/test_avatar_floating_day1_round_contracts.py
@@ -605,8 +605,12 @@ def test_pc_overlay_sequence_collision_retries_without_rotating_tutorial_run():
     assert "retryCount === PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES" in overlay_source
     assert "scheduleYuiGuidePcOverlayDeferredReconciliation(" in interpage_source
     assert "scheduleDeferredReconciliation(retryCount)" in overlay_source
+    assert "sendYuiGuidePcOverlayPatch(patch || {}, retryCount, {" in interpage_source
+    assert "send({}, true, retryCount);" in overlay_source
     assert "attemptedSequence !== yuiGuidePcOverlaySequence" in interpage_source
     assert "attemptedSequence !== sequence" in overlay_source
+    assert "activeSequence > attemptedSequence" in interpage_source
+    assert "activeSequence > attemptedSequence" in overlay_source
 
 
 def test_pc_overlay_screen_coordinates_use_niri_virtual_origin_and_crop_safe_area():

--- a/tests/unit/test_avatar_floating_day1_round_contracts.py
+++ b/tests/unit/test_avatar_floating_day1_round_contracts.py
@@ -581,7 +581,7 @@ def test_pc_overlay_sequence_collision_retries_without_rotating_tutorial_run():
     assert "PC_OVERLAY_SEQUENCE_STORAGE_KEY = 'yuiGuidePcOverlaySequence'" in overlay_source
     assert "YUI_GUIDE_PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES = 3" in interpage_source
     assert "PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES = 3" in overlay_source
-    assert "YUI_GUIDE_PC_OVERLAY_MAX_TOTAL_SAME_RUN_STALE_RETRIES = 6" in interpage_source
+    assert "YUI_GUIDE_PC_OVERLAY_MAX_TOTAL_STALE_RETRIES = 6" in interpage_source
     assert "PC_OVERLAY_MAX_TOTAL_SAME_RUN_STALE_RETRIES = 6" in overlay_source
     assert "YUI_GUIDE_PC_OVERLAY_DEFERRED_RECONCILIATION_DELAY_MS = 48" in interpage_source
     assert "PC_OVERLAY_DEFERRED_RECONCILIATION_DELAY_MS = 48" in overlay_source
@@ -603,7 +603,7 @@ def test_pc_overlay_sequence_collision_retries_without_rotating_tutorial_run():
     assert "nextSequence(result.activeSequence)" in overlay_source
     assert "retryCount < YUI_GUIDE_PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES" in interpage_source
     assert "retryCount < PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES" in overlay_source
-    assert "retryCount < YUI_GUIDE_PC_OVERLAY_MAX_TOTAL_SAME_RUN_STALE_RETRIES" in interpage_source
+    assert "retryCount < YUI_GUIDE_PC_OVERLAY_MAX_TOTAL_STALE_RETRIES" in interpage_source
     assert "retryCount < PC_OVERLAY_MAX_TOTAL_SAME_RUN_STALE_RETRIES" in overlay_source
     assert "scheduleYuiGuidePcOverlayDeferredReconciliation(" in interpage_source
     assert "scheduleDeferredReconciliation(retryCount, attemptedSequence)" in overlay_source
@@ -611,6 +611,8 @@ def test_pc_overlay_sequence_collision_retries_without_rotating_tutorial_run():
     assert "send({}, true, retryCount + 1);" in overlay_source
     assert "readStoredYuiGuidePcOverlaySequence() > attemptedSequence" in interpage_source
     assert "readStoredSequence() > attemptedSequence" in overlay_source
+    assert "isDifferentRunStale && retryCount > 0" in interpage_source
+    assert "attemptedOwnedRun && retryCount < YUI_GUIDE_PC_OVERLAY_MAX_TOTAL_STALE_RETRIES" in interpage_source
     assert "attemptedSequence !== yuiGuidePcOverlaySequence" in interpage_source
     assert "attemptedSequence !== sequence" in overlay_source
     assert "activeSequence > attemptedSequence" in interpage_source

--- a/tests/unit/test_avatar_floating_day1_round_contracts.py
+++ b/tests/unit/test_avatar_floating_day1_round_contracts.py
@@ -581,6 +581,8 @@ def test_pc_overlay_sequence_collision_retries_without_rotating_tutorial_run():
     assert "PC_OVERLAY_SEQUENCE_STORAGE_KEY = 'yuiGuidePcOverlaySequence'" in overlay_source
     assert "YUI_GUIDE_PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES = 3" in interpage_source
     assert "PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES = 3" in overlay_source
+    assert "YUI_GUIDE_PC_OVERLAY_MAX_TOTAL_SAME_RUN_STALE_RETRIES = 6" in interpage_source
+    assert "PC_OVERLAY_MAX_TOTAL_SAME_RUN_STALE_RETRIES = 6" in overlay_source
     assert "YUI_GUIDE_PC_OVERLAY_DEFERRED_RECONCILIATION_DELAY_MS = 48" in interpage_source
     assert "PC_OVERLAY_DEFERRED_RECONCILIATION_DELAY_MS = 48" in overlay_source
     assert "function nextYuiGuidePcOverlaySequence(minimumSequence)" in interpage_source
@@ -601,12 +603,14 @@ def test_pc_overlay_sequence_collision_retries_without_rotating_tutorial_run():
     assert "nextSequence(result.activeSequence)" in overlay_source
     assert "retryCount < YUI_GUIDE_PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES" in interpage_source
     assert "retryCount < PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES" in overlay_source
-    assert "retryCount === YUI_GUIDE_PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES" in interpage_source
-    assert "retryCount === PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES" in overlay_source
+    assert "retryCount < YUI_GUIDE_PC_OVERLAY_MAX_TOTAL_SAME_RUN_STALE_RETRIES" in interpage_source
+    assert "retryCount < PC_OVERLAY_MAX_TOTAL_SAME_RUN_STALE_RETRIES" in overlay_source
     assert "scheduleYuiGuidePcOverlayDeferredReconciliation(" in interpage_source
-    assert "scheduleDeferredReconciliation(retryCount)" in overlay_source
-    assert "sendYuiGuidePcOverlayPatch(patch || {}, retryCount, {" in interpage_source
-    assert "send({}, true, retryCount);" in overlay_source
+    assert "scheduleDeferredReconciliation(retryCount, attemptedSequence)" in overlay_source
+    assert "sendYuiGuidePcOverlayPatch({}, retryCount + 1, {" in interpage_source
+    assert "send({}, true, retryCount + 1);" in overlay_source
+    assert "readStoredYuiGuidePcOverlaySequence() > attemptedSequence" in interpage_source
+    assert "readStoredSequence() > attemptedSequence" in overlay_source
     assert "attemptedSequence !== yuiGuidePcOverlaySequence" in interpage_source
     assert "attemptedSequence !== sequence" in overlay_source
     assert "activeSequence > attemptedSequence" in interpage_source

--- a/tests/unit/test_avatar_floating_day1_round_contracts.py
+++ b/tests/unit/test_avatar_floating_day1_round_contracts.py
@@ -579,6 +579,8 @@ def test_pc_overlay_sequence_collision_retries_without_rotating_tutorial_run():
 
     assert "YUI_GUIDE_PC_OVERLAY_SEQUENCE_KEY = 'yuiGuidePcOverlaySequence'" in interpage_source
     assert "PC_OVERLAY_SEQUENCE_STORAGE_KEY = 'yuiGuidePcOverlaySequence'" in overlay_source
+    assert "YUI_GUIDE_PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES = 3" in interpage_source
+    assert "PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES = 3" in overlay_source
     assert "function nextYuiGuidePcOverlaySequence(minimumSequence)" in interpage_source
     assert "const nextSequence = (minimumSequence) => {" in overlay_source
     assert "window.localStorage.getItem(YUI_GUIDE_PC_OVERLAY_SEQUENCE_KEY)" in interpage_source
@@ -595,6 +597,8 @@ def test_pc_overlay_sequence_collision_retries_without_rotating_tutorial_run():
     assert "result.activeTutorialRunId === attemptedRunId" in overlay_source
     assert "nextYuiGuidePcOverlaySequence(result.activeSequence)" in interpage_source
     assert "nextSequence(result.activeSequence)" in overlay_source
+    assert "retryCount < YUI_GUIDE_PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES" in interpage_source
+    assert "retryCount < PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES" in overlay_source
 
 
 def test_pc_overlay_screen_coordinates_use_niri_virtual_origin_and_crop_safe_area():
@@ -788,7 +792,7 @@ def test_pc_overlay_resistance_cursor_uses_cursor_only_patch_without_touching_sp
 
     assert "const payload = completeStateStore.applyPatch({ cursor: cursor });" in cursor_only_block
     assert "const payload = { cursor: cursor };" not in cursor_only_block
-    assert "handleCursorOnlyStaleResult(result, cursor, retried === true, updateRunId);" in cursor_only_block
+    assert "handleCursorOnlyStaleResult(result, cursor, retried, updateRunId);" in cursor_only_block
     assert "handleCursorOnlyStaleResult(result, cursor, retried === true, beginRunId);" not in cursor_only_block
     assert "result && result.ok === false" in cursor_only_block
     assert "moveCursorOnlyTo(x, y, durationMs, effect, effectDurationMs)" in overlay_source

--- a/tests/unit/test_avatar_floating_day1_round_contracts.py
+++ b/tests/unit/test_avatar_floating_day1_round_contracts.py
@@ -581,6 +581,8 @@ def test_pc_overlay_sequence_collision_retries_without_rotating_tutorial_run():
     assert "PC_OVERLAY_SEQUENCE_STORAGE_KEY = 'yuiGuidePcOverlaySequence'" in overlay_source
     assert "YUI_GUIDE_PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES = 3" in interpage_source
     assert "PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES = 3" in overlay_source
+    assert "YUI_GUIDE_PC_OVERLAY_DEFERRED_RECONCILIATION_DELAY_MS = 48" in interpage_source
+    assert "PC_OVERLAY_DEFERRED_RECONCILIATION_DELAY_MS = 48" in overlay_source
     assert "function nextYuiGuidePcOverlaySequence(minimumSequence)" in interpage_source
     assert "const nextSequence = (minimumSequence) => {" in overlay_source
     assert "window.localStorage.getItem(YUI_GUIDE_PC_OVERLAY_SEQUENCE_KEY)" in interpage_source
@@ -599,6 +601,12 @@ def test_pc_overlay_sequence_collision_retries_without_rotating_tutorial_run():
     assert "nextSequence(result.activeSequence)" in overlay_source
     assert "retryCount < YUI_GUIDE_PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES" in interpage_source
     assert "retryCount < PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES" in overlay_source
+    assert "retryCount === YUI_GUIDE_PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES" in interpage_source
+    assert "retryCount === PC_OVERLAY_MAX_SAME_RUN_STALE_RETRIES" in overlay_source
+    assert "scheduleYuiGuidePcOverlayDeferredReconciliation(" in interpage_source
+    assert "scheduleDeferredReconciliation(retryCount)" in overlay_source
+    assert "attemptedSequence !== yuiGuidePcOverlaySequence" in interpage_source
+    assert "attemptedSequence !== sequence" in overlay_source
 
 
 def test_pc_overlay_screen_coordinates_use_niri_virtual_origin_and_crop_safe_area():
@@ -792,7 +800,7 @@ def test_pc_overlay_resistance_cursor_uses_cursor_only_patch_without_touching_sp
 
     assert "const payload = completeStateStore.applyPatch({ cursor: cursor });" in cursor_only_block
     assert "const payload = { cursor: cursor };" not in cursor_only_block
-    assert "handleCursorOnlyStaleResult(result, cursor, retried, updateRunId);" in cursor_only_block
+    assert "handleCursorOnlyStaleResult(result, cursor, retryCount, updateRunId, updateSequence);" in cursor_only_block
     assert "handleCursorOnlyStaleResult(result, cursor, retried === true, beginRunId);" not in cursor_only_block
     assert "result && result.ok === false" in cursor_only_block
     assert "moveCursorOnlyTo(x, y, durationMs, effect, effectDurationMs)" in overlay_source

--- a/tests/unit/test_avatar_floating_day1_round_contracts.py
+++ b/tests/unit/test_avatar_floating_day1_round_contracts.py
@@ -397,7 +397,7 @@ def test_external_chat_cursor_retry_cannot_replay_stale_wobble_after_clear():
     source = read_js_parts(INTERPAGE_PATH)
 
     assert "yuiGuideChatCursorRequestToken" in source
-    assert "var cursorRequestToken = ++yuiGuideChatCursorRequestToken;" in source
+    assert "var cursorRequestToken = yuiGuideChatCursorRequestToken;" in source
     assert "if (cursorRequestToken !== yuiGuideChatCursorRequestToken) {" in source
 
 
@@ -573,14 +573,14 @@ def test_external_chat_ready_replays_compact_fixed_layout_when_tutorial_is_activ
     assert "reason: typeof reason === 'string' ? reason : ''" in fixed_method_block
 
 
-def test_pc_overlay_sequence_is_shared_between_home_and_external_chat():
+def test_pc_overlay_sequence_collision_retries_without_rotating_tutorial_run():
     interpage_source = read_js_parts(INTERPAGE_PATH)
     overlay_source = (ROOT / "static" / "tutorial/yui-guide/overlay.js").read_text(encoding="utf-8")
 
     assert "YUI_GUIDE_PC_OVERLAY_SEQUENCE_KEY = 'yuiGuidePcOverlaySequence'" in interpage_source
     assert "PC_OVERLAY_SEQUENCE_STORAGE_KEY = 'yuiGuidePcOverlaySequence'" in overlay_source
-    assert "function nextYuiGuidePcOverlaySequence()" in interpage_source
-    assert "const nextSequence = () => {" in overlay_source
+    assert "function nextYuiGuidePcOverlaySequence(minimumSequence)" in interpage_source
+    assert "const nextSequence = (minimumSequence) => {" in overlay_source
     assert "window.localStorage.getItem(YUI_GUIDE_PC_OVERLAY_SEQUENCE_KEY)" in interpage_source
     assert "window.localStorage.setItem(YUI_GUIDE_PC_OVERLAY_SEQUENCE_KEY" in interpage_source
     assert "window.localStorage.getItem(PC_OVERLAY_SEQUENCE_STORAGE_KEY)" in overlay_source
@@ -589,6 +589,12 @@ def test_pc_overlay_sequence_is_shared_between_home_and_external_chat():
     assert "sequence = nextSequence();" in overlay_source
     assert "yuiGuidePcOverlaySequence = Math.max(yuiGuidePcOverlaySequence + 1, Date.now() * 1000);" not in interpage_source
     assert "sequence = Math.max(sequence + 1, Date.now() * 1000);" not in overlay_source
+    assert "result.reason === 'stale-sequence'" in interpage_source
+    assert "result.reason === 'stale-sequence'" in overlay_source
+    assert "result.activeTutorialRunId === attemptedRunId" in interpage_source
+    assert "result.activeTutorialRunId === attemptedRunId" in overlay_source
+    assert "nextYuiGuidePcOverlaySequence(result.activeSequence)" in interpage_source
+    assert "nextSequence(result.activeSequence)" in overlay_source
 
 
 def test_pc_overlay_screen_coordinates_use_niri_virtual_origin_and_crop_safe_area():

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -584,6 +584,8 @@ def test_home_tutorial_input_lock_blocks_compact_capsule_input_state():
         1,
     )[0]
     assert "compactInputLocked: next" in input_lock_block
+    assert "var previousAttachmentsVisible = getEffectiveComposerAttachmentsVisible();" in input_lock_block
+    assert "syncComposerAttachmentsVisibility(previousAttachmentsVisible);" in input_lock_block
     assert "setHomeTutorialInteractionLocked(next" not in input_lock_block
     assert "disabled={compactCapsuleEntryLocked}" in capsule_block
     assert "if (compactCapsuleEntryLocked) return;" in capsule_block

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -271,6 +271,10 @@ def test_goodbye_composer_hidden_survives_surface_mode_switches():
         "function createResizeEdges",
         1,
     )[0]
+    effective_composer_hidden_block = source.split("function getEffectiveComposerHidden()", 1)[1].split(
+        "function getNekoGoodbyeModeActive",
+        1,
+    )[0]
 
     assert "goodbyeComposerHidden: false" in source
     assert "function getEffectiveComposerHidden()" in source
@@ -280,7 +284,8 @@ def test_goodbye_composer_hidden_survives_surface_mode_switches():
     assert "&& window.isNekoGoodbyeModeActive()" in source
     assert "function getEffectiveComposerAttachmentsVisible()" in source
     assert "function syncComposerAttachmentsVisibility(previousVisible)" in source
-    assert "return !!(state.composerHidden || state.goodbyeComposerHidden);" in source
+    assert "!state.homeTutorialInputLocked" in effective_composer_hidden_block
+    assert "state.composerHidden || state.goodbyeComposerHidden" in effective_composer_hidden_block
     assert "composerHidden: getEffectiveComposerHidden()" in build_render_block
     assert "state.homeTutorialInteractionLocked" in submit_block
     assert "state.homeTutorialInputLocked" in submit_block


### PR DESCRIPTION
## 改动概述 / Summary

修复 Day2 等新手教程在 N.E.K.O 与外置聊天窗口协同时的多处竞态：

- PC overlay 序列冲突时沿用当前 tutorial run，并基于 PC 返回的活动序列重试，避免 ghost cursor 固定在胶囊输入框。
- 教程锁定期间临时显示原本隐藏的胶囊输入与工具入口，结束后恢复教程前的隐藏状态。
- 聊天窗口展开后的 720ms 定位重试只刷新坐标，不再重放一次性 click 效果。
- YUI 模型切换复用教程生命周期持有的主动搭话快照，避免模型恢复阶段覆盖已经恢复的用户设置。

根因是首页与聊天窗口分别维护 overlay 序列、聊天窗口展开与定位异步进行，以及模型重载控制器和教程生命周期重复持有主动搭话快照；这些状态在竞态下会互相覆盖。

## 回归报告 / Regression Report

### app

- **改动了什么：** 调整 `static/app/app-interpage` 的 overlay 序列冲突处理和聊天游标展开后重试；调整 `static/app/app-react-chat-window` 的教程锁定可见性与工具菜单打开状态。
- **理由 / 必要性：** `static/app` 是首页与外置聊天窗之间传递教程目标、游标和聊天界面状态的实际生效链路。ghost cursor 固定、聊天毛线球未被接管以及工具入口不可见均发生在这一层，无法通过后端或单纯延长动画规避。
- **改动前后：** 改动前同毫秒序列碰撞会旋转 run 或丢弃位置更新，展开重试还会再次播放 click；改动后同一 run 快进序列并重试，教程期间工具入口可见，720ms 重试只更新位置，结束后恢复原聊天隐藏状态。
- **潜在回归点：** 正常聊天的最小化/展开、goodbye 隐藏状态、教程跳过/自然结束后的恢复、跨窗口 overlay 顺序。通过浏览器契约测试和真实 Day2 运行验证这些链路。

### main_logic

未修改。问题不涉及后端对话编排、模型请求或会话生命周期，因此没有必要扩大到 `main_logic`。

### memory

未修改。问题不涉及记忆读写、索引、召回或维护流程，因此没有必要修改 `memory`。

## 不拆分理由 / Why Not Split

不适用：本 PR 修改 9 个文件，其中包含 3 个测试文件，未超过模板规定的拆分阈值；这些改动共同修复同一条跨窗口教程接管与恢复链路。

## 测试 / Testing

- `node --test static/yui-guide-avatar-reload-controller.test.cjs`：5/5 通过。
- `.venv/bin/python -m pytest -q tests/frontend/test_home_prompt_flow.py::test_home_tutorial_input_lock_temporarily_reveals_hidden_compact_tools tests/frontend/test_home_prompt_flow.py::test_externalized_chat_cursor_retries_position_without_replaying_click tests/unit/test_avatar_floating_day1_round_contracts.py`：54/54 通过。
- `bash build_frontend.sh`：构建成功。
- `git diff --check upstream/main...HEAD`：通过。
- 真实 Day2 运行：ghost cursor 能在胶囊、工具按钮和 GalGame 目标间移动；首次 click 保持 420ms，720ms 后仅刷新普通游标，PC 只触发一次 `cursor-click`；跳过后聊天状态与主动搭话快照恢复。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 优化外部化聊天光标展开/位置更新重试：以首次请求标识做对账，成功/失败时正确切换效果与时机，避免重复点击回放。
  * 强化引导浮层 stale-sequence 处理：同一运行分层上限，超限后延迟校正；支持最小序列推进，并完善重试/替换丢弃。
  * 教程输入锁定下的紧凑工具体验：锁定期间不隐藏 composer；工具打开时临时覆盖并在关闭后恢复，同时同步附件可见性。
  * 主动搭话开关覆盖更稳：仅在教程控制器未接管时才进行覆盖/禁用。
* **测试**
  * 新增/扩展家教程输入锁定、外部化聊天光标重试边界，以及 PC overlay/外部化聊天 stale 去重、延迟对账与替换丢弃回归用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->