### PR TITLE
fix(minecraft): ingest ordinary in-game chat

### DIFF
--- a/plugin/plugins/game_agent_minecraft/client.py
+++ b/plugin/plugins/game_agent_minecraft/client.py
@@ -7,6 +7,7 @@ The agent server speaks a small JSON protocol:
 * **server → client** ``{"type": "screenshot", "image": "<base64>", "encoding": "png"|"jpeg"}``
 * **server → client** ``{"type": "task_finished", "status": "ok", "text": "..."}``
 * **server → client** ``{"type": "agent_status", ...}``  # informational, ignored by callbacks
+* **server → client** ``{"type": "ingame_chat", "messages": [{"player": "...", "text": "..."}]}``
 
 Why a long-lived WebSocket instead of polling HTTP: screenshot frames can
 arrive at >1Hz, and the handshake cost of HTTP per frame would dominate
@@ -17,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Dict, Optional
 
 import websockets
@@ -30,6 +32,17 @@ OnTaskFinished = Callable[[dict[str, Any]], Awaitable[None]]
 OnAlert = Callable[[dict[str, Any]], Awaitable[None]]
 OnInventory = Callable[[dict[str, Any]], Awaitable[None]]
 OnBotStatus = Callable[[dict[str, Any]], Awaitable[None]]  # bot_status_nl frame
+
+
+@dataclass(frozen=True, slots=True)
+class IngameChatMessage:
+    """One validated ordinary-player chat item from an ``ingame_chat`` batch."""
+
+    player: str
+    text: str
+
+
+OnIngameChat = Callable[[tuple[IngameChatMessage, ...]], Awaitable[None]]
 
 
 class GameAgentClient:
@@ -51,6 +64,7 @@ class GameAgentClient:
         on_alert: Optional[OnAlert] = None,
         on_inventory: Optional[OnInventory] = None,
         on_bot_status: Optional[OnBotStatus] = None,
+        on_ingame_chat: Optional[OnIngameChat] = None,
         reconnect_interval: float = 5.0,
         logger: Any = None,
     ):
@@ -61,6 +75,7 @@ class GameAgentClient:
         self.on_alert = on_alert
         self.on_inventory = on_inventory
         self.on_bot_status = on_bot_status
+        self.on_ingame_chat = on_ingame_chat
         self.reconnect_interval = reconnect_interval
         # Plugin SDK injects a per-plugin loguru logger; fall back to a
         # noop when running outside that environment (unit tests).
@@ -259,6 +274,11 @@ class GameAgentClient:
                         # while the agent is already mid-action.
                         await self.on_bot_status(data)
 
+                    elif msg_type == "ingame_chat" and self.on_ingame_chat is not None:
+                        messages = self._parse_ingame_chat_messages(data)
+                        if messages:
+                            await self.on_ingame_chat(messages)
+
                     elif msg_type == "agent_status":
                         # Informational status — the original integration
                         # logged this at debug. Keep parity.
@@ -278,6 +298,35 @@ class GameAgentClient:
         except Exception as exc:
             self.is_connected = False
             self._log_error("listen error: {}: {}", type(exc).__name__, exc)
+
+    @staticmethod
+    def _parse_ingame_chat_messages(
+        data: dict[str, Any],
+    ) -> tuple[IngameChatMessage, ...]:
+        """Validate the structured batch and discard malformed or empty items.
+
+        The frame's aggregate ``text`` field intentionally is not consumed: the
+        structured ``messages`` list is authoritative, and reading both would
+        inject the same player chat into the dialog context twice.
+        """
+        raw_messages = data.get("messages")
+        if not isinstance(raw_messages, list):
+            return ()
+
+        messages: list[IngameChatMessage] = []
+        for item in raw_messages:
+            if not isinstance(item, dict):
+                continue
+            player = item.get("player")
+            text = item.get("text")
+            if not isinstance(player, str) or not isinstance(text, str):
+                continue
+            player = player.strip()
+            text = text.strip()
+            if not player or not text:
+                continue
+            messages.append(IngameChatMessage(player=player, text=text))
+        return tuple(messages)
 
     # ------------------------------------------------------------------
     # Logging helpers — silently no-op when no logger is supplied.
@@ -324,4 +373,6 @@ __all__ = [
     "OnAlert",
     "OnInventory",
     "OnBotStatus",
+    "IngameChatMessage",
+    "OnIngameChat",
 ]

--- a/plugin/plugins/game_agent_minecraft/client.py
+++ b/plugin/plugins/game_agent_minecraft/client.py
@@ -84,6 +84,7 @@ class GameAgentClient:
         self._ws: Optional[Any] = None
         self._running = False
         self.is_connected: bool = False
+        self._background_callbacks: set[asyncio.Task[None]] = set()
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -154,6 +155,12 @@ class GameAgentClient:
                 # already torn down (peer hung up, OS reaped fd, ...)
                 # there's nothing for us to recover; we're stopping.
                 pass
+        callbacks = tuple(self._background_callbacks)
+        for task in callbacks:
+            task.cancel()
+        if callbacks:
+            await asyncio.gather(*callbacks, return_exceptions=True)
+        self._background_callbacks.clear()
         self._log_info("stopped")
 
     # ------------------------------------------------------------------
@@ -277,7 +284,10 @@ class GameAgentClient:
                     elif msg_type == "ingame_chat" and self.on_ingame_chat is not None:
                         messages = self._parse_ingame_chat_messages(data)
                         if messages:
-                            await self.on_ingame_chat(messages)
+                            self._start_background_callback(
+                                self.on_ingame_chat(messages),
+                                msg_type=msg_type,
+                            )
 
                     elif msg_type == "agent_status":
                         # Informational status — the original integration
@@ -298,6 +308,33 @@ class GameAgentClient:
         except Exception as exc:
             self.is_connected = False
             self._log_error("listen error: {}: {}", type(exc).__name__, exc)
+
+    def _start_background_callback(
+        self,
+        callback: Awaitable[None],
+        *,
+        msg_type: str,
+    ) -> None:
+        """Run a potentially slow callback without stalling frame ingestion."""
+        task = asyncio.create_task(
+            callback,
+            name=f"game_agent_minecraft.callback.{msg_type}",
+        )
+        self._background_callbacks.add(task)
+
+        def _done(done: asyncio.Task[None]) -> None:
+            self._background_callbacks.discard(done)
+            if done.cancelled():
+                return
+            try:
+                done.result()
+            except Exception as exc:
+                self._log_error(
+                    "background callback error for type={}: {}: {}",
+                    msg_type, type(exc).__name__, exc,
+                )
+
+        task.add_done_callback(_done)
 
     @staticmethod
     def _parse_ingame_chat_messages(

--- a/plugin/plugins/game_agent_minecraft/service.py
+++ b/plugin/plugins/game_agent_minecraft/service.py
@@ -182,6 +182,10 @@ class GameAgentService:
         # Cross-callback state
         self._pending: Optional[PendingTask] = None
         self._pending_lock = asyncio.Lock()
+        # ``push_message`` ultimately performs a synchronous ZMQ send. Chat
+        # callbacks are dispatched in the background by the client, and this
+        # fair lock keeps their thread-offloaded pushes in WebSocket order.
+        self._ingame_chat_push_lock = asyncio.Lock()
         # Bounded history of dispatched task_id → task_text. Used by
         # ``_on_task_finished`` to recognize completion frames for tasks
         # that are no longer the active ``_pending`` (typical case:
@@ -1127,13 +1131,15 @@ class GameAgentService:
             "the existing tool rules."
         )
         try:
-            self._push_message(
-                source="game_agent_minecraft",
-                visibility=[],
-                ai_behavior="respond",
-                parts=[{"type": "text", "text": body}],
-                priority=5,
-            )
+            async with self._ingame_chat_push_lock:
+                await asyncio.to_thread(
+                    self._push_message,
+                    source="game_agent_minecraft",
+                    visibility=[],
+                    ai_behavior="respond",
+                    parts=[{"type": "text", "text": body}],
+                    priority=5,
+                )
         except Exception as exc:
             self._log_error(
                 "in-game chat push failed: {}: {}", type(exc).__name__, exc,

--- a/plugin/plugins/game_agent_minecraft/service.py
+++ b/plugin/plugins/game_agent_minecraft/service.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import collections
+import json
 import re
 import time
 import uuid
@@ -41,7 +42,7 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Optional
 
 from . import prompts
-from .client import GameAgentClient
+from .client import GameAgentClient, IngameChatMessage
 
 # Strip ANSI colour escapes from agent log lines before relaying to the
 # LLM — we don't want VT100 noise in the model's context window.
@@ -457,6 +458,7 @@ class GameAgentService:
             on_alert=self._on_alert,
             on_inventory=self._on_inventory,
             on_bot_status=self._on_bot_status,
+            on_ingame_chat=self._on_ingame_chat,
             reconnect_interval=self._reconnect_interval,
             logger=self.logger,
         )
@@ -1095,6 +1097,47 @@ class GameAgentService:
     # ------------------------------------------------------------------
     # WebSocket inbound callbacks — invoked from the WS listener task
     # ------------------------------------------------------------------
+
+    async def _on_ingame_chat(
+        self,
+        messages: tuple[IngameChatMessage, ...],
+    ) -> None:
+        """Inject one ordinary-player chat batch into the dialog LLM.
+
+        This is deliberately a conversational ``respond`` event, not the
+        ``@neko`` admin-mission path. The service emits one hidden context part
+        per WebSocket batch and never sends anything back over the game-agent
+        socket, avoiding both duplicate injection and a chat echo loop.
+        """
+        if not messages:
+            return
+
+        serialized = "\n".join(
+            json.dumps(
+                {"player": message.player, "text": message.text},
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+            for message in messages
+        )
+        body = (
+            "Ordinary Minecraft player chat (not a privileged @neko admin mission):\n"
+            f"{serialized}\n"
+            "Reply naturally. Use minecraft_task only when it is appropriate under "
+            "the existing tool rules."
+        )
+        try:
+            self._push_message(
+                source="game_agent_minecraft",
+                visibility=[],
+                ai_behavior="respond",
+                parts=[{"type": "text", "text": body}],
+                priority=5,
+            )
+        except Exception as exc:
+            self._log_error(
+                "in-game chat push failed: {}: {}", type(exc).__name__, exc,
+            )
 
     async def _on_log(self, text: str) -> None:
         text_strip = text.strip() if isinstance(text, str) else ""

--- a/tests/unit/test_game_agent_minecraft_ingame_chat.py
+++ b/tests/unit/test_game_agent_minecraft_ingame_chat.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import threading
 
 import pytest
 
@@ -73,11 +74,49 @@ async def test_client_dispatches_typed_ingame_chat_batch_once():
     ])
 
     await client._listen()
+    await asyncio.gather(*tuple(client._background_callbacks))
 
     assert received == [(
         IngameChatMessage(player="Alice", text="hello Neko"),
         IngameChatMessage(player="Bob", text="come explore"),
     )]
+
+
+@pytest.mark.asyncio
+async def test_slow_chat_callback_does_not_stall_later_frames():
+    chat_started = asyncio.Event()
+    release_chat = asyncio.Event()
+    finished_frames = []
+
+    async def on_ingame_chat(_messages) -> None:
+        chat_started.set()
+        await release_chat.wait()
+
+    async def on_task_finished(data) -> None:
+        finished_frames.append(data)
+
+    client = GameAgentClient(
+        "ws://example",
+        on_ingame_chat=on_ingame_chat,
+        on_task_finished=on_task_finished,
+    )
+    client._ws = _FrameStream([
+        json.dumps({
+            "type": "ingame_chat",
+            "messages": [{"player": "Alice", "text": "hello"}],
+        }),
+        json.dumps({"type": "task_finished", "status": "ok"}),
+    ])
+
+    await client._listen()
+    await chat_started.wait()
+
+    assert len(finished_frames) == 1
+    assert finished_frames[0]["type"] == "task_finished"
+
+    callbacks = tuple(client._background_callbacks)
+    release_chat.set()
+    await asyncio.gather(*callbacks)
 
 
 @pytest.mark.asyncio
@@ -142,6 +181,14 @@ async def test_service_pushes_one_non_admin_dialog_turn_without_echo():
     service, push_calls = _make_service()
     fake_client = _FakeClient()
     service._client = fake_client
+    event_loop_thread = threading.get_ident()
+    push_threads = []
+
+    def fake_push(**kwargs):
+        push_threads.append(threading.get_ident())
+        push_calls.append(kwargs)
+
+    service._push_message = fake_push
 
     await service._on_ingame_chat((
         IngameChatMessage(player="Alice", text="hello Neko"),
@@ -163,6 +210,7 @@ async def test_service_pushes_one_non_admin_dialog_turn_without_echo():
     assert '{"player":"Bob","text":"come explore"}' in body
     assert body.count("hello Neko") == 1
     assert fake_client.sent == []
+    assert push_threads and push_threads[0] != event_loop_thread
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_game_agent_minecraft_ingame_chat.py
+++ b/tests/unit/test_game_agent_minecraft_ingame_chat.py
@@ -1,0 +1,174 @@
+"""Focused coverage for ordinary Minecraft player-chat ingestion."""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from plugin.plugins.game_agent_minecraft.client import (
+    GameAgentClient,
+    IngameChatMessage,
+)
+from plugin.plugins.game_agent_minecraft.service import GameAgentService
+
+
+class _FrameStream:
+    """Small async iterable used to drive ``GameAgentClient._listen``."""
+
+    def __init__(self, frames: list[str]) -> None:
+        self._frames = iter(frames)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> str:
+        try:
+            return next(self._frames)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.is_connected = True
+        self.sent: list[str] = []
+
+    async def send_task(self, task: str, *, task_id: str = "") -> bool:
+        self.sent.append(task)
+        return True
+
+
+def _make_service(*, push_calls: list | None = None):
+    captured = push_calls if push_calls is not None else []
+
+    def fake_push(**kwargs):
+        captured.append(kwargs)
+
+    return GameAgentService(logger=None, push_message_fn=fake_push), captured
+
+
+@pytest.mark.asyncio
+async def test_client_dispatches_typed_ingame_chat_batch_once():
+    received: list[tuple[IngameChatMessage, ...]] = []
+
+    async def on_ingame_chat(messages: tuple[IngameChatMessage, ...]) -> None:
+        received.append(messages)
+
+    client = GameAgentClient("ws://example", on_ingame_chat=on_ingame_chat)
+    client._ws = _FrameStream([
+        json.dumps({"type": "future_unknown", "payload": "ignored"}),
+        json.dumps({
+            "type": "ingame_chat",
+            "count": 5,
+            "messages": [
+                {"player": " Alice ", "text": " hello Neko "},
+                {"player": "Bob", "text": "come explore"},
+                {"player": "", "text": "missing player"},
+                {"player": "Eve", "text": 123},
+                "not-an-object",
+            ],
+            "text": "<Alice> hello Neko\n<Bob> come explore",
+        }),
+    ])
+
+    await client._listen()
+
+    assert received == [(
+        IngameChatMessage(player="Alice", text="hello Neko"),
+        IngameChatMessage(player="Bob", text="come explore"),
+    )]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "messages",
+    [
+        None,
+        [],
+        {},
+        [None],
+        [{"player": "", "text": "hello"}],
+        [{"player": "Alice", "text": ""}],
+        [{"player": 7, "text": "hello"}],
+    ],
+)
+async def test_client_drops_malformed_or_empty_ingame_chat_batch(messages):
+    received = []
+
+    async def on_ingame_chat(batch) -> None:
+        received.append(batch)
+
+    client = GameAgentClient("ws://example", on_ingame_chat=on_ingame_chat)
+    client._ws = _FrameStream([
+        json.dumps({"type": "ingame_chat", "messages": messages}),
+    ])
+
+    await client._listen()
+
+    assert received == []
+
+
+@pytest.mark.asyncio
+async def test_service_wires_ingame_chat_callback_on_start(monkeypatch):
+    from plugin.plugins.game_agent_minecraft import service as service_module
+
+    captured = {}
+
+    class _StartClient:
+        is_connected = False
+
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        async def start(self):
+            await asyncio.Event().wait()
+
+        async def stop(self):
+            return None
+
+    monkeypatch.setattr(service_module, "GameAgentClient", _StartClient)
+    service, _ = _make_service()
+
+    await service.start()
+    try:
+        assert captured["on_ingame_chat"] == service._on_ingame_chat
+    finally:
+        await service.stop()
+
+
+@pytest.mark.asyncio
+async def test_service_pushes_one_non_admin_dialog_turn_without_echo():
+    service, push_calls = _make_service()
+    fake_client = _FakeClient()
+    service._client = fake_client
+
+    await service._on_ingame_chat((
+        IngameChatMessage(player="Alice", text="hello Neko"),
+        IngameChatMessage(player="Bob", text="come explore"),
+    ))
+
+    assert len(push_calls) == 1
+    call = push_calls[0]
+    assert call["source"] == "game_agent_minecraft"
+    assert call["visibility"] == []
+    assert call["ai_behavior"] == "respond"
+    assert call["priority"] == 5
+    assert call["priority"] < 9
+    assert "coalesce_key" not in call
+    assert call["parts"][0]["type"] == "text"
+    body = call["parts"][0]["text"]
+    assert "not a privileged @neko admin mission" in body
+    assert '{"player":"Alice","text":"hello Neko"}' in body
+    assert '{"player":"Bob","text":"come explore"}' in body
+    assert body.count("hello Neko") == 1
+    assert fake_client.sent == []
+
+
+@pytest.mark.asyncio
+async def test_service_ignores_empty_ingame_chat_batch():
+    service, push_calls = _make_service()
+
+    await service._on_ingame_chat(())
+
+    assert push_calls == []


### PR DESCRIPTION
## Summary

- add a typed `IngameChatMessage` callback to `GameAgentClient`
- bind `ingame_chat` through `GameAgentService` into the plugin's `push_message` path
- keep slow chat delivery off the WebSocket read loop while preserving batch order
- add focused coverage for valid multi-player batches, malformed/empty input, unknown frames, callback wiring, non-blocking delivery, and dialog boundaries

## Protocol and behavior

Consumes mc-agent frames shaped like:

```json
{"type":"ingame_chat","ts":0,"hint":"","count":2,"messages":[{"player":"Alice","text":"hello"},{"player":"Bob","text":"come explore"}],"text":"<Alice> hello\n<Bob> come explore"}
```

The structured `messages` array is authoritative. Invalid items and empty/malformed batches are dropped, while valid items in a mixed batch retain order. The aggregate `text` field is intentionally not consumed, so a batch is not injected twice. Unknown frame types keep their existing ignore behavior.

Each valid batch becomes one hidden `push_message` text part with `ai_behavior="respond"` and priority 5. The context explicitly identifies it as ordinary player conversation rather than a privileged `@neko` admin mission; N.E.K.O may reply naturally or use `minecraft_task` only under the existing tool rules. This path never calls `send_task` or writes back to the mc-agent WebSocket, avoiding an echo loop.

`ingame_chat` callbacks are lifecycle-tracked background tasks, so slow delivery cannot block later `task_finished`, alert, screenshot, or log frames. The service serializes batches with an `asyncio.Lock` and runs the synchronous ZMQ-backed `push_message` call through `asyncio.to_thread`, preserving order without blocking the event loop.

## Validation

- `uv run pytest tests/unit/test_game_agent_minecraft_ingame_chat.py tests/unit/test_game_agent_minecraft_plugin.py -q` — 82 passed
- `uv run ruff check plugin/plugins/game_agent_minecraft/client.py plugin/plugins/game_agent_minecraft/service.py tests/unit/test_game_agent_minecraft_ingame_chat.py` — passed
- `uv run python scripts/check_docstring_no_cjk.py --base origin/main` — passed
- `uv run python -m plugin.neko_plugin_cli.cli check plugin/plugins/game_agent_minecraft` — 0 errors (7 pre-existing standalone-package warnings)
- `git diff --check` — passed