### PR TITLE
perf: 空闲态 CPU 实测优化（Live2D 低频 tick / CSS 动画 / 音频调度链 / monitor ws）

### DIFF
--- a/app/monitor.py
+++ b/app/monitor.py
@@ -390,15 +390,25 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name:str):
     try:
         # 保持连接直到客户端断开
         while True:
-            # 接收任何类型的消息（文本或二进制），主要用于保持连接
+            # 接收任何类型的消息（文本或二进制），主要用于保持连接。
+            # 注意：断连必须重新抛出——旧实现的裸 except 会把 WebSocketDisconnect
+            # 一并吞掉，随后 receive 永远抛 RuntimeError，协程退化成每个已断开
+            # 客户端一条 10Hz 的永动空转循环。
             try:
                 await websocket.receive_text()
-            except:
+            except WebSocketDisconnect:
+                raise
+            except Exception:
                 # 如果收到的是二进制数据，receive_text() 会失败，尝试 receive_bytes()
                 try:
                     await websocket.receive_bytes()
-                except:
-                    # 如果两者都失败，等待一下再继续
+                except WebSocketDisconnect:
+                    raise
+                except RuntimeError as e:
+                    # starlette: 断开后继续 receive 抛 RuntimeError —— 视作断连收尾
+                    raise WebSocketDisconnect() from e
+                except Exception:
+                    # 两者都失败（非断连原因），等待一下再继续
                     await asyncio.sleep(0.1)
     except WebSocketDisconnect:
         print(f"❌ [CLIENT] 查看客户端已断开: {websocket.client}")

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -3497,20 +3497,17 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   color: rgba(0, 210, 255, 0.96);
 }
 
+/* 只呼吸 opacity，不呼吸 filter：drop-shadow 参与动画时每帧都要重光栅化
+   （无法走合成器捷径），在 120Hz 屏上是持续的 raster+GPU 开销。脉动的光晕感
+   由 ::after 的 opacity/transform 呼吸层承担，::before 保持基础态的静态阴影。 */
 @keyframes compact-history-handle-breathe {
   0%,
   100% {
     opacity: 0.72;
-    filter:
-      drop-shadow(0 0 3px rgba(118, 220, 255, 0.28))
-      drop-shadow(0 0 7px rgba(118, 220, 255, 0.12));
   }
 
   50% {
     opacity: 1;
-    filter:
-      drop-shadow(0 0 7px rgba(118, 220, 255, 0.72))
-      drop-shadow(0 0 16px rgba(118, 220, 255, 0.36));
   }
 }
 

--- a/static/app/app-audio-playback.js
+++ b/static/app/app-audio-playback.js
@@ -813,6 +813,7 @@
         dispatchAssistantSpeechCancel('clear_audio_queue');
         clearAssistantTurnCompletion();
         clearPendingAudioMetaStallTimer();
+        clearScheduleAudioChunksTimer();
         S.scheduledSources.forEach(function (source) {
             try { source.stop(); } catch (_) { /* noop */ }
         });
@@ -844,6 +845,7 @@
         dispatchAssistantSpeechCancel('clear_audio_queue_without_decoder_reset');
         clearAssistantTurnCompletion();
         clearPendingAudioMetaStallTimer();
+        clearScheduleAudioChunksTimer();
         S.scheduledSources.forEach(function (source) {
             try { source.stop(); } catch (_) { /* noop */ }
         });
@@ -984,9 +986,20 @@
 
     // ======================== Audio chunk scheduling ========================
 
+    // 取消调度链待触发的下一拍（中断/清队列路径用，让停链意图显式化）
+    function clearScheduleAudioChunksTimer() {
+        if (S.scheduleAudioChunksTimer) {
+            clearTimeout(S.scheduleAudioChunksTimer);
+            S.scheduleAudioChunksTimer = null;
+        }
+    }
+
     function scheduleAudioChunks() {
         if (S.scheduleAudioChunksRunning) return;
         S.scheduleAudioChunksRunning = true;
+        // 单飞行：外部直接调用时吞掉已排队的下一拍，避免并存多条 25ms 自续链
+        // （旧实现的定时器 id 不保存、无条件自续，每次外部触发都会多叠一条永动链）。
+        clearScheduleAudioChunksTimer();
 
         try {
             var scheduleAheadTime = 5;
@@ -1127,8 +1140,13 @@
                 }
             }
 
-            // Continue the scheduling loop
-            setTimeout(scheduleAudioChunks, 25);
+            // 只在仍有工作时自续（复用 _hasPendingAudioWork：含 meta 队列、解码中的
+            // blob、decoder reset 等 in-flight 状态，避免解码窗口期误停链）；
+            // 完全空闲时停链，由 handleAudioBlob 在新音频到达时重新拉起。
+            // 旧实现无条件自续，首次播放后循环以 40Hz 永久空转（且可叠加多条链）。
+            if (_hasPendingAudioWork()) {
+                S.scheduleAudioChunksTimer = setTimeout(scheduleAudioChunks, 25);
+            }
 
         } finally {
             S.scheduleAudioChunksRunning = false;
@@ -1228,9 +1246,11 @@
             );
             S.isPlaying = true;
             scheduleAudioChunks();
+        } else if (!S.scheduleAudioChunksTimer && !S.scheduleAudioChunksRunning) {
+            // isPlaying=true 但调度链已因队列见底而停止（流式间隙）：
+            // 新 chunk 到达时必须重新拉起，否则后续音频永远不会被调度。
+            scheduleAudioChunks();
         }
-        // When isPlaying is already true the scheduler loop is already running via
-        // its own setTimeout; no need to spawn an extra call.
     }
 
     // ======================== Incoming audio blob queue ========================

--- a/static/app/app-state.js
+++ b/static/app/app-state.js
@@ -48,6 +48,7 @@
         scheduledSources: [],
         isPlaying: false,
         scheduleAudioChunksRunning: false,
+        scheduleAudioChunksTimer: null,
         audioStartTime: 0,
         nextChunkTime: 0,
         lipSyncActive: false,

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -102,9 +102,14 @@ body {
     opacity: 1;
     filter: brightness(0) invert(1);
     /* 将emoji变成纯白色，移除阴影 */
-    animation: pawBounce 1.5s ease-in-out infinite;
     z-index: 1;
     /* 确保猫爪在遮罩层之上 */
+}
+
+/* 弹跳动画只在 toast 可见时运行：默认态 toast 以 opacity:0 隐藏（非 display:none），
+   若动画挂在基础态上会在两个窗口里以显示器刷新率永久空转（合成器无法休眠）。 */
+#status-toast.show::before {
+    animation: pawBounce 1.5s ease-in-out infinite;
 }
 
 /* 小猫爪爪弹跳动画 */

--- a/static/live2d/live2d-core.js
+++ b/static/live2d/live2d-core.js
@@ -304,6 +304,21 @@ class Live2DManager {
                 if (typeof window.targetFrameRate === 'number' && this.pixi_app.ticker) {
                     this.pixi_app.ticker.maxFPS = window.targetFrameRate;
                 }
+                // 包装 ticker.stop/start：外部代码（app-character / live2d-model 等）直接
+                // 操作 ticker 时先退出空闲低频 tick 模式，避免空闲定时器与外部暂停意图打架。
+                // 空闲模式自身通过 _tickerOrigStop/Start 绕过包装，不会自触发。
+                {
+                    const ticker = this.pixi_app.ticker;
+                    const mgr = this;
+                    // 闭包捕获本 ticker 自己的原始方法：PIXI 重建后旧 ticker 上残留的
+                    // 包装函数只会作用于旧 ticker 本身，不会透过实例属性误操作新 ticker。
+                    const origStop = ticker.stop.bind(ticker);
+                    const origStart = ticker.start.bind(ticker);
+                    this._tickerOrigStop = origStop;
+                    this._tickerOrigStart = origStart;
+                    ticker.stop = function () { mgr._exitIdleTickMode(); return origStop(); };
+                    ticker.start = function () { mgr._exitIdleTickMode(); return origStart(); };
+                }
                 // 启动自适应帧率守护：静止时降到地板（LIVE2D_IDLE_FPS），活动时升回配置帧率。
                 this._startIdleFpsGovernor();
 
@@ -530,7 +545,12 @@ class Live2DManager {
         if (this._hasRenderActivity()) {
             this.boostInteractiveFPS();
         } else {
+            // 改配置时如果正处于空闲低频 tick 模式，先退出再按新地板重新进入，
+            // 让 interval 周期与新的地板帧率一致。
+            const wasIdleTickMode = this._idleTickMode;
+            if (wasIdleTickMode) this._exitIdleTickMode();
             this.pixi_app.ticker.maxFPS = this._resolveIdleFps();
+            if (wasIdleTickMode) this._enterIdleTickMode();
         }
         console.log(`[Live2D Core] 目标帧率设置为 ${window.targetFrameRate === 0 ? 'VSync (无限制)' : window.targetFrameRate + 'fps'}`);
     }
@@ -550,6 +570,8 @@ class Live2DManager {
     // 有渲染活动时升回配置帧率，并安排在 durationMs 后衰减回静止地板（全平台）。
     boostInteractiveFPS(durationMs = LIVE2D_INTERACTIVE_FPS_HOLD_MS) {
         if (!this.pixi_app || !this.pixi_app.ticker) return;
+        // 有活动：先退出空闲低频 tick 模式，恢复 rAF 驱动的满帧管线。
+        this._exitIdleTickMode();
         const ticker = this.pixi_app.ticker;
         const configured = this._resolveConfiguredTargetFps();
         // 活动时升回用户配置上限（0=不限帧）。不再 Math.max(IDLE,...)，否则会把刻意设到
@@ -566,8 +588,96 @@ class Live2DManager {
             this._idleFpsRestoreTimer = null;
             if (this.pixi_app && this.pixi_app.ticker === originalTicker) {
                 originalTicker.maxFPS = this._resolveIdleFps();
+                // 无活动衰减到地板后，进一步切换到定时器驱动的低频 tick：
+                // rAF 驱动下即使 maxFPS 已限 30，三个 ticker 的 rAF 请求仍会让
+                // Blink 以显示器刷新率（如 120Hz）跑完整主帧生命周期，空耗 CPU/GPU。
+                this._enterIdleTickMode();
             }
         }, Math.max(100, Number(durationMs) || LIVE2D_INTERACTIVE_FPS_HOLD_MS));
+    }
+
+    /**
+     * 空闲低频 tick 模式：停掉 rAF 驱动的 ticker（app + 全局 shared/system），
+     * 改用 setInterval 以静止地板帧率手动 update()。效果等同 30fps 渲染，
+     * 但页面不再以显示器刷新率调度主帧。任何 boost / 外部 ticker.start()/stop()
+     * 都会立即退出该模式。
+     *
+     * 注意：PIXI.Ticker.shared/system 是全局单例。当前没有任何页面会同时运行
+     * 两个持有活跃 pixi_app 的 Live2DManager（预览管理器等都是互斥激活），
+     * 若未来出现共存场景，先进入空闲模式的实例会把另一个实例的 shared 驱动
+     * （模型 motion/physics 的 autoUpdate）降到自己的地板频率——届时需要把
+     * shared/system 的接管改成跨实例引用计数。
+     */
+    _enterIdleTickMode() {
+        if (this._idleTickMode) return;
+        if (!this.pixi_app || !this.pixi_app.ticker || !this._tickerOrigStop) return;
+        const ticker = this.pixi_app.ticker;
+        // 外部已显式暂停（pauseRendering / 角色切换）：不接管
+        if (ticker.started === false) return;
+        const PixiTicker = (typeof PIXI !== 'undefined' && PIXI.Ticker) ? PIXI.Ticker : null;
+        this._idleTickMode = true;
+        this._idleTickSharedWasStarted = !!(PixiTicker && PixiTicker.shared.started);
+        this._idleTickSystemWasStarted = !!(PixiTicker && PixiTicker.system.started);
+        // 定时器本身就是节流器：清掉 maxFPS 限制，避免 interval 抖动（33ms < minElapsed
+        // 33.33ms）导致 update() 被 maxFPS 丢帧、实际帧率减半。
+        this._idleTickSavedMaxFPS = ticker.maxFPS;
+        ticker.maxFPS = 0;
+        this._tickerOrigStop();
+        if (this._idleTickSharedWasStarted) PixiTicker.shared.stop();
+        if (this._idleTickSystemWasStarted) PixiTicker.system.stop();
+        const intervalMs = Math.max(16, Math.round(1000 / Math.max(1, this._resolveIdleFps())));
+        this._idleTickTimer = setInterval(() => {
+            if (!this._idleTickMode) return;
+            const app = this.pixi_app;
+            if (!app || !app.ticker) { this._exitIdleTickMode(); return; }
+            // 外部代码绕过包装直接把 ticker 拉起来了：让位给 rAF 模式
+            if (app.ticker.started) { this._exitIdleTickMode(); return; }
+            // 纯浏览器标签页隐藏时不渲染（对齐 rAF 模式下的完全暂停语义；
+            // Electron 宠物窗禁用 backgroundThrottling，不受影响）
+            if (typeof document !== 'undefined' && document.hidden) return;
+            const now = performance.now();
+            // 三个 update 各自捕获：一个 ticker 的异常不应拖累其余（对齐 rAF
+            // 模式下三条独立 rAF 链的失败隔离），且打印首个异常保住可诊断性。
+            const guardedUpdate = (t) => {
+                try {
+                    t.update(now);
+                } catch (e) {
+                    if (!this._idleTickErrorLogged) {
+                        this._idleTickErrorLogged = true;
+                        console.warn('[Live2D Core] 空闲低频 tick 渲染异常（同类后续异常不再打印）:', e);
+                    }
+                }
+            };
+            if (PixiTicker) {
+                if (this._idleTickSystemWasStarted) guardedUpdate(PixiTicker.system);
+                if (this._idleTickSharedWasStarted) guardedUpdate(PixiTicker.shared);
+            }
+            guardedUpdate(app.ticker);
+        }, intervalMs);
+    }
+
+    _exitIdleTickMode() {
+        if (!this._idleTickMode) return;
+        this._idleTickMode = false;
+        if (this._idleTickTimer) {
+            clearInterval(this._idleTickTimer);
+            this._idleTickTimer = null;
+        }
+        const PixiTicker = (typeof PIXI !== 'undefined' && PIXI.Ticker) ? PIXI.Ticker : null;
+        try {
+            if (PixiTicker) {
+                if (this._idleTickSharedWasStarted && !PixiTicker.shared.started) PixiTicker.shared.start();
+                if (this._idleTickSystemWasStarted && !PixiTicker.system.started) PixiTicker.system.start();
+            }
+        } catch (_) {}
+        const app = this.pixi_app;
+        if (app && app.ticker && typeof this._idleTickSavedMaxFPS === 'number') {
+            app.ticker.maxFPS = this._idleTickSavedMaxFPS;
+        }
+        if (app && app.ticker && app.ticker.started === false && this._tickerOrigStart) {
+            try { this._tickerOrigStart(); } catch (_) {}
+        }
+        this._idleTickSavedMaxFPS = null;
     }
 
     // 向后兼容旧调用名（live2d-interaction.js 的交互升帧），现已推广到全平台。
@@ -606,9 +716,17 @@ class Live2DManager {
             // （app-character / model_manager / app-ui / live2d-model 等）不走 resumeRendering，
             // 自终止后无人重启会让 Live2D 失去 idle 节流；ticker 恢复 started 后本守护自动继续治理。
             // 用 === false 安全降级：万一某 pixi 版本无 started 属性，守卫不触发即维持原行为。
-            if (this.pixi_app.ticker.started === false) return;
+            // 空闲低频 tick 模式下 started 恒为 false（由定时器驱动），但活动探测必须继续，
+            // 否则动作/拖拽/口型同步永远无法把帧率拉回来。
+            if (!this._idleTickMode && this.pixi_app.ticker.started === false) return;
             if (this._hasRenderActivity()) {
                 this.boostInteractiveFPS();
+            } else if (!this._idleTickMode && !this._idleFpsRestoreTimer) {
+                // 自愈：外部「确保渲染」路径（model-display / universal-manager 等的
+                // `!started && start()`）会把 ticker 拉回 rAF 模式并解除空闲低频 tick，
+                // 且不会再有 boost 衰减计时器带我们回来。无活动、无待衰减时直接重新进入。
+                this.pixi_app.ticker.maxFPS = this._resolveIdleFps();
+                this._enterIdleTickMode();
             }
         }, LIVE2D_IDLE_FPS_GOVERNOR_INTERVAL_MS);
     }
@@ -623,6 +741,9 @@ class Live2DManager {
             clearTimeout(this._idleFpsRestoreTimer);
             this._idleFpsRestoreTimer = null;
         }
+        // teardown 时必须退出空闲低频 tick 模式：全局 PIXI.Ticker.shared/system 是
+        // 我们停的，不恢复的话销毁重建后模型 autoUpdate（挂在 shared 上）会被冻住。
+        this._exitIdleTickMode();
     }
 
     /**


### PR DESCRIPTION
## 背景

对空闲态做了一轮**实测驱动**的性能分析（macOS · 120Hz ProMotion · psutil 进程采样 + CDP CPU profile + Chromium Tracing + CDP 实时暂停动画/ticker 的因果实验）。优化前 Electron 侧空闲共 **~61% 单核**（GPU 27.9% + 宠物页 19.8% + 聊天页 9.8% + 主进程 3.3%）；Python 后端空闲仅 0.6%，无需优化。

本 PR 修复其中归属于本仓库的 4 个问题（Electron 侧配套 PR：Project-N-E-K-O/N.E.K.O.-PC#355，两者独立可合）。

## 实测归因 → 修复

### 1. perf(live2d): 空闲低频 tick 模式（`live2d-core.js`）

Tracing 显示：idle governor 只设了 `maxFPS=30`，但三个 PIXI ticker（app + 全局 `Ticker.shared`/`system`）的 rAF 请求让 Blink 仍以显示器刷新率跑完整主帧生命周期（12 秒 1440 次 `BeginMainFrame`），且模型 update 挂在**未节流的 `Ticker.shared`** 上以 120Hz 跑物理，而实际渲染只有 30fps。

修复：空闲衰减后停掉全部 ticker，用 ~33ms `setInterval` 手动 `update()`（渲染语义不变，仍为地板帧率），主帧调度随之降到 30Hz。boost / 外部 `ticker.start()/stop()`（已包装）立即让位；governor 带自愈（外部「确保渲染」路径解除后自动重新进入）；`document.hidden` 跳过；teardown 恢复全局 ticker。

已运行时验证：空闲进入/boost 退出/衰减回落闭环、呼吸动画连续性、外部 start/stop 交互、尊重用户 `targetFrameRate` 配置。

### 2. perf(ui): CSS 动画（`index.css` + react `styles.css`）

- `#status-toast::before` 的 infinite pawBounce 在 toast `opacity:0` 隐藏时**在宠物页和聊天页各一份、以刷新率永久隐形空转**（toast 用 opacity 隐藏而非 display:none，合成器无法休眠）→ 门控到 `.show`。
- `compact-history-handle-breathe` 每帧动画 `filter: drop-shadow` —— filter 动画无法走合成器捷径，**120Hz 下逐帧重光栅化** → 改为只呼吸 opacity（静态阴影保留，脉动光晕由本就合成器友好的 `::after` opacity/transform 层承担）。

因果实验：暂停这些动画使聊天窗口 renderer **9.8% → 2.0%**、GPU 进程 **−12.7pp**。

### 3. fix(audio): `scheduleAudioChunks` 调度链泄漏（`app-audio-playback.js`）

25ms 自续 `setTimeout` 不存 id、无条件自续、外部调用可叠链——**实测空闲状态下 3 条并行链共 114 次/秒**，随会话时长恶化。修复：单飞行 + `_hasPendingAudioWork()` 判定 + 空闲停链 + 流式间隙后由 `handleAudioBlob` 重新拉起 + `clearAudioQueue*` 显式清 timer。

### 4. fix(monitor): /ws 断连死循环（`app/monitor.py`）

裸 `except` 吞掉 `WebSocketDisconnect` → 断连后 `receive_bytes()` 永远抛 `RuntimeError`（同样被吞）→ 每个断开的查看端留下一条 10Hz 永动协程。显式重抛。

## 优化效果（配合 N.E.K.O.-PC 侧 PR，空闲 5 分钟均值复测）

| 进程 | 前 | 后 |
|---|---|---|
| GPU 进程 | 27.9% | **10.7%（−62%）** |
| 聊天页 renderer | 9.8% | **0.3%（−97%）** |
| 宠物页 renderer | 19.8% | 18.4%（剩余为 30fps 全屏 Live2D 渲染本体，每帧 ~3.8ms） |
| Electron 合计 | **60.8%** | **32.1%（−47%）** |

内存：12 分钟观察 JS 堆呈健康 GC 锯齿、监听器/DOM 节点数恒定，无泄漏。

## 风险与已知边界

- 全部改动经 5 路对抗性 review，无 blocker；审查发现的 X11 竞态等问题已在 Electron 侧 PR 中处理。
- `PIXI.Ticker.shared/system` 为全局单例：当前没有页面会同时运行两个持有活跃 pixi_app 的 Live2DManager；若未来出现共存场景需改为引用计数（代码内已留注释）。
- VRM / MMD / PNGTuber 形态尚无同等 idle 节流（`vrm-manager.js:669`、`mmd-core.js:984`、`pngtuber-core.js:1352`），是后续优化方向。

## 回归报告

本 PR 触及 `app/` 的唯一改动是 `app/monitor.py` 的 `/ws/{lanlan_name}` 查看端点：

**改动与必要性**：内层 keep-alive 循环原先用裸 `except` 包住 `receive_text()`/`receive_bytes()`。客户端断开时 `WebSocketDisconnect` 被第一层裸 except 吞掉，此后每次 `receive_*()` 都抛 `RuntimeError`（"cannot receive after disconnect"，也被吞），协程永远不退出——每个断开的查看端留下一条 0.1s 间隔的永动空转循环，且 `connected_clients` 集合不收缩（依赖后台清理任务兜底）。改为：显式捕获并重抛 `WebSocketDisconnect`；断连后的 `RuntimeError` 归一为 `WebSocketDisconnect` 收尾。

**改动前后行为**：
- 前：客户端正常断开 → 协程空转、10Hz 唤醒、依赖周期清理任务移除句柄。
- 后：客户端正常断开 → 立即走外层 `except WebSocketDisconnect` → `finally` 移除句柄、协程退出。收到二进制帧（`receive_text()` 抛非断连异常）时行为不变：落入 `receive_bytes()` 分支或 0.1s 等待后继续循环。

**潜在回归面**：
- 若 starlette 在活跃连接上抛出非断连的 `RuntimeError`，现在会被归一为断连并结束该查看端连接（旧行为是无限空转）。查看端（monitor 页面）具备自动重连，影响为一次重连；且该场景在 starlette 0.46 的 `receive_bytes()` 路径上仅出现于断连后调用。
- 其余三个 ws 端点（/subtitle_ws、/sync、/sync_binary）无此模式，未改动。

其余文件（`static/`、`frontend/`）均为前端资源，不在 app/main_logic/main_routers/memory 监管范围内；改动说明与实测数据见上文。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
