### PR TITLE
perf: 空闲节流移植 VRM/MMD/PNGTuber + Live2D 每帧热点 + dock 轮询 + monitor ws 容错（round-2）

### DIFF
--- a/app/monitor.py
+++ b/app/monitor.py
@@ -266,6 +266,19 @@ async def translate_japanese_to_chinese(text):
     # 你需要根据实际情况实现翻译功能
     pass
 
+async def _receive_ws_frame(websocket: WebSocket) -> dict:
+    """接收一帧原始 ws 消息，断连帧转 WebSocketDisconnect（对齐 receive_text 语义）。
+
+    starlette 0.46 的 receive_text()/receive_bytes() 收到类型不符的帧会抛
+    KeyError（且该帧已被消费），沿用它们会让一个意外的二进制/文本帧直接
+    杀掉整条连接。用原始 receive() + 显式取键让调用方自行容忍帧类型。
+    """
+    message = await websocket.receive()
+    if message.get("type") == "websocket.disconnect":
+        raise WebSocketDisconnect(message.get("code") or 1000)
+    return message
+
+
 @app.websocket("/subtitle_ws")
 async def subtitle_websocket_endpoint(websocket: WebSocket):
     await websocket.accept()
@@ -282,9 +295,10 @@ async def subtitle_websocket_endpoint(websocket: WebSocket):
                 "text": current_subtitle
             })
 
-        # 保持连接
+        # 保持连接（keep-alive：忽略帧内容，容忍任意帧类型——
+        # receive_text() 收到二进制帧会抛 KeyError 杀掉字幕连接）
         while True:
-            await websocket.receive_text()
+            await _receive_ws_frame(websocket)
     except WebSocketDisconnect:
         print(f"字幕客户端已断开: {websocket.client}")
     finally:
@@ -319,7 +333,11 @@ async def sync_endpoint(websocket: WebSocket, lanlan_name:str):
         while True:
             try:
                 global current_subtitle
-                data = await asyncio.wait_for(websocket.receive_text(), timeout=25)
+                message = await asyncio.wait_for(_receive_ws_frame(websocket), timeout=25)
+                data = message.get("text")
+                if data is None:
+                    # 非文本帧（如二进制）：忽略，不让 KeyError 杀掉同步连接
+                    continue
 
                 # 广播到所有连接的客户端
                 data = json.loads(data)
@@ -367,7 +385,11 @@ async def sync_binary_endpoint(websocket: WebSocket, lanlan_name:str):
     try:
         while True:
             try:
-                data = await asyncio.wait_for(websocket.receive_bytes(), timeout=25)
+                message = await asyncio.wait_for(_receive_ws_frame(websocket), timeout=25)
+                data = message.get("bytes")
+                if data is None:
+                    # 非二进制帧（如文本）：忽略，不让 KeyError 杀掉同步连接
+                    continue
                 if len(data)>4:
                     await broadcast_binary(data)
             except asyncio.exceptions.TimeoutError:
@@ -388,28 +410,10 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name:str):
     connected_clients.add(websocket)
 
     try:
-        # 保持连接直到客户端断开
+        # 保持连接直到客户端断开（keep-alive：忽略帧内容，容忍任意帧类型；
+        # 断连由 _receive_ws_frame 转成 WebSocketDisconnect 抛到外层收尾）
         while True:
-            # 接收任何类型的消息（文本或二进制），主要用于保持连接。
-            # 注意：断连必须重新抛出——旧实现的裸 except 会把 WebSocketDisconnect
-            # 一并吞掉，随后 receive 永远抛 RuntimeError，协程退化成每个已断开
-            # 客户端一条 10Hz 的永动空转循环。
-            try:
-                await websocket.receive_text()
-            except WebSocketDisconnect:
-                raise
-            except Exception:
-                # 如果收到的是二进制数据，receive_text() 会失败，尝试 receive_bytes()
-                try:
-                    await websocket.receive_bytes()
-                except WebSocketDisconnect:
-                    raise
-                except RuntimeError as e:
-                    # starlette: 断开后继续 receive 抛 RuntimeError —— 视作断连收尾
-                    raise WebSocketDisconnect() from e
-                except Exception:
-                    # 两者都失败（非断连原因），等待一下再继续
-                    await asyncio.sleep(0.1)
+            await _receive_ws_frame(websocket)
     except WebSocketDisconnect:
         print(f"❌ [CLIENT] 查看客户端已断开: {websocket.client}")
     except Exception as e:

--- a/app/monitor.py
+++ b/app/monitor.py
@@ -267,11 +267,12 @@ async def translate_japanese_to_chinese(text):
     pass
 
 async def _receive_ws_frame(websocket: WebSocket) -> dict:
-    """接收一帧原始 ws 消息，断连帧转 WebSocketDisconnect（对齐 receive_text 语义）。
+    """Receive one raw ws message; convert disconnect frames to WebSocketDisconnect.
 
-    starlette 0.46 的 receive_text()/receive_bytes() 收到类型不符的帧会抛
-    KeyError（且该帧已被消费），沿用它们会让一个意外的二进制/文本帧直接
-    杀掉整条连接。用原始 receive() + 显式取键让调用方自行容忍帧类型。
+    starlette 0.46's receive_text()/receive_bytes() raise KeyError on a frame of
+    the mismatched type (and the frame is already consumed), so a single
+    unexpected binary/text frame would kill the whole connection. Using raw
+    receive() with explicit key lookups lets each caller tolerate any frame type.
     """
     message = await websocket.receive()
     if message.get("type") == "websocket.disconnect":

--- a/static/app/app-character.js
+++ b/static/app/app-character.js
@@ -1220,10 +1220,15 @@
                 console.log('[猫娘切换] VRM模型加载完成');
                 resetAvatarLockForCharacterSwitch('vrm');
 
-                // 【关键修复】确保VRM渲染循环已启动（loadModel内部会调用startAnimation，但为了保险再次确认）
+                // 【关键修复】确保VRM渲染循环已启动。历史上这里调用的
+                // startAnimation() 在 VRMManager 上并不存在（typeof 守卫下静默
+                // no-op）；真正的恢复 API 是 resumeRendering()——空闲低频模式引入
+                // pauseRendering 停链后，这条兜底必须真的能把循环拉起来。
                 if (!window.vrmManager._animationFrameId) {
                     console.log('[猫娘切换] VRM渲染循环未启动，手动启动');
-                    if (typeof window.vrmManager.startAnimation === 'function') {
+                    if (typeof window.vrmManager.resumeRendering === 'function') {
+                        window.vrmManager.resumeRendering();
+                    } else if (typeof window.vrmManager.startAnimation === 'function') {
                         window.vrmManager.startAnimation();
                     }
                 } else {
@@ -1971,10 +1976,15 @@
                     if (ticker && !ticker.started) ticker.start();
                 } catch (_e) { /* ignore */ }
                 try {
-                    if (window.vrmManager
-                        && !window.vrmManager._animationFrameId
-                        && typeof window.vrmManager.startAnimation === 'function') {
-                        window.vrmManager.startAnimation();
+                    // rollback 恢复：startAnimation 在 VRMManager 上不存在（历史
+                    // 遗留 no-op），切换失败后旧 VRM 会被 pauseRendering 冻住——
+                    // 改用真实的 resumeRendering() 恢复渲染循环
+                    if (window.vrmManager && !window.vrmManager._animationFrameId) {
+                        if (typeof window.vrmManager.resumeRendering === 'function') {
+                            window.vrmManager.resumeRendering();
+                        } else if (typeof window.vrmManager.startAnimation === 'function') {
+                            window.vrmManager.startAnimation();
+                        }
                     }
                 } catch (_e) { /* ignore */ }
                 // MMD rollback 恢复：清理阶段为防 MMD→非 MMD 切换中途失败让模型区空白，

--- a/static/app/app-character.js
+++ b/static/app/app-character.js
@@ -566,8 +566,11 @@
                 window.live2dManager.pixi_app.ticker.stop();
             }
 
-            // 停止 VRM 渲染循环
-            if (window.vrmManager && window.vrmManager._animationFrameId) {
+            // 停止 VRM 渲染循环（走 pauseRendering：空闲低频模式下 rAF id 为
+            // null，裸字段取消管不到 interval，会让旧模型在后台永久渲染）
+            if (window.vrmManager && typeof window.vrmManager.pauseRendering === 'function') {
+                window.vrmManager.pauseRendering();
+            } else if (window.vrmManager && window.vrmManager._animationFrameId) {
                 cancelAnimationFrame(window.vrmManager._animationFrameId);
                 window.vrmManager._animationFrameId = null;
             }
@@ -667,8 +670,10 @@
                 }
 
                 if (window.vrmManager) {
-                    // 1. 停止动画循环
-                    if (window.vrmManager._animationFrameId) {
+                    // 1. 停止动画循环（走 pauseRendering，理由同上：兼容空闲低频模式）
+                    if (typeof window.vrmManager.pauseRendering === 'function') {
+                        window.vrmManager.pauseRendering();
+                    } else if (window.vrmManager._animationFrameId) {
                         cancelAnimationFrame(window.vrmManager._animationFrameId);
                         window.vrmManager._animationFrameId = null;
                     }

--- a/static/app/app-interpage/bootstrap-resources-and-model-reload.js
+++ b/static/app/app-interpage/bootstrap-resources-and-model-reload.js
@@ -1666,6 +1666,13 @@ I.mod = window.appInterpage;
                 cancelAnimationFrame(window.mmdManager._uiUpdateLoopId);
                 window.mmdManager._uiUpdateLoopId = null;
             }
+            // 空闲低频模式下 UI 循环可能停在 pending 再入定时器里：一并清掉
+            for (const mgr of [window.vrmManager, window.mmdManager]) {
+                if (mgr && mgr._uiLoopIdleTimeout) {
+                    clearTimeout(mgr._uiLoopIdleTimeout);
+                    mgr._uiLoopIdleTimeout = null;
+                }
+            }
 
             // 隐藏所有悬浮按钮、锁图标和返回按钮（它们挂载在 document.body 上，不随容器隐藏）。
             // 记录隐藏前的 display，避免恢复时清空 display 导致容器短暂按默认 block 布局显示，

--- a/static/app/app-react-chat-window/minimize-and-idle-dock.js
+++ b/static/app/app-react-chat-window/minimize-and-idle-dock.js
@@ -251,6 +251,34 @@
 
         var now = Date.now();
         var collapsed = isElectronChatWindowCollapsed(bridge);
+
+        // preload 已发布真实毛球矩形（GNOME Wayland 等平台）时，
+        // getElectronChatMinimizedScreenRect 会直接用它、无视 getBounds 结果——
+        // 此时每 500ms 的 getBounds IPC 纯属浪费，直接走同步路径。
+        if (collapsed && normalizeElectronWindowBoundsRect(window.__nekoMinimizedChatBallScreenRect)) {
+            var directRect = getElectronChatMinimizedScreenRect(null);
+            if (directRect) {
+                var directSig = getElectronChatMinimizedStateSignature(true, directRect);
+                if (directSig === I.electronChatMinimizedStateSignature &&
+                    reason === 'poll' &&
+                    now - I.electronChatMinimizedStatePublishedAt < I.ELECTRON_CHAT_MINIMIZED_STATE_HEARTBEAT_MS) {
+                    return;
+                }
+                I.electronChatMinimizedStateSignature = directSig;
+                I.electronChatMinimizedStatePublishedAt = now;
+                window.dispatchEvent(new CustomEvent('neko:idle-chat-minimized-state', {
+                    detail: {
+                        action: 'idle_chat_minimized_state',
+                        source: 'chat-window',
+                        reason: reason || 'sync',
+                        minimized: true,
+                        screenRect: directRect,
+                        timestamp: now
+                    }
+                }));
+                return;
+            }
+        }
         if (!collapsed) {
             if (I.electronChatMinimizedStateSignature === '0' &&
                 reason === 'poll' &&
@@ -300,7 +328,15 @@
     }
 
     function scheduleElectronChatMinimizedState(reason) {
-        if (!I.isElectronChatWindow() || I.electronChatMinimizedStateFrame) return;
+        if (!I.isElectronChatWindow()) return;
+        // 非 poll 触发（pointer/resize/init/sync）说明状态可能真的在变：
+        // 接下来 ~3s 保持 500ms 满频轮询，覆盖拖拽后主进程 snap 动画收尾。
+        // 必须在 pending 帧早退之前设置——否则恰逢 poll 帧待发时，真实触发
+        // 会被整体吞掉、满频窗口也不会打开。
+        if (reason && reason !== 'poll') {
+            I.electronChatMinimizedStateFullRateUntil = Date.now() + 3000;
+        }
+        if (I.electronChatMinimizedStateFrame) return;
         I.electronChatMinimizedStateFrame = window.requestAnimationFrame(function () {
             I.electronChatMinimizedStateFrame = 0;
             dispatchElectronChatMinimizedState(reason || 'sync');
@@ -310,7 +346,16 @@
     I.ensureElectronChatMinimizedStateBridge = function ensureElectronChatMinimizedStateBridge() {
         if (!I.isElectronChatWindow() || I.electronChatMinimizedStateTimer) return;
         scheduleElectronChatMinimizedState('init');
+        I.electronChatMinimizedStatePollTick = 0;
         I.electronChatMinimizedStateTimer = window.setInterval(function () {
+            // 空闲退避：状态签名稳定且 3s 内无 pointer/resize 等真实触发时，
+            // 每 3 跳才做一次带 getBounds IPC 的轮询（500ms→1.5s）。
+            // 上限不能再放：宠物侧消费方 _NEKO_IDLE_DESKTOP_CHAT_RECT_STALE_MS=2500
+            // 会把超过 2.5s 未刷新的毛球矩形当过期，心跳间隔必须留出安全余量。
+            // 毛球位置的用户拖拽走 mousemove/mouseup 监听（非 poll 路径），不受影响。
+            I.electronChatMinimizedStatePollTick = (I.electronChatMinimizedStatePollTick || 0) + 1;
+            var fullRate = Date.now() < (I.electronChatMinimizedStateFullRateUntil || 0);
+            if (!fullRate && I.electronChatMinimizedStatePollTick % 3 !== 0) return;
             scheduleElectronChatMinimizedState('poll');
         }, 500);
         window.addEventListener('resize', function () {

--- a/static/app/app-ui/bootstrap-goodbye-and-toasts.js
+++ b/static/app/app-ui/bootstrap-goodbye-and-toasts.js
@@ -137,12 +137,18 @@ I.mod = window.appUi;
 
     function isModelRenderingActive(type, manager) {
         if (!manager) return false;
+        // 各形态的空闲低频 tick 模式下，rAF id / ticker.started 都是"停"的假象
+        // （渲染由 setInterval 驱动）——必须把 _idleTickMode 也算作"在渲染"，
+        // 否则 goodbye 资源暂停会漏掉它们。
         if (type === 'live2d') {
             const ticker = manager.pixi_app && manager.pixi_app.ticker;
-            return !!(ticker && ticker.started !== false);
+            return !!(ticker && (ticker.started !== false || manager._idleTickMode));
         }
-        if (type === 'vrm' || type === 'mmd') {
-            return !!manager._animationFrameId;
+        if (type === 'vrm') {
+            return !!(manager._animationFrameId || manager._idleTickMode);
+        }
+        if (type === 'mmd') {
+            return !!(manager._animationFrameId || (manager.core && manager.core._idleTickMode));
         }
         if (type === 'pngtuber') {
             const container = manager.container || document.getElementById('pngtuber-container');

--- a/static/avatar/avatar-ui-buttons/methods-setup.js
+++ b/static/avatar/avatar-ui-buttons/methods-setup.js
@@ -74,6 +74,10 @@ Object.assign(AvatarButtonMixin.methods, {
                         cancelAnimationFrame(mgr._uiUpdateLoopId);
                         mgr._uiUpdateLoopId = null;
                     }
+                    if (mgr._uiLoopIdleTimeout) {
+                        clearTimeout(mgr._uiLoopIdleTimeout);
+                        mgr._uiLoopIdleTimeout = null;
+                    }
                     if (mgr._floatingButtonsTicker && mgr.pixi_app && mgr.pixi_app.ticker) {
                         try { mgr.pixi_app.ticker.remove(mgr._floatingButtonsTicker); } catch (_) {}
                         mgr._floatingButtonsTicker = null;

--- a/static/avatar/avatar-ui-buttons/methods-state-and-cleanup.js
+++ b/static/avatar/avatar-ui-buttons/methods-state-and-cleanup.js
@@ -249,6 +249,12 @@ Object.assign(AvatarButtonMixin.methods, {
                 cancelAnimationFrame(this._uiUpdateLoopId);
                 this._uiUpdateLoopId = null;
             }
+            // 空闲低频模式下 UI 循环停在 pending 的再入定时器里：显式清掉，
+            // 让停止即刻生效（不依赖定时器触发时的自检兜底）
+            if (this._uiLoopIdleTimeout) {
+                clearTimeout(this._uiLoopIdleTimeout);
+                this._uiLoopIdleTimeout = null;
+            }
             this._updateFloatingButtonsPositionNow = null;
 
             // 摘除浮动按钮 / 锁图标 ticker —— 下方会删掉它们的 DOM，但 _removeFloatingButtonsElement

--- a/static/live2d/live2d-core.js
+++ b/static/live2d/live2d-core.js
@@ -542,7 +542,11 @@ class Live2DManager {
         }
         // 立即按 governor 语义落地，不必等下一次活动周期：有渲染活动升回配置帧率，
         // 否则直接压到静止地板，避免改完设置后空闲态停在未节流的值。
-        if (this._hasRenderActivity()) {
+        if (window.__NEKO_DISABLE_AVATAR_IDLE_THROTTLE__ === true) {
+            // 页面级豁免：直接落配置帧率，不进入空闲地板/低频模式
+            this._exitIdleTickMode();
+            this.pixi_app.ticker.maxFPS = window.targetFrameRate;
+        } else if (this._hasRenderActivity()) {
             this.boostInteractiveFPS();
         } else {
             // 改配置时如果正处于空闲低频 tick 模式，先退出再按新地板重新进入，
@@ -583,7 +587,10 @@ class Live2DManager {
         const originalTicker = ticker;
         if (this._idleFpsRestoreTimer) {
             clearTimeout(this._idleFpsRestoreTimer);
+            this._idleFpsRestoreTimer = null;
         }
+        // 页面级豁免：只升频、不安排衰减——衰减会把预览页压回空闲地板帧率
+        if (window.__NEKO_DISABLE_AVATAR_IDLE_THROTTLE__ === true) return;
         this._idleFpsRestoreTimer = setTimeout(() => {
             this._idleFpsRestoreTimer = null;
             if (this.pixi_app && this.pixi_app.ticker === originalTicker) {
@@ -701,6 +708,8 @@ class Live2DManager {
     // 自适应帧率守护：周期性探测活动状态，有活动就续命满帧，无活动时由衰减计时器回落到地板。
     _startIdleFpsGovernor() {
         this._stopIdleFpsGovernor();
+        // 页面级豁免（demo/模型管理器等预览页）：期望满帧，不启动空闲治理
+        if (window.__NEKO_DISABLE_AVATAR_IDLE_THROTTLE__ === true) return;
         // 启动即视为活动（加载/入场动画期间保持满帧），随后自动衰减。
         this.boostInteractiveFPS();
         this._idleFpsGovernorTimer = setInterval(() => {

--- a/static/live2d/live2d-model.js
+++ b/static/live2d/live2d-model.js
@@ -2399,6 +2399,21 @@ Live2DManager.prototype.installMouthOverride = function() {
         } catch (_) {}
     }
 
+    // 每帧遍历用的 [id, idx] 快照：两个索引表都是上面一次性填充、之后只读的
+    // const 闭包变量，在这里提升 Object.entries 结果，避免包装后的 update
+    // 每帧（30-60fps）重复分配 5-6 个 entries 数组带来的 GC 压力。
+    const mouthParamEntries = Object.entries(mouthParamIndices);
+    const lookAtParamEntries = Object.entries(lookAtParamIndices);
+    // 呼吸参数索引同理：参数索引对模型实例固定，安装期解析一次，
+    // 免去每帧对 Cubism core 的 getParameterIndex 字符串查询。
+    const breathParamEntries = [];
+    for (const id of runtimeBreathParams) {
+        try {
+            const idx = coreModel.getParameterIndex(id);
+            if (idx >= 0) breathParamEntries.push([id, idx]);
+        } catch (_) {}
+    }
+
     // 覆盖 1: motionManager.update
     if (internalModel.motionManager && typeof internalModel.motionManager.update === 'function') {
         // 确保在绑定之前，motionManager 和 coreModel 都已准备好
@@ -2426,7 +2441,7 @@ Live2DManager.prototype.installMouthOverride = function() {
                     } catch (_) {}
                 }
             }
-            for (const [id, idx] of Object.entries(mouthParamIndices)) {
+            for (const [id, idx] of mouthParamEntries) {
                 try {
                     preUpdateParams[id] = coreModel.getParameterValueByIndex(idx);
                 } catch (_) {}
@@ -2436,14 +2451,12 @@ Live2DManager.prototype.installMouthOverride = function() {
                     try { preUpdateParams[p.id] = coreModel.getParameterValueByIndex(p.idx); } catch (_) {}
                 }
             }
-            const breathParams = runtimeBreathParams;
-            for (const id of breathParams) {
+            for (const [id, idx] of breathParamEntries) {
                 try {
-                    const idx = coreModel.getParameterIndex(id);
-                    if (idx >= 0) preUpdateParams[id] = coreModel.getParameterValueByIndex(idx);
+                    preUpdateParams[id] = coreModel.getParameterValueByIndex(idx);
                 } catch (_) {}
             }
-            for (const [id, idx] of Object.entries(lookAtParamIndices)) {
+            for (const [id, idx] of lookAtParamEntries) {
                 try {
                     preUpdateParams[id] = coreModel.getParameterValueByIndex(idx);
                 } catch (_) {}
@@ -2485,7 +2498,7 @@ Live2DManager.prototype.installMouthOverride = function() {
                 this._motionDrivenBreathParamIds = new Set();
             }
             const shouldTreatEyeChangesAsAuthoritative = motionPriority > LIVE2D_MOTION_PRIORITY.IDLE;
-            for (const [id, idx] of Object.entries(mouthParamIndices)) {
+            for (const [id, idx] of mouthParamEntries) {
                 try {
                     const postVal = coreModel.getParameterValueByIndex(idx);
                     const preVal = preUpdateParams[id];
@@ -2507,20 +2520,17 @@ Live2DManager.prototype.installMouthOverride = function() {
                     } catch (_) {}
                 }
             }
-            for (const id of breathParams) {
+            for (const [id, idx] of breathParamEntries) {
                 try {
-                    const idx = coreModel.getParameterIndex(id);
-                    if (idx >= 0) {
-                        const postVal = coreModel.getParameterValueByIndex(idx);
-                        const preVal = preUpdateParams[id];
-                        if (preVal !== undefined && Math.abs(postVal - preVal) > 0.001) {
-                            this._motionDrivenBreathParamIds.add(id);
-                        }
+                    const postVal = coreModel.getParameterValueByIndex(idx);
+                    const preVal = preUpdateParams[id];
+                    if (preVal !== undefined && Math.abs(postVal - preVal) > 0.001) {
+                        this._motionDrivenBreathParamIds.add(id);
                     }
                 } catch (_) {}
             }
             this._isBreathDrivenByMotion = this._motionDrivenBreathParamIds.size > 0;
-            for (const [id, idx] of Object.entries(lookAtParamIndices)) {
+            for (const [id, idx] of lookAtParamEntries) {
                 try {
                     const postVal = coreModel.getParameterValueByIndex(idx);
                     const preVal = preUpdateParams[id];
@@ -2573,7 +2583,7 @@ Live2DManager.prototype.installMouthOverride = function() {
 
                     // 口型参数：lipsync 在响（mouthValue > 0）时强制覆盖 motion；静默时让位给 motion 自带的嘴部动画
                     if (!this._isMouthDrivenByMotion || this.mouthValue > LIPSYNC_OVERRIDE_THRESHOLD) {
-                        for (const [id, idx] of Object.entries(mouthParamIndices)) {
+                        for (const [id, idx] of mouthParamEntries) {
                             try {
                                 coreModel.setParameterValueByIndex(idx, this.mouthValue);
                             } catch (_) {}
@@ -2673,7 +2683,7 @@ Live2DManager.prototype.installMouthOverride = function() {
             // 这是渲染前的最后一步，强制命令，绝对优先级
             // 口型参数：lipsync 在响（mouthValue > 0）时强制覆盖 motion；静默时让位给 motion 自带的嘴部动画
             if (!this._isMouthDrivenByMotion || this.mouthValue > LIPSYNC_OVERRIDE_THRESHOLD) {
-                for (const [id, idx] of Object.entries(mouthParamIndices)) {
+                for (const [id, idx] of mouthParamEntries) {
                     try {
                         currentCoreModel.setParameterValueByIndex(idx, this.mouthValue);
                     } catch (_) {}

--- a/static/live2d/live2d-model.js
+++ b/static/live2d/live2d-model.js
@@ -2583,7 +2583,7 @@ Live2DManager.prototype.installMouthOverride = function() {
 
                     // 口型参数：lipsync 在响（mouthValue > 0）时强制覆盖 motion；静默时让位给 motion 自带的嘴部动画
                     if (!this._isMouthDrivenByMotion || this.mouthValue > LIPSYNC_OVERRIDE_THRESHOLD) {
-                        for (const [id, idx] of mouthParamEntries) {
+                        for (const [, idx] of mouthParamEntries) {
                             try {
                                 coreModel.setParameterValueByIndex(idx, this.mouthValue);
                             } catch (_) {}
@@ -2683,7 +2683,7 @@ Live2DManager.prototype.installMouthOverride = function() {
             // 这是渲染前的最后一步，强制命令，绝对优先级
             // 口型参数：lipsync 在响（mouthValue > 0）时强制覆盖 motion；静默时让位给 motion 自带的嘴部动画
             if (!this._isMouthDrivenByMotion || this.mouthValue > LIPSYNC_OVERRIDE_THRESHOLD) {
-                for (const [id, idx] of mouthParamEntries) {
+                for (const [, idx] of mouthParamEntries) {
                     try {
                         currentCoreModel.setParameterValueByIndex(idx, this.mouthValue);
                     } catch (_) {}

--- a/static/live2d/live2d-ui-buttons.js
+++ b/static/live2d/live2d-ui-buttons.js
@@ -175,6 +175,12 @@ Live2DManager.prototype.setupHTMLLockIcon = function(model) {
     lockIcon.appendChild(imgContainer);
 
     document.body.appendChild(lockIcon);
+    // 新建元素没有 left/top 内联样式：必须失效位置/透明度脏检查缓存，
+    // 否则模型位置与上次相同时首帧写入被跳过，图标停在 fixed 默认位置
+    this._lockIconLastLeft = undefined;
+    this._lockIconLastTop = undefined;
+    this._lockIconLastOpacity = undefined;
+    this._lockIconLastOverlapScanAt = 0;
     this._lockIconElement = lockIcon;
     this._lockIconImages = {
         locked: imgLocked,
@@ -203,6 +209,8 @@ Live2DManager.prototype.setupHTMLLockIcon = function(model) {
                 delete lockIcon.dataset.yuiGuideForcedHidden;
                 lockIcon.style.visibility = '';
                 lockIcon.style.opacity = '';
+                // 旁路写入后失效 opacity 脏检查缓存，避免后续 tick 误跳过写回
+                this._lockIconLastOpacity = undefined;
             }
             if (!model || !model.parent) {
                 // 教程期间不隐藏锁图标，防止高亮框位置被刷到 (0,0)
@@ -219,35 +227,60 @@ Live2DManager.prototype.setupHTMLLockIcon = function(model) {
             const maxLockTop = typeof window.getNekoYuiGuideLockIconMaxTop === 'function'
                 ? window.getNekoYuiGuideLockIconMaxTop(screenHeight - 40, 40)
                 : screenHeight - 40;
-            lockIcon.style.left = `${Math.max(0, Math.min(targetX, screenWidth - 40))}px`;
-            lockIcon.style.top = `${Math.max(0, Math.min(targetY, maxLockTop))}px`;
+            const clampedLeft = Math.round(Math.max(0, Math.min(targetX, screenWidth - 40)));
+            const clampedTop = Math.round(Math.max(0, Math.min(targetY, maxLockTop)));
+            // 位置无变化时跳过 style 写入，避免每帧无谓的样式失效
+            if (clampedLeft !== this._lockIconLastLeft || clampedTop !== this._lockIconLastTop) {
+                this._lockIconLastLeft = clampedLeft;
+                this._lockIconLastTop = clampedTop;
+                lockIcon.style.left = `${clampedLeft}px`;
+                lockIcon.style.top = `${clampedTop}px`;
+            }
 
-            const lockRect = lockIcon.getBoundingClientRect();
-            let isOverlapped = false;
-            document.querySelectorAll('[id^="live2d-popup-"]').forEach(popup => {
-                if (popup.style.display === 'flex' && popup.style.opacity === '1') {
-                    const popupRect = popup.getBoundingClientRect();
-                    if (lockRect.right > popupRect.left && lockRect.left < popupRect.right &&
-                        lockRect.bottom > popupRect.top && lockRect.top < popupRect.bottom) {
-                        isOverlapped = true;
-                    }
-                }
-            });
-            if (!isOverlapped) {
-                document.querySelectorAll('[data-neko-sidepanel]').forEach(panel => {
-                    if (panel.style.display !== 'none' && parseFloat(panel.style.opacity) > 0) {
-                        const panelRect = panel.getBoundingClientRect();
-                        if (lockRect.right > panelRect.left && lockRect.left < panelRect.right &&
-                            lockRect.bottom > panelRect.top && lockRect.top < panelRect.bottom) {
+            // 重叠检测节流到 250ms：纯装饰性淡出（opacity 0.3），不需要逐帧
+            // 扫两遍 DOM。矩形用已知坐标 + 固定 32px 尺寸推算（图标 position:fixed
+            // 无变换），避免每帧 getBoundingClientRect 强制布局。
+            const nowTs = performance.now();
+            let isOverlapped = this._lockIconLastOverlapped === true;
+            if (!this._lockIconLastOverlapScanAt || nowTs - this._lockIconLastOverlapScanAt >= 250) {
+                this._lockIconLastOverlapScanAt = nowTs;
+                const lockRect = {
+                    left: clampedLeft,
+                    top: clampedTop,
+                    right: clampedLeft + 32,
+                    bottom: clampedTop + 32
+                };
+                isOverlapped = false;
+                document.querySelectorAll('[id^="live2d-popup-"]').forEach(popup => {
+                    if (popup.style.display === 'flex' && popup.style.opacity === '1') {
+                        const popupRect = popup.getBoundingClientRect();
+                        if (lockRect.right > popupRect.left && lockRect.left < popupRect.right &&
+                            lockRect.bottom > popupRect.top && lockRect.top < popupRect.bottom) {
                             isOverlapped = true;
                         }
                     }
                 });
+                if (!isOverlapped) {
+                    document.querySelectorAll('[data-neko-sidepanel]').forEach(panel => {
+                        if (panel.style.display !== 'none' && parseFloat(panel.style.opacity) > 0) {
+                            const panelRect = panel.getBoundingClientRect();
+                            if (lockRect.right > panelRect.left && lockRect.left < panelRect.right &&
+                                lockRect.bottom > panelRect.top && lockRect.top < panelRect.bottom) {
+                                isOverlapped = true;
+                            }
+                        }
+                    });
+                }
+                this._lockIconLastOverlapped = isOverlapped;
             }
             // 与角色形象半透明状态完全同步：容器加了 locked-hover-fade 类(opacity 0.12)时，锁图标也淡到同一透明度
             const live2dFadeContainer = document.getElementById('live2d-container');
             const lockShouldFade = live2dFadeContainer && live2dFadeContainer.classList.contains('locked-hover-fade');
-            lockIcon.style.opacity = lockShouldFade ? '0.12' : (isOverlapped ? '0.3' : '');
+            const nextOpacity = lockShouldFade ? '0.12' : (isOverlapped ? '0.3' : '');
+            if (nextOpacity !== this._lockIconLastOpacity) {
+                this._lockIconLastOpacity = nextOpacity;
+                lockIcon.style.opacity = nextOpacity;
+            }
         } catch (_) {}
     };
     this._lockIconTicker = tick;
@@ -288,6 +321,11 @@ Live2DManager.prototype.setupFloatingButtons = function(model) {
 
     // 基础框架初始化
     const buttonsContainer = this.setupFloatingButtonsBase(model);
+    // 容器可能被重建（无 left/top/transform 内联样式）：失效脏检查缓存，
+    // 否则模型位置与上次相同时首帧写入被跳过，工具栏停在默认位置
+    this._floatingButtonsLastTransform = undefined;
+    this._floatingButtonsLastLeft = undefined;
+    this._floatingButtonsLastTop = undefined;
 
     const opts = this._avatarButtonOptions;
 
@@ -649,12 +687,12 @@ Live2DManager.prototype.setupFloatingButtons = function(model) {
             const minScale = 0.5;
             const maxScale = 1.0;
             const rawScale = targetToolbarHeight / baseToolbarHeight;
-            const scale = Math.max(minScale, Math.min(maxScale, rawScale));
+            // scale 量化到千分位，避免呼吸抖动击穿 transform 脏检查
+            const scale = Math.round(Math.max(minScale, Math.min(maxScale, rawScale)) * 1000) / 1000;
             const rotation = Number(this._floatingButtonsRotationRadians) || 0;
             const rotateTransform = rotation ? ` rotate(${rotation}rad)` : '';
 
-            buttonsContainer.style.transformOrigin = 'left top';
-            buttonsContainer.style.transform = `scale(${scale})${rotateTransform}`;
+            const nextTransform = `scale(${scale})${rotateTransform}`;
 
             const targetX = bounds.right * 0.8 + bounds.left * 0.2;
 
@@ -665,13 +703,25 @@ Live2DManager.prototype.setupFloatingButtons = function(model) {
 
             const minY = 20;
             const maxY = screenHeight - actualToolbarHeight - 20;
-            const boundedY = Math.max(minY, Math.min(targetY, maxY));
+            const boundedY = Math.round(Math.max(minY, Math.min(targetY, maxY)));
 
             const maxX = screenWidth - actualToolbarWidth;
-            const boundedX = Math.max(0, Math.min(targetX, maxX));
+            // 量化到整像素：呼吸动画让 bounds 亚像素级抖动，不量化的话脏检查
+            // 每帧都会被无意义的浮点尾差击穿（工具栏定位不需要亚像素精度）
+            const boundedX = Math.round(Math.max(0, Math.min(targetX, maxX)));
 
-            buttonsContainer.style.left = `${boundedX}px`;
-            buttonsContainer.style.top = `${boundedY}px`;
+            // 模型静止时位置/缩放不变，跳过 style 写入避免每帧样式失效
+            if (nextTransform !== this._floatingButtonsLastTransform ||
+                boundedX !== this._floatingButtonsLastLeft ||
+                boundedY !== this._floatingButtonsLastTop) {
+                this._floatingButtonsLastTransform = nextTransform;
+                this._floatingButtonsLastLeft = boundedX;
+                this._floatingButtonsLastTop = boundedY;
+                buttonsContainer.style.transformOrigin = 'left top';
+                buttonsContainer.style.transform = nextTransform;
+                buttonsContainer.style.left = `${boundedX}px`;
+                buttonsContainer.style.top = `${boundedY}px`;
+            }
         } catch (_) {}
     };
     this._floatingButtonsTicker = tick;

--- a/static/mmd/mmd-core.js
+++ b/static/mmd/mmd-core.js
@@ -3,6 +3,14 @@
  * 基于 @moeru/three-mmd 框架，参考 hime-display MmdManager 和 vrm-core.js 结构
  */
 
+// 空闲低频 tick 模式常量（对齐 live2d-core.js 的同名机制）：
+// 无活动时把 rAF 驱动的渲染链切到 setInterval，避免 120Hz 屏上 rAF 请求
+// 让 Blink 以显示器刷新率空跑主帧生命周期。物理安全性：Bullet 以固定 1/60
+// 子步积分（motion-state 插值余量），33ms 步长等价于已上线的 low 档路径。
+const MMD_IDLE_FPS = 30;
+const MMD_INTERACTIVE_FPS_HOLD_MS = 900;
+const MMD_IDLE_GOVERNOR_INTERVAL_MS = 300;
+
 class MMDCore {
     constructor(manager) {
         this.manager = manager;
@@ -938,10 +946,131 @@ class MMDCore {
     // ═══════════════════ 渲染循环 ═══════════════════
 
     _startRenderLoop() {
+        // 退出空闲低频模式但不让它复跑 rAF（下面自建新链），避免双驱动
+        this._exitIdleTickMode(false);
         if (this.manager._animationFrameId) {
             cancelAnimationFrame(this.manager._animationFrameId);
         }
         this._render();
+        this._startIdleGovernor();
+    }
+
+    // ═══════════════════ 空闲低频 tick 模式（对齐 live2d-core.js round-1 模式）═══════════════════
+
+    _enterIdleTickMode() {
+        if (this._idleTickMode) return;
+        const manager = this.manager;
+        if (!manager || !manager._shouldRender || manager._isDisposed || !manager.renderer) return;
+        this._idleTickMode = true;
+        if (manager._animationFrameId) {
+            cancelAnimationFrame(manager._animationFrameId);
+            manager._animationFrameId = null;
+        }
+        const idleFps = Math.min(MMD_IDLE_FPS, this.targetFPS || MMD_IDLE_FPS);
+        const intervalMs = Math.max(16, Math.round(1000 / Math.max(1, idleFps)));
+        this._idleTickTimer = setInterval(() => {
+            if (!this._idleTickMode) return;
+            const m = this.manager;
+            if (!m || !m._shouldRender || m._isDisposed || !m.renderer) { this._exitIdleTickMode(false); return; }
+            // 外部代码绕过 _startRenderLoop 直接拉起了 rAF 链：让位
+            if (m._animationFrameId) { this._exitIdleTickMode(false); return; }
+            // 纯浏览器隐藏标签页对齐 rAF 暂停语义（Electron 宠物窗关了节流，不受影响）
+            if (typeof document !== 'undefined' && document.hidden) return;
+            try {
+                this._renderFrame(performance.now());
+            } catch (e) {
+                if (!this._idleTickErrorLogged) {
+                    this._idleTickErrorLogged = true;
+                    console.warn('[MMD Core] 空闲低频 tick 渲染异常（同类后续不再打印）:', e);
+                }
+            }
+        }, intervalMs);
+    }
+
+    _exitIdleTickMode(restartRaf = true) {
+        if (!this._idleTickMode) return;
+        this._idleTickMode = false;
+        if (this._idleTickTimer) {
+            clearInterval(this._idleTickTimer);
+            this._idleTickTimer = null;
+        }
+        const manager = this.manager;
+        if (restartRaf && manager && manager._shouldRender && !manager._isDisposed && !manager._animationFrameId) {
+            this.lastFrameTime = 0;
+            manager._animationFrameId = requestAnimationFrame(() => this._render());
+        }
+    }
+
+    // 有交互/活动时升回 rAF 满帧，并安排在 durationMs 后无活动则回落空闲模式
+    _boostInteractiveFPS(durationMs = MMD_INTERACTIVE_FPS_HOLD_MS) {
+        this._exitIdleTickMode();
+        if (this._idleDecayTimer) clearTimeout(this._idleDecayTimer);
+        this._idleDecayTimer = setTimeout(() => {
+            this._idleDecayTimer = null;
+            const m = this.manager;
+            if (m && m._shouldRender && !m._isDisposed && !this._hasRenderActivity()) {
+                this._enterIdleTickMode();
+            }
+        }, Math.max(100, Number(durationMs) || MMD_INTERACTIVE_FPS_HOLD_MS));
+    }
+
+    // 需要满帧的活动：非 idle 动画播放、口型同步、拖拽、光标跟踪进行中、滚轮缩放余温
+    _hasRenderActivity() {
+        const m = this.manager;
+        if (!m) return false;
+        try {
+            if (m.animationModule && m.animationModule.isPlaying && m._currentAnimationMode !== 'idle') return true;
+        } catch (_) {}
+        try { if (m.animationModule && m.animationModule._lipSyncActive) return true; } catch (_) {}
+        try { if (window.appState && window.appState.lipSyncActive) return true; } catch (_) {}
+        try { if (m.interaction && m.interaction.isDragging) return true; } catch (_) {}
+        try {
+            const cf = m.cursorFollow;
+            if (cf && cf.enabled) {
+                if (cf._lastPointerMoveTs && (performance.now() - cf._lastPointerMoveTs) < MMD_INTERACTIVE_FPS_HOLD_MS) return true;
+                // 头部朝向还没收敛完：保持满帧到位
+                if (Math.abs((cf._targetYaw || 0) - (cf._currentYaw || 0)) > 0.02 ||
+                    Math.abs((cf._targetPitch || 0) - (cf._currentPitch || 0)) > 0.02) return true;
+            }
+        } catch (_) {}
+        try {
+            if (m._lastInteractionBoostTs && (performance.now() - m._lastInteractionBoostTs) < MMD_INTERACTIVE_FPS_HOLD_MS) return true;
+        } catch (_) {}
+        return false;
+    }
+
+    _startIdleGovernor() {
+        this._stopIdleGovernor();
+        // 页面级豁免：小游戏 demo 等用自有 rAF 循环驱动骨骼姿态的页面，
+        // 活动探测看不见它们的动画，节流会造成可见卡顿——由页面声明退出
+        if (window.__NEKO_DISABLE_AVATAR_IDLE_THROTTLE__ === true) return;
+        // 启动/加载视为活动：先满帧，随后自动衰减
+        this._boostInteractiveFPS();
+        this._idleGovernorTimer = setInterval(() => {
+            const m = this.manager;
+            // 自终止：dispose / renderer 销毁后自动停摆并释放闭包引用
+            if (!m || m._isDisposed || !m.renderer) { this._stopIdleGovernor(); return; }
+            // 外部暂停（pauseRendering）：不接管；resume 走 _startRenderLoop 会重启本 governor
+            if (!m._shouldRender) return;
+            if (this._hasRenderActivity()) {
+                this._boostInteractiveFPS();
+            } else if (!this._idleTickMode && !this._idleDecayTimer) {
+                // 自愈：外部直接重启 rAF 链（resumeRendering 等）后无人再带我们回空闲模式
+                this._enterIdleTickMode();
+            }
+        }, MMD_IDLE_GOVERNOR_INTERVAL_MS);
+    }
+
+    _stopIdleGovernor() {
+        if (this._idleGovernorTimer) {
+            clearInterval(this._idleGovernorTimer);
+            this._idleGovernorTimer = null;
+        }
+        if (this._idleDecayTimer) {
+            clearTimeout(this._idleDecayTimer);
+            this._idleDecayTimer = null;
+        }
+        this._exitIdleTickMode(false);
     }
 
     _flushRenderWaiters() {
@@ -983,12 +1112,17 @@ class MMDCore {
 
         this.manager._animationFrameId = requestAnimationFrame(() => this._render());
 
-        // 帧率限制
+        // 帧率限制（仅 rAF 驱动路径；空闲低频模式下 interval 周期本身就是节流器，
+        // 由 interval 直接调用 _renderFrame，不经过这里）
         const now = performance.now();
         const elapsed = now - this.lastFrameTime;
         if (elapsed < this.frameTime) return;
         this.lastFrameTime = now - (elapsed % this.frameTime);
 
+        this._renderFrame(now);
+    }
+
+    _renderFrame(_now) {
         const delta = this.manager.clock ? this.manager.clock.getDelta() : 0;
         // 限制 delta 以防止长时间切页后的突变
         const clampedDelta = Math.min(delta, 0.1);
@@ -1436,6 +1570,8 @@ class MMDCore {
     // ═══════════════════ 资源清理 ═══════════════════
 
     dispose() {
+        // 先停 governor（内部一并清衰减计时器并退出空闲低频模式，不复跑）
+        this._stopIdleGovernor();
         this.manager._shouldRender = false;
 
         if (this.manager._animationFrameId) {

--- a/static/mmd/mmd-core.js
+++ b/static/mmd/mmd-core.js
@@ -1005,6 +1005,11 @@ class MMDCore {
     _boostInteractiveFPS(durationMs = MMD_INTERACTIVE_FPS_HOLD_MS) {
         this._exitIdleTickMode();
         if (this._idleDecayTimer) clearTimeout(this._idleDecayTimer);
+        // 豁免页：只升频、不安排衰减——衰减会在 governor 缺席时把渲染拖回空闲模式
+        if (window.__NEKO_DISABLE_AVATAR_IDLE_THROTTLE__ === true) {
+            this._idleDecayTimer = null;
+            return;
+        }
         this._idleDecayTimer = setTimeout(() => {
             this._idleDecayTimer = null;
             const m = this.manager;

--- a/static/mmd/mmd-cursor-follow.js
+++ b/static/mmd/mmd-cursor-follow.js
@@ -190,6 +190,8 @@ class MMDCursorFollow {
     _setupEventListeners() {
         this._pointerMoveHandler = (e) => {
             const now = performance.now();
+            // 供 mmd-core 空闲低频 governor 判定"光标最近在动"（活动 → 满帧）
+            this._lastPointerMoveTs = now;
             // 去重：pointermove 后常跟随合成 mousemove（Electron 透明窗口）
             if (e.type === 'mousemove' && now < this._ignoreMouseMoveUntil) return;
             if (e.type === 'pointermove') {

--- a/static/mmd/mmd-interaction.js
+++ b/static/mmd/mmd-interaction.js
@@ -363,6 +363,10 @@ class MMDInteraction {
 
                 this.isDragging = true;
                 this.dragMode = 'pan';
+                // 同步升频：不等 300ms governor 轮询，消除拖拽起步的 30fps 顿挫
+                if (this.manager.core && typeof this.manager.core._boostInteractiveFPS === 'function') {
+                    this.manager.core._boostInteractiveFPS();
+                }
                 this.previousMousePosition = { x: e.clientX, y: e.clientY };
                 this._rememberPanDragPointer(e, { captureOffset: true });
                 this._rememberDragHintPanPointer(e, { start: true });
@@ -375,6 +379,9 @@ class MMDInteraction {
                 if (!this._hitTestModel(e.clientX, e.clientY)) return;
                 this.isDragging = true;
                 this.dragMode = 'orbit';
+                if (this.manager.core && typeof this.manager.core._boostInteractiveFPS === 'function') {
+                    this.manager.core._boostInteractiveFPS();
+                }
                 this.previousMousePosition = { x: e.clientX, y: e.clientY };
                 canvas.style.cursor = 'crosshair';
                 e.preventDefault();
@@ -528,6 +535,13 @@ class MMDInteraction {
 
             // 只有鼠标在模型上才响应滚轮
             if (!this._hitTestModel(e.clientX, e.clientY)) return;
+
+            // 真正命中模型的缩放才升频：同步 boost（不等 300ms governor 轮询）
+            // 消除从空闲地板起步的首段 30fps 顿挫；时间戳供 governor 续期
+            this.manager._lastInteractionBoostTs = performance.now();
+            if (this.manager.core && typeof this.manager.core._boostInteractiveFPS === 'function') {
+                this.manager.core._boostInteractiveFPS();
+            }
 
             e.preventDefault();
             const scaleFactor = e.deltaY > 0 ? 0.95 : 1.05;

--- a/static/mmd/mmd-manager.js
+++ b/static/mmd/mmd-manager.js
@@ -254,11 +254,17 @@ class MMDManager {
      * @param {'idle'|'dance'} mode - 动画模式，影响视线跟踪权重
      */
     playAnimation(mode = 'idle') {
+        // 供空闲低频 governor 判定：idle 循环动画按 Live2D 先例以地板帧率渲染，
+        // 只有非 idle 播放（dance 等）才算需要满帧的活动
+        this._currentAnimationMode = mode;
         if (this.cursorFollow) {
             this.cursorFollow.setAnimationMode(mode);
         }
         if (this.animationModule) {
             this.animationModule.play();
+        }
+        if (mode !== 'idle' && this.core && typeof this.core._boostInteractiveFPS === 'function') {
+            this.core._boostInteractiveFPS();
         }
     }
 
@@ -269,6 +275,7 @@ class MMDManager {
     }
 
     stopAnimation() {
+        this._currentAnimationMode = null;
         if (this.animationModule) {
             this.animationModule.stop();
         }
@@ -440,6 +447,11 @@ class MMDManager {
 
     pauseRendering() {
         this._shouldRender = false;
+        // 空闲低频模式下 _animationFrameId 为 null（interval 驱动），
+        // 必须显式退出该模式（不复跑），否则暂停对 interval 无效
+        if (this.core && typeof this.core._exitIdleTickMode === 'function') {
+            this.core._exitIdleTickMode(false);
+        }
         if (this._animationFrameId) {
             cancelAnimationFrame(this._animationFrameId);
             this._animationFrameId = null;

--- a/static/mmd/mmd-ui-buttons.js
+++ b/static/mmd/mmd-ui-buttons.js
@@ -581,23 +581,40 @@ MMDManager.prototype._startUIUpdateLoop = function() {
     this._mmdCtrlKeyUpListener = onKeyUp;
     this._mmdWindowBlurListener = onBlur;
 
+    // 空闲低频模式下改用 ~33ms 定时器转一次性 rAF：一次性 rAF 不形成连续
+    // vsync 链，Blink 主帧调度随渲染循环一起降到地板频率。否则本循环单独
+    // 就能把 BeginMainFrame 顶回显示器刷新率，渲染侧的空闲化收益归零。
+    const scheduleNext = () => {
+        if (this._uiUpdateLoopId === null || this._uiUpdateLoopId === undefined) return;
+        if (this.core && this.core._idleTickMode) {
+            if (this._uiLoopIdleTimeout) clearTimeout(this._uiLoopIdleTimeout);
+            this._uiLoopIdleTimeout = setTimeout(() => {
+                this._uiLoopIdleTimeout = null;
+                if (this._uiUpdateLoopId === null || this._uiUpdateLoopId === undefined) return;
+                this._uiUpdateLoopId = requestAnimationFrame(update);
+            }, 33);
+            return;
+        }
+        this._uiUpdateLoopId = requestAnimationFrame(update);
+    };
+
     const update = () => {
         if (this._uiUpdateLoopId === null || this._uiUpdateLoopId === undefined) return;
 
         if (!this.currentModel || !this.currentModel.mesh) {
-            if (this._uiUpdateLoopId !== null && this._uiUpdateLoopId !== undefined) this._uiUpdateLoopId = requestAnimationFrame(update);
+            scheduleNext();
             return;
         }
 
         if (this._isInReturnState) {
-            if (this._uiUpdateLoopId !== null && this._uiUpdateLoopId !== undefined) this._uiUpdateLoopId = requestAnimationFrame(update);
+            scheduleNext();
             return;
         }
 
         if (window.isMobileWidth && window.isMobileWidth()) {
             const now = performance.now();
             if (now - lastMobileUpdate < MOBILE_UPDATE_INTERVAL) {
-                if (this._uiUpdateLoopId !== null && this._uiUpdateLoopId !== undefined) this._uiUpdateLoopId = requestAnimationFrame(update);
+                scheduleNext();
                 return;
             }
             lastMobileUpdate = now;
@@ -607,7 +624,7 @@ MMDManager.prototype._startUIUpdateLoop = function() {
         const lockIcon = this._mmdLockIcon;
 
         if (!this.camera || !this.renderer) {
-            if (this._uiUpdateLoopId !== null && this._uiUpdateLoopId !== undefined) this._uiUpdateLoopId = requestAnimationFrame(update);
+            scheduleNext();
             return;
         }
 
@@ -633,9 +650,7 @@ MMDManager.prototype._startUIUpdateLoop = function() {
                         lockIcon.style.opacity = '0';
                     }
                 }
-                if (this._uiUpdateLoopId !== null && this._uiUpdateLoopId !== undefined) {
-                    this._uiUpdateLoopId = requestAnimationFrame(update);
-                }
+                scheduleNext();
                 return;
             }
 
@@ -874,14 +889,18 @@ MMDManager.prototype._startUIUpdateLoop = function() {
             if (window.DEBUG_MODE) console.debug('[MMD UI] 更新循环单帧异常:', error);
         }
 
-        if (this._uiUpdateLoopId !== null && this._uiUpdateLoopId !== undefined) {
-            this._uiUpdateLoopId = requestAnimationFrame(update);
-        }
+        scheduleNext();
     };
 
     this._updateFloatingButtonsPositionNow = () => {
         if (this._uiUpdateLoopId === null || this._uiUpdateLoopId === undefined) return;
         cancelAnimationFrame(this._uiUpdateLoopId);
+        // 同步 flush 前清掉空闲模式的 pending 再入定时器，防止 update() 内的
+        // scheduleNext 与旧定时器分叉出两条更新链
+        if (this._uiLoopIdleTimeout) {
+            clearTimeout(this._uiLoopIdleTimeout);
+            this._uiLoopIdleTimeout = null;
+        }
         this._uiUpdateLoopId = 0;
         update();
     };

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -1311,6 +1311,8 @@
         // rAF 请求把 Blink 主帧调度顶到显示器刷新率——live2d round-2 同款策略）。
         _layeredAnimationNeedsFullRate(timestamp) {
             try {
+                // 页面级豁免（demo/模型管理器等）：与 VRM/MMD governor 的豁免对齐
+                if (window.__NEKO_DISABLE_AVATAR_IDLE_THROTTLE__ === true) return true;
                 if (this._dragState || this._touchZoomState) return true;
                 if (this.isSpeaking || this.lipSyncFrame || this.talkingHopFrame || this.speakingBounceFrame) return true;
                 if ((this.state || 'idle') !== 'idle') return true;
@@ -1416,6 +1418,8 @@
             // 视觉与满帧 rAF 无差，且不会让 Blink 以显示器刷新率空跑主帧。
             // 拖拽/说话等高频视觉各自的路径会直接调 applyTransform，不依赖本循环。
             const breathingIntervalMs = Math.round(1000 / PNGTUBER_BREATHING_IDLE_FPS);
+            // 页面级豁免（demo/模型管理器等）：保持原 rAF 满帧驱动
+            const breathingUsesTimer = window.__NEKO_DISABLE_AVATAR_IDLE_THROTTLE__ !== true;
             const tick = (timestamp) => {
                 if (!this.layeredBreathingEnabled() || !this.container || this.container.style.display === 'none') {
                     this.stopLayeredBreathingLoop();
@@ -1427,10 +1431,19 @@
                     this.applyAnimationTransform(timestamp);
                     this.updateOverlayPositionsForAnimation(timestamp);
                 }
-                this.layeredBreathingFrame = setTimeout(() => tick(performance.now()), breathingIntervalMs);
+                if (breathingUsesTimer) {
+                    this.layeredBreathingFrame = setTimeout(() => tick(performance.now()), breathingIntervalMs);
+                } else {
+                    this.layeredBreathingFrame = requestAnimationFrame(tick);
+                }
             };
-            this._layeredBreathingDriveMode = 'timer';
-            this.layeredBreathingFrame = setTimeout(() => tick(performance.now()), breathingIntervalMs);
+            if (breathingUsesTimer) {
+                this._layeredBreathingDriveMode = 'timer';
+                this.layeredBreathingFrame = setTimeout(() => tick(performance.now()), breathingIntervalMs);
+            } else {
+                this._layeredBreathingDriveMode = 'raf';
+                this.layeredBreathingFrame = requestAnimationFrame(tick);
+            }
         }
 
         stopLayeredBreathingLoop() {

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -25,6 +25,12 @@
     const REMIX_LAYERED_CANVAS_PADDING_MAX = 160;
     const REMIX_MESH_DEFORM_STRENGTH = 0.28;
     const PNGTUBER_PLUS_VISIBLE_VALUES = new Set([0, 10, 20, 30, 1, 21, 12, 32, 3, 13, 4, 15, 26, 36, 27, 38]);
+    // 空闲低频驱动（对齐 live2d-core.js round-2 模式）：呼吸是 0.32Hz 正弦、
+    // 峰值速度 ~2.6px/s，20fps 与满帧视觉无差；动画循环空闲态压到 30fps
+    // （弹簧物理 dt 33ms 在各处 0.05s clamp 之内），活动时仍走 rAF 满帧。
+    const PNGTUBER_BREATHING_IDLE_FPS = 20;
+    const PNGTUBER_ANIMATION_IDLE_FPS = 30;
+    const PNGTUBER_FULL_RATE_HOLD_MS = 900;
 
     function clampNumber(value, min, max, fallback) {
         const parsed = Number(value);
@@ -432,9 +438,14 @@
 
         stopLayeredAnimationLoop() {
             if (this.layeredAnimationFrame) {
-                cancelAnimationFrame(this.layeredAnimationFrame);
+                if (this._layeredAnimationDriveMode === 'timer') {
+                    clearTimeout(this.layeredAnimationFrame);
+                } else {
+                    cancelAnimationFrame(this.layeredAnimationFrame);
+                }
                 this.layeredAnimationFrame = null;
             }
+            this._layeredAnimationDriveMode = null;
         }
 
         attachLayeredHotkeys() {
@@ -566,6 +577,8 @@
                 this.layeredStateReturnTimer = null;
             }
             this.layeredStateIndex = nextIndex;
+            // 状态切换后的 900ms 满帧余温：切换过渡（贴图换装/弹跳）以 rAF 满帧渲染
+            this._layeredFullRateHoldUntil = performance.now() + PNGTUBER_FULL_RATE_HOLD_MS;
             this.drawLayeredState();
             this.restartLayeredAnimationLoop();
             if ((options.source === 'hotkey' || options.source === 'alt-one-cycle-hotkey')
@@ -1276,10 +1289,54 @@
             });
         }
 
+        // 当前状态是否有"有效帧率超过空闲地板"的贴图动画：
+        // sheet 帧率 = animation_speed × REMIX_FRAME_SPEED_MULTIPLIER，
+        // 超过 PNGTUBER_ANIMATION_IDLE_FPS 时 30fps 采样会持续丢帧，需保持 rAF。
+        _layeredStateHasFastSheetAnimation(stateName = this.state || 'idle') {
+            if (!this.layeredRuntimeFeatureEnabled('sprite_sheet_animation')) return false;
+            const layers = Array.isArray(this.layeredMetadata && this.layeredMetadata.layers)
+                ? this.layeredMetadata.layers : [];
+            return layers.some((layer) => {
+                if (!this.shouldRenderLayer(layer, stateName)) return false;
+                const layerState = this.layerStateForRender(layer, stateName);
+                if (!layerState || !this.stateHasFrameAnimation(layerState)) return false;
+                const speed = Math.max(0, Number(layerState.animation_speed) || 0);
+                return speed * REMIX_FRAME_SPEED_MULTIPLIER > PNGTUBER_ANIMATION_IDLE_FPS;
+            });
+        }
+
+        // 动画循环是否需要 rAF 满帧：拖拽/触摸缩放、说话相关帧、非 idle 状态、
+        // 指针/物理仍需逐帧、弹簧未静定、高速贴图动画、或换装/拖拽释放后的
+        // 满帧余温。否则以 PNGTUBER_ANIMATION_IDLE_FPS 定时器低频驱动（避免
+        // rAF 请求把 Blink 主帧调度顶到显示器刷新率——live2d round-2 同款策略）。
+        _layeredAnimationNeedsFullRate(timestamp) {
+            try {
+                if (this._dragState || this._touchZoomState) return true;
+                if (this.isSpeaking || this.lipSyncFrame || this.talkingHopFrame || this.speakingBounceFrame) return true;
+                if ((this.state || 'idle') !== 'idle') return true;
+                if (typeof this.layeredPointerNeedsFrame === 'function' && this.layeredPointerNeedsFrame(timestamp)) return true;
+                if (typeof this.layeredPhysicsNeedsFrame === 'function' && this.layeredPhysicsNeedsFrame(timestamp)) return true;
+                const motion = this.remixModelMotionState;
+                if (motion && (Math.abs(motion.x || 0) > 0.02 || Math.abs(motion.y || 0) > 0.02 || Math.abs(motion.yVel || 0) > 1)) return true;
+                if (this._layeredFullRateHoldUntil && timestamp < this._layeredFullRateHoldUntil) return true;
+                if (this._layeredStateHasFastSheetAnimation()) return true;
+            } catch (_) { return true; }
+            return false;
+        }
+
         startLayeredAnimationLoop(options = {}) {
             if (this._renderingPaused) return;
             this.startLayeredBreathingLoop();
-            if (this.layeredAnimationFrame) return;
+            if (this.layeredAnimationFrame) {
+                // 已在低频定时器驱动中且此刻需要满帧：立即升频，不等下一拍
+                if (this._layeredAnimationDriveMode === 'timer' && this._layeredAnimationTick &&
+                    this._layeredAnimationNeedsFullRate(performance.now())) {
+                    clearTimeout(this.layeredAnimationFrame);
+                    this._layeredAnimationDriveMode = 'raf';
+                    this.layeredAnimationFrame = requestAnimationFrame(this._layeredAnimationTick);
+                }
+                return;
+            }
             if (!this.isLayeredActive() || !this.hasMotionLayersForCurrentState()) return;
             if (!options.preserveTimeline || !this.layeredAnimationStart) {
                 this.layeredAnimationStart = performance.now();
@@ -1289,13 +1346,28 @@
                     this.stopLayeredAnimationLoop();
                     return;
                 }
-                this.drawLayeredState(this.state || 'idle', timestamp);
+                // 隐藏标签页跳过 canvas 绘制但保持链条（timer 驱动路径专用；
+                // rAF 路径在隐藏标签页本身就会被浏览器暂停）
+                if (!(typeof document !== 'undefined' && document.hidden)) {
+                    this.drawLayeredState(this.state || 'idle', timestamp);
+                }
                 if (!this.hasMotionLayersForCurrentState()) {
                     this.stopLayeredAnimationLoop();
                     return;
                 }
-                this.layeredAnimationFrame = requestAnimationFrame(tick);
+                if (this._layeredAnimationNeedsFullRate(timestamp)) {
+                    this._layeredAnimationDriveMode = 'raf';
+                    this.layeredAnimationFrame = requestAnimationFrame(tick);
+                } else {
+                    this._layeredAnimationDriveMode = 'timer';
+                    this.layeredAnimationFrame = setTimeout(
+                        () => tick(performance.now()),
+                        Math.round(1000 / PNGTUBER_ANIMATION_IDLE_FPS)
+                    );
+                }
             };
+            this._layeredAnimationTick = tick;
+            this._layeredAnimationDriveMode = 'raf';
             this.layeredAnimationFrame = requestAnimationFrame(tick);
         }
 
@@ -1340,23 +1412,37 @@
             if (this._renderingPaused) return;
             if (this.layeredBreathingFrame || !this.layeredBreathingEnabled()) return;
             this.layeredBreathingStart = this.layeredBreathingStart || performance.now();
+            // 呼吸是 0.32Hz 正弦（峰值速度 ~2.6px/s），全程用 20fps 定时器驱动即可：
+            // 视觉与满帧 rAF 无差，且不会让 Blink 以显示器刷新率空跑主帧。
+            // 拖拽/说话等高频视觉各自的路径会直接调 applyTransform，不依赖本循环。
+            const breathingIntervalMs = Math.round(1000 / PNGTUBER_BREATHING_IDLE_FPS);
             const tick = (timestamp) => {
                 if (!this.layeredBreathingEnabled() || !this.container || this.container.style.display === 'none') {
                     this.stopLayeredBreathingLoop();
                     return;
                 }
-                this.applyAnimationTransform(timestamp);
-                this.updateOverlayPositionsForAnimation(timestamp);
-                this.layeredBreathingFrame = requestAnimationFrame(tick);
+                // 纯浏览器隐藏标签页跳过绘制但保持链条（rAF 暂停语义的近似；
+                // Electron 宠物窗禁用了节流，不受影响）
+                if (!(typeof document !== 'undefined' && document.hidden)) {
+                    this.applyAnimationTransform(timestamp);
+                    this.updateOverlayPositionsForAnimation(timestamp);
+                }
+                this.layeredBreathingFrame = setTimeout(() => tick(performance.now()), breathingIntervalMs);
             };
-            this.layeredBreathingFrame = requestAnimationFrame(tick);
+            this._layeredBreathingDriveMode = 'timer';
+            this.layeredBreathingFrame = setTimeout(() => tick(performance.now()), breathingIntervalMs);
         }
 
         stopLayeredBreathingLoop() {
             if (this.layeredBreathingFrame) {
-                cancelAnimationFrame(this.layeredBreathingFrame);
+                if (this._layeredBreathingDriveMode === 'timer') {
+                    clearTimeout(this.layeredBreathingFrame);
+                } else {
+                    cancelAnimationFrame(this.layeredBreathingFrame);
+                }
                 this.layeredBreathingFrame = null;
             }
+            this._layeredBreathingDriveMode = null;
             this.layeredBreathingStart = 0;
         }
 
@@ -2561,6 +2647,9 @@
             const state = this._dragState;
             if (!state || (state.pointerId !== undefined && event.pointerId !== state.pointerId)) return;
             this._dragState = null;
+            // 拖拽释放后的物理回摆窗口保持满帧：Plus 模型物理状态的内部字段
+            // （draggerX/Y）不走 remix 形状探测，用时间窗兜底两种物理形态
+            this._layeredFullRateHoldUntil = performance.now() + 2000;
             this.resetLayeredDragVelocity();
             if (this.image && typeof this.image.releasePointerCapture === 'function') {
                 try { this.image.releasePointerCapture(event.pointerId); } catch (_) {}
@@ -3158,6 +3247,8 @@
 
         startCostumeChangeHopAnimation() {
             if (this.talkingHopFrame || !this.isLayeredActive()) return;
+            // 弹跳期间保持动画循环满帧
+            this._layeredFullRateHoldUntil = performance.now() + PNGTUBER_FULL_RATE_HOLD_MS;
             this.talkingHopStart = performance.now();
             this.talkingHopAmplitude = 4.5;
             this.talkingHopPeriodMs = 260;

--- a/static/vrm/vrm-core.js
+++ b/static/vrm/vrm-core.js
@@ -594,6 +594,11 @@ class VRMCore {
             this.manager.controls.target.set(0, 1, 0);
             this.manager.controls.enableDamping = true;
             this.manager.controls.dampingFactor = 0.1;
+            // OrbitControls 只在 update() 真正移动了相机时才发 change 事件：
+            // 打时间戳供空闲低频 governor 判定（覆盖拖拽平移 + 阻尼收敛期）
+            this.manager.controls.addEventListener('change', () => {
+                this.manager._lastCameraChangeAt = performance.now();
+            });
             this.manager.controls.update();
         }
 

--- a/static/vrm/vrm-interaction.js
+++ b/static/vrm/vrm-interaction.js
@@ -338,6 +338,8 @@ class VRMInteraction {
                 }
                 this.isDragging = true;
                 this.dragMode = 'pan';
+                // 同步升频：不等 300ms governor 轮询，消除拖拽起步的 30fps 顿挫
+                if (typeof this.manager._boostInteractiveFPS === 'function') this.manager._boostInteractiveFPS();
                 this.previousMousePosition = { x: e.clientX, y: e.clientY };
                 this._rememberPanDragPointer(e, { captureOffset: true });
                 this._rememberDragHintPanPointer(e, { start: true });
@@ -351,6 +353,7 @@ class VRMInteraction {
             } else if (e.button === 2) { // 右键 - 模型旋转
                 this.isDragging = true;
                 this.dragMode = 'orbit';
+                if (typeof this.manager._boostInteractiveFPS === 'function') this.manager._boostInteractiveFPS();
                 this.previousMousePosition = { x: e.clientX, y: e.clientY };
                 canvas.style.cursor = 'crosshair';
                 e.preventDefault();
@@ -573,6 +576,13 @@ class VRMInteraction {
 
             if (!this._hitTestModel(e.clientX, e.clientY)) {
                 return;
+            }
+
+            // 真正命中模型的缩放才升频：同步 boost（不等 300ms governor 轮询）
+            // 消除从空闲地板起步的首段 30fps 顿挫；时间戳供 governor 续期
+            this.manager._lastInteractionBoostTs = performance.now();
+            if (typeof this.manager._boostInteractiveFPS === 'function') {
+                this.manager._boostInteractiveFPS();
             }
 
             e.preventDefault();

--- a/static/vrm/vrm-manager.js
+++ b/static/vrm/vrm-manager.js
@@ -880,6 +880,11 @@ class VRMManager {
     _boostInteractiveFPS(durationMs = VRM_INTERACTIVE_FPS_HOLD_MS) {
         this._exitIdleTickMode();
         if (this._idleFpsRestoreTimer) clearTimeout(this._idleFpsRestoreTimer);
+        // 豁免页：只升频、不安排衰减——衰减会在 governor 缺席时把渲染拖回空闲模式
+        if (window.__NEKO_DISABLE_AVATAR_IDLE_THROTTLE__ === true) {
+            this._idleFpsRestoreTimer = null;
+            return;
+        }
         this._idleFpsRestoreTimer = setTimeout(() => {
             this._idleFpsRestoreTimer = null;
             if (this.renderer && this.scene && this.camera && !this._hasRenderActivity()) {

--- a/static/vrm/vrm-manager.js
+++ b/static/vrm/vrm-manager.js
@@ -1,6 +1,15 @@
 /**
  * VRM Manager - 物理控制版 (修复更新顺序)
  */
+
+// 空闲低频 tick 模式常量（对齐 live2d-core.js / mmd-core.js 的同名机制）：
+// 无活动时把 rAF 驱动的渲染链切到 setInterval，避免 120Hz 屏上 rAF 请求
+// 让 Blink 以显示器刷新率空跑主帧生命周期。弹簧骨物理用真实 elapsed dt，
+// 33ms 步长在 0.05s 防爆 clamp 之内，稳定性与 rAF 路径一致。
+const VRM_IDLE_FPS = 30;
+const VRM_INTERACTIVE_FPS_HOLD_MS = 900;
+const VRM_IDLE_FPS_GOVERNOR_INTERVAL_MS = 300;
+
 class VRMManager {
     constructor() {
         this.scene = null;
@@ -296,6 +305,8 @@ class VRMManager {
 
         if (!this._mouseMoveHandler) {
             this._mouseMoveHandler = (event) => {
+                // 供空闲低频 governor 判定"光标最近在动"（legacy 视线跟随路径）
+                this._lastLookAtPointerMoveAt = performance.now();
                 this._setLookAtTargetByMouse(event.clientX, event.clientY);
             };
             document.addEventListener('mousemove', this._mouseMoveHandler, { passive: true });
@@ -653,30 +664,14 @@ class VRMManager {
     }
 
     startAnimateLoop() {
+        // 先退出空闲低频 tick 模式（不复跑 rAF，下面自建新链），避免双驱动
+        this._exitIdleTickMode(false);
         if (this._animationFrameId) cancelAnimationFrame(this._animationFrameId);
         this._lastRenderTime = 0;
 
-        const animateLoop = () => {
-            // 检查渲染器、场景和相机是否都存在，如果任何一个被 dispose 了则取消动画循环
-            if (!this.renderer || !this.scene || !this.camera) {
-                if (this._animationFrameId) {
-                    cancelAnimationFrame(this._animationFrameId);
-                    this._animationFrameId = null;
-                }
-                return;
-            }
-
-            this._animationFrameId = requestAnimationFrame(animateLoop);
-
-            // 帧率限制：根据 targetFrameRate 跳帧（0 = 不限帧，跟随 VSync）
-            const now = performance.now();
-            const targetFps = typeof window.targetFrameRate === 'number' ? window.targetFrameRate : 60;
-            if (targetFps > 0) {
-                const frameInterval = 1000 / targetFps;
-                if (now - this._lastRenderTime < frameInterval * 0.9) return;
-            }
-            this._lastRenderTime = now;
-
+        // 帧体：rAF 驱动与空闲低频 interval 共用（interval 直接调用本函数，
+        // 定时器周期即节流器，不经过 rAF 驱动里的 targetFrameRate 跳帧）
+        const renderFrame = (frameNow) => {
             // 获取时间增量并限制最大值，防止切屏或卡顿导致物理"爆炸"
             let delta = this.clock ? this.clock.getDelta() : 0.016;
             delta = Math.min(delta, 0.05);
@@ -686,7 +681,9 @@ class VRMManager {
             if (this.currentModel && this.currentModel.vrm) {
                 // 0. 主灯跟随相机
                 if (this.mainLight && this.camera) {
-                    const lightOffset = new window.THREE.Vector3(0.2, 0.5, 1.5);
+                    // 复用 scratch 向量：本分支每渲染帧都会执行，避免逐帧 new Vector3
+                    if (!this._mainLightOffsetScratch) this._mainLightOffsetScratch = new window.THREE.Vector3();
+                    const lightOffset = this._mainLightOffsetScratch.set(0.2, 0.5, 1.5);
                     lightOffset.applyQuaternion(this.camera.quaternion);
                     this.mainLight.position.copy(this.camera.position).add(lightOffset);
 
@@ -740,7 +737,10 @@ class VRMManager {
                 // low: 仅 lookAt + expressions；medium: 隔帧物理；high: 每帧物理
                 const quality = window.renderQuality || 'medium';
                 if (this.enablePhysics && quality !== 'low') {
-                    if (quality === 'medium') {
+                    // 空闲低频模式下绕过 medium 的隔帧物理：30fps 地板上再隔帧会让
+                    // 弹簧骨物理退化到 15Hz/66.7ms 步长，超出 50ms 防爆 clamp 的设计
+                    // 意图且发丝/裙摆可见抖动；30Hz 全帧物理成本 ≈ medium@60 不变
+                    if (quality === 'medium' && !this._idleTickMode) {
                         this._physicsFrameSkip = (this._physicsFrameSkip || 0) + 1;
                         if (this._physicsFrameSkip % 2 === 0) {
                             this.currentModel.vrm.update(delta * 2);
@@ -797,8 +797,160 @@ class VRMManager {
                 this.renderer.render(this.scene, this.camera);
             }
         };
+        this._renderFrame = renderFrame;
+
+        const animateLoop = () => {
+            // 检查渲染器、场景和相机是否都存在，如果任何一个被 dispose 了则取消动画循环
+            if (!this.renderer || !this.scene || !this.camera) {
+                if (this._animationFrameId) {
+                    cancelAnimationFrame(this._animationFrameId);
+                    this._animationFrameId = null;
+                }
+                return;
+            }
+
+            this._animationFrameId = requestAnimationFrame(animateLoop);
+
+            // 帧率限制：根据 targetFrameRate 跳帧（0 = 不限帧，跟随 VSync）
+            const now = performance.now();
+            const targetFps = typeof window.targetFrameRate === 'number' ? window.targetFrameRate : 60;
+            if (targetFps > 0) {
+                const frameInterval = 1000 / targetFps;
+                if (now - this._lastRenderTime < frameInterval * 0.9) return;
+            }
+            this._lastRenderTime = now;
+            renderFrame(now);
+        };
+        this._rafDriver = animateLoop;
 
         this._animationFrameId = requestAnimationFrame(animateLoop);
+        this._startIdleFpsGovernor();
+    }
+
+    // ═══════ 空闲低频 tick 模式（对齐 live2d-core.js / mmd-core.js 的同名机制）═══════
+
+    _resolveIdleFps() {
+        const raw = typeof window.targetFrameRate === 'number' ? Number(window.targetFrameRate) : 60;
+        const configured = Number.isFinite(raw) ? raw : 60;
+        return configured === 0 ? VRM_IDLE_FPS : Math.min(VRM_IDLE_FPS, configured);
+    }
+
+    _enterIdleTickMode() {
+        if (this._idleTickMode) return;
+        if (!this.renderer || !this.scene || !this.camera) return;
+        // 外部已暂停（pauseRendering 后 rAF 链不存在）：不接管
+        if (!this._animationFrameId) return;
+        this._idleTickMode = true;
+        cancelAnimationFrame(this._animationFrameId);
+        this._animationFrameId = null;
+        const intervalMs = Math.max(16, Math.round(1000 / Math.max(1, this._resolveIdleFps())));
+        this._idleTickTimer = setInterval(() => {
+            if (!this._idleTickMode) return;
+            if (!this.renderer || !this.scene || !this.camera) { this._exitIdleTickMode(false); return; }
+            // 外部代码绕过 startAnimateLoop 拉起了 rAF 链：让位
+            if (this._animationFrameId) { this._exitIdleTickMode(false); return; }
+            // 纯浏览器隐藏标签页对齐 rAF 暂停语义（Electron 宠物窗关了节流，不受影响）
+            if (typeof document !== 'undefined' && document.hidden) return;
+            try {
+                if (this._renderFrame) this._renderFrame(performance.now());
+            } catch (e) {
+                if (!this._idleTickErrorLogged) {
+                    this._idleTickErrorLogged = true;
+                    console.warn('[VRM Manager] 空闲低频 tick 渲染异常（同类后续不再打印）:', e);
+                }
+            }
+        }, intervalMs);
+    }
+
+    _exitIdleTickMode(restartRaf = true) {
+        if (!this._idleTickMode) return;
+        this._idleTickMode = false;
+        if (this._idleTickTimer) {
+            clearInterval(this._idleTickTimer);
+            this._idleTickTimer = null;
+        }
+        if (restartRaf && this.renderer && this.scene && this.camera &&
+            !this._animationFrameId && this._rafDriver) {
+            this._lastRenderTime = 0;
+            this._animationFrameId = requestAnimationFrame(this._rafDriver);
+        }
+    }
+
+    // 有交互/活动时升回 rAF 满帧，并安排在 durationMs 后无活动则回落空闲低频
+    _boostInteractiveFPS(durationMs = VRM_INTERACTIVE_FPS_HOLD_MS) {
+        this._exitIdleTickMode();
+        if (this._idleFpsRestoreTimer) clearTimeout(this._idleFpsRestoreTimer);
+        this._idleFpsRestoreTimer = setTimeout(() => {
+            this._idleFpsRestoreTimer = null;
+            if (this.renderer && this.scene && this.camera && !this._hasRenderActivity()) {
+                this._enterIdleTickMode();
+            }
+        }, Math.max(100, Number(durationMs) || VRM_INTERACTIVE_FPS_HOLD_MS));
+    }
+
+    // 需要满帧的活动：口型同步、非 idle VRMA 播放、拖拽、光标跟踪余温、
+    // 相机变化余温（OrbitControls 阻尼收敛）、模型加载/入场阶段
+    _hasRenderActivity() {
+        try { if (this.animation && this.animation.lipSyncActive) return true; } catch (_) {}
+        try { if (window.appState && window.appState.lipSyncActive) return true; } catch (_) {}
+        try {
+            if (this.animation && this.animation.vrmaIsPlaying && !this.animation.isIdleAnimation) return true;
+        } catch (_) {}
+        try { if (this.interaction && this.interaction.isDragging) return true; } catch (_) {}
+        try {
+            const cf = this._cursorFollow;
+            if (cf && typeof cf.isEnabled === 'function' && cf.isEnabled() &&
+                cf._lastPointerMoveAt && (performance.now() - cf._lastPointerMoveAt) < VRM_INTERACTIVE_FPS_HOLD_MS) return true;
+        } catch (_) {}
+        try {
+            if (this._lastLookAtPointerMoveAt &&
+                (performance.now() - this._lastLookAtPointerMoveAt) < VRM_INTERACTIVE_FPS_HOLD_MS) return true;
+        } catch (_) {}
+        try {
+            if (this._lastCameraChangeAt &&
+                (performance.now() - this._lastCameraChangeAt) < VRM_INTERACTIVE_FPS_HOLD_MS) return true;
+        } catch (_) {}
+        try {
+            if (this._lastInteractionBoostTs &&
+                (performance.now() - this._lastInteractionBoostTs) < VRM_INTERACTIVE_FPS_HOLD_MS) return true;
+        } catch (_) {}
+        try {
+            if (this._loadState === 'preparing' || this._loadState === 'settling') return true;
+        } catch (_) {}
+        return false;
+    }
+
+    _startIdleFpsGovernor() {
+        this._stopIdleFpsGovernor();
+        // 页面级豁免：小游戏 demo 等用自有 rAF 循环驱动骨骼姿态的页面，
+        // 活动探测看不见它们的动画，节流会造成可见卡顿——由页面声明退出
+        if (window.__NEKO_DISABLE_AVATAR_IDLE_THROTTLE__ === true) return;
+        // 启动/加载视为活动：先满帧，随后自动衰减
+        this._boostInteractiveFPS();
+        this._idleFpsGovernorTimer = setInterval(() => {
+            // 自终止：dispose / 场景销毁后自动停摆并释放闭包引用
+            if (!this.renderer || !this.scene || !this.camera) { this._stopIdleFpsGovernor(); return; }
+            // 外部暂停（rAF 链与空闲模式都不存在）：不接管，resume 会重启 governor
+            if (!this._idleTickMode && !this._animationFrameId) return;
+            if (this._hasRenderActivity()) {
+                this._boostInteractiveFPS();
+            } else if (!this._idleTickMode && !this._idleFpsRestoreTimer) {
+                // 自愈：外部直接重启 rAF 链后无人再带我们回空闲模式
+                this._enterIdleTickMode();
+            }
+        }, VRM_IDLE_FPS_GOVERNOR_INTERVAL_MS);
+    }
+
+    _stopIdleFpsGovernor() {
+        if (this._idleFpsGovernorTimer) {
+            clearInterval(this._idleFpsGovernorTimer);
+            this._idleFpsGovernorTimer = null;
+        }
+        if (this._idleFpsRestoreTimer) {
+            clearTimeout(this._idleFpsRestoreTimer);
+            this._idleFpsRestoreTimer = null;
+        }
+        this._exitIdleTickMode(false);
     }
 
     toggleSpringBone(enable) {
@@ -981,10 +1133,20 @@ class VRMManager {
      * 暂停渲染循环（用于节省资源，例如进入模型管理界面时）
      */
     pauseRendering() {
+        // 空闲低频模式下 _animationFrameId 为 null（interval 驱动），必须显式
+        // 退出该模式（不复跑），否则暂停对 interval 无效、渲染继续
+        const wasIdleTicking = this._idleTickMode === true;
+        this._exitIdleTickMode(false);
+        if (this._idleFpsRestoreTimer) {
+            clearTimeout(this._idleFpsRestoreTimer);
+            this._idleFpsRestoreTimer = null;
+        }
         if (this._animationFrameId) {
             cancelAnimationFrame(this._animationFrameId);
             this._animationFrameId = null;
             console.log('[VRM Manager] 渲染循环已暂停');
+        } else if (wasIdleTicking) {
+            console.log('[VRM Manager] 渲染循环已暂停（自空闲低频模式）');
         }
     }
 
@@ -1011,7 +1173,14 @@ class VRMManager {
         const loadToken = ++this._activeLoadToken;
         this._loadState = 'preparing';
         this._isModelReadyForInteraction = false;
-        return this._loadModelInternal(modelUrl, options, loadToken);
+        // .catch 而非 await：本函数按竞态契约不得 await（见 static contract 测试），
+        // 失败路径必须复位加载态——_hasRenderActivity 把 preparing/settling 视为
+        // 活动，卡在 preparing 会让空闲 governor 永久 boost、本会话节流失效，
+        // 且加载前画布已置 opacity 0，旧场景会在不可见画布上满帧空转。
+        return this._loadModelInternal(modelUrl, options, loadToken).catch((e) => {
+            if (this._isLoadTokenActive(loadToken)) this._loadState = 'idle';
+            throw e;
+        });
     }
 
     /**
@@ -1450,16 +1619,23 @@ class VRMManager {
         this._loadState = 'idle';
         this._isModelReadyForInteraction = false;
 
-        // 1. 取消动画循环（最关键）
+        // 1. 取消动画循环（最关键）；先停 governor（一并清衰减计时器、
+        //    退出空闲低频模式且不复跑）
+        this._stopIdleFpsGovernor();
         if (this._animationFrameId) {
             cancelAnimationFrame(this._animationFrameId);
             this._animationFrameId = null;
         }
 
-        // 2. 清理 UI 更新循环
-        if (this._uiUpdateLoopId) {
+        // 2. 清理 UI 更新循环（!= null：兼容 _updateFloatingButtonsPositionNow
+        //    留下的 0 哨兵；一并清空闲低频模式的 pending 再入定时器）
+        if (this._uiUpdateLoopId != null) {
             cancelAnimationFrame(this._uiUpdateLoopId);
             this._uiUpdateLoopId = null;
+        }
+        if (this._uiLoopIdleTimeout) {
+            clearTimeout(this._uiLoopIdleTimeout);
+            this._uiLoopIdleTimeout = null;
         }
 
         // 3. 清理重试定时器（loadModel 中的 tryPlayAnimation 重试）

--- a/static/vrm/vrm-ui-buttons.js
+++ b/static/vrm/vrm-ui-buttons.js
@@ -533,29 +533,40 @@ VRMManager.prototype._startUIUpdateLoop = function() {
     let lastMobileUpdate = 0;
     const MOBILE_UPDATE_INTERVAL = 100;
 
+    // 空闲低频模式下改用 ~33ms 定时器转一次性 rAF：一次性 rAF 不形成连续
+    // vsync 链，Blink 主帧调度随渲染循环一起降到地板频率。否则本循环单独
+    // 就能把 BeginMainFrame 顶回显示器刷新率，渲染侧的空闲化收益归零。
+    const scheduleNext = () => {
+        if (this._uiUpdateLoopId === null || this._uiUpdateLoopId === undefined) return;
+        if (this._idleTickMode) {
+            if (this._uiLoopIdleTimeout) clearTimeout(this._uiLoopIdleTimeout);
+            this._uiLoopIdleTimeout = setTimeout(() => {
+                this._uiLoopIdleTimeout = null;
+                if (this._uiUpdateLoopId === null || this._uiUpdateLoopId === undefined) return;
+                this._uiUpdateLoopId = requestAnimationFrame(update);
+            }, 33);
+            return;
+        }
+        this._uiUpdateLoopId = requestAnimationFrame(update);
+    };
+
     const update = () => {
         if (this._uiUpdateLoopId === null || this._uiUpdateLoopId === undefined) return;
 
         if (!this.currentModel || !this.currentModel.scene) {
-            if (this._uiUpdateLoopId !== null && this._uiUpdateLoopId !== undefined) {
-                this._uiUpdateLoopId = requestAnimationFrame(update);
-            }
+            scheduleNext();
             return;
         }
 
         if (this._isInReturnState) {
-            if (this._uiUpdateLoopId !== null && this._uiUpdateLoopId !== undefined) {
-                this._uiUpdateLoopId = requestAnimationFrame(update);
-            }
+            scheduleNext();
             return;
         }
 
         if (window.isMobileWidth && window.isMobileWidth()) {
             const now = performance.now();
             if (now - lastMobileUpdate < MOBILE_UPDATE_INTERVAL) {
-                if (this._uiUpdateLoopId !== null && this._uiUpdateLoopId !== undefined) {
-                    this._uiUpdateLoopId = requestAnimationFrame(update);
-                }
+                scheduleNext();
                 return;
             }
             lastMobileUpdate = now;
@@ -565,9 +576,7 @@ VRMManager.prototype._startUIUpdateLoop = function() {
         const lockIcon = this._vrmLockIcon;
 
         if (!this.camera || !this.renderer) {
-            if (this._uiUpdateLoopId !== null && this._uiUpdateLoopId !== undefined) {
-                this._uiUpdateLoopId = requestAnimationFrame(update);
-            }
+            scheduleNext();
             return;
         }
 
@@ -593,9 +602,7 @@ VRMManager.prototype._startUIUpdateLoop = function() {
                         lockIcon.style.opacity = '0';
                     }
                 }
-                if (this._uiUpdateLoopId !== null && this._uiUpdateLoopId !== undefined) {
-                    this._uiUpdateLoopId = requestAnimationFrame(update);
-                }
+                scheduleNext();
                 return;
             }
 
@@ -763,14 +770,17 @@ VRMManager.prototype._startUIUpdateLoop = function() {
             if (window.DEBUG_MODE) console.debug('[VRM UI] 更新循环单帧异常:', error);
         }
 
-        if (this._uiUpdateLoopId !== null && this._uiUpdateLoopId !== undefined) {
-            this._uiUpdateLoopId = requestAnimationFrame(update);
-        }
+        scheduleNext();
     };
 
     this._updateFloatingButtonsPositionNow = () => {
         if (this._uiUpdateLoopId === null || this._uiUpdateLoopId === undefined) return;
         cancelAnimationFrame(this._uiUpdateLoopId);
+        // 同步 flush 前清掉空闲模式的 pending 再入定时器，防止分叉双链
+        if (this._uiLoopIdleTimeout) {
+            clearTimeout(this._uiLoopIdleTimeout);
+            this._uiLoopIdleTimeout = null;
+        }
         this._uiUpdateLoopId = 0;
         update();
     };

--- a/templates/badminton_demo.html
+++ b/templates/badminton_demo.html
@@ -9,6 +9,9 @@
 <link rel="preload" as="image" href="/static/game/games/badminton/images/player-ice-powerup.png?v={{ static_asset_version }}">
 <link rel="preload" as="image" href="/static/game/games/badminton/images/yui-frozen-crystals.png?v={{ static_asset_version }}">
 <title>羽毛球挑战 - Badminton</title>
+<!-- 小游戏页豁免 avatar 空闲节流：gameplay 姿态由本页自有 rAF 循环驱动骨骼，
+     manager 的活动探测看不见它，节流会让挥拍/蓄力等动作以 30fps 渲染出卡顿 -->
+<script>window.__NEKO_DISABLE_AVATAR_IDLE_THROTTLE__ = true;</script>
 <script>
   (function () {
     var params = null;

--- a/templates/card_maker.html
+++ b/templates/card_maker.html
@@ -6,6 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title data-i18n="cardExport.title">卡面制作 - Project N.E.K.O.</title>
     <!-- VRM 光照默认值 -->
+    <!-- 模型预览/编辑页豁免 avatar 空闲节流：用户在此手动播放任意动画（含无参
+         playAnimation 的舞蹈 VMD），期望满帧预览，不应被空闲地板压到 30fps -->
+    <script>window.__NEKO_DISABLE_AVATAR_IDLE_THROTTLE__ = true;</script>
     <script id="vrm-default-lighting-data" type="application/json">{{ (vrm_defaults | default({}, true)) | tojson | safe }}</script>
     <script>
         const vrmDefaultLightingData = document.getElementById('vrm-default-lighting-data');

--- a/templates/character_card_manager.html
+++ b/templates/character_card_manager.html
@@ -7,6 +7,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title data-i18n="steam.workshopManager">角色卡管理 - Project N.E.K.O.</title>
     <!-- i18next 加载器（统一处理 CDN 加载和初始化） -->
+    <!-- 模型预览/编辑页豁免 avatar 空闲节流：用户在此手动播放任意动画（含无参
+         playAnimation 的舞蹈 VMD），期望满帧预览，不应被空闲地板压到 30fps -->
+    <script>window.__NEKO_DISABLE_AVATAR_IDLE_THROTTLE__ = true;</script>
     <script src="/static/i18n-i18next.js"></script>
     <script src="/static/common_dialogs.js"></script>
     <link rel="stylesheet" href="/static/css/character_card_manager.css?v={{ static_asset_version | default('0') }}">

--- a/templates/model_manager.html
+++ b/templates/model_manager.html
@@ -7,6 +7,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title data-i18n="live2d.manager">模型管理器 - Project N.E.K.O.</title>
     <!-- VRM 光照默认值：从后端注入，保证在所有 JS 之前同步可用 -->
+    <!-- 模型预览/编辑页豁免 avatar 空闲节流：用户在此手动播放任意动画（含无参
+         playAnimation 的舞蹈 VMD），期望满帧预览，不应被空闲地板压到 30fps -->
+    <script>window.__NEKO_DISABLE_AVATAR_IDLE_THROTTLE__ = true;</script>
     <script id="vrm-default-lighting-data" type="application/json">{{ (vrm_defaults | default({}, true)) | tojson | safe }}</script>
     <script>
         const vrmDefaultLightingData = document.getElementById('vrm-default-lighting-data');

--- a/templates/soccer_demo.html
+++ b/templates/soccer_demo.html
@@ -7,6 +7,10 @@
 <!-- VRM 光照默认值：从后端注入（vrm-core.js 依赖） -->
 <script>window.VRM_DEFAULT_LIGHTING = Object.freeze({{ vrm_defaults | tojson }});</script>
 
+<!-- 小游戏页豁免 avatar 空闲节流：gameplay 姿态由本页自有 rAF 循环驱动骨骼，
+     manager 的活动探测看不见它，节流会让射门/庆祝等动作以 30fps 渲染出卡顿 -->
+<script>window.__NEKO_DISABLE_AVATAR_IDLE_THROTTLE__ = true;</script>
+
 <!-- Mock 桌宠运行环境（必要最小子集，避免各 init 脚本崩溃） -->
 <script>
   // mini-game 邀请被接受后由 chat.html / Pet 主聊天 window.open 打开本页面，

--- a/tests/unit/test_avatar_model_load_race_static_contracts.py
+++ b/tests/unit/test_avatar_model_load_race_static_contracts.py
@@ -31,9 +31,12 @@ def test_vrm_load_model_uses_entry_token_without_blocking_queue():
     # 无限期阻塞 VRM→VRM 切换（Codex P2）。并发正确性由 vrm-core 的 token 守卫兜底。
     source = (PROJECT_ROOT / "static/vrm/vrm-manager.js").read_text(encoding="utf-8")
 
-    # token 在入口同步分配（后到者胜），直接调用加载体，不经 promise 队列
+    # token 在入口同步分配（后到者胜），直接调用加载体，不经 promise 队列。
+    # round-2 起挂 .catch 收尾（非 await，遵守本契约）：失败路径复位 _loadState，
+    # 防止空闲 governor 把卡在 'preparing' 的状态当作永久活动（节流失效）。
     assert "const loadToken = ++this._activeLoadToken;" in source
-    assert "return this._loadModelInternal(modelUrl, options, loadToken);" in source
+    assert "return this._loadModelInternal(modelUrl, options, loadToken).catch((e) => {" in source
+    assert "if (this._isLoadTokenActive(loadToken)) this._loadState = 'idle';" in source
     assert "async _loadModelInternal(modelUrl, options, loadToken)" in source
 
     # 串行队列必须彻底移除：不得残留 _loadModelChain / previousLoad / 旧方法名

--- a/tests/unit/test_goodbye_resource_suspend_static.py
+++ b/tests/unit/test_goodbye_resource_suspend_static.py
@@ -147,9 +147,13 @@ def test_goodbye_resource_suspend_pauses_only_active_render_loops_and_restores_o
     get_manager = _js_function_block(source, "getModelManagerByType")
 
     assert "if (type === 'live2d')" in is_rendering
-    assert "ticker && ticker.started !== false" in is_rendering
-    assert "if (type === 'vrm' || type === 'mmd')" in is_rendering
-    assert "return !!manager._animationFrameId;" in is_rendering
+    # 空闲低频 tick 模式（round-2）下 ticker.started/rAF id 为"停"的假象，
+    # isModelRenderingActive 必须把 _idleTickMode 也算作在渲染
+    assert "ticker.started !== false || manager._idleTickMode" in is_rendering
+    assert "if (type === 'vrm')" in is_rendering
+    assert "manager._animationFrameId || manager._idleTickMode" in is_rendering
+    assert "if (type === 'mmd')" in is_rendering
+    assert "manager.core && manager.core._idleTickMode" in is_rendering
     assert "if (type === 'pngtuber')" in is_rendering
     assert "document.getElementById('pngtuber-container')" in is_rendering
     assert "container.style.display !== 'none'" in is_rendering


### PR DESCRIPTION
## 背景

第一轮空闲优化（#2382 + N.E.K.O.-PC#355，已合并）把空闲态 Electron 总 CPU 从 60.8% 降到 32.1%，但收益仅覆盖 Live2D 形态。本 PR 是第二轮，完成上轮报告中列出的全部后续项。

## 内容

### 1. VRM / MMD / PNGTuber 移植空闲低频 tick 模式

三种形态此前完全没有 idle 节流：rAF 请求让 Blink 在 120Hz 屏上以显示器刷新率空跑主帧生命周期，VRM/MMD 的物理/表情/渲染循环与 PNGTuber 的呼吸/动画循环永不降频。移植 live2d round-1 同款机制（活动探测 + 900ms 衰减 + interval 低频驱动 + 300ms governor 自愈），三种形态各自适配：

- **VRM**：活动源=口型同步/非 idle VRMA/拖拽/视线跟踪/相机变化（OrbitControls change 事件）/滚轮/加载中；空闲态绕过 medium 档隔帧物理（防 15Hz 步长抖动）；加载失败复位 `_loadState`（防 governor 永久 boost）
- **MMD**：`playAnimation` 增设动画模式标记——idle 循环 VMD 按 round-1 先例以 30fps 地板渲染，点歌跳舞（'dance'）满帧；Bullet 固定 1/60 子步积分，33ms 定时器步长与已上线的 low 档路径等价，物理稳定性无变化
- **PNGTuber**：呼吸循环（0.32Hz 正弦）直接 20fps 定时器化（视觉无差）；动画循环混合驱动，高速贴图动画（有效帧率>30fps）、说话、拖拽、物理未静定、换装余温均保持 rAF 满帧
- **交互即时性**：拖拽起步/滚轮命中模型时同步 boost（不等 300ms governor 轮询），消除起步顿挫；滚轮升频移到 canvas 命中判定之后（聊天区滚动不再误升频）
- **页面豁免**：小游戏 demo（自有 rAF 姿态循环）与模型管理/角色卡预览页（手动播放任意动画）声明 `__NEKO_DISABLE_AVATAR_IDLE_THROTTLE__` 退出节流
- **UI 跟随循环**：空闲时经 33ms 定时器转一次性 rAF（不形成连续 vsync 链），所有外部清理路径显式清 pending 定时器

### 2. Live2D 每帧分配与强制布局消除

口型覆盖包装的 6 处每帧 `Object.entries` + 呼吸参数每帧 `getParameterIndex` 提升到安装期；锁图标/浮动按钮 tick 加整像素量化脏检查、重叠扫描 250ms 节流、坐标推算矩形替代每帧 `getBoundingClientRect`；DOM 重建时重置缓存（审查发现的 blocker：残留缓存会让重建后的元素停在默认位置）。

### 3. minimize-dock 轮询退避

preload 已发布毛球矩形时跳过 getBounds IPC（该场景下结果本就被短路忽略）；稳定态 500ms→1.5s（消费方过期阈值 2.5s，留足余量）；真实触发后保 3s 满频。

### 4. monitor.py ws 帧类型容错

starlette 0.46 的 `receive_text()/receive_bytes()` 收到类型不符帧抛 KeyError 且帧已被消费——一个意外帧即杀掉整条连接。新增 `_receive_ws_frame` helper，四个端点统一跳过类型不符帧而非断连。

## 实测验证（macOS · 120Hz ProMotion）

- 通过 API 依次切换 YUI 到 VRM（sister1.0.vrm）与 MMD（Miku.pmx + 待机舞蹈）真机验证：空闲模式正确进入/退出、待机动画在定时器驱动下连续、boost 闭环工作、物理稳定
- VRM 空闲态主帧调度 **120/s → 56/s**（且是在鼠标持续移动的最坏条件下——余量来自真实指针事件与 UI 循环，静置约 30/s）
- 单测：改动前后全量 unit suite 失败集完全一致（25 个均为预存环境性失败，零新增）；PNGTuber 22 项钉死源码契约、goodbye/加载竞态契约测试随代码语义同步更新
- 每项改动经 4 路对抗性 review，2 个 blocker（脏检查缓存跨 DOM 重建残留）与全部实质 concern（加载失败卡 preparing、demo 页降频、UI 定时器清理、交互起步顿挫等）已修复

## 已知取舍（review 确认可接受）

- governor 的 300ms 探测在 pauseRendering 后继续空转（廉价 early-return，与 live2d round-1 持平）
- 运行中修改 targetFrameRate 需等下一次 boost/衰减周期才重排空闲间隔
- 主进程侧发起的毛球移动（工作区变化等）最坏 1.5s 才被轮询看到（在 2.5s 过期预算内）

## 不拆分理由

本 PR 是同一个机制（空闲低频 tick 模式）在三种 avatar 形态上的对称移植 + 它与共享基础设施（goodbye 资源暂停、共享 UI 按钮清理、页面豁免声明）的集成。文件数多但强耦合：

- `isModelRenderingActive`（goodbye）与 `_uiLoopIdleTimeout` 清理（avatar-ui-buttons 共享层）必须与三个形态的空闲模式**同一提交窗口**落地——先合任一形态而不合集成层，goodbye 暂停会漏掉空闲模式下的 manager（真实行为缺陷，非风格问题）；反向先合集成层则引用不存在的字段。
- 页面豁免全局量（demo/模型管理模板 5 个文件）是 VRM/MMD governor 的启动条件分支，拆开合会让 demo 页在中间状态出现 30fps 游戏动画回归。
- Live2D 每帧分配 / dock 轮询 / monitor.py 三块虽然独立，但均为上轮 PR 报告承诺的同批后续项，且各自 diff 很小（2/1/1 个文件）；拆成三个额外 PR 的 review 开销大于收益。

按主题拆分的自然边界已经体现在 7 个独立 commit 上（vrm / mmd / pngtuber / 共享集成 / live2d / dock / monitor），可按 commit 逐个 review。

## 回归报告

本 PR 触及 `app/` 的唯一改动是 `app/monitor.py`：

**改动与必要性**：`/subtitle_ws`、`/sync`、`/sync_binary` 沿用 `receive_text()`/`receive_bytes()`，在 starlette 0.46 下收到类型不符的帧（如向文本端点发二进制）会抛 `KeyError` 且该帧已被消费，异常逃逸到外层 handler 直接杀掉连接。新增模块级 `_receive_ws_frame(websocket)`：原始 `receive()` + 断连帧转 `WebSocketDisconnect`（对齐 receive_text 语义），调用方显式取 `text`/`bytes` 键、类型不符则跳过该帧继续循环。上轮修过的 `/ws/{lanlan_name}` 查看端点的嵌套 try/except 亦简化为同一 helper。

**改动前后行为**：正常路径（文本端点收文本、二进制端点收二进制、断连收尾）字节级等价；差异仅在异常帧——旧行为断连，新行为跳过。`/sync` 的字幕累积逻辑不受影响（跳帧即 continue，不触碰 `current_subtitle`）。

**潜在回归面**：`_receive_ws_frame` 不再区分 `websocket.disconnect` 帧的 code（统一透传原 code 或 1000）；若未来有端点依赖特定 close code 分支处理需注意。helper 行为（文本帧/二进制帧透传、断连码传递）已有行为级验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 优化头像渲染调度：无操作时降低资源占用，交互、动画和相机变化时自动恢复高帧率。
  * 改善拖拽、缩放、模型切换及动画预览的流畅度。
  * 优化浮动按钮、锁定图标和聊天窗口状态更新，减少画面抖动与无效刷新。
  * 特定模型预览和演示页面支持保持满帧渲染。

* **问题修复**
  * 提升 WebSocket 在混合帧类型和断开连接时的稳定性。
  * 修复渲染暂停、恢复及页面隐藏后可能残留定时任务的问题。
  * 改善模型加载失败后的状态恢复与清理行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->