### PR TITLE
fix(cat): decouple sound setting and correct yarn walk start range

### DIFF
--- a/static/avatar/avatar-ui-buttons/idle-journey-and-presentation.js
+++ b/static/avatar/avatar-ui-buttons/idle-journey-and-presentation.js
@@ -445,6 +445,15 @@ function _isNekoIdleRectCenterInsideRect(innerRect, outerRect) {
         innerCenterY >= outerTop && innerCenterY <= outerBottom;
 }
 
+function _getNekoIdleRectCenterDistancePx(firstRect, secondRect) {
+    if (!firstRect || !secondRect) return NaN;
+    const dx = Number(secondRect.left) + Number(secondRect.width) / 2 -
+        (Number(firstRect.left) + Number(firstRect.width) / 2);
+    const dy = Number(secondRect.top) + Number(secondRect.height) / 2 -
+        (Number(firstRect.top) + Number(firstRect.height) / 2);
+    return Number.isFinite(dx) && Number.isFinite(dy) ? Math.hypot(dx, dy) : NaN;
+}
+
 // #1754：贴球后“原地以当前朝向站住”的侧目标（distance 0、moveFacingRight null，不再走动）。
 function _makeNekoIdleCat1CurrentSideTarget(rect, chatRect, options) {
     const facingRight = !!(options && options.facingRight);
@@ -1575,6 +1584,13 @@ function _syncNekoIdleCat1Journey(button, tier) {
     const switchingFromCompactTopEdgeToMinimizedSide =
         previousTargetKind === _NEKO_IDLE_CAT1_TARGET_KIND_COMPACT_TOP_EDGE &&
         target.kind === _NEKO_IDLE_CAT1_TARGET_KIND_MINIMIZED_SIDE;
+    const containerRect = typeof container.getBoundingClientRect === 'function'
+        ? container.getBoundingClientRect()
+        : null;
+    const centerDistancePx = _getNekoIdleRectCenterDistancePx(containerRect, chatRect);
+    const walkStartDistancePx = Number.isFinite(centerDistancePx)
+        ? centerDistancePx
+        : target.distance;
     if (compactTopEdgeTarget) {
         _cancelNekoIdleCat1PairMove(state);
         if (target.distance <= profile.target.exitDistancePx) {
@@ -1582,7 +1598,7 @@ function _syncNekoIdleCat1Journey(button, tier) {
         }
     }
 
-    if (target.distance < profile.target.enterDistancePx && state.substate !== profile.walkingSubstate && !compactTopEdgeTarget) {
+    if (walkStartDistancePx < profile.target.enterDistancePx && state.substate !== profile.walkingSubstate && !compactTopEdgeTarget) {
         _cancelNekoIdleReturnPendingWalk(state);
     }
 
@@ -1591,7 +1607,7 @@ function _syncNekoIdleCat1Journey(button, tier) {
         return;
     }
 
-    if (target.distance >= profile.target.enterDistancePx ||
+    if (walkStartDistancePx >= profile.target.enterDistancePx ||
         (compactTopEdgeTarget && target.distance > profile.target.exitDistancePx) ||
         (switchingFromCompactTopEdgeToMinimizedSide && target.distance > profile.target.exitDistancePx)) {
         state.actionSettled = false;

--- a/static/avatar/avatar-ui-popup.js
+++ b/static/avatar/avatar-ui-popup.js
@@ -637,7 +637,7 @@ function createChatSettingsSidePanel(manager, prefix, popup) {
         { id: 'focus-cognition', label: window.t ? window.t('settings.toggles.focusCognition') : '凝神模式', labelKey: 'settings.toggles.focusCognition', tooltipKey: 'settings.toggles.focusCognitionTooltip', storageKey: 'focusCognitionEnabled', alwaysTinted: true },
         { id: 'slop-filter', label: window.t ? window.t('settings.toggles.slopFilter') : '自然表达', labelKey: 'settings.toggles.slopFilter', tooltipKey: 'settings.toggles.slopFilterTooltip', storageKey: 'slopFilterEnabled', alwaysTinted: true },
         { id: 'auto-cat', label: window.t ? window.t('settings.toggles.autoCat') : '自动变猫', labelKey: 'settings.toggles.autoCat', tooltipKey: 'settings.toggles.autoCatTooltip', alwaysTinted: true },
-        { id: 'cat-audio', label: window.t ? window.t('settings.toggles.catAudio') : '猫猫音效', labelKey: 'settings.toggles.catAudio', tooltipKey: 'settings.toggles.catAudioTooltip', alwaysTinted: true, dependsOnToggleId: 'auto-cat' },
+        { id: 'cat-audio', label: window.t ? window.t('settings.toggles.catAudio') : '猫猫音效', labelKey: 'settings.toggles.catAudio', tooltipKey: 'settings.toggles.catAudioTooltip', alwaysTinted: true },
     ];
 
     chatToggles.forEach(toggle => {

--- a/tests/unit/test_avatar_return_button_cat1_static.py
+++ b/tests/unit/test_avatar_return_button_cat1_static.py
@@ -1,3 +1,5 @@
+import shutil
+import subprocess
 from pathlib import Path
 from tests.static_app_parts import read_js_parts
 
@@ -11,6 +13,19 @@ AVATAR_UI_BUTTONS_DIR = PROJECT_ROOT / "static" / "avatar" / "avatar-ui-buttons"
 
 def _read_avatar_ui_buttons_source() -> str:
     return read_avatar_ui_buttons_source()
+
+
+def _run_node_harness(script: str) -> subprocess.CompletedProcess[str]:
+    node_path = shutil.which("node")
+    if not node_path:
+        raise AssertionError("node is required to run avatar journey harness tests")
+    return subprocess.run(
+        [node_path, "-e", script],
+        cwd=PROJECT_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
 
 
 APP_UI_PATH = PROJECT_ROOT / "static" / "app" / "app-ui"
@@ -405,7 +420,40 @@ def test_cat1_compact_top_edge_to_minimized_side_transition_forces_walk():
     assert journey_sync_block.index("const switchingFromCompactTopEdgeToMinimizedSide =") < journey_sync_block.index("_scheduleNekoIdleCat1WalkStart(button, target);")
 
 
-def test_cat1_settled_minimized_side_uses_regular_walk_delay_when_ball_moves():
+def test_cat1_regular_walk_start_distance_uses_cat_and_yarn_centers():
+    source = _read_avatar_ui_buttons_source()
+    helper_source = "function _getNekoIdleRectCenterDistancePx" + source.split(
+        "function _getNekoIdleRectCenterDistancePx",
+        1,
+    )[1].split("function _makeNekoIdleCat1CurrentSideTarget", 1)[0]
+    script = f"""
+        const assert = require('node:assert/strict');
+        {helper_source}
+
+        const yarnRect = {{ left: 470, top: 300, width: 51, height: 51 }};
+        const overlappingCatRect = {{ left: 364.5, top: 264.5, width: 122, height: 122 }};
+        assert.equal(_getNekoIdleRectCenterDistancePx(overlappingCatRect, yarnRect), 70);
+        assert.equal(_getNekoIdleRectCenterDistancePx(overlappingCatRect, yarnRect) < 180, true);
+
+        for (const size of [96, 108, 122]) {{
+            const catRect = {{ left: 100 - size / 2, top: 100 - size / 2, width: size, height: size }};
+            const nearYarn = {{ left: 279 - 25.5, top: 100 - 25.5, width: 51, height: 51 }};
+            const farYarn = {{ left: 281 - 25.5, top: 100 - 25.5, width: 51, height: 51 }};
+            assert.equal(_getNekoIdleRectCenterDistancePx(catRect, nearYarn), 179);
+            assert.equal(_getNekoIdleRectCenterDistancePx(catRect, farYarn), 181);
+        }}
+
+        const diagonalCat = {{ left: 39, top: 39, width: 122, height: 122 }};
+        const diagonalYarn = {{ left: 182.5, top: 218.5, width: 51, height: 51 }};
+        const boundaryDistance = _getNekoIdleRectCenterDistancePx(diagonalCat, diagonalYarn);
+        assert.equal(boundaryDistance, 180);
+        assert.equal(boundaryDistance >= 180, true);
+    """
+    result = _run_node_harness(script)
+    assert result.returncode == 0, result.stderr
+
+
+def test_cat1_settled_minimized_side_uses_center_distance_for_regular_walk_delay_when_ball_moves():
     source = _read_avatar_ui_buttons_source()
 
     journey_sync_block = source.split("function _syncNekoIdleCat1Journey", 1)[1].split(
@@ -413,12 +461,19 @@ def test_cat1_settled_minimized_side_uses_regular_walk_delay_when_ball_moves():
         1,
     )[0]
     assert "const followingMovedMinimizedSideTarget =" not in journey_sync_block
-    assert "target.distance >= profile.target.enterDistancePx" in journey_sync_block
+    assert "const centerDistancePx = _getNekoIdleRectCenterDistancePx(containerRect, chatRect);" in journey_sync_block
+    assert "const walkStartDistancePx = Number.isFinite(centerDistancePx)" in journey_sync_block
+    assert ": target.distance;" in journey_sync_block
+    assert "walkStartDistancePx < profile.target.enterDistancePx" in journey_sync_block
+    assert "walkStartDistancePx >= profile.target.enterDistancePx" in journey_sync_block
+    assert "target.distance >= profile.target.enterDistancePx" not in journey_sync_block
     assert "if (switchingFromCompactTopEdgeToMinimizedSide) {" in journey_sync_block
     assert "if (switchingFromCompactTopEdgeToMinimizedSide ||" not in journey_sync_block
     assert "state.pendingWalkReady = true;" in journey_sync_block
     assert "state.pendingWalkDelayMs = 0;" in journey_sync_block
-    assert journey_sync_block.index("target.distance >= profile.target.enterDistancePx") < journey_sync_block.index("_scheduleNekoIdleCat1WalkStart(button, target);")
+    assert "state.substate === profile.walkingSubstate && target.distance > profile.target.exitDistancePx" in journey_sync_block
+    assert "compactTopEdgeTarget && target.distance > profile.target.exitDistancePx" in journey_sync_block
+    assert journey_sync_block.index("walkStartDistancePx >= profile.target.enterDistancePx") < journey_sync_block.index("_scheduleNekoIdleCat1WalkStart(button, target);")
 
 
 def test_cat1_settled_minimized_side_bypasses_small_desktop_move_filter():

--- a/tests/unit/test_avatar_return_button_cat1_static.py
+++ b/tests/unit/test_avatar_return_button_cat1_static.py
@@ -1,6 +1,8 @@
 import shutil
 import subprocess
 from pathlib import Path
+
+import pytest
 from tests.static_app_parts import read_js_parts
 
 from main_routers import pages_router
@@ -18,7 +20,7 @@ def _read_avatar_ui_buttons_source() -> str:
 def _run_node_harness(script: str) -> subprocess.CompletedProcess[str]:
     node_path = shutil.which("node")
     if not node_path:
-        raise AssertionError("node is required to run avatar journey harness tests")
+        pytest.skip("node not found")
     return subprocess.run(
         [node_path, "-e", script],
         cwd=PROJECT_ROOT,

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -74,7 +74,7 @@ def assert_no_layout_transition(block: str) -> None:
         assert prop not in transition_section
 
 
-def test_chat_settings_cat_audio_toggle_is_under_auto_cat_and_dependent():
+def test_chat_settings_auto_cat_and_cat_audio_toggles_are_independent():
     source = AVATAR_UI_POPUP_PATH.read_text(encoding="utf-8")
     chat_settings_block = source.split("const chatToggles = [", 1)[1].split("];", 1)[0]
 
@@ -82,7 +82,8 @@ def test_chat_settings_cat_audio_toggle_is_under_auto_cat_and_dependent():
     assert "id: 'cat-audio'" in chat_settings_block
     assert chat_settings_block.index("id: 'auto-cat'") < chat_settings_block.index("id: 'cat-audio'")
     assert "labelKey: 'settings.toggles.catAudio'" in chat_settings_block
-    assert "dependsOnToggleId: 'auto-cat'" in chat_settings_block
+    cat_audio_config = chat_settings_block.split("{ id: 'cat-audio'", 1)[1].split("}", 1)[0]
+    assert "dependsOnToggleId" not in cat_audio_config
     assert "neko:auto-cat-setting-changed" not in source
 
     cat_audio_init_block = source.split("} else if (toggle.id === 'cat-audio'", 1)[1].split(


### PR DESCRIPTION
## 改动概述 / Summary

- 将对话设置中的“猫猫音效”与“自动变猫”解绑：两个开关现在可以独立操作；音效开关继续复用既有存储与猫形态音频控制链。
- 将 CAT1 普通走向毛线球的开始范围改为猫容器中心到毛线球中心的欧氏距离，避免猫已靠近或重叠时因侧边停靠目标较远而误触发。
- 保持现有 180px 开始门槛、compact 迁移、walking 追踪、14px 停靠、动作结束表现和 N.E.K.O-PC 矩形转发职责不变。

## 回归报告 / Regression Report

不适用：本 PR 未修改 `app/`、`main_logic/`、`main_routers/` 或 `memory/` 下的 Python 文件。

## 不拆分理由 / Why Not Split

不适用：本 PR 共修改 4 个文件，其中计入上限的非测试文件为 2 个，未超过 20 个文件的阈值。

## 测试 / Testing

- `node --check static/avatar/avatar-ui-popup.js`
- `node --check static/avatar/avatar-ui-buttons/idle-journey-and-presentation.js`
- `.venv/bin/python -m pytest -q tests/unit/test_react_chat_window_static.py tests/unit/test_cat_idle_state_machine_static.py tests/unit/test_avatar_return_button_cat1_static.py tests/unit/test_avatar_return_button_idle_tiers_static.py`：173 passed。
- 中心距 harness 覆盖 96/108/122px 猫尺寸、横向与斜向距离、179/180/181px 边界，以及原误触样例。
- 设置回归断言确认“猫猫音效”不再依赖“自动变猫”，并仍调用既有 `nekoIdleCatAudio` 读写链。
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改进**
  - 猫咪进入/行走触发的距离判断已优化：当可用时改用容器与聊天区域中心点的距离，更准确地控制开始走路时机。
  - “猫咪音效”开关不再联动“自动猫咪”，两者可独立控制。
- **测试**
  - 新增 Node 测试运行支持，并补充覆盖中心距离计算与行走触发阈值的断言；相应调整与更新既有行走延迟相关用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->