### PR TITLE
Add authenticated graceful runtime shutdown

### DIFF
--- a/app/main_server/__init__.py
+++ b/app/main_server/__init__.py
@@ -511,6 +511,7 @@ _MAIN_LIMITED_MODE_ALLOWED_EXACT_PATHS = {
     "/health",
     "/favicon.ico",
     "/api/beacon/shutdown",
+    "/api/runtime/shutdown",
     "/api/config/steam_language",
     "/api/system/status",
 }
@@ -989,7 +990,7 @@ async def on_startup():
             init_one_catgirl=init_one_catgirl,
             remove_one_catgirl=remove_one_catgirl,
             request_app_shutdown=lambda: asyncio.create_task(
-                request_application_shutdown_async()
+                request_application_shutdown_async(reason="storage_location_restart")
             ),
             release_storage_startup_barrier=release_storage_startup_barrier,
         )
@@ -1281,14 +1282,14 @@ importlib.import_module(
 ).runtime.get_start_config = get_start_config
 
 
-async def request_application_shutdown_async():
+async def request_application_shutdown_async(*, reason: str = "application_request"):
     """Request an application-level shutdown compatible with both launcher modes."""
     current_config = get_start_config()
     request_runtime_shutdown = current_config.get("request_runtime_shutdown")
     if callable(request_runtime_shutdown):
         try:
             await asyncio.sleep(0.5)
-            result = request_runtime_shutdown()
+            result = request_runtime_shutdown(reason=reason)
             if inspect.isawaitable(result):
                 await result
             return
@@ -1348,6 +1349,9 @@ async def shutdown_server_async():
 importlib.import_module(
     f"{__package__}._shared"
 ).runtime.shutdown_server_async = shutdown_server_async
+importlib.import_module(
+    f"{__package__}._shared"
+).runtime.request_application_shutdown_async = request_application_shutdown_async
 
 
 # Steam 创意工坊管理相关API路由

--- a/app/main_server/_shared.py
+++ b/app/main_server/_shared.py
@@ -30,6 +30,7 @@ class RuntimeReferences:
     resolve_user_plugin_base: Callable[[], str] | None = None
     get_start_config: Callable[[], dict] | None = None
     shutdown_server_async: Callable[[], Any] | None = None
+    request_application_shutdown_async: Callable[..., Any] | None = None
 
 
 runtime = RuntimeReferences()

--- a/app/main_server/web_app.py
+++ b/app/main_server/web_app.py
@@ -17,6 +17,7 @@
 
 import asyncio
 import os
+import secrets
 
 import httpx
 from fastapi import Request
@@ -210,6 +211,54 @@ async def beacon_shutdown():
     except Exception as e:
         logger.error(f"Beacon处理错误: {e}")
         return {"success": False, "error": str(e)}
+
+
+@app.post("/api/runtime/shutdown")
+async def runtime_shutdown(request: Request):
+    """Request an authenticated application-level shutdown from the owning desktop app."""
+    configured_token = os.environ.get("NEKO_RUNTIME_SHUTDOWN_TOKEN", "").strip()
+    if not configured_token:
+        return JSONResponse(
+            {"success": False, "error": "runtime shutdown is not enabled"},
+            status_code=503,
+        )
+
+    provided_token = request.headers.get("x-neko-runtime-shutdown-token", "").strip()
+    if not provided_token or not secrets.compare_digest(
+        configured_token, provided_token
+    ):
+        return JSONResponse(
+            {"success": False, "error": "invalid runtime shutdown token"},
+            status_code=403,
+        )
+
+    from config import INSTANCE_ID
+
+    provided_instance = request.headers.get("x-neko-instance-id", "").strip()
+    if provided_instance and not secrets.compare_digest(
+        str(INSTANCE_ID), provided_instance
+    ):
+        return JSONResponse(
+            {"success": False, "error": "runtime instance mismatch"},
+            status_code=409,
+        )
+
+    shutdown = runtime.request_application_shutdown_async
+    if not callable(shutdown):
+        return JSONResponse(
+            {"success": False, "error": "runtime shutdown bridge is unavailable"},
+            status_code=503,
+        )
+
+    asyncio.create_task(shutdown(reason="desktop_owner_exit"))
+    return JSONResponse(
+        {
+            "success": True,
+            "message": "runtime shutdown accepted",
+            "instance_id": str(INSTANCE_ID),
+        },
+        status_code=202,
+    )
 
 
 @app.api_route(

--- a/app/main_server/web_app.py
+++ b/app/main_server/web_app.py
@@ -213,6 +213,24 @@ async def beacon_shutdown():
         return {"success": False, "error": str(e)}
 
 
+def _runtime_shutdown_has_target() -> bool:
+    current_config = runtime.get_start_config()
+    if callable(current_config.get("request_runtime_shutdown")):
+        return True
+    if current_config.get("server") is not None:
+        return True
+
+    launcher_pid_raw = os.environ.get("NEKO_LAUNCHER_PID", "").strip()
+    if os.name != "nt" and launcher_pid_raw:
+        try:
+            launcher_pid = int(launcher_pid_raw)
+        except ValueError:
+            return False
+        return launcher_pid > 0 and launcher_pid != os.getpid()
+
+    return False
+
+
 @app.post("/api/runtime/shutdown")
 async def runtime_shutdown(request: Request):
     """Request an authenticated application-level shutdown from the owning desktop app."""
@@ -241,6 +259,12 @@ async def runtime_shutdown(request: Request):
         return JSONResponse(
             {"success": False, "error": "runtime instance mismatch"},
             status_code=409,
+        )
+
+    if not _runtime_shutdown_has_target():
+        return JSONResponse(
+            {"success": False, "error": "runtime shutdown target is unavailable"},
+            status_code=503,
         )
 
     shutdown = runtime.request_application_shutdown_async

--- a/launcher_core/runtime.py
+++ b/launcher_core/runtime.py
@@ -903,8 +903,8 @@ def run_merged_servers() -> int:
                 "browser_mode_enabled": False,
                 "browser_page": "",
                 "shutdown_memory_server_on_exit": False,
-                "request_runtime_shutdown": lambda: _begin_merged_shutdown(
-                    reason="storage_location_restart"
+                "request_runtime_shutdown": lambda *, reason="application_request": _begin_merged_shutdown(
+                    reason=reason
                 ),
                 "server": None,
             }

--- a/tests/unit/test_cloudsave_startup_flow.py
+++ b/tests/unit/test_cloudsave_startup_flow.py
@@ -925,8 +925,8 @@ async def test_main_server_uses_runtime_shutdown_bridge_when_available(monkeypat
 
     callback_calls = []
 
-    def _request_runtime_shutdown():
-        callback_calls.append("called")
+    def _request_runtime_shutdown(*, reason):
+        callback_calls.append(reason)
 
     monkeypatch.setattr(
         main_server,
@@ -941,9 +941,9 @@ async def test_main_server_uses_runtime_shutdown_bridge_when_available(monkeypat
     )
     monkeypatch.setattr(main_server, "shutdown_server_async", AsyncMock())
 
-    await main_server.request_application_shutdown_async()
+    await main_server.request_application_shutdown_async(reason="desktop_owner_exit")
 
-    assert callback_calls == ["called"]
+    assert callback_calls == ["desktop_owner_exit"]
 
 
 @pytest.mark.unit

--- a/tests/unit/test_runtime_shutdown_route.py
+++ b/tests/unit/test_runtime_shutdown_route.py
@@ -1,0 +1,70 @@
+import asyncio
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_runtime_shutdown_route_requires_owner_token(monkeypatch):
+    from app.main_server import web_app
+
+    shutdown = AsyncMock()
+    monkeypatch.setenv("NEKO_RUNTIME_SHUTDOWN_TOKEN", "owner-secret")
+    monkeypatch.setattr(web_app.runtime, "request_application_shutdown_async", shutdown)
+
+    request = SimpleNamespace(
+        headers={
+            "x-neko-runtime-shutdown-token": "not-the-owner",
+        }
+    )
+    response = await web_app.runtime_shutdown(request)
+
+    assert response.status_code == 403
+    shutdown.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_runtime_shutdown_route_delegates_to_application_shutdown(monkeypatch):
+    from app.main_server import web_app
+    from config import INSTANCE_ID
+
+    shutdown = AsyncMock()
+    monkeypatch.setenv("NEKO_RUNTIME_SHUTDOWN_TOKEN", "owner-secret")
+    monkeypatch.setattr(web_app.runtime, "request_application_shutdown_async", shutdown)
+
+    request = SimpleNamespace(
+        headers={
+            "x-neko-runtime-shutdown-token": "owner-secret",
+            "x-neko-instance-id": str(INSTANCE_ID),
+        }
+    )
+    response = await web_app.runtime_shutdown(request)
+    await asyncio.sleep(0)
+
+    assert response.status_code == 202
+    shutdown.assert_awaited_once_with(reason="desktop_owner_exit")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_runtime_shutdown_route_rejects_different_instance(monkeypatch):
+    from app.main_server import web_app
+
+    shutdown = AsyncMock()
+    monkeypatch.setenv("NEKO_RUNTIME_SHUTDOWN_TOKEN", "owner-secret")
+    monkeypatch.setattr(web_app.runtime, "request_application_shutdown_async", shutdown)
+
+    request = SimpleNamespace(
+        headers={
+            "x-neko-runtime-shutdown-token": "owner-secret",
+            "x-neko-instance-id": "another-instance",
+        }
+    )
+    response = await web_app.runtime_shutdown(request)
+
+    assert response.status_code == 409
+    shutdown.assert_not_called()

--- a/tests/unit/test_runtime_shutdown_route.py
+++ b/tests/unit/test_runtime_shutdown_route.py
@@ -35,6 +35,11 @@ async def test_runtime_shutdown_route_delegates_to_application_shutdown(monkeypa
     shutdown = AsyncMock()
     monkeypatch.setenv("NEKO_RUNTIME_SHUTDOWN_TOKEN", "owner-secret")
     monkeypatch.setattr(web_app.runtime, "request_application_shutdown_async", shutdown)
+    monkeypatch.setattr(
+        web_app.runtime,
+        "get_start_config",
+        lambda: {"request_runtime_shutdown": lambda **_kwargs: None, "server": None},
+    )
 
     request = SimpleNamespace(
         headers={
@@ -48,6 +53,31 @@ async def test_runtime_shutdown_route_delegates_to_application_shutdown(monkeypa
     assert response.status_code == 202
     shutdown.assert_awaited_once_with(reason="desktop_owner_exit")
 
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_runtime_shutdown_route_rejects_missing_shutdown_target(monkeypatch):
+    from app.main_server import web_app
+
+    shutdown = AsyncMock()
+    monkeypatch.setenv("NEKO_RUNTIME_SHUTDOWN_TOKEN", "owner-secret")
+    monkeypatch.delenv("NEKO_LAUNCHER_PID", raising=False)
+    monkeypatch.setattr(web_app.runtime, "request_application_shutdown_async", shutdown)
+    monkeypatch.setattr(
+        web_app.runtime,
+        "get_start_config",
+        lambda: {"request_runtime_shutdown": None, "server": None},
+    )
+
+    request = SimpleNamespace(
+        headers={
+            "x-neko-runtime-shutdown-token": "owner-secret",
+        }
+    )
+    response = await web_app.runtime_shutdown(request)
+
+    assert response.status_code == 503
+    shutdown.assert_not_called()
 
 @pytest.mark.unit
 @pytest.mark.asyncio


### PR DESCRIPTION
﻿## 改动概述 / Summary

- add a token-authenticated localhost endpoint for application-level runtime shutdown
- propagate an explicit shutdown reason through the main-server and merged-launcher bridge
- keep the owner shutdown endpoint available while the main server is in limited mode

This complements #2382. It is lifecycle and ownership-safety work, not another runtime-performance claim.

## 回归报告 / Regression Report

- **改动了什么：** 新增 `/api/runtime/shutdown`，仅在进程环境存在 `NEKO_RUNTIME_SHUTDOWN_TOKEN` 时启用；校验 owner token，并可额外校验 instance ID。将 shutdown reason 从 main server 传入 merged-launcher 的应用级关闭桥。
- **理由 / 必要性：** Electron 需要让它自己启动的后端走完整、有序的 release path。此前桌面端只能依赖突然终止进程，无法等待数据库、memory server、agent server 等资源按顺序释放。
- **改动前：** 没有只对拥有者开放的应用级关闭入口；桌面退出可能直接终止后端进程树。
- **改动后：** 拥有 per-launch token 的桌面实例可请求后端有序退出并等待完成；无 token、错误 token 或不同 instance ID 的请求分别被禁用或拒绝。未设置 token 的浏览器/独立启动模式行为不变。
- **潜在回归点与验证：** 关注 limited mode 路由、merged/multi-process 关闭桥、错误凭据和现有 browser shutdown。针对性 pytest 38 个全部通过，Ruff 通过；错误 token 实测返回 403 且后端保持健康。三次真实退出均以 code 0 完成，并释放全部进程与端口。

## 不拆分理由 / Why Not Split

不适用。计入上限的生产文件少于 20 个；endpoint、共享 runtime reference 与 launcher reason propagation 构成同一个最小端到端契约。

## 测试 / Testing

- `uv run python -m pytest tests/unit/test_cloudsave_startup_flow.py tests/unit/test_runtime_shutdown_route.py -q` — 38 passed
- Ruff on all changed Python files — passed
- three real shutdown runs: request accepted in 1–4 ms; complete process-tree and port release in 3.971–5.227 s; exit code 0
- invalid-token probe returned 403 and left the backend healthy
- three-run latest-main RSS/USS comparison showed no meaningful regression
