### PR TITLE
feat(memory): external_import_state sidecar——空抽取/全去重天重导幂等（#2383 follow-up）

### DIFF
--- a/memory/facts.py
+++ b/memory/facts.py
@@ -1261,35 +1261,75 @@ class FactStore:
             return set()
         return {str(x) for x in fps if x}
 
-    async def _aload_imported_day_fps(self, name: str) -> set[str]:
-        """Union of processed-day fingerprints: sidecar + active fact provenance.
+    async def _aload_imported_day_fps(
+        self, name: str, *, include_archive: bool = True,
+    ) -> set[str]:
+        """Union of processed-day fingerprints from two carriers, split by
+        whether the day persisted any fact:
 
-        The ``external_import_state.json`` sidecar is the authoritative record
-        — it is the only carrier for days that persisted no fact (empty
-        extraction / every extracted fact deduped away, Codex P2 follow-up).
-        Fact ``external_import.day_fingerprint`` provenance is merged in for
-        data imported before the sidecar existed (backward compat).
+        - **Fact provenance** (``external_import.day_fingerprint`` inside
+          facts.json / facts_archive.json) is authoritative for days that
+          persisted at least one fact. It rides the fact data's own cloudsave
+          sync / restore / rollback lifecycle, so a rolled-back day loses its
+          fingerprint together with its facts and re-imports self-heal —
+          exactly #2383's behavior. Days-with-facts therefore do **not** get a
+          sidecar entry (see ``_arecord_unpersisted_day_fp``): a sidecar record
+          that outlived a facts.json rollback would permanently suppress the
+          re-extraction that restores the day.
+        - **Sidecar** (``external_import_state.json``) carries **only** the
+          no-fact-carrier days — empty extraction, or every extracted fact
+          deduped away (Codex P2 follow-up). Re-extracting such a day is
+          harmless (it yields nothing new), so a stale / desynced sidecar can
+          never lose data.
+
+        ``include_archive=True`` also scans facts_archive.json, covering days
+        whose facts were archived by ``_archive_absorbed`` (>7 days old); their
+        provenance would otherwise vanish from the active list and the day
+        re-extract. The concurrent re-check passes ``False``: a rival import
+        that just persisted a day writes the active list, never the archive, so
+        active + sidecar suffices there without an archive disk read per day.
         """
         state = await asyncio.to_thread(self._load_external_import_state, name)
         fps = self._state_daily_fingerprints(state)
-        for f in await self.aload_facts(name):
+        facts = (
+            await self.aload_facts_full(name) if include_archive
+            else await self.aload_facts(name)
+        )
+        for f in facts:
             meta = f.get('external_import')
             if isinstance(meta, dict) and meta.get('day_fingerprint'):
                 fps.add(str(meta['day_fingerprint']))
         return fps
 
-    async def _arecord_imported_day_fp(self, name: str, fingerprint: str) -> None:
-        """Durably mark one day (by content fingerprint) as processed.
+    async def _arecord_unpersisted_day_fp(self, name: str, fingerprint: str) -> None:
+        """Best-effort: record a **no-fact-carrier** day's fingerprint in the sidecar.
 
-        Serialized under the per-character persist alock (the same lock as
-        fact persistence) so concurrent same-character imports can't lose
-        each other's read-modify-write. Raises ``MaintenanceModeError`` when
-        the cloudsave write fence is up — the caller counts that day as
-        failed and a retry re-extracts it, mirroring the fact path.
+        Only for days that persisted zero facts (empty extraction / every
+        extracted fact deduped away) — days that did persist facts rely on
+        their provenance instead, keeping the idempotency record inside the
+        same cloudsave lifecycle as the data it guards (see
+        ``_aload_imported_day_fps``).
+
+        Serialized under the per-character persist alock (the same lock as fact
+        persistence) so concurrent same-character imports can't lose each
+        other's read-modify-write.
+
+        Best-effort by design: the sidecar is a pure idempotency accelerator.
+        A write failure (disk full / permission; the cloudsave fence is already
+        rejected at the import entrypoint) degrades to re-extracting this day on
+        the next import — the exact #2383-era cost — so it must never escalate
+        a day that otherwise succeeded into a failed_day / HTTP 500. Fact
+        persistence keeps its own hard ``assert_cloudsave_writable`` semantics;
+        only this accelerator layer is soft.
         """
-        async with self._get_persist_alock(name):
-            await asyncio.to_thread(
-                self._record_imported_day_fp_locked, name, fingerprint
+        try:
+            async with self._get_persist_alock(name):
+                await asyncio.to_thread(
+                    self._record_imported_day_fp_locked, name, fingerprint
+                )
+        except (MaintenanceModeError, OSError) as exc:
+            logger.warning(
+                f"[FactStore] {name}: sidecar 落盘失败（降级为下次重导重抽该天）: {exc}"
             )
 
     def _record_imported_day_fp_locked(self, name: str, fingerprint: str) -> None:
@@ -1341,18 +1381,19 @@ class FactStore:
         that day from scratch (a partially-persisted day would fingerprint-skip
         forever, Greptile P1).
 
-        Idempotency mirrors persona ``folded_fingerprints``: every successfully
-        processed day records its content fingerprint in the per-character
-        ``external_import_state.json`` sidecar — including days that persist no
-        fact (empty extraction, or every extracted fact deduped away), which
-        have no provenance carrier and would otherwise re-run the LLM and burn
-        cap quota on every re-import (Codex P2 follow-up). Persisted facts
-        additionally carry the fingerprint in their ``external_import``
-        provenance; the read side merges both sources so pre-sidecar imports
-        keep skipping (see ``_aload_imported_day_fps``). A re-imported day
-        whose fragments are unchanged is skipped outright — zero LLM calls
-        (Codex P2). Changed content re-extracts; near-identical re-extraction
-        output is absorbed by the same-date FTS5 dedup in ``_apersist_new_facts``.
+        Idempotency mirrors persona ``folded_fingerprints`` via each day's
+        content fingerprint, held by one of two carriers depending on whether
+        the day persisted any fact: days that persisted facts carry it in their
+        ``external_import`` provenance (inside facts.json, so it shares the fact
+        data's cloudsave lifecycle and self-heals on rollback); days with no
+        fact carrier — empty extraction, or every extracted fact deduped away —
+        record it in the ``external_import_state.json`` sidecar, which would
+        otherwise have no home and re-run the LLM + burn cap quota on every
+        re-import (Codex P2 follow-up). The read side unions both (see
+        ``_aload_imported_day_fps``). A re-imported day whose fragments are
+        unchanged is skipped outright — zero LLM calls (Codex P2). Changed
+        content re-extracts; near-identical re-extraction output is absorbed by
+        the same-date FTS5 dedup in ``_apersist_new_facts``.
 
         After fingerprint filtering, more than ``EXTERNAL_IMPORT_DAILY_MAX_FILES``
         genuinely-new days raises ``ExternalMemoryImportTooLargeError`` — an
@@ -1373,8 +1414,8 @@ class FactStore:
             by_file.setdefault(str(cand.get("source_file") or ""), []).append(cand)
 
         # 逐日指纹幂等（对偶 persona folded_fingerprints）：已导入且内容未变的
-        # 天直接 skip，不进 LLM。指纹权威记录在 external_import_state sidecar，
-        # 读取时合并旧 fact provenance 向后兼容（见 _aload_imported_day_fps）。
+        # 天直接 skip，不进 LLM。双载体合并（有 fact 天靠 provenance，无 fact 天
+        # 靠 sidecar；含 archive 覆盖已归档天，见 _aload_imported_day_fps）。
         imported_day_fps = await self._aload_imported_day_fps(lanlan_name)
 
         day_dates = {
@@ -1446,18 +1487,22 @@ class FactStore:
                     return 0, True
                 day_extracted.extend(f for f in extracted if isinstance(f, dict))
             if not day_extracted:
-                # 空抽取天也要落 processed 指纹：没有 fact 载体，不记 sidecar
-                # 的话每次重导都重抽该天并占 cap 配额（Codex P2 follow-up）。
-                await self._arecord_imported_day_fp(lanlan_name, day_fps[source_file])
+                # 空抽取天：LLM 判该日无 fact，无 fact 载体存指纹，只能靠 sidecar，
+                # 否则每次重导都重抽该天并占 cap 配额（Codex P2 follow-up）。
+                # best-effort：sidecar 写失败退回重抽，不把该天升级为 failed_day。
+                await self._arecord_unpersisted_day_fp(lanlan_name, day_fps[source_file])
                 return 0, False
             # 并发缩窗重查：两个同角色 commit 可能都在开头读过 imported_day_fps
             # 才各自跑 LLM；persist 前重读一次，若对方已把同指纹落盘则放弃本次
             # 写入（措辞不同的重复 facts 会绕过精确去重）。剩余极窄的 TOCTOU
             # 窗口由同日期 FTS5 近似去重兜底；前端 in-flight 单飞锁已挡住单
             # 客户端的并发导入（Codex P2）。
-            # 重查合并 sidecar + provenance 双源：对方并发导入若是空抽取/全去重
-            # 天，只有 sidecar 有指纹、没有 fact 落盘，只查 facts 会漏。
-            latest_fps = await self._aload_imported_day_fps(lanlan_name)
+            # 重查合并 sidecar + active provenance 双源：对方并发导入若是空抽取/
+            # 全去重天，只有 sidecar 有指纹、没有 fact 落盘，只查 facts 会漏。并发
+            # 落盘必在 active（刚写），不在 archive，故此处 include_archive=False。
+            latest_fps = await self._aload_imported_day_fps(
+                lanlan_name, include_archive=False,
+            )
             if day_fps[source_file] in latest_fps:
                 logger.info(
                     f"[FactStore] {lanlan_name}: {source_file} 已被并发导入落盘，"
@@ -1479,11 +1524,13 @@ class FactStore:
             new_facts = await self._apersist_new_facts(
                 lanlan_name, day_extracted, semantic_dedup=True,
             )
-            # 指纹在 facts **之后**落 sidecar（顺序不可换：先指纹后 facts 若中途
-            # 崩溃，重导会被整天 skip、该天内容永久丢失）。全去重天（new_facts
-            # 为空）同样要记——provenance 没有新载体，幂等只能靠 sidecar
-            # （Codex P2 follow-up）。
-            await self._arecord_imported_day_fp(lanlan_name, day_fps[source_file])
+            # 有 fact 落盘的天不记 sidecar：指纹已在 fact provenance 里、与 facts
+            # 同处 cloudsave 同步/回滚单元，回滚后 provenance 随 facts 一起消失、
+            # 重导自愈（若额外记 sidecar，facts.json 被云端回滚后 sidecar 残留指纹
+            # 会永久压制该天重抽 → 记忆丢失）。只有全去重天（new_facts 为空、无新
+            # 载体）才落 sidecar，且重抽无害，best-effort 写（Codex P2 follow-up）。
+            if not new_facts:
+                await self._arecord_unpersisted_day_fp(lanlan_name, day_fps[source_file])
             return len(new_facts), False
 
         outcomes = await asyncio.gather(

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -1223,6 +1223,98 @@ class FactStore:
             return []
         return await self._apersist_new_facts(lanlan_name, extracted)
 
+    # ── external import state (sidecar) ──────────────────────────────
+
+    def _external_import_state_path(self, name: str) -> str:
+        from memory import ensure_character_dir
+        return os.path.join(
+            ensure_character_dir(self._config_manager.memory_dir, name),
+            'external_import_state.json',
+        )
+
+    def _load_external_import_state(self, name: str) -> dict:
+        """Best-effort read of the per-character external-import sidecar.
+
+        Missing / corrupt / non-dict payloads degrade to ``{}``: the worst
+        case is re-extracting already-imported days (wasted LLM calls), never
+        data loss, so this read must not fail an import.
+        """
+        path = self._external_import_state_path(name)
+        if os.path.exists(path):
+            try:
+                with open(path, encoding='utf-8') as f:
+                    data = json.load(f)
+                if isinstance(data, dict):
+                    return data
+            except (json.JSONDecodeError, OSError) as e:
+                logger.warning(
+                    f"[FactStore] {name}: 读取 external_import_state 失败，降级为空: {e}"
+                )
+        return {}
+
+    @staticmethod
+    def _state_daily_fingerprints(state: dict) -> set[str]:
+        """Processed-day fingerprint set held by the sidecar state dict."""
+        daily = state.get('daily')
+        fps = daily.get('imported_day_fingerprints') if isinstance(daily, dict) else None
+        if not isinstance(fps, list):
+            return set()
+        return {str(x) for x in fps if x}
+
+    async def _aload_imported_day_fps(self, name: str) -> set[str]:
+        """Union of processed-day fingerprints: sidecar + active fact provenance.
+
+        The ``external_import_state.json`` sidecar is the authoritative record
+        — it is the only carrier for days that persisted no fact (empty
+        extraction / every extracted fact deduped away, Codex P2 follow-up).
+        Fact ``external_import.day_fingerprint`` provenance is merged in for
+        data imported before the sidecar existed (backward compat).
+        """
+        state = await asyncio.to_thread(self._load_external_import_state, name)
+        fps = self._state_daily_fingerprints(state)
+        for f in await self.aload_facts(name):
+            meta = f.get('external_import')
+            if isinstance(meta, dict) and meta.get('day_fingerprint'):
+                fps.add(str(meta['day_fingerprint']))
+        return fps
+
+    async def _arecord_imported_day_fp(self, name: str, fingerprint: str) -> None:
+        """Durably mark one day (by content fingerprint) as processed.
+
+        Serialized under the per-character persist alock (the same lock as
+        fact persistence) so concurrent same-character imports can't lose
+        each other's read-modify-write. Raises ``MaintenanceModeError`` when
+        the cloudsave write fence is up — the caller counts that day as
+        failed and a retry re-extracts it, mirroring the fact path.
+        """
+        async with self._get_persist_alock(name):
+            await asyncio.to_thread(
+                self._record_imported_day_fp_locked, name, fingerprint
+            )
+
+    def _record_imported_day_fp_locked(self, name: str, fingerprint: str) -> None:
+        assert_cloudsave_writable(
+            self._config_manager,
+            operation="save",
+            target=f"memory/{name}/external_import_state.json",
+        )
+        state = self._load_external_import_state(name)
+        fps = self._state_daily_fingerprints(state)
+        if fingerprint in fps:
+            return
+        fps.add(fingerprint)
+        state.setdefault('version', 1)
+        daily = state.get('daily')
+        if not isinstance(daily, dict):
+            daily = {}
+            state['daily'] = daily
+        # 对偶 persona folded_fingerprints：集合语义、sorted 落盘（稳定可 diff）。
+        daily['imported_day_fingerprints'] = sorted(fps)
+        atomic_write_json(
+            self._external_import_state_path(name), state,
+            indent=2, ensure_ascii=False,
+        )
+
     async def aimport_external_daily(
         self, lanlan_name: str, candidates: list[dict], source_format: str,
         imported_at: str,
@@ -1249,11 +1341,18 @@ class FactStore:
         that day from scratch (a partially-persisted day would fingerprint-skip
         forever, Greptile P1).
 
-        Idempotency mirrors persona ``folded_fingerprints``: each persisted fact
-        carries its day's content fingerprint; a re-imported day whose fragments
-        are unchanged is skipped outright — zero LLM calls (Codex P2). Changed
-        content re-extracts; near-identical re-extraction output is absorbed by
-        the same-date FTS5 dedup in ``_apersist_new_facts``.
+        Idempotency mirrors persona ``folded_fingerprints``: every successfully
+        processed day records its content fingerprint in the per-character
+        ``external_import_state.json`` sidecar — including days that persist no
+        fact (empty extraction, or every extracted fact deduped away), which
+        have no provenance carrier and would otherwise re-run the LLM and burn
+        cap quota on every re-import (Codex P2 follow-up). Persisted facts
+        additionally carry the fingerprint in their ``external_import``
+        provenance; the read side merges both sources so pre-sidecar imports
+        keep skipping (see ``_aload_imported_day_fps``). A re-imported day
+        whose fragments are unchanged is skipped outright — zero LLM calls
+        (Codex P2). Changed content re-extracts; near-identical re-extraction
+        output is absorbed by the same-date FTS5 dedup in ``_apersist_new_facts``.
 
         After fingerprint filtering, more than ``EXTERNAL_IMPORT_DAILY_MAX_FILES``
         genuinely-new days raises ``ExternalMemoryImportTooLargeError`` — an
@@ -1274,13 +1373,9 @@ class FactStore:
             by_file.setdefault(str(cand.get("source_file") or ""), []).append(cand)
 
         # 逐日指纹幂等（对偶 persona folded_fingerprints）：已导入且内容未变的
-        # 天直接 skip，不进 LLM。指纹在下方随每条 fact 的 provenance 落盘。
-        existing = await self.aload_facts(lanlan_name)
-        imported_day_fps: set[str] = set()
-        for f in existing:
-            meta = f.get('external_import')
-            if isinstance(meta, dict) and meta.get('day_fingerprint'):
-                imported_day_fps.add(str(meta['day_fingerprint']))
+        # 天直接 skip，不进 LLM。指纹权威记录在 external_import_state sidecar，
+        # 读取时合并旧 fact provenance 向后兼容（见 _aload_imported_day_fps）。
+        imported_day_fps = await self._aload_imported_day_fps(lanlan_name)
 
         day_dates = {
             source_file: next(
@@ -1351,24 +1446,24 @@ class FactStore:
                     return 0, True
                 day_extracted.extend(f for f in extracted if isinstance(f, dict))
             if not day_extracted:
+                # 空抽取天也要落 processed 指纹：没有 fact 载体，不记 sidecar
+                # 的话每次重导都重抽该天并占 cap 配额（Codex P2 follow-up）。
+                await self._arecord_imported_day_fp(lanlan_name, day_fps[source_file])
                 return 0, False
             # 并发缩窗重查：两个同角色 commit 可能都在开头读过 imported_day_fps
             # 才各自跑 LLM；persist 前重读一次，若对方已把同指纹落盘则放弃本次
             # 写入（措辞不同的重复 facts 会绕过精确去重）。剩余极窄的 TOCTOU
             # 窗口由同日期 FTS5 近似去重兜底；前端 in-flight 单飞锁已挡住单
             # 客户端的并发导入（Codex P2）。
-            latest = await self.aload_facts(lanlan_name)
-            for existing_fact in latest:
-                meta = existing_fact.get('external_import')
-                if (
-                    isinstance(meta, dict)
-                    and str(meta.get('day_fingerprint') or '') == day_fps[source_file]
-                ):
-                    logger.info(
-                        f"[FactStore] {lanlan_name}: {source_file} 已被并发导入落盘，"
-                        "放弃本次写入"
-                    )
-                    return 0, False
+            # 重查合并 sidecar + provenance 双源：对方并发导入若是空抽取/全去重
+            # 天，只有 sidecar 有指纹、没有 fact 落盘，只查 facts 会漏。
+            latest_fps = await self._aload_imported_day_fps(lanlan_name)
+            if day_fps[source_file] in latest_fps:
+                logger.info(
+                    f"[FactStore] {lanlan_name}: {source_file} 已被并发导入落盘，"
+                    "放弃本次写入"
+                )
+                return 0, False
             for fact in day_extracted:
                 # Stamp provenance; _apersist_new_facts_locked turns event_date
                 # into event_start_at and tags the entry as external_import.
@@ -1384,6 +1479,11 @@ class FactStore:
             new_facts = await self._apersist_new_facts(
                 lanlan_name, day_extracted, semantic_dedup=True,
             )
+            # 指纹在 facts **之后**落 sidecar（顺序不可换：先指纹后 facts 若中途
+            # 崩溃，重导会被整天 skip、该天内容永久丢失）。全去重天（new_facts
+            # 为空）同样要记——provenance 没有新载体，幂等只能靠 sidecar
+            # （Codex P2 follow-up）。
+            await self._arecord_imported_day_fp(lanlan_name, day_fps[source_file])
             return len(new_facts), False
 
         outcomes = await asyncio.gather(

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -1269,7 +1269,7 @@ class FactStore:
                     return data
             except (json.JSONDecodeError, UnicodeDecodeError, OSError) as e:
                 # UnicodeDecodeError（非法 UTF-8 字节，ValueError 子类，非
-                # JSONDecodeError/OSError）也要降级：_aload_imported_day_fps 在
+                # JSONDecodeError/OSError）也要降级：_acollect_day_fp_sources 在
                 # per-day 隔离**之前**跑，一个损坏 sidecar 冒泡会 abort 整个导入，
                 # 违背 docstring 承诺的「降级空集」（Codex P2）。
                 logger.warning(
@@ -1346,10 +1346,14 @@ class FactStore:
 
         Provenance is read over active + archive (``aload_facts_full``) so a day
         whose facts were archived by ``_archive_absorbed`` (>7 days old) still
-        skips instead of re-extracting. Used only for the up-front skip filter;
-        the persist-time concurrent re-check reads active provenance directly
-        (a rival import that just persisted writes the active list, and a
-        sidecar-only rival must not suppress this request's real facts).
+        skips instead of re-extracting. The production skip filter computes this
+        same union itself from ``_acollect_day_fp_sources`` (it also needs the
+        ``sidecar ∩ provenance`` intersection for the up-front self-heal), so
+        this wrapper is the read-side contract exercised by the sidecar
+        degradation tests. The persist-time concurrent re-check reads active
+        provenance directly (a rival import that just persisted writes the
+        active list, and a sidecar-only rival must not suppress this request's
+        real facts).
         """
         sidecar_fps, provenance_fps = await self._acollect_day_fp_sources(name)
         return sidecar_fps | provenance_fps
@@ -1657,8 +1661,10 @@ class FactStore:
             except Exception:
                 # persist 失败（FTS/JSON 写错等）也要清该天 sidecar：本请求已抽出真实
                 # facts（这天有内容），若并发空抽取先写下 sidecar，persist 失败后它会
-                # 成为唯一载体、压制用户重试 skip 未变日记而永不落盘（Codex）。失败天
-                # 由 gather 计入 failed_days、重试从头重抽。
+                # 成为唯一载体、压制用户重试 skip 未变日记而永不落盘（Codex）。收窄非
+                # 根除：对方空判定在本清理**之后**才落盘的序覆盖不到——失败天标识不
+                # 持久化、无法跨请求围栏，与「任意后续导入 LLM 恰判空即 checkpoint」
+                # 的既定接受面同构。失败天由 gather 计入 failed_days、重试从头重抽。
                 await self._aclear_day_fps(lanlan_name, {day_fps[source_file]})
                 raise
             # 抽出 fact 的天（成功落新 fact，或全去重命中既有）都清掉该天可能残留的

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -1246,7 +1246,11 @@ class FactStore:
                     data = json.load(f)
                 if isinstance(data, dict):
                     return data
-            except (json.JSONDecodeError, OSError) as e:
+            except (json.JSONDecodeError, UnicodeDecodeError, OSError) as e:
+                # UnicodeDecodeError（非法 UTF-8 字节，ValueError 子类，非
+                # JSONDecodeError/OSError）也要降级：_aload_imported_day_fps 在
+                # per-day 隔离**之前**跑，一个损坏 sidecar 冒泡会 abort 整个导入，
+                # 违背 docstring 承诺的「降级空集」（Codex P2）。
                 logger.warning(
                     f"[FactStore] {name}: 读取 external_import_state 失败，降级为空: {e}"
                 )
@@ -1261,9 +1265,24 @@ class FactStore:
             return set()
         return {str(x) for x in fps if x}
 
-    async def _aload_imported_day_fps(
-        self, name: str, *, include_archive: bool = True,
-    ) -> set[str]:
+    @staticmethod
+    def _facts_have_day_fingerprint(facts: list[dict], fingerprint: str) -> bool:
+        """Whether any fact's ``external_import`` provenance carries this day's
+        fingerprint — i.e. the day IS carried by a fact and must NOT get a
+        sidecar entry.
+
+        Covers both a newly appended fact and an existing fact whose provenance
+        was upgraded in place (e.g. ai_disclosure→user_observation on a same-day
+        exact-hash hit): both stamp ``day_fingerprint``, both ride facts.json's
+        rollback lifecycle and self-heal, so a sidecar entry for such a day
+        would outlive a rollback and suppress the re-extraction (Codex P2)."""
+        for f in facts:
+            meta = f.get('external_import')
+            if isinstance(meta, dict) and str(meta.get('day_fingerprint') or '') == fingerprint:
+                return True
+        return False
+
+    async def _aload_imported_day_fps(self, name: str) -> set[str]:
         """Union of processed-day fingerprints from two carriers, split by
         whether the day persisted any fact:
 
@@ -1282,37 +1301,37 @@ class FactStore:
           harmless (it yields nothing new), so a stale / desynced sidecar can
           never lose data.
 
-        ``include_archive=True`` also scans facts_archive.json, covering days
-        whose facts were archived by ``_archive_absorbed`` (>7 days old); their
-        provenance would otherwise vanish from the active list and the day
-        re-extract. The concurrent re-check passes ``False``: a rival import
-        that just persisted a day writes the active list, never the archive, so
-        active + sidecar suffices there without an archive disk read per day.
+        Provenance is read over active + archive (``aload_facts_full``) so a day
+        whose facts were archived by ``_archive_absorbed`` (>7 days old) still
+        skips instead of re-extracting. Used only for the up-front skip filter;
+        the persist-time concurrent re-check reads active provenance directly
+        (a rival import that just persisted writes the active list, and a
+        sidecar-only rival must not suppress this request's real facts).
         """
         state = await asyncio.to_thread(self._load_external_import_state, name)
         fps = self._state_daily_fingerprints(state)
-        facts = (
-            await self.aload_facts_full(name) if include_archive
-            else await self.aload_facts(name)
-        )
-        for f in facts:
+        for f in await self.aload_facts_full(name):
             meta = f.get('external_import')
             if isinstance(meta, dict) and meta.get('day_fingerprint'):
                 fps.add(str(meta['day_fingerprint']))
         return fps
 
     async def _arecord_unpersisted_day_fp(self, name: str, fingerprint: str) -> None:
-        """Best-effort: record a **no-fact-carrier** day's fingerprint in the sidecar.
+        """Best-effort: record a day's fingerprint in the sidecar **iff no fact
+        carries it**.
 
-        Only for days that persisted zero facts (empty extraction / every
-        extracted fact deduped away) — days that did persist facts rely on
-        their provenance instead, keeping the idempotency record inside the
-        same cloudsave lifecycle as the data it guards (see
-        ``_aload_imported_day_fps``).
-
-        Serialized under the per-character persist alock (the same lock as fact
-        persistence) so concurrent same-character imports can't lose each
-        other's read-modify-write.
+        For days that persisted zero facts AND left no provenance for this day
+        — empty extraction, or every extracted fact deduped away with no
+        in-place provenance upgrade. The active-provenance re-check runs
+        **inside** the persist alock (the same lock as fact persistence): a
+        concurrent same-character import that persists this day's facts (a new
+        fact, or an ai_disclosure fact upgraded in place — both stamp
+        ``day_fingerprint`` but the latter returns ``new_facts == []``) either
+        lands before us — we see its provenance and skip the sidecar — or after
+        us, blocked on the lock. So a day that ends up with a fact carrier never
+        also gets a sidecar entry (which would outlive a facts.json rollback and
+        suppress the self-healing re-extraction, Codex P2). No TOCTOU; the same
+        critical section also absorbs the sidecar's own read-modify-write.
 
         Best-effort by design: the sidecar is a pure idempotency accelerator.
         A write failure (disk full / permission; the cloudsave fence is already
@@ -1324,6 +1343,9 @@ class FactStore:
         """
         try:
             async with self._get_persist_alock(name):
+                active = await self.aload_facts(name)
+                if self._facts_have_day_fingerprint(active, fingerprint):
+                    return
                 await asyncio.to_thread(
                     self._record_imported_day_fp_locked, name, fingerprint
                 )
@@ -1489,21 +1511,21 @@ class FactStore:
             if not day_extracted:
                 # 空抽取天：LLM 判该日无 fact，无 fact 载体存指纹，只能靠 sidecar，
                 # 否则每次重导都重抽该天并占 cap 配额（Codex P2 follow-up）。
-                # best-effort：sidecar 写失败退回重抽，不把该天升级为 failed_day。
+                # _arecord 锁内二次确认 active 无该天 provenance 才落（兜并发对方
+                # 已 persist 真实 facts 的情况）；best-effort 写失败退回重抽、不升级
+                # failed_day。
                 await self._arecord_unpersisted_day_fp(lanlan_name, day_fps[source_file])
                 return 0, False
             # 并发缩窗重查：两个同角色 commit 可能都在开头读过 imported_day_fps
-            # 才各自跑 LLM；persist 前重读一次，若对方已把同指纹落盘则放弃本次
-            # 写入（措辞不同的重复 facts 会绕过精确去重）。剩余极窄的 TOCTOU
-            # 窗口由同日期 FTS5 近似去重兜底；前端 in-flight 单飞锁已挡住单
-            # 客户端的并发导入（Codex P2）。
-            # 重查合并 sidecar + active provenance 双源：对方并发导入若是空抽取/
-            # 全去重天，只有 sidecar 有指纹、没有 fact 落盘，只查 facts 会漏。并发
-            # 落盘必在 active（刚写），不在 archive，故此处 include_archive=False。
-            latest_fps = await self._aload_imported_day_fps(
-                lanlan_name, include_archive=False,
-            )
-            if day_fps[source_file] in latest_fps:
+            # 才各自跑 LLM；persist 前重读一次，若对方已把这天真实 facts 落盘则
+            # 放弃本次写入（措辞不同的重复 facts 会绕过精确去重）。剩余极窄的
+            # TOCTOU 窗口由同日期 FTS5 近似去重兜底；前端 in-flight 单飞锁已挡住
+            # 单客户端的并发导入（Codex P2）。
+            # 只认 active fact provenance、**不查 sidecar**：本请求已抽出非空
+            # facts，不能被对方并发的 sidecar-only（空抽取/全去重、无 fact 载体）
+            # 结果挤掉——那会让「无 fact 的 sidecar」压掉真实抽取的 facts（Codex）。
+            active_now = await self.aload_facts(lanlan_name)
+            if self._facts_have_day_fingerprint(active_now, day_fps[source_file]):
                 logger.info(
                     f"[FactStore] {lanlan_name}: {source_file} 已被并发导入落盘，"
                     "放弃本次写入"
@@ -1525,10 +1547,11 @@ class FactStore:
                 lanlan_name, day_extracted, semantic_dedup=True,
             )
             # 有 fact 落盘的天不记 sidecar：指纹已在 fact provenance 里、与 facts
-            # 同处 cloudsave 同步/回滚单元，回滚后 provenance 随 facts 一起消失、
-            # 重导自愈（若额外记 sidecar，facts.json 被云端回滚后 sidecar 残留指纹
-            # 会永久压制该天重抽 → 记忆丢失）。只有全去重天（new_facts 为空、无新
-            # 载体）才落 sidecar，且重抽无害，best-effort 写（Codex P2 follow-up）。
+            # 同处 cloudsave 同步/回滚单元，回滚后一起消失、重导自愈（若额外记
+            # sidecar，回滚后残留指纹永久压制重抽 → 记忆丢失）。new_facts 为空时
+            # 尝试记 sidecar，但 _arecord 会在锁内二次确认 active 无该天 provenance
+            # 才落——兜住「exact-hash 命中把 provenance upgrade 到既有 ai_disclosure
+            # fact」这类 new_facts 为空却有载体的天（Codex P2 follow-up）。
             if not new_facts:
                 await self._arecord_unpersisted_day_fp(lanlan_name, day_fps[source_file])
             return len(new_facts), False

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -208,7 +208,12 @@ class FactStore:
         RELATED_CONTEXT recall of reflection synthesis. Returns a new list; the
         archive never enters the cache.
 
-        A corrupted archive file degrades best-effort to active-only, no raise."""
+        A corrupted archive file degrades best-effort to active-only, no raise
+        (incl. invalid UTF-8: daily import's fingerprint scan now reads the
+        archive via this loader before any per-day isolation, so a non-UTF-8
+        archive must degrade here instead of aborting the whole import — Codex
+        P2). ``UnicodeDecodeError`` is a ``ValueError`` subclass, distinct from
+        ``JSONDecodeError``, so it is listed explicitly."""
         active = self.load_facts(name)
         archive_path = self._facts_archive_path(name)
         if not os.path.exists(archive_path):
@@ -216,7 +221,7 @@ class FactStore:
         try:
             with open(archive_path, encoding='utf-8') as f:
                 archived = json.load(f)
-        except (json.JSONDecodeError, OSError) as e:
+        except (json.JSONDecodeError, UnicodeDecodeError, OSError) as e:
             logger.warning(f"[FactStore] {name}: 读取 archive 失败，降级仅 active: {e}")
             return list(active)
         if not isinstance(archived, list):
@@ -1295,11 +1300,15 @@ class FactStore:
           sidecar entry (see ``_arecord_unpersisted_day_fp``): a sidecar record
           that outlived a facts.json rollback would permanently suppress the
           re-extraction that restores the day.
-        - **Sidecar** (``external_import_state.json``) carries **only** the
-          no-fact-carrier days — empty extraction, or every extracted fact
-          deduped away (Codex P2 follow-up). Re-extracting such a day is
-          harmless (it yields nothing new), so a stale / desynced sidecar can
-          never lose data.
+        - **Sidecar** (``external_import_state.json``) carries **only** days the
+          LLM judged to hold no fact at all (empty extraction). A day whose
+          extracted facts were *all deduped away* is NOT recorded here — its
+          content is already carried by the deduping facts (under a different
+          fingerprint, so a rollback of those facts couldn't self-heal a sidecar
+          entry), so it re-extracts instead (added=0, no data lost — chosen over
+          a fact-carried multi-fingerprint scheme). Re-extracting a truly
+          fact-less day is harmless, so a stale / desynced sidecar never loses
+          data (Codex P2 follow-up).
 
         Provenance is read over active + archive (``aload_facts_full``) so a day
         whose facts were archived by ``_archive_absorbed`` (>7 days old) still
@@ -1320,18 +1329,17 @@ class FactStore:
         """Best-effort: record a day's fingerprint in the sidecar **iff no fact
         carries it**.
 
-        For days that persisted zero facts AND left no provenance for this day
-        — empty extraction, or every extracted fact deduped away with no
-        in-place provenance upgrade. The active-provenance re-check runs
-        **inside** the persist alock (the same lock as fact persistence): a
-        concurrent same-character import that persists this day's facts (a new
-        fact, or an ai_disclosure fact upgraded in place — both stamp
-        ``day_fingerprint`` but the latter returns ``new_facts == []``) either
-        lands before us — we see its provenance and skip the sidecar — or after
-        us, blocked on the lock. So a day that ends up with a fact carrier never
-        also gets a sidecar entry (which would outlive a facts.json rollback and
-        suppress the self-healing re-extraction, Codex P2). No TOCTOU; the same
-        critical section also absorbs the sidecar's own read-modify-write.
+        Called only for days the LLM judged fact-less (empty extraction); a day
+        whose extracted facts all deduped away re-extracts instead of being
+        sidecar-recorded (see ``_aload_imported_day_fps``). The
+        active-provenance re-check runs **inside** the persist alock (the same
+        lock as fact persistence): a concurrent same-character import that
+        persists this day's facts either lands before us — we see its provenance
+        and skip the sidecar — or after us, blocked on the lock. So a day that
+        ends up with a fact carrier never also gets a sidecar entry (which would
+        outlive a facts.json rollback and suppress the self-healing
+        re-extraction, Codex P2). No TOCTOU; the same critical section also
+        absorbs the sidecar's own read-modify-write.
 
         Best-effort by design: the sidecar is a pure idempotency accelerator.
         A write failure (disk full / permission; the cloudsave fence is already
@@ -1377,6 +1385,48 @@ class FactStore:
             indent=2, ensure_ascii=False,
         )
 
+    async def _aclear_day_fp_if_present(self, name: str, fingerprint: str) -> None:
+        """Best-effort: drop a day's fingerprint from the sidecar once a fact
+        carries it, so a fact-backed day never also lives in the sidecar.
+
+        Fires the write only when the sidecar actually holds this fingerprint —
+        a concurrent sidecar-only import (empty / all-dedup LLM outcome) wrote it
+        before this request's real facts landed. Left in place, the day would
+        have both a fact provenance entry and a stale sidecar entry, and a later
+        facts.json rollback would leave the sidecar to suppress the re-extraction
+        that restores the fact (Codex P2). Same per-character alock +
+        best-effort contract as ``_arecord_unpersisted_day_fp``."""
+        try:
+            async with self._get_persist_alock(name):
+                await asyncio.to_thread(self._clear_day_fp_locked, name, fingerprint)
+        except (MaintenanceModeError, OSError) as exc:
+            logger.warning(
+                f"[FactStore] {name}: sidecar 清理陈旧指纹失败（无害，下次导入再清）: {exc}"
+            )
+
+    def _clear_day_fp_locked(self, name: str, fingerprint: str) -> None:
+        path = self._external_import_state_path(name)
+        if not os.path.exists(path):
+            return  # 绝大多数成功天无 sidecar 文件 → 只一次 stat、不碰盘。
+        state = self._load_external_import_state(name)
+        fps = self._state_daily_fingerprints(state)
+        if fingerprint not in fps:
+            return
+        assert_cloudsave_writable(
+            self._config_manager,
+            operation="save",
+            target=f"memory/{name}/external_import_state.json",
+        )
+        fps.discard(fingerprint)
+        daily = state.get('daily')
+        if not isinstance(daily, dict):
+            return
+        daily['imported_day_fingerprints'] = sorted(fps)
+        atomic_write_json(
+            self._external_import_state_path(name), state,
+            indent=2, ensure_ascii=False,
+        )
+
     async def aimport_external_daily(
         self, lanlan_name: str, candidates: list[dict], source_format: str,
         imported_at: str,
@@ -1404,18 +1454,22 @@ class FactStore:
         forever, Greptile P1).
 
         Idempotency mirrors persona ``folded_fingerprints`` via each day's
-        content fingerprint, held by one of two carriers depending on whether
-        the day persisted any fact: days that persisted facts carry it in their
-        ``external_import`` provenance (inside facts.json, so it shares the fact
-        data's cloudsave lifecycle and self-heals on rollback); days with no
-        fact carrier — empty extraction, or every extracted fact deduped away —
-        record it in the ``external_import_state.json`` sidecar, which would
-        otherwise have no home and re-run the LLM + burn cap quota on every
-        re-import (Codex P2 follow-up). The read side unions both (see
-        ``_aload_imported_day_fps``). A re-imported day whose fragments are
-        unchanged is skipped outright — zero LLM calls (Codex P2). Changed
-        content re-extracts; near-identical re-extraction output is absorbed by
-        the same-date FTS5 dedup in ``_apersist_new_facts``.
+        content fingerprint, held by the fact carrier when there is one and by
+        the sidecar only when there is none: days that persisted (or upgraded in
+        place) a fact carry it in their ``external_import`` provenance (inside
+        facts.json, so it shares the fact data's cloudsave lifecycle and
+        self-heals on rollback); days the LLM judged fact-less (empty
+        extraction) record it in the ``external_import_state.json`` sidecar,
+        which would otherwise have no home and re-run the LLM + burn cap quota on
+        every re-import (Codex P2 follow-up). A day whose extracted facts all
+        deduped away is left to re-extract (its content is already carried by
+        the deduping facts under a different fingerprint; recording a sidecar
+        entry that a facts rollback couldn't self-heal was rejected). The read
+        side unions provenance + sidecar (see ``_aload_imported_day_fps``). A
+        re-imported day whose fragments are unchanged is skipped outright — zero
+        LLM calls (Codex P2). Changed content re-extracts; near-identical
+        re-extraction output is absorbed by the same-date FTS5 dedup in
+        ``_apersist_new_facts``.
 
         After fingerprint filtering, more than ``EXTERNAL_IMPORT_DAILY_MAX_FILES``
         genuinely-new days raises ``ExternalMemoryImportTooLargeError`` — an
@@ -1552,8 +1606,16 @@ class FactStore:
             # 尝试记 sidecar，但 _arecord 会在锁内二次确认 active 无该天 provenance
             # 才落——兜住「exact-hash 命中把 provenance upgrade 到既有 ai_disclosure
             # fact」这类 new_facts 为空却有载体的天（Codex P2 follow-up）。
-            if not new_facts:
-                await self._arecord_unpersisted_day_fp(lanlan_name, day_fps[source_file])
+            if new_facts:
+                # 真实 facts 落盘（provenance 载体）：清掉并发 sidecar-only 竞态可能
+                # 残留的该天 sidecar 指纹，维持「有 fact 载体的天不在 sidecar」不变式
+                # （Codex）。绝大多数成功天 sidecar 无此天 → 一次 stat 即返回。
+                await self._aclear_day_fp_if_present(lanlan_name, day_fps[source_file])
+            # else 全去重天（抽出 fact 但全 exact-hash 命中既有、无新载体）：**不记
+            # sidecar**。这天的内容已被既有 fact 承载，但那条 fact 带的是别的指纹、
+            # 与本天新指纹不在同一 cloudsave 回滚单元，记 sidecar 会在 facts 回滚后
+            # 残留压制重抽 → fact 回不来（Codex）。退回每次重导重抽（added=0、不丢
+            # 数据）；只有 LLM 判定完全无 fact 的空抽取天才靠 sidecar。
             return len(new_facts), False
 
         outcomes = await asyncio.gather(

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -488,10 +488,20 @@ class FactStore:
 
     async def _allm_extract_facts(
         self, lanlan_name: str, messages: list,
+        *, treat_malformed_as_failure: bool = False,
     ) -> list[dict] | None:
         """Stage-1: pure extraction. Prompt carries no existing observations
         to avoid self-cycling (the LLM quoting an existing reflection back as a
-        new fact). Returns the raw LLM-extracted list, or None on terminal failure."""
+        new fact). Returns the raw LLM-extracted list, or None on terminal failure.
+
+        ``treat_malformed_as_failure``: a non-array payload (e.g. ``{"facts":
+        [...]}``) is a model-shape failure, not a confirmed empty extraction.
+        The conversation paths tolerate it as ``[]`` (advance the cursor; the
+        window is lossy but recoverable from live chat). Daily import passes
+        ``True`` so a malformed result becomes a failed day (retryable) rather
+        than being checkpointed in the sidecar as a fact-less day — a sidecar
+        checkpoint would skip the LLM on every later import and silently lose
+        that day's facts (Codex P2)."""
         _, _, _, _, name_mapping, _, _, _, _ = await self._config_manager.aget_character_data()
         name_mapping['ai'] = lanlan_name
         conversation_text = self._format_conversation(messages, name_mapping)
@@ -509,6 +519,12 @@ class FactStore:
         if extracted is None:
             return None
         if not isinstance(extracted, list):
+            if treat_malformed_as_failure:
+                logger.warning(
+                    f"[FactStore] {lanlan_name}: Stage-1 返回非数组 "
+                    f"{type(extracted).__name__}，当作抽取失败（可重试，不 checkpoint）"
+                )
+                return None
             logger.warning(
                 f"[FactStore] {lanlan_name}: Stage-1 返回非数组 "
                 f"{type(extracted).__name__}，当作空列表处理"
@@ -1287,6 +1303,24 @@ class FactStore:
                 return True
         return False
 
+    async def _acollect_day_fp_sources(self, name: str) -> tuple[set[str], set[str]]:
+        """The two idempotency carriers, returned separately as
+        ``(sidecar_fps, provenance_fps)``.
+
+        provenance_fps scans active + archive (``aload_facts_full``) so a day
+        whose facts were archived still counts as carried. Callers union the two
+        for the skip filter, and diff them (``sidecar ∩ provenance``) to detect
+        stale sidecar entries a fact now carries — see the up-front self-heal in
+        ``aimport_external_daily``."""
+        state = await asyncio.to_thread(self._load_external_import_state, name)
+        sidecar_fps = self._state_daily_fingerprints(state)
+        provenance_fps: set[str] = set()
+        for f in await self.aload_facts_full(name):
+            meta = f.get('external_import')
+            if isinstance(meta, dict) and meta.get('day_fingerprint'):
+                provenance_fps.add(str(meta['day_fingerprint']))
+        return sidecar_fps, provenance_fps
+
     async def _aload_imported_day_fps(self, name: str) -> set[str]:
         """Union of processed-day fingerprints from two carriers, split by
         whether the day persisted any fact:
@@ -1317,13 +1351,8 @@ class FactStore:
         (a rival import that just persisted writes the active list, and a
         sidecar-only rival must not suppress this request's real facts).
         """
-        state = await asyncio.to_thread(self._load_external_import_state, name)
-        fps = self._state_daily_fingerprints(state)
-        for f in await self.aload_facts_full(name):
-            meta = f.get('external_import')
-            if isinstance(meta, dict) and meta.get('day_fingerprint'):
-                fps.add(str(meta['day_fingerprint']))
-        return fps
+        sidecar_fps, provenance_fps = await self._acollect_day_fp_sources(name)
+        return sidecar_fps | provenance_fps
 
     async def _arecord_unpersisted_day_fp(self, name: str, fingerprint: str) -> None:
         """Best-effort: record a day's fingerprint in the sidecar **iff no fact
@@ -1385,39 +1414,40 @@ class FactStore:
             indent=2, ensure_ascii=False,
         )
 
-    async def _aclear_day_fp_if_present(self, name: str, fingerprint: str) -> None:
-        """Best-effort: drop a day's fingerprint from the sidecar once a fact
-        carries it, so a fact-backed day never also lives in the sidecar.
+    async def _aclear_day_fps(self, name: str, fingerprints: set[str]) -> None:
+        """Best-effort: drop day fingerprints from the sidecar because a fact now
+        carries them, or the day re-extracts — either way they must not linger as
+        stale sidecar entries that a facts rollback couldn't self-heal (Codex P2).
 
-        Fires the write only when the sidecar actually holds this fingerprint —
-        a concurrent sidecar-only import (empty / all-dedup LLM outcome) wrote it
-        before this request's real facts landed. Left in place, the day would
-        have both a fact provenance entry and a stale sidecar entry, and a later
-        facts.json rollback would leave the sidecar to suppress the re-extraction
-        that restores the fact (Codex P2). Same per-character alock +
+        Fires the write only when the sidecar actually holds one of them. Used
+        both for the up-front self-heal (``sidecar ∩ provenance``) and for the
+        per-day clear after a day yields facts. Same per-character alock +
         best-effort contract as ``_arecord_unpersisted_day_fp``."""
+        if not fingerprints:
+            return
         try:
             async with self._get_persist_alock(name):
-                await asyncio.to_thread(self._clear_day_fp_locked, name, fingerprint)
+                await asyncio.to_thread(self._clear_day_fps_locked, name, fingerprints)
         except (MaintenanceModeError, OSError) as exc:
             logger.warning(
                 f"[FactStore] {name}: sidecar 清理陈旧指纹失败（无害，下次导入再清）: {exc}"
             )
 
-    def _clear_day_fp_locked(self, name: str, fingerprint: str) -> None:
+    def _clear_day_fps_locked(self, name: str, fingerprints: set[str]) -> None:
         path = self._external_import_state_path(name)
         if not os.path.exists(path):
-            return  # 绝大多数成功天无 sidecar 文件 → 只一次 stat、不碰盘。
+            return  # 无 sidecar 文件 → 只一次 stat、不碰盘。
         state = self._load_external_import_state(name)
         fps = self._state_daily_fingerprints(state)
-        if fingerprint not in fps:
+        to_drop = fps & fingerprints
+        if not to_drop:
             return
         assert_cloudsave_writable(
             self._config_manager,
             operation="save",
             target=f"memory/{name}/external_import_state.json",
         )
-        fps.discard(fingerprint)
+        fps -= to_drop
         daily = state.get('daily')
         if not isinstance(daily, dict):
             return
@@ -1490,9 +1520,17 @@ class FactStore:
             by_file.setdefault(str(cand.get("source_file") or ""), []).append(cand)
 
         # 逐日指纹幂等（对偶 persona folded_fingerprints）：已导入且内容未变的
-        # 天直接 skip，不进 LLM。双载体合并（有 fact 天靠 provenance，无 fact 天
-        # 靠 sidecar；含 archive 覆盖已归档天，见 _aload_imported_day_fps）。
-        imported_day_fps = await self._aload_imported_day_fps(lanlan_name)
+        # 天直接 skip，不进 LLM。双载体：有 fact 天靠 provenance（含 archive），无
+        # fact 天靠 sidecar。
+        sidecar_fps, provenance_fps = await self._acollect_day_fp_sources(lanlan_name)
+        # skip 前自愈：sidecar 里凡 fact provenance 也持有的指纹 = 陈旧（这天已有
+        # fact 载体、不该在 sidecar）→ 清掉。覆盖 exact-hash upgrade 残留、并发
+        # sidecar-only 残留、以及成功天即时清理失败/进程中断——那次清理在 persist
+        # 后、会被本处 skip 绕过而永不重跑（CodeRabbit + Codex）。
+        stale_sidecar = sidecar_fps & provenance_fps
+        if stale_sidecar:
+            await self._aclear_day_fps(lanlan_name, stale_sidecar)
+        imported_day_fps = sidecar_fps | provenance_fps
 
         day_dates = {
             source_file: next(
@@ -1553,8 +1591,12 @@ class FactStore:
                 )
                 # 只有 LLM 往返占并发槽；写盘走 _apersist_new_facts 的 per-character
                 # 锁自行互斥，放在槽外让别的日子的 LLM 调用尽早起跑。
+                # 畸形非数组当失败天（可重试）：否则会被当空抽取天 checkpoint 进
+                # sidecar、后续导入 skip LLM 而静默丢该天 facts（Codex P2）。
                 async with llm_slots:
-                    extracted = await self._allm_extract_facts(lanlan_name, messages)
+                    extracted = await self._allm_extract_facts(
+                        lanlan_name, messages, treat_malformed_as_failure=True,
+                    )
                 if extracted is None:
                     logger.warning(
                         f"[FactStore] {lanlan_name}: 外部 daily 抽取 LLM 失败，"
@@ -1600,22 +1642,14 @@ class FactStore:
             new_facts = await self._apersist_new_facts(
                 lanlan_name, day_extracted, semantic_dedup=True,
             )
-            # 有 fact 落盘的天不记 sidecar：指纹已在 fact provenance 里、与 facts
-            # 同处 cloudsave 同步/回滚单元，回滚后一起消失、重导自愈（若额外记
-            # sidecar，回滚后残留指纹永久压制重抽 → 记忆丢失）。new_facts 为空时
-            # 尝试记 sidecar，但 _arecord 会在锁内二次确认 active 无该天 provenance
-            # 才落——兜住「exact-hash 命中把 provenance upgrade 到既有 ai_disclosure
-            # fact」这类 new_facts 为空却有载体的天（Codex P2 follow-up）。
-            if new_facts:
-                # 真实 facts 落盘（provenance 载体）：清掉并发 sidecar-only 竞态可能
-                # 残留的该天 sidecar 指纹，维持「有 fact 载体的天不在 sidecar」不变式
-                # （Codex）。绝大多数成功天 sidecar 无此天 → 一次 stat 即返回。
-                await self._aclear_day_fp_if_present(lanlan_name, day_fps[source_file])
-            # else 全去重天（抽出 fact 但全 exact-hash 命中既有、无新载体）：**不记
-            # sidecar**。这天的内容已被既有 fact 承载，但那条 fact 带的是别的指纹、
-            # 与本天新指纹不在同一 cloudsave 回滚单元，记 sidecar 会在 facts 回滚后
-            # 残留压制重抽 → fact 回不来（Codex）。退回每次重导重抽（added=0、不丢
-            # 数据）；只有 LLM 判定完全无 fact 的空抽取天才靠 sidecar。
+            # 抽出 fact 的天（成功落新 fact，或全去重命中既有）都清掉该天可能残留的
+            # sidecar 指纹（并发对方空抽取先写下的）——这些天不该在 sidecar：
+            #  - 成功/upgrade 天：指纹已在 fact provenance，与 facts 同处回滚单元、
+            #    回滚后一起消失重导自愈；残留 sidecar 会在回滚后压制重抽 → 记忆丢失。
+            #  - 全去重天：不记 sidecar，靠「每次重抽自愈」保 rollback-safe（既有 fact
+            #    回滚后重抽会重新 append）；若被并发空抽取的 sidecar 挡住就破坏自愈。
+            # 绝大多数天 sidecar 无此指纹 → 一次 stat 即返回（Codex）。
+            await self._aclear_day_fps(lanlan_name, {day_fps[source_file]})
             return len(new_facts), False
 
         outcomes = await asyncio.gather(

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -1603,7 +1603,18 @@ class FactStore:
                         f"放弃 {source_file}（整天重试重抽）"
                     )
                     return 0, True
-                day_extracted.extend(f for f in extracted if isinstance(f, dict))
+                batch_facts = [f for f in extracted if isinstance(f, dict)]
+                if extracted and not batch_facts:
+                    # 数组非空但无 object 元素（如 ["Master likes tea"]）= schema 失败、
+                    # 非确认空抽取——treat_malformed_as_failure 只挡「非数组」，挡不住
+                    # 「数组套字符串」。当失败天可重试，否则被 checkpoint 成空抽取天、
+                    # 后续导入 skip LLM 静默丢该天 facts（Codex P2）。
+                    logger.warning(
+                        f"[FactStore] {lanlan_name}: 外部 daily 抽取返回无 object 元素的"
+                        f"数组，放弃 {source_file}（整天重试重抽）"
+                    )
+                    return 0, True
+                day_extracted.extend(batch_facts)
             if not day_extracted:
                 # 空抽取天：LLM 判该日无 fact，无 fact 载体存指纹，只能靠 sidecar，
                 # 否则每次重导都重抽该天并占 cap 配额（Codex P2 follow-up）。
@@ -1639,9 +1650,17 @@ class FactStore:
                     "imported_at": imported_at,
                     "day_fingerprint": day_fps[source_file],
                 }
-            new_facts = await self._apersist_new_facts(
-                lanlan_name, day_extracted, semantic_dedup=True,
-            )
+            try:
+                new_facts = await self._apersist_new_facts(
+                    lanlan_name, day_extracted, semantic_dedup=True,
+                )
+            except Exception:
+                # persist 失败（FTS/JSON 写错等）也要清该天 sidecar：本请求已抽出真实
+                # facts（这天有内容），若并发空抽取先写下 sidecar，persist 失败后它会
+                # 成为唯一载体、压制用户重试 skip 未变日记而永不落盘（Codex）。失败天
+                # 由 gather 计入 failed_days、重试从头重抽。
+                await self._aclear_day_fps(lanlan_name, {day_fps[source_file]})
+                raise
             # 抽出 fact 的天（成功落新 fact，或全去重命中既有）都清掉该天可能残留的
             # sidecar 指纹（并发对方空抽取先写下的）——这些天不该在 sidecar：
             #  - 成功/upgrade 天：指纹已在 fact provenance，与 facts 同处回滚单元、

--- a/tests/unit/test_cloudsave_runtime.py
+++ b/tests/unit/test_cloudsave_runtime.py
@@ -1694,6 +1694,30 @@ def test_export_snapshot_emits_single_character_shards_and_meta(tmp_path):
 
 
 @pytest.mark.unit
+def test_export_snapshot_includes_external_import_state_sidecar(tmp_path):
+    # external_import_state sidecar（空/全去重天的逐日幂等账本）必须随 facts 一起
+    # 进快照，否则 cloudsave 用户换机/恢复后这些天丢指纹、重跑 LLM（修复对跨设备
+    # 场景不完整）。加入 MANAGED_MEMORY_FILENAMES 后应被采集。
+    cm = _make_config_manager(tmp_path)
+
+    from utils.cloudsave_runtime import export_local_cloudsave_snapshot
+
+    _write_runtime_state(cm, character_name="小满")
+    atomic_write_json(
+        Path(cm.memory_dir) / "小满" / "external_import_state.json",
+        {"version": 1, "daily": {"imported_day_fingerprints": ["fp-x"]}},
+        ensure_ascii=False, indent=2,
+    )
+    export_local_cloudsave_snapshot(cm)
+
+    staged = cm.cloudsave_dir / "characters" / "小满" / "memory" / "external_import_state.json"
+    assert staged.is_file()
+    assert json.loads(staged.read_text(encoding="utf-8"))["daily"][
+        "imported_day_fingerprints"
+    ] == ["fp-x"]
+
+
+@pytest.mark.unit
 def test_export_cloudsave_character_unit_updates_only_single_character_scope(tmp_path):
     cm = _make_config_manager(tmp_path)
 

--- a/tests/unit/test_daily_external_import.py
+++ b/tests/unit/test_daily_external_import.py
@@ -644,6 +644,48 @@ async def test_malformed_extraction_is_failed_day_not_sidecar_checkpoint():
 
 
 @pytest.mark.asyncio
+async def test_malformed_array_without_objects_is_failed_day():
+    # Codex：数组套字符串（["Master likes tea"]）isinstance(list) 为真、绕过
+    # treat_malformed_as_failure，但过滤 isinstance(dict) 后 day_extracted 空。这是
+    # schema 失败、非确认空抽取——当失败天（可重试），不 checkpoint sidecar。
+    harness = _DailyHarness(lambda journal: ["Master likes tea", "not an object"])
+    candidates = _daily("memories/2026-07-12.md", "2026-07-12", "some journal")
+
+    result = await harness.aimport_external_daily("Neko", candidates, "hermes", "t")
+    assert result == {"added": 0, "days": 1, "failed_days": 1, "skipped_days": 0}
+    assert harness.state_fps == set()             # 无 object 数组不 checkpoint
+
+
+@pytest.mark.asyncio
+async def test_persist_failure_clears_concurrent_sidecar():
+    # Codex：persist 抛异常时也清该天 sidecar（并发空抽取先写下的），否则残留成
+    # 唯一载体、压制用户重试 skip 未变日记而永不落盘。
+    harness_holder = {}
+
+    class _FailPersistHarness(_DailyHarness):
+        async def _apersist_new_facts(
+            self, lanlan_name, extracted, *,
+            default_source="user_observation", semantic_dedup=True,
+        ):
+            # 模拟：并发空抽取已把该天写进 sidecar，且本次 persist 失败。
+            h = harness_holder["h"]
+            fp = h._daily_fingerprint(["went hiking"], event_date="2026-07-12")
+            h.state_fps.add(fp)
+            raise RuntimeError("FTS write failed")
+
+    harness = _FailPersistHarness(
+        lambda journal: [{"text": "real fact", "importance": 5}]
+    )
+    harness_holder["h"] = harness
+    result = await harness.aimport_external_daily(
+        "Neko", _daily("memories/2026-07-12.md", "2026-07-12", "went hiking"),
+        "hermes", "t",
+    )
+    assert result["failed_days"] == 1             # persist 失败 → 失败天（重试重抽）
+    assert harness.state_fps == set()             # 残留 sidecar 被 except 路径清掉
+
+
+@pytest.mark.asyncio
 async def test_provenance_upgraded_day_uses_provenance_not_sidecar():
     # Codex：exact-hash 命中把**本天** day_fingerprint upgrade 到既有 ai_disclosure
     # fact 时，_apersist_new_facts 返回 [] 但这天有 fact 载体（本天指纹打在既有 fact

--- a/tests/unit/test_daily_external_import.py
+++ b/tests/unit/test_daily_external_import.py
@@ -38,6 +38,9 @@ class _DailyHarness(FactStore):
     def _record_imported_day_fp_locked(self, name, fingerprint):
         self.state_fps.add(fingerprint)
 
+    def _clear_day_fp_locked(self, name, fingerprint):
+        self.state_fps.discard(fingerprint)
+
     async def _allm_extract_facts(self, lanlan_name, messages):
         text = "\n".join(getattr(m, "content", "") for m in messages)
         self.extract_inputs.append(text)
@@ -413,10 +416,12 @@ async def test_daily_empty_extraction_day_records_fingerprint_and_skips_reimport
 
 
 @pytest.mark.asyncio
-async def test_daily_all_deduped_day_records_fingerprint_and_skips_reimport():
-    # 编辑过的天抽出的 facts 全部被同日期去重命中（_apersist_new_facts 返回
-    # []）：没有新 fact 载体存新指纹——processed 指纹落 sidecar，重导零 LLM
-    # 调用。
+async def test_daily_all_deduped_day_does_not_record_sidecar_and_reextracts():
+    # 方案 B（用户拍板）：抽出的 facts 全被同日期去重命中（_apersist_new_facts 返回
+    # []）的全去重天**不记 sidecar**——内容已被既有 fact 承载（指纹不同、不在同一
+    # cloudsave 回滚单元），记 sidecar 会在 facts 回滚后残留压制重抽（Codex）。退回
+    # 每次重导重抽（added=0、不丢数据）；只有 LLM 判定完全无 fact 的空抽取天靠
+    # sidecar。
     class _AllDedupedHarness(_DailyHarness):
         async def _apersist_new_facts(
             self, lanlan_name, extracted, *,
@@ -433,11 +438,11 @@ async def test_daily_all_deduped_day_records_fingerprint_and_skips_reimport():
     first = await harness.aimport_external_daily("Neko", candidates, "hermes", "t1")
     assert first == {"added": 0, "days": 1, "failed_days": 0, "skipped_days": 0}
     assert len(harness.extract_inputs) == 1
-    assert len(harness.state_fps) == 1      # 全去重天也落 processed 指纹
+    assert harness.state_fps == set()        # 全去重天不落 sidecar
 
     second = await harness.aimport_external_daily("Neko", candidates, "hermes", "t2")
-    assert second == {"added": 0, "days": 1, "failed_days": 0, "skipped_days": 1}
-    assert len(harness.extract_inputs) == 1  # 重导零新 LLM 调用
+    assert second == {"added": 0, "days": 1, "failed_days": 0, "skipped_days": 0}
+    assert len(harness.extract_inputs) == 2  # 无指纹载体 → 重导重抽（added=0 不丢数据）
 
 
 @pytest.mark.asyncio
@@ -547,6 +552,29 @@ async def test_concurrent_sidecar_only_does_not_suppress_real_facts():
 
 
 @pytest.mark.asyncio
+async def test_success_clears_stale_sidecar_from_concurrent_empty_race():
+    # Codex：并发下对方 sidecar-only（空抽取/全去重）先写这天指纹，本请求随后抽出
+    # 真实 facts 落盘 → 成功天要清掉陈旧 sidecar 指纹，维持「有 fact 载体的天不在
+    # sidecar」不变式（否则 facts 回滚后残留指纹压制自愈）。
+    harness_holder = {}
+
+    def stub(journal):
+        h = harness_holder["h"]
+        fp = h._daily_fingerprint(["went hiking"], event_date="2026-07-12")
+        h.state_fps.add(fp)                       # 对方 sidecar-only 先写
+        return [{"text": "real fact", "importance": 5}]  # 本请求抽出真实 facts
+
+    harness = _DailyHarness(stub)
+    harness_holder["h"] = harness
+    result = await harness.aimport_external_daily(
+        "Neko", _daily("memories/2026-07-12.md", "2026-07-12", "went hiking"),
+        "hermes", "t",
+    )
+    assert result["added"] == 1
+    assert harness.state_fps == set()             # 陈旧 sidecar 指纹被清
+
+
+@pytest.mark.asyncio
 async def test_concurrent_real_facts_before_persist_still_drops_this_write():
     # 并发重查的正路径保留：对方并发已把这天**真实 facts**（有 provenance）落盘，
     # 本请求 persist 前查 active provenance 命中即放弃（措辞不同的重复绕过精确去重）。
@@ -572,17 +600,18 @@ async def test_concurrent_real_facts_before_persist_still_drops_this_write():
 
 
 @pytest.mark.asyncio
-async def test_provenance_upgraded_day_does_not_record_sidecar():
-    # Codex：exact-hash 命中把 provenance upgrade 到既有 ai_disclosure fact 时，
-    # _apersist_new_facts 返回 [] 但这天**有 fact 载体**（provenance 打在既有 fact
-    # 上）。此天不该记 sidecar，否则 facts.json 回滚后残留指纹压制 upgrade 自愈。
+async def test_provenance_upgraded_day_uses_provenance_not_sidecar():
+    # Codex：exact-hash 命中把**本天** day_fingerprint upgrade 到既有 ai_disclosure
+    # fact 时，_apersist_new_facts 返回 [] 但这天有 fact 载体（本天指纹打在既有 fact
+    # 上）。此天不记 sidecar、靠 provenance skip——与「全去重天」相反：全去重天的本天
+    # 指纹谁都没有（既有 fact 带别的指纹）→ 无载体、重导重抽。
     class _UpgradeHarness(_DailyHarness):
         async def _apersist_new_facts(
             self, lanlan_name, extracted, *,
             default_source="user_observation", semantic_dedup=True,
         ):
             self.persisted.append([dict(f) for f in extracted])
-            # 模拟 upgrade：不新增 fact（返回 []），但把 provenance 打到既有 fact 上。
+            # 模拟 upgrade：不新增 fact（返回 []），但把**本天**指纹打到既有 fact 上。
             for fact in extracted:
                 meta = fact.get("_external_import")
                 if isinstance(meta, dict):
@@ -597,9 +626,14 @@ async def test_provenance_upgraded_day_does_not_record_sidecar():
     )
     candidates = _daily("memories/2026-07-12.md", "2026-07-12", "user corroboration")
 
-    result = await harness.aimport_external_daily("Neko", candidates, "hermes", "t")
+    result = await harness.aimport_external_daily("Neko", candidates, "hermes", "t1")
     assert result == {"added": 0, "days": 1, "failed_days": 0, "skipped_days": 0}
     assert harness.state_fps == set()        # 有 provenance 载体 → 不记 sidecar
+
+    # 本天指纹在既有 fact 的 provenance 上 → 重导靠 provenance skip、零新 LLM。
+    second = await harness.aimport_external_daily("Neko", candidates, "hermes", "t2")
+    assert second == {"added": 0, "days": 1, "failed_days": 0, "skipped_days": 1}
+    assert len(harness.extract_inputs) == 1
 
 
 @pytest.mark.asyncio
@@ -677,6 +711,30 @@ async def test_sidecar_corrupt_file_degrades_to_empty_and_recovers(tmp_path):
     # ……且下一次 record 原子重建文件。
     await harness._arecord_unpersisted_day_fp("Neko", "fp-new")
     assert await harness._aload_imported_day_fps("Neko") == {"fp-new"}
+
+
+@pytest.mark.asyncio
+async def test_load_facts_full_non_utf8_archive_degrades_to_active(tmp_path):
+    # Codex：读路径现经 aload_facts_full 扫 archive provenance（在 per-day 隔离前）。
+    # 非法 UTF-8 archive 抛 UnicodeDecodeError（非 JSONDecodeError/OSError）会 abort
+    # 整个导入 → load_facts_full 必须把它降级为仅 active。
+    class _H(FactStore):
+        def _facts_path(self, name):
+            return str(tmp_path / "facts.json")
+
+        def _facts_archive_path(self, name):
+            return str(tmp_path / "facts_archive.json")
+
+    from utils.file_utils import atomic_write_json as _awj
+
+    _awj(str(tmp_path / "facts.json"), [{"id": "a", "text": "active"}],
+         ensure_ascii=False, indent=2)
+    with open(tmp_path / "facts_archive.json", "wb") as f:
+        f.write(b"\xff\xfe not utf-8 \x80\x81")
+
+    harness = _H()
+    result = harness.load_facts_full("Neko")       # 不抛
+    assert [f["id"] for f in result] == ["a"]      # 降级仅 active
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_daily_external_import.py
+++ b/tests/unit/test_daily_external_import.py
@@ -19,17 +19,22 @@ class _DailyHarness(FactStore):
         self._stub = stub                       # journal_text -> list[dict] | None
         self.extract_inputs: list[str] = []
         self.persisted: list[list[dict]] = []
-        self.store: list[dict] = []             # simulated on-disk facts
+        self.store: list[dict] = []             # simulated on-disk facts (active)
+        self.archive: list[dict] = []           # simulated facts_archive.json
         self.state_fps: set[str] = set()        # simulated sidecar (external_import_state.json)
 
     async def aload_facts(self, lanlan_name):
         return self.store
 
+    async def aload_facts_full(self, lanlan_name):
+        # 对偶真实 load_facts_full：active + archive（含已归档天的 provenance）。
+        return self.store + self.archive
+
     # sidecar 只 stub 文件 IO 层：_aload_imported_day_fps 的双源合并逻辑走真实现。
     def _load_external_import_state(self, name):
         return {"daily": {"imported_day_fingerprints": sorted(self.state_fps)}}
 
-    async def _arecord_imported_day_fp(self, lanlan_name, fingerprint):
+    async def _arecord_unpersisted_day_fp(self, lanlan_name, fingerprint):
         self.state_fps.add(fingerprint)
 
     async def _allm_extract_facts(self, lanlan_name, messages):
@@ -435,16 +440,63 @@ async def test_daily_all_deduped_day_records_fingerprint_and_skips_reimport():
 
 
 @pytest.mark.asyncio
-async def test_successful_day_records_sidecar_fingerprint_too():
-    # 成功抽取天 provenance 已带指纹，但 sidecar 同样要记：facts 后续被归档/
-    # 清理后指纹不随载体丢失。
+async def test_successful_day_uses_provenance_not_sidecar():
+    # 有 fact 落盘的成功天**不**记 sidecar：指纹随 fact 存进 provenance、与 facts
+    # 同处 cloudsave 同步/回滚单元。若额外记 sidecar，facts.json 被云端回滚后
+    # sidecar 残留指纹会永久压制该天重抽 → 记忆丢失（回归 A）。重导靠 provenance
+    # skip，零新 LLM。
     harness = _DailyHarness(lambda journal: [{"text": "fact", "importance": 5}])
-    await harness.aimport_external_daily(
-        "Neko", _daily("memories/2026-07-12.md", "2026-07-12", "went hiking"),
-        "hermes", "t",
-    )
+    candidates = _daily("memories/2026-07-12.md", "2026-07-12", "went hiking")
+
+    first = await harness.aimport_external_daily("Neko", candidates, "hermes", "t1")
+    assert first == {"added": 1, "days": 1, "failed_days": 0, "skipped_days": 0}
+    assert harness.state_fps == set()       # 成功天不写 sidecar
     fp = harness._daily_fingerprint(["went hiking"], event_date="2026-07-12")
-    assert harness.state_fps == {fp}
+    assert any(
+        f.get("external_import", {}).get("day_fingerprint") == fp for f in harness.store
+    )                                        # 指纹落在 fact provenance 里
+
+    second = await harness.aimport_external_daily("Neko", candidates, "hermes", "t2")
+    assert second == {"added": 0, "days": 1, "failed_days": 0, "skipped_days": 1}
+    assert len(harness.extract_inputs) == 1  # 靠 provenance skip，零新 LLM
+
+
+@pytest.mark.asyncio
+async def test_archived_day_provenance_still_skips_reimport():
+    # 已导入天的 fact 被 _archive_absorbed 移进 facts_archive.json（从 active 移出）
+    # 后，重导仍要靠 archive 里的 provenance skip——_aload_imported_day_fps 默认
+    # include_archive 覆盖归档天，避免归档后重抽（成功天不再依赖 sidecar 兜底）。
+    harness = _DailyHarness(lambda journal: [{"text": "fact", "importance": 5}])
+    candidates = _daily("memories/2026-07-12.md", "2026-07-12", "went hiking")
+    await harness.aimport_external_daily("Neko", candidates, "hermes", "t1")
+
+    # 模拟归档：active 的 fact 移到 archive。
+    harness.archive.extend(harness.store)
+    harness.store.clear()
+
+    result = await harness.aimport_external_daily("Neko", candidates, "hermes", "t2")
+    assert result == {"added": 0, "days": 1, "failed_days": 0, "skipped_days": 1}
+    assert len(harness.extract_inputs) == 1  # 归档后重导仍 skip，零新 LLM
+
+
+@pytest.mark.asyncio
+async def test_sidecar_write_failure_does_not_fail_the_day():
+    # sidecar 写失败（磁盘满/权限）best-effort 吞掉：空抽取天不因此升级为
+    # failed_day → 整包 HTTP 500（回归 B）。走真实 _arecord_unpersisted_day_fp，
+    # 只让底层写盘抛 OSError。
+    class _FailingSidecarHarness(_DailyHarness):
+        # 恢复真实 best-effort 包裹（父 harness 把它 stub 成 set.add）。
+        _arecord_unpersisted_day_fp = FactStore._arecord_unpersisted_day_fp
+
+        def _record_imported_day_fp_locked(self, name, fingerprint):
+            raise OSError("disk full")
+
+    harness = _FailingSidecarHarness(lambda journal: [])  # 空抽取天
+    candidates = _daily("memories/2026-07-12.md", "2026-07-12", "nothing factual")
+
+    result = await harness.aimport_external_daily("Neko", candidates, "hermes", "t")
+    # 写失败被吞：该天仍算成功（added 0、非 failed），退回下次重导重抽。
+    assert result == {"added": 0, "days": 1, "failed_days": 0, "skipped_days": 0}
 
 
 @pytest.mark.asyncio
@@ -510,15 +562,18 @@ class _SidecarFileHarness(FactStore):
     async def aload_facts(self, name):
         return []
 
+    async def aload_facts_full(self, name):
+        return []
+
 
 @pytest.mark.asyncio
 async def test_sidecar_roundtrip_dedups_and_sorts(tmp_path):
     import json
 
     harness = _SidecarFileHarness(tmp_path)
-    await harness._arecord_imported_day_fp("Neko", "fp-b")
-    await harness._arecord_imported_day_fp("Neko", "fp-a")
-    await harness._arecord_imported_day_fp("Neko", "fp-b")  # 重复 record 幂等
+    await harness._arecord_unpersisted_day_fp("Neko", "fp-b")
+    await harness._arecord_unpersisted_day_fp("Neko", "fp-a")
+    await harness._arecord_unpersisted_day_fp("Neko", "fp-b")  # 重复 record 幂等
 
     assert await harness._aload_imported_day_fps("Neko") == {"fp-a", "fp-b"}
     with open(harness._external_import_state_path("Neko"), encoding="utf-8") as f:
@@ -538,5 +593,5 @@ async def test_sidecar_corrupt_file_degrades_to_empty_and_recovers(tmp_path):
     # 损坏文件降级为空集（最坏重抽一遍，不炸导入）……
     assert await harness._aload_imported_day_fps("Neko") == set()
     # ……且下一次 record 原子重建文件。
-    await harness._arecord_imported_day_fp("Neko", "fp-new")
+    await harness._arecord_unpersisted_day_fp("Neko", "fp-new")
     assert await harness._aload_imported_day_fps("Neko") == {"fp-new"}

--- a/tests/unit/test_daily_external_import.py
+++ b/tests/unit/test_daily_external_import.py
@@ -20,9 +20,17 @@ class _DailyHarness(FactStore):
         self.extract_inputs: list[str] = []
         self.persisted: list[list[dict]] = []
         self.store: list[dict] = []             # simulated on-disk facts
+        self.state_fps: set[str] = set()        # simulated sidecar (external_import_state.json)
 
     async def aload_facts(self, lanlan_name):
         return self.store
+
+    # sidecar 只 stub 文件 IO 层：_aload_imported_day_fps 的双源合并逻辑走真实现。
+    def _load_external_import_state(self, name):
+        return {"daily": {"imported_day_fingerprints": sorted(self.state_fps)}}
+
+    async def _arecord_imported_day_fp(self, lanlan_name, fingerprint):
+        self.state_fps.add(fingerprint)
 
     async def _allm_extract_facts(self, lanlan_name, messages):
         text = "\n".join(getattr(m, "content", "") for m in messages)
@@ -289,6 +297,7 @@ async def test_multi_batch_day_with_failed_batch_persists_nothing_and_retries_fu
     assert first["failed_days"] == 1
     assert harness.persisted == []          # 整天没落盘
     assert harness.store == []              # 无指纹残留
+    assert harness.state_fps == set()       # sidecar 同样无指纹残留
 
     retry = await harness.aimport_external_daily("Neko", candidates, "hermes", "t2")
     assert retry["failed_days"] == 0
@@ -375,3 +384,159 @@ async def test_concurrent_import_detected_before_persist_is_dropped():
     assert result["added"] == 0
     assert result["failed_days"] == 0
     assert harness.persisted == []  # 本次写入被放弃
+
+
+# ── external_import_state sidecar：无 fact 载体天的重导幂等（Codex P2 follow-up）──
+
+
+@pytest.mark.asyncio
+async def test_daily_empty_extraction_day_records_fingerprint_and_skips_reimport():
+    # 空抽取天（LLM 判定该日记无 fact）没有 fact 载体存指纹——processed 指纹
+    # 落 sidecar，重导零 LLM 调用、不再占 cap 配额。
+    harness = _DailyHarness(lambda journal: [])
+    candidates = _daily("memories/2026-07-12.md", "2026-07-12", "nothing factual")
+
+    first = await harness.aimport_external_daily("Neko", candidates, "hermes", "t1")
+    assert first == {"added": 0, "days": 1, "failed_days": 0, "skipped_days": 0}
+    assert len(harness.extract_inputs) == 1
+    assert len(harness.state_fps) == 1      # 空抽取天也落 processed 指纹
+
+    second = await harness.aimport_external_daily("Neko", candidates, "hermes", "t2")
+    assert second == {"added": 0, "days": 1, "failed_days": 0, "skipped_days": 1}
+    assert len(harness.extract_inputs) == 1  # 重导零新 LLM 调用
+
+
+@pytest.mark.asyncio
+async def test_daily_all_deduped_day_records_fingerprint_and_skips_reimport():
+    # 编辑过的天抽出的 facts 全部被同日期去重命中（_apersist_new_facts 返回
+    # []）：没有新 fact 载体存新指纹——processed 指纹落 sidecar，重导零 LLM
+    # 调用。
+    class _AllDedupedHarness(_DailyHarness):
+        async def _apersist_new_facts(
+            self, lanlan_name, extracted, *,
+            default_source="user_observation", semantic_dedup=True,
+        ):
+            self.persisted.append([dict(f) for f in extracted])
+            return []  # 全部判同日期重复，一条都没落盘
+
+    harness = _AllDedupedHarness(
+        lambda journal: [{"text": "already known", "importance": 5}]
+    )
+    candidates = _daily("memories/2026-07-12.md", "2026-07-12", "edited entry")
+
+    first = await harness.aimport_external_daily("Neko", candidates, "hermes", "t1")
+    assert first == {"added": 0, "days": 1, "failed_days": 0, "skipped_days": 0}
+    assert len(harness.extract_inputs) == 1
+    assert len(harness.state_fps) == 1      # 全去重天也落 processed 指纹
+
+    second = await harness.aimport_external_daily("Neko", candidates, "hermes", "t2")
+    assert second == {"added": 0, "days": 1, "failed_days": 0, "skipped_days": 1}
+    assert len(harness.extract_inputs) == 1  # 重导零新 LLM 调用
+
+
+@pytest.mark.asyncio
+async def test_successful_day_records_sidecar_fingerprint_too():
+    # 成功抽取天 provenance 已带指纹，但 sidecar 同样要记：facts 后续被归档/
+    # 清理后指纹不随载体丢失。
+    harness = _DailyHarness(lambda journal: [{"text": "fact", "importance": 5}])
+    await harness.aimport_external_daily(
+        "Neko", _daily("memories/2026-07-12.md", "2026-07-12", "went hiking"),
+        "hermes", "t",
+    )
+    fp = harness._daily_fingerprint(["went hiking"], event_date="2026-07-12")
+    assert harness.state_fps == {fp}
+
+
+@pytest.mark.asyncio
+async def test_imported_day_fps_merges_sidecar_and_fact_provenance():
+    # 读取侧合并双源：sidecar（新）+ fact provenance（sidecar 之前导入的存量，
+    # 向后兼容）——两边各持一天的指纹，重导两天都 skip、零 LLM 调用。
+    harness = _DailyHarness(lambda journal: [{"text": "f", "importance": 5}])
+    fp_sidecar = harness._daily_fingerprint(["day one"], event_date="2026-07-12")
+    fp_provenance = harness._daily_fingerprint(["day two"], event_date="2026-07-13")
+    harness.state_fps.add(fp_sidecar)
+    harness.store.append({
+        "text": "legacy fact", "importance": 5,
+        "external_import": {"day_fingerprint": fp_provenance},
+    })
+
+    result = await harness.aimport_external_daily(
+        "Neko",
+        _daily("memories/2026-07-12.md", "2026-07-12", "day one")
+        + _daily("memories/2026-07-13.md", "2026-07-13", "day two"),
+        "hermes", "t",
+    )
+    assert result == {"added": 0, "days": 2, "failed_days": 0, "skipped_days": 2}
+    assert harness.extract_inputs == []
+
+
+@pytest.mark.asyncio
+async def test_concurrent_sidecar_only_fingerprint_detected_before_persist():
+    # 并发缩窗重查同样合并 sidecar：对方并发导入把「空抽取天」只落进 sidecar
+    # （无 fact 落盘），本方 persist 前重查也必须命中并放弃写入。
+    harness_holder = {}
+
+    def stub(journal):
+        # 模拟「LLM 期间」并发请求把同一天以 sidecar-only 形式标记 processed
+        h = harness_holder["h"]
+        fp = h._daily_fingerprint(["went hiking"], event_date="2026-07-12")
+        h.state_fps.add(fp)
+        return [{"text": "my phrasing", "importance": 5}]
+
+    harness = _DailyHarness(stub)
+    harness_holder["h"] = harness
+    result = await harness.aimport_external_daily(
+        "Neko", _daily("memories/2026-07-12.md", "2026-07-12", "went hiking"),
+        "hermes", "t",
+    )
+    assert result["added"] == 0
+    assert result["failed_days"] == 0
+    assert harness.persisted == []  # 本次写入被放弃
+
+
+# ── sidecar 文件层（真实读写，tmp 目录）──
+
+
+class _SidecarFileHarness(FactStore):
+    """Real sidecar file IO redirected into a tmp dir (no facts, no model)."""
+
+    def __init__(self, tmp_path):
+        super().__init__()
+        self._tmp = tmp_path
+
+    def _external_import_state_path(self, name):
+        return str(self._tmp / f"{name}-external_import_state.json")
+
+    async def aload_facts(self, name):
+        return []
+
+
+@pytest.mark.asyncio
+async def test_sidecar_roundtrip_dedups_and_sorts(tmp_path):
+    import json
+
+    harness = _SidecarFileHarness(tmp_path)
+    await harness._arecord_imported_day_fp("Neko", "fp-b")
+    await harness._arecord_imported_day_fp("Neko", "fp-a")
+    await harness._arecord_imported_day_fp("Neko", "fp-b")  # 重复 record 幂等
+
+    assert await harness._aload_imported_day_fps("Neko") == {"fp-a", "fp-b"}
+    with open(harness._external_import_state_path("Neko"), encoding="utf-8") as f:
+        payload = json.load(f)
+    # 对偶 persona folded_fingerprints：集合语义、sorted 落盘。
+    assert payload["daily"]["imported_day_fingerprints"] == ["fp-a", "fp-b"]
+    assert payload["version"] == 1
+
+
+@pytest.mark.asyncio
+async def test_sidecar_corrupt_file_degrades_to_empty_and_recovers(tmp_path):
+    harness = _SidecarFileHarness(tmp_path)
+    path = harness._external_import_state_path("Neko")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("{corrupt")
+
+    # 损坏文件降级为空集（最坏重抽一遍，不炸导入）……
+    assert await harness._aload_imported_day_fps("Neko") == set()
+    # ……且下一次 record 原子重建文件。
+    await harness._arecord_imported_day_fp("Neko", "fp-new")
+    assert await harness._aload_imported_day_fps("Neko") == {"fp-new"}

--- a/tests/unit/test_daily_external_import.py
+++ b/tests/unit/test_daily_external_import.py
@@ -30,11 +30,12 @@ class _DailyHarness(FactStore):
         # 对偶真实 load_facts_full：active + archive（含已归档天的 provenance）。
         return self.store + self.archive
 
-    # sidecar 只 stub 文件 IO 层：_aload_imported_day_fps 的双源合并逻辑走真实现。
+    # 只 stub sidecar 文件 IO 层：_arecord_unpersisted_day_fp 的 has_carrier 检查
+    # + 锁 + best-effort 包裹走真实实现（state_fps 充当磁盘）。
     def _load_external_import_state(self, name):
         return {"daily": {"imported_day_fingerprints": sorted(self.state_fps)}}
 
-    async def _arecord_unpersisted_day_fp(self, lanlan_name, fingerprint):
+    def _record_imported_day_fp_locked(self, name, fingerprint):
         self.state_fps.add(fingerprint)
 
     async def _allm_extract_facts(self, lanlan_name, messages):
@@ -485,9 +486,8 @@ async def test_sidecar_write_failure_does_not_fail_the_day():
     # failed_day → 整包 HTTP 500（回归 B）。走真实 _arecord_unpersisted_day_fp，
     # 只让底层写盘抛 OSError。
     class _FailingSidecarHarness(_DailyHarness):
-        # 恢复真实 best-effort 包裹（父 harness 把它 stub 成 set.add）。
-        _arecord_unpersisted_day_fp = FactStore._arecord_unpersisted_day_fp
-
+        # 父 harness 已走真实 _arecord_unpersisted_day_fp（best-effort 包裹）；这里
+        # 只让底层写盘抛 OSError。
         def _record_imported_day_fp_locked(self, name, fingerprint):
             raise OSError("disk full")
 
@@ -523,16 +523,42 @@ async def test_imported_day_fps_merges_sidecar_and_fact_provenance():
 
 
 @pytest.mark.asyncio
-async def test_concurrent_sidecar_only_fingerprint_detected_before_persist():
-    # 并发缩窗重查同样合并 sidecar：对方并发导入把「空抽取天」只落进 sidecar
-    # （无 fact 落盘），本方 persist 前重查也必须命中并放弃写入。
+async def test_concurrent_sidecar_only_does_not_suppress_real_facts():
+    # Codex：并发缩窗重查只认 active fact provenance、**不查 sidecar**。对方并发
+    # 的 sidecar-only（空抽取/全去重、无 fact 载体）结果不能挤掉本请求已抽出的
+    # 真实 facts——否则「无 fact 的 sidecar」压掉真实抽取内容。
     harness_holder = {}
 
     def stub(journal):
-        # 模拟「LLM 期间」并发请求把同一天以 sidecar-only 形式标记 processed
+        # 模拟「LLM 期间」对方并发请求把同一天以 sidecar-only 形式标记 processed
         h = harness_holder["h"]
         fp = h._daily_fingerprint(["went hiking"], event_date="2026-07-12")
         h.state_fps.add(fp)
+        return [{"text": "my phrasing", "importance": 5}]  # 本请求抽出真实 facts
+
+    harness = _DailyHarness(stub)
+    harness_holder["h"] = harness
+    result = await harness.aimport_external_daily(
+        "Neko", _daily("memories/2026-07-12.md", "2026-07-12", "went hiking"),
+        "hermes", "t",
+    )
+    assert result["added"] == 1              # 真实 facts 落盘，不被 sidecar-only 挤掉
+    assert len(harness.persisted) == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_real_facts_before_persist_still_drops_this_write():
+    # 并发重查的正路径保留：对方并发已把这天**真实 facts**（有 provenance）落盘，
+    # 本请求 persist 前查 active provenance 命中即放弃（措辞不同的重复绕过精确去重）。
+    harness_holder = {}
+
+    def stub(journal):
+        h = harness_holder["h"]
+        fp = h._daily_fingerprint(["went hiking"], event_date="2026-07-12")
+        h.store.append({
+            "text": "someone else's phrasing", "importance": 5,
+            "external_import": {"day_fingerprint": fp},
+        })
         return [{"text": "my phrasing", "importance": 5}]
 
     harness = _DailyHarness(stub)
@@ -542,8 +568,64 @@ async def test_concurrent_sidecar_only_fingerprint_detected_before_persist():
         "hermes", "t",
     )
     assert result["added"] == 0
-    assert result["failed_days"] == 0
-    assert harness.persisted == []  # 本次写入被放弃
+    assert harness.persisted == []           # 本次写入被放弃
+
+
+@pytest.mark.asyncio
+async def test_provenance_upgraded_day_does_not_record_sidecar():
+    # Codex：exact-hash 命中把 provenance upgrade 到既有 ai_disclosure fact 时，
+    # _apersist_new_facts 返回 [] 但这天**有 fact 载体**（provenance 打在既有 fact
+    # 上）。此天不该记 sidecar，否则 facts.json 回滚后残留指纹压制 upgrade 自愈。
+    class _UpgradeHarness(_DailyHarness):
+        async def _apersist_new_facts(
+            self, lanlan_name, extracted, *,
+            default_source="user_observation", semantic_dedup=True,
+        ):
+            self.persisted.append([dict(f) for f in extracted])
+            # 模拟 upgrade：不新增 fact（返回 []），但把 provenance 打到既有 fact 上。
+            for fact in extracted:
+                meta = fact.get("_external_import")
+                if isinstance(meta, dict):
+                    self.store.append({
+                        "text": "pre-existing ai_disclosure fact",
+                        "external_import": dict(meta),
+                    })
+            return []
+
+    harness = _UpgradeHarness(
+        lambda journal: [{"text": "corroborated", "importance": 6}]
+    )
+    candidates = _daily("memories/2026-07-12.md", "2026-07-12", "user corroboration")
+
+    result = await harness.aimport_external_daily("Neko", candidates, "hermes", "t")
+    assert result == {"added": 0, "days": 1, "failed_days": 0, "skipped_days": 0}
+    assert harness.state_fps == set()        # 有 provenance 载体 → 不记 sidecar
+
+
+@pytest.mark.asyncio
+async def test_empty_day_skips_sidecar_when_concurrent_import_persisted_facts():
+    # Codex：空抽取分支写 sidecar 前也要查 active provenance。若并发对方已把这天
+    # 真实 facts 落盘（有载体），本空抽取请求不该再记 sidecar（那会给「现在有 fact」
+    # 的天留 sidecar、破坏回滚自愈）。
+    harness_holder = {}
+
+    def stub(journal):
+        h = harness_holder["h"]
+        fp = h._daily_fingerprint(["nothing factual"], event_date="2026-07-12")
+        h.store.append({
+            "text": "concurrent real fact", "importance": 5,
+            "external_import": {"day_fingerprint": fp},
+        })
+        return []  # 本请求空抽取
+
+    harness = _DailyHarness(stub)
+    harness_holder["h"] = harness
+    result = await harness.aimport_external_daily(
+        "Neko", _daily("memories/2026-07-12.md", "2026-07-12", "nothing factual"),
+        "hermes", "t",
+    )
+    assert result == {"added": 0, "days": 1, "failed_days": 0, "skipped_days": 0}
+    assert harness.state_fps == set()        # 并发对方已落 provenance → 不记 sidecar
 
 
 # ── sidecar 文件层（真实读写，tmp 目录）──
@@ -593,5 +675,21 @@ async def test_sidecar_corrupt_file_degrades_to_empty_and_recovers(tmp_path):
     # 损坏文件降级为空集（最坏重抽一遍，不炸导入）……
     assert await harness._aload_imported_day_fps("Neko") == set()
     # ……且下一次 record 原子重建文件。
+    await harness._arecord_unpersisted_day_fp("Neko", "fp-new")
+    assert await harness._aload_imported_day_fps("Neko") == {"fp-new"}
+
+
+@pytest.mark.asyncio
+async def test_sidecar_non_utf8_file_degrades_to_empty(tmp_path):
+    # Codex：非法 UTF-8 字节让 json.load 抛 UnicodeDecodeError（ValueError 子类、
+    # 非 JSONDecodeError/OSError）。_aload_imported_day_fps 在 per-day 隔离**前**
+    # 跑，不降级会 abort 整个导入——必须降级为空集，与文本损坏同等对待。
+    harness = _SidecarFileHarness(tmp_path)
+    path = harness._external_import_state_path("Neko")
+    with open(path, "wb") as f:
+        f.write(b"\xff\xfe not valid utf-8 \x80\x81")
+
+    assert await harness._aload_imported_day_fps("Neko") == set()
+    # 且下一次 record 原子重建文件。
     await harness._arecord_unpersisted_day_fp("Neko", "fp-new")
     assert await harness._aload_imported_day_fps("Neko") == {"fp-new"}

--- a/tests/unit/test_daily_external_import.py
+++ b/tests/unit/test_daily_external_import.py
@@ -786,6 +786,34 @@ async def test_sidecar_roundtrip_dedups_and_sorts(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_sidecar_clear_removes_only_targeted_fps(tmp_path):
+    import json
+    import os
+
+    # 对偶 roundtrip 测试：record 有文件层专测，clear 的落盘逻辑（to_drop 交集、
+    # sorted 重写、无文件早退）同样必须打在真实实现上——否则 clear 回归成磁盘
+    # no-op 时套件全绿，skip 前自愈/persist 失败清理/成功天清残留全部静默失效。
+    harness = _SidecarFileHarness(tmp_path)
+    await harness._arecord_unpersisted_day_fp("Neko", "fp-a")
+    await harness._arecord_unpersisted_day_fp("Neko", "fp-b")
+
+    # 只清目标指纹（含集合里混入的未知指纹），不无差别清空。
+    await harness._aclear_day_fps("Neko", {"fp-a", "fp-unknown"})
+    with open(harness._external_import_state_path("Neko"), encoding="utf-8") as f:
+        payload = json.load(f)
+    assert payload["daily"]["imported_day_fingerprints"] == ["fp-b"]
+
+    # 无交集 → 文件内容原样不动。
+    await harness._aclear_day_fps("Neko", {"fp-gone"})
+    with open(harness._external_import_state_path("Neko"), encoding="utf-8") as f:
+        assert json.load(f) == payload
+
+    # 无 sidecar 文件 → 一次 stat 即返回，不创建文件。
+    await harness._aclear_day_fps("hermes", {"fp-x"})
+    assert not os.path.exists(harness._external_import_state_path("hermes"))
+
+
+@pytest.mark.asyncio
 async def test_sidecar_corrupt_file_degrades_to_empty_and_recovers(tmp_path):
     harness = _SidecarFileHarness(tmp_path)
     path = harness._external_import_state_path("Neko")

--- a/tests/unit/test_daily_external_import.py
+++ b/tests/unit/test_daily_external_import.py
@@ -38,13 +38,20 @@ class _DailyHarness(FactStore):
     def _record_imported_day_fp_locked(self, name, fingerprint):
         self.state_fps.add(fingerprint)
 
-    def _clear_day_fp_locked(self, name, fingerprint):
-        self.state_fps.discard(fingerprint)
+    def _clear_day_fps_locked(self, name, fingerprints):
+        self.state_fps -= fingerprints
 
-    async def _allm_extract_facts(self, lanlan_name, messages):
+    async def _allm_extract_facts(
+        self, lanlan_name, messages, *, treat_malformed_as_failure=False,
+    ):
         text = "\n".join(getattr(m, "content", "") for m in messages)
         self.extract_inputs.append(text)
-        return self._stub(text)
+        result = self._stub(text)
+        # 忠实模拟真实 _allm_extract_facts 的非数组处理：daily 传 strict → None
+        # （畸形当失败天，可重试），非 strict → []（对话路径容忍）。
+        if result is not None and not isinstance(result, list):
+            return None if treat_malformed_as_failure else []
+        return result
 
     async def _apersist_new_facts(
         self, lanlan_name, extracted, *,
@@ -597,6 +604,43 @@ async def test_concurrent_real_facts_before_persist_still_drops_this_write():
     )
     assert result["added"] == 0
     assert harness.persisted == []           # 本次写入被放弃
+
+
+@pytest.mark.asyncio
+async def test_stale_sidecar_healed_before_skip():
+    # skip 前自愈（CodeRabbit + Codex）：sidecar 里 fp 同时被 fact provenance 持有 =
+    # 陈旧（这天已有 fact 载体、不该在 sidecar，来自 exact-hash upgrade 残留 / 成功天
+    # 清理失败或中断——那清理在 persist 后、会被 skip 绕过而永不重跑）。开头清掉，
+    # 否则 facts 回滚后陈旧 sidecar 压制重抽自愈。
+    harness = _DailyHarness(lambda journal: [{"text": "x", "importance": 5}])
+    fp = harness._daily_fingerprint(["went hiking"], event_date="2026-07-12")
+    harness.state_fps.add(fp)                     # 陈旧 sidecar 指纹
+    harness.store.append({                        # fact provenance 也持有该天
+        "text": "carried fact", "importance": 5,
+        "external_import": {"day_fingerprint": fp},
+    })
+
+    result = await harness.aimport_external_daily(
+        "Neko", _daily("memories/2026-07-12.md", "2026-07-12", "went hiking"),
+        "hermes", "t",
+    )
+    # 这天靠 provenance skip；陈旧 sidecar 在 skip 前被自愈清除。
+    assert result == {"added": 0, "days": 1, "failed_days": 0, "skipped_days": 1}
+    assert harness.state_fps == set()             # 陈旧 sidecar 已清
+    assert harness.extract_inputs == []           # 零 LLM
+
+
+@pytest.mark.asyncio
+async def test_malformed_extraction_is_failed_day_not_sidecar_checkpoint():
+    # Codex：畸形非数组（如 {"facts": [...]}）是模型格式失败、不是确认空抽取。daily
+    # 传 treat_malformed_as_failure=True → 当 failed_day（可重试），**不**记 sidecar；
+    # 否则会被 checkpoint 成空抽取天、后续导入 skip LLM 静默丢该天 facts。
+    harness = _DailyHarness(lambda journal: {"facts": ["wrapped, not a list"]})
+    candidates = _daily("memories/2026-07-12.md", "2026-07-12", "some journal")
+
+    result = await harness.aimport_external_daily("Neko", candidates, "hermes", "t")
+    assert result == {"added": 0, "days": 1, "failed_days": 1, "skipped_days": 0}
+    assert harness.state_fps == set()             # 畸形不 checkpoint sidecar
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_evidence_extraction.py
+++ b/tests/unit/test_evidence_extraction.py
@@ -104,6 +104,31 @@ async def test_stage1_prompt_has_no_existing_observation_section(tmp_path):
     assert "existing observation" not in text.lower()
 
 
+# ── Stage-1 non-array payload: strict vs lenient ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stage1_non_array_payload_strict_vs_lenient(tmp_path):
+    """treat_malformed_as_failure branches of the REAL method body."""
+    # daily 导入的 harness 复刻了这段分支逻辑，只能钉住调用点传 flag 那一半；
+    # 这里必须打在真实方法体上——若分支被重构回退成无条件 []，畸形
+    # {"facts": [...]} 会被当确认空抽取 checkpoint 进 sidecar、该天永久 skip
+    # LLM 静默丢 facts（本测试即防此假绿）。
+    fs, _cm = _install_factstore(str(tmp_path))
+
+    with patch.object(fs, '_allm_call_with_retries',
+                      new=AsyncMock(return_value={"facts": ["流水账"]})):
+        strict = await fs._allm_extract_facts(
+            "小天", [_FakeMessage("今天没啥事")],
+            treat_malformed_as_failure=True,
+        )
+        lenient = await fs._allm_extract_facts("小天", [_FakeMessage("今天没啥事")])
+    # strict（daily 导入）：畸形 = 失败天，可重试、不 checkpoint。
+    assert strict is None
+    # 非 strict（对话路径）：容忍为 []，行为与 pre-#2394 逐字节一致。
+    assert lenient == []
+
+
 # ── S7: Stage-2 target_id validation rejects hallucinations ─────────
 
 

--- a/tests/unit/test_external_import_concurrency.py
+++ b/tests/unit/test_external_import_concurrency.py
@@ -256,7 +256,7 @@ class _DailyConcurrencyHarness(FactStore):
         return []
 
     async def aload_facts_full(self, lanlan_name):
-        # 隔离真实盘：读路径 _aload_imported_day_fps 现取 active+archive。
+        # 隔离真实盘：读路径（_acollect_day_fp_sources）现取 active+archive。
         return []
 
     # 隔离 sidecar 文件 IO：否则无 fact 载体天会读写真实 memory_dir。
@@ -264,6 +264,12 @@ class _DailyConcurrencyHarness(FactStore):
         return {}
 
     async def _arecord_unpersisted_day_fp(self, lanlan_name, fingerprint):
+        return None
+
+    async def _aclear_day_fps(self, lanlan_name, fingerprints):
+        # 成功/persist 失败天的清理同样要隔离：真实 _clear_day_fps_locked 在
+        # exists 早退**之前**就 ensure_character_dir，会在真实 memory_dir 里
+        # mkdir 幽灵角色目录。
         return None
 
     async def _allm_extract_facts(self, lanlan_name, messages, **_kwargs):

--- a/tests/unit/test_external_import_concurrency.py
+++ b/tests/unit/test_external_import_concurrency.py
@@ -255,6 +255,17 @@ class _DailyConcurrencyHarness(FactStore):
     async def aload_facts(self, lanlan_name):
         return []
 
+    async def aload_facts_full(self, lanlan_name):
+        # 隔离真实盘：读路径 _aload_imported_day_fps 现取 active+archive。
+        return []
+
+    # 隔离 sidecar 文件 IO：否则无 fact 载体天会读写真实 memory_dir。
+    def _load_external_import_state(self, name):
+        return {}
+
+    async def _arecord_unpersisted_day_fp(self, lanlan_name, fingerprint):
+        return None
+
     async def _allm_extract_facts(self, lanlan_name, messages):
         text = "\n".join(getattr(m, "content", "") for m in messages)
         return await self._extract(text)

--- a/tests/unit/test_external_import_concurrency.py
+++ b/tests/unit/test_external_import_concurrency.py
@@ -266,7 +266,7 @@ class _DailyConcurrencyHarness(FactStore):
     async def _arecord_unpersisted_day_fp(self, lanlan_name, fingerprint):
         return None
 
-    async def _allm_extract_facts(self, lanlan_name, messages):
+    async def _allm_extract_facts(self, lanlan_name, messages, **_kwargs):
         text = "\n".join(getattr(m, "content", "") for m in messages)
         return await self._extract(text)
 

--- a/utils/cloudsave_runtime/_shared.py
+++ b/utils/cloudsave_runtime/_shared.py
@@ -112,6 +112,11 @@ MANAGED_MEMORY_FILENAMES = (
     "settings.json",
     "facts.json",
     "facts_archive.json",
+    # 外部导入逐日幂等 sidecar（可选：仅导入过、且有无 fact 载体天的角色才有）。
+    # 必须与 facts.json 同处一个 cloudsave 同步/回滚单元：sidecar 记的是空抽取/
+    # 全去重天的 processed 指纹，若它随云同步而 facts 回滚（或反之）会与账本失配，
+    # 故一起 hash/上传/删除/恢复（缺失文件在各遍历处 is_file/exists 判断跳过）。
+    "external_import_state.json",
     "persona.json",
     "persona_corrections.json",
     "reflections.json",


### PR DESCRIPTION
## 概述

#2383 的 follow-up，落地 Codex review 承诺的两个 defer 场景（threads [3599346248](https://github.com/Project-N-E-K-O/N.E.K.O/pull/2383#discussion_r3599346248) / [3599375011](https://github.com/Project-N-E-K-O/N.E.K.O/pull/2383#discussion_r3599375011)）。

#2383 的 daily 日记导入用逐日内容指纹（`day_fingerprint`）做重导幂等：内容未变的天整体 skip、零 LLM 调用。但该指纹此前只寄生在落盘 fact 的 `external_import` provenance 里。当一天**「LLM 抽取为空」**或**「抽出的 facts 全部被同日期去重命中」**时，没有新 fact 落盘 → 指纹无载体 → 该天每次重导都重跑 LLM 并占 `EXTERNAL_IMPORT_DAILY_MAX_FILES`(45) 配额。

## 实现

新增 per-character sidecar `memory/<name>/external_import_state.json`（原子写 + persist alock 串行 + cloudsave fence），承载**无 fact 载体天**的 processed 指纹。幂等账本按「该天有无 fact」分两个载体：

| 天类型 | 幂等载体 | 理由 |
|---|---|---|
| 有 fact 落盘（成功天） | fact provenance（facts.json / facts_archive.json） | 与 fact 数据同处一个 cloudsave 同步/回滚单元，回滚后随 facts 一起消失、重导自愈 |
| 无 fact 载体（空抽取 / 全去重天） | sidecar | 无 provenance 可寄生；重抽无害（空天无数据、全去重天内容已在库），残留 sidecar 不丢数据 |

- 读取侧 `_aload_imported_day_fps` 合并双源（provenance 覆盖 active+archive、含归档天；sidecar）。
- sidecar 写 best-effort（失败退回重抽，不升级为 failed_day）；与 persona `folded_fingerprints` 对偶（集合语义、sorted 落盘）。
- 纳入 cloudsave 同步白名单 `MANAGED_MEMORY_FILENAMES`，跨设备/恢复/回滚与 facts 一致。

## 回归报告

**改动范围**：`memory/facts.py`（sidecar 逻辑）、`utils/cloudsave_runtime/_shared.py`（白名单）、`tests/unit/*`（测试）。

初版实现（成功天也记 sidecar）经 6 维 × 3 视角对抗审查，发现并修复了相对 #2383 的**两处回归**，外加一处修复不完整：

**回归 A — cloudsave 回滚自愈性破坏（数据丢失，已修）**：初版成功天指纹同时写 facts.json（会同步）与 sidecar。若 facts.json 被 cloud restore / 多设备冲突回滚成不含某天的旧版本，sidecar 残留指纹会永久压制该天重导重抽 → 已导入天记忆再也回不来（#2383 里指纹只在 provenance、随 facts 一起回滚、重导自愈）。**修**：成功天不记 sidecar、skip 判定回到靠 provenance（读扩到 `aload_facts_full` 覆盖 active+archive、含归档天）；sidecar 只承载重抽无害的空/全去重天。

**回归 B — sidecar 写失败升级为 failed_day（已修）**：磁盘满/权限错误时，成功天 facts 已落却报 HTTP 500 + added 少报整天；空/全去重天从「永远成功」变 failed（route 层 `failed_days>0` 即 500）。**修**：`_arecord_unpersisted_day_fp` best-effort，catch `MaintenanceModeError`/`OSError` 后 warning 继续，退回 #2383 重抽语义。（维护态经 route 入口 `assert_cloudsave_writable(operation="import")` 已挡、不可达；仅磁盘 `OSError` 路径可达。）

**修复完整性 C — cloudsave 跨设备（已随本 PR 一并解决）**：sidecar 加入同步白名单后，空/全去重天的指纹随 facts 跨设备，换机/恢复后不再重抽。

**未导入用户 / 存量数据**：
- 从未导入过的用户：根本不触发 `aimport_external_daily`；`_load_external_import_state` 对缺失文件返回 `{}`；缺 sidecar 的角色在 cloudsave 各遍历处 `is_file`/`exists` 判断跳过。**零影响**。
- pre-sidecar 存量（#2383 已导入、只有 provenance）：`_aload_imported_day_fps` 合并 provenance，继续 skip、免重抽（向后兼容）。
- 损坏 sidecar 文件：降级为空集（最坏重抽一遍，不炸导入）。

## 测试

- daily / 并发 / eta：**38 passed**（新增：空抽取天 & 全去重天重导零 LLM、成功天靠 provenance 不记 sidecar、归档天重导仍 skip、sidecar 写失败不 failed、双源合并、并发 sidecar-only 命中）。
- cloudsave：**76 passed**（新增 sidecar 进快照采集集成测试）。
- character_memory rename/delete 回归：**61 passed**（sidecar 随整目录搬/删）。
- 并发 harness 补 sidecar / `aload_facts_full` 隔离（修初版测试污染真实 memory_dir 的缺陷）。
- ruff / docstring-CJK 守卫通过。

## 已知限制（自查确认）

- **混版本 cloudsave 窗口**：本 PR 是 `MANAGED_MEMORY_FILENAMES` 自 #681 以来首次新增条目。旧客户端对含 sidecar 的新版本快照整包 import 会被白名单校验硬拒（fail-closed，无数据损坏，更新客户端即恢复）。改 log+skip 会让残留 sidecar 与恢复的 facts 失配、复活回滚压制重抽的 bug，故硬拒是正确行为；release note 需提示「恢复新版本云存档前先更新客户端」。
- **fail→clear→record 交错**：persist 失败清 sidecar 后、并发空判定才落指纹的序覆盖不到（失败天标识不持久化）。与「任意后续导入 LLM 恰判空即 checkpoint」既定接受面同构，注释已如实标注「收窄非根除」（c1571896c）。

Codex threads 3599346248 / 3599375011 已在此落地。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 外部每日导入在空抽取、并发竞态与失败/回滚场景下保持幂等，避免重复或错误记录。
  - 归档或状态文件损坏/编码异常（非 UTF-8）时自动降级并继续导入，不会因解码问题中断。
  - LLM 返回畸形非数组载荷时按严格/宽松策略区分“失败天可重试”与“空抽取天”。

- **功能改进**
  - 新增外部导入状态文件（sidecar）去重与跨次准确跳过已处理日期，并支持快照同步与恢复。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
