### PR TITLE
Phase 4B：接入 RNNoise/Silero 节流并拆分 ASR 结束权

### DIFF
--- a/docs/benchmarks/index.md
+++ b/docs/benchmarks/index.md
@@ -8,4 +8,8 @@ Benchmark pages are dated evidence, not evergreen performance promises. Compare 
 2. [Merged-server memory follow-up](./runtime-memory-merged-followup-2026-07-15)
 3. [Runtime lifecycle soak](./runtime-memory-soak-2026-07-15)
 
+## 2026-07-19 speech-presence protocol
+
+- [RNNoise / Silero speech-presence benchmark](./voice-presence-rnnoise-silero-2026-07-19)
+
 When adding a benchmark, include the revision or artifact, environment, workload, warm-up period, sample interval, duration, observed metric, and known limitations. Sanitise paths and user data before committing evidence.

--- a/docs/benchmarks/voice-presence-rnnoise-silero-2026-07-19.md
+++ b/docs/benchmarks/voice-presence-rnnoise-silero-2026-07-19.md
@@ -1,0 +1,88 @@
+# RNNoise / Silero speech-presence benchmark protocol
+
+This dated page records the reproducible protocol carried forward from the
+2026-07-19 experiment. It is not an evergreen performance promise and does not
+claim that a new run was performed for this commit.
+
+## Scope
+
+The benchmark asks only whether a clip might contain speech. RNNoise and
+Silero are resource-throttling evidence. They cannot publish a logical final,
+replace provider endpoint authority, or decide which provider is selected.
+
+The online replay consumes one record per microphone chunk:
+
+- actual RNNoise frame count;
+- peak, mean, last, and streaming EMA probabilities;
+- a bounded adaptive baseline;
+- low-cardinality action/count/disagreement shadow metrics.
+
+It does not claim an online continuous-100 ms RNNoise state. The continuous
+100 ms calculation remains an offline candidate experiment so that historical
+results can be compared without silently changing production behavior.
+
+## Corpus and split
+
+Real-device evaluation uses a versioned JSON manifest with boolean labels,
+anonymous device IDs, scenarios, and optional speech-onset timestamps. Audio
+paths are resolved locally and are not written to the report.
+
+Calibration and holdout are split by source group. All clean and SNR variants
+from one source stay in the same partition. Positive strata retain locale;
+negative strata retain scenario; real-device strata retain device and
+scenario. Thresholds are selected from calibration only.
+
+Repository tutorial TTS, synthetic noise, and game sound effects can be used
+for offline exploration, but they must not be presented as real-device
+evidence. A device-independent publication decision requires a separately
+labeled device holdout.
+
+## Runtime paths
+
+- RNNoise uses the real 48 kHz `AudioProcessor` chain and captures its complete
+  per-chunk evidence.
+- Silero is imported from
+  `main_logic.asr_client.endpointing.silero_vad`.
+- Model assets default to
+  `main_logic/asr_client/endpointing/models`.
+- The benchmark does not restore `tools/voice_eval` or a legacy detector shim.
+
+## Report interpretation
+
+Report online and offline results in separate sections. At minimum include
+speech recall, negative specificity, balanced accuracy, F1, calibration and
+holdout counts, runtime revision, environment, CPU real-time factor, and
+observed RSS delta.
+
+A low clip-level false-positive rate is not equivalent to a low number of
+false prewarms per idle hour. Before changing defaults, measure long idle
+sessions, far-field speech, television and echo, overlapping speakers,
+multiple microphones, low-end CPUs, and the packaged Electron runtime.
+
+## Reproduction
+
+```powershell
+uv run python scripts/evaluate_speech_presence.py `
+  --real-device-manifest .\voice-presence-real-device.json `
+  --output .\speech-presence-report.json
+```
+
+The JSON manifest schema is:
+
+```json
+{
+  "schema_version": 1,
+  "clips": [
+    {
+      "id": "idle-fan-01",
+      "path": "recordings/idle-fan-01.wav",
+      "label": false,
+      "device_id": "desktop-usb",
+      "scenario": "real_idle_fan"
+    }
+  ]
+}
+```
+
+Do not commit raw microphone recordings or manifests containing identifying
+paths.

--- a/docs/design/phase4b-voice-throttling.md
+++ b/docs/design/phase4b-voice-throttling.md
@@ -1,0 +1,73 @@
+# Phase 4B voice throttling contract
+
+Phase 4B changes resource scheduling only. It does not change who owns an ASR
+endpoint, how a provider publishes a final transcript, or the microphone PCM
+wire format.
+
+## Evidence boundary
+
+The desktop 48 kHz audio pipeline emits one `RnnoiseEvidence` value for each
+processed input chunk. The value contains the actual RNNoise `frame_count` and
+the chunk's `peak`, `mean`, `last`, and streaming `ema`. A 16 kHz path or an
+unavailable RNNoise runtime reports unavailable evidence rather than inventing
+a one-frame sample.
+
+Evidence follows normal routing, hot-swap buffering, and replay to the
+independent ASR runtime. Core only transports the neutral DTO; it does not
+import endpointing or choose a throttle action.
+
+The production shadow counters are deliberately low-cardinality: action
+counts, evidence-chunk counts, incomplete-chunk counts, and RNNoise/Silero
+disagreement counts. They contain no provider key, transcript, audio, user
+identity, or unbounded label.
+
+## Wake and endpoint ownership
+
+- With optimization off, PCM continues through the detector lifecycle. No
+  synthetic `SPEECH_STARTED` event is emitted.
+- In idle state, quiet RNNoise chunks may stop before lifecycle ingestion.
+- RNNoise onset can prewarm transport without opening a speech candidate.
+- Silero confirmation opens or resumes a candidate.
+- Provider-authority streaming modes never load, pin, or evaluate SmartTurn;
+  their provider remains the final endpoint authority.
+- Still-supported manual streaming modes retain SmartTurn authority so their
+  explicit provider commit path can seal the turn.
+- Segmented providers also retain the configured SmartTurn authority.
+- `WARM_IDLE` and `PREWARMING` buffers are bounded and preserve pre-roll.
+
+Provider selection remains in the existing provider policy. Phase 4B policy
+accepts no provider key and cannot choose a provider.
+
+## Completion and successor safety
+
+SmartTurn completion and provider final each consume an identity-scoped fence.
+A stale or duplicate callback cannot complete a successor candidate. Provider
+final is marked accepted only after the provider-candidate fence succeeds.
+
+PCM arriving after a sealed turn is retained as bounded successor audio.
+Completion, final, and DRAINING-overflow paths preserve or replay that audio
+under session, lifecycle, detector, ingress, and generation fences. Detector
+bindings are released with a fixed upper bound.
+
+## Lifecycle expiry
+
+`PREWARMING` and post-final `WARM_IDLE` have separate TTL scheduling. Every
+timer captures the current epoch plus lifecycle, session, detector, and
+transport identities. A timer that wakes after any identity changes is stale
+and cannot close the successor.
+
+`IndependentAsrRuntime.submit()` always returns `AsrSubmitResult`, including
+the unavailable path. Callers do not infer lifecycle state from a bare
+boolean.
+
+## Evaluation boundary
+
+`scripts/evaluate_speech_presence.py`
+replays the online chunk contract and may also calculate continuous-window
+RNNoise candidates offline. A continuous 100 ms result is experimental
+benchmark evidence only; no production detector keeps that state.
+
+The tool imports Silero only from
+`main_logic.asr_client.endpointing.silero_vad` and defaults to
+`main_logic/asr_client/endpointing/models`. It accepts an explicit labeled
+device manifest and excludes local recording paths from its report.

--- a/main_logic/asr_client/endpointing/activity_evidence.py
+++ b/main_logic/asr_client/endpointing/activity_evidence.py
@@ -1,0 +1,37 @@
+"""Provider-neutral local activity evidence for voice resource throttling."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from main_logic.voice_turn.activity_evidence import RnnoiseEvidence
+from main_logic.voice_turn.contracts import SpeechActivityEvent
+
+
+def _validate_probability(name: str, value: float | None) -> None:
+    if value is not None and not 0.0 <= value <= 1.0:
+        raise ValueError(f"{name} must be within [0, 1]")
+
+
+@dataclass(frozen=True, slots=True)
+class SileroEvidence:
+    """Latest asynchronous Silero activity known to the throttling policy."""
+
+    available: bool
+    activity: SpeechActivityEvent | None = None
+    probability: float | None = None
+
+    def __post_init__(self) -> None:
+        _validate_probability("probability", self.probability)
+        if not self.available and (
+            self.activity is not None or self.probability is not None
+        ):
+            raise ValueError("unavailable Silero evidence cannot carry activity")
+
+
+@dataclass(frozen=True, slots=True)
+class ActivityEvidence:
+    """Evidence bundle that advises resources but never endpoint authority."""
+
+    rnnoise: RnnoiseEvidence
+    silero: SileroEvidence

--- a/main_logic/asr_client/endpointing/detector.py
+++ b/main_logic/asr_client/endpointing/detector.py
@@ -13,6 +13,7 @@ from typing import Generic, Literal, TypeAlias, TypeVar
 from main_logic.voice_turn.contracts import SpeechActivityEvent, TurnEvaluation
 
 from ..lifecycle import VoiceIngressToken, VoiceTurnToken
+from .throttle_policy import ThrottleAction
 
 
 logger = logging.getLogger(__name__)
@@ -59,6 +60,20 @@ class DetectorTurnEvent:
 
 
 @dataclass(frozen=True, slots=True)
+class DetectorPrewarmEvent:
+    ingress: DetectorIngressIdentity
+    candidate: DetectorCandidateKey
+    kind: Literal["prewarm", "continuous"]
+
+
+@dataclass(frozen=True, slots=True)
+class DetectorTransportPrewarmEvent:
+    """Request transport resources without binding or opening a logical turn."""
+
+    ingress: DetectorIngressIdentity
+
+
+@dataclass(frozen=True, slots=True)
 class DetectorRuntimeEvent:
     ingress: DetectorIngressIdentity
     candidate: DetectorCandidateKey | None
@@ -71,7 +86,11 @@ class DetectorRuntimeEvent:
 
 
 DetectorEvent: TypeAlias = (
-    DetectorActivityEvent | DetectorTurnEvent | DetectorRuntimeEvent
+    DetectorActivityEvent
+    | DetectorTurnEvent
+    | DetectorPrewarmEvent
+    | DetectorTransportPrewarmEvent
+    | DetectorRuntimeEvent
 )
 
 
@@ -116,6 +135,9 @@ class DetectorSubmitResult:
     throttle_available: bool
     endpointing_available: bool
     identity: DetectorIngressIdentity | None
+    throttle_action: ThrottleAction | None = None
+    candidate: DetectorCandidateKey | None = None
+    control_event_emitted: bool = False
 
 
 _ControlItem = TypeVar("_ControlItem")

--- a/main_logic/asr_client/endpointing/detector.py
+++ b/main_logic/asr_client/endpointing/detector.py
@@ -37,6 +37,35 @@ class DetectorCandidateKey:
 
 
 @dataclass(frozen=True, slots=True)
+class SmartTurnCompletionFence:
+    """Immutable detector boundary accepted with one SmartTurn completion."""
+
+    detector_epoch: int
+    candidate_generation: int
+    through_sequence_no: int
+    semantic_generation: int
+    semantic_turn_id: int
+    successor_candidate_generation: int
+    successor_present: bool
+
+    @property
+    def candidate(self) -> DetectorCandidateKey:
+        return DetectorCandidateKey(
+            self.detector_epoch,
+            self.candidate_generation,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderCandidateFence:
+    """Immutable detector boundary sealed by one Provider endpoint."""
+
+    detector_epoch: int
+    candidate_generation: int
+    through_sequence_no: int
+
+
+@dataclass(frozen=True, slots=True)
 class BoundDetectorTurn:
     """One-time binding between a detector candidate and a logical ASR turn."""
 

--- a/main_logic/asr_client/endpointing/detector_runtime.py
+++ b/main_logic/asr_client/endpointing/detector_runtime.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Literal, TypeAlias
 
+from main_logic.voice_turn.activity_evidence import RnnoiseEvidence
 from main_logic.voice_turn.contracts import (
     EvaluationStatus,
     SpeechActivityEvent,
@@ -25,12 +26,19 @@ from .detector import (
     DetectorDurationQueue,
     DetectorEvent,
     DetectorIngressIdentity,
+    DetectorPrewarmEvent,
     DetectorSubmitResult,
     DetectorSubmitStatus,
+    DetectorTransportPrewarmEvent,
     DetectorTurnEvent,
 )
 from .silero_vad import SileroActivityGate, SileroVad
 from .smart_turn_v3 import SmartTurnV3
+from .throttle_policy import (
+    ThrottleAction,
+    ThrottleShadowMetrics,
+    VoiceThrottlePolicy,
+)
 from ..lifecycle import VoiceIngressToken, VoiceTurnToken
 from ..provider_policy import AsrProviderPolicy
 
@@ -879,6 +887,7 @@ class DetectorFeedResult:
     events: tuple[SpeechActivityEvent, ...]
     throttle_available: bool
     endpointing_available: bool = True
+    throttle_action: ThrottleAction | None = None
 
 
 class SmartTurnReadiness(Enum):
@@ -937,6 +946,11 @@ class DetectorRuntime:
         self._closed = False
         self._rnnoise_onset_probability = rnnoise_onset_probability
         self._resource_optimization_enabled = bool(resource_optimization_enabled)
+        self._throttle_policy = VoiceThrottlePolicy(
+            resource_optimization_enabled=self._resource_optimization_enabled,
+            bootstrap_onset=rnnoise_onset_probability,
+        )
+        self._policy_event_candidate: DetectorCandidateKey | None = None
         self._speech_active = False
         self._events: list[SpeechActivityEvent] = []
         self._semantic_adapter: _VoiceTurnAdapter | None = None
@@ -965,7 +979,10 @@ class DetectorRuntime:
         self._deferred_completions: dict[
             DetectorCandidateKey, DetectorIngressIdentity
         ] = {}
-        if provider_policy is not None and provider_policy.endpoint_authority == "smart_turn":
+        if (
+            provider_policy is not None
+            and provider_policy.endpoint_authority == "smart_turn"
+        ):
             if on_turn_complete is None and on_event is None:
                 raise ValueError(
                     "SmartTurn DetectorRuntime requires a completion consumer"
@@ -982,6 +999,8 @@ class DetectorRuntime:
 
             async def commit(_generation: int, _buffer_epoch: int, _turn_id: int) -> None:
                 self._candidate_open = False
+                self._policy_event_candidate = None
+                self._throttle_policy.reset_candidate_activity()
                 if self._defer_turn_complete:
                     self._deferred_turn_complete = True
                     return
@@ -1068,6 +1087,10 @@ class DetectorRuntime:
     @property
     def candidate_open(self) -> bool:
         return self._candidate_open
+
+    @property
+    def throttle_shadow_metrics(self) -> ThrottleShadowMetrics:
+        return self._throttle_policy.shadow_metrics
 
     @property
     def queued_audio_ms(self) -> int:
@@ -1305,6 +1328,8 @@ class DetectorRuntime:
             self._detector_epoch += 1
             self._candidate_generation = 0
             self._candidate_open = False
+            self._policy_event_candidate = None
+            self._throttle_policy.reset_candidate_activity()
             self._ingress_token = None
             self._bound_turns.clear()
             self._deferred_completions.clear()
@@ -1324,6 +1349,9 @@ class DetectorRuntime:
         *,
         speech_probability: float | None = None,
         rnnoise_available: bool | None = None,
+        rnnoise_evidence: RnnoiseEvidence | None = None,
+        ingress_token: VoiceIngressToken | None = None,
+        allow_baseline_update: bool = False,
     ) -> DetectorFeedResult:
         if not isinstance(pcm16, bytes) or len(pcm16) % 2:
             raise ValueError("DetectorRuntime requires complete PCM16 bytes")
@@ -1336,7 +1364,7 @@ class DetectorRuntime:
         adapter = self._semantic_adapter
         if adapter is not None:
             self._events.clear()
-            ingress_token = self._ingress_token or VoiceIngressToken(
+            effective_ingress = ingress_token or self._ingress_token or VoiceIngressToken(
                 session_epoch=0,
                 connection_id="detector-feed-compat",
                 lease_generation=0,
@@ -1345,18 +1373,25 @@ class DetectorRuntime:
             )
             submitted = await self.submit_audio(
                 pcm16,
-                ingress_token=ingress_token,
+                ingress_token=effective_ingress,
                 sample_rate_hz=16_000,
                 speech_probability=speech_probability,
-                rnnoise_available=rnnoise_available,
+                rnnoise_available=bool(rnnoise_available),
+                rnnoise_evidence=rnnoise_evidence,
+                allow_baseline_update=allow_baseline_update,
             )
             if submitted.status is DetectorSubmitStatus.SKIPPED_QUIET:
-                return DetectorFeedResult((), submitted.throttle_available)
+                return DetectorFeedResult(
+                    (),
+                    submitted.throttle_available,
+                    throttle_action=submitted.throttle_action,
+                )
             if submitted.status is not DetectorSubmitStatus.ACCEPTED:
                 return DetectorFeedResult(
                     (),
                     submitted.throttle_available,
                     endpointing_available=submitted.endpointing_available,
+                    throttle_action=submitted.throttle_action,
                 )
             await adapter.wait_idle()
             if adapter.failed:
@@ -1369,6 +1404,7 @@ class DetectorRuntime:
                     (),
                     False,
                     endpointing_available=endpointing_available,
+                    throttle_action=submitted.throttle_action,
                 )
             events = tuple(self._events)
             if any(
@@ -1380,18 +1416,40 @@ class DetectorRuntime:
                 for event in events
             ):
                 self._speech_active = True
-            return DetectorFeedResult(events, adapter.throttle_available)
+            return DetectorFeedResult(
+                events,
+                adapter.throttle_available,
+                throttle_action=submitted.throttle_action,
+            )
         async with self._lock:
             if self._closed or not self._available:
                 return DetectorFeedResult((), False)
-            if (
-                self._resource_optimization_enabled
-                and rnnoise_available
-                and speech_probability is not None
-                and not self._speech_active
-                and speech_probability < self._rnnoise_onset_probability
-            ):
-                return DetectorFeedResult((), True)
+            effective_ingress = ingress_token or VoiceIngressToken(
+                session_epoch=0,
+                connection_id="detector-feed-compat",
+                lease_generation=0,
+                route_generation=0,
+                audio_generation=0,
+            )
+            if self._ingress_token is None:
+                self._ingress_token = effective_ingress
+            elif self._ingress_token != effective_ingress:
+                return DetectorFeedResult((), False, endpointing_available=False)
+            evidence = rnnoise_evidence or RnnoiseEvidence.from_legacy_probability(
+                speech_probability,
+                available=bool(rnnoise_available),
+            )
+            throttle = self._throttle_policy.decide(
+                evidence,
+                candidate_open=self._candidate_open,
+                allow_baseline_update=allow_baseline_update,
+            )
+            if throttle.action is ThrottleAction.SKIP_IDLE_PCM:
+                return DetectorFeedResult(
+                    (),
+                    True,
+                    throttle_action=throttle.action,
+                )
             if not self._load_attempted:
                 self._load_attempted = True
                 try:
@@ -1399,14 +1457,38 @@ class DetectorRuntime:
                 except Exception:
                     self._available = False
                 if not self._available:
-                    return DetectorFeedResult((), False)
-            # PC 48k 已经过 RNNoise：低概率环境音在尚未进入说话态时
-            # 不唤醒 Silero；移动端 16k 没有该概率，仍完整运行 Silero。
+                    return DetectorFeedResult(
+                        (),
+                        False,
+                        throttle_action=throttle.action,
+                    )
             try:
                 events = tuple(await asyncio.to_thread(self._gate.feed, pcm16))
             except Exception:
                 self._available = False
-                return DetectorFeedResult((), False)
+                return DetectorFeedResult(
+                    (),
+                    False,
+                    throttle_action=throttle.action,
+                )
+            self._candidate_open = True
+            self._sequence_no += 1
+            identity = DetectorIngressIdentity(
+                ingress_token=effective_ingress,
+                detector_epoch=self._detector_epoch,
+                sequence_no=self._sequence_no,
+            )
+            candidate = DetectorCandidateKey(
+                self._detector_epoch,
+                self._candidate_generation,
+            )
+            if (
+                throttle.action is ThrottleAction.PREWARM
+                and self._on_event is not None
+                and self._policy_event_candidate != candidate
+            ):
+                self._policy_event_candidate = candidate
+                await self._on_event(DetectorTransportPrewarmEvent(identity))
             if any(
                 event
                 in {
@@ -1416,8 +1498,13 @@ class DetectorRuntime:
                 for event in events
             ):
                 self._speech_active = True
-        return DetectorFeedResult(events, True)
-
+            for event in events:
+                self._throttle_policy.observe_silero(event)
+        return DetectorFeedResult(
+            events,
+            True,
+            throttle_action=throttle.action,
+        )
     async def submit_audio(
         self,
         pcm16: bytes,
@@ -1426,6 +1513,8 @@ class DetectorRuntime:
         sample_rate_hz: int,
         speech_probability: float | None,
         rnnoise_available: bool,
+        rnnoise_evidence: RnnoiseEvidence | None = None,
+        allow_baseline_update: bool = False,
     ) -> DetectorSubmitResult:
         """Validate and enqueue one frame without waiting for detector inference."""
 
@@ -1481,18 +1570,22 @@ class DetectorRuntime:
                 True,
                 None,
             )
-        if (
-            self._resource_optimization_enabled
-            and rnnoise_available
-            and speech_probability is not None
-            and not self._candidate_open
-            and speech_probability < self._rnnoise_onset_probability
-        ):
+        evidence = rnnoise_evidence or RnnoiseEvidence.from_legacy_probability(
+            speech_probability,
+            available=rnnoise_available,
+        )
+        throttle = self._throttle_policy.decide(
+            evidence,
+            candidate_open=self._candidate_open,
+            allow_baseline_update=allow_baseline_update,
+        )
+        if throttle.action is ThrottleAction.SKIP_IDLE_PCM:
             return DetectorSubmitResult(
                 DetectorSubmitStatus.SKIPPED_QUIET,
                 adapter.throttle_available,
                 True,
                 None,
+                throttle.action,
             )
         self._candidate_open = True
         await self._ensure_semantic_started(adapter)
@@ -1515,11 +1608,11 @@ class DetectorRuntime:
             self._detector_epoch += 1
             self._candidate_generation = 0
             self._candidate_open = False
+            self._policy_event_candidate = None
+            self._throttle_policy.reset_candidate_activity()
             self._ingress_token = None
             self._bound_turns.clear()
             self._deferred_completions.clear()
-            # Mirror reset(): a deferred completion from the overflowed epoch
-            # must not leak into the fresh epoch via release_deferred_turn.
             self._defer_turn_complete = False
             self._deferred_turn_complete = False
             self._semantic_generation += 1
@@ -1540,13 +1633,39 @@ class DetectorRuntime:
                 None,
             )
         self._sequence_no = next_sequence
+        candidate = DetectorCandidateKey(
+            identity.detector_epoch,
+            self._candidate_generation,
+        )
+        control_event_emitted = False
+        if (
+            self._on_event is not None
+            and self._policy_event_candidate != candidate
+            and throttle.action
+            in {ThrottleAction.PREWARM, ThrottleAction.PROCESS_PCM}
+        ):
+            self._policy_event_candidate = candidate
+            await self._on_event(
+                DetectorPrewarmEvent(
+                    ingress=identity,
+                    candidate=candidate,
+                    kind=(
+                        "continuous"
+                        if throttle.action is ThrottleAction.PROCESS_PCM
+                        else "prewarm"
+                    ),
+                )
+            )
+            control_event_emitted = True
         return DetectorSubmitResult(
             DetectorSubmitStatus.ACCEPTED,
             adapter.throttle_available,
             True,
             identity,
+            throttle.action,
+            candidate,
+            control_event_emitted,
         )
-
     async def _reset_after_overflow(
         self,
         adapter: _VoiceTurnAdapter,
@@ -1588,6 +1707,8 @@ class DetectorRuntime:
             self._sequence_no = 0
             self._ingress_token = None
             self._candidate_open = False
+            self._policy_event_candidate = None
+            self._throttle_policy.reset_candidate_activity()
             self._bound_turns.clear()
             self._deferred_completions.clear()
             self._speech_active = False
@@ -1662,6 +1783,8 @@ class DetectorRuntime:
             self._detector_epoch += 1
             self._candidate_generation = 0
             self._candidate_open = False
+            self._policy_event_candidate = None
+            self._throttle_policy.reset_candidate_activity()
             self._ingress_token = None
             self._bound_turns.clear()
             self._deferred_completions.clear()
@@ -1699,6 +1822,8 @@ class DetectorRuntime:
             self._detector_epoch += 1
             self._candidate_generation = 0
             self._candidate_open = False
+            self._policy_event_candidate = None
+            self._throttle_policy.reset_candidate_activity()
             self._ingress_token = None
             self._bound_turns.clear()
             self._deferred_completions.clear()

--- a/main_logic/asr_client/endpointing/detector_runtime.py
+++ b/main_logic/asr_client/endpointing/detector_runtime.py
@@ -1167,6 +1167,7 @@ class DetectorRuntime:
                     await on_turn_complete()
 
             async def activity(event: SpeechActivityEvent) -> None:
+                self._throttle_policy.observe_silero(event)
                 self._events.append(event)
 
             async def scoped_activity(

--- a/main_logic/asr_client/endpointing/detector_runtime.py
+++ b/main_logic/asr_client/endpointing/detector_runtime.py
@@ -465,6 +465,12 @@ class _VoiceTurnAdapter:
                 or item.detector_identity.sequence_no <= fence[1]
             ):
                 return
+            item = _AudioItem(
+                identity=self._identity,
+                pcm16=item.pcm16,
+                duration_us=item.duration_us,
+                detector_identity=item.detector_identity,
+            )
         if self._evaluation_task is not None:
             self._evaluation_tail.append(item)
             self._evaluation_tail_duration_us += item.duration_us
@@ -1054,6 +1060,7 @@ class DetectorRuntime:
         self._semantic_coordinator: TurnCoordinator | None = None
         self._semantic_started = False
         self._semantic_generation = 0
+        self._deferred_completion_identity_advanced = False
         self._semantic_turn_id = 1
         self._on_endpointing_failure = on_endpointing_failure
         self._on_turn_complete = on_turn_complete
@@ -1140,6 +1147,7 @@ class DetectorRuntime:
                     self._throttle_policy.reset_candidate_activity()
                 if self._defer_turn_complete:
                     self._deferred_turn_complete = True
+                    self._deferred_completion_identity_advanced = fence is not None
                     return
                 # 当前轮 seal 后立即把检测身份推进到下一轮。旧 provider final
                 # 到达前，新语音只做本地语义判断，完成信号延迟发布。
@@ -1481,6 +1489,7 @@ class DetectorRuntime:
             self._deferred_completions.clear()
             self._completion_fences.clear()
             self._provider_candidate_fence = None
+            self._deferred_completion_identity_advanced = False
             self._provider_discarded_through_sequence_no = None
             # A deferred completion belongs to the invalidated epoch; keeping
             # the flags would let release_deferred_turn spuriously advance the
@@ -1725,12 +1734,13 @@ class DetectorRuntime:
             )
             self._provider_discarded_through_sequence_no = None
             successor_present = self._sequence_no > successor_floor
-            if not successor_present:
+            successor_confirmed = successor_present and self._speech_active
+            if not successor_confirmed:
                 self._candidate_open = False
                 self._speech_active = False
                 self._policy_event_candidate = None
                 self._throttle_policy.reset_candidate_activity()
-            return successor_present
+            return successor_confirmed
 
     async def submit_audio(
         self,
@@ -1839,6 +1849,7 @@ class DetectorRuntime:
             self._throttle_policy.reset_candidate_activity()
             self._ingress_token = None
             self._bound_turns.clear()
+            self._deferred_completion_identity_advanced = False
             self._deferred_completions.clear()
             self._completion_fences.clear()
             self._provider_candidate_fence = None
@@ -1954,6 +1965,7 @@ class DetectorRuntime:
                     self._semantic_adapter.unpin_smart_turn()
                 self._defer_turn_complete = False
                 self._deferred_turn_complete = False
+                self._deferred_completion_identity_advanced = False
                 self._semantic_generation += 1
                 self._semantic_turn_id += 1
                 adapter = self._semantic_adapter
@@ -1985,13 +1997,16 @@ class DetectorRuntime:
             if self._deferred_turn_complete:
                 self._deferred_turn_complete = False
                 self._defer_turn_complete = True
-                self._semantic_generation += 1
-                self._semantic_turn_id += 1
-                await self._semantic_adapter.reset(
-                    generation=self._semantic_generation,
-                    buffer_epoch=0,
-                    utterance_id=self._semantic_turn_id,
-                )
+                identity_advanced = self._deferred_completion_identity_advanced
+                self._deferred_completion_identity_advanced = False
+                if not identity_advanced:
+                    self._semantic_generation += 1
+                    self._semantic_turn_id += 1
+                    await self._semantic_adapter.reset(
+                        generation=self._semantic_generation,
+                        buffer_epoch=0,
+                        utterance_id=self._semantic_turn_id,
+                    )
                 callback = self._on_turn_complete
         if callback is not None:
             # 不持有 detector lock 调用 Core，避免 Core 清理时反向 reset 死锁。

--- a/main_logic/asr_client/endpointing/detector_runtime.py
+++ b/main_logic/asr_client/endpointing/detector_runtime.py
@@ -31,6 +31,8 @@ from .detector import (
     DetectorSubmitStatus,
     DetectorTransportPrewarmEvent,
     DetectorTurnEvent,
+    ProviderCandidateFence,
+    SmartTurnCompletionFence,
 )
 from .silero_vad import SileroActivityGate, SileroVad
 from .smart_turn_v3 import SmartTurnV3
@@ -102,6 +104,10 @@ class _VoiceTurnAdapter:
         gate: SileroActivityGate,
         coordinator: TurnCoordinator,
         on_commit: Callable[[int, int, int], Awaitable[None]],
+        on_completion_fence: Callable[
+            [int, int, int, DetectorIngressIdentity], _Identity
+        ]
+        | None = None,
         on_activity: Callable[[SpeechActivityEvent], Awaitable[None]] | None = None,
         on_scoped_commit: Callable[
             [int, int, int, DetectorIngressIdentity], Awaitable[None]
@@ -139,6 +145,7 @@ class _VoiceTurnAdapter:
         self._gate = gate
         self._coordinator = coordinator
         self._on_commit = on_commit
+        self._on_completion_fence = on_completion_fence
         self._on_activity = on_activity
         self._on_scoped_commit = on_scoped_commit
         self._on_scoped_activity = on_scoped_activity
@@ -148,6 +155,9 @@ class _VoiceTurnAdapter:
                 max_frames=queue_maxsize,
             )
         )
+        self._evaluation_tail_capacity_us = queue_capacity_ms * 1_000
+        self._evaluation_tail: list[_AudioItem] = []
+        self._evaluation_tail_duration_us = 0
         self._continuation_timeout_seconds = continuation_timeout_seconds
         self._max_endpoint_wait_seconds = max_endpoint_wait_seconds
         self._smart_turn_required = smart_turn_required
@@ -181,6 +191,7 @@ class _VoiceTurnAdapter:
         self._resources_closed = False
         self._closed = False
         self._commit_dispatched: set[_Identity] = set()
+        self._successor_audio_fence: tuple[_Identity, int, _Identity] | None = None
         self._smart_turn_pin_count = 0
 
     async def start(self) -> None:
@@ -278,6 +289,18 @@ class _VoiceTurnAdapter:
         duration_us = (
             samples * 1_000_000 + sample_rate_hz - 1
         ) // sample_rate_hz
+        if (
+            self._evaluation_task is not None
+            and self._evaluation_tail_duration_us
+            + self._queue.audio_duration_us
+            + duration_us
+            > self._evaluation_tail_capacity_us
+        ):
+            # Surface the shared duration budget at ingress so DetectorRuntime
+            # can use its existing whole-candidate backpressure recovery. Once
+            # an item reaches the consumer it must remain replayable if the
+            # in-flight evaluation completes the predecessor turn.
+            raise asyncio.QueueFull
         self._queue.put_audio_nowait(
             _AudioItem(
                 (generation, buffer_epoch, utterance_id),
@@ -433,7 +456,18 @@ class _VoiceTurnAdapter:
         if self._identity is None:
             self._identity = item.identity
         if item.identity != self._identity:
-            return
+            fence = self._successor_audio_fence
+            if (
+                fence is None
+                or item.detector_identity is None
+                or item.identity != fence[0]
+                or self._identity != fence[2]
+                or item.detector_identity.sequence_no <= fence[1]
+            ):
+                return
+        if self._evaluation_task is not None:
+            self._evaluation_tail.append(item)
+            self._evaluation_tail_duration_us += item.duration_us
         self._latest_detector_identity = item.detector_identity
         self._coordinator.push_audio(item.pcm16)
         if self._vad_degraded:
@@ -575,6 +609,9 @@ class _VoiceTurnAdapter:
     async def _process_evaluation_result(self, item: _EvaluationResultItem) -> None:
         self._smart_turn_evaluation_ms = item.evaluation_ms
         self._evaluation_task = None
+        evaluation_tail = tuple(self._evaluation_tail)
+        self._evaluation_tail.clear()
+        self._evaluation_tail_duration_us = 0
         reevaluate = self._reevaluation_requested
         reevaluation_reason = self._reevaluation_reason or item.reason
         self._reevaluation_requested = False
@@ -617,7 +654,41 @@ class _VoiceTurnAdapter:
             return
         if status is EvaluationStatus.OK and decision is TurnDecision.COMPLETE:
             self._strict_endpoint_deadline = None
-            self._dispatch_commit(item.identity, item.detector_identity)
+            active_identity = item.identity
+            if (
+                self._on_completion_fence is not None
+                and item.detector_identity is not None
+            ):
+                active_identity = self._on_completion_fence(
+                    *item.identity,
+                    item.detector_identity,
+                )
+                if active_identity != item.identity:
+                    await self._process_reset(
+                        active_identity,
+                        requester=asyncio.current_task(),
+                    )
+                    self._successor_audio_fence = (
+                        item.identity,
+                        item.detector_identity.sequence_no,
+                        active_identity,
+                    )
+            completion_published = self._dispatch_commit(
+                item.identity,
+                item.detector_identity,
+                active_identity=active_identity,
+            )
+            if completion_published is not None:
+                await completion_published
+            for tail_item in evaluation_tail:
+                await self._process_audio(
+                    _AudioItem(
+                        identity=active_identity,
+                        pcm16=tail_item.pcm16,
+                        duration_us=tail_item.duration_us,
+                        detector_identity=tail_item.detector_identity,
+                    )
+                )
             return
         if status is EvaluationStatus.OK and decision is TurnDecision.INCOMPLETE:
             if reevaluate:
@@ -676,6 +747,9 @@ class _VoiceTurnAdapter:
         self._reevaluation_reason = None
         self._strict_endpoint_deadline = None
         self._latest_detector_identity = None
+        self._evaluation_tail.clear()
+        self._evaluation_tail_duration_us = 0
+        self._successor_audio_fence = None
         await self._coordinator.reset()
         await asyncio.to_thread(self._gate.reset)
         self._commit_dispatched.clear()
@@ -825,34 +899,56 @@ class _VoiceTurnAdapter:
         self,
         identity: _Identity,
         detector_identity: DetectorIngressIdentity | None = None,
-    ) -> None:
-        if self._closed or identity != self._identity:
-            return
+        *,
+        active_identity: _Identity | None = None,
+    ) -> asyncio.Future[None] | None:
+        expected_identity = active_identity or identity
+        if self._closed or expected_identity != self._identity:
+            return None
         if identity in self._commit_dispatched:
-            return
+            return None
         self._commit_dispatched.add(identity)
+        completion_published = asyncio.get_running_loop().create_future()
 
         async def commit() -> None:
             try:
-                if self._closed or self._failed or identity != self._identity:
+                if (
+                    self._closed
+                    or self._failed
+                    or expected_identity != self._identity
+                ):
                     return
                 if self._on_scoped_commit is not None and detector_identity is not None:
                     await self._on_scoped_commit(*identity, detector_identity)
-                    if self._closed or self._failed or identity != self._identity:
+                    if (
+                        self._closed
+                        or self._failed
+                        or expected_identity != self._identity
+                    ):
                         return
-                if self._closed or self._failed or identity != self._identity:
+                if not completion_published.done():
+                    completion_published.set_result(None)
+                if (
+                    self._closed
+                    or self._failed
+                    or expected_identity != self._identity
+                ):
                     return
                 await self._on_commit(*identity)
             except asyncio.CancelledError:
                 raise
             except Exception:
                 self._report_failure("runtime_error", "consumer")
+            finally:
+                if not completion_published.done():
+                    completion_published.set_result(None)
 
         task = asyncio.create_task(
             commit(), name="asr-voice-turn-commit"
         )
         self._callback_tasks.add(task)
         task.add_done_callback(self._callback_tasks.discard)
+        return completion_published
 
 
 def _create_voice_turn_adapter(
@@ -923,6 +1019,7 @@ class DetectorRuntime:
         resource_optimization_enabled: bool = True,
         provider_policy: AsrProviderPolicy | None = None,
         coordinator: TurnCoordinator | None = None,
+        throttle_policy: VoiceThrottlePolicy | None = None,
         on_turn_complete: Callable[[], Awaitable[None]] | None = None,
         on_endpointing_failure: Callable[[], Awaitable[None]] | None = None,
         on_event: Callable[[DetectorEvent], Awaitable[None]] | None = None,
@@ -946,7 +1043,7 @@ class DetectorRuntime:
         self._closed = False
         self._rnnoise_onset_probability = rnnoise_onset_probability
         self._resource_optimization_enabled = bool(resource_optimization_enabled)
-        self._throttle_policy = VoiceThrottlePolicy(
+        self._throttle_policy = throttle_policy or VoiceThrottlePolicy(
             resource_optimization_enabled=self._resource_optimization_enabled,
             bootstrap_onset=rnnoise_onset_probability,
         )
@@ -979,6 +1076,11 @@ class DetectorRuntime:
         self._deferred_completions: dict[
             DetectorCandidateKey, DetectorIngressIdentity
         ] = {}
+        self._completion_fences: dict[
+            tuple[int, int, int], SmartTurnCompletionFence
+        ] = {}
+        self._provider_candidate_fence: ProviderCandidateFence | None = None
+        self._provider_discarded_through_sequence_no: int | None = None
         if (
             provider_policy is not None
             and provider_policy.endpoint_authority == "smart_turn"
@@ -997,26 +1099,62 @@ class DetectorRuntime:
             )
             self._semantic_coordinator = semantic_coordinator
 
-            async def commit(_generation: int, _buffer_epoch: int, _turn_id: int) -> None:
-                self._candidate_open = False
+            def completion_fence(
+                generation: int,
+                buffer_epoch: int,
+                turn_id: int,
+                identity: DetectorIngressIdentity,
+            ) -> _Identity:
+                successor_present = self._sequence_no > identity.sequence_no
+                fence = SmartTurnCompletionFence(
+                    detector_epoch=identity.detector_epoch,
+                    candidate_generation=self._candidate_generation,
+                    through_sequence_no=identity.sequence_no,
+                    semantic_generation=generation,
+                    semantic_turn_id=turn_id,
+                    successor_candidate_generation=self._candidate_generation + 1,
+                    successor_present=successor_present,
+                )
+                self._completion_fences[(generation, buffer_epoch, turn_id)] = fence
+                self._semantic_generation += 1
+                self._semantic_turn_id += 1
+                self._candidate_generation = fence.successor_candidate_generation
                 self._policy_event_candidate = None
-                self._throttle_policy.reset_candidate_activity()
+                if not successor_present:
+                    self._candidate_open = False
+                    self._throttle_policy.reset_candidate_activity()
+                return (
+                    self._semantic_generation,
+                    buffer_epoch,
+                    self._semantic_turn_id,
+                )
+
+            async def commit(generation: int, buffer_epoch: int, turn_id: int) -> None:
+                fence = self._completion_fences.pop(
+                    (generation, buffer_epoch, turn_id),
+                    None,
+                )
+                if fence is None:
+                    self._candidate_open = False
+                    self._policy_event_candidate = None
+                    self._throttle_policy.reset_candidate_activity()
                 if self._defer_turn_complete:
                     self._deferred_turn_complete = True
                     return
                 # 当前轮 seal 后立即把检测身份推进到下一轮。旧 provider final
                 # 到达前，新语音只做本地语义判断，完成信号延迟发布。
                 self._defer_turn_complete = True
-                self._semantic_generation += 1
-                self._semantic_turn_id += 1
-                self._candidate_generation += 1
-                adapter = self._semantic_adapter
-                if adapter is not None:
-                    await adapter.reset(
-                        generation=self._semantic_generation,
-                        buffer_epoch=0,
-                        utterance_id=self._semantic_turn_id,
-                    )
+                if fence is None:
+                    self._semantic_generation += 1
+                    self._semantic_turn_id += 1
+                    self._candidate_generation += 1
+                    adapter = self._semantic_adapter
+                    if adapter is not None:
+                        await adapter.reset(
+                            generation=self._semantic_generation,
+                            buffer_epoch=0,
+                            utterance_id=self._semantic_turn_id,
+                        )
                 if on_turn_complete is not None:
                     await on_turn_complete()
 
@@ -1041,35 +1179,33 @@ class DetectorRuntime:
                 )
 
             async def scoped_commit(
-                _generation: int,
-                _buffer_epoch: int,
-                _turn_id: int,
+                generation: int,
+                buffer_epoch: int,
+                turn_id: int,
                 identity: DetectorIngressIdentity,
             ) -> None:
                 if self._on_event is None or identity.detector_epoch != self._detector_epoch:
                     return
-                candidate = DetectorCandidateKey(
-                    identity.detector_epoch,
-                    self._candidate_generation,
+                fence = self._completion_fences.get(
+                    (generation, buffer_epoch, turn_id)
                 )
-                bound_turn = self._bound_turns.get(candidate)
-                if bound_turn is None:
-                    self._deferred_completions[candidate] = identity
-                    return
-                await self._on_event(
-                    DetectorTurnEvent(
-                        ingress=identity,
-                        bound_turn=bound_turn,
-                        kind="complete",
+                candidate = (
+                    fence.candidate
+                    if fence is not None
+                    else DetectorCandidateKey(
+                        identity.detector_epoch,
+                        self._candidate_generation,
                     )
                 )
-                self._bound_turns.pop(candidate, None)
+                if not await self._publish_bound_completion(candidate, identity):
+                    self._deferred_completions[candidate] = identity
 
             self._semantic_adapter = _VoiceTurnAdapter(
                 vad=self._vad,
                 gate=self._gate,
                 coordinator=semantic_coordinator,
                 on_commit=commit,
+                on_completion_fence=completion_fence,
                 on_activity=activity,
                 on_scoped_commit=scoped_commit,
                 on_scoped_activity=scoped_activity,
@@ -1137,16 +1273,26 @@ class DetectorRuntime:
         self._bound_turns[candidate] = bound
         deferred = self._deferred_completions.pop(candidate, None)
         if deferred is not None:
-            if self._on_event is not None:
-                await self._on_event(
-                    DetectorTurnEvent(
-                        ingress=deferred,
-                        bound_turn=bound,
-                        kind="complete",
-                    )
-                )
-            self._bound_turns.pop(candidate, None)
+            await self._publish_bound_completion(candidate, deferred)
         return bound
+
+    async def _publish_bound_completion(
+        self,
+        candidate: DetectorCandidateKey,
+        identity: DetectorIngressIdentity,
+    ) -> bool:
+        bound_turn = self._bound_turns.pop(candidate, None)
+        if bound_turn is None:
+            return False
+        if self._on_event is not None:
+            await self._on_event(
+                DetectorTurnEvent(
+                    ingress=identity,
+                    bound_turn=bound_turn,
+                    kind="complete",
+                )
+            )
+        return True
 
     async def force_speech_started(
         self,
@@ -1333,6 +1479,9 @@ class DetectorRuntime:
             self._ingress_token = None
             self._bound_turns.clear()
             self._deferred_completions.clear()
+            self._completion_fences.clear()
+            self._provider_candidate_fence = None
+            self._provider_discarded_through_sequence_no = None
             # A deferred completion belongs to the invalidated epoch; keeping
             # the flags would let release_deferred_turn spuriously advance the
             # fresh epoch's first candidate.
@@ -1439,9 +1588,12 @@ class DetectorRuntime:
                 speech_probability,
                 available=bool(rnnoise_available),
             )
+            candidate_admission_open = bool(
+                self._candidate_open or self._provider_candidate_fence is not None
+            )
             throttle = self._throttle_policy.decide(
                 evidence,
-                candidate_open=self._candidate_open,
+                candidate_open=candidate_admission_open,
                 allow_baseline_update=allow_baseline_update,
             )
             if throttle.action is ThrottleAction.SKIP_IDLE_PCM:
@@ -1505,6 +1657,81 @@ class DetectorRuntime:
             True,
             throttle_action=throttle.action,
         )
+
+    async def seal_provider_candidate(self) -> ProviderCandidateFence | None:
+        """Seal local detector activity after a streaming Provider endpoint."""
+
+        async with self._lock:
+            if self._closed or self._semantic_adapter is not None:
+                return None
+            existing = self._provider_candidate_fence
+            if existing is not None:
+                return existing
+            fence = ProviderCandidateFence(
+                detector_epoch=self._detector_epoch,
+                candidate_generation=self._candidate_generation,
+                through_sequence_no=self._sequence_no,
+            )
+            self._provider_candidate_fence = fence
+            self._provider_discarded_through_sequence_no = None
+            self._candidate_generation += 1
+            self._candidate_open = False
+            self._speech_active = False
+            self._policy_event_candidate = None
+            self._throttle_policy.reset_candidate_activity()
+            return fence
+
+    async def discard_provider_successor(
+        self,
+        fence: ProviderCandidateFence,
+    ) -> bool:
+        """Discard only successor activity while preserving the sealed fence."""
+
+        async with self._lock:
+            if (
+                self._closed
+                or self._semantic_adapter is not None
+                or fence != self._provider_candidate_fence
+                or fence.detector_epoch != self._detector_epoch
+            ):
+                return False
+            await asyncio.to_thread(self._gate.reset)
+            self._provider_discarded_through_sequence_no = self._sequence_no
+            self._candidate_generation += 1
+            self._candidate_open = False
+            self._speech_active = False
+            self._policy_event_candidate = None
+            self._throttle_policy.reset_candidate_activity()
+            return True
+
+    async def complete_provider_candidate(
+        self,
+        fence: ProviderCandidateFence,
+    ) -> bool | None:
+        """Consume one Provider fence and report whether successor PCM exists."""
+
+        async with self._lock:
+            if (
+                self._closed
+                or fence != self._provider_candidate_fence
+                or fence.detector_epoch != self._detector_epoch
+            ):
+                return None
+            self._provider_candidate_fence = None
+            successor_floor = max(
+                fence.through_sequence_no,
+                self._provider_discarded_through_sequence_no
+                or fence.through_sequence_no,
+            )
+            self._provider_discarded_through_sequence_no = None
+            successor_present = self._sequence_no > successor_floor
+            if not successor_present:
+                self._candidate_open = False
+                self._speech_active = False
+                self._policy_event_candidate = None
+                self._throttle_policy.reset_candidate_activity()
+            return successor_present
+
     async def submit_audio(
         self,
         pcm16: bytes,
@@ -1613,6 +1840,9 @@ class DetectorRuntime:
             self._ingress_token = None
             self._bound_turns.clear()
             self._deferred_completions.clear()
+            self._completion_fences.clear()
+            self._provider_candidate_fence = None
+            self._provider_discarded_through_sequence_no = None
             self._defer_turn_complete = False
             self._deferred_turn_complete = False
             self._semantic_generation += 1
@@ -1711,6 +1941,9 @@ class DetectorRuntime:
             self._throttle_policy.reset_candidate_activity()
             self._bound_turns.clear()
             self._deferred_completions.clear()
+            self._completion_fences.clear()
+            self._provider_candidate_fence = None
+            self._provider_discarded_through_sequence_no = None
             self._speech_active = False
             self._prepare_token = None
             self._prepare_epoch = None
@@ -1750,15 +1983,8 @@ class DetectorRuntime:
                 return
             self._defer_turn_complete = False
             if self._deferred_turn_complete:
-                completed_candidate = DetectorCandidateKey(
-                    self._detector_epoch,
-                    self._candidate_generation,
-                )
                 self._deferred_turn_complete = False
                 self._defer_turn_complete = True
-                self._bound_turns.pop(completed_candidate, None)
-                self._deferred_completions.pop(completed_candidate, None)
-                self._candidate_generation += 1
                 self._semantic_generation += 1
                 self._semantic_turn_id += 1
                 await self._semantic_adapter.reset(
@@ -1788,6 +2014,9 @@ class DetectorRuntime:
             self._ingress_token = None
             self._bound_turns.clear()
             self._deferred_completions.clear()
+            self._completion_fences.clear()
+            self._provider_candidate_fence = None
+            self._provider_discarded_through_sequence_no = None
             watch_task, self._failure_watch_task = self._failure_watch_task, None
             if watch_task is not None:
                 watch_task.cancel()
@@ -1827,6 +2056,9 @@ class DetectorRuntime:
             self._ingress_token = None
             self._bound_turns.clear()
             self._deferred_completions.clear()
+            self._completion_fences.clear()
+            self._provider_candidate_fence = None
+            self._provider_discarded_through_sequence_no = None
             self._smart_turn_readiness = SmartTurnReadiness.FAILED
             callback = self._on_endpointing_failure
             if callback is not None and not self._closed:

--- a/main_logic/asr_client/endpointing/detector_runtime.py
+++ b/main_logic/asr_client/endpointing/detector_runtime.py
@@ -1740,7 +1740,7 @@ class DetectorRuntime:
                 self._speech_active = False
                 self._policy_event_candidate = None
                 self._throttle_policy.reset_candidate_activity()
-            return successor_confirmed
+            return successor_present
 
     async def submit_audio(
         self,

--- a/main_logic/asr_client/endpointing/throttle_policy.py
+++ b/main_logic/asr_client/endpointing/throttle_policy.py
@@ -1,0 +1,237 @@
+"""Provider-neutral policy for local voice resource decisions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from main_logic.voice_turn.activity_evidence import RnnoiseEvidence
+from main_logic.voice_turn.contracts import SpeechActivityEvent
+
+from .activity_evidence import ActivityEvidence, SileroEvidence
+
+
+class ThrottleAction(Enum):
+    SKIP_IDLE_PCM = "skip_idle_pcm"
+    PREWARM = "prewarm"
+    OPEN_CANDIDATE = "open_candidate"
+    KEEP_CANDIDATE_OPEN = "keep_candidate_open"
+    PROCESS_PCM = "process_pcm"
+
+
+class ThrottleStrategy(Enum):
+    RNNOISE_ONLY = "rnnoise_only"
+    SILERO_ONLY = "silero_only"
+    RNNOISE_PREWARM_SILERO_CONFIRM = "rnnoise_prewarm_silero_confirm"
+
+
+@dataclass(frozen=True, slots=True)
+class ThrottleDecision:
+    action: ThrottleAction
+    evidence: ActivityEvidence
+    onset_threshold: float
+    shadow_actions: tuple[tuple[ThrottleStrategy, ThrottleAction], ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class ThrottleShadowMetrics:
+    evidence_chunk_count: int
+    incomplete_chunk_count: int
+    rnnoise_trigger_count: int
+    silero_trigger_count: int
+    rnnoise_silero_disagreement_count: int
+
+
+class VoiceThrottlePolicy:
+    """Use local evidence only to manage resources, never endpoint authority."""
+
+    def __init__(
+        self,
+        *,
+        resource_optimization_enabled: bool,
+        bootstrap_onset: float = 0.35,
+        baseline_margin: float = 0.12,
+        minimum_onset: float = 0.20,
+        maximum_onset: float = 0.65,
+        baseline_alpha: float = 0.05,
+        minimum_baseline_samples: int = 20,
+    ) -> None:
+        for name, value in (
+            ("bootstrap_onset", bootstrap_onset),
+            ("baseline_margin", baseline_margin),
+            ("minimum_onset", minimum_onset),
+            ("maximum_onset", maximum_onset),
+            ("baseline_alpha", baseline_alpha),
+        ):
+            if not 0.0 <= value <= 1.0:
+                raise ValueError(f"{name} must be within [0, 1]")
+        if minimum_onset > maximum_onset:
+            raise ValueError("minimum_onset cannot exceed maximum_onset")
+        if minimum_baseline_samples <= 0:
+            raise ValueError("minimum_baseline_samples must be positive")
+        self.resource_optimization_enabled = bool(
+            resource_optimization_enabled
+        )
+        self._bootstrap_onset = bootstrap_onset
+        self._baseline_margin = baseline_margin
+        self._minimum_onset = minimum_onset
+        self._maximum_onset = maximum_onset
+        self._baseline_alpha = baseline_alpha
+        self._minimum_baseline_samples = minimum_baseline_samples
+        self._baseline: float | None = None
+        self._baseline_samples = 0
+        self._silero = SileroEvidence(False)
+        self._evidence_chunk_count = 0
+        self._incomplete_chunk_count = 0
+        self._shadow_trigger_counts = {
+            strategy: 0 for strategy in ThrottleStrategy
+        }
+        self._rnnoise_silero_disagreement_count = 0
+
+    @property
+    def baseline(self) -> float | None:
+        return self._baseline
+
+    @property
+    def onset_threshold(self) -> float:
+        if (
+            self._baseline is None
+            or self._baseline_samples < self._minimum_baseline_samples
+        ):
+            return self._bootstrap_onset
+        return min(
+            self._maximum_onset,
+            max(self._minimum_onset, self._baseline + self._baseline_margin),
+        )
+
+    def observe_silero(
+        self,
+        activity: SpeechActivityEvent,
+        *,
+        available: bool = True,
+        probability: float | None = None,
+    ) -> None:
+        self._silero = SileroEvidence(available, activity, probability)
+
+    def reset_candidate_activity(self) -> None:
+        """Forget candidate-scoped VAD state while retaining ambient baseline."""
+
+        self._silero = SileroEvidence(self._silero.available)
+
+    @property
+    def shadow_metrics(self) -> ThrottleShadowMetrics:
+        return ThrottleShadowMetrics(
+            evidence_chunk_count=self._evidence_chunk_count,
+            incomplete_chunk_count=self._incomplete_chunk_count,
+            rnnoise_trigger_count=self._shadow_trigger_counts[
+                ThrottleStrategy.RNNOISE_ONLY
+            ],
+            silero_trigger_count=self._shadow_trigger_counts[
+                ThrottleStrategy.SILERO_ONLY
+            ],
+            rnnoise_silero_disagreement_count=(
+                self._rnnoise_silero_disagreement_count
+            ),
+        )
+
+    def decide(
+        self,
+        rnnoise: RnnoiseEvidence,
+        *,
+        candidate_open: bool,
+        allow_baseline_update: bool,
+    ) -> ThrottleDecision:
+        silero_active = self._silero.activity in {
+            SpeechActivityEvent.SPEECH_STARTED,
+            SpeechActivityEvent.SPEECH_RESUMED,
+        }
+        threshold_before_observation = self.onset_threshold
+        if (
+            allow_baseline_update
+            and not candidate_open
+            and not silero_active
+            and rnnoise.available
+            and rnnoise.frame_count > 0
+            and rnnoise.peak is not None
+            and rnnoise.peak < threshold_before_observation
+            and rnnoise.mean is not None
+        ):
+            if self._baseline is None:
+                self._baseline = rnnoise.mean
+            else:
+                self._baseline = (
+                    self._baseline_alpha * rnnoise.mean
+                    + (1.0 - self._baseline_alpha) * self._baseline
+                )
+            self._baseline_samples += rnnoise.frame_count
+
+        threshold = self.onset_threshold
+        evidence = ActivityEvidence(
+            rnnoise.with_baseline(self._baseline),
+            self._silero,
+        )
+        rnnoise_active = bool(
+            rnnoise.available
+            and rnnoise.frame_count > 0
+            and rnnoise.peak is not None
+            and rnnoise.peak >= threshold
+        )
+
+        if not self.resource_optimization_enabled:
+            action = ThrottleAction.PROCESS_PCM
+        elif candidate_open:
+            action = ThrottleAction.KEEP_CANDIDATE_OPEN
+        elif silero_active:
+            action = ThrottleAction.OPEN_CANDIDATE
+        elif not rnnoise.available or rnnoise.frame_count == 0:
+            action = ThrottleAction.OPEN_CANDIDATE
+        elif rnnoise_active:
+            action = ThrottleAction.PREWARM
+        else:
+            action = ThrottleAction.SKIP_IDLE_PCM
+
+        rnnoise_action = (
+            ThrottleAction.PREWARM
+            if rnnoise_active
+            else ThrottleAction.SKIP_IDLE_PCM
+        )
+        silero_action = (
+            ThrottleAction.OPEN_CANDIDATE
+            if silero_active
+            else ThrottleAction.SKIP_IDLE_PCM
+        )
+        confirm_action = (
+            ThrottleAction.OPEN_CANDIDATE
+            if silero_active
+            else rnnoise_action
+        )
+        shadow_actions = (
+            (ThrottleStrategy.RNNOISE_ONLY, rnnoise_action),
+            (ThrottleStrategy.SILERO_ONLY, silero_action),
+            (
+                ThrottleStrategy.RNNOISE_PREWARM_SILERO_CONFIRM,
+                confirm_action,
+            ),
+        )
+        if rnnoise.available:
+            if rnnoise.frame_count > 0:
+                self._evidence_chunk_count += 1
+            else:
+                self._incomplete_chunk_count += 1
+        positive_actions = {
+            ThrottleAction.PREWARM,
+            ThrottleAction.OPEN_CANDIDATE,
+        }
+        for strategy, shadow_action in shadow_actions:
+            if shadow_action in positive_actions:
+                self._shadow_trigger_counts[strategy] += 1
+        if (rnnoise_action in positive_actions) != (
+            silero_action in positive_actions
+        ):
+            self._rnnoise_silero_disagreement_count += 1
+        return ThrottleDecision(
+            action,
+            evidence,
+            threshold,
+            shadow_actions,
+        )

--- a/main_logic/asr_client/lifecycle.py
+++ b/main_logic/asr_client/lifecycle.py
@@ -75,6 +75,7 @@ class VoiceLifecycleEvent(Enum):
     # 兼容旧调用方；新代码应使用 TURN_SEALED，明确区分语义端点和 provider final。
     TURN_ENDPOINTED = "turn_endpointed"
     PROVIDER_FINAL = "provider_final"
+    PREWARM_EXPIRED = "prewarm_expired"
     WARM_EXPIRED = "warm_expired"
     RECOVERED = "recovered"
     GAME_TAKEOVER = "game_takeover"
@@ -130,6 +131,7 @@ _TRANSITIONS: dict[
     (VoiceLifecycleState.DRAINING, VoiceLifecycleEvent.PROVIDER_FINAL): VoiceLifecycleState.WARM_IDLE,
     (VoiceLifecycleState.WARM_IDLE, VoiceLifecycleEvent.SOFT_WAKE): VoiceLifecycleState.PREWARMING,
     (VoiceLifecycleState.WARM_IDLE, VoiceLifecycleEvent.SPEECH_CONFIRMED): VoiceLifecycleState.ACTIVE,
+    (VoiceLifecycleState.PREWARMING, VoiceLifecycleEvent.PREWARM_EXPIRED): VoiceLifecycleState.LOCAL_LISTEN,
     (VoiceLifecycleState.WARM_IDLE, VoiceLifecycleEvent.WARM_EXPIRED): VoiceLifecycleState.DEEP_SLEEP,
     (VoiceLifecycleState.LOCAL_LISTEN, VoiceLifecycleEvent.WARM_EXPIRED): VoiceLifecycleState.DEEP_SLEEP,
     (VoiceLifecycleState.DEEP_SLEEP, VoiceLifecycleEvent.SOFT_WAKE): VoiceLifecycleState.PREWARMING,
@@ -367,6 +369,11 @@ class VoiceInputLifecycleController:
             self._completed_turn_id = self._turn_id
             self._pre_roll_sent_for_turn = False
             self._pre_roll.clear()
+        elif event is VoiceLifecycleEvent.PREWARM_EXPIRED:
+            self._pre_roll_sent_for_turn = False
+            self._pre_roll.clear()
+            self._pending_connect.clear()
+            self._active_start_audio = b""
         elif event is VoiceLifecycleEvent.GAME_TAKEOVER:
             self._turn_id = self._allocate_turn_id()
             self._completed_turn_id = self._turn_id

--- a/main_logic/asr_client/lifecycle.py
+++ b/main_logic/asr_client/lifecycle.py
@@ -520,6 +520,19 @@ class VoiceInputLifecycleController:
             return
         self._pending_turn.clear()
 
+    def preserve_unconfirmed_pending_audio(self) -> bool:
+        """Move an unconfirmed successor into pre-roll after the old final."""
+
+        if self._pending_turn_speech:
+            return False
+        payload = self._pending_turn.drain()
+        if not payload:
+            return False
+        dropped = self._pre_roll.append(payload, sample_rate_hz=16_000)
+        if dropped:
+            self.metrics.buffer_overflow_count += 1
+        return True
+
     def stop(self) -> None:
         if self._state is not VoiceLifecycleState.OFF:
             self._state = next_lifecycle_state(

--- a/main_logic/asr_client/runtime.py
+++ b/main_logic/asr_client/runtime.py
@@ -775,7 +775,10 @@ class IndependentAsrRuntime:
         ):
             return
         if event.kind != "continuous":
-            self._schedule_transport_warm_expiry(epoch)
+            self._schedule_transport_warm_expiry(
+                epoch,
+                expected_state=VoiceLifecycleState.PREWARMING,
+            )
             return
         session_ref = self._asr_session
         if session_ref is None or not getattr(session_ref, "is_ready", True):
@@ -854,7 +857,10 @@ class IndependentAsrRuntime:
             or lifecycle.snapshot.state is not VoiceLifecycleState.PREWARMING
         ):
             return
-        self._schedule_transport_warm_expiry(epoch)
+        self._schedule_transport_warm_expiry(
+            epoch,
+            expected_state=VoiceLifecycleState.PREWARMING,
+        )
 
     async def _ensure_continuous_provider_wake(
         self,
@@ -1575,7 +1581,10 @@ class IndependentAsrRuntime:
             self._asr_detector = detector_ref
             self._asr_session_factory = create_candidate
             self._asr_transport_selection = selection
-            self._schedule_transport_warm_expiry(epoch)
+            self._schedule_transport_warm_expiry(
+                epoch,
+                expected_state=VoiceLifecycleState.LOCAL_LISTEN,
+            )
             start_identity = self._capture_runtime_identity()
             delivered = await self._send_asr_lifecycle_state(
                 VoiceLifecycleState.LOCAL_LISTEN,
@@ -2310,28 +2319,91 @@ class IndependentAsrRuntime:
                     self.display_name,
                 )
 
-    def _schedule_transport_warm_expiry(self, epoch: int) -> None:
+    def _schedule_transport_warm_expiry(
+        self,
+        epoch: int,
+        *,
+        expected_state: VoiceLifecycleState,
+    ) -> None:
         task = self._asr_warm_expiry_task
         if task is not None:
             task.cancel()
         lifecycle = self._asr_lifecycle
         if lifecycle is None or not self._voice_input_resource_optimization_enabled:
             return
-        ttl_ms = lifecycle.provider_policy.warm_transport_ms
+        if expected_state is VoiceLifecycleState.WARM_IDLE:
+            ttl_ms = lifecycle.provider_policy.warm_transport_ms
+        elif expected_state in {
+            VoiceLifecycleState.LOCAL_LISTEN,
+            VoiceLifecycleState.PREWARMING,
+        }:
+            ttl_ms = lifecycle.config.default_warm_transport_ms
+        else:
+            raise ValueError(
+                "transport expiry requires local-listen, prewarming, or warm-idle"
+            )
+        session_ref = self._asr_session
+        detector_ref = self._asr_detector
+        transport_generation = lifecycle.snapshot.transport_generation
+
+        def timer_is_current() -> bool:
+            return bool(
+                epoch == self._asr_session_epoch
+                and self._asr_lifecycle is lifecycle
+                and self._asr_session is session_ref
+                and self._asr_detector is detector_ref
+                and lifecycle.snapshot.transport_generation
+                == transport_generation
+            )
 
         async def expire() -> None:
             try:
                 await asyncio.sleep(ttl_ms / 1_000)
-                if epoch != self._asr_session_epoch:
+                if (
+                    not timer_is_current()
+                    or lifecycle.snapshot.state is not expected_state
+                ):
                     return
-                current = self._asr_lifecycle
-                if current is not None and current.snapshot.state in {
-                    VoiceLifecycleState.LOCAL_LISTEN,
-                    VoiceLifecycleState.WARM_IDLE,
-                }:
-                    await self._close_transport_only()
+                if expected_state is VoiceLifecycleState.PREWARMING:
+                    lease, self._asr_smart_turn_lease = (
+                        self._asr_smart_turn_lease,
+                        None,
+                    )
+                    if lease is not None:
+                        await lease.release()
+                    if not timer_is_current():
+                        return
+                    if detector_ref is not None:
+                        await detector_ref.reset()
+                    if (
+                        not timer_is_current()
+                        or lifecycle.snapshot.state
+                        is not VoiceLifecycleState.PREWARMING
+                    ):
+                        return
+                    lifecycle.transition(VoiceLifecycleEvent.PREWARM_EXPIRED)
+                    self._asr_pending_speech_confirmed = False
+                    self._asr_pending_detector_candidate = None
+                    identity = self._capture_runtime_identity()
+                    delivered = await self._send_asr_lifecycle_state(
+                        VoiceLifecycleState.LOCAL_LISTEN,
+                        provider=identity.provider or "unknown",
+                        session_epoch=identity.session_epoch,
+                        expected_identity=identity,
+                    )
+                    if (
+                        not delivered
+                        or not timer_is_current()
+                        or lifecycle.snapshot.state
+                        is not VoiceLifecycleState.LOCAL_LISTEN
+                    ):
+                        return
+                await self._close_transport_only()
             except asyncio.CancelledError:
                 return
+            finally:
+                if self._asr_warm_expiry_task is asyncio.current_task():
+                    self._asr_warm_expiry_task = None
 
         warm_task = asyncio.create_task(
             expire(),
@@ -2982,7 +3054,10 @@ class IndependentAsrRuntime:
                     if successor_present and not has_pending_turn:
                         lifecycle_ref.preserve_unconfirmed_pending_audio()
                     if not has_pending_turn:
-                        self._schedule_transport_warm_expiry(epoch)
+                        self._schedule_transport_warm_expiry(
+                            epoch,
+                            expected_state=VoiceLifecycleState.WARM_IDLE,
+                        )
                     final_identity = self._capture_runtime_identity(
                         ingress_token=sealed_token.turn.ingress,
                         turn_token=sealed_token.turn,

--- a/main_logic/asr_client/runtime.py
+++ b/main_logic/asr_client/runtime.py
@@ -40,6 +40,7 @@ from .endpointing.detector import (
     DetectorTransportPrewarmEvent,
     DetectorSubmitStatus,
     DetectorTurnEvent,
+    ProviderCandidateFence,
 )
 from .endpointing.detector_runtime import DetectorRuntime, SmartTurnLease
 from .endpointing.throttle_policy import ThrottleAction
@@ -340,6 +341,7 @@ class IndependentAsrRuntime:
         self._asr_overlap_completed_token: VoiceIngressToken | None = None
         self._asr_overlap_completed_turns = 0
         self._asr_sealed_turn_token: VoiceTransportToken | None = None
+        self._asr_provider_candidate_fence: ProviderCandidateFence | None = None
         self._asr_audio_sequence = 0
         self._asr_audio_generation = 0
         self._asr_current_ingress_token: VoiceIngressToken | None = None
@@ -395,6 +397,8 @@ class IndependentAsrRuntime:
             self._asr_overlap_completed_turns = 0
         if not hasattr(self, "_asr_start_generation"):
             self._asr_start_generation = 0
+        if not hasattr(self, "_asr_provider_candidate_fence"):
+            self._asr_provider_candidate_fence = None
 
     def _capture_turn_token(
         self,
@@ -1038,6 +1042,8 @@ class IndependentAsrRuntime:
     async def _handle_audio_ingress_backpressure(
         self,
         token: VoiceIngressToken,
+        *,
+        observed_state: VoiceLifecycleState | None = None,
     ) -> None:
         """Invalidate a whole candidate/turn instead of dropping middle PCM."""
 
@@ -1047,7 +1053,93 @@ class IndependentAsrRuntime:
         epoch = self._asr_session_epoch
         detector = self._asr_detector
         provider = self._asr_provider or "unknown"
-        state = lifecycle.snapshot.state
+        state = observed_state or lifecycle.snapshot.state
+        if (
+            state is VoiceLifecycleState.DRAINING
+            and not _uses_smart_turn_endpointing(lifecycle.provider_policy)
+        ):
+            discard_failed = False
+            discard_handled = False
+            final_completed_before_discard = False
+            async with self._asr_final_lock:
+                if (
+                    self._asr_lifecycle is not lifecycle
+                    or self._asr_detector is not detector
+                    or epoch != self._asr_session_epoch
+                    or not self._ingress_token_matches(token)
+                ):
+                    return
+                state = lifecycle.snapshot.state
+                lifecycle.discard_pending_turn()
+                self._asr_pending_speech_confirmed = False
+                self._asr_pending_detector_candidate = None
+                if state is VoiceLifecycleState.DRAINING:
+                    sealed_token = self._asr_sealed_turn_token
+                    provider_fence = self._asr_provider_candidate_fence
+                    if (
+                        detector is None
+                        or sealed_token is None
+                        or provider_fence is None
+                        or not self._transport_token_matches(
+                            sealed_token,
+                            lifecycle,
+                        )
+                    ):
+                        discard_failed = True
+                    else:
+                        try:
+                            discard_handled = (
+                                await detector.discard_provider_successor(
+                                    provider_fence
+                                )
+                            )
+                        except asyncio.CancelledError:
+                            raise
+                        except Exception:
+                            logger.warning(
+                                "[%s] provider successor discard failed",
+                                self.display_name,
+                            )
+                        discard_failed = not discard_handled
+                elif state is VoiceLifecycleState.WARM_IDLE:
+                    final_completed_before_discard = True
+            if discard_failed:
+                identity = self._capture_runtime_identity(ingress_token=token)
+                await self._handle_independent_asr_error(
+                    epoch,
+                    provider,
+                    status_code="ASR_ENDPOINTING_FAILED",
+                    expected_identity=identity,
+                )
+                return
+            if discard_handled:
+                identity = self._capture_runtime_identity(ingress_token=token)
+                await self._send_asr_status(
+                    "ASR_INGRESS_BACKPRESSURE",
+                    provider,
+                    session_epoch=epoch,
+                    expected_identity=identity,
+                )
+                return
+            if final_completed_before_discard:
+                if detector is not None and detector is self._asr_detector:
+                    try:
+                        await detector.reset()
+                    except Exception:
+                        logger.warning(
+                            "[%s] detector reset failed after pending overflow",
+                            self.display_name,
+                        )
+                identity = self._capture_runtime_identity(ingress_token=token)
+                await self._send_asr_status(
+                    "ASR_INGRESS_BACKPRESSURE",
+                    provider,
+                    session_epoch=epoch,
+                    expected_identity=identity,
+                )
+                return
+            if state is VoiceLifecycleState.ACTIVE:
+                await self._asr_transcript_dispatcher.wait_idle()
         if state is VoiceLifecycleState.DRAINING:
             lifecycle.discard_pending_turn()
             self._asr_pending_speech_confirmed = False
@@ -1564,6 +1656,7 @@ class IndependentAsrRuntime:
         self._asr_accepted_final_keys.clear()
         self._asr_reserved_final_key = None
         self._asr_sealed_turn_token = None
+        self._asr_provider_candidate_fence = None
         self._asr_turn_endpointed_at = None
         self._asr_turn_audio_started_at = None
         self._asr_first_partial_recorded = False
@@ -1731,7 +1824,10 @@ class IndependentAsrRuntime:
                         return AsrSubmitResult(AsrSubmitStatus.ACCEPTED)
                     if submitted.status is DetectorSubmitStatus.BACKPRESSURE:
                         lifecycle.metrics.detector_overflow_count += 1
-                        await self._handle_audio_ingress_backpressure(ingress_token)
+                        await self._handle_audio_ingress_backpressure(
+                            ingress_token,
+                            observed_state=lifecycle.snapshot.state,
+                        )
                         return AsrSubmitResult(AsrSubmitStatus.ACCEPTED)
                     if (
                         submitted.status
@@ -1828,7 +1924,10 @@ class IndependentAsrRuntime:
             )
             if decision is not None and decision.disposition is AudioDisposition.BLOCK:
                 if decision.backpressure:
-                    await self._handle_audio_ingress_backpressure(ingress_token)
+                    await self._handle_audio_ingress_backpressure(
+                        ingress_token,
+                        observed_state=lifecycle.snapshot.state,
+                    )
                 return AsrSubmitResult(AsrSubmitStatus.ACCEPTED)
             if decision is not None and decision.disposition in {
                 AudioDisposition.BUFFER,
@@ -2575,7 +2674,8 @@ class IndependentAsrRuntime:
                 )
                 return
             final_key = FinalKey.from_turn(turn_token)
-            if not self._asr_transcript_dispatcher.try_reserve(final_key):
+            transcript_dispatcher = self._asr_transcript_dispatcher
+            if not transcript_dispatcher.try_reserve(final_key):
                 await self._handle_independent_asr_error(
                     epoch,
                     self._asr_provider or "unknown",
@@ -2583,6 +2683,36 @@ class IndependentAsrRuntime:
                 )
                 return
             self._asr_reserved_final_key = final_key
+            if not _uses_smart_turn_endpointing(lifecycle.provider_policy):
+                endpoint_identity = self._capture_runtime_identity(
+                    ingress_token=turn_token.ingress,
+                    turn_token=turn_token,
+                )
+                try:
+                    provider_fence = await detector.seal_provider_candidate()
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    provider_fence = None
+                    logger.warning(
+                        "[%s] provider candidate seal failed",
+                        self.display_name,
+                    )
+                if not self._runtime_identity_matches(endpoint_identity):
+                    transcript_dispatcher.release(final_key)
+                    self._asr_reserved_final_key = None
+                    return
+                if provider_fence is None:
+                    transcript_dispatcher.release(final_key)
+                    self._asr_reserved_final_key = None
+                    await self._handle_independent_asr_error(
+                        epoch,
+                        provider,
+                        status_code="ASR_ENDPOINTING_FAILED",
+                        expected_identity=endpoint_identity,
+                    )
+                    return
+                self._asr_provider_candidate_fence = provider_fence
             lifecycle.transition(VoiceLifecycleEvent.TURN_SEALED)
             self._asr_sealed_turn_token = self._capture_transport_token(lifecycle)
             self._asr_turn_endpointed_at = time.monotonic()
@@ -2747,6 +2877,8 @@ class IndependentAsrRuntime:
         final_key: FinalKey | None = None
         final_identity: _AsrRuntimeIdentity | None = None
         ordering_failure_identity: _AsrRuntimeIdentity | None = None
+        provider_failure_identity: _AsrRuntimeIdentity | None = None
+        successor_present = False
         async with self._asr_final_lock:
             if epoch != self._asr_session_epoch:
                 return
@@ -2768,6 +2900,8 @@ class IndependentAsrRuntime:
             ):
                 return
             final_key = FinalKey.from_turn(sealed_token.turn)
+            if final_key in self._asr_accepted_final_keys:
+                return
             transcript_dispatcher = self._asr_transcript_dispatcher
             if not transcript_dispatcher.try_reserve(final_key):
                 ordering_failure_identity = self._capture_runtime_identity(
@@ -2775,40 +2909,84 @@ class IndependentAsrRuntime:
                     turn_token=sealed_token.turn,
                 )
             if ordering_failure_identity is None:
-                if not self._accept_final_key(final_key):
-                    return
-                if self._asr_turn_endpointed_at is not None:
-                    lifecycle_ref.metrics.final_latency_ms = int(
-                        (time.monotonic() - self._asr_turn_endpointed_at) * 1_000
-                    )
                 has_pending_turn = lifecycle_ref.has_pending_turn
-                accepted_turn_token = sealed_token.turn
-                lifecycle_ref.transition(VoiceLifecycleEvent.PROVIDER_FINAL)
                 detector_ref = self._asr_detector
-                self._asr_turn_prepared = False
-                self._asr_received_audio = False
-                self._asr_sealed_turn_token = None
-                if self._asr_partial_turn_token == sealed_token.turn:
-                    self._asr_partial_turn_token = None
-                self._asr_turn_endpointed_at = None
-                self._asr_reserved_final_key = None
-                watchdog = self._asr_final_watchdog_task
-                self._asr_final_watchdog_task = None
-                if watchdog is not None and watchdog is not asyncio.current_task():
-                    watchdog.cancel()
-                envelope = TranscriptEnvelope(
-                    turn_token=sealed_token.turn,
-                    provider=provider,
-                    text=clean,
-                )
-                if not clean:
-                    lifecycle_ref.metrics.false_wake_count += 1
-                if not has_pending_turn:
-                    self._schedule_transport_warm_expiry(epoch)
-                final_identity = self._capture_runtime_identity(
-                    ingress_token=sealed_token.turn.ingress,
-                    turn_token=sealed_token.turn,
-                )
+                if not _uses_smart_turn_endpointing(lifecycle_ref.provider_policy):
+                    provider_fence = self._asr_provider_candidate_fence
+                    if provider_fence is None or detector_ref is None:
+                        provider_failure_identity = self._capture_runtime_identity(
+                            ingress_token=sealed_token.turn.ingress,
+                            turn_token=sealed_token.turn,
+                        )
+                    else:
+                        try:
+                            completion = (
+                                await detector_ref.complete_provider_candidate(
+                                    provider_fence
+                                )
+                            )
+                        except asyncio.CancelledError:
+                            raise
+                        except Exception:
+                            completion = None
+                            logger.warning(
+                                "[%s] provider candidate completion failed",
+                                self.display_name,
+                            )
+                        completion_identity = self._capture_runtime_identity(
+                            ingress_token=sealed_token.turn.ingress,
+                            turn_token=sealed_token.turn,
+                        )
+                        if (
+                            self._asr_lifecycle is not lifecycle_ref
+                            or self._asr_detector is not detector_ref
+                            or not self._runtime_identity_matches(
+                                completion_identity
+                            )
+                        ):
+                            transcript_dispatcher.release(final_key)
+                            return
+                        if completion is None:
+                            provider_failure_identity = completion_identity
+                        else:
+                            successor_present = completion
+                            self._asr_provider_candidate_fence = None
+                if provider_failure_identity is None:
+                    if not self._accept_final_key(final_key):
+                        return
+                    if self._asr_turn_endpointed_at is not None:
+                        lifecycle_ref.metrics.final_latency_ms = int(
+                            (time.monotonic() - self._asr_turn_endpointed_at) * 1_000
+                        )
+                    accepted_turn_token = sealed_token.turn
+                    if self._asr_partial_turn_token == accepted_turn_token:
+                        self._asr_partial_turn_token = None
+                    lifecycle_ref.transition(VoiceLifecycleEvent.PROVIDER_FINAL)
+                    self._asr_turn_prepared = False
+                    self._asr_received_audio = False
+                    self._asr_sealed_turn_token = None
+                    self._asr_provider_candidate_fence = None
+                    self._asr_turn_endpointed_at = None
+                    self._asr_reserved_final_key = None
+                    watchdog = self._asr_final_watchdog_task
+                    self._asr_final_watchdog_task = None
+                    if watchdog is not None and watchdog is not asyncio.current_task():
+                        watchdog.cancel()
+                    envelope = TranscriptEnvelope(
+                        turn_token=sealed_token.turn,
+                        provider=provider,
+                        text=clean,
+                    )
+                    if not clean:
+                        lifecycle_ref.metrics.false_wake_count += 1
+                    if successor_present and not has_pending_turn:
+                        lifecycle_ref.preserve_unconfirmed_pending_audio()
+                    if not has_pending_turn:
+                        self._schedule_transport_warm_expiry(epoch)
+                    final_identity = self._capture_runtime_identity(
+                        ingress_token=sealed_token.turn.ingress,
+                        turn_token=sealed_token.turn,
+                    )
 
         if ordering_failure_identity is not None:
             await self._handle_independent_asr_error(
@@ -2816,6 +2994,18 @@ class IndependentAsrRuntime:
                 ordering_failure_identity.provider or provider,
                 status_code="ASR_AUDIO_ORDERING_FAILED",
                 expected_identity=ordering_failure_identity,
+            )
+            return
+
+        if provider_failure_identity is not None:
+            assert transcript_dispatcher is not None
+            assert final_key is not None
+            transcript_dispatcher.release(final_key)
+            await self._handle_independent_asr_error(
+                provider_failure_identity.session_epoch,
+                provider_failure_identity.provider or provider,
+                status_code="ASR_ENDPOINTING_FAILED",
+                expected_identity=provider_failure_identity,
             )
             return
 

--- a/main_logic/asr_client/runtime.py
+++ b/main_logic/asr_client/runtime.py
@@ -35,11 +35,14 @@ from .endpointing.detector import (
     AsrDetectorDispatcher,
     CoreDetectorEventEnvelope,
     DetectorActivityEvent,
+    DetectorPrewarmEvent,
     DetectorRuntimeEvent,
+    DetectorTransportPrewarmEvent,
     DetectorSubmitStatus,
     DetectorTurnEvent,
 )
 from .endpointing.detector_runtime import DetectorRuntime, SmartTurnLease
+from .endpointing.throttle_policy import ThrottleAction
 from .lifecycle import (
     AudioDisposition,
     FinalKey,
@@ -70,6 +73,12 @@ _FRONTEND_START_DEADLINE_SECONDS = 15.0
 # the pending-input flush that follow it) so the fail-closed verdict lands
 # BEFORE the client gives up rather than a second after.
 _CONNECT_TOTAL_BUDGET_SECONDS = 12.0
+
+
+def _uses_smart_turn_endpointing(provider_policy: Any) -> bool:
+    """Honor the endpoint authority independently of transport shape."""
+
+    return bool(provider_policy.endpoint_authority == "smart_turn")
 
 
 class AsrStartStatus(Enum):
@@ -461,7 +470,7 @@ class IndependentAsrRuntime:
 
         if detector is None:
             return False
-        if lifecycle.provider_policy.endpoint_authority == "provider":
+        if not _uses_smart_turn_endpointing(lifecycle.provider_policy):
             return True
         return detector.endpointing_ready(turn_token)
 
@@ -599,6 +608,22 @@ class IndependentAsrRuntime:
                 expected_identity=identity,
             )
             return
+        if isinstance(event, DetectorTransportPrewarmEvent):
+            await self._handle_transport_prewarm_event(
+                event,
+                detector,
+                lifecycle,
+                envelope.session_epoch,
+            )
+            return
+        if isinstance(event, DetectorPrewarmEvent):
+            await self._handle_detector_prewarm_event(
+                event,
+                detector,
+                lifecycle,
+                envelope.session_epoch,
+            )
+            return
         if isinstance(event, DetectorActivityEvent):
             await self._handle_independent_asr_activity(
                 event.activity,
@@ -661,6 +686,265 @@ class IndependentAsrRuntime:
                 expected_identity=identity,
             )
 
+    async def _handle_detector_prewarm_event(
+        self,
+        event: DetectorPrewarmEvent,
+        detector: DetectorRuntime,
+        lifecycle: VoiceInputLifecycleController,
+        epoch: int,
+    ) -> None:
+        """Prepare segmented endpointing and transport without final authority."""
+
+        def event_is_current() -> bool:
+            return bool(
+                epoch == self._asr_session_epoch
+                and detector is self._asr_detector
+                and lifecycle is self._asr_lifecycle
+                and event.ingress.detector_epoch == detector.detector_epoch
+                and self._ingress_token_matches(event.ingress.ingress_token)
+            )
+
+        if not event_is_current():
+            return
+        state = lifecycle.snapshot.state
+        if state is VoiceLifecycleState.DRAINING:
+            if event.kind == "continuous":
+                lifecycle.mark_pending_turn_speech()
+                self._asr_pending_detector_candidate = event.candidate
+            return
+        if state in {
+            VoiceLifecycleState.LOCAL_LISTEN,
+            VoiceLifecycleState.WARM_IDLE,
+            VoiceLifecycleState.DEEP_SLEEP,
+        }:
+            warm_task = self._asr_warm_expiry_task
+            if warm_task is not None:
+                warm_task.cancel()
+                self._asr_warm_expiry_task = None
+            if state is VoiceLifecycleState.WARM_IDLE:
+                lifecycle.metrics.warm_hit_count += 1
+            lifecycle.transition(VoiceLifecycleEvent.SOFT_WAKE)
+            prewarm_identity = self._capture_runtime_identity(
+                ingress_token=event.ingress.ingress_token,
+            )
+            await self._send_asr_lifecycle_state(
+                VoiceLifecycleState.PREWARMING,
+                provider=prewarm_identity.provider or "unknown",
+                session_epoch=prewarm_identity.session_epoch,
+                expected_identity=prewarm_identity,
+            )
+            if not event_is_current():
+                return
+        if lifecycle.snapshot.state not in {
+            VoiceLifecycleState.PREWARMING,
+            VoiceLifecycleState.ACTIVE,
+        }:
+            return
+
+        turn_token = self._capture_turn_token(lifecycle)
+        bound = await detector.bind_candidate(event.candidate, turn_token)
+        if bound is None or not event_is_current():
+            return
+        if lifecycle.snapshot.state is VoiceLifecycleState.ACTIVE:
+            self._activate_asr_audio_dispatcher(lifecycle, turn_token)
+            if event.kind == "continuous":
+                await self._prepare_independent_asr_turn(epoch)
+            return
+
+        smart_turn_task = asyncio.create_task(
+            self._ensure_smart_turn_ready(lifecycle, epoch),
+            name="independent-asr-prewarm-smart-turn",
+        )
+        transport_task = asyncio.create_task(
+            self._restart_transport(),
+            name="independent-asr-prewarm-transport",
+        )
+        smart_turn_ready, _transport_result = await asyncio.gather(
+            smart_turn_task,
+            transport_task,
+            return_exceptions=True,
+        )
+        if (
+            smart_turn_ready is not True
+            or not event_is_current()
+            or lifecycle.snapshot.state is not VoiceLifecycleState.PREWARMING
+        ):
+            return
+        if event.kind != "continuous":
+            self._schedule_transport_warm_expiry(epoch)
+            return
+        session_ref = self._asr_session
+        if session_ref is None or not getattr(session_ref, "is_ready", True):
+            self._asr_pending_speech_confirmed = True
+            return
+        lifecycle.transition(VoiceLifecycleEvent.SPEECH_CONFIRMED)
+        active_identity = self._capture_runtime_identity(
+            ingress_token=event.ingress.ingress_token,
+        )
+        await self._send_asr_lifecycle_state(
+            VoiceLifecycleState.ACTIVE,
+            provider=active_identity.provider or "unknown",
+            session_epoch=active_identity.session_epoch,
+            expected_identity=active_identity,
+        )
+        if not event_is_current():
+            return
+        self._asr_turn_audio_started_at = time.monotonic()
+        self._asr_first_partial_recorded = False
+        self._activate_asr_audio_dispatcher(lifecycle, turn_token)
+        await self._prepare_independent_asr_turn(epoch)
+
+    async def _handle_transport_prewarm_event(
+        self,
+        event: DetectorTransportPrewarmEvent,
+        detector: DetectorRuntime,
+        lifecycle: VoiceInputLifecycleController,
+        epoch: int,
+    ) -> None:
+        """Preconnect a streaming transport without opening a logical turn."""
+
+        def event_is_current() -> bool:
+            return bool(
+                epoch == self._asr_session_epoch
+                and detector is self._asr_detector
+                and lifecycle is self._asr_lifecycle
+                and event.ingress.detector_epoch == detector.detector_epoch
+                and self._ingress_token_matches(event.ingress.ingress_token)
+            )
+
+        if not event_is_current():
+            return
+        state = lifecycle.snapshot.state
+        if state is VoiceLifecycleState.DRAINING:
+            return
+        if state in {
+            VoiceLifecycleState.LOCAL_LISTEN,
+            VoiceLifecycleState.WARM_IDLE,
+            VoiceLifecycleState.DEEP_SLEEP,
+        }:
+            warm_task = self._asr_warm_expiry_task
+            if warm_task is not None:
+                warm_task.cancel()
+                self._asr_warm_expiry_task = None
+            if state is VoiceLifecycleState.WARM_IDLE:
+                lifecycle.metrics.warm_hit_count += 1
+            lifecycle.transition(VoiceLifecycleEvent.SOFT_WAKE)
+            prewarm_identity = self._capture_runtime_identity(
+                ingress_token=event.ingress.ingress_token,
+            )
+            await self._send_asr_lifecycle_state(
+                VoiceLifecycleState.PREWARMING,
+                provider=prewarm_identity.provider or "unknown",
+                session_epoch=prewarm_identity.session_epoch,
+                expected_identity=prewarm_identity,
+            )
+            if not event_is_current():
+                return
+        if lifecycle.snapshot.state is not VoiceLifecycleState.PREWARMING:
+            return
+        session_ref = self._asr_session
+        if session_ref is None or not getattr(session_ref, "is_ready", True):
+            await self._restart_transport()
+        if (
+            not event_is_current()
+            or lifecycle.snapshot.state is not VoiceLifecycleState.PREWARMING
+        ):
+            return
+        self._schedule_transport_warm_expiry(epoch)
+
+    async def _ensure_continuous_provider_wake(
+        self,
+        lifecycle: VoiceInputLifecycleController,
+        epoch: int,
+    ) -> bool:
+        """Open a provider-owned streaming turn without fabricating VAD activity."""
+
+        detector = self._asr_detector
+        ingress_token = self._asr_current_ingress_token
+
+        def wake_is_current() -> bool:
+            return bool(
+                epoch == self._asr_session_epoch
+                and lifecycle is self._asr_lifecycle
+                and detector is self._asr_detector
+                and ingress_token is not None
+                and self._ingress_token_matches(ingress_token)
+            )
+
+        if not wake_is_current():
+            return False
+        state = lifecycle.snapshot.state
+        if state is VoiceLifecycleState.DRAINING:
+            lifecycle.mark_pending_turn_speech()
+            return wake_is_current()
+        if state in {
+            VoiceLifecycleState.LOCAL_LISTEN,
+            VoiceLifecycleState.WARM_IDLE,
+            VoiceLifecycleState.DEEP_SLEEP,
+        }:
+            warm_task = self._asr_warm_expiry_task
+            if warm_task is not None:
+                warm_task.cancel()
+                self._asr_warm_expiry_task = None
+            if state is VoiceLifecycleState.WARM_IDLE:
+                lifecycle.metrics.warm_hit_count += 1
+            lifecycle.transition(VoiceLifecycleEvent.SOFT_WAKE)
+            prewarm_identity = self._capture_runtime_identity(
+                ingress_token=ingress_token,
+            )
+            delivered = await self._send_asr_lifecycle_state(
+                VoiceLifecycleState.PREWARMING,
+                provider=prewarm_identity.provider or "unknown",
+                session_epoch=prewarm_identity.session_epoch,
+                expected_identity=prewarm_identity,
+            )
+            if not delivered or not wake_is_current():
+                return False
+        if lifecycle.snapshot.state is VoiceLifecycleState.ACTIVE:
+            return True
+        if lifecycle.snapshot.state is not VoiceLifecycleState.PREWARMING:
+            return False
+        session_ref = self._asr_session
+        if session_ref is None or not getattr(session_ref, "is_ready", True):
+            self._asr_pending_speech_confirmed = True
+            self._ensure_transport_restart_task()
+            return wake_is_current()
+        turn_token = self._capture_turn_token(lifecycle)
+        if not self._asr_endpointing_ready(lifecycle, detector, turn_token):
+            identity = self._capture_runtime_identity(
+                ingress_token=ingress_token,
+                turn_token=turn_token,
+            )
+            await self._handle_independent_asr_error(
+                epoch,
+                identity.provider or "unknown",
+                status_code="ASR_BLOCKED_ENDPOINTING",
+                expected_identity=identity,
+            )
+            return False
+        lifecycle.transition(VoiceLifecycleEvent.SPEECH_CONFIRMED)
+        active_identity = self._capture_runtime_identity(
+            ingress_token=ingress_token,
+            turn_token=turn_token,
+        )
+        delivered = await self._send_asr_lifecycle_state(
+            VoiceLifecycleState.ACTIVE,
+            provider=active_identity.provider or "unknown",
+            session_epoch=active_identity.session_epoch,
+            expected_identity=active_identity,
+        )
+        if not delivered or not wake_is_current():
+            return False
+        self._asr_turn_audio_started_at = time.monotonic()
+        self._asr_first_partial_recorded = False
+        await self._prepare_independent_asr_turn(epoch)
+        if not wake_is_current():
+            return False
+        return self._activate_asr_audio_dispatcher(
+            lifecycle,
+            turn_token,
+        )
+
     def _activate_asr_audio_dispatcher(
         self,
         lifecycle: VoiceInputLifecycleController,
@@ -698,7 +982,7 @@ class IndependentAsrRuntime:
     ) -> bool:
         if epoch != self._asr_session_epoch or self._asr_lifecycle is not lifecycle:
             return False
-        if lifecycle.provider_policy.endpoint_authority == "provider":
+        if not _uses_smart_turn_endpointing(lifecycle.provider_policy):
             return True
         turn_token = self._capture_turn_token(lifecycle)
         detector = self._asr_detector
@@ -1053,7 +1337,7 @@ class IndependentAsrRuntime:
                 on_speech_activity=on_activity,
                 on_turn_endpointed=on_endpoint,
                 external_endpointing_runtime=(
-                    candidate_policy.endpoint_authority == "smart_turn"
+                    _uses_smart_turn_endpointing(candidate_policy)
                 ),
                 user_language=user_language,
             )
@@ -1191,14 +1475,10 @@ class IndependentAsrRuntime:
                 provider_policy=policy,
                 on_endpointing_failure=(
                     on_detector_endpointing_failure
-                    if policy.endpoint_authority == "smart_turn"
+                    if _uses_smart_turn_endpointing(policy)
                     else None
                 ),
-                on_event=(
-                    on_detector_event
-                    if policy.endpoint_authority == "smart_turn"
-                    else None
-                ),
+                on_event=on_detector_event,
             )
             self._asr_detector = detector_ref
             self._asr_session_factory = create_candidate
@@ -1399,6 +1679,7 @@ class IndependentAsrRuntime:
         sample_rate_hz = frame.sample_rate_hz
         speech_probability = frame.speech_probability
         rnnoise_available = frame.rnnoise_available
+        rnnoise_evidence = frame.rnnoise_evidence
 
         try:
             lifecycle = identity.lifecycle
@@ -1409,9 +1690,7 @@ class IndependentAsrRuntime:
 
             if lifecycle is not None and detector is not None:
                 submit_audio = getattr(detector, "submit_audio", None)
-                uses_smart_turn = (
-                    lifecycle.provider_policy.endpoint_authority == "smart_turn"
-                )
+                uses_smart_turn = _uses_smart_turn_endpointing(lifecycle.provider_policy)
                 if uses_smart_turn and callable(submit_audio):
                     detector_submit_started_at = time.perf_counter()
                     submitted = await submit_audio(
@@ -1420,6 +1699,14 @@ class IndependentAsrRuntime:
                         sample_rate_hz=sample_rate_hz,
                         speech_probability=speech_probability,
                         rnnoise_available=bool(rnnoise_available),
+                        rnnoise_evidence=rnnoise_evidence,
+                        allow_baseline_update=(
+                            lifecycle.snapshot.state
+                            in {
+                                VoiceLifecycleState.LOCAL_LISTEN,
+                                VoiceLifecycleState.WARM_IDLE,
+                            }
+                        ),
                     )
                     if not ingress_is_current():
                         return AsrSubmitResult(AsrSubmitStatus.STALE)
@@ -1440,6 +1727,8 @@ class IndependentAsrRuntime:
                     lifecycle.metrics.smart_turn_coalesced_evaluation_count = (
                         detector.smart_turn_coalesced_evaluation_count
                     )
+                    if submitted.status is DetectorSubmitStatus.SKIPPED_QUIET:
+                        return AsrSubmitResult(AsrSubmitStatus.ACCEPTED)
                     if submitted.status is DetectorSubmitStatus.BACKPRESSURE:
                         lifecycle.metrics.detector_overflow_count += 1
                         await self._handle_audio_ingress_backpressure(ingress_token)
@@ -1458,39 +1747,45 @@ class IndependentAsrRuntime:
                         return AsrSubmitResult(AsrSubmitStatus.UNAVAILABLE)
                     if not submitted.throttle_available:
                         lifecycle.enable_independent_asr_fail_open()
-                    if (
-                        submitted.identity is not None
-                        and (
-                            not submitted.throttle_available
-                            or not self._voice_input_resource_optimization_enabled
-                        )
-                        and lifecycle.snapshot.state
-                        in {
-                            VoiceLifecycleState.LOCAL_LISTEN,
-                            VoiceLifecycleState.WARM_IDLE,
-                            VoiceLifecycleState.DEEP_SLEEP,
-                        }
-                    ):
-                        forced = await detector.force_speech_started(submitted.identity)
-                        if not ingress_is_current():
-                            return AsrSubmitResult(AsrSubmitStatus.STALE)
-                        if forced:
-                            # The detector callback is queued through the
-                            # session-owned dispatcher. Advance the lifecycle
-                            # synchronously for this frame so fail-open upload
-                            # cannot observe LOCAL_LISTEN and tear down the
-                            # session before that queued event runs.
-                            await self._handle_independent_asr_activity(
-                                SpeechActivityEvent.SPEECH_STARTED,
-                                identity.session_epoch,
+                        if (
+                            not submitted.control_event_emitted
+                            and submitted.identity is not None
+                            and submitted.candidate is not None
+                        ):
+                            accepted = self._asr_detector_dispatcher.submit_nowait(
+                                CoreDetectorEventEnvelope(
+                                    event=DetectorPrewarmEvent(
+                                        ingress=submitted.identity,
+                                        candidate=submitted.candidate,
+                                        kind="continuous",
+                                    ),
+                                    detector_ref=detector,
+                                    lifecycle_ref=lifecycle,
+                                    session_epoch=identity.session_epoch,
+                                )
                             )
-                            if not ingress_is_current():
-                                return AsrSubmitResult(AsrSubmitStatus.STALE)
+                            if not accepted:
+                                await self._handle_independent_asr_error(
+                                    identity.session_epoch,
+                                    identity.provider or "unknown",
+                                    status_code="ASR_ENDPOINTING_FAILED",
+                                    expected_identity=identity,
+                                )
+                                return AsrSubmitResult(AsrSubmitStatus.UNAVAILABLE)
                 else:
                     detector_result = await detector.feed(
                         pcm16,
                         speech_probability=speech_probability,
                         rnnoise_available=rnnoise_available,
+                        rnnoise_evidence=rnnoise_evidence,
+                        ingress_token=ingress_token,
+                        allow_baseline_update=(
+                            lifecycle.snapshot.state
+                            in {
+                                VoiceLifecycleState.LOCAL_LISTEN,
+                                VoiceLifecycleState.WARM_IDLE,
+                            }
+                        ),
                     )
                     if not ingress_is_current():
                         return AsrSubmitResult(AsrSubmitStatus.STALE)
@@ -1502,6 +1797,8 @@ class IndependentAsrRuntime:
                             expected_identity=identity,
                         )
                         return AsrSubmitResult(AsrSubmitStatus.UNAVAILABLE)
+                    if detector_result.throttle_action is ThrottleAction.SKIP_IDLE_PCM:
+                        return AsrSubmitResult(AsrSubmitStatus.ACCEPTED)
                     if not detector_result.throttle_available:
                         lifecycle.enable_independent_asr_fail_open()
                     else:
@@ -1515,17 +1812,13 @@ class IndependentAsrRuntime:
                     if (
                         not detector_result.throttle_available
                         or not self._voice_input_resource_optimization_enabled
-                    ) and lifecycle.snapshot.state in {
-                        VoiceLifecycleState.LOCAL_LISTEN,
-                        VoiceLifecycleState.WARM_IDLE,
-                        VoiceLifecycleState.DEEP_SLEEP,
-                    }:
-                        await self._handle_independent_asr_activity(
-                            SpeechActivityEvent.SPEECH_STARTED,
-                            identity.session_epoch,
-                        )
+                    ) and not await self._ensure_continuous_provider_wake(
+                        lifecycle,
+                        identity.session_epoch,
+                    ):
                         if not ingress_is_current():
                             return AsrSubmitResult(AsrSubmitStatus.STALE)
+                        return AsrSubmitResult(AsrSubmitStatus.UNAVAILABLE)
             if lifecycle is not None and not ingress_is_current():
                 return AsrSubmitResult(AsrSubmitStatus.STALE)
             decision = (

--- a/main_logic/core/asr_runtime.py
+++ b/main_logic/core/asr_runtime.py
@@ -42,6 +42,7 @@ from main_logic.voice_turn.contracts import (
     VoiceTranscriptEvent,
     VoiceTurnToken,
 )
+from main_logic.voice_turn.activity_evidence import RnnoiseEvidence
 from main_logic.voice_turn.audio_input import (
     ProcessedVoiceFrame,
     VoiceInputAudioPipeline,
@@ -159,6 +160,7 @@ class _HotSwapAudioFrame:
     token: VoiceIngressToken
     speech_probability: float | None = None
     rnnoise_available: bool = False
+    rnnoise_evidence: RnnoiseEvidence | None = None
     audio_stream_epoch: int = 0
     ingress_sequence: int = 0
 
@@ -1460,6 +1462,7 @@ class AsrRuntimeMixin:
                             token=ingress_token,
                             speech_probability=processed_frame.speech_probability,
                             rnnoise_available=processed_frame.rnnoise_available,
+                            rnnoise_evidence=processed_frame.rnnoise_evidence,
                             audio_stream_epoch=audio_epoch,
                             ingress_sequence=ingress_sequence,
                         )
@@ -1483,6 +1486,7 @@ class AsrRuntimeMixin:
                 sample_rate_hz=processed_frame.sample_rate_hz,
                 speech_probability=processed_frame.speech_probability,
                 rnnoise_available=processed_frame.rnnoise_available,
+                rnnoise_evidence=processed_frame.rnnoise_evidence,
                 ingress_token=ingress_token,
             )
         except struct.error:
@@ -1502,6 +1506,7 @@ class AsrRuntimeMixin:
         sample_rate_hz: int,
         speech_probability: float | None = None,
         rnnoise_available: bool | None = None,
+        rnnoise_evidence: RnnoiseEvidence | None = None,
         ingress_token: VoiceIngressToken | None = None,
     ) -> bool:
         route_mode = self._asr_route_mode
@@ -1602,6 +1607,7 @@ class AsrRuntimeMixin:
                 sample_rate_hz=sample_rate_hz,
                 speech_probability=speech_probability,
                 rnnoise_available=bool(rnnoise_available),
+                rnnoise_evidence=rnnoise_evidence,
             ),
             ingress_token=token,
         )
@@ -1724,6 +1730,7 @@ class AsrRuntimeMixin:
                             sample_rate_hz=16_000,
                             speech_probability=frame.speech_probability,
                             rnnoise_available=frame.rnnoise_available,
+                            rnnoise_evidence=frame.rnnoise_evidence,
                             ingress_token=token,
                         )
                     except asyncio.CancelledError:

--- a/main_logic/voice_turn/activity_evidence.py
+++ b/main_logic/voice_turn/activity_evidence.py
@@ -1,0 +1,63 @@
+"""Provider-neutral local activity evidence produced by voice audio input."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+def _validate_probability(name: str, value: float | None) -> None:
+    if value is not None and not 0.0 <= value <= 1.0:
+        raise ValueError(f"{name} must be within [0, 1]")
+
+
+@dataclass(frozen=True, slots=True)
+class RnnoiseEvidence:
+    """Statistics from only the RNNoise frames processed for one PCM chunk."""
+
+    available: bool
+    frame_count: int
+    peak: float | None
+    mean: float | None
+    last: float | None
+    ema: float | None
+    baseline: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.frame_count < 0:
+            raise ValueError("frame_count must not be negative")
+        for name in ("peak", "mean", "last", "ema", "baseline"):
+            _validate_probability(name, getattr(self, name))
+        probabilities = (self.peak, self.mean, self.last, self.ema)
+        if not self.available and any(value is not None for value in probabilities):
+            raise ValueError("unavailable RNNoise evidence cannot carry probabilities")
+        if self.frame_count == 0 and any(
+            value is not None for value in probabilities
+        ):
+            raise ValueError("an empty RNNoise chunk cannot reuse prior probabilities")
+
+    @classmethod
+    def unavailable(cls) -> "RnnoiseEvidence":
+        return cls(False, 0, None, None, None, None, None)
+
+    @classmethod
+    def from_legacy_probability(
+        cls,
+        probability: float | None,
+        *,
+        available: bool,
+    ) -> "RnnoiseEvidence":
+        if not available or probability is None:
+            return cls.unavailable()
+        value = float(probability)
+        return cls(True, 1, value, value, value, value, None)
+
+    def with_baseline(self, baseline: float | None) -> "RnnoiseEvidence":
+        return RnnoiseEvidence(
+            self.available,
+            self.frame_count,
+            self.peak,
+            self.mean,
+            self.last,
+            self.ema,
+            baseline,
+        )

--- a/main_logic/voice_turn/audio_input.py
+++ b/main_logic/voice_turn/audio_input.py
@@ -7,11 +7,18 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Protocol
 
+from .activity_evidence import RnnoiseEvidence
 from utils.audio_processor import AudioProcessor
 
 
 class _AudioProcessorProtocol(Protocol):
     speech_probability: float
+    rnnoise_available: bool
+    rnnoise_frame_count: int
+    rnnoise_probability_peak: float | None
+    rnnoise_probability_mean: float | None
+    rnnoise_probability_last: float | None
+    rnnoise_probability_ema: float | None
 
     def process_chunk(self, audio_bytes: bytes) -> bytes: ...
 
@@ -26,6 +33,7 @@ class ProcessedVoiceFrame:
     sample_rate_hz: int
     speech_probability: float | None
     rnnoise_available: bool = False
+    rnnoise_evidence: RnnoiseEvidence | None = None
 
 
 class VoiceInputAudioPipeline:
@@ -93,9 +101,13 @@ class VoiceInputAudioPipeline:
         if self._closed:
             raise RuntimeError("VOICE_AUDIO_PIPELINE_CLOSED")
         if not pcm16:
-            return ProcessedVoiceFrame(b"", 16_000, None, False)
+            return ProcessedVoiceFrame(
+                b"", 16_000, None, False, RnnoiseEvidence.unavailable()
+            )
         if sample_rate_hz == 16_000:
-            return ProcessedVoiceFrame(pcm16, 16_000, None, False)
+            return ProcessedVoiceFrame(
+                pcm16, 16_000, None, False, RnnoiseEvidence.unavailable()
+            )
 
         async with self._lock:
             if self._closed:
@@ -114,11 +126,41 @@ class VoiceInputAudioPipeline:
                     getattr(self._processor, "_denoiser", None) is not None,
                 )
             )
+            raw_frame_count = getattr(
+                self._processor,
+                "rnnoise_frame_count",
+                None,
+            )
+            if not rnnoise_available:
+                evidence = RnnoiseEvidence.unavailable()
+            elif raw_frame_count is None:
+                # Compatibility for injected legacy processors only. The production
+                # AudioProcessor always exposes real per-chunk frame statistics.
+                evidence = RnnoiseEvidence.from_legacy_probability(
+                    probability,
+                    available=True,
+                )
+            else:
+                frame_count = int(raw_frame_count)
+                if frame_count > 0:
+                    evidence = RnnoiseEvidence(
+                        True,
+                        frame_count,
+                        float(self._processor.rnnoise_probability_peak),
+                        float(self._processor.rnnoise_probability_mean),
+                        float(self._processor.rnnoise_probability_last),
+                        float(self._processor.rnnoise_probability_ema),
+                    )
+                else:
+                    evidence = RnnoiseEvidence(
+                        True, 0, None, None, None, None
+                    )
         return ProcessedVoiceFrame(
             processed,
             16_000,
-            probability if rnnoise_available else None,
+            evidence.peak,
             rnnoise_available,
+            evidence,
         )
 
     async def close(self) -> None:

--- a/scripts/evaluate_speech_presence.py
+++ b/scripts/evaluate_speech_presence.py
@@ -35,7 +35,11 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from main_logic.asr_client.endpointing.silero_vad import SileroVad  # noqa: E402
+from main_logic.asr_client.endpointing.config import SmartTurnConfig  # noqa: E402
+from main_logic.asr_client.endpointing.silero_vad import (  # noqa: E402
+    SileroActivityGate,
+    SileroVad,
+)
 from main_logic.asr_client.endpointing.throttle_policy import (  # noqa: E402
     ThrottleAction,
     ThrottleShadowMetrics,
@@ -592,28 +596,80 @@ def _replay_rnnoise_policy(
     chunks: Sequence[RnnoiseEvidence],
     *,
     chunk_ms: float,
+    silero_probabilities: Sequence[float] | None = None,
 ) -> tuple[float | None, ThrottleShadowMetrics]:
-    policy = VoiceThrottlePolicy(
+    rnnoise_policy = VoiceThrottlePolicy(
         resource_optimization_enabled=True,
         bootstrap_onset=RNNOISE_CURRENT_THRESHOLD,
     )
+    shadow_policy = VoiceThrottlePolicy(
+        resource_optimization_enabled=True,
+        bootstrap_onset=RNNOISE_CURRENT_THRESHOLD,
+    )
+    replay_vad = SileroVad(enabled=False)
+    silero_gate = SileroActivityGate(
+        replay_vad,
+        SmartTurnConfig(
+            enabled=True,
+            onset_probability=SILERO_CURRENT_THRESHOLD,
+            offset_probability=SILERO_OFFSET_THRESHOLD,
+            minimum_speech_ms=SILERO_MINIMUM_SPEECH_MS,
+        ),
+    )
     trigger_ms: float | None = None
-    candidate_open = False
+    rnnoise_candidate_open = False
+    shadow_candidate_open = False
+    silero_index = 0
     positive_actions = {
         ThrottleAction.PREWARM,
         ThrottleAction.OPEN_CANDIDATE,
     }
-    for index, evidence in enumerate(chunks):
-        decision = policy.decide(
-            evidence,
-            candidate_open=candidate_open,
-            allow_baseline_update=not candidate_open,
+    try:
+        for index, evidence in enumerate(chunks):
+            rnnoise_decision = rnnoise_policy.decide(
+                evidence,
+                candidate_open=rnnoise_candidate_open,
+                allow_baseline_update=not rnnoise_candidate_open,
+            )
+            if rnnoise_decision.action in positive_actions:
+                if trigger_ms is None:
+                    trigger_ms = (index + 1) * chunk_ms
+                rnnoise_candidate_open = True
+
+            shadow_decision = shadow_policy.decide(
+                evidence,
+                candidate_open=shadow_candidate_open,
+                allow_baseline_update=not shadow_candidate_open,
+            )
+            if shadow_decision.action in positive_actions:
+                shadow_candidate_open = True
+
+            chunk_end_ms = (index + 1) * chunk_ms
+            while (
+                silero_probabilities is not None
+                and silero_index < len(silero_probabilities)
+                and (silero_index + 1) * SILERO_WINDOW_MS <= chunk_end_ms
+            ):
+                probability = silero_probabilities[silero_index]
+                for event in silero_gate.process_probabilities((probability,)):
+                    shadow_policy.observe_silero(
+                        event,
+                        probability=probability,
+                    )
+                silero_index += 1
+    finally:
+        replay_vad.close()
+
+    metrics = shadow_policy.shadow_metrics
+    if not silero_probabilities:
+        metrics = ThrottleShadowMetrics(
+            evidence_chunk_count=metrics.evidence_chunk_count,
+            incomplete_chunk_count=metrics.incomplete_chunk_count,
+            rnnoise_trigger_count=metrics.rnnoise_trigger_count,
+            silero_trigger_count=0,
+            rnnoise_silero_disagreement_count=0,
         )
-        if decision.action in positive_actions:
-            if trigger_ms is None:
-                trigger_ms = (index + 1) * chunk_ms
-            candidate_open = True
-    return trigger_ms, policy.shadow_metrics
+    return trigger_ms, metrics
 
 
 def _replay_rnnoise_policy_trigger_ms(
@@ -690,6 +746,7 @@ def evaluate_corpus(
             online_trigger_ms, clip_shadow_metrics = _replay_rnnoise_policy(
                 chunk_evidence,
                 chunk_ms=RNNOISE_CHUNK_MS,
+                silero_probabilities=denoised_probabilities,
             )
             for name, value in asdict(clip_shadow_metrics).items():
                 throttle_shadow_metrics[name] += int(value)

--- a/scripts/evaluate_speech_presence.py
+++ b/scripts/evaluate_speech_presence.py
@@ -660,15 +660,21 @@ def _replay_rnnoise_policy(
     finally:
         replay_vad.close()
 
-    metrics = shadow_policy.shadow_metrics
-    if not silero_probabilities:
-        metrics = ThrottleShadowMetrics(
-            evidence_chunk_count=metrics.evidence_chunk_count,
-            incomplete_chunk_count=metrics.incomplete_chunk_count,
-            rnnoise_trigger_count=metrics.rnnoise_trigger_count,
-            silero_trigger_count=0,
-            rnnoise_silero_disagreement_count=0,
-        )
+    rnnoise_metrics = rnnoise_policy.shadow_metrics
+    shadow_metrics = shadow_policy.shadow_metrics
+    metrics = ThrottleShadowMetrics(
+        evidence_chunk_count=rnnoise_metrics.evidence_chunk_count,
+        incomplete_chunk_count=rnnoise_metrics.incomplete_chunk_count,
+        rnnoise_trigger_count=rnnoise_metrics.rnnoise_trigger_count,
+        silero_trigger_count=(
+            shadow_metrics.silero_trigger_count if silero_probabilities else 0
+        ),
+        rnnoise_silero_disagreement_count=(
+            shadow_metrics.rnnoise_silero_disagreement_count
+            if silero_probabilities
+            else 0
+        ),
+    )
     return trigger_ms, metrics
 
 

--- a/scripts/evaluate_speech_presence.py
+++ b/scripts/evaluate_speech_presence.py
@@ -471,6 +471,7 @@ def _current_rnnoise_policy_trigger_ms(
 
     if frames_per_chunk <= 0:
         raise ValueError("frames_per_chunk must be positive")
+    alpha = AudioProcessor.RNNOISE_EMA_ALPHA
     ema: float | None = None
     chunks: list[RnnoiseEvidence] = []
     for start in range(0, len(frame_probabilities), frames_per_chunk):
@@ -478,7 +479,11 @@ def _current_rnnoise_policy_trigger_ms(
         if not values:
             continue
         for probability in values:
-            ema = probability if ema is None else 0.35 * probability + 0.65 * ema
+            ema = (
+                probability
+                if ema is None
+                else alpha * probability + (1.0 - alpha) * ema
+            )
         mean = sum(values) / len(values)
         evidence = RnnoiseEvidence(
             available=True,
@@ -640,6 +645,7 @@ def evaluate_corpus(
     rss_after_rnnoise = process.memory_info().rss
     vad = SileroVad(enabled=True, asset_dir=asset_dir, intra_op_threads=1)
     if not vad.load():
+        vad.close()
         processor.close()
         raise RuntimeError(f"Silero failed to load: {vad.unavailable_reason}")
 

--- a/scripts/evaluate_speech_presence.py
+++ b/scripts/evaluate_speech_presence.py
@@ -1,0 +1,1020 @@
+#!/usr/bin/env python3
+"""Evaluate RNNoise and Silero as provider-neutral speech-presence evidence.
+
+This benchmark answers only whether a clip might contain speech. It does not
+measure semantic turn completion and cannot grant endpoint authority.
+
+The production-policy replay consumes one evidence record per input chunk:
+RNNoise frame count plus peak, mean, last, and EMA. Sustained-frame scores are
+reported separately as offline candidates and are not production behavior.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import hashlib
+import json
+import math
+import os
+import platform
+import sys
+import time
+from collections import defaultdict
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+import numpy as np
+import psutil
+import soundfile as sf
+import soxr
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from main_logic.asr_client.endpointing.silero_vad import SileroVad  # noqa: E402
+from main_logic.asr_client.endpointing.throttle_policy import (  # noqa: E402
+    ThrottleAction,
+    ThrottleShadowMetrics,
+    VoiceThrottlePolicy,
+)
+from main_logic.voice_turn.activity_evidence import RnnoiseEvidence  # noqa: E402
+from utils.audio_processor import AudioProcessor  # noqa: E402
+
+
+SAMPLE_RATE_48K = 48_000
+SAMPLE_RATE_16K = 16_000
+RNNOISE_CHUNK_MS = 10
+RNNOISE_CURRENT_THRESHOLD = 0.35
+RNNOISE_OFFLINE_SUSTAINED_THRESHOLD = 0.7
+RNNOISE_OFFLINE_SUSTAINED_FRAMES = 10
+SILERO_CURRENT_THRESHOLD = 0.5
+SILERO_OFFSET_THRESHOLD = 0.35
+SILERO_MINIMUM_SPEECH_MS = 200
+SILERO_WINDOW_MS = 1000 * SileroVad.WINDOW_SAMPLES / SileroVad.SAMPLE_RATE
+SILERO_MINIMUM_WINDOWS = max(
+    1,
+    math.ceil(SILERO_MINIMUM_SPEECH_MS / SILERO_WINDOW_MS),
+)
+DEFAULT_SEED = 2398
+DEFAULT_HOLDOUT_FRACTION = 0.25
+PRESENCE_THRESHOLDS = (
+    0.2,
+    0.25,
+    0.3,
+    0.35,
+    0.4,
+    0.45,
+    0.5,
+    0.6,
+    0.7,
+    0.8,
+    0.9,
+    0.95,
+    0.99,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class Confusion:
+    true_positive: int
+    false_negative: int
+    true_negative: int
+    false_positive: int
+
+
+@dataclass(frozen=True, slots=True)
+class CorpusClip:
+    clip_id: str
+    label: bool
+    scenario: str
+    samples_48k: np.ndarray
+    locale: str | None = None
+    snr_db: int | None = None
+    noise_kind: str | None = None
+    speech_start_ms: float | None = None
+    device_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class EvaluatedClip:
+    clip_id: str
+    label: bool
+    scenario: str
+    locale: str | None
+    snr_db: int | None
+    noise_kind: str | None
+    duration_seconds: float
+    rnnoise_chunk_peak: float
+    rnnoise_chunk_ema_peak: float
+    rnnoise_online_trigger_ms: float | None
+    rnnoise_offline_sustained_100ms_score: float
+    rnnoise_offline_sustained_100ms_trigger_ms: float | None
+    silero_raw_score: float
+    silero_after_rnnoise_score: float
+    silero_raw_trigger_ms: float | None
+    silero_after_rnnoise_trigger_ms: float | None
+    speech_start_ms: float | None
+    device_id: str | None
+
+
+def _project_relative_path(path: Path) -> str:
+    try:
+        return path.relative_to(PROJECT_ROOT).as_posix()
+    except ValueError:
+        return "<external>"
+
+
+def source_group_id(clip_id: str) -> str:
+    """Return a stable source identity so augmented variants stay together."""
+
+    parts = str(clip_id).split("/")
+    if len(parts) >= 4 and parts[0] == "speech":
+        return "/".join(parts[:3])
+    return str(clip_id)
+
+
+def confusion_from_predictions(
+    labels: Sequence[bool],
+    predictions: Sequence[bool],
+) -> Confusion:
+    if len(labels) != len(predictions):
+        raise ValueError("labels and predictions must have the same length")
+    tp = fn = tn = fp = 0
+    for label, predicted in zip(labels, predictions, strict=True):
+        if label and predicted:
+            tp += 1
+        elif label:
+            fn += 1
+        elif predicted:
+            fp += 1
+        else:
+            tn += 1
+    return Confusion(tp, fn, tn, fp)
+
+
+def metrics_from_confusion(confusion: Confusion) -> dict[str, float | int]:
+    tp = confusion.true_positive
+    fn = confusion.false_negative
+    tn = confusion.true_negative
+    fp = confusion.false_positive
+
+    def ratio(numerator: float, denominator: float) -> float:
+        return numerator / denominator if denominator else 0.0
+
+    recall = ratio(tp, tp + fn)
+    specificity = ratio(tn, tn + fp)
+    precision = ratio(tp, tp + fp)
+    return {
+        **asdict(confusion),
+        "accuracy": ratio(tp + tn, tp + fn + tn + fp),
+        "balanced_accuracy": (recall + specificity) / 2,
+        "speech_recall": recall,
+        "speech_miss_rate": 1 - recall,
+        "negative_specificity": specificity,
+        "false_positive_rate": 1 - specificity,
+        "precision": precision,
+        "f1": ratio(2 * precision * recall, precision + recall),
+    }
+
+
+def split_calibration_holdout(
+    clips: Sequence[Any],
+    *,
+    seed: int,
+    holdout_fraction: float = DEFAULT_HOLDOUT_FRACTION,
+) -> tuple[list[Any], list[Any]]:
+    """Split by source and stratum without leaking augmented variants."""
+
+    if not 0.0 < holdout_fraction < 1.0:
+        raise ValueError("holdout_fraction must be within (0, 1)")
+    groups: dict[str, list[Any]] = defaultdict(list)
+    for clip in clips:
+        groups[source_group_id(clip.clip_id)].append(clip)
+
+    strata: dict[tuple[bool, str], list[str]] = defaultdict(list)
+    for group_id, group in groups.items():
+        labels = {bool(clip.label) for clip in group}
+        locales = {str(getattr(clip, "locale", None) or "") for clip in group}
+        devices = {
+            str(getattr(clip, "device_id", None) or "") for clip in group
+        }
+        if len(labels) != 1 or len(locales) != 1 or len(devices) != 1:
+            raise ValueError(
+                f"source group is not label/locale/device homogeneous: {group_id}"
+            )
+        label = next(iter(labels))
+        locale = next(iter(locales))
+        device = next(iter(devices))
+        scenario = str(getattr(group[0], "scenario", "") or "unspecified")
+        if device:
+            stratum = f"device:{device}:{scenario}:{locale}"
+        elif label:
+            stratum = f"locale:{locale}"
+        else:
+            stratum = f"scenario:{scenario}"
+        strata[(label, stratum)].append(group_id)
+
+    holdout_groups: set[str] = set()
+    for stratum, group_ids in strata.items():
+        ordered = sorted(
+            group_ids,
+            key=lambda value: hashlib.sha256(
+                f"{seed}:{stratum}:{value}".encode()
+            ).hexdigest(),
+        )
+        if len(ordered) < 2:
+            continue
+        count = max(1, round(len(ordered) * holdout_fraction))
+        holdout_groups.update(ordered[: min(count, len(ordered) - 1)])
+
+    calibration = [
+        clip
+        for clip in clips
+        if source_group_id(clip.clip_id) not in holdout_groups
+    ]
+    holdout = [
+        clip
+        for clip in clips
+        if source_group_id(clip.clip_id) in holdout_groups
+    ]
+    if not calibration or not holdout:
+        raise ValueError("calibration/holdout split requires at least two source groups")
+    return calibration, holdout
+
+
+def select_presence_threshold(
+    clips: Sequence[Any],
+    *,
+    score_name: str,
+    thresholds: Sequence[float],
+) -> dict[str, float | int]:
+    """Select only from calibration data, with deterministic tie-breaking."""
+
+    if not clips or not thresholds:
+        raise ValueError("threshold selection requires clips and thresholds")
+    rows: list[dict[str, float | int]] = []
+    for threshold in thresholds:
+        predictions = [
+            float(getattr(clip, score_name)) >= threshold for clip in clips
+        ]
+        rows.append(
+            {
+                "threshold": float(threshold),
+                **metrics_from_confusion(
+                    confusion_from_predictions(
+                        [bool(clip.label) for clip in clips],
+                        predictions,
+                    )
+                ),
+            }
+        )
+    return max(
+        rows,
+        key=lambda row: (
+            float(row["balanced_accuracy"]),
+            float(row["speech_recall"]),
+            float(row["negative_specificity"]),
+            -float(row["threshold"]),
+        ),
+    )
+
+
+def sustained_presence_score(
+    probabilities: Sequence[float],
+    *,
+    minimum_windows: int = SILERO_MINIMUM_WINDOWS,
+) -> float:
+    if minimum_windows <= 0:
+        raise ValueError("minimum_windows must be positive")
+    if len(probabilities) < minimum_windows:
+        return 0.0
+    values = np.asarray(probabilities, dtype=np.float64)
+    return max(
+        float(np.min(values[index : index + minimum_windows]))
+        for index in range(len(values) - minimum_windows + 1)
+    )
+
+
+def silero_presence_score(
+    probabilities: Sequence[float],
+    *,
+    minimum_windows: int = SILERO_MINIMUM_WINDOWS,
+) -> float:
+    return sustained_presence_score(
+        probabilities,
+        minimum_windows=minimum_windows,
+    )
+
+
+def first_silero_trigger_ms(
+    probabilities: Sequence[float],
+    threshold: float,
+    *,
+    minimum_windows: int = SILERO_MINIMUM_WINDOWS,
+    offset_threshold: float = SILERO_OFFSET_THRESHOLD,
+) -> float | None:
+    speech_windows = 0
+    for index, probability in enumerate(probabilities):
+        if probability >= threshold:
+            speech_windows += 1
+            if speech_windows >= minimum_windows:
+                return (index + 1) * SILERO_WINDOW_MS
+        elif probability < offset_threshold:
+            speech_windows = 0
+    return None
+
+
+def mix_at_snr(
+    speech: np.ndarray,
+    noise: np.ndarray,
+    snr_db: float,
+    *,
+    speech_mask: np.ndarray | None = None,
+) -> np.ndarray:
+    """Build an offline SNR variant; the manifest-only CLI does not call this."""
+
+    if speech.shape != noise.shape:
+        raise ValueError("speech and noise must have the same shape")
+    active = speech if speech_mask is None else speech[speech_mask]
+    speech_rms = float(np.sqrt(np.mean(np.square(active), dtype=np.float64)))
+    noise_rms = float(np.sqrt(np.mean(np.square(noise), dtype=np.float64)))
+    if speech_rms <= 1e-9 or noise_rms <= 1e-9:
+        raise ValueError("speech and noise must both contain energy")
+    target_noise_rms = speech_rms / (10 ** (snr_db / 20))
+    mixed = speech + noise * (target_noise_rms / noise_rms)
+    peak = float(np.max(np.abs(mixed)))
+    if peak > 0.98:
+        mixed *= 0.98 / peak
+    return mixed.astype(np.float32)
+
+
+def _read_mono_48k(path: Path) -> np.ndarray:
+    samples, sample_rate = sf.read(path, dtype="float32", always_2d=True)
+    mono = np.mean(samples, axis=1, dtype=np.float32)
+    if sample_rate != SAMPLE_RATE_48K:
+        mono = soxr.resample(mono, sample_rate, SAMPLE_RATE_48K, quality="HQ")
+    return np.asarray(mono, dtype=np.float32)
+
+
+def load_real_device_manifest(
+    manifest_path: Path,
+) -> tuple[list[CorpusClip], dict[str, Any]]:
+    """Load labeled recordings while excluding local paths from report data."""
+
+    resolved_manifest = manifest_path.resolve()
+    payload = json.loads(resolved_manifest.read_text(encoding="utf-8"))
+    if payload.get("schema_version") != 1:
+        raise ValueError("real-device manifest schema_version must be 1")
+    entries = payload.get("clips")
+    if not isinstance(entries, list) or not entries:
+        raise ValueError("real-device manifest clips must be a non-empty list")
+
+    clips: list[CorpusClip] = []
+    seen_ids: set[str] = set()
+    device_ids: set[str] = set()
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError("real-device manifest clip must be an object")
+        clip_id = str(entry.get("id") or "").strip()
+        device_id = str(entry.get("device_id") or "").strip()
+        if (
+            not clip_id
+            or not device_id
+            or "/" in clip_id
+            or "\\" in clip_id
+            or "/" in device_id
+            or "\\" in device_id
+        ):
+            raise ValueError("real-device id and device_id must be path atoms")
+        report_id = f"real/{device_id}/{clip_id}"
+        if report_id in seen_ids:
+            raise ValueError(f"duplicate real-device clip id: {report_id}")
+        seen_ids.add(report_id)
+        device_ids.add(device_id)
+        label = entry.get("label")
+        if not isinstance(label, bool):
+            raise ValueError(f"real-device label must be boolean: {report_id}")
+        relative_path = entry.get("path")
+        if not isinstance(relative_path, str) or not relative_path.strip():
+            raise ValueError(f"real-device path is required: {report_id}")
+        declared_path = Path(relative_path)
+        audio_path = (resolved_manifest.parent / declared_path).resolve()
+        if declared_path.is_absolute() or not audio_path.is_relative_to(
+            resolved_manifest.parent
+        ):
+            raise ValueError(
+                "real-device path must stay inside the manifest directory: "
+                f"{report_id}"
+            )
+        if not audio_path.is_file():
+            raise FileNotFoundError(audio_path)
+        speech_start = entry.get("speech_start_ms")
+        if speech_start is not None and float(speech_start) < 0:
+            raise ValueError("speech_start_ms must not be negative")
+        clips.append(
+            CorpusClip(
+                clip_id=report_id,
+                label=label,
+                scenario=str(
+                    entry.get("scenario")
+                    or ("real_device_speech" if label else "real_device_negative")
+                ),
+                samples_48k=_read_mono_48k(audio_path),
+                locale=(
+                    str(entry["locale"]).strip() if entry.get("locale") else None
+                ),
+                speech_start_ms=(
+                    float(speech_start) if speech_start is not None else None
+                ),
+                device_id=device_id,
+            )
+        )
+    return clips, {
+        "manifest_schema_version": 1,
+        "clip_count": len(clips),
+        "device_ids": sorted(device_ids),
+    }
+
+
+def _pcm16(samples: np.ndarray) -> bytes:
+    return (
+        np.clip(samples, -1.0, 1.0) * 32767
+    ).round().astype("<i2").tobytes()
+
+
+def _first_sustained_trigger_ms(
+    scores: Sequence[float],
+    threshold: float,
+    minimum_windows: int,
+    frame_ms: float,
+) -> float | None:
+    """Offline-only sustained-window candidate."""
+
+    sustained = 0
+    for index, score in enumerate(scores):
+        sustained = sustained + 1 if score >= threshold else 0
+        if sustained >= minimum_windows:
+            return (index + 1) * frame_ms
+    return None
+
+
+def _current_rnnoise_policy_trigger_ms(
+    frame_probabilities: Sequence[float],
+    *,
+    frames_per_chunk: int = 1,
+) -> float | None:
+    """Replay production-shaped, chunk-level evidence from offline frames."""
+
+    if frames_per_chunk <= 0:
+        raise ValueError("frames_per_chunk must be positive")
+    ema: float | None = None
+    chunks: list[RnnoiseEvidence] = []
+    for start in range(0, len(frame_probabilities), frames_per_chunk):
+        values = frame_probabilities[start : start + frames_per_chunk]
+        if not values:
+            continue
+        for probability in values:
+            ema = probability if ema is None else 0.35 * probability + 0.65 * ema
+        mean = sum(values) / len(values)
+        evidence = RnnoiseEvidence(
+            available=True,
+            frame_count=len(values),
+            peak=max(values),
+            mean=mean,
+            last=values[-1],
+            ema=ema,
+        )
+        chunks.append(evidence)
+    return _replay_rnnoise_policy_trigger_ms(
+        chunks,
+        chunk_ms=float(RNNOISE_CHUNK_MS * frames_per_chunk),
+    )
+
+
+def _rnnoise_process(
+    processor: AudioProcessor,
+    samples_48k: np.ndarray,
+) -> tuple[list[float], list[RnnoiseEvidence], bytes, float, float]:
+    """Capture raw frames for offline candidates and chunk evidence for online replay."""
+
+    chunk_samples = SAMPLE_RATE_48K * RNNOISE_CHUNK_MS // 1000
+    frame_probabilities: list[float] = []
+    chunk_evidence: list[RnnoiseEvidence] = []
+    processed_chunks: list[bytes] = []
+    denoiser = processor._denoiser  # noqa: SLF001 - benchmark instrumentation
+    if denoiser is None:
+        raise RuntimeError("RNNoise native runtime is unavailable")
+    original_process_frame = denoiser.process_frame
+
+    def capture_process_frame(frame: np.ndarray) -> tuple[np.ndarray, float]:
+        denoised, probability = original_process_frame(frame)
+        frame_probabilities.append(float(probability))
+        return denoised, probability
+
+    denoiser.process_frame = capture_process_frame
+    wall_started = time.perf_counter()
+    cpu_started = time.process_time()
+    silence_audio_seconds = 0.0
+    try:
+        for start in range(0, samples_48k.size, chunk_samples):
+            if silence_audio_seconds >= processor.RESET_TIMEOUT_SECONDS:
+                processor.reset()
+                silence_audio_seconds = 0.0
+            frame_start = len(frame_probabilities)
+            input_chunk = samples_48k[start : start + chunk_samples]
+            processed = processor.process_chunk(
+                _pcm16(input_chunk)
+            )
+            if processed:
+                processed_chunks.append(processed)
+            count = processor.rnnoise_frame_count
+            chunk_evidence.append(
+                RnnoiseEvidence(
+                    available=processor.rnnoise_available,
+                    frame_count=count,
+                    peak=processor.rnnoise_probability_peak if count else None,
+                    mean=processor.rnnoise_probability_mean if count else None,
+                    last=processor.rnnoise_probability_last if count else None,
+                    ema=processor.rnnoise_probability_ema if count else None,
+                )
+            )
+            chunk_probabilities = frame_probabilities[frame_start:]
+            last_speech_frame = next(
+                (
+                    index
+                    for index in range(len(chunk_probabilities) - 1, -1, -1)
+                    if (
+                        chunk_probabilities[index]
+                        > AudioProcessor.RNNOISE_SPEECH_PROBABILITY_THRESHOLD
+                    )
+                ),
+                None,
+            )
+            if last_speech_frame is None:
+                silence_audio_seconds += input_chunk.size / SAMPLE_RATE_48K
+            else:
+                trailing_frames = len(chunk_probabilities) - last_speech_frame - 1
+                silence_audio_seconds = (
+                    trailing_frames * RNNOISE_CHUNK_MS / 1000.0
+                )
+    finally:
+        cpu_elapsed = time.process_time() - cpu_started
+        wall_elapsed = time.perf_counter() - wall_started
+        denoiser.process_frame = original_process_frame
+    return (
+        frame_probabilities,
+        chunk_evidence,
+        b"".join(processed_chunks),
+        wall_elapsed,
+        cpu_elapsed,
+    )
+
+
+def _online_trigger_from_chunks(
+    chunks: Sequence[RnnoiseEvidence],
+) -> float | None:
+    return _replay_rnnoise_policy_trigger_ms(
+        chunks,
+        chunk_ms=RNNOISE_CHUNK_MS,
+    )
+
+
+def _replay_rnnoise_policy(
+    chunks: Sequence[RnnoiseEvidence],
+    *,
+    chunk_ms: float,
+) -> tuple[float | None, ThrottleShadowMetrics]:
+    policy = VoiceThrottlePolicy(
+        resource_optimization_enabled=True,
+        bootstrap_onset=RNNOISE_CURRENT_THRESHOLD,
+    )
+    trigger_ms: float | None = None
+    candidate_open = False
+    positive_actions = {
+        ThrottleAction.PREWARM,
+        ThrottleAction.OPEN_CANDIDATE,
+    }
+    for index, evidence in enumerate(chunks):
+        decision = policy.decide(
+            evidence,
+            candidate_open=candidate_open,
+            allow_baseline_update=not candidate_open,
+        )
+        if decision.action in positive_actions:
+            if trigger_ms is None:
+                trigger_ms = (index + 1) * chunk_ms
+            candidate_open = True
+    return trigger_ms, policy.shadow_metrics
+
+
+def _replay_rnnoise_policy_trigger_ms(
+    chunks: Sequence[RnnoiseEvidence],
+    *,
+    chunk_ms: float,
+) -> float | None:
+    trigger_ms, _ = _replay_rnnoise_policy(chunks, chunk_ms=chunk_ms)
+    return trigger_ms
+
+
+def evaluate_corpus(
+    clips: Iterable[CorpusClip],
+    asset_dir: Path,
+) -> tuple[list[EvaluatedClip], dict[str, Any]]:
+    process = psutil.Process(os.getpid())
+    gc.collect()
+    rss_before = process.memory_info().rss
+    processor = AudioProcessor(
+        input_sample_rate=SAMPLE_RATE_48K,
+        output_sample_rate=SAMPLE_RATE_16K,
+        noise_reduce_enabled=True,
+        agc_enabled=True,
+        limiter_enabled=True,
+    )
+    if processor._denoiser is None:  # noqa: SLF001 - benchmark fails closed
+        processor.close()
+        raise RuntimeError("RNNoise native runtime is unavailable")
+    rss_after_rnnoise = process.memory_info().rss
+    vad = SileroVad(enabled=True, asset_dir=asset_dir, intra_op_threads=1)
+    if not vad.load():
+        processor.close()
+        raise RuntimeError(f"Silero failed to load: {vad.unavailable_reason}")
+
+    evaluated: list[EvaluatedClip] = []
+    total_audio_seconds = 0.0
+    rnnoise_wall_seconds = 0.0
+    rnnoise_cpu_seconds = 0.0
+    silero_wall_seconds = 0.0
+    silero_cpu_seconds = 0.0
+    throttle_shadow_metrics: defaultdict[str, int] = defaultdict(int)
+    try:
+        vad.process_pcm16(np.zeros(SileroVad.WINDOW_SAMPLES, dtype="<i2").tobytes())
+        vad.reset_stream()
+        rss_after_silero = process.memory_info().rss
+        for clip in clips:
+            processor.reset()
+            vad.reset_stream()
+            (
+                frame_probabilities,
+                chunk_evidence,
+                processed_16k,
+                rnnoise_wall,
+                rnnoise_cpu,
+            ) = _rnnoise_process(processor, clip.samples_48k)
+            raw_16k = soxr.resample(
+                clip.samples_48k,
+                SAMPLE_RATE_48K,
+                SAMPLE_RATE_16K,
+                quality="HQ",
+            )
+            started_wall = time.perf_counter()
+            started_cpu = time.process_time()
+            raw_probabilities = vad.process_pcm16(_pcm16(raw_16k))
+            vad.reset_stream()
+            denoised_probabilities = vad.process_pcm16(processed_16k)
+            silero_wall_seconds += time.perf_counter() - started_wall
+            silero_cpu_seconds += time.process_time() - started_cpu
+            duration = clip.samples_48k.size / SAMPLE_RATE_48K
+            total_audio_seconds += duration
+            rnnoise_wall_seconds += rnnoise_wall
+            rnnoise_cpu_seconds += rnnoise_cpu
+            online_trigger_ms, clip_shadow_metrics = _replay_rnnoise_policy(
+                chunk_evidence,
+                chunk_ms=RNNOISE_CHUNK_MS,
+            )
+            for name, value in asdict(clip_shadow_metrics).items():
+                throttle_shadow_metrics[name] += int(value)
+            evaluated.append(
+                EvaluatedClip(
+                    clip_id=clip.clip_id,
+                    label=clip.label,
+                    scenario=clip.scenario,
+                    locale=clip.locale,
+                    snr_db=clip.snr_db,
+                    noise_kind=clip.noise_kind,
+                    duration_seconds=duration,
+                    rnnoise_chunk_peak=max(
+                        (
+                            value.peak
+                            for value in chunk_evidence
+                            if value.peak is not None
+                        ),
+                        default=0.0,
+                    ),
+                    rnnoise_chunk_ema_peak=max(
+                        (
+                            value.ema
+                            for value in chunk_evidence
+                            if value.ema is not None
+                        ),
+                        default=0.0,
+                    ),
+                    rnnoise_online_trigger_ms=online_trigger_ms,
+                    rnnoise_offline_sustained_100ms_score=(
+                        sustained_presence_score(
+                            frame_probabilities,
+                            minimum_windows=RNNOISE_OFFLINE_SUSTAINED_FRAMES,
+                        )
+                    ),
+                    rnnoise_offline_sustained_100ms_trigger_ms=(
+                        _first_sustained_trigger_ms(
+                            frame_probabilities,
+                            RNNOISE_OFFLINE_SUSTAINED_THRESHOLD,
+                            RNNOISE_OFFLINE_SUSTAINED_FRAMES,
+                            RNNOISE_CHUNK_MS,
+                        )
+                    ),
+                    silero_raw_score=silero_presence_score(raw_probabilities),
+                    silero_after_rnnoise_score=silero_presence_score(
+                        denoised_probabilities
+                    ),
+                    silero_raw_trigger_ms=first_silero_trigger_ms(
+                        raw_probabilities,
+                        SILERO_CURRENT_THRESHOLD,
+                    ),
+                    silero_after_rnnoise_trigger_ms=first_silero_trigger_ms(
+                        denoised_probabilities,
+                        SILERO_CURRENT_THRESHOLD,
+                    ),
+                    speech_start_ms=clip.speech_start_ms,
+                    device_id=clip.device_id,
+                )
+            )
+    finally:
+        processor.close()
+        vad.close()
+
+    mib = 1024 * 1024
+    denominator = total_audio_seconds or 1.0
+    zero_shadow_metrics = asdict(
+        ThrottleShadowMetrics(
+            evidence_chunk_count=0,
+            incomplete_chunk_count=0,
+            rnnoise_trigger_count=0,
+            silero_trigger_count=0,
+            rnnoise_silero_disagreement_count=0,
+        )
+    )
+    normalized_shadow_metrics = {
+        name: throttle_shadow_metrics.get(name, 0)
+        for name in zero_shadow_metrics
+    }
+    return evaluated, {
+        "total_audio_seconds": total_audio_seconds,
+        "rnnoise_pipeline_wall_realtime_factor": (
+            rnnoise_wall_seconds / denominator
+        ),
+        "rnnoise_pipeline_cpu_realtime_factor": rnnoise_cpu_seconds / denominator,
+        "silero_pair_wall_realtime_factor": silero_wall_seconds / denominator,
+        "silero_pair_cpu_realtime_factor": silero_cpu_seconds / denominator,
+        "rnnoise_rss_delta_mib": (rss_after_rnnoise - rss_before) / mib,
+        "silero_rss_delta_mib": (rss_after_silero - rss_after_rnnoise) / mib,
+        "throttle_shadow_metrics": normalized_shadow_metrics,
+    }
+
+
+def _metrics(
+    clips: Sequence[EvaluatedClip],
+    predictions: Sequence[bool],
+) -> dict[str, float | int]:
+    return metrics_from_confusion(
+        confusion_from_predictions(
+            [clip.label for clip in clips],
+            predictions,
+        )
+    )
+
+
+def build_report(
+    clips: Sequence[EvaluatedClip],
+    *,
+    performance: dict[str, Any],
+    seed: int,
+    asset_dir: Path,
+    corpus_manifest: dict[str, Any],
+) -> dict[str, Any]:
+    calibration, holdout = split_calibration_holdout(clips, seed=seed)
+    selection = select_presence_threshold(
+        calibration,
+        score_name="rnnoise_offline_sustained_100ms_score",
+        thresholds=PRESENCE_THRESHOLDS,
+    )
+    offline_threshold = float(selection["threshold"])
+
+    def online_predictions(values: Sequence[EvaluatedClip]) -> list[bool]:
+        return [clip.rnnoise_online_trigger_ms is not None for clip in values]
+
+    def offline_predictions(values: Sequence[EvaluatedClip]) -> list[bool]:
+        return [
+            clip.rnnoise_offline_sustained_100ms_score >= offline_threshold
+            for clip in values
+        ]
+
+    def distribution(values: Sequence[float]) -> dict[str, float | int | None]:
+        if not values:
+            return {"count": 0, "median": None, "p95": None}
+        samples = np.asarray(values, dtype=np.float64)
+        return {
+            "count": len(values),
+            "median": float(np.median(samples)),
+            "p95": float(np.percentile(samples, 95)),
+        }
+
+    def score_report(score_name: str) -> dict[str, Any]:
+        selected = select_presence_threshold(
+            calibration,
+            score_name=score_name,
+            thresholds=PRESENCE_THRESHOLDS,
+        )
+        threshold = float(selected["threshold"])
+
+        def predictions(values: Sequence[EvaluatedClip]) -> list[bool]:
+            return [
+                float(getattr(clip, score_name)) >= threshold
+                for clip in values
+            ]
+
+        return {
+            "selection": selected,
+            "calibration": _metrics(calibration, predictions(calibration)),
+            "holdout": _metrics(holdout, predictions(holdout)),
+        }
+
+    def onset_latency(trigger_name: str) -> dict[str, float | int | None]:
+        values = [
+            float(trigger) - float(clip.speech_start_ms)
+            for clip in clips
+            if clip.label
+            and clip.speech_start_ms is not None
+            and (trigger := getattr(clip, trigger_name)) is not None
+        ]
+        return distribution(values)
+
+    default_asset_dir = (
+        PROJECT_ROOT
+        / "main_logic"
+        / "asr_client"
+        / "endpointing"
+        / "models"
+    ).resolve()
+    resolved_asset_dir = asset_dir.resolve()
+    reported_asset_dir = _project_relative_path(resolved_asset_dir)
+    default_asset_relative = _project_relative_path(default_asset_dir)
+    shadow_metrics = performance.get("throttle_shadow_metrics")
+    if not isinstance(shadow_metrics, dict):
+        shadow_metrics = asdict(
+            ThrottleShadowMetrics(
+                evidence_chunk_count=0,
+                incomplete_chunk_count=0,
+                rnnoise_trigger_count=0,
+                silero_trigger_count=0,
+                rnnoise_silero_disagreement_count=0,
+            )
+        )
+
+    return {
+        "schema_version": 2,
+        "scope": "speech_presence_only",
+        "revision": os.environ.get("GIT_COMMIT", "working-tree"),
+        "environment": {
+            "platform": platform.platform(),
+            "python": platform.python_version(),
+        },
+        "corpus": corpus_manifest,
+        "corpus_summary": {
+            "clip_count": len(clips),
+            "duration_seconds": sum(clip.duration_seconds for clip in clips),
+            "locales": sorted(
+                {clip.locale for clip in clips if clip.locale is not None}
+            ),
+            "device_ids": sorted(
+                {clip.device_id for clip in clips if clip.device_id is not None}
+            ),
+            "rnnoise_chunk_peak": distribution(
+                [clip.rnnoise_chunk_peak for clip in clips]
+            ),
+            "rnnoise_chunk_ema_peak": distribution(
+                [clip.rnnoise_chunk_ema_peak for clip in clips]
+            ),
+        },
+        "asset_contract": {
+            "silero_directory": reported_asset_dir,
+            "default_directory": default_asset_relative,
+            "uses_default_directory": resolved_asset_dir == default_asset_dir,
+        },
+        "online_contract": {
+            "granularity": "one_input_chunk",
+            "rnnoise_fields": ["frame_count", "peak", "mean", "last", "ema"],
+            "shadow_metric_kinds": [
+                "action_count",
+                "evidence_chunk_count",
+                "disagreement_count",
+            ],
+            "shadow_metrics": shadow_metrics,
+            "calibration": _metrics(
+                calibration,
+                online_predictions(calibration),
+            ),
+            "holdout": _metrics(holdout, online_predictions(holdout)),
+        },
+        "offline_candidates": {
+            "rnnoise_continuous_100ms": {
+                "production_behavior": False,
+                "selection": selection,
+                "calibration": _metrics(
+                    calibration,
+                    offline_predictions(calibration),
+                ),
+                "holdout": _metrics(holdout, offline_predictions(holdout)),
+            }
+        },
+        "silero_paths": {
+            "raw": score_report("silero_raw_score"),
+            "after_rnnoise": score_report("silero_after_rnnoise_score"),
+        },
+        "onset_latency_ms": {
+            "rnnoise_online": onset_latency("rnnoise_online_trigger_ms"),
+            "rnnoise_offline_sustained_100ms": onset_latency(
+                "rnnoise_offline_sustained_100ms_trigger_ms"
+            ),
+            "silero_raw": onset_latency("silero_raw_trigger_ms"),
+            "silero_after_rnnoise": onset_latency(
+                "silero_after_rnnoise_trigger_ms"
+            ),
+        },
+        "performance": performance,
+        "limitations": [
+            "Presence evidence never publishes a provider final.",
+            "The continuous 100ms RNNoise result is offline-only.",
+            (
+                "Its onset latency uses the fixed 0.7 threshold, not the "
+                "calibrated threshold reported for that offline candidate."
+            ),
+            (
+                "Silero onset latency uses onset/offset hysteresis counting, "
+                "not strictly consecutive windows at or above the onset "
+                "threshold used by the sustained score."
+            ),
+            "Repository TTS and synthetic noise do not replace device holdout.",
+            (
+                "Raw Silero uses one-shot soxr.resample on unprocessed audio, "
+                "while the RNNoise path uses AudioProcessor's streaming "
+                "resampler with RNNoise, AGC, and limiter enabled, so their "
+                "score difference is not attributable to RNNoise alone or "
+                "solely to resampling."
+            ),
+            "Reports contain aggregate identities, not local recording paths.",
+        ],
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--real-device-manifest",
+        required=True,
+        type=Path,
+        help="JSON manifest of labeled recordings",
+    )
+    parser.add_argument(
+        "--asset-dir",
+        type=Path,
+        default=(
+            PROJECT_ROOT
+            / "main_logic"
+            / "asr_client"
+            / "endpointing"
+            / "models"
+        ),
+    )
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    clips, manifest = load_real_device_manifest(args.real_device_manifest)
+    evaluated, performance = evaluate_corpus(clips, args.asset_dir.resolve())
+    report = build_report(
+        evaluated,
+        performance=performance,
+        seed=args.seed,
+        asset_dir=args.asset_dir.resolve(),
+        corpus_manifest={"real_device": manifest},
+    )
+    rendered = json.dumps(report, ensure_ascii=False, indent=2)
+    if args.output is None:
+        print(rendered)
+    else:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+        print(f"wrote {args.output}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/evaluate_speech_presence.py
+++ b/scripts/evaluate_speech_presence.py
@@ -18,6 +18,7 @@ import json
 import math
 import os
 import platform
+import subprocess
 import sys
 import time
 from collections import defaultdict
@@ -130,6 +131,36 @@ def _project_relative_path(path: Path) -> str:
         return path.relative_to(PROJECT_ROOT).as_posix()
     except ValueError:
         return "<external>"
+
+
+def _resolve_revision() -> str:
+    override = os.environ.get("GIT_COMMIT")
+    if override:
+        return override
+    try:
+        commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=PROJECT_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        ).stdout.strip()
+        dirty = bool(
+            subprocess.run(
+                ["git", "status", "--porcelain"],
+                cwd=PROJECT_ROOT,
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            ).stdout.strip()
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return "unknown"
+    if not commit:
+        return "unknown"
+    return f"{commit}-dirty" if dirty else commit
 
 
 def source_group_id(clip_id: str) -> str:
@@ -246,7 +277,11 @@ def split_calibration_holdout(
         if source_group_id(clip.clip_id) in holdout_groups
     ]
     if not calibration or not holdout:
-        raise ValueError("calibration/holdout split requires at least two source groups")
+        raise ValueError(
+            "calibration/holdout split requires at least two source groups "
+            "in one label/device/scenario/locale stratum; singleton-only "
+            "strata cannot be split without leakage"
+        )
     return calibration, holdout
 
 
@@ -504,6 +539,46 @@ def _current_rnnoise_policy_trigger_ms(
     )
 
 
+def _processor_rnnoise_evidence(
+    processor: AudioProcessor,
+) -> RnnoiseEvidence:
+    count = processor.rnnoise_frame_count
+    return RnnoiseEvidence(
+        available=processor.rnnoise_available,
+        frame_count=count,
+        peak=processor.rnnoise_probability_peak if count else None,
+        mean=processor.rnnoise_probability_mean if count else None,
+        last=processor.rnnoise_probability_last if count else None,
+        ema=processor.rnnoise_probability_ema if count else None,
+    )
+
+
+def _finalize_rnnoise_stream(
+    processor: AudioProcessor,
+) -> tuple[bytes, RnnoiseEvidence | None]:
+    processed_chunks: list[bytes] = []
+    final_evidence: RnnoiseEvidence | None = None
+    pending_samples = int(getattr(processor, "_frame_buffer_size", 0))
+    if pending_samples:
+        padding_samples = processor.RNNOISE_FRAME_SIZE - pending_samples
+        padded = processor.process_chunk(
+            np.zeros(padding_samples, dtype=np.int16).tobytes()
+        )
+        if padded:
+            processed_chunks.append(padded)
+        final_evidence = _processor_rnnoise_evidence(processor)
+
+    resampler = getattr(processor, "_downsample_resampler", None)
+    if resampler is not None:
+        tail = resampler.resample_chunk(
+            np.empty(0, dtype=np.float32),
+            last=True,
+        )
+        if tail.size:
+            processed_chunks.append(_pcm16(tail))
+    return b"".join(processed_chunks), final_evidence
+
+
 def _rnnoise_process(
     processor: AudioProcessor,
     samples_48k: np.ndarray,
@@ -540,17 +615,7 @@ def _rnnoise_process(
             )
             if processed:
                 processed_chunks.append(processed)
-            count = processor.rnnoise_frame_count
-            chunk_evidence.append(
-                RnnoiseEvidence(
-                    available=processor.rnnoise_available,
-                    frame_count=count,
-                    peak=processor.rnnoise_probability_peak if count else None,
-                    mean=processor.rnnoise_probability_mean if count else None,
-                    last=processor.rnnoise_probability_last if count else None,
-                    ema=processor.rnnoise_probability_ema if count else None,
-                )
-            )
+            chunk_evidence.append(_processor_rnnoise_evidence(processor))
             chunk_probabilities = frame_probabilities[frame_start:]
             last_speech_frame = next(
                 (
@@ -570,6 +635,11 @@ def _rnnoise_process(
                 silence_audio_seconds = (
                     trailing_frames * RNNOISE_CHUNK_MS / 1000.0
                 )
+        final_audio, final_evidence = _finalize_rnnoise_stream(processor)
+        if final_audio:
+            processed_chunks.append(final_audio)
+        if final_evidence is not None:
+            chunk_evidence.append(final_evidence)
     finally:
         cpu_elapsed = time.process_time() - cpu_started
         wall_elapsed = time.perf_counter() - wall_started
@@ -636,14 +706,6 @@ def _replay_rnnoise_policy(
                     trigger_ms = (index + 1) * chunk_ms
                 rnnoise_candidate_open = True
 
-            shadow_decision = shadow_policy.decide(
-                evidence,
-                candidate_open=shadow_candidate_open,
-                allow_baseline_update=not shadow_candidate_open,
-            )
-            if shadow_decision.action in positive_actions:
-                shadow_candidate_open = True
-
             chunk_end_ms = (index + 1) * chunk_ms
             while (
                 silero_probabilities is not None
@@ -657,6 +719,14 @@ def _replay_rnnoise_policy(
                         probability=probability,
                     )
                 silero_index += 1
+
+            shadow_decision = shadow_policy.decide(
+                evidence,
+                candidate_open=shadow_candidate_open,
+                allow_baseline_update=not shadow_candidate_open,
+            )
+            if shadow_decision.action in positive_actions:
+                shadow_candidate_open = True
     finally:
         replay_vad.close()
 
@@ -947,7 +1017,7 @@ def build_report(
     return {
         "schema_version": 2,
         "scope": "speech_presence_only",
-        "revision": os.environ.get("GIT_COMMIT", "working-tree"),
+        "revision": _resolve_revision(),
         "environment": {
             "platform": platform.platform(),
             "python": platform.python_version(),

--- a/tests/unit/asr_client/endpointing/test_throttle_policy.py
+++ b/tests/unit/asr_client/endpointing/test_throttle_policy.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import pytest
+
+from main_logic.asr_client.endpointing.activity_evidence import SileroEvidence
+from main_logic.asr_client.endpointing.throttle_policy import (
+    ThrottleAction,
+    ThrottleStrategy,
+    VoiceThrottlePolicy,
+)
+from main_logic.voice_turn.activity_evidence import RnnoiseEvidence
+from main_logic.voice_turn.contracts import SpeechActivityEvent
+
+
+def _evidence(
+    *,
+    peak: float,
+    mean: float,
+    last: float,
+    frame_count: int = 1,
+) -> RnnoiseEvidence:
+    return RnnoiseEvidence(
+        available=True,
+        frame_count=frame_count,
+        peak=peak,
+        mean=mean,
+        last=last,
+        ema=mean,
+    )
+
+
+def test_disabled_optimization_processes_pcm_without_granting_authority() -> None:
+    policy = VoiceThrottlePolicy(resource_optimization_enabled=False)
+
+    decision = policy.decide(
+        _evidence(peak=0.0, mean=0.0, last=0.0),
+        candidate_open=False,
+        allow_baseline_update=True,
+    )
+
+    assert decision.action is ThrottleAction.PROCESS_PCM
+    assert not {
+        "allow_provider_audio",
+        "complete_turn",
+        "publish_final",
+        "select_provider",
+        "fallback_omni",
+        "bypass_mic_lease",
+    } & {action.value for action in ThrottleAction}
+
+
+def test_rnnoise_onset_uses_peak_instead_of_last_probability() -> None:
+    policy = VoiceThrottlePolicy(resource_optimization_enabled=True)
+
+    decision = policy.decide(
+        _evidence(peak=0.8, mean=0.35, last=0.05),
+        candidate_open=False,
+        allow_baseline_update=False,
+    )
+
+    assert decision.action is ThrottleAction.PREWARM
+
+
+def test_open_candidate_keeps_low_probability_pcm() -> None:
+    policy = VoiceThrottlePolicy(resource_optimization_enabled=True)
+
+    decision = policy.decide(
+        _evidence(peak=0.0, mean=0.0, last=0.0),
+        candidate_open=True,
+        allow_baseline_update=False,
+    )
+
+    assert decision.action is ThrottleAction.KEEP_CANDIDATE_OPEN
+
+
+def test_unavailable_or_incomplete_rnnoise_fails_open_to_local_detection() -> None:
+    policy = VoiceThrottlePolicy(resource_optimization_enabled=True)
+
+    unavailable = policy.decide(
+        RnnoiseEvidence.unavailable(),
+        candidate_open=False,
+        allow_baseline_update=False,
+    )
+    incomplete = policy.decide(
+        RnnoiseEvidence(True, 0, None, None, None, None),
+        candidate_open=False,
+        allow_baseline_update=False,
+    )
+
+    assert unavailable.action is ThrottleAction.OPEN_CANDIDATE
+    assert incomplete.action is ThrottleAction.OPEN_CANDIDATE
+
+
+def test_baseline_updates_only_from_caller_approved_quiet_idle_chunks() -> None:
+    policy = VoiceThrottlePolicy(
+        resource_optimization_enabled=True,
+        minimum_baseline_samples=2,
+        baseline_alpha=1.0,
+    )
+    quiet = _evidence(peak=0.1, mean=0.1, last=0.1)
+    loud = _evidence(peak=0.8, mean=0.7, last=0.6)
+
+    policy.decide(quiet, candidate_open=False, allow_baseline_update=False)
+    policy.decide(quiet, candidate_open=True, allow_baseline_update=True)
+    policy.observe_silero(SpeechActivityEvent.SPEECH_STARTED)
+    policy.decide(quiet, candidate_open=False, allow_baseline_update=True)
+    policy.observe_silero(SpeechActivityEvent.NONE)
+    policy.decide(loud, candidate_open=False, allow_baseline_update=True)
+    assert policy.baseline is None
+
+    policy.decide(quiet, candidate_open=False, allow_baseline_update=True)
+    policy.decide(quiet, candidate_open=False, allow_baseline_update=True)
+
+    assert policy.baseline == 0.1
+    assert policy.onset_threshold == pytest.approx(0.22)
+
+
+def test_onset_threshold_is_bounded_after_baseline_warmup() -> None:
+    high = VoiceThrottlePolicy(
+        resource_optimization_enabled=True,
+        baseline_margin=0.5,
+        maximum_onset=0.65,
+        minimum_baseline_samples=1,
+    )
+    low = VoiceThrottlePolicy(
+        resource_optimization_enabled=True,
+        baseline_margin=0.0,
+        minimum_onset=0.2,
+        minimum_baseline_samples=1,
+    )
+
+    high.decide(
+        _evidence(peak=0.3, mean=0.3, last=0.3),
+        candidate_open=False,
+        allow_baseline_update=True,
+    )
+    low.decide(
+        _evidence(peak=0.05, mean=0.05, last=0.05),
+        candidate_open=False,
+        allow_baseline_update=True,
+    )
+
+    assert high.onset_threshold == 0.65
+    assert low.onset_threshold == 0.2
+
+
+def test_shadow_results_cover_all_supported_strategies() -> None:
+    policy = VoiceThrottlePolicy(resource_optimization_enabled=True)
+
+    decision = policy.decide(
+        _evidence(peak=0.8, mean=0.4, last=0.1),
+        candidate_open=False,
+        allow_baseline_update=False,
+    )
+
+    assert {strategy for strategy, _action in decision.shadow_actions} == set(
+        ThrottleStrategy
+    )
+
+
+def test_candidate_reset_clears_silero_activity_but_keeps_baseline() -> None:
+    policy = VoiceThrottlePolicy(
+        resource_optimization_enabled=True,
+        minimum_baseline_samples=1,
+    )
+    quiet = _evidence(peak=0.1, mean=0.1, last=0.1)
+    policy.decide(quiet, candidate_open=False, allow_baseline_update=True)
+    policy.observe_silero(SpeechActivityEvent.SPEECH_STARTED)
+
+    policy.reset_candidate_activity()
+    decision = policy.decide(
+        quiet,
+        candidate_open=False,
+        allow_baseline_update=False,
+    )
+
+    assert policy.baseline == 0.1
+    assert decision.evidence.silero.activity is None
+    assert decision.action is ThrottleAction.SKIP_IDLE_PCM
+
+
+def test_shadow_metrics_record_only_low_cardinality_outcomes() -> None:
+    policy = VoiceThrottlePolicy(resource_optimization_enabled=True)
+
+    policy.decide(
+        _evidence(peak=0.8, mean=0.4, last=0.1),
+        candidate_open=False,
+        allow_baseline_update=False,
+    )
+    policy.observe_silero(SpeechActivityEvent.SPEECH_STARTED)
+    policy.decide(
+        RnnoiseEvidence(True, 0, None, None, None, None),
+        candidate_open=False,
+        allow_baseline_update=False,
+    )
+
+    metrics = policy.shadow_metrics
+    assert metrics.evidence_chunk_count == 1
+    assert metrics.incomplete_chunk_count == 1
+    assert metrics.rnnoise_trigger_count == 1
+    assert metrics.silero_trigger_count == 1
+    assert metrics.rnnoise_silero_disagreement_count == 2
+    assert not hasattr(metrics, "pcm")
+    assert not hasattr(metrics, "probability_sequence")
+
+
+def test_shadow_actions_do_not_duplicate_confirm_strategy_as_fusion() -> None:
+    policy = VoiceThrottlePolicy(resource_optimization_enabled=True)
+
+    decision = policy.decide(
+        _evidence(peak=0.8, mean=0.4, last=0.1),
+        candidate_open=False,
+        allow_baseline_update=False,
+    )
+
+    strategies = [strategy for strategy, _ in decision.shadow_actions]
+    assert strategies == [
+        ThrottleStrategy.RNNOISE_ONLY,
+        ThrottleStrategy.SILERO_ONLY,
+        ThrottleStrategy.RNNOISE_PREWARM_SILERO_CONFIRM,
+    ]
+    assert len(strategies) == len(set(strategies))
+
+
+def test_unavailable_silero_cannot_carry_activity_or_probability() -> None:
+    with pytest.raises(
+        ValueError,
+        match="unavailable Silero evidence cannot carry activity",
+    ):
+        SileroEvidence(
+            False,
+            SpeechActivityEvent.SPEECH_STARTED,
+            0.9,
+        )

--- a/tests/unit/test_asr_client.py
+++ b/tests/unit/test_asr_client.py
@@ -2183,7 +2183,7 @@ def _patch_runtime_detector_start(
     candidates: list[_RuntimeStartCandidate],
 ) -> list[_RuntimeDetectorStub]:
     detectors: list[_RuntimeDetectorStub] = []
-    selection = SimpleNamespace(provider_key="qwen", endpointing_mode="manual")
+    selection = SimpleNamespace(provider_key="glm", endpointing_mode="manual")
     monkeypatch.setattr(
         asr_runtime_module,
         "_resolve_asr_selection",
@@ -2238,12 +2238,12 @@ def _install_active_runtime_state(
     detector: _RuntimeDetectorStub,
 ) -> None:
     lifecycle = VoiceInputLifecycleController(
-        provider_policy=resolve_provider_policy("qwen", "manual"),
+        provider_policy=resolve_provider_policy("glm", "manual"),
         shadow_mode=False,
     )
     lifecycle.open(route_mode=VoiceRouteMode.INDEPENDENT)
     runtime._asr_session = SimpleNamespace(is_ready=True, close=AsyncMock())
-    runtime._asr_provider = "qwen"
+    runtime._asr_provider = "glm"
     runtime._asr_lifecycle = lifecycle
     runtime._asr_detector = detector
     runtime._asr_current_ingress_token = runtime.capture_ingress_token(
@@ -2287,11 +2287,11 @@ async def test_stale_detector_failure_callback_cannot_close_new_runtime(
     runtime = IndependentAsrRuntime(
         _runtime_callbacks(failures=failures, statuses=statuses)
     )
-    await runtime.start(route_key="qwen", resource_optimization_enabled=True)
+    await runtime.start(route_key="glm", resource_optimization_enabled=True)
     old_detector = detectors[0]
     callback = old_detector.on_endpointing_failure
     assert callback is not None
-    await runtime.start(route_key="qwen", resource_optimization_enabled=True)
+    await runtime.start(route_key="glm", resource_optimization_enabled=True)
     new_session = runtime._asr_session
     new_lifecycle = runtime._asr_lifecycle
     new_detector = runtime._asr_detector
@@ -2319,7 +2319,7 @@ async def test_current_detector_failure_callback_fails_closed_once(monkeypatch) 
     runtime = IndependentAsrRuntime(
         _runtime_callbacks(failures=failures, statuses=statuses)
     )
-    await runtime.start(route_key="qwen", resource_optimization_enabled=True)
+    await runtime.start(route_key="glm", resource_optimization_enabled=True)
     callback = detectors[0].on_endpointing_failure
     assert callback is not None
 
@@ -2414,7 +2414,7 @@ async def test_stale_deferred_turn_release_error_cannot_fail_new_runtime() -> No
     )
     await runtime._handle_independent_asr_endpoint(epoch)
     final = asyncio.create_task(
-        runtime._handle_independent_asr_final("final", epoch, "qwen")
+        runtime._handle_independent_asr_final("final", epoch, "glm")
     )
     await asyncio.wait_for(release_entered.wait(), 1)
     new_session, new_lifecycle, new_detector = _replace_runtime_identity_same_epoch(
@@ -2450,7 +2450,7 @@ async def test_current_deferred_turn_release_error_fails_closed_once() -> None:
     )
     await runtime._handle_independent_asr_endpoint(epoch)
 
-    await runtime._handle_independent_asr_final("final", epoch, "qwen")
+    await runtime._handle_independent_asr_final("final", epoch, "glm")
 
     assert runtime._asr_session is None
     assert runtime._asr_lifecycle is None
@@ -2614,7 +2614,7 @@ async def test_stale_final_lease_unwind_uses_old_dispatcher_only() -> None:
 
     old_lease.release = AsyncMock(side_effect=block_release)
     final = asyncio.create_task(
-        runtime._handle_independent_asr_final("final", epoch, "qwen")
+        runtime._handle_independent_asr_final("final", epoch, "glm")
     )
     await asyncio.wait_for(release_started.wait(), 1)
     await runtime.abort("hard_mute")

--- a/tests/unit/test_asr_detector_runtime.py
+++ b/tests/unit/test_asr_detector_runtime.py
@@ -547,7 +547,7 @@ async def test_provider_candidate_fence_preserves_post_discard_successor() -> No
     await detector.close()
 
 
-async def test_provider_fence_buffers_quiet_pcm_until_final_then_closes() -> None:
+async def test_provider_fence_preserves_quiet_pcm_then_closes_candidate() -> None:
     gate = _Gate()
     detector = DetectorRuntime(
         vad=_Vad(),
@@ -577,7 +577,7 @@ async def test_provider_fence_buffers_quiet_pcm_until_final_then_closes() -> Non
 
     assert successor.throttle_action is ThrottleAction.KEEP_CANDIDATE_OPEN
     assert gate.inputs == [b"\x01\x00", b"\x02\x00"]
-    assert await detector.complete_provider_candidate(fence) is False
+    assert await detector.complete_provider_candidate(fence) is True
     assert detector.candidate_open is False
     quiet = await detector.feed(
         b"\x03\x00",

--- a/tests/unit/test_asr_detector_runtime.py
+++ b/tests/unit/test_asr_detector_runtime.py
@@ -850,7 +850,7 @@ async def test_smart_turn_activity_updates_throttle_shadow_metrics() -> None:
     adapter = detector._semantic_adapter
     assert adapter is not None
     await adapter.wait_idle()
-    await detector.submit_audio(
+    second_result = await detector.submit_audio(
         b"\x02\x00" * 160,
         ingress_token=_ingress_token(),
         sample_rate_hz=16_000,
@@ -860,6 +860,7 @@ async def test_smart_turn_activity_updates_throttle_shadow_metrics() -> None:
     await adapter.wait_idle()
 
     assert result.status is DetectorSubmitStatus.ACCEPTED
+    assert second_result.status is DetectorSubmitStatus.ACCEPTED
     assert detector.throttle_shadow_metrics.rnnoise_trigger_count == 2
     assert detector.throttle_shadow_metrics.silero_trigger_count == 1
     assert detector.throttle_shadow_metrics.rnnoise_silero_disagreement_count == 1

--- a/tests/unit/test_asr_detector_runtime.py
+++ b/tests/unit/test_asr_detector_runtime.py
@@ -20,10 +20,15 @@ from main_logic.asr_client.endpointing.detector import (
     DetectorPrewarmEvent,
     DetectorSubmitStatus,
     DetectorTurnEvent,
+    ProviderCandidateFence,
 )
 from main_logic.asr_client.lifecycle import VoiceIngressToken, VoiceTurnToken
 from main_logic.asr_client.provider_policy import AsrProviderPolicy
-from main_logic.asr_client.endpointing.throttle_policy import ThrottleAction
+from main_logic.asr_client.endpointing.throttle_policy import (
+    ThrottleAction,
+    VoiceThrottlePolicy,
+)
+from main_logic.voice_turn.activity_evidence import RnnoiseEvidence
 from main_logic.voice_turn.contracts import (
     EvaluationStatus,
     SpeechActivityEvent,
@@ -173,6 +178,17 @@ def _smart_turn_policy() -> AsrProviderPolicy:
     )
 
 
+def _provider_endpoint_policy() -> AsrProviderPolicy:
+    return AsrProviderPolicy(
+        transport="streaming",
+        endpoint_authority="provider",
+        smart_turn_required=False,
+        max_segment_ms=None,
+        warm_transport_ms=25_000,
+        replay_policy="preconnect_only",
+    )
+
+
 def _ingress_token() -> VoiceIngressToken:
     return VoiceIngressToken(1, "socket", 1, 1, 1)
 
@@ -242,6 +258,315 @@ async def test_stale_provider_ingress_does_not_mutate_throttle_policy() -> None:
     assert stale.endpointing_available is False
     assert policy.shadow_metrics == before
     assert policy.baseline is None
+    await detector.close()
+
+
+async def test_completion_fence_replays_pcm_consumed_during_inference() -> None:
+    coordinator = _BlockingSemanticCoordinator()
+    gate = _Gate((SpeechActivityEvent.CANDIDATE_PAUSE,))
+    completed = asyncio.Event()
+    detector = DetectorRuntime(
+        vad=_Vad(),
+        gate=gate,
+        provider_policy=_smart_turn_policy(),
+        coordinator=coordinator,
+        on_turn_complete=lambda: completed.set() or asyncio.sleep(0),
+    )
+
+    await detector.submit_audio(
+        b"\x01\x00" * 160,
+        ingress_token=_ingress_token(),
+        sample_rate_hz=16_000,
+        speech_probability=0.9,
+        rnnoise_available=True,
+    )
+    await asyncio.wait_for(coordinator.evaluate_started.wait(), 1)
+    gate.events = ()
+    successor_pcm = b"\x02\x00" * 160
+    successor = await detector.submit_audio(
+        successor_pcm,
+        ingress_token=_ingress_token(),
+        sample_rate_hz=16_000,
+        speech_probability=0.9,
+        rnnoise_available=True,
+    )
+    async with asyncio.timeout(1):
+        while gate.inputs.count(successor_pcm) < 1:
+            await asyncio.sleep(0)
+
+    coordinator.evaluate_release.set()
+    await asyncio.wait_for(completed.wait(), 1)
+    async with asyncio.timeout(1):
+        while gate.inputs.count(successor_pcm) < 2:
+            await asyncio.sleep(0)
+
+    assert successor.candidate is not None
+    assert successor.candidate.candidate_generation == 0
+    assert gate.inputs.count(successor_pcm) == 2
+    assert coordinator.audio.count(successor_pcm) == 2
+    await detector.close()
+
+
+async def test_completed_turn_does_not_clear_successor_candidate_activity() -> None:
+    completion_started = asyncio.Event()
+    completion_release = asyncio.Event()
+    completion_published = asyncio.Event()
+    events: list[object] = []
+    detector: DetectorRuntime
+
+    async def on_event(event: object) -> None:
+        events.append(event)
+        if isinstance(event, DetectorPrewarmEvent):
+            await detector.bind_candidate(
+                event.candidate,
+                VoiceTurnToken(event.ingress.ingress_token, 1),
+            )
+        elif isinstance(event, DetectorTurnEvent):
+            completion_started.set()
+            await completion_release.wait()
+
+    async def on_complete() -> None:
+        completion_published.set()
+
+    gate = _Gate((SpeechActivityEvent.CANDIDATE_PAUSE,))
+    detector = DetectorRuntime(
+        vad=_Vad(),
+        gate=gate,
+        provider_policy=_smart_turn_policy(),
+        coordinator=_SemanticCoordinator(),
+        on_event=on_event,
+        on_turn_complete=on_complete,
+    )
+
+    first = await detector.submit_audio(
+        b"\x01\x00" * 160,
+        ingress_token=_ingress_token(),
+        sample_rate_hz=16_000,
+        speech_probability=0.9,
+        rnnoise_available=True,
+    )
+    await asyncio.wait_for(completion_started.wait(), 1)
+    gate.events = ()
+    successor = await detector.submit_audio(
+        b"\x02\x00" * 160,
+        ingress_token=_ingress_token(),
+        sample_rate_hz=16_000,
+        speech_probability=0.9,
+        rnnoise_available=True,
+    )
+    completion_release.set()
+    await asyncio.wait_for(completion_published.wait(), 1)
+    followup = await detector.submit_audio(
+        b"\x03\x00" * 160,
+        ingress_token=_ingress_token(),
+        sample_rate_hz=16_000,
+        speech_probability=0.0,
+        rnnoise_available=True,
+    )
+
+    completed = [event for event in events if isinstance(event, DetectorTurnEvent)]
+    assert first.candidate is not None
+    assert successor.candidate is not None
+    assert successor.candidate.candidate_generation == (
+        first.candidate.candidate_generation + 1
+    )
+    assert followup.status is DetectorSubmitStatus.ACCEPTED
+    assert detector.candidate_open is True
+    assert len(completed) == 1
+    assert completed[0].bound_turn.candidate == first.candidate
+    await detector.close()
+
+
+async def test_completion_fence_clears_activity_without_successor_pcm() -> None:
+    completed = asyncio.Event()
+    detector = DetectorRuntime(
+        vad=_Vad(),
+        gate=_Gate((SpeechActivityEvent.CANDIDATE_PAUSE,)),
+        provider_policy=_smart_turn_policy(),
+        coordinator=_SemanticCoordinator(),
+        on_turn_complete=lambda: completed.set() or asyncio.sleep(0),
+    )
+    await detector.submit_audio(
+        b"\x01\x00" * 160,
+        ingress_token=_ingress_token(),
+        sample_rate_hz=16_000,
+        speech_probability=0.9,
+        rnnoise_available=True,
+    )
+    await asyncio.wait_for(completed.wait(), 1)
+
+    quiet = await detector.submit_audio(
+        b"\x02\x00" * 160,
+        ingress_token=_ingress_token(),
+        sample_rate_hz=16_000,
+        speech_probability=0.0,
+        rnnoise_available=True,
+    )
+
+    assert quiet.status is DetectorSubmitStatus.SKIPPED_QUIET
+    assert detector.candidate_open is False
+    await detector.close()
+
+
+async def test_completed_candidate_bindings_stay_bounded() -> None:
+    completed: list[DetectorTurnEvent] = []
+    detector: DetectorRuntime
+    next_turn_id = 0
+
+    async def on_event(event: object) -> None:
+        nonlocal next_turn_id
+        if (
+            isinstance(event, DetectorActivityEvent)
+            and event.activity is SpeechActivityEvent.SPEECH_STARTED
+        ):
+            next_turn_id += 1
+            bound = await detector.bind_candidate(
+                event.candidate,
+                VoiceTurnToken(_ingress_token(), turn_id=next_turn_id),
+            )
+            assert bound is not None
+        elif isinstance(event, DetectorTurnEvent):
+            completed.append(event)
+
+    detector = DetectorRuntime(
+        vad=_Vad(),
+        gate=_Gate(
+            (
+                SpeechActivityEvent.SPEECH_STARTED,
+                SpeechActivityEvent.CANDIDATE_PAUSE,
+            )
+        ),
+        provider_policy=_smart_turn_policy(),
+        coordinator=_SemanticCoordinator(),
+        on_event=on_event,
+    )
+
+    for turn_index in range(100):
+        await detector.submit_audio(
+            bytes((turn_index + 1, 0)) * 160,
+            ingress_token=_ingress_token(),
+            sample_rate_hz=16_000,
+            speech_probability=0.9,
+            rnnoise_available=True,
+        )
+        async with asyncio.timeout(1):
+            while len(completed) <= turn_index:
+                await asyncio.sleep(0)
+        assert detector._bound_turns == {}
+        assert detector._deferred_completions == {}
+        await detector.release_deferred_turn()
+
+    assert len(completed) == 100
+    await detector.close()
+
+
+async def test_provider_candidate_fence_preserves_post_discard_successor() -> None:
+    gate = _Gate((SpeechActivityEvent.SPEECH_STARTED,))
+    detector = DetectorRuntime(
+        vad=_Vad(),
+        gate=gate,
+        provider_policy=_provider_endpoint_policy(),
+    )
+    evidence = RnnoiseEvidence.from_legacy_probability(0.9, available=True)
+    await detector.feed(
+        b"\x01\x00",
+        rnnoise_evidence=evidence,
+        ingress_token=_ingress_token(),
+    )
+    fence = await detector.seal_provider_candidate()
+    assert isinstance(fence, ProviderCandidateFence)
+
+    await detector.feed(
+        b"\x02\x00",
+        rnnoise_evidence=evidence,
+        ingress_token=_ingress_token(),
+    )
+    assert await detector.discard_provider_successor(fence) is True
+    await detector.feed(
+        b"\x03\x00",
+        rnnoise_evidence=evidence,
+        ingress_token=_ingress_token(),
+    )
+
+    assert await detector.complete_provider_candidate(fence) is True
+    assert await detector.complete_provider_candidate(fence) is None
+    assert detector._speech_active is True
+    await detector.close()
+
+
+async def test_provider_fence_admits_low_rnnoise_successor_before_final() -> None:
+    gate = _Gate()
+    detector = DetectorRuntime(
+        vad=_Vad(),
+        gate=gate,
+        provider_policy=_provider_endpoint_policy(),
+    )
+    ingress = _ingress_token()
+    await detector.feed(
+        b"\x01\x00",
+        rnnoise_evidence=RnnoiseEvidence.from_legacy_probability(
+            0.9,
+            available=True,
+        ),
+        ingress_token=ingress,
+    )
+    fence = await detector.seal_provider_candidate()
+    assert fence is not None
+
+    successor = await detector.feed(
+        b"\x02\x00",
+        rnnoise_evidence=RnnoiseEvidence.from_legacy_probability(
+            0.05,
+            available=True,
+        ),
+        ingress_token=ingress,
+    )
+
+    assert successor.throttle_action is ThrottleAction.KEEP_CANDIDATE_OPEN
+    assert gate.inputs == [b"\x01\x00", b"\x02\x00"]
+    assert await detector.complete_provider_candidate(fence) is True
+    assert detector.candidate_open is True
+    await detector.close()
+
+
+async def test_provider_candidate_completion_restores_idle_throttle() -> None:
+    policy = VoiceThrottlePolicy(
+        resource_optimization_enabled=True,
+        minimum_baseline_samples=1,
+    )
+    gate = _Gate((SpeechActivityEvent.SPEECH_STARTED,))
+    detector = DetectorRuntime(
+        vad=_Vad(),
+        gate=gate,
+        provider_policy=_provider_endpoint_policy(),
+        throttle_policy=policy,
+    )
+    await detector.feed(
+        b"\x01\x00",
+        rnnoise_evidence=RnnoiseEvidence.from_legacy_probability(
+            0.9,
+            available=True,
+        ),
+        ingress_token=_ingress_token(),
+    )
+    fence = await detector.seal_provider_candidate()
+    assert fence is not None
+    assert await detector.complete_provider_candidate(fence) is False
+    gate.events = ()
+    before = len(gate.inputs)
+
+    quiet = await detector.feed(
+        b"\x02\x00",
+        rnnoise_evidence=RnnoiseEvidence.from_legacy_probability(
+            0.05,
+            available=True,
+        ),
+        ingress_token=_ingress_token(),
+        allow_baseline_update=True,
+    )
+
+    assert quiet.throttle_action is ThrottleAction.SKIP_IDLE_PCM
+    assert len(gate.inputs) == before
     await detector.close()
 
 
@@ -645,7 +970,7 @@ async def test_deferred_completion_retires_candidate_before_third_turn() -> None
 
     await detector.feed(b"\x02\x00" * 160)
     deferred_candidate = candidates[1]
-    assert detector._candidate_generation == 1
+    assert detector._candidate_generation == 2
     assert deferred_candidate not in detector._bound_turns
 
     await detector.release_deferred_turn()

--- a/tests/unit/test_asr_detector_runtime.py
+++ b/tests/unit/test_asr_detector_runtime.py
@@ -12,11 +12,13 @@ from main_logic.asr_client.endpointing.detector_runtime import (
     DetectorRuntime,
     SmartTurnLease,
     SmartTurnReadiness,
+    _AudioItem,
     _ResetItem,
     _VoiceTurnAdapter,
 )
 from main_logic.asr_client.endpointing.detector import (
     DetectorActivityEvent,
+    DetectorIngressIdentity,
     DetectorPrewarmEvent,
     DetectorSubmitStatus,
     DetectorTurnEvent,
@@ -129,6 +131,17 @@ class _BlockingSemanticCoordinator(_SemanticCoordinator):
         self.prepare_started.set()
         await self.prepare_release.wait()
         return True
+
+
+class _ResetClearsSemanticCoordinator(_SemanticCoordinator):
+    def __init__(self) -> None:
+        super().__init__()
+        self.reset_calls = 0
+
+    async def reset(self) -> None:
+        self.reset_calls += 1
+        self.audio.clear()
+        await super().reset()
 
 
 class _RaisingPrepareCoordinator(_SemanticCoordinator):
@@ -304,6 +317,46 @@ async def test_completion_fence_replays_pcm_consumed_during_inference() -> None:
     assert successor.candidate.candidate_generation == 0
     assert gate.inputs.count(successor_pcm) == 2
     assert coordinator.audio.count(successor_pcm) == 2
+    await detector.close()
+
+
+async def test_successor_fence_uses_active_identity_for_queued_pause() -> None:
+    coordinator = _BlockingSemanticCoordinator()
+    detector = DetectorRuntime(
+        vad=_Vad(),
+        gate=_Gate((SpeechActivityEvent.CANDIDATE_PAUSE,)),
+        provider_policy=_smart_turn_policy(),
+        coordinator=coordinator,
+        on_turn_complete=AsyncMock(),
+    )
+    adapter = detector._semantic_adapter
+    assert isinstance(adapter, _VoiceTurnAdapter)
+    await adapter.start()
+    predecessor_identity = (0, 0, 1)
+    active_identity = (1, 0, 2)
+    adapter._identity = active_identity
+    adapter._successor_audio_fence = (
+        predecessor_identity,
+        1,
+        active_identity,
+    )
+
+    await adapter._process_audio(
+        _AudioItem(
+            identity=predecessor_identity,
+            pcm16=b"\x01\x00" * 160,
+            duration_us=10_000,
+            detector_identity=DetectorIngressIdentity(
+                _ingress_token(),
+                detector_epoch=0,
+                sequence_no=2,
+            ),
+        )
+    )
+
+    await asyncio.wait_for(coordinator.evaluate_started.wait(), 1)
+    assert adapter._evaluation_task is not None
+    coordinator.evaluate_release.set()
     await detector.close()
 
 
@@ -494,7 +547,7 @@ async def test_provider_candidate_fence_preserves_post_discard_successor() -> No
     await detector.close()
 
 
-async def test_provider_fence_admits_low_rnnoise_successor_before_final() -> None:
+async def test_provider_fence_buffers_quiet_pcm_until_final_then_closes() -> None:
     gate = _Gate()
     detector = DetectorRuntime(
         vad=_Vad(),
@@ -524,8 +577,19 @@ async def test_provider_fence_admits_low_rnnoise_successor_before_final() -> Non
 
     assert successor.throttle_action is ThrottleAction.KEEP_CANDIDATE_OPEN
     assert gate.inputs == [b"\x01\x00", b"\x02\x00"]
-    assert await detector.complete_provider_candidate(fence) is True
-    assert detector.candidate_open is True
+    assert await detector.complete_provider_candidate(fence) is False
+    assert detector.candidate_open is False
+    quiet = await detector.feed(
+        b"\x03\x00",
+        rnnoise_evidence=RnnoiseEvidence.from_legacy_probability(
+            0.05,
+            available=True,
+        ),
+        ingress_token=ingress,
+        allow_baseline_update=True,
+    )
+    assert quiet.throttle_action is ThrottleAction.SKIP_IDLE_PCM
+    assert gate.inputs == [b"\x01\x00", b"\x02\x00"]
     await detector.close()
 
 
@@ -952,16 +1016,18 @@ async def test_deferred_completion_retires_candidate_before_third_turn() -> None
             assert bound is not None
             assert bound.turn_token == turn_token
 
+    gate = _Gate(
+        (
+            SpeechActivityEvent.SPEECH_STARTED,
+            SpeechActivityEvent.CANDIDATE_PAUSE,
+        )
+    )
+    coordinator = _ResetClearsSemanticCoordinator()
     detector = DetectorRuntime(
         vad=_Vad(),
-        gate=_Gate(
-            (
-                SpeechActivityEvent.SPEECH_STARTED,
-                SpeechActivityEvent.CANDIDATE_PAUSE,
-            )
-        ),
+        gate=gate,
         provider_policy=_smart_turn_policy(),
-        coordinator=_SemanticCoordinator(),
+        coordinator=coordinator,
         on_event=on_event,
     )
 
@@ -969,16 +1035,30 @@ async def test_deferred_completion_retires_candidate_before_third_turn() -> None
     assert detector._candidate_generation == 1
 
     await detector.feed(b"\x02\x00" * 160)
+    async with asyncio.timeout(1):
+        while not detector._deferred_turn_complete:
+            await asyncio.sleep(0)
     deferred_candidate = candidates[1]
     assert detector._candidate_generation == 2
     assert deferred_candidate not in detector._bound_turns
+
+    gate.events = ()
+    third_pcm = b"\x03\x00" * 160
+    await detector.feed(third_pcm)
+    reset_calls = coordinator.reset_calls
 
     await detector.release_deferred_turn()
     assert detector._candidate_generation == 2
     assert deferred_candidate not in detector._bound_turns
     assert deferred_candidate not in detector._deferred_completions
+    assert coordinator.reset_calls == reset_calls
+    assert third_pcm in coordinator.audio
 
-    await detector.feed(b"\x03\x00" * 160)
+    gate.events = (
+        SpeechActivityEvent.SPEECH_STARTED,
+        SpeechActivityEvent.CANDIDATE_PAUSE,
+    )
+    await detector.feed(b"\x04\x00" * 160)
 
     assert [candidate.candidate_generation for candidate in candidates] == [0, 1, 2]
     assert [

--- a/tests/unit/test_asr_detector_runtime.py
+++ b/tests/unit/test_asr_detector_runtime.py
@@ -17,11 +17,13 @@ from main_logic.asr_client.endpointing.detector_runtime import (
 )
 from main_logic.asr_client.endpointing.detector import (
     DetectorActivityEvent,
+    DetectorPrewarmEvent,
     DetectorSubmitStatus,
     DetectorTurnEvent,
 )
 from main_logic.asr_client.lifecycle import VoiceIngressToken, VoiceTurnToken
 from main_logic.asr_client.provider_policy import AsrProviderPolicy
+from main_logic.asr_client.endpointing.throttle_policy import ThrottleAction
 from main_logic.voice_turn.contracts import (
     EvaluationStatus,
     SpeechActivityEvent,
@@ -162,17 +164,85 @@ class _OverflowAdapter:
 
 def _smart_turn_policy() -> AsrProviderPolicy:
     return AsrProviderPolicy(
-        transport="streaming",
+        transport="segmented",
         endpoint_authority="smart_turn",
         smart_turn_required=True,
-        max_segment_ms=None,
-        warm_transport_ms=25_000,
-        replay_policy="preconnect_only",
+        max_segment_ms=30_000,
+        warm_transport_ms=0,
+        replay_policy="none",
     )
 
 
 def _ingress_token() -> VoiceIngressToken:
     return VoiceIngressToken(1, "socket", 1, 1, 1)
+
+
+async def test_provider_prewarm_keeps_candidate_open_until_silero_confirms() -> None:
+    gate = _Gate()
+    detector = DetectorRuntime(
+        vad=_Vad(),
+        gate=gate,
+        provider_policy=_provider_endpoint_policy(),
+    )
+    ingress = _ingress_token()
+
+    prewarm = await detector.feed(
+        b"\x01\x00",
+        rnnoise_evidence=RnnoiseEvidence.from_legacy_probability(
+            0.9,
+            available=True,
+        ),
+        ingress_token=ingress,
+    )
+    followup = await detector.feed(
+        b"\x02\x00",
+        rnnoise_evidence=RnnoiseEvidence.from_legacy_probability(
+            0.05,
+            available=True,
+        ),
+        ingress_token=ingress,
+    )
+
+    assert prewarm.throttle_action is ThrottleAction.PREWARM
+    assert followup.throttle_action is ThrottleAction.KEEP_CANDIDATE_OPEN
+    assert gate.inputs == [b"\x01\x00", b"\x02\x00"]
+    assert detector.candidate_open is True
+    await detector.close()
+
+
+async def test_stale_provider_ingress_does_not_mutate_throttle_policy() -> None:
+    policy = VoiceThrottlePolicy(
+        resource_optimization_enabled=True,
+        minimum_baseline_samples=1,
+    )
+    detector = DetectorRuntime(
+        vad=_Vad(),
+        gate=_Gate(),
+        provider_policy=_provider_endpoint_policy(),
+        throttle_policy=policy,
+    )
+    current_ingress = _ingress_token()
+    await detector.feed(
+        b"\x01\x00",
+        rnnoise_evidence=RnnoiseEvidence.unavailable(),
+        ingress_token=current_ingress,
+    )
+    before = policy.shadow_metrics
+
+    stale = await detector.feed(
+        b"\x02\x00",
+        rnnoise_evidence=RnnoiseEvidence.from_legacy_probability(
+            0.05,
+            available=True,
+        ),
+        ingress_token=VoiceIngressToken(1, "stale-socket", 1, 1, 1),
+        allow_baseline_update=True,
+    )
+
+    assert stale.endpointing_available is False
+    assert policy.shadow_metrics == before
+    assert policy.baseline is None
+    await detector.close()
 
 
 async def test_detector_loads_silero_off_loop_and_returns_activity() -> None:
@@ -185,6 +255,7 @@ async def test_detector_loads_silero_off_loop_and_returns_activity() -> None:
     assert result == DetectorFeedResult(
         events=(SpeechActivityEvent.SPEECH_STARTED,),
         throttle_available=True,
+        throttle_action=ThrottleAction.OPEN_CANDIDATE,
     )
     assert gate.inputs == [b"\x01\x00" * 160]
     assert vad.load_threads and vad.load_threads[0] != threading.get_ident()
@@ -467,6 +538,7 @@ async def test_scoped_detector_events_bind_before_logical_complete() -> None:
         await asyncio.sleep(0.001)
 
     assert [type(event) for event in events] == [
+        DetectorPrewarmEvent,
         DetectorActivityEvent,
         DetectorActivityEvent,
         DetectorTurnEvent,
@@ -597,14 +669,7 @@ async def test_smart_turn_readiness_is_pinned_to_one_logical_turn() -> None:
     detector = DetectorRuntime(
         vad=_Vad(),
         gate=_Gate(),
-        provider_policy=AsrProviderPolicy(
-            transport="streaming",
-            endpoint_authority="smart_turn",
-            smart_turn_required=True,
-            max_segment_ms=None,
-            warm_transport_ms=25_000,
-            replay_policy="preconnect_only",
-        ),
+        provider_policy=_smart_turn_policy(),
         coordinator=coordinator,
         on_turn_complete=AsyncMock(),
     )
@@ -630,6 +695,63 @@ async def test_smart_turn_readiness_is_pinned_to_one_logical_turn() -> None:
     await detector.reset()
     assert detector.smart_turn_readiness is SmartTurnReadiness.UNLOADED
     await next_lease.release()
+    await detector.close()
+
+
+async def test_provider_authority_streaming_never_builds_or_prepares_smart_turn() -> None:
+    coordinator = _SemanticCoordinator()
+    detector = DetectorRuntime(
+        vad=_Vad(),
+        gate=_Gate((SpeechActivityEvent.CANDIDATE_PAUSE,)),
+        provider_policy=AsrProviderPolicy(
+            transport="streaming",
+            endpoint_authority="provider",
+            smart_turn_required=False,
+            max_segment_ms=None,
+            warm_transport_ms=25_000,
+            replay_policy="preconnect_only",
+        ),
+        coordinator=coordinator,
+        on_turn_complete=AsyncMock(),
+    )
+
+    result = await detector.feed(b"\x01\x00" * 160)
+
+    assert result.events == (SpeechActivityEvent.CANDIDATE_PAUSE,)
+    assert detector._semantic_adapter is None
+    assert detector.smart_turn_readiness is SmartTurnReadiness.UNLOADED
+    assert coordinator.prepare_calls == 0
+    assert coordinator.audio == []
+    assert coordinator.state is CoordinatorState.IDLE
+    await detector.close()
+    assert coordinator.state is CoordinatorState.IDLE
+
+
+async def test_manual_streaming_provider_builds_and_prepares_smart_turn() -> None:
+    coordinator = _SemanticCoordinator()
+    detector = DetectorRuntime(
+        vad=_Vad(),
+        gate=_Gate(),
+        provider_policy=AsrProviderPolicy(
+            transport="streaming",
+            endpoint_authority="smart_turn",
+            smart_turn_required=True,
+            max_segment_ms=None,
+            warm_transport_ms=25_000,
+            replay_policy="preconnect_only",
+        ),
+        coordinator=coordinator,
+        on_turn_complete=AsyncMock(),
+    )
+    token = VoiceTurnToken(_ingress_token(), turn_id=1)
+
+    lease = await detector.prepare_endpointing(token)
+
+    assert lease is not None
+    assert detector.smart_turn_readiness is SmartTurnReadiness.READY
+    assert detector.endpointing_ready(token) is True
+    assert coordinator.prepare_calls == 1
+    await lease.release()
     await detector.close()
 
 
@@ -994,14 +1116,7 @@ async def test_silero_unavailable_keeps_periodic_smart_turn_authority() -> None:
     detector = DetectorRuntime(
         vad=_Vad(available=False),
         gate=_Gate(),
-        provider_policy=AsrProviderPolicy(
-            transport="streaming",
-            endpoint_authority="smart_turn",
-            smart_turn_required=True,
-            max_segment_ms=None,
-            warm_transport_ms=25_000,
-            replay_policy="preconnect_only",
-        ),
+        provider_policy=_smart_turn_policy(),
         coordinator=_SemanticCoordinator(),
         on_turn_complete=lambda: completed.set() or asyncio.sleep(0),
     )

--- a/tests/unit/test_asr_detector_runtime.py
+++ b/tests/unit/test_asr_detector_runtime.py
@@ -829,6 +829,43 @@ async def test_candidate_open_prevents_rnnoise_from_skipping_followup_pcm() -> N
     await detector.close()
 
 
+async def test_smart_turn_activity_updates_throttle_shadow_metrics() -> None:
+    policy = VoiceThrottlePolicy(resource_optimization_enabled=True)
+    detector = DetectorRuntime(
+        vad=_Vad(),
+        gate=_Gate((SpeechActivityEvent.SPEECH_STARTED,)),
+        provider_policy=_smart_turn_policy(),
+        coordinator=_SemanticCoordinator(),
+        on_turn_complete=AsyncMock(),
+        throttle_policy=policy,
+    )
+
+    result = await detector.submit_audio(
+        b"\x01\x00" * 160,
+        ingress_token=_ingress_token(),
+        sample_rate_hz=16_000,
+        speech_probability=0.9,
+        rnnoise_available=True,
+    )
+    adapter = detector._semantic_adapter
+    assert adapter is not None
+    await adapter.wait_idle()
+    await detector.submit_audio(
+        b"\x02\x00" * 160,
+        ingress_token=_ingress_token(),
+        sample_rate_hz=16_000,
+        speech_probability=0.9,
+        rnnoise_available=True,
+    )
+    await adapter.wait_idle()
+
+    assert result.status is DetectorSubmitStatus.ACCEPTED
+    assert detector.throttle_shadow_metrics.rnnoise_trigger_count == 2
+    assert detector.throttle_shadow_metrics.silero_trigger_count == 1
+    assert detector.throttle_shadow_metrics.rnnoise_silero_disagreement_count == 1
+    await detector.close()
+
+
 async def test_disabled_resource_optimization_never_skips_quiet_smart_turn_pcm() -> None:
     detector = DetectorRuntime(
         vad=_Vad(),

--- a/tests/unit/test_asr_lifecycle_controller.py
+++ b/tests/unit/test_asr_lifecycle_controller.py
@@ -71,6 +71,22 @@ def test_prewarming_uses_eight_second_pending_connect_buffer() -> None:
     assert controller.pending_connect_bytes == 0
 
 
+def test_prewarm_expiry_returns_to_local_listen_and_clears_buffer() -> None:
+    controller = VoiceInputLifecycleController(
+        provider_policy=resolve_provider_policy("openai", "provider"),
+        shadow_mode=False,
+    )
+    controller.open(route_mode=VoiceRouteMode.INDEPENDENT)
+    controller.transition(VoiceLifecycleEvent.SOFT_WAKE)
+    controller.accept_audio(_pcm(10), sample_rate_hz=16_000)
+    assert controller.pending_connect_bytes == len(_pcm(10))
+
+    controller.transition(VoiceLifecycleEvent.PREWARM_EXPIRED)
+
+    assert controller.snapshot.state is VoiceLifecycleState.LOCAL_LISTEN
+    assert controller.pending_connect_bytes == 0
+
+
 def test_blocked_route_consumes_audio_without_buffer_or_forward() -> None:
     controller = VoiceInputLifecycleController(
         provider_policy=resolve_provider_policy("gemini", "manual"),

--- a/tests/unit/test_asr_voice_turn_adapter.py
+++ b/tests/unit/test_asr_voice_turn_adapter.py
@@ -574,6 +574,63 @@ async def test_silero_keeps_consuming_while_smart_turn_is_blocked() -> None:
     await adapter.close()
 
 
+async def test_evaluation_tail_overflow_uses_backpressure_without_failure() -> None:
+    coordinator = _FakeCoordinator([_complete()], block_evaluation=True)
+    adapter = _VoiceTurnAdapter(
+        vad=_FakeVad(),
+        gate=_FakeGate(
+            [
+                (SpeechActivityEvent.CANDIDATE_PAUSE,),
+                (),
+                (),
+                (),
+            ]
+        ),
+        coordinator=coordinator,
+        on_commit=_noop_commit,
+        queue_capacity_ms=20,
+    )
+    await adapter.start()
+    try:
+        await adapter.push_audio(
+            generation=1,
+            buffer_epoch=1,
+            utterance_id=1,
+            pcm16=b"\x01\x00" * 160,
+        )
+        await asyncio.wait_for(coordinator.evaluate_started.wait(), 1)
+
+        for value in (2, 3):
+            await adapter.push_audio(
+                generation=1,
+                buffer_epoch=1,
+                utterance_id=1,
+                pcm16=bytes((value, 0)) * 160,
+            )
+            await _eventually(lambda: len(coordinator.pushed_audio) >= value)
+
+        with pytest.raises(asyncio.QueueFull):
+            await adapter.push_audio(
+                generation=1,
+                buffer_epoch=1,
+                utterance_id=1,
+                pcm16=b"\x04\x00" * 160,
+            )
+
+        assert adapter.failed is False
+        assert coordinator.pushed_audio == [
+            b"\x01\x00" * 160,
+            b"\x02\x00" * 160,
+            b"\x03\x00" * 160,
+        ]
+        coordinator.evaluate_release.set()
+        await adapter.wait_idle()
+        assert adapter.failed is False
+    finally:
+        coordinator.evaluate_release.set()
+        await adapter.close()
+
+
 async def test_multiple_pauses_coalesce_to_one_followup_evaluation() -> None:
     coordinator = _FakeCoordinator(
         [_failed_evaluation(EvaluationStatus.STALE), _complete()],

--- a/tests/unit/test_audio_memory_optimization.py
+++ b/tests/unit/test_audio_memory_optimization.py
@@ -28,6 +28,14 @@ class _IdentityDenoiser:
         return frame.copy(), 0.1
 
 
+class _ProbabilityDenoiser:
+    def __init__(self, probabilities: list[float]) -> None:
+        self._probabilities = iter(probabilities)
+
+    def process_frame(self, frame: np.ndarray) -> tuple[np.ndarray, float]:
+        return frame.copy(), next(self._probabilities)
+
+
 def _processor() -> AudioProcessor:
     processor = AudioProcessor.__new__(AudioProcessor)
     processor._denoiser = _IdentityDenoiser()
@@ -36,6 +44,17 @@ def _processor() -> AudioProcessor:
     processor._last_speech_prob = 0.0
     processor._last_speech_time = time.time()
     return processor
+
+
+def test_audio_processor_exposes_current_rnnoise_availability() -> None:
+    processor = AudioProcessor.__new__(AudioProcessor)
+    processor.noise_reduce_enabled = True
+    processor._denoiser = _IdentityDenoiser()
+
+    assert processor.rnnoise_available is True
+
+    processor.noise_reduce_enabled = False
+    assert processor.rnnoise_available is False
 
 
 @pytest.mark.parametrize(
@@ -166,3 +185,33 @@ def test_rnnoise_overflow_keeps_latest_one_second() -> None:
 
     np.testing.assert_array_equal(output, audio)
     assert processor._frame_buffer_size == 0
+
+
+def test_rnnoise_evidence_aggregates_every_complete_frame_in_chunk() -> None:
+    processor = _processor()
+    processor._denoiser = _ProbabilityDenoiser([0.1, 0.8, 0.2])
+    audio = np.zeros(processor.RNNOISE_FRAME_SIZE * 3, dtype=np.int16)
+
+    processor._process_with_rnnoise(audio)
+
+    assert processor.rnnoise_frame_count == 3
+    assert processor.rnnoise_probability_peak == pytest.approx(0.8)
+    assert processor.rnnoise_probability_mean == pytest.approx(1.1 / 3.0)
+    assert processor.rnnoise_probability_last == pytest.approx(0.2)
+    assert processor.rnnoise_probability_ema == pytest.approx(0.29425)
+
+
+def test_rnnoise_incomplete_chunk_does_not_reuse_prior_evidence() -> None:
+    processor = _processor()
+    processor._denoiser = _ProbabilityDenoiser([0.75])
+    processor._process_with_rnnoise(
+        np.zeros(processor.RNNOISE_FRAME_SIZE, dtype=np.int16)
+    )
+
+    processor._process_with_rnnoise(np.zeros(100, dtype=np.int16))
+
+    assert processor.rnnoise_frame_count == 0
+    assert processor.rnnoise_probability_peak is None
+    assert processor.rnnoise_probability_mean is None
+    assert processor.rnnoise_probability_last is None
+    assert processor.rnnoise_probability_ema is None

--- a/tests/unit/test_audio_memory_optimization.py
+++ b/tests/unit/test_audio_memory_optimization.py
@@ -201,6 +201,18 @@ def test_rnnoise_evidence_aggregates_every_complete_frame_in_chunk() -> None:
     assert processor.rnnoise_probability_ema == pytest.approx(0.29425)
 
 
+def test_rnnoise_evidence_uses_exposed_ema_alpha() -> None:
+    processor = _processor()
+    processor.RNNOISE_EMA_ALPHA = 0.5
+    processor._denoiser = _ProbabilityDenoiser([0.2, 1.0])
+
+    processor._process_with_rnnoise(
+        np.zeros(processor.RNNOISE_FRAME_SIZE * 2, dtype=np.int16)
+    )
+
+    assert processor.rnnoise_probability_ema == pytest.approx(0.6)
+
+
 def test_rnnoise_incomplete_chunk_does_not_reuse_prior_evidence() -> None:
     processor = _processor()
     processor._denoiser = _ProbabilityDenoiser([0.75])

--- a/tests/unit/test_audio_processor_lifecycle.py
+++ b/tests/unit/test_audio_processor_lifecycle.py
@@ -114,6 +114,52 @@ def test_reenabling_noise_reduction_recreates_frame_buffer(monkeypatch) -> None:
     assert len(output) == 480 * np.dtype(np.int16).itemsize
     processor.close()
 
+def test_toggling_noise_reduction_clears_rnnoise_evidence(monkeypatch) -> None:
+    class _Denoiser:
+        def close(self) -> None:
+            return None
+
+    processor = AudioProcessor(
+        input_sample_rate=48_000,
+        output_sample_rate=48_000,
+        noise_reduce_enabled=False,
+        agc_enabled=False,
+        limiter_enabled=False,
+    )
+    monkeypatch.setattr(
+        processor,
+        "_init_denoiser",
+        lambda: setattr(processor, "_denoiser", _Denoiser()),
+    )
+    processor._last_speech_prob = 0.9
+    processor._rnnoise_frame_count = 2
+    processor._rnnoise_peak = 0.9
+    processor._rnnoise_mean = 0.8
+    processor._rnnoise_last = 0.7
+    processor._rnnoise_ema = 0.6
+    processor._rnnoise_ema_state = 0.5
+
+    processor.set_enabled(True)
+
+    assert processor.speech_probability == 0.0
+    assert processor.rnnoise_frame_count == 0
+    assert processor.rnnoise_probability_peak is None
+    assert processor.rnnoise_probability_mean is None
+    assert processor.rnnoise_probability_last is None
+    assert processor.rnnoise_probability_ema is None
+    assert processor._rnnoise_ema_state is None
+
+    processor._rnnoise_ema = 0.4
+    processor._rnnoise_ema_state = 0.4
+    processor.set_enabled(True)
+    assert processor.rnnoise_probability_ema == 0.4
+    assert processor._rnnoise_ema_state == 0.4
+
+    processor.set_enabled(False)
+    assert processor.rnnoise_probability_ema is None
+    assert processor._rnnoise_ema_state is None
+
+
 
 @pytest.mark.asyncio
 async def test_audio_close_waits_for_executor_chunk_processing() -> None:

--- a/tests/unit/test_audio_processor_lifecycle.py
+++ b/tests/unit/test_audio_processor_lifecycle.py
@@ -149,6 +149,11 @@ def test_toggling_noise_reduction_clears_rnnoise_evidence(monkeypatch) -> None:
     assert processor.rnnoise_probability_ema is None
     assert processor._rnnoise_ema_state is None
 
+    processor._last_speech_prob = 0.3
+    processor._rnnoise_frame_count = 1
+    processor._rnnoise_peak = 0.3
+    processor._rnnoise_mean = 0.2
+    processor._rnnoise_last = 0.1
     processor._rnnoise_ema = 0.4
     processor._rnnoise_ema_state = 0.4
     processor.set_enabled(True)
@@ -156,6 +161,11 @@ def test_toggling_noise_reduction_clears_rnnoise_evidence(monkeypatch) -> None:
     assert processor._rnnoise_ema_state == 0.4
 
     processor.set_enabled(False)
+    assert processor.speech_probability == 0.0
+    assert processor.rnnoise_frame_count == 0
+    assert processor.rnnoise_probability_peak is None
+    assert processor.rnnoise_probability_mean is None
+    assert processor.rnnoise_probability_last is None
     assert processor.rnnoise_probability_ema is None
     assert processor._rnnoise_ema_state is None
 

--- a/tests/unit/test_audio_stream_queue.py
+++ b/tests/unit/test_audio_stream_queue.py
@@ -493,6 +493,7 @@ async def test_independent_audio_route_precedes_omni_websocket_checks():
         sample_rate_hz=16_000,
         speech_probability=0.8,
         rnnoise_available=True,
+        rnnoise_evidence=None,
         ingress_token=token,
     )
     mgr.session.stream_audio.assert_not_awaited()
@@ -530,6 +531,7 @@ async def test_independent_audio_route_does_not_require_omni_session_container()
         sample_rate_hz=16_000,
         speech_probability=0.5,
         rnnoise_available=True,
+        rnnoise_evidence=None,
         ingress_token=token,
     )
     mgr.start_session.assert_not_awaited()
@@ -600,6 +602,7 @@ async def test_hot_swap_flush_preserves_identity_and_detector_metadata():
         sample_rate_hz=16_000,
         speech_probability=0.75,
         rnnoise_available=True,
+        rnnoise_evidence=None,
         ingress_token=token,
     )
     mgr.session.stream_audio.assert_not_awaited()

--- a/tests/unit/test_core_independent_asr.py
+++ b/tests/unit/test_core_independent_asr.py
@@ -24,6 +24,7 @@ from main_logic.asr_client.lifecycle import (
 )
 from main_logic.asr_client.lifecycle import VoiceInputLifecycleController
 from main_logic.asr_client.provider_policy import resolve_provider_policy
+from main_logic.voice_turn.activity_evidence import RnnoiseEvidence
 from main_logic.voice_turn.audio_input import ProcessedVoiceFrame
 from main_logic.voice_turn.contracts import (
     AsrFailureEvent,
@@ -986,11 +987,13 @@ async def test_game_consumer_accepts_real_pcm_through_pipeline(
     runtime._independent_asr_provider = "qwen"
     route_audio = AsyncMock(return_value=True)
     runtime._route_microphone_audio = route_audio
+    evidence = RnnoiseEvidence(True, 3, 0.9, 0.6, 0.2, 0.55)
     processed = ProcessedVoiceFrame(
         pcm16=b"\x01\x00" * 160,
         sample_rate_hz=16_000,
         speech_probability=0.8,
         rnnoise_available=True,
+        rnnoise_evidence=evidence,
     )
     runtime._voice_input_audio_pipeline.process = AsyncMock(return_value=processed)
     token = runtime._capture_ingress_token()
@@ -1010,6 +1013,7 @@ async def test_game_consumer_accepts_real_pcm_through_pipeline(
         sample_rate_hz=processed.sample_rate_hz,
         speech_probability=processed.speech_probability,
         rnnoise_available=processed.rnnoise_available,
+        rnnoise_evidence=evidence,
         ingress_token=token,
     )
 
@@ -1036,11 +1040,13 @@ async def test_game_consumer_submit_preserves_owner_identity(monkeypatch) -> Non
         return_value=AsrSubmitResult(AsrSubmitStatus.ACCEPTED)
     )
     token = runtime._capture_ingress_token()
+    evidence = RnnoiseEvidence(True, 3, 0.9, 0.6, 0.2, 0.55)
     processed = ProcessedVoiceFrame(
         pcm16=b"\x01\x00" * 160,
         sample_rate_hz=16_000,
         speech_probability=0.8,
         rnnoise_available=True,
+        rnnoise_evidence=evidence,
     )
 
     await runtime._route_microphone_audio(
@@ -1048,6 +1054,7 @@ async def test_game_consumer_submit_preserves_owner_identity(monkeypatch) -> Non
         sample_rate_hz=processed.sample_rate_hz,
         speech_probability=processed.speech_probability,
         rnnoise_available=processed.rnnoise_available,
+        rnnoise_evidence=evidence,
         ingress_token=token,
     )
 
@@ -1055,6 +1062,82 @@ async def test_game_consumer_submit_preserves_owner_identity(monkeypatch) -> Non
         processed,
         ingress_token=token,
     )
+
+
+async def test_hot_swap_cache_replay_preserves_rnnoise_evidence() -> None:
+    runtime = _Runtime()
+    runtime.is_active = True
+    runtime.is_hot_swap_imminent = True
+    runtime._set_microphone_route("independent")
+    runtime._independent_asr_provider = "qwen"
+    evidence = RnnoiseEvidence(True, 3, 0.9, 0.6, 0.2, 0.55)
+    processed = ProcessedVoiceFrame(
+        pcm16=b"\x01\x00" * 160,
+        sample_rate_hz=16_000,
+        speech_probability=evidence.peak,
+        rnnoise_available=True,
+        rnnoise_evidence=evidence,
+    )
+    runtime._voice_input_audio_pipeline.process = AsyncMock(return_value=processed)
+    route_audio = AsyncMock(return_value=True)
+    runtime._route_microphone_audio = route_audio
+    token = runtime._capture_ingress_token()
+
+    await runtime._process_microphone_stream_data(
+        {
+            "input_type": "audio",
+            "sample_rate_hz": 16_000,
+            "data": [1] * 160,
+        },
+        ingress_token=token,
+    )
+
+    assert len(runtime.hot_swap_audio_cache) == 1
+    route_audio.assert_not_awaited()
+    runtime.is_hot_swap_imminent = False
+    await runtime._flush_hot_swap_audio_cache()
+
+    route_audio.assert_awaited_once_with(
+        processed.pcm16,
+        sample_rate_hz=processed.sample_rate_hz,
+        speech_probability=processed.speech_probability,
+        rnnoise_available=processed.rnnoise_available,
+        rnnoise_evidence=evidence,
+        ingress_token=token,
+    )
+
+
+async def test_stale_audio_epoch_rejects_processed_rnnoise_evidence() -> None:
+    runtime = _Runtime()
+    runtime.is_active = True
+    runtime.is_hot_swap_imminent = False
+    runtime.is_flushing_hot_swap_cache = False
+    runtime._set_microphone_route("independent")
+    runtime._independent_asr_provider = "qwen"
+    evidence = RnnoiseEvidence(True, 3, 0.9, 0.6, 0.2, 0.55)
+    processed = ProcessedVoiceFrame(
+        pcm16=b"\x01\x00" * 160,
+        sample_rate_hz=16_000,
+        speech_probability=evidence.peak,
+        rnnoise_available=True,
+        rnnoise_evidence=evidence,
+    )
+    runtime._voice_input_audio_pipeline.process = AsyncMock(return_value=processed)
+    route_audio = AsyncMock(return_value=True)
+    runtime._route_microphone_audio = route_audio
+
+    await runtime._process_microphone_stream_data(
+        {
+            "input_type": "audio",
+            "sample_rate_hz": 16_000,
+            "data": [1] * 160,
+        },
+        ingress_token=runtime._capture_ingress_token(),
+        audio_stream_epoch=runtime._audio_stream_epoch + 1,
+    )
+
+    runtime._voice_input_audio_pipeline.process.assert_awaited_once()
+    route_audio.assert_not_awaited()
 
 
 async def test_game_consumer_failure_never_falls_back_to_core(

--- a/tests/unit/test_core_independent_asr.py
+++ b/tests/unit/test_core_independent_asr.py
@@ -17,6 +17,7 @@ from main_logic.asr_client.endpointing.detector_runtime import DetectorFeedResul
 from main_logic.voice_input import VoiceInputDispatchResult
 from main_logic.voice_input.consumers import CoreChatTurnContext
 from main_logic.asr_client.lifecycle import (
+    AudioDisposition,
     VoiceLifecycleEvent,
     VoiceLifecycleState,
     VoiceTurnToken,
@@ -43,6 +44,7 @@ from main_logic.asr_client.endpointing.detector import (
     CoreDetectorEventEnvelope,
     DetectorCandidateKey,
     DetectorIngressIdentity,
+    ProviderCandidateFence,
     DetectorRuntimeEvent,
     DetectorTurnEvent,
     DetectorSubmitResult,
@@ -124,6 +126,11 @@ class _ReadyDetector:
         self.reset = AsyncMock(side_effect=self._reset)
         self.close = AsyncMock()
         self.release_deferred_turn = AsyncMock()
+        self.seal_provider_candidate = AsyncMock(
+            return_value=ProviderCandidateFence(1, 0, 0)
+        )
+        self.complete_provider_candidate = AsyncMock(return_value=False)
+        self.discard_provider_successor = AsyncMock(return_value=True)
 
     async def prepare_endpointing(self, token):
         self._token = token
@@ -2762,7 +2769,10 @@ async def test_draining_pending_turn_overflow_discards_candidate_and_reports_bac
     assert runtime._asr_sealed_turn_token is not None
     assert runtime._asr_lifecycle.pending_turn_bytes == 0
     assert runtime._asr_lifecycle.has_pending_turn is False
-    runtime._asr_detector.reset.assert_awaited_once()
+    runtime._asr_detector.reset.assert_not_awaited()
+    runtime._asr_detector.discard_provider_successor.assert_awaited_once_with(
+        runtime._asr_provider_candidate_fence
+    )
     assert any(
         "ASR_INGRESS_BACKPRESSURE" in call.args[0]
         for call in runtime.send_status.await_args_list
@@ -7587,3 +7597,274 @@ def test_hot_swap_replay_damage_accounts_for_rebound_frames() -> None:
     assert "_invalidate_interrupted_voice_turn" in source[checked_at:], (
         "the damage check must still be what gates the invalidation"
     )
+
+
+async def test_provider_final_preserves_unconfirmed_successor_pcm_as_pre_roll() -> None:
+    runtime = _Runtime()
+    _install_ready_lifecycle(runtime, "openai")
+    detector = runtime._asr_detector
+    assert isinstance(detector, _ReadyDetector)
+    detector.complete_provider_candidate.return_value = True
+    epoch = runtime._asr_session_epoch
+
+    await runtime._handle_independent_asr_activity(
+        SpeechActivityEvent.SPEECH_STARTED,
+        epoch,
+    )
+    await runtime._handle_independent_asr_endpoint(epoch)
+    successor_pcm = b"\x02\x00" * 160
+    assert runtime._asr_lifecycle.accept_audio(
+        successor_pcm,
+        sample_rate_hz=16_000,
+    ).disposition is AudioDisposition.BUFFER
+
+    await runtime._handle_independent_asr_final("first", epoch, "openai")
+    await runtime._handle_independent_asr_activity(
+        SpeechActivityEvent.SPEECH_STARTED,
+        epoch,
+    )
+    decision = runtime._asr_lifecycle.accept_audio(
+        b"\x03\x00" * 160,
+        sample_rate_hz=16_000,
+    )
+
+    assert decision.disposition is AudioDisposition.FORWARD_WITH_PRE_ROLL
+    assert decision.pre_roll.startswith(successor_pcm)
+    detector.complete_provider_candidate.assert_awaited_once()
+
+
+async def test_provider_fence_failure_does_not_accept_final() -> None:
+    runtime = _Runtime()
+    _install_ready_lifecycle(runtime, "openai")
+    detector = runtime._asr_detector
+    assert isinstance(detector, _ReadyDetector)
+    detector.complete_provider_candidate.return_value = None
+    epoch = runtime._asr_session_epoch
+    await runtime._handle_independent_asr_activity(
+        SpeechActivityEvent.SPEECH_STARTED,
+        epoch,
+    )
+    await runtime._handle_independent_asr_endpoint(epoch)
+
+    await runtime._handle_independent_asr_final(
+        "must-not-publish",
+        epoch,
+        "openai",
+    )
+
+    statuses = [json.loads(call.args[0]) for call in runtime.send_status.await_args_list]
+    codes = [payload["code"] for payload in statuses]
+    assert codes.count("ASR_ENDPOINTING_FAILED") == 1
+    assert runtime._asr_accepted_final_keys == {}
+    runtime.handle_input_transcript.assert_not_awaited()
+    assert runtime._asr_route_mode == "blocked"
+
+
+async def test_stale_provider_endpoint_releases_local_final_reservation() -> None:
+    runtime = _Runtime()
+    _install_ready_lifecycle(runtime, "openai")
+    component = runtime._asr_runtime
+    component._runtime_identity_matches = MagicMock(return_value=False)
+    epoch = component._asr_session_epoch
+    await runtime._handle_independent_asr_activity(
+        SpeechActivityEvent.SPEECH_STARTED,
+        epoch,
+    )
+
+    await runtime._handle_independent_asr_endpoint(epoch)
+
+    assert component._asr_reserved_final_key is None
+    assert component._asr_lifecycle.snapshot.state is VoiceLifecycleState.ACTIVE
+
+
+async def test_provider_successor_discard_failure_fails_closed_once() -> None:
+    runtime = _Runtime()
+    _install_ready_lifecycle(runtime, "openai")
+    detector = runtime._asr_detector
+    assert isinstance(detector, _ReadyDetector)
+    detector.discard_provider_successor.side_effect = RuntimeError("private failure")
+    epoch = runtime._asr_session_epoch
+    await runtime._handle_independent_asr_activity(
+        SpeechActivityEvent.SPEECH_STARTED,
+        epoch,
+    )
+    await runtime._handle_independent_asr_endpoint(epoch)
+    ingress_token = runtime._asr_runtime._asr_current_ingress_token
+    assert ingress_token is not None
+
+    await runtime._handle_audio_ingress_backpressure(
+        ingress_token,
+        observed_state=VoiceLifecycleState.DRAINING,
+    )
+
+    statuses = [json.loads(call.args[0]) for call in runtime.send_status.await_args_list]
+    codes = [payload["code"] for payload in statuses]
+    assert codes.count("ASR_ENDPOINTING_FAILED") == 1
+    assert codes.count("ASR_INGRESS_BACKPRESSURE") == 0
+    assert runtime._asr_session_epoch == epoch + 1
+    assert runtime._asr_route_mode == "blocked"
+    assert "private failure" not in str(runtime.send_status.await_args_list)
+
+
+async def test_provider_final_lock_then_overflow_preserves_accepted_final() -> None:
+    runtime = _Runtime()
+    asr = type(
+        "Asr",
+        (),
+        {
+            "is_ready": True,
+            "stream_audio": AsyncMock(),
+            "close": AsyncMock(),
+        },
+    )()
+    runtime._asr_session = asr
+    _install_ready_lifecycle(runtime, "openai")
+    detector = runtime._asr_detector
+    assert isinstance(detector, _ReadyDetector)
+    completion_started = asyncio.Event()
+    completion_release = asyncio.Event()
+
+    async def complete_provider_candidate(_fence) -> bool:
+        completion_started.set()
+        await completion_release.wait()
+        return False
+
+    detector.complete_provider_candidate.side_effect = complete_provider_candidate
+    epoch = runtime._asr_session_epoch
+    await runtime._handle_independent_asr_activity(
+        SpeechActivityEvent.SPEECH_STARTED,
+        epoch,
+    )
+    await runtime._handle_independent_asr_endpoint(epoch)
+    await runtime._handle_independent_asr_activity(
+        SpeechActivityEvent.SPEECH_RESUMED,
+        epoch,
+    )
+    runtime._asr_lifecycle.accept_audio(
+        b"\x01\x00" * 160,
+        sample_rate_hz=16_000,
+    )
+    ingress_token = runtime._asr_runtime._asr_current_ingress_token
+    assert ingress_token is not None
+
+    final_task = asyncio.create_task(
+        runtime._handle_independent_asr_final("first", epoch, "openai")
+    )
+    await asyncio.wait_for(completion_started.wait(), 1)
+    overflow_task = asyncio.create_task(
+        runtime._handle_audio_ingress_backpressure(
+            ingress_token,
+            observed_state=VoiceLifecycleState.DRAINING,
+        )
+    )
+    await asyncio.sleep(0)
+    completion_release.set()
+    await asyncio.gather(final_task, overflow_task)
+    await runtime._wait_asr_transcript_dispatch_idle()
+
+    runtime.handle_input_transcript.assert_awaited_once_with(
+        "first",
+        is_voice_source=True,
+        source="independent_asr",
+        metadata={"provider": "openai"},
+    )
+    assert runtime._asr_lifecycle.has_pending_turn is False
+    assert runtime._asr_sealed_turn_token is None
+
+
+async def test_provider_overflow_lock_then_final_preserves_accepted_final() -> None:
+    runtime = _Runtime()
+    _install_ready_lifecycle(runtime, "openai")
+    detector = runtime._asr_detector
+    assert isinstance(detector, _ReadyDetector)
+    discard_started = asyncio.Event()
+    discard_release = asyncio.Event()
+
+    async def discard_provider_successor(_fence) -> bool:
+        discard_started.set()
+        await discard_release.wait()
+        return True
+
+    detector.discard_provider_successor.side_effect = discard_provider_successor
+    detector.complete_provider_candidate.return_value = False
+    epoch = runtime._asr_session_epoch
+    await runtime._handle_independent_asr_activity(
+        SpeechActivityEvent.SPEECH_STARTED,
+        epoch,
+    )
+    await runtime._handle_independent_asr_endpoint(epoch)
+    ingress_token = runtime._asr_runtime._asr_current_ingress_token
+    assert ingress_token is not None
+
+    overflow_task = asyncio.create_task(
+        runtime._handle_audio_ingress_backpressure(
+            ingress_token,
+            observed_state=VoiceLifecycleState.DRAINING,
+        )
+    )
+    await asyncio.wait_for(discard_started.wait(), 1)
+    final_task = asyncio.create_task(
+        runtime._handle_independent_asr_final("first", epoch, "openai")
+    )
+    await asyncio.sleep(0)
+    assert final_task.done() is False
+    discard_release.set()
+    await asyncio.gather(overflow_task, final_task)
+    await runtime._wait_asr_transcript_dispatch_idle()
+
+    detector.discard_provider_successor.assert_awaited_once()
+    detector.complete_provider_candidate.assert_awaited_once()
+    runtime.handle_input_transcript.assert_awaited_once_with(
+        "first",
+        is_voice_source=True,
+        source="independent_asr",
+        metadata={"provider": "openai"},
+    )
+    assert runtime._asr_lifecycle.snapshot.state is VoiceLifecycleState.WARM_IDLE
+    assert runtime._asr_accepted_final_keys
+
+
+@pytest.mark.parametrize("replacement", ["epoch", "lifecycle", "detector"])
+async def test_provider_overflow_waiting_on_final_lock_is_identity_fenced(
+    replacement: str,
+) -> None:
+    runtime = _Runtime()
+    _install_ready_lifecycle(runtime, "openai")
+    detector = runtime._asr_detector
+    assert isinstance(detector, _ReadyDetector)
+    epoch = runtime._asr_session_epoch
+    await runtime._handle_independent_asr_activity(
+        SpeechActivityEvent.SPEECH_STARTED,
+        epoch,
+    )
+    await runtime._handle_independent_asr_endpoint(epoch)
+    ingress_token = runtime._asr_runtime._asr_current_ingress_token
+    assert ingress_token is not None
+
+    await runtime._asr_final_lock.acquire()
+    overflow_task = asyncio.create_task(
+        runtime._handle_audio_ingress_backpressure(
+            ingress_token,
+            observed_state=VoiceLifecycleState.DRAINING,
+        )
+    )
+    await asyncio.sleep(0)
+    if replacement == "epoch":
+        runtime._asr_session_epoch += 1
+    elif replacement == "lifecycle":
+        replacement_lifecycle = VoiceInputLifecycleController(
+            provider_policy=resolve_provider_policy("openai", "provider"),
+            shadow_mode=False,
+        )
+        replacement_lifecycle.open(route_mode=VoiceRouteMode.INDEPENDENT)
+        runtime._asr_lifecycle = replacement_lifecycle
+    else:
+        runtime._asr_detector = _ReadyDetector()
+    runtime._asr_final_lock.release()
+    await overflow_task
+
+    detector.discard_provider_successor.assert_not_awaited()
+    assert "ASR_INGRESS_BACKPRESSURE" not in str(runtime.send_status.await_args_list)
+    watchdog = runtime._asr_final_watchdog_task
+    if watchdog is not None:
+        watchdog.cancel()

--- a/tests/unit/test_core_independent_asr.py
+++ b/tests/unit/test_core_independent_asr.py
@@ -117,8 +117,10 @@ class _TestSmartTurnLease:
 
 class _ReadyDetector:
     def __init__(self, feed_result: DetectorFeedResult | None = None) -> None:
+        self.detector_epoch = 1
         self._token = None
         self._feed_result = feed_result or DetectorFeedResult((), True)
+        self.bind_candidate = AsyncMock(return_value=object())
         self.reset = AsyncMock(side_effect=self._reset)
         self.close = AsyncMock()
         self.release_deferred_turn = AsyncMock()
@@ -173,6 +175,7 @@ class _QueuedSmartTurnDetector(_ReadyDetector):
                 detector_epoch=1,
                 sequence_no=self._sequence_no,
             ),
+            candidate=DetectorCandidateKey(1, 0),
         )
 
 
@@ -479,10 +482,10 @@ async def test_async_detector_orders_pre_roll_before_smart_turn_seal() -> None:
     asr.stream_audio = AsyncMock()
     asr.signal_user_activity_end = AsyncMock()
     runtime._asr_session = asr
-    runtime._asr_provider = "qwen"
+    runtime._asr_provider = "glm"
     runtime._asr_route_mode = "independent"
     lifecycle = VoiceInputLifecycleController(
-        provider_policy=resolve_provider_policy("qwen", "manual"),
+        provider_policy=resolve_provider_policy("glm", "manual"),
         shadow_mode=False,
     )
     lifecycle.open(route_mode=VoiceRouteMode.INDEPENDENT)
@@ -502,7 +505,7 @@ async def test_async_detector_orders_pre_roll_before_smart_turn_seal() -> None:
     detector = DetectorRuntime(
         vad=Vad(),
         gate=Gate(),
-        provider_policy=resolve_provider_policy("qwen", "manual"),
+        provider_policy=resolve_provider_policy("glm", "manual"),
         coordinator=Coordinator(),
         on_event=on_event,
     )
@@ -594,6 +597,25 @@ async def test_provider_endpoint_does_not_wait_for_smart_turn(
     asr.stream_audio.assert_awaited_once_with(pcm16, sample_rate_hz=16_000)
     assert runtime._asr_route_mode == "independent"
     assert runtime._omni_mic_audio_bytes == 0
+
+
+@pytest.mark.parametrize("provider", ["qwen", "soniox"])
+async def test_manual_streaming_provider_waits_for_smart_turn(
+    provider: str,
+) -> None:
+    runtime = _Runtime()
+    lifecycle = VoiceInputLifecycleController(
+        provider_policy=resolve_provider_policy(provider, "manual"),
+        shadow_mode=False,
+    )
+    lifecycle.open(route_mode=VoiceRouteMode.INDEPENDENT)
+    detector = _FailedSmartTurnDetector()
+    turn_token = VoiceTurnToken(
+        VoiceIngressToken(1, "socket", 1, 1, 1),
+        turn_id=1,
+    )
+
+    assert runtime._asr_endpointing_ready(lifecycle, detector, turn_token) is False
 
 
 async def test_enforced_lifecycle_suppresses_local_silence_upload() -> None:
@@ -2098,7 +2120,7 @@ async def test_provider_final_watchdog_honors_per_provider_policy_timeout() -> N
     )
 
 
-async def test_optimization_disabled_continuously_uploads_with_smart_turn() -> None:
+async def test_optimization_disabled_streaming_uploads_without_smart_turn() -> None:
     runtime = _Runtime()
     runtime._voice_input_resource_optimization_enabled = False
     asr = type("Asr", (), {"is_ready": True, "stream_audio": AsyncMock()})()
@@ -2106,7 +2128,7 @@ async def test_optimization_disabled_continuously_uploads_with_smart_turn() -> N
     runtime._asr_provider = "qwen"
     runtime._asr_route_mode = "independent"
     runtime._asr_lifecycle = VoiceInputLifecycleController(
-        provider_policy=resolve_provider_policy("qwen", "manual"),
+        provider_policy=resolve_provider_policy("qwen", "provider"),
         shadow_mode=False,
         resource_optimization_enabled=False,
     )
@@ -2122,13 +2144,12 @@ async def test_optimization_disabled_continuously_uploads_with_smart_turn() -> N
 
     asr.stream_audio.assert_awaited_once()
     assert runtime._asr_lifecycle.snapshot.state is VoiceLifecycleState.ACTIVE
-    assert runtime._asr_detector.endpointing_ready(
-        runtime._capture_turn_token(runtime._asr_lifecycle)
-    )
+    assert runtime._asr_smart_turn_lease is None
+    assert runtime._asr_detector._token is None
     assert runtime._omni_mic_audio_bytes == 0
 
 
-async def test_smart_turn_fail_open_advances_lifecycle_before_current_frame() -> None:
+async def test_segmented_fail_open_uses_continuous_wake_without_fake_speech() -> None:
     runtime = _Runtime()
     runtime._voice_input_resource_optimization_enabled = False
     asr = type("Asr", (), {"is_ready": True, "stream_audio": AsyncMock()})()
@@ -2149,9 +2170,10 @@ async def test_smart_turn_fail_open_advances_lifecycle_before_current_frame() ->
         sample_rate_hz=16_000,
         rnnoise_available=False,
     )
+    await runtime._asr_detector_dispatcher.wait_idle()
     await runtime._asr_audio_dispatcher.wait_idle()
 
-    detector.force_speech_started.assert_awaited_once()
+    detector.force_speech_started.assert_not_awaited()
     assert runtime._asr_lifecycle.snapshot.state is VoiceLifecycleState.ACTIVE
     asr.stream_audio.assert_awaited_once()
     assert runtime._asr_route_mode == "independent"
@@ -2712,7 +2734,7 @@ async def test_draining_pending_turn_overflow_discards_candidate_and_reports_bac
     runtime._asr_provider = "qwen"
     runtime._asr_route_mode = "independent"
     runtime._asr_lifecycle = VoiceInputLifecycleController(
-        provider_policy=resolve_provider_policy("qwen", "manual"),
+        provider_policy=resolve_provider_policy("qwen", "provider"),
         shadow_mode=False,
     )
     runtime._asr_lifecycle.open(route_mode=VoiceRouteMode.INDEPENDENT)
@@ -2919,7 +2941,14 @@ async def test_deep_sleep_speech_reconnects_and_flushes_pending_audio() -> None:
     runtime._asr_detector = detector
     new_asr = type("Asr", (), {})()
     new_asr.is_ready = True
-    new_asr.connect = AsyncMock()
+    connect_started = asyncio.Event()
+    connect_release = asyncio.Event()
+
+    async def connect() -> None:
+        connect_started.set()
+        await connect_release.wait()
+
+    new_asr.connect = AsyncMock(side_effect=connect)
     new_asr.stream_audio = AsyncMock()
     runtime._asr_session_factory = MagicMock(return_value=new_asr)
     runtime._asr_transport_selection = _selection("qwen")
@@ -2928,6 +2957,11 @@ async def test_deep_sleep_speech_reconnects_and_flushes_pending_audio() -> None:
         b"\x03\x00" * 160,
         sample_rate_hz=16_000,
     )
+    await asyncio.wait_for(connect_started.wait(), 1)
+
+    assert runtime._asr_lifecycle.snapshot.state is VoiceLifecycleState.PREWARMING
+    assert runtime._asr_lifecycle.pending_connect_bytes == 320
+    connect_release.set()
     assert runtime._asr_transport_task is not None
     await runtime._asr_transport_task
 
@@ -2959,7 +2993,14 @@ async def test_smart_turn_fail_open_buffers_until_deep_sleep_transport_reconnect
     runtime._asr_detector = _QueuedSmartTurnDetector()
     new_asr = type("Asr", (), {})()
     new_asr.is_ready = True
-    new_asr.connect = AsyncMock()
+    connect_started = asyncio.Event()
+    connect_release = asyncio.Event()
+
+    async def connect() -> None:
+        connect_started.set()
+        await connect_release.wait()
+
+    new_asr.connect = AsyncMock(side_effect=connect)
     new_asr.stream_audio = AsyncMock()
     runtime._asr_session_factory = MagicMock(return_value=new_asr)
     runtime._asr_transport_selection = _selection(provider)
@@ -2970,11 +3011,14 @@ async def test_smart_turn_fail_open_buffers_until_deep_sleep_transport_reconnect
         sample_rate_hz=16_000,
         rnnoise_available=False,
     )
+    await asyncio.wait_for(connect_started.wait(), 1)
 
     assert runtime._asr_lifecycle.snapshot.state is VoiceLifecycleState.PREWARMING
     assert runtime._asr_route_mode == "independent"
-    assert runtime._asr_transport_task is not None
-    await runtime._asr_transport_task
+    assert runtime._asr_lifecycle.pending_connect_bytes == len(pcm16)
+    connect_release.set()
+    await runtime._asr_detector_dispatcher.wait_idle()
+    await runtime._asr_audio_dispatcher.wait_idle()
 
     assert runtime._asr_lifecycle.snapshot.state is VoiceLifecycleState.ACTIVE
     assert runtime._asr_route_mode == "independent"
@@ -3004,7 +3048,14 @@ async def test_optimization_disabled_buffers_until_initial_transport_is_ready() 
     runtime._asr_detector = _QueuedSmartTurnDetector()
     new_asr = type("Asr", (), {})()
     new_asr.is_ready = True
-    new_asr.connect = AsyncMock()
+    connect_started = asyncio.Event()
+    connect_release = asyncio.Event()
+
+    async def connect() -> None:
+        connect_started.set()
+        await connect_release.wait()
+
+    new_asr.connect = AsyncMock(side_effect=connect)
     new_asr.stream_audio = AsyncMock()
     runtime._asr_session_factory = MagicMock(return_value=new_asr)
     runtime._asr_transport_selection = _selection("glm")
@@ -3015,11 +3066,14 @@ async def test_optimization_disabled_buffers_until_initial_transport_is_ready() 
         sample_rate_hz=16_000,
         rnnoise_available=False,
     )
+    await asyncio.wait_for(connect_started.wait(), 1)
 
     assert runtime._asr_lifecycle.snapshot.state is VoiceLifecycleState.PREWARMING
     assert runtime._asr_route_mode == "independent"
-    assert runtime._asr_transport_task is not None
-    await runtime._asr_transport_task
+    assert runtime._asr_lifecycle.pending_connect_bytes == len(pcm16)
+    connect_release.set()
+    await runtime._asr_detector_dispatcher.wait_idle()
+    await runtime._asr_audio_dispatcher.wait_idle()
 
     assert runtime._asr_lifecycle.snapshot.state is VoiceLifecycleState.ACTIVE
     assert runtime._asr_route_mode == "independent"
@@ -5685,7 +5739,7 @@ async def test_old_detector_endpoint_cannot_seal_replacement_runtime() -> None:
 
 async def test_old_smart_turn_release_cannot_clear_replacement_lease() -> None:
     runtime = _Runtime()
-    _install_ready_lifecycle(runtime, "qwen")
+    _install_ready_lifecycle(runtime, "glm")
     lifecycle = runtime._asr_lifecycle
     detector = runtime._asr_detector
     assert lifecycle is not None
@@ -5711,7 +5765,7 @@ async def test_old_smart_turn_release_cannot_clear_replacement_lease() -> None:
     await asyncio.wait_for(release_started.wait(), 1)
 
     new_session, new_lifecycle, new_detector = _install_replacement_runtime_generation(
-        runtime, "qwen"
+        runtime, "glm"
     )
     new_lease = _TestSmartTurnLease(
         runtime._asr_runtime._capture_turn_token(new_lifecycle)
@@ -7349,11 +7403,11 @@ async def test_accepted_final_dropped_by_generation_bump_abandons_turn(
 
 async def test_accepted_final_identity_loss_before_dispatch_abandons_turn() -> None:
     runtime = _Runtime()
-    _install_ready_lifecycle(runtime, "qwen")
+    _install_ready_lifecycle(runtime, "glm")
     runtime.session.abandon_external_voice_turn = MagicMock()
     component = runtime._asr_runtime
     epoch = component._asr_session_epoch
-    await _start_and_seal_turn(runtime, "qwen")
+    await _start_and_seal_turn(runtime, "glm")
     sealed_turn_id = component._asr_lifecycle.snapshot.turn_id
     lease = component._asr_smart_turn_lease
     assert lease is not None
@@ -7363,7 +7417,7 @@ async def test_accepted_final_identity_loss_before_dispatch_abandons_turn() -> N
 
     lease.release = bumping_release
 
-    await runtime._handle_independent_asr_final("hello", epoch, "qwen")
+    await runtime._handle_independent_asr_final("hello", epoch, "glm")
     await runtime._wait_asr_transcript_dispatch_idle()
 
     runtime.handle_input_transcript.assert_not_awaited()
@@ -7374,10 +7428,14 @@ async def test_accepted_final_identity_loss_before_dispatch_abandons_turn() -> N
 
 async def test_failed_lease_release_does_not_skip_accepted_final_delivery() -> None:
     runtime = _Runtime()
-    _install_ready_lifecycle(runtime, "qwen")
+    _install_ready_lifecycle(runtime, "glm")
     component = runtime._asr_runtime
+    component._asr_lifecycle.provider_policy = replace(
+        component._asr_lifecycle.provider_policy,
+        warm_transport_ms=60_000,
+    )
     epoch = component._asr_session_epoch
-    await _start_and_seal_turn(runtime, "qwen")
+    await _start_and_seal_turn(runtime, "glm")
     lease = component._asr_smart_turn_lease
     assert lease is not None
 
@@ -7386,7 +7444,7 @@ async def test_failed_lease_release_does_not_skip_accepted_final_delivery() -> N
 
     lease.release = raising_release
 
-    await runtime._handle_independent_asr_final("hello", epoch, "qwen")
+    await runtime._handle_independent_asr_final("hello", epoch, "glm")
     await runtime._wait_asr_transcript_dispatch_idle()
 
     assert component._asr_smart_turn_lease is None
@@ -7397,7 +7455,7 @@ async def test_failed_lease_release_does_not_skip_accepted_final_delivery() -> N
         "hello",
         is_voice_source=True,
         source="independent_asr",
-        metadata={"provider": "qwen"},
+        metadata={"provider": "glm"},
     )
     assert component._asr_warm_expiry_task is not None
     component._asr_warm_expiry_task.cancel()

--- a/tests/unit/test_core_independent_asr.py
+++ b/tests/unit/test_core_independent_asr.py
@@ -7963,6 +7963,9 @@ async def test_provider_final_lock_then_overflow_preserves_accepted_final() -> N
         )
     )
     await asyncio.sleep(0)
+    assert final_task.done() is False
+    assert overflow_task.done() is False
+    assert runtime._asr_final_lock.locked()
     completion_release.set()
     await asyncio.gather(final_task, overflow_task)
     await runtime._wait_asr_transcript_dispatch_idle()

--- a/tests/unit/test_core_independent_asr.py
+++ b/tests/unit/test_core_independent_asr.py
@@ -1,7 +1,9 @@
+import ast
 import asyncio
 import inspect
 import json
 import logging
+import textwrap
 import threading
 import time
 from dataclasses import replace
@@ -12,12 +14,17 @@ import pytest
 
 from main_logic.core import LLMSessionManager
 from main_logic.core.asr_runtime import AsrRuntimeMixin, _HotSwapAudioFrame
-from main_logic.asr_client.runtime import AsrStartResult, AsrStartStatus
+from main_logic.asr_client.runtime import (
+    AsrStartResult,
+    AsrStartStatus,
+    IndependentAsrRuntime,
+)
 from main_logic.asr_client.endpointing.detector_runtime import DetectorFeedResult, DetectorRuntime
 from main_logic.voice_input import VoiceInputDispatchResult
 from main_logic.voice_input.consumers import CoreChatTurnContext
 from main_logic.asr_client.lifecycle import (
     AudioDisposition,
+    VoiceLifecycleConfig,
     VoiceLifecycleEvent,
     VoiceLifecycleState,
     VoiceTurnToken,
@@ -34,6 +41,7 @@ from main_logic.voice_turn.contracts import (
     AsrSubmitResult,
     AsrSubmitStatus,
     SpeechActivityEvent,
+    VoiceIngressToken,
     VoicePartialEvent,
     VoiceTranscriptEvent,
 )
@@ -2908,18 +2916,19 @@ async def test_initial_ready_transport_also_expires_from_local_listen() -> None:
     asr = type("Asr", (), {"close": AsyncMock()})()
     runtime._asr_session = asr
     runtime._asr_route_mode = "independent"
-    policy = replace(
-        resolve_provider_policy("qwen", "manual"),
-        warm_transport_ms=10,
-    )
+    policy = replace(resolve_provider_policy("qwen", "manual"), warm_transport_ms=1_000)
     runtime._asr_lifecycle = VoiceInputLifecycleController(
         provider_policy=policy,
+        config=VoiceLifecycleConfig(default_warm_transport_ms=0),
         shadow_mode=False,
     )
     runtime._asr_lifecycle.open(route_mode=VoiceRouteMode.INDEPENDENT)
 
-    runtime._schedule_transport_warm_expiry(runtime._asr_session_epoch)
-    # 同上：10ms TTL 落在 Windows 定时器分辨率的量级里，固定 sleep 赌不起；
+    runtime._schedule_transport_warm_expiry(
+        runtime._asr_session_epoch,
+        expected_state=VoiceLifecycleState.LOCAL_LISTEN,
+    )
+    # default_warm_transport_ms=0 会立刻到期，固定 sleep 赌不起；
     # 到期任务本身就是「已过期并关闭」的同步点。
     expiry = runtime._asr_warm_expiry_task
     assert expiry is not None
@@ -2928,6 +2937,202 @@ async def test_initial_ready_transport_also_expires_from_local_listen() -> None:
     assert runtime._asr_session is None
     assert runtime._asr_lifecycle.snapshot.state is VoiceLifecycleState.DEEP_SLEEP
     asr.close.assert_awaited_once_with()
+
+
+async def test_prewarming_uses_idle_transport_ttl() -> None:
+    runtime = _Runtime()
+    asr = type("Asr", (), {"close": AsyncMock()})()
+    runtime._asr_session = asr
+    runtime._asr_route_mode = "independent"
+    policy = replace(resolve_provider_policy("openai", "provider"), warm_transport_ms=1_000)
+    lifecycle = VoiceInputLifecycleController(
+        provider_policy=policy,
+        config=VoiceLifecycleConfig(default_warm_transport_ms=0),
+        shadow_mode=False,
+    )
+    lifecycle.open(route_mode=VoiceRouteMode.INDEPENDENT)
+    lifecycle.transition(VoiceLifecycleEvent.SOFT_WAKE)
+    runtime._asr_lifecycle = lifecycle
+
+    runtime._schedule_transport_warm_expiry(
+        runtime._asr_session_epoch,
+        expected_state=VoiceLifecycleState.PREWARMING,
+    )
+    expiry = runtime._asr_warm_expiry_task
+    assert expiry is not None
+    await asyncio.wait_for(expiry, 1)
+
+    assert runtime._asr_session is None
+    assert lifecycle.snapshot.state is VoiceLifecycleState.DEEP_SLEEP
+    asr.close.assert_awaited_once_with()
+
+
+async def test_warm_idle_uses_provider_transport_ttl() -> None:
+    runtime = _Runtime()
+    asr = type("Asr", (), {"close": AsyncMock()})()
+    runtime._asr_session = asr
+    runtime._asr_route_mode = "independent"
+    policy = replace(resolve_provider_policy("openai", "provider"), warm_transport_ms=0)
+    lifecycle = VoiceInputLifecycleController(
+        provider_policy=policy,
+        config=VoiceLifecycleConfig(default_warm_transport_ms=1_000),
+        shadow_mode=False,
+    )
+    lifecycle.open(route_mode=VoiceRouteMode.INDEPENDENT)
+    lifecycle.transition(VoiceLifecycleEvent.SOFT_WAKE)
+    lifecycle.transition(VoiceLifecycleEvent.SPEECH_CONFIRMED)
+    lifecycle.transition(VoiceLifecycleEvent.TURN_SEALED)
+    lifecycle.transition(VoiceLifecycleEvent.PROVIDER_FINAL)
+    runtime._asr_lifecycle = lifecycle
+
+    runtime._schedule_transport_warm_expiry(
+        runtime._asr_session_epoch,
+        expected_state=VoiceLifecycleState.WARM_IDLE,
+    )
+    expiry = runtime._asr_warm_expiry_task
+    assert expiry is not None
+    await asyncio.wait_for(expiry, 1)
+
+    assert runtime._asr_session is None
+    assert lifecycle.snapshot.state is VoiceLifecycleState.DEEP_SLEEP
+    asr.close.assert_awaited_once_with()
+
+
+@pytest.mark.parametrize(
+    "replacement",
+    ["epoch", "lifecycle", "session", "transport", "state"],
+)
+async def test_stale_transport_expiry_never_closes_successor(
+    replacement: str,
+) -> None:
+    runtime = _Runtime()
+    original_session = type("Asr", (), {"close": AsyncMock()})()
+    runtime._asr_session = original_session
+    runtime._asr_route_mode = "independent"
+    policy = replace(resolve_provider_policy("openai", "provider"), warm_transport_ms=0)
+    original_lifecycle = VoiceInputLifecycleController(
+        provider_policy=policy,
+        shadow_mode=False,
+    )
+    original_lifecycle.open(route_mode=VoiceRouteMode.INDEPENDENT)
+    original_lifecycle.transition(VoiceLifecycleEvent.SOFT_WAKE)
+    original_lifecycle.transition(VoiceLifecycleEvent.SPEECH_CONFIRMED)
+    original_lifecycle.transition(VoiceLifecycleEvent.TURN_SEALED)
+    original_lifecycle.transition(VoiceLifecycleEvent.PROVIDER_FINAL)
+    runtime._asr_lifecycle = original_lifecycle
+    runtime._schedule_transport_warm_expiry(
+        runtime._asr_session_epoch,
+        expected_state=VoiceLifecycleState.WARM_IDLE,
+    )
+
+    successor_session = type("Asr", (), {"close": AsyncMock()})()
+    if replacement == "epoch":
+        runtime._asr_session_epoch += 1
+    elif replacement == "lifecycle":
+        successor_lifecycle = VoiceInputLifecycleController(
+            provider_policy=policy,
+            shadow_mode=False,
+        )
+        successor_lifecycle.open(route_mode=VoiceRouteMode.INDEPENDENT)
+        runtime._asr_lifecycle = successor_lifecycle
+    elif replacement == "session":
+        runtime._asr_session = successor_session
+    elif replacement == "transport":
+        original_lifecycle.invalidate_transport()
+    else:
+        original_lifecycle.transition(VoiceLifecycleEvent.SOFT_WAKE)
+        original_lifecycle.transition(VoiceLifecycleEvent.SPEECH_CONFIRMED)
+
+    expected_current_session = (
+        successor_session if replacement == "session" else original_session
+    )
+    assert runtime._asr_session is expected_current_session
+    expiry = runtime._asr_warm_expiry_task
+    assert expiry is not None
+    await asyncio.wait_for(expiry, 1)
+
+    original_session.close.assert_not_awaited()
+    expected_current_session.close.assert_not_awaited()
+
+
+async def test_prewarm_expiry_rechecks_identity_after_detector_reset() -> None:
+    runtime = _Runtime()
+    original_session = type("Asr", (), {"close": AsyncMock()})()
+    runtime._asr_session = original_session
+    runtime._asr_route_mode = "independent"
+    policy = replace(resolve_provider_policy("openai", "provider"), warm_transport_ms=1_000)
+    lifecycle = VoiceInputLifecycleController(
+        provider_policy=policy,
+        config=VoiceLifecycleConfig(default_warm_transport_ms=0),
+        shadow_mode=False,
+    )
+    lifecycle.open(route_mode=VoiceRouteMode.INDEPENDENT)
+    lifecycle.transition(VoiceLifecycleEvent.SOFT_WAKE)
+    runtime._asr_lifecycle = lifecycle
+    reset_started = asyncio.Event()
+    reset_release = asyncio.Event()
+    detector = _ReadyDetector()
+
+    async def reset() -> None:
+        reset_started.set()
+        await reset_release.wait()
+
+    detector.reset.side_effect = reset
+    runtime._asr_detector = detector
+    runtime._schedule_transport_warm_expiry(
+        runtime._asr_session_epoch,
+        expected_state=VoiceLifecycleState.PREWARMING,
+    )
+    await asyncio.wait_for(reset_started.wait(), 1)
+
+    successor_session = type("Asr", (), {"close": AsyncMock()})()
+    runtime._asr_session = successor_session
+    reset_release.set()
+    expiry = runtime._asr_warm_expiry_task
+    assert expiry is not None
+    await asyncio.wait_for(expiry, 1)
+
+    assert lifecycle.snapshot.state is VoiceLifecycleState.PREWARMING
+    original_session.close.assert_not_awaited()
+    successor_session.close.assert_not_awaited()
+
+
+async def test_submit_without_lifecycle_returns_typed_unavailable() -> None:
+    runtime = _Runtime()
+    result = await runtime._asr_runtime.submit(
+        ProcessedVoiceFrame(b"\x01\x00" * 160, 16_000, 0.0, False),
+        ingress_token=VoiceIngressToken(0, "socket", 0, 0, 0),
+    )
+
+    assert result == AsrSubmitResult(AsrSubmitStatus.UNAVAILABLE)
+    assert not isinstance(result, bool)
+
+
+async def test_submit_has_only_typed_top_level_return_paths() -> None:
+    source = textwrap.dedent(inspect.getsource(IndependentAsrRuntime.submit))
+    function = ast.parse(source).body[0]
+    assert isinstance(function, ast.AsyncFunctionDef)
+    returns: list[ast.Return] = []
+
+    def collect(node: ast.AST) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+                continue
+            if isinstance(child, ast.Return):
+                returns.append(child)
+            else:
+                collect(child)
+
+    for statement in function.body:
+        collect(statement)
+
+    assert returns
+    assert all(
+        isinstance(return_node.value, ast.Call)
+        and isinstance(return_node.value.func, ast.Name)
+        and return_node.value.func.id == "AsrSubmitResult"
+        for return_node in returns
+    )
 
 
 async def test_deep_sleep_speech_reconnects_and_flushes_pending_audio() -> None:

--- a/tests/unit/test_voice_input_audio_pipeline.py
+++ b/tests/unit/test_voice_input_audio_pipeline.py
@@ -14,6 +14,11 @@ class _Processor:
         self.closed = False
         self.speech_probability = 0.75
         self.rnnoise_available = True
+        self.rnnoise_frame_count = 3
+        self.rnnoise_probability_peak = 0.9
+        self.rnnoise_probability_mean = 0.6
+        self.rnnoise_probability_last = 0.2
+        self.rnnoise_probability_ema = 0.55
 
     def process_chunk(self, pcm16: bytes) -> bytes:
         self.inputs.append(pcm16)
@@ -35,6 +40,8 @@ async def test_pipeline_passes_16k_without_creating_rnnoise_processor() -> None:
     assert frame.pcm16 == pcm16
     assert frame.sample_rate_hz == 16_000
     assert frame.speech_probability is None
+    assert frame.rnnoise_evidence is not None
+    assert frame.rnnoise_evidence.available is False
     assert created == []
 
 
@@ -48,10 +55,30 @@ async def test_pipeline_owns_48k_processor_and_exposes_rnnoise_probability() -> 
     assert processor.inputs == [source]
     assert frame.pcm16 == b"\x02\x00" * 160
     assert frame.sample_rate_hz == 16_000
-    assert frame.speech_probability == 0.75
+    assert frame.speech_probability == 0.9
     assert frame.rnnoise_available is True
+    assert frame.rnnoise_evidence is not None
+    assert frame.rnnoise_evidence.frame_count == 3
+    assert frame.rnnoise_evidence.peak == 0.9
+    assert frame.rnnoise_evidence.mean == 0.6
+    assert frame.rnnoise_evidence.last == 0.2
+    assert frame.rnnoise_evidence.ema == 0.55
     await pipeline.close()
     assert processor.closed is True
+
+
+async def test_pipeline_does_not_reuse_stale_evidence_when_rnnoise_unavailable() -> None:
+    processor = _Processor()
+    processor.rnnoise_available = False
+    pipeline = VoiceInputAudioPipeline(processor_factory=lambda: processor)
+
+    frame = await pipeline.process(b"\x01\x00" * 480, sample_rate_hz=48_000)
+
+    assert frame.speech_probability is None
+    assert frame.rnnoise_available is False
+    assert frame.rnnoise_evidence is not None
+    assert frame.rnnoise_evidence.available is False
+    assert frame.rnnoise_evidence.frame_count == 0
 
 
 async def test_pipeline_rejects_invalid_pcm_and_sample_rate() -> None:

--- a/tests/unit/voice_turn/test_activity_evidence.py
+++ b/tests/unit/voice_turn/test_activity_evidence.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+
+from main_logic.voice_turn.activity_evidence import RnnoiseEvidence
+
+
+def test_unavailable_rnnoise_evidence_cannot_carry_probabilities() -> None:
+    with pytest.raises(
+        ValueError,
+        match="unavailable RNNoise evidence cannot carry probabilities",
+    ):
+        RnnoiseEvidence(False, 1, 0.5, 0.5, 0.5, 0.5)
+
+
+def test_empty_rnnoise_chunk_cannot_reuse_prior_probabilities() -> None:
+    with pytest.raises(
+        ValueError,
+        match="empty RNNoise chunk cannot reuse prior probabilities",
+    ):
+        RnnoiseEvidence(True, 0, 0.5, 0.5, 0.5, 0.5)
+
+
+def test_legacy_probability_conversion_is_explicit_and_bounded() -> None:
+    evidence = RnnoiseEvidence.from_legacy_probability(0.6, available=True)
+
+    assert evidence == RnnoiseEvidence(True, 1, 0.6, 0.6, 0.6, 0.6)
+    assert RnnoiseEvidence.from_legacy_probability(
+        None,
+        available=True,
+    ) == RnnoiseEvidence.unavailable()
+
+
+def test_rnnoise_baseline_returns_a_new_validated_value() -> None:
+    evidence = RnnoiseEvidence(True, 3, 0.9, 0.6, 0.2, 0.55)
+
+    assert evidence.with_baseline(0.4).baseline == 0.4
+    assert evidence.baseline is None

--- a/tests/unit/voice_turn/test_phase4b_boundaries.py
+++ b/tests/unit/voice_turn/test_phase4b_boundaries.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _import_targets(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    targets: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            targets.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            prefix = "." * node.level
+            module = node.module or ""
+            targets.add(prefix + module)
+            targets.update(
+                prefix + (f"{module}." if module else "") + alias.name
+                for alias in node.names
+            )
+    return targets
+
+
+def test_import_targets_include_import_from_symbols(tmp_path: Path) -> None:
+    source = tmp_path / "imports.py"
+    source.write_text(
+        "\n".join(
+            (
+                "from main_logic.asr_client import endpointing",
+                "from . import endpointing",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    assert _import_targets(source) >= {
+        "main_logic.asr_client.endpointing",
+        ".endpointing",
+    }
+
+
+def test_core_and_lifecycle_do_not_reverse_import_endpointing() -> None:
+    for relative in (
+        "main_logic/core/asr_runtime.py",
+        "main_logic/asr_client/lifecycle.py",
+    ):
+        targets = _import_targets(PROJECT_ROOT / relative)
+        assert all("endpointing" not in target for target in targets)
+
+
+def test_endpointing_package_init_is_docstring_only() -> None:
+    path = PROJECT_ROOT / "main_logic/asr_client/endpointing/__init__.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+
+    assert len(tree.body) == 1
+    expression = tree.body[0]
+    assert isinstance(expression, ast.Expr)
+    assert isinstance(expression.value, ast.Constant)
+    assert isinstance(expression.value.value, str)
+
+
+def test_legacy_detector_and_evaluation_paths_do_not_exist() -> None:
+    forbidden = (
+        "main_logic/asr_client/detector.py",
+        "main_logic/asr_client/detector_runtime.py",
+        "main_logic/voice_turn/silero_vad.py",
+        "tools/voice_eval",
+    )
+
+    assert all(not (PROJECT_ROOT / relative).exists() for relative in forbidden)
+
+
+def test_evaluation_tool_uses_endpointing_assets_and_project_root() -> None:
+    path = PROJECT_ROOT / "scripts/evaluate_speech_presence.py"
+    source = path.read_text(encoding="utf-8")
+    targets = _import_targets(path)
+
+    assert "PROJECT_ROOT = Path(__file__).resolve().parents[1]" in source
+    assert (
+        "main_logic.asr_client.endpointing.silero_vad"
+        in targets
+    )
+    assert (
+        '"main_logic"\n            / "asr_client"\n'
+        '            / "endpointing"\n            / "models"'
+    ) in source
+
+
+def test_online_report_contract_is_chunk_level_and_low_cardinality() -> None:
+    path = PROJECT_ROOT / "scripts/evaluate_speech_presence.py"
+    source = path.read_text(encoding="utf-8")
+
+    assert '"granularity": "one_input_chunk"' in source
+    assert '"rnnoise_fields": ["frame_count", "peak", "mean", "last", "ema"]' in source
+    assert '"action_count"' in source
+    assert '"evidence_chunk_count"' in source
+    assert '"disagreement_count"' in source
+    assert '"production_behavior": False' in source
+
+
+def test_shadow_metric_zero_values_use_named_production_fields() -> None:
+    path = PROJECT_ROOT / "scripts/evaluate_speech_presence.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    expected_fields = {
+        "evidence_chunk_count",
+        "incomplete_chunk_count",
+        "rnnoise_trigger_count",
+        "silero_trigger_count",
+        "rnnoise_silero_disagreement_count",
+    }
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "ThrottleShadowMetrics"
+    ]
+
+    assert calls
+    assert all(not call.args for call in calls)
+    assert all({keyword.arg for keyword in call.keywords} == expected_fields for call in calls)
+
+
+def test_rnnoise_silence_duration_uses_shared_chunk_constant() -> None:
+    source = (
+        PROJECT_ROOT / "scripts/evaluate_speech_presence.py"
+    ).read_text(encoding="utf-8")
+
+    assert "trailing_frames * 0.01" not in source
+    assert "trailing_frames * RNNOISE_CHUNK_MS / 1000.0" in source

--- a/tests/unit/voice_turn/test_speech_presence_evaluation.py
+++ b/tests/unit/voice_turn/test_speech_presence_evaluation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -246,12 +247,17 @@ def test_online_replay_omits_silero_metrics_when_activity_is_unavailable() -> No
 
 
 def test_online_replay_aligns_silero_activity_with_rnnoise_chunks() -> None:
+    aligned_chunk_count = math.ceil(
+        evaluation.SILERO_MINIMUM_WINDOWS
+        * evaluation.SILERO_WINDOW_MS
+        / evaluation.RNNOISE_CHUNK_MS
+    )
     chunks = [
         evaluation.RnnoiseEvidence.from_legacy_probability(
             0.05,
             available=True,
         )
-        for _ in range(24)
+        for _ in range(aligned_chunk_count)
     ]
 
     trigger, metrics = evaluation._replay_rnnoise_policy(
@@ -261,7 +267,7 @@ def test_online_replay_aligns_silero_activity_with_rnnoise_chunks() -> None:
     )
 
     assert trigger is None
-    assert metrics.evidence_chunk_count == 24
+    assert metrics.evidence_chunk_count == aligned_chunk_count
     assert metrics.rnnoise_trigger_count == 0
     assert metrics.silero_trigger_count == 1
     assert metrics.rnnoise_silero_disagreement_count == 1
@@ -325,6 +331,64 @@ def test_offline_replay_resets_rnnoise_from_audio_time() -> None:
     evaluation._rnnoise_process(processor, samples)
 
     assert processor.reset_count == 1
+
+
+def test_rnnoise_process_flushes_pending_frame_and_resampler_tail() -> None:
+    class _TailResampler:
+        def resample_chunk(
+            self,
+            samples: np.ndarray,
+            *,
+            last: bool = False,
+        ) -> np.ndarray:
+            assert samples.size == 0
+            assert last is True
+            return np.asarray([0.25, -0.25], dtype=np.float32)
+
+    class _BufferedProcessor(_OfflineProcessor):
+        def __init__(self) -> None:
+            super().__init__()
+            self._pending = np.empty(0, dtype=np.int16)
+            self._frame_buffer_size = 0
+            self._downsample_resampler = _TailResampler()
+
+        def process_chunk(self, audio_bytes: bytes) -> bytes:
+            incoming = np.frombuffer(audio_bytes, dtype=np.int16)
+            combined = np.concatenate((self._pending, incoming))
+            if combined.size < self.RNNOISE_FRAME_SIZE:
+                self._pending = combined.copy()
+                self._frame_buffer_size = combined.size
+                self.rnnoise_frame_count = 0
+                return b""
+            frame = combined[: self.RNNOISE_FRAME_SIZE]
+            self._pending = combined[self.RNNOISE_FRAME_SIZE :].copy()
+            self._frame_buffer_size = self._pending.size
+            denoised, probability = self._denoiser.process_frame(frame)
+            self.rnnoise_frame_count = 1
+            self.rnnoise_probability_peak = probability
+            self.rnnoise_probability_mean = probability
+            self.rnnoise_probability_last = probability
+            self.rnnoise_probability_ema = probability
+            return denoised.astype("<i2").tobytes()
+
+    processor = _BufferedProcessor()
+    (
+        frame_probabilities,
+        chunk_evidence,
+        processed,
+        _wall_elapsed,
+        _cpu_elapsed,
+    ) = evaluation._rnnoise_process(
+        processor,
+        np.full(100, 0.5, dtype=np.float32),
+    )
+
+    assert frame_probabilities == [0.0]
+    assert [evidence.frame_count for evidence in chunk_evidence] == [0, 1]
+    assert len(processed) == (processor.RNNOISE_FRAME_SIZE + 2) * 2
+    assert processed[-4:] == evaluation._pcm16(
+        np.asarray([0.25, -0.25], dtype=np.float32)
+    )
 
 
 def test_offline_replay_uses_production_rnnoise_speech_threshold() -> None:
@@ -498,6 +562,42 @@ def test_calibration_holdout_keeps_source_variants_together() -> None:
     }
 
 
+def test_calibration_holdout_rejects_singleton_only_strata_explicitly() -> None:
+    clips = [
+        SimpleNamespace(
+            clip_id="real/mic-a/speech-a",
+            label=True,
+            locale="en",
+            scenario="speech-a",
+            device_id="mic-a",
+        ),
+        SimpleNamespace(
+            clip_id="real/mic-b/speech-b",
+            label=True,
+            locale="zh",
+            scenario="speech-b",
+            device_id="mic-b",
+        ),
+        SimpleNamespace(
+            clip_id="real/mic-a/idle-a",
+            label=False,
+            locale=None,
+            scenario="idle-a",
+            device_id="mic-a",
+        ),
+        SimpleNamespace(
+            clip_id="real/mic-b/idle-b",
+            label=False,
+            locale=None,
+            scenario="idle-b",
+            device_id="mic-b",
+        ),
+    ]
+
+    with pytest.raises(ValueError, match="singleton-only strata"):
+        evaluation.split_calibration_holdout(clips, seed=2398)
+
+
 def test_threshold_is_selected_from_calibration_metrics_only() -> None:
     clips = [
         SimpleNamespace(label=True, score=0.80),
@@ -616,6 +716,29 @@ def test_real_device_manifest_rejects_paths_outside_its_directory(
         match="real-device path must stay inside the manifest directory",
     ):
         evaluation.load_real_device_manifest(manifest_path)
+
+
+@pytest.mark.parametrize(
+    ("status_output", "expected"),
+    [
+        ("", "abc123"),
+        (" M scripts/evaluate_speech_presence.py", "abc123-dirty"),
+    ],
+)
+def test_revision_uses_repository_commit_and_dirty_marker(
+    monkeypatch: pytest.MonkeyPatch,
+    status_output: str,
+    expected: str,
+) -> None:
+    outputs = iter(("abc123\n", status_output))
+    monkeypatch.delenv("GIT_COMMIT", raising=False)
+    monkeypatch.setattr(
+        evaluation.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(stdout=next(outputs)),
+    )
+
+    assert evaluation._resolve_revision() == expected
 
 
 def test_report_includes_silero_latency_and_private_asset_contract(

--- a/tests/unit/voice_turn/test_speech_presence_evaluation.py
+++ b/tests/unit/voice_turn/test_speech_presence_evaluation.py
@@ -267,6 +267,39 @@ def test_online_replay_aligns_silero_activity_with_rnnoise_chunks() -> None:
     assert metrics.rnnoise_silero_disagreement_count == 1
 
 
+def test_online_replay_reports_rnnoise_count_from_trigger_trajectory() -> None:
+    chunks = [
+        evaluation.RnnoiseEvidence.from_legacy_probability(
+            0.05,
+            available=True,
+        )
+        for _ in range(20)
+    ]
+    chunks.extend(
+        evaluation.RnnoiseEvidence.from_legacy_probability(
+            0.19,
+            available=True,
+        )
+        for _ in range(100)
+    )
+    chunks.append(
+        evaluation.RnnoiseEvidence.from_legacy_probability(
+            0.25,
+            available=True,
+        )
+    )
+
+    trigger, metrics = evaluation._replay_rnnoise_policy(
+        chunks,
+        chunk_ms=evaluation.RNNOISE_CHUNK_MS,
+        silero_probabilities=[0.9] * evaluation.SILERO_MINIMUM_WINDOWS,
+    )
+
+    assert trigger is None
+    assert metrics.rnnoise_trigger_count == 0
+    assert metrics.silero_trigger_count > 0
+
+
 def test_online_replay_delegates_to_production_throttle_policy(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/voice_turn/test_speech_presence_evaluation.py
+++ b/tests/unit/voice_turn/test_speech_presence_evaluation.py
@@ -1,0 +1,606 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from scripts import evaluate_speech_presence as evaluation
+
+
+class _OfflineDenoiser:
+    def process_frame(self, frame: np.ndarray) -> tuple[np.ndarray, float]:
+        return frame.copy(), 0.0
+
+
+class _OfflineProcessor:
+    RESET_TIMEOUT_SECONDS = 0.02
+    RNNOISE_FRAME_SIZE = 480
+
+    def __init__(self) -> None:
+        self._denoiser = _OfflineDenoiser()
+        self.reset_count = 0
+        self.rnnoise_frame_count = 0
+        self.rnnoise_probability_peak: float | None = None
+        self.rnnoise_probability_mean: float | None = None
+        self.rnnoise_probability_last: float | None = None
+        self.rnnoise_probability_ema: float | None = None
+
+    @property
+    def rnnoise_available(self) -> bool:
+        return True
+
+    def process_chunk(self, audio_bytes: bytes) -> bytes:
+        frame = np.frombuffer(audio_bytes, dtype=np.int16)
+        _, probability = self._denoiser.process_frame(frame)
+        self.rnnoise_frame_count = 1
+        self.rnnoise_probability_peak = probability
+        self.rnnoise_probability_mean = probability
+        self.rnnoise_probability_last = probability
+        self.rnnoise_probability_ema = probability
+        return audio_bytes
+
+    def reset(self) -> None:
+        self.reset_count += 1
+        self.rnnoise_frame_count = 0
+        self.rnnoise_probability_peak = None
+        self.rnnoise_probability_mean = None
+        self.rnnoise_probability_last = None
+        self.rnnoise_probability_ema = None
+
+
+def test_offline_processor_matches_audio_processor_contract() -> None:
+    offline_processor = _OfflineProcessor()
+    for name in (
+        "RESET_TIMEOUT_SECONDS",
+        "RNNOISE_FRAME_SIZE",
+        "rnnoise_available",
+        "rnnoise_frame_count",
+        "rnnoise_probability_peak",
+        "rnnoise_probability_mean",
+        "rnnoise_probability_last",
+        "rnnoise_probability_ema",
+    ):
+        assert hasattr(evaluation.AudioProcessor, name)
+        assert hasattr(offline_processor, name)
+
+
+def _evaluated_clip(
+    clip_id: str,
+    *,
+    label: bool,
+    score: float,
+    trigger_ms: float | None,
+) -> evaluation.EvaluatedClip:
+    return evaluation.EvaluatedClip(
+        clip_id=clip_id,
+        label=label,
+        scenario="real_speech" if label else "real_negative",
+        locale="zh-CN",
+        snr_db=None,
+        noise_kind=None,
+        duration_seconds=1.0,
+        rnnoise_chunk_peak=score,
+        rnnoise_chunk_ema_peak=score / 2,
+        rnnoise_online_trigger_ms=trigger_ms,
+        rnnoise_offline_sustained_100ms_score=score,
+        rnnoise_offline_sustained_100ms_trigger_ms=trigger_ms,
+        silero_raw_score=score,
+        silero_after_rnnoise_score=score,
+        silero_raw_trigger_ms=trigger_ms,
+        silero_after_rnnoise_trigger_ms=trigger_ms,
+        speech_start_ms=100.0 if label else None,
+        device_id="desktop-usb",
+    )
+
+
+def test_confusion_metrics_keep_recall_and_specificity_separate() -> None:
+    confusion = evaluation.confusion_from_predictions(
+        [True, True, False, False],
+        [True, False, True, False],
+    )
+
+    metrics = evaluation.metrics_from_confusion(confusion)
+
+    assert confusion == evaluation.Confusion(1, 1, 1, 1)
+    assert metrics["accuracy"] == pytest.approx(0.5)
+    assert metrics["balanced_accuracy"] == pytest.approx(0.5)
+    assert metrics["speech_recall"] == pytest.approx(0.5)
+    assert metrics["negative_specificity"] == pytest.approx(0.5)
+
+
+def test_silero_score_and_trigger_require_sustained_windows() -> None:
+    assert evaluation.silero_presence_score(
+        [0.9, 0.1, 0.9],
+        minimum_windows=2,
+    ) == pytest.approx(0.1)
+    assert evaluation.silero_presence_score(
+        [0.2, 0.7, 0.8],
+        minimum_windows=2,
+    ) == pytest.approx(0.7)
+    assert evaluation.first_silero_trigger_ms(
+        [0.6, 0.4, 0.6],
+        0.5,
+        minimum_windows=2,
+        offset_threshold=0.35,
+    ) == pytest.approx(3 * evaluation.SILERO_WINDOW_MS)
+    assert (
+        evaluation.first_silero_trigger_ms(
+            [0.6, 0.2, 0.6],
+            0.5,
+            minimum_windows=2,
+            offset_threshold=0.35,
+        )
+        is None
+    )
+
+
+def test_neutral_sustained_score_is_not_silero_specific() -> None:
+    assert evaluation.sustained_presence_score(
+        [0.2, 0.7, 0.8],
+        minimum_windows=2,
+    ) == pytest.approx(0.7)
+
+
+def test_offline_sustained_candidate_rejects_isolated_spikes() -> None:
+    isolated = evaluation._first_sustained_trigger_ms(
+        [0.9, 0.1, 0.9],
+        0.8,
+        2,
+        20,
+    )
+    sustained = evaluation._first_sustained_trigger_ms(
+        [0.1, 0.8, 0.9],
+        0.8,
+        2,
+        20,
+    )
+
+    assert isolated is None
+    assert sustained == 60
+
+
+def test_online_replay_uses_chunk_shaped_adaptive_evidence() -> None:
+    probabilities = [0.0] * 20 + [0.25, 0.25]
+
+    assert (
+        evaluation._current_rnnoise_policy_trigger_ms(
+            probabilities,
+            frames_per_chunk=2,
+        )
+        == 220
+    )
+
+
+def test_online_replay_defaults_to_browser_ten_millisecond_chunks() -> None:
+    probabilities = [0.0] * 20 + [0.25]
+
+    assert evaluation.RNNOISE_CHUNK_MS == 10
+    assert evaluation._current_rnnoise_policy_trigger_ms(probabilities) == 210
+
+
+def test_online_replay_derives_grouped_chunk_duration_from_shared_constant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(evaluation, "RNNOISE_CHUNK_MS", 7)
+    probabilities = [0.0] * 20 + [0.25, 0.25]
+
+    assert (
+        evaluation._current_rnnoise_policy_trigger_ms(
+            probabilities,
+            frames_per_chunk=2,
+        )
+        == 154
+    )
+
+
+def test_threshold_grid_has_provider_neutral_ownership() -> None:
+    assert not hasattr(evaluation, "RNNOISE_THRESHOLDS")
+    assert evaluation.PRESENCE_THRESHOLDS == (
+        0.2,
+        0.25,
+        0.3,
+        0.35,
+        0.4,
+        0.45,
+        0.5,
+        0.6,
+        0.7,
+        0.8,
+        0.9,
+        0.95,
+        0.99,
+    )
+
+
+def test_online_replay_treats_fail_open_as_a_presence_trigger() -> None:
+    trigger = evaluation._online_trigger_from_chunks(
+        [evaluation.RnnoiseEvidence.unavailable()]
+    )
+
+    assert trigger == evaluation.RNNOISE_CHUNK_MS
+
+
+def test_online_replay_preserves_production_shadow_metrics() -> None:
+    trigger, metrics = evaluation._replay_rnnoise_policy(
+        [
+            evaluation.RnnoiseEvidence.from_legacy_probability(
+                0.05,
+                available=True,
+            ),
+            evaluation.RnnoiseEvidence.from_legacy_probability(
+                0.9,
+                available=True,
+            ),
+        ],
+        chunk_ms=evaluation.RNNOISE_CHUNK_MS,
+    )
+
+    assert trigger == 2 * evaluation.RNNOISE_CHUNK_MS
+    assert metrics.evidence_chunk_count == 2
+    assert metrics.rnnoise_trigger_count == 1
+    assert metrics.rnnoise_silero_disagreement_count == 1
+
+
+def test_online_replay_delegates_to_production_throttle_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    production_policy = evaluation.VoiceThrottlePolicy
+    decisions = 0
+
+    class _RecordingPolicy(production_policy):
+        def decide(self, *args, **kwargs):
+            nonlocal decisions
+            decisions += 1
+            return super().decide(*args, **kwargs)
+
+    monkeypatch.setattr(evaluation, "VoiceThrottlePolicy", _RecordingPolicy)
+
+    assert evaluation._current_rnnoise_policy_trigger_ms([0.0, 0.9]) == 20
+    assert decisions == 2
+
+
+def test_offline_replay_resets_rnnoise_from_audio_time() -> None:
+    processor = _OfflineProcessor()
+    samples = np.zeros(4 * processor.RNNOISE_FRAME_SIZE, dtype=np.float32)
+
+    evaluation._rnnoise_process(processor, samples)
+
+    assert processor.reset_count == 1
+
+
+def test_offline_replay_uses_production_rnnoise_speech_threshold() -> None:
+    assert evaluation.AudioProcessor.RNNOISE_SPEECH_PROBABILITY_THRESHOLD == 0.2
+
+
+def test_evaluate_corpus_closes_processor_when_rnnoise_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    closed: list[str] = []
+
+    class _UnavailableProcessor:
+        def __init__(self, **_kwargs) -> None:
+            self._denoiser = None
+
+        def close(self) -> None:
+            closed.append("processor")
+
+    monkeypatch.setattr(evaluation, "AudioProcessor", _UnavailableProcessor)
+
+    with pytest.raises(RuntimeError, match="RNNoise native runtime is unavailable"):
+        evaluation.evaluate_corpus([], tmp_path)
+
+    assert closed == ["processor"]
+
+
+def test_evaluate_corpus_closes_runtimes_when_silero_warmup_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    closed: list[str] = []
+
+    class _WarmupProcessor:
+        def __init__(self, **_kwargs) -> None:
+            self._denoiser = object()
+
+        def close(self) -> None:
+            closed.append("processor")
+
+    class _WarmupVad:
+        WINDOW_SAMPLES = 512
+
+        def __init__(self, **_kwargs) -> None:
+            self.unavailable_reason = None
+
+        def load(self) -> bool:
+            return True
+
+        def process_pcm16(self, _pcm16: bytes) -> None:
+            raise RuntimeError("warmup failed")
+
+        def reset_stream(self) -> None:
+            return None
+
+        def close(self) -> None:
+            closed.append("vad")
+
+    monkeypatch.setattr(evaluation, "AudioProcessor", _WarmupProcessor)
+    monkeypatch.setattr(evaluation, "SileroVad", _WarmupVad)
+
+    with pytest.raises(RuntimeError, match="warmup failed"):
+        evaluation.evaluate_corpus([], tmp_path)
+
+    assert closed == ["processor", "vad"]
+
+
+def test_mix_at_snr_preserves_requested_rms_ratio() -> None:
+    rng = np.random.default_rng(123)
+    speech = rng.normal(size=48_000).astype(np.float32) * 0.02
+    noise = rng.normal(size=48_000).astype(np.float32)
+
+    mixed = evaluation.mix_at_snr(speech, noise, 10)
+    added_noise = mixed - speech
+    speech_rms = np.sqrt(np.mean(np.square(speech), dtype=np.float64))
+    noise_rms = np.sqrt(np.mean(np.square(added_noise), dtype=np.float64))
+
+    assert 20 * np.log10(speech_rms / noise_rms) == pytest.approx(10, abs=0.05)
+
+
+def test_calibration_holdout_keeps_source_variants_together() -> None:
+    clips = []
+    for locale in ("en", "zh"):
+        for source in range(4):
+            for variant in ("clean", "snr_+10"):
+                clips.append(
+                    SimpleNamespace(
+                        clip_id=f"speech/{locale}/{source:02d}/{variant}",
+                        label=True,
+                        locale=locale,
+                    )
+                )
+    for scenario in ("negative_fan", "negative_game_sfx"):
+        clips.extend(
+            SimpleNamespace(
+                clip_id=f"negative/{scenario}/{index:02d}",
+                label=False,
+                locale=None,
+                scenario=scenario,
+                device_id=None,
+            )
+            for index in range(2)
+        )
+
+    calibration, holdout = evaluation.split_calibration_holdout(
+        clips,
+        seed=2398,
+    )
+
+    calibration_groups = {
+        evaluation.source_group_id(clip.clip_id) for clip in calibration
+    }
+    holdout_groups = {
+        evaluation.source_group_id(clip.clip_id) for clip in holdout
+    }
+    assert calibration_groups.isdisjoint(holdout_groups)
+    assert {clip.locale for clip in holdout if clip.label} == {"en", "zh"}
+    assert {clip.scenario for clip in holdout if not clip.label} == {
+        "negative_fan",
+        "negative_game_sfx",
+    }
+
+
+def test_threshold_is_selected_from_calibration_metrics_only() -> None:
+    clips = [
+        SimpleNamespace(label=True, score=0.80),
+        SimpleNamespace(label=True, score=0.75),
+        SimpleNamespace(label=False, score=0.60),
+        SimpleNamespace(label=False, score=0.10),
+    ]
+
+    selected = evaluation.select_presence_threshold(
+        clips,
+        score_name="score",
+        thresholds=(0.6, 0.7, 0.8),
+    )
+
+    assert selected["threshold"] == pytest.approx(0.7)
+    assert selected["balanced_accuracy"] == pytest.approx(1.0)
+
+
+def test_real_device_manifest_does_not_expose_paths(tmp_path: Path) -> None:
+    audio_path = tmp_path / "desk-mic.wav"
+    evaluation.sf.write(
+        audio_path,
+        np.zeros(evaluation.SAMPLE_RATE_48K, dtype=np.float32),
+        evaluation.SAMPLE_RATE_48K,
+    )
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "clips": [
+                    {
+                        "id": "idle-fan-01",
+                        "path": audio_path.name,
+                        "label": False,
+                        "device_id": "desktop-usb",
+                        "scenario": "real_idle_fan",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    clips, summary = evaluation.load_real_device_manifest(manifest_path)
+
+    assert clips[0].clip_id == "real/desktop-usb/idle-fan-01"
+    assert summary == {
+        "manifest_schema_version": 1,
+        "clip_count": 1,
+        "device_ids": ["desktop-usb"],
+    }
+    assert str(audio_path) not in json.dumps(summary)
+
+
+def test_real_device_manifest_summary_omits_audio_filename(tmp_path: Path) -> None:
+    audio_path = tmp_path / "private-device-name.wav"
+    evaluation.sf.write(
+        audio_path,
+        np.zeros(evaluation.SAMPLE_RATE_48K, dtype=np.float32),
+        evaluation.SAMPLE_RATE_48K,
+    )
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "clips": [
+                    {
+                        "id": "idle-01",
+                        "path": audio_path.name,
+                        "label": False,
+                        "device_id": "desktop-usb",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    _, summary = evaluation.load_real_device_manifest(manifest_path)
+
+    assert audio_path.name not in json.dumps(summary)
+
+
+@pytest.mark.parametrize("path_kind", ["absolute", "traversal"])
+def test_real_device_manifest_rejects_paths_outside_its_directory(
+    tmp_path: Path,
+    path_kind: str,
+) -> None:
+    manifest_path = tmp_path / "manifest.json"
+    declared_path = (
+        str((tmp_path / "absolute.wav").resolve())
+        if path_kind == "absolute"
+        else str(Path("..") / "traversal.wav")
+    )
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "clips": [
+                    {
+                        "id": "idle-01",
+                        "path": declared_path,
+                        "label": False,
+                        "device_id": "desktop-usb",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="real-device path must stay inside the manifest directory",
+    ):
+        evaluation.load_real_device_manifest(manifest_path)
+
+
+def test_report_includes_silero_latency_and_private_asset_contract(
+    tmp_path: Path,
+) -> None:
+    clips = [
+        _evaluated_clip("real/desktop-usb/speech-1", label=True, score=0.9, trigger_ms=150),
+        _evaluated_clip("real/desktop-usb/speech-2", label=True, score=0.8, trigger_ms=200),
+        _evaluated_clip("real/desktop-usb/noise-1", label=False, score=0.1, trigger_ms=None),
+        _evaluated_clip("real/desktop-usb/noise-2", label=False, score=0.05, trigger_ms=None),
+    ]
+    external_assets = tmp_path / "private-user" / "models"
+    shadow_metrics = {
+        "evidence_chunk_count": 8,
+        "incomplete_chunk_count": 1,
+        "rnnoise_trigger_count": 3,
+        "silero_trigger_count": 2,
+        "rnnoise_silero_disagreement_count": 1,
+    }
+
+    report = evaluation.build_report(
+        clips,
+        performance={"throttle_shadow_metrics": shadow_metrics},
+        seed=2398,
+        asset_dir=external_assets,
+        corpus_manifest={"real_device": {"clip_count": len(clips)}},
+    )
+
+    assert report["asset_contract"] == {
+        "silero_directory": "<external>",
+        "default_directory": "main_logic/asr_client/endpointing/models",
+        "uses_default_directory": False,
+    }
+    assert set(report["silero_paths"]) == {"raw", "after_rnnoise"}
+    assert set(report["onset_latency_ms"]) == {
+        "rnnoise_online",
+        "rnnoise_offline_sustained_100ms",
+        "silero_raw",
+        "silero_after_rnnoise",
+    }
+    assert report["corpus_summary"]["duration_seconds"] == pytest.approx(4.0)
+    assert report["corpus_summary"]["locales"] == ["zh-CN"]
+    assert report["corpus_summary"]["device_ids"] == ["desktop-usb"]
+    assert report["corpus_summary"]["rnnoise_chunk_peak"]["p95"] > 0
+    online_contract = report["online_contract"]
+    assert set(online_contract) == {
+        "granularity",
+        "rnnoise_fields",
+        "shadow_metric_kinds",
+        "shadow_metrics",
+        "calibration",
+        "holdout",
+    }
+    assert online_contract["granularity"] == "one_input_chunk"
+    assert online_contract["rnnoise_fields"] == [
+        "frame_count",
+        "peak",
+        "mean",
+        "last",
+        "ema",
+    ]
+    assert report["online_contract"]["shadow_metric_kinds"] == [
+        "action_count",
+        "evidence_chunk_count",
+        "disagreement_count",
+    ]
+    assert report["online_contract"]["shadow_metrics"] == shadow_metrics
+    assert (
+        report["offline_candidates"]["rnnoise_continuous_100ms"][
+            "production_behavior"
+        ]
+        is False
+    )
+    assert any(
+        "AGC" in limitation and "limiter" in limitation
+        for limitation in report["limitations"]
+    )
+    assert any(
+        "fixed 0.7 threshold" in limitation
+        and "calibrated threshold" in limitation
+        for limitation in report["limitations"]
+    )
+    assert any(
+        "onset/offset hysteresis" in limitation
+        and "strictly consecutive windows" in limitation
+        for limitation in report["limitations"]
+    )
+    serialized = json.dumps(report)
+    assert str(tmp_path) not in serialized
+    assert "private-user" not in serialized
+    assert all(
+        "private-user" not in json.dumps(value)
+        for value in report["silero_paths"].values()
+    )

--- a/tests/unit/voice_turn/test_speech_presence_evaluation.py
+++ b/tests/unit/voice_turn/test_speech_presence_evaluation.py
@@ -223,7 +223,7 @@ def test_online_replay_treats_fail_open_as_a_presence_trigger() -> None:
     assert trigger == evaluation.RNNOISE_CHUNK_MS
 
 
-def test_online_replay_preserves_production_shadow_metrics() -> None:
+def test_online_replay_omits_silero_metrics_when_activity_is_unavailable() -> None:
     trigger, metrics = evaluation._replay_rnnoise_policy(
         [
             evaluation.RnnoiseEvidence.from_legacy_probability(
@@ -241,6 +241,29 @@ def test_online_replay_preserves_production_shadow_metrics() -> None:
     assert trigger == 2 * evaluation.RNNOISE_CHUNK_MS
     assert metrics.evidence_chunk_count == 2
     assert metrics.rnnoise_trigger_count == 1
+    assert metrics.silero_trigger_count == 0
+    assert metrics.rnnoise_silero_disagreement_count == 0
+
+
+def test_online_replay_aligns_silero_activity_with_rnnoise_chunks() -> None:
+    chunks = [
+        evaluation.RnnoiseEvidence.from_legacy_probability(
+            0.05,
+            available=True,
+        )
+        for _ in range(24)
+    ]
+
+    trigger, metrics = evaluation._replay_rnnoise_policy(
+        chunks,
+        chunk_ms=evaluation.RNNOISE_CHUNK_MS,
+        silero_probabilities=[0.9] * evaluation.SILERO_MINIMUM_WINDOWS,
+    )
+
+    assert trigger is None
+    assert metrics.evidence_chunk_count == 24
+    assert metrics.rnnoise_trigger_count == 0
+    assert metrics.silero_trigger_count == 1
     assert metrics.rnnoise_silero_disagreement_count == 1
 
 
@@ -259,7 +282,7 @@ def test_online_replay_delegates_to_production_throttle_policy(
     monkeypatch.setattr(evaluation, "VoiceThrottlePolicy", _RecordingPolicy)
 
     assert evaluation._current_rnnoise_policy_trigger_ms([0.0, 0.9]) == 20
-    assert decisions == 2
+    assert decisions == 4
 
 
 def test_offline_replay_resets_rnnoise_from_audio_time() -> None:

--- a/tests/unit/voice_turn/test_speech_presence_evaluation.py
+++ b/tests/unit/voice_turn/test_speech_presence_evaluation.py
@@ -275,6 +275,24 @@ def test_offline_replay_uses_production_rnnoise_speech_threshold() -> None:
     assert evaluation.AudioProcessor.RNNOISE_SPEECH_PROBABILITY_THRESHOLD == 0.2
 
 
+def test_offline_replay_uses_audio_processor_rnnoise_ema_alpha(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[evaluation.RnnoiseEvidence] = []
+
+    def _capture(chunks, *, chunk_ms):
+        assert chunk_ms == 10.0
+        captured.extend(chunks)
+        return None
+
+    monkeypatch.setattr(evaluation.AudioProcessor, "RNNOISE_EMA_ALPHA", 0.5)
+    monkeypatch.setattr(evaluation, "_replay_rnnoise_policy_trigger_ms", _capture)
+
+    evaluation._current_rnnoise_policy_trigger_ms([0.2, 1.0])
+
+    assert [chunk.ema for chunk in captured] == pytest.approx([0.2, 0.6])
+
+
 def test_evaluate_corpus_closes_processor_when_rnnoise_is_unavailable(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -294,6 +312,38 @@ def test_evaluate_corpus_closes_processor_when_rnnoise_is_unavailable(
         evaluation.evaluate_corpus([], tmp_path)
 
     assert closed == ["processor"]
+
+
+def test_evaluate_corpus_closes_runtimes_when_silero_load_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    closed: list[str] = []
+
+    class _LoadProcessor:
+        def __init__(self, **_kwargs) -> None:
+            self._denoiser = object()
+
+        def close(self) -> None:
+            closed.append("processor")
+
+    class _LoadVad:
+        def __init__(self, **_kwargs) -> None:
+            self.unavailable_reason = "load failed"
+
+        def load(self) -> bool:
+            return False
+
+        def close(self) -> None:
+            closed.append("vad")
+
+    monkeypatch.setattr(evaluation, "AudioProcessor", _LoadProcessor)
+    monkeypatch.setattr(evaluation, "SileroVad", _LoadVad)
+
+    with pytest.raises(RuntimeError, match="Silero failed to load: load failed"):
+        evaluation.evaluate_corpus([], tmp_path)
+
+    assert closed == ["vad", "processor"]
 
 
 def test_evaluate_corpus_closes_runtimes_when_silero_warmup_fails(

--- a/utils/audio_processor.py
+++ b/utils/audio_processor.py
@@ -484,10 +484,8 @@ class AudioProcessor:
             self._rnnoise_ema = ema_state
         return output
     
-    def _reset_internal_state(self) -> None:
-        """Reset RNNoise internal state without full reinitialization."""
-        self._frame_buffer.fill(0)
-        self._frame_buffer_size = 0
+    def _clear_rnnoise_evidence(self) -> None:
+        """Clear per-chunk evidence and the cross-chunk EMA accumulator."""
         self._last_speech_prob = 0.0
         self._rnnoise_frame_count = 0
         self._rnnoise_peak = None
@@ -495,6 +493,12 @@ class AudioProcessor:
         self._rnnoise_last = None
         self._rnnoise_ema = None
         self._rnnoise_ema_state = None
+
+    def _reset_internal_state(self) -> None:
+        """Reset RNNoise internal state without full reinitialization."""
+        self._frame_buffer.fill(0)
+        self._frame_buffer_size = 0
+        self._clear_rnnoise_evidence()
         # Reset AGC gain state
         self._agc_gain = 1.0
         # Reset denoiser GRU hidden states (do not reinitialize)
@@ -634,6 +638,7 @@ class AudioProcessor:
                 self._frame_buffer.fill(0)
             self._frame_buffer_size = 0
             self._agc_gain = 1.0
+            self._clear_rnnoise_evidence()
         logger.info(f"🎤 Noise reduction {'enabled' if enabled else 'disabled'}")
     
     def set_agc_enabled(self, enabled: bool) -> None:

--- a/utils/audio_processor.py
+++ b/utils/audio_processor.py
@@ -226,6 +226,7 @@ class AudioProcessor:
     
     RNNOISE_SAMPLE_RATE = 48000  # RNNoise requires 48kHz
     RNNOISE_FRAME_SIZE = 480     # 10ms at 48kHz
+    RNNOISE_SPEECH_PROBABILITY_THRESHOLD = 0.2
     API_SAMPLE_RATE = 16000      # API expects 16kHz
     
     # Reset denoiser if no speech detected for this many seconds
@@ -273,6 +274,12 @@ class AudioProcessor:
         self._last_speech_prob = 0.0
         self._last_speech_time = time.time()
         self._needs_reset = False
+        self._rnnoise_frame_count = 0
+        self._rnnoise_peak: float | None = None
+        self._rnnoise_mean: float | None = None
+        self._rnnoise_last: float | None = None
+        self._rnnoise_ema: float | None = None
+        self._rnnoise_ema_state: float | None = None
         
         # AGC state
         self._agc_gain = 1.0
@@ -396,6 +403,12 @@ class AudioProcessor:
         Returns:
             Denoised int16 numpy array
         """
+        self._rnnoise_frame_count = 0
+        self._rnnoise_peak = None
+        self._rnnoise_mean = None
+        self._rnnoise_last = None
+        self._rnnoise_ema = None
+        frame_probabilities: list[float] = []
         pending_size = self._frame_buffer_size
         max_buffer_samples = self.RNNOISE_SAMPLE_RATE
 
@@ -427,8 +440,10 @@ class AudioProcessor:
             nonlocal output_offset
             try:
                 denoised, prob = self._denoiser.process_frame(frame)
-                self._last_speech_prob = prob
-                if prob > 0.2:
+                probability = min(1.0, max(0.0, float(prob)))
+                frame_probabilities.append(probability)
+                self._last_speech_prob = probability
+                if probability > self.RNNOISE_SPEECH_PROBABILITY_THRESHOLD:
                     self._last_speech_time = time.time()
                 output[output_offset : output_offset + self.RNNOISE_FRAME_SIZE] = denoised
             except Exception as e:
@@ -452,6 +467,19 @@ class AudioProcessor:
         if remaining:
             self._frame_buffer[:remaining] = audio[input_offset:]
         self._frame_buffer_size = remaining
+        if frame_probabilities:
+            self._rnnoise_frame_count = len(frame_probabilities)
+            self._rnnoise_peak = max(frame_probabilities)
+            self._rnnoise_mean = sum(frame_probabilities) / len(frame_probabilities)
+            self._rnnoise_last = frame_probabilities[-1]
+            ema_state = getattr(self, "_rnnoise_ema_state", None)
+            for probability in frame_probabilities:
+                if ema_state is None:
+                    ema_state = probability
+                else:
+                    ema_state = 0.35 * probability + 0.65 * ema_state
+            self._rnnoise_ema_state = ema_state
+            self._rnnoise_ema = ema_state
         return output
     
     def _reset_internal_state(self) -> None:
@@ -459,6 +487,12 @@ class AudioProcessor:
         self._frame_buffer.fill(0)
         self._frame_buffer_size = 0
         self._last_speech_prob = 0.0
+        self._rnnoise_frame_count = 0
+        self._rnnoise_peak = None
+        self._rnnoise_mean = None
+        self._rnnoise_last = None
+        self._rnnoise_ema = None
+        self._rnnoise_ema_state = None
         # Reset AGC gain state
         self._agc_gain = 1.0
         # Reset denoiser GRU hidden states (do not reinitialize)
@@ -549,6 +583,32 @@ class AudioProcessor:
     def speech_probability(self) -> float:
         """Get the last detected speech probability (0.0-1.0)."""
         return self._last_speech_prob
+
+    @property
+    def rnnoise_frame_count(self) -> int:
+        return self._rnnoise_frame_count
+
+    @property
+    def rnnoise_available(self) -> bool:
+        """Whether this processor can currently produce RNNoise evidence."""
+
+        return bool(self.noise_reduce_enabled and self._denoiser is not None)
+
+    @property
+    def rnnoise_probability_peak(self) -> float | None:
+        return self._rnnoise_peak
+
+    @property
+    def rnnoise_probability_mean(self) -> float | None:
+        return self._rnnoise_mean
+
+    @property
+    def rnnoise_probability_last(self) -> float | None:
+        return self._rnnoise_last
+
+    @property
+    def rnnoise_probability_ema(self) -> float | None:
+        return self._rnnoise_ema
     
     def set_enabled(self, enabled: bool) -> None:
         """Enable or disable noise reduction."""

--- a/utils/audio_processor.py
+++ b/utils/audio_processor.py
@@ -227,6 +227,7 @@ class AudioProcessor:
     RNNOISE_SAMPLE_RATE = 48000  # RNNoise requires 48kHz
     RNNOISE_FRAME_SIZE = 480     # 10ms at 48kHz
     RNNOISE_SPEECH_PROBABILITY_THRESHOLD = 0.2
+    RNNOISE_EMA_ALPHA = 0.35
     API_SAMPLE_RATE = 16000      # API expects 16kHz
     
     # Reset denoiser if no speech detected for this many seconds
@@ -477,7 +478,8 @@ class AudioProcessor:
                 if ema_state is None:
                     ema_state = probability
                 else:
-                    ema_state = 0.35 * probability + 0.65 * ema_state
+                    alpha = self.RNNOISE_EMA_ALPHA
+                    ema_state = alpha * probability + (1.0 - alpha) * ema_state
             self._rnnoise_ema_state = ema_state
             self._rnnoise_ema = ema_state
         return output


### PR DESCRIPTION
## 概述

本 PR 已正式 restack 到 `main@a4a633016`，head 为 `b3b9496b9`。#2396、#2576、#2582 均已合并进 main；相对 main 本 PR **正好六个 Phase 4B 提交**，不再携带前置 PR 差异。

路径遵循已合并迁移：

- endpointing 实现位于 `main_logic/asr_client/endpointing/`，不恢复旧 detector 路径或 shim；
- 评测脚本位于 `scripts/evaluate_speech_presence.py`，不恢复 `tools/voice_eval/`；
- 默认模型资产目录为 `main_logic/asr_client/endpointing/models`；
- `VoiceTransportToken` / `FinalKey` 继续由 `asr_client/lifecycle.py` 单一拥有。

## 六提交

1. `fcab7cff7` — RNNoise chunk evidence 全链路透传；
2. `1fe88f72c` — bounded adaptive throttle policy；
3. `c52bb77fe` — Provider-authority streaming / SmartTurn-authority wake path 分离；
4. `8ab0f4e3f` — completion/provider candidate fence 与 successor PCM；
5. `a796c007d` — PREWARMING/WARM_IDLE TTL 与 typed submit result；
6. `b3b9496b9` — 评测迁移、结构合同和边界守门。

## 行为边界

- Provider-authority streaming：SmartTurn 零加载、零 pin、零评估；logical final 仍由 Provider 发布。
- 仍受支持的 manual streaming：继续使用现有 SmartTurn authority，以驱动 Provider 的显式 commit。
- 分段 Provider：继续使用现有 policy 指定的 SmartTurn authority。
- RNNoise 只提供 chunk-level `frame_count/peak/mean/last/ema` evidence；Silero 负责 confirm/pause。
- transport-only prewarm、candidate open、continuous wake 与 WARM_IDLE/PREWARMING 有界缓冲均受 session/detector/ingress identity fence 保护。
- Provider final 必须先成功消费 candidate fence，才可标记 accepted；旧 callback/timer 不得关闭 successor。
- throttle policy 不接收 Provider key，不选择 Provider；本 PR 不修改 Provider worker/policy/fallback、WebSocket、game、UI、locale 或模型资产。

## 本轮 review 修复

- `submit()` 所有顶层失败路径统一返回 `AsrSubmitResult`，不再泄漏裸 `bool`。
- RNNoise 完整 evidence 经 Core 正常路由、hot-swap cache/replay 到 `IndependentAsrRuntime.submit()`，不虚构 `frame_count=1`。
- Provider candidate 在首个 RNNoise prewarm 后保持打开，后续低峰 chunk 仍送入 Silero，直到确认或显式 reset。
- lazy prewarm 默认遵循 `lifecycle.provider_policy.connect_max_attempts`；显式 override 仍优先。
- Qwen/Soniox manual streaming 恢复 SmartTurn endpointing；Provider-authority streaming 仍保持 SmartTurn 零加载。
- real-device 录音按 source group 拆分 calibration/holdout；阈值只由 calibration 选择，rollout 指标使用 holdout。
- 评测默认模拟浏览器 480-sample / 10ms、`frames_per_chunk=1`；20ms 仅作为显式实验模式。

## 验证

- Phase 4B 12 文件聚焦回归：644 passed。
- 最新 `main@a4a633016` 完整 unit：10,527 passed / 49 skipped。
- 十个 Phase 4B 生产白名单文件覆盖率：84%。
- `uv run ruff check`、`uv run python scripts/check_core_contracts.py`、`git diff --check` 通过。
- GitNexus：188,421 nodes / 323,035 edges / 300 flows；compare 风险 MEDIUM，仅命中 3 条预期 submit/backpressure 流程。
- 相对 main 正好 6 提交；生产差异仅白名单 10 文件；硬禁止差异为零。

## 风险

主要风险集中在连续语音、DRAINING successor overflow、Provider final/candidate completion 的锁顺序、manual streaming endpointing，以及 stale timer/callback 隔离。对应竞态、重复/stale final、首字保护、两种锁顺序、TTL、manual/provider authority 对偶和有界 binding 均有回归覆盖。

## 回归报告 / Regression Report

- 改动与必要性：在不改变 Provider final authority 的前提下，为语音数据面补齐 RNNoise chunk evidence、bounded throttle、endpoint-authority 唤醒分流、completion/candidate fence、successor PCM 保护和 lifecycle TTL；目的是降低静音期成本，同时封住 stale callback/timer 与连续语音竞态。
- 改动前：RNNoise evidence 会在 Core/hot-swap 链路丢失；wake path 未正确区分 Provider authority 与 SmartTurn authority；submit 失败结果类型不统一；candidate/completion/TTL 对 successor 的隔离不足。
- 改动后：完整 evidence 端到端透传；Provider-authority streaming SmartTurn 零加载，manual streaming 与 segmented 保留现有 SmartTurn authority；Provider final 先消费 fence；旧 callback/timer 不能关闭 successor；所有 submit 顶层分支返回 typed result。
- 潜在回归与验证：风险集中在连续语音、DRAINING overflow、Provider final/candidate completion 锁顺序、stale timer/callback、manual streaming endpointing 和 hot-swap replay。聚焦回归 644 passed，白名单生产文件覆盖率 84%，完整 unit 10,527 passed / 49 skipped。

## 不拆分理由 / Why Not Split

六个提交分别隔离 evidence、policy、wake paths、fence、TTL 与测试/评测，但共同构成一个不可缺环的 Phase 4B 数据面合同；继续拆为多个 PR 会让中间状态出现未受 fence/TTL 保护的唤醒或 completion 行为。当前 PR 已保持线性六提交，生产差异仅 10 个白名单文件，便于逐提交审阅且不包含 #2396/#2576/#2582 的前置差异。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 引入结合 RNNoise 与 Silero 证据的智能语音节流，减少静音音频处理。
  * 优化语音端点检测、连续对话、候选切换与预热流程，提升识别稳定性。
  * 新增语音存在性评估工具，支持真实设备数据、阈值校准、延迟与资源报告。
* **体验改进**
  * 增强过期、重连、异常及后继语音场景的状态恢复，降低误触发与音频丢失风险。
* **文档**
  * 新增语音存在性基准测试、节流契约及评估复现规范。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->