### PR TITLE
统一音色克隆预览错误弹窗样式

### DIFF
--- a/static/css/voice_clone.css
+++ b/static/css/voice_clone.css
@@ -1747,3 +1747,225 @@ html[lang="zh-CN"] .register-voice-btn .register-text {
     color: #fff;
     box-shadow: 0 2px 8px rgba(42, 123, 196, 0.3);
 }
+
+/* 声音预览错误提示：与记忆管理页的教程重置提示保持一致。 */
+.voice-preview-notice-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 10000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    background: rgba(23, 87, 122, 0.36);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    animation: voice-preview-notice-fade 0.18s ease-out;
+}
+
+.voice-preview-notice-backdrop.is-closing {
+    animation: voice-preview-notice-fade-out 0.16s ease-in forwards;
+}
+
+.voice-preview-notice-card {
+    width: min(440px, 100%);
+    overflow: hidden;
+    border: 2px solid rgba(179, 229, 252, 0.92);
+    border-radius: 20px;
+    background: #ffffff;
+    box-shadow: 0 18px 46px rgba(64, 197, 241, 0.24), 0 8px 20px rgba(23, 167, 255, 0.16);
+    font-family: 'Comic Neue', 'Source Han Sans CN', 'Noto Sans SC', sans-serif;
+    animation: voice-preview-notice-pop 0.22s ease-out;
+}
+
+.voice-preview-notice-backdrop.is-closing .voice-preview-notice-card {
+    animation: voice-preview-notice-pop-out 0.16s ease-in forwards;
+}
+
+.voice-preview-notice-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 18px 22px;
+    background: linear-gradient(to right, #ff8a70, #ff4d67);
+}
+
+.voice-preview-notice-mark {
+    position: relative;
+    flex: 0 0 auto;
+    width: 34px;
+    height: 34px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.95);
+    box-shadow: inset 0 -3px 7px rgba(64, 197, 241, 0.18), 0 4px 12px rgba(23, 167, 255, 0.25);
+}
+
+.voice-preview-notice-mark::before {
+    content: "";
+    position: absolute;
+    top: 7px;
+    left: 50%;
+    width: 4px;
+    height: 14px;
+    border-radius: 999px;
+    background: #ff5252;
+    transform: translateX(-50%);
+}
+
+.voice-preview-notice-mark::after {
+    content: "";
+    position: absolute;
+    bottom: 7px;
+    left: 50%;
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    background: #ff5252;
+    transform: translateX(-50%);
+}
+
+.voice-preview-notice-title {
+    min-width: 0;
+    margin: 0;
+    color: #ffffff;
+    font-size: 1.18rem;
+    font-weight: 800;
+    line-height: 1.25;
+    overflow-wrap: anywhere;
+    text-shadow: 0 2px 0 rgba(161, 34, 65, 0.35);
+}
+
+.voice-preview-notice-body {
+    padding: 22px 24px 10px;
+}
+
+.voice-preview-notice-message {
+    margin: 0;
+    color: #268fb8;
+    font-size: 0.98rem;
+    font-weight: 600;
+    line-height: 1.7;
+    overflow-wrap: anywhere;
+}
+
+.voice-preview-notice-actions {
+    display: flex;
+    justify-content: flex-end;
+    padding: 14px 24px 24px;
+}
+
+.voice-preview-notice-ok {
+    min-width: 112px;
+    min-height: 42px;
+    padding: 10px 22px;
+    border: 0;
+    border-radius: 50px;
+    background: linear-gradient(135deg, #40C5F1 0%, #22b3ff 100%);
+    color: #ffffff;
+    font-size: 0.95rem;
+    font-weight: 800;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+    box-shadow: 0 6px 16px rgba(64, 197, 241, 0.28);
+}
+
+.voice-preview-notice-ok:hover {
+    opacity: 0.95;
+    transform: translateY(-1px);
+    box-shadow: 0 8px 20px rgba(64, 197, 241, 0.34);
+}
+
+.voice-preview-notice-ok:active {
+    transform: translateY(1px) scale(0.98);
+}
+
+.voice-preview-notice-ok:focus-visible {
+    outline: 3px solid rgba(64, 197, 241, 0.32);
+    outline-offset: 3px;
+}
+
+[data-theme="dark"] .voice-preview-notice-backdrop {
+    background: rgba(0, 0, 0, 0.58);
+}
+
+[data-theme="dark"] .voice-preview-notice-card {
+    border-color: rgba(74, 163, 223, 0.45);
+    background: #2d2d2d;
+    box-shadow: 0 22px 54px rgba(0, 0, 0, 0.48), 0 8px 22px rgba(58, 159, 216, 0.16);
+}
+
+[data-theme="dark"] .voice-preview-notice-header {
+    background: linear-gradient(to right, #c04b42, #8f1d3a);
+}
+
+[data-theme="dark"] .voice-preview-notice-mark {
+    background: #252525;
+    box-shadow: inset 0 -3px 7px rgba(74, 163, 223, 0.18), 0 4px 12px rgba(0, 0, 0, 0.28);
+}
+
+[data-theme="dark"] .voice-preview-notice-message {
+    color: #e0e0e0;
+}
+
+@keyframes voice-preview-notice-fade {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+@keyframes voice-preview-notice-fade-out {
+    from { opacity: 1; }
+    to { opacity: 0; }
+}
+
+@keyframes voice-preview-notice-pop {
+    from {
+        opacity: 0;
+        transform: translateY(12px) scale(0.97);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+@keyframes voice-preview-notice-pop-out {
+    from {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+    to {
+        opacity: 0;
+        transform: translateY(8px) scale(0.98);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .voice-preview-notice-backdrop,
+    .voice-preview-notice-backdrop.is-closing,
+    .voice-preview-notice-card,
+    .voice-preview-notice-backdrop.is-closing .voice-preview-notice-card {
+        animation: none;
+    }
+
+    .voice-preview-notice-ok {
+        transition: none;
+    }
+}
+
+@media (max-width: 760px) {
+    .voice-preview-notice-backdrop {
+        padding: 18px;
+    }
+
+    .voice-preview-notice-header {
+        padding: 16px 18px;
+    }
+
+    .voice-preview-notice-body {
+        padding: 18px 18px 8px;
+    }
+
+    .voice-preview-notice-actions {
+        padding: 12px 18px 20px;
+    }
+}

--- a/static/js/voice_clone.js
+++ b/static/js/voice_clone.js
@@ -5,6 +5,7 @@ let workshopReferenceFile = null;
 let workshopReferenceAudioUrl = '';
 let providerTouchedByUser = false;
 let suppressProviderTouchedTracking = false;
+let activeVoicePreviewNotice = null;
 // 防止并发应用音色的可重入守卫
 let isApplyingVoice = false;
 const VOICE_CLONE_PROVIDER_REGISTRY_KEYS = Object.freeze({
@@ -2082,6 +2083,102 @@ window.addEventListener('message', function (event) {
     }
 });
 
+function showVoicePreviewErrorNotice(message) {
+    if (activeVoicePreviewNotice) {
+        activeVoicePreviewNotice.dispose();
+    }
+
+    const backdrop = document.createElement('div');
+    backdrop.className = 'voice-preview-notice-backdrop';
+
+    const card = document.createElement('div');
+    card.className = 'voice-preview-notice-card';
+    card.setAttribute('role', 'alertdialog');
+    card.setAttribute('aria-modal', 'true');
+    card.setAttribute('aria-labelledby', 'voice-preview-notice-title');
+    card.setAttribute('aria-describedby', 'voice-preview-notice-message');
+
+    const header = document.createElement('div');
+    header.className = 'voice-preview-notice-header';
+
+    const mark = document.createElement('span');
+    mark.className = 'voice-preview-notice-mark';
+    mark.setAttribute('aria-hidden', 'true');
+
+    const title = document.createElement('h3');
+    title.className = 'voice-preview-notice-title';
+    title.id = 'voice-preview-notice-title';
+    title.textContent = window.t ? window.t('voice.preview') : 'Preview';
+
+    const body = document.createElement('div');
+    body.className = 'voice-preview-notice-body';
+
+    const messageEl = document.createElement('p');
+    messageEl.className = 'voice-preview-notice-message';
+    messageEl.id = 'voice-preview-notice-message';
+    messageEl.textContent = String(message || '');
+
+    const actions = document.createElement('div');
+    actions.className = 'voice-preview-notice-actions';
+
+    const okButton = document.createElement('button');
+    okButton.type = 'button';
+    okButton.className = 'voice-preview-notice-ok';
+    okButton.textContent = window.t ? window.t('common.ok') : 'OK';
+
+    header.appendChild(mark);
+    header.appendChild(title);
+    body.appendChild(messageEl);
+    actions.appendChild(okButton);
+    card.appendChild(header);
+    card.appendChild(body);
+    card.appendChild(actions);
+    backdrop.appendChild(card);
+
+    let closed = false;
+    let cleaned = false;
+
+    function cleanup() {
+        if (cleaned) return;
+        cleaned = true;
+        document.removeEventListener('keydown', onKeydown);
+        if (backdrop.parentNode) {
+            backdrop.parentNode.removeChild(backdrop);
+        }
+        if (activeVoicePreviewNotice && activeVoicePreviewNotice.backdrop === backdrop) {
+            activeVoicePreviewNotice = null;
+        }
+    }
+
+    function close() {
+        if (closed) return;
+        closed = true;
+        backdrop.classList.add('is-closing');
+        window.setTimeout(cleanup, 160);
+    }
+
+    function dispose() {
+        closed = true;
+        cleanup();
+    }
+
+    function onKeydown(event) {
+        if (event.key === 'Escape' || event.key === 'Enter') {
+            event.preventDefault();
+            close();
+        }
+    }
+
+    okButton.addEventListener('click', close);
+    backdrop.addEventListener('click', event => {
+        if (event.target === backdrop) close();
+    });
+    document.addEventListener('keydown', onKeydown);
+    document.body.appendChild(backdrop);
+    activeVoicePreviewNotice = { backdrop, dispose };
+    window.setTimeout(() => okButton.focus(), 0);
+}
+
 async function playPreview(voiceId, btn, options = {}) {
     if (btn.disabled) return;
 
@@ -2181,7 +2278,9 @@ async function playPreview(voiceId, btn, options = {}) {
             const audio = new Audio(audioSrc);
             audio.play().catch(e => {
                 console.error('Audio play error:', e);
-                alert(window.t ? window.t('voice.playFailed', { error: e.message }) : '播放失败: ' + e.message);
+                showVoicePreviewErrorNotice(
+                    window.t ? window.t('voice.playFailed', { error: e.message }) : '播放失败: ' + e.message
+                );
             });
             btn.innerHTML = originalContent;
             btn.disabled = false;
@@ -2189,7 +2288,9 @@ async function playPreview(voiceId, btn, options = {}) {
     } catch (error) {
         console.error('Preview error:', error);
         const errorMsg = error?.message || error?.toString();
-        alert(window.t ? window.t('voice.previewFailed', { error: errorMsg }) : '预览失败: ' + errorMsg);
+        showVoicePreviewErrorNotice(
+            window.t ? window.t('voice.previewFailed', { error: errorMsg }) : '预览失败: ' + errorMsg
+        );
         btn.innerHTML = originalContent;
         btn.disabled = false;
     }

--- a/static/js/voice_clone.js
+++ b/static/js/voice_clone.js
@@ -2141,7 +2141,7 @@ function showVoicePreviewErrorNotice(message) {
     function cleanup() {
         if (cleaned) return;
         cleaned = true;
-        document.removeEventListener('keydown', onKeydown);
+        document.removeEventListener('keydown', onKeydown, true);
         if (backdrop.parentNode) {
             backdrop.parentNode.removeChild(backdrop);
         }
@@ -2163,8 +2163,15 @@ function showVoicePreviewErrorNotice(message) {
     }
 
     function onKeydown(event) {
+        if (event.key === 'Tab') {
+            event.preventDefault();
+            event.stopPropagation();
+            okButton.focus();
+            return;
+        }
         if (event.key === 'Escape' || event.key === 'Enter') {
             event.preventDefault();
+            event.stopPropagation();
             close();
         }
     }
@@ -2173,7 +2180,7 @@ function showVoicePreviewErrorNotice(message) {
     backdrop.addEventListener('click', event => {
         if (event.target === backdrop) close();
     });
-    document.addEventListener('keydown', onKeydown);
+    document.addEventListener('keydown', onKeydown, true);
     document.body.appendChild(backdrop);
     activeVoicePreviewNotice = { backdrop, dispose };
     window.setTimeout(() => okButton.focus(), 0);

--- a/tests/frontend/test_voice_clone.py
+++ b/tests/frontend/test_voice_clone.py
@@ -213,16 +213,22 @@ def test_voice_preview_error_uses_styled_notice(mock_page: Page, running_server:
         mock_page.goto(f"{running_server}/voice_clone")
         item = mock_page.locator('.voice-list-item[data-voice-id="preview-error-test"]')
         expect(item).to_be_visible()
-        item.locator(".voice-preview-btn").click()
+        preview_button = item.locator(".voice-preview-btn")
+        preview_button.click()
 
         notice = mock_page.locator(".voice-preview-notice-backdrop")
         expect(notice).to_be_visible(timeout=20000)
         expect(mock_page.locator(".voice-preview-notice-title")).to_have_text("预览")
         expect(mock_page.locator(".voice-preview-notice-message")).to_contain_text("preview backend unavailable")
-        expect(mock_page.locator(".voice-preview-notice-ok")).to_be_focused()
+        ok_button = mock_page.locator(".voice-preview-notice-ok")
+        expect(ok_button).to_be_focused()
         assert native_dialogs == []
 
-        mock_page.locator(".voice-preview-notice-ok").click()
+        mock_page.keyboard.press("Tab")
+        expect(ok_button).to_be_focused()
+        mock_page.keyboard.press("Shift+Tab")
+        expect(ok_button).to_be_focused()
+        mock_page.keyboard.press("Escape")
         expect(notice).to_have_count(0)
     finally:
         mock_page.unroute("**/api/config/steam_language")

--- a/tests/frontend/test_voice_clone.py
+++ b/tests/frontend/test_voice_clone.py
@@ -172,6 +172,67 @@ def test_saved_design_voice_preview_uses_runtime_endpoint(mock_page: Page, runni
 
 
 @pytest.mark.frontend
+def test_voice_preview_error_uses_styled_notice(mock_page: Page, running_server: str):
+    native_dialogs = []
+    try:
+        route_voice_clone_region_dependencies(
+            mock_page,
+            {
+                "success": True,
+                "steam_language": "schinese",
+                "i18n_language": "zh-CN",
+                "ip_country": "CN",
+                "is_mainland_china": True,
+            },
+        )
+        mock_page.on("dialog", lambda dialog: (native_dialogs.append(dialog.message), dialog.dismiss()))
+        mock_page.route(
+            "**/api/characters/voices",
+            lambda route: route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps({
+                    "voices": {},
+                    "free_voices": {
+                        "previewErrorTest": "preview-error-test",
+                    },
+                    "pinned_voices": [],
+                    "native_voices": {},
+                }),
+            ),
+        )
+        mock_page.route(
+            "**/api/characters/voice_preview?*",
+            lambda route: route.fulfill(
+                status=500,
+                content_type="application/json",
+                body=json.dumps({"error": "preview backend unavailable"}),
+            ),
+        )
+
+        mock_page.goto(f"{running_server}/voice_clone")
+        item = mock_page.locator('.voice-list-item[data-voice-id="preview-error-test"]')
+        expect(item).to_be_visible()
+        item.locator(".voice-preview-btn").click()
+
+        notice = mock_page.locator(".voice-preview-notice-backdrop")
+        expect(notice).to_be_visible(timeout=20000)
+        expect(mock_page.locator(".voice-preview-notice-title")).to_have_text("预览")
+        expect(mock_page.locator(".voice-preview-notice-message")).to_contain_text("preview backend unavailable")
+        expect(mock_page.locator(".voice-preview-notice-ok")).to_be_focused()
+        assert native_dialogs == []
+
+        mock_page.locator(".voice-preview-notice-ok").click()
+        expect(notice).to_have_count(0)
+    finally:
+        mock_page.unroute("**/api/config/steam_language")
+        mock_page.unroute("**/api/config/api_providers")
+        mock_page.unroute("**/api/config/core_api")
+        mock_page.unroute("**/api/characters/voices")
+        mock_page.unroute("**/api/characters/voice_preview?*")
+
+
+@pytest.mark.frontend
 def test_voice_clone_page_load(mock_page: Page, running_server: str):
     """Test that the voice clone page loads with all expected UI elements."""
     mock_page.on("console", lambda msg: print(f"Browser Console: {msg.text}"))


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

统一音色克隆预览错误弹窗样式

## 测试 / Testing

断开连接测试UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 语音试听失败时，改用样式化提示弹窗显示错误信息，替代浏览器原生提示。
  * 弹窗支持遮罩点击关闭、Enter/Escape 快捷关闭，并自动恢复试听按钮状态。
  * 弹窗适配深色模式、小屏布局，并在“减少动态效果”场景下禁用相关动画。
* **测试**
  * 新增前端自动化用例：验证错误提示样式与本地化文案、OK 按钮初始焦点与 Tab 焦点陷阱，以及关闭后不再出现原生对话框。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->