### PR TITLE
feat: add personalized Twitch proactive source

### DIFF
--- a/main_routers/cookies_login_router.py
+++ b/main_routers/cookies_login_router.py
@@ -49,6 +49,7 @@ from utils.cookies_login import (
     get_cookie_key_file,
 )
 from utils.logger_config import get_module_logger
+from utils.twitch_auth import TwitchAuthService
 
 logger = get_module_logger(__name__, "Main")
 
@@ -74,6 +75,7 @@ def verify_local_access(request: Request):
 router = APIRouter(prefix="/api/auth", tags=["认证管理"], dependencies=[Depends(verify_local_access)])
 templates = Jinja2Templates(directory="templates")
 login_manager = PlatformLoginManager()
+twitch_auth_service = TwitchAuthService()
 
 # Only these credential types can back the personal-dynamics proactive source.
 # Keep this aligned with ``utils.web_scraper.personal_dynamics``.
@@ -102,6 +104,12 @@ class CookieSubmit(BaseModel):
             logger.warning(f"🚨 检测到恶意内容注入尝试！恶意内容注入，length={len(v)}")
             raise ValueError("检测到非法或危险字符，请求已被系统拦截。")
         return v
+
+
+class TwitchDeviceSubmit(BaseModel):
+    """The public Twitch Developer Client ID used for Device Code authorization."""
+
+    client_id: str = Field(..., min_length=8, max_length=80, pattern=r"^[A-Za-z0-9]+$")
 
 
 # ============ 1. 内部辅助逻辑 ============
@@ -172,6 +180,11 @@ async def get_supported_platforms():
 @router.post("/cookies/save", summary="保存Cookie")
 async def save_cookie(data: CookieSubmit):
     try:
+        if data.platform == "twitch":
+            raise HTTPException(
+                status_code=400,
+                detail="Twitch 凭证只能通过 Device Code 授权保存",
+            )
         # 1. 验证平台是否支持
         supported_platforms = login_manager.get_supported_platforms()
         if data.platform not in supported_platforms:
@@ -202,6 +215,27 @@ async def save_cookie(data: CookieSubmit):
         logger.error(f"保存失败: {type(e).__name__}")
         logger.debug(f"详细错误: {e}")  # debug 级别记录详情
         raise HTTPException(status_code=500, detail="内部服务器错误")
+
+
+@router.post("/twitch/device/start", summary="启动 Twitch Device Code 授权")
+async def start_twitch_device_authorization(data: TwitchDeviceSubmit):
+    """Start a local-only OAuth Device Code flow without returning secrets."""
+    result = await twitch_auth_service.start(data.client_id)
+    if result.get("success"):
+        return result
+    raise HTTPException(status_code=502, detail="无法启动 Twitch 授权，请检查 Client ID 或网络连接")
+
+
+@router.post("/twitch/device/check", summary="检查 Twitch Device Code 授权")
+async def check_twitch_device_authorization(data: TwitchDeviceSubmit):
+    """Poll Twitch once; successful credentials are encrypted before returning."""
+    result = await twitch_auth_service.check_device_code(data.client_id)
+    if result.get("success"):
+        return result
+    code = result.get("code")
+    if code in {"device_authorization_not_active", "device_authorization_expired"}:
+        raise HTTPException(status_code=400, detail="Twitch 授权已失效，请重新开始授权")
+    raise HTTPException(status_code=502, detail="Twitch 授权检查失败，请稍后重试")
 
 @router.get("/cookies/status", summary="获取所有平台Cookie状态汇总")
 async def get_all_cookies_status():

--- a/main_routers/cookies_login_router.py
+++ b/main_routers/cookies_login_router.py
@@ -180,15 +180,17 @@ async def get_supported_platforms():
 @router.post("/cookies/save", summary="保存Cookie")
 async def save_cookie(data: CookieSubmit):
     try:
-        if data.platform == "twitch":
-            raise HTTPException(
-                status_code=400,
-                detail="Twitch 凭证只能通过 Device Code 授权保存",
-            )
         # 1. 验证平台是否支持
         supported_platforms = login_manager.get_supported_platforms()
         if data.platform not in supported_platforms:
             raise HTTPException(status_code=400, detail=f"不支持的平台: {data.platform}")
+        platform_info = supported_platforms[data.platform]
+        if "manual" not in platform_info.get("methods", []):
+            method = platform_info.get("default_method") or "平台专用授权流程"
+            raise HTTPException(
+                status_code=400,
+                detail=f"{platform_info['name']} 凭证只能通过 {method} 授权保存",
+            )
             
         # 2. 解析与验证
         cookies = parse_cookie_string(data.cookie_string)

--- a/main_routers/cookies_login_router.py
+++ b/main_routers/cookies_login_router.py
@@ -263,6 +263,10 @@ async def get_platform_cookies(platform: str):
     supported = login_manager.get_supported_platforms()
     if platform not in supported:
         raise HTTPException(status_code=400, detail="平台无效")
+
+    if platform == "twitch":
+        status_data = await twitch_auth_service.status()
+        return {"success": True, "data": status_data}
             
     cookies = await asyncio.to_thread(load_cookies_from_file, platform)
     if not cookies:

--- a/main_routers/system_router/proactive_content.py
+++ b/main_routers/system_router/proactive_content.py
@@ -81,7 +81,8 @@ def _log_video_content(lanlan_name: str, video_content: dict):
         titles = [video.get('title', '') for video in videos[:5]]
         if titles:
             source = "B站视频" if region == 'china' else (
-                "Twitch 直播分类" if video_data.get("source") == "twitch" else "YouTube视频"
+                "Twitch 与 YouTube 视频" if video_data.get("source") == "mixed" else
+                "Twitch 直播" if video_data.get("source") == "twitch" else "YouTube视频"
             )
             print(f"[{lanlan_name}] 成功获取{source}:")
             for title in titles:

--- a/main_routers/system_router/proactive_content.py
+++ b/main_routers/system_router/proactive_content.py
@@ -80,7 +80,9 @@ def _log_video_content(lanlan_name: str, video_content: dict):
         videos = video_data.get('videos', [])
         titles = [video.get('title', '') for video in videos[:5]]
         if titles:
-            source = "B站视频" if region == 'china' else "YouTube视频"
+            source = "B站视频" if region == 'china' else (
+                "Twitch 直播分类" if video_data.get("source") == "twitch" else "YouTube视频"
+            )
             print(f"[{lanlan_name}] 成功获取{source}:")
             for title in titles:
                 print(f"  - {title}")

--- a/static/js/cookies_login.js
+++ b/static/js/cookies_login.js
@@ -49,6 +49,14 @@ const PLATFORM_CONFIG_DATA = {
         cookieStringDescKey: 'cookiesLogin.fields.youtubeCookie.desc',
         fields: []
     },
+    'twitch': {
+        name: 'Twitch',
+        nameKey: 'cookiesLogin.twitch',
+        theme: '#9146ff',
+        instructionKey: 'cookiesLogin.instructions.twitch',
+        authMode: 'deviceCode',
+        fields: []
+    },
     'douyin': {
         name: '抖音', 
         nameKey: 'cookiesLogin.douyin', 
@@ -199,6 +207,7 @@ function initPlatformConfig() {
             cookieStringMode: data.cookieStringMode === true,
             cookieStringLabel: data.cookieStringLabelKey ? safeT(data.cookieStringLabelKey, '完整 Cookie') : '',
             cookieStringDesc: data.cookieStringDescKey ? safeT(data.cookieStringDescKey, '粘贴 Request Headers 中完整的 Cookie 值') : '',
+            authMode: data.authMode || '',
             fields: data.fields.map(field => ({
                 key: field.key,
                 mapKey: field.mapKey,
@@ -621,6 +630,10 @@ function switchTab(platformKey, btnElement, isReRender = false) {
     }
     currentPlatform = platformKey;
     const config = PLATFORM_CONFIG[platformKey];
+    const tutorialBanner = document.querySelector('.tutorial-banner');
+    if (tutorialBanner) tutorialBanner.style.display = config.authMode ? 'none' : '';
+    const encryptRow = document.getElementById('encrypt-toggle')?.parentElement;
+    if (encryptRow) encryptRow.style.display = config.authMode ? 'none' : '';
     // 更新选项卡文本
     if (btnElement) {
         document.querySelectorAll('.tab-btn').forEach(btn =>{
@@ -639,7 +652,15 @@ function switchTab(platformKey, btnElement, isReRender = false) {
             descBox.style.display = 'none'; 
         }
     }
-    showQRLogin(PLATFORM_CONFIG_DATA[platformKey], platformKey)
+    if (config.authMode === 'deviceCode') {
+        const qrLoginBox = document.getElementById('QRLogin');
+        if (qrLoginBox) {
+            qrLoginBox.replaceChildren();
+            qrLoginBox.style.display = 'none';
+        }
+    } else {
+        showQRLogin(PLATFORM_CONFIG_DATA[platformKey], platformKey);
+    }
     // 更新动态 Cookies 配置字段
     const fieldsContainer = document.getElementById('dynamic-fields');
     if (fieldsContainer) {
@@ -651,7 +672,17 @@ function switchTab(platformKey, btnElement, isReRender = false) {
         }
 
         const placeholderBase = safeT('cookiesLogin.pasteHere', '在此粘贴');
-        if (config.cookieStringMode) {
+        if (config.authMode === 'deviceCode') {
+            fieldsContainer.innerHTML = `
+            <div class="field-group">
+                <label for="input-twitch-client-id">
+                    <span>${DOMPurify.sanitize(safeT('cookiesLogin.twitchAuth.clientId', 'Twitch Developer Client ID'))} <span class="req-star">*</span></span>
+                    <span class="desc">${DOMPurify.sanitize(safeT('cookiesLogin.twitchAuth.clientIdDesc', 'Create a public app in the Twitch Developer Console and paste its Client ID.'))}</span>
+                </label>
+                <input type="text" id="input-twitch-client-id" autocomplete="off" autocapitalize="off" spellcheck="false" class="credential-input">
+            </div>
+            <div id="twitch-device-result" aria-live="polite"></div>`;
+        } else if (config.cookieStringMode) {
             fieldsContainer.innerHTML = `
             <div class="field-group">
                 <label for="input-cookie-string">
@@ -705,14 +736,105 @@ function switchTab(platformKey, btnElement, isReRender = false) {
     // 更新提交按钮文本
     const submitText = document.getElementById('submit-text');
     if (submitText) {
-        const translatedText = safeT('cookiesLogin.saveConfig', '保存配置');
+        const translatedText = config.authMode === 'deviceCode'
+            ? safeT('cookiesLogin.twitchAuth.start', '开始 Twitch 授权')
+            : safeT('cookiesLogin.saveConfig', '保存配置');
         submitText.textContent = `${config.name} ${translatedText}`;
+    }
+}
+
+function twitchClientId() {
+    return document.getElementById('input-twitch-client-id')?.value.trim() || '';
+}
+
+function renderTwitchDeviceCode(result) {
+    const container = document.getElementById('twitch-device-result');
+    if (!container) return;
+    container.textContent = '';
+    const card = document.createElement('div');
+    card.className = 'tutorial-banner';
+    card.style.marginTop = '18px';
+    const instruction = document.createElement('div');
+    instruction.textContent = safeT('cookiesLogin.twitchAuth.authorizeHint', 'Open the Twitch activation page and enter this code:');
+    const link = document.createElement('a');
+    link.href = result.verification_uri;
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    link.textContent = result.verification_uri;
+    link.style.display = 'block';
+    link.style.margin = '8px 0';
+    const code = document.createElement('strong');
+    code.textContent = result.user_code;
+    code.style.fontSize = '20px';
+    code.style.letterSpacing = '0.08em';
+    const checkButton = document.createElement('button');
+    checkButton.type = 'button';
+    checkButton.className = 'submit-btn';
+    checkButton.style.marginTop = '14px';
+    checkButton.textContent = safeT('cookiesLogin.twitchAuth.check', '我已授权，检查状态');
+    checkButton.addEventListener('click', () => checkTwitchDeviceCode(checkButton));
+    card.append(instruction, link, code, checkButton);
+    container.appendChild(card);
+}
+
+async function startTwitchDeviceCode() {
+    const clientId = twitchClientId();
+    if (!/^[A-Za-z0-9]{8,80}$/.test(clientId)) {
+        showAlert(false, safeT('cookiesLogin.twitchAuth.invalidClientId', '请输入有效的 Twitch Client ID'));
+        document.getElementById('input-twitch-client-id')?.focus();
+        return;
+    }
+    const submitBtn = document.getElementById('submit-btn');
+    if (submitBtn) submitBtn.disabled = true;
+    try {
+        const response = await fetch('/api/auth/twitch/device/start', {
+            method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ client_id: clientId })
+        });
+        const result = await response.json();
+        if (response.ok && result.success) {
+            renderTwitchDeviceCode(result);
+            showAlert(true, safeT('cookiesLogin.twitchAuth.started', 'Twitch 授权已启动，请在浏览器完成确认'));
+        } else {
+            showAlert(false, safeT('cookiesLogin.twitchAuth.startFailed', '无法启动 Twitch 授权，请检查 Client ID 和网络'));
+        }
+    } catch (_) {
+        showAlert(false, safeT('cookiesLogin.networkError', '网络请求失败，请检查连接'));
+    } finally {
+        if (submitBtn) submitBtn.disabled = false;
+    }
+}
+
+async function checkTwitchDeviceCode(button) {
+    const clientId = twitchClientId();
+    if (button) button.disabled = true;
+    try {
+        const response = await fetch('/api/auth/twitch/device/check', {
+            method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ client_id: clientId })
+        });
+        const result = await response.json();
+        if (response.ok && result.success && result.logged_in) {
+            showAlert(true, safeT('cookiesLogin.twitchAuth.authorized', 'Twitch 凭证已加密保存'));
+            document.getElementById('twitch-device-result')?.replaceChildren();
+            refreshStatusList();
+        } else if (response.ok && result.pending) {
+            showAlert(true, safeT('cookiesLogin.twitchAuth.pending', '授权尚未完成，请在 Twitch 页面确认后重试'));
+        } else {
+            showAlert(false, safeT('cookiesLogin.twitchAuth.checkFailed', '授权检查失败，请重新开始授权'));
+        }
+    } catch (_) {
+        showAlert(false, safeT('cookiesLogin.networkError', '网络请求失败，请检查连接'));
+    } finally {
+        if (button) button.disabled = false;
     }
 }
 
 // 提交当前平台的 Cookies 配置
 async function submitCurrentCookie() {
     const config = PLATFORM_CONFIG[currentPlatform];
+    if (config.authMode === 'deviceCode') {
+        await startTwitchDeviceCode();
+        return;
+    }
     let cookieString = '';
 
     if (config.cookieStringMode) {

--- a/static/js/cookies_login.js
+++ b/static/js/cookies_login.js
@@ -183,6 +183,10 @@ function getQrStatusMessage(status, message) {
 
 let PLATFORM_CONFIG = {};
 let currentPlatform = 'netease';
+let twitchDevicePollTimeout = null;
+let twitchDevicePollInFlight = false;
+let twitchDevicePollActive = false;
+let twitchDevicePollIntervalMs = 5000;
 
 // 当语言切换时，重新初始化平台配置
 function initPlatformConfig() {
@@ -275,6 +279,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const firstTab = document.querySelector('.tab-btn');
     if (firstTab) switchTab('netease', firstTab);
     refreshStatusList();
+});
+
+document.addEventListener('visibilitychange', () => {
+    if (document.hidden) {
+        clearTwitchDevicePollTimer();
+    } else if (twitchDevicePollActive) {
+        scheduleTwitchDevicePoll();
+    }
 });
 
 /**
@@ -622,6 +634,14 @@ function switchTab(platformKey, btnElement, isReRender = false) {
         return;
     }
 
+    const previousPlatform = currentPlatform;
+    const existingTwitchResult = isReRender && previousPlatform === 'twitch'
+        ? document.getElementById('twitch-device-result')
+        : null;
+    if (!isReRender && previousPlatform !== platformKey) {
+        stopTwitchDevicePoll();
+    }
+
     stopQrPoll();
     currentQrKey = null;
     if (qrRefreshTimeout) {
@@ -630,7 +650,7 @@ function switchTab(platformKey, btnElement, isReRender = false) {
     }
     currentPlatform = platformKey;
     const config = PLATFORM_CONFIG[platformKey];
-    const tutorialBanner = document.querySelector('.tutorial-banner');
+    const tutorialBanner = document.querySelector('#main-panel > .tutorial-banner');
     if (tutorialBanner) tutorialBanner.style.display = config.authMode ? 'none' : '';
     const encryptRow = document.getElementById('encrypt-toggle')?.parentElement;
     if (encryptRow) encryptRow.style.display = config.authMode ? 'none' : '';
@@ -682,6 +702,10 @@ function switchTab(platformKey, btnElement, isReRender = false) {
                 <input type="text" id="input-twitch-client-id" autocomplete="off" autocapitalize="off" spellcheck="false" class="credential-input">
             </div>
             <div id="twitch-device-result" aria-live="polite"></div>`;
+            const freshTwitchResult = fieldsContainer.querySelector('#twitch-device-result');
+            if (existingTwitchResult && freshTwitchResult) {
+                freshTwitchResult.replaceWith(existingTwitchResult);
+            }
         } else if (config.cookieStringMode) {
             fieldsContainer.innerHTML = `
             <div class="field-group">
@@ -747,6 +771,38 @@ function twitchClientId() {
     return document.getElementById('input-twitch-client-id')?.value.trim() || '';
 }
 
+function clearTwitchDevicePollTimer() {
+    if (twitchDevicePollTimeout) {
+        clearTimeout(twitchDevicePollTimeout);
+        twitchDevicePollTimeout = null;
+    }
+}
+
+function stopTwitchDevicePoll() {
+    twitchDevicePollActive = false;
+    clearTwitchDevicePollTimer();
+}
+
+function scheduleTwitchDevicePoll() {
+    clearTwitchDevicePollTimer();
+    if (!twitchDevicePollActive || currentPlatform !== 'twitch' || document.hidden) return;
+    twitchDevicePollTimeout = setTimeout(async () => {
+        twitchDevicePollTimeout = null;
+        const outcome = await checkTwitchDeviceCode(null, true);
+        if (outcome === 'pending' || outcome === 'in_flight') {
+            scheduleTwitchDevicePoll();
+        }
+    }, twitchDevicePollIntervalMs);
+}
+
+function startTwitchDevicePoll(intervalSeconds) {
+    stopTwitchDevicePoll();
+    const seconds = Number(intervalSeconds);
+    twitchDevicePollIntervalMs = Math.max(1, Math.min(Number.isFinite(seconds) ? seconds : 5, 60)) * 1000;
+    twitchDevicePollActive = true;
+    scheduleTwitchDevicePoll();
+}
+
 function renderTwitchDeviceCode(result) {
     const container = document.getElementById('twitch-device-result');
     if (!container) return;
@@ -784,6 +840,7 @@ async function startTwitchDeviceCode() {
         document.getElementById('input-twitch-client-id')?.focus();
         return;
     }
+    stopTwitchDevicePoll();
     const submitBtn = document.getElementById('submit-btn');
     if (submitBtn) submitBtn.disabled = true;
     try {
@@ -793,6 +850,7 @@ async function startTwitchDeviceCode() {
         const result = await response.json();
         if (response.ok && result.success) {
             renderTwitchDeviceCode(result);
+            startTwitchDevicePoll(result.interval);
             showAlert(true, safeT('cookiesLogin.twitchAuth.started', 'Twitch 授权已启动，请在浏览器完成确认'));
         } else {
             showAlert(false, safeT('cookiesLogin.twitchAuth.startFailed', '无法启动 Twitch 授权，请检查 Client ID 和网络'));
@@ -804,7 +862,9 @@ async function startTwitchDeviceCode() {
     }
 }
 
-async function checkTwitchDeviceCode(button) {
+async function checkTwitchDeviceCode(button, automatic = false) {
+    if (twitchDevicePollInFlight) return 'in_flight';
+    twitchDevicePollInFlight = true;
     const clientId = twitchClientId();
     if (button) button.disabled = true;
     try {
@@ -813,17 +873,27 @@ async function checkTwitchDeviceCode(button) {
         });
         const result = await response.json();
         if (response.ok && result.success && result.logged_in) {
+            stopTwitchDevicePoll();
             showAlert(true, safeT('cookiesLogin.twitchAuth.authorized', 'Twitch 凭证已加密保存'));
             document.getElementById('twitch-device-result')?.replaceChildren();
             refreshStatusList();
+            return 'authorized';
         } else if (response.ok && result.pending) {
-            showAlert(true, safeT('cookiesLogin.twitchAuth.pending', '授权尚未完成，请在 Twitch 页面确认后重试'));
+            if (!automatic) {
+                showAlert(true, safeT('cookiesLogin.twitchAuth.pending', '授权尚未完成，请在 Twitch 页面确认后重试'));
+            }
+            return 'pending';
         } else {
+            stopTwitchDevicePoll();
             showAlert(false, safeT('cookiesLogin.twitchAuth.checkFailed', '授权检查失败，请重新开始授权'));
+            return 'failed';
         }
     } catch (_) {
+        stopTwitchDevicePoll();
         showAlert(false, safeT('cookiesLogin.networkError', '网络请求失败，请检查连接'));
+        return 'failed';
     } finally {
+        twitchDevicePollInFlight = false;
         if (button) button.disabled = false;
     }
 }
@@ -1089,4 +1159,5 @@ function showAlert(success, message) {
 // 内存泄漏防护：当窗口关闭或页面卸载前，强制清理所有挂起的定时器
 window.addEventListener('beforeunload', () => {
     clearAlertTimer();
+    stopTwitchDevicePoll();
 });

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -3787,6 +3787,7 @@
         "bilibili": "Bilibili",
         "xhh": "Xiaoheihe",
         "youtube": "YouTube",
+        "twitch": "Twitch",
         "douyin": "Douyin",
         "kuaishou": "Kuaishou",
         "weibo": "Weibo",
@@ -3812,7 +3813,15 @@
         "noCookies": "Please configure Cookies first",
         "statusLoadFailed": "Status load failed",
         "thisPlatform": "this platform",
+        "twitchAuth": {
+            "clientId": "Twitch Developer Client ID", "clientIdDesc": "Create a public app in the Twitch Developer Console and enter its Client ID. A Client Secret is neither requested nor stored.",
+            "start": "Start Twitch authorization", "authorizeHint": "Open the Twitch activation page and enter this code:", "check": "I've authorized it; check status",
+            "invalidClientId": "Enter a valid Twitch Client ID", "started": "Twitch authorization started; finish confirmation in your browser",
+            "startFailed": "Could not start Twitch authorization. Check the Client ID and network.", "authorized": "Twitch credential was encrypted and saved",
+            "pending": "Authorization is not complete. Confirm it on Twitch, then try again.", "checkFailed": "Authorization check failed. Start authorization again."
+        },
         "instructions": {
+            "twitch": "<b>Device Code authorization:</b> Create a public app in the Twitch Developer Console, enter its Client ID, then follow the authorization prompt.",
             "bilibili": "<b>Target:</b> Go to <b>bilibili.com</b> to fetch these cookies.",
             "xhh": "<b>Recommended:</b> use QR login below, or sign in at <b>xiaoheihe.cn</b> and enter the cookies manually.",
             "youtube": "<b>1. Get the Cookie</b><br>In a browser signed in to YouTube:<br>1. Open <b>youtube.com</b><br>2. Press F12 → Network<br>3. Refresh the page and select a <code>youtubei/v1/browse</code> request<br>4. Copy the complete Cookie value from Request Headers",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -3787,6 +3787,7 @@
         "bilibili": "Bilibili",
         "xhh": "Xiaoheihe",
         "youtube": "YouTube",
+        "twitch": "Twitch",
         "douyin": "Douyin",
         "kuaishou": "Kuaishou",
         "weibo": "Weibo",
@@ -3812,7 +3813,15 @@
         "noCookies": "Primero configure las cookies",
         "statusLoadFailed": "Error al cargar el estado",
         "thisPlatform": "esta plataforma",
+        "twitchAuth": {
+            "clientId": "Twitch Developer Client ID", "clientIdDesc": "Crea una aplicación pública en Twitch Developer Console e introduce su Client ID. No se solicita ni almacena Client Secret.",
+            "start": "Iniciar autorización de Twitch", "authorizeHint": "Abre la página de activación de Twitch e introduce este código:", "check": "Ya autoricé; comprobar estado",
+            "invalidClientId": "Introduce un Twitch Client ID válido", "started": "La autorización de Twitch se inició; completa la confirmación en el navegador",
+            "startFailed": "No se pudo iniciar la autorización de Twitch. Comprueba el Client ID y la red.", "authorized": "La credencial de Twitch se cifró y guardó",
+            "pending": "La autorización aún no termina. Confírmala en Twitch y vuelve a intentarlo", "checkFailed": "Falló la comprobación. Inicia la autorización de nuevo."
+        },
         "instructions": {
+            "twitch": "<b>Autorización con Device Code:</b> crea una aplicación pública en Twitch Developer Console, introduce su Client ID y sigue las indicaciones.",
             "bilibili": "<b>Destino:</b> Vaya a <b>bilibili.com</b> para buscar estas cookies.",
             "xhh": "<b>Recomendado:</b> use el inicio de sesión QR o entre en <b>xiaoheihe.cn</b> e introduzca las cookies manualmente.",
             "youtube": "<b>1. Obtén la Cookie</b><br>En un navegador con la sesión de YouTube iniciada:<br>1. Abre <b>youtube.com</b><br>2. Pulsa F12 → Network<br>3. Actualiza la página y selecciona una solicitud <code>youtubei/v1/browse</code><br>4. Copia el valor completo de Cookie desde Request Headers",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -3787,6 +3787,7 @@
         "bilibili": "ビリビリ (Bilibili)",
         "xhh": "小黒盒",
         "youtube": "YouTube",
+        "twitch": "Twitch",
         "douyin": "抖音 (Douyin)",
         "kuaishou": "快手 (Kuaishou)",
         "weibo": "微博 (Weibo)",
@@ -3812,7 +3813,15 @@
         "noCookies": "Cookiesを先に設定してください",
         "statusLoadFailed": "状態の読み込みに失敗しました",
         "thisPlatform": "このプラットフォーム",
+        "twitchAuth": {
+            "clientId": "Twitch Developer Client ID", "clientIdDesc": "Twitch Developer Console で公開アプリを作成し Client ID を入力します。Client Secret は要求も保存もされません。",
+            "start": "Twitch 認可を開始", "authorizeHint": "Twitch の有効化ページを開き、次のコードを入力してください：", "check": "認可しました。状態を確認",
+            "invalidClientId": "有効な Twitch Client ID を入力してください", "started": "Twitch 認可を開始しました。ブラウザで確認を完了してください",
+            "startFailed": "Twitch 認可を開始できません。Client ID とネットワークを確認してください", "authorized": "Twitch 認証情報を暗号化して保存しました",
+            "pending": "認可はまだ完了していません。Twitch で確認してから再試行してください", "checkFailed": "認可の確認に失敗しました。もう一度開始してください"
+        },
         "instructions": {
+            "twitch": "<b>Device Code 認可：</b>Twitch Developer Console で公開アプリを作成し、Client ID を入力して画面の案内に従ってください。",
             "bilibili": "<b>対象：</b> <b>bilibili.com</b> にアクセスして Cookie を取得してください。",
             "xhh": "<b>推奨：</b>下のQRコードログインを使うか、<b>xiaoheihe.cn</b> にログインしてCookieを手動入力してください。",
             "youtube": "<b>1. Cookie を取得</b><br>YouTube にログイン済みのブラウザで：<br>1. <b>youtube.com</b> を開く<br>2. F12 → Network を押す<br>3. ページを更新し、<code>youtubei/v1/browse</code> リクエストを選択する<br>4. Request Headers から完全な Cookie 値をコピーする",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -3787,6 +3787,7 @@
         "bilibili": "빌리빌리 (Bilibili)",
         "xhh": "Xiaoheihe",
         "youtube": "YouTube",
+        "twitch": "Twitch",
         "douyin": "도인 (Douyin)",
         "kuaishou": "쾌수 (Kuaishou)",
         "weibo": "위보 (Weibo)",
@@ -3812,7 +3813,15 @@
         "noCookies": "먼저 쿠키를 설정하세요",
         "statusLoadFailed": "상태 로드 실패",
         "thisPlatform": "이 플랫폼",
+        "twitchAuth": {
+            "clientId": "Twitch Developer Client ID", "clientIdDesc": "Twitch Developer Console에서 공개 앱을 만들고 Client ID를 입력하세요. Client Secret은 요청하거나 저장하지 않습니다.",
+            "start": "Twitch 인증 시작", "authorizeHint": "Twitch 활성화 페이지를 열고 다음 코드를 입력하세요:", "check": "인증했습니다. 상태 확인",
+            "invalidClientId": "유효한 Twitch Client ID를 입력하세요", "started": "Twitch 인증을 시작했습니다. 브라우저에서 확인을 완료하세요",
+            "startFailed": "Twitch 인증을 시작할 수 없습니다. Client ID와 네트워크를 확인하세요", "authorized": "Twitch 자격 증명을 암호화해 저장했습니다",
+            "pending": "인증이 아직 완료되지 않았습니다. Twitch에서 확인한 후 다시 시도하세요", "checkFailed": "인증 확인에 실패했습니다. 다시 시작하세요"
+        },
         "instructions": {
+            "twitch": "<b>Device Code 인증:</b> Twitch Developer Console에서 공개 앱을 만들고 Client ID를 입력한 다음 안내를 따르세요.",
             "bilibili": "<b>대상:</b> <b>bilibili.com</b>에 접속하여 해당 쿠키를 가져오세요.",
             "xhh": "<b>권장:</b> 아래 QR 로그인을 사용하거나 <b>xiaoheihe.cn</b>에 로그인한 뒤 쿠키를 직접 입력하세요.",
             "youtube": "<b>1. Cookie 가져오기</b><br>YouTube에 로그인된 브라우저에서:<br>1. <b>youtube.com</b> 열기<br>2. F12 → Network 누르기<br>3. 페이지를 새로고침하고 <code>youtubei/v1/browse</code> 요청 선택<br>4. Request Headers에서 전체 Cookie 값 복사",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -3787,6 +3787,7 @@
         "bilibili": "Bilíbili",
         "xhh": "Xiaoheihe",
         "youtube": "YouTube",
+        "twitch": "Twitch",
         "douyin": "Douyin",
         "kuaishou": "Kuaishou",
         "weibo": "Weibo",
@@ -3812,7 +3813,15 @@
         "noCookies": "Por favor configure os cookies primeiro",
         "statusLoadFailed": "Falha no carregamento do status",
         "thisPlatform": "esta plataforma",
+        "twitchAuth": {
+            "clientId": "Twitch Developer Client ID", "clientIdDesc": "Crie um aplicativo público no Twitch Developer Console e informe o Client ID. O Client Secret não é solicitado nem armazenado.",
+            "start": "Iniciar autorização da Twitch", "authorizeHint": "Abra a página de ativação da Twitch e informe este código:", "check": "Já autorizei; verificar status",
+            "invalidClientId": "Informe um Twitch Client ID válido", "started": "A autorização da Twitch foi iniciada; conclua a confirmação no navegador",
+            "startFailed": "Não foi possível iniciar a autorização da Twitch. Verifique o Client ID e a rede.", "authorized": "A credencial da Twitch foi criptografada e salva",
+            "pending": "A autorização ainda não terminou. Confirme na Twitch e tente novamente", "checkFailed": "Falha ao verificar a autorização. Inicie novamente."
+        },
         "instructions": {
+            "twitch": "<b>Autorização por Device Code:</b> crie um aplicativo público no Twitch Developer Console, informe o Client ID e siga as instruções.",
             "bilibili": "<b>Target:</b> Vá para <b>bilibili.com</b> para buscar esses cookies.",
             "xhh": "<b>Recomendado:</b> use o login por QR abaixo ou entre em <b>xiaoheihe.cn</b> e preencha os cookies manualmente.",
             "youtube": "<b>1. Obtenha o Cookie</b><br>Em um navegador conectado ao YouTube:<br>1. Abra <b>youtube.com</b><br>2. Pressione F12 → Network<br>3. Atualize a página e selecione uma solicitação <code>youtubei/v1/browse</code><br>4. Copie o valor completo do Cookie em Request Headers",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -3787,6 +3787,7 @@
         "bilibili": "Bilibili",
         "xhh": "Xiaoheihe",
         "youtube": "YouTube",
+        "twitch": "Twitch",
         "douyin": "Douyin",
         "kuaishou": "Kuaishou",
         "weibo": "Weibo",
@@ -3812,7 +3813,15 @@
         "noCookies": "Пожалуйста, сначала настройте Cookies",
         "statusLoadFailed": "Ошибка загрузки статуса",
         "thisPlatform": "Эта платформа",
+        "twitchAuth": {
+            "clientId": "Twitch Developer Client ID", "clientIdDesc": "Создайте публичное приложение в Twitch Developer Console и введите Client ID. Client Secret не запрашивается и не сохраняется.",
+            "start": "Начать авторизацию Twitch", "authorizeHint": "Откройте страницу активации Twitch и введите этот код:", "check": "Я авторизовался; проверить статус",
+            "invalidClientId": "Введите корректный Twitch Client ID", "started": "Авторизация Twitch начата; завершите подтверждение в браузере",
+            "startFailed": "Не удалось начать авторизацию Twitch. Проверьте Client ID и сеть.", "authorized": "Учётные данные Twitch зашифрованы и сохранены",
+            "pending": "Авторизация ещё не завершена. Подтвердите её на Twitch и повторите попытку", "checkFailed": "Не удалось проверить авторизацию. Начните снова."
+        },
         "instructions": {
+            "twitch": "<b>Авторизация Device Code:</b> Создайте публичное приложение в Twitch Developer Console, введите Client ID и следуйте подсказкам.",
             "bilibili": "<b>Цель:</b> Перейдите на <b>bilibili.com</b>, чтобы получить эти файлы cookie.",
             "xhh": "<b>Рекомендуется:</b> используйте вход по QR-коду ниже или войдите на <b>xiaoheihe.cn</b> и введите cookies вручную.",
             "youtube": "<b>1. Получите Cookie</b><br>В браузере, где выполнен вход в YouTube:<br>1. Откройте <b>youtube.com</b><br>2. Нажмите F12 → Network<br>3. Обновите страницу и выберите запрос <code>youtubei/v1/browse</code><br>4. Скопируйте полное значение Cookie из Request Headers",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -3787,6 +3787,7 @@
         "bilibili": "Bilibili",
         "xhh": "小黑盒",
         "youtube": "YouTube",
+        "twitch": "Twitch",
         "douyin": "抖音",
         "kuaishou": "快手",
         "weibo": "微博",
@@ -3812,7 +3813,15 @@
         "noCookies": "请先配置 Cookies",
         "statusLoadFailed": "状态加载失败",
         "thisPlatform": "此平台",
+        "twitchAuth": {
+            "clientId": "Twitch Developer Client ID", "clientIdDesc": "在 Twitch Developer Console 创建公开应用并填写 Client ID；不会要求或保存 Client Secret。",
+            "start": "开始 Twitch 授权", "authorizeHint": "打开 Twitch 激活页面并输入以下代码：", "check": "我已授权，检查状态",
+            "invalidClientId": "请输入有效的 Twitch Client ID", "started": "Twitch 授权已启动，请在浏览器完成确认",
+            "startFailed": "无法启动 Twitch 授权，请检查 Client ID 和网络", "authorized": "Twitch 凭证已加密保存",
+            "pending": "授权尚未完成，请在 Twitch 页面确认后重试", "checkFailed": "授权检查失败，请重新开始授权"
+        },
         "instructions": {
+            "twitch": "<b>Device Code 授权：</b>在 Twitch Developer Console 创建公开应用，填入 Client ID 后按提示完成授权。",
             "bilibili": "<b>目标：</b>请前往 <b>bilibili.com</b>获取这些 Cookies。",
             "xhh": "<b>推荐：</b>点击下方扫码登录；也可前往 <b>xiaoheihe.cn</b> 登录后手动填写 Cookies。",
             "youtube": "<b>1. 获取 Cookie</b><br>在已登录 YouTube 的浏览器中：<br>1. 打开 <b>youtube.com</b><br>2. 按 F12 → Network<br>3. 刷新页面，选择一个 <code>youtubei/v1/browse</code> 请求<br>4. 在 Request Headers 中复制完整的 Cookie 值",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -3787,6 +3787,7 @@
         "bilibili": "嗶哩嗶哩",
         "xhh": "小黑盒",
         "youtube": "YouTube",
+        "twitch": "Twitch",
         "douyin": "抖音",
         "kuaishou": "快手",
         "weibo": "微博",
@@ -3812,7 +3813,15 @@
         "noCookies": "請先配置 Cookies",
         "statusLoadFailed": "狀態載入失敗",
         "thisPlatform": "該平台",
+        "twitchAuth": {
+            "clientId": "Twitch Developer Client ID", "clientIdDesc": "在 Twitch Developer Console 建立公開應用程式並填入 Client ID；不會要求或保存 Client Secret。",
+            "start": "開始 Twitch 授權", "authorizeHint": "開啟 Twitch 啟用頁面並輸入以下代碼：", "check": "我已授權，檢查狀態",
+            "invalidClientId": "請輸入有效的 Twitch Client ID", "started": "Twitch 授權已啟動，請在瀏覽器完成確認",
+            "startFailed": "無法啟動 Twitch 授權，請檢查 Client ID 與網路", "authorized": "Twitch 憑證已加密保存",
+            "pending": "授權尚未完成，請在 Twitch 頁面確認後重試", "checkFailed": "授權檢查失敗，請重新開始授權"
+        },
         "instructions": {
+            "twitch": "<b>Device Code 授權：</b>在 Twitch Developer Console 建立公開應用程式，填入 Client ID 後依提示完成授權。",
             "bilibili": "<b>目標：</b> 請前往 <b>bilibili.com</b> 獲取這些 Cookies。",
             "xhh": "<b>建議：</b>點擊下方掃碼登入；也可前往 <b>xiaoheihe.cn</b> 登入後手動填寫 Cookies。",
             "youtube": "<b>1. 取得 Cookie</b><br>在已登入 YouTube 的瀏覽器中：<br>1. 開啟 <b>youtube.com</b><br>2. 按 F12 → Network<br>3. 重新整理頁面，選擇一個 <code>youtubei/v1/browse</code> 請求<br>4. 在 Request Headers 中複製完整的 Cookie 值",

--- a/templates/cookies_login.html
+++ b/templates/cookies_login.html
@@ -512,6 +512,7 @@
             <button class="tab-btn" onclick="switchTab('bilibili', this)" data-i18n="cookiesLogin.bilibili">Bilibili</button>
             <button class="tab-btn" onclick="switchTab('xhh', this)" data-i18n="cookiesLogin.xhh">小黑盒</button>
             <button class="tab-btn" onclick="switchTab('youtube', this)" data-i18n="cookiesLogin.youtube">YouTube</button>
+            <button class="tab-btn" onclick="switchTab('twitch', this)" data-i18n="cookiesLogin.twitch">Twitch</button>
             <button class="tab-btn" onclick="switchTab('douyin', this)" data-i18n="cookiesLogin.douyin">抖音</button>
             <button class="tab-btn" onclick="switchTab('kuaishou', this)" data-i18n="cookiesLogin.kuaishou">快手</button>
             <button class="tab-btn" onclick="switchTab('weibo', this)" data-i18n="cookiesLogin.weibo">微博</button>

--- a/tests/unit/test_twitch_feed.py
+++ b/tests/unit/test_twitch_feed.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from utils import twitch_auth
+from utils.web_scraper import trending_content, twitch_feed
+
+
+@pytest.mark.asyncio
+async def test_twitch_categories_use_encrypted_credential_and_public_projection(monkeypatch):
+    captured = {}
+
+    class _Response:
+        status_code = 200
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"data": [{"id": "123", "name": "Just Chatting"}]}
+
+    class _Client:
+        async def get(self, url, **kwargs):
+            captured["url"] = url
+            captured.update(kwargs)
+            return _Response()
+
+    async def _credential(*, force_refresh=False):
+        assert force_refresh is False
+        return "clientid123", "secret-token"
+
+    monkeypatch.setattr(twitch_feed._auth_service, "access_token", _credential)
+    monkeypatch.setattr(twitch_feed, "get_external_http_client", lambda: _Client())
+
+    result = await twitch_feed.fetch_twitch_top_categories(limit=5)
+
+    assert result == {
+        "success": True,
+        "source": "twitch",
+        "videos": [{
+            "title": "Just Chatting",
+            "author": "Twitch",
+            "url": "https://www.twitch.tv/directory/category/Just%20Chatting",
+            "source": "Twitch",
+            "category_id": "123",
+        }],
+    }
+    assert captured["params"] == {"first": 5}
+    assert captured["headers"]["Client-ID"] == "clientid123"
+    assert captured["headers"]["Authorization"] == "Bearer secret-token"
+    assert "secret-token" not in str(result)
+
+
+@pytest.mark.asyncio
+async def test_twitch_device_exchange_sends_scopes_and_saves_only_after_validation(monkeypatch):
+    requests = []
+
+    async def _request(method, url, *, headers=None, data=None):
+        requests.append((method, url, headers, data))
+        if url.endswith("/device"):
+            return 200, {
+                "device_code": "device-code", "user_code": "ABCD-EFGH",
+                "verification_uri": "https://www.twitch.tv/activate", "expires_in": 900, "interval": 5,
+            }
+        if url.endswith("/token"):
+            return 200, {"access_token": "access-secret", "refresh_token": "refresh-secret"}
+        return 200, {
+            "client_id": "clientid123", "user_id": "42", "login": "neko_user",
+            "scopes": ["user:read:chat"], "expires_in": 3600,
+        }
+
+    saved = []
+    async def _save(credential):
+        saved.append(credential)
+        return True
+
+    monkeypatch.setattr(twitch_auth, "_request", _request)
+    monkeypatch.setattr(twitch_auth, "_save", _save)
+    service = twitch_auth.TwitchAuthService()
+
+    started = await service.start("clientid123")
+    checked = await service.check_device_code("clientid123")
+
+    assert started["user_code"] == "ABCD-EFGH"
+    assert checked["logged_in"] is True
+    device_request = next(data for _, url, _, data in requests if url.endswith("/device"))
+    token_request = next(data for _, url, _, data in requests if url.endswith("/token"))
+    assert device_request["scopes"] == "user:read:chat"
+    assert token_request["scopes"] == "user:read:chat"
+    assert saved and saved[0]["access_token"] == "access-secret"
+    assert "access-secret" not in str(checked)
+
+
+def test_twitch_media_credential_ui_is_localized_in_every_locale():
+    for locale_path in Path("static/locales").glob("*.json"):
+        payload = json.loads(locale_path.read_text(encoding="utf-8"))
+        section = payload["cookiesLogin"]
+        assert section["twitch"]
+        assert section["instructions"]["twitch"]
+        assert section["twitchAuth"]["start"]
+
+
+@pytest.mark.asyncio
+async def test_non_china_video_source_prefers_twitch_and_skips_youtube(monkeypatch):
+    async def _twitch(limit):
+        return {"success": True, "source": "twitch", "videos": [{"title": f"Category {limit}"}]}
+
+    async def _youtube(_limit):
+        pytest.fail("Twitch success must not fetch the YouTube fallback")
+
+    monkeypatch.setattr(trending_content, "is_china_region", lambda: False)
+    monkeypatch.setattr(trending_content, "fetch_twitch_top_categories", _twitch)
+    monkeypatch.setattr(trending_content, "fetch_youtube_home_feed", _youtube)
+
+    result = await trending_content.fetch_video_content(limit=7)
+
+    assert result == {
+        "success": True,
+        "region": "non-china",
+        "video": {"success": True, "source": "twitch", "videos": [{"title": "Category 7"}]},
+    }
+    assert "[Twitch live categories]" in trending_content.format_video_content(result)
+
+
+@pytest.mark.asyncio
+async def test_non_china_video_source_falls_back_to_youtube_when_twitch_is_unavailable(monkeypatch):
+    async def _twitch(_limit):
+        return {"success": False, "source": "twitch", "videos": [], "error": "not configured"}
+
+    async def _youtube(limit):
+        return {"success": True, "source": "youtube", "videos": [{"title": f"Video {limit}"}]}
+
+    monkeypatch.setattr(trending_content, "is_china_region", lambda: False)
+    monkeypatch.setattr(trending_content, "fetch_twitch_top_categories", _twitch)
+    monkeypatch.setattr(trending_content, "fetch_youtube_home_feed", _youtube)
+
+    result = await trending_content.fetch_video_content(limit=3)
+
+    assert result["success"] is True
+    assert result["video"]["source"] == "youtube"
+    assert result["video"]["videos"][0]["title"] == "Video 3"

--- a/tests/unit/test_twitch_feed.py
+++ b/tests/unit/test_twitch_feed.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from utils import twitch_auth
+from utils import cookies_login, twitch_auth
 from utils.web_scraper import trending_content, twitch_feed
 
 
@@ -63,6 +63,44 @@ async def test_twitch_live_streams_use_encrypted_credential_and_public_projectio
 
 
 @pytest.mark.asyncio
+async def test_twitch_live_streams_report_reauthorization_when_401_refresh_fails(monkeypatch):
+    credential_calls = []
+    request_count = 0
+
+    class _Response:
+        status_code = 401
+
+        def raise_for_status(self):
+            raise AssertionError("401 response should not reach raise_for_status")
+
+    class _Client:
+        async def get(self, _url, **_kwargs):
+            nonlocal request_count
+            request_count += 1
+            return _Response()
+
+    async def _credential(*, force_refresh=False):
+        credential_calls.append(force_refresh)
+        if force_refresh:
+            return "", "", ""
+        return "clientid123", "expired-token", "42"
+
+    monkeypatch.setattr(twitch_feed._auth_service, "followed_stream_access", _credential)
+    monkeypatch.setattr(twitch_feed, "get_external_http_client", lambda: _Client())
+
+    result = await twitch_feed.fetch_twitch_live_streams(limit=5)
+
+    assert result == {
+        "success": False,
+        "source": "twitch",
+        "videos": [],
+        "error": "Twitch followed-stream access requires reauthorization",
+    }
+    assert credential_calls == [False, True]
+    assert request_count == 1
+
+
+@pytest.mark.asyncio
 async def test_twitch_device_exchange_sends_scopes_and_saves_only_after_validation(monkeypatch):
     requests = []
 
@@ -71,7 +109,8 @@ async def test_twitch_device_exchange_sends_scopes_and_saves_only_after_validati
         if url.endswith("/device"):
             return 200, {
                 "device_code": "device-code", "user_code": "ABCD-EFGH",
-                "verification_uri": "https://www.twitch.tv/activate", "expires_in": 900, "interval": 5,
+                "verification_uri": "https://www.twitch.tv/activate?public=true&device-code=ABCD-EFGH",
+                "expires_in": 900, "interval": 5,
             }
         if url.endswith("/token"):
             return 200, {"access_token": "access-secret", "refresh_token": "refresh-secret"}
@@ -125,6 +164,34 @@ async def test_twitch_status_reports_saved_follow_credential(monkeypatch):
     assert "access-secret" not in str(result)
 
 
+def test_twitch_oauth_response_validation_handles_expiry_and_strict_activation_url():
+    assert twitch_auth._oauth_error({"message": "The device code has expired."}) == "expired_token"
+    assert twitch_auth._verification_uri("https://www.twitch.tv/activate") == "https://www.twitch.tv/activate"
+    documented_uri = "https://www.twitch.tv/activate?public=true&device-code=ABCD-EFGH"
+    assert twitch_auth._verification_uri(documented_uri, "ABCD-EFGH") == documented_uri
+    assert twitch_auth._verification_uri("https://www.twitch.tv/activate?state=injected", "ABCD-EFGH") == ""
+
+
+def test_twitch_save_never_logs_masked_bearer_material(tmp_path, monkeypatch):
+    credential_file = tmp_path / "twitch_credentials.json"
+    messages = []
+    monkeypatch.setattr(cookies_login, "CONFIG_DIR", tmp_path)
+    monkeypatch.setitem(cookies_login.COOKIE_FILES, "twitch", credential_file)
+    monkeypatch.setattr(cookies_login.logger, "info", lambda message: messages.append(str(message)))
+
+    assert cookies_login.save_cookies_to_file("twitch", {
+        "access_token": "access-secret-value",
+        "refresh_token": "refresh-secret-value",
+        "client_id": "clientid123",
+    }) is True
+
+    rendered = "\n".join(messages)
+    assert "access_token" not in rendered
+    assert "refresh_token" not in rendered
+    assert "acce...alue" not in rendered
+    assert "refr...alue" not in rendered
+
+
 def test_twitch_media_credential_ui_is_localized_in_every_locale():
     for locale_path in Path("static/locales").glob("*.json"):
         payload = json.loads(locale_path.read_text(encoding="utf-8"))
@@ -132,6 +199,22 @@ def test_twitch_media_credential_ui_is_localized_in_every_locale():
         assert section["twitch"]
         assert section["instructions"]["twitch"]
         assert section["twitchAuth"]["start"]
+
+
+def test_twitch_device_ui_polls_and_preserves_active_authorization_card():
+    source = Path("static/js/cookies_login.js").read_text(encoding="utf-8")
+
+    assert "startTwitchDevicePoll(result.interval)" in source
+    assert "if (twitchDevicePollInFlight) return 'in_flight'" in source
+    assert "freshTwitchResult.replaceWith(existingTwitchResult)" in source
+    assert "document.addEventListener('visibilitychange'" in source
+
+
+def test_cookie_save_rejects_non_manual_platforms_from_login_manager_metadata():
+    source = Path("main_routers/cookies_login_router.py").read_text(encoding="utf-8")
+
+    assert 'if "manual" not in platform_info.get("methods", [])' in source
+    assert 'if data.platform == "twitch"' not in source
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_twitch_feed.py
+++ b/tests/unit/test_twitch_feed.py
@@ -10,7 +10,7 @@ from utils.web_scraper import trending_content, twitch_feed
 
 
 @pytest.mark.asyncio
-async def test_twitch_categories_use_encrypted_credential_and_public_projection(monkeypatch):
+async def test_twitch_live_streams_use_encrypted_credential_and_public_projection(monkeypatch):
     captured = {}
 
     class _Response:
@@ -20,7 +20,10 @@ async def test_twitch_categories_use_encrypted_credential_and_public_projection(
             return None
 
         def json(self):
-            return {"data": [{"id": "123", "name": "Just Chatting"}]}
+            return {"data": [{
+                "id": "stream-123", "user_login": "streamer", "user_name": "Streamer", "title": "Ranked matches",
+                "game_name": "VALORANT", "viewer_count": 1234,
+            }]}
 
     class _Client:
         async def get(self, url, **kwargs):
@@ -30,28 +33,33 @@ async def test_twitch_categories_use_encrypted_credential_and_public_projection(
 
     async def _credential(*, force_refresh=False):
         assert force_refresh is False
-        return "clientid123", "secret-token"
+        return "clientid123", "secret-token", "42"
 
-    monkeypatch.setattr(twitch_feed._auth_service, "access_token", _credential)
+    monkeypatch.setattr(twitch_feed._auth_service, "followed_stream_access", _credential)
     monkeypatch.setattr(twitch_feed, "get_external_http_client", lambda: _Client())
 
-    result = await twitch_feed.fetch_twitch_top_categories(limit=5)
+    result = await twitch_feed.fetch_twitch_live_streams(limit=5)
 
     assert result == {
         "success": True,
         "source": "twitch",
         "videos": [{
-            "title": "Just Chatting",
-            "author": "Twitch",
-            "url": "https://www.twitch.tv/directory/category/Just%20Chatting",
+            "stream_id": "stream-123",
+            "title": "Ranked matches",
+            "author": "Streamer",
+            "url": "https://www.twitch.tv/streamer",
             "source": "Twitch",
-            "category_id": "123",
+            "game_name": "VALORANT",
+            "viewer_count": "1234",
         }],
     }
-    assert captured["params"] == {"first": 5}
+    assert captured["params"] == {"user_id": "42", "first": 5}
     assert captured["headers"]["Client-ID"] == "clientid123"
     assert captured["headers"]["Authorization"] == "Bearer secret-token"
     assert "secret-token" not in str(result)
+
+    repeated = await twitch_feed.fetch_twitch_live_streams(limit=5)
+    assert repeated == result
 
 
 @pytest.mark.asyncio
@@ -69,7 +77,7 @@ async def test_twitch_device_exchange_sends_scopes_and_saves_only_after_validati
             return 200, {"access_token": "access-secret", "refresh_token": "refresh-secret"}
         return 200, {
             "client_id": "clientid123", "user_id": "42", "login": "neko_user",
-            "scopes": ["user:read:chat"], "expires_in": 3600,
+            "scopes": ["user:read:follows"], "expires_in": 3600,
         }
 
     saved = []
@@ -88,10 +96,33 @@ async def test_twitch_device_exchange_sends_scopes_and_saves_only_after_validati
     assert checked["logged_in"] is True
     device_request = next(data for _, url, _, data in requests if url.endswith("/device"))
     token_request = next(data for _, url, _, data in requests if url.endswith("/token"))
-    assert device_request["scopes"] == "user:read:chat"
-    assert token_request["scopes"] == "user:read:chat"
+    assert device_request["scopes"] == "user:read:follows"
+    assert token_request["scopes"] == "user:read:follows"
     assert saved and saved[0]["access_token"] == "access-secret"
     assert "access-secret" not in str(checked)
+
+
+@pytest.mark.asyncio
+async def test_twitch_status_reports_saved_follow_credential(monkeypatch):
+    async def _load():
+        return {
+            "client_id": "clientid123",
+            "access_token": "access-secret",
+            "refresh_token": "refresh-secret",
+            "user_id": "42",
+            "login": "neko_user",
+            "scopes": "user:read:follows",
+            "expires_at": "2000000000",
+        }
+
+    monkeypatch.setattr(twitch_auth, "_load", _load)
+
+    result = await twitch_auth.TwitchAuthService().status()
+
+    assert result["logged_in"] is True
+    assert result["has_cookies"] is True
+    assert result["login"] == "neko_user"
+    assert "access-secret" not in str(result)
 
 
 def test_twitch_media_credential_ui_is_localized_in_every_locale():
@@ -104,25 +135,33 @@ def test_twitch_media_credential_ui_is_localized_in_every_locale():
 
 
 @pytest.mark.asyncio
-async def test_non_china_video_source_prefers_twitch_and_skips_youtube(monkeypatch):
+async def test_non_china_video_source_combines_twitch_and_youtube(monkeypatch):
     async def _twitch(limit):
-        return {"success": True, "source": "twitch", "videos": [{"title": f"Category {limit}"}]}
+        return {"success": True, "source": "twitch", "videos": [
+            {"title": f"Live {limit}-1", "author": "Streamer"},
+            {"title": f"Live {limit}-2", "author": "Streamer"},
+        ]}
 
-    async def _youtube(_limit):
-        pytest.fail("Twitch success must not fetch the YouTube fallback")
+    async def _youtube(limit):
+        return {"success": True, "source": "youtube", "videos": [
+            {"title": f"Video {limit}-1"},
+            {"title": f"Video {limit}-2"},
+        ]}
 
     monkeypatch.setattr(trending_content, "is_china_region", lambda: False)
-    monkeypatch.setattr(trending_content, "fetch_twitch_top_categories", _twitch)
+    monkeypatch.setattr(trending_content, "fetch_twitch_live_streams", _twitch)
     monkeypatch.setattr(trending_content, "fetch_youtube_home_feed", _youtube)
 
     result = await trending_content.fetch_video_content(limit=7)
 
-    assert result == {
-        "success": True,
-        "region": "non-china",
-        "video": {"success": True, "source": "twitch", "videos": [{"title": "Category 7"}]},
-    }
-    assert "[Twitch live categories]" in trending_content.format_video_content(result)
+    assert result["success"] is True
+    assert result["video"]["source"] == "mixed"
+    assert [item["title"] for item in result["video"]["videos"]] == [
+        "Live 7-1", "Video 7-1", "Live 7-2", "Video 7-2",
+    ]
+    formatted = trending_content.format_video_content(result)
+    assert "[Followed Twitch live streams]" in formatted
+    assert "【YouTube 推荐】" in formatted
 
 
 @pytest.mark.asyncio
@@ -134,11 +173,11 @@ async def test_non_china_video_source_falls_back_to_youtube_when_twitch_is_unava
         return {"success": True, "source": "youtube", "videos": [{"title": f"Video {limit}"}]}
 
     monkeypatch.setattr(trending_content, "is_china_region", lambda: False)
-    monkeypatch.setattr(trending_content, "fetch_twitch_top_categories", _twitch)
+    monkeypatch.setattr(trending_content, "fetch_twitch_live_streams", _twitch)
     monkeypatch.setattr(trending_content, "fetch_youtube_home_feed", _youtube)
 
     result = await trending_content.fetch_video_content(limit=3)
 
     assert result["success"] is True
-    assert result["video"]["source"] == "youtube"
-    assert result["video"]["videos"][0]["title"] == "Video 3"
+    assert result["video"]["source"] == "mixed"
+    assert result["youtube"]["videos"][0]["title"] == "Video 3"

--- a/tests/unit/test_youtube_feed.py
+++ b/tests/unit/test_youtube_feed.py
@@ -482,18 +482,22 @@ async def test_fetch_youtube_home_feed_formats_empty_timeout_error(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_video_region_route_uses_youtube_outside_china(monkeypatch):
+async def test_video_region_route_combines_youtube_with_twitch_outside_china(monkeypatch):
     async def fake_youtube(limit):
         return {"success": True, "source": "youtube", "videos": [{"title": str(limit)}]}
 
+    async def fake_twitch(limit):
+        return {"success": True, "source": "twitch", "videos": [{"title": f"live-{limit}"}]}
+
     monkeypatch.setattr(trending_content, "is_china_region", lambda: False)
+    monkeypatch.setattr(trending_content, "fetch_twitch_live_streams", fake_twitch)
     monkeypatch.setattr(trending_content, "fetch_youtube_home_feed", fake_youtube)
 
     result = await trending_content.fetch_video_content(limit=7)
 
     assert result["region"] == "non-china"
-    assert result["video"]["source"] == "youtube"
-    assert result["video"]["videos"][0]["title"] == "7"
+    assert result["video"]["source"] == "mixed"
+    assert [item["title"] for item in result["video"]["videos"]] == ["live-7", "7"]
 
 
 @pytest.mark.asyncio
@@ -501,7 +505,11 @@ async def test_video_region_route_always_propagates_failure_error(monkeypatch):
     async def fake_youtube(_limit):
         return {"success": False, "source": "youtube", "videos": []}
 
+    async def fake_twitch(_limit):
+        return {"success": False, "source": "twitch", "videos": []}
+
     monkeypatch.setattr(trending_content, "is_china_region", lambda: False)
+    monkeypatch.setattr(trending_content, "fetch_twitch_live_streams", fake_twitch)
     monkeypatch.setattr(trending_content, "fetch_youtube_home_feed", fake_youtube)
 
     result = await trending_content.fetch_video_content(limit=7)

--- a/tests/unit/test_youtube_feed.py
+++ b/tests/unit/test_youtube_feed.py
@@ -515,7 +515,7 @@ async def test_video_region_route_always_propagates_failure_error(monkeypatch):
     result = await trending_content.fetch_video_content(limit=7)
 
     assert result["success"] is False
-    assert result["error"] == "youtube 获取失败（无错误详情）"
+    assert result["error"] == "Twitch 与 YouTube 获取失败（无错误详情）"
 
 
 def test_youtube_video_format_and_source_links():

--- a/utils/cookies_login.py
+++ b/utils/cookies_login.py
@@ -178,9 +178,12 @@ def save_cookies_to_file(platform: str, cookies: Dict[str, Any], encrypt: bool =
             
             logger.info(f"✅ 已明文保存 {platform} 凭证到: {cookie_file}")
         
-        logger.info(f"🔐 【{platform.capitalize()} 凭证摘要】:")
-        for k, v in list(cookies.items())[:3]: # 仅展示前三个键
-            logger.info(f"   - {k}: {mask_string(v)}")
+        # OAuth bearer material must never enter logs, even in partially masked
+        # form. Cookie-based platforms retain the existing diagnostic summary.
+        if platform != 'twitch':
+            logger.info(f"🔐 【{platform.capitalize()} 凭证摘要】:")
+            for k, v in list(cookies.items())[:3]: # 仅展示前三个键
+                logger.info(f"   - {k}: {mask_string(v)}")
         return True
         
     except Exception as e:

--- a/utils/cookies_login.py
+++ b/utils/cookies_login.py
@@ -51,7 +51,10 @@ COOKIE_FILES = {
     'weibo': CONFIG_DIR / 'weibo_cookies.json',
     'reddit': CONFIG_DIR / 'reddit_cookies.json',
     'twitter': CONFIG_DIR / 'twitter_cookies.json',
-    'youtube': CONFIG_DIR / 'youtube_cookies.json'
+    'youtube': CONFIG_DIR / 'youtube_cookies.json',
+    # Twitch stores OAuth credentials here, not browser cookies.  Reuse the
+    # existing encrypted, permission-restricted credential store.
+    'twitch': CONFIG_DIR / 'twitch_credentials.json',
 }
 
 class LoginStatus:
@@ -75,6 +78,13 @@ def validate_cookies(platform: str, cookies: Dict[str, str]) -> bool:
     if platform == 'youtube':
         if not cookies.get('SAPISID'):
             logger.warning("⚠️ 安全拦截：YouTube Cookie 缺少 SAPISID！")
+            return False
+        return True
+
+    if platform == 'twitch':
+        required = ('access_token', 'refresh_token', 'client_id')
+        if not all(cookies.get(key) for key in required):
+            logger.warning("⚠️ 安全拦截：Twitch OAuth 凭证缺少必要字段！")
             return False
         return True
 
@@ -407,7 +417,8 @@ class PlatformLoginManager:
             'weibo': {'name': '微博', 'methods': ['manual'], 'func': get_weibo_cookies},
             'reddit': {'name': 'Reddit', 'methods': ['manual'], 'func': get_reddit_cookies},
             'twitter': {'name': 'Twitter/X', 'methods': ['manual'], 'func': get_twitter_cookies},
-            'youtube': {'name': 'YouTube', 'methods': ['manual'], 'func': get_youtube_cookies}
+            'youtube': {'name': 'YouTube', 'methods': ['manual'], 'func': get_youtube_cookies},
+            'twitch': {'name': 'Twitch', 'methods': ['device_code'], 'func': lambda _method: None},
         }
     
     def login_platform(self, platform: str, method: str) -> Optional[Dict[str, str]]:

--- a/utils/twitch_auth.py
+++ b/utils/twitch_auth.py
@@ -12,7 +12,7 @@ import re
 import time
 from dataclasses import dataclass
 from typing import Any
-from urllib.parse import urlsplit
+from urllib.parse import parse_qs, urlsplit
 
 from utils.cookies_login import load_cookies_from_file, save_cookies_to_file
 from utils.external_http_client import get_external_http_client
@@ -50,7 +50,7 @@ class TwitchAuthService:
         })
         device_code = _text(data.get("device_code"), 512)
         user_code = _text(data.get("user_code"), 64)
-        verification_uri = _verification_uri(data.get("verification_uri"))
+        verification_uri = _verification_uri(data.get("verification_uri"), user_code)
         expires_in = _positive_int(data.get("expires_in"), 0, 3600)
         interval = _positive_int(data.get("interval"), 5, 60)
         if status != 200 or not all((device_code, user_code, verification_uri, expires_in)):
@@ -242,17 +242,33 @@ def _positive_int(value: Any, default: int, maximum: int) -> int:
     return number if 0 < number <= maximum else default
 
 
-def _verification_uri(value: Any) -> str:
+def _verification_uri(value: Any, user_code: str = "") -> str:
     value = _text(value, 200)
     try:
         parsed = urlsplit(value)
     except ValueError:
         return ""
-    if parsed.scheme != "https" or parsed.hostname not in {"twitch.tv", "www.twitch.tv"} or parsed.path != "/activate" or parsed.username or parsed.password or parsed.fragment:
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname not in {"twitch.tv", "www.twitch.tv"}
+        or parsed.path != "/activate"
+        or parsed.username
+        or parsed.password
+        or parsed.fragment
+    ):
         return ""
+    if parsed.query:
+        try:
+            query = parse_qs(parsed.query, strict_parsing=True)
+        except ValueError:
+            return ""
+        if query != {"public": ["true"], "device-code": [user_code]}:
+            return ""
     return value
 
 
 def _oauth_error(data: Any) -> str:
     value = _text(data.get("message"), 80).lower() if isinstance(data, dict) else ""
-    return value if value in {"authorization_pending", "slow_down", "expired_token"} else ""
+    if value in {"authorization_pending", "slow_down", "expired_token"}:
+        return value
+    return "expired_token" if "expired" in value else ""

--- a/utils/twitch_auth.py
+++ b/utils/twitch_auth.py
@@ -21,7 +21,7 @@ from utils.external_http_client import get_external_http_client
 _DEVICE_URL = "https://id.twitch.tv/oauth2/device"
 _TOKEN_URL = "https://id.twitch.tv/oauth2/token"
 _VALIDATE_URL = "https://id.twitch.tv/oauth2/validate"
-_SCOPES = ("user:read:chat",)
+_SCOPES = ("user:read:follows",)
 _CLIENT_ID_RE = re.compile(r"^[A-Za-z0-9]{8,80}$")
 
 
@@ -101,8 +101,11 @@ class TwitchAuthService:
 
     async def status(self) -> dict[str, Any]:
         credential = await _load()
-        if not _credential_present(credential):
-            return {"success": True, "platform": "twitch", "logged_in": False, "has_cookies": False}
+        if not _credential_present(credential) or not set(_SCOPES).issubset(_scopes(credential.get("scopes") if credential else "")):
+            return {
+                "success": True, "platform": "twitch", "logged_in": False, "has_cookies": False,
+                "requires_reauthorization": bool(credential),
+            }
         return _public_status(credential, refreshed=False)
 
     async def access_token(self, *, force_refresh: bool = False) -> tuple[str, str]:
@@ -129,6 +132,15 @@ class TwitchAuthService:
         if refreshed is None or not await _save(refreshed):
             return "", ""
         return client_id, _secret(refreshed, "access_token")
+
+    async def followed_stream_access(self, *, force_refresh: bool = False) -> tuple[str, str, str]:
+        """Return the credential context required by ``/streams/followed``."""
+        credential = await _load()
+        if not set(_SCOPES).issubset(_scopes(credential.get("scopes") if credential else "")):
+            return "", "", ""
+        user_id = _text(credential.get("user_id") if credential else "", 64)
+        client_id, access_token = await self.access_token(force_refresh=force_refresh)
+        return (client_id, access_token, user_id) if client_id and access_token and user_id else ("", "", "")
 
 
 async def _request(method: str, url: str, *, headers: dict[str, str] | None = None, data: dict[str, str] | None = None) -> tuple[int, dict[str, Any]]:
@@ -179,6 +191,17 @@ def _public_status(credential: dict[str, str], *, refreshed: bool) -> dict[str, 
         "login": _login(credential.get("login")), "user_id": _text(credential.get("user_id"), 64),
         "expires_at": _text(credential.get("expires_at"), 24), "refreshed": refreshed,
     }
+
+
+def _credential_present(data: Any) -> bool:
+    """Return whether the encrypted store contains a complete OAuth credential."""
+    return (
+        isinstance(data, dict)
+        and bool(_client_id(data.get("client_id")))
+        and bool(_secret(data, "access_token"))
+        and bool(_secret(data, "refresh_token"))
+        and bool(_text(data.get("user_id"), 64))
+    )
 
 
 def _error(code: str) -> dict[str, Any]:

--- a/utils/twitch_auth.py
+++ b/utils/twitch_auth.py
@@ -1,0 +1,235 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Twitch Device Code authentication backed by the local encrypted store."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import time
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlsplit
+
+from utils.cookies_login import load_cookies_from_file, save_cookies_to_file
+from utils.external_http_client import get_external_http_client
+
+
+_DEVICE_URL = "https://id.twitch.tv/oauth2/device"
+_TOKEN_URL = "https://id.twitch.tv/oauth2/token"
+_VALIDATE_URL = "https://id.twitch.tv/oauth2/validate"
+_SCOPES = ("user:read:chat",)
+_CLIENT_ID_RE = re.compile(r"^[A-Za-z0-9]{8,80}$")
+
+
+@dataclass(slots=True)
+class _DeviceSession:
+    client_id: str
+    device_code: str
+    expires_at: float
+    interval: int
+
+
+class TwitchAuthService:
+    """Own the short-lived device code and persist only validated credentials."""
+
+    def __init__(self) -> None:
+        self._device_session: _DeviceSession | None = None
+
+    async def start(self, client_id: Any) -> dict[str, Any]:
+        client_id = _client_id(client_id)
+        if not client_id:
+            self._device_session = None
+            return _error("invalid_client_id")
+        status, data = await _request("POST", _DEVICE_URL, data={
+            "client_id": client_id,
+            "scopes": " ".join(_SCOPES),
+        })
+        device_code = _text(data.get("device_code"), 512)
+        user_code = _text(data.get("user_code"), 64)
+        verification_uri = _verification_uri(data.get("verification_uri"))
+        expires_in = _positive_int(data.get("expires_in"), 0, 3600)
+        interval = _positive_int(data.get("interval"), 5, 60)
+        if status != 200 or not all((device_code, user_code, verification_uri, expires_in)):
+            self._device_session = None
+            return _error("device_authorization_failed")
+        self._device_session = _DeviceSession(
+            client_id=client_id,
+            device_code=device_code,
+            expires_at=time.time() + expires_in,
+            interval=interval,
+        )
+        return {
+            "success": True,
+            "platform": "twitch",
+            "pending": True,
+            "user_code": user_code,
+            "verification_uri": verification_uri,
+            "expires_in": expires_in,
+            "interval": interval,
+        }
+
+    async def check_device_code(self, client_id: Any) -> dict[str, Any]:
+        session = self._device_session
+        if session is None or _client_id(client_id) != session.client_id:
+            return _error("device_authorization_not_active")
+        if time.time() >= session.expires_at:
+            self._device_session = None
+            return _error("device_authorization_expired")
+        status, data = await _request("POST", _TOKEN_URL, data={
+            "client_id": session.client_id,
+            "scopes": " ".join(_SCOPES),
+            "device_code": session.device_code,
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+        })
+        if status != 200:
+            message = _oauth_error(data)
+            if message in {"authorization_pending", "slow_down"}:
+                return {"success": True, "platform": "twitch", "pending": True, "interval": session.interval}
+            if message == "expired_token":
+                self._device_session = None
+            return _error("device_authorization_failed")
+        credential = await _validated_credential(session.client_id, data)
+        if credential is None or not await _save(credential):
+            self._device_session = None
+            return _error("credential_save_failed")
+        self._device_session = None
+        return _public_status(credential, refreshed=False)
+
+    async def status(self) -> dict[str, Any]:
+        credential = await _load()
+        if not _credential_present(credential):
+            return {"success": True, "platform": "twitch", "logged_in": False, "has_cookies": False}
+        return _public_status(credential, refreshed=False)
+
+    async def access_token(self, *, force_refresh: bool = False) -> tuple[str, str]:
+        """Return a valid ``(client_id, access_token)`` pair, refreshing when needed."""
+        credential = await _load()
+        client_id = _client_id(credential.get("client_id") if credential else "")
+        access_token = _secret(credential, "access_token")
+        if not client_id or not access_token:
+            return "", ""
+        expires_at = _positive_int(credential.get("expires_at"), 0, 2_147_483_647)
+        if not force_refresh and expires_at > int(time.time()) + 90:
+            return client_id, access_token
+        refresh_token = _secret(credential, "refresh_token")
+        if not refresh_token:
+            return "", ""
+        status, data = await _request("POST", _TOKEN_URL, data={
+            "client_id": client_id,
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+        })
+        if status != 200:
+            return "", ""
+        refreshed = await _validated_credential(client_id, data)
+        if refreshed is None or not await _save(refreshed):
+            return "", ""
+        return client_id, _secret(refreshed, "access_token")
+
+
+async def _request(method: str, url: str, *, headers: dict[str, str] | None = None, data: dict[str, str] | None = None) -> tuple[int, dict[str, Any]]:
+    try:
+        response = await get_external_http_client().request(method, url, headers=headers, data=data, timeout=15.0)
+        try:
+            payload = response.json()
+        except Exception:
+            payload = {}
+        return response.status_code, payload if isinstance(payload, dict) else {}
+    except Exception:
+        return 0, {}
+
+
+async def _validated_credential(client_id: str, token_data: dict[str, Any]) -> dict[str, str] | None:
+    access_token = _secret(token_data, "access_token")
+    refresh_token = _secret(token_data, "refresh_token")
+    if not access_token or not refresh_token:
+        return None
+    status, data = await _request("GET", _VALIDATE_URL, headers={"Authorization": f"OAuth {access_token}"})
+    login = _login(data.get("login"))
+    user_id = _text(data.get("user_id"), 64)
+    scopes = _scopes(data.get("scopes"))
+    if status != 200 or _client_id(data.get("client_id")) != client_id or not login or not user_id or not set(_SCOPES).issubset(scopes):
+        return None
+    return {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "client_id": client_id,
+        "user_id": user_id,
+        "login": login,
+        "scopes": " ".join(sorted(scopes)),
+        "expires_at": str(int(time.time()) + _positive_int(data.get("expires_in"), 0, 31_536_000)),
+    }
+
+
+async def _load() -> dict[str, str]:
+    return await asyncio.to_thread(load_cookies_from_file, "twitch")
+
+
+async def _save(credential: dict[str, str]) -> bool:
+    return await asyncio.to_thread(save_cookies_to_file, "twitch", credential, True)
+
+
+def _public_status(credential: dict[str, str], *, refreshed: bool) -> dict[str, Any]:
+    return {
+        "success": True, "platform": "twitch", "logged_in": True, "has_cookies": True,
+        "login": _login(credential.get("login")), "user_id": _text(credential.get("user_id"), 64),
+        "expires_at": _text(credential.get("expires_at"), 24), "refreshed": refreshed,
+    }
+
+
+def _error(code: str) -> dict[str, Any]:
+    return {"success": False, "platform": "twitch", "pending": False, "code": code}
+
+
+def _client_id(value: Any) -> str:
+    value = value.strip() if isinstance(value, str) else ""
+    return value if _CLIENT_ID_RE.fullmatch(value) else ""
+
+
+def _secret(data: Any, key: str) -> str:
+    value = data.get(key) if isinstance(data, dict) else ""
+    return value.strip()[:4096] if isinstance(value, str) else ""
+
+
+def _text(value: Any, limit: int) -> str:
+    return " ".join(value.split()).strip()[:limit] if isinstance(value, str) else ""
+
+
+def _login(value: Any) -> str:
+    value = _text(value, 25).lower()
+    return value if re.fullmatch(r"[a-z0-9_]{1,25}", value) else ""
+
+
+def _scopes(value: Any) -> set[str]:
+    items = value if isinstance(value, list) else value.split() if isinstance(value, str) else []
+    return {item.strip() for item in items if isinstance(item, str) and re.fullmatch(r"[a-z]+(?::[a-z]+)+", item.strip())}
+
+
+def _positive_int(value: Any, default: int, maximum: int) -> int:
+    if isinstance(value, bool):
+        return default
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return default
+    return number if 0 < number <= maximum else default
+
+
+def _verification_uri(value: Any) -> str:
+    value = _text(value, 200)
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return ""
+    if parsed.scheme != "https" or parsed.hostname not in {"twitch.tv", "www.twitch.tv"} or parsed.path != "/activate" or parsed.username or parsed.password or parsed.fragment:
+        return ""
+    return value
+
+
+def _oauth_error(data: Any) -> str:
+    value = _text(data.get("message"), 80).lower() if isinstance(data, dict) else ""
+    return value if value in {"authorization_pending", "slow_down", "expired_token"} else ""

--- a/utils/web_scraper/__init__.py
+++ b/utils/web_scraper/__init__.py
@@ -60,6 +60,7 @@ from .trending_content import (
     _fetch_weibo_trending_fallback,
     _format_bilibili_videos,
     _format_reddit_posts,
+    _format_twitch_categories,
     _format_youtube_videos,
     _format_score,
     _format_twitter_trending,
@@ -80,6 +81,7 @@ from .trending_content import (
     format_xhh_feed,
     normalize_xhh_feed,
 )
+from .twitch_feed import fetch_twitch_top_categories
 from .youtube_feed import fetch_youtube_home_feed
 from .window_context import (
     _SEARCH_TEXT_WS_RE,

--- a/utils/web_scraper/__init__.py
+++ b/utils/web_scraper/__init__.py
@@ -60,7 +60,7 @@ from .trending_content import (
     _fetch_weibo_trending_fallback,
     _format_bilibili_videos,
     _format_reddit_posts,
-    _format_twitch_categories,
+    _format_twitch_live_streams,
     _format_youtube_videos,
     _format_score,
     _format_twitter_trending,
@@ -81,7 +81,7 @@ from .trending_content import (
     format_xhh_feed,
     normalize_xhh_feed,
 )
-from .twitch_feed import fetch_twitch_top_categories
+from .twitch_feed import fetch_twitch_live_streams
 from .youtube_feed import fetch_youtube_home_feed
 from .window_context import (
     _SEARCH_TEXT_WS_RE,

--- a/utils/web_scraper/trending_content.py
+++ b/utils/web_scraper/trending_content.py
@@ -807,7 +807,7 @@ async def fetch_video_content(limit: int = 10) -> Dict[str, Any]:
     }
     if not success:
         errors = [str(item.get("error")) for item in (twitch_result, youtube_result) if item.get("error")]
-        response["error"] = "; ".join(errors) if errors else "youtube 获取失败（无错误详情）"
+        response["error"] = "; ".join(errors) if errors else "Twitch 与 YouTube 获取失败（无错误详情）"
     return response
 
 async def fetch_news_content(limit: int = 10) -> Dict[str, Any]:
@@ -1498,7 +1498,12 @@ def _format_youtube_videos(videos: List[Dict], limit: int = 5) -> List[str]:
 
 
 def _format_twitch_live_streams(streams: List[Dict], limit: int = 5) -> List[str]:
-    """Format followed Twitch live streams as lightweight conversation material."""
+    """Format followed Twitch live streams as lightweight conversation material.
+
+    The English header and viewer unit are intentional: this is structured LLM
+    context rather than user-interface copy. Keep them aligned with the fixture
+    in ``test_twitch_feed.py``.
+    """
     output_lines = ["[Followed Twitch live streams]"]
     for index, stream in enumerate(streams[:limit], 1):
         title = stream.get("title", "")

--- a/utils/web_scraper/trending_content.py
+++ b/utils/web_scraper/trending_content.py
@@ -39,6 +39,7 @@ from .platform_helpers import (
     build_xhh_request_params,
 )
 from .youtube_feed import fetch_youtube_home_feed
+from .twitch_feed import fetch_twitch_top_categories
 
 
 XHH_API_BASE = "https://api.xiaoheihe.cn"
@@ -756,7 +757,7 @@ async def fetch_video_content(limit: int = 10) -> Dict[str, Any]:
     Fetch video content based on the user's region
     
     Chinese region: Bilibili homepage videos
-    non-Chinese region: YouTube Home Feed
+    non-Chinese region: Twitch category discovery, with YouTube as a fallback
     
     Args:
         limit: maximum amount of content
@@ -764,14 +765,26 @@ async def fetch_video_content(limit: int = 10) -> Dict[str, Any]:
     Returns:
         Dict with success status and video content
     """
-    return await _fetch_content_by_region(
-        china_fetch_func=fetch_bilibili_trending,
-        non_china_fetch_func=fetch_youtube_home_feed,
-        limit=limit,
-        content_key='video',
-        china_log_msg="检测到中文区域，获取B站视频内容",
-        non_china_log_msg="检测到非中文区域，获取 YouTube 首页 Feed"
-    )
+    if is_china_region():
+        return await _fetch_content_by_region(
+            china_fetch_func=fetch_bilibili_trending,
+            non_china_fetch_func=fetch_youtube_home_feed,
+            limit=limit,
+            content_key='video',
+            china_log_msg="检测到中文区域，获取B站视频内容",
+            non_china_log_msg="检测到非中文区域，获取 YouTube 首页 Feed",
+        )
+
+    twitch_result = await fetch_twitch_top_categories(limit)
+    if twitch_result.get("success"):
+        return {"success": True, "region": "non-china", "video": twitch_result}
+
+    youtube_result = await fetch_youtube_home_feed(limit)
+    response = {"success": bool(youtube_result.get("success")), "region": "non-china", "video": youtube_result}
+    if not response["success"]:
+        source = youtube_result.get("source") or "video"
+        response["error"] = youtube_result.get("error") or f"{source} 获取失败（无错误详情）"
+    return response
 
 async def fetch_news_content(limit: int = 10) -> Dict[str, Any]:
     """
@@ -1459,6 +1472,17 @@ def _format_youtube_videos(videos: List[Dict], limit: int = 5) -> List[str]:
     output_lines.append("")
     return output_lines
 
+
+def _format_twitch_categories(categories: List[Dict], limit: int = 5) -> List[str]:
+    """Format public Twitch categories as lightweight conversation material."""
+    output_lines = ["[Twitch live categories]"]
+    for index, category in enumerate(categories[:limit], 1):
+        title = category.get("title", "")
+        if title:
+            output_lines.append(f"{index}. {title}")
+    output_lines.append("")
+    return output_lines
+
 def _format_reddit_posts(posts: List[Dict], limit: int = 5) -> List[str]:
     """Format the Reddit post list"""
     output_lines = ["【Reddit Hot Posts】"]
@@ -1553,7 +1577,7 @@ def format_video_content(video_content: Dict[str, Any]) -> str:
     
     Formats automatically by region:
     - Chinese region: Bilibili video content
-    - non-Chinese region: YouTube Home Feed
+    - non-Chinese region: Twitch categories, with YouTube fallback
     
     Args:
         video_content: result returned by fetch_video_content
@@ -1573,9 +1597,12 @@ def format_video_content(video_content: Dict[str, Any]) -> str:
     else:
         if video_data.get('success'):
             videos = video_data.get('videos', [])
-            output_lines = _format_youtube_videos(videos)
+            if video_data.get("source") == "twitch":
+                output_lines = _format_twitch_categories(videos)
+            else:
+                output_lines = _format_youtube_videos(videos)
             return "\n".join(output_lines)
-        return "Unable to fetch YouTube recommendations at the moment"
+        return "Unable to fetch Twitch or YouTube recommendations at the moment"
 
 def format_news_content(news_content: Dict[str, Any]) -> str:
     """

--- a/utils/web_scraper/trending_content.py
+++ b/utils/web_scraper/trending_content.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import OrderedDict
+from itertools import zip_longest
 import httpx
 from utils.cookies_login import load_cookies_from_file
 from utils.external_http_client import get_external_http_client
@@ -39,7 +40,7 @@ from .platform_helpers import (
     build_xhh_request_params,
 )
 from .youtube_feed import fetch_youtube_home_feed
-from .twitch_feed import fetch_twitch_top_categories
+from .twitch_feed import fetch_twitch_live_streams
 
 
 XHH_API_BASE = "https://api.xiaoheihe.cn"
@@ -757,7 +758,7 @@ async def fetch_video_content(limit: int = 10) -> Dict[str, Any]:
     Fetch video content based on the user's region
     
     Chinese region: Bilibili homepage videos
-    non-Chinese region: Twitch category discovery, with YouTube as a fallback
+    non-Chinese region: followed Twitch live streams and YouTube recommendations in parallel
     
     Args:
         limit: maximum amount of content
@@ -775,15 +776,38 @@ async def fetch_video_content(limit: int = 10) -> Dict[str, Any]:
             non_china_log_msg="检测到非中文区域，获取 YouTube 首页 Feed",
         )
 
-    twitch_result = await fetch_twitch_top_categories(limit)
-    if twitch_result.get("success"):
-        return {"success": True, "region": "non-china", "video": twitch_result}
+    logger.info("检测到非中文区域，并行获取 Twitch 直播与 YouTube 视频")
+    twitch_result, youtube_result = await asyncio.gather(
+        fetch_twitch_live_streams(limit),
+        fetch_youtube_home_feed(limit),
+        return_exceptions=True,
+    )
+    if isinstance(twitch_result, Exception):
+        logger.warning(f"Twitch 直播获取失败: {twitch_result}")
+        twitch_result = {"success": False, "source": "twitch", "videos": [], "error": str(twitch_result)}
+    if isinstance(youtube_result, Exception):
+        logger.warning(f"YouTube 视频获取失败: {youtube_result}")
+        youtube_result = {"success": False, "source": "youtube", "videos": [], "error": str(youtube_result)}
 
-    youtube_result = await fetch_youtube_home_feed(limit)
-    response = {"success": bool(youtube_result.get("success")), "region": "non-china", "video": youtube_result}
-    if not response["success"]:
-        source = youtube_result.get("source") or "video"
-        response["error"] = youtube_result.get("error") or f"{source} 获取失败（无错误详情）"
+    twitch_videos = list(twitch_result.get("videos") or []) if twitch_result.get("success") else []
+    youtube_videos = list(youtube_result.get("videos") or []) if youtube_result.get("success") else []
+    merged_videos = [
+        item
+        for pair in zip_longest(twitch_videos, youtube_videos)
+        for item in pair
+        if item is not None
+    ]
+    success = bool(twitch_result.get("success") or youtube_result.get("success"))
+    response = {
+        "success": success,
+        "region": "non-china",
+        "video": {"success": success, "source": "mixed", "videos": merged_videos},
+        "twitch": twitch_result,
+        "youtube": youtube_result,
+    }
+    if not success:
+        errors = [str(item.get("error")) for item in (twitch_result, youtube_result) if item.get("error")]
+        response["error"] = "; ".join(errors) if errors else "youtube 获取失败（无错误详情）"
     return response
 
 async def fetch_news_content(limit: int = 10) -> Dict[str, Any]:
@@ -1473,13 +1497,19 @@ def _format_youtube_videos(videos: List[Dict], limit: int = 5) -> List[str]:
     return output_lines
 
 
-def _format_twitch_categories(categories: List[Dict], limit: int = 5) -> List[str]:
-    """Format public Twitch categories as lightweight conversation material."""
-    output_lines = ["[Twitch live categories]"]
-    for index, category in enumerate(categories[:limit], 1):
-        title = category.get("title", "")
+def _format_twitch_live_streams(streams: List[Dict], limit: int = 5) -> List[str]:
+    """Format followed Twitch live streams as lightweight conversation material."""
+    output_lines = ["[Followed Twitch live streams]"]
+    for index, stream in enumerate(streams[:limit], 1):
+        title = stream.get("title", "")
         if title:
             output_lines.append(f"{index}. {title}")
+            details = [detail for detail in (stream.get("author", ""), stream.get("game_name", "")) if detail]
+            viewers = stream.get("viewer_count", "")
+            if viewers:
+                details.append(f"{viewers} viewers")
+            if details:
+                output_lines.append(f"   {' | '.join(details)}")
     output_lines.append("")
     return output_lines
 
@@ -1577,7 +1607,7 @@ def format_video_content(video_content: Dict[str, Any]) -> str:
     
     Formats automatically by region:
     - Chinese region: Bilibili video content
-    - non-Chinese region: Twitch categories, with YouTube fallback
+    - non-Chinese region: followed Twitch live streams and YouTube recommendations
     
     Args:
         video_content: result returned by fetch_video_content
@@ -1596,11 +1626,17 @@ def format_video_content(video_content: Dict[str, Any]) -> str:
         return "暂时无法获取视频推荐内容"
     else:
         if video_data.get('success'):
-            videos = video_data.get('videos', [])
-            if video_data.get("source") == "twitch":
-                output_lines = _format_twitch_categories(videos)
+            if video_data.get("source") == "mixed":
+                output_lines = []
+                twitch_data = video_content.get("twitch", {})
+                youtube_data = video_content.get("youtube", {})
+                if twitch_data.get("success"):
+                    output_lines.extend(_format_twitch_live_streams(twitch_data.get("videos", [])))
+                if youtube_data.get("success"):
+                    output_lines.extend(_format_youtube_videos(youtube_data.get("videos", [])))
             else:
-                output_lines = _format_youtube_videos(videos)
+                videos = video_data.get('videos', [])
+                output_lines = _format_twitch_live_streams(videos) if video_data.get("source") == "twitch" else _format_youtube_videos(videos)
             return "\n".join(output_lines)
         return "Unable to fetch Twitch or YouTube recommendations at the moment"
 

--- a/utils/web_scraper/twitch_feed.py
+++ b/utils/web_scraper/twitch_feed.py
@@ -1,0 +1,104 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Public Twitch category discovery for the proactive video source.
+
+The official Helix endpoint uses the encrypted Twitch Device Code credential
+managed by the local media-credentials page. The shared external HTTP client
+respects HTTP(S)_PROXY, ALL_PROXY, and NO_PROXY.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import quote
+
+from utils.external_http_client import get_external_http_client
+from utils.twitch_auth import TwitchAuthService
+
+
+_TOP_GAMES_URL = "https://api.twitch.tv/helix/games/top"
+_auth_service = TwitchAuthService()
+
+
+def _category_item(value: Any) -> dict[str, str] | None:
+    if not isinstance(value, dict):
+        return None
+    game_id = str(value.get("id") or "").strip()[:64]
+    name = " ".join(str(value.get("name") or "").split())[:120]
+    if not game_id or not name:
+        return None
+    return {
+        "title": name,
+        "author": "Twitch",
+        "url": f"https://www.twitch.tv/directory/category/{quote(name, safe='')}",
+        "source": "Twitch",
+        "category_id": game_id,
+    }
+
+
+async def fetch_twitch_top_categories(limit: int = 10) -> dict[str, Any]:
+    """Fetch public top Twitch categories without exposing credentials."""
+
+    client_id, access_token = await _auth_service.access_token()
+    if not client_id or not access_token:
+        return {
+            "success": False,
+            "source": "twitch",
+            "videos": [],
+            "error": "Twitch source is not configured",
+        }
+
+    bounded_limit = max(1, min(int(limit) if isinstance(limit, int) else 10, 20))
+    headers = {
+        "Client-ID": client_id,
+        "Authorization": f"Bearer {access_token}",
+    }
+    try:
+        response = await get_external_http_client().get(
+            _TOP_GAMES_URL,
+            params={"first": bounded_limit},
+            headers=headers,
+            timeout=10.0,
+        )
+        if response.status_code == 401:
+            client_id, access_token = await _auth_service.access_token(force_refresh=True)
+            if not client_id or not access_token:
+                raise RuntimeError("Twitch credential refresh failed")
+            response = await get_external_http_client().get(
+                _TOP_GAMES_URL,
+                params={"first": bounded_limit},
+                headers={"Client-ID": client_id, "Authorization": f"Bearer {access_token}"},
+                timeout=10.0,
+            )
+        response.raise_for_status()
+        payload = response.json()
+    except Exception as exc:
+        return {
+            "success": False,
+            "source": "twitch",
+            "videos": [],
+            "error": f"Twitch category fetch failed: {type(exc).__name__}",
+        }
+
+    raw_items = payload.get("data") if isinstance(payload, dict) else []
+    categories = [item for item in (_category_item(raw) for raw in raw_items or []) if item]
+    if not categories:
+        return {
+            "success": False,
+            "source": "twitch",
+            "videos": [],
+            "error": "Twitch returned no usable categories",
+        }
+    return {"success": True, "source": "twitch", "videos": categories[:bounded_limit]}

--- a/utils/web_scraper/twitch_feed.py
+++ b/utils/web_scraper/twitch_feed.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Public Twitch category discovery for the proactive video source.
+"""Public Twitch live-stream discovery for the proactive video source.
 
 The official Helix endpoint uses the encrypted Twitch Device Code credential
 managed by the local media-credentials page. The shared external HTTP client
@@ -28,36 +28,44 @@ from utils.external_http_client import get_external_http_client
 from utils.twitch_auth import TwitchAuthService
 
 
-_TOP_GAMES_URL = "https://api.twitch.tv/helix/games/top"
+_FOLLOWED_STREAMS_URL = "https://api.twitch.tv/helix/streams/followed"
 _auth_service = TwitchAuthService()
 
 
-def _category_item(value: Any) -> dict[str, str] | None:
+def _stream_item(value: Any) -> dict[str, str] | None:
     if not isinstance(value, dict):
         return None
-    game_id = str(value.get("id") or "").strip()[:64]
-    name = " ".join(str(value.get("name") or "").split())[:120]
-    if not game_id or not name:
+    login = str(value.get("user_login") or "").strip().lower()[:25]
+    title = " ".join(str(value.get("title") or "").split())[:180]
+    author = " ".join(str(value.get("user_name") or "").split())[:80]
+    game_name = " ".join(str(value.get("game_name") or "").split())[:120]
+    if not login or not title or not author:
         return None
+    try:
+        viewers = max(0, int(value.get("viewer_count")))
+    except (TypeError, ValueError):
+        viewers = 0
     return {
-        "title": name,
-        "author": "Twitch",
-        "url": f"https://www.twitch.tv/directory/category/{quote(name, safe='')}",
+        "stream_id": str(value.get("id") or "").strip()[:64],
+        "title": title,
+        "author": author,
+        "url": f"https://www.twitch.tv/{quote(login, safe='')}",
         "source": "Twitch",
-        "category_id": game_id,
+        "game_name": game_name,
+        "viewer_count": str(viewers),
     }
 
 
-async def fetch_twitch_top_categories(limit: int = 10) -> dict[str, Any]:
-    """Fetch public top Twitch categories without exposing credentials."""
+async def fetch_twitch_live_streams(limit: int = 10) -> dict[str, Any]:
+    """Fetch live streams from the authorized account's followed channels."""
 
-    client_id, access_token = await _auth_service.access_token()
-    if not client_id or not access_token:
+    client_id, access_token, user_id = await _auth_service.followed_stream_access()
+    if not client_id or not access_token or not user_id:
         return {
             "success": False,
             "source": "twitch",
             "videos": [],
-            "error": "Twitch source is not configured",
+            "error": "Twitch followed-stream access requires reauthorization",
         }
 
     bounded_limit = max(1, min(int(limit) if isinstance(limit, int) else 10, 20))
@@ -67,18 +75,18 @@ async def fetch_twitch_top_categories(limit: int = 10) -> dict[str, Any]:
     }
     try:
         response = await get_external_http_client().get(
-            _TOP_GAMES_URL,
-            params={"first": bounded_limit},
+            _FOLLOWED_STREAMS_URL,
+            params={"user_id": user_id, "first": bounded_limit},
             headers=headers,
             timeout=10.0,
         )
         if response.status_code == 401:
-            client_id, access_token = await _auth_service.access_token(force_refresh=True)
-            if not client_id or not access_token:
+            client_id, access_token, user_id = await _auth_service.followed_stream_access(force_refresh=True)
+            if not client_id or not access_token or not user_id:
                 raise RuntimeError("Twitch credential refresh failed")
             response = await get_external_http_client().get(
-                _TOP_GAMES_URL,
-                params={"first": bounded_limit},
+                _FOLLOWED_STREAMS_URL,
+                params={"user_id": user_id, "first": bounded_limit},
                 headers={"Client-ID": client_id, "Authorization": f"Bearer {access_token}"},
                 timeout=10.0,
             )
@@ -89,16 +97,16 @@ async def fetch_twitch_top_categories(limit: int = 10) -> dict[str, Any]:
             "success": False,
             "source": "twitch",
             "videos": [],
-            "error": f"Twitch category fetch failed: {type(exc).__name__}",
+            "error": f"Twitch live stream fetch failed: {type(exc).__name__}",
         }
 
     raw_items = payload.get("data") if isinstance(payload, dict) else []
-    categories = [item for item in (_category_item(raw) for raw in raw_items or []) if item]
-    if not categories:
+    streams = [item for item in (_stream_item(raw) for raw in raw_items or []) if item]
+    if not streams:
         return {
             "success": False,
             "source": "twitch",
             "videos": [],
-            "error": "Twitch returned no usable categories",
+            "error": "No followed Twitch live streams are currently online",
         }
-    return {"success": True, "source": "twitch", "videos": categories[:bounded_limit]}
+    return {"success": True, "source": "twitch", "videos": streams[:bounded_limit]}

--- a/utils/web_scraper/twitch_feed.py
+++ b/utils/web_scraper/twitch_feed.py
@@ -83,7 +83,12 @@ async def fetch_twitch_live_streams(limit: int = 10) -> dict[str, Any]:
         if response.status_code == 401:
             client_id, access_token, user_id = await _auth_service.followed_stream_access(force_refresh=True)
             if not client_id or not access_token or not user_id:
-                raise RuntimeError("Twitch credential refresh failed")
+                return {
+                    "success": False,
+                    "source": "twitch",
+                    "videos": [],
+                    "error": "Twitch followed-stream access requires reauthorization",
+                }
             response = await get_external_http_client().get(
                 _FOLLOWED_STREAMS_URL,
                 params={"user_id": user_id, "first": bounded_limit},


### PR DESCRIPTION
## 改动概述 / Summary

为非中国区域的主动搭话视频源接入个性化 Twitch 直播信息：

- 在媒体凭证页增加 Twitch Device Code 授权，使用 `user:read:follows` scope，并通过现有本地加密凭证存储保存 access/refresh token。
- 使用 `/helix/streams/followed` 获取授权账号关注且正在直播的频道，包括直播标题、主播、分类、观众数和直播间链接。
- Twitch 与 YouTube 并行抓取并交错合并，任一来源成功即可继续生成主动搭话；中国区域的 Bilibili 路由保持不变。
- 移除 Twitch 数据源短时去重，确保每轮都能看到当前仍在线的关注直播。
- 修复 Twitch 凭证状态完整性检查缺失导致媒体凭证页误报“未配置”的问题。
- Twitch OAuth 和 Helix 请求复用尊重 `HTTP(S)_PROXY`、`ALL_PROXY`、`NO_PROXY` 的外部 HTTP 客户端，且不会向前端或日志返回 token。

修改前，非中国区域视频源没有可配置的个性化 Twitch 关注直播数据；修改后，Twitch 与 YouTube 会作为两个独立来源共同参与主动搭话候选筛选。

## 回归报告 / Regression Report

不适用：未修改 `app/`、`main_logic/` 或 `memory/`。

潜在回归点主要是非中国区域的视频来源聚合、Twitch token 刷新和凭证状态展示。对应路径已增加单元测试，并保留 Twitch 不可用时由 YouTube 单独成功的降级行为。

## 不拆分理由 / Why Not Split

不适用：按模板规则计入上限的文件数不超过 20。

## 测试 / Testing

- `python -m compileall`：相关 Python 模块及单元测试语法检查通过。
- `node --check static/js/cookies_login.js`：通过。
- `python -m json.tool static/locales/*.json`：全部 locale JSON 解析通过。
- `git diff --check upstream/main...HEAD`：通过。
- 使用当前加密凭证手动请求 `/helix/streams/followed`：HTTP 200，并成功返回关注中的直播。
- 本地 pytest 未执行：现有 `.venv`/`uv` 指向缺失的 Python 3.11 解释器；交由 CI 运行完整测试。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增 Twitch 平台登录：支持 Device Code 授权、授权状态查询及完成后加密保存凭据。
  - 在非中文地区将 Twitch 直播与 YouTube 内容合并展示（`mixed`），并同步更新展示来源文案与顺序。
  - 新增 Twitch 关注直播发现能力，展示标题、作者/游戏与观众数等信息。
- **本地化**
  - 增加 Twitch 授权流程与操作指引多语言文案，覆盖所有已支持语言。
- **安全性**
  - 保存凭据前进行必填校验；对不支持的授权方式保存请求进行拒绝，避免敏感信息被记录。
- **测试**
  - 扩展 Twitch 授权/轮询、直播抓取、内容合并及多语言键一致性等单测。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->