### PR TITLE
修复导入角色卡后并发请求覆盖最新数据、导致列表未自动刷新的问题

### DIFF
--- a/static/js/character_card_manager/character-data-and-transfer.js
+++ b/static/js/character_card_manager/character-data-and-transfer.js
@@ -311,30 +311,34 @@ async function loadCharacterCards() {
 
     // 获取角色数据
     const characterData = await loadCharacterData();
-    if (!characterData) return;
+    // 页面初始化、工坊同步和导入都可能并发触发刷新。旧请求晚返回时必须整轮退出，
+    // 不能只淘汰它的模型扫描，否则它会用导入前的快照覆盖最新列表。
+    if (!characterData || loadSequence !== characterCardLoadSequence) return;
 
     // 模型扫描可能受 Linux 新存储根、创意工坊目录或 Steam 状态影响变慢。
     // 角色列表不应被模型扫描阻塞；扫描完成后再用于预览/上传等增强能力。
     const modelScanPromise = scanModels(loadSequence);
 
-    // 转换角色数据为角色卡格式（定义为全局变量，供其他函数使用）
-    window.characterCards = [];
+    // 先在局部数组中组装完整快照，确认仍是最新一轮后再一次性提交到 UI；
+    // 避免并发刷新通过共享 window.characterCards 相互追加或清空。
+    const nextCharacterCards = [];
     let idCounter = 1;
 
     // 只处理猫娘数据，忽略其他角色类型（包括主人）
     const catgirls = characterData['猫娘'] || {};
     for (const [name, data] of Object.entries(catgirls)) {
-        window.characterCards.push(buildCharacterCardEntry(name, data, idCounter++));
+        nextCharacterCards.push(buildCharacterCardEntry(name, data, idCounter++));
     }
 
     // 从character_cards文件夹加载角色卡
     try {
-        const response = await fetch('/api/characters/character-card/list');
+        const response = await fetch('/api/characters/character-card/list', { cache: 'no-store' });
         if (response.ok) {
             const data = await response.json();
+            if (loadSequence !== characterCardLoadSequence) return;
             if (data.success) {
                 for (const card of data.character_cards) {
-                    window.characterCards.push({
+                    nextCharacterCards.push({
                         id: idCounter++,
                         name: card.name,
                         description: card.description,
@@ -347,29 +351,32 @@ async function loadCharacterCards() {
     } catch (error) {
         console.error('从character_cards文件夹加载角色卡失败:', error);
     }
+    if (loadSequence !== characterCardLoadSequence) return;
 
     // 扫描模型文件夹中的 character_settings JSON 文件仅用于旧格式兼容，不能阻塞角色管理主列表。
     const characterSettingsStartId = idCounter;
 
-    // 渲染角色卡列表（改为下拉选单）
-    refreshCharacterCardSelectOptions();
-
-    // 将角色卡列表保存到全局变量（已使用window.characterCards，这里保持兼容）
-    globalCharacterCards = window.characterCards || [];
-
     // 获取当前猫娘
+    let currentCatgirl = '';
     try {
-        const currentResp = await fetch('/api/characters/current_catgirl');
+        const currentResp = await fetch('/api/characters/current_catgirl', { cache: 'no-store' });
         const currentData = await currentResp.json();
-        window._workshopCurrentCatgirl = currentData.current_catgirl || '';
-    } catch (e) {
-        window._workshopCurrentCatgirl = '';
-    }
+        currentCatgirl = currentData.current_catgirl || '';
+    } catch (e) {}
+    if (loadSequence !== characterCardLoadSequence) return;
 
     // 预取已设置卡面的猫娘名单（避免逐个发起 404 请求）
-    await loadCardFaceNames();
+    await loadCardFaceNames(loadSequence);
+    if (loadSequence !== characterCardLoadSequence) return;
     // 预取卡面元数据（作者/创建时间/来源）
-    await loadCardMetas();
+    await loadCardMetas(loadSequence);
+    if (loadSequence !== characterCardLoadSequence) return;
+
+    // 只有最新一轮加载可以提交共享状态和重绘列表。
+    window.characterCards = nextCharacterCards;
+    globalCharacterCards = nextCharacterCards;
+    window._workshopCurrentCatgirl = currentCatgirl;
+    refreshCharacterCardSelectOptions();
 
     // 渲染卡片/列表视图
     renderCharaCardsView();
@@ -418,11 +425,12 @@ async function loadCharacterCards() {
 // 已设置卡面的猫娘名集合（避免无卡面的 404 控制台噪声）
 window._cardFaceNames = window._cardFaceNames || new Set();
 const CHARACTER_MANAGER_CARD_MAKER_WINDOW_NAME = 'neko_card_maker';
-async function loadCardFaceNames() {
+async function loadCardFaceNames(loadSequence) {
     try {
-        const resp = await fetch('/api/characters/card-faces');
+        const resp = await fetch('/api/characters/card-faces', { cache: 'no-store' });
         if (!resp.ok) return;
         const data = await resp.json();
+        if (loadSequence !== undefined && loadSequence !== characterCardLoadSequence) return;
         if (data && data.success && Array.isArray(data.names)) {
             window._cardFaceNames = new Set(data.names);
         }
@@ -781,11 +789,12 @@ async function showProfileNameRequiredDialog(key = 'character.fillProfileNameFir
 
 // 卡面元数据缓存 { name: { author, origin, created_at, updated_at } }
 window._cardMetas = window._cardMetas || {};
-async function loadCardMetas() {
+async function loadCardMetas(loadSequence) {
     try {
-        const resp = await fetch('/api/characters/card-metas');
+        const resp = await fetch('/api/characters/card-metas', { cache: 'no-store' });
         if (!resp.ok) return;
         const data = await resp.json();
+        if (loadSequence !== undefined && loadSequence !== characterCardLoadSequence) return;
         if (data && data.success && data.metas && typeof data.metas === 'object') {
             window._cardMetas = data.metas;
         }

--- a/static/js/character_card_manager/character-data-and-transfer.js
+++ b/static/js/character_card_manager/character-data-and-transfer.js
@@ -8,6 +8,10 @@ let currentCharacterCardId = null;
 const CHARACTER_CARD_MODEL_SCAN_RENDER_BUDGET_MS = 2500;
 let characterCardLoadSequence = 0;
 
+function isCharacterCardLoadStale(loadSequence) {
+    return loadSequence !== undefined && loadSequence !== characterCardLoadSequence;
+}
+
 function getCharacterCardDescriptionFromData(data) {
     if (!data || typeof data !== 'object') {
         return window.t ? window.t('steam.noDescription') : '暂无描述';
@@ -166,7 +170,7 @@ async function collectCharacterSettingsCardsFromModels(idCounter, loadSequence) 
     for (const model of availableModels) {
         // 每个模型外层 fetch 前先校验序列号；旧轮被新一轮 loadCharacterCards 抢占后立刻早退，
         // 避免在大目录下继续打 model_files / *.chara.json 的废请求拖慢最新一轮 I/O
-        if (loadSequence !== undefined && loadSequence !== characterCardLoadSequence) {
+        if (isCharacterCardLoadStale(loadSequence)) {
             return { cards: newCards, nextId };
         }
         try {
@@ -183,7 +187,7 @@ async function collectCharacterSettingsCardsFromModels(idCounter, loadSequence) 
 
                     // 如果找到character_settings文件，解析并添加到角色卡列表
                     for (const file of characterSettingsFiles) {
-                        if (loadSequence !== undefined && loadSequence !== characterCardLoadSequence) {
+                        if (isCharacterCardLoadStale(loadSequence)) {
                             return { cards: newCards, nextId };
                         }
                         try {
@@ -313,7 +317,7 @@ async function loadCharacterCards() {
     const characterData = await loadCharacterData();
     // 页面初始化、工坊同步和导入都可能并发触发刷新。旧请求晚返回时必须整轮退出，
     // 不能只淘汰它的模型扫描，否则它会用导入前的快照覆盖最新列表。
-    if (!characterData || loadSequence !== characterCardLoadSequence) return;
+    if (!characterData || isCharacterCardLoadStale(loadSequence)) return;
 
     // 模型扫描可能受 Linux 新存储根、创意工坊目录或 Steam 状态影响变慢。
     // 角色列表不应被模型扫描阻塞；扫描完成后再用于预览/上传等增强能力。
@@ -335,7 +339,7 @@ async function loadCharacterCards() {
         const response = await fetch('/api/characters/character-card/list', { cache: 'no-store' });
         if (response.ok) {
             const data = await response.json();
-            if (loadSequence !== characterCardLoadSequence) return;
+            if (isCharacterCardLoadStale(loadSequence)) return;
             if (data.success) {
                 for (const card of data.character_cards) {
                     nextCharacterCards.push({
@@ -351,7 +355,7 @@ async function loadCharacterCards() {
     } catch (error) {
         console.error('从character_cards文件夹加载角色卡失败:', error);
     }
-    if (loadSequence !== characterCardLoadSequence) return;
+    if (isCharacterCardLoadStale(loadSequence)) return;
 
     // 扫描模型文件夹中的 character_settings JSON 文件仅用于旧格式兼容，不能阻塞角色管理主列表。
     const characterSettingsStartId = idCounter;
@@ -363,14 +367,14 @@ async function loadCharacterCards() {
         const currentData = await currentResp.json();
         currentCatgirl = currentData.current_catgirl || '';
     } catch (e) {}
-    if (loadSequence !== characterCardLoadSequence) return;
+    if (isCharacterCardLoadStale(loadSequence)) return;
 
     // 预取已设置卡面的猫娘名单（避免逐个发起 404 请求）
     await loadCardFaceNames(loadSequence);
-    if (loadSequence !== characterCardLoadSequence) return;
+    if (isCharacterCardLoadStale(loadSequence)) return;
     // 预取卡面元数据（作者/创建时间/来源）
     await loadCardMetas(loadSequence);
-    if (loadSequence !== characterCardLoadSequence) return;
+    if (isCharacterCardLoadStale(loadSequence)) return;
 
     // 只有最新一轮加载可以提交共享状态和重绘列表。
     window.characterCards = nextCharacterCards;
@@ -430,7 +434,7 @@ async function loadCardFaceNames(loadSequence) {
         const resp = await fetch('/api/characters/card-faces', { cache: 'no-store' });
         if (!resp.ok) return;
         const data = await resp.json();
-        if (loadSequence !== undefined && loadSequence !== characterCardLoadSequence) return;
+        if (isCharacterCardLoadStale(loadSequence)) return;
         if (data && data.success && Array.isArray(data.names)) {
             window._cardFaceNames = new Set(data.names);
         }
@@ -794,7 +798,7 @@ async function loadCardMetas(loadSequence) {
         const resp = await fetch('/api/characters/card-metas', { cache: 'no-store' });
         if (!resp.ok) return;
         const data = await resp.json();
-        if (loadSequence !== undefined && loadSequence !== characterCardLoadSequence) return;
+        if (isCharacterCardLoadStale(loadSequence)) return;
         if (data && data.success && data.metas && typeof data.metas === 'object') {
             window._cardMetas = data.metas;
         }

--- a/tests/unit/test_character_card_manager_refresh.py
+++ b/tests/unit/test_character_card_manager_refresh.py
@@ -114,6 +114,7 @@ def test_latest_character_card_refresh_wins_when_an_older_request_finishes_last(
         cwd=PROJECT_ROOT,
         capture_output=True,
         text=True,
+        encoding="utf-8",
         timeout=20,
         check=False,
     )

--- a/tests/unit/test_character_card_manager_refresh.py
+++ b/tests/unit/test_character_card_manager_refresh.py
@@ -24,8 +24,8 @@ def test_latest_character_card_refresh_wins_when_an_older_request_finishes_last(
 
     script = textwrap.dedent(
         f"""
-        const fs = require('node:fs');
-        const vm = require('node:vm');
+        const fs = require('fs');
+        const vm = require('vm');
         const source = fs.readFileSync({json.dumps(str(CHARACTER_DATA_SCRIPT))}, 'utf8');
         const pendingCharacterLoads = [];
         const renderedSnapshots = [];

--- a/tests/unit/test_character_card_manager_refresh.py
+++ b/tests/unit/test_character_card_manager_refresh.py
@@ -1,0 +1,120 @@
+import json
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+CHARACTER_DATA_SCRIPT = (
+    PROJECT_ROOT
+    / "static"
+    / "js"
+    / "character_card_manager"
+    / "character-data-and-transfer.js"
+)
+
+
+def test_latest_character_card_refresh_wins_when_an_older_request_finishes_last() -> None:
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is required for the character-card manager browser contract test")
+
+    script = textwrap.dedent(
+        f"""
+        const fs = require('node:fs');
+        const vm = require('node:vm');
+        const source = fs.readFileSync({json.dumps(str(CHARACTER_DATA_SCRIPT))}, 'utf8');
+        const pendingCharacterLoads = [];
+        const renderedSnapshots = [];
+
+        const document = {{
+          readyState: 'loading',
+          addEventListener() {{}},
+          getElementById() {{ return null; }},
+        }};
+        const context = {{
+          console,
+          document,
+          Promise,
+          Set,
+          Map,
+          Date,
+          Math,
+          JSON,
+          URL,
+          TextEncoder,
+          Uint8Array,
+          DataView,
+          Blob,
+          FormData,
+          availableModels: [],
+          availableVrmModels: [],
+          availableMmdModels: [],
+          loadCharacterData() {{
+            return new Promise(resolve => pendingCharacterLoads.push(resolve));
+          }},
+          scanModels() {{ return Promise.resolve(true); }},
+          loadMasterProfile() {{}},
+          renderHiddenCatgirls() {{}},
+          expandCharacterCardSection() {{}},
+          showMessage() {{}},
+          renderCharaCardsView() {{
+            renderedSnapshots.push((context.characterCards || []).map(card => card.name));
+          }},
+          fetch: async (url, options = {{}}) => {{
+            if (options.cache !== 'no-store') {{
+              throw new Error(`refresh request did not bypass cache: ${{url}}`);
+            }}
+            const payload = url.endsWith('/character-card/list')
+              ? {{ success: true, character_cards: [] }}
+              : url.endsWith('/current_catgirl')
+                ? {{ current_catgirl: '' }}
+                : url.endsWith('/card-faces')
+                  ? {{ success: true, names: [] }}
+                  : {{ success: true, metas: {{}} }};
+            return {{ ok: true, json: async () => payload }};
+          }},
+          addEventListener() {{}},
+          setTimeout(callback) {{ callback(); return 1; }},
+          clearTimeout() {{}},
+        }};
+        context.window = context;
+        vm.runInNewContext(source, context);
+
+        (async () => {{
+          const olderRefresh = context.loadCharacterCards();
+          const importRefresh = context.loadCharacterCards();
+          if (pendingCharacterLoads.length !== 2) throw new Error('expected two concurrent refreshes');
+
+          pendingCharacterLoads[1]({{ '猫娘': {{ '刚导入的角色': {{ description: 'fresh' }} }} }});
+          await importRefresh;
+          pendingCharacterLoads[0]({{ '猫娘': {{ '导入前的旧角色': {{ description: 'stale' }} }} }});
+          await olderRefresh;
+          await Promise.resolve();
+
+          const finalNames = (context.characterCards || []).map(card => card.name);
+          if (JSON.stringify(finalNames) !== JSON.stringify(['刚导入的角色'])) {{
+            throw new Error(`stale refresh replaced imported card list: ${{JSON.stringify(finalNames)}}`);
+          }}
+          if (renderedSnapshots.some(names => names.includes('导入前的旧角色'))) {{
+            throw new Error(`stale refresh rendered after import: ${{JSON.stringify(renderedSnapshots)}}`);
+          }}
+        }})().catch(error => {{
+          console.error(error);
+          process.exitCode = 1;
+        }});
+        """
+    )
+
+    result = subprocess.run(
+        [node, "-e", script],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复导入角色卡后并发请求覆盖最新数据、导致列表未自动刷新的问题

## 测试 / Testing

手动进行导入测试


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 修复角色卡并发加载时“旧请求晚返回覆盖新数据”的问题：只有最新轮次会刷新角色卡列表与下拉选项。
  - 当前猫娘信息与卡面数据加入轮次校验；过期响应会提前终止，避免陈旧内容进入界面。
  - 角色卡/卡面相关请求改为绕过缓存（`cache: 'no-store'`），降低展示过期数据的概率。
- **测试**
  - 新增并发刷新胜出单测：模拟旧请求更晚返回，断言最终仅显示最新导入角色，并校验关键请求使用 `cache: 'no-store'`。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->