### PR TITLE
修复角色卡导入提示不可见问题，仅保留非阻塞的导入中提示，并清理其他冗余通知

### DIFF
--- a/static/css/character_card_manager.css
+++ b/static/css/character_card_manager.css
@@ -4134,6 +4134,20 @@ margin-top: 10px;
     filter: brightness(1.1);
 }
 
+@keyframes ccm-toast-spin {
+    to { transform: rotate(360deg); }
+}
+
+.ccm-toast-spinner {
+    animation: ccm-toast-spin 0.8s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ccm-toast-spinner {
+        animation: none;
+    }
+}
+
 .chara-import-btn {
     display: flex;
     align-items: center;
@@ -7495,13 +7509,6 @@ margin-top: 10px;
 [data-theme="dark"] #snapshot-diff-area strong,
 [data-theme="dark"] #snapshot-diff-list {
     color: #facc15 !important;
-}
-
-[data-theme="dark"] .auto-save-toast {
-    background: #123a2a;
-    border-color: #34d399;
-    color: #a7f3d0;
-    box-shadow: 0 8px 22px rgba(0, 0, 0, 0.36);
 }
 
 [data-theme="dark"] .tag,

--- a/static/js/character_card_manager/character-data-and-transfer.js
+++ b/static/js/character_card_manager/character-data-and-transfer.js
@@ -1042,7 +1042,7 @@ async function handleImportCharacterCard(event) {
         importNotice.dismiss();
         console.error('导入角色卡失败:', error);
         const errorText = window.t ? window.t('character.importCardFailed', { error: error.message }) : `导入角色卡失败: ${error.message}`;
-        showMessage(errorText, 'error');
+        showMessage(errorText, 'import-error');
     }
 }
 

--- a/static/js/character_card_manager/character-data-and-transfer.js
+++ b/static/js/character_card_manager/character-data-and-transfer.js
@@ -374,13 +374,6 @@ async function loadCharacterCards() {
     // 渲染卡片/列表视图
     renderCharaCardsView();
 
-    // 显示刷新成功消息
-    if (window.characterCards && window.characterCards.length > 0) {
-        showMessage(window.t ? window.t('steam.characterCardsRefreshed', { count: window.characterCards.length }) : `已刷新角色卡列表，共 ${window.characterCards.length} 个角色卡`, 'success');
-    } else {
-        showMessage(window.t ? window.t('steam.characterCardsRefreshedEmpty') : '已刷新角色卡列表，暂无角色卡', 'info');
-    }
-
     // 同步加载我的档案和已隐藏猫娘列表
     loadMasterProfile();
     renderHiddenCatgirls();
@@ -982,7 +975,11 @@ async function handleImportCharacterCard(event) {
     }
 
     const loadingText = window.t ? window.t('character.importingCard') : '正在导入角色卡...';
-    showMessage(loadingText, 'info');
+    // 导入和解包大角色卡可能超过普通 toast 的展示时长。提示随整个导入流程常驻，
+    // 但仍是非模态浮层，不阻塞用户操作页面中的其他功能。
+    const importNotice = showMessage(loadingText, 'importing', 0);
+    // 先让浏览器绘制提示，再开始可能占用主线程的旧版 PNG 标记扫描。
+    await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
 
     try {
         const arrayBuffer = await file.arrayBuffer();
@@ -1033,18 +1030,16 @@ async function handleImportCharacterCard(event) {
             const errorData = await response.json().catch(() => ({ error: '导入失败' }));
             throw new Error(errorData.error || `HTTP ${response.status}`);
         }
-        const result = await response.json();
-
-        const successText = window.t ? window.t('character.importCardSuccess', { name: result.character_name }) : `角色卡 "${result.character_name}" 导入成功`;
-        showMessage(successText, 'success');
-
         // 刷新角色卡列表（含 sidecar / 卡面 / 视图重新渲染）
         if (typeof loadCharacterCards === 'function') {
             await loadCharacterCards();
         } else if (typeof loadCharacterData === 'function') {
             await loadCharacterData();
         }
+
+        importNotice.dismiss();
     } catch (error) {
+        importNotice.dismiss();
         console.error('导入角色卡失败:', error);
         const errorText = window.t ? window.t('character.importCardFailed', { error: error.message }) : `导入角色卡失败: ${error.message}`;
         showMessage(errorText, 'error');

--- a/static/js/character_card_manager/core-and-upload.js
+++ b/static/js/character_card_manager/core-and-upload.js
@@ -1359,6 +1359,12 @@ function showConfirmModal(message, confirmCallback, cancelCallback = null) {
 }
 
 function showMessage(message, type = 'info', duration = 3000) {
+    // 角色卡管理页只保留导入过程提示；历史调用继续保留为无操作，避免各业务流程
+    // 因通知策略变化而需要掺入无关控制逻辑。
+    if (type !== 'importing') {
+        return null;
+    }
+
     // 统一为「导出角色卡」同款风格的居中顶部浮层卡片（非模态），
     // 保证桌面端网页也能稳定显示。调用签名保持与旧版兼容。
     function createMessageArea() {
@@ -1370,6 +1376,11 @@ function showMessage(message, type = 'info', duration = 3000) {
     }
 
     const messageArea = document.getElementById('message-area') || createMessageArea();
+    // 旧模板曾把全局通知容器放在默认隐藏的上传模态框内，导致通知节点已创建但不可见。
+    // 始终挂到 body，既能避开隐藏祖先，也能保持通知为不阻塞操作的页面级浮层。
+    if (messageArea.parentElement !== document.body) {
+        document.body.appendChild(messageArea);
+    }
 
     // 布局：居中、顶部向下滑入，堆叠显示
     messageArea.style.position = 'fixed';
@@ -1385,16 +1396,12 @@ function showMessage(message, type = 'info', duration = 3000) {
     messageArea.style.alignItems = 'center';
     messageArea.style.pointerEvents = 'none';
 
-    const typeConfig = {
-        error:   { icon: 'fa-exclamation-circle', accent: '#ff5a5a', grad: 'linear-gradient(135deg,#ff7a7a,#ff5a5a)' },
-        warning: { icon: 'fa-exclamation-triangle', accent: '#f0ad4e', grad: 'linear-gradient(135deg,#f6c266,#f0ad4e)' },
-        success: { icon: 'fa-check-circle', accent: '#58c38a', grad: 'linear-gradient(135deg,#6ec5a8,#58c38a)' },
-        info:    { icon: 'fa-info-circle', accent: '#40C5F1', grad: 'linear-gradient(135deg,#40C5F1,#5dd4f7)' },
-    };
-    const cfg = typeConfig[type] || typeConfig.info;
+    const cfg = { icon: 'ccm-toast-spinner', accent: '#40C5F1' };
 
     const card = document.createElement('div');
-    card.className = 'ccm-toast-card ccm-toast-' + type;
+    card.className = 'ccm-toast-card ccm-toast-importing';
+    card.setAttribute('role', 'status');
+    card.setAttribute('aria-live', 'polite');
     card.style.cssText = [
         'background:#fff',
         'border-radius:14px',
@@ -1418,8 +1425,9 @@ function showMessage(message, type = 'info', duration = 3000) {
     ].join(';');
 
     const iconEl = document.createElement('i');
-    iconEl.className = 'fa ' + cfg.icon;
-    iconEl.style.cssText = 'color:' + cfg.accent + ';font-size:18px;margin-top:2px;flex-shrink:0';
+    iconEl.className = cfg.icon;
+    iconEl.setAttribute('aria-hidden', 'true');
+    iconEl.style.cssText = 'width:16px;height:16px;border:2px solid ' + cfg.accent + ';border-right-color:transparent;border-radius:50%;margin-top:2px;flex-shrink:0';
     card.appendChild(iconEl);
 
     const body = document.createElement('div');
@@ -1438,6 +1446,7 @@ function showMessage(message, type = 'info', duration = 3000) {
         card.style.transform = 'translateY(-8px)';
         setTimeout(() => { if (card.parentNode) card.parentNode.removeChild(card); }, 220);
     };
+    card.dismiss = dismiss;
     closeBtn.onclick = dismiss;
     card.appendChild(closeBtn);
 
@@ -1467,60 +1476,6 @@ function escapeHtml(text) {
         .replace(/'/g, '&#39;');
 }
 
-
-// 共享的提示框功能
-function showToast(message, duration = 3000) {
-    let container = document.getElementById('message-area');
-    if (!container) {
-        container = document.createElement('div');
-        container.id = 'message-area';
-        container.className = 'message-area';
-        document.body.appendChild(container);
-    }
-
-    // 若容器由模板/其他逻辑预先创建，首个 toast 沿用旧 zIndex 会被新模态遮挡；
-    // 无条件刷新定位 / 层级，确保每次都落在最顶层。
-    container.style.position = 'fixed';
-    container.style.top = '20px';
-    container.style.right = '20px';
-    container.style.maxWidth = '400px';
-    container.style.zIndex = '2147483647';
-    container.style.display = 'flex';
-    container.style.flexDirection = 'column';
-    container.style.alignItems = 'flex-end';
-    container.style.boxShadow = '0 4px 12px rgba(0,0,0,0.15)';
-
-    const messageElement = document.createElement('div');
-    // 使用 textContent 避免 HTML 注入风险 (resolved duplicate innerHTML comment review safely)
-    messageElement.textContent = message;
-    messageElement.style.cssText = `
-        padding: 15px 20px;
-        margin-bottom: 10px;
-        background: #e8f5e9;
-        color: #2e7d32;
-        border-radius: 6px;
-        box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-        font-weight: bold;
-        opacity: 0;
-        transform: translateY(-10px);
-        transition: opacity 0.3s ease, transform 0.3s ease;
-    `;
-
-    container.appendChild(messageElement);
-
-    setTimeout(() => {
-        messageElement.style.opacity = '1';
-        messageElement.style.transform = 'translateY(0)';
-    }, 10);
-
-    setTimeout(() => {
-        messageElement.style.opacity = '0';
-        messageElement.style.transform = 'translateY(-10px)';
-        setTimeout(() => {
-            messageElement.remove();
-        }, 300);
-    }, duration);
-}
 
 // 加载状态管理器
 function LoadingManager() {
@@ -1937,12 +1892,6 @@ function uploadItem() {
                 setButtonState(uploadButton, false);
             }
 
-            // 清除所有现有消息
-            const messageArea = document.getElementById('message-area');
-            if (messageArea) {
-                messageArea.innerHTML = '';
-            }
-
             if (data.success) {
                 // 标记上传已完成
                 isUploadCompleted = true;
@@ -2027,18 +1976,6 @@ function uploadItem() {
                 // 添加默认标签
                     addTag(window.t ? window.t('steam.defaultTagMod') : '模组');
 
-                // 显示成功提示和操作选项
-                setTimeout(() => {
-                    const messageArea = document.getElementById('message-area');
-                    const actionMessage = document.createElement('div');
-                    actionMessage.className = 'success-message';
-                    actionMessage.innerHTML = `
-                    <span>${window.t ? window.t('steam.operationComplete') : 'Operation complete, you can:'}</span>
-                    <button class="button button-sm" onclick="closeUploadModal()">${window.t ? window.t('steam.hideUploadSection') : 'Hide Upload Section'}</button>
-                    <span class="message-close" onclick="this.parentElement.remove()">×</span>
-                `;
-                    messageArea.appendChild(actionMessage);
-                }, 1000);
             } else {
                 // 上传失败，重置上传完成标志
                 isUploadCompleted = false;
@@ -2047,21 +1984,6 @@ function uploadItem() {
                     showMessage(window.t ? window.t('steam.uploadWarning', { message: data.message }) : `警告: ${data.message}`, 'warning', 8000);
                 }
 
-                // 提供重试建议
-                setTimeout(() => {
-                    const retryButton = document.createElement('button');
-                    retryButton.className = 'button button-sm';
-                    retryButton.textContent = window.t ? window.t('steam.retryUpload') : '重试上传';
-                    retryButton.onclick = uploadItem;
-
-                    const messageArea = document.getElementById('message-area');
-                    const retryMessage = document.createElement('div');
-                    retryMessage.className = 'error-message';
-                    retryMessage.innerHTML = `<span>${window.t ? window.t('steam.retryPrompt') : 'Would you like to retry the upload?'}</span>
-                    <button class="button button-sm" onclick="uploadItem()">${window.t ? window.t('steam.retryUpload') : 'Retry Upload'}</button>
-                    <span class="message-close" onclick="this.parentElement.remove()">×</span>`;
-                    messageArea.appendChild(retryMessage);
-                }, 2000);
             }
         })
         .catch(error => {
@@ -2074,12 +1996,6 @@ function uploadItem() {
             if (uploadButton) {
                 uploadButton.textContent = originalText;
                 setButtonState(uploadButton, false);
-            }
-
-            // 清除所有现有消息
-            const messageArea = document.getElementById('message-area');
-            if (messageArea) {
-                messageArea.innerHTML = '';
             }
 
             let errorMessage = window.t ? window.t('steam.uploadGeneralError') : '上传失败';

--- a/static/js/character_card_manager/core-and-upload.js
+++ b/static/js/character_card_manager/core-and-upload.js
@@ -1359,9 +1359,9 @@ function showConfirmModal(message, confirmCallback, cancelCallback = null) {
 }
 
 function showMessage(message, type = 'info', duration = 3000) {
-    // 角色卡管理页只保留导入过程提示；历史调用继续保留为无操作，避免各业务流程
-    // 因通知策略变化而需要掺入无关控制逻辑。
-    if (type !== 'importing') {
+    // 只显示导入过程及导入失败；模型预览关闭等历史路径可能把正常取消误报为
+    // error，因此不能在这里全局恢复所有旧错误 toast。
+    if (type !== 'importing' && type !== 'import-error') {
         return null;
     }
 
@@ -1396,12 +1396,15 @@ function showMessage(message, type = 'info', duration = 3000) {
     messageArea.style.alignItems = 'center';
     messageArea.style.pointerEvents = 'none';
 
-    const cfg = { icon: 'ccm-toast-spinner', accent: '#40C5F1' };
+    const isError = type === 'import-error';
+    const cfg = isError
+        ? { icon: 'ccm-toast-error-icon', accent: '#ff5a5a' }
+        : { icon: 'ccm-toast-spinner', accent: '#40C5F1' };
 
     const card = document.createElement('div');
-    card.className = 'ccm-toast-card ccm-toast-importing';
-    card.setAttribute('role', 'status');
-    card.setAttribute('aria-live', 'polite');
+    card.className = 'ccm-toast-card ccm-toast-' + type;
+    card.setAttribute('role', isError ? 'alert' : 'status');
+    card.setAttribute('aria-live', isError ? 'assertive' : 'polite');
     card.style.cssText = [
         'background:#fff',
         'border-radius:14px',
@@ -1424,10 +1427,15 @@ function showMessage(message, type = 'info', duration = 3000) {
         'transition:opacity 0.22s ease, transform 0.22s ease',
     ].join(';');
 
-    const iconEl = document.createElement('i');
+    const iconEl = document.createElement('span');
     iconEl.className = cfg.icon;
     iconEl.setAttribute('aria-hidden', 'true');
-    iconEl.style.cssText = 'width:16px;height:16px;border:2px solid ' + cfg.accent + ';border-right-color:transparent;border-radius:50%;margin-top:2px;flex-shrink:0';
+    if (isError) {
+        iconEl.textContent = '!';
+        iconEl.style.cssText = 'width:18px;height:18px;display:inline-flex;align-items:center;justify-content:center;background:' + cfg.accent + ';color:#fff;border-radius:50%;font-weight:700;margin-top:2px;flex-shrink:0';
+    } else {
+        iconEl.style.cssText = 'width:16px;height:16px;border:2px solid ' + cfg.accent + ';border-right-color:transparent;border-radius:50%;margin-top:2px;flex-shrink:0';
+    }
     card.appendChild(iconEl);
 
     const body = document.createElement('div');
@@ -1437,7 +1445,7 @@ function showMessage(message, type = 'info', duration = 3000) {
 
     const closeBtn = document.createElement('button');
     closeBtn.type = 'button';
-    closeBtn.innerHTML = '<i class="fa fa-times"></i>';
+    closeBtn.textContent = '×';
     closeBtn.style.cssText = 'background:transparent;border:none;color:#888;cursor:pointer;font-size:14px;padding:2px 4px;border-radius:4px;flex-shrink:0';
     closeBtn.onmouseenter = () => { closeBtn.style.background = 'rgba(0,0,0,0.06)'; closeBtn.style.color = '#333'; };
     closeBtn.onmouseleave = () => { closeBtn.style.background = 'transparent'; closeBtn.style.color = '#888'; };

--- a/static/js/character_card_manager/master-profile.js
+++ b/static/js/character_card_manager/master-profile.js
@@ -273,7 +273,6 @@ async function autoSaveMasterField(input) {
                 if (saveBtn) saveBtn.style.display = 'none';
                 if (cancelBtn) cancelBtn.style.display = 'none';
             }
-            showAutoSaveToast(window.t ? window.t('character.autoSaved') : '已自动保存设定');
         }
     } catch (e) {
         console.error('自动保存主人字段失败:', e);
@@ -318,27 +317,10 @@ async function panelAutoSaveCatgirlField(input, catgirlName) {
                 if (saveBtn) saveBtn.style.display = 'none';
                 if (cancelBtn) cancelBtn.style.display = 'none';
             }
-            showAutoSaveToast(window.t ? window.t('character.autoSaved') : '已自动保存设定');
         }
     } catch (e) {
         console.error('自动保存猫娘字段失败:', e);
     }
-}
-
-let _autoSaveToastTimer = null;
-let _autoSaveToastEl = null;
-function showAutoSaveToast(message) {
-    if (!_autoSaveToastEl) {
-        _autoSaveToastEl = document.createElement('div');
-        _autoSaveToastEl.className = 'auto-save-toast';
-        document.body.appendChild(_autoSaveToastEl);
-    }
-    _autoSaveToastEl.textContent = message;
-    _autoSaveToastEl.classList.add('visible');
-    if (_autoSaveToastTimer) clearTimeout(_autoSaveToastTimer);
-    _autoSaveToastTimer = setTimeout(() => {
-        if (_autoSaveToastEl) _autoSaveToastEl.classList.remove('visible');
-    }, 2000);
 }
 
 async function addMasterField() {

--- a/static/js/character_card_manager/model-previews.js
+++ b/static/js/character_card_manager/model-previews.js
@@ -321,7 +321,6 @@ async function loadVrmPreview(modelPath, rawData) {
         if (result) {
             scheduleWorkshop3DPreviewResize(localVrmManager, 'vrm-preview-canvas');
             console.log('[Workshop VRM] 模型预览加载成功');
-            showMessage(window.t ? window.t('steam.vrmPreviewLoaded') || 'VRM 模型预览已加载' : 'VRM 模型预览已加载', 'success');
         }
     } catch (error) {
         console.error('[Workshop VRM] 加载预览失败:', error);
@@ -434,7 +433,6 @@ async function loadMmdPreview(modelPath, rawData) {
                 }
             }
             console.log('[Workshop MMD] 模型预览加载成功');
-            showMessage(window.t ? window.t('steam.mmdPreviewLoaded') || 'MMD 模型预览已加载' : 'MMD 模型预览已加载', 'success');
         }
     } catch (error) {
         console.error('[Workshop MMD] 加载预览失败:', error);
@@ -664,7 +662,6 @@ async function loadLive2DModelByName(modelName, modelInfo = null) {
 
         // 确保获取正确的steam_id，优先使用modelInfo中的item_id
         let finalSteamId = modelInfo.item_id;
-        showMessage((window.t && window.t('live2d.loadingModel', { model: modelName })) || `正在加载模型: ${modelName}...`, 'info');
 
         // 1. Fetch files list
         let filesRes;
@@ -773,7 +770,6 @@ async function loadLive2DModelByName(modelName, modelInfo = null) {
         // 更新全局selectedModelInfo变量
         selectedModelInfo = modelInfo;
         setLive2DPreviewRefreshButtonState(true, true);
-        showMessage((window.t && window.t('live2d.modelLoadSuccess', { model: modelName })) || `模型 ${modelName} 加载成功`, 'success');
     } catch (error) {
         if (error && error.code === 'STALE_LIVE2D_PREVIEW_LOAD') {
             return;
@@ -1211,8 +1207,6 @@ async function loadLive2DModelFromFolder(files) {
         if (previewOverlay) {
             previewOverlay.style.pointerEvents = 'auto';
         }
-
-        showMessage(window.t('steam.live2dPreviewLoaded'), 'success');
 
     } catch (error) {
         console.error('Failed to load Live2D model:', error);

--- a/static/js/character_card_manager/workshop-card-and-upload.js
+++ b/static/js/character_card_manager/workshop-card-and-upload.js
@@ -768,12 +768,6 @@ function closeWorkshopSnapshotModal(event) {
     }
 }
 
-// 加载角色卡
-function loadCharacterCard() {
-    // 这里将实现加载角色卡的逻辑
-    showMessage(window.t ? window.t('steam.characterCardLoaded') : '角色卡已加载', 'info');
-}
-
 // 存储临时上传目录路径，供上传时使用
 let currentUploadTempFolder = null;
 // 标记是否已上传成功
@@ -1138,8 +1132,6 @@ function editCharacterCardModal() {
 
 // 扫描Live2D模型
 async function scanModels(loadSequence) {
-    showMessage(window.t ? window.t('steam.scanningModels') : '正在扫描模型...', 'info');
-
     try {
         // 并行获取 Live2D、VRM、MMD 模型列表
         const [live2dResponse, vrmResponse, mmdResponse] = await Promise.all([
@@ -1312,9 +1304,6 @@ function fitLive2DPreviewModelToContainer(model) {
 // 音色相关函数（功能暂未实现）
 // 加载音色列表
 async function loadVoices() {
-    // 显示扫描开始提示
-    showMessage(window.t ? window.t('steam.scanningVoices') : '正在扫描音色...', 'info');
-
     try {
         const response = await fetch('/api/characters/voices');
         const data = await response.json();
@@ -1322,14 +1311,6 @@ async function loadVoices() {
         if (voiceSelect) {
             // 保存完整的音色数据到全局变量
             window.availableVoices = data.voices;
-
-            // 音色数据已加载，用于后续显示音色名称
-            const voiceCount = Object.keys(data.voices).length;
-
-            // 显示扫描完成提示
-            const successMessage = window.t ? window.t('steam.scanComplete', { count: voiceCount }) : `扫描完成，共找到 ${voiceCount} 个音色`;
-
-            showToast(successMessage);
         }
     } catch (error) {
         console.error('加载音色列表失败:', error);

--- a/templates/character_card_manager.html
+++ b/templates/character_card_manager.html
@@ -353,29 +353,6 @@
         .card-hide-btn:hover, .list-hide-btn:hover {
             background: rgba(64, 197, 241, 0.12);
         }
-        /* 自动保存提示 */
-        .auto-save-toast {
-            position: fixed;
-            top: 80px;
-            right: 20px;
-            background: #e8f5e9;
-            border: 2px solid #4caf50;
-            border-radius: 999px;
-            padding: 8px 20px;
-            color: #2e7d32;
-            font-size: 0.9rem;
-            font-weight: 500;
-            z-index: 100000;
-            opacity: 0;
-            transform: translateY(-10px);
-            transition: opacity 0.3s ease, transform 0.3s ease;
-            pointer-events: none;
-            box-shadow: 0 4px 12px rgba(76, 175, 80, 0.2);
-        }
-        .auto-save-toast.visible {
-            opacity: 1;
-            transform: translateY(0);
-        }
         /* 卡片左上角隐藏按钮 */
         .card-hide-corner {
             position: absolute;
@@ -711,6 +688,9 @@
 </div>
 </div>
 
+<!-- 全局非模态通知必须位于页面顶层，避免被任一隐藏的模态框连带隐藏。 -->
+<div id="message-area"></div>
+
 <!-- 上传到创意工坊模态框 -->
 <div id="uploadToWorkshopModal" class="modal" onclick="closeUploadModalOnOutsideClick(event)" style="display: none;">
 <div class="modal-content" onclick="event.stopPropagation()" style="max-width: 900px;">
@@ -719,8 +699,6 @@
 <button class="modal-close" onclick="closeUploadModal()">&times;</button>
 </div>
 <div class="modal-body" style="padding: 20px;">
-<div id="message-area"></div>
-                
 <div class="control-group">
 <div class="control-label" data-i18n="steam.title">标题</div>
 <div id="item-title" class="control-input" style="background-color: #f5f5f5; padding: 8px 12px; border-radius: 4px; min-height: 20px;"></div>

--- a/tests/unit/test_card_maker_static_contracts.py
+++ b/tests/unit/test_card_maker_static_contracts.py
@@ -62,6 +62,45 @@ def test_character_card_manager_parts_load_in_dependency_order():
     assert script_positions == sorted(script_positions)
 
 
+def test_character_card_import_keeps_non_blocking_progress_visible_until_completion():
+    core = (CHARACTER_CARD_MANAGER_JS_DIR / "core-and-upload.js").read_text(encoding="utf-8")
+    styles = (PROJECT_ROOT / "static" / "css" / "character_card_manager.css").read_text(encoding="utf-8")
+    template = (PROJECT_ROOT / "templates" / "character_card_manager.html").read_text(encoding="utf-8")
+    transfer = (CHARACTER_CARD_MANAGER_JS_DIR / "character-data-and-transfer.js").read_text(encoding="utf-8")
+    master_profile = (CHARACTER_CARD_MANAGER_JS_DIR / "master-profile.js").read_text(encoding="utf-8")
+    previews = (CHARACTER_CARD_MANAGER_JS_DIR / "model-previews.js").read_text(encoding="utf-8")
+    workshop = (CHARACTER_CARD_MANAGER_JS_DIR / "workshop-card-and-upload.js").read_text(encoding="utf-8")
+
+    assert template.count('id="message-area"') == 1
+    assert template.index('id="message-area"') < template.index('id="uploadToWorkshopModal"')
+    assert "messageArea.parentElement !== document.body" in core
+    assert "if (type !== 'importing')" in core
+    assert "const cfg = { icon: 'ccm-toast-spinner'" in core
+    assert "@keyframes ccm-toast-spin" in styles
+    assert "card.dismiss = dismiss;" in core
+    assert "showMessage(loadingText, 'importing', 0)" in transfer
+    assert "function showToast(" not in core
+    assert "showAutoSaveToast" not in master_profile
+    assert "auto-save-toast" not in template
+    assert "auto-save-toast" not in styles
+    assert "requestAnimationFrame(() => requestAnimationFrame(resolve))" in transfer
+    assert transfer.count("importNotice.dismiss();") == 2
+    assert "character.importCardSuccess" not in transfer
+    assert "steam.characterCardsRefreshed" not in transfer
+    assert "steam.scanningModels" not in workshop
+    assert "steam.scanningVoices" not in workshop
+    assert "steam.scanComplete" not in workshop
+    assert "steam.characterCardLoaded" not in workshop
+    assert "live2d.loadingModel" not in previews
+    assert "live2d.modelLoadSuccess" not in previews
+    assert "steam.vrmPreviewLoaded" not in previews
+    assert "steam.mmdPreviewLoaded" not in previews
+    assert "steam.live2dPreviewLoaded" not in previews
+    assert "character.importCardFailed" in transfer
+    assert "steam.voiceScanError" in workshop
+    assert "live2d.modelLoadFailed" in previews
+
+
 def test_model_manager_parts_load_in_dependency_order():
     discovered_names = {path.name for path in MODEL_MANAGER_JS_DIR.glob("*.js")}
     assert discovered_names == set(MODEL_MANAGER_PART_NAMES)

--- a/tests/unit/test_card_maker_static_contracts.py
+++ b/tests/unit/test_card_maker_static_contracts.py
@@ -74,11 +74,13 @@ def test_character_card_import_keeps_non_blocking_progress_visible_until_complet
     assert template.count('id="message-area"') == 1
     assert template.index('id="message-area"') < template.index('id="uploadToWorkshopModal"')
     assert "messageArea.parentElement !== document.body" in core
-    assert "if (type !== 'importing')" in core
-    assert "const cfg = { icon: 'ccm-toast-spinner'" in core
+    assert "if (type !== 'importing' && type !== 'import-error')" in core
+    assert "icon: 'ccm-toast-spinner'" in core
+    assert "icon: 'ccm-toast-error-icon'" in core
     assert "@keyframes ccm-toast-spin" in styles
     assert "card.dismiss = dismiss;" in core
     assert "showMessage(loadingText, 'importing', 0)" in transfer
+    assert "showMessage(errorText, 'import-error')" in transfer
     assert "function showToast(" not in core
     assert "showAutoSaveToast" not in master_profile
     assert "auto-save-toast" not in template


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复角色卡导入提示不可见问题，仅保留非阻塞的导入中提示，并清理其他冗余通知
（删除的提示为本来就不可见，不影响现有可见提示）

## 测试 / Testing

手动测试导入


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改进**
  - 优化角色卡导入：持续显示“导入中/导入失败”非阻塞提示，完成或出错后自动关闭，交互与无障碍表现更明确。
  - 精简提示：减少导入、模型扫描、音频加载与自动保存等过程中的重复成功通知。
  - 调整通知区域到页面顶部，避免被弹窗遮挡。
  - 模型预览与工坊加载成功不再弹出多余提示，状态照常更新。
- **样式**
  - 新增加载旋转动画，并在“减少动态效果”时自动停用；同时调整深色主题标签样式。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->