### PR TITLE
修复完整聊天框截图候选图片删除按钮重复显示叉号的问题，并补充回归测试

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -8610,6 +8610,22 @@ describe('App', () => {
     expect(onComposerRemoveAttachment).toHaveBeenCalledWith('img-1');
   });
 
+  it('renders a single CSS-drawn remove icon for full chat attachments', () => {
+    const { container } = render(
+      <App
+        chatSurfaceMode="full"
+        composerAttachments={[
+          { id: 'img-1', url: 'data:image/png;base64,aaa', alt: 'Screenshot 1' },
+        ]}
+      />,
+    );
+
+    const removeButton = screen.getByRole('button', { name: 'Remove image: Screenshot 1' });
+    expect(removeButton.textContent).toBe('');
+    expect(removeButton.childElementCount).toBe(0);
+    expect(container.querySelector('.composer-panel > .composer-attachments')).not.toBeNull();
+  });
+
   it('keeps pending composer attachments locked while the composer is disabled', () => {
     const onComposerRemoveAttachment = vi.fn();
 

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -5478,9 +5478,7 @@ function CompactChatApp({
                   onComposerRemoveAttachment?.(attachment.id);
                 }
               }}
-            >
-              <span className="composer-attachment-remove-icon" aria-hidden="true" />
-            </button>
+            />
           </figure>
         ))}
       </div>

--- a/frontend/react-neko-chat/src/FullChatSurface.tsx
+++ b/frontend/react-neko-chat/src/FullChatSurface.tsx
@@ -3061,9 +3061,7 @@ export default function FullChatSurface({
                         onComposerRemoveAttachment?.(attachment.id);
                       }
                     }}
-                  >
-                    ×
-                  </button>
+                  />
                 </figure>
               ))}
             </div>


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复完整聊天框截图候选图片删除按钮重复显示叉号的问题，并补充回归测试

## 测试 / Testing

手动截图查看UI

##  issues

解决[关于UI/UX的一些探讨](https://github.com/Project-N-E-K-O/N.E.K.O/issues/2414)中“聊天框待发送的图片有两个X”的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **样式**
  * 优化附件移除按钮的图标呈现，改为使用 CSS 绘制，界面显示更简洁一致。

* **Bug 修复**
  * 保留移除附件功能，点击按钮后仍可正常删除待上传图片。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->