### PR TITLE
补齐 Live2D 锁定按钮的自适应缩放，使 Live2D、VRM、MMD 的锁定按钮行为保持一致

### DIFF
--- a/static/live2d/live2d-ui-buttons.js
+++ b/static/live2d/live2d-ui-buttons.js
@@ -20,6 +20,13 @@ AvatarButtonMixin.apply(Live2DManager.prototype, 'live2d', {
 
 const LIVE2D_X11_UI_TICK_MS = 80;
 
+function getLive2DFloatingControlScale(modelHeight, baseToolbarHeight) {
+    const minScale = 0.5;
+    const maxScale = 1.0;
+    const rawScale = modelHeight / 2 / baseToolbarHeight;
+    return Math.round(Math.max(minScale, Math.min(maxScale, rawScale)) * 1000) / 1000;
+}
+
 function shouldThrottleLive2DUiTicker(manager) {
     return !!(window.__NEKO_DESKTOP_RUNTIME__ && window.__NEKO_DESKTOP_RUNTIME__.isLinuxX11) &&
         !(manager && manager._isDraggingModel);
@@ -179,6 +186,7 @@ Live2DManager.prototype.setupHTMLLockIcon = function(model) {
     // 否则模型位置与上次相同时首帧写入被跳过，图标停在 fixed 默认位置
     this._lockIconLastLeft = undefined;
     this._lockIconLastTop = undefined;
+    this._lockIconLastTransform = undefined;
     this._lockIconLastOpacity = undefined;
     this._lockIconLastOverlapScanAt = 0;
     this._lockIconElement = lockIcon;
@@ -221,13 +229,34 @@ Live2DManager.prototype.setupHTMLLockIcon = function(model) {
             const screenWidth = window.innerWidth;
             const screenHeight = window.innerHeight;
 
+            const baseButtonSize = 48;
+            const baseGap = 12;
+            const buttonCount = 5;
+            const baseToolbarHeight = baseButtonSize * buttonCount + baseGap * (buttonCount - 1);
+            const modelHeight = bounds.bottom - bounds.top;
+            const scale = isMobileWidth()
+                ? 1
+                : getLive2DFloatingControlScale(modelHeight, baseToolbarHeight);
+            const nextTransform = `scale(${scale})`;
+            if (nextTransform !== this._lockIconLastTransform) {
+                this._lockIconLastTransform = nextTransform;
+                lockIcon.style.transformOrigin = 'left top';
+                lockIcon.style.transform = nextTransform;
+            }
+
+            const baseLockIconSize = 32;
+            const actualLockIconSize = baseLockIconSize * scale;
+            const viewportEdgePadding = 8;
+
             const targetX = bounds.right * 0.7 + bounds.left * 0.3;
             const targetY = bounds.top * 0.3 + bounds.bottom * 0.7;
 
+            const defaultMaxLockTop = screenHeight - actualLockIconSize - viewportEdgePadding;
             const maxLockTop = typeof window.getNekoYuiGuideLockIconMaxTop === 'function'
-                ? window.getNekoYuiGuideLockIconMaxTop(screenHeight - 40, 40)
-                : screenHeight - 40;
-            const clampedLeft = Math.round(Math.max(0, Math.min(targetX, screenWidth - 40)));
+                ? window.getNekoYuiGuideLockIconMaxTop(defaultMaxLockTop, actualLockIconSize)
+                : defaultMaxLockTop;
+            const maxLockLeft = screenWidth - actualLockIconSize - viewportEdgePadding;
+            const clampedLeft = Math.round(Math.max(0, Math.min(targetX, maxLockLeft)));
             const clampedTop = Math.round(Math.max(0, Math.min(targetY, maxLockTop)));
             // 位置无变化时跳过 style 写入，避免每帧无谓的样式失效
             if (clampedLeft !== this._lockIconLastLeft || clampedTop !== this._lockIconLastTop) {
@@ -238,8 +267,8 @@ Live2DManager.prototype.setupHTMLLockIcon = function(model) {
             }
 
             // 重叠检测节流到 250ms：纯装饰性淡出（opacity 0.3），不需要逐帧
-            // 扫两遍 DOM。矩形用已知坐标 + 固定 32px 尺寸推算（图标 position:fixed
-            // 无变换），避免每帧 getBoundingClientRect 强制布局。
+            // 扫两遍 DOM。矩形用已知坐标 + 缩放后的实际尺寸推算，避免每帧
+            // getBoundingClientRect 强制布局。
             const nowTs = performance.now();
             let isOverlapped = this._lockIconLastOverlapped === true;
             if (!this._lockIconLastOverlapScanAt || nowTs - this._lockIconLastOverlapScanAt >= 250) {
@@ -247,8 +276,8 @@ Live2DManager.prototype.setupHTMLLockIcon = function(model) {
                 const lockRect = {
                     left: clampedLeft,
                     top: clampedTop,
-                    right: clampedLeft + 32,
-                    bottom: clampedTop + 32
+                    right: clampedLeft + actualLockIconSize,
+                    bottom: clampedTop + actualLockIconSize
                 };
                 isOverlapped = false;
                 document.querySelectorAll('[id^="live2d-popup-"]').forEach(popup => {
@@ -682,13 +711,8 @@ Live2DManager.prototype.setupFloatingButtons = function(model) {
             const modelCenterY = (bounds.top + bounds.bottom) / 2;
 
             const modelHeight = bounds.bottom - bounds.top;
-            const targetToolbarHeight = modelHeight / 2;
-
-            const minScale = 0.5;
-            const maxScale = 1.0;
-            const rawScale = targetToolbarHeight / baseToolbarHeight;
             // scale 量化到千分位，避免呼吸抖动击穿 transform 脏检查
-            const scale = Math.round(Math.max(minScale, Math.min(maxScale, rawScale)) * 1000) / 1000;
+            const scale = getLive2DFloatingControlScale(modelHeight, baseToolbarHeight);
             const rotation = Number(this._floatingButtonsRotationRadians) || 0;
             const rotateTransform = rotation ? ` rotate(${rotation}rad)` : '';
 

--- a/static/live2d/live2d-ui-buttons.js
+++ b/static/live2d/live2d-ui-buttons.js
@@ -19,6 +19,12 @@ AvatarButtonMixin.apply(Live2DManager.prototype, 'live2d', {
 });
 
 const LIVE2D_X11_UI_TICK_MS = 80;
+const LIVE2D_FLOATING_BUTTON_SIZE = 48;
+const LIVE2D_FLOATING_BUTTON_GAP = 12;
+const LIVE2D_FLOATING_BUTTON_COUNT = 5;
+const LIVE2D_BASE_TOOLBAR_HEIGHT =
+    LIVE2D_FLOATING_BUTTON_SIZE * LIVE2D_FLOATING_BUTTON_COUNT +
+    LIVE2D_FLOATING_BUTTON_GAP * (LIVE2D_FLOATING_BUTTON_COUNT - 1);
 
 function getLive2DFloatingControlScale(modelHeight, baseToolbarHeight) {
     const minScale = 0.5;
@@ -229,14 +235,10 @@ Live2DManager.prototype.setupHTMLLockIcon = function(model) {
             const screenWidth = window.innerWidth;
             const screenHeight = window.innerHeight;
 
-            const baseButtonSize = 48;
-            const baseGap = 12;
-            const buttonCount = 5;
-            const baseToolbarHeight = baseButtonSize * buttonCount + baseGap * (buttonCount - 1);
             const modelHeight = bounds.bottom - bounds.top;
             const scale = isMobileWidth()
                 ? 1
-                : getLive2DFloatingControlScale(modelHeight, baseToolbarHeight);
+                : getLive2DFloatingControlScale(modelHeight, LIVE2D_BASE_TOOLBAR_HEIGHT);
             const nextTransform = `scale(${scale})`;
             if (nextTransform !== this._lockIconLastTransform) {
                 this._lockIconLastTransform = nextTransform;
@@ -680,11 +682,6 @@ Live2DManager.prototype.setupFloatingButtons = function(model) {
 
     container.style.pointerEvents = this.isLocked ? 'none' : 'auto';
 
-    const baseButtonSize = 48;
-    const baseGap = 12;
-    const buttonCount = 5;
-    const baseToolbarHeight = baseButtonSize * buttonCount + baseGap * (buttonCount - 1);
-
     const tick = () => {
         try {
             if (shouldSkipLive2DUiTick(this, '_x11FloatingButtonsLastTickAt', LIVE2D_X11_UI_TICK_MS)) {
@@ -712,7 +709,7 @@ Live2DManager.prototype.setupFloatingButtons = function(model) {
 
             const modelHeight = bounds.bottom - bounds.top;
             // scale 量化到千分位，避免呼吸抖动击穿 transform 脏检查
-            const scale = getLive2DFloatingControlScale(modelHeight, baseToolbarHeight);
+            const scale = getLive2DFloatingControlScale(modelHeight, LIVE2D_BASE_TOOLBAR_HEIGHT);
             const rotation = Number(this._floatingButtonsRotationRadians) || 0;
             const rotateTransform = rotation ? ` rotate(${rotation}rad)` : '';
 
@@ -720,7 +717,7 @@ Live2DManager.prototype.setupFloatingButtons = function(model) {
 
             const targetX = bounds.right * 0.8 + bounds.left * 0.2;
 
-            const actualToolbarHeight = baseToolbarHeight * scale;
+            const actualToolbarHeight = LIVE2D_BASE_TOOLBAR_HEIGHT * scale;
             const actualToolbarWidth = 80 * scale;
 
             const targetY = modelCenterY - actualToolbarHeight / 2;

--- a/tests/unit/test_avatar_floating_button_layout_static.py
+++ b/tests/unit/test_avatar_floating_button_layout_static.py
@@ -40,8 +40,10 @@ def test_avatar_floating_button_rows_keep_fixed_height_when_aux_controls_toggle(
     # Live2D positions the toolbar from five 48px rows plus four 12px gaps.
     # The row wrapper must keep that height even when the mic mute button or
     # popup trigger is shown, otherwise the vertical toolbar visibly contracts.
-    assert "const baseButtonSize = 48;" in live2d_source
-    assert "const baseGap = 12;" in live2d_source
+    assert "const LIVE2D_FLOATING_BUTTON_SIZE = 48;" in live2d_source
+    assert "const LIVE2D_FLOATING_BUTTON_GAP = 12;" in live2d_source
+    assert "const LIVE2D_FLOATING_BUTTON_COUNT = 5;" in live2d_source
+    assert "const LIVE2D_BASE_TOOLBAR_HEIGHT =" in live2d_source
     assert "height: '48px'" in wrapper_block
     assert "minHeight: '48px'" in wrapper_block
     assert "flex: '0 0 48px'" in wrapper_block
@@ -70,7 +72,7 @@ def test_live2d_lock_icon_tracks_the_floating_toolbar_scale():
         "Live2DManager.prototype.setupFloatingButtons = function(model) {"
     ):]
 
-    scale_call = "getLive2DFloatingControlScale(modelHeight, baseToolbarHeight)"
+    scale_call = "getLive2DFloatingControlScale(modelHeight, LIVE2D_BASE_TOOLBAR_HEIGHT)"
     assert scale_call in lock_icon_block
     assert scale_call in floating_buttons_block
     assert "lockIcon.style.transform = nextTransform;" in lock_icon_block

--- a/tests/unit/test_avatar_floating_button_layout_static.py
+++ b/tests/unit/test_avatar_floating_button_layout_static.py
@@ -58,6 +58,28 @@ def test_avatar_floating_button_rows_keep_fixed_height_when_aux_controls_toggle(
     assert "transform: 'translateY(-50%)'" in mute_button_block
 
 
+def test_live2d_lock_icon_tracks_the_floating_toolbar_scale():
+    source = LIVE2D_UI_BUTTONS_PATH.read_text(encoding="utf-8")
+    lock_icon_block = _source_slice_between(
+        source,
+        "Live2DManager.prototype.setupHTMLLockIcon = function(model) {",
+        "Live2DManager.prototype.setupFloatingButtons = function(model) {",
+        "Live2D lock icon setup",
+    )
+    floating_buttons_block = source[source.find(
+        "Live2DManager.prototype.setupFloatingButtons = function(model) {"
+    ):]
+
+    scale_call = "getLive2DFloatingControlScale(modelHeight, baseToolbarHeight)"
+    assert scale_call in lock_icon_block
+    assert scale_call in floating_buttons_block
+    assert "lockIcon.style.transform = nextTransform;" in lock_icon_block
+    assert "const actualLockIconSize = baseLockIconSize * scale;" in lock_icon_block
+    assert "window.getNekoYuiGuideLockIconMaxTop(defaultMaxLockTop, actualLockIconSize)" in lock_icon_block
+    assert "right: clampedLeft + actualLockIconSize" in lock_icon_block
+    assert "bottom: clampedTop + actualLockIconSize" in lock_icon_block
+
+
 def test_interpage_restore_keeps_floating_button_containers_in_flex_layout():
     source = read_js_parts(APP_INTERPAGE_PATH)
     restore_block = _source_slice_between(


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

补齐 Live2D 锁定按钮的自适应缩放，使 Live2D、VRM、MMD 的锁定按钮行为保持一致

## 测试 / Testing

手动测试缩放

## issues

解决[关于UI/UX的一些探讨](https://github.com/Project-N-E-K-O/N.E.K.O/issues/2414)中“操作按钮设计”部分的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改进**
  - 统一 Live2D 浮动按钮与锁定图标的缩放基准与计算结果，锁定图标的 transform 更新会基于一致的缩放值。
  - 锁定图标的尺寸、最大可放置位置与重叠检测现已按实际缩放后的图标尺寸重新推导，提升不同模型高度下的布局准确性。

- **测试**
  - 增加静态校验，确认相关缩放函数在浮动按钮与锁定图标逻辑中一致调用，并验证图标尺寸与边界计算联动正确。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->