### PR TITLE
feat: 添加把文件拖动到聊天框作为文件读取的逻辑

### DIFF
--- a/static/app/app-buttons.js
+++ b/static/app/app-buttons.js
@@ -3727,7 +3727,7 @@
             var files = getFilesFromDataTransfer(e.dataTransfer);
             var imageFiles = [];
             var otherFiles = [];
-            Array.from(files).forEach(function (f) {
+            files.forEach(function (f) {
                 if (f instanceof File && isLikelyImageFile(f)) {
                     imageFiles.push(f);
                 } else {

--- a/static/app/app-buttons.js
+++ b/static/app/app-buttons.js
@@ -3707,7 +3707,6 @@
             }
         });
 
-        // 图片文件拖到聊天框时按「导入图片」处理，避免浏览器默认打开本地文件。
         document.addEventListener('dragover', function (e) {
             if (!shouldHandleChatFileDrop(e)) return;
             e.preventDefault();
@@ -3717,7 +3716,7 @@
             }
         }, true);
 
-        document.addEventListener('drop', function (e) {
+        document.addEventListener('drop', async function (e) {
             if (!shouldHandleChatFileDrop(e)) return;
             e.preventDefault();
             e.stopPropagation();
@@ -3726,7 +3725,37 @@
                 return;
             }
             var files = getFilesFromDataTransfer(e.dataTransfer);
-            mod.importImageFilesToPendingList(files, { logPrefix: '[拖放图片]' });
+            var imageFiles = [];
+            var otherFiles = [];
+            Array.from(files).forEach(function (f) {
+                if (f instanceof File && isLikelyImageFile(f)) {
+                    imageFiles.push(f);
+                } else {
+                    otherFiles.push(f);
+                }
+            });
+            if (imageFiles.length > 0) {
+                mod.importImageFilesToPendingList(imageFiles, { logPrefix: '[拖放图片]' });
+            }
+            if (otherFiles.length > 0) {
+                try {
+                    var parser = window.NekoAvatarDropParser;
+                    if (parser && typeof parser.parseFiles === 'function') {
+                        var result = await parser.parseFiles(otherFiles);
+                        var accepted = result && Array.isArray(result.accepted) ? result.accepted : [];
+                        var rejected = result && Array.isArray(result.rejected) ? result.rejected : [];
+                        if (accepted.length > 0 || rejected.length > 0) {
+                            await mod.sendAvatarDropPayload({
+                                items: accepted,
+                                targetType: 'chat',
+                                rejected: rejected
+                            });
+                        }
+                    }
+                } catch (error) {
+                    console.warn('[ChatDrop] non-image file parse failed:', error && error.message ? error.message : error);
+                }
+            }
         }, true);
 
         mod.ensureImportImageInput();

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -673,6 +673,7 @@
     <script src="/static/app/app-websocket.js?v={{ static_asset_version }}"></script>
     <script src="/static/app/app-telemetry.js?v={{ static_asset_version }}"></script>
     <script src="/static/app/app-buttons.js?v={{ react_chat_asset_version }}"></script>
+    <script src="/static/avatar/avatar-drop-parser.js?v={{ static_asset_version }}"></script>
     <script src="/static/app/app.js?v={{ static_asset_version }}"></script>
     <script src="/static/subtitle/subtitle.js?v={{ static_asset_version }}"></script>
 

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -2630,7 +2630,10 @@ def test_chat_image_file_drop_uses_import_pipeline_and_blocks_browser_navigation
     assert "e.preventDefault();" in drop_block
     assert "e.stopPropagation();" in drop_block
     assert "showHomeTutorialLockedToast();" in drop_block
-    assert "mod.importImageFilesToPendingList(files, { logPrefix: '[拖放图片]' });" in drop_block
+    assert "mod.importImageFilesToPendingList(imageFiles, { logPrefix: '[拖放图片]' });" in drop_block
+    assert "window.NekoAvatarDropParser" in drop_block
+    assert "parser.parseFiles(otherFiles)" in drop_block
+    assert "mod.sendAvatarDropPayload" in drop_block
 
 
 def test_chat_composer_user_images_use_text_attachment_input_type():


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

#2367
文件可以拖给猫娘，不能拖给聊天窗口，这不公平喵
新增一个判断，如果拖进去的不是图片，就用喂文件给猫娘的同款逻辑处理
AI还顺便改了个`tests\unit\test_react_chat_window_static.py`以匹配新的更改，人工看了一下没什么问题

## 回归报告 / Regression Report

<!--
仅当本 PR 触碰 app/、main_logic/、memory/ 时必填。请逐项说明：
  - 改动了什么
  - 理由 / 必要性
  - 改动前后的表现对比
  - 潜在回归点（影响哪些链路、怎么验证的）
未触碰这三个模块：写「不适用」或删除本节。
-->

## 不拆分理由 / Why Not Split

<!--
仅当本 PR 改动计入上限的文件 > 20 个时必填：为什么不拆成多个更小的 PR。
计入上限的文件数 ≤ 20：写「不适用」或删除本节。（新增文件、i18n locale 文件、测试文件不计入这个上限）
-->

## 测试 / Testing

<!-- 怎么验证的：跑了哪些测试、手动验证了哪些场景。 -->
手动验证通过
`tests/unit/test_react_chat_window_static.py` 通过
`tests/unit/test_avatar_drop_frontend_static.py` 通过


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 聊天窗口拖放时支持对拖入文件进行分类处理：图片会自动进入待发送截图/图片列表。
  * 非图片文件会通过拖放解析器进行解析后再发送；解析失败的文件会原样保留在发送结果中。
* **Bug Fixes**
  * 修复拖放处理由同步改为异步后的流程不完整问题，避免非图片文件无法正确转发。
* **测试**
  * 更新并新增相关单元测试，覆盖图片导入与非图片解析发送路径。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->