### PR TITLE
fix(chat): stabilize hover and desktop minimized chat

### DIFF
--- a/static/app/app-react-chat-window/minimize-and-idle-dock.js
+++ b/static/app/app-react-chat-window/minimize-and-idle-dock.js
@@ -531,6 +531,17 @@
         nextBounds = clampElectronDockBounds(nextBounds, I.electronIdleDockWorkArea);
         if (positionSeq !== I.electronIdleDockPositionSeq || !I.electronIdleDockActive || !I.electronIdleDockDesired) return;
 
+        if (typeof bridge.idleDockCommitCollapsedBounds === 'function') {
+            var committedBounds = null;
+            try {
+                committedBounds = await bridge.idleDockCommitCollapsedBounds(nextBounds);
+            } catch (_) {
+                committedBounds = null;
+            }
+            if (positionSeq !== I.electronIdleDockPositionSeq || !I.electronIdleDockActive || !I.electronIdleDockDesired) return;
+            rememberElectronIdleDockBounds(committedBounds || nextBounds);
+            return;
+        }
         bridge.setBounds(nextBounds.x, nextBounds.y, nextBounds.width, nextBounds.height);
         rememberElectronIdleDockBounds(nextBounds);
     }
@@ -558,6 +569,13 @@
 
     function shouldIgnoreElectronIdleDockInactiveViewportResize(detail, activeTier) {
         return !!(detail && detail.reason === 'viewport-resize' && !activeTier);
+    }
+
+    function shouldIgnoreElectronIdleDockTransientDragHide(detail) {
+        if (!detail || detail.visible) return false;
+        return detail.reason === 'return-ball-drag-start'
+            || detail.reason === 'return-ball-drag-active'
+            || detail.reason === 'return-ball-dragging';
     }
 
     function waitElectronIdleDockCommitRetry(delayMs) {
@@ -793,10 +811,17 @@
             return;
         }
         if (I.hasElectronIdleDockPendingOrActive()) {
+            // Pet 在把 return-ball 交给原生拖动窗口时会暂时把 DOM 容器设为不可见；
+            // 这是拖动中的中间帧，不是 idle-dock 退出信号，不能在这里恢复旧 bounds。
+            if (shouldIgnoreElectronIdleDockTransientDragHide(detail)) {
+                return;
+            }
             if (shouldIgnoreElectronIdleDockInactiveViewportResize(detail, activeTier)) {
                 return;
             }
-            var shouldPreserveCurrentPosition = activeTier && detail && (
+            // CAT2 拖动结束会先降级成 CAT1；此时 activeTier 已为 false。是否保留落点
+            // 必须由终止事件语义决定，不能再依赖降级后的最终 tier。
+            var shouldPreserveCurrentPosition = detail && !!detail.screenRect && (
                 detail.reason === 'return-ball-drag-demotion'
                 || detail.reason === 'return-ball-drag-end'
             );

--- a/static/app/app-react-chat-window/minimize-and-idle-dock.js
+++ b/static/app/app-react-chat-window/minimize-and-idle-dock.js
@@ -539,8 +539,10 @@
                 committedBounds = null;
             }
             if (positionSeq !== I.electronIdleDockPositionSeq || !I.electronIdleDockActive || !I.electronIdleDockDesired) return;
-            rememberElectronIdleDockBounds(committedBounds || nextBounds);
-            return;
+            if (committedBounds !== false && committedBounds !== null && committedBounds !== undefined) {
+                rememberElectronIdleDockBounds(committedBounds);
+                return;
+            }
         }
         bridge.setBounds(nextBounds.x, nextBounds.y, nextBounds.width, nextBounds.height);
         rememberElectronIdleDockBounds(nextBounds);

--- a/static/avatar/avatar-ui-buttons/methods-return.js
+++ b/static/avatar/avatar-ui-buttons/methods-return.js
@@ -58,8 +58,12 @@ Object.assign(AvatarButtonMixin.methods, {
                 }
             });
 
-            returnBtn.addEventListener('mouseleave', (event) => {
-                if (_isNekoIdleThoughtBubbleEventHit(returnBtn, event)) return;
+            returnBtn.addEventListener('mouseleave', () => {
+                if (!returnArt.__nekoIdleHoverSrc) return;
+                // The active thought bubble is a child of the return button. When its
+                // pop animation disables pointer events, Chromium emits the button's
+                // real mouseleave at the bubble coordinates. Reusing the bubble hit
+                // guard here would suppress the only hover-completion signal.
                 const tier = returnBtn.getAttribute('data-neko-idle-tier');
                 if (tier && tier !== 'none') {
                     _finishNekoIdleHoverArtAfterPlayback(returnArt, tier);

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -709,6 +709,9 @@
 
         // BALL: 折叠态毛线球窗口总尺寸（CSS .minimized 51px 内容 + 32px Electron 窗口边框/透明余量）
         var BALL = 83;
+        // NEKO-PC full 折叠由主进程落成 88×88；保留 2px DWM/缩放取整容差。
+        // 不能复用 BALL + 4（87），否则页面重载时会把真实 88px 球误判为展开窗口并撑高。
+        var ELECTRON_COLLAPSED_MAX_SIZE = 90;
         var MIN_W = 300;
         var MIN_H_BASE = 200;
         // GalGame 模式开启时输入框需要额外 ~110px 容纳 A/B/C 选项 + 间距，
@@ -759,7 +762,7 @@
                 W.getBounds().then(function(b) {
                     if (!b) return;
                     if (isReactElectronCollapsed()) return;
-                    if (b.width <= BALL + 4 && b.height <= BALL + 4) return;
+                    if (b.width <= ELECTRON_COLLAPSED_MAX_SIZE && b.height <= ELECTRON_COLLAPSED_MAX_SIZE) return;
                     if (b.height >= minH) return;
                     W.setBounds(b.x, b.y, b.width, minH);
                 });

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -2954,6 +2954,19 @@ def test_idle_thought_bubble_is_sound_triggered_with_fade():
     assert "returnBtn.addEventListener('mouseenter', (event) => {" in source
     assert "if (_isNekoIdleThoughtBubbleEventHit(returnBtn, event)) return;" in source
     assert "_playNekoIdleHoverArt(returnArt, tier, { userInitiated: true });" in source
+    hover_leave_block = _source_slice_between(
+        source,
+        "returnBtn.addEventListener('mouseleave', () => {",
+        "returnBtn.addEventListener('click', (e) => {",
+        "return button hover leave completion",
+    )
+    assert "_isNekoIdleThoughtBubbleEventHit" not in hover_leave_block
+    _assert_source_order(
+        hover_leave_block,
+        "return button only completes an active hover",
+        "if (!returnArt.__nekoIdleHoverSrc) return;",
+        "_finishNekoIdleHoverArtAfterPlayback(returnArt, tier);",
+    )
     native_drag_block = _source_slice_between(
         app_ui_source,
         "function isThoughtBubbleEventTarget(event) {",

--- a/tests/unit/test_react_chat_idle_dock_static.py
+++ b/tests/unit/test_react_chat_idle_dock_static.py
@@ -126,6 +126,17 @@ def test_electron_idle_dock_uses_desktop_return_ball_bridge():
     assert "preserveScreenRect" in source
     assert "idleDockCommitCollapsedBounds" in source
     assert "await bridge.idleDockCommitCollapsedBounds(nextBounds)" in source
+    apply_position_block = _between(
+        source,
+        "async function applyElectronIdleDockPosition() {",
+        "function clearElectronIdleDockRetry() {",
+    )
+    assert "committedBounds !== false && committedBounds !== null && committedBounds !== undefined" in apply_position_block
+    assert "rememberElectronIdleDockBounds(committedBounds);" in apply_position_block
+    assert "rememberElectronIdleDockBounds(committedBounds || nextBounds);" not in apply_position_block
+    assert apply_position_block.index("bridge.setBounds(nextBounds.x") > apply_position_block.index(
+        "committedBounds !== false"
+    )
     assert "clampElectronDockBounds(preserveBounds, workArea)" in source
     assert "HOME_IDLE_DOCK_GAP" in source
 

--- a/tests/unit/test_react_chat_idle_dock_static.py
+++ b/tests/unit/test_react_chat_idle_dock_static.py
@@ -125,8 +125,36 @@ def test_electron_idle_dock_uses_desktop_return_ball_bridge():
     assert "idle-dock-exit-preserve" in source
     assert "preserveScreenRect" in source
     assert "idleDockCommitCollapsedBounds" in source
+    assert "await bridge.idleDockCommitCollapsedBounds(nextBounds)" in source
     assert "clampElectronDockBounds(preserveBounds, workArea)" in source
     assert "HOME_IDLE_DOCK_GAP" in source
+
+    handler_block = _between(
+        source,
+        "handleElectronIdleReturnBallState = function handleElectronIdleReturnBallState(detail) {",
+        "// Enter idle-dock: minimize if needed, then position next to return-ball.",
+    )
+    assert "shouldIgnoreElectronIdleDockTransientDragHide(detail)" in handler_block
+    assert "var shouldPreserveCurrentPosition = detail && !!detail.screenRect && (" in handler_block
+    assert "var shouldPreserveCurrentPosition = activeTier && detail" not in handler_block
+
+    transient_drag_block = _between(
+        source,
+        "function shouldIgnoreElectronIdleDockTransientDragHide(detail) {",
+        "function waitElectronIdleDockCommitRetry(delayMs) {",
+    )
+    assert "detail.reason === 'return-ball-drag-start'" in transient_drag_block
+    assert "detail.reason === 'return-ball-drag-active'" in transient_drag_block
+    assert "detail.reason === 'return-ball-dragging'" in transient_drag_block
+
+
+def test_full_chat_min_height_guard_recognizes_native_88px_collapsed_window():
+    source = CHAT_TEMPLATE_PATH.read_text(encoding="utf-8")
+
+    assert "var ELECTRON_COLLAPSED_MAX_SIZE = 90;" in source
+    assert "b.width <= ELECTRON_COLLAPSED_MAX_SIZE" in source
+    assert "b.height <= ELECTRON_COLLAPSED_MAX_SIZE" in source
+    assert "b.width <= BALL + 4 && b.height <= BALL + 4" not in source
 
 
 def test_app_ui_broadcasts_return_ball_screen_rect_for_desktop_idle_dock():
@@ -580,7 +608,8 @@ def test_idle_dock_exit_clears_cat2_to_cat1_drag_binding():
     assert "async function commitElectronIdleDockCollapsedBounds(bridge, bounds, generation)" in source
     assert "result !== false && result !== null && result !== undefined" in source
     assert "await waitElectronIdleDockCommitRetry(80)" in source
-    assert "activeTier && detail && (" in source
+    assert "var shouldPreserveCurrentPosition = detail && !!detail.screenRect && (" in source
+    assert "activeTier && detail && (" not in source
     assert "preserveScreenRect: shouldPreserveCurrentPosition ? detail.screenRect : null" in source
     assert "await commitElectronIdleDockCollapsedBounds(bridge, preserveBounds, exitGeneration)" in source
     assert "wasActive && saved && !preserveCurrentPosition" in source


### PR DESCRIPTION
## 改动概述 / Summary

本 PR 修复桌面端猫 idle 交互与聊天框最小化链路中的四个问题：

1. **思考气泡结束后，猫的 hover/click 画面无法正常恢复**
   - 表现：思考气泡播放并消失后，猫仍停留在 hover 或点击画面。
   - 根因：气泡关闭时会触发真实的 `mouseleave`，但该事件被气泡命中保护误判并拦截，导致 hover 收尾逻辑没有执行。

2. **CAT2/CAT3 停靠后，毛线球位置与猫不一致**
   - 表现：猫进入睡眠等 idle 状态后，聊天框对应的毛线球仍停留在原位置。
   - 根因：idle-dock 只更新了隐藏聊天 carrier 的窗口位置，没有通过桌面桥同步提交外置毛线球的位置。

3. **拖拽 CAT2/CAT3 猫并降级到 CAT1 后，毛线球跳回旧位置**
   - 表现：拖动猫到新位置并触发 CAT1 后，毛线球没有保留新落点，而是恢复到拖拽前的位置。
   - 根因：拖拽开始时的临时隐藏被误认为 idle-dock 退出；同时，原有落点保留条件依赖最终仍处于 CAT2/CAT3，无法覆盖 CAT2→CAT1 的降级结果。

4. **完整聊天框折叠后刷新会变成窄条**
   - 表现：完整聊天框以毛线球形态折叠后刷新，窗口可能从 `88×88` 被撑成约 `88×385`，视觉上近似消失。
   - 根因：页面仍按旧的 `87px` 上限识别折叠窗口，无法识别桌面主进程实际使用的 `88×88` 尺寸，随后错误执行了聊天框最小高度修正。

PC侧适配：https://github.com/Project-N-E-K-O/N.E.K.O.-PC/pull/367

## 回归报告 / Regression Report

不适用。本 PR 未修改 `app/`、`main_logic/`、`main_routers/` 或 `memory/` 下的 Python 文件。

## 不拆分理由 / Why Not Split

不适用。本 PR 共修改 5 个文件，其中 2 个为测试文件，计入上限的文件为 3 个，未超过 20 个。

## 测试 / Testing

- `.venv/Scripts/python.exe -m pytest tests/unit/test_react_chat_idle_dock_static.py tests/unit/test_cat_idle_state_machine_static.py tests/unit/test_react_chat_window_static.py -q`：148 passed。
- `.venv/Scripts/python.exe -m pytest tests/unit/test_avatar_return_button_idle_tiers_static.py::test_idle_thought_bubble_is_sound_triggered_with_fade -q`：1 passed。
- 桌面端真实 Electron 验证：完整聊天框折叠为 `88×88` 后刷新仍保持折叠态，并可恢复原尺寸。
- 桌面端真实 Electron 验证：紧凑聊天框自动最小化后，外置毛线球与 carrier 在 CAT2 停靠、拖拽临时隐藏及 CAT2→CAT1 降级过程中保持同步，且不再回跳旧位置。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化桌面独立窗口折叠后的定位与尺寸识别，减少窗口被意外撑大或位置恢复异常。
  * 修复拖拽返回球过程中可能出现的闪烁、误退出及位置跳回问题。
  * 改善返回按钮悬停结束后的动画收尾，减少鼠标移出时的异常触发。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->