### PR TITLE
Fix DataForSEO report artifact upload

### DIFF
--- a/.github/workflows/dataforseo.yml
+++ b/.github/workflows/dataforseo.yml
@@ -131,5 +131,6 @@ jobs:
         with:
           name: dataforseo-report-${{ github.run_id }}
           path: docs/.seo-reports/*.json
-          if-no-files-found: ignore
+          if-no-files-found: error
+          include-hidden-files: true
           retention-days: 14


### PR DESCRIPTION
## Summary

- allow `actions/upload-artifact` to include reports stored under the hidden `docs/.seo-reports/` directory
- fail the workflow when an expected report is missing instead of silently completing without an artifact

## Root cause and impact

The DataForSEO CLI correctly wrote its JSON report to `docs/.seo-reports/`, but `actions/upload-artifact@v4` defaults `include-hidden-files` to `false`. Both dry-run and paid workflows therefore completed successfully while the Actions summary showed no downloadable artifact. The paid API request itself was unaffected, but its report was lost when the hosted runner was removed.

## Regression Report

Not applicable. This PR changes only the DataForSEO GitHub Actions artifact upload settings and does not touch application runtime code.

## Why Not Split

Not applicable. This is a single-file workflow fix.

## Testing

- `npm run test:dataforseo` (17 passed)
- `npm run seo:dataforseo -- --dry-run --output .seo-reports/dataforseo-artifact-test.json`
- verified the dry-run report is created inside the hidden `.seo-reports` directory
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **修复**
  * 优化报告文件上传流程：找不到报告文件时将明确提示错误，避免流程静默跳过。
  * 上传报告时现已包含隐藏文件，确保相关产物完整保存。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->