### PR TITLE
fix(docs): restore GA4 event delivery

### DIFF
--- a/docs/.vitepress/theme/analytics-consent.mjs
+++ b/docs/.vitepress/theme/analytics-consent.mjs
@@ -105,8 +105,8 @@ export function setAnalyticsConsent(
 
 function installGtag(windowObject) {
   windowObject.dataLayer = windowObject.dataLayer || []
-  windowObject.gtag = windowObject.gtag || function gtag(...args) {
-    windowObject.dataLayer.push(args)
+  windowObject.gtag = windowObject.gtag || function gtag() {
+    windowObject.dataLayer.push(arguments)
   }
   return windowObject.gtag
 }

--- a/docs/scripts/analytics-consent.test.mjs
+++ b/docs/scripts/analytics-consent.test.mjs
@@ -138,7 +138,12 @@ test('granting consent queues consent before measurement and loads one tag', asy
   )
 
   const commands = fixture.windowObject.dataLayer
-  assert.deepEqual(commands.slice(0, 5).map((command) => command.slice(0, 2)), [
+  assert.equal(Array.isArray(commands[0]), false)
+  assert.equal(Object.prototype.toString.call(commands[0]), '[object Arguments]')
+  const queuedCommands = commands.slice(0, 5).map(
+    (command) => Array.from(command).slice(0, 2),
+  )
+  assert.deepEqual(queuedCommands, [
     ['consent', 'default'],
     ['consent', 'update'],
     ['js', commands[2][1]],
@@ -201,7 +206,7 @@ test('a cross-tab denial immediately disables active analytics', async () => {
   assert.equal(analytics.trackAnalyticsPageView('/plugins/', fixture), false)
   assert.equal(fixture.reloadCount(), 1)
   assert.deepEqual(
-    fixture.windowObject.dataLayer.at(-1).slice(0, 2),
+    Array.from(fixture.windowObject.dataLayer.at(-1)).slice(0, 2),
     ['consent', 'update'],
   )
   assert.equal(
@@ -223,7 +228,7 @@ test('revoking active analytics stores denial and reloads without a second tag',
   assert.equal(fixture.reloadCount(), 1)
   assert.equal(fixture.elements.size, 1)
   assert.deepEqual(
-    fixture.windowObject.dataLayer.at(-1).slice(0, 2),
+    Array.from(fixture.windowObject.dataLayer.at(-1)).slice(0, 2),
     ['consent', 'update'],
   )
   assert.equal(


### PR DESCRIPTION
## Summary

Fix GA4 delivery on the documentation site after analytics consent is granted.

## Root cause

The local `gtag` shim queued each command as a plain array created by a rest parameter. Google's supported bootstrap queues the function's `arguments` object instead. The Google tag script loaded successfully, but did not consume the queued commands, so no `g/collect` request was emitted and GA4 Realtime remained empty.

This change restores the official queue shape while keeping the existing consent ordering, disabled advertising storage, manual SPA page views, and single-script guard unchanged.

Reference: https://developers.google.com/tag-platform/gtagjs

## Regression Report

Not applicable to `app/`, `main_logic/`, or `memory/`. A regression assertion now verifies that queued commands are `[object Arguments]`, and the consent/revocation assertions handle the resulting array-like values.

## Why Not Split

Not applicable. This is one atomic runtime correction plus its regression test.

## Testing

- `npm run test:analytics` — 7/7 passed
- `npm test` — 32/32 passed
- `npm run build` — VitePress production build completed
- `git diff --check` — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进分析同意队列中事件命令的处理方式，确保数据层能够正确接收和识别分析事件。
  * 优化同意、拒绝及撤销操作相关的分析事件验证，提升统计功能的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->