### PR TITLE
将创意工坊上传结果页及 OpenClaw 教程外链改为使用系统默认浏览器打开

### DIFF
--- a/static/js/character_card_manager/core-and-upload.js
+++ b/static/js/character_card_manager/core-and-upload.js
@@ -1771,6 +1771,24 @@ async function removeWorkshopReferenceAudio(contentFolder) {
     return data;
 }
 
+function openPublishedWorkshopItem(webUrl) {
+    if (window.electronShell && typeof window.electronShell.openExternal === 'function') {
+        Promise.resolve(window.electronShell.openExternal(webUrl))
+            .then(result => {
+                if (result && result.success === false) {
+                    console.error('无法使用系统默认浏览器打开创意工坊页面:', result.error || 'Unknown error');
+                }
+            })
+            .catch(error => {
+                console.error('无法使用系统默认浏览器打开创意工坊页面:', error);
+            });
+        return;
+    }
+
+    // 普通网页环境没有 Electron 桥，交给当前浏览器打开新标签页。
+    window.open(webUrl, '_blank', 'noopener,noreferrer');
+}
+
 // 上传物品功能
 function uploadItem() {
     // 检查是否为默认模型
@@ -1915,21 +1933,13 @@ function uploadItem() {
                         cleanupTempFolder(currentUploadTempFolder, true);
                     }
 
-                    // 使用Steam overlay打开物品页面
+                    // 上传完成后使用系统默认浏览器打开创意工坊物品页面。
                     try {
                         const published_id = data.published_file_id;
-                        const overlayUrl = `steam://url/CommunityFilePage/${published_id}`;
                         const webUrl = `https://steamcommunity.com/sharedfiles/filedetails/?id=${published_id}`;
-
-                        // 检查是否支持Steam overlay
-                        if (window.steam && typeof window.steam.ActivateGameOverlayToWebPage === 'function') {
-                            window.steam.ActivateGameOverlayToWebPage(overlayUrl);
-                        } else {
-                            // Electron / 嵌入浏览器环境下直接打开 steam:// 可能导致窗口异常，回退到网页链接
-                            window.open(webUrl, '_blank', 'noopener');
-                        }
+                        openPublishedWorkshopItem(webUrl);
                     } catch (e) {
-                        console.error('无法打开Steam overlay:', e);
+                        console.error('无法打开创意工坊页面:', e);
                     }
 
                     // 延迟关闭modal并跳转到角色卡页面

--- a/templates/openclaw_guide.html
+++ b/templates/openclaw_guide.html
@@ -1241,6 +1241,43 @@
                 });
             }
 
+            function initializeGuideExternalLinks() {
+                if (!guideContent) return;
+                guideContent.addEventListener('click', (event) => {
+                    const target = event.target;
+                    const link = target && typeof target.closest === 'function'
+                        ? target.closest('a[href]')
+                        : null;
+                    if (!link || !guideContent.contains(link)) return;
+
+                    let externalUrl;
+                    try {
+                        externalUrl = new URL(link.getAttribute('href'), window.location.href);
+                    } catch (_) {
+                        return;
+                    }
+                    if (!['http:', 'https:'].includes(externalUrl.protocol)) return;
+                    if (externalUrl.origin === window.location.origin) return;
+
+                    event.preventDefault();
+                    const href = externalUrl.toString();
+                    if (window.electronShell && typeof window.electronShell.openExternal === 'function') {
+                        Promise.resolve(window.electronShell.openExternal(href))
+                            .then((result) => {
+                                if (result && result.success === false) {
+                                    console.warn('[OpenClawGuide] Failed to open external link:', result.error || 'Unknown error');
+                                }
+                            })
+                            .catch((error) => {
+                                console.warn('[OpenClawGuide] Failed to open external link:', error);
+                            });
+                        return;
+                    }
+
+                    window.open(href, '_blank', 'noopener,noreferrer');
+                });
+            }
+
             function renderGuideContent() {
                 guideContent.innerHTML = renderMarkdown(guideMarkdown);
                 buildGuideToc();
@@ -1288,6 +1325,7 @@
                 initializeCloseButton();
                 initializeGuideTocScroll();
                 initializeGuideContentScrollbar();
+                initializeGuideExternalLinks();
                 applyLocalizedChrome();
                 await loadGuideContent();
             }

--- a/tests/unit/test_card_maker_static_contracts.py
+++ b/tests/unit/test_card_maker_static_contracts.py
@@ -107,6 +107,7 @@ def test_workshop_publish_opens_item_in_system_browser():
     core = (CHARACTER_CARD_MANAGER_JS_DIR / "core-and-upload.js").read_text(encoding="utf-8")
 
     assert "function openPublishedWorkshopItem(webUrl)" in core
+    assert "https://steamcommunity.com/sharedfiles/filedetails/?id=${published_id}" in core
     assert "window.electronShell.openExternal(webUrl)" in core
     assert "window.open(webUrl, '_blank', 'noopener,noreferrer')" in core
     assert "openPublishedWorkshopItem(webUrl);" in core

--- a/tests/unit/test_card_maker_static_contracts.py
+++ b/tests/unit/test_card_maker_static_contracts.py
@@ -103,6 +103,17 @@ def test_character_card_import_keeps_non_blocking_progress_visible_until_complet
     assert "live2d.modelLoadFailed" in previews
 
 
+def test_workshop_publish_opens_item_in_system_browser():
+    core = (CHARACTER_CARD_MANAGER_JS_DIR / "core-and-upload.js").read_text(encoding="utf-8")
+
+    assert "function openPublishedWorkshopItem(webUrl)" in core
+    assert "window.electronShell.openExternal(webUrl)" in core
+    assert "window.open(webUrl, '_blank', 'noopener,noreferrer')" in core
+    assert "openPublishedWorkshopItem(webUrl);" in core
+    assert "ActivateGameOverlayToWebPage" not in core
+    assert "steam://url/CommunityFilePage" not in core
+
+
 def test_model_manager_parts_load_in_dependency_order():
     discovered_names = {path.name for path in MODEL_MANAGER_JS_DIR.glob("*.js")}
     assert discovered_names == set(MODEL_MANAGER_PART_NAMES)

--- a/tests/unit/test_openclaw_guide_static_contracts.py
+++ b/tests/unit/test_openclaw_guide_static_contracts.py
@@ -21,6 +21,8 @@ def test_openclaw_guide_routes_external_links_to_system_browser():
     assert "function initializeGuideExternalLinks()" in template
     assert "target.closest('a[href]')" in template
     assert "externalUrl.origin === window.location.origin" in template
+    assert "if (!['http:', 'https:'].includes(externalUrl.protocol)) return;" in template
+    assert "event.preventDefault();" in template
     assert "window.electronShell.openExternal(href)" in template
     assert "window.open(href, '_blank', 'noopener,noreferrer')" in template
     assert "initializeGuideExternalLinks();" in template

--- a/tests/unit/test_openclaw_guide_static_contracts.py
+++ b/tests/unit/test_openclaw_guide_static_contracts.py
@@ -9,8 +9,17 @@ OFFICIAL_REPOSITORY_URL = "https://github.com/agentscope-ai/QwenPaw"
 
 def test_openclaw_guide_locales_link_to_official_repository():
     guide_paths = sorted(GUIDE_DIR.glob("openclaw_guide*.md"))
+    guide_names = {guide_path.name for guide_path in guide_paths}
+    expected_guide_names = {
+        "openclaw_guide.md",
+        "openclaw_guide.en.md",
+        "openclaw_guide.ja.md",
+        "openclaw_guide.ko.md",
+        "openclaw_guide.ru.md",
+        "openclaw_guide.zh-TW.md",
+    }
 
-    assert len(guide_paths) == 6
+    assert expected_guide_names <= guide_names
     for guide_path in guide_paths:
         assert OFFICIAL_REPOSITORY_URL in guide_path.read_text(encoding="utf-8")
 

--- a/tests/unit/test_openclaw_guide_static_contracts.py
+++ b/tests/unit/test_openclaw_guide_static_contracts.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+GUIDE_TEMPLATE = PROJECT_ROOT / "templates" / "openclaw_guide.html"
+GUIDE_DIR = PROJECT_ROOT / "docs" / "zh-CN" / "guide"
+OFFICIAL_REPOSITORY_URL = "https://github.com/agentscope-ai/QwenPaw"
+
+
+def test_openclaw_guide_locales_link_to_official_repository():
+    guide_paths = sorted(GUIDE_DIR.glob("openclaw_guide*.md"))
+
+    assert len(guide_paths) == 6
+    for guide_path in guide_paths:
+        assert OFFICIAL_REPOSITORY_URL in guide_path.read_text(encoding="utf-8")
+
+
+def test_openclaw_guide_routes_external_links_to_system_browser():
+    template = GUIDE_TEMPLATE.read_text(encoding="utf-8")
+
+    assert "function initializeGuideExternalLinks()" in template
+    assert "target.closest('a[href]')" in template
+    assert "externalUrl.origin === window.location.origin" in template
+    assert "window.electronShell.openExternal(href)" in template
+    assert "window.open(href, '_blank', 'noopener,noreferrer')" in template
+    assert "initializeGuideExternalLinks();" in template


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

将创意工坊上传结果页及 OpenClaw 教程外链改为使用系统默认浏览器打开

## 测试 / Testing

手动跳转测试


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 发布创意工坊物品后，将在系统默认浏览器中打开物品详情页（桌面环境优先外部打开，浏览器环境以新窗口打开并保持安全隔离）。
  * 指南页面外链点击将先进行安全校验，并启用统一的外链打开初始化逻辑。
* **测试**
  * 新增“静态契约”单元测试：验证物品发布后打开行为、指南外链初始化实现要点，并校验指南文档包含官方仓库链接。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->