### PR TITLE
refactor(proactive): [1/4] extract state and contracts

### DIFF
--- a/main_logic/proactive_chat/__init__.py
+++ b/main_logic/proactive_chat/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Domain modules for proactive chat.
+
+HTTP adapters remain in :mod:`main_routers.system_router`; this package owns
+framework-independent proactive-chat contracts and business behavior.
+"""

--- a/main_logic/proactive_chat/contracts.py
+++ b/main_logic/proactive_chat/contracts.py
@@ -1,0 +1,218 @@
+# -*- coding: utf-8 -*-
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Stable command and result contracts for proactive chat.
+
+This module is intentionally framework-independent.  It owns the public
+request command plus the ``action`` / ``reason_code`` / ``stage`` vocabulary
+and helpers that construct domain result bodies.
+"""
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class ProactiveChatCommand:
+    """Framework-independent snapshot of a proactive-chat request payload.
+
+    Values intentionally retain the request's existing truthiness semantics.
+    In particular, ``enabled_modes_provided`` distinguishes a missing field
+    (legacy source inference) from an explicitly supplied empty list (all
+    source toggles disabled).
+    """
+
+    lanlan_name: Any = None
+    voice_mode: bool = False
+    is_playing_music: bool = False
+    current_track: Any = None
+    music_cooldown: bool = False
+    mini_game_invite_enabled: bool = True
+    base_interval_seconds: Any = None
+    enabled_modes: Any = None
+    enabled_modes_provided: bool = False
+    content_type: Any = None
+    screenshot_data: Any = None
+    use_window_search: bool = False
+    use_personal_dynamic: bool = False
+    avatar_position: Any = None
+    window_title: Any = ""
+    language: Any = None
+    lang: Any = None
+    i18n_language: Any = None
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any]) -> "ProactiveChatCommand":
+        """Build a command without importing HTTP framework types."""
+        return cls(
+            lanlan_name=payload.get("lanlan_name"),
+            voice_mode=bool(payload.get("voice_mode", False)),
+            is_playing_music=bool(payload.get("is_playing_music", False)),
+            current_track=payload.get("current_track"),
+            music_cooldown=bool(payload.get("music_cooldown", False)),
+            mini_game_invite_enabled=bool(
+                payload.get("mini_game_invite_enabled", True)
+            ),
+            base_interval_seconds=payload.get("base_interval_seconds"),
+            enabled_modes=payload.get("enabled_modes"),
+            enabled_modes_provided="enabled_modes" in payload,
+            content_type=payload.get("content_type"),
+            screenshot_data=payload.get("screenshot_data"),
+            use_window_search=bool(payload.get("use_window_search", False)),
+            use_personal_dynamic=bool(
+                payload.get("use_personal_dynamic", False)
+            ),
+            avatar_position=payload.get("avatar_position"),
+            window_title=payload.get("window_title", ""),
+            language=payload.get("language"),
+            lang=payload.get("lang"),
+            i18n_language=payload.get("i18n_language"),
+        )
+
+    @property
+    def language_candidates(self) -> tuple[Any, Any, Any]:
+        """Return request locale aliases in their established precedence."""
+        return self.language, self.lang, self.i18n_language
+
+
+@dataclass(frozen=True, slots=True)
+class ProactiveChatResult:
+    """Framework-independent result adapted to HTTP by the Router."""
+
+    body: dict[str, Any]
+    status_code: int = 200
+
+
+PROACTIVE_REASON_CHAT_DELIVERED = "CHAT_DELIVERED"
+PROACTIVE_REASON_PASS_BUSY = "PASS_BUSY"
+PROACTIVE_REASON_PASS_ACTIVITY_BUSY = "PASS_ACTIVITY_BUSY"
+PROACTIVE_REASON_PASS_DELIVERY_BUSY = "PASS_DELIVERY_BUSY"
+PROACTIVE_REASON_PASS_DISABLED = "PASS_DISABLED"
+PROACTIVE_REASON_PASS_ROUTE_ACTIVE = "PASS_ROUTE_ACTIVE"
+PROACTIVE_REASON_PASS_PRIVACY = "PASS_PRIVACY"
+PROACTIVE_REASON_PASS_RESTRICTED_SCREEN_ONLY = "PASS_RESTRICTED_SCREEN_ONLY"
+PROACTIVE_REASON_PASS_THROTTLED = "PASS_THROTTLED"
+PROACTIVE_REASON_PASS_SOURCE_EMPTY = "PASS_SOURCE_EMPTY"
+PROACTIVE_REASON_PASS_MODEL_PASS = "PASS_MODEL_PASS"
+PROACTIVE_REASON_PASS_GENERATION_EMPTY = "PASS_GENERATION_EMPTY"
+PROACTIVE_REASON_PASS_DUPLICATE = "PASS_DUPLICATE"
+PROACTIVE_REASON_DELIVERY_PREEMPTED = "DELIVERY_PREEMPTED"
+PROACTIVE_REASON_DELIVERY_FAILED = "DELIVERY_FAILED"
+PROACTIVE_REASON_ERROR_TIMEOUT = "ERROR_TIMEOUT"
+PROACTIVE_REASON_ERROR_INTERNAL = "ERROR_INTERNAL"
+PROACTIVE_REASON_ERROR_CHARACTER_NOT_FOUND = "ERROR_CHARACTER_NOT_FOUND"
+PROACTIVE_REASON_ERROR_SOURCE_FETCH_FAILED = "ERROR_SOURCE_FETCH_FAILED"
+PROACTIVE_REASON_PASS_UNSPECIFIED = "PASS_UNSPECIFIED"
+
+PROACTIVE_STAGE_ENTRY_GUARD = "entry_guard"
+PROACTIVE_STAGE_ACTIVITY_GATE = "activity_gate"
+PROACTIVE_STAGE_SOURCE_SELECTION = "source_selection"
+PROACTIVE_STAGE_MODEL_DECISION = "model_decision"
+PROACTIVE_STAGE_GENERATION = "generation"
+PROACTIVE_STAGE_DEDUP = "dedup"
+PROACTIVE_STAGE_DELIVERY = "delivery"
+PROACTIVE_STAGE_RUNTIME_ERROR = "runtime_error"
+PROACTIVE_STAGE_UNKNOWN = "unknown"
+
+_PROACTIVE_REASON_STAGE: dict[str, str] = {
+    PROACTIVE_REASON_CHAT_DELIVERED: PROACTIVE_STAGE_DELIVERY,
+    PROACTIVE_REASON_PASS_BUSY: PROACTIVE_STAGE_ENTRY_GUARD,
+    PROACTIVE_REASON_PASS_ACTIVITY_BUSY: PROACTIVE_STAGE_ACTIVITY_GATE,
+    PROACTIVE_REASON_PASS_DELIVERY_BUSY: PROACTIVE_STAGE_DELIVERY,
+    PROACTIVE_REASON_PASS_DISABLED: PROACTIVE_STAGE_ENTRY_GUARD,
+    PROACTIVE_REASON_PASS_ROUTE_ACTIVE: PROACTIVE_STAGE_ENTRY_GUARD,
+    PROACTIVE_REASON_PASS_PRIVACY: PROACTIVE_STAGE_ACTIVITY_GATE,
+    PROACTIVE_REASON_PASS_RESTRICTED_SCREEN_ONLY: PROACTIVE_STAGE_ACTIVITY_GATE,
+    PROACTIVE_REASON_PASS_THROTTLED: PROACTIVE_STAGE_ACTIVITY_GATE,
+    PROACTIVE_REASON_PASS_SOURCE_EMPTY: PROACTIVE_STAGE_SOURCE_SELECTION,
+    PROACTIVE_REASON_PASS_MODEL_PASS: PROACTIVE_STAGE_MODEL_DECISION,
+    PROACTIVE_REASON_PASS_GENERATION_EMPTY: PROACTIVE_STAGE_GENERATION,
+    PROACTIVE_REASON_PASS_DUPLICATE: PROACTIVE_STAGE_DEDUP,
+    PROACTIVE_REASON_DELIVERY_PREEMPTED: PROACTIVE_STAGE_DELIVERY,
+    PROACTIVE_REASON_DELIVERY_FAILED: PROACTIVE_STAGE_DELIVERY,
+    PROACTIVE_REASON_ERROR_TIMEOUT: PROACTIVE_STAGE_RUNTIME_ERROR,
+    PROACTIVE_REASON_ERROR_INTERNAL: PROACTIVE_STAGE_RUNTIME_ERROR,
+    PROACTIVE_REASON_ERROR_CHARACTER_NOT_FOUND: PROACTIVE_STAGE_ENTRY_GUARD,
+    PROACTIVE_REASON_ERROR_SOURCE_FETCH_FAILED: PROACTIVE_STAGE_SOURCE_SELECTION,
+    PROACTIVE_REASON_PASS_UNSPECIFIED: PROACTIVE_STAGE_UNKNOWN,
+}
+
+
+def _proactive_stage_for_reason(reason_code: str | None) -> str:
+    if not reason_code:
+        return PROACTIVE_STAGE_UNKNOWN
+    return _PROACTIVE_REASON_STAGE.get(reason_code, PROACTIVE_STAGE_UNKNOWN)
+
+
+def _proactive_response_body(
+    action: str | None,
+    reason_code: str,
+    *,
+    success: bool,
+    **extra: Any,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {"success": success, "reason_code": reason_code}
+    if action is not None:
+        body["action"] = action
+    body.update(extra)
+    body["reason_code"] = reason_code
+    if not body.get("stage"):
+        body["stage"] = _proactive_stage_for_reason(reason_code)
+    if action is not None:
+        body["action"] = action
+    return body
+
+
+def _proactive_pass_body(reason_code: str, **extra: Any) -> dict[str, Any]:
+    success = bool(extra.pop("success", True))
+    return _proactive_response_body("pass", reason_code, success=success, **extra)
+
+
+def _proactive_chat_body(
+    reason_code: str = PROACTIVE_REASON_CHAT_DELIVERED,
+    **extra: Any,
+) -> dict[str, Any]:
+    success = bool(extra.pop("success", True))
+    return _proactive_response_body("chat", reason_code, success=success, **extra)
+
+
+def _proactive_error_body(reason_code: str, **extra: Any) -> dict[str, Any]:
+    success = bool(extra.pop("success", False))
+    return _proactive_response_body(None, reason_code, success=success, **extra)
+
+
+def _ensure_proactive_reason_code(
+    body: dict[str, Any],
+    *,
+    default_reason_code: str | None = None,
+) -> dict[str, Any]:
+    existing_reason_code = body.get("reason_code")
+    if existing_reason_code:
+        if not body.get("stage"):
+            body["stage"] = _proactive_stage_for_reason(str(existing_reason_code))
+        return body
+    action = body.get("action")
+    if default_reason_code is None:
+        if action == "chat":
+            default_reason_code = PROACTIVE_REASON_CHAT_DELIVERED
+        elif action == "pass":
+            default_reason_code = PROACTIVE_REASON_PASS_UNSPECIFIED
+        else:
+            default_reason_code = PROACTIVE_REASON_ERROR_INTERNAL
+    body["reason_code"] = default_reason_code
+    if not body.get("stage"):
+        body["stage"] = _proactive_stage_for_reason(default_reason_code)
+    return body

--- a/main_logic/proactive_chat/contracts.py
+++ b/main_logic/proactive_chat/contracts.py
@@ -168,11 +168,8 @@ def _proactive_response_body(
     if action is not None:
         body["action"] = action
     body.update(extra)
-    body["reason_code"] = reason_code
     if not body.get("stage"):
         body["stage"] = _proactive_stage_for_reason(reason_code)
-    if action is not None:
-        body["action"] = action
     return body
 
 

--- a/main_logic/proactive_chat/decisions.py
+++ b/main_logic/proactive_chat/decisions.py
@@ -1,0 +1,486 @@
+# -*- coding: utf-8 -*-
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Framework-independent proactive-chat entry and source decisions."""
+
+import math
+import random
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from utils.logger_config import get_module_logger
+
+from .contracts import (
+    PROACTIVE_REASON_ERROR_CHARACTER_NOT_FOUND,
+    PROACTIVE_REASON_PASS_BUSY,
+    PROACTIVE_REASON_PASS_DISABLED,
+    PROACTIVE_REASON_PASS_PRIVACY,
+    PROACTIVE_REASON_PASS_RESTRICTED_SCREEN_ONLY,
+    PROACTIVE_REASON_PASS_ROUTE_ACTIVE,
+    PROACTIVE_REASON_PASS_SOURCE_EMPTY,
+    PROACTIVE_REASON_PASS_THROTTLED,
+    ProactiveChatCommand,
+    ProactiveChatResult,
+    _proactive_error_body,
+    _proactive_pass_body,
+)
+from .state import (
+    _RECENT_CHAT_MAX_AGE_SECONDS,
+    _get_source_history_entry,
+    _half_life_for,
+    _recent_proactive_chat_entries,
+    _reminiscence_usage_entries,
+    _source_skip_probability,
+)
+
+logger = get_module_logger(__name__, "Main")
+
+
+def build_proactive_response(source_tag: str, ctx: dict) -> tuple[str, list]:
+    """Resolve the effective delivery channel and its selected source links."""
+    primary_channel = "unknown"
+    source_links = []
+    lanlan_name = ctx.get("lanlan_name", "System")
+
+    match source_tag:
+        case "CHAT":
+            primary_channel = "chat"
+        case "WEB":
+            web_link = ctx.get("selected_web_link")
+            primary_channel = web_link.get("mode", "web") if web_link else "web"
+            if web_link:
+                source_links.append(web_link)
+                logger.debug(
+                    "[%s] Phase 2 确定选择 WEB (子通道: %s)，已添加链接",
+                    lanlan_name,
+                    primary_channel,
+                )
+        case "MUSIC":
+            primary_channel = "music"
+            if ctx.get("selected_music_link"):
+                source_links.append(ctx["selected_music_link"])
+                logger.debug("[%s] Phase 2 确定选择 MUSIC，已添加链接", lanlan_name)
+        case "MEME":
+            primary_channel = "meme"
+            if ctx.get("selected_meme_link"):
+                source_links.append(ctx["selected_meme_link"])
+                logger.debug("[%s] Phase 2 确定选择 MEME，已添加相关链接", lanlan_name)
+            else:
+                logger.warning(
+                    "[%s] Phase 2 AI 选择 MEME 但无可用表情包链接，回退处理",
+                    lanlan_name,
+                )
+                if ctx.get("selected_web_link"):
+                    primary_channel = ctx["selected_web_link"].get("mode", "web")
+                    source_links.append(ctx["selected_web_link"])
+                    logger.debug(
+                        "[%s] Phase 2 回退到 WEB 通道 (子通道: %s)",
+                        lanlan_name,
+                        primary_channel,
+                    )
+                elif ctx.get("vision_content"):
+                    primary_channel = "vision"
+                    logger.debug("[%s] Phase 2 回退到 VISION 通道", lanlan_name)
+                else:
+                    logger.debug(
+                        "[%s] Phase 2 MEME 无表情包且无回退通道，将跳过链接展示",
+                        lanlan_name,
+                    )
+    return primary_channel, source_links
+
+
+def _decide_manager_entry_guard(
+    lanlan_name: Any,
+    *,
+    manager_exists: bool,
+    goodbye_silent: bool = False,
+) -> ProactiveChatResult | None:
+    """Reject missing characters or sessions silenced by a goodbye."""
+    if not manager_exists:
+        return ProactiveChatResult(
+            body=_proactive_error_body(
+                PROACTIVE_REASON_ERROR_CHARACTER_NOT_FOUND,
+                error=f"角色 {lanlan_name} 不存在",
+            ),
+            status_code=404,
+        )
+    if goodbye_silent:
+        return ProactiveChatResult(
+            body=_proactive_pass_body(
+                PROACTIVE_REASON_PASS_DISABLED,
+                message="goodbye silent; proactive skipped",
+            )
+        )
+    return None
+
+
+def _decide_game_route_entry_guard(
+    game_route_active: bool | None,
+) -> ProactiveChatResult | None:
+    """Fail closed when the game-route ownership check is active or unavailable."""
+    if game_route_active is False:
+        return None
+    message = (
+        "game route active; ordinary proactive skipped"
+        if game_route_active
+        else "game route guard unavailable; ordinary proactive skipped"
+    )
+    return ProactiveChatResult(
+        body=_proactive_pass_body(
+            PROACTIVE_REASON_PASS_ROUTE_ACTIVE,
+            message=message,
+        )
+    )
+
+
+def _decide_busy_entry_guard(
+    can_start: bool,
+    *,
+    state_snapshot: Any,
+) -> ProactiveChatResult | None:
+    """Return the stable 409 contract when a proactive turn cannot start."""
+    if can_start:
+        return None
+    return ProactiveChatResult(
+        body=_proactive_error_body(
+            PROACTIVE_REASON_PASS_BUSY,
+            error="AI正在响应中，无法主动搭话",
+            message="请等待当前响应完成",
+            state=state_snapshot,
+        ),
+        status_code=409,
+    )
+
+
+def _should_use_voice_fast_path(
+    *,
+    voice_mode: bool,
+    manager_active: bool,
+    realtime_session: bool,
+) -> bool:
+    """Select the voice entry path without depending on its session class."""
+    return voice_mode and manager_active and realtime_session
+
+
+@dataclass(frozen=True, slots=True)
+class ActivityScheduleDecision:
+    """Scheduling effects derived from an activity snapshot."""
+
+    fixed_mode: bool = False
+    base_interval: float = 0.0
+    jitter_max: float = 0.0
+    has_must_fire: bool = False
+
+
+def _should_fetch_activity_snapshot(privacy_mode: bool) -> bool:
+    """Privacy mode disables activity inspection and falls back to open policy."""
+    return not privacy_mode
+
+
+def _decide_closed_activity_gate(
+    activity_snapshot: Any,
+    *,
+    debug_force_invite: bool,
+) -> ProactiveChatResult | None:
+    """Stop before source work when the activity tracker closes propensity."""
+    if (
+        debug_force_invite
+        or activity_snapshot is None
+        or activity_snapshot.propensity != "closed"
+    ):
+        return None
+    return ProactiveChatResult(
+        body=_proactive_pass_body(
+            PROACTIVE_REASON_PASS_PRIVACY,
+            message=(
+                f"user state={activity_snapshot.state} "
+                "→ closed (privacy lockdown)"
+            ),
+        )
+    )
+
+
+def _decide_activity_schedule(
+    activity_snapshot: Any,
+    *,
+    base_interval_seconds: Any,
+) -> ActivityScheduleDecision:
+    """Derive fixed scheduling and bounded jitter without sleeping."""
+    if (
+        activity_snapshot is None
+        or activity_snapshot.propensity != "restricted_screen_only"
+    ):
+        return ActivityScheduleDecision()
+
+    has_must_fire = (
+        activity_snapshot.anti_slack_pending is not None
+        or activity_snapshot.work_break_pending is not None
+    )
+    if has_must_fire:
+        return ActivityScheduleDecision(
+            fixed_mode=True,
+            has_must_fire=True,
+        )
+    try:
+        base_interval = (
+            float(base_interval_seconds)
+            if base_interval_seconds is not None
+            else 0.0
+        )
+    except (TypeError, ValueError):
+        base_interval = 0.0
+    jitter_max = (
+        min(base_interval * 0.5, 60.0)
+        if base_interval > 0
+        else 0.0
+    )
+    return ActivityScheduleDecision(
+        fixed_mode=True,
+        base_interval=base_interval,
+        jitter_max=jitter_max,
+        has_must_fire=False,
+    )
+
+
+def _decide_probabilistic_activity_gate(
+    activity_snapshot: Any,
+    *,
+    debug_force_invite: bool,
+    random_value: float | None = None,
+) -> ProactiveChatResult | None:
+    """Apply the activity skip roll while preserving unfinished-thread priority."""
+    if (
+        debug_force_invite
+        or activity_snapshot is None
+        or activity_snapshot.skip_probability <= 0
+        or activity_snapshot.unfinished_thread is not None
+    ):
+        return None
+    if random_value is None:
+        random_value = random.random()
+    if random_value >= activity_snapshot.skip_probability:
+        return None
+    return ProactiveChatResult(
+        body=_proactive_pass_body(
+            PROACTIVE_REASON_PASS_THROTTLED,
+            message=(
+                f"probabilistic skip: state={activity_snapshot.state} "
+                f"intensity={activity_snapshot.game_intensity} "
+                f"skip_prob={activity_snapshot.skip_probability:.2f}"
+            ),
+        )
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class SourceModeSelection:
+    """Initial source modes plus activity-based restrictions."""
+
+    enabled_modes: Any
+    has_unfinished_thread: bool
+    result: ProactiveChatResult | None = None
+    restricted_to_vision: bool = False
+    text_only_followup: bool = False
+
+
+def _select_source_modes(
+    command: ProactiveChatCommand,
+    activity_snapshot: Any,
+    *,
+    debug_force_invite: bool,
+) -> SourceModeSelection:
+    """Resolve legacy source fields and apply restricted-screen policy."""
+    if command.enabled_modes_provided:
+        enabled_modes = command.enabled_modes or []
+    elif command.screenshot_data and isinstance(command.screenshot_data, str):
+        enabled_modes = ["vision"]
+    elif command.use_window_search:
+        enabled_modes = ["window"]
+    elif command.content_type == "news":
+        enabled_modes = ["news"]
+    elif command.content_type == "video":
+        enabled_modes = ["video"]
+    elif command.use_personal_dynamic:
+        enabled_modes = ["personal"]
+    else:
+        enabled_modes = ["home"]
+
+    has_unfinished_thread = (
+        activity_snapshot is not None
+        and activity_snapshot.unfinished_thread is not None
+    )
+    restricted = (
+        not debug_force_invite
+        and activity_snapshot is not None
+        and activity_snapshot.propensity == "restricted_screen_only"
+    )
+    if not restricted:
+        return SourceModeSelection(
+            enabled_modes=enabled_modes,
+            has_unfinished_thread=has_unfinished_thread,
+        )
+    if "vision" in enabled_modes:
+        return SourceModeSelection(
+            enabled_modes=["vision"],
+            has_unfinished_thread=has_unfinished_thread,
+            restricted_to_vision=True,
+        )
+    if has_unfinished_thread:
+        return SourceModeSelection(
+            enabled_modes=[],
+            has_unfinished_thread=True,
+            text_only_followup=True,
+        )
+    return SourceModeSelection(
+        enabled_modes=enabled_modes,
+        has_unfinished_thread=False,
+        result=ProactiveChatResult(
+            body=_proactive_pass_body(
+                PROACTIVE_REASON_PASS_RESTRICTED_SCREEN_ONLY,
+                message=(
+                    f"user state={activity_snapshot.state} restricts proactive "
+                    "to screen-only, but vision not enabled this round"
+                ),
+            )
+        ),
+    )
+
+
+def _decide_empty_source_gate(
+    enabled_modes: Any,
+    *,
+    has_unfinished_thread: bool,
+) -> ProactiveChatResult | None:
+    """Pass after the mini-game opportunity when no source or thread remains."""
+    if enabled_modes or has_unfinished_thread:
+        return None
+    return ProactiveChatResult(
+        body=_proactive_pass_body(
+            PROACTIVE_REASON_PASS_SOURCE_EMPTY,
+            message="no source modes enabled and mini-game invite did not fire",
+        )
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class SourceWeightSelection:
+    """Computed source weights and channels suppressed for this round."""
+
+    weights: dict[str, float]
+    suppressed: set[str]
+
+
+def _select_weighted_sources(
+    lanlan_name: str,
+    enabled_modes: Any,
+    available_channels: Any,
+    *,
+    has_reminiscence: bool,
+) -> SourceWeightSelection:
+    """Apply source-history decay without mutating fetched source payloads."""
+    candidates = [
+        mode
+        for mode in enabled_modes
+        if mode != "vision" and mode in available_channels
+    ]
+    if has_reminiscence:
+        candidates.append("reminiscence")
+    if not candidates:
+        return SourceWeightSelection(weights={}, suppressed=set())
+    weights = _compute_source_weights(lanlan_name, candidates)
+    return SourceWeightSelection(
+        weights=weights,
+        suppressed=_filter_sources_by_weight(weights),
+    )
+
+
+def _should_skip_source(url_hash: str) -> bool:
+    """Return whether source decay should suppress a stable source hash."""
+    entry = _get_source_history_entry(url_hash)
+    if not entry:
+        return False
+    age = time.time() - entry.get('ts', 0.0)
+    probability = _source_skip_probability(
+        age,
+        _half_life_for(entry.get('kind', 'web')),
+    )
+    if probability >= 1.0:
+        return True
+    if probability <= 0.0:
+        return False
+    return random.random() < probability
+
+
+_SOURCE_WEIGHT_DECAY_LAMBDA = 0.002
+_SOURCE_WEIGHT_K = 0.30
+_SOURCE_WEIGHT_FLOOR = 0.20
+_SOURCE_WEIGHT_WINDOW = _RECENT_CHAT_MAX_AGE_SECONDS
+
+
+def _compute_source_weights(
+    lanlan_name: str,
+    candidate_channels: list[str],
+) -> dict[str, float]:
+    """Compute normalized freshness weights for candidate source channels."""
+    channel_count = len(candidate_channels)
+    if channel_count == 0:
+        return {}
+
+    now = time.time()
+    raw_scores: dict[str, float] = {
+        channel: 0.0 for channel in candidate_channels
+    }
+
+    for timestamp, _message, channel in _recent_proactive_chat_entries(lanlan_name):
+        age = now - timestamp
+        if age <= _SOURCE_WEIGHT_WINDOW and channel in raw_scores:
+            raw_scores[channel] += math.exp(-_SOURCE_WEIGHT_DECAY_LAMBDA * age)
+
+    if 'reminiscence' in raw_scores:
+        for timestamp in _reminiscence_usage_entries(lanlan_name):
+            age = now - timestamp
+            if age <= _SOURCE_WEIGHT_WINDOW:
+                raw_scores['reminiscence'] += math.exp(
+                    -_SOURCE_WEIGHT_DECAY_LAMBDA * age
+                )
+
+    freshness = {
+        channel: 1.0 / (1.0 + _SOURCE_WEIGHT_K * raw_scores[channel])
+        for channel in candidate_channels
+    }
+    total = sum(freshness.values())
+    if total <= 0:
+        return {
+            channel: 1.0 / channel_count
+            for channel in candidate_channels
+        }
+    return {
+        channel: value / total
+        for channel, value in freshness.items()
+    }
+
+
+def _filter_sources_by_weight(weights: dict[str, float]) -> set[str]:
+    """Return channels whose normalized weight falls below the dynamic floor."""
+    channel_count = len(weights)
+    if channel_count <= 1:
+        return set()
+    threshold = min(_SOURCE_WEIGHT_FLOOR, 1.0 / channel_count)
+    return {
+        channel
+        for channel, weight in weights.items()
+        if weight < threshold
+    }

--- a/main_logic/proactive_chat/state.py
+++ b/main_logic/proactive_chat/state.py
@@ -51,6 +51,7 @@ _SOURCE_HISTORY_SCHEMA_VERSION = 1
 _source_history: dict[str, dict[str, Any]] = {}
 _source_history_lock = asyncio.Lock()
 _source_history_loaded = False
+_source_history_loaded_path: Path | None = None
 
 
 def _resolve_memory_dir(memory_dir: str | Path | None) -> Path:
@@ -100,13 +101,14 @@ async def _ensure_source_history_loaded(
     *, memory_dir: str | Path | None = None
 ) -> None:
     """Load source history once without blocking the event loop."""
-    global _source_history_loaded
-    if _source_history_loaded:
+    global _source_history_loaded, _source_history_loaded_path
+    path = _source_history_path(memory_dir=memory_dir)
+    if _source_history_loaded and _source_history_loaded_path == path:
         return
     async with _source_history_lock:
-        if _source_history_loaded:
+        if _source_history_loaded and _source_history_loaded_path == path:
             return
-        path = _source_history_path(memory_dir=memory_dir)
+        _source_history.clear()
         try:
             data = await asyncio.to_thread(read_json, path)
             entries = data.get('entries') if isinstance(data, dict) else None
@@ -132,6 +134,7 @@ async def _ensure_source_history_loaded(
                 exc,
             )
         _source_history_loaded = True
+        _source_history_loaded_path = path
 
 
 async def _record_source_used(
@@ -229,6 +232,7 @@ _proactive_chat_totals_lock = asyncio.Lock()
 
 
 _proactive_chat_totals_loaded = False
+_proactive_chat_totals_loaded_path: Path | None = None
 
 
 _RECENT_CHAT_MAX_AGE_SECONDS = 3600  # 1小时内的搭话记录
@@ -349,7 +353,7 @@ def _record_proactive_chat(lanlan_name: str, message: str, channel: str = ''):
     args:
     - lanlan_name: model name
     - message: chat content
-    - channel: source channel (optional, default 'vision')
+    - channel: source channel (optional, default '')
     """
     if lanlan_name not in _proactive_chat_history:
         _proactive_chat_history[lanlan_name] = deque(maxlen=PROACTIVE_CHAT_HISTORY_MAX)
@@ -447,13 +451,21 @@ async def _ensure_proactive_chat_totals_loaded(
     "force-first re-deliver once" for existing users (at most once, because
     ever_delivered is set True and persisted immediately after delivery); this is
     a one-off v1→v2 migration cost and needs no dedicated migration script."""
-    global _proactive_chat_totals_loaded
-    if _proactive_chat_totals_loaded:
+    global _proactive_chat_totals_loaded, _proactive_chat_totals_loaded_path
+    path = _proactive_chat_totals_path(memory_dir=memory_dir)
+    if (
+        _proactive_chat_totals_loaded
+        and _proactive_chat_totals_loaded_path == path
+    ):
         return
     async with _proactive_chat_totals_lock:
-        if _proactive_chat_totals_loaded:
+        if (
+            _proactive_chat_totals_loaded
+            and _proactive_chat_totals_loaded_path == path
+        ):
             return
-        path = _proactive_chat_totals_path(memory_dir=memory_dir)
+        _proactive_chat_totals.clear()
+        _invite_ever_delivered.clear()
         try:
             data = await asyncio.to_thread(read_json, path)
             totals = data.get('totals') if isinstance(data, dict) else None
@@ -473,6 +485,7 @@ async def _ensure_proactive_chat_totals_loaded(
         except Exception as exc:
             logger.warning("proactive_chat_totals load failed: %s", exc)
         _proactive_chat_totals_loaded = True
+        _proactive_chat_totals_loaded_path = path
 
 
 def _get_proactive_chat_total(lanlan_name: str) -> int:

--- a/main_logic/proactive_chat/state.py
+++ b/main_logic/proactive_chat/state.py
@@ -1,0 +1,643 @@
+# -*- coding: utf-8 -*-
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Proactive-chat state, history, deduplication and persistent counters."""
+
+import asyncio
+import difflib
+import hashlib
+import re
+import time
+from collections import deque
+from pathlib import Path
+from typing import Any
+
+from config import (
+    PROACTIVE_CHAT_HISTORY_MAX,
+    PROACTIVE_SOURCE_FORGET_P,
+    PROACTIVE_SOURCE_HALF_LIFE_BY_KIND,
+    PROACTIVE_SOURCE_HALF_LIFE_DEFAULT,
+    PROACTIVE_SOURCE_HARD_SKIP_SECONDS,
+)
+from config.prompts.prompts_proactive import (
+    RECENT_PROACTIVE_CHANNEL_LABELS,
+    RECENT_PROACTIVE_CHATS_FOOTER,
+    RECENT_PROACTIVE_CHATS_HEADER,
+    RECENT_PROACTIVE_TIME_LABELS,
+)
+from config.prompts.prompts_sys import _loc
+from utils.config_manager import get_config_manager
+from utils.file_utils import atomic_write_json_async, read_json
+from utils.logger_config import get_module_logger
+
+logger = get_module_logger(__name__, "Main")
+
+
+# --- Global source decay history (cross-character, persisted) ---
+_SOURCE_HISTORY_FILENAME = "proactive_source_history.json"
+_SOURCE_HISTORY_SCHEMA_VERSION = 1
+_source_history: dict[str, dict[str, Any]] = {}
+_source_history_lock = asyncio.Lock()
+_source_history_loaded = False
+
+
+def _resolve_memory_dir(memory_dir: str | Path | None) -> Path:
+    """Resolve the persistence root while preserving the legacy singleton fallback."""
+    if memory_dir is None:
+        memory_dir = get_config_manager().memory_dir
+    return Path(memory_dir)
+
+
+def _source_history_path(*, memory_dir: str | Path | None = None) -> Path:
+    return _resolve_memory_dir(memory_dir) / _SOURCE_HISTORY_FILENAME
+
+
+def _source_hash(url: str = '', fallback_title: str = '') -> str:
+    """Return a stable URL hash, falling back to a normalized title."""
+    norm = (url or '').strip().lower().rstrip('/')
+    if norm:
+        return hashlib.sha256(norm.encode('utf-8')).hexdigest()
+    title_norm = re.sub(r'\s+', ' ', (fallback_title or '').strip().lower())
+    if title_norm:
+        return hashlib.sha256(('t::' + title_norm).encode('utf-8')).hexdigest()
+    return ''
+
+
+def _half_life_for(kind: str) -> float:
+    return PROACTIVE_SOURCE_HALF_LIFE_BY_KIND.get(
+        kind,
+        PROACTIVE_SOURCE_HALF_LIFE_DEFAULT,
+    )
+
+
+def _source_skip_probability(age: float, half_life: float) -> float:
+    if age < PROACTIVE_SOURCE_HARD_SKIP_SECONDS:
+        return 1.0
+    decay_age = age - PROACTIVE_SOURCE_HARD_SKIP_SECONDS
+    return 0.5 ** (decay_age / half_life)
+
+
+def _get_source_history_entry(url_hash: str) -> dict[str, Any] | None:
+    """Return the current in-memory source record for a stable hash."""
+    if not url_hash:
+        return None
+    return _source_history.get(url_hash)
+
+
+async def _ensure_source_history_loaded(
+    *, memory_dir: str | Path | None = None
+) -> None:
+    """Load source history once without blocking the event loop."""
+    global _source_history_loaded
+    if _source_history_loaded:
+        return
+    async with _source_history_lock:
+        if _source_history_loaded:
+            return
+        path = _source_history_path(memory_dir=memory_dir)
+        try:
+            data = await asyncio.to_thread(read_json, path)
+            entries = data.get('entries') if isinstance(data, dict) else None
+            if isinstance(entries, dict):
+                now = time.time()
+                for source_hash, entry in entries.items():
+                    if not isinstance(entry, dict):
+                        continue
+                    age = now - float(entry.get('ts', 0.0) or 0.0)
+                    probability = _source_skip_probability(
+                        age,
+                        _half_life_for(entry.get('kind', 'web')),
+                    )
+                    if probability >= PROACTIVE_SOURCE_FORGET_P:
+                        _source_history[source_hash] = entry
+        except FileNotFoundError:
+            pass
+        except Exception as exc:
+            logger.warning(
+                "加载 %s 失败，按空历史处理: %s: %s",
+                _SOURCE_HISTORY_FILENAME,
+                type(exc).__name__,
+                exc,
+            )
+        _source_history_loaded = True
+
+
+async def _record_source_used(
+    *,
+    url: str,
+    kind: str,
+    title: str = '',
+    memory_dir: str | Path | None = None,
+) -> None:
+    """Update, prune and persist one consumed source record."""
+    source_hash = _source_hash(url, title)
+    if not source_hash:
+        return
+    async with _source_history_lock:
+        _source_history[source_hash] = {
+            "ts": time.time(),
+            "kind": kind,
+            "title": (title or '')[:80],
+        }
+        now = time.time()
+        forgotten = [
+            existing_hash
+            for existing_hash, entry in _source_history.items()
+            if _source_skip_probability(
+                now - float(entry.get('ts', 0.0) or 0.0),
+                _half_life_for(entry.get('kind', 'web')),
+            )
+            < PROACTIVE_SOURCE_FORGET_P
+        ]
+        for existing_hash in forgotten:
+            _source_history.pop(existing_hash, None)
+        snapshot = {
+            "v": _SOURCE_HISTORY_SCHEMA_VERSION,
+            "entries": dict(_source_history),
+        }
+    try:
+        await atomic_write_json_async(
+            _source_history_path(memory_dir=memory_dir), snapshot
+        )
+    except Exception as exc:
+        logger.warning(
+            "落盘 %s 失败: %s: %s",
+            _SOURCE_HISTORY_FILENAME,
+            type(exc).__name__,
+            exc,
+        )
+
+
+# --- 主动搭话近期记录暂存区 ---
+# {lanlan_name: deque([(timestamp, message), ...], maxlen=10)}
+_proactive_chat_history: dict[str, deque] = {}
+
+
+# --- 主动搭话"素材标识"近期去重暂存区（ANTI_REPEAT_EXEMPT_SOURCE_TAGS 用）---
+# {lanlan_name: {source_tag: deque([(timestamp, material_key), ...], maxlen=N)}}
+# 素材推送类 channel（MUSIC/MEME）豁免台词级复读判定，改按"素材本身"去重：
+# MUSIC 看曲目（title|artist），MEME 看搜索关键词。本轮素材与近期不雷同就放行；
+# 雷同才回落到台词判定。进程内、重启清零——短期复读保护，与 _proactive_chat_
+# history / _mini_game_invite_state 同样是内存态即可。
+_proactive_material_history: dict[str, dict[str, deque]] = {}
+
+
+_PROACTIVE_MATERIAL_HISTORY_MAX = 10
+
+
+# --- 持久化"该角色累计成功投递的主动搭话次数 + 是否曾被邀请过"---
+# 单文件 schema：
+#   {"version": 2,
+#    "totals": {<lanlan_name>: <int>, ...},
+#    "ever_delivered": {<lanlan_name>: true, ...}}
+# 跨进程重启保留。两份数据合一个文件方便维护。
+#
+# - totals: 「新用户第 N 次主动搭话强制走 mini-game 邀请」(N=NEW_USER_FORCE_AT)
+#   必须依赖跨重启的累计计数——否则用户每次重启 app，force-trigger 会反复触发，
+#   体感邀请密度抖。计数语义与 _record_proactive_chat 对齐：仅在「成功投递给
+#   用户」时 +1，PASS 不算（spec 上"第 N 次主动搭话"指用户实际收到的）。
+# - ever_delivered: 「该角色是否曾经被发过 mini-game 邀请」一次性 true 标记，
+#   force-first 的 "is new user" 判定基础。和 in-memory 的 ``state.delivered_at``
+#   不同：后者跟随 PR-B 的 D2「回头再说」会被 reset，但 ever_delivered 一旦置
+#   True 就不再翻——「曾经被邀请过」是历史事实，不能被反悔。codex review (P1)
+#   指出，没这条 force-first 在重启后会把已邀请过的用户当新用户重新强制邀请。
+_PROACTIVE_CHAT_TOTALS_FILENAME = "proactive_chat_totals.json"
+
+
+_PROACTIVE_CHAT_TOTALS_SCHEMA_VERSION = 2
+
+
+_proactive_chat_totals: dict[str, int] = {}
+
+
+_invite_ever_delivered: dict[str, bool] = {}
+
+
+_proactive_chat_totals_lock = asyncio.Lock()
+
+
+_proactive_chat_totals_loaded = False
+
+
+_RECENT_CHAT_MAX_AGE_SECONDS = 3600  # 1小时内的搭话记录
+
+
+_PROACTIVE_SIMILARITY_THRESHOLD = 0.90  # 保守硬拦截阈值：90% 以上重复直接放弃本轮
+
+
+def _recent_proactive_chat_entries(lanlan_name: str) -> tuple[tuple, ...]:
+    """Return an immutable snapshot of one character's recent chat records."""
+    history = _proactive_chat_history.get(lanlan_name)
+    return tuple(history) if history else ()
+
+
+def _format_recent_proactive_chats(lanlan_name: str, lang: str = 'zh') -> str:
+    """
+    Format recent proactive-chat records into a text block injectable into the prompt (with relative time and source channel).
+    Logic:
+    - fetch the given model's proactive-chat records from _proactive_chat_history
+    - filter to records within the last _RECENT_CHAT_MAX_AGE_SECONDS seconds
+    - format the time label according to lang ('zh', 'en', 'ja', 'ko')
+    - format the source channel label ('vision', 'web')
+    """
+    history = _proactive_chat_history.get(lanlan_name)
+    if not history:
+        return ""
+    now = time.time()
+    recent = [entry for entry in history if now - entry[0] < _RECENT_CHAT_MAX_AGE_SECONDS]
+    if not recent:
+        return ""
+
+    tl = RECENT_PROACTIVE_TIME_LABELS.get(lang, RECENT_PROACTIVE_TIME_LABELS['en'])
+    cl = RECENT_PROACTIVE_CHANNEL_LABELS.get(lang, RECENT_PROACTIVE_CHANNEL_LABELS['en'])
+
+    def _rel(ts):
+        """
+        Format the time label.
+        args:
+        - ts: timestamp (seconds)
+        returns:
+        - str: formatted time label
+        """
+        d = int(now - ts)
+        if d < 60:
+            return tl[0]
+        m = d // 60
+        if m < 60:
+            return tl['m'].format(m)
+        return tl['h'].format(m // 60)
+
+    header = _loc(RECENT_PROACTIVE_CHATS_HEADER, lang)
+    footer = _loc(RECENT_PROACTIVE_CHATS_FOOTER, lang)
+    lines = []
+    for entry in recent:
+        ts, msg = entry[0], entry[1]
+        ch = entry[2] if len(entry) > 2 else ''
+        # 过滤掉 vision 通道的记录，避免 AI 引用已过期的屏幕内容产生幻觉
+        if ch == 'vision':
+            continue
+        tag = _rel(ts)
+        if ch:
+            tag += f"·{cl.get(ch, ch)}"
+        lines.append(f"- [{tag}] {msg}")
+    if not lines:
+        return ""
+    return f"\n{header}\n" + "\n".join(lines) + f"\n{footer}\n"
+
+
+# Reminiscence usage buffer — separate from _proactive_chat_history because
+# the latter feeds dedup / similarity checks (_format_recent_proactive_chats /
+# _is_similar_to_recent_proactive_chat) and any double-recording there would
+# inflate similarity scores against its own message. This buffer is read
+# only by _compute_source_weights to factor reminiscence into channel
+# weight decay alongside web/news/etc.
+#
+# Why 50 (not tied to PROACTIVE_CHAT_HISTORY_MAX=10): the two buffers serve
+# opposite sizing constraints. PROACTIVE_CHAT_HISTORY_MAX bounds *dedup*
+# memory (1h text-similarity check, 10 entries are plenty). This buffer
+# bounds *decay-signal completeness* — _compute_source_weights walks every
+# timestamp inside the _SOURCE_WEIGHT_WINDOW (=1h) for the exponential
+# decay sum, so the maxlen MUST be larger than the worst-case usage count
+# in that window or oldest entries get evicted and the channel under-
+# counts. 50 leaves ~5× safety margin for high-cadence proactive cycles.
+# Kept as a private module constant alongside the other _SOURCE_WEIGHT_*
+# tunables (_SOURCE_WEIGHT_DECAY_LAMBDA / _K / _FLOOR / _WINDOW) — it's
+# tied to that model's calibration, not a user-facing config knob.
+_REMINISCENCE_USAGE_MAX = 50
+
+
+_reminiscence_usage_history: dict[str, deque[float]] = {}
+
+
+def _reminiscence_usage_entries(lanlan_name: str) -> tuple[float, ...]:
+    """Return an immutable snapshot of reminiscence usage timestamps."""
+    history = _reminiscence_usage_history.get(lanlan_name)
+    return tuple(history) if history else ()
+
+
+def _record_reminiscence_usage(lanlan_name: str) -> None:
+    """Record one reminiscence usage timestamp for source-weight decay.
+
+    Kept separate from ``_record_proactive_chat`` to avoid polluting
+    the dedup / similarity history (which compares the proactive
+    response text against past entries by channel-agnostic match).
+    """
+    if lanlan_name not in _reminiscence_usage_history:
+        _reminiscence_usage_history[lanlan_name] = deque(maxlen=_REMINISCENCE_USAGE_MAX)
+    _reminiscence_usage_history[lanlan_name].append(time.time())
+
+
+def _record_proactive_chat(lanlan_name: str, message: str, channel: str = ''):
+    """
+    Record one successful proactive chat (with its source channel).
+    Logic:
+    - get the current timestamp
+    - append the record (timestamp, message content, channel) to the given model's queue in _proactive_chat_history
+    - if the queue is full, the oldest record is popped automatically, keeping the length within maxlen (default 10)
+    args:
+    - lanlan_name: model name
+    - message: chat content
+    - channel: source channel (optional, default 'vision')
+    """
+    if lanlan_name not in _proactive_chat_history:
+        _proactive_chat_history[lanlan_name] = deque(maxlen=PROACTIVE_CHAT_HISTORY_MAX)
+    _proactive_chat_history[lanlan_name].append((time.time(), message, channel))
+
+    # Telemetry：主动搭话实际投递。channel 是低基数 enum（vision/news/video/
+    # personal/music/meme/mini_game/...），截断防意外高基数。配合 settings_state
+    # 的 proactive 配置档，能看深度用户每天实际被主动搭话几次。
+    #
+    # 不在这里做 responded 回应率配对：这会要求 core turn 与主动搭话状态共享
+    # “上次投递时刻”，扩大两个生命周期之间的耦合。回应率先由 server 端使用
+    # proactive_fired 时刻与用户消息活动 timestamp 关联粗估；精确配对另行设计。
+    try:
+        from utils.instrument import counter as _instr_counter
+        _instr_counter("proactive_fired", channel=(str(channel) or "default")[:24])
+    except Exception:
+        # 埋点失败不能影响主动搭话投递
+        pass
+
+
+def _normalize_material_key(raw: str) -> str:
+    """Normalize a material identity string for exact-match dedup (lowercase + collapse whitespace)."""
+    s = (raw or "").strip().lower()
+    return re.sub(r'\s+', ' ', s)
+
+
+def _proactive_material_key(
+    source_tag: str | None,
+    selected_music_link: dict | None,
+    meme_content: dict | None,
+) -> str:
+    """Compute the dedup identity of the material this round pushes.
+
+    - MUSIC → the picked track (title|artist); two different songs never collide
+    - MEME → the **search keyword** (not the image): same keyword reused soon is a
+      repeat, a fresh keyword is not. Random hot-word fallback has an empty keyword
+      → empty key → treated as "never a repeat" (each random fetch is varied)
+
+    Empty/unknown → "" (caller treats as non-repeat, i.e. always exempt).
+    """
+    if source_tag == 'MUSIC' and selected_music_link:
+        title = (selected_music_link.get('title') or '').strip()
+        artist = (selected_music_link.get('artist') or '').strip()
+        return _normalize_material_key(f"{title}|{artist}") if (title or artist) else ""
+    if source_tag == 'MEME' and meme_content:
+        return _normalize_material_key(meme_content.get('keyword') or '')
+    return ""
+
+
+def _is_recent_proactive_material(lanlan_name: str, source_tag: str, key: str) -> bool:
+    """Whether *key* was pushed for *source_tag* within the recent window (exact match).
+
+    Empty key → never a repeat (no material identity to compare on).
+    """
+    if not key:
+        return False
+    bucket = _proactive_material_history.get(lanlan_name, {}).get(source_tag)
+    if not bucket:
+        return False
+    now = time.time()
+    return any(
+        k == key and now - ts < _RECENT_CHAT_MAX_AGE_SECONDS
+        for ts, k in bucket
+    )
+
+
+def _record_proactive_material(lanlan_name: str, source_tag: str, key: str) -> None:
+    """Record one successfully delivered material identity (skip empty keys)."""
+    if not key:
+        return
+    per_tag = _proactive_material_history.setdefault(lanlan_name, {})
+    if source_tag not in per_tag:
+        per_tag[source_tag] = deque(maxlen=_PROACTIVE_MATERIAL_HISTORY_MAX)
+    per_tag[source_tag].append((time.time(), key))
+
+
+def _proactive_chat_totals_path(
+    *, memory_dir: str | Path | None = None
+) -> Path:
+    return _resolve_memory_dir(memory_dir) / _PROACTIVE_CHAT_TOTALS_FILENAME
+
+
+async def _ensure_proactive_chat_totals_loaded(
+    *, memory_dir: str | Path | None = None
+) -> None:
+    """Lazy-load the persisted cumulative counters + ever_delivered. Idempotent. File reads go to the thread pool.
+
+    schema: {"version": 2,
+             "totals": {<lanlan_name>: <int>, ...},
+             "ever_delivered": {<lanlan_name>: true, ...}}
+
+    A missing file / corrupted JSON is not fatal — start from empty, and the next
+    increment writes a fresh file. The old schema v1 has no ever_delivered field,
+    so it loads as an empty dict — after upgrading, the first proactive chat will
+    "force-first re-deliver once" for existing users (at most once, because
+    ever_delivered is set True and persisted immediately after delivery); this is
+    a one-off v1→v2 migration cost and needs no dedicated migration script."""
+    global _proactive_chat_totals_loaded
+    if _proactive_chat_totals_loaded:
+        return
+    async with _proactive_chat_totals_lock:
+        if _proactive_chat_totals_loaded:
+            return
+        path = _proactive_chat_totals_path(memory_dir=memory_dir)
+        try:
+            data = await asyncio.to_thread(read_json, path)
+            totals = data.get('totals') if isinstance(data, dict) else None
+            if isinstance(totals, dict):
+                for k, v in totals.items():
+                    if isinstance(k, str) and isinstance(v, (int, float)):
+                        _proactive_chat_totals[k] = int(v)
+            ever = data.get('ever_delivered') if isinstance(data, dict) else None
+            if isinstance(ever, dict):
+                for k, v in ever.items():
+                    if isinstance(k, str) and bool(v):
+                        _invite_ever_delivered[k] = True
+        except FileNotFoundError:
+            # 首次启动 / cleanup 后没文件——按全空起步，下次 increment 会创建。
+            # 不是异常，不打 warning。
+            pass
+        except Exception as exc:
+            logger.warning("proactive_chat_totals load failed: %s", exc)
+        _proactive_chat_totals_loaded = True
+
+
+def _get_proactive_chat_total(lanlan_name: str) -> int:
+    """Synchronous read of cached counter. 0 if loaded-but-unset or not loaded yet.
+
+    `_maybe_deliver_mini_game_invite` calls this after the caller has already
+    awaited `_ensure_proactive_chat_totals_loaded()`, so there is no await here."""
+    return int(_proactive_chat_totals.get(lanlan_name, 0))
+
+
+def _was_invite_ever_delivered(lanlan_name: str) -> bool:
+    """Synchronous read of ever-delivered flag.
+
+    The caller must await ``_ensure_proactive_chat_totals_loaded()`` first."""
+    return bool(_invite_ever_delivered.get(lanlan_name, False))
+
+
+async def _persist_totals_unlocked(
+    *, memory_dir: str | Path | None = None
+) -> None:
+    """Persist totals + ever_delivered to disk. The caller must hold _proactive_chat_totals_lock."""
+    try:
+        await atomic_write_json_async(
+            _proactive_chat_totals_path(memory_dir=memory_dir),
+            {
+                'version': _PROACTIVE_CHAT_TOTALS_SCHEMA_VERSION,
+                'totals': dict(_proactive_chat_totals),
+                'ever_delivered': dict(_invite_ever_delivered),
+            },
+            indent=2,
+            ensure_ascii=False,
+        )
+    except Exception as exc:
+        logger.warning(
+            "proactive_chat_totals persist failed (in-memory still up-to-date): %s",
+            exc,
+        )
+
+
+async def _increment_proactive_chat_total(
+    lanlan_name: str, *, memory_dir: str | Path | None = None
+) -> int:
+    """+1 cached counter and persist atomically. Returns new value.
+
+    Serialization is guaranteed by ``_proactive_chat_totals_lock``: concurrent
+    proactive_chat calls each await a serial update, so no increment is lost.
+    Persistence failures are not raised to the caller — the counter is
+    best-effort; losing one +1 is not fatal, but the log line is kept."""
+    await _ensure_proactive_chat_totals_loaded(memory_dir=memory_dir)
+    async with _proactive_chat_totals_lock:
+        new_value = _proactive_chat_totals.get(lanlan_name, 0) + 1
+        _proactive_chat_totals[lanlan_name] = new_value
+        await _persist_totals_unlocked(memory_dir=memory_dir)
+    return new_value
+
+
+async def _mark_invite_ever_delivered(
+    lanlan_name: str, *, memory_dir: str | Path | None = None
+) -> None:
+    """One-shot set-True + persist. Skips the disk write when already True to save IO.
+
+    Shares ``_proactive_chat_totals_lock`` with ``_increment_proactive_chat_total``
+    so concurrent updates write totals + ever_delivered together atomically.
+
+    ⚠️ The invite delivery path must not call ``_increment_proactive_chat_total +
+    _mark_invite_ever_delivered`` separately — the lock is released between the
+    two awaits, and a process dying in between leaves a ``totals: N+1,
+    ever_delivered: stale`` half-state on disk, making force-first fire once more
+    after restart. Use ``_record_invite_delivery_persistent`` for one atomic
+    write under a single lock."""
+    await _ensure_proactive_chat_totals_loaded(memory_dir=memory_dir)
+    async with _proactive_chat_totals_lock:
+        if _invite_ever_delivered.get(lanlan_name):
+            return
+        _invite_ever_delivered[lanlan_name] = True
+        await _persist_totals_unlocked(memory_dir=memory_dir)
+
+
+async def _record_invite_delivery_persistent(
+    lanlan_name: str, *, memory_dir: str | Path | None = None
+) -> int:
+    """Atomic persistent record of one successfully delivered mini-game invite:
+    counter +1 + ever_delivered=True written to disk once under one lock.
+    Returns the new total.
+
+    Reason to exist: doing +1 then mark as two separate awaits releases the lock
+    in between; a process crash / coroutine cancel can leave a ``totals: N+1,
+    ever_delivered: stale`` half-state on disk — after restart
+    ``_was_invite_ever_delivered`` sees the stale false and force-first fires
+    again. Pointed out by CodeRabbit Major review."""
+    await _ensure_proactive_chat_totals_loaded(memory_dir=memory_dir)
+    async with _proactive_chat_totals_lock:
+        new_value = _proactive_chat_totals.get(lanlan_name, 0) + 1
+        _proactive_chat_totals[lanlan_name] = new_value
+        _invite_ever_delivered[lanlan_name] = True
+        await _persist_totals_unlocked(memory_dir=memory_dir)
+    return new_value
+
+
+def _clear_channel_from_proactive_history(lanlan_name: str, channel: str) -> int:
+    """Blank out the channel mark of the given channel's entries in _proactive_chat_history.
+
+    Purpose: when the user gives strong positive feedback (e.g. a recommended
+    song played all the way through), that amounts to explicitly accepting this
+    channel's recent output, so _compute_source_weights should no longer
+    penalize the channel for "just used". Clearing the channel field stops
+    raw_score from accumulating those entries, while the message text stays in
+    the deque for dedup / similarity / format_recent_proactive_chats reuse.
+
+    Returns the number of entries cleared.
+    """
+    history = _proactive_chat_history.get(lanlan_name)
+    if not history:
+        return 0
+    rewritten: list[tuple] = []
+    cleared = 0
+    for entry in history:
+        if len(entry) >= 3 and entry[2] == channel:
+            rewritten.append((entry[0], entry[1], ''))
+            cleared += 1
+        else:
+            rewritten.append(entry)
+    if cleared == 0:
+        return 0
+    history.clear()
+    history.extend(rewritten)
+    return cleared
+
+
+def _normalize_text_for_similarity(text: str) -> str:
+    """
+    Text normalization (conservative strategy):
+    - lowercase
+    - collapse consecutive whitespace
+    Only light normalization, to avoid false kills from over-cleaning.
+    """
+    text = (text or "").strip().lower()
+    return re.sub(r'\s+', ' ', text)
+
+
+def _is_similar_to_recent_proactive_chat(lanlan_name: str, message: str) -> tuple[bool, float]:
+    """
+    Check whether message is highly similar to recent proactive chats (high threshold against false kills).
+    Returns (is_duplicate, best_score).
+    """
+    history = _proactive_chat_history.get(lanlan_name)
+    if not history or not message.strip():
+        return False, 0.0
+
+    now = time.time()
+    current = _normalize_text_for_similarity(message)
+    if not current:
+        return False, 0.0
+
+    best = 0.0
+    for entry in history:
+        ts, old_msg = entry[0], entry[1]
+        if now - ts >= _RECENT_CHAT_MAX_AGE_SECONDS:
+            continue
+        old_norm = _normalize_text_for_similarity(old_msg)
+        if not old_norm:
+            continue
+        score = difflib.SequenceMatcher(None, current, old_norm).ratio()
+        if score > best:
+            best = score
+        if score >= _PROACTIVE_SIMILARITY_THRESHOLD:
+            return True, score
+    return False, best

--- a/main_routers/system_router/__init__.py
+++ b/main_routers/system_router/__init__.py
@@ -170,6 +170,7 @@ from .activity_signal import (  # noqa: F401
     _activity_signal_validate_str,
     push_activity_signal,
 )
+from . import proactive_history as _proactive_history_module
 from .proactive_history import (  # noqa: F401
     _proactive_chat_history,
     _proactive_material_history,
@@ -179,7 +180,6 @@ from .proactive_history import (  # noqa: F401
     _proactive_chat_totals,
     _invite_ever_delivered,
     _proactive_chat_totals_lock,
-    _proactive_chat_totals_loaded,
     _RECENT_CHAT_MAX_AGE_SECONDS,
     _PROACTIVE_SIMILARITY_THRESHOLD,
     _format_recent_proactive_chats,
@@ -203,12 +203,12 @@ from .proactive_history import (  # noqa: F401
     _normalize_text_for_similarity,
     _is_similar_to_recent_proactive_chat,
 )
+from . import proactive_sources as _proactive_sources_module
 from .proactive_sources import (  # noqa: F401
     _SOURCE_HISTORY_FILENAME,
     _SOURCE_HISTORY_SCHEMA_VERSION,
     _source_history,
     _source_history_lock,
-    _source_history_loaded,
     _source_history_path,
     _source_hash,
     _half_life_for,
@@ -326,3 +326,12 @@ from .mini_game_invite import (  # noqa: F401
 from .translate import (  # noqa: F401
     translate_text_api,
 )
+
+
+def __getattr__(name: str):
+    """Keep immutable compatibility flags synchronized with their owners."""
+    if name == "_proactive_chat_totals_loaded":
+        return _proactive_history_module._proactive_chat_totals_loaded
+    if name == "_source_history_loaded":
+        return _proactive_sources_module._source_history_loaded
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/main_routers/system_router/proactive_history.py
+++ b/main_routers/system_router/proactive_history.py
@@ -13,468 +13,75 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Proactive chat in-memory history, material dedup, similarity checks
-and the persistent per-character chat totals / invite-ever-delivered store.
+"""Compatibility facade for proactive-chat state.
 
-Split out of the former monolithic ``main_routers/system_router.py``.
+The canonical implementation lives in :mod:`main_logic.proactive_chat.state`.
+New code must import that module directly.
 """
 
-from ._shared import logger
-import asyncio
-import difflib
-import re
-import time
-from collections import deque
-from pathlib import Path
-from ..shared_state import get_config_manager
-from config import (
-    PROACTIVE_CHAT_HISTORY_MAX,
+from main_logic.proactive_chat import state as _state
+from main_logic.proactive_chat.state import (  # noqa: F401
+    _proactive_chat_history,
+    _proactive_material_history,
+    _PROACTIVE_MATERIAL_HISTORY_MAX,
+    _PROACTIVE_CHAT_TOTALS_FILENAME,
+    _PROACTIVE_CHAT_TOTALS_SCHEMA_VERSION,
+    _proactive_chat_totals,
+    _invite_ever_delivered,
+    _proactive_chat_totals_lock,
+    _proactive_chat_totals_loaded,
+    _RECENT_CHAT_MAX_AGE_SECONDS,
+    _PROACTIVE_SIMILARITY_THRESHOLD,
+    _format_recent_proactive_chats,
+    _REMINISCENCE_USAGE_MAX,
+    _reminiscence_usage_history,
+    _record_reminiscence_usage,
+    _record_proactive_chat,
+    _normalize_material_key,
+    _proactive_material_key,
+    _is_recent_proactive_material,
+    _record_proactive_material,
+    _get_proactive_chat_total,
+    _was_invite_ever_delivered,
+    _clear_channel_from_proactive_history,
+    _normalize_text_for_similarity,
+    _is_similar_to_recent_proactive_chat,
 )
-from config.prompts.prompts_sys import _loc
-from config.prompts.prompts_proactive import (
-    RECENT_PROACTIVE_CHATS_HEADER, RECENT_PROACTIVE_CHATS_FOOTER,
-    RECENT_PROACTIVE_TIME_LABELS,
-    RECENT_PROACTIVE_CHANNEL_LABELS,
-)
-from utils.file_utils import atomic_write_json_async, read_json
+from ..shared_state import get_config_manager as _get_legacy_config_manager
 
 
-# --- 主动搭话近期记录暂存区 ---
-# {lanlan_name: deque([(timestamp, message), ...], maxlen=10)}
-_proactive_chat_history: dict[str, deque] = {}
+def _legacy_memory_dir():
+    return _get_legacy_config_manager().memory_dir
 
 
-# --- 主动搭话"素材标识"近期去重暂存区（ANTI_REPEAT_EXEMPT_SOURCE_TAGS 用）---
-# {lanlan_name: {source_tag: deque([(timestamp, material_key), ...], maxlen=N)}}
-# 素材推送类 channel（MUSIC/MEME）豁免台词级复读判定，改按"素材本身"去重：
-# MUSIC 看曲目（title|artist），MEME 看搜索关键词。本轮素材与近期不雷同就放行；
-# 雷同才回落到台词判定。进程内、重启清零——短期复读保护，与 _proactive_chat_
-# history / _mini_game_invite_state 同样是内存态即可。
-_proactive_material_history: dict[str, dict[str, deque]] = {}
-
-
-_PROACTIVE_MATERIAL_HISTORY_MAX = 10
-
-
-# --- 持久化"该角色累计成功投递的主动搭话次数 + 是否曾被邀请过"---
-# 单文件 schema：
-#   {"version": 2,
-#    "totals": {<lanlan_name>: <int>, ...},
-#    "ever_delivered": {<lanlan_name>: true, ...}}
-# 跨进程重启保留。两份数据合一个文件方便维护。
-#
-# - totals: 「新用户第 N 次主动搭话强制走 mini-game 邀请」(N=NEW_USER_FORCE_AT)
-#   必须依赖跨重启的累计计数——否则用户每次重启 app，force-trigger 会反复触发，
-#   体感邀请密度抖。计数语义与 _record_proactive_chat 对齐：仅在「成功投递给
-#   用户」时 +1，PASS 不算（spec 上"第 N 次主动搭话"指用户实际收到的）。
-# - ever_delivered: 「该角色是否曾经被发过 mini-game 邀请」一次性 true 标记，
-#   force-first 的 "is new user" 判定基础。和 in-memory 的 ``state.delivered_at``
-#   不同：后者跟随 PR-B 的 D2「回头再说」会被 reset，但 ever_delivered 一旦置
-#   True 就不再翻——「曾经被邀请过」是历史事实，不能被反悔。codex review (P1)
-#   指出，没这条 force-first 在重启后会把已邀请过的用户当新用户重新强制邀请。
-_PROACTIVE_CHAT_TOTALS_FILENAME = "proactive_chat_totals.json"
-
-
-_PROACTIVE_CHAT_TOTALS_SCHEMA_VERSION = 2
-
-
-_proactive_chat_totals: dict[str, int] = {}
-
-
-_invite_ever_delivered: dict[str, bool] = {}
-
-
-_proactive_chat_totals_lock = asyncio.Lock()
-
-
-_proactive_chat_totals_loaded = False
-
-
-_RECENT_CHAT_MAX_AGE_SECONDS = 3600  # 1小时内的搭话记录
-
-
-_PROACTIVE_SIMILARITY_THRESHOLD = 0.90  # 保守硬拦截阈值：90% 以上重复直接放弃本轮
-
-
-def _format_recent_proactive_chats(lanlan_name: str, lang: str = 'zh') -> str:
-    """
-    Format recent proactive-chat records into a text block injectable into the prompt (with relative time and source channel).
-    Logic:
-    - fetch the given model's proactive-chat records from _proactive_chat_history
-    - filter to records within the last _RECENT_CHAT_MAX_AGE_SECONDS seconds
-    - format the time label according to lang ('zh', 'en', 'ja', 'ko')
-    - format the source channel label ('vision', 'web')
-    """
-    history = _proactive_chat_history.get(lanlan_name)
-    if not history:
-        return ""
-    now = time.time()
-    recent = [entry for entry in history if now - entry[0] < _RECENT_CHAT_MAX_AGE_SECONDS]
-    if not recent:
-        return ""
-
-    tl = RECENT_PROACTIVE_TIME_LABELS.get(lang, RECENT_PROACTIVE_TIME_LABELS['en'])
-    cl = RECENT_PROACTIVE_CHANNEL_LABELS.get(lang, RECENT_PROACTIVE_CHANNEL_LABELS['en'])
-
-    def _rel(ts):
-        """
-        Format the time label.
-        args:
-        - ts: timestamp (seconds)
-        returns:
-        - str: formatted time label
-        """
-        d = int(now - ts)
-        if d < 60:
-            return tl[0]
-        m = d // 60
-        if m < 60:
-            return tl['m'].format(m)
-        return tl['h'].format(m // 60)
-
-    header = _loc(RECENT_PROACTIVE_CHATS_HEADER, lang)
-    footer = _loc(RECENT_PROACTIVE_CHATS_FOOTER, lang)
-    lines = []
-    for entry in recent:
-        ts, msg = entry[0], entry[1]
-        ch = entry[2] if len(entry) > 2 else ''
-        # 过滤掉 vision 通道的记录，避免 AI 引用已过期的屏幕内容产生幻觉
-        if ch == 'vision':
-            continue
-        tag = _rel(ts)
-        if ch:
-            tag += f"·{cl.get(ch, ch)}"
-        lines.append(f"- [{tag}] {msg}")
-    if not lines:
-        return ""
-    return f"\n{header}\n" + "\n".join(lines) + f"\n{footer}\n"
-
-
-# Reminiscence usage buffer — separate from _proactive_chat_history because
-# the latter feeds dedup / similarity checks (_format_recent_proactive_chats /
-# _is_similar_to_recent_proactive_chat) and any double-recording there would
-# inflate similarity scores against its own message. This buffer is read
-# only by _compute_source_weights to factor reminiscence into channel
-# weight decay alongside web/news/etc.
-#
-# Why 50 (not tied to PROACTIVE_CHAT_HISTORY_MAX=10): the two buffers serve
-# opposite sizing constraints. PROACTIVE_CHAT_HISTORY_MAX bounds *dedup*
-# memory (1h text-similarity check, 10 entries are plenty). This buffer
-# bounds *decay-signal completeness* — _compute_source_weights walks every
-# timestamp inside the _SOURCE_WEIGHT_WINDOW (=1h) for the exponential
-# decay sum, so the maxlen MUST be larger than the worst-case usage count
-# in that window or oldest entries get evicted and the channel under-
-# counts. 50 leaves ~5× safety margin for high-cadence proactive cycles.
-# Kept as a private module constant alongside the other _SOURCE_WEIGHT_*
-# tunables (_SOURCE_WEIGHT_DECAY_LAMBDA / _K / _FLOOR / _WINDOW) — it's
-# tied to that model's calibration, not a user-facing config knob.
-_REMINISCENCE_USAGE_MAX = 50
-
-
-_reminiscence_usage_history: dict[str, deque[float]] = {}
-
-
-def _record_reminiscence_usage(lanlan_name: str) -> None:
-    """Record one reminiscence usage timestamp for source-weight decay.
-
-    Kept separate from ``_record_proactive_chat`` to avoid polluting
-    the dedup / similarity history (which compares the proactive
-    response text against past entries by channel-agnostic match).
-    """
-    if lanlan_name not in _reminiscence_usage_history:
-        _reminiscence_usage_history[lanlan_name] = deque(maxlen=_REMINISCENCE_USAGE_MAX)
-    _reminiscence_usage_history[lanlan_name].append(time.time())
-
-
-def _record_proactive_chat(lanlan_name: str, message: str, channel: str = ''):
-    """
-    Record one successful proactive chat (with its source channel).
-    Logic:
-    - get the current timestamp
-    - append the record (timestamp, message content, channel) to the given model's queue in _proactive_chat_history
-    - if the queue is full, the oldest record is popped automatically, keeping the length within maxlen (default 10)
-    args:
-    - lanlan_name: model name
-    - message: chat content
-    - channel: source channel (optional, default 'vision')
-    """
-    if lanlan_name not in _proactive_chat_history:
-        _proactive_chat_history[lanlan_name] = deque(maxlen=PROACTIVE_CHAT_HISTORY_MAX)
-    _proactive_chat_history[lanlan_name].append((time.time(), message, channel))
-
-    # Telemetry：主动搭话实际投递。channel 是低基数 enum（vision/news/video/
-    # personal/music/meme/mini_game/...），截断防意外高基数。配合 settings_state
-    # 的 proactive 配置档，能看深度用户每天实际被主动搭话几次。
-    #
-    # 不在这里做 responded 回应率配对：用户消息分发在 core.py（main_logic 层），
-    # 主动搭话在 main_routers 层，module-layering CI 禁止 core.py 反向 import
-    # system_router；跨层共享"上次投递时刻"状态会破坏分层。回应率由 server 端
-    # 用 proactive_fired 时刻与用户消息活动 timestamp 关联粗估即可，要精确配对
-    # 再单独开 PR。
-    try:
-        from utils.instrument import counter as _instr_counter
-        _instr_counter("proactive_fired", channel=(str(channel) or "default")[:24])
-    except Exception:
-        # 埋点失败不能影响主动搭话投递
-        pass
-
-
-def _normalize_material_key(raw: str) -> str:
-    """Normalize a material identity string for exact-match dedup (lowercase + collapse whitespace)."""
-    s = (raw or "").strip().lower()
-    return re.sub(r'\s+', ' ', s)
-
-
-def _proactive_material_key(
-    source_tag: str | None,
-    selected_music_link: dict | None,
-    meme_content: dict | None,
-) -> str:
-    """Compute the dedup identity of the material this round pushes.
-
-    - MUSIC → the picked track (title|artist); two different songs never collide
-    - MEME → the **search keyword** (not the image): same keyword reused soon is a
-      repeat, a fresh keyword is not. Random hot-word fallback has an empty keyword
-      → empty key → treated as "never a repeat" (each random fetch is varied)
-
-    Empty/unknown → "" (caller treats as non-repeat, i.e. always exempt).
-    """
-    if source_tag == 'MUSIC' and selected_music_link:
-        title = (selected_music_link.get('title') or '').strip()
-        artist = (selected_music_link.get('artist') or '').strip()
-        return _normalize_material_key(f"{title}|{artist}") if (title or artist) else ""
-    if source_tag == 'MEME' and meme_content:
-        return _normalize_material_key(meme_content.get('keyword') or '')
-    return ""
-
-
-def _is_recent_proactive_material(lanlan_name: str, source_tag: str, key: str) -> bool:
-    """Whether *key* was pushed for *source_tag* within the recent window (exact match).
-
-    Empty key → never a repeat (no material identity to compare on).
-    """
-    if not key:
-        return False
-    bucket = _proactive_material_history.get(lanlan_name, {}).get(source_tag)
-    if not bucket:
-        return False
-    now = time.time()
-    return any(
-        k == key and now - ts < _RECENT_CHAT_MAX_AGE_SECONDS
-        for ts, k in bucket
-    )
-
-
-def _record_proactive_material(lanlan_name: str, source_tag: str, key: str) -> None:
-    """Record one successfully delivered material identity (skip empty keys)."""
-    if not key:
-        return
-    per_tag = _proactive_material_history.setdefault(lanlan_name, {})
-    if source_tag not in per_tag:
-        per_tag[source_tag] = deque(maxlen=_PROACTIVE_MATERIAL_HISTORY_MAX)
-    per_tag[source_tag].append((time.time(), key))
-
-
-def _proactive_chat_totals_path() -> Path:
-    return Path(get_config_manager().memory_dir) / _PROACTIVE_CHAT_TOTALS_FILENAME
+def _proactive_chat_totals_path():
+    return _state._proactive_chat_totals_path(memory_dir=_legacy_memory_dir())
 
 
 async def _ensure_proactive_chat_totals_loaded() -> None:
-    """Lazy-load the persisted cumulative counters + ever_delivered. Idempotent. File reads go to the thread pool.
-
-    schema: {"version": 2,
-             "totals": {<lanlan_name>: <int>, ...},
-             "ever_delivered": {<lanlan_name>: true, ...}}
-
-    A missing file / corrupted JSON is not fatal — start from empty, and the next
-    increment writes a fresh file. The old schema v1 has no ever_delivered field,
-    so it loads as an empty dict — after upgrading, the first proactive chat will
-    "force-first re-deliver once" for existing users (at most once, because
-    ever_delivered is set True and persisted immediately after delivery); this is
-    a one-off v1→v2 migration cost and needs no dedicated migration script."""
-    global _proactive_chat_totals_loaded
-    if _proactive_chat_totals_loaded:
-        return
-    async with _proactive_chat_totals_lock:
-        if _proactive_chat_totals_loaded:
-            return
-        path = _proactive_chat_totals_path()
-        try:
-            data = await asyncio.to_thread(read_json, path)
-            totals = data.get('totals') if isinstance(data, dict) else None
-            if isinstance(totals, dict):
-                for k, v in totals.items():
-                    if isinstance(k, str) and isinstance(v, (int, float)):
-                        _proactive_chat_totals[k] = int(v)
-            ever = data.get('ever_delivered') if isinstance(data, dict) else None
-            if isinstance(ever, dict):
-                for k, v in ever.items():
-                    if isinstance(k, str) and bool(v):
-                        _invite_ever_delivered[k] = True
-        except FileNotFoundError:
-            # 首次启动 / cleanup 后没文件——按全空起步，下次 increment 会创建。
-            # 不是异常，不打 warning。
-            pass
-        except Exception as exc:
-            logger.warning("proactive_chat_totals load failed: %s", exc)
-        _proactive_chat_totals_loaded = True
-
-
-def _get_proactive_chat_total(lanlan_name: str) -> int:
-    """Synchronous read of cached counter. 0 if loaded-but-unset or not loaded yet.
-
-    `_maybe_deliver_mini_game_invite` calls this after the caller has already
-    awaited `_ensure_proactive_chat_totals_loaded()`, so there is no await here."""
-    return int(_proactive_chat_totals.get(lanlan_name, 0))
-
-
-def _was_invite_ever_delivered(lanlan_name: str) -> bool:
-    """Synchronous read of ever-delivered flag.
-
-    The caller must await ``_ensure_proactive_chat_totals_loaded()`` first."""
-    return bool(_invite_ever_delivered.get(lanlan_name, False))
+    await _state._ensure_proactive_chat_totals_loaded(memory_dir=_legacy_memory_dir())
 
 
 async def _persist_totals_unlocked() -> None:
-    """Persist totals + ever_delivered to disk. The caller must hold _proactive_chat_totals_lock."""
-    try:
-        await atomic_write_json_async(
-            _proactive_chat_totals_path(),
-            {
-                'version': _PROACTIVE_CHAT_TOTALS_SCHEMA_VERSION,
-                'totals': dict(_proactive_chat_totals),
-                'ever_delivered': dict(_invite_ever_delivered),
-            },
-            indent=2,
-            ensure_ascii=False,
-        )
-    except Exception as exc:
-        logger.warning(
-            "proactive_chat_totals persist failed (in-memory still up-to-date): %s",
-            exc,
-        )
+    await _state._persist_totals_unlocked(memory_dir=_legacy_memory_dir())
 
 
 async def _increment_proactive_chat_total(lanlan_name: str) -> int:
-    """+1 cached counter and persist atomically. Returns new value.
-
-    Serialization is guaranteed by ``_proactive_chat_totals_lock``: concurrent
-    proactive_chat calls each await a serial update, so no increment is lost.
-    Persistence failures are not raised to the caller — the counter is
-    best-effort; losing one +1 is not fatal, but the log line is kept."""
-    await _ensure_proactive_chat_totals_loaded()
-    async with _proactive_chat_totals_lock:
-        new_value = _proactive_chat_totals.get(lanlan_name, 0) + 1
-        _proactive_chat_totals[lanlan_name] = new_value
-        await _persist_totals_unlocked()
-    return new_value
+    return await _state._increment_proactive_chat_total(
+        lanlan_name,
+        memory_dir=_legacy_memory_dir(),
+    )
 
 
 async def _mark_invite_ever_delivered(lanlan_name: str) -> None:
-    """One-shot set-True + persist. Skips the disk write when already True to save IO.
-
-    Shares ``_proactive_chat_totals_lock`` with ``_increment_proactive_chat_total``
-    so concurrent updates write totals + ever_delivered together atomically.
-
-    ⚠️ The invite delivery path must not call ``_increment_proactive_chat_total +
-    _mark_invite_ever_delivered`` separately — the lock is released between the
-    two awaits, and a process dying in between leaves a ``totals: N+1,
-    ever_delivered: stale`` half-state on disk, making force-first fire once more
-    after restart. Use ``_record_invite_delivery_persistent`` for one atomic
-    write under a single lock."""
-    await _ensure_proactive_chat_totals_loaded()
-    async with _proactive_chat_totals_lock:
-        if _invite_ever_delivered.get(lanlan_name):
-            return
-        _invite_ever_delivered[lanlan_name] = True
-        await _persist_totals_unlocked()
+    await _state._mark_invite_ever_delivered(
+        lanlan_name,
+        memory_dir=_legacy_memory_dir(),
+    )
 
 
 async def _record_invite_delivery_persistent(lanlan_name: str) -> int:
-    """Atomic persistent record of one successfully delivered mini-game invite:
-    counter +1 + ever_delivered=True written to disk once under one lock.
-    Returns the new total.
-
-    Reason to exist: doing +1 then mark as two separate awaits releases the lock
-    in between; a process crash / coroutine cancel can leave a ``totals: N+1,
-    ever_delivered: stale`` half-state on disk — after restart
-    ``_was_invite_ever_delivered`` sees the stale false and force-first fires
-    again. Pointed out by CodeRabbit Major review."""
-    await _ensure_proactive_chat_totals_loaded()
-    async with _proactive_chat_totals_lock:
-        new_value = _proactive_chat_totals.get(lanlan_name, 0) + 1
-        _proactive_chat_totals[lanlan_name] = new_value
-        _invite_ever_delivered[lanlan_name] = True
-        await _persist_totals_unlocked()
-    return new_value
-
-
-def _clear_channel_from_proactive_history(lanlan_name: str, channel: str) -> int:
-    """Blank out the channel mark of the given channel's entries in _proactive_chat_history.
-
-    Purpose: when the user gives strong positive feedback (e.g. a recommended
-    song played all the way through), that amounts to explicitly accepting this
-    channel's recent output, so _compute_source_weights should no longer
-    penalize the channel for "just used". Clearing the channel field stops
-    raw_score from accumulating those entries, while the message text stays in
-    the deque for dedup / similarity / format_recent_proactive_chats reuse.
-
-    Returns the number of entries cleared.
-    """
-    history = _proactive_chat_history.get(lanlan_name)
-    if not history:
-        return 0
-    rewritten: list[tuple] = []
-    cleared = 0
-    for entry in history:
-        if len(entry) >= 3 and entry[2] == channel:
-            rewritten.append((entry[0], entry[1], ''))
-            cleared += 1
-        else:
-            rewritten.append(entry)
-    if cleared == 0:
-        return 0
-    history.clear()
-    history.extend(rewritten)
-    return cleared
-
-
-def _normalize_text_for_similarity(text: str) -> str:
-    """
-    Text normalization (conservative strategy):
-    - lowercase
-    - collapse consecutive whitespace
-    Only light normalization, to avoid false kills from over-cleaning.
-    """
-    text = (text or "").strip().lower()
-    return re.sub(r'\s+', ' ', text)
-
-
-def _is_similar_to_recent_proactive_chat(lanlan_name: str, message: str) -> tuple[bool, float]:
-    """
-    Check whether message is highly similar to recent proactive chats (high threshold against false kills).
-    Returns (is_duplicate, best_score).
-    """
-    history = _proactive_chat_history.get(lanlan_name)
-    if not history or not message.strip():
-        return False, 0.0
-
-    now = time.time()
-    current = _normalize_text_for_similarity(message)
-    if not current:
-        return False, 0.0
-
-    best = 0.0
-    for entry in history:
-        ts, old_msg = entry[0], entry[1]
-        if now - ts >= _RECENT_CHAT_MAX_AGE_SECONDS:
-            continue
-        old_norm = _normalize_text_for_similarity(old_msg)
-        if not old_norm:
-            continue
-        score = difflib.SequenceMatcher(None, current, old_norm).ratio()
-        if score > best:
-            best = score
-        if score >= _PROACTIVE_SIMILARITY_THRESHOLD:
-            return True, score
-    return False, best
+    return await _state._record_invite_delivery_persistent(
+        lanlan_name,
+        memory_dir=_legacy_memory_dir(),
+    )

--- a/main_routers/system_router/proactive_history.py
+++ b/main_routers/system_router/proactive_history.py
@@ -29,7 +29,6 @@ from main_logic.proactive_chat.state import (  # noqa: F401
     _proactive_chat_totals,
     _invite_ever_delivered,
     _proactive_chat_totals_lock,
-    _proactive_chat_totals_loaded,
     _RECENT_CHAT_MAX_AGE_SECONDS,
     _PROACTIVE_SIMILARITY_THRESHOLD,
     _format_recent_proactive_chats,
@@ -48,6 +47,12 @@ from main_logic.proactive_chat.state import (  # noqa: F401
     _is_similar_to_recent_proactive_chat,
 )
 from ..shared_state import get_config_manager as _get_legacy_config_manager
+
+
+def __getattr__(name: str):
+    if name == "_proactive_chat_totals_loaded":
+        return _state._proactive_chat_totals_loaded
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def _legacy_memory_dir():

--- a/main_routers/system_router/proactive_sources.py
+++ b/main_routers/system_router/proactive_sources.py
@@ -13,126 +13,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Proactive source decay history (persistent) and source weight
-computation for proactive phase 1 source selection.
+"""Compatibility facade for proactive source state and decisions."""
 
-Split out of the former monolithic ``main_routers/system_router.py``.
-"""
-
-from ._shared import logger
-from .proactive_history import _RECENT_CHAT_MAX_AGE_SECONDS, _proactive_chat_history, _reminiscence_usage_history
-import asyncio
-import hashlib
-import random
-import re
-import time
-from pathlib import Path
-from typing import Any
-from ..shared_state import get_config_manager
-from config import (
-    PROACTIVE_SOURCE_HARD_SKIP_SECONDS,
-    PROACTIVE_SOURCE_HALF_LIFE_BY_KIND,
-    PROACTIVE_SOURCE_HALF_LIFE_DEFAULT,
-    PROACTIVE_SOURCE_FORGET_P,
+from main_logic.proactive_chat import state as _state
+from main_logic.proactive_chat.decisions import (  # noqa: F401
+    _SOURCE_WEIGHT_DECAY_LAMBDA,
+    _SOURCE_WEIGHT_FLOOR,
+    _SOURCE_WEIGHT_K,
+    _SOURCE_WEIGHT_WINDOW,
+    _compute_source_weights,
+    _filter_sources_by_weight,
+    _should_skip_source,
 )
-from utils.file_utils import atomic_write_json_async, read_json
+from main_logic.proactive_chat.state import (  # noqa: F401
+    _SOURCE_HISTORY_FILENAME,
+    _SOURCE_HISTORY_SCHEMA_VERSION,
+    _half_life_for,
+    _source_hash,
+    _source_history,
+    _source_history_loaded,
+    _source_history_lock,
+    _source_skip_probability,
+)
+from ..shared_state import get_config_manager as _get_legacy_config_manager
 
 
-# --- 全局来源衰减历史（跨角色 / 持久化）---
-# 主动搭话消费过的 web / music / image 链接进入这里，按 URL hash 索引。
-# 5h 内硬 skip（p_skip=1），其后按 kind 各自半衰期指数衰减；p_skip 低于阈值
-# 时直接遗忘。所有 IO 走 asyncio.to_thread / atomic_write_json_async，过滤
-# 路径只读 dict + RNG，不阻塞 event loop。
-# （衰减参数定义在 config/__init__.py 与项目其他 budget 常量统一维护）
-_SOURCE_HISTORY_FILENAME = "proactive_source_history.json"
+def _legacy_memory_dir():
+    return _get_legacy_config_manager().memory_dir
 
 
-_SOURCE_HISTORY_SCHEMA_VERSION = 1
-
-
-_source_history: dict[str, dict[str, Any]] = {}
-
-
-_source_history_lock = asyncio.Lock()
-
-
-_source_history_loaded = False
-
-
-def _source_history_path() -> Path:
-    return Path(get_config_manager().memory_dir) / _SOURCE_HISTORY_FILENAME
-
-
-def _source_hash(url: str = '', fallback_title: str = '') -> str:
-    """URL first, otherwise the normalized title as fallback. An empty string means "cannot be identified stably"."""
-    norm = (url or '').strip().lower().rstrip('/')
-    if norm:
-        return hashlib.sha256(norm.encode('utf-8')).hexdigest()
-    title_norm = re.sub(r'\s+', ' ', (fallback_title or '').strip().lower())
-    if title_norm:
-        return hashlib.sha256(('t::' + title_norm).encode('utf-8')).hexdigest()
-    return ''
-
-
-def _half_life_for(kind: str) -> float:
-    return PROACTIVE_SOURCE_HALF_LIFE_BY_KIND.get(kind, PROACTIVE_SOURCE_HALF_LIFE_DEFAULT)
-
-
-def _source_skip_probability(age: float, half_life: float) -> float:
-    if age < PROACTIVE_SOURCE_HARD_SKIP_SECONDS:
-        return 1.0
-    decay_age = age - PROACTIVE_SOURCE_HARD_SKIP_SECONDS
-    return 0.5 ** (decay_age / half_life)
-
-
-def _should_skip_source(url_hash: str) -> bool:
-    """Synchronous, purely in-memory check, O(1); callable directly inside the synchronous picking loop."""
-    if not url_hash:
-        return False
-    entry = _source_history.get(url_hash)
-    if not entry:
-        return False
-    age = time.time() - entry.get('ts', 0.0)
-    p = _source_skip_probability(age, _half_life_for(entry.get('kind', 'web')))
-    if p >= 1.0:
-        return True
-    if p <= 0.0:
-        return False
-    return random.random() < p
+def _source_history_path():
+    return _state._source_history_path(memory_dir=_legacy_memory_dir())
 
 
 async def _ensure_source_history_loaded() -> None:
-    """Lazy loading, idempotent. The file read goes to the thread pool and does not block the event loop."""
-    global _source_history_loaded
-    if _source_history_loaded:
-        return
-    async with _source_history_lock:
-        if _source_history_loaded:
-            return
-        path = _source_history_path()
-        try:
-            data = await asyncio.to_thread(read_json, path)
-            entries = data.get('entries') if isinstance(data, dict) else None
-            if isinstance(entries, dict):
-                # 加载时顺便丢掉早已遗忘阈值之下的条目
-                now = time.time()
-                for h, entry in entries.items():
-                    if not isinstance(entry, dict):
-                        continue
-                    age = now - float(entry.get('ts', 0.0) or 0.0)
-                    p = _source_skip_probability(
-                        age, _half_life_for(entry.get('kind', 'web'))
-                    )
-                    if p >= PROACTIVE_SOURCE_FORGET_P:
-                        _source_history[h] = entry
-        except FileNotFoundError:
-            # 首次运行 / 全新机器：尚无历史文件，按空历史继续
-            pass
-        except Exception as e:
-            logger.warning(
-                f"加载 {_SOURCE_HISTORY_FILENAME} 失败，按空历史处理: {type(e).__name__}: {e}"
-            )
-        _source_history_loaded = True
+    await _state._ensure_source_history_loaded(memory_dir=_legacy_memory_dir())
 
 
 async def _record_source_used(
@@ -141,144 +56,9 @@ async def _record_source_used(
     kind: str,
     title: str = '',
 ) -> None:
-    """Called after a source is consumed or deliberately suppressed: update memory → prune → persist.
-
-    Concurrent records are serialized by an asyncio.Lock; persistence goes through
-    atomic_write_json_async (fsync + os.replace in the thread pool), so the main
-    coroutine is never stalled by disk IO.
-    """
-    h = _source_hash(url, title)
-    if not h:
-        return
-    snapshot: dict[str, Any] | None = None
-    async with _source_history_lock:
-        _source_history[h] = {
-            "ts": time.time(),
-            "kind": kind,
-            "title": (title or '')[:80],
-        }
-        # 顺手 prune：写盘前剔除已遗忘条目，文件体积自然有界
-        now = time.time()
-        forget = [
-            hh for hh, entry in _source_history.items()
-            if _source_skip_probability(
-                now - float(entry.get('ts', 0.0) or 0.0),
-                _half_life_for(entry.get('kind', 'web'))
-            ) < PROACTIVE_SOURCE_FORGET_P
-        ]
-        for hh in forget:
-            _source_history.pop(hh, None)
-        snapshot = {
-            "v": _SOURCE_HISTORY_SCHEMA_VERSION,
-            "entries": dict(_source_history),
-        }
-    try:
-        await atomic_write_json_async(_source_history_path(), snapshot)
-    except Exception as e:
-        # 写盘失败不影响主流程：下一次 record 会整文件重写覆盖
-        logger.warning(
-            f"落盘 {_SOURCE_HISTORY_FILENAME} 失败: {type(e).__name__}: {e}"
-        )
-
-
-# --- 来源动态权重系统 ---
-_SOURCE_WEIGHT_DECAY_LAMBDA = 0.002   # 指数衰减系数，半衰期 ≈ 5.8 分钟
-
-
-_SOURCE_WEIGHT_K = 0.30               # freshness 惩罚系数：freshness = 1 / (1 + k * raw_score)
-
-
-_SOURCE_WEIGHT_FLOOR = 0.20           # 归一化权重绝对下限
-
-
-def _compute_source_weights(
-    lanlan_name: str,
-    candidate_channels: list[str],
-) -> dict[str, float]:
-    """
-    Compute normalized weights for each source.
-
-    Algorithm:
-    1. take records within 1h from _proactive_chat_history
-    2. raw_score[ch] = Σ exp(-λ·age)  (each use accumulates with time decay)
-    3. freshness[ch] = 1 / (1 + k·raw_score[ch])
-    4. normalize: weight[ch] = freshness[ch] / Σ freshness
-
-    With no history, returns a uniform distribution.
-
-    Args:
-        lanlan_name: character name
-        candidate_channels: channels participating in the weighting (excluding vision)
-
-    Returns:
-        {channel: normalized_weight}, with weights summing to 1.0
-    """
-    import math
-    n = len(candidate_channels)
-    if n == 0:
-        return {}
-
-    # 收集 1h 内历史
-    history = _proactive_chat_history.get(lanlan_name)
-    now = time.time()
-
-    raw_scores: dict[str, float] = {ch: 0.0 for ch in candidate_channels}
-
-    if history:
-        for ts, _msg, ch in history:
-            age = now - ts
-            if age > _SOURCE_WEIGHT_WINDOW:
-                continue
-            if ch in raw_scores:
-                raw_scores[ch] += math.exp(-_SOURCE_WEIGHT_DECAY_LAMBDA * age)
-
-    # Reminiscence usage lives in a separate buffer (kept out of
-    # _proactive_chat_history to avoid polluting dedup / similarity
-    # checks). Inject its decayed-frequency contribution here so the
-    # weight calculation treats it on the same footing as web/news/etc.
-    if 'reminiscence' in raw_scores:
-        rem_buf = _reminiscence_usage_history.get(lanlan_name)
-        if rem_buf:
-            for ts in rem_buf:
-                age = now - ts
-                if age > _SOURCE_WEIGHT_WINDOW:
-                    continue
-                raw_scores['reminiscence'] += math.exp(-_SOURCE_WEIGHT_DECAY_LAMBDA * age)
-
-    # freshness: 使用越多 → raw 越高 → freshness 越低
-    freshness: dict[str, float] = {}
-    for ch in candidate_channels:
-        freshness[ch] = 1.0 / (1.0 + _SOURCE_WEIGHT_K * raw_scores[ch])
-
-    total = sum(freshness.values())
-    if total <= 0:
-        # 不可能发生，但做防御
-        return {ch: 1.0 / n for ch in candidate_channels}
-
-    return {ch: freshness[ch] / total for ch in candidate_channels}
-
-
-def _filter_sources_by_weight(weights: dict[str, float]) -> set[str]:
-    """
-    Return the set of channels that should be culled.
-
-    Threshold = min(_SOURCE_WEIGHT_FLOOR, 1 / N)
-    - with 4 channels, threshold=0.20; 2 uses trigger culling
-    - with 6 channels, threshold=0.167; competition is fiercer
-
-    Args:
-        weights: normalized weights returned by _compute_source_weights
-
-    Returns:
-        set of channel names to cull
-    """
-    n = len(weights)
-    if n <= 1:
-        return set()  # 只剩 1 个来源时不剔除
-
-    threshold = min(_SOURCE_WEIGHT_FLOOR, 1.0 / n)
-    return {ch for ch, w in weights.items() if w < threshold}
-
-
-# 复用 _RECENT_CHAT_MAX_AGE_SECONDS 作为权重窗口
-_SOURCE_WEIGHT_WINDOW = _RECENT_CHAT_MAX_AGE_SECONDS
+    await _state._record_source_used(
+        url=url,
+        kind=kind,
+        title=title,
+        memory_dir=_legacy_memory_dir(),
+    )

--- a/main_routers/system_router/proactive_sources.py
+++ b/main_routers/system_router/proactive_sources.py
@@ -31,11 +31,16 @@ from main_logic.proactive_chat.state import (  # noqa: F401
     _half_life_for,
     _source_hash,
     _source_history,
-    _source_history_loaded,
     _source_history_lock,
     _source_skip_probability,
 )
 from ..shared_state import get_config_manager as _get_legacy_config_manager
+
+
+def __getattr__(name: str):
+    if name == "_source_history_loaded":
+        return _state._source_history_loaded
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def _legacy_memory_dir():

--- a/tests/unit/test_music_played_through_reset.py
+++ b/tests/unit/test_music_played_through_reset.py
@@ -15,9 +15,9 @@ import pytest
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
 
-from main_routers.system_router import proactive_history as sr
-from main_routers.system_router import proactive_sources as sr_sources
-from main_routers.system_router import proactive_parsing as sr_parsing
+from main_logic.proactive_chat import state as sr
+from main_logic.proactive_chat import decisions as sr_sources
+from main_logic.proactive_chat import contracts as sr_parsing
 
 
 LL = "测试娘"

--- a/tests/unit/test_proactive_state_persistence.py
+++ b/tests/unit/test_proactive_state_persistence.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from main_logic.proactive_chat import state
+from main_routers import system_router
 from main_routers.system_router import proactive_history, proactive_sources
 
 
@@ -15,18 +16,22 @@ from main_routers.system_router import proactive_history, proactive_sources
 def _restore_state_globals():
     source_history = dict(state._source_history)
     source_loaded = state._source_history_loaded
+    source_loaded_path = state._source_history_loaded_path
     totals = dict(state._proactive_chat_totals)
     ever_delivered = dict(state._invite_ever_delivered)
     totals_loaded = state._proactive_chat_totals_loaded
+    totals_loaded_path = state._proactive_chat_totals_loaded_path
     yield
     state._source_history.clear()
     state._source_history.update(source_history)
     state._source_history_loaded = source_loaded
+    state._source_history_loaded_path = source_loaded_path
     state._proactive_chat_totals.clear()
     state._proactive_chat_totals.update(totals)
     state._invite_ever_delivered.clear()
     state._invite_ever_delivered.update(ever_delivered)
     state._proactive_chat_totals_loaded = totals_loaded
+    state._proactive_chat_totals_loaded_path = totals_loaded_path
 
 
 def test_explicit_memory_dir_overrides_singleton_fallback(monkeypatch, tmp_path) -> None:
@@ -169,3 +174,74 @@ def test_legacy_facades_share_canonical_mutable_state() -> None:
         proactive_history._proactive_chat_totals_lock
         is state._proactive_chat_totals_lock
     )
+
+
+def test_legacy_facades_read_live_loaded_flags() -> None:
+    state._source_history_loaded = False
+    state._proactive_chat_totals_loaded = False
+    assert proactive_sources._source_history_loaded is False
+    assert proactive_history._proactive_chat_totals_loaded is False
+    assert system_router._source_history_loaded is False
+    assert system_router._proactive_chat_totals_loaded is False
+
+    state._source_history_loaded = True
+    state._proactive_chat_totals_loaded = True
+    assert proactive_sources._source_history_loaded is True
+    assert proactive_history._proactive_chat_totals_loaded is True
+    assert system_router._source_history_loaded is True
+    assert system_router._proactive_chat_totals_loaded is True
+
+
+@pytest.mark.asyncio
+async def test_source_history_reloads_when_memory_root_changes(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    root_a = tmp_path / "a"
+    root_b = tmp_path / "b"
+
+    def read_json(path):
+        return {
+            "entries": {
+                path.parent.name: {
+                    "ts": state.time.time(),
+                    "kind": "web",
+                }
+            }
+        }
+
+    monkeypatch.setattr(state, "read_json", read_json)
+    state._source_history_loaded = False
+    state._source_history_loaded_path = None
+
+    await state._ensure_source_history_loaded(memory_dir=root_a)
+    assert set(state._source_history) == {"a"}
+    await state._ensure_source_history_loaded(memory_dir=root_b)
+    assert set(state._source_history) == {"b"}
+
+
+@pytest.mark.asyncio
+async def test_totals_reload_when_memory_root_changes(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    root_a = tmp_path / "a"
+    root_b = tmp_path / "b"
+
+    def read_json(path):
+        total = 1 if path.parent == root_a else 2
+        return {
+            "totals": {"Yui": total},
+            "ever_delivered": {path.parent.name: True},
+        }
+
+    monkeypatch.setattr(state, "read_json", read_json)
+    state._proactive_chat_totals_loaded = False
+    state._proactive_chat_totals_loaded_path = None
+
+    await state._ensure_proactive_chat_totals_loaded(memory_dir=root_a)
+    assert state._proactive_chat_totals == {"Yui": 1}
+    assert state._invite_ever_delivered == {"a": True}
+    await state._ensure_proactive_chat_totals_loaded(memory_dir=root_b)
+    assert state._proactive_chat_totals == {"Yui": 2}
+    assert state._invite_ever_delivered == {"b": True}

--- a/tests/unit/test_proactive_state_persistence.py
+++ b/tests/unit/test_proactive_state_persistence.py
@@ -1,0 +1,171 @@
+"""Persistence-root compatibility tests for proactive-chat state."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from main_logic.proactive_chat import state
+from main_routers.system_router import proactive_history, proactive_sources
+
+
+@pytest.fixture(autouse=True)
+def _restore_state_globals():
+    source_history = dict(state._source_history)
+    source_loaded = state._source_history_loaded
+    totals = dict(state._proactive_chat_totals)
+    ever_delivered = dict(state._invite_ever_delivered)
+    totals_loaded = state._proactive_chat_totals_loaded
+    yield
+    state._source_history.clear()
+    state._source_history.update(source_history)
+    state._source_history_loaded = source_loaded
+    state._proactive_chat_totals.clear()
+    state._proactive_chat_totals.update(totals)
+    state._invite_ever_delivered.clear()
+    state._invite_ever_delivered.update(ever_delivered)
+    state._proactive_chat_totals_loaded = totals_loaded
+
+
+def test_explicit_memory_dir_overrides_singleton_fallback(monkeypatch, tmp_path) -> None:
+    singleton_root = tmp_path / "singleton"
+    injected_root = tmp_path / "injected"
+    monkeypatch.setattr(
+        state,
+        "get_config_manager",
+        lambda: SimpleNamespace(memory_dir=singleton_root),
+    )
+
+    assert state._source_history_path() == (
+        singleton_root / state._SOURCE_HISTORY_FILENAME
+    )
+    assert state._proactive_chat_totals_path() == (
+        singleton_root / state._PROACTIVE_CHAT_TOTALS_FILENAME
+    )
+    assert state._source_history_path(memory_dir=injected_root) == (
+        injected_root / state._SOURCE_HISTORY_FILENAME
+    )
+    assert state._proactive_chat_totals_path(memory_dir=injected_root) == (
+        injected_root / state._PROACTIVE_CHAT_TOTALS_FILENAME
+    )
+
+
+@pytest.mark.asyncio
+async def test_source_history_reads_and_writes_only_in_explicit_root(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    injected_root = tmp_path / "injected"
+    expected_path = injected_root / state._SOURCE_HISTORY_FILENAME
+    reads = []
+
+    def read_json(path):
+        reads.append(path)
+        return {"v": state._SOURCE_HISTORY_SCHEMA_VERSION, "entries": {}}
+
+    writer = AsyncMock()
+    monkeypatch.setattr(state, "read_json", read_json)
+    monkeypatch.setattr(state, "atomic_write_json_async", writer)
+    monkeypatch.setattr(
+        state,
+        "get_config_manager",
+        lambda: pytest.fail("singleton manager must not be read"),
+    )
+    state._source_history.clear()
+    state._source_history_loaded = False
+
+    await state._ensure_source_history_loaded(memory_dir=injected_root)
+    await state._record_source_used(
+        url="https://example.test/topic",
+        kind="web",
+        title="topic",
+        memory_dir=injected_root,
+    )
+
+    assert reads == [expected_path]
+    assert writer.await_count == 1
+    assert writer.await_args.args[0] == expected_path
+    assert writer.await_args.args[1]["v"] == state._SOURCE_HISTORY_SCHEMA_VERSION
+
+
+@pytest.mark.asyncio
+async def test_totals_schema_and_atomic_invite_update_use_explicit_root(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    injected_root = tmp_path / "injected"
+    expected_path = injected_root / state._PROACTIVE_CHAT_TOTALS_FILENAME
+    writer = AsyncMock()
+    monkeypatch.setattr(state, "read_json", lambda path: {})
+    monkeypatch.setattr(state, "atomic_write_json_async", writer)
+    monkeypatch.setattr(
+        state,
+        "get_config_manager",
+        lambda: pytest.fail("singleton manager must not be read"),
+    )
+    state._proactive_chat_totals.clear()
+    state._invite_ever_delivered.clear()
+    state._proactive_chat_totals_loaded = False
+
+    assert await state._increment_proactive_chat_total(
+        "Yui", memory_dir=injected_root
+    ) == 1
+    assert await state._record_invite_delivery_persistent(
+        "Yui", memory_dir=injected_root
+    ) == 2
+
+    assert writer.await_count == 2
+    for write in writer.await_args_list:
+        assert write.args[0] == expected_path
+        assert write.args[1]["version"] == state._PROACTIVE_CHAT_TOTALS_SCHEMA_VERSION
+    final_snapshot = writer.await_args_list[-1].args[1]
+    assert final_snapshot["totals"] == {"Yui": 2}
+    assert final_snapshot["ever_delivered"] == {"Yui": True}
+
+
+@pytest.mark.asyncio
+async def test_legacy_facades_resolve_router_shared_state_manager(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    legacy_root = tmp_path / "legacy-injected"
+    manager = SimpleNamespace(memory_dir=legacy_root)
+    monkeypatch.setattr(
+        proactive_sources,
+        "_get_legacy_config_manager",
+        lambda: manager,
+    )
+    monkeypatch.setattr(
+        proactive_history,
+        "_get_legacy_config_manager",
+        lambda: manager,
+    )
+    ensure_sources = AsyncMock()
+    increment_total = AsyncMock(return_value=1)
+    monkeypatch.setattr(state, "_ensure_source_history_loaded", ensure_sources)
+    monkeypatch.setattr(state, "_increment_proactive_chat_total", increment_total)
+
+    assert proactive_sources._source_history_path() == (
+        legacy_root / state._SOURCE_HISTORY_FILENAME
+    )
+    assert proactive_history._proactive_chat_totals_path() == (
+        legacy_root / state._PROACTIVE_CHAT_TOTALS_FILENAME
+    )
+    await proactive_sources._ensure_source_history_loaded()
+    assert await proactive_history._increment_proactive_chat_total("Yui") == 1
+
+    ensure_sources.assert_awaited_once_with(memory_dir=legacy_root)
+    increment_total.assert_awaited_once_with("Yui", memory_dir=legacy_root)
+
+
+def test_legacy_facades_share_canonical_mutable_state() -> None:
+    assert proactive_sources._source_history is state._source_history
+    assert proactive_sources._source_history_lock is state._source_history_lock
+    assert proactive_history._proactive_chat_totals is state._proactive_chat_totals
+    assert proactive_history._invite_ever_delivered is state._invite_ever_delivered
+    assert (
+        proactive_history._proactive_chat_totals_lock
+        is state._proactive_chat_totals_lock
+    )

--- a/tests/unit/test_proactive_state_persistence.py
+++ b/tests/unit/test_proactive_state_persistence.py
@@ -229,7 +229,12 @@ async def test_totals_reload_when_memory_root_changes(
     root_b = tmp_path / "b"
 
     def read_json(path):
-        total = 1 if path.parent == root_a else 2
+        if path.parent == root_a:
+            total = 1
+        elif path.parent == root_b:
+            total = 2
+        else:
+            raise AssertionError(f"unexpected totals path: {path}")
         return {
             "totals": {"Yui": total},
             "ever_delivered": {path.parent.name: True},


### PR DESCRIPTION
## 改动概述

- 将主动聊天的命令与结果契约、可变状态、持久化逻辑以及纯入口与来源决策提取到 `main_logic/proactive_chat/`。
- 通过轻量兼容门面保留现有 Router 编排方式和旧版导入路径。
- 保持注入的 `memory_dir`、历史记录与计数器语义、随机调用顺序以及传输契约不变。

## 背景与必要性

Router 当前同时承担框架编排职责和领域状态管理。本 PR 在不改变编排机制的前提下，为状态和契约建立唯一的规范归属，以便在后续能力层和 Service PR 之前独立完成审查与合并。

## 回归报告

| 区域 | 变更前 | 变更后 | 审查重点 |
|---|---|---|---|
| `contracts.py` | 命令与结果映射位于 Router 辅助函数中 | 类型化命令与结果，以及原因、阶段和动作映射由单一模块统一管理 | HTTP 状态码和传输结构兼容性 |
| `state.py` | 历史记录、计数器、锁和持久化逻辑位于 Router 下 | 由单一领域状态模块统一管理；Router 门面重新导出相同对象 | 注入的持久化根目录、原子写入、无重复状态 |
| `decisions.py` | 入口门控和来源决策混杂在编排逻辑中 | 纯决策逻辑已隔离；Router 仍负责控制编排 | 门控顺序、随机调用次数、来源优先级 |
| `__init__.py` | 不存在领域包边界 | 定义包，但不在导入时执行注册 | 不产生 Router 导入或钩子副作用 |

未修改 `app/` 和 `memory/`。

## 不拆分理由

不适用：本 PR 计入阈值的文件数未超过 20；本次重构已拆分为四个按顺序合并的独立 PR。

## 兼容性与风险

- 现有 Router 导出仍然可用。
- HTTP、WebSocket、插件、提示词、概率及前端协议均无变更。
- 主要审查风险是持久化根目录注入、共享可变对象的身份一致性、原因与阶段映射以及随机决策顺序。

## 验证结果

- Ruff 已在四个 PR 的集成验证中通过。
- PR 局部审查回归：`122 passed`，包括 `25` 个持久化、兼容性与响应测试，以及 `97` 个小游戏测试。
- 最新审核修正的定向测试：`1 passed`。
- 四个 PR 合并后的主动聊天回归：`766 passed`。
- 合并后的 `tests/unit`：`6247 passed, 18 skipped, 20 failed`。
- 最新干净的 `upstream/main`：`6188 passed, 18 skipped, 20 failed`；失败节点完全相同。

## 合并顺序

本 PR 为四个顺序合并 PR 中的第一个。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## CodeRabbit 摘要

- **新功能**
  - 提供主动聊天的统一请求与响应契约，以及结果状态管理，包括原因码和阶段补全。
  - 新增前瞻主动聊天的入口与来源决策，支持通道选择、活动与隐私门控、节流以及基于历史的抑制和跳过概率。
  - 强化主动聊天状态与素材、来源的去重衰减，并持久化小游戏邀请计数与投递标记。
- **兼容性**
  - 通过兼容性外观层迁移旧的历史与来源能力，并按新根目录隔离持久化数据。
- **测试**
  - 新增持久化、根目录隔离与兼容性外观层行为测试，并更新相关单元测试导入路径。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->