### PR TITLE
优化聊天字体与紧凑聊天框玻璃质感，内置悠哉字体及许可证；修复历史阴影裁切、展开矩形阴影、导出预览边缘、暗背景输入可读性和毛线球焦点圈；统一…

### DIFF
--- a/frontend/react-neko-chat/public/LICENSE-Yozai-OFL-1.1.txt
+++ b/frontend/react-neko-chat/public/LICENSE-Yozai-OFL-1.1.txt
@@ -1,0 +1,94 @@
+Copyright 2020, 2024 LXGW (https://github.com/lxgw/yozai-font)
+Copyright (c) 2021-03-07, Y.Oz (Y.OzVox) (http://yozvox.web.fc2.com), words containing "Y.Oz" or "YOz" are reserved as font names.
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created using
+the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -5619,7 +5619,7 @@ describe('App', () => {
 
     const editButton = container.querySelector('.avatar-tool-quickbar-edit') as HTMLButtonElement;
     expect(editButton).not.toBeNull();
-    editButton.focus();
+    act(() => editButton.focus());
     expect(editButton).toHaveFocus();
     fireEvent.click(editButton);
 
@@ -6749,6 +6749,86 @@ describe('App', () => {
     );
   });
 
+  it('uses the bundled Yozai font for conversation content while controls keep the UI font', () => {
+    expect(compactChatStyles).toMatch(
+      /@font-face\s*\{[\s\S]*?font-family:\s*"Neko Chat Hand";[\s\S]*?url\("\/assets\/Yozai-Medium\.ttf"\)/,
+    );
+    expect(compactChatStyles).toContain('--neko-ui-font: "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;');
+    expect(compactChatStyles).toContain('--neko-chat-content-font: "Neko Chat Hand", "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;');
+    expect(compactChatStyles).toMatch(
+      /\.message-block-text,\s*\.message-block-markdown,\s*\.composer-input,\s*\.compact-chat-capsule-text\s*\{[\s\S]*?font-family:\s*var\(--neko-chat-content-font\);/,
+    );
+    expect(compactChatStyles).toMatch(
+      /\.composer-choice-layer,\s*\.avatar-tool-manager-dialog\s*\{[\s\S]*?font-family:\s*var\(--neko-ui-font\);/,
+    );
+    expect(compactChatStyles).not.toContain('Neko ChillReunion Round');
+  });
+
+  it('gives the compact surface the full chat liquid-glass edge hierarchy', () => {
+    const steadyFrameRule = compactChatStyles.match(/\.compact-chat-surface-frame\s*\{[\s\S]*?\n\}/)?.[0] ?? '';
+    expect(compactChatStyles).toContain('--compact-chat-surface-edge-top: rgba(255, 255, 255, 0.7);');
+    expect(compactChatStyles).toContain('border-width: 2px 1px 1px 1px;');
+    expect(compactChatStyles).toContain('box-shadow: var(--compact-chat-surface-shadow);');
+    expect(steadyFrameRule).not.toContain('clip-path: inset(0 round 999px);');
+    expect(compactChatStyles).toMatch(
+      /\.compact-chat-surface-frame::after\s*\{[\s\S]*?radial-gradient\(ellipse at 14% 4%[\s\S]*?inset -2px 0 4px[\s\S]*?animation: compact-chat-liquid-edge 20s ease-in-out infinite;/,
+    );
+    expect(compactChatStyles).toContain('@keyframes compact-chat-liquid-edge');
+    expect(compactChatStyles).toMatch(
+      /@media \(prefers-reduced-motion: reduce\)\s*\{\s*\.compact-chat-surface-frame::after\s*\{\s*animation: none;/,
+    );
+    expect(compactChatStyles).toContain('--compact-chat-surface-edge-top: rgba(196, 228, 255, 0.44);');
+  });
+
+  it('keeps the backdrop layer pill-clipped while compact reveal masks are active', () => {
+    expect(compactChatStyles).toMatch(
+      /\.compact-chat-surface-shell\.neko-compact-collapsing > \.compact-chat-surface-frame,\s*\.compact-chat-surface-shell\.neko-compact-expanding > \.compact-chat-surface-frame\s*\{[\s\S]*?-webkit-clip-path: inset\(0 round 999px\);[\s\S]*?clip-path: inset\(0 round 999px\);/,
+    );
+  });
+
+  it('frosts the backdrop without increasing the compact surface opacity', () => {
+    expect(compactChatStyles).toMatch(
+      /\.compact-chat-surface-frame\s*\{[\s\S]*?background: rgba\(255, 255, 255, 0\.035\);[\s\S]*?backdrop-filter: blur\(36px\) saturate\(0\.9\) contrast\(0\.78\) brightness\(1\.08\);/,
+    );
+    expect(compactChatStyles).toContain(
+      'linear-gradient(180deg, rgba(255, 255, 255, 0.34), rgba(242, 249, 255, 0.19) 46%, rgba(219, 238, 253, 0.24))',
+    );
+    expect(compactChatStyles).toContain(
+      'linear-gradient(180deg, rgba(31, 48, 66, 0.72), rgba(15, 29, 46, 0.68) 58%, rgba(8, 17, 30, 0.62))',
+    );
+  });
+
+  it('adds a restrained edge hierarchy to the export preview stage', () => {
+    expect(compactChatStyles).toMatch(
+      /\.compact-export-preview-stage\s*\{[\s\S]*?inset 0 0 0 1px rgba\(159, 202, 238, 0\.36\),[\s\S]*?inset 0 1px 0 rgba\(255, 255, 255, 0\.7\),[\s\S]*?0 5px 12px rgba\(22, 48, 84, 0\.06\);/,
+    );
+    expect(compactChatStyles).toMatch(
+      /\[data-theme="dark"\] \.compact-export-preview-stage\s*\{[\s\S]*?inset 0 0 0 1px rgba\(116, 187, 255, 0\.24\),[\s\S]*?0 5px 12px rgba\(0, 0, 0, 0\.14\);/,
+    );
+    expect(compactChatStyles).toMatch(
+      /\.compact-export-preview-stage\.is-fallback\s*\{[\s\S]*?box-shadow: none;/,
+    );
+  });
+
+  it('keeps history bubble shadows inside the scroll viewport clipping edge', () => {
+    expect(compactChatStyles).toContain('--compact-export-history-shadow-gutter-right: 32px;');
+    expect(compactChatStyles).toMatch(
+      /\.compact-export-history-scroll\s*\{[\s\S]*?overflow-y: auto;[\s\S]*?padding: 4px 0 16px;/,
+    );
+    expect(compactChatStyles).toMatch(
+      /\.compact-export-history-scroll-content\s*\{[\s\S]*?width: 100%;[\s\S]*?padding-right: var\(--compact-export-history-shadow-gutter-right\);[\s\S]*?padding-left: var\(--compact-export-history-shadow-gutter-left\);/,
+    );
+  });
+
+  it('keeps compact composer text legible over both light and dark backdrops', () => {
+    expect(compactChatStyles).toMatch(
+      /\.compact-chat-surface-frame\[data-compact-chat-state="input"\] \.composer-input\s*\{[\s\S]*?color: #2f526b;[\s\S]*?caret-color: #167fbd;[\s\S]*?0 1px 1px rgba\(255, 255, 255, 0\.94\),[\s\S]*?0 0 4px rgba\(255, 255, 255, 0\.72\);/,
+    );
+    expect(compactChatStyles).toMatch(
+      /\[data-theme="dark"\] \.compact-chat-surface-frame\[data-compact-chat-state="input"\] \.composer-input\s*\{[\s\S]*?caret-color: #74d7ff;[\s\S]*?text-shadow: 0 1px 2px rgba\(0, 0, 0, 0\.42\);/,
+    );
+  });
+
   it('uses the same visual slot stacking hierarchy for both compact tool wheel layouts', () => {
     expect(compactChatStyles).toMatch(
       /data-compact-input-tool-fan-open="true"\]\s+\.compact-input-tool-item\[data-compact-tool-wheel-slot="-2"\],[\s\S]*?data-compact-tool-wheel-slot="2"\]\s*\{\s*z-index:\s*1;/s,
@@ -6773,6 +6853,21 @@ describe('App', () => {
     expect(darkToolButtonRule).toContain('rgba(17, 34, 51, 0.98)');
     expect(darkToolButtonRule).toContain('--compact-tool-button-active-shadow:');
     expect(darkToolButtonRule).not.toContain('rgba(255, 255, 255, 0.98)');
+  });
+
+  it('uses light tooltip bubbles by default and dark bubbles only in dark mode', () => {
+    expect(compactChatStyles).toMatch(
+      /\.neko-chat-tooltip\s*\{[\s\S]*?linear-gradient\(145deg, rgba\(255, 255, 255, 0\.97\), rgba\(232, 246, 255, 0\.96\)\)[\s\S]*?color: rgba\(43, 72, 96, 0\.96\);/,
+    );
+    expect(compactChatStyles).toMatch(
+      /\.compact-input-tool-fan \.compact-input-tool-tooltip\s*\{[\s\S]*?linear-gradient\(145deg, rgba\(255, 255, 255, 0\.97\), rgba\(232, 246, 255, 0\.96\)\)[\s\S]*?color: rgba\(43, 72, 96, 0\.96\);/,
+    );
+    expect(compactChatStyles).toMatch(
+      /\[data-theme="dark"\] \.neko-chat-tooltip,\s*\[data-theme="dark"\] \.compact-input-tool-fan \.compact-input-tool-tooltip\s*\{[\s\S]*?rgba\(13, 24, 37, 0\.96\)[\s\S]*?color: rgba\(244, 250, 255, 0\.98\);/,
+    );
+    expect(compactChatStyles).toMatch(
+      /\[data-theme="dark"\] \.neko-chat-tooltip::after\s*\{[\s\S]*?background: rgba\(20, 34, 49, 0\.98\);/,
+    );
   });
 
   it('shows compact tool wheel tooltips from pointer hover or keyboard-visible focus only', () => {
@@ -7685,6 +7780,8 @@ describe('App', () => {
     );
     const ball = container.querySelector('.compact-chat-minimize-ball');
     expect(ball).not.toBeNull();
+    expect(ball).toHaveAttribute('data-neko-tooltip-variant', 'compact-tool');
+    expect(ball).toHaveAttribute('data-neko-tooltip-placement', 'top');
     // 毛绒球走 origin-drag 手势（单击折叠 / 长按拖 surface，与右侧轮盘原点对偶），
     // 标记 no-drag 避免宿主被动 hit-test 重复起拖。
     expect(ball).toHaveAttribute('data-compact-no-drag', 'true');

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -6751,7 +6751,7 @@ describe('App', () => {
 
   it('uses the bundled Yozai font for conversation content while controls keep the UI font', () => {
     expect(compactChatStyles).toMatch(
-      /@font-face\s*\{[\s\S]*?font-family:\s*"Neko Chat Hand";[\s\S]*?url\("\/assets\/Yozai-Medium\.ttf"\)/,
+      /@font-face\s*\{[\s\S]*?font-family:\s*"Neko Chat Hand";[\s\S]*?url\("\/static\/react\/neko-chat\/assets\/Yozai-Medium\.ttf"\)/,
     );
     expect(compactChatStyles).toContain('--neko-ui-font: "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;');
     expect(compactChatStyles).toContain('--neko-chat-content-font: "Neko Chat Hand", "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;');
@@ -6788,7 +6788,7 @@ describe('App', () => {
 
   it('frosts the backdrop without increasing the compact surface opacity', () => {
     expect(compactChatStyles).toMatch(
-      /\.compact-chat-surface-frame\s*\{[\s\S]*?background: rgba\(255, 255, 255, 0\.035\);[\s\S]*?backdrop-filter: blur\(36px\) saturate\(0\.9\) contrast\(0\.78\) brightness\(1\.08\);/,
+      /\.compact-chat-surface-frame\s*\{[\s\S]*?background-clip: padding-box;[\s\S]*?background-color: rgba\(255, 255, 255, 0\.035\);[\s\S]*?backdrop-filter: blur\(36px\) saturate\(0\.9\) contrast\(0\.78\) brightness\(1\.08\);/,
     );
     expect(compactChatStyles).toContain(
       'linear-gradient(180deg, rgba(255, 255, 255, 0.34), rgba(242, 249, 255, 0.19) 46%, rgba(219, 238, 253, 0.24))',

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -15,6 +15,7 @@ import { createPortal } from 'react-dom';
 import AvatarToolItemManager, { type AvatarToolManagerAnchorRect } from './AvatarToolItemManager';
 import AvatarToolQuickbar from './AvatarToolQuickbar';
 import FullChatSurface from './FullChatSurface';
+import NekoTooltipLayer from './NekoTooltipLayer';
 import AvatarToolVisuals from './avatar-tools/presentation';
 import { useAvatarToolRuntime } from './avatar-tools/runtime';
 import {
@@ -847,10 +848,14 @@ function getCompactHistoryScrollUnderCompactToolWheel(
  * same shared runtime.
  */
 export default function ChatWindowRoot(props: ChatWindowProps) {
-  if (props.chatSurfaceMode === 'full') {
-    return <FullChatSurface {...props} />;
-  }
-  return <CompactChatApp {...props} />;
+  return (
+    <>
+      {props.chatSurfaceMode === 'full'
+        ? <FullChatSurface {...props} />
+        : <CompactChatApp {...props} />}
+      <NekoTooltipLayer />
+    </>
+  );
 }
 
 function CompactChatApp({
@@ -5061,7 +5066,9 @@ function CompactChatApp({
       type="button"
       className="compact-chat-minimize-ball"
       aria-label={i18n('chat.reactWindowMinimize', 'Minimize')}
-      title={i18n('chat.reactWindowMinimize', 'Minimize')}
+      data-neko-tooltip={i18n('chat.reactWindowMinimize', 'Minimize')}
+      data-neko-tooltip-variant="compact-tool"
+      data-neko-tooltip-placement="top"
       data-compact-no-drag="true"
       data-compact-hit-region="true"
       data-compact-hit-region-id="input:minimize"
@@ -5404,7 +5411,7 @@ function CompactChatApp({
             className="composer-tool-clear-btn"
             type="button"
             aria-label={clearAvatarToolAriaLabel}
-            title={clearAvatarToolAriaLabel}
+            data-neko-tooltip={clearAvatarToolAriaLabel}
             disabled={compactAvatarToolActionsDisabled}
             tabIndex={getCompactToolWheelTabIndex(1)}
             onClick={(event) => {
@@ -5690,7 +5697,7 @@ function CompactChatApp({
       type="button"
       aria-label={compactExportHistoryToggleLabel}
       aria-expanded={compactExportHistoryOpen}
-      title={compactExportHistoryToggleLabel}
+      data-neko-tooltip={compactExportHistoryToggleLabel}
       disabled={composerDisabled}
       data-compact-geometry-owner="surface"
       data-compact-geometry-item="historyHandle"
@@ -5747,7 +5754,7 @@ function CompactChatApp({
             data-compact-hit-region-id="meme:close"
             data-compact-hit-region-kind="meme-close"
             aria-label={closeMemeButtonAriaLabel}
-            title={closeMemeButtonAriaLabel}
+            data-neko-tooltip={closeMemeButtonAriaLabel}
             onClick={(event) => {
               event.stopPropagation();
               setDismissedMemeId(compactMemeOverlay.id);
@@ -5833,7 +5840,7 @@ function CompactChatApp({
           className="chat-surface-focus-indicator"
           role="status"
           aria-live="polite"
-          title={i18n('chat.focusIndicator', '凝神中')}
+          data-neko-tooltip={i18n('chat.focusIndicator', '凝神中')}
         >
           <span className="chat-surface-focus-indicator-label">
             {i18n('chat.focusIndicator', '凝神中')}

--- a/frontend/react-neko-chat/src/AvatarToolItemManager.tsx
+++ b/frontend/react-neko-chat/src/AvatarToolItemManager.tsx
@@ -693,7 +693,7 @@ export default function AvatarToolItemManager({
           type="button"
           ref={closeButtonRef}
           aria-label={i18n('chat.avatarToolManagerClose', 'Close')}
-          title={i18n('chat.avatarToolManagerClose', 'Close')}
+          data-neko-tooltip={i18n('chat.avatarToolManagerClose', 'Close')}
           onClick={onCancel}
         >
           <img src="/static/icons/close_button.png" alt="" aria-hidden="true" />
@@ -741,7 +741,7 @@ export default function AvatarToolItemManager({
                       className="avatar-tool-manager-remove"
                       type="button"
                       aria-label={`${i18n('chat.avatarToolRemove', 'Remove')} ${label}`}
-                      title={`${i18n('chat.avatarToolRemove', 'Remove')} ${label}`}
+                      data-neko-tooltip={`${i18n('chat.avatarToolRemove', 'Remove')} ${label}`}
                       onClick={() => handleRemoveSlot(index)}
                     >
                       {i18n('chat.avatarToolRemove', 'Remove')}

--- a/frontend/react-neko-chat/src/AvatarToolQuickbar.tsx
+++ b/frontend/react-neko-chat/src/AvatarToolQuickbar.tsx
@@ -59,7 +59,7 @@ export default function AvatarToolQuickbar({
               data-avatar-tool-id={tool.id}
               aria-label={label}
               aria-pressed={activeAvatarToolId === tool.id}
-              title={label}
+              data-neko-tooltip={label}
               disabled={disabled}
               onClick={(event) => onToolClick(tool, event)}
             >
@@ -84,7 +84,7 @@ export default function AvatarToolQuickbar({
         className="avatar-tool-quickbar-edit"
         type="button"
         aria-label={i18n('chat.avatarToolEdit', 'Edit quick tools')}
-        title={i18n('chat.avatarToolEdit', 'Edit quick tools')}
+        data-neko-tooltip={i18n('chat.avatarToolEdit', 'Edit quick tools')}
         disabled={disabled}
         onClick={onEditClick}
       >

--- a/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
+++ b/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
@@ -792,7 +792,7 @@ export default function CompactExportHistoryPanel({
           className="compact-export-preview-back"
           onClick={onClosePreview}
           aria-label={i18n('chat.previewClose', 'Close')}
-          title={i18n('chat.previewClose', 'Close')}
+          data-neko-tooltip={i18n('chat.previewClose', 'Close')}
         >
           <svg
             className="compact-export-preview-back-icon"

--- a/frontend/react-neko-chat/src/FullChatSurface.tsx
+++ b/frontend/react-neko-chat/src/FullChatSurface.tsx
@@ -2235,7 +2235,7 @@ export default function FullChatSurface({
       type="button"
       aria-label={resolvedTranslateAriaLabel}
       aria-pressed={translateEnabled}
-      title={translateButtonLabel}
+      data-neko-tooltip={translateButtonLabel}
       disabled={composerInteractionsDisabled}
       onClick={() => onTranslateToggle?.()}
     >
@@ -2248,7 +2248,7 @@ export default function FullChatSurface({
       className="composer-tool-btn"
       type="button"
       aria-label={jukeboxButtonAriaLabel}
-      title={jukeboxButtonLabel}
+      data-neko-tooltip={jukeboxButtonLabel}
       disabled={composerInteractionsDisabled}
       onClick={() => onJukeboxClick?.()}
     >
@@ -2262,7 +2262,7 @@ export default function FullChatSurface({
       type="button"
       aria-label={resolvedGalgameAriaLabel}
       aria-pressed={galgameModeEnabled}
-      title={galgameToggleButtonLabel}
+      data-neko-tooltip={galgameToggleButtonLabel}
       disabled={composerInteractionsDisabled}
       onClick={() => onGalgameModeToggle?.()}
     >
@@ -2276,7 +2276,7 @@ export default function FullChatSurface({
         className={`composer-tool-btn composer-emoji-btn${toolMenuOpen || activeToolItem ? ' is-active' : ''}`}
         type="button"
         aria-label={selectedEmojiButtonAriaLabel}
-        title={selectedEmojiButtonAriaLabel}
+        data-neko-tooltip={selectedEmojiButtonAriaLabel}
         aria-controls={toolMenuOpen ? 'composer-tool-popover' : undefined}
         aria-expanded={toolMenuOpen}
         disabled={composerInteractionsDisabled}
@@ -2302,7 +2302,7 @@ export default function FullChatSurface({
           className="composer-tool-clear-btn"
           type="button"
           aria-label={clearAvatarToolAriaLabel}
-          title={clearAvatarToolAriaLabel}
+          data-neko-tooltip={clearAvatarToolAriaLabel}
           disabled={composerInteractionsDisabled}
           onClick={(event) => {
             event.stopPropagation();
@@ -2332,7 +2332,7 @@ export default function FullChatSurface({
               type="button"
               aria-pressed={activeAvatarToolId === item.id}
               aria-label={itemLabel}
-              title={itemLabel}
+              data-neko-tooltip={itemLabel}
               disabled={composerInteractionsDisabled}
               onClick={(event) => {
                 selectAvatarTool(item, event);
@@ -2617,7 +2617,7 @@ export default function FullChatSurface({
         className="composer-tool-btn compact-input-tool-item compact-input-tool-item-import"
         type="button"
         aria-label={resolvedImportImageAriaLabel}
-        title={importImageButtonLabel}
+        data-neko-tooltip={importImageButtonLabel}
         disabled={isCompactToolWheelActionDisabled(0)}
         tabIndex={getCompactToolWheelTabIndex(0)}
         aria-hidden={getCompactToolWheelAriaHidden(0)}
@@ -2630,7 +2630,7 @@ export default function FullChatSurface({
         className="composer-tool-btn compact-input-tool-item compact-input-tool-item-screenshot"
         type="button"
         aria-label={resolvedScreenshotAriaLabel}
-        title={screenshotButtonLabel}
+        data-neko-tooltip={screenshotButtonLabel}
         disabled={isCompactToolWheelActionDisabled(1)}
         tabIndex={getCompactToolWheelTabIndex(1)}
         aria-hidden={getCompactToolWheelAriaHidden(1)}
@@ -2644,7 +2644,7 @@ export default function FullChatSurface({
         type="button"
         aria-label={resolvedGalgameAriaLabel}
         aria-pressed={galgameModeEnabled}
-        title={galgameToggleButtonLabel}
+        data-neko-tooltip={galgameToggleButtonLabel}
         disabled={isCompactToolWheelActionDisabled(2)}
         tabIndex={getCompactToolWheelTabIndex(2)}
         aria-hidden={getCompactToolWheelAriaHidden(2)}
@@ -2659,7 +2659,7 @@ export default function FullChatSurface({
         type="button"
         aria-label={resolvedTranslateAriaLabel}
         aria-pressed={translateEnabled}
-        title={translateButtonLabel}
+        data-neko-tooltip={translateButtonLabel}
         disabled={isCompactToolWheelActionDisabled(3)}
         tabIndex={getCompactToolWheelTabIndex(3)}
         aria-hidden={getCompactToolWheelAriaHidden(3)}
@@ -2673,7 +2673,7 @@ export default function FullChatSurface({
         className="composer-tool-btn compact-input-tool-item compact-input-tool-item-jukebox"
         type="button"
         aria-label={jukeboxButtonAriaLabel}
-        title={jukeboxButtonLabel}
+        data-neko-tooltip={jukeboxButtonLabel}
         disabled={isCompactToolWheelActionDisabled(4)}
         tabIndex={getCompactToolWheelTabIndex(4)}
         aria-hidden={getCompactToolWheelAriaHidden(4)}
@@ -2687,7 +2687,7 @@ export default function FullChatSurface({
         type="button"
         aria-label={compactExportHistoryButtonLabel}
         aria-pressed={compactExportHistoryOpen}
-        title={compactExportHistoryButtonLabel}
+        data-neko-tooltip={compactExportHistoryButtonLabel}
         disabled={isCompactToolWheelActionDisabled(5)}
         tabIndex={getCompactToolWheelTabIndex(5)}
         aria-hidden={getCompactToolWheelAriaHidden(5)}
@@ -2709,7 +2709,7 @@ export default function FullChatSurface({
           className={`composer-tool-btn composer-emoji-btn${toolMenuOpen || activeToolItem ? ' is-active' : ''}`}
           type="button"
           aria-label={selectedEmojiButtonAriaLabel}
-          title={selectedEmojiButtonAriaLabel}
+          data-neko-tooltip={selectedEmojiButtonAriaLabel}
           aria-controls={toolMenuOpen ? 'composer-tool-popover-compact' : undefined}
           aria-expanded={toolMenuOpen}
           disabled={isCompactToolWheelActionDisabled(6)}
@@ -2744,7 +2744,7 @@ export default function FullChatSurface({
             className="composer-tool-clear-btn"
             type="button"
             aria-label={clearAvatarToolAriaLabel}
-            title={clearAvatarToolAriaLabel}
+            data-neko-tooltip={clearAvatarToolAriaLabel}
             disabled={compactInputToolFanActionsDisabled}
             tabIndex={compactInputToolFanOpen ? 0 : -1}
             onClick={(event) => {
@@ -2782,7 +2782,7 @@ export default function FullChatSurface({
               type="button"
               aria-pressed={activeAvatarToolId === item.id}
               aria-label={itemLabel}
-              title={itemLabel}
+              data-neko-tooltip={itemLabel}
               disabled={compactInputToolFanActionsDisabled}
               onClick={(event) => {
                 if (shouldSuppressCompactToolClick(event)) {
@@ -2838,7 +2838,7 @@ export default function FullChatSurface({
                     key={`${index}-${option.label}`}
                     type="button"
                     className="composer-galgame-option"
-                    title={option.text}
+                    data-neko-tooltip={option.text}
                     disabled={composerInteractionsDisabled || galgameOptionsLoading}
                     tabIndex={compactChoiceLayerOpen && galgameOptionsVisible ? 0 : -1}
                     onClick={() => {
@@ -2894,7 +2894,7 @@ export default function FullChatSurface({
                 key={`${index}-${option.choice}`}
                 type="button"
                 className="composer-galgame-option composer-choice-option"
-                title={option.label}
+                data-neko-tooltip={option.label}
                 disabled={composerInteractionsDisabled}
                 onClick={() => {
                   if (submittingRef.current) return;
@@ -3004,7 +3004,7 @@ export default function FullChatSurface({
           className="chat-surface-focus-indicator"
           role="status"
           aria-live="polite"
-          title={i18n('chat.focusIndicator', '凝神中')}
+          data-neko-tooltip={i18n('chat.focusIndicator', '凝神中')}
         >
           <span className="chat-surface-focus-indicator-label">
             {i18n('chat.focusIndicator', '凝神中')}
@@ -3239,7 +3239,7 @@ export default function FullChatSurface({
                     className="composer-tool-btn"
                     type="button"
                     aria-label={resolvedImportImageAriaLabel}
-                    title={importImageButtonLabel}
+                    data-neko-tooltip={importImageButtonLabel}
                     disabled={composerInteractionsDisabled}
                     onClick={() => onComposerImportImage?.()}
                   >
@@ -3250,7 +3250,7 @@ export default function FullChatSurface({
                     className="composer-tool-btn"
                     type="button"
                     aria-label={resolvedScreenshotAriaLabel}
-                    title={screenshotButtonLabel}
+                    data-neko-tooltip={screenshotButtonLabel}
                     disabled={composerInteractionsDisabled}
                     onClick={() => onComposerScreenshot?.()}
                   >
@@ -3287,7 +3287,7 @@ export default function FullChatSurface({
                         className={`composer-tool-btn composer-overflow-btn${overflowMenuOpen ? ' is-active' : ''}`}
                         type="button"
                         aria-label={overflowMenuAriaLabel}
-                        title={overflowMenuAriaLabel}
+                        data-neko-tooltip={overflowMenuAriaLabel}
                         aria-haspopup="true"
                         aria-expanded={overflowMenuOpen}
                         disabled={composerInteractionsDisabled}

--- a/frontend/react-neko-chat/src/NekoTooltipLayer.test.tsx
+++ b/frontend/react-neko-chat/src/NekoTooltipLayer.test.tsx
@@ -1,0 +1,142 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import NekoTooltipLayer from './NekoTooltipLayer';
+import chatStyles from './styles.css?raw';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('NekoTooltipLayer', () => {
+  it('shows custom tooltip copy for keyboard focus without a native title', () => {
+    render(
+      <>
+        <button type="button" data-neko-tooltip="打开历史记录">历史</button>
+        <NekoTooltipLayer />
+      </>,
+    );
+
+    const button = screen.getByRole('button', { name: '历史' });
+    expect(button).not.toHaveAttribute('title');
+
+    act(() => button.focus());
+    expect(screen.getByRole('tooltip')).toHaveTextContent('打开历史记录');
+
+    act(() => button.blur());
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('uses a short delay for pointer hover and closes when the pointer leaves', () => {
+    vi.useFakeTimers();
+    render(
+      <>
+        <button type="button" data-neko-tooltip="截图">截图按钮</button>
+        <NekoTooltipLayer />
+      </>,
+    );
+
+    const button = screen.getByRole('button', { name: '截图按钮' });
+    fireEvent.pointerOver(button);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+
+    act(() => vi.advanceTimersByTime(320));
+    expect(screen.getByRole('tooltip')).toHaveTextContent('截图');
+
+    fireEvent.pointerOut(button);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('keeps compact minimize copy above the button with in-wheel tooltip styling', () => {
+    render(
+      <>
+        <button
+          type="button"
+          data-neko-tooltip="最小化聊天框"
+          data-neko-tooltip-variant="compact-tool"
+          data-neko-tooltip-placement="top"
+        >
+          最小化
+        </button>
+        <NekoTooltipLayer />
+      </>,
+    );
+
+    act(() => screen.getByRole('button', { name: '最小化' }).focus());
+    expect(screen.getByRole('tooltip')).toHaveAttribute('data-variant', 'compact-tool');
+    expect(screen.getByRole('tooltip')).toHaveAttribute('data-placement', 'top');
+    expect(chatStyles).toMatch(
+      /\.neko-chat-tooltip\[data-variant="compact-tool"\]::after\s*\{\s*content: none;/,
+    );
+  });
+
+  it('dismisses a visible tooltip instead of following viewport movement', () => {
+    render(
+      <>
+        <button type="button" data-neko-tooltip="最小化聊天框">最小化</button>
+        <NekoTooltipLayer />
+      </>,
+    );
+
+    act(() => screen.getByRole('button', { name: '最小化' }).focus());
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+
+    fireEvent.scroll(window);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('dismisses a visible tooltip when its anchor changes position', () => {
+    let frameCallback: FrameRequestCallback | null = null;
+    const requestFrame = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      frameCallback = callback;
+      return 17;
+    });
+    const cancelFrame = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+
+    try {
+      render(
+        <>
+          <button type="button" data-neko-tooltip="最小化聊天框">最小化</button>
+          <NekoTooltipLayer />
+        </>,
+      );
+
+      const button = screen.getByRole('button', { name: '最小化' });
+      let left = 20;
+      vi.spyOn(button, 'getBoundingClientRect').mockImplementation(() => ({
+        x: left,
+        y: 40,
+        left,
+        top: 40,
+        right: left + 46,
+        bottom: 86,
+        width: 46,
+        height: 46,
+        toJSON: () => ({}),
+      }));
+
+      act(() => button.focus());
+      expect(screen.getByRole('tooltip')).toBeInTheDocument();
+      expect(frameCallback).not.toBeNull();
+
+      left = 26;
+      act(() => frameCallback?.(16));
+      expect(screen.queryByRole('tooltip')).toBeNull();
+    } finally {
+      requestFrame.mockRestore();
+      cancelFrame.mockRestore();
+    }
+  });
+
+  it('keeps generic and compact-wheel tooltips in the same restrained frosted style', () => {
+    const genericRule = chatStyles.match(/\.neko-chat-tooltip\s*\{[\s\S]*?\n\}/)?.[0] ?? '';
+    const wheelRule = chatStyles.match(
+      /\.compact-input-tool-fan \.compact-input-tool-tooltip\s*\{[\s\S]*?\n\}/,
+    )?.[0] ?? '';
+
+    expect(genericRule).toContain('border-radius: 10px');
+    expect(genericRule).toContain('backdrop-filter: blur(16px)');
+    expect(wheelRule).toContain('border-radius: 9px');
+    expect(wheelRule).toContain('backdrop-filter: blur(16px)');
+    expect(wheelRule).not.toContain('border-radius: 0');
+  });
+});

--- a/frontend/react-neko-chat/src/NekoTooltipLayer.test.tsx
+++ b/frontend/react-neko-chat/src/NekoTooltipLayer.test.tsx
@@ -20,10 +20,13 @@ describe('NekoTooltipLayer', () => {
     expect(button).not.toHaveAttribute('title');
 
     act(() => button.focus());
-    expect(screen.getByRole('tooltip')).toHaveTextContent('打开历史记录');
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toHaveTextContent('打开历史记录');
+    expect(button).toHaveAttribute('aria-describedby', tooltip.id);
 
     act(() => button.blur());
     expect(screen.queryByRole('tooltip')).toBeNull();
+    expect(button).not.toHaveAttribute('aria-describedby');
   });
 
   it('uses a short delay for pointer hover and closes when the pointer leaves', () => {
@@ -138,5 +141,14 @@ describe('NekoTooltipLayer', () => {
     expect(wheelRule).toContain('border-radius: 9px');
     expect(wheelRule).toContain('backdrop-filter: blur(16px)');
     expect(wheelRule).not.toContain('border-radius: 0');
+  });
+
+  it('hides pointer focus chrome while preserving a custom keyboard focus indicator', () => {
+    expect(chatStyles).toMatch(
+      /\.compact-chat-minimize-ball:focus:not\(:focus-visible\)\s*\{[\s\S]*?outline: none;[\s\S]*?box-shadow: none;/,
+    );
+    expect(chatStyles).toMatch(
+      /\.compact-chat-minimize-ball:focus-visible\s*\{[\s\S]*?outline: 2px solid[\s\S]*?box-shadow: inset 0 0 0 3px/,
+    );
   });
 });

--- a/frontend/react-neko-chat/src/NekoTooltipLayer.test.tsx
+++ b/frontend/react-neko-chat/src/NekoTooltipLayer.test.tsx
@@ -64,7 +64,20 @@ describe('NekoTooltipLayer', () => {
       </>,
     );
 
-    act(() => screen.getByRole('button', { name: '最小化' }).focus());
+    const button = screen.getByRole('button', { name: '最小化' });
+    vi.spyOn(button, 'getBoundingClientRect').mockImplementation(() => ({
+      x: 20,
+      y: 100,
+      left: 20,
+      top: 100,
+      right: 66,
+      bottom: 146,
+      width: 46,
+      height: 46,
+      toJSON: () => ({}),
+    }));
+
+    act(() => button.focus());
     expect(screen.getByRole('tooltip')).toHaveAttribute('data-variant', 'compact-tool');
     expect(screen.getByRole('tooltip')).toHaveAttribute('data-placement', 'top');
     expect(chatStyles).toMatch(
@@ -85,6 +98,53 @@ describe('NekoTooltipLayer', () => {
 
     fireEvent.scroll(window);
     expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('does not reopen a dismissed tooltip when pointer focus follows pointerdown', () => {
+    render(
+      <>
+        <button type="button" data-neko-tooltip="最小化聊天框">最小化</button>
+        <NekoTooltipLayer />
+      </>,
+    );
+
+    const button = screen.getByRole('button', { name: '最小化' });
+    fireEvent.pointerDown(button);
+    act(() => button.focus());
+    fireEvent.pointerUp(button);
+
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('flips a preferred top tooltip below when the viewport has no top space', () => {
+    render(
+      <>
+        <button
+          type="button"
+          data-neko-tooltip="最小化聊天框"
+          data-neko-tooltip-placement="top"
+        >
+          最小化
+        </button>
+        <NekoTooltipLayer />
+      </>,
+    );
+
+    const button = screen.getByRole('button', { name: '最小化' });
+    vi.spyOn(button, 'getBoundingClientRect').mockImplementation(() => ({
+      x: 20,
+      y: 4,
+      left: 20,
+      top: 4,
+      right: 66,
+      bottom: 50,
+      width: 46,
+      height: 46,
+      toJSON: () => ({}),
+    }));
+
+    act(() => button.focus());
+    expect(screen.getByRole('tooltip')).toHaveAttribute('data-placement', 'bottom');
   });
 
   it('dismisses a visible tooltip when its anchor changes position', () => {

--- a/frontend/react-neko-chat/src/NekoTooltipLayer.tsx
+++ b/frontend/react-neko-chat/src/NekoTooltipLayer.tsx
@@ -1,0 +1,236 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+const POINTER_OPEN_DELAY_MS = 320;
+const VIEWPORT_EDGE_GAP_PX = 8;
+const TARGET_GAP_PX = 9;
+const ANCHOR_MOVEMENT_EPSILON_PX = 0.5;
+
+type TooltipPlacement = 'top' | 'bottom';
+type TooltipVariant = 'default' | 'compact-tool';
+
+interface TooltipTarget {
+  anchor: HTMLElement;
+  text: string;
+  variant: TooltipVariant;
+}
+
+interface TooltipLayout {
+  left: number;
+  top: number;
+  placement: TooltipPlacement;
+  ready: boolean;
+}
+
+interface AnchorRectSnapshot {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+function snapshotAnchorRect(anchor: HTMLElement): AnchorRectSnapshot {
+  const rect = anchor.getBoundingClientRect();
+  return {
+    left: rect.left,
+    top: rect.top,
+    width: rect.width,
+    height: rect.height,
+  };
+}
+
+function hasAnchorMoved(
+  initialRect: AnchorRectSnapshot,
+  currentRect: AnchorRectSnapshot,
+): boolean {
+  return (
+    Math.abs(initialRect.left - currentRect.left) > ANCHOR_MOVEMENT_EPSILON_PX
+    || Math.abs(initialRect.top - currentRect.top) > ANCHOR_MOVEMENT_EPSILON_PX
+    || Math.abs(initialRect.width - currentRect.width) > ANCHOR_MOVEMENT_EPSILON_PX
+    || Math.abs(initialRect.height - currentRect.height) > ANCHOR_MOVEMENT_EPSILON_PX
+  );
+}
+
+function findTooltipAnchor(target: EventTarget | null): HTMLElement | null {
+  return target instanceof Element
+    ? target.closest<HTMLElement>('[data-neko-tooltip]')
+    : null;
+}
+
+function isInsideAnchor(anchor: HTMLElement, target: EventTarget | null): boolean {
+  return target instanceof Node && anchor.contains(target);
+}
+
+export default function NekoTooltipLayer() {
+  const [target, setTarget] = useState<TooltipTarget | null>(null);
+  const [layout, setLayout] = useState<TooltipLayout>({
+    left: -9999,
+    top: -9999,
+    placement: 'top',
+    ready: false,
+  });
+  const tooltipRef = useRef<HTMLDivElement | null>(null);
+  const openTimerRef = useRef<number | null>(null);
+  const pendingAnchorRef = useRef<HTMLElement | null>(null);
+  const anchorRectRef = useRef<AnchorRectSnapshot | null>(null);
+
+  const clearOpenTimer = useCallback(() => {
+    if (openTimerRef.current !== null) {
+      window.clearTimeout(openTimerRef.current);
+      openTimerRef.current = null;
+    }
+  }, []);
+
+  const hideTooltip = useCallback((anchor?: HTMLElement | null) => {
+    if (anchor && pendingAnchorRef.current && pendingAnchorRef.current !== anchor) return;
+    pendingAnchorRef.current = null;
+    anchorRectRef.current = null;
+    clearOpenTimer();
+    setTarget(null);
+  }, [clearOpenTimer]);
+
+  const showTooltip = useCallback((anchor: HTMLElement, delay: number) => {
+    const text = anchor.dataset.nekoTooltip?.trim();
+    if (!text) return;
+    const variant: TooltipVariant = anchor.dataset.nekoTooltipVariant === 'compact-tool'
+      ? 'compact-tool'
+      : 'default';
+
+    pendingAnchorRef.current = anchor;
+    clearOpenTimer();
+
+    const reveal = () => {
+      openTimerRef.current = null;
+      if (pendingAnchorRef.current !== anchor || !anchor.isConnected) return;
+      setTarget({ anchor, text, variant });
+    };
+
+    if (delay <= 0) {
+      reveal();
+      return;
+    }
+    openTimerRef.current = window.setTimeout(reveal, delay);
+  }, [clearOpenTimer]);
+
+  const updatePosition = useCallback(() => {
+    if (!target || !tooltipRef.current || !target.anchor.isConnected) return;
+
+    const anchorRect = target.anchor.getBoundingClientRect();
+    const tooltipRect = tooltipRef.current.getBoundingClientRect();
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+    const preferredPlacement = target.anchor.dataset.nekoTooltipPlacement;
+    const hasTopSpace = anchorRect.top >= tooltipRect.height + TARGET_GAP_PX + VIEWPORT_EDGE_GAP_PX;
+    const hasBottomSpace = viewportHeight - anchorRect.bottom
+      >= tooltipRect.height + TARGET_GAP_PX + VIEWPORT_EDGE_GAP_PX;
+    const placement: TooltipPlacement = preferredPlacement === 'top'
+      ? 'top'
+      : preferredPlacement === 'bottom' || (!hasTopSpace && hasBottomSpace)
+        ? 'bottom'
+        : 'top';
+    const unclampedLeft = anchorRect.left + (anchorRect.width - tooltipRect.width) / 2;
+    const maxLeft = Math.max(VIEWPORT_EDGE_GAP_PX, viewportWidth - tooltipRect.width - VIEWPORT_EDGE_GAP_PX);
+    const left = Math.min(Math.max(unclampedLeft, VIEWPORT_EDGE_GAP_PX), maxLeft);
+    const top = placement === 'top'
+      ? Math.max(VIEWPORT_EDGE_GAP_PX, anchorRect.top - tooltipRect.height - TARGET_GAP_PX)
+      : Math.min(
+        viewportHeight - tooltipRect.height - VIEWPORT_EDGE_GAP_PX,
+        anchorRect.bottom + TARGET_GAP_PX,
+      );
+
+    setLayout({ left, top, placement, ready: true });
+  }, [target]);
+
+  useEffect(() => {
+    const handlePointerOver = (event: PointerEvent) => {
+      const anchor = findTooltipAnchor(event.target);
+      if (!anchor || isInsideAnchor(anchor, event.relatedTarget)) return;
+      showTooltip(anchor, POINTER_OPEN_DELAY_MS);
+    };
+    const handlePointerOut = (event: PointerEvent) => {
+      const anchor = findTooltipAnchor(event.target);
+      if (!anchor || isInsideAnchor(anchor, event.relatedTarget)) return;
+      hideTooltip(anchor);
+    };
+    const handleFocusIn = (event: FocusEvent) => {
+      const anchor = findTooltipAnchor(event.target);
+      if (anchor) showTooltip(anchor, 0);
+    };
+    const handleFocusOut = (event: FocusEvent) => {
+      const anchor = findTooltipAnchor(event.target);
+      if (!anchor || isInsideAnchor(anchor, event.relatedTarget)) return;
+      hideTooltip(anchor);
+    };
+    const handlePointerDown = () => hideTooltip();
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') hideTooltip();
+    };
+
+    document.addEventListener('pointerover', handlePointerOver);
+    document.addEventListener('pointerout', handlePointerOut);
+    document.addEventListener('focusin', handleFocusIn);
+    document.addEventListener('focusout', handleFocusOut);
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      clearOpenTimer();
+      document.removeEventListener('pointerover', handlePointerOver);
+      document.removeEventListener('pointerout', handlePointerOut);
+      document.removeEventListener('focusin', handleFocusIn);
+      document.removeEventListener('focusout', handleFocusOut);
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [clearOpenTimer, hideTooltip, showTooltip]);
+
+  useLayoutEffect(() => {
+    if (!target) return;
+    anchorRectRef.current = snapshotAnchorRect(target.anchor);
+    setLayout(current => ({ ...current, ready: false }));
+    updatePosition();
+  }, [target, updatePosition]);
+
+  useEffect(() => {
+    if (!target) return;
+    let movementFrame = 0;
+    const hideForViewportChange = () => hideTooltip(target.anchor);
+    const watchAnchorMovement = () => {
+      const initialRect = anchorRectRef.current;
+      if (
+        !target.anchor.isConnected
+        || (initialRect && hasAnchorMoved(initialRect, snapshotAnchorRect(target.anchor)))
+      ) {
+        hideTooltip(target.anchor);
+        return;
+      }
+      movementFrame = window.requestAnimationFrame(watchAnchorMovement);
+    };
+
+    movementFrame = window.requestAnimationFrame(watchAnchorMovement);
+    window.addEventListener('resize', hideForViewportChange);
+    window.addEventListener('scroll', hideForViewportChange, true);
+    return () => {
+      window.cancelAnimationFrame(movementFrame);
+      window.removeEventListener('resize', hideForViewportChange);
+      window.removeEventListener('scroll', hideForViewportChange, true);
+    };
+  }, [hideTooltip, target]);
+
+  if (!target || typeof document === 'undefined') return null;
+
+  return createPortal(
+    <div
+      ref={tooltipRef}
+      className="neko-chat-tooltip"
+      role="tooltip"
+      data-placement={layout.placement}
+      data-variant={target.variant}
+      data-ready={layout.ready ? 'true' : 'false'}
+      style={{ left: layout.left, top: layout.top }}
+    >
+      {target.text}
+    </div>,
+    document.body,
+  );
+}

--- a/frontend/react-neko-chat/src/NekoTooltipLayer.tsx
+++ b/frontend/react-neko-chat/src/NekoTooltipLayer.tsx
@@ -74,6 +74,7 @@ export default function NekoTooltipLayer() {
   const openTimerRef = useRef<number | null>(null);
   const pendingAnchorRef = useRef<HTMLElement | null>(null);
   const anchorRectRef = useRef<AnchorRectSnapshot | null>(null);
+  const pointerInteractionRef = useRef(false);
 
   const clearOpenTimer = useCallback(() => {
     if (openTimerRef.current !== null) {
@@ -125,10 +126,10 @@ export default function NekoTooltipLayer() {
     const hasBottomSpace = viewportHeight - anchorRect.bottom
       >= tooltipRect.height + TARGET_GAP_PX + VIEWPORT_EDGE_GAP_PX;
     const placement: TooltipPlacement = preferredPlacement === 'top'
-      ? 'top'
-      : preferredPlacement === 'bottom' || (!hasTopSpace && hasBottomSpace)
-        ? 'bottom'
-        : 'top';
+      ? hasTopSpace || !hasBottomSpace ? 'top' : 'bottom'
+      : preferredPlacement === 'bottom'
+        ? hasBottomSpace || !hasTopSpace ? 'bottom' : 'top'
+        : !hasTopSpace && hasBottomSpace ? 'bottom' : 'top';
     const unclampedLeft = anchorRect.left + (anchorRect.width - tooltipRect.width) / 2;
     const maxLeft = Math.max(VIEWPORT_EDGE_GAP_PX, viewportWidth - tooltipRect.width - VIEWPORT_EDGE_GAP_PX);
     const left = Math.min(Math.max(unclampedLeft, VIEWPORT_EDGE_GAP_PX), maxLeft);
@@ -154,6 +155,7 @@ export default function NekoTooltipLayer() {
       hideTooltip(anchor);
     };
     const handleFocusIn = (event: FocusEvent) => {
+      if (pointerInteractionRef.current) return;
       const anchor = findTooltipAnchor(event.target);
       if (anchor) showTooltip(anchor, 0);
     };
@@ -162,7 +164,13 @@ export default function NekoTooltipLayer() {
       if (!anchor || isInsideAnchor(anchor, event.relatedTarget)) return;
       hideTooltip(anchor);
     };
-    const handlePointerDown = () => hideTooltip();
+    const handlePointerDown = () => {
+      pointerInteractionRef.current = true;
+      hideTooltip();
+    };
+    const handlePointerEnd = () => {
+      pointerInteractionRef.current = false;
+    };
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') hideTooltip();
     };
@@ -172,6 +180,8 @@ export default function NekoTooltipLayer() {
     document.addEventListener('focusin', handleFocusIn);
     document.addEventListener('focusout', handleFocusOut);
     document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('pointerup', handlePointerEnd);
+    document.addEventListener('pointercancel', handlePointerEnd);
     document.addEventListener('keydown', handleKeyDown);
 
     return () => {
@@ -181,6 +191,8 @@ export default function NekoTooltipLayer() {
       document.removeEventListener('focusin', handleFocusIn);
       document.removeEventListener('focusout', handleFocusOut);
       document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('pointerup', handlePointerEnd);
+      document.removeEventListener('pointercancel', handlePointerEnd);
       document.removeEventListener('keydown', handleKeyDown);
     };
   }, [clearOpenTimer, hideTooltip, showTooltip]);

--- a/frontend/react-neko-chat/src/NekoTooltipLayer.tsx
+++ b/frontend/react-neko-chat/src/NekoTooltipLayer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 const POINTER_OPEN_DELAY_MS = 320;
@@ -62,6 +62,7 @@ function isInsideAnchor(anchor: HTMLElement, target: EventTarget | null): boolea
 }
 
 export default function NekoTooltipLayer() {
+  const tooltipId = useId();
   const [target, setTarget] = useState<TooltipTarget | null>(null);
   const [layout, setLayout] = useState<TooltipLayout>({
     left: -9999,
@@ -193,6 +194,27 @@ export default function NekoTooltipLayer() {
 
   useEffect(() => {
     if (!target) return;
+    const anchor = target.anchor;
+    const describedBy = new Set(
+      (anchor.getAttribute('aria-describedby') ?? '').split(/\s+/).filter(Boolean),
+    );
+    describedBy.add(tooltipId);
+    anchor.setAttribute('aria-describedby', Array.from(describedBy).join(' '));
+
+    return () => {
+      const remainingIds = (anchor.getAttribute('aria-describedby') ?? '')
+        .split(/\s+/)
+        .filter(id => id && id !== tooltipId);
+      if (remainingIds.length > 0) {
+        anchor.setAttribute('aria-describedby', remainingIds.join(' '));
+      } else {
+        anchor.removeAttribute('aria-describedby');
+      }
+    };
+  }, [target, tooltipId]);
+
+  useEffect(() => {
+    if (!target) return;
     let movementFrame = 0;
     const hideForViewportChange = () => hideTooltip(target.anchor);
     const watchAnchorMovement = () => {
@@ -221,6 +243,7 @@ export default function NekoTooltipLayer() {
 
   return createPortal(
     <div
+      id={tooltipId}
       ref={tooltipRef}
       className="neko-chat-tooltip"
       role="tooltip"

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -1,8 +1,18 @@
 @import 'katex/dist/katex.min.css';
 
+@font-face {
+  font-family: "Neko Chat Hand";
+  src: url("/assets/Yozai-Medium.ttf") format("truetype");
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+}
+
 :root {
+  --neko-ui-font: "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
+  --neko-chat-content-font: "Neko Chat Hand", "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
   color: #1f2329;
-  font-family: "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
+  font-family: var(--neko-ui-font);
   line-height: 1.5;
   font-weight: 400;
   font-synthesis: none;
@@ -60,10 +70,18 @@ svg {
 .app-shell {
   width: 100%;
   height: 100%;
+  font-family: var(--neko-ui-font);
   /* Positioned containing block for absolutely-placed overlays anchored to the
      surface (e.g. .chat-focus-overlay). The compact variant already sets this;
      declaring it on the base keeps the full surface consistent. */
   position: relative;
+}
+
+/* Portaled controls cannot inherit from the chat shell. Keep them on the UI
+   typeface instead of the conversational typeface used by message content. */
+.composer-choice-layer,
+.avatar-tool-manager-dialog {
+  font-family: var(--neko-ui-font);
 }
 
 .avatar-tool-visual-overlay {
@@ -734,7 +752,8 @@ body.neko-electron-runtime .app-shell:not(.chat-surface-mode-compact)[data-focus
 .app-shell.chat-surface-mode-compact[data-focus-glow="true"] .compact-chat-surface-frame {
   box-shadow:
     0 0 0 1px rgba(150, 190, 255, calc(0.3 + 0.5 * var(--focus-glow, 0))),
-    0 0 calc(6px + 22px * var(--focus-glow, 0)) calc(1px + 4px * var(--focus-glow, 0)) rgba(120, 170, 255, calc(0.25 + 0.55 * var(--focus-glow, 0)));
+    0 0 calc(6px + 22px * var(--focus-glow, 0)) calc(1px + 4px * var(--focus-glow, 0)) rgba(120, 170, 255, calc(0.25 + 0.55 * var(--focus-glow, 0))),
+    var(--compact-chat-surface-shadow);
 }
 .app-shell.chat-surface-mode-compact[data-focus-breathing="true"] .compact-chat-surface-frame {
   animation: focus-glow-breathe-compact 3.4s ease-in-out infinite;
@@ -743,12 +762,14 @@ body.neko-electron-runtime .app-shell:not(.chat-surface-mode-compact)[data-focus
   0%, 100% {
     box-shadow:
       0 0 0 1px rgba(150, 190, 255, calc(0.35 * var(--focus-glow, 0.6))),
-      0 0 calc(8px * var(--focus-glow, 0.6)) 1px rgba(120, 170, 255, calc(0.4 * var(--focus-glow, 0.6)));
+      0 0 calc(8px * var(--focus-glow, 0.6)) 1px rgba(120, 170, 255, calc(0.4 * var(--focus-glow, 0.6))),
+      var(--compact-chat-surface-shadow);
   }
   50% {
     box-shadow:
       0 0 0 2px rgba(150, 190, 255, calc(0.9 * var(--focus-glow, 0.6))),
-      0 0 calc(30px * var(--focus-glow, 0.6)) calc(6px * var(--focus-glow, 0.6)) rgba(120, 170, 255, calc(0.85 * var(--focus-glow, 0.6)));
+      0 0 calc(30px * var(--focus-glow, 0.6)) calc(6px * var(--focus-glow, 0.6)) rgba(120, 170, 255, calc(0.85 * var(--focus-glow, 0.6))),
+      var(--compact-chat-surface-shadow);
   }
 }
 
@@ -1175,6 +1196,15 @@ body.neko-electron-runtime .app-shell:not(.chat-surface-mode-compact)[data-focus
 
 .message-block-text {
   white-space: pre-wrap;
+}
+
+.message-block-text,
+.message-block-markdown,
+.composer-input,
+.compact-chat-capsule-text {
+  font-family: var(--neko-chat-content-font);
+  font-weight: 500;
+  font-synthesis: weight;
 }
 
 .message-block-markdown {
@@ -2552,13 +2582,29 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
     + var(--compact-chat-minimize-ball-gap)
   );
   --compact-chat-surface-bg:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.7), rgba(247, 251, 255, 0.6) 58%, rgba(232, 243, 255, 0.54));
-  --compact-chat-surface-edge: rgba(255, 255, 255, 0.5);
-  --compact-chat-surface-glow: rgba(255, 255, 255, 0.22);
+    linear-gradient(180deg, rgba(255, 255, 255, 0.34), rgba(242, 249, 255, 0.19) 46%, rgba(219, 238, 253, 0.24));
+  --compact-chat-surface-edge-top: rgba(255, 255, 255, 0.7);
+  --compact-chat-surface-edge-right: rgba(255, 255, 255, 0.15);
+  --compact-chat-surface-edge-bottom: rgba(255, 255, 255, 0.06);
+  --compact-chat-surface-edge-left: rgba(255, 255, 255, 0.35);
+  --compact-chat-surface-glow: rgba(255, 255, 255, 0.2);
+  --compact-chat-surface-shadow:
+    0 8px 20px rgba(12, 20, 34, 0.16),
+    0 2px 7px rgba(49, 104, 154, 0.08),
+    inset 0 2px 4px rgba(255, 255, 255, 0.34),
+    inset 0 -1px 2px rgba(68, 126, 176, 0.08);
+  --compact-chat-highlight-top: rgba(255, 255, 255, 0.46);
+  --compact-chat-highlight-bottom: rgba(255, 255, 255, 0.08);
+  --compact-chat-highlight-left: rgba(255, 255, 255, 0.14);
+  --compact-chat-highlight-right: rgba(255, 255, 255, 0.06);
+  --compact-chat-refraction-blue: rgba(100, 180, 255, 0.18);
+  --compact-chat-refraction-violet: rgba(180, 140, 255, 0.12);
+  --compact-chat-refraction-rose: rgba(240, 150, 200, 0.09);
   position: relative;
   overflow: hidden;
   isolation: isolate;
-  clip-path: inset(0 round 999px);
+  /* border-radius + overflow clip the inner refraction layers; a clip-path here
+     would also cut off the exterior shadow and Focus halo. */
   background-clip: padding-box;
   display: flex;
   align-items: center;
@@ -2569,14 +2615,18 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
   max-height: 54px;
   box-sizing: border-box;
   padding: 0 20px 0 var(--compact-chat-minimize-ball-slot);
-  border: 1px solid var(--compact-chat-surface-edge);
+  border-style: solid;
+  border-width: 2px 1px 1px 1px;
+  border-color:
+    var(--compact-chat-surface-edge-top)
+    var(--compact-chat-surface-edge-right)
+    var(--compact-chat-surface-edge-bottom)
+    var(--compact-chat-surface-edge-left);
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
-  box-shadow:
-    0 0 0 1px rgba(208, 233, 255, 0.14),
-    0 6px 18px rgba(42, 89, 132, 0.05);
-  backdrop-filter: blur(18px) saturate(1.22) brightness(1.08);
-  -webkit-backdrop-filter: blur(18px) saturate(1.22) brightness(1.08);
+  background: rgba(255, 255, 255, 0.035);
+  box-shadow: var(--compact-chat-surface-shadow);
+  backdrop-filter: blur(36px) saturate(0.9) contrast(0.78) brightness(1.08);
+  -webkit-backdrop-filter: blur(36px) saturate(0.9) contrast(0.78) brightness(1.08);
 }
 
 .compact-chat-surface-frame[data-compact-chat-state="input"] {
@@ -2602,8 +2652,19 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
   overflow: hidden;
   contain: paint;
   background: transparent;
+  appearance: none;
+  -webkit-appearance: none;
+  outline: none;
+  box-shadow: none;
+  -webkit-tap-highlight-color: transparent;
   cursor: grab;
   touch-action: none;
+}
+
+.compact-chat-minimize-ball:focus,
+.compact-chat-minimize-ball:focus-visible {
+  outline: none;
+  box-shadow: none;
 }
 
 .compact-chat-minimize-ball:active {
@@ -2655,14 +2716,45 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
 .compact-chat-surface-frame::after {
   content: "";
   position: absolute;
-  inset: 1px;
+  inset: 0;
   z-index: 1;
   border-radius: inherit;
-  background:
-    linear-gradient(180deg, var(--compact-chat-surface-glow), transparent 42%);
+  background-image:
+    linear-gradient(180deg, var(--compact-chat-surface-glow) 0%, rgba(255, 255, 255, 0.05) 16%, transparent 40%, transparent 82%, rgba(115, 181, 229, 0.05) 100%),
+    radial-gradient(ellipse at 14% 4%, var(--compact-chat-refraction-blue) 0%, transparent 34%),
+    radial-gradient(ellipse at 62% 100%, var(--compact-chat-refraction-violet) 0%, transparent 36%),
+    radial-gradient(ellipse at 92% 12%, var(--compact-chat-refraction-rose) 0%, transparent 30%);
+  background-position: 0 0, 0% 0%, 55% 100%, 100% 10%;
+  background-repeat: no-repeat;
+  background-size: 100% 100%, 180% 220%, 190% 220%, 180% 200%;
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.28);
+    inset 0 2px 6px var(--compact-chat-highlight-top),
+    inset 0 -1px 3px var(--compact-chat-highlight-bottom),
+    inset 2px 0 4px var(--compact-chat-highlight-left),
+    inset -2px 0 4px var(--compact-chat-highlight-right);
+  animation: compact-chat-liquid-edge 20s ease-in-out infinite;
   pointer-events: none;
+}
+
+@keyframes compact-chat-liquid-edge {
+  0%,
+  100% {
+    background-position: 0 0, 0% 0%, 55% 100%, 100% 10%;
+  }
+
+  33% {
+    background-position: 0 0, 58% 18%, 8% 48%, 42% 88%;
+  }
+
+  66% {
+    background-position: 0 0, 92% 72%, 86% 12%, 4% 34%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .compact-chat-surface-frame::after {
+    animation: none;
+  }
 }
 
 .compact-chat-surface-frame > * {
@@ -2822,6 +2914,8 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
   );
   --compact-export-history-viewport-gutter: 24px;
   --compact-export-history-width-ratio: 1;
+  --compact-export-history-shadow-gutter-right: 32px;
+  --compact-export-history-shadow-gutter-left: 12px;
   --compact-export-history-max-inline-size: calc(100vw - var(--compact-export-history-viewport-gutter));
   --compact-export-history-inline-size: min(
     calc(var(--compact-export-surface-width) * var(--compact-export-history-width-ratio)),
@@ -2919,7 +3013,10 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
      下沿只到气泡实体底以下~16px(此处 alpha≈3/255≈1.2%,再往下不可察)；清晰可见段(alpha≥8)仅~9px、
      可感知段(alpha≥5)~13px,均落在 16px 内。压到 16 让气泡实体底更贴输入框(实体底到输入框由~28px→~18px)、
      同时可见阴影完整不裁。再小(如12)会切到可感知段,不取。 */
-  padding: 4px 24px 16px 6px;
+  /* 横向阴影缓冲不能依赖 scroll box 自身的 padding：overflow-y:auto 会让
+     Chromium 同时建立横向裁剪边界。横向 gutter 放到 scroll-content，
+     这里只保留必须计入 scrollHeight 的上下 padding。 */
+  padding: 4px 0 16px;
   scrollbar-width: none;
   pointer-events: none;
   -webkit-app-region: no-drag;
@@ -2931,6 +3028,9 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   display: flex;
   flex-direction: column;
   gap: 0;
+  width: 100%;
+  padding-right: var(--compact-export-history-shadow-gutter-right);
+  padding-left: var(--compact-export-history-shadow-gutter-left);
   /* 稳态：撑到 scroll 盒高度，配合 first-child margin-top:auto 让内容底部对齐、内容少时不产生可滚空白。 */
   min-height: 100%;
   overflow-anchor: none;
@@ -3665,6 +3765,17 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   -webkit-mask-size: 300% 100%; mask-size: 300% 100%;
   -webkit-mask-repeat: no-repeat; mask-repeat: no-repeat;
 }
+
+/* The animated mask promotes the backdrop-filter layer during reveal. Chromium
+   can briefly rasterize that promoted layer as a square texture, so enforce a
+   pill clip only while the wipe is active. The class is removed after the wipe,
+   restoring the unclipped exterior shadow and Focus halo in steady state. */
+.compact-chat-surface-shell.neko-compact-collapsing > .compact-chat-surface-frame,
+.compact-chat-surface-shell.neko-compact-expanding > .compact-chat-surface-frame {
+  -webkit-clip-path: inset(0 round 999px);
+  clip-path: inset(0 round 999px);
+}
+
 .compact-chat-surface-shell.neko-compact-collapsing {
   animation: neko-compact-collapse-wipe 280ms ease forwards;
 }
@@ -3965,7 +4076,10 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   overflow: hidden;
   border-radius: 12px;
   background: rgba(255, 255, 255, 0.34);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.34);
+  box-shadow:
+    inset 0 0 0 1px rgba(159, 202, 238, 0.36),
+    inset 0 1px 0 rgba(255, 255, 255, 0.7),
+    0 5px 12px rgba(22, 48, 84, 0.06);
 }
 
 .compact-export-preview-stage.is-fallback {
@@ -4132,8 +4246,12 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   border: 0;
   background: transparent;
   color: #2f526b;
+  caret-color: #167fbd;
   font-weight: 500;
   line-height: 22px;
+  text-shadow:
+    0 1px 1px rgba(255, 255, 255, 0.94),
+    0 0 4px rgba(255, 255, 255, 0.72);
   overflow-y: auto;
 }
 
@@ -4141,6 +4259,9 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   font-size: 1em;
   line-height: 22px;
   color: rgba(70, 96, 122, 0.66);
+  text-shadow:
+    0 1px 1px rgba(255, 255, 255, 0.88),
+    0 0 4px rgba(255, 255, 255, 0.58);
 }
 
 .compact-chat-surface-shell[data-compact-chat-state="input"] .composer-bottom-bar {
@@ -4458,31 +4579,115 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   background: var(--compact-tool-button-hover-fill);
 }
 
+.neko-chat-tooltip {
+  position: fixed;
+  z-index: 2147483600;
+  box-sizing: border-box;
+  max-width: min(240px, calc(100vw - 16px));
+  padding: 6px 9px;
+  border: 1px solid rgba(137, 196, 234, 0.52);
+  border-radius: 10px;
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.97), rgba(232, 246, 255, 0.96)),
+    rgba(241, 249, 255, 0.96);
+  color: rgba(43, 72, 96, 0.96);
+  font-family: var(--neko-ui-font);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.4;
+  letter-spacing: 0.01em;
+  overflow-wrap: anywhere;
+  pointer-events: none;
+  user-select: none;
+  opacity: 0;
+  transform: translateY(2px) scale(0.98);
+  transform-origin: 50% 100%;
+  box-shadow:
+    0 9px 24px rgba(20, 76, 116, 0.15),
+    0 2px 7px rgba(20, 76, 116, 0.09),
+    inset 0 1px 0 rgba(255, 255, 255, 0.92);
+  -webkit-backdrop-filter: blur(16px) saturate(1.08);
+  backdrop-filter: blur(16px) saturate(1.08);
+  transition: opacity 0.12s ease, transform 0.12s ease;
+}
+
+.neko-chat-tooltip[data-placement="bottom"] {
+  transform: translateY(-2px) scale(0.98);
+  transform-origin: 50% 0;
+}
+
+.neko-chat-tooltip[data-variant="compact-tool"] {
+  max-width: 124px;
+  padding: 5px 8px;
+  border-radius: 9px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.neko-chat-tooltip[data-ready="true"] {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+.neko-chat-tooltip::after {
+  position: absolute;
+  left: 50%;
+  bottom: -4px;
+  width: 7px;
+  height: 7px;
+  content: "";
+  background: rgba(239, 248, 255, 0.98);
+  border-right: 1px solid rgba(137, 196, 234, 0.48);
+  border-bottom: 1px solid rgba(137, 196, 234, 0.48);
+  transform: translateX(-50%) rotate(45deg);
+}
+
+.neko-chat-tooltip[data-placement="bottom"]::after {
+  top: -4px;
+  bottom: auto;
+  border: 0;
+  border-top: 1px solid rgba(137, 196, 234, 0.48);
+  border-left: 1px solid rgba(137, 196, 234, 0.48);
+}
+
+.neko-chat-tooltip[data-variant="compact-tool"]::after {
+  content: none;
+}
+
 .compact-input-tool-fan .compact-input-tool-tooltip {
   position: absolute;
   left: calc(100% + 5px);
   top: calc(100% - 6px);
   z-index: 4;
-  max-width: 104px;
-  padding: 2px 5px;
-  border: 1px solid #6b7280;
-  border-radius: 0;
-  background: #ffffff;
-  color: #111827;
-  font-family: "Microsoft YaHei", "Segoe UI", Arial, sans-serif;
+  max-width: 124px;
+  padding: 5px 8px;
+  border: 1px solid rgba(137, 196, 234, 0.52);
+  border-radius: 9px;
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.97), rgba(232, 246, 255, 0.96)),
+    rgba(241, 249, 255, 0.96);
+  color: rgba(43, 72, 96, 0.96);
+  font-family: var(--neko-ui-font);
   font-size: 12px;
-  font-weight: 400;
-  line-height: 1.35;
+  font-weight: 500;
+  line-height: 1.4;
+  letter-spacing: 0.01em;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   opacity: 0;
   pointer-events: none;
   user-select: none;
-  transform: translate(0, -1px);
-  transition: opacity 0.08s ease, transform 0.08s ease;
+  transform: translate(-2px, 1px) scale(0.98);
+  transition: opacity 0.12s ease, transform 0.12s ease;
   transform-origin: 0 0;
-  box-shadow: none;
+  box-shadow:
+    0 9px 24px rgba(20, 76, 116, 0.15),
+    0 2px 7px rgba(20, 76, 116, 0.09),
+    inset 0 1px 0 rgba(255, 255, 255, 0.92);
+  -webkit-backdrop-filter: blur(16px) saturate(1.08);
+  backdrop-filter: blur(16px) saturate(1.08);
 }
 
 .compact-input-tool-fan button.compact-input-tool-item:not(:disabled):focus-within,
@@ -6089,13 +6294,24 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 [data-theme="dark"] .compact-chat-surface-frame {
   --compact-chat-surface-bg:
     linear-gradient(180deg, rgba(31, 48, 66, 0.72), rgba(15, 29, 46, 0.68) 58%, rgba(8, 17, 30, 0.62));
-  --compact-chat-surface-edge: rgba(177, 216, 255, 0.28);
-  --compact-chat-surface-glow: rgba(176, 219, 255, 0.08);
+  --compact-chat-surface-edge-top: rgba(196, 228, 255, 0.44);
+  --compact-chat-surface-edge-right: rgba(156, 207, 249, 0.13);
+  --compact-chat-surface-edge-bottom: rgba(132, 189, 232, 0.07);
+  --compact-chat-surface-edge-left: rgba(177, 216, 255, 0.24);
+  --compact-chat-surface-glow: rgba(176, 219, 255, 0.1);
+  --compact-chat-surface-shadow:
+    0 8px 20px rgba(0, 0, 0, 0.28),
+    0 2px 7px rgba(0, 0, 0, 0.16),
+    inset 0 2px 4px rgba(225, 242, 255, 0.12),
+    inset 0 -1px 2px rgba(0, 0, 0, 0.18);
+  --compact-chat-highlight-top: rgba(225, 242, 255, 0.18);
+  --compact-chat-highlight-bottom: rgba(177, 216, 255, 0.05);
+  --compact-chat-highlight-left: rgba(177, 216, 255, 0.09);
+  --compact-chat-highlight-right: rgba(177, 216, 255, 0.04);
+  --compact-chat-refraction-blue: rgba(90, 174, 255, 0.16);
+  --compact-chat-refraction-violet: rgba(170, 125, 255, 0.11);
+  --compact-chat-refraction-rose: rgba(235, 120, 190, 0.07);
   background: rgba(12, 22, 35, 0.1);
-  box-shadow:
-    0 0 0 1px rgba(132, 184, 236, 0.14),
-    0 6px 18px rgba(0, 0, 0, 0.16);
-  border-color: var(--compact-chat-surface-edge);
 }
 
 [data-theme="dark"] .compact-chat-surface-shell[data-compact-chat-state="input"],
@@ -6112,10 +6328,13 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 
 [data-theme="dark"] .compact-chat-surface-frame[data-compact-chat-state="input"] .composer-input {
   color: #e9f4ff;
+  caret-color: #74d7ff;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.42);
 }
 
 [data-theme="dark"] .compact-chat-surface-frame[data-compact-chat-state="input"] .composer-input::placeholder {
   color: rgba(202, 222, 244, 0.66);
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.34);
 }
 
 [data-theme="dark"] .compact-chat-surface-frame[data-compact-tool-toggle-visible="true"] .send-button-circle {
@@ -6144,10 +6363,22 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   background: transparent;
 }
 
+[data-theme="dark"] .neko-chat-tooltip,
 [data-theme="dark"] .compact-input-tool-fan .compact-input-tool-tooltip {
-  border-color: #8b949e;
-  background: #202124;
-  color: #f3f4f6;
+  border-color: rgba(166, 214, 246, 0.38);
+  background:
+    linear-gradient(145deg, rgba(31, 47, 65, 0.94), rgba(13, 24, 37, 0.96)),
+    rgba(15, 27, 41, 0.94);
+  color: rgba(244, 250, 255, 0.98);
+  box-shadow:
+    0 9px 24px rgba(7, 18, 31, 0.24),
+    0 2px 7px rgba(7, 18, 31, 0.18),
+    inset 0 1px 0 rgba(255, 255, 255, 0.16);
+}
+
+[data-theme="dark"] .neko-chat-tooltip::after {
+  background: rgba(20, 34, 49, 0.98);
+  border-color: rgba(166, 214, 246, 0.34);
 }
 
 [data-theme="dark"] .compact-input-tool-fan .avatar-tool-quickbar {
@@ -6390,7 +6621,10 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 }
 
 [data-theme="dark"] .compact-export-preview-stage {
-  box-shadow: inset 0 0 0 1px rgba(116, 187, 255, 0.14);
+  box-shadow:
+    inset 0 0 0 1px rgba(116, 187, 255, 0.24),
+    inset 0 1px 0 rgba(218, 240, 255, 0.12),
+    0 5px 12px rgba(0, 0, 0, 0.14);
 }
 
 [data-theme="dark"] .compact-export-preview-chip.is-active {
@@ -6435,6 +6669,10 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   }
 
   .compact-input-tool-fan .compact-input-tool-tooltip {
+    transition: none !important;
+  }
+
+  .neko-chat-tooltip {
     transition: none !important;
   }
 

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -2,7 +2,7 @@
 
 @font-face {
   font-family: "Neko Chat Hand";
-  src: url("/assets/Yozai-Medium.ttf") format("truetype");
+  src: url("/static/react/neko-chat/assets/Yozai-Medium.ttf") format("truetype");
   font-style: normal;
   font-weight: 500;
   font-display: swap;
@@ -2623,7 +2623,7 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
     var(--compact-chat-surface-edge-bottom)
     var(--compact-chat-surface-edge-left);
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.035);
+  background-color: rgba(255, 255, 255, 0.035);
   box-shadow: var(--compact-chat-surface-shadow);
   backdrop-filter: blur(36px) saturate(0.9) contrast(0.78) brightness(1.08);
   -webkit-backdrop-filter: blur(36px) saturate(0.9) contrast(0.78) brightness(1.08);

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -2661,10 +2661,15 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
   touch-action: none;
 }
 
-.compact-chat-minimize-ball:focus,
-.compact-chat-minimize-ball:focus-visible {
+.compact-chat-minimize-ball:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
+}
+
+.compact-chat-minimize-ball:focus-visible {
+  outline: 2px solid rgba(248, 253, 255, 0.94);
+  outline-offset: -3px;
+  box-shadow: inset 0 0 0 3px rgba(36, 151, 217, 0.58);
 }
 
 .compact-chat-minimize-ball:active {

--- a/frontend/react-neko-chat/vite.config.js
+++ b/frontend/react-neko-chat/vite.config.js
@@ -1,6 +1,7 @@
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vitest/config';
 export default defineConfig({
+    base: '/static/react/neko-chat/',
     plugins: [react()],
     test: {
         environment: 'jsdom',

--- a/frontend/react-neko-chat/vite.config.ts
+++ b/frontend/react-neko-chat/vite.config.ts
@@ -2,6 +2,7 @@ import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  base: '/static/react/neko-chat/',
   plugins: [react()],
   test: {
     environment: 'jsdom',

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -1484,6 +1484,13 @@ body.subtitle-web-host #react-chat-window-shell.is-dragging {
     -webkit-mask-size: 300% 100%; mask-size: 300% 100%;
     -webkit-mask-repeat: no-repeat; mask-repeat: no-repeat;
 }
+.compact-chat-surface-shell.neko-compact-collapsing > .compact-chat-surface-frame,
+.compact-chat-surface-shell.neko-compact-expanding > .compact-chat-surface-frame {
+    /* Electron/Chromium 在 mask 动画首帧可能把 backdrop-filter 合成为矩形纹理；
+       仅在擦除期间强制胶囊裁剪，稳态移除 class 后外阴影仍可正常越界绘制。 */
+    -webkit-clip-path: inset(0 round 999px);
+    clip-path: inset(0 round 999px);
+}
 .compact-chat-surface-shell.neko-compact-collapsing {
     animation: neko-compact-collapse-wipe 280ms ease forwards;
 }


### PR DESCRIPTION
…完整与紧凑聊天界面的悬浮提示样式及移动消失交互，并补充资源路径和相关测试

## 改动概述 / Summary

- 内置悠哉字体及 OFL 许可证，将其应用于聊天消息、输入框和紧凑聊天文本，同时保留工具控件的系统 UI 字体。
- 优化紧凑聊天框的玻璃边缘、阴影、磨砂与明暗模式表现。
- 修复历史对话气泡阴影被滚动区域边缘截断的问题。
- 修复聊天框展开或收起时短暂出现矩形阴影的问题。
- 为导出预览补充轻量边缘和阴影效果。
- 增强输入框在复杂、深色背景上的文字、光标和占位符可读性。
- 统一完整聊天框、紧凑聊天框、工具轮盘、历史预览及快捷工具管理中的悬浮提示样式，并适配亮色和暗色主题。
- 最小化提示保持显示在毛线球上方；目标移动、页面滚动或窗口尺寸变化时立即消失，不停留或跟随移动。
- 移除毛线球按钮的 Chromium 原生焦点圆环，同时保留原有悬浮和按压反馈。
- 修正 Vite 静态资源基础路径，并补充悬浮提示相关测试。

## 测试 / Testing

- `npm run build`
- `npm test -- --run src/App.test.tsx`：240 项通过
- `npm test -- --run src/NekoTooltipLayer.test.tsx`：6 项通过
- 检查亮色与暗色主题下的悬浮提示样式。
- 检查最小化提示的位置及移动、滚动、窗口变化时的消失行为。
- 检查毛线球获得焦点后不再出现异常蓝色圆环。

## 改动对比

- 之前：
<img width="609" height="524" alt="image" src="https://github.com/user-attachments/assets/162e61cd-1049-40b1-8ba0-7366ae7dab40" />

- 之后：
<img width="624" height="504" alt="image" src="https://github.com/user-attachments/assets/535ecd66-54ef-47b6-8f7f-da01af7141ce" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增统一的自定义工具提示系统：支持悬停、键盘聚焦、延迟展示与自动销毁，可配置位置，并提供紧凑/深色视觉变体。
  * 将多处按钮与交互控件的提示从原生 title 统一切换到自定义提示体验。
* **界面优化**
  * 优化紧凑/全量模式字体与玻璃质感、焦点凝神与涟漪表现。
  * 改进折叠/展开过程的圆角裁切与毛绒球控件的 focus-visible 表现；减少动画引发的视觉瑕疵（含减少动态效果）。
* **兼容性**
  * 调整静态资源基础路径，适配部署到指定子目录。
* **测试**
  * 扩展工具提示相关的交互与样式回归测试覆盖面。
* **授权**
  * 新增 Yozai 字体授权文本文件。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->