### PR TITLE
为嵌入式 WebUI 提供按聊天框模式修正可视范围的通用接口，不改变普通网页与 Electron 的默认定位行为

### DIFF
--- a/static/app/app-react-chat-window/message-bundle-actions-and-prompts.js
+++ b/static/app/app-react-chat-window/message-bundle-actions-and-prompts.js
@@ -149,7 +149,7 @@
         }
     }
 
-    I.clampPosition = function clampPosition(left, top) {
+    I.clampPosition = function clampPosition(left, top, options) {
         var shell = I.getShell();
         if (!shell) {
             return { left: left, top: top };
@@ -158,13 +158,57 @@
         var rect = shell.getBoundingClientRect();
         var width = rect.width || 960;
         var headerHeight = 52;
+        var visibleHeight = options && options.fullHeight === true
+            ? (rect.height || headerHeight)
+            : headerHeight;
         var maxLeft = Math.max(0, window.innerWidth - width);
-        var maxTop = Math.max(0, window.innerHeight - headerHeight);
+        var maxTop = Math.max(0, window.innerHeight - visibleHeight);
 
         return {
             left: Math.max(0, Math.min(maxLeft, left)),
             top: Math.max(0, Math.min(maxTop, top))
         };
+    }
+
+    I.ensureChatSurfaceVisible = function ensureChatSurfaceVisible() {
+        var mode = I.getCurrentChatSurfaceMode();
+        if (mode === 'compact' && !I.minimized) {
+            var currentCompactRect = I.getCurrentCompactSurfaceRect();
+            var compactTarget = I.getCompactSurfaceTarget();
+            if (!currentCompactRect || !compactTarget) return false;
+
+            var compactHeight = compactTarget.height || I.COMPACT_SURFACE_DEFAULT_HEIGHT;
+            var compactChanged = Math.abs(compactTarget.left - currentCompactRect.left) >= 0.5
+                || Math.abs(compactTarget.top - currentCompactRect.top) >= 0.5
+                || Math.abs(compactTarget.width - currentCompactRect.width) >= 0.5
+                || Math.abs(compactHeight - currentCompactRect.height) >= 0.5;
+            if (!compactChanged) return false;
+
+            return !!I.applyCompactSurfaceRect(
+                compactTarget.left,
+                compactTarget.top,
+                compactTarget.width,
+                compactHeight,
+                { persist: false }
+            );
+        }
+
+        if (mode !== 'full' || I.minimized) return false;
+        var shell = I.getShell();
+        if (!shell) return false;
+
+        var rect = shell.getBoundingClientRect();
+        if (!(rect.width > 0) || !(rect.height > 0)) return false;
+
+        var clamped = I.clampPosition(rect.left, rect.top, { fullHeight: true });
+        if (Math.abs(clamped.left - rect.left) < 0.5 && Math.abs(clamped.top - rect.top) < 0.5) {
+            return false;
+        }
+
+        shell.style.left = clamped.left + 'px';
+        shell.style.top = clamped.top + 'px';
+        shell.style.transform = 'none';
+        return true;
     }
 
     I.applyPosition = function applyPosition(left, top) {

--- a/static/app/app-react-chat-window/resize-drag-and-api.js
+++ b/static/app/app-react-chat-window/resize-drag-and-api.js
@@ -938,6 +938,7 @@
         },
         rollbackLastDraft: I.rollbackLastDraft,
         clearPendingRollbackDraft: I.clearPendingRollbackDraft,
+        ensureChatSurfaceVisible: I.ensureChatSurfaceVisible,
         setChatSurfaceMode: I.setChatSurfaceMode,
         cycleChatSurfaceMode: I.cycleChatSurfaceMode,
         setCompactChatState: I.setCompactChatState,

--- a/static/react-chat-surface-visibility.test.cjs
+++ b/static/react-chat-surface-visibility.test.cjs
@@ -72,6 +72,17 @@ test('full chat uses complete height only through the explicit visibility operat
     assert.equal(shell.style.transform, 'none');
 });
 
+test('full chat returns false without rewriting a position that already fits', () => {
+    const { context, shell } = createContext({
+        mode: 'full',
+        viewportHeight: 600,
+        shellRect: { top: 100 }
+    });
+
+    assert.equal(context.I.ensureChatSurfaceVisible(), false);
+    assert.deepEqual(shell.style, {});
+});
+
 test('dragged compact chat reapplies its mode-specific clamped target without persistence', () => {
     const { context, getCompactApplication } = createContext({
         mode: 'compact',
@@ -87,4 +98,16 @@ test('dragged compact chat reapplies its mode-specific clamped target without pe
     assert.equal(application.height, 96);
     assert.equal(application.options.persist, false);
     assert.match(apiSource, /ensureChatSurfaceVisible: I\.ensureChatSurfaceVisible/);
+});
+
+test('compact chat returns false when its clamped target already matches the current rect', () => {
+    const compactRect = { left: 100, top: 180, width: 430, height: 96 };
+    const { context, getCompactApplication } = createContext({
+        mode: 'compact',
+        currentCompactRect: compactRect,
+        compactTarget: { ...compactRect }
+    });
+
+    assert.equal(context.I.ensureChatSurfaceVisible(), false);
+    assert.equal(getCompactApplication(), null);
 });

--- a/static/react-chat-surface-visibility.test.cjs
+++ b/static/react-chat-surface-visibility.test.cjs
@@ -1,0 +1,90 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const geometrySource = fs.readFileSync(
+    path.join(__dirname, 'app', 'app-react-chat-window', 'message-bundle-actions-and-prompts.js'),
+    'utf8'
+);
+const apiSource = fs.readFileSync(
+    path.join(__dirname, 'app', 'app-react-chat-window', 'resize-drag-and-api.js'),
+    'utf8'
+);
+
+function assignmentBlock(name, nextName) {
+    const start = geometrySource.indexOf(`I.${name} = function ${name}`);
+    const end = geometrySource.indexOf(`\n    I.${nextName}`, start);
+    assert.notEqual(start, -1, `missing ${name}`);
+    assert.notEqual(end, -1, `missing ${nextName} boundary`);
+    return geometrySource.slice(start, end);
+}
+
+function createContext(options = {}) {
+    const shell = {
+        style: {},
+        getBoundingClientRect: () => ({
+            left: 100,
+            top: 300,
+            width: 500,
+            height: 400,
+            ...(options.shellRect || {})
+        })
+    };
+    let compactApplication = null;
+    const context = {
+        I: {
+            minimized: false,
+            COMPACT_SURFACE_DEFAULT_HEIGHT: 96,
+            getShell: () => shell,
+            getCurrentChatSurfaceMode: () => options.mode || 'full',
+            getCurrentCompactSurfaceRect: () => options.currentCompactRect || null,
+            getCompactSurfaceTarget: () => options.compactTarget || null,
+            applyCompactSurfaceRect: (left, top, width, height, applyOptions) => {
+                compactApplication = { left, top, width, height, options: applyOptions };
+                return compactApplication;
+            }
+        },
+        window: {
+            innerWidth: 1000,
+            innerHeight: options.viewportHeight || 600
+        }
+    };
+    vm.runInNewContext(assignmentBlock('clampPosition', 'ensureChatSurfaceVisible'), context);
+    vm.runInNewContext(assignmentBlock('ensureChatSurfaceVisible', 'applyPosition'), context);
+    return { context, shell, getCompactApplication: () => compactApplication };
+}
+
+test('the default position clamp keeps the existing header-visible boundary', () => {
+    const { context } = createContext({ viewportHeight: 300 });
+    const position = context.I.clampPosition(100, 200);
+    assert.equal(position.left, 100);
+    assert.equal(position.top, 200);
+});
+
+test('full chat uses complete height only through the explicit visibility operation', () => {
+    const { context, shell } = createContext({ mode: 'full', viewportHeight: 600 });
+
+    assert.equal(context.I.ensureChatSurfaceVisible(), true);
+    assert.equal(shell.style.left, '100px');
+    assert.equal(shell.style.top, '200px');
+    assert.equal(shell.style.transform, 'none');
+});
+
+test('dragged compact chat reapplies its mode-specific clamped target without persistence', () => {
+    const { context, getCompactApplication } = createContext({
+        mode: 'compact',
+        currentCompactRect: { left: 100, top: 300, width: 430, height: 96 },
+        compactTarget: { left: 100, top: 180, width: 430, height: 96 }
+    });
+
+    assert.equal(context.I.ensureChatSurfaceVisible(), true);
+    const application = getCompactApplication();
+    assert.equal(application.left, 100);
+    assert.equal(application.top, 180);
+    assert.equal(application.width, 430);
+    assert.equal(application.height, 96);
+    assert.equal(application.options.persist, false);
+    assert.match(apiSource, /ensureChatSurfaceVisible: I\.ensureChatSurfaceVisible/);
+});


### PR DESCRIPTION
## 改动概述 / Summary

新增供嵌入式 WebUI 显式调用的聊天框可视范围修正接口：

- 完整模式按聊天框完整高度修正位置。
- 紧凑模式复用现有位置与边界算法重新计算目标位置。
- 临时修正不会覆盖用户保存的位置。
- 普通网页与 Electron 不会主动调用该接口，默认定位行为不变。

## 测试 / Testing

- 通过 JavaScript 语法检查：

  ```bash
  node --check static/app/app-react-chat-window/message-bundle-actions-and-prompts.js
  node --check static/app/app-react-chat-window/resize-drag-and-api.js
  ```
## 相关pr
 [插件浮窗尺寸变化时调用本体的可视范围接口，使拖动过的聊天框重新适配嵌入视口](https://github.com/Project-N-E-K-O/N.E.K.O.-Browser/pull/1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增聊天窗口可见性校正接口，可根据当前紧凑/完整模式与最小化状态自动纠偏窗口位置与显示区域。
  * 位置校正逻辑增强：在完整模式下使用“完整窗口高度”计算可拖动边界，默认场景保持原行为。

* **Bug 修复**
  * 改进完整窗口模式下拖动边界与可见性校正，减少窗口超出可视范围的情况。

* **测试**
  * 新增/扩展聊天窗口定位、拖动与可见性校正的覆盖测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->