### PR TITLE
Phase 4C-B：接入可验证的 CAM++ Speaker Shadow 后端

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -56,6 +56,11 @@ N.E.K.O/
 # the obsolete directory so local leftovers cannot duplicate weights.
 /data/vad_models
 
+# CAM++ is likewise prepared on the native runner into the package-local
+# speaker_shadow/models directory and must remain in the build context. Reject
+# the obsolete data/ location so a local checkout cannot ship a second copy.
+/data/speaker_models
+
 # Build artifacts
 build/
 dist/

--- a/.github/workflows/build-desktop-linux.yml
+++ b/.github/workflows/build-desktop-linux.yml
@@ -209,6 +209,16 @@ jobs:
         shell: bash
         run: uv run --no-sync python scripts/prepare_voice_turn_assets.py
 
+      - name: Cache CAM++ speaker model weight
+        uses: actions/cache@v4
+        with:
+          path: main_logic/asr_client/speaker_shadow/models/*.onnx
+          key: speaker-shadow-campplus-v1-${{ runner.os }}-${{ hashFiles('main_logic/asr_client/speaker_shadow/models/manifest.json') }}
+
+      - name: Prepare verified CAM++ speaker model
+        shell: bash
+        run: uv run --no-sync python scripts/prepare_speaker_model.py
+
       # --- Warm tiktoken o200k_base cache for offline use (PR #929) ---
       # tiktoken downloads encoding blobs (~1.5 MB each) on first use into
       # TIKTOKEN_CACHE_DIR; without warming, the bundled app would either
@@ -279,6 +289,7 @@ jobs:
             NUITKA_OPTS="$NUITKA_OPTS --include-data-dir=data/embedding_models=data/embedding_models"
           fi
           NUITKA_OPTS="$NUITKA_OPTS --include-data-dir=main_logic/asr_client/endpointing/models=main_logic/asr_client/endpointing/models"
+          NUITKA_OPTS="$NUITKA_OPTS --include-data-dir=main_logic/asr_client/speaker_shadow/models=main_logic/asr_client/speaker_shadow/models"
           NUITKA_OPTS="$NUITKA_OPTS --include-data-dir=static=static"
           # 应用内 OpenClaw 引导文档 + 图片，由 agent_router 经 /api/agent/openclaw/guide/* 提供；
           # 是纯数据目录，--include-package 不带，漏了引导页内容/图片打包后 404。
@@ -425,6 +436,24 @@ jobs:
           fi
           uv run --no-sync python scripts/prepare_voice_turn_assets.py \
             --asset-dir "$endpointing_assets" --offline || missing=1
+          speaker_shadow_assets="dist/Xiao8/main_logic/asr_client/speaker_shadow/models"
+          for rel in manifest.json THIRD_PARTY_NOTICES.md campplus-zh-en-advanced.onnx; do
+            if [ ! -s "$speaker_shadow_assets/$rel" ]; then
+              echo "::error::missing or empty bundled CAM++ asset: $rel"
+              missing=1
+            fi
+          done
+          if [ -e "dist/Xiao8/data/speaker_models" ]; then
+            echo "::error::obsolete data/speaker_models must not be packaged"
+            missing=1
+          fi
+          speaker_weight_count="$(find dist/Xiao8 -type f -name campplus-zh-en-advanced.onnx | wc -l | tr -d ' ')"
+          if [ "$speaker_weight_count" -ne 1 ]; then
+            echo "::error::CAM++ weight must be packaged exactly once"
+            missing=1
+          fi
+          uv run --no-sync python scripts/prepare_speaker_model.py \
+            --asset-dir "$speaker_shadow_assets" --offline || missing=1
           [ "$missing" -eq 0 ]
 
       # --- Generic dist invariant check ---

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -247,6 +247,16 @@ jobs:
         shell: bash
         run: uv run --no-sync python scripts/prepare_voice_turn_assets.py
 
+      - name: Cache CAM++ speaker model weight
+        uses: actions/cache@v4
+        with:
+          path: main_logic/asr_client/speaker_shadow/models/*.onnx
+          key: speaker-shadow-campplus-v1-${{ runner.os }}-${{ hashFiles('main_logic/asr_client/speaker_shadow/models/manifest.json') }}
+
+      - name: Prepare verified CAM++ speaker model
+        shell: bash
+        run: uv run --no-sync python scripts/prepare_speaker_model.py
+
       # --- Warm tiktoken o200k_base cache for offline use (PR #929) ---
       # tiktoken downloads encoding blobs (~1.5 MB each) on first use into
       # TIKTOKEN_CACHE_DIR; without warming, the bundled app would either
@@ -342,6 +352,7 @@ jobs:
             NUITKA_OPTS="$NUITKA_OPTS --include-data-dir=data/embedding_models=data/embedding_models"
           fi
           NUITKA_OPTS="$NUITKA_OPTS --include-data-dir=main_logic/asr_client/endpointing/models=main_logic/asr_client/endpointing/models"
+          NUITKA_OPTS="$NUITKA_OPTS --include-data-dir=main_logic/asr_client/speaker_shadow/models=main_logic/asr_client/speaker_shadow/models"
           NUITKA_OPTS="$NUITKA_OPTS --include-data-dir=static=static"
           # 应用内 OpenClaw 引导文档 + 图片，由 agent_router 经 /api/agent/openclaw/guide/* 提供；
           # 是纯数据目录，--include-package 不带，漏了引导页内容/图片打包后 404。
@@ -484,6 +495,7 @@ jobs:
           if exist "data\tiktoken_cache" set NUITKA_OPTS=%NUITKA_OPTS% --include-data-dir=data/tiktoken_cache=data/tiktoken_cache
           if exist "data\embedding_models" set NUITKA_OPTS=%NUITKA_OPTS% --include-data-dir=data/embedding_models=data/embedding_models
           set NUITKA_OPTS=%NUITKA_OPTS% --include-data-dir=main_logic/asr_client/endpointing/models=main_logic/asr_client/endpointing/models
+          set NUITKA_OPTS=%NUITKA_OPTS% --include-data-dir=main_logic/asr_client/speaker_shadow/models=main_logic/asr_client/speaker_shadow/models
           set NUITKA_OPTS=%NUITKA_OPTS% --include-data-dir=static=static
           rem 应用内 OpenClaw 引导文档 + 图片，由 agent_router 经 /api/agent/openclaw/guide/* 提供；
           rem 纯数据目录，漏了引导页内容/图片打包后 404。
@@ -645,6 +657,24 @@ jobs:
           fi
           uv run --no-sync python scripts/prepare_voice_turn_assets.py \
             --asset-dir "$endpointing_assets" --offline || missing=1
+          speaker_shadow_assets="$NEKO_NUITKA_RUNTIME_DIR/main_logic/asr_client/speaker_shadow/models"
+          for rel in manifest.json THIRD_PARTY_NOTICES.md campplus-zh-en-advanced.onnx; do
+            if [ ! -s "$speaker_shadow_assets/$rel" ]; then
+              echo "::error::missing or empty bundled CAM++ asset: $rel"
+              missing=1
+            fi
+          done
+          if [ -e "$NEKO_NUITKA_RUNTIME_DIR/data/speaker_models" ]; then
+            echo "::error::obsolete data/speaker_models must not be packaged"
+            missing=1
+          fi
+          speaker_weight_count="$(find "$NEKO_NUITKA_RUNTIME_DIR" -type f -name campplus-zh-en-advanced.onnx | wc -l | tr -d ' ')"
+          if [ "$speaker_weight_count" -ne 1 ]; then
+            echo "::error::CAM++ weight must be packaged exactly once"
+            missing=1
+          fi
+          uv run --no-sync python scripts/prepare_speaker_model.py \
+            --asset-dir "$speaker_shadow_assets" --offline || missing=1
           [ "$missing" -eq 0 ]
 
       # --- Generic dist invariant check ---

--- a/.github/workflows/docker-multi-arch.yml
+++ b/.github/workflows/docker-multi-arch.yml
@@ -204,6 +204,15 @@ jobs:
       - name: Prepare verified voice-turn assets
         run: python3 scripts/prepare_voice_turn_assets.py
 
+      - name: Cache CAM++ speaker model weight
+        uses: actions/cache@v4
+        with:
+          path: main_logic/asr_client/speaker_shadow/models/*.onnx
+          key: speaker-shadow-campplus-v1-${{ runner.os }}-${{ hashFiles('main_logic/asr_client/speaker_shadow/models/manifest.json') }}
+
+      - name: Prepare verified CAM++ speaker model
+        run: python3 scripts/prepare_speaker_model.py
+
       - name: Check if Dockerfile exists
         id: check-dockerfile
         run: |
@@ -360,6 +369,15 @@ jobs:
 
       - name: Prepare verified voice-turn assets
         run: python3 scripts/prepare_voice_turn_assets.py
+
+      - name: Cache CAM++ speaker model weight
+        uses: actions/cache@v4
+        with:
+          path: main_logic/asr_client/speaker_shadow/models/*.onnx
+          key: speaker-shadow-campplus-v1-${{ runner.os }}-${{ hashFiles('main_logic/asr_client/speaker_shadow/models/manifest.json') }}
+
+      - name: Prepare verified CAM++ speaker model
+        run: python3 scripts/prepare_speaker_model.py
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -75,6 +75,12 @@ jobs:
         # fails if this pin and the lock ever drift apart.
         run: uv pip install pyclipper==1.4.0
 
+      - name: Install CAM++ frontend parity oracle
+        # Test-only reference implementation. It is intentionally absent from
+        # product dependencies; the unit gate installs a fixed version so the
+        # CAM++ frontend parity test cannot silently importorskip in CI.
+        run: uv pip install kaldi-native-fbank==1.22.3
+
       - name: Run unit test suite
         # Separate pytest process from plugin/tests, which carries its own
         # pytest.ini.

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,11 @@ tests/test_inputs/
 /main_logic/asr_client/endpointing/models/*
 !/main_logic/asr_client/endpointing/models/manifest.json
 !/main_logic/asr_client/endpointing/models/THIRD_PARTY_NOTICES.md
+# CAM++ follows the same supply-chain rule: review the pinned manifest and
+# notices, but never commit downloaded weights or partial transfers.
+/main_logic/asr_client/speaker_shadow/models/*
+!/main_logic/asr_client/speaker_shadow/models/manifest.json
+!/main_logic/asr_client/speaker_shadow/models/THIRD_PARTY_NOTICES.md
 debug_audio/*
 # Binaries (but keep our committed Windows tools listed explicitly if needed)
 *.exe

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -189,6 +189,15 @@ RUN cd /app && \
     unset http_proxy && \
     unset https_proxy
 
+# 6d. CAM++ is pre-fetched and SHA/size verified on the native CI runner. The
+# image build only verifies the copied package-local asset; it never downloads
+# under QEMU. Reject the obsolete data/ location and duplicate model bytes.
+RUN cd /app && \
+    python3 scripts/prepare_speaker_model.py --offline && \
+    test -s /app/main_logic/asr_client/speaker_shadow/models/THIRD_PARTY_NOTICES.md && \
+    test ! -e /app/data/speaker_models && \
+    test "$(find /app -type f -name campplus-zh-en-advanced.onnx | wc -l)" -eq 1
+
 # 7. Copy frontend build artifacts
 # Note: react-neko-chat's vite.config.ts writes to outDir `../../static/react/neko-chat`
 # (relative to its package root), so the actual build output lives at

--- a/docker/Dockerfile.full
+++ b/docker/Dockerfile.full
@@ -258,6 +258,15 @@ RUN cd /app && \
     unset http_proxy && \
     unset https_proxy
 
+# 6d. CAM++ is pre-fetched and SHA/size verified on the native CI runner. The
+# image build only verifies the copied package-local asset; it never downloads
+# under QEMU. Reject the obsolete data/ location and duplicate model bytes.
+RUN cd /app && \
+    python3 scripts/prepare_speaker_model.py --offline && \
+    test -s /app/main_logic/asr_client/speaker_shadow/models/THIRD_PARTY_NOTICES.md && \
+    test ! -e /app/data/speaker_models && \
+    test "$(find /app -type f -name campplus-zh-en-advanced.onnx | wc -l)" -eq 1
+
 # 7. Copy frontend build artifacts
 # Note: react-neko-chat's vite.config.ts writes to outDir `../../static/react/neko-chat`
 # (relative to its package root), so the actual build output lives at

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -33,9 +33,15 @@ Back up the first mount before upgrades. Never expose the data or private-key di
 The Compose service declares `image:`, not `build:`. Build from the repository root explicitly:
 
 ```bash
+uv run python scripts/prepare_speaker_model.py
 docker build -f docker/Dockerfile -t neko-local:standard .
 docker build -f docker/Dockerfile.full -t neko-local:full .
 ```
+
+The preparation step downloads and verifies the pinned CAM++ weight on the
+native host. Both Dockerfiles intentionally re-verify it with `--offline`; this
+keeps emulated multi-architecture builds and image layers free of model network
+fallbacks. Re-run the preparation step after the speaker-model manifest changes.
 
 Set `NEKO_IMAGE=neko-local:standard` or `neko-local:full` before `docker compose up`. `docker compose build` does nothing useful here unless a reviewed `build:` definition is added.
 

--- a/docs/design/speaker-shadow-phase4c-b-campplus.md
+++ b/docs/design/speaker-shadow-phase4c-b-campplus.md
@@ -1,0 +1,116 @@
+# Phase 4C-B：可验证的 CAM++ Speaker Shadow 后端
+
+## 1. 目标
+
+本阶段只为现有、默认关闭的 Speaker Shadow 运行时提供一个可验证的
+CAM++ score-only 后端。它不改变 ASR、Smart Turn、Silero VAD 或 Provider
+的任何决策，也不把说话人身份能力接入 Core。
+
+后端接收一份调用方已经持有的、仅内存的 192 维 CAM++ reference
+embedding，并对现有 Shadow candidate PCM 计算余弦相似度。相似度只允许
+进入测试或离线评估回调；生产 ASR 路径仍然完全由 Provider 和 endpointing
+现有事实驱动。
+
+## 2. 边界
+
+本阶段新增：
+
+- CAM++ 16 kHz frontend、ONNX 合同校验和 score-only backend；
+- 可被 Windows `spawn` 序列化、构造时零 I/O 的 backend factory；
+- 固定 revision、许可、大小和 SHA-256 的资产 manifest；
+- 本地准备、离线评估及 Windows/Linux/Docker 发行链；
+- backend、资产和发行合同的聚焦测试。
+
+本阶段明确不包含：
+
+- `voice_turn` 或 `voice_identity` 模块；
+- Speaker Profile、Enrollment、UI、API、配置或持久化；
+- Core composition、raw similarity observer 产品接口或运行中热切换；
+- 对 `asr_client/runtime.py`、`endpointing/**`、现有 Shadow contracts/runtime、
+  workers、routers 的修改；
+- 模型下载、用户缓存或任何运行时网络回退。
+
+Provider-neutral reference、显式 Enrollment 和 Core composition 必须分别经过
+后续设计与独立 PR。
+
+## 3. 依赖方向
+
+```text
+core/asr_runtime
+  -> asr_client.runtime.SpeakerShadowFactory
+      -> endpointing.detector_runtime
+          -> speaker_shadow.contracts
+
+speaker_shadow.campplus
+  -> speaker_shadow.asset_manifest
+
+speaker_shadow.runtime
+  -> speaker_shadow.contracts.SpeakerShadowBackendFactory
+  <- CampPlusBackendFactory (structural protocol implementation)
+```
+
+CAM++ 代码不得反向依赖 Core、endpointing、workers、Provider、route、queue、
+candidate 生命周期或模型所有者。`speaker_shadow/__init__.py` 保持惰性且只含
+包说明。
+
+## 4. 生命周期和故障边界
+
+Factory 构造只复制并归一化 reference embedding，保存可序列化的路径配置；
+不得读盘、计算 SHA、导入 ONNX Runtime、创建锁、task、process 或 session。
+
+首个达到现有 Shadow 最小时长的 candidate 才触发既有
+`SpeakerShadowRuntime` 创建 `spawn` 子进程。子进程中的 backend `load()` 才：
+
+1. 按统一规则解析并验证资产；
+2. 函数内导入 `onnxruntime`；
+3. 创建一个 CPU session并验证 input、output 和 metadata 合同。
+
+`score()` 只返回有限的余弦分数，不拥有 ASR 执行权。加载、评分和关闭继续由
+现有 Shadow runtime 的硬超时、fail-open、idle unload 和进程终止边界托管。
+一个 runtime 最多持有一个 CAM++ session。
+
+父进程与子进程各自持有独立的 reference 副本。Runtime 关闭时会调用父侧
+factory 的幂等 `close()` 擦除父副本；子进程 backend 和 factory 关闭时分别擦除
+各自副本。候选 embedding 与 feature/output 临时数组在计算后尽力清零。
+
+## 5. 固定资产
+
+资产只允许位于：
+
+`main_logic/asr_client/speaker_shadow/models`
+
+显式 override 存在时只验证该目录，失败不回退。未指定 override 时，顺序为：
+
+1. PyInstaller `_MEIPASS` 下的 package-local 路径；
+2. 冻结可执行文件父目录下的 package-local 路径；
+3. 源码包内的 `models` 目录。
+
+每个候选来源都必须在同一目录内取得 manifest 和权重，并执行完全相同的
+revision、size 与 SHA-256 校验。发行产物还必须在该目录包含 notice。禁止跨目录
+拼装、`data/speaker_models`、用户缓存和运行时下载。
+
+权重不进入 Git、wheel 或 sdist。正式桌面和 Docker 构建在原生 runner 上按
+manifest 准备资产，构建产物内再离线复验，并要求权重、manifest、notice 各一
+份且不存在旧资产目录。
+
+## 6. 隐私与可观测性
+
+PCM、reference/candidate embedding、similarity、输入路径、candidate key 和身份
+信息不得写入日志、持久化或 aggregate snapshot。生产错误仅使用低基数类型，
+例如 `asset_missing`、`asset_size_mismatch`、`asset_sha256_mismatch`，不得拼接
+绝对路径或实际摘要。
+
+离线评估工具可以在进程内输出按输入序号排列的 similarity 和阈值对照，但不得
+回显文件路径、embedding 或 PCM；退出前应释放并尽力擦除这些内存对象。
+
+## 7. 验收
+
+- frontend 与 `kaldi_native_fbank` 对确定性合成音频保持数值一致；
+- embedding 固定为 float32、192 维、finite、L2-normalized；
+- factory 构造零 I/O、可 pickle，并在关闭后擦除父侧 reference；
+- 资产 identity、解析顺序、离线准备和损坏拒绝都有测试；
+- Windows/Linux/Docker 产物各只包含一份固定权重、manifest 和 notice；
+- 现有 Shadow 的 load/score/close 超时、idle unload、spawn 和完整关闭测试继续
+  通过；
+- `voice_turn/**`、`voice_identity/**`、Core、endpointing 和 workers 对主线保持
+  零差异。

--- a/main_logic/asr_client/speaker_shadow/asset_manifest.py
+++ b/main_logic/asr_client/speaker_shadow/asset_manifest.py
@@ -1,0 +1,177 @@
+"""Pinned CAM++ asset resolution and verification without runtime downloads."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+CAMPPLUS_FILENAME = "campplus-zh-en-advanced.onnx"
+CAMPPLUS_MODEL_ID = "iic/speech_campplus_sv_zh_en_16k-common_advanced"
+CAMPPLUS_MODEL_REVISION = "v1.0.0"
+CAMPPLUS_LICENSE = "Apache-2.0"
+CAMPPLUS_SOURCE = (
+    "https://github.com/k2-fsa/sherpa-onnx/releases/download/"
+    "speaker-recongition-models/"
+    "3dspeaker_speech_campplus_sv_zh_en_16k-common_advanced.onnx"
+)
+CAMPPLUS_EXPORT_SOURCE = "k2-fsa/sherpa-onnx"
+CAMPPLUS_SIZE_BYTES = 28_281_164
+CAMPPLUS_SHA256 = "aa3cfc16963a10586a9393f5035d6d6b57e98d358b347f80c2a30bf4f00ceba2"
+CAMPPLUS_SAMPLE_RATE_HZ = 16_000
+CAMPPLUS_PREPROCESSING = "kaldi-native-fbank-sniped-global-mean-v1"
+CAMPPLUS_INPUT_CONTRACT = "float32[batch,time,80]"
+CAMPPLUS_OUTPUT_CONTRACT = "float32[batch,192]"
+
+MANIFEST_FILENAME = "manifest.json"
+ASSET_RELATIVE_PATH = (
+    Path("main_logic") / "asr_client" / "speaker_shadow" / "models"
+)
+
+
+class CampPlusAssetError(RuntimeError):
+    """A low-cardinality CAM++ asset validation failure."""
+
+
+@dataclass(frozen=True, slots=True)
+class CampPlusManifest:
+    filename: str
+    model_id: str
+    revision: str
+    license: str
+    source: str
+    export_source: str
+    size_bytes: int
+    sha256: str
+    sample_rate_hz: int
+    preprocessing: str
+    input_contract: str
+    output_contract: str
+
+
+_EXPECTED_MANIFEST = CampPlusManifest(
+    filename=CAMPPLUS_FILENAME,
+    model_id=CAMPPLUS_MODEL_ID,
+    revision=CAMPPLUS_MODEL_REVISION,
+    license=CAMPPLUS_LICENSE,
+    source=CAMPPLUS_SOURCE,
+    export_source=CAMPPLUS_EXPORT_SOURCE,
+    size_bytes=CAMPPLUS_SIZE_BYTES,
+    sha256=CAMPPLUS_SHA256,
+    sample_rate_hz=CAMPPLUS_SAMPLE_RATE_HZ,
+    preprocessing=CAMPPLUS_PREPROCESSING,
+    input_contract=CAMPPLUS_INPUT_CONTRACT,
+    output_contract=CAMPPLUS_OUTPUT_CONTRACT,
+)
+
+
+def _manifest_from_mapping(value: dict[str, Any]) -> CampPlusManifest:
+    fields = frozenset(CampPlusManifest.__dataclass_fields__)
+    if set(value) != fields:
+        raise CampPlusAssetError("manifest_invalid")
+    string_fields = fields - {"size_bytes", "sample_rate_hz"}
+    if any(not isinstance(value[field], str) for field in string_fields):
+        raise CampPlusAssetError("manifest_invalid")
+    if type(value["size_bytes"]) is not int or value["size_bytes"] <= 0:
+        raise CampPlusAssetError("manifest_invalid")
+    if type(value["sample_rate_hz"]) is not int:
+        raise CampPlusAssetError("manifest_invalid")
+    if Path(value["filename"]).name != value["filename"]:
+        raise CampPlusAssetError("manifest_invalid")
+    sha256 = value["sha256"]
+    if len(sha256) != 64 or any(
+        character not in "0123456789abcdef" for character in sha256
+    ):
+        raise CampPlusAssetError("manifest_invalid")
+    return CampPlusManifest(**value)
+
+
+def load_campplus_manifest(directory: Path) -> CampPlusManifest:
+    """Load and pin the reviewed CAM++ manifest from exactly ``directory``."""
+
+    try:
+        raw = json.loads((directory / MANIFEST_FILENAME).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        raise CampPlusAssetError("manifest_unreadable") from None
+    if not isinstance(raw, dict):
+        raise CampPlusAssetError("manifest_invalid")
+    manifest = _manifest_from_mapping(raw)
+    if manifest != _EXPECTED_MANIFEST:
+        raise CampPlusAssetError("manifest_identity_mismatch")
+    return manifest
+
+
+def candidate_campplus_asset_directories(
+    override: Path | None = None,
+) -> tuple[Path, ...]:
+    """Return the fixed asset lookup order without probing the filesystem.
+
+    An explicit override is authoritative and therefore disables every fallback.
+    """
+
+    if override is not None:
+        return (Path(override).resolve(),)
+
+    candidates: list[Path] = []
+    meipass = getattr(sys, "_MEIPASS", None)
+    if meipass:
+        candidates.append(Path(meipass) / ASSET_RELATIVE_PATH)
+    candidates.append(Path(sys.executable).resolve().parent / ASSET_RELATIVE_PATH)
+    candidates.append(Path(__file__).resolve().parent / "models")
+
+    unique: list[Path] = []
+    for candidate in candidates:
+        resolved = candidate.resolve()
+        if resolved not in unique:
+            unique.append(resolved)
+    return tuple(unique)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError:
+        raise CampPlusAssetError("asset_unreadable") from None
+    return digest.hexdigest()
+
+
+def verify_campplus_asset(
+    directory: Path,
+    manifest: CampPlusManifest | None = None,
+) -> Path:
+    """Verify one pinned weight without falling back or exposing its path."""
+
+    pinned = manifest or load_campplus_manifest(directory)
+    if pinned != _EXPECTED_MANIFEST:
+        raise CampPlusAssetError("manifest_identity_mismatch")
+    model_path = directory / pinned.filename
+    try:
+        if not model_path.is_file():
+            raise CampPlusAssetError("asset_missing")
+        if model_path.stat().st_size != pinned.size_bytes:
+            raise CampPlusAssetError("asset_size_mismatch")
+    except CampPlusAssetError:
+        raise
+    except OSError:
+        raise CampPlusAssetError("asset_unreadable") from None
+    if _sha256_file(model_path) != pinned.sha256:
+        raise CampPlusAssetError("asset_sha256_mismatch")
+    return model_path
+
+
+def resolve_verified_campplus_asset(override: Path | None = None) -> Path:
+    """Resolve the first fully verified asset in the fixed lookup order."""
+
+    for directory in candidate_campplus_asset_directories(override):
+        try:
+            return verify_campplus_asset(directory)
+        except CampPlusAssetError:
+            continue
+    raise CampPlusAssetError("no_verified_asset")

--- a/main_logic/asr_client/speaker_shadow/asset_manifest.py
+++ b/main_logic/asr_client/speaker_shadow/asset_manifest.py
@@ -95,7 +95,7 @@ def load_campplus_manifest(directory: Path) -> CampPlusManifest:
 
     try:
         raw = json.loads((directory / MANIFEST_FILENAME).read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         raise CampPlusAssetError("manifest_unreadable") from None
     if not isinstance(raw, dict):
         raise CampPlusAssetError("manifest_invalid")

--- a/main_logic/asr_client/speaker_shadow/campplus.py
+++ b/main_logic/asr_client/speaker_shadow/campplus.py
@@ -1,0 +1,445 @@
+"""Lazy, score-only CAM++ backend for the observation-only speaker shadow."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from .asset_manifest import (
+    CAMPPLUS_FILENAME,
+    CAMPPLUS_MODEL_ID,
+    CAMPPLUS_MODEL_REVISION,
+    CAMPPLUS_SAMPLE_RATE_HZ,
+    CAMPPLUS_SHA256,
+    CAMPPLUS_SIZE_BYTES,
+    CAMPPLUS_SOURCE,
+    resolve_verified_campplus_asset,
+)
+
+
+CAMPPLUS_EMBEDDING_DIM = 192
+CAMPPLUS_MINIMUM_SAMPLES = 24_000
+_FRAME_LENGTH = 400
+_FRAME_SHIFT = 160
+_PADDED_FRAME_LENGTH = 512
+_MEL_BIN_COUNT = 80
+_PREEMPHASIS_COEFFICIENT = np.float32(0.97)
+_FLOAT32_EPSILON = np.finfo(np.float32).eps
+
+
+def _wipe_array(value: np.ndarray | None) -> None:
+    """Best-effort wipe for temporary biometric arrays owned by this module."""
+
+    if value is None or not value.flags.writeable:
+        return
+    try:
+        value.fill(0)
+    except (TypeError, ValueError):
+        pass
+
+
+class _ZeroizableEmbedding:
+    """Pickle-safe float32 storage whose owned bytes can be overwritten."""
+
+    def __init__(self, reference_embedding: np.ndarray) -> None:
+        embedding: np.ndarray | None = None
+        try:
+            embedding = np.array(reference_embedding, dtype=np.float32, copy=True)
+            if embedding.shape != (CAMPPLUS_EMBEDDING_DIM,):
+                raise ValueError("reference_embedding_shape")
+            if not np.isfinite(embedding).all():
+                raise ValueError("reference_embedding_non_finite")
+            norm = float(np.linalg.norm(embedding))
+            if not math.isfinite(norm) or norm <= 1e-12:
+                raise ValueError("reference_embedding_norm")
+            embedding /= np.float32(norm)
+            self._storage = bytearray(
+                embedding.astype("<f4", copy=False).tobytes()
+            )
+        finally:
+            _wipe_array(embedding)
+        self._closed = False
+
+    def copy(self) -> np.ndarray:
+        if self._closed:
+            raise RuntimeError("reference_embedding_closed")
+        return np.frombuffer(self._storage, dtype="<f4").astype(
+            np.float32,
+            copy=True,
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._storage[:] = b"\x00" * len(self._storage)
+
+
+def _povey_window() -> np.ndarray:
+    indices = np.arange(_FRAME_LENGTH, dtype=np.float64)
+    window = (
+        0.5 - 0.5 * np.cos(2 * np.pi * indices / (_FRAME_LENGTH - 1))
+    ) ** 0.85
+    return window.astype(np.float32)
+
+
+def _mel_scale(frequency_hz: float | np.ndarray) -> np.ndarray:
+    return 1127.0 * np.log1p(np.asarray(frequency_hz) / 700.0)
+
+
+def _mel_filter_bank() -> np.ndarray:
+    low_mel = float(_mel_scale(20.0))
+    high_mel = float(_mel_scale(CAMPPLUS_SAMPLE_RATE_HZ / 2))
+    mel_delta = (high_mel - low_mel) / (_MEL_BIN_COUNT + 1)
+    frequencies = (
+        np.arange(_PADDED_FRAME_LENGTH // 2 + 1, dtype=np.float64)
+        * CAMPPLUS_SAMPLE_RATE_HZ
+        / _PADDED_FRAME_LENGTH
+    )
+    mel_frequencies = _mel_scale(frequencies)
+    filters = np.zeros(
+        (_MEL_BIN_COUNT, _PADDED_FRAME_LENGTH // 2 + 1),
+        dtype=np.float32,
+    )
+    segments = np.floor((mel_frequencies - low_mel) / mel_delta).astype(
+        np.int32
+    )
+    for fft_bin, segment in enumerate(segments):
+        if segment < 0 or segment > _MEL_BIN_COUNT:
+            continue
+        weight = (
+            mel_frequencies[fft_bin] - (low_mel + segment * mel_delta)
+        ) / mel_delta
+        if segment < _MEL_BIN_COUNT:
+            filters[segment, fft_bin] += np.float32(weight)
+        if segment > 0:
+            filters[segment - 1, fft_bin] += np.float32(1.0 - weight)
+    return filters
+
+
+_POVEY_WINDOW = _povey_window()
+_MEL_FILTER_BANK = _mel_filter_bank()
+
+
+def compute_campplus_features(
+    pcm16: bytes,
+    *,
+    sample_rate_hz: int,
+) -> np.ndarray:
+    """Match the reviewed sherpa-onnx 3D-Speaker Kaldi fbank frontend."""
+
+    if sample_rate_hz != CAMPPLUS_SAMPLE_RATE_HZ:
+        raise ValueError("sample_rate_mismatch")
+    if not isinstance(pcm16, bytes) or not pcm16:
+        raise ValueError("pcm_invalid")
+    if len(pcm16) % 2:
+        raise ValueError("pcm_invalid")
+
+    samples: np.ndarray | None = None
+    frames: np.ndarray | None = None
+    spectrum: np.ndarray | None = None
+    power: np.ndarray | None = None
+    mel_energies: np.ndarray | None = None
+    features: np.ndarray | None = None
+    try:
+        samples = np.frombuffer(pcm16, dtype="<i2").astype(np.float32)
+        samples /= np.float32(32768.0)
+        if samples.size < _FRAME_LENGTH:
+            raise ValueError("pcm_too_short")
+        frame_count = 1 + (samples.size - _FRAME_LENGTH) // _FRAME_SHIFT
+        shape = (frame_count, _FRAME_LENGTH)
+        strides = (samples.strides[0] * _FRAME_SHIFT, samples.strides[0])
+        frames = np.lib.stride_tricks.as_strided(
+            samples,
+            shape=shape,
+            strides=strides,
+            writeable=False,
+        ).copy()
+        frames -= frames.mean(axis=1, keepdims=True, dtype=np.float32)
+        frames[:, 1:] -= _PREEMPHASIS_COEFFICIENT * frames[:, :-1]
+        frames[:, 0] *= np.float32(1.0) - _PREEMPHASIS_COEFFICIENT
+        frames *= _POVEY_WINDOW
+        spectrum = np.fft.rfft(frames, n=_PADDED_FRAME_LENGTH, axis=1)
+        power = (
+            spectrum.real * spectrum.real + spectrum.imag * spectrum.imag
+        ).astype(np.float32)
+        mel_energies = power @ _MEL_FILTER_BANK.T
+        np.maximum(mel_energies, _FLOAT32_EPSILON, out=mel_energies)
+        features = np.log(mel_energies, dtype=np.float32)
+        features -= features.mean(axis=0, keepdims=True, dtype=np.float32)
+        return np.array(features, dtype=np.float32, order="C", copy=True)
+    finally:
+        _wipe_array(features)
+        _wipe_array(mel_energies)
+        _wipe_array(power)
+        _wipe_array(spectrum)
+        _wipe_array(frames)
+        _wipe_array(samples)
+
+
+class CampPlusEmbeddingModel:
+    """One lazy CPU ONNX session owned by the spawned backend process."""
+
+    model_id = CAMPPLUS_MODEL_ID
+    model_revision = CAMPPLUS_MODEL_REVISION
+
+    def __init__(self, asset_dir: Path | None = None) -> None:
+        self._asset_dir = Path(asset_dir) if asset_dir is not None else None
+        self._session: Any | None = None
+        self._closed = False
+
+    @property
+    def is_ready(self) -> bool:
+        return self._session is not None and not self._closed
+
+    def load(self) -> bool:
+        if self._closed:
+            return False
+        if self._session is not None:
+            return True
+        session: Any | None = None
+        try:
+            model_path = resolve_verified_campplus_asset(self._asset_dir)
+            import onnxruntime as ort
+
+            options = ort.SessionOptions()
+            options.execution_mode = ort.ExecutionMode.ORT_SEQUENTIAL
+            options.intra_op_num_threads = 1
+            options.inter_op_num_threads = 1
+            options.graph_optimization_level = (
+                ort.GraphOptimizationLevel.ORT_ENABLE_ALL
+            )
+            options.enable_cpu_mem_arena = False
+            session = ort.InferenceSession(
+                str(model_path),
+                sess_options=options,
+                providers=["CPUExecutionProvider"],
+            )
+            self._validate_session_contract(session)
+        except Exception:
+            session = None
+            return False
+        self._session = session
+        return True
+
+    @staticmethod
+    def _validate_session_contract(session: Any) -> None:
+        inputs = session.get_inputs()
+        outputs = session.get_outputs()
+        if len(inputs) != 1:
+            raise ValueError("onnx_input_count")
+        if inputs[0].name != "x":
+            raise ValueError("onnx_input_name")
+        if inputs[0].type != "tensor(float)":
+            raise ValueError("onnx_input_type")
+        if len(inputs[0].shape) != 3 or inputs[0].shape[2] != 80:
+            raise ValueError("onnx_input_shape")
+        if len(outputs) != 1:
+            raise ValueError("onnx_output_count")
+        if outputs[0].name != "embedding":
+            raise ValueError("onnx_output_name")
+        if outputs[0].type != "tensor(float)":
+            raise ValueError("onnx_output_type")
+        if (
+            len(outputs[0].shape) != 2
+            or outputs[0].shape[1] != CAMPPLUS_EMBEDDING_DIM
+        ):
+            raise ValueError("onnx_output_shape")
+        metadata = session.get_modelmeta().custom_metadata_map
+        expected_metadata = {
+            "framework": "3d-speaker",
+            "language": "Chinese-English",
+            "feature_normalize_type": "global-mean",
+            "sample_rate": "16000",
+            "output_dim": "192",
+            "normalize_samples": "1",
+        }
+        if any(
+            metadata.get(key) != expected
+            for key, expected in expected_metadata.items()
+        ):
+            raise ValueError("onnx_metadata")
+
+    def embedding_from_pcm16(
+        self,
+        pcm16: bytes,
+        *,
+        sample_rate_hz: int,
+    ) -> np.ndarray:
+        session = self._session
+        if self._closed or session is None:
+            raise RuntimeError("model_not_loaded")
+        if not isinstance(pcm16, bytes) or not pcm16 or len(pcm16) % 2:
+            raise ValueError("pcm_invalid")
+        if sample_rate_hz != CAMPPLUS_SAMPLE_RATE_HZ:
+            raise ValueError("sample_rate_mismatch")
+        if len(pcm16) // 2 < CAMPPLUS_MINIMUM_SAMPLES:
+            raise ValueError("pcm_too_short")
+
+        features: np.ndarray | None = None
+        raw_embedding: np.ndarray | None = None
+        result: np.ndarray | None = None
+        outputs: list[Any] | None = None
+        keep_result = False
+        try:
+            features = compute_campplus_features(
+                pcm16,
+                sample_rate_hz=sample_rate_hz,
+            )
+            outputs = session.run(
+                ["embedding"],
+                {"x": features[np.newaxis, :, :]},
+            )
+            if len(outputs) != 1:
+                raise ValueError("onnx_output_count")
+            raw_embedding = np.asarray(outputs[0], dtype=np.float32)
+            if raw_embedding.shape != (1, CAMPPLUS_EMBEDDING_DIM):
+                raise ValueError("onnx_output_shape")
+            result = np.array(raw_embedding[0], dtype=np.float32, copy=True)
+            if not np.isfinite(result).all():
+                raise ValueError("embedding_non_finite")
+            norm = float(np.linalg.norm(result))
+            if not math.isfinite(norm) or norm <= 1e-12:
+                raise ValueError("embedding_norm")
+            result /= np.float32(norm)
+            keep_result = True
+            return result
+        finally:
+            _wipe_array(features)
+            if outputs is not None:
+                for output in outputs:
+                    if isinstance(output, np.ndarray):
+                        _wipe_array(output)
+            _wipe_array(raw_embedding)
+            if not keep_result:
+                _wipe_array(result)
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._session = None
+
+
+class CampPlusSpeakerShadowBackend:
+    """Convert candidate PCM to one finite cosine score and retain no result."""
+
+    def __init__(
+        self,
+        reference_embedding: np.ndarray,
+        *,
+        asset_dir: Path | None = None,
+        model_factory: Callable[[], Any] | None = None,
+    ) -> None:
+        self._reference = _ZeroizableEmbedding(reference_embedding)
+        self._asset_dir = Path(asset_dir) if asset_dir is not None else None
+        self._model_factory = model_factory
+        self._model: Any | None = None
+        self._closed = False
+
+    def load(self) -> bool:
+        if self._closed:
+            return False
+        if self._model is not None:
+            return True
+        model: Any | None = None
+        try:
+            model = (
+                CampPlusEmbeddingModel(asset_dir=self._asset_dir)
+                if self._model_factory is None
+                else self._model_factory()
+            )
+            if not bool(model.load()):
+                model.close()
+                return False
+        except Exception:
+            if model is not None:
+                try:
+                    model.close()
+                except Exception:
+                    pass
+            return False
+        self._model = model
+        return True
+
+    def score(self, pcm16: bytes, sample_rate_hz: int) -> float:
+        if self._closed:
+            raise RuntimeError("backend_closed")
+        model = self._model
+        if model is None:
+            raise RuntimeError("backend_not_loaded")
+
+        raw_candidate: Any = None
+        candidate: np.ndarray | None = None
+        reference: np.ndarray | None = None
+        try:
+            raw_candidate = model.embedding_from_pcm16(
+                pcm16,
+                sample_rate_hz=sample_rate_hz,
+            )
+            candidate = np.array(raw_candidate, dtype=np.float32, copy=True)
+            if candidate.shape != (CAMPPLUS_EMBEDDING_DIM,):
+                raise ValueError("embedding_shape")
+            if not np.isfinite(candidate).all():
+                raise ValueError("embedding_non_finite")
+            norm = float(np.linalg.norm(candidate))
+            if not math.isfinite(norm) or norm <= 1e-12:
+                raise ValueError("embedding_norm")
+            candidate /= np.float32(norm)
+            reference = self._reference.copy()
+            similarity = float(np.dot(reference, candidate))
+            if not math.isfinite(similarity):
+                raise ValueError("similarity_non_finite")
+            return min(1.0, max(-1.0, similarity))
+        finally:
+            _wipe_array(reference)
+            _wipe_array(candidate)
+            if isinstance(raw_candidate, np.ndarray):
+                _wipe_array(raw_candidate)
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        model, self._model = self._model, None
+        try:
+            if model is not None:
+                model.close()
+        finally:
+            self._reference.close()
+
+
+class CampPlusBackendFactory:
+    """Lightweight spawn-pickleable factory owning parent reference material."""
+
+    def __init__(
+        self,
+        reference_embedding: np.ndarray,
+        *,
+        asset_dir: Path | None = None,
+    ) -> None:
+        self._reference = _ZeroizableEmbedding(reference_embedding)
+        self._asset_dir = Path(asset_dir) if asset_dir is not None else None
+        self._closed = False
+
+    def __call__(self) -> CampPlusSpeakerShadowBackend:
+        if self._closed:
+            raise RuntimeError("backend_factory_closed")
+        reference = self._reference.copy()
+        try:
+            return CampPlusSpeakerShadowBackend(
+                reference,
+                asset_dir=self._asset_dir,
+            )
+        finally:
+            _wipe_array(reference)
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._reference.close()

--- a/main_logic/asr_client/speaker_shadow/models/THIRD_PARTY_NOTICES.md
+++ b/main_logic/asr_client/speaker_shadow/models/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,33 @@
+# CAM++ speaker model notice
+
+Release artifacts may include an ONNX export of the third-party model below.
+The weight is prepared only by the release workflow and is not stored in this
+Git repository. Its immutable byte identity is pinned in `manifest.json`.
+
+## CAM++ zh-en advanced
+
+- Model: CAM++ speaker verification, common 16 kHz Chinese-English advanced
+- ModelScope ID: `iic/speech_campplus_sv_zh_en_16k-common_advanced`
+- ModelScope revision: `v1.0.0`
+- ONNX exporter/distributor: `k2-fsa/sherpa-onnx`
+- License: Apache License 2.0
+
+Copyright (c) Alibaba Cloud and the 3D-Speaker contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at:
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+
+Upstream references:
+
+- https://modelscope.cn/models/iic/speech_campplus_sv_zh_en_16k-common_advanced
+- https://github.com/alibaba-damo-academy/3D-Speaker
+- https://github.com/k2-fsa/sherpa-onnx/tree/master/scripts/3dspeaker

--- a/main_logic/asr_client/speaker_shadow/models/manifest.json
+++ b/main_logic/asr_client/speaker_shadow/models/manifest.json
@@ -1,0 +1,14 @@
+{
+  "filename": "campplus-zh-en-advanced.onnx",
+  "model_id": "iic/speech_campplus_sv_zh_en_16k-common_advanced",
+  "revision": "v1.0.0",
+  "license": "Apache-2.0",
+  "source": "https://github.com/k2-fsa/sherpa-onnx/releases/download/speaker-recongition-models/3dspeaker_speech_campplus_sv_zh_en_16k-common_advanced.onnx",
+  "export_source": "k2-fsa/sherpa-onnx",
+  "size_bytes": 28281164,
+  "sha256": "aa3cfc16963a10586a9393f5035d6d6b57e98d358b347f80c2a30bf4f00ceba2",
+  "sample_rate_hz": 16000,
+  "preprocessing": "kaldi-native-fbank-sniped-global-mean-v1",
+  "input_contract": "float32[batch,time,80]",
+  "output_contract": "float32[batch,192]"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,8 @@ exclude = [
   "plugin/plugins",
   "main_logic/asr_client/endpointing/models/*.onnx",
   "main_logic/asr_client/endpointing/models/*.part",
+  "main_logic/asr_client/speaker_shadow/models/*.onnx",
+  "main_logic/asr_client/speaker_shadow/models/*.part",
 ]
 
 [tool.hatch.build.targets.sdist]
@@ -144,6 +146,8 @@ exclude = [
   "plugin/plugins",
   "main_logic/asr_client/endpointing/models/*.onnx",
   "main_logic/asr_client/endpointing/models/*.part",
+  "main_logic/asr_client/speaker_shadow/models/*.onnx",
+  "main_logic/asr_client/speaker_shadow/models/*.part",
 ]
 
 # pyncm-async 已从 PyPI 下架（连同上游 pyncm 与 GitHub 仓库），改为本地 wheel 安装。

--- a/scripts/evaluate_campplus_shadow.py
+++ b/scripts/evaluate_campplus_shadow.py
@@ -30,18 +30,21 @@ THRESHOLDS = (0.40, 0.44, 0.48, 0.52, 0.55)
 
 
 def _read_pcm16(path: Path, *, maximum_seconds: float | None = None) -> bytes:
-    with wave.open(str(path), "rb") as source:
-        if (
-            source.getnchannels() != 1
-            or source.getsampwidth() != 2
-            or source.getframerate() != SAMPLE_RATE_HZ
-            or source.getcomptype() != "NONE"
-        ):
-            raise ValueError("all WAV inputs must be mono PCM16LE at 16 kHz")
-        frame_count = source.getnframes()
-        if maximum_seconds is not None:
-            frame_count = min(frame_count, round(SAMPLE_RATE_HZ * maximum_seconds))
-        pcm16 = source.readframes(frame_count)
+    try:
+        with wave.open(str(path), "rb") as source:
+            if (
+                source.getnchannels() != 1
+                or source.getsampwidth() != 2
+                or source.getframerate() != SAMPLE_RATE_HZ
+                or source.getcomptype() != "NONE"
+            ):
+                raise ValueError("all WAV inputs must be mono PCM16LE at 16 kHz")
+            frame_count = source.getnframes()
+            if maximum_seconds is not None:
+                frame_count = min(frame_count, round(SAMPLE_RATE_HZ * maximum_seconds))
+            pcm16 = source.readframes(frame_count)
+    except (OSError, EOFError, wave.Error):
+        raise ValueError("wav_unreadable") from None
     if len(pcm16) < round(SAMPLE_RATE_HZ * MINIMUM_AUDIO_SECONDS) * 2:
         raise ValueError("all voice segments must contain at least 1.5 seconds")
     return pcm16
@@ -146,8 +149,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--asset-dir", type=Path)
     args = parser.parse_args(argv)
     result = evaluate(
-        reference_paths=[path.resolve() for path in args.reference],
-        candidate_paths=[path.resolve() for path in args.candidate],
+        reference_paths=list(args.reference),
+        candidate_paths=list(args.candidate),
         asset_dir=args.asset_dir.resolve() if args.asset_dir else None,
     )
     print(json.dumps(result, ensure_ascii=False, sort_keys=True))

--- a/scripts/evaluate_campplus_shadow.py
+++ b/scripts/evaluate_campplus_shadow.py
@@ -1,0 +1,158 @@
+"""Evaluate CAM++ speaker-shadow scores offline without retaining voice data."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import wave
+from pathlib import Path
+
+import numpy as np
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from main_logic.asr_client.speaker_shadow.campplus import (  # noqa: E402
+    CampPlusEmbeddingModel,
+    CampPlusSpeakerShadowBackend,
+)
+
+
+SAMPLE_RATE_HZ = 16_000
+MINIMUM_AUDIO_SECONDS = 1.5
+MAXIMUM_CANDIDATE_SECONDS = 4.0
+MINIMUM_REFERENCE_SEGMENTS = 3
+MAXIMUM_REFERENCE_SEGMENTS = 5
+THRESHOLDS = (0.40, 0.44, 0.48, 0.52, 0.55)
+
+
+def _read_pcm16(path: Path, *, maximum_seconds: float | None = None) -> bytes:
+    with wave.open(str(path), "rb") as source:
+        if (
+            source.getnchannels() != 1
+            or source.getsampwidth() != 2
+            or source.getframerate() != SAMPLE_RATE_HZ
+            or source.getcomptype() != "NONE"
+        ):
+            raise ValueError("all WAV inputs must be mono PCM16LE at 16 kHz")
+        frame_count = source.getnframes()
+        if maximum_seconds is not None:
+            frame_count = min(frame_count, round(SAMPLE_RATE_HZ * maximum_seconds))
+        pcm16 = source.readframes(frame_count)
+    if len(pcm16) < round(SAMPLE_RATE_HZ * MINIMUM_AUDIO_SECONDS) * 2:
+        raise ValueError("all voice segments must contain at least 1.5 seconds")
+    return pcm16
+
+
+def _normalized_reference(embeddings: list[np.ndarray]) -> np.ndarray:
+    reference = np.mean(
+        np.stack(embeddings, axis=0),
+        axis=0,
+        dtype=np.float32,
+    ).astype(np.float32, copy=False)
+    norm = float(np.linalg.norm(reference))
+    if not np.isfinite(reference).all() or not np.isfinite(norm) or norm <= 0.0:
+        reference.fill(0)
+        raise ValueError("CAM++ reference embedding must be finite and non-zero")
+    reference /= np.float32(norm)
+    return reference
+
+
+def evaluate(
+    *,
+    reference_paths: list[Path],
+    candidate_paths: list[Path],
+    asset_dir: Path | None,
+) -> dict[str, object]:
+    """Return an in-memory score report containing no voice data or paths."""
+
+    if not MINIMUM_REFERENCE_SEGMENTS <= len(reference_paths) <= MAXIMUM_REFERENCE_SEGMENTS:
+        raise ValueError("reference requires 3 to 5 voice segments")
+    if not candidate_paths:
+        raise ValueError("at least one candidate voice segment is required")
+
+    reference_pcm16 = [_read_pcm16(path) for path in reference_paths]
+    embeddings: list[np.ndarray] = []
+    reference: np.ndarray | None = None
+    model = CampPlusEmbeddingModel(asset_dir=asset_dir)
+    if not model.load():
+        for index in range(len(reference_pcm16)):
+            reference_pcm16[index] = b""
+        model.close()
+        raise RuntimeError("campplus_reference_load_failed")
+    try:
+        for pcm16 in reference_pcm16:
+            embeddings.append(
+                model.embedding_from_pcm16(pcm16, sample_rate_hz=SAMPLE_RATE_HZ)
+            )
+        reference = _normalized_reference(embeddings)
+    finally:
+        for index in range(len(reference_pcm16)):
+            reference_pcm16[index] = b""
+        for embedding in embeddings:
+            embedding.fill(0)
+        model.close()
+
+    assert reference is not None
+    backend = CampPlusSpeakerShadowBackend(
+        reference,
+        asset_dir=asset_dir,
+        model_factory=lambda: CampPlusEmbeddingModel(asset_dir=asset_dir),
+    )
+    reference.fill(0)
+    if not backend.load():
+        backend.close()
+        raise RuntimeError("campplus_candidate_load_failed")
+
+    observations: list[dict[str, object]] = []
+    try:
+        for index, path in enumerate(candidate_paths):
+            candidate_pcm16 = _read_pcm16(
+                path,
+                maximum_seconds=MAXIMUM_CANDIDATE_SECONDS,
+            )
+            try:
+                similarity = float(backend.score(candidate_pcm16, SAMPLE_RATE_HZ))
+            finally:
+                candidate_pcm16 = b""
+            observations.append(
+                {
+                    "candidate_index": index,
+                    "similarity": similarity,
+                    "would_block": {
+                        f"{threshold:.2f}": similarity < threshold
+                        for threshold in THRESHOLDS
+                    },
+                }
+            )
+    finally:
+        backend.close()
+
+    return {
+        "schema_version": 1,
+        "reference_segment_count": len(reference_paths),
+        "candidate_count": len(candidate_paths),
+        "observations": observations,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--reference", type=Path, nargs="+", required=True)
+    parser.add_argument("--candidate", type=Path, nargs="+", required=True)
+    parser.add_argument("--asset-dir", type=Path)
+    args = parser.parse_args(argv)
+    result = evaluate(
+        reference_paths=[path.resolve() for path in args.reference],
+        candidate_paths=[path.resolve() for path in args.candidate],
+        asset_dir=args.asset_dir.resolve() if args.asset_dir else None,
+    )
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/prepare_speaker_model.py
+++ b/scripts/prepare_speaker_model.py
@@ -97,9 +97,11 @@ def _download_verified(
             )
             os.replace(temporary, destination)
             return
-        except CampPlusAssetError:
+        except CampPlusAssetError as exc:
             temporary.unlink(missing_ok=True)
-            raise
+            if exc.args != ("asset_size_mismatch",) or attempt == 2:
+                raise
+            time.sleep(1 << attempt)
         except (OSError, TimeoutError, URLError) as exc:
             last_error = exc
             temporary.unlink(missing_ok=True)

--- a/scripts/prepare_speaker_model.py
+++ b/scripts/prepare_speaker_model.py
@@ -1,0 +1,198 @@
+"""Prepare the pinned CAM++ speaker model and verify every byte before use."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import os
+import shutil
+import sys
+import time
+import urllib.request
+from pathlib import Path
+from urllib.error import URLError
+from urllib.parse import urlsplit
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+ASSET_MANIFEST_PATH = (
+    PROJECT_ROOT
+    / "main_logic"
+    / "asr_client"
+    / "speaker_shadow"
+    / "asset_manifest.py"
+)
+DEFAULT_ASSET_DIR = ASSET_MANIFEST_PATH.parent / "models"
+
+
+def _load_asset_manifest_module():
+    """Load the stdlib-only manifest module without importing ASR facades."""
+
+    module_name = "main_logic.asr_client.speaker_shadow.asset_manifest"
+    existing = sys.modules.get(module_name)
+    if existing is not None:
+        return existing
+    spec = importlib.util.spec_from_file_location(module_name, ASSET_MANIFEST_PATH)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load CAM++ asset manifest from {ASSET_MANIFEST_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except BaseException:
+        sys.modules.pop(module_name, None)
+        raise
+    return module
+
+
+_asset_manifest = _load_asset_manifest_module()
+CampPlusAssetError = _asset_manifest.CampPlusAssetError
+load_campplus_manifest = _asset_manifest.load_campplus_manifest
+verify_campplus_asset = _asset_manifest.verify_campplus_asset
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _verify_transfer(path: Path, *, expected_size: int, expected_sha256: str) -> None:
+    if path.stat().st_size != expected_size:
+        raise CampPlusAssetError("asset_size_mismatch")
+    if _sha256_file(path).lower() != expected_sha256.lower():
+        raise CampPlusAssetError("asset_sha256_mismatch")
+
+
+def _download_verified(
+    source: str,
+    destination: Path,
+    *,
+    expected_size: int,
+    expected_sha256: str,
+) -> None:
+    if urlsplit(source).scheme.lower() != "https":
+        raise CampPlusAssetError("manifest_invalid")
+
+    temporary = destination.with_suffix(destination.suffix + ".part")
+    request = urllib.request.Request(
+        source,
+        headers={"User-Agent": "NEKO-speaker-model-preparer/1"},
+    )
+    last_error: Exception | None = None
+    for attempt in range(3):
+        try:
+            with urllib.request.urlopen(request, timeout=60) as response:
+                if urlsplit(response.geturl()).scheme.lower() != "https":
+                    raise CampPlusAssetError("manifest_invalid")
+                with temporary.open("wb") as output:
+                    shutil.copyfileobj(response, output, length=1024 * 1024)
+            _verify_transfer(
+                temporary,
+                expected_size=expected_size,
+                expected_sha256=expected_sha256,
+            )
+            os.replace(temporary, destination)
+            return
+        except CampPlusAssetError:
+            temporary.unlink(missing_ok=True)
+            raise
+        except (OSError, TimeoutError, URLError) as exc:
+            last_error = exc
+            temporary.unlink(missing_ok=True)
+            if attempt < 2:
+                time.sleep(1 << attempt)
+    raise CampPlusAssetError("asset_missing") from last_error
+
+
+def _copy_verified(
+    source: Path,
+    destination: Path,
+    *,
+    expected_size: int,
+    expected_sha256: str,
+) -> None:
+    temporary = destination.with_suffix(destination.suffix + ".part")
+    try:
+        shutil.copyfile(source, temporary)
+        _verify_transfer(
+            temporary,
+            expected_size=expected_size,
+            expected_sha256=expected_sha256,
+        )
+        os.replace(temporary, destination)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def prepare_speaker_model(
+    directory: Path,
+    *,
+    offline: bool = False,
+    source_cache: Path | None = None,
+) -> Path:
+    """Prepare one pinned asset; release callers use ``offline`` to hard-fail."""
+
+    manifest = load_campplus_manifest(directory)
+    directory.mkdir(parents=True, exist_ok=True)
+    try:
+        return verify_campplus_asset(directory, manifest)
+    except CampPlusAssetError:
+        if offline:
+            raise
+
+    destination = directory / manifest.filename
+    cached = source_cache / manifest.filename if source_cache is not None else None
+    if cached is not None and cached.is_file():
+        _copy_verified(
+            cached,
+            destination,
+            expected_size=manifest.size_bytes,
+            expected_sha256=manifest.sha256,
+        )
+    else:
+        _download_verified(
+            manifest.source,
+            destination,
+            expected_size=manifest.size_bytes,
+            expected_sha256=manifest.sha256,
+        )
+    return verify_campplus_asset(directory, manifest)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--asset-dir",
+        type=Path,
+        default=DEFAULT_ASSET_DIR,
+        help="directory containing manifest.json and the prepared CAM++ model",
+    )
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="verify the existing model without making network requests",
+    )
+    parser.add_argument(
+        "--source-cache",
+        type=Path,
+        help="optional directory containing the manifest filename; still fully verified",
+    )
+    args = parser.parse_args(argv)
+    try:
+        path = prepare_speaker_model(
+            args.asset_dir.resolve(),
+            offline=args.offline,
+            source_cache=args.source_cache.resolve() if args.source_cache else None,
+        )
+    except CampPlusAssetError as exc:
+        parser.error(str(exc))
+    print(f"verified {path.name}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/specs/launcher.spec
+++ b/specs/launcher.spec
@@ -71,6 +71,15 @@ voice_turn_assets_present = os.path.isdir(
         'models',
     )
 )
+speaker_shadow_assets_present = os.path.isdir(
+    os.path.join(
+        PROJECT_ROOT,
+        'main_logic',
+        'asr_client',
+        'speaker_shadow',
+        'models',
+    )
+)
 
 # galgame OCR deps: bundling is the ONLY path post-refactor (in-app install
 # routes were removed). Two distinct failure modes get distinct diagnostics:
@@ -108,6 +117,7 @@ for pkg in critical_packages:
         if pkg in embedding_runtime_packages and (
             embedding_assets_present
             or (pkg == 'onnxruntime' and voice_turn_assets_present)
+            or (pkg == 'onnxruntime' and speaker_shadow_assets_present)
         ):
             raise RuntimeError(
                 f"Cannot collect {pkg!r}, but packaged model assets require it. "
@@ -186,6 +196,10 @@ add_data('data/embedding_models', 'data/embedding_models')
 add_data(
     'main_logic/asr_client/endpointing/models',
     'main_logic/asr_client/endpointing/models',
+)
+add_data(
+    'main_logic/asr_client/speaker_shadow/models',
+    'main_logic/asr_client/speaker_shadow/models',
 )
 add_data('steam_appid.txt', '.')
 

--- a/specs/launcher.spec
+++ b/specs/launcher.spec
@@ -123,7 +123,7 @@ for pkg in critical_packages:
                 f"Cannot collect {pkg!r}, but packaged model assets require it. "
                 "Install with "
                 "`uv sync` or remove the embedding "
-                "or voice-turn assets directory before building."
+                "voice-turn, or speaker-shadow assets directory before building."
             ) from e
         if pkg in galgame_group_packages:
             raise RuntimeError(

--- a/tests/unit/asr_client/speaker_shadow/test_campplus.py
+++ b/tests/unit/asr_client/speaker_shadow/test_campplus.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import pickle
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+import main_logic.asr_client.speaker_shadow.campplus as campplus
+from main_logic.asr_client.speaker_shadow.campplus import (
+    CampPlusBackendFactory,
+    CampPlusEmbeddingModel,
+    CampPlusSpeakerShadowBackend,
+    compute_campplus_features,
+)
+
+
+def _pcm16(duration_seconds: float = 1.5, frequency_hz: float = 220.0) -> bytes:
+    sample_count = round(16_000 * duration_seconds)
+    time = np.arange(sample_count, dtype=np.float64) / 16_000
+    samples = (
+        0.19 * np.sin(2 * np.pi * frequency_hz * time)
+        + 0.07 * np.sin(2 * np.pi * 733 * time)
+        + 0.01 * np.sin(2 * np.pi * 37 * time)
+    )
+    return np.clip(np.rint(samples * 32767), -32768, 32767).astype("<i2").tobytes()
+
+
+class _FakeSession:
+    def __init__(
+        self,
+        output: np.ndarray,
+        *,
+        input_name: str = "x",
+        input_type: str = "tensor(float)",
+        input_shape: list[object] | None = None,
+        output_name: str = "embedding",
+        output_type: str = "tensor(float)",
+        output_shape: list[object] | None = None,
+    ) -> None:
+        self.output = np.asarray(output, dtype=np.float32)
+        self.input = SimpleNamespace(
+            name=input_name,
+            type=input_type,
+            shape=input_shape or ["N", "T", 80],
+        )
+        self.output_info = SimpleNamespace(
+            name=output_name,
+            type=output_type,
+            shape=output_shape or ["N", 192],
+        )
+        self.last_inputs: dict[str, np.ndarray] | None = None
+
+    def get_inputs(self):
+        return [self.input]
+
+    def get_outputs(self):
+        return [self.output_info]
+
+    def get_modelmeta(self):
+        return SimpleNamespace(
+            custom_metadata_map={
+                "framework": "3d-speaker",
+                "language": "Chinese-English",
+                "url": (
+                    "https://www.modelscope.cn/models/iic/"
+                    "speech_campplus_sv_zh_en_16k-common_advanced/summary"
+                ),
+                "comment": (
+                    "iic/speech_campplus_sv_zh_en_16k-common_advanced"
+                ),
+                "feature_normalize_type": "global-mean",
+                "sample_rate": "16000",
+                "output_dim": "192",
+                "normalize_samples": "1",
+            }
+        )
+
+    def run(self, output_names, inputs):
+        assert output_names == ["embedding"]
+        self.last_inputs = inputs
+        return [self.output]
+
+
+def _install_fake_onnxruntime(
+    monkeypatch,
+    session: _FakeSession,
+    sessions: list[_FakeSession],
+) -> None:
+    class _SessionOptions:
+        pass
+
+    def create_session(*_args, **_kwargs):
+        sessions.append(session)
+        return session
+
+    fake = SimpleNamespace(
+        SessionOptions=_SessionOptions,
+        ExecutionMode=SimpleNamespace(ORT_SEQUENTIAL="sequential"),
+        GraphOptimizationLevel=SimpleNamespace(ORT_ENABLE_ALL="all"),
+        InferenceSession=create_session,
+        get_available_providers=lambda: ["CPUExecutionProvider"],
+    )
+    monkeypatch.setitem(sys.modules, "onnxruntime", fake)
+
+
+def _install_verified_model_path(monkeypatch, tmp_path: Path) -> Path:
+    model_path = tmp_path / "campplus-zh-en-advanced.onnx"
+    model_path.write_bytes(b"verified by asset layer")
+    monkeypatch.setattr(
+        campplus,
+        "resolve_verified_campplus_asset",
+        lambda _asset_dir=None: model_path,
+    )
+    return model_path
+
+
+def test_embedding_model_constructor_is_zero_io_and_onnxruntime_is_lazy(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    calls: list[object] = []
+
+    def fail_resolve(asset_dir=None):
+        calls.append(asset_dir)
+        raise AssertionError("constructor must not resolve assets")
+
+    monkeypatch.setattr(campplus, "resolve_verified_campplus_asset", fail_resolve)
+    monkeypatch.delitem(sys.modules, "onnxruntime", raising=False)
+
+    model = CampPlusEmbeddingModel(asset_dir=tmp_path)
+
+    assert calls == []
+    assert "onnxruntime" not in sys.modules
+    model.close()
+
+
+@pytest.mark.parametrize(
+    ("session_kwargs", "message"),
+    [
+        ({"input_name": "features"}, "input name"),
+        ({"input_type": "tensor(double)"}, "input type"),
+        ({"input_shape": ["N", "T", 64]}, "input shape"),
+        ({"output_name": "speaker"}, "output name"),
+        ({"output_type": "tensor(double)"}, "output type"),
+        ({"output_shape": ["N", 256]}, "output shape"),
+    ],
+)
+def test_load_rejects_wrong_onnx_tensor_contract(
+    tmp_path,
+    monkeypatch,
+    session_kwargs,
+    message,
+) -> None:
+    _install_verified_model_path(monkeypatch, tmp_path)
+    session = _FakeSession(np.ones((1, 192), dtype=np.float32), **session_kwargs)
+    _install_fake_onnxruntime(monkeypatch, session, [])
+    model = CampPlusEmbeddingModel(asset_dir=tmp_path)
+
+    assert model.load() is False
+    assert message.startswith(("input", "output"))
+    model.close()
+
+
+def test_frontend_matches_official_kaldi_native_fbank() -> None:
+    knf = pytest.importorskip("kaldi_native_fbank")
+    pcm16 = _pcm16(1.5)
+    samples = np.frombuffer(pcm16, dtype="<i2").astype(np.float32) / 32768.0
+    options = knf.FbankOptions()
+    options.frame_opts.dither = 0
+    options.frame_opts.samp_freq = 16_000
+    options.frame_opts.snip_edges = True
+    options.mel_opts.num_bins = 80
+    options.mel_opts.debug_mel = False
+    fbank = knf.OnlineFbank(options)
+    fbank.accept_waveform(16_000, samples)
+    fbank.input_finished()
+    expected = np.stack(
+        [fbank.get_frame(index) for index in range(fbank.num_frames_ready)],
+        axis=0,
+    ).astype(np.float32)
+    expected -= expected.mean(axis=0, keepdims=True)
+
+    actual = compute_campplus_features(pcm16, sample_rate_hz=16_000)
+
+    assert actual.shape == expected.shape == (148, 80)
+    assert actual.dtype == np.float32
+    assert np.max(np.abs(actual - expected)) <= 1e-3
+    assert np.mean(np.abs(actual - expected)) <= 1e-4
+
+
+def test_embedding_is_finite_l2_normalized_and_uses_expected_tensor(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    _install_verified_model_path(monkeypatch, tmp_path)
+    raw = np.arange(1, 193, dtype=np.float32)[None, :]
+    session = _FakeSession(raw)
+    sessions: list[_FakeSession] = []
+    _install_fake_onnxruntime(monkeypatch, session, sessions)
+    model = CampPlusEmbeddingModel(asset_dir=tmp_path)
+
+    assert model.load() is True
+    embedding = model.embedding_from_pcm16(_pcm16(), sample_rate_hz=16_000)
+
+    assert len(sessions) == 1
+    assert embedding.shape == (192,)
+    assert embedding.dtype == np.float32
+    assert np.isfinite(embedding).all()
+    assert np.linalg.norm(embedding) == pytest.approx(1.0, abs=1e-6)
+    assert session.last_inputs is not None
+    assert session.last_inputs["x"].shape == (1, 148, 80)
+    model.close()
+
+
+@pytest.mark.parametrize("case", ["empty", "odd", "wrong-rate", "too-short"])
+def test_embedding_rejects_invalid_pcm_boundaries(
+    tmp_path,
+    monkeypatch,
+    case,
+) -> None:
+    _install_verified_model_path(monkeypatch, tmp_path)
+    session = _FakeSession(np.ones((1, 192), dtype=np.float32))
+    _install_fake_onnxruntime(monkeypatch, session, [])
+    model = CampPlusEmbeddingModel(asset_dir=tmp_path)
+    assert model.load()
+    pcm16, sample_rate_hz, message = {
+        "empty": (b"", 16_000, "pcm_invalid"),
+        "odd": (b"\x00", 16_000, "pcm_invalid"),
+        "wrong-rate": (_pcm16(), 48_000, "sample_rate_mismatch"),
+        "too-short": (_pcm16(1.499), 16_000, "pcm_too_short"),
+    }[case]
+
+    with pytest.raises(ValueError, match=message):
+        model.embedding_from_pcm16(pcm16, sample_rate_hz=sample_rate_hz)
+    model.close()
+
+
+def test_load_and_close_are_idempotent(tmp_path, monkeypatch) -> None:
+    _install_verified_model_path(monkeypatch, tmp_path)
+    session = _FakeSession(np.ones((1, 192), dtype=np.float32))
+    sessions: list[_FakeSession] = []
+    _install_fake_onnxruntime(monkeypatch, session, sessions)
+    model = CampPlusEmbeddingModel(asset_dir=tmp_path)
+
+    assert model.load()
+    assert model.load()
+    assert len(sessions) == 1
+    model.close()
+    model.close()
+    assert model.load() is False
+
+
+class _BackendModel:
+    def __init__(self, embeddings: dict[bytes, np.ndarray]) -> None:
+        self.embeddings = embeddings
+        self.load_calls = 0
+        self.close_calls = 0
+
+    def load(self) -> bool:
+        self.load_calls += 1
+        return True
+
+    def embedding_from_pcm16(self, pcm16: bytes, *, sample_rate_hz: int) -> np.ndarray:
+        assert sample_rate_hz == 16_000
+        return np.array(self.embeddings[pcm16], dtype=np.float32, copy=True)
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+def test_backend_scores_cosine_copies_reference_and_wipes_on_close() -> None:
+    basis = np.eye(192, dtype=np.float32)
+    source = basis[0].copy()
+    model = _BackendModel({b"same": basis[0], b"other": basis[1]})
+    backend = CampPlusSpeakerShadowBackend(source, model_factory=lambda: model)
+    private_reference = backend._reference._storage
+    source.fill(0)
+
+    assert backend.load()
+    assert backend.load()
+    assert backend.score(b"same", 16_000) == pytest.approx(1.0, abs=1e-6)
+    assert backend.score(b"other", 16_000) == pytest.approx(0.0, abs=1e-6)
+    backend.close()
+    backend.close()
+
+    assert model.load_calls == 1
+    assert model.close_calls == 1
+    assert not any(private_reference)
+    with pytest.raises(RuntimeError, match="backend_closed"):
+        backend.score(b"same", 16_000)
+
+
+def test_backend_factory_is_zero_io_spawn_pickleable_and_wipes_parent_copy(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    resolve_calls: list[object] = []
+
+    def fail_resolve(asset_dir=None):
+        resolve_calls.append(asset_dir)
+        raise AssertionError("parent factory must not resolve assets")
+
+    monkeypatch.setattr(campplus, "resolve_verified_campplus_asset", fail_resolve)
+    source = np.arange(1, 193, dtype=np.float32)
+    factory = CampPlusBackendFactory(source, asset_dir=tmp_path)
+    private_reference = factory._reference._storage
+    source.fill(0)
+
+    payload = pickle.dumps(factory)
+    restored = pickle.loads(payload)
+
+    assert resolve_calls == []
+    assert any(private_reference)
+    assert "embedding" not in repr(factory).lower()
+    restored.close()
+    factory.close()
+    factory.close()
+    assert not any(private_reference)
+    with pytest.raises(RuntimeError, match="backend_factory_closed"):
+        factory()
+
+
+def test_backend_does_not_log_pcm_embedding_similarity_or_identity(caplog) -> None:
+    pcm16 = b"\x42\x13" * 24_000
+    basis = np.eye(192, dtype=np.float32)
+    model = _BackendModel({pcm16: basis[1]})
+    backend = CampPlusSpeakerShadowBackend(
+        basis[0],
+        model_factory=lambda: model,
+    )
+
+    assert backend.load()
+    assert backend.score(pcm16, 16_000) == pytest.approx(0.0, abs=1e-6)
+    backend.close()
+
+    logged = caplog.text.lower()
+    assert "4213" not in logged
+    assert "embedding" not in logged
+    assert "similarity" not in logged
+    assert "candidate" not in logged

--- a/tests/unit/asr_client/speaker_shadow/test_campplus.py
+++ b/tests/unit/asr_client/speaker_shadow/test_campplus.py
@@ -138,29 +138,30 @@ def test_embedding_model_constructor_is_zero_io_and_onnxruntime_is_lazy(
 
 
 @pytest.mark.parametrize(
-    ("session_kwargs", "message"),
+    ("session_kwargs", "expected_token"),
     [
-        ({"input_name": "features"}, "input name"),
-        ({"input_type": "tensor(double)"}, "input type"),
-        ({"input_shape": ["N", "T", 64]}, "input shape"),
-        ({"output_name": "speaker"}, "output name"),
-        ({"output_type": "tensor(double)"}, "output type"),
-        ({"output_shape": ["N", 256]}, "output shape"),
+        ({"input_name": "features"}, "onnx_input_name"),
+        ({"input_type": "tensor(double)"}, "onnx_input_type"),
+        ({"input_shape": ["N", "T", 64]}, "onnx_input_shape"),
+        ({"output_name": "speaker"}, "onnx_output_name"),
+        ({"output_type": "tensor(double)"}, "onnx_output_type"),
+        ({"output_shape": ["N", 256]}, "onnx_output_shape"),
     ],
 )
 def test_load_rejects_wrong_onnx_tensor_contract(
     tmp_path,
     monkeypatch,
     session_kwargs,
-    message,
+    expected_token,
 ) -> None:
     _install_verified_model_path(monkeypatch, tmp_path)
     session = _FakeSession(np.ones((1, 192), dtype=np.float32), **session_kwargs)
     _install_fake_onnxruntime(monkeypatch, session, [])
     model = CampPlusEmbeddingModel(asset_dir=tmp_path)
 
+    with pytest.raises(ValueError, match=expected_token):
+        model._validate_session_contract(session)
     assert model.load() is False
-    assert message.startswith(("input", "output"))
     model.close()
 
 

--- a/tests/unit/asr_client/speaker_shadow/test_campplus_asset_manifest.py
+++ b/tests/unit/asr_client/speaker_shadow/test_campplus_asset_manifest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import socket
 import sys
 from pathlib import Path
 
@@ -108,6 +109,13 @@ def test_manifest_rejects_malformed_security_fields(
         load_campplus_manifest(tmp_path)
 
 
+def test_manifest_rejects_non_utf8_as_unreadable(tmp_path) -> None:
+    (tmp_path / "manifest.json").write_bytes(b"\xff\xfe\x00")
+
+    with pytest.raises(CampPlusAssetError, match="manifest_unreadable"):
+        load_campplus_manifest(tmp_path)
+
+
 def test_asset_verification_rejects_missing_empty_wrong_size_and_wrong_sha(
     tmp_path,
     monkeypatch,
@@ -196,7 +204,8 @@ def test_runtime_resolution_never_opens_network(monkeypatch, tmp_path) -> None:
     def fail_network(*_args, **_kwargs):
         raise AssertionError("runtime CAM++ resolution must remain offline")
 
-    monkeypatch.setattr("urllib.request.urlopen", fail_network)
+    monkeypatch.setattr(socket.socket, "connect", fail_network)
+    monkeypatch.setattr(socket, "create_connection", fail_network)
 
     with pytest.raises(CampPlusAssetError):
         resolve_verified_campplus_asset(tmp_path)

--- a/tests/unit/asr_client/speaker_shadow/test_campplus_asset_manifest.py
+++ b/tests/unit/asr_client/speaker_shadow/test_campplus_asset_manifest.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+import main_logic.asr_client.speaker_shadow.asset_manifest as asset_manifest
+from main_logic.asr_client.speaker_shadow.asset_manifest import (
+    CampPlusAssetError,
+    candidate_campplus_asset_directories,
+    load_campplus_manifest,
+    resolve_verified_campplus_asset,
+    verify_campplus_asset,
+)
+
+
+ROOT = Path(__file__).resolve().parents[4]
+MODELS = ROOT / "main_logic" / "asr_client" / "speaker_shadow" / "models"
+ASSET_RELATIVE_PATH = (
+    Path("main_logic") / "asr_client" / "speaker_shadow" / "models"
+)
+MODEL_FILENAME = "campplus-zh-en-advanced.onnx"
+MODEL_SHA256 = "aa3cfc16963a10586a9393f5035d6d6b57e98d358b347f80c2a30bf4f00ceba2"
+
+
+def _manifest_payload(*, payload: bytes) -> dict[str, object]:
+    return {
+        "filename": MODEL_FILENAME,
+        "model_id": "iic/speech_campplus_sv_zh_en_16k-common_advanced",
+        "revision": "v1.0.0",
+        "license": "Apache-2.0",
+        "source": (
+            "https://github.com/k2-fsa/sherpa-onnx/releases/download/"
+            "speaker-recongition-models/"
+            "3dspeaker_speech_campplus_sv_zh_en_16k-common_advanced.onnx"
+        ),
+        "export_source": "k2-fsa/sherpa-onnx",
+        "size_bytes": len(payload),
+        "sha256": hashlib.sha256(payload).hexdigest(),
+        "sample_rate_hz": 16_000,
+        "preprocessing": "kaldi-native-fbank-sniped-global-mean-v1",
+        "input_contract": "float32[batch,time,80]",
+        "output_contract": "float32[batch,192]",
+    }
+
+
+def _write_asset_dir(directory: Path, payload: bytes = b"reviewed model") -> Path:
+    directory.mkdir(parents=True)
+    (directory / MODEL_FILENAME).write_bytes(payload)
+    (directory / "manifest.json").write_text(
+        json.dumps(_manifest_payload(payload=payload)),
+        encoding="utf-8",
+    )
+    return directory
+
+
+def _patch_expected_manifest(monkeypatch, payload: bytes) -> None:
+    monkeypatch.setattr(
+        asset_manifest,
+        "_EXPECTED_MANIFEST",
+        asset_manifest.CampPlusManifest(**_manifest_payload(payload=payload)),
+    )
+
+
+def test_repository_manifest_pins_reviewed_model_identity() -> None:
+    manifest = load_campplus_manifest(MODELS)
+
+    assert manifest.filename == MODEL_FILENAME
+    assert manifest.model_id == "iic/speech_campplus_sv_zh_en_16k-common_advanced"
+    assert manifest.revision == "v1.0.0"
+    assert manifest.license == "Apache-2.0"
+    assert manifest.source.startswith("https://")
+    assert manifest.export_source == "k2-fsa/sherpa-onnx"
+    assert manifest.size_bytes == 28_281_164
+    assert manifest.sha256 == MODEL_SHA256
+    assert manifest.sample_rate_hz == 16_000
+    assert manifest.preprocessing == "kaldi-native-fbank-sniped-global-mean-v1"
+    assert manifest.input_contract == "float32[batch,time,80]"
+    assert manifest.output_contract == "float32[batch,192]"
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda value: value.pop("revision"), "manifest_invalid"),
+        (lambda value: value.__setitem__("filename", "../model.onnx"), "manifest_invalid"),
+        (lambda value: value.__setitem__("size_bytes", 0), "manifest_invalid"),
+        (lambda value: value.__setitem__("sha256", "not-a-digest"), "manifest_invalid"),
+        (
+            lambda value: value.__setitem__("sample_rate_hz", 48_000),
+            "manifest_identity_mismatch",
+        ),
+    ],
+)
+def test_manifest_rejects_malformed_security_fields(
+    tmp_path,
+    mutation,
+    message,
+) -> None:
+    payload = _manifest_payload(payload=b"model")
+    mutation(payload)
+    (tmp_path / "manifest.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(CampPlusAssetError, match=message):
+        load_campplus_manifest(tmp_path)
+
+
+def test_asset_verification_rejects_missing_empty_wrong_size_and_wrong_sha(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    payload = b"reviewed model"
+    _patch_expected_manifest(monkeypatch, payload)
+    directory = _write_asset_dir(tmp_path / "speaker", payload)
+    model_path = directory / MODEL_FILENAME
+
+    assert verify_campplus_asset(directory) == model_path
+
+    model_path.unlink()
+    with pytest.raises(CampPlusAssetError, match="asset_missing"):
+        verify_campplus_asset(directory)
+
+    model_path.write_bytes(b"")
+    with pytest.raises(CampPlusAssetError, match="asset_size_mismatch"):
+        verify_campplus_asset(directory)
+
+    model_path.write_bytes(b"short")
+    with pytest.raises(CampPlusAssetError, match="asset_size_mismatch"):
+        verify_campplus_asset(directory)
+
+    corrupt = b"reviewed modeX"
+    assert len(corrupt) == len(b"reviewed model")
+    model_path.write_bytes(corrupt)
+    with pytest.raises(CampPlusAssetError, match="asset_sha256_mismatch"):
+        verify_campplus_asset(directory)
+
+
+def test_explicit_override_is_the_only_candidate(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path / "bundle"), raising=False)
+    monkeypatch.setattr(sys, "executable", str(tmp_path / "runtime" / "Xiao8.exe"))
+
+    override = tmp_path / "explicit"
+
+    assert candidate_campplus_asset_directories(override) == (override.resolve(),)
+
+
+def test_default_candidate_order_is_bundle_executable_then_package(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    bundle = tmp_path / "bundle"
+    runtime = tmp_path / "runtime"
+    monkeypatch.setattr(sys, "_MEIPASS", str(bundle), raising=False)
+    monkeypatch.setattr(sys, "executable", str(runtime / "Xiao8.exe"))
+
+    candidates = candidate_campplus_asset_directories()
+
+    assert candidates == (
+        (bundle / ASSET_RELATIVE_PATH).resolve(),
+        (runtime / ASSET_RELATIVE_PATH).resolve(),
+        MODELS.resolve(),
+    )
+
+
+def test_candidate_directories_are_deduplicated(monkeypatch) -> None:
+    package_root = MODELS.parents[3]
+    monkeypatch.setattr(sys, "_MEIPASS", str(package_root), raising=False)
+    monkeypatch.setattr(
+        sys,
+        "executable",
+        str(package_root / "Xiao8.exe"),
+    )
+
+    candidates = candidate_campplus_asset_directories()
+
+    assert candidates.count(MODELS.resolve()) == 1
+
+
+def test_invalid_explicit_override_never_falls_back(monkeypatch, tmp_path) -> None:
+    invalid = tmp_path / "invalid"
+    valid = _write_asset_dir(tmp_path / "valid")
+    monkeypatch.setattr(
+        asset_manifest,
+        "candidate_campplus_asset_directories",
+        lambda override=None: (override.resolve(),) if override is not None else (valid,),
+    )
+
+    with pytest.raises(CampPlusAssetError):
+        resolve_verified_campplus_asset(invalid)
+
+
+def test_runtime_resolution_never_opens_network(monkeypatch, tmp_path) -> None:
+    def fail_network(*_args, **_kwargs):
+        raise AssertionError("runtime CAM++ resolution must remain offline")
+
+    monkeypatch.setattr("urllib.request.urlopen", fail_network)
+
+    with pytest.raises(CampPlusAssetError):
+        resolve_verified_campplus_asset(tmp_path)

--- a/tests/unit/asr_client/speaker_shadow/test_campplus_distribution_contracts.py
+++ b/tests/unit/asr_client/speaker_shadow/test_campplus_distribution_contracts.py
@@ -19,6 +19,14 @@ def test_hatch_artifacts_exclude_downloaded_campplus_weights() -> None:
         assert f"{MODEL_DIRECTORY}/*.part" in excludes
 
 
+def test_unit_ci_installs_pinned_frontend_parity_oracle() -> None:
+    workflow = (ROOT / ".github/workflows/unit-tests.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "uv pip install kaldi-native-fbank==1.22.3" in workflow
+
+
 def test_pyinstaller_bundles_campplus_and_requires_onnxruntime() -> None:
     spec = (ROOT / "specs" / "launcher.spec").read_text(encoding="utf-8")
 

--- a/tests/unit/asr_client/speaker_shadow/test_campplus_distribution_contracts.py
+++ b/tests/unit/asr_client/speaker_shadow/test_campplus_distribution_contracts.py
@@ -4,6 +4,8 @@ import re
 import tomllib
 from pathlib import Path
 
+import yaml
+
 
 ROOT = Path(__file__).resolve().parents[4]
 MODEL_DIRECTORY = "main_logic/asr_client/speaker_shadow/models"
@@ -20,11 +22,12 @@ def test_hatch_artifacts_exclude_downloaded_campplus_weights() -> None:
 
 
 def test_unit_ci_installs_pinned_frontend_parity_oracle() -> None:
-    workflow = (ROOT / ".github/workflows/unit-tests.yml").read_text(
-        encoding="utf-8"
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/unit-tests.yml").read_text(encoding="utf-8")
     )
+    runs = [step.get("run") for step in workflow["jobs"]["unit-pytest"]["steps"]]
 
-    assert "uv pip install kaldi-native-fbank==1.22.3" in workflow
+    assert "uv pip install kaldi-native-fbank==1.22.3" in runs
 
 
 def test_pyinstaller_bundles_campplus_and_requires_onnxruntime() -> None:

--- a/tests/unit/asr_client/speaker_shadow/test_campplus_distribution_contracts.py
+++ b/tests/unit/asr_client/speaker_shadow/test_campplus_distribution_contracts.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[4]
+MODEL_DIRECTORY = "main_logic/asr_client/speaker_shadow/models"
+MODEL_FILENAME = "campplus-zh-en-advanced.onnx"
+
+
+def test_hatch_artifacts_exclude_downloaded_campplus_weights() -> None:
+    config = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    targets = config["tool"]["hatch"]["build"]["targets"]
+    for target in ("wheel", "sdist"):
+        excludes = targets[target]["exclude"]
+        assert f"{MODEL_DIRECTORY}/*.onnx" in excludes
+        assert f"{MODEL_DIRECTORY}/*.part" in excludes
+
+
+def test_pyinstaller_bundles_campplus_and_requires_onnxruntime() -> None:
+    spec = (ROOT / "specs" / "launcher.spec").read_text(encoding="utf-8")
+
+    assert spec.count(f"'{MODEL_DIRECTORY}'") == 2
+    assert "speaker_shadow_assets_present" in spec
+    assert re.search(
+        r"pkg == ['\"]onnxruntime['\"] and speaker_shadow_assets_present",
+        spec,
+    )
+
+
+def test_nuitka_workflows_prepare_and_verify_one_campplus_weight() -> None:
+    desktop = (ROOT / ".github/workflows/build-desktop.yml").read_text(
+        encoding="utf-8"
+    )
+    linux = (ROOT / ".github/workflows/build-desktop-linux.yml").read_text(
+        encoding="utf-8"
+    )
+    include_option = f"--include-data-dir={MODEL_DIRECTORY}={MODEL_DIRECTORY}"
+
+    assert desktop.count(include_option) == 2
+    assert linux.count(include_option) == 1
+    for workflow in (desktop, linux):
+        assert "scripts/prepare_speaker_model.py" in workflow
+        assert f"hashFiles('{MODEL_DIRECTORY}/manifest.json')" in workflow
+        assert '--asset-dir "$speaker_shadow_assets" --offline' in workflow
+        assert "CAM++ weight must be packaged exactly once" in workflow
+        assert "obsolete data/speaker_models must not be packaged" in workflow
+        assert "THIRD_PARTY_NOTICES.md" in workflow
+
+
+def test_docker_builds_prepare_natively_then_verify_offline() -> None:
+    workflow = (ROOT / ".github/workflows/docker-multi-arch.yml").read_text(
+        encoding="utf-8"
+    )
+    assert workflow.count("run: python3 scripts/prepare_speaker_model.py") == 2
+    assert workflow.count(f"path: {MODEL_DIRECTORY}/*.onnx") == 2
+    assert workflow.count(f"hashFiles('{MODEL_DIRECTORY}/manifest.json')") == 2
+
+    for name in ("Dockerfile", "Dockerfile.full"):
+        dockerfile = (ROOT / "docker" / name).read_text(encoding="utf-8")
+        copy_index = dockerfile.index("COPY --chown=neko:neko . /app")
+        verify_index = dockerfile.index(
+            "python3 scripts/prepare_speaker_model.py --offline"
+        )
+        sync_index = dockerfile.index("uv sync --frozen", verify_index)
+        assert copy_index < verify_index < sync_index, name
+        assert f"/app/{MODEL_DIRECTORY}/THIRD_PARTY_NOTICES.md" in dockerfile
+        assert "test ! -e /app/data/speaker_models" in dockerfile
+        assert f"find /app -type f -name {MODEL_FILENAME}" in dockerfile
+
+
+def test_ignore_rules_keep_only_reviewable_campplus_metadata() -> None:
+    gitignore = (ROOT / ".gitignore").read_text(encoding="utf-8").splitlines()
+    assert f"/{MODEL_DIRECTORY}/*" in gitignore
+    assert f"!/{MODEL_DIRECTORY}/manifest.json" in gitignore
+    assert f"!/{MODEL_DIRECTORY}/THIRD_PARTY_NOTICES.md" in gitignore
+
+    dockerignore = (ROOT / ".dockerignore").read_text(encoding="utf-8")
+    patterns = {
+        line.strip().rstrip("/")
+        for line in dockerignore.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+    assert "/data/speaker_models" in patterns
+    assert not any(MODEL_DIRECTORY in pattern for pattern in patterns)
+
+
+def test_legacy_voice_identity_and_model_locations_are_absent() -> None:
+    assert not (ROOT / "main_logic" / "voice_identity").exists()
+    assert not (ROOT / "data" / "speaker_models").exists()
+    assert not (ROOT / "tools" / "voice_eval").exists()
+    assert not (ROOT / "main_logic" / "asr_client" / "campplus.py").exists()
+    assert not (ROOT / "main_logic" / "asr_client" / "speaker_shadow.py").exists()

--- a/tests/unit/asr_client/speaker_shadow/test_campplus_real_model.py
+++ b/tests/unit/asr_client/speaker_shadow/test_campplus_real_model.py
@@ -1,0 +1,151 @@
+"""Opt-in smoke checks against the pinned, locally prepared CAM++ asset."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from main_logic.asr_client.speaker_shadow.asset_manifest import (
+    CampPlusAssetError,
+    resolve_verified_campplus_asset,
+)
+from main_logic.asr_client.speaker_shadow.campplus import (
+    CampPlusBackendFactory,
+    CampPlusEmbeddingModel,
+    compute_campplus_features,
+)
+from main_logic.asr_client.speaker_shadow.contracts import (
+    SpeakerShadowCandidateKey,
+    SpeakerShadowConfig,
+)
+from main_logic.asr_client.speaker_shadow.runtime import SpeakerShadowRuntime
+
+
+_OVERRIDE = os.environ.get("NEKO_CAMPPLUS_ASSET_DIR")
+try:
+    _MODEL_PATH = resolve_verified_campplus_asset(
+        Path(_OVERRIDE) if _OVERRIDE else None
+    )
+except CampPlusAssetError:
+    if os.environ.get("NEKO_RELEASE_BUILD") == "1":
+        raise
+    _MODEL_PATH = None
+
+needs_model = pytest.mark.skipif(
+    _MODEL_PATH is None,
+    reason="run prepare_speaker_model.py or set NEKO_CAMPPLUS_ASSET_DIR",
+)
+
+
+def _fixed_pcm16() -> bytes:
+    samples = np.arange(24_000, dtype=np.float64)
+    waveform = (
+        0.18 * np.sin(2 * np.pi * 173 * samples / 16_000)
+        + 0.07 * np.sin(2 * np.pi * 641 * samples / 16_000)
+    )
+    return np.rint(waveform * 32767).astype("<i2").tobytes()
+
+
+@needs_model
+def test_real_campplus_outputs_deterministic_normalized_192_embedding() -> None:
+    model = CampPlusEmbeddingModel(asset_dir=Path(_MODEL_PATH).parent)
+    assert model.load()
+    try:
+        first = model.embedding_from_pcm16(_fixed_pcm16(), sample_rate_hz=16_000)
+        second = model.embedding_from_pcm16(_fixed_pcm16(), sample_rate_hz=16_000)
+    finally:
+        model.close()
+
+    assert first.shape == second.shape == (192,)
+    assert np.isfinite(first).all()
+    assert np.linalg.norm(first) == pytest.approx(1.0, abs=1e-6)
+    assert float(np.dot(first, second)) >= 0.99999
+    first.fill(0)
+    second.fill(0)
+
+
+@needs_model
+def test_real_embedding_matches_official_frontend() -> None:
+    knf = pytest.importorskip("kaldi_native_fbank")
+    import onnxruntime as ort
+
+    pcm16 = _fixed_pcm16()
+    samples = np.frombuffer(pcm16, dtype="<i2").astype(np.float32) / 32768.0
+    options = knf.FbankOptions()
+    options.frame_opts.dither = 0
+    options.frame_opts.samp_freq = 16_000
+    options.frame_opts.snip_edges = True
+    options.mel_opts.num_bins = 80
+    fbank = knf.OnlineFbank(options)
+    fbank.accept_waveform(16_000, samples)
+    fbank.input_finished()
+    official = np.stack(
+        [fbank.get_frame(index) for index in range(fbank.num_frames_ready)],
+        axis=0,
+    ).astype(np.float32)
+    official -= official.mean(axis=0, keepdims=True)
+    native = compute_campplus_features(pcm16, sample_rate_hz=16_000)
+    session = ort.InferenceSession(
+        str(_MODEL_PATH),
+        providers=["CPUExecutionProvider"],
+    )
+    official_embedding = session.run(
+        ["embedding"], {"x": official[np.newaxis, ...]}
+    )[0][0]
+    native_embedding = session.run(
+        ["embedding"], {"x": native[np.newaxis, ...]}
+    )[0][0]
+    official_embedding /= np.linalg.norm(official_embedding)
+    native_embedding /= np.linalg.norm(native_embedding)
+
+    assert official.shape == native.shape == (148, 80)
+    assert np.max(np.abs(official - native)) <= 1e-3
+    assert float(np.dot(official_embedding, native_embedding)) >= 0.99999
+    official.fill(0)
+    native.fill(0)
+    official_embedding.fill(0)
+    native_embedding.fill(0)
+
+
+@needs_model
+@pytest.mark.asyncio
+async def test_real_factory_scores_through_spawned_observation_only_runtime() -> None:
+    pcm16 = _fixed_pcm16()
+    model = CampPlusEmbeddingModel(asset_dir=Path(_MODEL_PATH).parent)
+    assert model.load()
+    try:
+        reference = model.embedding_from_pcm16(pcm16, sample_rate_hz=16_000)
+    finally:
+        model.close()
+    factory = CampPlusBackendFactory(reference, asset_dir=Path(_MODEL_PATH).parent)
+    reference.fill(0)
+    observations = []
+
+    async def observe(observation) -> None:
+        observations.append(observation)
+
+    runtime = SpeakerShadowRuntime(
+        backend_factory=factory,
+        config=SpeakerShadowConfig(enabled=True, idle_unload_seconds=10.0),
+        on_observation=observe,
+    )
+    candidate = SpeakerShadowCandidateKey(
+        detector_epoch=1,
+        shadow_generation=1,
+        scope="provider_candidate",
+    )
+    assert runtime.submit(pcm16, sample_rate_hz=16_000, candidate=candidate)
+    assert runtime.finish_candidate(candidate)
+    await runtime.wait_idle()
+    await runtime.close()
+
+    assert len(observations) == 1
+    assert observations[0].candidate == candidate
+    assert observations[0].similarity >= 0.99999
+    metrics = runtime.snapshot()
+    assert metrics["backend_process_count"] == 0
+    assert metrics["worker_task_count"] == 0
+    assert metrics["callback_task_count"] == 0

--- a/tests/unit/asr_client/speaker_shadow/test_campplus_tools.py
+++ b/tests/unit/asr_client/speaker_shadow/test_campplus_tools.py
@@ -19,6 +19,7 @@ from main_logic.asr_client.speaker_shadow.asset_manifest import CampPlusAssetErr
 
 ROOT = Path(__file__).resolve().parents[4]
 PREPARER = ROOT / "scripts" / "prepare_speaker_model.py"
+EVALUATOR = ROOT / "scripts" / "evaluate_campplus_shadow.py"
 MODEL_FILENAME = "campplus-zh-en-advanced.onnx"
 
 
@@ -319,3 +320,32 @@ def test_evaluation_rejects_non_mono_pcm16_16khz_wav(tmp_path) -> None:
 
     with pytest.raises(ValueError, match="mono PCM16LE at 16 kHz"):
         evaluator._read_pcm16(path)
+
+
+@pytest.mark.parametrize("payload", [None, b"not a WAV file"])
+def test_evaluation_redacts_unreadable_input_paths(tmp_path, payload) -> None:
+    private_path = tmp_path / "private-speaker-input.wav"
+    if payload is not None:
+        private_path.write_bytes(payload)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(EVALUATOR),
+            "--reference",
+            str(private_path),
+            str(private_path),
+            str(private_path),
+            "--candidate",
+            str(private_path),
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "wav_unreadable" in result.stderr
+    assert private_path.name not in result.stderr

--- a/tests/unit/asr_client/speaker_shadow/test_campplus_tools.py
+++ b/tests/unit/asr_client/speaker_shadow/test_campplus_tools.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import subprocess
+import sys
+import textwrap
+import wave
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import scripts.evaluate_campplus_shadow as evaluator
+import scripts.prepare_speaker_model as preparer
+from main_logic.asr_client.speaker_shadow.asset_manifest import CampPlusAssetError
+
+
+ROOT = Path(__file__).resolve().parents[4]
+PREPARER = ROOT / "scripts" / "prepare_speaker_model.py"
+MODEL_FILENAME = "campplus-zh-en-advanced.onnx"
+
+
+def _manifest(directory: Path, *, payload: bytes, source: str = "https://example.test/model") -> None:
+    manifest = {
+        "filename": MODEL_FILENAME,
+        "model_id": "iic/speech_campplus_sv_zh_en_16k-common_advanced",
+        "revision": "v1.0.0",
+        "license": "Apache-2.0",
+        "source": source,
+        "export_source": "k2-fsa/sherpa-onnx",
+        "size_bytes": len(payload),
+        "sha256": hashlib.sha256(payload).hexdigest(),
+        "sample_rate_hz": 16_000,
+        "preprocessing": "kaldi-native-fbank-sniped-global-mean-v1",
+        "input_contract": "float32[batch,time,80]",
+        "output_contract": "float32[batch,192]",
+    }
+    (directory / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+
+class _Response(io.BytesIO):
+    def geturl(self) -> str:
+        return "https://example.test/model"
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        self.close()
+
+
+def test_preparer_downloads_atomically_and_verifies_size_and_sha(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    payload = b"reviewed model"
+    _manifest(tmp_path, payload=payload)
+    monkeypatch.setattr(
+        preparer._asset_manifest,
+        "_EXPECTED_MANIFEST",
+        preparer._asset_manifest.CampPlusManifest(
+            **json.loads((tmp_path / "manifest.json").read_text(encoding="utf-8"))
+        ),
+    )
+    monkeypatch.setattr(
+        preparer.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: _Response(payload),
+    )
+
+    prepared = preparer.prepare_speaker_model(tmp_path)
+
+    assert prepared.read_bytes() == payload
+    assert not (tmp_path / f"{MODEL_FILENAME}.part").exists()
+
+
+def test_preparer_offline_and_source_cache_are_fail_closed(tmp_path, monkeypatch) -> None:
+    payload = b"reviewed model"
+    output = tmp_path / "output"
+    cache = tmp_path / "cache"
+    output.mkdir()
+    cache.mkdir()
+    _manifest(output, payload=payload)
+    monkeypatch.setattr(
+        preparer._asset_manifest,
+        "_EXPECTED_MANIFEST",
+        preparer._asset_manifest.CampPlusManifest(
+            **json.loads((output / "manifest.json").read_text(encoding="utf-8"))
+        ),
+    )
+
+    with pytest.raises(CampPlusAssetError):
+        preparer.prepare_speaker_model(output, offline=True)
+
+    (cache / MODEL_FILENAME).write_bytes(b"wrong model")
+    with pytest.raises(CampPlusAssetError, match="asset_size_mismatch"):
+        preparer.prepare_speaker_model(output, source_cache=cache)
+    assert not (output / MODEL_FILENAME).exists()
+    assert not (output / f"{MODEL_FILENAME}.part").exists()
+
+    (cache / MODEL_FILENAME).write_bytes(payload)
+    assert preparer.prepare_speaker_model(output, source_cache=cache).read_bytes() == payload
+    assert preparer.prepare_speaker_model(output, offline=True).read_bytes() == payload
+
+
+def test_preparer_rejects_non_https_download_source(tmp_path, monkeypatch) -> None:
+    payload = b"reviewed model"
+    _manifest(tmp_path, payload=payload, source="file:///local/model.onnx")
+    monkeypatch.setattr(
+        preparer._asset_manifest,
+        "_EXPECTED_MANIFEST",
+        preparer._asset_manifest.CampPlusManifest(
+            **json.loads((tmp_path / "manifest.json").read_text(encoding="utf-8"))
+        ),
+    )
+
+    with pytest.raises(CampPlusAssetError, match="manifest_invalid"):
+        preparer.prepare_speaker_model(tmp_path)
+
+    assert not (tmp_path / MODEL_FILENAME).exists()
+
+
+def test_preparer_removes_partial_file_after_bad_download(tmp_path, monkeypatch) -> None:
+    payload = b"reviewed model"
+    _manifest(tmp_path, payload=payload)
+    monkeypatch.setattr(
+        preparer._asset_manifest,
+        "_EXPECTED_MANIFEST",
+        preparer._asset_manifest.CampPlusManifest(
+            **json.loads((tmp_path / "manifest.json").read_text(encoding="utf-8"))
+        ),
+    )
+    monkeypatch.setattr(
+        preparer.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: _Response(b"corrupt model"),
+    )
+
+    with pytest.raises(CampPlusAssetError, match="size|SHA-256"):
+        preparer.prepare_speaker_model(tmp_path)
+
+    assert not (tmp_path / MODEL_FILENAME).exists()
+    assert not (tmp_path / f"{MODEL_FILENAME}.part").exists()
+
+
+def test_preparer_runs_on_bare_interpreter_without_numpy() -> None:
+    driver = textwrap.dedent(
+        """
+        import runpy
+        import sys
+
+        class _BlockNumpy:
+            def find_spec(self, name, path=None, target=None):
+                if name == "numpy" or name.startswith("numpy."):
+                    raise ModuleNotFoundError("numpy blocked")
+                return None
+
+        sys.meta_path.insert(0, _BlockNumpy())
+        script, asset_dir = sys.argv[1], sys.argv[2]
+        module = runpy.run_path(script, run_name="speaker_preparer_probe")
+        manifest = module["load_campplus_manifest"](__import__("pathlib").Path(asset_dir))
+        print(f"manifest {manifest.filename}")
+        """
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-S",
+            "-c",
+            driver,
+            str(PREPARER),
+            str(ROOT / "main_logic" / "asr_client" / "speaker_shadow" / "models"),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert f"manifest {MODEL_FILENAME}" in result.stdout
+    assert "ModuleNotFoundError" not in result.stderr
+
+
+def _wav(path: Path, samples: np.ndarray, *, channels: int = 1) -> None:
+    with wave.open(str(path), "wb") as wav_file:
+        wav_file.setnchannels(channels)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(16_000)
+        wav_file.writeframes(np.asarray(samples, dtype="<i2").tobytes())
+
+
+class _EvaluationModel:
+    embeddings: list[np.ndarray] = []
+    calls: list[int] = []
+    closed = 0
+
+    def __init__(self, *, asset_dir=None) -> None:
+        self.asset_dir = asset_dir
+
+    def load(self) -> bool:
+        return True
+
+    def embedding_from_pcm16(self, pcm16: bytes, *, sample_rate_hz: int) -> np.ndarray:
+        assert sample_rate_hz == 16_000
+        type(self).calls.append(len(pcm16))
+        embedding = np.zeros(192, dtype=np.float32)
+        embedding[len(type(self).embeddings) % 3] = 1.0
+        type(self).embeddings.append(embedding)
+        return embedding
+
+    def close(self) -> None:
+        type(self).closed += 1
+
+
+class _EvaluationBackend:
+    received_lengths: list[int] = []
+    private_references: list[np.ndarray] = []
+
+    def __init__(self, reference_embedding, **_kwargs) -> None:
+        reference = np.array(reference_embedding, dtype=np.float32, copy=True)
+        type(self).private_references.append(reference)
+        self.reference = reference
+
+    def load(self) -> bool:
+        return True
+
+    def score(self, pcm16: bytes, sample_rate_hz: int) -> float:
+        assert sample_rate_hz == 16_000
+        type(self).received_lengths.append(len(pcm16))
+        return 0.75
+
+    def close(self) -> None:
+        self.reference.fill(0)
+
+
+def test_evaluation_reports_only_ephemeral_indexed_scores(monkeypatch, tmp_path) -> None:
+    _EvaluationModel.embeddings = []
+    _EvaluationModel.calls = []
+    _EvaluationModel.closed = 0
+    _EvaluationBackend.received_lengths = []
+    _EvaluationBackend.private_references = []
+    monkeypatch.setattr(evaluator, "CampPlusEmbeddingModel", _EvaluationModel)
+    monkeypatch.setattr(evaluator, "CampPlusSpeakerShadowBackend", _EvaluationBackend)
+    samples = np.arange(16_000 * 5, dtype=np.int16)
+    references = [tmp_path / f"reference-{index}.wav" for index in range(3)]
+    candidate = tmp_path / "private-candidate.wav"
+    for path in [*references, candidate]:
+        _wav(path, samples)
+
+    report = evaluator.evaluate(
+        reference_paths=references,
+        candidate_paths=[candidate],
+        asset_dir=tmp_path / "models",
+    )
+
+    assert report == {
+        "schema_version": 1,
+        "reference_segment_count": 3,
+        "candidate_count": 1,
+        "observations": [
+            {
+                "candidate_index": 0,
+                "similarity": 0.75,
+                "would_block": {
+                    "0.40": False,
+                    "0.44": False,
+                    "0.48": False,
+                    "0.52": False,
+                    "0.55": False,
+                },
+            }
+        ],
+    }
+    serialized = json.dumps(report, sort_keys=True).lower()
+    assert "private-candidate" not in serialized
+    assert "reference-" not in serialized
+    assert "embedding" not in serialized
+    assert "pcm" not in serialized
+    assert _EvaluationModel.calls == [160_000, 160_000, 160_000]
+    assert _EvaluationBackend.received_lengths == [128_000]
+    assert all(np.count_nonzero(value) == 0 for value in _EvaluationModel.embeddings)
+    assert all(
+        np.count_nonzero(value) == 0
+        for value in _EvaluationBackend.private_references
+    )
+    assert _EvaluationModel.closed == 1
+
+
+@pytest.mark.parametrize("count", [0, 1, 2, 6])
+def test_evaluation_requires_three_to_five_reference_segments(count: int) -> None:
+    with pytest.raises(ValueError, match="3 to 5"):
+        evaluator.evaluate(
+            reference_paths=[Path(f"reference-{index}.wav") for index in range(count)],
+            candidate_paths=[Path("candidate.wav")],
+            asset_dir=None,
+        )
+
+
+def test_evaluation_rejects_non_mono_pcm16_16khz_wav(tmp_path) -> None:
+    path = tmp_path / "stereo.wav"
+    _wav(path, np.zeros(48_000, dtype=np.int16), channels=2)
+
+    with pytest.raises(ValueError, match="mono PCM16LE at 16 kHz"):
+        evaluator._read_pcm16(path)

--- a/tests/unit/asr_client/speaker_shadow/test_campplus_tools.py
+++ b/tests/unit/asr_client/speaker_shadow/test_campplus_tools.py
@@ -15,6 +15,7 @@ import pytest
 import scripts.evaluate_campplus_shadow as evaluator
 import scripts.prepare_speaker_model as preparer
 from main_logic.asr_client.speaker_shadow.asset_manifest import CampPlusAssetError
+from tests.fake_clock import patch_module_clock
 
 
 ROOT = Path(__file__).resolve().parents[4]
@@ -74,6 +75,34 @@ def test_preparer_downloads_atomically_and_verifies_size_and_sha(
     prepared = preparer.prepare_speaker_model(tmp_path)
 
     assert prepared.read_bytes() == payload
+    assert not (tmp_path / f"{MODEL_FILENAME}.part").exists()
+
+
+def test_preparer_retries_truncated_download(tmp_path, monkeypatch) -> None:
+    payload = b"reviewed model"
+    _manifest(tmp_path, payload=payload)
+    monkeypatch.setattr(
+        preparer._asset_manifest,
+        "_EXPECTED_MANIFEST",
+        preparer._asset_manifest.CampPlusManifest(
+            **json.loads((tmp_path / "manifest.json").read_text(encoding="utf-8"))
+        ),
+    )
+    responses = iter((b"truncated", payload))
+    attempts: list[bytes] = []
+
+    def urlopen(*_args, **_kwargs):
+        downloaded = next(responses)
+        attempts.append(downloaded)
+        return _Response(downloaded)
+
+    monkeypatch.setattr(preparer.urllib.request, "urlopen", urlopen)
+    patch_module_clock(monkeypatch, preparer, sleep=lambda _seconds: None)
+
+    prepared = preparer.prepare_speaker_model(tmp_path)
+
+    assert prepared.read_bytes() == payload
+    assert attempts == [b"truncated", payload]
     assert not (tmp_path / f"{MODEL_FILENAME}.part").exists()
 
 
@@ -150,6 +179,7 @@ def test_preparer_removes_partial_file_after_bad_download(
         "urlopen",
         lambda *_args, **_kwargs: _Response(downloaded),
     )
+    patch_module_clock(monkeypatch, preparer, sleep=lambda _seconds: None)
 
     with pytest.raises(CampPlusAssetError, match=expected_reason):
         preparer.prepare_speaker_model(tmp_path)

--- a/tests/unit/asr_client/speaker_shadow/test_campplus_tools.py
+++ b/tests/unit/asr_client/speaker_shadow/test_campplus_tools.py
@@ -122,7 +122,19 @@ def test_preparer_rejects_non_https_download_source(tmp_path, monkeypatch) -> No
     assert not (tmp_path / MODEL_FILENAME).exists()
 
 
-def test_preparer_removes_partial_file_after_bad_download(tmp_path, monkeypatch) -> None:
+@pytest.mark.parametrize(
+    ("downloaded", "expected_reason"),
+    [
+        (b"corrupt model", "asset_size_mismatch"),
+        (b"reviewed modeX", "asset_sha256_mismatch"),
+    ],
+)
+def test_preparer_removes_partial_file_after_bad_download(
+    tmp_path,
+    monkeypatch,
+    downloaded: bytes,
+    expected_reason: str,
+) -> None:
     payload = b"reviewed model"
     _manifest(tmp_path, payload=payload)
     monkeypatch.setattr(
@@ -135,10 +147,10 @@ def test_preparer_removes_partial_file_after_bad_download(tmp_path, monkeypatch)
     monkeypatch.setattr(
         preparer.urllib.request,
         "urlopen",
-        lambda *_args, **_kwargs: _Response(b"corrupt model"),
+        lambda *_args, **_kwargs: _Response(downloaded),
     )
 
-    with pytest.raises(CampPlusAssetError, match="size|SHA-256"):
+    with pytest.raises(CampPlusAssetError, match=expected_reason):
         preparer.prepare_speaker_model(tmp_path)
 
     assert not (tmp_path / MODEL_FILENAME).exists()


### PR DESCRIPTION
## 背景

#2450 原分支仍建立在旧的 Speaker Shadow head 上，并同时携带了已被主线独立 ASR / Smart Turn 重构取代的 `voice_turn`、`voice_identity` 与 Core composition。此次从最新 `main` 强制重建，将范围收敛为 Phase 4C-B：只交付可验证的 CAM++ score-only backend 与固定发行链。

## 技术决策

- `main_logic/voice_turn/**`、`main_logic/voice_identity/**`、Core、endpointing、workers 与现有 Shadow contracts/runtime 对主线保持零差异。
- `CampPlusBackendFactory` 只持有可清零的 192 维内存 reference 与路径配置；构造阶段零 I/O、零 ONNX session、零 task/process，并可被 Windows `spawn` 序列化。
- 资产验证与 `onnxruntime` 导入延迟到现有 Shadow 子进程的 `backend.load()`；加载、评分、关闭继续复用 #2408 的硬超时、fail-open、PCM 总预算与完整关闭边界。
- 固定模型 revision、license、source、size 与 SHA-256；运行时只解析 package-local 资产，绝不联网或读取用户缓存。
- PCM、embedding、路径、candidate、身份和 production similarity 不写日志、不持久化；raw similarity 只存在于离线评估与测试路径。

## 交付内容

- CAM++ frontend、ONNX 合同校验、192D finite/L2 embedding 与 cosine score backend。
- package-local manifest / third-party notice、离线准备脚本，以及 Windows/Linux/Docker/PyInstaller/Nuitka 的单份资产发行合同。
- 不回显输入路径或 embedding 的离线评估脚本。
- Phase 4C-B 设计边界与 backend、资产、真实模型、发行静态合同测试。

## 回归报告

- CAM++ / Speaker Shadow 聚焦套件：116 项通过，包含真实固定权重、Kaldi frontend parity 和 `spawn` observation-only 集成。
- Core opaque factory 回归：5 项通过；结构守门相关回归：25 项通过，独立合同检查通过。
- Ruff、Python 编译、三条 workflow YAML 解析、manifest 离线复验和 diff whitespace 检查通过。
- 权重未进入 Git；最终差异中无 `voice_turn`、`voice_identity`、Core、endpointing、workers 或旧资产路径。

## 风险边界

默认行为仍完全关闭，Core 的 Shadow factory 仍为 `None`，因此本 PR 不改变产品 ASR 决策或用户数据生命周期。Provider-neutral reference、显式 Enrollment、Core composition 和运行中热切换均留给后续独立设计与 PR。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增 CAM++ 说话人影子评分能力，可根据语音片段生成相似度分数。
  - 提供离线评估工具，支持参考音频与候选音频评分及多阈值统计。

- **构建与发布**
  - 桌面版及 Docker 镜像会自动准备、校验并打包所需模型资源。
  - 增强模型完整性、许可证及离线构建验证，提升部署可靠性。

- **隐私保护**
  - 处理完成后清理语音和嵌入等敏感数据，不保存音频、路径或评分结果。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->