### PR TITLE
fix(peek-mode): 右边缘无法吸附

### DIFF
--- a/static/live2d/live2d-core.js
+++ b/static/live2d/live2d-core.js
@@ -4684,10 +4684,10 @@ class Live2DManager {
                 const viewportLeft = 0;
                 const viewportTop = 0;
                 const viewportRight = Math.max(0, Number.isFinite(rendererW) && rendererW > 0
-                    ? rendererW
+                    ? Math.min(rendererW, Number(window.innerWidth) || rendererW)
                     : Number(window.innerWidth) || 0);
                 const viewportBottom = Math.max(0, Number.isFinite(rendererH) && rendererH > 0
-                    ? rendererH
+                    ? Math.min(rendererH, Number(window.innerHeight) || rendererH)
                     : Number(window.innerHeight) || 0);
                 const visibleLeft = Math.max(left, viewportLeft);
                 const visibleRight = Math.min(right, viewportRight);

--- a/static/live2d/live2d-interaction.js
+++ b/static/live2d/live2d-interaction.js
@@ -311,12 +311,14 @@ function getLive2DPeekViewport(bounds = null, manager = null) {
     const canvasH = Number(screen && screen.height);
     const vw = Number(window.innerWidth);
     const vh = Number(window.innerHeight);
+    const validVw = Number.isFinite(vw) && vw > 0;
+    const validVh = Number.isFinite(vh) && vh > 0;
     const viewportW = Number.isFinite(canvasW) && canvasW > 0
-        ? Math.min(canvasW, vw)
-        : (Number.isFinite(vw) && vw > 0 ? vw : fallbackW);
+        ? (validVw ? Math.min(canvasW, vw) : canvasW)
+        : (validVw ? vw : fallbackW);
     const viewportH = Number.isFinite(canvasH) && canvasH > 0
-        ? Math.min(canvasH, vh)
-        : (Number.isFinite(vh) && vh > 0 ? vh : fallbackH);
+        ? (validVh ? Math.min(canvasH, vh) : canvasH)
+        : (validVh ? vh : fallbackH);
     return { left: 0, top: 0, right: viewportW, bottom: viewportH, width: viewportW, height: viewportH };
 }
 

--- a/static/live2d/live2d-interaction.js
+++ b/static/live2d/live2d-interaction.js
@@ -307,13 +307,17 @@ function getLive2DPeekViewport(bounds = null, manager = null) {
     const fallbackH = bounds && Number.isFinite(bounds.height) ? bounds.height : 1;
     const renderer = manager && manager.pixi_app && manager.pixi_app.renderer;
     const screen = renderer && renderer.screen;
-    const rendererW = Number(screen && screen.width);
-    const rendererH = Number(screen && screen.height);
-    const viewportW = Number.isFinite(rendererW) && rendererW > 0 ? rendererW : Number(window.innerWidth);
-    const viewportH = Number.isFinite(rendererH) && rendererH > 0 ? rendererH : Number(window.innerHeight);
-    const width = Number.isFinite(viewportW) && viewportW > 0 ? viewportW : fallbackW;
-    const height = Number.isFinite(viewportH) && viewportH > 0 ? viewportH : fallbackH;
-    return { left: 0, top: 0, right: width, bottom: height, width, height };
+    const canvasW = Number(screen && screen.width);
+    const canvasH = Number(screen && screen.height);
+    const vw = Number(window.innerWidth);
+    const vh = Number(window.innerHeight);
+    const viewportW = Number.isFinite(canvasW) && canvasW > 0
+        ? Math.min(canvasW, vw)
+        : (Number.isFinite(vw) && vw > 0 ? vw : fallbackW);
+    const viewportH = Number.isFinite(canvasH) && canvasH > 0
+        ? Math.min(canvasH, vh)
+        : (Number.isFinite(vh) && vh > 0 ? vh : fallbackH);
+    return { left: 0, top: 0, right: viewportW, bottom: viewportH, width: viewportW, height: viewportH };
 }
 
 function getLive2DPeekViewportIntersection(bounds, viewport) {
@@ -489,7 +493,10 @@ function getLive2DPeekPlacement(model, bounds, manager = null) {
     const baseScaleX = model.scale && Number.isFinite(Number(model.scale.x)) ? Number(model.scale.x) : 1;
     const targetRotationDegrees = getLive2DPeekRotationDegrees(anchor);
     const targetRotation = targetRotationDegrees * Math.PI / 180;
-    const targetScaleX = getLive2DPeekInwardScaleX(model, side);
+    let targetScaleX = getLive2DPeekInwardScaleX(model, side);
+    if (side === 'right') {
+        targetScaleX = Math.abs(targetScaleX);
+    }
     const baseHeadAnchor = getLive2DPeekHeadAnchor(manager);
     const fallbackHeadLocalPoint = baseHeadAnchor
         ? null
@@ -734,6 +741,12 @@ Live2DManager.prototype._tryApplyLive2DPeek = async function (model) {
     if (isLive2DPeekDesktopRuntime()) {
         await refreshLive2DPeekDisplayContext();
     }
+    try {
+        const stage = this.pixi_app && this.pixi_app.stage;
+        if (stage && typeof stage.updateTransform === 'function') {
+            stage.updateTransform();
+        }
+    } catch (_) {}
     const bounds = getLive2DPeekBounds(model);
     const target = getLive2DPeekPlacement(model, bounds, this);
     if (!bounds || !target) {

--- a/static/live2d/live2d-interaction.js
+++ b/static/live2d/live2d-interaction.js
@@ -743,12 +743,6 @@ Live2DManager.prototype._tryApplyLive2DPeek = async function (model) {
     if (isLive2DPeekDesktopRuntime()) {
         await refreshLive2DPeekDisplayContext();
     }
-    try {
-        const stage = this.pixi_app && this.pixi_app.stage;
-        if (stage && typeof stage.updateTransform === 'function') {
-            stage.updateTransform();
-        }
-    } catch (_) {}
     const bounds = getLive2DPeekBounds(model);
     const target = getLive2DPeekPlacement(model, bounds, this);
     if (!bounds || !target) {

--- a/tests/unit/live2d_peek_behavior.test.js
+++ b/tests/unit/live2d_peek_behavior.test.js
@@ -497,7 +497,7 @@ test('right edge peek faces inward and restores original transform', async () =>
     assert.equal(model.x, 890);
     assert.equal(model.y, 100);
     assert.equal(model.rotation, -60 * Math.PI / 180);
-    assert.equal(model.scale.x, -1);
+    assert.equal(model.scale.x, 1);
 
     const restorePromise = manager.restoreLive2DPeek('click-restore');
     flushNextFrame(harness);
@@ -527,7 +527,7 @@ test('edge peek uses renderer screen bounds when canvas differs from window view
 
     assert.equal(model.x, 970);
     assert.equal(model.rotation, -60 * Math.PI / 180);
-    assert.equal(model.scale.x, -1);
+    assert.equal(model.scale.x, 1);
     assert.deepEqual(JSON.parse(JSON.stringify(manager._live2DPeekState.visibleBounds)), {
         left: 970,
         right: 1080,

--- a/tests/unit/test_live2d_peek_static.py
+++ b/tests/unit/test_live2d_peek_static.py
@@ -165,10 +165,11 @@ def test_live2d_widget_mode_edge_peek_reports_viewport_intersection_bounds():
     assert "drawPolygon" not in bounds_source
     assert "const renderer = manager && manager.pixi_app && manager.pixi_app.renderer;" in edge_peek_source
     assert "const screen = renderer && renderer.screen;" in edge_peek_source
-    assert "const viewportW = Number.isFinite(rendererW) && rendererW > 0 ? rendererW : Number(window.innerWidth);" in edge_peek_source
-    assert "const viewportH = Number.isFinite(rendererH) && rendererH > 0 ? rendererH : Number(window.innerHeight);" in edge_peek_source
-    assert "const width = Number.isFinite(viewportW) && viewportW > 0 ? viewportW : fallbackW;" in edge_peek_source
-    assert "const height = Number.isFinite(viewportH) && viewportH > 0 ? viewportH : fallbackH;" in edge_peek_source
+    assert "const canvasW = Number(screen && screen.width);" in edge_peek_source
+    assert "const vw = Number(window.innerWidth);" in edge_peek_source
+    assert "const viewportW = Number.isFinite(canvasW) && canvasW > 0" in edge_peek_source
+    assert "? Math.min(canvasW, vw)" in edge_peek_source
+    assert ": (validVw ? vw : fallbackW);" in edge_peek_source
     assert "getLive2DPeekPlacement(model, bounds, this)" in edge_peek_source
     assert "Math.max(fallbackW" not in viewport_source
     assert "Math.max(fallbackH" not in viewport_source


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

1. 发现挂边模式不能正常吸附右边缘（但是窗口resize后就没问题了），修复喵~
2. 你不觉得这个贴靠右边缘的镜像翻转很难绷吗 (￣_￣|||) 如果只是旋转的话会不会顺眼很多？

## 回归报告 / Regression Report

<!--
仅当本 PR 触碰 app/、main_logic/、memory/ 时必填。请逐项说明：
  - 改动了什么
  - 理由 / 必要性
  - 改动前后的表现对比
  - 潜在回归点（影响哪些链路、怎么验证的）
未触碰这三个模块：写「不适用」或删除本节。
-->

## 不拆分理由 / Why Not Split

<!--
仅当本 PR 改动计入上限的文件 > 20 个时必填：为什么不拆成多个更小的 PR。
计入上限的文件数 ≤ 20：写「不适用」或删除本节。（新增文件、i18n locale 文件、测试文件不计入这个上限）
-->

## 测试 / Testing

`live2d_peek_behavior.test.js`，通过，但是`assert.equal(model.scale.x, -1);`被改成`assert.equal(model.scale.x, 1);`
手动测试没问题

附视频：
<!-- ~~诶我靠视频太大了我压一下~~ 重新编码 ~~少女乞讨中~~ -->

https://github.com/user-attachments/assets/c1b57b3a-ba60-40e0-84d8-5c44131ce437



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进 Live2D 边缘窥视的视口与裁剪边界计算：优先使用 PIXI 渲染画布尺寸（并在窗口尺寸有效时取更小的最小值），无效则回退到预估范围。
  * 修复右侧边缘窥视时模型缩放/朝向符号语义不一致的问题（右侧进入后方向切换并保持正确恢复）。
* **Tests**
  * 更新边缘窥视相关单测断言，匹配新的右侧行为及视口宽度计算结果。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->