### PR TITLE
调整自定义API布局

### DIFF
--- a/static/css/api_key_settings.css
+++ b/static/css/api_key_settings.css
@@ -1088,13 +1088,21 @@ padding-left: 4px;
 
 /* 自定义API折叠样式 */
 .custom-api-container {
-transition: all 0.3s ease-in-out;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    column-gap: 18px;
+    row-gap: 14px;
+    align-items: start;
+    transition: all 0.3s ease-in-out;
 }
 
 /* 清空自定义API按钮 */
 .clear-custom-api-wrapper {
-    margin-bottom: 16px;
-    text-align: right;
+    grid-column: 2;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    min-width: 0;
+    margin: 0;
 }
 
 .clear-custom-api-btn {
@@ -1125,11 +1133,67 @@ transition: all 0.3s ease-in-out;
 }
 
 .model-config-container {
-    margin-bottom: 16px;
+    min-width: 0;
+    margin-bottom: 0;
     border: 0;
     border-radius: 0;
     overflow: visible;
     transition: all 0.3s ease-in-out;
+}
+
+@media (min-width: 801px) {
+    .custom-api-container
+        > .model-config-container
+        > .model-content.expanded {
+        width: calc(200% + 18px);
+    }
+
+    .custom-api-container
+        > .model-config-container:has(> #summary-model-content, > #correction-model-content, > #vision-model-content, > #omni-model-content)
+        > .model-content.expanded {
+        margin-left: calc(-100% - 18px);
+    }
+
+    .custom-api-container:has(#conversation-model-content:is(.expanded, .is-collapsing)):has(#summary-model-content:is(.expanded, .is-collapsing))
+        :is(#conversation-model-content, #summary-model-content):is(.expanded, .is-collapsing),
+    .custom-api-container:has(#game-model-content:is(.expanded, .is-collapsing)):has(#correction-model-content:is(.expanded, .is-collapsing))
+        :is(#game-model-content, #correction-model-content):is(.expanded, .is-collapsing),
+    .custom-api-container:has(#emotion-model-content:is(.expanded, .is-collapsing)):has(#vision-model-content:is(.expanded, .is-collapsing))
+        :is(#emotion-model-content, #vision-model-content):is(.expanded, .is-collapsing),
+    .custom-api-container:has(#agent-model-content:is(.expanded, .is-collapsing)):has(#omni-model-content:is(.expanded, .is-collapsing))
+        :is(#agent-model-content, #omni-model-content):is(.expanded, .is-collapsing) {
+        width: 100%;
+        margin-left: 0;
+    }
+
+    .custom-api-container:has(#conversation-model-content.expanded)
+        > .model-config-container:has(> #summary-model-content)
+        > .model-header[aria-expanded="false"],
+    .custom-api-container:has(#summary-model-content.expanded)
+        > .model-config-container:has(> #conversation-model-content)
+        > .model-header[aria-expanded="false"],
+    .custom-api-container:has(#game-model-content.expanded)
+        > .model-config-container:has(> #correction-model-content)
+        > .model-header[aria-expanded="false"],
+    .custom-api-container:has(#correction-model-content.expanded)
+        > .model-config-container:has(> #game-model-content)
+        > .model-header[aria-expanded="false"],
+    .custom-api-container:has(#emotion-model-content.expanded)
+        > .model-config-container:has(> #vision-model-content)
+        > .model-header[aria-expanded="false"],
+    .custom-api-container:has(#vision-model-content.expanded)
+        > .model-config-container:has(> #emotion-model-content)
+        > .model-header[aria-expanded="false"],
+    .custom-api-container:has(#agent-model-content.expanded)
+        > .model-config-container:has(> #omni-model-content)
+        > .model-header[aria-expanded="false"],
+    .custom-api-container:has(#omni-model-content.expanded)
+        > .model-config-container:has(> #agent-model-content)
+        > .model-header[aria-expanded="false"] {
+        opacity: 0.62;
+        filter: saturate(0.55);
+    }
+
 }
 
 .model-header {
@@ -1161,6 +1225,25 @@ transform: translateY(1px) scale(0.98);
 box-shadow: 0 1px 3px rgba(64, 197, 241, 0.2);
 }
 
+.custom-api-container
+    > .model-config-container
+    > .model-header[aria-expanded="true"] {
+    opacity: 1;
+    background: linear-gradient(135deg, #4bd0f7 0%, #13adfa 100%);
+    transform: translateY(-2px) scale(1.006);
+    box-shadow:
+        inset 0 0 0 2px rgba(255, 255, 255, 0.9),
+        0 0 16px rgba(64, 197, 241, 0.3),
+        0 8px 18px rgba(16, 131, 193, 0.3);
+}
+
+.custom-api-container
+    > .model-config-container
+    > .model-header[aria-expanded="true"]:hover {
+    opacity: 1;
+    transform: translateY(-2px) scale(1.006);
+}
+
 .model-title {
 display: flex;
 align-items: center;
@@ -1185,13 +1268,23 @@ font-size: 0.9rem;
 .model-content {
 max-height: 0;
 overflow: hidden;
+box-sizing: border-box;
 transition: max-height 0.3s ease-in-out, margin-top 0.3s ease-in-out;
+}
+
+.model-content.is-reflowing {
+    transition:
+        max-height 0.3s ease-in-out,
+        margin-top 0.3s ease-in-out,
+        width 0.24s ease-in-out,
+        margin-left 0.24s ease-in-out;
 }
 
 .model-content.expanded {
     max-height: 2000px;
     margin-top: 8px;
-    border: 1px solid #e0e0e0;
+    border: 1px solid #d5eaf4;
+    border-top: 3px solid #40c5f1;
     border-radius: 24px;
 }
 
@@ -1684,6 +1777,21 @@ padding: 0;
 margin: 0;
 }
 
+.custom-api-container {
+    grid-template-columns: minmax(0, 1fr);
+    row-gap: 12px;
+}
+
+.custom-api-container > .clear-custom-api-wrapper,
+.custom-api-container > .connectivity-test-btn-wrapper,
+.custom-api-container > .model-config-container {
+    grid-column: 1;
+}
+
+.clear-custom-api-wrapper {
+    justify-content: flex-start;
+}
+
 .container-content {
     padding: 18px 18px 120px;
 }
@@ -1755,9 +1863,17 @@ font-size: 0.8em;
     max-width: 600px;
 }
 
+.model-content .connectivity-input-row {
+    margin-top: 8px;
+}
+
 .connectivity-input-row input {
     flex: 1;
     min-width: 0;
+}
+
+.model-content .connectivity-input-row input {
+    margin-top: 0;
 }
 
 /* Connected - Green */
@@ -1842,6 +1958,14 @@ font-size: 0.8em;
     transition: all 0.2s ease;
     user-select: none;
     margin-bottom: 12px;
+}
+
+.connectivity-test-btn-wrapper {
+    grid-column: 1;
+    display: flex;
+    align-items: center;
+    min-width: 0;
+    margin: 0;
 }
 
 .connectivity-test-btn:hover:not(:disabled) {

--- a/static/css/api_key_settings.css
+++ b/static/css/api_key_settings.css
@@ -1149,45 +1149,45 @@ padding-left: 4px;
     }
 
     .custom-api-container
-        > .model-config-container:has(> #summary-model-content, > #correction-model-content, > #vision-model-content, > #omni-model-content)
+        > .model-config-container:has(> #vision-model-content, > #correction-model-content, > #omni-model-content, > #tts-model-content)
         > .model-content.expanded {
         margin-left: calc(-100% - 18px);
     }
 
-    .custom-api-container:has(#conversation-model-content:is(.expanded, .is-collapsing)):has(#summary-model-content:is(.expanded, .is-collapsing))
-        :is(#conversation-model-content, #summary-model-content):is(.expanded, .is-collapsing),
-    .custom-api-container:has(#game-model-content:is(.expanded, .is-collapsing)):has(#correction-model-content:is(.expanded, .is-collapsing))
-        :is(#game-model-content, #correction-model-content):is(.expanded, .is-collapsing),
-    .custom-api-container:has(#emotion-model-content:is(.expanded, .is-collapsing)):has(#vision-model-content:is(.expanded, .is-collapsing))
-        :is(#emotion-model-content, #vision-model-content):is(.expanded, .is-collapsing),
-    .custom-api-container:has(#agent-model-content:is(.expanded, .is-collapsing)):has(#omni-model-content:is(.expanded, .is-collapsing))
-        :is(#agent-model-content, #omni-model-content):is(.expanded, .is-collapsing) {
+    .custom-api-container:has(#conversation-model-content:is(.expanded, .is-collapsing)):has(#vision-model-content:is(.expanded, .is-collapsing))
+        :is(#conversation-model-content, #vision-model-content):is(.expanded, .is-collapsing),
+    .custom-api-container:has(#summary-model-content:is(.expanded, .is-collapsing)):has(#correction-model-content:is(.expanded, .is-collapsing))
+        :is(#summary-model-content, #correction-model-content):is(.expanded, .is-collapsing),
+    .custom-api-container:has(#emotion-model-content:is(.expanded, .is-collapsing)):has(#omni-model-content:is(.expanded, .is-collapsing))
+        :is(#emotion-model-content, #omni-model-content):is(.expanded, .is-collapsing),
+    .custom-api-container:has(#agent-model-content:is(.expanded, .is-collapsing)):has(#tts-model-content:is(.expanded, .is-collapsing))
+        :is(#agent-model-content, #tts-model-content):is(.expanded, .is-collapsing) {
         width: 100%;
         margin-left: 0;
     }
 
     .custom-api-container:has(#conversation-model-content.expanded)
-        > .model-config-container:has(> #summary-model-content)
-        > .model-header[aria-expanded="false"],
-    .custom-api-container:has(#summary-model-content.expanded)
-        > .model-config-container:has(> #conversation-model-content)
-        > .model-header[aria-expanded="false"],
-    .custom-api-container:has(#game-model-content.expanded)
-        > .model-config-container:has(> #correction-model-content)
-        > .model-header[aria-expanded="false"],
-    .custom-api-container:has(#correction-model-content.expanded)
-        > .model-config-container:has(> #game-model-content)
-        > .model-header[aria-expanded="false"],
-    .custom-api-container:has(#emotion-model-content.expanded)
         > .model-config-container:has(> #vision-model-content)
         > .model-header[aria-expanded="false"],
     .custom-api-container:has(#vision-model-content.expanded)
-        > .model-config-container:has(> #emotion-model-content)
+        > .model-config-container:has(> #conversation-model-content)
         > .model-header[aria-expanded="false"],
-    .custom-api-container:has(#agent-model-content.expanded)
+    .custom-api-container:has(#summary-model-content.expanded)
+        > .model-config-container:has(> #correction-model-content)
+        > .model-header[aria-expanded="false"],
+    .custom-api-container:has(#correction-model-content.expanded)
+        > .model-config-container:has(> #summary-model-content)
+        > .model-header[aria-expanded="false"],
+    .custom-api-container:has(#emotion-model-content.expanded)
         > .model-config-container:has(> #omni-model-content)
         > .model-header[aria-expanded="false"],
     .custom-api-container:has(#omni-model-content.expanded)
+        > .model-config-container:has(> #emotion-model-content)
+        > .model-header[aria-expanded="false"],
+    .custom-api-container:has(#agent-model-content.expanded)
+        > .model-config-container:has(> #tts-model-content)
+        > .model-header[aria-expanded="false"],
+    .custom-api-container:has(#tts-model-content.expanded)
         > .model-config-container:has(> #agent-model-content)
         > .model-header[aria-expanded="false"] {
         opacity: 0.62;

--- a/static/css/dark-mode.css
+++ b/static/css/dark-mode.css
@@ -1017,12 +1017,23 @@ html[data-theme="dark"].subtitle-window-host body.subtitle-window-host {
   border-color: #365a72;
 }
 
+[data-theme="dark"] .custom-api-container
+  > .model-config-container
+  > .model-header[aria-expanded="true"] {
+  background: linear-gradient(135deg, #318bd0, #2173bb);
+  box-shadow:
+    inset 0 0 0 2px rgba(185, 225, 250, 0.9),
+    0 0 16px rgba(74, 163, 223, 0.24),
+    0 8px 18px rgba(0, 0, 0, 0.38);
+}
+
 [data-theme="dark"] .model-content {
   background: #2d2d2d;
 }
 
 [data-theme="dark"] .model-content.expanded {
   border-color: #444;
+  border-top-color: #4aa3df;
 }
 
 [data-theme="dark"] .nested-model-config-container {

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -2253,7 +2253,7 @@ function toggleCustomApi(skipAutoFill) {
     const customApiContainer = document.getElementById('custom-api-container');
     if (customApiContainer) {
         if (isCustomEnabled) {
-            customApiContainer.style.display = 'block';
+            customApiContainer.style.display = 'grid';
             // 展开所有模型配置
             const modelContainers = document.querySelectorAll('.model-config-container');
             modelContainers.forEach(container => {
@@ -3157,6 +3157,37 @@ function positionTooltip(iconElement, tooltipElement) {
     tooltipElement.style.setProperty('--arrow-left', arrowLeft + 'px');
 }
 
+const MODEL_CONFIG_ROW_PAIRS = Object.freeze({
+    conversation: 'summary',
+    summary: 'conversation',
+    game: 'correction',
+    correction: 'game',
+    emotion: 'vision',
+    vision: 'emotion',
+    agent: 'omni',
+    omni: 'agent',
+});
+
+function finishModelConfigCollapse(content, pairedContent, transitionId) {
+    if (content.dataset.collapseTransitionId !== transitionId) return;
+
+    delete content.dataset.collapseTransitionId;
+    const expandedPair = pairedContent?.classList.contains('expanded') ? pairedContent : null;
+    if (expandedPair) {
+        expandedPair.classList.add('is-reflowing');
+        expandedPair.getBoundingClientRect();
+    }
+
+    content.classList.remove('is-collapsing');
+    content.style.removeProperty('max-height');
+
+    if (expandedPair) {
+        window.setTimeout(() => {
+            expandedPair.classList.remove('is-reflowing');
+        }, 260);
+    }
+}
+
 // 二级折叠功能：切换模型配置的展开/折叠状态
 function toggleModelConfig(modelType) {
     const content = document.getElementById(`${modelType}-model-content`);
@@ -3169,11 +3200,41 @@ function toggleModelConfig(modelType) {
     if (!icon) return;
 
     if (content.classList.contains('expanded')) {
+        const pairedType = MODEL_CONFIG_ROW_PAIRS[modelType];
+        const pairedContent = pairedType
+            ? document.getElementById(`${pairedType}-model-content`)
+            : null;
+        const transitionId = `${Date.now()}-${Math.random()}`;
+
+        content.dataset.collapseTransitionId = transitionId;
+        content.classList.add('is-collapsing');
+        content.style.maxHeight = `${content.scrollHeight}px`;
+        content.getBoundingClientRect();
         content.classList.remove('expanded');
         icon.style.transform = 'rotate(0deg)';
         header.setAttribute('aria-expanded', 'false');
         content.setAttribute('aria-hidden', 'true');
+
+        window.requestAnimationFrame(() => {
+            if (content.dataset.collapseTransitionId === transitionId) {
+                content.style.maxHeight = '0px';
+            }
+        });
+
+        const handleTransitionEnd = event => {
+            if (event.target !== content || event.propertyName !== 'max-height') return;
+            content.removeEventListener('transitionend', handleTransitionEnd);
+            finishModelConfigCollapse(content, pairedContent, transitionId);
+        };
+        content.addEventListener('transitionend', handleTransitionEnd);
+        window.setTimeout(() => {
+            content.removeEventListener('transitionend', handleTransitionEnd);
+            finishModelConfigCollapse(content, pairedContent, transitionId);
+        }, 360);
     } else {
+        delete content.dataset.collapseTransitionId;
+        content.classList.remove('is-collapsing');
+        content.style.removeProperty('max-height');
         content.classList.add('expanded');
         icon.style.transform = 'rotate(180deg)';
         header.setAttribute('aria-expanded', 'true');
@@ -3194,7 +3255,7 @@ function navigateToCustomModelConfig(modelType) {
 
     const customApiContainer = document.getElementById('custom-api-container');
     if (customApiContainer && getComputedStyle(customApiContainer).display === 'none') {
-        customApiContainer.style.display = 'block';
+        customApiContainer.style.display = 'grid';
     }
 
     let expandedConfig = false;
@@ -3372,11 +3433,23 @@ function createIndicatorLight(inputElement, context) {
 
     // 将灯和 input 包在一个水平 flex 容器中，确保同行对齐
     if (inputElement && inputElement.parentNode) {
+        const fieldRow = inputElement.closest('.field-row');
         const wrapper = document.createElement('div');
         wrapper.className = 'connectivity-input-row';
         inputElement.parentNode.insertBefore(wrapper, inputElement);
         wrapper.appendChild(light);
         wrapper.appendChild(inputElement);
+
+        // 服务商配置可能先于连通性组件初始化。此时“前往管理簿”已经被
+        // 插入 field-row，需要一并移入横向容器，避免它留在输入框下一行。
+        const keyBookShortcut = fieldRow
+            ? Array.from(fieldRow.querySelectorAll('.key-book-shortcut')).find(
+                link => !link.dataset.sourceInputId || link.dataset.sourceInputId === inputElement.id
+            )
+            : null;
+        if (keyBookShortcut) {
+            wrapper.appendChild(keyBookShortcut);
+        }
     }
 
     return light;
@@ -4475,8 +4548,6 @@ function initConnectivityLights() {
         const btnWrapper = document.createElement('div');
         btnWrapper.className = 'connectivity-test-btn-wrapper';
         btnWrapper.style.display = 'flex';
-        btnWrapper.style.alignItems = 'center';
-        btnWrapper.style.marginBottom = '12px';
 
         // Move button into wrapper (replace its position)
         testButton.style.marginBottom = '0';

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -30,7 +30,7 @@ let _apiSaveInProgress = false;
 const _aliyunUsApiWarningShownKeys = new Set();
 
 // 所有模型类型
-const MODEL_TYPES = ['conversation', 'summary', 'gameMain', 'gameSummary', 'correction', 'emotion', 'vision', 'agent', 'omni', 'tts'];
+const MODEL_TYPES = ['conversation', 'vision', 'summary', 'correction', 'emotion', 'omni', 'agent', 'tts', 'gameMain', 'gameSummary'];
 // Model types that support connectivity testing.
 // All model types including TTS are testable — TTS follows the same
 // provider resolution logic (follow_core/follow_assist/custom).
@@ -3158,14 +3158,14 @@ function positionTooltip(iconElement, tooltipElement) {
 }
 
 const MODEL_CONFIG_ROW_PAIRS = Object.freeze({
-    conversation: 'summary',
-    summary: 'conversation',
-    game: 'correction',
-    correction: 'game',
-    emotion: 'vision',
-    vision: 'emotion',
-    agent: 'omni',
-    omni: 'agent',
+    conversation: 'vision',
+    vision: 'conversation',
+    summary: 'correction',
+    correction: 'summary',
+    emotion: 'omni',
+    omni: 'emotion',
+    agent: 'tts',
+    tts: 'agent',
 });
 
 function finishModelConfigCollapse(content, pairedContent, transitionId) {
@@ -3376,16 +3376,16 @@ const LightStatus = {
 
 function getCustomModelDisplayLabel(modelType) {
     const labelMap = {
-        conversation: ['api.conversationModelConfig', '文本对话模型配置'],
-        summary: ['api.summaryModelConfig', '摘要模型配置'],
+        conversation: ['api.conversationModelConfig', '文本聊天模型'],
+        summary: ['api.summaryModelConfig', '摘要模型'],
         gameMain: ['api.gameMainModelConfig', '小游戏主模型配置'],
         gameSummary: ['api.gameSummaryModelConfig', '小游戏摘要模型配置'],
-        correction: ['api.correctionModelConfig', '纠错模型配置'],
-        emotion: ['api.emotionModelConfig', '情感模型配置'],
-        vision: ['api.visionModelConfig', '视觉模型配置'],
-        agent: ['api.agentApiConfigTitle', 'Agent API 配置（需支持视觉功能）'],
-        omni: ['api.realtimeModelConfig', '实时模型配置（Local模式）'],
-        tts: ['api.ttsModelConfig', 'TTS模型配置（双工流式）'],
+        correction: ['api.correctionModelConfig', '纠错模型'],
+        emotion: ['api.emotionModelConfig', '情感模型'],
+        vision: ['api.visionModelConfig', '视觉聊天模型'],
+        agent: ['api.agentApiConfigTitle', 'Agent API（需支持视觉功能）'],
+        omni: ['api.realtimeModelConfig', '实时全模态模型（Local模式）'],
+        tts: ['api.ttsModelConfig', 'TTS模型'],
     };
     const [key, fallback] = labelMap[modelType] || ['', modelType];
     if (!key || !window.t) return fallback;

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -1161,20 +1161,20 @@
             "title": "Alibaba US API Notice",
             "message": "You are currently using Alibaba's US API, which does not support TTS or realtime voice. We recommend switching to Alibaba's Singapore API."
         },
-        "conversationModelConfig": "Text Dialogue Model Configuration",
-        "summaryModelConfig": "Summary Model Configuration",
-        "gameModelsConfig": "Mini-game Model Configuration",
+        "conversationModelConfig": "Text Chat Model",
+        "summaryModelConfig": "Summary Model",
+        "gameModelsConfig": "Mini-game Model",
         "gameMainModelConfig": "Mini-game Main Model Configuration",
         "gameSummaryModelConfig": "Mini-game Summary Model Configuration",
-        "correctionModelConfig": "Correction Model Configuration",
-        "emotionModelConfig": "Emotion Model Configuration",
-        "visionModelConfig": "Vision Model Configuration",
-        "realtimeModelConfig": "Realtime API (Local Mode)",
-        "ttsModelConfig": "TTS Model Configuration (Duplex Streaming)",
+        "correctionModelConfig": "Correction Model",
+        "emotionModelConfig": "Emotion Model",
+        "visionModelConfig": "Vision Chat Model",
+        "realtimeModelConfig": "Realtime Multimodal Model (Local Mode)",
+        "ttsModelConfig": "TTS Model",
         "apiUrl": "API URL",
         "apiKey": "API Key",
         "modelId": "Model ID",
-        "agentApiConfigTitle": "Agent API Config (Vision-capable required)",
+        "agentApiConfigTitle": "Agent API (Vision-capable required)",
         "providerPlaceholder": "e.g., openai, azure, local",
         "apiUrlPlaceholder": "e.g., https://api.openai.com/v1",
         "modelIdPlaceholder": "e.g., gpt-5.1-chat-latest, qwen-flash",
@@ -3386,7 +3386,7 @@
                 "desc": "Check to enable custom API configuration. Then configure independent APIs for different modules like summarization, correction, emotion analysis, etc."
             },
             "step9": {
-                "title": "📝 Summary Model Configuration",
+                "title": "📝 Summary Model",
                 "desc": "Summary model generates conversation summaries and manages memory. Configure independent API service for summary tasks."
             }
         },

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -1161,20 +1161,20 @@
             "title": "Aviso de API de Alibaba en EE. UU.",
             "message": "Actualmente está usando la API de Alibaba en EE. UU., que no admite TTS ni voz en tiempo real. Se recomienda cambiar a la API de Alibaba en Singapur."
         },
-        "conversationModelConfig": "Configuración del modelo de diálogo de texto",
-        "summaryModelConfig": "Configuración del modelo resumido",
-        "gameModelsConfig": "Configuración de modelos del minijuego",
+        "conversationModelConfig": "Modelo de chat de texto",
+        "summaryModelConfig": "Modelo de resumen",
+        "gameModelsConfig": "Modelo de minijuego",
         "gameMainModelConfig": "Configuración del modelo principal del minijuego",
         "gameSummaryModelConfig": "Configuración del modelo de resumen del minijuego",
-        "correctionModelConfig": "Configuración del modelo de corrección",
-        "emotionModelConfig": "Configuración del modelo de emoción",
-        "visionModelConfig": "Configuración del modelo de visión",
-        "realtimeModelConfig": "API en tiempo real (modo local)",
-        "ttsModelConfig": "Configuración del modelo TTS (transmisión dúplex)",
+        "correctionModelConfig": "Modelo de corrección",
+        "emotionModelConfig": "Modelo de emociones",
+        "visionModelConfig": "Modelo de chat visual",
+        "realtimeModelConfig": "Modelo multimodal en tiempo real (modo local)",
+        "ttsModelConfig": "Modelo TTS",
         "apiUrl": "URL de la API",
         "apiKey": "Clave API",
         "modelId": "ID del modelo",
-        "agentApiConfigTitle": "Configuración de API del agente (se requiere compatibilidad con Vision)",
+        "agentApiConfigTitle": "API del agente (se requiere compatibilidad con Vision)",
         "providerPlaceholder": "por ejemplo, openai, azure, local",
         "apiUrlPlaceholder": "por ejemplo, https://api.openai.com/v1",
         "modelIdPlaceholder": "por ejemplo, gpt-5.1-chat-latest, qwen-flash",
@@ -3386,7 +3386,7 @@
                 "desc": "Marque para habilitar la configuración de API personalizada. Luego configure API independientes para diferentes módulos como resumen, corrección, análisis de emociones, etc."
             },
             "step9": {
-                "title": "📝 Configuración del modelo resumido",
+                "title": "📝 Modelo de resumen",
                 "desc": "El modelo de resumen genera resúmenes de conversaciones y gestiona la memoria. Configure el servicio API independiente para tareas de resumen."
             }
         },

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -1161,20 +1161,20 @@
             "title": "Alibaba 米国 API の注意",
             "message": "現在 Alibaba の米国 API を使用しています。この API は TTS とリアルタイム音声に対応していません。Alibaba のシンガポール API への切り替えをおすすめします。"
         },
-        "conversationModelConfig": "テキスト対話モデル設定",
-        "summaryModelConfig": "要約モデル設定",
-        "gameModelsConfig": "ミニゲームモデル設定",
+        "conversationModelConfig": "テキストチャットモデル",
+        "summaryModelConfig": "要約モデル",
+        "gameModelsConfig": "ミニゲームモデル",
         "gameMainModelConfig": "ミニゲーム主モデル設定",
         "gameSummaryModelConfig": "ミニゲーム要約モデル設定",
-        "correctionModelConfig": "修正モデル設定",
-        "emotionModelConfig": "感情モデル設定",
-        "visionModelConfig": "視覚モデル設定",
-        "realtimeModelConfig": "リアルタイムAPI（ローカルモード）",
-        "ttsModelConfig": "TTSモデル設定（全二重ストリーミング）",
+        "correctionModelConfig": "修正モデル",
+        "emotionModelConfig": "感情モデル",
+        "visionModelConfig": "視覚チャットモデル",
+        "realtimeModelConfig": "リアルタイムマルチモーダルモデル（ローカルモード）",
+        "ttsModelConfig": "TTSモデル",
         "apiUrl": "API URL",
         "apiKey": "APIキー",
         "modelId": "モデルID",
-        "agentApiConfigTitle": "Agent API 設定（視覚機能対応が必要）",
+        "agentApiConfigTitle": "Agent API（視覚機能対応が必要）",
         "providerPlaceholder": "例: openai, azure, local",
         "apiUrlPlaceholder": "例: https://api.openai.com/v1",
         "modelIdPlaceholder": "例: gpt-5.1-chat-latest",
@@ -3386,7 +3386,7 @@
                 "desc": "このオプションをチェックしてカスタムAPI設定を有効にしてください。有効にすると、要約、修正、感情分析など、異なるモジュール用に独立したAPIを設定できます。"
             },
             "step9": {
-                "title": "📝 要約モデル設定",
+                "title": "📝 要約モデル",
                 "desc": "要約モデルは会話要約を生成し、メモリを管理します。要約生成タスク用に独立したAPIサービスを設定できます。"
             }
         },

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -1161,20 +1161,20 @@
             "title": "Alibaba 미국 API 안내",
             "message": "현재 Alibaba의 미국 API를 사용 중입니다. 이 API는 TTS와 실시간 음성을 지원하지 않으므로 Alibaba 싱가포르 API로 변경하는 것을 권장합니다."
         },
-        "conversationModelConfig": "텍스트 대화 모델 구성",
-        "summaryModelConfig": "요약 모델 구성",
-        "gameModelsConfig": "미니게임 모델 구성",
+        "conversationModelConfig": "텍스트 채팅 모델",
+        "summaryModelConfig": "요약 모델",
+        "gameModelsConfig": "미니게임 모델",
         "gameMainModelConfig": "미니게임 메인 모델 구성",
         "gameSummaryModelConfig": "미니게임 요약 모델 구성",
-        "correctionModelConfig": "수정 모델 구성",
-        "emotionModelConfig": "감정 모델 구성",
-        "visionModelConfig": "비전 모델 구성",
-        "realtimeModelConfig": "실시간 API(로컬 모드)",
-        "ttsModelConfig": "TTS 모델 구성(이중 스트리밍)",
+        "correctionModelConfig": "교정 모델",
+        "emotionModelConfig": "감정 모델",
+        "visionModelConfig": "비전 채팅 모델",
+        "realtimeModelConfig": "실시간 멀티모달 모델(로컬 모드)",
+        "ttsModelConfig": "TTS 모델",
         "apiUrl": "API URL",
         "apiKey": "API 키",
         "modelId": "모델 ID",
-        "agentApiConfigTitle": "에이전트 API 설정(시각 기능 지원 필요)",
+        "agentApiConfigTitle": "에이전트 API(시각 기능 지원 필요)",
         "providerPlaceholder": "예: openai, azure, 로컬",
         "apiUrlPlaceholder": "예: https://api.openai.com/v1",
         "modelIdPlaceholder": "예: gpt-5.1-chat-latest, qwen-flash",
@@ -3386,7 +3386,7 @@
                 "desc": "사용자 정의 API 구성을 활성화하려면 선택합니다. 그런 다음 요약, 수정, 감정 분석 등과 같은 다양한 모듈에 대해 독립적인 API를 구성합니다."
             },
             "step9": {
-                "title": "📝 요약 모델 구성",
+                "title": "📝 요약 모델",
                 "desc": "요약 모델은 대화 요약을 생성하고 메모리를 관리합니다. 요약 작업을 위한 독립적인 API 서비스를 구성합니다."
             }
         },

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -1161,20 +1161,20 @@
             "title": "Aviso da API dos EUA da Alibaba",
             "message": "Você está usando a API dos EUA da Alibaba, que não oferece suporte a TTS nem voz em tempo real. Recomendamos mudar para a API de Singapura da Alibaba."
         },
-        "conversationModelConfig": "Configuração do modelo de diálogo de texto",
-        "summaryModelConfig": "Configuração resumida do modelo",
-        "gameModelsConfig": "Configuração dos modelos do minijogo",
+        "conversationModelConfig": "Modelo de chat de texto",
+        "summaryModelConfig": "Modelo de resumo",
+        "gameModelsConfig": "Modelo de minijogo",
         "gameMainModelConfig": "Configuração do modelo principal do minijogo",
         "gameSummaryModelConfig": "Configuração do modelo de resumo do minijogo",
-        "correctionModelConfig": "Configuração do modelo de correção",
-        "emotionModelConfig": "Configuração do modelo de emoção",
-        "visionModelConfig": "Configuração do modelo de visão",
-        "realtimeModelConfig": "API em tempo real (modo local)",
-        "ttsModelConfig": "Configuração do modelo TTS (streaming duplex)",
+        "correctionModelConfig": "Modelo de correção",
+        "emotionModelConfig": "Modelo de emoção",
+        "visionModelConfig": "Modelo de chat visual",
+        "realtimeModelConfig": "Modelo multimodal em tempo real (modo local)",
+        "ttsModelConfig": "Modelo TTS",
         "apiUrl": "URL da API",
         "apiKey": "Chave de API",
         "modelId": "ID do modelo",
-        "agentApiConfigTitle": "Configuração da API do agente (é necessário ter capacidade para Vision)",
+        "agentApiConfigTitle": "API do agente (é necessário ter capacidade para Vision)",
         "providerPlaceholder": "por exemplo, openai, azul, local",
         "apiUrlPlaceholder": "por exemplo, https://api.openai.com/v1",
         "modelIdPlaceholder": "por exemplo, gpt-5.1-chat-latest, qwen-flash",
@@ -3386,7 +3386,7 @@
                 "desc": "Marque para ativar a configuração de API personalizada. Em seguida, configure APIs independentes para diferentes módulos, como resumo, correção, análise emocional, etc."
             },
             "step9": {
-                "title": "📝 Configuração resumida do modelo",
+                "title": "📝 Modelo de resumo",
                 "desc": "O modelo de resumo gera resumos de conversas e gerencia a memória. Configure o serviço de API independente para tarefas de resumo."
             }
         },

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -1161,20 +1161,20 @@
             "title": "Уведомление об API Alibaba в США",
             "message": "Сейчас используется API Alibaba в США. Он не поддерживает TTS и голос в реальном времени. Рекомендуется перейти на API Alibaba в Сингапуре."
         },
-        "conversationModelConfig": "Конфигурация модели текстового диалога",
-        "summaryModelConfig": "Конфигурация модели сводки",
-        "gameModelsConfig": "Конфигурация моделей мини-игры",
+        "conversationModelConfig": "Модель текстового чата",
+        "summaryModelConfig": "Модель сводки",
+        "gameModelsConfig": "Модель мини-игры",
         "gameMainModelConfig": "Конфигурация основной модели мини-игры",
         "gameSummaryModelConfig": "Конфигурация модели сводки мини-игры",
-        "correctionModelConfig": "Конфигурация модели коррекции",
-        "emotionModelConfig": "Конфигурация модели эмоций",
-        "visionModelConfig": "Конфигурация модели визуального распознавания",
-        "realtimeModelConfig": "Realtime API (Локальный режим)",
-        "ttsModelConfig": "Конфигурация модели TTS (Дуплексная потоковая передача)",
+        "correctionModelConfig": "Модель коррекции",
+        "emotionModelConfig": "Модель эмоций",
+        "visionModelConfig": "Модель визуального чата",
+        "realtimeModelConfig": "Мультимодальная модель реального времени (Локальный режим)",
+        "ttsModelConfig": "Модель TTS",
         "apiUrl": "URL API",
         "apiKey": "API Key",
         "modelId": "ID модели",
-        "agentApiConfigTitle": "Конфигурация API Агента (нужна поддержка зрения)",
+        "agentApiConfigTitle": "API Агента (нужна поддержка зрения)",
         "providerPlaceholder": "например, openai, azure, local",
         "apiUrlPlaceholder": "например, https://api.openai.com/v1",
         "modelIdPlaceholder": "например, gpt-5.1-chat-latest, qwen-flash",
@@ -3386,7 +3386,7 @@
                 "desc": "Check to enable custom API configuration. Then configure independent APIs for different modules like summarization, correction, emotion analysis, etc."
             },
             "step9": {
-                "title": "📝 Summary Model Configuration",
+                "title": "📝 Модель сводки",
                 "desc": "Summary model generates conversation summaries and manages memory. Configure independent API service for summary tasks."
             }
         },

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -1161,20 +1161,20 @@
             "title": "阿里美国 API 提醒",
             "message": "当前使用了阿里的美国API，不支持TTS与实时语音，建议更换阿里的新加坡API"
         },
-        "conversationModelConfig": "文本对话模型配置",
-        "summaryModelConfig": "摘要模型配置",
-        "gameModelsConfig": "小游戏模型配置",
+        "conversationModelConfig": "文本聊天模型",
+        "summaryModelConfig": "摘要模型",
+        "gameModelsConfig": "小游戏模型",
         "gameMainModelConfig": "小游戏主模型配置",
         "gameSummaryModelConfig": "小游戏摘要模型配置",
-        "correctionModelConfig": "纠错模型配置",
-        "emotionModelConfig": "情感模型配置",
-        "visionModelConfig": "视觉模型配置",
-        "realtimeModelConfig": "实时模型配置（Local模式）",
-        "ttsModelConfig": "TTS模型配置（双工流式）",
+        "correctionModelConfig": "纠错模型",
+        "emotionModelConfig": "情感模型",
+        "visionModelConfig": "视觉聊天模型",
+        "realtimeModelConfig": "实时全模态模型（Local模式）",
+        "ttsModelConfig": "TTS模型",
         "apiUrl": "API URL",
         "apiKey": "API Key",
         "modelId": "模型ID",
-        "agentApiConfigTitle": "Agent API 配置（需支持视觉功能）",
+        "agentApiConfigTitle": "Agent API（需支持视觉功能）",
         "providerPlaceholder": "如：openai、azure、local",
         "apiUrlPlaceholder": "如：https://api.openai.com/v1",
         "modelIdPlaceholder": "如：gpt-5.1-chat-latest、qwen-flash",
@@ -3386,7 +3386,7 @@
                 "desc": "勾选这个选项可以启用自定义 API 配置。启用后，您可以为不同的功能模块（摘要、纠错、情感分析等）配置独立的 API。"
             },
             "step9": {
-                "title": "📝 摘要模型配置",
+                "title": "📝 摘要模型",
                 "desc": "摘要模型用于生成对话摘要和记忆管理。您可以配置独立的 API 服务来处理摘要生成任务。"
             }
         },

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -1161,20 +1161,20 @@
             "title": "阿里美國 API 提醒",
             "message": "目前使用的是阿里的美國 API，不支援 TTS 與即時語音，建議更換為阿里的新加坡 API"
         },
-        "conversationModelConfig": "文本對話模型配置",
-        "summaryModelConfig": "摘要模型配置",
-        "gameModelsConfig": "小遊戲模型配置",
+        "conversationModelConfig": "文本聊天模型",
+        "summaryModelConfig": "摘要模型",
+        "gameModelsConfig": "小遊戲模型",
         "gameMainModelConfig": "小遊戲主模型配置",
         "gameSummaryModelConfig": "小遊戲摘要模型配置",
-        "correctionModelConfig": "糾錯模型配置",
-        "emotionModelConfig": "情感模型配置",
-        "visionModelConfig": "視覺模型配置",
-        "realtimeModelConfig": "實時模型配置（Local模式）",
-        "ttsModelConfig": "TTS模型配置（雙工流式）",
+        "correctionModelConfig": "糾錯模型",
+        "emotionModelConfig": "情感模型",
+        "visionModelConfig": "視覺聊天模型",
+        "realtimeModelConfig": "實時全模態模型（Local模式）",
+        "ttsModelConfig": "TTS模型",
         "apiUrl": "API URL",
         "apiKey": "API Key",
         "modelId": "模型ID",
-        "agentApiConfigTitle": "Agent API 配置（需支援視覺功能）",
+        "agentApiConfigTitle": "Agent API（需支援視覺功能）",
         "providerPlaceholder": "如：openai、azure、local",
         "apiUrlPlaceholder": "如：https://api.openai.com/v1",
         "modelIdPlaceholder": "如：gpt-5.1-chat-latest、qwen-flash",
@@ -3386,7 +3386,7 @@
                 "desc": "勾選這個選項可以啟用自定義 API 配置。啟用後，妳可以為不同的功能模塊（摘要、糾錯、情感分析等）配置獨立的 API。"
             },
             "step9": {
-                "title": "📝 摘要模型配置",
+                "title": "📝 摘要模型",
                 "desc": "摘要模型用於生成對話摘要和記憶管理。妳可以配置獨立的 API 服務來處理摘要生成任務。"
             }
         },

--- a/templates/api_key_settings.html
+++ b/templates/api_key_settings.html
@@ -292,14 +292,14 @@
                                     </button>
                                 </div>
 
-                                <!-- 文本对话模型配置 -->
+                                <!-- 文本聊天模型 -->
                                 <div class="model-config-container">
                                     <div class="model-header" onclick="toggleModelConfig('conversation')">
                                         <span class="model-title">
                                             <img src="/static/icons/correction_model_icon.png"
                                                 data-i18n-alt="api.conversationModelConfig"
                                                 class="model-title-icon">
-                                            <span data-i18n="api.conversationModelConfig">文本对话模型模型配置</span>
+                                            <span data-i18n="api.conversationModelConfig">文本聊天模型</span>
                                         </span>
                                         <span class="toggle-icon">▼</span>
                                     </div>
@@ -334,220 +334,13 @@
                                     </div>
                                 </div>
 
-                                <!-- 摘要模型配置 -->
-                                <div class="model-config-container">
-                                    <div class="model-header" onclick="toggleModelConfig('summary')">
-                                        <span class="model-title">
-                                            <img src="/static/icons/summary_model_icon.png"
-                                                data-i18n-alt="api.summaryModelConfig" class="model-title-icon">
-                                            <span data-i18n="api.summaryModelConfig">摘要模型配置</span>
-                                        </span>
-                                        <span class="toggle-icon">▼</span>
-                                    </div>
-                                    <div id="summary-model-content" class="model-content">
-                                        <div class="field-row">
-                                            <label for="summaryModelProvider" data-i18n="api.providerLabel">服务商</label>
-                                            <select id="summaryModelProvider" class="api-provider-select" style="max-width: 600px;">
-                                            </select>
-                                        </div>
-                                        <div class="field-row">
-                                            <label for="summaryModelUrl" data-i18n="api.apiUrl">API URL</label>
-                                            <input type="text" id="summaryModelUrl"
-                                                data-i18n-placeholder="api.baseUrlExamplePlaceholder"
-                                                placeholder="e.g., https://api.openai.com/v1" value=""
-                                                style="max-width: 600px;">
-                                        </div>
-                                        <div class="field-row">
-                                            <label for="summaryModelId" data-i18n="api.modelId">模型ID</label>
-                                            <input type="text" id="summaryModelId"
-                                                data-i18n-placeholder="api.modelExamplePlaceholder"
-                                                placeholder="e.g., gpt-3.5-turbo, qwen-turbo, glm-4-flash" value=""
-                                                style="max-width: 600px;">
-                                        </div>
-                                        <div class="field-row">
-                                            <label for="summaryModelApiKey" data-i18n="api.apiKey">API Key</label>
-                                            <input type="text" id="summaryModelApiKey"
-                                                data-i18n-placeholder="api.summaryModelApiKeyPlaceholder"
-                                                placeholder="Enter Summary API Key" value=""
-                                                style="max-width: 600px;">
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <!-- 小游戏模型配置 -->
-                                <div class="model-config-container">
-                                    <button type="button" class="model-header" onclick="toggleModelConfig('game')" aria-expanded="false" aria-controls="game-model-content">
-                                        <span class="model-title">
-                                            <img src="/static/icons/correction_model_icon.png"
-                                                data-i18n-alt="api.gameModelsConfig"
-                                                class="model-title-icon">
-                                            <span data-i18n="api.gameModelsConfig">小游戏模型配置</span>
-                                        </span>
-                                        <span class="toggle-icon">▼</span>
-                                    </button>
-                                    <div id="game-model-content" class="model-content">
-                                        <div class="nested-model-config-container">
-                                            <button type="button" class="model-header nested-model-header" onclick="toggleModelConfig('game-main')" aria-expanded="false" aria-controls="game-main-model-content">
-                                                <span class="model-title">
-                                                    <span data-i18n="api.gameMainModelConfig">小游戏主模型配置</span>
-                                                </span>
-                                                <span class="toggle-icon">▼</span>
-                                            </button>
-                                            <div id="game-main-model-content" class="model-content nested-model-content">
-                                                <div class="field-row">
-                                                    <label for="gameMainModelProvider" data-i18n="api.providerLabel">服务商</label>
-                                                    <select id="gameMainModelProvider" class="api-provider-select" style="max-width: 600px;">
-                                                    </select>
-                                                </div>
-                                                <div class="field-row">
-                                                    <label for="gameMainModelUrl" data-i18n="api.apiUrl">API URL</label>
-                                                    <input type="text" id="gameMainModelUrl"
-                                                        data-i18n-placeholder="api.baseUrlExamplePlaceholder"
-                                                        placeholder="e.g., https://api.openai.com/v1" value=""
-                                                        style="max-width: 600px;">
-                                                </div>
-                                                <div class="field-row">
-                                                    <label for="gameMainModelId" data-i18n="api.modelId">模型ID</label>
-                                                    <input type="text" id="gameMainModelId"
-                                                        data-i18n-placeholder="api.modelExamplePlaceholder"
-                                                        placeholder="e.g., gpt-3.5-turbo, qwen-turbo, glm-4-flash" value=""
-                                                        style="max-width: 600px;">
-                                                </div>
-                                                <div class="field-row">
-                                                    <label for="gameMainModelApiKey" data-i18n="api.apiKey">API Key</label>
-                                                    <input type="text" id="gameMainModelApiKey"
-                                                        data-i18n-placeholder="api.gameMainModelApiKeyPlaceholder"
-                                                        placeholder="Enter Mini-game Main Model API Key" value=""
-                                                        style="max-width: 600px;">
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div class="nested-model-config-container">
-                                            <button type="button" class="model-header nested-model-header" onclick="toggleModelConfig('game-summary')" aria-expanded="false" aria-controls="game-summary-model-content">
-                                                <span class="model-title">
-                                                    <span data-i18n="api.gameSummaryModelConfig">小游戏摘要模型配置</span>
-                                                </span>
-                                                <span class="toggle-icon">▼</span>
-                                            </button>
-                                            <div id="game-summary-model-content" class="model-content nested-model-content">
-                                                <div class="field-row">
-                                                    <label for="gameSummaryModelProvider" data-i18n="api.providerLabel">服务商</label>
-                                                    <select id="gameSummaryModelProvider" class="api-provider-select" style="max-width: 600px;">
-                                                    </select>
-                                                </div>
-                                                <div class="field-row">
-                                                    <label for="gameSummaryModelUrl" data-i18n="api.apiUrl">API URL</label>
-                                                    <input type="text" id="gameSummaryModelUrl"
-                                                        data-i18n-placeholder="api.baseUrlExamplePlaceholder"
-                                                        placeholder="e.g., https://api.openai.com/v1" value=""
-                                                        style="max-width: 600px;">
-                                                </div>
-                                                <div class="field-row">
-                                                    <label for="gameSummaryModelId" data-i18n="api.modelId">模型ID</label>
-                                                    <input type="text" id="gameSummaryModelId"
-                                                        data-i18n-placeholder="api.modelExamplePlaceholder"
-                                                        placeholder="e.g., gpt-3.5-turbo, qwen-turbo, glm-4-flash" value=""
-                                                        style="max-width: 600px;">
-                                                </div>
-                                                <div class="field-row">
-                                                    <label for="gameSummaryModelApiKey" data-i18n="api.apiKey">API Key</label>
-                                                    <input type="text" id="gameSummaryModelApiKey"
-                                                        data-i18n-placeholder="api.gameSummaryModelApiKeyPlaceholder"
-                                                        placeholder="Enter Mini-game Summary Model API Key" value=""
-                                                        style="max-width: 600px;">
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <!-- 纠错模型配置 -->
-                                <div class="model-config-container">
-                                    <div class="model-header" onclick="toggleModelConfig('correction')">
-                                        <span class="model-title">
-                                            <img src="/static/icons/correction_model_icon.png"
-                                                data-i18n-alt="api.correctionModelConfig" class="model-title-icon">
-                                            <span data-i18n="api.correctionModelConfig">纠错模型配置</span>
-                                        </span>
-                                        <span class="toggle-icon">▼</span>
-                                    </div>
-                                    <div id="correction-model-content" class="model-content">
-                                        <div class="field-row">
-                                            <label for="correctionModelProvider" data-i18n="api.providerLabel">服务商</label>
-                                            <select id="correctionModelProvider" class="api-provider-select" style="max-width: 600px;">
-                                            </select>
-                                        </div>
-                                        <div class="field-row">
-                                            <label for="correctionModelUrl" data-i18n="api.apiUrl">API URL</label>
-                                            <input type="text" id="correctionModelUrl"
-                                                data-i18n-placeholder="api.baseUrlExamplePlaceholder"
-                                                placeholder="e.g., https://api.openai.com/v1" value=""
-                                                style="max-width: 600px;">
-                                        </div>
-                                        <div class="field-row">
-                                            <label for="correctionModelId" data-i18n="api.modelId">模型ID</label>
-                                            <input type="text" id="correctionModelId"
-                                                data-i18n-placeholder="api.modelExamplePlaceholder"
-                                                placeholder="e.g., gpt-3.5-turbo, qwen-turbo, glm-4-flash" value=""
-                                                style="max-width: 600px;">
-                                        </div>
-                                        <div class="field-row">
-                                            <label for="correctionModelApiKey" data-i18n="api.apiKey">API Key</label>
-                                            <input type="text" id="correctionModelApiKey"
-                                                data-i18n-placeholder="api.correctionModelApiKeyPlaceholder"
-                                                placeholder="Enter Correction API Key" value=""
-                                                style="max-width: 600px;">
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <!-- 情感模型配置 -->
-                                <div class="model-config-container">
-                                    <div class="model-header" onclick="toggleModelConfig('emotion')">
-                                        <span class="model-title">
-                                            <img src="/static/icons/emotion_model_icon.png"
-                                                data-i18n-alt="api.emotionModelConfig" class="model-title-icon">
-                                            <span data-i18n="api.emotionModelConfig">情感模型配置</span>
-                                        </span>
-                                        <span class="toggle-icon">▼</span>
-                                    </div>
-                                    <div id="emotion-model-content" class="model-content">
-                                        <div class="field-row">
-                                            <label for="emotionModelProvider" data-i18n="api.providerLabel">服务商</label>
-                                            <select id="emotionModelProvider" class="api-provider-select" style="max-width: 600px;">
-                                            </select>
-                                        </div>
-                                        <div class="field-row">
-                                            <label for="emotionModelUrl" data-i18n="api.apiUrl">API URL</label>
-                                            <input type="text" id="emotionModelUrl"
-                                                data-i18n-placeholder="api.baseUrlExamplePlaceholder"
-                                                placeholder="e.g., https://api.openai.com/v1" value=""
-                                                style="max-width: 600px;">
-                                        </div>
-                                        <div class="field-row">
-                                            <label for="emotionModelId" data-i18n="api.modelId">模型ID</label>
-                                            <input type="text" id="emotionModelId"
-                                                data-i18n-placeholder="api.modelExamplePlaceholder"
-                                                placeholder="e.g., gpt-3.5-turbo, qwen-turbo, glm-4-flash" value=""
-                                                style="max-width: 600px;">
-                                        </div>
-                                        <div class="field-row">
-                                            <label for="emotionModelApiKey" data-i18n="api.apiKey">API Key</label>
-                                            <input type="text" id="emotionModelApiKey"
-                                                data-i18n-placeholder="api.emotionModelApiKeyPlaceholder"
-                                                placeholder="Enter Emotion API Key" value=""
-                                                style="max-width: 600px;">
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <!-- 视觉模型配置 -->
+                                <!-- 视觉聊天模型 -->
                                 <div class="model-config-container">
                                     <div class="model-header" onclick="toggleModelConfig('vision')">
                                         <span class="model-title">
                                             <img src="/static/icons/vision_model_icon.png"
                                                 data-i18n-alt="api.visionModelConfig" class="model-title-icon">
-                                            <span data-i18n="api.visionModelConfig">视觉模型配置</span>
+                                            <span data-i18n="api.visionModelConfig">视觉聊天模型</span>
                                         </span>
                                         <span class="toggle-icon">▼</span>
                                     </div>
@@ -581,53 +374,133 @@
                                     </div>
                                 </div>
 
-                                <!-- Agent API 配置 -->
+                                <!-- 摘要模型 -->
                                 <div class="model-config-container">
-                                    <div class="model-header" onclick="toggleModelConfig('agent')">
+                                    <div class="model-header" onclick="toggleModelConfig('summary')">
                                         <span class="model-title">
-                                            <img src="/static/icons/correction_model_icon.png"
-                                                data-i18n-alt="api.agentApiConfigTitle" class="model-title-icon">
-                                            <span data-i18n="api.agentApiConfigTitle">Agent API 配置（需支持视觉功能）</span>
+                                            <img src="/static/icons/summary_model_icon.png"
+                                                data-i18n-alt="api.summaryModelConfig" class="model-title-icon">
+                                            <span data-i18n="api.summaryModelConfig">摘要模型</span>
                                         </span>
                                         <span class="toggle-icon">▼</span>
                                     </div>
-                                    <div id="agent-model-content" class="model-content">
+                                    <div id="summary-model-content" class="model-content">
                                         <div class="field-row">
-                                            <label for="agentModelProvider" data-i18n="api.providerLabel">服务商</label>
-                                            <select id="agentModelProvider" class="api-provider-select" style="max-width: 600px;">
+                                            <label for="summaryModelProvider" data-i18n="api.providerLabel">服务商</label>
+                                            <select id="summaryModelProvider" class="api-provider-select" style="max-width: 600px;">
                                             </select>
                                         </div>
                                         <div class="field-row">
-                                            <label for="agentModelUrl" data-i18n="api.apiUrl">API URL</label>
-                                            <input type="text" id="agentModelUrl"
-                                                data-i18n-placeholder="api.agentModelUrlPlaceholder"
-                                                placeholder="Leave blank to follow Assist API vision model URL"
-                                                value="" style="max-width: 600px;">
+                                            <label for="summaryModelUrl" data-i18n="api.apiUrl">API URL</label>
+                                            <input type="text" id="summaryModelUrl"
+                                                data-i18n-placeholder="api.baseUrlExamplePlaceholder"
+                                                placeholder="e.g., https://api.openai.com/v1" value=""
+                                                style="max-width: 600px;">
                                         </div>
                                         <div class="field-row">
-                                            <label for="agentModelId" data-i18n="api.modelId">模型ID</label>
-                                            <input type="text" id="agentModelId"
-                                                data-i18n-placeholder="api.agentModelIdPlaceholder"
-                                                placeholder="Leave blank to follow Assist API vision model ID"
-                                                value="" style="max-width: 600px;">
+                                            <label for="summaryModelId" data-i18n="api.modelId">模型ID</label>
+                                            <input type="text" id="summaryModelId"
+                                                data-i18n-placeholder="api.modelExamplePlaceholder"
+                                                placeholder="e.g., gpt-3.5-turbo, qwen-turbo, glm-4-flash" value=""
+                                                style="max-width: 600px;">
                                         </div>
                                         <div class="field-row">
-                                            <label for="agentModelApiKey" data-i18n="api.apiKey">API Key</label>
-                                            <input type="text" id="agentModelApiKey"
-                                                data-i18n-placeholder="api.agentModelApiKeyPlaceholder"
-                                                placeholder="Leave blank to follow Assist API Key (not available for 'free')"
-                                                value="" style="max-width: 600px;">
+                                            <label for="summaryModelApiKey" data-i18n="api.apiKey">API Key</label>
+                                            <input type="text" id="summaryModelApiKey"
+                                                data-i18n-placeholder="api.summaryModelApiKeyPlaceholder"
+                                                placeholder="Enter Summary API Key" value=""
+                                                style="max-width: 600px;">
                                         </div>
                                     </div>
                                 </div>
 
-                                <!-- 全模态模型配置 -->
+                                <!-- 纠错模型 -->
+                                <div class="model-config-container">
+                                    <div class="model-header" onclick="toggleModelConfig('correction')">
+                                        <span class="model-title">
+                                            <img src="/static/icons/correction_model_icon.png"
+                                                data-i18n-alt="api.correctionModelConfig" class="model-title-icon">
+                                            <span data-i18n="api.correctionModelConfig">纠错模型</span>
+                                        </span>
+                                        <span class="toggle-icon">▼</span>
+                                    </div>
+                                    <div id="correction-model-content" class="model-content">
+                                        <div class="field-row">
+                                            <label for="correctionModelProvider" data-i18n="api.providerLabel">服务商</label>
+                                            <select id="correctionModelProvider" class="api-provider-select" style="max-width: 600px;">
+                                            </select>
+                                        </div>
+                                        <div class="field-row">
+                                            <label for="correctionModelUrl" data-i18n="api.apiUrl">API URL</label>
+                                            <input type="text" id="correctionModelUrl"
+                                                data-i18n-placeholder="api.baseUrlExamplePlaceholder"
+                                                placeholder="e.g., https://api.openai.com/v1" value=""
+                                                style="max-width: 600px;">
+                                        </div>
+                                        <div class="field-row">
+                                            <label for="correctionModelId" data-i18n="api.modelId">模型ID</label>
+                                            <input type="text" id="correctionModelId"
+                                                data-i18n-placeholder="api.modelExamplePlaceholder"
+                                                placeholder="e.g., gpt-3.5-turbo, qwen-turbo, glm-4-flash" value=""
+                                                style="max-width: 600px;">
+                                        </div>
+                                        <div class="field-row">
+                                            <label for="correctionModelApiKey" data-i18n="api.apiKey">API Key</label>
+                                            <input type="text" id="correctionModelApiKey"
+                                                data-i18n-placeholder="api.correctionModelApiKeyPlaceholder"
+                                                placeholder="Enter Correction API Key" value=""
+                                                style="max-width: 600px;">
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <!-- 情感模型 -->
+                                <div class="model-config-container">
+                                    <div class="model-header" onclick="toggleModelConfig('emotion')">
+                                        <span class="model-title">
+                                            <img src="/static/icons/emotion_model_icon.png"
+                                                data-i18n-alt="api.emotionModelConfig" class="model-title-icon">
+                                            <span data-i18n="api.emotionModelConfig">情感模型</span>
+                                        </span>
+                                        <span class="toggle-icon">▼</span>
+                                    </div>
+                                    <div id="emotion-model-content" class="model-content">
+                                        <div class="field-row">
+                                            <label for="emotionModelProvider" data-i18n="api.providerLabel">服务商</label>
+                                            <select id="emotionModelProvider" class="api-provider-select" style="max-width: 600px;">
+                                            </select>
+                                        </div>
+                                        <div class="field-row">
+                                            <label for="emotionModelUrl" data-i18n="api.apiUrl">API URL</label>
+                                            <input type="text" id="emotionModelUrl"
+                                                data-i18n-placeholder="api.baseUrlExamplePlaceholder"
+                                                placeholder="e.g., https://api.openai.com/v1" value=""
+                                                style="max-width: 600px;">
+                                        </div>
+                                        <div class="field-row">
+                                            <label for="emotionModelId" data-i18n="api.modelId">模型ID</label>
+                                            <input type="text" id="emotionModelId"
+                                                data-i18n-placeholder="api.modelExamplePlaceholder"
+                                                placeholder="e.g., gpt-3.5-turbo, qwen-turbo, glm-4-flash" value=""
+                                                style="max-width: 600px;">
+                                        </div>
+                                        <div class="field-row">
+                                            <label for="emotionModelApiKey" data-i18n="api.apiKey">API Key</label>
+                                            <input type="text" id="emotionModelApiKey"
+                                                data-i18n-placeholder="api.emotionModelApiKeyPlaceholder"
+                                                placeholder="Enter Emotion API Key" value=""
+                                                style="max-width: 600px;">
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <!-- 实时全模态模型 -->
                                 <div class="model-config-container">
                                     <div class="model-header" onclick="toggleModelConfig('omni')">
                                         <span class="model-title">
                                             <img src="/static/icons/omni_model_icon.png"
                                                 data-i18n-alt="api.realtimeModelConfig" class="model-title-icon">
-                                            <span data-i18n="api.realtimeModelConfig">实时模型配置</span>
+                                            <span data-i18n="api.realtimeModelConfig">实时全模态模型（Local模式）</span>
                                         </span>
                                         <span class="toggle-icon">▼</span>
                                     </div>
@@ -662,13 +535,53 @@
                                     </div>
                                 </div>
 
-                                <!-- TTS模型配置 -->
+                                <!-- Agent API -->
+                                <div class="model-config-container">
+                                    <div class="model-header" onclick="toggleModelConfig('agent')">
+                                        <span class="model-title">
+                                            <img src="/static/icons/correction_model_icon.png"
+                                                data-i18n-alt="api.agentApiConfigTitle" class="model-title-icon">
+                                            <span data-i18n="api.agentApiConfigTitle">Agent API（需支持视觉功能）</span>
+                                        </span>
+                                        <span class="toggle-icon">▼</span>
+                                    </div>
+                                    <div id="agent-model-content" class="model-content">
+                                        <div class="field-row">
+                                            <label for="agentModelProvider" data-i18n="api.providerLabel">服务商</label>
+                                            <select id="agentModelProvider" class="api-provider-select" style="max-width: 600px;">
+                                            </select>
+                                        </div>
+                                        <div class="field-row">
+                                            <label for="agentModelUrl" data-i18n="api.apiUrl">API URL</label>
+                                            <input type="text" id="agentModelUrl"
+                                                data-i18n-placeholder="api.agentModelUrlPlaceholder"
+                                                placeholder="Leave blank to follow Assist API vision model URL"
+                                                value="" style="max-width: 600px;">
+                                        </div>
+                                        <div class="field-row">
+                                            <label for="agentModelId" data-i18n="api.modelId">模型ID</label>
+                                            <input type="text" id="agentModelId"
+                                                data-i18n-placeholder="api.agentModelIdPlaceholder"
+                                                placeholder="Leave blank to follow Assist API vision model ID"
+                                                value="" style="max-width: 600px;">
+                                        </div>
+                                        <div class="field-row">
+                                            <label for="agentModelApiKey" data-i18n="api.apiKey">API Key</label>
+                                            <input type="text" id="agentModelApiKey"
+                                                data-i18n-placeholder="api.agentModelApiKeyPlaceholder"
+                                                placeholder="Leave blank to follow Assist API Key (not available for 'free')"
+                                                value="" style="max-width: 600px;">
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <!-- TTS模型 -->
                                 <div class="model-config-container">
                                     <div class="model-header" onclick="toggleModelConfig('tts')">
                                         <span class="model-title">
                                             <img src="/static/icons/tts_model_icon.png"
                                                 data-i18n-alt="api.ttsModelConfig" class="model-title-icon">
-                                            <span data-i18n="api.ttsModelConfig">TTS模型配置</span>
+                                            <span data-i18n="api.ttsModelConfig">TTS模型</span>
                                         </span>
                                         <span class="toggle-icon">▼</span>
                                     </div>
@@ -768,6 +681,93 @@
                                                 </div>
                                             </div>
 
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <!-- 小游戏模型 -->
+                                <div class="model-config-container">
+                                    <button type="button" class="model-header" onclick="toggleModelConfig('game')" aria-expanded="false" aria-controls="game-model-content">
+                                        <span class="model-title">
+                                            <img src="/static/icons/correction_model_icon.png"
+                                                data-i18n-alt="api.gameModelsConfig"
+                                                class="model-title-icon">
+                                            <span data-i18n="api.gameModelsConfig">小游戏模型</span>
+                                        </span>
+                                        <span class="toggle-icon">▼</span>
+                                    </button>
+                                    <div id="game-model-content" class="model-content">
+                                        <div class="nested-model-config-container">
+                                            <button type="button" class="model-header nested-model-header" onclick="toggleModelConfig('game-main')" aria-expanded="false" aria-controls="game-main-model-content">
+                                                <span class="model-title">
+                                                    <span data-i18n="api.gameMainModelConfig">小游戏主模型配置</span>
+                                                </span>
+                                                <span class="toggle-icon">▼</span>
+                                            </button>
+                                            <div id="game-main-model-content" class="model-content nested-model-content">
+                                                <div class="field-row">
+                                                    <label for="gameMainModelProvider" data-i18n="api.providerLabel">服务商</label>
+                                                    <select id="gameMainModelProvider" class="api-provider-select" style="max-width: 600px;">
+                                                    </select>
+                                                </div>
+                                                <div class="field-row">
+                                                    <label for="gameMainModelUrl" data-i18n="api.apiUrl">API URL</label>
+                                                    <input type="text" id="gameMainModelUrl"
+                                                        data-i18n-placeholder="api.baseUrlExamplePlaceholder"
+                                                        placeholder="e.g., https://api.openai.com/v1" value=""
+                                                        style="max-width: 600px;">
+                                                </div>
+                                                <div class="field-row">
+                                                    <label for="gameMainModelId" data-i18n="api.modelId">模型ID</label>
+                                                    <input type="text" id="gameMainModelId"
+                                                        data-i18n-placeholder="api.modelExamplePlaceholder"
+                                                        placeholder="e.g., gpt-3.5-turbo, qwen-turbo, glm-4-flash" value=""
+                                                        style="max-width: 600px;">
+                                                </div>
+                                                <div class="field-row">
+                                                    <label for="gameMainModelApiKey" data-i18n="api.apiKey">API Key</label>
+                                                    <input type="text" id="gameMainModelApiKey"
+                                                        data-i18n-placeholder="api.gameMainModelApiKeyPlaceholder"
+                                                        placeholder="Enter Mini-game Main Model API Key" value=""
+                                                        style="max-width: 600px;">
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="nested-model-config-container">
+                                            <button type="button" class="model-header nested-model-header" onclick="toggleModelConfig('game-summary')" aria-expanded="false" aria-controls="game-summary-model-content">
+                                                <span class="model-title">
+                                                    <span data-i18n="api.gameSummaryModelConfig">小游戏摘要模型配置</span>
+                                                </span>
+                                                <span class="toggle-icon">▼</span>
+                                            </button>
+                                            <div id="game-summary-model-content" class="model-content nested-model-content">
+                                                <div class="field-row">
+                                                    <label for="gameSummaryModelProvider" data-i18n="api.providerLabel">服务商</label>
+                                                    <select id="gameSummaryModelProvider" class="api-provider-select" style="max-width: 600px;">
+                                                    </select>
+                                                </div>
+                                                <div class="field-row">
+                                                    <label for="gameSummaryModelUrl" data-i18n="api.apiUrl">API URL</label>
+                                                    <input type="text" id="gameSummaryModelUrl"
+                                                        data-i18n-placeholder="api.baseUrlExamplePlaceholder"
+                                                        placeholder="e.g., https://api.openai.com/v1" value=""
+                                                        style="max-width: 600px;">
+                                                </div>
+                                                <div class="field-row">
+                                                    <label for="gameSummaryModelId" data-i18n="api.modelId">模型ID</label>
+                                                    <input type="text" id="gameSummaryModelId"
+                                                        data-i18n-placeholder="api.modelExamplePlaceholder"
+                                                        placeholder="e.g., gpt-3.5-turbo, qwen-turbo, glm-4-flash" value=""
+                                                        style="max-width: 600px;">
+                                                </div>
+                                                <div class="field-row">
+                                                    <label for="gameSummaryModelApiKey" data-i18n="api.apiKey">API Key</label>
+                                                    <input type="text" id="gameSummaryModelApiKey"
+                                                        data-i18n-placeholder="api.gameSummaryModelApiKeyPlaceholder"
+                                                        placeholder="Enter Mini-game Summary Model API Key" value=""
+                                                        style="max-width: 600px;">
+                                                </div>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>

--- a/templates/api_key_settings.html
+++ b/templates/api_key_settings.html
@@ -511,7 +511,7 @@
                                             </select>
                                         </div>
                                         <div class="field-row">
-                                            <label for="omniModelUrl">API URL<em
+                                            <label for="omniModelUrl"><span data-i18n="api.apiUrl">API URL</span><em
                                                     data-i18n="api.omniApiUrlNote">（必须是WebSocket地址，以ws://或wss://开头）</em></label>
                                             <input type="text" id="omniModelUrl"
                                                 data-i18n-placeholder="api.realtimeWsUrlExamplePlaceholder"

--- a/tests/frontend/test_api_settings.py
+++ b/tests/frontend/test_api_settings.py
@@ -79,7 +79,7 @@ def test_custom_model_headers_own_their_capsule_shape(mock_page: Page, running_s
     styles = mock_page.evaluate("""
         () => {
             document.getElementById('custom-api-options').style.display = 'block';
-            document.getElementById('custom-api-container').style.display = 'block';
+            document.getElementById('custom-api-container').style.display = 'grid';
             const container = document.querySelector('.model-config-container');
             const header = container.querySelector(':scope > .model-header');
 
@@ -122,10 +122,247 @@ def test_custom_model_headers_own_their_capsule_shape(mock_page: Page, running_s
     """)
 
     assert expanded_styles == {
-        "borderWidth": "1px",
+        "borderWidth": "3px",
         "borderRadius": "24px",
         "marginTop": "8px",
     }
+
+
+@pytest.mark.frontend
+def test_custom_model_grid_uses_two_columns_and_full_width_expansion(
+    mock_page: Page, running_server: str
+):
+    """Every desktop card uses the same two-column grid while expanded content uses full width."""
+    mock_page.set_viewport_size({"width": 1280, "height": 1000})
+    mock_page.add_init_script("window.localStorage.setItem('neko_tutorial_settings', 'seen')")
+    mock_page.goto(f"{running_server}/api_key")
+
+    expect(mock_page.locator("#loading-overlay")).to_be_hidden(timeout=10000)
+    mock_page.evaluate("""() => {
+        const enableCustomApi = document.getElementById('enableCustomApi');
+        enableCustomApi.checked = true;
+        enableCustomApi.dispatchEvent(new Event('change', { bubbles: true }));
+        document.getElementById('custom-api-options').style.display = 'block';
+    }""")
+
+    desktop = mock_page.evaluate("""() => {
+        const grid = document.getElementById('custom-api-container');
+        const cards = Array.from(grid.querySelectorAll(':scope > .model-config-container'));
+        const rect = element => {
+            const box = element.getBoundingClientRect();
+            return {
+                left: Math.round(box.left),
+                top: Math.round(box.top),
+                width: Math.round(box.width),
+            };
+        };
+
+        return {
+            display: getComputedStyle(grid).display,
+            columns: getComputedStyle(grid).gridTemplateColumns.split(' ').length,
+            grid: rect(grid),
+            conversation: rect(cards[0]),
+            summary: rect(cards[1]),
+            game: rect(cards[2]),
+            correction: rect(cards[3]),
+            emotion: rect(cards[4]),
+            vision: rect(cards[5]),
+        };
+    }""")
+
+    assert desktop["display"] == "grid"
+    assert desktop["columns"] == 2
+    assert desktop["conversation"]["top"] == desktop["summary"]["top"]
+    assert desktop["conversation"]["left"] < desktop["summary"]["left"]
+    assert abs(desktop["conversation"]["width"] - desktop["summary"]["width"]) <= 1
+    assert desktop["game"]["top"] == desktop["correction"]["top"]
+    assert desktop["game"]["left"] < desktop["correction"]["left"]
+    assert abs(desktop["game"]["width"] - desktop["correction"]["width"]) <= 1
+    assert desktop["emotion"]["top"] == desktop["vision"]["top"]
+
+    mock_page.evaluate("toggleModelConfig('conversation')")
+    mock_page.wait_for_timeout(350)
+
+    expanded = mock_page.evaluate("""() => {
+        const grid = document.getElementById('custom-api-container').getBoundingClientRect();
+        const content = document.getElementById('conversation-model-content');
+        const card = content.closest('.model-config-container').getBoundingClientRect();
+        const summary = document.getElementById('summary-model-content')
+            .closest('.model-config-container').getBoundingClientRect();
+        const contentRect = content.getBoundingClientRect();
+        const header = content.previousElementSibling;
+        const summaryHeader = document.getElementById('summary-model-content').previousElementSibling;
+        const gameHeader = document.getElementById('game-model-content').previousElementSibling;
+        const headerStyle = getComputedStyle(header);
+        return {
+            cardWidth: Math.round(card.width),
+            gridWidth: Math.round(grid.width),
+            contentLeft: Math.round(contentRect.left),
+            contentWidth: Math.round(contentRect.width),
+            gridLeft: Math.round(grid.left),
+            cardTop: Math.round(card.top),
+            summaryTop: Math.round(summary.top),
+            labelCount: content.querySelectorAll(':scope > .model-content-label').length,
+            headerExpanded: header?.getAttribute('aria-expanded'),
+            headerShadow: headerStyle.boxShadow,
+            headerOpacity: headerStyle.opacity,
+            headerTransform: headerStyle.transform,
+            headerBackground: headerStyle.backgroundImage,
+            summaryOpacity: getComputedStyle(summaryHeader).opacity,
+            gameOpacity: getComputedStyle(gameHeader).opacity,
+            contentBorderTopWidth: getComputedStyle(content).borderTopWidth,
+            contentBorderTopColor: getComputedStyle(content).borderTopColor,
+        };
+    }""")
+
+    assert abs(expanded["cardWidth"] - desktop["conversation"]["width"]) <= 1
+    assert abs(expanded["contentWidth"] - expanded["gridWidth"]) <= 1
+    assert abs(expanded["contentLeft"] - expanded["gridLeft"]) <= 1
+    assert expanded["cardTop"] == expanded["summaryTop"]
+    assert expanded["labelCount"] == 0
+    assert expanded["headerExpanded"] == "true"
+    assert expanded["headerShadow"] != "none"
+    assert expanded["headerOpacity"] == "1"
+    assert expanded["headerTransform"] != "none"
+    assert "linear-gradient" in expanded["headerBackground"]
+    assert float(expanded["summaryOpacity"]) < 1
+    assert expanded["gameOpacity"] == "1"
+    assert expanded["contentBorderTopWidth"] == "3px"
+    assert expanded["contentBorderTopColor"] == "rgb(64, 197, 241)"
+
+    mock_page.evaluate("""() => {
+        toggleModelConfig('conversation');
+        toggleModelConfig('summary');
+    }""")
+    mock_page.wait_for_timeout(650)
+
+    right_expanded = mock_page.evaluate("""() => {
+        const grid = document.getElementById('custom-api-container').getBoundingClientRect();
+        const content = document.getElementById('summary-model-content').getBoundingClientRect();
+        return {
+            gridLeft: Math.round(grid.left),
+            gridWidth: Math.round(grid.width),
+            contentLeft: Math.round(content.left),
+            contentWidth: Math.round(content.width),
+        };
+    }""")
+
+    assert abs(right_expanded["contentLeft"] - right_expanded["gridLeft"]) <= 1
+    assert abs(right_expanded["contentWidth"] - right_expanded["gridWidth"]) <= 1
+
+    mock_page.evaluate("toggleModelConfig('conversation')")
+    mock_page.wait_for_timeout(350)
+    paired_expansion = mock_page.evaluate("""() => {
+        const left = document.getElementById('conversation-model-content').getBoundingClientRect();
+        const right = document.getElementById('summary-model-content').getBoundingClientRect();
+        return {
+            leftWidth: Math.round(left.width),
+            leftRight: Math.round(left.right),
+            rightLeft: Math.round(right.left),
+            rightWidth: Math.round(right.width),
+        };
+    }""")
+
+    assert abs(paired_expansion["leftWidth"] - desktop["conversation"]["width"]) <= 1
+    assert abs(paired_expansion["rightWidth"] - desktop["summary"]["width"]) <= 1
+    assert paired_expansion["leftRight"] < paired_expansion["rightLeft"]
+
+    mock_page.evaluate("toggleModelConfig('conversation')")
+    mock_page.wait_for_timeout(80)
+    collapsing_pair = mock_page.evaluate("""() => {
+        const left = document.getElementById('conversation-model-content');
+        const right = document.getElementById('summary-model-content');
+        const leftRect = left.getBoundingClientRect();
+        const rightRect = right.getBoundingClientRect();
+        return {
+            leftHeight: Math.round(leftRect.height),
+            leftRight: Math.round(leftRect.right),
+            rightLeft: Math.round(rightRect.left),
+            isCollapsing: left.classList.contains('is-collapsing'),
+            rightWidth: Math.round(rightRect.width),
+        };
+    }""")
+
+    assert collapsing_pair["leftHeight"] > 0
+    assert collapsing_pair["isCollapsing"] is True
+    assert collapsing_pair["leftRight"] < collapsing_pair["rightLeft"]
+    assert abs(collapsing_pair["rightWidth"] - desktop["summary"]["width"]) <= 1
+
+    mock_page.wait_for_timeout(600)
+    settled_pair = mock_page.evaluate("""() => {
+        const grid = document.getElementById('custom-api-container').getBoundingClientRect();
+        const left = document.getElementById('conversation-model-content');
+        const right = document.getElementById('summary-model-content');
+        const rightRect = right.getBoundingClientRect();
+        return {
+            gridLeft: Math.round(grid.left),
+            gridWidth: Math.round(grid.width),
+            leftHeight: Math.round(left.getBoundingClientRect().height),
+            isCollapsing: left.classList.contains('is-collapsing'),
+            isReflowing: right.classList.contains('is-reflowing'),
+            rightLeft: Math.round(rightRect.left),
+            rightWidth: Math.round(rightRect.width),
+        };
+    }""")
+
+    assert settled_pair["leftHeight"] == 0
+    assert settled_pair["isCollapsing"] is False
+    assert settled_pair["isReflowing"] is False
+    assert abs(settled_pair["rightLeft"] - settled_pair["gridLeft"]) <= 1
+    assert abs(settled_pair["rightWidth"] - settled_pair["gridWidth"]) <= 1
+
+    mock_page.set_viewport_size({"width": 760, "height": 1000})
+    mobile = mock_page.evaluate("""() => {
+        const grid = document.getElementById('custom-api-container');
+        const cards = Array.from(grid.querySelectorAll(':scope > .model-config-container'));
+        const first = cards[0].getBoundingClientRect();
+        const second = cards[1].getBoundingClientRect();
+        return {
+            columns: getComputedStyle(grid).gridTemplateColumns.split(' ').length,
+            gridWidth: Math.round(grid.getBoundingClientRect().width),
+            firstWidth: Math.round(first.width),
+            firstTop: Math.round(first.top),
+            secondTop: Math.round(second.top),
+        };
+    }""")
+
+    assert mobile["columns"] == 1
+    assert abs(mobile["firstWidth"] - mobile["gridWidth"]) <= 1
+    assert mobile["secondTop"] > mobile["firstTop"]
+
+
+@pytest.mark.frontend
+def test_nested_game_headers_skip_top_level_active_highlight(
+    mock_page: Page, running_server: str
+):
+    """Nested mini-game panels should not inherit the top-level selected treatment."""
+    mock_page.goto(f"{running_server}/api_key")
+    expect(mock_page.locator("#loading-overlay")).to_be_hidden(timeout=10000)
+    mock_page.evaluate("""() => {
+        const enableCustomApi = document.getElementById('enableCustomApi');
+        enableCustomApi.checked = true;
+        enableCustomApi.dispatchEvent(new Event('change', { bubbles: true }));
+        document.getElementById('custom-api-options').style.display = 'block';
+        toggleModelConfig('game');
+        toggleModelConfig('game-main');
+    }""")
+    mock_page.wait_for_timeout(350)
+
+    styles = mock_page.evaluate("""() => {
+        const topLevel = document.getElementById('game-model-content').previousElementSibling;
+        const nested = document.getElementById('game-main-model-content').previousElementSibling;
+        const topLevelStyle = getComputedStyle(topLevel);
+        const nestedStyle = getComputedStyle(nested);
+        return {
+            topLevelShadow: topLevelStyle.boxShadow,
+            nestedShadow: nestedStyle.boxShadow,
+            nestedTransform: nestedStyle.transform,
+        };
+    }""")
+
+    assert styles["topLevelShadow"] != "none"
+    assert styles["nestedShadow"] == "none"
+    assert styles["nestedTransform"] == "none"
 
 
 @pytest.mark.frontend
@@ -192,6 +429,47 @@ def test_key_book_shortcut_centers_and_selects_provider_input(
         "selectionStart": 0,
         "selectionEnd": len("sk-qwen-shortcut-test"),
     }
+
+
+@pytest.mark.frontend
+def test_realtime_key_book_shortcut_stays_in_api_key_row(
+    mock_page: Page, running_server: str
+):
+    """Realtime's key-book shortcut should share the light/input flex row."""
+    mock_page.set_viewport_size({"width": 1280, "height": 1000})
+    mock_page.add_init_script("window.localStorage.setItem('neko_tutorial_settings', 'seen')")
+    mock_page.goto(f"{running_server}/api_key")
+
+    expect(mock_page.locator("#loading-overlay")).to_be_hidden(timeout=10000)
+    mock_page.evaluate("""() => {
+        const enableCustomApi = document.getElementById('enableCustomApi');
+        enableCustomApi.checked = true;
+        enableCustomApi.dispatchEvent(new Event('change', { bubbles: true }));
+        document.getElementById('custom-api-options').style.display = 'block';
+        toggleModelConfig('omni');
+    }""")
+    mock_page.wait_for_timeout(350)
+
+    state = mock_page.evaluate("""() => {
+        const input = document.getElementById('omniModelApiKey');
+        const row = input.parentElement;
+        const shortcut = document.querySelector(
+            '#omni-model-content .key-book-shortcut'
+        );
+        const inputBox = input.getBoundingClientRect();
+        const shortcutBox = shortcut.getBoundingClientRect();
+
+        return {
+            rowClass: row.className,
+            shortcutSharesRow: shortcut.parentElement === row,
+            inputCenter: Math.round(inputBox.top + inputBox.height / 2),
+            shortcutCenter: Math.round(shortcutBox.top + shortcutBox.height / 2),
+        };
+    }""")
+
+    assert state["rowClass"] == "connectivity-input-row"
+    assert state["shortcutSharesRow"] is True
+    assert abs(state["inputCenter"] - state["shortcutCenter"]) <= 1
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_api_settings.py
+++ b/tests/frontend/test_api_settings.py
@@ -490,7 +490,7 @@ def test_key_book_shortcut_centers_and_selects_provider_input(
 def test_realtime_key_book_shortcut_stays_in_api_key_row(
     mock_page: Page, running_server: str
 ):
-    """Realtime's key-book shortcut should share the light/input flex row."""
+    """Realtime fields keep their localized label and aligned key-book shortcut."""
     mock_page.set_viewport_size({"width": 1280, "height": 1000})
     mock_page.add_init_script("window.localStorage.setItem('neko_tutorial_settings', 'seen')")
     mock_page.goto(f"{running_server}/api_key")
@@ -519,12 +519,16 @@ def test_realtime_key_book_shortcut_stays_in_api_key_row(
             shortcutSharesRow: shortcut.parentElement === row,
             inputCenter: Math.round(inputBox.top + inputBox.height / 2),
             shortcutCenter: Math.round(shortcutBox.top + shortcutBox.height / 2),
+            urlLabelKey: document.querySelector(
+                'label[for="omniModelUrl"] [data-i18n]'
+            )?.dataset.i18n,
         };
     }""")
 
     assert state["rowClass"] == "connectivity-input-row"
     assert state["shortcutSharesRow"] is True
     assert abs(state["inputCenter"] - state["shortcutCenter"]) <= 1
+    assert state["urlLabelKey"] == "api.apiUrl"
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_api_settings.py
+++ b/tests/frontend/test_api_settings.py
@@ -132,7 +132,7 @@ def test_custom_model_headers_own_their_capsule_shape(mock_page: Page, running_s
 def test_custom_model_grid_uses_two_columns_and_full_width_expansion(
     mock_page: Page, running_server: str
 ):
-    """Every desktop card uses the same two-column grid while expanded content uses full width."""
+    """Cards follow the requested order and retain their paired two-column behavior."""
     mock_page.set_viewport_size({"width": 1280, "height": 1000})
     mock_page.add_init_script("window.localStorage.setItem('neko_tutorial_settings', 'seen')")
     mock_page.goto(f"{running_server}/api_key")
@@ -161,24 +161,79 @@ def test_custom_model_grid_uses_two_columns_and_full_width_expansion(
             display: getComputedStyle(grid).display,
             columns: getComputedStyle(grid).gridTemplateColumns.split(' ').length,
             grid: rect(grid),
+            contentIds: cards.map(card => card.querySelector(':scope > .model-content')?.id),
+            titleKeys: cards.map(card => card.querySelector(':scope > .model-header [data-i18n]')?.dataset.i18n),
+            summaryTypes: Array.from(document.querySelectorAll(
+                '#customApiSummaryLights .connectivity-summary-light'
+            )).map(light => light.dataset.modelType),
+            rowPairs: { ...MODEL_CONFIG_ROW_PAIRS },
             conversation: rect(cards[0]),
-            summary: rect(cards[1]),
-            game: rect(cards[2]),
+            vision: rect(cards[1]),
+            summary: rect(cards[2]),
             correction: rect(cards[3]),
             emotion: rect(cards[4]),
-            vision: rect(cards[5]),
+            omni: rect(cards[5]),
+            agent: rect(cards[6]),
+            tts: rect(cards[7]),
+            game: rect(cards[8]),
         };
     }""")
 
     assert desktop["display"] == "grid"
     assert desktop["columns"] == 2
-    assert desktop["conversation"]["top"] == desktop["summary"]["top"]
-    assert desktop["conversation"]["left"] < desktop["summary"]["left"]
-    assert abs(desktop["conversation"]["width"] - desktop["summary"]["width"]) <= 1
-    assert desktop["game"]["top"] == desktop["correction"]["top"]
-    assert desktop["game"]["left"] < desktop["correction"]["left"]
-    assert abs(desktop["game"]["width"] - desktop["correction"]["width"]) <= 1
-    assert desktop["emotion"]["top"] == desktop["vision"]["top"]
+    assert desktop["contentIds"] == [
+        "conversation-model-content",
+        "vision-model-content",
+        "summary-model-content",
+        "correction-model-content",
+        "emotion-model-content",
+        "omni-model-content",
+        "agent-model-content",
+        "tts-model-content",
+        "game-model-content",
+    ]
+    assert desktop["titleKeys"] == [
+        "api.conversationModelConfig",
+        "api.visionModelConfig",
+        "api.summaryModelConfig",
+        "api.correctionModelConfig",
+        "api.emotionModelConfig",
+        "api.realtimeModelConfig",
+        "api.agentApiConfigTitle",
+        "api.ttsModelConfig",
+        "api.gameModelsConfig",
+    ]
+    assert desktop["summaryTypes"] == [
+        "conversation",
+        "vision",
+        "summary",
+        "correction",
+        "emotion",
+        "omni",
+        "agent",
+        "tts",
+        "gameMain",
+        "gameSummary",
+    ]
+    assert desktop["rowPairs"] == {
+        "conversation": "vision",
+        "vision": "conversation",
+        "summary": "correction",
+        "correction": "summary",
+        "emotion": "omni",
+        "omni": "emotion",
+        "agent": "tts",
+        "tts": "agent",
+    }
+    assert desktop["conversation"]["top"] == desktop["vision"]["top"]
+    assert desktop["conversation"]["left"] < desktop["vision"]["left"]
+    assert abs(desktop["conversation"]["width"] - desktop["vision"]["width"]) <= 1
+    assert desktop["summary"]["top"] == desktop["correction"]["top"]
+    assert desktop["summary"]["left"] < desktop["correction"]["left"]
+    assert abs(desktop["summary"]["width"] - desktop["correction"]["width"]) <= 1
+    assert desktop["emotion"]["top"] == desktop["omni"]["top"]
+    assert desktop["agent"]["top"] == desktop["tts"]["top"]
+    assert desktop["game"]["top"] > desktop["agent"]["top"]
 
     mock_page.evaluate("toggleModelConfig('conversation')")
     mock_page.wait_for_timeout(350)
@@ -187,12 +242,12 @@ def test_custom_model_grid_uses_two_columns_and_full_width_expansion(
         const grid = document.getElementById('custom-api-container').getBoundingClientRect();
         const content = document.getElementById('conversation-model-content');
         const card = content.closest('.model-config-container').getBoundingClientRect();
-        const summary = document.getElementById('summary-model-content')
+        const partner = document.getElementById('vision-model-content')
             .closest('.model-config-container').getBoundingClientRect();
         const contentRect = content.getBoundingClientRect();
         const header = content.previousElementSibling;
+        const partnerHeader = document.getElementById('vision-model-content').previousElementSibling;
         const summaryHeader = document.getElementById('summary-model-content').previousElementSibling;
-        const gameHeader = document.getElementById('game-model-content').previousElementSibling;
         const headerStyle = getComputedStyle(header);
         return {
             cardWidth: Math.round(card.width),
@@ -201,15 +256,15 @@ def test_custom_model_grid_uses_two_columns_and_full_width_expansion(
             contentWidth: Math.round(contentRect.width),
             gridLeft: Math.round(grid.left),
             cardTop: Math.round(card.top),
-            summaryTop: Math.round(summary.top),
+            partnerTop: Math.round(partner.top),
             labelCount: content.querySelectorAll(':scope > .model-content-label').length,
             headerExpanded: header?.getAttribute('aria-expanded'),
             headerShadow: headerStyle.boxShadow,
             headerOpacity: headerStyle.opacity,
             headerTransform: headerStyle.transform,
             headerBackground: headerStyle.backgroundImage,
+            partnerOpacity: getComputedStyle(partnerHeader).opacity,
             summaryOpacity: getComputedStyle(summaryHeader).opacity,
-            gameOpacity: getComputedStyle(gameHeader).opacity,
             contentBorderTopWidth: getComputedStyle(content).borderTopWidth,
             contentBorderTopColor: getComputedStyle(content).borderTopColor,
         };
@@ -218,27 +273,27 @@ def test_custom_model_grid_uses_two_columns_and_full_width_expansion(
     assert abs(expanded["cardWidth"] - desktop["conversation"]["width"]) <= 1
     assert abs(expanded["contentWidth"] - expanded["gridWidth"]) <= 1
     assert abs(expanded["contentLeft"] - expanded["gridLeft"]) <= 1
-    assert expanded["cardTop"] == expanded["summaryTop"]
+    assert expanded["cardTop"] == expanded["partnerTop"]
     assert expanded["labelCount"] == 0
     assert expanded["headerExpanded"] == "true"
     assert expanded["headerShadow"] != "none"
     assert expanded["headerOpacity"] == "1"
     assert expanded["headerTransform"] != "none"
     assert "linear-gradient" in expanded["headerBackground"]
-    assert float(expanded["summaryOpacity"]) < 1
-    assert expanded["gameOpacity"] == "1"
+    assert float(expanded["partnerOpacity"]) < 1
+    assert expanded["summaryOpacity"] == "1"
     assert expanded["contentBorderTopWidth"] == "3px"
     assert expanded["contentBorderTopColor"] == "rgb(64, 197, 241)"
 
     mock_page.evaluate("""() => {
         toggleModelConfig('conversation');
-        toggleModelConfig('summary');
+        toggleModelConfig('vision');
     }""")
     mock_page.wait_for_timeout(650)
 
     right_expanded = mock_page.evaluate("""() => {
         const grid = document.getElementById('custom-api-container').getBoundingClientRect();
-        const content = document.getElementById('summary-model-content').getBoundingClientRect();
+        const content = document.getElementById('vision-model-content').getBoundingClientRect();
         return {
             gridLeft: Math.round(grid.left),
             gridWidth: Math.round(grid.width),
@@ -254,7 +309,7 @@ def test_custom_model_grid_uses_two_columns_and_full_width_expansion(
     mock_page.wait_for_timeout(350)
     paired_expansion = mock_page.evaluate("""() => {
         const left = document.getElementById('conversation-model-content').getBoundingClientRect();
-        const right = document.getElementById('summary-model-content').getBoundingClientRect();
+        const right = document.getElementById('vision-model-content').getBoundingClientRect();
         return {
             leftWidth: Math.round(left.width),
             leftRight: Math.round(left.right),
@@ -264,14 +319,14 @@ def test_custom_model_grid_uses_two_columns_and_full_width_expansion(
     }""")
 
     assert abs(paired_expansion["leftWidth"] - desktop["conversation"]["width"]) <= 1
-    assert abs(paired_expansion["rightWidth"] - desktop["summary"]["width"]) <= 1
+    assert abs(paired_expansion["rightWidth"] - desktop["vision"]["width"]) <= 1
     assert paired_expansion["leftRight"] < paired_expansion["rightLeft"]
 
     mock_page.evaluate("toggleModelConfig('conversation')")
     mock_page.wait_for_timeout(80)
     collapsing_pair = mock_page.evaluate("""() => {
         const left = document.getElementById('conversation-model-content');
-        const right = document.getElementById('summary-model-content');
+        const right = document.getElementById('vision-model-content');
         const leftRect = left.getBoundingClientRect();
         const rightRect = right.getBoundingClientRect();
         return {
@@ -286,13 +341,13 @@ def test_custom_model_grid_uses_two_columns_and_full_width_expansion(
     assert collapsing_pair["leftHeight"] > 0
     assert collapsing_pair["isCollapsing"] is True
     assert collapsing_pair["leftRight"] < collapsing_pair["rightLeft"]
-    assert abs(collapsing_pair["rightWidth"] - desktop["summary"]["width"]) <= 1
+    assert abs(collapsing_pair["rightWidth"] - desktop["vision"]["width"]) <= 1
 
     mock_page.wait_for_timeout(600)
     settled_pair = mock_page.evaluate("""() => {
         const grid = document.getElementById('custom-api-container').getBoundingClientRect();
         const left = document.getElementById('conversation-model-content');
-        const right = document.getElementById('summary-model-content');
+        const right = document.getElementById('vision-model-content');
         const rightRect = right.getBoundingClientRect();
         return {
             gridLeft: Math.round(grid.left),

--- a/tests/frontend/test_connectivity_lights.py
+++ b/tests/frontend/test_connectivity_lights.py
@@ -300,7 +300,7 @@ def test_custom_api_test_button(mock_page: Page, running_server: str):
         const summaryLight = document.querySelector('.connectivity-summary-light[data-model-type="conversation"]');
         const coreInput = document.getElementById('apiKeyInput');
         const coreLight = coreInput?.closest('.connectivity-input-row')?.querySelector('.connectivity-light');
-        const label = window.t ? window.t('api.conversationModelConfig', '文本对话模型配置') : '文本对话模型配置';
+        const label = window.t ? window.t('api.conversationModelConfig', '文本聊天模型') : '文本聊天模型';
         const status = window.t ? window.t('connectivity.status.connected', '已连通') : '已连通';
         const modelIdLabel = window.t ? window.t('api.modelId', '模型ID') : '模型ID';
         return {


### PR DESCRIPTION
将自定义 API 配置调整为双列布局，优化面板展开补位动画与选中反馈，并统一实时模型管理簿入口的行内对齐

<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

将自定义 API 配置调整为双列布局，优化面板展开补位动画与选中反馈，并统一实时模型管理簿入口的行内对齐

[关于UI/UX的一些探讨](https://github.com/Project-N-E-K-O/N.E.K.O/issues/2414)

## 测试 / Testing

手动测试自定义 API UI 布局

## 对比

- 修改之前：
<img width="1240" height="940" alt="image" src="https://github.com/user-attachments/assets/5a24547f-7e3d-4648-9a1d-5999288eafbd" />
<img width="1240" height="940" alt="image" src="https://github.com/user-attachments/assets/fa235c3a-496d-48d3-961c-05ca9adfb31d" />

- 修改之后：
<img width="1240" height="940" alt="image" src="https://github.com/user-attachments/assets/f233773e-de26-45a0-9651-ad3690e025b5" />
<img width="1240" height="940" alt="image" src="https://github.com/user-attachments/assets/479ec630-4a61-4145-bcb9-cc1eb385c239" />
<img width="1240" height="940" alt="image" src="https://github.com/user-attachments/assets/0776e1b1-8e20-49f2-bf6a-2526921f4fa9" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 自定义 API 配置区域采用更清晰的网格布局：桌面端双列展示，移动端自动单列；展开态占满对应卡片全宽。
- **体验优化**
  - 优化模型配置折叠/展开与连续切换时的动画与重排稳定性，强化展开态的背景、边框与阴影反馈。
  - 连通性测试按钮与输入行对齐更准确，快捷按钮始终留在同一行；深色模式下展开高亮更一致。
- **本地化**
  - 多语言界面文案精简更新，并在实时全模态模型处补充 WebSocket（ws/wss）提示。
- **测试**
  - 更新并新增前端 UI 用例覆盖网格展开、重排状态与快捷按钮对齐场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->