### PR TITLE
Phase 4C-C：建立仅内存的 Speaker Reference / Profile 合同

### DIFF
--- a/docs/design/speaker-reference-profile.md
+++ b/docs/design/speaker-reference-profile.md
@@ -1,0 +1,73 @@
+# Phase 4C-C：仅内存 Speaker Reference / Profile
+
+## 目标
+
+本阶段只建立 provider-neutral 的模型身份、说话人参考向量和 Profile 生命周期。
+它不进行 Enrollment 计算，不加载具体模型，不持久化数据，也不接入 ASR、Core、
+API 或 UI。
+
+## 依赖方向
+
+```text
+voice_identity.profile
+  -> voice_identity.reference
+      -> voice_identity.contracts
+```
+
+`contracts.py` 只包含不可变的 `SpeakerModelIdentity`；`reference.py` 是本阶段
+唯一允许导入 NumPy 的领域模块。包初始化文件只保留 docstring，因此
+`import main_logic.voice_identity` 不会触发 NumPy、模型或运行时导入。
+
+领域模块不得依赖 `asr_client`、Core、Voice Turn、router、app、ONNX Runtime、
+keyring 或 cryptography。ASR、Core 和 Voice Turn 可以作为外层消费者依赖本包；
+本包不得反向依赖这些运行时层。
+
+`scripts/check_core_contracts.py` 是针对可静态解析 import/call 的结构性工程门禁，
+用于阻止意外依赖和越层调用；它不承担 Python 运行时隔离，也不枚举反射或刻意混淆
+写法。仓库内代码仍以可信提交和代码审查作为边界。
+
+## 数据合同
+
+`SpeakerModelIdentity` 由调用方提供非空 model ID、非空 model revision 和正整数
+embedding dimension。它不持有模型实例、资产路径或下载能力。
+
+`SpeakerReference` 在构造时创建独占、C-contiguous 的一维 `float32` 副本，
+验证维度、finite 和非零范数后执行 L2 normalization。调用方随后修改原数组不会
+影响内部状态。内部 embedding backing storage 没有公开属性、JSON 表示或普通读取
+接口。
+
+需要消费向量的可信内部 adapter 只能调用 `copy_embedding()`，取得独立且由调用方
+拥有的副本。调用方负责该副本的生命周期，并在使用后通过 `fill(0.0)` 尽力清零；
+修改或清零导出副本不会影响 Reference 内部状态。该能力不是面向产品、网络或插件的
+raw embedding 接口。
+
+本合同以仓库内第一方调用者可信为前提，不防御恶意进程内代码、插件或 native
+extension。任何能够持有 Reference 的恶意代码本就可以复制、持久化或发送数据；
+需要隔离不可信代码时必须使用独立进程。`clone()` 创建独立所有权，关闭任一实例不会
+影响其他 clone。
+
+`SpeakerProfile` 接收调用方分配的非空 opaque generation，不解释顺序，也不分配、
+回退或持久化 generation。构造时它 clone 输入 Reference，从而拥有独立副本；
+外部只能取得新的 Reference clone，不能访问 Profile 内部实例。
+
+## 生命周期与隐私
+
+Reference 与 Profile 都提供幂等 `close()`。Reference 关闭时清零内部 embedding；
+Profile 关闭时级联关闭其内部 Reference。关闭后除 `closed` 和安全 `repr` 外的使用
+操作都会失败。调用方必须显式调用 `close()`；合同不依赖析构器或 GC 执行清理。
+异常和 repr 不包含 embedding。
+
+显式清零是 best-effort：Python、NumPy 或底层分配器仍可能保留不可寻址的历史
+副本，因此本合同不宣称提供进程内的密码学擦除保证，也不构成 Python 沙箱。
+
+## 明确不包含
+
+- Enrollment service/session、TTL、PCM 或 verification threshold；
+- CAM++ adapter、模型资产、产品/模型工作线程或子进程；
+- ProfileStore、keyring、AES-GCM、文件或数据库；
+- registry、service locator、manager fan-out activation；
+- Core composition、麦克风 gate、runtime hot swap；
+- raw embedding/similarity 产品接口、API、router 或 UI。
+
+这些能力必须按 Enrollment compute、CAM++ worker、持久化、app-owned service、
+session-start composition 和 UI 的顺序分别评审与交付。

--- a/main_logic/voice_identity/__init__.py
+++ b/main_logic/voice_identity/__init__.py
@@ -1,0 +1,1 @@
+"""Provider-neutral, in-memory speaker identity contracts."""

--- a/main_logic/voice_identity/contracts.py
+++ b/main_logic/voice_identity/contracts.py
@@ -1,0 +1,25 @@
+"""Provider-neutral model identity contracts for speaker references."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class SpeakerModelIdentity:
+    """Immutable identity and output shape of an embedding model."""
+
+    model_id: str
+    model_revision: str
+    embedding_dimension: int
+
+    def __post_init__(self) -> None:
+        if type(self.model_id) is not str or not self.model_id.strip():
+            raise ValueError("model_id must be a non-empty string")
+        if type(self.model_revision) is not str or not self.model_revision.strip():
+            raise ValueError("model_revision must be a non-empty string")
+        if (
+            type(self.embedding_dimension) is not int
+            or self.embedding_dimension <= 0
+        ):
+            raise ValueError("embedding_dimension must be a positive integer")

--- a/main_logic/voice_identity/profile.py
+++ b/main_logic/voice_identity/profile.py
@@ -1,0 +1,99 @@
+"""In-memory speaker profiles with explicit reference ownership."""
+
+from __future__ import annotations
+
+import threading
+
+from .contracts import SpeakerModelIdentity
+from .reference import SpeakerReference
+
+
+class SpeakerProfile:
+    """Own a reference clone under a caller-supplied opaque generation."""
+
+    __slots__ = ("_closed", "_generation", "_lock", "_reference")
+
+    def __init__(self, generation: str, reference: SpeakerReference) -> None:
+        if type(generation) is not str or not generation.strip():
+            raise ValueError("generation must be a non-empty string")
+        if type(reference) is not SpeakerReference:
+            raise TypeError("reference must be SpeakerReference")
+
+        self._generation = generation
+        self._lock = threading.Lock()
+        self._closed = False
+        cloned_reference: SpeakerReference | None = None
+        try:
+            cloned_reference = reference.clone()
+            self._reference = cloned_reference
+            return
+        except BaseException:
+            if cloned_reference is not None:
+                cloned_reference.close()
+            raise
+
+    @property
+    def closed(self) -> bool:
+        with self._lock:
+            return self._closed
+
+    @property
+    def generation(self) -> str:
+        with self._lock:
+            self._require_open()
+            return self._generation
+
+    @property
+    def model_identity(self) -> SpeakerModelIdentity:
+        with self._lock:
+            self._require_open()
+            return self._reference.model_identity
+
+    def clone_reference(self) -> SpeakerReference:
+        with self._lock:
+            self._require_open()
+            return self._reference.clone()
+
+    def __copy__(self) -> SpeakerProfile:
+        return self._clone()
+
+    def __deepcopy__(self, memo: dict[int, object]) -> SpeakerProfile:
+        del memo
+        return self._clone()
+
+    def close(self) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            try:
+                self._reference.close()
+                self._closed = True
+            except BaseException:
+                if self._reference.closed:
+                    self._closed = True
+                raise
+
+    def __repr__(self) -> str:
+        with self._lock:
+            return f"SpeakerProfile(generation={self._generation!r}, closed={self._closed})"
+
+    def _require_open(self) -> None:
+        if self._closed:
+            raise RuntimeError("speaker profile is closed")
+
+    def _clone(self) -> SpeakerProfile:
+        with self._lock:
+            self._require_open()
+            clone = object.__new__(SpeakerProfile)
+            clone._generation = self._generation
+            clone._lock = threading.Lock()
+            clone._closed = False
+            cloned_reference: SpeakerReference | None = None
+            try:
+                cloned_reference = self._reference.clone()
+                clone._reference = cloned_reference
+                return clone
+            except BaseException:
+                if cloned_reference is not None:
+                    cloned_reference.close()
+                raise

--- a/main_logic/voice_identity/reference.py
+++ b/main_logic/voice_identity/reference.py
@@ -44,6 +44,7 @@ def _owned_normalized_embedding(
         raise ValueError("embedding must be convertible to float32") from None
 
     owned: np.ndarray | None = None
+    normalized: np.ndarray | None = None
     try:
         if np.iscomplexobj(materialized):
             raise ValueError("embedding must be real-valued")
@@ -72,8 +73,15 @@ def _owned_normalized_embedding(
         if not math.isfinite(norm) or norm == 0.0:
             raise ValueError("embedding norm must be finite and non-zero")
 
+        normalized = np.array(
+            owned,
+            dtype=np.float64,
+            order="C",
+            copy=True,
+        )
         with np.errstate(over="ignore", divide="ignore", invalid="ignore"):
-            np.divide(owned, norm, out=owned, casting="unsafe")
+            np.divide(normalized, norm, out=normalized)
+        owned[:] = normalized
         if not bool(np.all(np.isfinite(owned))):
             raise ValueError("normalized embedding must contain only finite values")
         return owned
@@ -82,6 +90,8 @@ def _owned_normalized_embedding(
             _wipe(owned)
         raise
     finally:
+        if normalized is not None:
+            _wipe(normalized)
         _wipe(materialized)
 
 

--- a/main_logic/voice_identity/reference.py
+++ b/main_logic/voice_identity/reference.py
@@ -1,0 +1,184 @@
+"""Owned, normalized in-memory speaker references."""
+
+from __future__ import annotations
+
+import math
+import threading
+
+import numpy as np
+import numpy.typing as npt
+
+from .contracts import SpeakerModelIdentity
+
+
+def _wipe(array: np.ndarray) -> None:
+    """Best-effort zeroization for an owned array."""
+
+    try:
+        if not array.flags.writeable:
+            array.setflags(write=True)
+        array.fill(0.0)
+    except Exception:
+        pass
+
+
+def _copy_model_identity(identity: SpeakerModelIdentity) -> SpeakerModelIdentity:
+    return SpeakerModelIdentity(
+        identity.model_id,
+        identity.model_revision,
+        identity.embedding_dimension,
+    )
+
+
+def _owned_normalized_embedding(
+    model_identity: SpeakerModelIdentity,
+    embedding: npt.ArrayLike,
+) -> np.ndarray:
+    """Materialize, validate, and normalize a caller-independent array."""
+
+    try:
+        materialized = np.array(embedding, order="C", copy=True)
+    except MemoryError:
+        raise
+    except Exception:
+        raise ValueError("embedding must be convertible to float32") from None
+
+    owned: np.ndarray | None = None
+    try:
+        if np.iscomplexobj(materialized):
+            raise ValueError("embedding must be real-valued")
+        try:
+            with np.errstate(over="ignore", invalid="ignore"):
+                owned = np.array(
+                    materialized,
+                    dtype=np.float32,
+                    order="C",
+                    copy=True,
+                )
+        except MemoryError:
+            raise
+        except Exception:
+            raise ValueError("embedding must be convertible to float32") from None
+
+        if owned.ndim != 1:
+            raise ValueError("embedding must be one-dimensional")
+        if owned.shape[0] != model_identity.embedding_dimension:
+            raise ValueError("embedding dimension does not match model identity")
+        if not bool(np.all(np.isfinite(owned))):
+            raise ValueError("embedding must contain only finite values")
+
+        squared_norm = math.fsum(float(value) * float(value) for value in owned)
+        norm = math.sqrt(squared_norm)
+        if not math.isfinite(norm) or norm == 0.0:
+            raise ValueError("embedding norm must be finite and non-zero")
+
+        with np.errstate(over="ignore", divide="ignore", invalid="ignore"):
+            np.divide(owned, norm, out=owned, casting="unsafe")
+        if not bool(np.all(np.isfinite(owned))):
+            raise ValueError("normalized embedding must contain only finite values")
+        return owned
+    except BaseException:
+        if owned is not None:
+            _wipe(owned)
+        raise
+    finally:
+        _wipe(materialized)
+
+
+class SpeakerReference:
+    """Own a normalized embedding and export only caller-owned copies."""
+
+    __slots__ = ("_closed", "_embedding", "_lock", "_model_identity")
+
+    def __init__(
+        self,
+        model_identity: SpeakerModelIdentity,
+        embedding: npt.ArrayLike,
+    ) -> None:
+        if type(model_identity) is not SpeakerModelIdentity:
+            raise TypeError("model_identity must be SpeakerModelIdentity")
+
+        self._lock = threading.Lock()
+        self._closed = False
+        self._model_identity = _copy_model_identity(model_identity)
+        self._embedding = _owned_normalized_embedding(
+            self._model_identity,
+            embedding,
+        )
+
+    @property
+    def closed(self) -> bool:
+        with self._lock:
+            return self._closed
+
+    @property
+    def model_identity(self) -> SpeakerModelIdentity:
+        with self._lock:
+            self._require_open()
+            return _copy_model_identity(self._model_identity)
+
+    def clone(self) -> SpeakerReference:
+        """Return an independently owned reference with the same value."""
+
+        identity, embedding = self._copy_embedding()
+        try:
+            clone = object.__new__(SpeakerReference)
+            clone._lock = threading.Lock()
+            clone._closed = False
+            clone._model_identity = identity
+            clone._embedding = embedding
+            return clone
+        except BaseException:
+            _wipe(embedding)
+            raise
+
+    def copy_embedding(self) -> np.ndarray:
+        """Return an independent caller-owned embedding copy.
+
+        Trusted in-process adapters are responsible for clearing this copy
+        after use. This method is an ownership boundary, not a sandbox for
+        untrusted Python code.
+        """
+
+        _, embedding = self._copy_embedding()
+        return embedding
+
+    def __copy__(self) -> SpeakerReference:
+        return self.clone()
+
+    def __deepcopy__(self, memo: dict[int, object]) -> SpeakerReference:
+        del memo
+        return self.clone()
+
+    def __reduce__(self) -> object:
+        raise TypeError("SpeakerReference must not be pickled")
+
+    def __reduce_ex__(self, protocol: int) -> object:
+        del protocol
+        raise TypeError("SpeakerReference must not be pickled")
+
+    def close(self) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            _wipe(self._embedding)
+
+    def __repr__(self) -> str:
+        with self._lock:
+            return (
+                "SpeakerReference("
+                f"model_identity={self._model_identity!r}, closed={self._closed})"
+            )
+
+    def _copy_embedding(self) -> tuple[SpeakerModelIdentity, np.ndarray]:
+        with self._lock:
+            self._require_open()
+            return (
+                _copy_model_identity(self._model_identity),
+                self._embedding.copy(order="C"),
+            )
+
+    def _require_open(self) -> None:
+        if self._closed:
+            raise RuntimeError("speaker reference is closed")

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -101,6 +101,13 @@ VOICE_INPUT_LAYERING
     processing, routers, or arbitrary utility modules. ASR runtime code emits
     neutral callbacks and cannot import the Core-owned Registry in reverse.
 
+VOICE_IDENTITY_LAYERING
+    The in-memory speaker identity domain owns only model identity, normalized
+    references, and profiles. Its package initializer is inert; its domain
+    modules cannot depend on ASR, Core, Voice Turn, routers, app runtime, model
+    runtimes, or persistence/cryptography libraries. Trusted outer layers may
+    consume these provider-neutral contracts without reversing that direction.
+
 Every violation prints as ``path:line:col  CODE  message``. Exit 1 on any
 violation, 0 otherwise, 2 when the expected layout itself is missing (this
 gate hard-fails rather than silently skipping when paths move — see the
@@ -933,6 +940,872 @@ def check_fail_closed_chokepoint(core_dir: Path) -> list[Violation]:
     return violations
 
 
+def _assignment_target_names(target: ast.AST) -> set[str]:
+    """Return names directly bound by one assignment target."""
+
+    if isinstance(target, ast.Name):
+        return {target.id}
+    if isinstance(target, ast.Starred):
+        return _assignment_target_names(target.value)
+    if isinstance(target, (ast.List, ast.Tuple)):
+        return {
+            name
+            for element in target.elts
+            for name in _assignment_target_names(element)
+        }
+    return set()
+
+
+def _match_pattern_binding_names(pattern: ast.pattern) -> set[str]:
+    """Return names captured by one structural pattern."""
+
+    names: set[str] = set()
+    for node in ast.walk(pattern):
+        if isinstance(node, (ast.MatchAs, ast.MatchStar)) and node.name is not None:
+            names.add(node.name)
+        elif isinstance(node, ast.MatchMapping) and node.rest is not None:
+            names.add(node.rest)
+    return names
+
+
+def _class_global_binding_sites(node: ast.ClassDef) -> list[tuple[str, ast.AST]]:
+    """Return bindings redirected to module scope by class-body ``global``."""
+
+    global_names: set[str] = set()
+    nested_classes: list[ast.ClassDef] = []
+    stack: list[ast.AST] = list(reversed(node.body))
+    while stack:
+        child = stack.pop()
+        if isinstance(child, ast.Global):
+            global_names.update(child.names)
+            continue
+        if isinstance(child, ast.ClassDef):
+            nested_classes.append(child)
+            continue
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            continue
+        stack.extend(reversed(list(ast.iter_child_nodes(child))))
+
+    synthetic = ast.Module(body=node.body, type_ignores=[])
+    sites = [
+        (name, binding_node)
+        for name, binding_node in _module_scope_binding_sites(
+            synthetic,
+            include_class_globals=False,
+        )
+        if name in global_names
+    ]
+    for nested_class in nested_classes:
+        sites.extend(_class_global_binding_sites(nested_class))
+    return sites
+
+
+def _module_scope_binding_sites(
+    tree: ast.Module,
+    *,
+    include_class_globals: bool = True,
+) -> list[tuple[str, ast.AST]]:
+    """Return lexical module bindings without descending into local scopes.
+
+    This intentionally models ordinary Python binding syntax, not reflective
+    mutation through globals(), exec(), or arbitrary object state.
+    """
+
+    sites: list[tuple[str, ast.AST]] = []
+    stack: list[ast.AST] = list(reversed(tree.body))
+    while stack:
+        node = stack.pop()
+        names: set[str] = set()
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            continue
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            sites.append((node.name, node))
+            evaluated_expressions: list[ast.AST] = [
+                *node.decorator_list,
+                *node.args.defaults,
+                *(default for default in node.args.kw_defaults if default is not None),
+            ]
+            stack.extend(reversed(evaluated_expressions))
+            continue
+        if isinstance(node, ast.ClassDef):
+            sites.append((node.name, node))
+            if include_class_globals:
+                sites.extend(_class_global_binding_sites(node))
+            evaluated_expressions = [
+                *node.decorator_list,
+                *node.bases,
+                *(keyword.value for keyword in node.keywords),
+            ]
+            stack.extend(reversed(evaluated_expressions))
+            continue
+        if isinstance(node, ast.Lambda):
+            evaluated_expressions = [
+                *node.args.defaults,
+                *(default for default in node.args.kw_defaults if default is not None),
+            ]
+            stack.extend(reversed(evaluated_expressions))
+            continue
+        if isinstance(node, ast.Assign):
+            names = {
+                name
+                for target in node.targets
+                for name in _assignment_target_names(target)
+            }
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            names = _assignment_target_names(node.target)
+        elif isinstance(node, ast.AugAssign):
+            names = _assignment_target_names(node.target)
+        elif isinstance(node, ast.NamedExpr):
+            names = _assignment_target_names(node.target)
+        elif isinstance(node, (ast.For, ast.AsyncFor)):
+            names = _assignment_target_names(node.target)
+        elif isinstance(node, (ast.With, ast.AsyncWith)):
+            names = {
+                name
+                for item in node.items
+                if item.optional_vars is not None
+                for name in _assignment_target_names(item.optional_vars)
+            }
+        elif isinstance(node, ast.ExceptHandler) and node.name is not None:
+            names = {node.name}
+        elif isinstance(node, ast.match_case):
+            names = _match_pattern_binding_names(node.pattern)
+        sites.extend((name, node) for name in names)
+        stack.extend(reversed(list(ast.iter_child_nodes(node))))
+    return sites
+
+
+def _voice_identity_call_scope_metadata(
+    tree: ast.Module,
+    alias_paths: dict[str, str],
+    module_import_names: set[str],
+) -> tuple[set[int], set[int]]:
+    """Return shadowed import calls and statically NumPy-backed dump calls."""
+
+    def scope_bindings(body: list[ast.stmt]) -> tuple[set[str], set[str]]:
+        synthetic = ast.Module(body=body, type_ignores=[])
+        bound = {
+            name
+            for name, _ in _module_scope_binding_sites(
+                synthetic,
+                include_class_globals=False,
+            )
+        }
+        global_names: set[str] = set()
+        nonlocal_names: set[str] = set()
+        stack: list[ast.AST] = list(reversed(body))
+        while stack:
+            node = stack.pop()
+            if isinstance(node, ast.Global):
+                global_names.update(node.names)
+                continue
+            if isinstance(node, ast.Nonlocal):
+                nonlocal_names.update(node.names)
+                continue
+            if isinstance(node, ast.Import):
+                bound.update(alias.asname or alias.name.split(".", 1)[0] for alias in node.names)
+                continue
+            if isinstance(node, ast.ImportFrom):
+                bound.update(
+                    alias.asname or alias.name
+                    for alias in node.names
+                    if alias.name != "*"
+                )
+                continue
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)):
+                continue
+            stack.extend(reversed(list(ast.iter_child_nodes(node))))
+        return bound - global_names - nonlocal_names, global_names
+
+    def argument_names(arguments: ast.arguments) -> set[str]:
+        names = {
+            argument.arg
+            for argument in (
+                *arguments.posonlyargs,
+                *arguments.args,
+                *arguments.kwonlyargs,
+            )
+        }
+        if arguments.vararg is not None:
+            names.add(arguments.vararg.arg)
+        if arguments.kwarg is not None:
+            names.add(arguments.kwarg.arg)
+        return names
+
+    def numpy_result_bindings(
+        body: list[ast.stmt],
+        shadowed_imports: set[str],
+    ) -> set[str]:
+        bindings: set[str] = set()
+        stack: list[ast.AST] = list(reversed(body))
+        while stack:
+            node = stack.pop()
+            targets: list[ast.AST] = []
+            value: ast.AST | None = None
+            if isinstance(node, ast.Assign):
+                targets = list(node.targets)
+                value = node.value
+            elif isinstance(node, ast.AnnAssign) and node.value is not None:
+                targets = [node.target]
+                value = node.value
+            elif isinstance(node, ast.NamedExpr):
+                targets = [node.target]
+                value = node.value
+            if isinstance(value, ast.Call):
+                chain = dotted_node_path(value.func)
+                if chain is not None and chain.split(".", 1)[0] not in shadowed_imports:
+                    resolved = resolve_chain(chain, alias_paths) or chain
+                    if resolved.startswith("numpy."):
+                        bindings.update(
+                            name
+                            for target in targets
+                            for name in _assignment_target_names(target)
+                        )
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)):
+                continue
+            stack.extend(reversed(list(ast.iter_child_nodes(node))))
+        return bindings
+
+    protected_call_names = module_import_names | {
+        "__import__",
+        "eval",
+        "exec",
+        "open",
+    }
+
+    def statement_binding_names(
+        statement: ast.stmt,
+        *,
+        include_class_globals: bool,
+    ) -> set[str]:
+        synthetic = ast.Module(body=[statement], type_ignores=[])
+        return {
+            name
+            for name, _ in _module_scope_binding_sites(
+                synthetic,
+                include_class_globals=include_class_globals,
+            )
+        }
+
+    class ScopeVisitor(ast.NodeVisitor):
+        def __init__(self) -> None:
+            module_shadowed: set[str] = set()
+            module_numpy: set[str] = set()
+            self.shadowed_stack: list[set[str]] = [module_shadowed]
+            self.numpy_stack: list[set[str]] = [module_numpy]
+            self.lexical_shadowed_stack: list[set[str]] = [module_shadowed]
+            self.lexical_numpy_stack: list[set[str]] = [module_numpy]
+            self.shadowed_call_ids: set[int] = set()
+            self.numpy_dump_call_ids: set[int] = set()
+
+        def _visit_statement_sequence(
+            self,
+            body: list[ast.stmt],
+            *,
+            global_names: set[str],
+            include_class_globals: bool,
+        ) -> None:
+            for statement in body:
+                self.visit(statement)
+                bound_names = statement_binding_names(
+                    statement,
+                    include_class_globals=include_class_globals,
+                ) - global_names
+                numpy_bindings = numpy_result_bindings(
+                    [statement],
+                    self.shadowed_stack[-1],
+                ) - global_names
+                self.numpy_stack[-1].difference_update(bound_names)
+                self.numpy_stack[-1].update(numpy_bindings)
+                self.shadowed_stack[-1].update(
+                    bound_names & protected_call_names
+                )
+
+        def visit_Module(self, node: ast.Module) -> None:  # noqa: N802
+            self._visit_statement_sequence(
+                node.body,
+                global_names=set(),
+                include_class_globals=True,
+            )
+
+        def visit_Call(self, node: ast.Call) -> None:  # noqa: N802 - ast visitor API
+            chain = dotted_node_path(node.func)
+            if (
+                chain is not None
+                and chain.split(".", 1)[0] in self.shadowed_stack[-1]
+            ):
+                self.shadowed_call_ids.add(id(node))
+            if (
+                isinstance(node.func, ast.Attribute)
+                and node.func.attr == "dump"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id in self.numpy_stack[-1]
+            ):
+                self.numpy_dump_call_ids.add(id(node))
+            self.generic_visit(node)
+
+        def _visit_function(
+            self,
+            node: ast.FunctionDef | ast.AsyncFunctionDef,
+        ) -> None:
+            outer_expressions: list[ast.AST] = [
+                *node.decorator_list,
+                *node.args.defaults,
+                *(default for default in node.args.kw_defaults if default is not None),
+            ]
+            for expression in outer_expressions:
+                self.visit(expression)
+            local_names, global_names = scope_bindings(node.body)
+            local_names.update(argument_names(node.args))
+            shadowed = (
+                self.lexical_shadowed_stack[-1] - global_names
+            ) | (local_names & protected_call_names)
+            numpy_names = self.lexical_numpy_stack[-1] - local_names
+            self.shadowed_stack.append(shadowed)
+            self.numpy_stack.append(numpy_names)
+            self.lexical_shadowed_stack.append(shadowed)
+            self.lexical_numpy_stack.append(numpy_names)
+            self._visit_statement_sequence(
+                node.body,
+                global_names=global_names,
+                include_class_globals=False,
+            )
+            self.lexical_numpy_stack.pop()
+            self.lexical_shadowed_stack.pop()
+            self.numpy_stack.pop()
+            self.shadowed_stack.pop()
+
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # noqa: N802
+            self._visit_function(node)
+
+        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:  # noqa: N802
+            self._visit_function(node)
+
+        def visit_ClassDef(self, node: ast.ClassDef) -> None:  # noqa: N802
+            outer_expressions: list[ast.AST] = [
+                *node.decorator_list,
+                *node.bases,
+                *(keyword.value for keyword in node.keywords),
+            ]
+            for expression in outer_expressions:
+                self.visit(expression)
+            _, global_names = scope_bindings(node.body)
+            shadowed = self.shadowed_stack[-1] - global_names
+            numpy_names = set(self.numpy_stack[-1])
+            self.shadowed_stack.append(shadowed)
+            self.numpy_stack.append(numpy_names)
+            self.lexical_shadowed_stack.append(self.lexical_shadowed_stack[-1])
+            self.lexical_numpy_stack.append(self.lexical_numpy_stack[-1])
+            self._visit_statement_sequence(
+                node.body,
+                global_names=global_names,
+                include_class_globals=False,
+            )
+            self.lexical_numpy_stack.pop()
+            self.lexical_shadowed_stack.pop()
+            self.numpy_stack.pop()
+            self.shadowed_stack.pop()
+
+        def visit_Lambda(self, node: ast.Lambda) -> None:  # noqa: N802
+            for default in (*node.args.defaults, *node.args.kw_defaults):
+                if default is not None:
+                    self.visit(default)
+            local_names = argument_names(node.args)
+            shadowed = self.lexical_shadowed_stack[-1] | (
+                local_names & protected_call_names
+            )
+            numpy_names = self.lexical_numpy_stack[-1] - local_names
+            self.shadowed_stack.append(shadowed)
+            self.numpy_stack.append(numpy_names)
+            self.lexical_shadowed_stack.append(shadowed)
+            self.lexical_numpy_stack.append(numpy_names)
+            self.visit(node.body)
+            self.lexical_numpy_stack.pop()
+            self.lexical_shadowed_stack.pop()
+            self.numpy_stack.pop()
+            self.shadowed_stack.pop()
+
+        def _visit_comprehension(
+            self,
+            generators: list[ast.comprehension],
+            result_nodes: tuple[ast.AST, ...],
+        ) -> None:
+            if not generators:
+                for result in result_nodes:
+                    self.visit(result)
+                return
+            self.visit(generators[0].iter)
+            shadowed = set(self.lexical_shadowed_stack[-1])
+            numpy_names = set(self.lexical_numpy_stack[-1])
+            self.shadowed_stack.append(shadowed)
+            self.numpy_stack.append(numpy_names)
+            self.lexical_shadowed_stack.append(shadowed)
+            self.lexical_numpy_stack.append(numpy_names)
+            for index, generator in enumerate(generators):
+                if index:
+                    self.visit(generator.iter)
+                target_names = _assignment_target_names(generator.target)
+                self.shadowed_stack[-1].update(
+                    target_names & protected_call_names
+                )
+                self.numpy_stack[-1].difference_update(target_names)
+                for condition in generator.ifs:
+                    self.visit(condition)
+            for result in result_nodes:
+                self.visit(result)
+            self.lexical_numpy_stack.pop()
+            self.lexical_shadowed_stack.pop()
+            self.numpy_stack.pop()
+            self.shadowed_stack.pop()
+
+        def visit_ListComp(self, node: ast.ListComp) -> None:  # noqa: N802
+            self._visit_comprehension(node.generators, (node.elt,))
+
+        def visit_SetComp(self, node: ast.SetComp) -> None:  # noqa: N802
+            self._visit_comprehension(node.generators, (node.elt,))
+
+        def visit_GeneratorExp(self, node: ast.GeneratorExp) -> None:  # noqa: N802
+            self._visit_comprehension(node.generators, (node.elt,))
+
+        def visit_DictComp(self, node: ast.DictComp) -> None:  # noqa: N802
+            self._visit_comprehension(node.generators, (node.key, node.value))
+
+    visitor = ScopeVisitor()
+    visitor.visit(tree)
+    return visitor.shadowed_call_ids, visitor.numpy_dump_call_ids
+
+
+def check_voice_identity_contracts(root: Path) -> list[Violation]:
+    """Cooperatively lint the provider-neutral voice-identity boundary.
+
+    This check covers module-scope imports and direct call sites. It is an
+    architecture guard for trusted repository code, not a Python sandbox or a
+    proof against reflection and intentionally obscured runtime behavior.
+    """
+
+    package_dir = root / "main_logic" / "voice_identity"
+    violations: list[Violation] = []
+    if not package_dir.exists():
+        violations.append(Violation(
+            package_dir,
+            1,
+            0,
+            "VOICE_IDENTITY_LAYERING",
+            "required voice_identity package is missing",
+        ))
+
+    init_path = package_dir / "__init__.py"
+    domain_paths = tuple(
+        package_dir / name
+        for name in ("contracts.py", "reference.py", "profile.py")
+    )
+    for required in (init_path, *domain_paths):
+        if not required.exists():
+            violations.append(Violation(
+                required,
+                1,
+                0,
+                "VOICE_IDENTITY_LAYERING",
+                "required voice_identity domain file is missing",
+            ))
+
+    for packaged_path in sorted(
+        candidate
+        for candidate in package_dir.rglob("*")
+        if candidate.is_file()
+    ):
+        relative_path = packaged_path.relative_to(package_dir)
+        if packaged_path.suffix == ".py" or "__pycache__" in relative_path.parts:
+            continue
+        violations.append(Violation(
+            packaged_path,
+            1,
+            0,
+            "VOICE_IDENTITY_LAYERING",
+            "voice_identity domain must not contain packaged assets; "
+            f"found {relative_path.as_posix()}",
+        ))
+
+    if init_path.exists():
+        init_tree = parse(init_path)
+        docstring_only = (
+            len(init_tree.body) == 1
+            and isinstance(init_tree.body[0], ast.Expr)
+            and isinstance(init_tree.body[0].value, ast.Constant)
+            and isinstance(init_tree.body[0].value.value, str)
+        )
+        if not docstring_only:
+            offender = init_tree.body[1] if len(init_tree.body) > 1 else (
+                init_tree.body[0] if init_tree.body else None
+            )
+            violations.append(Violation(
+                init_path,
+                getattr(offender, "lineno", 1),
+                getattr(offender, "col_offset", 0),
+                "VOICE_IDENTITY_LAYERING",
+                "voice_identity/__init__.py may contain only a package docstring",
+            ))
+
+    forbidden_domain_prefixes = (
+        "main_logic.asr_client",
+        "main_logic.core",
+        "main_logic.voice_turn",
+        "main_routers",
+        "app",
+        "onnxruntime",
+        "keyring",
+        "cryptography",
+    )
+    allowed_import_prefixes = {
+        package_dir / "contracts.py": (
+            "__future__",
+            "dataclasses",
+        ),
+        package_dir / "reference.py": (
+            "__future__",
+            "math",
+            "threading",
+            "numpy",
+            "main_logic.voice_identity.contracts",
+        ),
+        package_dir / "profile.py": (
+            "__future__",
+            "threading",
+            "main_logic.voice_identity.contracts",
+            "main_logic.voice_identity.reference",
+        ),
+    }
+    direct_dynamic_calls = {
+        "eval",
+        "exec",
+        "__import__",
+        "builtins.eval",
+        "builtins.exec",
+        "builtins.__import__",
+        "importlib.import_module",
+    }
+    direct_file_io_calls = {
+        "open",
+        "builtins.open",
+        "numpy.fromfile",
+        "numpy.fromregex",
+        "numpy.genfromtxt",
+        "numpy.lib.format.open_memmap",
+        "numpy.load",
+        "numpy.loadtxt",
+        "numpy.memmap",
+        "numpy.ndarray.dump",
+        "numpy.recfromtxt",
+        "numpy.save",
+        "numpy.savetxt",
+        "numpy.savez",
+        "numpy.savez_compressed",
+    }
+    direct_native_loading_calls = {
+        "numpy.ctypeslib.load_library",
+    }
+    direct_native_compilation_calls = {
+        "numpy.f2py.compile",
+    }
+    allowed_numpy_calls = {
+        "numpy.all",
+        "numpy.array",
+        "numpy.asarray",
+        "numpy.ascontiguousarray",
+        "numpy.copy",
+        "numpy.divide",
+        "numpy.empty",
+        "numpy.errstate",
+        "numpy.iscomplexobj",
+        "numpy.isfinite",
+        "numpy.linalg.norm",
+        "numpy.ones",
+        "numpy.zeros",
+    }
+    allowed_threading_calls = {
+        "threading.Lock",
+    }
+    direct_file_io_methods = {
+        "tofile",
+    }
+
+    scanned_paths = sorted(
+        path
+        for path in package_dir.rglob("*.py")
+        if path != init_path
+    )
+    for path in scanned_paths:
+        tree = parse(path)
+        pkg = ".".join(path.relative_to(root).parts[:-1])
+        alias_paths = module_alias_paths(tree, pkg)
+        module_scope_imports = {
+            id(node)
+            for node in tree.body
+            if isinstance(node, (ast.Import, ast.ImportFrom))
+        }
+        module_scope_import_bindings: set[str] = set()
+        for import_node in tree.body:
+            if isinstance(import_node, ast.Import):
+                bound_names = (
+                    alias.asname or alias.name.split(".", 1)[0]
+                    for alias in import_node.names
+                )
+            elif (
+                isinstance(import_node, ast.ImportFrom)
+                and import_node.module != "__future__"
+            ):
+                bound_names = (
+                    alias.asname or alias.name
+                    for alias in import_node.names
+                    if alias.name != "*"
+                )
+            else:
+                continue
+            for bound_name in bound_names:
+                if bound_name in module_scope_import_bindings:
+                    violations.append(Violation(
+                        path,
+                        import_node.lineno,
+                        import_node.col_offset,
+                        "VOICE_IDENTITY_LAYERING",
+                        "voice_identity module-scope import bindings must not "
+                        f"be rebound; found {bound_name}",
+                    ))
+                else:
+                    module_scope_import_bindings.add(bound_name)
+        reported_rebindings: set[tuple[str, int, int]] = set()
+        for bound_name, binding_node in _module_scope_binding_sites(tree):
+            if bound_name not in module_scope_import_bindings:
+                continue
+            location = (
+                bound_name,
+                getattr(binding_node, "lineno", 1),
+                getattr(binding_node, "col_offset", 0),
+            )
+            if location in reported_rebindings:
+                continue
+            reported_rebindings.add(location)
+            violations.append(Violation(
+                path,
+                location[1],
+                location[2],
+                "VOICE_IDENTITY_LAYERING",
+                "voice_identity module-scope import bindings must not "
+                f"be rebound; found {bound_name}",
+            ))
+        shadowed_import_call_ids, numpy_dump_call_ids = (
+            _voice_identity_call_scope_metadata(
+                tree,
+                alias_paths,
+                module_scope_import_bindings,
+            )
+        )
+        allowed = allowed_import_prefixes.get(path)
+        if allowed is None:
+            violations.append(Violation(
+                path,
+                1,
+                0,
+                "VOICE_IDENTITY_LAYERING",
+                "voice_identity module is missing an explicit dependency allowlist",
+            ))
+            allowed = ()
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, (ast.Import, ast.ImportFrom))
+                and id(node) not in module_scope_imports
+            ):
+                violations.append(Violation(
+                    path,
+                    node.lineno,
+                    node.col_offset,
+                    "VOICE_IDENTITY_LAYERING",
+                    "voice_identity imports must be declared at module scope",
+                ))
+            if (
+                isinstance(node, ast.ImportFrom)
+                and any(alias.name == "*" for alias in node.names)
+            ):
+                violations.append(Violation(
+                    path,
+                    node.lineno,
+                    node.col_offset,
+                    "VOICE_IDENTITY_LAYERING",
+                    "voice_identity domain must not use wildcard imports",
+                ))
+            imported_paths = _imported_paths(node, pkg)
+            if imported_paths:
+                allowed_paths = {
+                    imported
+                    for imported in imported_paths
+                    if any(
+                        imported == prefix
+                        or imported.startswith(f"{prefix}.")
+                        for prefix in allowed
+                    )
+                }
+                if (
+                    isinstance(node, ast.ImportFrom)
+                    and any(
+                        imported in allowed_paths
+                        for imported in imported_paths[1:]
+                    )
+                ):
+                    # ``from . import contracts`` imports the package anchor
+                    # alongside the approved member. That structural base is
+                    # allowed only for this exact ImportFrom node; a broad
+                    # standalone ``import main_logic`` remains forbidden.
+                    allowed_paths.add(imported_paths[0])
+                disallowed = next(
+                    (
+                        imported
+                        for imported in dict.fromkeys(imported_paths)
+                        if imported not in allowed_paths
+                    ),
+                    None,
+                )
+                if disallowed is not None:
+                    forbidden = next(
+                        (
+                            prefix
+                            for prefix in forbidden_domain_prefixes
+                            if disallowed == prefix
+                            or disallowed.startswith(f"{prefix}.")
+                        ),
+                        None,
+                    )
+                    message = (
+                        f"voice_identity domain must not import {forbidden}"
+                        if forbidden is not None
+                        else "voice_identity domain may only import approved "
+                        f"in-memory dependencies; found {disallowed}"
+                    )
+                    violations.append(Violation(
+                        path,
+                        node.lineno,
+                        node.col_offset,
+                        "VOICE_IDENTITY_LAYERING",
+                        message,
+                    ))
+
+            if not isinstance(node, ast.Call):
+                continue
+            direct_file_io_method = (
+                isinstance(node.func, ast.Attribute)
+                and node.func.attr in direct_file_io_methods
+            )
+            direct_numpy_ndarray_dump = False
+            if (
+                isinstance(node.func, ast.Attribute)
+                and node.func.attr == "dump"
+                and isinstance(node.func.value, ast.Call)
+                and id(node.func.value) not in shadowed_import_call_ids
+            ):
+                receiver_chain = dotted_node_path(node.func.value.func)
+                if receiver_chain is not None:
+                    resolved_receiver = (
+                        resolve_chain(receiver_chain, alias_paths) or receiver_chain
+                    )
+                    direct_numpy_ndarray_dump = resolved_receiver.startswith("numpy.")
+            direct_bound_numpy_dump = id(node) in numpy_dump_call_ids
+            if direct_numpy_ndarray_dump or direct_bound_numpy_dump:
+                dump_path = (
+                    "numpy.ndarray.dump"
+                    if direct_numpy_ndarray_dump
+                    else dotted_node_path(node.func) or ".dump"
+                )
+                violations.append(Violation(
+                    path,
+                    node.lineno,
+                    node.col_offset,
+                    "VOICE_IDENTITY_LAYERING",
+                    "voice_identity domain must not perform file I/O via "
+                    f"{dump_path}",
+                ))
+                continue
+            chain = dotted_node_path(node.func)
+            if chain is None:
+                if direct_file_io_method:
+                    violations.append(Violation(
+                        path,
+                        node.lineno,
+                        node.col_offset,
+                        "VOICE_IDENTITY_LAYERING",
+                        "voice_identity domain must not perform file I/O via "
+                        f".{node.func.attr}",
+                    ))
+                continue
+            if (
+                id(node) in shadowed_import_call_ids
+                and isinstance(node.func, ast.Name)
+            ):
+                continue
+            resolved = (
+                chain
+                if id(node) in shadowed_import_call_ids
+                else resolve_chain(chain, alias_paths) or chain
+            )
+            if resolved in direct_dynamic_calls:
+                violations.append(Violation(
+                    path,
+                    node.lineno,
+                    node.col_offset,
+                    "VOICE_IDENTITY_LAYERING",
+                    f"voice_identity domain must not call {resolved}",
+                ))
+            elif resolved in direct_file_io_calls or direct_file_io_method:
+                violations.append(Violation(
+                    path,
+                    node.lineno,
+                    node.col_offset,
+                    "VOICE_IDENTITY_LAYERING",
+                    f"voice_identity domain must not perform file I/O via {resolved}",
+                ))
+            elif resolved in direct_native_loading_calls:
+                violations.append(Violation(
+                    path,
+                    node.lineno,
+                    node.col_offset,
+                    "VOICE_IDENTITY_LAYERING",
+                    "voice_identity domain must not load a native library via "
+                    f"{resolved}",
+                ))
+            elif resolved in direct_native_compilation_calls:
+                violations.append(Violation(
+                    path,
+                    node.lineno,
+                    node.col_offset,
+                    "VOICE_IDENTITY_LAYERING",
+                    f"voice_identity domain must not compile native code via {resolved}",
+                ))
+            elif (
+                resolved.startswith("numpy.")
+                and resolved not in allowed_numpy_calls
+            ):
+                violations.append(Violation(
+                    path,
+                    node.lineno,
+                    node.col_offset,
+                    "VOICE_IDENTITY_LAYERING",
+                    "voice_identity domain may only call approved in-memory "
+                    f"NumPy APIs; found {resolved}",
+                ))
+            elif (
+                resolved.startswith("threading.")
+                and resolved not in allowed_threading_calls
+            ):
+                violations.append(Violation(
+                    path,
+                    node.lineno,
+                    node.col_offset,
+                    "VOICE_IDENTITY_LAYERING",
+                    "voice_identity domain may only call threading.Lock; "
+                    f"found {resolved}",
+                ))
+
+    return violations
+
+
 def run(root: Path) -> list[Violation]:
     core_dir = root / "main_logic" / "core"
     tests_dir = root / "tests"
@@ -946,6 +1819,7 @@ def run(root: Path) -> list[Violation]:
             sys.exit(2)
 
     violations: list[Violation] = []
+    violations.extend(check_voice_identity_contracts(root))
     violations.extend(check_fail_closed_chokepoint(core_dir))
     init_tree = parse(init_path)
     facade_names = facade_top_level_names(init_tree)

--- a/tests/unit/asr_client/speaker_shadow/test_campplus_distribution_contracts.py
+++ b/tests/unit/asr_client/speaker_shadow/test_campplus_distribution_contracts.py
@@ -99,7 +99,9 @@ def test_ignore_rules_keep_only_reviewable_campplus_metadata() -> None:
 
 
 def test_legacy_voice_identity_and_model_locations_are_absent() -> None:
-    assert not (ROOT / "main_logic" / "voice_identity").exists()
+    voice_identity = ROOT / "main_logic" / "voice_identity"
+    assert not (voice_identity / "runtime.py").exists()
+    assert not (voice_identity / "campplus.py").exists()
     assert not (ROOT / "data" / "speaker_models").exists()
     assert not (ROOT / "tools" / "voice_eval").exists()
     assert not (ROOT / "main_logic" / "asr_client" / "campplus.py").exists()

--- a/tests/unit/test_check_core_contracts.py
+++ b/tests/unit/test_check_core_contracts.py
@@ -1136,3 +1136,842 @@ def test_fail_closed_gate_reports_a_missing_chokepoint(
     assert _chokepoint_codes(contract_checker, core) == [
         "VOICE_FAIL_CLOSED_CHOKEPOINT"
     ]
+
+
+def _write_minimal_voice_identity_layout(root: Path) -> Path:
+    package = root / "main_logic" / "voice_identity"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text('"""identity."""\n', encoding="utf-8")
+    (package / "contracts.py").write_text('"""contracts."""\n', encoding="utf-8")
+    (package / "reference.py").write_text(
+        '"""reference."""\n'
+        "import numpy as np\n"
+        "from .contracts import SpeakerModelIdentity\n",
+        encoding="utf-8",
+    )
+    (package / "profile.py").write_text(
+        '"""profile."""\nfrom .reference import SpeakerReference\n',
+        encoding="utf-8",
+    )
+    return package
+
+
+@pytest.mark.unit
+def test_voice_identity_contract_accepts_in_memory_dependency_direction(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    _write_minimal_voice_identity_layout(tmp_path)
+
+    assert contract_checker.check_voice_identity_contracts(tmp_path) == []
+
+
+@pytest.mark.unit
+def test_voice_identity_contract_fails_closed_when_package_is_missing(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    violations = contract_checker.check_voice_identity_contracts(tmp_path)
+
+    assert any(
+        violation.path == tmp_path / "main_logic" / "voice_identity"
+        and violation.message == "required voice_identity package is missing"
+        for violation in violations
+    )
+    assert sum(
+        violation.message == "required voice_identity domain file is missing"
+        for violation in violations
+    ) == 4
+
+
+@pytest.mark.unit
+def test_voice_identity_contract_rejects_unlisted_modules(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    package = _write_minimal_voice_identity_layout(tmp_path)
+    probe = package / "nested" / "store.py"
+    probe.parent.mkdir()
+    probe.write_text("import cryptography\n", encoding="utf-8")
+
+    messages = [
+        violation.message
+        for violation in contract_checker.check_voice_identity_contracts(tmp_path)
+        if violation.path == probe
+    ]
+
+    assert "voice_identity module is missing an explicit dependency allowlist" in messages
+    assert "voice_identity domain must not import cryptography" in messages
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "source",
+    [
+        "from . import contracts\n",
+        "from main_logic.voice_identity import contracts\n",
+    ],
+)
+def test_voice_identity_contract_allows_approved_importfrom_package_anchors(
+    contract_checker,
+    tmp_path: Path,
+    source: str,
+) -> None:
+    package = _write_minimal_voice_identity_layout(tmp_path)
+    (package / "reference.py").write_text(source, encoding="utf-8")
+
+    assert contract_checker.check_voice_identity_contracts(tmp_path) == []
+
+
+@pytest.mark.unit
+def test_voice_identity_contract_rejects_broad_parent_package_import(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    package = _write_minimal_voice_identity_layout(tmp_path)
+    (package / "reference.py").write_text("import main_logic\n", encoding="utf-8")
+
+    messages = [
+        violation.message
+        for violation in contract_checker.check_voice_identity_contracts(tmp_path)
+    ]
+
+    assert any("found main_logic" in message for message in messages)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "source",
+    [
+        "def persist():\n"
+        "    from numpy import save as write\n"
+        "    write('embedding.npy', [1.0])\n",
+        "def persist():\n"
+        "    import numpy as np\n"
+        "    np.save('embedding.npy', [1.0])\n",
+    ],
+)
+def test_voice_identity_contract_rejects_local_import_aliases(
+    contract_checker,
+    tmp_path: Path,
+    source: str,
+) -> None:
+    package = _write_minimal_voice_identity_layout(tmp_path)
+    (package / "reference.py").write_text(source, encoding="utf-8")
+
+    messages = [
+        violation.message
+        for violation in contract_checker.check_voice_identity_contracts(tmp_path)
+    ]
+
+    assert "voice_identity imports must be declared at module scope" in messages
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "rebind",
+    [
+        "import math as np",
+        "np = object()",
+        "np: object = object()",
+        "(np := object())",
+        "def np():\n    pass",
+        "class np:\n    pass",
+        "np, other = object(), object()",
+        "if True:\n    np = object()",
+        "async def np():\n    pass",
+        "values = [(np := value) for value in ()]",
+    ],
+)
+def test_voice_identity_contract_rejects_module_scope_import_rebinding(
+    contract_checker,
+    tmp_path: Path,
+    rebind: str,
+) -> None:
+    package = _write_minimal_voice_identity_layout(tmp_path)
+    (package / "reference.py").write_text(
+        f"import numpy as np\n{rebind}\n",
+        encoding="utf-8",
+    )
+
+    messages = [
+        violation.message
+        for violation in contract_checker.check_voice_identity_contracts(tmp_path)
+    ]
+
+    assert (
+        "voice_identity module-scope import bindings must not be rebound; found np"
+        in messages
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "binding",
+    [
+        "for math in (np,):\n    pass",
+        "with np.errstate() as math:\n    pass",
+        "try:\n    raise Exception()\nexcept Exception as math:\n    pass",
+        "match np:\n    case math:\n        pass",
+        "math += np",
+        "def holder(value=(math := np)):\n    pass",
+    ],
+)
+def test_voice_identity_contract_rejects_other_module_scope_binding_forms(
+    contract_checker,
+    tmp_path: Path,
+    binding: str,
+) -> None:
+    package = _write_minimal_voice_identity_layout(tmp_path)
+    (package / "reference.py").write_text(
+        f"import numpy as np\nimport math\n{binding}\n",
+        encoding="utf-8",
+    )
+
+    messages = [
+        violation.message
+        for violation in contract_checker.check_voice_identity_contracts(tmp_path)
+    ]
+
+    assert (
+        "voice_identity module-scope import bindings must not be rebound; "
+        "found math"
+        in messages
+    )
+
+
+@pytest.mark.unit
+def test_voice_identity_contract_rejects_global_rebinding_from_class_body(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    package = _write_minimal_voice_identity_layout(tmp_path)
+    (package / "reference.py").write_text(
+        "import numpy as np\n"
+        "import math\n"
+        "class Rebind:\n"
+        "    global math\n"
+        "    math = np\n"
+        "    math.save('embedding.npy', [1.0])\n",
+        encoding="utf-8",
+    )
+
+    messages = [
+        violation.message
+        for violation in contract_checker.check_voice_identity_contracts(tmp_path)
+    ]
+
+    assert (
+        "voice_identity module-scope import bindings must not be rebound; "
+        "found math"
+        in messages
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "local_source",
+    [
+        "def local():\n    np = object()\n    return np",
+        "class Local:\n    np = object()",
+        "values = [np for np in ()]",
+        "np: object",
+    ],
+)
+def test_voice_identity_contract_allows_non_rebinding_name_reuse(
+    contract_checker,
+    tmp_path: Path,
+    local_source: str,
+) -> None:
+    package = _write_minimal_voice_identity_layout(tmp_path)
+    (package / "reference.py").write_text(
+        f"import numpy as np\n{local_source}\n",
+        encoding="utf-8",
+    )
+
+    assert contract_checker.check_voice_identity_contracts(tmp_path) == []
+
+
+@pytest.mark.unit
+def test_voice_identity_contract_allows_class_local_import_alias_shadowing(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    package = _write_minimal_voice_identity_layout(tmp_path)
+    (package / "reference.py").write_text(
+        "import numpy as np\n"
+        "class SnapshotFactory:\n"
+        "    def save(self):\n"
+        "        pass\n"
+        "class Snapshot:\n"
+        "    np = SnapshotFactory()\n"
+        "    np.save()\n",
+        encoding="utf-8",
+    )
+
+    assert contract_checker.check_voice_identity_contracts(tmp_path) == []
+
+
+@pytest.mark.unit
+def test_voice_identity_contract_rejects_wildcard_imports(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    package = _write_minimal_voice_identity_layout(tmp_path)
+    (package / "reference.py").write_text(
+        "from numpy import *\nsave('embedding.npy', [1.0])\n",
+        encoding="utf-8",
+    )
+
+    messages = [
+        violation.message
+        for violation in contract_checker.check_voice_identity_contracts(tmp_path)
+    ]
+
+    assert "voice_identity domain must not use wildcard imports" in messages
+
+
+@pytest.mark.unit
+def test_voice_identity_initializer_must_be_docstring_only(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    package = _write_minimal_voice_identity_layout(tmp_path)
+    (package / "__init__.py").write_text(
+        '"""identity."""\nfrom .profile import SpeakerProfile\n',
+        encoding="utf-8",
+    )
+
+    messages = [
+        violation.message
+        for violation in contract_checker.check_voice_identity_contracts(tmp_path)
+    ]
+
+    assert "voice_identity/__init__.py may contain only a package docstring" in messages
+
+
+@pytest.mark.unit
+def test_voice_identity_contract_requires_complete_domain_layout(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    package = _write_minimal_voice_identity_layout(tmp_path)
+    (package / "profile.py").unlink()
+
+    violations = contract_checker.check_voice_identity_contracts(tmp_path)
+
+    assert any(
+        violation.code == "VOICE_IDENTITY_LAYERING"
+        and violation.path == package / "profile.py"
+        and "required voice_identity domain file is missing" in violation.message
+        for violation in violations
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "forbidden_import",
+    [
+        "from main_logic.asr_client import runtime",
+        "from main_logic.core import LLMSessionManager",
+        "from main_logic.voice_turn import contracts",
+        "import main_routers",
+        "import app",
+        "import onnxruntime",
+        "import keyring",
+        "import cryptography",
+        "import importlib",
+        "import logging",
+        "import os",
+        "import pathlib",
+        "import pickle",
+        "import sqlite3",
+    ],
+)
+def test_voice_identity_domain_rejects_cross_layer_imports(
+    contract_checker,
+    tmp_path: Path,
+    forbidden_import: str,
+) -> None:
+    package = _write_minimal_voice_identity_layout(tmp_path)
+    (package / "reference.py").write_text(f"{forbidden_import}\n", encoding="utf-8")
+
+    violations = contract_checker.check_voice_identity_contracts(tmp_path)
+
+    assert any(
+        violation.code == "VOICE_IDENTITY_LAYERING"
+        for violation in violations
+    )
+
+
+@pytest.mark.unit
+def test_voice_identity_domain_rejects_dynamic_cross_layer_import(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    package = _write_minimal_voice_identity_layout(tmp_path)
+    (package / "reference.py").write_text(
+        "import importlib\n"
+        "runtime = importlib.import_module('main_logic.asr_client.runtime')\n",
+        encoding="utf-8",
+    )
+
+    messages = [
+        violation.message
+        for violation in contract_checker.check_voice_identity_contracts(tmp_path)
+    ]
+
+    assert (
+        "voice_identity domain must not call importlib.import_module"
+        in messages
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "owner_path",
+    [
+        "main_logic/asr_client/probe.py",
+        "main_logic/core/probe.py",
+        "main_logic/voice_turn/probe.py",
+    ],
+)
+def test_voice_identity_contract_allows_outer_layers_to_consume_domain(
+    contract_checker,
+    tmp_path: Path,
+    owner_path: str,
+) -> None:
+    _write_minimal_voice_identity_layout(tmp_path)
+    probe = tmp_path / owner_path
+    probe.parent.mkdir(parents=True)
+    probe.write_text(
+        "from main_logic.voice_identity import profile\n",
+        encoding="utf-8",
+    )
+
+    assert contract_checker.check_voice_identity_contracts(tmp_path) == []
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("eval('1 + 1')\n", "must not call eval"),
+        ("exec('value = 1')\n", "must not call exec"),
+        ("__import__('math')\n", "must not call __import__"),
+        ("open('embedding.bin', 'wb')\n", "file I/O via open"),
+        (
+            "import numpy as np\nnp.save('embedding.npy', np.ones(1))\n",
+            "file I/O via numpy.save",
+        ),
+        (
+            "from numpy import load\nload('embedding.npy')\n",
+            "file I/O via numpy.load",
+        ),
+        (
+            "import numpy as np\nnp.savetxt('embedding.txt', np.ones(1))\n",
+            "file I/O via numpy.savetxt",
+        ),
+        (
+            "import numpy as np\nnp.loadtxt('embedding.txt')\n",
+            "file I/O via numpy.loadtxt",
+        ),
+        (
+            "import numpy as np\nnp.genfromtxt('embedding.csv')\n",
+            "file I/O via numpy.genfromtxt",
+        ),
+        (
+            "import numpy as np\nnp.lib.format.open_memmap('embedding.npy')\n",
+            "file I/O via numpy.lib.format.open_memmap",
+        ),
+        (
+            "import numpy as np\nnp.array([1.0]).tofile('embedding.bin')\n",
+            "file I/O via .tofile",
+        ),
+        (
+            "class Holder:\n"
+            "    def persist(self):\n"
+            "        self._embedding.tofile('embedding.bin')\n",
+            "file I/O via self._embedding.tofile",
+        ),
+    ],
+)
+def test_voice_identity_contract_rejects_direct_dynamic_and_file_io_calls(
+    contract_checker,
+    tmp_path: Path,
+    source: str,
+    expected: str,
+) -> None:
+    package = _write_minimal_voice_identity_layout(tmp_path)
+    (package / "reference.py").write_text(source, encoding="utf-8")
+
+    messages = [
+        violation.message
+        for violation in contract_checker.check_voice_identity_contracts(tmp_path)
+    ]
+
+    assert any(expected in message for message in messages)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "call",
+    [
+        "np.copy([1.0])",
+        "np.zeros(1)",
+        "np.linalg.norm([1.0])",
+    ],
+)
+def test_voice_identity_contract_allows_in_memory_numpy_calls(
+    contract_checker,
+    tmp_path: Path,
+    call: str,
+) -> None:
+    package = _write_minimal_voice_identity_layout(tmp_path)
+    (package / "reference.py").write_text(
+        f"import numpy as np\n{call}\n",
+        encoding="utf-8",
+    )
+
+    assert contract_checker.check_voice_identity_contracts(tmp_path) == []
+
+
+@pytest.mark.unit
+def test_voice_identity_contract_allows_required_threading_lock(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    package = _write_minimal_voice_identity_layout(tmp_path)
+    (package / "reference.py").write_text(
+        "import threading\nthreading.Lock()\n",
+        encoding="utf-8",
+    )
+
+    assert contract_checker.check_voice_identity_contracts(tmp_path) == []
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "call",
+    [
+        "threading.Thread(target=lambda: None)",
+        "threading.Timer(1.0, lambda: None)",
+    ],
+)
+def test_voice_identity_contract_rejects_thread_creation(
+    contract_checker,
+    tmp_path: Path,
+    call: str,
+) -> None:
+    package = _write_minimal_voice_identity_layout(tmp_path)
+    (package / "reference.py").write_text(
+        f"import threading\n{call}.start()\n",
+        encoding="utf-8",
+    )
+
+    messages = [
+        violation.message
+        for violation in contract_checker.check_voice_identity_contracts(tmp_path)
+    ]
+
+    assert any(
+        "may only call threading.Lock" in message
+        for message in messages
+    )
+
+
+@pytest.mark.unit
+def test_voice_identity_contract_applies_comprehension_targets_in_order(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    package = _write_minimal_voice_identity_layout(tmp_path)
+    (package / "reference.py").write_text(
+        "import numpy as np\n"
+        "values = [x for x in (1,) for np in np.load('embedding.npy')]\n",
+        encoding="utf-8",
+    )
+
+    messages = [
+        violation.message
+        for violation in contract_checker.check_voice_identity_contracts(tmp_path)
+    ]
+
+    assert "voice_identity domain must not perform file I/O via numpy.load" in messages
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "source",
+    [
+        "def invoke(open):\n    open()\n",
+        "def invoke(eval):\n    eval()\n",
+        "def invoke(exec):\n    exec()\n",
+        "def invoke(__import__):\n    __import__()\n",
+        "def open():\n    pass\nopen()\n",
+    ],
+)
+def test_voice_identity_contract_allows_shadowed_protected_builtins(
+    contract_checker,
+    tmp_path: Path,
+    source: str,
+) -> None:
+    package = _write_minimal_voice_identity_layout(tmp_path)
+    (package / "reference.py").write_text(source, encoding="utf-8")
+
+    assert contract_checker.check_voice_identity_contracts(tmp_path) == []
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("call", "resolved"),
+    [
+        ("np.lib.npyio.load('embedding.npy')", "numpy.lib.npyio.load"),
+        ("np.lib.format.read_array(stream)", "numpy.lib.format.read_array"),
+        (
+            "np.lib.format.write_array(stream, np.zeros(1))",
+            "numpy.lib.format.write_array",
+        ),
+        ("np.lib.npyio.DataSource()", "numpy.lib.npyio.DataSource"),
+        ("np.DataSource().open('embedding.npy')", "numpy.DataSource"),
+    ],
+)
+def test_voice_identity_contract_rejects_unapproved_direct_numpy_calls(
+    contract_checker,
+    tmp_path: Path,
+    call: str,
+    resolved: str,
+) -> None:
+    package = _write_minimal_voice_identity_layout(tmp_path)
+    (package / "reference.py").write_text(
+        f"import numpy as np\n{call}\n",
+        encoding="utf-8",
+    )
+
+    messages = [
+        violation.message
+        for violation in contract_checker.check_voice_identity_contracts(tmp_path)
+    ]
+
+    assert any(
+        "may only call approved in-memory NumPy APIs" in message
+        and resolved in message
+        for message in messages
+    )
+
+
+@pytest.mark.unit
+def test_voice_identity_contract_allows_unresolved_dump_method(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    package = _write_minimal_voice_identity_layout(tmp_path)
+    (package / "reference.py").write_text(
+        "class Snapshot:\n"
+        "    def dump(self):\n"
+        "        return b'snapshot'\n"
+        "\n"
+        "value = Snapshot().dump()\n",
+        encoding="utf-8",
+    )
+
+    assert contract_checker.check_voice_identity_contracts(tmp_path) == []
+
+
+@pytest.mark.unit
+def test_voice_identity_contract_allows_local_variable_dump_method(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    package = _write_minimal_voice_identity_layout(tmp_path)
+    (package / "reference.py").write_text(
+        "class Snapshot:\n"
+        "    def dump(self):\n"
+        "        return b'snapshot'\n"
+        "\n"
+        "snapshot = Snapshot()\n"
+        "value = snapshot.dump()\n",
+        encoding="utf-8",
+    )
+
+    assert contract_checker.check_voice_identity_contracts(tmp_path) == []
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "function_source",
+    [
+        "def use(np):\n    np.save()",
+        "async def use(np):\n    np.save()",
+        "def use():\n    np = Snapshot()\n    np.save()",
+        "use = lambda np: np.save()",
+        "values = [np.save() for np in (Snapshot(),)]",
+        "values = {np.save() for np in (Snapshot(),)}",
+        "values = (np.save() for np in (Snapshot(),))",
+        "values = {np: np.save() for np in (Snapshot(),)}",
+    ],
+)
+def test_voice_identity_contract_respects_local_import_shadowing(
+    contract_checker,
+    tmp_path: Path,
+    function_source: str,
+) -> None:
+    package = _write_minimal_voice_identity_layout(tmp_path)
+    (package / "reference.py").write_text(
+        "import numpy as np\n"
+        "class Snapshot:\n"
+        "    def save(self):\n"
+        "        return None\n"
+        f"{function_source}\n",
+        encoding="utf-8",
+    )
+
+    assert contract_checker.check_voice_identity_contracts(tmp_path) == []
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        (
+            "import numpy as np\nnp.array([1.0]).dump('embedding.pkl')\n",
+            "file I/O via numpy.ndarray.dump",
+        ),
+        (
+            "import numpy as np\n"
+            "np.f2py.compile('end', modulename='carrier')\n",
+            "native code via numpy.f2py.compile",
+        ),
+    ],
+)
+def test_voice_identity_contract_rejects_direct_numpy_boundary_bypasses(
+    contract_checker,
+    tmp_path: Path,
+    source: str,
+    expected: str,
+) -> None:
+    package = _write_minimal_voice_identity_layout(tmp_path)
+    (package / "reference.py").write_text(source, encoding="utf-8")
+
+    messages = [
+        violation.message
+        for violation in contract_checker.check_voice_identity_contracts(tmp_path)
+    ]
+
+    assert any(expected in message for message in messages)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        (
+            "import numpy as np\n"
+            "embedding = np.array([1.0])\n"
+            "embedding.dump('embedding.pkl')\n",
+            "file I/O via embedding.dump",
+        ),
+        (
+            "import numpy as np\n"
+            "embedding = np.array([1.0])\n"
+            "np.ndarray.dump(embedding, 'embedding.pkl')\n",
+            "file I/O via numpy.ndarray.dump",
+        ),
+        (
+            "import numpy as np\n"
+            "def persist():\n"
+            "    embedding = np.array([1.0])\n"
+            "    embedding.dump('embedding.pkl')\n",
+            "file I/O via embedding.dump",
+        ),
+    ],
+)
+def test_voice_identity_contract_rejects_other_ndarray_dump_forms(
+    contract_checker,
+    tmp_path: Path,
+    source: str,
+    expected: str,
+) -> None:
+    package = _write_minimal_voice_identity_layout(tmp_path)
+    (package / "reference.py").write_text(source, encoding="utf-8")
+
+    messages = [
+        violation.message
+        for violation in contract_checker.check_voice_identity_contracts(tmp_path)
+    ]
+
+    assert any(expected in message for message in messages)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("call", "expected"),
+    [
+        (
+            "np.recfromtxt('embedding.csv')",
+            "file I/O via numpy.recfromtxt",
+        ),
+        (
+            "np.fromregex('embedding.txt', r'.*', [('value', float)])",
+            "file I/O via numpy.fromregex",
+        ),
+        (
+            "np.ctypeslib.load_library('carrier', '.')",
+            "native library via numpy.ctypeslib.load_library",
+        ),
+    ],
+)
+def test_voice_identity_contract_rejects_explicitly_dangerous_numpy_calls(
+    contract_checker,
+    tmp_path: Path,
+    call: str,
+    expected: str,
+) -> None:
+    package = _write_minimal_voice_identity_layout(tmp_path)
+    (package / "reference.py").write_text(
+        f"import numpy as np\n{call}\n",
+        encoding="utf-8",
+    )
+
+    messages = [
+        violation.message
+        for violation in contract_checker.check_voice_identity_contracts(tmp_path)
+    ]
+
+    assert any(expected in message for message in messages)
+
+
+@pytest.mark.unit
+def test_voice_identity_contract_does_not_claim_reflection_is_a_sandbox(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    package = _write_minimal_voice_identity_layout(tmp_path)
+    (package / "reference.py").write_text(
+        "getter = getattr(__builtins__, 'open')\n",
+        encoding="utf-8",
+    )
+
+    assert contract_checker.check_voice_identity_contracts(tmp_path) == []
+
+
+@pytest.mark.unit
+def test_voice_identity_contract_rejects_model_assets_inside_domain_package(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    package = _write_minimal_voice_identity_layout(tmp_path)
+    model_path = package / "models" / "speaker.onnx"
+    model_path.parent.mkdir()
+    model_path.write_bytes(b"not-a-real-model")
+
+    messages = [
+        violation.message
+        for violation in contract_checker.check_voice_identity_contracts(tmp_path)
+    ]
+
+    assert (
+        "voice_identity domain must not contain packaged assets; "
+        "found models/speaker.onnx"
+        in messages
+    )

--- a/tests/unit/voice_identity/test_profile.py
+++ b/tests/unit/voice_identity/test_profile.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import copy
+import gc
+
+import numpy as np
+import pytest
+
+from main_logic.voice_identity.contracts import SpeakerModelIdentity
+from main_logic.voice_identity.profile import SpeakerProfile
+from main_logic.voice_identity.reference import SpeakerReference
+
+
+def _reference() -> SpeakerReference:
+    return SpeakerReference(
+        SpeakerModelIdentity(
+            model_id="speaker-model",
+            model_revision="revision-1",
+            embedding_dimension=2,
+        ),
+        [3.0, 4.0],
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("generation", ["", "   ", 1, None])
+def test_profile_rejects_invalid_generation(generation: object) -> None:
+    reference = _reference()
+    try:
+        with pytest.raises(ValueError):
+            SpeakerProfile(generation, reference)  # type: ignore[arg-type]
+    finally:
+        reference.close()
+
+
+@pytest.mark.unit
+def test_profile_rejects_generation_string_subclasses() -> None:
+    class Generation(str):
+        pass
+
+    reference = _reference()
+    try:
+        with pytest.raises(ValueError, match="generation"):
+            SpeakerProfile(Generation("generation-a"), reference)
+    finally:
+        reference.close()
+
+
+@pytest.mark.unit
+def test_profile_requires_concrete_reference() -> None:
+    class ReferenceSubclass(SpeakerReference):
+        pass
+
+    reference = ReferenceSubclass(
+        SpeakerModelIdentity("speaker-model", "revision-1", 2),
+        [3.0, 4.0],
+    )
+    try:
+        with pytest.raises(TypeError, match="reference"):
+            SpeakerProfile("generation-a", reference)
+    finally:
+        reference.close()
+
+
+@pytest.mark.unit
+def test_profile_clones_input_reference_and_exposes_only_clones() -> None:
+    reference = _reference()
+    profile = SpeakerProfile("generation-a", reference)
+    reference.close()
+
+    clone = profile.clone_reference()
+    observed = clone.copy_embedding()
+    try:
+        assert profile.generation == "generation-a"
+        assert profile.model_identity.model_id == "speaker-model"
+        np.testing.assert_allclose(
+            observed,
+            np.array([0.6, 0.8], dtype=np.float32),
+        )
+
+        profile.close()
+        after_close = clone.copy_embedding()
+        try:
+            np.testing.assert_allclose(
+                after_close,
+                np.array([0.6, 0.8], dtype=np.float32),
+            )
+        finally:
+            after_close.fill(0.0)
+    finally:
+        observed.fill(0.0)
+        clone.close()
+        profile.close()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("copy_profile", [copy.copy, copy.deepcopy])
+def test_profile_copy_has_independent_ownership(copy_profile) -> None:
+    reference = _reference()
+    profile = SpeakerProfile("generation-a", reference)
+    reference.close()
+    copied = copy_profile(profile)
+    profile.close()
+
+    clone = copied.clone_reference()
+    observed = clone.copy_embedding()
+    try:
+        np.testing.assert_allclose(
+            observed,
+            np.array([0.6, 0.8], dtype=np.float32),
+        )
+    finally:
+        observed.fill(0.0)
+        clone.close()
+        copied.close()
+
+
+@pytest.mark.unit
+def test_profile_close_cascades_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    reference = _reference()
+    profile = SpeakerProfile("generation-a", reference)
+    reference.close()
+    close_calls: list[SpeakerReference] = []
+    original_close = SpeakerReference.close
+
+    def tracked_close(instance: SpeakerReference) -> None:
+        close_calls.append(instance)
+        original_close(instance)
+
+    monkeypatch.setattr(SpeakerReference, "close", tracked_close)
+
+    profile.close()
+    profile.close()
+    assert profile.closed
+    del profile
+    gc.collect()
+
+    assert len(close_calls) == 1
+
+
+@pytest.mark.unit
+def test_closed_profile_blocks_use() -> None:
+    reference = _reference()
+    profile = SpeakerProfile("generation-a", reference)
+    reference.close()
+    profile.close()
+
+    with pytest.raises(RuntimeError, match="closed"):
+        _ = profile.generation
+    with pytest.raises(RuntimeError, match="closed"):
+        _ = profile.model_identity
+    with pytest.raises(RuntimeError, match="closed"):
+        profile.clone_reference()
+    with pytest.raises(RuntimeError, match="closed"):
+        copy.copy(profile)
+
+
+@pytest.mark.unit
+def test_profile_repr_never_contains_embedding() -> None:
+    reference = SpeakerReference(
+        SpeakerModelIdentity("speaker-model", "revision-1", 2),
+        [0.1234567, 0.7654321],
+    )
+    profile = SpeakerProfile("generation-a", reference)
+    try:
+        assert "0.1234567" not in repr(profile)
+        assert "0.7654321" not in repr(profile)
+    finally:
+        profile.close()
+        reference.close()

--- a/tests/unit/voice_identity/test_reference.py
+++ b/tests/unit/voice_identity/test_reference.py
@@ -119,6 +119,27 @@ def test_reference_normalizes_and_defensively_copies_input() -> None:
 
 
 @pytest.mark.unit
+def test_reference_normalizes_float32_subnormals_in_float64() -> None:
+    smallest = np.nextafter(np.float32(0.0), np.float32(1.0))
+    reference = SpeakerReference(
+        _identity(),
+        np.array([smallest, smallest], dtype=np.float32),
+    )
+
+    observed = reference.copy_embedding()
+    try:
+        expected = np.float32(1.0 / np.sqrt(2.0))
+        np.testing.assert_array_equal(
+            observed,
+            np.array([expected, expected], dtype=np.float32),
+        )
+        assert np.linalg.norm(observed.astype(np.float64)) == pytest.approx(1.0)
+    finally:
+        observed.fill(0.0)
+        reference.close()
+
+
+@pytest.mark.unit
 def test_embedding_copies_have_independent_caller_ownership() -> None:
     reference = SpeakerReference(_identity(), [3.0, 4.0])
     first = reference.copy_embedding()

--- a/tests/unit/voice_identity/test_reference.py
+++ b/tests/unit/voice_identity/test_reference.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import copy
+import json
+import pickle
+import threading
+
+import numpy as np
+import pytest
+
+import main_logic.voice_identity.reference as reference_module
+from main_logic.voice_identity.contracts import SpeakerModelIdentity
+from main_logic.voice_identity.reference import SpeakerReference
+
+
+def _identity(dimension: int = 2) -> SpeakerModelIdentity:
+    return SpeakerModelIdentity(
+        model_id="speaker-model",
+        model_revision="revision-1",
+        embedding_dimension=dimension,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"model_id": "", "model_revision": "revision", "embedding_dimension": 2},
+        {"model_id": "   ", "model_revision": "revision", "embedding_dimension": 2},
+        {"model_id": "model", "model_revision": "", "embedding_dimension": 2},
+        {"model_id": "model", "model_revision": "   ", "embedding_dimension": 2},
+        {"model_id": "model", "model_revision": "revision", "embedding_dimension": 0},
+        {"model_id": "model", "model_revision": "revision", "embedding_dimension": -1},
+        {"model_id": "model", "model_revision": "revision", "embedding_dimension": True},
+        {"model_id": "model", "model_revision": "revision", "embedding_dimension": 2.0},
+    ],
+)
+def test_model_identity_rejects_invalid_values(kwargs: dict[str, object]) -> None:
+    with pytest.raises(ValueError):
+        SpeakerModelIdentity(**kwargs)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_reference_requires_concrete_model_identity() -> None:
+    class IdentitySubclass(SpeakerModelIdentity):
+        pass
+
+    identity = IdentitySubclass("speaker-model", "revision-1", 2)
+
+    with pytest.raises(TypeError, match="model_identity"):
+        SpeakerReference(identity, [3.0, 4.0])
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "embedding",
+    [
+        np.array(1.0, dtype=np.float32),
+        np.array([[1.0, 0.0]], dtype=np.float32),
+        np.array([1.0], dtype=np.float32),
+        np.array([0.0, 0.0], dtype=np.float32),
+        np.array([np.nan, 1.0], dtype=np.float32),
+        np.array([np.inf, 1.0], dtype=np.float32),
+        np.array([1.0 + 1.0j, 2.0], dtype=np.complex64),
+    ],
+)
+def test_reference_rejects_invalid_embeddings(embedding: np.ndarray) -> None:
+    with pytest.raises(ValueError):
+        SpeakerReference(_identity(), embedding)
+
+
+@pytest.mark.unit
+def test_reference_error_does_not_echo_embedding() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        SpeakerReference(_identity(), ["sensitive-vector", "value"])
+
+    assert "sensitive-vector" not in str(exc_info.value)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("failing_call", [1, 2])
+def test_reference_preserves_memory_error_during_conversion(
+    monkeypatch: pytest.MonkeyPatch,
+    failing_call: int,
+) -> None:
+    original_array = reference_module.np.array
+    call_count = 0
+
+    def array_with_allocation_failure(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == failing_call:
+            raise MemoryError("allocation failed")
+        return original_array(*args, **kwargs)
+
+    monkeypatch.setattr(reference_module.np, "array", array_with_allocation_failure)
+
+    with pytest.raises(MemoryError, match="allocation failed"):
+        SpeakerReference(_identity(), [3.0, 4.0])
+
+
+@pytest.mark.unit
+def test_reference_normalizes_and_defensively_copies_input() -> None:
+    source = np.array([3.0, 4.0], dtype=np.float64)
+    reference = SpeakerReference(_identity(), source)
+    source[:] = 99.0
+
+    observed = reference.copy_embedding()
+    try:
+        assert observed.dtype == np.dtype(np.float32)
+        assert observed.flags.c_contiguous
+        np.testing.assert_allclose(
+            observed,
+            np.array([0.6, 0.8], dtype=np.float32),
+        )
+    finally:
+        observed.fill(0.0)
+        reference.close()
+
+
+@pytest.mark.unit
+def test_embedding_copies_have_independent_caller_ownership() -> None:
+    reference = SpeakerReference(_identity(), [3.0, 4.0])
+    first = reference.copy_embedding()
+    second = reference.copy_embedding()
+    try:
+        assert first.flags.owndata
+        assert second.flags.owndata
+        assert not np.shares_memory(first, second)
+
+        first.fill(0.0)
+        np.testing.assert_allclose(
+            second,
+            np.array([0.6, 0.8], dtype=np.float32),
+        )
+
+        third = reference.copy_embedding()
+        try:
+            np.testing.assert_allclose(
+                third,
+                np.array([0.6, 0.8], dtype=np.float32),
+            )
+        finally:
+            third.fill(0.0)
+    finally:
+        first.fill(0.0)
+        second.fill(0.0)
+        reference.close()
+
+
+@pytest.mark.unit
+def test_exported_copy_survives_reference_close() -> None:
+    reference = SpeakerReference(_identity(), [3.0, 4.0])
+    exported = reference.copy_embedding()
+
+    reference.close()
+
+    try:
+        assert type(exported) is np.ndarray
+        assert exported.flags.owndata
+        np.testing.assert_allclose(
+            exported,
+            np.array([0.6, 0.8], dtype=np.float32),
+        )
+    finally:
+        exported.fill(0.0)
+
+
+@pytest.mark.unit
+def test_clone_and_copy_protocols_have_independent_ownership() -> None:
+    reference = SpeakerReference(_identity(), [3.0, 4.0])
+    clones = (reference.clone(), copy.copy(reference), copy.deepcopy(reference))
+    reference.close()
+
+    try:
+        for clone in clones:
+            observed = clone.copy_embedding()
+            try:
+                np.testing.assert_allclose(
+                    observed,
+                    np.array([0.6, 0.8], dtype=np.float32),
+                )
+            finally:
+                observed.fill(0.0)
+    finally:
+        for clone in clones:
+            clone.close()
+
+
+@pytest.mark.unit
+def test_model_identity_is_returned_as_an_independent_value() -> None:
+    identity = _identity()
+    reference = SpeakerReference(identity, [3.0, 4.0])
+    try:
+        observed = reference.model_identity
+
+        assert observed == identity
+        assert observed is not identity
+    finally:
+        reference.close()
+
+
+@pytest.mark.unit
+def test_close_is_idempotent_and_blocks_use() -> None:
+    reference = SpeakerReference(_identity(), [3.0, 4.0])
+
+    reference.close()
+    reference.close()
+
+    assert reference.closed
+    with pytest.raises(RuntimeError, match="closed"):
+        _ = reference.model_identity
+    with pytest.raises(RuntimeError, match="closed"):
+        reference.clone()
+    with pytest.raises(RuntimeError, match="closed"):
+        reference.copy_embedding()
+
+
+@pytest.mark.unit
+def test_close_commits_state_before_best_effort_wipe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reference = SpeakerReference(_identity(), [3.0, 4.0])
+    original_wipe = reference_module._wipe
+
+    def interrupted_wipe(array: np.ndarray) -> None:
+        original_wipe(array)
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(reference_module, "_wipe", interrupted_wipe)
+
+    with pytest.raises(KeyboardInterrupt):
+        reference.close()
+
+    assert reference.closed
+    with pytest.raises(RuntimeError, match="closed"):
+        reference.copy_embedding()
+
+
+@pytest.mark.unit
+def test_copy_and_close_are_serialized() -> None:
+    reference = SpeakerReference(_identity(), [3.0, 4.0])
+    barrier = threading.Barrier(2)
+    copies: list[np.ndarray] = []
+    failures: list[BaseException] = []
+
+    def copy_once() -> None:
+        barrier.wait()
+        try:
+            copies.append(reference.copy_embedding())
+        except BaseException as exc:
+            failures.append(exc)
+
+    worker = threading.Thread(target=copy_once)
+    worker.start()
+    barrier.wait()
+    reference.close()
+    worker.join(timeout=2.0)
+
+    assert not worker.is_alive()
+    assert len(copies) + len(failures) == 1
+    if copies:
+        try:
+            np.testing.assert_allclose(
+                copies[0],
+                np.array([0.6, 0.8], dtype=np.float32),
+            )
+        finally:
+            copies[0].fill(0.0)
+    else:
+        assert isinstance(failures[0], RuntimeError)
+
+
+@pytest.mark.unit
+def test_reference_has_no_internal_embedding_representation() -> None:
+    reference = SpeakerReference(_identity(), [0.1234567, 0.7654321])
+    try:
+        assert not hasattr(reference, "reference_embedding")
+        assert not hasattr(reference, "__dict__")
+        assert "0.1234567" not in repr(reference)
+        assert "0.7654321" not in repr(reference)
+        with pytest.raises(TypeError):
+            json.dumps(reference)
+        with pytest.raises(TypeError, match="must not be pickled"):
+            pickle.dumps(reference)
+        with pytest.raises(TypeError, match="must not be pickled"):
+            reference.__reduce__()
+    finally:
+        reference.close()


### PR DESCRIPTION
## 背景

Owner voice 后续能力需要一个 provider-neutral、仅内存且具备明确所有权的
Speaker Reference / Profile 基础。旧实现把可信进程内 adapter 误建模为不可信
Python callback，导致审查过程中持续扩张对象图扫描和静态传播分析；这些机制既不能
形成完整沙箱，也超出了本 PR 的领域基础范围。

本 PR 保留原 PR 编号，并将最终实现整理为 3 个逻辑提交；通过根因收敛移除上述
通用扫描能力，将最终代码边界恢复为显式所有权合同。

## 本 PR 交付

- immutable `SpeakerModelIdentity`；
- owned、finite、非零、L2-normalized 的一维 `float32` `SpeakerReference`；
- `copy_embedding()` 返回 caller-owned 独立副本，调用方负责使用后的清理；
- 独立 `clone()`、幂等 `close()`、关闭后 fail-closed 和禁止 pickle；
- caller-supplied opaque generation 的内存 `SpeakerProfile`；
- docstring-only 包初始化和协作式 import/layering 守门；
- 聚焦所有权、生命周期和直接架构违规的回归测试。

## 信任模型与边界

- `SpeakerReference` 保护内部 backing storage 的所有权，不构成 Python 沙箱；
- 进程内消费者必须是可信第一方代码，插件或其他不可信代码必须使用独立进程隔离；
- Core Contracts 是面向可信第一方仓库代码的合作式结构守门，只约束规范化、静态可解析的 import/call 与明确架构禁区；它不是 Python sandbox、解释器或完整语义分析器；
- “技术反例可复现”不自动构成当前合同缺陷：alias 重绑定、名称遮蔽、反射、刻意混淆语法、执行顺序和跨语句数据流只有在本 PR 明确支持的编码风格内才是 blocker；
- 当前 head 的守门能力到此冻结；后续 reviewer 若要求新增词法/动态作用域栈、执行顺序模型、别名传播、跨语句数据流或反射推断，默认按超出范围处理，不再自动补丁；领域代码应采用受限且规范化的写法；
- 不提供面向产品、网络、插件或 UI 的 raw embedding/similarity 接口。

## 明确不包含

- #2460 的 Owner 声纹软拦截、策略、ASR runtime 或 Core composition；
- Enrollment service/session/TTL、PCM 状态机或 CAM++ worker；
- ProfileStore、keyring、AES-GCM、配置、数据库或迁移；
- app-owned service、API、router、registry、service locator 或 UI。

#2460 仍是独立业务 PR；它需要在本 PR 收敛后的 head 上 rebase，并把唯一消费者改为
`reference.copy_embedding()`。

## 回归报告 / Regression Report

- **改动内容：** 新增仅内存的模型身份、Reference、Profile 合同；最终净实现删除泛型
  builder/object-graph 扫描、deferred cleanup 和反射数据流分析，改为明确的 caller-owned
  copy API 与协作式架构 lint。
- **理由与必要性：** 实际消费者只需要独立 embedding copy。收窄 API 后，临时向量是否
  藏在任意 Python 对象图中的开放世界问题不再存在，领域层也不再承担恶意进程内代码
  隔离责任。
- **改动前：** main 没有 `main_logic.voice_identity`；PR 审查版本曾扩张到约 11.2k 行
  新增，并试图跟踪 Future、generator、weakref、descriptor、native carrier 和任意反射
  import 绕过。
- **改动后：** PR 净新增约 2.6k 行；`reference.py` 保持聚焦的所有权、校验、复制和生命周期
  实现。当前 main 产品执行流不创建或消费这些对象，运行时行为保持不变。
- **潜在回归点：** embedding dtype/shape/norm、caller-owned copy 与内部数组隔离、并发
  copy/close、Profile clone/close，以及 Core Contracts 对正常 import 的误报。上述边界由
  聚焦回归覆盖；真正 PR merge-base 的 GitNexus 检测为 LOW、0 affected processes。

## 风险

调用方取得独立 copy 后必须自行清理；Python、NumPy 和底层分配器仍可能保留不可寻址
历史副本，因此 best-effort 清零不宣称密码学擦除。后续新增领域模块必须明确更新依赖
allowlist，不得重新引入通用对象图扫描或定制 Python 解释器行为。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增与供应商无关的内存式说话人身份模型、引用和配置。
  - 支持嵌入向量校验、归一化、防御性复制及独立克隆。
  - 提供线程安全的关闭、清零和生命周期管理，关闭后限制访问。
  - 公开表示、错误信息及序列化不会暴露嵌入数据。

- **文档**
  - 新增设计说明，明确模型边界与支持范围。

- **测试**
  - 增加身份模型、生命周期、数据安全及依赖约束的自动化验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->