### PR TITLE
feat: 增加测试版 Owner 声纹软拦截

### DIFF
--- a/docs/design/owner-voice-soft-filter.md
+++ b/docs/design/owner-voice-soft-filter.md
@@ -1,0 +1,52 @@
+# Owner Voice Soft Filter (Beta v1)
+
+## Scope
+
+This phase introduces a pure, provider-neutral policy that evaluates Speaker
+Shadow observations plus an opt-in ASR composition layer. The policy itself
+does not own or mutate ASR, Core, CAM++, or application services, and its
+`HYPOTHETICAL_REJECT` result remains non-authoritative in isolation.
+
+When an `OwnerVoiceAsrCompositionFactory` is explicitly injected, the
+composition correlates that result with the current authoritative detector
+candidate and may issue a `CandidateRejectionRequest`. The ASR runtime accepts
+only an exact session, audio, transport, turn, detector-candidate, profile, and
+filter identity match. An accepted request releases the reserved final,
+invalidates and detaches the provider transport, aborts queued audio, and
+suppresses only the rejected candidate's tail until its matching pause resets
+the detector. Stale or incomplete identity, already-paused candidates, model
+or cleanup failures, and teardown all fail open while abandoning any prepared
+Core turn exactly once.
+
+This repository phase does not install that factory in application startup and
+does not introduce profile persistence, service-location, configuration, UI,
+or runtime profile hot-swap behavior.
+
+## Fixed beta-v1 rule
+
+The policy accepts observations only at two exact checkpoints:
+
+- 1,500 ms
+- 3,000 ms
+
+It emits `HYPOTHETICAL_REJECT` only when both observations belong to the same
+active detector epoch, candidate generation, and profile generation, and both
+finite similarity scores are strictly below `0.40`.
+
+Every other case emits `FORWARD`, including a score equal to `0.40`, a missing
+checkpoint, an invalid score, a disabled evaluation, or a detector/candidate/
+profile identity mismatch. This is a fail-open beta policy, not an identity
+claim.
+
+## State and dependency boundary
+
+Only the first low observation is retained. Pending state is keyed by the full
+detector epoch, candidate generation, and profile generation, bounded by a
+caller-selected positive capacity (256 by default), and evicts the oldest
+candidate when full. Candidate completion may explicitly forget its state,
+and session teardown may reset all pending state.
+
+`main_logic.voice_identity.policy` uses only built-in Python types. It imports
+neither ASR nor Core nor a model runtime, and it does not expose raw embeddings
+or a product-facing similarity API. No profile persistence, registry, service
+locator, runtime profile swap, configuration, UI, or API is introduced here.

--- a/main_logic/asr_client/candidate_control/__init__.py
+++ b/main_logic/asr_client/candidate_control/__init__.py
@@ -1,0 +1,5 @@
+"""Provider-neutral candidate rejection contracts."""
+
+from .contracts import CandidateRejectionOutcome, CandidateRejectionRequest
+
+__all__ = ["CandidateRejectionOutcome", "CandidateRejectionRequest"]

--- a/main_logic/asr_client/candidate_control/contracts.py
+++ b/main_logic/asr_client/candidate_control/contracts.py
@@ -1,0 +1,46 @@
+"""Immutable fences for an asynchronous candidate rejection transaction."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from ..endpointing.detector import DetectorCandidateKey
+
+
+class CandidateRejectionOutcome(Enum):
+    """Result of a fail-open candidate rejection attempt."""
+
+    APPLIED = "applied"
+    STALE = "stale"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateRejectionRequest:
+    """Full runtime fence for one detector-authoritative candidate."""
+
+    session_epoch: int
+    audio_generation: int
+    transport_generation: int
+    turn_id: int
+    candidate: DetectorCandidateKey
+    profile_generation: str
+    filter_generation: str
+
+    def __post_init__(self) -> None:
+        for name in (
+            "session_epoch",
+            "audio_generation",
+            "transport_generation",
+            "turn_id",
+        ):
+            value = getattr(self, name)
+            if type(value) is not int or value < 0:
+                raise ValueError(f"{name} must be a non-negative integer")
+        if type(self.candidate) is not DetectorCandidateKey:
+            raise TypeError("candidate must be DetectorCandidateKey")
+        for name in ("profile_generation", "filter_generation"):
+            value = getattr(self, name)
+            if type(value) is not str or not value.strip():
+                raise ValueError(f"{name} must be a non-empty string")

--- a/main_logic/asr_client/endpointing/detector_runtime.py
+++ b/main_logic/asr_client/endpointing/detector_runtime.py
@@ -175,6 +175,7 @@ class _VoiceTurnAdapter:
         self._evaluation_tail_capacity_us = queue_capacity_ms * 1_000
         self._evaluation_tail: list[_AudioItem] = []
         self._evaluation_tail_duration_us = 0
+        self._evaluation_tail_candidate_start: _AudioItem | None = None
         self._continuation_timeout_seconds = continuation_timeout_seconds
         self._max_endpoint_wait_seconds = max_endpoint_wait_seconds
         self._smart_turn_required = smart_turn_required
@@ -488,7 +489,8 @@ class _VoiceTurnAdapter:
                 duration_us=item.duration_us,
                 detector_identity=item.detector_identity,
             )
-        if self._evaluation_task is not None:
+        evaluation_in_flight = self._evaluation_task is not None
+        if evaluation_in_flight:
             self._evaluation_tail.append(item)
             self._evaluation_tail_duration_us += item.duration_us
         else:
@@ -533,11 +535,17 @@ class _VoiceTurnAdapter:
                 await self._on_scoped_activity(event, item.detector_identity)
             await self._coordinator.on_activity_event(event)
 
-        if any(
+        candidate_started = any(
             event
             in (SpeechActivityEvent.SPEECH_STARTED, SpeechActivityEvent.SPEECH_RESUMED)
             for event in events
-        ):
+        )
+        if candidate_started:
+            if (
+                evaluation_in_flight
+                and self._evaluation_tail_candidate_start is None
+            ):
+                self._evaluation_tail_candidate_start = item
             self._start_observed_candidate(item)
             self._cancel_smart_turn_unload()
             self._cancel_fallback()
@@ -639,6 +647,8 @@ class _VoiceTurnAdapter:
         evaluation_tail = tuple(self._evaluation_tail)
         self._evaluation_tail.clear()
         self._evaluation_tail_duration_us = 0
+        evaluation_tail_candidate_start = self._evaluation_tail_candidate_start
+        self._evaluation_tail_candidate_start = None
         reevaluate = self._reevaluation_requested
         reevaluation_reason = self._reevaluation_reason or item.reason
         self._reevaluation_requested = False
@@ -718,14 +728,18 @@ class _VoiceTurnAdapter:
             if completion_published is not None:
                 await completion_published
             for tail_item in evaluation_tail:
-                await self._process_audio(
-                    _AudioItem(
-                        identity=active_identity,
-                        pcm16=tail_item.pcm16,
-                        duration_us=tail_item.duration_us,
-                        detector_identity=tail_item.detector_identity,
-                    )
+                replay_item = _AudioItem(
+                    identity=active_identity,
+                    pcm16=tail_item.pcm16,
+                    duration_us=tail_item.duration_us,
+                    detector_identity=tail_item.detector_identity,
                 )
+                await self._process_audio(replay_item)
+                if (
+                    active_identity != item.identity
+                    and tail_item is evaluation_tail_candidate_start
+                ):
+                    self._start_observed_candidate(replay_item)
             return
         if status is EvaluationStatus.OK and decision is TurnDecision.INCOMPLETE:
             self._observe_evaluation_tail(evaluation_tail)
@@ -825,6 +839,7 @@ class _VoiceTurnAdapter:
         self._latest_detector_identity = None
         self._evaluation_tail.clear()
         self._evaluation_tail_duration_us = 0
+        self._evaluation_tail_candidate_start = None
         self._successor_audio_fence = None
         await self._coordinator.reset()
         await asyncio.to_thread(self._gate.reset)

--- a/main_logic/asr_client/endpointing/detector_runtime.py
+++ b/main_logic/asr_client/endpointing/detector_runtime.py
@@ -755,8 +755,15 @@ class _VoiceTurnAdapter:
         self._enter_semantic_degraded()
         self._schedule_fallback(item.identity, "semantic_degraded")
 
-    def _observe_accepted_audio(self, item: _AudioItem) -> None:
-        callback = self._on_accepted_audio
+    def _dispatch_audio_observer(
+        self,
+        callback: Callable[
+            [bytes, int, DetectorIngressIdentity | None],
+            None,
+        ]
+        | None,
+        item: _AudioItem,
+    ) -> None:
         if callback is None:
             return
         try:
@@ -764,14 +771,11 @@ class _VoiceTurnAdapter:
         except Exception:
             return
 
+    def _observe_accepted_audio(self, item: _AudioItem) -> None:
+        self._dispatch_audio_observer(self._on_accepted_audio, item)
+
     def _start_observed_candidate(self, item: _AudioItem) -> None:
-        callback = self._on_candidate_start
-        if callback is None:
-            return
-        try:
-            callback(item.pcm16, 16_000, item.detector_identity)
-        except Exception:
-            return
+        self._dispatch_audio_observer(self._on_candidate_start, item)
 
     def _observe_evaluation_tail(self, items: tuple[_AudioItem, ...]) -> None:
         for item in items:

--- a/main_logic/asr_client/endpointing/detector_runtime.py
+++ b/main_logic/asr_client/endpointing/detector_runtime.py
@@ -125,6 +125,10 @@ class _VoiceTurnAdapter:
             [bytes, int, DetectorIngressIdentity | None], None
         ]
         | None = None,
+        on_candidate_start: Callable[
+            [bytes, int, DetectorIngressIdentity | None], None
+        ]
+        | None = None,
         on_candidate_complete: Callable[[DetectorIngressIdentity | None], None]
         | None = None,
         queue_maxsize: int = 128,
@@ -160,6 +164,7 @@ class _VoiceTurnAdapter:
         self._on_scoped_commit = on_scoped_commit
         self._on_scoped_activity = on_scoped_activity
         self._on_accepted_audio = on_accepted_audio
+        self._on_candidate_start = on_candidate_start
         self._on_candidate_complete = on_candidate_complete
         self._queue: DetectorDurationQueue[_AudioItem, _ControlItem] = (
             DetectorDurationQueue(
@@ -533,6 +538,7 @@ class _VoiceTurnAdapter:
             in (SpeechActivityEvent.SPEECH_STARTED, SpeechActivityEvent.SPEECH_RESUMED)
             for event in events
         ):
+            self._start_observed_candidate(item)
             self._cancel_smart_turn_unload()
             self._cancel_fallback()
             self._strict_endpoint_deadline = None
@@ -569,6 +575,7 @@ class _VoiceTurnAdapter:
             if self._on_scoped_activity is not None and item.detector_identity is not None:
                 await self._on_scoped_activity(event, item.detector_identity)
             await self._coordinator.on_activity_event(event)
+            self._start_observed_candidate(item)
         self._fallback_audio_bytes += len(item.pcm16)
         if started_now:
             return
@@ -750,6 +757,15 @@ class _VoiceTurnAdapter:
 
     def _observe_accepted_audio(self, item: _AudioItem) -> None:
         callback = self._on_accepted_audio
+        if callback is None:
+            return
+        try:
+            callback(item.pcm16, 16_000, item.detector_identity)
+        except Exception:
+            return
+
+    def _start_observed_candidate(self, item: _AudioItem) -> None:
+        callback = self._on_candidate_start
         if callback is None:
             return
         try:
@@ -1277,6 +1293,11 @@ class DetectorRuntime:
                     if self._speaker_shadow is not None
                     else None
                 ),
+                on_candidate_start=(
+                    self._start_smart_turn_speaker_shadow
+                    if self._speaker_shadow is not None
+                    else None
+                ),
                 on_candidate_complete=(
                     self._finish_smart_turn_speaker_shadow
                     if self._speaker_shadow is not None
@@ -1324,6 +1345,51 @@ class DetectorRuntime:
             if adapter is not None
             else 0
         )
+
+    async def current_candidate(self) -> DetectorCandidateKey | None:
+        """Return the current detector-owned candidate, if one is open."""
+
+        async with self._lock:
+            if self._closed or not self._candidate_open:
+                return None
+            return DetectorCandidateKey(
+                self._detector_epoch,
+                self._candidate_generation,
+            )
+
+    async def candidate_is_current(self, candidate: DetectorCandidateKey) -> bool:
+        """Fence execution against the detector's authoritative identity."""
+
+        if type(candidate) is not DetectorCandidateKey:
+            return False
+        async with self._lock:
+            return bool(
+                not self._closed
+                and self._candidate_open
+                and candidate.detector_epoch == self._detector_epoch
+                and candidate.candidate_generation == self._candidate_generation
+            )
+
+    async def correlate_speaker_shadow_candidate(
+        self,
+        shadow_candidate: SpeakerShadowCandidateKey,
+    ) -> DetectorCandidateKey | None:
+        """Resolve a private Shadow key to current detector authority."""
+
+        if type(shadow_candidate) is not SpeakerShadowCandidateKey:
+            return None
+        async with self._lock:
+            if (
+                self._closed
+                or not self._candidate_open
+                or shadow_candidate != self._speaker_shadow_candidate
+                or shadow_candidate.detector_epoch != self._detector_epoch
+            ):
+                return None
+            return DetectorCandidateKey(
+                self._detector_epoch,
+                self._candidate_generation,
+            )
 
     async def bind_candidate(
         self,
@@ -2040,7 +2106,11 @@ class DetectorRuntime:
                     if failed and not self._closed:
                         self._smart_turn_readiness = SmartTurnReadiness.FAILED
 
-    async def reset(self) -> None:
+    async def reset(
+        self,
+        *,
+        expected_candidate: DetectorCandidateKey | None = None,
+    ) -> bool:
         overflow_reset_task = self._overflow_reset_task
         if (
             overflow_reset_task is not None
@@ -2050,10 +2120,20 @@ class DetectorRuntime:
         adapter: _VoiceTurnAdapter | None = None
         semantic_identity: tuple[int, int, int] | None = None
         speaker_shadow: SpeakerShadowObserver | None = None
+        reset_applied = False
         try:
             async with self._lock:
                 if self._closed:
-                    return
+                    return False
+                if expected_candidate is not None and (
+                    type(expected_candidate) is not DetectorCandidateKey
+                    or not self._candidate_open
+                    or expected_candidate.detector_epoch != self._detector_epoch
+                    or expected_candidate.candidate_generation
+                    != self._candidate_generation
+                ):
+                    return False
+                reset_applied = True
                 self._detector_epoch += 1
                 self._reset_speaker_shadow_identity()
                 speaker_shadow = self._speaker_shadow
@@ -2099,7 +2179,9 @@ class DetectorRuntime:
                     utterance_id=semantic_identity[2],
                 )
         finally:
-            await self._reset_speaker_shadow(speaker_shadow)
+            if reset_applied:
+                await self._reset_speaker_shadow(speaker_shadow)
+        return reset_applied
 
     async def release_deferred_turn(self) -> None:
         """Release a deferred SmartTurn completion after the prior final."""
@@ -2192,9 +2274,30 @@ class DetectorRuntime:
         ):
             return
         candidate = self._speaker_shadow_candidate
-        if candidate is None:
-            candidate = self._open_speaker_shadow_candidate("smart_turn_turn")
         if candidate is None or candidate.scope != "smart_turn_turn":
+            return
+        self._submit_speaker_shadow(
+            pcm16,
+            sample_rate_hz=sample_rate_hz,
+            candidate=candidate,
+        )
+
+    def _start_smart_turn_speaker_shadow(
+        self,
+        pcm16: bytes,
+        sample_rate_hz: int,
+        detector_identity: DetectorIngressIdentity | None,
+    ) -> None:
+        if (
+            detector_identity is None
+            or detector_identity.detector_epoch != self._detector_epoch
+            or detector_identity.ingress_token != self._ingress_token
+            or detector_identity.sequence_no > self._sequence_no
+            or self._speaker_shadow_candidate is not None
+        ):
+            return
+        candidate = self._open_speaker_shadow_candidate("smart_turn_turn")
+        if candidate is None:
             return
         self._submit_speaker_shadow(
             pcm16,

--- a/main_logic/asr_client/endpointing/detector_runtime.py
+++ b/main_logic/asr_client/endpointing/detector_runtime.py
@@ -1370,6 +1370,29 @@ class DetectorRuntime:
                 and candidate.candidate_generation == self._candidate_generation
             )
 
+    async def candidate_is_bound_to(
+        self,
+        candidate: DetectorCandidateKey,
+        turn_token: VoiceTurnToken,
+    ) -> bool:
+        """Require current candidate authority to belong to one exact turn."""
+
+        if (
+            type(candidate) is not DetectorCandidateKey
+            or not isinstance(turn_token, VoiceTurnToken)
+        ):
+            return False
+        async with self._lock:
+            bound = self._bound_turns.get(candidate)
+            return bool(
+                not self._closed
+                and self._candidate_open
+                and candidate.detector_epoch == self._detector_epoch
+                and candidate.candidate_generation == self._candidate_generation
+                and bound is not None
+                and bound.turn_token == turn_token
+            )
+
     async def correlate_speaker_shadow_candidate(
         self,
         shadow_candidate: SpeakerShadowCandidateKey,

--- a/main_logic/asr_client/runtime.py
+++ b/main_logic/asr_client/runtime.py
@@ -138,6 +138,7 @@ class _CandidateRejectionSuppression:
     final_key: FinalKey
     lifecycle: VoiceInputLifecycleController
     detector: DetectorRuntime
+    cleanup_outcome: asyncio.Future[bool]
 
 
 class IndependentAsrRuntime:
@@ -2714,6 +2715,7 @@ class IndependentAsrRuntime:
                 final_key=final_key,
                 lifecycle=lifecycle,
                 detector=detector,
+                cleanup_outcome=asyncio.get_running_loop().create_future(),
             )
             self._asr_candidate_rejection = suppression
 
@@ -2735,11 +2737,24 @@ class IndependentAsrRuntime:
                 "[%s] candidate rejection session close failed open",
                 self.display_name,
             )
+        assert suppression is not None
+        if not suppression.cleanup_outcome.done():
+            suppression.cleanup_outcome.set_result(not cleanup_failed)
         if cleanup_failed:
-            assert suppression is not None
             await self._recover_candidate_rejection(suppression)
             return CandidateRejectionOutcome.FAILED
         return CandidateRejectionOutcome.APPLIED
+
+    def _candidate_rejection_matches_runtime(
+        self,
+        suppression: _CandidateRejectionSuppression,
+    ) -> bool:
+        return bool(
+            suppression.request.session_epoch == self._asr_session_epoch
+            and suppression.request.audio_generation == self._asr_audio_generation
+            and self._asr_lifecycle is suppression.lifecycle
+            and self._asr_detector is suppression.detector
+        )
 
     async def _recover_candidate_rejection(
         self,
@@ -2747,25 +2762,22 @@ class IndependentAsrRuntime:
     ) -> None:
         """Clear suppression after cleanup failure and resume fail-open input."""
 
-        should_restart = False
+        reset_required = False
         async with self._asr_final_lock:
             if self._asr_candidate_rejection is not suppression:
                 return
-            self._asr_candidate_rejection = None
-            lifecycle = suppression.lifecycle
-            if (
-                suppression.request.session_epoch == self._asr_session_epoch
-                and suppression.request.audio_generation == self._asr_audio_generation
-                and self._asr_lifecycle is lifecycle
-                and self._asr_detector is suppression.detector
-            ):
-                lifecycle.invalidate_audio()
-                should_restart = True
-        await self._notify_asr_turn_abandoned(suppression.turn_token)
-        if should_restart:
+            reset_required = self._candidate_rejection_matches_runtime(suppression)
+        if reset_required:
             try:
                 reset_applied = await suppression.detector.reset()
             except asyncio.CancelledError:
+                await self._notify_asr_turn_abandoned(suppression.turn_token)
+                async with self._asr_final_lock:
+                    if self._asr_candidate_rejection is suppression:
+                        lifecycle = suppression.lifecycle
+                        if self._candidate_rejection_matches_runtime(suppression):
+                            lifecycle.invalidate_audio()
+                        self._asr_candidate_rejection = None
                 raise
             except Exception:
                 logger.warning(
@@ -2773,14 +2785,35 @@ class IndependentAsrRuntime:
                     self.display_name,
                 )
                 reset_applied = False
-            if reset_applied:
-                self._ensure_transport_restart_task()
-            else:
+            if not reset_applied:
                 await self._handle_independent_asr_error(
                     suppression.request.session_epoch,
                     self._asr_provider or "unknown",
                     status_code="ASR_ENDPOINTING_FAILED",
                 )
+                notify_abandoned = False
+                async with self._asr_final_lock:
+                    if self._asr_candidate_rejection is suppression:
+                        self._asr_candidate_rejection = None
+                        notify_abandoned = True
+                if notify_abandoned:
+                    await self._notify_asr_turn_abandoned(suppression.turn_token)
+                return
+        should_restart = False
+        async with self._asr_final_lock:
+            if self._asr_candidate_rejection is not suppression:
+                return
+            self._asr_candidate_rejection = None
+            lifecycle = suppression.lifecycle
+            if (
+                reset_required
+                and self._candidate_rejection_matches_runtime(suppression)
+            ):
+                lifecycle.invalidate_audio()
+                should_restart = True
+        await self._notify_asr_turn_abandoned(suppression.turn_token)
+        if should_restart:
+            self._ensure_transport_restart_task()
 
     async def _finish_candidate_rejection(
         self,
@@ -2790,6 +2823,12 @@ class IndependentAsrRuntime:
 
         suppression = self._asr_candidate_rejection
         if suppression is None or suppression.request.candidate != candidate:
+            return False
+        cleanup_succeeded = await asyncio.shield(suppression.cleanup_outcome)
+        if (
+            not cleanup_succeeded
+            or self._asr_candidate_rejection is not suppression
+        ):
             return False
         reset_applied = False
         try:

--- a/main_logic/asr_client/runtime.py
+++ b/main_logic/asr_client/runtime.py
@@ -2006,16 +2006,15 @@ class IndependentAsrRuntime:
                     if not detector_result.throttle_available:
                         lifecycle.enable_independent_asr_fail_open()
                     else:
-                        current_candidate = getattr(
-                            detector,
-                            "current_candidate",
-                            None,
-                        )
-                        activity_candidate = (
-                            await current_candidate()
-                            if callable(current_candidate)
-                            else None
-                        )
+                        activity_candidate = None
+                        if detector_result.events:
+                            current_candidate = getattr(
+                                detector,
+                                "current_candidate",
+                                None,
+                            )
+                            if callable(current_candidate):
+                                activity_candidate = await current_candidate()
                         for event in detector_result.events:
                             await self._handle_independent_asr_activity(
                                 event,

--- a/main_logic/asr_client/runtime.py
+++ b/main_logic/asr_client/runtime.py
@@ -30,11 +30,13 @@ from main_logic.voice_turn.audio_input import ProcessedVoiceFrame
 
 from ._infra import logger, _READY_TIMEOUT_SECONDS
 from .audio import AsrAudioDispatcher
+from .candidate_control import CandidateRejectionOutcome, CandidateRejectionRequest
 from ._registry_meta import AsrProviderAvailability
 from .endpointing.detector import (
     AsrDetectorDispatcher,
     CoreDetectorEventEnvelope,
     DetectorActivityEvent,
+    DetectorCandidateKey,
     DetectorPrewarmEvent,
     DetectorRuntimeEvent,
     DetectorTransportPrewarmEvent,
@@ -127,6 +129,15 @@ class _AsrRuntimeIdentity:
     transport_task: asyncio.Task[None] | None
     ingress_token: VoiceIngressToken | None = None
     turn_token: VoiceTurnToken | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _CandidateRejectionSuppression:
+    request: CandidateRejectionRequest
+    turn_token: VoiceTurnToken
+    final_key: FinalKey
+    lifecycle: VoiceInputLifecycleController
+    detector: DetectorRuntime
 
 
 class IndependentAsrRuntime:
@@ -352,6 +363,10 @@ class IndependentAsrRuntime:
         self._asr_partial_turn_token: VoiceTurnToken | None = None
         self._asr_accepted_final_keys: OrderedDict[FinalKey, None] = OrderedDict()
         self._asr_reserved_final_key: FinalKey | None = None
+        self._asr_candidate_rejection: _CandidateRejectionSuppression | None = None
+        self._asr_candidate_pause_fence: (
+            tuple[int, int, DetectorCandidateKey] | None
+        ) = None
         self._asr_transcript_dispatcher = TranscriptDispatcher(
             self._dispatch_asr_transcript_envelope,
         )
@@ -636,6 +651,7 @@ class IndependentAsrRuntime:
             await self._handle_independent_asr_activity(
                 event.activity,
                 envelope.session_epoch,
+                candidate=event.candidate,
             )
             if not self._detector_envelope_is_current(envelope):
                 return
@@ -1726,9 +1742,11 @@ class IndependentAsrRuntime:
         except Exception:
             return
 
-    def _reset_asr_turn_state(self) -> None:
+    def _reset_asr_turn_state(self) -> VoiceTurnToken | None:
         """Reset per-turn bookkeeping shared by close/abort/error teardown."""
 
+        suppression = self._asr_candidate_rejection
+        abandoned_turn = suppression.turn_token if suppression is not None else None
         self._asr_turn_prepared = False
         self._asr_received_audio = False
         self._asr_pending_speech_confirmed = False
@@ -1741,11 +1759,13 @@ class IndependentAsrRuntime:
         self._asr_partial_turn_token = None
         self._asr_accepted_final_keys.clear()
         self._asr_reserved_final_key = None
+        self._asr_candidate_rejection = None
         self._asr_sealed_turn_token = None
         self._asr_provider_candidate_fence = None
         self._asr_turn_endpointed_at = None
         self._asr_turn_audio_started_at = None
         self._asr_first_partial_recorded = False
+        return abandoned_turn
 
     async def _notify_asr_turn_abandoned(
         self,
@@ -1813,9 +1833,11 @@ class IndependentAsrRuntime:
         self._asr_provider = None
         if lifecycle is not None:
             lifecycle.stop()
-        self._reset_asr_turn_state()
+        abandoned_turn = self._reset_asr_turn_state()
         self._asr_session_factory = None
         self._asr_transport_selection = None
+        if abandoned_turn is not None:
+            await self._notify_asr_turn_abandoned(abandoned_turn)
         if detector is not None:
             await detector.close()
         if lease is not None:
@@ -1984,10 +2006,21 @@ class IndependentAsrRuntime:
                     if not detector_result.throttle_available:
                         lifecycle.enable_independent_asr_fail_open()
                     else:
+                        current_candidate = getattr(
+                            detector,
+                            "current_candidate",
+                            None,
+                        )
+                        activity_candidate = (
+                            await current_candidate()
+                            if callable(current_candidate)
+                            else None
+                        )
                         for event in detector_result.events:
                             await self._handle_independent_asr_activity(
                                 event,
                                 identity.session_epoch,
+                                candidate=activity_candidate,
                             )
                             if not ingress_is_current():
                                 return AsrSubmitResult(AsrSubmitStatus.STALE)
@@ -2001,6 +2034,16 @@ class IndependentAsrRuntime:
                         if not ingress_is_current():
                             return AsrSubmitResult(AsrSubmitStatus.STALE)
                         return AsrSubmitResult(AsrSubmitStatus.UNAVAILABLE)
+            suppression = self._asr_candidate_rejection
+            if (
+                suppression is not None
+                and identity.session_epoch == suppression.request.session_epoch
+                and identity.audio_generation
+                == suppression.request.audio_generation
+                and identity.lifecycle is suppression.lifecycle
+                and identity.detector is suppression.detector
+            ):
+                return AsrSubmitResult(AsrSubmitStatus.ACCEPTED)
             if lifecycle is not None and not ingress_is_current():
                 return AsrSubmitResult(AsrSubmitStatus.STALE)
             decision = (
@@ -2335,7 +2378,7 @@ class IndependentAsrRuntime:
         self._asr_transcript_dispatcher.invalidate_all()
         self._asr_detector_dispatcher.invalidate_all()
         self._asr_audio_dispatcher.abort()
-        self._reset_asr_turn_state()
+        abandoned_turn = self._reset_asr_turn_state()
         lease, self._asr_smart_turn_lease = self._asr_smart_turn_lease, None
         for task_name in (
             "_asr_transport_task",
@@ -2354,6 +2397,8 @@ class IndependentAsrRuntime:
             )
             lifecycle.invalidate_transport()
         post_detach = self._capture_runtime_identity()
+        if abandoned_turn is not None:
+            await self._notify_asr_turn_abandoned(abandoned_turn)
         if lease is not None:
             await lease.release()
         if asr_session is not None:
@@ -2557,13 +2602,245 @@ class IndependentAsrRuntime:
                 fallback_audio_bytes * 1_000 // (16_000 * 2)
             )
 
+    async def _reject_candidate(
+        self,
+        request: CandidateRejectionRequest,
+        *,
+        active_profile_generation: str,
+        active_filter_generation: str,
+    ) -> CandidateRejectionOutcome:
+        """Reject one exact detector candidate without hard-blocking ASR."""
+
+        if type(request) is not CandidateRejectionRequest:
+            return CandidateRejectionOutcome.STALE
+        if (
+            type(active_profile_generation) is not str
+            or not active_profile_generation.strip()
+            or type(active_filter_generation) is not str
+            or not active_filter_generation.strip()
+        ):
+            return CandidateRejectionOutcome.STALE
+
+        asr_session: Any = None
+        lease: SmartTurnLease | None = None
+        suppression: _CandidateRejectionSuppression | None = None
+        async with self._asr_final_lock:
+            lifecycle = self._asr_lifecycle
+            detector = self._asr_detector
+            if (
+                request.session_epoch != self._asr_session_epoch
+                or request.audio_generation != self._asr_audio_generation
+                or request.profile_generation != active_profile_generation
+                or request.filter_generation != active_filter_generation
+                or lifecycle is None
+                or detector is None
+                or self._asr_session is None
+                or self._asr_candidate_rejection is not None
+                or self._asr_candidate_pause_fence
+                == (
+                    request.session_epoch,
+                    request.audio_generation,
+                    request.candidate,
+                )
+            ):
+                return CandidateRejectionOutcome.STALE
+            snapshot = lifecycle.snapshot
+            if (
+                request.transport_generation != snapshot.transport_generation
+                or request.turn_id != snapshot.turn_id
+                or snapshot.state
+                not in {
+                    VoiceLifecycleState.ACTIVE,
+                    VoiceLifecycleState.DRAINING,
+                }
+                or not await detector.candidate_is_current(request.candidate)
+            ):
+                return CandidateRejectionOutcome.STALE
+
+            sealed_token = self._asr_sealed_turn_token
+            turn_token = (
+                sealed_token.turn
+                if sealed_token is not None
+                else self._asr_partial_turn_token
+            )
+            if (
+                turn_token is None
+                or turn_token.turn_id != request.turn_id
+                or turn_token.ingress.session_epoch != request.session_epoch
+                or turn_token.ingress.audio_generation != request.audio_generation
+                or not self._ingress_token_matches(turn_token.ingress)
+                or not self._asr_turn_prepared
+                or self._asr_audio_dispatcher.active_turn != turn_token
+            ):
+                return CandidateRejectionOutcome.STALE
+            final_key = FinalKey.from_turn(turn_token)
+            if (
+                self._asr_reserved_final_key != final_key
+                or final_key in self._asr_accepted_final_keys
+            ):
+                return CandidateRejectionOutcome.STALE
+            if sealed_token is not None and sealed_token.turn != turn_token:
+                return CandidateRejectionOutcome.STALE
+            lease = self._asr_smart_turn_lease
+            if lease is not None and lease.token != turn_token:
+                return CandidateRejectionOutcome.STALE
+
+            self._asr_transcript_dispatcher.release(final_key)
+            if self._asr_reserved_final_key == final_key:
+                self._asr_reserved_final_key = None
+            lifecycle.invalidate_transport()
+            self._asr_audio_dispatcher.abort(turn_token)
+            asr_session, self._asr_session = self._asr_session, None
+            if lease is not None:
+                self._asr_smart_turn_lease = None
+            self._asr_turn_prepared = False
+            self._asr_received_audio = False
+            self._asr_audio_sequence = 0
+            if self._asr_partial_turn_token == turn_token:
+                self._asr_partial_turn_token = None
+            self._asr_sealed_turn_token = None
+            self._asr_provider_candidate_fence = None
+            self._asr_turn_endpointed_at = None
+            watchdog = self._asr_final_watchdog_task
+            self._asr_final_watchdog_task = None
+            if watchdog is not None and watchdog is not asyncio.current_task():
+                watchdog.cancel()
+            suppression = _CandidateRejectionSuppression(
+                request=request,
+                turn_token=turn_token,
+                final_key=final_key,
+                lifecycle=lifecycle,
+                detector=detector,
+            )
+            self._asr_candidate_rejection = suppression
+
+        cleanup_failed = False
+        if lease is not None:
+            try:
+                await lease.release()
+            except Exception:
+                cleanup_failed = True
+                logger.warning(
+                    "[%s] candidate rejection lease release failed open",
+                    self.display_name,
+                )
+        try:
+            await asr_session.close()
+        except Exception:
+            cleanup_failed = True
+            logger.warning(
+                "[%s] candidate rejection session close failed open",
+                self.display_name,
+            )
+        if cleanup_failed:
+            assert suppression is not None
+            await self._recover_candidate_rejection(suppression)
+            return CandidateRejectionOutcome.FAILED
+        return CandidateRejectionOutcome.APPLIED
+
+    async def _recover_candidate_rejection(
+        self,
+        suppression: _CandidateRejectionSuppression,
+    ) -> None:
+        """Clear suppression after cleanup failure and resume fail-open input."""
+
+        should_restart = False
+        async with self._asr_final_lock:
+            if self._asr_candidate_rejection is not suppression:
+                return
+            self._asr_candidate_rejection = None
+            lifecycle = suppression.lifecycle
+            if (
+                suppression.request.session_epoch == self._asr_session_epoch
+                and suppression.request.audio_generation == self._asr_audio_generation
+                and self._asr_lifecycle is lifecycle
+                and self._asr_detector is suppression.detector
+            ):
+                lifecycle.invalidate_audio()
+                should_restart = True
+        await self._notify_asr_turn_abandoned(suppression.turn_token)
+        if should_restart:
+            try:
+                await suppression.detector.reset()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.warning(
+                    "[%s] detector reset failed during rejection recovery",
+                    self.display_name,
+                )
+            self._ensure_transport_restart_task()
+
+    async def _finish_candidate_rejection(
+        self,
+        candidate: DetectorCandidateKey,
+    ) -> bool:
+        """End tail suppression only at the rejected candidate's own pause."""
+
+        suppression = self._asr_candidate_rejection
+        if suppression is None or suppression.request.candidate != candidate:
+            return False
+        reset_applied = False
+        try:
+            reset_applied = await suppression.detector.reset(
+                expected_candidate=candidate
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning(
+                "[%s] rejected candidate reset failed open",
+                self.display_name,
+            )
+        should_restart = False
+        async with self._asr_final_lock:
+            if self._asr_candidate_rejection is not suppression:
+                return False
+            self._asr_candidate_rejection = None
+            lifecycle = suppression.lifecycle
+            if (
+                suppression.request.session_epoch == self._asr_session_epoch
+                and suppression.request.audio_generation == self._asr_audio_generation
+                and self._asr_lifecycle is lifecycle
+                and self._asr_detector is suppression.detector
+            ):
+                lifecycle.invalidate_audio()
+                should_restart = True
+        await self._notify_asr_turn_abandoned(suppression.turn_token)
+        if should_restart:
+            self._ensure_transport_restart_task()
+        return reset_applied
+
     async def _handle_independent_asr_activity(
         self,
         event: SpeechActivityEvent,
         epoch: int,
+        *,
+        candidate: DetectorCandidateKey | None = None,
     ) -> None:
         if epoch != self._asr_session_epoch:
             return
+        if event is SpeechActivityEvent.CANDIDATE_PAUSE and candidate is not None:
+            async with self._asr_final_lock:
+                if epoch != self._asr_session_epoch:
+                    return
+                self._asr_candidate_pause_fence = (
+                    epoch,
+                    self._asr_audio_generation,
+                    candidate,
+                )
+            await self._finish_candidate_rejection(candidate)
+            if epoch != self._asr_session_epoch:
+                return
+        elif event is SpeechActivityEvent.SPEECH_RESUMED and candidate is not None:
+            async with self._asr_final_lock:
+                resumed_identity = (
+                    epoch,
+                    self._asr_audio_generation,
+                    candidate,
+                )
+                if self._asr_candidate_pause_fence == resumed_identity:
+                    self._asr_candidate_pause_fence = None
         provider = self._asr_provider or "unknown"
         lifecycle = self._asr_lifecycle
         if (
@@ -2982,30 +3259,37 @@ class IndependentAsrRuntime:
         clean = str(text or "").strip()
         if not clean or epoch != self._asr_session_epoch:
             return
-        lifecycle = self._asr_lifecycle
-        turn_token = self._asr_partial_turn_token
-        if (
-            lifecycle is None
-            or turn_token is None
-            or not self._asr_turn_prepared
-            or lifecycle.snapshot.state is not VoiceLifecycleState.ACTIVE
-            or not self._ingress_token_matches(turn_token.ingress)
-            or lifecycle.snapshot.turn_id != turn_token.turn_id
-            or self._asr_audio_dispatcher.active_turn != turn_token
-        ):
+        async with self._asr_final_lock:
+            lifecycle = self._asr_lifecycle
+            turn_token = self._asr_partial_turn_token
+            if (
+                lifecycle is None
+                or turn_token is None
+                or not self._asr_turn_prepared
+                or self._asr_candidate_rejection is not None
+                or lifecycle.snapshot.state is not VoiceLifecycleState.ACTIVE
+                or not self._ingress_token_matches(turn_token.ingress)
+                or lifecycle.snapshot.turn_id != turn_token.turn_id
+                or self._asr_audio_dispatcher.active_turn != turn_token
+            ):
+                return
+            if (
+                not self._asr_first_partial_recorded
+                and self._asr_turn_audio_started_at is not None
+            ):
+                lifecycle.metrics.first_partial_latency_ms = int(
+                    (time.monotonic() - self._asr_turn_audio_started_at) * 1_000
+                )
+                self._asr_first_partial_recorded = True
+            partial_event = VoicePartialEvent(turn_token=turn_token, text=clean)
+            partial_identity = self._capture_runtime_identity(
+                ingress_token=turn_token.ingress,
+                turn_token=turn_token,
+            )
+        if not self._runtime_identity_matches(partial_identity):
             return
-        if (
-            not self._asr_first_partial_recorded
-            and self._asr_turn_audio_started_at is not None
-        ):
-            lifecycle.metrics.first_partial_latency_ms = int(
-                (time.monotonic() - self._asr_turn_audio_started_at) * 1_000
-            )
-            self._asr_first_partial_recorded = True
         try:
-            await self._callbacks.on_partial(
-                VoicePartialEvent(turn_token=turn_token, text=clean)
-            )
+            await self._callbacks.on_partial(partial_event)
         except Exception:
             logger.debug(
                 "[%s] independent ASR preview delivery failed",
@@ -3333,7 +3617,7 @@ class IndependentAsrRuntime:
         self._asr_provider = None
         self._asr_session_factory = None
         self._asr_transport_selection = None
-        self._reset_asr_turn_state()
+        abandoned_turn = self._reset_asr_turn_state()
         for task_name in (
             "_asr_transport_task",
             "_asr_warm_expiry_task",
@@ -3357,6 +3641,8 @@ class IndependentAsrRuntime:
             task = asyncio.create_task(self._close_asr_session(asr_session))
             self._asr_close_tasks.add(task)
             task.add_done_callback(self._asr_close_tasks.discard)
+        if abandoned_turn is not None:
+            await self._notify_asr_turn_abandoned(abandoned_turn)
         failure_identity = self._capture_runtime_identity()
         try:
             delivered = await self._send_asr_lifecycle_state(

--- a/main_logic/asr_client/runtime.py
+++ b/main_logic/asr_client/runtime.py
@@ -2671,6 +2671,10 @@ class IndependentAsrRuntime:
                 or not self._ingress_token_matches(turn_token.ingress)
                 or not self._asr_turn_prepared
                 or self._asr_audio_dispatcher.active_turn != turn_token
+                or not await detector.candidate_is_bound_to(
+                    request.candidate,
+                    turn_token,
+                )
             ):
                 return CandidateRejectionOutcome.STALE
             final_key = FinalKey.from_turn(turn_token)
@@ -2761,7 +2765,7 @@ class IndependentAsrRuntime:
         await self._notify_asr_turn_abandoned(suppression.turn_token)
         if should_restart:
             try:
-                await suppression.detector.reset()
+                reset_applied = await suppression.detector.reset()
             except asyncio.CancelledError:
                 raise
             except Exception:
@@ -2769,7 +2773,15 @@ class IndependentAsrRuntime:
                     "[%s] detector reset failed during rejection recovery",
                     self.display_name,
                 )
-            self._ensure_transport_restart_task()
+                reset_applied = False
+            if reset_applied:
+                self._ensure_transport_restart_task()
+            else:
+                await self._handle_independent_asr_error(
+                    suppression.request.session_epoch,
+                    self._asr_provider or "unknown",
+                    status_code="ASR_ENDPOINTING_FAILED",
+                )
 
     async def _finish_candidate_rejection(
         self,
@@ -2792,6 +2804,23 @@ class IndependentAsrRuntime:
                 "[%s] rejected candidate reset failed open",
                 self.display_name,
             )
+            try:
+                reset_applied = await suppression.detector.reset()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.warning(
+                    "[%s] unconditional rejected candidate reset failed",
+                    self.display_name,
+                )
+                reset_applied = False
+        if not reset_applied:
+            await self._handle_independent_asr_error(
+                suppression.request.session_epoch,
+                self._asr_provider or "unknown",
+                status_code="ASR_ENDPOINTING_FAILED",
+            )
+            return False
         should_restart = False
         async with self._asr_final_lock:
             if self._asr_candidate_rejection is not suppression:

--- a/main_logic/asr_client/speaker_shadow/contracts.py
+++ b/main_logic/asr_client/speaker_shadow/contracts.py
@@ -21,6 +21,7 @@ MAX_SPEAKER_SHADOW_CANDIDATE_PCM_BYTES = (
 MAX_SPEAKER_SHADOW_FRAME_AUDIO_MS = MAX_SPEAKER_SHADOW_CANDIDATE_AUDIO_MS
 MAX_SPEAKER_SHADOW_FRAME_PCM_BYTES = MAX_SPEAKER_SHADOW_CANDIDATE_PCM_BYTES
 MAX_SPEAKER_SHADOW_THRESHOLDS = 16
+MAX_SPEAKER_SHADOW_CHECKPOINTS = 16
 MAX_SPEAKER_SHADOW_QUEUE_CAPACITY = 64
 MAX_SPEAKER_SHADOW_BUFFERED_CANDIDATES = 32
 MAX_SPEAKER_SHADOW_FINALIZED_CANDIDATES = 4_096
@@ -87,6 +88,7 @@ class SpeakerShadowConfig:
     similarity_thresholds: tuple[float, ...] = (0.40, 0.44, 0.48, 0.52, 0.55)
     minimum_audio_ms: int = 1_500
     maximum_audio_ms: int = 4_000
+    observation_checkpoints_ms: tuple[int, ...] | None = None
     idle_unload_seconds: float = 60.0
     queue_capacity: int = 32
     buffered_candidate_capacity: int = 32
@@ -129,6 +131,27 @@ class SpeakerShadowConfig:
             raise ValueError(
                 "maximum_audio_ms cannot exceed "
                 f"{MAX_SPEAKER_SHADOW_CANDIDATE_AUDIO_MS}"
+            )
+        checkpoints = self.observation_checkpoints_ms
+        if checkpoints is not None and (
+            type(checkpoints) is not tuple
+            or not checkpoints
+            or len(checkpoints) > MAX_SPEAKER_SHADOW_CHECKPOINTS
+            or any(
+                type(checkpoint) is not int
+                or checkpoint < self.minimum_audio_ms
+                or checkpoint > self.maximum_audio_ms
+                for checkpoint in checkpoints
+            )
+            or any(
+                left >= right
+                for left, right in zip(checkpoints, checkpoints[1:])
+            )
+        ):
+            raise ValueError(
+                "observation_checkpoints_ms must contain at most "
+                f"{MAX_SPEAKER_SHADOW_CHECKPOINTS} unique, increasing integer "
+                "values within [minimum_audio_ms, maximum_audio_ms]"
             )
         if not math.isfinite(self.idle_unload_seconds) or self.idle_unload_seconds <= 0:
             raise ValueError("idle_unload_seconds must be positive")
@@ -212,6 +235,7 @@ class SpeakerShadowObservation:
     similarity: float
     would_block: tuple[tuple[float, bool], ...]
     audio_ms: int
+    checkpoint_ms: int | None = None
 
 
 ObservationCallback = Callable[

--- a/main_logic/asr_client/speaker_shadow/runtime.py
+++ b/main_logic/asr_client/speaker_shadow/runtime.py
@@ -522,7 +522,12 @@ class SpeakerShadowRuntime:
         sample_rate_hz: int,
         candidate: SpeakerShadowCandidateKey,
     ) -> bool:
-        """Queue immutable PCM accepted by the current candidate fence."""
+        """Queue PCM accepted by the current candidate fence.
+
+        The queued tail remains mutable while an intermediate evaluation is
+        active so later PCM can coalesce into it. The worker clears the tail
+        reference immediately after dequeue, before it reads that frame.
+        """
 
         if not self.enabled:
             return False

--- a/main_logic/asr_client/speaker_shadow/runtime.py
+++ b/main_logic/asr_client/speaker_shadow/runtime.py
@@ -332,7 +332,7 @@ class _BackendProcessHost:
             self.pcm_bytes_in_use = 0
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(slots=True)
 class _AudioFrame:
     generation: int
     candidate: SpeakerShadowCandidateKey
@@ -364,6 +364,7 @@ class _CandidateBuffer:
     sample_rate_hz: int
     pcm16: bytearray
     sample_count: int = 0
+    next_checkpoint_index: int = 0
 
     @property
     def audio_ms(self) -> int:
@@ -414,6 +415,7 @@ class SpeakerShadowRuntime:
             maxsize=self._config.queue_capacity
         )
         self._queued_pcm_bytes = 0
+        self._queued_audio_tail: _AudioFrame | None = None
         self._active_pcm_bytes = 0
         self._buffers: OrderedDict[SpeakerShadowCandidateKey, _CandidateBuffer] = (
             OrderedDict()
@@ -430,6 +432,7 @@ class SpeakerShadowRuntime:
         self._cleanup_task: asyncio.Task[None] | None = None
         self._host_start_task: asyncio.Task[_BackendProcessHost] | None = None
         self._active_evaluation: tuple[int, SpeakerShadowCandidateKey] | None = None
+        self._active_evaluation_terminal = False
         self._backend_host: _BackendProcessHost | None = None
         self._load_failure_streak = 0
         self._next_load_attempt_at = 0.0
@@ -543,7 +546,10 @@ class SpeakerShadowRuntime:
         if (
             candidate in self._finalized
             or self._candidate_was_evicted(candidate)
-            or identity == self._active_evaluation
+            or (
+                identity == self._active_evaluation
+                and self._active_evaluation_terminal
+            )
         ):
             return False
 
@@ -599,16 +605,38 @@ class SpeakerShadowRuntime:
             self._wipe_bytearray(bounded_pcm16)
             self._drop_candidate(candidate, token=token)
             return False
-        try:
-            self._queue.put_nowait(frame)
-        except asyncio.QueueFull:
-            self._metrics.dropped_frame_count += 1
-            self._metrics.dropped_audio_ms += self._audio_ms(
-                sample_count, sample_rate_hz
-            )
+        queued_tail = self._queued_audio_tail
+        coalesce_tail = bool(
+            self._active_evaluation == identity
+            and not self._active_evaluation_terminal
+            and queued_tail is not None
+            and queued_tail.generation == frame.generation
+            and queued_tail.candidate == frame.candidate
+            and queued_tail.token is frame.token
+            and queued_tail.sample_rate_hz == frame.sample_rate_hz
+        )
+        if coalesce_tail:
+            assert queued_tail is not None
+            queued_tail.pcm16.extend(bounded_pcm16)
+            queued_tail.sample_count += sample_count
             self._wipe_bytearray(bounded_pcm16)
-            self._drop_candidate(candidate, token=token)
-            return False
+        else:
+            try:
+                self._queue.put_nowait(frame)
+            except asyncio.QueueFull:
+                self._metrics.dropped_frame_count += 1
+                self._metrics.dropped_audio_ms += self._audio_ms(
+                    sample_count, sample_rate_hz
+                )
+                self._wipe_bytearray(bounded_pcm16)
+                self._drop_candidate(candidate, token=token)
+                return False
+            self._queued_audio_tail = (
+                frame
+                if self._active_evaluation == identity
+                and not self._active_evaluation_terminal
+                else None
+            )
         self._queued_pcm_bytes += len(bounded_pcm16)
         if not self._ensure_worker():
             self._drain_queue()
@@ -642,6 +670,7 @@ class SpeakerShadowRuntime:
         if token is None:
             token = _CandidateToken(candidate, 0)
         marker = _CandidateFinished(self._generation, candidate, token)
+        self._queued_audio_tail = None
         try:
             self._queue.put_nowait(marker)
         except asyncio.QueueFull:
@@ -742,6 +771,8 @@ class SpeakerShadowRuntime:
                     work_items.get(),
                     timeout=self._config.idle_unload_seconds,
                 )
+                if item is self._queued_audio_tail:
+                    self._queued_audio_tail = None
             except asyncio.TimeoutError:
                 await self._unload_backend()
                 if self._queue.empty():
@@ -832,26 +863,64 @@ class SpeakerShadowRuntime:
         if allowed_samples > 0:
             buffer.pcm16.extend(frame.pcm16[: allowed_samples * 2])
             buffer.sample_count += allowed_samples
-        minimum_samples = math.ceil(
-            buffer.sample_rate_hz * self._config.minimum_audio_ms / 1_000
-        )
-        if buffer.sample_count < minimum_samples:
-            return
-
-        self._buffers.pop(frame.candidate, None)
-        candidate_pcm = bytearray(buffer.pcm16)
-        self._wipe_bytearray(buffer.pcm16)
-        try:
-            await self._evaluate_candidate(
-                generation=frame.generation,
-                candidate=frame.candidate,
-                token=frame.token,
-                pcm16=candidate_pcm,
-                sample_rate_hz=buffer.sample_rate_hz,
-                audio_ms=buffer.audio_ms,
+        explicit_checkpoints = self._config.observation_checkpoints_ms
+        checkpoints = explicit_checkpoints or (self._config.minimum_audio_ms,)
+        while buffer.next_checkpoint_index < len(checkpoints):
+            checkpoint_index = buffer.next_checkpoint_index
+            checkpoint_ms = checkpoints[checkpoint_index]
+            checkpoint_samples = math.ceil(
+                buffer.sample_rate_hz * checkpoint_ms / 1_000
             )
-        finally:
-            self._wipe_bytearray(candidate_pcm)
+            if buffer.sample_count < checkpoint_samples:
+                return
+
+            terminal = checkpoint_index == len(checkpoints) - 1
+            buffer.next_checkpoint_index += 1
+            score_sample_count = (
+                buffer.sample_count
+                if explicit_checkpoints is None
+                else checkpoint_samples
+            )
+            candidate_pcm = bytearray(
+                buffer.pcm16[: score_sample_count * 2]
+            )
+            if terminal:
+                self._buffers.pop(frame.candidate, None)
+                self._wipe_bytearray(buffer.pcm16)
+            try:
+                await self._evaluate_candidate(
+                    generation=frame.generation,
+                    candidate=frame.candidate,
+                    token=frame.token,
+                    pcm16=candidate_pcm,
+                    sample_rate_hz=buffer.sample_rate_hz,
+                    audio_ms=(
+                        buffer.audio_ms
+                        if explicit_checkpoints is None
+                        else checkpoint_ms
+                    ),
+                    checkpoint_ms=(
+                        checkpoint_ms
+                        if explicit_checkpoints is not None
+                        else None
+                    ),
+                    terminal=terminal,
+                )
+            finally:
+                self._wipe_bytearray(candidate_pcm)
+            if (
+                not terminal
+                and frame.token.terminal_reason is not None
+                and self._buffers.get(frame.candidate) is buffer
+            ):
+                self._buffers.pop(frame.candidate, None)
+                self._wipe_bytearray(buffer.pcm16)
+            if not self._identity_is_current(
+                frame.generation,
+                frame.candidate,
+                frame.token,
+            ):
+                return
 
     async def _evaluate_candidate(
         self,
@@ -862,8 +931,11 @@ class SpeakerShadowRuntime:
         pcm16: bytearray,
         sample_rate_hz: int,
         audio_ms: int,
+        checkpoint_ms: int | None,
+        terminal: bool,
     ) -> None:
         self._active_evaluation = (generation, candidate)
+        self._active_evaluation_terminal = terminal
         self._active_pcm_bytes = len(pcm16)
         try:
             backend_host = await self._ensure_backend()
@@ -913,8 +985,9 @@ class SpeakerShadowRuntime:
                 (threshold, similarity < threshold)
                 for threshold in self._config.similarity_thresholds
             )
-            self._finalize_candidate(candidate, "scored", token=token)
-            self._metrics.evaluated_candidate_count += 1
+            if terminal:
+                self._finalize_candidate(candidate, "scored", token=token)
+                self._metrics.evaluated_candidate_count += 1
             if any(blocked for _, blocked in would_block):
                 self._metrics.would_block_count += 1
             for threshold, blocked in would_block:
@@ -934,6 +1007,7 @@ class SpeakerShadowRuntime:
                 similarity=similarity,
                 would_block=would_block,
                 audio_ms=audio_ms,
+                checkpoint_ms=checkpoint_ms,
             )
             callback_task = asyncio.create_task(
                 callback(observation),
@@ -962,6 +1036,7 @@ class SpeakerShadowRuntime:
         finally:
             if self._active_evaluation == (generation, candidate):
                 self._active_evaluation = None
+                self._active_evaluation_terminal = False
                 self._active_pcm_bytes = 0
 
     async def _ensure_backend(self) -> _BackendProcessHost | None:
@@ -1184,11 +1259,15 @@ class SpeakerShadowRuntime:
             self._record_finish(marker.candidate, finalized)
             return
         buffer = self._buffers.pop(marker.candidate, None)
+        terminal_reason: SpeakerShadowTerminalReason = "insufficient"
         if buffer is not None:
+            if buffer.next_checkpoint_index > 0:
+                terminal_reason = "scored"
+                self._metrics.evaluated_candidate_count += 1
             self._wipe_bytearray(buffer.pcm16)
         self._finalize_candidate(
             marker.candidate,
-            "insufficient",
+            terminal_reason,
             finish_seen=True,
             token=marker.token,
         )
@@ -1358,6 +1437,7 @@ class SpeakerShadowRuntime:
         )
 
     def _drain_queue(self) -> None:
+        self._queued_audio_tail = None
         while True:
             try:
                 item = self._queue.get_nowait()

--- a/main_logic/core/asr_runtime.py
+++ b/main_logic/core/asr_runtime.py
@@ -20,7 +20,6 @@ from main_logic.asr_client.runtime import (
     AsrRuntimeCallbacks,
     AsrStartStatus,
     IndependentAsrRuntime,
-    SpeakerShadowFactory,
 )
 from main_logic.voice_input import (
     BuiltinVoiceInputConsumer,
@@ -254,7 +253,10 @@ class AsrRuntimeMixin:
         self._independent_asr_provider: str | None = None
         self._independent_asr_route_key: str | None = None
         self._independent_asr_handshake_override: bool | None = None
-        self._speaker_shadow_factory: SpeakerShadowFactory | None = None
+        # Opaque app-owned composition seam. Core only forwards the callable;
+        # it never imports or inspects voice identity, Shadow, models, scores,
+        # candidate identities, or profile material.
+        self._speaker_shadow_factory: Callable[[], object] | None = None
         self._voice_input_resource_optimization_handshake_override: bool | None = None
         self._voice_input_resource_optimization_session_value: bool | None = None
         self._voice_input_noise_reduction_enabled = True

--- a/main_logic/voice_identity/asr_composition.py
+++ b/main_logic/voice_identity/asr_composition.py
@@ -1,0 +1,176 @@
+"""Session-scoped Owner voice composition for independent ASR."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import threading
+from collections.abc import Callable
+
+from main_logic.asr_client.candidate_control import CandidateRejectionRequest
+from main_logic.asr_client.runtime import IndependentAsrRuntime
+from main_logic.asr_client.speaker_shadow.asset_manifest import (
+    CAMPPLUS_MODEL_ID,
+    CAMPPLUS_MODEL_REVISION,
+)
+from main_logic.asr_client.speaker_shadow.campplus import (
+    CAMPPLUS_EMBEDDING_DIM,
+    CampPlusBackendFactory,
+)
+from main_logic.asr_client.speaker_shadow.contracts import (
+    SpeakerShadowBackendFactory,
+    SpeakerShadowConfig,
+    SpeakerShadowObservation,
+)
+from main_logic.asr_client.speaker_shadow.runtime import SpeakerShadowRuntime
+
+from .contracts import SpeakerModelIdentity
+from .policy import OwnerVoiceBetaPolicy, OwnerVoicePolicyDecision
+from .profile import SpeakerProfile
+from .reference import SpeakerReference
+
+
+_BackendFactoryBuilder = Callable[
+    [SpeakerReference],
+    SpeakerShadowBackendFactory,
+]
+
+
+def _build_campplus_backend_factory(
+    reference: SpeakerReference,
+) -> SpeakerShadowBackendFactory:
+    expected_identity = SpeakerModelIdentity(
+        CAMPPLUS_MODEL_ID,
+        CAMPPLUS_MODEL_REVISION,
+        CAMPPLUS_EMBEDDING_DIM,
+    )
+    if reference.model_identity != expected_identity:
+        raise ValueError("speaker profile model identity does not match CAM++")
+    embedding = reference.copy_embedding()
+    try:
+        return CampPlusBackendFactory(embedding)
+    finally:
+        embedding.fill(0.0)
+
+
+class OwnerVoiceAsrCompositionFactory:
+    """Create one fixed-generation Owner voice observer per ASR session.
+
+    The factory owns a clone of the supplied profile. Calling it captures a
+    fresh reference and the immutable generation for exactly one ASR session;
+    there is deliberately no setter or runtime profile replacement path.
+    """
+
+    __slots__ = (
+        "_backend_factory_builder",
+        "_closed",
+        "_lock",
+        "_profile",
+        "_runtime",
+    )
+
+    def __init__(
+        self,
+        runtime: IndependentAsrRuntime,
+        profile: SpeakerProfile,
+        *,
+        backend_factory_builder: _BackendFactoryBuilder | None = None,
+    ) -> None:
+        if not isinstance(runtime, IndependentAsrRuntime):
+            raise TypeError("runtime must be IndependentAsrRuntime")
+        if type(profile) is not SpeakerProfile:
+            raise TypeError("profile must be SpeakerProfile")
+        self._runtime = runtime
+        self._profile = copy.copy(profile)
+        self._backend_factory_builder = (
+            backend_factory_builder or _build_campplus_backend_factory
+        )
+        self._lock = threading.Lock()
+        self._closed = False
+
+    def __call__(self) -> SpeakerShadowRuntime:
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("Owner voice ASR composition factory is closed")
+            profile_generation = self._profile.generation
+            reference = self._profile.clone_reference()
+        try:
+            backend_factory = self._backend_factory_builder(reference)
+        finally:
+            reference.close()
+
+        policy = OwnerVoiceBetaPolicy()
+        runtime = self._runtime
+
+        async def on_observation(observation: SpeakerShadowObservation) -> None:
+            try:
+                checkpoint_ms = observation.checkpoint_ms
+                if checkpoint_ms not in {
+                    policy.FIRST_CHECKPOINT_MS,
+                    policy.SECOND_CHECKPOINT_MS,
+                }:
+                    return
+                detector = runtime._asr_detector
+                lifecycle = runtime._asr_lifecycle
+                if detector is None or lifecycle is None:
+                    return
+                candidate = await detector.correlate_speaker_shadow_candidate(
+                    observation.candidate
+                )
+                if candidate is None:
+                    return
+                result = policy.observe(
+                    detector_epoch=candidate.detector_epoch,
+                    candidate_generation=candidate.candidate_generation,
+                    profile_generation=profile_generation,
+                    active_detector_epoch=candidate.detector_epoch,
+                    active_candidate_generation=candidate.candidate_generation,
+                    active_profile_generation=profile_generation,
+                    checkpoint_ms=checkpoint_ms,
+                    similarity=observation.similarity,
+                )
+                if result.decision != OwnerVoicePolicyDecision.HYPOTHETICAL_REJECT:
+                    return
+                snapshot = lifecycle.snapshot
+                request = CandidateRejectionRequest(
+                    session_epoch=runtime._asr_session_epoch,
+                    audio_generation=runtime._asr_audio_generation,
+                    transport_generation=snapshot.transport_generation,
+                    turn_id=snapshot.turn_id,
+                    candidate=candidate,
+                    profile_generation=profile_generation,
+                    filter_generation=policy.VERSION,
+                )
+                await runtime._reject_candidate(
+                    request,
+                    active_profile_generation=profile_generation,
+                    active_filter_generation=policy.VERSION,
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                # Composition is advisory. Every correlation, policy, or
+                # transaction failure preserves the independent ASR route.
+                return
+
+        return SpeakerShadowRuntime(
+            backend_factory=backend_factory,
+            config=SpeakerShadowConfig(
+                enabled=True,
+                similarity_thresholds=(OwnerVoiceBetaPolicy.SIMILARITY_THRESHOLD,),
+                minimum_audio_ms=OwnerVoiceBetaPolicy.FIRST_CHECKPOINT_MS,
+                maximum_audio_ms=OwnerVoiceBetaPolicy.SECOND_CHECKPOINT_MS,
+                observation_checkpoints_ms=(
+                    OwnerVoiceBetaPolicy.FIRST_CHECKPOINT_MS,
+                    OwnerVoiceBetaPolicy.SECOND_CHECKPOINT_MS,
+                ),
+            ),
+            on_observation=on_observation,
+        )
+
+    def close(self) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            self._profile.close()

--- a/main_logic/voice_identity/asr_composition.py
+++ b/main_logic/voice_identity/asr_composition.py
@@ -7,7 +7,10 @@ import copy
 import threading
 from collections.abc import Callable
 
-from main_logic.asr_client.candidate_control import CandidateRejectionRequest
+from main_logic.asr_client.candidate_control import (
+    CandidateRejectionOutcome,
+    CandidateRejectionRequest,
+)
 from main_logic.asr_client.runtime import IndependentAsrRuntime
 from main_logic.asr_client.speaker_shadow.asset_manifest import (
     CAMPPLUS_MODEL_ID,
@@ -101,6 +104,16 @@ class OwnerVoiceAsrCompositionFactory:
 
         policy = OwnerVoiceBetaPolicy()
         runtime = self._runtime
+        rejection_tasks: set[asyncio.Task[CandidateRejectionOutcome]] = set()
+
+        def reap_rejection(task: asyncio.Task[CandidateRejectionOutcome]) -> None:
+            rejection_tasks.discard(task)
+            if task.cancelled():
+                return
+            try:
+                task.exception()
+            except Exception:
+                return
 
         async def on_observation(observation: SpeakerShadowObservation) -> None:
             try:
@@ -141,11 +154,17 @@ class OwnerVoiceAsrCompositionFactory:
                     profile_generation=profile_generation,
                     filter_generation=policy.VERSION,
                 )
-                await runtime._reject_candidate(
-                    request,
-                    active_profile_generation=profile_generation,
-                    active_filter_generation=policy.VERSION,
+                rejection_task = asyncio.create_task(
+                    runtime._reject_candidate(
+                        request,
+                        active_profile_generation=profile_generation,
+                        active_filter_generation=policy.VERSION,
+                    ),
+                    name="owner-voice-candidate-rejection",
                 )
+                rejection_tasks.add(rejection_task)
+                rejection_task.add_done_callback(reap_rejection)
+                await asyncio.shield(rejection_task)
             except asyncio.CancelledError:
                 raise
             except Exception:

--- a/main_logic/voice_identity/policy.py
+++ b/main_logic/voice_identity/policy.py
@@ -1,0 +1,273 @@
+"""Pure, provider-neutral Owner voice policy for the beta experiment."""
+
+
+class OwnerVoicePolicyDecision:
+    """Non-authoritative outcomes emitted by the observation-only policy."""
+
+    FORWARD = "FORWARD"
+    HYPOTHETICAL_REJECT = "HYPOTHETICAL_REJECT"
+
+
+class OwnerVoicePolicyResult:
+    """Immutable-by-interface record of one beta policy evaluation."""
+
+    __slots__ = (
+        "_candidate_generation",
+        "_checkpoint_ms",
+        "_decision",
+        "_policy_version",
+        "_profile_generation",
+        "_reason",
+    )
+
+    def __init__(
+        self,
+        *,
+        decision: str,
+        reason: str,
+        candidate_generation: int,
+        profile_generation: str,
+        checkpoint_ms: int,
+    ) -> None:
+        self._decision = decision
+        self._reason = reason
+        self._candidate_generation = candidate_generation
+        self._profile_generation = profile_generation
+        self._checkpoint_ms = checkpoint_ms
+        self._policy_version = OwnerVoiceBetaPolicy.VERSION
+
+    @property
+    def decision(self) -> str:
+        return self._decision
+
+    @property
+    def reason(self) -> str:
+        return self._reason
+
+    @property
+    def candidate_generation(self) -> int:
+        return self._candidate_generation
+
+    @property
+    def profile_generation(self) -> str:
+        return self._profile_generation
+
+    @property
+    def checkpoint_ms(self) -> int:
+        return self._checkpoint_ms
+
+    @property
+    def policy_version(self) -> str:
+        return self._policy_version
+
+
+class OwnerVoiceBetaPolicy:
+    """Evaluate two fixed checkpoints and otherwise fail open.
+
+    The policy has no execution authority. ``HYPOTHETICAL_REJECT`` is an
+    observation result, not a Provider, transport, or candidate command.
+    """
+
+    VERSION = "beta-v1"
+    FIRST_CHECKPOINT_MS = 1_500
+    SECOND_CHECKPOINT_MS = 3_000
+    SIMILARITY_THRESHOLD = 0.40
+    DEFAULT_CANDIDATE_CAPACITY = 256
+
+    __slots__ = ("_candidate_capacity", "_first_low")
+
+    def __init__(self, *, candidate_capacity: int = DEFAULT_CANDIDATE_CAPACITY) -> None:
+        if type(candidate_capacity) is not int or candidate_capacity <= 0:
+            raise ValueError("candidate_capacity must be a positive integer")
+        self._candidate_capacity = candidate_capacity
+        self._first_low: dict[tuple[int, int, str], bool] = {}
+
+    @property
+    def candidate_capacity(self) -> int:
+        return self._candidate_capacity
+
+    @property
+    def pending_candidate_count(self) -> int:
+        return len(self._first_low)
+
+    def observe(
+        self,
+        *,
+        detector_epoch: int,
+        candidate_generation: int,
+        profile_generation: str,
+        active_detector_epoch: int,
+        active_candidate_generation: int,
+        active_profile_generation: str,
+        checkpoint_ms: int,
+        similarity: float,
+        enabled: bool = True,
+    ) -> OwnerVoicePolicyResult:
+        """Return a non-authoritative beta decision for one observation."""
+
+        valid_identity = self._valid_identity(
+            detector_epoch,
+            candidate_generation,
+            profile_generation,
+            active_detector_epoch,
+            active_candidate_generation,
+            active_profile_generation,
+        )
+        if not valid_identity:
+            return self._forward(
+                candidate_generation,
+                profile_generation,
+                checkpoint_ms,
+                "stale_or_invalid_generation",
+            )
+
+        key = (detector_epoch, candidate_generation, profile_generation)
+        if enabled is not True:
+            self._first_low.pop(key, None)
+            return self._forward(
+                candidate_generation,
+                profile_generation,
+                checkpoint_ms,
+                "disabled",
+            )
+        if not self._valid_observation(checkpoint_ms, similarity):
+            self._first_low.pop(key, None)
+            return self._forward(
+                candidate_generation,
+                profile_generation,
+                checkpoint_ms,
+                "invalid_observation",
+            )
+
+        clearly_low = float(similarity) < self.SIMILARITY_THRESHOLD
+        if checkpoint_ms == self.FIRST_CHECKPOINT_MS:
+            self._first_low.pop(key, None)
+            if clearly_low:
+                self._remember_first_low(key)
+                reason = "awaiting_second_low_observation"
+            else:
+                reason = "owner_or_uncertain"
+            return self._forward(
+                candidate_generation,
+                profile_generation,
+                checkpoint_ms,
+                reason,
+            )
+
+        first_was_low = self._first_low.pop(key, False)
+        if first_was_low and clearly_low:
+            return OwnerVoicePolicyResult(
+                decision=OwnerVoicePolicyDecision.HYPOTHETICAL_REJECT,
+                reason="stable_clear_mismatch",
+                candidate_generation=candidate_generation,
+                profile_generation=profile_generation,
+                checkpoint_ms=checkpoint_ms,
+            )
+        return self._forward(
+            candidate_generation,
+            profile_generation,
+            checkpoint_ms,
+            "owner_or_uncertain",
+        )
+
+    def forget_candidate(
+        self,
+        *,
+        detector_epoch: int,
+        candidate_generation: int,
+        profile_generation: str,
+    ) -> None:
+        """Forget a candidate-local first observation, if present."""
+
+        self._first_low.pop(
+            (detector_epoch, candidate_generation, profile_generation),
+            None,
+        )
+
+    def reset(self) -> None:
+        """Drop all bounded candidate-local observation state."""
+
+        self._first_low.clear()
+
+    @staticmethod
+    def _valid_identity(
+        detector_epoch: object,
+        candidate_generation: object,
+        profile_generation: object,
+        active_detector_epoch: object,
+        active_candidate_generation: object,
+        active_profile_generation: object,
+    ) -> bool:
+        return bool(
+            type(detector_epoch) is int
+            and detector_epoch >= 0
+            and type(active_detector_epoch) is int
+            and active_detector_epoch >= 0
+            and detector_epoch == active_detector_epoch
+            and type(candidate_generation) is int
+            and candidate_generation >= 0
+            and type(active_candidate_generation) is int
+            and active_candidate_generation >= 0
+            and candidate_generation == active_candidate_generation
+            and type(profile_generation) is str
+            and bool(profile_generation.strip())
+            and type(active_profile_generation) is str
+            and bool(active_profile_generation.strip())
+            and profile_generation == active_profile_generation
+        )
+
+    @classmethod
+    def _valid_observation(cls, checkpoint_ms: object, similarity: object) -> bool:
+        return bool(
+            type(checkpoint_ms) is int
+            and checkpoint_ms in {
+                cls.FIRST_CHECKPOINT_MS,
+                cls.SECOND_CHECKPOINT_MS,
+            }
+            and type(similarity) in {int, float}
+            and similarity == similarity
+            and -1.0 <= similarity <= 1.0
+        )
+
+    def _remember_first_low(self, key: tuple[int, int, str]) -> None:
+        self._first_low[key] = True
+        while len(self._first_low) > self._candidate_capacity:
+            oldest = next(iter(self._first_low))
+            self._first_low.pop(oldest, None)
+
+    @staticmethod
+    def _forward(
+        candidate_generation: object,
+        profile_generation: object,
+        checkpoint_ms: object,
+        reason: str,
+    ) -> OwnerVoicePolicyResult:
+        safe_candidate_generation = (
+            candidate_generation
+            if type(candidate_generation) is int and candidate_generation >= 0
+            else 0
+        )
+        safe_profile_generation = (
+            profile_generation
+            if type(profile_generation) is str and profile_generation.strip()
+            else "invalid"
+        )
+        safe_checkpoint_ms = (
+            checkpoint_ms
+            if type(checkpoint_ms) is int and checkpoint_ms >= 0
+            else 0
+        )
+        return OwnerVoicePolicyResult(
+            decision=OwnerVoicePolicyDecision.FORWARD,
+            reason=reason,
+            candidate_generation=safe_candidate_generation,
+            profile_generation=safe_profile_generation,
+            checkpoint_ms=safe_checkpoint_ms,
+        )
+
+
+__all__ = [
+    "OwnerVoiceBetaPolicy",
+    "OwnerVoicePolicyDecision",
+    "OwnerVoicePolicyResult",
+]

--- a/scripts/check_core_contracts.py
+++ b/scripts/check_core_contracts.py
@@ -1474,6 +1474,19 @@ def check_voice_identity_contracts(root: Path) -> list[Violation]:
             "main_logic.voice_identity.contracts",
             "main_logic.voice_identity.reference",
         ),
+        package_dir / "policy.py": (),
+        package_dir / "asr_composition.py": (
+            "__future__",
+            "asyncio",
+            "copy",
+            "threading",
+            "collections",
+            "main_logic.asr_client",
+            "main_logic.voice_identity.contracts",
+            "main_logic.voice_identity.policy",
+            "main_logic.voice_identity.profile",
+            "main_logic.voice_identity.reference",
+        ),
     }
     direct_dynamic_calls = {
         "eval",

--- a/tests/unit/asr_client/candidate_control/__init__.py
+++ b/tests/unit/asr_client/candidate_control/__init__.py
@@ -1,0 +1,1 @@
+"""Candidate-control unit tests."""

--- a/tests/unit/asr_client/candidate_control/test_contracts.py
+++ b/tests/unit/asr_client/candidate_control/test_contracts.py
@@ -1,0 +1,53 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from main_logic.asr_client.candidate_control import (
+    CandidateRejectionOutcome,
+    CandidateRejectionRequest,
+)
+from main_logic.asr_client.endpointing.detector import DetectorCandidateKey
+
+
+def _request(**overrides: object) -> CandidateRejectionRequest:
+    values = {
+        "session_epoch": 7,
+        "audio_generation": 3,
+        "transport_generation": 5,
+        "turn_id": 11,
+        "candidate": DetectorCandidateKey(2, 13),
+        "profile_generation": "profile-4",
+        "filter_generation": "beta-v1",
+    }
+    values.update(overrides)
+    return CandidateRejectionRequest(**values)  # type: ignore[arg-type]
+
+
+def test_request_is_immutable_and_preserves_authoritative_candidate() -> None:
+    request = _request()
+
+    assert request.candidate == DetectorCandidateKey(2, 13)
+    assert CandidateRejectionOutcome.APPLIED.value == "applied"
+    with pytest.raises(FrozenInstanceError):
+        request.turn_id = 12  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("session_epoch", -1),
+        ("audio_generation", True),
+        ("transport_generation", -1),
+        ("turn_id", 1.5),
+        ("profile_generation", " "),
+        ("filter_generation", ""),
+    ],
+)
+def test_request_rejects_invalid_fences(field: str, value: object) -> None:
+    with pytest.raises(ValueError):
+        _request(**{field: value})
+
+
+def test_request_rejects_non_detector_candidate() -> None:
+    with pytest.raises(TypeError):
+        _request(candidate=object())

--- a/tests/unit/asr_client/speaker_shadow/test_contracts.py
+++ b/tests/unit/asr_client/speaker_shadow/test_contracts.py
@@ -28,6 +28,19 @@ from main_logic.asr_client.speaker_shadow.contracts import (
             "maximum_audio_ms",
         ),
         ({"maximum_audio_ms": 4_001}, "maximum_audio_ms"),
+        ({"observation_checkpoints_ms": ()}, "observation_checkpoints_ms"),
+        (
+            {"observation_checkpoints_ms": (1_500, 1_500)},
+            "observation_checkpoints_ms",
+        ),
+        (
+            {"observation_checkpoints_ms": (1_499, 3_000)},
+            "observation_checkpoints_ms",
+        ),
+        (
+            {"observation_checkpoints_ms": (1_500, 4_001)},
+            "observation_checkpoints_ms",
+        ),
         ({"queue_capacity": 0}, "queue_capacity"),
         (
             {"queue_capacity": MAX_SPEAKER_SHADOW_QUEUE_CAPACITY + 1},
@@ -107,6 +120,7 @@ def test_config_is_default_off_and_caps_candidate_audio() -> None:
 
     assert config.enabled is False
     assert config.maximum_audio_ms == 4_000
+    assert config.observation_checkpoints_ms is None
     assert MAX_SPEAKER_SHADOW_FRAME_PCM_BYTES == 128_000
     assert MAX_SPEAKER_SHADOW_CANDIDATE_PCM_BYTES == 128_000
     assert MAX_SPEAKER_SHADOW_RETAINED_PCM_BYTES < 8 * 1024 * 1024

--- a/tests/unit/asr_client/speaker_shadow/test_runtime.py
+++ b/tests/unit/asr_client/speaker_shadow/test_runtime.py
@@ -283,6 +283,252 @@ async def test_ordered_finish_scores_once_and_rejects_late_pcm() -> None:
     await runtime.close()
 
 
+async def test_explicit_checkpoints_emit_two_independent_observations() -> None:
+    observations: list[SpeakerShadowObservation] = []
+
+    async def observe(observation: SpeakerShadowObservation) -> None:
+        observations.append(observation)
+
+    runtime = SpeakerShadowRuntime(
+        backend_factory=_BackendFactory(score_value=0.2),
+        config=_config(
+            minimum_audio_ms=1_500,
+            maximum_audio_ms=4_000,
+            observation_checkpoints_ms=(1_500, 3_000),
+        ),
+        on_observation=observe,
+    )
+    candidate = _candidate(47)
+
+    assert runtime.submit(
+        _pcm(3_000),
+        sample_rate_hz=SPEAKER_SHADOW_SAMPLE_RATE_HZ,
+        candidate=candidate,
+    )
+    await runtime.wait_idle()
+
+    assert [item.checkpoint_ms for item in observations] == [1_500, 3_000]
+    assert [item.audio_ms for item in observations] == [1_500, 3_000]
+    assert [item.candidate for item in observations] == [candidate, candidate]
+    metrics = runtime.snapshot()
+    assert metrics["scored_candidate_count"] == 1
+    assert metrics["evaluated_candidate_count"] == 1
+    assert metrics["would_block_at_0_4_count"] == 2
+    await runtime.close()
+
+
+async def test_explicit_checkpoint_callback_failure_does_not_block_next() -> None:
+    seen_checkpoints: list[int | None] = []
+
+    async def observe(observation: SpeakerShadowObservation) -> None:
+        if observation.checkpoint_ms == 1_500:
+            raise RuntimeError("first checkpoint callback failed")
+        seen_checkpoints.append(observation.checkpoint_ms)
+
+    runtime = SpeakerShadowRuntime(
+        backend_factory=_BackendFactory(score_value=0.2),
+        config=_config(
+            minimum_audio_ms=1_500,
+            maximum_audio_ms=4_000,
+            observation_checkpoints_ms=(1_500, 3_000),
+        ),
+        on_observation=observe,
+    )
+
+    assert runtime.submit(
+        _pcm(3_000),
+        sample_rate_hz=SPEAKER_SHADOW_SAMPLE_RATE_HZ,
+        candidate=_candidate(48),
+    )
+    await runtime.wait_idle()
+
+    assert seen_checkpoints == [3_000]
+    assert runtime.snapshot()["callback_failure_count"] == 1
+    assert runtime.snapshot()["scored_candidate_count"] == 1
+    await runtime.close()
+
+
+@pytest.mark.parametrize("failure_stage", ["load", "score"])
+async def test_intermediate_checkpoint_failure_wipes_buffered_pcm(
+    failure_stage: str,
+) -> None:
+    stage_started = _spawn_event()
+    stage_release = _spawn_event()
+    runtime = SpeakerShadowRuntime(
+        backend_factory=_BackendFactory(
+            load_error=failure_stage == "load",
+            score_error=failure_stage == "score",
+            block_stage=failure_stage,
+            stage_started=stage_started,
+            stage_release=stage_release,
+        ),
+        config=_config(
+            minimum_audio_ms=1_500,
+            maximum_audio_ms=4_000,
+            observation_checkpoints_ms=(1_500, 3_000),
+        ),
+    )
+    candidate = _candidate(52)
+
+    try:
+        assert runtime.submit(
+            _pcm(1_500),
+            sample_rate_hz=SPEAKER_SHADOW_SAMPLE_RATE_HZ,
+            candidate=candidate,
+        )
+        await _wait_until(stage_started.is_set)
+        retained_pcm = runtime._buffers[candidate].pcm16
+        assert any(retained_pcm)
+        assert runtime.finish_candidate(candidate)
+
+        stage_release.set()
+        await runtime.wait_idle()
+
+        metrics = runtime.snapshot()
+        terminal_count = sum(
+            metrics[f"{reason}_candidate_count"]
+            for reason in ("scored", "insufficient", "dropped", "failed")
+        )
+        assert metrics["failed_candidate_count"] == 1
+        assert metrics["finished_candidate_count"] == 1
+        assert terminal_count == 1
+        assert metrics["buffered_candidate_count"] == 0
+        assert metrics["buffered_audio_bytes"] == 0
+        assert metrics["retained_pcm_bytes"] == 0
+        assert not any(retained_pcm)
+    finally:
+        stage_release.set()
+        await runtime.close()
+
+
+async def test_explicit_checkpoints_accept_pcm_during_intermediate_score() -> None:
+    score_started = _spawn_event()
+    score_release = _spawn_event()
+    observations: list[SpeakerShadowObservation] = []
+
+    async def observe(observation: SpeakerShadowObservation) -> None:
+        observations.append(observation)
+
+    runtime = SpeakerShadowRuntime(
+        backend_factory=_BackendFactory(
+            score_value=0.2,
+            block_stage="score",
+            stage_started=score_started,
+            stage_release=score_release,
+        ),
+        config=_config(
+            minimum_audio_ms=1_500,
+            maximum_audio_ms=4_000,
+            observation_checkpoints_ms=(1_500, 3_000),
+        ),
+        on_observation=observe,
+    )
+    candidate = _candidate(50)
+
+    assert runtime.submit(
+        _pcm(1_500),
+        sample_rate_hz=SPEAKER_SHADOW_SAMPLE_RATE_HZ,
+        candidate=candidate,
+    )
+    await _wait_until(score_started.is_set)
+    assert runtime.submit(
+        _pcm(1_500),
+        sample_rate_hz=SPEAKER_SHADOW_SAMPLE_RATE_HZ,
+        candidate=candidate,
+    )
+    score_release.set()
+    await runtime.wait_idle()
+
+    assert [item.checkpoint_ms for item in observations] == [1_500, 3_000]
+    assert runtime.snapshot()["scored_candidate_count"] == 1
+    await runtime.close()
+
+
+async def test_intermediate_score_coalesces_frames_beyond_queue_capacity() -> None:
+    score_started = _spawn_event()
+    score_release = _spawn_event()
+    observations: list[SpeakerShadowObservation] = []
+
+    async def observe(observation: SpeakerShadowObservation) -> None:
+        observations.append(observation)
+
+    runtime = SpeakerShadowRuntime(
+        backend_factory=_BackendFactory(
+            score_value=0.2,
+            block_stage="score",
+            stage_started=score_started,
+            stage_release=score_release,
+        ),
+        config=_config(
+            minimum_audio_ms=1_500,
+            maximum_audio_ms=4_000,
+            queue_capacity=8,
+            observation_checkpoints_ms=(1_500, 3_000),
+        ),
+        on_observation=observe,
+    )
+    candidate = _candidate(51)
+
+    try:
+        assert runtime.submit(
+            _pcm(1_500),
+            sample_rate_hz=SPEAKER_SHADOW_SAMPLE_RATE_HZ,
+            candidate=candidate,
+        )
+        await _wait_until(score_started.is_set)
+        for _ in range(50):
+            assert runtime.submit(
+                _pcm(30),
+                sample_rate_hz=SPEAKER_SHADOW_SAMPLE_RATE_HZ,
+                candidate=candidate,
+            )
+
+        score_release.set()
+        await runtime.wait_idle()
+
+        assert [item.checkpoint_ms for item in observations] == [1_500, 3_000]
+        metrics = runtime.snapshot()
+        assert metrics["dropped_frame_count"] == 0
+        assert metrics["scored_candidate_count"] == 1
+        assert metrics["retained_pcm_bytes"] == 0
+    finally:
+        score_release.set()
+        await runtime.close()
+
+
+async def test_finish_after_first_explicit_checkpoint_scores_once() -> None:
+    observations: list[SpeakerShadowObservation] = []
+
+    async def observe(observation: SpeakerShadowObservation) -> None:
+        observations.append(observation)
+
+    runtime = SpeakerShadowRuntime(
+        backend_factory=_BackendFactory(score_value=0.2),
+        config=_config(
+            minimum_audio_ms=1_500,
+            maximum_audio_ms=4_000,
+            observation_checkpoints_ms=(1_500, 3_000),
+        ),
+        on_observation=observe,
+    )
+    candidate = _candidate(49)
+
+    assert runtime.submit(
+        _pcm(1_500),
+        sample_rate_hz=SPEAKER_SHADOW_SAMPLE_RATE_HZ,
+        candidate=candidate,
+    )
+    assert runtime.finish_candidate(candidate)
+    await runtime.wait_idle()
+
+    assert [item.checkpoint_ms for item in observations] == [1_500]
+    metrics = runtime.snapshot()
+    assert metrics["scored_candidate_count"] == 1
+    assert metrics["insufficient_candidate_count"] == 0
+    assert metrics["finished_candidate_count"] == 1
+    await runtime.close()
+
+
 async def test_finish_releases_short_buffer_without_starting_host() -> None:
     runtime = SpeakerShadowRuntime(
         backend_factory=_BackendFactory(),
@@ -358,6 +604,35 @@ async def test_single_lifecycle_preroll_payload_above_one_second_is_accepted() -
     assert metrics["submitted_audio_ms"] == 2_500
     assert metrics["scored_candidate_count"] == 1
     assert metrics["retained_pcm_bytes"] == 0
+    await runtime.close()
+
+
+async def test_default_checkpoint_scores_the_full_accepted_preroll() -> None:
+    preroll = _pcm(2_500)
+    observations: list[SpeakerShadowObservation] = []
+
+    async def observe(observation: SpeakerShadowObservation) -> None:
+        observations.append(observation)
+
+    runtime = SpeakerShadowRuntime(
+        backend_factory=_BackendFactory(expected_pcm=preroll),
+        config=_config(
+            minimum_audio_ms=1_500,
+            maximum_audio_ms=4_000,
+        ),
+        on_observation=observe,
+    )
+
+    assert runtime.submit(
+        preroll,
+        sample_rate_hz=SPEAKER_SHADOW_SAMPLE_RATE_HZ,
+        candidate=_candidate(51),
+    )
+    await runtime.wait_idle()
+
+    assert [(item.audio_ms, item.checkpoint_ms) for item in observations] == [
+        (2_500, None)
+    ]
     await runtime.close()
 
 

--- a/tests/unit/test_asr_client.py
+++ b/tests/unit/test_asr_client.py
@@ -23,6 +23,14 @@ from main_logic.asr_client._registry_meta import (
     ASR_PROVIDER_REGISTRY,
     CORE_ASR_ROUTES,
 )
+from main_logic.asr_client.candidate_control import (
+    CandidateRejectionOutcome,
+    CandidateRejectionRequest,
+)
+from main_logic.asr_client.endpointing.detector import (
+    DetectorCandidateKey,
+    ProviderCandidateFence,
+)
 from main_logic.asr_client.workers.dummy import dummy_asr_worker
 from main_logic.asr_client.lifecycle import (
     VoiceInputLifecycleController,
@@ -37,6 +45,7 @@ from main_logic.asr_client.runtime import (
 )
 from main_logic.asr_client.transcript import TranscriptDispatcher
 from main_logic.voice_turn.contracts import SpeechActivityEvent
+from main_logic.voice_turn.audio_input import ProcessedVoiceFrame
 
 
 async def _scripted_worker(request_queue, response_queue, api_key, config):
@@ -2274,6 +2283,543 @@ def _replace_runtime_identity_same_epoch(
         route_generation=2,
     )
     return session, lifecycle, detector
+
+
+def _install_candidate_rejection_state(
+    runtime: IndependentAsrRuntime,
+    detector: _RuntimeDetectorStub,
+    *,
+    draining: bool = False,
+) -> tuple[
+    CandidateRejectionRequest,
+    object,
+    object,
+    DetectorCandidateKey,
+]:
+    _install_active_runtime_state(runtime, detector)
+    lifecycle = runtime._asr_lifecycle
+    assert lifecycle is not None
+    lifecycle.transition(VoiceLifecycleEvent.SOFT_WAKE)
+    lifecycle.transition(VoiceLifecycleEvent.SPEECH_CONFIRMED)
+    turn_token = runtime._capture_turn_token(lifecycle)
+    final_key = asr_runtime_module.FinalKey.from_turn(turn_token)
+    assert runtime._asr_transcript_dispatcher.try_reserve(final_key)
+    runtime._asr_reserved_final_key = final_key
+    runtime._asr_turn_prepared = True
+    runtime._asr_partial_turn_token = turn_token
+    runtime._asr_audio_dispatcher = SimpleNamespace(
+        active_turn=turn_token,
+        abort=MagicMock(),
+    )
+    if draining:
+        lifecycle.transition(VoiceLifecycleEvent.TURN_SEALED)
+        runtime._asr_sealed_turn_token = runtime._capture_transport_token(lifecycle)
+    candidate = DetectorCandidateKey(4, 9)
+    detector.candidate_is_current = AsyncMock(
+        side_effect=lambda observed: observed == candidate
+    )
+    detector.current_candidate = AsyncMock(return_value=candidate)
+    detector.reset = AsyncMock(return_value=True)
+    snapshot = lifecycle.snapshot
+    request = CandidateRejectionRequest(
+        session_epoch=runtime._asr_session_epoch,
+        audio_generation=runtime._asr_audio_generation,
+        transport_generation=snapshot.transport_generation,
+        turn_id=snapshot.turn_id,
+        candidate=candidate,
+        profile_generation="profile-7",
+        filter_generation="beta-v1",
+    )
+    return request, turn_token, final_key, candidate
+
+
+@pytest.mark.parametrize(
+    ("request_change", "active_profile", "active_filter"),
+    [
+        ({"session_epoch": 1}, "profile-7", "beta-v1"),
+        ({"audio_generation": 1}, "profile-7", "beta-v1"),
+        ({"transport_generation": 1}, "profile-7", "beta-v1"),
+        ({"turn_id": 1}, "profile-7", "beta-v1"),
+        (
+            {"candidate": DetectorCandidateKey(4, 10)},
+            "profile-7",
+            "beta-v1",
+        ),
+        ({}, "profile-8", "beta-v1"),
+        ({}, "profile-7", "beta-v2"),
+    ],
+)
+async def test_candidate_rejection_fails_open_for_every_stale_fence(
+    request_change,
+    active_profile,
+    active_filter,
+) -> None:
+    runtime = IndependentAsrRuntime(_runtime_callbacks())
+    detector = _RuntimeDetectorStub()
+    request, _, _, _ = _install_candidate_rejection_state(runtime, detector)
+    values = {
+        "session_epoch": request.session_epoch,
+        "audio_generation": request.audio_generation,
+        "transport_generation": request.transport_generation,
+        "turn_id": request.turn_id,
+        "candidate": request.candidate,
+        "profile_generation": request.profile_generation,
+        "filter_generation": request.filter_generation,
+    }
+    for field, delta in request_change.items():
+        values[field] = (
+            values[field] + delta if isinstance(delta, int) else delta
+        )
+    stale = CandidateRejectionRequest(**values)
+    session = runtime._asr_session
+
+    result = await runtime._reject_candidate(
+        stale,
+        active_profile_generation=active_profile,
+        active_filter_generation=active_filter,
+    )
+
+    assert result is CandidateRejectionOutcome.STALE
+    assert runtime._asr_session is session
+    session.close.assert_not_awaited()
+
+
+async def test_candidate_pause_before_rejection_closes_exact_rejection_window() -> None:
+    runtime = IndependentAsrRuntime(_runtime_callbacks())
+    detector = _RuntimeDetectorStub()
+    request, turn_token, final_key, candidate = _install_candidate_rejection_state(
+        runtime,
+        detector,
+    )
+    session = runtime._asr_session
+    lifecycle = runtime._asr_lifecycle
+    audio_dispatcher = runtime._asr_audio_dispatcher
+    assert session is not None
+    assert lifecycle is not None
+    transport_generation = lifecycle.snapshot.transport_generation
+
+    await runtime._handle_independent_asr_activity(
+        SpeechActivityEvent.CANDIDATE_PAUSE,
+        request.session_epoch,
+        candidate=candidate,
+    )
+    result = await runtime._reject_candidate(
+        request,
+        active_profile_generation="profile-7",
+        active_filter_generation="beta-v1",
+    )
+
+    assert result is CandidateRejectionOutcome.STALE
+    assert runtime._asr_session is session
+    session.close.assert_not_awaited()
+    assert lifecycle.snapshot.transport_generation == transport_generation
+    audio_dispatcher.abort.assert_not_called()
+    assert runtime._asr_candidate_rejection is None
+    assert runtime._asr_turn_prepared is True
+    assert runtime._asr_partial_turn_token == turn_token
+    assert runtime._asr_reserved_final_key == final_key
+    assert final_key in runtime._asr_transcript_dispatcher._reservations
+
+
+async def test_blocked_partial_callback_does_not_block_candidate_rejection() -> None:
+    partial_started = asyncio.Event()
+    release_partial = asyncio.Event()
+
+    async def on_partial(_event) -> None:
+        partial_started.set()
+        await release_partial.wait()
+
+    callbacks = replace(_runtime_callbacks(), on_partial=on_partial)
+    runtime = IndependentAsrRuntime(callbacks)
+    detector = _RuntimeDetectorStub()
+    request, turn_token, _, _ = _install_candidate_rejection_state(
+        runtime,
+        detector,
+    )
+    audio_dispatcher = runtime._asr_audio_dispatcher
+    preview_task = asyncio.create_task(
+        runtime._send_independent_asr_preview("blocked preview", request.session_epoch)
+    )
+    rejection_task: asyncio.Task[CandidateRejectionOutcome] | None = None
+
+    try:
+        await asyncio.wait_for(partial_started.wait(), 1)
+        rejection_task = asyncio.create_task(
+            runtime._reject_candidate(
+                request,
+                active_profile_generation="profile-7",
+                active_filter_generation="beta-v1",
+            )
+        )
+
+        result = await asyncio.wait_for(asyncio.shield(rejection_task), 1)
+
+        assert result is CandidateRejectionOutcome.APPLIED
+        assert preview_task.done() is False
+        assert runtime._asr_session is None
+        assert runtime._asr_candidate_rejection is not None
+        audio_dispatcher.abort.assert_called_once_with(turn_token)
+    finally:
+        release_partial.set()
+        tasks = [preview_task]
+        if rejection_task is not None:
+            tasks.append(rejection_task)
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+async def test_candidate_rejection_suppresses_tail_until_exact_pause() -> None:
+    callbacks = _runtime_callbacks()
+    runtime = IndependentAsrRuntime(callbacks)
+    detector = _RuntimeDetectorStub()
+    request, turn_token, final_key, candidate = _install_candidate_rejection_state(
+        runtime,
+        detector,
+    )
+    other_key = replace(final_key, turn_id=final_key.turn_id + 100)
+    assert runtime._asr_transcript_dispatcher.try_reserve(other_key)
+    session = runtime._asr_session
+    runtime._ensure_transport_restart_task = MagicMock()
+
+    result = await runtime._reject_candidate(
+        request,
+        active_profile_generation="profile-7",
+        active_filter_generation="beta-v1",
+    )
+
+    assert result is CandidateRejectionOutcome.APPLIED
+    session.close.assert_awaited_once_with()
+    assert final_key not in runtime._asr_transcript_dispatcher._reservations
+    assert other_key in runtime._asr_transcript_dispatcher._reservations
+    assert runtime._asr_candidate_rejection is not None
+    detector.feed = AsyncMock(
+        return_value=SimpleNamespace(
+            events=(),
+            endpointing_available=True,
+            throttle_action=None,
+            throttle_available=True,
+        )
+    )
+    frame = ProcessedVoiceFrame(b"\x01\x00" * 160, 16_000, 0.9, True)
+    submitted = await runtime.submit(
+        frame,
+        ingress_token=turn_token.ingress,
+    )
+    assert submitted.status is asr_runtime_module.AsrSubmitStatus.ACCEPTED
+    detector.feed.assert_awaited_once()
+    runtime._ensure_transport_restart_task.assert_not_called()
+
+    await runtime._handle_independent_asr_activity(
+        SpeechActivityEvent.CANDIDATE_PAUSE,
+        request.session_epoch,
+        candidate=DetectorCandidateKey(4, 10),
+    )
+    assert runtime._asr_candidate_rejection is not None
+    detector.reset.assert_not_awaited()
+
+    await runtime._handle_independent_asr_activity(
+        SpeechActivityEvent.CANDIDATE_PAUSE,
+        request.session_epoch,
+        candidate=candidate,
+    )
+
+    detector.reset.assert_awaited_once_with(expected_candidate=candidate)
+    assert runtime._asr_candidate_rejection is None
+    assert runtime._asr_lifecycle.snapshot.state.value == "local_listen"
+    callbacks.on_turn_abandoned.assert_awaited_once_with(turn_token)
+    runtime._ensure_transport_restart_task.assert_called_once_with()
+
+
+async def test_candidate_rejection_cleanup_failure_recovers_upload() -> None:
+    callbacks = _runtime_callbacks()
+    runtime = IndependentAsrRuntime(callbacks)
+    detector = _RuntimeDetectorStub()
+    request, turn_token, _, _ = _install_candidate_rejection_state(
+        runtime,
+        detector,
+    )
+    runtime._asr_session.close = AsyncMock(side_effect=RuntimeError("close failed"))
+    runtime._ensure_transport_restart_task = MagicMock()
+
+    result = await runtime._reject_candidate(
+        request,
+        active_profile_generation="profile-7",
+        active_filter_generation="beta-v1",
+    )
+
+    assert result is CandidateRejectionOutcome.FAILED
+    assert runtime._asr_candidate_rejection is None
+    callbacks.on_turn_abandoned.assert_awaited_once_with(turn_token)
+    runtime._ensure_transport_restart_task.assert_called_once_with()
+
+
+async def test_candidate_rejection_cleanup_failure_resets_detector_before_restart() -> None:
+    runtime = IndependentAsrRuntime(_runtime_callbacks())
+    detector = _RuntimeDetectorStub()
+    request, _, _, _ = _install_candidate_rejection_state(runtime, detector)
+    runtime._asr_session.close = AsyncMock(side_effect=RuntimeError("close failed"))
+    recovery_steps: list[str] = []
+
+    async def reset_detector(*, expected_candidate=None) -> bool:
+        assert expected_candidate is None
+        recovery_steps.append("reset")
+        return True
+
+    detector.reset = AsyncMock(side_effect=reset_detector)
+    runtime._ensure_transport_restart_task = MagicMock(
+        side_effect=lambda: recovery_steps.append("restart")
+    )
+
+    result = await runtime._reject_candidate(
+        request,
+        active_profile_generation="profile-7",
+        active_filter_generation="beta-v1",
+    )
+
+    assert result is CandidateRejectionOutcome.FAILED
+    assert recovery_steps == ["reset", "restart"]
+
+
+async def test_candidate_rejection_recovery_restarts_after_detector_reset_error() -> None:
+    callbacks = _runtime_callbacks()
+    runtime = IndependentAsrRuntime(callbacks)
+    detector = _RuntimeDetectorStub()
+    request, turn_token, _, _ = _install_candidate_rejection_state(runtime, detector)
+    runtime._asr_session.close = AsyncMock(side_effect=RuntimeError("close failed"))
+    detector.reset = AsyncMock(side_effect=RuntimeError("reset failed"))
+    runtime._ensure_transport_restart_task = MagicMock()
+
+    result = await runtime._reject_candidate(
+        request,
+        active_profile_generation="profile-7",
+        active_filter_generation="beta-v1",
+    )
+
+    assert result is CandidateRejectionOutcome.FAILED
+    detector.reset.assert_awaited_once_with()
+    callbacks.on_turn_abandoned.assert_awaited_once_with(turn_token)
+    runtime._ensure_transport_restart_task.assert_called_once_with()
+
+
+async def test_candidate_rejection_recovery_preserves_detector_reset_cancellation() -> None:
+    callbacks = _runtime_callbacks()
+    runtime = IndependentAsrRuntime(callbacks)
+    detector = _RuntimeDetectorStub()
+    request, turn_token, _, _ = _install_candidate_rejection_state(runtime, detector)
+    runtime._asr_session.close = AsyncMock(side_effect=RuntimeError("close failed"))
+    detector.reset = AsyncMock(side_effect=asyncio.CancelledError())
+    runtime._ensure_transport_restart_task = MagicMock()
+
+    with pytest.raises(asyncio.CancelledError):
+        await runtime._reject_candidate(
+            request,
+            active_profile_generation="profile-7",
+            active_filter_generation="beta-v1",
+        )
+
+    callbacks.on_turn_abandoned.assert_awaited_once_with(turn_token)
+    runtime._ensure_transport_restart_task.assert_not_called()
+
+
+async def test_resumed_candidate_reopens_exact_rejection_window() -> None:
+    runtime = IndependentAsrRuntime(_runtime_callbacks())
+    detector = _RuntimeDetectorStub()
+    request, _, _, candidate = _install_candidate_rejection_state(runtime, detector)
+
+    await runtime._handle_independent_asr_activity(
+        SpeechActivityEvent.CANDIDATE_PAUSE,
+        request.session_epoch,
+        candidate=candidate,
+    )
+    await runtime._handle_independent_asr_activity(
+        SpeechActivityEvent.SPEECH_RESUMED,
+        request.session_epoch,
+        candidate=candidate,
+    )
+    result = await runtime._reject_candidate(
+        request,
+        active_profile_generation="profile-7",
+        active_filter_generation="beta-v1",
+    )
+
+    assert result is CandidateRejectionOutcome.APPLIED
+
+
+@pytest.mark.parametrize("teardown", ["close", "abort", "error"])
+async def test_candidate_rejection_teardown_notifies_abandoned_turn(
+    teardown: str,
+) -> None:
+    callbacks = _runtime_callbacks()
+    runtime = IndependentAsrRuntime(callbacks)
+    detector = _RuntimeDetectorStub()
+    request, turn_token, _, _ = _install_candidate_rejection_state(runtime, detector)
+
+    result = await runtime._reject_candidate(
+        request,
+        active_profile_generation="profile-7",
+        active_filter_generation="beta-v1",
+    )
+    assert result is CandidateRejectionOutcome.APPLIED
+    runtime._asr_audio_dispatcher.close = AsyncMock()
+    runtime._asr_audio_dispatcher.asr_abort_discarded_command_count = 0
+
+    if teardown == "close":
+        await runtime.close()
+    elif teardown == "abort":
+        await runtime.abort("route_closed")
+    else:
+        await runtime._handle_independent_asr_error(
+            request.session_epoch,
+            "qwen",
+        )
+
+    callbacks.on_turn_abandoned.assert_awaited_once_with(turn_token)
+
+
+async def test_candidate_rejection_teardown_swallows_abandon_callback_error() -> None:
+    callbacks = replace(
+        _runtime_callbacks(),
+        on_turn_abandoned=AsyncMock(side_effect=RuntimeError("callback failed")),
+    )
+    runtime = IndependentAsrRuntime(callbacks)
+    detector = _RuntimeDetectorStub()
+    request, turn_token, _, _ = _install_candidate_rejection_state(runtime, detector)
+
+    result = await runtime._reject_candidate(
+        request,
+        active_profile_generation="profile-7",
+        active_filter_generation="beta-v1",
+    )
+    assert result is CandidateRejectionOutcome.APPLIED
+    runtime._asr_audio_dispatcher.close = AsyncMock()
+
+    await runtime.close()
+
+    callbacks.on_turn_abandoned.assert_awaited_once_with(turn_token)
+
+
+async def test_close_tolerates_lease_and_session_cleanup_errors() -> None:
+    runtime = IndependentAsrRuntime(_runtime_callbacks())
+    detector = _RuntimeDetectorStub()
+    _install_active_runtime_state(runtime, detector)
+    runtime._asr_smart_turn_lease = SimpleNamespace(
+        release=AsyncMock(side_effect=RuntimeError("release failed"))
+    )
+    runtime._asr_session.close = AsyncMock(side_effect=RuntimeError("close failed"))
+
+    await runtime.close()
+
+    detector.close.assert_awaited_once_with()
+
+
+async def test_abort_continues_after_detector_reset_error() -> None:
+    runtime = IndependentAsrRuntime(_runtime_callbacks())
+    detector = _RuntimeDetectorStub()
+    _install_active_runtime_state(runtime, detector)
+    detector.reset = AsyncMock(side_effect=RuntimeError("reset failed"))
+
+    await runtime.abort("hard_mute")
+
+    detector.reset.assert_awaited_once_with()
+
+
+async def test_abort_routes_current_ingress_backpressure_to_local_recovery() -> None:
+    runtime = IndependentAsrRuntime(_runtime_callbacks())
+    ingress_token = runtime.capture_ingress_token(
+        connection_id="connection",
+        lease_generation=1,
+        route_generation=1,
+    )
+    runtime._asr_current_ingress_token = ingress_token
+    runtime._handle_audio_ingress_backpressure = AsyncMock()
+
+    await runtime.abort("ingress_backpressure")
+
+    runtime._handle_audio_ingress_backpressure.assert_awaited_once_with(ingress_token)
+
+
+async def test_provider_final_wins_rejection_waiting_on_detector_completion() -> None:
+    runtime = IndependentAsrRuntime(_runtime_callbacks())
+    detector = _RuntimeDetectorStub()
+    request, _, _, candidate = _install_candidate_rejection_state(
+        runtime,
+        detector,
+        draining=True,
+    )
+    runtime._asr_lifecycle.provider_policy = resolve_provider_policy(
+        "qwen",
+        "provider",
+    )
+    runtime._asr_provider_candidate_fence = ProviderCandidateFence(4, 9, 10)
+    completion_started = asyncio.Event()
+    release_completion = asyncio.Event()
+
+    async def complete_provider_candidate(_fence):
+        completion_started.set()
+        await release_completion.wait()
+        return False
+
+    detector.complete_provider_candidate = AsyncMock(
+        side_effect=complete_provider_candidate
+    )
+    final = asyncio.create_task(
+        runtime._handle_independent_asr_final(
+            "accepted",
+            request.session_epoch,
+            "qwen",
+        )
+    )
+    await asyncio.wait_for(completion_started.wait(), 1)
+    rejection = asyncio.create_task(
+        runtime._reject_candidate(
+            request,
+            active_profile_generation="profile-7",
+            active_filter_generation="beta-v1",
+        )
+    )
+    release_completion.set()
+
+    await asyncio.wait_for(final, 1)
+    assert await asyncio.wait_for(rejection, 1) is CandidateRejectionOutcome.STALE
+    await runtime.wait_transcript_idle()
+    runtime._callbacks.on_final.assert_awaited_once()
+    detector.candidate_is_current.assert_not_awaited()
+    assert candidate == request.candidate
+
+
+async def test_rejection_wins_and_old_final_permanently_loses_eligibility() -> None:
+    runtime = IndependentAsrRuntime(_runtime_callbacks())
+    detector = _RuntimeDetectorStub()
+    request, _, _, _ = _install_candidate_rejection_state(
+        runtime,
+        detector,
+        draining=True,
+    )
+    close_started = asyncio.Event()
+    release_close = asyncio.Event()
+
+    async def close_session() -> None:
+        close_started.set()
+        await release_close.wait()
+
+    runtime._asr_session.close = AsyncMock(side_effect=close_session)
+    rejection = asyncio.create_task(
+        runtime._reject_candidate(
+            request,
+            active_profile_generation="profile-7",
+            active_filter_generation="beta-v1",
+        )
+    )
+    await asyncio.wait_for(close_started.wait(), 1)
+
+    await runtime._handle_independent_asr_final(
+        "stale final",
+        request.session_epoch,
+        "glm",
+    )
+    release_close.set()
+
+    assert await asyncio.wait_for(rejection, 1) is CandidateRejectionOutcome.APPLIED
+    runtime._callbacks.on_final.assert_not_awaited()
 
 
 async def test_stale_detector_failure_callback_cannot_close_new_runtime(

--- a/tests/unit/test_asr_client.py
+++ b/tests/unit/test_asr_client.py
@@ -5,7 +5,7 @@ import gc
 import weakref
 from dataclasses import replace
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 
@@ -2176,6 +2176,7 @@ class _RuntimeDetectorStub:
         self.close = AsyncMock()
         self.reset = AsyncMock()
         self.bind_candidate = bind_candidate or AsyncMock(return_value=object())
+        self.candidate_is_bound_to = AsyncMock(return_value=True)
         self.release_deferred_turn = release_deferred_turn or AsyncMock()
         self._turn_token = None
 
@@ -2318,6 +2319,11 @@ def _install_candidate_rejection_state(
     detector.candidate_is_current = AsyncMock(
         side_effect=lambda observed: observed == candidate
     )
+    detector.candidate_is_bound_to = AsyncMock(
+        side_effect=lambda observed, bound_turn: (
+            observed == candidate and bound_turn == turn_token
+        )
+    )
     detector.current_candidate = AsyncMock(return_value=candidate)
     detector.reset = AsyncMock(return_value=True)
     snapshot = lifecycle.snapshot
@@ -2419,6 +2425,36 @@ async def test_candidate_pause_before_rejection_closes_exact_rejection_window() 
     assert runtime._asr_partial_turn_token == turn_token
     assert runtime._asr_reserved_final_key == final_key
     assert final_key in runtime._asr_transcript_dispatcher._reservations
+
+
+async def test_candidate_rejection_refuses_current_candidate_bound_to_pending_turn() -> (
+    None
+):
+    runtime = IndependentAsrRuntime(_runtime_callbacks())
+    detector = _RuntimeDetectorStub()
+    request, previous_turn, final_key, _ = _install_candidate_rejection_state(
+        runtime,
+        detector,
+        draining=True,
+    )
+    detector.candidate_is_bound_to = AsyncMock(return_value=False)
+    session = runtime._asr_session
+
+    result = await runtime._reject_candidate(
+        request,
+        active_profile_generation="profile-7",
+        active_filter_generation="beta-v1",
+    )
+
+    assert result is CandidateRejectionOutcome.STALE
+    detector.candidate_is_bound_to.assert_awaited_once_with(
+        request.candidate,
+        previous_turn,
+    )
+    assert runtime._asr_session is session
+    assert runtime._asr_reserved_final_key == final_key
+    assert final_key in runtime._asr_transcript_dispatcher._reservations
+    session.close.assert_not_awaited()
 
 
 async def test_blocked_partial_callback_does_not_block_candidate_rejection() -> None:
@@ -2529,6 +2565,69 @@ async def test_candidate_rejection_suppresses_tail_until_exact_pause() -> None:
     runtime._ensure_transport_restart_task.assert_called_once_with()
 
 
+async def test_candidate_pause_retries_unconditional_reset_before_restart() -> None:
+    runtime = IndependentAsrRuntime(_runtime_callbacks())
+    detector = _RuntimeDetectorStub()
+    request, _, _, candidate = _install_candidate_rejection_state(runtime, detector)
+    assert (
+        await runtime._reject_candidate(
+            request,
+            active_profile_generation="profile-7",
+            active_filter_generation="beta-v1",
+        )
+        is CandidateRejectionOutcome.APPLIED
+    )
+    recovery_steps: list[object] = []
+
+    async def reset_detector(*, expected_candidate=None) -> bool:
+        recovery_steps.append(expected_candidate)
+        if expected_candidate is not None:
+            raise RuntimeError("exact reset failed")
+        return True
+
+    detector.reset = AsyncMock(side_effect=reset_detector)
+    runtime._ensure_transport_restart_task = MagicMock(
+        side_effect=lambda: recovery_steps.append("restart")
+    )
+
+    reset_applied = await runtime._finish_candidate_rejection(candidate)
+
+    assert reset_applied is True
+    assert recovery_steps == [candidate, None, "restart"]
+    assert runtime._asr_candidate_rejection is None
+
+
+async def test_candidate_pause_escalates_when_all_detector_resets_fail() -> None:
+    runtime = IndependentAsrRuntime(_runtime_callbacks())
+    detector = _RuntimeDetectorStub()
+    request, _, _, candidate = _install_candidate_rejection_state(runtime, detector)
+    assert (
+        await runtime._reject_candidate(
+            request,
+            active_profile_generation="profile-7",
+            active_filter_generation="beta-v1",
+        )
+        is CandidateRejectionOutcome.APPLIED
+    )
+    detector.reset = AsyncMock(side_effect=RuntimeError("reset failed"))
+    runtime._ensure_transport_restart_task = MagicMock()
+    runtime._handle_independent_asr_error = AsyncMock()
+
+    reset_applied = await runtime._finish_candidate_rejection(candidate)
+
+    assert reset_applied is False
+    assert detector.reset.await_args_list == [
+        call(expected_candidate=candidate),
+        call(),
+    ]
+    runtime._handle_independent_asr_error.assert_awaited_once_with(
+        request.session_epoch,
+        "glm",
+        status_code="ASR_ENDPOINTING_FAILED",
+    )
+    runtime._ensure_transport_restart_task.assert_not_called()
+
+
 async def test_candidate_rejection_cleanup_failure_recovers_upload() -> None:
     callbacks = _runtime_callbacks()
     runtime = IndependentAsrRuntime(callbacks)
@@ -2579,7 +2678,7 @@ async def test_candidate_rejection_cleanup_failure_resets_detector_before_restar
     assert recovery_steps == ["reset", "restart"]
 
 
-async def test_candidate_rejection_recovery_restarts_after_detector_reset_error() -> None:
+async def test_candidate_rejection_recovery_escalates_detector_reset_error() -> None:
     callbacks = _runtime_callbacks()
     runtime = IndependentAsrRuntime(callbacks)
     detector = _RuntimeDetectorStub()
@@ -2587,6 +2686,7 @@ async def test_candidate_rejection_recovery_restarts_after_detector_reset_error(
     runtime._asr_session.close = AsyncMock(side_effect=RuntimeError("close failed"))
     detector.reset = AsyncMock(side_effect=RuntimeError("reset failed"))
     runtime._ensure_transport_restart_task = MagicMock()
+    runtime._handle_independent_asr_error = AsyncMock()
 
     result = await runtime._reject_candidate(
         request,
@@ -2597,7 +2697,12 @@ async def test_candidate_rejection_recovery_restarts_after_detector_reset_error(
     assert result is CandidateRejectionOutcome.FAILED
     detector.reset.assert_awaited_once_with()
     callbacks.on_turn_abandoned.assert_awaited_once_with(turn_token)
-    runtime._ensure_transport_restart_task.assert_called_once_with()
+    runtime._handle_independent_asr_error.assert_awaited_once_with(
+        request.session_epoch,
+        "glm",
+        status_code="ASR_ENDPOINTING_FAILED",
+    )
+    runtime._ensure_transport_restart_task.assert_not_called()
 
 
 async def test_candidate_rejection_recovery_preserves_detector_reset_cancellation() -> None:

--- a/tests/unit/test_asr_client.py
+++ b/tests/unit/test_asr_client.py
@@ -2570,6 +2570,41 @@ async def test_candidate_rejection_suppresses_tail_until_exact_pause() -> None:
     runtime._ensure_transport_restart_task.assert_called_once_with()
 
 
+async def test_candidate_pause_waits_for_detached_cleanup_before_restart() -> None:
+    runtime = IndependentAsrRuntime(_runtime_callbacks())
+    detector = _RuntimeDetectorStub()
+    request, _, _, candidate = _install_candidate_rejection_state(runtime, detector)
+    cleanup_started = asyncio.Event()
+    release_cleanup = asyncio.Event()
+
+    async def close_session() -> None:
+        cleanup_started.set()
+        await release_cleanup.wait()
+
+    runtime._asr_session.close = AsyncMock(side_effect=close_session)
+    runtime._ensure_transport_restart_task = MagicMock()
+    rejection = asyncio.create_task(
+        runtime._reject_candidate(
+            request,
+            active_profile_generation="profile-7",
+            active_filter_generation="beta-v1",
+        )
+    )
+    await asyncio.wait_for(cleanup_started.wait(), 1)
+    finish = asyncio.create_task(runtime._finish_candidate_rejection(candidate))
+    await asyncio.sleep(0)
+
+    assert finish.done() is False
+    detector.reset.assert_not_awaited()
+    runtime._ensure_transport_restart_task.assert_not_called()
+
+    release_cleanup.set()
+    assert await asyncio.wait_for(rejection, 1) is CandidateRejectionOutcome.APPLIED
+    assert await asyncio.wait_for(finish, 1) is True
+    detector.reset.assert_awaited_once_with(expected_candidate=candidate)
+    runtime._ensure_transport_restart_task.assert_called_once_with()
+
+
 async def test_candidate_pause_retries_unconditional_reset_before_restart() -> None:
     runtime = IndependentAsrRuntime(_runtime_callbacks())
     detector = _RuntimeDetectorStub()
@@ -2657,14 +2692,23 @@ async def test_candidate_rejection_cleanup_failure_recovers_upload() -> None:
 
 
 async def test_candidate_rejection_cleanup_failure_resets_detector_before_restart() -> None:
-    runtime = IndependentAsrRuntime(_runtime_callbacks())
+    recovery_steps: list[str] = []
+
+    async def on_turn_abandoned(_turn_token) -> None:
+        recovery_steps.append("abandoned")
+
+    callbacks = replace(
+        _runtime_callbacks(),
+        on_turn_abandoned=on_turn_abandoned,
+    )
+    runtime = IndependentAsrRuntime(callbacks)
     detector = _RuntimeDetectorStub()
     request, _, _, _ = _install_candidate_rejection_state(runtime, detector)
     runtime._asr_session.close = AsyncMock(side_effect=RuntimeError("close failed"))
-    recovery_steps: list[str] = []
 
     async def reset_detector(*, expected_candidate=None) -> bool:
         assert expected_candidate is None
+        assert runtime._asr_candidate_rejection is not None
         recovery_steps.append("reset")
         return True
 
@@ -2680,7 +2724,7 @@ async def test_candidate_rejection_cleanup_failure_resets_detector_before_restar
     )
 
     assert result is CandidateRejectionOutcome.FAILED
-    assert recovery_steps == ["reset", "restart"]
+    assert recovery_steps == ["reset", "abandoned", "restart"]
 
 
 async def test_candidate_rejection_recovery_escalates_detector_reset_error() -> None:

--- a/tests/unit/test_asr_client.py
+++ b/tests/unit/test_asr_client.py
@@ -2353,6 +2353,10 @@ def _install_candidate_rejection_state(
         ),
         ({}, "profile-8", "beta-v1"),
         ({}, "profile-7", "beta-v2"),
+        ({}, "   ", "beta-v1"),
+        ({}, None, "beta-v1"),
+        ({}, "profile-7", ""),
+        ({}, "profile-7", 1),
     ],
 )
 async def test_candidate_rejection_fails_open_for_every_stale_fence(
@@ -2542,6 +2546,7 @@ async def test_candidate_rejection_suppresses_tail_until_exact_pause() -> None:
     )
     assert submitted.status is asr_runtime_module.AsrSubmitStatus.ACCEPTED
     detector.feed.assert_awaited_once()
+    detector.current_candidate.assert_not_awaited()
     runtime._ensure_transport_restart_task.assert_not_called()
 
     await runtime._handle_independent_asr_activity(

--- a/tests/unit/test_asr_client.py
+++ b/tests/unit/test_asr_client.py
@@ -2845,7 +2845,7 @@ async def test_abort_routes_current_ingress_backpressure_to_local_recovery() -> 
 async def test_provider_final_wins_rejection_waiting_on_detector_completion() -> None:
     runtime = IndependentAsrRuntime(_runtime_callbacks())
     detector = _RuntimeDetectorStub()
-    request, _, _, candidate = _install_candidate_rejection_state(
+    request, _, _, _ = _install_candidate_rejection_state(
         runtime,
         detector,
         draining=True,
@@ -2888,7 +2888,9 @@ async def test_provider_final_wins_rejection_waiting_on_detector_completion() ->
     await runtime.wait_transcript_idle()
     runtime._callbacks.on_final.assert_awaited_once()
     detector.candidate_is_current.assert_not_awaited()
-    assert candidate == request.candidate
+    assert runtime._asr_candidate_rejection is None
+    assert runtime._asr_sealed_turn_token is None
+    detector.reset.assert_not_awaited()
 
 
 async def test_rejection_wins_and_old_final_permanently_loses_eligibility() -> None:

--- a/tests/unit/test_asr_detector_runtime.py
+++ b/tests/unit/test_asr_detector_runtime.py
@@ -644,7 +644,7 @@ async def test_completion_fence_replays_pcm_consumed_during_inference() -> None:
     await asyncio.wait_for(coordinator.evaluate_started.wait(), 1)
     predecessor = SpeakerShadowCandidateKey(0, 0, "smart_turn_turn")
     assert shadow.frames == [(first_pcm, 16_000, predecessor)]
-    gate.events = ()
+    gate.events = (SpeechActivityEvent.SPEECH_STARTED,)
     successor_pcm = b"\x02\x00" * 160
     successor = await detector.submit_audio(
         successor_pcm,
@@ -656,23 +656,29 @@ async def test_completion_fence_replays_pcm_consumed_during_inference() -> None:
     async with asyncio.timeout(1):
         while gate.inputs.count(successor_pcm) < 1:
             await asyncio.sleep(0)
+    gate.events = ()
     assert shadow.frames == [(first_pcm, 16_000, predecessor)]
 
     coordinator.evaluate_release.set()
     await asyncio.wait_for(completed.wait(), 1)
     async with asyncio.timeout(1):
-        while gate.inputs.count(successor_pcm) < 2:
+        while gate.inputs.count(successor_pcm) < 2 or len(shadow.frames) < 2:
             await asyncio.sleep(0)
 
     assert successor.candidate is not None
     assert successor.candidate.candidate_generation == 0
     assert gate.inputs.count(successor_pcm) == 2
     assert coordinator.audio.count(successor_pcm) == 2
-    assert shadow.frames == [(first_pcm, 16_000, predecessor)]
+    successor_shadow = SpeakerShadowCandidateKey(0, 1, "smart_turn_turn")
+    assert shadow.frames == [
+        (first_pcm, 16_000, predecessor),
+        (successor_pcm, 16_000, successor_shadow),
+    ]
     assert shadow.finished == [predecessor]
     assert shadow.events == [
         ("submit", predecessor),
         ("finish", predecessor),
+        ("submit", successor_shadow),
     ]
     await detector.close()
 

--- a/tests/unit/test_asr_detector_runtime.py
+++ b/tests/unit/test_asr_detector_runtime.py
@@ -421,6 +421,14 @@ async def test_shadow_correlation_never_replaces_detector_authority() -> None:
 
     assert await detector.current_candidate() == detector_candidate
     assert await detector.candidate_is_current(detector_candidate) is True
+    turn_token = VoiceTurnToken(_ingress_token(), turn_id=1)
+    other_turn_token = VoiceTurnToken(_ingress_token(), turn_id=2)
+    assert await detector.bind_candidate(detector_candidate, turn_token) is not None
+    assert await detector.candidate_is_bound_to(detector_candidate, turn_token) is True
+    assert (
+        await detector.candidate_is_bound_to(detector_candidate, other_turn_token)
+        is False
+    )
     assert (
         await detector.correlate_speaker_shadow_candidate(shadow_candidate)
         == detector_candidate

--- a/tests/unit/test_asr_detector_runtime.py
+++ b/tests/unit/test_asr_detector_runtime.py
@@ -18,6 +18,7 @@ from main_logic.asr_client.endpointing.detector_runtime import (
 )
 from main_logic.asr_client.endpointing.detector import (
     DetectorActivityEvent,
+    DetectorCandidateKey,
     DetectorIngressIdentity,
     DetectorPrewarmEvent,
     DetectorSubmitStatus,
@@ -300,6 +301,43 @@ async def test_speaker_shadow_default_none_installs_no_smart_turn_callbacks() ->
     await detector.close()
 
 
+async def test_smart_turn_shadow_opens_only_at_authoritative_speech_onset() -> None:
+    shadow = _SpeakerShadowSpy()
+    gate = _Gate()
+    detector = DetectorRuntime(
+        vad=_Vad(),
+        gate=gate,
+        resource_optimization_enabled=False,
+        provider_policy=_smart_turn_policy(),
+        coordinator=_SemanticCoordinator(),
+        speaker_shadow=shadow,
+        on_turn_complete=AsyncMock(),
+    )
+    idle_pcm = b"\x00\x00" * 160
+    speech_pcm = b"\x01\x00" * 160
+
+    await detector.feed(
+        idle_pcm,
+        speech_probability=0.0,
+        ingress_token=_ingress_token(),
+    )
+
+    assert shadow.frames == []
+    assert detector._speaker_shadow_candidate is None
+
+    gate.events = (SpeechActivityEvent.SPEECH_STARTED,)
+    await detector.feed(
+        speech_pcm,
+        speech_probability=0.9,
+        ingress_token=_ingress_token(),
+    )
+
+    candidate = SpeakerShadowCandidateKey(0, 0, "smart_turn_turn")
+    assert shadow.frames == [(speech_pcm, 16_000, candidate)]
+    assert detector._speaker_shadow_candidate == candidate
+    await detector.close()
+
+
 async def test_provider_shadow_observes_admitted_pcm_until_explicit_seal() -> None:
     shadow = _SpeakerShadowSpy()
     gate = _Gate((SpeechActivityEvent.CANDIDATE_PAUSE,))
@@ -362,6 +400,48 @@ async def test_provider_shadow_observes_admitted_pcm_until_explicit_seal() -> No
 
     await detector.close()
     assert shadow.close_calls == 1
+
+
+async def test_shadow_correlation_never_replaces_detector_authority() -> None:
+    shadow = _SpeakerShadowSpy()
+    detector = DetectorRuntime(
+        vad=_Vad(),
+        gate=_Gate((SpeechActivityEvent.SPEECH_STARTED,)),
+        provider_policy=_provider_endpoint_policy(),
+        speaker_shadow=shadow,
+    )
+    await detector.feed(
+        b"\x01\x00" * 160,
+        speech_probability=0.9,
+        ingress_token=_ingress_token(),
+    )
+    detector.observe_provider_audio(b"\x01\x00" * 160, sample_rate_hz=16_000)
+    shadow_candidate = SpeakerShadowCandidateKey(0, 0, "provider_candidate")
+    detector_candidate = DetectorCandidateKey(0, 0)
+
+    assert await detector.current_candidate() == detector_candidate
+    assert await detector.candidate_is_current(detector_candidate) is True
+    assert (
+        await detector.correlate_speaker_shadow_candidate(shadow_candidate)
+        == detector_candidate
+    )
+    assert (
+        await detector.correlate_speaker_shadow_candidate(
+            SpeakerShadowCandidateKey(0, 1, "provider_candidate")
+        )
+        is None
+    )
+
+    assert (
+        await detector.reset(expected_candidate=DetectorCandidateKey(0, 1))
+        is False
+    )
+    assert detector.detector_epoch == 0
+    assert await detector.candidate_is_current(detector_candidate) is True
+    assert await detector.reset(expected_candidate=detector_candidate) is True
+    assert detector.detector_epoch == 1
+    assert await detector.current_candidate() is None
+    await detector.close()
 
 
 async def test_speaker_shadow_reset_and_close_advance_generation_fail_open() -> None:
@@ -528,7 +608,12 @@ async def test_stale_provider_ingress_does_not_mutate_throttle_policy() -> None:
 
 async def test_completion_fence_replays_pcm_consumed_during_inference() -> None:
     coordinator = _BlockingSemanticCoordinator()
-    gate = _Gate((SpeechActivityEvent.CANDIDATE_PAUSE,))
+    gate = _Gate(
+        (
+            SpeechActivityEvent.SPEECH_STARTED,
+            SpeechActivityEvent.CANDIDATE_PAUSE,
+        )
+    )
     completed = asyncio.Event()
     shadow = _SpeakerShadowSpy()
     detector = DetectorRuntime(
@@ -575,17 +660,11 @@ async def test_completion_fence_replays_pcm_consumed_during_inference() -> None:
     assert successor.candidate.candidate_generation == 0
     assert gate.inputs.count(successor_pcm) == 2
     assert coordinator.audio.count(successor_pcm) == 2
-    successor_candidate = SpeakerShadowCandidateKey(0, 1, "smart_turn_turn")
-    assert shadow.frames == [
-        (first_pcm, 16_000, predecessor),
-        (successor_pcm, 16_000, successor_candidate),
-    ]
-    assert shadow.frames[1][0] is successor_pcm
+    assert shadow.frames == [(first_pcm, 16_000, predecessor)]
     assert shadow.finished == [predecessor]
     assert shadow.events == [
         ("submit", predecessor),
         ("finish", predecessor),
-        ("submit", successor_candidate),
     ]
     await detector.close()
 
@@ -608,7 +687,12 @@ async def test_speaker_shadow_keeps_stale_or_incomplete_tail_on_predecessor(
     tail_events: tuple[SpeechActivityEvent, ...],
 ) -> None:
     coordinator = _BlockingResultCoordinator(status=status, decision=decision)
-    gate = _Gate((SpeechActivityEvent.CANDIDATE_PAUSE,))
+    gate = _Gate(
+        (
+            SpeechActivityEvent.SPEECH_STARTED,
+            SpeechActivityEvent.CANDIDATE_PAUSE,
+        )
+    )
     shadow = _SpeakerShadowSpy()
     detector = DetectorRuntime(
         vad=_Vad(),

--- a/tests/unit/test_check_core_contracts.py
+++ b/tests/unit/test_check_core_contracts.py
@@ -1167,6 +1167,32 @@ def test_voice_identity_contract_accepts_in_memory_dependency_direction(
 
 
 @pytest.mark.unit
+def test_voice_identity_contract_allows_only_the_bounded_asr_composition_bridge(
+    contract_checker,
+    tmp_path: Path,
+) -> None:
+    package = _write_minimal_voice_identity_layout(tmp_path)
+    composition = package / "asr_composition.py"
+    composition.write_text(
+        "from main_logic.asr_client.runtime import IndependentAsrRuntime\n",
+        encoding="utf-8",
+    )
+
+    assert contract_checker.check_voice_identity_contracts(tmp_path) == []
+
+    composition.write_text(
+        "from main_logic.core import LLMSessionManager\n",
+        encoding="utf-8",
+    )
+    messages = [
+        violation.message
+        for violation in contract_checker.check_voice_identity_contracts(tmp_path)
+        if violation.path == composition
+    ]
+    assert messages == ["voice_identity domain must not import main_logic.core"]
+
+
+@pytest.mark.unit
 def test_voice_identity_contract_fails_closed_when_package_is_missing(
     contract_checker,
     tmp_path: Path,

--- a/tests/unit/test_core_independent_asr.py
+++ b/tests/unit/test_core_independent_asr.py
@@ -1,6 +1,7 @@
 import ast
 import asyncio
 import hashlib
+import importlib.util
 import inspect
 import json
 import logging
@@ -5398,11 +5399,17 @@ async def test_core_passes_only_configured_speaker_shadow_factory(
 
 async def test_core_composition_seam_has_no_voice_identity_or_shadow_imports() -> None:
     tree = ast.parse(inspect.getsource(core_asr_runtime_module))
-    imported = {
-        node.module or ""
-        for node in ast.walk(tree)
-        if isinstance(node, ast.ImportFrom)
-    }
+    imported = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        module = node.module or ""
+        if node.level:
+            module = importlib.util.resolve_name(
+                f"{'.' * node.level}{module}",
+                core_asr_runtime_module.__package__,
+            )
+        imported.add(module)
     imported.update(
         alias.name
         for node in ast.walk(tree)
@@ -5410,11 +5417,13 @@ async def test_core_composition_seam_has_no_voice_identity_or_shadow_imports() -
         for alias in node.names
     )
 
-    assert not any(
-        module.startswith("main_logic.voice_identity")
-        or module.startswith("main_logic.asr_client.speaker_shadow")
+    violations = sorted(
+        module
         for module in imported
+        if module.startswith("main_logic.voice_identity")
+        or module.startswith("main_logic.asr_client.speaker_shadow")
     )
+    assert violations == [], f"composition seam leaked imports: {violations}"
 
 
 async def test_provider_restart_reuses_accepted_session_optimization(

--- a/tests/unit/test_core_independent_asr.py
+++ b/tests/unit/test_core_independent_asr.py
@@ -5396,6 +5396,27 @@ async def test_core_passes_only_configured_speaker_shadow_factory(
     factory.assert_not_called()
 
 
+async def test_core_composition_seam_has_no_voice_identity_or_shadow_imports() -> None:
+    tree = ast.parse(inspect.getsource(core_asr_runtime_module))
+    imported = {
+        node.module or ""
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+    }
+    imported.update(
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    )
+
+    assert not any(
+        module.startswith("main_logic.voice_identity")
+        or module.startswith("main_logic.asr_client.speaker_shadow")
+        for module in imported
+    )
+
+
 async def test_provider_restart_reuses_accepted_session_optimization(
     monkeypatch,
 ) -> None:

--- a/tests/unit/voice_identity/test_asr_composition.py
+++ b/tests/unit/voice_identity/test_asr_composition.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import numpy as np
+import pytest
+
+from main_logic.asr_client.endpointing.detector import DetectorCandidateKey
+from main_logic.asr_client.runtime import AsrRuntimeCallbacks, IndependentAsrRuntime
+from main_logic.asr_client.speaker_shadow.asset_manifest import (
+    CAMPPLUS_MODEL_ID,
+    CAMPPLUS_MODEL_REVISION,
+)
+from main_logic.asr_client.speaker_shadow.campplus import (
+    CAMPPLUS_EMBEDDING_DIM,
+    CampPlusBackendFactory,
+)
+from main_logic.asr_client.speaker_shadow.contracts import (
+    SpeakerShadowCandidateKey,
+    SpeakerShadowObservation,
+)
+from main_logic.voice_identity.asr_composition import (
+    OwnerVoiceAsrCompositionFactory,
+)
+from main_logic.voice_identity.contracts import SpeakerModelIdentity
+from main_logic.voice_identity.policy import OwnerVoiceBetaPolicy
+from main_logic.voice_identity.profile import SpeakerProfile
+from main_logic.voice_identity.reference import SpeakerReference
+
+
+def _runtime() -> IndependentAsrRuntime:
+    return IndependentAsrRuntime(
+        AsrRuntimeCallbacks(
+            display_name=lambda: "test",
+            on_prepare_turn=AsyncMock(return_value=True),
+            on_partial=AsyncMock(),
+            on_final=AsyncMock(),
+            on_turn_abandoned=AsyncMock(),
+            on_failure=AsyncMock(),
+            on_status=AsyncMock(),
+            on_lifecycle=AsyncMock(),
+        )
+    )
+
+
+def _profile(
+    generation: str = "profile-7",
+    *,
+    model_id: str = CAMPPLUS_MODEL_ID,
+) -> SpeakerProfile:
+    identity = SpeakerModelIdentity(
+        model_id,
+        CAMPPLUS_MODEL_REVISION,
+        CAMPPLUS_EMBEDDING_DIM,
+    )
+    reference = SpeakerReference(
+        identity,
+        np.arange(1, CAMPPLUS_EMBEDDING_DIM + 1, dtype=np.float32),
+    )
+    try:
+        return SpeakerProfile(generation, reference)
+    finally:
+        reference.close()
+
+
+def _fake_backend_builder(reference: SpeakerReference):
+    assert reference.model_identity.model_id == CAMPPLUS_MODEL_ID
+    return MagicMock(name="backend_factory")
+
+
+def test_factory_captures_owned_profile_and_exact_beta_checkpoints() -> None:
+    runtime = _runtime()
+    profile = _profile()
+    factory = OwnerVoiceAsrCompositionFactory(
+        runtime,
+        profile,
+        backend_factory_builder=_fake_backend_builder,
+    )
+    profile.close()
+
+    observer = factory()
+
+    assert observer.enabled is True
+    assert observer._config.minimum_audio_ms == 1_500
+    assert observer._config.maximum_audio_ms == 3_000
+    assert observer._config.observation_checkpoints_ms == (1_500, 3_000)
+    assert observer._worker_task is None
+    assert observer._callback_task is None
+
+
+def test_default_backend_builder_copies_profile_into_campplus_factory() -> None:
+    runtime = _runtime()
+    profile = _profile()
+    factory = OwnerVoiceAsrCompositionFactory(runtime, profile)
+
+    observer = factory()
+
+    assert isinstance(observer._backend_factory, CampPlusBackendFactory)
+    profile.close()
+    factory.close()
+
+
+def test_default_backend_rejects_wrong_model_identity_fail_open_at_seam() -> None:
+    runtime = _runtime()
+    profile = _profile(model_id="other-model")
+    factory = OwnerVoiceAsrCompositionFactory(runtime, profile)
+
+    with pytest.raises(ValueError, match=r"does not match CAM\+\+"):
+        factory()
+
+    profile.close()
+    factory.close()
+
+
+async def test_two_low_observations_build_detector_authoritative_rejection() -> None:
+    runtime = _runtime()
+    profile = _profile()
+    candidate = DetectorCandidateKey(8, 12)
+    detector = SimpleNamespace(
+        correlate_speaker_shadow_candidate=AsyncMock(return_value=candidate)
+    )
+    runtime._asr_detector = detector
+    runtime._asr_lifecycle = SimpleNamespace(
+        snapshot=SimpleNamespace(transport_generation=4, turn_id=6)
+    )
+    runtime._asr_session_epoch = 3
+    runtime._asr_audio_generation = 5
+    runtime._reject_candidate = AsyncMock()
+    factory = OwnerVoiceAsrCompositionFactory(
+        runtime,
+        profile,
+        backend_factory_builder=_fake_backend_builder,
+    )
+    observer = factory()
+    callback = observer._on_observation
+    shadow_candidate = SpeakerShadowCandidateKey(8, 2, "provider_candidate")
+
+    await callback(
+        SpeakerShadowObservation(
+            candidate=shadow_candidate,
+            similarity=0.39,
+            would_block=((0.40, True),),
+            audio_ms=1_500,
+            checkpoint_ms=1_500,
+        )
+    )
+    runtime._reject_candidate.assert_not_awaited()
+
+    await callback(
+        SpeakerShadowObservation(
+            candidate=shadow_candidate,
+            similarity=0.38,
+            would_block=((0.40, True),),
+            audio_ms=3_000,
+            checkpoint_ms=3_000,
+        )
+    )
+
+    runtime._reject_candidate.assert_awaited_once()
+    request = runtime._reject_candidate.await_args.args[0]
+    assert request.session_epoch == 3
+    assert request.audio_generation == 5
+    assert request.transport_generation == 4
+    assert request.turn_id == 6
+    assert request.candidate is candidate
+    assert request.profile_generation == "profile-7"
+    assert request.filter_generation == OwnerVoiceBetaPolicy.VERSION
+    assert runtime._reject_candidate.await_args.kwargs == {
+        "active_profile_generation": "profile-7",
+        "active_filter_generation": OwnerVoiceBetaPolicy.VERSION,
+    }
+    profile.close()
+    factory.close()
+
+
+async def test_stale_shadow_correlation_and_callback_failure_are_fail_open() -> None:
+    runtime = _runtime()
+    profile = _profile()
+    detector = SimpleNamespace(
+        correlate_speaker_shadow_candidate=AsyncMock(return_value=None)
+    )
+    runtime._asr_detector = detector
+    runtime._asr_lifecycle = SimpleNamespace(
+        snapshot=SimpleNamespace(transport_generation=1, turn_id=1)
+    )
+    runtime._reject_candidate = AsyncMock()
+    factory = OwnerVoiceAsrCompositionFactory(
+        runtime,
+        profile,
+        backend_factory_builder=_fake_backend_builder,
+    )
+    callback = factory()._on_observation
+    observation = SpeakerShadowObservation(
+        candidate=SpeakerShadowCandidateKey(0, 0, "provider_candidate"),
+        similarity=0.1,
+        would_block=((0.40, True),),
+        audio_ms=1_500,
+        checkpoint_ms=1_500,
+    )
+
+    await callback(observation)
+    detector.correlate_speaker_shadow_candidate.side_effect = RuntimeError("race")
+    await callback(observation)
+
+    runtime._reject_candidate.assert_not_awaited()
+    profile.close()
+    factory.close()
+
+
+def test_closed_factory_cannot_capture_a_later_session() -> None:
+    runtime = _runtime()
+    profile = _profile()
+    factory = OwnerVoiceAsrCompositionFactory(
+        runtime,
+        profile,
+        backend_factory_builder=_fake_backend_builder,
+    )
+    factory.close()
+
+    with pytest.raises(RuntimeError, match="factory is closed"):
+        factory()
+
+    profile.close()

--- a/tests/unit/voice_identity/test_asr_composition.py
+++ b/tests/unit/voice_identity/test_asr_composition.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -206,6 +207,71 @@ async def test_stale_shadow_correlation_and_callback_failure_are_fail_open() -> 
     runtime._reject_candidate.assert_not_awaited()
     profile.close()
     factory.close()
+
+
+async def test_rejection_transaction_survives_observation_callback_cancellation() -> (
+    None
+):
+    runtime = _runtime()
+    profile = _profile()
+    candidate = DetectorCandidateKey(8, 12)
+    runtime._asr_detector = SimpleNamespace(
+        correlate_speaker_shadow_candidate=AsyncMock(return_value=candidate)
+    )
+    runtime._asr_lifecycle = SimpleNamespace(
+        snapshot=SimpleNamespace(transport_generation=4, turn_id=6)
+    )
+    transaction_started = asyncio.Event()
+    transaction_release = asyncio.Event()
+    transaction_completed = asyncio.Event()
+
+    async def reject_candidate(*_args, **_kwargs) -> None:
+        transaction_started.set()
+        await transaction_release.wait()
+        transaction_completed.set()
+
+    runtime._reject_candidate = AsyncMock(side_effect=reject_candidate)
+    factory = OwnerVoiceAsrCompositionFactory(
+        runtime,
+        profile,
+        backend_factory_builder=_fake_backend_builder,
+    )
+    callback = factory()._on_observation
+    shadow_candidate = SpeakerShadowCandidateKey(8, 2, "provider_candidate")
+
+    try:
+        await callback(
+            SpeakerShadowObservation(
+                candidate=shadow_candidate,
+                similarity=0.39,
+                would_block=((0.40, True),),
+                audio_ms=1_500,
+                checkpoint_ms=1_500,
+            )
+        )
+        callback_task = asyncio.create_task(
+            callback(
+                SpeakerShadowObservation(
+                    candidate=shadow_candidate,
+                    similarity=0.38,
+                    would_block=((0.40, True),),
+                    audio_ms=3_000,
+                    checkpoint_ms=3_000,
+                )
+            )
+        )
+        await asyncio.wait_for(transaction_started.wait(), 1)
+
+        callback_task.cancel()
+        await asyncio.sleep(0)
+        transaction_release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await callback_task
+        await asyncio.wait_for(transaction_completed.wait(), 1)
+    finally:
+        transaction_release.set()
+        profile.close()
+        factory.close()
 
 
 def test_closed_factory_cannot_capture_a_later_session() -> None:

--- a/tests/unit/voice_identity/test_policy.py
+++ b/tests/unit/voice_identity/test_policy.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import pytest
+
+from main_logic.voice_identity.policy import (
+    OwnerVoiceBetaPolicy,
+    OwnerVoicePolicyDecision,
+)
+
+
+def _observe(
+    policy: OwnerVoiceBetaPolicy,
+    checkpoint_ms: int,
+    similarity: float,
+    *,
+    detector_epoch: int = 8,
+    candidate_generation: int = 3,
+    profile_generation: str = "profile-7",
+    active_detector_epoch: int = 8,
+    active_candidate_generation: int = 3,
+    active_profile_generation: str = "profile-7",
+    enabled: bool = True,
+):
+    return policy.observe(
+        detector_epoch=detector_epoch,
+        candidate_generation=candidate_generation,
+        profile_generation=profile_generation,
+        active_detector_epoch=active_detector_epoch,
+        active_candidate_generation=active_candidate_generation,
+        active_profile_generation=active_profile_generation,
+        checkpoint_ms=checkpoint_ms,
+        similarity=similarity,
+        enabled=enabled,
+    )
+
+
+def test_beta_v1_requires_two_strictly_low_observations() -> None:
+    policy = OwnerVoiceBetaPolicy()
+
+    first = _observe(policy, 1_500, 0.20)
+    second = _observe(policy, 3_000, 0.39)
+
+    assert first.decision == OwnerVoicePolicyDecision.FORWARD
+    assert first.reason == "awaiting_second_low_observation"
+    assert second.decision == OwnerVoicePolicyDecision.HYPOTHETICAL_REJECT
+    assert second.reason == "stable_clear_mismatch"
+    assert second.policy_version == "beta-v1"
+    assert policy.pending_candidate_count == 0
+
+
+@pytest.mark.parametrize(
+    ("first_score", "second_score"),
+    (
+        (0.20, 0.60),
+        (0.60, 0.20),
+        (0.40, 0.20),
+        (0.20, 0.40),
+    ),
+)
+def test_beta_v1_forwards_uncertain_boundary_and_fluctuating_scores(
+    first_score: float,
+    second_score: float,
+) -> None:
+    policy = OwnerVoiceBetaPolicy()
+
+    _observe(policy, 1_500, first_score)
+    result = _observe(policy, 3_000, second_score)
+
+    assert result.decision == OwnerVoicePolicyDecision.FORWARD
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    (
+        {"active_detector_epoch": 9},
+        {"active_candidate_generation": 4},
+        {"active_profile_generation": "profile-8"},
+        {"enabled": False},
+    ),
+)
+def test_beta_v1_forwards_disabled_and_stale_generations(overrides) -> None:
+    policy = OwnerVoiceBetaPolicy()
+
+    result = _observe(policy, 1_500, 0.10, **overrides)
+
+    assert result.decision == OwnerVoicePolicyDecision.FORWARD
+    assert policy.pending_candidate_count == 0
+
+
+@pytest.mark.parametrize(
+    ("checkpoint_ms", "similarity"),
+    (
+        (1_499, 0.10),
+        (1_501, 0.10),
+        (3_001, 0.10),
+        (1_500, float("nan")),
+        (1_500, float("inf")),
+        (1_500, -1.01),
+        (1_500, 1.01),
+    ),
+)
+def test_beta_v1_forwards_invalid_or_non_checkpoint_observations(
+    checkpoint_ms: int,
+    similarity: float,
+) -> None:
+    result = _observe(OwnerVoiceBetaPolicy(), checkpoint_ms, similarity)
+
+    assert result.decision == OwnerVoicePolicyDecision.FORWARD
+    assert result.reason == "invalid_observation"
+
+
+def test_beta_v1_requires_the_first_checkpoint() -> None:
+    result = _observe(OwnerVoiceBetaPolicy(), 3_000, 0.10)
+
+    assert result.decision == OwnerVoicePolicyDecision.FORWARD
+
+
+def test_beta_v1_does_not_join_checkpoints_across_detector_epochs() -> None:
+    policy = OwnerVoiceBetaPolicy()
+
+    first = _observe(
+        policy,
+        1_500,
+        0.10,
+        detector_epoch=8,
+        active_detector_epoch=8,
+        candidate_generation=0,
+        active_candidate_generation=0,
+    )
+    second = _observe(
+        policy,
+        3_000,
+        0.10,
+        detector_epoch=9,
+        active_detector_epoch=9,
+        candidate_generation=0,
+        active_candidate_generation=0,
+    )
+
+    assert first.decision == OwnerVoicePolicyDecision.FORWARD
+    assert second.decision == OwnerVoicePolicyDecision.FORWARD
+
+
+def test_beta_v1_candidate_cache_is_bounded_and_evicts_the_oldest() -> None:
+    policy = OwnerVoiceBetaPolicy(candidate_capacity=2)
+    for generation in (1, 2, 3):
+        _observe(
+            policy,
+            1_500,
+            0.10,
+            candidate_generation=generation,
+            active_candidate_generation=generation,
+        )
+
+    oldest = _observe(
+        policy,
+        3_000,
+        0.10,
+        candidate_generation=1,
+        active_candidate_generation=1,
+    )
+    newest = _observe(
+        policy,
+        3_000,
+        0.10,
+        candidate_generation=3,
+        active_candidate_generation=3,
+    )
+
+    assert oldest.decision == OwnerVoicePolicyDecision.FORWARD
+    assert newest.decision == OwnerVoicePolicyDecision.HYPOTHETICAL_REJECT
+
+
+def test_beta_v1_forget_and_reset_only_drop_policy_state() -> None:
+    policy = OwnerVoiceBetaPolicy()
+    _observe(policy, 1_500, 0.10)
+    policy.forget_candidate(
+        detector_epoch=8,
+        candidate_generation=3,
+        profile_generation="profile-7",
+    )
+    assert policy.pending_candidate_count == 0
+
+    _observe(policy, 1_500, 0.10)
+    policy.reset()
+    assert policy.pending_candidate_count == 0
+
+
+def test_beta_v1_rejects_unbounded_cache_configuration() -> None:
+    with pytest.raises(ValueError, match="candidate_capacity"):
+        OwnerVoiceBetaPolicy(candidate_capacity=0)


### PR DESCRIPTION
## 概要

这是基于 #2459 当前收敛 head 的第二个堆栈 PR，为测试版 Owner 声纹增加宽松判定与 Independent ASR 当前候选软截断。

测试版目标是在尽量不影响 Owner 正常语音的前提下，截断一部分稳定、明显不匹配的长语音尾部，减少后续 ASR/LLM 消耗。它不是身份认证或安全边界。

本 PR 收敛为 2 个逻辑提交：

1. 建立 provider-neutral 的 `FORWARD` / `REJECT_CURRENT_CANDIDATE` 决策合同、版本化 `beta-v1` 两阶段策略及 Speaker Shadow checkpoint 观测。
2. 在 Independent ASR 公共控制层执行当前候选软截断，并由 Core 组合当前 Profile/filter 状态；能力不进入 Provider worker。

## 判定行为

- 功能默认关闭；无有效 Profile 时不能开启。
- 1.5 秒与 3 秒分别产生一次独立 CAM++ 观测。
- 两次相似度都严格低于 0.40 才允许形成拒绝结论。
- 不读取旧 `would_block` 观测字段作为执行命令。
- 不足 3 秒、Owner、边界分数、分数波动、缺失观测、模型异常、队列压力或 identity/profile 状态变化均放行。
- 阈值是固定、版本化的 Beta 参数，不自动学习或调整。

## 执行行为

每个拒绝请求携带并在执行前复核：

- session ID
- detector epoch
- candidate generation
- candidate scope
- profile revision
- observation generation

命中后只处理当前候选：

- 使旧 Provider transport 立即失去回调资格。
- 停止当前候选剩余 PCM 的排队与上传。
- 只释放当前候选 transcript reservation，保留先前候选的 reservation/final。
- 丢弃该候选尚未进入对话的 Provider partial/final，不发送 LLM。
- 持续发声尾部保持抑制；检测到 pause 后复位 detector，下一句建立新 candidate 并正常重连。
- Provider 已收到的约前 3 秒不可撤回，因此只承诺部分节省。

## 边界

- 不修改 OpenAI、Qwen、Soniox、Grok、Step、GLM 或 Gemini worker。
- 不修改 SmartTurn、server_vad 或 Provider endpointing 算法。
- 不增加上传前暂存、hard block、整场会话封禁、多人识别、回放/克隆/活体检测。
- 不改变 Native Omni 路径。
- 不把该功能描述为认证或安全功能。
- 声纹与 ASR 架构守门继续是针对可信仓库代码的合作式结构 lint；不扩展为作用域解释器、跨语句数据流或反射推断器。

## 回归报告 / Regression Report

### 改动、理由与必要性

改动前，Speaker Shadow 只能提供观测，Independent ASR 没有针对“连续两个稳定低分 checkpoint”的候选级软截断事务；明显不匹配的长语音仍会继续上传并可能进入后续 LLM。改动后，provider-neutral 策略只在完整 identity 与两阶段低分条件同时满足时请求拒绝，公共 ASR runtime 通过候选事务完成精确截断，其余情况保持 fail-open。

### 范围与前后表现

执行能力只存在于 `IndependentAsrRuntime` 公共控制层；Core 只负责组合当前 Profile/filter 状态并提交带完整 identity 的请求。Provider worker、模型协议和 endpointing 决策保持不变。重整到 #2459 当前 head 后，策略、组合、candidate control、Speaker Shadow、detector、Core Independent ASR 与 voice-identity 守门的 571 项定向回归通过。

### 风险与回归点

主要风险位于公共 ASR runtime 的候选生命周期、transport 失效、transcript reservation 隔离、pause/reset 恢复与取消传播。执行同时匹配 session、detector epoch、candidate generation、scope、profile revision 与 observation generation；任何 identity 不匹配、Profile 更新、策略异常、detector 不可用、reset 失败或清理失败都不会升级为 hard block。

### Provider Matrix

- OpenAI / Qwen / Soniox / Grok / Step：继续使用 provider-native endpointing，Owner 策略不等待 CAM++ 才上传。
- GLM / Gemini：继续使用 SmartTurn；拒绝只消费公共 detector activity，不改变 SmartTurn 语义判断。
- 所有 Provider：旧 transport 在拒绝时由公共层摘除，provider-specific callback 因 session identity 不再匹配而失效。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增 Owner Voice Soft Filter Beta 方案，支持在指定音频检查点进行说话人观测。
  * 增加候选状态管理与拒绝处理，支持释放预留结果、终止排队音频并抑制被拒候选尾部。
  * 对过期、无效或异常情况采用安全放行，降低对 ASR 流程的影响。

* **文档**
  * 新增 Beta 设计文档，说明检查点、相似度判定、会话重置及清理规则。

* **测试**
  * 补充候选拒绝、检查点观测、并发竞态、异常恢复及边界条件测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->