### PR TITLE
refactor(plugin-cli): reuse package inspection and sync vendor in CI

### DIFF
--- a/plugin/neko_plugin_cli/commands/deps_cmd.py
+++ b/plugin/neko_plugin_cli/commands/deps_cmd.py
@@ -163,8 +163,8 @@ def handle_sync(args: argparse.Namespace) -> int:
 
     pyproject_path = plugin_dir / "pyproject.toml"
     if not pyproject_path.is_file():
-        print(f"[FAIL] {plugin_dir.name}: pyproject.toml not found.", file=sys.stderr)
-        return 1
+        print(f"[OK] {plugin_dir.name}: no external dependencies to sync")
+        return 0
 
     # 1. Read declared dependencies
     all_deps = _read_dependencies(pyproject_path)

--- a/plugin/neko_plugin_cli/core/inspect.py
+++ b/plugin/neko_plugin_cli/core/inspect.py
@@ -31,22 +31,36 @@ class PackageInspector:
         package_path = Path(package_path).expanduser().resolve()
 
         with zipfile.ZipFile(package_path) as archive:
-            manifest = read_manifest(archive)
-            metadata = read_metadata(archive)
+            return self.inspect_archive(
+                archive,
+                package_path=package_path,
+            )
 
-            package_type = self.require_string(manifest, "package_type")
-            package_id = self.require_string(manifest, "id")
-            plugin_folders = collect_plugin_folders(archive)
-            validate_package_type(package_type, plugin_folders)
-            validate_plugin_layout(archive, plugin_folders)
-            validate_plugin_manifest_types(archive, plugin_folders)
-            validate_dependency_layout(archive, plugin_folders)
+    def inspect_archive(
+        self,
+        archive: zipfile.ZipFile,
+        *,
+        package_path: Path,
+    ) -> PackageInspectResult:
+        """Inspect and validate an already-open package archive."""
 
-            payload_hash = compute_archive_payload_hash(archive)
-            payload_hash_verified = verify_payload_hash(metadata, payload_hash)
-            plugins = self.collect_plugins(archive, plugin_folders)
-            profile_names = collect_profile_names(archive)
-            dependencies = self.parse_dependency_manifest(read_dependency_manifest(archive))
+        manifest = read_manifest(archive)
+        metadata = read_metadata(archive)
+
+        package_type = self.require_string(manifest, "package_type")
+        package_id = self.require_string(manifest, "id")
+        plugin_folders = collect_plugin_folders(archive)
+        validate_package_type(package_type, plugin_folders)
+        validate_plugin_layout(archive, plugin_folders)
+        validate_plugin_manifest_types(archive, plugin_folders)
+        validate_dependency_layout(archive, plugin_folders)
+
+        payload_hash = compute_archive_payload_hash(archive)
+        payload_hash_verified = verify_payload_hash(metadata, payload_hash)
+
+        plugins = self.collect_plugins(archive, plugin_folders)
+        profile_names = collect_profile_names(archive)
+        dependencies = self.parse_dependency_manifest(read_dependency_manifest(archive))
 
         return PackageInspectResult(
             package_path=package_path,

--- a/plugin/neko_plugin_cli/core/install.py
+++ b/plugin/neko_plugin_cli/core/install.py
@@ -4,19 +4,9 @@ from pathlib import Path
 import re
 import zipfile
 
+from .inspect import PackageInspector
 from .models import InstalledPlugin, InstallResult
-from .archive_utils import (
-    collect_plugin_folders,
-    compute_archive_payload_hash,
-    read_manifest,
-    read_metadata,
-    safe_archive_path,
-    validate_dependency_layout,
-    validate_plugin_manifest_types,
-    validate_package_type,
-    validate_plugin_layout,
-    verify_payload_hash,
-)
+from .archive_utils import read_metadata, safe_archive_path
 
 _SAFE_PACKAGE_ID_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 
@@ -40,31 +30,31 @@ class PackageInstaller:
         on_conflict = self.normalize_conflict_strategy(on_conflict)
 
         with zipfile.ZipFile(package_path) as archive:
-            manifest = read_manifest(archive)
-            package_type = self.require_string(manifest, "package_type")
-            package_id = self.validate_package_id(self.require_string(manifest, "id"))
-            metadata = read_metadata(archive)
-            plugin_folders = collect_plugin_folders(archive)
-            validate_package_type(package_type, plugin_folders)
-            validate_plugin_layout(archive, plugin_folders)
-            validate_plugin_manifest_types(archive, plugin_folders)
-            validate_dependency_layout(archive, plugin_folders)
-            payload_hash = compute_archive_payload_hash(archive)
-            payload_hash_verified = verify_payload_hash(metadata, payload_hash)
-            if payload_hash_verified is False:
-                meta_payload = metadata.get("payload", {}) if metadata else {}
-                expected = meta_payload.get("hash", "<unknown>") if isinstance(meta_payload, dict) else "<unknown>"
-                raise ValueError(
-                    f"payload hash mismatch: the archive content does not match the hash "
-                    f"recorded in metadata.toml.\n"
-                    f"  expected (metadata.toml): {expected}\n"
-                    f"  computed (archive):       {payload_hash}\n"
-                    f"This usually means the package was built on a different platform "
-                    f"(e.g. Windows vs Linux) with an older version of neko_plugin_cli "
-                    f"that had cross-platform sorting issues, or the archive was modified "
-                    f"after packaging. Try re-building the plugin with the latest "
-                    f"neko_plugin_cli."
+            inspected = PackageInspector().inspect_archive(
+                archive,
+                package_path=package_path,
+            )
+            if inspected.payload_hash_verified is False:
+                metadata = read_metadata(archive)
+                payload_table = metadata.get("payload", {}) if metadata else {}
+                expected = (
+                    payload_table.get("hash", "<unknown>")
+                    if isinstance(payload_table, dict)
+                    else "<unknown>"
                 )
+                raise ValueError(
+                    "payload hash mismatch: the archive content does not match the hash "
+                    "recorded in metadata.toml.\n"
+                    f"  expected (metadata.toml): {expected}\n"
+                    f"  computed (archive):       {inspected.payload_hash}\n"
+                    "This usually means the package was built on a different platform "
+                    "(e.g. Windows vs Linux) with an older version of neko_plugin_cli "
+                    "that had cross-platform sorting issues, or the archive was modified "
+                    "after packaging. Try re-building the plugin with the latest "
+                    "neko_plugin_cli."
+                )
+            package_id = self.validate_package_id(inspected.package_id)
+            plugin_folders = [item.plugin_id for item in inspected.plugins]
             folder_mapping = self.plan_plugin_targets(
                 plugin_folders,
                 plugins_root_path,
@@ -89,7 +79,7 @@ class PackageInstaller:
 
         return InstallResult(
             package_path=package_path,
-            package_type=package_type,
+            package_type=inspected.package_type,
             package_id=package_id,
             plugins_root=plugins_root_path,
             profiles_root=profiles_root_path,
@@ -103,9 +93,9 @@ class PackageInstaller:
                 for source_folder, target_dir in sorted(folder_mapping.items())
             ],
             profile_dir=profile_dir,
-            metadata_found=(metadata is not None),
-            payload_hash=payload_hash,
-            payload_hash_verified=payload_hash_verified,
+            metadata_found=inspected.metadata_found,
+            payload_hash=inspected.payload_hash,
+            payload_hash_verified=inspected.payload_hash_verified,
             conflict_strategy=on_conflict,
         )
 
@@ -230,16 +220,6 @@ class PackageInstaller:
             if candidate.name not in reserved_names and not candidate.exists():
                 return candidate.resolve()
             counter += 1
-
-    def require_string(self, data: dict[str, object], key: str) -> str:
-        value = data.get(key)
-        if not isinstance(value, str) or not value.strip():
-            actual = repr(value) if value is not None else "<missing>"
-            raise ValueError(
-                f"manifest.toml field '{key}' must be a non-empty string, got {actual}. "
-                f"The package manifest may be malformed or was created by an incompatible tool."
-            )
-        return value.strip()
 
     def validate_package_id(self, package_id: str) -> str:
         if (

--- a/plugin/neko_plugin_cli/templates/generator.py
+++ b/plugin/neko_plugin_cli/templates/generator.py
@@ -472,9 +472,17 @@ dependencies = []
 # Repository support files
 # ---------------------------------------------------------------------------
 
+def _dependency_sync_command(plugin: str) -> str:
+    return (
+        "uv run --with pip python -m plugin.neko_plugin_cli.cli "
+        f"sync {plugin} --clean"
+    )
+
+
 def _render_readme_md(spec: PluginSpec) -> str:
     name = spec.name or spec.plugin_id
     description = spec.description or "Describe what this plugin does and how to configure it."
+    sync_command = _dependency_sync_command(spec.plugin_id)
     return f'''# {name}
 
 {description}
@@ -496,9 +504,14 @@ When publishing to the plugin market, use this GitHub repository name:
 From the N.E.K.O repository root:
 
 ```bash
+{sync_command}
 uv run python -m plugin.neko_plugin_cli.cli check {spec.plugin_id}
 uv run python -m plugin.neko_plugin_cli.cli check -r {spec.plugin_id}
 ```
+
+Python runtime dependencies are declared in `pyproject.toml` and synced into
+`vendor/` for packaging. The generated `vendor/` directory is not committed;
+local builds and CI recreate it before release checks.
 
 ## Market release
 
@@ -542,6 +555,7 @@ def _render_gitignore() -> str:
 .ruff_cache/
 .venv/
 venv/
+vendor/
 dist/
 build/
 *.egg-info/
@@ -562,6 +576,7 @@ def _render_vscode_settings() -> str:
 
 
 def _render_vscode_tasks(spec: PluginSpec) -> str:
+    sync_command = _dependency_sync_command(spec.plugin_id)
     return f'''{{
   "version": "2.0.0",
   "tasks": [
@@ -569,6 +584,15 @@ def _render_vscode_tasks(spec: PluginSpec) -> str:
       "label": "N.E.K.O: check {spec.plugin_id}",
       "type": "shell",
       "command": "uv run python -m plugin.neko_plugin_cli.cli check {spec.plugin_id}",
+      "options": {{
+        "cwd": "${{config:nekoPlugin.repoRoot}}"
+      }},
+      "problemMatcher": []
+    }},
+    {{
+      "label": "N.E.K.O: sync {spec.plugin_id}",
+      "type": "shell",
+      "command": "{sync_command}",
       "options": {{
         "cwd": "${{config:nekoPlugin.repoRoot}}"
       }},
@@ -598,6 +622,7 @@ def _render_vscode_tasks(spec: PluginSpec) -> str:
 
 
 def _render_verify_workflow(spec: PluginSpec) -> str:
+    sync_command = _dependency_sync_command('"${PLUGIN_ID}"')
     return f'''name: Verify N.E.K.O Plugin
 
 on:
@@ -634,6 +659,10 @@ jobs:
           rm -rf "neko/plugin/plugins/${{PLUGIN_ID}}"
           mkdir -p neko/plugin/plugins
           cp -R plugin-repo "neko/plugin/plugins/${{PLUGIN_ID}}"
+
+      - name: Sync plugin dependencies
+        working-directory: neko
+        run: {sync_command}
 
       - name: Release check
         working-directory: neko
@@ -680,6 +709,7 @@ jobs:
 
 
 def _render_release_workflow(spec: PluginSpec) -> str:
+    sync_command = _dependency_sync_command('"${PLUGIN_ID}"')
     return f'''name: Release N.E.K.O Plugin
 
 on:
@@ -720,6 +750,10 @@ jobs:
           rm -rf "neko/plugin/plugins/${{PLUGIN_ID}}"
           mkdir -p neko/plugin/plugins
           cp -R plugin-repo "neko/plugin/plugins/${{PLUGIN_ID}}"
+
+      - name: Sync plugin dependencies
+        working-directory: neko
+        run: {sync_command}
 
       - name: Market release check
         working-directory: neko

--- a/plugin/tests/unit/test_neko_plugin_cli_cli.py
+++ b/plugin/tests/unit/test_neko_plugin_cli_cli.py
@@ -709,6 +709,23 @@ def test_init_repo_documents_and_exposes_dependency_sync(tmp_path: Path) -> None
     assert sync_command in tasks
 
 
+def test_sync_without_pyproject_is_successful_noop(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    plugin_dir = _make_plugin_dir(tmp_path, "no_pyproject")
+    vendor_file = plugin_dir / "vendor" / "legacy_dependency.py"
+    vendor_file.parent.mkdir()
+    vendor_file.write_text("value = 1\n", encoding="utf-8")
+
+    exit_code = neko_plugin_cli.main(["sync", str(plugin_dir), "--clean"])
+
+    assert exit_code == 0
+    assert vendor_file.is_file()
+    captured = capsys.readouterr()
+    assert "[OK] no_pyproject: no external dependencies to sync" in captured.out
+
+
 def test_market_release_check_enforces_repo_and_tag_conventions(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/plugin/tests/unit/test_neko_plugin_cli_cli.py
+++ b/plugin/tests/unit/test_neko_plugin_cli_cli.py
@@ -644,6 +644,71 @@ def test_init_repo_uses_market_repository_name_and_keeps_plugin_id(
     assert "[OK] market_demo: check found" in captured.out
 
 
+def test_init_repo_generates_online_vendor_build_workflow(tmp_path: Path) -> None:
+    exit_code = neko_plugin_cli.main(
+        [
+            "init-repo",
+            "dependency_demo",
+            "--plugins-root",
+            str(tmp_path),
+            "--no-git",
+            "--neko-repo",
+            "Project-N-E-K-O/N.E.K.O",
+        ]
+    )
+
+    assert exit_code == 0
+    repo_dir = tmp_path / "n.e.k.o_plugin_dependency_demo"
+    gitignore = (repo_dir / ".gitignore").read_text(encoding="utf-8")
+    verify_workflow = (
+        repo_dir / ".github" / "workflows" / "verify.yml"
+    ).read_text(encoding="utf-8")
+    release_workflow = (
+        repo_dir / ".github" / "workflows" / "release.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "vendor/" in gitignore.splitlines()
+    sync_command = (
+        'uv run --with pip python -m plugin.neko_plugin_cli.cli sync '
+        '"${PLUGIN_ID}" --clean'
+    )
+    assert sync_command in verify_workflow
+    assert sync_command in release_workflow
+    assert verify_workflow.index(sync_command) < verify_workflow.index(
+        "check -r"
+    )
+    assert release_workflow.index(sync_command) < release_workflow.index(
+        "check -r --market-release"
+    )
+
+
+def test_init_repo_documents_and_exposes_dependency_sync(tmp_path: Path) -> None:
+    exit_code = neko_plugin_cli.main(
+        [
+            "init-repo",
+            "dependency_demo",
+            "--plugins-root",
+            str(tmp_path),
+            "--no-git",
+        ]
+    )
+
+    assert exit_code == 0
+    repo_dir = tmp_path / "n.e.k.o_plugin_dependency_demo"
+    readme = (repo_dir / "README.md").read_text(encoding="utf-8")
+    tasks = (repo_dir / ".vscode" / "tasks.json").read_text(encoding="utf-8")
+
+    sync_command = (
+        "uv run --with pip python -m plugin.neko_plugin_cli.cli "
+        "sync dependency_demo --clean"
+    )
+    assert sync_command in readme
+    assert "`vendor/`" in readme
+    assert "not committed" in readme
+    assert "N.E.K.O: sync dependency_demo" in tasks
+    assert sync_command in tasks
+
+
 def test_market_release_check_enforces_repo_and_tag_conventions(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/plugin/tests/unit/test_neko_plugin_cli_public.py
+++ b/plugin/tests/unit/test_neko_plugin_cli_public.py
@@ -575,6 +575,12 @@ def test_build_bundle_writes_multi_plugin_archive_and_installs(tmp_path: Path) -
         on_conflict="rename",
     )
     assert install_result.package_type == "bundle"
+    assert install_result.package_id == "demo_bundle"
+    assert install_result.package_type == inspect_result.package_type
+    assert install_result.package_id == inspect_result.package_id
+    assert install_result.metadata_found == inspect_result.metadata_found
+    assert install_result.payload_hash == inspect_result.payload_hash
+    assert install_result.payload_hash_verified == inspect_result.payload_hash_verified
     assert install_result.installed_plugin_count == 2
     assert (tmp_path / "plugins" / "bundle_one" / "plugin.toml").is_file()
     assert (tmp_path / "plugins" / "bundle_two" / "plugin.toml").is_file()


### PR DESCRIPTION
这个pr改进了目前的plugin cli命令行。

统一插件包检查与安装的验证逻辑，install_package() 复用 PackageInspector，减少重复代码。
标准插件模板不再提交 vendor/。
GitHub CI 在检查和发布前自动执行依赖同步，在线构建 vendor/。
README 和 VS Code Tasks 增加依赖同步说明与快捷任务。
补充相关单元测试，确保检查与安装结果一致。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 初始化插件仓库时新增依赖同步命令，并在 README、VS Code 任务与验证/发布工作流中进行展示；同时新增忽略 `vendor/` 的规则。
- **改进**
  - 安装插件前先对压缩包执行集中检查，安装流程基于检查结果继续，并提升包信息与校验字段的一致性。
  - 校验失败时提供更详细的期望值/计算值提示，便于定位包内容变更或构建异常。
- **测试**
  - 补充依赖同步相关单元测试，并在安装 bundle 后校验检查结果与安装结果逐项一致。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->