### PR TITLE
fix(ci): restore nightly desktop builds

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -641,6 +641,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # Playwright uses .links only for browser-cache install/GC bookkeeping.
+          # codesign --deep otherwise mistakes it for a nested bundle.
+          rm -rf -- "$NEKO_NUITKA_RUNTIME_DIR/playwright_browsers/.links"
           codesign --force --deep --sign - dist/Xiao8/projectneko_server.app
           codesign --verify --deep --strict dist/Xiao8/projectneko_server.app
 

--- a/main_logic/asr_client/workers/openai.py
+++ b/main_logic/asr_client/workers/openai.py
@@ -392,10 +392,13 @@ async def openai_asr_worker(
         )
     finally:
         shutdown_requested.set()
+        tasks = []
         for task in (sender_task, receiver_task):
-            if task is not None and not task.done():
+            if task is None:
+                continue
+            if not task.done():
                 task.cancel()
-        tasks = [task for task in (sender_task, receiver_task) if task is not None]
+            tasks.append(task)
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
         if websocket is not None:

--- a/tests/unit/test_nuitka_macos_bundle_contract.py
+++ b/tests/unit/test_nuitka_macos_bundle_contract.py
@@ -27,6 +27,13 @@ def test_macos_pyobjc_build_uses_background_app_with_electron_wrapper():
         "codesign --verify --deep --strict "
         "dist/Xiao8/projectneko_server.app"
     ) in workflow
+    playwright_links_cleanup = (
+        'rm -rf -- "$NEKO_NUITKA_RUNTIME_DIR/playwright_browsers/.links"'
+    )
+    assert playwright_links_cleanup in workflow
+    assert workflow.index(playwright_links_cleanup) < workflow.index(
+        "codesign --force --deep --sign - dist/Xiao8/projectneko_server.app"
+    )
     assert 'NEKO_NUITKA_RUNTIME_DIR=$RUNTIME_DIR' in workflow
 
 


### PR DESCRIPTION
## 改动概述 / Summary

- macOS 后端重新签名前移除 Playwright 浏览器缓存的 `.links` 元数据，避免 `codesign --deep` 把它误判为无效嵌套 bundle。
- 将 OpenAI ASR worker 清理阶段的任务列表推导式改为等价显式循环，绕开 Nuitka 4.1.3 的 `listcomp_1__.0_clone` 编译器断言。
- 扩展现有 macOS Nuitka bundle contract，固定清理动作必须发生在签名前。

本 PR 只恢复现有 `build-desktop.yml` nightly 流程，不包含 #2439 的 workflow 复用、Windows-only、Portable 或增量更新改造。

## 根因 / Root Cause

- 2026-07-15 起，macOS matrix 在 `Re-sign macOS backend after post-processing` 报 `bundle format unrecognized`，失败子组件为 `playwright_browsers/.links`。
- 2026-07-19 起，四个平台均在 Nuitka 4.1.3 编译 `main_logic/asr_client/workers/openai.py` 时触发 `AssertionError: listcomp_1__.0_clone`，导致 Electron 和 nightly 发布 jobs 被跳过。

## 回归报告 / Regression Report

- ASR 清理仍会取消所有已创建且未完成的 sender/receiver task，并统一等待实际创建的任务结束；仅改变任务列表的构造方式。
- `.links` 只用于 Playwright 浏览器缓存的安装/GC bookkeeping，不是运行时浏览器 payload；删除后再签名不会移除 Chromium 可执行文件。
- 主要回归面是 OpenAI ASR 关闭/取消路径与 macOS 后端 bundle 签名顺序，均由针对性测试或 contract 覆盖。

## 不拆分理由 / Why Not Split

这两个最小改动分别修复当前 nightly 的连续两个确定性阻塞点；缺少任一项都不能恢复完整跨平台 nightly 发布。PR 仅涉及 3 个文件，不包含无关重构。

## 测试 / Testing

- `uv run pytest tests/unit/test_asr_workers.py tests/unit/test_nuitka_macos_bundle_contract.py -q`：33 passed。
- `uv run ruff check main_logic/asr_client/workers/openai.py tests/unit/test_nuitka_macos_bundle_contract.py`：通过。
- `git diff --check`：通过。
- 使用 nightly 相同的 Nuitka 4.1.3 对 `main_logic/asr_client/workers/openai.py` 运行 `--module --generate-c-only`：Python 编译与优化、C 源码生成阶段通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 修复 macOS 应用签名过程中对 Playwright 浏览器资源的误判，提升桌面应用构建与签名的可靠性。
  - 优化语音识别任务取消与清理流程，减少任务结束时的资源残留和异常。

- **Tests**
  - 增加 macOS 构建流程校验，确保签名前正确清理相关资源。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->