### PR TITLE
docs: require UI evidence in PR descriptions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,8 @@ Two project rules are enforced by CI (`scripts/check_pr_report.py`). Both report
 1. **Regression report** — if your PR changes any `*.py` under `app/`, `main_logic/`, `main_routers/`, or `memory/` (our highest-risk modules), the description must contain a non-empty **"回归报告 / Regression Report"** section covering: what changed, the rationale / necessity, before-and-after behaviour, and the potential regressions.
 2. **Why-not-split rationale** — if your PR changes more than 20 counted files, the description must contain a non-empty **"不拆分理由 / Why Not Split"** section explaining why it isn't broken into smaller PRs. New files, i18n locale files, and test files (anywhere, under the main tree or `plugin/`) don't count toward the limit.
 
+For UI-related changes, the PR description must also include before-and-after screenshots or a screen recording that demonstrates the change.
+
 Notes:
 - CI only checks that the section exists and is non-empty — a maintainer reviews the report's substance (these paths are routed via [CODEOWNERS](.github/CODEOWNERS)). Don't fill it with placeholders (`不适用` / `N/A` / `TBD` fail the check when the rule is triggered).
 - If a rule doesn't apply, write "不适用 / N/A" or delete that section.
@@ -145,6 +147,8 @@ uv run python -m app.main_server
 
 1. **回归报告** —— 凡是改动了 `app/`、`main_logic/`、`main_routers/`、`memory/` 下任一 `*.py`（项目最高风险模块），PR 描述必须有非空的 **「回归报告 / Regression Report」** 一节，逐项说明：改动了什么、理由 / 必要性、前后表现对比、潜在回归点。
 2. **不拆分理由** —— 单个 PR 改动计入上限的文件超过 20 个，PR 描述必须有非空的 **「不拆分理由 / Why Not Split」** 一节，说明为什么不拆成更小的 PR。新增文件、i18n locale 文件和测试文件（无论在主目录还是 `plugin/` 下）不计入这个上限。
+
+如果改动涉及 UI，PR 描述还必须附上改动前后的截图，或能够展示改动效果的录屏。
 
 说明：
 - CI 只验区块存在且非空，报告质量由维护者评审兜底（这些路径经 [CODEOWNERS](.github/CODEOWNERS) 强制指派维护者）。别拿占位符糊弄（触发条件成立时 `不适用` / `N/A` / `TBD` 会被判失败）。


### PR DESCRIPTION
## 改动概述 / Summary

- Require UI-related pull requests to include before-and-after screenshots or a screen recording in the PR description.
- Keep the English and Chinese contribution guidance aligned.
- Leave the pull request template unchanged.

## 回归报告 / Regression Report

不适用 / N/A — documentation-only change.

## 不拆分理由 / Why Not Split

不适用 / N/A — this PR changes one file.

## 测试 / Testing

- `git diff --check origin/main...HEAD`
- `uv run python scripts/check_pr_report.py --base origin/main`