### PR TITLE
fix(geoip): 修复语音会话必崩的 UnboundLocalError（realtime 分支区域翻转诊断）

### DIFF
--- a/main_logic/core/lifecycle.py
+++ b/main_logic/core/lifecycle.py
@@ -715,7 +715,8 @@ class LifecycleMixin:
             tts_result, llm_result = await asyncio.gather(
                 self._start_session_start_tts_if_needed(),
                 self._start_session_start_llm(
-                    input_mode, core_config_snapshot, _new_dialog_task, _mem_start
+                    input_mode, core_config_snapshot, realtime_config,
+                    _new_dialog_task, _mem_start
                 ),
                 return_exceptions=True
             )
@@ -1179,6 +1180,7 @@ class LifecycleMixin:
         return resp.text
 
     async def _start_session_start_llm(self, input_mode, core_config_snapshot,
+                                       prepared_realtime_config,
                                        new_dialog_task, mem_start):
         """Asynchronously create and connect the LLM Session.
 
@@ -1318,7 +1320,7 @@ class LifecycleMixin:
             new_session.on_thinking_active = self._make_thinking_active_callback(new_session)
         else:
             # 同上：await 记忆拉取之后必须重读，不复用 prepare_runtime 的快照
-            _prev_realtime_base = str(realtime_config.get('base_url') or '')
+            _prev_realtime_base = str((prepared_realtime_config or {}).get('base_url') or '')
             realtime_config = await self._config_manager.aget_model_api_config('realtime')
             # 区域翻转诊断，与 text 分支对偶；realtime 的音色下发按本快照的
             # base_url 走配对闸门，错配不下发、落服务端默认（fail-safe）。

--- a/tests/unit/test_session_llm_start_paths.py
+++ b/tests/unit/test_session_llm_start_paths.py
@@ -1,0 +1,207 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Executable coverage for the session-creation body.
+
+``_start_session_start_llm`` is the function that builds and connects the
+per-session client, and both of its branches (text -> OmniOfflineClient,
+voice -> OmniRealtimeClient) had no test that ever *ran* them: every existing
+guard around this file asserts on its source text (AST / string matching), and
+the ``start_session`` tests all return at the re-entrancy guard.  A branch that
+cannot execute at all therefore stayed green through review and CI.
+
+That is not hypothetical: a diagnostic added to the voice branch read
+``realtime_config`` before its first assignment in the same scope, so every
+voice session died with ``UnboundLocalError`` while the text branch — the one
+the structural guards cover — kept working.  These tests drive both branches
+end to end against stub collaborators, so any unbound name, missing argument,
+or renamed collaborator in either branch fails here.
+"""
+
+import asyncio
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import main_logic.core as core_facade  # noqa: E402
+import main_logic.core.lifecycle as lifecycle  # noqa: E402
+from main_logic.core import LLMSessionManager  # noqa: E402
+
+
+class _StubClient:
+    """Stands in for OmniOfflineClient / OmniRealtimeClient."""
+
+    instances = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.connected_with = None
+        self.closed = False
+        self._audio_processor = None
+        type(self).instances.append(self)
+
+    async def connect(self, initial_prompt, native_audio=True):
+        self.connected_with = (initial_prompt, native_audio)
+
+    async def close(self):
+        self.closed = True
+
+    async def set_audio_noise_reduction_enabled(self, enabled):
+        self.noise_reduction = enabled
+
+    async def handle_messages(self):
+        return None
+
+
+class _StubConfigManager:
+    def __init__(self, core_config, model_configs):
+        self._core_config = core_config
+        self._model_configs = model_configs
+        self.resolved_calls = 0
+
+    async def aensure_region_resolved(self, *a, **k):
+        self.resolved_calls += 1
+        return True
+
+    async def aget_core_config(self, *a, **k):
+        return dict(self._core_config)
+
+    async def aget_model_api_config(self, kind, core_config=None):
+        return dict(self._model_configs[kind])
+
+
+def _make_manager(monkeypatch, *, input_mode):
+    """A manager positioned exactly at ``_start_session_start_llm``.
+
+    Only the collaborators that function touches are real-ish; everything else
+    is a stub, so a failure here means the function itself is broken rather
+    than some unrelated dependency.
+    """
+    mgr = LLMSessionManager.__new__(LLMSessionManager)
+    mgr.lanlan_name = "兰兰"
+    mgr.master_name = "用户"
+    mgr.user_language = "zh"
+    mgr.memory_server_port = 48911
+    mgr.use_tts = True
+    mgr.core_api_type = "qwen"
+    mgr.voice_id = "yui"
+    mgr.session = None
+    mgr.current_speech_id = ""
+    mgr.lock = asyncio.Lock()
+    mgr.tool_registry = types.SimpleNamespace(all=lambda: [])
+
+    mgr._config_manager = _StubConfigManager(
+        core_config={"CORE_URL": "https://www.lanlan.app", "DISABLE_TTS": False},
+        model_configs={
+            "realtime": {"base_url": "wss://www.lanlan.app/v1", "api_key": "k",
+                         "model": "m", "api_type": "qwen"},
+            "conversation": {"base_url": "https://www.lanlan.app/text/v1",
+                             "api_key": "k", "model": "m"},
+            "vision": {"base_url": "https://www.lanlan.app/text/v1",
+                       "api_key": "k", "model": "vm"},
+        },
+    )
+
+    mgr._get_text_guard_max_length = lambda: 4096
+    mgr._build_initial_prompt = _async_return("PROMPT ")
+    mgr._snapshot_next_session_context_messages = lambda: []
+    mgr._mark_pending_context_appends_delivered_in_start_prompt = lambda *a, **k: None
+    mgr._clear_pending_context_start_prompt_marks = lambda *a, **k: None
+    mgr._convert_cache_to_str = lambda cache: ""
+    mgr._register_builtin_tools = lambda: None
+    mgr._resolve_realtime_voice = lambda cfg: "yui"
+    mgr._drop_free_voice_on_route_flip = lambda old, new: False
+    mgr._is_livestream_active = lambda: False
+    mgr._make_thinking_active_callback = lambda session: (lambda *a, **k: None)
+    mgr._bind_session_lifecycle_callbacks = lambda session: None
+    mgr._sync_tools_to_active_session = _async_return(None)
+    mgr.input_mode = input_mode
+
+    _StubClient.instances = []
+    monkeypatch.setattr(lifecycle, "OmniRealtimeClient", _StubClient)
+    monkeypatch.setattr(lifecycle, "OmniOfflineClient", _StubClient)
+    monkeypatch.setattr(
+        core_facade, "aload_global_conversation_settings",
+        _async_return({"noiseReductionEnabled": True}),
+    )
+    return mgr
+
+
+def _async_return(value):
+    async def _inner(*a, **k):
+        return value
+    return _inner
+
+
+async def _new_dialog_task(text="MEMORY"):
+    return text
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("input_mode", ["audio", "text"])
+async def test_session_creation_runs_end_to_end(monkeypatch, input_mode):
+    """Both branches build a client and connect it.
+
+    Mutation check: reverting the voice branch's diagnostic to read
+    ``realtime_config`` before it is assigned turns the ``audio`` case red with
+    ``UnboundLocalError`` while ``text`` stays green — which is exactly the
+    asymmetry that shipped.
+    """
+    mgr = _make_manager(monkeypatch, input_mode=input_mode)
+
+    count = await LLMSessionManager._start_session_start_llm(
+        mgr,
+        input_mode,
+        await mgr._config_manager.aget_core_config(),
+        await mgr._config_manager.aget_model_api_config("realtime"),
+        asyncio.create_task(_new_dialog_task()),
+        0.0,
+    )
+
+    assert count == 0
+    assert len(_StubClient.instances) == 1, "应当恰好构造一个 client"
+    client = _StubClient.instances[0]
+    assert client.connected_with is not None, "构造了 client 却没有 connect"
+    assert mgr.session is client, "connect 成功后必须提升为 self.session"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("input_mode", ["audio", "text"])
+async def test_region_flip_between_prepare_and_connect_is_logged(monkeypatch, caplog, input_mode):
+    """The route-flip diagnostic fires when the region lands mid-start.
+
+    The whole point of the diagnostic is to make a mid-start flip visible in the
+    field, so it has to survive a real call — reading the snapshot handed down
+    by ``_start_session_prepare_runtime`` rather than a name that only exists in
+    the caller.
+    """
+    mgr = _make_manager(monkeypatch, input_mode=input_mode)
+    prepare_core = {"CORE_URL": "https://www.lanlan.tech", "DISABLE_TTS": False}
+    prepare_realtime = {"base_url": "wss://www.lanlan.tech/v1", "api_key": "k",
+                        "model": "m", "api_type": "qwen"}
+
+    with caplog.at_level("WARNING", logger=lifecycle.logger.name):
+        await LLMSessionManager._start_session_start_llm(
+            mgr, input_mode, prepare_core, prepare_realtime,
+            asyncio.create_task(_new_dialog_task()), 0.0,
+        )
+
+    assert any("[GeoIP]" in r.message for r in caplog.records), (
+        f"{input_mode} 分支的区域翻转诊断没有触发"
+    )

--- a/tests/unit/test_session_llm_start_paths.py
+++ b/tests/unit/test_session_llm_start_paths.py
@@ -183,25 +183,34 @@ async def test_session_creation_runs_end_to_end(monkeypatch, input_mode):
 @pytest.mark.unit
 @pytest.mark.asyncio
 @pytest.mark.parametrize("input_mode", ["audio", "text"])
-async def test_region_flip_between_prepare_and_connect_is_logged(monkeypatch, caplog, input_mode):
+async def test_region_flip_between_prepare_and_connect_is_logged(monkeypatch, input_mode):
     """The route-flip diagnostic fires when the region lands mid-start.
 
     The whole point of the diagnostic is to make a mid-start flip visible in the
     field, so it has to survive a real call — reading the snapshot handed down
     by ``_start_session_prepare_runtime`` rather than a name that only exists in
     the caller.
+
+    Records straight off the module logger rather than via ``caplog``: the app's
+    logging setup puts ``propagate=False`` on the ``N.E.K.O`` parent, so caplog's
+    root handler sees nothing once any test has pulled that setup in.
     """
     mgr = _make_manager(monkeypatch, input_mode=input_mode)
     prepare_core = {"CORE_URL": "https://www.lanlan.tech", "DISABLE_TTS": False}
     prepare_realtime = {"base_url": "wss://www.lanlan.tech/v1", "api_key": "k",
                         "model": "m", "api_type": "qwen"}
 
-    with caplog.at_level("WARNING", logger=lifecycle.logger.name):
-        await LLMSessionManager._start_session_start_llm(
-            mgr, input_mode, prepare_core, prepare_realtime,
-            asyncio.create_task(_new_dialog_task()), 0.0,
-        )
+    warnings = []
+    monkeypatch.setattr(
+        lifecycle.logger, "warning",
+        lambda msg, *a, **k: warnings.append(str(msg) % a if a else str(msg)),
+    )
 
-    assert any("[GeoIP]" in r.message for r in caplog.records), (
-        f"{input_mode} 分支的区域翻转诊断没有触发"
+    await LLMSessionManager._start_session_start_llm(
+        mgr, input_mode, prepare_core, prepare_realtime,
+        asyncio.create_task(_new_dialog_task()), 0.0,
+    )
+
+    assert any("[GeoIP]" in w for w in warnings), (
+        f"{input_mode} 分支的区域翻转诊断没有触发，实际: {warnings}"
     )


### PR DESCRIPTION
## Summary

- `_start_session_start_llm` 的 realtime 分支读了一个只存在于调用方作用域的 `realtime_config`，且同一作用域下一行才给它赋值 —— 非 text 的每一次 `start_session` 都抛 `UnboundLocalError`，语音模式自 #2454 合入起完全不可用
- 把 `_start_session_prepare_runtime` 落定的 realtime 快照透传进来，诊断改读该参数（与 text 分支读 `core_config_snapshot` 参数同构）
- 新增 `tests/unit/test_session_llm_start_paths.py`：第一份真正**执行**会话构造体的用例

## Why

线上日志（用户实机）：

```
UnboundLocalError: cannot access local variable 'realtime_config' where it is not associated with a value
  File "main_logic/core/lifecycle.py", line 1317, in _start_session_start_llm
    _prev_realtime_base = str(realtime_config.get('base_url') or '')
```

#2454 的 commit `1cef832cd` 给「二次落定的区域翻转」补诊断日志，text/realtime 两分支按对偶写。text 分支比较的 `core_config_snapshot` 是函数参数、`_fresh_core_config` 是本地新读，都成立；realtime 分支照形状写成 `realtime_config`，但这个名字只在调用方 `start_session` 里，本函数签名只收到 `core_config_snapshot`。

## 回归报告

- 变更与必要性：realtime 分支的区域翻转诊断读未绑定局部变量，语音会话 100% 启动失败（`start_session` 把 LLM 侧异常视为致命并 raise）。必须修，且这是主线路 P0。
- 修改前：`input_mode != 'text'` 的 `start_session` 必抛 `UnboundLocalError`，前端拿到 SESSION_START_FAILED；text 模式不受影响（走另一分支）。
- 修改后：`_start_session_start_llm` 增加 `prepared_realtime_config` 参数（由 `_start_session_prepare_runtime` 的返回值透传），诊断比较 prepare 快照与连接前 fresh 快照的 `base_url`，语义与 #2454 的原意一致，仅修正取值来源。
- 潜在回归：新增位置参数，仓库内唯一调用点已同步；`prepared_realtime_config` 用 `or {}` 兜 None，text 分支完全不读它。诊断只发 `logger.warning`，不改任何下发行为，音色配对闸门与 `_drop_free_voice_on_route_flip` 语义不动。
- 兼容性：无配置、协议或前端契约变化。

## 为什么评审和测试都漏了（同步补的护栏）

- `lifecycle.py` 现有的护栏**全是读源码文本的 AST/字符串断言**（`test_geoip_region_gate.py` 里扫构造点清单、断言调用行序），它们对「这段代码根本无法执行」完全不敏感；`test_session_start_guard.py` 的用例又都停在重入闸门，从不进入构造体。整个会话构造路径此前**零可执行覆盖**。
- ruff 只启用了 ASYNC* 规则；且实测 pyflakes / ruff 的 F821·F823 都**检测不出**这种分支内的 use-before-assign（最小复现验证过），所以不是「打开某条 lint 就能防住」。
- 本 PR 补的用例 audio/text 双参数化跑到 `connect` + `self.session` 提升，并覆盖翻转诊断。**变异验证**：把那行改回 `realtime_config`，audio 两例转红（`UnboundLocalError`）、text 两例保持绿——精确复现线上这条不对称。

## Validation

- `uv run pytest tests/unit/test_session_llm_start_paths.py tests/unit/test_geoip_region_gate.py tests/unit/test_session_start_guard.py tests/unit/test_config_read_off_event_loop.py tests/unit/test_free_voice_route_pairing.py -q` — 152 passed
- 变异验证：还原 bug 后 `2 failed (audio), 2 passed (text)`
- `ruff check main_logic/core/lifecycle.py tests/unit/test_session_llm_start_paths.py` — passed
- `python scripts/check_docstring_no_cjk.py --base origin/main` — passed
- 非 UI 改动，无截图

🤖 Generated with [Claude Code](https://claude.com/claude-code)
