### PR TITLE
fix(tests): 分诊并修完 tests/unit 的 18 条存量失败，并把该目录挂进 CI

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,70 @@
+name: Unit Tests
+
+# Repo-wide pytest gate for tests/unit.
+#
+# Until now nothing in CI ran this directory: plugin-tests.yml covered
+# plugin/tests plus two hand-listed root files, and everything else in
+# tests/unit only ever ran when someone happened to run it locally. A PR could
+# therefore add thousands of lines of tests that never executed in CI, and an
+# existing test could go red for weeks without anyone noticing — both happened.
+# #2454 shipped a crash that made every voice session fail on start while the
+# suite guarding that file was green-by-omission, and the sweep that followed
+# found 18 pre-existing failures on main, two of them real product bugs.
+#
+# No paths filter on purpose. tests/unit reads Python packages, static/,
+# templates/ and frontend sources, so any useful filter would approximate
+# "everything"; an over-narrow one reintroduces exactly the failure mode above
+# — the one PR that needed the gate is the one that does not trigger it.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: unit-tests-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  unit-pytest:
+    name: Unit pytest (Windows)
+    # windows-latest for the same reason as plugin-tests.yml: parts of the
+    # suite exercise win32 paths, and Windows is the product's primary desktop
+    # platform. It is also where the command-line length limit that silently
+    # broke the cat-mind harness lives, so the guard against it stays honest.
+    runs-on: windows-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        # Plain `uv sync` = main deps + dev group. Deliberately no extras:
+        # the galgame group (rapidocr + cv2, ~130 MB) is not needed — the OCR
+        # teardown tests drive pure-Python paths and the rest self-skip. node
+        # comes preinstalled on the runner image; the frontend harness suites
+        # need it and fail loudly rather than silently skipping if it is gone.
+        run: uv sync
+
+      - name: Run unit test suite
+        # Separate pytest process from plugin/tests, which carries its own
+        # pytest.ini.
+        #
+        # Not built here: static/react/ is a gitignored vite output, so the one
+        # assertion that reads the built bundle skips. build-desktop.yml
+        # rebuilds and verifies that artifact on every run, which is the right
+        # place for it — a stale local bundle would only produce a false green.
+        run: uv run pytest tests/unit -q

--- a/main_routers/agent_router.py
+++ b/main_routers/agent_router.py
@@ -239,8 +239,16 @@ def _get_http_client() -> httpx.AsyncClient:
 async def _close_http_client():
     global _HTTP_CLIENT
     if _HTTP_CLIENT is not None:
-        await _HTTP_CLIENT.aclose()
-        _HTTP_CLIENT = None
+        # 关连接失败不许拖垮整个 shutdown：这个 handler 挂在合并 lifespan 链上，
+        # 抛出去会中断后面所有 router 的收尾。最典型的触发是 client 建在另一个
+        # 已经关掉的事件循环上（aclose 走 call_soon 撞上 closed loop）。无论成败
+        # 都把引用清掉，下次 startup 在当前循环上重建。
+        try:
+            await _HTTP_CLIENT.aclose()
+        except Exception as exc:
+            logger.warning(f"关闭 agent_router HTTP client 失败，继续收尾: {exc}")
+        finally:
+            _HTTP_CLIENT = None
 
 
 @router.post('/flags')

--- a/plugin/plugins/galgame_plugin/ocr_reader.py
+++ b/plugin/plugins/galgame_plugin/ocr_reader.py
@@ -377,12 +377,10 @@ class OcrReaderManager(
         return (repo_root / path).resolve()
 
     def close(self) -> None:
-        self._release_rapidocr_backend()
-        classifier = self.vision_classifier
-        self.vision_classifier = None
-        close_classifier = getattr(classifier, "close", None)
-        if callable(close_classifier):
-            close_classifier()
+        # 顺序与 ocr_manager_poll.shutdown() 对偶：先停前台监听线程与 capture
+        # 线程池，再释放它们可能仍在用的重依赖。两步重依赖释放原本裸奔在最前
+        # 面，任一抛错就把下面两段守卫整个跳过、线程与线程池全漏 —— 正是这
+        # 两段 try/except 当初要防的场景。
         try:
             self._stop_foreground_advance_monitor(join_timeout=1.0)
         except Exception as exc:
@@ -399,6 +397,20 @@ class OcrReaderManager(
             if callable(warning):
                 try:
                     warning("ocr_reader capture worker shutdown failed: {}", exc)
+                except Exception:
+                    pass
+        try:
+            self._release_rapidocr_backend()
+            classifier = self.vision_classifier
+            self.vision_classifier = None
+            close_classifier = getattr(classifier, "close", None)
+            if callable(close_classifier):
+                close_classifier()
+        except Exception as exc:
+            warning = getattr(getattr(self, "_logger", None), "warning", None)
+            if callable(warning):
+                try:
+                    warning("ocr_reader heavy backend release failed: {}", exc)
                 except Exception:
                     pass
 

--- a/plugin/plugins/galgame_plugin/ocr_reader.py
+++ b/plugin/plugins/galgame_plugin/ocr_reader.py
@@ -376,43 +376,54 @@ class OcrReaderManager(
         repo_root = Path(__file__).resolve().parents[3]
         return (repo_root / path).resolve()
 
+    def _warn_teardown_failed(self, what: str, exc: BaseException) -> None:
+        """Best-effort warning for one failed teardown step.
+
+        The logger itself is treated as unreliable here: close() runs while the
+        plugin is being torn down, so a logger that is already gone or raising
+        must not turn one failed step into a lost one.
+        """
+        warning = getattr(getattr(self, "_logger", None), "warning", None)
+        if callable(warning):
+            try:
+                warning(f"ocr_reader {what} failed: {{}}", exc)
+            except Exception:
+                # 记日志本身失败没有下一手可用——再往上抛就会把这次收尾变成
+                # 「一个步骤没关成，剩下的也别关了」，正是本函数要避免的。
+                pass
+
     def close(self) -> None:
         # 顺序与 ocr_manager_poll.shutdown() 对偶：先停前台监听线程与 capture
         # 线程池，再释放它们可能仍在用的重依赖。两步重依赖释放原本裸奔在最前
-        # 面，任一抛错就把下面两段守卫整个跳过、线程与线程池全漏 —— 正是这
-        # 两段 try/except 当初要防的场景。
+        # 面，任一抛错就把下面几段守卫整个跳过、线程与线程池全漏 —— 正是这
+        # 些 try/except 当初要防的场景。
+        #
+        # 四步各自独立守卫，不合并：合并后任一步抛错都会把它后面的步骤连带
+        # 跳过，而异常又已经被吞掉，调用方看到的是「关成功了」，实际还留着
+        # 活着的资源（Codex P2）。
         try:
             self._stop_foreground_advance_monitor(join_timeout=1.0)
         except Exception as exc:
-            warning = getattr(getattr(self, "_logger", None), "warning", None)
-            if callable(warning):
-                try:
-                    warning("ocr_reader foreground advance monitor shutdown failed: {}", exc)
-                except Exception:
-                    pass
+            self._warn_teardown_failed("foreground advance monitor shutdown", exc)
         try:
             self._shutdown_capture_worker()
         except Exception as exc:
-            warning = getattr(getattr(self, "_logger", None), "warning", None)
-            if callable(warning):
-                try:
-                    warning("ocr_reader capture worker shutdown failed: {}", exc)
-                except Exception:
-                    pass
+            self._warn_teardown_failed("capture worker shutdown", exc)
         try:
             self._release_rapidocr_backend()
-            classifier = self.vision_classifier
-            self.vision_classifier = None
-            close_classifier = getattr(classifier, "close", None)
-            if callable(close_classifier):
-                close_classifier()
         except Exception as exc:
-            warning = getattr(getattr(self, "_logger", None), "warning", None)
-            if callable(warning):
-                try:
-                    warning("ocr_reader heavy backend release failed: {}", exc)
-                except Exception:
-                    pass
+            self._warn_teardown_failed("rapidocr backend release", exc)
+        # 引用先摘掉再 close：close 失败也不能把一个已经宣告释放的 classifier
+        # 继续挂在 self 上。getattr 兜底与本文件对 _logger 的取法一致——收尾
+        # 路径不该假设自己被构造完整。
+        classifier = getattr(self, "vision_classifier", None)
+        self.vision_classifier = None
+        close_classifier = getattr(classifier, "close", None)
+        if callable(close_classifier):
+            try:
+                close_classifier()
+            except Exception as exc:
+                self._warn_teardown_failed("vision classifier close", exc)
 
     def __enter__(self) -> "OcrReaderManager":
         return self

--- a/tests/node_harness.py
+++ b/tests/node_harness.py
@@ -1,0 +1,48 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared launcher for the generated node simulation harnesses.
+
+Several static-contract suites drive real frontend modules through a node
+script built at test time.  Those scripts grow with the behaviour they
+simulate, and passing one via ``node -e`` puts the whole thing on the command
+line: past 32767 characters Windows' ``CreateProcess`` refuses it and
+``subprocess`` raises ``WinError 206`` before node ever starts, so not one
+assertion runs and the failure reads as unrelated to the code under test.
+One suite crossed that line at 34067 characters and stayed red unnoticed
+because ``tests/unit`` does not run in CI.
+
+Writing the script to a temp file removes the ceiling.  Node lookup and the
+node-missing policy (skip vs. hard failure) stay with each caller, since the
+suites deliberately differ there.
+"""
+
+import os
+import subprocess
+import tempfile
+
+
+def run_node_script(node_path: str, script: str, **kwargs) -> subprocess.CompletedProcess[str]:
+    """Run ``script`` from a temp file under ``node_path``.
+
+    Extra keyword arguments go straight to ``subprocess.run``.
+    """
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".js", delete=False, encoding="utf-8"
+    ) as handle:
+        handle.write(script)
+        script_path = handle.name
+    try:
+        return subprocess.run([node_path, script_path], **kwargs)
+    finally:
+        os.unlink(script_path)

--- a/tests/unit/test_ai_aware_stage1_path_b.py
+++ b/tests/unit/test_ai_aware_stage1_path_b.py
@@ -35,6 +35,24 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
+def _make_fact_store(*, facts=None, time_indexed=None):
+    """Build a FactStore whose every ``__init__``-owned attribute exists.
+
+    The tests below drive ``_apersist_new_facts`` directly, so they need a
+    store that is fully formed but talks to no config manager.  They used to
+    do that with ``FactStore.__new__`` plus a hand-written list of attributes,
+    which silently stranded six of them for ten weeks when #2282 added one
+    field (``_persist_alocks``) to ``__init__``.  Running the real ``__init__``
+    with only the singleton patched out keeps that from happening again.
+    """
+    from memory.facts import FactStore
+
+    with patch('memory.facts.get_config_manager', return_value=MagicMock()):
+        fs = FactStore(time_indexed_memory=time_indexed)
+    fs._facts = {'悠怡': []} if facts is None else facts
+    return fs
+
+
 @pytest.mark.unit
 def test_extract_role_tagged_messages_keeps_user_and_ai():
     """跟 _extract_user_messages_from_rows 形成对偶：path B 必须收 ai msg。"""
@@ -278,15 +296,7 @@ async def test_path_b_no_user_msg_in_window_skips_extraction():
 async def test_apersist_writes_source_field_default_user_observation():
     """path A 调用方不传 default_source → 落盘 source='user_observation'，
     signal_processed=False（正常进 Stage-2）。"""
-    from memory.facts import FactStore
-
-    fs = FactStore.__new__(FactStore)
-    fs._config_manager = MagicMock()
-    fs._time_indexed = None
-    fs._facts = {'悠怡': []}
-    fs._locks = {}
-    import threading
-    fs._locks_guard = threading.Lock()
+    fs = _make_fact_store()
     fs.aload_facts = AsyncMock(return_value=[])
     fs.asave_facts = AsyncMock(return_value=None)
 
@@ -308,15 +318,7 @@ async def test_apersist_writes_source_field_default_user_observation():
 async def test_apersist_writes_source_ai_disclosure_with_signal_processed_true():
     """path B 调用方传 default_source='ai_disclosure' → 落盘 source 字段
     一致，signal_processed=True（不进 Stage-2 evidence loop）。"""
-    from memory.facts import FactStore
-
-    fs = FactStore.__new__(FactStore)
-    fs._config_manager = MagicMock()
-    fs._time_indexed = None
-    fs._facts = {'悠怡': []}
-    fs._locks = {}
-    import threading
-    fs._locks_guard = threading.Lock()
+    fs = _make_fact_store()
     fs.asave_facts = AsyncMock(return_value=None)
 
     extracted = [
@@ -339,15 +341,7 @@ async def test_apersist_writes_source_ai_disclosure_with_signal_processed_true()
 async def test_apersist_llm_source_field_overrides_default():
     """LLM 显式输出的 source 字段优先于 default_source（trust LLM 的
     per-fact 判断）。"""
-    from memory.facts import FactStore
-
-    fs = FactStore.__new__(FactStore)
-    fs._config_manager = MagicMock()
-    fs._time_indexed = None
-    fs._facts = {'悠怡': []}
-    fs._locks = {}
-    import threading
-    fs._locks_guard = threading.Lock()
+    fs = _make_fact_store()
     fs.asave_facts = AsyncMock(return_value=None)
 
     # LLM 输出 source='user_observation'，但 caller 传 default='ai_disclosure'
@@ -369,18 +363,22 @@ async def test_apersist_llm_source_field_overrides_default():
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_apersist_monotonic_source_upgrade_ai_to_user():
-    """SHA-256 撞已有 ai_disclosure fact + 新 fact source=user_observation
-    → in-place 升级 existing.source + 重置 signal_processed=False。"""
-    from memory.facts import FactStore
+    """An incoming user_observation whose SHA-256 hits a stored ai_disclosure
+    fact upgrades that fact's source in place and resets signal_processed.
+
+    Covers the in-memory reset only.  ``asave_facts`` is an AsyncMock here,
+    while the real one re-applies ``signal_processed=True`` from disk for any
+    id already marked there (the monotonic read-merge in facts.py) — which
+    lands on this very fact and erases the reset, so "re-enters Stage-2 after
+    the upgrade" does not actually hold once persisted.  That gap went
+    unnoticed for ten weeks precisely because the only test guarding it mocks
+    away the code that breaks it.  The fix is still open (exempt the upgrade
+    in read-merge / mark it at the upgrade site / retire the behaviour); once
+    it is settled this test should drive a real save round-trip instead.
+    """
     import hashlib
 
-    fs = FactStore.__new__(FactStore)
-    fs._config_manager = MagicMock()
-    fs._time_indexed = None
-    fs._facts = {'悠怡': []}
-    fs._locks = {}
-    import threading
-    fs._locks_guard = threading.Lock()
+    fs = _make_fact_store()
 
     text = '博士喜欢三文鱼'
     content_hash = hashlib.sha256(text.encode()).hexdigest()[:16]
@@ -420,15 +418,7 @@ async def test_apersist_monotonic_source_upgrade_within_same_batch():
     `content_hash in existing_hashes` 时 `hash_to_existing.get()` 返 None，
     monotonic upgrade 路径被跳过，user_observation 升级被静默丢弃。
     """
-    from memory.facts import FactStore
-
-    fs = FactStore.__new__(FactStore)
-    fs._config_manager = MagicMock()
-    fs._time_indexed = None
-    fs._facts = {'悠怡': []}
-    fs._locks = {}
-    import threading
-    fs._locks['悠怡'] = threading.RLock()
+    fs = _make_fact_store()
     fs.asave_facts = AsyncMock()
 
     # 模拟单次 Stage-1 payload 包含同 text 两条：先 ai_disclosure 后 user_observation
@@ -466,16 +456,9 @@ async def test_apersist_monotonic_source_upgrade_within_same_batch():
 async def test_apersist_no_downgrade_user_to_ai():
     """反向：撞已有 user_observation fact + 新 fact source=ai_disclosure
     → existing 不动（user 印证不可逆退回 ai_disclosure）。"""
-    from memory.facts import FactStore
     import hashlib
 
-    fs = FactStore.__new__(FactStore)
-    fs._config_manager = MagicMock()
-    fs._time_indexed = None
-    fs._facts = {'悠怡': []}
-    fs._locks = {}
-    import threading
-    fs._locks_guard = threading.Lock()
+    fs = _make_fact_store()
 
     text = '博士喜欢三文鱼'
     content_hash = hashlib.sha256(text.encode()).hexdigest()[:16]
@@ -509,15 +492,7 @@ async def test_apersist_no_downgrade_user_to_ai():
 async def test_stage2_filters_out_ai_disclosure_facts():
     """Stage-2 unprocessed pool 必须 filter ``source='ai_disclosure'``。
     双重防御（写盘 signal_processed=True 是第一层；这是第二层）。"""
-    from memory.facts import FactStore
-
-    fs = FactStore.__new__(FactStore)
-    fs._config_manager = MagicMock()
-    fs._time_indexed = None
-    fs._facts = {}
-    fs._locks = {}
-    import threading
-    fs._locks_guard = threading.Lock()
+    fs = _make_fact_store(facts={})
 
     # 模拟 facts.json 三条 fact：一条 user_observation 未处理（应入 Stage-2 池），
     # 一条 ai_disclosure 未处理（**不该**入池，即使 signal_processed=False bug），

--- a/tests/unit/test_app_auto_goodbye_phase1.py
+++ b/tests/unit/test_app_auto_goodbye_phase1.py
@@ -7,6 +7,8 @@ from tests.static_app_parts import read_js_parts
 
 from main_routers import pages_router
 
+from tests.node_harness import run_node_script
+
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 APP_AUTO_GOODBYE_PATH = PROJECT_ROOT / "static" / "app" / "app-auto-goodbye.js"
@@ -20,8 +22,9 @@ def _run_node_harness(script: str) -> subprocess.CompletedProcess[str]:
     if not node_path:
         raise AssertionError("node is required to run app-auto-goodbye harness tests")
 
-    return subprocess.run(
-        [node_path, "-e", script],
+    return run_node_script(
+        node_path,
+        script,
         cwd=PROJECT_ROOT,
         capture_output=True,
         text=True,

--- a/tests/unit/test_app_widget_mode.py
+++ b/tests/unit/test_app_widget_mode.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.node_harness import run_node_script
+
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 APP_WIDGET_MODE_PATH = PROJECT_ROOT / "static" / "app" / "app-widget-mode.js"
@@ -17,8 +19,9 @@ def _run_node_harness(script: str) -> subprocess.CompletedProcess[str]:
     node = shutil.which("node")
     if not node:
         pytest.skip("node is required for the Widget Mode browser contract test")
-    return subprocess.run(
-        [node, "-e", script],
+    return run_node_script(
+        node,
+        script,
         cwd=PROJECT_ROOT,
         capture_output=True,
         text=True,

--- a/tests/unit/test_avatar_floating_day1_round_contracts.py
+++ b/tests/unit/test_avatar_floating_day1_round_contracts.py
@@ -1325,6 +1325,15 @@ def test_day1_intro_externalized_chat_suppresses_home_pc_cursor_before_hiding_it
     )
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "#2434 一并删掉的 5 个 day1 pair 里，capture_cursor -> return_control 是 "
+        "PC->chat 反方向，没有被同 commit 新增的 releaseExternalizedChatCursorToHome() "
+        "接管，Ghost Cursor 的反向动画因此丢失。归属人在 issue #2490 决定按哪种形态修，"
+        "修好后这里会以 XPASS 转红，届时删掉本 marker。"
+    ),
+)
 def test_day1_return_control_preserves_externalized_cursor_from_capture_scene():
     source = read_director_source(ROOT)
     preserve_block = source.split("shouldPreserveExternalizedChatCursor(previousSceneId, scene)", 1)[1].split(

--- a/tests/unit/test_avatar_model_load_race_static_contracts.py
+++ b/tests/unit/test_avatar_model_load_race_static_contracts.py
@@ -44,8 +44,22 @@ def test_vrm_load_model_uses_entry_token_without_blocking_queue():
     assert "previousLoad" not in source
     assert "_loadModelExclusive" not in source
 
-    # loadModel 包装体必须极薄：bump token → 直接委派，中间不 await 任何前序加载
-    wrapper = source.split("async loadModel(modelUrl, options = {})", 1)[1]
+    # loadModel 包装体必须极薄：bump token → 直接委派，中间不 await 任何前序加载。
+    # #2253 之后 loadModel 与 token 分配之间多了一层只记在飞计数的薄包装
+    # (_loadModelImplementation)，所以两段分开断言——包装层唯一允许的 await 就是
+    # 那一次委派，token 分配层仍然一个 await 都不许有。
+    outer = source.split("async loadModel(modelUrl, options = {})", 1)[1]
+    outer = outer.split("async _loadModelImplementation", 1)[0]
+    assert "return await this._loadModelImplementation(modelUrl, options);" in outer, (
+        "loadModel 包装层必须直接委派给 _loadModelImplementation"
+    )
+    outer_rest = outer.replace(
+        "return await this._loadModelImplementation(modelUrl, options);", ""
+    )
+    assert "await this." not in outer_rest, "loadModel 包装层除委派外不得 await 任何东西"
+    assert ".then(" not in outer, "loadModel 不得挂 promise 链（否则重现阻塞队列）"
+
+    wrapper = source.split("async _loadModelImplementation", 1)[1]
     wrapper = wrapper.split("async _loadModelInternal", 1)[0]
     assert "await this." not in wrapper, "loadModel 不得 await 前序加载（否则重现阻塞）"
     assert ".then(" not in wrapper, "loadModel 不得挂 promise 链（否则重现阻塞队列）"

--- a/tests/unit/test_avatar_return_button_cat1_static.py
+++ b/tests/unit/test_avatar_return_button_cat1_static.py
@@ -8,6 +8,8 @@ from tests.static_app_parts import read_js_parts
 from main_routers import pages_router
 from tests.unit.avatar_ui_buttons_source import read_avatar_ui_buttons_source
 
+from tests.node_harness import run_node_script
+
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 AVATAR_UI_BUTTONS_DIR = PROJECT_ROOT / "static" / "avatar" / "avatar-ui-buttons"
@@ -21,8 +23,9 @@ def _run_node_harness(script: str) -> subprocess.CompletedProcess[str]:
     node_path = shutil.which("node")
     if not node_path:
         pytest.skip("node not found")
-    return subprocess.run(
-        [node_path, "-e", script],
+    return run_node_script(
+        node_path,
+        script,
         cwd=PROJECT_ROOT,
         text=True,
         capture_output=True,

--- a/tests/unit/test_cat_idle_state_machine_static.py
+++ b/tests/unit/test_cat_idle_state_machine_static.py
@@ -4,6 +4,8 @@ import subprocess
 import textwrap
 from pathlib import Path
 
+from tests.node_harness import run_node_script
+
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 CAT_MIND_PATH = PROJECT_ROOT / "static" / "app" / "app-cat-mind.js"
@@ -31,8 +33,13 @@ def _run_node_harness(script: str) -> subprocess.CompletedProcess[str]:
     if not node_path:
         raise AssertionError("node is required to run cat mind harness tests")
 
-    return subprocess.run(
-        [node_path, "-e", script],
+    # 走临时文件而不是 `node -e <script>`：这些仿真脚本会随被测行为一起变长，
+    # 最长的一条已经 34067 字符，超过 Windows CreateProcess 命令行 32767 上限，
+    # 于是 subprocess 在 node 起来之前就抛 WinError 206——断言一条都跑不到，
+    # 表现成一个与状态机无关的红。脚本内的路径都是绝对路径，cwd 仍保留。
+    return run_node_script(
+        node_path,
+        script,
         cwd=PROJECT_ROOT,
         capture_output=True,
         text=True,

--- a/tests/unit/test_galgame_ocr_capture_worker.py
+++ b/tests/unit/test_galgame_ocr_capture_worker.py
@@ -31,6 +31,80 @@ class _ExplodingLogger(_NullLogger):
         raise RuntimeError("logger failed")
 
 
+@pytest.mark.parametrize("exploding_step", [
+    "_stop_foreground_advance_monitor",
+    "_shutdown_capture_worker",
+    "_release_rapidocr_backend",
+])
+def test_ocr_reader_manager_close_releases_every_resource_despite_one_failure(
+    exploding_step: str,
+) -> None:
+    """No teardown step may take another one down with it.
+
+    close() swallows failures so callers can tear down unconditionally — which
+    means a shared guard is worse than none: one failing step would skip the
+    rest while the caller still sees a clean close and keeps live threads,
+    executors, or a classifier around.
+    """
+    manager = object.__new__(OcrReaderManager)
+    manager._logger = _NullLogger()
+    done: list[str] = []
+    closed_classifier: list[bool] = []
+
+    class _Classifier:
+        def close(self) -> None:
+            closed_classifier.append(True)
+
+    manager.vision_classifier = _Classifier()
+
+    def _step(name: str):
+        def _run(self, *_args, **_kwargs) -> None:
+            del self
+            done.append(name)
+            if name == exploding_step:
+                raise RuntimeError(f"{name} exploded")
+        return _run
+
+    for name in (
+        "_stop_foreground_advance_monitor",
+        "_shutdown_capture_worker",
+        "_release_rapidocr_backend",
+    ):
+        setattr(manager, name, types.MethodType(_step(name), manager))
+
+    manager.close()
+
+    assert done == [
+        "_stop_foreground_advance_monitor",
+        "_shutdown_capture_worker",
+        "_release_rapidocr_backend",
+    ], f"{exploding_step} 抛错后其余步骤仍必须跑到"
+    assert closed_classifier == [True], "classifier 必须被关掉"
+    assert manager.vision_classifier is None, "classifier 引用必须摘掉"
+
+
+def test_ocr_reader_manager_close_drops_classifier_reference_when_its_close_raises() -> None:
+    """A classifier whose own close() raises must still be let go of."""
+    manager = object.__new__(OcrReaderManager)
+    manager._logger = _NullLogger()
+
+    class _Classifier:
+        def close(self) -> None:
+            raise RuntimeError("classifier close exploded")
+
+    manager.vision_classifier = _Classifier()
+    for name in (
+        "_stop_foreground_advance_monitor",
+        "_shutdown_capture_worker",
+        "_release_rapidocr_backend",
+    ):
+        setattr(manager, name, types.MethodType(lambda self, *a, **k: None, manager))
+
+    manager.close()
+
+    assert manager.vision_classifier is None
+
+
 def test_ocr_reader_manager_context_manager_closes_capture_resources() -> None:
     manager = object.__new__(OcrReaderManager)
     manager._logger = _NullLogger()

--- a/tests/unit/test_model_manager_window_features.py
+++ b/tests/unit/test_model_manager_window_features.py
@@ -56,23 +56,6 @@ def test_model_manager_hide_show_cross_page_messages_are_removed():
     assert "show_main_ui" not in interpage_source
 
 
-def test_model_manager_pngtuber_import_supports_package_files_and_folders():
-    template = Path("templates/model_manager.html").read_text(encoding="utf-8")
-    source = Path("static/js/model_manager.js").read_text(encoding="utf-8")
-
-    assert 'id="pngtuber-model-upload" webkitdirectory directory multiple' in template
-    assert 'id="pngtuber-package-upload"' in template
-    assert '.pngremix,.pngRemix,.save,.veadomini,.veado' in template
-    assert "const pngtuberPackageUpload = document.getElementById('pngtuber-package-upload');" in source
-    assert "showPNGTuberUploadChoice()" in source
-    assert "let pngtuberUploadChoiceOpeningPicker = false;" in source
-    assert "if (pngtuberUploadChoiceOpeningPicker) return;" in source
-    assert "menu.parentNode.removeChild(menu);" in source
-    assert "async function uploadPNGTuberFiles(" in source
-    assert "await uploadPNGTuberFiles(e.target.files, pngtuberModelUpload);" in source
-    assert "await uploadPNGTuberFiles(e.target.files, pngtuberPackageUpload);" in source
-
-
 def test_voice_clone_api_settings_uses_shared_named_window():
     source = Path("static/js/voice_clone.js").read_text(encoding="utf-8")
     common_source = Path("static/common_dialogs.js").read_text(encoding="utf-8")

--- a/tests/unit/test_model_wheel_hit_guard_static.py
+++ b/tests/unit/test_model_wheel_hit_guard_static.py
@@ -17,10 +17,22 @@ def test_live2d_wheel_zoom_requires_model_hit_before_consuming_event():
     assert re.search(r"getBoundingClientRect\s*\(\)", block)
     assert re.search(r"event\.clientX\s*-\s*canvasRect\.left", block)
     assert re.search(r"event\.clientY\s*-\s*canvasRect\.top", block)
+    # 逐个消费点判定，而不是拿首个 preventDefault 当"那一个"：#2253 的挂边
+    # 探身分支在缩放路径之前自带一个 preventDefault（它自己也在命中检查里面），
+    # 首匹配写法会误判成守卫失效——测试比它声称的主张更弱。
+    hit_checks = [m.start() for m in re.finditer(r"isWheelPointOnCurrentModel\(event\)", block)]
+    prevent_sites = [m.start() for m in re.finditer(r"event\.preventDefault\(\);", block)]
+    assert prevent_sites, "找不到任何 preventDefault，切片或实现已变"
+    for site in prevent_sites:
+        assert any(check < site for check in hit_checks), (
+            f"offset {site} 处的 preventDefault 前面没有命中检查，滚轮会在模型外被吞掉"
+        )
     guard_index = re.search(r"if\s*\(!isWheelPointOnCurrentModel\(event\)\)\s*return;", block).start()
-    prevent_index = re.search(r"event\.preventDefault\(\);", block).start()
     scale_index = re.search(r"this\.currentModel\.scale\.set\(newScale\);", block).start()
-    assert guard_index < prevent_index < scale_index
+    assert guard_index < scale_index
+    assert any(guard_index < site < scale_index for site in prevent_sites), (
+        "缩放路径自己那一次 preventDefault 必须夹在早退守卫与 scale.set 之间"
+    )
 
 
 def test_vrm_wheel_zoom_requires_model_hit_before_consuming_event():

--- a/tests/unit/test_music_crawlers.py
+++ b/tests/unit/test_music_crawlers.py
@@ -216,7 +216,7 @@ async def test_soundcloud_crawler_token_logic():
     
     # 模拟搜索响应
     mock_search = MagicMock(status_code=200)
-    mock_search.json.return_value = {"collection": [{"title": "SC Song", "media": {"transcodings": [{"url": "http://sc.url/stream"}]}}]}
+    mock_search.json.return_value = {"collection": [{"title": "SC Song", "media": {"transcodings": [{"url": "http://sc.url/stream", "format": {"protocol": "progressive", "mime_type": "audio/mpeg"}}]}}]}
     
     # 模拟音频流 URL 响应
     mock_stream = MagicMock(status_code=200)
@@ -242,12 +242,12 @@ async def test_soundcloud_crawler_skips_ten_minute_candidates_before_stream_reso
             {
                 "title": "Long DJ Set",
                 "duration": 10 * 60 * 1000,
-                "media": {"transcodings": [{"url": "http://sc.url/long"}]},
+                "media": {"transcodings": [{"url": "http://sc.url/long", "format": {"protocol": "progressive", "mime_type": "audio/mpeg"}}]},
             },
             {
                 "title": "Normal Track",
                 "duration": 5 * 60 * 1000,
-                "media": {"transcodings": [{"url": "http://sc.url/normal"}]},
+                "media": {"transcodings": [{"url": "http://sc.url/normal", "format": {"protocol": "progressive", "mime_type": "audio/mpeg"}}]},
             },
         ]
     }

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -1,5 +1,7 @@
 import json
 import re
+
+import pytest
 from pathlib import Path
 from tests.static_app_parts import read_js_parts
 
@@ -1118,7 +1120,7 @@ def test_compact_tool_fan_uses_shell_local_anchor_not_fixed_viewport_position():
     assert "id: index === 0 ? 'toolFan:native' : 'toolFan:native:' + index" in script
 
 
-def test_compact_tool_fan_labels_are_plain_noninteractive_tags():
+def test_compact_tool_fan_tooltips_stay_noninteractive_and_anchored():
     styles = REACT_CHAT_STYLES_PATH.read_text(encoding="utf-8")
 
     tooltip_block = css_block(
@@ -1137,35 +1139,45 @@ def test_compact_tool_fan_labels_are_plain_noninteractive_tags():
     dark_tooltip_block = css_block(
         styles,
         '[data-theme="dark"] .compact-input-tool-fan .compact-input-tool-tooltip {',
-        '[data-theme="dark"] .compact-input-tool-fan .avatar-tool-quickbar {',
+        # 终止标记必须是紧邻的下一条规则：原来那个 .avatar-tool-quickbar 隔了
+        # 很远，切片会把 .neko-chat-tooltip::after 一起吞进来，对它做的断言其实
+        # 在断别的规则。
+        '[data-theme="dark"] .neko-chat-tooltip::after {',
     )
 
-    assert "pointer-events: none;" in tooltip_block
+    # 只钉行为性质，不钉观感取值：#2447 把这个 tooltip 从「白底方角平面标签」
+    # 重设计成了带圆角/渐变/backdrop-filter 的玻璃质感，原来那几条
+    # border-radius: 0 / background: #ffffff / box-shadow: none / 暗色具体色值
+    # 全是被有意改掉的外观，留着只会在每次视觉迭代时假报警。
+    assert "pointer-events: none;" in tooltip_block, "tooltip 不能吃掉指针事件"
     assert "user-select: none;" in tooltip_block
-    assert "left: calc(100% + 5px);" in tooltip_block
+    assert "left: calc(100% + 5px);" in tooltip_block, "tooltip 锚点定在按钮右侧"
     assert "top: calc(100% - 6px);" in tooltip_block
-    assert "border-radius: 0;" in tooltip_block
-    assert "background: #ffffff;" in tooltip_block
-    assert "box-shadow: none;" in tooltip_block
-    assert "scale(" not in tooltip_block
     assert "transform-origin: 0 0;" in tooltip_block
+    # 显示态必须落在静止几何上（不残留位移/缩放），否则标签会停在偏移位置。
     assert "transform: translate(0, 0);" in visible_block
     assert "scale(" not in visible_block
-    assert "border-color: #8b949e;" in dark_tooltip_block
-    assert "background: #202124;" in dark_tooltip_block
-    assert "color: #f3f4f6;" in dark_tooltip_block
+    # 暗色必须自带一套，不能继承亮色的底与字色（不钉具体色值）。
+    assert "background:" in dark_tooltip_block
+    assert "color:" in dark_tooltip_block
 
 
 def test_compact_tool_wheel_rotate_request_is_present_in_host_and_built_bundle():
     host_source = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
     app_source = REACT_CHAT_APP_PATH.read_text(encoding="utf-8")
-    bundle_source = REACT_CHAT_IIFE_PATH.read_text(encoding="utf-8")
 
     assert "rotateCompactToolWheel: rotateCompactToolWheel" in host_source
     assert "compactToolWheelRotateRequest = null" in app_source
     assert "rotateCompactInputToolWheelSteps(request.direction, request.stepCount" in app_source
+
+    # 产物断言放在源码断言之后，并且产物缺席时跳过而不是红：
+    # static/react/neko-chat/ 是 .gitignore 的 vite 输出，只有本地构建过或
+    # 打包流水线里才有。它还会「假绿」——一份陈旧产物同样能匹配到这个符号。
+    # 真正每次重建并校验产物的是 build-desktop 流水线，那才是该盯它的地方。
+    if not REACT_CHAT_IIFE_PATH.is_file():
+        pytest.skip("react chat bundle not built (static/react/ is a gitignored vite output)")
+    bundle_source = REACT_CHAT_IIFE_PATH.read_text(encoding="utf-8")
     assert "compactToolWheelRotateRequest:" in bundle_source
-    assert "compactToolWheelRotateRequest" in bundle_source
 
 
 def test_compact_history_open_request_drives_export_panel():

--- a/tests/unit/test_startup_default_cat_static.py
+++ b/tests/unit/test_startup_default_cat_static.py
@@ -4,6 +4,8 @@ import subprocess
 import textwrap
 from pathlib import Path
 
+from tests.node_harness import run_node_script
+
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 APP_AUTO_GOODBYE = PROJECT_ROOT / "static" / "app" / "app-auto-goodbye.js"
@@ -115,5 +117,5 @@ def test_startup_default_cat_request_survives_tutorial_and_runs_after_unlock():
         }}).catch((error) => {{ console.error(error); process.exitCode = 1; }});
         """
     )
-    result = subprocess.run([node, "-e", script], capture_output=True, text=True, check=False)
+    result = run_node_script(node, script, capture_output=True, text=True, check=False)
     assert result.returncode == 0, result.stderr or result.stdout


### PR DESCRIPTION
## Summary

- 分诊并修完 `tests/unit` 在 main 上的 **18 条存量失败**，全量转绿：`6571 passed / 18 skipped / 1 xfailed`
- 其中 **2 条是实现真 bug**（不是测试过期），**1 条**留给归属人（issue #2490）标了 `xfail(strict)`
- 新增 `.github/workflows/unit-tests.yml`：`tests/unit` 从此进 CI

## Why

#2486 修的那个「语音会话必崩」是 #2454 引入的，而守着那段代码的测试文件从来没在 CI 跑过。顺着查下去发现根因不是那一个 PR：**CI 里没有任何 job 跑 `tests/unit`**（`plugin-tests.yml` 只跑 `plugin/tests` + 两个手工点名的根测试），于是 main 上积了 18 条红没人知道。

## 分诊结果

| 类别 | 条数 | 处理 |
|---|---|---|
| 实现真 bug | 2 | 修实现 |
| 测试过期（实现有意改了、断言没跟上） | 12 | 修测试 |
| 环境依赖（gitignore 的构建产物） | 1 | 缺席时 skip |
| Windows 命令行长度上限 | 1 | 抽共享 harness 走临时文件 |
| 顺序污染 | 1 | 与真 bug #2 同一处修好 |
| 留给归属人 | 1 | `xfail(strict)` + issue #2490 |

分诊方法：每个失败簇一个取证 agent（读实现 + `git log -S` 定位漂移点 + 实跑复现），凡是判「该改测试」的结论再派一个对抗 agent 尝试推翻。**两条因此从「测试过期」翻成「实现真 bug」**，下面这两条都是被推翻后才发现的。

### 实现真 bug 1：galgame `OcrReaderManager.close()` teardown 倒置

`plugin/plugins/galgame_plugin/ocr_reader.py:379`：两步重依赖释放（rapidocr backend + vision classifier）裸奔在两段 `try/except` **之前**，任一抛错就把前台监听线程与 `galgame-ocr-capture` 线程池的收尾整个跳过——正是那两段守卫当初（#1440）要防的场景。对偶入口 `ocr_manager_poll.shutdown()` 的顺序恰好相反（先停线程与线程池，再释放它们可能仍在用的重依赖）。

改成与对偶同序并各自套守卫。

**严重度诚实说**：`close()` / `__exit__` 目前没有生产调用方（插件卸载走 `plugin_core` 的 `await shutdown()`），所以是「防御性 API 的防御性没了」，不是线上正在泄漏线程。修它的理由是成本极低 + 两个 teardown 入口现在对同一条安全性质给出相反答案。

### 实现真 bug 2：`agent_router` 的 shutdown handler 无守卫 aclose

`main_routers/agent_router.py:238` 的 `@router.on_event("shutdown")` 直接 `await _HTTP_CLIENT.aclose()`。当这个模块级 client 建在另一个已经关闭的事件循环上时（aclose 走 `call_soon` 撞上 closed loop），异常会沿合并 lifespan 链抛出去，**中断后面所有 router 的收尾**。

这也正是那条「只有全量顺序才红」的用例的污染源：`test_character_memory_regression` 先在自己的 pytest-asyncio loop 里建了 client，下一个用例的 `TestClient` 退出时炸在这里。二分定位到污染者/受害者单条对，确认修完两条按序跑即绿。

改成 `try/except` + `finally` 清引用（无论成败都清，下次 startup 在当前循环上重建）。

### 测试过期 12 条（每条都有漂移点 commit）

- `test_ai_aware_stage1_path_b` ×6：7 处 `FactStore.__new__` 手搭夹具没跟上 #2282 给 `__init__` 新增的 `_persist_alocks`。改成 `_make_fact_store()` 走真 `__init__`（只 patch 掉 config manager 单例），以后再加字段不会重演。
- `test_music_crawlers` ×2：3 处 transcoding fixture 缺 `format`，被 #2373 的 progressive-only 过滤全判掉。
- `test_react_chat_window_static` ×1：#2447 把 tooltip 从「白底方角平面标签」重设计成玻璃质感。只保留行为性质断言（`pointer-events: none` / 锚点 / 显示态静止几何），删掉观感取值；顺带修正暗色切片越界的终止标记（原来会把 `.neko-chat-tooltip::after` 一起吞进来，对它做的断言其实在断别的规则）。函数名 `_are_plain_noninteractive_tags` 已失真，改名。
- `test_avatar_model_load_race_static_contracts` ×1：#2253 在 `loadModel` 与 token 分配之间插了一层只记在飞计数的薄包装，原切片把委派行圈了进去。改成两段分开断言——包装层唯一允许的 `await` 就是那次委派，token 分配层仍一个都不许有。
- `test_model_wheel_hit_guard_static` ×1：`re.search` 取首个 `preventDefault`，被 #2253 新增的挂边探身分支截胡（那个 `preventDefault` 自己也在命中检查里面，契约没破）。改成「每个消费点前面都必须有命中检查」的全量判定。
- `test_model_manager_window_features` 的 pngtuber 用例 ×1：读的是 #2311 已拆成目录的旧扁平路径 `static/js/model_manager.js`；且它唯一比 `test_card_maker_static_contracts` 那条（已绿、用新路径、断言更强）多出来的 accept 断言，与 #2048 有意收窄 accept 的事实**相反**（后端 `pngtuber_importers` 至今对 `.veadomini/.veado` 直接 raise「该版本格式暂未支持」）。是严格子集 + 唯一增量还是错的，删除。

### 环境依赖 1 条

`static/react/neko-chat/*.iife.js` 是 gitignore 的 vite 输出。改成缺席时 `skip`，并把三条源码断言提到读产物之前。**不给 CI 加 npm build**：陈旧产物同样能匹配到符号（本机那份 mtime 落后 main 一周），真正每次重建并校验产物的是 `build-desktop` 流水线，那才是该盯它的地方。

### Windows 命令行长度 1 条

`test_cat_idle_state_machine_static` 的仿真脚本随被测行为一起涨到 34067 字符，超过 `CreateProcess` 的 32767 上限，`subprocess` 在 node 起来之前就抛 `WinError 206`——45 条断言一条都跑不到，红得跟状态机毫无关系。抽出 `tests/node_harness.py` 走临时文件；另外 4 个同写法、目前尚未越线的 harness 一并迁走（各自的 node-missing 策略 skip/raise 原样保留）。

## 回归报告

- 变更与必要性：main 上 `tests/unit` 有 18 条存量红，其中 2 条是实现缺陷。不修就没法把这个目录挂进 CI，而不挂 CI 就是 #2454 那类事故的温床。
- 修改前：`uv run pytest tests/unit -q` → 18 failed / 6556 passed；CI 完全不跑该目录。
- 修改后：6571 passed / 18 skipped / 1 xfailed / 0 failed，166s；新增 workflow 每个 PR 跑一次。
- 潜在回归：两处实现改动都在 teardown 路径。`ocr_reader.close()` 改了释放顺序（先线程后重依赖，与既有 `shutdown()` 对偶）并加守卫，`plugin/tests` 中 ocr 相关 498 条全绿；`agent_router` 只是把 shutdown 的 aclose 包进守卫、失败也清引用，不改任何请求路径。测试侧改动全部是断言/夹具，无实现依赖。
- 兼容性：无配置、协议、前端契约变化。

## 未在本 PR 处理（都有去处）

1. **FactStore「升级后重进 Stage-2」是坏的**（真 bug，修法待定）：`memory/facts.py:677` 升级 source 时把 `signal_processed` 重置为 `False`，但 `:269-278` 的 read-merge 把该字段当成只能 False→True 的单调字段、从磁盘无条件回写 `True`，而 `:755` 保证 `ai_disclosure` 建档就是 `True`。净效果是**标签升级生效、解封失效**，用户印证过的内容进不了记忆合成。十周没人发现，因为唯一守它的用例把 `asave_facts` mock 成了 `AsyncMock`——正好把出问题的那段代码 mock 没了。本 PR 只把该用例的夹具修好并在 docstring 里写明这条断言只覆盖内存态，**没有**把它改成真落盘往返（那要等修法定下来，否则会锁死一个还没决定的语义）。
2. **day1 Ghost Cursor 反向动画丢失**（issue #2490）：#2434 一并删掉的 5 个 day1 pair 里，`capture_cursor -> return_control` 是 PC→chat 反方向，没被同 commit 新增的 `releaseExternalizedChatCursorToHome()` 接管。用例标 `xfail(strict=True)` 并指向 issue，归属人修好后会以 XPASS 转红、强制摘掉 marker。
3. **`test_event_log` 的后台线程 `PermissionError [WinError 5]`**：`atomic_write_json` 的 `os.replace` 撞上 Windows 文件锁，目前只是 `PytestUnhandledThreadExceptionWarning`，不是 failure。属于「后台线程污染」形态，未来可能升级成随机红，建议单独跟进。
4. `plugin-tests.yml` 里那一步「Run repository contract tests」现在与本 workflow 重复，没动它——不想在同一个 PR 里碰 plugin 那道闸。

## Validation

- `uv run pytest tests/unit -q` — **6571 passed, 18 skipped, 1 xfailed** in 166s（此前 18 failed）
- `uv run pytest plugin/tests -q -k ocr` — 498 passed（覆盖 `ocr_reader.close()` 的改动面）
- 变异验证（改断言的三条都做了）：
  - wheel guard：删掉缩放路径的命中守卫 → 转红
  - vrm loadModel：① token 分配层重新 await 前序加载 ② 包装层多 await 一个别的东西 → 两次都转红
  - react bundle skip：把主 checkout 的产物拷进 worktree → 88 passed 无 skip，断言确实跑到了
- `ruff check <改动的 py 文件>` — passed
- `python scripts/check_docstring_no_cjk.py --base origin/main` — passed（commit 后跑的，工作区脏时该门会空过）
- 非 UI 改动，无截图

🤖 Generated with [Claude Code](https://claude.com/claude-code)
