### PR TITLE
修复“请她回来”后聊天框自动进入输入态的问题，猫形态结束时恢复字幕胶囊态，并补充跨窗口回归测试

### DIFF
--- a/static/app/app-react-chat-window/cat-local-chat.js
+++ b/static/app/app-react-chat-window/cat-local-chat.js
@@ -139,6 +139,13 @@
         }
     }
 
+    function restoreCompactSubtitleState(previousActive) {
+        if (!previousActive || state.active) return;
+        if (typeof I.setCompactChatState === 'function') {
+            I.setCompactChatState('default');
+        }
+    }
+
     function syncHostPresentation(previousActive, previousAttachmentsVisible) {
         if (previousActive === state.active) return;
         if (typeof I.applyGalgameBodyClass === 'function') {
@@ -188,6 +195,7 @@
             });
             keepCompactInputAvailable();
         }
+        restoreCompactSubtitleState(previousActive);
         syncHostPresentation(previousActive, previousAttachmentsVisible);
         renderHost();
         return true;
@@ -221,6 +229,7 @@
         state.enteredAt = nextEnteredAt;
         if (!nextActive) state.items = [];
         keepCompactInputAvailable();
+        restoreCompactSubtitleState(previousActive);
         syncHostPresentation(previousActive, previousAttachmentsVisible);
         renderHost();
         return getSnapshot();

--- a/static/cat-local-chat.test.cjs
+++ b/static/cat-local-chat.test.cjs
@@ -322,6 +322,7 @@ test('an older cross-window snapshot cannot revive an ended cat cycle', () => {
     items: [],
     updatedAt: 3000,
   }), true);
+  assert.equal(runtime.compactChatState, 'default');
   assert.equal(manager.applySnapshot({
     active: true,
     tier: 'cat1',
@@ -354,6 +355,7 @@ test('the real cat appearance event opens compact input and closes the same cycl
   runtime.window.dispatchEvent({ type: 'neko:cat-local-active-change' });
   assert.equal(manager.getSnapshot().active, false);
   assert.deepEqual(Array.from(manager.getSnapshot().items), []);
+  assert.equal(runtime.compactChatState, 'default');
 });
 
 test('the existing goodbye clear event also closes temporary cat chat', () => {


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复“请她回来”后聊天框自动进入输入态的问题，猫形态结束时恢复字幕胶囊态，并补充跨窗口回归测试

## 测试 / Testing

手动测试请她离开和回来


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复本地聊天周期结束或关闭后，紧凑聊天界面未恢复默认状态的问题。
  * 确保聊天输入与字幕状态在快照恢复和状态同步后正确重置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->