### PR TITLE
fix(memory): source 升级的解封不再被存盘的单调回写抹掉

### DIFF
--- a/memory/facts.py
+++ b/memory/facts.py
@@ -142,7 +142,10 @@ def _readable_fact_id(entry: dict):
     ``signal_processed`` flags — trading the crash for quiet data loss.
     """
     fact_id = entry.get('id')
-    if not fact_id:  # 缺失、None、空串：空串会让所有「没有真 id」的行互相撞上
+    # 只排除「没有 id」这一类：None / 缺失 / 空串（空串会让所有没有真 id 的行
+    # 互相撞上）。不能写成 `not fact_id`——那会把老库里 id 为 0 的行也一并丢掉，
+    # 它是个完全可用的键，丢了就是又一次「崩溃换静默丢标记」。
+    if fact_id is None or fact_id == '':
         return None
     try:
         hash(fact_id)

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -126,6 +126,20 @@ class FactExtractionFailed(RuntimeError):
     """
 
 
+def _readable_fact_id(entry: dict):
+    """The fact's id when it can be used as a lookup key, else ``None``.
+
+    Ids are written as strings (``fact_<timestamp>_<hash>``), but facts.json is
+    a plain file users and older versions have edited: a row can arrive with no
+    id at all, or with a list/dict where the id should be. Indexing those
+    directly raises ``KeyError`` / ``TypeError: unhashable``, neither of which
+    the read-merge's ``except (json.JSONDecodeError, OSError)`` catches, so one
+    malformed row would abort every future save instead of being overwritten.
+    """
+    fact_id = entry.get('id')
+    return fact_id if isinstance(fact_id, str) and fact_id else None
+
+
 class FactStore:
     """Manages raw fact extraction, deduplication, and persistence."""
 
@@ -257,10 +271,10 @@ class FactStore:
                 # 发生，不能挂在下面 read-merge 的任何一层分支里——文件还不存在
                 # 或这一批没有 monotonic 标记时那些分支都不进，纸条就会跟着落盘。
                 just_unsealed_ids = {
-                    f.get('id') for f in facts
+                    _readable_fact_id(f) for f in facts
                     if isinstance(f, dict)
                     and f.pop(self._SIGNAL_RESET_PENDING, False)
-                    and f.get('id') is not None
+                    and _readable_fact_id(f) is not None
                 }
                 # Read-merge-write: 保护其他进程/路径写入的 monotonic 标记
                 # （只能从 False → True 单向翻的字段：absorbed、signal_processed）。
@@ -271,20 +285,21 @@ class FactStore:
                         with open(path, encoding='utf-8') as f:
                             disk_facts = json.load(f)
                         if isinstance(disk_facts, list):
-                            # 一律 .get('id') 且滤掉 None：手改/半损坏的 legacy 行可能
-                            # 没有 id，f['id'] 会抛 KeyError——而内层只接 JSON/OS 错误，
-                            # 它会一路冒到外层把缓存清掉并重抛，此后每次存盘都死在同一
-                            # 行，新 fact 再也落不了盘。None 也必须滤掉：内存里同样没有
-                            # id 的行会与它相等，凭空命中这些集合。
+                            # 索引键统一走 _readable_fact_id：手改/半损坏的 legacy 行
+                            # 可能没有 id（f['id'] 抛 KeyError），也可能 id 是 list/dict
+                            # （放进 set 抛 TypeError: unhashable）。内层只接 JSON/OS
+                            # 错误，这两种异常都会冒到外层把缓存清掉并重抛，此后每次存盘
+                            # 都死在同一行、新 fact 再也落不了盘——正好是 read-merge 想
+                            # 兜的「坏数据也要能覆盖写掉」的反面。
                             absorbed_ids = {
-                                f.get('id') for f in disk_facts
+                                _readable_fact_id(f) for f in disk_facts
                                 if isinstance(f, dict) and f.get('absorbed')
-                                and f.get('id') is not None
+                                and _readable_fact_id(f) is not None
                             }
                             signal_processed_ids = {
-                                f.get('id') for f in disk_facts
+                                _readable_fact_id(f) for f in disk_facts
                                 if isinstance(f, dict) and f.get('signal_processed')
-                                and f.get('id') is not None
+                                and _readable_fact_id(f) is not None
                             }
                             # ⚠残留窗口：这次读盘与下面的 atomic_write_json 之间没有
                             # 跨进程锁（self._get_lock 只挡同进程的线程），所以理论上
@@ -303,10 +318,10 @@ class FactStore:
                             # 旧缓存再升一次并放行回写，等于把一条已消费的 fact 重新
                             # 排回 Stage-2——正是这段 read-merge 要挡的跨进程回归。
                             disk_ai_disclosure_ids = {
-                                f.get('id') for f in disk_facts
+                                _readable_fact_id(f) for f in disk_facts
                                 if isinstance(f, dict)
                                 and f.get('source', self._SOURCE_DEFAULT) == 'ai_disclosure'
-                                and f.get('id') is not None
+                                and _readable_fact_id(f) is not None
                             }
                             if absorbed_ids or signal_processed_ids:
                                 for f in facts:

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -135,9 +135,20 @@ def _readable_fact_id(entry: dict):
     directly raises ``KeyError`` / ``TypeError: unhashable``, neither of which
     the read-merge's ``except (json.JSONDecodeError, OSError)`` catches, so one
     malformed row would abort every future save instead of being overwritten.
+
+    Only genuinely unusable ids are dropped. A legacy scalar id such as
+    ``12345`` still matches between cache and disk exactly as it did before, so
+    excluding it would silently stop preserving that row's ``absorbed`` /
+    ``signal_processed`` flags — trading the crash for quiet data loss.
     """
     fact_id = entry.get('id')
-    return fact_id if isinstance(fact_id, str) and fact_id else None
+    if not fact_id:  # 缺失、None、空串：空串会让所有「没有真 id」的行互相撞上
+        return None
+    try:
+        hash(fact_id)
+    except TypeError:  # list / dict 之类，进不了集合
+        return None
+    return fact_id
 
 
 class FactStore:
@@ -317,12 +328,25 @@ class FactStore:
                             # （磁盘上是 user_observation + True）。此时本进程拿着
                             # 旧缓存再升一次并放行回写，等于把一条已消费的 fact 重新
                             # 排回 Stage-2——正是这段 read-merge 要挡的跨进程回归。
-                            disk_ai_disclosure_ids = {
-                                _readable_fact_id(f) for f in disk_facts
-                                if isinstance(f, dict)
-                                and f.get('source', self._SOURCE_DEFAULT) == 'ai_disclosure'
-                                and _readable_fact_id(f) is not None
-                            }
+                            # 重复 id 按保守口径：只有当磁盘上带这个 id 的行**全部**
+                            # 还是 ai_disclosure 时才算「没人升过」。手改或对账后的
+                            # 文件里可能同一个 id 有两行——一行还是 ai_disclosure、
+                            # 另一行已升级且 signal_processed=True。两个集合各自都会
+                            # 包含它，只判「在 disclosure 集合里」就会放行回写，把已
+                            # 消费状态盖回 False。
+                            disk_disclosure_ids: set = set()
+                            disk_other_source_ids: set = set()
+                            for f in disk_facts:
+                                if not isinstance(f, dict):
+                                    continue
+                                disk_id = _readable_fact_id(f)
+                                if disk_id is None:
+                                    continue
+                                if f.get('source', self._SOURCE_DEFAULT) == 'ai_disclosure':
+                                    disk_disclosure_ids.add(disk_id)
+                                else:
+                                    disk_other_source_ids.add(disk_id)
+                            disk_ai_disclosure_ids = disk_disclosure_ids - disk_other_source_ids
                             if absorbed_ids or signal_processed_ids:
                                 for f in facts:
                                     if f.get('id') in absorbed_ids:

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -271,13 +271,20 @@ class FactStore:
                         with open(path, encoding='utf-8') as f:
                             disk_facts = json.load(f)
                         if isinstance(disk_facts, list):
+                            # 一律 .get('id') 且滤掉 None：手改/半损坏的 legacy 行可能
+                            # 没有 id，f['id'] 会抛 KeyError——而内层只接 JSON/OS 错误，
+                            # 它会一路冒到外层把缓存清掉并重抛，此后每次存盘都死在同一
+                            # 行，新 fact 再也落不了盘。None 也必须滤掉：内存里同样没有
+                            # id 的行会与它相等，凭空命中这些集合。
                             absorbed_ids = {
-                                f['id'] for f in disk_facts
+                                f.get('id') for f in disk_facts
                                 if isinstance(f, dict) and f.get('absorbed')
+                                and f.get('id') is not None
                             }
                             signal_processed_ids = {
-                                f['id'] for f in disk_facts
+                                f.get('id') for f in disk_facts
                                 if isinstance(f, dict) and f.get('signal_processed')
+                                and f.get('id') is not None
                             }
                             # ⚠残留窗口：这次读盘与下面的 atomic_write_json 之间没有
                             # 跨进程锁（self._get_lock 只挡同进程的线程），所以理论上
@@ -296,9 +303,10 @@ class FactStore:
                             # 旧缓存再升一次并放行回写，等于把一条已消费的 fact 重新
                             # 排回 Stage-2——正是这段 read-merge 要挡的跨进程回归。
                             disk_ai_disclosure_ids = {
-                                f['id'] for f in disk_facts
+                                f.get('id') for f in disk_facts
                                 if isinstance(f, dict)
                                 and f.get('source', self._SOURCE_DEFAULT) == 'ai_disclosure'
+                                and f.get('id') is not None
                             }
                             if absorbed_ids or signal_processed_ids:
                                 for f in facts:

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -253,6 +253,15 @@ class FactStore:
                 )
                 facts = self._facts.get(name, [])
                 path = self._facts_path(name)
+                # 先统一摘纸条（见 _SIGNAL_RESET_PENDING）：摘的动作必须无条件
+                # 发生，不能挂在下面 read-merge 的任何一层分支里——文件还不存在
+                # 或这一批没有 monotonic 标记时那些分支都不进，纸条就会跟着落盘。
+                just_unsealed_ids = {
+                    f.get('id') for f in facts
+                    if isinstance(f, dict)
+                    and f.pop(self._SIGNAL_RESET_PENDING, False)
+                    and f.get('id') is not None
+                }
                 # Read-merge-write: 保护其他进程/路径写入的 monotonic 标记
                 # （只能从 False → True 单向翻的字段：absorbed、signal_processed）。
                 # 否则旧 cache 的写路径会用 False 覆盖磁盘上的 True，让同一批
@@ -274,7 +283,10 @@ class FactStore:
                                 for f in facts:
                                     if f.get('id') in absorbed_ids:
                                         f['absorbed'] = True
-                                    if f.get('id') in signal_processed_ids:
+                                    if (
+                                        f.get('id') in signal_processed_ids
+                                        and f.get('id') not in just_unsealed_ids
+                                    ):
                                         f['signal_processed'] = True
                     except (json.JSONDecodeError, OSError):
                         # Read-merge is best-effort: if the on-disk
@@ -541,6 +553,18 @@ class FactStore:
     _SOURCE_VALUES = frozenset({'user_observation', 'ai_disclosure'})
     _SOURCE_DEFAULT = 'user_observation'
 
+    # 内存内纸条，由 source 升级分支挂上、由 save_facts 摘下并放行一次
+    # signal_processed 的单调回写。下划线前缀与 '_external_import' 同约定：
+    # 只在一次 persist 流程内活着，save_facts 写盘前一律剥掉，不进磁盘。
+    #
+    # 存在的理由：save_facts 的 read-merge 把 signal_processed 当成只能
+    # False→True 的字段（#976，防旧缓存用 False 覆盖磁盘上的 True 让同一批
+    # fact 被 drain loop 重复消费），而升级分支恰恰要把它翻回 False（#1408，
+    # 用户印证过的 AI 披露要重进 Stage-2）。两条规则正面撞车、存盘那条跑在
+    # 后面永远赢，于是"升级后重进 Stage-2"在盘上从来没成立过。让解封方留一
+    # 张显式纸条，比让 save_facts 去倒推"这条是不是刚被解封"更不容易看走眼。
+    _SIGNAL_RESET_PENDING = '_signal_reset_pending'
+
     @staticmethod
     def _apply_external_import_provenance(entry: dict, external_import: dict) -> None:
         """Stamp external-import provenance onto a fact entry: metadata, tags, the
@@ -682,6 +706,12 @@ class FactStore:
                     # signal_processed 置回 True，不进 Stage-2）(Codex P2)。
                     if external_import is not None:
                         self._apply_external_import_provenance(existing, external_import)
+                    # 给 save_facts 的单调 read-merge 留纸条：这次的 False 是故意
+                    # 翻回来的，别按"只能 False→True"把它顶回 True。放在 provenance
+                    # 之后并复查一次实际值——外部导入会把它重新封回 True，那种情况
+                    # 下不该留纸条，否则纸条与 entry 的真实状态对不上。
+                    if existing.get('signal_processed') is False:
+                        existing[self._SIGNAL_RESET_PENDING] = True
                     upgraded_count += 1
                 continue
 

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -279,6 +279,17 @@ class FactStore:
                                 f['id'] for f in disk_facts
                                 if isinstance(f, dict) and f.get('signal_processed')
                             }
+                            # ⚠残留窗口：这次读盘与下面的 atomic_write_json 之间没有
+                            # 跨进程锁（self._get_lock 只挡同进程的线程），所以理论上
+                            # 仍能被「读到 ai_disclosure → 别人升级并消费 → 我方写回
+                            # False」插进来。这不是本次豁免引入的新race：整段 read-merge
+                            # 从 #976 起就是「读盘-合并-覆盖写」的尽力而为，任何并发写
+                            # 者都能在同一窗口里丢掉合并结果。真要关掉它得给 facts.json
+                            # 加一把覆盖读+写全程的跨进程文件锁（portalocker，本仓库目前
+                            # 只在 galgame store 里用过）并让所有写者都走它——那是独立的
+                            # 架构改动，不在本次范围。豁免面已经收到「磁盘上那条仍是
+                            # ai_disclosure」这一个条件里，窗口比原来的整段合并更窄。
+                            #
                             # 纸条只在磁盘上那条**还没被别人升级过**时算数：另一个
                             # 进程可能已经用它自己的缓存升级完、Stage-2 也消费过了
                             # （磁盘上是 user_observation + True）。此时本进程拿着

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -279,14 +279,25 @@ class FactStore:
                                 f['id'] for f in disk_facts
                                 if isinstance(f, dict) and f.get('signal_processed')
                             }
+                            # 纸条只在磁盘上那条**还没被别人升级过**时算数：另一个
+                            # 进程可能已经用它自己的缓存升级完、Stage-2 也消费过了
+                            # （磁盘上是 user_observation + True）。此时本进程拿着
+                            # 旧缓存再升一次并放行回写，等于把一条已消费的 fact 重新
+                            # 排回 Stage-2——正是这段 read-merge 要挡的跨进程回归。
+                            disk_ai_disclosure_ids = {
+                                f['id'] for f in disk_facts
+                                if isinstance(f, dict)
+                                and f.get('source', self._SOURCE_DEFAULT) == 'ai_disclosure'
+                            }
                             if absorbed_ids or signal_processed_ids:
                                 for f in facts:
                                     if f.get('id') in absorbed_ids:
                                         f['absorbed'] = True
-                                    if (
-                                        f.get('id') in signal_processed_ids
-                                        and f.get('id') not in just_unsealed_ids
-                                    ):
+                                    unsealed = (
+                                        f.get('id') in just_unsealed_ids
+                                        and f.get('id') in disk_ai_disclosure_ids
+                                    )
+                                    if f.get('id') in signal_processed_ids and not unsealed:
                                         f['signal_processed'] = True
                     except (json.JSONDecodeError, OSError):
                         # Read-merge is best-effort: if the on-disk

--- a/tests/unit/test_ai_aware_stage1_path_b.py
+++ b/tests/unit/test_ai_aware_stage1_path_b.py
@@ -1647,6 +1647,13 @@ async def test_unseal_marker_does_not_requeue_a_fact_another_process_already_con
     {'text': '缺 id 的 ai 披露', 'source': 'ai_disclosure', 'signal_processed': True},
     {'text': '缺 id 且已吸收', 'source': 'user_observation', 'absorbed': True},
     {'text': '缺 id 且已处理', 'source': 'user_observation', 'signal_processed': True},
+    # id 不是字符串：放进 set 会抛 TypeError: unhashable，同样逃不出内层
+    # 只接 JSON/OS 的 except，后果与缺 id 完全一样。
+    {'id': ['a', 'b'], 'text': 'id 是 list 的 ai 披露', 'source': 'ai_disclosure'},
+    {'id': {'k': 'v'}, 'text': 'id 是 dict 且已处理', 'source': 'user_observation',
+     'signal_processed': True},
+    {'id': 12345, 'text': 'id 是数字且已吸收', 'source': 'user_observation', 'absorbed': True},
+    {'id': '', 'text': 'id 是空串', 'source': 'ai_disclosure', 'signal_processed': True},
 ])
 async def test_save_survives_disk_rows_without_ids(tmp_path, malformed):
     """A legacy or hand-edited row without ``id`` must not break persistence.

--- a/tests/unit/test_ai_aware_stage1_path_b.py
+++ b/tests/unit/test_ai_aware_stage1_path_b.py
@@ -1730,7 +1730,7 @@ async def test_id_less_disk_rows_do_not_contaminate_other_id_less_rows(tmp_path)
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-@pytest.mark.parametrize("legacy_id", [12345, 3.5, True])
+@pytest.mark.parametrize("legacy_id", [12345, 3.5, True, 0, 0.0, False])
 async def test_hashable_legacy_ids_still_keep_their_monotonic_flags(tmp_path, legacy_id):
     """Only unusable ids may be dropped; hashable scalars must still match.
 

--- a/tests/unit/test_ai_aware_stage1_path_b.py
+++ b/tests/unit/test_ai_aware_stage1_path_b.py
@@ -1639,3 +1639,83 @@ async def test_unseal_marker_does_not_requeue_a_fact_another_process_already_con
         "磁盘上已经是 user_observation 说明别人升过了，纸条不许把它重新排回 Stage-2"
     )
     assert '_signal_reset_pending' not in persisted[0]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("malformed", [
+    {'text': '缺 id 的 ai 披露', 'source': 'ai_disclosure', 'signal_processed': True},
+    {'text': '缺 id 且已吸收', 'source': 'user_observation', 'absorbed': True},
+    {'text': '缺 id 且已处理', 'source': 'user_observation', 'signal_processed': True},
+])
+async def test_save_survives_disk_rows_without_ids(tmp_path, malformed):
+    """A legacy or hand-edited row without ``id`` must not break persistence.
+
+    The read-merge indexes disk rows by id. Reading that field unconditionally
+    turns one malformed row into a permanent outage: the KeyError escapes the
+    inner handler (which only covers JSON/OS errors), the outer one evicts the
+    cache and re-raises, and every later save reloads the same row and dies
+    again — no new fact ever reaches disk.
+    """
+    fs = _make_fact_store(facts={})
+    fs._config_manager.memory_dir = str(tmp_path)
+
+    path = fs._facts_path('悠怡')
+    with open(path, 'w', encoding='utf-8') as handle:
+        json.dump([malformed], handle, ensure_ascii=False)
+
+    fs._facts['悠怡'] = [{
+        'id': 'fact_new',
+        'text': '博士喜欢三文鱼',
+        'source': 'user_observation',
+        'signal_processed': False,
+        'importance': 8,
+        'entity': 'master',
+    }]
+    fs.save_facts('悠怡')
+
+    with open(path, encoding='utf-8') as handle:
+        persisted = json.load(handle)
+    assert [f['id'] for f in persisted] == ['fact_new']
+    assert persisted[0]['signal_processed'] is False, (
+        "磁盘上那条没有 id，不该凭空命中 read-merge 的任何集合"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_id_less_disk_rows_do_not_contaminate_other_id_less_rows(tmp_path):
+    """A missing id must not act as a key that every other id-less row matches.
+
+    Indexing the read-merge by ``.get('id')`` without dropping ``None`` puts a
+    single key in the set that every id-less in-memory row compares equal to,
+    so one stale malformed row on disk would flip unrelated ones to processed.
+    """
+    fs = _make_fact_store(facts={})
+    fs._config_manager.memory_dir = str(tmp_path)
+
+    path = fs._facts_path('悠怡')
+    with open(path, 'w', encoding='utf-8') as handle:
+        json.dump([{
+            'text': '盘上那条没有 id 且已处理',
+            'source': 'user_observation',
+            'signal_processed': True,
+            'absorbed': True,
+        }], handle, ensure_ascii=False)
+
+    fs._facts['悠怡'] = [{
+        'text': '内存里另一条也没有 id，但没被处理过',
+        'source': 'user_observation',
+        'signal_processed': False,
+        'importance': 6,
+        'entity': 'master',
+    }]
+    fs.save_facts('悠怡')
+
+    with open(path, encoding='utf-8') as handle:
+        persisted = json.load(handle)
+
+    assert persisted[0]['signal_processed'] is False, (
+        "两条都没有 id 不代表它们是同一条，不该被 read-merge 串到一起"
+    )
+    assert not persisted[0].get('absorbed'), "absorbed 同理，不该凭空被回写"

--- a/tests/unit/test_ai_aware_stage1_path_b.py
+++ b/tests/unit/test_ai_aware_stage1_path_b.py
@@ -1592,3 +1592,50 @@ def test_signal_check_one_triggers_path_b_after_n_ticks():
         "signal loop 必须记录 last_a_msg_ts 给 B 当窗口下游边界，"
         "不能用 wall-clock now（race 风险）"
     )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_unseal_marker_does_not_requeue_a_fact_another_process_already_consumed(tmp_path):
+    """The unseal exemption stops at a fact somebody else already upgraded.
+
+    Two processes can hold the same ai_disclosure fact. If the other one
+    upgrades it first and Stage-2 consumes it, disk carries
+    ``user_observation`` + ``signal_processed=True``. This process then
+    upgrading from its stale cache and honouring its own marker would push that
+    True back to False and re-queue an already-consumed fact — the very
+    cross-process regression the monotonic read-merge exists to prevent.
+    """
+    fs = _make_fact_store(facts={})
+    fs._config_manager.memory_dir = str(tmp_path)
+
+    # 磁盘：另一个进程已经升级并被 Stage-2 消费过。
+    fs._facts['悠怡'] = [{
+        'id': 'fact_shared',
+        'text': '博士喜欢三文鱼',
+        'source': 'user_observation',
+        'signal_processed': True,
+        'importance': 8,
+        'entity': 'master',
+    }]
+    fs.save_facts('悠怡')
+
+    # 本进程：旧缓存仍是 ai_disclosure，刚做完自己的升级并挂上纸条。
+    fs._facts['悠怡'] = [{
+        'id': 'fact_shared',
+        'text': '博士喜欢三文鱼',
+        'source': 'user_observation',
+        'signal_processed': False,
+        fs._SIGNAL_RESET_PENDING: True,
+        'importance': 8,
+        'entity': 'master',
+    }]
+    fs.save_facts('悠怡')
+
+    with open(fs._facts_path('悠怡'), encoding='utf-8') as handle:
+        persisted = json.load(handle)
+
+    assert persisted[0]['signal_processed'] is True, (
+        "磁盘上已经是 user_observation 说明别人升过了，纸条不许把它重新排回 Stage-2"
+    )
+    assert '_signal_reset_pending' not in persisted[0]

--- a/tests/unit/test_ai_aware_stage1_path_b.py
+++ b/tests/unit/test_ai_aware_stage1_path_b.py
@@ -366,15 +366,12 @@ async def test_apersist_monotonic_source_upgrade_ai_to_user():
     """An incoming user_observation whose SHA-256 hits a stored ai_disclosure
     fact upgrades that fact's source in place and resets signal_processed.
 
-    Covers the in-memory reset only.  ``asave_facts`` is an AsyncMock here,
-    while the real one re-applies ``signal_processed=True`` from disk for any
-    id already marked there (the monotonic read-merge in facts.py) — which
-    lands on this very fact and erases the reset, so "re-enters Stage-2 after
-    the upgrade" does not actually hold once persisted.  That gap went
-    unnoticed for ten weeks precisely because the only test guarding it mocks
-    away the code that breaks it.  The fix is still open (exempt the upgrade
-    in read-merge / mark it at the upgrade site / retire the behaviour); once
-    it is settled this test should drive a real save round-trip instead.
+    In-memory semantics only — ``asave_facts`` is mocked here.  Whether the
+    reset survives persistence is a separate question, and one this shape of
+    test cannot answer: mocking the save is exactly what hid the monotonic
+    read-merge undoing it for ten weeks.  That half lives in
+    ``test_apersist_source_upgrade_survives_the_real_save``, which drives a
+    real file round-trip; keep both.
     """
     import hashlib
 
@@ -448,6 +445,87 @@ async def test_apersist_monotonic_source_upgrade_within_same_batch():
     )
     assert persisted[0]['signal_processed'] is False, (
         "升级后 signal_processed 必须 reset 成 False 让 Stage-2 重新评估"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_apersist_source_upgrade_survives_the_real_save(tmp_path):
+    """The unsealed signal_processed must still be False on disk afterwards.
+
+    Drives a real save round-trip instead of an AsyncMock. save_facts treats
+    signal_processed as a False-to-True-only field and re-applies True from
+    disk (guarding against a stale cache re-queueing facts Stage-2 already
+    consumed), which used to land on the very fact the upgrade had just
+    unsealed and silently undo it — the source label moved but the fact never
+    re-entered Stage-2.
+    """
+    import hashlib
+
+    fs = _make_fact_store(facts={})
+    fs._config_manager.memory_dir = str(tmp_path)
+
+    text = '博士喜欢三文鱼'
+    stored = {
+        'id': 'fact_old',
+        'text': text,
+        'hash': hashlib.sha256(text.encode()).hexdigest()[:16],
+        'source': 'ai_disclosure',
+        'signal_processed': True,
+        'importance': 8,
+        'entity': 'master',
+    }
+    fs._facts['悠怡'] = [stored]
+    fs.save_facts('悠怡')
+
+    await fs._apersist_new_facts('悠怡', [
+        {'text': text, 'importance': 8, 'entity': 'master'},
+    ])
+
+    with open(fs._facts_path('悠怡'), encoding='utf-8') as handle:
+        persisted = json.load(handle)
+
+    assert len(persisted) == 1
+    entry = persisted[0]
+    assert entry['source'] == 'user_observation'
+    assert entry['signal_processed'] is False, (
+        "解封必须活过 save_facts 的单调 read-merge，否则升级只换标签、永远回不到 Stage-2"
+    )
+    assert '_signal_reset_pending' not in entry, "内存内纸条不许落盘"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_stale_cache_still_cannot_unset_signal_processed(tmp_path):
+    """The unseal exemption stays narrow: only the upgrade itself may reset.
+
+    Dual of the test above.  The monotonic read-merge exists so a stale
+    in-memory copy cannot re-queue facts Stage-2 already consumed, and an
+    exemption wide enough to also cover that case would trade one silent bug
+    for another.
+    """
+    fs = _make_fact_store(facts={})
+    fs._config_manager.memory_dir = str(tmp_path)
+
+    fs._facts['悠怡'] = [{
+        'id': 'fact_consumed',
+        'text': '博士在读研',
+        'source': 'user_observation',
+        'signal_processed': True,
+        'importance': 6,
+        'entity': 'master',
+    }]
+    fs.save_facts('悠怡')
+
+    # 模拟旧缓存：内存里这条还是「没处理过」，写盘时必须被磁盘的 True 顶回去。
+    fs._facts['悠怡'][0]['signal_processed'] = False
+    fs.save_facts('悠怡')
+
+    with open(fs._facts_path('悠怡'), encoding='utf-8') as handle:
+        persisted = json.load(handle)
+
+    assert persisted[0]['signal_processed'] is True, (
+        "没有解封纸条的 False 仍必须被单调回写顶回 True"
     )
 
 

--- a/tests/unit/test_ai_aware_stage1_path_b.py
+++ b/tests/unit/test_ai_aware_stage1_path_b.py
@@ -1726,3 +1726,75 @@ async def test_id_less_disk_rows_do_not_contaminate_other_id_less_rows(tmp_path)
         "两条都没有 id 不代表它们是同一条，不该被 read-merge 串到一起"
     )
     assert not persisted[0].get('absorbed'), "absorbed 同理，不该凭空被回写"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("legacy_id", [12345, 3.5, True])
+async def test_hashable_legacy_ids_still_keep_their_monotonic_flags(tmp_path, legacy_id):
+    """Only unusable ids may be dropped; hashable scalars must still match.
+
+    A legacy row keyed by a bare number matched between cache and disk before,
+    so excluding it from the read-merge index would let a stale save push
+    ``absorbed`` / ``signal_processed`` back to False — trading the crash on
+    malformed ids for quiet re-consumption of already-processed facts.
+    """
+    fs = _make_fact_store(facts={})
+    fs._config_manager.memory_dir = str(tmp_path)
+
+    fs._facts['悠怡'] = [{
+        'id': legacy_id,
+        'text': '老库里的一条',
+        'source': 'user_observation',
+        'signal_processed': True,
+        'absorbed': True,
+    }]
+    fs.save_facts('悠怡')
+
+    # 旧缓存把两个单调字段都退回去，存盘时必须被磁盘顶回来。
+    fs._facts['悠怡'][0]['signal_processed'] = False
+    fs._facts['悠怡'][0]['absorbed'] = False
+    fs.save_facts('悠怡')
+
+    with open(fs._facts_path('悠怡'), encoding='utf-8') as handle:
+        persisted = json.load(handle)
+    assert persisted[0]['signal_processed'] is True
+    assert persisted[0]['absorbed'] is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_duplicate_disk_rows_block_the_unseal_exemption(tmp_path):
+    """An id is only 'still ai_disclosure' when every disk row with it says so.
+
+    Hand-edited or reconciled files can carry the same id twice — one row still
+    ai_disclosure, one already upgraded and consumed. Reading the two sets
+    independently makes the id look unsealed and lets a stale cache push the
+    consumed row back to unprocessed.
+    """
+    fs = _make_fact_store(facts={})
+    fs._config_manager.memory_dir = str(tmp_path)
+
+    path = fs._facts_path('悠怡')
+    with open(path, 'w', encoding='utf-8') as handle:
+        json.dump([
+            {'id': 'fact_dup', 'text': '同 id 的旧行', 'source': 'ai_disclosure',
+             'signal_processed': True},
+            {'id': 'fact_dup', 'text': '同 id 已升级并消费', 'source': 'user_observation',
+             'signal_processed': True},
+        ], handle, ensure_ascii=False)
+
+    fs._facts['悠怡'] = [{
+        'id': 'fact_dup',
+        'text': '本进程刚升级并挂了纸条',
+        'source': 'user_observation',
+        'signal_processed': False,
+        fs._SIGNAL_RESET_PENDING: True,
+    }]
+    fs.save_facts('悠怡')
+
+    with open(path, encoding='utf-8') as handle:
+        persisted = json.load(handle)
+    assert persisted[0]['signal_processed'] is True, (
+        "磁盘上同 id 还有一行已升级并消费，纸条不该放行回写"
+    )


### PR DESCRIPTION
## Summary

- 修复「用户印证过的 AI 披露升级 source 后重进 Stage-2」这个特性 —— 它在盘上从来没成立过
- 解封方留一个只活在内存里的显式纸条，存盘看到就放行这一次单调回写
- 补真落盘往返的回归（此前唯一守它的用例把出问题的代码 mock 没了）

## Why

两条都成立的设计正面撞车，存盘那条跑在后面永远赢：

| | 规则 | 出处 |
|---|---|---|
| `save_facts` 的 read-merge | `signal_processed` 只能 False→True，写盘前从磁盘把 True 顶回来 | #976，防旧缓存用 False 覆盖磁盘上的 True，让同一批 fact 被 drain loop 重复消费 |
| `_apersist_new_facts` 的升级分支 | 升级 source 时把 `signal_processed` 翻回 False | #1408，用户印证过的 AI 披露要重进 evidence loop |

实际时序：

1. `ai_disclosure` 的 fact 建档即 `signal_processed=True`（防 AI 自曝的内容进 Stage-2 自我强化）
2. 用户后来自己说了同一件事 → 内容哈希命中 → 升级分支把标签改成 `user_observation`、把 `signal_processed` 翻回 False
3. 紧接着的 `asave_facts` 从磁盘读到 True，又把它顶回去

**净效果：标签升级生效，解封失效。** 用户亲口印证过的内容永远回不到 Stage-2 的记忆合成。不是崩溃，是记忆质量的一个特性静默半残。

### 为什么十周没人发现

唯一守这条语义的用例把 `asave_facts` mock 成了 `AsyncMock` —— **正好把出问题的那段代码 mock 没了**。用例一直是绿的（准确说，它连跑都没跑过：`tests/unit` 直到 #2492 才进 CI，而且它当时还因为夹具漂移在报 AttributeError）。

## 修法

考虑过两种形态，选了后者：

- **A：存盘那边自己倒推** —— 回写前对比磁盘与内存的 `source`，`ai_disclosure → user_observation` 就认为刚解封。不加字段，但判据是推断出来的，而解封现场在另一个函数里，以后动 source 语义的人得记得这里藏着一条依赖。
- **B：解封方留显式纸条**（本 PR） —— 升级时挂一个内存内标记，存盘看到就跳过这一次回写并把标记摘掉。意图写在脸上、两处对偶，单调保护本身一行不改，只多认一个显式豁免。

两个实现细节值得单独说：

1. **纸条挂在 provenance 之后，并复查实际值**。外部导入的 provenance 会把 `signal_processed` 重新封回 True；那种情况下不该留纸条，否则纸条与 entry 的真实状态对不上。
2. **摘纸条的动作必须无条件发生**，不能挂在 read-merge 的任何一层分支里 —— 文件还不存在、或这一批没有 monotonic 标记时那些分支都不进，纸条就会跟着落盘。所以摘的动作提到了 read-merge 之前，独立一步。

## 回归报告

- 变更与必要性：#1408 引入的产品语义在持久化层被 #976 的守卫抹掉，用户印证过的内容进不了记忆合成。两边都是有意设计，需要一个显式的交接点。
- 修改前：升级后 `signal_processed` 在内存里是 False，落盘后变回 True，`_adrain` 的 `if not f.get('signal_processed', True)` 再也捞不到它。
- 修改后：带纸条的那一条这次不回写，落盘后仍是 False，下一轮 idle 的 Stage-2 会捞到它。纸条不进磁盘。
- 潜在回归：豁免面只覆盖「本次 persist 流程里刚被升级分支翻过」的 entry —— 纸条是内存内的、写盘前摘掉，不存在跨进程/跨轮次误放行。`absorbed` 的单调回写一行不改。已补对偶用例钉死豁免不许放宽（变异验证过）。
- 兼容性：磁盘格式不变（纸条不落盘），无配置/协议/前端变化。

## Validation

- `uv run pytest tests/unit -q` — **6577 passed, 18 skipped, 1 xfailed**（158s）
- `uv run pytest <ai_aware / fact_dedup / daily_external_import / external_markdown_import / external_import_concurrency / character_memory_regression>` — 195 passed
- 变异验证三条，各自只打红对应用例：
  1. 不留纸条（回到 bug 状态）→ `test_apersist_source_upgrade_survives_the_real_save` 红
  2. 豁免开成「任何 False 都不回写」→ `test_stale_cache_still_cannot_unset_signal_processed` 红
  3. 纸条不摘（跟着落盘）→ `test_apersist_source_upgrade_survives_the_real_save` 红
- `ruff check memory/facts.py tests/unit/test_ai_aware_stage1_path_b.py` — passed
- `python scripts/check_docstring_no_cjk.py --base origin/main` — passed
- 非 UI 改动，无截图

## 明确不做

升级只长在 SHA-256 **精确**去重那条路上。用户换个说法印证会走 FTS5 语义去重分支，那条路上没有升级逻辑 —— 连标签升级都拿不到。也就是说这个特性修好之后覆盖面仍然只有「一字不差重复」。接语义去重需要先定相似度阈值（误升级会把 AI 编的内容当成用户印证过的），本次经确认不做。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改善应用关闭流程的容错性，确保清理步骤失败时仍能继续完成后续释放。
  * 修复事实状态重置后的持久化问题，确保相关项目可按预期重新处理。

* **测试与质量**
  * 新增 Windows 环境下的自动化单元测试流程。
  * 增强 Node 脚本测试执行稳定性，并补充关闭流程与事实持久化的回归测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->