### PR TITLE
fix(ci): 让 Unit Tests 在干净 runner 上真绿（修 main 当前的红）

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -67,7 +67,13 @@ jobs:
         # ~260 KB on its own, so install just that and keep the four fork tests
         # running instead of letting them skip in the one environment that
         # would otherwise never exercise them.
-        run: uv pip install pyclipper
+        #
+        # Pinned to the version uv.lock already resolved for the galgame group,
+        # so an index update cannot make an unchanged commit install a different
+        # release and turn this workflow red (Greptile P2). uv.lock stays the
+        # single source of truth: test_unit_tests_workflow_pins_locked_pyclipper
+        # fails if this pin and the lock ever drift apart.
+        run: uv pip install pyclipper==1.4.0
 
       - name: Run unit test suite
         # Separate pytest process from plugin/tests, which carries its own

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -59,6 +59,16 @@ jobs:
         # need it and fail loudly rather than silently skipping if it is gone.
         run: uv sync
 
+      - name: Install pyclipper (in-tree rapidocr fork)
+        # tests/unit/test_galgame_dependency_slimming.py exercises the in-tree
+        # deps/rapidocr_pillow fork, whose det post-processing imports pyclipper
+        # at module scope. It ships with the galgame group, but that group also
+        # drags in opencv (~130 MB) which nothing else here needs. The wheel is
+        # ~260 KB on its own, so install just that and keep the four fork tests
+        # running instead of letting them skip in the one environment that
+        # would otherwise never exercise them.
+        run: uv pip install pyclipper
+
       - name: Run unit test suite
         # Separate pytest process from plugin/tests, which carries its own
         # pytest.ini.

--- a/tests/node_harness.py
+++ b/tests/node_harness.py
@@ -14,17 +14,26 @@
 """Shared launcher for the generated node simulation harnesses.
 
 Several static-contract suites drive real frontend modules through a node
-script built at test time.  Those scripts grow with the behaviour they
-simulate, and passing one via ``node -e`` puts the whole thing on the command
-line: past 32767 characters Windows' ``CreateProcess`` refuses it and
-``subprocess`` raises ``WinError 206`` before node ever starts, so not one
-assertion runs and the failure reads as unrelated to the code under test.
-One suite crossed that line at 34067 characters and stayed red unnoticed
-because ``tests/unit`` does not run in CI.
+script built at test time.  Two ways of handing that script to node have both
+bitten this repo, and both failures look like anything but what they are:
 
-Writing the script to a temp file removes the ceiling.  Node lookup and the
-node-missing policy (skip vs. hard failure) stay with each caller, since the
-suites deliberately differ there.
+Command-line length
+    ``node -e <script>`` puts the whole script on the command line.  Past 32767
+    characters Windows' ``CreateProcess`` refuses it and ``subprocess`` raises
+    ``WinError 206`` before node starts, so not one assertion runs.  A suite
+    crossed that line at 34067 characters and stayed red unnoticed.
+
+Locale encoding
+    ``subprocess.run(..., text=True)`` without an explicit ``encoding`` encodes
+    stdin and decodes stdout with ``locale.getpreferredencoding()``.  On a
+    machine with the Windows UTF-8 option enabled that is cp65001 and CJK in a
+    harness script sails through; on a stock English Windows (every GitHub
+    runner) it is cp1252 and the same script dies with ``UnicodeEncodeError``.
+    Five tests passed locally and failed in CI on exactly this.
+
+Both runners here take the script off the command line and pin UTF-8 in both
+directions.  Node lookup and the node-missing policy (skip vs. hard failure)
+stay with each caller, since the suites deliberately differ there.
 """
 
 import os
@@ -32,9 +41,18 @@ import subprocess
 import tempfile
 
 
+def _utf8(kwargs: dict) -> dict:
+    """Force UTF-8 for stdin/stdout so the host locale cannot decide."""
+    merged = dict(kwargs)
+    merged.setdefault("text", True)
+    merged["encoding"] = "utf-8"
+    return merged
+
+
 def run_node_script(node_path: str, script: str, **kwargs) -> subprocess.CompletedProcess[str]:
     """Run ``script`` from a temp file under ``node_path``.
 
+    Use this when the script is large or grows with the behaviour it simulates.
     Extra keyword arguments go straight to ``subprocess.run``.
     """
     with tempfile.NamedTemporaryFile(
@@ -43,6 +61,16 @@ def run_node_script(node_path: str, script: str, **kwargs) -> subprocess.Complet
         handle.write(script)
         script_path = handle.name
     try:
-        return subprocess.run([node_path, script_path], **kwargs)
+        return subprocess.run([node_path, script_path], **_utf8(kwargs))
     finally:
         os.unlink(script_path)
+
+
+def run_node_stdin(node_path: str, script: str, **kwargs) -> subprocess.CompletedProcess[str]:
+    """Pipe ``script`` into ``node -`` over stdin.
+
+    Equivalent to ``run_node_script`` for callers already written against the
+    stdin form; stdin has no length ceiling, so only the encoding pin matters
+    here. Extra keyword arguments go straight to ``subprocess.run``.
+    """
+    return subprocess.run([node_path, "-"], input=script, **_utf8(kwargs))

--- a/tests/unit/test_autostart_provider.py
+++ b/tests/unit/test_autostart_provider.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.node_harness import run_node_stdin
+
 
 AUTOSTART_PROVIDER_PATH = Path(__file__).resolve().parents[2] / "static" / "app" / "app-autostart-provider.js"
 
@@ -89,15 +91,13 @@ runScenario()
   }});
 """
 
-    result = subprocess.run(
-        [node_executable, "-"],
-        input=node_harness,
-        text=True,
+    result = run_node_stdin(
+        node_executable,
+        node_harness,
         capture_output=True,
         check=False,
         timeout=10,
     )
-
     if result.returncode != 0:
         raise AssertionError(
             "Node autostart_provider scenario failed:\n"

--- a/tests/unit/test_common_dialogs.py
+++ b/tests/unit/test_common_dialogs.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.node_harness import run_node_stdin
+
 
 COMMON_DIALOGS_PATH = Path(__file__).resolve().parents[2] / "static" / "common_dialogs.js"
 
@@ -307,15 +309,13 @@ runScenario()
   }});
 """
 
-    result = subprocess.run(
-        [node_executable, "-"],
-        input=node_harness,
-        text=True,
+    result = run_node_stdin(
+        node_executable,
+        node_harness,
         capture_output=True,
         check=False,
         timeout=10,
     )
-
     if result.returncode != 0:
         raise AssertionError(
             "Node common_dialogs scenario failed:\n"

--- a/tests/unit/test_galgame_dependency_slimming.py
+++ b/tests/unit/test_galgame_dependency_slimming.py
@@ -18,6 +18,15 @@ import yaml
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 RAPIDOCR_PILLOW_ROOT = ROOT / "deps" / "rapidocr_pillow"
 
+# The fork's det post-processing imports pyclipper at module scope, and
+# pyclipper only arrives with the galgame group (`uv sync --group galgame`),
+# which plain dev installs and CI deliberately skip — it drags in ~130 MB of
+# opencv. Without this guard those tests do not fail informatively, they raise
+# ModuleNotFoundError, and they only ever passed on machines that happened to
+# have the group installed. The CI workflow installs the single ~260 KB
+# pyclipper wheel so the cohort still runs there; everywhere else it skips.
+_HAS_PYCLIPPER = importlib.util.find_spec("pyclipper") is not None
+
 
 def _rapidocr_modnames() -> list[str]:
     return [
@@ -138,6 +147,7 @@ def test_rapidocr_pillow_source_has_no_removed_dependency_imports() -> None:
     assert sorted(offenders) == []
 
 
+@pytest.mark.skipif(not _HAS_PYCLIPPER, reason="pyclipper missing (galgame group not installed)")
 def test_pillow_cv_geometry_helpers_cover_shapely_and_perspective_replacements() -> None:
     from rapidocr_onnxruntime._pillow_cv import (
         dilate,
@@ -356,6 +366,7 @@ def test_rapidocr_pillow_verifier_can_build_manifest_from_category_dirs() -> Non
         shutil.rmtree(temp_root, ignore_errors=True)
 
 
+@pytest.mark.skipif(not _HAS_PYCLIPPER, reason="pyclipper missing (galgame group not installed)")
 def test_rapidocr_pillow_preprocess_accumulates_resize_ratios() -> None:
     from rapidocr_onnxruntime.main import RapidOCR
 
@@ -371,6 +382,7 @@ def test_rapidocr_pillow_preprocess_accumulates_resize_ratios() -> None:
     assert ratio_w == pytest.approx(8000 / 3968)
 
 
+@pytest.mark.skipif(not _HAS_PYCLIPPER, reason="pyclipper missing (galgame group not installed)")
 def test_rapidocr_call_uses_per_call_thresholds_without_mutating_instance() -> None:
     from rapidocr_onnxruntime.main import RapidOCR
 
@@ -406,6 +418,7 @@ def test_rapidocr_call_uses_per_call_thresholds_without_mutating_instance() -> N
     assert engine.text_score == 0.5
 
 
+@pytest.mark.skipif(not _HAS_PYCLIPPER, reason="pyclipper missing (galgame group not installed)")
 def test_rapidocr_cli_visualization_handles_empty_and_det_only_results(monkeypatch, tmp_path) -> None:
     from rapidocr_onnxruntime import main as rapidocr_main
 

--- a/tests/unit/test_galgame_dependency_slimming.py
+++ b/tests/unit/test_galgame_dependency_slimming.py
@@ -485,6 +485,7 @@ def test_rapidocr_cli_visualization_handles_empty_and_det_only_results(monkeypat
     assert writes[-1][0] == tmp_path / "sample_vis.png"
 
 
+@pytest.mark.skipif(not _HAS_PYCLIPPER, reason="pyclipper missing (galgame group not installed)")
 def test_rapidocr_pillow_read_yaml_uses_safe_loader(tmp_path) -> None:
     from rapidocr_onnxruntime.utils import read_yaml
 
@@ -498,6 +499,7 @@ def test_rapidocr_pillow_read_yaml_uses_safe_loader(tmp_path) -> None:
         read_yaml(unsafe_yaml)
 
 
+@pytest.mark.skipif(not _HAS_PYCLIPPER, reason="pyclipper missing (galgame group not installed)")
 def test_rapidocr_pillow_rgba_conversion_uses_white_background_alpha_composite() -> None:
     from rapidocr_onnxruntime.utils import LoadImage
 
@@ -517,6 +519,7 @@ def test_rapidocr_pillow_rgba_conversion_uses_white_background_alpha_composite()
     assert np.array_equal(bgr[1, 1], np.array([199, 196, 194], dtype=np.uint8))
 
 
+@pytest.mark.skipif(not _HAS_PYCLIPPER, reason="pyclipper missing (galgame group not installed)")
 def test_rapidocr_pillow_cli_list_args_parse_comma_separated_values(monkeypatch, tmp_path) -> None:
     from rapidocr_onnxruntime.utils.parse_parameters import init_args
 
@@ -545,6 +548,7 @@ def test_rapidocr_pillow_cli_list_args_parse_comma_separated_values(monkeypatch,
     assert args.rec_img_shape == [3, 48, 320]
 
 
+@pytest.mark.skipif(not _HAS_PYCLIPPER, reason="pyclipper missing (galgame group not installed)")
 def test_rapidocr_pillow_update_parameters_strips_module_prefixes_consistently() -> None:
     from rapidocr_onnxruntime.utils.parse_parameters import UpdateParameters
 
@@ -562,3 +566,54 @@ def test_rapidocr_pillow_update_parameters_strips_module_prefixes_consistently()
     assert det_dict == {"box_thresh": 0.7, "use_dilation": False}
     assert cls_dict == {"batch_num": 8, "label_list": ["0", "180"]}
     assert rec_dict == {"batch_num": 12, "img_shape": [3, 48, 320]}
+
+
+def test_every_fork_importing_test_carries_the_dependency_guard():
+    """Any test importing the fork must be guarded, discovered not listed.
+
+    Importing any ``rapidocr_onnxruntime`` submodule runs the package
+    ``__init__``, which reaches pyclipper — so without the guard the test does
+    not skip on a plain ``uv sync``, it raises ModuleNotFoundError. Which tests
+    that actually hits is order-dependent: run the file top to bottom and a
+    failed first import leaves enough behind that later ones sail through, but
+    select a later one on its own and it explodes. A hand-kept list of guarded
+    tests would go stale the first time someone adds one, so the list is
+    derived from the AST instead.
+    """
+    import ast
+
+    source = pathlib.Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    def _imports_fork(fn: ast.FunctionDef) -> bool:
+        for node in ast.walk(fn):
+            if isinstance(node, ast.ImportFrom) and (node.module or "").startswith(
+                "rapidocr_onnxruntime"
+            ):
+                return True
+            if isinstance(node, ast.Import):
+                if any(a.name.startswith("rapidocr_onnxruntime") for a in node.names):
+                    return True
+        return False
+
+    def _is_guarded(fn: ast.FunctionDef) -> bool:
+        for decorator in fn.decorator_list:
+            if "_HAS_PYCLIPPER" in (ast.get_source_segment(source, decorator) or ""):
+                return True
+        return False
+
+    importers, unguarded = [], []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef) or not node.name.startswith("test_"):
+            continue
+        if not _imports_fork(node):
+            continue
+        importers.append(node.name)
+        if not _is_guarded(node):
+            unguarded.append(f"{node.name} (line {node.lineno})")
+
+    assert len(importers) >= 8, f"发现到的 fork 导入用例太少，断言已失效: {importers}"
+    assert not unguarded, (
+        "这些用例导入了 rapidocr_onnxruntime 却没挂 _HAS_PYCLIPPER 守卫，"
+        f"干净环境下会抛 ModuleNotFoundError 而不是跳过: {unguarded}"
+    )

--- a/tests/unit/test_live2d_appearance_baseline_static.py
+++ b/tests/unit/test_live2d_appearance_baseline_static.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.node_harness import run_node_stdin
+
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 LIVE2D_CORE_PATH = PROJECT_ROOT / "static" / "live2d" / "live2d-core.js"
@@ -17,17 +19,14 @@ def _run_node_harness(script: str) -> subprocess.CompletedProcess[str]:
     node_executable = shutil.which("node")
     if node_executable is None:
         pytest.skip("node not found")
-    return subprocess.run(
-        [node_executable, "-"],
-        input=script,
-        text=True,
+    return run_node_stdin(
+        node_executable,
+        script,
         capture_output=True,
         cwd=PROJECT_ROOT,
         timeout=10,
         check=False,
     )
-
-
 def test_saved_live2d_parameters_feed_appearance_baseline():
     core_source = LIVE2D_CORE_PATH.read_text(encoding="utf-8")
     model_source = LIVE2D_MODEL_PATH.read_text(encoding="utf-8")

--- a/tests/unit/test_live2d_parameter_persistence_static.py
+++ b/tests/unit/test_live2d_parameter_persistence_static.py
@@ -7,6 +7,8 @@ from tests.static_app_parts import read_js_parts
 
 import pytest
 
+from tests.node_harness import run_node_stdin
+
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 LIVE2D_MODEL_PATH = PROJECT_ROOT / "static" / "live2d" / "live2d-model.js"
@@ -20,17 +22,14 @@ def _run_node_harness(script: str) -> subprocess.CompletedProcess[str]:
     node_executable = shutil.which("node")
     if node_executable is None:
         pytest.skip("node not found")
-    return subprocess.run(
-        [node_executable, "-"],
-        input=script,
-        text=True,
+    return run_node_stdin(
+        node_executable,
+        script,
         capture_output=True,
         cwd=PROJECT_ROOT,
         timeout=10,
         check=False,
     )
-
-
 def _manager_harness(body: str) -> str:
     return textwrap.dedent(
         f"""

--- a/tests/unit/test_node_harness_contract.py
+++ b/tests/unit/test_node_harness_contract.py
@@ -31,11 +31,14 @@ exactly what a new harness file would slip past.
 """
 
 import ast
+import re
+import tomllib
 from pathlib import Path
 
 import pytest
 
 TESTS_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = TESTS_ROOT.parent
 # The launcher itself is the one place allowed to call subprocess.run on node.
 EXEMPT = {TESTS_ROOT / "node_harness.py"}
 
@@ -84,6 +87,29 @@ def test_node_harnesses_go_through_the_shared_launcher():
     assert not offenders, (
         "这些地方直接用 subprocess 跑 node，绕开了 tests/node_harness 的"
         f"命令行长度与 UTF-8 兜底：{offenders}"
+    )
+
+
+def test_unit_tests_workflow_pins_locked_pyclipper():
+    """The workflow's standalone pyclipper install must track uv.lock.
+
+    It is installed outside ``uv sync`` because the group carrying it also
+    carries opencv, so nothing else keeps the two in step: an index update
+    could otherwise hand an unchanged commit a different release and turn the
+    workflow red. Pinning without this check just moves the drift somewhere
+    nobody looks.
+    """
+    workflow = (REPO_ROOT / ".github" / "workflows" / "unit-tests.yml").read_text(
+        encoding="utf-8"
+    )
+    pinned = re.search(r"uv pip install pyclipper==([\w.]+)", workflow)
+    assert pinned, "unit-tests.yml 里的 pyclipper 安装必须钉版本"
+
+    lock = tomllib.loads((REPO_ROOT / "uv.lock").read_text(encoding="utf-8"))
+    locked = [p["version"] for p in lock["package"] if p["name"] == "pyclipper"]
+    assert locked, "uv.lock 里找不到 pyclipper，断言已失效"
+    assert pinned.group(1) == locked[0], (
+        f"workflow 钉的是 {pinned.group(1)}，uv.lock 解析的是 {locked[0]}"
     )
 
 

--- a/tests/unit/test_node_harness_contract.py
+++ b/tests/unit/test_node_harness_contract.py
@@ -62,11 +62,12 @@ _ENTRY_POINTS = frozenset({"run", "Popen", "check_output", "check_call", "call"}
 
 
 def _subprocess_bindings(tree: ast.AST) -> tuple[set[str], set[str]]:
-    """本文件里哪些名字指向 subprocess。
+    """Which names in this file resolve to subprocess.
 
-    模块名不一定叫 subprocess：``import subprocess as sp`` 与
-    ``from subprocess import run`` 都是常见写法，只认字面量 "subprocess."
-    等于把这两条路留给新 harness 当后门（Codex P2）。
+    The module is not always spelled ``subprocess``: ``import subprocess as sp``
+    and ``from subprocess import run`` are both ordinary, and matching only the
+    literal ``subprocess.`` prefix leaves either one as a way around this
+    contract.
     """
     module_aliases = {"subprocess"}
     direct_names: set[str] = set()

--- a/tests/unit/test_node_harness_contract.py
+++ b/tests/unit/test_node_harness_contract.py
@@ -1,0 +1,107 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Every node-driving test must go through tests/node_harness.
+
+Hand-rolled ``subprocess.run`` calls to node have broken this suite twice, both
+times in a way that hides what actually went wrong:
+
+* ``node -e <script>`` blows past Windows' 32767-character command line and
+  raises ``WinError 206`` before node starts, so no assertion in the test runs.
+* ``text=True`` without ``encoding`` encodes stdin with the host locale, so a
+  harness carrying CJK passes on a UTF-8-configured machine and dies with
+  ``UnicodeEncodeError`` on a stock English Windows — i.e. on every CI runner.
+
+Both are invisible locally to whoever writes the harness.  The shared launcher
+pins the temp-file form and UTF-8, so this test keeps new harnesses on it
+rather than re-deriving the raw call.
+
+Discovered by walking the AST, not from a hand-maintained file list: a list is
+exactly what a new harness file would slip past.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+TESTS_ROOT = Path(__file__).resolve().parents[1]
+# The launcher itself is the one place allowed to call subprocess.run on node.
+EXEMPT = {TESTS_ROOT / "node_harness.py"}
+
+
+def _mentions_node(call: ast.Call) -> bool:
+    """True when this subprocess.run call is driving node."""
+    for node in ast.walk(call):
+        if isinstance(node, ast.Name) and "node" in node.id.lower():
+            return True
+        if isinstance(node, ast.Attribute) and "node" in node.attr.lower():
+            return True
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            if node.value.lower() in {"node", "node.exe"} or node.value.lower().endswith("/node"):
+                return True
+    return False
+
+
+def _subprocess_run_calls(tree: ast.AST):
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = getattr(func, "attr", None) or getattr(func, "id", None)
+        if name in {"run", "Popen", "check_output", "call"}:
+            module = getattr(getattr(func, "value", None), "id", None)
+            if module == "subprocess" or name == "Popen":
+                yield node
+
+
+def test_node_harnesses_go_through_the_shared_launcher():
+    offenders = []
+    scanned = 0
+    for path in sorted(TESTS_ROOT.rglob("*.py")):
+        if path in EXEMPT:
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:  # pragma: no cover - a broken test file fails elsewhere
+            continue
+        scanned += 1
+        for call in _subprocess_run_calls(tree):
+            if _mentions_node(call):
+                offenders.append(f"{path.relative_to(TESTS_ROOT).as_posix()}:{call.lineno}")
+
+    assert scanned > 50, f"扫描面太小，断言已失效（只扫到 {scanned} 个文件）"
+    assert not offenders, (
+        "这些地方直接用 subprocess 跑 node，绕开了 tests/node_harness 的"
+        f"命令行长度与 UTF-8 兜底：{offenders}"
+    )
+
+
+@pytest.mark.parametrize("runner", ["run_node_script", "run_node_stdin"])
+def test_shared_launcher_pins_utf8(runner):
+    """Both runners must pin the encoding rather than inherit the locale."""
+    source = (TESTS_ROOT / "node_harness.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    func = next(
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == runner
+    )
+    body = ast.get_source_segment(source, func) or ""
+    assert "_utf8(kwargs)" in body, f"{runner} 必须把 kwargs 过一遍 _utf8()"
+
+    helper = next(
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "_utf8"
+    )
+    helper_body = ast.get_source_segment(source, helper) or ""
+    assert '"encoding"] = "utf-8"' in helper_body, "_utf8 必须强制 encoding，而不是 setdefault"

--- a/tests/unit/test_node_harness_contract.py
+++ b/tests/unit/test_node_harness_contract.py
@@ -62,7 +62,9 @@ def _subprocess_run_calls(tree: ast.AST):
             continue
         func = node.func
         name = getattr(func, "attr", None) or getattr(func, "id", None)
-        if name in {"run", "Popen", "check_output", "call"}:
+        # 全部 subprocess 入口，不只是 run：漏一个（比如 check_call）就等于给
+        # 新 harness 留了一条绕过这条契约、退回 node -e 的合法路径（Codex P2）。
+        if name in {"run", "Popen", "check_output", "check_call", "call"}:
             module = getattr(getattr(func, "value", None), "id", None)
             if module == "subprocess" or name == "Popen":
                 yield node

--- a/tests/unit/test_node_harness_contract.py
+++ b/tests/unit/test_node_harness_contract.py
@@ -56,18 +56,46 @@ def _mentions_node(call: ast.Call) -> bool:
     return False
 
 
+# 全部 subprocess 入口，不只是 run：漏一个（比如 check_call）就等于给新
+# harness 留了一条绕过这条契约、退回 node -e 的合法路径（Codex P2）。
+_ENTRY_POINTS = frozenset({"run", "Popen", "check_output", "check_call", "call"})
+
+
+def _subprocess_bindings(tree: ast.AST) -> tuple[set[str], set[str]]:
+    """本文件里哪些名字指向 subprocess。
+
+    模块名不一定叫 subprocess：``import subprocess as sp`` 与
+    ``from subprocess import run`` 都是常见写法，只认字面量 "subprocess."
+    等于把这两条路留给新 harness 当后门（Codex P2）。
+    """
+    module_aliases = {"subprocess"}
+    direct_names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "subprocess":
+                    module_aliases.add(alias.asname or alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.module == "subprocess":
+            for alias in node.names:
+                if alias.name in _ENTRY_POINTS:
+                    direct_names.add(alias.asname or alias.name)
+    return module_aliases, direct_names
+
+
 def _subprocess_run_calls(tree: ast.AST):
+    module_aliases, direct_names = _subprocess_bindings(tree)
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
         func = node.func
-        name = getattr(func, "attr", None) or getattr(func, "id", None)
-        # 全部 subprocess 入口，不只是 run：漏一个（比如 check_call）就等于给
-        # 新 harness 留了一条绕过这条契约、退回 node -e 的合法路径（Codex P2）。
-        if name in {"run", "Popen", "check_output", "check_call", "call"}:
-            module = getattr(getattr(func, "value", None), "id", None)
-            if module == "subprocess" or name == "Popen":
+        if isinstance(func, ast.Attribute):
+            if (
+                func.attr in _ENTRY_POINTS
+                and getattr(func.value, "id", None) in module_aliases
+            ):
                 yield node
+        elif isinstance(func, ast.Name) and func.id in direct_names:
+            yield node
 
 
 def test_node_harnesses_go_through_the_shared_launcher():

--- a/tests/unit/test_prompt_shared.py
+++ b/tests/unit/test_prompt_shared.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.node_harness import run_node_stdin
+
 
 PROMPT_SHARED_PATH = Path(__file__).resolve().parents[2] / "static" / "app" / "app-prompt-shared.js"
 
@@ -66,15 +68,13 @@ runScenario()
   }});
 """
 
-    result = subprocess.run(
-        [node_executable, "-"],
-        input=node_harness,
-        text=True,
+    result = run_node_stdin(
+        node_executable,
+        node_harness,
         capture_output=True,
         check=False,
         timeout=10,
     )
-
     if result.returncode != 0:
         raise AssertionError(
             "Node prompt_shared scenario failed:\n"

--- a/tests/unit/test_tutorial_script_normalizer.py
+++ b/tests/unit/test_tutorial_script_normalizer.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.node_harness import run_node_stdin
+
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
@@ -15,12 +17,11 @@ def _run_node_harness(script: str) -> subprocess.CompletedProcess[str]:
     if not node_path:
         pytest.skip("node not found")
     try:
-        return subprocess.run(
-            [node_path, "-"],
-            input=script,
+        return run_node_stdin(
+            node_path,
+            script,
             cwd=PROJECT_ROOT,
             capture_output=True,
-            text=True,
             check=False,
             timeout=10,
         )

--- a/tests/unit/test_tutorial_timeline_engine.py
+++ b/tests/unit/test_tutorial_timeline_engine.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.node_harness import run_node_stdin
+
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
@@ -14,16 +16,13 @@ def _run_node_harness(script: str) -> subprocess.CompletedProcess[str]:
     node_path = shutil.which("node")
     if not node_path:
         pytest.skip("node not found")
-    return subprocess.run(
-        [node_path, "-"],
-        input=script,
+    return run_node_stdin(
+        node_path,
+        script,
         cwd=PROJECT_ROOT,
         capture_output=True,
-        text=True,
         check=False,
     )
-
-
 def test_non_blocking_timeline_event_rejections_are_warned_not_unhandled():
     script = textwrap.dedent(
         """

--- a/tests/unit/test_voice_start_failure_static.py
+++ b/tests/unit/test_voice_start_failure_static.py
@@ -7,6 +7,8 @@ from tests.static_app_parts import read_path_or_parts
 
 import pytest
 
+from tests.node_harness import run_node_stdin
+
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 APP_AUDIO_CAPTURE_PATH = PROJECT_ROOT / "static" / "app" / "app-audio-capture.js"
 APP_BUTTONS_PATH = PROJECT_ROOT / "static" / "app" / "app-buttons.js"
@@ -254,10 +256,9 @@ runScenario()
   }});
 """
 
-    result = subprocess.run(
-        [node_executable, "-"],
-        input=node_harness,
-        text=True,
+    result = run_node_stdin(
+        node_executable,
+        node_harness,
         capture_output=True,
         check=False,
         timeout=10,

--- a/tests/unit/test_window_pin_static_contracts.py
+++ b/tests/unit/test_window_pin_static_contracts.py
@@ -227,7 +227,17 @@ def test_plugin_manager_pin_control_and_bridge_contract():
 
 def test_pin_labels_exist_in_all_main_and_plugin_locales():
     i18n_bootstrap = read_text("static/i18n-i18next.js")
-    assert "LOCALE_VERSION = '2026-07-22-window-pin-controls-i18n'" in i18n_bootstrap
+    # 只要求存在一个非空的 LOCALE_VERSION（locale 文件靠它做 cache-bust），
+    # 不再钉死具体取值：钉死等于让每一次无关的版本串变更都打红这条用例。
+    # #2465「Refactor memory browser UI」把它从 2026-07-22-window-pin-controls-i18n
+    # 改成 2026-07-24-memory-browser-ui-refactor，这条就一直红着——当时
+    # tests/unit 还没进 CI，没人看见。
+    locale_version = re.search(
+        r"const\s+LOCALE_VERSION\s*=\s*'([^']+)'", i18n_bootstrap
+    )
+    assert locale_version and locale_version.group(1).strip(), (
+        "i18n-i18next.js 必须带一个非空的 LOCALE_VERSION 常量做 locale cache-bust"
+    )
 
     locale_names = (
         "en",


### PR DESCRIPTION
## Summary

**main 上的 `Unit Tests` 目前是红的**（#2492 合入后第一跑 10 条失败），本 PR 修红。

10 条**本地一条都不复现** —— 全部是「开发机」与干净 runner 的环境差异，正是这道闸该抓的东西。分三类。

## 1. UnicodeEncodeError（5 条）

8 个测试文件用 `subprocess.run(..., text=True)` 把 node 脚本从 stdin 灌进去，**不给 `encoding`**，于是走 `locale.getpreferredencoding()`：

| 环境 | preferred encoding | 脚本里的中文 |
|---|---|---|
| 开了 Windows「UTF-8 全球语言支持」的机器 | cp65001 | 正常 |
| GitHub windows runner（stock 英文） | cp1252 | `UnicodeEncodeError: 'charmap' codec can't encode` |

失败点在 node 起来之前，报的是 codec 错，跟被测行为毫无关系。

**修法**：`tests/node_harness` 补 `run_node_stdin()`，两个 runner 都强制 UTF-8（stdin 与 stdout 两个方向），8 个文件全部迁走。

## 2. ModuleNotFoundError: pyclipper（4 条）

`test_galgame_dependency_slimming` 驱动的 in-tree `deps/rapidocr_pillow` fork 在模块级 import pyclipper，而 pyclipper 只随 galgame group 安装。我本机 `.venv` 里有历史残留所以一直是绿的，干净 `uv sync` 没有 —— **也就是说这批用例此前只在"恰好装过 galgame group"的机器上跑过**。

**修法**：用例加 `skipif`（缺依赖时跳过，而不是抛 ModuleNotFoundError），同时 CI 单独装那个 ~260 KB 的 wheel。这样它们在唯一会稳定跑它们的环境里仍然**真跑**，既不用为 4 条用例装 130 MB 的 opencv，也不是干脆跳过了事。

## 3. window_pin 的 LOCALE_VERSION（1 条）

`test_pin_labels_exist_in_all_main_and_plugin_locales` 钉死了 `LOCALE_VERSION = '2026-07-22-window-pin-controls-i18n'`。#2465「Refactor memory browser UI」把它改成了 `2026-07-24-memory-browser-ui-refactor`，没同步这条断言。

**这条在 #2465 合入时就红了**，只是当时 `tests/unit` 还没进 CI，没人看见 —— 和这次分诊出的 18 条同一个成因。

**修法**：改成断言「存在一个非空的 `LOCALE_VERSION`」，locale key 的断言全部保留。钉死取值等于让每一次无关的版本串变更都打红，这次就是。

## 顺带补的护栏

`tests/unit/test_node_harness_contract.py`：

- AST **自动发现**（不是维护一份文件清单）所有直接 `subprocess` 跑 node 的地方并判红
- 钉死两个 runner 必须**强制** UTF-8 而不是 `setdefault`（后者会被调用方或 locale 反超）

命令行长度上限（#2492 修的那条）和 locale 编码（本 PR 这条）是同一类雷：**写 harness 的人在自己机器上永远看不到**，靠人记不住。

## 回归报告

- 变更与必要性：main 上新接入的 Unit Tests workflow 是红的，不修则这道闸从第一天起就形同虚设（所有人学会忽略它）。
- 修改前：CI 10 failed；本地 0 failed。
- 修改后：本地全量 6579 passed / 18 skipped / 1 xfailed；三类根因逐条对症。
- 潜在回归：`run_node_stdin` 只是把原来的 `subprocess.run([node, "-"], input=..., text=True)` 换成同形状带 UTF-8 的调用，8 个文件的断言一条没动；`skipif` 只在依赖缺席时生效，装了就照跑；LOCALE_VERSION 由钉值放宽为钉存在，locale key 覆盖面不变。
- 兼容性：无产品代码改动（全部在 tests/ 与 workflow）。

## Validation

- `uv run pytest tests/unit -q` — **6579 passed, 18 skipped, 1 xfailed**（160s）
- 迁移的 8 个 node harness 文件单独跑 — 53 passed
- 变异验证：
  1. 某个文件退回手搓 `subprocess.run` → 发现性断言转红
  2. `_utf8` 改成 `setdefault` → 强制性断言转红（`run_node_stdin` 与 `run_node_script` 两个参数化都覆盖）
- `ruff check <改动的 py 文件>` — passed
- `python scripts/check_docstring_no_cjk.py --base origin/main` — passed
- 非 UI 改动，无截图

## 说明

三类里只有第 2 类的**断言**是我在 #2492 里写错的（PR 描述里说「不需要 galgame extra」，那是拿 OCR teardown 那两条推的，没覆盖 dependency_slimming 这一批）。第 1、3 类是既有的 locale 依赖和 #2465 的漏同步，被这道新闸第一次照出来。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
