### PR TITLE
refactor(galgame): close() 复用既有日志助手；滚轮守卫按分支绑定

### DIFF
--- a/plugin/plugins/galgame_plugin/ocr_reader.py
+++ b/plugin/plugins/galgame_plugin/ocr_reader.py
@@ -376,22 +376,6 @@ class OcrReaderManager(
         repo_root = Path(__file__).resolve().parents[3]
         return (repo_root / path).resolve()
 
-    def _warn_teardown_failed(self, what: str, exc: BaseException) -> None:
-        """Best-effort warning for one failed teardown step.
-
-        The logger itself is treated as unreliable here: close() runs while the
-        plugin is being torn down, so a logger that is already gone or raising
-        must not turn one failed step into a lost one.
-        """
-        warning = getattr(getattr(self, "_logger", None), "warning", None)
-        if callable(warning):
-            try:
-                warning(f"ocr_reader {what} failed: {{}}", exc)
-            except Exception:
-                # 记日志本身失败没有下一手可用——再往上抛就会把这次收尾变成
-                # 「一个步骤没关成，剩下的也别关了」，正是本函数要避免的。
-                pass
-
     def close(self) -> None:
         # 顺序与 ocr_manager_poll.shutdown() 对偶：先停前台监听线程与 capture
         # 线程池，再释放它们可能仍在用的重依赖。两步重依赖释放原本裸奔在最前
@@ -404,15 +388,15 @@ class OcrReaderManager(
         try:
             self._stop_foreground_advance_monitor(join_timeout=1.0)
         except Exception as exc:
-            self._warn_teardown_failed("foreground advance monitor shutdown", exc)
+            self._log_warning("ocr_reader foreground advance monitor shutdown failed: {}", exc)
         try:
             self._shutdown_capture_worker()
         except Exception as exc:
-            self._warn_teardown_failed("capture worker shutdown", exc)
+            self._log_warning("ocr_reader capture worker shutdown failed: {}", exc)
         try:
             self._release_rapidocr_backend()
         except Exception as exc:
-            self._warn_teardown_failed("rapidocr backend release", exc)
+            self._log_warning("ocr_reader rapidocr backend release failed: {}", exc)
         # 引用先摘掉再 close：close 失败也不能把一个已经宣告释放的 classifier
         # 继续挂在 self 上。getattr 兜底与本文件对 _logger 的取法一致——收尾
         # 路径不该假设自己被构造完整。
@@ -423,7 +407,7 @@ class OcrReaderManager(
             try:
                 close_classifier()
             except Exception as exc:
-                self._warn_teardown_failed("vision classifier close", exc)
+                self._log_warning("ocr_reader vision classifier close failed: {}", exc)
 
     def __enter__(self) -> "OcrReaderManager":
         return self

--- a/tests/unit/test_model_wheel_hit_guard_static.py
+++ b/tests/unit/test_model_wheel_hit_guard_static.py
@@ -14,6 +14,30 @@ LIVE2D_INTERACTION = PROJECT_ROOT / "static" / "live2d" / "live2d-interaction.js
 VRM_INTERACTION = PROJECT_ROOT / "static" / "vrm" / "vrm-interaction.js"
 
 
+def _node_path() -> str:
+    node_path = shutil.which("node")
+    if not node_path:
+        # 硬失败而不是 skip：这些用例取代的是无条件运行的静态检查，若 node 从
+        # PATH 上消失就静默跳过，闸门会在没有检查过滚轮行为的情况下报绿。
+        # CI runner 自带 node（见 unit-tests.yml 的说明）。
+        raise AssertionError("node is required to run the wheel guard behaviour tests")
+    return node_path
+
+
+def _run_harness(harness: str) -> list[dict]:
+    completed = run_node_stdin(
+        _node_path(),
+        harness,
+        capture_output=True,
+        check=False,
+        timeout=20,
+    )
+    assert completed.returncode == 0, (
+        f"wheel harness failed:\n{completed.stderr or completed.stdout}"
+    )
+    return json.loads(completed.stdout)
+
+
 def _live2d_wheel_zoom_source() -> str:
     source = LIVE2D_INTERACTION.read_text(encoding="utf-8")
     start = source.index("Live2DManager.prototype.setupWheelZoom = function (model)")
@@ -21,7 +45,14 @@ def _live2d_wheel_zoom_source() -> str:
     return source[start:end]
 
 
-def _run_wheel_scenarios(scenarios: list[dict]) -> list[dict]:
+def _vrm_wheel_handler_source() -> str:
+    source = VRM_INTERACTION.read_text(encoding="utf-8")
+    start = source.index("this.wheelHandler = (e) => {")
+    end = source.index("this.auxClickHandler = (e) => {", start)
+    return source[start:end]
+
+
+def _run_live2d_wheel_scenarios(scenarios: list[dict]) -> dict[str, dict]:
     """Drive the real setupWheelZoom in node and report what each event did.
 
     Static text analysis was tried three times here and leaked every time —
@@ -33,13 +64,6 @@ def _run_wheel_scenarios(scenarios: list[dict]) -> list[dict]:
     question the file actually claims to answer: does the wheel get consumed
     when the pointer is not on the model?
     """
-    node_path = shutil.which("node")
-    if not node_path:
-        # 硬失败而不是 skip：这条用例取代的是一条无条件运行的静态检查，
-        # 若 node 从 PATH 上消失就静默跳过，闸门会在没有检查过滚轮行为的
-        # 情况下报绿。CI 的 runner 自带 node（见 unit-tests.yml 的说明）。
-        raise AssertionError("node is required to run the wheel guard behaviour test")
-
     harness = textwrap.dedent("""
         const SCALE_LIMITS = { MIN: 0.1, MAX: 10 };
         function Live2DManager() {}
@@ -49,7 +73,10 @@ def _run_wheel_scenarios(scenarios: list[dict]) -> list[dict]:
         const results = [];
 
         for (const scenario of scenarios) {
-            let registered = null;
+            // 浏览器会挨个调用同一元素上注册的每个 wheel listener，所以这里
+            // 累积全部而不是只留最后一个：只留最后一个的话，实现多注册一个
+            // 无守卫的 listener，真实页面照样吞事件，而这里会被覆盖掉。
+            const listeners = [];
             const model = {
                 getBounds: () => ({ x: 100, y: 100, width: 200, height: 200,
                                     left: 100, top: 100, right: 300, bottom: 300 }),
@@ -64,28 +91,36 @@ def _run_wheel_scenarios(scenarios: list[dict]) -> list[dict]:
                 renderer: { screen: { width: 400, height: 400 } },
                 view: {
                     getBoundingClientRect: () => ({ left: 0, top: 0, width: 400, height: 400 }),
-                    addEventListener: (type, handler) => { if (type === 'wheel') registered = handler; },
-                    removeEventListener: () => {},
+                    addEventListener: (type, handler) => {
+                        if (type === 'wheel') listeners.push(handler);
+                    },
+                    removeEventListener: (type, handler) => {
+                        const index = listeners.indexOf(handler);
+                        if (index >= 0) listeners.splice(index, 1);
+                    },
                 },
             };
 
             Live2DManager.prototype.setupWheelZoom.call(manager, model);
-            if (typeof registered !== 'function') {
+            if (listeners.length === 0) {
                 throw new Error('setupWheelZoom did not register a wheel listener');
             }
 
             let prevented = false;
-            registered({
-                clientX: scenario.x,
-                clientY: scenario.y,
-                deltaY: -100,
-                preventDefault: () => { prevented = true; },
-            });
+            for (const listener of listeners) {
+                listener({
+                    clientX: scenario.x,
+                    clientY: scenario.y,
+                    deltaY: scenario.deltaY,
+                    preventDefault: () => { prevented = true; },
+                });
+            }
 
             results.push({
                 name: scenario.name,
                 prevented,
                 zoomed: model.scale.x !== 1,
+                listeners: listeners.length,
             });
         }
 
@@ -93,55 +128,107 @@ def _run_wheel_scenarios(scenarios: list[dict]) -> list[dict]:
     """)
     harness = harness.replace("__WHEEL_ZOOM_SOURCE__", _live2d_wheel_zoom_source())
     harness = harness.replace("__SCENARIOS__", json.dumps(scenarios))
+    return {r["name"]: r for r in _run_harness(harness)}
 
-    completed = run_node_stdin(
-        node_path,
-        harness,
-        capture_output=True,
-        check=False,
-        timeout=20,
-    )
-    assert completed.returncode == 0, (
-        f"wheel harness failed:\n{completed.stderr or completed.stdout}"
-    )
-    return json.loads(completed.stdout)
+
+def _run_vrm_wheel_scenarios(scenarios: list[dict]) -> dict[str, dict]:
+    """Same treatment for the VRM handler.
+
+    It used to be checked by comparing offsets plus counting the literal string
+    ``e.preventDefault()``, which misses ``e?.preventDefault()`` — an idiom the
+    repo already uses elsewhere. Counting syntax forms is the same losing game
+    as parsing them, so this drives the handler instead.
+    """
+    harness = textwrap.dedent("""
+        const scenarios = __SCENARIOS__;
+        const results = [];
+
+        for (const scenario of scenarios) {
+            const canvasEl = { contains: (node) => node === canvasEl };
+            const scaleCalls = [];
+            const context = {
+                checkLocked: () => scenario.locked === true,
+                _hitTestModel: () => scenario.hit === true,
+                _debouncedSavePosition: () => {},
+                _wheelListenerOptions: { passive: false },
+                manager: {
+                    currentModel: { scene: { scale: { x: 1 } } },
+                    renderer: { domElement: canvasEl },
+                    _lastInteractionBoostTs: 0,
+                    _boostInteractiveFPS: () => {},
+                    setModelScaleScalar: (next) => { scaleCalls.push(next); },
+                },
+                wheelHandler: null,
+            };
+
+            (function () { __VRM_WHEEL_SOURCE__ }).call(context);
+            if (typeof context.wheelHandler !== 'function') {
+                throw new Error('wheelHandler was not assigned');
+            }
+
+            let prevented = false;
+            context.wheelHandler({
+                clientX: scenario.x,
+                clientY: scenario.y,
+                deltaY: scenario.deltaY,
+                target: scenario.offCanvas === true ? { other: true } : canvasEl,
+                preventDefault: () => { prevented = true; },
+                stopPropagation: () => {},
+            });
+
+            results.push({ name: scenario.name, prevented, zoomed: scaleCalls.length > 0 });
+        }
+
+        process.stdout.write(JSON.stringify(results));
+    """)
+    harness = harness.replace("__VRM_WHEEL_SOURCE__", _vrm_wheel_handler_source())
+    harness = harness.replace("__SCENARIOS__", json.dumps(scenarios))
+    return {r["name"]: r for r in _run_harness(harness)}
+
+
+def _both_directions(base: dict) -> list[dict]:
+    """Same scenario scrolled up and down.
+
+    A guard that only covers one sign still reads as correct otherwise: e.g.
+    ``if (event.deltaY > 0) event.preventDefault()`` ahead of the hit test
+    swallows off-model wheel-down while every upward assertion stays green.
+    """
+    return [
+        {**base, "name": f"{base['name']}_up", "deltaY": -100},
+        {**base, "name": f"{base['name']}_down", "deltaY": 100},
+    ]
 
 
 @pytest.mark.unit
 def test_live2d_wheel_zoom_requires_model_hit_before_consuming_event():
     """Off-model wheel events must reach the page; on-model ones must not."""
-    results = {
-        r["name"]: r
-        for r in _run_wheel_scenarios([
-            # 模型盒是 canvas 上的 100..300；中心点必然命中，远角必然不命中。
-            {"name": "on_model", "x": 200, "y": 200},
-            {"name": "off_model", "x": 20, "y": 20},
-            {"name": "on_model_peek", "x": 200, "y": 200, "peek": True},
-            # 探身分支必须同样以命中为前提：只测 on-model 的话，把该分支改成
-            # 无条件 preventDefault 仍能满足全部断言（实测过）。
-            {"name": "off_model_peek", "x": 20, "y": 20, "peek": True},
-            {"name": "locked", "x": 200, "y": 200, "locked": True},
-        ])
-    }
-
-    assert results["off_model"]["prevented"] is False, (
-        "指针不在模型上时吞掉滚轮，页面就滚不动了"
+    # 模型盒是 canvas 上的 100..300；中心点必然命中，远角必然不命中。
+    scenarios = (
+        _both_directions({"name": "on_model", "x": 200, "y": 200})
+        + _both_directions({"name": "off_model", "x": 20, "y": 20})
+        + _both_directions({"name": "on_model_peek", "x": 200, "y": 200, "peek": True})
+        # 探身分支必须同样以命中为前提：只测 on-model 的话，把该分支改成
+        # 无条件 preventDefault 仍能满足全部断言（实测过）。
+        + _both_directions({"name": "off_model_peek", "x": 20, "y": 20, "peek": True})
+        + _both_directions({"name": "locked", "x": 200, "y": 200, "locked": True})
     )
-    assert results["off_model"]["zoomed"] is False
+    results = _run_live2d_wheel_scenarios(scenarios)
 
-    assert results["on_model"]["prevented"] is True, "命中模型必须消费掉滚轮"
-    assert results["on_model"]["zoomed"] is True, "命中模型必须真的缩放"
-
-    # 挂边探身（#2253）：吞掉滚轮但不缩放，且这一步同样以命中检查为前提。
-    assert results["on_model_peek"]["prevented"] is True
-    assert results["on_model_peek"]["zoomed"] is False
-    assert results["off_model_peek"]["prevented"] is False, (
-        "探身态下指针不在模型上，滚轮同样不该被吞掉"
-    )
-    assert results["off_model_peek"]["zoomed"] is False
-
-    assert results["locked"]["prevented"] is False
-    assert results["locked"]["zoomed"] is False
+    for direction in ("up", "down"):
+        assert results[f"off_model_{direction}"]["prevented"] is False, (
+            f"指针不在模型上时吞掉滚轮（{direction}），页面就滚不动了"
+        )
+        assert results[f"off_model_{direction}"]["zoomed"] is False
+        # 挂边探身（#2253）同样以命中为前提。
+        assert results[f"off_model_peek_{direction}"]["prevented"] is False
+        assert results[f"off_model_peek_{direction}"]["zoomed"] is False
+        assert results[f"on_model_{direction}"]["prevented"] is True, "命中模型必须消费掉滚轮"
+        assert results[f"on_model_{direction}"]["zoomed"] is True, "命中模型必须真的缩放"
+        # 探身态：吞事件但不缩放。
+        assert results[f"on_model_peek_{direction}"]["prevented"] is True
+        assert results[f"on_model_peek_{direction}"]["zoomed"] is False
+        assert results[f"locked_{direction}"]["prevented"] is False
+        assert results[f"locked_{direction}"]["zoomed"] is False
 
 
 @pytest.mark.unit
@@ -161,20 +248,31 @@ def test_live2d_wheel_hit_test_uses_canvas_relative_coordinates():
 
 @pytest.mark.unit
 def test_vrm_wheel_zoom_requires_model_hit_before_consuming_event():
-    # VRM 侧只有一个 preventDefault，且守卫是同一层的早退，顺序比较足够表达
-    # 该不变量；live2d 那边换成行为验证是因为它有两条消费路径（缩放 + 挂边
-    # 探身），静态判定要区分它们就得真的解析 JS。
-    source = VRM_INTERACTION.read_text(encoding="utf-8")
-    start = source.index("this.wheelHandler = (e) => {")
-    end = source.index("this.auxClickHandler = (e) => {", start)
-    block = source[start:end]
-
-    hit_guard = re.search(r"if\s*\(!this\._hitTestModel\(e\.clientX,\s*e\.clientY\)\)\s*{", block)
-    assert hit_guard
-    guard_index = hit_guard.start()
-    prevent_index = re.search(r"e\.preventDefault\(\);", block).start()
-    scale_index = re.search(r"const\s+scaleFactor\s*=\s*e\.deltaY\s*>\s*0\s*\?\s*0\.95\s*:\s*1\.05;", block).start()
-    assert guard_index < prevent_index < scale_index
-    assert block.count("e.preventDefault()") == 1, (
-        "VRM handler 出现了第二个消费点，顺序比较不再足够，改走行为验证"
+    scenarios = (
+        _both_directions({"name": "on_model", "x": 200, "y": 200, "hit": True})
+        + _both_directions({"name": "off_model", "x": 20, "y": 20})
+        + _both_directions({"name": "off_canvas", "x": 200, "y": 200, "hit": True,
+                            "offCanvas": True})
+        + _both_directions({"name": "locked", "x": 200, "y": 200, "hit": True,
+                            "locked": True})
     )
+    results = _run_vrm_wheel_scenarios(scenarios)
+
+    for direction in ("up", "down"):
+        assert results[f"off_model_{direction}"]["prevented"] is False, (
+            f"未命中模型时吞掉滚轮（{direction}）"
+        )
+        assert results[f"off_model_{direction}"]["zoomed"] is False
+        # 事件不在 canvas 上时必须完全放行，否则聊天区滚不动。
+        assert results[f"off_canvas_{direction}"]["prevented"] is False
+        assert results[f"off_canvas_{direction}"]["zoomed"] is False
+        assert results[f"locked_{direction}"]["prevented"] is False
+        assert results[f"on_model_{direction}"]["prevented"] is True
+        assert results[f"on_model_{direction}"]["zoomed"] is True
+
+
+@pytest.mark.unit
+def test_vrm_wheel_hit_test_uses_client_coordinates():
+    """Dual of the live2d mechanism check: the stubbed hit test hides this."""
+    block = _vrm_wheel_handler_source()
+    assert "this._hitTestModel(e.clientX, e.clientY)" in block

--- a/tests/unit/test_model_wheel_hit_guard_static.py
+++ b/tests/unit/test_model_wheel_hit_guard_static.py
@@ -1,111 +1,159 @@
+import json
 import re
+import shutil
+import textwrap
 from pathlib import Path
+
+import pytest
+
+from tests.node_harness import run_node_stdin
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 LIVE2D_INTERACTION = PROJECT_ROOT / "static" / "live2d" / "live2d-interaction.js"
 VRM_INTERACTION = PROJECT_ROOT / "static" / "vrm" / "vrm-interaction.js"
 
-_TOKENS = re.compile(
-    r"(?P<positive_guard>if\s*\(\s*isWheelPointOnCurrentModel\(event\)\s*\)\s*(?=\{))"
-    r"|(?P<early_return>if\s*\(\s*!\s*isWheelPointOnCurrentModel\(event\)\s*\)\s*return;)"
-    r"|(?P<consume>event\.preventDefault\(\);)"
-    r"|(?P<open>\{)"
-    r"|(?P<close>\})"
-)
-_COMMENTS_AND_STRINGS = re.compile(
-    r"//[^\n]*|/\*.*?\*/|'(?:\\.|[^'\\])*'|\"(?:\\.|[^\"\\])*\"|`(?:\\.|[^`\\])*`",
-    re.S,
-)
 
-
-def _blank_out_noise(block: str) -> str:
-    """Blank comments and string literals, preserving offsets.
-
-    Braces inside them are not block structure; counting them would desync the
-    scope stack below.
-    """
-    return _COMMENTS_AND_STRINGS.sub(lambda m: " " * len(m.group(0)), block)
-
-
-def _unguarded_prevent_defaults(block: str) -> tuple[int, list[str]]:
-    """Find preventDefault calls that no hit check actually controls.
-
-    Three weaker shapes were tried and each admitted a real regression:
-
-    * "some hit check appears earlier in the text" — the peek branch's own
-      check sits in a nested block and governs nothing once that block closes,
-      so a consume added after it still read as guarded.
-    * per-line brace depth — ``} else {`` nets to zero, leaving the positive
-      guard's depth in scope, so ``if (hit) {...} else { consume }`` read as
-      guarded even though the else branch runs exactly when the hit test fails.
-    * registering a line's guards before scanning it for consumes — the order
-      within a line was lost, so ``consume; if (!hit) return;`` read as guarded
-      despite consuming before testing.
-
-    So walk the tokens in source order over a real scope stack: a consume is
-    guarded only if some enclosing scope was opened by a positive hit check, or
-    an early-return guard has already fired in a scope still on the stack.
-    """
-    scrubbed = _blank_out_noise(block)
-    # 栈里每层记 (是否由正向命中检查开出, 该层是否已经过早退守卫)
-    scopes: list[dict[str, bool]] = [{"guarded": False, "early_returned": False}]
-    pending_guarded_open = False
-    total = 0
-    unguarded: list[str] = []
-
-    for match in _TOKENS.finditer(scrubbed):
-        kind = match.lastgroup
-        if kind == "positive_guard":
-            pending_guarded_open = True
-        elif kind == "early_return":
-            scopes[-1]["early_returned"] = True
-        elif kind == "open":
-            scopes.append({"guarded": pending_guarded_open, "early_returned": False})
-            pending_guarded_open = False
-        elif kind == "close":
-            if len(scopes) > 1:
-                scopes.pop()
-        elif kind == "consume":
-            total += 1
-            covered = any(s["guarded"] or s["early_returned"] for s in scopes)
-            if not covered:
-                lineno = scrubbed.count("\n", 0, match.start()) + 1
-                unguarded.append(f"line {lineno}: {block.splitlines()[lineno - 1].strip()}")
-
-    return total, unguarded
-
-
-def test_live2d_wheel_zoom_requires_model_hit_before_consuming_event():
+def _live2d_wheel_zoom_source() -> str:
     source = LIVE2D_INTERACTION.read_text(encoding="utf-8")
     start = source.index("Live2DManager.prototype.setupWheelZoom = function (model)")
     end = source.index("// 设置触摸缩放", start)
-    block = source[start:end]
+    return source[start:end]
 
+
+def _run_wheel_scenarios(scenarios: list[dict]) -> list[dict]:
+    """Drive the real setupWheelZoom in node and report what each event did.
+
+    Static text analysis was tried three times here and leaked every time —
+    per-line brace depth missed ``} else {``, registering a line's guards
+    before scanning it missed ``consume; if (!hit) return;``, and a regex-based
+    scrubber still had to keep up with comments, strings, regex literals and
+    automatic semicolon insertion.  That is a JavaScript parser, and a
+    half-written one reads as a passing guard.  Running the handler answers the
+    question the file actually claims to answer: does the wheel get consumed
+    when the pointer is not on the model?
+    """
+    node_path = shutil.which("node")
+    if not node_path:
+        pytest.skip("node is required for the wheel guard behaviour test")
+
+    harness = textwrap.dedent("""
+        const SCALE_LIMITS = { MIN: 0.1, MAX: 10 };
+        function Live2DManager() {}
+        __WHEEL_ZOOM_SOURCE__
+
+        const scenarios = __SCENARIOS__;
+        const results = [];
+
+        for (const scenario of scenarios) {
+            let registered = null;
+            const model = {
+                getBounds: () => ({ x: 100, y: 100, width: 200, height: 200,
+                                    left: 100, top: 100, right: 300, bottom: 300 }),
+                scale: { x: 1, set(next) { this.x = next; } },
+            };
+            const manager = new Live2DManager();
+            manager.isLocked = scenario.locked === true;
+            manager.currentModel = model;
+            manager.isLive2DPeekActive = () => scenario.peek === true;
+            manager._debouncedSnapCheck = () => {};
+            manager.pixi_app = {
+                renderer: { screen: { width: 400, height: 400 } },
+                view: {
+                    getBoundingClientRect: () => ({ left: 0, top: 0, width: 400, height: 400 }),
+                    addEventListener: (type, handler) => { if (type === 'wheel') registered = handler; },
+                    removeEventListener: () => {},
+                },
+            };
+
+            Live2DManager.prototype.setupWheelZoom.call(manager, model);
+            if (typeof registered !== 'function') {
+                throw new Error('setupWheelZoom did not register a wheel listener');
+            }
+
+            let prevented = false;
+            registered({
+                clientX: scenario.x,
+                clientY: scenario.y,
+                deltaY: -100,
+                preventDefault: () => { prevented = true; },
+            });
+
+            results.push({
+                name: scenario.name,
+                prevented,
+                zoomed: model.scale.x !== 1,
+            });
+        }
+
+        process.stdout.write(JSON.stringify(results));
+    """)
+    harness = harness.replace("__WHEEL_ZOOM_SOURCE__", _live2d_wheel_zoom_source())
+    harness = harness.replace("__SCENARIOS__", json.dumps(scenarios))
+
+    completed = run_node_stdin(
+        node_path,
+        harness,
+        capture_output=True,
+        check=False,
+        timeout=20,
+    )
+    assert completed.returncode == 0, (
+        f"wheel harness failed:\n{completed.stderr or completed.stdout}"
+    )
+    return json.loads(completed.stdout)
+
+
+@pytest.mark.unit
+def test_live2d_wheel_zoom_requires_model_hit_before_consuming_event():
+    """Off-model wheel events must reach the page; on-model ones must not."""
+    results = {
+        r["name"]: r
+        for r in _run_wheel_scenarios([
+            # 模型盒是 canvas 上的 100..300；中心点必然命中，远角必然不命中。
+            {"name": "on_model", "x": 200, "y": 200},
+            {"name": "off_model", "x": 20, "y": 20},
+            {"name": "on_model_peek", "x": 200, "y": 200, "peek": True},
+            {"name": "locked", "x": 200, "y": 200, "locked": True},
+        ])
+    }
+
+    assert results["off_model"]["prevented"] is False, (
+        "指针不在模型上时吞掉滚轮，页面就滚不动了"
+    )
+    assert results["off_model"]["zoomed"] is False
+
+    assert results["on_model"]["prevented"] is True, "命中模型必须消费掉滚轮"
+    assert results["on_model"]["zoomed"] is True, "命中模型必须真的缩放"
+
+    # 挂边探身（#2253）：吞掉滚轮但不缩放，且这一步同样以命中检查为前提。
+    assert results["on_model_peek"]["prevented"] is True
+    assert results["on_model_peek"]["zoomed"] is False
+
+    assert results["locked"]["prevented"] is False
+    assert results["locked"]["zoomed"] is False
+
+
+@pytest.mark.unit
+def test_live2d_wheel_hit_test_uses_canvas_relative_coordinates():
+    """Pin the mechanism the behaviour test cannot see from outside.
+
+    Reading the hit point off the canvas rect (rather than raw client
+    coordinates) is what keeps the check correct once the canvas is offset or
+    scaled; a regression there still passes a centred-canvas simulation.
+    """
+    block = _live2d_wheel_zoom_source()
     assert re.search(r"const\s+isWheelPointOnCurrentModel\s*=\s*\(event\)\s*=>\s*{", block)
     assert re.search(r"getBoundingClientRect\s*\(\)", block)
     assert re.search(r"event\.clientX\s*-\s*canvasRect\.left", block)
     assert re.search(r"event\.clientY\s*-\s*canvasRect\.top", block)
-    # 逐个消费点按「归它管的那个分支」判定，而不是拿首个 preventDefault 当
-    # "那一个"，也不是只比全文偏移：#2253 的挂边探身分支在缩放路径之前自带
-    # 一个 preventDefault（它自己在命中检查里面），首匹配写法会误判成守卫
-    # 失效；而只看"前面出现过命中检查"又会放过一个新加在探身块之后、早退
-    # 守卫之前的裸消费点——两种写法都比这条用例声称的主张弱。
-    total_prevents, unguarded = _unguarded_prevent_defaults(block)
-    assert total_prevents, "找不到任何 preventDefault，切片或实现已变"
-    assert not unguarded, (
-        f"这些 preventDefault 不在任何命中检查管辖的分支里，滚轮会在模型外被吞掉: {unguarded}"
-    )
-    prevent_sites = [m.start() for m in re.finditer(r"event\.preventDefault\(\);", block)]
-    guard_index = re.search(r"if\s*\(!isWheelPointOnCurrentModel\(event\)\)\s*return;", block).start()
-    scale_index = re.search(r"this\.currentModel\.scale\.set\(newScale\);", block).start()
-    assert guard_index < scale_index
-    assert any(guard_index < site < scale_index for site in prevent_sites), (
-        "缩放路径自己那一次 preventDefault 必须夹在早退守卫与 scale.set 之间"
-    )
 
 
+@pytest.mark.unit
 def test_vrm_wheel_zoom_requires_model_hit_before_consuming_event():
+    # VRM 侧只有一个 preventDefault，且守卫是同一层的早退，顺序比较足够表达
+    # 该不变量；live2d 那边换成行为验证是因为它有两条消费路径（缩放 + 挂边
+    # 探身），静态判定要区分它们就得真的解析 JS。
     source = VRM_INTERACTION.read_text(encoding="utf-8")
     start = source.index("this.wheelHandler = (e) => {")
     end = source.index("this.auxClickHandler = (e) => {", start)
@@ -117,3 +165,6 @@ def test_vrm_wheel_zoom_requires_model_hit_before_consuming_event():
     prevent_index = re.search(r"e\.preventDefault\(\);", block).start()
     scale_index = re.search(r"const\s+scaleFactor\s*=\s*e\.deltaY\s*>\s*0\s*\?\s*0\.95\s*:\s*1\.05;", block).start()
     assert guard_index < prevent_index < scale_index
+    assert block.count("e.preventDefault()") == 1, (
+        "VRM handler 出现了第二个消费点，顺序比较不再足够，改走行为验证"
+    )

--- a/tests/unit/test_model_wheel_hit_guard_static.py
+++ b/tests/unit/test_model_wheel_hit_guard_static.py
@@ -6,6 +6,51 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 LIVE2D_INTERACTION = PROJECT_ROOT / "static" / "live2d" / "live2d-interaction.js"
 VRM_INTERACTION = PROJECT_ROOT / "static" / "vrm" / "vrm-interaction.js"
 
+_POSITIVE_GUARD_OPEN = re.compile(r"if\s*\(\s*isWheelPointOnCurrentModel\(event\)\s*\)\s*\{")
+_EARLY_RETURN_GUARD = re.compile(r"if\s*\(\s*!\s*isWheelPointOnCurrentModel\(event\)\s*\)\s*return;")
+
+
+def _unguarded_prevent_defaults(block: str) -> tuple[int, list[str]]:
+    """Find preventDefault calls that no hit check actually controls.
+
+    Comparing raw offsets ("some hit check appears earlier in the text") is
+    weaker than the invariant this file claims: the peek branch's own check
+    sits inside a nested block and governs nothing after that block closes, so
+    a new unguarded consume placed after it would still read as guarded.  Track
+    brace depth instead and only count a call as guarded when it sits inside a
+    block opened by a positive check, or after an early-return guard in an
+    enclosing scope.
+    """
+    depth = 0
+    guarded_depths: set[int] = set()
+    early_return_depths: set[int] = set()
+    total = 0
+    unguarded: list[str] = []
+
+    for lineno, raw in enumerate(block.split("\n"), start=1):
+        line = raw.strip()
+        opens_guard = bool(_POSITIVE_GUARD_OPEN.search(line))
+        if opens_guard:
+            guarded_depths.add(depth + 1)
+        if _EARLY_RETURN_GUARD.search(line):
+            early_return_depths.add(depth)
+
+        if "event.preventDefault();" in line:
+            total += 1
+            effective_depth = depth + 1 if opens_guard else depth
+            covered = any(d <= effective_depth for d in early_return_depths) or any(
+                d <= effective_depth for d in guarded_depths
+            )
+            if not covered:
+                unguarded.append(f"line {lineno}: {line}")
+
+        depth += line.count("{") - line.count("}")
+        # 退出某层后，该层及更深处立下的守卫不再覆盖后续代码。
+        guarded_depths = {d for d in guarded_depths if d <= depth}
+        early_return_depths = {d for d in early_return_depths if d <= depth}
+
+    return total, unguarded
+
 
 def test_live2d_wheel_zoom_requires_model_hit_before_consuming_event():
     source = LIVE2D_INTERACTION.read_text(encoding="utf-8")
@@ -17,16 +62,17 @@ def test_live2d_wheel_zoom_requires_model_hit_before_consuming_event():
     assert re.search(r"getBoundingClientRect\s*\(\)", block)
     assert re.search(r"event\.clientX\s*-\s*canvasRect\.left", block)
     assert re.search(r"event\.clientY\s*-\s*canvasRect\.top", block)
-    # 逐个消费点判定，而不是拿首个 preventDefault 当"那一个"：#2253 的挂边
-    # 探身分支在缩放路径之前自带一个 preventDefault（它自己也在命中检查里面），
-    # 首匹配写法会误判成守卫失效——测试比它声称的主张更弱。
-    hit_checks = [m.start() for m in re.finditer(r"isWheelPointOnCurrentModel\(event\)", block)]
+    # 逐个消费点按「归它管的那个分支」判定，而不是拿首个 preventDefault 当
+    # "那一个"，也不是只比全文偏移：#2253 的挂边探身分支在缩放路径之前自带
+    # 一个 preventDefault（它自己在命中检查里面），首匹配写法会误判成守卫
+    # 失效；而只看"前面出现过命中检查"又会放过一个新加在探身块之后、早退
+    # 守卫之前的裸消费点——两种写法都比这条用例声称的主张弱。
+    total_prevents, unguarded = _unguarded_prevent_defaults(block)
+    assert total_prevents, "找不到任何 preventDefault，切片或实现已变"
+    assert not unguarded, (
+        f"这些 preventDefault 不在任何命中检查管辖的分支里，滚轮会在模型外被吞掉: {unguarded}"
+    )
     prevent_sites = [m.start() for m in re.finditer(r"event\.preventDefault\(\);", block)]
-    assert prevent_sites, "找不到任何 preventDefault，切片或实现已变"
-    for site in prevent_sites:
-        assert any(check < site for check in hit_checks), (
-            f"offset {site} 处的 preventDefault 前面没有命中检查，滚轮会在模型外被吞掉"
-        )
     guard_index = re.search(r"if\s*\(!isWheelPointOnCurrentModel\(event\)\)\s*return;", block).start()
     scale_index = re.search(r"this\.currentModel\.scale\.set\(newScale\);", block).start()
     assert guard_index < scale_index

--- a/tests/unit/test_model_wheel_hit_guard_static.py
+++ b/tests/unit/test_model_wheel_hit_guard_static.py
@@ -6,48 +6,72 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 LIVE2D_INTERACTION = PROJECT_ROOT / "static" / "live2d" / "live2d-interaction.js"
 VRM_INTERACTION = PROJECT_ROOT / "static" / "vrm" / "vrm-interaction.js"
 
-_POSITIVE_GUARD_OPEN = re.compile(r"if\s*\(\s*isWheelPointOnCurrentModel\(event\)\s*\)\s*\{")
-_EARLY_RETURN_GUARD = re.compile(r"if\s*\(\s*!\s*isWheelPointOnCurrentModel\(event\)\s*\)\s*return;")
+_TOKENS = re.compile(
+    r"(?P<positive_guard>if\s*\(\s*isWheelPointOnCurrentModel\(event\)\s*\)\s*(?=\{))"
+    r"|(?P<early_return>if\s*\(\s*!\s*isWheelPointOnCurrentModel\(event\)\s*\)\s*return;)"
+    r"|(?P<consume>event\.preventDefault\(\);)"
+    r"|(?P<open>\{)"
+    r"|(?P<close>\})"
+)
+_COMMENTS_AND_STRINGS = re.compile(
+    r"//[^\n]*|/\*.*?\*/|'(?:\\.|[^'\\])*'|\"(?:\\.|[^\"\\])*\"|`(?:\\.|[^`\\])*`",
+    re.S,
+)
+
+
+def _blank_out_noise(block: str) -> str:
+    """Blank comments and string literals, preserving offsets.
+
+    Braces inside them are not block structure; counting them would desync the
+    scope stack below.
+    """
+    return _COMMENTS_AND_STRINGS.sub(lambda m: " " * len(m.group(0)), block)
 
 
 def _unguarded_prevent_defaults(block: str) -> tuple[int, list[str]]:
     """Find preventDefault calls that no hit check actually controls.
 
-    Comparing raw offsets ("some hit check appears earlier in the text") is
-    weaker than the invariant this file claims: the peek branch's own check
-    sits inside a nested block and governs nothing after that block closes, so
-    a new unguarded consume placed after it would still read as guarded.  Track
-    brace depth instead and only count a call as guarded when it sits inside a
-    block opened by a positive check, or after an early-return guard in an
-    enclosing scope.
+    Three weaker shapes were tried and each admitted a real regression:
+
+    * "some hit check appears earlier in the text" — the peek branch's own
+      check sits in a nested block and governs nothing once that block closes,
+      so a consume added after it still read as guarded.
+    * per-line brace depth — ``} else {`` nets to zero, leaving the positive
+      guard's depth in scope, so ``if (hit) {...} else { consume }`` read as
+      guarded even though the else branch runs exactly when the hit test fails.
+    * registering a line's guards before scanning it for consumes — the order
+      within a line was lost, so ``consume; if (!hit) return;`` read as guarded
+      despite consuming before testing.
+
+    So walk the tokens in source order over a real scope stack: a consume is
+    guarded only if some enclosing scope was opened by a positive hit check, or
+    an early-return guard has already fired in a scope still on the stack.
     """
-    depth = 0
-    guarded_depths: set[int] = set()
-    early_return_depths: set[int] = set()
+    scrubbed = _blank_out_noise(block)
+    # 栈里每层记 (是否由正向命中检查开出, 该层是否已经过早退守卫)
+    scopes: list[dict[str, bool]] = [{"guarded": False, "early_returned": False}]
+    pending_guarded_open = False
     total = 0
     unguarded: list[str] = []
 
-    for lineno, raw in enumerate(block.split("\n"), start=1):
-        line = raw.strip()
-        opens_guard = bool(_POSITIVE_GUARD_OPEN.search(line))
-        if opens_guard:
-            guarded_depths.add(depth + 1)
-        if _EARLY_RETURN_GUARD.search(line):
-            early_return_depths.add(depth)
-
-        if "event.preventDefault();" in line:
+    for match in _TOKENS.finditer(scrubbed):
+        kind = match.lastgroup
+        if kind == "positive_guard":
+            pending_guarded_open = True
+        elif kind == "early_return":
+            scopes[-1]["early_returned"] = True
+        elif kind == "open":
+            scopes.append({"guarded": pending_guarded_open, "early_returned": False})
+            pending_guarded_open = False
+        elif kind == "close":
+            if len(scopes) > 1:
+                scopes.pop()
+        elif kind == "consume":
             total += 1
-            effective_depth = depth + 1 if opens_guard else depth
-            covered = any(d <= effective_depth for d in early_return_depths) or any(
-                d <= effective_depth for d in guarded_depths
-            )
+            covered = any(s["guarded"] or s["early_returned"] for s in scopes)
             if not covered:
-                unguarded.append(f"line {lineno}: {line}")
-
-        depth += line.count("{") - line.count("}")
-        # 退出某层后，该层及更深处立下的守卫不再覆盖后续代码。
-        guarded_depths = {d for d in guarded_depths if d <= depth}
-        early_return_depths = {d for d in early_return_depths if d <= depth}
+                lineno = scrubbed.count("\n", 0, match.start()) + 1
+                unguarded.append(f"line {lineno}: {block.splitlines()[lineno - 1].strip()}")
 
     return total, unguarded
 

--- a/tests/unit/test_model_wheel_hit_guard_static.py
+++ b/tests/unit/test_model_wheel_hit_guard_static.py
@@ -35,7 +35,10 @@ def _run_wheel_scenarios(scenarios: list[dict]) -> list[dict]:
     """
     node_path = shutil.which("node")
     if not node_path:
-        pytest.skip("node is required for the wheel guard behaviour test")
+        # 硬失败而不是 skip：这条用例取代的是一条无条件运行的静态检查，
+        # 若 node 从 PATH 上消失就静默跳过，闸门会在没有检查过滚轮行为的
+        # 情况下报绿。CI 的 runner 自带 node（见 unit-tests.yml 的说明）。
+        raise AssertionError("node is required to run the wheel guard behaviour test")
 
     harness = textwrap.dedent("""
         const SCALE_LIMITS = { MIN: 0.1, MAX: 10 };
@@ -114,6 +117,9 @@ def test_live2d_wheel_zoom_requires_model_hit_before_consuming_event():
             {"name": "on_model", "x": 200, "y": 200},
             {"name": "off_model", "x": 20, "y": 20},
             {"name": "on_model_peek", "x": 200, "y": 200, "peek": True},
+            # 探身分支必须同样以命中为前提：只测 on-model 的话，把该分支改成
+            # 无条件 preventDefault 仍能满足全部断言（实测过）。
+            {"name": "off_model_peek", "x": 20, "y": 20, "peek": True},
             {"name": "locked", "x": 200, "y": 200, "locked": True},
         ])
     }
@@ -129,6 +135,10 @@ def test_live2d_wheel_zoom_requires_model_hit_before_consuming_event():
     # 挂边探身（#2253）：吞掉滚轮但不缩放，且这一步同样以命中检查为前提。
     assert results["on_model_peek"]["prevented"] is True
     assert results["on_model_peek"]["zoomed"] is False
+    assert results["off_model_peek"]["prevented"] is False, (
+        "探身态下指针不在模型上，滚轮同样不该被吞掉"
+    )
+    assert results["off_model_peek"]["zoomed"] is False
 
     assert results["locked"]["prevented"] is False
     assert results["locked"]["zoomed"] is False


### PR DESCRIPTION
> 基于 #2496（那个 PR 修的是 main 上 Unit Tests 的红），base 指向它的分支，只看本 PR 的 2 个文件即可；#2496 合入后 GitHub 会自动改基到 main。

## Summary

两条针对 #2492 已合入代码的评审跟进，都来自 CodeRabbit。

## 1. `close()` 复用既有 `_log_warning`，删掉重复的手搓版本

`OcrReaderManager` 继承的 `TextMixin` 早就有 `_log_warning(message, *args)`，语义和我在 #2492 里手搓的 `_warn_teardown_failed` 完全重合 —— 取 `self._logger`、调不到就算了、调用抛错再用 `repr` 过的参数重试一次、还失败就放弃（比我那版多一层兜底）。

删掉自己那份，四处改调 `_log_warning`，消息形态与改动前一致（`"ocr_reader ... failed: {}"` + exc）。

## 2. 滚轮守卫按分支绑定，不再只比全文偏移

`test_model_wheel_hit_guard_static` 原来的判据是「这个 `preventDefault` 前面出现过命中检查」。**这比它声称的不变量弱**：探身分支的命中检查在嵌套块里，管不到该块之后的代码，所以一个新加在探身块之后、早退守卫之前的裸 `preventDefault` 照样能过。

实测确认了这个洞：把那样一行插进 `onWheelScroll`，**旧断言 2 passed**。

改为按大括号深度判定每个消费点归哪个分支管 —— 要么在正向命中检查开的块里，要么在外层早退守卫之后。

## 回归报告

- 变更与必要性：一处是重复实现（同一语义两份代码，其中一份还少一层兜底），一处是护栏断言弱于其主张，后者会放过真正的回归。
- 修改前：`_warn_teardown_failed` 与 `_log_warning` 并存；滚轮断言只比偏移。
- 修改后：teardown 走 mixin 的统一日志路径；滚轮断言按分支归属判定。
- 潜在回归：`_log_warning` 在 `self._logger` 缺失/抛错时同样静默返回，`close()` 的「一步失败不带走其余」语义不变，`test_galgame_ocr_capture_worker` 10 条全绿（含 `_ExplodingLogger` 那条）。滚轮改动只动测试。
- 兼容性：无配置/协议/前端契约变化。

## Validation

- `uv run pytest tests/unit/test_model_wheel_hit_guard_static.py tests/unit/test_galgame_ocr_capture_worker.py tests/unit/test_window_pin_static_contracts.py -q` — 19 passed
- `uv run pytest plugin/tests -q -k ocr` — 498 passed
- 变异验证：
  1. 在探身块之后插一行裸 `preventDefault`（旧断言放行的那种）→ 转红
  2. 删掉缩放路径的早退守卫 → 转红
- `python scripts/check_docstring_no_cjk.py --base origin/main` — passed
- 非 UI 改动，无截图

🤖 Generated with [Claude Code](https://claude.com/claude-code)
