### PR TITLE
修复首次启动时七日教程状态初始化与页面配置互相等待的问题，确保教程及主页模型正常载入，并补充回归测试

### DIFF
--- a/static/tutorial-seven-day-state.test.cjs
+++ b/static/tutorial-seven-day-state.test.cjs
@@ -34,7 +34,12 @@ function createJsonResponse(payload, status = 200) {
     };
 }
 
-function loadBrowserStateApi({ storage, fetch, storageBarrier = Promise.resolve() }) {
+function loadBrowserStateApi({
+    storage,
+    fetch,
+    storageBarrier = Promise.resolve(),
+    mutationSecurity = null,
+}) {
     const window = {
         document: {},
         location: { origin: 'http://localhost:48911' },
@@ -42,6 +47,7 @@ function loadBrowserStateApi({ storage, fetch, storageBarrier = Promise.resolve(
         fetch,
         console,
         __nekoStorageLocationStartupBarrier: storageBarrier,
+        nekoLocalMutationSecurity: mutationSecurity,
     };
     vm.runInNewContext(stateSource, {
         window,
@@ -371,6 +377,47 @@ test('mutations are queued to the authoritative store after initial synchronizat
 
     assert.deepEqual(Array.from(writes.at(-1).completedRounds), [1]);
     assert.deepEqual(Array.from(writes.at(-1).skippedRounds), [2]);
+});
+
+test('first authoritative state creation does not wait on pageConfigReady mutation helper', async () => {
+    const requests = [];
+    const fetch = async (url, options = {}) => {
+        requests.push({ url, options });
+        if (url === stateApi.SERVER_STATE_ENDPOINT && options.method === 'PUT') {
+            const body = JSON.parse(options.body);
+            return createJsonResponse({
+                ok: true,
+                initialized: true,
+                revision: 1,
+                state: body.state,
+            });
+        }
+        if (url === stateApi.SERVER_STATE_ENDPOINT) {
+            return createJsonResponse({ ok: true, initialized: false, revision: 0, state: null });
+        }
+        if (url === '/api/config/page_config') {
+            return createJsonResponse({ autostart_csrf_token: 'first-run-token' });
+        }
+        return createJsonResponse({}, 404);
+    };
+    const browserApi = loadBrowserStateApi({
+        storage: createMemoryStorage(),
+        fetch,
+        mutationSecurity: {
+            peekCachedToken() {
+                return '';
+            },
+            getMutationHeaders() {
+                return new Promise(() => {});
+            },
+        },
+    });
+
+    await browserApi.ready();
+
+    const putRequest = requests.find(item => item.options.method === 'PUT');
+    assert.ok(putRequest);
+    assert.equal(putRequest.options.headers['X-CSRF-Token'], 'first-run-token');
 });
 
 test('a reset made during startup wins over the initial authoritative read', async () => {

--- a/static/tutorial-seven-day-state.test.cjs
+++ b/static/tutorial-seven-day-state.test.cjs
@@ -381,6 +381,7 @@ test('mutations are queued to the authoritative store after initial synchronizat
 
 test('first authoritative state creation does not wait on pageConfigReady mutation helper', async () => {
     const requests = [];
+    let getMutationHeadersCalls = 0;
     const fetch = async (url, options = {}) => {
         requests.push({ url, options });
         if (url === stateApi.SERVER_STATE_ENDPOINT && options.method === 'PUT') {
@@ -408,16 +409,40 @@ test('first authoritative state creation does not wait on pageConfigReady mutati
                 return '';
             },
             getMutationHeaders() {
+                getMutationHeadersCalls += 1;
                 return new Promise(() => {});
             },
         },
     });
 
-    await browserApi.ready();
+    let timeoutId;
+    try {
+        await Promise.race([
+            browserApi.ready(),
+            new Promise((_, reject) => {
+                timeoutId = setTimeout(
+                    () => reject(new Error('first-run state creation must not wait for mutation helper')),
+                    1000,
+                );
+            }),
+        ]);
+    } finally {
+        clearTimeout(timeoutId);
+    }
 
     const putRequest = requests.find(item => item.options.method === 'PUT');
     assert.ok(putRequest);
     assert.equal(putRequest.options.headers['X-CSRF-Token'], 'first-run-token');
+    assert.equal(getMutationHeadersCalls, 0);
+
+    browserApi.markRoundOutcome(1, 'complete');
+    await browserApi.flush();
+
+    const pageConfigRequests = requests.filter(item => item.url === '/api/config/page_config');
+    const putRequests = requests.filter(item => item.options.method === 'PUT');
+    assert.equal(pageConfigRequests.length, 1);
+    assert.equal(putRequests.length, 2);
+    assert.equal(putRequests[1].options.headers['X-CSRF-Token'], 'first-run-token');
 });
 
 test('a reset made during startup wins over the initial authoritative read', async () => {

--- a/static/tutorial-seven-day-state.test.cjs
+++ b/static/tutorial-seven-day-state.test.cjs
@@ -445,6 +445,55 @@ test('first authoritative state creation does not wait on pageConfigReady mutati
     assert.equal(putRequests[1].options.headers['X-CSRF-Token'], 'first-run-token');
 });
 
+test('a rejected cached token is refreshed once after a backend restart', async () => {
+    const requests = [];
+    let activeToken = 'initial-token';
+    let revision = 0;
+    const fetch = async (url, options = {}) => {
+        requests.push({ url, options });
+        if (url === stateApi.SERVER_STATE_ENDPOINT && options.method === 'PUT') {
+            if (options.headers['X-CSRF-Token'] !== activeToken) {
+                return createJsonResponse({ error_code: 'csrf_validation_failed' }, 403);
+            }
+            revision += 1;
+            const body = JSON.parse(options.body);
+            return createJsonResponse({
+                ok: true,
+                initialized: true,
+                revision,
+                state: body.state,
+            });
+        }
+        if (url === stateApi.SERVER_STATE_ENDPOINT) {
+            return createJsonResponse({ ok: true, initialized: false, revision: 0, state: null });
+        }
+        if (url === '/api/config/page_config') {
+            return createJsonResponse({ autostart_csrf_token: activeToken });
+        }
+        return createJsonResponse({}, 404);
+    };
+    const browserApi = loadBrowserStateApi({
+        storage: createMemoryStorage(),
+        fetch,
+    });
+
+    await browserApi.ready();
+    activeToken = 'restarted-backend-token';
+    browserApi.markRoundOutcome(1, 'complete');
+    await browserApi.flush();
+
+    const pageConfigRequests = requests.filter(item => item.url === '/api/config/page_config');
+    const putTokens = requests
+        .filter(item => item.options.method === 'PUT')
+        .map(item => item.options.headers['X-CSRF-Token']);
+    assert.equal(pageConfigRequests.length, 2);
+    assert.deepEqual(putTokens, [
+        'initial-token',
+        'initial-token',
+        'restarted-backend-token',
+    ]);
+});
+
 test('a reset made during startup wins over the initial authoritative read', async () => {
     let releaseStorageBarrier;
     const storageBarrier = new Promise(resolve => {

--- a/static/tutorial-seven-day-state.test.cjs
+++ b/static/tutorial-seven-day-state.test.cjs
@@ -448,6 +448,8 @@ test('first authoritative state creation does not wait on pageConfigReady mutati
 test('a rejected cached token is refreshed once after a backend restart', async () => {
     const requests = [];
     let activeToken = 'initial-token';
+    let helperToken = activeToken;
+    let refreshTokenCalls = 0;
     let revision = 0;
     const fetch = async (url, options = {}) => {
         requests.push({ url, options });
@@ -475,21 +477,37 @@ test('a rejected cached token is refreshed once after a backend restart', async 
     const browserApi = loadBrowserStateApi({
         storage: createMemoryStorage(),
         fetch,
+        mutationSecurity: {
+            peekCachedToken() {
+                return helperToken;
+            },
+            async refreshToken() {
+                refreshTokenCalls += 1;
+                const response = await fetch('/api/config/page_config', { cache: 'no-store' });
+                const payload = await response.json();
+                helperToken = payload.autostart_csrf_token;
+                return helperToken;
+            },
+        },
     });
 
     await browserApi.ready();
     activeToken = 'restarted-backend-token';
     browserApi.markRoundOutcome(1, 'complete');
     await browserApi.flush();
+    browserApi.markRoundOutcome(2, 'complete');
+    await browserApi.flush();
 
     const pageConfigRequests = requests.filter(item => item.url === '/api/config/page_config');
     const putTokens = requests
         .filter(item => item.options.method === 'PUT')
         .map(item => item.options.headers['X-CSRF-Token']);
-    assert.equal(pageConfigRequests.length, 2);
+    assert.equal(refreshTokenCalls, 1);
+    assert.equal(pageConfigRequests.length, 1);
     assert.deepEqual(putTokens, [
         'initial-token',
         'initial-token',
+        'restarted-backend-token',
         'restarted-backend-token',
     ]);
 });

--- a/static/tutorial/core/seven-day-state.js
+++ b/static/tutorial/core/seven-day-state.js
@@ -223,6 +223,19 @@
         // helper here can form a cycle:
         // seven-day ready -> mutation headers -> pageConfigReady -> seven-day ready.
         // Reuse only an already-cached token; otherwise fetch the token directly.
+        if (forceRefresh && helper && typeof helper.refreshToken === 'function') {
+            try {
+                const refreshedToken = String(await helper.refreshToken() || '').trim();
+                if (refreshedToken) {
+                    cachedMutationToken = refreshedToken;
+                    headers['X-CSRF-Token'] = refreshedToken;
+                    return headers;
+                }
+            } catch (error) {
+                console.warn('[SevenDayTutorialState] 刷新共享写入令牌失败，尝试页面配置:', error);
+            }
+        }
+
         if (!forceRefresh && helper && typeof helper.peekCachedToken === 'function') {
             try {
                 const cachedToken = String(helper.peekCachedToken() || '').trim();

--- a/static/tutorial/core/seven-day-state.js
+++ b/static/tutorial/core/seven-day-state.js
@@ -24,6 +24,7 @@
     let dirtyServerState = null;
     let dirtyServerGeneration = 0;
     let lastServerSyncError = null;
+    let cachedMutationToken = '';
 
     function getTodayLocalDate(now) {
         const value = now instanceof Date ? now : new Date();
@@ -225,6 +226,7 @@
             try {
                 const cachedToken = String(helper.peekCachedToken() || '').trim();
                 if (cachedToken) {
+                    cachedMutationToken = cachedToken;
                     headers['X-CSRF-Token'] = cachedToken;
                     return headers;
                 }
@@ -233,12 +235,20 @@
             }
         }
 
+        if (cachedMutationToken) {
+            headers['X-CSRF-Token'] = cachedMutationToken;
+            return headers;
+        }
+
         try {
             const response = await host.fetch('/api/config/page_config', { cache: 'no-store' });
             if (!response.ok) return headers;
             const payload = await response.json();
             if (payload && typeof payload.autostart_csrf_token === 'string' && payload.autostart_csrf_token) {
-                headers['X-CSRF-Token'] = payload.autostart_csrf_token;
+                cachedMutationToken = payload.autostart_csrf_token.trim();
+                if (cachedMutationToken) {
+                    headers['X-CSRF-Token'] = cachedMutationToken;
+                }
             }
         } catch (error) {
             console.warn('[SevenDayTutorialState] 读取页面配置失败，保留本地进度:', error);

--- a/static/tutorial/core/seven-day-state.js
+++ b/static/tutorial/core/seven-day-state.js
@@ -214,15 +214,16 @@
         );
     }
 
-    async function getMutationHeaders() {
+    async function getMutationHeaders(options) {
         const headers = { 'Content-Type': 'application/json' };
         const helper = host.nekoLocalMutationSecurity;
+        const forceRefresh = !!(options && options.forceRefresh);
         // page_config waits for this module's authoritative ready barrier. On a brand-new
         // profile the initial server state must be created with PUT, so awaiting the shared
         // helper here can form a cycle:
         // seven-day ready -> mutation headers -> pageConfigReady -> seven-day ready.
         // Reuse only an already-cached token; otherwise fetch the token directly.
-        if (helper && typeof helper.peekCachedToken === 'function') {
+        if (!forceRefresh && helper && typeof helper.peekCachedToken === 'function') {
             try {
                 const cachedToken = String(helper.peekCachedToken() || '').trim();
                 if (cachedToken) {
@@ -235,7 +236,7 @@
             }
         }
 
-        if (cachedMutationToken) {
+        if (!forceRefresh && cachedMutationToken) {
             headers['X-CSRF-Token'] = cachedMutationToken;
             return headers;
         }
@@ -357,10 +358,10 @@
         });
     }
 
-    async function writeServerState(state, expectedRevision) {
+    async function writeServerState(state, expectedRevision, isCsrfRetry) {
         const response = await host.fetch(SERVER_STATE_ENDPOINT, {
             method: 'PUT',
-            headers: await getMutationHeaders(),
+            headers: await getMutationHeaders({ forceRefresh: isCsrfRetry === true }),
             body: JSON.stringify({
                 state,
                 expectedRevision,
@@ -368,6 +369,12 @@
             keepalive: true,
         });
         const payload = await response.json().catch(() => null);
+        if (response.status === 403 && payload && payload.error_code === 'csrf_validation_failed') {
+            cachedMutationToken = '';
+            if (isCsrfRetry !== true) {
+                return writeServerState(state, expectedRevision, true);
+            }
+        }
         if (response.status === 409 && payload) {
             const conflict = new Error('seven-day tutorial state revision conflict');
             conflict.code = 'seven_day_tutorial_revision_conflict';

--- a/static/tutorial/core/seven-day-state.js
+++ b/static/tutorial/core/seven-day-state.js
@@ -216,11 +216,20 @@
     async function getMutationHeaders() {
         const headers = { 'Content-Type': 'application/json' };
         const helper = host.nekoLocalMutationSecurity;
-        if (helper && typeof helper.getMutationHeaders === 'function') {
+        // page_config waits for this module's authoritative ready barrier. On a brand-new
+        // profile the initial server state must be created with PUT, so awaiting the shared
+        // helper here can form a cycle:
+        // seven-day ready -> mutation headers -> pageConfigReady -> seven-day ready.
+        // Reuse only an already-cached token; otherwise fetch the token directly.
+        if (helper && typeof helper.peekCachedToken === 'function') {
             try {
-                return Object.assign(headers, await helper.getMutationHeaders());
+                const cachedToken = String(helper.peekCachedToken() || '').trim();
+                if (cachedToken) {
+                    headers['X-CSRF-Token'] = cachedToken;
+                    return headers;
+                }
             } catch (error) {
-                console.warn('[SevenDayTutorialState] 获取写入安全头失败，尝试页面配置:', error);
+                console.warn('[SevenDayTutorialState] 读取已缓存写入令牌失败，尝试页面配置:', error);
             }
         }
 


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复首次启动时七日教程状态初始化与页面配置互相等待的问题，确保教程及主页模型正常载入，并补充回归测试

## 测试 / Testing

手动重置后测试教程


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 优化状态首次创建与就绪流程：即使安全令牌助手不返回，也能在超时内完成 `ready`；首个服务器状态 `PUT` 使用首次页面配置的 `X-CSRF-Token`。
  * 改进 CSRF 令牌获取与复用：优先复用已缓存/已读取令牌，不命中时再兜底获取。
  * 增强 CSRF 校验失败恢复：遇到 `403` 且为 CSRF 校验失败时清除缓存并强制刷新后重试一次。
* **Tests**
  * 新增校验两类场景：助手不返回不阻塞、后端重启后缓存令牌刷新且 `X-CSRF-Token` 时序正确。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->