### PR TITLE
fix: cap pending image payloads below the free API boundary

### DIFF
--- a/static/app/app-buttons.js
+++ b/static/app/app-buttons.js
@@ -280,7 +280,17 @@
             return 0;
         }
 
-        return text.slice(commaIndex + 1).replace(/\s/g, '').length;
+        return text.slice(commaIndex + 1).length;
+    }
+
+    function canonicalizeBase64DataUrl(dataUrl) {
+        var text = String(dataUrl || '');
+        var commaIndex = text.indexOf(',');
+        if (commaIndex < 0) {
+            return text;
+        }
+
+        return text.slice(0, commaIndex + 1) + text.slice(commaIndex + 1).replace(/\s/g, '');
     }
 
     function getDataUrlBinaryBytes(dataUrl) {
@@ -562,9 +572,12 @@
             throw new Error('INVALID_IMAGE_DATA_URL');
         }
 
+        var isBase64Jpeg = /^data:image\/jpe?g;base64,/i.test(src);
+        if (isBase64Jpeg) {
+            src = canonicalizeBase64DataUrl(src);
+        }
         var image = await loadImageFromSource(src);
-        if (/^data:image\/jpe?g;base64,/i.test(src)
-                && isPendingImageWithinTransportBudget(src)) {
+        if (isBase64Jpeg && isPendingImageWithinTransportBudget(src)) {
             return src;
         }
         return compressLoadedImageToPendingDataUrl(image);
@@ -2635,6 +2648,21 @@
             if (isHomeTutorialInteractionLocked()) {
                 showHomeTutorialLockedToast();
                 return false;
+            }
+
+            if (hasExtraImages) {
+                try {
+                    extraImageDataUrls = await Promise.all(extraImageDataUrls.map(function (dataUrl) {
+                        return mod.normalizeImageDataUrlForPendingList(dataUrl);
+                    }));
+                } catch (error) {
+                    console.error('[Chat] 额外图片处理失败:', error);
+                    window.showStatusToast(
+                        window.t ? window.t('app.importImageFailed') : '导入图片失败',
+                        4000
+                    );
+                    return false;
+                }
             }
 
             if (hasScreenshots) {

--- a/static/app/app-buttons.js
+++ b/static/app/app-buttons.js
@@ -12,15 +12,17 @@
     const S = window.appState;
     const C = window.appConst;
     const U = window.appUtils;
-    // 待发送图片编码后的字节上限：1MB。720p 截图通常 150~400KB，普通上传图压到
-    // 长边 1920 后也基本在此之下；超标才逐步降采样/降质。
-    const PENDING_IMAGE_MAX_ENCODED_BYTES = 1 * 1024 * 1024;
+    // 免费服务器实测在 Base64 约 1MiB（JPEG 约 768KiB）附近会拒绝请求。
+    // 统一把待发送 JPEG 控制在 700KiB，并显式约束实际传输的 Base64 字符数，
+    // 为 Data URL、JSON 包装和会话上下文留出余量。
+    const PENDING_IMAGE_MAX_JPEG_BYTES = 700 * 1024;
+    const PENDING_IMAGE_MAX_BASE64_CHARS = Math.ceil(PENDING_IMAGE_MAX_JPEG_BYTES / 3) * 4;
     const PENDING_IMAGE_MIN_LONG_SIDE = 320;
     // 手动上传图首次超出字节上限时，一步到位把长边压到 ≤1920px，再走后续逐步降采样。
     const PENDING_IMAGE_FIRST_STEP_LONG_SIDE = 1920;
     const PENDING_IMAGE_JPEG_QUALITIES = [0.92, 0.86, 0.78, 0.7, 0.62, 0.52, 0.42, 0.32];
     // 手动截图入列前压缩用的质量阶梯：主质量 0.8（与屏幕分享、后端 vision 分析一致），
-    // 720p 下若仍超 1MB 再逐步降质兜底。
+    // 720p 下若仍超出运输预算再逐步降质兜底。
     const SCREENSHOT_JPEG_QUALITIES = [0.8, 0.72, 0.64, 0.56, 0.48];
 
     let compactHistoryDropPayloadQueue = Promise.resolve();
@@ -271,7 +273,17 @@
         return dataUrl;
     }
 
-    function getDataUrlEncodedBytes(dataUrl) {
+    function getDataUrlBase64Chars(dataUrl) {
+        var text = String(dataUrl || '');
+        var commaIndex = text.indexOf(',');
+        if (commaIndex < 0) {
+            return 0;
+        }
+
+        return text.slice(commaIndex + 1).replace(/\s/g, '').length;
+    }
+
+    function getDataUrlBinaryBytes(dataUrl) {
         var text = String(dataUrl || '');
         var commaIndex = text.indexOf(',');
         if (commaIndex < 0) {
@@ -281,6 +293,13 @@
         var base64Text = text.slice(commaIndex + 1).replace(/\s/g, '');
         var padding = base64Text.endsWith('==') ? 2 : (base64Text.endsWith('=') ? 1 : 0);
         return Math.max(0, Math.floor(base64Text.length * 3 / 4) - padding);
+    }
+
+    function isPendingImageWithinTransportBudget(dataUrl) {
+        var base64Chars = getDataUrlBase64Chars(dataUrl);
+        return base64Chars > 0
+            && base64Chars <= PENDING_IMAGE_MAX_BASE64_CHARS
+            && getDataUrlBinaryBytes(dataUrl) <= PENDING_IMAGE_MAX_JPEG_BYTES;
     }
 
     function compressLoadedImageToPendingDataUrl(image) {
@@ -298,7 +317,7 @@
             for (var i = 0; i < PENDING_IMAGE_JPEG_QUALITIES.length; i += 1) {
                 var dataUrl = drawImageToJpegDataUrl(image, width, height, PENDING_IMAGE_JPEG_QUALITIES[i]);
                 bestDataUrl = dataUrl;
-                if (getDataUrlEncodedBytes(dataUrl) <= PENDING_IMAGE_MAX_ENCODED_BYTES) {
+                if (isPendingImageWithinTransportBudget(dataUrl)) {
                     return dataUrl;
                 }
             }
@@ -315,7 +334,7 @@
                 }
             }
 
-            var ratio = Math.sqrt(PENDING_IMAGE_MAX_ENCODED_BYTES / Math.max(getDataUrlEncodedBytes(bestDataUrl), 1)) * 0.92;
+            var ratio = Math.sqrt(PENDING_IMAGE_MAX_JPEG_BYTES / Math.max(getDataUrlBinaryBytes(bestDataUrl), 1)) * 0.92;
             var longSide = Math.max(width, height);
             var nextLongSide = Math.max(PENDING_IMAGE_MIN_LONG_SIDE, Math.floor(longSide * ratio));
             var nextScale = nextLongSide / Math.max(longSide, 1);
@@ -328,7 +347,7 @@
             height = nextHeight;
         }
 
-        if (getDataUrlEncodedBytes(bestDataUrl) > PENDING_IMAGE_MAX_ENCODED_BYTES) {
+        if (!isPendingImageWithinTransportBudget(bestDataUrl)) {
             throw new Error('IMAGE_TOO_LARGE');
         }
         return bestDataUrl;
@@ -524,10 +543,13 @@
             throw new Error('INVALID_FILE');
         }
 
-        if (isLikelyJpegBlob(blob) && blob.size <= PENDING_IMAGE_MAX_ENCODED_BYTES) {
+        if (isLikelyJpegBlob(blob) && blob.size <= PENDING_IMAGE_MAX_JPEG_BYTES) {
             var originalDataUrl = await readBlobAsDataUrl(blob, 'image/jpeg');
-            await loadImageFromSource(originalDataUrl);
-            return originalDataUrl;
+            var originalImage = await loadImageFromSource(originalDataUrl);
+            if (isPendingImageWithinTransportBudget(originalDataUrl)) {
+                return originalDataUrl;
+            }
+            return compressLoadedImageToPendingDataUrl(originalImage);
         }
 
         var image = await loadImageFromBlob(blob);
@@ -542,14 +564,14 @@
 
         var image = await loadImageFromSource(src);
         if (/^data:image\/jpe?g;base64,/i.test(src)
-                && getDataUrlEncodedBytes(src) <= PENDING_IMAGE_MAX_ENCODED_BYTES) {
+                && isPendingImageWithinTransportBudget(src)) {
             return src;
         }
         return compressLoadedImageToPendingDataUrl(image);
     };
 
     // 手动截图入列前的压缩：捕获/裁剪叠层保留全分辨率（清晰），裁剪结束后调用这里统一
-    // 压成 720p / 0.8 JPEG，并保证编码字节 ≤ 1MB（与屏幕分享、后端 vision 分析口径一致）。
+    // 压成 720p / 0.8 JPEG，并保证二进制与 Base64 均不超过待发送运输预算。
     mod.compressScreenshotDataUrlTo720p = async function compressScreenshotDataUrlTo720p(dataUrl) {
         var src = String(dataUrl || '');
         if (!/^data:image\//i.test(src)) {
@@ -572,17 +594,16 @@
         for (var i = 0; i < SCREENSHOT_JPEG_QUALITIES.length; i += 1) {
             var encoded = drawImageToJpegDataUrl(image, width, height, SCREENSHOT_JPEG_QUALITIES[i]);
             bestDataUrl = encoded;
-            if (getDataUrlEncodedBytes(encoded) <= PENDING_IMAGE_MAX_ENCODED_BYTES) {
+            if (isPendingImageWithinTransportBudget(encoded)) {
                 return encoded;
             }
         }
-        // 720p 下极少触达这里；兜底返回最低质量结果，不再硬抛错以免阻塞发送。
-        // 真触达说明这张图异常难压，加条 warn 记录尺寸，方便事后发现"列表混入超 1MB"的个例。
+        // 720p 下极少触达这里；但不能把已知超预算图片继续入列，否则发送时仍会失败。
         console.warn(
-            '[截图] 720p 最低质量仍超出 1MB 上限（' +
-            Math.round(getDataUrlEncodedBytes(bestDataUrl) / 1024) + 'KB），仍按兜底入列'
+            '[截图] 720p 最低质量仍超出 ' + Math.round(PENDING_IMAGE_MAX_JPEG_BYTES / 1024) + 'KB 上限（' +
+            Math.round(getDataUrlBinaryBytes(bestDataUrl) / 1024) + 'KB），取消入列'
         );
-        return bestDataUrl;
+        throw new Error('IMAGE_TOO_LARGE');
     };
 
     mod.normalizePendingAttachmentItem = async function normalizePendingAttachmentItem(item) {
@@ -595,7 +616,7 @@
             throw new Error('INVALID_ATTACHMENT_IMAGE');
         }
 
-        // 截图入列前已压到 720p JPEG（≤1MB），这里会原样透传；上传图按字节上限压缩。
+        // 截图入列前已压到 720p JPEG 并满足运输预算，这里会原样透传；上传图按同一预算压缩。
         var normalized = await mod.normalizeImageDataUrlForPendingList(img.src);
         if (normalized && normalized !== img.src) {
             img.src = normalized;
@@ -3672,11 +3693,9 @@
                 try {
                     await mod.enqueueCapturedScreenshotResult(result);
                 } catch (compressErr) {
-                    // Compression only throws when the image can't be decoded/encoded (the 720p
-                    // canvas is small enough that size limits never apply). Don't fall back to the
-                    // full-res original -- that would break the "list holds only compressed <=1MB"
-                    // invariant and pin a huge dataUrl in memory, and a broken image would fail at
-                    // send anyway. Abort queueing and surface an error toast instead.
+                    // Don't fall back to the full-res original: decode/encode failures and the rare
+                    // 720p image that still exceeds the transport budget must not enter the pending
+                    // list, otherwise it would either pin a huge dataUrl or fail during send.
                     console.warn('[\u622A\u56FE] 720p \u538B\u7F29\u5931\u8D25\uFF0C\u53D6\u6D88\u5165\u5217:', compressErr);
                     window.showStatusToast(window.t ? window.t('app.screenshotFailed') : '\u622A\u56FE\u5931\u8D25', 4000);
                     return false;

--- a/tests/frontend/test_chat_user_message_dedup.py
+++ b/tests/frontend/test_chat_user_message_dedup.py
@@ -642,6 +642,78 @@ def test_import_jpeg_over_limit_compresses_attachment(
 
 
 @pytest.mark.frontend
+def test_high_entropy_image_uses_quality_ladder_before_resolution_downsampling(
+    mock_page: Page,
+    running_server: str,
+):
+    _open_app_buttons_page(mock_page, running_server)
+
+    result = mock_page.evaluate(
+        r"""async () => {
+            const limitBytes = 700 * 1024;
+            const limitBase64Chars = Math.ceil(limitBytes / 3) * 4;
+            const dataUrlBytes = (dataUrl) => {
+                const b64 = String(dataUrl || '').split(',')[1] || '';
+                const padding = b64.endsWith('==') ? 2 : (b64.endsWith('=') ? 1 : 0);
+                return Math.max(0, Math.floor(b64.length * 3 / 4) - padding);
+            };
+            const canvas = document.createElement('canvas');
+            canvas.width = 1921;
+            canvas.height = 1921;
+            const context = canvas.getContext('2d');
+            const imageData = context.createImageData(canvas.width, canvas.height);
+            let seed = 0x13579bdf;
+            for (let offset = 0; offset < imageData.data.length; offset += 4) {
+                seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0;
+                imageData.data[offset] = seed & 0xff;
+                imageData.data[offset + 1] = (seed >>> 8) & 0xff;
+                imageData.data[offset + 2] = (seed >>> 16) & 0xff;
+                imageData.data[offset + 3] = 255;
+            }
+            context.putImageData(imageData, 0, 0);
+            const source = canvas.toDataURL('image/jpeg', 0.98);
+
+            const calls = [];
+            const originalToDataURL = HTMLCanvasElement.prototype.toDataURL;
+            HTMLCanvasElement.prototype.toDataURL = function (type, quality) {
+                calls.push({ width: this.width, height: this.height, quality });
+                return originalToDataURL.call(this, type, quality);
+            };
+            let normalized;
+            try {
+                normalized = await window.appButtons.normalizeImageDataUrlForPendingList(source);
+            } finally {
+                HTMLCanvasElement.prototype.toDataURL = originalToDataURL;
+            }
+
+            const normalizedPayload = String(normalized || '').split(',')[1] || '';
+            return {
+                sourceBytes: dataUrlBytes(source),
+                normalizedBytes: dataUrlBytes(normalized),
+                normalizedBase64Chars: normalizedPayload.length,
+                limitBase64Chars,
+                calls
+            };
+        }"""
+    )
+
+    assert result["sourceBytes"] > 700 * 1024
+    assert result["normalizedBytes"] <= 700 * 1024
+    assert result["normalizedBase64Chars"] <= result["limitBase64Chars"]
+    quality_ladder = [0.92, 0.86, 0.78, 0.70, 0.62, 0.52, 0.42, 0.32]
+    assert len(result["calls"]) >= 16
+    assert [call["quality"] for call in result["calls"][:8]] == pytest.approx(quality_ladder)
+    assert [call["quality"] for call in result["calls"][8:16]] == pytest.approx(quality_ladder)
+    dimensions = []
+    for call in result["calls"]:
+        size = (call["width"], call["height"])
+        if not dimensions or dimensions[-1] != size:
+            dimensions.append(size)
+    assert dimensions[0] == (1921, 1921)
+    assert dimensions[1] == (1920, 1920)
+
+
+@pytest.mark.frontend
 def test_extra_image_data_url_is_normalized_before_avatar_drop_send(
     mock_page: Page,
     running_server: str,

--- a/tests/frontend/test_chat_user_message_dedup.py
+++ b/tests/frontend/test_chat_user_message_dedup.py
@@ -21,6 +21,17 @@ def _open_react_chat_page(mock_page: Page, running_server: str) -> None:
     )
 
 
+def _open_app_buttons_page(mock_page: Page, running_server: str) -> None:
+    mock_page.add_init_script(
+        "window.localStorage.setItem('neko_tutorial_settings', 'seen')"
+    )
+    mock_page.goto(running_server, wait_until="domcontentloaded")
+    mock_page.wait_for_function(
+        "() => window.appButtons"
+        " && typeof window.appButtons.normalizeImageBlobForPendingList === 'function'"
+    )
+
+
 def _install_chat_send_harness(
     mock_page: Page,
     *,
@@ -484,11 +495,11 @@ def test_import_jpeg_under_limit_keeps_original_data(
     mock_page: Page,
     running_server: str,
 ):
-    _open_react_chat_page(mock_page, running_server)
-    _install_chat_send_harness(mock_page)
+    _open_app_buttons_page(mock_page, running_server)
 
     result = mock_page.evaluate(
         """async () => {
+            const targetBytes = 700 * 1024;
             const canvas = document.createElement('canvas');
             canvas.width = 2;
             canvas.height = 2;
@@ -497,22 +508,26 @@ def test_import_jpeg_under_limit_keeps_original_data(
             context.fillRect(0, 0, 2, 2);
             const original = canvas.toDataURL('image/jpeg', 0.92);
             const b64 = original.split(',')[1];
-            const bytes = Uint8Array.from(atob(b64), (char) => char.charCodeAt(0));
-            const file = new File([bytes], 'tiny.jpg', { type: 'image/jpeg' });
-            await window.appButtons.importImageFileToPendingList(file);
-            const state = window.reactChatWindowHost.getState();
-            if (state.composerAttachments.length !== 1) {
-                throw new Error(`Expected one composer attachment, got ${state.composerAttachments.length}`);
-            }
+            const jpegBytes = Uint8Array.from(atob(b64), (char) => char.charCodeAt(0));
+            const bytes = new Uint8Array(targetBytes);
+            bytes.set(jpegBytes);
+            const file = new File([bytes], 'exactly-700kib.jpg', { type: 'image/jpeg' });
+            const expected = await new Promise((resolve, reject) => {
+                const reader = new FileReader();
+                reader.onload = () => resolve(reader.result);
+                reader.onerror = () => reject(reader.error);
+                reader.readAsDataURL(file);
+            });
+            const imported = await window.appButtons.normalizeImageBlobForPendingList(file);
             return {
-                original,
-                attachmentCount: state.composerAttachments.length,
-                imported: state.composerAttachments[0] && state.composerAttachments[0].url
+                original: expected,
+                originalBytes: file.size,
+                imported
             };
         }"""
     )
 
-    assert result["attachmentCount"] == 1
+    assert result["originalBytes"] == 700 * 1024
     assert result["imported"] == result["original"]
 
 
@@ -521,69 +536,54 @@ def test_import_jpeg_over_limit_compresses_attachment(
     mock_page: Page,
     running_server: str,
 ):
-    _open_react_chat_page(mock_page, running_server)
-    _install_chat_send_harness(mock_page)
+    _open_app_buttons_page(mock_page, running_server)
 
     result = mock_page.evaluate(
-        """async () => {
-            const limitBytes = 10 * 1024 * 1024;
+        r"""async () => {
+            const sourceBytes = 768 * 1024;
+            const limitBytes = 700 * 1024;
+            const limitBase64Chars = Math.ceil(limitBytes / 3) * 4;
             const dataUrlBytes = (dataUrl) => {
                 const b64 = String(dataUrl || '').split(',')[1] || '';
                 const padding = b64.endsWith('==') ? 2 : (b64.endsWith('=') ? 1 : 0);
                 return Math.max(0, Math.floor(b64.length * 3 / 4) - padding);
             };
-            const makeNoisyJpeg = (size) => {
-                const canvas = document.createElement('canvas');
-                canvas.width = size;
-                canvas.height = size;
-                const context = canvas.getContext('2d');
-                const imageData = context.createImageData(size, size);
-                const pixels = imageData.data;
-                for (let y = 0; y < size; y += 1) {
-                    for (let x = 0; x < size; x += 1) {
-                        const offset = (y * size + x) * 4;
-                        const value = (x * 17 + y * 31 + ((x ^ y) * 13)) & 255;
-                        pixels[offset] = value;
-                        pixels[offset + 1] = (value * 7 + x) & 255;
-                        pixels[offset + 2] = (value * 13 + y) & 255;
-                        pixels[offset + 3] = 255;
-                    }
-                }
-                context.putImageData(imageData, 0, 0);
-                return canvas.toDataURL('image/jpeg', 1);
-            };
-
-            let original = makeNoisyJpeg(3072);
-            if (dataUrlBytes(original) <= limitBytes) {
-                original = makeNoisyJpeg(4096);
-            }
-            const originalBytes = dataUrlBytes(original);
-            if (originalBytes <= limitBytes) {
-                throw new Error(`Expected source JPEG to exceed 10MB, got ${originalBytes}`);
-            }
-
-            const response = await fetch(original);
-            const blob = await response.blob();
-            const file = new File([blob], 'big.jpg', { type: 'image/jpeg' });
-            await window.appButtons.importImageFileToPendingList(file);
-            const state = window.reactChatWindowHost.getState();
-            if (state.composerAttachments.length !== 1) {
-                throw new Error(`Expected one composer attachment, got ${state.composerAttachments.length}`);
-            }
-            const imported = state.composerAttachments[0] && state.composerAttachments[0].url;
+            const canvas = document.createElement('canvas');
+            canvas.width = 2;
+            canvas.height = 2;
+            const context = canvas.getContext('2d');
+            context.fillStyle = '#336699';
+            context.fillRect(0, 0, 2, 2);
+            const jpegDataUrl = canvas.toDataURL('image/jpeg', 0.92);
+            const jpegBytes = Uint8Array.from(
+                atob(jpegDataUrl.split(',')[1]),
+                (char) => char.charCodeAt(0)
+            );
+            const bytes = new Uint8Array(sourceBytes);
+            bytes.set(jpegBytes);
+            const file = new File([bytes], 'exactly-768kib.jpg', { type: 'image/jpeg' });
+            const original = await new Promise((resolve, reject) => {
+                const reader = new FileReader();
+                reader.onload = () => resolve(reader.result);
+                reader.onerror = () => reject(reader.error);
+                reader.readAsDataURL(file);
+            });
+            const imported = await window.appButtons.normalizeImageBlobForPendingList(file);
+            const importedBase64Chars = String(imported || '').split(',')[1].replace(/\s/g, '').length;
             return {
-                attachmentCount: state.composerAttachments.length,
-                originalBytes,
+                originalBytes: file.size,
                 importedBytes: dataUrlBytes(imported),
+                importedBase64Chars,
+                limitBase64Chars,
                 importedChanged: imported !== original,
                 importedIsJpeg: String(imported || '').startsWith('data:image/jpeg;base64,')
             };
         }"""
     )
 
-    assert result["attachmentCount"] == 1
-    assert result["originalBytes"] > 10 * 1024 * 1024
-    assert result["importedBytes"] <= 10 * 1024 * 1024
+    assert result["originalBytes"] == 768 * 1024
+    assert result["importedBytes"] <= 700 * 1024
+    assert result["importedBase64Chars"] <= result["limitBase64Chars"]
     assert result["importedChanged"] is True
     assert result["importedIsJpeg"] is True
 

--- a/tests/frontend/test_chat_user_message_dedup.py
+++ b/tests/frontend/test_chat_user_message_dedup.py
@@ -532,6 +532,59 @@ def test_import_jpeg_under_limit_keeps_original_data(
 
 
 @pytest.mark.frontend
+def test_wrapped_jpeg_data_url_is_canonicalized_before_budget_check(
+    mock_page: Page,
+    running_server: str,
+):
+    _open_app_buttons_page(mock_page, running_server)
+
+    result = mock_page.evaluate(
+        r"""async () => {
+            const targetBytes = 700 * 1024;
+            const limitBase64Chars = Math.ceil(targetBytes / 3) * 4;
+            const canvas = document.createElement('canvas');
+            canvas.width = 2;
+            canvas.height = 2;
+            const context = canvas.getContext('2d');
+            context.fillStyle = '#336699';
+            context.fillRect(0, 0, 2, 2);
+            const jpegDataUrl = canvas.toDataURL('image/jpeg', 0.92);
+            const jpegBytes = Uint8Array.from(
+                atob(jpegDataUrl.split(',')[1]),
+                (char) => char.charCodeAt(0)
+            );
+            const bytes = new Uint8Array(targetBytes);
+            bytes.set(jpegBytes);
+            const file = new File([bytes], 'wrapped-700kib.jpg', { type: 'image/jpeg' });
+            const canonical = await new Promise((resolve, reject) => {
+                const reader = new FileReader();
+                reader.onload = () => resolve(reader.result);
+                reader.onerror = () => reject(reader.error);
+                reader.readAsDataURL(file);
+            });
+            const commaIndex = canonical.indexOf(',');
+            const wrappedPayload = canonical.slice(commaIndex + 1).replace(/.{64}/g, '$&\n');
+            const wrapped = canonical.slice(0, commaIndex + 1) + wrappedPayload;
+            const normalized = await window.appButtons.normalizeImageDataUrlForPendingList(wrapped);
+            const normalizedPayload = normalized.slice(normalized.indexOf(',') + 1);
+            return {
+                canonical,
+                normalized,
+                wrappedBase64Chars: wrappedPayload.length,
+                normalizedBase64Chars: normalizedPayload.length,
+                normalizedHasWhitespace: /\s/.test(normalizedPayload),
+                limitBase64Chars
+            };
+        }"""
+    )
+
+    assert result["wrappedBase64Chars"] > result["limitBase64Chars"]
+    assert result["normalized"] == result["canonical"]
+    assert result["normalizedBase64Chars"] <= result["limitBase64Chars"]
+    assert result["normalizedHasWhitespace"] is False
+
+
+@pytest.mark.frontend
 def test_import_jpeg_over_limit_compresses_attachment(
     mock_page: Page,
     running_server: str,
@@ -586,6 +639,77 @@ def test_import_jpeg_over_limit_compresses_attachment(
     assert result["importedBase64Chars"] <= result["limitBase64Chars"]
     assert result["importedChanged"] is True
     assert result["importedIsJpeg"] is True
+
+
+@pytest.mark.frontend
+def test_extra_image_data_url_is_normalized_before_avatar_drop_send(
+    mock_page: Page,
+    running_server: str,
+):
+    _open_app_buttons_page(mock_page, running_server)
+    _install_chat_send_harness(mock_page)
+
+    result = mock_page.evaluate(
+        r"""async () => {
+            window.appState.isTextSessionActive = true;
+            const sourceBytes = 768 * 1024;
+            const limitBytes = 700 * 1024;
+            const limitBase64Chars = Math.ceil(limitBytes / 3) * 4;
+            const dataUrlBytes = (dataUrl) => {
+                const b64 = String(dataUrl || '').split(',')[1] || '';
+                const padding = b64.endsWith('==') ? 2 : (b64.endsWith('=') ? 1 : 0);
+                return Math.max(0, Math.floor(b64.length * 3 / 4) - padding);
+            };
+            const canvas = document.createElement('canvas');
+            canvas.width = 2;
+            canvas.height = 2;
+            const context = canvas.getContext('2d');
+            context.fillStyle = '#336699';
+            context.fillRect(0, 0, 2, 2);
+            const jpegDataUrl = canvas.toDataURL('image/jpeg', 0.92);
+            const jpegBytes = Uint8Array.from(
+                atob(jpegDataUrl.split(',')[1]),
+                (char) => char.charCodeAt(0)
+            );
+            const bytes = new Uint8Array(sourceBytes);
+            bytes.set(jpegBytes);
+            const file = new File([bytes], 'avatar-drop-768kib.jpg', { type: 'image/jpeg' });
+            const original = await new Promise((resolve, reject) => {
+                const reader = new FileReader();
+                reader.onload = () => resolve(reader.result);
+                reader.onerror = () => reject(reader.error);
+                reader.readAsDataURL(file);
+            });
+
+            const sent = await window.sendTextPayload('avatar drop image', {
+                source: 'avatar-drop',
+                extraImageDataUrls: [original],
+                ignoreComposerAttachments: true
+            });
+            const imageMessage = window.__chatTest.sentPayloads.find(
+                (payload) => payload.action === 'stream_data'
+                    && payload.input_type === 'avatar_drop_image'
+            );
+            const sentData = imageMessage && imageMessage.data;
+            const sentPayload = String(sentData || '').split(',')[1] || '';
+            return {
+                sent,
+                sourceBytes: file.size,
+                sentBytes: dataUrlBytes(sentData),
+                sentBase64Chars: sentPayload.length,
+                limitBase64Chars,
+                changed: sentData !== original,
+                source: imageMessage && imageMessage.source
+            };
+        }"""
+    )
+
+    assert result["sent"] is True
+    assert result["sourceBytes"] == 768 * 1024
+    assert result["sentBytes"] <= 700 * 1024
+    assert result["sentBase64Chars"] <= result["limitBase64Chars"]
+    assert result["changed"] is True
+    assert result["source"] == "avatar-drop"
 
 
 @pytest.mark.frontend

--- a/tests/unit/test_avatar_drop_frontend_static.py
+++ b/tests/unit/test_avatar_drop_frontend_static.py
@@ -156,6 +156,7 @@ def test_avatar_drop_payload_sends_full_prompt_but_records_memory_summary_only()
     wait_teardown = _js_function_block(source, "waitForAvatarDropVoiceTeardown")
     prepare_text_mode = _js_function_block(source, "prepareAvatarDropTextMode")
     send_payload = _js_function_block(source, "sendAvatarDropPayload")
+    send_text_internal = _js_function_block(source, "sendTextPayloadInternal")
     audio_capture_source = _read(APP_AUDIO_CAPTURE_PATH)
     stop_recording = _js_function_block(audio_capture_source, "stopRecording")
     app_websocket_source = _read(APP_WEBSOCKET_PATH)
@@ -186,6 +187,14 @@ def test_avatar_drop_payload_sends_full_prompt_but_records_memory_summary_only()
     assert "memoryText: displayText" in send_payload
     assert "memoryText: prompt" not in send_payload
     assert "extraImageDataUrls: imageDataUrls" in send_payload
+    normalize_extra_images = (
+        "extraImageDataUrls = await Promise.all(extraImageDataUrls.map(function (dataUrl)"
+    )
+    assert normalize_extra_images in send_text_internal
+    assert "return mod.normalizeImageDataUrlForPendingList(dataUrl);" in send_text_internal
+    assert send_text_internal.index(normalize_extra_images) < send_text_internal.index(
+        "var optimisticImageUrls"
+    )
     assert "input_type: 'avatar_drop_image',\n                                request_id: requestId" in source
     assert "var messageSource = typeof options.source === 'string' ? options.source.trim() : '';" in source
     assert "extraMessage.source = messageSource" in source


### PR DESCRIPTION
## 改动概述 / Summary

Fixes #2506

- Lower the shared pending JPEG budget from 1 MiB to 700 KiB and enforce the corresponding Base64 character budget.
- Keep JPEGs that already fit the budget byte-for-byte unchanged, while reusing the existing quality-first compression and progressive downsampling path for oversized images.
- Apply the same transport-budget check to uploaded images, image data URLs, and screenshots.
- Canonicalize whitespace in Base64 JPEG data URLs so the measured character budget matches the payload placed on the wire.
- Normalize extra image inputs, including avatar-drop images, through the same shared budget path before optimistic rendering or WebSocket transmission.
- Reject the rare 720p screenshot that still exceeds the budget instead of knowingly placing an oversized payload in the pending list.
- Add browser regression coverage for the exact boundary behavior and real compression order: a 700 KiB JPEG remains unchanged, a 768 KiB JPEG must be compressed below both budgets, and a deterministic high-entropy image must exhaust the quality ladder before downsampling.

### Why this is needed

The previous client-side limit was based on decoded JPEG bytes. A 768 KiB JPEG expands to exactly 1,048,576 Base64 characters, and controlled free-API tests consistently failed at that point while 760 KiB succeeded. The backend validates images but does not resize or recompress them before forwarding, so the client must leave enough transport headroom.

This is a black-box safety budget rather than a claim about the server's formal protocol limit: no authoritative free-server limit configuration or server-side logs were available.

### Scope and behavior

It is not yet clear whether this safety budget should ultimately become a free-server-only configuration. This PR intentionally applies the 700 KiB budget to the shared pending-image path as the smallest practical fix, rather than introducing provider-specific attachment state before that design is settled.

Pending attachments can be created before a provider switch, so applying the budget at normalization time avoids stale provider-dependent state. As a tradeoff, JPEGs between 700 KiB and the previous 1 MiB limit are recompressed for all API paths. A future provider-specific refinement can move the lower budget to the final free-API send path if preserving larger originals for paid or custom providers becomes necessary.

This PR does not add backend recompression, free-server region detection, or new pure-image turn semantics. In text mode, an image is still staged until text for the same turn is submitted.

## 回归报告 / Regression Report

Not applicable. This PR does not modify Python files under `app/`, `main_logic/`, or `memory/`.

Potential regression points considered:

- JPEGs at or below 700 KiB must remain unchanged.
- Images above 700 KiB must preserve the existing quality-first, resolution-second compression order.
- Screenshot failures must not fall back to the full-resolution original.
- Data URL and Blob entry points must enforce the same binary and Base64 budgets.
- Alternate image inputs must not bypass normalization, and whitespace-wrapped Base64 must not be sent unchanged.

## 不拆分理由 / Why Not Split

Not applicable. The change is limited to one frontend implementation file and two focused regression test files.

## 测试 / Testing

- `git diff --check`
- `node --check static/app/app-buttons.js`
- Focused Playwright boundary tests:
  - `test_import_jpeg_under_limit_keeps_original_data`
  - `test_import_jpeg_over_limit_compresses_attachment`
  - `test_wrapped_jpeg_data_url_is_canonicalized_before_budget_check`
  - `test_high_entropy_image_uses_quality_ladder_before_resolution_downsampling`
  - `test_extra_image_data_url_is_normalized_before_avatar_drop_send`
  - Result: `5 passed`
- The unrelated Windows CI failure in `test_topic_pool_restored_signals_respect_persisted_used_history` was rerun three consecutive times on the Windows 11 test host; each run passed.
- Related static regression tests:
  - `tests/unit/test_avatar_drop_frontend_static.py`
  - `tests/unit/test_desktop_screenshot_overlay_static.py`
  - `tests/unit/test_react_chat_window_static.py`
  - `tests/unit/test_auto_goodbye_goodbye_return_contract.py`
  - Result: `103 passed, 1 skipped`
- Real free-API regression from a Windows 11 test host:
  - The exact 768 KiB sample was normalized to 662,561 bytes / 883,416 Base64 characters and completed a response in 2.50 seconds.
  - The original 5,707,267-byte failing image was normalized to 655,501 bytes / 874,004 Base64 characters and completed a response in 2.47 seconds.
  - Main and memory health endpoints returned HTTP 200 before and after the requests.

### Not completed

- The full `tests/frontend/test_chat_user_message_dedup.py` run did not complete within the outer 240-second limit. A React chat asset (`message-bundle-actions-and-prompts.js`) returned 404 during the run, causing chat-window-dependent cases to consume their wait timeout.
- Manual regression through the real chat UI is still pending.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能改进**
  * 优化图片与截图发送前的大小校验，确保内容符合传输限制。
  * 超出限制的 JPEG 会自动压缩；仍无法满足要求时将阻止加入待发送列表。
  * 规范化图片数据，自动清理 Base64 空白字符并提升兼容性。
  * 发送额外图片失败时显示“导入图片失败”提示，并中止发送。

* **测试**
  * 新增并完善多种图片大小、压缩、规范化及发送场景的验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->