### PR TITLE
优化足球小游戏开局走位，使猫娘根据玩家站位和反弹路线调整移动偏向

### DIFF
--- a/templates/soccer_demo.html
+++ b/templates/soccer_demo.html
@@ -1462,14 +1462,16 @@
   };
 
   // 开局时根据玩家相对球的站位估计出脚方向；球已经被踢出后则改用实际速度。
-  // 只采样 AI 当前横向位置附近的单次上下墙反弹路线，用来给原进攻目标增加
+  // 只采样 AI 当前横向位置附近的上下墙反弹路线，用来给原进攻目标增加
   // 有限的纵向偏移，而不是把 AI 直接变成精确追踪落点的守门员。
   function estimateOpeningAttackRouteY(ball, player, ai, fieldHeight, cfg, openingConfig) {
     const playerCx = player.x + cfg.charSize / 2;
     const playerCy = player.y + cfg.charSize / 2;
     const aiCx = ai.x + cfg.charSize / 2;
     const ballSpeed = Math.hypot(ball.vx, ball.vy);
-    const useLiveBallPath = ballSpeed >= openingConfig.liveBallSpeedMin && ball.vx > 0;
+    const hasLiveBallPath = ballSpeed >= openingConfig.liveBallSpeedMin;
+    if (hasLiveBallPath && ball.vx <= 0) return null;
+    const useLiveBallPath = hasLiveBallPath;
     const dirX = useLiveBallPath ? ball.vx : ball.x - playerCx;
     const dirY = useLiveBallPath ? ball.vy : ball.y - playerCy;
     const travelX = aiCx - ball.x;
@@ -1484,10 +1486,16 @@
     const bottom = fieldHeight - cfg.ballRadius;
     let routeY = ball.y + projectedDeltaY;
 
-    if (routeY < top) {
-      routeY = top + (top - routeY) * cfg.wallRestitution;
-    } else if (routeY > bottom) {
-      routeY = bottom - (routeY - bottom) * cfg.wallRestitution;
+    for (
+      let bounce = 0;
+      bounce < 4 && (routeY < top || routeY > bottom);
+      bounce += 1
+    ) {
+      if (routeY < top) {
+        routeY = top + (top - routeY) * cfg.wallRestitution;
+      } else {
+        routeY = bottom - (routeY - bottom) * cfg.wallRestitution;
+      }
     }
 
     return Math.max(top, Math.min(bottom, routeY));

--- a/templates/soccer_demo.html
+++ b/templates/soccer_demo.html
@@ -1454,6 +1454,45 @@
     charBallRestitution: 1.25,
   };
 
+  const OPENING_MOVEMENT = {
+    liveBallSpeedMin: 120,
+    routeBlend: 0.55,
+    maxVerticalShiftRatio: 0.32,
+    maxProjectionRatio: 1.5,
+  };
+
+  // 开局时根据玩家相对球的站位估计出脚方向；球已经被踢出后则改用实际速度。
+  // 只采样 AI 当前横向位置附近的单次上下墙反弹路线，用来给原进攻目标增加
+  // 有限的纵向偏移，而不是把 AI 直接变成精确追踪落点的守门员。
+  function estimateOpeningAttackRouteY(ball, player, ai, fieldHeight, cfg, openingConfig) {
+    const playerCx = player.x + cfg.charSize / 2;
+    const playerCy = player.y + cfg.charSize / 2;
+    const aiCx = ai.x + cfg.charSize / 2;
+    const ballSpeed = Math.hypot(ball.vx, ball.vy);
+    const useLiveBallPath = ballSpeed >= openingConfig.liveBallSpeedMin && ball.vx > 0;
+    const dirX = useLiveBallPath ? ball.vx : ball.x - playerCx;
+    const dirY = useLiveBallPath ? ball.vy : ball.y - playerCy;
+    const travelX = aiCx - ball.x;
+    if (dirX <= cfg.ballRadius || travelX <= 0) return null;
+
+    const maxProjection = fieldHeight * openingConfig.maxProjectionRatio;
+    const projectedDeltaY = Math.max(
+      -maxProjection,
+      Math.min(maxProjection, travelX * dirY / dirX),
+    );
+    const top = cfg.ballRadius;
+    const bottom = fieldHeight - cfg.ballRadius;
+    let routeY = ball.y + projectedDeltaY;
+
+    if (routeY < top) {
+      routeY = top + (top - routeY) * cfg.wallRestitution;
+    } else if (routeY > bottom) {
+      routeY = bottom - (routeY - bottom) * cfg.wallRestitution;
+    }
+
+    return Math.max(top, Math.min(bottom, routeY));
+  }
+
   // ── 边界系统 ──────────────────────────────────────────────────────
   // 边界 = 球场内缩一定距离的矩形区域，球超出边界视为出界
   const BOUNDARY = {
@@ -1908,6 +1947,7 @@
     flashTimer: 0,
     flashSide: null,
   };
+  let openingMovementActive = true;
 
   function resize() {
     canvas.width = window.innerWidth;
@@ -1932,6 +1972,7 @@
     state.ball.vy = 0;
     state.mouse.x = state.player.x + CFG.charSize/2;
     state.mouse.y = state.player.y + CFG.charSize/2;
+    openingMovementActive = true;
   }
   resetPositions();
 
@@ -2007,6 +2048,7 @@
     lastTouchSide = isPlayer ? 'player' : 'ai';
     lastPlayerKickAtMs = isPlayer ? performance.now() : 0;
     playerKickWallBounceForStartle = false;
+    if (!isPlayer) openingMovementActive = false;
     logGameEvent(isPlayer ? 'player-kick' : 'ai-kick');
     markBallTouched();
     void soccerGameAudio.playSfx('ball.kick');
@@ -2387,6 +2429,9 @@
     const b = state.ball;
     const W = canvas.width, H = canvas.height;
     const goalY = H / 2;
+    if (openingMovementActive && b.x > W * 0.72) {
+      openingMovementActive = false;
+    }
 
     // relaxed 预判更远（提前走位），其他默认 0.25s
     const predictT = mood.style === 'patient' ? 0.4 : 0.25;
@@ -2411,6 +2456,9 @@
                         y: Math.max(margin, Math.min(H - margin, pby)) };
     } else {
       aiMode = 'attack';
+      const openingRouteY = openingMovementActive
+        ? estimateOpeningAttackRouteY(b, state.player, state.ai, H, CFG, OPENING_MOVEMENT)
+        : null;
       const toGoalX = 0 - pbx;
       const toGoalY = goalY - pby;
       const gl = Math.hypot(toGoalX, toGoalY) || 1;
@@ -2420,6 +2468,17 @@
       let ty = pby - ngy * stalkDist;
       if (tx < margin || tx > W - margin || ty < margin || ty > H - margin) {
         tx = pbx; ty = pby;
+      }
+      if (openingRouteY !== null) {
+        const maxVerticalShift = H * OPENING_MOVEMENT.maxVerticalShiftRatio;
+        const routeShift = Math.max(
+          -maxVerticalShift,
+          Math.min(maxVerticalShift, openingRouteY - ty),
+        );
+        ty = Math.max(
+          margin,
+          Math.min(H - margin, ty + routeShift * OPENING_MOVEMENT.routeBlend),
+        );
       }
       aiTargetCache = { x: tx, y: ty };
     }

--- a/tests/unit/test_soccer_opening_movement.py
+++ b/tests/unit/test_soccer_opening_movement.py
@@ -90,6 +90,8 @@ const lowerRoute = estimateRouteY(ball, playerAbove, ai, 720, cfg, openingConfig
 
 assert.ok(upperRoute < 360);
 assert.ok(lowerRoute > 360);
+assert.equal(upperRoute, 25.5);
+assert.equal(lowerRoute, 694.5);
 assert.ok(Math.abs((upperRoute + lowerRoute) - 720) < 0.001);
 assert.equal(
   estimateRouteY(ball, {{ x: 680, y: 460 }}, ai, 720, cfg, openingConfig),
@@ -104,7 +106,40 @@ const liveDownwardRoute = estimateRouteY(
   cfg,
   openingConfig,
 );
-assert.ok(liveDownwardRoute > 360);
+assert.equal(liveDownwardRoute, 694.5);
+
+assert.equal(
+  estimateRouteY(
+    {{ x: 640, y: 360, vx: 0, vy: 500 }},
+    playerBelow,
+    ai,
+    720,
+    cfg,
+    openingConfig,
+  ),
+  null,
+);
+assert.equal(
+  estimateRouteY(
+    {{ x: 640, y: 360, vx: -500, vy: 100 }},
+    playerBelow,
+    ai,
+    720,
+    cfg,
+    openingConfig,
+  ),
+  null,
+);
+
+const multipleBounceRoute = estimateRouteY(
+  {{ x: 640, y: 705, vx: 120, vy: 500 }},
+  playerBelow,
+  ai,
+  720,
+  cfg,
+  openingConfig,
+);
+assert.ok(Math.abs(multipleBounceRoute - 61.2) < 0.001);
 """
     result = _run_node(script)
 

--- a/tests/unit/test_soccer_opening_movement.py
+++ b/tests/unit/test_soccer_opening_movement.py
@@ -1,0 +1,111 @@
+import json
+import re
+import shutil
+from pathlib import Path
+
+import pytest
+
+from tests.node_harness import run_node_stdin
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SOCCER_TEMPLATE = PROJECT_ROOT / "templates" / "soccer_demo.html"
+
+
+def _extract_js_function(source: str, name: str) -> str:
+    start = source.index(f"function {name}(")
+    opening_brace = source.index("{", start)
+    depth = 0
+    for index in range(opening_brace, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+    raise AssertionError(f"unterminated JavaScript function: {name}")
+
+
+def _run_node(script: str):
+    node_executable = shutil.which("node")
+    if node_executable is None:
+        pytest.skip("node not found")
+    return run_node_stdin(
+        node_executable,
+        script,
+        capture_output=True,
+        cwd=PROJECT_ROOT,
+        timeout=10,
+        check=False,
+    )
+
+
+@pytest.mark.unit
+def test_soccer_opening_movement_bias_is_scoped_to_the_opening_play():
+    source = SOCCER_TEMPLATE.read_text(encoding="utf-8")
+
+    assert "function estimateOpeningAttackRouteY(" in source
+    assert "openingMovementActive = true;" in source
+    assert "if (!isPlayer) openingMovementActive = false;" in source
+    assert "b.x > W * 0.72" in source
+    assert "ty + routeShift * OPENING_MOVEMENT.routeBlend" in source
+    assert "if (ballThreatensOwnGoal)" not in source
+    assert "function predictBallAtX(" not in source
+
+
+@pytest.mark.unit
+def test_soccer_gameplay_script_has_valid_javascript_syntax():
+    source = SOCCER_TEMPLATE.read_text(encoding="utf-8")
+    inline_scripts = re.findall(r"<script>([\s\S]*?)</script>", source)
+    assert inline_scripts
+
+    result = _run_node(f"new Function({json.dumps(inline_scripts[-1])});")
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.unit
+def test_soccer_opening_route_follows_player_stance_with_symmetric_wall_bounces():
+    source = SOCCER_TEMPLATE.read_text(encoding="utf-8")
+    route_function = _extract_js_function(source, "estimateOpeningAttackRouteY")
+    script = f"""
+const assert = require('node:assert/strict');
+const estimateRouteY = (0, eval)('(' + {json.dumps(route_function)} + ')');
+const cfg = {{
+  charSize: 80,
+  ballRadius: 15,
+  wallRestitution: 0.7,
+}};
+const openingConfig = {{
+  liveBallSpeedMin: 120,
+  maxProjectionRatio: 1.5,
+}};
+const ball = {{ x: 640, y: 360, vx: 0, vy: 0 }};
+const ai = {{ x: 960, y: 320 }};
+const playerBelow = {{ x: 460, y: 460 }};
+const playerAbove = {{ x: 460, y: 180 }};
+
+const upperRoute = estimateRouteY(ball, playerBelow, ai, 720, cfg, openingConfig);
+const lowerRoute = estimateRouteY(ball, playerAbove, ai, 720, cfg, openingConfig);
+
+assert.ok(upperRoute < 360);
+assert.ok(lowerRoute > 360);
+assert.ok(Math.abs((upperRoute + lowerRoute) - 720) < 0.001);
+assert.equal(
+  estimateRouteY(ball, {{ x: 680, y: 460 }}, ai, 720, cfg, openingConfig),
+  null,
+);
+
+const liveDownwardRoute = estimateRouteY(
+  {{ x: 640, y: 360, vx: 500, vy: 500 }},
+  playerBelow,
+  ai,
+  720,
+  cfg,
+  openingConfig,
+);
+assert.ok(liveDownwardRoute > 360);
+"""
+    result = _run_node(script)
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

优化足球小游戏开局走位，使猫娘根据玩家站位和反弹路线调整移动偏向

相关issues：[关于小游戏的两个bug](https://github.com/Project-N-E-K-O/N.E.K.O/issues/2155)

## 回归报告 / Regression Report

## 测试 / Testing

尝试开局斜向踢球


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 足球小游戏新增开局“路线Y估计/修正”：结合球速、站位与墙面反弹，平滑计算并限制目标落点。
  * 仅在开局阶段启用，踢球或推进到阈值后自动切换回原追踪/防守逻辑。
* **测试**
  * 增加路由数值、对称性与内联脚本语法校验，提升游戏行为稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->