### PR TITLE
fix(tutorial): 恢复 day1 接管环节 Ghost Cursor 反向动画的保留判定

### DIFF
--- a/static/tutorial/yui-guide/director/avatar-rounds.js
+++ b/static/tutorial/yui-guide/director/avatar-rounds.js
@@ -1017,6 +1017,15 @@
                     this.isDay2WrapSceneId(previousSceneId)
                     && this.isDay2WrapSceneId(nextSceneId)
                 )
+                || (
+                    // day1 接管环节：capture_cursor 把外置光标锚到 PC 侧按钮，
+                    // return_control 要把锚点同步回 chat 侧胶囊输入框，反向 Ghost
+                    // Cursor 动画依赖这个保留判定不被提前清掉。#2434 重构时另外 4 个
+                    // chat→PC 方向的 day1 pair 已由 releaseExternalizedChatCursorToHome()
+                    // 接管，唯独这条 PC→chat 方向没有替代，补回。
+                    previousSceneId === 'day1_takeover_capture_cursor'
+                    && nextSceneId === 'day1_takeover_return_control'
+                )
             );
         },
 


### PR DESCRIPTION
## 背景

修复 #2490。

#2434 统一前七日新手教程重构时，[avatar-rounds.js](static/tutorial/yui-guide/director/avatar-rounds.js) 的 `shouldPreserveExternalizedChatCursor()` 里 5 个 day1 scene-id pair 被一次删光。其中 4 个 chat→PC 方向的 pair 已由同 PR 新增的 `releaseExternalizedChatCursorToHome()` 正确接管，删得对；但 `day1_takeover_capture_cursor → day1_takeover_return_control` 是 **PC→chat 反方向**（外置光标锚点要从 PC 侧按钮同步回 chat 侧胶囊输入框），没有任何替代，导致反向 Ghost Cursor 动画的锚点在进入 `return_control` 时被提前清掉，光标瞬移到终点、飞回来动画丢失。

守这条行为的测试 `tests/unit/test_avatar_floating_day1_round_contracts.py::test_day1_return_control_preserves_externalized_cursor_from_capture_scene` 从 #1886 起就存在，但 `plugin-tests.yml` 不跑 `tests/unit`，所以 #2434 合入后红了没人看见（详见 #2490）。

## 改动

按 #2490 建议的方案 A：在 `shouldPreserveExternalizedChatCursor()` 的 OR 链末尾补回这一个 pair，不恢复另外 4 个已被接管的 pair。

```js
|| (
    previousSceneId === 'day1_takeover_capture_cursor'
    && nextSceneId === 'day1_takeover_return_control'
)
```

+9 行（含注释，说明为什么只有这一条需要补回）。

选 A 而不是 B（声明式 `preserveExternalizedChatGuideTarget: true` flag）的原因：现有单测断言字面就是检查这两个字符串出现在谓词体里，方案 A 零测试改动、零回归面，且与 issue 里「A 胜在一行且零回归面」的判断一致。

## 验证

- 单测 `test_day1_return_control_preserves_externalized_cursor_from_capture_scene` 的两条断言已字面通过（直接跑了测试的等价文本断言，未走 conftest 因为本机 venv 没装 dev 依赖）。
- 三个相关 node 测试套全部通过：
  - `static/yui-guide-scene-orchestrator.test.cjs`：22/22 ✅
  - `static/tutorial-script-normalizer.test.cjs`：10/10 ✅
  - `static/tutorial-visual-runtime.test.cjs`：21/21 ✅
- day2 的现有保留判定未受影响（`day2_intro_context → day2_screen_entry` 等 pair 仍返回 true）。
- 反向动画的起点/终点逻辑 [avatar-rounds.js:2315-2328](static/tutorial/yui-guide/director/avatar-rounds.js#L2315-L2328) 一直在、且一直是从 `day1_takeover_capture_cursor` 读回锚点；本提交唯一修的是「锚点被提前清掉」这道门。

## 建议 reviewer 实机确认

以上为静态/单测验证。Ghost Cursor 反向动画的**视觉观感**（与花瓣转场是否打架、900ms `cursorMoveDurationMs` 节奏是否舒服）单待测不到，麻烦熟悉教程演出的同学在 Electron 桌面包里走一遍 day1「接管」环节扫一眼。

Closes #2490

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复特定 Day 1 场景切换时光标动画状态未能保留的问题。
  * 改善接管与控制权返回流程中的光标显示连续性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->