### PR TITLE
chore: 删除 #1542 遗留的 WS-broadcaster 死 seam

### DIFF
--- a/app/main_server/character_runtime.py
+++ b/app/main_server/character_runtime.py
@@ -23,7 +23,7 @@ from typing import Any, Optional
 
 from config import MONITOR_SERVER_PORT, USER_NOTIFICATION_ERROR_MAX_CHARS
 from main_logic import core, cross_server
-from main_logic.agent_event_bus import notify_analyze_ack, register_ws_broadcaster
+from main_logic.agent_event_bus import notify_analyze_ack
 from utils.config_manager import get_reserved
 
 from ._shared import runtime
@@ -282,12 +282,6 @@ async def _broadcast_to_all_connected(event_payload: dict) -> int:
         *(_send_one(n, ws) for n, ws in targets), return_exceptions=False
     )
     return sum(1 for r in results if r is True)
-
-
-# Wire the app-owned WebSocket fan-out into the lower-layer event-bus seam.
-# Consumers such as quota dropper and card-drop routes can then broadcast
-# without importing ``app.main_server`` and inverting the module layering.
-register_ws_broadcaster(_broadcast_to_all_connected)
 
 
 async def _handle_agent_event(event: dict):

--- a/main_logic/agent_event_bus.py
+++ b/main_logic/agent_event_bus.py
@@ -439,35 +439,6 @@ def dispatch_user_utterance(bucket: str, event: Dict[str, Any]) -> None:
             logger.debug("[EventBus] user_utterance sink raised: %s", exc)
 
 
-# Async WS-broadcaster seam. ``app.main_server._broadcast_to_all_connected`` is an
-# app-layer (L6) coroutine that fans a payload out to every connected WebSocket.
-# Low layers (main_logic dropper / main_routers card_drop) must NOT import ``app``
-# — that is a layer inversion (and closes a plugin→main_logic→app→brain→plugin
-# import cycle). Instead ``app`` registers its broadcaster here at startup and low
-# layers call ``broadcast_ws_event``, staying layer-clean. No-op until wired (e.g.
-# a memory_server entrypoint that doesn't ship the main WS server).
-_ws_broadcaster: Optional[Callable[[Dict[str, Any]], Awaitable[int]]] = None
-
-
-def register_ws_broadcaster(
-    fn: Callable[[Dict[str, Any]], Awaitable[int]],
-) -> None:
-    """Wire the app-layer WS broadcaster. Last registration wins (single sink)."""
-    global _ws_broadcaster
-    _ws_broadcaster = fn
-
-
-async def broadcast_ws_event(payload: Dict[str, Any]) -> int:
-    """Fan ``payload`` to all connected WebSockets via the registered broadcaster.
-
-    Returns the number of sessions reached, or 0 if no broadcaster is wired.
-    """
-    fn = _ws_broadcaster
-    if fn is None:
-        return 0
-    return await fn(payload)
-
-
 # First-hit-wins text-message hook with optional return value.
 # main_routers' mini-game-invite keyword matcher is the canonical consumer.
 _text_user_message_hooks: list[

--- a/utils/document_parser.py
+++ b/utils/document_parser.py
@@ -359,6 +359,14 @@ def _open_checked_zip(data: bytes, document_type: str) -> zipfile.ZipFile:
             raise DocumentParseError("zip_too_many_entries")
         total_size = 0
         for info in archive.infolist():
+            # Some ZIP writers preserve a Windows separator in member names.
+            # A backslash path is otherwise invalid, but a vbaProject member is
+            # semantically a macro payload and must keep the stronger macro
+            # rejection code used by the UI/security policy.
+            if "\\" in info.filename and info.filename.replace("\\", "/").lower().endswith(
+                "/vbaproject.bin"
+            ):
+                raise DocumentParseError("macro_document_unsupported")
             _validate_zip_member_name(info.filename)
             total_size += max(0, int(info.file_size or 0))
             if total_size > MAX_ZIP_UNCOMPRESSED_BYTES:

--- a/utils/document_parser.py
+++ b/utils/document_parser.py
@@ -359,14 +359,6 @@ def _open_checked_zip(data: bytes, document_type: str) -> zipfile.ZipFile:
             raise DocumentParseError("zip_too_many_entries")
         total_size = 0
         for info in archive.infolist():
-            # Some ZIP writers preserve a Windows separator in member names.
-            # A backslash path is otherwise invalid, but a vbaProject member is
-            # semantically a macro payload and must keep the stronger macro
-            # rejection code used by the UI/security policy.
-            if "\\" in info.filename and info.filename.replace("\\", "/").lower().endswith(
-                "/vbaproject.bin"
-            ):
-                raise DocumentParseError("macro_document_unsupported")
             _validate_zip_member_name(info.filename)
             total_size += max(0, int(info.file_size or 0))
             if total_size > MAX_ZIP_UNCOMPRESSED_BYTES:


### PR DESCRIPTION
#1542 收尾第 1 批。**范围已缩小**：原本还包含 `utils/document_parser.py` 的一处删除，经 bot review 复核后确认我判错，已在 `b8ab3123b` 撤回（说明见文末）。现在只剩一处纯删除。

## 删除 `main_logic/agent_event_bus.py` 的 WS-broadcaster seam

删掉 `_ws_broadcaster` / `register_ws_broadcaster()` / `broadcast_ws_event()`，以及 `app/main_server/character_runtime.py` 里的 import 和模块级注册调用。

这个 seam 当初有正当理由：掉落卡代码直接 `from app.main_server import _broadcast_to_all_connected` 会触发 `check_module_layering.py` 的 L2→L6 倒挂，并闭合 `plugin→main_logic→app→brain→plugin` 循环，所以改由 app 层反向注册（沿用仓库已有的 `register_user_utterance_sink` 模式）。

但 #1542 内部的 `7b6231565`「退役旧对话掉落直抽路径（券经济取代）」把两个消费者（`quota/dropper._emit_card_drop_event`、`card_drop_router.test_trigger_endpoint`）一起删了，seam 就成了孤儿：

- `broadcast_ws_event` 全仓零调用方、零测试
- `main_logic/` 与 `main_routers/` 下已无任何 `from app.main_server import` —— 它当初要防的分层违规已经自然消失，连「防将来再犯」的作用都不剩（真要再犯，`check_module_layering` 会在 CI 上拦住）
- 既有 WS 广播不受影响：`character_runtime` 内三处直调 `_broadcast_to_all_connected` 一行未动

## 回归报告 / Regression Report

- **改动了什么**：删除 `agent_event_bus` 的 WS-broadcaster seam 及其在 `character_runtime` 的注册点。净 -36/+1，2 个文件。
- **理由 / 必要性**：#1542 合入时留下的孤儿。消费者已在同一个 PR 内被作者自己删光，留着会让后来人误以为它是活契约 —— 而它没有任何测试守护。
- **改动前后的表现对比**：无行为差异。`broadcast_ws_event` 在未注册时本就 `return 0`，且当前无人调用；WS 广播路径未改道。
- **潜在回归点**：若将来有低层模块需要推 WS 事件，需重新引入 seam 或改走别的通道 —— 但那时才会有真实消费者，且 `check_module_layering` 会在 CI 上拦住直接 import `app` 的写法。
- **验证**：`check_module_layering` / `check_core_contracts` / `check_prompt_hygiene` 退出码均 0；`ruff` 通过（无孤儿 import，`Awaitable` 等仍被同文件其它签名使用）；`uv run pytest tests/unit -q` → **6790 passed, 26 skipped, 0 failed**。

## 不拆分理由 / Why Not Split

单一改动，2 个文件，删除同一个 seam 的定义与唯一注册点 —— 分开会留下悬空引用。

---

## 附：撤回的那部分（记录判断失误）

原本还删了 `utils/document_parser.py:362-369`（`_open_checked_zip` 里对 backslash + `vbaProject.bin` 的宏错误码分支）。Greptile P1 和 Codex P2 都指出这会破坏错误码，**它们是对的**。

根因比两条评论描述的更具体 —— `zipfile.ZipInfo.__init__` 的分隔符规范化是**平台条件**的：

```python
if os.sep != "/" and os.sep in filename:
    filename = filename.replace(os.sep, "/")
```

| 平台 | `os.sep` | 条件 | 结果 |
|---|---|---|---|
| Windows | `\` | 成立 | 反斜杠被规范化 → 分支不可达 |
| POSIX | `/` | 为假 | 反斜杠保留 → **分支可达且必要** |

我判错的原因：变异验证（把 `raise` 换成 canary 后 35 项全绿）和全量 pytest 都只在 Windows 上跑，CI 的 `unit-tests.yml` 也是 `windows-latest`。「该分支在 Windows 上从未被执行」这个观察成立，但被我推广成了「不可达」。项目有 docker 部署，POSIX 是真实生产环境。

**顺带暴露一个覆盖盲区**（不在本 PR 处理）：`macro-backslash.docx` 这条用例在 Windows CI 上是无效覆盖 —— 它走的是 `_reject_macro_members` 路径而非被测分支，所以即使那段代码被删掉，CI 也不会红。这段代码的实际保护只在 POSIX 上成立，而 CI 不跑 POSIX。
