### PR TITLE
ci: plugin-tests 不再重复跑 tests/unit（#2492 后已冗余）

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -1,36 +1,20 @@
 name: Plugin Tests
 
-# First pytest gate in CI. Scoped to the plugin subsystem on purpose: plugin
-# PRs historically shipped with no test gate at all, which let silent drift
+# The plugin-subsystem pytest gate. Scoped to plugin/** on purpose: plugin PRs
+# historically shipped with no test gate at all, which let silent drift
 # accumulate (e.g. #1464's ocr_reader → ocr_window_scanner extraction broke
 # monkeypatch namespaces in 4 tests, #1480's install_source field broke the
 # query-status expectations — none of it surfaced until a manual full run).
+#
+# Everything under tests/unit/ is covered by unit-tests.yml (#2492), which runs
+# `pytest tests/unit -q` in full on every PR with no paths filter. This workflow
+# therefore only runs plugin/tests and only triggers on plugin-scoped changes —
+# naming individual tests/unit files here would just run them twice.
 on:
   push:
     branches: [main]
     paths:
       - 'plugin/**'
-      - 'static/avatar/avatar-ui-buttons/**'
-      - 'tests/unit/test_avatar_return_button_idle_tiers_static.py'
-      - 'main_routers/card_drop_router.py'
-      - 'main_routers/community_oauth.py'
-      - 'main_routers/system_router/**'
-      - 'main_logic/card_forge_facts.py'
-      - 'main_logic/card_cache/**'
-      - 'main_logic/facts_sync/**'
-      - 'main_logic/forge_credit_ledger.py'
-      - 'local_server/card_forge_server/forge_story_generator.py'
-      - 'tests/unit/test_card_cache_puller.py'
-      - 'tests/unit/test_card_forge_story_generator.py'
-      - 'tests/unit/test_card_drop_session_facts.py'
-      - 'tests/unit/test_card_drop_steam_pkce.py'
-      - 'tests/unit/test_community_oauth.py'
-      - 'tests/unit/test_facts_sync_worker.py'
-      - 'tests/unit/test_forge_credit_ledger.py'
-      - 'tests/unit/test_neko_warthunder_review_regressions.py'
-      - 'tests/unit/test_plugin_sdk_packaging.py'
-      - 'tests/unit/test_system_status_router.py'
-      - 'specs/launcher.spec'
       - '.github/workflows/plugin-tests.yml'
       # Dependency changes alter the plugin test/runtime environment (e.g.
       # removing a dev dep plugin/tests needs) — without these a deps-only
@@ -41,27 +25,6 @@ on:
     branches: [main]
     paths:
       - 'plugin/**'
-      - 'static/avatar/avatar-ui-buttons/**'
-      - 'tests/unit/test_avatar_return_button_idle_tiers_static.py'
-      - 'main_routers/card_drop_router.py'
-      - 'main_routers/community_oauth.py'
-      - 'main_routers/system_router/**'
-      - 'main_logic/card_forge_facts.py'
-      - 'main_logic/card_cache/**'
-      - 'main_logic/facts_sync/**'
-      - 'main_logic/forge_credit_ledger.py'
-      - 'local_server/card_forge_server/forge_story_generator.py'
-      - 'tests/unit/test_card_cache_puller.py'
-      - 'tests/unit/test_card_forge_story_generator.py'
-      - 'tests/unit/test_card_drop_session_facts.py'
-      - 'tests/unit/test_card_drop_steam_pkce.py'
-      - 'tests/unit/test_community_oauth.py'
-      - 'tests/unit/test_facts_sync_worker.py'
-      - 'tests/unit/test_forge_credit_ledger.py'
-      - 'tests/unit/test_neko_warthunder_review_regressions.py'
-      - 'tests/unit/test_plugin_sdk_packaging.py'
-      - 'tests/unit/test_system_status_router.py'
-      - 'specs/launcher.spec'
       - '.github/workflows/plugin-tests.yml'
       - 'pyproject.toml'
       - 'uv.lock'
@@ -112,21 +75,3 @@ jobs:
         # pytest.ini, so unit/plugins — where the silent drift lived — is
         # collected too.
         run: uv run pytest plugin/tests -q
-
-      - name: Run repository contract tests
-        # Keep this in a separate pytest process so plugin/tests continues to
-        # use its own pytest.ini while repo-root contracts are still covered.
-        run: >
-          uv run pytest
-          tests/unit/test_avatar_return_button_idle_tiers_static.py
-          tests/unit/test_plugin_sdk_packaging.py
-          tests/unit/test_card_cache_puller.py
-          tests/unit/test_card_forge_story_generator.py
-          tests/unit/test_card_drop_session_facts.py
-          tests/unit/test_card_drop_steam_pkce.py
-          tests/unit/test_community_oauth.py
-          tests/unit/test_facts_sync_worker.py
-          tests/unit/test_forge_credit_ledger.py
-          tests/unit/test_neko_warthunder_review_regressions.py
-          tests/unit/test_system_status_router.py
-          -q

--- a/tests/unit/test_neko_warthunder_review_regressions.py
+++ b/tests/unit/test_neko_warthunder_review_regressions.py
@@ -15,13 +15,6 @@ from plugin.plugins.neko_warthunder.detectors.discrete.lifecycle import BattleEn
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DATA_PROCESS_DIR = PROJECT_ROOT / "plugin" / "plugins" / "neko_warthunder" / "data_layer" / "data process"
-PLUGIN_TEST_WORKFLOW = PROJECT_ROOT / ".github" / "workflows" / "plugin-tests.yml"
-
-
-def test_warthunder_review_regressions_are_in_plugin_ci() -> None:
-    workflow = PLUGIN_TEST_WORKFLOW.read_text(encoding="utf-8")
-
-    assert workflow.count("tests/unit/test_neko_warthunder_review_regressions.py") == 3
 
 
 def test_coalesced_kill_bypasses_post_flush_event_cooldown() -> None:


### PR DESCRIPTION
#1542 收尾第 2 批。纯 CI 去重，不改任何产品代码。

## 起因

#2492 加的 `unit-tests.yml` 在**每个 PR 上无 paths 过滤地**跑 `pytest tests/unit -q` 全量。而 `plugin-tests.yml` 仍在两处 paths 过滤器 + 一个 `Run repository contract tests` step 里点名同一批 11 个 `tests/unit/*` 文件 —— 全部是重复执行。

其中 9 个（card_cache_puller、card_forge_story_generator、card_drop_session_facts、card_drop_steam_pkce、community_oauth、facts_sync_worker、forge_credit_ledger、neko_warthunder_review_regressions、system_status_router）是 #1542 加进去的；另外 2 个（avatar_return_button_idle_tiers_static、plugin_sdk_packaging）是 #2492 之前就在的遗留。

## 改动

1. **删掉 `Run repository contract tests` step** —— 11 个文件全在 `tests/unit/` 下，已被 `unit-tests.yml` 覆盖。
2. **paths 收回 plugin 自身范围**，只留 `plugin/**`、workflow 自身、`pyproject.toml`、`uv.lock`。移除的是那 11 条 `tests/unit/*`、为它们服务的主程序路径（`card_drop_router.py` / `community_oauth.py` / `system_router/**` / `card_forge_facts.py` / `card_cache/**` / `facts_sync/**` / `forge_credit_ledger.py` / `forge_story_generator.py`），以及 `static/avatar/avatar-ui-buttons/**` 和 `specs/launcher.spec`。后两者已确认 `plugin/tests` 自身不引用（grep 零命中），它们纯粹是为触发被点名的那两个 tests/unit 文件而加的。
3. **更新顶部注释** —— 原文自称 "First pytest gate in CI"，#2492 之后不再准确；改为说明 `tests/unit` 由 `unit-tests.yml` 全量覆盖，本 workflow 只管 `plugin/tests`。
4. **删掉一条自锁测试** —— `test_neko_warthunder_review_regressions.py::test_warthunder_review_regressions_are_in_plugin_ci` 只做一件事：

   ```python
   assert workflow.count("tests/unit/test_neko_warthunder_review_regressions.py") == 3
   ```

   它把「我必须留在 plugin-tests.yml 里」自锁住了，摘掉 workflow 那几行它就红。`tests/unit` 全量进 CI 后这个前提不存在了。同文件其余 warthunder 回归测试全部保留，改由 `unit-tests.yml` 跑。

## 回归报告 / Regression Report

- **改动了什么**：`plugin-tests.yml` 去掉与 `unit-tests.yml` 重复的 `tests/unit` 执行与触发路径；删除一条自锁的元测试。无产品代码改动。
- **理由 / 必要性**：同一批测试在两个 workflow 里各跑一遍，白白占 Windows runner 时间；`plugin-tests.yml` 的 paths 被撑到覆盖大片主程序路径，与它自述的 "Scoped to the plugin subsystem on purpose" 相悖。
- **改动前后的表现对比**：测试覆盖不变 —— 11 个文件全部仍由 `unit-tests.yml` 每 PR 全量执行（两个 workflow 同为 `windows-latest`，平台覆盖也无变化）。差别只是不再跑第二遍，以及改动主程序文件时不再触发 `plugin-tests`（它只跑 `plugin/tests`，与那些文件无关）。
- **潜在回归点**：(a) 若将来 `unit-tests.yml` 被缩回 paths 过滤或点名模式，这批测试会失去覆盖 —— 届时需同步恢复；(b) 改 `specs/launcher.spec` 不再触发 `plugin-tests`，但 `test_plugin_sdk_packaging.py` 仍由 `unit-tests.yml` 每 PR 跑到，覆盖未丢。
- **验证**：`yaml.safe_load` 解析通过（jobs / steps 结构完好）；`ruff` 通过；原本被点名的 11 个文件单独跑 → **188 passed**；`uv run pytest tests/unit -q` → **6789 passed, 26 skipped, 0 failed**（比改动前少 1 项，正是删掉的那条自锁断言）。

## 不拆分理由 / Why Not Split

workflow 的清理和那条自锁测试的删除必须同一个 PR：只删 workflow 行会让该测试立刻变红，只删测试则清理没做。两者加起来 2 个文件、-69/+7。
