### PR TITLE
fix(warthunder): 数据层 CORS 回到 fail-closed，移除隐式 Origin 兜底

### DIFF
--- a/plugin/plugins/neko_warthunder/data_layer/data process/wt_server.py
+++ b/plugin/plugins/neko_warthunder/data_layer/data process/wt_server.py
@@ -54,7 +54,6 @@ import argparse
 import ipaddress
 import json
 import os
-import platform
 import socket
 import sys
 import threading
@@ -90,71 +89,6 @@ from wt_telemetry import (
 _CONTENT_TYPE_BY_EXT = {"jpg": "image/jpeg", "png": "image/png"}
 DEFAULT_BIND_HOST = "127.0.0.1"
 
-
-def _read_port_config() -> dict[str, Any]:
-    """Read the Electron port overrides without importing the main application."""
-    try:
-        system = platform.system()
-        home = os.environ.get("HOME") or os.path.expanduser("~")
-        if system == "Windows":
-            appdata = os.environ.get("APPDATA") or os.path.join(
-                home, "AppData", "Roaming"
-            )
-            base = os.path.join(appdata, "N.E.K.O")
-        elif system == "Darwin":
-            base = os.path.join(home, "Library", "Application Support", "N.E.K.O")
-        else:
-            base = os.path.join(
-                os.environ.get("XDG_CONFIG_HOME", os.path.join(home, ".config")),
-                "N.E.K.O",
-            )
-        with open(os.path.join(base, "port_config.json"), encoding="utf-8") as config_file:
-            config = json.load(config_file)
-        return config if isinstance(config, dict) else {}
-    except (OSError, json.JSONDecodeError):
-        return {}
-
-
-def _read_main_server_port() -> int:
-    """Mirror the root config's port precedence without importing the application."""
-    for key in ("NEKO_MAIN_SERVER_PORT", "MAIN_SERVER_PORT"):
-        raw = os.getenv(key)
-        if not raw:
-            continue
-        try:
-            port = int(raw)
-        except (TypeError, ValueError):
-            continue
-        if 1 <= port <= 65535:
-            return port
-    try:
-        port = int(_read_port_config().get("MAIN_SERVER_PORT"))
-    except (TypeError, ValueError):
-        pass
-    else:
-        if 1 <= port <= 65535:
-            return port
-    return 48911
-
-
-def _build_allowed_cors_origins(port: int) -> frozenset[str]:
-    origins = {
-        f"http://127.0.0.1:{port}",
-        f"http://localhost:{port}",
-        f"http://[::1]:{port}",
-    }
-    if port == 80:
-        origins.update(
-            {
-                "http://127.0.0.1",
-                "http://localhost",
-                "http://[::1]",
-            }
-        )
-    return frozenset(origins)
-
-
-_ALLOWED_CORS_ORIGINS = _build_allowed_cors_origins(_read_main_server_port())
 
 _HUD_BUFFER = 200   # HUD 事件累积上限
 _CHAT_BUFFER = 200  # 聊天累积上限
@@ -964,9 +898,6 @@ class _Handler(BaseHTTPRequestHandler):
         origin = str(self.headers.get("Origin") or "").strip()
         server = getattr(self, "server", None)
         allowed_origins = getattr(server, "cors_origins", frozenset()) if server else frozenset()
-        # 兼容本地开发：未显式配置 cors_origins 时，回退到主服务端口的 loopback Origin 集合。
-        if not allowed_origins:
-            allowed_origins = _ALLOWED_CORS_ORIGINS
         if origin and origin in allowed_origins:
             self.send_header("Access-Control-Allow-Origin", origin)
             self.send_header("Access-Control-Allow-Methods", "GET, OPTIONS")
@@ -1013,8 +944,6 @@ class _Handler(BaseHTTPRequestHandler):
             return
         origin = str(self.headers.get("Origin") or "").strip()
         allowed_origins = getattr(self.server, "cors_origins", frozenset())
-        if not allowed_origins:
-            allowed_origins = _ALLOWED_CORS_ORIGINS
         if origin and origin not in allowed_origins:
             self._send_json({"error": "origin_not_allowed"}, 403)
             return

--- a/tests/unit/test_neko_warthunder_review_regressions.py
+++ b/tests/unit/test_neko_warthunder_review_regressions.py
@@ -73,13 +73,11 @@ def _make_handler(wt_server_module, server):
 
 
 def test_data_layer_cors_is_closed_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    """未显式配置 cors_origins 时不放行任何 Origin。
-
-    数据层只被 Python 侧消费（adapters/telemetry_client.py 的 HTTP 客户端与
-    data_layer_process 的 health check），浏览器不直连，所以默认拒绝一切跨源读取
-    是正确的默认值。放行范围只能通过 create_http_server(cors_origins=...) 或
-    CLI 的 --cors-origin 显式给出。
-    """
+    """No Origin is echoed unless cors_origins was configured explicitly."""
+    # 数据层只被 Python 侧消费（adapters/telemetry_client.py 的 HTTP 客户端与
+    # data_layer_process 的 health check），浏览器不直连，所以默认拒绝一切跨源
+    # 读取是正确的默认值。放行范围只能通过 create_http_server(cors_origins=...)
+    # 或 CLI 的 --cors-origin 显式给出。
     wt_server_module = _load_wt_server_module(monkeypatch)
     handler, emitted = _make_handler(wt_server_module, SimpleNamespace())
 
@@ -98,7 +96,7 @@ def test_data_layer_cors_is_closed_by_default(monkeypatch: pytest.MonkeyPatch) -
 def test_data_layer_cors_echoes_only_explicitly_allowed_origins(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """显式配置后只回显白名单内的 Origin，且永不回显通配符。"""
+    """Once configured, only whitelisted Origins are echoed — never a wildcard."""
     wt_server_module = _load_wt_server_module(monkeypatch)
     handler, emitted = _make_handler(
         wt_server_module,
@@ -119,12 +117,10 @@ def test_data_layer_cors_echoes_only_explicitly_allowed_origins(
 
 
 def test_data_layer_cors_has_no_implicit_origin_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
-    """守住 fail-closed：模块不得再提供任何隐式的 Origin 白名单来源。
-
-    历史回归：曾有一个模块级 _ALLOWED_CORS_ORIGINS 在 cors_origins 为空时兜底，
-    而两条启动路径（adapters/data_layer_process.py 的 in-process 与子进程）都不传
-    cors_origins，等于该兜底恒生效，把上游 #2371 定的默认拒绝改成了默认放行。
-    """
+    """Guard fail-closed: the module must expose no implicit Origin whitelist."""
+    # 历史回归：曾有一个模块级 _ALLOWED_CORS_ORIGINS 在 cors_origins 为空时兜底，
+    # 而两条启动路径（adapters/data_layer_process.py 的 in-process 与子进程）都不
+    # 传 cors_origins，等于该兜底恒生效，把上游 #2371 定的默认拒绝改成了默认放行。
     wt_server_module = _load_wt_server_module(monkeypatch)
 
     assert not hasattr(wt_server_module, "_ALLOWED_CORS_ORIGINS")

--- a/tests/unit/test_neko_warthunder_review_regressions.py
+++ b/tests/unit/test_neko_warthunder_review_regressions.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import importlib.util
-import os
-import platform
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -65,114 +64,69 @@ def _load_wt_server_module(monkeypatch: pytest.MonkeyPatch):
     return module
 
 
-def test_data_layer_cors_only_echoes_approved_neko_origins(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    monkeypatch.delenv("NEKO_MAIN_SERVER_PORT", raising=False)
-    monkeypatch.delenv("MAIN_SERVER_PORT", raising=False)
-    monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("APPDATA", str(tmp_path / "AppData" / "Roaming"))
-    wt_server_module = _load_wt_server_module(monkeypatch)
+def _make_handler(wt_server_module, server):
     handler = wt_server_module._Handler.__new__(wt_server_module._Handler)
     emitted: list[tuple[str, str]] = []
     handler.send_header = lambda name, value: emitted.append((name, value))
+    handler.server = server
+    return handler, emitted
 
-    handler.headers = {"Origin": "https://attacker.example"}
-    handler._cors()
-    assert ("Access-Control-Allow-Origin", "https://attacker.example") not in emitted
-    assert all(value != "*" for name, value in emitted if name == "Access-Control-Allow-Origin")
 
-    emitted.clear()
+def test_data_layer_cors_is_closed_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """未显式配置 cors_origins 时不放行任何 Origin。
+
+    数据层只被 Python 侧消费（adapters/telemetry_client.py 的 HTTP 客户端与
+    data_layer_process 的 health check），浏览器不直连，所以默认拒绝一切跨源读取
+    是正确的默认值。放行范围只能通过 create_http_server(cors_origins=...) 或
+    CLI 的 --cors-origin 显式给出。
+    """
+    wt_server_module = _load_wt_server_module(monkeypatch)
+    handler, emitted = _make_handler(wt_server_module, SimpleNamespace())
+
+    for origin in (
+        "https://attacker.example",
+        "http://localhost:48911",
+        "http://127.0.0.1:48911",
+        "http://[::1]:48911",
+    ):
+        emitted.clear()
+        handler.headers = {"Origin": origin}
+        handler._cors()
+        assert all(name != "Access-Control-Allow-Origin" for name, _value in emitted), origin
+
+
+def test_data_layer_cors_echoes_only_explicitly_allowed_origins(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """显式配置后只回显白名单内的 Origin，且永不回显通配符。"""
+    wt_server_module = _load_wt_server_module(monkeypatch)
+    handler, emitted = _make_handler(
+        wt_server_module,
+        SimpleNamespace(cors_origins=frozenset({"http://localhost:48911"})),
+    )
+
     handler.headers = {"Origin": "http://localhost:48911"}
     handler._cors()
     assert ("Access-Control-Allow-Origin", "http://localhost:48911") in emitted
     assert ("Vary", "Origin") in emitted
     assert ("Access-Control-Allow-Methods", "GET, OPTIONS") in emitted
 
-
-def test_data_layer_cors_uses_configured_main_server_port(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("NEKO_MAIN_SERVER_PORT", "43102")
-    monkeypatch.setenv("MAIN_SERVER_PORT", "43103")
-    wt_server_module = _load_wt_server_module(monkeypatch)
-
-    assert wt_server_module._ALLOWED_CORS_ORIGINS == frozenset(
-        {
-            "http://127.0.0.1:43102",
-            "http://localhost:43102",
-            "http://[::1]:43102",
-        }
-    )
-
-    handler = wt_server_module._Handler.__new__(wt_server_module._Handler)
-    emitted: list[tuple[str, str]] = []
-    handler.send_header = lambda name, value: emitted.append((name, value))
-
-    handler.headers = {"Origin": "http://localhost:43102"}
-    handler._cors()
-    assert ("Access-Control-Allow-Origin", "http://localhost:43102") in emitted
-
     emitted.clear()
-    handler.headers = {"Origin": "http://localhost:48911"}
+    handler.headers = {"Origin": "https://attacker.example"}
     handler._cors()
     assert all(name != "Access-Control-Allow-Origin" for name, _value in emitted)
+    assert all(value != "*" for name, value in emitted if name == "Access-Control-Allow-Origin")
 
 
-def test_data_layer_cors_accepts_normalized_http_origins_on_port_80(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("NEKO_MAIN_SERVER_PORT", "80")
+def test_data_layer_cors_has_no_implicit_origin_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """守住 fail-closed：模块不得再提供任何隐式的 Origin 白名单来源。
+
+    历史回归：曾有一个模块级 _ALLOWED_CORS_ORIGINS 在 cors_origins 为空时兜底，
+    而两条启动路径（adapters/data_layer_process.py 的 in-process 与子进程）都不传
+    cors_origins，等于该兜底恒生效，把上游 #2371 定的默认拒绝改成了默认放行。
+    """
     wt_server_module = _load_wt_server_module(monkeypatch)
 
-    assert wt_server_module._ALLOWED_CORS_ORIGINS == frozenset(
-        {
-            "http://127.0.0.1:80",
-            "http://localhost:80",
-            "http://[::1]:80",
-            "http://127.0.0.1",
-            "http://localhost",
-            "http://[::1]",
-        }
-    )
-
-    handler = wt_server_module._Handler.__new__(wt_server_module._Handler)
-    emitted: list[tuple[str, str]] = []
-    handler.send_header = lambda name, value: emitted.append((name, value))
-    handler.headers = {"Origin": "http://localhost"}
-
-    handler._cors()
-
-    assert ("Access-Control-Allow-Origin", "http://localhost") in emitted
-
-
-def test_data_layer_cors_supports_legacy_main_server_port_env(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.delenv("NEKO_MAIN_SERVER_PORT", raising=False)
-    monkeypatch.setenv("MAIN_SERVER_PORT", "43103")
-    wt_server_module = _load_wt_server_module(monkeypatch)
-
-    assert "http://localhost:43103" in wt_server_module._ALLOWED_CORS_ORIGINS
-    assert "http://localhost:48911" not in wt_server_module._ALLOWED_CORS_ORIGINS
-
-
-def test_data_layer_cors_uses_electron_port_config(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    monkeypatch.delenv("NEKO_MAIN_SERVER_PORT", raising=False)
-    monkeypatch.delenv("MAIN_SERVER_PORT", raising=False)
-    monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setattr(platform, "system", lambda: "Darwin")
-    monkeypatch.setattr(os.path, "expanduser", lambda _path: str(tmp_path / "ignored-home"))
-    config_dir = tmp_path / "Library" / "Application Support" / "N.E.K.O"
-    config_dir.mkdir(parents=True)
-    (config_dir / "port_config.json").write_text(
-        '{"MAIN_SERVER_PORT": 43104}',
-        encoding="utf-8",
-    )
-
-    wt_server_module = _load_wt_server_module(monkeypatch)
-
-    assert "http://localhost:43104" in wt_server_module._ALLOWED_CORS_ORIGINS
-    assert "http://localhost:48911" not in wt_server_module._ALLOWED_CORS_ORIGINS
+    assert not hasattr(wt_server_module, "_ALLOWED_CORS_ORIGINS")
+    assert not hasattr(wt_server_module, "_build_allowed_cors_origins")
+    assert not hasattr(wt_server_module, "_read_main_server_port")


### PR DESCRIPTION
#1542 收尾第 3 批。这是收尾清单里唯一有实际安全影响的一条。

## 问题

上游 #2371（`5dcec54d2`，7-16）把 `wt_server` 的 CORS 做成了显式白名单 + 默认拒绝：`create_http_server(..., cors_origins=())` 默认空集，CLI 提供 `--cors-origin`。

#1542 在此之上加了一个模块级 `_ALLOWED_CORS_ORIGINS` 兜底 —— `cors_origins` 为空时回退到主服务端口的 loopback Origin 集合：

```python
allowed_origins = getattr(server, "cors_origins", frozenset()) if server else frozenset()
# 兼容本地开发：未显式配置 cors_origins 时，回退到主服务端口的 loopback Origin 集合。
if not allowed_origins:
    allowed_origins = _ALLOWED_CORS_ORIGINS
```

而**两条启动路径都不传 `cors_origins`**：

- `adapters/data_layer_process.py:180` 的 in-process 路径：`wt_server.create_http_server(host, port)`
- 同文件 `:372-379` 的子进程路径：`cmd` 只带 `--host` / `--port`

所以这个兜底 100% 生效，等于把上游刚立的默认拒绝改回了默认放行。

需要说明的是**这不是作者的疏忽**：他写这段时（7-13 / 7-14）上游那套参数还不存在，是被 bot 追着从 `*` → 硬编码 48911 → 读 env → 读 Electron `port_config.json` 一路补出来的。上游 7-16 才用另一套机制解决同一问题，此后两套就叠在了一起。

## 为什么放行范围应当为空

数据层没有浏览器消费者：

- `:8112` 的调用方是 `adapters/telemetry_client.py` 的 Python HTTP 客户端和 `data_layer_process` 的 health check —— 服务端 HTTP，**不受 CORS 约束**
- `plugin/plugins/neko_warthunder/ui/panel.tsx` 里 grep 不到任何 `fetch` / `axios` / `XMLHttpRequest`，它走的是插件后端

CORS 只对浏览器有意义。既然没有浏览器直连，默认放行范围就该是空集；真需要时通过 `--cors-origin` 显式给。

## 改动

- 删除 `_read_port_config` / `_read_main_server_port` / `_build_allowed_cors_origins` 与模块级 `_ALLOWED_CORS_ORIGINS`（-71 行），连带删掉因此变孤儿的 `import platform`
- `_cors()` 与 `do_OPTIONS()` 去掉兜底分支，只认 `server.cors_origins`
- 保留 `_cors()` 里 `getattr(self, "server", None)` 的防御（让裸 handler 可测）
- 上游机制原样保留：`create_http_server(cors_origins=...)` 与 CLI `--cors-origin` 未动

测试：5 个断言兜底行为的用例换成 3 个断言 fail-closed 语义的用例 —— 默认不放行任何 Origin、显式配置后只回显白名单内的、以及一条反回归守卫（模块不得再出现 `_ALLOWED_CORS_ORIGINS` 等符号）。

## 回归报告 / Regression Report

- **改动了什么**：移除 warthunder 数据层 CORS 的隐式 Origin 兜底，恢复上游的 fail-closed 默认；同步替换对应测试。
- **理由 / 必要性**：兜底必然生效，把「默认不允许任何跨源读取遥测」变成了「默认允许主服务端口的 loopback origin 读取」。虽只放行 loopback，但这是安全默认值的方向性回退，且收益为零（无浏览器消费者）。
- **改动前后的表现对比**：不传 `cors_origins` 时，改动前会回显主服务 loopback Origin，改动后不回显任何 Origin。显式传 `cors_origins` 的行为完全不变。因为生产路径上没有浏览器直连，实际运行行为无差异。
- **潜在回归点**：若有人依赖「在主服务页面里手动 `fetch` :8112 调试遥测」这一用法，改动后会被 CORS 拦下 —— 恢复方式是启动数据层时加 `--cors-origin http://localhost:48911`。
- **验证**：变异验证 —— 把兜底加回去后 `test_data_layer_cors_is_closed_by_default` 与 `test_data_layer_cors_has_no_implicit_origin_fallback` 立刻变红，还原后 6 passed；`uv run pytest plugin/tests -q` → **2752 passed, 20 skipped**；`uv run pytest tests/unit -q` → **6788 passed, 26 skipped, 0 failed**。

## 不拆分理由 / Why Not Split

生产代码与其测试必须同 PR：只删兜底会让 5 个旧用例立刻变红，只改测试则回退没做。共 2 个文件、-162/+45。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **安全性改进**
  * 跨域请求默认关闭，未配置允许来源时不再返回跨域响应头。
  * 仅对通过 `--cors-origin` 显式配置的来源进行跨域放行。
  * 不再支持通配符 `*` 或基于本地端口、环境配置推导的隐式来源。

* **测试**
  * 新增并更新跨域行为验证，覆盖默认拒绝和显式白名单场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->