### PR TITLE
refactor(settings): 移除无人消费的 NEKO_SERVERS_DESKTOP_CLIENT_ID 第二真相源

### DIFF
--- a/plugin/settings.py
+++ b/plugin/settings.py
@@ -268,17 +268,10 @@ NEKO_AUTH_URL = _validate_http_url(
 
 # 桌面端 OAuth public client id。必须是无 client secret 的 public client。
 # Env: NEKO_AUTH_CLIENT_ID, default="neko-desktop"
-# NOTE: This is the Plugin Market client. Community / Servers Desktop PKCE must
-# use NEKO_SERVERS_DESKTOP_CLIENT_ID instead — never reuse neko-desktop there.
+# NOTE: This is the Plugin Market client. The community / Servers Desktop PKCE
+# flow uses a different client id (env NEKO_SERVERS_DESKTOP_CLIENT_ID) and owns
+# it in main_routers/community_oauth.py — never reuse neko-desktop there.
 NEKO_AUTH_CLIENT_ID = os.getenv("NEKO_AUTH_CLIENT_ID", "neko-desktop").strip() or "neko-desktop"
-
-# N.E.K.O.Servers Desktop community OAuth public client id (neko-auth-platform).
-# Env: NEKO_SERVERS_DESKTOP_CLIENT_ID, default="neko-servers-desktop-dev"
-# Must stay on the neko-servers-desktop-{env} family; never default to neko-desktop.
-NEKO_SERVERS_DESKTOP_CLIENT_ID = (
-    os.getenv("NEKO_SERVERS_DESKTOP_CLIENT_ID", "neko-servers-desktop-dev").strip()
-    or "neko-servers-desktop-dev"
-)
 
 # 插件市场 API URL。配置后插件管理面板会显示"插件市场"入口。
 # Env: NEKO_MARKET_API_URL, default="https://market.project-neko.cn"
@@ -690,7 +683,6 @@ __all__ = [
     "PLUGIN_CONFIG_ROOTS",
     "NEKO_AUTH_URL",
     "NEKO_AUTH_CLIENT_ID",
-    "NEKO_SERVERS_DESKTOP_CLIENT_ID",
     "MARKET_API_URL",
     "MARKET_URL",
     "MARKET_WEB_URL",
@@ -785,7 +777,6 @@ PUBLIC_SYSTEM_CONFIG_KEYS = (
     "PLUGIN_CONFIG_ROOTS",
     "NEKO_AUTH_URL",
     "NEKO_AUTH_CLIENT_ID",
-    "NEKO_SERVERS_DESKTOP_CLIENT_ID",
     "MARKET_API_URL",
     "MARKET_URL",
     "MARKET_WEB_URL",

--- a/tests/unit/test_community_oauth.py
+++ b/tests/unit/test_community_oauth.py
@@ -45,16 +45,14 @@ def oauth_app(tmp_path, monkeypatch):
 
 @pytest.mark.unit
 def test_desktop_client_id_is_owned_here_and_rejects_plugin_market_client(monkeypatch):
-    """社区 PKCE 的 client id 只由本模块解析，且拒绝复用插件市场的 neko-desktop。
-
-    `plugin/settings.py` 的 `NEKO_AUTH_CLIENT_ID`（默认 neko-desktop）是插件市场
-    的 public client，在 neko-auth-platform 上与社区桌面端是两个不同的注册。误把
-    它配到 NEKO_SERVERS_DESKTOP_CLIENT_ID 上会让授权请求指向错误的 client，
-    所以这里必须回落到 servers-desktop 默认值而不是照用。
-
-    单一真相源：main_routers 是 L3、plugin 是 L4，前者不能 import 后者，所以这个
-    值不在 plugin/settings.py 里另立常量（那份曾经存在但无人消费）。
-    """
+    """This module owns the community PKCE client id and rejects the Market one."""
+    # plugin/settings.py 的 NEKO_AUTH_CLIENT_ID（默认 neko-desktop）是插件市场的
+    # public client，在 neko-auth-platform 上与社区桌面端是两个不同的注册。误把它
+    # 配到 NEKO_SERVERS_DESKTOP_CLIENT_ID 上会让授权请求指向错误的 client，所以
+    # 这里必须回落到 servers-desktop 默认值而不是照用。
+    #
+    # 单一真相源：main_routers 是 L3、plugin 是 L4，前者不能 import 后者，所以这个
+    # 值不在 plugin/settings.py 里另立常量（那份曾经存在但无人消费）。
     monkeypatch.setenv("NEKO_SERVERS_DESKTOP_CLIENT_ID", "neko-desktop")
     assert O._desktop_client_id() == "neko-servers-desktop-dev"
 

--- a/tests/unit/test_community_oauth.py
+++ b/tests/unit/test_community_oauth.py
@@ -44,6 +44,31 @@ def oauth_app(tmp_path, monkeypatch):
 
 
 @pytest.mark.unit
+def test_desktop_client_id_is_owned_here_and_rejects_plugin_market_client(monkeypatch):
+    """社区 PKCE 的 client id 只由本模块解析，且拒绝复用插件市场的 neko-desktop。
+
+    `plugin/settings.py` 的 `NEKO_AUTH_CLIENT_ID`（默认 neko-desktop）是插件市场
+    的 public client，在 neko-auth-platform 上与社区桌面端是两个不同的注册。误把
+    它配到 NEKO_SERVERS_DESKTOP_CLIENT_ID 上会让授权请求指向错误的 client，
+    所以这里必须回落到 servers-desktop 默认值而不是照用。
+
+    单一真相源：main_routers 是 L3、plugin 是 L4，前者不能 import 后者，所以这个
+    值不在 plugin/settings.py 里另立常量（那份曾经存在但无人消费）。
+    """
+    monkeypatch.setenv("NEKO_SERVERS_DESKTOP_CLIENT_ID", "neko-desktop")
+    assert O._desktop_client_id() == "neko-servers-desktop-dev"
+
+    monkeypatch.setenv("NEKO_SERVERS_DESKTOP_CLIENT_ID", "  ")
+    assert O._desktop_client_id() == "neko-servers-desktop-dev"
+
+    monkeypatch.delenv("NEKO_SERVERS_DESKTOP_CLIENT_ID", raising=False)
+    assert O._desktop_client_id() == "neko-servers-desktop-dev"
+
+    monkeypatch.setenv("NEKO_SERVERS_DESKTOP_CLIENT_ID", "neko-servers-desktop-prod")
+    assert O._desktop_client_id() == "neko-servers-desktop-prod"
+
+
+@pytest.mark.unit
 def test_oauth_start_returns_desktop_pkce_auth_url(oauth_app):
     client, _auth, _social, pending = oauth_app
     response = client.post("/api/card-drop/oauth/start")


### PR DESCRIPTION
#1542 收尾第 4 批。

## 问题

#1542 在 `plugin/settings.py` 里定义了 `NEKO_SERVERS_DESKTOP_CLIENT_ID`，并同时加进 `__all__` 和 `PUBLIC_SYSTEM_CONFIG_KEYS`（后者会经 `PLUGIN_SYSTEM_CONFIG_GET` 暴露给**任何已装插件**读取）。

但真正消费这个配置的 `main_routers/community_oauth.py:84` 是直接读 `os.environ`，从未 import 过这个常量。两份的兜底逻辑还不一致：

| 位置 | 逻辑 |
|---|---|
| `plugin/settings.py` | `os.getenv(..., "neko-servers-desktop-dev").strip() or 默认值` |
| `main_routers/community_oauth.py` | 多一层 `raw != "neko-desktop"` 防误配 |

也就是说**改 settings 那份不会有任何效果** —— 是个会误导后来人的埋雷。

## 为什么是删掉而不是反向统一

`scripts/check_module_layering.py` 定义 **L3 = `main_routers`、L4 = `plugin`**，低层不能 import 高层。现有 `main_routers/` 下确实零个 `from plugin` import。所以不能让 `community_oauth` 去读 `plugin.settings` —— 唯一方向是删掉 settings 那份。

这也符合语义：该值是**桌面端社区 OAuth** 的 client id，插件用不到，本就不属于"插件公共配置"（`PUBLIC_SYSTEM_CONFIG_KEYS` 里的 `NEKO_AUTH_CLIENT_ID` 是插件市场的，那个才需要暴露）。

## 改动

- 删除 `NEKO_SERVERS_DESKTOP_CLIENT_ID` 的常量定义、`__all__` 条目、`PUBLIC_SYSTEM_CONFIG_KEYS` 条目
- 原注释里的防误配意图改挂到 `NEKO_AUTH_CLIENT_ID` 上，并指明该值归 `main_routers/community_oauth.py` 所有
- 新增 `test_desktop_client_id_is_owned_here_and_rejects_plugin_market_client`，把"误配成 `neko-desktop` 时必须回落到 servers-desktop 默认值"这条意图钉死 —— 原先只有 `assert "neko-desktop" not in body["auth_url"]` 的间接覆盖

## 回归报告 / Regression Report

- **改动了什么**：移除 `plugin/settings.py` 中无人消费的 `NEKO_SERVERS_DESKTOP_CLIENT_ID` 定义与两处注册；补一条防误配的直接守卫测试。
- **理由 / 必要性**：第二真相源且永不生效，改它无效果；同时它把一个插件用不到的值暴露给了所有已装插件。
- **改动前后的表现对比**：无行为差异 —— 该常量零消费，`community_oauth` 的解析逻辑一行未动。唯一变化是插件通过 `PLUGIN_SYSTEM_CONFIG_GET` 拿到的字典少一个 key（该 key 无插件读取）。
- **潜在回归点**：若某个第三方插件依赖从系统配置里读到这个 key —— 已 grep 全仓（`.py` / `.ts` / `.tsx` / `.js`）确认无消费者；`plugin/tests` 中对 `PUBLIC_SYSTEM_CONFIG_KEYS` 的测试是整体 `monkeypatch` 替换元组、不钉具体成员，不受影响。
- **验证**：变异验证 —— 删掉 `community_oauth` 的 `raw != "neko-desktop"` 后新测试立刻变红，还原后 29 passed；`uv run pytest tests/unit -q` → **6791 passed, 26 skipped**；`uv run pytest plugin/tests -q` → **2752 passed, 20 skipped**。

## 不拆分理由 / Why Not Split

删除定义与补上守卫测试是同一件事的两半：删掉那份"文档式常量"后，它承载的防误配意图需要由测试接住，否则下次有人简化 `_desktop_client_id()` 就没人拦。共 2 个文件、+28/-12。
