### PR TITLE
fix(memory): outbox 不再固化本进程猜测的 locale

### DIFF
--- a/app/memory_server/post_turn.py
+++ b/app/memory_server/post_turn.py
@@ -72,6 +72,13 @@ async def _spawn_outbox_post_turn_signals(
         # Persist the locale with the work item: after a memory_server restart,
         # replay must not re-resolve from a neutral process locale and switch
         # the same conversation window back to English.
+        #
+        # Callers must pass the locale the client actually declared, NOT the
+        # value resolved for the in-flight request. Persisting a locale this
+        # process merely *guessed* would freeze that guess into outbox.ndjson:
+        # replay would keep reusing it even after the detection itself is fixed,
+        # whereas omitting the key lets replay re-resolve against the then-current
+        # process language (the pre-outbox behaviour).
         payload['language'] = language
     try:
         op_id = await runtime.outbox.aappend_pending(lanlan_name, OP_POST_TURN_SIGNALS, payload)

--- a/app/memory_server/routes.py
+++ b/app/memory_server/routes.py
@@ -64,7 +64,13 @@ class HistoryRequest(BaseModel):
 
 
 def _activate_request_language(language: str | None) -> str:
-    """Select a replay-safe request locale without changing the process default."""
+    """Resolve the locale for this request without changing the process default.
+
+    Falls back to the process-wide language when the request does not carry a
+    usable one. That fallback is fine for the in-flight request, but it must not
+    be persisted — see the ``language=request.language`` argument at each
+    ``_spawn_outbox_post_turn_signals`` call site.
+    """
     if is_supported_language_code(language):
         return normalize_language_code(language, format='full')
     return get_global_language_full()
@@ -534,7 +540,7 @@ async def cache_conversation(request: HistoryRequest, lanlan_name: str):
             # outbox 登记走锁外——它会 spawn background task 跑 LLM，长持锁会
             # 阻塞下一轮 /cache 写盘。
             await post_turn._spawn_outbox_post_turn_signals(
-                lanlan_name, input_history, language=memory_language,
+                lanlan_name, input_history, language=request.language,
             )
             return {"status": "cached", "count": len(input_history)}
         except Exception as e:
@@ -581,7 +587,7 @@ async def process_conversation(request: HistoryRequest, lanlan_name: str):
 
             # 异步事实提取（不阻塞返回，失败静默跳过）
             await post_turn._spawn_outbox_post_turn_signals(
-                lanlan_name, input_history, language=memory_language,
+                lanlan_name, input_history, language=request.language,
             )
 
             # Phase C: 不再 cancel-and-restart review；让 maybe_spawn_review 在新消息
@@ -632,7 +638,7 @@ async def process_conversation_for_renew(request: HistoryRequest, lanlan_name: s
             # 以下操作在锁外执行，不阻塞 /new_dialog
             # 异步事实提取
             await post_turn._spawn_outbox_post_turn_signals(
-                lanlan_name, input_history, language=memory_language,
+                lanlan_name, input_history, language=request.language,
             )
 
             # Phase C: 见 /process 的注释——不再 cancel-and-restart。
@@ -675,7 +681,7 @@ async def settle_conversation(request: HistoryRequest, lanlan_name: str):
 
             if input_history:
                 await post_turn._spawn_outbox_post_turn_signals(
-                    lanlan_name, input_history, language=memory_language,
+                    lanlan_name, input_history, language=request.language,
                 )
 
             # Phase C: 见 /process 的注释——不再 cancel-and-restart。

--- a/tests/unit/test_memory_request_language_context.py
+++ b/tests/unit/test_memory_request_language_context.py
@@ -89,6 +89,86 @@ async def test_process_requests_keep_language_task_local_across_awaits(monkeypat
     }
 
 
+@pytest.mark.asyncio
+async def test_cache_hands_outbox_the_undeclared_language_as_none(monkeypatch):
+    """请求未声明 locale 时，交给 outbox 的必须是 None 而不是本进程的探测值。"""
+    spawn = AsyncMock()
+    monkeypatch.setattr(
+        routes.runtime,
+        "recent_history_manager",
+        SimpleNamespace(update_history=AsyncMock()),
+    )
+    monkeypatch.setattr(
+        routes.runtime,
+        "time_manager",
+        SimpleNamespace(astore_conversation=AsyncMock()),
+    )
+    monkeypatch.setattr(routes.runtime, "_get_settle_lock", lambda _name: asyncio.Lock())
+    monkeypatch.setattr(routes.gates, "_touch_activity", lambda: None)
+    monkeypatch.setattr(routes.gates, "_aclear_review_clean", AsyncMock())
+    monkeypatch.setattr(routes.post_turn, "_spawn_outbox_post_turn_signals", spawn)
+
+    history = '[{"type": "human", "data": {"content": "喵"}}]'
+    await routes.cache_conversation(
+        routes.HistoryRequest(input_history=history, language=None), "小天"
+    )
+
+    spawn.assert_awaited_once()
+    assert spawn.await_args.kwargs["language"] is None
+
+    spawn.reset_mock()
+    await routes.cache_conversation(
+        routes.HistoryRequest(input_history=history, language="ja"), "小天"
+    )
+    spawn.assert_awaited_once()
+    assert spawn.await_args.kwargs["language"] == "ja"
+
+
+def test_outbox_enqueue_persists_only_client_declared_language():
+    """四个写路由必须把 request.language 原值交给 outbox，而不是回落后的 memory_language。
+
+    memory_language 在请求未声明 locale 时等于 get_global_language_full() 的探测
+    结果。把它写进 outbox.ndjson 会让这个「猜测」被永久冻结：重启 replay 一直复用
+    它，即使探测本身后来修好也不会自愈。省掉该键才能让 replay 按当时的进程语言
+    重新解析（即 outbox 引入之前的行为）。
+
+    用 AST 盯调用点而非只测 _spawn_outbox_post_turn_signals 自身：后者只能证明
+    「传 None 就不写 payload」，证明不了路由真的传了 None。
+    """
+    source = routes.__file__
+    assert source is not None
+    tree = ast.parse(Path(source).read_text(encoding="utf-8"))
+    expected_handlers = {
+        "cache_conversation",
+        "process_conversation",
+        "process_conversation_for_renew",
+        "settle_conversation",
+    }
+    passed_expr: dict[str, str] = {}
+
+    for node in tree.body:
+        if not isinstance(node, ast.AsyncFunctionDef) or node.name not in expected_handlers:
+            continue
+        for child in ast.walk(node):
+            if not isinstance(child, ast.Call):
+                continue
+            func = child.func
+            called = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+            if called != "_spawn_outbox_post_turn_signals":
+                continue
+            for keyword in child.keywords:
+                if keyword.arg == "language":
+                    passed_expr[node.name] = ast.dump(keyword.value)
+
+    missing = expected_handlers - set(passed_expr)
+    assert not missing, f"这些写路由没有把 language 交给 outbox: {sorted(missing)}"
+    for handler, dumped in sorted(passed_expr.items()):
+        assert "attr='language'" in dumped and "id='request'" in dumped, (
+            f"{handler} 应把 request.language 原值交给 outbox（不要传回落后的 "
+            f"memory_language，那会把探测值冻进 outbox.ndjson），实际传的是: {dumped}"
+        )
+
+
 def test_all_memory_write_routes_install_request_language_context():
     source = routes.__file__
     assert source is not None

--- a/tests/unit/test_outbox_wiring.py
+++ b/tests/unit/test_outbox_wiring.py
@@ -77,6 +77,59 @@ async def test_spawn_outbox_happy_path_marks_done(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_spawn_outbox_omits_language_when_request_declared_none(tmp_path):
+    """请求未声明 locale 时不得把本进程的探测值写进 payload。
+
+    _activate_request_language 在请求没带 language 时会回落到
+    get_global_language_full()。那个回落值用于处理本次请求没问题，但一旦被
+    持久化进 outbox.ndjson，重启 replay 就会一直复用这个「猜测」——即使探测
+    本身后来修好了也不会自愈。省掉这个键才能让 replay 按当时的进程语言重新解析
+    （即 outbox 引入之前的行为）。
+    """
+    ob, _ = _install_fresh_memory_state(str(tmp_path))
+    from app import memory_server
+    from memory.outbox import OP_POST_TURN_SIGNALS
+
+    calls: list[tuple[str, dict]] = []
+
+    async def _fake_handler(name: str, payload: dict):
+        calls.append((name, payload))
+
+    with patch.dict(
+        memory_server._OUTBOX_HANDLERS,
+        {OP_POST_TURN_SIGNALS: _fake_handler},
+        clear=False,
+    ):
+        task = await memory_server._spawn_outbox_post_turn_signals(
+            "小天", [HumanMessage(content="喵")], language=None,
+        )
+        await task
+
+    assert len(calls) == 1
+    _name, payload = calls[0]
+    assert "language" not in payload
+
+
+@pytest.mark.asyncio
+async def test_replay_without_recorded_language_falls_back_to_process_locale():
+    """存量 outbox 条目（无 language 键）replay 时回落进程语言，而不是报错或冻结旧值。
+
+    这是升级用户唯一会走的路径：#1542 之前入队的条目都没有这个键。
+    """
+    from app import memory_server
+    from utils.llm_client import messages_to_dict
+
+    runner = AsyncMock(return_value=None)
+    payload = {"messages": messages_to_dict([HumanMessage(content="旧条目")])}
+
+    with patch("app.memory_server.post_turn._run_post_turn_signals", runner):
+        await memory_server._outbox_post_turn_signals_handler("小天", payload)
+
+    runner.assert_awaited_once()
+    assert runner.await_args.kwargs["language"] is None
+
+
+@pytest.mark.asyncio
 async def test_post_turn_outbox_replay_restores_recorded_language():
     """Replay the language recorded at enqueue time instead of the server locale."""
     from app import memory_server


### PR DESCRIPTION
#1542 收尾第 5 批。

## 问题

`app/memory_server/routes.py` 的四个写路由（`/cache` `/process` `/renew` `/settle`）把 `_activate_request_language()` 的返回值同时用于两处：

1. 包住本次请求的 `language_context(memory_language)`
2. 交给 `_spawn_outbox_post_turn_signals(..., language=memory_language)` **持久化进 `outbox.ndjson`**

但这个返回值在请求未声明 locale 时是回落值 `get_global_language_full()` —— **本进程的探测结果**。而 `_spawn_outbox_post_turn_signals` 里 `if language:` 恒真，于是这个「猜测」被写进 payload 永久冻结：重启后 replay 一直复用它，**即使探测本身后来修好也不会自愈**。

改动前（outbox 引入之前）replay 读的是当时的进程全局语言，探测修好后旧条目能跟着变。

## 改动

只持久化客户端**真正声明**的值：

- 四个调用点 `language=memory_language` → `language=request.language`
- `memory_language` 继续用于 `language_context` —— 本次请求内的回落是正确的，问题只在于不该落盘
- 未声明时 payload 不含 `language` 键，replay 走 `language_context(None)` 空转 → 回落当时的进程语言

进程内直跑路径不受影响：`_spawn_outbox_post_turn_signals` 在 `with` 块内调用，spawn 出的 task 会复制当前 context，仍然继承 `memory_language`。

## 关于测试（一个值得记录的返工）

第一版我只加了 `_spawn_outbox_post_turn_signals` 的契约测试（传 `None` 就不写 payload）。**变异验证时把四个调用点全改回 `memory_language`，测试照样全绿** —— 因为它测的是那个函数自己的行为，证明不了路由真的传了 `None`。这正是「只测谓词不测调用点」。

补上之后是四条：

| 测试 | 守什么 |
|---|---|
| `test_cache_hands_outbox_the_undeclared_language_as_none` | 走真实 handler，断言未声明时交给 outbox 的是 `None`、声明了则原样透传 |
| `test_outbox_enqueue_persists_only_client_declared_language` | AST 守卫，盯住四个调用点传的是 `request.language` 而非 `memory_language` |
| `test_spawn_outbox_omits_language_when_request_declared_none` | 契约：传 `None` 不写 payload |
| `test_replay_without_recorded_language_falls_back_to_process_locale` | 补上此前完全缺失的「存量 outbox 条目无 `language` 键」replay 覆盖 —— **这是升级用户唯一会走的路径** |

AST 守卫用自动发现（遍历四个 handler 找 `_spawn_outbox_post_turn_signals` 调用），漏掉任一调用点会直接断言失败，不是硬编码清单。

## 回归报告 / Regression Report

- **改动了什么**：四个 memory 写路由交给 outbox 持久化的 locale，从「回落后的值」改为「客户端声明的原值」；补 4 条测试。
- **理由 / 必要性**：把本进程的探测结果写进持久化队列，会让一次错误探测被永久固化，且 replay 无法自愈。
- **改动前后的表现对比**：请求带 `language` 时行为完全不变（原值透传）。请求不带时，改动前 payload 会存入探测值，改动后不存该键 —— replay 回落到当时的进程语言，与 outbox 引入之前一致。当前 in-flight 请求的语言解析完全不变。
- **潜在回归点**：(a) 若有调用方依赖「outbox 条目总是带 language 键」，改动后需处理缺键 —— `_outbox_post_turn_signals_handler` 本就用 `payload.get('language')`，已覆盖并新增测试；(b) 进程内直跑路径依赖 task 继承 context，已由既有的 `test_concurrent_post_turn_tasks_keep_their_recorded_language` 覆盖。
- **验证**：变异验证 —— 把四处改回 `memory_language` 后行为测试与 AST 守卫立刻变红，还原后 17 passed；`uv run pytest tests/unit -q` → **6794 passed, 26 skipped, 0 failed**。

## 不拆分理由 / Why Not Split

生产改动（4 个调用点 + 注释）与其守卫测试必须同 PR：调用点很容易在后续重构里被"顺手统一"回 `memory_language`，AST 守卫就是为此存在的。共 4 个文件、+151/-5。
