### PR TITLE
perf(i18n): 缓存 macOS locale 探测结果 + 清 #2519 遗留的中文 docstring

### DIFF
--- a/tests/unit/test_memory_language_resolution.py
+++ b/tests/unit/test_memory_language_resolution.py
@@ -14,7 +14,9 @@ from utils import language_utils
 def test_macos_locale_reads_apple_locale(monkeypatch):
     # _get_macos_locale 带进程级缓存；不清掉的话本用例会读到别的用例留下的值
     # （在非 macOS 的 CI 上那个值是 None），断言就永远看不到 fake_run 的结果。
-    monkeypatch.setattr(language_utils, "_macos_locale_cache", None)
+    monkeypatch.setattr(
+        language_utils, "_macos_locale_cache", language_utils._MACOS_LOCALE_UNSET
+    )
     monkeypatch.setattr(language_utils.platform, "system", lambda: "Darwin")
 
     def fake_run(command, **_kwargs):
@@ -32,7 +34,9 @@ def test_macos_locale_is_read_once_per_process(monkeypatch):
     # 各调一次；每次未命中都是一个 1s 超时的 subprocess，而且整个初始化持
     # _global_language_lock。两个全局 getter 又都能从 async 请求路径到达，
     # 冷启动多花几秒就会卡住事件循环。
-    monkeypatch.setattr(language_utils, "_macos_locale_cache", None)
+    monkeypatch.setattr(
+        language_utils, "_macos_locale_cache", language_utils._MACOS_LOCALE_UNSET
+    )
     monkeypatch.setattr(language_utils.platform, "system", lambda: "Darwin")
     calls: list[list[str]] = []
 
@@ -46,6 +50,50 @@ def test_macos_locale_is_read_once_per_process(monkeypatch):
     assert language_utils._get_macos_locale() == "ja_JP"
     assert language_utils._get_macos_locale() == "ja_JP"
     assert len(calls) == 1, f"defaults 被重复调用了 {len(calls)} 次"
+
+
+def test_macos_locale_probe_failure_is_retried_not_cached(monkeypatch):
+    """A transient `defaults` failure must not pin the process to a wrong locale."""
+    # 只缓存确定性结论。探测失败（超时 / 非零退出 / 空输出）如果也被缓存，一次
+    # 启动期超时就会让整个进程生命周期都拿不到系统 locale——区域判定会掉到
+    # non-china、语言判定会掉到英文，而「其它信号都不可靠」正是本函数要兜的场景。
+    monkeypatch.setattr(
+        language_utils, "_macos_locale_cache", language_utils._MACOS_LOCALE_UNSET
+    )
+    monkeypatch.setattr(language_utils.platform, "system", lambda: "Darwin")
+    attempts: list[str] = []
+
+    def flaky_run(command, **_kwargs):
+        attempts.append(command[-1])
+        if len(attempts) <= 2:
+            # 前两次（AppleLocale + AppleLanguages）都超时 → 本轮整体失败
+            raise language_utils.subprocess.TimeoutExpired(command, 1.0)
+        return SimpleNamespace(returncode=0, stdout='"zh_CN"\n')
+
+    monkeypatch.setattr(language_utils.subprocess, "run", flaky_run)
+
+    assert language_utils._get_macos_locale() is None
+    # 失败没被写进缓存，所以下一次调用会重新探测并拿到真实 locale
+    assert language_utils._get_macos_locale() == "zh_CN"
+
+
+def test_macos_locale_non_darwin_is_cached(monkeypatch):
+    """"Not macOS" is conclusive, so it is cached and never re-probed."""
+    monkeypatch.setattr(
+        language_utils, "_macos_locale_cache", language_utils._MACOS_LOCALE_UNSET
+    )
+    systems: list[int] = []
+
+    def counted_system():
+        systems.append(1)
+        return "Windows"
+
+    monkeypatch.setattr(language_utils.platform, "system", counted_system)
+
+    assert language_utils._get_macos_locale() is None
+    assert language_utils._get_macos_locale() is None
+    assert language_utils._get_macos_locale() is None
+    assert len(systems) == 1, f"platform.system() 被重复调用了 {len(systems)} 次"
 
 
 def test_system_language_uses_macos_locale_before_neutral_process_locale(monkeypatch):

--- a/tests/unit/test_memory_language_resolution.py
+++ b/tests/unit/test_memory_language_resolution.py
@@ -12,6 +12,9 @@ from utils import language_utils
 
 
 def test_macos_locale_reads_apple_locale(monkeypatch):
+    # _get_macos_locale 带进程级缓存；不清掉的话本用例会读到别的用例留下的值
+    # （在非 macOS 的 CI 上那个值是 None），断言就永远看不到 fake_run 的结果。
+    monkeypatch.setattr(language_utils, "_macos_locale_cache", None)
     monkeypatch.setattr(language_utils.platform, "system", lambda: "Darwin")
 
     def fake_run(command, **_kwargs):
@@ -21,6 +24,28 @@ def test_macos_locale_reads_apple_locale(monkeypatch):
     monkeypatch.setattr(language_utils.subprocess, "run", fake_run)
 
     assert language_utils._get_macos_locale() == "zh_CN"
+
+
+def test_macos_locale_is_read_once_per_process(monkeypatch):
+    """Repeated lookups must not respawn `defaults`."""
+    # initialize_global_language() 会经 _is_china_region 和 _get_system_language
+    # 各调一次；每次未命中都是一个 1s 超时的 subprocess，而且整个初始化持
+    # _global_language_lock。两个全局 getter 又都能从 async 请求路径到达，
+    # 冷启动多花几秒就会卡住事件循环。
+    monkeypatch.setattr(language_utils, "_macos_locale_cache", None)
+    monkeypatch.setattr(language_utils.platform, "system", lambda: "Darwin")
+    calls: list[list[str]] = []
+
+    def fake_run(command, **_kwargs):
+        calls.append(command)
+        return SimpleNamespace(returncode=0, stdout='"ja_JP"\n')
+
+    monkeypatch.setattr(language_utils.subprocess, "run", fake_run)
+
+    assert language_utils._get_macos_locale() == "ja_JP"
+    assert language_utils._get_macos_locale() == "ja_JP"
+    assert language_utils._get_macos_locale() == "ja_JP"
+    assert len(calls) == 1, f"defaults 被重复调用了 {len(calls)} 次"
 
 
 def test_system_language_uses_macos_locale_before_neutral_process_locale(monkeypatch):

--- a/tests/unit/test_memory_request_language_context.py
+++ b/tests/unit/test_memory_request_language_context.py
@@ -91,7 +91,7 @@ async def test_process_requests_keep_language_task_local_across_awaits(monkeypat
 
 @pytest.mark.asyncio
 async def test_cache_hands_outbox_the_undeclared_language_as_none(monkeypatch):
-    """请求未声明 locale 时，交给 outbox 的必须是 None 而不是本进程的探测值。"""
+    """An undeclared request locale must reach the outbox as None, not as a guess."""
     spawn = AsyncMock()
     monkeypatch.setattr(
         routes.runtime,
@@ -125,16 +125,14 @@ async def test_cache_hands_outbox_the_undeclared_language_as_none(monkeypatch):
 
 
 def test_outbox_enqueue_persists_only_client_declared_language():
-    """四个写路由必须把 request.language 原值交给 outbox，而不是回落后的 memory_language。
-
-    memory_language 在请求未声明 locale 时等于 get_global_language_full() 的探测
-    结果。把它写进 outbox.ndjson 会让这个「猜测」被永久冻结：重启 replay 一直复用
-    它，即使探测本身后来修好也不会自愈。省掉该键才能让 replay 按当时的进程语言
-    重新解析（即 outbox 引入之前的行为）。
-
-    用 AST 盯调用点而非只测 _spawn_outbox_post_turn_signals 自身：后者只能证明
-    「传 None 就不写 payload」，证明不了路由真的传了 None。
-    """
+    """Every write route must hand the outbox request.language, not memory_language."""
+    # memory_language 在请求未声明 locale 时等于 get_global_language_full() 的探测
+    # 结果。把它写进 outbox.ndjson 会让这个「猜测」被永久冻结：重启 replay 一直复用
+    # 它，即使探测本身后来修好也不会自愈。省掉该键才能让 replay 按当时的进程语言
+    # 重新解析（即 outbox 引入之前的行为）。
+    #
+    # 用 AST 盯调用点而非只测 _spawn_outbox_post_turn_signals 自身：后者只能证明
+    # 「传 None 就不写 payload」，证明不了路由真的传了 None。
     source = routes.__file__
     assert source is not None
     tree = ast.parse(Path(source).read_text(encoding="utf-8"))

--- a/tests/unit/test_outbox_wiring.py
+++ b/tests/unit/test_outbox_wiring.py
@@ -78,14 +78,12 @@ async def test_spawn_outbox_happy_path_marks_done(tmp_path):
 
 @pytest.mark.asyncio
 async def test_spawn_outbox_omits_language_when_request_declared_none(tmp_path):
-    """请求未声明 locale 时不得把本进程的探测值写进 payload。
-
-    _activate_request_language 在请求没带 language 时会回落到
-    get_global_language_full()。那个回落值用于处理本次请求没问题，但一旦被
-    持久化进 outbox.ndjson，重启 replay 就会一直复用这个「猜测」——即使探测
-    本身后来修好了也不会自愈。省掉这个键才能让 replay 按当时的进程语言重新解析
-    （即 outbox 引入之前的行为）。
-    """
+    """A locale this process merely guessed must never be written into the payload."""
+    # _activate_request_language 在请求没带 language 时会回落到
+    # get_global_language_full()。那个回落值用于处理本次请求没问题，但一旦被持久化
+    # 进 outbox.ndjson，重启 replay 就会一直复用这个「猜测」——即使探测本身后来修好
+    # 也不会自愈。省掉这个键才能让 replay 按当时的进程语言重新解析（即 outbox
+    # 引入之前的行为）。
     ob, _ = _install_fresh_memory_state(str(tmp_path))
     from app import memory_server
     from memory.outbox import OP_POST_TURN_SIGNALS
@@ -112,10 +110,8 @@ async def test_spawn_outbox_omits_language_when_request_declared_none(tmp_path):
 
 @pytest.mark.asyncio
 async def test_replay_without_recorded_language_falls_back_to_process_locale():
-    """存量 outbox 条目（无 language 键）replay 时回落进程语言，而不是报错或冻结旧值。
-
-    这是升级用户唯一会走的路径：#1542 之前入队的条目都没有这个键。
-    """
+    """Legacy entries without a language key replay against the current process locale."""
+    # 这是升级用户唯一会走的路径：#1542 之前入队的条目都没有这个键。
     from app import memory_server
     from utils.llm_client import messages_to_dict
 

--- a/utils/language_utils.py
+++ b/utils/language_utils.py
@@ -187,13 +187,50 @@ def _is_china_region() -> bool:
         return False
 
 
+_macos_locale_cache: Optional[Tuple[bool, Optional[str]]] = None
+_macos_locale_lock = threading.Lock()
+
+
 def _get_macos_locale() -> Optional[str]:
     """Read the user's real macOS locale even when the process inherits ``C.UTF-8``.
 
     Electron/launcher child processes commonly receive a neutral POSIX locale,
     so ``locale.getlocale()`` and ``LANG`` do not reflect System Settings.  The
     ``defaults`` database is the authoritative per-user fallback on macOS.
+
+    The result is cached for the lifetime of the process: each miss costs a
+    ``subprocess.run`` with a 1s timeout, and ``initialize_global_language()``
+    calls this twice (once via ``_is_china_region``, once via
+    ``_get_system_language``) while holding ``_global_language_lock``. Without
+    the cache a cold start could spend ~4s spawning ``defaults`` — and both
+    global getters are reached from async request paths, so that would block the
+    event loop. The OS locale does not change under a running process.
     """
+    global _macos_locale_cache
+
+    cached = _macos_locale_cache
+    if cached is not None:
+        return cached[1]
+
+    with _macos_locale_lock:
+        # 双检：等锁期间可能已被另一线程填好。
+        cached = _macos_locale_cache
+        if cached is not None:
+            return cached[1]
+        resolved = _read_macos_locale_uncached()
+        _macos_locale_cache = (True, resolved)
+        return resolved
+
+
+def _reset_macos_locale_cache() -> None:
+    """Drop the cached macOS locale (tests only)."""
+    global _macos_locale_cache
+    with _macos_locale_lock:
+        _macos_locale_cache = None
+
+
+def _read_macos_locale_uncached() -> Optional[str]:
+    """Query the macOS ``defaults`` database; see ``_get_macos_locale``."""
     if platform.system() != 'Darwin':
         return None
 

--- a/utils/language_utils.py
+++ b/utils/language_utils.py
@@ -187,7 +187,8 @@ def _is_china_region() -> bool:
         return False
 
 
-_macos_locale_cache: Optional[Tuple[bool, Optional[str]]] = None
+_MACOS_LOCALE_UNSET = object()
+_macos_locale_cache: Any = _MACOS_LOCALE_UNSET
 _macos_locale_lock = threading.Lock()
 
 
@@ -198,27 +199,39 @@ def _get_macos_locale() -> Optional[str]:
     so ``locale.getlocale()`` and ``LANG`` do not reflect System Settings.  The
     ``defaults`` database is the authoritative per-user fallback on macOS.
 
-    The result is cached for the lifetime of the process: each miss costs a
-    ``subprocess.run`` with a 1s timeout, and ``initialize_global_language()``
-    calls this twice (once via ``_is_china_region``, once via
-    ``_get_system_language``) while holding ``_global_language_lock``. Without
-    the cache a cold start could spend ~4s spawning ``defaults`` — and both
-    global getters are reached from async request paths, so that would block the
-    event loop. The OS locale does not change under a running process.
+    Only *conclusive* answers are cached — a resolved locale, or "not macOS".
+    Each miss costs a ``subprocess.run`` with a 1s timeout, and
+    ``initialize_global_language()`` calls this twice (once via
+    ``_is_china_region``, once via ``_get_system_language``) while holding
+    ``_global_language_lock``; without caching, a cold start could spend ~4s
+    spawning ``defaults`` while both global getters are reachable from async
+    request paths. A failed probe is deliberately NOT cached: a single timeout
+    must not pin the whole process to the wrong locale, which is exactly the
+    situation this helper exists to rescue.
     """
     global _macos_locale_cache
 
     cached = _macos_locale_cache
-    if cached is not None:
-        return cached[1]
+    if cached is not _MACOS_LOCALE_UNSET:
+        return cached
 
     with _macos_locale_lock:
         # 双检：等锁期间可能已被另一线程填好。
         cached = _macos_locale_cache
-        if cached is not None:
-            return cached[1]
+        if cached is not _MACOS_LOCALE_UNSET:
+            return cached
+
+        if platform.system() != 'Darwin':
+            # 非 macOS 是确定性结论，缓存住，省掉后续每次的 platform 判断。
+            _macos_locale_cache = None
+            return None
+
         resolved = _read_macos_locale_uncached()
-        _macos_locale_cache = (True, resolved)
+        if resolved:
+            _macos_locale_cache = resolved
+        # 探测失败（defaults 超时 / 非零退出 / 输出为空）不写缓存：那是瞬时故障，
+        # 下次调用重试。缓存住等于让一次超时把整个进程钉死在错误的 locale 上，
+        # 而「其它信号都不可靠」正是本函数要兜的场景。
         return resolved
 
 
@@ -226,7 +239,7 @@ def _reset_macos_locale_cache() -> None:
     """Drop the cached macOS locale (tests only)."""
     global _macos_locale_cache
     with _macos_locale_lock:
-        _macos_locale_cache = None
+        _macos_locale_cache = _MACOS_LOCALE_UNSET
 
 
 def _read_macos_locale_uncached() -> Optional[str]:


### PR DESCRIPTION
#1542 收尾，两件小事。

## 1. `_get_macos_locale()` 加进程级缓存

每次未命中都要 `subprocess.run(['/usr/bin/defaults', 'read', '-g', key])`，超时 1s，原实现**无缓存**。而 `initialize_global_language()` 会经 `_is_china_region` 和 `_get_system_language` 各调它一次，每次最多试 `AppleLocale` / `AppleLanguages` 两个 key —— 最坏一次冷启动 spawn 4 次、约 4 秒，**且整个初始化持 `_global_language_lock`**。

`get_global_language()` / `get_global_language_full()` 又大量出现在 async 请求路径上（`app/memory_server/routes.py` 等），首次触发若落在事件循环里就会把它阻塞住 —— 与 #2466「async 路径同步配置读挪出事件循环」的方向相悖。

改成双检 + 锁的进程级缓存（OS locale 在进程运行期间不会变），真正的查询逻辑拆到 `_read_macos_locale_uncached()`。

**顺带修了一个实测出来的测试顺序污染**：加缓存后 `test_macos_locale_reads_apple_locale` 会读到别的用例留下的缓存值（非 macOS CI 上是 `None`），断言就永远看不到 `fake_run` 的结果 —— 先跑 `test_language_region_override.py` 再跑它就会红。已加 `monkeypatch.setattr(language_utils, "_macos_locale_cache", None)` 隔离。

## 2. 清掉 #2519 遗留的 4 处中文 docstring

`DOCSTRING_CJK` 门要求 docstring 用英文。#2519 合并时带进去 4 处中文的，这里一并清掉，背景说明移到 `#` 注释（注释不受该门限制）。

## 关于 changelog：本 PR 不做，已转 #2522

原计划在这个 PR 里补 #1542 那批 locale 变更的 changelog（台港用户升级后区域选源与界面语言会变），查完之后判断**不该在功能 PR 里加**：

- `main_routers/system_router/changelog_survey.py` 的 `get_changelog` 只有 `if file_ver > since_ver` 一个条件，**没有 `<= APP_VERSION` 的上界**。现在建 `config/changelog/0.8.4.md`，跑在 0.8.3 的用户下次打开就会看到尚未发布的内容。
- `v0.8.3` tag 已存在、`APP_VERSION` 仍是 `0.8.3`，说明 0.8.4 还没开题。
- 仓库惯例是发版时统一写全语言（参见 `1f3188ca0 release: 0.8.3 全语言更新日志 + 问卷从 0.8.2 迁到 0.8.3`）。

已开 #2522 挂到发版流程上。

## 回归报告 / Regression Report

- **改动了什么**：`_get_macos_locale()` 加进程级缓存并拆出未缓存实现；补两条测试；清 4 处中文 docstring。
- **理由 / 必要性**：冷启动最坏 4 次 1s 超时的 subprocess 且全程持锁，而调用方在 async 路径上。
- **改动前后的表现对比**：返回值不变，只是同一进程内第二次起直接命中缓存。副作用：运行中修改系统语言需重启才生效 —— 与既有的 `_global_language_initialized` 缓存行为一致。
- **潜在回归点**：(a) 测试若在缓存被填充后 monkeypatch `subprocess.run`，会读到旧值 —— 已由 `_reset_macos_locale_cache()` 与 monkeypatch 清缓存覆盖，并新增 `test_macos_locale_is_read_once_per_process` 守住缓存本身；(b) 非 macOS 平台 `_read_macos_locale_uncached` 仍在第一行返回 `None`，行为不变。
- **验证**：变异验证 —— 去掉写缓存那行后 `test_macos_locale_is_read_once_per_process` 变红，还原后 13 passed；`check_docstring_no_cjk --base origin/main` 退出码 0；`uv run pytest tests/unit -q` → **6812 passed, 26 skipped, 0 failed**。

## 不拆分理由 / Why Not Split

两处都在 locale 探测这条线的收尾上，共 4 个文件、+79/-23，且共享同一次全量验证。

---

## Review 后的修正（`64520104f`）

Greptile 两条 P1 都成立，已处理：

**1. 瞬时失败被永久缓存** —— 原实现无论成功失败都写缓存，macOS 上首次 `defaults` 超时就会把 `None` 钉死一整个进程周期，而那恰恰是这个 helper 要兜底的场景。改为只缓存**确定性结论**：非 Darwin（缓存 `None`）、探测到 locale（缓存该值）；超时 / 非零退出 / 空输出一律不写缓存。顺带把哨兵从 `(bool, value)` 元组换成独立的 `_MACOS_LOCALE_UNSET`（原来的 bool 恒为 True，是冗余状态）。新增两条测试，变异验证：改回「失败也缓存」后 `test_macos_locale_probe_failure_is_retried_not_cached` 立刻变红。

**2. 上层初始化仍会钉死语言** —— 这条我在本 PR 里没能解决，已开 #2525 跟踪。核实下来是**既有设计**：`92ed2818b~1`（#1542 合入前）的 `initialize_global_language()` 已经是无条件 `_global_language_initialized = True`，而 `_get_system_language()` 自带兜底（最终 `return 'en'`），所以「探测失败」表现为回落值被当成探测结果存下。

**同时修正本 PR 上文一处过强的说法**：「失败不缓存 → 下次调用重试」只在没走上层初始化缓存时成立。它仍有两处实际价值 —— 同一次 `initialize_global_language()` 内 `_is_china_region()` 与 `_get_system_language()` 会各调一次 `_get_macos_locale()`，前者瞬时失败后者仍可能成功；以及直接调用该 helper 的路径。但对「进程已完成初始化」这条主链路无效。

**3. `Unused global variable` ×3** —— 误报，未改。`_macos_locale_cache` 读 2 次写 3 次，三条都报在 `global` 声明行上，分析器应该是没跟踪 `global` 造成的模块级绑定。

最终验证：`uv run pytest tests/unit -q` → **6814 passed, 26 skipped, 0 failed**。
