### PR TITLE
fix(plugin-manager): silence automatic panel action errors

### DIFF
--- a/frontend/plugin-manager/src/api/plugins.test.ts
+++ b/frontend/plugin-manager/src/api/plugins.test.ts
@@ -14,7 +14,7 @@ describe('plugin hosted UI API', () => {
     getMock.mockReset()
   })
 
-  it('passes hosted action timeout to the request body and axios config', async () => {
+  it('silences initial hosted action errors while passing its timeout', async () => {
     postMock.mockResolvedValue({ ok: true })
     const { callPluginHostedSurfaceAction } = await import('./plugins')
 
@@ -34,7 +34,24 @@ describe('plugin hosted UI API', () => {
         locale: 'zh-CN',
         timeout_ms: 80000,
       },
-      { timeout: 80000 },
+      { suppressErrorMessage: true, timeout: 80000 },
+    )
+  })
+
+  it('keeps the global error message for a user-initiated hosted action', async () => {
+    postMock.mockResolvedValue({ ok: true })
+    const { callPluginHostedSurfaceAction } = await import('./plugins')
+
+    await callPluginHostedSurfaceAction('demo', 'save', {}, {
+      kind: 'panel',
+      id: 'main',
+      userInitiated: true,
+    })
+
+    expect(postMock).toHaveBeenCalledWith(
+      '/plugin/demo/hosted-ui/action/save',
+      expect.objectContaining({ timeout_ms: undefined }),
+      { suppressErrorMessage: false },
     )
   })
 })

--- a/frontend/plugin-manager/src/api/plugins.test.ts
+++ b/frontend/plugin-manager/src/api/plugins.test.ts
@@ -14,7 +14,7 @@ describe('plugin hosted UI API', () => {
     getMock.mockReset()
   })
 
-  it('passes hosted action timeout and suppresses global error messages', async () => {
+  it('passes hosted action timeout to the request body and axios config', async () => {
     postMock.mockResolvedValue({ ok: true })
     const { callPluginHostedSurfaceAction } = await import('./plugins')
 
@@ -34,20 +34,7 @@ describe('plugin hosted UI API', () => {
         locale: 'zh-CN',
         timeout_ms: 80000,
       },
-      { suppressErrorMessage: true, timeout: 80000 },
-    )
-  })
-
-  it('suppresses global error messages even without a custom timeout', async () => {
-    postMock.mockResolvedValue({ ok: true })
-    const { callPluginHostedSurfaceAction } = await import('./plugins')
-
-    await callPluginHostedSurfaceAction('demo', 'status')
-
-    expect(postMock).toHaveBeenCalledWith(
-      '/plugin/demo/hosted-ui/action/status',
-      expect.objectContaining({ timeout_ms: undefined }),
-      { suppressErrorMessage: true },
+      { timeout: 80000 },
     )
   })
 })

--- a/frontend/plugin-manager/src/api/plugins.test.ts
+++ b/frontend/plugin-manager/src/api/plugins.test.ts
@@ -34,7 +34,7 @@ describe('plugin hosted UI API', () => {
         locale: 'zh-CN',
         timeout_ms: 80000,
       },
-      { suppressErrorMessage: true, timeout: 80000 },
+      { suppressPluginNotRunningMessage: true, timeout: 80000 },
     )
   })
 
@@ -51,7 +51,7 @@ describe('plugin hosted UI API', () => {
     expect(postMock).toHaveBeenCalledWith(
       '/plugin/demo/hosted-ui/action/save',
       expect.objectContaining({ timeout_ms: undefined }),
-      { suppressErrorMessage: false },
+      { suppressPluginNotRunningMessage: false },
     )
   })
 })

--- a/frontend/plugin-manager/src/api/plugins.test.ts
+++ b/frontend/plugin-manager/src/api/plugins.test.ts
@@ -14,7 +14,7 @@ describe('plugin hosted UI API', () => {
     getMock.mockReset()
   })
 
-  it('passes hosted action timeout to the request body and axios config', async () => {
+  it('passes hosted action timeout and suppresses global error messages', async () => {
     postMock.mockResolvedValue({ ok: true })
     const { callPluginHostedSurfaceAction } = await import('./plugins')
 
@@ -34,7 +34,20 @@ describe('plugin hosted UI API', () => {
         locale: 'zh-CN',
         timeout_ms: 80000,
       },
-      { timeout: 80000 },
+      { suppressErrorMessage: true, timeout: 80000 },
+    )
+  })
+
+  it('suppresses global error messages even without a custom timeout', async () => {
+    postMock.mockResolvedValue({ ok: true })
+    const { callPluginHostedSurfaceAction } = await import('./plugins')
+
+    await callPluginHostedSurfaceAction('demo', 'status')
+
+    expect(postMock).toHaveBeenCalledWith(
+      '/plugin/demo/hosted-ui/action/status',
+      expect.objectContaining({ timeout_ms: undefined }),
+      { suppressErrorMessage: true },
     )
   })
 })

--- a/frontend/plugin-manager/src/api/plugins.ts
+++ b/frontend/plugin-manager/src/api/plugins.ts
@@ -266,13 +266,20 @@ export function callPluginHostedSurfaceAction(pluginId: string, actionId: string
   const safeActionId = encodeURIComponent(actionId)
   const requestedTimeoutMs = Number(surface?.timeoutMs)
   const timeoutMs = Number.isFinite(requestedTimeoutMs) && requestedTimeoutMs > 0 ? requestedTimeoutMs : undefined
+  // Hosted surfaces receive this rejection through the postMessage bridge and
+  // render it in their own UI. Avoid one global Element Plus message per
+  // concurrent panel request (notably when a manual-start plugin is stopped).
+  const requestConfig = {
+    suppressErrorMessage: true,
+    ...(timeoutMs ? { timeout: timeoutMs } : {}),
+  }
   return post(`/plugin/${safeId}/hosted-ui/action/${safeActionId}`, {
     args: args || {},
     kind: surface?.kind,
     surface_id: surface?.id,
     locale: surface?.locale,
     timeout_ms: timeoutMs,
-  }, timeoutMs ? { timeout: timeoutMs } : undefined)
+  }, requestConfig)
 }
 
 /**

--- a/frontend/plugin-manager/src/api/plugins.ts
+++ b/frontend/plugin-manager/src/api/plugins.ts
@@ -266,20 +266,13 @@ export function callPluginHostedSurfaceAction(pluginId: string, actionId: string
   const safeActionId = encodeURIComponent(actionId)
   const requestedTimeoutMs = Number(surface?.timeoutMs)
   const timeoutMs = Number.isFinite(requestedTimeoutMs) && requestedTimeoutMs > 0 ? requestedTimeoutMs : undefined
-  // Hosted surfaces receive this rejection through the postMessage bridge and
-  // render it in their own UI. Avoid one global Element Plus message per
-  // concurrent panel request (notably when a manual-start plugin is stopped).
-  const requestConfig = {
-    suppressErrorMessage: true,
-    ...(timeoutMs ? { timeout: timeoutMs } : {}),
-  }
   return post(`/plugin/${safeId}/hosted-ui/action/${safeActionId}`, {
     args: args || {},
     kind: surface?.kind,
     surface_id: surface?.id,
     locale: surface?.locale,
     timeout_ms: timeoutMs,
-  }, requestConfig)
+  }, timeoutMs ? { timeout: timeoutMs } : undefined)
 }
 
 /**

--- a/frontend/plugin-manager/src/api/plugins.ts
+++ b/frontend/plugin-manager/src/api/plugins.ts
@@ -268,11 +268,11 @@ export function callPluginHostedSurfaceAction(pluginId: string, actionId: string
   const safeActionId = encodeURIComponent(actionId)
   const requestedTimeoutMs = Number(surface?.timeoutMs)
   const timeoutMs = Number.isFinite(requestedTimeoutMs) && requestedTimeoutMs > 0 ? requestedTimeoutMs : undefined
-  // Initial hosted-panel calls are expected to fail while a manual-start
-  // plugin is stopped. Let the panel render that state silently. Calls made
-  // after a real iframe interaction keep the standard global error message.
+  // Initial hosted-panel calls may probe actions while a manual-start plugin
+  // is stopped. Suppress only that expected response; all other failures keep
+  // the standard global error handling.
   const requestConfig = {
-    suppressErrorMessage: !surface?.userInitiated,
+    suppressPluginNotRunningMessage: !surface?.userInitiated,
     ...(timeoutMs ? { timeout: timeoutMs } : {}),
   }
   return post(`/plugin/${safeId}/hosted-ui/action/${safeActionId}`, {

--- a/frontend/plugin-manager/src/api/plugins.ts
+++ b/frontend/plugin-manager/src/api/plugins.ts
@@ -257,6 +257,8 @@ export function callPluginHostedSurfaceAction(pluginId: string, actionId: string
   id: string
   locale?: string
   timeoutMs?: number
+  /** True only when the request originates from a user action in the hosted iframe. */
+  userInitiated?: boolean
 }): Promise<{
   plugin_id: string
   action_id: string
@@ -266,13 +268,20 @@ export function callPluginHostedSurfaceAction(pluginId: string, actionId: string
   const safeActionId = encodeURIComponent(actionId)
   const requestedTimeoutMs = Number(surface?.timeoutMs)
   const timeoutMs = Number.isFinite(requestedTimeoutMs) && requestedTimeoutMs > 0 ? requestedTimeoutMs : undefined
+  // Initial hosted-panel calls are expected to fail while a manual-start
+  // plugin is stopped. Let the panel render that state silently. Calls made
+  // after a real iframe interaction keep the standard global error message.
+  const requestConfig = {
+    suppressErrorMessage: !surface?.userInitiated,
+    ...(timeoutMs ? { timeout: timeoutMs } : {}),
+  }
   return post(`/plugin/${safeId}/hosted-ui/action/${safeActionId}`, {
     args: args || {},
     kind: surface?.kind,
     surface_id: surface?.id,
     locale: surface?.locale,
     timeout_ms: timeoutMs,
-  }, timeoutMs ? { timeout: timeoutMs } : undefined)
+  }, requestConfig)
 }
 
 /**

--- a/frontend/plugin-manager/src/components/plugin/HostedSurfaceFrame.vue
+++ b/frontend/plugin-manager/src/components/plugin/HostedSurfaceFrame.vue
@@ -496,6 +496,7 @@ async function handleHostedRequest(data: any) {
   const requestId = typeof data.requestId === 'string' ? data.requestId : ''
   const method = typeof data.method === 'string' ? data.method : ''
   const actionId = method === 'call' ? String(data.payload?.actionId || '') : ''
+  const userInitiated = method === 'call' && data.userInitiated === true
   const respond = (payload: Record<string, any>) => {
     // PR #1480 review-fix 1.30: target the trusted origin instead of '*'.
     // For srcdoc iframes (opaque origin, reported as 'null'), the postMessage
@@ -518,6 +519,7 @@ async function handleHostedRequest(data: any) {
         id: props.surface.id,
         locale: String(locale.value),
         timeoutMs: Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : undefined,
+        userInitiated,
       })
       respond({ ok: true, result })
       return

--- a/frontend/plugin-manager/src/components/plugin/hosted/ui-kit/runtime.js
+++ b/frontend/plugin-manager/src/components/plugin/hosted/ui-kit/runtime.js
@@ -1054,8 +1054,8 @@ function useConfirm() {
       const close = (value) => {
         renderPortal(null);
         host.remove();
-        if (value && __hostedUserActionDepth > 0) retainHostedConfirmedAction();
         resolve(value);
+        if (value && __hostedUserActionDepth > 0) retainHostedConfirmedAction();
       };
       renderPortal(h(ConfirmDialog, {
         open: true,

--- a/frontend/plugin-manager/src/components/plugin/hosted/ui-kit/runtime.js
+++ b/frontend/plugin-manager/src/components/plugin/hosted/ui-kit/runtime.js
@@ -955,18 +955,28 @@ function ensureToastRoot() {
   }
   return root;
 }
+const activeDangerToastKeys = new Set();
 function showToast(message, options) {
   const opts = typeof options === 'string' ? { tone: options } : (options || {});
+  const renderedMessage = formatErrorMessage(message);
+  // A hosted panel can issue several initial requests concurrently.  When a
+  // stopped plugin rejects all of them, each caller may report the same error
+  // through toast.error().  Keep one visible error for the duration of the
+  // toast, but do not swallow other messages or a later retry.
+  const dangerKey = opts.tone === 'danger' ? renderedMessage : '';
+  if (dangerKey && activeDangerToastKeys.has(dangerKey)) return () => {};
+  if (dangerKey) activeDangerToastKeys.add(dangerKey);
   const item = document.createElement('div');
   item.className = 'neko-toast';
   item.setAttribute('data-tone', opts.tone || 'info');
-  item.textContent = formatErrorMessage(message);
+  item.textContent = renderedMessage;
   ensureToastRoot().appendChild(item);
   const timeout = opts.timeout === undefined ? 3000 : Number(opts.timeout);
   let removed = false;
   const remove = () => {
     if (removed) return;
     removed = true;
+    if (dangerKey) activeDangerToastKeys.delete(dangerKey);
     item.remove();
   };
   if (timeout > 0) window.setTimeout(remove, timeout);

--- a/frontend/plugin-manager/src/components/plugin/hosted/ui-kit/runtime.js
+++ b/frontend/plugin-manager/src/components/plugin/hosted/ui-kit/runtime.js
@@ -578,6 +578,22 @@ function patchProps(dom, oldProps, newProps) {
     if (oldProps[name] !== newProps[name]) setProp(dom, name, oldProps[name], newProps[name]);
   });
 }
+const __hostedUserActionEvents = new Set(['click', 'submit', 'keydown']);
+let __hostedUserActionDepth = 0;
+function wrapHostedEventHandler(eventName, handler) {
+  if (!__hostedUserActionEvents.has(eventName)) return handler;
+  return (event) => {
+    // Synthetic events are automatic activity, even if they invoke the same
+    // handler as a real click. happy-dom leaves isTrusted undefined.
+    const userInitiated = event && event.isTrusted !== false;
+    if (userInitiated) __hostedUserActionDepth += 1;
+    try {
+      return handler(event);
+    } finally {
+      if (userInitiated) __hostedUserActionDepth -= 1;
+    }
+  };
+}
 function setProp(dom, name, oldValue, newValue) {
   if (name === 'className') name = 'class';
   if (name === 'style') {
@@ -597,8 +613,15 @@ function setProp(dom, name, oldValue, newValue) {
   }
   if (name.startsWith('on') && typeof (oldValue || newValue) === 'function') {
     const eventName = name.slice(2).toLowerCase();
-    if (oldValue) dom.removeEventListener(eventName, oldValue);
-    if (newValue) dom.addEventListener(eventName, newValue);
+    const listeners = dom.__nekoEventListeners || (dom.__nekoEventListeners = {});
+    if (listeners[eventName]) dom.removeEventListener(eventName, listeners[eventName]);
+    if (newValue) {
+      const listener = wrapHostedEventHandler(eventName, newValue);
+      listeners[eventName] = listener;
+      dom.addEventListener(eventName, listener);
+    } else {
+      delete listeners[eventName];
+    }
     return;
   }
   if (name === 'dangerouslySetInnerHTML' || name === 'innerHTML' || name === 'srcdoc') {
@@ -1911,16 +1934,6 @@ function refreshHostedPayload(context) {
 }
 
 const __pendingRequests = new Map();
-let __lastUserInteractionAt = 0;
-// Hosted surfaces make background calls during their initial render.  The
-// parent uses this marker to keep those expected failures quiet, while still
-// surfacing an error caused by an actual click or keyboard submission.
-function markHostedUserInteraction() {
-  __lastUserInteractionAt = Date.now();
-}
-document.addEventListener('click', markHostedUserInteraction, true);
-document.addEventListener('submit', markHostedUserInteraction, true);
-document.addEventListener('keydown', markHostedUserInteraction, true);
 window.addEventListener('message', (event) => {
   const data = event.data;
   if (!data || typeof data !== 'object' || data.type !== 'neko-hosted-surface-response') return;
@@ -1936,7 +1949,7 @@ function requestHost(method, payload, options) {
   const timeoutMs = Number.isFinite(requestedTimeoutMs) && requestedTimeoutMs > 0 ? requestedTimeoutMs : 30000;
   return new Promise((resolve, reject) => {
     __pendingRequests.set(requestId, { resolve, reject });
-    const userInitiated = method === 'call' && Date.now() - __lastUserInteractionAt < 1000;
+    const userInitiated = method === 'call' && __hostedUserActionDepth > 0;
     parent.postMessage({ type: 'neko-hosted-surface-request', requestId, method, payload, timeoutMs, userInitiated }, hostedTargetOrigin());
     window.setTimeout(() => {
       if (!__pendingRequests.has(requestId)) return;

--- a/frontend/plugin-manager/src/components/plugin/hosted/ui-kit/runtime.js
+++ b/frontend/plugin-manager/src/components/plugin/hosted/ui-kit/runtime.js
@@ -1949,7 +1949,7 @@ function requestHost(method, payload, options) {
   const timeoutMs = Number.isFinite(requestedTimeoutMs) && requestedTimeoutMs > 0 ? requestedTimeoutMs : 30000;
   return new Promise((resolve, reject) => {
     __pendingRequests.set(requestId, { resolve, reject });
-    const userInitiated = method === 'call' && __hostedUserActionDepth > 0;
+    const userInitiated = method === 'call' && options && options.userInitiated === true;
     parent.postMessage({ type: 'neko-hosted-surface-request', requestId, method, payload, timeoutMs, userInitiated }, hostedTargetOrigin());
     window.setTimeout(() => {
       if (!__pendingRequests.has(requestId)) return;
@@ -1959,7 +1959,16 @@ function requestHost(method, payload, options) {
   });
 }
 const api = {
-  call(actionId, args, options) { return requestHost('call', { actionId, args: args || {} }, options || {}); },
+  // Async handlers lose the synchronous DOM event scope after an await. They
+  // can explicitly preserve the attribution for this one action with
+  // { userInitiated: true }, without making unrelated background calls noisy.
+  call(actionId, args, options) {
+    const requestOptions = options || {};
+    return requestHost('call', { actionId, args: args || {} }, {
+      ...requestOptions,
+      userInitiated: requestOptions.userInitiated === true || __hostedUserActionDepth > 0,
+    });
+  },
   async refresh() {
     const context = await requestHost('refresh', {});
     return refreshHostedPayload(context);
@@ -1984,7 +1993,7 @@ function ActionButton(props) {
           return;
         }
         setLoading(true);
-        const result = await api.call(actionId, props.values || props.args || {});
+        const result = await api.call(actionId, props.values || props.args || {}, { userInitiated: true });
         if (action.refresh_context !== false && props.refresh !== false) await api.refresh();
         if (typeof props.onResult === 'function') props.onResult(result);
       } catch (error) {

--- a/frontend/plugin-manager/src/components/plugin/hosted/ui-kit/runtime.js
+++ b/frontend/plugin-manager/src/components/plugin/hosted/ui-kit/runtime.js
@@ -1911,6 +1911,16 @@ function refreshHostedPayload(context) {
 }
 
 const __pendingRequests = new Map();
+let __lastUserInteractionAt = 0;
+// Hosted surfaces make background calls during their initial render.  The
+// parent uses this marker to keep those expected failures quiet, while still
+// surfacing an error caused by an actual click or keyboard submission.
+function markHostedUserInteraction() {
+  __lastUserInteractionAt = Date.now();
+}
+document.addEventListener('click', markHostedUserInteraction, true);
+document.addEventListener('submit', markHostedUserInteraction, true);
+document.addEventListener('keydown', markHostedUserInteraction, true);
 window.addEventListener('message', (event) => {
   const data = event.data;
   if (!data || typeof data !== 'object' || data.type !== 'neko-hosted-surface-response') return;
@@ -1926,7 +1936,8 @@ function requestHost(method, payload, options) {
   const timeoutMs = Number.isFinite(requestedTimeoutMs) && requestedTimeoutMs > 0 ? requestedTimeoutMs : 30000;
   return new Promise((resolve, reject) => {
     __pendingRequests.set(requestId, { resolve, reject });
-    parent.postMessage({ type: 'neko-hosted-surface-request', requestId, method, payload, timeoutMs }, hostedTargetOrigin());
+    const userInitiated = method === 'call' && Date.now() - __lastUserInteractionAt < 1000;
+    parent.postMessage({ type: 'neko-hosted-surface-request', requestId, method, payload, timeoutMs, userInitiated }, hostedTargetOrigin());
     window.setTimeout(() => {
       if (!__pendingRequests.has(requestId)) return;
       __pendingRequests.delete(requestId);

--- a/frontend/plugin-manager/src/components/plugin/hosted/ui-kit/runtime.js
+++ b/frontend/plugin-manager/src/components/plugin/hosted/ui-kit/runtime.js
@@ -955,28 +955,18 @@ function ensureToastRoot() {
   }
   return root;
 }
-const activeDangerToastKeys = new Set();
 function showToast(message, options) {
   const opts = typeof options === 'string' ? { tone: options } : (options || {});
-  const renderedMessage = formatErrorMessage(message);
-  // A hosted panel can issue several initial requests concurrently.  When a
-  // stopped plugin rejects all of them, each caller may report the same error
-  // through toast.error().  Keep one visible error for the duration of the
-  // toast, but do not swallow other messages or a later retry.
-  const dangerKey = opts.tone === 'danger' ? renderedMessage : '';
-  if (dangerKey && activeDangerToastKeys.has(dangerKey)) return () => {};
-  if (dangerKey) activeDangerToastKeys.add(dangerKey);
   const item = document.createElement('div');
   item.className = 'neko-toast';
   item.setAttribute('data-tone', opts.tone || 'info');
-  item.textContent = renderedMessage;
+  item.textContent = formatErrorMessage(message);
   ensureToastRoot().appendChild(item);
   const timeout = opts.timeout === undefined ? 3000 : Number(opts.timeout);
   let removed = false;
   const remove = () => {
     if (removed) return;
     removed = true;
-    if (dangerKey) activeDangerToastKeys.delete(dangerKey);
     item.remove();
   };
   if (timeout > 0) window.setTimeout(remove, timeout);

--- a/frontend/plugin-manager/src/components/plugin/hosted/ui-kit/runtime.js
+++ b/frontend/plugin-manager/src/components/plugin/hosted/ui-kit/runtime.js
@@ -578,8 +578,23 @@ function patchProps(dom, oldProps, newProps) {
     if (oldProps[name] !== newProps[name]) setProp(dom, name, oldProps[name], newProps[name]);
   });
 }
-const __hostedUserActionEvents = new Set(['click', 'submit', 'keydown']);
+const __hostedUserActionEvents = new Set(['click', 'submit', 'keydown', 'change', 'input']);
 let __hostedUserActionDepth = 0;
+const __hostedConfirmedActionCredits = [];
+function retainHostedConfirmedAction() {
+  const credit = {};
+  __hostedConfirmedActionCredits.push(credit);
+  // Promise continuations registered by resolve run before this cleanup, so a
+  // confirmed `await useConfirm()` flow can claim one action without giving a
+  // later background request a time-based attribution window.
+  queueMicrotask(() => {
+    const index = __hostedConfirmedActionCredits.indexOf(credit);
+    if (index >= 0) __hostedConfirmedActionCredits.splice(index, 1);
+  });
+}
+function consumeHostedConfirmedAction() {
+  return __hostedConfirmedActionCredits.shift() !== undefined;
+}
 function wrapHostedEventHandler(eventName, handler) {
   if (!__hostedUserActionEvents.has(eventName)) return handler;
   return (event) => {
@@ -1039,6 +1054,7 @@ function useConfirm() {
       const close = (value) => {
         renderPortal(null);
         host.remove();
+        if (value && __hostedUserActionDepth > 0) retainHostedConfirmedAction();
         resolve(value);
       };
       renderPortal(h(ConfirmDialog, {
@@ -1964,9 +1980,10 @@ const api = {
   // { userInitiated: true }, without making unrelated background calls noisy.
   call(actionId, args, options) {
     const requestOptions = options || {};
+    const confirmedUserAction = consumeHostedConfirmedAction();
     return requestHost('call', { actionId, args: args || {} }, {
       ...requestOptions,
-      userInitiated: requestOptions.userInitiated === true || __hostedUserActionDepth > 0,
+      userInitiated: requestOptions.userInitiated === true || __hostedUserActionDepth > 0 || confirmedUserAction,
     });
   },
   async refresh() {
@@ -1985,7 +2002,7 @@ function ActionButton(props) {
     tone: props.tone || action.tone || 'primary',
     disabled: loading,
     children: props.children || label,
-    onClick: async () => {
+    onClick: async (event) => {
       try {
         setError('');
         const confirmMessage = props.confirm || action.confirm;
@@ -1993,7 +2010,7 @@ function ActionButton(props) {
           return;
         }
         setLoading(true);
-        const result = await api.call(actionId, props.values || props.args || {}, { userInitiated: true });
+        const result = await api.call(actionId, props.values || props.args || {}, { userInitiated: event && event.isTrusted !== false });
         if (action.refresh_context !== false && props.refresh !== false) await api.refresh();
         if (typeof props.onResult === 'function') props.onResult(result);
       } catch (error) {

--- a/frontend/plugin-manager/src/components/plugin/hosted/ui-kit/runtime.test.ts
+++ b/frontend/plugin-manager/src/components/plugin/hosted/ui-kit/runtime.test.ts
@@ -111,6 +111,36 @@ describe('hosted ui runtime', () => {
     })
   })
 
+  it('preserves explicit user attribution after an async handler awaits', async () => {
+    let requestMessage: any
+    Object.defineProperty(window, 'parent', {
+      value: {
+        postMessage(message: any) {
+          requestMessage = message
+          window.dispatchEvent(new MessageEvent('message', {
+            data: { type: 'neko-hosted-surface-response', requestId: message.requestId, ok: true, result: {} },
+          }))
+        },
+      },
+      configurable: true,
+    })
+    ui.render(ui.h('button', {
+      onClick: async () => {
+        await Promise.resolve()
+        void ui.api.call('save', {}, { userInitiated: true })
+      },
+    }), root)
+    const event = new Event('click', { bubbles: true })
+    Object.defineProperty(event, 'isTrusted', { value: true })
+    fireEvent(root.querySelector('button')!, event)
+    await flushMicrotasks()
+
+    expect(requestMessage).toMatchObject({
+      method: 'call',
+      userInitiated: true,
+    })
+  })
+
   it('runs hooks inside function components', async () => {
     function Counter() {
       const [count, setCount] = ui.useState(0)

--- a/frontend/plugin-manager/src/components/plugin/hosted/ui-kit/runtime.test.ts
+++ b/frontend/plugin-manager/src/components/plugin/hosted/ui-kit/runtime.test.ts
@@ -51,6 +51,32 @@ describe('hosted ui runtime', () => {
     document.body.appendChild(root)
   })
 
+  it('marks hosted action calls triggered by an iframe click as user initiated', () => {
+    let requestMessage: any
+    Object.defineProperty(window, 'parent', {
+      value: {
+        postMessage(message: any) {
+          requestMessage = message
+          window.dispatchEvent(new MessageEvent('message', {
+            data: { type: 'neko-hosted-surface-response', requestId: message.requestId, ok: true, result: {} },
+          }))
+        },
+      },
+      configurable: true,
+    })
+    const button = document.createElement('button')
+    button.addEventListener('click', () => { void ui.api.call('save') })
+    document.body.appendChild(button)
+
+    fireEvent.click(button)
+
+    expect(requestMessage).toMatchObject({
+      type: 'neko-hosted-surface-request',
+      method: 'call',
+      userInitiated: true,
+    })
+  })
+
   it('runs hooks inside function components', async () => {
     function Counter() {
       const [count, setCount] = ui.useState(0)

--- a/frontend/plugin-manager/src/components/plugin/hosted/ui-kit/runtime.test.ts
+++ b/frontend/plugin-manager/src/components/plugin/hosted/ui-kit/runtime.test.ts
@@ -55,6 +55,8 @@ describe('hosted ui runtime', () => {
     ['click', 'button', 'onClick'],
     ['submit', 'form', 'onSubmit'],
     ['keydown', 'input', 'onKeyDown'],
+    ['change', 'select', 'onChange'],
+    ['input', 'input', 'onInput'],
   ])('marks hosted action calls triggered by a trusted iframe %s as user initiated', (eventName, tagName, propName) => {
     let requestMessage: any
     Object.defineProperty(window, 'parent', {
@@ -138,6 +140,68 @@ describe('hosted ui runtime', () => {
     expect(requestMessage).toMatchObject({
       method: 'call',
       userInitiated: true,
+    })
+  })
+
+  it('preserves user attribution for the action immediately following useConfirm', async () => {
+    const requestMessages: any[] = []
+    Object.defineProperty(window, 'parent', {
+      value: {
+        postMessage(message: any) {
+          requestMessages.push(message)
+          window.dispatchEvent(new MessageEvent('message', {
+            data: { type: 'neko-hosted-surface-response', requestId: message.requestId, ok: true, result: {} },
+          }))
+        },
+      },
+      configurable: true,
+    })
+    function App() {
+      const confirm = ui.useConfirm()
+      return ui.h('button', {
+        onClick: async () => {
+          if (await confirm('Run this action?')) void ui.api.call('save')
+        },
+      }, 'Open confirmation')
+    }
+    ui.render(ui.h(App, null), root)
+    const click = (target: Element) => {
+      const event = new Event('click', { bubbles: true })
+      Object.defineProperty(event, 'isTrusted', { value: true })
+      fireEvent(target, event)
+    }
+    click(root.querySelector('button')!)
+    click(Array.from(document.querySelectorAll('button')).find((button) => button.textContent === 'Confirm')!)
+    await flushMicrotasks()
+
+    expect(requestMessages.at(-1)).toMatchObject({
+      method: 'call',
+      userInitiated: true,
+    })
+  })
+
+  it('keeps synthetic ActionButton clicks automatic', async () => {
+    let requestMessage: any
+    Object.defineProperty(window, 'parent', {
+      value: {
+        postMessage(message: any) {
+          requestMessage = message
+          window.dispatchEvent(new MessageEvent('message', {
+            data: { type: 'neko-hosted-surface-response', requestId: message.requestId, ok: true, result: {} },
+          }))
+        },
+      },
+      configurable: true,
+    })
+    ui.render(ui.h(ui.ActionButton, { actionId: 'save' }), root)
+    const event = new Event('click', { bubbles: true })
+    Object.defineProperty(event, 'isTrusted', { value: false })
+    fireEvent(root.querySelector('button')!, event)
+    await flushMicrotasks()
+
+    expect(requestMessage).toMatchObject({
+      method: 'call',
+      userInitiated: false,
     })
   })
 

--- a/frontend/plugin-manager/src/components/plugin/hosted/ui-kit/runtime.test.ts
+++ b/frontend/plugin-manager/src/components/plugin/hosted/ui-kit/runtime.test.ts
@@ -51,7 +51,11 @@ describe('hosted ui runtime', () => {
     document.body.appendChild(root)
   })
 
-  it('marks hosted action calls triggered by an iframe click as user initiated', () => {
+  it.each([
+    ['click', 'button', 'onClick'],
+    ['submit', 'form', 'onSubmit'],
+    ['keydown', 'input', 'onKeyDown'],
+  ])('marks hosted action calls triggered by a trusted iframe %s as user initiated', (eventName, tagName, propName) => {
     let requestMessage: any
     Object.defineProperty(window, 'parent', {
       value: {
@@ -64,16 +68,46 @@ describe('hosted ui runtime', () => {
       },
       configurable: true,
     })
-    const button = document.createElement('button')
-    button.addEventListener('click', () => { void ui.api.call('save') })
-    document.body.appendChild(button)
-
-    fireEvent.click(button)
+    const handler = (event: Event) => {
+      event.preventDefault()
+      void ui.api.call('save')
+    }
+    ui.render(ui.h(tagName, { [propName]: handler }), root)
+    const target = root.firstElementChild!
+    const event = new Event(eventName, { bubbles: true, cancelable: true })
+    Object.defineProperty(event, 'isTrusted', { value: true })
+    fireEvent(target, event)
 
     expect(requestMessage).toMatchObject({
       type: 'neko-hosted-surface-request',
       method: 'call',
       userInitiated: true,
+    })
+  })
+
+  it('does not attribute a later automatic call to an earlier iframe interaction', () => {
+    const requestMessages: any[] = []
+    Object.defineProperty(window, 'parent', {
+      value: {
+        postMessage(message: any) {
+          requestMessages.push(message)
+          window.dispatchEvent(new MessageEvent('message', {
+            data: { type: 'neko-hosted-surface-response', requestId: message.requestId, ok: true, result: {} },
+          }))
+        },
+      },
+      configurable: true,
+    })
+    ui.render(ui.h('button', { onClick: () => undefined }), root)
+    const event = new Event('click', { bubbles: true })
+    Object.defineProperty(event, 'isTrusted', { value: true })
+    fireEvent(root.querySelector('button')!, event)
+
+    void ui.api.call('background-refresh')
+
+    expect(requestMessages.at(-1)).toMatchObject({
+      method: 'call',
+      userInitiated: false,
     })
   })
 

--- a/frontend/plugin-manager/src/components/plugin/hosted/ui-kit/runtime.test.ts
+++ b/frontend/plugin-manager/src/components/plugin/hosted/ui-kit/runtime.test.ts
@@ -51,23 +51,6 @@ describe('hosted ui runtime', () => {
     document.body.appendChild(root)
   })
 
-  it('deduplicates identical error toasts while the first one is visible', () => {
-    const removeFirst = ui.showToast('插件未运行。请先启动该插件，再执行这个操作。', {
-      tone: 'danger',
-      timeout: 0,
-    })
-    const removeDuplicate = ui.showToast('插件未运行。请先启动该插件，再执行这个操作。', {
-      tone: 'danger',
-      timeout: 0,
-    })
-
-    expect(document.querySelectorAll('.neko-toast')).toHaveLength(1)
-    removeDuplicate()
-    expect(document.querySelectorAll('.neko-toast')).toHaveLength(1)
-    removeFirst()
-    expect(document.querySelectorAll('.neko-toast')).toHaveLength(0)
-  })
-
   it('runs hooks inside function components', async () => {
     function Counter() {
       const [count, setCount] = ui.useState(0)

--- a/frontend/plugin-manager/src/components/plugin/hosted/ui-kit/runtime.test.ts
+++ b/frontend/plugin-manager/src/components/plugin/hosted/ui-kit/runtime.test.ts
@@ -51,6 +51,23 @@ describe('hosted ui runtime', () => {
     document.body.appendChild(root)
   })
 
+  it('deduplicates identical error toasts while the first one is visible', () => {
+    const removeFirst = ui.showToast('插件未运行。请先启动该插件，再执行这个操作。', {
+      tone: 'danger',
+      timeout: 0,
+    })
+    const removeDuplicate = ui.showToast('插件未运行。请先启动该插件，再执行这个操作。', {
+      tone: 'danger',
+      timeout: 0,
+    })
+
+    expect(document.querySelectorAll('.neko-toast')).toHaveLength(1)
+    removeDuplicate()
+    expect(document.querySelectorAll('.neko-toast')).toHaveLength(1)
+    removeFirst()
+    expect(document.querySelectorAll('.neko-toast')).toHaveLength(0)
+  })
+
   it('runs hooks inside function components', async () => {
     function Counter() {
       const [count, setCount] = ui.useState(0)

--- a/frontend/plugin-manager/src/utils/request.test.ts
+++ b/frontend/plugin-manager/src/utils/request.test.ts
@@ -1,9 +1,63 @@
 // @vitest-environment happy-dom
 
-import { describe, expect, it } from 'vitest'
-import type { InternalAxiosRequestConfig } from 'axios'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AxiosError, AxiosRequestConfig, InternalAxiosRequestConfig } from 'axios'
 
-import { formatHttpError, stripJsonContentTypeForFormData } from './request'
+const requestMocks = vi.hoisted(() => ({
+  errorMessage: vi.fn(),
+  closeAllMessages: vi.fn(),
+  connectionStore: {
+    disconnected: false,
+    markConnected: vi.fn(),
+    markDisconnected: vi.fn(),
+  },
+}))
+
+vi.mock('element-plus', () => ({
+  ElMessage: {
+    error: requestMocks.errorMessage,
+    closeAll: requestMocks.closeAllMessages,
+  },
+}))
+
+vi.mock('@/stores/connection', () => ({
+  useConnectionStore: () => requestMocks.connectionStore,
+}))
+
+vi.mock('@/i18n', () => ({
+  i18n: {
+    global: {
+      t: (key: string) => key,
+    },
+  },
+}))
+
+import request, { formatHttpError, stripJsonContentTypeForFormData } from './request'
+
+type ErrorScenario = {
+  message: string
+  request?: unknown
+  response?: {
+    status: number
+    data: unknown
+    headers?: Record<string, string>
+  }
+}
+
+function rejectWith(scenario: ErrorScenario, config: AxiosRequestConfig = {}): Promise<unknown> {
+  return request.get('/test', {
+    ...config,
+    adapter: async (requestConfig) => {
+      const error = Object.assign(new Error(scenario.message), scenario, {
+        config: requestConfig,
+        isAxiosError: true,
+        name: 'AxiosError',
+        toJSON: () => ({}),
+      }) as AxiosError
+      throw error
+    },
+  })
+}
 
 describe('request FormData handling', () => {
   it('removes application/json Content-Type so the browser can set multipart boundary', () => {
@@ -102,5 +156,89 @@ describe('formatHttpError', () => {
     })
 
     expect(message).toBe('')
+  })
+})
+
+describe('hosted panel error suppression', () => {
+  beforeEach(() => {
+    requestMocks.errorMessage.mockReset()
+    requestMocks.closeAllMessages.mockReset()
+    requestMocks.connectionStore.disconnected = false
+    requestMocks.connectionStore.markConnected.mockReset()
+    requestMocks.connectionStore.markDisconnected.mockReset()
+    requestMocks.connectionStore.markDisconnected.mockImplementation(() => {
+      requestMocks.connectionStore.disconnected = true
+    })
+  })
+
+  it('silences PLUGIN_NOT_RUNNING only when an automatic panel request opts in', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    await expect(rejectWith({
+      message: 'Request failed with status code 409',
+      response: {
+        status: 409,
+        data: { detail: 'Plugin is not running' },
+        headers: { 'x-error-code': 'PLUGIN_NOT_RUNNING' },
+      },
+    }, {
+      suppressPluginNotRunningMessage: true,
+    } as AxiosRequestConfig)).rejects.toThrow('Request failed with status code 409')
+
+    expect(consoleError).not.toHaveBeenCalled()
+    expect(requestMocks.errorMessage).not.toHaveBeenCalled()
+    consoleError.mockRestore()
+  })
+
+  it('keeps PLUGIN_NOT_RUNNING visible for a user-initiated panel request', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    await expect(rejectWith({
+      message: 'Request failed with status code 409',
+      response: {
+        status: 409,
+        data: { detail: 'Plugin is not running' },
+        headers: { 'x-error-code': 'PLUGIN_NOT_RUNNING' },
+      },
+    }, {
+      suppressPluginNotRunningMessage: false,
+    } as AxiosRequestConfig)).rejects.toThrow('Request failed with status code 409')
+
+    expect(consoleError).toHaveBeenCalledWith('Response error:', expect.anything())
+    expect(requestMocks.errorMessage).toHaveBeenCalledWith('Plugin is not running')
+    consoleError.mockRestore()
+  })
+
+  it('does not hide a 500 response from an automatic panel request', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    await expect(rejectWith({
+      message: 'Request failed with status code 500',
+      response: {
+        status: 500,
+        data: { detail: 'Internal failure' },
+      },
+    }, {
+      suppressPluginNotRunningMessage: true,
+    } as AxiosRequestConfig)).rejects.toThrow('Request failed with status code 500')
+
+    expect(consoleError).toHaveBeenCalledWith('Response error:', expect.anything())
+    expect(requestMocks.errorMessage).toHaveBeenCalledWith('Internal failure')
+    consoleError.mockRestore()
+  })
+
+  it('does not hide a network error from an automatic panel request', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    await expect(rejectWith({
+      message: 'Network Error',
+      request: {},
+    }, {
+      suppressPluginNotRunningMessage: true,
+    } as AxiosRequestConfig)).rejects.toThrow('Network Error')
+
+    expect(consoleError).toHaveBeenCalledWith('Response error:', expect.anything())
+    expect(requestMocks.errorMessage).toHaveBeenCalledWith('messages.networkError')
+    consoleError.mockRestore()
   })
 })

--- a/frontend/plugin-manager/src/utils/request.ts
+++ b/frontend/plugin-manager/src/utils/request.ts
@@ -2,18 +2,13 @@
  * HTTP 请求封装
  */
 import axios from 'axios'
-import type { AxiosInstance, InternalAxiosRequestConfig, AxiosResponse, AxiosError, AxiosRequestConfig } from 'axios'
+import type { AxiosInstance, InternalAxiosRequestConfig, AxiosResponse, AxiosError } from 'axios'
 import { ElMessage } from 'element-plus'
 import { API_BASE_URL, API_TIMEOUT } from './constants'
 import { useConnectionStore } from '@/stores/connection'
 import { i18n } from '@/i18n'
 
 let lastNetworkErrorShownAt = 0
-
-type ErrorDisplayRequestConfig = AxiosRequestConfig & {
-  /** The caller renders the response error itself (for example, a hosted UI iframe). */
-  suppressErrorMessage?: boolean
-}
 
 type HeaderBag = Record<string, unknown> & {
   delete?: (name: string) => void
@@ -124,9 +119,6 @@ service.interceptors.response.use(
     // 对于 404 错误，不输出错误日志（这是正常的，某些资源可能不存在）
     // 对于 401/403 错误，也不输出错误日志
     const status = error.response?.status
-    const suppressErrorMessage = Boolean(
-      (error.config as ErrorDisplayRequestConfig | undefined)?.suppressErrorMessage,
-    )
     if (status !== 404 && status !== 401 && status !== 403) {
       console.error('Response error:', error)
     }
@@ -196,9 +188,7 @@ service.interceptors.response.use(
       return Promise.reject(error)
     }
 
-    if (!suppressErrorMessage) {
-      ElMessage.error(message)
-    }
+    ElMessage.error(message)
     return Promise.reject(error)
   }
 )

--- a/frontend/plugin-manager/src/utils/request.ts
+++ b/frontend/plugin-manager/src/utils/request.ts
@@ -96,9 +96,15 @@ function readErrorCode(error: AxiosError): string {
   }
   const headerValue = headers?.['x-error-code'] ?? headers?.['X-Error-Code']
   if (headerValue != null) return String(headerValue)
-  const data = error.response?.data as any
-  if (typeof data?.code === 'string') return data.code
-  if (typeof data?.detail?.code === 'string') return data.detail.code
+  const data = error.response?.data
+  if (data && typeof data === 'object') {
+    const record = data as Record<string, unknown>
+    if (typeof record.code === 'string') return record.code
+    if (record.detail && typeof record.detail === 'object') {
+      const detail = record.detail as Record<string, unknown>
+      if (typeof detail.code === 'string') return detail.code
+    }
+  }
   return ''
 }
 

--- a/frontend/plugin-manager/src/utils/request.ts
+++ b/frontend/plugin-manager/src/utils/request.ts
@@ -2,13 +2,18 @@
  * HTTP 请求封装
  */
 import axios from 'axios'
-import type { AxiosInstance, InternalAxiosRequestConfig, AxiosResponse, AxiosError } from 'axios'
+import type { AxiosInstance, InternalAxiosRequestConfig, AxiosResponse, AxiosError, AxiosRequestConfig } from 'axios'
 import { ElMessage } from 'element-plus'
 import { API_BASE_URL, API_TIMEOUT } from './constants'
 import { useConnectionStore } from '@/stores/connection'
 import { i18n } from '@/i18n'
 
 let lastNetworkErrorShownAt = 0
+
+type ErrorDisplayRequestConfig = AxiosRequestConfig & {
+  /** The caller will render a known error state in its own UI. */
+  suppressErrorMessage?: boolean
+}
 
 type HeaderBag = Record<string, unknown> & {
   delete?: (name: string) => void
@@ -119,7 +124,10 @@ service.interceptors.response.use(
     // 对于 404 错误，不输出错误日志（这是正常的，某些资源可能不存在）
     // 对于 401/403 错误，也不输出错误日志
     const status = error.response?.status
-    if (status !== 404 && status !== 401 && status !== 403) {
+    const suppressErrorMessage = Boolean(
+      (error.config as ErrorDisplayRequestConfig | undefined)?.suppressErrorMessage,
+    )
+    if (!suppressErrorMessage && status !== 404 && status !== 401 && status !== 403) {
       console.error('Response error:', error)
     }
 
@@ -188,7 +196,9 @@ service.interceptors.response.use(
       return Promise.reject(error)
     }
 
-    ElMessage.error(message)
+    if (!suppressErrorMessage) {
+      ElMessage.error(message)
+    }
     return Promise.reject(error)
   }
 )

--- a/frontend/plugin-manager/src/utils/request.ts
+++ b/frontend/plugin-manager/src/utils/request.ts
@@ -2,13 +2,18 @@
  * HTTP 请求封装
  */
 import axios from 'axios'
-import type { AxiosInstance, InternalAxiosRequestConfig, AxiosResponse, AxiosError } from 'axios'
+import type { AxiosInstance, InternalAxiosRequestConfig, AxiosResponse, AxiosError, AxiosRequestConfig } from 'axios'
 import { ElMessage } from 'element-plus'
 import { API_BASE_URL, API_TIMEOUT } from './constants'
 import { useConnectionStore } from '@/stores/connection'
 import { i18n } from '@/i18n'
 
 let lastNetworkErrorShownAt = 0
+
+type ErrorDisplayRequestConfig = AxiosRequestConfig & {
+  /** The caller renders the response error itself (for example, a hosted UI iframe). */
+  suppressErrorMessage?: boolean
+}
 
 type HeaderBag = Record<string, unknown> & {
   delete?: (name: string) => void
@@ -119,6 +124,9 @@ service.interceptors.response.use(
     // 对于 404 错误，不输出错误日志（这是正常的，某些资源可能不存在）
     // 对于 401/403 错误，也不输出错误日志
     const status = error.response?.status
+    const suppressErrorMessage = Boolean(
+      (error.config as ErrorDisplayRequestConfig | undefined)?.suppressErrorMessage,
+    )
     if (status !== 404 && status !== 401 && status !== 403) {
       console.error('Response error:', error)
     }
@@ -188,7 +196,9 @@ service.interceptors.response.use(
       return Promise.reject(error)
     }
 
-    ElMessage.error(message)
+    if (!suppressErrorMessage) {
+      ElMessage.error(message)
+    }
     return Promise.reject(error)
   }
 )

--- a/frontend/plugin-manager/src/utils/request.ts
+++ b/frontend/plugin-manager/src/utils/request.ts
@@ -11,8 +11,8 @@ import { i18n } from '@/i18n'
 let lastNetworkErrorShownAt = 0
 
 type ErrorDisplayRequestConfig = AxiosRequestConfig & {
-  /** The caller will render a known error state in its own UI. */
-  suppressErrorMessage?: boolean
+  /** Suppress only the expected stopped-plugin response for panel probes. */
+  suppressPluginNotRunningMessage?: boolean
 }
 
 type HeaderBag = Record<string, unknown> & {
@@ -88,6 +88,27 @@ export function formatHttpError(error: unknown): string {
   return !anyError?.response && error instanceof Error ? error.message : ''
 }
 
+function readErrorCode(error: AxiosError): string {
+  const headers = error.response?.headers
+  if (headers && typeof headers.get === 'function') {
+    const value = headers.get('X-Error-Code')
+    if (value != null) return String(value)
+  }
+  const headerValue = headers?.['x-error-code'] ?? headers?.['X-Error-Code']
+  if (headerValue != null) return String(headerValue)
+  const data = error.response?.data as any
+  if (typeof data?.code === 'string') return data.code
+  if (typeof data?.detail?.code === 'string') return data.detail.code
+  return ''
+}
+
+export function shouldSuppressPluginNotRunningMessage(error: AxiosError): boolean {
+  const requested = Boolean(
+    (error.config as ErrorDisplayRequestConfig | undefined)?.suppressPluginNotRunningMessage,
+  )
+  return requested && readErrorCode(error) === 'PLUGIN_NOT_RUNNING'
+}
+
 // 创建 axios 实例
 const service: AxiosInstance = axios.create({
   baseURL: API_BASE_URL,
@@ -124,9 +145,7 @@ service.interceptors.response.use(
     // 对于 404 错误，不输出错误日志（这是正常的，某些资源可能不存在）
     // 对于 401/403 错误，也不输出错误日志
     const status = error.response?.status
-    const suppressErrorMessage = Boolean(
-      (error.config as ErrorDisplayRequestConfig | undefined)?.suppressErrorMessage,
-    )
+    const suppressErrorMessage = shouldSuppressPluginNotRunningMessage(error)
     if (!suppressErrorMessage && status !== 404 && status !== 401 && status !== 403) {
       console.error('Response error:', error)
     }

--- a/frontend/plugin-manager/src/views/PluginDetail.vue
+++ b/frontend/plugin-manager/src/views/PluginDetail.vue
@@ -20,7 +20,7 @@
       </template>
 
       <el-tabs v-model="activeTab" data-yui-guide-id="plugin-detail-tabs">
-        <el-tab-pane v-if="panelSurfaces.length > 0" :label="$t('plugins.ui.panel')" name="panel">
+        <el-tab-pane v-if="panelSurfaces.length > 0" :label="$t('plugins.ui.panel')" name="panel" lazy>
           <div class="surface-section" data-yui-guide-id="plugin-detail-panel">
             <el-alert
               v-if="surfaceWarnings.length > 0"
@@ -43,6 +43,7 @@
                 :key="surface.id"
                 :label="surface.title || surface.id"
                 :name="surface.id"
+                lazy
               >
                 <HostedSurfaceFrame :plugin-id="pluginId" :surface="surface" :height="hostedSurfaceFrameHeight" @open-logs="openLogsTab" @message="relayHostedSurfaceMessageToStaticUi" />
               </el-tab-pane>
@@ -51,7 +52,7 @@
           </div>
         </el-tab-pane>
 
-        <el-tab-pane v-if="guideSurfaces.length > 0" :label="$t('plugins.ui.guide')" name="guide">
+        <el-tab-pane v-if="guideSurfaces.length > 0" :label="$t('plugins.ui.guide')" name="guide" lazy>
           <div class="surface-section" data-yui-guide-id="plugin-detail-guide">
             <el-alert
               v-if="surfaceWarnings.length > 0"
@@ -74,6 +75,7 @@
                 :key="surface.id"
                 :label="surface.title || surface.id"
                 :name="surface.id"
+                lazy
               >
                 <HostedSurfaceFrame :plugin-id="pluginId" :surface="surface" :height="hostedSurfaceFrameHeight" @open-logs="openLogsTab" @message="relayHostedSurfaceMessageToStaticUi" />
               </el-tab-pane>
@@ -82,7 +84,7 @@
           </div>
         </el-tab-pane>
 
-        <el-tab-pane v-if="hasStaticUI" :label="$t('plugins.ui.title')" name="ui">
+        <el-tab-pane v-if="hasStaticUI" :label="$t('plugins.ui.title')" name="ui" lazy>
           <PluginUIFrame ref="staticUiFrameRef" :plugin-id="pluginId" height="560px" @open-surface="openHostedSurfaceFromStaticUi" />
         </el-tab-pane>
 

--- a/frontend/plugin-manager/src/views/PluginDetail.vue
+++ b/frontend/plugin-manager/src/views/PluginDetail.vue
@@ -20,7 +20,7 @@
       </template>
 
       <el-tabs v-model="activeTab" data-yui-guide-id="plugin-detail-tabs">
-        <el-tab-pane v-if="panelSurfaces.length > 0" :label="$t('plugins.ui.panel')" name="panel" lazy>
+        <el-tab-pane v-if="panelSurfaces.length > 0" :label="$t('plugins.ui.panel')" name="panel">
           <div class="surface-section" data-yui-guide-id="plugin-detail-panel">
             <el-alert
               v-if="surfaceWarnings.length > 0"
@@ -43,7 +43,6 @@
                 :key="surface.id"
                 :label="surface.title || surface.id"
                 :name="surface.id"
-                lazy
               >
                 <HostedSurfaceFrame :plugin-id="pluginId" :surface="surface" :height="hostedSurfaceFrameHeight" @open-logs="openLogsTab" @message="relayHostedSurfaceMessageToStaticUi" />
               </el-tab-pane>
@@ -52,7 +51,7 @@
           </div>
         </el-tab-pane>
 
-        <el-tab-pane v-if="guideSurfaces.length > 0" :label="$t('plugins.ui.guide')" name="guide" lazy>
+        <el-tab-pane v-if="guideSurfaces.length > 0" :label="$t('plugins.ui.guide')" name="guide">
           <div class="surface-section" data-yui-guide-id="plugin-detail-guide">
             <el-alert
               v-if="surfaceWarnings.length > 0"
@@ -75,7 +74,6 @@
                 :key="surface.id"
                 :label="surface.title || surface.id"
                 :name="surface.id"
-                lazy
               >
                 <HostedSurfaceFrame :plugin-id="pluginId" :surface="surface" :height="hostedSurfaceFrameHeight" @open-logs="openLogsTab" @message="relayHostedSurfaceMessageToStaticUi" />
               </el-tab-pane>
@@ -84,7 +82,7 @@
           </div>
         </el-tab-pane>
 
-        <el-tab-pane v-if="hasStaticUI" :label="$t('plugins.ui.title')" name="ui" lazy>
+        <el-tab-pane v-if="hasStaticUI" :label="$t('plugins.ui.title')" name="ui">
           <PluginUIFrame ref="staticUiFrameRef" :plugin-id="pluginId" height="560px" @open-surface="openHostedSurfaceFromStaticUi" />
         </el-tab-pane>
 

--- a/plugin/sdk/hosted-ui/index.d.ts
+++ b/plugin/sdk/hosted-ui/index.d.ts
@@ -26,7 +26,7 @@ export type HostedAction = {
 }
 
 export type HostedApi = {
-  call: (actionId: string, args?: Record<string, any>, options?: { timeoutMs?: number }) => Promise<any>
+  call: (actionId: string, args?: Record<string, any>, options?: { timeoutMs?: number; userInitiated?: boolean }) => Promise<any>
   refresh: () => Promise<any>
 }
 


### PR DESCRIPTION
## 改动概述 / Summary

- 区分 Hosted 插件面板的自动请求与用户主动请求。
- iframe 内可信的 `click`、`submit`、`keydown` 事件处理函数在同步执行 `api.call` 时，将请求标记为用户主动操作；不再使用共享的 1 秒时间窗。
- 面板初始化、轮询等自动 `api.call` 仅在后端明确返回 `PLUGIN_NOT_RUNNING` 时静默全局提示和错误日志。
- 用户主动操作触发的 `PLUGIN_NOT_RUNNING`，以及自动请求遇到的 500、网络错误等其他异常，仍保留标准全局错误处理。
- 保持后端错误响应和面板内错误状态展示不变。

## 回归报告 / Regression Report

不适用：未修改 `app/`、`main_logic/` 或 `memory/` 下的 Python 文件。

## 不拆分理由 / Why Not Split

不适用：本 PR 仅修改 7 个前端文件，其中 3 个为测试文件。

## 测试 / Testing

- `npm.cmd exec vitest run src/components/plugin/hosted/ui-kit/runtime.test.ts src/api/plugins.test.ts src/utils/request.test.ts`：55 项通过。
- `npm.cmd run test:hosted`：76 项通过。
- `npm.cmd run type-check`：通过。
- `npm.cmd run build`：生产构建通过。
- 回归用例覆盖可信点击、提交、键盘事件，事件结束后的自动请求不会被误判为用户操作。
- 错误拦截器用例覆盖：自动请求的 `PLUGIN_NOT_RUNNING` 静默；用户主动请求的同一错误正常提示；500 和网络错误不会被静默。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **功能改进**
  - 自动触发的插件托管界面操作遇到“插件未运行”错误时，将静默处理，避免显示不必要的错误提示。
  - 用户直接触发的操作仍会保留全局错误提示，便于及时获知执行失败。
  - 可准确识别点击、提交、键盘、选择和输入等真实用户交互，并区分后台自动请求。

- **测试**
  - 新增并完善相关错误处理、用户操作识别及回归测试覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->