### PR TITLE
fix(qq): 首次同时开启群记忆与成员记忆时不再丢掉成员开关（#2433 残留）

### DIFF
--- a/plugin/plugins/qq_auto_reply/settings_service.py
+++ b/plugin/plugins/qq_auto_reply/settings_service.py
@@ -110,12 +110,15 @@ class QQSettingsService:
             return
         if deferred_opt_ins is not None and deferred_opt_ins.get(
             "group_memory_enabled"
-        ):
-            # 父开关也在同一次扣发队列里：两个键会在写盘成功后一起发布，
+        ) and deferred_opt_ins.get("group_member_memory_enabled"):
+            # 父子都在同一次扣发队列里：两个键会在写盘成功后一起发布，
             # 此刻"父还没生效"是延迟发布的中间态，不是没授权。首次开箱
             # 正走这条路（两个面板每次保存都同时提交两个复选框），按未
             # 授权砍掉 member 会连磁盘一起写成关闭——用户看着勾上了，
             # 回来一刷新又是关的，得再存一次才算数。
+            # 只有父开关在队列里则不放行：那条请求根本没要开成员记忆，
+            # 残留的 group_member_memory_enabled=true（手改配置/更早的
+            # 版本写下的）必须在这里清掉，不能随父开关一起被发布出去。
             return
         if deferred_opt_ins is not None:
             deferred_opt_ins.pop("group_member_memory_enabled", None)
@@ -514,7 +517,17 @@ class QQSettingsService:
             value = kwargs.get(key)
             if value is None:
                 continue
-            if bool(value) and not bool(self.plugin._qq_settings.get(key, False)):
+            live = bool(self.plugin._qq_settings.get(key, False))
+            if key == "group_member_memory_enabled":
+                # 子开关在父开关关着时授权不了任何采集（收集侧与接收边界
+                # 读的都是 member and group），所以"是否已经生效"要与父
+                # 开关取与。否则一条残留的 group_member_memory_enabled=
+                # true 会让"这次真的在开成员记忆"看起来像没变化，跳过延迟
+                # 发布、也跳过与父开关同批发布。
+                live = live and bool(
+                    self.plugin._qq_settings.get("group_memory_enabled", False)
+                )
+            if bool(value) and not live:
                 deferred_opt_ins[key] = True
                 continue
             self.plugin._qq_settings[key] = bool(value)

--- a/plugin/plugins/qq_auto_reply/settings_service.py
+++ b/plugin/plugins/qq_auto_reply/settings_service.py
@@ -108,6 +108,15 @@ class QQSettingsService:
         group memory came back on."""
         if self.plugin._qq_settings.get("group_memory_enabled", False):
             return
+        if deferred_opt_ins is not None and deferred_opt_ins.get(
+            "group_memory_enabled"
+        ):
+            # 父开关也在同一次扣发队列里：两个键会在写盘成功后一起发布，
+            # 此刻"父还没生效"是延迟发布的中间态，不是没授权。首次开箱
+            # 正走这条路（两个面板每次保存都同时提交两个复选框），按未
+            # 授权砍掉 member 会连磁盘一起写成关闭——用户看着勾上了，
+            # 回来一刷新又是关的，得再存一次才算数。
+            return
         if deferred_opt_ins is not None:
             deferred_opt_ins.pop("group_member_memory_enabled", None)
         self.plugin._qq_settings["group_member_memory_enabled"] = False

--- a/tests/unit/test_group_memory_scopes.py
+++ b/tests/unit/test_group_memory_scopes.py
@@ -10987,6 +10987,7 @@ async def test_first_time_setup_publishes_both_memory_opt_ins():
     }
     during: list = []
     written: list = []
+    persisted: list = []
     plugin = SimpleNamespace(
         _qq_settings=settings,
         _user_sessions={},
@@ -11007,6 +11008,13 @@ async def test_first_time_setup_publishes_both_memory_opt_ins():
     async def _write(overlay=None):
         during.append(dict(plugin._qq_settings))
         written.append(dict(overlay or {}))
+        # persist_business_config writes dict(_qq_settings) updated with the
+        # overlay, so a switch can reach disk through EITHER of them. Asserting
+        # the overlay alone leaves the runtime half of the payload untested —
+        # and that half is exactly where a stale member flag would slip out.
+        payload = dict(plugin._qq_settings)
+        payload.update(overlay or {})
+        persisted.append(payload)
         return True
 
     service.persist_business_config = _write
@@ -11020,6 +11028,7 @@ async def test_first_time_setup_publishes_both_memory_opt_ins():
     assert written[-1] == {
         "group_memory_enabled": True, "group_member_memory_enabled": True,
     }
+    assert persisted[-1]["group_member_memory_enabled"] is True
     assert plugin._qq_settings["group_memory_enabled"] is True
     assert plugin._qq_settings["group_member_memory_enabled"] is True
 
@@ -11028,15 +11037,19 @@ async def test_first_time_setup_publishes_both_memory_opt_ins():
     settings["group_member_memory_enabled"] = False
     await service.save_settings(group_member_memory_enabled=True)
     assert written[-1] == {}
+    assert persisted[-1]["group_member_memory_enabled"] is False
     assert plugin._qq_settings["group_member_memory_enabled"] is False
 
     # A stale child left over from a hand-edited config (or an older build)
     # must not ride along on a parent-only save — that request never asked
-    # for member memory.
+    # for member memory. The clearing has to happen BEFORE the write, or the
+    # stale value is what lands on disk and comes back at the next restart,
+    # this time under a parent that is now on.
     settings["group_memory_enabled"] = False
     settings["group_member_memory_enabled"] = True
     await service.save_settings(group_memory_enabled=True)
     assert written[-1] == {"group_memory_enabled": True}
+    assert persisted[-1]["group_member_memory_enabled"] is False
     assert plugin._qq_settings["group_memory_enabled"] is True
     assert plugin._qq_settings["group_member_memory_enabled"] is False
 
@@ -11052,6 +11065,7 @@ async def test_first_time_setup_publishes_both_memory_opt_ins():
     assert written[-1] == {
         "group_memory_enabled": True, "group_member_memory_enabled": True,
     }
+    assert persisted[-1]["group_member_memory_enabled"] is True
     assert plugin._qq_settings["group_member_memory_enabled"] is True
 
 

--- a/tests/unit/test_group_memory_scopes.py
+++ b/tests/unit/test_group_memory_scopes.py
@@ -10952,6 +10952,14 @@ def test_member_memory_never_outlives_its_parent_switch():
         "group_memory_enabled": True, "group_member_memory_enabled": True,
     }
 
+    # A deferred parent on its own does not carry a stale child along: that
+    # request never asked for member memory.
+    settings["group_member_memory_enabled"] = True
+    deferred = {"group_memory_enabled": True}
+    service._clamp_member_to_group(deferred)
+    assert deferred == {"group_memory_enabled": True}
+    assert settings["group_member_memory_enabled"] is False
+
     # The write gate refuses collection even if the flag is forced on.
     memory = QQSessionMemoryService(SimpleNamespace(_qq_settings={
         "group_memory_enabled": False, "group_member_memory_enabled": True,
@@ -11021,6 +11029,30 @@ async def test_first_time_setup_publishes_both_memory_opt_ins():
     await service.save_settings(group_member_memory_enabled=True)
     assert written[-1] == {}
     assert plugin._qq_settings["group_member_memory_enabled"] is False
+
+    # A stale child left over from a hand-edited config (or an older build)
+    # must not ride along on a parent-only save — that request never asked
+    # for member memory.
+    settings["group_memory_enabled"] = False
+    settings["group_member_memory_enabled"] = True
+    await service.save_settings(group_memory_enabled=True)
+    assert written[-1] == {"group_memory_enabled": True}
+    assert plugin._qq_settings["group_memory_enabled"] is True
+    assert plugin._qq_settings["group_member_memory_enabled"] is False
+
+    # ...but when the same stale state is saved from a dashboard, which
+    # always submits both checkboxes, the requested child still lands. The
+    # stale flag grants nothing while its parent is off, so "already true"
+    # must not be read as "no change to publish".
+    settings["group_memory_enabled"] = False
+    settings["group_member_memory_enabled"] = True
+    await service.save_settings(
+        group_memory_enabled=True, group_member_memory_enabled=True,
+    )
+    assert written[-1] == {
+        "group_memory_enabled": True, "group_member_memory_enabled": True,
+    }
+    assert plugin._qq_settings["group_member_memory_enabled"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_group_memory_scopes.py
+++ b/tests/unit/test_group_memory_scopes.py
@@ -10942,6 +10942,16 @@ def test_member_memory_never_outlives_its_parent_switch():
     service._clamp_member_to_group(deferred)
     assert deferred == {}
 
+    # ...but a parent held back in the SAME batch still counts as open: both
+    # keys get published together once the write lands.
+    deferred = {
+        "group_memory_enabled": True, "group_member_memory_enabled": True,
+    }
+    service._clamp_member_to_group(deferred)
+    assert deferred == {
+        "group_memory_enabled": True, "group_member_memory_enabled": True,
+    }
+
     # The write gate refuses collection even if the flag is forced on.
     memory = QQSessionMemoryService(SimpleNamespace(_qq_settings={
         "group_memory_enabled": False, "group_member_memory_enabled": True,
@@ -10952,6 +10962,65 @@ def test_member_memory_never_outlives_its_parent_switch():
         member_memory_enabled=True,
     ))
     assert "group_member_memory_messages" not in user_data
+
+
+@pytest.mark.asyncio
+async def test_first_time_setup_publishes_both_memory_opt_ins():
+    """Both dashboards submit every checkbox on every save, so the first
+    enable arrives as group+member in one call. Clamping the child against a
+    parent that is only deferred dropped it from the overlay: disk got member
+    memory as OFF and the user had to notice and save a second time."""
+    from plugin.plugins.qq_auto_reply.settings_service import QQSettingsService
+
+    settings = {
+        "group_memory_enabled": False,
+        "group_member_memory_enabled": False,
+        "allow_cross_group_context": False,
+    }
+    during: list = []
+    written: list = []
+    plugin = SimpleNamespace(
+        _qq_settings=settings,
+        _user_sessions={},
+        _emit_log=lambda *a, **k: None,
+        logger=MagicMock(),
+        attention_service=None,
+        qq_client=None,
+        _running=False,
+        _startup_error=None,
+        _ensure_qq_client_initialized=lambda: None,
+    )
+    service = QQSettingsService.__new__(QQSettingsService)
+    service.plugin = plugin
+    service._enforce_attention_for_dynamic_mode = lambda: None
+    service._stamp_group_memory_transition = lambda *, enabled_after: None
+    service._spawn_group_memory_sync_task = lambda coro: coro.close()
+
+    async def _write(overlay=None):
+        during.append(dict(plugin._qq_settings))
+        written.append(dict(overlay or {}))
+        return True
+
+    service.persist_business_config = _write
+
+    await service.save_settings(
+        group_memory_enabled=True, group_member_memory_enabled=True,
+    )
+    # Still fail-closed while the write is in flight...
+    assert during[-1]["group_member_memory_enabled"] is False
+    # ...and both requested values reach disk and the runtime together.
+    assert written[-1] == {
+        "group_memory_enabled": True, "group_member_memory_enabled": True,
+    }
+    assert plugin._qq_settings["group_memory_enabled"] is True
+    assert plugin._qq_settings["group_member_memory_enabled"] is True
+
+    # The parent constraint still binds when only the child is requested.
+    settings["group_memory_enabled"] = False
+    settings["group_member_memory_enabled"] = False
+    await service.save_settings(group_member_memory_enabled=True)
+    assert written[-1] == {}
+    assert plugin._qq_settings["group_member_memory_enabled"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_topic_pipeline.py
+++ b/tests/unit/test_topic_pipeline.py
@@ -982,10 +982,16 @@ async def test_topic_pool_restored_signals_respect_persisted_used_history(tmp_pa
     )
     pool.note_user_message("妮可", "先投递一次，建立今天已经用过 deep topic 的节流历史", lang="zh-CN")
     await pool.process_now("妮可", lang="zh-CN")
-    await asyncio.sleep(0.02)
+    used_path = path.with_name("topic_signals.used_topics.json")
+    # The trigger writes this file from a worker thread (to_thread), so a
+    # fixed sleep is a race: a loaded CI runner needs more than 20ms just to
+    # hand the write off. Wait for the artifact itself.
+    deadline = time.monotonic() + 5.0
+    while not used_path.exists() and time.monotonic() < deadline:
+        await asyncio.sleep(0.01)
+    assert used_path.exists(), "used-topics file was never persisted"
 
     assert delivered == ["买车"]
-    used_path = path.with_name("topic_signals.used_topics.json")
     used_payload = json.loads(used_path.read_text(encoding="utf-8"))
     assert used_payload["characters"]["妮可"][0]["used_at"] > 0
     used_text = used_path.read_text(encoding="utf-8")


### PR DESCRIPTION
#2433 合并后 Codex 又提了一条 P2（[评论](https://github.com/Project-N-E-K-O/N.E.K.O/pull/2433#discussion_r3663947249)），本 PR 修它。

## 原本什么样

`plugin/plugins/qq_auto_reply/static/napcat.html` 和 `open_platform.html` 的 `doSave()` 每次保存都把三个记忆复选框一起提交，所以「第一次开启群记忆」这条最常见的路径必然是 `group_memory_enabled` 和 `group_member_memory_enabled` 同时 false→true。

这两个键都走 #2433 的延迟发布：opt-in 要等写盘成功才对消息处理链可见，期间先扣在 `deferred_opt_ins` 里、运行时仍是 false。而 `_clamp_member_to_group()` 判父子约束时只看运行时的 `group_memory_enabled`——此刻它还是 false，于是把 `group_member_memory_enabled` 从扣发队列里 pop 掉。队列就是写盘用的 overlay，所以磁盘上成员记忆被写成 **关闭**。

用户看到的：勾了两个框、提示保存成功、刷新回来成员记忆是关的，必须再存一次（这次父开关已经 true 了）才生效。

## 改法

父开关如果就在同一批扣发队列里，视为已满足父子约束——两个键会在写盘成功后由 `_publish_consent_opt_ins()` 一起发布，中间那段「父还没生效」是延迟发布的中间态，不是没授权。

约束本身没松：

- 只请求子开关而父开关关着 → 照旧从队列里摘掉 + 运行时置 false；
- 发布路径 `_publish_consent_opt_ins()` 里的 `_clamp_member_to_group()` 无参调用不受影响（那时父开关已经写进运行时了）；
- 写盘失败 → 两个 opt-in 都不发布，运行时仍双 false，收集侧的 fail-closed 语义不变。

## 测试

- `test_first_time_setup_publishes_both_memory_opt_ins`：走完整 `save_settings()`，断言写盘期间成员开关仍不可见、落盘 overlay 与运行时最终两个都为 true，以及「只请求子开关」时仍被摘掉。
- `test_member_memory_never_outlives_its_parent_switch` 补一条同批父开关的正向断言。
- 变异验证：撤掉修复两条都变红。
- `tests/unit/test_group_memory_scopes.py` 201 passed；`plugin/tests` 2752 passed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 追加（评审后）

**81a8fe2b2** — Codex 追了一条 P1：上一版的放行条件只看父开关在不在扣发队列里，配置里存着 `group_member_memory_enabled=true` 而 `group_memory_enabled=false` 时（手改配置/更早版本写下的状态），只带父开关的保存会命中放行，残留值既没被清掉也没算进这次请求，写盘照旧值写成开启、父开关一发布成员采集就活了。

修法两处（只按「要求父子同批」会在面板路径留个洞）：

- 放行要求父子**同时**在 `deferred_opt_ins` 里；只有父开关在队列里就走原路径，清掉残留子开关。
- 子开关的「当前是否已生效」与父开关取与——收集侧和接收边界读的都是 `member and group`，父开关关着时子开关授权不了任何采集。否则面板在残留态下同时提交两个复选框时，子开关会因为运行时旧值已是 `true`、看起来"没变化"而跳过延迟发布，接着被上一条当成"没请求过"清掉。

两条各自变异验证，另加两个端到端用例（残留态 + 只带父开关 / 残留态 + 面板提交两个）。

**7e4b89634** — 顺手修一条与本 PR 无关的 Windows CI 偶发红：`test_topic_pool_restored_signals_respect_persisted_used_history` 投递后只 `sleep(0.02)` 就去读 `topic_signals.used_topics.json`，而那次写盘是 `asyncio.to_thread` 交给工作线程的，CI runner 负载高时光把写交出去就不止 20ms。改成 5s 内轮询等文件出现；给 `_persist_used_topics` 注入 0.4s 慢写验证过：旧断言必红、新断言照过。放在这个 PR 里是因为它卡着本 PR 的 gate。

**21cddeeba** — push 后自己挂了一轮对抗自查（状态矩阵 / 生命周期结算 / 调用点与孪生读点 / 测试有效性四个视角，逐条证伪），6 条候选里 5 条被证伪，留下 1 条断言缺口且已修：这两个用例只断言 overlay（`written[-1]`）和发布后的运行时值，而 `persist_business_config` 落盘的是 `dict(_qq_settings)` 再 `update(overlay)`——成员开关那一位来自写盘时刻的运行时快照，不在 overlay 里。于是「把 `_clamp_member_to_group` 挪到写盘之后」这类改动能 201 全绿通过，而磁盘写成 `member=true`、重启后残留开关在已打开的父开关下复活，正是 81a8fe2b2 要挡的伤害面。假 persist 改成按真实语义算合并 payload，四个场景各加一条断言；变异验证：该时序变异体现在变红。
