### PR TITLE
fix(build): exclude GitHub metadata from Nuitka plugins

### DIFF
--- a/plugin/neko_plugin_cli/core/build_rules.py
+++ b/plugin/neko_plugin_cli/core/build_rules.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 # not replace them, so common cache/build artifacts never leak into packages.
 _DEFAULT_EXCLUDE_DIR_NAMES = {
     "__pycache__",
+    ".github",
     ".pytest_cache",
     ".mypy_cache",
     ".venv",

--- a/tests/unit/test_prepare_nuitka_plugins.py
+++ b/tests/unit/test_prepare_nuitka_plugins.py
@@ -44,6 +44,7 @@ def test_prepare_and_install_plugins_apply_neko_build_rules(tmp_path: Path) -> N
     _write(plugin_dir / "data layer" / "worker.py")
     _write(plugin_dir / "tests" / "__init__.py")
     _write(plugin_dir / "tests" / "test_runtime.py")
+    _write(plugin_dir / ".github" / "workflows" / "verify.yml")
     _write(plugin_dir / "local_logs" / "private.txt")
     _write(plugin_dir / "README.md")
     _write(plugin_dir / "scratch.tmp")
@@ -62,6 +63,7 @@ def test_prepare_and_install_plugins_apply_neko_build_rules(tmp_path: Path) -> N
     assert (stage_plugin / "runtime.py").is_file()
     assert (stage_plugin / "data layer" / "worker.py").is_file()
     assert not (stage_plugin / "tests").exists()
+    assert not (stage_plugin / ".github").exists()
     assert not (stage_plugin / "local_logs").exists()
     assert not (stage_plugin / "README.md").exists()
     assert not (stage_plugin / "scratch.tmp").exists()
@@ -77,6 +79,7 @@ def test_prepare_and_install_plugins_apply_neko_build_rules(tmp_path: Path) -> N
         (result.stage_dir.parent / "nuitka-plugin-stage.json").read_text(encoding="utf-8")
     )
     assert "demo_plugin/tests/" in manifest["excluded_paths"]
+    assert "demo_plugin/.github/" in manifest["excluded_paths"]
     assert "plugin.plugins.demo_plugin.tests" in manifest["excluded_modules"]
 
     destination = project_root / "dist" / "Xiao8" / "plugin" / "plugins"


### PR DESCRIPTION
## Summary

- exclude `.github` directories from the built-in plugin payload staged for Nuitka
- add a regression fixture proving repository workflow metadata is absent from the staged payload and recorded in the exclusion manifest

## Root cause

The scheduled desktop build failed for both macOS architectures while ad-hoc re-signing the post-processed Nuitka backend. `codesign --deep` treated `plugin/plugins/lifekit/.github` as a nested bundle and aborted with `bundle format unrecognized, invalid, or unsuitable`.

This happened before Electron packaging, so the macOS backend failures skipped `build-electron` and the final nightly publishing job. It is independent of the scheduled build's distribution-signing skip.

Failing run: https://github.com/Project-N-E-K-O/N.E.K.O/actions/runs/30322883250

## Impact

Repository-only GitHub workflow metadata no longer enters desktop runtime artifacts. Runtime plugin files and the existing ad-hoc backend sealing behavior are unchanged.

## Validation

- `uv run ruff check plugin/neko_plugin_cli/core/build_rules.py tests/unit/test_prepare_nuitka_plugins.py`
- `uv run pytest tests/unit/test_prepare_nuitka_plugins.py tests/unit/test_nuitka_macos_bundle_contract.py plugin/tests/unit/test_neko_plugin_cli_public.py -q` (`36 passed`)
- ran the real plugin staging helper over all 20 built-in plugin directories; `lifekit/.github` was absent and `lifekit/.github/` was recorded in `nuitka-plugin-stage.json`
- `git diff --check`