### PR TITLE
fix(core): 丢弃的回复不再残留在 activity tracker 的 AI turn buffer 里

### DIFF
--- a/main_logic/core/turn.py
+++ b/main_logic/core/turn.py
@@ -510,8 +510,13 @@ class TurnMixin:
         #   - recovery：截断恢复的正文追加在丢弃版后面，一并 flush
         # 这里清空而不是 flush：这一轮要么还会重试、要么下面 recovery 会补发正文，
         # 都还没到 turn end，flush 会凭空多喂 tracker 一个 AI turn。
+        #
+        # ⚠️ 这行和紧跟的 _clear_tts_pipeline() 是"清掉本轮丢弃留下的共享输出"
+        # 的两半，将来给这段加请求产权门控时必须一起门控。文本请求由
+        # websocket_router 作为各自独立的后台任务分发，旧请求 A 的迟到 discard
+        # 可以落在新请求 B 已经开始 publish 之后——那时无条件清空会连 B 的前缀
+        # 一起抹掉。只门 TTS 不门这行，就会漏出一处跨请求误伤。
         self._current_ai_turn_text = ''
-
         await self._clear_tts_pipeline()
 
         if self.websocket and hasattr(self.websocket, 'client_state') and \

--- a/main_logic/core/turn.py
+++ b/main_logic/core/turn.py
@@ -500,6 +500,18 @@ class TurnMixin:
                 )
                 print(f"[response_discarded parse_err] raw: {message!r}")
 
+        # 被丢弃的这段回复前端已经 clear 掉了，用户没看到——不该作为"AI 说过的
+        # 话"进 activity tracker 的 unfinished_thread 检测。_clear_tts_pipeline
+        # 只管 TTS 队列和音频缓存，从不碰 _current_ai_turn_text，而这个 buffer
+        # 唯一的出口是 turn end 的 _flush_ai_turn_text_to_tracker()，所以丢弃的
+        # 文本会一直躺到下一次 turn end 才被算进去：
+        #   - will_retry：重试后的文本继续往同一个 buffer 追加，turn end 时
+        #     flush 的是"丢弃版 + 重发版"拼在一起的内容
+        #   - recovery：截断恢复的正文追加在丢弃版后面，一并 flush
+        # 这里清空而不是 flush：这一轮要么还会重试、要么下面 recovery 会补发正文，
+        # 都还没到 turn end，flush 会凭空多喂 tracker 一个 AI turn。
+        self._current_ai_turn_text = ''
+
         await self._clear_tts_pipeline()
 
         if self.websocket and hasattr(self.websocket, 'client_state') and \

--- a/tests/unit/test_core_game_route_memory_contract.py
+++ b/tests/unit/test_core_game_route_memory_contract.py
@@ -2137,3 +2137,61 @@ async def test_takeover_response_complete_clears_interrupted_ordinary_turn():
     assert mgr._current_ai_turn_text == ""
     assert mgr.tts_pending_chunks == []
     assert mgr.sync_message_queue.messages == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_discarded_retry_drops_stream_text_from_activity_buffer():
+    """A discarded reply must not stay queued for the tracker across the retry."""
+    mgr = _make_manager()
+    # 流式阶段每个 chunk 都走 send_lanlan_response，默认 track_ai_turn=True，
+    # 所以被丢弃的那版正文此刻还躺在 buffer 里。
+    mgr._current_ai_turn_text = "discarded stream body"
+
+    await core_module.LLMSessionManager.handle_response_discarded(
+        mgr,
+        "guard",
+        1,
+        3,
+        True,
+    )
+
+    assert mgr._current_ai_turn_text == ""
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_truncated_recovery_flushes_only_recovery_body_to_tracker():
+    """Turn end must see the recovery body alone, not the discarded draft too."""
+    mgr = _make_manager()
+    mgr._current_ai_turn_text = "discarded stream body"
+    mgr.session = MagicMock()
+    mgr.session._conversation_history = []
+    mgr._finalize_turn_after_emit = AsyncMock()
+
+    # 真实 send_lanlan_response 会同步累加 _current_ai_turn_text（turn.py 内
+    # track_ai_turn 分支）；fixture 的 stub 不累加，这里补上，否则测不到
+    # "turn end 那一刻 buffer 里到底有什么"。
+    async def send_and_track(text, is_first_chunk=False, turn_id=None, metadata=None, **kwargs):
+        mgr._current_ai_turn_text += text
+
+    mgr.send_lanlan_response = send_and_track
+
+    # _flush_ai_turn_text_to_tracker 由 _emit_turn_end 调用，捕获调用当刻的 buffer。
+    buffer_at_turn_end = []
+
+    async def capture_emit(request_id):
+        buffer_at_turn_end.append(mgr._current_ai_turn_text)
+
+    mgr._emit_turn_end = capture_emit
+
+    await core_module.LLMSessionManager.handle_response_discarded(
+        mgr,
+        "guard",
+        3,
+        3,
+        False,
+        '{"code":"RESPONSE_LENGTH_TRUNCATED","text":"recovered body"}',
+    )
+
+    assert buffer_at_turn_end == ["recovered body"]


### PR DESCRIPTION
## 改动概述

`handle_response_discarded` 在清前端气泡和 TTS 管线时不碰 `_current_ai_turn_text`，改成在 discard 入口把它清空。

## 根因

`_current_ai_turn_text` 是喂给 activity tracker 的本轮 AI 文本 buffer：每个 chunk 经 `handle_output_transcript` → `send_lanlan_response`（`track_ai_turn` 默认 `True`）同步累加，唯一的出口是 turn end 的 `_flush_ai_turn_text_to_tracker()`。

而 `_clear_tts_pipeline()` 只管 TTS 队列和音频缓存，从不碰这个 buffer。于是被丢弃、前端已经 clear 掉、用户根本没看到的那版正文，会一直躺到下一次 turn end 才被算成"AI 说过的话"送进 unfinished_thread 检测：

- **`will_retry=True`**：重试后的文本继续往同一个 buffer 追加，turn end 时 flush 的是"丢弃版 + 重发版"拼在一起的内容。
- **`RESPONSE_LENGTH_TRUNCATED` / `RESPONSE_TOO_LONG`**：截断恢复的正文追加在丢弃版后面，一并 flush。

## 技术决策

清空而不是 flush：走到这里时这一轮要么还会重试、要么下面 recovery 会补发正文，都还没到 turn end，flush 会凭空多喂 tracker 一个 AI turn。

## 回归报告 / Regression Report

- **改动**：`handle_response_discarded` 在 `_clear_tts_pipeline()` 之前把 `_current_ai_turn_text` 清空。
- **理由 / 必要性**：被丢弃的回复用户从未看到，不该参与 activity tracker 的 unfinished_thread 启发式；且 retry 路径下会与重发版拼接，喂进去的是一段现实中不存在的文本。
- **前后表现**：此前 discard 后 buffer 残留，turn end 时"丢弃版 + 实际发出版"一起进 tracker；现在只有实际发给用户的那版进 tracker。前端显示、TTS、`_conversation_history` 与 turn end 时序均不变。
- **潜在回归点**：`unfinished_thread` 检测与 `_conv_seq` bump 的输入变短（少了丢弃版文本），主动搭话/开放话题的判定阈值需要留意；`handle_response_complete`、proactive 与 takeover 路径不经过本函数，行为不变。

## 来源

发现于 #2467 的 review。greptile 在那个 PR 报的是新引入的产权门控下 recovery 文本残留（[thread](https://github.com/Project-N-E-K-O/N.E.K.O/pull/2467#discussion_r3666034876)），核实后根因在 main 上就存在、范围更大——流式阶段的文本走同一个 buffer，只防护 recovery 那一次写入堵不住。bot 已收回原定级。

#2467 特有的跨请求泄漏（A 让位给 B 后不再走 turn end，残留归到 B 名下）需要在那个 PR 的 recovery 步骤表结构上另外收口，不在本 PR 范围。

## 测试

- 新增 `test_discarded_retry_drops_stream_text_from_activity_buffer`：retry 路径清空 buffer。
- 新增 `test_truncated_recovery_flushes_only_recovery_body_to_tracker`：recovery 路径下 turn end 那一刻 buffer 里只有恢复正文。
- 变异验证：删掉清空那行，上面两条都红。
- `tests/unit -k "core or turn or tts or activity or discard or proactive"` 1759 passed / 1 skipped；docstring 禁 CJK 门通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 修复响应过长或被截断后，已丢弃的 AI 回复草稿仍被错误计入活动跟踪的问题。
  - 确保恢复流程结束时，仅记录恢复后的有效内容，避免重复或错误内容出现在未完成对话记录中。

- **Tests**
  - 增加针对丢弃回复和截断恢复流程的测试，确保活动跟踪内容准确。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->