### PR TITLE
test: isolate Bilibili web scraper fake clocks

### DIFF
--- a/tests/unit/test_web_scraper.py
+++ b/tests/unit/test_web_scraper.py
@@ -4,6 +4,7 @@ import os
 import sys
 
 import pytest
+from tests.fake_clock import patch_module_clock
 from utils.llm_client import AIMessage, HumanMessage, SystemMessage
 
 
@@ -302,7 +303,11 @@ async def test_bilibili_hot_uses_recent_stale_cache_after_failure(monkeypatch):
             ]
         }
 
-    monkeypatch.setattr(bilibili_content.time, "monotonic", lambda: clock["now"])
+    patch_module_clock(
+        monkeypatch,
+        bilibili_content,
+        monotonic=lambda: clock["now"],
+    )
     monkeypatch.setattr(hot, "get_hot_videos", fake_get_hot_videos)
 
     first = await bilibili_content.fetch_bilibili_hot(limit=10)
@@ -331,7 +336,11 @@ async def test_bilibili_hot_rejects_stale_cache_older_than_limit(monkeypatch):
             raise RuntimeError("still unavailable")
         return {"list": [{"bvid": "BVexpired", "title": "即将过期"}]}
 
-    monkeypatch.setattr(bilibili_content.time, "monotonic", lambda: clock["now"])
+    patch_module_clock(
+        monkeypatch,
+        bilibili_content,
+        monotonic=lambda: clock["now"],
+    )
     monkeypatch.setattr(hot, "get_hot_videos", fake_get_hot_videos)
 
     await bilibili_content.fetch_bilibili_hot(limit=10)
@@ -835,8 +844,10 @@ async def test_bilibili_following_uses_two_minute_cache(monkeypatch):
         "_fetch_bilibili_personal_dynamic_uncached",
         fake_fetch,
     )
-    monkeypatch.setattr(
-        personal_dynamics.time, "monotonic", lambda: clock["now"]
+    patch_module_clock(
+        monkeypatch,
+        personal_dynamics,
+        monotonic=lambda: clock["now"],
     )
 
     first = await personal_dynamics.fetch_bilibili_personal_dynamic(10)


### PR DESCRIPTION
## 问题

当前 `upstream/main` 的 Unit Tests 与 PR #2535 的 `Unit pytest (Windows)` 都被 `tests/unit/test_web_scraper.py` 中相同的三个用例打红：

- `test_bilibili_hot_uses_recent_stale_cache_after_failure`
- `test_bilibili_hot_rejects_stale_cache_older_than_limit`
- `test_bilibili_following_uses_two_minute_cache`

失败证据：

- `main`：https://github.com/Project-N-E-K-O/N.E.K.O/actions/runs/30376814991
- PR #2535：https://github.com/Project-N-E-K-O/N.E.K.O/actions/runs/30377512408

## 根因

#2510 建立了运行期全局时钟隔离守卫，并迁移了当时已经存在的全局假时钟。#2494 随后新增上述三个测试，仍直接执行：

- `monkeypatch.setattr(bilibili_content.time, monotonic, ...)`
- `monkeypatch.setattr(personal_dynamics.time, monotonic, ...)`

这里的 `module.time` 并不是模块私有副本，而是共享的 Python stdlib `time` 模块对象。因此这些写法实际会在整个 pytest 进程内替换 `time.monotonic`，违反 #2510 的隔离守卫。

全量 `tests/unit` 会在同一进程内运行大量测试和后台线程；进程级假时钟可能被无关线程读取，也可能让后续测试观察到错误时间。因此该守卫会主动拒绝这些用例，而不是容忍依赖测试顺序的隐式全局副作用。

## 影响范围

- 当前 `main` 的 Unit Tests 失败。
- 所有基于该 `main` 构造 merge ref 并运行完整 Unit CI 的 PR 都可能继承同样失败；#2535 已实际复现。
- 同一 pytest 进程内的后续测试存在受到全局 `time.monotonic` 污染的风险。
- 影响仅来自上述三个测试的 fake-clock 安装方式。

## 不受影响范围

- 不修改任何生产代码。
- 不改变 Bilibili web scraper 的缓存、回退或过期行为。
- 不属于 #2535 的 proactive delivery 功能回归；本 PR 与 #2535 没有代码依赖。
- 不等同于 #2528 所跟踪的 Windows `atomic_write_json` / `os.replace` 偶发失败。
- 不处理 realtime arbiter 或其他无关 Issue。

## 修复方式

仅将上述三处测试迁移到 `tests.fake_clock.patch_module_clock`：

- 假时钟绑定到真正读取时间的 `bilibili_content` / `personal_dynamics` 模块；
- 未覆盖的 `time` 属性继续委托给真实 stdlib 模块；
- 保留原测试场景和业务断言；
- 避免 process-wide 时钟污染。

## 验证

- 失败三用例 + clock guard：4 passed
- 完整 `test_web_scraper.py` + clock guard：43 passed
- 完整 `tests/unit`：7103 passed, 43 skipped
- `uv run ruff check tests/unit/test_web_scraper.py`：passed
- `git diff --check`：passed

## 风险与回滚

Test-only、低风险；无需数据、配置或兼容性迁移。回滚只会恢复三个测试的进程级假时钟写法，并再次触发 clock guard / Unit CI 失败，不会改变生产行为。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 统一了多个缓存相关测试中的时间模拟方式。
  * 保持原有业务断言和测试场景不变，继续覆盖缓存复用、陈旧缓存回退及过期缓存拒绝等行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->