### PR TITLE
docs: 纠正 language_utils.py 四处 docstring 里默认语言的描述

### DIFF
--- a/utils/language_utils.py
+++ b/utils/language_utils.py
@@ -297,7 +297,7 @@ def _get_system_language() -> str:
     Get the language from system settings
 
     Returns:
-        Language code ('zh', 'en', 'ja', 'ko', 'ru'), defaults to 'zh'
+        Language code ('zh', 'en', 'ja', 'ko', 'ru'), defaults to 'en'
     """
     def _parse_locale(s: str) -> Optional[str]:
         s = s.lower().replace('_', '-')
@@ -461,7 +461,7 @@ def get_global_language() -> str:
     Get the global language variable
     
     Returns:
-        Language code ('zh', 'en', 'ja', 'ko', 'ru', 'es', 'pt'), defaults to 'zh'
+        Language code ('zh', 'en', 'ja', 'ko', 'ru', 'es', 'pt'), defaults to 'en'
     """
     contextual = _language_context_short.get()
     if contextual:
@@ -484,7 +484,7 @@ def get_global_language_full() -> str:
     this function keeps the full code ('zh-TW') for scenarios distinguishing Simplified/Traditional.
     
     Returns:
-        Language code ('zh', 'zh-TW', 'en', 'ja', 'ko', 'ru'), defaults to 'zh'
+        Language code ('zh', 'zh-TW', 'en', 'ja', 'ko', 'ru'), defaults to 'en'
     """
     contextual = _language_context_full.get()
     if contextual:
@@ -693,7 +693,7 @@ def normalize_language_code(lang: str, format: str = 'short') -> str:
             - 'full': returns the full form ('zh-CN', 'zh-TW', 'en', 'ja', 'ko')
         
     Returns:
-        The normalized language code, or the default ('zh' or 'zh-CN') when unrecognizable
+        The normalized language code, or the default ('en') when unrecognizable
     """
     if not lang:
         return 'en'


### PR DESCRIPTION
## 背景

扫代码时发现 [utils/language_utils.py](utils/language_utils.py) 里有四处 docstring 声明的兜底语言是 `'zh'`，但实际代码的兜底返回值全部是 `'en'`：

| 函数 | docstring 原文（修前） | 代码实际返回 |
|---|---|---|
| `_get_system_language()` | `defaults to 'zh'` | `return 'en'`（末行） |
| `get_global_language()` | `defaults to 'zh'` | `return _global_language or 'en'` |
| `get_global_language_full()` | `defaults to 'zh'` | `return _global_language_full or _global_language or 'en'` |
| `normalize_language_code()` | `default ('zh' or 'zh-CN') when unrecognizable` | 空输入 / 未识别分支都 `return 'en'` |

同文件的 `get_user_language()` / `get_user_language_async()` 已经写对了（`defaults to 'en'`，注释也写着"使用默认英文"）。这四处是历史 copy-paste 漂移。

## 改动

纯 docstring 修正，4 行替换，零逻辑改动，零行为变化：

```diff
-        Language code (...), defaults to 'zh'
+        Language code (...), defaults to 'en'
...
-        The normalized language code, or the default ('zh' or 'zh-CN') when unrecognizable
+        The normalized language code, or the default ('en') when unrecognizable
```

没有任何 runtime 行为被改，不会影响现有测试或用户侧的任何东西——只是让 docstring 和代码对齐，避免后续贡献者读 docstring 误以为中文兜底而写出 bug。

## 验证

- `ruff check utils/language_utils.py` 通过（出现的 3 条 `Invalid # noqa directive` warning 是同文件 761/1268/1500 行上早已存在的问题，不在本次改动范围内）。
- 人工核对四处兜底分支，全部返回 `'en'`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能改进**
  - 当系统语言无法识别、未初始化或缺少有效设置时，应用现在默认使用英文。
  - 无法解析的语言代码将统一回退为英文，提升语言设置的一致性与可预测性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->