### PR TITLE
fix(time): format_elapsed 在天数 >0 且剩余小时为 0 时保留非零分钟

### DIFF
--- a/tests/unit/test_time_format.py
+++ b/tests/unit/test_time_format.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""Tests for utils.time_format.format_elapsed."""
+
+import pytest
+
+from utils.time_format import format_elapsed
+
+
+@pytest.mark.parametrize(("gap_seconds", "lang", "expected"), [
+    # Day boundary with leftover minutes — regression guard for the dropped-minutes bug.
+    (86400 + 1800, "en", "1 days and 30 minutes"),
+    (86400 + 60, "en", "1 days and 1 minutes"),
+    (2 * 86400 + 300, "en", "2 days and 5 minutes"),
+    # Exactly on a day boundary — must use day-only template, no dangling minute suffix.
+    (86400, "en", "1 days"),
+    # Day + hours still uses DH (minutes dropped by design for hours>0).
+    (86400 + 2 * 3600, "en", "1 days and 2 hours"),
+    (86400 + 3600 + 60, "en", "1 days and 1 hours"),
+    # Sub-day behaviour unchanged: HM for hours<3, H for hours>=3, M otherwise.
+    (2 * 3600 + 1800, "en", "2 hours and 30 minutes"),
+    (4 * 3600, "en", "4 hours"),
+    (300, "en", "5 minutes"),
+    # Every supported locale ships an ELAPSED_TIME_DM template; verify none render a placeholder.
+    (86400 + 1800, "zh", "1天30分钟"),
+    (86400 + 1800, "ja", "1日30分"),
+    (86400 + 1800, "ko", "1일 30분"),
+    (86400 + 1800, "ru", "1 дн. 30 мин."),
+    (86400 + 1800, "es", "1 días y 30 minutos"),
+    (86400 + 1800, "pt", "1 dias e 30 minutos"),
+])
+def test_format_elapsed(gap_seconds, lang, expected):
+    assert format_elapsed(lang, gap_seconds) == expected
+
+
+def test_format_elapsed_does_not_leave_unsubstituted_placeholder():
+    """If a template key is missing from _loc, .format would leave a literal '{...}' behind."""
+    for gap_seconds in (86400 + 1800, 86400, 86400 + 3600, 2 * 3600 + 1800, 300):
+        out = format_elapsed("en", gap_seconds)
+        assert "{" not in out and "}" not in out, out

--- a/utils/time_format.py
+++ b/utils/time_format.py
@@ -17,7 +17,7 @@
 
 from config.prompts.prompts_sys import _loc
 from config.prompts.prompts_memory import (
-    ELAPSED_TIME_DH, ELAPSED_TIME_D,
+    ELAPSED_TIME_DH, ELAPSED_TIME_D, ELAPSED_TIME_DM,
     ELAPSED_TIME_HM, ELAPSED_TIME_H, ELAPSED_TIME_M,
 )
 
@@ -30,8 +30,9 @@ def format_elapsed(lang: str, gap_seconds: float) -> str:
     if days > 0:
         if hours > 0:
             return _loc(ELAPSED_TIME_DH, lang).format(d=days, h=hours)
-        else:
-            return _loc(ELAPSED_TIME_D, lang).format(d=days)
+        if minutes > 0:
+            return _loc(ELAPSED_TIME_DM, lang).format(d=days, m=minutes)
+        return _loc(ELAPSED_TIME_D, lang).format(d=days)
     elif hours > 0 and hours < 3 and minutes > 0:
         return _loc(ELAPSED_TIME_HM, lang).format(h=hours, m=minutes)
     elif hours > 0:


### PR DESCRIPTION
## 背景

扫代码时发现 `utils/time_format.py::format_elapsed(lang, gap_seconds)` 有一个静默丢精度的分支：跨过整天、但剩余小时为 0 且分钟 >0 时，分钟数被直接吞掉。

```python
>>> format_elapsed('en', 86400 + 1800)   # 1 day + 30 minutes
'1 days'                                 # 期望 '1 days and 30 minutes'
>>> format_elapsed('en', 2*86400 + 300)  # 2 days + 5 minutes
'2 days'                                 # 期望 '2 days and 5 minutes'
>>> format_elapsed('zh', 86400 + 1800)
'1天'                                    # 期望 '1天30分钟'
```

## 根因

[utils/time_format.py:30-34](utils/time_format.py#L30-L34) 里 `days > 0` 分支只有 `hours > 0`（`ELAPSED_TIME_DH`）和 `else`（`ELAPSED_TIME_D`）两档，漏掉了「hours == 0 且 minutes > 0」这一档。

但 [config/prompts/prompts_memory.py:975-983](config/prompts/prompts_memory.py#L975-L983) 其实早就定义了 `ELAPSED_TIME_DM` 模板（七 locale 全齐：`"{d} days and {m} minutes"` / `"{d}天{m}分钟"` / `"{d}日{m}分"` / `"{d}일 {m}분"` / `"{d} дн. {m} мин."` / `"{d} días y {m} minutos"` / `"{d} dias e {m} minutos"`），`time_format.py` 只是没 import、没接上分支。

## 改动

**`utils/time_format.py`**：
- import 里加上 `ELAPSED_TIME_DM`
- `days > 0` 分支改成：`hours > 0` → DH；`hours == 0 且 minutes > 0` → DM；两者都为 0 → D

```diff
     if days > 0:
         if hours > 0:
             return _loc(ELAPSED_TIME_DH, lang).format(d=days, h=hours)
-        else:
-            return _loc(ELAPSED_TIME_D, lang).format(d=days)
+        if minutes > 0:
+            return _loc(ELAPSED_TIME_DM, lang).format(d=days, m=minutes)
+        return _loc(ELAPSED_TIME_D, lang).format(d=days)
```

**`tests/unit/test_time_format.py`**（新增）：16 条用例覆盖：
- day+minutes 走 DM（3 例，含 1d1m 的小边界）
- 正好一天无余数走 D
- day+hours 走 DH，分钟按原设计省略
- sub-day 三种情况（hours<3 with minutes / hours>=3 / minutes only）行为不变
- 七 locale 全部能正确渲染 `ELAPSED_TIME_DM`，无未替换的 `{...}` 占位符
- 额外一条 placeholder 守护用例扫所有 gap 档位

`ELAPSED_TIME_DHM`（天+小时+分钟全写）**故意不接**——和现有 `hours >= 3` 时省略分钟的设计保持一致（长间隔保留粗粒度即可，避免在「3 天 2 小时 7 分钟」这种间隔上突然改变信息密度）。

## 影响面

`format_elapsed` 的返回值用在「距离上次对话过了多久」这条用户可见的拼接上：
- [app/memory_server/routes.py:988](app/memory_server/routes.py#L988)
- [main_logic/core/greeting.py](main_logic/core/greeting.py)

用户隔了 1 天 30 分钟没开 N.E.K.O，回来看到的 greeting 不再少报 30 分钟。

## 验证

- `python -m pytest tests/unit/test_time_format.py -v`：16/16 通过
- `ruff check utils/time_format.py tests/unit/test_time_format.py`：All checks passed
- 人工核对 callers：`greeting.py` 和 `routes.py` 只把字符串塞进模板 `{elapsed}` 位置，不会因为模板字符变多而断行或溢出

_🤖 Submitted by [Claude Code](https://claude.com/claude-code)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化跨天时长的显示逻辑：当小时数为 0 但仍有分钟时，现在会正确显示“天+分钟”。
  * 改进多语言时长格式化，避免出现未替换的模板占位符。
* **Tests**
  * 增加对英文及多种语言环境下跨天、整天和天数加小时等场景的测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->