### PR TITLE
fix(proactive): sanitize Bilibili context

### DIFF
--- a/tests/unit/test_web_scraper.py
+++ b/tests/unit/test_web_scraper.py
@@ -1087,6 +1087,7 @@ def test_bilibili_phase2_context_does_not_invent_missing_summary():
     assert "看起来在聊" in context
     assert "登录态确认：否" in context
     assert "链接：" not in context
+    assert "https://www.bilibili.com/video/BVempty" not in context
 
 
 def test_bilibili_phase2_context_uses_published_at_label_without_link():
@@ -1102,7 +1103,9 @@ def test_bilibili_phase2_context_uses_published_at_label_without_link():
 
     assert "发布时间：2026-07-29 13:20" in context
     assert "发布时间戳" not in context
+    assert "1785302400" not in context
     assert "链接：" not in context
+    assert "https://www.bilibili.com/video/BVpublished" not in context
 
 
 @pytest.mark.unit

--- a/tests/unit/test_web_scraper.py
+++ b/tests/unit/test_web_scraper.py
@@ -1086,6 +1086,23 @@ def test_bilibili_phase2_context_does_not_invent_missing_summary():
     assert "无可靠摘要" in context
     assert "看起来在聊" in context
     assert "登录态确认：否" in context
+    assert "链接：" not in context
+
+
+def test_bilibili_phase2_context_uses_published_at_label_without_link():
+    context = bilibili_content.format_bilibili_phase2_context(
+        {
+            "platform": "bilibili",
+            "lane": "home",
+            "title": "带发布时间的视频",
+            "url": "https://www.bilibili.com/video/BVpublished",
+            "published_at": 1785302400,
+        }
+    )
+
+    assert "发布时间：2026-07-29 13:20" in context
+    assert "发布时间戳" not in context
+    assert "链接：" not in context
 
 
 @pytest.mark.unit

--- a/utils/web_scraper/bilibili_content.py
+++ b/utils/web_scraper/bilibili_content.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 from copy import deepcopy
+from datetime import datetime, timedelta, timezone
 import re
 import time
 from typing import Any, Awaitable, Callable
@@ -36,6 +37,7 @@ _ENRICHMENT_TTL_SECONDS = 24 * 60 * 60
 _SUBTITLE_MAX_CHARS = 8_000
 _SUMMARY_MAX_CHARS = 120
 _PREEMPT_POLL_SECONDS = 0.1
+_BILIBILI_TIMEZONE = timezone(timedelta(hours=8))
 
 _RESULT_CACHE: dict[str, tuple[float, dict[str, Any]]] = {}
 _ENRICHMENT_CACHE: dict[str, tuple[float, dict[str, Any]]] = {}
@@ -635,10 +637,16 @@ def format_bilibili_phase2_context(candidate: dict[str, Any]) -> str:
     else:
         lines.append("内容摘要：无可靠摘要；只能把标题描述为“看起来在聊……”，不得断言具体内容。")
     if candidate.get("published_at"):
-        lines.append(f"发布时间戳：{candidate['published_at']}")
+        try:
+            published_at = int(candidate["published_at"])
+            published_text = datetime.fromtimestamp(
+                published_at, tz=_BILIBILI_TIMEZONE
+            ).strftime("%Y-%m-%d %H:%M")
+            lines.append(f"发布时间：{published_text}")
+        except (TypeError, ValueError, OverflowError, OSError):
+            logger.debug("Invalid Bilibili published_at: %r", candidate["published_at"])
     lines.extend(
         [
-            f"链接：{candidate.get('url', '')}",
             "表达约束：热门只能说“最近热门/挺火/热门榜靠前”；首页只能说“可能感兴趣”；"
             "只有“登录态确认：是”的关注更新才能说“你关注的UP主更新了”。",
             "请自然说1至2句，不朗读统计数据，不补充资料中不存在的情节。",


### PR DESCRIPTION
## 改动概述 / Summary

- 移除 B 站候选最终 Phase 2 上下文中的链接，避免模型收到不必要的 URL。
- 将 Unix 发布时间戳渲染为 UTC+8 的人类可读时间（`YYYY-MM-DD HH:MM`）。
- 增加回归测试，覆盖无链接和可读发布时间。

## 回归报告 / Regression Report

不适用：未修改 `app/`、`main_logic/` 或 `memory/` 下的 Python 文件。

## 不拆分理由 / Why Not Split

不适用：计入上限的改动文件数不超过 20。

## 测试 / Testing

- `uv run pytest tests/unit/test_web_scraper.py -k bilibili_phase2_context`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 优化哔哩哔哩内容上下文中的发布时间展示：统一按 UTC+8 格式化为“发布时间：YYYY-MM-DD HH:MM”。
  * 当发布时间无法解析时自动跳过展示，避免出现不准确信息。
  * 移除上下文中不必要的“链接：”与发布时间戳内容，避免回显输入中的视频 URL。
* **测试**
  * 新增与更新单元测试，覆盖“无链接/无 URL 回显”及“published_at 正确格式化”的场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->