### PR TITLE
fix(locale): retry provisional global detection

### DIFF
--- a/tests/unit/test_language_env_override.py
+++ b/tests/unit/test_language_env_override.py
@@ -24,7 +24,11 @@ def test_language_env_overrides_steam_and_system(
 ):
     monkeypatch.setenv("NEKO_LANGUAGE", value)
     monkeypatch.setattr(language_utils, "_get_steam_language", lambda: "zh")
-    monkeypatch.setattr(language_utils, "_detect_system_language", lambda: "zh")
+    monkeypatch.setattr(
+        language_utils,
+        "_probe_system_language",
+        lambda: language_utils._LocaleProbeResult("zh", True),
+    )
 
     assert language_utils.initialize_global_language() == expected_short
     assert language_utils.get_global_language_full() == expected_full
@@ -50,6 +54,10 @@ def test_language_and_region_overrides_are_independent(monkeypatch):
 def test_invalid_language_env_falls_back_to_detected_language(monkeypatch):
     monkeypatch.setenv("NEKO_LANGUAGE", "not-a-language")
     monkeypatch.setattr(language_utils, "_get_steam_language", lambda: None)
-    monkeypatch.setattr(language_utils, "_detect_system_language", lambda: "zh")
+    monkeypatch.setattr(
+        language_utils,
+        "_probe_system_language",
+        lambda: language_utils._LocaleProbeResult("zh", True),
+    )
 
     assert language_utils.initialize_global_language() == "zh"

--- a/tests/unit/test_language_env_override.py
+++ b/tests/unit/test_language_env_override.py
@@ -24,7 +24,7 @@ def test_language_env_overrides_steam_and_system(
 ):
     monkeypatch.setenv("NEKO_LANGUAGE", value)
     monkeypatch.setattr(language_utils, "_get_steam_language", lambda: "zh")
-    monkeypatch.setattr(language_utils, "_get_system_language", lambda: "zh")
+    monkeypatch.setattr(language_utils, "_detect_system_language", lambda: "zh")
 
     assert language_utils.initialize_global_language() == expected_short
     assert language_utils.get_global_language_full() == expected_full
@@ -50,6 +50,6 @@ def test_language_and_region_overrides_are_independent(monkeypatch):
 def test_invalid_language_env_falls_back_to_detected_language(monkeypatch):
     monkeypatch.setenv("NEKO_LANGUAGE", "not-a-language")
     monkeypatch.setattr(language_utils, "_get_steam_language", lambda: None)
-    monkeypatch.setattr(language_utils, "_get_system_language", lambda: "zh")
+    monkeypatch.setattr(language_utils, "_detect_system_language", lambda: "zh")
 
     assert language_utils.initialize_global_language() == "zh"

--- a/tests/unit/test_language_env_override.py
+++ b/tests/unit/test_language_env_override.py
@@ -29,6 +29,11 @@ def test_language_env_overrides_steam_and_system(
         "_probe_system_language",
         lambda: language_utils._LocaleProbeResult("zh", True),
     )
+    monkeypatch.setattr(
+        language_utils,
+        "_probe_china_region",
+        lambda: language_utils._LocaleProbeResult(False, True),
+    )
 
     assert language_utils.initialize_global_language() == expected_short
     assert language_utils.get_global_language_full() == expected_full
@@ -58,6 +63,11 @@ def test_invalid_language_env_falls_back_to_detected_language(monkeypatch):
         language_utils,
         "_probe_system_language",
         lambda: language_utils._LocaleProbeResult("zh", True),
+    )
+    monkeypatch.setattr(
+        language_utils,
+        "_probe_china_region",
+        lambda: language_utils._LocaleProbeResult(False, True),
     )
 
     assert language_utils.initialize_global_language() == "zh"

--- a/tests/unit/test_language_probe_retry.py
+++ b/tests/unit/test_language_probe_retry.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import pytest
+
+from utils import language_utils
+from utils.config_manager.migrations import MigrationsMixin
+from tests.fake_clock import patch_module_clock
+
+
+@pytest.fixture(autouse=True)
+def reset_probe_state(monkeypatch):
+    monkeypatch.delenv("NEKO_LANGUAGE", raising=False)
+    monkeypatch.delenv("NEKO_IS_CHINA_REGION", raising=False)
+    language_utils.reset_global_language()
+    yield
+    language_utils.reset_global_language()
+
+
+def test_neutral_process_locale_is_provisional(monkeypatch):
+    monkeypatch.setattr(language_utils, "_get_windows_locale", lambda: None)
+    monkeypatch.setattr(language_utils, "_get_macos_locale", lambda: None)
+    monkeypatch.setattr(language_utils.locale, "getlocale", lambda: (None, None))
+    monkeypatch.setenv("LANG", "C.UTF-8")
+
+    assert language_utils._detect_system_language() is None
+    assert language_utils._get_system_language() == "en"
+    assert language_utils._detect_china_region() is None
+    assert language_utils._is_china_region() is False
+
+
+@pytest.mark.parametrize("raw", ["garbage", "javascript", "english-garbage"])
+def test_malformed_locale_is_not_a_conclusive_signal(raw):
+    assert language_utils._parse_system_language(raw) is None
+    assert language_utils._system_language_signal(raw) is None
+    assert language_utils._locale_region_signal(raw) is None
+
+
+def test_windows_user_locale_is_a_conclusive_region_signal(monkeypatch):
+    monkeypatch.setattr(language_utils, "_get_windows_locale", lambda: "zh-CN")
+    monkeypatch.setattr(
+        language_utils,
+        "_get_macos_locale",
+        lambda: pytest.fail("Windows verdict should win"),
+    )
+
+    assert language_utils._detect_china_region() is True
+
+
+def test_valid_unsupported_os_locale_conclusively_falls_back_to_english(monkeypatch):
+    monkeypatch.setattr(language_utils, "_get_windows_locale", lambda: "fr-FR")
+    monkeypatch.setattr(language_utils, "_get_macos_locale", lambda: None)
+    monkeypatch.setattr(language_utils.locale, "getlocale", lambda: (None, None))
+    monkeypatch.setenv("LANG", "C.UTF-8")
+    monkeypatch.setattr(language_utils, "_get_steam_language", lambda: None)
+
+    assert language_utils._detect_system_language() == "en"
+    assert language_utils.initialize_global_language() == "en"
+    assert language_utils._global_language_initialized is True
+    assert language_utils._global_region_initialized is True
+    assert language_utils._global_probe_next_retry_monotonic == 0.0
+
+
+def test_provisional_fallback_retries_after_cooldown_and_recovers(monkeypatch):
+    now = [100.0]
+    patch_module_clock(monkeypatch, language_utils, monotonic=lambda: now[0])
+    monkeypatch.setattr(language_utils, "_get_steam_language", lambda: None)
+
+    region_results = iter((None, True))
+    language_results = iter((None, "zh-TW"))
+    region_calls: list[int] = []
+    language_calls: list[int] = []
+
+    def detect_region():
+        region_calls.append(1)
+        return next(region_results)
+
+    def detect_language():
+        language_calls.append(1)
+        return next(language_results)
+
+    monkeypatch.setattr(language_utils, "_detect_china_region", detect_region)
+    monkeypatch.setattr(language_utils, "_detect_system_language", detect_language)
+
+    assert language_utils.get_global_language() == "en"
+    assert language_utils.get_global_language_full() == "en"
+    assert language_utils.get_global_region() == "non-china"
+    assert len(region_calls) == len(language_calls) == 1
+    assert language_utils._global_language_initialized is False
+    assert language_utils._global_region_initialized is False
+    assert language_utils._global_probe_next_retry_monotonic == 105.0
+
+    now[0] = 104.999
+    assert language_utils.get_global_language() == "en"
+    assert language_utils.get_global_region() == "non-china"
+    assert len(region_calls) == len(language_calls) == 1
+
+    now[0] = 105.0
+    assert language_utils.get_global_language() == "zh"
+    assert language_utils.get_global_language_full() == "zh-TW"
+    assert language_utils.get_global_region() == "china"
+    assert len(region_calls) == len(language_calls) == 2
+    assert language_utils._global_language_initialized is True
+    assert language_utils._global_region_initialized is True
+    assert language_utils._global_probe_next_retry_monotonic == 0.0
+
+
+def test_probe_retry_uses_bounded_exponential_backoff(monkeypatch):
+    now = [0.0]
+    patch_module_clock(monkeypatch, language_utils, monotonic=lambda: now[0])
+    monkeypatch.setattr(language_utils, "_get_steam_language", lambda: None)
+    monkeypatch.setattr(language_utils, "_detect_china_region", lambda: None)
+    monkeypatch.setattr(language_utils, "_detect_system_language", lambda: None)
+
+    for expected_delay in (5.0, 10.0, 20.0, 40.0, 80.0, 160.0, 300.0, 300.0):
+        language_utils.initialize_global_language()
+        deadline = language_utils._global_probe_next_retry_monotonic
+        assert deadline - now[0] == expected_delay
+        now[0] = deadline
+
+
+def test_retry_cooldown_starts_after_slow_probe_finishes(monkeypatch):
+    stamps = iter((100.0, 104.0))
+    patch_module_clock(monkeypatch, language_utils, monotonic=lambda: next(stamps))
+    monkeypatch.setattr(language_utils, "_get_steam_language", lambda: None)
+    monkeypatch.setattr(language_utils, "_detect_china_region", lambda: None)
+    monkeypatch.setattr(language_utils, "_detect_system_language", lambda: None)
+
+    assert language_utils.initialize_global_language() == "en"
+    assert language_utils._global_probe_next_retry_monotonic == 109.0
+
+
+def test_conclusive_steam_and_os_signals_are_not_reprobed(monkeypatch):
+    steam_calls: list[int] = []
+    region_calls: list[int] = []
+
+    def steam_language():
+        steam_calls.append(1)
+        return "english"
+
+    def detect_region():
+        region_calls.append(1)
+        return False
+
+    monkeypatch.setattr(language_utils, "_get_steam_language", steam_language)
+    monkeypatch.setattr(language_utils, "_detect_china_region", detect_region)
+    monkeypatch.setattr(
+        language_utils,
+        "_detect_system_language",
+        lambda: pytest.fail("system language must not run after a Steam verdict"),
+    )
+
+    assert language_utils.get_global_language() == "en"
+    assert language_utils.get_global_language_full() == "en"
+    assert language_utils.get_global_region() == "non-china"
+    assert len(steam_calls) == len(region_calls) == 1
+
+    language_utils.reset_global_language()
+    steam_calls.clear()
+    region_calls.clear()
+    system_calls: list[int] = []
+
+    def no_steam():
+        steam_calls.append(1)
+        return None
+
+    def system_language():
+        system_calls.append(1)
+        return "ja"
+
+    monkeypatch.setattr(language_utils, "_get_steam_language", no_steam)
+    monkeypatch.setattr(language_utils, "_detect_system_language", system_language)
+
+    assert language_utils.get_global_language() == "ja"
+    assert language_utils.get_global_language_full() == "ja"
+    assert language_utils.get_global_region() == "non-china"
+    assert len(steam_calls) == len(system_calls) == len(region_calls) == 1
+
+
+def test_set_refresh_and_reset_keep_probe_confidence_consistent(monkeypatch):
+    now = [20.0]
+    patch_module_clock(monkeypatch, language_utils, monotonic=lambda: now[0])
+    monkeypatch.setattr(language_utils, "_detect_china_region", lambda: None)
+    monkeypatch.setattr(language_utils, "_get_steam_language", lambda: None)
+    monkeypatch.setattr(language_utils, "_detect_system_language", lambda: None)
+
+    assert language_utils.initialize_global_language() == "en"
+    assert language_utils._global_probe_next_retry_monotonic == 25.0
+
+    language_utils.set_global_language("ja")
+    assert language_utils._global_language_initialized is True
+    assert language_utils._global_region_initialized is False
+    assert language_utils._global_probe_next_retry_monotonic == 0.0
+
+    monkeypatch.setattr(language_utils, "_detect_china_region", lambda: True)
+    assert language_utils.refresh_global_language("schinese") is True
+    assert language_utils.get_global_language() == "zh"
+    assert language_utils.get_global_region() == "china"
+    assert language_utils._global_probe_next_retry_monotonic == 0.0
+
+    language_utils.reset_global_language()
+    assert language_utils._global_language is None
+    assert language_utils._global_region is None
+    assert language_utils._global_language_initialized is False
+    assert language_utils._global_region_initialized is False
+    assert language_utils._global_probe_next_retry_monotonic == 0.0
+
+
+def test_language_refresh_does_not_postpone_region_retry(monkeypatch):
+    now = [30.0]
+    patch_module_clock(monkeypatch, language_utils, monotonic=lambda: now[0])
+    monkeypatch.setattr(language_utils, "_get_steam_language", lambda: None)
+    monkeypatch.setattr(language_utils, "_detect_system_language", lambda: None)
+    region_calls: list[int] = []
+
+    def no_region():
+        region_calls.append(1)
+        return None
+
+    monkeypatch.setattr(language_utils, "_detect_china_region", no_region)
+    assert language_utils.initialize_global_language() == "en"
+    assert language_utils._global_probe_next_retry_monotonic == 35.0
+
+    now[0] = 31.0
+    assert language_utils.refresh_global_language("ja") is True
+    assert language_utils._global_probe_next_retry_monotonic == 35.0
+    assert len(region_calls) == 1
+
+
+def test_same_language_refresh_is_no_change_while_region_stays_provisional(
+    monkeypatch,
+):
+    patch_module_clock(monkeypatch, language_utils, monotonic=lambda: 10.0)
+    monkeypatch.setattr(language_utils, "_detect_china_region", lambda: None)
+    language_utils.set_global_language("ja")
+
+    assert language_utils.refresh_global_language("ja") is False
+    assert language_utils._global_language_initialized is True
+    assert language_utils._global_region_initialized is False
+
+
+def test_config_migration_does_not_persist_a_provisional_english_fallback(
+    monkeypatch,
+    tmp_path,
+):
+    characters_dir = tmp_path / "characters"
+    characters_dir.mkdir()
+    english_source = characters_dir / "en.json"
+    english_source.write_text("{}", encoding="utf-8")
+
+    class Manager(MigrationsMixin):
+        project_config_dir = tmp_path
+
+        @staticmethod
+        def _log(_message):
+            return None
+
+    monkeypatch.setattr(language_utils, "_get_steam_language", lambda: None)
+    monkeypatch.setattr(language_utils, "_detect_system_language", lambda: None)
+    assert Manager()._get_localized_characters_source() is None
+
+    monkeypatch.setattr(language_utils, "_detect_system_language", lambda: "en")
+    assert Manager()._get_localized_characters_source() == english_source

--- a/tests/unit/test_language_probe_retry.py
+++ b/tests/unit/test_language_probe_retry.py
@@ -1,10 +1,19 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
+import threading
+from types import SimpleNamespace
+
 import pytest
 
 from utils import language_utils
-from utils.config_manager.migrations import MigrationsMixin
 from tests.fake_clock import patch_module_clock
+
+
+def _probe_result(value, *, conclusive=None):
+    if conclusive is None:
+        conclusive = value is not None
+    return language_utils._LocaleProbeResult(value, conclusive)
 
 
 @pytest.fixture(autouse=True)
@@ -28,11 +37,68 @@ def test_neutral_process_locale_is_provisional(monkeypatch):
     assert language_utils._is_china_region() is False
 
 
-@pytest.mark.parametrize("raw", ["garbage", "javascript", "english-garbage"])
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "garbage",
+        "javascript",
+        "english-garbage",
+        "notjapanese_Japan",
+        "Japanese_",
+        "_Japan",
+        "Japanese_Japan_extra",
+        "Chinese (Unknown)_China",
+    ],
+)
 def test_malformed_locale_is_not_a_conclusive_signal(raw):
     assert language_utils._parse_system_language(raw) is None
     assert language_utils._system_language_signal(raw) is None
     assert language_utils._locale_region_signal(raw) is None
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected", "expected_region"),
+    [
+        ("Japanese_Japan", "ja", False),
+        ("Korean_Korea", "ko", False),
+        ("Russian_Russia", "ru", False),
+        ("Spanish_Spain", "es", False),
+        ("Portuguese_Brazil", "pt", False),
+        ("English_United States", "en", False),
+        ("Chinese (Simplified)_China", "zh", True),
+        ("Chinese (Traditional)_Taiwan", "zh-TW", False),
+        ("Chinese_PR China.936", "zh", True),
+        ("Chinese (Simplified)_PR-China", "zh", True),
+        ("Chinese_CHN", "zh", True),
+        ("Chinese_CN", "zh", True),
+        ("Chinese_Taiwan", "zh-TW", False),
+        ("Chinese_Hong Kong", "zh-TW", False),
+        ("Chinese_Macao", "zh-TW", False),
+        ("Chinese_Singapore", "zh", False),
+        ("Chinese-Simplified", "zh", True),
+        ("Chinese-Traditional", "zh-TW", False),
+        ("Chinese-HongKong", "zh-TW", False),
+        ("Chinese-Singapore", "zh", False),
+        ("Japanese_Japan.932", "ja", False),
+        ("Portuguese_Brazil@latin", "pt", False),
+    ],
+)
+def test_legacy_python_locale_names_are_conclusive(
+    monkeypatch,
+    raw,
+    expected,
+    expected_region,
+):
+    monkeypatch.setattr(language_utils.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(language_utils, "_get_windows_locale", lambda: None)
+    monkeypatch.setattr(language_utils, "_get_macos_locale", lambda: None)
+    monkeypatch.setattr(language_utils.locale, "getlocale", lambda: (raw, None))
+    monkeypatch.setenv("LANG", "C.UTF-8")
+
+    assert language_utils._parse_system_language(raw) == expected
+    assert language_utils._system_language_signal(raw) == expected
+    assert language_utils._locale_region_signal(raw) is expected_region
+    assert language_utils._detect_system_language() == expected
 
 
 def test_windows_user_locale_is_a_conclusive_region_signal(monkeypatch):
@@ -46,7 +112,103 @@ def test_windows_user_locale_is_a_conclusive_region_signal(monkeypatch):
     assert language_utils._detect_china_region() is True
 
 
+def test_unknown_legacy_chinese_territory_keeps_region_provisional():
+    assert language_utils._parse_system_language("Chinese_Unknown") == "zh"
+    assert language_utils._system_language_signal("Chinese_Unknown") == "zh"
+    assert language_utils._locale_region_signal("Chinese_Unknown") is None
+    assert language_utils._locale_region_signal("Chinese") is None
+
+
+@pytest.mark.parametrize(
+    ("platform_name", "windows_locale", "macos_locale"),
+    [
+        ("Windows", "Chinese_Unknown", None),
+        ("Darwin", None, "Chinese_Unknown"),
+    ],
+)
+def test_authoritative_language_only_signal_keeps_region_provisional(
+    monkeypatch,
+    platform_name,
+    windows_locale,
+    macos_locale,
+):
+    monkeypatch.setattr(language_utils.platform, "system", lambda: platform_name)
+    monkeypatch.setattr(
+        language_utils,
+        "_get_windows_locale",
+        lambda: windows_locale,
+    )
+    monkeypatch.setattr(
+        language_utils,
+        "_get_macos_locale",
+        lambda: macos_locale,
+    )
+    monkeypatch.setattr(
+        language_utils.locale,
+        "getlocale",
+        lambda: ("en_US", "UTF-8"),
+    )
+    monkeypatch.setenv("LANG", "C.UTF-8")
+    monkeypatch.setattr(language_utils, "_get_steam_language", lambda: None)
+
+    language_probe = language_utils._probe_system_language()
+    region_probe = language_utils._probe_china_region()
+
+    assert language_probe == _probe_result("zh")
+    assert region_probe == _probe_result(False, conclusive=False)
+
+    assert language_utils.initialize_global_language() == "zh"
+    assert language_utils.get_global_region() == "non-china"
+    assert language_utils._global_language_initialized is True
+    assert language_utils._global_region_initialized is False
+
+
+@pytest.mark.parametrize(
+    ("platform_name", "windows_locale", "macos_locale"),
+    [
+        ("Windows", "global", None),
+        ("Darwin", None, "global"),
+    ],
+)
+def test_authoritative_region_only_signal_keeps_language_provisional(
+    monkeypatch,
+    platform_name,
+    windows_locale,
+    macos_locale,
+):
+    monkeypatch.setattr(language_utils.platform, "system", lambda: platform_name)
+    monkeypatch.setattr(
+        language_utils,
+        "_get_windows_locale",
+        lambda: windows_locale,
+    )
+    monkeypatch.setattr(
+        language_utils,
+        "_get_macos_locale",
+        lambda: macos_locale,
+    )
+    monkeypatch.setattr(
+        language_utils.locale,
+        "getlocale",
+        lambda: ("ja_JP", "UTF-8"),
+    )
+    monkeypatch.setenv("LANG", "C.UTF-8")
+    monkeypatch.setattr(language_utils, "_get_steam_language", lambda: None)
+
+    language_probe = language_utils._probe_system_language()
+    region_probe = language_utils._probe_china_region()
+
+    assert language_probe == _probe_result("ja", conclusive=False)
+    assert region_probe == _probe_result(False)
+
+    assert language_utils.initialize_global_language() == "ja"
+    assert language_utils.get_global_region() == "non-china"
+    assert language_utils._global_language_initialized is False
+    assert language_utils._global_region_initialized is True
+
+
 def test_valid_unsupported_os_locale_conclusively_falls_back_to_english(monkeypatch):
+    monkeypatch.setattr(language_utils.platform, "system", lambda: "Windows")
     monkeypatch.setattr(language_utils, "_get_windows_locale", lambda: "fr-FR")
     monkeypatch.setattr(language_utils, "_get_macos_locale", lambda: None)
     monkeypatch.setattr(language_utils.locale, "getlocale", lambda: (None, None))
@@ -72,14 +234,14 @@ def test_provisional_fallback_retries_after_cooldown_and_recovers(monkeypatch):
 
     def detect_region():
         region_calls.append(1)
-        return next(region_results)
+        return _probe_result(next(region_results))
 
     def detect_language():
         language_calls.append(1)
-        return next(language_results)
+        return _probe_result(next(language_results))
 
-    monkeypatch.setattr(language_utils, "_detect_china_region", detect_region)
-    monkeypatch.setattr(language_utils, "_detect_system_language", detect_language)
+    monkeypatch.setattr(language_utils, "_probe_china_region", detect_region)
+    monkeypatch.setattr(language_utils, "_probe_system_language", detect_language)
 
     assert language_utils.get_global_language() == "en"
     assert language_utils.get_global_language_full() == "en"
@@ -104,12 +266,146 @@ def test_provisional_fallback_retries_after_cooldown_and_recovers(monkeypatch):
     assert language_utils._global_probe_next_retry_monotonic == 0.0
 
 
+def test_one_retry_generation_shares_transient_macos_failure(monkeypatch):
+    now = [100.0]
+    available = [False]
+    calls: list[str] = []
+    patch_module_clock(monkeypatch, language_utils, monotonic=lambda: now[0])
+    monkeypatch.setattr(
+        language_utils,
+        "_macos_locale_cache",
+        language_utils._MACOS_LOCALE_UNSET,
+    )
+    monkeypatch.setattr(language_utils.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(language_utils, "_get_windows_locale", lambda: None)
+    # A lower-priority process locale can be valid but stale. It may provide
+    # this attempt's best-effort value, but it must not hide the failed
+    # authoritative macOS probe and become a permanent cache entry.
+    monkeypatch.setattr(
+        language_utils.locale,
+        "getlocale",
+        lambda: ("en_US", "UTF-8"),
+    )
+    monkeypatch.setenv("LANG", "C.UTF-8")
+    monkeypatch.setattr(language_utils, "_get_steam_language", lambda: None)
+
+    def fake_run(command, **_kwargs):
+        calls.append(command[-1])
+        if not available[0]:
+            raise language_utils.subprocess.TimeoutExpired(command, 1.0)
+        return SimpleNamespace(returncode=0, stdout='"zh_CN"\n')
+
+    monkeypatch.setattr(language_utils.subprocess, "run", fake_run)
+
+    assert language_utils.get_global_language() == "en"
+    assert language_utils.get_global_region() == "non-china"
+    assert calls == ["AppleLocale", "AppleLanguages"]
+    assert language_utils._global_language_initialized is False
+    assert language_utils._global_region_initialized is False
+
+    now[0] = 104.999
+    assert language_utils.get_global_region() == "non-china"
+    assert calls == ["AppleLocale", "AppleLanguages"]
+
+    available[0] = True
+    now[0] = 105.0
+    assert language_utils.get_global_language_full() == "zh-CN"
+    assert language_utils.get_global_region() == "china"
+    assert calls == ["AppleLocale", "AppleLanguages", "AppleLocale"]
+    assert language_utils._global_language_initialized is True
+    assert language_utils._global_region_initialized is True
+
+
+def test_windows_api_failure_with_valid_lower_locale_stays_provisional(
+    monkeypatch,
+):
+    now = [200.0]
+    available = [False]
+    windows_calls: list[int] = []
+    patch_module_clock(monkeypatch, language_utils, monotonic=lambda: now[0])
+    monkeypatch.setattr(language_utils.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(language_utils, "_get_macos_locale", lambda: None)
+    monkeypatch.setattr(
+        language_utils.locale,
+        "getlocale",
+        lambda: ("en_US", "UTF-8"),
+    )
+    monkeypatch.setenv("LANG", "C.UTF-8")
+    monkeypatch.setattr(language_utils, "_get_steam_language", lambda: None)
+
+    def windows_locale():
+        windows_calls.append(1)
+        return "zh-CN" if available[0] else None
+
+    monkeypatch.setattr(language_utils, "_get_windows_locale", windows_locale)
+
+    assert language_utils.get_global_language() == "en"
+    assert language_utils.get_global_region() == "non-china"
+    assert language_utils._global_language_initialized is False
+    assert language_utils._global_region_initialized is False
+    assert language_utils._global_probe_next_retry_monotonic == 205.0
+    assert len(windows_calls) == 1
+
+    now[0] = 204.999
+    assert language_utils.get_global_language() == "en"
+    assert len(windows_calls) == 1
+
+    available[0] = True
+    now[0] = 205.0
+    assert language_utils.get_global_language_full() == "zh-CN"
+    assert language_utils.get_global_region() == "china"
+    assert language_utils._global_language_initialized is True
+    assert language_utils._global_region_initialized is True
+    assert len(windows_calls) == 2
+
+
+@pytest.mark.parametrize("invalid_apple_locale", ["C", "garbage"])
+def test_invalid_apple_locale_falls_through_to_apple_languages(
+    monkeypatch,
+    invalid_apple_locale,
+):
+    calls: list[str] = []
+    monkeypatch.setattr(
+        language_utils,
+        "_macos_locale_cache",
+        language_utils._MACOS_LOCALE_UNSET,
+    )
+    monkeypatch.setattr(language_utils.platform, "system", lambda: "Darwin")
+
+    def fake_run(command, **_kwargs):
+        key = command[-1]
+        calls.append(key)
+        if key == "AppleLocale":
+            return SimpleNamespace(
+                returncode=0,
+                stdout=f'"{invalid_apple_locale}"\n',
+            )
+        return SimpleNamespace(
+            returncode=0,
+            stdout='(\n    "zh-Hans-CN"\n)\n',
+        )
+
+    monkeypatch.setattr(language_utils.subprocess, "run", fake_run)
+
+    assert language_utils._get_macos_locale() == "zh-Hans-CN"
+    assert language_utils._get_macos_locale() == "zh-Hans-CN"
+    assert calls == ["AppleLocale", "AppleLanguages"]
+
+
 def test_probe_retry_uses_bounded_exponential_backoff(monkeypatch):
     now = [0.0]
     patch_module_clock(monkeypatch, language_utils, monotonic=lambda: now[0])
     monkeypatch.setattr(language_utils, "_get_steam_language", lambda: None)
-    monkeypatch.setattr(language_utils, "_detect_china_region", lambda: None)
-    monkeypatch.setattr(language_utils, "_detect_system_language", lambda: None)
+    monkeypatch.setattr(
+        language_utils,
+        "_probe_china_region",
+        lambda: _probe_result(None),
+    )
+    monkeypatch.setattr(
+        language_utils,
+        "_probe_system_language",
+        lambda: _probe_result(None),
+    )
 
     for expected_delay in (5.0, 10.0, 20.0, 40.0, 80.0, 160.0, 300.0, 300.0):
         language_utils.initialize_global_language()
@@ -118,12 +414,84 @@ def test_probe_retry_uses_bounded_exponential_backoff(monkeypatch):
         now[0] = deadline
 
 
+def test_only_provisional_region_is_reprobed_after_cooldown(monkeypatch):
+    now = [100.0]
+    patch_module_clock(monkeypatch, language_utils, monotonic=lambda: now[0])
+    monkeypatch.setattr(language_utils, "_get_steam_language", lambda: "japanese")
+    monkeypatch.setattr(
+        language_utils,
+        "_probe_system_language",
+        lambda: pytest.fail("a conclusive Steam language must not be reprobed"),
+    )
+    region_results = iter((None, True))
+    region_calls: list[int] = []
+
+    def detect_region():
+        region_calls.append(1)
+        return _probe_result(next(region_results))
+
+    monkeypatch.setattr(language_utils, "_probe_china_region", detect_region)
+
+    assert language_utils.get_global_language() == "ja"
+    assert language_utils.get_global_region() == "non-china"
+    assert language_utils._global_language_initialized is True
+    assert language_utils._global_region_initialized is False
+    assert language_utils._global_probe_next_retry_monotonic == 105.0
+
+    now[0] = 105.0
+    assert language_utils.get_global_region() == "china"
+    assert language_utils.get_global_language() == "ja"
+    assert language_utils._global_region_initialized is True
+    assert len(region_calls) == 2
+
+
+def test_only_provisional_language_is_reprobed_after_cooldown(monkeypatch):
+    now = [200.0]
+    patch_module_clock(monkeypatch, language_utils, monotonic=lambda: now[0])
+    monkeypatch.setattr(language_utils, "_get_steam_language", lambda: None)
+    language_results = iter((None, "zh-TW"))
+    language_calls: list[int] = []
+    region_calls: list[int] = []
+
+    def detect_language():
+        language_calls.append(1)
+        return _probe_result(next(language_results))
+
+    def detect_region():
+        region_calls.append(1)
+        return _probe_result(False)
+
+    monkeypatch.setattr(language_utils, "_probe_system_language", detect_language)
+    monkeypatch.setattr(language_utils, "_probe_china_region", detect_region)
+
+    assert language_utils.get_global_language() == "en"
+    assert language_utils.get_global_region() == "non-china"
+    assert language_utils._global_language_initialized is False
+    assert language_utils._global_region_initialized is True
+    assert language_utils._global_probe_next_retry_monotonic == 205.0
+
+    now[0] = 205.0
+    assert language_utils.get_global_language_full() == "zh-TW"
+    assert language_utils.get_global_region() == "non-china"
+    assert language_utils._global_language_initialized is True
+    assert len(language_calls) == 2
+    assert len(region_calls) == 1
+
+
 def test_retry_cooldown_starts_after_slow_probe_finishes(monkeypatch):
     stamps = iter((100.0, 104.0))
     patch_module_clock(monkeypatch, language_utils, monotonic=lambda: next(stamps))
     monkeypatch.setattr(language_utils, "_get_steam_language", lambda: None)
-    monkeypatch.setattr(language_utils, "_detect_china_region", lambda: None)
-    monkeypatch.setattr(language_utils, "_detect_system_language", lambda: None)
+    monkeypatch.setattr(
+        language_utils,
+        "_probe_china_region",
+        lambda: _probe_result(None),
+    )
+    monkeypatch.setattr(
+        language_utils,
+        "_probe_system_language",
+        lambda: _probe_result(None),
+    )
 
     assert language_utils.initialize_global_language() == "en"
     assert language_utils._global_probe_next_retry_monotonic == 109.0
@@ -139,13 +507,13 @@ def test_conclusive_steam_and_os_signals_are_not_reprobed(monkeypatch):
 
     def detect_region():
         region_calls.append(1)
-        return False
+        return _probe_result(False)
 
     monkeypatch.setattr(language_utils, "_get_steam_language", steam_language)
-    monkeypatch.setattr(language_utils, "_detect_china_region", detect_region)
+    monkeypatch.setattr(language_utils, "_probe_china_region", detect_region)
     monkeypatch.setattr(
         language_utils,
-        "_detect_system_language",
+        "_probe_system_language",
         lambda: pytest.fail("system language must not run after a Steam verdict"),
     )
 
@@ -165,10 +533,10 @@ def test_conclusive_steam_and_os_signals_are_not_reprobed(monkeypatch):
 
     def system_language():
         system_calls.append(1)
-        return "ja"
+        return _probe_result("ja")
 
     monkeypatch.setattr(language_utils, "_get_steam_language", no_steam)
-    monkeypatch.setattr(language_utils, "_detect_system_language", system_language)
+    monkeypatch.setattr(language_utils, "_probe_system_language", system_language)
 
     assert language_utils.get_global_language() == "ja"
     assert language_utils.get_global_language_full() == "ja"
@@ -176,12 +544,61 @@ def test_conclusive_steam_and_os_signals_are_not_reprobed(monkeypatch):
     assert len(steam_calls) == len(system_calls) == len(region_calls) == 1
 
 
+def test_concurrent_mixed_getters_share_one_initialization_attempt(monkeypatch):
+    start = threading.Event()
+    region_calls: list[int] = []
+    language_calls: list[int] = []
+
+    monkeypatch.setattr(language_utils, "_get_steam_language", lambda: None)
+
+    def detect_region():
+        region_calls.append(1)
+        return _probe_result(True)
+
+    def detect_language():
+        language_calls.append(1)
+        return _probe_result("zh-TW")
+
+    monkeypatch.setattr(language_utils, "_probe_china_region", detect_region)
+    monkeypatch.setattr(language_utils, "_probe_system_language", detect_language)
+
+    calls = (
+        [(language_utils.get_global_language, "zh")] * 16
+        + [(language_utils.get_global_language_full, "zh-TW")] * 16
+        + [(language_utils.get_global_region, "china")] * 16
+    )
+
+    def run(getter, expected):
+        assert start.wait(timeout=5)
+        return getter(), expected
+
+    with ThreadPoolExecutor(max_workers=len(calls)) as executor:
+        futures = [
+            executor.submit(run, getter, expected)
+            for getter, expected in calls
+        ]
+        start.set()
+        results = [future.result(timeout=5) for future in futures]
+
+    assert all(actual == expected for actual, expected in results)
+    assert len(region_calls) == 1
+    assert len(language_calls) == 1
+
+
 def test_set_refresh_and_reset_keep_probe_confidence_consistent(monkeypatch):
     now = [20.0]
     patch_module_clock(monkeypatch, language_utils, monotonic=lambda: now[0])
-    monkeypatch.setattr(language_utils, "_detect_china_region", lambda: None)
+    monkeypatch.setattr(
+        language_utils,
+        "_probe_china_region",
+        lambda: _probe_result(None),
+    )
     monkeypatch.setattr(language_utils, "_get_steam_language", lambda: None)
-    monkeypatch.setattr(language_utils, "_detect_system_language", lambda: None)
+    monkeypatch.setattr(
+        language_utils,
+        "_probe_system_language",
+        lambda: _probe_result(None),
+    )
 
     assert language_utils.initialize_global_language() == "en"
     assert language_utils._global_probe_next_retry_monotonic == 25.0
@@ -191,7 +608,11 @@ def test_set_refresh_and_reset_keep_probe_confidence_consistent(monkeypatch):
     assert language_utils._global_region_initialized is False
     assert language_utils._global_probe_next_retry_monotonic == 0.0
 
-    monkeypatch.setattr(language_utils, "_detect_china_region", lambda: True)
+    monkeypatch.setattr(
+        language_utils,
+        "_probe_china_region",
+        lambda: _probe_result(True),
+    )
     assert language_utils.refresh_global_language("schinese") is True
     assert language_utils.get_global_language() == "zh"
     assert language_utils.get_global_region() == "china"
@@ -209,14 +630,18 @@ def test_language_refresh_does_not_postpone_region_retry(monkeypatch):
     now = [30.0]
     patch_module_clock(monkeypatch, language_utils, monotonic=lambda: now[0])
     monkeypatch.setattr(language_utils, "_get_steam_language", lambda: None)
-    monkeypatch.setattr(language_utils, "_detect_system_language", lambda: None)
+    monkeypatch.setattr(
+        language_utils,
+        "_probe_system_language",
+        lambda: _probe_result(None),
+    )
     region_calls: list[int] = []
 
     def no_region():
         region_calls.append(1)
-        return None
+        return _probe_result(None)
 
-    monkeypatch.setattr(language_utils, "_detect_china_region", no_region)
+    monkeypatch.setattr(language_utils, "_probe_china_region", no_region)
     assert language_utils.initialize_global_language() == "en"
     assert language_utils._global_probe_next_retry_monotonic == 35.0
 
@@ -230,7 +655,11 @@ def test_same_language_refresh_is_no_change_while_region_stays_provisional(
     monkeypatch,
 ):
     patch_module_clock(monkeypatch, language_utils, monotonic=lambda: 10.0)
-    monkeypatch.setattr(language_utils, "_detect_china_region", lambda: None)
+    monkeypatch.setattr(
+        language_utils,
+        "_probe_china_region",
+        lambda: _probe_result(None),
+    )
     language_utils.set_global_language("ja")
 
     assert language_utils.refresh_global_language("ja") is False
@@ -238,25 +667,23 @@ def test_same_language_refresh_is_no_change_while_region_stays_provisional(
     assert language_utils._global_region_initialized is False
 
 
-def test_config_migration_does_not_persist_a_provisional_english_fallback(
-    monkeypatch,
-    tmp_path,
-):
-    characters_dir = tmp_path / "characters"
-    characters_dir.mkdir()
-    english_source = characters_dir / "en.json"
-    english_source.write_text("{}", encoding="utf-8")
+def test_same_language_refresh_reports_region_recovery(monkeypatch):
+    now = [10.0]
+    patch_module_clock(monkeypatch, language_utils, monotonic=lambda: now[0])
+    region_results = iter((None, True))
+    monkeypatch.setattr(
+        language_utils,
+        "_probe_china_region",
+        lambda: _probe_result(next(region_results)),
+    )
+    language_utils.set_global_language("ja")
 
-    class Manager(MigrationsMixin):
-        project_config_dir = tmp_path
+    assert language_utils.refresh_global_language("ja") is False
+    assert language_utils._global_region_initialized is False
+    assert language_utils._global_probe_next_retry_monotonic == 15.0
 
-        @staticmethod
-        def _log(_message):
-            return None
-
-    monkeypatch.setattr(language_utils, "_get_steam_language", lambda: None)
-    monkeypatch.setattr(language_utils, "_detect_system_language", lambda: None)
-    assert Manager()._get_localized_characters_source() is None
-
-    monkeypatch.setattr(language_utils, "_detect_system_language", lambda: "en")
-    assert Manager()._get_localized_characters_source() == english_source
+    now[0] = 15.0
+    assert language_utils.refresh_global_language("ja") is True
+    assert language_utils.get_global_language() == "ja"
+    assert language_utils.get_global_region() == "china"
+    assert language_utils._global_region_initialized is True

--- a/tests/unit/test_language_probe_retry.py
+++ b/tests/unit/test_language_probe_retry.py
@@ -479,8 +479,12 @@ def test_only_provisional_language_is_reprobed_after_cooldown(monkeypatch):
 
 
 def test_retry_cooldown_starts_after_slow_probe_finishes(monkeypatch):
-    stamps = iter((100.0, 104.0))
-    patch_module_clock(monkeypatch, language_utils, monotonic=lambda: next(stamps))
+    stamps = [100.0, 104.0]
+
+    def monotonic():
+        return stamps.pop(0) if len(stamps) > 1 else stamps[0]
+
+    patch_module_clock(monkeypatch, language_utils, monotonic=monotonic)
     monkeypatch.setattr(language_utils, "_get_steam_language", lambda: None)
     monkeypatch.setattr(
         language_utils,

--- a/tests/unit/test_language_region_override.py
+++ b/tests/unit/test_language_region_override.py
@@ -28,6 +28,9 @@ def test_region_env_falsy_forces_non_china(monkeypatch, value):
 
 def test_invalid_region_env_falls_back_to_locale(monkeypatch):
     monkeypatch.setenv("NEKO_IS_CHINA_REGION", "unexpected")
+    monkeypatch.setattr(language_utils.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(language_utils, "_get_windows_locale", lambda: None)
+    monkeypatch.setattr(language_utils, "_get_macos_locale", lambda: None)
     monkeypatch.setattr(language_utils.locale, "getlocale", lambda: ("Chinese (Simplified)_China", "936"))
 
     assert language_utils._is_china_region() is True
@@ -53,6 +56,8 @@ def test_macos_chinese_locale_uses_mainland_region_contract(
 ):
     monkeypatch.delenv("NEKO_IS_CHINA_REGION", raising=False)
     monkeypatch.setenv("LANG", "C.UTF-8")
+    monkeypatch.setattr(language_utils.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(language_utils, "_get_windows_locale", lambda: None)
     monkeypatch.setattr(language_utils, "_get_macos_locale", lambda: macos_locale)
     monkeypatch.setattr(language_utils.locale, "getlocale", lambda: (None, None))
 
@@ -62,6 +67,8 @@ def test_macos_chinese_locale_uses_mainland_region_contract(
 def test_macos_locale_overrides_stale_process_locale(monkeypatch):
     monkeypatch.delenv("NEKO_IS_CHINA_REGION", raising=False)
     monkeypatch.setenv("LANG", "zh_CN.UTF-8")
+    monkeypatch.setattr(language_utils.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(language_utils, "_get_windows_locale", lambda: None)
     monkeypatch.setattr(language_utils, "_get_macos_locale", lambda: "zh_TW")
     monkeypatch.setattr(language_utils.locale, "getlocale", lambda: ("zh_CN", "UTF-8"))
 

--- a/tests/unit/test_memory_language_resolution.py
+++ b/tests/unit/test_memory_language_resolution.py
@@ -110,9 +110,11 @@ def test_global_language_still_prefers_steam_over_system_locale(monkeypatch):
     monkeypatch.setattr(language_utils, "_global_language_full", None)
     monkeypatch.setattr(language_utils, "_global_region", None)
     monkeypatch.setattr(language_utils, "_global_language_initialized", False)
-    monkeypatch.setattr(language_utils, "_is_china_region", lambda: True)
+    monkeypatch.setattr(language_utils, "_global_region_initialized", False)
+    monkeypatch.setattr(language_utils, "_global_probe_next_retry_monotonic", 0.0)
+    monkeypatch.setattr(language_utils, "_detect_china_region", lambda: True)
     monkeypatch.setattr(language_utils, "_get_steam_language", lambda: "japanese")
-    monkeypatch.setattr(language_utils, "_get_system_language", lambda: "zh")
+    monkeypatch.setattr(language_utils, "_detect_system_language", lambda: "zh")
 
     assert language_utils.initialize_global_language() == "ja"
     assert language_utils.get_global_language_full() == "ja"

--- a/tests/unit/test_memory_language_resolution.py
+++ b/tests/unit/test_memory_language_resolution.py
@@ -112,9 +112,17 @@ def test_global_language_still_prefers_steam_over_system_locale(monkeypatch):
     monkeypatch.setattr(language_utils, "_global_language_initialized", False)
     monkeypatch.setattr(language_utils, "_global_region_initialized", False)
     monkeypatch.setattr(language_utils, "_global_probe_next_retry_monotonic", 0.0)
-    monkeypatch.setattr(language_utils, "_detect_china_region", lambda: True)
+    monkeypatch.setattr(
+        language_utils,
+        "_probe_china_region",
+        lambda: language_utils._LocaleProbeResult(True, True),
+    )
     monkeypatch.setattr(language_utils, "_get_steam_language", lambda: "japanese")
-    monkeypatch.setattr(language_utils, "_detect_system_language", lambda: "zh")
+    monkeypatch.setattr(
+        language_utils,
+        "_probe_system_language",
+        lambda: language_utils._LocaleProbeResult("zh", True),
+    )
 
     assert language_utils.initialize_global_language() == "ja"
     assert language_utils.get_global_language_full() == "ja"

--- a/utils/config_manager/migrations.py
+++ b/utils/config_manager/migrations.py
@@ -70,16 +70,12 @@ class MigrationsMixin:
             Path | None: localized file path, or None when language detection fails or the file does not exist (fall back to default)
         """
         try:
-            from utils.language_utils import (
-                _detect_system_language,
-                _get_steam_language,
-                normalize_language_code,
-            )
+            from utils.language_utils import _get_steam_language, _get_system_language, normalize_language_code
             
             # 优先使用 Steam 语言，其次系统语言
             raw_lang = _get_steam_language()
             if not raw_lang:
-                raw_lang = _detect_system_language()
+                raw_lang = _get_system_language()
             if not raw_lang:
                 return None
             

--- a/utils/config_manager/migrations.py
+++ b/utils/config_manager/migrations.py
@@ -70,12 +70,16 @@ class MigrationsMixin:
             Path | None: localized file path, or None when language detection fails or the file does not exist (fall back to default)
         """
         try:
-            from utils.language_utils import _get_steam_language, _get_system_language, normalize_language_code
+            from utils.language_utils import (
+                _detect_system_language,
+                _get_steam_language,
+                normalize_language_code,
+            )
             
             # 优先使用 Steam 语言，其次系统语言
             raw_lang = _get_steam_language()
             if not raw_lang:
-                raw_lang = _get_system_language()
+                raw_lang = _detect_system_language()
             if not raw_lang:
                 return None
             

--- a/utils/language_utils.py
+++ b/utils/language_utils.py
@@ -172,19 +172,15 @@ _LEGACY_NON_MAINLAND_CHINESE_TERRITORIES = frozenset({
     'sg',
     'sgp',
 })
-_LEGACY_TRADITIONAL_CHINESE_TERRITORIES = frozenset({
-    'taiwan',
-    'tw',
-    'twn',
-    'hong kong',
-    'hong-kong',
-    'hk',
-    'hkg',
-    'macao',
-    'macau',
-    'mo',
-    'mac',
+_LEGACY_SINGAPORE_TERRITORIES = frozenset({
+    'singapore',
+    'sg',
+    'sgp',
 })
+_LEGACY_TRADITIONAL_CHINESE_TERRITORIES = (
+    _LEGACY_NON_MAINLAND_CHINESE_TERRITORIES
+    - _LEGACY_SINGAPORE_TERRITORIES
+)
 _LEGACY_MAINLAND_LANGUAGE_ALIASES = frozenset({
     'chinese-simplified',
 })
@@ -378,13 +374,7 @@ def _probe_china_region() -> _LocaleProbeResult:
             lambda: locale.getlocale()[0],
         )
         if system_locale:
-            system_locale_lower = system_locale.lower()
-            if _locale_is_mainland_china(system_locale_lower):
-                return _LocaleProbeResult(
-                    True,
-                    not authoritative_probe_unresolved,
-                )
-            verdict = _locale_region_signal(system_locale_lower)
+            verdict = _locale_region_signal(system_locale.lower())
             if verdict is not None:
                 return _LocaleProbeResult(
                     verdict,
@@ -951,7 +941,8 @@ def set_global_language(language: str) -> None:
         _global_language_initialized = True
         # 手动真值到达后，若区域仍是 provisional，允许下一次 region getter
         # 立即重试，而不是继承旧失败留下的退避窗口。
-        _reset_global_probe_backoff_locked()
+        if not _global_region_initialized:
+            _reset_global_probe_backoff_locked()
         logger.info(f"全局语言已手动设置为: {_global_language} (full: {_global_language_full})")
 
 
@@ -999,10 +990,9 @@ def refresh_global_language(language: str) -> bool:
         return False
 
     with _global_language_lock:
-        # ``_global_region is not None`` 也要 hold，否则 ``set_global_language`` 这条
-        # pre-existing 路径（只置 ``_global_language_initialized=True``、不碰 region）
-        # 留下的 ``language=short, region=None`` 状态会让本次 refresh 走早 return，
-        # 漏掉 region 自愈，``get_global_region`` 永久卡 ``'non-china'`` fallback。
+        # ``_global_region_initialized`` 也要 hold，否则 ``set_global_language`` 这条
+        # pre-existing 路径可能留下 language 已确定、region 仍 provisional 的状态，
+        # 让本次 refresh 过早返回并漏掉 region 自愈。
         if (_global_language_initialized
                 and _global_language == short
                 and _global_language_full == full

--- a/utils/language_utils.py
+++ b/utils/language_utils.py
@@ -30,6 +30,7 @@ import os
 import hashlib
 import platform
 import subprocess
+import time
 from collections import OrderedDict
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -55,6 +56,15 @@ _global_language_initialized = False
 
 # 全局区域标识（中文区/非中文区）
 _global_region: Optional[str] = None  # 'china' 或 'non-china'
+_global_region_initialized = False
+
+# 系统探测没有拿到确定信号时，仍允许当前调用使用安全默认值，但不把默认值
+# 当成进程级真值。重试使用单调时钟与指数退避，避免每个 getter 都重新触发
+# Windows API / macOS defaults 等系统调用。
+_GLOBAL_PROBE_RETRY_INITIAL_SECONDS = 5.0
+_GLOBAL_PROBE_RETRY_MAX_SECONDS = 300.0
+_global_probe_next_retry_monotonic = 0.0
+_global_probe_retry_delay_seconds = _GLOBAL_PROBE_RETRY_INITIAL_SECONDS
 
 # Background work may carry a conversation-specific locale while other
 # conversations run concurrently. ContextVars keep that override task-local;
@@ -141,9 +151,37 @@ def _locale_is_mainland_china(raw: Any) -> bool:
     return source_region_from_locale(normalized) == 'china'
 
 
-def _is_china_region() -> bool:
+def _locale_region_signal(raw: Any) -> Optional[bool]:
+    """Return a conclusive region verdict for a real locale, or ``None``.
+
+    ``C`` / ``POSIX`` locales are process defaults rather than user settings, so
+    they must not permanently classify the user as non-China.
     """
-    Decide whether the current system is in the Chinese region
+    if not raw:
+        return None
+    normalized = str(raw).strip().split('@', 1)[0].split('.', 1)[0]
+    if not normalized or normalized.lower() in {'c', 'posix'}:
+        return None
+    if _locale_is_mainland_china(normalized):
+        return True
+    normalized_lower = normalized.lower()
+    if 'chinese' in normalized_lower and 'china' in normalized_lower:
+        return True
+    if _parse_system_language(normalized) is not None:
+        return False
+    if normalized_lower in {'global', 'international', 'non-china', 'non_china'}:
+        return False
+    if re.fullmatch(
+        r'[A-Za-z]{2,3}(?:[-_][A-Za-z0-9]{2,8})*',
+        normalized,
+    ):
+        return False
+    return None
+
+
+def _detect_china_region() -> Optional[bool]:
+    """
+    Detect whether the current system is in the Chinese region.
 
     ``NEKO_IS_CHINA_REGION`` can explicitly override auto detection:
     truthy values (1/true/yes/on) force the Chinese region, while falsy
@@ -151,7 +189,8 @@ def _is_china_region() -> bool:
     or invalid value falls back to locale-based detection.
     
     Returns:
-        True for the Chinese region, False otherwise
+        ``True`` / ``False`` for a conclusive signal, or ``None`` when all
+        probes are unavailable or only expose a neutral process locale.
     """
     region_override = os.environ.get('NEKO_IS_CHINA_REGION', '').strip().lower()
     if region_override in {'1', 'true', 'yes', 'on'}:
@@ -165,9 +204,15 @@ def _is_china_region() -> bool:
         )
 
     try:
+        windows_locale = _get_windows_locale()
+        verdict = _locale_region_signal(windows_locale)
+        if verdict is not None:
+            return verdict
+
         macos_locale = _get_macos_locale()
-        if macos_locale:
-            return _locale_is_mainland_china(macos_locale)
+        verdict = _locale_region_signal(macos_locale)
+        if verdict is not None:
+            return verdict
 
         system_locale = locale.getlocale()[0]
         if system_locale:
@@ -176,15 +221,23 @@ def _is_china_region() -> bool:
                 return True
             if 'chinese' in system_locale_lower and 'china' in system_locale_lower:
                 return True
+            verdict = _locale_region_signal(system_locale_lower)
+            if verdict is not None:
+                return verdict
         
-        lang_env = os.environ.get('LANG', '').lower()
-        if _locale_is_mainland_china(lang_env):
-            return True
+        verdict = _locale_region_signal(os.environ.get('LANG', ''))
+        if verdict is not None:
+            return verdict
         
-        return False
+        return None
     except Exception as e:
-        logger.warning(f"判断系统区域失败: {e}，默认使用非中文区")
-        return False
+        logger.warning(f"判断系统区域失败: {e}，本次使用非中文区并稍后重试")
+        return None
+
+
+def _is_china_region() -> bool:
+    """Return the current region verdict, defaulting provisionally to non-China."""
+    return _detect_china_region() is True
 
 
 _MACOS_LOCALE_UNSET = object()
@@ -292,38 +345,75 @@ def _get_windows_locale() -> Optional[str]:
         return None
 
 
-def _get_system_language() -> str:
+def _parse_system_language(raw: Any) -> Optional[str]:
+    """Map one OS locale signal to a supported language."""
+    if not raw:
+        return None
+    s = str(raw).lower().replace('_', '-')
+    if s.split('@', 1)[0].split('.', 1)[0] in {'c', 'posix'}:
+        return None
+    chinese_name = (
+        s == 'chinese'
+        or s.startswith('chinese (')
+        or s.startswith('simplified chinese')
+        or s.startswith('traditional chinese')
+    )
+    if _matches_lang_code(s, 'zh') or chinese_name:
+        if any(marker in s for marker in ('-tw', '-hk', 'hant', 'traditional')):
+            return 'zh-TW'
+        return 'zh'
+    if _matches_lang_code(s, 'ja') or s == 'japanese':
+        return 'ja'
+    if (
+        _matches_lang_code(s, 'ko')
+        or s == 'korean'
+        or s == 'koreana'
+    ):
+        return 'ko'
+    if _matches_lang_code(s, 'ru') or s == 'russian':
+        return 'ru'
+    if _matches_lang_code(s, 'es', {'spanish', 'latam'}):
+        return 'es'
+    if _matches_lang_code(s, 'pt', {'portuguese', 'brazilian'}):
+        return 'pt'
+    if _matches_lang_code(s, 'en') or s == 'english':
+        return 'en'
+    return None
+
+
+def _system_language_signal(raw: Any) -> Optional[str]:
+    """Map a conclusive OS locale to a supported language or English.
+
+    A valid but unsupported locale (for example ``fr_FR``) is still a real
+    user-setting signal. The application's supported-language fallback for
+    that signal is English; only missing, neutral, or malformed values remain
+    provisional.
     """
-    Get the language from system settings
+    parsed = _parse_system_language(raw)
+    if parsed:
+        return parsed
+    if not raw:
+        return None
+    base = str(raw).strip().split('@', 1)[0].split('.', 1)[0]
+    if base.lower() in {'c', 'posix'}:
+        return None
+    if re.fullmatch(r'[A-Za-z]{2,3}(?:[-_][A-Za-z0-9]{2,8})*', base):
+        return 'en'
+    return None
+
+
+def _detect_system_language() -> Optional[str]:
+    """
+    Detect the language from system settings without inventing a fallback.
 
     Returns:
-        Language code ('zh', 'en', 'ja', 'ko', 'ru'), defaults to 'en'
+        A supported language code, or ``None`` when no probe is conclusive.
     """
-    def _parse_locale(s: str) -> Optional[str]:
-        s = s.lower().replace('_', '-')
-        if s.startswith('zh') or 'chinese' in s:
-            if any(marker in s for marker in ('-tw', '-hk', 'hant', 'traditional')):
-                return 'zh-TW'
-            return 'zh'
-        if s.startswith('ja') or 'japanese' in s:
-            return 'ja'
-        if s.startswith('ko') or 'korean' in s:
-            return 'ko'
-        if s.startswith('ru') or 'russian' in s:
-            return 'ru'
-        if _matches_lang_code(s, 'es', {'spanish', 'latam'}):
-            return 'es'
-        if _matches_lang_code(s, 'pt', {'portuguese', 'brazilian'}):
-            return 'pt'
-        if s.startswith('en') or 'english' in s:
-            return 'en'
-        return None
-
     try:
         # 优先：Windows API（locale.getlocale() 在 Windows 上几乎总是 (None, None)）
         windows_locale = _get_windows_locale()
         if windows_locale:
-            lang = _parse_locale(windows_locale)
+            lang = _system_language_signal(windows_locale)
             if lang:
                 return lang
 
@@ -332,28 +422,33 @@ def _get_system_language() -> str:
         # process locale so standalone memory_server chooses the real language.
         macos_locale = _get_macos_locale()
         if macos_locale:
-            lang = _parse_locale(macos_locale)
+            lang = _system_language_signal(macos_locale)
             if lang:
                 return lang
 
         # 次选：Python locale（Unix / 少数 Windows 场景有效）
         system_locale = locale.getlocale()[0]
         if system_locale:
-            lang = _parse_locale(system_locale)
+            lang = _system_language_signal(system_locale)
             if lang:
                 return lang
 
         # 末选：LANG 环境变量（Unix 常见）
         lang_env = os.environ.get('LANG', '')
         if lang_env:
-            lang = _parse_locale(lang_env)
+            lang = _system_language_signal(lang_env)
             if lang:
                 return lang
 
-        return 'en'  # 默认英文
+        return None
     except Exception as e:
-        logger.warning(f"获取系统语言失败: {e}，使用默认英文")
-        return 'en'
+        logger.warning(f"获取系统语言失败: {e}，本次使用默认英文并稍后重试")
+        return None
+
+
+def _get_system_language() -> str:
+    """Compatibility wrapper returning the outward-facing English default."""
+    return _detect_system_language() or 'en'
 
 
 def _get_steam_language() -> Optional[str]:
@@ -404,6 +499,27 @@ def _get_steam_language() -> Optional[str]:
         return None
 
 
+def _reset_global_probe_backoff_locked() -> None:
+    """Reset provisional-probe retry state while holding the global lock."""
+    global _global_probe_next_retry_monotonic, _global_probe_retry_delay_seconds
+    _global_probe_next_retry_monotonic = 0.0
+    _global_probe_retry_delay_seconds = _GLOBAL_PROBE_RETRY_INITIAL_SECONDS
+
+
+def _schedule_global_probe_retry_locked(now: float) -> None:
+    """Schedule the next provisional-probe attempt with bounded backoff."""
+    global _global_probe_next_retry_monotonic, _global_probe_retry_delay_seconds
+    delay = max(
+        _GLOBAL_PROBE_RETRY_INITIAL_SECONDS,
+        float(_global_probe_retry_delay_seconds),
+    )
+    _global_probe_next_retry_monotonic = now + delay
+    _global_probe_retry_delay_seconds = min(
+        _GLOBAL_PROBE_RETRY_MAX_SECONDS,
+        delay * 2.0,
+    )
+
+
 def initialize_global_language() -> str:
     """
     Initialize the global language variable (priority: Steam settings > system settings)
@@ -411,48 +527,73 @@ def initialize_global_language() -> str:
     Returns:
         The initialized language code ('zh', 'en', 'ja', 'ko')
     """
-    global _global_language, _global_language_full, _global_region, _global_language_initialized
+    global _global_language, _global_language_full, _global_language_initialized
+    global _global_region, _global_region_initialized
     
     with _global_language_lock:
-        if _global_language_initialized:
+        if _global_language_initialized and _global_region_initialized:
             return _global_language or 'en'
-        
-        # 判断区域
-        if _is_china_region():
-            _global_region = 'china'
-        else:
-            _global_region = 'non-china'
-        logger.info(f"系统区域判断: {_global_region}")
 
-        # 显式环境变量覆盖优先于 Steam 和系统语言，主要用于启动/集成测试。
-        language_override = _get_language_env_override()
-        if language_override:
-            _global_language = normalize_language_code(language_override, format='short')
-            _global_language_full = normalize_language_code(language_override, format='full')
-            _global_language_initialized = True
-            logger.info(
-                "全局语言已由 NEKO_LANGUAGE 强制设置为: %s (full: %s)",
-                _global_language,
-                _global_language_full,
-            )
-            return _global_language
-        
-        # 优先级1：尝试从 Steam 获取
-        steam_lang = _get_steam_language()
-        if steam_lang:
-            # 归一化 Steam 语言代码为短格式
-            _global_language = normalize_language_code(steam_lang, format='short')
-            _global_language_full = normalize_language_code(steam_lang, format='full')
-            logger.info(f"全局语言已初始化（来自Steam）: {_global_language} (full: {_global_language_full})")
-            _global_language_initialized = True
-            return _global_language
-        
-        # 优先级2：从系统设置获取
-        system_lang = _get_system_language()
-        _global_language = normalize_language_code(system_lang, format='short')
-        _global_language_full = normalize_language_code(system_lang, format='full')
-        logger.info(f"全局语言已初始化（来自系统设置）: {_global_language}")
-        _global_language_initialized = True
+        now = time.monotonic()
+        if now < _global_probe_next_retry_monotonic:
+            return _global_language or 'en'
+
+        # 语言与区域分别记录置信状态：Steam 可能已经给出确定语言，但 OS
+        # 区域仍处于瞬时探测失败，反之亦然。只重试没有结论的部分。
+        if not _global_region_initialized:
+            region_verdict = _detect_china_region()
+            if region_verdict is None:
+                _global_region = _global_region or 'non-china'
+                logger.info("系统区域暂未探测到确定信号，本次使用 non-china")
+            else:
+                _global_region = 'china' if region_verdict else 'non-china'
+                _global_region_initialized = True
+                logger.info(f"系统区域判断: {_global_region}")
+
+        if not _global_language_initialized:
+            # 显式环境变量覆盖优先于 Steam 和系统语言，主要用于启动/集成测试。
+            language_override = _get_language_env_override()
+            if language_override:
+                _global_language = normalize_language_code(language_override, format='short')
+                _global_language_full = normalize_language_code(language_override, format='full')
+                _global_language_initialized = True
+                logger.info(
+                    "全局语言已由 NEKO_LANGUAGE 强制设置为: %s (full: %s)",
+                    _global_language,
+                    _global_language_full,
+                )
+            else:
+                # 优先级1：尝试从 Steam 获取
+                steam_lang = _get_steam_language()
+                if steam_lang:
+                    _global_language = normalize_language_code(steam_lang, format='short')
+                    _global_language_full = normalize_language_code(steam_lang, format='full')
+                    _global_language_initialized = True
+                    logger.info(
+                        "全局语言已初始化（来自Steam）: %s (full: %s)",
+                        _global_language,
+                        _global_language_full,
+                    )
+                else:
+                    # 优先级2：从系统设置获取。None 表示没有确定信号；
+                    # 对外仍返回 en，但不把这个 fallback 永久钉进缓存。
+                    system_lang = _detect_system_language()
+                    if system_lang:
+                        _global_language = normalize_language_code(system_lang, format='short')
+                        _global_language_full = normalize_language_code(system_lang, format='full')
+                        _global_language_initialized = True
+                        logger.info(f"全局语言已初始化（来自系统设置）: {_global_language}")
+                    else:
+                        _global_language = _global_language or 'en'
+                        _global_language_full = _global_language_full or 'en'
+                        logger.info("全局语言暂未探测到确定信号，本次使用 en")
+
+        if _global_language_initialized and _global_region_initialized:
+            _reset_global_probe_backoff_locked()
+        else:
+            # Slow system probes (notably macOS defaults timeouts) must not eat
+            # into the cooldown itself.
+            _schedule_global_probe_retry_locked(time.monotonic())
         return _global_language
 
 
@@ -553,6 +694,9 @@ def set_global_language(language: str) -> None:
         _global_language = normalized_lang
         _global_language_full = full_lang
         _global_language_initialized = True
+        # 手动真值到达后，若区域仍是 provisional，允许下一次 region getter
+        # 立即重试，而不是继承旧失败留下的退避窗口。
+        _reset_global_probe_backoff_locked()
         logger.info(f"全局语言已手动设置为: {_global_language} (full: {_global_language_full})")
 
 
@@ -566,19 +710,17 @@ def refresh_global_language(language: str) -> bool:
       shouldn't spam each time).
     - only overwrites and logs when the value differs / the cache is uninitialized.
 
-    Motivation: ``initialize_global_language`` runs only once at process startup; if the
-    Steam SDK isn't ready it degrades to the system locale and **caches it for life**;
-    the frontend's ``/api/config/steam_language`` endpoint re-reads Steam every time and
-    gets the right value, but had no path to write it back to the global cache — so all
-    downstream consumers of ``get_global_language()`` (memory / reflection / tts /
-    soccer fallback, etc.) kept using the wrong English. This function is that
-    write-back path.
+    Motivation: a late Steam verdict should replace either a conclusive OS language or
+    a provisional English fallback immediately. Automatic probes use bounded backoff,
+    while the frontend's ``/api/config/steam_language`` endpoint can provide the truth
+    as soon as Steam becomes ready.
 
     Returns:
         ``True`` when a real change happened; ``False`` when already current or the
         argument is invalid.
     """
-    global _global_language, _global_language_full, _global_region, _global_language_initialized
+    global _global_language, _global_language_full, _global_language_initialized
+    global _global_region, _global_region_initialized
 
     # NEKO_LANGUAGE 是进程级强制覆盖；前端冷启动随后读取到 Steam 语言时，
     # 不允许该晚到值把显式环境配置覆盖回去。
@@ -609,30 +751,51 @@ def refresh_global_language(language: str) -> bool:
         if (_global_language_initialized
                 and _global_language == short
                 and _global_language_full == full
-                and _global_region is not None):
+                and _global_region_initialized):
             return False
+        language_changed = (
+            not _global_language_initialized
+            or _global_language != short
+            or _global_language_full != full
+        )
+        region_was_initialized = _global_region_initialized
         prev_short = _global_language
         prev_full = _global_language_full
         _global_language = short
         _global_language_full = full
-        # _global_region 必须和 _global_language_initialized 同时建立：``get_global_region``
-        # 看到 region 为 None 才会再调 ``initialize_global_language``，但后者一旦看到
-        # initialized=True 就 early-return，会把 region 永久卡在 None → 'non-china'
-        # fallback。startup 路径正常会先初始化 region；但 startup 异常 / 测试 / 子进程
-        # 等场景下若 refresh 先于 init 跑到这里，必须自补 region 来维持不变量。
-        if _global_region is None:
+        # Language and region keep separate confidence flags. A refresh can settle the
+        # language while the region remains provisional, so opportunistically probe a
+        # due region without postponing an existing retry deadline.
+        probe_now = time.monotonic()
+        if (
+            not _global_region_initialized
+            and probe_now >= _global_probe_next_retry_monotonic
+        ):
             try:
-                _global_region = 'china' if _is_china_region() else 'non-china'
+                region_verdict = _detect_china_region()
+                if region_verdict is None:
+                    _global_region = _global_region or 'non-china'
+                else:
+                    _global_region = 'china' if region_verdict else 'non-china'
+                    _global_region_initialized = True
                 logger.info(f"系统区域判断（refresh 路径补齐）: {_global_region}")
             except Exception:
                 _global_region = 'non-china'
                 logger.debug("refresh_global_language 补齐 region 失败，回落 non-china", exc_info=True)
         _global_language_initialized = True
-        logger.info(
-            f"全局语言已刷新（晚到真值覆盖）: {prev_short} -> {short} "
-            f"(full: {prev_full} -> {full})"
+        if _global_region_initialized:
+            _reset_global_probe_backoff_locked()
+        elif _global_probe_next_retry_monotonic <= probe_now:
+            _schedule_global_probe_retry_locked(time.monotonic())
+        if language_changed:
+            logger.info(
+                f"全局语言已刷新（晚到真值覆盖）: {prev_short} -> {short} "
+                f"(full: {prev_full} -> {full})"
+            )
+        state_changed = language_changed or (
+            not region_was_initialized and _global_region_initialized
         )
-    return True
+    return state_changed
 
 
 def get_global_region() -> str:
@@ -645,7 +808,7 @@ def get_global_region() -> str:
     global _global_region
     
     with _global_language_lock:
-        if _global_region is None:
+        if not _global_region_initialized:
             # 如果区域未初始化，先初始化语言（会同时初始化区域）
             initialize_global_language()
         
@@ -666,13 +829,16 @@ def reset_global_language() -> None:
     """
     Reset the global language variable (re-initialize)
     """
-    global _global_language, _global_language_full, _global_region, _global_language_initialized
+    global _global_language, _global_language_full, _global_language_initialized
+    global _global_region, _global_region_initialized
     
     with _global_language_lock:
         _global_language = None
         _global_language_full = None
         _global_region = None
         _global_language_initialized = False
+        _global_region_initialized = False
+        _reset_global_probe_backoff_locked()
         logger.info("全局语言变量已重置")
 
 

--- a/utils/language_utils.py
+++ b/utils/language_utils.py
@@ -34,7 +34,7 @@ import time
 from collections import OrderedDict
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import Optional, Tuple, List, Any, Dict, Iterator
+from typing import Optional, Tuple, List, Any, Callable, Dict, Iterator, NamedTuple
 from utils.llm_client import SystemMessage, HumanMessage, create_chat_llm_async
 from utils.config_manager import get_config_manager
 from utils.logger_config import get_module_logger
@@ -65,6 +65,23 @@ _GLOBAL_PROBE_RETRY_INITIAL_SECONDS = 5.0
 _GLOBAL_PROBE_RETRY_MAX_SECONDS = 300.0
 _global_probe_next_retry_monotonic = 0.0
 _global_probe_retry_delay_seconds = _GLOBAL_PROBE_RETRY_INITIAL_SECONDS
+
+# A single initialization attempt needs both a language and a region verdict.
+# Share the raw OS signals between those two detectors so a transient macOS
+# ``defaults`` failure costs one probe generation, not one subprocess sequence
+# per detector.  The snapshot is deliberately task/thread-local and discarded
+# at the end of the attempt; failed signals must remain retryable later.
+_system_locale_probe_snapshot: ContextVar[Optional[Dict[str, Any]]] = ContextVar(
+    "neko_system_locale_probe_snapshot",
+    default=None,
+)
+
+
+class _LocaleProbeResult(NamedTuple):
+    """Best-effort locale value plus whether it is safe to cache permanently."""
+
+    value: Any
+    conclusive: bool
 
 # Background work may carry a conversation-specific locale while other
 # conversations run concurrently. ContextVars keep that override task-local;
@@ -114,6 +131,79 @@ _SUPPORTED_STEAM_LITERALS: frozenset = frozenset({
     'koreana', 'korean', 'russian', 'spanish', 'latam',
     'portuguese', 'brazilian',
 })
+_LEGACY_SYSTEM_LANGUAGE_NAMES = {
+    'english': 'en',
+    'japanese': 'ja',
+    'korean': 'ko',
+    'russian': 'ru',
+    'spanish': 'es',
+    'portuguese': 'pt',
+    'chinese': 'zh',
+    'chinese (simplified)': 'zh',
+    'simplified chinese': 'zh',
+    'chinese-simplified': 'zh',
+    'chinese-singapore': 'zh',
+    'chinese (traditional)': 'zh-TW',
+    'traditional chinese': 'zh-TW',
+    'chinese-traditional': 'zh-TW',
+    'chinese-hongkong': 'zh-TW',
+}
+_LEGACY_MAINLAND_TERRITORIES = frozenset({
+    'china',
+    'cn',
+    'prc',
+    'pr china',
+    'pr-china',
+    'chn',
+})
+_LEGACY_NON_MAINLAND_CHINESE_TERRITORIES = frozenset({
+    'taiwan',
+    'tw',
+    'twn',
+    'hong kong',
+    'hong-kong',
+    'hk',
+    'hkg',
+    'macao',
+    'macau',
+    'mo',
+    'mac',
+    'singapore',
+    'sg',
+    'sgp',
+})
+_LEGACY_TRADITIONAL_CHINESE_TERRITORIES = frozenset({
+    'taiwan',
+    'tw',
+    'twn',
+    'hong kong',
+    'hong-kong',
+    'hk',
+    'hkg',
+    'macao',
+    'macau',
+    'mo',
+    'mac',
+})
+_LEGACY_MAINLAND_LANGUAGE_ALIASES = frozenset({
+    'chinese-simplified',
+})
+
+
+def _legacy_named_locale_parts(base: str) -> Optional[tuple[str, str]]:
+    """Parse an exact CRT ``<Language>_<Territory>`` locale name."""
+    if base.count('_') != 1:
+        return None
+    language_name, territory = base.split('_', 1)
+    language_name = language_name.strip().lower()
+    territory = territory.strip().lower()
+    if (
+        not language_name
+        or not territory
+        or any(marker in territory for marker in ('\x00', '\r', '\n'))
+    ):
+        return None
+    return language_name, territory
 
 
 def is_supported_language_code(raw: Any) -> bool:
@@ -151,6 +241,33 @@ def _locale_is_mainland_china(raw: Any) -> bool:
     return source_region_from_locale(normalized) == 'china'
 
 
+@contextmanager
+def _system_locale_probe_generation() -> Iterator[None]:
+    """Share raw OS locale signals within one logical detection attempt."""
+    if _system_locale_probe_snapshot.get() is not None:
+        yield
+        return
+
+    token = _system_locale_probe_snapshot.set({})
+    try:
+        yield
+    finally:
+        _system_locale_probe_snapshot.reset(token)
+
+
+def _read_system_locale_signal_once(
+    name: str,
+    loader: Callable[[], Any],
+) -> Any:
+    """Read one raw signal, reusing it only inside the current generation."""
+    snapshot = _system_locale_probe_snapshot.get()
+    if snapshot is None:
+        return loader()
+    if name not in snapshot:
+        snapshot[name] = loader()
+    return snapshot[name]
+
+
 def _locale_region_signal(raw: Any) -> Optional[bool]:
     """Return a conclusive region verdict for a real locale, or ``None``.
 
@@ -165,8 +282,22 @@ def _locale_region_signal(raw: Any) -> Optional[bool]:
     if _locale_is_mainland_china(normalized):
         return True
     normalized_lower = normalized.lower()
-    if 'chinese' in normalized_lower and 'china' in normalized_lower:
+    if normalized_lower in _LEGACY_MAINLAND_LANGUAGE_ALIASES:
         return True
+    legacy_parts = _legacy_named_locale_parts(normalized)
+    if legacy_parts is not None:
+        language_name, territory = legacy_parts
+        parsed_language = _LEGACY_SYSTEM_LANGUAGE_NAMES.get(language_name)
+        if parsed_language in {'zh', 'zh-TW'}:
+            if territory in _LEGACY_MAINLAND_TERRITORIES:
+                return True
+            if territory in _LEGACY_NON_MAINLAND_CHINESE_TERRITORIES:
+                return False
+            return None
+        if parsed_language is not None:
+            return False
+    if normalized_lower == 'chinese':
+        return None
     if _parse_system_language(normalized) is not None:
         return False
     if normalized_lower in {'global', 'international', 'non-china', 'non_china'}:
@@ -179,9 +310,17 @@ def _locale_region_signal(raw: Any) -> Optional[bool]:
     return None
 
 
-def _detect_china_region() -> Optional[bool]:
+def _system_locale_candidate_is_valid(raw: Any) -> bool:
+    """Return whether an OS locale is usable for at least one detection dimension."""
+    return (
+        _parse_system_language(raw) is not None
+        or _locale_region_signal(raw) is not None
+    )
+
+
+def _probe_china_region() -> _LocaleProbeResult:
     """
-    Detect whether the current system is in the Chinese region.
+    Probe whether the current system is in the Chinese region.
 
     ``NEKO_IS_CHINA_REGION`` can explicitly override auto detection:
     truthy values (1/true/yes/on) force the Chinese region, while falsy
@@ -189,14 +328,15 @@ def _detect_china_region() -> Optional[bool]:
     or invalid value falls back to locale-based detection.
     
     Returns:
-        ``True`` / ``False`` for a conclusive signal, or ``None`` when all
-        probes are unavailable or only expose a neutral process locale.
+        A best-effort verdict and whether it is safe to cache permanently.
+        A lower-priority process locale remains provisional when the current
+        platform's authoritative Windows/macOS probe failed.
     """
     region_override = os.environ.get('NEKO_IS_CHINA_REGION', '').strip().lower()
     if region_override in {'1', 'true', 'yes', 'on'}:
-        return True
+        return _LocaleProbeResult(True, True)
     if region_override in {'0', 'false', 'no', 'off'}:
-        return False
+        return _LocaleProbeResult(False, True)
     if region_override:
         logger.warning(
             "NEKO_IS_CHINA_REGION=%r 无效，支持 1/true/yes/on 或 0/false/no/off；回退系统区域检测",
@@ -204,40 +344,79 @@ def _detect_china_region() -> Optional[bool]:
         )
 
     try:
-        windows_locale = _get_windows_locale()
+        platform_name = str(_read_system_locale_signal_once(
+            'platform_system',
+            platform.system,
+        ) or '')
+        authoritative_probe_unresolved = False
+
+        windows_locale = _read_system_locale_signal_once(
+            'windows_locale',
+            _get_windows_locale,
+        )
         verdict = _locale_region_signal(windows_locale)
         if verdict is not None:
-            return verdict
+            return _LocaleProbeResult(verdict, True)
+        if platform_name == 'Windows':
+            authoritative_probe_unresolved = True
 
-        macos_locale = _get_macos_locale()
+        macos_locale = _read_system_locale_signal_once(
+            'macos_locale',
+            _get_macos_locale,
+        )
         verdict = _locale_region_signal(macos_locale)
         if verdict is not None:
-            return verdict
+            return _LocaleProbeResult(
+                verdict,
+                not authoritative_probe_unresolved,
+            )
+        if platform_name == 'Darwin':
+            authoritative_probe_unresolved = True
 
-        system_locale = locale.getlocale()[0]
+        system_locale = _read_system_locale_signal_once(
+            'python_locale',
+            lambda: locale.getlocale()[0],
+        )
         if system_locale:
             system_locale_lower = system_locale.lower()
             if _locale_is_mainland_china(system_locale_lower):
-                return True
-            if 'chinese' in system_locale_lower and 'china' in system_locale_lower:
-                return True
+                return _LocaleProbeResult(
+                    True,
+                    not authoritative_probe_unresolved,
+                )
             verdict = _locale_region_signal(system_locale_lower)
             if verdict is not None:
-                return verdict
+                return _LocaleProbeResult(
+                    verdict,
+                    not authoritative_probe_unresolved,
+                )
         
-        verdict = _locale_region_signal(os.environ.get('LANG', ''))
+        lang_env = _read_system_locale_signal_once(
+            'lang_env',
+            lambda: os.environ.get('LANG', ''),
+        )
+        verdict = _locale_region_signal(lang_env)
         if verdict is not None:
-            return verdict
+            return _LocaleProbeResult(
+                verdict,
+                not authoritative_probe_unresolved,
+            )
         
-        return None
+        return _LocaleProbeResult(None, False)
     except Exception as e:
         logger.warning(f"判断系统区域失败: {e}，本次使用非中文区并稍后重试")
-        return None
+        return _LocaleProbeResult(None, False)
+
+
+def _detect_china_region() -> Optional[bool]:
+    """Return only a region verdict that is safe to cache permanently."""
+    result = _probe_china_region()
+    return result.value if result.conclusive else None
 
 
 def _is_china_region() -> bool:
     """Return the current region verdict, defaulting provisionally to non-China."""
-    return _detect_china_region() is True
+    return _probe_china_region().value is True
 
 
 _MACOS_LOCALE_UNSET = object()
@@ -253,14 +432,11 @@ def _get_macos_locale() -> Optional[str]:
     ``defaults`` database is the authoritative per-user fallback on macOS.
 
     Only *conclusive* answers are cached — a resolved locale, or "not macOS".
-    Each miss costs a ``subprocess.run`` with a 1s timeout, and
-    ``initialize_global_language()`` calls this twice (once via
-    ``_is_china_region``, once via ``_get_system_language``) while holding
-    ``_global_language_lock``; without caching, a cold start could spend ~4s
-    spawning ``defaults`` while both global getters are reachable from async
-    request paths. A failed probe is deliberately NOT cached: a single timeout
-    must not pin the whole process to the wrong locale, which is exactly the
-    situation this helper exists to rescue.
+    Each miss costs a ``subprocess.run`` with a 1s timeout. A failed probe is
+    deliberately NOT cached across retry generations: a single timeout must
+    not pin the whole process to the wrong locale. The global initializer does
+    share that failed result between its language and region detectors for the
+    duration of one generation, avoiding duplicate subprocess sequences.
     """
     global _macos_locale_cache
 
@@ -317,10 +493,12 @@ def _read_macos_locale_uncached() -> Optional[str]:
         if not raw:
             continue
         if key == 'AppleLocale':
-            return raw.strip('"').split('@', 1)[0]
-        match = re.search(r'"([^"\n]+)"', raw)
-        if match:
-            return match.group(1)
+            candidate = raw.strip('"').split('@', 1)[0]
+        else:
+            match = re.search(r'"([^"\n]+)"', raw)
+            candidate = match.group(1) if match else None
+        if candidate and _system_locale_candidate_is_valid(candidate):
+            return candidate
     return None
 
 
@@ -349,16 +527,30 @@ def _parse_system_language(raw: Any) -> Optional[str]:
     """Map one OS locale signal to a supported language."""
     if not raw:
         return None
-    s = str(raw).lower().replace('_', '-')
-    if s.split('@', 1)[0].split('.', 1)[0] in {'c', 'posix'}:
+    base = str(raw).strip().split('@', 1)[0].split('.', 1)[0]
+    base_lower = base.lower()
+    if base_lower in {'c', 'posix'}:
         return None
-    chinese_name = (
-        s == 'chinese'
-        or s.startswith('chinese (')
-        or s.startswith('simplified chinese')
-        or s.startswith('traditional chinese')
-    )
-    if _matches_lang_code(s, 'zh') or chinese_name:
+    # ``locale.getlocale()`` can expose Windows/Python's legacy
+    # ``<Language>_<Territory>`` names instead of BCP 47 codes. Match the
+    # language head and single underscore structure exactly so strings such
+    # as ``english-garbage`` and ``notjapanese_Japan`` stay provisional.
+    named_language = _LEGACY_SYSTEM_LANGUAGE_NAMES.get(base_lower)
+    if named_language is not None:
+        return named_language
+    legacy_parts = _legacy_named_locale_parts(base)
+    if legacy_parts is not None:
+        language_name, territory = legacy_parts
+        legacy_language = _LEGACY_SYSTEM_LANGUAGE_NAMES.get(language_name)
+        if legacy_language is not None:
+            if (
+                language_name == 'chinese'
+                and territory in _LEGACY_TRADITIONAL_CHINESE_TERRITORIES
+            ):
+                return 'zh-TW'
+            return legacy_language
+    s = base_lower.replace('_', '-')
+    if _matches_lang_code(s, 'zh'):
         if any(marker in s for marker in ('-tw', '-hk', 'hant', 'traditional')):
             return 'zh-TW'
         return 'zh'
@@ -402,53 +594,90 @@ def _system_language_signal(raw: Any) -> Optional[str]:
     return None
 
 
-def _detect_system_language() -> Optional[str]:
+def _probe_system_language() -> _LocaleProbeResult:
     """
-    Detect the language from system settings without inventing a fallback.
+    Probe the language from system settings without inventing a fallback.
 
     Returns:
-        A supported language code, or ``None`` when no probe is conclusive.
+        A best-effort language and whether it is safe to cache permanently.
+        A lower-priority process locale remains provisional when the current
+        platform's authoritative Windows/macOS probe failed.
     """
     try:
+        platform_name = str(_read_system_locale_signal_once(
+            'platform_system',
+            platform.system,
+        ) or '')
+        authoritative_probe_unresolved = False
+
         # 优先：Windows API（locale.getlocale() 在 Windows 上几乎总是 (None, None)）
-        windows_locale = _get_windows_locale()
-        if windows_locale:
-            lang = _system_language_signal(windows_locale)
-            if lang:
-                return lang
+        windows_locale = _read_system_locale_signal_once(
+            'windows_locale',
+            _get_windows_locale,
+        )
+        windows_language = _system_language_signal(windows_locale)
+        if windows_language:
+            return _LocaleProbeResult(windows_language, True)
+        if platform_name == 'Windows':
+            authoritative_probe_unresolved = True
 
         # macOS GUI apps often inherit LANG=C.UTF-8 even when System Settings
         # is Chinese/Japanese/etc. Read Apple's locale database before the
         # process locale so standalone memory_server chooses the real language.
-        macos_locale = _get_macos_locale()
-        if macos_locale:
-            lang = _system_language_signal(macos_locale)
-            if lang:
-                return lang
+        macos_locale = _read_system_locale_signal_once(
+            'macos_locale',
+            _get_macos_locale,
+        )
+        macos_language = _system_language_signal(macos_locale)
+        if macos_language:
+            return _LocaleProbeResult(
+                macos_language,
+                not authoritative_probe_unresolved,
+            )
+        if platform_name == 'Darwin':
+            authoritative_probe_unresolved = True
 
         # 次选：Python locale（Unix / 少数 Windows 场景有效）
-        system_locale = locale.getlocale()[0]
+        system_locale = _read_system_locale_signal_once(
+            'python_locale',
+            lambda: locale.getlocale()[0],
+        )
         if system_locale:
             lang = _system_language_signal(system_locale)
             if lang:
-                return lang
+                return _LocaleProbeResult(
+                    lang,
+                    not authoritative_probe_unresolved,
+                )
 
         # 末选：LANG 环境变量（Unix 常见）
-        lang_env = os.environ.get('LANG', '')
+        lang_env = _read_system_locale_signal_once(
+            'lang_env',
+            lambda: os.environ.get('LANG', ''),
+        )
         if lang_env:
             lang = _system_language_signal(lang_env)
             if lang:
-                return lang
+                return _LocaleProbeResult(
+                    lang,
+                    not authoritative_probe_unresolved,
+                )
 
-        return None
+        return _LocaleProbeResult(None, False)
     except Exception as e:
         logger.warning(f"获取系统语言失败: {e}，本次使用默认英文并稍后重试")
-        return None
+        return _LocaleProbeResult(None, False)
+
+
+def _detect_system_language() -> Optional[str]:
+    """Return only a system language that is safe to cache permanently."""
+    result = _probe_system_language()
+    return result.value if result.conclusive else None
 
 
 def _get_system_language() -> str:
     """Compatibility wrapper returning the outward-facing English default."""
-    return _detect_system_language() or 'en'
+    return _probe_system_language().value or 'en'
 
 
 def _get_steam_language() -> Optional[str]:
@@ -538,55 +767,81 @@ def initialize_global_language() -> str:
         if now < _global_probe_next_retry_monotonic:
             return _global_language or 'en'
 
-        # 语言与区域分别记录置信状态：Steam 可能已经给出确定语言，但 OS
-        # 区域仍处于瞬时探测失败，反之亦然。只重试没有结论的部分。
-        if not _global_region_initialized:
-            region_verdict = _detect_china_region()
-            if region_verdict is None:
-                _global_region = _global_region or 'non-china'
-                logger.info("系统区域暂未探测到确定信号，本次使用 non-china")
-            else:
-                _global_region = 'china' if region_verdict else 'non-china'
-                _global_region_initialized = True
-                logger.info(f"系统区域判断: {_global_region}")
+        with _system_locale_probe_generation():
+            # 语言与区域分别记录置信状态：Steam 可能已经给出确定语言，但 OS
+            # 区域仍处于瞬时探测失败，反之亦然。只重试没有结论的部分。
+            if not _global_region_initialized:
+                region_probe = _probe_china_region()
+                if region_probe.value is None:
+                    _global_region = _global_region or 'non-china'
+                    logger.debug("系统区域暂未探测到确定信号，本次使用 non-china")
+                else:
+                    _global_region = (
+                        'china' if region_probe.value else 'non-china'
+                    )
+                    _global_region_initialized = region_probe.conclusive
+                    if region_probe.conclusive:
+                        logger.info(f"系统区域判断: {_global_region}")
+                    else:
+                        logger.debug(
+                            "高优先级系统区域探测暂不可用，本次临时使用: %s",
+                            _global_region,
+                        )
 
-        if not _global_language_initialized:
-            # 显式环境变量覆盖优先于 Steam 和系统语言，主要用于启动/集成测试。
-            language_override = _get_language_env_override()
-            if language_override:
-                _global_language = normalize_language_code(language_override, format='short')
-                _global_language_full = normalize_language_code(language_override, format='full')
-                _global_language_initialized = True
-                logger.info(
-                    "全局语言已由 NEKO_LANGUAGE 强制设置为: %s (full: %s)",
-                    _global_language,
-                    _global_language_full,
-                )
-            else:
-                # 优先级1：尝试从 Steam 获取
-                steam_lang = _get_steam_language()
-                if steam_lang:
-                    _global_language = normalize_language_code(steam_lang, format='short')
-                    _global_language_full = normalize_language_code(steam_lang, format='full')
+            if not _global_language_initialized:
+                # 显式环境变量覆盖优先于 Steam 和系统语言，主要用于启动/集成测试。
+                language_override = _get_language_env_override()
+                if language_override:
+                    _global_language = normalize_language_code(language_override, format='short')
+                    _global_language_full = normalize_language_code(language_override, format='full')
                     _global_language_initialized = True
                     logger.info(
-                        "全局语言已初始化（来自Steam）: %s (full: %s)",
+                        "全局语言已由 NEKO_LANGUAGE 强制设置为: %s (full: %s)",
                         _global_language,
                         _global_language_full,
                     )
                 else:
-                    # 优先级2：从系统设置获取。None 表示没有确定信号；
-                    # 对外仍返回 en，但不把这个 fallback 永久钉进缓存。
-                    system_lang = _detect_system_language()
-                    if system_lang:
-                        _global_language = normalize_language_code(system_lang, format='short')
-                        _global_language_full = normalize_language_code(system_lang, format='full')
+                    # 优先级1：尝试从 Steam 获取
+                    steam_lang = _get_steam_language()
+                    if steam_lang:
+                        _global_language = normalize_language_code(steam_lang, format='short')
+                        _global_language_full = normalize_language_code(steam_lang, format='full')
                         _global_language_initialized = True
-                        logger.info(f"全局语言已初始化（来自系统设置）: {_global_language}")
+                        logger.info(
+                            "全局语言已初始化（来自Steam）: %s (full: %s)",
+                            _global_language,
+                            _global_language_full,
+                        )
                     else:
-                        _global_language = _global_language or 'en'
-                        _global_language_full = _global_language_full or 'en'
-                        logger.info("全局语言暂未探测到确定信号，本次使用 en")
+                        # 优先级2：从系统设置获取。None 表示没有确定信号；
+                        # 对外仍返回 en，但不把这个 fallback 永久钉进缓存。
+                        language_probe = _probe_system_language()
+                        if language_probe.value:
+                            _global_language = normalize_language_code(
+                                language_probe.value,
+                                format='short',
+                            )
+                            _global_language_full = normalize_language_code(
+                                language_probe.value,
+                                format='full',
+                            )
+                            _global_language_initialized = (
+                                language_probe.conclusive
+                            )
+                            if language_probe.conclusive:
+                                logger.info(
+                                    "全局语言已初始化（来自系统设置）: %s",
+                                    _global_language,
+                                )
+                            else:
+                                logger.debug(
+                                    "高优先级系统语言探测暂不可用，本次临时使用: %s",
+                                    _global_language,
+                                )
+                        else:
+                            _global_language = _global_language or 'en'
+                            _global_language_full = _global_language_full or 'en'
+                            logger.debug("全局语言暂未探测到确定信号，本次使用 en")
 
         if _global_language_initialized and _global_region_initialized:
             _reset_global_probe_backoff_locked()
@@ -772,13 +1027,24 @@ def refresh_global_language(language: str) -> bool:
             and probe_now >= _global_probe_next_retry_monotonic
         ):
             try:
-                region_verdict = _detect_china_region()
-                if region_verdict is None:
+                region_probe = _probe_china_region()
+                if region_probe.value is None:
                     _global_region = _global_region or 'non-china'
                 else:
-                    _global_region = 'china' if region_verdict else 'non-china'
-                    _global_region_initialized = True
-                logger.info(f"系统区域判断（refresh 路径补齐）: {_global_region}")
+                    _global_region = (
+                        'china' if region_probe.value else 'non-china'
+                    )
+                    _global_region_initialized = region_probe.conclusive
+                if region_probe.conclusive:
+                    logger.info(
+                        "系统区域判断（refresh 路径补齐）: %s",
+                        _global_region,
+                    )
+                else:
+                    logger.debug(
+                        "refresh 路径区域探测仍为临时值: %s",
+                        _global_region,
+                    )
             except Exception:
                 _global_region = 'non-china'
                 logger.debug("refresh_global_language 补齐 region 失败，回落 non-china", exc_info=True)


### PR DESCRIPTION
## 改动概述 / Summary

修复全局 locale 初始化把临时 fallback 当成最终结果、导致进程生命周期内不再探测的问题。

- 将语言与区域探测拆分为带置信度的结果，只有确定结果才标记为已初始化
- 当 Steam、Windows/macOS 系统接口等权威信号暂时不可用时，保留可用的临时 fallback，但允许后续自动恢复
- 为未确定维度增加 5 秒起步、最高 5 分钟的有界指数退避，避免每次 getter 都重复执行系统探测
- 语言与区域分别记录初始化状态；已确定的一侧不会因另一侧未确定而被重复探测
- 同一次初始化共享原始 locale 快照，并用全局锁避免并发 getter 触发重复探测
- 补充 Linux、Windows、macOS、Steam、环境变量、刷新/重置、退避与并发场景的回归测试

Closes #2525

## 回归报告 / Regression Report

- 保持现有公开 getter 的兼容行为：探测尚未确定时仍返回 `en` / 非中国区等现有 fallback
- Linux 上有效的进程 locale 仍可直接确定结果；Windows/macOS 上权威平台探测失败时，低优先级信号只作为临时结果
- 显式 `NEKO_LANGUAGE`、`NEKO_IS_CHINA_REGION` 与 Steam language 仍优先于系统 locale
- 配置迁移逻辑没有纳入本 PR，最终差异仅涉及 `utils/language_utils.py` 及对应单元测试

## 不拆分理由 / Why Not Split

本 PR 是一个原子修复：置信度状态、重试调度和跨平台探测语义相互依赖；测试与实现需要一起提交，拆分后中间状态会重新引入一次性缓存或平台行为不一致。

## 测试 / Testing

- `uv run pytest -q tests/unit/test_language_probe_retry.py tests/unit/test_language_env_override.py tests/unit/test_language_region_override.py tests/unit/test_language_translation_chunks.py tests/unit/test_memory_language_resolution.py tests/unit/test_memory_request_language_context.py tests/unit/test_system_router_topic_hooks.py tests/unit/test_tts_language_hint.py tests/unit/test_youtube_feed.py` — 149 passed
- `uv run ruff check utils/language_utils.py utils/config_manager/migrations.py tests/unit/test_language_probe_retry.py tests/unit/test_language_env_override.py tests/unit/test_memory_language_resolution.py` — passed（仅有仓库既有的无效 `# noqa` 警告）
- `git diff --check` — passed
- `uv run pytest -q tests/unit` — 7199 passed, 29 skipped, 1 个与本 PR 无关的现有 macOS 基线失败：`test_runtime_memory_soak.py::test_process_row_records_threads_handles_and_onnx_maps`，当前平台的 `psutil.Process` 不提供 `memory_maps`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 优化语言与地区自动检测，扩展系统 locale 解析（支持 legacy/BCP47、简繁与领土映射等）。
  * 强化消息来源优先级与回退策略，避免晚到信息覆盖已确认结果。
  * 新增有界重试与指数退避：仅对仍为临时状态的维度重探，并改进 cooldown、缓存与跨平台（macOS/Windows）边界表现。
  * 手动设置/刷新后提升地区自愈速度，且刷新不会延后地区重试。
* **测试**
  * 新增与调整多组探测、并发初始化、重试退避边界及平台差异用例，提升覆盖率与稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->