### PR TITLE
test(process-model): 原子发布 guard 标记，修 ubuntu leg 的间歇性红

### DIFF
--- a/tests/unit/test_launcher_foreground_residency.py
+++ b/tests/unit/test_launcher_foreground_residency.py
@@ -312,16 +312,29 @@ _GUARDED_CHILD = textwrap.dedent(
 
     marker = {marker!r}
 
+    def _write_marker(path, text):
+        # Write-then-rename, because the test side waits on path.exists() and
+        # then reads immediately. `open(path, "w")` publishes a ZERO-LENGTH
+        # file first and fills it afterwards, so the reader could win that gap
+        # and read "" -- which is exactly how this suite failed on CI:
+        #   AssertionError: assert '' in ('stdin_eof', 'pdeathsig')
+        # POSIX rename is atomic within a filesystem (these tests are
+        # POSIX-only), so the marker becomes visible already complete.
+        temp_path = path + ".partial"
+        with open(temp_path, "w", encoding="utf-8") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_path, path)
+
     def _on_death(mechanism):
-        with open(marker, "w", encoding="utf-8") as handle:
-            handle.write(mechanism)
+        _write_marker(marker, mechanism)
         os._exit(0)
 
     guard = parent_guard.install(
         _on_death, poll_interval={poll_interval}, watch_stdin={watch_stdin}
     )
-    with open({armed!r}, "w", encoding="utf-8") as handle:
-        handle.write(",".join(guard.mechanisms))
+    _write_marker({armed!r}, ",".join(guard.mechanisms))
     while True:
         time.sleep(0.05)
     """
@@ -329,6 +342,15 @@ _GUARDED_CHILD = textwrap.dedent(
 
 
 def _wait_for(path: Path, timeout: float = 15.0) -> bool:
+    """Wait for ``path`` to appear.
+
+    Callers read the file immediately afterwards, so anything that writes one
+    of these markers must publish it ATOMICALLY -- see ``_write_marker`` in
+    ``_GUARDED_CHILD``. A plain ``open(path, "w")`` creates the file empty and
+    fills it after, and this returns on the create, so the reader can win that
+    gap and see "". That is not hypothetical: it is what made this suite flake
+    on CI as ``assert '' in ('stdin_eof', 'pdeathsig')``.
+    """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if path.exists():


### PR DESCRIPTION
## 问题

`Process model (ubuntu-latest)` 在 main 上间歇性红，失败形态**每次都一样**：

```
AssertionError: assert '' in ('stdin_eof', 'pdeathsig')
```

它不是"时序玄学"，是一个可定位的竞态：guarded child 用 `open(marker, "w")` 写标记，
**先发布一个零长度文件**、之后才填内容；而测试侧 `_wait_for()` 是等 `path.exists()`、
返回后立刻读——于是 reader 可以抢在这个缝隙里读到 `""`。

我见到的三次 CI 失败全是这个形态，横跨两个用例
（`test_guarded_process_dies_when_the_owner_pipe_closes` 与
`test_guarded_process_dies_when_its_real_parent_dies`），两者都是这类标记的 reader。

## 修法

child 改成写 `<marker>.partial` → `flush` → `fsync` → `os.replace` 落位。
POSIX rename 在同一文件系统内是原子的，而这些用例本来就是 POSIX-only，
所以标记一旦可见就必然是完整的。文件里所有标记都走这一个 writer，
因此六处 `_wait_for` reader 一次性都被覆盖。

`_wait_for` 补了 docstring 写明这条要求，避免以后新增的 writer 悄悄把它带回来。

## 验证

不是靠推理，是量出来的。用和测试同款的 reader（poll `exists()` 后立刻读），
对比两种写法各跑 400 轮：

| writer | 读到空文件 |
| --- | --- |
| `open(w)` 然后 write | **315 / 400** |
| 写 `.partial` + rename | **0 / 400** |

⚠️ **需要说明的验证边界**：这些用例是 `skipif(os.name != "posix")`，
在 Windows 开发机上**不会执行**（本地 39 passed / 16 skipped，相关用例全 skip）。
真正的验证是本 PR 的 ubuntu leg。上面那份复现就是为了不让这条修复停留在"我觉得是这样"。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进测试标记文件的发布方式，避免读取到不完整内容。
  * 提升相关测试在持续集成环境中的稳定性，减少偶发断言失败。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->