### PR TITLE
fix(voice): 给 voice-start 共享槽加归属，被抢占的 flow 不能再清掉别人的槽

### DIFF
--- a/static/app/app-buttons.js
+++ b/static/app/app-buttons.js
@@ -2150,10 +2150,12 @@
                 }
 
                 // Create a promise for session_started
+                var micStartOwner = null;
                 var sessionStartPromise = new Promise(function (resolve, reject) {
-                    S.sessionStartedResolver = resolve;
-                    S.sessionStartedRejecter = reject;
-                    S._pendingSessionStartMode = 'audio';
+                    // Claim the shared slot and keep the owner token (the
+                    // resolver itself). Every release below is gated on it, so
+                    // this flow can never clear a slot that a newer start owns.
+                    micStartOwner = window.claimSessionStart('audio', resolve, reject);
                     // Re-arm the fail-closed voice latch on user intent, strictly
                     // before start_session goes out and therefore before any route
                     // verdict for this session can arrive.
@@ -2185,11 +2187,13 @@
 
                 // Timeout (15s)
                 window.sessionTimeoutId = setTimeout(function () {
+                    // Only fire for the start this timer was armed for: a newer
+                    // start may own the slot by now, and rejecting/clearing it
+                    // here would strand the promise its awaiter is holding.
+                    if (!window.sessionStartIsCurrent(micStartOwner)) return;
                     if (S.sessionStartedRejecter) {
                         var rejecter = S.sessionStartedRejecter;
-                        S.sessionStartedResolver = null;
-                        S.sessionStartedRejecter = null;
-                        S._pendingSessionStartMode = null;
+                        window.releaseSessionStart(micStartOwner);
                         window.sessionTimeoutId = null;
 
                         if (S.socket && S.socket.readyState === WebSocket.OPEN) {
@@ -2311,15 +2315,20 @@
                     console.error(window.t('console.startVoiceSessionFailed'), error);
                 }
 
-                // Cleanup
-                if (window.sessionTimeoutId) {
-                    clearTimeout(window.sessionTimeoutId);
-                    window.sessionTimeoutId = null;
+                // Cleanup -- but only of THIS start. This handler is the most
+                // damaging of the unconditional clears: it wiped the shared
+                // resolver/rejecter/mode and rejected the pending text start,
+                // so a mic start failing while the user had already switched to
+                // typing tore down the text session that had superseded it.
+                var micStartStillOurs = window.sessionStartIsCurrent(micStartOwner);
+                if (micStartStillOurs) {
+                    if (window.sessionTimeoutId) {
+                        clearTimeout(window.sessionTimeoutId);
+                        window.sessionTimeoutId = null;
+                    }
+                    rejectPendingTextSessionStart(error);
+                    window.releaseSessionStart(micStartOwner);
                 }
-                rejectPendingTextSessionStart(error);
-                S.sessionStartedResolver = null;
-                S.sessionStartedRejecter = null;
-                S._pendingSessionStartMode = null;
 
                 if (!isVoiceStartCancelled && !(error && error.voiceConfigSwitchTimedOut) && S.socket && S.socket.readyState === WebSocket.OPEN) {
                     S.socket.send(JSON.stringify({ action: 'end_session' }));
@@ -2574,10 +2583,11 @@
                 window.showStatusToast(window.t ? window.t('app.initializingText') : '\u6B63\u5728\u521D\u59CB\u5316\u6587\u672C\u5BF9\u8BDD...', initToastMs1);
 
                 // Wait for session_started
+                var textStartOwner = null;
                 var sessionStartPromise = new Promise(function (resolve, reject) {
-                    S.sessionStartedResolver = resolve;
-                    S.sessionStartedRejecter = reject;
-                    S._pendingSessionStartMode = 'text';
+                    // Owner token for every release in this flow; see
+                    // window.claimSessionStart in app-state.js.
+                    textStartOwner = window.claimSessionStart('text', resolve, reject);
 
                     if (window.sessionTimeoutId) {
                         clearTimeout(window.sessionTimeoutId);
@@ -2585,11 +2595,11 @@
                     }
 
                     window.sessionTimeoutId = setTimeout(function () {
+                        // Only for the start this timer was armed for.
+                        if (!window.sessionStartIsCurrent(textStartOwner)) return;
                         if (S.sessionStartedRejecter) {
                             var rejecter = S.sessionStartedRejecter;
-                            S.sessionStartedResolver = null;
-                            S.sessionStartedRejecter = null;
-                            S._pendingSessionStartMode = null;
+                            window.releaseSessionStart(textStartOwner);
                             window.sessionTimeoutId = null;
 
                             if (S.socket && S.socket.readyState === WebSocket.OPEN) {
@@ -2681,13 +2691,16 @@
                     5000
                 );
 
-                if (window.sessionTimeoutId) {
-                    clearTimeout(window.sessionTimeoutId);
-                    window.sessionTimeoutId = null;
+                // Only tear down THIS start: a newer one may own the slot by
+                // now, and clearing it would strand its awaiter.
+                if (window.sessionStartIsCurrent(textStartOwner)) {
+                    if (window.sessionTimeoutId) {
+                        clearTimeout(window.sessionTimeoutId);
+                        window.sessionTimeoutId = null;
+                    }
+                    rejectPendingTextSessionStart(error);
+                    window.releaseSessionStart(textStartOwner);
                 }
-                rejectPendingTextSessionStart(error);
-                S.sessionStartedResolver = null;
-                S.sessionStartedRejecter = null;
 
                 returnSessionButton.disabled = false;
             } finally {
@@ -2814,6 +2827,7 @@
                 screenshotButton.disabled = true;
                 resetSessionButton.disabled = false;
 
+                var composerStartOwner = null;
                 try {
                     if (!mod._textSessionStartPromise) {
                         mod._textSessionStartPromise = (async function () {
@@ -2822,9 +2836,8 @@
                             window.showStatusToast(window.t ? window.t('app.initializingText') : '\u6B63\u5728\u521D\u59CB\u5316\u6587\u672C\u5BF9\u8BDD...', initToastMs2);
 
                             var sessionStartPromise = new Promise(function (resolve, reject) {
-                                S.sessionStartedResolver = resolve;
-                                S.sessionStartedRejecter = reject;
-                                S._pendingSessionStartMode = 'text';
+                                // Owner token for every release in this flow.
+                                composerStartOwner = window.claimSessionStart('text', resolve, reject);
                                 mod._textSessionStartRejecter = reject;
 
                                 if (window.sessionTimeoutId) {
@@ -2842,11 +2855,11 @@
 
                             // Timeout after WebSocket confirms connection
                             window.sessionTimeoutId = setTimeout(function () {
+                                // Only for the start this timer was armed for.
+                                if (!window.sessionStartIsCurrent(composerStartOwner)) return;
                                 if (S.sessionStartedRejecter) {
                                     var rejecter = S.sessionStartedRejecter;
-                                    S.sessionStartedResolver = null;
-                                    S.sessionStartedRejecter = null;
-                                    S._pendingSessionStartMode = null;
+                                    window.releaseSessionStart(composerStartOwner);
                                     mod._textSessionStartRejecter = null;
                                     window.sessionTimeoutId = null;
 
@@ -2878,12 +2891,13 @@
                     }
 
                     await mod._textSessionStartPromise;
-                    if (window.sessionTimeoutId) {
-                        clearTimeout(window.sessionTimeoutId);
-                        window.sessionTimeoutId = null;
+                    if (window.sessionStartIsCurrent(composerStartOwner)) {
+                        if (window.sessionTimeoutId) {
+                            clearTimeout(window.sessionTimeoutId);
+                            window.sessionTimeoutId = null;
+                        }
+                        window.releaseSessionStart(composerStartOwner);
                     }
-                    S.sessionStartedResolver = null;
-                    S.sessionStartedRejecter = null;
                 } catch (error) {
                     console.error(window.t('console.startTextSessionFailed'), error);
                     window.hideVoicePreparingToast();
@@ -2894,12 +2908,13 @@
                         5000
                     );
 
-                    if (window.sessionTimeoutId) {
-                        clearTimeout(window.sessionTimeoutId);
-                        window.sessionTimeoutId = null;
+                    if (window.sessionStartIsCurrent(composerStartOwner)) {
+                        if (window.sessionTimeoutId) {
+                            clearTimeout(window.sessionTimeoutId);
+                            window.sessionTimeoutId = null;
+                        }
+                        window.releaseSessionStart(composerStartOwner);
                     }
-                    S.sessionStartedResolver = null;
-                    S.sessionStartedRejecter = null;
 
                     textSendButton.disabled = false;
                     textInputBox.disabled = false;

--- a/static/app/app-state.js
+++ b/static/app/app-state.js
@@ -250,6 +250,44 @@
         return error;
     };
 
+    // ---- voice-start slot ownership -------------------------------------
+    //
+    // S.sessionStartedResolver / Rejecter / _pendingSessionStartMode are ONE
+    // shared slot, and concurrent starts genuinely exist: the mic button, the
+    // composer's text send, the avatar-drop text entry and the automatic
+    // reconnect restart can all be in flight together. Every flow used to
+    // clear the slot unconditionally on its own way out, so whichever finished
+    // first wiped whoever currently owned it -- the newer start then hung on a
+    // promise nobody would ever settle, or had its timeout cancelled out from
+    // under it.
+    //
+    // The owner token is the resolver function itself: it is already unique
+    // per start and already in scope at every site that needs to check.
+    // claim/release below are the only way a FLOW should touch the slot;
+    // cancelPendingSessionStart stays deliberately unconditional because it is
+    // the global "abandon whatever is pending" lever (goodbye, avatar drop,
+    // character switch), where killing a foreign start is the intent.
+    window.claimSessionStart = function (mode, resolve, reject) {
+        S.sessionStartedResolver = resolve;
+        S.sessionStartedRejecter = reject;
+        S._pendingSessionStartMode = mode;
+        return resolve;
+    };
+
+    /** Release the slot only while ``owner`` still holds it. */
+    window.releaseSessionStart = function (owner) {
+        if (!owner || S.sessionStartedResolver !== owner) return false;
+        S.sessionStartedResolver = null;
+        S.sessionStartedRejecter = null;
+        S._pendingSessionStartMode = null;
+        return true;
+    };
+
+    /** True while ``owner`` is still the pending start. */
+    window.sessionStartIsCurrent = function (owner) {
+        return !!owner && S.sessionStartedResolver === owner;
+    };
+
     window.cancelPendingSessionStart = function (reason) {
         if (window.sessionTimeoutId) {
             clearTimeout(window.sessionTimeoutId);

--- a/static/app/app-websocket.js
+++ b/static/app/app-websocket.js
@@ -2682,11 +2682,13 @@
                             var _rt = returnSessionButton(); if (_rt) _rt.disabled = true;
 
                             setTimeout(async function () {
+                                var restartStartOwner = null;
                                 try {
                                     var sessionStartPromise = new Promise(function (resolve, reject) {
-                                        S.sessionStartedResolver = resolve;
-                                        S.sessionStartedRejecter = reject;
-                                        S._pendingSessionStartMode = 'audio';
+                                        // Owner token for every release in this
+                                        // flow; see claimSessionStart in
+                                        // app-state.js.
+                                        restartStartOwner = window.claimSessionStart('audio', resolve, reject);
                                         // Re-arm the fail-closed latch on user
                                         // intent, strictly before start_session
                                         // goes out and therefore before any
@@ -2702,10 +2704,11 @@
                                     S.socket.send(JSON.stringify({ action: 'start_session', input_type: 'audio' }));
 
                                     window.sessionTimeoutId = setTimeout(function () {
+                                        // Only for the start this timer was armed for.
+                                        if (!window.sessionStartIsCurrent(restartStartOwner)) return;
                                         if (S.sessionStartedRejecter) {
                                             var rejecter = S.sessionStartedRejecter;
-                                            S.sessionStartedResolver = null;
-                                            S.sessionStartedRejecter = null;
+                                            window.releaseSessionStart(restartStartOwner);
                                             window.sessionTimeoutId = null;
 
                                             if (S.socket && S.socket.readyState === WebSocket.OPEN) {
@@ -2787,12 +2790,14 @@
                                 } catch (error) {
                                     console.error(window.t('console.restartError'), error);
 
-                                    if (window.sessionTimeoutId) {
-                                        clearTimeout(window.sessionTimeoutId);
-                                        window.sessionTimeoutId = null;
+                                    // Only tear down THIS restart's slot.
+                                    if (window.sessionStartIsCurrent(restartStartOwner)) {
+                                        if (window.sessionTimeoutId) {
+                                            clearTimeout(window.sessionTimeoutId);
+                                            window.sessionTimeoutId = null;
+                                        }
+                                        window.releaseSessionStart(restartStartOwner);
                                     }
-                                    S.sessionStartedResolver = null;
-                                    S.sessionStartedRejecter = null;
 
                                     if (S.socket && S.socket.readyState === WebSocket.OPEN) {
                                         S.socket.send(JSON.stringify({ action: 'end_session' }));

--- a/tests/unit/test_voice_start_slot_ownership.py
+++ b/tests/unit/test_voice_start_slot_ownership.py
@@ -1,0 +1,135 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Ownership of the shared voice-start slot.
+
+``S.sessionStartedResolver`` / ``Rejecter`` / ``_pendingSessionStartMode`` are
+ONE slot, and concurrent starts genuinely exist: the mic button, the composer's
+text send, the avatar-drop text entry and the automatic reconnect restart can
+all be in flight together. Every flow used to clear the slot unconditionally on
+its way out, so whichever finished first wiped whoever owned it -- the newer
+start then hung on a promise nobody would settle, or lost its timeout.
+
+The owner token is the resolver function itself. These cases drive the real
+helpers from app-state.js rather than asserting on source text, because the
+property that matters is behavioural: a release by a superseded flow must be a
+no-op.
+"""
+
+import json
+import shutil
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from tests.node_harness import run_node_script
+
+APP_STATE_PATH = Path(__file__).resolve().parents[2] / "static" / "app" / "app-state.js"
+
+_HARNESS = r"""
+const fs = require('node:fs');
+const vm = require('node:vm');
+
+function assert(cond, msg) {
+  if (!cond) throw new Error('ASSERT: ' + msg);
+}
+
+// app-state.js is a large IIFE with browser dependencies; the ownership helpers
+// are self-contained, so lift just those out and run them against a stub S.
+const source = fs.readFileSync(__APP_STATE_PATH__, 'utf8');
+const start = source.indexOf('window.claimSessionStart = function');
+const end = source.indexOf('window.cancelPendingSessionStart = function');
+assert(start > 0 && end > start, 'could not locate the ownership helpers');
+
+const S = {
+  sessionStartedResolver: null,
+  sessionStartedRejecter: null,
+  _pendingSessionStartMode: null,
+};
+const sandbox = { S, window: {}, console: { log() {}, warn() {} } };
+vm.createContext(sandbox);
+vm.runInContext(source.slice(start, end), sandbox, { filename: 'app-state-helpers.js' });
+const W = sandbox.window;
+
+// --- a superseded flow must not release the newer start's slot -------------
+const firstResolve = () => {};
+const firstReject = () => {};
+const firstOwner = W.claimSessionStart('audio', firstResolve, firstReject);
+assert(S.sessionStartedResolver === firstResolve, 'the first start claimed the slot');
+
+const secondResolve = () => {};
+const secondReject = () => {};
+const secondOwner = W.claimSessionStart('text', secondResolve, secondReject);
+assert(S.sessionStartedResolver === secondResolve, 'the second start took the slot');
+assert(S._pendingSessionStartMode === 'text', 'the mode follows the newest start');
+
+assert(W.sessionStartIsCurrent(firstOwner) === false,
+       'the superseded start must not report itself current');
+assert(W.sessionStartIsCurrent(secondOwner) === true,
+       'the owning start must report itself current');
+
+assert(W.releaseSessionStart(firstOwner) === false,
+       'a superseded flow releasing must be refused');
+assert(S.sessionStartedResolver === secondResolve,
+       'the newer start must still own the slot after a foreign release');
+assert(S.sessionStartedRejecter === secondReject, 'and keep its rejecter');
+assert(S._pendingSessionStartMode === 'text', 'and keep its mode');
+
+// --- the owner CAN release, exactly once -----------------------------------
+assert(W.releaseSessionStart(secondOwner) === true, 'the owner may release');
+assert(S.sessionStartedResolver === null, 'the slot is cleared by its owner');
+assert(S.sessionStartedRejecter === null, 'rejecter cleared too');
+assert(S._pendingSessionStartMode === null, 'mode cleared too');
+assert(W.releaseSessionStart(secondOwner) === false,
+       'a second release by the same owner is a no-op, not a clear of whoever came next');
+
+// --- a null/absent owner can never clear -----------------------------------
+W.claimSessionStart('audio', firstResolve, firstReject);
+assert(W.releaseSessionStart(null) === false, 'a missing token must not clear the slot');
+assert(W.releaseSessionStart(undefined) === false, 'nor an undefined one');
+assert(S.sessionStartedResolver === firstResolve, 'slot survives both');
+assert(W.sessionStartIsCurrent(null) === false, 'a missing token is never current');
+
+console.log('HARNESS_OK');
+"""
+
+
+def _run(script: str):
+    node_path = shutil.which("node")
+    if not node_path:
+        pytest.skip("node is not installed; skipping voice-start ownership harness")
+    return run_node_script(
+        node_path,
+        script,
+        cwd=str(Path(__file__).resolve().parents[2]),
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
+    )
+
+
+@pytest.mark.unit
+def test_a_superseded_flow_cannot_release_the_newer_starts_slot():
+    # Mutation-verified: drop the identity check in releaseSessionStart and this
+    # reddens on "a superseded flow releasing must be refused".
+    harness = textwrap.dedent(_HARNESS).replace(
+        "__APP_STATE_PATH__", json.dumps(str(APP_STATE_PATH))
+    )
+    result = _run(harness)
+    assert result.returncode == 0, (
+        "voice-start ownership harness failed\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "HARNESS_OK" in result.stdout


### PR DESCRIPTION
## 问题

`S.sessionStartedResolver` / `Rejecter` / `_pendingSessionStartMode` 是**一个共享槽**，而并发 start 是真实存在的：麦克风按钮、composer 文本发送、avatar-drop 切文本、断连自动重启，都可能同时在飞。

每条 flow 在退出时都**无条件**清这个槽，所以谁先结束谁就抹掉当前持有者——新的那次 start 于是挂在一个永远没人 settle 的 promise 上，或者丢掉本该救它的超时。

这正是 `#2345` 里连续三轮评审的根因：同一段十几行里，**每一次修复引出下一条**——延迟 resolve 结算了别人的 promise → 加守卫后自己的 promise 没人结算 → 无条件结算后恢复的音频流开麦到 blocked 路由。

## 改动

owner token 就用 **resolver 函数本身**：它本来就每次 start 唯一，而且在每个需要判断的地方都已经在作用域内。

`app-state.js` 新增 `claimSessionStart` / `releaseSessionStart` / `sessionStartIsCurrent`，四条 flow 全部改走它们，每次 release 都先确认归属：

| 文件 | flow | 归属化的点 |
| --- | --- | --- |
| `app-buttons.js` | 麦克风按钮（audio） | claim / timeout / catch |
| `app-buttons.js` | 文本发送 | claim / timeout / catch |
| `app-buttons.js` | composer 文本 | claim / timeout / 成功 / 失败 |
| `app-websocket.js` | 自动重启 | claim / timeout / catch |

其中**麦克风按钮的 catch 是最狠的一个**：它清槽**并且**调 `rejectPendingTextSessionStart`，也就是说用户切去打字之后麦克风启动失败，会把那个刚接管的文本会话一起拆掉。

## 刻意保持无条件的

`cancelPendingSessionStart` 及其几处降级副本、`session_failed` handler、断连 onclose 清理。这些是「放弃一切待定 start」的**全局杠杆**（goodbye / avatar drop / 角色切换 / socket 关闭），杀掉别人的 start 正是它们的意图，不是 bug。

这个分类来自对全部 **125 处**触碰点的清点（67 owner-scoped / 35 global-cancel / 23 只读），本 PR 只转换其中属于 flow 的那部分。

**部分转换是单调安全的**：加了判断的站点只会**拒绝**清别人的槽，没加的站点行为与今天完全一致，两者混存不会比现状更糟。

## 测试

`tests/unit/test_voice_start_slot_ownership.py` 在 node 里驱动**真实的 helper**，而不是断言源码文本——要保证的是行为属性：被抢占的 flow 去 release 必须是 no-op。

变异验证：去掉 `releaseSessionStart` 里的 identity 判断 → 红在 `a superseded flow releasing must be refused`。

全量 `tests/unit`：**8182 passed / 35 skipped**；`check_docstring_no_cjk --base origin/main` 通过。

## 后续

`window.sessionTimeoutId` 那 ~50 处，以及「让每个 start 都 mint `voiceSessionStartEpoch`」，见 #2553。

⚠️ 第二项**对本 PR 有顺序依赖**：让 text start 也 mint epoch，会让并发 audio 流的 `ensureVoiceStartCurrent()` 开始抛 → 进 mic-button 的 catch；那个 catch 必须先是 owner-scoped 的（也就是本 PR），否则会把新 start 拆掉。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
