### PR TITLE
fix(voice): gate the mic flow's takeover check on ownership, not on mode

### DIFF
--- a/static/app/app-buttons.js
+++ b/static/app/app-buttons.js
@@ -2239,8 +2239,20 @@
                     // generic catch clears S.sessionStartedResolver /
                     // Rejecter / _pendingSessionStartMode unconditionally,
                     // which would tear down the very start that superseded us.
-                    if (S._pendingSessionStartMode
-                            && S._pendingSessionStartMode !== 'audio') {
+                    //
+                    // The test is OWNERSHIP, not mode. A newer AUDIO start --
+                    // the CHARACTER_DISCONNECTED automatic restart in
+                    // app-websocket.js claims 'audio' too -- passes a
+                    // `mode !== 'audio'` test, falls through to the timeout
+                    // clear below and cancels the 15s timer that newer start
+                    // is relying on; with its ack lost as well, it then stays
+                    // pending forever. The mode check is kept as an OR because
+                    // the disconnect cleanup nulls the resolver but leaves
+                    // _pendingSessionStartMode set, so neither test subsumes
+                    // the other.
+                    if (window.sessionStartSuperseded(micStartOwner)
+                            || (S._pendingSessionStartMode
+                                && S._pendingSessionStartMode !== 'audio')) {
                         // Deliberately NOT clearing window.sessionTimeoutId:
                         // that timer belongs to the newer start now, and
                         // cancelling it is the same cross-start damage in
@@ -2271,7 +2283,15 @@
                     await window.startMicCapture();
                     ensureVoiceStartCurrent();
                 } catch (error) {
-                    if (window.sessionTimeoutId) {
+                    // Same ownership gate as the success path above: this
+                    // failure can arrive after a newer start has claimed the
+                    // slot and armed its own timer (startMicCapture rejecting
+                    // on a denied getUserMedia is the easy way in), and the
+                    // timer would then be the newer start's. Refuse only in
+                    // that case -- an empty slot still means the timer is ours
+                    // to clear.
+                    if (window.sessionTimeoutId
+                            && !window.sessionStartSuperseded(micStartOwner)) {
                         clearTimeout(window.sessionTimeoutId);
                         window.sessionTimeoutId = null;
                     }

--- a/static/app/app-buttons.js
+++ b/static/app/app-buttons.js
@@ -2219,19 +2219,19 @@
                     }
                 });
 
-                // Send start session (ensure WS open)
-                await window.ensureWebSocketOpen();
-                ensureVoiceStartCurrent();
-
+                // Send start session (ensure WS open).
+                //
                 // The reconnect is an await like any other, and a text send
-                // inside it displaces this flow's claim. Sending anyway is the
-                // worst outcome available: the backend gets a stale audio
+                // inside it displaces this flow's claim -- hence the stand-down
+                // between the two lines below. Sending anyway is the worst
+                // outcome available: the backend gets a stale audio
                 // start_session, and this flow then waits forever on a promise
                 // whose resolver has been replaced -- its own timeout returns
                 // early because it is no longer current, so none of the
                 // stand-downs further down are ever reached (codex P2).
+                await window.ensureWebSocketOpen();
+                ensureVoiceStartCurrent();
                 if (micStartMustStandDown()) return;
-
                 S.socket.send(JSON.stringify({
                     action: 'start_session',
                     input_type: 'audio'

--- a/static/app/app-buttons.js
+++ b/static/app/app-buttons.js
@@ -2157,6 +2157,22 @@
                     // P2). Only in this branch -- a newer audio start clears it
                     // through its own success or failure path.
                     S.isSwitchingMode = false;
+
+                    // Cancellation outranks the takeover. If the user hit
+                    // goodbye or reset after the takeover, that is the LATER
+                    // intent and it has already put its own UI on screen --
+                    // unwinding now would re-enable the mic button and unhide
+                    // the composer on top of it, and returning skips the
+                    // catch's preserveGoodbyeUi handling that would have put it
+                    // back (codex P2). The claim sequence cannot see this: a
+                    // cancellation clears the slot without claiming, so we stay
+                    // superseded by whoever came before it.
+                    if ((typeof window.isNekoGoodbyeModeActive === 'function'
+                            && window.isNekoGoodbyeModeActive())
+                            || !window.voiceStartEpochIsCurrent(voiceStartEpoch)) {
+                        return true;
+                    }
+
                     // If capture already COMMITTED, the unwind alone leaks the
                     // hardware microphone: abortVoiceStartForBlockedRoute sets
                     // S.isRecording = false without stopping the stream, closing

--- a/static/app/app-buttons.js
+++ b/static/app/app-buttons.js
@@ -2341,6 +2341,15 @@
                     console.warn(window.t('console.startVoiceActiveVisionFailed'), e);
                 }
 
+                // acquireProactiveVisionStream awaits a backend request AND a
+                // display-capture prompt, so this is the longest window of all
+                // -- and the last one before the success path commits. A text
+                // send completing inside it would otherwise get proactive
+                // vision started, ready-to-speak scheduled and
+                // neko:voice-session-started dispatched over its session
+                // (codex P2).
+                if (micStartMustStandDown()) return;
+
                 // Success — hide preparing toast, show ready
                 window.hideVoicePreparingToast();
 

--- a/static/app/app-buttons.js
+++ b/static/app/app-buttons.js
@@ -2130,6 +2130,7 @@
             window.showVoicePreparingToast(window.t ? window.t('app.connectingToServer') : '\u6B63\u5728\u8FDE\u63A5\u670D\u52A1\u5668...');
 
             var micStartOwner = null;
+            var micStartRejecter = null;
 
             // Every point this handler resumes from an await asks the same
             // question, and each await is wide open: on mobile the composer
@@ -2198,6 +2199,10 @@
                     // resolver itself). Every release below is gated on it, so
                     // this flow can never clear a slot that a newer start owns.
                     micStartOwner = window.claimSessionStart('audio', resolve, reject);
+                    // Kept separately from the slot: once a newer start claims,
+                    // S.sessionStartedRejecter is THEIRS, and this is the only
+                    // remaining handle on our own promise.
+                    micStartRejecter = reject;
                     // Re-arm the fail-closed voice latch on user intent, strictly
                     // before start_session goes out and therefore before any route
                     // verdict for this session can arrive.
@@ -2242,7 +2247,26 @@
                     // Only fire for the start this timer was armed for: a newer
                     // start may own the slot by now, and rejecting/clearing it
                     // here would strand the promise its awaiter is holding.
-                    if (!window.sessionStartIsCurrent(micStartOwner)) return;
+                    if (!window.sessionStartIsCurrent(micStartOwner)) {
+                        // But settle OUR OWN promise on the way out, or this
+                        // flow never resumes at all: once displaced, our ack is
+                        // dropped by the cross-mode guard in app-websocket.js
+                        // and this timer was the only other thing that could
+                        // have settled us. Suspended forever means suspended
+                        // holding window.isMicStarting and an active/disabled
+                        // mic button, straight through the session that took
+                        // over (codex P2). Nothing shared is touched here --
+                        // not the slot, not window.sessionTimeoutId, not the
+                        // socket; they belong to the newer start. Rejecting
+                        // hands control to the outer catch, which stands down
+                        // and unwinds exactly as much as it is allowed to.
+                        if (micStartRejecter) {
+                            micStartRejecter(typeof window.makeNekoSessionAbortError === 'function'
+                                ? window.makeNekoSessionAbortError('Voice start superseded')
+                                : new Error('Voice start superseded'));
+                        }
+                        return;
+                    }
                     if (S.sessionStartedRejecter) {
                         var rejecter = S.sessionStartedRejecter;
                         window.releaseSessionStart(micStartOwner);

--- a/static/app/app-buttons.js
+++ b/static/app/app-buttons.js
@@ -2148,9 +2148,26 @@
                             && S._pendingSessionStartMode !== 'audio')) {
                     return false;
                 }
-                if (!window.supersededByAudioStart(micStartOwner)
-                        && typeof window.abortVoiceStartForBlockedRoute === 'function') {
-                    window.abortVoiceStartForBlockedRoute();
+                if (!window.supersededByAudioStart(micStartOwner)) {
+                    // If capture already COMMITTED, the unwind alone leaks the
+                    // hardware microphone: abortVoiceStartForBlockedRoute sets
+                    // S.isRecording = false without stopping the stream, closing
+                    // the audio context or disconnecting the worklet, and the
+                    // text session_started handler only runs that teardown while
+                    // S.isRecording is still true -- so aborting first makes it
+                    // skip the sole pipeline teardown and the mic stays live
+                    // after the user switched to text (codex P1). Stop first,
+                    // while the flag still says there is something to stop.
+                    //
+                    // notifyServer:false: the newer start owns the socket now,
+                    // and a pause_session from a superseded flow is read as a
+                    // character switch, closing the socket out from under it.
+                    if (S.isRecording === true && typeof window.stopRecording === 'function') {
+                        window.stopRecording({ notifyServer: false });
+                    }
+                    if (typeof window.abortVoiceStartForBlockedRoute === 'function') {
+                        window.abortVoiceStartForBlockedRoute();
+                    }
                 }
                 return true;
             }
@@ -2205,6 +2222,16 @@
                 // Send start session (ensure WS open)
                 await window.ensureWebSocketOpen();
                 ensureVoiceStartCurrent();
+
+                // The reconnect is an await like any other, and a text send
+                // inside it displaces this flow's claim. Sending anyway is the
+                // worst outcome available: the backend gets a stale audio
+                // start_session, and this flow then waits forever on a promise
+                // whose resolver has been replaced -- its own timeout returns
+                // early because it is no longer current, so none of the
+                // stand-downs further down are ever reached (codex P2).
+                if (micStartMustStandDown()) return;
+
                 S.socket.send(JSON.stringify({
                     action: 'start_session',
                     input_type: 'audio'
@@ -2348,6 +2375,13 @@
                 // vision started, ready-to-speak scheduled and
                 // neko:voice-session-started dispatched over its session
                 // (codex P2).
+                //
+                // BOTH questions here. A goodbye or reset inside that same
+                // window goes through cancelPendingSessionStart, which moves the
+                // epoch and clears isMicStarting WITHOUT claiming anything, so
+                // the stand-down alone cannot see it and this handler would
+                // announce a voice session the user just ended (codex P2).
+                ensureVoiceStartCurrent();
                 if (micStartMustStandDown()) return;
 
                 // Success — hide preparing toast, show ready

--- a/static/app/app-buttons.js
+++ b/static/app/app-buttons.js
@@ -2130,7 +2130,6 @@
             window.showVoicePreparingToast(window.t ? window.t('app.connectingToServer') : '\u6B63\u5728\u8FDE\u63A5\u670D\u52A1\u5668...');
 
             var micStartOwner = null;
-            var micStartRejecter = null;
 
             // Every point this handler resumes from an await asks the same
             // question, and each await is wide open: on mobile the composer
@@ -2150,6 +2149,14 @@
                     return false;
                 }
                 if (!window.supersededByAudioStart(micStartOwner)) {
+                    // This flow may have set S.isSwitchingMode when it began
+                    // from a live text session, and standing down returns past
+                    // both places that normally clear it. Left true it is
+                    // permanent: CHARACTER_LEFT handling stays suppressed and
+                    // auto-goodbye keeps treating the app as mid-switch (codex
+                    // P2). Only in this branch -- a newer audio start clears it
+                    // through its own success or failure path.
+                    S.isSwitchingMode = false;
                     // If capture already COMMITTED, the unwind alone leaks the
                     // hardware microphone: abortVoiceStartForBlockedRoute sets
                     // S.isRecording = false without stopping the stream, closing
@@ -2199,10 +2206,6 @@
                     // resolver itself). Every release below is gated on it, so
                     // this flow can never clear a slot that a newer start owns.
                     micStartOwner = window.claimSessionStart('audio', resolve, reject);
-                    // Kept separately from the slot: once a newer start claims,
-                    // S.sessionStartedRejecter is THEIRS, and this is the only
-                    // remaining handle on our own promise.
-                    micStartRejecter = reject;
                     // Re-arm the fail-closed voice latch on user intent, strictly
                     // before start_session goes out and therefore before any route
                     // verdict for this session can arrive.
@@ -2247,26 +2250,11 @@
                     // Only fire for the start this timer was armed for: a newer
                     // start may own the slot by now, and rejecting/clearing it
                     // here would strand the promise its awaiter is holding.
-                    if (!window.sessionStartIsCurrent(micStartOwner)) {
-                        // But settle OUR OWN promise on the way out, or this
-                        // flow never resumes at all: once displaced, our ack is
-                        // dropped by the cross-mode guard in app-websocket.js
-                        // and this timer was the only other thing that could
-                        // have settled us. Suspended forever means suspended
-                        // holding window.isMicStarting and an active/disabled
-                        // mic button, straight through the session that took
-                        // over (codex P2). Nothing shared is touched here --
-                        // not the slot, not window.sessionTimeoutId, not the
-                        // socket; they belong to the newer start. Rejecting
-                        // hands control to the outer catch, which stands down
-                        // and unwinds exactly as much as it is allowed to.
-                        if (micStartRejecter) {
-                            micStartRejecter(typeof window.makeNekoSessionAbortError === 'function'
-                                ? window.makeNekoSessionAbortError('Voice start superseded')
-                                : new Error('Voice start superseded'));
-                        }
-                        return;
-                    }
+                    // Settling a displaced start is claimSessionStart's job, not
+                    // this timer's: the flow that displaces us clears the shared
+                    // window.sessionTimeoutId in its own claim setup, so by the
+                    // time it matters this callback no longer runs at all.
+                    if (!window.sessionStartIsCurrent(micStartOwner)) return;
                     if (S.sessionStartedRejecter) {
                         var rejecter = S.sessionStartedRejecter;
                         window.releaseSessionStart(micStartOwner);
@@ -2812,6 +2800,17 @@
                 );
 
             } catch (error) {
+                // Displaced by a newer start rather than failed: claimSessionStart
+                // settles the start it takes over from, and reporting that as
+                // "\u56DE\u6765\u5931\u8D25" would blame the user's own next action -- with an
+                // internal English reason string, at that.
+                if (error && error.sessionStartCancelled
+                        && !window.sessionStartIsCurrent(textStartOwner)) {
+                    window.hideVoicePreparingToast();
+                    returnSessionButton.disabled = false;
+                    return;
+                }
+
                 console.error(window.t('console.askHerBackFailed'), error);
                 window.hideVoicePreparingToast();
                 window.showStatusToast(
@@ -3029,14 +3028,24 @@
                         window.releaseSessionStart(composerStartOwner);
                     }
                 } catch (error) {
-                    console.error(window.t('console.startTextSessionFailed'), error);
+                    // Displaced rather than failed. The message still cannot go
+                    // out -- the session it was waiting for never started, so
+                    // the optimistic bubble is still marked failed below and the
+                    // composer still comes back -- but the toast would report a
+                    // start failure, in internal English, for what was really
+                    // the user's own newer action taking over.
+                    var composerDisplaced = !!(error && error.sessionStartCancelled)
+                        && !window.sessionStartIsCurrent(composerStartOwner);
+                    if (!composerDisplaced) {
+                        console.error(window.t('console.startTextSessionFailed'), error);
+                        window.showStatusToast(
+                            window.t
+                                ? window.t('app.startFailed', { error: error.message })
+                                : '\u542F\u52A8\u5931\u8D25: ' + error.message,
+                            5000
+                        );
+                    }
                     window.hideVoicePreparingToast();
-                    window.showStatusToast(
-                        window.t
-                            ? window.t('app.startFailed', { error: error.message })
-                            : '\u542F\u52A8\u5931\u8D25: ' + error.message,
-                        5000
-                    );
 
                     if (window.sessionStartIsCurrent(composerStartOwner)) {
                         if (window.sessionTimeoutId) {

--- a/static/app/app-buttons.js
+++ b/static/app/app-buttons.js
@@ -2226,6 +2226,14 @@
                         window.sessionTimeoutId = null;
                     }
                 });
+                // Consume the rejection up front. claimSessionStart settles the start it
+                // displaces, and that can land while this flow is still inside
+                // ensureWebSocketOpen -- before it reaches the await, and possibly before a
+                // stand-down returns without ever awaiting at all. Without a handler on the
+                // promise itself a routine takeover surfaces as an unhandledrejection and
+                // the health diagnostics log it as a runtime error. `await` below still sees
+                // the rejection: this attaches a handler, it does not swallow one.
+                sessionStartPromise.catch(function () { });
 
                 // Send start session (ensure WS open).
                 //
@@ -2730,6 +2738,14 @@
                         }
                     }, 15000);
                 });
+                // Consume the rejection up front. claimSessionStart settles the start it
+                // displaces, and that can land while this flow is still inside
+                // ensureWebSocketOpen -- before it reaches the await, and possibly before a
+                // stand-down returns without ever awaiting at all. Without a handler on the
+                // promise itself a routine takeover surfaces as an unhandledrejection and
+                // the health diagnostics log it as a runtime error. `await` below still sees
+                // the rejection: this attaches a handler, it does not swallow one.
+                sessionStartPromise.catch(function () { });
 
                 // Start text session
                 await window.ensureWebSocketOpen();
@@ -2974,6 +2990,14 @@
                                     window.sessionTimeoutId = null;
                                 }
                             });
+                            // Consume the rejection up front. claimSessionStart settles the start it
+                            // displaces, and that can land while this flow is still inside
+                            // ensureWebSocketOpen -- before it reaches the await, and possibly before a
+                            // stand-down returns without ever awaiting at all. Without a handler on the
+                            // promise itself a routine takeover surfaces as an unhandledrejection and
+                            // the health diagnostics log it as a runtime error. `await` below still sees
+                            // the rejection: this attaches a handler, it does not swallow one.
+                            sessionStartPromise.catch(function () { });
 
                             await window.ensureWebSocketOpen();
                             S.socket.send(JSON.stringify({

--- a/static/app/app-buttons.js
+++ b/static/app/app-buttons.js
@@ -2129,6 +2129,32 @@
             window.showStatusToast(window.t ? window.t('app.initializingVoice') : '\u6B63\u5728\u521D\u59CB\u5316\u8BED\u97F3\u5BF9\u8BDD...', 3000);
             window.showVoicePreparingToast(window.t ? window.t('app.connectingToServer') : '\u6B63\u5728\u8FDE\u63A5\u670D\u52A1\u5668...');
 
+            var micStartOwner = null;
+
+            // Every point this handler resumes from an await asks the same
+            // question, and each await is wide open: on mobile the composer
+            // stays visible during an audio session, so a text send can claim
+            // the slot inside the ack's 500ms settle window, inside
+            // showCurrentModel, or inside getUserMedia. Returns true when this
+            // start must stand down -- and unwinds the shared voice-start UI on
+            // its way out UNLESS a newer audio start is driving that very state,
+            // because the unwind is global (it bumps the mic generation and
+            // clears window.isMicStarting) and would make that start abandon
+            // capture. A text start touches none of it and would instead leave
+            // the mic button stranded, so there the unwind must run.
+            function micStartMustStandDown() {
+                if (!window.sessionStartSuperseded(micStartOwner)
+                        && !(S._pendingSessionStartMode
+                            && S._pendingSessionStartMode !== 'audio')) {
+                    return false;
+                }
+                if (!window.supersededByAudioStart(micStartOwner)
+                        && typeof window.abortVoiceStartForBlockedRoute === 'function') {
+                    window.abortVoiceStartForBlockedRoute();
+                }
+                return true;
+            }
+
             try {
                 if (typeof window.waitForVoiceConfigSwitchReady === 'function') {
                     var voiceConfigWaitResult = await window.waitForVoiceConfigSwitchReady({
@@ -2150,7 +2176,6 @@
                 }
 
                 // Create a promise for session_started
-                var micStartOwner = null;
                 var sessionStartPromise = new Promise(function (resolve, reject) {
                     // Claim the shared slot and keep the owner token (the
                     // resolver itself). Every release below is gated on it, so
@@ -2246,32 +2271,17 @@
                     // `mode !== 'audio'` test, falls through to the timeout
                     // clear below and cancels the 15s timer that newer start
                     // is relying on; with its ack lost as well, it then stays
-                    // pending forever. The mode check is kept as an OR because
-                    // the disconnect cleanup nulls the resolver but leaves
+                    // pending forever. The mode check survives inside
+                    // micStartMustStandDown as an OR because the disconnect
+                    // cleanup nulls the resolver but leaves
                     // _pendingSessionStartMode set, so neither test subsumes
                     // the other.
-                    if (window.sessionStartSuperseded(micStartOwner)
-                            || (S._pendingSessionStartMode
-                                && S._pendingSessionStartMode !== 'audio')) {
-                        // Deliberately NOT clearing window.sessionTimeoutId:
-                        // that timer belongs to the newer start now, and
-                        // cancelling it is the same cross-start damage in
-                        // miniature.
-                        //
-                        // And the unwind itself is global: it bumps the mic
-                        // generation and clears window.isMicStarting, so
-                        // running it while a newer AUDIO start is inside
-                        // getUserMedia makes THAT start abandon capture and
-                        // fail its own ensureVoiceStartCurrent -- a session the
-                        // backend accepted, with the mic closed. A newer audio
-                        // start is already driving this UI; leave it alone. A
-                        // text start is not, so there the unwind still runs.
-                        if (!window.supersededByAudioStart(micStartOwner)
-                                && typeof window.abortVoiceStartForBlockedRoute === 'function') {
-                            window.abortVoiceStartForBlockedRoute();
-                        }
-                        return;
-                    }
+                    //
+                    // Standing down here deliberately does NOT clear
+                    // window.sessionTimeoutId: that timer belongs to the newer
+                    // start now, and cancelling it is the same cross-start
+                    // damage in miniature.
+                    if (micStartMustStandDown()) return;
 
                     ensureVoiceStartCurrent();
 
@@ -2292,6 +2302,17 @@
                     }
                     await window.startMicCapture();
                     ensureVoiceStartCurrent();
+
+                    // getUserMedia and the worklet setup are another wide-open
+                    // await, and a text takeover inside it is invisible to
+                    // everything above: startMicCapture's own cancellation path
+                    // returns normally rather than throwing, and a text ack
+                    // moves neither voiceSessionStartEpoch nor isMicStarting, so
+                    // ensureVoiceStartCurrent passes. Without this the handler
+                    // walks into its success path -- neko:voice-session-started,
+                    // silence detection, "ready to speak" -- on top of the text
+                    // session that took over (codex P2).
+                    if (micStartMustStandDown()) return;
                 } catch (error) {
                     // Same ownership gate as the success path above: this
                     // failure can arrive after a newer start has claimed the
@@ -2365,20 +2386,12 @@
                 // now, so the end_session send would tear ITS session down, and
                 // stopRecording / the button row / the failure toast would
                 // rewrite the UI it is driving -- all to report a failure the
-                // user has already moved on from (codex P2).
-                //
-                // A newer AUDIO start is driving the voice UI and must be left
-                // strictly alone. A newer TEXT start is not, so the mic button
-                // still has to be handed back -- the same asymmetry as the
-                // takeover branch above, and the same reason
-                // abortVoiceStartForBlockedRoute may not run in the audio case.
-                if (window.sessionStartSuperseded(micStartOwner)) {
-                    if (!window.supersededByAudioStart(micStartOwner)
-                            && typeof window.abortVoiceStartForBlockedRoute === 'function') {
-                        window.abortVoiceStartForBlockedRoute();
-                    }
-                    return;
-                }
+                // user has already moved on from (codex P2). Note the takeover
+                // is frequently what CAUSED this error, and just as frequently
+                // has finished by the time we get here: the text ack that
+                // invalidated our getUserMedia also released the slot, which is
+                // why this asks the claim sequence and not who holds it now.
+                if (micStartMustStandDown()) return;
 
                 if (!isVoiceStartCancelled && !(error && error.voiceConfigSwitchTimedOut) && S.socket && S.socket.readyState === WebSocket.OPEN) {
                     S.socket.send(JSON.stringify({ action: 'end_session' }));

--- a/static/app/app-buttons.js
+++ b/static/app/app-buttons.js
@@ -2257,7 +2257,17 @@
                         // that timer belongs to the newer start now, and
                         // cancelling it is the same cross-start damage in
                         // miniature.
-                        if (typeof window.abortVoiceStartForBlockedRoute === 'function') {
+                        //
+                        // And the unwind itself is global: it bumps the mic
+                        // generation and clears window.isMicStarting, so
+                        // running it while a newer AUDIO start is inside
+                        // getUserMedia makes THAT start abandon capture and
+                        // fail its own ensureVoiceStartCurrent -- a session the
+                        // backend accepted, with the mic closed. A newer audio
+                        // start is already driving this UI; leave it alone. A
+                        // text start is not, so there the unwind still runs.
+                        if (!window.supersededByAudioStart(micStartOwner)
+                                && typeof window.abortVoiceStartForBlockedRoute === 'function') {
                             window.abortVoiceStartForBlockedRoute();
                         }
                         return;
@@ -2348,6 +2358,26 @@
                     }
                     rejectPendingTextSessionStart(error);
                     window.releaseSessionStart(micStartOwner);
+                }
+
+                // Gating the slot was not enough: everything below is just as
+                // cross-start destructive. A newer start owns the session by
+                // now, so the end_session send would tear ITS session down, and
+                // stopRecording / the button row / the failure toast would
+                // rewrite the UI it is driving -- all to report a failure the
+                // user has already moved on from (codex P2).
+                //
+                // A newer AUDIO start is driving the voice UI and must be left
+                // strictly alone. A newer TEXT start is not, so the mic button
+                // still has to be handed back -- the same asymmetry as the
+                // takeover branch above, and the same reason
+                // abortVoiceStartForBlockedRoute may not run in the audio case.
+                if (window.sessionStartSuperseded(micStartOwner)) {
+                    if (!window.supersededByAudioStart(micStartOwner)
+                            && typeof window.abortVoiceStartForBlockedRoute === 'function') {
+                        window.abortVoiceStartForBlockedRoute();
+                    }
+                    return;
                 }
 
                 if (!isVoiceStartCancelled && !(error && error.voiceConfigSwitchTimedOut) && S.socket && S.socket.readyState === WebSocket.OPEN) {

--- a/static/app/app-state.js
+++ b/static/app/app-state.js
@@ -304,6 +304,22 @@
         return true;
     };
 
+    /**
+     * The current claim count, for a flow that must detect takeovers BEFORE it
+     * has an owner token of its own -- the automatic restart spends 7.5s in a
+     * timer before it claims, and a text session can be started and finished
+     * whole inside that window. Snapshot this when the work is scheduled and
+     * ask sessionStartsSince when it runs.
+     */
+    window.sessionStartClaimSeq = function () {
+        return startClaimSeq;
+    };
+
+    /** True when any start has claimed since ``seq`` was taken. */
+    window.sessionStartsSince = function (seq) {
+        return startClaimSeq > seq;
+    };
+
     /** True while ``owner`` is still the pending start. */
     window.sessionStartIsCurrent = function (owner) {
         return !!owner && S.sessionStartedResolver === owner;

--- a/static/app/app-state.js
+++ b/static/app/app-state.js
@@ -280,6 +280,13 @@
     // WeakMap keeps it off the tokens themselves and out of GC's way.
     var startClaimSeq = 0;
     var startClaimSeqByOwner = new WeakMap();
+    // The sequence of the last AUDIO claim, tracked separately because "was the
+    // takeover a voice start" is not the same question as "what claimed last":
+    // a text send can claim after a newer audio start that is still acquiring
+    // its microphone, and the mode of the last claim then says 'text' while an
+    // audio start is very much alive and holding the state the global unwind
+    // destroys.
+    var lastAudioClaimSeq = 0;
 
     window.claimSessionStart = function (mode, resolve, reject) {
         S.sessionStartedResolver = resolve;
@@ -287,6 +294,7 @@
         S._pendingSessionStartMode = mode;
         startClaimSeq += 1;
         startClaimSeqByOwner.set(resolve, startClaimSeq);
+        if (mode === 'audio') lastAudioClaimSeq = startClaimSeq;
         // Sticky twin of _pendingSessionStartMode: which KIND of start claimed
         // last, still readable after it has released. supersededByAudioStart
         // needs it to decide whether the global voice-start unwind would land
@@ -318,6 +326,11 @@
     /** True when any start has claimed since ``seq`` was taken. */
     window.sessionStartsSince = function (seq) {
         return startClaimSeq > seq;
+    };
+
+    /** True when an AUDIO start has claimed since ``seq`` was taken. */
+    window.audioStartsSince = function (seq) {
+        return lastAudioClaimSeq > seq;
     };
 
     /** True while ``owner`` is still the pending start. */
@@ -364,11 +377,21 @@
      * instead, so there the unwind must still run.
      */
     window.supersededByAudioStart = function (owner) {
-        // The STICKY mode, not the pending one: the start that took over may
-        // already have been acknowledged and released the slot, and it is just
-        // as alive -- more so -- than one still pending.
-        return window.sessionStartSuperseded(owner)
-            && S._lastSessionStartMode === 'audio';
+        var seq = owner ? startClaimSeqByOwner.get(owner) : undefined;
+        // "Did an audio start claim after me", not "was the last claim audio".
+        // With A superseded by an audio B that is still acquiring and then by a
+        // text C, the last claim is C -- and unwinding on that verdict bumps the
+        // mic generation out from under B, whose session the backend has already
+        // accepted. Asking about audio claims after our own sequence keeps B
+        // visible however many text starts follow it.
+        if (seq === undefined) {
+            // No token we minted: the sticky mode is all that is left. Callers
+            // that must decide before they own anything pass their scheduling
+            // snapshot to audioStartsSince instead.
+            return window.sessionStartSuperseded(owner)
+                && S._lastSessionStartMode === 'audio';
+        }
+        return lastAudioClaimSeq > seq;
     };
 
     /**

--- a/static/app/app-state.js
+++ b/static/app/app-state.js
@@ -139,6 +139,10 @@
         // 不一致（典型是 proactive/greeting 并发自起的 text 会话发来的 ack）时
         // 忽略，避免错误模式的 ack 收口用户的启动 promise / 翻转会话状态。
         _pendingSessionStartMode: null,
+        // 上一次 claim 的模式，释放后依然保留（_pendingSessionStartMode 会被清空）。
+        // 用于判断"抢走槽位的那个启动是不是语音启动"——它可能已经 ack 完并释放，
+        // 但仍然活着且正在驱动语音 UI，见 supersededByAudioStart。
+        _lastSessionStartMode: null,
         voiceSessionStartEpoch: 0,
         assistantTurnId: null,
         assistantTurnStartedAt: 0,
@@ -267,10 +271,27 @@
     // cancelPendingSessionStart stays deliberately unconditional because it is
     // the global "abandon whatever is pending" lever (goodbye, avatar drop,
     // character switch), where killing a foreign start is the intent.
+    // An owner token answers "who holds the slot RIGHT NOW", and that is not
+    // enough on its own: a start that claimed after us and has since finished
+    // or been cancelled leaves the slot empty again -- byte for byte what our
+    // own release looks like. Three separate review findings reduced to that
+    // one blind spot. A claim sequence closes it, because it only ever moves
+    // forward: "somebody claimed after me" survives their departure. The
+    // WeakMap keeps it off the tokens themselves and out of GC's way.
+    var startClaimSeq = 0;
+    var startClaimSeqByOwner = new WeakMap();
+
     window.claimSessionStart = function (mode, resolve, reject) {
         S.sessionStartedResolver = resolve;
         S.sessionStartedRejecter = reject;
         S._pendingSessionStartMode = mode;
+        startClaimSeq += 1;
+        startClaimSeqByOwner.set(resolve, startClaimSeq);
+        // Sticky twin of _pendingSessionStartMode: which KIND of start claimed
+        // last, still readable after it has released. supersededByAudioStart
+        // needs it to decide whether the global voice-start unwind would land
+        // on a live voice start, and by then the pending mode may be gone.
+        S._lastSessionStartMode = mode;
         return resolve;
     };
 
@@ -289,18 +310,28 @@
     };
 
     /**
-     * True when some OTHER start now holds the slot, i.e. ``owner`` has been
-     * superseded. Note this is not the negation of sessionStartIsCurrent: an
-     * EMPTY slot is not superseded, and that distinction is the whole point.
-     * The normal success path releases the slot inside the ack handler and
-     * only then settles the promise, so a flow that resumes after its own ack
-     * legitimately finds the slot empty and must still run its own cleanup --
-     * including clearing the start timeout it armed. Asking
-     * `!sessionStartIsCurrent(owner)` there would make every successful start
-     * think it had been superseded.
+     * True when ANY start claimed after ``owner`` did -- whether it still holds
+     * the slot, has completed, or was cancelled.
+     *
+     * Not "somebody else holds the slot now", which misses a completed takeover:
+     * a text send can claim and be acknowledged inside an audio start's
+     * getUserMedia await, releasing the slot before that start resumes, and the
+     * stale start would then read an empty slot and go on to end the session and
+     * rewrite the UI the text session is using. Not
+     * `!sessionStartIsCurrent(owner)` either, which misses nothing but flags
+     * everything: the normal success path releases the slot inside the ack
+     * handler before settling the promise, so a start that simply succeeded also
+     * resumes to an empty slot, and it must still clear the timeout it armed.
+     * The claim sequence separates the two: it moved iff somebody else started.
      */
     window.sessionStartSuperseded = function (owner) {
-        return !!S.sessionStartedResolver && S.sessionStartedResolver !== owner;
+        var seq = owner ? startClaimSeqByOwner.get(owner) : undefined;
+        // An owner we never minted (or none at all): all we can say is whether
+        // somebody is pending right now.
+        if (seq === undefined) {
+            return !!S.sessionStartedResolver && S.sessionStartedResolver !== owner;
+        }
+        return startClaimSeq > seq;
     };
 
     /**
@@ -317,8 +348,11 @@
      * instead, so there the unwind must still run.
      */
     window.supersededByAudioStart = function (owner) {
+        // The STICKY mode, not the pending one: the start that took over may
+        // already have been acknowledged and released the slot, and it is just
+        // as alive -- more so -- than one still pending.
         return window.sessionStartSuperseded(owner)
-            && S._pendingSessionStartMode === 'audio';
+            && S._lastSessionStartMode === 'audio';
     };
 
     /**

--- a/static/app/app-state.js
+++ b/static/app/app-state.js
@@ -289,12 +289,32 @@
     var lastAudioClaimSeq = 0;
 
     window.claimSessionStart = function (mode, resolve, reject) {
+        // Whoever we are about to displace can no longer be settled by anything
+        // else, so settle them HERE. Their acknowledgement is dropped by the
+        // cross-mode guard in the session_started handler once our mode is the
+        // pending one, and their 15s timeout is cancelled a few lines later by
+        // the very flow that is claiming -- every claim setup clears the shared
+        // window.sessionTimeoutId. A displaced start that nobody settles sits on
+        // `await sessionStartPromise` forever, holding window.isMicStarting and
+        // an active/disabled mic button straight through OUR session.
+        //
+        // A cancellation, not a failure: makeNekoSessionAbortError marks it so
+        // the flows treat it as "abandoned", not "start failed".
+        var displaced = S.sessionStartedRejecter;
+
         S.sessionStartedResolver = resolve;
         S.sessionStartedRejecter = reject;
         S._pendingSessionStartMode = mode;
         startClaimSeq += 1;
         startClaimSeqByOwner.set(resolve, startClaimSeq);
         if (mode === 'audio') lastAudioClaimSeq = startClaimSeq;
+        // After the slot is ours, so anything the displaced flow does on its way
+        // out already sees the new owner and stands down against it.
+        if (displaced) {
+            try {
+                displaced(window.makeNekoSessionAbortError('Session start superseded by a newer start'));
+            } catch (_) { }
+        }
         // Sticky twin of _pendingSessionStartMode: which KIND of start claimed
         // last, still readable after it has released. supersededByAudioStart
         // needs it to decide whether the global voice-start unwind would land

--- a/static/app/app-state.js
+++ b/static/app/app-state.js
@@ -303,6 +303,41 @@
         return !!S.sessionStartedResolver && S.sessionStartedResolver !== owner;
     };
 
+    /**
+     * True when the start that superseded ``owner`` is itself an AUDIO start.
+     *
+     * It matters because the superseded flow's unwind --
+     * abortVoiceStartForBlockedRoute -- is GLOBAL: it bumps the mic generation
+     * (invalidatePendingMicStart) and clears window.isMicStarting, which is
+     * exactly the state a newer AUDIO start is relying on while it sits in
+     * getUserMedia / addModule. Running it there makes that start abandon
+     * capture and then fail its own ensureVoiceStartCurrent, leaving a session
+     * the backend accepted with the microphone closed. A newer TEXT start
+     * touches none of that state and leaves the voice-start UI stranded
+     * instead, so there the unwind must still run.
+     */
+    window.supersededByAudioStart = function (owner) {
+        return window.sessionStartSuperseded(owner)
+            && S._pendingSessionStartMode === 'audio';
+    };
+
+    /**
+     * True while ``epoch`` is still the newest voice-start intent.
+     *
+     * Ownership cannot see an ABA: a newer start may claim the slot inside the
+     * ack's 500ms deferred-resolution window and then be cancelled or complete,
+     * leaving the slot back at EMPTY -- indistinguishable, to
+     * sessionStartSuperseded, from "my own ack released it". The epoch can tell
+     * them apart, because it only ever moves forward and only on a NEWER voice
+     * intent: every mic-button press mints one, and cancelPendingSessionStart
+     * -- the global abandon lever behind goodbye, avatar drop and character
+     * switch -- bumps it. A flow that snapshots it when it claims can check
+     * after its await whether the user has moved on.
+     */
+    window.voiceStartEpochIsCurrent = function (epoch) {
+        return S.voiceSessionStartEpoch === epoch;
+    };
+
     window.cancelPendingSessionStart = function (reason) {
         if (window.sessionTimeoutId) {
             clearTimeout(window.sessionTimeoutId);

--- a/static/app/app-state.js
+++ b/static/app/app-state.js
@@ -288,6 +288,21 @@
         return !!owner && S.sessionStartedResolver === owner;
     };
 
+    /**
+     * True when some OTHER start now holds the slot, i.e. ``owner`` has been
+     * superseded. Note this is not the negation of sessionStartIsCurrent: an
+     * EMPTY slot is not superseded, and that distinction is the whole point.
+     * The normal success path releases the slot inside the ack handler and
+     * only then settles the promise, so a flow that resumes after its own ack
+     * legitimately finds the slot empty and must still run its own cleanup --
+     * including clearing the start timeout it armed. Asking
+     * `!sessionStartIsCurrent(owner)` there would make every successful start
+     * think it had been superseded.
+     */
+    window.sessionStartSuperseded = function (owner) {
+        return !!S.sessionStartedResolver && S.sessionStartedResolver !== owner;
+    };
+
     window.cancelPendingSessionStart = function (reason) {
         if (window.sessionTimeoutId) {
             clearTimeout(window.sessionTimeoutId);

--- a/static/app/app-websocket.js
+++ b/static/app/app-websocket.js
@@ -2703,7 +2703,6 @@
 
                             setTimeout(async function () {
                                 var restartStartOwner = null;
-                                var restartStartRejecter = null;
 
                                 // Every point where this flow resumes from an await asks the
                                 // same question, and asking only part of it is how round
@@ -2775,9 +2774,6 @@
                                         // flow; see claimSessionStart in
                                         // app-state.js.
                                         restartStartOwner = window.claimSessionStart('audio', resolve, reject);
-                                        // The only handle on our own promise once a newer
-                                        // start owns S.sessionStartedRejecter.
-                                        restartStartRejecter = reject;
                                         // Re-arm the fail-closed latch on user
                                         // intent, strictly before start_session
                                         // goes out and therefore before any
@@ -2804,21 +2800,11 @@
 
                                     window.sessionTimeoutId = setTimeout(function () {
                                         // Only for the start this timer was armed for.
-                                        if (!window.sessionStartIsCurrent(restartStartOwner)) {
-                                            // Settling our own promise is still ours to do,
-                                            // and the last chance: a displaced start's ack is
-                                            // dropped by the cross-mode guard, so nothing
-                                            // else would ever resume this flow (codex P2).
-                                            // Nothing shared is touched -- slot, timer handle
-                                            // and socket belong to the newer start; the catch
-                                            // below stands down before it cleans anything up.
-                                            if (restartStartRejecter) {
-                                                restartStartRejecter(typeof window.makeNekoSessionAbortError === 'function'
-                                                    ? window.makeNekoSessionAbortError('Restart superseded')
-                                                    : new Error('Restart superseded'));
-                                            }
-                                            return;
-                                        }
+                                        // A displaced start is settled by claimSessionStart:
+                                        // the flow that displaces us clears the shared
+                                        // window.sessionTimeoutId in its own claim setup, so
+                                        // this callback would not run to do it anyway.
+                                        if (!window.sessionStartIsCurrent(restartStartOwner)) return;
                                         if (S.sessionStartedRejecter) {
                                             var rejecter = S.sessionStartedRejecter;
                                             window.releaseSessionStart(restartStartOwner);

--- a/static/app/app-websocket.js
+++ b/static/app/app-websocket.js
@@ -2725,6 +2725,17 @@
                                     if (takenOver
                                             || (S._pendingSessionStartMode
                                                 && S._pendingSessionStartMode !== 'audio')) {
+                                        // Cancellation outranks the takeover: goodbye, avatar
+                                        // drop and character switch are the later intent and
+                                        // have already unwound and re-dressed the UI, so
+                                        // unwinding again would re-enable the mic button and
+                                        // unhide the composer on top of theirs (codex P2).
+                                        // The claim sequence cannot see it -- a cancellation
+                                        // clears the slot without claiming -- so it is asked
+                                        // here, ahead of the unwind, rather than at the end.
+                                        if (!window.voiceStartEpochIsCurrent(restartVoiceEpoch)) {
+                                            return true;
+                                        }
                                         // The unwind is global -- it bumps the mic
                                         // generation and clears window.isMicStarting -- so
                                         // running it while the newer AUDIO start (a mic

--- a/static/app/app-websocket.js
+++ b/static/app/app-websocket.js
@@ -2785,18 +2785,17 @@
                                         }
                                     });
 
-                                    await ensureWebSocketOpen();
-
-                                    // The pre-claim check does not cover the reconnect: a
-                                    // text send or a mic press inside it takes the slot, and
-                                    // sending anyway hands the backend a stale audio
+                                    // The pre-claim check does not cover the reconnect below:
+                                    // a text send or a mic press inside it takes the slot,
+                                    // and sending anyway hands the backend a stale audio
                                     // start_session, overwrites the shared timeout handle
                                     // and leaves this flow awaiting a promise whose resolver
                                     // is no longer installed -- its own owner-gated timeout
                                     // returns early, so nothing settles it and no later
-                                    // stand-down runs (codex P2).
+                                    // stand-down runs. Hence the check between the two lines
+                                    // that follow (codex P2).
+                                    await ensureWebSocketOpen();
                                     if (restartMustStandDown()) return;
-
                                     S.socket.send(JSON.stringify({ action: 'start_session', input_type: 'audio' }));
 
                                     window.sessionTimeoutId = setTimeout(function () {

--- a/static/app/app-websocket.js
+++ b/static/app/app-websocket.js
@@ -2681,13 +2681,53 @@
                             var _rs = resetSessionButton(); if (_rs) _rs.disabled = true;
                             var _rt = returnSessionButton(); if (_rt) _rt.disabled = true;
 
+                            // Snapshot the voice-start intent this restart is acting on --
+                            // HERE, where the restart is decided, not inside the callback
+                            // 7.5s later. A goodbye or avatar drop during the delay goes
+                            // through cancelPendingSessionStart and bumps the epoch, and a
+                            // snapshot taken afterwards would read that cancellation as its
+                            // own starting point and restart anyway (codex P2). Nothing
+                            // between here and the callback moves the epoch on its own: the
+                            // three cancelPendingSessionStart callers are all user actions.
+                            //
+                            // Unlike the mic-button flow this path has no
+                            // ensureVoiceStartCurrent, and ownership alone cannot see an
+                            // ABA -- see voiceStartEpochIsCurrent.
+                            var restartVoiceEpoch = S.voiceSessionStartEpoch;
+
                             setTimeout(async function () {
                                 var restartStartOwner = null;
-                                // Snapshot the voice-start intent this restart is acting
-                                // on. Unlike the mic-button flow there is no
-                                // ensureVoiceStartCurrent here, and ownership alone cannot
-                                // see an ABA -- see voiceStartEpochIsCurrent.
-                                var restartVoiceEpoch = S.voiceSessionStartEpoch;
+
+                                // Both points where this flow resumes from an await ask the
+                                // same question, and asking only half of it is how the last
+                                // two rounds of this bug survived: ownership cannot see a
+                                // cancel-and-clear (the slot is back to empty), and the
+                                // epoch cannot see a TEXT takeover (text starts never mint
+                                // one). Returns true when this restart must stand down.
+                                function restartMustStandDown() {
+                                    if (window.sessionStartSuperseded(restartStartOwner)
+                                            || (S._pendingSessionStartMode
+                                                && S._pendingSessionStartMode !== 'audio')) {
+                                        // The unwind is global -- it bumps the mic
+                                        // generation and clears window.isMicStarting -- so
+                                        // running it while the newer AUDIO start (a mic
+                                        // press inside the ack window) is still acquiring
+                                        // media makes that start abandon capture and fail
+                                        // its own ensureVoiceStartCurrent, leaving a
+                                        // backend-accepted session with the mic closed
+                                        // (greptile P1). That start is already driving this
+                                        // UI; a text start is not, so there it still runs.
+                                        if (!window.supersededByAudioStart(restartStartOwner)
+                                                && typeof window.abortVoiceStartForBlockedRoute === 'function') {
+                                            window.abortVoiceStartForBlockedRoute();
+                                        }
+                                        return true;
+                                    }
+                                    // Quietly: the cancel lever has already unwound the UI,
+                                    // and a newer mic start is driving it.
+                                    return !window.voiceStartEpochIsCurrent(restartVoiceEpoch);
+                                }
+
                                 try {
                                     var sessionStartPromise = new Promise(function (resolve, reject) {
                                         // Owner token for every release in this
@@ -2745,41 +2785,22 @@
                                     // inside the ack window) passes `mode !== 'audio'`, and
                                     // this restart would then open the microphone on top of
                                     // it. Neither test subsumes the other -- the disconnect
-                                    // cleanup nulls the resolver but leaves the mode set.
-                                    if (window.sessionStartSuperseded(restartStartOwner)
-                                            || (S._pendingSessionStartMode
-                                                && S._pendingSessionStartMode !== 'audio')) {
-                                        // The unwind is global -- it bumps the mic
-                                        // generation and clears window.isMicStarting -- so
-                                        // running it while the newer AUDIO start (a mic
-                                        // press inside the ack window) is still acquiring
-                                        // media makes that start abandon capture and fail
-                                        // its own ensureVoiceStartCurrent, leaving a
-                                        // backend-accepted session with the mic closed
-                                        // (greptile P1). That start is already driving this
-                                        // UI; a text start is not, so there it still runs.
-                                        if (!window.supersededByAudioStart(restartStartOwner)
-                                                && typeof window.abortVoiceStartForBlockedRoute === 'function') {
-                                            window.abortVoiceStartForBlockedRoute();
-                                        }
-                                        return;
-                                    }
-
-                                    // The slot can be back at EMPTY without this restart ever
-                                    // having owned it again: a newer start may claim inside
-                                    // the ack's 500ms window and then be cancelled (goodbye,
-                                    // avatar drop, character switch) or complete, and
-                                    // ownership cannot tell that apart from "my own ack
-                                    // released it". The epoch can -- both a mic press and
-                                    // cancelPendingSessionStart move it -- and without the
-                                    // check this path reopens the microphone after the user
-                                    // has already walked away (codex P2). Quietly: the
-                                    // cancel lever has already unwound the UI, and a newer
-                                    // mic start is driving it.
-                                    if (!window.voiceStartEpochIsCurrent(restartVoiceEpoch)) return;
+                                    // cleanup nulls the resolver but leaves the mode set --
+                                    // and neither sees a cancel-and-clear, which is why
+                                    // restartMustStandDown also asks the epoch.
+                                    if (restartMustStandDown()) return;
 
                                     if (typeof window.showCurrentModel === 'function') await window.showCurrentModel();
-                                    if (!window.voiceStartEpochIsCurrent(restartVoiceEpoch)) return;
+
+                                    // The SAME full question again, not just the epoch: this
+                                    // await is wide open, the disconnect path never disabled
+                                    // the mobile composer, and a text send inside it claims
+                                    // the slot without minting a voice epoch. An epoch-only
+                                    // recheck passes and this stale restart then opens the
+                                    // microphone on top of the text session and reports
+                                    // "restart complete" (codex P2).
+                                    if (restartMustStandDown()) return;
+
                                     if (S.voiceInputRouteBlocked === true) {
                                         // The rebuilt session came back fail-closed (independent
                                         // ASR was enabled and failed to start). Its status ALWAYS

--- a/static/app/app-websocket.js
+++ b/static/app/app-websocket.js
@@ -2734,8 +2734,16 @@
                                     // sets voiceInputRouteBlocked. This automatic restart
                                     // would otherwise reclaim a lease onto the text
                                     // session's blocked route (Codex P2).
-                                    if (S._pendingSessionStartMode
-                                            && S._pendingSessionStartMode !== 'audio') {
+                                    //
+                                    // Ownership first, mode second, for the same reason as
+                                    // app-buttons.js: a newer AUDIO start (a mic press
+                                    // inside the ack window) passes `mode !== 'audio'`, and
+                                    // this restart would then open the microphone on top of
+                                    // it. Neither test subsumes the other -- the disconnect
+                                    // cleanup nulls the resolver but leaves the mode set.
+                                    if (window.sessionStartSuperseded(restartStartOwner)
+                                            || (S._pendingSessionStartMode
+                                                && S._pendingSessionStartMode !== 'audio')) {
                                         if (typeof window.abortVoiceStartForBlockedRoute === 'function') {
                                             window.abortVoiceStartForBlockedRoute();
                                         }

--- a/static/app/app-websocket.js
+++ b/static/app/app-websocket.js
@@ -2703,6 +2703,7 @@
 
                             setTimeout(async function () {
                                 var restartStartOwner = null;
+                                var restartStartRejecter = null;
 
                                 // Every point where this flow resumes from an await asks the
                                 // same question, and asking only part of it is how round
@@ -2774,6 +2775,9 @@
                                         // flow; see claimSessionStart in
                                         // app-state.js.
                                         restartStartOwner = window.claimSessionStart('audio', resolve, reject);
+                                        // The only handle on our own promise once a newer
+                                        // start owns S.sessionStartedRejecter.
+                                        restartStartRejecter = reject;
                                         // Re-arm the fail-closed latch on user
                                         // intent, strictly before start_session
                                         // goes out and therefore before any
@@ -2800,7 +2804,21 @@
 
                                     window.sessionTimeoutId = setTimeout(function () {
                                         // Only for the start this timer was armed for.
-                                        if (!window.sessionStartIsCurrent(restartStartOwner)) return;
+                                        if (!window.sessionStartIsCurrent(restartStartOwner)) {
+                                            // Settling our own promise is still ours to do,
+                                            // and the last chance: a displaced start's ack is
+                                            // dropped by the cross-mode guard, so nothing
+                                            // else would ever resume this flow (codex P2).
+                                            // Nothing shared is touched -- slot, timer handle
+                                            // and socket belong to the newer start; the catch
+                                            // below stands down before it cleans anything up.
+                                            if (restartStartRejecter) {
+                                                restartStartRejecter(typeof window.makeNekoSessionAbortError === 'function'
+                                                    ? window.makeNekoSessionAbortError('Restart superseded')
+                                                    : new Error('Restart superseded'));
+                                            }
+                                            return;
+                                        }
                                         if (S.sessionStartedRejecter) {
                                             var rejecter = S.sessionStartedRejecter;
                                             window.releaseSessionStart(restartStartOwner);

--- a/static/app/app-websocket.js
+++ b/static/app/app-websocket.js
@@ -2694,18 +2694,34 @@
                             // ensureVoiceStartCurrent, and ownership alone cannot see an
                             // ABA -- see voiceStartEpochIsCurrent.
                             var restartVoiceEpoch = S.voiceSessionStartEpoch;
+                            // ...and the claim count with it. Until the callback claims, it
+                            // has no owner token to compare against, and a whole text
+                            // session can be started AND finished inside the 7.5s: by the
+                            // time we look, its resolver is gone, and text never moves the
+                            // epoch. Only the claim count still remembers it (codex P2).
+                            var restartClaimSeq = window.sessionStartClaimSeq();
 
                             setTimeout(async function () {
                                 var restartStartOwner = null;
 
-                                // Both points where this flow resumes from an await ask the
-                                // same question, and asking only half of it is how the last
-                                // two rounds of this bug survived: ownership cannot see a
+                                // Every point where this flow resumes from an await asks the
+                                // same question, and asking only part of it is how round
+                                // after round of this bug survived: ownership cannot see a
                                 // cancel-and-clear (the slot is back to empty), and the
                                 // epoch cannot see a TEXT takeover (text starts never mint
                                 // one). Returns true when this restart must stand down.
+                                //
+                                // Before the claim there is no owner token to compare
+                                // against, so the snapshot taken at scheduling time stands
+                                // in: it catches a text session that both started and
+                                // finished during the delay, which leaves nothing else
+                                // behind. After the claim the owner's own sequence carries
+                                // the same fact.
                                 function restartMustStandDown() {
-                                    if (window.sessionStartSuperseded(restartStartOwner)
+                                    var takenOver = restartStartOwner
+                                        ? window.sessionStartSuperseded(restartStartOwner)
+                                        : window.sessionStartsSince(restartClaimSeq);
+                                    if (takenOver
                                             || (S._pendingSessionStartMode
                                                 && S._pendingSessionStartMode !== 'audio')) {
                                         // The unwind is global -- it bumps the mic
@@ -2842,6 +2858,15 @@
                                     if (S.screenCaptureStream != null) {
                                         if (typeof window.startScreenSharing === 'function') await window.startScreenSharing();
                                     }
+
+                                    // The capture awaits are the last wide-open window, and
+                                    // the dual of the mic-button flow's post-getUserMedia
+                                    // check: a text takeover invalidates an in-flight mic
+                                    // start, but that cancellation path RETURNS rather than
+                                    // throws, so without this the restart lights the
+                                    // floating controls and reports "restart complete" over
+                                    // the text session (codex P2).
+                                    if (restartMustStandDown()) return;
 
                                     if (window.live2dManager && window.live2dManager._floatingButtons) {
                                         if (typeof window.syncFloatingMicButtonState === 'function') window.syncFloatingMicButtonState(true);

--- a/static/app/app-websocket.js
+++ b/static/app/app-websocket.js
@@ -2729,6 +2729,14 @@
                                 }
 
                                 try {
+                                    // BEFORE claiming anything. The first check used to sit
+                                    // after claim + start_session + ack, so a goodbye, an
+                                    // avatar drop or a mic press during the 7.5s delay was
+                                    // answered by taking the slot from whoever it belonged
+                                    // to, asking the backend for a session, and only then
+                                    // walking away -- without ending it (codex P2).
+                                    if (restartMustStandDown()) return;
+
                                     var sessionStartPromise = new Promise(function (resolve, reject) {
                                         // Owner token for every release in this
                                         // flow; see claimSessionStart in
@@ -2856,6 +2864,16 @@
                                         }
                                         window.releaseSessionStart(restartStartOwner);
                                     }
+
+                                    // A takeover during any await above -- including one
+                                    // that caused this very error, and including
+                                    // ensureWebSocketOpen rejecting before the claim -- means
+                                    // everything below lands on somebody else: end_session
+                                    // would kill their session, and the failure toast plus
+                                    // the global recording/UI teardown would rewrite the
+                                    // state they are driving (codex P2). Gating the slot
+                                    // release alone left all of that unguarded.
+                                    if (restartMustStandDown()) return;
 
                                     if (S.socket && S.socket.readyState === WebSocket.OPEN) {
                                         S.socket.send(JSON.stringify({ action: 'end_session' }));

--- a/static/app/app-websocket.js
+++ b/static/app/app-websocket.js
@@ -2737,9 +2737,21 @@
                                         var byAudio = owned
                                             ? window.supersededByAudioStart(restartStartOwner)
                                             : window.audioStartsSince(restartClaimSeq);
-                                        if (!byAudio
-                                                && typeof window.abortVoiceStartForBlockedRoute === 'function') {
-                                            window.abortVoiceStartForBlockedRoute();
+                                        if (!byAudio) {
+                                            // Committed capture must be stopped BEFORE the
+                                            // unwind: the unwind clears S.isRecording without
+                                            // touching the stream, and the text
+                                            // session_started teardown is gated on that very
+                                            // flag, so the hardware microphone would stay
+                                            // live (codex P1). notifyServer:false -- the
+                                            // newer start owns the socket.
+                                            if (S.isRecording === true
+                                                    && typeof window.stopRecording === 'function') {
+                                                window.stopRecording({ notifyServer: false });
+                                            }
+                                            if (typeof window.abortVoiceStartForBlockedRoute === 'function') {
+                                                window.abortVoiceStartForBlockedRoute();
+                                            }
                                         }
                                         return true;
                                     }
@@ -2774,6 +2786,17 @@
                                     });
 
                                     await ensureWebSocketOpen();
+
+                                    // The pre-claim check does not cover the reconnect: a
+                                    // text send or a mic press inside it takes the slot, and
+                                    // sending anyway hands the backend a stale audio
+                                    // start_session, overwrites the shared timeout handle
+                                    // and leaves this flow awaiting a promise whose resolver
+                                    // is no longer installed -- its own owner-gated timeout
+                                    // returns early, so nothing settles it and no later
+                                    // stand-down runs (codex P2).
+                                    if (restartMustStandDown()) return;
+
                                     S.socket.send(JSON.stringify({ action: 'start_session', input_type: 'audio' }));
 
                                     window.sessionTimeoutId = setTimeout(function () {

--- a/static/app/app-websocket.js
+++ b/static/app/app-websocket.js
@@ -2784,6 +2784,14 @@
                                             window.sessionTimeoutId = null;
                                         }
                                     });
+                                    // Consume the rejection up front. claimSessionStart settles the start it
+                                    // displaces, and that can land while this flow is still inside
+                                    // ensureWebSocketOpen -- before it reaches the await, and possibly before a
+                                    // stand-down returns without ever awaiting at all. Without a handler on the
+                                    // promise itself a routine takeover surfaces as an unhandledrejection and
+                                    // the health diagnostics log it as a runtime error. `await` below still sees
+                                    // the rejection: this attaches a handler, it does not swallow one.
+                                    sessionStartPromise.catch(function () { });
 
                                     // The pre-claim check does not cover the reconnect below:
                                     // a text send or a mic press inside it takes the slot,

--- a/static/app/app-websocket.js
+++ b/static/app/app-websocket.js
@@ -2683,6 +2683,11 @@
 
                             setTimeout(async function () {
                                 var restartStartOwner = null;
+                                // Snapshot the voice-start intent this restart is acting
+                                // on. Unlike the mic-button flow there is no
+                                // ensureVoiceStartCurrent here, and ownership alone cannot
+                                // see an ABA -- see voiceStartEpochIsCurrent.
+                                var restartVoiceEpoch = S.voiceSessionStartEpoch;
                                 try {
                                     var sessionStartPromise = new Promise(function (resolve, reject) {
                                         // Owner token for every release in this
@@ -2744,13 +2749,37 @@
                                     if (window.sessionStartSuperseded(restartStartOwner)
                                             || (S._pendingSessionStartMode
                                                 && S._pendingSessionStartMode !== 'audio')) {
-                                        if (typeof window.abortVoiceStartForBlockedRoute === 'function') {
+                                        // The unwind is global -- it bumps the mic
+                                        // generation and clears window.isMicStarting -- so
+                                        // running it while the newer AUDIO start (a mic
+                                        // press inside the ack window) is still acquiring
+                                        // media makes that start abandon capture and fail
+                                        // its own ensureVoiceStartCurrent, leaving a
+                                        // backend-accepted session with the mic closed
+                                        // (greptile P1). That start is already driving this
+                                        // UI; a text start is not, so there it still runs.
+                                        if (!window.supersededByAudioStart(restartStartOwner)
+                                                && typeof window.abortVoiceStartForBlockedRoute === 'function') {
                                             window.abortVoiceStartForBlockedRoute();
                                         }
                                         return;
                                     }
 
+                                    // The slot can be back at EMPTY without this restart ever
+                                    // having owned it again: a newer start may claim inside
+                                    // the ack's 500ms window and then be cancelled (goodbye,
+                                    // avatar drop, character switch) or complete, and
+                                    // ownership cannot tell that apart from "my own ack
+                                    // released it". The epoch can -- both a mic press and
+                                    // cancelPendingSessionStart move it -- and without the
+                                    // check this path reopens the microphone after the user
+                                    // has already walked away (codex P2). Quietly: the
+                                    // cancel lever has already unwound the UI, and a newer
+                                    // mic start is driving it.
+                                    if (!window.voiceStartEpochIsCurrent(restartVoiceEpoch)) return;
+
                                     if (typeof window.showCurrentModel === 'function') await window.showCurrentModel();
+                                    if (!window.voiceStartEpochIsCurrent(restartVoiceEpoch)) return;
                                     if (S.voiceInputRouteBlocked === true) {
                                         // The rebuilt session came back fail-closed (independent
                                         // ASR was enabled and failed to start). Its status ALWAYS

--- a/static/app/app-websocket.js
+++ b/static/app/app-websocket.js
@@ -2718,7 +2718,8 @@
                                 // behind. After the claim the owner's own sequence carries
                                 // the same fact.
                                 function restartMustStandDown() {
-                                    var takenOver = restartStartOwner
+                                    var owned = !!restartStartOwner;
+                                    var takenOver = owned
                                         ? window.sessionStartSuperseded(restartStartOwner)
                                         : window.sessionStartsSince(restartClaimSeq);
                                     if (takenOver
@@ -2733,7 +2734,10 @@
                                         // backend-accepted session with the mic closed
                                         // (greptile P1). That start is already driving this
                                         // UI; a text start is not, so there it still runs.
-                                        if (!window.supersededByAudioStart(restartStartOwner)
+                                        var byAudio = owned
+                                            ? window.supersededByAudioStart(restartStartOwner)
+                                            : window.audioStartsSince(restartClaimSeq);
+                                        if (!byAudio
                                                 && typeof window.abortVoiceStartForBlockedRoute === 'function') {
                                             window.abortVoiceStartForBlockedRoute();
                                         }

--- a/tests/unit/test_voice_start_failure_static.py
+++ b/tests/unit/test_voice_start_failure_static.py
@@ -704,13 +704,16 @@ def test_voice_start_bails_when_another_start_took_over_the_pending_slot():
     source = _read(APP_BUTTONS_PATH)
     start_flow = _mic_button_start_flow(source)
 
+    # The takeover decision now lives in one micStartMustStandDown() check --
+    # see tests/unit/test_voice_start_slot_ownership.py for what that check has
+    # to consider, which grew well past the pending mode. What this case pins is
+    # WHERE the resumed flow consults it.
     await_index = start_flow.index("await sessionStartPromise;")
-    guard = "S._pendingSessionStartMode !== 'audio'"
+    guard = "micStartMustStandDown()"
     assert guard in start_flow, (
-        "the resumed voice start must notice that another start owns the slot"
+        "the resumed voice start must notice that another start took the slot"
     )
-    guard_index = start_flow.index(guard)
-    assert await_index < guard_index, "the check belongs after the await, not before"
+    guard_index = start_flow.index(guard, await_index)
 
     # It has to come before BOTH downstream guards, because neither can see a
     # takeover -- that is the whole finding.
@@ -718,15 +721,21 @@ def test_voice_start_bails_when_another_start_took_over_the_pending_slot():
     assert guard_index < start_flow.index("S.voiceInputRouteBlocked === true")
     assert guard_index < start_flow.index("await window.startMicCapture();")
 
-    # And it must unwind via the non-throwing helper: the generic catch clears
+    # And it must unwind without throwing: the generic catch used to clear
     # S.sessionStartedResolver / Rejecter / _pendingSessionStartMode
     # unconditionally, which would tear down the start that superseded us.
     bail = start_flow[guard_index:start_flow.index("ensureVoiceStartCurrent();", await_index)]
     bail_code = " ".join(
         line for line in bail.splitlines() if not line.strip().startswith("//")
     )
-    assert "abortVoiceStartForBlockedRoute" in bail_code
     assert "throw" not in bail_code
     # The newer start owns the shared timeout now; cancelling it is the same
     # cross-start damage this guard exists to prevent.
     assert "clearTimeout" not in bail_code
+
+    # The unwind itself sits inside the check, and is gated there: it is global
+    # (mic generation + isMicStarting), so it may not run while a newer AUDIO
+    # start is driving that state.
+    check = start_flow[start_flow.index("function micStartMustStandDown()"):await_index]
+    assert "abortVoiceStartForBlockedRoute" in check
+    assert "supersededByAudioStart" in check

--- a/tests/unit/test_voice_start_slot_ownership.py
+++ b/tests/unit/test_voice_start_slot_ownership.py
@@ -54,7 +54,7 @@ function assert(cond, msg) {
 // comes along deliberately: the epoch property below is about how the two
 // interact, and reimplementing the lever here would test nothing.
 const source = fs.readFileSync(__APP_STATE_PATH__, 'utf8');
-const start = source.indexOf('window.claimSessionStart = function');
+const start = source.indexOf('// ---- voice-start slot ownership');
 const end = source.indexOf('// ======================== 工具函数');
 assert(start > 0 && end > start, 'could not locate the ownership helpers');
 
@@ -145,6 +145,14 @@ assert(W.sessionStartSuperseded(ownerB) === false,
 assert(W.sessionStartIsCurrent(ownerB) === false,
        'and the released owner is no longer current -- the two differ here');
 
+// ...but a COMPLETED takeover is still a takeover. B has claimed and released,
+// so the slot is empty again and, to anything that only looks at who holds it,
+// indistinguishable from A's own release. That is the blind spot that let a
+// stale mic start send end_session and reset the UI for the text session which
+// had just succeeded inside its getUserMedia await.
+assert(W.sessionStartSuperseded(ownerA) === true,
+       'a takeover that has already finished must still supersede the start it took over from');
+
 // --- who superseded us decides whether the GLOBAL unwind may run -----------
 // abortVoiceStartForBlockedRoute bumps the mic generation and clears
 // window.isMicStarting. A newer AUDIO start is sitting on exactly that state
@@ -168,37 +176,53 @@ assert(W.supersededByAudioStart(ownerC) === false,
 const ownerD = S.sessionStartedResolver;
 W.releaseSessionStart(ownerD);
 assert(W.supersededByAudioStart(ownerC) === false,
-       'an empty slot means nobody is driving the UI -- the unwind must still run');
+       'a text takeover that has completed is still a text takeover -- unwind');
 
-// --- the epoch sees the ABA that ownership cannot --------------------------
-// The automatic restart has no ensureVoiceStartCurrent of its own, so this is
-// the only signal standing between it and reopening the microphone after the
-// user has walked away.
+// The mirror case, and the one the pending mode gets wrong: an AUDIO takeover
+// that has already been acknowledged and released the slot is MORE alive than a
+// pending one, not less. Reading _pendingSessionStartMode here would find null
+// and unwind the mic generation out from under a session that is recording.
+W.claimSessionStart('audio', () => {}, () => {});
+W.releaseSessionStart(S.sessionStartedResolver);
+assert(S._pendingSessionStartMode === null, 'the pending mode is gone once released');
+assert(W.supersededByAudioStart(ownerC) === true,
+       'a completed AUDIO takeover must still suppress the global unwind');
+
+// --- the two signals abandon-detect different things -----------------------
+// A cancellation claims nothing, so the claim sequence never moves for it: a
+// goodbye, avatar drop or character switch during the restart's 7.5s delay
+// leaves the slot untouched and every start's sequence intact. The epoch is
+// what sees those -- and it is the automatic restart's only guard, since that
+// flow has no ensureVoiceStartCurrent of its own. The mirror hole is above: a
+// takeover that claimed and finished moves the sequence and never the epoch,
+// which is minted by voice starts only. Neither signal subsumes the other,
+// which is why both stand-down checks ask both.
 S.voiceSessionStartEpoch = 7;
 const restartEpoch = S.voiceSessionStartEpoch;
 const ownerR = W.claimSessionStart('audio', () => {}, () => {});
 assert(W.voiceStartEpochIsCurrent(restartEpoch) === true,
        'claiming the slot does not by itself move the intent epoch');
 
-// A newer start claims inside the ack's deferred window, and then the user
-// walks away: goodbye / avatar drop / character switch go through
-// cancelPendingSessionStart, which clears the slot outright. Ownership is back
-// to EMPTY -- byte for byte what "my own ack released it" looks like.
-W.claimSessionStart('audio', () => {}, () => {});
 W.cancelPendingSessionStart('goodbye');
 assert(S.sessionStartedResolver === null, 'the cancel lever cleared the slot');
 assert(W.sessionStartSuperseded(ownerR) === false,
-       'ownership alone cannot see the ABA -- that blind spot is the point');
+       'a cancellation claims nothing, so the claim sequence cannot see it');
 assert(W.voiceStartEpochIsCurrent(restartEpoch) === false,
-       'the epoch must still know the user moved on');
+       'the epoch must know the user walked away');
 
 console.log('HARNESS_OK');
 """
 
-# Both takeover guards resume from `await sessionStartPromise` and must decide
-# whether a newer start has taken the slot. Mode alone cannot tell: the
-# automatic restart claims 'audio' exactly like the mic button does.
+# Both flows funnel every "has someone taken over?" decision through one check.
+# Mode alone cannot tell: the automatic restart claims 'audio' exactly like the
+# mic button does, and a completed takeover leaves no pending mode at all.
 _MODE_TEST = "_pendingSessionStartMode !== 'audio'"
+
+# file -> (stand-down check, how many points in that flow must call it)
+STAND_DOWN_CHECKS = {
+    "app-buttons.js": ("micStartMustStandDown", 3),
+    "app-websocket.js": ("restartMustStandDown", 4),
+}
 
 
 def _run(script: str):
@@ -232,83 +256,72 @@ def test_a_superseded_flow_cannot_release_the_newer_starts_slot():
 
 
 @pytest.mark.unit
-def test_takeover_guards_ask_ownership_not_only_mode():
-    """Every "did someone take the slot?" guard must consult the owner token.
+def test_each_flow_decides_takeovers_in_exactly_one_place():
+    """Both stand-down checks must ask the whole question.
 
-    The harness above proves the predicate; this pins the call sites, which is
-    where the bug actually lived: both flows resumed from
-    ``await sessionStartPromise`` and tested only
-    ``_pendingSessionStartMode !== 'audio'``, so a newer AUDIO start (the
-    automatic reconnect restart claims 'audio' too) sailed through and the
-    superseded flow went on to cancel the newer start's 15s timeout.
+    Each signal is blind to something the others see, and every round of this
+    bug was one await covered by only the blind half: ownership misses a
+    takeover that has already finished, the pending mode is null by then, and
+    the epoch never moves for a text start at all. The checks also decide
+    whether the GLOBAL unwind may run -- it bumps the mic generation and clears
+    ``window.isMicStarting``, which is exactly the state a newer audio start is
+    sitting on inside getUserMedia.
 
-    Mutation-verified: drop ``sessionStartSuperseded`` from either guard and
-    this reddens naming that file and the surviving mode-only condition.
+    Mutation-verified: drop any one signal from either check and this reddens
+    naming that file and that signal.
     """
-    checked = 0
+    required = (
+        "sessionStartSuperseded",
+        _MODE_TEST,
+        "supersededByAudioStart",
+        "abortVoiceStartForBlockedRoute",
+    )
     for path in START_FLOW_PATHS:
         source = path.read_text(encoding="utf-8")
-        for match in re.finditer(re.escape(_MODE_TEST), source):
-            head = source[:match.start()]
-            condition_start = head.rfind("if (")
-            assert condition_start != -1, f"{path.name}: mode test outside any if()"
-            condition = source[condition_start:match.end()]
-            assert "sessionStartSuperseded" in condition, (
-                f"{path.name}: a takeover guard tests the pending mode without asking "
-                f"who owns the slot -- a newer AUDIO start passes it.\n{condition}"
+        name = STAND_DOWN_CHECKS[path.name][0]
+        start = source.find(f"function {name}()")
+        assert start != -1, f"{path.name}: the stand-down check {name} has been renamed"
+        body = source[start:source.find("try {", start)]
+        for signal in required:
+            assert signal in body, (
+                f"{path.name}: {name} ignores `{signal}`, so a takeover it cannot see "
+                f"reaches the microphone or tears down the start that took over.\n{body}"
             )
-            checked += 1
-    assert checked >= 2, (
-        "expected the mic-button and automatic-restart takeover guards to be found; "
-        f"only {checked} matched -- has the guard been rewritten?"
-    )
 
 
 @pytest.mark.unit
-def test_takeover_branches_do_not_unwind_under_a_newer_audio_start():
-    """The global voice-start unwind must be gated on WHO took the slot.
+def test_every_point_a_flow_resumes_from_an_await_stands_down():
+    """One check is worth nothing at the one await that skips it.
 
-    ``abortVoiceStartForBlockedRoute`` bumps the mic generation and clears
-    ``window.isMicStarting``. Making the takeover branches ownership-aware is
-    what made "a newer AUDIO start took over" reachable at all, and that is
-    precisely the case where the unwind lands on a start still inside
-    getUserMedia: it abandons capture and then fails its own
-    ``ensureVoiceStartCurrent``, leaving a session the backend accepted with no
-    microphone.
+    The counts are the awaits each flow resumes from, plus its failure path:
+    the mic handler after its start promise, after getUserMedia, and in its
+    outer catch; the restart before it claims at all, after its start promise,
+    after showCurrentModel, and in its catch. Every one of those was reported
+    separately, in three rounds, as its own bug.
 
-    Mutation-verified: drop the ``supersededByAudioStart`` gate from either
-    branch and this reddens naming that file.
+    Mutation-verified: delete any single call and this reddens with the count.
     """
-    checked = 0
     for path in START_FLOW_PATHS:
         source = path.read_text(encoding="utf-8")
-        for match in re.finditer(re.escape(_MODE_TEST), source):
-            branch_end = source.find("return", match.end())
-            assert branch_end != -1, f"{path.name}: takeover branch has no return"
-            branch = source[match.end():branch_end]
-            if "abortVoiceStartForBlockedRoute" not in branch:
-                continue
-            assert "supersededByAudioStart" in branch, (
-                f"{path.name}: the takeover branch runs the global voice-start unwind "
-                "without checking whether a newer AUDIO start is driving that very "
-                f"state.\n{branch}"
-            )
-            checked += 1
-    assert checked >= 2, (
-        "expected both takeover branches to reach the unwind; "
-        f"only {checked} matched -- has the branch been rewritten?"
-    )
+        name, expected = STAND_DOWN_CHECKS[path.name]
+        calls = source.count(f"{name}()") - 1  # minus the definition
+        assert calls >= expected, (
+            f"{path.name}: {name} is called at {calls} of the {expected} points this "
+            "flow can resume or fail at -- the uncovered one is where a takeover walks "
+            "into the microphone or into a foreign session's teardown."
+        )
 
 
 @pytest.mark.unit
-def test_a_superseded_mic_start_does_not_run_its_failure_cleanup():
-    """A failed start that no longer owns the slot must not end the session.
+def test_the_mic_failure_cleanup_stands_down_before_ending_the_session():
+    """A failed start that was superseded must not end the winner's session.
 
-    Gating the slot was never enough: the mic handler's failure cleanup also
-    sends ``end_session``, calls ``stopRecording`` and rewrites the button row,
-    and by then those land on whichever start took over.
+    Gating the slot was never enough: the cleanup also sends ``end_session``,
+    calls ``stopRecording`` and rewrites the button row, and after a takeover
+    those all land on the start that took over -- frequently the very start
+    whose acknowledgement caused this failure.
 
-    Mutation-verified: remove the superseded early-return and this reddens.
+    Mutation-verified: remove the stand-down call and this reddens.
     """
     source = (_STATIC_APP / "app-buttons.js").read_text(encoding="utf-8")
     anchor = source.find("var micStartStillOurs")
@@ -317,10 +330,10 @@ def test_a_superseded_mic_start_does_not_run_its_failure_cleanup():
     assert end_session != -1, "expected the failure cleanup to send end_session"
 
     guard_region = source[anchor:end_session]
-    assert "sessionStartSuperseded" in guard_region and "return;" in guard_region, (
+    assert "micStartMustStandDown()" in guard_region, (
         "app-buttons.js: the mic start's failure cleanup reaches end_session without "
-        "first bailing out when a newer start owns the slot -- it would tear down "
-        f"that start's session.\n{guard_region}"
+        "standing down first -- it would tear down the session of whoever took over.\n"
+        f"{guard_region}"
     )
 
 

--- a/tests/unit/test_voice_start_slot_ownership.py
+++ b/tests/unit/test_voice_start_slot_ownership.py
@@ -433,6 +433,40 @@ def test_standing_down_stops_committed_capture_before_it_unwinds():
 
 
 @pytest.mark.unit
+def test_a_cancelled_start_does_not_unwind_over_the_goodbye_ui():
+    """Goodbye outranks a takeover, and the claim sequence cannot see it.
+
+    A cancellation clears the slot without claiming anything, so a start
+    superseded before the goodbye stays superseded after it -- and unwinding
+    then re-enables the mic button and unhides the composer on top of the
+    goodbye UI, while the early return skips the catch's preserveGoodbyeUi
+    handling that would have restored it.
+
+    Mutation-verified: move the cancellation check after the unwind, or drop it,
+    and this reddens naming that file.
+    """
+    for path, signals in (
+        ("app-buttons.js", ("isNekoGoodbyeModeActive", "voiceStartEpochIsCurrent")),
+        ("app-websocket.js", ("voiceStartEpochIsCurrent",)),
+    ):
+        source = (_STATIC_APP / path).read_text(encoding="utf-8")
+        name = STAND_DOWN_CHECKS[path][0]
+        body = _region(source, f"function {name}()", "try {", path)
+        unwind = body.find("abortVoiceStartForBlockedRoute()")
+        assert unwind != -1, f"{path}: {name} no longer unwinds at all"
+        for signal in signals:
+            at = body.find(signal)
+            assert at != -1, (
+                f"{path}: {name} never asks `{signal}`, so a cancellation after a takeover "
+                f"is invisible to it.\n{body}"
+            )
+            assert at < unwind, (
+                f"{path}: {name} unwinds before it checks `{signal}` -- a goodbye after a "
+                "takeover would have its UI overwritten by the unwind."
+            )
+
+
+@pytest.mark.unit
 def test_the_mic_flow_rechecks_cancellation_after_proactive_vision():
     """That await needs BOTH questions asked on the other side.
 

--- a/tests/unit/test_voice_start_slot_ownership.py
+++ b/tests/unit/test_voice_start_slot_ownership.py
@@ -225,6 +225,21 @@ STAND_DOWN_CHECKS = {
 }
 
 
+def _region(source: str, opening: str, closing: str, where: str) -> str:
+    """Slice between two markers, refusing to degrade into "the rest of the file".
+
+    A missing marker makes ``find`` return -1, and ``source[start:-1]`` would then
+    hand every later ``in`` assertion nearly the whole file to match against: the
+    guard under test could be deleted outright and the case would stay green.
+    Anything this returns is bounded by markers that were actually found.
+    """
+    start = source.find(opening)
+    assert start != -1, f"{where}: `{opening}` is gone"
+    end = source.find(closing, start)
+    assert end != -1, f"{where}: `{closing}` no longer follows `{opening}`"
+    return source[start:end]
+
+
 def _run(script: str):
     node_path = shutil.which("node")
     if not node_path:
@@ -279,9 +294,7 @@ def test_each_flow_decides_takeovers_in_exactly_one_place():
     for path in START_FLOW_PATHS:
         source = path.read_text(encoding="utf-8")
         name = STAND_DOWN_CHECKS[path.name][0]
-        start = source.find(f"function {name}()")
-        assert start != -1, f"{path.name}: the stand-down check {name} has been renamed"
-        body = source[start:source.find("try {", start)]
+        body = _region(source, f"function {name}()", "try {", path.name)
         for signal in required:
             assert signal in body, (
                 f"{path.name}: {name} ignores `{signal}`, so a takeover it cannot see "
@@ -324,12 +337,9 @@ def test_the_mic_failure_cleanup_stands_down_before_ending_the_session():
     Mutation-verified: remove the stand-down call and this reddens.
     """
     source = (_STATIC_APP / "app-buttons.js").read_text(encoding="utf-8")
-    anchor = source.find("var micStartStillOurs")
-    assert anchor != -1, "the mic handler's failure cleanup has been rewritten"
-    end_session = source.find("action: 'end_session'", anchor)
-    assert end_session != -1, "expected the failure cleanup to send end_session"
-
-    guard_region = source[anchor:end_session]
+    guard_region = _region(
+        source, "var micStartStillOurs", "action: 'end_session'", "app-buttons.js"
+    )
     assert "micStartMustStandDown()" in guard_region, (
         "app-buttons.js: the mic start's failure cleanup reaches end_session without "
         "standing down first -- it would tear down the session of whoever took over.\n"
@@ -351,21 +361,18 @@ def test_the_automatic_restart_stands_down_at_every_resumption_point():
     predicate, and this reddens.
     """
     source = (_STATIC_APP / "app-websocket.js").read_text(encoding="utf-8")
-    helper = source.find("function restartMustStandDown()")
-    assert helper != -1, "the automatic restart's stand-down check has been renamed"
-    helper_body = source[helper:source.find("try {", helper)]
+    helper_body = _region(
+        source, "function restartMustStandDown()", "try {", "app-websocket.js"
+    )
     for signal in ("sessionStartSuperseded", "voiceStartEpochIsCurrent"):
         assert signal in helper_body, (
             f"app-websocket.js: the restart's stand-down check ignores {signal}, so a "
             f"takeover it cannot see reaches the microphone.\n{helper_body}"
         )
 
-    resumed = source.find("await sessionStartPromise;", helper)
-    assert resumed != -1, "the automatic restart no longer awaits its start promise"
-    opens_mic = source.find("window.startMicCapture()", resumed)
-    assert opens_mic != -1, "the automatic restart no longer opens the mic"
-
-    resumption = source[resumed:opens_mic]
+    resumption = _region(
+        source, "await sessionStartPromise;", "window.startMicCapture()", "app-websocket.js"
+    )
     assert resumption.count("restartMustStandDown()") >= 2, (
         "app-websocket.js: the automatic restart resumes twice before opening the "
         "microphone -- from its start promise and from showCurrentModel -- and must "

--- a/tests/unit/test_voice_start_slot_ownership.py
+++ b/tests/unit/test_voice_start_slot_ownership.py
@@ -257,13 +257,15 @@ _MODE_TEST = "_pendingSessionStartMode !== 'audio'"
 
 # file -> (stand-down check, how many points in that flow must call it)
 #
-# app-buttons.js:   after the start promise, after getUserMedia, after the
-#                   proactive-vision acquisition, and in the outer catch.
-# app-websocket.js: before the claim, after the start promise, after
-#                   showCurrentModel, after the capture awaits, and in the catch.
+# app-buttons.js:   after ensureWebSocketOpen, after the start promise, after
+#                   getUserMedia, after the proactive-vision acquisition, and in
+#                   the outer catch.
+# app-websocket.js: before the claim, after ensureWebSocketOpen, after the start
+#                   promise, after showCurrentModel, after the capture awaits,
+#                   and in the catch.
 STAND_DOWN_CHECKS = {
-    "app-buttons.js": ("micStartMustStandDown", 4),
-    "app-websocket.js": ("restartMustStandDown", 5),
+    "app-buttons.js": ("micStartMustStandDown", 5),
+    "app-websocket.js": ("restartMustStandDown", 6),
 }
 
 
@@ -364,6 +366,66 @@ def test_every_point_a_flow_resumes_from_an_await_stands_down():
             f"{path.name}: {name} is called at {calls} of the {expected} points this "
             "flow can resume or fail at -- the uncovered one is where a takeover walks "
             "into the microphone or into a foreign session's teardown."
+        )
+
+
+@pytest.mark.unit
+def test_standing_down_stops_committed_capture_before_it_unwinds():
+    """The unwind on its own leaks the hardware microphone.
+
+    ``abortVoiceStartForBlockedRoute`` clears ``S.isRecording`` without stopping
+    the stream, closing the audio context or disconnecting the worklet -- it was
+    written for a route that was refused before the mic ever opened. But the
+    text ``session_started`` teardown is gated on ``S.isRecording`` being true,
+    so unwinding first makes it skip the only pipeline teardown there is, and
+    the microphone stays live after the user switched to text.
+
+    Mutation-verified: drop the stopRecording call, or move it after the unwind,
+    and this reddens naming that file.
+    """
+    for path in START_FLOW_PATHS:
+        source = path.read_text(encoding="utf-8")
+        name = STAND_DOWN_CHECKS[path.name][0]
+        body = _region(source, f"function {name}()", "try {", path.name)
+
+        stop = body.find("stopRecording({ notifyServer: false })")
+        assert stop != -1, (
+            f"{path.name}: {name} unwinds without stopping capture that already "
+            f"committed -- the microphone survives the takeover.\n{body}"
+        )
+        assert "S.isRecording === true" in body, (
+            f"{path.name}: the capture teardown in {name} must be gated on there being "
+            f"capture to tear down.\n{body}"
+        )
+        abort = body.find("abortVoiceStartForBlockedRoute()")
+        assert abort != -1, f"{path.name}: {name} no longer unwinds at all"
+        assert stop < abort, (
+            f"{path.name}: {name} unwinds before it stops capture, and the unwind "
+            "clears the very flag stopRecording needs -- order matters here."
+        )
+
+
+@pytest.mark.unit
+def test_the_mic_flow_rechecks_cancellation_after_proactive_vision():
+    """That await needs BOTH questions asked on the other side.
+
+    Proactive vision acquisition spans a backend request and a display-capture
+    prompt. A takeover inside it is a new claim, which the stand-down sees; a
+    goodbye or reset is not -- cancelPendingSessionStart moves the epoch and
+    clears isMicStarting without claiming anything, and only
+    ensureVoiceStartCurrent looks at those.
+
+    Mutation-verified: drop either call and this reddens.
+    """
+    source = (_STATIC_APP / "app-buttons.js").read_text(encoding="utf-8")
+    region = _region(
+        source, "acquireProactiveVisionStream", "hideVoicePreparingToast", "app-buttons.js"
+    )
+    for signal in ("ensureVoiceStartCurrent()", "micStartMustStandDown()"):
+        assert signal in region, (
+            f"app-buttons.js: nothing asks `{signal}` between the proactive-vision await "
+            "and the success path, so a voice session the user already ended still gets "
+            f"announced.\n{region}"
         )
 
 

--- a/tests/unit/test_voice_start_slot_ownership.py
+++ b/tests/unit/test_voice_start_slot_ownership.py
@@ -461,9 +461,10 @@ def test_a_displaced_start_is_abandoned_quietly_not_reported_as_a_failure():
     """Being taken over is the user's own next action, not a failure.
 
     Now that claimSessionStart settles the start it displaces, every flow that
-    awaits a start promise can be rejected by a takeover -- and the text flows
-    reported that as "启动失败 / 回来失败", carrying the internal English reason
-    string into a toast.
+    awaits a start promise can be rejected by a takeover -- and both text flows
+    reported that through their start-failure toast, which interpolates the
+    error message and would therefore have put the internal English reason
+    string in front of the user.
 
     Mutation-verified: remove either quiet-abandon branch and this reddens.
     """

--- a/tests/unit/test_voice_start_slot_ownership.py
+++ b/tests/unit/test_voice_start_slot_ownership.py
@@ -53,7 +53,10 @@ function assert(cond, msg) {
 // comes along deliberately: the epoch property below is about how the two
 // interact, and reimplementing the lever here would test nothing.
 const source = fs.readFileSync(__APP_STATE_PATH__, 'utf8');
-const start = source.indexOf('// ---- voice-start slot ownership');
+// makeNekoSessionAbortError comes along because claimSessionStart settles the
+// start it displaces with it, and "is that a cancellation or a failure" is the
+// property the flows branch on -- stubbing it here would test the stub.
+const start = source.indexOf('window.makeNekoSessionAbortError = function');
 const end = source.indexOf('// ======================== 工具函数');
 assert(start > 0 && end > start, 'could not locate the ownership helpers');
 
@@ -64,15 +67,31 @@ const S = {
   voiceSessionStartEpoch: 0,
   voiceStartPending: false,
 };
-const sandbox = {
-  S,
-  window: { makeNekoSessionAbortError: (reason) => new Error(reason) },
-  clearTimeout: () => {},
-  console: { log() {}, warn() {} },
-};
+const sandbox = { S, window: {}, clearTimeout: () => {}, console: { log() {}, warn() {} } };
 vm.createContext(sandbox);
 vm.runInContext(source.slice(start, end), sandbox, { filename: 'app-state-helpers.js' });
 const W = sandbox.window;
+
+// --- displacing a start settles it ----------------------------------------
+// Nothing else can, once it has been displaced: its acknowledgement is dropped
+// by the cross-mode guard in the session_started handler, and its 15s timeout
+// is cancelled by the claim setup of the very flow that displaced it. Left
+// unsettled it sits on `await sessionStartPromise` forever, holding
+// window.isMicStarting and an active/disabled mic button through OUR session.
+let displacedWith = 'not settled';
+W.claimSessionStart('audio', () => {}, (e) => { displacedWith = e; });
+W.claimSessionStart('text', () => {}, () => {});
+assert(displacedWith !== 'not settled', 'displacing a start must settle it');
+assert(displacedWith.sessionStartCancelled === true,
+       'settled as a cancellation, so the flows abandon quietly instead of reporting a failure');
+assert(displacedWith.voiceStartCancelled === true, 'and the voice flows see the same');
+
+// Claiming an EMPTY slot settles nobody.
+W.releaseSessionStart(S.sessionStartedResolver);
+let settledFromEmpty = false;
+W.claimSessionStart('audio', () => {}, () => { settledFromEmpty = true; });
+assert(settledFromEmpty === false, 'claiming an empty slot must not settle anything');
+W.releaseSessionStart(S.sessionStartedResolver);
 
 // --- a superseded flow must not release the newer start's slot -------------
 const firstResolve = () => {};
@@ -388,6 +407,14 @@ def test_standing_down_stops_committed_capture_before_it_unwinds():
         name = STAND_DOWN_CHECKS[path.name][0]
         body = _region(source, f"function {name}()", "try {", path.name)
 
+        if path.name == "app-buttons.js":
+            assert "S.isSwitchingMode = false" in body, (
+                "app-buttons.js: standing down returns past both places that clear "
+                "S.isSwitchingMode, and this flow may have set it when it began from a "
+                "live text session -- left true it suppresses CHARACTER_LEFT handling and "
+                f"keeps auto-goodbye treating the app as mid-switch.\n{body}"
+            )
+
         stop = body.find("stopRecording({ notifyServer: false })")
         assert stop != -1, (
             f"{path.name}: {name} unwinds without stopping capture that already "
@@ -430,34 +457,30 @@ def test_the_mic_flow_rechecks_cancellation_after_proactive_vision():
 
 
 @pytest.mark.unit
-def test_a_displaced_start_still_settles_its_own_promise():
-    """Refusing to fire is not the same as having nothing to do.
+def test_a_displaced_start_is_abandoned_quietly_not_reported_as_a_failure():
+    """Being taken over is the user's own next action, not a failure.
 
-    A start that loses the slot has its acknowledgement dropped by the
-    cross-mode guard in the session_started handler, so its own timeout is the
-    only thing left that can settle it. Returning early there -- correct about
-    the shared state -- left the flow suspended forever at
-    ``await sessionStartPromise``, holding ``window.isMicStarting`` and an
-    active/disabled mic button straight through the session that took over. It
-    keeps its own rejecter precisely because ``S.sessionStartedRejecter`` is the
-    newer start's by then.
+    Now that claimSessionStart settles the start it displaces, every flow that
+    awaits a start promise can be rejected by a takeover -- and the text flows
+    reported that as "启动失败 / 回来失败", carrying the internal English reason
+    string into a toast.
 
-    Mutation-verified: drop the rejecter call from either timeout and this
-    reddens naming that file.
+    Mutation-verified: remove either quiet-abandon branch and this reddens.
     """
-    for path in START_FLOW_PATHS:
-        source = path.read_text(encoding="utf-8")
-        branch = _region(
-            source, "if (!window.sessionStartIsCurrent(", "return;", path.name
-        )
-        assert "Rejecter(" in branch, (
-            f"{path.name}: the timeout of a displaced start returns without settling its "
-            "own promise, so that flow never resumes and never releases the voice-start "
-            f"UI.\n{branch}"
-        )
-        assert "window.sessionTimeoutId = null" not in branch, (
-            f"{path.name}: a displaced start must not clear the shared timer handle -- it "
-            f"belongs to the start that displaced it.\n{branch}"
+    source = (_STATIC_APP / "app-buttons.js").read_text(encoding="utf-8")
+    catches = [
+        ("console.askHerBackFailed", "textStartOwner"),
+        ("console.startTextSessionFailed", "composerStartOwner"),
+    ]
+    for marker, owner in catches:
+        where = source.find(marker)
+        assert where != -1, f"the catch logging {marker} has been rewritten"
+        # The decision has to be made before the toast, so look at the window
+        # just ahead of it.
+        head = source[max(0, where - 900):where]
+        assert "sessionStartCancelled" in head and owner in head, (
+            f"app-buttons.js: the catch at {marker} reports a takeover as a start failure "
+            f"-- with the internal reason string in the toast.\n{head}"
         )
 
 

--- a/tests/unit/test_voice_start_slot_ownership.py
+++ b/tests/unit/test_voice_start_slot_ownership.py
@@ -27,6 +27,7 @@ no-op.
 """
 
 import json
+import re
 import shutil
 import textwrap
 from pathlib import Path
@@ -35,7 +36,9 @@ import pytest
 
 from tests.node_harness import run_node_script
 
-APP_STATE_PATH = Path(__file__).resolve().parents[2] / "static" / "app" / "app-state.js"
+_STATIC_APP = Path(__file__).resolve().parents[2] / "static" / "app"
+APP_STATE_PATH = _STATIC_APP / "app-state.js"
+START_FLOW_PATHS = (_STATIC_APP / "app-buttons.js", _STATIC_APP / "app-websocket.js")
 
 _HARNESS = r"""
 const fs = require('node:fs');
@@ -101,8 +104,44 @@ assert(W.releaseSessionStart(undefined) === false, 'nor an undefined one');
 assert(S.sessionStartedResolver === firstResolve, 'slot survives both');
 assert(W.sessionStartIsCurrent(null) === false, 'a missing token is never current');
 
+// --- superseded is about IDENTITY, not mode, and not "not current" ---------
+// The takeover guards in the two start flows used to ask
+// `_pendingSessionStartMode !== 'audio'`, which is blind to a newer AUDIO
+// start -- the automatic reconnect restart claims 'audio' too. The superseded
+// flow then fell through and cancelled the newer start's 15s timeout, leaving
+// it pending forever when its ack never arrived.
+W.releaseSessionStart(firstOwner);
+const audioA = () => {};
+const ownerA = W.claimSessionStart('audio', audioA, () => {});
+assert(W.sessionStartSuperseded(ownerA) === false,
+       'the start holding the slot is not superseded');
+
+const audioB = () => {};
+const ownerB = W.claimSessionStart('audio', audioB, () => {});
+assert(S._pendingSessionStartMode === 'audio',
+       'a newer AUDIO start leaves the mode indistinguishable from our own');
+assert(W.sessionStartSuperseded(ownerA) === true,
+       'an audio start superseded by another audio start must still know it');
+assert(W.sessionStartSuperseded(ownerB) === false, 'the newcomer owns the slot');
+
+// An EMPTY slot is NOT superseded: the ack handler releases the slot before it
+// settles the promise, so the successful start resumes to an empty slot and
+// must still clear the timeout it armed itself. `!sessionStartIsCurrent` here
+// would make every successful start believe it had been taken over.
+W.releaseSessionStart(ownerB);
+assert(S.sessionStartedResolver === null, 'slot is empty');
+assert(W.sessionStartSuperseded(ownerB) === false,
+       'an empty slot must not read as superseded');
+assert(W.sessionStartIsCurrent(ownerB) === false,
+       'and the released owner is no longer current -- the two differ here');
+
 console.log('HARNESS_OK');
 """
+
+# Both takeover guards resume from `await sessionStartPromise` and must decide
+# whether a newer start has taken the slot. Mode alone cannot tell: the
+# automatic restart claims 'audio' exactly like the mic button does.
+_MODE_TEST = "_pendingSessionStartMode !== 'audio'"
 
 
 def _run(script: str):
@@ -133,3 +172,36 @@ def test_a_superseded_flow_cannot_release_the_newer_starts_slot():
         f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     )
     assert "HARNESS_OK" in result.stdout
+
+
+@pytest.mark.unit
+def test_takeover_guards_ask_ownership_not_only_mode():
+    """Every "did someone take the slot?" guard must consult the owner token.
+
+    The harness above proves the predicate; this pins the call sites, which is
+    where the bug actually lived: both flows resumed from
+    ``await sessionStartPromise`` and tested only
+    ``_pendingSessionStartMode !== 'audio'``, so a newer AUDIO start (the
+    automatic reconnect restart claims 'audio' too) sailed through and the
+    superseded flow went on to cancel the newer start's 15s timeout.
+
+    Mutation-verified: drop ``sessionStartSuperseded`` from either guard and
+    this reddens naming that file and the surviving mode-only condition.
+    """
+    checked = 0
+    for path in START_FLOW_PATHS:
+        source = path.read_text(encoding="utf-8")
+        for match in re.finditer(re.escape(_MODE_TEST), source):
+            head = source[:match.start()]
+            condition_start = head.rfind("if (")
+            assert condition_start != -1, f"{path.name}: mode test outside any if()"
+            condition = source[condition_start:match.end()]
+            assert "sessionStartSuperseded" in condition, (
+                f"{path.name}: a takeover guard tests the pending mode without asking "
+                f"who owns the slot -- a newer AUDIO start passes it.\n{condition}"
+            )
+            checked += 1
+    assert checked >= 2, (
+        "expected the mic-button and automatic-restart takeover guards to be found; "
+        f"only {checked} matched -- has the guard been rewritten?"
+    )

--- a/tests/unit/test_voice_start_slot_ownership.py
+++ b/tests/unit/test_voice_start_slot_ownership.py
@@ -168,13 +168,16 @@ W.claimSessionStart('audio', () => {}, () => {});
 assert(W.supersededByAudioStart(ownerC) === true,
        'an audio takeover must suppress the global voice-start unwind');
 
+// A TEXT takeover with no audio start after us: nobody is driving the voice UI,
+// so the unwind must run and hand the mic button back.
+const ownerT = W.claimSessionStart('audio', () => {}, () => {});
 W.claimSessionStart('text', () => {}, () => {});
-assert(W.supersededByAudioStart(ownerC) === false,
+assert(W.supersededByAudioStart(ownerT) === false,
        'a TEXT takeover leaves the voice-start UI to us -- the unwind must still run');
 
 const ownerD = S.sessionStartedResolver;
 W.releaseSessionStart(ownerD);
-assert(W.supersededByAudioStart(ownerC) === false,
+assert(W.supersededByAudioStart(ownerT) === false,
        'a text takeover that has completed is still a text takeover -- unwind');
 
 // The mirror case, and the one the pending mode gets wrong: an AUDIO takeover
@@ -184,8 +187,21 @@ assert(W.supersededByAudioStart(ownerC) === false,
 W.claimSessionStart('audio', () => {}, () => {});
 W.releaseSessionStart(S.sessionStartedResolver);
 assert(S._pendingSessionStartMode === null, 'the pending mode is gone once released');
-assert(W.supersededByAudioStart(ownerC) === true,
+assert(W.supersededByAudioStart(ownerT) === true,
        'a completed AUDIO takeover must still suppress the global unwind');
+
+// And the one the LAST claim's mode gets wrong: an audio start still acquiring
+// its microphone, followed by a text send. The last claim is text, but the
+// audio start is alive and holding exactly the state the unwind destroys, so
+// the question is "did an audio start claim after me", not "what claimed last".
+const ownerE = W.claimSessionStart('audio', () => {}, () => {});
+const ownerF = W.claimSessionStart('audio', () => {}, () => {});
+W.claimSessionStart('text', () => {}, () => {});
+assert(S._lastSessionStartMode === 'text', 'the newest claim is the text one');
+assert(W.supersededByAudioStart(ownerE) === true,
+       'an audio start claimed after E and is still live -- E must not unwind');
+assert(W.supersededByAudioStart(ownerF) === false,
+       'only a text start came after F, which drives none of that state -- F unwinds');
 
 // --- the two signals abandon-detect different things -----------------------
 // A cancellation claims nothing, so the claim sequence never moves for it: a
@@ -224,6 +240,12 @@ assert(W.sessionStartSuperseded(null) === false,
        'with no owner token, "who holds it now" sees nothing at all');
 assert(W.sessionStartsSince(scheduledAt) === true,
        'the scheduling snapshot must still see the start that came and went');
+assert(W.audioStartsSince(scheduledAt) === false,
+       'and must not mistake that text start for a voice one');
+
+W.claimSessionStart('audio', () => {}, () => {});
+assert(W.audioStartsSince(scheduledAt) === true,
+       'an audio start after the snapshot must suppress the global unwind too');
 
 console.log('HARNESS_OK');
 """
@@ -384,7 +406,12 @@ def test_the_automatic_restart_stands_down_at_every_resumption_point():
     helper_body = _region(
         source, "function restartMustStandDown()", "try {", "app-websocket.js"
     )
-    for signal in ("sessionStartSuperseded", "voiceStartEpochIsCurrent", "sessionStartsSince"):
+    for signal in (
+        "sessionStartSuperseded",
+        "voiceStartEpochIsCurrent",
+        "sessionStartsSince",
+        "audioStartsSince",
+    ):
         assert signal in helper_body, (
             f"app-websocket.js: the restart's stand-down check ignores {signal}, so a "
             f"takeover it cannot see reaches the microphone.\n{helper_body}"

--- a/tests/unit/test_voice_start_slot_ownership.py
+++ b/tests/unit/test_voice_start_slot_ownership.py
@@ -457,6 +457,34 @@ def test_the_mic_flow_rechecks_cancellation_after_proactive_vision():
 
 
 @pytest.mark.unit
+def test_every_start_promise_has_a_handler_from_the_moment_it_exists():
+    """A takeover can settle a start before its flow reaches the await.
+
+    claimSessionStart rejects the start it displaces, and that can land while
+    the displaced flow is still inside ensureWebSocketOpen -- or before a
+    stand-down returns without ever awaiting at all. An unhandled rejected
+    promise raises ``unhandledrejection``, which the health diagnostics record
+    as a runtime error, for what is a routine takeover.
+
+    Mutation-verified: drop the handler from any claim site and this reddens
+    with the count for that file.
+    """
+    for path, claims in (("app-buttons.js", 3), ("app-websocket.js", 1)):
+        source = (_STATIC_APP / path).read_text(encoding="utf-8")
+        found = source.count("= window.claimSessionStart(")
+        assert found == claims, (
+            f"{path}: expected {claims} claim sites, found {found} -- if a flow was added "
+            "or removed, this case and its count need updating together."
+        )
+        handled = source.count("sessionStartPromise.catch(")
+        assert handled >= claims, (
+            f"{path}: {handled} of {claims} start promises have a rejection handler from "
+            "creation; the rest raise unhandledrejection when a takeover settles them "
+            "before their flow awaits."
+        )
+
+
+@pytest.mark.unit
 def test_a_displaced_start_is_abandoned_quietly_not_reported_as_a_failure():
     """Being taken over is the user's own next action, not a failure.
 

--- a/tests/unit/test_voice_start_slot_ownership.py
+++ b/tests/unit/test_voice_start_slot_ownership.py
@@ -209,6 +209,22 @@ assert(W.sessionStartSuperseded(ownerR) === false,
 assert(W.voiceStartEpochIsCurrent(restartEpoch) === false,
        'the epoch must know the user walked away');
 
+// --- a flow with no owner token yet still has a snapshot -------------------
+// The automatic restart sits in a 7.5s timer before it claims anything, and a
+// whole text session can start AND finish inside that window: its resolver is
+// gone by the time the restart looks, and text never mints an epoch. The claim
+// count taken when the restart was scheduled is the only thing that remembers.
+const scheduledAt = W.sessionStartClaimSeq();
+assert(W.sessionStartsSince(scheduledAt) === false, 'nothing has started yet');
+
+const ghost = W.claimSessionStart('text', () => {}, () => {});
+W.releaseSessionStart(ghost);
+assert(S.sessionStartedResolver === null, 'the text start finished and released');
+assert(W.sessionStartSuperseded(null) === false,
+       'with no owner token, "who holds it now" sees nothing at all');
+assert(W.sessionStartsSince(scheduledAt) === true,
+       'the scheduling snapshot must still see the start that came and went');
+
 console.log('HARNESS_OK');
 """
 
@@ -218,9 +234,14 @@ console.log('HARNESS_OK');
 _MODE_TEST = "_pendingSessionStartMode !== 'audio'"
 
 # file -> (stand-down check, how many points in that flow must call it)
+#
+# app-buttons.js:   after the start promise, after getUserMedia, after the
+#                   proactive-vision acquisition, and in the outer catch.
+# app-websocket.js: before the claim, after the start promise, after
+#                   showCurrentModel, after the capture awaits, and in the catch.
 STAND_DOWN_CHECKS = {
-    "app-buttons.js": ("micStartMustStandDown", 3),
-    "app-websocket.js": ("restartMustStandDown", 4),
+    "app-buttons.js": ("micStartMustStandDown", 4),
+    "app-websocket.js": ("restartMustStandDown", 5),
 }
 
 
@@ -363,7 +384,7 @@ def test_the_automatic_restart_stands_down_at_every_resumption_point():
     helper_body = _region(
         source, "function restartMustStandDown()", "try {", "app-websocket.js"
     )
-    for signal in ("sessionStartSuperseded", "voiceStartEpochIsCurrent"):
+    for signal in ("sessionStartSuperseded", "voiceStartEpochIsCurrent", "sessionStartsSince"):
         assert signal in helper_body, (
             f"app-websocket.js: the restart's stand-down check ignores {signal}, so a "
             f"takeover it cannot see reaches the microphone.\n{helper_body}"
@@ -380,26 +401,32 @@ def test_the_automatic_restart_stands_down_at_every_resumption_point():
 
 
 @pytest.mark.unit
-def test_the_restart_snapshots_its_epoch_before_the_delay():
+def test_the_restart_takes_both_snapshots_before_the_delay():
     """Snapshot when the restart is DECIDED, not 7.5s later inside the callback.
 
-    A goodbye or avatar drop during the delay bumps the epoch through
-    cancelPendingSessionStart. A snapshot taken inside the callback reads that
-    cancellation as its own starting point, so every check against it passes and
-    the restart proceeds against a user who has already walked away.
+    Both signals, because the delay is long enough for either kind of event: a
+    goodbye or avatar drop bumps the epoch through cancelPendingSessionStart,
+    and a whole text session can be started and finished, which moves only the
+    claim count. A snapshot taken inside the callback reads whatever happened
+    during the delay as its own starting point, so every later check passes and
+    the restart proceeds against a user who has already moved on.
 
-    Mutation-verified: move the snapshot inside the callback and this reddens.
+    Mutation-verified: move either snapshot inside the callback and this reddens.
     """
     source = (_STATIC_APP / "app-websocket.js").read_text(encoding="utf-8")
-    snapshot = source.find("var restartVoiceEpoch = S.voiceSessionStartEpoch;")
-    assert snapshot != -1, "the automatic restart no longer snapshots the intent epoch"
     helper = source.find("function restartMustStandDown()")
     assert helper != -1, "the automatic restart's stand-down check has been renamed"
     scheduled = source.rfind("setTimeout(async function ()", 0, helper)
     assert scheduled != -1, "the automatic restart is no longer scheduled on a timer"
 
-    assert snapshot < scheduled, (
-        "app-websocket.js: the epoch snapshot sits inside the delayed callback, so a "
-        "cancellation during the delay becomes its own baseline and every check "
-        "against it passes."
-    )
+    for what, marker in (
+        ("intent epoch", "var restartVoiceEpoch = S.voiceSessionStartEpoch;"),
+        ("claim sequence", "var restartClaimSeq = window.sessionStartClaimSeq();"),
+    ):
+        snapshot = source.find(marker)
+        assert snapshot != -1, f"the automatic restart no longer snapshots the {what}"
+        assert snapshot < scheduled, (
+            f"app-websocket.js: the {what} snapshot sits inside the delayed callback, so "
+            "whatever happened during the delay becomes its own baseline and every check "
+            "against it passes."
+        )

--- a/tests/unit/test_voice_start_slot_ownership.py
+++ b/tests/unit/test_voice_start_slot_ownership.py
@@ -49,18 +49,28 @@ function assert(cond, msg) {
 }
 
 // app-state.js is a large IIFE with browser dependencies; the ownership helpers
-// are self-contained, so lift just those out and run them against a stub S.
+// and the cancel lever they are defined against are self-contained, so lift
+// just that section out and run it against a stub S. cancelPendingSessionStart
+// comes along deliberately: the epoch property below is about how the two
+// interact, and reimplementing the lever here would test nothing.
 const source = fs.readFileSync(__APP_STATE_PATH__, 'utf8');
 const start = source.indexOf('window.claimSessionStart = function');
-const end = source.indexOf('window.cancelPendingSessionStart = function');
+const end = source.indexOf('// ======================== 工具函数');
 assert(start > 0 && end > start, 'could not locate the ownership helpers');
 
 const S = {
   sessionStartedResolver: null,
   sessionStartedRejecter: null,
   _pendingSessionStartMode: null,
+  voiceSessionStartEpoch: 0,
+  voiceStartPending: false,
 };
-const sandbox = { S, window: {}, console: { log() {}, warn() {} } };
+const sandbox = {
+  S,
+  window: { makeNekoSessionAbortError: (reason) => new Error(reason) },
+  clearTimeout: () => {},
+  console: { log() {}, warn() {} },
+};
 vm.createContext(sandbox);
 vm.runInContext(source.slice(start, end), sandbox, { filename: 'app-state-helpers.js' });
 const W = sandbox.window;
@@ -135,6 +145,53 @@ assert(W.sessionStartSuperseded(ownerB) === false,
 assert(W.sessionStartIsCurrent(ownerB) === false,
        'and the released owner is no longer current -- the two differ here');
 
+// --- who superseded us decides whether the GLOBAL unwind may run -----------
+// abortVoiceStartForBlockedRoute bumps the mic generation and clears
+// window.isMicStarting. A newer AUDIO start is sitting on exactly that state
+// inside getUserMedia, so unwinding there makes it abandon capture and fail
+// its own ensureVoiceStartCurrent -- a session the backend accepted, with the
+// microphone closed. A newer TEXT start touches none of it and would instead
+// be left with a stranded voice-start UI, so there the unwind must still run.
+const audioC = () => {};
+const ownerC = W.claimSessionStart('audio', audioC, () => {});
+assert(W.supersededByAudioStart(ownerC) === false,
+       'the start holding the slot was superseded by nobody');
+
+W.claimSessionStart('audio', () => {}, () => {});
+assert(W.supersededByAudioStart(ownerC) === true,
+       'an audio takeover must suppress the global voice-start unwind');
+
+W.claimSessionStart('text', () => {}, () => {});
+assert(W.supersededByAudioStart(ownerC) === false,
+       'a TEXT takeover leaves the voice-start UI to us -- the unwind must still run');
+
+const ownerD = S.sessionStartedResolver;
+W.releaseSessionStart(ownerD);
+assert(W.supersededByAudioStart(ownerC) === false,
+       'an empty slot means nobody is driving the UI -- the unwind must still run');
+
+// --- the epoch sees the ABA that ownership cannot --------------------------
+// The automatic restart has no ensureVoiceStartCurrent of its own, so this is
+// the only signal standing between it and reopening the microphone after the
+// user has walked away.
+S.voiceSessionStartEpoch = 7;
+const restartEpoch = S.voiceSessionStartEpoch;
+const ownerR = W.claimSessionStart('audio', () => {}, () => {});
+assert(W.voiceStartEpochIsCurrent(restartEpoch) === true,
+       'claiming the slot does not by itself move the intent epoch');
+
+// A newer start claims inside the ack's deferred window, and then the user
+// walks away: goodbye / avatar drop / character switch go through
+// cancelPendingSessionStart, which clears the slot outright. Ownership is back
+// to EMPTY -- byte for byte what "my own ack released it" looks like.
+W.claimSessionStart('audio', () => {}, () => {});
+W.cancelPendingSessionStart('goodbye');
+assert(S.sessionStartedResolver === null, 'the cancel lever cleared the slot');
+assert(W.sessionStartSuperseded(ownerR) === false,
+       'ownership alone cannot see the ABA -- that blind spot is the point');
+assert(W.voiceStartEpochIsCurrent(restartEpoch) === false,
+       'the epoch must still know the user moved on');
+
 console.log('HARNESS_OK');
 """
 
@@ -204,4 +261,89 @@ def test_takeover_guards_ask_ownership_not_only_mode():
     assert checked >= 2, (
         "expected the mic-button and automatic-restart takeover guards to be found; "
         f"only {checked} matched -- has the guard been rewritten?"
+    )
+
+
+@pytest.mark.unit
+def test_takeover_branches_do_not_unwind_under_a_newer_audio_start():
+    """The global voice-start unwind must be gated on WHO took the slot.
+
+    ``abortVoiceStartForBlockedRoute`` bumps the mic generation and clears
+    ``window.isMicStarting``. Making the takeover branches ownership-aware is
+    what made "a newer AUDIO start took over" reachable at all, and that is
+    precisely the case where the unwind lands on a start still inside
+    getUserMedia: it abandons capture and then fails its own
+    ``ensureVoiceStartCurrent``, leaving a session the backend accepted with no
+    microphone.
+
+    Mutation-verified: drop the ``supersededByAudioStart`` gate from either
+    branch and this reddens naming that file.
+    """
+    checked = 0
+    for path in START_FLOW_PATHS:
+        source = path.read_text(encoding="utf-8")
+        for match in re.finditer(re.escape(_MODE_TEST), source):
+            branch_end = source.find("return;", match.end())
+            assert branch_end != -1, f"{path.name}: takeover branch has no return"
+            branch = source[match.end():branch_end]
+            if "abortVoiceStartForBlockedRoute" not in branch:
+                continue
+            assert "supersededByAudioStart" in branch, (
+                f"{path.name}: the takeover branch runs the global voice-start unwind "
+                "without checking whether a newer AUDIO start is driving that very "
+                f"state.\n{branch}"
+            )
+            checked += 1
+    assert checked >= 2, (
+        "expected both takeover branches to reach the unwind; "
+        f"only {checked} matched -- has the branch been rewritten?"
+    )
+
+
+@pytest.mark.unit
+def test_a_superseded_mic_start_does_not_run_its_failure_cleanup():
+    """A failed start that no longer owns the slot must not end the session.
+
+    Gating the slot was never enough: the mic handler's failure cleanup also
+    sends ``end_session``, calls ``stopRecording`` and rewrites the button row,
+    and by then those land on whichever start took over.
+
+    Mutation-verified: remove the superseded early-return and this reddens.
+    """
+    source = (_STATIC_APP / "app-buttons.js").read_text(encoding="utf-8")
+    anchor = source.find("var micStartStillOurs")
+    assert anchor != -1, "the mic handler's failure cleanup has been rewritten"
+    end_session = source.find("action: 'end_session'", anchor)
+    assert end_session != -1, "expected the failure cleanup to send end_session"
+
+    guard_region = source[anchor:end_session]
+    assert "sessionStartSuperseded" in guard_region and "return;" in guard_region, (
+        "app-buttons.js: the mic start's failure cleanup reaches end_session without "
+        "first bailing out when a newer start owns the slot -- it would tear down "
+        f"that start's session.\n{guard_region}"
+    )
+
+
+@pytest.mark.unit
+def test_the_automatic_restart_rechecks_the_voice_start_epoch():
+    """The restart flow needs the epoch, because ownership cannot see an ABA.
+
+    A newer start can claim inside the ack's 500ms window and then be cancelled,
+    putting the slot back to EMPTY -- which ownership reads as "mine was
+    released normally". This flow has no ensureVoiceStartCurrent, so the epoch
+    is the only thing left between it and reopening the mic after a goodbye.
+
+    Mutation-verified: drop either epoch check and this reddens.
+    """
+    source = (_STATIC_APP / "app-websocket.js").read_text(encoding="utf-8")
+    resumed = source.find("await sessionStartPromise;")
+    assert resumed != -1, "the automatic restart no longer awaits its start promise"
+    opens_mic = source.find("window.startMicCapture()", resumed)
+    assert opens_mic != -1, "the automatic restart no longer opens the mic"
+
+    resumption = source[resumed:opens_mic]
+    assert resumption.count("voiceStartEpochIsCurrent") >= 2, (
+        "app-websocket.js: the automatic restart resumes and opens the microphone "
+        "without re-checking the voice-start intent epoch on both sides of its "
+        f"showCurrentModel await.\n{resumption}"
     )

--- a/tests/unit/test_voice_start_slot_ownership.py
+++ b/tests/unit/test_voice_start_slot_ownership.py
@@ -283,7 +283,7 @@ def test_takeover_branches_do_not_unwind_under_a_newer_audio_start():
     for path in START_FLOW_PATHS:
         source = path.read_text(encoding="utf-8")
         for match in re.finditer(re.escape(_MODE_TEST), source):
-            branch_end = source.find("return;", match.end())
+            branch_end = source.find("return", match.end())
             assert branch_end != -1, f"{path.name}: takeover branch has no return"
             branch = source[match.end():branch_end]
             if "abortVoiceStartForBlockedRoute" not in branch:
@@ -325,25 +325,62 @@ def test_a_superseded_mic_start_does_not_run_its_failure_cleanup():
 
 
 @pytest.mark.unit
-def test_the_automatic_restart_rechecks_the_voice_start_epoch():
-    """The restart flow needs the epoch, because ownership cannot see an ABA.
+def test_the_automatic_restart_stands_down_at_every_resumption_point():
+    """Each await this flow resumes from must ask the WHOLE question.
 
-    A newer start can claim inside the ack's 500ms window and then be cancelled,
-    putting the slot back to EMPTY -- which ownership reads as "mine was
-    released normally". This flow has no ensureVoiceStartCurrent, so the epoch
-    is the only thing left between it and reopening the mic after a goodbye.
+    Neither half is sufficient alone, and asking only one is how this bug kept
+    coming back: ownership cannot see a cancel-and-clear (the slot is back to
+    empty, exactly like a normal release), and the epoch cannot see a TEXT
+    takeover (text starts never mint one, and the disconnect path leaves the
+    mobile composer live throughout the showCurrentModel await).
 
-    Mutation-verified: drop either epoch check and this reddens.
+    Mutation-verified: drop either stand-down call, or either half of the
+    predicate, and this reddens.
     """
     source = (_STATIC_APP / "app-websocket.js").read_text(encoding="utf-8")
-    resumed = source.find("await sessionStartPromise;")
+    helper = source.find("function restartMustStandDown()")
+    assert helper != -1, "the automatic restart's stand-down check has been renamed"
+    helper_body = source[helper:source.find("try {", helper)]
+    for signal in ("sessionStartSuperseded", "voiceStartEpochIsCurrent"):
+        assert signal in helper_body, (
+            f"app-websocket.js: the restart's stand-down check ignores {signal}, so a "
+            f"takeover it cannot see reaches the microphone.\n{helper_body}"
+        )
+
+    resumed = source.find("await sessionStartPromise;", helper)
     assert resumed != -1, "the automatic restart no longer awaits its start promise"
     opens_mic = source.find("window.startMicCapture()", resumed)
     assert opens_mic != -1, "the automatic restart no longer opens the mic"
 
     resumption = source[resumed:opens_mic]
-    assert resumption.count("voiceStartEpochIsCurrent") >= 2, (
-        "app-websocket.js: the automatic restart resumes and opens the microphone "
-        "without re-checking the voice-start intent epoch on both sides of its "
-        f"showCurrentModel await.\n{resumption}"
+    assert resumption.count("restartMustStandDown()") >= 2, (
+        "app-websocket.js: the automatic restart resumes twice before opening the "
+        "microphone -- from its start promise and from showCurrentModel -- and must "
+        f"stand down at both.\n{resumption}"
+    )
+
+
+@pytest.mark.unit
+def test_the_restart_snapshots_its_epoch_before_the_delay():
+    """Snapshot when the restart is DECIDED, not 7.5s later inside the callback.
+
+    A goodbye or avatar drop during the delay bumps the epoch through
+    cancelPendingSessionStart. A snapshot taken inside the callback reads that
+    cancellation as its own starting point, so every check against it passes and
+    the restart proceeds against a user who has already walked away.
+
+    Mutation-verified: move the snapshot inside the callback and this reddens.
+    """
+    source = (_STATIC_APP / "app-websocket.js").read_text(encoding="utf-8")
+    snapshot = source.find("var restartVoiceEpoch = S.voiceSessionStartEpoch;")
+    assert snapshot != -1, "the automatic restart no longer snapshots the intent epoch"
+    helper = source.find("function restartMustStandDown()")
+    assert helper != -1, "the automatic restart's stand-down check has been renamed"
+    scheduled = source.rfind("setTimeout(async function ()", 0, helper)
+    assert scheduled != -1, "the automatic restart is no longer scheduled on a timer"
+
+    assert snapshot < scheduled, (
+        "app-websocket.js: the epoch snapshot sits inside the delayed callback, so a "
+        "cancellation during the delay becomes its own baseline and every check "
+        "against it passes."
     )

--- a/tests/unit/test_voice_start_slot_ownership.py
+++ b/tests/unit/test_voice_start_slot_ownership.py
@@ -430,6 +430,38 @@ def test_the_mic_flow_rechecks_cancellation_after_proactive_vision():
 
 
 @pytest.mark.unit
+def test_a_displaced_start_still_settles_its_own_promise():
+    """Refusing to fire is not the same as having nothing to do.
+
+    A start that loses the slot has its acknowledgement dropped by the
+    cross-mode guard in the session_started handler, so its own timeout is the
+    only thing left that can settle it. Returning early there -- correct about
+    the shared state -- left the flow suspended forever at
+    ``await sessionStartPromise``, holding ``window.isMicStarting`` and an
+    active/disabled mic button straight through the session that took over. It
+    keeps its own rejecter precisely because ``S.sessionStartedRejecter`` is the
+    newer start's by then.
+
+    Mutation-verified: drop the rejecter call from either timeout and this
+    reddens naming that file.
+    """
+    for path in START_FLOW_PATHS:
+        source = path.read_text(encoding="utf-8")
+        branch = _region(
+            source, "if (!window.sessionStartIsCurrent(", "return;", path.name
+        )
+        assert "Rejecter(" in branch, (
+            f"{path.name}: the timeout of a displaced start returns without settling its "
+            "own promise, so that flow never resumes and never releases the voice-start "
+            f"UI.\n{branch}"
+        )
+        assert "window.sessionTimeoutId = null" not in branch, (
+            f"{path.name}: a displaced start must not clear the shared timer handle -- it "
+            f"belongs to the start that displaced it.\n{branch}"
+        )
+
+
+@pytest.mark.unit
 def test_the_mic_failure_cleanup_stands_down_before_ending_the_session():
     """A failed start that was superseded must not end the winner's session.
 

--- a/tests/unit/test_voice_start_slot_ownership.py
+++ b/tests/unit/test_voice_start_slot_ownership.py
@@ -27,7 +27,6 @@ no-op.
 """
 
 import json
-import re
 import shutil
 import textwrap
 from pathlib import Path


### PR DESCRIPTION
Follow-up to #2552 — addresses the one review comment that was still open when it merged ([greptile P1](https://github.com/Project-N-E-K-O/N.E.K.O/pull/2552#discussion_r3673482336)).

## 原本啥样

#2552 给共享的 voice-start 槽位加了 owner，但两处「我 await 的时候有没有人把槽位抢走」的守卫仍然只问 `_pendingSessionStartMode !== 'audio'`。这个判据看不见**更新的 audio 启动**——而它真实存在：app-websocket.js 里 CHARACTER_DISCONNECTED 的自动重启 claim 的也是 `'audio'`。

窗口是 ack 的 500ms 延迟 resolve：`session_started` 一到就先拆掉 15s 超时，然后把 resolve 推迟；若这段窗口内新启动占了槽位并装上自己的 timer，延迟 resolve 仍会 settle 旧 promise（这是设计——旧 promise 的超时已经没了，不 settle 就永远挂着）。麦克风流程随后恢复，mode 检查看到 `'audio'` 分不出是谁的，直接走成功清理，**把新启动的超时 timer 取消掉**。新启动此时既没等到 ack 也没了兜底 timer，永久 pending。

## 改法

- `app-state.js` 新增 `sessionStartSuperseded(owner)`。它**故意不是** `sessionStartIsCurrent` 的取反：空槽位不算被抢。正常成功路径是 ack handler 先释放槽位再 settle promise，所以成功的启动恢复时看到的就是空槽位，它必须继续清掉自己装的 timer；用 `!sessionStartIsCurrent` 会让每个成功启动都误判成被抢。
- 两处 takeover 守卫改成先问 ownership。mode 判据保留成 OR 而不是替换掉——两者互不包含：app-websocket.js 的断线清理会把 resolver 置空但留着 `_pendingSessionStartMode`。
- 麦克风流程的内层 catch 同样加闸：失败发生在新启动占位之后时（`startMicCapture` 因 getUserMedia 被拒而 reject 是最容易的入口），原来也会清掉那个 timer。

每处闸门只可能**拒绝**清别人的 timer，保持 #2552 立下的单调安全性质。

## 测试

沿用已有的 node harness，补上 identity-vs-mode、空槽位不算被抢两条性质，外加一条调用点检查（防止守卫再退回 mode-only）。三向变异验证：

- 谓词写成 `!sessionStartIsCurrent` → 红在 "an empty slot must not read as superseded"
- 谓词写成 mode 判据 → 红在 "an audio start superseded by another audio start must still know it"
- 任一调用点退回 mode-only → 守卫测试红，并点名文件

```
uv run pytest tests/unit/test_voice_start_slot_ownership.py
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 改善语音启动与自动重启在并发接管场景下的处理，避免旧流程误关闭新会话或重置界面。
  - 防止麦克风启动失败时错误取消新会话的超时计时器。
  - 减少延迟回调导致的过期语音启动，提升会话稳定性。

- **测试**
  - 扩展并发启动、会话接管、失败清理及自动重启相关测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->