### PR TITLE
修复自定义 TTS 音色映射、优先级与失败保底

### DIFF
--- a/main_logic/core/__init__.py
+++ b/main_logic/core/__init__.py
@@ -62,6 +62,9 @@ from main_logic.omni_offline_client import OmniOfflineClient, _is_safety_violati
 from main_logic.tts_client import (
     get_tts_worker,
     dummy_tts_worker,
+    selected_configured_tts_preset_provider_key,
+    tts_provider_falls_back_on_failure,
+    tts_provider_uses_configured_preset_voice,
     TTS_PROVIDER_REGISTRY,
     VLLM_OMNI_DEFAULT_BASE_URL,
     VLLM_OMNI_DEFAULT_MODEL,

--- a/main_logic/core/lifecycle.py
+++ b/main_logic/core/lifecycle.py
@@ -1085,6 +1085,9 @@ class LifecycleMixin:
         async with self.tts_cache_lock:
             self.tts_ready = preserve_tts_ready
             self.tts_pending_chunks.clear()
+            # Session replacement invalidates the previous utterance replay ledger.
+            # 新会话不得继承上一轮的 TTS 回放文本或结束信号。
+            self._reset_tts_replay_state()
 
         # 重置输入缓存状态
         async with self.input_cache_lock:
@@ -1198,6 +1201,12 @@ class LifecycleMixin:
                     logger.warning(f"[语音会话诊断] TTS 在 {timeout} 秒内未就绪，可能为 TTS 服务慢或网络问题")
                 else:
                     logger.error("❌ TTS进程初始化失败，但继续执行...")
+
+                # The replacement worker writes readiness to a fresh queue;
+                # the handler created below will consume it and flush pending text.
+                # 自定义端点启动失败时先切保底，下面的新 handler 会接管新队列。
+                if self._activate_configured_tts_fallback("会话启动"):
+                    logger.info("🔄 自定义 TTS API 启动失败，已启动既有保底 worker")
         else:
             # TTS线程已存活，复用现有线程；保留上次的就绪状态（避免失败的 worker 被误标为就绪）
             tts_ready = self.tts_ready

--- a/main_logic/core/manager.py
+++ b/main_logic/core/manager.py
@@ -80,6 +80,11 @@ class LLMSessionManager(
         self.tts_response_queue = Queue()  # TTS response (线程队列)
         self.tts_thread = None  # TTS线程
         self._tts_runtime_key = None
+        # Runtime fallback excludes only providers that failed in this session;
+        # the remaining dispatcher order is never rewritten.
+        # 运行时保底只排除本场失败的 provider，其余调度顺序保持不变。
+        self._tts_active_provider_key: Optional[str] = None
+        self._tts_excluded_provider_keys: frozenset[str] = frozenset()
         # 跨 chunk 规范化器：Gemini Live 输出转录会在中文 token 之间插入 ASCII
         # 空格，让 MiniMax / CosyVoice 等 streaming TTS 把中文读断。normalizer
         # 按 replace_blank 的语义剔除空格，同时延后处理 chunk 尾部空格以保证边界正确。
@@ -280,6 +285,21 @@ class LLMSessionManager(
         self._tts_retry_notify_count: int = 0  # TTS 重试通知计数，前3次不通知前端
         self._tts_done_queued_for_turn: bool = False  # 防止同一轮次多次排入 TTS 结束信号
         self._tts_done_pending_until_ready: bool = False  # TTS未就绪时延迟到 flush 后再排入结束信号
+        # Keep one utterance ledger so a replacement worker can replay consumed text.
+        # 已送入当前 worker 的原始文本账本。配置型 provider 运行时失败时，
+        # 用它把本轮文本与 done 信号交给替代 worker，避免整段回复静音。
+        self._tts_replay_speech_id: Optional[str] = None
+        self._tts_replay_chunks: list[tuple[Optional[str], str]] = []
+        # HTTP 分句 worker 回报已完成/失败的句界后，只保留尚未播出的规范化文本。
+        self._tts_replay_sent_chunks: list[tuple[Optional[str], str]] = []
+        self._tts_replay_done: bool = False
+        self._tts_replay_audio_emitted: bool = False
+        self._tts_replay_sentence_audio_emitted: bool = False
+        self._tts_replay_progress_supported: bool = False
+        # A failed configured preset must not leak its identity into legacy clone routing.
+        # 配置型 preset 失败后，本会话保留角色配置，但替代 worker 使用默认音色，
+        # 防止把该 Voice ID 和自定义凭证误送给 CosyVoice 等无关 provider。
+        self._tts_fallback_uses_default_voice: bool = False
         self._active_text_request_id: Optional[str] = None
         self._magic_command_image_drop_request_ids: set[str] = set()
         self._magic_command_image_drop_request_order: deque[str] = deque()

--- a/main_logic/core/tts_runtime.py
+++ b/main_logic/core/tts_runtime.py
@@ -79,6 +79,46 @@ class TtsRuntimeMixin:
         except Exception:
             return 300
 
+    def _reset_tts_replay_state(self) -> None:
+        """Forget text retained for configured-provider runtime recovery."""
+        self._tts_replay_speech_id = None
+        self._tts_replay_chunks = []
+        self._tts_replay_sent_chunks = []
+        self._tts_replay_done = False
+        self._tts_replay_audio_emitted = False
+        self._tts_replay_sentence_audio_emitted = False
+
+    def _remember_tts_replay_chunk(self, speech_id, text: str) -> None:
+        """Retain one raw text chunk until the active utterance is replaced."""
+        if speech_id != getattr(self, "_tts_replay_speech_id", None):
+            self._reset_tts_replay_state()
+            self._tts_replay_speech_id = speech_id
+        if text:
+            self._tts_replay_chunks.append((speech_id, text))
+
+    def _remember_tts_sent_chunk(self, speech_id, text: str) -> None:
+        """Retain text actually submitted to a sentence-aware worker."""
+        if speech_id == getattr(self, "_tts_replay_speech_id", None) and text:
+            self._tts_replay_sent_chunks.append((speech_id, text))
+
+    def _consume_tts_replay_sentence(self, speech_id, sentence: str) -> None:
+        """Remove one confirmed audible sentence from the fallback suffix."""
+        if speech_id != getattr(self, "_tts_replay_speech_id", None) or not sentence:
+            return
+        remaining = "".join(
+            text
+            for sid, text in getattr(self, "_tts_replay_sent_chunks", ())
+            if sid == speech_id
+        )
+        if not remaining.startswith(sentence):
+            # 边界不一致时宁可保留文本，也不能误删尚未播出的内容。
+            logger.warning("TTS 回放句界不匹配，保留现有未确认文本")
+            return
+        remaining = remaining[len(sentence):]
+        self._tts_replay_sent_chunks = (
+            [(speech_id, remaining)] if remaining else []
+        )
+
     def _enqueue_tts_text_chunk(self, speech_id, text: str) -> None:
         """Enqueue a text chunk into the TTS queue; http_sentence-class providers go through the normalizer.
 
@@ -92,6 +132,10 @@ class TtsRuntimeMixin:
         ``tts_request_queue.put``, calling ``_reset_tts_stream_normalizer`` at the
         appropriate moment.
         """
+        # Retain pre-normalized text because the replacement may use another protocol class.
+        # 保留规范化前的原始文本；替代 worker 可能属于另一协议类别，需要从原文重放。
+        self._remember_tts_replay_chunk(speech_id, text)
+
         # speech_id 切换时重置所有 stripper 状态（pending 内容属于上一轮，丢弃）
         if speech_id != self._tts_norm_speech_id:
             self._tts_stream_normalizer.reset()
@@ -111,6 +155,7 @@ class TtsRuntimeMixin:
         if not text:
             return
         self.tts_request_queue.put((speech_id, text))
+        self._remember_tts_sent_chunk(speech_id, text)
         self._remember_pending_ai_voice_echo(speech_id, text)
 
     def _reset_tts_stream_normalizer(self) -> None:
@@ -136,6 +181,7 @@ class TtsRuntimeMixin:
             return "no_worker"
 
         if not self.tts_ready or self.tts_pending_chunks:
+            self._tts_replay_done = True
             self._tts_done_pending_until_ready = True
             return "deferred"
 
@@ -150,9 +196,11 @@ class TtsRuntimeMixin:
         self._tts_bracket_stripper.flush()
         if flushed and self._tts_norm_speech_id is not None:
             self.tts_request_queue.put((self._tts_norm_speech_id, flushed))
+            self._remember_tts_sent_chunk(self._tts_norm_speech_id, flushed)
             self._remember_pending_ai_voice_echo(self._tts_norm_speech_id, flushed)
 
         self.tts_request_queue.put((None, None))
+        self._tts_replay_done = True
         self._tts_done_queued_for_turn = True
         self._tts_done_pending_until_ready = False
         return "queued"
@@ -232,11 +280,14 @@ class TtsRuntimeMixin:
             core_config = self._config_manager.get_core_config()
             if core_config.get('DISABLE_TTS', False):
                 return ("disabled",)
-            has_custom = self._has_custom_tts()
+            route_voice_id, has_custom = self._effective_tts_route()
             _, api_key_override, provider_key = _core_facade.get_tts_worker(
                 core_api_type=self.core_api_type,
                 has_custom_voice=has_custom,
-                voice_id=self.voice_id or '',
+                voice_id=route_voice_id,
+                excluded_provider_keys=getattr(
+                    self, "_tts_excluded_provider_keys", frozenset()
+                ),
             )
             tts_config = self._config_manager.get_model_api_config(
                 'tts_custom' if has_custom else 'tts_default'
@@ -245,13 +296,14 @@ class TtsRuntimeMixin:
             return (
                 provider_key,
                 self.core_api_type,
-                self.voice_id or '',
+                route_voice_id,
                 bool(getattr(self, "_is_free_preset_voice", False)),
                 bool(has_custom),
                 tts_config.get('base_url', ''),
                 tts_config.get('model', ''),
                 self._resolve_vllm_omni_runtime_config(core_config),
                 api_key,
+                tuple(sorted(getattr(self, "_tts_excluded_provider_keys", frozenset()))),
             )
         except Exception:
             return (
@@ -292,6 +344,7 @@ class TtsRuntimeMixin:
         async with self.tts_cache_lock:
             self.tts_pending_chunks.clear()
             self._tts_done_pending_until_ready = False
+            self._reset_tts_replay_state()
             # Drop only queued-but-unconfirmed TTS text. Already-confirmed
             # audio may still be echoed by STT shortly after an interrupt.
             self._discard_pending_ai_voice_echo()
@@ -315,7 +368,11 @@ class TtsRuntimeMixin:
         ``tts_ready`` flips).
         """
         if not (self.tts_thread and self.tts_thread.is_alive()):
-            self._start_tts_thread()
+            self._start_tts_thread(
+                preserve_provider_exclusions=bool(
+                    getattr(self, "_tts_excluded_provider_keys", frozenset())
+                )
+            )
         if self.tts_handler_task is None or self.tts_handler_task.done():
             self.tts_handler_task = asyncio.create_task(self.tts_response_handler())
 
@@ -350,7 +407,16 @@ class TtsRuntimeMixin:
             return True
         return False
 
-    def _start_tts_thread(self):
+    def _effective_tts_route(self) -> tuple[str, bool]:
+        """Return the voice identity and custom flag used for worker dispatch."""
+        # Recovery keeps character storage unchanged but strips the failed preset
+        # from the replacement worker's routing and credential context.
+        # 回退只清理替代 worker 的路由上下文，不修改角色卡中保存的音色。
+        if getattr(self, "_tts_fallback_uses_default_voice", False):
+            return "", False
+        return self.voice_id or "", self._has_custom_tts()
+
+    def _start_tts_thread(self, *, preserve_provider_exclusions: bool = False):
         """Create and start the TTS worker thread.
 
         Selects the worker by voice_id / core_api_type, resolves the api_key,
@@ -361,9 +427,13 @@ class TtsRuntimeMixin:
         # 重置就绪状态，新 worker 需重新握手
         self.tts_ready = False
         self._tts_runtime_key = None
+        if not preserve_provider_exclusions:
+            self._tts_excluded_provider_keys = frozenset()
+            self._tts_fallback_uses_default_voice = False
 
         # 检查是否禁用了 TTS
         core_config = self._config_manager.get_core_config()
+        route_voice_id = self.voice_id or ''
         if core_config.get('DISABLE_TTS', False):
             logger.info("TTS 已被用户禁用, 使用 dummy worker")
             tts_worker = dummy_tts_worker
@@ -371,11 +441,12 @@ class TtsRuntimeMixin:
             provider_key = None
             api_key = ''
         else:
-            has_custom = self._has_custom_tts()
+            route_voice_id, has_custom = self._effective_tts_route()
             tts_worker, api_key_override, provider_key = _core_facade.get_tts_worker(
                 core_api_type=self.core_api_type,
                 has_custom_voice=has_custom,
-                voice_id=self.voice_id or '',
+                voice_id=route_voice_id,
+                excluded_provider_keys=self._tts_excluded_provider_keys,
             )
             tts_config = self._config_manager.get_model_api_config(
                 'tts_custom' if has_custom else 'tts_default'
@@ -391,17 +462,114 @@ class TtsRuntimeMixin:
         # 因为 free 国外模式走 Gemini 后端，需要 CJK 空格清理。
         meta = TTS_PROVIDER_REGISTRY.get(provider_key) if provider_key else None
         self._tts_normalize_enabled = not meta or meta.category != "ws_bistream"
+        self._tts_replay_progress_supported = bool(
+            meta and meta.category == "http_sentence"
+        )
 
         self.tts_request_queue = Queue()
         self.tts_response_queue = Queue()
 
         self.tts_thread = Thread(
             target=tts_worker,
-            args=(self.tts_request_queue, self.tts_response_queue, api_key, self.voice_id),
+            args=(self.tts_request_queue, self.tts_response_queue, api_key, route_voice_id),
             daemon=True,
         )
+        self._tts_active_provider_key = provider_key
         self._tts_runtime_key = self._build_tts_runtime_key()
         self.tts_thread.start()
+
+    def _activate_configured_tts_fallback(self, failure_stage: str) -> bool:
+        """Exclude a failed configured provider and restart with existing order."""
+        failed_provider = getattr(self, "_tts_active_provider_key", None)
+        if not _core_facade.tts_provider_falls_back_on_failure(failed_provider):
+            return False
+
+        excluded = frozenset(getattr(self, "_tts_excluded_provider_keys", frozenset()))
+        if failed_provider in excluded:
+            return False
+
+        # The ledger is authoritative after response.done: some realtime paths
+        # rotate ``current_speech_id`` before trailing TTS audio has finished.
+        # 回复流结束时 current_speech_id 可能已提前轮换；旧 worker 的尾音仍在处理，
+        # 因此优先使用账本中的 speech_id，避免恰在收尾失败时漏掉整轮重放。
+        active_speech_id = getattr(self, "_tts_replay_speech_id", None)
+        if active_speech_id is None:
+            active_speech_id = getattr(self, "current_speech_id", None)
+
+        # Only replay the active utterance. A new turn can be cached while a late
+        # error from the superseded worker is still arriving on the old queue.
+        # 只重放当前轮次，避免旧 worker 的迟到错误把上一轮文本带进新回复。
+        replay_chunks = [
+            item
+            for item in getattr(self, "_tts_replay_chunks", ())
+            if active_speech_id is None or item[0] == active_speech_id
+        ]
+        pending_chunks = [
+            item
+            for item in getattr(self, "tts_pending_chunks", ())
+            if active_speech_id is None or item[0] == active_speech_id
+        ]
+        replay_done = bool(
+            getattr(self, "_tts_replay_done", False)
+            or getattr(self, "_tts_done_queued_for_turn", False)
+            or getattr(self, "_tts_done_pending_until_ready", False)
+        )
+        audio_emitted = bool(getattr(self, "_tts_replay_audio_emitted", False))
+        if audio_emitted:
+            if getattr(self, "_tts_replay_progress_supported", False):
+                # HTTP 分句 worker 会逐句确认进度：已播句从该账本删除，失败句若
+                # 已输出部分音频也只跳过本句，后续完整句仍交给保底 provider。
+                replay_chunks = [
+                    item
+                    for item in getattr(self, "_tts_replay_sent_chunks", ())
+                    if active_speech_id is None or item[0] == active_speech_id
+                ]
+                replay_done = bool((replay_chunks or pending_chunks) and replay_done)
+                logger.warning(
+                    "自定义 TTS API 已输出部分音频，仅重放未确认的后续文本"
+                )
+            else:
+                # WS 双流协议没有文本到音频位置确认，不能安全推导精确后缀。
+                replay_chunks = []
+                replay_done = bool(pending_chunks and replay_done)
+                logger.warning(
+                    "自定义 TTS API 已输出部分音频，跳过当前句重放以避免重复播报"
+                )
+
+        # Excluding one failed provider lets get_tts_worker reuse every existing
+        # fallback rule below it; no fallback provider or priority is hardcoded.
+        # 这里只排除失败项，再调用原 dispatcher；不新增、不重排任何保底方案。
+        self._tts_excluded_provider_keys = excluded | {failed_provider}
+        if _core_facade.tts_provider_uses_configured_preset_voice(failed_provider):
+            self._tts_fallback_uses_default_voice = True
+        # 替代 worker 不继承故障 provider 的错误码和提示次数。
+        self._last_tts_error_code = ''
+        self._tts_retry_notify_count = 0
+        old_request_queue = self.tts_request_queue
+        try:
+            old_request_queue.put(("__shutdown__", None))
+        except Exception:
+            logger.debug("关闭故障 TTS worker 失败，继续启动保底 worker", exc_info=True)
+
+        logger.warning(
+            "自定义 TTS API provider=%s 在%s阶段失败；开始按既有顺序选择保底 provider",
+            failed_provider,
+            failure_stage,
+        )
+        # 新 worker 就绪后按原始文本重建本轮请求。不能沿用失败 preset 的
+        # Voice ID/凭证；角色配置本身不变，下个会话仍可重新尝试该 provider。
+        self.tts_pending_chunks = replay_chunks + pending_chunks
+        self._reset_tts_replay_state()
+        self._tts_done_queued_for_turn = False
+        self._tts_done_pending_until_ready = replay_done
+        self._reset_tts_stream_normalizer()
+        self._start_tts_thread(preserve_provider_exclusions=True)
+        logger.warning(
+            "自定义 TTS API 已回退: failed_provider=%s fallback_provider=%s",
+            failed_provider,
+            self._tts_active_provider_key or "default",
+        )
+        return True
 
     def _reset_tts_retry_state(self):
         """Cancel pending TTS respawn task and clear error/cooldown state.
@@ -418,7 +586,11 @@ class TtsRuntimeMixin:
         self._last_tts_respawn_time = 0.0
         self._tts_retry_notify_count = 0
         self._tts_done_queued_for_turn = False
+        self._tts_fallback_uses_default_voice = False
+        self._reset_tts_replay_state()
         self._tts_done_pending_until_ready = False
+        self._tts_active_provider_key = None
+        self._tts_excluded_provider_keys = frozenset()
 
     async def _teardown_tts_runtime(self, handler_task_ref, thread_ref,
                                      req_queue_ref, resp_queue_ref):
@@ -505,7 +677,11 @@ class TtsRuntimeMixin:
         self._last_tts_respawn_time = now
 
         logger.info("🔄 TTS Worker 已死亡，尝试重新拉起...")
-        self._start_tts_thread()
+        self._start_tts_thread(
+            preserve_provider_exclusions=bool(
+                getattr(self, "_tts_excluded_provider_keys", frozenset())
+            )
+        )
 
         # 重新启动 tts_response_handler 以监听新队列
         if self.tts_handler_task and not self.tts_handler_task.done():
@@ -567,6 +743,21 @@ class TtsRuntimeMixin:
         if self._is_livestream_active():
             logger.info(f"{log_prefix}🎙️ livestream 模式：使用服务端原生语音，跳过外部 TTS")
             return False
+        # Configured preset ownership must be resolved before core-native voice
+        # routing; identical IDs still belong to the explicitly selected TTS API.
+        # 配置型音色与核心原生音色同名时，自定义 TTS 的显式归属优先，不能被原生路由抢走。
+        configured_provider = _core_facade.selected_configured_tts_preset_provider_key(
+            core_config_snapshot,
+            self._config_manager,
+            self.voice_id,
+        )
+        if configured_provider:
+            logger.info(
+                "%s🔊 语音模式：音色归属已配置 TTS provider=%s，将使用外部 TTS",
+                log_prefix,
+                configured_provider,
+            )
+            return True
         if self._is_vllm_omni_tts_enabled(core_config_snapshot):
             logger.info(f"{log_prefix}🔊 语音模式：检测到 vLLM-Omni TTS provider，将使用外部 TTS")
             return True
@@ -783,6 +974,21 @@ class TtsRuntimeMixin:
                 if isinstance(data, tuple) and len(data) == 2 and data[0] == "__handler_exit__":
                     continue
 
+                if (
+                    isinstance(data, tuple)
+                    and len(data) == 3
+                    and data[0] in {"__tts_sentence_done__", "__tts_sentence_failed__"}
+                ):
+                    _, speech_id, sentence = data
+                    if speech_id == getattr(self, "_tts_replay_speech_id", None):
+                        # marker 排在该句所有音频之后；只有音频实际送达前端才推进边界。
+                        # 失败句若已播放过前缀也整体跳过，避免 fallback 从句首重念；
+                        # 其后的未确认句仍保留在账本中。
+                        if getattr(self, "_tts_replay_sentence_audio_emitted", False):
+                            self._consume_tts_replay_sentence(speech_id, str(sentence))
+                        self._tts_replay_sentence_audio_emitted = False
+                    continue
+
                 if isinstance(data, tuple) and len(data) == 2:
                     if data[0] == "__ready__":
                         ready_flag = bool(data[1])
@@ -794,6 +1000,12 @@ class TtsRuntimeMixin:
                             logger.info("✅ 收到TTS运行时就绪信号，开始刷新缓存文本")
                             await self._flush_tts_pending_chunks()
                         else:
+                            # Configured endpoints fall back once; the handler
+                            # then follows the replacement worker's new queue.
+                            # 自定义端点未就绪时立即切到保底 worker，并改听新队列。
+                            if self._activate_configured_tts_fallback("初始化"):
+                                q = self.tts_response_queue
+                                continue
                             # 复用 __error__ 分支记录的 code 判断是否重试
                             _last_code = self._last_tts_error_code
                             if _last_code in NO_RETRY_TTS_CODES:
@@ -841,6 +1053,14 @@ class TtsRuntimeMixin:
                         error_msg = data[1]
                         error_msg_text = str(error_msg)
                         logger.error(f"TTS Worker Error: {error_msg}")
+
+                        # A configured endpoint failure is observable in the
+                        # backend log above, then redispatched through the exact
+                        # pre-existing fallback chain for subsequent audio.
+                        # 自定义 API 运行时出错后，仅切换 provider；现有保底顺序不变。
+                        if self._activate_configured_tts_fallback("运行时"):
+                            q = self.tts_response_queue
+                            continue
 
                         # 优先尝试从结构化 JSON 中提取明确的 code 字段
                         _known_codes = {
@@ -933,6 +1153,8 @@ class TtsRuntimeMixin:
                 elif isinstance(data, tuple) and len(data) == 3 and data[0] == "__audio__":
                     _, speech_id, audio_payload = data
                     if await self.send_speech(audio_payload, speech_id=speech_id):
+                        self._tts_replay_audio_emitted = True
+                        self._tts_replay_sentence_audio_emitted = True
                         self._confirm_pending_ai_voice_echo(speech_id)
                         # Telemetry：音频成功投递 = 用户听到了角色的声音。配合
                         # note_core_loop_completed 的"用户已开口"前置，构成 D1
@@ -950,7 +1172,9 @@ class TtsRuntimeMixin:
 
                 size = len(data) if isinstance(data, (bytes, bytearray)) else f"type={type(data).__name__}"
                 logger.debug(f"🎧 handler dequeued audio: {size}, qsize≈{q.qsize()}")
-                await self.send_speech(data)
+                if await self.send_speech(data):
+                    self._tts_replay_audio_emitted = True
+                    self._tts_replay_sentence_audio_emitted = True
                 self._discard_pending_ai_voice_echo()
             except asyncio.CancelledError:
                 logger.info("🎧 tts_response_handler cancelled")

--- a/main_logic/tts_client/__init__.py
+++ b/main_logic/tts_client/__init__.py
@@ -178,6 +178,8 @@ __all__ = [
     "_vllm_omni_normalize_ws_endpoint",
     "_gptsovits_is_selected", "_gptsovits_resolve",
     "_custom_openai_tts_is_selected", "_custom_openai_tts_resolve",
+    "tts_provider_falls_back_on_failure", "tts_provider_uses_configured_preset_voice",
+    "selected_configured_tts_preset_provider_key",
     "_minimax_clone_is_selected", "_minimax_clone_resolve",
     "_elevenlabs_clone_is_selected", "_elevenlabs_clone_resolve",
     "_cosyvoice_clone_is_selected", "_cosyvoice_clone_resolve",
@@ -261,7 +263,13 @@ def _grok_voice_id_is_xai_custom(voice_id: str) -> bool:
     return bool(_XAI_CUSTOM_VOICE_PATTERN.match(voice_id))
 
 
-def get_tts_worker(core_api_type='qwen', has_custom_voice=False, voice_id=''):
+def get_tts_worker(
+    core_api_type='qwen',
+    has_custom_voice=False,
+    voice_id='',
+    *,
+    excluded_provider_keys=frozenset(),
+):
     """
     Return a callable based on the core_api type and whether a custom voice exists.
 
@@ -313,7 +321,13 @@ def get_tts_worker(core_api_type='qwen', has_custom_voice=False, voice_id=''):
         has_custom_voice=bool(has_custom_voice),
         voice_meta_loader=lambda: _get_voice_meta(voice_id),
     )
-    special = _tts_providers.resolve_selected(_dispatch_ctx)
+    # Runtime fallback passes only the failed provider key here; all remaining
+    # providers keep their established priority and selection behavior.
+    # 运行时回退只排除故障 provider，不改变其余 provider 的既有优先级。
+    special = _tts_providers.resolve_selected(
+        _dispatch_ctx,
+        excluded_provider_keys=frozenset(excluded_provider_keys or ()),
+    )
     if special is not None:
         logger.info("[get_tts_worker] 命中 TTS provider: %s", special[2])
         return special
@@ -442,6 +456,8 @@ _tts_providers.register(_tts_providers.TTSProvider(
     probe_kind='ws_handshake',
     probe_sub_type='vllm_omni_tts',
     probe_ws_path='/audio/speech/stream',
+    configured_preset_voice=True,
+    fallback_on_failure=True,
 ))
 
 _tts_providers.register(_tts_providers.TTSProvider(
@@ -454,10 +470,40 @@ _tts_providers.register(_tts_providers.TTSProvider(
     editable_endpoint=True,
     probe_kind='http_tts',
     probe_sub_type='openai_tts',
+    configured_preset_voice=True,
+    fallback_on_failure=True,
     # The generic "custom" option is already inserted into every model dropdown.
     # Keep this registry entry available as metadata without adding a duplicate.
     tts_config_visible=False,
 ))
+
+
+def tts_provider_falls_back_on_failure(provider_key):
+    """Expose registry fallback metadata without importing utils in core mixins."""
+    # The facade keeps provider policy out of core; core only asks whether the
+    # active worker opted into replacement after failure.
+    # 通过门面隔离 provider 策略；core 只查询当前 worker 是否允许故障切换。
+    return _tts_providers.falls_back_on_failure(provider_key)
+
+
+def tts_provider_uses_configured_preset_voice(provider_key):
+    """Expose configured-preset ownership without importing utils in core mixins."""
+    return _tts_providers.uses_configured_preset_voice(provider_key)
+
+
+def selected_configured_tts_preset_provider_key(core_config, cm, voice_id):
+    """Return the selected configured-preset owner for ``voice_id``, if any."""
+    # Reuse registry dispatch so core never hardcodes custom/vLLM ownership.
+    # 复用注册表判定，让 core 不需要识别 custom、vLLM 等具体 provider 名称。
+    provider_key = _tts_providers.selected_preset_provider_key(
+        core_config,
+        cm,
+        voice_id,
+    )
+    if not _tts_providers.uses_configured_preset_voice(provider_key):
+        return None
+    return provider_key
+
 
 # 克隆音色 provider（hosted SaaS，按 voice_meta.provider 选中）。priority 30/40/50
 # 沿用原 get_tts_worker 克隆块顺序：都在 vllm(20) 之后、mimo/native 之前。capabilities

--- a/main_logic/tts_client/__init__.py
+++ b/main_logic/tts_client/__init__.py
@@ -43,6 +43,7 @@ from ._infra import (
     _parse_env_float,
     _enqueue_error,
     _ws_is_open,
+    log_configured_tts_failure,
     SentenceBuffer,
     _AudioQueueProxy,
     _non_bistream_tts_main_loop,
@@ -495,14 +496,21 @@ def selected_configured_tts_preset_provider_key(core_config, cm, voice_id):
     """Return the selected configured-preset owner for ``voice_id``, if any."""
     # Reuse registry dispatch so core never hardcodes custom/vLLM ownership.
     # 复用注册表判定，让 core 不需要识别 custom、vLLM 等具体 provider 名称。
-    provider_key = _tts_providers.selected_preset_provider_key(
-        core_config,
-        cm,
-        voice_id,
-    )
-    if not _tts_providers.uses_configured_preset_voice(provider_key):
+    try:
+        provider_key = _tts_providers.selected_preset_provider_key(
+            core_config,
+            cm,
+            voice_id,
+        )
+        if not _tts_providers.uses_configured_preset_voice(provider_key):
+            return None
+        return provider_key
+    except Exception:
+        # Ownership lookup is advisory. A malformed provider must not abort the
+        # session, and its exception may contain credentials or signed URLs.
+        # 音色归属查询失败时按旧路由继续，且不记录可能含凭证的原始异常。
+        log_configured_tts_failure("configured", "ownership")
         return None
-    return provider_key
 
 
 # 克隆音色 provider（hosted SaaS，按 voice_meta.provider 选中）。priority 30/40/50

--- a/main_logic/tts_client/_infra.py
+++ b/main_logic/tts_client/_infra.py
@@ -32,6 +32,26 @@ logger = get_module_logger(__name__, "Main")
 # worker 的 sid is None 分支）。两种语义必须分开。
 TTS_SHUTDOWN_SENTINEL = "__shutdown__"
 
+# Stable diagnostic code for user-configured endpoints. Never attach the raw
+# exception because SDK/network errors may echo API keys, signed queries, or text.
+# 用户自填端点的异常可能回显密钥、签名 query 或原文；后端日志只记录稳定错误码、
+# provider 和阶段，详细原始异常不得进入 logger。
+CONFIGURED_TTS_FAILURE_CODE = "TTS_CONFIGURED_API_FAILURE"
+
+
+def configured_tts_unavailable_worker(
+    request_queue,
+    response_queue,
+    _audio_api_key,
+    _voice_id,
+):
+    """Report a configured-provider setup failure through the normal ready channel."""
+    # Keep the failed provider as the active owner until core observes readiness;
+    # this prevents legacy clone fallthrough from reusing its voice ID or API key.
+    # 配置解析失败也要先归属原 provider，再由统一监管层清空音色和凭证后回退。
+    _ = request_queue
+    response_queue.put(("__ready__", False))
+
 def _parse_env_float(env_name: str, default: float, min_value: float) -> float:
     raw = os.getenv(env_name)
     if raw is None or raw == "":
@@ -179,6 +199,31 @@ def _enqueue_error(response_queue, error_value):
     logger.error(f"TTS错误: {formatted_msg}")
     response_queue.put(("__error__", formatted_msg))
 
+
+def configured_tts_failure_payload(provider_key: str, stage: str) -> dict[str, str]:
+    """Build the non-sensitive error payload for a configured TTS endpoint."""
+    return {
+        "code": CONFIGURED_TTS_FAILURE_CODE,
+        "provider": str(provider_key or "configured"),
+        "stage": str(stage or "unknown"),
+        "message": "Configured TTS API unavailable; using existing fallback order",
+    }
+
+
+def log_configured_tts_failure(provider_key: str, stage: str) -> None:
+    """Log a configured-endpoint failure without serializing its exception."""
+    logger.error(
+        "code=%s provider=%s stage=%s",
+        CONFIGURED_TTS_FAILURE_CODE,
+        str(provider_key or "configured"),
+        str(stage or "unknown"),
+    )
+
+
+def enqueue_configured_tts_failure(response_queue, provider_key: str, stage: str) -> None:
+    """Enqueue and log the stable configured-endpoint failure payload."""
+    _enqueue_error(response_queue, configured_tts_failure_payload(provider_key, stage))
+
 try:
     from websockets.connection import State as _WsState
 except (ImportError, AttributeError):
@@ -281,6 +326,7 @@ async def _non_bistream_tts_main_loop(
     label: str = "TTS",
     max_concurrent: int = 3,
     sentence_trace_fn=None,
+    safe_error_provider: str | None = None,
 ):
     """Generic main loop for non-bistream-input TTS (sentence splitting + parallel synthesis + in-order delivery).
 
@@ -340,6 +386,7 @@ async def _non_bistream_tts_main_loop(
     _slot_new_data: dict[int, asyncio.Event] = {}       # seq_id → 有新数据通知
     _tasks: dict[int, asyncio.Task] = {}                # seq_id → synth task
     _sentence_enqueued_at: dict[int, float] = {}        # seq_id → enqueue monotonic time
+    _slot_sentences: dict[int, tuple[str, str]] = {}    # seq_id → (speech_id, sentence)
     _sem = asyncio.Semaphore(max_concurrent)
     _drain_seq: int = 0                                 # drain 当前正在投递的序号
     _drain_task: asyncio.Task | None = None
@@ -368,6 +415,7 @@ async def _non_bistream_tts_main_loop(
         _slot_new_data.pop(seq, None)
         _tasks.pop(seq, None)
         _sentence_enqueued_at.pop(seq, None)
+        _slot_sentences.pop(seq, None)
 
     def _slot_put(seq: int, gen_id: int, item) -> None:
         """Write one chunk into the given slot's buffer (called back by the proxy)."""
@@ -402,9 +450,27 @@ async def _non_bistream_tts_main_loop(
                 raise
             except Exception as exc:
                 if gen_id == _generation_id:
-                    _trace_sentence("error", seq, sid, text, error=str(exc))
-                    _slot_put(seq, gen_id,
-                              ("__synth_error__", f"{label} 合成失败: {exc}"))
+                    if safe_error_provider:
+                        # Do not pass the raw exception or sentence into traces.
+                        # 配置型 API 的追踪与队列都只能使用脱敏错误载荷。
+                        safe_error = configured_tts_failure_payload(
+                            safe_error_provider, "synthesis"
+                        )
+                        _trace_sentence(
+                            "error",
+                            seq,
+                            sid,
+                            "",
+                            error=CONFIGURED_TTS_FAILURE_CODE,
+                        )
+                        _slot_put(seq, gen_id, ("__synth_error__", safe_error))
+                    else:
+                        _trace_sentence("error", seq, sid, text, error=str(exc))
+                        _slot_put(
+                            seq,
+                            gen_id,
+                            ("__synth_error__", f"{label} 合成失败: {exc}"),
+                        )
             finally:
                 total_ms = int((time.perf_counter() - started_at) * 1000)
                 _trace_sentence("done", seq, sid, text, total_ms=total_ms)
@@ -431,6 +497,7 @@ async def _non_bistream_tts_main_loop(
                 continue
 
             cursor = 0
+            had_error = False
             while gen_id == _generation_id:
                 # 转发已有的 chunk
                 while cursor < len(buf):
@@ -438,7 +505,10 @@ async def _non_bistream_tts_main_loop(
                     cursor += 1
                     if (isinstance(item, tuple) and len(item) >= 2
                             and item[0] == "__synth_error__"):
+                        sid, sentence = _slot_sentences.get(seq, ("", ""))
+                        real_queue.put(("__tts_sentence_failed__", sid, sentence))
                         _enqueue_error(real_queue, item[1])
+                        had_error = True
                     else:
                         real_queue.put(item)
 
@@ -449,9 +519,15 @@ async def _non_bistream_tts_main_loop(
                         cursor += 1
                         if (isinstance(item, tuple) and len(item) >= 2
                                 and item[0] == "__synth_error__"):
+                            sid, sentence = _slot_sentences.get(seq, ("", ""))
+                            real_queue.put(("__tts_sentence_failed__", sid, sentence))
                             _enqueue_error(real_queue, item[1])
+                            had_error = True
                         else:
                             real_queue.put(item)
+                    if not had_error:
+                        sid, sentence = _slot_sentences.get(seq, ("", ""))
+                        real_queue.put(("__tts_sentence_done__", sid, sentence))
                     _free_slot(seq)
                     _drain_seq = seq + 1
                     break
@@ -473,6 +549,7 @@ async def _non_bistream_tts_main_loop(
     def _enqueue_sentence(text: str, sid: str) -> None:
         seq = _alloc_slot()
         _sentence_enqueued_at[seq] = time.perf_counter()
+        _slot_sentences[seq] = (sid, text)
         _trace_sentence("enqueue", seq, sid, text)
         task = asyncio.create_task(_synth_one(seq, text, sid, _generation_id))
         _tasks[seq] = task
@@ -515,6 +592,7 @@ async def _non_bistream_tts_main_loop(
         _slot_new_data.clear()
         _tasks.clear()
         _sentence_enqueued_at.clear()
+        _slot_sentences.clear()
         _next_seq = 0
         _drain_seq = 0
         if proxy is not None:
@@ -564,6 +642,7 @@ def _run_sentence_tts_worker(
     *,
     label: str,
     sentence_trace_fn=None,
+    safe_error_provider: str | None = None,
 ):
     """Generic skeleton for HTTP per-sentence synthesis TTS workers.
 
@@ -599,7 +678,10 @@ def _run_sentence_tts_worker(
         try:
             synthesize_fn, cleanup_fn = await async_setup_fn(proxy)
         except Exception as exc:
-            logger.error(f"{label} 初始化失败: {exc}")
+            if safe_error_provider:
+                log_configured_tts_failure(safe_error_provider, "initialization")
+            else:
+                logger.error(f"{label} 初始化失败: {exc}")
             try:
                 response_queue.put(("__ready__", False))
             except Exception:
@@ -614,9 +696,15 @@ def _run_sentence_tts_worker(
                 request_queue, proxy, synthesize_fn,
                 label=label,
                 sentence_trace_fn=sentence_trace_fn,
+                safe_error_provider=safe_error_provider,
             )
         except Exception as exc:
-            _enqueue_error(response_queue, f"{label} Worker 错误: {exc}")
+            if safe_error_provider:
+                enqueue_configured_tts_failure(
+                    response_queue, safe_error_provider, "worker_runtime"
+                )
+            else:
+                _enqueue_error(response_queue, f"{label} Worker 错误: {exc}")
             response_queue.put(("__ready__", False))
         finally:
             if cleanup_fn:
@@ -628,5 +716,8 @@ def _run_sentence_tts_worker(
     try:
         asyncio.run(_worker())
     except Exception as e:
-        logger.error(f"{label} Worker 启动失败: {e}")
+        if safe_error_provider:
+            log_configured_tts_failure(safe_error_provider, "worker_start")
+        else:
+            logger.error(f"{label} Worker 启动失败: {e}")
         response_queue.put(("__ready__", False))

--- a/main_logic/tts_client/workers/openai.py
+++ b/main_logic/tts_client/workers/openai.py
@@ -21,7 +21,13 @@ import httpx
 import numpy as np
 import soxr
 
-from .._infra import TTS_SHUTDOWN_SENTINEL, _resample_audio, _run_sentence_tts_worker
+from .._infra import (
+    TTS_SHUTDOWN_SENTINEL,
+    _resample_audio,
+    _run_sentence_tts_worker,
+    configured_tts_unavailable_worker,
+    log_configured_tts_failure,
+)
 from .._telemetry import _record_tts_telemetry
 from utils.config_manager import _as_bool
 from utils.logger_config import get_module_logger
@@ -30,12 +36,13 @@ from utils.openai_tts import (
     OPENAI_TTS_DEFAULT_MODEL,
     OPENAI_TTS_DEFAULT_VOICE,
     OPENAI_TTS_PCM_SAMPLE_RATE,
+    build_openai_tts_payload,
+    openai_tts_base_url,
     openai_tts_extra_body,
     openai_tts_sdk_options,
 )
 
 logger = get_module_logger(__name__, "Main")
-
 
 def _openai_auth_client_kwargs(client_type, audio_api_key):
     """Build SDK credentials for authenticated and auth-free endpoints."""
@@ -82,10 +89,14 @@ def openai_tts_worker(
     base_url=None,
     model=OPENAI_TTS_DEFAULT_MODEL,
     voice=OPENAI_TTS_DEFAULT_VOICE,
+    label="OpenAI TTS",
+    safe_error_provider=None,
 ):
     """OpenAI-compatible TTS: sentence input with a streamed PCM response."""
 
-    # 纯空白 key 等同未填写，避免误发 ``Bearer <空白>``。
+    # Normalize once so whitespace-only credentials use the auth-free path.
+    # 配置文件或环境变量里只含空白字符的 key 等同于未填写；否则 SDK 会误发
+    # ``Authorization: Bearer <空白>``，与连接测试的免鉴权行为不一致。
     audio_api_key = str(audio_api_key or "").strip()
 
     try:
@@ -114,6 +125,7 @@ def openai_tts_worker(
         if base_url:
             # Validate/normalize inside setup so configuration failures travel
             # through the shared worker skeleton's normal __ready__ channel.
+            # 配置错误必须走统一的未就绪信号，不能在线程外静默退出。
             sdk_base_url, endpoint_query = openai_tts_sdk_options(base_url)
             client_kwargs["base_url"] = sdk_base_url
             if endpoint_query:
@@ -123,14 +135,10 @@ def openai_tts_worker(
                 )
         client = AsyncOpenAI(**client_kwargs)
         extra_body = openai_tts_extra_body(base_url or OPENAI_TTS_DEFAULT_BASE_URL)
+        base_payload = build_openai_tts_payload("", effective_model, effective_voice)
 
         async def synthesize(text: str, speech_id: str) -> None:
-            request_kwargs = {
-                "model": effective_model,
-                "voice": effective_voice,
-                "input": text,
-                "response_format": "pcm",
-            }
+            request_kwargs = {**base_payload, "input": text}
             if extra_body:
                 request_kwargs["extra_body"] = extra_body
             if not audio_api_key:
@@ -186,7 +194,13 @@ def openai_tts_worker(
 
         return synthesize, client.close
 
-    _run_sentence_tts_worker(request_queue, response_queue, setup, label="OpenAI TTS")
+    _run_sentence_tts_worker(
+        request_queue,
+        response_queue,
+        setup,
+        label=label,
+        safe_error_provider=safe_error_provider,
+    )
 
 
 def _custom_openai_tts_is_selected(ctx) -> bool:
@@ -198,13 +212,23 @@ def _custom_openai_tts_is_selected(ctx) -> bool:
         return False
 
     configured_voice = str(ctx.core_config.get("ttsVoiceId") or "").strip()
-    # A saved clone/design voice owns its provider route. The custom endpoint is
-    # the configured fallback, not a blanket override of existing voice vendors.
-    if ctx.voice_id and ctx.has_custom_voice and ctx.voice_meta:
+    selected_voice = str(ctx.voice_id or "").strip()
+    if selected_voice and configured_voice and selected_voice != configured_voice:
         return False
-    if ctx.voice_id and configured_voice and str(ctx.voice_id).strip() != configured_voice:
+
+    # The exact configured voice is an explicit Custom API selection and wins
+    # even if an old clone with the same ID still exists in voice storage.
+    # 角色选中的音色与配置音色一致时，自定义 API 必须优先于同名历史克隆记录。
+    exact_configured_voice = bool(selected_voice and selected_voice == configured_voice)
+    if (
+        not exact_configured_voice
+        and selected_voice
+        and ctx.has_custom_voice
+        and ctx.voice_meta
+    ):
         return False
-    effective_voice = str(ctx.voice_id or "").strip() or configured_voice
+
+    effective_voice = selected_voice or configured_voice
     return bool(
         str(ctx.core_config.get("ttsModelUrl") or "").strip()
         and str(ctx.core_config.get("ttsModelId") or "").strip()
@@ -215,12 +239,28 @@ def _custom_openai_tts_is_selected(ctx) -> bool:
 def _custom_openai_tts_resolve(ctx):
     try:
         raw = ctx.cm.load_json_config("core_config.json", {}) or {}
+        base_url = str(raw.get("ttsModelUrl") or "").strip()
+        model = str(raw.get("ttsModelId") or "").strip()
+        configured_voice = str(raw.get("ttsVoiceId") or "").strip()
+        effective_voice = str(ctx.voice_id or "").strip() or configured_voice
+
+        # Validate before spawning the network worker, but retain the provider
+        # identity so the shared supervisor can sanitize and replay on fallback.
+        # 在线程启动前校验配置；失败时仍保留 provider 身份，交给监管层安全回退。
+        openai_tts_base_url(base_url)
+        build_openai_tts_payload("", model, effective_voice)
     except Exception:
-        raw = {}
+        # The exception can contain a signed URL, credential, or provider echo.
+        # 配置读取/校验异常只记录稳定错误码和阶段，禁止输出原始异常内容。
+        log_configured_tts_failure("custom", "configuration")
+        return configured_tts_unavailable_worker, "", "custom"
+
     worker = partial(
         openai_tts_worker,
-        base_url=str(raw.get("ttsModelUrl") or "").strip(),
-        model=str(raw.get("ttsModelId") or "").strip(),
-        voice=str(raw.get("ttsVoiceId") or "").strip(),
+        base_url=base_url,
+        model=model,
+        voice=configured_voice,
+        label="自定义 TTS API (Custom OpenAI-compatible TTS)",
+        safe_error_provider="custom",
     )
     return worker, str(raw.get("ttsModelApiKey") or "").strip(), "custom"

--- a/main_logic/tts_client/workers/vllm_omni.py
+++ b/main_logic/tts_client/workers/vllm_omni.py
@@ -25,7 +25,14 @@ from urllib.parse import urlparse, urlunparse
 from utils.config_manager import _as_bool
 from utils.gptsovits_config import redact_url_for_log
 
-from .._infra import TTS_SHUTDOWN_SENTINEL, _resample_audio, _enqueue_error
+from .._infra import (
+    TTS_SHUTDOWN_SENTINEL,
+    _enqueue_error,
+    _resample_audio,
+    configured_tts_unavailable_worker,
+    enqueue_configured_tts_failure,
+    log_configured_tts_failure,
+)
 from .._telemetry import _record_tts_telemetry
 from .dummy import dummy_tts_worker
 from utils.logger_config import get_module_logger
@@ -119,12 +126,9 @@ def vllm_omni_tts_worker(request_queue, response_queue, audio_api_key, voice_id,
     """
     raw_base_url = (base_url or '').strip().rstrip('/')
     if not raw_base_url:
-        logger.error("[vLLM-Omni TTS] 未配置 base_url（TTS_MODEL_URL 为空）")
-        _enqueue_error(response_queue, {
-            "code": "TTS_CONFIG_INVALID",
-            "provider": "vllm_omni",
-            "message": "vLLM-Omni TTS 未配置 URL",
-        })
+        enqueue_configured_tts_failure(
+            response_queue, "vllm_omni", "configuration"
+        )
         response_queue.put(("__ready__", False))
         return
 
@@ -206,11 +210,11 @@ def vllm_omni_tts_worker(request_queue, response_queue, audio_api_key, voice_id,
                     ws_kwargs["extra_headers"] = ws_kwargs.pop("additional_headers")
                 try:
                     ws = await websockets.connect(ws_endpoint, **ws_kwargs)
-                except Exception as e:
-                    logger.error(f"[vLLM-Omni TTS] WS 连接失败(兼容旧版): {e}")
+                except Exception:
+                    log_configured_tts_failure("vllm_omni", "connect_legacy")
                     return False
-            except Exception as e:
-                logger.error(f"[vLLM-Omni TTS] WS 连接失败: {e}")
+            except Exception:
+                log_configured_tts_failure("vllm_omni", "connect")
                 return False
 
             try:
@@ -237,8 +241,8 @@ def vllm_omni_tts_worker(request_queue, response_queue, audio_api_key, voice_id,
                     config["api_key"] = key_for_auth
                 await ws.send(json.dumps(config))
                 return True
-            except Exception as e:
-                logger.error(f"[vLLM-Omni TTS] 发送 session.config 失败: {e}")
+            except Exception:
+                log_configured_tts_failure("vllm_omni", "session_config")
                 try:
                     await ws.close()
                 except Exception:
@@ -287,7 +291,11 @@ def vllm_omni_tts_worker(request_queue, response_queue, audio_api_key, voice_id,
                         elif event_type == "audio.done":
                             pass  # 静默
                         elif event_type == "error":
-                            _enqueue_error(response_queue, event)
+                            # Provider events may echo signed URLs or input text.
+                            # 服务端 error 事件只转换为稳定错误码，不记录原始 payload。
+                            enqueue_configured_tts_failure(
+                                response_queue, "vllm_omni", "server_event"
+                            )
                             # 修复 PR #1764 review 第六轮：服务端 error 事件后会话已不可用，
                             # 标记 session 失效，主循环下次 input 前会主动重建（与 session.done 处理对齐）
                             session_state["active"] = False
@@ -308,9 +316,9 @@ def vllm_omni_tts_worker(request_queue, response_queue, audio_api_key, voice_id,
                         "message": "vLLM-Omni TTS 连接在 session.done 前关闭",
                     })
                     response_queue.put(("__ready__", False))
-            except Exception as e:
+            except Exception:
                 was_awaiting_done = bool(session_state.get("awaiting_done"))
-                logger.error(f"[vLLM-Omni TTS] 接收异常: {e}")
+                log_configured_tts_failure("vllm_omni", "receive")
                 session_state["active"] = False
                 session_state["awaiting_done"] = False
                 session_state["speech_id"] = None
@@ -386,8 +394,8 @@ def vllm_omni_tts_worker(request_queue, response_queue, audio_api_key, voice_id,
                 session_state["speech_id"] = pending_text_sid
                 session_state["awaiting_done"] = False
                 return True
-            except Exception as e:
-                logger.error(f"[vLLM-Omni TTS] 重放 pending_text 失败: {e}")
+            except Exception:
+                log_configured_tts_failure("vllm_omni", "replay_pending")
                 session_state["active"] = False
                 return False
 
@@ -466,8 +474,8 @@ def vllm_omni_tts_worker(request_queue, response_queue, audio_api_key, voice_id,
                         pending_text.clear()
                         pending_text_sid = None
                         session_state["awaiting_done"] = True
-                    except Exception as e:
-                        logger.warning(f"[vLLM-Omni TTS] 发送 input.done 失败: {e}")
+                    except Exception:
+                        log_configured_tts_failure("vllm_omni", "input_done")
                         session_state["active"] = False
                         session_state["awaiting_done"] = False
                         if not await _rebuild_session():
@@ -482,8 +490,8 @@ def vllm_omni_tts_worker(request_queue, response_queue, audio_api_key, voice_id,
                             pending_text_sid = None
                             session_state["awaiting_done"] = True
                             logger.info("[vLLM-Omni TTS] 重放 pending_text 并重发 input.done 成功")
-                        except Exception as e2:
-                            logger.warning(f"[vLLM-Omni TTS] 重发 input.done 仍失败: {e2}")
+                        except Exception:
+                            log_configured_tts_failure("vllm_omni", "input_done_retry")
                             _fail_pending_flush("vLLM-Omni TTS flush 重发失败")
                             break
                 else:
@@ -541,8 +549,8 @@ def vllm_omni_tts_worker(request_queue, response_queue, audio_api_key, voice_id,
                     pending_text_sid = sid
                     session_state["speech_id"] = sid
                     session_state["awaiting_done"] = False
-                except Exception as e:
-                    logger.error(f"[vLLM-Omni TTS] 发送 input.text 失败: {e}，尝试重建并重发")
+                except Exception:
+                    log_configured_tts_failure("vllm_omni", "input_text")
                     session_state["active"] = False
                     session_state["awaiting_done"] = False
                     if await _rebuild_session():
@@ -557,8 +565,8 @@ def vllm_omni_tts_worker(request_queue, response_queue, audio_api_key, voice_id,
                             session_state["speech_id"] = sid
                             session_state["awaiting_done"] = False
                             logger.info("[vLLM-Omni TTS] 重发 input.text 成功")
-                        except Exception as e2:
-                            logger.error(f"[vLLM-Omni TTS] 重发 input.text 仍失败: {e2}，标记 worker 未就绪")
+                        except Exception:
+                            log_configured_tts_failure("vllm_omni", "input_text_retry")
                             session_state["active"] = False
                             _enqueue_error(response_queue, {
                                 "code": "TTS_CONNECTION_FAILED",
@@ -591,8 +599,8 @@ def vllm_omni_tts_worker(request_queue, response_queue, audio_api_key, voice_id,
 
     try:
         asyncio.run(async_worker())
-    except Exception as e:
-        logger.error(f"[vLLM-Omni TTS] Worker 启动失败: {e}")
+    except Exception:
+        log_configured_tts_failure("vllm_omni", "worker_start")
         response_queue.put(("__ready__", False))
 
 # ── vLLM-Omni（本地 self-hosted 服务）────────────────────────────────────────
@@ -626,13 +634,21 @@ def _vllm_omni_is_selected(ctx) -> bool:
     # 显式选中 vllm_omni（下拉默认）时不能触发 voice_meta 加载，否则违反
     # test_get_tts_worker_routes_explicit_vllm_before_cloned_voice 的短路契约（对偶 _mimo_is_selected
     # 的顺序：config-selected 先判，clone-meta 后判）。
-    core_config, cm = ctx.core_config, ctx.cm
+    core_config = ctx.core_config
     if _as_bool(core_config.get('ENABLE_CUSTOM_API'), False):
-        try:
-            raw = cm.load_json_config('core_config.json', {})
-        except Exception:
-            raw = {}
-        if (raw.get('ttsModelProvider') or '').strip() == 'vllm_omni':
+        # Selection uses the existing sanitized snapshot; sensitive credentials
+        # remain a resolver-only disk read.
+        # 选中判断只读现有快照，API Key 仍只在 resolve 阶段读取原始配置。
+        configured_provider = str(core_config.get('ttsModelProvider') or '').strip()
+        if not configured_provider:
+            try:
+                raw = ctx.cm.load_json_config('core_config.json', {}) or {}
+                configured_provider = str(raw.get('ttsModelProvider') or '').strip()
+            except Exception:
+                # Selection errors use the same redacted diagnostic contract.
+                # 选中判定失败也不能把配置异常原文写入后端日志。
+                log_configured_tts_failure("vllm_omni", "selection")
+        if configured_provider == 'vllm_omni':
             return True
     # 克隆音色选中：按所选音色的 voice_meta.provider 路由（惰性，命中前面 config-selected
     # provider / 本 provider 的 config 分支时不会触发 voice_meta 加载）。
@@ -693,7 +709,11 @@ def _vllm_omni_resolve(ctx):
     try:
         raw = cm.load_json_config('core_config.json', {})
     except Exception:
-        raw = {}
+        log_configured_tts_failure("vllm_omni", "configuration")
+        # Preserve WSS/HTTPS provider symmetry: both report setup failure through
+        # the same ready channel before core activates the existing fallback.
+        # WSS 与 HTTPS 配置读取失败都先回报原 provider，再进入同一保底接缝。
+        return configured_tts_unavailable_worker, "", "vllm_omni"
 
     # 克隆音色始终优先于配置默认（preset）：用户选了克隆音色 = 明确意图用克隆，
     # 无论是否配置了 vllm_omni 作为默认 provider 都应走 clone resolve。之前的

--- a/main_logic/tts_client/workers/vllm_omni.py
+++ b/main_logic/tts_client/workers/vllm_omni.py
@@ -639,8 +639,9 @@ def _vllm_omni_is_selected(ctx) -> bool:
         # Selection uses the existing sanitized snapshot; sensitive credentials
         # remain a resolver-only disk read.
         # 选中判断只读现有快照，API Key 仍只在 resolve 阶段读取原始配置。
-        configured_provider = str(core_config.get('ttsModelProvider') or '').strip()
-        if not configured_provider:
+        if 'ttsModelProvider' in core_config:
+            configured_provider = str(core_config.get('ttsModelProvider') or '').strip()
+        else:
             try:
                 raw = ctx.cm.load_json_config('core_config.json', {}) or {}
                 configured_provider = str(raw.get('ttsModelProvider') or '').strip()
@@ -715,16 +716,27 @@ def _vllm_omni_resolve(ctx):
         # WSS 与 HTTPS 配置读取失败都先回报原 provider，再进入同一保底接缝。
         return configured_tts_unavailable_worker, "", "vllm_omni"
 
-    configured_voice = (raw.get('ttsVoiceId') or '').strip() or 'default'
-    configured_provider = str(
-        raw.get('ttsModelProvider')
-        or ctx.core_config.get('ttsModelProvider')
-        or ''
-    ).strip()
+    def _config_value(key):
+        # Selection and resolution must use one session snapshot. Disk is only
+        # a compatibility fallback when an older snapshot omits the field.
+        # 选中与解析共用会话快照；仅旧快照缺字段时回退磁盘配置。
+        if key in ctx.core_config:
+            return ctx.core_config.get(key)
+        return raw.get(key)
+
+    configured_voice = str(_config_value('ttsVoiceId') or '').strip() or 'default'
+    configured_provider = str(_config_value('ttsModelProvider') or '').strip()
     config_selected = (
         _as_bool(ctx.core_config.get('ENABLE_CUSTOM_API'), False)
         and configured_provider == 'vllm_omni'
     )
+    raw_provider = str(raw.get('ttsModelProvider') or '').strip()
+    if config_selected and raw_provider and raw_provider != configured_provider:
+        # The raw credential may already belong to a newly selected provider.
+        # Never send it to the endpoint retained by this session snapshot.
+        # 磁盘中的凭证可能已属于新 provider，禁止发往旧会话快照的端点。
+        log_configured_tts_failure("vllm_omni", "configuration")
+        return configured_tts_unavailable_worker, "", "vllm_omni"
     # The exact configured preset owns a same-ID collision; a different clone
     # still keeps the historical clone-first behavior.
     # 仅当角色音色与配置 Voice ID 精确相同时，显式配置才压过同名克隆；
@@ -748,10 +760,13 @@ def _vllm_omni_resolve(ctx):
         and not configured_preset_selected
     ):
         return _vllm_omni_clone_resolve(ctx)
-    vllm_url = (raw.get('ttsModelUrl') or '').strip() or VLLM_OMNI_DEFAULT_BASE_URL
-    vllm_model = (raw.get('ttsModelId') or '').strip() or VLLM_OMNI_DEFAULT_MODEL
+    vllm_url = str(_config_value('ttsModelUrl') or '').strip() or VLLM_OMNI_DEFAULT_BASE_URL
+    vllm_model = str(_config_value('ttsModelId') or '').strip() or VLLM_OMNI_DEFAULT_MODEL
     vllm_voice = configured_voice
-    # 凭证防泄漏：无 key 时返回空字符串而非 None，配合 core.resolve_tts_api_key
+    # Credentials remain a resolver-only raw read and never enter the session
+    # snapshot; an empty key must still block fallback to another provider's key.
+    # 凭证仍只在 resolve 阶段读原始配置，不进会话快照；空 key 也禁止借用其他 provider 凭证。
+    # 无 key 时返回空字符串而非 None，配合 core.resolve_tts_api_key
     # 的 provider_key=='vllm_omni' 特判，禁止 fallback 到别家 provider 的 key
     # （见 get_tts_worker 原注释 / PR #1764 review 第三轮 #3）。
     vllm_key = (raw.get('ttsModelApiKey') or '').strip()

--- a/main_logic/tts_client/workers/vllm_omni.py
+++ b/main_logic/tts_client/workers/vllm_omni.py
@@ -715,8 +715,27 @@ def _vllm_omni_resolve(ctx):
         # WSS 与 HTTPS 配置读取失败都先回报原 provider，再进入同一保底接缝。
         return configured_tts_unavailable_worker, "", "vllm_omni"
 
-    # 克隆音色始终优先于配置默认（preset）：用户选了克隆音色 = 明确意图用克隆，
-    # 无论是否配置了 vllm_omni 作为默认 provider 都应走 clone resolve。之前的
+    configured_voice = (raw.get('ttsVoiceId') or '').strip() or 'default'
+    configured_provider = str(
+        raw.get('ttsModelProvider')
+        or ctx.core_config.get('ttsModelProvider')
+        or ''
+    ).strip()
+    config_selected = (
+        _as_bool(ctx.core_config.get('ENABLE_CUSTOM_API'), False)
+        and configured_provider == 'vllm_omni'
+    )
+    # The exact configured preset owns a same-ID collision; a different clone
+    # still keeps the historical clone-first behavior.
+    # 仅当角色音色与配置 Voice ID 精确相同时，显式配置才压过同名克隆；
+    # 其他克隆仍沿用原有优先级。
+    configured_preset_selected = (
+        config_selected
+        and str(ctx.voice_id or '').strip() == configured_voice
+    )
+
+    # 克隆音色通常优先于配置默认（preset）：用户选了不同的克隆音色 = 明确意图用克隆，
+    # 即使配置了 vllm_omni 作为默认 provider 也应走 clone resolve。之前的
     # `not config_selected` 守卫导致"配置选了 vllm_omni + 用户选了克隆音色"时走
     # preset 路径，把克隆音色的内部 ID（如 vllm-omni-clone-ch-xxx）当作 voice
     # 发给 vLLM-Omni 服务端，服务端报 Invalid Voice（该 ID 是 N.E.K.O. 本地
@@ -724,11 +743,14 @@ def _vllm_omni_resolve(ctx):
     # 避免触发 voice_meta 惰性加载（短路契约），但 _vllm_omni_is_selected 已在
     # config-selected 后惰性检查 voice_meta，resolve 到达时 is_selected 已返回
     # True，voice_meta 已加载完毕，不存在短路问题。
-    if _vllm_omni_voice_meta_is_clone(ctx.voice_meta):
+    if (
+        _vllm_omni_voice_meta_is_clone(ctx.voice_meta)
+        and not configured_preset_selected
+    ):
         return _vllm_omni_clone_resolve(ctx)
     vllm_url = (raw.get('ttsModelUrl') or '').strip() or VLLM_OMNI_DEFAULT_BASE_URL
     vllm_model = (raw.get('ttsModelId') or '').strip() or VLLM_OMNI_DEFAULT_MODEL
-    vllm_voice = (raw.get('ttsVoiceId') or '').strip() or 'default'
+    vllm_voice = configured_voice
     # 凭证防泄漏：无 key 时返回空字符串而非 None，配合 core.resolve_tts_api_key
     # 的 provider_key=='vllm_omni' 特判，禁止 fallback 到别家 provider 的 key
     # （见 get_tts_worker 原注释 / PR #1764 review 第三轮 #3）。

--- a/main_routers/characters_router/voice_preview.py
+++ b/main_routers/characters_router/voice_preview.py
@@ -405,13 +405,13 @@ async def get_voices():
             # Remove colliding clone rows so every frontend keeps the winning owner.
             # 配置型 preset 对精确 Voice ID 拥有显式所有权。目录中移除同名历史
             # 克隆，避免前端去重逻辑把真正会命中的 Custom API 条目隐藏掉。
-            configured_ids = {
-                str(voice_id).casefold() for voice_id in selected_preset_catalog
-            }
+            # Runtime configured-preset ownership is exact and case-sensitive.
+            # 目录去重必须与运行时精确 ID 语义一致；大小写不同的克隆仍可选择。
+            configured_ids = {str(voice_id) for voice_id in selected_preset_catalog}
             result["voices"] = {
                 voice_id: voice_data
                 for voice_id, voice_data in (result["voices"] or {}).items()
-                if str(voice_id).casefold() not in configured_ids
+                if str(voice_id) not in configured_ids
             }
         result["native_voices"] = selected_preset_catalog
     elif active_native_provider:

--- a/main_routers/characters_router/voice_preview.py
+++ b/main_routers/characters_router/voice_preview.py
@@ -137,6 +137,19 @@ def _is_unpreviewable_selected_preset_voice(config_manager, core_config, voice_i
     static-catalog provider like MiMo (60), so the clone wins. Any id present in a voice
     storage bucket is therefore never treated as an unpreviewable preset (dual to the
     native-preview collision guard, which passes voice_id_exists_in_any_storage)."""
+    try:
+        selected_preset_key = tts_provider_registry.selected_preset_provider_key(
+            core_config or {}, config_manager, voice_id
+        )
+        selected_provider = tts_provider_registry.get(selected_preset_key)
+        if selected_provider and selected_provider.configured_preset_voice:
+            # The exact configured preset owns preview routing over a stale clone.
+            # 配置框中的精确 Voice ID 归当前 Custom API 所有；即使存储里有同名
+            # 克隆，也不能借旧克隆的 preview 路径制造预览/运行时身份分裂。
+            return True
+    except Exception:
+        logger.debug("configured preset preview 归属判定失败，按普通冲突规则继续", exc_info=True)
+
     if voice_data:
         return False
     try:
@@ -379,7 +392,7 @@ async def get_voices():
         core_config or {}, _config_manager
     )
     selected_preset_catalog = (
-        tts_provider_registry.preset_catalog_for_ui(winning_provider_key)
+        tts_provider_registry.preset_catalog_for_ui(winning_provider_key, core_config)
         if winning_provider_key else None
     )
     active_native_provider = (
@@ -387,6 +400,19 @@ async def get_voices():
         if winning_provider_key is None else None
     )
     if selected_preset_catalog is not None:
+        selected_provider = tts_provider_registry.get(winning_provider_key)
+        if selected_provider and selected_provider.configured_preset_voice:
+            # Remove colliding clone rows so every frontend keeps the winning owner.
+            # 配置型 preset 对精确 Voice ID 拥有显式所有权。目录中移除同名历史
+            # 克隆，避免前端去重逻辑把真正会命中的 Custom API 条目隐藏掉。
+            configured_ids = {
+                str(voice_id).casefold() for voice_id in selected_preset_catalog
+            }
+            result["voices"] = {
+                voice_id: voice_data
+                for voice_id, voice_data in (result["voices"] or {}).items()
+                if str(voice_id).casefold() not in configured_ids
+            }
         result["native_voices"] = selected_preset_catalog
     elif active_native_provider:
         native_catalog = get_native_voice_catalog_for_ui(active_native_provider) or {}

--- a/static/js/character_card_manager/card-form-and-actions.js
+++ b/static/js/character_card_manager/card-form-and-actions.js
@@ -763,13 +763,20 @@ function _panelGetNativeVoiceProviderLabel(nativeEntries) {
     if (!Array.isArray(nativeEntries)) return '';
     for (const [, voiceData] of nativeEntries) {
         const provider = voiceData && String(voiceData.provider || '').trim();
+        const configuredLabel = voiceData && String(voiceData.provider_label || '').trim();
+        // A configured preset is grouped under Custom API while its real
+        // provider identity remains available for save and runtime routing.
+        // 配置音色展示为“自定义 API”，保存与运行时仍使用真实 provider。
+        if (VoiceDisplayUtils.isKnownProvider(configuredLabel, { includeFree: false })) {
+            return _panelVoiceProviderShortName(configuredLabel);
+        }
         if (provider === 'free') {
             return _panelVoiceI18n('voice.providerFreeApi', 'Free API');
         }
         if (VoiceDisplayUtils.isKnownProvider(provider, { includeFree: false })) {
             return _panelVoiceProviderShortName(provider);
         }
-        const label = voiceData && (voiceData.provider_label || provider);
+        const label = configuredLabel || provider;
         if (label) return String(label);
     }
     return '';

--- a/static/js/voice_clone.js
+++ b/static/js/voice_clone.js
@@ -217,10 +217,17 @@ function getNativeVoiceProviderLabel(nativeEntries) {
     if (!Array.isArray(nativeEntries)) return '';
     for (const [, voiceData] of nativeEntries) {
         const provider = voiceData && String(voiceData.provider || '').trim();
+        const configuredLabel = voiceData && String(voiceData.provider_label || '').trim();
+        // Configured presets share the Custom API source label without losing
+        // the provider key that owns preview and synthesis behavior.
+        // 配置音色共用“自定义 API”来源名，provider key 仍负责试听与合成路由。
+        if (VoiceDisplayUtils.isKnownProvider(configuredLabel)) {
+            return getNativeProviderShortName(configuredLabel);
+        }
         if (VoiceDisplayUtils.isKnownProvider(provider)) {
             return getNativeProviderShortName(provider);
         }
-        const label = voiceData && (voiceData.provider_label || provider);
+        const label = configuredLabel || provider;
         if (label) return String(label);
     }
     return '';

--- a/static/js/voice_display_utils.js
+++ b/static/js/voice_display_utils.js
@@ -18,6 +18,7 @@ const VoiceDisplayUtils = (() => {
         grok: 'Grok',
         mimo: 'MiMo',
         vllm_omni: 'vLLM-Omni',
+        custom: 'Custom API',
     });
 
     function t(key, fallback) {
@@ -50,6 +51,9 @@ const VoiceDisplayUtils = (() => {
         }
         if (normalized === 'free') {
             return t(options.freeKey || 'voice.providerFree', options.freeFallback || 'Free');
+        }
+        if (normalized === 'custom') {
+            return t('api.customModelProviderCustom', 'Custom API');
         }
         return PROVIDER_SHORT[normalized] || normalized;
     }

--- a/tests/frontend/test_character_card_manager_regressions.py
+++ b/tests/frontend/test_character_card_manager_regressions.py
@@ -446,6 +446,85 @@ def test_character_card_manager_voice_dropdown_groups_by_provider_source(
 
 
 @pytest.mark.frontend
+@pytest.mark.parametrize(
+    ("provider", "voice_id"),
+    [
+        ("vllm_omni", "default"),
+        ("custom", "vendor-voice"),
+    ],
+)
+def test_character_card_manager_shows_configured_custom_api_voice(
+    mock_page: Page,
+    running_server: str,
+    provider: str,
+    voice_id: str,
+):
+    """Configured HTTPS/WSS voices replace the unspecified placeholder when selected."""
+    _open_character_card_manager(mock_page, running_server)
+
+    state = mock_page.evaluate(
+        """
+        async ({ provider, voiceId }) => {
+            window.t = (key) => ({
+                'api.customModelProviderCustom': 'Custom API',
+                'voice.sourcePreset': 'Preset',
+                'voice.providerUnknown': 'Other',
+                'character.voiceNotSet': 'Unspecified voice'
+            }[key] || key);
+
+            const originalFetch = window.fetch.bind(window);
+            window.fetch = async (input, init) => {
+                const url = typeof input === 'string' ? input : input.url;
+                const path = new URL(url, window.location.origin).pathname;
+                if (path === '/api/characters/voices') {
+                    return new Response(JSON.stringify({
+                        voices: {},
+                        free_voices: {},
+                        native_voices: {
+                            [voiceId]: {
+                                prefix: voiceId,
+                                provider,
+                                provider_label: 'custom'
+                            }
+                        }
+                    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+                }
+                if (path === '/api/characters/custom_tts_voices') {
+                    return new Response(JSON.stringify({ success: true, voices: [] }), {
+                        status: 200, headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                return originalFetch(input, init);
+            };
+
+            const select = document.createElement('select');
+            document.body.appendChild(select);
+            await _loadPanelVoices(select, voiceId);
+
+            const selected = select.options[select.selectedIndex];
+            const group = Array.from(select.querySelectorAll('optgroup'))
+                .find(item => Array.from(item.querySelectorAll('option'))
+                    .some(option => option.value === voiceId));
+            return {
+                value: select.value,
+                selectedText: selected ? selected.textContent : '',
+                groupLabel: group ? group.label : '',
+                unspecifiedSelected: select.options[0] ? select.options[0].selected : true
+            };
+        }
+        """,
+        {"provider": provider, "voiceId": voice_id},
+    )
+
+    assert state == {
+        "value": voice_id,
+        "selectedText": voice_id,
+        "groupLabel": "Custom API · Preset",
+        "unspecifiedSelected": False,
+    }
+
+
+@pytest.mark.frontend
 def test_character_card_manager_localizes_free_api_native_voice_provider_label(
     mock_page: Page,
     running_server: str,

--- a/tests/unit/test_gemini_realtime_voice_routing.py
+++ b/tests/unit/test_gemini_realtime_voice_routing.py
@@ -479,6 +479,38 @@ def test_explicit_vllm_tts_uses_external_tts_before_native_voice():
     )
 
 
+def test_explicit_custom_tts_owns_configured_voice_before_native_voice():
+    core_config = {
+        "ENABLE_CUSTOM_API": True,
+        "ttsModelProvider": "custom",
+        "ttsModelUrl": "https://speech.example.com/v1",
+        "ttsModelId": "vendor-model",
+        "ttsVoiceId": "Puck",
+        "GPTSOVITS_ENABLED": False,
+    }
+    mgr = _make_mgr("Puck", core_config=core_config)
+
+    assert (
+        LLMSessionManager._resolve_session_use_tts(
+            mgr,
+            "audio",
+            {"base_url": "https://generativelanguage.googleapis.com"},
+            core_config,
+        )
+        is True
+    )
+    disabled_config = {**core_config, "ENABLE_CUSTOM_API": False}
+    assert (
+        LLMSessionManager._resolve_session_use_tts(
+            mgr,
+            "audio",
+            {"base_url": "https://generativelanguage.googleapis.com"},
+            disabled_config,
+        )
+        is False
+    )
+
+
 def test_vllm_runtime_key_tracks_raw_runtime_config(monkeypatch):
     class _CM:
         def __init__(self, url, model, voice_id, tts_model=""):

--- a/tests/unit/test_mimo_tts_voices.py
+++ b/tests/unit/test_mimo_tts_voices.py
@@ -106,7 +106,7 @@ def test_mimo_preset_catalog_for_ui_shape_matches_native():
 def _selected_catalog(core_config, cm):
     # 模拟 /voices 取目录的两步：先拿赢家 key，再按 key 取其静态预制目录
     key = tts_provider_registry.selected_provider_key(core_config, cm)
-    return tts_provider_registry.preset_catalog_for_ui(key) if key else None
+    return tts_provider_registry.preset_catalog_for_ui(key, core_config) if key else None
 
 
 @pytest.mark.unit
@@ -143,14 +143,28 @@ def test_mimo_catalog_hidden_when_gptsovits_custom_tts_wins():
 
 
 @pytest.mark.unit
-def test_no_catalog_winner_suppresses_native_voices():
-    # vLLM-Omni（无静态目录）赢得 dispatch：selected_provider_key 返回 vllm_omni、
-    # 目录为 None → /voices 的三路分支既不出目录、也不回退 core-native。
-    core_config = {"CORE_API_TYPE": "gemini", "ENABLE_CUSTOM_API": True}
+def test_vllm_winner_exposes_configured_default_voice():
+    # WSS 自定义 TTS 与 HTTPS custom 对偶：配置音色为空时展示 provider 默认音色，
+    # 并归入“自定义 API”来源，同时保留 vllm_omni 作为真实路由 owner。
+    core_config = {
+        "CORE_API_TYPE": "gemini",
+        "ENABLE_CUSTOM_API": True,
+        "ttsModelProvider": "vllm_omni",
+        "ttsVoiceId": "",
+    }
     cm = _CM(core_config, raw_core_config={"ttsModelProvider": "vllm_omni"})
     key = tts_provider_registry.selected_provider_key(core_config, cm)
     assert key == "vllm_omni"
-    assert tts_provider_registry.preset_catalog_for_ui(key) is None
+    assert tts_provider_registry.preset_catalog_for_ui(key, core_config) == {
+        "default": {
+            "prefix": "default",
+            "provider": "vllm_omni",
+            "provider_label": "custom",
+            "gender": "",
+            "display_name": "default",
+            "builtin": True,
+        }
+    }
 
 
 @pytest.mark.unit
@@ -234,3 +248,76 @@ def test_normalize_mimo_preset_unresolved_when_not_selected(config_manager):
     stored = config_manager.voice_id_to_storage_value("Milo")
     assert stored == "Milo"
     assert read_legacy_voice_id(stored) == "Milo"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("provider", "voice_id"),
+    [
+        ("custom", "vendor-voice"),
+        ("vllm_omni", "default"),
+    ],
+)
+def test_configured_custom_tts_voice_saves_with_runtime_owner(
+    config_manager,
+    provider,
+    voice_id,
+):
+    # Both HTTPS and WSS configured voices use the same preset storage schema,
+    # while provider keeps the real worker owner for runtime dispatch.
+    # HTTPS 与 WSS 配置音色都按预制音色保存，provider 必须保留真实路由归属。
+    _write_core_config(
+        config_manager,
+        {
+            "coreApi": "qwen",
+            "enableCustomApi": True,
+            "ttsModelProvider": provider,
+            "ttsModelUrl": "https://speech.example.com/v1"
+            if provider == "custom"
+            else "wss://speech.example.com/v1",
+            "ttsModelId": "vendor-tts",
+            "ttsVoiceId": voice_id,
+        },
+    )
+
+    stored = config_manager.voice_id_to_storage_value(voice_id)
+
+    assert stored == {
+        "source": "preset",
+        "provider": provider,
+        "ref": voice_id,
+    }
+    assert read_legacy_voice_id(stored) == voice_id
+
+
+@pytest.mark.unit
+def test_configured_custom_voice_owner_wins_over_same_id_clone(
+    config_manager,
+    monkeypatch,
+):
+    _write_core_config(
+        config_manager,
+        {
+            "coreApi": "qwen",
+            "enableCustomApi": True,
+            "ttsModelProvider": "custom",
+            "ttsModelUrl": "https://speech.example.com/v1",
+            "ttsModelId": "vendor-tts",
+            "ttsVoiceId": "vendor-voice",
+        },
+    )
+    monkeypatch.setattr(
+        config_manager,
+        "get_voices_for_current_api",
+        lambda **_kwargs: {
+            "vendor-voice": {"provider": "cosyvoice", "source": "clone"}
+        },
+    )
+
+    stored = config_manager.voice_id_to_storage_value("vendor-voice")
+
+    assert stored == {
+        "source": "preset",
+        "provider": "custom",
+        "ref": "vendor-voice",
+    }

--- a/tests/unit/test_mimo_tts_worker.py
+++ b/tests/unit/test_mimo_tts_worker.py
@@ -634,12 +634,24 @@ def test_vllm_omni_worker_marks_not_ready_on_server_error_event(monkeypatch):
     assert not thread.is_alive()
 
     assert ("__ready__", True) in seen
-    assert any(
-        isinstance(item, tuple)
-        and item[0] == "__error__"
-        and "BAD_MODEL" in str(item[1])
+    error_payloads = [
+        json.loads(item[1])
         for item in seen
-    )
+        if isinstance(item, tuple) and item[0] == "__error__"
+    ]
+    # Configured endpoints expose only the stable diagnostic contract; the raw
+    # server code/message may contain provider echoes and must stay private.
+    # 自定义端点只上报稳定错误码、provider 与阶段，禁止透传原始服务端内容。
+    assert error_payloads == [
+        {
+            "code": "TTS_CONFIGURED_API_FAILURE",
+            "provider": "vllm_omni",
+            "stage": "server_event",
+            "message": "Configured TTS API unavailable; using existing fallback order",
+        }
+    ]
+    assert "BAD_MODEL" not in str(error_payloads)
+    assert "invalid model" not in str(error_payloads)
 
 
 @pytest.mark.unit

--- a/tests/unit/test_openai_compatible_tts.py
+++ b/tests/unit/test_openai_compatible_tts.py
@@ -298,6 +298,24 @@ async def test_configured_custom_voice_hides_same_id_clone_from_character_catalo
 
 
 @pytest.mark.asyncio
+async def test_configured_voice_keeps_case_distinct_clone_in_character_catalog(
+    monkeypatch,
+):
+    cm = _CustomTtsConfigManager()
+    cm.voices["Vendor-Voice"] = {
+        "voice_id": "Vendor-Voice",
+        "provider": "cosyvoice",
+        "source": "clone",
+    }
+    monkeypatch.setattr(voice_preview_module, "get_config_manager", lambda: cm)
+
+    result = await voice_preview_module.get_voices()
+
+    assert result["voices"]["Vendor-Voice"]["provider"] == "cosyvoice"
+    assert result["native_voices"]["vendor-voice"]["provider"] == "custom"
+
+
+@pytest.mark.asyncio
 async def test_voices_endpoint_maps_vllm_default_to_custom_api_catalog(monkeypatch):
     cm = _CustomTtsConfigManager()
     cm.raw.update(
@@ -322,6 +340,46 @@ async def test_voices_endpoint_maps_vllm_default_to_custom_api_catalog(monkeypat
         "display_name": "default",
         "builtin": True,
     }
+
+
+def test_exact_configured_vllm_voice_wins_over_same_id_clone(monkeypatch):
+    cm = _CustomTtsConfigManager()
+    cm.raw.update(
+        {
+            "ttsModelProvider": "vllm_omni",
+            "ttsModelUrl": "wss://speech.example.com/v1",
+            "ttsModelId": "vendor-tts",
+            "ttsVoiceId": "default",
+        }
+    )
+    cm.snapshot.update(cm.raw)
+    monkeypatch.setattr(tts_client, "get_config_manager", lambda: cm)
+    monkeypatch.setattr(
+        tts_client,
+        "_get_voice_meta",
+        lambda _voice_id: {
+            "provider": "vllm_omni",
+            "source": "clone",
+            "clone_sample_b64": "QUJDRA==",
+            "clone_sample_mime": "audio/wav",
+        },
+    )
+
+    worker, api_key, provider_key = tts_client.get_tts_worker(
+        core_api_type="qwen",
+        has_custom_voice=True,
+        voice_id="default",
+    )
+
+    assert isinstance(worker, partial)
+    assert worker.func is tts_client.vllm_omni_tts_worker
+    assert worker.keywords == {
+        "base_url": "wss://speech.example.com/v1",
+        "model": "vendor-tts",
+        "voice": "default",
+    }
+    assert api_key == "sk-custom"
+    assert provider_key == "vllm_omni"
 
 
 def test_configured_custom_voice_is_saveable_for_character():

--- a/tests/unit/test_openai_compatible_tts.py
+++ b/tests/unit/test_openai_compatible_tts.py
@@ -642,6 +642,34 @@ def test_configured_provider_predicate_failure_redacts_exception(monkeypatch):
     assert all(secret not in "\n".join(errors) for secret in secrets)
 
 
+def test_configured_preset_ownership_failure_is_redacted_and_non_fatal(monkeypatch):
+    errors = []
+    secrets = ("sk-secret-should-not-log", "token=signed-query", "角色原文不能记录")
+    monkeypatch.setattr(
+        provider_registry,
+        "selected_preset_provider_key",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError(" ".join(secrets))
+        ),
+    )
+    monkeypatch.setattr(
+        tts_infra_module.logger,
+        "error",
+        lambda message, *args, **_kwargs: errors.append(message % args),
+    )
+
+    assert (
+        tts_client.selected_configured_tts_preset_provider_key(
+            {}, SimpleNamespace(), "configured-voice"
+        )
+        is None
+    )
+    assert errors == [
+        "code=TTS_CONFIGURED_API_FAILURE provider=configured stage=ownership"
+    ]
+    assert all(secret not in "\n".join(errors) for secret in secrets)
+
+
 def test_configured_sentence_worker_redacts_exception_and_input(monkeypatch):
     errors = []
     secrets = ("sk-secret-should-not-log", "token=signed-query", "角色原文不能记录")

--- a/tests/unit/test_openai_compatible_tts.py
+++ b/tests/unit/test_openai_compatible_tts.py
@@ -382,6 +382,98 @@ def test_exact_configured_vllm_voice_wins_over_same_id_clone(monkeypatch):
     assert provider_key == "vllm_omni"
 
 
+def test_vllm_resolve_keeps_selection_snapshot_when_disk_changes(monkeypatch):
+    cm = _CustomTtsConfigManager()
+    cm.snapshot.update(
+        {
+            "ttsModelProvider": "vllm_omni",
+            "ttsModelUrl": "wss://snapshot.example.com/v1",
+            "ttsModelId": "snapshot-model",
+            "ttsVoiceId": "snapshot-voice",
+        }
+    )
+    cm.raw.update(
+        {
+            "ttsModelProvider": "vllm_omni",
+            "ttsModelUrl": "wss://new-disk.example.com/v1",
+            "ttsModelId": "new-disk-model",
+            "ttsModelApiKey": "new-disk-key",
+            "ttsVoiceId": "new-disk-voice",
+        }
+    )
+    monkeypatch.setattr(tts_client, "get_config_manager", lambda: cm)
+    monkeypatch.setattr(
+        tts_client,
+        "_get_voice_meta",
+        lambda _voice_id: {
+            "provider": "vllm_omni",
+            "source": "clone",
+            "clone_sample_b64": "QUJDRA==",
+            "clone_sample_mime": "audio/wav",
+        },
+    )
+
+    worker, api_key, provider_key = tts_client.get_tts_worker(
+        core_api_type="qwen",
+        has_custom_voice=True,
+        voice_id="snapshot-voice",
+    )
+
+    assert isinstance(worker, partial)
+    assert worker.func is tts_client.vllm_omni_tts_worker
+    assert worker.keywords == {
+        "base_url": "wss://snapshot.example.com/v1",
+        "model": "snapshot-model",
+        "voice": "snapshot-voice",
+    }
+    # Sensitive credentials are intentionally resolved from raw storage only.
+    # 敏感 API Key 不进会话快照，仍只从原始配置解析。
+    assert api_key == "new-disk-key"
+    assert provider_key == "vllm_omni"
+
+
+def test_vllm_resolve_does_not_send_new_provider_key_to_stale_snapshot(monkeypatch):
+    cm = _CustomTtsConfigManager()
+    cm.snapshot.update(
+        {
+            "ttsModelProvider": "vllm_omni",
+            "ttsModelUrl": "wss://snapshot.example.com/v1",
+            "ttsModelId": "snapshot-model",
+            "ttsVoiceId": "snapshot-voice",
+        }
+    )
+    cm.raw.update(
+        {
+            "ttsModelProvider": "custom",
+            "ttsModelUrl": "https://new-provider.example.com/v1",
+            "ttsModelApiKey": "new-provider-secret",
+        }
+    )
+    monkeypatch.setattr(tts_client, "get_config_manager", lambda: cm)
+
+    worker, api_key, provider_key = tts_client.get_tts_worker(
+        core_api_type="qwen",
+        has_custom_voice=False,
+        voice_id="snapshot-voice",
+    )
+
+    assert worker is tts_infra_module.configured_tts_unavailable_worker
+    assert api_key == ""
+    assert provider_key == "vllm_omni"
+
+
+def test_vllm_selection_respects_explicit_empty_snapshot_provider():
+    cm = _CustomTtsConfigManager()
+    cm.raw["ttsModelProvider"] = "vllm_omni"
+    ctx = provider_registry.DispatchContext(
+        core_config={"ENABLE_CUSTOM_API": True, "ttsModelProvider": ""},
+        cm=cm,
+    )
+
+    assert vllm_worker_module._vllm_omni_is_selected(ctx) is False
+    assert cm.load_count == 0
+
+
 def test_configured_custom_voice_is_saveable_for_character():
     cm = _CustomTtsConfigManager()
 

--- a/tests/unit/test_openai_compatible_tts.py
+++ b/tests/unit/test_openai_compatible_tts.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import queue
 import threading
@@ -10,7 +11,12 @@ import numpy as np
 import pytest
 
 from main_logic import tts_client
+from main_logic.core import LLMSessionManager
+from main_logic.core import tts_runtime as tts_runtime_module
+from main_logic.tts_client import _infra as tts_infra_module
 from main_logic.tts_client.workers import openai as openai_worker_module
+from main_logic.tts_client.workers import vllm_omni as vllm_worker_module
+from main_routers.characters_router import voice_preview as voice_preview_module
 from main_routers.config_router.connectivity import _test_connectivity_candidates
 from utils.openai_tts import (
     OPENAI_TTS_PCM_SAMPLE_RATE,
@@ -118,6 +124,7 @@ def test_siliconflow_pins_streaming_pcm_sample_rate_without_polluting_other_prov
 class _CustomTtsConfigManager:
     def __init__(self):
         self.load_count = 0
+        self.voices = {}
         self.raw = {
             "enableCustomApi": True,
             "ttsModelProvider": "custom",
@@ -138,8 +145,17 @@ class _CustomTtsConfigManager:
         self.load_count += 1
         return dict(self.raw)
 
-    def get_voices_for_current_api(self):
-        return {}
+    def get_voices_for_current_api(self, **_kwargs):
+        return dict(self.voices)
+
+    async def aensure_region_resolved(self):
+        return True
+
+    async def aget_core_config(self):
+        return dict(self.snapshot)
+
+    async def aload_characters(self):
+        return {"猫娘": {}}
 
 
 def test_custom_openai_tts_dispatch_binds_config(monkeypatch):
@@ -158,6 +174,8 @@ def test_custom_openai_tts_dispatch_binds_config(monkeypatch):
         "base_url": "https://speech.example.com/v1",
         "model": "vendor-tts",
         "voice": "vendor-voice",
+        "label": "自定义 TTS API (Custom OpenAI-compatible TTS)",
+        "safe_error_provider": "custom",
     }
     assert api_key == "sk-custom"
     assert provider_key == "custom"
@@ -188,6 +206,19 @@ def test_custom_openai_tts_does_not_override_stored_clone():
     assert openai_worker_module._custom_openai_tts_is_selected(ctx) is False
 
 
+def test_exact_configured_custom_voice_wins_over_same_id_clone():
+    cm = _CustomTtsConfigManager()
+    ctx = provider_registry.DispatchContext(
+        core_config=cm.snapshot,
+        cm=cm,
+        voice_id="vendor-voice",
+        has_custom_voice=True,
+        voice_meta_loader=lambda: {"provider": "cosyvoice", "source": "clone"},
+    )
+
+    assert openai_worker_module._custom_openai_tts_is_selected(ctx) is True
+
+
 def test_custom_openai_tts_uses_character_voice_without_configured_fallback():
     cm = _CustomTtsConfigManager()
     cm.snapshot["ttsVoiceId"] = ""
@@ -212,6 +243,672 @@ def test_custom_openai_tts_requires_an_effective_voice():
     )
 
     assert openai_worker_module._custom_openai_tts_is_selected(ctx) is False
+
+
+def test_configured_custom_voice_is_exposed_to_character_picker():
+    cm = _CustomTtsConfigManager()
+
+    assert provider_registry.preset_catalog_for_ui("custom", cm.snapshot) == {
+        "vendor-voice": {
+            "prefix": "vendor-voice",
+            "provider": "custom",
+            "provider_label": "custom",
+            "gender": "",
+            "display_name": "vendor-voice",
+            "builtin": True,
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_voices_endpoint_maps_configured_custom_voice_to_character_catalog(
+    monkeypatch,
+):
+    cm = _CustomTtsConfigManager()
+    monkeypatch.setattr(voice_preview_module, "get_config_manager", lambda: cm)
+
+    result = await voice_preview_module.get_voices()
+
+    assert result["native_voices"]["vendor-voice"]["provider"] == "custom"
+    assert result["voice_owners"] == {}
+
+
+@pytest.mark.asyncio
+async def test_configured_custom_voice_hides_same_id_clone_from_character_catalog(
+    monkeypatch,
+):
+    cm = _CustomTtsConfigManager()
+    cm.voices["vendor-voice"] = {
+        "voice_id": "vendor-voice",
+        "provider": "cosyvoice",
+        "source": "clone",
+    }
+    monkeypatch.setattr(voice_preview_module, "get_config_manager", lambda: cm)
+
+    result = await voice_preview_module.get_voices()
+
+    assert "vendor-voice" not in result["voices"]
+    assert result["native_voices"]["vendor-voice"]["provider"] == "custom"
+    assert voice_preview_module._is_unpreviewable_selected_preset_voice(
+        cm,
+        cm.snapshot,
+        "vendor-voice",
+        cm.voices["vendor-voice"],
+    ) is True
+
+
+@pytest.mark.asyncio
+async def test_voices_endpoint_maps_vllm_default_to_custom_api_catalog(monkeypatch):
+    cm = _CustomTtsConfigManager()
+    cm.raw.update(
+        {
+            "ttsModelProvider": "vllm_omni",
+            "ttsModelUrl": "wss://speech.example.com/v1",
+            "ttsVoiceId": "",
+        }
+    )
+    cm.snapshot.update(cm.raw)
+    monkeypatch.setattr(voice_preview_module, "get_config_manager", lambda: cm)
+
+    result = await voice_preview_module.get_voices()
+
+    # The catalog source is Custom API, but the runtime owner stays vllm_omni.
+    # 目录显示“自定义 API”，实际保存与调度仍归属 vllm_omni。
+    assert result["native_voices"]["default"] == {
+        "prefix": "default",
+        "provider": "vllm_omni",
+        "provider_label": "custom",
+        "gender": "",
+        "display_name": "default",
+        "builtin": True,
+    }
+
+
+def test_configured_custom_voice_is_saveable_for_character():
+    cm = _CustomTtsConfigManager()
+
+    assert provider_registry.is_selected_preset_voice(
+        cm.snapshot,
+        cm,
+        "vendor-voice",
+    )
+    assert not provider_registry.is_selected_preset_voice(
+        cm.snapshot,
+        cm,
+        "another-voice",
+    )
+
+
+def test_custom_config_read_failure_stays_owned_until_supervised_fallback(monkeypatch):
+    cm = _CustomTtsConfigManager()
+    errors = []
+    secrets = ("sk-secret-should-not-log", "token=signed-query", "角色原文不能记录")
+
+    def broken_load(*_args, **_kwargs):
+        raise OSError(" ".join(secrets))
+
+    cm.load_json_config = broken_load
+    monkeypatch.setattr(tts_client, "get_config_manager", lambda: cm)
+    monkeypatch.setattr(
+        tts_infra_module.logger,
+        "error",
+        lambda message, *args, **_kwargs: errors.append(message % args),
+    )
+
+    worker, api_key, provider_key = tts_client.get_tts_worker(
+        core_api_type="qwen",
+        has_custom_voice=True,
+        voice_id="vendor-voice",
+    )
+
+    request_queue = queue.Queue()
+    response_queue = queue.Queue()
+    worker(request_queue, response_queue, api_key, "vendor-voice")
+
+    # Keep ownership until core strips the failed preset identity and credentials.
+    # 读取失败不能直接误入 CosyVoice；先保留 custom 身份，再由监管层安全回退。
+    assert provider_key == "custom"
+    assert api_key == ""
+    assert response_queue.get_nowait() == ("__ready__", False)
+    assert errors == [
+        "code=TTS_CONFIGURED_API_FAILURE provider=custom stage=configuration"
+    ]
+    assert all(secret not in "\n".join(errors) for secret in secrets)
+
+
+def test_failed_configured_preset_redispatch_uses_default_voice_route(monkeypatch):
+    cm = _CustomTtsConfigManager()
+    monkeypatch.setattr(tts_client, "get_config_manager", lambda: cm)
+
+    _worker, _api_key, provider_key = tts_client.get_tts_worker(
+        core_api_type="qwen",
+        has_custom_voice=False,
+        voice_id="",
+        excluded_provider_keys={"custom"},
+    )
+
+    assert provider_key == "qwen"
+
+
+def test_supervised_fallback_uses_default_voice_and_default_credentials(monkeypatch):
+    mgr = LLMSessionManager.__new__(LLMSessionManager)
+    config_slots = []
+    dispatch_calls = []
+    thread_args = []
+
+    class _FakeThread:
+        def __init__(self, *, target, args, daemon):
+            _ = target, daemon
+            thread_args.append(args)
+
+        def start(self):
+            return None
+
+    def get_model_api_config(slot):
+        config_slots.append(slot)
+        return {"api_key": "sk-default" if slot == "tts_default" else "sk-custom"}
+
+    def get_worker(**kwargs):
+        dispatch_calls.append(kwargs)
+        return (lambda *_args: None), None, "qwen"
+
+    mgr._config_manager = SimpleNamespace(
+        get_core_config=lambda: {},
+        get_model_api_config=get_model_api_config,
+    )
+    mgr.core_api_type = "qwen"
+    mgr.voice_id = "vendor-voice"
+    mgr._is_free_preset_voice = False
+    mgr._tts_fallback_uses_default_voice = True
+    mgr._tts_excluded_provider_keys = frozenset({"custom"})
+    mgr._build_tts_runtime_key = lambda: ("fallback",)
+    monkeypatch.setattr(tts_runtime_module, "Thread", _FakeThread)
+    monkeypatch.setattr(tts_runtime_module._core_facade, "get_tts_worker", get_worker)
+
+    LLMSessionManager._start_tts_thread(mgr, preserve_provider_exclusions=True)
+
+    # The replacement sees neither the failed Voice ID nor the custom credential.
+    # 替代 worker 只能收到默认路由的空音色和默认凭证，不能复用失败配置。
+    assert dispatch_calls[0]["voice_id"] == ""
+    assert dispatch_calls[0]["has_custom_voice"] is False
+    assert config_slots == ["tts_default"]
+    assert thread_args[0][2:] == ("sk-default", "")
+
+
+def test_vllm_config_read_failure_stays_owned_until_supervised_fallback(monkeypatch):
+    cm = _CustomTtsConfigManager()
+    cm.raw["ttsModelProvider"] = "vllm_omni"
+    cm.snapshot.update(cm.raw)
+    errors = []
+    secrets = ("sk-secret-should-not-log", "token=signed-query", "角色原文不能记录")
+
+    def broken_load(*_args, **_kwargs):
+        raise OSError(" ".join(secrets))
+
+    cm.load_json_config = broken_load
+    monkeypatch.setattr(tts_client, "get_config_manager", lambda: cm)
+    monkeypatch.setattr(
+        tts_infra_module.logger,
+        "error",
+        lambda message, *args, **_kwargs: errors.append(message % args),
+    )
+
+    worker, api_key, provider_key = tts_client.get_tts_worker(
+        core_api_type="qwen",
+        has_custom_voice=False,
+        voice_id="default",
+    )
+
+    request_queue = queue.Queue()
+    response_queue = queue.Queue()
+    worker(request_queue, response_queue, api_key, "default")
+
+    assert provider_key == "vllm_omni"
+    assert api_key == ""
+    assert response_queue.get_nowait() == ("__ready__", False)
+    assert errors == [
+        "code=TTS_CONFIGURED_API_FAILURE provider=vllm_omni stage=configuration"
+    ]
+    assert all(secret not in "\n".join(errors) for secret in secrets)
+
+
+def test_vllm_connection_failure_logs_only_safe_provider_stage(monkeypatch):
+    logs = []
+    secret_key = "sk-secret-should-not-log"
+    secret_token = "signed-query-should-not-log"
+    raw_text = "角色原文不能记录"
+
+    async def broken_connect(*_args, **_kwargs):
+        raise RuntimeError(f"{secret_key} {secret_token} {raw_text}")
+
+    def capture(message, *args, **_kwargs):
+        logs.append(message % args)
+
+    monkeypatch.setattr(vllm_worker_module.websockets, "connect", broken_connect)
+    monkeypatch.setattr(vllm_worker_module.logger, "error", capture)
+    monkeypatch.setattr(vllm_worker_module.logger, "warning", capture)
+    monkeypatch.setattr(vllm_worker_module.logger, "info", capture)
+    monkeypatch.setattr(tts_infra_module.logger, "error", capture)
+
+    response_queue = queue.Queue()
+    vllm_worker_module.vllm_omni_tts_worker(
+        queue.Queue(),
+        response_queue,
+        secret_key,
+        "default",
+        base_url=f"wss://speech.example.test/v1?token={secret_token}",
+    )
+    queued = []
+    while not response_queue.empty():
+        queued.append(response_queue.get_nowait())
+    serialized = "\n".join(logs + [repr(item) for item in queued])
+
+    assert "code=TTS_CONFIGURED_API_FAILURE provider=vllm_omni stage=connect" in logs
+    assert ("__ready__", False) in queued
+    assert secret_key not in serialized
+    assert secret_token not in serialized
+    assert raw_text not in serialized
+
+
+def test_unconfigured_custom_tts_keeps_existing_native_route(monkeypatch):
+    cm = _CustomTtsConfigManager()
+    cm.snapshot["ENABLE_CUSTOM_API"] = False
+    cm.snapshot["enableCustomApi"] = False
+    monkeypatch.setattr(tts_client, "get_config_manager", lambda: cm)
+
+    _worker, _api_key, provider_key = tts_client.get_tts_worker(
+        core_api_type="qwen",
+        has_custom_voice=False,
+        voice_id="",
+    )
+
+    assert provider_key == "qwen"
+
+
+def test_resolve_selected_skips_broken_predicate_like_catalog_selection(monkeypatch):
+    ctx = provider_registry.DispatchContext(
+        core_config={},
+        cm=SimpleNamespace(),
+    )
+    warnings = []
+    fallback_result = (object(), None, "fallback")
+    broken = SimpleNamespace(
+        key="broken",
+        is_selected=lambda _ctx: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    healthy = SimpleNamespace(
+        key="healthy",
+        is_selected=lambda _ctx: True,
+        resolve=lambda _ctx: fallback_result,
+    )
+    monkeypatch.setattr(provider_registry, "all_providers", lambda: [broken, healthy])
+    monkeypatch.setattr(
+        provider_registry.logger,
+        "warning",
+        lambda message, *args, **_kwargs: warnings.append(message % args),
+    )
+
+    assert provider_registry.resolve_selected(ctx) == fallback_result
+    assert any("'broken' is_selected 判定异常" in message for message in warnings)
+
+
+def test_configured_provider_predicate_failure_redacts_exception(monkeypatch):
+    ctx = provider_registry.DispatchContext(core_config={}, cm=SimpleNamespace())
+    errors = []
+    secrets = ("sk-secret-should-not-log", "token=signed-query", "角色原文不能记录")
+    fallback_result = (object(), None, "fallback")
+    broken = SimpleNamespace(
+        key="custom",
+        fallback_on_failure=True,
+        is_selected=lambda _ctx: (_ for _ in ()).throw(
+            RuntimeError(" ".join(secrets))
+        ),
+    )
+    healthy = SimpleNamespace(
+        key="healthy",
+        fallback_on_failure=False,
+        is_selected=lambda _ctx: True,
+        resolve=lambda _ctx: fallback_result,
+    )
+    monkeypatch.setattr(provider_registry, "all_providers", lambda: [broken, healthy])
+    monkeypatch.setattr(
+        provider_registry.logger,
+        "error",
+        lambda message, *args, **_kwargs: errors.append(message % args),
+    )
+
+    assert provider_registry.resolve_selected(ctx) == fallback_result
+    assert errors == [
+        "code=TTS_CONFIGURED_API_FAILURE provider=custom stage=selection"
+    ]
+    assert all(secret not in "\n".join(errors) for secret in secrets)
+
+
+def test_configured_sentence_worker_redacts_exception_and_input(monkeypatch):
+    errors = []
+    secrets = ("sk-secret-should-not-log", "token=signed-query", "角色原文不能记录")
+    request_queue = queue.Queue()
+    response_queue = queue.Queue()
+
+    async def setup(_queue_proxy):
+        async def synthesize(_text, _speech_id):
+            raise RuntimeError(" ".join(secrets))
+
+        return synthesize, None
+
+    monkeypatch.setattr(
+        tts_infra_module.logger,
+        "error",
+        lambda message, *args, **_kwargs: errors.append(message % args),
+    )
+    thread = threading.Thread(
+        target=tts_infra_module._run_sentence_tts_worker,
+        args=(request_queue, response_queue, setup),
+        kwargs={"label": "Configured TTS", "safe_error_provider": "custom"},
+        daemon=True,
+    )
+    thread.start()
+    assert _wait_for_item(response_queue, lambda item: item == ("__ready__", True))
+    request_queue.put(("speech-1", "角色原文不能记录。"))
+    error = _wait_for_item(
+        response_queue,
+        lambda item: isinstance(item, tuple) and item[0] == "__error__",
+    )
+    request_queue.put((tts_client.TTS_SHUTDOWN_SENTINEL, None))
+    thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert "TTS_CONFIGURED_API_FAILURE" in error[1]
+    assert all(secret not in error[1] for secret in secrets)
+    assert all(secret not in "\n".join(errors) for secret in secrets)
+
+
+def test_configured_tts_failure_switches_to_existing_dispatch_order(monkeypatch):
+    mgr = LLMSessionManager.__new__(LLMSessionManager)
+    mgr._tts_active_provider_key = "custom"
+    mgr._tts_excluded_provider_keys = frozenset()
+    mgr.tts_request_queue = queue.Queue()
+    mgr.current_speech_id = "speech-1"
+    mgr.tts_pending_chunks = [("speech-1", "later")]
+    mgr._tts_replay_speech_id = "speech-1"
+    mgr._tts_replay_chunks = [
+        ("old-speech", "stale"),
+        ("speech-1", "first"),
+        ("speech-1", "second"),
+    ]
+    mgr._tts_replay_done = True
+    mgr._tts_replay_audio_emitted = False
+    mgr._tts_done_queued_for_turn = True
+    mgr._tts_done_pending_until_ready = False
+    mgr._tts_fallback_uses_default_voice = False
+    mgr._last_tts_error_code = "API_KEY_REJECTED"
+    mgr._tts_retry_notify_count = 2
+    mgr._reset_tts_stream_normalizer = lambda: None
+    starts = []
+    warnings = []
+
+    def start_fallback(*, preserve_provider_exclusions=False):
+        starts.append(preserve_provider_exclusions)
+        mgr._tts_active_provider_key = "qwen"
+
+    mgr._start_tts_thread = start_fallback
+    monkeypatch.setattr(
+        tts_runtime_module.logger,
+        "warning",
+        lambda message, *args, **_kwargs: warnings.append(message % args),
+    )
+
+    assert LLMSessionManager._activate_configured_tts_fallback(mgr, "测试") is True
+    assert mgr._tts_excluded_provider_keys == frozenset({"custom"})
+    assert mgr.tts_request_queue.get_nowait() == ("__shutdown__", None)
+    assert starts == [True]
+    assert mgr._tts_fallback_uses_default_voice is True
+    assert mgr.tts_pending_chunks == [
+        ("speech-1", "first"),
+        ("speech-1", "second"),
+        ("speech-1", "later"),
+    ]
+    assert mgr._tts_done_queued_for_turn is False
+    assert mgr._tts_done_pending_until_ready is True
+    assert mgr._last_tts_error_code == ""
+    assert mgr._tts_retry_notify_count == 0
+    assert LLMSessionManager._effective_tts_route(mgr) == ("", False)
+    assert any("fallback_provider=qwen" in message for message in warnings)
+
+
+def test_fallback_skips_complete_replay_after_audio_reached_playback(monkeypatch):
+    mgr = LLMSessionManager.__new__(LLMSessionManager)
+    mgr._tts_active_provider_key = "custom"
+    mgr._tts_excluded_provider_keys = frozenset()
+    mgr.tts_request_queue = queue.Queue()
+    mgr.current_speech_id = "speech-1"
+    mgr.tts_pending_chunks = []
+    mgr._tts_replay_speech_id = "speech-1"
+    mgr._tts_replay_chunks = [("speech-1", "already heard")]
+    mgr._tts_replay_done = True
+    mgr._tts_replay_audio_emitted = True
+    mgr._tts_replay_progress_supported = False
+    mgr._tts_done_queued_for_turn = True
+    mgr._tts_done_pending_until_ready = False
+    mgr._tts_fallback_uses_default_voice = False
+    mgr._reset_tts_stream_normalizer = lambda: None
+
+    def start_fallback(*, preserve_provider_exclusions=False):
+        assert preserve_provider_exclusions is True
+        mgr._tts_active_provider_key = "qwen"
+
+    mgr._start_tts_thread = start_fallback
+    monkeypatch.setattr(tts_runtime_module.logger, "warning", lambda *_args, **_kwargs: None)
+
+    assert LLMSessionManager._activate_configured_tts_fallback(mgr, "运行时") is True
+    assert mgr.tts_pending_chunks == []
+    assert mgr._tts_done_pending_until_ready is False
+
+
+def test_http_fallback_replays_only_unconfirmed_sentence_suffix(monkeypatch):
+    mgr = LLMSessionManager.__new__(LLMSessionManager)
+    mgr._tts_active_provider_key = "custom"
+    mgr._tts_excluded_provider_keys = frozenset()
+    mgr.tts_request_queue = queue.Queue()
+    mgr.current_speech_id = "speech-1"
+    mgr.tts_pending_chunks = []
+    mgr._tts_replay_speech_id = "speech-1"
+    mgr._tts_replay_chunks = [("speech-1", "heard.unheard suffix.")]
+    mgr._tts_replay_sent_chunks = [("speech-1", "unheard suffix.")]
+    mgr._tts_replay_done = True
+    mgr._tts_replay_audio_emitted = True
+    mgr._tts_replay_sentence_audio_emitted = False
+    mgr._tts_replay_progress_supported = True
+    mgr._tts_done_queued_for_turn = True
+    mgr._tts_done_pending_until_ready = False
+    mgr._tts_fallback_uses_default_voice = False
+    mgr._last_tts_error_code = "TTS_CONNECTION_FAILED"
+    mgr._tts_retry_notify_count = 2
+    mgr._reset_tts_stream_normalizer = lambda: None
+
+    def start_fallback(*, preserve_provider_exclusions=False):
+        assert preserve_provider_exclusions is True
+        mgr._tts_active_provider_key = "qwen"
+
+    mgr._start_tts_thread = start_fallback
+    monkeypatch.setattr(tts_runtime_module.logger, "warning", lambda *_args, **_kwargs: None)
+
+    assert LLMSessionManager._activate_configured_tts_fallback(mgr, "运行时") is True
+    assert mgr.tts_pending_chunks == [("speech-1", "unheard suffix.")]
+    assert mgr._tts_done_pending_until_ready is True
+    assert mgr._last_tts_error_code == ""
+    assert mgr._tts_retry_notify_count == 0
+
+
+def test_sentence_progress_prunes_only_the_confirmed_prefix():
+    mgr = LLMSessionManager.__new__(LLMSessionManager)
+    mgr._tts_replay_speech_id = "speech-1"
+    mgr._tts_replay_sent_chunks = [
+        ("speech-1", "first."),
+        ("speech-1", "second."),
+        ("speech-1", "third."),
+    ]
+
+    LLMSessionManager._consume_tts_replay_sentence(mgr, "speech-1", "first.")
+    LLMSessionManager._consume_tts_replay_sentence(mgr, "speech-1", "second.")
+
+    assert mgr._tts_replay_sent_chunks == [("speech-1", "third.")]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "audio_message",
+    [b"audio-prefix", ("__audio__", "speech-1", b"audio-prefix")],
+)
+async def test_tts_handler_marks_audio_before_runtime_fallback(audio_message):
+    mgr = LLMSessionManager.__new__(LLMSessionManager)
+    old_queue = queue.Queue()
+    new_queue = queue.Queue()
+    old_queue.put(audio_message)
+    old_queue.put(("__error__", "late upstream failure"))
+    new_queue.put(("__ready__", True))
+    mgr.tts_response_queue = old_queue
+    mgr.tts_cache_lock = asyncio.Lock()
+    mgr.tts_ready = True
+    mgr._tts_replay_audio_emitted = False
+    mgr._last_tts_error_code = ""
+    mgr._tts_retry_notify_count = 0
+    observed = []
+    ready_seen = asyncio.Event()
+
+    async def send_speech(*_args, **_kwargs):
+        return True
+
+    def activate(_stage):
+        observed.append(mgr._tts_replay_audio_emitted)
+        mgr.tts_response_queue = new_queue
+        return True
+
+    async def flush_pending():
+        ready_seen.set()
+
+    mgr.send_speech = send_speech
+    mgr._confirm_pending_ai_voice_echo = lambda *_args: None
+    mgr._discard_pending_ai_voice_echo = lambda: None
+    mgr._activate_configured_tts_fallback = activate
+    mgr._flush_tts_pending_chunks = flush_pending
+
+    task = asyncio.create_task(LLMSessionManager.tts_response_handler(mgr))
+    await asyncio.wait_for(ready_seen.wait(), timeout=1)
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+
+    assert observed == [True]
+
+
+def test_configured_tts_failure_replays_ledger_after_current_speech_id_rotates(
+    monkeypatch,
+):
+    mgr = LLMSessionManager.__new__(LLMSessionManager)
+    mgr.core_api_type = "qwen"
+    mgr.voice_id = "vendor-voice"
+    mgr.current_speech_id = "next-speech"
+    mgr._tts_active_provider_key = "custom"
+    mgr._tts_excluded_provider_keys = frozenset()
+    mgr.tts_request_queue = queue.Queue()
+    mgr.tts_pending_chunks = []
+    mgr._tts_replay_speech_id = "completed-speech"
+    mgr._tts_replay_chunks = [("completed-speech", "complete reply")]
+    mgr._tts_replay_done = True
+    mgr._tts_done_queued_for_turn = True
+    mgr._tts_done_pending_until_ready = False
+    mgr._tts_fallback_uses_default_voice = False
+    mgr._reset_tts_stream_normalizer = lambda: None
+    mgr._start_tts_thread = lambda **_kwargs: None
+    monkeypatch.setattr(
+        tts_runtime_module._core_facade,
+        "tts_provider_falls_back_on_failure",
+        lambda provider: provider == "custom",
+    )
+    monkeypatch.setattr(
+        tts_runtime_module._core_facade,
+        "tts_provider_uses_configured_preset_voice",
+        lambda provider: provider == "custom",
+    )
+
+    assert LLMSessionManager._activate_configured_tts_fallback(mgr, "运行时") is True
+
+    assert mgr.tts_pending_chunks == [("completed-speech", "complete reply")]
+    assert mgr._tts_done_pending_until_ready is True
+
+
+@pytest.mark.asyncio
+async def test_replayed_utterance_and_done_flush_to_replacement_worker():
+    mgr = LLMSessionManager.__new__(LLMSessionManager)
+    mgr.tts_cache_lock = asyncio.Lock()
+    mgr.tts_pending_chunks = [
+        ("speech-1", "first"),
+        ("speech-1", "second"),
+        ("speech-1", "later"),
+    ]
+    mgr._tts_done_pending_until_ready = True
+    mgr.tts_thread = SimpleNamespace(is_alive=lambda: True)
+    mgr.tts_request_queue = queue.Queue()
+    mgr._enqueue_tts_text_chunk = lambda sid, text: mgr.tts_request_queue.put((sid, text))
+
+    def request_done():
+        mgr.tts_request_queue.put((None, None))
+        mgr._tts_done_pending_until_ready = False
+        return "queued"
+
+    mgr._request_tts_done_locked = request_done
+
+    await LLMSessionManager._flush_tts_pending_chunks(mgr)
+
+    assert [mgr.tts_request_queue.get_nowait() for _ in range(4)] == [
+        ("speech-1", "first"),
+        ("speech-1", "second"),
+        ("speech-1", "later"),
+        (None, None),
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("failure_message", "expected_stage"),
+    [
+        (("__ready__", False), "初始化"),
+        (("__error__", "upstream connection failed"), "运行时"),
+    ],
+)
+async def test_tts_handler_follows_fallback_worker_queue(failure_message, expected_stage):
+    mgr = LLMSessionManager.__new__(LLMSessionManager)
+    old_queue = queue.Queue()
+    new_queue = queue.Queue()
+    old_queue.put(failure_message)
+    new_queue.put(("__ready__", True))
+    mgr.tts_response_queue = old_queue
+    mgr.tts_cache_lock = asyncio.Lock()
+    mgr.tts_ready = False
+    mgr._last_tts_error_code = ""
+    mgr._tts_retry_notify_count = 0
+    stages = []
+    ready_seen = asyncio.Event()
+
+    def activate(stage):
+        stages.append(stage)
+        mgr.tts_response_queue = new_queue
+        return True
+
+    async def flush_pending():
+        ready_seen.set()
+
+    mgr._activate_configured_tts_fallback = activate
+    mgr._flush_tts_pending_chunks = flush_pending
+
+    task = asyncio.create_task(LLMSessionManager.tts_response_handler(mgr))
+    await asyncio.wait_for(ready_seen.wait(), timeout=1)
+    task.cancel()
+    result = await asyncio.gather(task, return_exceptions=True)
+
+    assert isinstance(result[0], asyncio.CancelledError)
+    assert stages == [expected_stage]
+    assert mgr.tts_ready is True
 
 
 def _wait_for_item(q, predicate, timeout=5.0):
@@ -312,6 +1009,52 @@ def _run_worker_once(
     request_queue.put(("speech-1", "hello world."))
     request_queue.put((None, None))
     return clients, request_queue, response_queue, thread
+
+
+def test_sentence_worker_reports_audible_boundaries_before_runtime_error():
+    request_queue = queue.Queue()
+    response_queue = queue.Queue()
+
+    async def setup(queue_proxy):
+        async def synthesize(text, _speech_id):
+            if text == "First.":
+                queue_proxy.put(b"first-audio")
+                return
+            queue_proxy.put(b"partial-second-audio")
+            raise RuntimeError("late failure")
+
+        return synthesize, None
+
+    thread = threading.Thread(
+        target=tts_client._run_sentence_tts_worker,
+        args=(request_queue, response_queue, setup),
+        kwargs={"label": "Mock TTS"},
+        daemon=True,
+    )
+    thread.start()
+    assert _wait_for_item(response_queue, lambda item: item == ("__ready__", True)) == (
+        "__ready__",
+        True,
+    )
+    request_queue.put(("speech-1", "First.Second."))
+    request_queue.put((None, None))
+
+    delivered = []
+    while not delivered or delivered[-1][0] != "__error__":
+        item = response_queue.get(timeout=5)
+        delivered.append(item)
+
+    request_queue.put((tts_client.TTS_SHUTDOWN_SENTINEL, None))
+    thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert delivered[:5] == [
+        b"first-audio",
+        ("__tts_sentence_done__", "speech-1", "First."),
+        b"partial-second-audio",
+        ("__tts_sentence_failed__", "speech-1", "Second."),
+        ("__error__", "Mock TTS 合成失败: late failure"),
+    ]
 
 
 def test_custom_worker_uses_openai_sdk_and_siliconflow_extensions(monkeypatch):

--- a/tests/unit/test_voice_config.py
+++ b/tests/unit/test_voice_config.py
@@ -101,6 +101,16 @@ def test_normalize_bare_clone_voice():
     assert vc == VoiceConfig(source=SOURCE_CLONE, provider="cosyvoice_intl", ref="cosyvoice-clone-123")
 
 
+def test_normalize_preferred_configured_preset_before_same_id_clone():
+    vc = normalize_voice_id(
+        "vendor-voice",
+        preferred_preset_provider=lambda ref: "custom" if ref == "vendor-voice" else None,
+        clone_provider_lookup=lambda _ref: "cosyvoice",
+    )
+
+    assert vc == VoiceConfig(source=SOURCE_PRESET, provider="custom", ref="vendor-voice")
+
+
 def test_normalize_native_preset():
     vc = normalize_voice_id(
         "qingchunshaonv",

--- a/utils/config_manager/voice_storage.py
+++ b/utils/config_manager/voice_storage.py
@@ -878,9 +878,26 @@ class VoiceStorageMixin:
                 logger.warning("hosted preset voice 归一化异常，按非预制处理", exc_info=True)
                 return None
 
+        def _preferred_configured_preset_provider(ref):
+            """Return an exact configured preset owner before clone lookup."""
+            # Explicit configuration wins only for dynamic configured presets;
+            # static hosted catalogs keep their existing clone-first behavior.
+            # 仅动态配置音色优先于同名克隆；静态厂商目录仍保持原有优先级。
+            provider_key = _hosted_preset_provider(ref)
+            if not provider_key:
+                return None
+            try:
+                from utils.tts import provider_registry
+                if provider_registry.uses_configured_preset_voice(provider_key):
+                    return provider_key
+            except Exception:
+                logger.warning("configured preset voice 归一化异常，按普通优先级处理", exc_info=True)
+            return None
+
         return normalize_voice_id(
             voice_id,
             vllm_selected=self._is_vllm_omni_tts_selected(self.get_core_config()),
+            preferred_preset_provider=_preferred_configured_preset_provider,
             clone_provider_lookup=_clone_lookup,
             is_native=lambda ref: is_saveable_native_voice(self, ref),
             native_provider=get_active_realtime_native_provider(self) or '',

--- a/utils/openai_tts.py
+++ b/utils/openai_tts.py
@@ -23,7 +23,7 @@ should receive the standard OpenAI body unless it is explicitly recognized by
 
 from __future__ import annotations
 
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import parse_qsl, urlparse, urlunparse
 
 
 OPENAI_TTS_DEFAULT_BASE_URL = "https://api.openai.com/v1"

--- a/utils/tts/provider_registry.py
+++ b/utils/tts/provider_registry.py
@@ -268,6 +268,13 @@ class TTSProvider:
     # ``/voices`` endpoint and ``validate_voice_id`` query it instead of restating
     # the catalog elsewhere (see design doc §3 ``preset_catalog``).
     preset_catalog: "PresetCatalog | None" = None
+    # User-configured providers can expose the single value stored in
+    # ``voice_field`` as a preset voice without maintaining a static catalog.
+    configured_preset_voice: bool = False
+    # User-pointed endpoints may fall back to the unchanged downstream dispatch
+    # order after configuration, startup, or synthesis failures.
+    # 用户自填端点失败时，仅排除当前 provider，后续仍严格沿用既有调度顺序。
+    fallback_on_failure: bool = False
 
     # Alternate provider ids that share this provider's implementation and
     # capabilities while retaining provider-specific runtime configuration.
@@ -330,6 +337,24 @@ def all_providers() -> list[TTSProvider]:
     return sorted(_REGISTRY.values(), key=lambda p: p.priority)
 
 
+def _log_provider_predicate_failure(provider: TTSProvider) -> None:
+    """Log selection failures while protecting configured-endpoint secrets."""
+    if getattr(provider, "fallback_on_failure", False):
+        # Configured predicates may read signed URLs or credentials. Their raw
+        # exceptions must not enter backend logs; provider and stage are enough.
+        # 配置型 provider 的异常可能携带签名 query/密钥，仅记录错误码、归属和阶段。
+        logger.error(
+            "code=TTS_CONFIGURED_API_FAILURE provider=%s stage=selection",
+            provider.key,
+        )
+        return
+    logger.warning(
+        "TTS provider %r is_selected 判定异常，跳过该 provider",
+        provider.key,
+        exc_info=True,
+    )
+
+
 def selected_provider(ctx: "DispatchContext") -> "TTSProvider | None":
     """Return the first provider selected for ``ctx`` in priority order, or None.
 
@@ -345,10 +370,7 @@ def selected_provider(ctx: "DispatchContext") -> "TTSProvider | None":
         except Exception:
             # is_selected 判定异常不应连带打挂整个 dispatch，跳过该 provider 继续；
             # 但静默会掩盖配置/适配器 bug，至少留一条带堆栈的可观测日志。
-            logger.warning(
-                "TTS provider %r is_selected 判定异常，跳过该 provider", provider.key,
-                exc_info=True,
-            )
+            _log_provider_predicate_failure(provider)
             selected = False
         if selected:
             return provider
@@ -357,6 +379,8 @@ def selected_provider(ctx: "DispatchContext") -> "TTSProvider | None":
 
 def resolve_selected(
     ctx: "DispatchContext",
+    *,
+    excluded_provider_keys: "frozenset[str]" = frozenset(),
 ) -> "tuple[Callable[..., Any], str | None, str] | None":
     """Return the dispatch tuple for the first provider selected for ``ctx``, in
     priority order, or ``None`` when none apply.
@@ -366,8 +390,47 @@ def resolve_selected(
     pick or an implied clone-voice provider — wins over native / core default
     routing in the original hand-written precedence (priority order).
     """
-    provider = selected_provider(ctx)
-    return provider.resolve(ctx) if provider is not None else None
+    # Opted-in configured endpoints may be unreadable while the existing
+    # fallback providers remain usable. Other providers retain their original
+    # exception behavior, so this issue does not broaden unrelated fallback.
+    # 仅允许声明过的自定义 provider 在解析失败时跳过；其他 provider 维持旧异常语义。
+    for provider in all_providers():
+        if provider.key in excluded_provider_keys:
+            continue
+        try:
+            selected = provider.is_selected(ctx)
+        except Exception:
+            # Match selected_provider's established fault isolation so runtime
+            # dispatch and the /voices catalog cannot disagree after one bad predicate.
+            # 与 selected_provider 复用旧容错语义，单个判定异常不能打断后续 provider。
+            _log_provider_predicate_failure(provider)
+            selected = False
+        if not selected:
+            continue
+        try:
+            return provider.resolve(ctx)
+        except Exception:
+            if not provider.fallback_on_failure:
+                raise
+            logger.error(
+                "code=TTS_CONFIGURED_API_FAILURE provider=%s stage=resolve",
+                provider.key,
+            )
+    return None
+
+
+def falls_back_on_failure(provider_key: str | None) -> bool:
+    """Whether runtime failures should exclude this provider and redispatch."""
+    provider = get(provider_key)
+    return bool(provider and provider.fallback_on_failure)
+
+
+def uses_configured_preset_voice(provider_key: str | None) -> bool:
+    """Whether the provider owns the configured voice field as its preset."""
+    # Core and storage query metadata here instead of hardcoding custom/vllm keys.
+    # core 与存储层统一查元数据，避免写死 custom/vllm provider 名称。
+    provider = get(provider_key)
+    return bool(provider and provider.configured_preset_voice)
 
 
 # ── Preset-catalog queries (single source of truth for built-in voices) ──────
@@ -380,20 +443,54 @@ def resolve_selected(
 # ``config_router``'s ``ui_metadata`` call site.
 
 
-def preset_catalog_for_ui(provider_key: str | None) -> "dict[str, dict[str, str | bool]] | None":
+def preset_catalog_for_ui(
+    provider_key: str | None,
+    core_config: Mapping[str, Any] | None = None,
+) -> "dict[str, dict[str, str | bool]] | None":
     """The UI voice catalog for ``provider_key``'s preset_catalog, or None."""
     provider = get(provider_key)
-    if provider is None or provider.preset_catalog is None:
+    if provider is None:
         return None
-    return provider.preset_catalog.catalog_for_ui(provider.key)
+    if provider.preset_catalog is not None:
+        return provider.preset_catalog.catalog_for_ui(provider.key)
+    if not provider.configured_preset_voice:
+        return None
+    config = core_config or {}
+    voice_id = str(config.get(provider.voice_field) or provider.default_voice or "").strip()
+    if not voice_id:
+        return {}
+    return {
+        voice_id: {
+            "prefix": voice_id,
+            "provider": provider.key,
+            # Configured voices are shown under the generic Custom API source,
+            # while ``provider`` retains the real runtime owner for dispatch.
+            # 配置音色统一显示为“自定义 API”，但 provider 字段仍保留真实路由身份。
+            "provider_label": "custom",
+            "gender": "",
+            "display_name": voice_id,
+            "builtin": True,
+        }
+    }
 
 
-def is_preset_voice(provider_key: str | None, voice_id: str | None) -> bool:
+def is_preset_voice(
+    provider_key: str | None,
+    voice_id: str | None,
+    core_config: Mapping[str, Any] | None = None,
+) -> bool:
     """Whether ``voice_id`` is a built-in voice of ``provider_key``'s catalog."""
     provider = get(provider_key)
-    if provider is None or provider.preset_catalog is None:
+    if provider is None:
         return False
-    return provider.preset_catalog.is_voice(voice_id)
+    if provider.preset_catalog is not None:
+        return provider.preset_catalog.is_voice(voice_id)
+    if not provider.configured_preset_voice:
+        return False
+    configured_voice = str(
+        (core_config or {}).get(provider.voice_field) or provider.default_voice or ""
+    ).strip()
+    return bool(configured_voice and configured_voice == str(voice_id or "").strip())
 
 
 def selected_provider_key(
@@ -431,7 +528,7 @@ def selected_preset_provider_key(
     provider = selected_provider(
         DispatchContext(core_config=core_config, cm=cm, voice_id=voice_id or "")
     )
-    if provider is None or not is_preset_voice(provider.key, voice_id):
+    if provider is None or not is_preset_voice(provider.key, voice_id, core_config):
         return None
     return provider.key
 

--- a/utils/voice_config.py
+++ b/utils/voice_config.py
@@ -154,6 +154,7 @@ def normalize_voice_id(
     voice_id: Any,
     *,
     vllm_selected: bool = False,
+    preferred_preset_provider: "Any" = None,
     clone_provider_lookup: "Any" = None,
     is_native: "Any" = None,
     native_provider: str = "",
@@ -169,17 +170,21 @@ def normalize_voice_id(
     1. unambiguous prefix (``eleven:`` / ``gsv:`` / disabled placeholder / empty) —
        handled by :func:`parse_legacy_voice_id`.
     2. ``vllm_selected`` → ``{preset, vllm_omni, ref}`` (vLLM-Omni uses preset ids).
-    3. ``clone_provider_lookup(ref)`` returns a provider (the ref is a cloned voice
+    3. ``preferred_preset_provider(ref)`` returns a provider for an explicitly
+       configured preset that owns this exact ID.
+    4. ``clone_provider_lookup(ref)`` returns a provider (the ref is a cloned voice
        in the current API's voice_storage) → ``{clone, <provider>, ref}``.
-    4. ``is_native(ref)`` → ``{preset, <native_provider>, ref}``.
-    5. ``hosted_preset_provider(ref)`` returns a provider key (the ref is a built-in
+    5. ``is_native(ref)`` → ``{preset, <native_provider>, ref}``.
+    6. ``hosted_preset_provider(ref)`` returns a provider key (the ref is a built-in
        preset of the currently selected hosted/local provider, e.g. MiMo's "Milo")
        → ``{preset, <provider key>, ref}``.
-    6. ``ref in free_voice_ids`` → ``{preset, free, ref}``.
-    7. otherwise unresolved → ``{ref}`` only (provider/source unknown; carried through
+    7. ``ref in free_voice_ids`` → ``{preset, free, ref}``.
+    8. otherwise unresolved → ``{ref}`` only (provider/source unknown; carried through
        so nothing is lost — callers treat an unresolved ref as "leave as-is").
 
     Args:
+        preferred_preset_provider: ``ref -> provider|None`` for configured presets
+            that intentionally take precedence over a stored clone with the same ID.
         clone_provider_lookup: ``ref -> provider|None`` (None = not a known clone).
         is_native: ``ref -> bool``.
         hosted_preset_provider: ``ref -> provider key|None`` — the selected
@@ -197,6 +202,13 @@ def normalize_voice_id(
 
     if vllm_selected:
         return VoiceConfig(source=SOURCE_PRESET, provider="vllm_omni", ref=ref)
+
+    # Explicit configured presets own an exact collision before clone lookup.
+    # 显式配置的预制音色在同名冲突时先于历史克隆记录确定归属。
+    if preferred_preset_provider is not None:
+        provider = preferred_preset_provider(ref)
+        if provider:
+            return VoiceConfig(source=SOURCE_PRESET, provider=str(provider), ref=ref)
 
     if clone_provider_lookup is not None:
         provider = clone_provider_lookup(ref)


### PR DESCRIPTION
## 改动概述 / Summary

Closes #2527

基于已合并的 #2477（OpenAI-compatible HTTPS TTS 协议基础），补齐自定义 TTS 的角色音色映射、显式优先级、脱敏错误日志与失败保底闭环。

- HTTPS `custom` 与 WSS `vllm_omni` 都会把配置的 `ttsVoiceId` 暴露为“自定义 API / 实际音色名”。
- 角色卡可选择并保存真实 provider 身份；同名旧克隆或 Realtime 原生音色不会抢走显式配置。
- 配置读取、初始化、连接、校验、解析或合成失败时，日志仅记录稳定错误码、provider 与阶段。
- 失败时只排除本会话的故障 provider，再调用原 dispatcher；没有新增或重排保底线路。
- 未配置自定义 TTS 时保持原行为。

## 回归报告 / Regression Report

### 改动与必要性

- `tts_client/provider_registry`：声明配置型预制音色、失败保底能力及 provider-neutral 排除机制。
- 角色音色目录/保存：让配置音色进入角色卡，并保留实际 runtime owner。
- HTTP/WSS worker：对称地产生 `TTS_CONFIGURED_API_FAILURE` 脱敏错误，不记录 URL query、密钥、原始异常或合成文本。
- `main_logic/core` 仅增加通用会话监管接缝：
  - `core/__init__.py`：3 行 facade 导入；
  - `lifecycle.py`：处理 handler 创建前已被消费的启动失败信号；
  - `manager.py`：保存本会话失败 provider、待播文本和播放确认状态；
  - `tts_runtime.py`：切换 worker/队列、排除失败项并重放安全的未确认文本。
  Core 不识别 `custom` 或 `vllm_omni` 名称，也不定义保底顺序。完全移到 worker 会重复实现 dispatcher/凭证解析，且无法获知音频是否真正送达前端。

### 改动前后

- 改动前：已填 Voice ID 仍可能显示“未指定音色”，角色无法明确绑定；同名原生/克隆音色可能抢路由；失败后不会立即进入既有保底。
- 改动后：可显示并保存“自定义 API / Voice ID”，显式配置优先；错误脱敏可观测，并在当前会话复用既有保底顺序。

### 潜在回归点

- Realtime 原生音色与配置音色同名时的路由归属。
- HTTP 分句与 WSS 双流协议之间切换时的文本规范化、done 信号和部分音频重放。
- 角色音色目录与保存结构的一致性。
- 未配置自定义 API 时的旧 dispatcher 行为。

上述路径均有 Mock、路由、浏览器、分层与 core contract 覆盖。

## 不拆分理由 / Why Not Split

这是同一缺陷的端到端闭环：provider 元数据决定目录与保存，worker 产生脱敏失败事件，session supervisor 才能沿现有顺序切换并安全续播。拆开会产生“看得到但不能用”或“能失败但不能保底”的中间状态。测试与 i18n 文件不计入项目的拆分文件阈值。

## 测试 / Testing

- `415 passed`：OpenAI-compatible、vLLM-Omni、provider/voice 路由、失败保底、脱敏日志与 Mock 音频。
- `29 passed`：Chromium 角色卡用例（HTTPS custom / WSS vllm_omni）与网页端/Electron 静态契约。
- `20 passed`：8 locale key 一致性与 module layering。
- `uv run python scripts/check_core_contracts.py`
- Ruff、3 个 JavaScript 文件语法检查、`git diff --check`。

## UI 验证 / UI Evidence

参数化 Chromium 测试验证两种配置均显示并可选择：

- WSS：`自定义 API / default`
- HTTPS：`自定义 API / vendor-voice`

本 PR 没有新增界面文案，复用 #2477 已有的 `api.customModelProviderCustom`；8 个 locale 均已通过一致性测试。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 自定义配置音色的归属识别、展示标签与保存结构更准确，并优先于同名克隆；角色音色/目录中也会正确映射与去重。
  * 配置型 TTS 端点异常时自动启用保底，并对未确认片段进行回放续播。
* **错误修复**
  * 连接/就绪失败时不再卡住流程；句子级完成/失败事件边界更可靠，失败信息更稳定且更好脱敏。
* **测试**
  * 新增/扩展覆盖回放、归属优先级与脱敏回退的回归与单元测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->