### PR TITLE
chore(docker): consolidate volume mounts to /home/neko, remove separa…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -41,6 +41,16 @@ config/user_preferences.json
 config/voice_storage.json
 N.E.K.O/
 
+# 同样的用户数据，但在 docker/ 下：维护中的 compose 文件在那里，它的 ./ 相对路径
+# 也就落在那里。上面的模式是相对 build context 根的，`N.E.K.O/` 只匹配根级，
+# 匹配不到 docker/ 下的同名目录 —— 而文档教的构建命令是在仓库根执行
+# `docker build -f docker/Dockerfile .`，于是这些目录会随 `COPY . /app` 进镜像层。
+# 里面有用户记忆、角色卡、含 API key 的配置，以及 TLS 私钥。
+docker/neko-home/
+docker/N.E.K.O/
+docker/ssl/
+docker/logs/
+
 # Embedding model weights are intentionally NOT ignored: CI pre-fetches the
 # pinned revision on the native runner (cached via actions/cache) and ships it in
 # the build context so the in-image step runs fully offline — see step 6b in

--- a/.dockerignore
+++ b/.dockerignore
@@ -40,6 +40,8 @@ config/characters.json
 config/user_preferences.json
 config/voice_storage.json
 N.E.K.O/
+neko-home/
+ssl/
 
 # 同样的用户数据，但在 docker/ 下：维护中的 compose 文件在那里，它的 ./ 相对路径
 # 也就落在那里。上面的模式是相对 build context 根的，`N.E.K.O/` 只匹配根级，

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@ tests/test_inputs/
 *.log
 /logs/
 /data/
+
+# docker-compose.yml 在 docker/ 下，它的 ./ 相对路径落在这里
+/docker/neko-home/
+/docker/logs/
+
 debug_audio/*
 # Binaries (but keep our committed Windows tools listed explicitly if needed)
 *.exe

--- a/.gitignore
+++ b/.gitignore
@@ -12,11 +12,15 @@ tests/test_inputs/
 # 一旦被 `git add -A` 带进提交就等于公开。两个位置都要挡：维护中的
 # docker-compose.yml 在 docker/ 下（它的 ./ 相对路径落在那里），而 README 教的是
 # 把 compose 片段存到自己的目录里跑，那个目录可能就是仓库根。
+# 旧布局的 N.E.K.O/ 与 ssl/ 一并挡上 —— 迁移做到一半时它们就摊在工作区里，
+# 那恰恰是最容易顺手 `git add -A` 的时候。
 /neko-home/
 /ssl/
+/N.E.K.O/
 /docker/neko-home/
 /docker/ssl/
 /docker/logs/
+/docker/N.E.K.O/
 
 # 忽略日志文件
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -8,11 +8,6 @@ tests/test_inputs/
 # scripts/check_i18n.py 偶尔会被人 redirect 到这里，别再次入库
 /i18n_check_output.txt
 
-# 忽略日志文件
-*.log
-/logs/
-/data/
-
 # 容器的持久化目录：里面有用户记忆、角色卡、含 API key 的配置和 TLS 私钥，
 # 一旦被 `git add -A` 带进提交就等于公开。两个位置都要挡：维护中的
 # docker-compose.yml 在 docker/ 下（它的 ./ 相对路径落在那里），而 README 教的是
@@ -23,6 +18,10 @@ tests/test_inputs/
 /docker/ssl/
 /docker/logs/
 
+# 忽略日志文件
+*.log
+/logs/
+/data/
 debug_audio/*
 # Binaries (but keep our committed Windows tools listed explicitly if needed)
 *.exe

--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,14 @@ tests/test_inputs/
 /logs/
 /data/
 
-# docker-compose.yml 在 docker/ 下，它的 ./ 相对路径落在这里
+# 容器的持久化目录：里面有用户记忆、角色卡、含 API key 的配置和 TLS 私钥，
+# 一旦被 `git add -A` 带进提交就等于公开。两个位置都要挡：维护中的
+# docker-compose.yml 在 docker/ 下（它的 ./ 相对路径落在那里），而 README 教的是
+# 把 compose 片段存到自己的目录里跑，那个目录可能就是仓库根。
+/neko-home/
+/ssl/
 /docker/neko-home/
+/docker/ssl/
 /docker/logs/
 
 debug_audio/*

--- a/README.MD
+++ b/README.MD
@@ -201,10 +201,17 @@ ls "$BASE/N.E.K.O/"
 ```bash
 # 1) 先导出只存在于容器里的东西。旧版没有挂载 OpenFang 的工作目录，它的配置和
 #    agent 一直在容器可写层，容器一删就没了。这一步要赶在停容器之前做。
-mkdir -p "$BASE/neko-home/.openfang"
-# 报 "No such container:path" 只说明从没初始化过 OpenFang，可以忽略；其他错误
-# （daemon 没起、权限、磁盘满）不能忽略，所以这里不用 `|| true` 吞掉
-docker cp neko:/home/neko/.openfang/. "$BASE/neko-home/.openfang/"
+#    先确认容器还是旧布局：它若已经按新版挂载，容器里的 /home/neko 就是宿主的
+#    neko-home，导出等于把目录复制到它自己（而且那种情况下旧容器早被重建掉了，
+#    本来就没什么可救的）。
+if docker inspect neko --format '{{range .Mounts}}{{println .Destination}}{{end}}' 2>/dev/null | grep -qx /home/neko; then
+  echo "容器已按新布局挂载，跳过导出"
+else
+  mkdir -p "$BASE/neko-home/.openfang"
+  # 报 "No such container:path" 只说明从没初始化过 OpenFang，可以忽略；其他错误
+  # （daemon 没起、权限、磁盘满）不能忽略，所以这里不用 `|| true` 吞掉
+  docker cp neko:/home/neko/.openfang/. "$BASE/neko-home/.openfang/"
+fi
 ```
 
 **确认上一步成功后**再往下——下面第一条就会销毁容器：
@@ -240,9 +247,15 @@ cp -a "$BASE/ssl/."     "$BASE/neko-home/ssl/"                 && rm -rf "$BASE/
 
 mkdir -p "$BASE/neko-home/.local/share/N.E.K.O" "$BASE/neko-home/ssl" "$BASE/neko-home/.openfang"
 
-# 源路径末尾的 /. 表示复制目录内容，否则目标已存在时会多套一层
-docker cp neko:/home/neko/.local/share/N.E.K.O/. "$BASE/neko-home/.local/share/N.E.K.O/"
-docker cp neko:/home/neko/.openfang/.            "$BASE/neko-home/.openfang/"   # 报 "No such container:path" 可忽略
+# 容器若已按新布局挂载，/home/neko 就是宿主的 neko-home，下面两条会把目录复制到
+# 它自己；而那种情况下旧容器早被重建，容器里也没有待救的数据了
+if docker inspect neko --format '{{range .Mounts}}{{println .Destination}}{{end}}' 2>/dev/null | grep -qx /home/neko; then
+  echo "容器已按新布局挂载，容器内没有待救的旧数据（若数据确实还没迁移，请检查 $BASE/N.E.K.O）"
+else
+  # 源路径末尾的 /. 表示复制目录内容，否则目标已存在时会多套一层
+  docker cp neko:/home/neko/.local/share/N.E.K.O/. "$BASE/neko-home/.local/share/N.E.K.O/"
+  docker cp neko:/home/neko/.openfang/.            "$BASE/neko-home/.openfang/"   # 报 "No such container:path" 可忽略
+fi
 
 cp -a "$BASE/ssl/." "$BASE/neko-home/ssl/" && rm -rf "$BASE/ssl"
 ```

--- a/README.MD
+++ b/README.MD
@@ -213,14 +213,19 @@ docker cp neko:/home/neko/.openfang/. "$BASE/neko-home/.openfang/"
 # 2) 停容器。Compose 部署用 down；Docker Run 部署改用 docker rm -f neko
 docker-compose down
 
-# 3) 合并宿主机上的旧目录。若已经用新版启动过一次，容器会在 neko-home 下建好
-#    同名的空目录和一张新的自签证书，此时直接 mv 会把旧目录套进去多一层，
-#    所以按内容合并（同名文件以旧数据为准）
+# 3) 若已经用新版启动过一次，neko-home 下的属主已经被容器改成了内部的 neko
+#    （一个系统 uid），宿主机上的普通用户写不进去，下面的 cp 会 Permission denied。
+#    先把属主要回来；容器下次启动会自行改回去。
+sudo chown -R "$(id -u):$(id -g)" "$BASE/neko-home"
+
+# 4) 合并宿主机上的旧目录。容器已经在 neko-home 下建好了同名的空目录和一张新的
+#    自签证书，此时直接 mv 会把旧目录套进去多一层，所以按内容合并
+#    （同名文件以旧数据为准）
 mkdir -p "$BASE/neko-home/.local/share/N.E.K.O" "$BASE/neko-home/ssl"
 cp -a "$BASE/N.E.K.O/." "$BASE/neko-home/.local/share/N.E.K.O/" && rm -rf "$BASE/N.E.K.O"
 cp -a "$BASE/ssl/."     "$BASE/neko-home/ssl/"                 && rm -rf "$BASE/ssl"
 
-# 4) Compose 部署把 volumes 换成本文档上方的新版写法后 docker-compose up -d；
+# 5) Compose 部署把 volumes 换成本文档上方的新版写法后 docker-compose up -d；
 #    Docker Run 部署按上方的新命令重新 docker run
 ```
 
@@ -229,6 +234,10 @@ cp -a "$BASE/ssl/."     "$BASE/neko-home/ssl/"                 && rm -rf "$BASE/
 旧版 README 的挂载目标写成了 `/root/Documents/N.E.K.O`，而容器内的服务实际把数据写在 `/home/neko/.local/share/N.E.K.O`，两者对不上，因此这部分数据一直留在容器内部、从未落到宿主机。**必须在旧容器还没删除时导出**（证书不受影响，仍在宿主机的 `$BASE/ssl`）：
 
 ```bash
+# 若已经用新版启动过一次，neko-home 下的属主已经被容器改成内部的 neko（系统 uid），
+# 宿主机上的普通用户写不进去；先要回来，容器下次启动会自行改回去
+[ -d "$BASE/neko-home" ] && sudo chown -R "$(id -u):$(id -g)" "$BASE/neko-home"
+
 mkdir -p "$BASE/neko-home/.local/share/N.E.K.O" "$BASE/neko-home/ssl" "$BASE/neko-home/.openfang"
 
 # 源路径末尾的 /. 表示复制目录内容，否则目标已存在时会多套一层

--- a/README.MD
+++ b/README.MD
@@ -183,67 +183,52 @@ docker run -d \
 <details>
 <summary>点击展开查看迁移步骤（旧版部署过的用户必看）</summary>
 
-先看一眼宿主机上的 `N.E.K.O/` 目录里有没有 `config/`、`memory/` 之类的内容，据此选择对应情况：
+下面几段命令请在**同一个终端里依次执行**——`BASE` 是它们共用的基准目录，换终端就丢了。Docker Compose 部署的旧目录在 compose 文件旁边，Docker Run 部署的在你当初传给 `-v` 的那个路径下：
 
 ```bash
-ls N.E.K.O/
+# Docker Compose 部署
+BASE="."
+# Docker Run 部署改用这行，路径要和你当初 docker run 时用的一致
+# BASE="/home/neko/neko-data"
+
+ls "$BASE/N.E.K.O/"
 ```
 
-**情况一：有内容，且用 Docker Compose 部署**
+里面有 `config/`、`memory/` 之类的内容就走情况一；空的或者目录不存在，走情况二。
+
+**情况一：`$BASE/N.E.K.O/` 有内容**
 
 ```bash
 # 1) 先导出只存在于容器里的东西。旧版没有挂载 OpenFang 的工作目录，它的配置和
 #    agent 一直在容器可写层，容器一删就没了。这一步要赶在停容器之前做。
-mkdir -p neko-home/.openfang
+mkdir -p "$BASE/neko-home/.openfang"
 # 报 "No such container:path" 只说明从没初始化过 OpenFang，可以忽略；其他错误
 # （daemon 没起、权限、磁盘满）不能忽略，所以这里不用 `|| true` 吞掉
-docker cp neko:/home/neko/.openfang/. ./neko-home/.openfang/
+docker cp neko:/home/neko/.openfang/. "$BASE/neko-home/.openfang/"
+```
 
-# 2) 停容器，合并宿主机上的旧目录。若已经用新版启动过一次，容器会在 neko-home 下
-#    建好同名的空目录和一张新的自签证书，此时直接 mv 会把旧目录套进去多一层，
-#    所以按内容合并（同名文件以旧数据为准）
+**确认上一步成功后**再往下——下面第一条就会销毁容器：
+
+```bash
+# 2) 停容器。Compose 部署用 down；Docker Run 部署改用 docker rm -f neko
 docker-compose down
-mkdir -p neko-home/.local/share/N.E.K.O neko-home/ssl
-cp -a N.E.K.O/. neko-home/.local/share/N.E.K.O/ && rm -rf N.E.K.O
-cp -a ssl/.     neko-home/ssl/                 && rm -rf ssl
 
-# 3) 把 docker-compose.yml 的 volumes 换成本文档上方的新版写法，再启动
-docker-compose up -d
+# 3) 合并宿主机上的旧目录。若已经用新版启动过一次，容器会在 neko-home 下建好
+#    同名的空目录和一张新的自签证书，此时直接 mv 会把旧目录套进去多一层，
+#    所以按内容合并（同名文件以旧数据为准）
+mkdir -p "$BASE/neko-home/.local/share/N.E.K.O" "$BASE/neko-home/ssl"
+cp -a "$BASE/N.E.K.O/." "$BASE/neko-home/.local/share/N.E.K.O/" && rm -rf "$BASE/N.E.K.O"
+cp -a "$BASE/ssl/."     "$BASE/neko-home/ssl/"                 && rm -rf "$BASE/ssl"
+
+# 4) Compose 部署把 volumes 换成本文档上方的新版写法后 docker-compose up -d；
+#    Docker Run 部署按上方的新命令重新 docker run
 ```
 
-**情况二：有内容，且用 Docker Run 部署**
+**情况二：`$BASE/N.E.K.O/` 是空的或不存在**
+
+旧版 README 的挂载目标写成了 `/root/Documents/N.E.K.O`，而容器内的服务实际把数据写在 `/home/neko/.local/share/N.E.K.O`，两者对不上，因此这部分数据一直留在容器内部、从未落到宿主机。**必须在旧容器还没删除时导出**（证书不受影响，仍在宿主机的 `$BASE/ssl`）：
 
 ```bash
-# 0) 这一段是独立的 shell，NEKO_BASE_PATH 不会从上面的部署命令继承过来；
-#    改成你当初 docker run 时实际用的路径
-NEKO_BASE_PATH="/home/neko/neko-data"
-
-# 1) 先导出只存在于容器里的 OpenFang 状态（同上，必须赶在删容器之前）
-mkdir -p "${NEKO_BASE_PATH}/neko-home/.openfang"
-# 同上，不吞错误：报 "No such container:path" 可忽略，其他错误必须停下来看
-docker cp neko:/home/neko/.openfang/. "${NEKO_BASE_PATH}/neko-home/.openfang/"
-
-# 2) 删容器，合并宿主机上的旧目录
-docker rm -f neko
-mkdir -p "${NEKO_BASE_PATH}/neko-home/.local/share/N.E.K.O" "${NEKO_BASE_PATH}/neko-home/ssl"
-cp -a "${NEKO_BASE_PATH}/N.E.K.O/." "${NEKO_BASE_PATH}/neko-home/.local/share/N.E.K.O/" \
-  && rm -rf "${NEKO_BASE_PATH}/N.E.K.O"
-cp -a "${NEKO_BASE_PATH}/ssl/."     "${NEKO_BASE_PATH}/neko-home/ssl/" \
-  && rm -rf "${NEKO_BASE_PATH}/ssl"
-
-# 3) 再按本文档上方的新命令重新 docker run
-```
-
-**情况三：`N.E.K.O/` 是空的**
-
-旧版 README 的挂载目标写成了 `/root/Documents/N.E.K.O`，而容器内的服务实际把数据写在 `/home/neko/.local/share/N.E.K.O`，两者对不上，因此这部分数据一直留在容器内部、从未落到宿主机。**必须在旧容器还没删除时导出**（证书不受影响，仍在宿主机的 `./ssl`）：
-
-```bash
-# Docker Compose 部署的用这个（目录在 compose 文件旁边）
-BASE="."
-# Docker Run 部署的改用这个，路径要和你当初 docker run 时用的一致
-# BASE="/home/neko/neko-data"
-
 mkdir -p "$BASE/neko-home/.local/share/N.E.K.O" "$BASE/neko-home/ssl" "$BASE/neko-home/.openfang"
 
 # 源路径末尾的 /. 表示复制目录内容，否则目标已存在时会多套一层

--- a/README.MD
+++ b/README.MD
@@ -220,10 +220,9 @@ fi
 # 2) 停容器。Compose 部署用 down；Docker Run 部署改用 docker rm -f neko
 docker-compose down
 
-# 3) 若已经用新版启动过一次，neko-home 下的属主已经被容器改成了内部的 neko
-#    （一个系统 uid），宿主机上的普通用户写不进去，下面的 cp 会 Permission denied。
-#    先把属主要回来；容器下次启动会自行改回去。
-sudo chown -R "$(id -u):$(id -g)" "$BASE/neko-home"
+# 3) 容器内的 neko 固定为 uid/gid 1000，和绝大多数发行版第一个普通用户一致，
+#    所以通常不必动属主。只有你的宿主账号不是 1000 时才需要这一步。
+[ "$(id -u)" = 1000 ] || sudo chown -R "$(id -u):$(id -g)" "$BASE/neko-home"
 
 # 4) 合并宿主机上的旧目录。容器已经在 neko-home 下建好了同名的空目录和一张新的
 #    自签证书，此时直接 mv 会把旧目录套进去多一层，所以按内容合并
@@ -241,9 +240,8 @@ cp -a "$BASE/ssl/."     "$BASE/neko-home/ssl/"                 && rm -rf "$BASE/
 旧版 README 的挂载目标写成了 `/root/Documents/N.E.K.O`，而容器内的服务实际把数据写在 `/home/neko/.local/share/N.E.K.O`，两者对不上，因此这部分数据一直留在容器内部、从未落到宿主机。**必须在旧容器还没删除时导出**（证书不受影响，仍在宿主机的 `$BASE/ssl`）：
 
 ```bash
-# 若已经用新版启动过一次，neko-home 下的属主已经被容器改成内部的 neko（系统 uid），
-# 宿主机上的普通用户写不进去；先要回来，容器下次启动会自行改回去
-[ -d "$BASE/neko-home" ] && sudo chown -R "$(id -u):$(id -g)" "$BASE/neko-home"
+# 容器内的 neko 固定为 uid/gid 1000；宿主账号不是 1000 时才需要先要回属主
+[ "$(id -u)" = 1000 ] || sudo chown -R "$(id -u):$(id -g)" "$BASE/neko-home"
 
 mkdir -p "$BASE/neko-home/.local/share/N.E.K.O" "$BASE/neko-home/ssl" "$BASE/neko-home/.openfang"
 
@@ -268,7 +266,7 @@ docker rm -f neko
 
 若旧容器已经删除，这部分数据无法找回。本次挂载调整正是为了修掉这个问题。
 
-> `./logs` 挂载没有变化，无需处理。迁移完成后目录属主由容器启动时自动修正，不需要手动 `chown`。
+> `./logs` 挂载没有变化，无需处理。容器内的应用用户固定为 uid/gid **1000**，和绝大多数 Linux 发行版第一个普通用户的号一致——所以 `neko-home/` 在宿主机上的属主就是你自己，备份、编辑、删除都不需要 `sudo`。
 
 </details>
 
@@ -395,7 +393,7 @@ ss -tulpn | grep ':4891[12]'
 
 ##### 2. 权限问题
 ```bash
-# 确保目录有正确权限（容器启动时会把 neko-home 的属主改成容器内的 neko 用户）
+# 确保目录有正确权限（容器启动时会把数据目录的属主改成 1000:1000，即容器内的 neko）
 mkdir -p neko-home logs
 chmod 755 neko-home logs
 ```

--- a/README.MD
+++ b/README.MD
@@ -239,17 +239,24 @@ cp -a "${NEKO_BASE_PATH}/ssl/."     "${NEKO_BASE_PATH}/neko-home/ssl/" \
 旧版 README 的挂载目标写成了 `/root/Documents/N.E.K.O`，而容器内的服务实际把数据写在 `/home/neko/.local/share/N.E.K.O`，两者对不上，因此这部分数据一直留在容器内部、从未落到宿主机。**必须在旧容器还没删除时导出**（证书不受影响，仍在宿主机的 `./ssl`）：
 
 ```bash
-mkdir -p neko-home/.local/share/N.E.K.O neko-home/ssl neko-home/.openfang
+# Docker Compose 部署的用这个（目录在 compose 文件旁边）
+BASE="."
+# Docker Run 部署的改用这个，路径要和你当初 docker run 时用的一致
+# BASE="/home/neko/neko-data"
+
+mkdir -p "$BASE/neko-home/.local/share/N.E.K.O" "$BASE/neko-home/ssl" "$BASE/neko-home/.openfang"
 
 # 源路径末尾的 /. 表示复制目录内容，否则目标已存在时会多套一层
-docker cp neko:/home/neko/.local/share/N.E.K.O/. ./neko-home/.local/share/N.E.K.O/
-docker cp neko:/home/neko/.openfang/.            ./neko-home/.openfang/   # 报 "No such container:path" 可忽略
+docker cp neko:/home/neko/.local/share/N.E.K.O/. "$BASE/neko-home/.local/share/N.E.K.O/"
+docker cp neko:/home/neko/.openfang/.            "$BASE/neko-home/.openfang/"   # 报 "No such container:path" 可忽略
 
-cp -a ssl/. neko-home/ssl/ && rm -rf ssl
+cp -a "$BASE/ssl/." "$BASE/neko-home/ssl/" && rm -rf "$BASE/ssl"
+```
 
-# 确认上面几步都成功之后再删旧容器
+**确认上面几步都成功之后**，再删旧容器并按新版配置启动。导出这一步一旦失败（权限、磁盘满、daemon 没起），千万不要往下执行——容器是这部分数据唯一的副本：
+
+```bash
 docker rm -f neko
-# 再按新版配置启动
 ```
 
 若旧容器已经删除，这部分数据无法找回。本次挂载调整正是为了修掉这个问题。

--- a/README.MD
+++ b/README.MD
@@ -201,15 +201,19 @@ mkdir -p "$BASE/neko-home/.local/share/N.E.K.O" "$BASE/neko-home/ssl" "$BASE/nek
 # 部署的人是错的：那个目录里可能有你自己放进去的文件，而真数据仍然只在容器里。
 MOUNTS=$(docker inspect neko --format '{{range .Mounts}}{{println .Destination}}{{end}}' 2>/dev/null)
 
-if printf '%s
-' "$MOUNTS" | grep -qx /home/neko; then
+# 第 4 步要用：真数据是从容器里捞出来的话，就不能再被宿主机上那个旧目录覆盖
+EXPORTED_APP_DATA=""
+
+if [ -z "$MOUNTS" ]; then
+  echo "容器 neko 不在（可能已经删过），跳过导出；旧数据若还在宿主机上，直接做下面几步"
+elif printf '%s\n' "$MOUNTS" | grep -qx /home/neko; then
   echo "容器已按新布局挂载，没有待导出的内容"
 else
   # 应用数据先导，这部分丢了找不回来。容器没把数据目录挂出去，就说明它只存在于
   # 容器可写层。源路径末尾的 /. 表示复制目录内容，否则目标已存在时会多套一层。
-  if ! printf '%s
-' "$MOUNTS" | grep -qx /home/neko/.local/share/N.E.K.O; then
+  if ! printf '%s\n' "$MOUNTS" | grep -qx /home/neko/.local/share/N.E.K.O; then
     docker cp neko:/home/neko/.local/share/N.E.K.O/. "$BASE/neko-home/.local/share/N.E.K.O/"
+    EXPORTED_APP_DATA=1
   fi
   # OpenFang 状态其次，且不致命：从没初始化过的话容器里就没这个目录，而 docker cp
   # 对不存在的源路径是报错退出的 —— 不能让它挡住上面已经完成的关键导出。
@@ -231,8 +235,18 @@ docker-compose down
 # 第 4 步：把宿主机上的旧目录并进来——有就并，没有就跳过。容器可能已经在 neko-home
 #         下建好了同名目录和一张新的自签证书，所以按内容合并、不要用 mv：mv 到已存在
 #         的目录会套进去多一层。同名文件以旧数据为准。
-[ -d "$BASE/N.E.K.O" ] && cp -a "$BASE/N.E.K.O/." "$BASE/neko-home/.local/share/N.E.K.O/" && rm -rf "$BASE/N.E.K.O"
-[ -d "$BASE/ssl" ]     && cp -a "$BASE/ssl/."     "$BASE/neko-home/ssl/"                 && rm -rf "$BASE/ssl"
+#
+#         但如果第 1 步是从容器里把真数据捞出来的（旧版 README 布局），那
+#         $BASE/N.E.K.O 只是个服务从不写入的空壳，里面顶多是你自己放过的过时
+#         文件 —— 拿它覆盖刚导出的数据就白救了。
+if [ -n "$EXPORTED_APP_DATA" ]; then
+  echo "应用数据已在第 1 步从容器导出，跳过合并 $BASE/N.E.K.O"
+  echo "（旧版 README 把它挂到了服务不写入的路径；确认里面没有你还需要的东西后自行删除）"
+elif [ -d "$BASE/N.E.K.O" ]; then
+  cp -a "$BASE/N.E.K.O/." "$BASE/neko-home/.local/share/N.E.K.O/" && rm -rf "$BASE/N.E.K.O"
+fi
+# 证书在两种旧布局下挂的都是 /home/neko/ssl，宿主机上这份始终是权威
+[ -d "$BASE/ssl" ] && cp -a "$BASE/ssl/." "$BASE/neko-home/ssl/" && rm -rf "$BASE/ssl"
 
 # 第 5 步：Compose 部署把 volumes 换成本文档上方的新版写法后 docker-compose up -d；
 #         Docker Run 部署按上方的新命令重新 docker run

--- a/README.MD
+++ b/README.MD
@@ -176,13 +176,65 @@ docker run -d \
 
 </details>
 
+#### ⚠️ 从旧版本升级（挂载目录已变更）
+
+> 旧版把数据和证书分成 `./N.E.K.O`、`./ssl` 两个挂载，现在合并为 `./neko-home` 一个。**直接拉新镜像启动会得到一个空的数据目录**——容器照常起来、API Key 也会从环境变量重新生成，看上去一切正常，但人格、记忆、插件、模型都不在。旧数据不会被删除，只是不再挂进容器，按下面的步骤搬一次即可。
+
+<details>
+<summary>点击展开查看迁移步骤（旧版部署过的用户必看）</summary>
+
+先看一眼宿主机上的 `N.E.K.O/` 目录里有没有 `config/`、`memory/` 之类的内容，据此选择对应情况：
+
+```bash
+ls N.E.K.O/
+```
+
+**情况一：有内容，且用 Docker Compose 部署**
+
+```bash
+docker-compose down
+mkdir -p neko-home/.local/share
+mv N.E.K.O neko-home/.local/share/N.E.K.O
+mv ssl     neko-home/ssl
+# 把 docker-compose.yml 的 volumes 换成本文档上方的新版写法，再启动
+docker-compose up -d
+```
+
+**情况二：有内容，且用 Docker Run 部署**
+
+```bash
+docker rm -f neko
+mkdir -p "${NEKO_BASE_PATH}/neko-home/.local/share"
+mv "${NEKO_BASE_PATH}/N.E.K.O" "${NEKO_BASE_PATH}/neko-home/.local/share/N.E.K.O"
+mv "${NEKO_BASE_PATH}/ssl"     "${NEKO_BASE_PATH}/neko-home/ssl"
+# 再按本文档上方的新命令重新 docker run
+```
+
+**情况三：`N.E.K.O/` 是空的**
+
+旧版 README 的挂载目标写成了 `/root/Documents/N.E.K.O`，而容器内的服务实际把数据写在 `/home/neko/.local/share/N.E.K.O`，两者对不上，因此这部分数据一直留在容器内部、从未落到宿主机。**必须在旧容器还没删除时导出**（证书不受影响，仍在宿主机的 `./ssl`）：
+
+```bash
+mkdir -p neko-home/.local/share
+docker cp neko:/home/neko/.local/share/N.E.K.O ./neko-home/.local/share/N.E.K.O
+mv ssl neko-home/ssl
+docker rm -f neko
+# 再按新版配置启动
+```
+
+若旧容器已经删除，这部分数据无法找回。本次挂载调整正是为了修掉这个问题。
+
+> `./logs` 挂载没有变化，无需处理。迁移完成后目录属主由容器启动时自动修正，不需要手动 `chown`。
+
+</details>
+
 #### 🔐 SSL 证书配置
 
 <details>
 <summary>点击展开查看 SSL 证书详细说明</summary>
 
 ##### 自动证书
-容器首次启动时会自动生成有效期为 **1000 年** 的自签名证书，证书文件保存在 `./ssl/` 目录。
+容器首次启动时会自动生成有效期为 **1000 年** 的自签名证书，证书文件保存在 `./neko-home/ssl/` 目录（即挂载目录下的 `ssl/`）。
 
 ##### 自定义证书
 如需使用自己的 SSL 证书：
@@ -191,11 +243,11 @@ docker run -d \
 
 ```bash
 # 创建证书目录
-mkdir -p ./ssl
+mkdir -p ./neko-home/ssl
 
 # 放入您的证书文件（必须命名为特定名称）
-cp your-cert.crt ./ssl/N.E.K.O.crt
-cp your-cert.key ./ssl/N.E.K.O.key
+cp your-cert.crt ./neko-home/ssl/N.E.K.O.crt
+cp your-cert.key ./neko-home/ssl/N.E.K.O.key
 ```
 
 **方法二：启动后替换**
@@ -205,8 +257,8 @@ cp your-cert.key ./ssl/N.E.K.O.key
 docker-compose down
 
 # 2. 替换证书文件
-cp your-cert.crt ./ssl/N.E.K.O.crt
-cp your-cert.key ./ssl/N.E.K.O.key
+cp your-cert.crt ./neko-home/ssl/N.E.K.O.crt
+cp your-cert.key ./neko-home/ssl/N.E.K.O.key
 
 # 3. 重新启动
 docker-compose up -d
@@ -299,9 +351,9 @@ ss -tulpn | grep ':4891[12]'
 
 ##### 2. 权限问题
 ```bash
-# 确保目录有正确权限
-mkdir -p N.E.K.O logs ssl
-chmod 755 N.E.K.O logs ssl
+# 确保目录有正确权限（容器启动时会把 neko-home 的属主改成容器内的 neko 用户）
+mkdir -p neko-home logs
+chmod 755 neko-home logs
 ```
 
 ##### 3. 容器启动失败
@@ -316,7 +368,7 @@ docker logs neko --tail=100
 ##### 4. SSL 证书错误
 ```bash
 # 删除错误证书，让容器重新生成
-rm -f ssl/N.E.K.O.crt ssl/N.E.K.O.key
+rm -f neko-home/ssl/N.E.K.O.crt neko-home/ssl/N.E.K.O.key
 docker-compose up -d
 ```
 
@@ -401,14 +453,16 @@ docker-compose up -d
 
 ##### 数据备份
 ```bash
-# 备份重要数据
+# 备份重要数据（neko-home/ 内含 SSL 私钥，备份文件请勿公开）
 tar -czf neko-backup-$(date +%Y%m%d).tar.gz \
-  N.E.K.O/ \
-  ssl/ \
+  neko-home/ \
+  logs/ \
   docker-compose.yml
 ```
 
 ##### 版本升级
+> 若现有部署仍在使用旧版的 `./N.E.K.O` + `./ssl` 双挂载，升级前请先完成上文「从旧版本升级（挂载目录已变更）」的迁移步骤，否则新容器会对着空数据目录启动。
+
 ```bash
 # 拉取最新镜像
 docker-compose pull

--- a/README.MD
+++ b/README.MD
@@ -195,7 +195,9 @@ ls N.E.K.O/
 # 1) 先导出只存在于容器里的东西。旧版没有挂载 OpenFang 的工作目录，它的配置和
 #    agent 一直在容器可写层，容器一删就没了。这一步要赶在停容器之前做。
 mkdir -p neko-home/.openfang
-docker cp neko:/home/neko/.openfang/. ./neko-home/.openfang/ 2>/dev/null || true
+# 报 "No such container:path" 只说明从没初始化过 OpenFang，可以忽略；其他错误
+# （daemon 没起、权限、磁盘满）不能忽略，所以这里不用 `|| true` 吞掉
+docker cp neko:/home/neko/.openfang/. ./neko-home/.openfang/
 
 # 2) 停容器，合并宿主机上的旧目录。若已经用新版启动过一次，容器会在 neko-home 下
 #    建好同名的空目录和一张新的自签证书，此时直接 mv 会把旧目录套进去多一层，
@@ -212,9 +214,14 @@ docker-compose up -d
 **情况二：有内容，且用 Docker Run 部署**
 
 ```bash
+# 0) 这一段是独立的 shell，NEKO_BASE_PATH 不会从上面的部署命令继承过来；
+#    改成你当初 docker run 时实际用的路径
+NEKO_BASE_PATH="/home/neko/neko-data"
+
 # 1) 先导出只存在于容器里的 OpenFang 状态（同上，必须赶在删容器之前）
 mkdir -p "${NEKO_BASE_PATH}/neko-home/.openfang"
-docker cp neko:/home/neko/.openfang/. "${NEKO_BASE_PATH}/neko-home/.openfang/" 2>/dev/null || true
+# 同上，不吞错误：报 "No such container:path" 可忽略，其他错误必须停下来看
+docker cp neko:/home/neko/.openfang/. "${NEKO_BASE_PATH}/neko-home/.openfang/"
 
 # 2) 删容器，合并宿主机上的旧目录
 docker rm -f neko
@@ -236,7 +243,7 @@ mkdir -p neko-home/.local/share/N.E.K.O neko-home/ssl neko-home/.openfang
 
 # 源路径末尾的 /. 表示复制目录内容，否则目标已存在时会多套一层
 docker cp neko:/home/neko/.local/share/N.E.K.O/. ./neko-home/.local/share/N.E.K.O/
-docker cp neko:/home/neko/.openfang/.            ./neko-home/.openfang/ 2>/dev/null || true
+docker cp neko:/home/neko/.openfang/.            ./neko-home/.openfang/   # 报 "No such container:path" 可忽略
 
 cp -a ssl/. neko-home/ssl/ && rm -rf ssl
 

--- a/README.MD
+++ b/README.MD
@@ -125,9 +125,8 @@ services:
       - "48911:80"   # HTTP 访问端口
       - "48912:443"  # HTTPS 访问端口
     volumes:
-      - ./N.E.K.O:/root/Documents/N.E.K.O
+      - ./neko-home:/home/neko
       - ./logs:/app/logs
-      - ./ssl:/home/neko/ssl
     networks:
       - neko-network
 networks:
@@ -160,9 +159,8 @@ docker run -d \
   --restart unless-stopped \
   -p 48911:80 \
   -p 48912:443 \
-  -v "${NEKO_BASE_PATH}/N.E.K.O:/root/Documents/N.E.K.O" \
+  -v "${NEKO_BASE_PATH}/neko-home:/home/neko" \
   -v "${NEKO_BASE_PATH}/logs:/app/logs" \
-  -v "${NEKO_BASE_PATH}/ssl:/home/neko/ssl" \
   --network neko-network \
   docker.gh-proxy.org/ghcr.io/project-n-e-k-o/n.e.k.o:latest
 ```
@@ -171,9 +169,8 @@ docker run -d \
 启动后会自动生成以下目录结构：
 ```plaintext
 当前目录/
-├── N.E.K.O/      # 配置文件和数据
+├── neko-home/    # 用户主目录（配置、数据、SSL、OpenFang agent）
 ├── logs/         # 应用日志
-├── ssl/          # SSL证书
 └── docker-compose.yml
 ```
 

--- a/README.MD
+++ b/README.MD
@@ -192,22 +192,39 @@ ls N.E.K.O/
 **情况一：有内容，且用 Docker Compose 部署**
 
 ```bash
+# 1) 先导出只存在于容器里的东西。旧版没有挂载 OpenFang 的工作目录，它的配置和
+#    agent 一直在容器可写层，容器一删就没了。这一步要赶在停容器之前做。
+mkdir -p neko-home/.openfang
+docker cp neko:/home/neko/.openfang/. ./neko-home/.openfang/ 2>/dev/null || true
+
+# 2) 停容器，合并宿主机上的旧目录。若已经用新版启动过一次，容器会在 neko-home 下
+#    建好同名的空目录和一张新的自签证书，此时直接 mv 会把旧目录套进去多一层，
+#    所以按内容合并（同名文件以旧数据为准）
 docker-compose down
-mkdir -p neko-home/.local/share
-mv N.E.K.O neko-home/.local/share/N.E.K.O
-mv ssl     neko-home/ssl
-# 把 docker-compose.yml 的 volumes 换成本文档上方的新版写法，再启动
+mkdir -p neko-home/.local/share/N.E.K.O neko-home/ssl
+cp -a N.E.K.O/. neko-home/.local/share/N.E.K.O/ && rm -rf N.E.K.O
+cp -a ssl/.     neko-home/ssl/                 && rm -rf ssl
+
+# 3) 把 docker-compose.yml 的 volumes 换成本文档上方的新版写法，再启动
 docker-compose up -d
 ```
 
 **情况二：有内容，且用 Docker Run 部署**
 
 ```bash
+# 1) 先导出只存在于容器里的 OpenFang 状态（同上，必须赶在删容器之前）
+mkdir -p "${NEKO_BASE_PATH}/neko-home/.openfang"
+docker cp neko:/home/neko/.openfang/. "${NEKO_BASE_PATH}/neko-home/.openfang/" 2>/dev/null || true
+
+# 2) 删容器，合并宿主机上的旧目录
 docker rm -f neko
-mkdir -p "${NEKO_BASE_PATH}/neko-home/.local/share"
-mv "${NEKO_BASE_PATH}/N.E.K.O" "${NEKO_BASE_PATH}/neko-home/.local/share/N.E.K.O"
-mv "${NEKO_BASE_PATH}/ssl"     "${NEKO_BASE_PATH}/neko-home/ssl"
-# 再按本文档上方的新命令重新 docker run
+mkdir -p "${NEKO_BASE_PATH}/neko-home/.local/share/N.E.K.O" "${NEKO_BASE_PATH}/neko-home/ssl"
+cp -a "${NEKO_BASE_PATH}/N.E.K.O/." "${NEKO_BASE_PATH}/neko-home/.local/share/N.E.K.O/" \
+  && rm -rf "${NEKO_BASE_PATH}/N.E.K.O"
+cp -a "${NEKO_BASE_PATH}/ssl/."     "${NEKO_BASE_PATH}/neko-home/ssl/" \
+  && rm -rf "${NEKO_BASE_PATH}/ssl"
+
+# 3) 再按本文档上方的新命令重新 docker run
 ```
 
 **情况三：`N.E.K.O/` 是空的**
@@ -215,9 +232,15 @@ mv "${NEKO_BASE_PATH}/ssl"     "${NEKO_BASE_PATH}/neko-home/ssl"
 旧版 README 的挂载目标写成了 `/root/Documents/N.E.K.O`，而容器内的服务实际把数据写在 `/home/neko/.local/share/N.E.K.O`，两者对不上，因此这部分数据一直留在容器内部、从未落到宿主机。**必须在旧容器还没删除时导出**（证书不受影响，仍在宿主机的 `./ssl`）：
 
 ```bash
-mkdir -p neko-home/.local/share
-docker cp neko:/home/neko/.local/share/N.E.K.O ./neko-home/.local/share/N.E.K.O
-mv ssl neko-home/ssl
+mkdir -p neko-home/.local/share/N.E.K.O neko-home/ssl neko-home/.openfang
+
+# 源路径末尾的 /. 表示复制目录内容，否则目标已存在时会多套一层
+docker cp neko:/home/neko/.local/share/N.E.K.O/. ./neko-home/.local/share/N.E.K.O/
+docker cp neko:/home/neko/.openfang/.            ./neko-home/.openfang/ 2>/dev/null || true
+
+cp -a ssl/. neko-home/ssl/ && rm -rf ssl
+
+# 确认上面几步都成功之后再删旧容器
 docker rm -f neko
 # 再按新版配置启动
 ```

--- a/README.MD
+++ b/README.MD
@@ -190,81 +190,55 @@ docker run -d \
 BASE="."
 # Docker Run 部署改用这行，路径要和你当初 docker run 时用的一致
 # BASE="/home/neko/neko-data"
-
-ls "$BASE/N.E.K.O/"
 ```
 
-里面有 `config/`、`memory/` 之类的内容就走情况一；空的或者目录不存在，走情况二。
-
-**情况一：`$BASE/N.E.K.O/` 有内容**
+**第 1 步：把只存在于容器里的东西导出来。** 必须赶在删容器之前。两类东西可能只在容器可写层里：OpenFang 的工作目录（旧版从没挂过它），以及——如果你当初跟的是旧版 README——应用数据本身，因为那份文档把 `N.E.K.O/` 挂到了 `/root/Documents/N.E.K.O`，而服务从不往那里写。
 
 ```bash
-# 1) 先导出只存在于容器里的东西。旧版没有挂载 OpenFang 的工作目录，它的配置和
-#    agent 一直在容器可写层，容器一删就没了。这一步要赶在停容器之前做。
-#    先确认容器还是旧布局：它若已经按新版挂载，容器里的 /home/neko 就是宿主的
-#    neko-home，导出等于把目录复制到它自己（而且那种情况下旧容器早被重建掉了，
-#    本来就没什么可救的）。
-if docker inspect neko --format '{{range .Mounts}}{{println .Destination}}{{end}}' 2>/dev/null | grep -qx /home/neko; then
-  echo "容器已按新布局挂载，跳过导出"
-else
-  mkdir -p "$BASE/neko-home/.openfang"
-  # 报 "No such container:path" 只说明从没初始化过 OpenFang，可以忽略；其他错误
-  # （daemon 没起、权限、磁盘满）不能忽略，所以这里不用 `|| true` 吞掉
-  docker cp neko:/home/neko/.openfang/. "$BASE/neko-home/.openfang/"
-fi
-```
-
-**确认上一步成功后**再往下——下面第一条就会销毁容器：
-
-```bash
-# 2) 停容器。Compose 部署用 down；Docker Run 部署改用 docker rm -f neko
-docker-compose down
-
-# 3) 容器内的 neko 固定为 uid/gid 1000，和绝大多数发行版第一个普通用户一致，
-#    所以通常不必动属主。只有你的宿主账号不是 1000 时才需要这一步。
-[ "$(id -u)" = 1000 ] || sudo chown -R "$(id -u):$(id -g)" "$BASE/neko-home"
-
-# 4) 合并宿主机上的旧目录。容器已经在 neko-home 下建好了同名的空目录和一张新的
-#    自签证书，此时直接 mv 会把旧目录套进去多一层，所以按内容合并
-#    （同名文件以旧数据为准）
-mkdir -p "$BASE/neko-home/.local/share/N.E.K.O" "$BASE/neko-home/ssl"
-cp -a "$BASE/N.E.K.O/." "$BASE/neko-home/.local/share/N.E.K.O/" && rm -rf "$BASE/N.E.K.O"
-cp -a "$BASE/ssl/."     "$BASE/neko-home/ssl/"                 && rm -rf "$BASE/ssl"
-
-# 5) Compose 部署把 volumes 换成本文档上方的新版写法后 docker-compose up -d；
-#    Docker Run 部署按上方的新命令重新 docker run
-```
-
-**情况二：`$BASE/N.E.K.O/` 是空的或不存在**
-
-旧版 README 的挂载目标写成了 `/root/Documents/N.E.K.O`，而容器内的服务实际把数据写在 `/home/neko/.local/share/N.E.K.O`，两者对不上，因此这部分数据一直留在容器内部、从未落到宿主机。**必须在旧容器还没删除时导出**（证书不受影响，仍在宿主机的 `$BASE/ssl`）：
-
-```bash
-# 容器内的 neko 固定为 uid/gid 1000；宿主账号不是 1000 时才需要先要回属主
-[ "$(id -u)" = 1000 ] || sudo chown -R "$(id -u):$(id -g)" "$BASE/neko-home"
-
 mkdir -p "$BASE/neko-home/.local/share/N.E.K.O" "$BASE/neko-home/ssl" "$BASE/neko-home/.openfang"
 
-# 容器若已按新布局挂载，/home/neko 就是宿主的 neko-home，下面两条会把目录复制到
-# 它自己；而那种情况下旧容器早被重建，容器里也没有待救的数据了
-if docker inspect neko --format '{{range .Mounts}}{{println .Destination}}{{end}}' 2>/dev/null | grep -qx /home/neko; then
-  echo "容器已按新布局挂载，容器内没有待救的旧数据（若数据确实还没迁移，请检查 $BASE/N.E.K.O）"
-else
-  # 源路径末尾的 /. 表示复制目录内容，否则目标已存在时会多套一层
-  docker cp neko:/home/neko/.local/share/N.E.K.O/. "$BASE/neko-home/.local/share/N.E.K.O/"
-  docker cp neko:/home/neko/.openfang/.            "$BASE/neko-home/.openfang/"   # 报 "No such container:path" 可忽略
-fi
+# 判据用「容器实际挂了什么」，不是「宿主目录里有没有东西」——后者对旧版 README
+# 部署的人是错的：那个目录里可能有你自己放进去的文件，而真数据仍然只在容器里。
+MOUNTS=$(docker inspect neko --format '{{range .Mounts}}{{println .Destination}}{{end}}' 2>/dev/null)
 
-cp -a "$BASE/ssl/." "$BASE/neko-home/ssl/" && rm -rf "$BASE/ssl"
+if printf '%s
+' "$MOUNTS" | grep -qx /home/neko; then
+  echo "容器已按新布局挂载，没有待导出的内容"
+else
+  # 应用数据先导，这部分丢了找不回来。容器没把数据目录挂出去，就说明它只存在于
+  # 容器可写层。源路径末尾的 /. 表示复制目录内容，否则目标已存在时会多套一层。
+  if ! printf '%s
+' "$MOUNTS" | grep -qx /home/neko/.local/share/N.E.K.O; then
+    docker cp neko:/home/neko/.local/share/N.E.K.O/. "$BASE/neko-home/.local/share/N.E.K.O/"
+  fi
+  # OpenFang 状态其次，且不致命：从没初始化过的话容器里就没这个目录，而 docker cp
+  # 对不存在的源路径是报错退出的 —— 不能让它挡住上面已经完成的关键导出。
+  docker cp neko:/home/neko/.openfang/. "$BASE/neko-home/.openfang/" \
+    || echo "（容器里没有 .openfang，或导出失败；不影响上面的应用数据）"
+fi
 ```
 
-**确认上面几步都成功之后**，再删旧容器并按新版配置启动。导出这一步一旦失败（权限、磁盘满、daemon 没起），千万不要往下执行——容器是这部分数据唯一的副本：
+**确认上一步成功后**再往下——下面第一条就会销毁容器，而对跟旧版 README 部署的人来说，那是应用数据唯一的副本：
 
 ```bash
-docker rm -f neko
+# 第 2 步：停容器。Compose 部署用 down；Docker Run 部署改用 docker rm -f neko
+docker-compose down
+
+# 第 3 步：容器内的 neko 固定为 uid/gid 1000，和绝大多数发行版第一个普通用户一致，
+#         所以通常不必动属主。只有你的宿主账号不是 1000 时才需要这一步。
+[ "$(id -u)" = 1000 ] || sudo chown -R "$(id -u):$(id -g)" "$BASE/neko-home"
+
+# 第 4 步：把宿主机上的旧目录并进来——有就并，没有就跳过。容器可能已经在 neko-home
+#         下建好了同名目录和一张新的自签证书，所以按内容合并、不要用 mv：mv 到已存在
+#         的目录会套进去多一层。同名文件以旧数据为准。
+[ -d "$BASE/N.E.K.O" ] && cp -a "$BASE/N.E.K.O/." "$BASE/neko-home/.local/share/N.E.K.O/" && rm -rf "$BASE/N.E.K.O"
+[ -d "$BASE/ssl" ]     && cp -a "$BASE/ssl/."     "$BASE/neko-home/ssl/"                 && rm -rf "$BASE/ssl"
+
+# 第 5 步：Compose 部署把 volumes 换成本文档上方的新版写法后 docker-compose up -d；
+#         Docker Run 部署按上方的新命令重新 docker run
 ```
 
-若旧容器已经删除，这部分数据无法找回。本次挂载调整正是为了修掉这个问题。
+若旧容器已经删除、宿主机上的 `N.E.K.O/` 又是空的，那部分数据无法找回。本次挂载调整正是为了修掉这个问题。
 
 > `./logs` 挂载没有变化，无需处理。容器内的应用用户固定为 uid/gid **1000**，和绝大多数 Linux 发行版第一个普通用户的号一致——所以 `neko-home/` 在宿主机上的属主就是你自己，备份、编辑、删除都不需要 `sudo`。
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -107,12 +107,25 @@ RUN if [ -n "$HTTP_PROXY" ]; then export http_proxy=$HTTP_PROXY; fi; \
     unset https_proxy
 
 # Create nginx user and neko application user, plus Playwright cache directory
+#
+# neko 固定 uid/gid 1000（不用 `-r` 的系统号段）。/home/neko 是 bind mount 出去的
+# 持久化目录，容器给它的属主会原样出现在宿主机上；1000 是绝大多数 Linux 发行版第一个
+# 普通用户的号，对上之后用户备份、编辑、删除 neko-home 都不必 sudo。系统号段（100-999）
+# 是动态分配的，宿主上通常对应某个无关的服务账户，甚至每次重建镜像都可能变。
+# entrypoint 里对 /home/neko 的 chown 用的就是字面量 1000:1000，两处必须一致。
+# 1000 在 debian:bookworm 上是空的，而且是结构性的空：base-passwd 的静态表只到
+# uid 42 和 65534，Debian Policy 把 100-999 划给系统账户（`adduser --system` 强制落
+# 在这一段，上面的 nginx 就是），1000 起才是普通用户段，而基础镜像里压根没有"普通
+# 用户"这个概念。⚠️ 别把最终阶段的 FROM 换成 ubuntu:* 或 node:*-bookworm —— 它们
+# 预建的 ubuntu / node 用户正好占着 1000。（本文件的 node:24-slim 只是 builder 阶段，
+# 产物靠 COPY --from 取，不进最终镜像。）真撞上了，下面两条会直接失败让 build 红，
+# 而不是静默退回另一个号。
 RUN groupadd -r nginx && \
     useradd -r -g nginx nginx && \
     mkdir -p /var/log/nginx /var/cache/nginx && \
     chown -R nginx:nginx /var/log/nginx /var/cache/nginx && \
-    groupadd -r neko && \
-    useradd -r -g neko -d /home/neko -s /bin/bash neko && \
+    groupadd -g 1000 neko && \
+    useradd -u 1000 -g 1000 -d /home/neko -s /bin/bash neko && \
     mkdir -p /home/neko /app/logs /app/N.E.K.O /home/neko/ssl /opt/ms-playwright && \
     chown -R neko:neko /home/neko /app /opt/ms-playwright
 

--- a/docker/Dockerfile.full
+++ b/docker/Dockerfile.full
@@ -178,12 +178,25 @@ RUN if [ -n "$HTTP_PROXY" ]; then export http_proxy=$HTTP_PROXY; fi; \
     && rm -rf /var/lib/apt/lists/*
 
 #创建nginx用户和应用用户，以及Playwright缓存目录
+#
+# neko 固定 uid/gid 1000（不用 `-r` 的系统号段）。/home/neko 是 bind mount 出去的
+# 持久化目录，容器给它的属主会原样出现在宿主机上；1000 是绝大多数 Linux 发行版第一个
+# 普通用户的号，对上之后用户备份、编辑、删除 neko-home 都不必 sudo。系统号段（100-999）
+# 是动态分配的，宿主上通常对应某个无关的服务账户，甚至每次重建镜像都可能变。
+# entrypoint 里对 /home/neko 的 chown 用的就是字面量 1000:1000，两处必须一致。
+# 1000 在 debian:bookworm 上是空的，而且是结构性的空：base-passwd 的静态表只到
+# uid 42 和 65534，Debian Policy 把 100-999 划给系统账户（`adduser --system` 强制落
+# 在这一段，上面的 nginx 就是），1000 起才是普通用户段，而基础镜像里压根没有"普通
+# 用户"这个概念。⚠️ 别把最终阶段的 FROM 换成 ubuntu:* 或 node:*-bookworm —— 它们
+# 预建的 ubuntu / node 用户正好占着 1000。（本文件的 node:24-slim 只是 builder 阶段，
+# 产物靠 COPY --from 取，不进最终镜像。）真撞上了，下面两条会直接失败让 build 红，
+# 而不是静默退回另一个号。
 RUN groupadd -r nginx && \
     useradd -r -g nginx nginx && \
     mkdir -p /var/log/nginx /var/cache/nginx && \
     chown -R nginx:nginx /var/log/nginx /var/cache/nginx && \
-    groupadd -r neko && \
-    useradd -r -g neko -d /home/neko -s /bin/bash neko && \
+    groupadd -g 1000 neko && \
+    useradd -u 1000 -g 1000 -d /home/neko -s /bin/bash neko && \
     mkdir -p /home/neko /app/logs /app/N.E.K.O /home/neko/ssl /opt/ms-playwright && \
     chown -R neko:neko /home/neko /app /opt/ms-playwright
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -49,14 +49,11 @@ services:
 
     # 卷挂载配置
     volumes:
-      # 1. 持久化配置目录（XDG_DATA_HOME 规范路径）
-      - ./N.E.K.O:/home/neko/.local/share/N.E.K.O
+      # 1. neko 用户主目录（持久化数据、SSL 证书、OpenFang 配置等）
+      - ./neko-home:/home/neko
 
       # 2. 日志目录
       - ./logs:/app/logs
-
-      # 3. SSL证书目录
-      - ./ssl:/home/neko/ssl
 
     # 环境变量
     environment:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -48,8 +48,11 @@ services:
       - "48912:443"
 
     # 卷挂载配置
+    # ⚠️ 旧版本用 ./N.E.K.O + ./ssl 两个挂载，现已合并为 ./neko-home 一个。
+    #    从旧版升级必须先迁移数据（见 README「从旧版本升级」一节），
+    #    否则容器会对着一个空目录启动，表现为"数据全没了"。
     volumes:
-      # 1. neko 用户主目录（持久化数据、SSL 证书、OpenFang 配置等）
+      # 1. neko 用户主目录（用户数据、SSL 证书与私钥、OpenFang 运行状态）
       - ./neko-home:/home/neko
 
       # 2. 日志目录

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1225,12 +1225,16 @@ warn_legacy_layout() {
             ;;
         stale-logs)
             echo "   日志目录里有历史日志，说明这个部署以前跑过，而数据目录是空的。"
-            echo "   本版本把 ./N.E.K.O + ./ssl 两个挂载合并成了 ./neko-home 一个，"
-            echo "   旧数据没有丢，只是不再挂进容器。请停止容器后执行："
-            echo "       mkdir -p neko-home/.local/share/N.E.K.O neko-home/ssl"
-            echo "       cp -a N.E.K.O/. neko-home/.local/share/N.E.K.O/ && rm -rf N.E.K.O"
-            echo "       cp -a ssl/.     neko-home/ssl/                 && rm -rf ssl"
-            echo "   （本次启动已经在 neko-home 下建好了同名目录，直接 mv 会多套一层）"
+            echo "   本版本把 ./N.E.K.O + ./ssl 两个挂载合并成了 ./neko-home 一个。"
+            echo "   先看宿主机上的 N.E.K.O/ 是不是空的："
+            echo "     · 非空 —— 数据还在，停容器后执行（直接 mv 会多套一层，本次"
+            echo "       启动已经在 neko-home 下建好了同名目录）："
+            echo "         mkdir -p neko-home/.local/share/N.E.K.O neko-home/ssl"
+            echo "         cp -a N.E.K.O/. neko-home/.local/share/N.E.K.O/ && rm -rf N.E.K.O"
+            echo "         cp -a ssl/.     neko-home/ssl/                 && rm -rf ssl"
+            echo "     · 空 —— 此前跟的是旧版 README，其挂载目标从来对不上服务的实际"
+            echo "       写入位置，数据只存在于旧容器里。若那个容器已被重建或删除，"
+            echo "       这部分数据无法找回；OpenFang 状态同理。"
             ;;
     esac
     echo "   详见 README「从旧版本升级」一节。全新安装可忽略本提示。"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1277,11 +1277,17 @@ main() {
     #
     # 失败必须停：三个业务进程都以 neko 跑，数据目录不可写的话它们会在运行期
     # 各处零散报错，比在这里干脆退出难诊断得多。
+    #
+    # 属主写字面量 1000:1000 而不是 neko:neko —— 两者在本镜像里是同一个（Dockerfile
+    # 用 `useradd -u 1000 -g 1000` 固定住了），但这些路径是 bind mount 出去的，落到
+    # 宿主机上只有数字有意义：宿主那边没有叫 neko 的账户，它看到的就是 1000，而 1000
+    # 恰是绝大多数发行版第一个普通用户的号，对上之后用户不必 sudo 就能管自己的备份。
+    # 写死数字也让这层契约在文件里是可见的：改 Dockerfile 里的号就必须同步改这里。
     mkdir -p /home/neko/.local/share/N.E.K.O /home/neko/.openfang
-    if ! chown neko:neko /home/neko /home/neko/.local /home/neko/.local/share \
+    if ! chown 1000:1000 /home/neko /home/neko/.local /home/neko/.local/share \
         || ! find /home/neko/.local/share/N.E.K.O /home/neko/.openfang \
-               \( ! -user neko -o ! -group neko \) -exec chown -h neko:neko {} + ; then
-        echo "❌ 无法把数据目录的属主改为 neko"
+               \( ! -uid 1000 -o ! -gid 1000 \) -exec chown -h 1000:1000 {} + ; then
+        echo "❌ 无法把数据目录的属主改为 1000:1000（容器内的 neko）"
         echo "   宿主机的挂载可能不允许改属主 —— NFS 带 root_squash、CIFS 没带"
         echo "   cifsacl、或只读挂载都会这样。容器内的服务以 neko 身份运行，"
         echo "   数据目录写不进去会在启动之后才零散暴露，所以这里直接停。"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1168,24 +1168,107 @@ start_nginx_proxy() {
     return 0
 }
 
+# ── 旧版挂载布局检测 ──────────────────────────────────────────
+# 数据挂载从 ./N.E.K.O + ./ssl 两条合并成了 ./neko-home 一条。被落下的旧目录在
+# 宿主机上，根本没挂进容器，所以这里无法自动迁移；能做的只是在认出「这是一次升级」
+# 时把话说清楚，免得用户把一个空数据目录当成正常的全新安装 —— core_config.json
+# 会从环境变量重新生成，容器看起来一切正常，最容易让人误判。
+# 快照必须在本脚本自己往 /home/neko 和 /app/logs 写东西之前取。
+LEGACY_LAYOUT_HINT=""
+
+detect_legacy_layout() {
+    local data_root="/home/neko/.local/share/N.E.K.O"
+
+    # 数据目录有内容 → 挂载是通的，不用多嘴
+    if [ -n "$(ls -A "$data_root" 2>/dev/null)" ]; then
+        return 0
+    fi
+
+    # 痕迹一：旧的 N.E.K.O 目录被整个当成了 neko-home，数据根的子目录直接躺在家目录里
+    if [ -d /home/neko/config ] || [ -d /home/neko/memory ]; then
+        LEGACY_LAYOUT_HINT="wrong-level"
+        return 0
+    fi
+
+    # 痕迹二：旧目录搬进 neko-home 了，但没落到 XDG 路径下
+    if [ -d /home/neko/N.E.K.O ]; then
+        LEGACY_LAYOUT_HINT="wrong-depth"
+        return 0
+    fi
+
+    # 痕迹三：./logs 里有历史日志 → 这个部署以前跑起来过，而数据目录却是空的。
+    # 典型的「直接 pull 新镜像重启」，旧数据还留在宿主机的 ./N.E.K.O 里。
+    if [ -n "$(find /app/logs -type f -name '*.log' 2>/dev/null | head -n 1)" ]; then
+        LEGACY_LAYOUT_HINT="stale-logs"
+    fi
+
+    return 0
+}
+
+warn_legacy_layout() {
+    if [ -z "$LEGACY_LAYOUT_HINT" ]; then
+        return 0
+    fi
+
+    echo ""
+    echo "=================================================="
+    echo "⚠️  数据目录为空，但检测到旧版部署的痕迹"
+    case "$LEGACY_LAYOUT_HINT" in
+        wrong-level)
+            echo "   /home/neko 下直接出现了 config/ 或 memory/ —— 旧的 N.E.K.O 目录"
+            echo "   可能被整个当成了 neko-home。它应该放在下面这一层："
+            echo "       neko-home/.local/share/N.E.K.O/"
+            ;;
+        wrong-depth)
+            echo "   /home/neko/N.E.K.O 存在，但服务读的是 .local/share 下的路径。"
+            echo "   请把它移动到：neko-home/.local/share/N.E.K.O/"
+            ;;
+        stale-logs)
+            echo "   日志目录里有历史日志，说明这个部署以前跑过，而数据目录是空的。"
+            echo "   本版本把 ./N.E.K.O + ./ssl 两个挂载合并成了 ./neko-home 一个，"
+            echo "   旧数据没有丢，只是不再挂进容器。请停止容器后执行："
+            echo "       mkdir -p neko-home/.local/share"
+            echo "       mv N.E.K.O neko-home/.local/share/N.E.K.O"
+            echo "       mv ssl     neko-home/ssl"
+            ;;
+    esac
+    echo "   详见 README「从旧版本升级」一节。全新安装可忽略本提示。"
+    echo "=================================================="
+    echo ""
+}
+
 # 9. 主执行流程
 main() {
     echo "=================================================="
     echo "   N.E.K.O. Container with Nginx Proxy - Startup"
     echo "=================================================="
-    
+
+    # 先取快照：后面的 setup_* 会往 /home/neko 和 /app/logs 里写东西
+    detect_legacy_layout
+
     setup_signal_handlers
     check_dependencies
     setup_configuration
     setup_dependencies
     setup_nginx_proxy
-    
-    # 确保 home 目录对 neko 用户可写（Docker volume 可能以 root 创建）
-    chown -R neko:neko /home/neko
-    
+
+    # 确保 home 目录对 neko 用户可写（Docker volume 可能以 root 创建）。
+    # 只改属主不对的条目：稳态下这一遍是纯遍历、不产生写入，数据量大的部署不必
+    # 每次启动都把整棵树重写一遍。
+    find /home/neko -path /home/neko/ssl -prune -o \
+        \( ! -user neko -o ! -group neko \) -exec chown neko:neko {} + || true
+
+    # ssl/ 被上面刻意跳过。私钥由 root 生成并 chmod 600，nginx 主进程也以 root
+    # 读取它，而三个业务进程（含内嵌的用户插件服务）以 neko 身份运行。合并挂载后
+    # ssl/ 落进了 /home/neko 里，若跟着一起 chown，等于把 TLS 私钥交给应用用户，
+    # 功能上却一分钱都不值。用户自带证书的属主同样不该被容器改写。
+
     # 启动 OpenFang A2A 守护进程（编译在镜像中的 Rust 二进制）
     start_openfang_daemon
-    
+
+    # 放在服务启动前打印：此时前面的初始化日志已经刷完，这条不会被淹掉
+    warn_legacy_layout
+
     # 启动N.E.K.O服务
     if ! start_services; then
         echo "❌ Failed to start N.E.K.O services"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1257,28 +1257,36 @@ main() {
     setup_dependencies
     setup_nginx_proxy
 
-    # 确保 home 目录对 neko 用户可写（Docker volume 可能以 root 创建）。
-    # 只改属主不对的条目：稳态下这一遍是纯遍历、不产生写入，数据量大的部署不必
-    # 每次启动都把整棵树重写一遍。
-    # chown 必须带 -h：不带的话它会解引用命令行上的符号链接，把宿主机备份里
-    # 可能存在的链接的**目标**改掉（`chown -R` 默认 -P 会跳过符号链接，这里换成
-    # find 驱动就没有那层保护了）。
+    # 确保数据目录对 neko 用户可写（Docker volume 可能以 root 创建）。
+    #
+    # 只认应用真正要写的两棵子树，不扫整个 home。合并挂载之后 /home/neko 是宿主
+    # 目录，用户完全可以往它下面再挂别的东西；递归整棵树意味着那些嵌套挂载的宿主
+    # 侧对象会被改成 neko —— 挂进来的要是个 docker socket，等于把 docker 控制权
+    # 交给以 neko 运行的业务进程和插件代码。（-xdev 挡不住：同一宿主文件系统的
+    # bind mount 设备号相同。）
+    #
+    # /home/neko 本身只非递归地给一次：neko 要能在自己家里创建 .cache 之类的
+    # 目录，否则运行期任何往 $HOME 写东西的库都会踩坑；但它下面挂了什么不归我们管。
+    #
+    # ssl/ 因此天然不在范围内。私钥由 root 生成并 chmod 600，nginx 主进程也以
+    # root 读取，业务进程没有任何理由读得到它。
+    #
+    # 只改属主不对的条目：稳态下这一遍是纯遍历、不产生写入。chown 必须带 -h，
+    # 否则它会解引用符号链接去改**目标**（`chown -R` 默认 -P 有这层保护，换成
+    # find 驱动就没有了）。
+    #
     # 失败必须停：三个业务进程都以 neko 跑，数据目录不可写的话它们会在运行期
-    # 各种写入上零散报错，比在这里干脆退出难诊断得多。（原先这里挂了 `|| true`，
-    # 把 set -e 本来的 fail-fast 吞掉了。）
-    if ! find /home/neko -path /home/neko/ssl -prune -o \
-            \( ! -user neko -o ! -group neko \) -exec chown -h neko:neko {} + ; then
-        echo "❌ 无法把 /home/neko 的属主改为 neko"
+    # 各处零散报错，比在这里干脆退出难诊断得多。
+    mkdir -p /home/neko/.local/share/N.E.K.O /home/neko/.openfang
+    if ! chown neko:neko /home/neko /home/neko/.local /home/neko/.local/share \
+        || ! find /home/neko/.local/share/N.E.K.O /home/neko/.openfang \
+               \( ! -user neko -o ! -group neko \) -exec chown -h neko:neko {} + ; then
+        echo "❌ 无法把数据目录的属主改为 neko"
         echo "   宿主机的挂载可能不允许改属主 —— NFS 带 root_squash、CIFS 没带"
         echo "   cifsacl、或只读挂载都会这样。容器内的服务以 neko 身份运行，"
         echo "   数据目录写不进去会在启动之后才零散暴露，所以这里直接停。"
         exit 1
     fi
-
-    # ssl/ 被上面刻意跳过。私钥由 root 生成并 chmod 600，nginx 主进程也以 root
-    # 读取它，而三个业务进程（含内嵌的用户插件服务）以 neko 身份运行。合并挂载后
-    # ssl/ 落进了 /home/neko 里，若跟着一起 chown，等于把 TLS 私钥交给应用用户，
-    # 功能上却一分钱都不值。用户自带证书的属主同样不该被容器改写。
 
     # 启动 OpenFang A2A 守护进程（编译在镜像中的 Rust 二进制）
     start_openfang_daemon

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1179,11 +1179,11 @@ LEGACY_LAYOUT_HINT=""
 detect_legacy_layout() {
     local data_root="/home/neko/.local/share/N.E.K.O"
 
-    # 数据目录有内容 → 挂载是通的，不用多嘴
-    if [ -n "$(ls -A "$data_root" 2>/dev/null)" ]; then
-        return 0
-    fi
-
+    # 放错位置的旧目录先查，且不拿「数据根是否为空」当前提。用户很可能是先用新版
+    # 起了一次（应用于是往数据根写了一份默认配置），发现东西不见了才去搬旧目录，
+    # 而后搬错层 —— 那正是最该提醒的时刻，此时数据根恰恰是非空的。这两个目录名
+    # 应用自己永远不会在家目录根下创建，出现即是人为放置。
+    #
     # 痕迹一：旧的 N.E.K.O 目录被整个当成了 neko-home，数据根的子目录直接躺在家目录里
     if [ -d /home/neko/config ] || [ -d /home/neko/memory ]; then
         LEGACY_LAYOUT_HINT="wrong-level"
@@ -1193,6 +1193,11 @@ detect_legacy_layout() {
     # 痕迹二：旧目录搬进 neko-home 了，但没落到 XDG 路径下
     if [ -d /home/neko/N.E.K.O ]; then
         LEGACY_LAYOUT_HINT="wrong-depth"
+        return 0
+    fi
+
+    # 剩下这条必须以数据根为空为前提：日志有历史 + 数据根有内容 = 正常运行中
+    if [ -n "$(ls -A "$data_root" 2>/dev/null)" ]; then
         return 0
     fi
 
@@ -1212,16 +1217,20 @@ warn_legacy_layout() {
 
     echo ""
     echo "=================================================="
-    echo "⚠️  数据目录为空，但检测到旧版部署的痕迹"
+    echo "⚠️  检测到旧版部署的痕迹"
     case "$LEGACY_LAYOUT_HINT" in
         wrong-level)
             echo "   /home/neko 下直接出现了 config/ 或 memory/ —— 旧的 N.E.K.O 目录"
             echo "   可能被整个当成了 neko-home。它应该放在下面这一层："
             echo "       neko-home/.local/share/N.E.K.O/"
+            echo "   若那个位置已经有本次启动生成的默认配置，别直接覆盖，按内容合并："
+            echo "       cp -a neko-home/config neko-home/memory ... neko-home/.local/share/N.E.K.O/"
             ;;
         wrong-depth)
             echo "   /home/neko/N.E.K.O 存在，但服务读的是 .local/share 下的路径。"
-            echo "   请把它移动到：neko-home/.local/share/N.E.K.O/"
+            echo "   请把它的内容并到：neko-home/.local/share/N.E.K.O/"
+            echo "       cp -a neko-home/N.E.K.O/. neko-home/.local/share/N.E.K.O/ \\"
+            echo "         && rm -rf neko-home/N.E.K.O"
             ;;
         stale-logs)
             echo "   日志目录里有历史日志，说明这个部署以前跑过，而数据目录是空的。"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1263,8 +1263,17 @@ main() {
     # chown 必须带 -h：不带的话它会解引用命令行上的符号链接，把宿主机备份里
     # 可能存在的链接的**目标**改掉（`chown -R` 默认 -P 会跳过符号链接，这里换成
     # find 驱动就没有那层保护了）。
-    find /home/neko -path /home/neko/ssl -prune -o \
-        \( ! -user neko -o ! -group neko \) -exec chown -h neko:neko {} + || true
+    # 失败必须停：三个业务进程都以 neko 跑，数据目录不可写的话它们会在运行期
+    # 各种写入上零散报错，比在这里干脆退出难诊断得多。（原先这里挂了 `|| true`，
+    # 把 set -e 本来的 fail-fast 吞掉了。）
+    if ! find /home/neko -path /home/neko/ssl -prune -o \
+            \( ! -user neko -o ! -group neko \) -exec chown -h neko:neko {} + ; then
+        echo "❌ 无法把 /home/neko 的属主改为 neko"
+        echo "   宿主机的挂载可能不允许改属主 —— NFS 带 root_squash、CIFS 没带"
+        echo "   cifsacl、或只读挂载都会这样。容器内的服务以 neko 身份运行，"
+        echo "   数据目录写不进去会在启动之后才零散暴露，所以这里直接停。"
+        exit 1
+    fi
 
     # ssl/ 被上面刻意跳过。私钥由 root 生成并 chmod 600，nginx 主进程也以 root
     # 读取它，而三个业务进程（含内嵌的用户插件服务）以 neko 身份运行。合并挂载后

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1227,9 +1227,10 @@ warn_legacy_layout() {
             echo "   日志目录里有历史日志，说明这个部署以前跑过，而数据目录是空的。"
             echo "   本版本把 ./N.E.K.O + ./ssl 两个挂载合并成了 ./neko-home 一个，"
             echo "   旧数据没有丢，只是不再挂进容器。请停止容器后执行："
-            echo "       mkdir -p neko-home/.local/share"
-            echo "       mv N.E.K.O neko-home/.local/share/N.E.K.O"
-            echo "       mv ssl     neko-home/ssl"
+            echo "       mkdir -p neko-home/.local/share/N.E.K.O neko-home/ssl"
+            echo "       cp -a N.E.K.O/. neko-home/.local/share/N.E.K.O/ && rm -rf N.E.K.O"
+            echo "       cp -a ssl/.     neko-home/ssl/                 && rm -rf ssl"
+            echo "   （本次启动已经在 neko-home 下建好了同名目录，直接 mv 会多套一层）"
             ;;
     esac
     echo "   详见 README「从旧版本升级」一节。全新安装可忽略本提示。"
@@ -1255,8 +1256,11 @@ main() {
     # 确保 home 目录对 neko 用户可写（Docker volume 可能以 root 创建）。
     # 只改属主不对的条目：稳态下这一遍是纯遍历、不产生写入，数据量大的部署不必
     # 每次启动都把整棵树重写一遍。
+    # chown 必须带 -h：不带的话它会解引用命令行上的符号链接，把宿主机备份里
+    # 可能存在的链接的**目标**改掉（`chown -R` 默认 -P 会跳过符号链接，这里换成
+    # find 驱动就没有那层保护了）。
     find /home/neko -path /home/neko/ssl -prune -o \
-        \( ! -user neko -o ! -group neko \) -exec chown neko:neko {} + || true
+        \( ! -user neko -o ! -group neko \) -exec chown -h neko:neko {} + || true
 
     # ssl/ 被上面刻意跳过。私钥由 root 生成并 chmod 600，nginx 主进程也以 root
     # 读取它，而三个业务进程（含内嵌的用户插件服务）以 neko 身份运行。合并挂载后

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1292,8 +1292,11 @@ main() {
     # 宿主机上只有数字有意义：宿主那边没有叫 neko 的账户，它看到的就是 1000，而 1000
     # 恰是绝大多数发行版第一个普通用户的号，对上之后用户不必 sudo 就能管自己的备份。
     # 写死数字也让这层契约在文件里是可见的：改 Dockerfile 里的号就必须同步改这里。
+    # 两条 chown 都必须带 -h。不带的话它会解引用命令行上的符号链接去改**目标**：
+    # neko-home 是用户的目录，.local 或 .local/share 完全可能是指向别处（甚至别的
+    # 磁盘）的软链，那样一来被改属主的就是 /home/neko 之外的宿主路径了。
     mkdir -p /home/neko/.local/share/N.E.K.O /home/neko/.openfang
-    if ! chown 1000:1000 /home/neko /home/neko/.local /home/neko/.local/share \
+    if ! chown -h 1000:1000 /home/neko /home/neko/.local /home/neko/.local/share \
         || ! find /home/neko/.local/share/N.E.K.O /home/neko/.openfang \
                \( ! -uid 1000 -o ! -gid 1000 \) -exec chown -h 1000:1000 {} + ; then
         echo "❌ 无法把数据目录的属主改为 1000:1000（容器内的 neko）"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1292,9 +1292,23 @@ main() {
     # 宿主机上只有数字有意义：宿主那边没有叫 neko 的账户，它看到的就是 1000，而 1000
     # 恰是绝大多数发行版第一个普通用户的号，对上之后用户不必 sudo 就能管自己的备份。
     # 写死数字也让这层契约在文件里是可见的：改 Dockerfile 里的号就必须同步改这里。
-    # 两条 chown 都必须带 -h。不带的话它会解引用命令行上的符号链接去改**目标**：
-    # neko-home 是用户的目录，.local 或 .local/share 完全可能是指向别处（甚至别的
-    # 磁盘）的软链，那样一来被改属主的就是 /home/neko 之外的宿主路径了。
+    # 状态目录不接受软链。两条 chown 都带了 -h（不带会解引用命令行参数去改目标），
+    # 但那挡不住 find：路径中间那几段的符号链接是内核在解析路径时就跟随掉的，
+    # find 根本无从拒绝，于是它会走到 /home/neko 之外的树上，把那里每个不属于
+    # 1000 的条目都改掉。与其想办法处理，不如直接不收 —— 想把数据放到别的磁盘，
+    # 该在 compose 里把 neko-home 挂到那个位置，而不是在里面做软链。
+    for _state_dir in /home/neko/.local /home/neko/.local/share \
+                      /home/neko/.local/share/N.E.K.O /home/neko/.openfang; do
+        if [ -L "$_state_dir" ]; then
+            echo "❌ $_state_dir 是符号链接，数据目录不支持这样放"
+            echo "   启动时的属主修复会顺着它改到 /home/neko 之外的宿主路径上。"
+            echo "   请把它换成真实目录；想让数据落在别的位置，就在 compose 里把"
+            echo "   neko-home 直接挂到那个位置。"
+            exit 1
+        fi
+    done
+    unset _state_dir
+
     mkdir -p /home/neko/.local/share/N.E.K.O /home/neko/.openfang
     if ! chown -h 1000:1000 /home/neko /home/neko/.local /home/neko/.local/share \
         || ! find /home/neko/.local/share/N.E.K.O /home/neko/.openfang \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1180,9 +1180,8 @@ main() {
     setup_dependencies
     setup_nginx_proxy
     
-    # 确保数据目录对 neko 用户可写（Docker volume 可能以 root 创建）
-    mkdir -p /home/neko/.local/share/N.E.K.O
-    chown -R neko:neko /home/neko/.local/share/N.E.K.O
+    # 确保 home 目录对 neko 用户可写（Docker volume 可能以 root 创建）
+    chown -R neko:neko /home/neko
     
     # 启动 OpenFang A2A 守护进程（编译在镜像中的 Rust 二进制）
     start_openfang_daemon

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -49,7 +49,11 @@ docker cp neko:/home/neko/.openfang/. ./neko-home/.openfang/
 if [ -z "$(ls -A N.E.K.O 2>/dev/null)" ]; then
   docker cp neko:/home/neko/.local/share/N.E.K.O/. ./neko-home/.local/share/N.E.K.O/
 fi
+```
 
+**Only continue once step 1 succeeded.** `docker compose down` removes the container, which for an empty host `N.E.K.O/` is the only copy of that data — if the export failed on permissions, a full disk or an unreachable daemon, stop here and fix that first.
+
+```bash
 # 2. Stop the container, then merge the host-side directories by content. If the
 #    new layout has been started once, the destinations already exist (plus a
 #    freshly generated self-signed certificate) and `mv` would nest them one level

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -64,10 +64,10 @@ fi
 #    freshly generated self-signed certificate) and `mv` would nest them one level
 #    deeper. Same-named files resolve in favour of the old data.
 docker compose down
-# The container has chowned neko-home to its internal neko user (a system uid),
-# so a normal host user cannot write there. Take it back; the container fixes it
-# again on the next start.
-sudo chown -R "$(id -u):$(id -g)" neko-home
+# The container's neko user is pinned to uid/gid 1000, matching the first regular
+# user on most distributions, so ownership usually already lines up. Only needed
+# when your host account is not 1000.
+[ "$(id -u)" = 1000 ] || sudo chown -R "$(id -u):$(id -g)" neko-home
 cp -a N.E.K.O/. neko-home/.local/share/N.E.K.O/ && rm -rf N.E.K.O
 cp -a ssl/.     neko-home/ssl/                 && rm -rf ssl
 
@@ -75,7 +75,7 @@ cp -a ssl/.     neko-home/ssl/                 && rm -rf ssl
 docker compose up -d
 ```
 
-`./logs` is unaffected. Ownership is corrected automatically on the next start.
+`./logs` is unaffected. The application user inside the container is pinned to uid/gid **1000** — the first regular user on most Linux distributions — so `neko-home/` is owned by you on the host and needs no `sudo` to back up or edit.
 :::
 
 ## Build locally

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -40,8 +40,15 @@ Order matters: `docker compose down` **removes** the container, and some state e
 #    actually write — the application data is in there too.
 #    The trailing /. copies directory *contents*, avoiding a nested N.E.K.O/N.E.K.O.
 mkdir -p neko-home/.local/share/N.E.K.O neko-home/ssl neko-home/.openfang
-docker cp neko:/home/neko/.openfang/. ./neko-home/.openfang/ 2>/dev/null || true
-docker cp neko:/home/neko/.local/share/N.E.K.O/. ./neko-home/.local/share/N.E.K.O/   # only if N.E.K.O/ is empty
+# "No such container:path" here just means OpenFang was never initialised — ignore it.
+# Everything else (daemon down, permissions, disk full) must NOT be ignored, so no `|| true`.
+docker cp neko:/home/neko/.openfang/. ./neko-home/.openfang/
+# Only when the host directory is empty is the data inside the container. Guard it:
+# on a deployment already restarted under the new layout the container mounts
+# neko-home itself, and this would copy the directory onto itself.
+if [ -z "$(ls -A N.E.K.O 2>/dev/null)" ]; then
+  docker cp neko:/home/neko/.local/share/N.E.K.O/. ./neko-home/.local/share/N.E.K.O/
+fi
 
 # 2. Stop the container, then merge the host-side directories by content. If the
 #    new layout has been started once, the destinations already exist (plus a

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -40,19 +40,27 @@ Order matters: `docker compose down` **removes** the container, and some state e
 #    actually write — the application data is in there too.
 #    The trailing /. copies directory *contents*, avoiding a nested N.E.K.O/N.E.K.O.
 mkdir -p neko-home/.local/share/N.E.K.O neko-home/ssl neko-home/.openfang
-# "No such container:path" here just means OpenFang was never initialised — ignore it.
-# Everything else (daemon down, permissions, disk full) must NOT be ignored, so no `|| true`.
-# Nothing to export once the container already mounts neko-home at /home/neko:
-# source and destination would be the same bind mount, and the old container that
-# held the only copy is long gone anyway.
-if docker inspect neko --format '{{range .Mounts}}{{println .Destination}}{{end}}' 2>/dev/null | grep -qx /home/neko; then
+# Decide from what the container actually mounts, not from what the host directory
+# contains: the old README mounted ./N.E.K.O at /root/Documents/N.E.K.O, a path the
+# services never write to, so that host directory can hold files you put there while
+# the real data still lives only in the container's writable layer.
+MOUNTS=$(docker inspect neko --format '{{range .Mounts}}{{println .Destination}}{{end}}' 2>/dev/null)
+
+if printf '%s
+' "$MOUNTS" | grep -qx /home/neko; then
   echo "Container already uses the new layout — nothing to export."
 else
-  docker cp neko:/home/neko/.openfang/. ./neko-home/.openfang/
-  # The application data is inside the container only when the host directory is empty.
-  if [ -z "$(ls -A N.E.K.O 2>/dev/null)" ]; then
+  # Application data first; this is the part that cannot be recovered later. If the
+  # container does not mount the data directory, that data exists nowhere else.
+  if ! printf '%s
+' "$MOUNTS" | grep -qx /home/neko/.local/share/N.E.K.O; then
     docker cp neko:/home/neko/.local/share/N.E.K.O/. ./neko-home/.local/share/N.E.K.O/
   fi
+  # OpenFang state second, and non-fatal: a container that never initialised it has
+  # no such directory, and `docker cp` fails on a missing SRC_PATH — that must not
+  # abort the run after the application data above already succeeded.
+  docker cp neko:/home/neko/.openfang/. ./neko-home/.openfang/ \
+    || echo "(no .openfang in the container, or its export failed — application data above is unaffected)"
 fi
 ```
 

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -22,10 +22,26 @@ The entrypoint generates `/app/config/core_config.json` only when absent or when
 
 | Host path | Container path | Purpose |
 | --- | --- | --- |
-| `./neko-home` | `/home/neko` | User configuration, characters, memories, feature data, TLS certificates |
+| `./neko-home` | `/home/neko` | User configuration, characters, memories, feature data, TLS certificate and private key, OpenFang runtime state |
 | `./logs` | `/app/logs` | Logs |
 
 Back up the first mount before upgrades. Never expose the data or private-key directories through a web server.
+
+::: danger Upgrading from the two-mount layout
+Earlier versions mounted `./N.E.K.O` and `./ssl` separately. Pulling a new image without migrating leaves the container with an **empty** data directory: it starts normally and API keys are regenerated from the environment, so nothing looks wrong, but characters, memories and plugins are all missing. The old data is not deleted — it is simply no longer mounted.
+
+```bash
+docker compose down
+mkdir -p neko-home/.local/share
+mv N.E.K.O neko-home/.local/share/N.E.K.O
+mv ssl     neko-home/ssl
+docker compose up -d
+```
+
+If the host `N.E.K.O/` directory is empty, you followed the old README quickstart, whose mount target (`/root/Documents/N.E.K.O`) never matched where the services actually write. That data only exists inside the container, so export it before removing the old container: `docker cp neko:/home/neko/.local/share/N.E.K.O ./neko-home/.local/share/N.E.K.O`.
+
+`./logs` is unaffected. Ownership is corrected automatically on the next start.
+:::
 
 ## Build locally
 

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -46,15 +46,19 @@ mkdir -p neko-home/.local/share/N.E.K.O neko-home/ssl neko-home/.openfang
 # the real data still lives only in the container's writable layer.
 MOUNTS=$(docker inspect neko --format '{{range .Mounts}}{{println .Destination}}{{end}}' 2>/dev/null)
 
-if printf '%s
-' "$MOUNTS" | grep -qx /home/neko; then
+# Needed in step 4: data recovered from the container must not be overwritten by the host copy.
+EXPORTED_APP_DATA=""
+
+if [ -z "$MOUNTS" ]; then
+  echo "Container neko is gone (already removed?) - skipping export."
+elif printf '%s\n' "$MOUNTS" | grep -qx /home/neko; then
   echo "Container already uses the new layout — nothing to export."
 else
   # Application data first; this is the part that cannot be recovered later. If the
   # container does not mount the data directory, that data exists nowhere else.
-  if ! printf '%s
-' "$MOUNTS" | grep -qx /home/neko/.local/share/N.E.K.O; then
+  if ! printf '%s\n' "$MOUNTS" | grep -qx /home/neko/.local/share/N.E.K.O; then
     docker cp neko:/home/neko/.local/share/N.E.K.O/. ./neko-home/.local/share/N.E.K.O/
+    EXPORTED_APP_DATA=1
   fi
   # OpenFang state second, and non-fatal: a container that never initialised it has
   # no such directory, and `docker cp` fails on a missing SRC_PATH — that must not
@@ -76,8 +80,15 @@ docker compose down
 # user on most distributions, so ownership usually already lines up. Only needed
 # when your host account is not 1000.
 [ "$(id -u)" = 1000 ] || sudo chown -R "$(id -u):$(id -g)" neko-home
-cp -a N.E.K.O/. neko-home/.local/share/N.E.K.O/ && rm -rf N.E.K.O
-cp -a ssl/.     neko-home/ssl/                 && rm -rf ssl
+# Only merge the host copy when step 1 did NOT recover the data from the container:
+# under the old README layout that directory was mounted at a path the services never
+# wrote to, so anything in it would overwrite the only correct copy.
+if [ -n "$EXPORTED_APP_DATA" ]; then
+  echo "Application data came from the container in step 1 - not merging the host N.E.K.O/"
+elif [ -d N.E.K.O ]; then
+  cp -a N.E.K.O/. neko-home/.local/share/N.E.K.O/ && rm -rf N.E.K.O
+fi
+[ -d ssl ] && cp -a ssl/. neko-home/ssl/ && rm -rf ssl
 
 # 3. Start again
 docker compose up -d

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -42,12 +42,17 @@ Order matters: `docker compose down` **removes** the container, and some state e
 mkdir -p neko-home/.local/share/N.E.K.O neko-home/ssl neko-home/.openfang
 # "No such container:path" here just means OpenFang was never initialised — ignore it.
 # Everything else (daemon down, permissions, disk full) must NOT be ignored, so no `|| true`.
-docker cp neko:/home/neko/.openfang/. ./neko-home/.openfang/
-# Only when the host directory is empty is the data inside the container. Guard it:
-# on a deployment already restarted under the new layout the container mounts
-# neko-home itself, and this would copy the directory onto itself.
-if [ -z "$(ls -A N.E.K.O 2>/dev/null)" ]; then
-  docker cp neko:/home/neko/.local/share/N.E.K.O/. ./neko-home/.local/share/N.E.K.O/
+# Nothing to export once the container already mounts neko-home at /home/neko:
+# source and destination would be the same bind mount, and the old container that
+# held the only copy is long gone anyway.
+if docker inspect neko --format '{{range .Mounts}}{{println .Destination}}{{end}}' 2>/dev/null | grep -qx /home/neko; then
+  echo "Container already uses the new layout — nothing to export."
+else
+  docker cp neko:/home/neko/.openfang/. ./neko-home/.openfang/
+  # The application data is inside the container only when the host directory is empty.
+  if [ -z "$(ls -A N.E.K.O 2>/dev/null)" ]; then
+    docker cp neko:/home/neko/.local/share/N.E.K.O/. ./neko-home/.local/share/N.E.K.O/
+  fi
 fi
 ```
 

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -22,9 +22,8 @@ The entrypoint generates `/app/config/core_config.json` only when absent or when
 
 | Host path | Container path | Purpose |
 | --- | --- | --- |
-| `./N.E.K.O` | `/home/neko/.local/share/N.E.K.O` | User configuration, characters, memories, feature data |
+| `./neko-home` | `/home/neko` | User configuration, characters, memories, feature data, TLS certificates |
 | `./logs` | `/app/logs` | Logs |
-| `./ssl` | `/home/neko/ssl` | TLS certificate/key |
 
 Back up the first mount before upgrades. Never expose the data or private-key directories through a web server.
 

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -59,6 +59,10 @@ fi
 #    freshly generated self-signed certificate) and `mv` would nest them one level
 #    deeper. Same-named files resolve in favour of the old data.
 docker compose down
+# The container has chowned neko-home to its internal neko user (a system uid),
+# so a normal host user cannot write there. Take it back; the container fixes it
+# again on the next start.
+sudo chown -R "$(id -u):$(id -g)" neko-home
 cp -a N.E.K.O/. neko-home/.local/share/N.E.K.O/ && rm -rf N.E.K.O
 cp -a ssl/.     neko-home/ssl/                 && rm -rf ssl
 

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -30,15 +30,30 @@ Back up the first mount before upgrades. Never expose the data or private-key di
 ::: danger Upgrading from the two-mount layout
 Earlier versions mounted `./N.E.K.O` and `./ssl` separately. Pulling a new image without migrating leaves the container with an **empty** data directory: it starts normally and API keys are regenerated from the environment, so nothing looks wrong, but characters, memories and plugins are all missing. The old data is not deleted — it is simply no longer mounted.
 
+Order matters: `docker compose down` **removes** the container, and some state exists nowhere else.
+
 ```bash
+# 1. Export what lives only inside the container — before it is removed.
+#    OpenFang's workspace was never mounted under the old layout. And if the host
+#    N.E.K.O/ directory is empty, you followed the old README quickstart, whose
+#    mount target (/root/Documents/N.E.K.O) never matched where the services
+#    actually write — the application data is in there too.
+#    The trailing /. copies directory *contents*, avoiding a nested N.E.K.O/N.E.K.O.
+mkdir -p neko-home/.local/share/N.E.K.O neko-home/ssl neko-home/.openfang
+docker cp neko:/home/neko/.openfang/. ./neko-home/.openfang/ 2>/dev/null || true
+docker cp neko:/home/neko/.local/share/N.E.K.O/. ./neko-home/.local/share/N.E.K.O/   # only if N.E.K.O/ is empty
+
+# 2. Stop the container, then merge the host-side directories by content. If the
+#    new layout has been started once, the destinations already exist (plus a
+#    freshly generated self-signed certificate) and `mv` would nest them one level
+#    deeper. Same-named files resolve in favour of the old data.
 docker compose down
-mkdir -p neko-home/.local/share
-mv N.E.K.O neko-home/.local/share/N.E.K.O
-mv ssl     neko-home/ssl
+cp -a N.E.K.O/. neko-home/.local/share/N.E.K.O/ && rm -rf N.E.K.O
+cp -a ssl/.     neko-home/ssl/                 && rm -rf ssl
+
+# 3. Start again
 docker compose up -d
 ```
-
-If the host `N.E.K.O/` directory is empty, you followed the old README quickstart, whose mount target (`/root/Documents/N.E.K.O`) never matched where the services actually write. That data only exists inside the container, so export it before removing the old container: `docker cp neko:/home/neko/.local/share/N.E.K.O ./neko-home/.local/share/N.E.K.O`.
 
 `./logs` is unaffected. Ownership is corrected automatically on the next start.
 :::

--- a/docs/ja/deployment/docker.md
+++ b/docs/ja/deployment/docker.md
@@ -38,7 +38,11 @@ docker cp neko:/home/neko/.openfang/. ./neko-home/.openfang/
 if [ -z "$(ls -A N.E.K.O 2>/dev/null)" ]; then
   docker cp neko:/home/neko/.local/share/N.E.K.O/. ./neko-home/.local/share/N.E.K.O/
 fi
+```
 
+**手順 1 が成功したことを確認してから次へ進んでください。** `docker compose down` は container を削除しますが、host 側 `N.E.K.O/` が空の場合その container が data の唯一の複製です。権限・disk full・daemon 停止などで export が失敗した場合は、ここで止めて先にそちらを解決してください。
+
+```bash
 # 2. container を停止し、host 側の旧 directory を内容単位で merge。新レイアウトで
 #    一度でも起動していると宛先 directory は既に存在し（新しい自己署名証明書付き）、
 #    mv では一階層深くネストされます。同名 file は旧 data を優先します。

--- a/docs/ja/deployment/docker.md
+++ b/docs/ja/deployment/docker.md
@@ -31,12 +31,17 @@ Persistent mounts は `./neko-home` → `/home/neko`（設定、データ、TLS 
 mkdir -p neko-home/.local/share/N.E.K.O neko-home/ssl neko-home/.openfang
 # ここで "No such container:path" が出るのは OpenFang を一度も初期化していないだけなので無視して構いません。
 # それ以外（daemon 停止・権限・disk full）は無視してはいけないため `|| true` は付けません
-docker cp neko:/home/neko/.openfang/. ./neko-home/.openfang/
-# data が container 内にあるのは host 側 directory が空の場合だけです。条件を command に落とします：
-# 新レイアウトで既に再起動済みの環境では container が neko-home 自体を mount しているため、
-# 無条件に実行すると directory を自分自身へコピーすることになります
-if [ -z "$(ls -A N.E.K.O 2>/dev/null)" ]; then
-  docker cp neko:/home/neko/.local/share/N.E.K.O/. ./neko-home/.local/share/N.E.K.O/
+# container が既に neko-home を /home/neko に mount している場合、source と destination が
+# 同一の bind mount になり、directory を自分自身へコピーすることになります。その状況では
+# 唯一の複製を保持していた旧 container は既に再作成されて存在しません。
+if docker inspect neko --format '{{range .Mounts}}{{println .Destination}}{{end}}' 2>/dev/null | grep -qx /home/neko; then
+  echo "container は既に新レイアウトです。export するものはありません。"
+else
+  docker cp neko:/home/neko/.openfang/. ./neko-home/.openfang/
+  # data が container 内にあるのは host 側 directory が空の場合だけです
+  if [ -z "$(ls -A N.E.K.O 2>/dev/null)" ]; then
+    docker cp neko:/home/neko/.local/share/N.E.K.O/. ./neko-home/.local/share/N.E.K.O/
+  fi
 fi
 ```
 

--- a/docs/ja/deployment/docker.md
+++ b/docs/ja/deployment/docker.md
@@ -29,8 +29,15 @@ Persistent mounts は `./neko-home` → `/home/neko`（設定、データ、TLS 
 #    アプリケーション data も container 内にあります。
 #    末尾の /. は directory の中身をコピーする指定で、N.E.K.O/N.E.K.O のようなネストを防ぎます。
 mkdir -p neko-home/.local/share/N.E.K.O neko-home/ssl neko-home/.openfang
-docker cp neko:/home/neko/.openfang/. ./neko-home/.openfang/ 2>/dev/null || true
-docker cp neko:/home/neko/.local/share/N.E.K.O/. ./neko-home/.local/share/N.E.K.O/   # N.E.K.O/ が空の場合のみ
+# ここで "No such container:path" が出るのは OpenFang を一度も初期化していないだけなので無視して構いません。
+# それ以外（daemon 停止・権限・disk full）は無視してはいけないため `|| true` は付けません
+docker cp neko:/home/neko/.openfang/. ./neko-home/.openfang/
+# data が container 内にあるのは host 側 directory が空の場合だけです。条件を command に落とします：
+# 新レイアウトで既に再起動済みの環境では container が neko-home 自体を mount しているため、
+# 無条件に実行すると directory を自分自身へコピーすることになります
+if [ -z "$(ls -A N.E.K.O 2>/dev/null)" ]; then
+  docker cp neko:/home/neko/.local/share/N.E.K.O/. ./neko-home/.local/share/N.E.K.O/
+fi
 
 # 2. container を停止し、host 側の旧 directory を内容単位で merge。新レイアウトで
 #    一度でも起動していると宛先 directory は既に存在し（新しい自己署名証明書付き）、

--- a/docs/ja/deployment/docker.md
+++ b/docs/ja/deployment/docker.md
@@ -29,19 +29,27 @@ Persistent mounts は `./neko-home` → `/home/neko`（設定、データ、TLS 
 #    アプリケーション data も container 内にあります。
 #    末尾の /. は directory の中身をコピーする指定で、N.E.K.O/N.E.K.O のようなネストを防ぎます。
 mkdir -p neko-home/.local/share/N.E.K.O neko-home/ssl neko-home/.openfang
-# ここで "No such container:path" が出るのは OpenFang を一度も初期化していないだけなので無視して構いません。
-# それ以外（daemon 停止・権限・disk full）は無視してはいけないため `|| true` は付けません
-# container が既に neko-home を /home/neko に mount している場合、source と destination が
-# 同一の bind mount になり、directory を自分自身へコピーすることになります。その状況では
-# 唯一の複製を保持していた旧 container は既に再作成されて存在しません。
-if docker inspect neko --format '{{range .Mounts}}{{println .Destination}}{{end}}' 2>/dev/null | grep -qx /home/neko; then
+# 判断は「host 側 directory の中身」ではなく「container が実際に何を mount しているか」で
+# 行います：旧 README は ./N.E.K.O を /root/Documents/N.E.K.O に mount しており、そこは
+# サービスが書き込まない path なので、その host directory に自分で置いた file があっても
+# 実データは container の writable layer にしか存在しません。
+MOUNTS=$(docker inspect neko --format '{{range .Mounts}}{{println .Destination}}{{end}}' 2>/dev/null)
+
+if printf '%s
+' "$MOUNTS" | grep -qx /home/neko; then
   echo "container は既に新レイアウトです。export するものはありません。"
 else
-  docker cp neko:/home/neko/.openfang/. ./neko-home/.openfang/
-  # data が container 内にあるのは host 側 directory が空の場合だけです
-  if [ -z "$(ls -A N.E.K.O 2>/dev/null)" ]; then
+  # application data を先に。失われると復旧できないのはこちらです。container が data
+  # directory を mount していない場合、その data は他のどこにも存在しません。
+  if ! printf '%s
+' "$MOUNTS" | grep -qx /home/neko/.local/share/N.E.K.O; then
     docker cp neko:/home/neko/.local/share/N.E.K.O/. ./neko-home/.local/share/N.E.K.O/
   fi
+  # OpenFang state はその次で、致命的ではありません：一度も初期化していない container
+  # には該当 directory がなく、docker cp は存在しない SRC_PATH で失敗します。上の
+  # 重要な export が済んだ後にそれで中断させてはいけません。
+  docker cp neko:/home/neko/.openfang/. ./neko-home/.openfang/ \
+    || echo "（container に .openfang がないか export に失敗しました。上の application data には影響しません）"
 fi
 ```
 

--- a/docs/ja/deployment/docker.md
+++ b/docs/ja/deployment/docker.md
@@ -19,15 +19,29 @@ Persistent mounts は `./neko-home` → `/home/neko`（設定、データ、TLS 
 ::: danger 旧 2 マウント構成からの移行
 旧版は `./N.E.K.O` と `./ssl` を別々に mount していました。移行せずに新しい image を pull すると、container は**空の** data directory で起動します。サービスは正常に立ち上がり API key も環境変数から再生成されるため一見問題なく見えますが、キャラクター・記憶・plugin が全て存在しない状態です。旧 data は削除されておらず、mount されなくなっただけです。
 
+順序が重要です：`docker compose down` は container を**削除**しますが、container 内にしか存在しない state があります。
+
 ```bash
+# 1. container 内にしかないものを先に export（削除前に必ず実行）。
+#    旧レイアウトでは OpenFang の workspace を mount していませんでした。また host 側の
+#    N.E.K.O/ が空の場合は旧 README の quickstart のケースで、その mount 先
+#    （/root/Documents/N.E.K.O）はサービスの実際の書き込み先と一致していなかったため、
+#    アプリケーション data も container 内にあります。
+#    末尾の /. は directory の中身をコピーする指定で、N.E.K.O/N.E.K.O のようなネストを防ぎます。
+mkdir -p neko-home/.local/share/N.E.K.O neko-home/ssl neko-home/.openfang
+docker cp neko:/home/neko/.openfang/. ./neko-home/.openfang/ 2>/dev/null || true
+docker cp neko:/home/neko/.local/share/N.E.K.O/. ./neko-home/.local/share/N.E.K.O/   # N.E.K.O/ が空の場合のみ
+
+# 2. container を停止し、host 側の旧 directory を内容単位で merge。新レイアウトで
+#    一度でも起動していると宛先 directory は既に存在し（新しい自己署名証明書付き）、
+#    mv では一階層深くネストされます。同名 file は旧 data を優先します。
 docker compose down
-mkdir -p neko-home/.local/share
-mv N.E.K.O neko-home/.local/share/N.E.K.O
-mv ssl     neko-home/ssl
+cp -a N.E.K.O/. neko-home/.local/share/N.E.K.O/ && rm -rf N.E.K.O
+cp -a ssl/.     neko-home/ssl/                 && rm -rf ssl
+
+# 3. 再起動
 docker compose up -d
 ```
-
-host 側の `N.E.K.O/` が空の場合は旧 README の quickstart に従っていたケースです。その mount 先（`/root/Documents/N.E.K.O`）はサービスの実際の書き込み先と一致していなかったため、data は container 内部にしか存在しません。旧 container を削除する前に export してください：`docker cp neko:/home/neko/.local/share/N.E.K.O ./neko-home/.local/share/N.E.K.O`。
 
 `./logs` は影響を受けません。所有者は次回起動時に自動修正されます。
 :::

--- a/docs/ja/deployment/docker.md
+++ b/docs/ja/deployment/docker.md
@@ -14,7 +14,7 @@ docker compose up -d
 
 Entrypoint は `/app/config/core_config.json` がない時、または `NEKO_FORCE_ENV_UPDATE` 指定時だけ初期 config を生成します。API env は live universal override ではありません。
 
-Persistent mounts は `./N.E.K.O` → `/home/neko/.local/share/N.E.K.O`、`./logs` → `/app/logs`、`./ssl` → `/home/neko/ssl`。更新前に backup し、data/private key を公開しません。
+Persistent mounts は `./neko-home` → `/home/neko`（設定、データ、SSL、OpenFang agent）、`./logs` → `/app/logs`。更新前に backup し、data/private key を公開しません。
 
 Compose には `build:` がありません。Repository root で明示します。
 

--- a/docs/ja/deployment/docker.md
+++ b/docs/ja/deployment/docker.md
@@ -52,9 +52,10 @@ fi
 #    一度でも起動していると宛先 directory は既に存在し（新しい自己署名証明書付き）、
 #    mv では一階層深くネストされます。同名 file は旧 data を優先します。
 docker compose down
-# container が neko-home の所有者を内部の neko（system uid）に変更済みのため、host 側の
-# 一般ユーザーでは書き込めません。一度取り戻します（次回起動時に container が戻します）。
-sudo chown -R "$(id -u):$(id -g)" neko-home
+# container の neko は uid/gid 1000 に固定されており、多くの distribution の最初の
+# 一般ユーザーと一致するため通常は所有者が既に揃っています。host 側の account が
+# 1000 でない場合だけ必要です。
+[ "$(id -u)" = 1000 ] || sudo chown -R "$(id -u):$(id -g)" neko-home
 cp -a N.E.K.O/. neko-home/.local/share/N.E.K.O/ && rm -rf N.E.K.O
 cp -a ssl/.     neko-home/ssl/                 && rm -rf ssl
 
@@ -62,7 +63,7 @@ cp -a ssl/.     neko-home/ssl/                 && rm -rf ssl
 docker compose up -d
 ```
 
-`./logs` は影響を受けません。所有者は次回起動時に自動修正されます。
+`./logs` は影響を受けません。container 内の application user は uid/gid **1000**（多くの Linux distribution で最初の一般ユーザーの番号）に固定されているため、host 側で `neko-home/` の所有者は自分自身になり、backup や編集に `sudo` は不要です。
 :::
 
 Compose には `build:` がありません。Repository root で明示します。

--- a/docs/ja/deployment/docker.md
+++ b/docs/ja/deployment/docker.md
@@ -47,6 +47,9 @@ fi
 #    一度でも起動していると宛先 directory は既に存在し（新しい自己署名証明書付き）、
 #    mv では一階層深くネストされます。同名 file は旧 data を優先します。
 docker compose down
+# container が neko-home の所有者を内部の neko（system uid）に変更済みのため、host 側の
+# 一般ユーザーでは書き込めません。一度取り戻します（次回起動時に container が戻します）。
+sudo chown -R "$(id -u):$(id -g)" neko-home
 cp -a N.E.K.O/. neko-home/.local/share/N.E.K.O/ && rm -rf N.E.K.O
 cp -a ssl/.     neko-home/ssl/                 && rm -rf ssl
 

--- a/docs/ja/deployment/docker.md
+++ b/docs/ja/deployment/docker.md
@@ -14,7 +14,23 @@ docker compose up -d
 
 Entrypoint は `/app/config/core_config.json` がない時、または `NEKO_FORCE_ENV_UPDATE` 指定時だけ初期 config を生成します。API env は live universal override ではありません。
 
-Persistent mounts は `./neko-home` → `/home/neko`（設定、データ、SSL、OpenFang agent）、`./logs` → `/app/logs`。更新前に backup し、data/private key を公開しません。
+Persistent mounts は `./neko-home` → `/home/neko`（設定、データ、TLS 証明書と秘密鍵、OpenFang runtime state）、`./logs` → `/app/logs`。更新前に backup し、data/private key を公開しません。
+
+::: danger 旧 2 マウント構成からの移行
+旧版は `./N.E.K.O` と `./ssl` を別々に mount していました。移行せずに新しい image を pull すると、container は**空の** data directory で起動します。サービスは正常に立ち上がり API key も環境変数から再生成されるため一見問題なく見えますが、キャラクター・記憶・plugin が全て存在しない状態です。旧 data は削除されておらず、mount されなくなっただけです。
+
+```bash
+docker compose down
+mkdir -p neko-home/.local/share
+mv N.E.K.O neko-home/.local/share/N.E.K.O
+mv ssl     neko-home/ssl
+docker compose up -d
+```
+
+host 側の `N.E.K.O/` が空の場合は旧 README の quickstart に従っていたケースです。その mount 先（`/root/Documents/N.E.K.O`）はサービスの実際の書き込み先と一致していなかったため、data は container 内部にしか存在しません。旧 container を削除する前に export してください：`docker cp neko:/home/neko/.local/share/N.E.K.O ./neko-home/.local/share/N.E.K.O`。
+
+`./logs` は影響を受けません。所有者は次回起動時に自動修正されます。
+:::
 
 Compose には `build:` がありません。Repository root で明示します。
 

--- a/docs/ja/deployment/docker.md
+++ b/docs/ja/deployment/docker.md
@@ -35,15 +35,19 @@ mkdir -p neko-home/.local/share/N.E.K.O neko-home/ssl neko-home/.openfang
 # 実データは container の writable layer にしか存在しません。
 MOUNTS=$(docker inspect neko --format '{{range .Mounts}}{{println .Destination}}{{end}}' 2>/dev/null)
 
-if printf '%s
-' "$MOUNTS" | grep -qx /home/neko; then
+# 手順 4 で使用：container から救出した実データを host 側の旧 directory で上書きさせないため
+EXPORTED_APP_DATA=""
+
+if [ -z "$MOUNTS" ]; then
+  echo "container neko が存在しません（削除済み？）。export を skip します。"
+elif printf '%s\n' "$MOUNTS" | grep -qx /home/neko; then
   echo "container は既に新レイアウトです。export するものはありません。"
 else
   # application data を先に。失われると復旧できないのはこちらです。container が data
   # directory を mount していない場合、その data は他のどこにも存在しません。
-  if ! printf '%s
-' "$MOUNTS" | grep -qx /home/neko/.local/share/N.E.K.O; then
+  if ! printf '%s\n' "$MOUNTS" | grep -qx /home/neko/.local/share/N.E.K.O; then
     docker cp neko:/home/neko/.local/share/N.E.K.O/. ./neko-home/.local/share/N.E.K.O/
+    EXPORTED_APP_DATA=1
   fi
   # OpenFang state はその次で、致命的ではありません：一度も初期化していない container
   # には該当 directory がなく、docker cp は存在しない SRC_PATH で失敗します。上の
@@ -64,8 +68,15 @@ docker compose down
 # 一般ユーザーと一致するため通常は所有者が既に揃っています。host 側の account が
 # 1000 でない場合だけ必要です。
 [ "$(id -u)" = 1000 ] || sudo chown -R "$(id -u):$(id -g)" neko-home
-cp -a N.E.K.O/. neko-home/.local/share/N.E.K.O/ && rm -rf N.E.K.O
-cp -a ssl/.     neko-home/ssl/                 && rm -rf ssl
+# host 側の copy が権威なのは「手順 1 で container から救出しなかった」場合だけです：
+# 旧 README はその directory をサービスが書き込まない path に mount していたため、
+# 中身をそのまま被せると唯一正しい copy を上書きしてしまいます。
+if [ -n "$EXPORTED_APP_DATA" ]; then
+  echo "application data は手順 1 で container から export 済み。host 側の N.E.K.O/ は merge しません"
+elif [ -d N.E.K.O ]; then
+  cp -a N.E.K.O/. neko-home/.local/share/N.E.K.O/ && rm -rf N.E.K.O
+fi
+[ -d ssl ] && cp -a ssl/. neko-home/ssl/ && rm -rf ssl
 
 # 3. 再起動
 docker compose up -d

--- a/docs/zh-CN/deployment/docker.md
+++ b/docs/zh-CN/deployment/docker.md
@@ -24,15 +24,28 @@ docker compose up -d
 ::: danger 从旧版双挂载升级
 旧版本分别挂载 `./N.E.K.O` 与 `./ssl`。不迁移就直接拉新镜像，容器会对着一个**空的**数据目录启动：服务照常运行、API Key 也会从环境变量重新生成，看上去没有异常，但人格、记忆、插件都不在。旧数据没有被删除，只是不再挂进容器。
 
+顺序不能颠倒：`docker compose down` 会**删除**容器，而有些状态只存在于容器里。
+
 ```bash
+# 1. 先导出只存在于容器内的东西，必须赶在删容器之前。
+#    旧布局从没挂载 OpenFang 的工作目录；另外，若宿主机的 N.E.K.O/ 是空的，说明
+#    此前跟的是旧版 README 的快速开始，其挂载目标（/root/Documents/N.E.K.O）与服务
+#    实际写入的位置从来对不上，应用数据也在容器里。
+#    末尾的 /. 表示复制目录内容，避免出现 N.E.K.O/N.E.K.O 这样多套一层。
+mkdir -p neko-home/.local/share/N.E.K.O neko-home/ssl neko-home/.openfang
+docker cp neko:/home/neko/.openfang/. ./neko-home/.openfang/ 2>/dev/null || true
+docker cp neko:/home/neko/.local/share/N.E.K.O/. ./neko-home/.local/share/N.E.K.O/   # 仅当 N.E.K.O/ 为空
+
+# 2. 停容器，再把宿主机上的旧目录按内容合并。若已经用新布局启动过一次，目标目录
+#    已经存在（还带一张新生成的自签证书），直接 mv 会把旧目录套进去多一层。
+#    同名文件以旧数据为准。
 docker compose down
-mkdir -p neko-home/.local/share
-mv N.E.K.O neko-home/.local/share/N.E.K.O
-mv ssl     neko-home/ssl
+cp -a N.E.K.O/. neko-home/.local/share/N.E.K.O/ && rm -rf N.E.K.O
+cp -a ssl/.     neko-home/ssl/                 && rm -rf ssl
+
+# 3. 重新启动
 docker compose up -d
 ```
-
-若宿主机的 `N.E.K.O/` 是空的，说明此前跟的是旧版 README 的快速开始，其挂载目标（`/root/Documents/N.E.K.O`）与服务实际写入的位置从来对不上，数据只存在于容器内部。删除旧容器前先导出：`docker cp neko:/home/neko/.local/share/N.E.K.O ./neko-home/.local/share/N.E.K.O`。
 
 `./logs` 不受影响；目录属主在下次启动时自动修正。
 :::

--- a/docs/zh-CN/deployment/docker.md
+++ b/docs/zh-CN/deployment/docker.md
@@ -33,18 +33,25 @@ docker compose up -d
 #    实际写入的位置从来对不上，应用数据也在容器里。
 #    末尾的 /. 表示复制目录内容，避免出现 N.E.K.O/N.E.K.O 这样多套一层。
 mkdir -p neko-home/.local/share/N.E.K.O neko-home/ssl neko-home/.openfang
-# 这里报 "No such container:path" 只说明从没初始化过 OpenFang，可以忽略；
-# 其他错误（daemon 没起、权限、磁盘满）不能忽略，所以不加 `|| true` 吞掉
-# 容器若已经把 neko-home 挂在 /home/neko 上，源和目标就是同一个 bind mount，
-# 导出等于把目录复制到它自己；而那种情况下持有唯一副本的旧容器早已被重建掉了
-if docker inspect neko --format '{{range .Mounts}}{{println .Destination}}{{end}}' 2>/dev/null | grep -qx /home/neko; then
+# 判据用「容器实际挂了什么」，而不是「宿主目录里有没有东西」：旧版 README 把
+# ./N.E.K.O 挂到了 /root/Documents/N.E.K.O，那是服务从不写入的路径，所以那个宿主
+# 目录里可能有你自己放的文件，而真数据仍然只在容器可写层里。
+MOUNTS=$(docker inspect neko --format '{{range .Mounts}}{{println .Destination}}{{end}}' 2>/dev/null)
+
+if printf '%s
+' "$MOUNTS" | grep -qx /home/neko; then
   echo "容器已按新布局挂载，没有待导出的内容"
 else
-  docker cp neko:/home/neko/.openfang/. ./neko-home/.openfang/
-  # 只有宿主目录为空时，应用数据才在容器里
-  if [ -z "$(ls -A N.E.K.O 2>/dev/null)" ]; then
+  # 应用数据先导，这部分丢了找不回来。容器没把数据目录挂出去，就说明它只存在于
+  # 容器可写层。
+  if ! printf '%s
+' "$MOUNTS" | grep -qx /home/neko/.local/share/N.E.K.O; then
     docker cp neko:/home/neko/.local/share/N.E.K.O/. ./neko-home/.local/share/N.E.K.O/
   fi
+  # OpenFang 状态其次，且不致命：从没初始化过的话容器里就没这个目录，而 docker cp
+  # 对不存在的 SRC_PATH 是报错退出的 —— 不能让它挡住上面已经完成的关键导出。
+  docker cp neko:/home/neko/.openfang/. ./neko-home/.openfang/ \
+    || echo "（容器里没有 .openfang，或导出失败；不影响上面的应用数据）"
 fi
 ```
 

--- a/docs/zh-CN/deployment/docker.md
+++ b/docs/zh-CN/deployment/docker.md
@@ -16,9 +16,8 @@ docker compose up -d
 
 | 宿主 | 容器 | 用途 |
 | --- | --- | --- |
-| `./N.E.K.O` | `/home/neko/.local/share/N.E.K.O` | 配置、角色、记忆、功能数据 |
+| `./neko-home` | `/home/neko` | 配置、角色、记忆、功能数据、TLS 证书 |
 | `./logs` | `/app/logs` | 日志 |
-| `./ssl` | `/home/neko/ssl` | TLS 证书/私钥 |
 
 升级前备份数据，严禁公开数据或私钥目录。
 

--- a/docs/zh-CN/deployment/docker.md
+++ b/docs/zh-CN/deployment/docker.md
@@ -35,11 +35,16 @@ docker compose up -d
 mkdir -p neko-home/.local/share/N.E.K.O neko-home/ssl neko-home/.openfang
 # 这里报 "No such container:path" 只说明从没初始化过 OpenFang，可以忽略；
 # 其他错误（daemon 没起、权限、磁盘满）不能忽略，所以不加 `|| true` 吞掉
-docker cp neko:/home/neko/.openfang/. ./neko-home/.openfang/
-# 只有宿主目录为空时数据才在容器里，这个条件要落到命令上：已经用新布局重启过的
-# 部署，容器挂的就是 neko-home 本身，无条件执行等于把目录复制到它自己
-if [ -z "$(ls -A N.E.K.O 2>/dev/null)" ]; then
-  docker cp neko:/home/neko/.local/share/N.E.K.O/. ./neko-home/.local/share/N.E.K.O/
+# 容器若已经把 neko-home 挂在 /home/neko 上，源和目标就是同一个 bind mount，
+# 导出等于把目录复制到它自己；而那种情况下持有唯一副本的旧容器早已被重建掉了
+if docker inspect neko --format '{{range .Mounts}}{{println .Destination}}{{end}}' 2>/dev/null | grep -qx /home/neko; then
+  echo "容器已按新布局挂载，没有待导出的内容"
+else
+  docker cp neko:/home/neko/.openfang/. ./neko-home/.openfang/
+  # 只有宿主目录为空时，应用数据才在容器里
+  if [ -z "$(ls -A N.E.K.O 2>/dev/null)" ]; then
+    docker cp neko:/home/neko/.local/share/N.E.K.O/. ./neko-home/.local/share/N.E.K.O/
+  fi
 fi
 ```
 

--- a/docs/zh-CN/deployment/docker.md
+++ b/docs/zh-CN/deployment/docker.md
@@ -41,7 +41,11 @@ docker cp neko:/home/neko/.openfang/. ./neko-home/.openfang/
 if [ -z "$(ls -A N.E.K.O 2>/dev/null)" ]; then
   docker cp neko:/home/neko/.local/share/N.E.K.O/. ./neko-home/.local/share/N.E.K.O/
 fi
+```
 
+**确认第 1 步成功后再往下。** `docker compose down` 会删除容器，而在宿主 `N.E.K.O/` 为空的情况下，容器是那部分数据唯一的副本——导出若因权限、磁盘满或 daemon 没起而失败，请先解决再继续。
+
+```bash
 # 2. 停容器，再把宿主机上的旧目录按内容合并。若已经用新布局启动过一次，目标目录
 #    已经存在（还带一张新生成的自签证书），直接 mv 会把旧目录套进去多一层。
 #    同名文件以旧数据为准。

--- a/docs/zh-CN/deployment/docker.md
+++ b/docs/zh-CN/deployment/docker.md
@@ -16,10 +16,26 @@ docker compose up -d
 
 | 宿主 | 容器 | 用途 |
 | --- | --- | --- |
-| `./neko-home` | `/home/neko` | 配置、角色、记忆、功能数据、TLS 证书 |
+| `./neko-home` | `/home/neko` | 配置、角色、记忆、功能数据、TLS 证书与私钥、OpenFang 运行状态 |
 | `./logs` | `/app/logs` | 日志 |
 
 升级前备份数据，严禁公开数据或私钥目录。
+
+::: danger 从旧版双挂载升级
+旧版本分别挂载 `./N.E.K.O` 与 `./ssl`。不迁移就直接拉新镜像，容器会对着一个**空的**数据目录启动：服务照常运行、API Key 也会从环境变量重新生成，看上去没有异常，但人格、记忆、插件都不在。旧数据没有被删除，只是不再挂进容器。
+
+```bash
+docker compose down
+mkdir -p neko-home/.local/share
+mv N.E.K.O neko-home/.local/share/N.E.K.O
+mv ssl     neko-home/ssl
+docker compose up -d
+```
+
+若宿主机的 `N.E.K.O/` 是空的，说明此前跟的是旧版 README 的快速开始，其挂载目标（`/root/Documents/N.E.K.O`）与服务实际写入的位置从来对不上，数据只存在于容器内部。删除旧容器前先导出：`docker cp neko:/home/neko/.local/share/N.E.K.O ./neko-home/.local/share/N.E.K.O`。
+
+`./logs` 不受影响；目录属主在下次启动时自动修正。
+:::
 
 当前 Compose 没有 `build:`，旧的 `docker compose build` 说法无效。本地构建应在仓库根目录执行：
 

--- a/docs/zh-CN/deployment/docker.md
+++ b/docs/zh-CN/deployment/docker.md
@@ -50,6 +50,9 @@ fi
 #    已经存在（还带一张新生成的自签证书），直接 mv 会把旧目录套进去多一层。
 #    同名文件以旧数据为准。
 docker compose down
+# 容器已经把 neko-home 的属主改成了内部的 neko（一个系统 uid），宿主机上的普通
+# 用户写不进去。先要回来，容器下次启动会自行改回去。
+sudo chown -R "$(id -u):$(id -g)" neko-home
 cp -a N.E.K.O/. neko-home/.local/share/N.E.K.O/ && rm -rf N.E.K.O
 cp -a ssl/.     neko-home/ssl/                 && rm -rf ssl
 

--- a/docs/zh-CN/deployment/docker.md
+++ b/docs/zh-CN/deployment/docker.md
@@ -33,8 +33,14 @@ docker compose up -d
 #    实际写入的位置从来对不上，应用数据也在容器里。
 #    末尾的 /. 表示复制目录内容，避免出现 N.E.K.O/N.E.K.O 这样多套一层。
 mkdir -p neko-home/.local/share/N.E.K.O neko-home/ssl neko-home/.openfang
-docker cp neko:/home/neko/.openfang/. ./neko-home/.openfang/ 2>/dev/null || true
-docker cp neko:/home/neko/.local/share/N.E.K.O/. ./neko-home/.local/share/N.E.K.O/   # 仅当 N.E.K.O/ 为空
+# 这里报 "No such container:path" 只说明从没初始化过 OpenFang，可以忽略；
+# 其他错误（daemon 没起、权限、磁盘满）不能忽略，所以不加 `|| true` 吞掉
+docker cp neko:/home/neko/.openfang/. ./neko-home/.openfang/
+# 只有宿主目录为空时数据才在容器里，这个条件要落到命令上：已经用新布局重启过的
+# 部署，容器挂的就是 neko-home 本身，无条件执行等于把目录复制到它自己
+if [ -z "$(ls -A N.E.K.O 2>/dev/null)" ]; then
+  docker cp neko:/home/neko/.local/share/N.E.K.O/. ./neko-home/.local/share/N.E.K.O/
+fi
 
 # 2. 停容器，再把宿主机上的旧目录按内容合并。若已经用新布局启动过一次，目标目录
 #    已经存在（还带一张新生成的自签证书），直接 mv 会把旧目录套进去多一层。

--- a/docs/zh-CN/deployment/docker.md
+++ b/docs/zh-CN/deployment/docker.md
@@ -38,15 +38,19 @@ mkdir -p neko-home/.local/share/N.E.K.O neko-home/ssl neko-home/.openfang
 # 目录里可能有你自己放的文件，而真数据仍然只在容器可写层里。
 MOUNTS=$(docker inspect neko --format '{{range .Mounts}}{{println .Destination}}{{end}}' 2>/dev/null)
 
-if printf '%s
-' "$MOUNTS" | grep -qx /home/neko; then
+# 第 4 步要用：真数据是从容器里捞出来的，就不能再被宿主机上那个旧目录覆盖
+EXPORTED_APP_DATA=""
+
+if [ -z "$MOUNTS" ]; then
+  echo "容器 neko 不在（可能已经删过），跳过导出"
+elif printf '%s\n' "$MOUNTS" | grep -qx /home/neko; then
   echo "容器已按新布局挂载，没有待导出的内容"
 else
   # 应用数据先导，这部分丢了找不回来。容器没把数据目录挂出去，就说明它只存在于
   # 容器可写层。
-  if ! printf '%s
-' "$MOUNTS" | grep -qx /home/neko/.local/share/N.E.K.O; then
+  if ! printf '%s\n' "$MOUNTS" | grep -qx /home/neko/.local/share/N.E.K.O; then
     docker cp neko:/home/neko/.local/share/N.E.K.O/. ./neko-home/.local/share/N.E.K.O/
+    EXPORTED_APP_DATA=1
   fi
   # OpenFang 状态其次，且不致命：从没初始化过的话容器里就没这个目录，而 docker cp
   # 对不存在的 SRC_PATH 是报错退出的 —— 不能让它挡住上面已经完成的关键导出。
@@ -65,8 +69,14 @@ docker compose down
 # 容器内的 neko 固定为 uid/gid 1000，和绝大多数发行版第一个普通用户一致，属主
 # 通常已经对上。只有宿主账号不是 1000 时才需要这一步。
 [ "$(id -u)" = 1000 ] || sudo chown -R "$(id -u):$(id -g)" neko-home
-cp -a N.E.K.O/. neko-home/.local/share/N.E.K.O/ && rm -rf N.E.K.O
-cp -a ssl/.     neko-home/ssl/                 && rm -rf ssl
+# 宿主机上那份只有在「第 1 步没从容器里救数据」时才是权威：旧版 README 把该目录
+# 挂到了服务从不写入的路径，里面的东西会覆盖掉唯一正确的那份。
+if [ -n "$EXPORTED_APP_DATA" ]; then
+  echo "应用数据已在第 1 步从容器导出，不合并宿主机上的 N.E.K.O/"
+elif [ -d N.E.K.O ]; then
+  cp -a N.E.K.O/. neko-home/.local/share/N.E.K.O/ && rm -rf N.E.K.O
+fi
+[ -d ssl ] && cp -a ssl/. neko-home/ssl/ && rm -rf ssl
 
 # 3. 重新启动
 docker compose up -d

--- a/docs/zh-CN/deployment/docker.md
+++ b/docs/zh-CN/deployment/docker.md
@@ -55,9 +55,9 @@ fi
 #    已经存在（还带一张新生成的自签证书），直接 mv 会把旧目录套进去多一层。
 #    同名文件以旧数据为准。
 docker compose down
-# 容器已经把 neko-home 的属主改成了内部的 neko（一个系统 uid），宿主机上的普通
-# 用户写不进去。先要回来，容器下次启动会自行改回去。
-sudo chown -R "$(id -u):$(id -g)" neko-home
+# 容器内的 neko 固定为 uid/gid 1000，和绝大多数发行版第一个普通用户一致，属主
+# 通常已经对上。只有宿主账号不是 1000 时才需要这一步。
+[ "$(id -u)" = 1000 ] || sudo chown -R "$(id -u):$(id -g)" neko-home
 cp -a N.E.K.O/. neko-home/.local/share/N.E.K.O/ && rm -rf N.E.K.O
 cp -a ssl/.     neko-home/ssl/                 && rm -rf ssl
 
@@ -65,7 +65,7 @@ cp -a ssl/.     neko-home/ssl/                 && rm -rf ssl
 docker compose up -d
 ```
 
-`./logs` 不受影响；目录属主在下次启动时自动修正。
+`./logs` 不受影响。容器内的应用用户固定为 uid/gid **1000**（绝大多数 Linux 发行版第一个普通用户的号），因此 `neko-home/` 在宿主机上的属主就是你自己，备份和编辑都不需要 `sudo`。
 :::
 
 当前 Compose 没有 `build:`，旧的 `docker compose build` 说法无效。本地构建应在仓库根目录执行：


### PR DESCRIPTION
## 改动概述 / Summary

合并 Docker volume mount，将分散的 `./N.E.K.O`（→ `/home/neko/.local/share/N.E.K.O`）和 `./ssl`（→ `/home/neko/ssl`）替换为统一的 `./neko-home:/home/neko`，同时移除 entrypoint.sh 中多余的 `mkdir -p /home/neko/.local/share/N.E.K.O`。

## 回归报告 / Regression Report

不适用 — 未触碰 `app/`、`main_logic/`、`memory/`。

## 不拆分理由 / Why Not Split

不适用 — 改动计入上限的文件数 = 6（≤ 20）。

## 测试 / Testing

- 本地 diff 验证：6 个文件合计 +10/-19 行，语义正确
- CI 将验证 Docker build 是否通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **文档**
  * 更新 Docker 部署说明，统一使用 `neko-home` 保存配置、数据、TLS 证书及运行状态。
  * 补充旧版挂载布局的备份、数据与证书迁移、权限处理及升级检查流程，并同步更新中、日文档。

* **改进**
  * 启动时检测旧版目录布局并提供迁移提示，避免数据未迁移导致内容不可见。
  * 优化持久化目录权限处理，并统一容器运行账户权限。
  * 增加敏感数据、证书和日志目录的忽略规则，降低误提交或打包风险。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->