### PR TITLE
修复配置接口密钥明文泄露与 DNS rebinding 风险，完善 Host/Origin 校验、前端密钥遮罩及安全回传逻辑

### DIFF
--- a/app/agent_server/api_shared.py
+++ b/app/agent_server/api_shared.py
@@ -104,6 +104,7 @@ from config import (  # noqa: F401  (tail entries keep facade parity with the ol
     AGENT_PROACTIVE_ANALYZE_MAX_PER_SESSION,
 )
 from utils.config_manager import get_config_manager
+from utils.host_origin_guard import HostOriginGuardMiddleware
 from utils.tokenize import truncate_to_tokens as _tt
 
 from .tracker import (  # noqa: F401
@@ -197,3 +198,4 @@ from .channels.user_plugin import (  # noqa: F401
 
 
 app = FastAPI(title="N.E.K.O Tool Server")
+app.add_middleware(HostOriginGuardMiddleware)

--- a/app/main_server/__init__.py
+++ b/app/main_server/__init__.py
@@ -125,6 +125,7 @@ from utils.logger_config import setup_logging  # noqa: E402
 from utils.ssl_env_diagnostics import probe_ssl_environment, write_ssl_diagnostic  # noqa: E402
 from utils.asyncio_executor import configure_default_executor  # noqa: E402
 from utils.asgi_body_limit import InboundBodySizeLimitMiddleware  # noqa: E402
+from utils.host_origin_guard import HostOriginGuardMiddleware  # noqa: E402
 
 _main_log_level = getattr(
     logging, (os.environ.get("NEKO_LOG_LEVEL") or "INFO").upper(), logging.INFO
@@ -607,6 +608,9 @@ async def main_storage_limited_mode_guard(request: Request, call_next):
 # 文件上传（模型/音乐/角色卡等）一律放行，交给各上传 router 自带的流式分块守门。
 # add_middleware 后注册即处于最外层，最先执行——解析前拒收，不浪费后续处理。
 app.add_middleware(InboundBodySizeLimitMiddleware)
+# Registered after the body guard so it is the outermost ASGI middleware and
+# rejects DNS-rebinding Host values before any HTTP or WebSocket route runs.
+app.add_middleware(HostOriginGuardMiddleware)
 
 
 @app.exception_handler(MaintenanceModeError)

--- a/app/memory_server/runtime.py
+++ b/app/memory_server/runtime.py
@@ -62,6 +62,7 @@ from utils.cloudsave_runtime import (
 from utils.config_manager import get_config_manager
 from utils.storage_location_bootstrap import get_storage_startup_blocking_reason
 from utils.asgi_body_limit import InboundBodySizeLimitMiddleware
+from utils.host_origin_guard import HostOriginGuardMiddleware
 
 from . import gates
 from ._shared import logger, validate_lanlan_name
@@ -129,6 +130,7 @@ async def storage_limited_mode_guard(request: Request, call_next):
 # agent_server 因 /openfang-llm-proxy 透明转发大 LLM 请求（vision/长上下文 JSON
 # 可超 16M）有意不装，见 PR 说明。
 app.add_middleware(InboundBodySizeLimitMiddleware)
+app.add_middleware(HostOriginGuardMiddleware)
 
 
 @app.exception_handler(MaintenanceModeError)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -15,6 +15,9 @@ export NGINX_AUTO_RELOAD=${NGINX_AUTO_RELOAD:-1}  # 是否启用自动重载，�
 
 # Docker 容器内 Nginx 作为反向代理前置，强制启用 uvicorn proxy_headers
 export NEKO_BEHIND_PROXY=true
+# Nginx 保留客户端 Host；将配置的部署域名显式加入应用层可信主机。
+# loopback 和 IP 字面量由中间件默认允许，因此本地/IP 访问不依赖此项。
+export NEKO_TRUSTED_HOSTS="${NEKO_TRUSTED_HOSTS:-${SSL_DOMAIN}}"
 
 # 1. 信号处理优化
 setup_signal_handlers() {

--- a/docs/config/environment-vars.md
+++ b/docs/config/environment-vars.md
@@ -25,9 +25,17 @@ Electron stores port overrides in `port_config.json` under `%APPDATA%\N.E.K.O` o
 | `NEKO_INSTANCE_ID` | Shared instance ID; normally created by the launcher |
 | `NEKO_AUTOSTART_CSRF_TOKEN` | Autostart request token; defaults to the instance ID |
 | `NEKO_AUTOSTART_ALLOWED_ORIGINS` | Comma-separated extra allowed origins |
+| `NEKO_TRUSTED_HOSTS` | Comma-separated extra hostnames accepted by local HTTP/WebSocket services. Loopback names and IP literals are accepted automatically. |
+| `NEKO_TRUSTED_ORIGINS` | Comma-separated extra browser origins accepted for WebSocket connections. Same-origin connections and loopback aliases are accepted automatically. |
 | `NEKO_BEHIND_PROXY` | Enables proxy-header handling in supported entrypoints |
 | `NEKO_LOG_LEVEL` | Main-server log level |
 | `NEKO_MERGED` | Launcher merged-mode override |
+
+Trusted hosts are exact names (optionally with a port); `*.example.com` permits
+subdomains but not the bare suffix. A global `*` is deliberately ignored. The
+Docker entrypoint adds `SSL_DOMAIN` to `NEKO_TRUSTED_HOSTS` by default. Trusted
+origins must be complete `http://` or `https://` origins and affect browser
+WebSocket handshakes, not CORS.
 
 Most shared boolean helpers accept `1/true/yes/on` and `0/false/no/off`.
 `NEKO_MERGED` itself accepts `1/true/yes` and `0/false/no`.

--- a/main_routers/config_router/core_config.py
+++ b/main_routers/config_router/core_config.py
@@ -30,6 +30,104 @@ from utils.cloudsave_runtime import MaintenanceModeError
 from utils.config_manager import ensure_default_yui_voice_for_free_api
 
 
+CORE_CONFIG_SECRET_SENTINEL = "__NEKO_SECRET_MASKED__"
+
+CORE_CONFIG_MODEL_TYPES = (
+    'conversation', 'summary', 'gameMain', 'gameSummary', 'correction', 'emotion',
+    'vision', 'agent', 'omni', 'tts',
+)
+
+CORE_CONFIG_ASSIST_API_KEY_FIELDS = (
+    'assistApiKeyQwen', 'assistApiKeyQwenIntl', 'assistApiKeyOpenai',
+    'assistApiKeyDeepseek', 'assistApiKeyGlm', 'assistApiKeyStep',
+    'assistApiKeySilicon', 'assistApiKeyGemini', 'assistApiKeyKimi',
+    'assistApiKeyDoubao', 'assistApiKeyDoubaoTts', 'assistApiKeyMinimax',
+    'assistApiKeyMinimaxIntl', 'assistApiKeyMimo',
+    'assistApiKeyMimoTokenPlan', 'assistApiKeyElevenlabs', 'assistApiKeyGrok',
+    'assistApiKeyClaude', 'assistApiKeyKimiCode', 'assistApiKeyOpenrouter',
+)
+
+CORE_CONFIG_MODEL_API_KEY_FIELDS = tuple(
+    f'{model_type}ModelApiKey' for model_type in CORE_CONFIG_MODEL_TYPES
+)
+
+CORE_CONFIG_PROVIDER_API_KEY_FIELDS = frozenset(
+    CORE_CONFIG_ASSIST_API_KEY_FIELDS
+)
+
+# Config-file field names.  The GET response uses ``api_key`` for
+# ``coreApiKey``; all other secret names are identical in both directions.
+CORE_CONFIG_SECRET_FIELDS = (
+    'coreApiKey',
+    *CORE_CONFIG_ASSIST_API_KEY_FIELDS,
+    'mcpToken',
+    *CORE_CONFIG_MODEL_API_KEY_FIELDS,
+)
+
+
+def is_core_config_secret_placeholder(value) -> bool:
+    """Return whether *value* means "keep the stored secret".
+
+    New clients use one exact sentinel.  The narrowly-shaped star checks keep
+    round-trips from older clients working without treating every real key
+    containing ``***`` as a placeholder.
+    """
+    if not isinstance(value, str):
+        return False
+
+    stripped = value.strip()
+    if stripped == CORE_CONFIG_SECRET_SENTINEL:
+        return True
+    if len(stripped) >= 3 and set(stripped) == {'*'}:
+        return True
+
+    # Legacy web UI masking kept six characters at each end and replaced the
+    # middle with stars.  Require that exact shape and at least three stars.
+    if len(stripped) < 15:
+        return False
+    prefix, masked, suffix = stripped[:6], stripped[6:-6], stripped[-6:]
+    return (
+        '*' not in prefix
+        and '*' not in suffix
+        and len(masked) >= 3
+        and set(masked) == {'*'}
+    )
+
+
+def redact_core_config_secret(value, *, preserve_free_access: bool = False) -> str:
+    """Replace a non-empty config secret with the public response sentinel."""
+    if value is None or value == '':
+        return ''
+    if preserve_free_access and value == 'free-access':
+        return 'free-access'
+    return CORE_CONFIG_SECRET_SENTINEL
+
+
+def apply_core_config_secret_update(target: dict, source: dict, field: str) -> bool:
+    """Apply a submitted secret unless it is a keep-existing placeholder.
+
+    Returns ``True`` only when the field was written.  In particular, an empty
+    string is a real update so optional credentials can be explicitly cleared.
+    """
+    if field not in source or is_core_config_secret_placeholder(source[field]):
+        return False
+    target[field] = source[field]
+    return True
+
+
+def get_core_config_provider_api_key_field(provider, api_key_registry):
+    """Resolve a provider's config field through the allowlisted registry."""
+    if not isinstance(provider, str) or not isinstance(api_key_registry, dict):
+        return None
+    provider_config = api_key_registry.get(provider)
+    if not isinstance(provider_config, dict):
+        return None
+    field = provider_config.get('config_field')
+    if field not in CORE_CONFIG_PROVIDER_API_KEY_FIELDS:
+        return None
+    return field
+
+
 @router.get("/core_api")
 async def get_core_config_api():
     """Get the core config (API keys)."""
@@ -72,7 +170,7 @@ async def get_core_config_api():
             """Fall back to coreApiKey only when the provider matches the user-selected coreApi/assistApi."""
             return fallback_key if provider in _fallback_providers else ''
 
-        return {
+        response = {
             "api_key": api_key,
             "coreApi": _core_api_provider,
             "assistApi": _assist_api_provider,
@@ -108,8 +206,7 @@ async def get_core_config_api():
             # 自定义API相关字段（Provider / Url / Id / ApiKey per model type）
             **{
                 f'{mt}Model{suffix}': core_cfg.get(f'{mt}Model{suffix}', '')
-                for mt in ('conversation', 'summary', 'gameMain', 'gameSummary', 'correction', 'emotion',
-                           'vision', 'agent', 'omni', 'tts')
+                for mt in CORE_CONFIG_MODEL_TYPES
                 for suffix in ('Provider', 'Url', 'Id', 'ApiKey')
             },
             "gptsovitsEnabled": core_cfg.get('gptsovitsEnabled'),
@@ -118,6 +215,17 @@ async def get_core_config_api():
             "disableTts": core_cfg.get('disableTts', False) is True or str(core_cfg.get('disableTts', False)).lower() in ('true', '1', 'yes', 'on'),
             "success": True
         }
+        response['api_key'] = redact_core_config_secret(
+            response['api_key'],
+            preserve_free_access=True,
+        )
+        for field in (
+            *CORE_CONFIG_ASSIST_API_KEY_FIELDS,
+            'mcpToken',
+            *CORE_CONFIG_MODEL_API_KEY_FIELDS,
+        ):
+            response[field] = redact_core_config_secret(response[field])
+        return response
     except Exception as e:
         return {
             "success": False,
@@ -171,18 +279,102 @@ async def update_core_config(request: Request):
         except TypeError as exc:
             return {"success": False, "error": str(exc)}
 
-        effective_core_api = incoming_core_api or _stored_provider('coreApi')
+        stored_core_api = _stored_provider('coreApi') or 'qwen'
+        effective_core_api = incoming_core_api or stored_core_api
         core_uses_free_provider = effective_core_api == 'free'
-        
-        def _is_masked_secret(value) -> bool:
+        stored_assist_api = _stored_provider('assistApi')
+        effective_assist_api = incoming_assist_api or stored_assist_api
+        if not effective_assist_api:
+            effective_assist_api = 'free' if core_uses_free_provider else 'qwen'
+
+        def _usable_provider_api_key(value):
             if not isinstance(value, str):
-                return False
-            stripped = value.strip()
-            return bool(stripped) and ('***' in stripped or set(stripped) == {'*'})
+                return ''
+            normalized = value.strip()
+            if (
+                not normalized
+                or normalized == 'free-access'
+                or is_core_config_secret_placeholder(normalized)
+            ):
+                return ''
+            return normalized
+
+        provider_changed = bool(
+            incoming_core_api and incoming_core_api != stored_core_api
+        )
+        core_key_is_placeholder = (
+            'coreApiKey' in data
+            and is_core_config_secret_placeholder(data['coreApiKey'])
+        )
+        stored_core_api_key = _usable_provider_api_key(
+            core_cfg.get('coreApiKey', '')
+        )
+        needs_provider_key_promotion = (
+            core_key_is_placeholder
+            and (provider_changed or not stored_core_api_key)
+        )
+        promoted_core_api_key = None
+
+        if provider_changed or needs_provider_key_promotion:
+            from utils.api_config_loader import get_config
+
+            provider_config = await asyncio.to_thread(get_config)
+            api_key_registry = (
+                provider_config.get('api_key_registry', {})
+                if isinstance(provider_config, dict)
+                else {}
+            )
+
+            # Preserve the old core provider's authoritative key in its Key
+            # Book slot before coreApiKey is repointed.  A distinct non-empty
+            # key remains authoritative only when that provider stays selected
+            # as assist; otherwise the old slot is stale and must be replaced.
+            if provider_changed and stored_core_api != 'free' and stored_core_api_key:
+                old_provider_field = get_core_config_provider_api_key_field(
+                    stored_core_api,
+                    api_key_registry,
+                )
+                old_provider_key = (
+                    _usable_provider_api_key(core_cfg.get(old_provider_field, ''))
+                    if old_provider_field
+                    else ''
+                )
+                if (
+                    old_provider_field
+                    and (
+                        effective_assist_api != stored_core_api
+                        or not old_provider_key
+                    )
+                ):
+                    core_cfg[old_provider_field] = stored_core_api_key
+
+            if needs_provider_key_promotion:
+                if core_uses_free_provider:
+                    promoted_core_api_key = 'free-access'
+                else:
+                    target_provider_field = get_core_config_provider_api_key_field(
+                        effective_core_api,
+                        api_key_registry,
+                    )
+                    if target_provider_field:
+                        submitted_target_key = data.get(target_provider_field)
+                        if (
+                            target_provider_field in data
+                            and not is_core_config_secret_placeholder(submitted_target_key)
+                        ):
+                            target_key = submitted_target_key
+                        else:
+                            target_key = core_cfg.get(target_provider_field, '')
+                        promoted_core_api_key = _usable_provider_api_key(target_key)
+
+                    if promoted_core_api_key is None:
+                        promoted_core_api_key = ''
+                    if not promoted_core_api_key and not enable_custom_api:
+                        return {"success": False, "error": "API Key不能为空"}
 
         def _normalize_core_api_key(value):
-            if _is_masked_secret(value):
-                return None
+            if is_core_config_secret_placeholder(value):
+                return promoted_core_api_key
             if value is None:
                 raise ValueError("API Key不能为null")
             if not isinstance(value, str):
@@ -211,7 +403,12 @@ async def update_core_config(request: Request):
                 )
             except (TypeError, ValueError) as exc:
                 return {"success": False, "error": str(exc)}
-            if not core_uses_free_provider and not api_key:
+            effective_api_key = (
+                core_cfg.get('coreApiKey', '')
+                if api_key is None
+                else api_key
+            )
+            if not core_uses_free_provider and not effective_api_key:
                 return {"success": False, "error": "API Key不能为空"}
             if api_key is not None:
                 core_cfg['coreApiKey'] = api_key
@@ -235,22 +432,8 @@ async def update_core_config(request: Request):
                 if normalized_key and normalized_value:
                     sanitized_resolved_urls[normalized_key] = normalized_value
             core_cfg['resolvedProviderUrls'] = sanitized_resolved_urls
-        _api_key_fields = [
-            'assistApiKeyQwen', 'assistApiKeyQwenIntl', 'assistApiKeyOpenai', 'assistApiKeyDeepseek',
-            'assistApiKeyGlm', 'assistApiKeyStep', 'assistApiKeySilicon',
-            'assistApiKeyGemini', 'assistApiKeyKimi', 'assistApiKeyDoubao', 'assistApiKeyDoubaoTts',
-            'assistApiKeyMinimax', 'assistApiKeyMinimaxIntl', 'assistApiKeyMimo',
-            'assistApiKeyMimoTokenPlan', 'assistApiKeyElevenlabs', 'assistApiKeyGrok',
-            'assistApiKeyClaude', 'assistApiKeyKimiCode', 'assistApiKeyOpenrouter',
-        ]
-        for field in _api_key_fields:
-            if field in data:
-                value = data[field]
-                if isinstance(value, str) and '***' in value:
-                    continue
-                core_cfg[field] = value
-        if 'mcpToken' in data:
-            core_cfg['mcpToken'] = data['mcpToken']
+        for field in (*CORE_CONFIG_ASSIST_API_KEY_FIELDS, 'mcpToken'):
+            apply_core_config_secret_update(core_cfg, data, field)
         if 'openclawUrl' in data:
             # 前端表单回填的是文件里的原始值。若启动期迁移曾写盘失败（Windows 上
             # os.replace 可能被杀软占用），这里收到的就还是旧的 8089，原样落盘等于把
@@ -284,15 +467,14 @@ async def update_core_config(request: Request):
             core_cfg['disableTts'] = data['disableTts']
 
         # 自定义API配置（Provider / Url / Id / ApiKey per model type）
-        _model_types = [
-            'conversation', 'summary', 'gameMain', 'gameSummary', 'correction', 'emotion',
-            'vision', 'agent', 'omni', 'tts',
-        ]
-        for mt in _model_types:
+        for mt in CORE_CONFIG_MODEL_TYPES:
             for suffix in ['Provider', 'Url', 'Id', 'ApiKey']:
                 field = f'{mt}Model{suffix}'
                 if field in data:
-                    core_cfg[field] = data[field]
+                    if suffix == 'ApiKey':
+                        apply_core_config_secret_update(core_cfg, data, field)
+                    else:
+                        core_cfg[field] = data[field]
         # gptsovitsEnabled 退役后的惰性迁移（save choke point，对偶 #1842 voice_id 思路）：
         # GSV 启用已收口到 ttsModelProvider=='gptsovits' 单一真相，旧 gptsovitsEnabled 仅作
         # pre-#1830 存量兜底。前端加载会把启用中的 GSV 下拉钉到 'gptsovits'，故任何提交了
@@ -304,7 +486,7 @@ async def update_core_config(request: Request):
             core_cfg['gptsovitsEnabled'] = False
         if _incoming_tts_provider == 'doubao_tts':
             doubao_key = str(core_cfg.get('assistApiKeyDoubaoTts') or '').strip()
-            if doubao_key and '***' not in doubao_key:
+            if doubao_key and not is_core_config_secret_placeholder(doubao_key):
                 core_cfg['ttsModelApiKey'] = doubao_key
             else:
                 core_cfg['ttsModelApiKey'] = ''

--- a/main_routers/config_router/core_config.py
+++ b/main_routers/config_router/core_config.py
@@ -466,6 +466,22 @@ async def update_core_config(request: Request):
                 return {"success": False, "error": "disableTts must be a boolean"}
             core_cfg['disableTts'] = data['disableTts']
 
+        # Capture the stored provider and whether either Doubao TTS credential
+        # was explicitly changed before applying the submitted model fields.
+        # A masked value means "keep existing"; an empty string is an explicit
+        # clear and must remain distinguishable from that no-op.
+        stored_tts_model_provider = str(
+            core_cfg.get('ttsModelProvider') or ''
+        ).strip()
+        doubao_tts_key_was_explicitly_updated = (
+            'assistApiKeyDoubaoTts' in data
+            and not is_core_config_secret_placeholder(data['assistApiKeyDoubaoTts'])
+        )
+        tts_model_key_was_explicitly_updated = (
+            'ttsModelApiKey' in data
+            and not is_core_config_secret_placeholder(data['ttsModelApiKey'])
+        )
+
         # 自定义API配置（Provider / Url / Id / ApiKey per model type）
         for mt in CORE_CONFIG_MODEL_TYPES:
             for suffix in ['Provider', 'Url', 'Id', 'ApiKey']:
@@ -486,10 +502,19 @@ async def update_core_config(request: Request):
             core_cfg['gptsovitsEnabled'] = False
         if _incoming_tts_provider == 'doubao_tts':
             doubao_key = str(core_cfg.get('assistApiKeyDoubaoTts') or '').strip()
-            if doubao_key and not is_core_config_secret_placeholder(doubao_key):
+            if doubao_tts_key_was_explicitly_updated:
+                # The dedicated Key Book field is authoritative when the user
+                # explicitly edits it, including an explicit empty-string clear.
                 core_cfg['ttsModelApiKey'] = doubao_key
-            else:
-                core_cfg['ttsModelApiKey'] = ''
+            elif not tts_model_key_was_explicitly_updated:
+                if doubao_key and not is_core_config_secret_placeholder(doubao_key):
+                    core_cfg['ttsModelApiKey'] = doubao_key
+                elif stored_tts_model_provider != 'doubao_tts':
+                    # Switching from another provider must not reuse its shared
+                    # model key as a Doubao credential. When already on Doubao,
+                    # however, masked/no-op saves preserve the legacy key stored
+                    # only in ttsModelApiKey.
+                    core_cfg['ttsModelApiKey'] = ''
         if 'ttsVoiceId' in data:
             core_cfg['ttsVoiceId'] = data['ttsVoiceId']
 

--- a/plugin/server/http_app.py
+++ b/plugin/server/http_app.py
@@ -16,6 +16,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.responses import Response
 
 from plugin.logging_config import get_logger
+from utils.host_origin_guard import HostOriginGuardMiddleware
 from utils.logger_config import get_module_logger
 from plugin.server.infrastructure.exceptions import register_exception_handlers
 from plugin.server.lifecycle import shutdown as lifecycle_shutdown
@@ -246,4 +247,7 @@ def build_plugin_server_app(title: str = "N.E.K.O User Plugin Server") -> FastAP
     app.include_router(plugin_cli_router)
     app.include_router(llm_tools_router)
     app.include_router(market_bridge_router)
+    # Keep the Host/Origin guard outside CORS and the cache-header middleware;
+    # untrusted requests must not be short-circuited before the guard runs.
+    app.add_middleware(HostOriginGuardMiddleware)
     return app

--- a/plugin/tests/unit/server/test_proxy_double_encoding_exploration.py
+++ b/plugin/tests/unit/server/test_proxy_double_encoding_exploration.py
@@ -144,7 +144,7 @@ async def _run_one(body: bytes) -> None:
     try:
         async with original_async_client(
             transport=httpx.ASGITransport(app=app),
-            base_url="http://testserver",
+            base_url="http://127.0.0.1:48911",
         ) as client:
             # Stream the response so we can inspect headers AND read
             # raw bytes via ``aiter_raw`` without httpx auto-decoding
@@ -217,7 +217,7 @@ async def test_proxy_uses_runtime_user_plugin_server_port(monkeypatch: pytest.Mo
     try:
         async with original_async_client(
             transport=httpx.ASGITransport(app=app),
-            base_url="http://testserver",
+            base_url="http://127.0.0.1:48911",
         ) as client:
             response = await client.get("/market/status?x=1")
     finally:

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -36,6 +36,10 @@ const MODEL_TYPES = ['conversation', 'vision', 'summary', 'correction', 'emotion
 // provider resolution logic (follow_core/follow_assist/custom).
 // Future: GPT-SoVITS custom TTS may need dedicated WebSocket test path.
 const CONNECTIVITY_TESTABLE_TYPES = MODEL_TYPES;
+// 后端用于表示“密钥已配置但不下发明文”的保留值。该值可以原样 POST 回去，
+// 由后端保留原密钥；绝不能当作真实凭据展示或用于连通性测试。
+const MASKED_SECRET_SENTINEL = '__NEKO_SECRET_MASKED__';
+const MASKED_SECRET_DISPLAY = '••••••••••••';
 const MIMO_TOKEN_PLAN_PROVIDER_KEY = 'mimo_token_plan';
 const MIMO_TOKEN_PLAN_OPENROUTER_URLS = [
     'https://token-plan-cn.xiaomimimo.com/v1',
@@ -370,9 +374,24 @@ function rememberResolvedProviderUrl(scope, providerKey, resolvedUrl) {
  */
 function maskApiKey(key) {
     if (!key || typeof key !== 'string') return key;
+    if (isMaskedSecretValue(key)) return MASKED_SECRET_DISPLAY;
     if (key.length < 14) return key;
     const midLen = key.length - 12;
     return key.slice(0, 6) + '*'.repeat(midLen) + key.slice(-6);
+}
+
+/**
+ * 判断后端保留哨兵或旧版遮罩。旧值只接受全星号，或 maskApiKey 生成的
+ * “6 字符前缀 + 至少 3 个星号 + 6 字符后缀”完整形状，避免把任意内部
+ * 含星号的用户输入误判成遮罩。
+ */
+function isMaskedSecretValue(value) {
+    if (typeof value !== 'string') return false;
+    const normalized = value.trim();
+    return normalized === MASKED_SECRET_SENTINEL
+        || normalized === MASKED_SECRET_DISPLAY
+        || /^\*{3,}$/.test(normalized)
+        || /^[^*]{6}\*{3,}[^*]{6}$/.test(normalized);
 }
 
 /**
@@ -382,32 +401,53 @@ function setMaskedInput(input, realKey) {
     if (!input) return;
     if (!realKey) {
         input.dataset.realKey = '';
+        delete input.dataset.maskedSecret;
         input.value = '';
         return;
     }
+    if (isMaskedSecretValue(realKey)) {
+        // 只保留“后端已有密钥”这一状态，不把哨兵伪装成真实 key 放进 DOM。
+        input.dataset.realKey = '';
+        input.dataset.maskedSecret = 'true';
+        input.value = MASKED_SECRET_DISPLAY;
+        return;
+    }
+    delete input.dataset.maskedSecret;
     input.dataset.realKey = realKey;
     input.value = maskApiKey(realKey);
+}
+
+function setSecretInputValue(elementId, value) {
+    const input = document.getElementById(elementId);
+    if (!input) return;
+    attachMaskBehavior(input);
+    setMaskedInput(input, typeof value === 'string' ? value : '');
 }
 
 /**
  * ⚠️ 重要：所有需要读取 API Key 真实值的地方，必须使用 getRealKey(input)
  * 而不是 input.value。因为 input.value 可能是遮蔽后的值（如 sk-a04****6b53）。
- * 真实 key 存储在 input.dataset.realKey 中，由 setMaskedInput() 写入。
+ * 用户新输入的真实 key 存储在 input.dataset.realKey 中；后端遮罩值只保存
+ * dataset.maskedSecret 状态，不会作为真实 key 放进 DOM。
  * 新增读取 key 的代码时请务必使用此函数。
  */
 function getRealKey(input) {
     if (!input) return '';
+    if (input.dataset.maskedSecret === 'true') {
+        return MASKED_SECRET_SENTINEL;
+    }
     // 聚焦中：用户可能正在编辑，优先使用当前 value
     if (input === document.activeElement) {
-        return input.value.trim();
+        const focusedValue = input.value.trim();
+        return isMaskedSecretValue(focusedValue) ? MASKED_SECRET_SENTINEL : focusedValue;
     }
     // 非聚焦：优先使用存储的真实 key（value 可能是遮蔽值）
     if (input.dataset.realKey) {
         return input.dataset.realKey;
     }
-    // 防御：如果 value 全是星号，说明是遮蔽残留，返回空
+    // 兼容旧遮罩：全星号表示后端已有密钥，应回传统一哨兵以便保留。
     const val = input.value.trim();
-    if (/\*{3,}/.test(val)) return '';
+    if (isMaskedSecretValue(val)) return MASKED_SECRET_SENTINEL;
     return val;
 }
 
@@ -418,17 +458,49 @@ function attachMaskBehavior(input) {
     if (!input || input.dataset.maskAttached) return;
     input.dataset.maskAttached = 'true';
     input.addEventListener('focus', () => {
+        if (input.dataset.maskedSecret === 'true') {
+            // 无明文可显示。选中通用掩码，让直接键入自然替换它。
+            input.value = MASKED_SECRET_DISPLAY;
+            input.select();
+            return;
+        }
         const real = input.dataset.realKey;
         if (real) input.value = real;
     });
+    input.addEventListener('beforeinput', () => {
+        if (input.dataset.maskedSecret !== 'true') return;
+        // 用户开始编辑时才丢弃“保留旧值”状态；单纯聚焦/失焦不会清空密钥。
+        delete input.dataset.maskedSecret;
+        input.dataset.realKey = '';
+        input.value = '';
+    });
+    input.addEventListener('input', () => {
+        if (input.dataset.maskedSecret === 'true' && input.value !== MASKED_SECRET_DISPLAY) {
+            // 兼容脚本赋值后派发 input（以及不支持 beforeinput 的浏览器）。
+            delete input.dataset.maskedSecret;
+            input.dataset.realKey = '';
+        }
+    });
     input.addEventListener('blur', () => {
+        if (input.dataset.maskedSecret === 'true') {
+            input.dataset.realKey = '';
+            input.value = MASKED_SECRET_DISPLAY;
+            return;
+        }
         // 用户可能编辑了 value，同步回 realKey
         const current = input.value.trim();
         if (current) {
+            if (isMaskedSecretValue(current)) {
+                input.dataset.realKey = '';
+                input.dataset.maskedSecret = 'true';
+                input.value = MASKED_SECRET_DISPLAY;
+                return;
+            }
             input.dataset.realKey = current;
             input.value = maskApiKey(current);
         } else {
             input.dataset.realKey = '';
+            delete input.dataset.maskedSecret;
         }
     });
 }
@@ -530,8 +602,8 @@ function showCurrentApiKey(message, rawKey = '', hasKey = false) {
     const textNode = document.createTextNode(message);
     currentApiKeyDiv.appendChild(textNode);
 
-    // 存储状态到 dataset
-    currentApiKeyDiv.dataset.apiKey = rawKey;
+    // 这里只需要“是否已配置”状态；不要把凭据复制到无用途的 DOM dataset。
+    currentApiKeyDiv.dataset.apiKey = '';
     currentApiKeyDiv.dataset.hasKey = hasKey ? 'true' : 'false';
 
     currentApiKeyDiv.style.display = 'flex';
@@ -990,7 +1062,14 @@ function syncKeyToBook(providerKey, keyValue, sourceInput = null) {
         if (input !== sourceInput) {
             setMaskedInput(input, keyValue || '');
         } else {
-            input.dataset.realKey = (keyValue || '').trim();
+            const normalizedKey = (keyValue || '').trim();
+            if (isMaskedSecretValue(normalizedKey)) {
+                input.dataset.realKey = '';
+                input.dataset.maskedSecret = 'true';
+            } else {
+                input.dataset.realKey = normalizedKey;
+                delete input.dataset.maskedSecret;
+            }
         }
         attachMaskBehavior(input);
     }
@@ -1319,6 +1398,7 @@ function onCustomModelProviderChange(modelType) {
         if (_isLoadingSavedConfig) return;
         // 清除残留的遮蔽状态和遮蔽值，让用户从空白开始输入
         input.dataset.realKey = '';
+        delete input.dataset.maskedSecret;
         input.value = '';
         // 恢复原始 placeholder
         const origPlaceholder = input.getAttribute('data-i18n-placeholder');
@@ -1712,7 +1792,7 @@ async function loadCurrentApiKey() {
     _ttsConfigDirty = false;
 
     if (apiKeyInput) {
-        apiKeyInput.value = '';
+        setMaskedInput(apiKeyInput, '');
     }
     if (coreApiSelect) {
         coreApiSelect.value = '';
@@ -1721,7 +1801,7 @@ async function loadCurrentApiKey() {
         assistApiSelect.value = '';
     }
     if (assistApiKeyInput) {
-        assistApiKeyInput.value = '';
+        setMaskedInput(assistApiKeyInput, '');
     }
 
     syncProviderSelectDropdowns();
@@ -1814,9 +1894,8 @@ async function loadCurrentApiKey() {
                 useMimoTokenPlanToggle.checked = data.useMimoTokenPlan === true;
             }
             const mimoTokenPlanKeyInput = document.getElementById('mimoTokenPlanKeyInput');
-            if (mimoTokenPlanKeyInput && data.assistApiKeyMimoTokenPlan) {
-                setMaskedInput(mimoTokenPlanKeyInput, data.assistApiKeyMimoTokenPlan);
-                attachMaskBehavior(mimoTokenPlanKeyInput);
+            if (mimoTokenPlanKeyInput) {
+                setSecretInputValue('mimoTokenPlanKeyInput', data.assistApiKeyMimoTokenPlan);
             }
             updateMimoTokenPlanControls();
 
@@ -1878,42 +1957,42 @@ async function loadCurrentApiKey() {
             // 加载用户自定义API配置
             setInputValue('conversationModelUrl', data.conversationModelUrl);
             setInputValue('conversationModelId', data.conversationModelId);
-            setInputValue('conversationModelApiKey', data.conversationModelApiKey);
+            setSecretInputValue('conversationModelApiKey', data.conversationModelApiKey);
 
             setInputValue('summaryModelUrl', data.summaryModelUrl);
             setInputValue('summaryModelId', data.summaryModelId);
-            setInputValue('summaryModelApiKey', data.summaryModelApiKey);
+            setSecretInputValue('summaryModelApiKey', data.summaryModelApiKey);
 
             setInputValue('gameMainModelUrl', data.gameMainModelUrl);
             setInputValue('gameMainModelId', data.gameMainModelId);
-            setInputValue('gameMainModelApiKey', data.gameMainModelApiKey);
+            setSecretInputValue('gameMainModelApiKey', data.gameMainModelApiKey);
 
             setInputValue('gameSummaryModelUrl', data.gameSummaryModelUrl);
             setInputValue('gameSummaryModelId', data.gameSummaryModelId);
-            setInputValue('gameSummaryModelApiKey', data.gameSummaryModelApiKey);
+            setSecretInputValue('gameSummaryModelApiKey', data.gameSummaryModelApiKey);
 
             setInputValue('correctionModelUrl', data.correctionModelUrl);
             setInputValue('correctionModelId', data.correctionModelId);
-            setInputValue('correctionModelApiKey', data.correctionModelApiKey);
+            setSecretInputValue('correctionModelApiKey', data.correctionModelApiKey);
 
             setInputValue('emotionModelUrl', data.emotionModelUrl);
             setInputValue('emotionModelId', data.emotionModelId);
-            setInputValue('emotionModelApiKey', data.emotionModelApiKey);
+            setSecretInputValue('emotionModelApiKey', data.emotionModelApiKey);
 
             setInputValue('visionModelUrl', data.visionModelUrl);
             setInputValue('visionModelId', data.visionModelId);
-            setInputValue('visionModelApiKey', data.visionModelApiKey);
+            setSecretInputValue('visionModelApiKey', data.visionModelApiKey);
             setInputValue('agentModelUrl', data.agentModelUrl);
             setInputValue('agentModelId', data.agentModelId);
-            setInputValue('agentModelApiKey', data.agentModelApiKey);
+            setSecretInputValue('agentModelApiKey', data.agentModelApiKey);
 
             setInputValue('omniModelUrl', data.omniModelUrl);
             setInputValue('omniModelId', data.omniModelId);
-            setInputValue('omniModelApiKey', data.omniModelApiKey);
+            setSecretInputValue('omniModelApiKey', data.omniModelApiKey);
 
             setInputValue('ttsModelUrl', data.ttsModelUrl);
             setInputValue('ttsModelId', data.ttsModelId);
-            setInputValue('ttsModelApiKey', data.ttsModelApiKey);
+            setSecretInputValue('ttsModelApiKey', data.ttsModelApiKey);
             setInputValue('ttsVoiceId', data.ttsVoiceId);
 
             // 加载 GPT-SoVITS 配置：启用状态以 ttsModelProvider 下拉为准，
@@ -1928,7 +2007,7 @@ async function loadCurrentApiKey() {
             );
 
             // 加载MCPR_TOKEN
-            setInputValue('mcpTokenInput', data.mcpToken);
+            setSecretInputValue('mcpTokenInput', data.mcpToken);
 
             // Load *ModelProvider for each model type and apply
             _isLoadingSavedConfig = true;
@@ -2247,6 +2326,7 @@ function updateAssistApiKeyInputAvailability() {
         const freeText = window.t ? window.t('api.freeVersionNoApiKey') : '免费版无需API Key';
         assistApiKeyInput.placeholder = freeText;
         assistApiKeyInput.dataset.realKey = '';
+        delete assistApiKeyInput.dataset.maskedSecret;
         assistApiKeyInput.value = freeText;
         attachMaskBehavior(assistApiKeyInput);
         updateMimoTokenPlanControls();
@@ -2363,7 +2443,7 @@ function confirmClearCustomApi() {
             // 清除遮蔽状态（如果有）
             if (keyEl.dataset) {
                 delete keyEl.dataset.realKey;
-                delete keyEl.dataset.masked;
+                delete keyEl.dataset.maskedSecret;
             }
         }
         // 重置 Provider 下拉为默认值并同步联动状态
@@ -2435,8 +2515,30 @@ document.addEventListener('DOMContentLoaded', function () {
 
 
 });
+function resolveCoreApiKeyForSave(coreApi, inputKey, allBookKeys, inputDirty) {
+    if (coreApi === 'free') return 'free-access';
+    const hasSelectedBookKey = !!(
+        coreApi
+        && Object.prototype.hasOwnProperty.call(allBookKeys, coreApi)
+    );
+    if (!inputDirty && hasSelectedBookKey) {
+        return allBookKeys[coreApi];
+    }
+    return inputKey;
+}
 
-
+function buildKeyBookSecretPayload(allBookKeys, registry) {
+    const payload = {};
+    Object.keys(allBookKeys).forEach(providerKey => {
+        const field = (registry[providerKey] || {}).config_field;
+        if (!field) return;
+        const value = allBookKeys[providerKey];
+        if (!Object.prototype.hasOwnProperty.call(payload, field) || value || !payload[field]) {
+            payload[field] = value;
+        }
+    });
+    return payload;
+}
 
 async function save_button_down(e) {
 
@@ -2604,20 +2706,11 @@ async function save_button_down(e) {
     // ttsVoiceId 直接用标准字段值，不再把旧 GSV 配置冻进 voice_id（旧前缀仍由
     // loadGptSovitsConfig 读路径兼容解析，只是不再写出）。
 
-    const mcpToken = getVal('mcpTokenInput');
+    const mcpToken = getKeyVal('mcpTokenInput');
 
-    const hasCoreBookKeyForSave = !!(
-        coreApi
-        && coreApi !== 'free'
-        && Object.prototype.hasOwnProperty.call(allBookKeys, coreApi)
-    );
-    const coreBookKeyForSave = hasCoreBookKeyForSave ? allBookKeys[coreApi] : '';
-    const effectiveCoreApiKeyForSave = (!_coreApiKeyInputDirty && hasCoreBookKeyForSave)
-        ? coreBookKeyForSave
-        : apiKey;
     // coreApiKey 只看 core 自己：assist=free 与付费 core 组合时，付费 core 仍需要真实 Key，
     // 不能被 free-access 覆盖。
-    const apiKeyForSave = coreApi === 'free' ? 'free-access' : effectiveCoreApiKeyForSave;
+    const apiKeyForSave = resolveCoreApiKeyForSave(coreApi, apiKey, allBookKeys, _coreApiKeyInputDirty);
 
     // 免费版和启用自定义API时不需要API Key检查
     if (!enableCustomApi && coreApi !== 'free' && !apiKeyForSave) {
@@ -2637,16 +2730,7 @@ async function save_button_down(e) {
 
     // Build payload — map book keys to config field names via registry.
     // Only include providers present in allBookKeys (skips restricted/hidden ones).
-    const bookPayload = {};
-    Object.keys(allBookKeys).forEach(pk => {
-        const field = (_apiKeyRegistry[pk] || {}).config_field;
-        if (field) {
-            const value = allBookKeys[pk];
-            if (!Object.prototype.hasOwnProperty.call(bookPayload, field) || value || !bookPayload[field]) {
-                bookPayload[field] = value;
-            }
-        }
-    });
+    const bookPayload = buildKeyBookSecretPayload(allBookKeys, _apiKeyRegistry);
 
     const payload = {
         apiKey: apiKeyForSave, coreApi, assistApi,
@@ -3590,6 +3674,16 @@ function buildCustomConnectivityCacheId(providerType, subType, url, key, model, 
     ].join('|');
 }
 
+function omitMaskedSecretFromConnectivity(result) {
+    if (result && isMaskedSecretValue(result.key)) {
+        // GET 配置不再包含明文，因此当前页面无法验证这个凭据。保留“已配置”
+        // 状态供指示灯注册，但绝不把哨兵发送到连通性测试端点。
+        result.key = '';
+        result.secretMasked = true;
+    }
+    return result;
+}
+
 // ==================== 连通性测试：ConnectivityManager ====================
 
 const ConnectivityManager = {
@@ -3618,7 +3712,7 @@ const ConnectivityManager = {
      * @returns {{ key: string, url: string, providerType: string }} 解析结果
      */
     resolveEffectiveKey(context) {
-        const result = { key: '', url: '', providerType: 'openai_compatible', subType: '', providerKey: '', providerScope: '', cacheId: '' };
+        const result = { key: '', url: '', providerType: 'openai_compatible', subType: '', providerKey: '', providerScope: '', cacheId: '', secretMasked: false };
 
         if (!context || !context.type) return result;
 
@@ -3651,6 +3745,7 @@ const ConnectivityManager = {
                 }
                 result.providerType = 'websocket';
             }
+            omitMaskedSecretFromConnectivity(result);
             result.cacheId = buildConnectivityCacheId(result.providerScope, result.providerKey, result.key, result.url);
             return result;
         }
@@ -3679,6 +3774,7 @@ const ConnectivityManager = {
                 }
                 result.providerType = getProviderType(assistProvider);
             }
+            omitMaskedSecretFromConnectivity(result);
             const cacheProviderKey = getEffectiveAssistProviderKey(result.providerKey);
             result.cacheId = buildConnectivityCacheId(result.providerScope, cacheProviderKey, result.key, result.url);
             return result;
@@ -3710,6 +3806,7 @@ const ConnectivityManager = {
                 // omni 模型使用 core_url (WebSocket)，其他模型使用 openrouter_url
                 if (mt === 'omni') {
                     result.key = coreResult.key;
+                    result.secretMasked = coreResult.secretMasked;
                     result.url = coreResult.url;
                     result.providerType = 'websocket';
                     result.providerKey = coreResult.providerKey;
@@ -3720,6 +3817,7 @@ const ConnectivityManager = {
                     const pInfo = _assistApiProviders[coreProvider] || _coreApiProviders[coreProvider] || {};
                     result.url = getProviderOpenrouterUrl(coreProvider, pInfo) || getProviderCoreUrl(coreProvider, pInfo);
                     result.key = coreResult.key;
+                    result.secretMasked = coreResult.secretMasked;
                     result.providerType = getProviderType(coreProvider);
                     result.providerKey = coreProvider;
                     result.providerScope = 'assist';
@@ -3728,6 +3826,7 @@ const ConnectivityManager = {
                 // 跟随辅助 API
                 const assistResult = this.resolveEffectiveKey({ type: 'assist' });
                 result.key = assistResult.key;
+                result.secretMasked = assistResult.secretMasked;
                 result.url = assistResult.url;
                 result.providerType = assistResult.providerType;
                 result.providerKey = assistResult.providerKey;
@@ -3830,7 +3929,8 @@ const ConnectivityManager = {
                 }
             }
 
-            if (result.key || result.url) {
+            omitMaskedSecretFromConnectivity(result);
+            if (result.key || result.url || result.secretMasked) {
                 if (result.providerKey && result.providerScope) {
                     result.cacheId = buildConnectivityCacheId(result.providerScope, result.providerKey, result.key, result.url);
                 } else {
@@ -3907,6 +4007,14 @@ const ConnectivityManager = {
      */
     async testKey(params) {
         const { provider_key, provider_scope, url, api_key: apiKey, model, voice_id: voiceId, provider_type: providerType, sub_type: subType, is_free: isFree, cache_id: cacheId } = params;
+        if (isMaskedSecretValue(apiKey)) {
+            return {
+                success: false,
+                skipped: true,
+                error: null,
+                error_code: null
+            };
+        }
         console.log('[ConnectivityManager] testKey called:', {
             provider_key: provider_key || '(custom)',
             provider_scope: provider_scope || '(none)',
@@ -4069,7 +4177,7 @@ const ConnectivityManager = {
         const coreResult = this.resolveEffectiveKey({ type: 'core' });
         const coreCacheId = coreResult.cacheId;
         console.log('[ConnectivityManager] testAll - core resolved:', { hasUrl: !!coreResult.url, hasKey: !!coreResult.key, providerType: coreResult.providerType });
-        if (coreCacheId && !(coreResult.key && coreResult.key !== 'free-access' && isFreeVersionText(coreResult.key))) {
+        if (!coreResult.secretMasked && coreCacheId && !(coreResult.key && coreResult.key !== 'free-access' && isFreeVersionText(coreResult.key))) {
             if (!keyConfigs[coreCacheId]) {
                 keyConfigs[coreCacheId] = {
                     provider_key: coreResult.providerKey, provider_scope: coreResult.providerScope,
@@ -4083,7 +4191,7 @@ const ConnectivityManager = {
         const assistIsFree = assistSelect && assistSelect.value === 'free';
         const assistResult = this.resolveEffectiveKey({ type: 'assist' });
         const assistCacheId = assistResult.cacheId;
-        if (assistCacheId && !keyConfigs[assistCacheId]) {
+        if (!assistResult.secretMasked && assistCacheId && !keyConfigs[assistCacheId]) {
             keyConfigs[assistCacheId] = {
                 provider_key: assistResult.providerKey, provider_scope: assistResult.providerScope,
                 url: assistResult.url, api_key: assistResult.key || '', provider_type: assistResult.providerType, is_free: assistIsFree
@@ -4096,7 +4204,7 @@ const ConnectivityManager = {
             CONNECTIVITY_TESTABLE_TYPES.forEach(mt => {
                 const customResult = this.resolveEffectiveKey({ type: 'custom', modelType: mt });
                 const customCacheId = customResult.cacheId;
-                if (customCacheId && !keyConfigs[customCacheId]) {
+                if (!customResult.secretMasked && customCacheId && !keyConfigs[customCacheId]) {
                     const providerSel = document.getElementById(`${mt}ModelProvider`);
                     const provider = providerSel ? providerSel.value : '';
                     let isFree = false;
@@ -4247,7 +4355,7 @@ const ConnectivityManager = {
             CONNECTIVITY_TESTABLE_TYPES.forEach(mt => {
                 const customResult = this.resolveEffectiveKey({ type: 'custom', modelType: mt });
                 const cacheId = customResult.cacheId;
-                if (cacheId && !keyConfigs[cacheId]) {
+                if (!customResult.secretMasked && cacheId && !keyConfigs[cacheId]) {
                     const providerSel = document.getElementById(`${mt}ModelProvider`);
                     const provider = providerSel ? providerSel.value : '';
                     let isFree = false;
@@ -4432,7 +4540,7 @@ function initConnectivityLights() {
             coreTestBtn.disabled = true;
             coreTestBtn.classList.add('testing');
             const resolved = ConnectivityManager.resolveEffectiveKey({ type: 'core' });
-            if (resolved.cacheId) {
+            if (resolved.cacheId && !resolved.secretMasked) {
                 const coreSelect = document.getElementById('coreApiSelect');
                 const isFree = coreSelect && coreSelect.value === 'free';
                 ConnectivityManager.keyStatusMap[resolved.cacheId] = LightStatus.TESTING;
@@ -4492,7 +4600,7 @@ function initConnectivityLights() {
             assistTestBtn.disabled = true;
             assistTestBtn.classList.add('testing');
             const resolved = ConnectivityManager.resolveEffectiveKey({ type: 'assist' });
-            if (resolved.cacheId) {
+            if (resolved.cacheId && !resolved.secretMasked) {
                 const assistSelect = document.getElementById('assistApiSelect');
                 const isFree = assistSelect && assistSelect.value === 'free';
                 ConnectivityManager.keyStatusMap[resolved.cacheId] = LightStatus.TESTING;

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -381,15 +381,16 @@ function maskApiKey(key) {
 }
 
 /**
- * 判断后端保留哨兵或旧版遮罩。旧值只接受全星号，或 maskApiKey 生成的
- * “6 字符前缀 + 至少 3 个星号 + 6 字符后缀”完整形状，避免把任意内部
- * 含星号的用户输入误判成遮罩。
+ * 判断后端保留哨兵、通用圆点遮罩（含非空残片）或旧版遮罩。旧值只接受
+ * 全星号，或 maskApiKey 生成的“6 字符前缀 + 至少 3 个星号 + 6 字符后缀”
+ * 完整形状，避免把任意内部含星号的用户输入误判成遮罩。
  */
 function isMaskedSecretValue(value) {
     if (typeof value !== 'string') return false;
     const normalized = value.trim();
     return normalized === MASKED_SECRET_SENTINEL
         || normalized === MASKED_SECRET_DISPLAY
+        || /^•+$/.test(normalized)
         || /^\*{3,}$/.test(normalized)
         || /^[^*]{6}\*{3,}[^*]{6}$/.test(normalized);
 }
@@ -4419,6 +4420,14 @@ const ConnectivityManager = {
 
 // ==================== 连通性测试：集成初始化 ====================
 
+function showMaskedSecretConnectivityNotice() {
+    const fallback = '密钥已保存但不可回显，请重新输入后再测试';
+    const message = window.t
+        ? window.t('connectivity.maskedSecretRetype', fallback)
+        : fallback;
+    showStatus(message, 'info');
+}
+
 /**
  * 初始化所有连通性指示灯、错误信息展示、测试按钮和事件绑定。
  * 在 initializePage() 中调用，负责 Tasks 6.1, 6.2, 6.3, 7.1, 7.2, 8.1, 8.2。
@@ -4540,7 +4549,9 @@ function initConnectivityLights() {
             coreTestBtn.disabled = true;
             coreTestBtn.classList.add('testing');
             const resolved = ConnectivityManager.resolveEffectiveKey({ type: 'core' });
-            if (resolved.cacheId && !resolved.secretMasked) {
+            if (resolved.secretMasked) {
+                showMaskedSecretConnectivityNotice();
+            } else if (resolved.cacheId) {
                 const coreSelect = document.getElementById('coreApiSelect');
                 const isFree = coreSelect && coreSelect.value === 'free';
                 ConnectivityManager.keyStatusMap[resolved.cacheId] = LightStatus.TESTING;
@@ -4600,7 +4611,9 @@ function initConnectivityLights() {
             assistTestBtn.disabled = true;
             assistTestBtn.classList.add('testing');
             const resolved = ConnectivityManager.resolveEffectiveKey({ type: 'assist' });
-            if (resolved.cacheId && !resolved.secretMasked) {
+            if (resolved.secretMasked) {
+                showMaskedSecretConnectivityNotice();
+            } else if (resolved.cacheId) {
                 const assistSelect = document.getElementById('assistApiSelect');
                 const isFree = assistSelect && assistSelect.value === 'free';
                 ConnectivityManager.keyStatusMap[resolved.cacheId] = LightStatus.TESTING;

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -4337,6 +4337,7 @@
         "testCoreTooltip": "Test Core API Connectivity",
         "testAssist": "Test",
         "testAssistTooltip": "Test Assist API Connectivity",
+        "maskedSecretRetype": "This key is saved but cannot be displayed. Re-enter it before testing.",
         "gsvTestText": "GSV connectivity test",
         "gsvTestTooltip": "Test GPT-SoVITS Connectivity",
         "error": {

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -4337,6 +4337,7 @@
         "testCoreTooltip": "Probar conectividad de API principal",
         "testAssist": "Probar",
         "testAssistTooltip": "Probar conectividad de API auxiliar",
+        "maskedSecretRetype": "La clave está guardada, pero no se puede mostrar. Vuelve a introducirla antes de probar.",
         "gsvTestText": "Prueba de conectividad GSV",
         "gsvTestTooltip": "Probar conectividad de GPT-SoVITS",
         "error": {

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -4337,6 +4337,7 @@
         "testCoreTooltip": "コアAPI接続テスト",
         "testAssist": "テスト",
         "testAssistTooltip": "アシストAPI接続テスト",
+        "maskedSecretRetype": "このキーは保存済みですが表示できません。テストするには再入力してください。",
         "gsvTestText": "GSV接続テスト",
         "gsvTestTooltip": "GPT-SoVITS 接続テスト",
         "error": {

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -4337,6 +4337,7 @@
         "testCoreTooltip": "코어 API 연결 테스트",
         "testAssist": "테스트",
         "testAssistTooltip": "보조 API 연결 테스트",
+        "maskedSecretRetype": "이 키는 저장되어 있지만 표시할 수 없습니다. 테스트하려면 다시 입력하세요.",
         "gsvTestText": "GSV 연결 테스트",
         "gsvTestTooltip": "GPT-SoVITS 연결 테스트",
         "error": {

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -4337,6 +4337,7 @@
         "testCoreTooltip": "Testar conectividade da API principal",
         "testAssist": "Testar",
         "testAssistTooltip": "Testar conectividade da API auxiliar",
+        "maskedSecretRetype": "A chave está salva, mas não pode ser exibida. Digite-a novamente antes de testar.",
         "gsvTestText": "Teste de conectividade GSV",
         "gsvTestTooltip": "Testar conectividade do GPT-SoVITS",
         "error": {

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -4337,6 +4337,7 @@
         "testCoreTooltip": "Тест подключения основного API",
         "testAssist": "Тест",
         "testAssistTooltip": "Тест подключения вспомогательного API",
+        "maskedSecretRetype": "Ключ сохранён, но не может быть показан. Введите его заново перед проверкой.",
         "gsvTestText": "Тест подключения GSV",
         "gsvTestTooltip": "Тест подключения GPT-SoVITS",
         "error": {

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -4337,6 +4337,7 @@
         "testCoreTooltip": "测试核心 API 连通性",
         "testAssist": "测试",
         "testAssistTooltip": "测试辅助 API 连通性",
+        "maskedSecretRetype": "密钥已保存但不可回显，请重新输入后再测试。",
         "gsvTestText": "GSV连通性测试",
         "gsvTestTooltip": "GPT-SoVITS 连通性测试",
         "error": {

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -4337,6 +4337,7 @@
         "testCoreTooltip": "測試核心 API 連通性",
         "testAssist": "測試",
         "testAssistTooltip": "測試輔助 API 連通性",
+        "maskedSecretRetype": "金鑰已儲存但無法顯示，請重新輸入後再測試。",
         "gsvTestText": "GSV 連通性測試",
         "gsvTestTooltip": "GPT-SoVITS 連通性測試",
         "error": {

--- a/tests/frontend/api_key_secret_masking.test.cjs
+++ b/tests/frontend/api_key_secret_masking.test.cjs
@@ -119,6 +119,25 @@ test('editing or deleting the generic mask replaces the preserved secret state',
     assert.equal(context.getRealKey(input), '');
 });
 
+test('partial bullet input fallback cannot become a real key without beforeinput', () => {
+    const context = createInputContext();
+    const input = createFakeInput();
+    context.setMaskedInput(input, context.MASKED_SECRET_SENTINEL_FOR_TEST);
+    context.attachMaskBehavior(input);
+
+    context.document.activeElement = input;
+    input.dispatch('focus');
+    input.value = '••••••';
+    input.dispatch('input');
+    context.document.activeElement = null;
+    input.dispatch('blur');
+
+    assert.equal(input.dataset.realKey, '');
+    assert.equal(input.dataset.maskedSecret, 'true');
+    assert.equal(input.value, context.MASKED_SECRET_DISPLAY_FOR_TEST);
+    assert.equal(context.getRealKey(input), context.MASKED_SECRET_SENTINEL_FOR_TEST);
+});
+
 test('secret loading clears stale masked state when a reload returns an empty value', () => {
     const context = createInputContext();
     const input = createFakeInput();
@@ -137,6 +156,8 @@ test('legacy masks are recognized narrowly without treating arbitrary starred ke
     const context = createInputContext();
 
     assert.equal(context.isMaskedSecretValue(context.MASKED_SECRET_DISPLAY_FOR_TEST), true);
+    assert.equal(context.isMaskedSecretValue('•'), true);
+    assert.equal(context.isMaskedSecretValue('••••••'), true);
     assert.equal(context.isMaskedSecretValue('***'), true);
     assert.equal(context.isMaskedSecretValue('********'), true);
     assert.equal(context.isMaskedSecretValue('abcdef***ghijkl'), true);
@@ -244,4 +265,22 @@ test('all secret-bearing form fields use masked loading and masked save accessor
     assert.match(source, /if \(!coreResult\.secretMasked && coreCacheId/);
     assert.match(source, /if \(!assistResult\.secretMasked && assistCacheId/);
     assert.match(source, /if \(!customResult\.secretMasked && customCacheId/);
+});
+
+test('manual core and assist tests show a localized notice instead of testing masked secrets', () => {
+    const guardedBranches = source.match(
+        /if \(resolved\.secretMasked\) \{\s*showMaskedSecretConnectivityNotice\(\);\s*\} else if \(resolved\.cacheId\) \{/g,
+    ) || [];
+    assert.equal(guardedBranches.length, 2);
+    assert.match(
+        source,
+        /window\.t\('connectivity\.maskedSecretRetype', fallback\)/,
+    );
+
+    for (const locale of ['en', 'ja', 'ko', 'zh-CN', 'zh-TW', 'ru', 'pt', 'es']) {
+        const localePath = path.join(PROJECT_ROOT, 'static', 'locales', `${locale}.json`);
+        const messages = JSON.parse(fs.readFileSync(localePath, 'utf8'));
+        assert.equal(typeof messages.connectivity.maskedSecretRetype, 'string', locale);
+        assert.notEqual(messages.connectivity.maskedSecretRetype.trim(), '', locale);
+    }
 });

--- a/tests/frontend/api_key_secret_masking.test.cjs
+++ b/tests/frontend/api_key_secret_masking.test.cjs
@@ -1,0 +1,247 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const PROJECT_ROOT = path.resolve(__dirname, '..', '..');
+const SOURCE_PATH = path.join(PROJECT_ROOT, 'static', 'js', 'api_key_settings.js');
+const source = fs.readFileSync(SOURCE_PATH, 'utf8');
+
+function sourceBetween(startMarker, endMarker) {
+    const start = source.indexOf(startMarker);
+    const end = source.indexOf(endMarker, start + startMarker.length);
+    assert.notEqual(start, -1, `missing start marker: ${startMarker}`);
+    assert.notEqual(end, -1, `missing end marker: ${endMarker}`);
+    return source.slice(start, end);
+}
+
+function createInputContext() {
+    const document = {
+        activeElement: null,
+        getElementById() { return null; },
+    };
+    const context = vm.createContext({ document });
+    const helperSource = [
+        "const MASKED_SECRET_SENTINEL = '__NEKO_SECRET_MASKED__';",
+        "const MASKED_SECRET_DISPLAY = '••••••••••••';",
+        sourceBetween('function maskApiKey(', '/**\n * 判断后端保留哨兵'),
+        sourceBetween('function isMaskedSecretValue(', '/**\n * 将真实 key 写入'),
+        sourceBetween('function setMaskedInput(', 'function setSecretInputValue('),
+        sourceBetween('function setSecretInputValue(', '/**\n * ⚠️ 重要'),
+        sourceBetween('function getRealKey(', '/**\n * 为 API Key 输入框绑定'),
+        sourceBetween('function attachMaskBehavior(', '// 允许的来源列表'),
+        'globalThis.maskApiKey = maskApiKey;',
+        'globalThis.isMaskedSecretValue = isMaskedSecretValue;',
+        'globalThis.setMaskedInput = setMaskedInput;',
+        'globalThis.setSecretInputValue = setSecretInputValue;',
+        'globalThis.getRealKey = getRealKey;',
+        'globalThis.attachMaskBehavior = attachMaskBehavior;',
+        'globalThis.MASKED_SECRET_SENTINEL_FOR_TEST = MASKED_SECRET_SENTINEL;',
+        'globalThis.MASKED_SECRET_DISPLAY_FOR_TEST = MASKED_SECRET_DISPLAY;',
+    ].join('\n');
+    vm.runInContext(helperSource, context, { filename: SOURCE_PATH });
+    return context;
+}
+
+function createFakeInput() {
+    const listeners = new Map();
+    return {
+        dataset: {},
+        value: '',
+        selected: false,
+        addEventListener(type, listener) {
+            if (!listeners.has(type)) listeners.set(type, []);
+            listeners.get(type).push(listener);
+        },
+        dispatch(type) {
+            for (const listener of listeners.get(type) || []) listener({ type });
+        },
+        select() {
+            this.selected = true;
+        },
+    };
+}
+
+test('masked secret sentinel is displayed generically and round-trips without entering the DOM as a real key', () => {
+    const context = createInputContext();
+    const input = createFakeInput();
+
+    context.setMaskedInput(input, context.MASKED_SECRET_SENTINEL_FOR_TEST);
+    context.attachMaskBehavior(input);
+
+    assert.equal(input.value, context.MASKED_SECRET_DISPLAY_FOR_TEST);
+    assert.equal(input.dataset.realKey, '');
+    assert.equal(input.dataset.maskedSecret, 'true');
+    assert.equal(context.getRealKey(input), context.MASKED_SECRET_SENTINEL_FOR_TEST);
+
+    context.document.activeElement = input;
+    input.dispatch('focus');
+    assert.equal(input.value, context.MASKED_SECRET_DISPLAY_FOR_TEST);
+    assert.equal(input.selected, true);
+    assert.equal(context.getRealKey(input), context.MASKED_SECRET_SENTINEL_FOR_TEST);
+
+    context.document.activeElement = null;
+    input.dispatch('blur');
+    assert.equal(input.value, context.MASKED_SECRET_DISPLAY_FOR_TEST);
+    assert.equal(context.getRealKey(input), context.MASKED_SECRET_SENTINEL_FOR_TEST);
+});
+
+test('editing or deleting the generic mask replaces the preserved secret state', () => {
+    const context = createInputContext();
+    const input = createFakeInput();
+    context.setMaskedInput(input, context.MASKED_SECRET_SENTINEL_FOR_TEST);
+    context.attachMaskBehavior(input);
+
+    context.document.activeElement = input;
+    input.dispatch('focus');
+    input.dispatch('beforeinput');
+    input.value = 'sk-new-user-value';
+    input.dispatch('input');
+    context.document.activeElement = null;
+    input.dispatch('blur');
+
+    assert.equal(input.dataset.maskedSecret, undefined);
+    assert.equal(context.getRealKey(input), 'sk-new-user-value');
+
+    context.setMaskedInput(input, context.MASKED_SECRET_SENTINEL_FOR_TEST);
+    context.document.activeElement = input;
+    input.dispatch('focus');
+    // Backspace/Delete produces beforeinput; the listener clears the reserved state.
+    input.dispatch('beforeinput');
+    input.value = '';
+    input.dispatch('input');
+    context.document.activeElement = null;
+    input.dispatch('blur');
+
+    assert.equal(input.dataset.maskedSecret, undefined);
+    assert.equal(input.value, '');
+    assert.equal(context.getRealKey(input), '');
+});
+
+test('secret loading clears stale masked state when a reload returns an empty value', () => {
+    const context = createInputContext();
+    const input = createFakeInput();
+    context.document.getElementById = id => id === 'mimoTokenPlanKeyInput' ? input : null;
+
+    context.setSecretInputValue('mimoTokenPlanKeyInput', context.MASKED_SECRET_SENTINEL_FOR_TEST);
+    assert.equal(input.dataset.maskedSecret, 'true');
+
+    context.setSecretInputValue('mimoTokenPlanKeyInput', undefined);
+    assert.equal(input.dataset.maskedSecret, undefined);
+    assert.equal(input.dataset.realKey, '');
+    assert.equal(input.value, '');
+});
+
+test('legacy masks are recognized narrowly without treating arbitrary starred keys as placeholders', () => {
+    const context = createInputContext();
+
+    assert.equal(context.isMaskedSecretValue(context.MASKED_SECRET_DISPLAY_FOR_TEST), true);
+    assert.equal(context.isMaskedSecretValue('***'), true);
+    assert.equal(context.isMaskedSecretValue('********'), true);
+    assert.equal(context.isMaskedSecretValue('abcdef***ghijkl'), true);
+    assert.equal(context.isMaskedSecretValue('abcdef*******ghijkl'), true);
+    assert.equal(context.isMaskedSecretValue('abc***def'), false);
+    assert.equal(context.isMaskedSecretValue('abcdef**ghijkl'), false);
+    assert.equal(context.isMaskedSecretValue('abcde****fghijkl'), false);
+    assert.equal(context.isMaskedSecretValue('prefix-a***b-suffix'), false);
+    assert.equal(context.isMaskedSecretValue('sk-live-a***b-extra-long'), false);
+});
+
+test('connectivity testKey refuses the sentinel before making a request', async () => {
+    const connectivitySource = sourceBetween(
+        'const ConnectivityManager = {',
+        '// ==================== 连通性测试：集成初始化 ====================',
+    );
+    let fetchCalls = 0;
+    const context = vm.createContext({
+        console,
+        fetch() {
+            fetchCalls += 1;
+            throw new Error('fetch must not be called for a masked secret');
+        },
+    });
+    vm.runInContext([
+        "const MASKED_SECRET_SENTINEL = '__NEKO_SECRET_MASKED__';",
+        "const MASKED_SECRET_DISPLAY = '••••••••••••';",
+        sourceBetween('function isMaskedSecretValue(', '/**\n * 将真实 key 写入'),
+        connectivitySource,
+        'globalThis.ConnectivityManagerForTest = ConnectivityManager;',
+    ].join('\n'), context, { filename: SOURCE_PATH });
+
+    for (const apiKey of [
+        '__NEKO_SECRET_MASKED__',
+        '••••••••••••',
+        'abcdef***ghijkl',
+    ]) {
+        const result = await context.ConnectivityManagerForTest.testKey({ api_key: apiKey });
+        assert.equal(result.skipped, true);
+        assert.equal(result.success, false);
+    }
+    assert.equal(fetchCalls, 0);
+});
+
+test('switching core providers preserves key-book provenance in the save payload', () => {
+    const context = vm.createContext({});
+    vm.runInContext([
+        sourceBetween('function resolveCoreApiKeyForSave(', 'async function save_button_down('),
+        'globalThis.resolveCoreApiKeyForSaveForTest = resolveCoreApiKeyForSave;',
+        'globalThis.buildKeyBookSecretPayloadForTest = buildKeyBookSecretPayload;',
+    ].join('\n'), context, { filename: SOURCE_PATH });
+
+    const sentinel = '__NEKO_SECRET_MASKED__';
+    const allBookKeys = {
+        qwen: sentinel,
+        openai: sentinel,
+    };
+    const registry = {
+        qwen: { config_field: 'assistApiKeyQwen' },
+        openai: { config_field: 'assistApiKeyOpenai' },
+    };
+    const coreApiKey = context.resolveCoreApiKeyForSaveForTest(
+        'openai',
+        sentinel,
+        allBookKeys,
+        false,
+    );
+    const keyBookPayload = context.buildKeyBookSecretPayloadForTest(allBookKeys, registry);
+
+    // coreApi identifies the selected source. Both book fields remain present so
+    // the backend can preserve the previous provider and copy the selected one.
+    assert.equal(coreApiKey, sentinel);
+    assert.deepEqual(
+        JSON.parse(JSON.stringify(keyBookPayload)),
+        {
+            assistApiKeyQwen: sentinel,
+            assistApiKeyOpenai: sentinel,
+        },
+    );
+    assert.equal(
+        context.resolveCoreApiKeyForSaveForTest('openai', 'sk-new-openai', allBookKeys, true),
+        'sk-new-openai',
+    );
+});
+
+test('all secret-bearing form fields use masked loading and masked save accessors', () => {
+    const modelTypes = [
+        'conversation', 'summary', 'gameMain', 'gameSummary', 'correction',
+        'emotion', 'vision', 'agent', 'omni', 'tts',
+    ];
+    for (const modelType of modelTypes) {
+        assert.match(
+            source,
+            new RegExp(`setSecretInputValue\\('${modelType}ModelApiKey', data\\.${modelType}ModelApiKey\\)`),
+        );
+        assert.doesNotMatch(
+            source,
+            new RegExp(`setInputValue\\('${modelType}ModelApiKey',`),
+        );
+    }
+    assert.match(source, /setSecretInputValue\('mcpTokenInput', data\.mcpToken\)/);
+    assert.match(source, /const mcpToken = getKeyVal\('mcpTokenInput'\)/);
+    assert.match(source, /setSecretInputValue\('mimoTokenPlanKeyInput', data\.assistApiKeyMimoTokenPlan\)/);
+    assert.doesNotMatch(source, /mimoTokenPlanKeyInput && data\.assistApiKeyMimoTokenPlan/);
+    assert.match(source, /if \(!coreResult\.secretMasked && coreCacheId/);
+    assert.match(source, /if \(!assistResult\.secretMasked && assistCacheId/);
+    assert.match(source, /if \(!customResult\.secretMasked && customCacheId/);
+});

--- a/tests/unit/test_api_config_manager.py
+++ b/tests/unit/test_api_config_manager.py
@@ -1976,6 +1976,114 @@ class TestGptsovitsEnabledSaveMigration:
         )
 
     @pytest.mark.unit
+    def test_update_core_config_doubao_tts_masked_noop_preserves_owned_shared_key(
+        self,
+        config_manager,
+        monkeypatch,
+    ):
+        config_router, asyncio = self._neutralize_side_effects(monkeypatch)
+        stored_key = 'ark-doubao-legacy-shared-key'
+        _write_core_config(config_manager, {
+            'coreApi': 'qwen',
+            'assistApi': 'qwen',
+            'enableCustomApi': True,
+            'ttsModelProvider': 'doubao_tts',
+            'ttsModelApiKey': stored_key,
+            'assistApiKeyDoubaoTts': '',
+        })
+
+        loaded = asyncio.run(config_router.get_core_config_api())
+        assert loaded['ttsModelApiKey'] == config_router.CORE_CONFIG_SECRET_SENTINEL
+        assert (
+            loaded['assistApiKeyDoubaoTts']
+            == config_router.CORE_CONFIG_SECRET_SENTINEL
+        )
+
+        resp = asyncio.run(config_router.update_core_config(self._FakeRequest({
+            'enableCustomApi': True,
+            'coreApi': 'qwen',
+            'assistApi': 'qwen',
+            'ttsModelProvider': 'doubao_tts',
+            'ttsModelApiKey': loaded['ttsModelApiKey'],
+            'assistApiKeyDoubaoTts': loaded['assistApiKeyDoubaoTts'],
+        })))
+        assert resp.get('success') is True
+
+        saved = config_manager.load_json_config('core_config.json', {})
+        assert saved['ttsModelApiKey'] == stored_key
+        assert saved['assistApiKeyDoubaoTts'] == ''
+        assert config_router.CORE_CONFIG_SECRET_SENTINEL not in json.dumps(saved)
+
+    @pytest.mark.unit
+    def test_update_core_config_doubao_tts_explicit_clear_removes_owned_shared_key(
+        self,
+        config_manager,
+        monkeypatch,
+    ):
+        config_router, asyncio = self._neutralize_side_effects(monkeypatch)
+        _write_core_config(config_manager, {
+            'coreApi': 'qwen',
+            'assistApi': 'qwen',
+            'enableCustomApi': True,
+            'ttsModelProvider': 'doubao_tts',
+            'ttsModelApiKey': 'ark-doubao-legacy-shared-key',
+            'assistApiKeyDoubaoTts': '',
+        })
+
+        resp = asyncio.run(config_router.update_core_config(self._FakeRequest({
+            'enableCustomApi': True,
+            'coreApi': 'qwen',
+            'assistApi': 'qwen',
+            'ttsModelProvider': 'doubao_tts',
+            'ttsModelApiKey': config_router.CORE_CONFIG_SECRET_SENTINEL,
+            'assistApiKeyDoubaoTts': '',
+        })))
+        assert resp.get('success') is True
+
+        saved = config_manager.load_json_config('core_config.json', {})
+        assert saved['ttsModelApiKey'] == ''
+        assert saved['assistApiKeyDoubaoTts'] == ''
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        ('stored_provider', 'submitted_key'),
+        (
+            ('vllm_omni', 'ark-doubao-explicit-model-key'),
+            ('doubao_tts', ''),
+        ),
+    )
+    def test_update_core_config_doubao_tts_respects_explicit_model_key_update(
+        self,
+        config_manager,
+        monkeypatch,
+        stored_provider,
+        submitted_key,
+    ):
+        config_router, asyncio = self._neutralize_side_effects(monkeypatch)
+        _write_core_config(config_manager, {
+            'coreApi': 'qwen',
+            'assistApi': 'qwen',
+            'enableCustomApi': True,
+            'ttsModelProvider': stored_provider,
+            'ttsModelApiKey': 'previous-shared-key',
+            'assistApiKeyDoubaoTts': '',
+        })
+
+        resp = asyncio.run(config_router.update_core_config(self._FakeRequest({
+            'enableCustomApi': True,
+            'coreApi': 'qwen',
+            'assistApi': 'qwen',
+            'ttsModelProvider': 'doubao_tts',
+            'ttsModelApiKey': submitted_key,
+            'assistApiKeyDoubaoTts': config_router.CORE_CONFIG_SECRET_SENTINEL,
+        })))
+        assert resp.get('success') is True
+
+        saved = config_manager.load_json_config('core_config.json', {})
+        assert saved['ttsModelApiKey'] == submitted_key
+        assert saved['assistApiKeyDoubaoTts'] == ''
+
+    @pytest.mark.unit
     def test_get_model_api_config_returns_kimi_code_provider_type(self, config_manager):
         _write_core_config(config_manager, {
             'coreApi': 'qwen',

--- a/tests/unit/test_api_config_manager.py
+++ b/tests/unit/test_api_config_manager.py
@@ -553,9 +553,8 @@ class TestAssistFollowsCore:
 
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_get_core_config_api_returns_kimi_code_key(self, monkeypatch):
-        """GET must echo back assistApiKeyKimiCode; otherwise the frontend reads
-        an empty value and a re-save overwrites the stored secret."""
+    async def test_get_core_config_api_returns_kimi_code_key_placeholder(self, monkeypatch):
+        """GET reports that the Kimi Code key is configured without exposing it."""
         from main_routers.config_router import core_config as config_router
 
         async def fake_read_json_async(_path):
@@ -580,7 +579,10 @@ class TestAssistFollowsCore:
 
         assert response['success'] is True
         assert response['assistApi'] == 'kimi_code'
-        assert response['assistApiKeyKimiCode'] == 'sk-kimi-code-stored'
+        assert (
+            response['assistApiKeyKimiCode']
+            == config_router.CORE_CONFIG_SECRET_SENTINEL
+        )
 
     @pytest.mark.unit
     def test_free_core_defaults_assist_to_free_when_key_missing(self, config_manager):
@@ -1932,7 +1934,7 @@ class TestGptsovitsEnabledSaveMigration:
         config_manager,
     ):
         import asyncio
-        from main_routers import config_router
+        from main_routers.config_router import core_config as config_router
 
         _write_core_config(config_manager, {
             'coreApi': 'qwen',
@@ -1949,12 +1951,12 @@ class TestGptsovitsEnabledSaveMigration:
         assert resp['assistApiKeyDoubaoTts'] == ''
 
     @pytest.mark.unit
-    def test_get_core_config_api_doubao_tts_display_uses_owned_shared_key(
+    def test_get_core_config_api_doubao_tts_redacts_owned_shared_key(
         self,
         config_manager,
     ):
         import asyncio
-        from main_routers import config_router
+        from main_routers.config_router import core_config as config_router
 
         _write_core_config(config_manager, {
             'coreApi': 'qwen',
@@ -1968,7 +1970,10 @@ class TestGptsovitsEnabledSaveMigration:
         resp = asyncio.run(config_router.get_core_config_api())
 
         assert resp['success'] is True
-        assert resp['assistApiKeyDoubaoTts'] == 'ark-doubao-speech-key'
+        assert (
+            resp['assistApiKeyDoubaoTts']
+            == config_router.CORE_CONFIG_SECRET_SENTINEL
+        )
 
     @pytest.mark.unit
     def test_get_model_api_config_returns_kimi_code_provider_type(self, config_manager):

--- a/tests/unit/test_core_config_secret_redaction.py
+++ b/tests/unit/test_core_config_secret_redaction.py
@@ -1,0 +1,513 @@
+"""Regression tests for secret redaction on ``/api/config/core_api``."""
+
+import asyncio
+import json
+
+import pytest
+
+
+_ASSIST_API_KEY_FIELDS = (
+    'assistApiKeyQwen', 'assistApiKeyQwenIntl', 'assistApiKeyOpenai',
+    'assistApiKeyDeepseek', 'assistApiKeyGlm', 'assistApiKeyStep',
+    'assistApiKeySilicon', 'assistApiKeyGemini', 'assistApiKeyKimi',
+    'assistApiKeyDoubao', 'assistApiKeyDoubaoTts', 'assistApiKeyMinimax',
+    'assistApiKeyMinimaxIntl', 'assistApiKeyMimo',
+    'assistApiKeyMimoTokenPlan', 'assistApiKeyElevenlabs', 'assistApiKeyGrok',
+    'assistApiKeyClaude', 'assistApiKeyKimiCode', 'assistApiKeyOpenrouter',
+)
+
+_MODEL_TYPES = (
+    'conversation', 'summary', 'gameMain', 'gameSummary', 'correction', 'emotion',
+    'vision', 'agent', 'omni', 'tts',
+)
+
+_MODEL_API_KEY_FIELDS = tuple(
+    f'{model_type}ModelApiKey' for model_type in _MODEL_TYPES
+)
+
+_CONFIG_SECRET_FIELDS = (
+    'coreApiKey',
+    *_ASSIST_API_KEY_FIELDS,
+    'mcpToken',
+    *_MODEL_API_KEY_FIELDS,
+)
+
+
+@pytest.fixture()
+def config_manager(clean_user_data_dir):
+    from utils.config_manager import get_config_manager
+
+    manager = get_config_manager('N.E.K.O')
+    manager.config_dir.mkdir(parents=True, exist_ok=True)
+    return manager
+
+
+@pytest.fixture()
+def core_config_router(monkeypatch):
+    from main_routers.config_router import core_config
+
+    async def _noop(*args, **kwargs):
+        return None
+
+    class _FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+        async def post(self, *args, **kwargs):
+            return None
+
+    monkeypatch.setattr(core_config, 'get_session_manager', lambda: {})
+    monkeypatch.setattr(core_config, 'get_initialize_character_data', lambda: _noop)
+    monkeypatch.setattr(core_config, 'ensure_default_yui_voice_for_free_api', _noop)
+    monkeypatch.setattr(core_config, '_auto_resolve_provider_urls_for_save', _noop)
+
+    import httpx
+
+    monkeypatch.setattr(httpx, 'AsyncClient', _FakeAsyncClient)
+    return core_config
+
+
+class _FakeRequest:
+    def __init__(self, payload):
+        self._payload = payload
+
+    async def json(self):
+        return self._payload
+
+
+def _write_core_config(manager, config):
+    manager.save_json_config('core_config.json', config)
+    manager._core_config_cache = None
+
+
+def _stored_config_with_all_secrets(core_config_router):
+    # Keep this explicit test-side inventory independent from the production
+    # constants so accidentally omitting a currently exposed field is caught.
+    assert core_config_router.CORE_CONFIG_ASSIST_API_KEY_FIELDS == _ASSIST_API_KEY_FIELDS
+    assert core_config_router.CORE_CONFIG_MODEL_TYPES == _MODEL_TYPES
+    assert core_config_router.CORE_CONFIG_MODEL_API_KEY_FIELDS == _MODEL_API_KEY_FIELDS
+    assert core_config_router.CORE_CONFIG_SECRET_FIELDS == _CONFIG_SECRET_FIELDS
+
+    config = {
+        field: f'stored-secret-for-{field}'
+        for field in _CONFIG_SECRET_FIELDS
+    }
+    config.update({
+        'coreApi': 'qwen',
+        'assistApi': 'openai',
+        'enableCustomApi': False,
+    })
+    for model_type in _MODEL_TYPES:
+        config[f'{model_type}ModelProvider'] = 'custom'
+        config[f'{model_type}ModelUrl'] = f'https://{model_type}.example.test/v1'
+        config[f'{model_type}ModelId'] = f'{model_type}-model'
+    return config
+
+
+@pytest.mark.unit
+def test_get_redacts_every_core_config_secret(
+    config_manager,
+    core_config_router,
+):
+    stored = _stored_config_with_all_secrets(core_config_router)
+    _write_core_config(config_manager, stored)
+
+    response = asyncio.run(core_config_router.get_core_config_api())
+
+    assert response['success'] is True
+    response_secret_fields = (
+        'api_key',
+        *_ASSIST_API_KEY_FIELDS,
+        'mcpToken',
+        *_MODEL_API_KEY_FIELDS,
+    )
+    assert all(
+        response[field] == core_config_router.CORE_CONFIG_SECRET_SENTINEL
+        for field in response_secret_fields
+    )
+
+    # Provider metadata remains usable while no original credential is exposed.
+    for model_type in _MODEL_TYPES:
+        assert response[f'{model_type}ModelProvider'] == 'custom'
+        assert response[f'{model_type}ModelUrl'] == f'https://{model_type}.example.test/v1'
+        assert response[f'{model_type}ModelId'] == f'{model_type}-model'
+
+    serialized_response = json.dumps(response)
+    for field in _CONFIG_SECRET_FIELDS:
+        assert stored[field] not in serialized_response
+
+
+@pytest.mark.unit
+def test_get_preserves_empty_secrets_and_free_access(
+    config_manager,
+    core_config_router,
+):
+    stored = {
+        field: ''
+        for field in _CONFIG_SECRET_FIELDS
+    }
+    stored.update({
+        'coreApiKey': 'free-access',
+        'coreApi': 'free',
+        'assistApi': 'free',
+    })
+    _write_core_config(config_manager, stored)
+
+    response = asyncio.run(core_config_router.get_core_config_api())
+
+    assert response['success'] is True
+    assert response['api_key'] == 'free-access'
+    for field in (
+        *_ASSIST_API_KEY_FIELDS,
+        'mcpToken',
+        *_MODEL_API_KEY_FIELDS,
+    ):
+        assert response[field] == ''
+
+
+@pytest.mark.unit
+def test_post_sentinel_preserves_every_secret_and_never_persists_it(
+    config_manager,
+    core_config_router,
+):
+    stored = _stored_config_with_all_secrets(core_config_router)
+    _write_core_config(config_manager, stored)
+    payload = {
+        field: core_config_router.CORE_CONFIG_SECRET_SENTINEL
+        for field in _CONFIG_SECRET_FIELDS
+    }
+    payload.update({
+        'coreApi': 'qwen',
+        'assistApi': 'openai',
+        'enableCustomApi': False,
+    })
+
+    response = asyncio.run(
+        core_config_router.update_core_config(_FakeRequest(payload))
+    )
+
+    assert response['success'] is True
+    saved = config_manager.load_json_config('core_config.json', {})
+    for field in _CONFIG_SECRET_FIELDS:
+        assert saved[field] == stored[field]
+    assert core_config_router.CORE_CONFIG_SECRET_SENTINEL not in json.dumps(saved)
+
+
+@pytest.mark.unit
+def test_post_empty_string_explicitly_clears_secrets_when_core_is_optional(
+    config_manager,
+    core_config_router,
+):
+    stored = _stored_config_with_all_secrets(core_config_router)
+    _write_core_config(config_manager, stored)
+    payload = {
+        field: ''
+        for field in _CONFIG_SECRET_FIELDS
+    }
+    payload.update({
+        'coreApi': 'qwen',
+        'assistApi': 'openai',
+        'enableCustomApi': True,
+    })
+
+    response = asyncio.run(
+        core_config_router.update_core_config(_FakeRequest(payload))
+    )
+
+    assert response['success'] is True
+    saved = config_manager.load_json_config('core_config.json', {})
+    for field in _CONFIG_SECRET_FIELDS:
+        assert saved[field] == ''
+
+
+@pytest.mark.unit
+def test_paid_core_still_rejects_explicit_empty_key(
+    config_manager,
+    core_config_router,
+):
+    stored = _stored_config_with_all_secrets(core_config_router)
+    _write_core_config(config_manager, stored)
+
+    response = asyncio.run(core_config_router.update_core_config(_FakeRequest({
+        'coreApiKey': '',
+        'coreApi': 'qwen',
+        'assistApi': 'openai',
+        'enableCustomApi': False,
+    })))
+
+    assert response['success'] is False
+    assert response['error'] == 'API Key不能为空'
+    saved = config_manager.load_json_config('core_config.json', {})
+    assert saved['coreApiKey'] == stored['coreApiKey']
+
+
+@pytest.mark.unit
+def test_paid_core_rejects_placeholder_when_no_key_is_stored(
+    config_manager,
+    core_config_router,
+):
+    stored = _stored_config_with_all_secrets(core_config_router)
+    stored['coreApiKey'] = ''
+    stored['assistApiKeyQwen'] = ''
+    _write_core_config(config_manager, stored)
+
+    response = asyncio.run(core_config_router.update_core_config(_FakeRequest({
+        'coreApiKey': core_config_router.CORE_CONFIG_SECRET_SENTINEL,
+        'coreApi': 'qwen',
+        'assistApi': 'openai',
+        'enableCustomApi': False,
+    })))
+
+    assert response['success'] is False
+    assert response['error'] == 'API Key不能为空'
+
+
+@pytest.mark.unit
+def test_placeholder_promotes_same_provider_key_when_core_key_is_empty(
+    config_manager,
+    core_config_router,
+):
+    _write_core_config(config_manager, {
+        'coreApiKey': '',
+        'coreApi': 'qwen',
+        'assistApi': 'qwen',
+        'assistApiKeyQwen': 'sk-qwen-from-key-book',
+        'enableCustomApi': False,
+    })
+
+    response = asyncio.run(core_config_router.update_core_config(_FakeRequest({
+        'coreApiKey': core_config_router.CORE_CONFIG_SECRET_SENTINEL,
+        'coreApi': 'qwen',
+        'assistApi': 'qwen',
+        'enableCustomApi': False,
+    })))
+
+    assert response['success'] is True
+    saved = config_manager.load_json_config('core_config.json', {})
+    assert saved['coreApiKey'] == 'sk-qwen-from-key-book'
+
+
+@pytest.mark.unit
+def test_provider_key_lookup_rejects_non_assist_secret_fields(core_config_router):
+    registry = {
+        'qwen': {'config_field': 'assistApiKeyQwen'},
+        'vllm_omni': {'config_field': 'ttsModelApiKey'},
+        'unsafe': {'config_field': 'mcpToken'},
+    }
+
+    assert (
+        core_config_router.get_core_config_provider_api_key_field('qwen', registry)
+        == 'assistApiKeyQwen'
+    )
+    assert (
+        core_config_router.get_core_config_provider_api_key_field('vllm_omni', registry)
+        is None
+    )
+    assert (
+        core_config_router.get_core_config_provider_api_key_field('unsafe', registry)
+        is None
+    )
+
+
+@pytest.mark.unit
+def test_provider_switch_preserves_both_provider_keys(
+    config_manager,
+    core_config_router,
+):
+    _write_core_config(config_manager, {
+        'coreApiKey': 'sk-qwen-core',
+        'coreApi': 'qwen',
+        'assistApi': 'qwen',
+        'assistApiKeyQwen': 'sk-qwen-stale',
+        'assistApiKeyOpenai': 'sk-openai-key-book',
+        'enableCustomApi': False,
+    })
+
+    to_openai = asyncio.run(core_config_router.update_core_config(_FakeRequest({
+        'coreApiKey': core_config_router.CORE_CONFIG_SECRET_SENTINEL,
+        'coreApi': 'openai',
+        'assistApi': 'openai',
+        'assistApiKeyQwen': core_config_router.CORE_CONFIG_SECRET_SENTINEL,
+        'assistApiKeyOpenai': core_config_router.CORE_CONFIG_SECRET_SENTINEL,
+        'enableCustomApi': False,
+    })))
+
+    assert to_openai['success'] is True
+    saved = config_manager.load_json_config('core_config.json', {})
+    assert saved['coreApi'] == 'openai'
+    assert saved['coreApiKey'] == 'sk-openai-key-book'
+    assert saved['assistApiKeyQwen'] == 'sk-qwen-core'
+    assert saved['assistApiKeyOpenai'] == 'sk-openai-key-book'
+
+    back_to_qwen = asyncio.run(core_config_router.update_core_config(_FakeRequest({
+        'coreApiKey': core_config_router.CORE_CONFIG_SECRET_SENTINEL,
+        'coreApi': 'qwen',
+        'assistApi': 'qwen',
+        'assistApiKeyQwen': core_config_router.CORE_CONFIG_SECRET_SENTINEL,
+        'assistApiKeyOpenai': core_config_router.CORE_CONFIG_SECRET_SENTINEL,
+        'enableCustomApi': False,
+    })))
+
+    assert back_to_qwen['success'] is True
+    saved = config_manager.load_json_config('core_config.json', {})
+    assert saved['coreApi'] == 'qwen'
+    assert saved['coreApiKey'] == 'sk-qwen-core'
+    assert saved['assistApiKeyQwen'] == 'sk-qwen-core'
+    assert saved['assistApiKeyOpenai'] == 'sk-openai-key-book'
+
+
+@pytest.mark.unit
+def test_provider_switch_preserves_distinct_key_when_old_core_stays_assist(
+    config_manager,
+    core_config_router,
+):
+    _write_core_config(config_manager, {
+        'coreApiKey': 'sk-qwen-core',
+        'coreApi': 'qwen',
+        'assistApi': 'qwen',
+        'assistApiKeyQwen': 'sk-qwen-assist',
+        'assistApiKeyOpenai': 'sk-openai-key-book',
+        'enableCustomApi': False,
+    })
+
+    response = asyncio.run(core_config_router.update_core_config(_FakeRequest({
+        'coreApiKey': core_config_router.CORE_CONFIG_SECRET_SENTINEL,
+        'coreApi': 'openai',
+        'assistApi': 'qwen',
+        'assistApiKeyQwen': core_config_router.CORE_CONFIG_SECRET_SENTINEL,
+        'assistApiKeyOpenai': core_config_router.CORE_CONFIG_SECRET_SENTINEL,
+        'enableCustomApi': False,
+    })))
+
+    assert response['success'] is True
+    saved = config_manager.load_json_config('core_config.json', {})
+    assert saved['coreApiKey'] == 'sk-openai-key-book'
+    assert saved['assistApiKeyQwen'] == 'sk-qwen-assist'
+
+
+@pytest.mark.unit
+def test_provider_switch_backfills_key_when_old_core_stays_assist_and_slot_empty(
+    config_manager,
+    core_config_router,
+):
+    _write_core_config(config_manager, {
+        'coreApiKey': 'sk-qwen-core',
+        'coreApi': 'qwen',
+        'assistApi': 'qwen',
+        'assistApiKeyQwen': '',
+        'assistApiKeyOpenai': 'sk-openai-key-book',
+        'enableCustomApi': False,
+    })
+
+    response = asyncio.run(core_config_router.update_core_config(_FakeRequest({
+        'coreApiKey': core_config_router.CORE_CONFIG_SECRET_SENTINEL,
+        'coreApi': 'openai',
+        'assistApi': 'qwen',
+        'assistApiKeyQwen': core_config_router.CORE_CONFIG_SECRET_SENTINEL,
+        'assistApiKeyOpenai': core_config_router.CORE_CONFIG_SECRET_SENTINEL,
+        'enableCustomApi': False,
+    })))
+
+    assert response['success'] is True
+    saved = config_manager.load_json_config('core_config.json', {})
+    assert saved['coreApiKey'] == 'sk-openai-key-book'
+    assert saved['assistApiKeyQwen'] == 'sk-qwen-core'
+
+
+@pytest.mark.unit
+def test_provider_switch_without_target_key_is_rejected_without_saving(
+    config_manager,
+    core_config_router,
+):
+    stored = {
+        'coreApiKey': 'sk-qwen-core',
+        'coreApi': 'qwen',
+        'assistApi': 'qwen',
+        'assistApiKeyQwen': '',
+        'assistApiKeyOpenai': '',
+        'enableCustomApi': False,
+    }
+    _write_core_config(config_manager, stored)
+
+    response = asyncio.run(core_config_router.update_core_config(_FakeRequest({
+        'coreApiKey': core_config_router.CORE_CONFIG_SECRET_SENTINEL,
+        'coreApi': 'openai',
+        'assistApi': 'openai',
+        'enableCustomApi': False,
+    })))
+
+    assert response['success'] is False
+    assert response['error'] == 'API Key不能为空'
+    assert config_manager.load_json_config('core_config.json', {}) == stored
+
+
+@pytest.mark.unit
+def test_custom_provider_switch_without_target_key_clears_stale_core_key(
+    config_manager,
+    core_config_router,
+):
+    _write_core_config(config_manager, {
+        'coreApiKey': 'sk-qwen-core',
+        'coreApi': 'qwen',
+        'assistApi': 'qwen',
+        'assistApiKeyQwen': '',
+        'assistApiKeyOpenai': '',
+        'enableCustomApi': True,
+    })
+
+    response = asyncio.run(core_config_router.update_core_config(_FakeRequest({
+        'coreApiKey': core_config_router.CORE_CONFIG_SECRET_SENTINEL,
+        'coreApi': 'openai',
+        'assistApi': 'openai',
+        'enableCustomApi': True,
+    })))
+
+    assert response['success'] is True
+    saved = config_manager.load_json_config('core_config.json', {})
+    assert saved['coreApi'] == 'openai'
+    assert saved['coreApiKey'] == ''
+    assert saved['assistApiKeyQwen'] == 'sk-qwen-core'
+    assert saved['assistApiKeyOpenai'] == ''
+
+
+@pytest.mark.unit
+def test_legacy_masks_are_narrowly_recognized_as_placeholders(
+    config_manager,
+    core_config_router,
+):
+    assert core_config_router.is_core_config_secret_placeholder('********') is True
+    assert core_config_router.is_core_config_secret_placeholder('*') is False
+    assert core_config_router.is_core_config_secret_placeholder('**') is False
+    assert (
+        core_config_router.is_core_config_secret_placeholder('abcdef***uvwxyz')
+        is True
+    )
+    assert (
+        core_config_router.is_core_config_secret_placeholder('real***secret')
+        is False
+    )
+
+    stored = _stored_config_with_all_secrets(core_config_router)
+    _write_core_config(config_manager, stored)
+    response = asyncio.run(core_config_router.update_core_config(_FakeRequest({
+        'coreApiKey': 'abcdef***uvwxyz',
+        'assistApiKeyQwen': '********',
+        'assistApiKeyOpenai': '**',
+        'mcpToken': 'real***secret',
+        'coreApi': 'qwen',
+        'assistApi': 'openai',
+        'enableCustomApi': False,
+    })))
+
+    assert response['success'] is True
+    saved = config_manager.load_json_config('core_config.json', {})
+    assert saved['coreApiKey'] == stored['coreApiKey']
+    assert saved['assistApiKeyQwen'] == stored['assistApiKeyQwen']
+    assert saved['assistApiKeyOpenai'] == '**'
+    assert saved['mcpToken'] == 'real***secret'

--- a/tests/unit/test_host_origin_guard.py
+++ b/tests/unit/test_host_origin_guard.py
@@ -1,0 +1,311 @@
+# -*- coding: utf-8 -*-
+"""Tests for the DNS-rebinding Host and WebSocket Origin guard."""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from utils.host_origin_guard import HostOriginGuardMiddleware
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _scope(
+    scope_type: str,
+    host: str | None,
+    *,
+    origin: str | None = None,
+    scheme: str | None = None,
+    client=("127.0.0.1", 41000),
+    extra_headers=(),
+):
+    headers = []
+    if host is not None:
+        headers.append((b"host", host.encode("ascii")))
+    if origin is not None:
+        headers.append((b"origin", origin.encode("ascii")))
+    headers.extend(extra_headers)
+    return {
+        "type": scope_type,
+        "scheme": scheme or ("ws" if scope_type == "websocket" else "http"),
+        "method": "GET",
+        "path": "/probe",
+        "headers": headers,
+        "client": client,
+        "server": ("127.0.0.1", 48911),
+    }
+
+
+async def _drive(middleware, scope):
+    called = {"hit": False}
+
+    async def downstream(_scope, _receive, _send):
+        called["hit"] = True
+        if _scope["type"] == "websocket":
+            await _send({"type": "websocket.accept"})
+        else:
+            await _send({"type": "http.response.start", "status": 200, "headers": []})
+            await _send({"type": "http.response.body", "body": b"ok"})
+
+    middleware.app = downstream
+
+    async def receive():
+        if scope["type"] == "websocket":
+            return {"type": "websocket.connect"}
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    await middleware(scope, receive, send)
+    return called["hit"], sent
+
+
+def _make(*, trusted_hosts="", trusted_origins=""):
+    return HostOriginGuardMiddleware(
+        app=None,
+        trusted_hosts=trusted_hosts,
+        trusted_origins=trusted_origins,
+    )
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "localhost",
+        "localhost:48911",
+        "127.0.0.1:48911",
+        "192.168.10.25:48911",
+        "[::1]:48911",
+        "[2001:db8::25]:48911",
+        "::1",
+    ],
+)
+def test_http_accepts_loopback_and_ip_literal_hosts(host):
+    hit, sent = _run(_drive(_make(), _scope("http", host)))
+    assert hit is True
+    assert sent[0]["status"] == 200
+
+
+def test_http_rejects_dns_rebinding_hostname():
+    hit, sent = _run(_drive(_make(), _scope("http", "attacker.example:48911")))
+    assert hit is False
+    assert sent[0]["type"] == "http.response.start"
+    assert sent[0]["status"] == 400
+    payload = json.loads(sent[1]["body"])
+    assert payload["error_code"] == "untrusted_host"
+
+
+@pytest.mark.parametrize(
+    "host",
+    [None, "[::1", "localhost:0", "localhost:65536", "bad_host.example"],
+)
+def test_http_rejects_missing_or_malformed_host(host):
+    hit, sent = _run(_drive(_make(), _scope("http", host)))
+    assert hit is False
+    assert sent[0]["status"] == 400
+
+
+def test_http_rejects_duplicate_host_headers():
+    scope = _scope("http", "localhost", extra_headers=[(b"host", b"127.0.0.1")])
+    hit, sent = _run(_drive(_make(), scope))
+    assert hit is False
+    assert sent[0]["status"] == 400
+
+
+def test_explicit_trusted_host_and_subdomain_pattern_are_allowed():
+    middleware = _make(trusted_hosts="neko.example:8443,*.internal.example")
+
+    exact_hit, _ = _run(
+        _drive(middleware, _scope("http", "neko.example:8443", scheme="https"))
+    )
+    wildcard_hit, _ = _run(
+        _drive(middleware, _scope("http", "desktop.internal.example:48911"))
+    )
+    bare_suffix_hit, sent = _run(
+        _drive(middleware, _scope("http", "internal.example:48911"))
+    )
+
+    assert exact_hit is True
+    assert wildcard_hit is True
+    assert bare_suffix_hit is False
+    assert sent[0]["status"] == 400
+
+
+def test_global_trusted_host_wildcard_is_ignored():
+    hit, sent = _run(
+        _drive(_make(trusted_hosts="*"), _scope("http", "attacker.example"))
+    )
+    assert hit is False
+    assert sent[0]["status"] == 400
+
+
+def test_trusted_hosts_are_loaded_from_environment(monkeypatch):
+    monkeypatch.setenv("NEKO_TRUSTED_HOSTS", "proxy.neko.example")
+    monkeypatch.delenv("NEKO_TRUSTED_ORIGINS", raising=False)
+    middleware = HostOriginGuardMiddleware(app=None)
+
+    hit, _ = _run(_drive(middleware, _scope("http", "proxy.neko.example")))
+    assert hit is True
+
+
+def test_testserver_is_limited_to_starlette_testclient_scope():
+    testclient_scope = _scope(
+        "http", "testserver", client=("testclient", 50000)
+    )
+    production_scope = _scope("http", "testserver", client=("127.0.0.1", 50000))
+
+    testclient_hit, _ = _run(_drive(_make(), testclient_scope))
+    production_hit, sent = _run(_drive(_make(), production_scope))
+
+    assert testclient_hit is True
+    assert production_hit is False
+    assert sent[0]["status"] == 400
+
+
+def test_http_only_checks_host_not_origin():
+    hit, sent = _run(
+        _drive(
+            _make(),
+            _scope("http", "127.0.0.1:48911", origin="https://attacker.example"),
+        )
+    )
+    assert hit is True
+    assert sent[0]["status"] == 200
+
+
+def test_websocket_without_origin_is_allowed_for_native_clients():
+    hit, sent = _run(
+        _drive(_make(), _scope("websocket", "127.0.0.1:48911"))
+    )
+    assert hit is True
+    assert sent[0]["type"] == "websocket.accept"
+
+
+@pytest.mark.parametrize(
+    ("host", "origin"),
+    [
+        ("127.0.0.1:48911", "http://127.0.0.1:48911"),
+        ("[::1]:48911", "http://[::1]:48911"),
+    ],
+)
+def test_websocket_same_origin_is_allowed(host, origin):
+    hit, sent = _run(
+        _drive(_make(), _scope("websocket", host, origin=origin))
+    )
+    assert hit is True
+    assert sent[0]["type"] == "websocket.accept"
+
+
+def test_websocket_loopback_origins_can_cross_local_aliases_and_ports():
+    hit, sent = _run(
+        _drive(
+            _make(),
+            _scope(
+                "websocket",
+                "127.0.0.1:48916",
+                origin="http://localhost:48911",
+            ),
+        )
+    )
+    assert hit is True
+    assert sent[0]["type"] == "websocket.accept"
+
+
+def test_websocket_cross_origin_is_rejected_with_policy_violation():
+    hit, sent = _run(
+        _drive(
+            _make(),
+            _scope(
+                "websocket",
+                "192.168.10.25:48911",
+                origin="https://attacker.example",
+            ),
+        )
+    )
+    assert hit is False
+    assert sent == [{"type": "websocket.close", "code": 1008}]
+
+
+def test_websocket_duplicate_or_malformed_origin_is_rejected():
+    duplicate_scope = _scope(
+        "websocket",
+        "127.0.0.1:48911",
+        origin="http://127.0.0.1:48911",
+        extra_headers=[(b"origin", b"http://localhost:48911")],
+    )
+    malformed_scope = _scope(
+        "websocket", "127.0.0.1:48911", origin="null"
+    )
+
+    duplicate_hit, duplicate_sent = _run(_drive(_make(), duplicate_scope))
+    malformed_hit, malformed_sent = _run(_drive(_make(), malformed_scope))
+
+    assert duplicate_hit is False
+    assert duplicate_sent[0]["code"] == 1008
+    assert malformed_hit is False
+    assert malformed_sent[0]["code"] == 1008
+
+
+@pytest.mark.parametrize(
+    ("configured_origin", "browser_origin"),
+    [
+        ("https://ui.neko.example", "https://ui.neko.example:443"),
+        ("https://ui.neko.example:443", "https://ui.neko.example"),
+    ],
+)
+def test_websocket_explicit_origin_allowlist_normalizes_default_port(
+    configured_origin, browser_origin, monkeypatch
+):
+    monkeypatch.setenv("NEKO_TRUSTED_ORIGINS", configured_origin)
+    monkeypatch.delenv("NEKO_TRUSTED_HOSTS", raising=False)
+    middleware = HostOriginGuardMiddleware(app=None)
+    hit, sent = _run(
+        _drive(
+            middleware,
+            _scope(
+                "websocket",
+                "192.168.10.25:48916",
+                origin=browser_origin,
+            ),
+        )
+    )
+    assert hit is True
+    assert sent[0]["type"] == "websocket.accept"
+
+
+def test_secure_websocket_requires_https_same_origin():
+    middleware = _make(trusted_hosts="neko.example")
+    secure_scope = _scope(
+        "websocket",
+        "neko.example",
+        origin="https://neko.example",
+        scheme="wss",
+    )
+    insecure_scope = _scope(
+        "websocket",
+        "neko.example",
+        origin="http://neko.example",
+        scheme="wss",
+    )
+
+    secure_hit, _ = _run(_drive(middleware, secure_scope))
+    insecure_hit, sent = _run(_drive(middleware, insecure_scope))
+
+    assert secure_hit is True
+    assert insecure_hit is False
+    assert sent[0]["code"] == 1008
+
+
+def test_lifespan_scope_passes_through():
+    middleware = _make()
+    hit, _ = _run(
+        _drive(middleware, {"type": "lifespan", "headers": []})
+    )
+    assert hit is True

--- a/utils/host_origin_guard.py
+++ b/utils/host_origin_guard.py
@@ -1,0 +1,360 @@
+# -*- coding: utf-8 -*-
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ASGI Host and WebSocket Origin guard for local N.E.K.O services.
+
+The desktop services intentionally accept requests addressed to loopback and
+IP literals.  IP literals cannot be changed by DNS rebinding, while allowing
+them keeps LAN access and Docker's published ports working.  DNS hostnames are
+denied by default and can be enabled explicitly with ``NEKO_TRUSTED_HOSTS``.
+
+Web browsers do not apply CORS to WebSocket handshakes.  For that reason a
+present WebSocket ``Origin`` must be same-origin, another loopback origin, or
+listed in ``NEKO_TRUSTED_ORIGINS``.  A missing Origin is retained for native
+clients, which do not provide the browser attack primitive this guard targets.
+
+Both environment variables are comma-separated.  Trusted hosts accept an
+exact hostname (optionally with a port) or a ``*.example.com`` subdomain
+pattern.  Trusted origins must be complete ``http://`` or ``https://`` origins.
+"""
+from __future__ import annotations
+
+import ipaddress
+import json
+import os
+import re
+from dataclasses import dataclass
+from urllib.parse import urlsplit
+
+TRUSTED_HOSTS_ENV = "NEKO_TRUSTED_HOSTS"
+TRUSTED_ORIGINS_ENV = "NEKO_TRUSTED_ORIGINS"
+
+_HOST_LABEL_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
+_HTTP_DEFAULT_PORTS = {"http": 80, "https": 443, "ws": 80, "wss": 443}
+
+
+@dataclass(frozen=True)
+class _Authority:
+    hostname: str
+    port: int | None
+    ip: ipaddress.IPv4Address | ipaddress.IPv6Address | None = None
+
+    @property
+    def is_loopback(self) -> bool:
+        if self.ip is not None:
+            return self.ip.is_loopback
+        return self.hostname == "localhost"
+
+
+@dataclass(frozen=True)
+class _TrustedHost:
+    hostname: str
+    port: int | None
+    wildcard: bool = False
+
+
+@dataclass(frozen=True)
+class _Origin:
+    scheme: str
+    authority: _Authority
+
+
+def _canonicalize_hostname(
+    value: str,
+) -> tuple[str, ipaddress.IPv4Address | ipaddress.IPv6Address | None] | None:
+    if not value or "%" in value:
+        # Scoped IPv6 addresses are not valid DNS-rebinding targets, but their
+        # multiple wire spellings make exact Origin comparisons error-prone.
+        return None
+
+    try:
+        parsed_ip = ipaddress.ip_address(value)
+    except ValueError:
+        parsed_ip = None
+
+    if parsed_ip is not None:
+        return str(parsed_ip).lower(), parsed_ip
+
+    hostname = value.rstrip(".")
+    if not hostname:
+        return None
+    try:
+        hostname = hostname.encode("idna").decode("ascii").lower()
+    except (UnicodeError, UnicodeDecodeError):
+        return None
+
+    if len(hostname) > 253:
+        return None
+    labels = hostname.split(".")
+    if any(not _HOST_LABEL_RE.fullmatch(label) for label in labels):
+        return None
+    return hostname, None
+
+
+def _parse_port(value: str) -> int | None:
+    if not value or not value.isascii() or not value.isdecimal():
+        return None
+    port = int(value)
+    if not 1 <= port <= 65535:
+        return None
+    return port
+
+
+def _parse_authority(value: str) -> _Authority | None:
+    """Parse an HTTP authority without relying on Starlette's Host parser."""
+    if not value or value != value.strip():
+        return None
+    if any(ord(char) <= 0x20 or char in "/\\?#@," for char in value):
+        return None
+
+    hostname_text: str
+    port: int | None = None
+    if value.startswith("["):
+        closing = value.find("]")
+        if closing <= 1:
+            return None
+        hostname_text = value[1:closing]
+        remainder = value[closing + 1 :]
+        if remainder:
+            if not remainder.startswith(":"):
+                return None
+            port = _parse_port(remainder[1:])
+            if port is None:
+                return None
+        canonical = _canonicalize_hostname(hostname_text)
+        if canonical is None or not isinstance(canonical[1], ipaddress.IPv6Address):
+            return None
+    else:
+        # A bare IPv6 literal has several colons and no unambiguous port.  It is
+        # accepted for tolerant native clients; standards-compliant HTTP clients
+        # use the bracketed form handled above.
+        canonical = _canonicalize_hostname(value)
+        if canonical is not None and isinstance(canonical[1], ipaddress.IPv6Address):
+            hostname_text = value
+        else:
+            if value.count(":") > 1:
+                return None
+            if ":" in value:
+                hostname_text, port_text = value.rsplit(":", 1)
+                port = _parse_port(port_text)
+                if port is None:
+                    return None
+            else:
+                hostname_text = value
+            canonical = _canonicalize_hostname(hostname_text)
+            if canonical is None:
+                return None
+
+    hostname, parsed_ip = canonical
+    return _Authority(hostname=hostname, port=port, ip=parsed_ip)
+
+
+def _parse_origin(value: str) -> _Origin | None:
+    if not value or value != value.strip():
+        return None
+    if any(ord(char) <= 0x20 or char == "\\" for char in value):
+        return None
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return None
+
+    scheme = parsed.scheme.lower()
+    if scheme not in {"http", "https"}:
+        return None
+    if not parsed.netloc or parsed.username is not None or parsed.password is not None:
+        return None
+    if parsed.path not in {"", "/"} or parsed.query or parsed.fragment:
+        return None
+
+    authority = _parse_authority(parsed.netloc)
+    if authority is None:
+        return None
+    return _Origin(scheme=scheme, authority=authority)
+
+
+def _read_trusted_hosts(value: str | None) -> tuple[_TrustedHost, ...]:
+    trusted: list[_TrustedHost] = []
+    for raw_item in (value or "").split(","):
+        item = raw_item.strip()
+        if not item or item == "*":
+            # A global wildcard would restore the DNS-rebinding vulnerability.
+            continue
+        wildcard = item.startswith("*.")
+        authority = _parse_authority(item[2:] if wildcard else item)
+        if authority is None or (wildcard and authority.ip is not None):
+            continue
+        trusted.append(
+            _TrustedHost(
+                hostname=authority.hostname,
+                port=authority.port,
+                wildcard=wildcard,
+            )
+        )
+    return tuple(trusted)
+
+
+def _read_trusted_origins(value: str | None) -> tuple[_Origin, ...]:
+    origins: list[_Origin] = []
+    for raw_item in (value or "").split(","):
+        origin = _parse_origin(raw_item.strip())
+        if origin is not None and origin not in origins:
+            origins.append(origin)
+    return tuple(origins)
+
+
+def _header_values(scope, name: bytes) -> list[str] | None:
+    values: list[str] = []
+    for key, value in scope.get("headers") or ():
+        if not isinstance(key, bytes) or not isinstance(value, bytes):
+            return None
+        if key.lower() != name:
+            continue
+        try:
+            values.append(value.decode("ascii"))
+        except UnicodeDecodeError:
+            return None
+    return values
+
+
+def _effective_port(authority: _Authority, scheme: str) -> int | None:
+    return authority.port if authority.port is not None else _HTTP_DEFAULT_PORTS.get(scheme)
+
+
+def _origins_match(left: _Origin, right: _Origin) -> bool:
+    return (
+        left.scheme == right.scheme
+        and left.authority.hostname == right.authority.hostname
+        and _effective_port(left.authority, left.scheme)
+        == _effective_port(right.authority, right.scheme)
+    )
+
+
+class HostOriginGuardMiddleware:
+    """Block DNS-rebinding Host values and cross-origin browser WebSockets."""
+
+    def __init__(
+        self,
+        app,
+        *,
+        trusted_hosts: str | None = None,
+        trusted_origins: str | None = None,
+    ):
+        self.app = app
+        self.trusted_hosts = _read_trusted_hosts(
+            os.getenv(TRUSTED_HOSTS_ENV) if trusted_hosts is None else trusted_hosts
+        )
+        self.trusted_origins = _read_trusted_origins(
+            os.getenv(TRUSTED_ORIGINS_ENV) if trusted_origins is None else trusted_origins
+        )
+
+    async def __call__(self, scope, receive, send):
+        scope_type = scope.get("type")
+        if scope_type not in {"http", "websocket"}:
+            await self.app(scope, receive, send)
+            return
+
+        host_values = _header_values(scope, b"host")
+        if host_values is None or len(host_values) != 1:
+            await self._reject(scope_type, send)
+            return
+        authority = _parse_authority(host_values[0])
+        if authority is None or not self._host_is_allowed(authority, scope):
+            await self._reject(scope_type, send)
+            return
+
+        if scope_type == "websocket" and not self._websocket_origin_is_allowed(
+            authority, scope
+        ):
+            await self._reject(scope_type, send)
+            return
+
+        await self.app(scope, receive, send)
+
+    def _host_is_allowed(self, authority: _Authority, scope) -> bool:
+        if authority.ip is not None or authority.hostname == "localhost":
+            return True
+
+        # Starlette's TestClient uses this exact synthetic pair.  Restricting
+        # both sides prevents "testserver" becoming a production hostname.
+        client = scope.get("client")
+        if (
+            authority.hostname == "testserver"
+            and isinstance(client, (tuple, list))
+            and len(client) >= 1
+            and client[0] == "testclient"
+        ):
+            return True
+
+        request_scheme = str(scope.get("scheme") or "http").lower()
+        request_port = _effective_port(authority, request_scheme)
+        for trusted in self.trusted_hosts:
+            hostname_matches = authority.hostname == trusted.hostname
+            if trusted.wildcard:
+                hostname_matches = authority.hostname.endswith("." + trusted.hostname)
+            if not hostname_matches:
+                continue
+            if trusted.port is None or trusted.port == request_port:
+                return True
+        return False
+
+    def _websocket_origin_is_allowed(self, host: _Authority, scope) -> bool:
+        origin_values = _header_values(scope, b"origin")
+        if origin_values is None or len(origin_values) > 1:
+            return False
+        if not origin_values:
+            return True
+
+        origin = _parse_origin(origin_values[0])
+        if origin is None:
+            return False
+
+        websocket_scheme = str(scope.get("scheme") or "ws").lower()
+        expected_origin_scheme = "https" if websocket_scheme == "wss" else "http"
+        if (
+            origin.scheme == expected_origin_scheme
+            and origin.authority.hostname == host.hostname
+            and _effective_port(origin.authority, origin.scheme)
+            == _effective_port(host, websocket_scheme)
+        ):
+            return True
+
+        # Local frontends legitimately connect across N.E.K.O's loopback ports
+        # and may mix localhost with 127.0.0.1 / ::1.
+        if host.is_loopback and origin.authority.is_loopback:
+            return True
+
+        return any(_origins_match(origin, trusted) for trusted in self.trusted_origins)
+
+    async def _reject(self, scope_type: str, send) -> None:
+        if scope_type == "websocket":
+            await send({"type": "websocket.close", "code": 1008})
+            return
+
+        body = json.dumps(
+            {"ok": False, "error_code": "untrusted_host", "error": "Invalid Host header"},
+            separators=(",", ":"),
+        ).encode("utf-8")
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 400,
+                "headers": [
+                    (b"content-type", b"application/json; charset=utf-8"),
+                    (b"content-length", str(len(body)).encode("ascii")),
+                    (b"connection", b"close"),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": body, "more_body": False})


### PR DESCRIPTION
## 改动概述 / Summary

对 `/api/config/core_api` 返回的全部 API Key 和 Token 统一脱敏，避免明文泄露。

支持遮罩值安全回传、显式清空及 provider 切换，确保 sentinel 不会写入配置。

为 main、memory、agent/tool 和 plugin server 增加 Host 校验及 WebSocket Origin 防护，阻止 DNS rebinding。

完善前端密钥遮罩、编辑、清空及 Key Book 切换逻辑，避免遮罩值被发送到连通性接口。

增加 Docker 反向代理域名兼容、环境变量文档和相关回归测试。

Closes #2558

## 回归报告 / Regression Report

改动内容：在 main、memory、agent/tool 服务入口接入统一的 Host/Origin 中间件。配置接口不再向前端返回真实密钥，前后端改用固定 sentinel 表示“已配置”。

理由 / 必要性：原接口会明文返回全部服务商密钥，且没有 Host 校验，浏览器可通过 DNS rebinding 读取这些凭据。脱敏后必须同步处理保存、provider 切换和前端输入状态，否则可能覆盖或错配已有密钥。

改动前后的表现对比：改动前，伪造 Host、恶意 WebSocket Origin 均可访问，配置接口返回真实密钥；改动后，未受信任 Host 返回 400，恶意 WebSocket Origin 被拒绝，已配置密钥仅返回 sentinel。

潜在回归点：使用自定义域名或 mDNS 名称访问时，需要通过 `NEKO_TRUSTED_HOSTS` 显式允许；loopback 和 IP 地址不受影响，Docker 会自动允许 `SSL_DOMAIN`。浏览器没有真实密钥时会跳过已有密钥的连通性检测并提示重新输入，避免将 sentinel 当成凭据发送。Doubao TTS 的遮罩回传、显式更新、显式清空及跨 provider 切换均已补充回归覆盖。

## 测试 / Testing

- 修复分支原有相关后端回归：381 passed。
- 配置、脱敏与 Host 审查修复回归：161 passed。
- 全部前端 Node 测试：44 passed。
- Plugin Host/代理定向回归：3 passed；Host guard 定向回归：29 passed。
- Ruff、JavaScript 语法检查及 `git diff --check` 通过。
- 真实服务验证：32 个敏感字段均未返回明文。
- main/memory 正常 Host 返回 200，伪造 Host 返回 400。
- 原生客户端和本地 WebSocket Origin 正常连接，恶意 Origin 被拒绝。
- sentinel POST 成功，32 个敏感字段保存前后保持一致，sentinel 未写入配置。
- 主分支对照：现有后端测试 338 passed，前端测试 35 passed；配置接口仍返回明文，伪造 Host 返回 200，恶意 WebSocket Origin 可连接，确认修复前问题可稳定复现。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增主机与 WebSocket 来源校验中间件，拒绝不可信请求，降低 DNS 重绑定与跨源风险。
  * 新增受信主机/受信来源配置（支持通配符、端口与安全协议规则），并在 Docker 启动时默认关联现有域名。
* **改进**
  * API Key/MCP token 输入与回显加入安全掩码哨兵：界面不再回显明文，连通性测试对掩码密钥跳过并提示重新输入。
  * 核心配置接口敏感字段统一脱敏占位符与保存/清除语义更可靠。
* **文档**
  * 补充 `NEKO_TRUSTED_HOSTS` / `NEKO_TRUSTED_ORIGINS` 规则与说明。
* **测试**
  * 新增主机来源守护、密钥掩码、敏感配置脱敏与落盘一致性等覆盖用例。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->