### PR TITLE
fix(arbiter): gate dispatch after queue selection

### DIFF
--- a/main_logic/omni_realtime_client/_response_arbiter.py
+++ b/main_logic/omni_realtime_client/_response_arbiter.py
@@ -1,14 +1,8 @@
 """Serialize client-initiated realtime responses across their full lifecycle.
 
-CPython 3.11 only, and this module is why. The queue worker dequeues
-BEFORE re-checking ``_dispatch_allowed``, so a ``pause_dispatch()`` landing
-between those two points is only honored because of 3.11's task-yield
-ordering. On 3.12+ that ordering changes and proactive chat can jump the
-queue ahead of user speech. ``pyproject.toml`` pins ``requires-python`` to
-``==3.11.*`` for this reason and
-``tests/unit/test_realtime_arbiter_native_path.py`` fails if the pin is
-widened. The real fix is #2516: gate the dequeue on ``_dispatch_allowed``
-AFTER ``_next_queued`` and requeue. Do that before touching the pin.
+Dispatch permission is checked both before and after queue selection. If a
+pause lands while an item is being selected, that item is returned to the
+queue without consuming any fairness allowance.
 """
 
 from __future__ import annotations
@@ -853,8 +847,10 @@ class RealtimeResponseArbiter:
                 type(exc).__name__,
             )
 
-    async def _next_queued(self) -> _QueuedResponse:
-        """Select fairly: a lower-priority item may be bypassed at most 3 times."""
+    async def _next_queued(
+        self,
+    ) -> tuple[_QueuedResponse, tuple[_QueuedResponse, ...]]:
+        """Select fairly, deferring bypass accounting until dispatch is allowed."""
 
         candidates = [await self._queue.get()]
         while True:
@@ -868,13 +864,13 @@ class RealtimeResponseArbiter:
             selected = min(starved, key=lambda item: item.sequence)
         else:
             selected = min(candidates, key=lambda item: (item.priority, item.sequence))
-        for candidate in candidates:
-            if candidate is selected:
-                continue
-            candidate.bypass_count += 1
-            self._queue.task_done()
+        bypassed = tuple(
+            candidate for candidate in candidates if candidate is not selected
+        )
+        for candidate in bypassed:
             self._queue.put_nowait(candidate)
-        return selected
+            self._queue.task_done()
+        return selected, bypassed
 
     def _ensure_worker(self) -> None:
         if self._worker is None or self._worker.done():
@@ -887,7 +883,13 @@ class RealtimeResponseArbiter:
             await self._dispatch_allowed.wait()
             if not self._connection_available:
                 return
-            queued = await self._next_queued()
+            queued, bypassed = await self._next_queued()
+            if not self._dispatch_allowed.is_set():
+                self._queue.put_nowait(queued)
+                self._queue.task_done()
+                continue
+            for candidate in bypassed:
+                candidate.bypass_count += 1
             try:
                 await self._process(queued)
             finally:

--- a/main_logic/omni_realtime_client/_response_arbiter.py
+++ b/main_logic/omni_realtime_client/_response_arbiter.py
@@ -2,7 +2,9 @@
 
 Dispatch permission is checked both before and after queue selection. If a
 pause lands while an item is being selected, that item is returned to the
-queue without consuming any fairness allowance.
+queue without consuming any fairness allowance. After resolving a ticket's
+``sent`` future, the worker explicitly yields to its waiter before selecting
+more work so that an external-turn hand-off can restore a newer pause.
 """
 
 from __future__ import annotations
@@ -894,6 +896,13 @@ class RealtimeResponseArbiter:
                 await self._process(queued)
             finally:
                 self._queue.task_done()
+            if queued.ticket.sent.done():
+                # Resolving ``ticket.sent`` schedules callers that may need to
+                # restore a newer external-turn pause. ``sleep(0)`` always
+                # suspends the current task, unlike ``wait_for`` on an already
+                # completed future on Python 3.12+, so the waiter runs before
+                # this worker can select another queued response.
+                await asyncio.sleep(0)
 
     async def _wait_for_dispatch_or_interrupt(
         self,

--- a/main_logic/omni_realtime_client/_responses.py
+++ b/main_logic/omni_realtime_client/_responses.py
@@ -268,16 +268,9 @@ class _ResponseMixin:
         # turn is present, so queued proactive work cannot win the race. An
         # older completed turn may still be ahead of a newer paused turn in
         # the serial transcript dispatcher; let that ticket through, then
-        # restore the newer pause before lower-priority work can run.
-        # NOTE(py3.11): the resume -> await sent -> re-pause hand-off below
-        # relies on the arbiter worker suspending between resolving
-        # ``ticket.sent`` and dequeuing its next queued item, so the re-pause
-        # lands before lower-priority work can pass the dispatch gate. That
-        # holds on the pinned Python 3.11 event loop (3.11's ``wait_for``
-        # always yields once even on a done future) but is not a documented
-        # asyncio guarantee on 3.12+ (the rewritten ``wait_for`` awaits a done
-        # future without suspending). A structural fix needs the arbiter
-        # itself to gate every dequeue on the active external-turn pause.
+        # restore the newer pause. The arbiter rechecks the gate after queue
+        # selection and returns blocked work without charging its fairness
+        # allowance, so this hand-off does not depend on task-yield ordering.
         active_pause_id = getattr(self, "_external_voice_turn_pause_id", None)
         if active_pause_id == stable_turn_id:
             self._external_voice_turn_pause_id = None

--- a/main_logic/omni_realtime_client/_responses.py
+++ b/main_logic/omni_realtime_client/_responses.py
@@ -268,9 +268,10 @@ class _ResponseMixin:
         # turn is present, so queued proactive work cannot win the race. An
         # older completed turn may still be ahead of a newer paused turn in
         # the serial transcript dispatcher; let that ticket through, then
-        # restore the newer pause. The arbiter rechecks the gate after queue
-        # selection and returns blocked work without charging its fairness
-        # allowance, so this hand-off does not depend on task-yield ordering.
+        # restore the newer pause. Before selecting again, the arbiter
+        # explicitly yields to this ticket's waiter; its post-selection gate
+        # then returns any concurrently blocked work without charging the
+        # fairness allowance.
         active_pause_id = getattr(self, "_external_voice_turn_pause_id", None)
         if active_pause_id == stable_turn_id:
             self._external_voice_turn_pause_id = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,12 +7,6 @@ name = "N.E.K.O"
 dynamic = ["version"]
 description = "N.E.K.O. Desktop"
 readme = "README.MD"
-# Pinned to 3.11 exactly, not >=3.11. Raising this is a gated change, not a
-# routine bump: RealtimeResponseArbiter's resume -> await -> re-pause hand-off
-# relies on 3.11's undocumented task-yield ordering and is unsound on 3.12+,
-# where proactive chat can jump the queue ahead of user speech. See #2516 --
-# fix that first (gate the dequeue on _dispatch_allowed AFTER _next_queued and
-# requeue), then widen this.
 requires-python = "==3.11.*"
 dependencies = [
   "fastapi~=0.115.9",

--- a/tests/unit/test_external_text_turns.py
+++ b/tests/unit/test_external_text_turns.py
@@ -2435,6 +2435,70 @@ async def test_old_external_text_turn_rearms_newer_pause_after_dispatch():
     await arbiter.shutdown()
 
 
+@pytest.mark.asyncio
+async def test_old_external_text_turn_repauses_before_done_waits_can_skip_yield(
+    monkeypatch,
+):
+    original_wait_for = asyncio.wait_for
+
+    async def wait_for_without_done_future_yield(awaitable, timeout):
+        if isinstance(awaitable, asyncio.Future) and awaitable.done():
+            return awaitable.result()
+        return await original_wait_for(awaitable, timeout)
+
+    monkeypatch.setattr(
+        arbiter_module.asyncio,
+        "wait_for",
+        wait_for_without_done_future_yield,
+    )
+
+    arbiter = None
+    sent = []
+
+    async def send(event):
+        sent.append(dict(event))
+        if event["type"] == "conversation.item.create":
+            arbiter.notify_item_created(
+                {"item": {"id": event["item"]["id"], "role": "user"}}
+            )
+        elif event["type"] == "response.create":
+            arbiter.notify_response_created({})
+            arbiter.notify_response_terminal({})
+            # Complete the lifecycle while the transport send is suspended,
+            # matching the Python 3.12+ review reproduction.
+            await asyncio.sleep(0)
+
+    client = OmniRealtimeClient.__new__(OmniRealtimeClient)
+    client._is_gemini = False
+    arbiter = RealtimeResponseArbiter(send)
+    client._response_arbiter = arbiter
+    client._external_voice_turn_pause_id = "turn-new"
+    arbiter.pause_dispatch()
+    proactive = await arbiter.enqueue(
+        source="proactive",
+        response_event={"type": "response.create", "event_id": "proactive"},
+    )
+
+    ticket = await client.submit_external_text_turn("hello", turn_id="turn-old")
+    await ticket.done
+
+    response_event_ids = [
+        event["event_id"]
+        for event in sent
+        if event["type"] == "response.create"
+    ]
+    assert len(response_event_ids) == 1
+    assert response_event_ids[0].startswith("event_asr_response_")
+    assert "proactive" not in response_event_ids
+    assert proactive.sent.done() is False
+    assert not arbiter._dispatch_allowed.is_set()
+
+    client.abandon_external_voice_turn("turn-new")
+    await proactive.done
+    assert sent[-1]["event_id"] == "proactive"
+    await arbiter.shutdown()
+
+
 def test_abandon_without_active_pause_does_not_create_arbiter():
     client = OmniRealtimeClient.__new__(OmniRealtimeClient)
     client._is_gemini = False

--- a/tests/unit/test_external_text_turns.py
+++ b/tests/unit/test_external_text_turns.py
@@ -2020,6 +2020,53 @@ async def test_paused_precreated_proactive_yields_to_completed_user_turn():
 
 
 @pytest.mark.asyncio
+async def test_repause_after_dequeue_requeues_without_processing_or_bypass_charge():
+    async def send(_event):
+        raise AssertionError("paused work must not be sent")
+
+    arbiter = RealtimeResponseArbiter(send)
+    arbiter.pause_dispatch()
+    first = await arbiter.enqueue(source="proactive-1", priority=20)
+    second = await arbiter.enqueue(source="proactive-2", priority=20)
+    first_queued = arbiter._queued_by_ticket[id(first)]
+    second_queued = arbiter._queued_by_ticket[id(second)]
+
+    selection_ready = asyncio.Event()
+    return_selection = asyncio.Event()
+    original_next_queued = arbiter._next_queued
+
+    async def controlled_next_queued():
+        selected = await original_next_queued()
+        selection_ready.set()
+        await return_selection.wait()
+        return selected
+
+    arbiter._next_queued = controlled_next_queued
+    process = AsyncMock(wraps=arbiter._process)
+    arbiter._process = process
+
+    try:
+        arbiter.resume_dispatch()
+        await asyncio.wait_for(selection_ready.wait(), timeout=0.2)
+        arbiter.pause_dispatch()
+        return_selection.set()
+
+        for _ in range(20):
+            if arbiter._queue.qsize() == 2:
+                break
+            await asyncio.sleep(0)
+
+        assert arbiter._queue.qsize() == 2
+        process.assert_not_awaited()
+        assert first.sent.done() is False
+        assert second.sent.done() is False
+        assert first_queued.bypass_count == 0
+        assert second_queued.bypass_count == 0
+    finally:
+        await arbiter.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_external_text_turn_rejects_gemini_before_creating_arbiter():
     client = OmniRealtimeClient.__new__(OmniRealtimeClient)
     client._is_gemini = True

--- a/tests/unit/test_realtime_arbiter_native_path.py
+++ b/tests/unit/test_realtime_arbiter_native_path.py
@@ -37,13 +37,8 @@ and would hit every user.
 
 import asyncio
 import json
-import re
-import tomllib
-from pathlib import Path
 
 import pytest
-
-_REPO_ROOT = Path(__file__).resolve().parents[2]
 
 from main_logic.omni_realtime_client import OmniRealtimeClient
 from main_logic.omni_realtime_client._response_arbiter import RealtimeResponseArbiter
@@ -396,75 +391,3 @@ async def test_a_native_create_response_runs_through_the_arbiter_end_to_end():
 
     socket.finish()
     await asyncio.wait_for(receive_loop, timeout=1)
-
-
-@pytest.mark.unit
-def test_the_python_pin_that_this_arbiter_depends_on_stays_gated():
-    # ``requires-python = "==3.11.*"`` is not a routine bump: the arbiter's
-    # resume -> await -> re-pause hand-off relies on 3.11 task-yield ordering
-    # and #2516 is still open. The pyproject comment says raising it is a
-    # "gated change" -- this is the gate, so that claim is true rather than
-    # aspirational.
-    #
-    # CodeRabbit asked instead for a `sys.version_info >= (3, 12): sys.exit()`
-    # kill switch in launcher.py / launcher_core / the main_server entry
-    # points. Declined here on blast radius: #2516 is a response-ORDERING
-    # defect (proactive chat can jump ahead of user speech), not a crash, and
-    # hard-exiting every entry point would brick the whole application for
-    # anyone already running 3.12 over a bug most of them will never hit.
-    # Shipping that is a release decision, not a review fix. Widening the pin
-    # is what needs stopping, and that is what this stops.
-    pyproject = _REPO_ROOT / "pyproject.toml"
-    with pyproject.open("rb") as handle:
-        config = tomllib.load(handle)
-
-    assert config["project"]["requires-python"] == "==3.11.*", (
-        "requires-python was widened while #2516 (RealtimeResponseArbiter "
-        "dispatch ordering on 3.12+) is still open. Fix the dequeue gate "
-        "first -- see the comment above requires-python in pyproject.toml."
-    )
-
-
-@pytest.mark.unit
-def test_every_runtime_that_actually_executes_this_code_is_pinned_to_311():
-    # CodeRabbit, correctly: the assertion above guards the PIN, not the
-    # INTERPRETER. requires-python only binds at install resolution, so
-    # `python3.12 launcher.py`, a CI matrix bump, or a Docker base image that
-    # quietly moves on would all hit #2516 without touching a character of
-    # pyproject.toml -- a paper gate.
-    #
-    # Auto-discovered rather than a hand-kept list: a new workflow, or a new
-    # docker/Dockerfile.*, is covered the moment it is added. A hardcoded
-    # roster is the failure mode this whole class of gate keeps dying of.
-    offenders: list[str] = []
-
-    version_decl = re.compile(r"^\s*(python-version|PYTHON_VERSION):\s*(\S.*?)\s*$")
-    workflows = sorted((_REPO_ROOT / ".github" / "workflows").glob("*.yml"))
-    assert workflows, "no workflows found -- the discovery glob is broken, not the pin"
-    for workflow in workflows:
-        for number, line in enumerate(workflow.read_text(encoding="utf-8").splitlines(), 1):
-            match = version_decl.match(line)
-            if not match:
-                continue
-            value = match.group(2).strip().strip("'\"")
-            # An `${{ env.PYTHON_VERSION }}` indirection is fine: the
-            # PYTHON_VERSION declaration it resolves to is itself matched here.
-            if value == "3.11" or value.startswith("${{"):
-                continue
-            offenders.append(f"{workflow.name}:{number} -> {value}")
-
-    dockerfiles = sorted((_REPO_ROOT / "docker").glob("Dockerfile*"))
-    assert dockerfiles, "no Dockerfiles found -- the discovery glob is broken, not the pin"
-    for dockerfile in dockerfiles:
-        minors = set(re.findall(r"python3\.(\d+)", dockerfile.read_text(encoding="utf-8")))
-        stray = minors - {"11"}
-        if stray:
-            offenders.append(f"{dockerfile.name} -> python3.{', python3.'.join(sorted(stray))}")
-
-    assert not offenders, (
-        "a runtime that executes RealtimeResponseArbiter moved off Python 3.11 "
-        "while #2516 (dispatch ordering on 3.12+) is still open:\n  "
-        + "\n  ".join(offenders)
-        + "\nFix the dequeue gate first -- see the module docstring in "
-        "main_logic/omni_realtime_client/_response_arbiter.py."
-    )


### PR DESCRIPTION
## 摘要

- `ticket.sent` 完成后显式让出事件循环，确保 waiter 能先恢复新一轮 external-turn pause
- 在队列完成候选选择后、调用 `_process` 前再次检查派发闸门
- 新一轮 pause 生效时，将已选中的 ticket 原样放回队列
- 仅在确认允许派发后更新 `bypass_count`
- 删除 Python 3.11 隐式时序依赖说明及已经失效的版本 pin 防护测试

## 根因

external-turn 的 resume → await sent → re-pause 交接依赖 Python 3.11 在 arbiter 取出并处理下一条低优先级工作前让出事件循环。Python 3.12 对已经完成的 future 不再保证这次挂起，因此 proactive work 可能在新一轮用户话轮前越过闸门。

修复后，worker 在 `ticket.sent` 完成后、选择下一条工作前通过 `asyncio.sleep(0)` 显式把控制权交给 waiter，使其能够恢复更新一轮的 pause。随后 post-selection gate 继续覆盖 pause 在队列选择期间落地的窗口；被阻止的 ticket 会原样回队，且不消耗 starvation protection 的公平性配额。

## 用户影响

排队中的主动搭话或工具结果响应不再会因事件循环调度差异，抢在新一轮 external voice turn 之前派发。

## 回归报告

- 变更与必要性：在 ticket 完成后显式交还控制权，并把 dispatch pause 的最终确认放在 queue selection 之后、`_process` 之前，消除 external-turn 交接对 Python 3.11 未文档化让步时序的依赖。
- 变更前：若 response lifecycle futures 已在 transport send 期间完成，Python 3.12+ 的 done-future `wait_for()` 可以不让步；worker 会在 waiter 恢复 pause 前继续选择并派发低优先级 proactive work。pause 若在 `_next_queued()` 期间重新生效，其他候选还会被错误增加 `bypass_count`。
- 变更后：worker 先把控制权交给 `ticket.sent` waiter；派发前若发现 pause 已恢复，selected ticket 原样回队且 `_process()` 不会被调用，所有候选的 starvation/fairness 配额保持不变。
- 潜在回归与防护：主要风险是 priority queue 的 `task_done()` 记账、starvation 保护、external/native response 串行化和单 ticket 吞吐。新增测试模拟 done-future `wait_for()` 不让步且 lifecycle 在 transport send 挂起期间完成，并直接断言 proactive 未抢跑；原有竞态测试继续断言未调用 `_process()`、ticket 未发送且 `bypass_count` 未变化。external-turn 与 native-path 两个完整模块共 78 个测试通过。

## 验证

- `uv run pytest tests/unit/test_external_text_turns.py tests/unit/test_realtime_arbiter_native_path.py -q`：78 个测试通过
- 变异验证：移除显式 waiter hand-off 后，新回归测试会稳定捕获 proactive 抢跑；删除 post-selection gate 后，原竞态测试也会按预期失败
- `uv run ruff check ...`：通过
- 完整单测（首个 commit）：8402 个通过、23 个跳过；另有 1 个与本次修改无关的 macOS/psutil 环境失败，原因是当前平台没有 `Process.memory_maps()`

Fixes #2516


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化暂停与恢复期间的实时任务调度，暂停发生在任务选取后时，任务会安全回到队列。
  * 被暂停的任务不会被错误处理，也不会消耗公平调度配额。

* **Tests**
  * 新增回归测试，验证重新暂停场景下任务不会执行或产生旁路计数。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
