### PR TITLE
fix(social): hint Electron community window features for OS chrome

### DIFF
--- a/static/app/app-ui/surface-floating-controls.js
+++ b/static/app/app-ui/surface-floating-controls.js
@@ -289,7 +289,14 @@
                 return false;
             };
             const openElectronSocialWindow = (targetUrl) => {
-                const socialWin = window.open(String(targetUrl), 'neko-social');
+                // frameName=neko-social：NEKO-PC setWindowOpenHandler 靠名字识别社区窗，
+                // 强制 frame/thickFrame + 原生最小/最大/关（尤其 Windows 右上角）。
+                // features 为兜底提示；最终以主进程 overrideBrowserWindowOptions 为准。
+                const socialWin = window.open(
+                    String(targetUrl),
+                    'neko-social',
+                    'popup=yes,width=1200,height=800,resizable=yes'
+                );
                 if (!socialWin) {
                     return false;
                 }

--- a/tests/unit/test_social_button_static_contracts.py
+++ b/tests/unit/test_social_button_static_contracts.py
@@ -33,9 +33,15 @@ def test_social_open_request_is_deduped_before_fetching_config():
     assert listener.count("releaseSocialOpenRequest();") == 2
     assert "if (!socialOpenRequestReleased)" in listener
     # Community opens in-app (Electron framed child / browser tab); OAuth may still use openExternal.
-    assert "window.open(" in listener
-    assert "'neko-social'" in listener
-    assert "popup=yes,width=1200,height=800,resizable=yes" in listener
+    helper_start = listener.index("const openElectronSocialWindow = (targetUrl) => {")
+    helper_end = listener.index("const fetchNativeSyncTicket = async () => {", helper_start)
+    electron_helper = listener[helper_start:helper_end]
+    assert re.search(
+        r"window\.open\(\s*String\(targetUrl\),\s*"
+        r"'neko-social',\s*"
+        r"'popup=yes,width=1200,height=800,resizable=yes'\s*\)",
+        electron_helper,
+    )
     assert "openElectronSocialWindow(url)" in listener
     assert listener.index("releaseSocialOpenRequest();") > listener.index("openElectronSocialWindow(url)")
     assert "fetch('/api/card-drop/sync-ticket', {" in listener

--- a/tests/unit/test_social_button_static_contracts.py
+++ b/tests/unit/test_social_button_static_contracts.py
@@ -33,7 +33,9 @@ def test_social_open_request_is_deduped_before_fetching_config():
     assert listener.count("releaseSocialOpenRequest();") == 2
     assert "if (!socialOpenRequestReleased)" in listener
     # Community opens in-app (Electron framed child / browser tab); OAuth may still use openExternal.
-    assert "window.open(String(targetUrl), 'neko-social')" in listener
+    assert "window.open(" in listener
+    assert "'neko-social'" in listener
+    assert "popup=yes,width=1200,height=800,resizable=yes" in listener
     assert "openElectronSocialWindow(url)" in listener
     assert listener.index("releaseSocialOpenRequest();") > listener.index("openElectronSocialWindow(url)")
     assert "fetch('/api/card-drop/sync-ticket', {" in listener


### PR DESCRIPTION
## Summary
- Open the Electron community window with stable `neko-social` features (`popup`, size, resizable) so NEKO-PC can reliably apply a framed BrowserWindow.
- Update the social-button static contract to cover the new `window.open` features string.

Pairs with the NEKO-PC PR that forces native minimize/maximize/close controls (especially Windows top-right caption buttons).

## Test plan
- [ ] With matching NEKO-PC fix: click 猫娘社区 and confirm Windows shows min/max/close.
- [ ] Confirm named-window reuse still focuses/navigates the same community window.
- [ ] Run `pytest tests/unit/test_social_button_static_contracts.py -q`.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **用户体验**
  * 优化在 Electron 中打开社区窗口的方式：弹窗固定使用同一窗口标识，并提供更明确的默认尺寸与窗口特性（可调整大小的弹窗体验）。
  * 相关窗口控制的预期行为更清晰，最终显示效果由应用端统一接管。
* **测试**
  * 更新了对社交弹窗请求的静态合约校验，更精确地验证弹窗调用形态。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->