### PR TITLE
fix(galgame): 收尾时先等在飞 capture 跑完再释放 OCR runtime

### DIFF
--- a/plugin/plugins/galgame_plugin/ocr_manager_capture.py
+++ b/plugin/plugins/galgame_plugin/ocr_manager_capture.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor, wait as _futures_wait
 import ctypes
 from datetime import datetime, timezone
 import hashlib
@@ -21,7 +21,7 @@ from ctypes import wintypes
 from dataclasses import dataclass, field, replace
 from functools import wraps
 from pathlib import Path
-from typing import Any, Callable, ClassVar, Iterable, Protocol
+from typing import Any, Callable, ClassVar, Iterable, Protocol, Sequence
 from uuid import uuid4
 
 from .models import (
@@ -690,17 +690,29 @@ class CaptureMixin:
         return executors
 
 
-    def _shutdown_capture_worker(self) -> None:
+    def _shutdown_capture_worker(self) -> list[Future[OcrExtractionResult]]:
+        """Detach capture workers without blocking; return the ones still running.
+
+        Callers on the hot path (worker rotation) drop the return value: they
+        must not block. Teardown paths feed it to
+        `_drain_inflight_capture_workers` before releasing heavy dependencies.
+        """
         executors: list[ThreadPoolExecutor] = []
+        # cancel() 只对还在队列里的任务有效；已经进 _capture_and_extract_text 的
+        # 那个照跑不误，而它正攥着 RapidOCR runtime。收尾路径必须知道它还在，
+        # 否则紧接着的 _release_rapidocr_backend() 就是在它脚下拆台。
+        inflight: list[Future[OcrExtractionResult]] = []
         with self._capture_worker_lock:
             future = self._capture_future
             if future is not None and not future.done():
-                future.cancel()
+                if not future.cancel():
+                    inflight.append(future)
             if self._capture_executor is not None:
                 executors.append(self._capture_executor)
             for executor, abandoned_future in self._abandoned_capture_workers:
                 if not abandoned_future.done():
-                    abandoned_future.cancel()
+                    if not abandoned_future.cancel():
+                        inflight.append(abandoned_future)
                 executors.append(executor)
             self._abandoned_capture_workers = []
             self._capture_executor = None
@@ -710,6 +722,39 @@ class CaptureMixin:
         for executor in executors:
             # Project requires Python 3.11; cancel_futures is available on >=3.9.
             executor.shutdown(wait=False, cancel_futures=True)
+        return inflight
+
+
+    def _drain_inflight_capture_workers(
+        self,
+        futures: Sequence[Future[OcrExtractionResult]],
+        *,
+        timeout: float | None = None,
+    ) -> list[Future[OcrExtractionResult]]:
+        """Bounded wait for detached capture workers; returns those still running.
+
+        Only teardown calls this. Waiting is bounded on purpose: a worker stuck
+        inside a native capture call cannot be killed from Python, so past the
+        deadline the only options are to leak the wait or move on with a warning.
+        """
+        pending = [future for future in futures if not future.done()]
+        if not pending:
+            return []
+        if timeout is None:
+            timeout = float(
+                _ocr_reader_module._OCR_SHUTDOWN_CAPTURE_DRAIN_TIMEOUT_SECONDS
+            )
+        if timeout > 0.0:
+            _done, not_done = _futures_wait(pending, timeout=timeout)
+            pending = [future for future in pending if future in not_done]
+        if pending:
+            self._logger.warning(
+                "ocr_reader gave up waiting for {} in-flight capture worker(s) after {:.1f}s; "
+                "releasing OCR runtime anyway",
+                len(pending),
+                timeout,
+            )
+        return pending
 
 
     def _clear_completed_capture_worker(self) -> None:

--- a/plugin/plugins/galgame_plugin/ocr_manager_poll.py
+++ b/plugin/plugins/galgame_plugin/ocr_manager_poll.py
@@ -210,7 +210,11 @@ class PollMixin:
 
     async def shutdown(self) -> None:
         self._stop_foreground_advance_monitor()
-        self._shutdown_capture_worker()
+        # 顺序与 OcrReaderManager.close() 对偶：停线程/线程池 → 等在飞 capture
+        # 跑完 → 再释放它可能仍在用的重依赖。中间这一等是有界的，跑到点就放行。
+        inflight = self._shutdown_capture_worker() or []
+        if inflight:
+            await asyncio.to_thread(self._drain_inflight_capture_workers, inflight)
         self._release_rapidocr_backend()
         classifier = self.vision_classifier
         self.vision_classifier = None

--- a/plugin/plugins/galgame_plugin/ocr_manager_poll.py
+++ b/plugin/plugins/galgame_plugin/ocr_manager_poll.py
@@ -209,22 +209,52 @@ class PollMixin:
 
 
     async def shutdown(self) -> None:
-        self._stop_foreground_advance_monitor()
         # 顺序与 OcrReaderManager.close() 对偶：停线程/线程池 → 等在飞 capture
         # 跑完 → 再释放它可能仍在用的重依赖。中间这一等是有界的，跑到点就放行。
-        inflight = self._shutdown_capture_worker() or []
+        #
+        # 各步独立守卫，理由与 close() 那边同一条：合并后任一步抛错都会把后面
+        # 的释放连带跳过，而调用方（plugin_core.shutdown）只会记一条 warning
+        # 且不重试，资源就这么留下了。这条是生产卸载路径，比 close() 更要紧。
+        try:
+            self._stop_foreground_advance_monitor()
+        except Exception as exc:
+            self._log_warning("ocr_reader foreground advance monitor shutdown failed: {}", exc)
+        inflight: list[Future[OcrExtractionResult]] = []
+        try:
+            inflight = self._shutdown_capture_worker() or []
+        except Exception as exc:
+            self._log_warning("ocr_reader capture worker shutdown failed: {}", exc)
+        # 这是本函数唯一的 await 点，也就是唯一能被取消打断的地方。被打断同样
+        # 不能让下面的释放落空：先把取消记下来，收尾跑完再原样抛出去。
+        cancelled: asyncio.CancelledError | None = None
         if inflight:
-            await asyncio.to_thread(self._drain_inflight_capture_workers, inflight)
-        self._release_rapidocr_backend()
+            try:
+                await asyncio.to_thread(self._drain_inflight_capture_workers, inflight)
+            except asyncio.CancelledError as exc:
+                cancelled = exc
+            except Exception as exc:
+                self._log_warning("ocr_reader in-flight capture drain failed: {}", exc)
+        try:
+            self._release_rapidocr_backend()
+        except Exception as exc:
+            self._log_warning("ocr_reader rapidocr backend release failed: {}", exc)
         classifier = self.vision_classifier
         self.vision_classifier = None
         close_classifier = getattr(classifier, "close", None)
         if callable(close_classifier):
-            close_classifier()
-        if self._writer.session_id:
-            self._writer.end_session(ts=utc_now_iso(self._time_fn()))
-            self._ocr_lang_detector.reset(clear_switch_time=True)
+            try:
+                close_classifier()
+            except Exception as exc:
+                self._log_warning("ocr_reader vision classifier close failed: {}", exc)
+        try:
+            if self._writer.session_id:
+                self._writer.end_session(ts=utc_now_iso(self._time_fn()))
+                self._ocr_lang_detector.reset(clear_switch_time=True)
+        except Exception as exc:
+            self._log_warning("ocr_reader writer session close failed: {}", exc)
         self._attached_window = None
+        if cancelled is not None:
+            raise cancelled
 
 
     async def _tick_preflight(

--- a/plugin/plugins/galgame_plugin/ocr_manager_poll.py
+++ b/plugin/plugins/galgame_plugin/ocr_manager_poll.py
@@ -228,23 +228,21 @@ class PollMixin:
         # 不能让下面的释放落空：先把取消记下来，收尾跑完再原样抛出去。
         #
         # 取消不会停掉 to_thread 那个线程 —— 它照样在 _futures_wait 里等满上限。
-        # 所以这里用 shield 把取消挡在外层，仍旧等 drain 落地再往下拆；否则取消
-        # 路径会整个绕过 drain，退回到「在还在跑的 worker 脚下关 backend」，正是
-        # 本次要修的那件事。代价是取消后最多多等一个 drain 上限（默认 0.3s），
-        # 这个数就是照着宿主关闭预算挑的。
+        # 若就这么往下走，取消路径会整个绕过 drain，退回到「在还在跑的 worker 脚下
+        # 关 backend」，正是本次要修的那件事。
+        #
+        # 所以取消之后改在当前线程上把这一等重做一遍：同步调用挡不掉也躲不开，
+        # 二次、三次 cancel 都打断不了它。用 shield 套 await 只能挡住一次取消，
+        # 下一次照样从同一个口子穿过去。代价是取消路径最坏等两个 drain 上限
+        # （默认 2 × 0.3s），仍远小于宿主给的关闭预算，且只在被取消时才付。
         cancelled: asyncio.CancelledError | None = None
         if inflight:
-            drain = asyncio.ensure_future(
-                asyncio.to_thread(self._drain_inflight_capture_workers, inflight)
-            )
             try:
-                await asyncio.shield(drain)
+                await asyncio.to_thread(self._drain_inflight_capture_workers, inflight)
             except asyncio.CancelledError as exc:
                 cancelled = exc
                 try:
-                    await drain
-                except asyncio.CancelledError:
-                    pass
+                    self._drain_inflight_capture_workers(inflight)
                 except Exception as drain_exc:
                     self._log_warning(
                         "ocr_reader in-flight capture drain failed: {}", drain_exc

--- a/plugin/plugins/galgame_plugin/ocr_manager_poll.py
+++ b/plugin/plugins/galgame_plugin/ocr_manager_poll.py
@@ -226,12 +226,29 @@ class PollMixin:
             self._log_warning("ocr_reader capture worker shutdown failed: {}", exc)
         # 这是本函数唯一的 await 点，也就是唯一能被取消打断的地方。被打断同样
         # 不能让下面的释放落空：先把取消记下来，收尾跑完再原样抛出去。
+        #
+        # 取消不会停掉 to_thread 那个线程 —— 它照样在 _futures_wait 里等满上限。
+        # 所以这里用 shield 把取消挡在外层，仍旧等 drain 落地再往下拆；否则取消
+        # 路径会整个绕过 drain，退回到「在还在跑的 worker 脚下关 backend」，正是
+        # 本次要修的那件事。代价是取消后最多多等一个 drain 上限（默认 0.3s），
+        # 这个数就是照着宿主关闭预算挑的。
         cancelled: asyncio.CancelledError | None = None
         if inflight:
+            drain = asyncio.ensure_future(
+                asyncio.to_thread(self._drain_inflight_capture_workers, inflight)
+            )
             try:
-                await asyncio.to_thread(self._drain_inflight_capture_workers, inflight)
+                await asyncio.shield(drain)
             except asyncio.CancelledError as exc:
                 cancelled = exc
+                try:
+                    await drain
+                except asyncio.CancelledError:
+                    pass
+                except Exception as drain_exc:
+                    self._log_warning(
+                        "ocr_reader in-flight capture drain failed: {}", drain_exc
+                    )
             except Exception as exc:
                 self._log_warning("ocr_reader in-flight capture drain failed: {}", exc)
         try:

--- a/plugin/plugins/galgame_plugin/ocr_reader.py
+++ b/plugin/plugins/galgame_plugin/ocr_reader.py
@@ -382,17 +382,24 @@ class OcrReaderManager(
         # 面，任一抛错就把下面几段守卫整个跳过、线程与线程池全漏 —— 正是这
         # 些 try/except 当初要防的场景。
         #
-        # 四步各自独立守卫，不合并：合并后任一步抛错都会把它后面的步骤连带
+        # 各步各自独立守卫，不合并：合并后任一步抛错都会把它后面的步骤连带
         # 跳过，而异常又已经被吞掉，调用方看到的是「关成功了」，实际还留着
         # 活着的资源（Codex P2）。
         try:
             self._stop_foreground_advance_monitor(join_timeout=1.0)
         except Exception as exc:
             self._log_warning("ocr_reader foreground advance monitor shutdown failed: {}", exc)
+        inflight: list[Future[OcrExtractionResult]] = []
         try:
-            self._shutdown_capture_worker()
+            inflight = self._shutdown_capture_worker() or []
         except Exception as exc:
             self._log_warning("ocr_reader capture worker shutdown failed: {}", exc)
+        # 关线程池不等于任务停了：已经在跑的那次 capture 还攥着下面要释放的
+        # RapidOCR runtime。先有界地等它退栈，再往下拆。
+        try:
+            self._drain_inflight_capture_workers(inflight)
+        except Exception as exc:
+            self._log_warning("ocr_reader in-flight capture drain failed: {}", exc)
         try:
             self._release_rapidocr_backend()
         except Exception as exc:

--- a/plugin/plugins/galgame_plugin/ocr_runtime_types.py
+++ b/plugin/plugins/galgame_plugin/ocr_runtime_types.py
@@ -203,6 +203,7 @@ __all__ = [
     "_OCR_PREPARE_TARGET_LONG_EDGE",
     "_OCR_PREPARE_UPSCALE_SOURCE_LONG_EDGE",
     "_OCR_SHUTDOWN_CAPTURE_DRAIN_BUDGET_SHARE",
+    "_OCR_SHUTDOWN_CAPTURE_DRAIN_MAX_SECONDS",
     "_OCR_SHUTDOWN_CAPTURE_DRAIN_TIMEOUT_SECONDS",
     "_OCR_STABILITY_IGNORED_CHARS_RE",
     "_OCR_TRAILING_GARBAGE_AFTER_BRACKET_RE",
@@ -303,6 +304,7 @@ __all__ = [
     "_rapidocr_runtime_cache_key",
     "_rapidocr_text_from_output",
     "_rapidocr_tokens_from_output",
+    "_resolve_ocr_shutdown_drain_timeout",
     "_resolve_stage_capture_profile",
     "_score_ocr_text",
     "_should_insert_ascii_space",
@@ -352,9 +354,31 @@ _OCR_MAX_ABANDONED_CAPTURE_WORKERS = 1
 # 内存晚一会儿吐出来外加一条 warning。而且 Python 杀不掉跑飞的线程，真卡死的
 # worker 等多久都等不到，只能记 warning 放它去。
 _OCR_SHUTDOWN_CAPTURE_DRAIN_BUDGET_SHARE = 0.2
-_OCR_SHUTDOWN_CAPTURE_DRAIN_TIMEOUT_SECONDS = min(
-    0.3,
-    max(0.05, float(_PLUGIN_SHUTDOWN_TIMEOUT) * _OCR_SHUTDOWN_CAPTURE_DRAIN_BUDGET_SHARE),
+_OCR_SHUTDOWN_CAPTURE_DRAIN_MAX_SECONDS = 0.3
+
+
+def _resolve_ocr_shutdown_drain_timeout(host_shutdown_budget: float) -> float:
+    """Drain bound for a given host graceful-shutdown budget; never exceeds its share.
+
+    No lower floor on purpose: a floor independent of the budget can outgrow a
+    small `NEKO_PLUGIN_SHUTDOWN_TIMEOUT` and put us back to spending the whole
+    thing. A zero or negative budget yields 0.0, which skips the wait entirely.
+    """
+    try:
+        budget = float(host_shutdown_budget)
+    except (TypeError, ValueError):
+        return 0.0
+    return max(
+        0.0,
+        min(
+            _OCR_SHUTDOWN_CAPTURE_DRAIN_MAX_SECONDS,
+            budget * _OCR_SHUTDOWN_CAPTURE_DRAIN_BUDGET_SHARE,
+        ),
+    )
+
+
+_OCR_SHUTDOWN_CAPTURE_DRAIN_TIMEOUT_SECONDS = _resolve_ocr_shutdown_drain_timeout(
+    _PLUGIN_SHUTDOWN_TIMEOUT
 )
 class _CaptureStillRunning(TimeoutError):
     """Backpressure: previous capture worker has not finished yet."""

--- a/plugin/plugins/galgame_plugin/ocr_runtime_types.py
+++ b/plugin/plugins/galgame_plugin/ocr_runtime_types.py
@@ -83,6 +83,12 @@ from plugin.plugins._shared.rapidocr.rapidocr_support import (
     inspect_rapidocr_installation,
     load_rapidocr_runtime,
 )
+
+try:
+    from plugin.settings import PLUGIN_SHUTDOWN_TIMEOUT as _PLUGIN_SHUTDOWN_TIMEOUT
+except Exception:  # pragma: no cover - plugin may run without the framework settings module.
+    _PLUGIN_SHUTDOWN_TIMEOUT = 1.5
+
 from .reader import normalize_text
 from .screen_classifier import (
     ScreenClassification,
@@ -196,6 +202,7 @@ __all__ = [
     "_OCR_PREPARE_MAX_LONG_EDGE",
     "_OCR_PREPARE_TARGET_LONG_EDGE",
     "_OCR_PREPARE_UPSCALE_SOURCE_LONG_EDGE",
+    "_OCR_SHUTDOWN_CAPTURE_DRAIN_BUDGET_SHARE",
     "_OCR_SHUTDOWN_CAPTURE_DRAIN_TIMEOUT_SECONDS",
     "_OCR_STABILITY_IGNORED_CHARS_RE",
     "_OCR_TRAILING_GARBAGE_AFTER_BRACKET_RE",
@@ -206,6 +213,7 @@ __all__ = [
     "_OVERLAY_PROCESS_NAME_SUBSTRINGS",
     "_OVERLAY_WINDOW_TITLE_SUBSTRINGS",
     "_PENDING_VISUAL_SCENE_MAX_SECONDS",
+    "_PLUGIN_SHUTDOWN_TIMEOUT",
     "_PUNCTUATION_CONFUSION_FIXES",
     "_RAPIDOCR_INFERENCE_LOCK",
     "_RAPIDOCR_RUNTIME_CACHE",
@@ -332,12 +340,22 @@ _KEYBOARD_ADVANCE_VK_CODES = frozenset({
 _OCR_FOLLOWUP_CONFIRM_DELAY_SECONDS = 0.18
 _OCR_CAPTURE_TIMEOUT_SECONDS = 12.0
 _OCR_MAX_ABANDONED_CAPTURE_WORKERS = 1
-# 收尾时等在飞 capture 跑完的上限。不复用上面那 12s：worker 拖住的只是
-# RapidOCR runtime 的回收时机（capture 线程栈上还攥着 runtime 引用，重依赖
-# 要等它退栈才真落地），代价是「内存晚几秒吐出来 + 一条 OCR warning」，拿
-# 插件卸载卡十几秒来换不划算。而且 Python 杀不掉跑飞的线程：真卡死的 worker
-# 多等十几秒同样等不到，只能记 warning 放它去。
-_OCR_SHUTDOWN_CAPTURE_DRAIN_TIMEOUT_SECONDS = 1.5
+# 收尾时等在飞 capture 跑完的上限。
+#
+# 必须远小于宿主给单个插件的优雅关闭预算（PLUGIN_SHUTDOWN_TIMEOUT，默认 1.5s）：
+# 宿主用同一份预算 join 子进程，到点直接 terminate。drain 若把预算吃光，它后面
+# 的 backend / classifier / writer 收尾根本轮不到跑 —— 那比不等还糟，等于用一次
+# 强杀换来什么都没释放。所以只取预算的一小段，剩下的留给后续收尾。
+#
+# 也不复用上面那 12s 的 capture 超时：worker 拖住的只是 RapidOCR runtime 的回收
+# 时机（capture 线程栈上还攥着 runtime 引用，重依赖要等它退栈才真落地），代价是
+# 内存晚一会儿吐出来外加一条 warning。而且 Python 杀不掉跑飞的线程，真卡死的
+# worker 等多久都等不到，只能记 warning 放它去。
+_OCR_SHUTDOWN_CAPTURE_DRAIN_BUDGET_SHARE = 0.2
+_OCR_SHUTDOWN_CAPTURE_DRAIN_TIMEOUT_SECONDS = min(
+    0.3,
+    max(0.05, float(_PLUGIN_SHUTDOWN_TIMEOUT) * _OCR_SHUTDOWN_CAPTURE_DRAIN_BUDGET_SHARE),
+)
 class _CaptureStillRunning(TimeoutError):
     """Backpressure: previous capture worker has not finished yet."""
 

--- a/plugin/plugins/galgame_plugin/ocr_runtime_types.py
+++ b/plugin/plugins/galgame_plugin/ocr_runtime_types.py
@@ -196,6 +196,7 @@ __all__ = [
     "_OCR_PREPARE_MAX_LONG_EDGE",
     "_OCR_PREPARE_TARGET_LONG_EDGE",
     "_OCR_PREPARE_UPSCALE_SOURCE_LONG_EDGE",
+    "_OCR_SHUTDOWN_CAPTURE_DRAIN_TIMEOUT_SECONDS",
     "_OCR_STABILITY_IGNORED_CHARS_RE",
     "_OCR_TRAILING_GARBAGE_AFTER_BRACKET_RE",
     "_OCR_TRAILING_GARBAGE_AFTER_DASH_RE",
@@ -331,6 +332,12 @@ _KEYBOARD_ADVANCE_VK_CODES = frozenset({
 _OCR_FOLLOWUP_CONFIRM_DELAY_SECONDS = 0.18
 _OCR_CAPTURE_TIMEOUT_SECONDS = 12.0
 _OCR_MAX_ABANDONED_CAPTURE_WORKERS = 1
+# 收尾时等在飞 capture 跑完的上限。不复用上面那 12s：worker 拖住的只是
+# RapidOCR runtime 的回收时机（capture 线程栈上还攥着 runtime 引用，重依赖
+# 要等它退栈才真落地），代价是「内存晚几秒吐出来 + 一条 OCR warning」，拿
+# 插件卸载卡十几秒来换不划算。而且 Python 杀不掉跑飞的线程：真卡死的 worker
+# 多等十几秒同样等不到，只能记 warning 放它去。
+_OCR_SHUTDOWN_CAPTURE_DRAIN_TIMEOUT_SECONDS = 1.5
 class _CaptureStillRunning(TimeoutError):
     """Backpressure: previous capture worker has not finished yet."""
 

--- a/tests/unit/test_galgame_ocr_capture_worker.py
+++ b/tests/unit/test_galgame_ocr_capture_worker.py
@@ -679,7 +679,9 @@ def test_async_shutdown_finishes_cleanup_when_cancelled_mid_drain() -> None:
     """Cancelling the unload must neither strand the heavy deps nor skip the drain."""
     manager, observed = _async_shutdown_manager()
     order: list[str] = []
+    order_lock = threading.Lock()
     drain_entered = threading.Event()
+    worker_finished = threading.Event()
     still_running: Future[OcrExtractionResult] = Future()
 
     manager._stop_foreground_advance_monitor = types.MethodType(
@@ -694,28 +696,46 @@ def test_async_shutdown_finishes_cleanup_when_cancelled_mid_drain() -> None:
     def _slow_drain(self, _futures, **_kwargs) -> list:
         del self
         drain_entered.set()
-        # 取消不会停掉这个线程，它照样跑满 —— 收尾必须等它落地再释放 backend。
-        time.sleep(0.3)
-        order.append("drain-finished")
+        # 取消不会停掉在飞的 worker —— 收尾必须等它落地再释放 backend。
+        worker_finished.wait(timeout=5.0)
+        with order_lock:
+            order.append("drain-returned")
         return []
 
     manager._drain_inflight_capture_workers = types.MethodType(_slow_drain, manager)
-    manager._release_rapidocr_backend = types.MethodType(
-        lambda self: order.append("backend-released"),
-        manager,
-    )
+
+    def _release(self) -> None:
+        del self
+        with order_lock:
+            order.append("backend-released")
+
+    manager._release_rapidocr_backend = types.MethodType(_release, manager)
 
     async def _cancel_during_drain() -> None:
         task = asyncio.create_task(manager.shutdown())
         await asyncio.to_thread(drain_entered.wait, 2.0)
+        releaser = threading.Timer(0.2, worker_finished.set)
+        releaser.start()
         task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await task
+        # 让第一次取消真正投递进去、shutdown 走进它的取消分支，再补第二刀。
+        # 连着调两次 cancel() 是幂等的，抓不到这个场景：`await` 形式的等待
+        # （哪怕套了 shield）只挡得住第一次，第二次会从同一个口子把 drain 绕过去。
+        await asyncio.sleep(0.05)
+        task.cancel()
+        try:
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        finally:
+            releaser.cancel()
+            worker_finished.set()
 
     asyncio.run(_cancel_during_drain())
 
-    assert order == ["drain-finished", "backend-released"], (
-        "取消绕过了 drain —— backend 在 worker 还没跑完时就被释放了"
+    with order_lock:
+        settled = list(order)
+    assert "drain-returned" in settled, "取消绕过了 drain，没等在飞任务落地"
+    assert settled[-1] == "backend-released", (
+        f"backend 在 worker 还没跑完时就被释放了：{settled}"
     )
     assert observed["closed_classifier"] == [True]
     assert manager.vision_classifier is None

--- a/tests/unit/test_galgame_ocr_capture_worker.py
+++ b/tests/unit/test_galgame_ocr_capture_worker.py
@@ -609,6 +609,132 @@ def test_close_gives_up_on_stuck_capture_after_bounded_wait(
         running_future.result(timeout=5.0)
 
 
+_ASYNC_SHUTDOWN_STEPS = (
+    "_stop_foreground_advance_monitor",
+    "_shutdown_capture_worker",
+    "_drain_inflight_capture_workers",
+    "_release_rapidocr_backend",
+)
+
+
+def _async_shutdown_manager() -> tuple[OcrReaderManager, dict]:
+    manager = object.__new__(OcrReaderManager)
+    manager._logger = _NullLogger()
+    observed: dict = {"closed_classifier": [], "ended_sessions": []}
+
+    class _Classifier:
+        def close(self) -> None:
+            observed["closed_classifier"].append(True)
+
+    manager.vision_classifier = _Classifier()
+    manager._writer = types.SimpleNamespace(
+        session_id="session-1",
+        end_session=lambda ts: observed["ended_sessions"].append(ts),
+    )
+    manager._ocr_lang_detector = types.SimpleNamespace(reset=lambda **_kwargs: None)
+    manager._time_fn = lambda: 0.0
+    manager._attached_window = object()
+    return manager, observed
+
+
+@pytest.mark.parametrize("exploding_step", list(_ASYNC_SHUTDOWN_STEPS))
+def test_async_shutdown_releases_every_resource_despite_one_failure(
+    exploding_step: str,
+) -> None:
+    """Plugin unload is the production teardown path; one bad step must not skip the rest."""
+    manager, observed = _async_shutdown_manager()
+    done: list[str] = []
+    still_running: Future[OcrExtractionResult] = Future()
+
+    def _step(name: str):
+        def _run(self, *_args, **_kwargs):
+            del self
+            done.append(name)
+            if name == exploding_step:
+                raise RuntimeError(f"{name} exploded")
+            if name == "_shutdown_capture_worker":
+                return [still_running]
+            return []
+        return _run
+
+    for name in _ASYNC_SHUTDOWN_STEPS:
+        setattr(manager, name, types.MethodType(_step(name), manager))
+
+    asyncio.run(manager.shutdown())
+
+    expected = list(_ASYNC_SHUTDOWN_STEPS)
+    if exploding_step == "_shutdown_capture_worker":
+        # 拿不到在飞清单就没有东西可等，跳过 drain 是对的；其余步骤照跑。
+        expected.remove("_drain_inflight_capture_workers")
+    assert done == expected, f"{exploding_step} 抛错后其余步骤仍必须跑到"
+    assert observed["closed_classifier"] == [True], "classifier 必须被关掉"
+    assert manager.vision_classifier is None, "classifier 引用必须摘掉"
+    assert len(observed["ended_sessions"]) == 1, "writer session 必须收掉"
+    assert manager._attached_window is None
+
+    still_running.cancel()
+
+
+def test_async_shutdown_finishes_cleanup_when_cancelled_mid_drain() -> None:
+    """Cancelling the unload during the drain must not strand the heavy deps."""
+    manager, observed = _async_shutdown_manager()
+    released: list[str] = []
+    drain_entered = threading.Event()
+    still_running: Future[OcrExtractionResult] = Future()
+
+    manager._stop_foreground_advance_monitor = types.MethodType(
+        lambda self, **_kwargs: None,
+        manager,
+    )
+    manager._shutdown_capture_worker = types.MethodType(
+        lambda self: [still_running],
+        manager,
+    )
+
+    def _slow_drain(self, _futures, **_kwargs) -> list:
+        del self
+        drain_entered.set()
+        time.sleep(0.3)
+        return []
+
+    manager._drain_inflight_capture_workers = types.MethodType(_slow_drain, manager)
+    manager._release_rapidocr_backend = types.MethodType(
+        lambda self: released.append("backend"),
+        manager,
+    )
+
+    async def _cancel_during_drain() -> None:
+        task = asyncio.create_task(manager.shutdown())
+        await asyncio.to_thread(drain_entered.wait, 2.0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(_cancel_during_drain())
+
+    assert released == ["backend"], "取消发生在 drain 期间，重依赖仍然必须被释放"
+    assert observed["closed_classifier"] == [True]
+    assert manager.vision_classifier is None
+    assert len(observed["ended_sessions"]) == 1
+    assert manager._attached_window is None
+
+    still_running.cancel()
+
+
+def test_drain_timeout_leaves_room_for_the_rest_of_plugin_shutdown() -> None:
+    """The host joins the child on the same budget; eating it trades cleanup for a kill."""
+    from plugin.plugins.galgame_plugin import ocr_runtime_types as runtime_types
+
+    drain_timeout = runtime_types._OCR_SHUTDOWN_CAPTURE_DRAIN_TIMEOUT_SECONDS
+    host_budget = runtime_types._PLUGIN_SHUTDOWN_TIMEOUT
+
+    assert drain_timeout > 0.0
+    assert drain_timeout <= host_budget * 0.5, (
+        f"drain 上限 {drain_timeout}s 吃掉了宿主优雅关闭预算 {host_budget}s 的一半以上，"
+        "backend / classifier / writer 的收尾会来不及跑就被 terminate"
+    )
+
+
 def test_drain_inflight_capture_workers_skips_wait_when_nothing_is_running() -> None:
     manager = _teardown_manager(_FakeRapidOcrBackend())
     finished: Future[OcrExtractionResult] = Future()

--- a/tests/unit/test_galgame_ocr_capture_worker.py
+++ b/tests/unit/test_galgame_ocr_capture_worker.py
@@ -676,9 +676,9 @@ def test_async_shutdown_releases_every_resource_despite_one_failure(
 
 
 def test_async_shutdown_finishes_cleanup_when_cancelled_mid_drain() -> None:
-    """Cancelling the unload during the drain must not strand the heavy deps."""
+    """Cancelling the unload must neither strand the heavy deps nor skip the drain."""
     manager, observed = _async_shutdown_manager()
-    released: list[str] = []
+    order: list[str] = []
     drain_entered = threading.Event()
     still_running: Future[OcrExtractionResult] = Future()
 
@@ -694,12 +694,14 @@ def test_async_shutdown_finishes_cleanup_when_cancelled_mid_drain() -> None:
     def _slow_drain(self, _futures, **_kwargs) -> list:
         del self
         drain_entered.set()
+        # 取消不会停掉这个线程，它照样跑满 —— 收尾必须等它落地再释放 backend。
         time.sleep(0.3)
+        order.append("drain-finished")
         return []
 
     manager._drain_inflight_capture_workers = types.MethodType(_slow_drain, manager)
     manager._release_rapidocr_backend = types.MethodType(
-        lambda self: released.append("backend"),
+        lambda self: order.append("backend-released"),
         manager,
     )
 
@@ -712,7 +714,9 @@ def test_async_shutdown_finishes_cleanup_when_cancelled_mid_drain() -> None:
 
     asyncio.run(_cancel_during_drain())
 
-    assert released == ["backend"], "取消发生在 drain 期间，重依赖仍然必须被释放"
+    assert order == ["drain-finished", "backend-released"], (
+        "取消绕过了 drain —— backend 在 worker 还没跑完时就被释放了"
+    )
     assert observed["closed_classifier"] == [True]
     assert manager.vision_classifier is None
     assert len(observed["ended_sessions"]) == 1
@@ -727,12 +731,24 @@ def test_drain_timeout_leaves_room_for_the_rest_of_plugin_shutdown() -> None:
 
     drain_timeout = runtime_types._OCR_SHUTDOWN_CAPTURE_DRAIN_TIMEOUT_SECONDS
     host_budget = runtime_types._PLUGIN_SHUTDOWN_TIMEOUT
+    share = runtime_types._OCR_SHUTDOWN_CAPTURE_DRAIN_BUDGET_SHARE
 
     assert drain_timeout > 0.0
     assert drain_timeout <= host_budget * 0.5, (
         f"drain 上限 {drain_timeout}s 吃掉了宿主优雅关闭预算 {host_budget}s 的一半以上，"
         "backend / classifier / writer 的收尾会来不及跑就被 terminate"
     )
+
+    # 派生公式在任何预算下都不能越过它那一份 —— 独立于预算的下限会在预算被调小时
+    # 反过来吃满它（NEKO_PLUGIN_SHUTDOWN_TIMEOUT 是可配的）。
+    for budget in (0.0, 0.01, 0.05, 0.2, 1.5, 30.0):
+        derived = runtime_types._resolve_ocr_shutdown_drain_timeout(budget)
+        assert 0.0 <= derived <= budget * share + 1e-9, (
+            f"预算 {budget}s 下派生出的 drain 上限 {derived}s 超过了它的份额"
+        )
+        assert derived <= runtime_types._OCR_SHUTDOWN_CAPTURE_DRAIN_MAX_SECONDS
+
+    assert runtime_types._resolve_ocr_shutdown_drain_timeout(-1.0) == 0.0
 
 
 def test_drain_inflight_capture_workers_skips_wait_when_nothing_is_running() -> None:

--- a/tests/unit/test_galgame_ocr_capture_worker.py
+++ b/tests/unit/test_galgame_ocr_capture_worker.py
@@ -693,13 +693,19 @@ def test_async_shutdown_finishes_cleanup_when_cancelled_mid_drain() -> None:
         manager,
     )
 
+    # 被取消的那次 drain 跑在 to_thread 的线程上，它什么时候返回不受本用例控制，
+    # 迟到几毫秒排到 order 末尾都算正常。真正要盯的是「取消后在当前线程重做的那
+    # 次」有没有在释放 backend 之前跑完，所以两次按线程分开记。
+    loop_thread = threading.current_thread()
+
     def _slow_drain(self, _futures, **_kwargs) -> list:
         del self
         drain_entered.set()
         # 取消不会停掉在飞的 worker —— 收尾必须等它落地再释放 backend。
         worker_finished.wait(timeout=5.0)
+        on_loop_thread = threading.current_thread() is loop_thread
         with order_lock:
-            order.append("drain-returned")
+            order.append("sync-drain" if on_loop_thread else "threaded-drain")
         return []
 
     manager._drain_inflight_capture_workers = types.MethodType(_slow_drain, manager)
@@ -733,9 +739,12 @@ def test_async_shutdown_finishes_cleanup_when_cancelled_mid_drain() -> None:
 
     with order_lock:
         settled = list(order)
-    assert "drain-returned" in settled, "取消绕过了 drain，没等在飞任务落地"
-    assert settled[-1] == "backend-released", (
-        f"backend 在 worker 还没跑完时就被释放了：{settled}"
+    assert "sync-drain" in settled, (
+        f"取消绕过了 drain，没在当前线程把等待重做一遍：{settled}"
+    )
+    assert "backend-released" in settled
+    assert settled.index("sync-drain") < settled.index("backend-released"), (
+        f"backend 在重做的那次 drain 落地之前就被释放了：{settled}"
     )
     assert observed["closed_classifier"] == [True]
     assert manager.vision_classifier is None

--- a/tests/unit/test_galgame_ocr_capture_worker.py
+++ b/tests/unit/test_galgame_ocr_capture_worker.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from concurrent.futures import Future, ThreadPoolExecutor
 import threading
 import time
@@ -31,11 +32,15 @@ class _ExplodingLogger(_NullLogger):
         raise RuntimeError("logger failed")
 
 
-@pytest.mark.parametrize("exploding_step", [
+_CLOSE_STEPS = (
     "_stop_foreground_advance_monitor",
     "_shutdown_capture_worker",
+    "_drain_inflight_capture_workers",
     "_release_rapidocr_backend",
-])
+)
+
+
+@pytest.mark.parametrize("exploding_step", list(_CLOSE_STEPS))
 def test_ocr_reader_manager_close_releases_every_resource_despite_one_failure(
     exploding_step: str,
 ) -> None:
@@ -65,20 +70,12 @@ def test_ocr_reader_manager_close_releases_every_resource_despite_one_failure(
                 raise RuntimeError(f"{name} exploded")
         return _run
 
-    for name in (
-        "_stop_foreground_advance_monitor",
-        "_shutdown_capture_worker",
-        "_release_rapidocr_backend",
-    ):
+    for name in _CLOSE_STEPS:
         setattr(manager, name, types.MethodType(_step(name), manager))
 
     manager.close()
 
-    assert done == [
-        "_stop_foreground_advance_monitor",
-        "_shutdown_capture_worker",
-        "_release_rapidocr_backend",
-    ], f"{exploding_step} 抛错后其余步骤仍必须跑到"
+    assert done == list(_CLOSE_STEPS), f"{exploding_step} 抛错后其余步骤仍必须跑到"
     assert closed_classifier == [True], "classifier 必须被关掉"
     assert manager.vision_classifier is None, "classifier 引用必须摘掉"
 
@@ -93,11 +90,7 @@ def test_ocr_reader_manager_close_drops_classifier_reference_when_its_close_rais
             raise RuntimeError("classifier close exploded")
 
     manager.vision_classifier = _Classifier()
-    for name in (
-        "_stop_foreground_advance_monitor",
-        "_shutdown_capture_worker",
-        "_release_rapidocr_backend",
-    ):
+    for name in _CLOSE_STEPS:
         setattr(manager, name, types.MethodType(lambda self, *a, **k: None, manager))
 
     manager.close()
@@ -116,13 +109,19 @@ def test_ocr_reader_manager_context_manager_closes_capture_resources() -> None:
     def _shutdown(self) -> None:
         calls.append(("shutdown", None))
 
+    def _drain(self, futures, **_kwargs) -> list:
+        del self
+        calls.append(("drain", None))
+        return list(futures)
+
     manager._stop_foreground_advance_monitor = types.MethodType(_stop, manager)
     manager._shutdown_capture_worker = types.MethodType(_shutdown, manager)
+    manager._drain_inflight_capture_workers = types.MethodType(_drain, manager)
 
     with manager as active:
         assert active is manager
 
-    assert calls == [("stop", 1.0), ("shutdown", None)]
+    assert calls == [("stop", 1.0), ("shutdown", None), ("drain", None)]
 
 
 def test_ocr_reader_manager_close_swallows_shutdown_errors() -> None:
@@ -140,12 +139,20 @@ def test_ocr_reader_manager_close_swallows_shutdown_errors() -> None:
         calls.append(("shutdown", None))
         raise RuntimeError("shutdown failed")
 
+    def _drain(self, futures, **_kwargs) -> list:
+        del self
+        calls.append(("drain", list(futures)))
+        return []
+
     manager._stop_foreground_advance_monitor = types.MethodType(_stop, manager)
     manager._shutdown_capture_worker = types.MethodType(_shutdown, manager)
+    manager._drain_inflight_capture_workers = types.MethodType(_drain, manager)
 
     manager.close()
 
-    assert calls == [("stop", 1.0), ("shutdown", None)]
+    # _shutdown_capture_worker 抛错时拿不到在飞清单，drain 仍要跑（独立守卫），
+    # 只是无事可等。
+    assert calls == [("stop", 1.0), ("shutdown", None), ("drain", [])]
 
 
 def test_stop_foreground_advance_monitor_does_not_retry_without_timeout() -> None:
@@ -372,3 +379,243 @@ def test_timed_out_capture_is_retained_when_recovery_limit_is_reached(
         assert first_future.result(timeout=1.0).text == "stale"
     finally:
         manager._shutdown_capture_worker()
+
+
+class _FakeRapidOcrBackend:
+    """Stand-in for the real backend: only tracks whether close() has run."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _teardown_manager(backend: _FakeRapidOcrBackend) -> OcrReaderManager:
+    manager = object.__new__(OcrReaderManager)
+    manager._logger = _NullLogger()
+    manager._capture_worker_lock = threading.Lock()
+    manager._capture_executor = None
+    manager._capture_future = None
+    manager._capture_future_started_at = 0.0
+    manager._capture_future_timed_out = False
+    manager._abandoned_capture_workers = []
+    manager._rapidocr_backend_cache = backend
+    manager._rapidocr_backend_cache_key = ("a", "b", "c", "d", "e")
+    manager.vision_classifier = None
+    manager._writer = types.SimpleNamespace(session_id="")
+    manager._attached_window = None
+    manager._stop_foreground_advance_monitor = types.MethodType(
+        lambda self, **_kwargs: None,
+        manager,
+    )
+    return manager
+
+
+def _submit_blocked_capture(
+    manager: OcrReaderManager,
+    capture,
+) -> Future[OcrExtractionResult]:
+    manager._capture_and_extract_text = capture
+    return manager._submit_capture_worker(
+        DetectedGameWindow(hwnd=1, width=800, height=600),
+        OcrCaptureProfile(),
+        SelectedOcrBackendPlan(),
+        True,
+        True,
+    )
+
+
+def test_shutdown_capture_worker_reports_only_uncancellable_futures_as_inflight() -> None:
+    """Report the worker that is already running; cancelled ones need no wait."""
+    manager = _teardown_manager(_FakeRapidOcrBackend())
+
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+
+    def _blocked_capture(*_args, **_kwargs) -> OcrExtractionResult:
+        worker_started.set()
+        release_worker.wait(timeout=5.0)
+        return OcrExtractionResult(text="done")
+
+    running_future = _submit_blocked_capture(manager, _blocked_capture)
+    assert worker_started.wait(timeout=1.0)
+
+    queued_executor = ThreadPoolExecutor(max_workers=1)
+    queued_future: Future[OcrExtractionResult] = Future()
+    finished_executor = ThreadPoolExecutor(max_workers=1)
+    finished_future: Future[OcrExtractionResult] = Future()
+    finished_future.set_result(OcrExtractionResult(text="already done"))
+    manager._abandoned_capture_workers = [
+        (queued_executor, queued_future),
+        (finished_executor, finished_future),
+    ]
+
+    try:
+        inflight = manager._shutdown_capture_worker()
+
+        assert inflight == [running_future], "只有取消不掉的在飞任务需要等"
+        assert queued_future.cancelled(), "还在排队的任务应该被取消而不是被等"
+    finally:
+        release_worker.set()
+        running_future.result(timeout=5.0)
+        queued_executor.shutdown(wait=True)
+        finished_executor.shutdown(wait=True)
+
+
+def test_shutdown_capture_worker_itself_never_waits_for_running_worker() -> None:
+    """Only teardown waits. Hot-path worker rotation calls this too."""
+    manager = _teardown_manager(_FakeRapidOcrBackend())
+
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+
+    def _blocked_capture(*_args, **_kwargs) -> OcrExtractionResult:
+        worker_started.set()
+        release_worker.wait(timeout=5.0)
+        return OcrExtractionResult(text="done")
+
+    running_future = _submit_blocked_capture(manager, _blocked_capture)
+    assert worker_started.wait(timeout=1.0)
+
+    drain_calls: list[object] = []
+
+    def _record_drain(self, futures, **_kwargs) -> list:
+        del self
+        drain_calls.append(futures)
+        return []
+
+    manager._drain_inflight_capture_workers = types.MethodType(_record_drain, manager)
+
+    try:
+        started_at = time.monotonic()
+        manager._shutdown_capture_worker()
+        elapsed = time.monotonic() - started_at
+
+        assert elapsed < 0.5, f"_shutdown_capture_worker 阻塞了 {elapsed:.2f}s"
+        assert drain_calls == [], "等待只能发生在收尾路径，不能塞进这个函数"
+    finally:
+        release_worker.set()
+        running_future.result(timeout=5.0)
+
+
+def test_close_releases_rapidocr_backend_only_after_inflight_capture_finishes() -> None:
+    """close() must not free the backend while a capture still holds its runtime."""
+    backend = _FakeRapidOcrBackend()
+    manager = _teardown_manager(backend)
+
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+    backend_closed_seen_by_worker: list[bool] = []
+
+    def _blocked_capture(*_args, **_kwargs) -> OcrExtractionResult:
+        worker_started.set()
+        release_worker.wait(timeout=5.0)
+        backend_closed_seen_by_worker.append(backend.closed)
+        return OcrExtractionResult(text="done")
+
+    running_future = _submit_blocked_capture(manager, _blocked_capture)
+    assert worker_started.wait(timeout=1.0)
+
+    releaser = threading.Timer(0.15, release_worker.set)
+    releaser.start()
+    try:
+        manager.close()
+    finally:
+        releaser.cancel()
+        release_worker.set()
+        running_future.result(timeout=5.0)
+
+    assert backend_closed_seen_by_worker == [False], (
+        "worker 跑完之前 backend 就被 close 了 —— 释放没有等在飞任务"
+    )
+    assert backend.closed is True, "等完之后重依赖仍然必须释放"
+
+
+def test_async_shutdown_releases_rapidocr_backend_only_after_inflight_capture_finishes() -> None:
+    """Plugin unload goes through async shutdown(); it waits just like close()."""
+    backend = _FakeRapidOcrBackend()
+    manager = _teardown_manager(backend)
+
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+    backend_closed_seen_by_worker: list[bool] = []
+
+    def _blocked_capture(*_args, **_kwargs) -> OcrExtractionResult:
+        worker_started.set()
+        release_worker.wait(timeout=5.0)
+        backend_closed_seen_by_worker.append(backend.closed)
+        return OcrExtractionResult(text="done")
+
+    running_future = _submit_blocked_capture(manager, _blocked_capture)
+    assert worker_started.wait(timeout=1.0)
+
+    releaser = threading.Timer(0.15, release_worker.set)
+    releaser.start()
+    try:
+        asyncio.run(manager.shutdown())
+    finally:
+        releaser.cancel()
+        release_worker.set()
+        running_future.result(timeout=5.0)
+
+    assert backend_closed_seen_by_worker == [False], (
+        "worker 跑完之前 backend 就被 close 了 —— 释放没有等在飞任务"
+    )
+    assert backend.closed is True
+
+
+def test_close_gives_up_on_stuck_capture_after_bounded_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stuck worker cannot be killed, so teardown must move on at the deadline."""
+    monkeypatch.setattr(
+        "plugin.plugins.galgame_plugin.ocr_reader._OCR_SHUTDOWN_CAPTURE_DRAIN_TIMEOUT_SECONDS",
+        0.05,
+    )
+    backend = _FakeRapidOcrBackend()
+    manager = _teardown_manager(backend)
+    warnings: list[str] = []
+
+    class _RecordingLogger(_NullLogger):
+        def warning(self, message: str, *_args) -> None:
+            warnings.append(str(message))
+
+    manager._logger = _RecordingLogger()
+
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+
+    def _stuck_capture(*_args, **_kwargs) -> OcrExtractionResult:
+        worker_started.set()
+        release_worker.wait(timeout=10.0)
+        return OcrExtractionResult(text="finally")
+
+    running_future = _submit_blocked_capture(manager, _stuck_capture)
+    assert worker_started.wait(timeout=1.0)
+
+    try:
+        started_at = time.monotonic()
+        manager.close()
+        elapsed = time.monotonic() - started_at
+
+        assert elapsed < 2.0, f"卡死的 worker 把 close() 拖了 {elapsed:.2f}s"
+        assert backend.closed is True, "等不到也必须继续释放重依赖"
+        assert any("in-flight capture worker" in message for message in warnings), (
+            "放弃等待必须留下 warning"
+        )
+    finally:
+        release_worker.set()
+        running_future.result(timeout=5.0)
+
+
+def test_drain_inflight_capture_workers_skips_wait_when_nothing_is_running() -> None:
+    manager = _teardown_manager(_FakeRapidOcrBackend())
+    finished: Future[OcrExtractionResult] = Future()
+    finished.set_result(OcrExtractionResult(text="done"))
+
+    started_at = time.monotonic()
+    pending = manager._drain_inflight_capture_workers([finished], timeout=30.0)
+
+    assert pending == []
+    assert time.monotonic() - started_at < 0.5, "没有在飞任务时不该等待"

--- a/tests/unit/test_galgame_ocr_capture_worker.py
+++ b/tests/unit/test_galgame_ocr_capture_worker.py
@@ -771,6 +771,25 @@ def test_drain_timeout_leaves_room_for_the_rest_of_plugin_shutdown() -> None:
     assert runtime_types._resolve_ocr_shutdown_drain_timeout(-1.0) == 0.0
 
 
+def test_drain_inflight_capture_workers_is_safe_to_repeat() -> None:
+    """The cancel path hands the same futures to drain twice; it must stay a pure wait."""
+    manager = _teardown_manager(_FakeRapidOcrBackend())
+    running: Future[OcrExtractionResult] = Future()
+    running.set_running_or_notify_cancel()
+
+    first = manager._drain_inflight_capture_workers([running], timeout=0.01)
+    second = manager._drain_inflight_capture_workers([running], timeout=0.01)
+
+    assert first == [running]
+    assert second == [running], "重复 drain 必须得到一致结果"
+    assert running.running(), "drain 不该改变 future 的状态"
+    assert not running.done()
+
+    running.set_result(OcrExtractionResult(text="done"))
+    assert manager._drain_inflight_capture_workers([running], timeout=0.01) == []
+    assert running.result(timeout=0).text == "done", "drain 不该消费掉 future 的结果"
+
+
 def test_drain_inflight_capture_workers_skips_wait_when_nothing_is_running() -> None:
     manager = _teardown_manager(_FakeRapidOcrBackend())
     finished: Future[OcrExtractionResult] = Future()


### PR DESCRIPTION
Closes #2498

## 原本什么样

galgame OCR 的收尾路径（插件卸载走的 `ocr_manager_poll.shutdown()`，以及对偶的 `OcrReaderManager.close()`）是这个顺序：

```
_stop_foreground_advance_monitor()
_shutdown_capture_worker()       # shutdown(wait=False, cancel_futures=True)
_release_rapidocr_backend()      # backend.close()
classifier.close()
```

`cancel_futures=True` 只能取消**还在队列里**的任务，已经进 `_capture_and_extract_text()` 的那个不受影响；`wait=False` 意味着函数立刻返回。紧接着的 `_release_rapidocr_backend()` 就把这个 worker 正在用的 RapidOCR backend 关了。

而且这不是罕见竞态。`plugin_core.shutdown()` 先 `_cancel_ocr_fast_loop()`，而 tick 等 capture future 用的是 `asyncio.shield`，cancel 只掐掉 await 方，worker 线程照跑到底。**只要卸载点落在一次 capture 的执行窗口内，重叠必然发生。**

## 实际后果没有标题听起来那么严重

不是 use-after-free，有两道现成的防线：

- `RapidOcrBackend.close()` 只置 `_closed=True` 并从全局 runtime cache 摘掉条目（refcount 制），**不销毁 ONNX session**。worker 若已经在推理里，栈上的局部 `runtime` 引用给 session 续命，跑完才回收。
- worker 若在 close 之后才调 `_ensure_runtime()`，撞的是 `RuntimeError("RapidOCR backend is closed")`，被 `_extract_text_from_image` 的 per-backend `except` 接住 → warning + 试 fallback backend。

所以真实代价是：**卸载 API 已经返回、日志说释放完了，但 ONNX 那份内存还挂在后台线程的栈上**，要等 worker 退栈才落地（#2355 那波"停用后立刻吐内存"的收益在这个窗口里落空），外加一条 OCR warning 噪音。

## 这版怎么改

`_shutdown_capture_worker()` 现在返回**取消不掉的在飞 future**（`future.cancel()` 返回 False 的那些）。收尾路径在释放重依赖之前对它们做一次有界等待，超时记 warning 继续往下走。

关键约束：**不能**把 `_shutdown_capture_worker()` 本身改成 `wait=True`——它还有两个热路径调用方（超时 worker 轮换、完成 worker 回收），那些地方不能被拖住。所以等待只加在收尾路径，而 `_shutdown_capture_worker()` 依然不阻塞。

### 等待上限从宿主的关闭预算派生

```python
def _resolve_ocr_shutdown_drain_timeout(host_shutdown_budget: float) -> float:
    ...
    return max(0.0, min(
        _OCR_SHUTDOWN_CAPTURE_DRAIN_MAX_SECONDS,          # 0.3
        budget * _OCR_SHUTDOWN_CAPTURE_DRAIN_BUDGET_SHARE,  # 0.2
    ))
```

默认 0.3s。这个上限必须远小于 `PLUGIN_SHUTDOWN_TIMEOUT`（默认 1.5s）——`PluginHost.shutdown()` 拿同一份预算 `process.join(timeout)`，到点直接 `terminate()`。drain 若把预算吃光，它后面的 backend / classifier / writer 收尾根本轮不到跑，等于用一次强杀换来什么都没释放（Codex 在 review 里指出这点，第一版正是这么写的）。

上限钉死在 0.3 而不随预算等比放大：正常一次 capture+OCR 远小于这个数，等更久只在 worker 卡死时才有区别，而 Python 杀不掉跑飞的线程，卡死的等多久都等不到——过了 deadline 只能记 warning 放行。`_OCR_MAX_ABANDONED_CAPTURE_WORKERS` 那套限流机制的存在说明这种卡死见过。

刻意不设独立于预算的下限：那样的地板会在 `NEKO_PLUGIN_SHUTDOWN_TIMEOUT` 被调小时反过来吃满整个预算（Codex 第二轮指出）。预算为 0 或负数时派生出 0.0，drain 里 `timeout > 0.0` 的分支直接跳过等待。

### async 收尾路径补上逐步守卫

`shutdown()` 里的 `await asyncio.to_thread(...)` 是这个函数唯一的 await 点，也是这次改动新引入的——改之前函数体全同步、不可被打断。被取消或线程调度失败时，后面的 backend / classifier / writer 清理会整个跳过，而调用方 `plugin_core.shutdown()` 只记一条 warning 不重试（Greptile 指出）。

现在 async `shutdown()` 与 `close()` 对偶：各步独立 `try/except`；`CancelledError` 单独接住存下来，等同步收尾全跑完再原样 `raise` 出去，取消语义不变但资源不会落在半路。

**取消之后仍然要等 drain 落地。** 取消不会停掉 `to_thread` 那个线程，它照样在 `_futures_wait` 里等；直接往下走等于取消路径整个绕过 drain，退回到「在还在跑的 worker 脚下关 backend」——正是本 PR 要修的那件事。这里没有用 `asyncio.shield`：shield 只挡得住第一次取消，第二刀落在内层 `await` 上照样能从同一个口子穿过去（Greptile 连提两轮，第二轮那条已用 shield-only 版本实证复现）。改成在当前线程上把这一等重做一遍——同步调用挡不掉也躲不开，几次 cancel 都打断不了。代价是取消路径最坏等两个 drain 上限（默认 2 × 0.3s），只在被取消时才付；正常路径依旧走 `to_thread`，不阻塞事件循环。

## 顺带说一个隐式前提

worker 用的是提交时传进去的 `plan`，descriptor 里挂着**同一个已 close 的 backend 实例**，所以它不会绕回 `_rapidocr_backend_for_config()` 去 new 一个新 backend、把 ONNX 复活到一个已经宣告释放的 manager 上。这是目前最糟情况没发生的唯一原因，但它是隐式的——如果将来有人给 worker 加 `plan=None` 兜底，复活会立刻变成真问题。

同类窗口在热路径还有一份：`_maybe_auto_switch_rapidocr_lang()` 切语言时也调 `_release_rapidocr_backend()`，此时可能有个被 abandon 的超时 worker 还攥着旧 backend。后果同上（warning + 该次 OCR 作废），频率被 cooldown 压着。**本 PR 不碰**——那是热路径行为，与收尾无关。

## 测试

`tests/unit/test_galgame_ocr_capture_worker.py`，23 passed。新增 12 条，并把既有的收尾顺序断言从四步扩到五步。

九个变异都验证过会被抓：

| 变异 | 被抓的用例 |
| --- | --- |
| `close()` 里去掉 drain | 8 failed（含端到端那条） |
| async `shutdown()` 里去掉 drain | `test_async_shutdown_releases_rapidocr_backend_only_after_inflight_capture_finishes` |
| `_shutdown_capture_worker()` 不上报在飞 future | 4 failed |
| 等待改成无界 | `test_close_gives_up_on_stuck_capture_after_bounded_wait` |
| 上限调回 1.5s（吃光宿主预算） | `test_drain_timeout_leaves_room_for_the_rest_of_plugin_shutdown` |
| 把独立于预算的 50ms 地板加回来 | 同上 |
| 不接 `CancelledError` | `test_async_shutdown_finishes_cleanup_when_cancelled_mid_drain` |
| 取消后不重做 drain | 同上 |
| 取消后改用 shield-only（挡不住二次取消） | 同上 |

端到端那两条（`close()` / async `shutdown()` 各一条）的断言方式是：worker 在退出前记录一次 `backend.closed` 快照，必须是 `False`——即 backend 是在 worker 跑完**之后**才被关的。

本地门：`check_docstring_no_cjk.py --base origin/main`、`check_pr_report.py`、`ruff check` 全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
