### PR TITLE
ci(prompts): 新增 prompt dict 必须带 zh-TW 的棘轮门禁（#2500 第 2 步）

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -205,10 +205,12 @@ jobs:
         # localized prompt table, and `_loc` falls back to 'en' rather than
         # 'zh' on a missing key — so a table without 'zh-TW' serves Traditional
         # Chinese users an English prompt. 339 existing tables are still short
-        # one (the batched backfill in issue #2500), so this is a diff-ratchet
-        # keyed on the dict's own definition line: it fires for dicts a PR
-        # introduces and stays quiet about the existing stock. Editing an
-        # existing table's copy does not trip it. `--full` lists the whole
+        # one (the batched backfill in issue #2500), so this is a ratchet: it
+        # compares how many such tables exist at the merge-base vs at HEAD and
+        # fails only when the total grew. A plain total is what keeps renames,
+        # copy edits, added locales, and the eventual 'zh'->'zh-CN' migration
+        # from tripping it — see the script docstring for the three narrower
+        # keys that were tried and why each broke. `--full` lists the whole
         # backlog, `--count` just sizes it. Suppress a single dict with
         # `# noqa: PROMPT_ZH_TW` on its opening line. Skipped on direct push
         # to main — nothing to diff against.

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -212,7 +212,9 @@ jobs:
         # from tripping it — see the script docstring for the three narrower
         # keys that were tried and why each broke. `--full` lists the whole
         # backlog, `--count` just sizes it. Suppress a single dict with
-        # `# noqa: PROMPT_ZH_TW` on its opening line. Skipped on direct push
+        # a `noqa` comment naming PROMPT_ZH_TW on its opening or closing line
+        # (comma-separated lists and a bare `noqa` work too, as in the sibling
+        # gates). Skipped on direct push
         # to main — nothing to diff against.
         if: github.event_name == 'pull_request'
         env:

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -200,6 +200,24 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: python scripts/check_docstring_no_cjk.py --base "origin/${BASE_REF}"
 
+      - name: Require zh-TW on new localized prompt dicts (PR-only)
+        # A dict under config/prompts/ with an 'en' key plus 'zh'/'zh-CN' is a
+        # localized prompt table, and `_loc` falls back to 'en' rather than
+        # 'zh' on a missing key — so a table without 'zh-TW' serves Traditional
+        # Chinese users an English prompt. 339 existing tables are still short
+        # one (the batched backfill in issue #2500), so this is a diff-ratchet
+        # keyed on the dict's own definition line: it fires for dicts a PR
+        # introduces and stays quiet about the existing stock. Editing an
+        # existing table's copy does not trip it. `--full` lists the whole
+        # backlog, `--count` just sizes it. Suppress a single dict with
+        # `# noqa: PROMPT_ZH_TW` on its opening line. Skipped on direct push
+        # to main — nothing to diff against.
+        if: github.event_name == 'pull_request'
+        env:
+          # Same zizmor template-injection indirection as the i18n-sync step.
+          BASE_REF: ${{ github.base_ref }}
+        run: python scripts/check_prompt_zh_tw.py --base "origin/${BASE_REF}"
+
   api-layering:
     name: API & layering
     runs-on: ubuntu-latest

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -137,8 +137,13 @@ def resolve_keys(node: ast.AST) -> set[str] | None:
                 if inner is None:
                     return None
                 keys |= inner
-            elif isinstance(key, ast.Constant) and isinstance(key.value, str):
-                keys.add(key.value)
+            elif isinstance(key, ast.Constant):
+                # A *constant* non-string key (a None sentinel, an int) cannot be
+                # 'zh-TW', so it hides nothing and is simply not a locale key —
+                # skip it and keep reading. Only a non-constant key forces the
+                # whole table to be abandoned, since that one could be anything.
+                if isinstance(key.value, str):
+                    keys.add(key.value)
             else:
                 return None
         return keys
@@ -175,7 +180,39 @@ def resolve_keys(node: ast.AST) -> set[str] | None:
         return left | right
     if isinstance(node, ast.DictComp):
         return _comprehension_keys(node)
+    if isinstance(node, ast.Call) and _is_dict_fromkeys(node.func):
+        # `dict.fromkeys(("en", "zh"), template)` — one template shared across a
+        # literal locale list. func is an Attribute, so the `dict(...)` branch
+        # above does not see it, and there is no child mapping node for the walker
+        # to fall back on.
+        return _literal_string_sequence(node.args[0]) if node.args else None
     return None
+
+
+def _is_dict_fromkeys(func: ast.AST) -> bool:
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr == "fromkeys"
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "dict"
+    )
+
+
+def _literal_string_sequence(node: ast.AST) -> set[str] | None:
+    """String constants of a literal Tuple/List/Set, or None if not literal.
+
+    Non-string *constants* are skipped rather than disqualifying the sequence, for
+    the same reason as constant non-string dict keys: they cannot be 'zh-TW'.
+    """
+    if not isinstance(node, (ast.Tuple, ast.List, ast.Set)):
+        return None
+    keys: set[str] = set()
+    for element in node.elts:
+        if not isinstance(element, ast.Constant):
+            return None
+        if isinstance(element.value, str):
+            keys.add(element.value)
+    return keys
 
 
 def _pair_sequence_keys(node: ast.AST) -> set[str] | None:
@@ -192,9 +229,12 @@ def _pair_sequence_keys(node: ast.AST) -> set[str] | None:
         if not isinstance(element, (ast.Tuple, ast.List)) or len(element.elts) != 2:
             return None
         first = element.elts[0]
-        if not isinstance(first, ast.Constant) or not isinstance(first.value, str):
+        if not isinstance(first, ast.Constant):
             return None
-        keys.add(first.value)
+        # Constant non-string keys are skipped, not disqualifying — same rule as
+        # dict literals: such a key cannot be 'zh-TW'.
+        if isinstance(first.value, str):
+            keys.add(first.value)
     return keys
 
 
@@ -229,13 +269,7 @@ def _comprehension_keys(node: ast.DictComp) -> set[str] | None:
     if isinstance(gen.target, ast.Name):
         if gen.target.id != node.key.id:
             return None
-        keys: set[str] = set()
-        for element in gen.iter.elts:
-            if not (isinstance(element, ast.Constant)
-                    and isinstance(element.value, str)):
-                return None
-            keys.add(element.value)
-        return keys
+        return _literal_string_sequence(gen.iter)
 
     if isinstance(gen.target, ast.Tuple):
         names = [e.id for e in gen.target.elts if isinstance(e, ast.Name)]

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -337,8 +337,38 @@ def _comprehension_keys(node: ast.DictComp) -> set[str] | None:
     return None
 
 
+def _operand_branches(node: ast.AST) -> list[ast.AST]:
+    """An operand, or — when it is conditional — the branches it picks between.
+
+    ``{**(A if flag else B), "zh-TW": t}`` merges whichever of A/B runs, so both
+    are fragments of the same table. Naming only the ``IfExp`` left traversal free
+    to reach A and B and judge each on its own — two false offenders for one
+    compliant table.
+
+    The ``IfExp`` itself is not returned: nothing judges one (it is not a mapping
+    expression), so listing it would be a line no test can hold to account.
+    """
+    if isinstance(node, ast.IfExp):
+        return [*_operand_branches(node.body), *_operand_branches(node.orelse)]
+    return [node]
+
+
 def _merge_operands(node: ast.AST) -> list[ast.AST]:
     """The sub-mappings a merged construction composes, or ``[]`` if not a merge.
+
+    Conditional operands are expanded into their branches here rather than at each
+    caller, so every consumer — fragment suppression, the merge exemption, and
+    payload key resolution — agrees on what counts as a fragment.
+    """
+    return [
+        part
+        for operand in _direct_merge_operands(node)
+        for part in _operand_branches(operand)
+    ]
+
+
+def _direct_merge_operands(node: ast.AST) -> list[ast.AST]:
+    """The operands a merge names outright, before conditionals are expanded.
 
     ``{**a, **b}``, ``dict(BASE, zh=...)`` and ``a | b`` compose their keys out of
     other mappings, so each operand is a *fragment*: the ``'zh-TW'`` entry may
@@ -419,12 +449,17 @@ def _directly_visible_keys(
         return _directly_visible_keys(node.left, resolve_name) | _directly_visible_keys(node.right, resolve_name)
     if isinstance(node, ast.Name) and resolve_name is not None:
         return resolve_name(node.id)
-    if isinstance(node, ast.Call) and _is_dict_fromkeys(node.func) and node.args:
-        # `_F | dict.fromkeys(("zh-TW",), t)` — resolve_keys handles this
-        # constructor, so the visibility scan has to as well or the union looks
-        # like it supplies nothing and _F gets reported.
-        return _literal_string_sequence(node.args[0]) or set()
-    return set()
+    if isinstance(node, ast.IfExp):
+        # Either branch may be the one that carries zh-TW, and a conditional
+        # supply still counts here — same call as `if enabled: T["zh-TW"] = t`.
+        return _directly_visible_keys(node.body, resolve_name) | _directly_visible_keys(
+            node.orelse, resolve_name
+        )
+    # Anything else resolve_keys understands: `_F | dict.fromkeys(("zh-TW",), t)`,
+    # `_F | {loc: tpl for loc in ("zh-TW",)}`. Delegating rather than re-listing
+    # the constructors keeps this from lagging behind resolve_keys again — each
+    # time it did, the union looked like it supplied nothing and _F got reported.
+    return resolve_keys(node) or set()
 
 
 def _exempt_table_nodes(tree: ast.AST) -> set[int]:
@@ -510,6 +545,56 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
         if value is not None:
             exempt.add(id(value))
 
+    def _mapping_keys(
+        node: ast.AST | None, at: int, _seen: frozenset[str] = frozenset()
+    ) -> set[str]:
+        """Keys a mapping expression supplies, following names to their bindings.
+
+        One resolver for every place a name can stand in for a mapping — a mutation
+        payload, a merge operand, an alias of either. Each of those grew its own
+        partial version first (``resolve_keys`` only; no iterable-of-pairs; no
+        second hop through ``TW2 = dict(TW)``), and every gap read as "no zh-TW
+        here", i.e. a table reported despite being compliant at runtime.
+
+        ``_seen`` guards the name hops, so mutual or self-referential bindings
+        terminate instead of recursing forever.
+        """
+        if node is None:
+            return set()
+        if isinstance(node, ast.Name):
+            if node.id in _seen:
+                return set()
+            return _name_keys(node.id, at, _seen=_seen)
+        if isinstance(node, ast.IfExp):
+            # `T |= TW if flag else {"zh-TW": t}` — either branch may carry it, and
+            # a conditional supply counts, same as in `_directly_visible_keys`.
+            return _mapping_keys(node.body, at, _seen) | _mapping_keys(
+                node.orelse, at, _seen
+            )
+        keys = resolve_keys(node)
+        if keys is None:
+            keys = _pair_sequence_keys(node)
+        if keys is None:
+            # A construction resolve_keys gave up on because its own parts are
+            # names: `dict(TW)`, `{**TW}`, `BASE | TW`.
+            operands = _merge_operands(node)
+            if operands:
+                keys = _directly_visible_keys(node)
+                for operand in operands:
+                    keys |= _mapping_keys(operand, at, _seen)
+        return keys or set()
+
+    def _name_keys(
+        name: str,
+        at: int,
+        exclude: ast.AST | None = None,
+        _seen: frozenset[str] = frozenset(),
+    ) -> set[str]:
+        """Keys of the mapping `name` is bound to just before `at`."""
+        return _mapping_keys(
+            _binding_before(name, at, exclude), at, _seen | {name}
+        )
+
     for node in ast.walk(tree):
         # `T["zh-TW"] = t`, and its annotated form `T["zh-TW"]: str = t`.
         # AnnAssign carries a single `target` rather than a `targets` list, so it
@@ -565,23 +650,10 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
         if target is None or not payloads:
             continue
 
-        def _payload_keys(payload: ast.AST, _at: int = node.lineno) -> set[str]:
-            """Keys a mutation payload supplies, or empty if unknowable.
-
-            Three shapes, in order: a mapping expression, an iterable of pairs
-            (`update([("zh-TW", t)])`), and a name bound to a mapping earlier
-            (`TW = {"zh-TW": t}` / `T.update(TW)`) — the last one uses the same
-            preceding-binding lookup as merge operands, which it previously did not.
-            """
-            keys = resolve_keys(payload)
-            if keys is None:
-                keys = _pair_sequence_keys(payload)
-            if keys is None and isinstance(payload, ast.Name):
-                bound = _binding_before(payload.id, _at)
-                keys = resolve_keys(bound) if bound is not None else None
-            return keys or set()
-
-        if any(TRADITIONAL_KEY in _payload_keys(p) for p in payloads):
+        if any(
+            TRADITIONAL_KEY in _mapping_keys(payload, node.lineno)
+            for payload in payloads
+        ):
             _exempt_binding_before(target, node.lineno)
 
     # A name merged into a construction that *demonstrably supplies zh-TW* is a
@@ -597,15 +669,11 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
         if not operands:
             continue
 
+        # `_TW = {"zh-TW": t}` / `T = {**_F, **_TW}` supplies zh-TW as plainly as an
+        # inline literal. Following the name only ever *adds* visible keys, so
+        # `U = dict(T)` still sees {en, zh} and leaves T subject to the rule.
         def _named_keys(name: str, _at: int = node.lineno, _self: ast.AST = node) -> set[str]:
-            """Keys of a name's preceding binding, so a named supplier counts.
-
-            `_TW = {"zh-TW": t}` / `T = {**_F, **_TW}` supplies zh-TW as plainly as
-            an inline literal. Following the name only ever *adds* visible keys, so
-            `U = dict(T)` still sees {en, zh} and leaves T subject to the rule.
-            """
-            bound = _binding_before(name, _at, exclude=_self)
-            return (resolve_keys(bound) or set()) if bound is not None else set()
+            return _name_keys(name, _at, exclude=_self)
 
         if TRADITIONAL_KEY not in _directly_visible_keys(node, _named_keys):
             continue

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -80,7 +80,7 @@ exemption is deliberately keyed on the mutation *demonstrably supplying zh-TW*:
 exempting on any mutation would let an unrelated ``T["other"] = x`` excuse a real
 offender, trading one rare false positive for a broad blind spot.
 
-Three accepted blind spots, all on the miss side:
+Four accepted blind spots, all on the miss side:
 
   * The exemption is not ordered against *other* uses of the name, so a copy taken
     before the backfill is not judged::
@@ -98,6 +98,16 @@ Three accepted blind spots, all on the miss side:
     bodies unreadable, so it is not a shape prompt modules use — there are zero
     occurrences under config/prompts. Chasing constructor forms with no realistic
     use grows ``resolve_keys`` without shrinking the backlog.
+  * A removal that reaches the table through a different name is not seen::
+
+        T = {"en": "e", "zh": "s"}
+        A = T                    # same object
+        T["zh-TW"] = "t"
+        A.pop("zh-TW")           # …so this really does un-complete T
+
+    Knowing that A and T are the same object is alias analysis -- a set of names
+    per object, maintained across rebinding -- rather than the per-name timeline
+    everything else here uses.
   * A table assembled from fragments that are each *individually* fine is not
     judged::
 
@@ -661,7 +671,7 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
     # table. The same index answers the reverse — a later `del TW["zh-TW"]` means
     # an earlier backfill no longer makes its table compliant.
     mutations: dict[
-        str, list[tuple[tuple[int, int], set[str], set[str], tuple[str, ...]]]
+        str, list[tuple[tuple[int, int], set[str], set[str], tuple[ast.AST, ...]]]
     ] = {}
 
     def _record(
@@ -669,10 +679,10 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
         at: tuple[int, int],
         added: set[str],
         removed: set[str],
-        added_names: tuple[str, ...] = (),
+        payloads: tuple[ast.AST, ...] = (),
     ) -> None:
-        if added or removed or added_names:
-            mutations.setdefault(name, []).append((at, added, removed, added_names))
+        if added or removed or payloads:
+            mutations.setdefault(name, []).append((at, added, removed, payloads))
 
     for node in ast.walk(tree):
         at = _source_position(node)
@@ -708,27 +718,22 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
             elif node.func.attr == "update":
                 # Only what the payload states outright. Resolving names here would
                 # need the very index being built.
-                added: set[str] = set()
-                # A payload that is a name is kept as a reference and resolved
-                # later: resolving it here would need this very index.
-                names: list[str] = []
-                for payload in list(node.args) + [
-                    kw.value for kw in node.keywords if kw.arg is None
-                ]:
-                    if isinstance(payload, ast.Name):
-                        names.append(payload.id)
-                        continue
-                    added |= resolve_keys(payload) or _pair_sequence_keys(payload) or set()
-                _record(node.func.value.id, at, added, set(), tuple(names))
+                # The payload expressions themselves, resolved on the way out:
+                # resolving them here would need this very index. Keeping the
+                # nodes rather than just the names they mention also covers a
+                # wrapped source — `update({**A})`, `update(dict(A))`.
+                _record(
+                    node.func.value.id, at, set(), set(),
+                    tuple(node.args) + tuple(
+                        kw.value for kw in node.keywords if kw.arg is None
+                    ),
+                )
         elif (
             isinstance(node, ast.AugAssign)
             and isinstance(node.op, ast.BitOr)
             and isinstance(node.target, ast.Name)
         ):
-            if isinstance(node.value, ast.Name):
-                _record(node.target.id, at, set(), set(), (node.value.id,))
-            else:
-                _record(node.target.id, at, resolve_keys(node.value) or set(), set())
+            _record(node.target.id, at, set(), set(), (node.value,))
 
     for entries in mutations.values():
         entries.sort(key=lambda item: item[0])
@@ -785,7 +790,7 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
         rebound = next(
             (pos for pos, _ in assignments.get(name, ()) if pos > at), None
         )
-        for pos, _added, removed, _names in mutations.get(name, ()):
+        for pos, _added, removed, _payloads in mutations.get(name, ()):
             if pos <= at or (rebound is not None and pos > rebound):
                 continue
             if TRADITIONAL_KEY in removed:
@@ -894,11 +899,11 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
         # `A.update(A)`. Nothing legitimate sits at exactly the use position — a
         # statement records its mutation against the name it mutates, not the one
         # it reads.
-        for pos, added, removed, added_names in mutations.get(name, ()):
+        for pos, added, removed, payloads in mutations.get(name, ()):
             if not bound_at < pos < at:
                 continue
-            for other in added_names:
-                added = added | _name_keys(other, pos)
+            for payload in payloads:
+                added = added | _mapping_keys(payload, pos)
             keys = (keys | added) - removed
         return keys
 

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -367,7 +367,9 @@ def _generator_pair_keys(node: ast.GeneratorExp) -> set[str] | None:
     handed to ``_comprehension_keys`` in the slots a DictComp keeps them in, so the
     two spellings cannot drift apart.
     """
-    if not isinstance(node.elt, ast.Tuple) or len(node.elt.elts) != 2:
+    # A list element is as valid a pair as a tuple one — `dict` only asks for a
+    # two-item iterable, and `_pair_sequence_keys` already accepts both.
+    if not isinstance(node.elt, (ast.Tuple, ast.List)) or len(node.elt.elts) != 2:
         return None
     return _comprehension_keys(
         ast.DictComp(
@@ -386,6 +388,61 @@ def _source_position(node: ast.AST) -> tuple[int, int]:
     them as preceding the mutation in the middle.
     """
     return getattr(node, "lineno", 0), getattr(node, "col_offset", 0)
+
+
+def _subscript_key(slot: ast.AST) -> str | None:
+    """The constant string key of ``NAME["key"]``, or None for anything else."""
+    if (
+        isinstance(slot, ast.Subscript)
+        and isinstance(slot.value, ast.Name)
+        and isinstance(slot.slice, ast.Constant)
+        and isinstance(slot.slice.value, str)
+    ):
+        return slot.slice.value
+    return None
+
+
+def _unpacked_bindings(target: ast.AST, value: ast.AST) -> list[tuple[str, ast.AST]]:
+    """``(name, bound expression)`` pairs an assignment establishes.
+
+    A plain ``T = {...}`` is one pair. Unpacking is the other shape that binds a
+    name to a table: ``T, flag = ({...}, True)`` reads as an ordinary way to bind
+    two things at once, and registering only top-level Name targets left a later
+    ``T["zh-TW"] = t`` with no binding to exempt.
+
+    Positional only, and only when both sides are literal sequences — anything
+    else (a call, a name) makes the pairing unknowable, and guessing here would
+    exempt the wrong table. A starred slot is paired from both ends around it, the
+    way Python does; the starred name itself always receives a list, never a
+    table, so it binds nothing.
+    """
+    if isinstance(target, ast.Name):
+        return [(target.id, value)]
+    if not (
+        isinstance(target, (ast.Tuple, ast.List))
+        and isinstance(value, (ast.Tuple, ast.List))
+    ):
+        return []
+    stars = [i for i, slot in enumerate(target.elts) if isinstance(slot, ast.Starred)]
+    if len(stars) > 1:
+        return []
+    if not stars:
+        if len(target.elts) != len(value.elts):
+            return []  # a ValueError at runtime; the gate does not guess past it
+        head, tail = list(zip(target.elts, value.elts)), []
+    else:
+        star = stars[0]
+        after = len(target.elts) - star - 1
+        if len(value.elts) < star + after:
+            return []
+        head = list(zip(target.elts[:star], value.elts[:star]))
+        tail = list(
+            zip(target.elts[star + 1:], value.elts[len(value.elts) - after:])
+        ) if after else []
+    pairs: list[tuple[str, ast.AST]] = []
+    for slot, item in head + tail:
+        pairs.extend(_unpacked_bindings(slot, item))
+    return pairs
 
 
 def _assignment_slots(targets: list[ast.AST]) -> list[ast.AST]:
@@ -565,10 +622,12 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
         if isinstance(node, ast.Assign):
             # Every simple target, so a chained `T = U = {...}` registers both —
             # they name the same object, and a mutation through either completes it.
+            # Unpacking counts too: `T, flag = ({...}, True)` binds T just as much,
+            # and without it a later `T["zh-TW"] = t` found nothing to exempt.
             for target in node.targets:
-                if isinstance(target, ast.Name):
-                    assignments.setdefault(target.id, []).append(
-                        (_source_position(node.value), node.value)
+                for bound, value in _unpacked_bindings(target, node.value):
+                    assignments.setdefault(bound, []).append(
+                        (_source_position(value), value)
                     )
             continue
         if (
@@ -587,6 +646,62 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
         )
     for bindings in assignments.values():
         bindings.sort(key=lambda item: item[0])
+
+    # What each name's table gains and loses after it is bound, in source order.
+    # A name is not only what it was bound to: `TW = {}` / `TW["zh-TW"] = t` is an
+    # ordinary way to assemble one, and reading only the literal saw an empty
+    # table. The same index answers the reverse — a later `del TW["zh-TW"]` means
+    # an earlier backfill no longer makes its table compliant.
+    mutations: dict[str, list[tuple[tuple[int, int], set[str], set[str]]]] = {}
+
+    def _record(name: str, at: tuple[int, int], added: set[str], removed: set[str]) -> None:
+        if added or removed:
+            mutations.setdefault(name, []).append((at, added, removed))
+
+    for node in ast.walk(tree):
+        at = _source_position(node)
+        slots: list[ast.AST] = []
+        if isinstance(node, ast.Assign):
+            slots = _assignment_slots(node.targets)
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            slots = _assignment_slots([node.target])
+        elif isinstance(node, ast.Delete):
+            for slot in _assignment_slots(node.targets):
+                key = _subscript_key(slot)
+                if key is not None:
+                    _record(slot.value.id, at, set(), {key})
+            continue
+        for slot in slots:
+            key = _subscript_key(slot)
+            if key is not None:
+                _record(slot.value.id, at, {key}, set())
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+        ):
+            if node.func.attr == "setdefault" and node.args:
+                first = node.args[0]
+                if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                    _record(node.func.value.id, at, {first.value}, set())
+            elif node.func.attr == "update":
+                # Only what the payload states outright. Resolving names here would
+                # need the very index being built.
+                added: set[str] = set()
+                for payload in list(node.args) + [
+                    kw.value for kw in node.keywords if kw.arg is None
+                ]:
+                    added |= resolve_keys(payload) or _pair_sequence_keys(payload) or set()
+                _record(node.func.value.id, at, added, set())
+        elif (
+            isinstance(node, ast.AugAssign)
+            and isinstance(node.op, ast.BitOr)
+            and isinstance(node.target, ast.Name)
+        ):
+            _record(node.target.id, at, resolve_keys(node.value) or set(), set())
+
+    for entries in mutations.values():
+        entries.sort(key=lambda item: item[0])
 
     # Every node back to the bound expression it sits inside, so a self-rebinding
     # merge can be recognized through any wrapper. Identity against the merge node
@@ -630,6 +745,23 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
             return pos, value
         return None
 
+    def _traditional_removed_after(name: str, at: tuple[int, int]) -> bool:
+        """Whether `del name["zh-TW"]` undoes a backfill before `name` is rebound.
+
+        The exemption says "this literal is compliant by the time it runs". A later
+        removal makes that false again, and since a deletion creates no mapping node
+        of its own, nothing else would notice.
+        """
+        rebound = next(
+            (pos for pos, _ in assignments.get(name, ()) if pos > at), None
+        )
+        for pos, _added, removed in mutations.get(name, ()):
+            if pos <= at or (rebound is not None and pos > rebound):
+                continue
+            if TRADITIONAL_KEY in removed:
+                return True
+        return False
+
     def _exempt_binding_before(
         name: str, at: tuple[int, int], strict: bool = False
     ) -> None:
@@ -640,6 +772,8 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
         bare ``Name``, so ``F``'s literal — the node actually judged — stayed
         subject to the rule and a compliant table still grew the count.
         """
+        if _traditional_removed_after(name, at):
+            return
         pending, walked = [(name, at, strict)], set()
         while pending:
             current, pos, skip_self = pending.pop()
@@ -721,7 +855,14 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
         if found is None:
             return set()
         bound_at, value = found
-        return _mapping_keys(value, bound_at, strict=True)
+        keys = _mapping_keys(value, bound_at, strict=True)
+        # Plus whatever demonstrable mutations did to it between then and here.
+        # `TW = {}` / `TW["zh-TW"] = t` / `T.update(TW)` assembles a supplier in two
+        # steps, and reading only the literal saw an empty table.
+        for pos, added, removed in mutations.get(name, ()):
+            if bound_at < pos <= at:
+                keys = (keys | added) - removed
+        return keys
 
     for node in ast.walk(tree):
         # `T["zh-TW"] = t`, and its annotated form `T["zh-TW"]: str = t`.

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -559,6 +559,20 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
     for bindings in assignments.values():
         bindings.sort(key=lambda item: item[0])
 
+    # Every node back to the bound expression it sits inside, so a self-rebinding
+    # merge can be recognized through any wrapper. Identity against the merge node
+    # alone missed `T = (T | {"zh-TW": t}) if flag else ...`, where the registered
+    # binding is the IfExp and each `T` then resolved to the assignment being
+    # evaluated rather than the table it actually reads.
+    # A node belongs to exactly one bound expression, so plain assignment is
+    # enough — a chained `T = U = {...}` registers the same value node twice and
+    # writes the same answer both times.
+    bound_expression: dict[int, ast.AST] = {}
+    for bindings in assignments.values():
+        for _, value in bindings:
+            for inner in ast.walk(value):
+                bound_expression[id(inner)] = value
+
     exempt: set[int] = set()
 
     def _binding_before(
@@ -586,9 +600,38 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
     def _exempt_binding_before(
         name: str, lineno: int, exclude: ast.AST | None = None
     ) -> None:
-        found = _binding_before(name, lineno, exclude)
-        if found is not None:
-            exempt.add(id(found[1]))
+        """Exempt what `name` holds, down through aliases and nested merges.
+
+        Stopping at the binding's own value node exempted the wrong thing whenever
+        a fragment reached the merge indirectly: for ``F2 = F`` that value is a
+        bare ``Name``, so ``F``'s literal — the node actually judged — stayed
+        subject to the rule and a compliant table still grew the count.
+        """
+        pending, walked = [(name, lineno, exclude)], set()
+        while pending:
+            current, at, skip = pending.pop()
+            found = _binding_before(current, at, skip)
+            if found is None:
+                continue
+            bound_at, value = found
+            if id(value) in walked:
+                continue
+            walked.add(id(value))
+            exempt.add(id(value))
+            for part in _fragment_parts(value):
+                if isinstance(part, ast.Name):
+                    pending.append((part.id, bound_at, None))
+
+    def _fragment_parts(node: ast.AST) -> list[ast.AST]:
+        """The sub-expressions that stand in for `node` — aliases and operands.
+
+        A bare name is an alias for whatever it holds; a merge is made of its
+        operands. Either way the fragment being exempted may be one level further
+        down, and each level is the same fragment of the same compliant table.
+        """
+        if isinstance(node, ast.Name):
+            return [node]
+        return _merge_operands(node)
 
     def _mapping_keys(
         node: ast.AST | None, at: int, _seen: frozenset[str] = frozenset()
@@ -724,10 +767,16 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
         if not operands:
             continue
 
+        # The whole bound expression, not this merge node: `T = (T | {"zh-TW": t})
+        # if flag else ...` registers the IfExp as T's new binding, so excluding
+        # the merge by identity left each `T` resolving to the assignment being
+        # evaluated instead of the table it reads.
+        enclosing = bound_expression.get(id(node), node)
+
         # `_TW = {"zh-TW": t}` / `T = {**_F, **_TW}` supplies zh-TW as plainly as an
         # inline literal. Following the name only ever *adds* visible keys, so
         # `U = dict(T)` still sees {en, zh} and leaves T subject to the rule.
-        def _named_keys(name: str, _at: int = node.lineno, _self: ast.AST = node) -> set[str]:
+        def _named_keys(name: str, _at: int = node.lineno, _self: ast.AST = enclosing) -> set[str]:
             return _name_keys(name, _at, exclude=_self)
 
         if TRADITIONAL_KEY not in _directly_visible_keys(node, _named_keys):
@@ -743,7 +792,7 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
                 continue
             walked.add(id(operand))
             if isinstance(operand, ast.Name):
-                _exempt_binding_before(operand.id, node.lineno, exclude=node)
+                _exempt_binding_before(operand.id, node.lineno, exclude=enclosing)
             else:
                 pending.extend(_merge_operands(operand))
 

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -124,44 +124,53 @@ def _string_keys(node: ast.AST) -> set[str]:
     return set()
 
 
-def _is_merged_construction(node: ast.AST) -> bool:
-    """Whether this node assembles a mapping out of other mappings.
+def _merge_operands(node: ast.AST) -> list[ast.AST]:
+    """The sub-mappings a merged construction composes, or ``[]`` if not a merge.
 
-    ``{**a, **b}``, ``dict(BASE, zh=...)`` and ``a | b`` all have keys that are
-    not statically knowable, and their component literals are *fragments* rather
-    than tables: the ``'zh-TW'`` entry may live in any one of them.
+    ``{**a, **b}``, ``dict(BASE, zh=...)`` and ``a | b`` compose their keys out of
+    other mappings, so each operand is a *fragment*: the ``'zh-TW'`` entry may
+    live in any one of them and none can be judged alone.
+
+    Only the operands themselves. A value keyed normally alongside a spread
+    (``{**COMMON, "new": {...}}``) is not a fragment — it is an independent table
+    that happens to sit in a merged container.
     """
     if isinstance(node, ast.Dict):
-        return any(k is None for k in node.keys)
+        return [v for k, v in zip(node.keys, node.values) if k is None]
     if (
         isinstance(node, ast.Call)
         and isinstance(node.func, ast.Name)
         and node.func.id == "dict"
     ):
-        return bool(node.args) or any(kw.arg is None for kw in node.keywords)
+        return list(node.args) + [kw.value for kw in node.keywords if kw.arg is None]
     if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
-        return True
-    return False
+        return [node.left, node.right]
+    return []
 
 
 def _table_nodes(tree: ast.AST) -> Iterator[ast.AST]:
-    """Yield dict-shaped nodes, pruning the innards of merged constructions.
+    """Yield dict-shaped nodes, suppressing merge fragments.
 
-    Skipping a merged construction is not enough — ``ast.walk`` would still
-    descend into it and judge each component literal on its own, reporting the
-    fragment that happens to lack ``'zh-TW'`` even though the assembled mapping
-    carries it. So a merged construction is skipped *with its descendants*.
+    Two failure modes to thread between:
 
-    Ordinary nesting (``{"greeting": {"en": ..., "zh": ...}}``) is not merging:
-    the inner dict is a table in its own right and is still yielded.
+      * Plain ``ast.walk`` judges each operand of a merge on its own, so
+        ``{**{"en": ..., "zh": ...}, **{"zh-TW": ...}}`` reports the first half as
+        missing zh-TW even though the assembled mapping has it.
+      * Pruning a merge's whole subtree instead loses the independent tables
+        inside it — ``{**COMMON, "new": {"en": ..., "zh": ...}}`` would never
+        check ``"new"``.
+
+    So operand roots are suppressed (not yielded) while traversal continues
+    through them and through everything else the container holds.
     """
+    suppressed: set[int] = set()
     stack: list[ast.AST] = [tree]
     while stack:
         node = stack.pop()
-        if _is_merged_construction(node):
-            continue
-        if isinstance(node, (ast.Dict, ast.Call)):
+        if isinstance(node, (ast.Dict, ast.Call)) and id(node) not in suppressed:
             yield node
+        for operand in _merge_operands(node):
+            suppressed.add(id(operand))
         stack.extend(ast.iter_child_nodes(node))
 
 

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -91,37 +91,65 @@ def _has_noqa(line: str) -> bool:
     return bool(re.search(rf"#\s*noqa:\s*{CODE}\b", line))
 
 
-def _string_keys(node: ast.AST) -> set[str]:
-    """String keys of a dict literal, or of a ``dict(en=..., zh=...)`` call.
+def resolve_keys(node: ast.AST) -> set[str] | None:
+    """Statically resolve a mapping expression's key set, or None if unknowable.
 
-    The call form cannot express ``zh-CN`` or ``zh-TW`` as keywords (neither is
-    an identifier), but it can express ``zh``, so a table written that way is
-    still subject to the rule.
+    Merges are resolved *through*, not skipped: ``{"en": ...} | {"zh": ...}``
+    resolves to ``{en, zh}``, so the assembled table is judged even though neither
+    half is a table on its own. That is what stops a compliant
+    ``{"en", "zh"} | {"zh-TW"}`` from being reported as two fragments, and equally
+    stops a non-compliant ``{"en"} | {"zh"}`` from slipping through as neither.
 
-    Returns empty — i.e. "not a table I can judge" — for a call carrying ``**``,
-    since the unpacked mapping is exactly where such a table would have to put
-    its ``'zh-TW'`` entry. Reporting it would be a false positive, and a gate
-    that cries wolf gets worked around rather than satisfied.
+    ``None`` means some part is not statically knowable — a spread of a name, a
+    non-constant key, ``dict()`` over a variable. The gate stays silent on those
+    rather than guessing, because the unknowable part is exactly where a
+    ``'zh-TW'`` entry could be hiding, and a gate that cries wolf gets worked
+    around rather than satisfied.
+
+    Note the ``dict(...)`` call form cannot express ``zh-CN`` or ``zh-TW`` as
+    keywords (neither is an identifier), but it can express ``zh``, so a table
+    written that way is still subject to the rule.
     """
     if isinstance(node, ast.Dict):
-        if any(k is None for k in node.keys):
-            return set()  # `{**other}` — same unknowable-keys problem
-        return {
-            k.value
-            for k in node.keys
-            if isinstance(k, ast.Constant) and isinstance(k.value, str)
-        }
+        keys: set[str] = set()
+        for key, value in zip(node.keys, node.values):
+            if key is None:
+                inner = resolve_keys(value)
+                if inner is None:
+                    return None
+                keys |= inner
+            elif isinstance(key, ast.Constant) and isinstance(key.value, str):
+                keys.add(key.value)
+            else:
+                return None
+        return keys
     if (
         isinstance(node, ast.Call)
         and isinstance(node.func, ast.Name)
         and node.func.id == "dict"
     ):
-        # A positional arg is a base mapping (`dict(BASE, zh=...)`) and is just
-        # as unknowable as `**`: either could be where zh-TW comes from.
-        if node.args or any(kw.arg is None for kw in node.keywords):
-            return set()
-        return {kw.arg for kw in node.keywords if kw.arg is not None}
-    return set()
+        keys = set()
+        for arg in node.args:
+            inner = resolve_keys(arg)
+            if inner is None:
+                return None
+            keys |= inner
+        for kw in node.keywords:
+            if kw.arg is None:
+                inner = resolve_keys(kw.value)
+                if inner is None:
+                    return None
+                keys |= inner
+            else:
+                keys.add(kw.arg)
+        return keys
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        left = resolve_keys(node.left)
+        right = resolve_keys(node.right)
+        if left is None or right is None:
+            return None
+        return left | right
+    return None
 
 
 def _merge_operands(node: ast.AST) -> list[ast.AST]:
@@ -148,10 +176,11 @@ def _merge_operands(node: ast.AST) -> list[ast.AST]:
     return []
 
 
-def _table_nodes(tree: ast.AST) -> Iterator[ast.AST]:
-    """Yield dict-shaped nodes, suppressing merge fragments.
+def _table_nodes(tree: ast.AST) -> Iterator[tuple[ast.AST, set[str]]]:
+    """Yield ``(node, keys)`` for every mapping expression with knowable keys.
 
-    Two failure modes to thread between:
+    Three failure modes this threads between, each of which was shipped and then
+    reported:
 
       * Plain ``ast.walk`` judges each operand of a merge on its own, so
         ``{**{"en": ..., "zh": ...}, **{"zh-TW": ...}}`` reports the first half as
@@ -159,16 +188,29 @@ def _table_nodes(tree: ast.AST) -> Iterator[ast.AST]:
       * Pruning a merge's whole subtree instead loses the independent tables
         inside it — ``{**COMMON, "new": {"en": ..., "zh": ...}}`` would never
         check ``"new"``.
+      * Suppressing operands without resolving the merge lets the *result* escape:
+        ``{"en": ...} | {"zh": ...}`` has both halves suppressed and the enclosing
+        BinOp is not a dict node, so nothing was judged at all.
 
-    So operand roots are suppressed (not yielded) while traversal continues
-    through them and through everything else the container holds.
+    So: a resolvable expression is judged as a whole, and its merge operands are
+    then suppressed as fragments of something already accounted for. An
+    unresolvable one is not judged, but traversal continues through it so the
+    independent tables it holds are still found.
     """
     suppressed: set[int] = set()
     stack: list[ast.AST] = [tree]
     while stack:
         node = stack.pop()
-        if isinstance(node, (ast.Dict, ast.Call)) and id(node) not in suppressed:
-            yield node
+        if id(node) not in suppressed:
+            keys = resolve_keys(node)
+            if keys is not None:
+                yield node, keys
+        # Suppress operands whether or not the merge resolved. An operand is a
+        # fragment by definition, so judging it alone is wrong either way: if the
+        # merge resolved, the operand's keys are already counted in the result; if
+        # it did not (`BASE | {"en": ..., "zh": ...}`), the unknown side is exactly
+        # where zh-TW could be. Unconditional also handles nesting — the operands
+        # of a suppressed operand are deeper fragments still.
         for operand in _merge_operands(node):
             suppressed.add(id(operand))
         stack.extend(ast.iter_child_nodes(node))
@@ -177,10 +219,7 @@ def _table_nodes(tree: ast.AST) -> Iterator[ast.AST]:
 def find_violations(tree: ast.Module, source_lines: list[str]) -> list[int]:
     """Return the line number of every localized dict with no zh-TW key."""
     out: list[int] = []
-    for node in _table_nodes(tree):
-        keys = _string_keys(node)
-        if not keys:
-            continue
+    for node, keys in _table_nodes(tree):
         if ANCHOR_KEY not in keys:
             continue
         if not any(k in keys for k in SIMPLIFIED_KEYS):
@@ -231,8 +270,7 @@ def locate_touched(
         tree, lines = _parse_source(source, path)
         if tree is None:
             continue
-        by_line = {node.lineno: node for node in _table_nodes(tree)
-                   if _string_keys(node)}
+        by_line = {node.lineno: node for node, _keys in _table_nodes(tree)}
         added = (touched or {}).get(path, set())
         for lineno in find_violations(tree, lines):
             node = by_line.get(lineno)
@@ -294,16 +332,30 @@ def _merge_base(base: str) -> str:
     return _git("merge-base", base, "HEAD").strip()
 
 
+SYMLINK_MODE = "120000"
+
+
 def _prompt_files_at(rev: str) -> list[str]:
-    """Prompt modules present at `rev`, including any in subpackages."""
-    # -z: NUL-separated and unquoted. Without it git wraps non-ASCII paths in
-    # quotes and octal-escapes the bytes, which would not resolve as a path.
-    out = _git("ls-tree", "-r", "-z", "--name-only", rev, "--", PROMPTS_SUBDIR)
-    return [
-        entry.replace("\\", "/")
-        for entry in out.split("\0")
-        if entry.endswith(".py")
-    ]
+    """Prompt modules present at `rev`: recursive, subpackages included, no symlinks.
+
+    ``-z`` keeps paths verbatim; without it git wraps non-ASCII paths in quotes and
+    octal-escapes the bytes, which would not resolve as a path. Modes are read
+    rather than using ``--name-only`` so symlinks can be excluded — see
+    ``_sources_on_disk`` for why both sides must agree on that.
+    """
+    out = _git("ls-tree", "-r", "-z", rev, "--", PROMPTS_SUBDIR)
+    paths: list[str] = []
+    for entry in out.split("\0"):
+        if not entry:
+            continue
+        meta, _tab, path = entry.partition("\t")
+        if not path.endswith(".py"):
+            continue
+        if meta.split(" ", 1)[0] == SYMLINK_MODE:
+            sys.stderr.write(f"{rev}:{path}: symlink, not scanned\n")
+            continue
+        paths.append(path.replace("\\", "/"))
+    return paths
 
 
 def _sources_at(rev: str) -> dict[str, str]:
@@ -365,6 +417,14 @@ def _sources_on_disk() -> dict[str, str]:
     sources: dict[str, str] = {}
     for path in sorted(PROMPTS_DIR.rglob("*.py")):
         rel = path.relative_to(REPO_ROOT).as_posix()
+        if path.is_symlink():
+            # Must match _prompt_files_at, which skips mode 120000. Reading here
+            # would follow the link and scan its target, while `git show` on the
+            # base side yields the link's target *path* as blob content — the two
+            # sides would then disagree about the same path forever, and every
+            # later PR would fail on a difference no PR introduced.
+            sys.stderr.write(f"{rel}: symlink, not scanned\n")
+            continue
         try:
             raw = path.read_bytes()
         except OSError as exc:

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -132,6 +132,11 @@ def resolve_keys(node: ast.AST) -> set[str] | None:
         for arg in node.args:
             inner = resolve_keys(arg)
             if inner is None:
+                # `dict([("en", ...), ("zh", ...)])` — the iterable-of-pairs
+                # constructor. Not a mapping, so resolve_keys says nothing about
+                # it, but its keys are as statically known as a literal's.
+                inner = _pair_sequence_keys(arg)
+            if inner is None:
                 return None
             keys |= inner
         for kw in node.keywords:
@@ -152,6 +157,26 @@ def resolve_keys(node: ast.AST) -> set[str] | None:
     if isinstance(node, ast.DictComp):
         return _comprehension_keys(node)
     return None
+
+
+def _pair_sequence_keys(node: ast.AST) -> set[str] | None:
+    """Keys of a literal iterable of ``(key, value)`` pairs, or None.
+
+    Covers the standard ``dict([("en", ...), ("zh", ...)])`` constructor. Every
+    element must be a two-item sequence whose first item is a string constant;
+    anything else makes the key set unknowable.
+    """
+    if not isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+        return None
+    keys: set[str] = set()
+    for element in node.elts:
+        if not isinstance(element, (ast.Tuple, ast.List)) or len(element.elts) != 2:
+            return None
+        first = element.elts[0]
+        if not isinstance(first, ast.Constant) or not isinstance(first.value, str):
+            return None
+        keys.add(first.value)
+    return keys
 
 
 def _comprehension_keys(node: ast.DictComp) -> set[str] | None:
@@ -277,22 +302,40 @@ def _table_nodes(tree: ast.AST) -> Iterator[tuple[ast.AST, set[str]]]:
         stack.extend(ast.iter_child_nodes(node))
 
 
-def find_violations(tree: ast.Module, source_lines: list[str]) -> list[int]:
-    """Return the line number of every localized dict with no zh-TW key."""
-    out: list[int] = []
+def is_offender(keys: set[str]) -> bool:
+    """Whether a resolved key set belongs to a table that needs a zh-TW entry."""
+    if ANCHOR_KEY not in keys:
+        return False
+    if not any(k in keys for k in SIMPLIFIED_KEYS):
+        return False
+    return TRADITIONAL_KEY not in keys
+
+
+def _offending_nodes(
+    tree: ast.Module, source_lines: list[str]
+) -> Iterator[tuple[ast.AST, int, int]]:
+    """Yield ``(node, lineno, end_lineno)`` for each offending table, in order.
+
+    Nodes rather than bare line numbers, because two tables can share an opening
+    line (``T = {"en": {``) and each needs its own span — see ``locate_touched``.
+    """
+    found: list[tuple[ast.AST, int, int]] = []
     for node, keys in _table_nodes(tree):
-        if ANCHOR_KEY not in keys:
-            continue
-        if not any(k in keys for k in SIMPLIFIED_KEYS):
-            continue
-        if TRADITIONAL_KEY in keys:
+        if not is_offender(keys):
             continue
         lineno = node.lineno
         if 1 <= lineno <= len(source_lines) and _has_noqa(source_lines[lineno - 1]):
             continue
-        out.append(lineno)
+        end = getattr(node, "end_lineno", lineno) or lineno
+        found.append((node, lineno, end))
     # _table_nodes walks depth-first off a stack, so restore source order.
-    return sorted(out)
+    found.sort(key=lambda item: (item[1], item[2]))
+    yield from found
+
+
+def find_violations(tree: ast.Module, source_lines: list[str]) -> list[int]:
+    """Return the line number of every localized dict with no zh-TW key."""
+    return [lineno for _node, lineno, _end in _offending_nodes(tree, source_lines)]
 
 
 def _parse_source(source: str, origin: str) -> tuple[ast.Module | None, list[str]]:
@@ -324,6 +367,16 @@ def locate_touched(
     A total says *that* the backlog grew but not *where*, and 339 pre-existing
     offenders is far too many to print, so the diff's own lines are what make the
     failure actionable.
+
+    Each node carries its own span. Keying nodes by start line instead would let a
+    nested table opening on its parent's line (``T = {"en": {``) evict the parent,
+    and the parent would then be matched against the child's shorter span — so
+    touching a line inside the parent but past the child classified both as
+    pre-existing and degraded the message to "run --full".
+
+    Labels are de-duplicated: two offenders sharing an opening line render to the
+    same ``path:lineno``, and printing it twice reads as a bug rather than as two
+    tables.
     """
     likely: list[str] = []
     other = 0
@@ -331,13 +384,14 @@ def locate_touched(
         tree, lines = _parse_source(source, path)
         if tree is None:
             continue
-        by_line = {node.lineno: node for node, _keys in _table_nodes(tree)}
         added = (touched or {}).get(path, set())
-        for lineno in find_violations(tree, lines):
-            node = by_line.get(lineno)
-            span = range(lineno, (getattr(node, "end_lineno", lineno) or lineno) + 1)
-            if added and any(ln in added for ln in span):
-                likely.append(f"{path}:{lineno}")
+        seen: set[str] = set()
+        for _node, lineno, end in _offending_nodes(tree, lines):
+            if added and any(ln in added for ln in range(lineno, end + 1)):
+                label = f"{path}:{lineno}"
+                if label not in seen:
+                    seen.add(label)
+                    likely.append(label)
             else:
                 other += 1
     return likely, other

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -332,7 +332,9 @@ def _comprehension_keys(node: ast.DictComp) -> set[str] | None:
             return None
         return _literal_string_sequence(gen.iter)
 
-    if isinstance(gen.target, ast.Tuple):
+    # A list target unpacks the same way a tuple one does, and the pair inputs
+    # already accept both — restricting to Tuple left this shape unresolved.
+    if isinstance(gen.target, (ast.Tuple, ast.List)):
         names = [e.id for e in gen.target.elts if isinstance(e, ast.Name)]
         if len(names) != len(gen.target.elts) or node.key.id not in names:
             return None
@@ -630,6 +632,12 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
                         (_source_position(value), value)
                     )
             continue
+        if isinstance(node, ast.NamedExpr) and isinstance(node.target, ast.Name):
+            # `if (T := {...}): T["zh-TW"] = t` binds T as much as a statement does.
+            assignments.setdefault(node.target.id, []).append(
+                (_source_position(node.value), node.value)
+            )
+            continue
         if (
             # `T: dict[str, str] = {...}` — an annotated binding is still a
             # binding, and typed prompt constants are ordinary style. Missing them
@@ -652,11 +660,19 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
     # ordinary way to assemble one, and reading only the literal saw an empty
     # table. The same index answers the reverse — a later `del TW["zh-TW"]` means
     # an earlier backfill no longer makes its table compliant.
-    mutations: dict[str, list[tuple[tuple[int, int], set[str], set[str]]]] = {}
+    mutations: dict[
+        str, list[tuple[tuple[int, int], set[str], set[str], tuple[str, ...]]]
+    ] = {}
 
-    def _record(name: str, at: tuple[int, int], added: set[str], removed: set[str]) -> None:
-        if added or removed:
-            mutations.setdefault(name, []).append((at, added, removed))
+    def _record(
+        name: str,
+        at: tuple[int, int],
+        added: set[str],
+        removed: set[str],
+        added_names: tuple[str, ...] = (),
+    ) -> None:
+        if added or removed or added_names:
+            mutations.setdefault(name, []).append((at, added, removed, added_names))
 
     for node in ast.walk(tree):
         at = _source_position(node)
@@ -680,7 +696,12 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
             and isinstance(node.func, ast.Attribute)
             and isinstance(node.func.value, ast.Name)
         ):
-            if node.func.attr == "setdefault" and node.args:
+            if node.func.attr == "pop" and node.args:
+                # `T.pop("zh-TW")` removes the key as plainly as `del T["zh-TW"]`.
+                first = node.args[0]
+                if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                    _record(node.func.value.id, at, set(), {first.value})
+            elif node.func.attr == "setdefault" and node.args:
                 first = node.args[0]
                 if isinstance(first, ast.Constant) and isinstance(first.value, str):
                     _record(node.func.value.id, at, {first.value}, set())
@@ -688,17 +709,26 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
                 # Only what the payload states outright. Resolving names here would
                 # need the very index being built.
                 added: set[str] = set()
+                # A payload that is a name is kept as a reference and resolved
+                # later: resolving it here would need this very index.
+                names: list[str] = []
                 for payload in list(node.args) + [
                     kw.value for kw in node.keywords if kw.arg is None
                 ]:
+                    if isinstance(payload, ast.Name):
+                        names.append(payload.id)
+                        continue
                     added |= resolve_keys(payload) or _pair_sequence_keys(payload) or set()
-                _record(node.func.value.id, at, added, set())
+                _record(node.func.value.id, at, added, set(), tuple(names))
         elif (
             isinstance(node, ast.AugAssign)
             and isinstance(node.op, ast.BitOr)
             and isinstance(node.target, ast.Name)
         ):
-            _record(node.target.id, at, resolve_keys(node.value) or set(), set())
+            if isinstance(node.value, ast.Name):
+                _record(node.target.id, at, set(), set(), (node.value.id,))
+            else:
+                _record(node.target.id, at, resolve_keys(node.value) or set(), set())
 
     for entries in mutations.values():
         entries.sort(key=lambda item: item[0])
@@ -755,7 +785,7 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
         rebound = next(
             (pos for pos, _ in assignments.get(name, ()) if pos > at), None
         )
-        for pos, _added, removed in mutations.get(name, ()):
+        for pos, _added, removed, _names in mutations.get(name, ()):
             if pos <= at or (rebound is not None and pos > rebound):
                 continue
             if TRADITIONAL_KEY in removed:
@@ -859,9 +889,17 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
         # Plus whatever demonstrable mutations did to it between then and here.
         # `TW = {}` / `TW["zh-TW"] = t` / `T.update(TW)` assembles a supplier in two
         # steps, and reading only the literal saw an empty table.
-        for pos, added, removed in mutations.get(name, ()):
-            if bound_at < pos <= at:
-                keys = (keys | added) - removed
+        # Strictly before `at`: a mutation resolves its own named payload through
+        # here, and including the mutation itself would recurse forever on
+        # `A.update(A)`. Nothing legitimate sits at exactly the use position — a
+        # statement records its mutation against the name it mutates, not the one
+        # it reads.
+        for pos, added, removed, added_names in mutations.get(name, ()):
+            if not bound_at < pos < at:
+                continue
+            for other in added_names:
+                added = added | _name_keys(other, pos)
+            keys = (keys | added) - removed
         return keys
 
     for node in ast.walk(tree):

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -635,7 +635,9 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
     preceding binding is right in either nesting direction.
     """
     assignments: dict[str, list[tuple[tuple[int, int], ast.AST]]] = {}
-    loop_alternatives: list[set[int]] = []
+    # (body span, alternatives) — the span is what tells a backfill inside the
+    # loop from one that runs after it, where only the last binding survives.
+    loop_alternatives: list[tuple[tuple[tuple[int, int], tuple[int, int]], set[int]]] = []
     for node in ast.walk(tree):
         name: str | None = None
         if isinstance(node, ast.Assign):
@@ -669,7 +671,13 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
             # alternatives rather than a sequence: a backfill in the body
             # completes every one of them, not just the last. A single-element
             # group is kept rather than filtered — closing over it is a no-op.
-            loop_alternatives.extend(groups.values())
+            last = node.body[-1]
+            span = (
+                _source_position(node.body[0]),
+                (getattr(last, "end_lineno", last.lineno) or last.lineno,
+                 getattr(last, "end_col_offset", 0) or 0),
+            )
+            loop_alternatives.extend((span, group) for group in groups.values())
             continue
         if isinstance(node, ast.NamedExpr) and isinstance(node.target, ast.Name):
             # `if (T := {...}): T["zh-TW"] = t` binds T as much as a statement does.
@@ -736,7 +744,11 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
             and isinstance(node.func, ast.Attribute)
             and isinstance(node.func.value, ast.Name)
         ):
-            if node.func.attr == "clear" and not node.args:
+            if node.func.attr == "popitem":
+                # Removes a key without naming one, so nothing this gate could
+                # still claim survives: recorded the same way as `clear()`.
+                _record(node.func.value.id, at, set(), None)
+            elif node.func.attr == "clear" and not node.args:
                 # `TW.clear()` empties it, so anything recorded before is gone.
                 # `None` rather than a key set: there is no list of keys to name.
                 _record(node.func.value.id, at, set(), None)
@@ -854,6 +866,11 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
                 continue
             walked.add(id(value))
             exempt.add(id(value))
+            for (lo, hi), group in loop_alternatives:
+                # Only a backfill written *inside* the loop reaches every element.
+                # One placed after it sees only whatever the last iteration left.
+                if id(value) in group and lo <= at <= hi:
+                    exempt.update(group)
             for part in _fragment_parts(value):
                 if isinstance(part, ast.Name):
                     pending.append((part.id, bound_at, True))
@@ -885,6 +902,9 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
         """
         if node is None:
             return set()
+        if isinstance(node, ast.NamedExpr):
+            # `T.update(P := {...})` evaluates to the mapping it binds.
+            return _mapping_keys(node.value, at, strict)
         if isinstance(node, ast.Name):
             return _name_keys(node.id, at, strict)
         if (
@@ -892,10 +912,9 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
             and not node.args
             and isinstance(node.func, ast.Attribute)
             and node.func.attr in ("items", "copy")
-            and isinstance(node.func.value, ast.Name)
         ):
             # `T.update(TW.items())` / `dict(TW.copy())` — both hand over exactly
-            # the keys TW has, and passing a view is ordinary Python.
+            # the keys the receiver has, whatever the receiver is spelled as.
             return _mapping_keys(node.func.value, at, strict)
         if isinstance(node, ast.IfExp):
             # `T |= TW if flag else {"zh-TW": t}` — either branch may carry it, and
@@ -1063,10 +1082,6 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
                 _exempt_binding_before(operand.id, origin, inside_binding)
             else:
                 pending.extend(_merge_operands(operand))
-
-    for group in loop_alternatives:
-        if group & exempt:
-            exempt |= group
 
     return exempt
 

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -367,14 +367,44 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
     The table is compliant at runtime, so reporting it is a false positive — and
     false positives are what get a gate worked around rather than satisfied.
 
-    Deliberately narrow: only a mutation that *demonstrably supplies zh-TW*
-    exempts its target. Suppressing on any mutation would let an unrelated
-    ``T["other"] = x`` excuse a real offender, trading one rare false positive for
-    a broad blind spot. Names are matched across the whole module rather than
-    per-scope: over-matching here can only exempt a table whose name is somewhere
-    given zh-TW, which is the safe direction.
+    Deliberately narrow in two ways:
+
+    * Only a mutation that *demonstrably supplies zh-TW* exempts its target.
+      Exempting on any mutation would let an unrelated ``T["other"] = x`` excuse a
+      real offender, trading one rare false positive for a broad blind spot.
+    * The exemption lands on the binding **most recently before** the mutation, not
+      on every same-named assignment. Otherwise a name reassigned afterwards::
+
+          T = {"en": "e", "zh": "s"}
+          T["zh-TW"] = "t"
+          T = {"en": "e2", "zh": "s2"}   # a real offender
+
+      would have its later table exempted too.
+
+    No scope analysis: line order is enough here because a mutation and the
+    binding it mutates sit in the same scope in practice, and picking the nearest
+    preceding binding is right in either nesting direction.
     """
-    backfilled: set[str] = set()
+    assignments: dict[str, list[tuple[int, int]]] = {}
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+        ):
+            assignments.setdefault(node.targets[0].id, []).append(
+                (node.lineno, id(node.value))
+            )
+    for bindings in assignments.values():
+        bindings.sort()
+
+    exempt: set[int] = set()
+
+    def _exempt_binding_before(name: str, lineno: int) -> None:
+        prior = [vid for ln, vid in assignments.get(name, []) if ln <= lineno]
+        if prior:
+            exempt.add(prior[-1])
+
     for node in ast.walk(tree):
         if (
             isinstance(node, ast.Assign)
@@ -384,7 +414,7 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
             and isinstance(node.targets[0].slice, ast.Constant)
             and node.targets[0].slice.value == TRADITIONAL_KEY
         ):
-            backfilled.add(node.targets[0].value.id)
+            _exempt_binding_before(node.targets[0].value.id, node.lineno)
             continue
         target: str | None = None
         payload: ast.AST | None = None
@@ -405,29 +435,23 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
         if target is None or payload is None:
             continue
         keys = resolve_keys(payload)
+        if keys is None:
+            # `T.update([("zh-TW", "t")])` — the iterable-of-pairs form is just as
+            # knowable, and missing it means the target is not marked backfilled
+            # and its literal gets reported despite being compliant at runtime.
+            keys = _pair_sequence_keys(payload)
         if keys and TRADITIONAL_KEY in keys:
-            backfilled.add(target)
+            _exempt_binding_before(target, node.lineno)
 
     # A name used as a merge operand is a fragment by the same argument as an
     # inline one: `_FRAGMENT = {"en": .., "zh": ..}` / `T = {**_FRAGMENT, "zh-TW":
-    # ..}` assembles a compliant table, so reporting _FRAGMENT is a false
-    # positive. Costs a blind spot if the same name is also used as a whole table,
-    # which is the direction to err in.
+    # ..}` assembles a compliant table, so reporting _FRAGMENT is a false positive.
     for node in ast.walk(tree):
         for operand in _merge_operands(node):
             if isinstance(operand, ast.Name):
-                backfilled.add(operand.id)
+                _exempt_binding_before(operand.id, node.lineno)
 
-    if not backfilled:
-        return set()
-    return {
-        id(node.value)
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Assign)
-        and len(node.targets) == 1
-        and isinstance(node.targets[0], ast.Name)
-        and node.targets[0].id in backfilled
-    }
+    return exempt
 
 
 def _table_nodes(tree: ast.AST) -> Iterator[tuple[ast.AST, set[str]]]:

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -67,10 +67,12 @@ from __future__ import annotations
 
 import argparse
 import ast
+import io
 import os
 import re
 import subprocess
 import sys
+import tokenize
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -113,7 +115,9 @@ def _string_keys(node: ast.AST) -> set[str]:
         and isinstance(node.func, ast.Name)
         and node.func.id == "dict"
     ):
-        if any(kw.arg is None for kw in node.keywords):
+        # A positional arg is a base mapping (`dict(BASE, zh=...)`) and is just
+        # as unknowable as `**`: either could be where zh-TW comes from.
+        if node.args or any(kw.arg is None for kw in node.keywords):
             return set()
         return {kw.arg for kw in node.keywords if kw.arg is not None}
     return set()
@@ -194,23 +198,44 @@ def locate_touched(
 
 
 def _git(*args: str) -> str:
-    """Run git and return stdout.
+    """Run git and return stdout as text.
 
-    ``errors="replace"`` is the base-side counterpart to ``_sources_on_disk``
-    tolerating a bad decode: ``git show`` of a non-UTF-8 prompt module would
-    otherwise raise mid-decode. A replaced source then fails ``ast.parse``, which
-    ``_parse_source`` reports and skips — same outcome as the disk side.
+    ``errors="replace"`` because this decodes git's own reporting (diff headers,
+    path lists); a malformed byte there should not abort the gate. Source blobs go
+    through ``_git_bytes`` instead, so they can honour a PEP 263 declaration.
     """
+    return _git_bytes(*args).decode("utf-8", errors="replace")
+
+
+def _git_bytes(*args: str) -> bytes:
+    """Run git and return raw stdout."""
     result = subprocess.run(
         ["git", *args],
         cwd=REPO_ROOT,
         capture_output=True, check=False,
-        text=True, encoding="utf-8", errors="replace",
     )
     if result.returncode != 0:
-        sys.stderr.write(result.stderr)
+        sys.stderr.write(result.stderr.decode("utf-8", errors="replace"))
         sys.exit(2)
     return result.stdout
+
+
+def _decode_source(raw: bytes, origin: str) -> str | None:
+    """Decode Python source, honouring a PEP 263 coding declaration.
+
+    A module carrying ``# coding: latin-1`` is valid Python that a plain UTF-8
+    read would reject; skipping it would mean silently not checking a real prompt
+    module. Only genuinely undecodable bytes are skipped, with a diagnostic.
+    """
+    try:
+        encoding, _ = tokenize.detect_encoding(io.BytesIO(raw).readline)
+    except SyntaxError:
+        encoding = "utf-8"
+    try:
+        return raw.decode(encoding)
+    except (UnicodeDecodeError, LookupError) as exc:
+        sys.stderr.write(f"{origin}: cannot decode as {encoding} ({exc})\n")
+        return None
 
 
 def _merge_base(base: str) -> str:
@@ -230,7 +255,12 @@ def _prompt_files_at(rev: str) -> list[str]:
 
 
 def _sources_at(rev: str) -> dict[str, str]:
-    return {path: _git("show", f"{rev}:{path}") for path in _prompt_files_at(rev)}
+    sources: dict[str, str] = {}
+    for path in _prompt_files_at(rev):
+        text = _decode_source(_git_bytes("show", f"{rev}:{path}"), f"{rev}:{path}")
+        if text is not None:
+            sources[path] = text
+    return sources
 
 
 _HUNK_HEADER_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
@@ -242,7 +272,14 @@ def _touched_lines(rev: str) -> dict[str, set[int]]:
     ``-M`` keeps a pure rename from reporting every line of the new path as
     added, which would make the hint point at the whole file.
     """
-    diff = _git("diff", "-M", "--unified=0", f"{rev}...HEAD", "--", PROMPTS_SUBDIR)
+    # core.quotePath=false: git otherwise C-quotes non-ASCII paths in the `+++`
+    # header (`+++ "b/config/prompts/\344\270\255.py"`), which would not match the
+    # real path and would drop that file's hints. Same class of problem as the
+    # `-z` on ls-tree, different output channel.
+    diff = _git(
+        "-c", "core.quotePath=false",
+        "diff", "-M", "--unified=0", f"{rev}...HEAD", "--", PROMPTS_SUBDIR,
+    )
     touched: dict[str, set[int]] = {}
     current: str | None = None
     for line in diff.splitlines():
@@ -259,19 +296,23 @@ def _touched_lines(rev: str) -> dict[str, set[int]]:
 
 
 def _sources_on_disk() -> dict[str, str]:
-    """Read every prompt module off disk, skipping any that cannot be decoded.
+    """Read every prompt module off disk, decoding per PEP 263.
 
-    ``UnicodeDecodeError`` is a ``ValueError``, not an ``OSError``, so catching
-    only the latter would let a non-UTF-8 prompt module take the whole gate down
-    with a traceback instead of skipping that one file.
+    Reads bytes and hands them to ``_decode_source``, the same path the base side
+    uses, so a module with a coding declaration is checked rather than skipped and
+    an unreadable one is reported rather than fatal.
     """
     sources: dict[str, str] = {}
     for path in sorted(PROMPTS_DIR.rglob("*.py")):
         rel = path.relative_to(REPO_ROOT).as_posix()
         try:
-            sources[rel] = path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError) as exc:
+            raw = path.read_bytes()
+        except OSError as exc:
             sys.stderr.write(f"{rel}: cannot read ({exc})\n")
+            continue
+        text = _decode_source(raw, rel)
+        if text is not None:
+            sources[rel] = text
     return sources
 
 
@@ -296,6 +337,15 @@ def main(argv: list[str] | None = None) -> int:
         help="Print the backlog size and exit 0.",
     )
     args = parser.parse_args(argv)
+
+    # Force UTF-8 on our own streams. When stdout is a pipe, Python encodes with
+    # the locale encoding — cp1252 on the Windows CI runner — so printing a
+    # non-ASCII path, or a SyntaxError whose text carries CJK source, would raise
+    # UnicodeEncodeError from inside the gate. Callers decode as UTF-8 to match.
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is not None:
+            reconfigure(encoding="utf-8", errors="replace")
 
     disk = _sources_on_disk()
 

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -80,7 +80,7 @@ exemption is deliberately keyed on the mutation *demonstrably supplying zh-TW*:
 exempting on any mutation would let an unrelated ``T["other"] = x`` excuse a real
 offender, trading one rare false positive for a broad blind spot.
 
-Two accepted blind spots follow from that choice, both on the miss side:
+Three accepted blind spots, all on the miss side:
 
   * The exemption is not ordered against *other* uses of the name, so a copy taken
     before the backfill is not judged::
@@ -98,6 +98,19 @@ Two accepted blind spots follow from that choice, both on the miss side:
     bodies unreadable, so it is not a shape prompt modules use — there are zero
     occurrences under config/prompts. Chasing constructor forms with no realistic
     use grows ``resolve_keys`` without shrinking the backlog.
+  * A table assembled from fragments that are each *individually* fine is not
+    judged::
+
+        EN = {"en": "e"}         # no simplified key — not an offender
+        ZH = {"zh": "s"}         # no anchor key — not an offender
+        T = EN | ZH              # the runtime table is one, and lacks zh-TW
+
+    Judging the result would mean following names from ``_table_nodes``, which is
+    the reverse of the union-style resolution used for the supply question: there,
+    over-approximating is safe; here, a merge with one unknowable operand would be
+    reported despite that operand possibly carrying zh-TW. Under config/prompts
+    there are zero ``NAME | NAME`` merges, and the shape — one dict per locale,
+    merged — is strictly more verbose than the single dict it replaces.
 
 
 Usage:
@@ -262,12 +275,14 @@ def _literal_string_sequence(node: ast.AST) -> set[str] | None:
 
 
 def _pair_sequence_keys(node: ast.AST) -> set[str] | None:
-    """Keys of a literal iterable of ``(key, value)`` pairs, or None.
+    """Keys of an iterable of ``(key, value)`` pairs, or None.
 
     Covers the standard ``dict([("en", ...), ("zh", ...)])`` constructor. Every
     element must be a two-item sequence whose first item is a string constant;
     anything else makes the key set unknowable.
     """
+    if isinstance(node, ast.GeneratorExp):
+        return _generator_pair_keys(node)
     if not isinstance(node, (ast.List, ast.Tuple, ast.Set)):
         return None
     keys: set[str] = set()
@@ -329,12 +344,38 @@ def _comprehension_keys(node: ast.DictComp) -> set[str] | None:
             if index >= len(element.elts):
                 return None
             item = element.elts[index]
-            if not isinstance(item, ast.Constant) or not isinstance(item.value, str):
+            if not isinstance(item, ast.Constant):
                 return None
-            keys.add(item.value)
+            # Constant non-string keys are skipped, not disqualifying — the dict
+            # literal and iterable-of-pairs paths already say so, and a sentinel
+            # like `(None, default)` cannot be hiding 'zh-TW'.
+            if isinstance(item.value, str):
+                keys.add(item.value)
         return keys
 
     return None
+
+
+def _generator_pair_keys(node: ast.GeneratorExp) -> set[str] | None:
+    """Keys of ``dict((loc, build(loc)) for loc in ("en", "zh"))``, or None.
+
+    The generator spelling of a dict comprehension, resolved on exactly the same
+    terms because it is the same table written with different syntax — accepting
+    one and not the other is the kind of near-miss the gate gets worked around by.
+
+    Rather than restate those terms, the generator's ``(key, value)`` element is
+    handed to ``_comprehension_keys`` in the slots a DictComp keeps them in, so the
+    two spellings cannot drift apart.
+    """
+    if not isinstance(node.elt, ast.Tuple) or len(node.elt.elts) != 2:
+        return None
+    return _comprehension_keys(
+        ast.DictComp(
+            key=node.elt.elts[0],
+            value=node.elt.elts[1],
+            generators=node.generators,
+        )
+    )
 
 
 def _operand_branches(node: ast.AST) -> list[ast.AST]:
@@ -522,8 +563,12 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
 
     def _binding_before(
         name: str, lineno: int, exclude: ast.AST | None = None
-    ) -> ast.AST | None:
+    ) -> tuple[int, ast.AST] | None:
         """The value bound to `name` most recently at or before `lineno`.
+
+        Returns the binding's own line along with it, because a hop through an
+        alias has to continue searching from where the alias was bound rather than
+        from the far-away line that reads it.
 
         ``exclude`` skips one candidate: for a self-rebinding merge like
         ``T = T | {...}`` the new assignment registers on the same line as the
@@ -535,15 +580,15 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
                 continue
             if exclude is not None and value is exclude:
                 continue
-            return value
+            return ln, value
         return None
 
     def _exempt_binding_before(
         name: str, lineno: int, exclude: ast.AST | None = None
     ) -> None:
-        value = _binding_before(name, lineno, exclude)
-        if value is not None:
-            exempt.add(id(value))
+        found = _binding_before(name, lineno, exclude)
+        if found is not None:
+            exempt.add(id(found[1]))
 
     def _mapping_keys(
         node: ast.AST | None, at: int, _seen: frozenset[str] = frozenset()
@@ -590,10 +635,20 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
         exclude: ast.AST | None = None,
         _seen: frozenset[str] = frozenset(),
     ) -> set[str]:
-        """Keys of the mapping `name` is bound to just before `at`."""
-        return _mapping_keys(
-            _binding_before(name, at, exclude), at, _seen | {name}
-        )
+        """Keys of the mapping `name` is bound to just before `at`.
+
+        The hop moves the search position back to that binding's own line. Keeping
+        the original `at` through every hop read an alias against a *later*
+        rebinding of its source: in ``ALIAS = P`` / ``P = {"zh-TW": t}`` / ``T.
+        update(ALIAS)``, ALIAS still holds the earlier object at runtime, so
+        resolving P at the update line would exempt a table that really is missing
+        zh-TW.
+        """
+        found = _binding_before(name, at, exclude)
+        if found is None:
+            return set()
+        bound_at, value = found
+        return _mapping_keys(value, bound_at, _seen | {name})
 
     for node in ast.walk(tree):
         # `T["zh-TW"] = t`, and its annotated form `T["zh-TW"]: str = t`.
@@ -677,9 +732,20 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
 
         if TRADITIONAL_KEY not in _directly_visible_keys(node, _named_keys):
             continue
-        for operand in operands:
+        # Down through nested merges, not just the operands spelled as bare names:
+        # `{**dict(_F), "zh-TW": t}` wraps the same fragment `{**_F, "zh-TW": t}`
+        # names directly, and stopping at the outer Call reported _F for a table
+        # that is compliant either way it is written.
+        pending, walked = list(operands), set()
+        while pending:
+            operand = pending.pop()
+            if id(operand) in walked:
+                continue
+            walked.add(id(operand))
             if isinstance(operand, ast.Name):
                 _exempt_binding_before(operand.id, node.lineno, exclude=node)
+            else:
+                pending.extend(_merge_operands(operand))
 
     return exempt
 

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -101,7 +101,7 @@ exemption is deliberately keyed on the mutation *demonstrably supplying zh-TW*:
 exempting on any mutation would let an unrelated ``T["other"] = x`` excuse a real
 offender, trading one rare false positive for a broad blind spot.
 
-Five accepted blind spots:
+Six accepted blind spots:
 
   * The exemption is not ordered against *other* uses of the name, so a copy taken
     before the backfill is not judged::
@@ -135,6 +135,14 @@ Five accepted blind spots:
     Knowing that A and T are the same object is alias analysis -- a set of names
     per object, maintained across rebinding -- rather than the per-name timeline
     everything else here uses.
+  * ``for`` targets and ``popitem()`` are not read at all. A loop target's
+    bindings are alternatives rather than a sequence, and only a backfill inside
+    the body reaches them all; which key ``popitem()`` removes depends on the
+    dict's insertion order. Both were supported for one round and both produced
+    follow-up defects — a backfill through one loop target excusing another's
+    tables, and ``popitem()`` revoking an exemption for a table that was still
+    compliant. Neither shape occurs under config/prompts, so the gate stays with
+    what it can prove and the escape hatch covers the rest.
   * A table assembled from fragments that are each *individually* fine is not
     judged::
 
@@ -656,9 +664,6 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
     preceding binding is right in either nesting direction.
     """
     assignments: dict[str, list[tuple[tuple[int, int], ast.AST]]] = {}
-    # (body span, alternatives) — the span is what tells a backfill inside the
-    # loop from one that runs after it, where only the last binding survives.
-    loop_alternatives: list[tuple[tuple[tuple[int, int], tuple[int, int]], set[int]]] = []
     for node in ast.walk(tree):
         name: str | None = None
         if isinstance(node, ast.Assign):
@@ -671,34 +676,6 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
                     assignments.setdefault(bound, []).append(
                         (_source_position(value), value)
                     )
-            continue
-        if isinstance(node, (ast.For, ast.AsyncFor)) and isinstance(
-            node.iter, (ast.Tuple, ast.List, ast.Set)
-        ):
-            # `for T in ({...}, {...}): T["zh-TW"] = t` — a literal iterable makes
-            # every element a binding of the loop target. Anything else (a name, a
-            # call, a range) is not knowable and binds nothing.
-            # One group per target name: `for T, U in ((a, b), (c, d))` makes a
-            # and c alternatives of T, b and d alternatives of U. Pooling them
-            # would let a backfill through T excuse U's tables as well.
-            groups: dict[str, set[int]] = {}
-            for item in node.iter.elts:
-                for bound, value in _unpacked_bindings(node.target, item):
-                    assignments.setdefault(bound, []).append(
-                        (_source_position(value), value)
-                    )
-                    groups.setdefault(bound, set()).add(id(value))
-            # The body runs once per element, so a target's bindings are
-            # alternatives rather than a sequence: a backfill in the body
-            # completes every one of them, not just the last. A single-element
-            # group is kept rather than filtered — closing over it is a no-op.
-            last = node.body[-1]
-            span = (
-                _source_position(node.body[0]),
-                (getattr(last, "end_lineno", last.lineno) or last.lineno,
-                 getattr(last, "end_col_offset", 0) or 0),
-            )
-            loop_alternatives.extend((span, group) for group in groups.values())
             continue
         if isinstance(node, ast.NamedExpr) and isinstance(node.target, ast.Name):
             # `if (T := {...}): T["zh-TW"] = t` binds T as much as a statement does.
@@ -765,11 +742,7 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
             and isinstance(node.func, ast.Attribute)
             and isinstance(node.func.value, ast.Name)
         ):
-            if node.func.attr == "popitem":
-                # Removes a key without naming one, so nothing this gate could
-                # still claim survives: recorded the same way as `clear()`.
-                _record(node.func.value.id, at, set(), None)
-            elif node.func.attr == "clear" and not node.args:
+            if node.func.attr == "clear" and not node.args:
                 # `TW.clear()` empties it, so anything recorded before is gone.
                 # `None` rather than a key set: there is no list of keys to name.
                 _record(node.func.value.id, at, set(), None)
@@ -887,11 +860,6 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
                 continue
             walked.add(id(value))
             exempt.add(id(value))
-            for (lo, hi), group in loop_alternatives:
-                # Only a backfill written *inside* the loop reaches every element.
-                # One placed after it sees only whatever the last iteration left.
-                if id(value) in group and lo <= at <= hi:
-                    exempt.update(group)
             for part in _fragment_parts(value):
                 if isinstance(part, ast.Name):
                     pending.append((part.id, bound_at, True))

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -80,6 +80,25 @@ exemption is deliberately keyed on the mutation *demonstrably supplying zh-TW*:
 exempting on any mutation would let an unrelated ``T["other"] = x`` excuse a real
 offender, trading one rare false positive for a broad blind spot.
 
+Two accepted blind spots follow from that choice, both on the miss side:
+
+  * The exemption is not ordered against *other* uses of the name, so a copy taken
+    before the backfill is not judged::
+
+        T = {"en": "e", "zh": "s"}
+        U = dict(T)              # U really does lack zh-TW at runtime
+        T["zh-TW"] = "t"         # …but this exempts T's literal, and dict(T)
+                                 #    resolves through the name to the same keys
+
+    Ordering the exemption against each use needs statement-level data flow, the
+    same analysis the section above declines.
+  * ``dict(zip(keys, values))`` is not resolved. Every other static constructor is
+    (literal, ``dict()``, ``|``, comprehension, iterable-of-pairs, ``fromkeys``),
+    but splitting a localized table into two parallel sequences makes the template
+    bodies unreadable, so it is not a shape prompt modules use — there are zero
+    occurrences under config/prompts. Chasing constructor forms with no realistic
+    use grows ``resolve_keys`` without shrinking the backlog.
+
 
 Usage:
     python scripts/check_prompt_zh_tw.py [--base origin/main]
@@ -513,7 +532,7 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
         if matched:
             continue
         target: str | None = None
-        payload: ast.AST | None = None
+        payloads: list[ast.AST] = []
         if (
             isinstance(node, ast.Call)
             and isinstance(node.func, ast.Attribute)
@@ -530,29 +549,39 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
                 ):
                     _exempt_binding_before(target, node.lineno)
                 continue
-            if node.args:
-                payload = node.args[0]
-            else:
-                # `T.update(**{"zh-TW": t})` — the spread carries the mapping.
-                # Named keywords are deliberately not consulted: 'zh-TW' is not a
-                # valid identifier, so it can never arrive as `update(zh-TW=...)`.
-                spread = [kw.value for kw in node.keywords if kw.arg is None]
-                payload = spread[0] if spread else None
+            # Every payload, not just the first: `update({...}, **{...})` is legal
+            # and so is more than one `**`. Named keywords are deliberately not
+            # consulted — 'zh-TW' is not an identifier, so it can never arrive as
+            # `update(zh-TW=...)`.
+            payloads = list(node.args) + [
+                kw.value for kw in node.keywords if kw.arg is None
+            ]
         elif (
             isinstance(node, ast.AugAssign)
             and isinstance(node.op, ast.BitOr)
             and isinstance(node.target, ast.Name)
         ):
-            target, payload = node.target.id, node.value
-        if target is None or payload is None:
+            target, payloads = node.target.id, [node.value]
+        if target is None or not payloads:
             continue
-        keys = resolve_keys(payload)
-        if keys is None:
-            # `T.update([("zh-TW", "t")])` — the iterable-of-pairs form is just as
-            # knowable, and missing it means the target is not marked backfilled
-            # and its literal gets reported despite being compliant at runtime.
-            keys = _pair_sequence_keys(payload)
-        if keys and TRADITIONAL_KEY in keys:
+
+        def _payload_keys(payload: ast.AST, _at: int = node.lineno) -> set[str]:
+            """Keys a mutation payload supplies, or empty if unknowable.
+
+            Three shapes, in order: a mapping expression, an iterable of pairs
+            (`update([("zh-TW", t)])`), and a name bound to a mapping earlier
+            (`TW = {"zh-TW": t}` / `T.update(TW)`) — the last one uses the same
+            preceding-binding lookup as merge operands, which it previously did not.
+            """
+            keys = resolve_keys(payload)
+            if keys is None:
+                keys = _pair_sequence_keys(payload)
+            if keys is None and isinstance(payload, ast.Name):
+                bound = _binding_before(payload.id, _at)
+                keys = resolve_keys(bound) if bound is not None else None
+            return keys or set()
+
+        if any(TRADITIONAL_KEY in _payload_keys(p) for p in payloads):
             _exempt_binding_before(target, node.lineno)
 
     # A name merged into a construction that *demonstrably supplies zh-TW* is a

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -160,7 +160,7 @@ def _comprehension_keys(node: ast.DictComp) -> set[str] | None:
     Resolves the two shapes whose keys are fully determined by the source::
 
         {loc: build(loc) for loc in ("en", "zh", "ja")}
-        {k: v for k, v in (("en", "hello"), ("zh", "你好"))}
+        {k: v for k, v in (("en", "hello"), ("zh", "ni hao"))}
 
     The first is a realistic way to write a localized table — one template per
     locale off a literal locale list — so leaving it unresolved would be a real

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -80,7 +80,7 @@ exemption is deliberately keyed on the mutation *demonstrably supplying zh-TW*:
 exempting on any mutation would let an unrelated ``T["other"] = x`` excuse a real
 offender, trading one rare false positive for a broad blind spot.
 
-Four accepted blind spots, all on the miss side:
+Five accepted blind spots:
 
   * The exemption is not ordered against *other* uses of the name, so a copy taken
     before the backfill is not judged::
@@ -98,6 +98,12 @@ Four accepted blind spots, all on the miss side:
     bodies unreadable, so it is not a shape prompt modules use — there are zero
     occurrences under config/prompts. Chasing constructor forms with no realistic
     use grows ``resolve_keys`` without shrinking the backlog.
+  * Bindings are ordered by source position, with no scope or reachability
+    analysis. Two functions that each bind a local ``T`` share one timeline, and a
+    backfill written inside a function nobody calls counts as if it ran. Both
+    follow from the same choice the section above states: a mutation and the
+    binding it mutates sit in the same scope in practice, and prompt modules are
+    tables at import time, not call graphs.
   * A removal that reaches the table through a different name is not seen::
 
         T = {"en": "e", "zh": "s"}
@@ -629,6 +635,7 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
     preceding binding is right in either nesting direction.
     """
     assignments: dict[str, list[tuple[tuple[int, int], ast.AST]]] = {}
+    loop_alternatives: list[set[int]] = []
     for node in ast.walk(tree):
         name: str | None = None
         if isinstance(node, ast.Assign):
@@ -641,6 +648,25 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
                     assignments.setdefault(bound, []).append(
                         (_source_position(value), value)
                     )
+            continue
+        if isinstance(node, (ast.For, ast.AsyncFor)) and isinstance(
+            node.iter, (ast.Tuple, ast.List, ast.Set)
+        ):
+            # `for T in ({...}, {...}): T["zh-TW"] = t` — a literal iterable makes
+            # every element a binding of the loop target. Anything else (a name, a
+            # call, a range) is not knowable and binds nothing.
+            group: set[int] = set()
+            for item in node.iter.elts:
+                for bound, value in _unpacked_bindings(node.target, item):
+                    assignments.setdefault(bound, []).append(
+                        (_source_position(value), value)
+                    )
+                    group.add(id(value))
+            if len(group) > 1:
+                # The body runs once per element, so these bindings are
+                # alternatives rather than a sequence: a backfill in the body
+                # completes every one of them, not just the last.
+                loop_alternatives.append(group)
             continue
         if isinstance(node, ast.NamedExpr) and isinstance(node.target, ast.Name):
             # `if (T := {...}): T["zh-TW"] = t` binds T as much as a statement does.
@@ -671,17 +697,18 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
     # table. The same index answers the reverse — a later `del TW["zh-TW"]` means
     # an earlier backfill no longer makes its table compliant.
     mutations: dict[
-        str, list[tuple[tuple[int, int], set[str], set[str], tuple[ast.AST, ...]]]
+        str,
+        list[tuple[tuple[int, int], set[str], set[str] | None, tuple[ast.AST, ...]]],
     ] = {}
 
     def _record(
         name: str,
         at: tuple[int, int],
         added: set[str],
-        removed: set[str],
+        removed: set[str] | None,
         payloads: tuple[ast.AST, ...] = (),
     ) -> None:
-        if added or removed or payloads:
+        if added or removed is None or removed or payloads:
             mutations.setdefault(name, []).append((at, added, removed, payloads))
 
     for node in ast.walk(tree):
@@ -706,7 +733,11 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
             and isinstance(node.func, ast.Attribute)
             and isinstance(node.func.value, ast.Name)
         ):
-            if node.func.attr == "pop" and node.args:
+            if node.func.attr == "clear" and not node.args:
+                # `TW.clear()` empties it, so anything recorded before is gone.
+                # `None` rather than a key set: there is no list of keys to name.
+                _record(node.func.value.id, at, set(), None)
+            elif node.func.attr == "pop" and node.args:
                 # `T.pop("zh-TW")` removes the key as plainly as `del T["zh-TW"]`.
                 first = node.args[0]
                 if isinstance(first, ast.Constant) and isinstance(first.value, str):
@@ -793,7 +824,7 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
         for pos, _added, removed, _payloads in mutations.get(name, ()):
             if pos <= at or (rebound is not None and pos > rebound):
                 continue
-            if TRADITIONAL_KEY in removed:
+            if removed is None or TRADITIONAL_KEY in removed:
                 return True
         return False
 
@@ -853,6 +884,16 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
             return set()
         if isinstance(node, ast.Name):
             return _name_keys(node.id, at, strict)
+        if (
+            isinstance(node, ast.Call)
+            and not node.args
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in ("items", "copy")
+            and isinstance(node.func.value, ast.Name)
+        ):
+            # `T.update(TW.items())` / `dict(TW.copy())` — both hand over exactly
+            # the keys TW has, and passing a view is ordinary Python.
+            return _mapping_keys(node.func.value, at, strict)
         if isinstance(node, ast.IfExp):
             # `T |= TW if flag else {"zh-TW": t}` — either branch may carry it, and
             # a conditional supply counts, same as in `_directly_visible_keys`.
@@ -904,7 +945,7 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
                 continue
             for payload in payloads:
                 added = added | _mapping_keys(payload, pos)
-            keys = (keys | added) - removed
+            keys = set() if removed is None else (keys | added) - removed
         return keys
 
     for node in ast.walk(tree):
@@ -1019,6 +1060,10 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
                 _exempt_binding_before(operand.id, origin, inside_binding)
             else:
                 pending.extend(_merge_operands(operand))
+
+    for group in loop_alternatives:
+        if group & exempt:
+            exempt |= group
 
     return exempt
 

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -345,14 +345,16 @@ def _merge_operands(node: ast.AST) -> list[ast.AST]:
         isinstance(node, ast.Call)
         and isinstance(node.func, ast.Attribute)
         and node.func.attr == "update"
-        and node.args
     ):
         # `T.update({...})` merges into T, so the payload is a fragment for the
         # same reason a spread operand is: whether the assembled table has zh-TW
         # depends on T, which this expression does not show. Suppressing it avoids
         # reporting `T = {"zh-TW": ...}` / `T.update({"en": ..., "zh": ...})` —
         # compliant at runtime — as an offender.
-        return [node.args[0]]
+        #
+        # Both argument forms count: `update({...})` and `update(**{...})` are the
+        # same merge, so the keyword-spread payload is a fragment too.
+        return list(node.args) + [kw.value for kw in node.keywords if kw.arg is None]
     return []
 
 
@@ -490,15 +492,25 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
             exempt.add(id(value))
 
     for node in ast.walk(tree):
-        if (
-            isinstance(node, ast.Assign)
-            and len(node.targets) == 1
-            and isinstance(node.targets[0], ast.Subscript)
-            and isinstance(node.targets[0].value, ast.Name)
-            and isinstance(node.targets[0].slice, ast.Constant)
-            and node.targets[0].slice.value == TRADITIONAL_KEY
-        ):
-            _exempt_binding_before(node.targets[0].value.id, node.lineno)
+        # `T["zh-TW"] = t`, and its annotated form `T["zh-TW"]: str = t`.
+        # AnnAssign carries a single `target` rather than a `targets` list, so it
+        # needs its own unpacking even though the shape being matched is identical.
+        subscripts: list[ast.AST] = []
+        if isinstance(node, ast.Assign):
+            subscripts = list(node.targets)
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            subscripts = [node.target]
+        matched = False
+        for slot in subscripts:
+            if (
+                isinstance(slot, ast.Subscript)
+                and isinstance(slot.value, ast.Name)
+                and isinstance(slot.slice, ast.Constant)
+                and slot.slice.value == TRADITIONAL_KEY
+            ):
+                _exempt_binding_before(slot.value.id, node.lineno)
+                matched = True
+        if matched:
             continue
         target: str | None = None
         payload: ast.AST | None = None
@@ -679,8 +691,13 @@ def _comment_lines(source: str) -> list[str]:
     wrong suppression, and ``ast.parse`` will have reported the syntax error.
     """
     blank = [""] * len(re.split(r"\r\n|\r|\n", source))
+    # Normalize line endings first: io.StringIO does not treat a lone \r as a
+    # newline, so a CR-only module collapses to one line for tokenize while the
+    # split above counts them properly. The comment then lands on the wrong index
+    # — which suppresses a table that has no noqa and reports the one that does.
+    normalized = re.sub(r"\r\n|\r", "\n", source)
     try:
-        for token in tokenize.generate_tokens(io.StringIO(source).readline):
+        for token in tokenize.generate_tokens(io.StringIO(normalized).readline):
             if token.type == tokenize.COMMENT:
                 row = token.start[0]
                 if 1 <= row <= len(blank):

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -149,6 +149,67 @@ def resolve_keys(node: ast.AST) -> set[str] | None:
         if left is None or right is None:
             return None
         return left | right
+    if isinstance(node, ast.DictComp):
+        return _comprehension_keys(node)
+    return None
+
+
+def _comprehension_keys(node: ast.DictComp) -> set[str] | None:
+    """Keys of a dict comprehension over an inline literal, or None.
+
+    Resolves the two shapes whose keys are fully determined by the source::
+
+        {loc: build(loc) for loc in ("en", "zh", "ja")}
+        {k: v for k, v in (("en", "hello"), ("zh", "你好"))}
+
+    The first is a realistic way to write a localized table — one template per
+    locale off a literal locale list — so leaving it unresolved would be a real
+    blind spot, not a theoretical one.
+
+    Deliberately does NOT follow a name to its definition. `{lang: build(lang)
+    for lang in _L10N}` stays unresolved: chasing the symbol would mean judging
+    derived structures whose keys are a language list rather than templates, and
+    the three comprehensions that exist under config/prompts today are all of
+    that kind.
+    """
+    if len(node.generators) != 1:
+        return None
+    gen = node.generators[0]
+    if gen.ifs or gen.is_async:
+        return None
+    if not isinstance(node.key, ast.Name):
+        return None
+    if not isinstance(gen.iter, (ast.Tuple, ast.List, ast.Set)):
+        return None
+
+    if isinstance(gen.target, ast.Name):
+        if gen.target.id != node.key.id:
+            return None
+        keys: set[str] = set()
+        for element in gen.iter.elts:
+            if not (isinstance(element, ast.Constant)
+                    and isinstance(element.value, str)):
+                return None
+            keys.add(element.value)
+        return keys
+
+    if isinstance(gen.target, ast.Tuple):
+        names = [e.id for e in gen.target.elts if isinstance(e, ast.Name)]
+        if len(names) != len(gen.target.elts) or node.key.id not in names:
+            return None
+        index = names.index(node.key.id)
+        keys = set()
+        for element in gen.iter.elts:
+            if not isinstance(element, (ast.Tuple, ast.List)):
+                return None
+            if index >= len(element.elts):
+                return None
+            item = element.elts[index]
+            if not isinstance(item, ast.Constant) or not isinstance(item.value, str):
+                return None
+            keys.add(item.value)
+        return keys
+
     return None
 
 

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -394,6 +394,11 @@ def _directly_visible_keys(node: ast.AST) -> set[str]:
         return keys
     if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
         return _directly_visible_keys(node.left) | _directly_visible_keys(node.right)
+    if isinstance(node, ast.Call) and _is_dict_fromkeys(node.func) and node.args:
+        # `_F | dict.fromkeys(("zh-TW",), t)` — resolve_keys handles this
+        # constructor, so the visibility scan has to as well or the union looks
+        # like it supplies nothing and _F gets reported.
+        return _literal_string_sequence(node.args[0]) or set()
     return set()
 
 
@@ -429,13 +434,16 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
     assignments: dict[str, list[tuple[int, int]]] = {}
     for node in ast.walk(tree):
         name: str | None = None
+        if isinstance(node, ast.Assign):
+            # Every simple target, so a chained `T = U = {...}` registers both —
+            # they name the same object, and a mutation through either completes it.
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    assignments.setdefault(target.id, []).append(
+                        (node.lineno, id(node.value))
+                    )
+            continue
         if (
-            isinstance(node, ast.Assign)
-            and len(node.targets) == 1
-            and isinstance(node.targets[0], ast.Name)
-        ):
-            name = node.targets[0].id
-        elif (
             # `T: dict[str, str] = {...}` — an annotated binding is still a
             # binding, and typed prompt constants are ordinary style. Missing them
             # left the table unexempted and reported despite being compliant.

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -378,6 +378,33 @@ def _generator_pair_keys(node: ast.GeneratorExp) -> set[str] | None:
     )
 
 
+def _source_position(node: ast.AST) -> tuple[int, int]:
+    """``(line, column)`` of a node, for ordering bindings against uses.
+
+    Lines alone are not an order: ``T = {}; T["zh-TW"] = "t"; T = {"en": ..}``
+    puts three statements on one, and a line-only comparison read the last of
+    them as preceding the mutation in the middle.
+    """
+    return getattr(node, "lineno", 0), getattr(node, "col_offset", 0)
+
+
+def _assignment_slots(targets: list[ast.AST]) -> list[ast.AST]:
+    """Assignment targets, flattened through tuple / list / starred unpacking.
+
+    ``T["zh-TW"], flag = t, True`` puts the subscript inside an ``ast.Tuple``, so
+    a top-level-only scan missed the backfill and reported the completed table.
+    """
+    slots: list[ast.AST] = []
+    for target in targets:
+        if isinstance(target, (ast.Tuple, ast.List)):
+            slots.extend(_assignment_slots(list(target.elts)))
+        elif isinstance(target, ast.Starred):
+            slots.extend(_assignment_slots([target.value]))
+        else:
+            slots.append(target)
+    return slots
+
+
 def _operand_branches(node: ast.AST) -> list[ast.AST]:
     """An operand, or — when it is conditional — the branches it picks between.
 
@@ -528,11 +555,11 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
 
       would have its later table exempted too.
 
-    No scope analysis: line order is enough here because a mutation and the
+    No scope analysis: source order is enough here because a mutation and the
     binding it mutates sit in the same scope in practice, and picking the nearest
     preceding binding is right in either nesting direction.
     """
-    assignments: dict[str, list[tuple[int, int]]] = {}
+    assignments: dict[str, list[tuple[tuple[int, int], ast.AST]]] = {}
     for node in ast.walk(tree):
         name: str | None = None
         if isinstance(node, ast.Assign):
@@ -541,7 +568,7 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
             for target in node.targets:
                 if isinstance(target, ast.Name):
                     assignments.setdefault(target.id, []).append(
-                        (node.lineno, node.value)
+                        (_source_position(node.value), node.value)
                     )
             continue
         if (
@@ -555,7 +582,9 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
             name = node.target.id
         if name is None:
             continue
-        assignments.setdefault(name, []).append((node.lineno, node.value))
+        assignments.setdefault(name, []).append(
+            (_source_position(node.value), node.value)
+        )
     for bindings in assignments.values():
         bindings.sort(key=lambda item: item[0])
 
@@ -576,29 +605,33 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
     exempt: set[int] = set()
 
     def _binding_before(
-        name: str, lineno: int, exclude: ast.AST | None = None
-    ) -> tuple[int, ast.AST] | None:
-        """The value bound to `name` most recently at or before `lineno`.
+        name: str, at: tuple[int, int], strict: bool = False
+    ) -> tuple[tuple[int, int], ast.AST] | None:
+        """The value bound to `name` most recently at or before source position `at`.
 
-        Returns the binding's own line along with it, because a hop through an
-        alias has to continue searching from where the alias was bound rather than
-        from the far-away line that reads it.
+        Positions are ``(line, column)``, not lines: ``T = {}; T["zh-TW"] = "t";
+        T = {"en": .., "zh": ..}`` puts three statements on one line, and a
+        line-only search picked the *last* of them for a mutation that runs before
+        it — exempting a table that really does end up missing zh-TW.
 
-        ``exclude`` skips one candidate: for a self-rebinding merge like
-        ``T = T | {...}`` the new assignment registers on the same line as the
-        merge, so an inclusive line search would pick the merge's own result
-        instead of the binding its right-hand side actually reads.
+        ``strict`` excludes a binding at exactly `at`, which is what descending
+        into a binding's own right-hand side needs: the ``TW`` inside
+        ``TW = dict(TW)`` reads the binding *before* this one. It also makes every
+        hop move strictly earlier in the file, so alias chains terminate on source
+        order rather than on a visited-name set — and a set was wrong here, since
+        a name legitimately reappears inside its own rebinding.
+
+        Returns the binding's own position along with the value, because the next
+        hop has to continue from there rather than from the far-away use site.
         """
-        for ln, value in reversed(assignments.get(name, [])):
-            if ln > lineno:
+        for pos, value in reversed(assignments.get(name, [])):
+            if pos > at or (strict and pos == at):
                 continue
-            if exclude is not None and value is exclude:
-                continue
-            return ln, value
+            return pos, value
         return None
 
     def _exempt_binding_before(
-        name: str, lineno: int, exclude: ast.AST | None = None
+        name: str, at: tuple[int, int], strict: bool = False
     ) -> None:
         """Exempt what `name` holds, down through aliases and nested merges.
 
@@ -607,10 +640,10 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
         bare ``Name``, so ``F``'s literal — the node actually judged — stayed
         subject to the rule and a compliant table still grew the count.
         """
-        pending, walked = [(name, lineno, exclude)], set()
+        pending, walked = [(name, at, strict)], set()
         while pending:
-            current, at, skip = pending.pop()
-            found = _binding_before(current, at, skip)
+            current, pos, skip_self = pending.pop()
+            found = _binding_before(current, pos, skip_self)
             if found is None:
                 continue
             bound_at, value = found
@@ -620,7 +653,7 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
             exempt.add(id(value))
             for part in _fragment_parts(value):
                 if isinstance(part, ast.Name):
-                    pending.append((part.id, bound_at, None))
+                    pending.append((part.id, bound_at, True))
 
     def _fragment_parts(node: ast.AST) -> list[ast.AST]:
         """The sub-expressions that stand in for `node` — aliases and operands.
@@ -634,7 +667,7 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
         return _merge_operands(node)
 
     def _mapping_keys(
-        node: ast.AST | None, at: int, _seen: frozenset[str] = frozenset()
+        node: ast.AST | None, at: tuple[int, int], strict: bool = False
     ) -> set[str]:
         """Keys a mapping expression supplies, following names to their bindings.
 
@@ -644,20 +677,18 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
         second hop through ``TW2 = dict(TW)``), and every gap read as "no zh-TW
         here", i.e. a table reported despite being compliant at runtime.
 
-        ``_seen`` guards the name hops, so mutual or self-referential bindings
-        terminate instead of recursing forever.
+        ``at``/``strict`` say where names inside `node` are resolved from. Each hop
+        moves strictly earlier in the file, which is what terminates the recursion.
         """
         if node is None:
             return set()
         if isinstance(node, ast.Name):
-            if node.id in _seen:
-                return set()
-            return _name_keys(node.id, at, _seen=_seen)
+            return _name_keys(node.id, at, strict)
         if isinstance(node, ast.IfExp):
             # `T |= TW if flag else {"zh-TW": t}` — either branch may carry it, and
             # a conditional supply counts, same as in `_directly_visible_keys`.
-            return _mapping_keys(node.body, at, _seen) | _mapping_keys(
-                node.orelse, at, _seen
+            return _mapping_keys(node.body, at, strict) | _mapping_keys(
+                node.orelse, at, strict
             )
         keys = resolve_keys(node)
         if keys is None:
@@ -669,29 +700,28 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
             if operands:
                 keys = _directly_visible_keys(node)
                 for operand in operands:
-                    keys |= _mapping_keys(operand, at, _seen)
+                    keys |= _mapping_keys(operand, at, strict)
         return keys or set()
 
     def _name_keys(
-        name: str,
-        at: int,
-        exclude: ast.AST | None = None,
-        _seen: frozenset[str] = frozenset(),
+        name: str, at: tuple[int, int], strict: bool = False
     ) -> set[str]:
         """Keys of the mapping `name` is bound to just before `at`.
 
-        The hop moves the search position back to that binding's own line. Keeping
-        the original `at` through every hop read an alias against a *later*
-        rebinding of its source: in ``ALIAS = P`` / ``P = {"zh-TW": t}`` / ``T.
-        update(ALIAS)``, ALIAS still holds the earlier object at runtime, so
-        resolving P at the update line would exempt a table that really is missing
-        zh-TW.
+        The hop moves the search position back to that binding's own, and descends
+        `strict`ly from there. Keeping the original `at` through every hop read an
+        alias against a *later* rebinding of its source: in ``ALIAS = P`` /
+        ``P = {"zh-TW": t}`` / ``T.update(ALIAS)``, ALIAS still holds the earlier
+        object at runtime, so resolving P at the update site would exempt a table
+        that really is missing zh-TW. Descending strictly is the other half: the
+        ``TW`` inside ``TW = dict(TW)`` reads the binding before that one, and
+        resolving it against the binding being descended into found nothing.
         """
-        found = _binding_before(name, at, exclude)
+        found = _binding_before(name, at, strict)
         if found is None:
             return set()
         bound_at, value = found
-        return _mapping_keys(value, bound_at, _seen | {name})
+        return _mapping_keys(value, bound_at, strict=True)
 
     for node in ast.walk(tree):
         # `T["zh-TW"] = t`, and its annotated form `T["zh-TW"]: str = t`.
@@ -699,9 +729,12 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
         # needs its own unpacking even though the shape being matched is identical.
         subscripts: list[ast.AST] = []
         if isinstance(node, ast.Assign):
-            subscripts = list(node.targets)
+            # Through tuple/list/starred targets too: `T["zh-TW"], flag = t, True`
+            # puts the subscript inside an ast.Tuple, and looking only at top-level
+            # targets left the completed table reported.
+            subscripts = _assignment_slots(node.targets)
         elif isinstance(node, ast.AnnAssign) and node.value is not None:
-            subscripts = [node.target]
+            subscripts = _assignment_slots([node.target])
         matched = False
         for slot in subscripts:
             if (
@@ -710,7 +743,7 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
                 and isinstance(slot.slice, ast.Constant)
                 and slot.slice.value == TRADITIONAL_KEY
             ):
-                _exempt_binding_before(slot.value.id, node.lineno)
+                _exempt_binding_before(slot.value.id, _source_position(node))
                 matched = True
         if matched:
             continue
@@ -730,7 +763,7 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
                     isinstance(first, ast.Constant)
                     and first.value == TRADITIONAL_KEY
                 ):
-                    _exempt_binding_before(target, node.lineno)
+                    _exempt_binding_before(target, _source_position(node))
                 continue
             # Every payload, not just the first: `update({...}, **{...})` is legal
             # and so is more than one `**`. Named keywords are deliberately not
@@ -749,10 +782,10 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
             continue
 
         if any(
-            TRADITIONAL_KEY in _mapping_keys(payload, node.lineno)
+            TRADITIONAL_KEY in _mapping_keys(payload, _source_position(node))
             for payload in payloads
         ):
-            _exempt_binding_before(target, node.lineno)
+            _exempt_binding_before(target, _source_position(node))
 
     # A name merged into a construction that *demonstrably supplies zh-TW* is a
     # fragment of a compliant table: `_F = {"en": .., "zh": ..}` /
@@ -767,17 +800,24 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
         if not operands:
             continue
 
-        # The whole bound expression, not this merge node: `T = (T | {"zh-TW": t})
-        # if flag else ...` registers the IfExp as T's new binding, so excluding
-        # the merge by identity left each `T` resolving to the assignment being
-        # evaluated instead of the table it reads.
+        # Names inside a merge resolve from the position of the *whole bound
+        # expression* it sits in, strictly — `T = (T | {"zh-TW": t}) if flag else
+        # ...` registers the IfExp as T's new binding, and anything less than "the
+        # binding being evaluated, excluded" left each `T` resolving to that new
+        # binding instead of the table it actually reads.
         enclosing = bound_expression.get(id(node), node)
+        origin = _source_position(enclosing)
+        inside_binding = enclosing is not node or id(node) in bound_expression
 
         # `_TW = {"zh-TW": t}` / `T = {**_F, **_TW}` supplies zh-TW as plainly as an
         # inline literal. Following the name only ever *adds* visible keys, so
         # `U = dict(T)` still sees {en, zh} and leaves T subject to the rule.
-        def _named_keys(name: str, _at: int = node.lineno, _self: ast.AST = enclosing) -> set[str]:
-            return _name_keys(name, _at, exclude=_self)
+        def _named_keys(
+            name: str,
+            _at: tuple[int, int] = origin,
+            _strict: bool = inside_binding,
+        ) -> set[str]:
+            return _name_keys(name, _at, _strict)
 
         if TRADITIONAL_KEY not in _directly_visible_keys(node, _named_keys):
             continue
@@ -792,7 +832,7 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
                 continue
             walked.add(id(operand))
             if isinstance(operand, ast.Name):
-                _exempt_binding_before(operand.id, node.lineno, exclude=enclosing)
+                _exempt_binding_before(operand.id, origin, inside_binding)
             else:
                 pending.extend(_merge_operands(operand))
 

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -56,6 +56,31 @@ and passes. That is a deliberate accept — the alternative is matching dicts
 across revisions by identity, and every candidate for that identity (position,
 key set, scheme) is what the three wrong turns above already tried.
 
+Scope: one expression at a time, plus one cross-statement exemption
+==================================================================
+A table assembled across statements is not judged::
+
+    T = {"en": "e"}
+    T["zh"] = "s"          # T now needs zh-TW, and this gate will not say so
+
+Judging that needs intra-procedural data flow — binding names to mapping state,
+then following subscript assignments, ``update()`` calls and ``|=`` through
+scopes, aliases, branches and loops. So mutation *payloads* are suppressed as
+fragments (alone they say nothing about the assembled table) and the assembled
+table goes unjudged. Same family as the "unknowable keys stay silent" rule.
+
+The one cross-statement case that *is* handled is the false-positive direction::
+
+    T = {"en": "e", "zh": "s"}
+    T.update({"zh-TW": "t"})    # or T["zh-TW"] = ..., or T |= {...}
+
+That table is compliant at runtime, so reporting it would be a false positive —
+and false positives are what get a gate worked around rather than satisfied. The
+exemption is deliberately keyed on the mutation *demonstrably supplying zh-TW*:
+exempting on any mutation would let an unrelated ``T["other"] = x`` excuse a real
+offender, trading one rare false positive for a broad blind spot.
+
+
 Usage:
     python scripts/check_prompt_zh_tw.py [--base origin/main]
     python scripts/check_prompt_zh_tw.py --full     # list the whole backlog
@@ -314,7 +339,85 @@ def _merge_operands(node: ast.AST) -> list[ast.AST]:
         return list(node.args) + [kw.value for kw in node.keywords if kw.arg is None]
     if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
         return [node.left, node.right]
+    if isinstance(node, ast.AugAssign) and isinstance(node.op, ast.BitOr):
+        return [node.value]  # `T |= {...}` — same merge, statement form
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "update"
+        and node.args
+    ):
+        # `T.update({...})` merges into T, so the payload is a fragment for the
+        # same reason a spread operand is: whether the assembled table has zh-TW
+        # depends on T, which this expression does not show. Suppressing it avoids
+        # reporting `T = {"zh-TW": ...}` / `T.update({"en": ..., "zh": ...})` —
+        # compliant at runtime — as an offender.
+        return [node.args[0]]
     return []
+
+
+def _backfilled_table_nodes(tree: ast.AST) -> set[int]:
+    """ids of tables that a later mutation gives ``'zh-TW'`` to.
+
+    Covers the one cross-statement shape worth handling::
+
+        T = {"en": "e", "zh": "s"}
+        T.update({"zh-TW": "t"})        # or T["zh-TW"] = ..., or T |= {...}
+
+    The table is compliant at runtime, so reporting it is a false positive — and
+    false positives are what get a gate worked around rather than satisfied.
+
+    Deliberately narrow: only a mutation that *demonstrably supplies zh-TW*
+    exempts its target. Suppressing on any mutation would let an unrelated
+    ``T["other"] = x`` excuse a real offender, trading one rare false positive for
+    a broad blind spot. Names are matched across the whole module rather than
+    per-scope: over-matching here can only exempt a table whose name is somewhere
+    given zh-TW, which is the safe direction.
+    """
+    backfilled: set[str] = set()
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Subscript)
+            and isinstance(node.targets[0].value, ast.Name)
+            and isinstance(node.targets[0].slice, ast.Constant)
+            and node.targets[0].slice.value == TRADITIONAL_KEY
+        ):
+            backfilled.add(node.targets[0].value.id)
+            continue
+        target: str | None = None
+        payload: ast.AST | None = None
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "update"
+            and isinstance(node.func.value, ast.Name)
+            and node.args
+        ):
+            target, payload = node.func.value.id, node.args[0]
+        elif (
+            isinstance(node, ast.AugAssign)
+            and isinstance(node.op, ast.BitOr)
+            and isinstance(node.target, ast.Name)
+        ):
+            target, payload = node.target.id, node.value
+        if target is None or payload is None:
+            continue
+        keys = resolve_keys(payload)
+        if keys and TRADITIONAL_KEY in keys:
+            backfilled.add(target)
+
+    if not backfilled:
+        return set()
+    return {
+        id(node.value)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name)
+        and node.targets[0].id in backfilled
+    }
 
 
 def _table_nodes(tree: ast.AST) -> Iterator[tuple[ast.AST, set[str]]]:
@@ -338,7 +441,7 @@ def _table_nodes(tree: ast.AST) -> Iterator[tuple[ast.AST, set[str]]]:
     unresolvable one is not judged, but traversal continues through it so the
     independent tables it holds are still found.
     """
-    suppressed: set[int] = set()
+    suppressed: set[int] = _backfilled_table_nodes(tree)
     stack: list[ast.AST] = [tree]
     while stack:
         node = stack.pop()

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -655,18 +655,21 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
             # `for T in ({...}, {...}): T["zh-TW"] = t` — a literal iterable makes
             # every element a binding of the loop target. Anything else (a name, a
             # call, a range) is not knowable and binds nothing.
-            group: set[int] = set()
+            # One group per target name: `for T, U in ((a, b), (c, d))` makes a
+            # and c alternatives of T, b and d alternatives of U. Pooling them
+            # would let a backfill through T excuse U's tables as well.
+            groups: dict[str, set[int]] = {}
             for item in node.iter.elts:
                 for bound, value in _unpacked_bindings(node.target, item):
                     assignments.setdefault(bound, []).append(
                         (_source_position(value), value)
                     )
-                    group.add(id(value))
-            if len(group) > 1:
-                # The body runs once per element, so these bindings are
-                # alternatives rather than a sequence: a backfill in the body
-                # completes every one of them, not just the last.
-                loop_alternatives.append(group)
+                    groups.setdefault(bound, set()).add(id(value))
+            # The body runs once per element, so a target's bindings are
+            # alternatives rather than a sequence: a backfill in the body
+            # completes every one of them, not just the last. A single-element
+            # group is kept rather than filtered — closing over it is a no-op.
+            loop_alternatives.extend(groups.values())
             continue
         if isinstance(node, ast.NamedExpr) and isinstance(node.target, ast.Name):
             # `if (T := {...}): T["zh-TW"] = t` binds T as much as a statement does.

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -13,22 +13,45 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Require a 'zh-TW' key on newly added i18n prompt dicts (issue #2500).
+"""Stop new i18n prompt dicts from landing without a 'zh-TW' key (issue #2500).
 
 A dict under config/prompts/ that has an 'en' key plus 'zh' or 'zh-CN' is a
 localized prompt table. Most of them predate Traditional Chinese support, and
-`_loc` falls back to 'en' rather than 'zh' on a missing key, so a zh-TW user
-who reaches such a dict gets an English prompt.
+`_loc` falls back to 'en' rather than 'zh' on a missing key, so a zh-TW user who
+reaches such a dict gets an English prompt.
 
-Backfilling the existing tables is a batched effort tracked in issue #2500.
-This gate only stops the hole from growing: it is a **diff ratchet** keyed on
-the dict's own definition line, so it fires for dicts this change introduces
-and stays quiet about the ones already in the tree. Editing an existing dict's
-copy does not trip it.
+Backfilling the existing tables is a batched effort tracked in issue #2500. This
+gate only stops the hole from growing.
+
+How the ratchet works
+=====================
+It compares the **multiset of key signatures** of offending dicts between the
+merge-base and HEAD, rather than asking which source lines the diff touched.
+A dict contributes ``frozenset(its string keys)``; HEAD needing more copies of
+some signature than the base had is what fails the check.
+
+Line-based ratcheting was tried first and is wrong in both directions:
+
+  * A pre-existing ``{'en': ..., 'ja': ...}`` table that a PR turns into a
+    localized one by adding a single ``'zh'`` line never has its own definition
+    line in the diff, so the gate this is meant to be would miss exactly the
+    case it exists for.
+  * Renaming a prompt module with no content change makes every line of the new
+    path count as added, so a rename would report the whole file's existing
+    backlog.
+
+Signatures dodge both: adding a Chinese key changes a dict's signature (and so
+increments a count), while renaming a file or editing a template's copy leaves
+every signature untouched.
+
+The tradeoff is that a PR which removes one offending table and adds another
+with the identical key set nets to zero and passes. That is a deliberate
+accept: the alternative is matching dicts across revisions by position, which
+breaks on every reformat.
 
 Usage:
     python scripts/check_prompt_zh_tw.py [--base origin/main]
-    python scripts/check_prompt_zh_tw.py --full     # report the whole backlog
+    python scripts/check_prompt_zh_tw.py --full     # list the whole backlog
     python scripts/check_prompt_zh_tw.py --count    # backlog size only
 
 Escape hatch: put ``# noqa: PROMPT_ZH_TW`` on the dict's opening line.
@@ -41,9 +64,11 @@ import os
 import re
 import subprocess
 import sys
+from collections import Counter
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+PROMPTS_SUBDIR = "config/prompts"
 PROMPTS_DIR = REPO_ROOT / "config" / "prompts"
 
 CODE = "PROMPT_ZH_TW"
@@ -66,18 +91,10 @@ def _string_keys(node: ast.Dict) -> set[str]:
 
 
 def find_violations(
-    tree: ast.Module,
-    source_lines: list[str],
-    changed_lines: set[int] | None = None,
-) -> list[tuple[int, str]]:
-    """Return (lineno, present-keys-summary) for localized dicts missing zh-TW.
-
-    ``changed_lines`` is the ratchet: when given, only a dict whose own
-    definition line is in the set is reported, so pre-existing tables are
-    exempt and editing a table's copy does not trip the gate. Pass ``None`` to
-    scan everything.
-    """
-    out: list[tuple[int, str]] = []
+    tree: ast.Module, source_lines: list[str]
+) -> list[tuple[int, frozenset[str]]]:
+    """Return (lineno, key-signature) for localized dicts with no zh-TW key."""
+    out: list[tuple[int, frozenset[str]]] = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Dict):
             continue
@@ -89,17 +106,69 @@ def find_violations(
         if TRADITIONAL_KEY in keys:
             continue
         lineno = node.lineno
-        if changed_lines is not None and lineno not in changed_lines:
-            continue
         if 1 <= lineno <= len(source_lines) and _has_noqa(source_lines[lineno - 1]):
             continue
-        present = ", ".join(sorted(k for k in keys if len(k) <= 6))
-        out.append((lineno, present))
+        out.append((lineno, frozenset(keys)))
     return out
 
 
+def _parse_source(source: str, origin: str) -> tuple[ast.Module | None, list[str]]:
+    try:
+        return ast.parse(source), source.splitlines()
+    except SyntaxError as exc:
+        sys.stderr.write(f"{origin}: syntax error ({exc})\n")
+        return None, []
+
+
+def signature_counter(sources: dict[str, str]) -> Counter[frozenset[str]]:
+    """Count offending key signatures across a {path: source} mapping."""
+    counter: Counter[frozenset[str]] = Counter()
+    for path, source in sorted(sources.items()):
+        tree, lines = _parse_source(source, path)
+        if tree is None:
+            continue
+        for _lineno, signature in find_violations(tree, lines):
+            counter[signature] += 1
+    return counter
+
+
+def locate(
+    sources: dict[str, str],
+    signature: frozenset[str],
+    touched: dict[str, set[int]] | None = None,
+) -> tuple[list[str], int]:
+    """Locate offending dicts matching `signature`.
+
+    Returns (likely, other_count). A dict counts as *likely* when `touched` says
+    the diff added a line inside its body, which is only a presentation hint:
+    the pass/fail decision is the signature comparison, because line spans alone
+    both miss added-key cases and misfire on renames. Common key sets like
+    {en, zh} match dozens of pre-existing tables, so surfacing the touched ones
+    is what makes the failure actionable.
+    """
+    likely: list[str] = []
+    other = 0
+    for path, source in sorted(sources.items()):
+        tree, lines = _parse_source(source, path)
+        if tree is None:
+            continue
+        by_line = {node.lineno: node for node in ast.walk(tree)
+                   if isinstance(node, ast.Dict)}
+        for lineno, sig in find_violations(tree, lines):
+            if sig != signature:
+                continue
+            node = by_line.get(lineno)
+            span = range(lineno, (getattr(node, "end_lineno", lineno) or lineno) + 1)
+            added = (touched or {}).get(path, set())
+            if added and any(ln in added for ln in span):
+                likely.append(f"{path}:{lineno}")
+            else:
+                other += 1
+    return likely, other
+
+
 # ---------------------------------------------------------------------------
-# git diff plumbing (mirrors scripts/check_docstring_no_cjk.py)
+# git plumbing (mirrors scripts/check_docstring_no_cjk.py)
 # ---------------------------------------------------------------------------
 
 
@@ -115,71 +184,75 @@ def _git(*args: str) -> str:
     return result.stdout
 
 
-def _changed_prompt_files(base: str) -> list[str]:
-    out = _git("diff", "--name-only", f"{base}...HEAD")
+def _merge_base(base: str) -> str:
+    return _git("merge-base", base, "HEAD").strip()
+
+
+def _prompt_files_at(rev: str) -> list[str]:
+    """Prompt modules present at `rev`, including any in subpackages."""
+    out = _git("ls-tree", "-r", "--name-only", rev, "--", PROMPTS_SUBDIR)
     return [
         ln.strip().replace("\\", "/")
         for ln in out.splitlines()
-        if ln.strip().startswith("config/prompts/") and ln.strip().endswith(".py")
+        if ln.strip().endswith(".py")
     ]
+
+
+def _sources_at(rev: str) -> dict[str, str]:
+    return {path: _git("show", f"{rev}:{path}") for path in _prompt_files_at(rev)}
 
 
 _HUNK_HEADER_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
 
 
-def _added_lines(base: str, path: str) -> set[int]:
-    """1-based line numbers in the NEW file touched by the diff."""
-    diff = _git("diff", "--unified=0", f"{base}...HEAD", "--", path)
-    lines: set[int] = set()
-    for ln in diff.splitlines():
-        m = _HUNK_HEADER_RE.match(ln)
-        if not m:
+def _touched_lines(rev: str) -> dict[str, set[int]]:
+    """Lines the diff added per prompt file — a hint for error messages only.
+
+    ``-M`` keeps a pure rename from reporting every line of the new path as
+    added, which would make the hint point at the whole file.
+    """
+    diff = _git("diff", "-M", "--unified=0", f"{rev}...HEAD", "--", PROMPTS_SUBDIR)
+    touched: dict[str, set[int]] = {}
+    current: str | None = None
+    for line in diff.splitlines():
+        if line.startswith("+++ b/"):
+            current = line[len("+++ b/"):].strip().replace("\\", "/")
             continue
-        start = int(m.group(1))
-        count = int(m.group(2)) if m.group(2) is not None else 1
-        lines.update(range(start, start + count))
-    return lines
-
-
-def _parse(path: Path) -> tuple[ast.Module | None, list[str]]:
-    try:
-        text = path.read_text(encoding="utf-8")
-    except OSError as exc:
-        sys.stderr.write(f"{path}: cannot read ({exc})\n")
-        return None, []
-    try:
-        return ast.parse(text), text.splitlines()
-    except SyntaxError as exc:
-        sys.stderr.write(f"{path}: syntax error ({exc})\n")
-        return None, []
-
-
-def _scan_all() -> list[tuple[Path, int, str]]:
-    found: list[tuple[Path, int, str]] = []
-    for path in sorted(PROMPTS_DIR.glob("*.py")):
-        tree, lines = _parse(path)
-        if tree is None:
+        match = _HUNK_HEADER_RE.match(line)
+        if not match or current is None:
             continue
-        for lineno, present in find_violations(tree, lines):
-            found.append((path, lineno, present))
-    return found
+        start = int(match.group(1))
+        count = int(match.group(2)) if match.group(2) is not None else 1
+        touched.setdefault(current, set()).update(range(start, start + count))
+    return touched
+
+
+def _sources_on_disk() -> dict[str, str]:
+    sources: dict[str, str] = {}
+    for path in sorted(PROMPTS_DIR.rglob("*.py")):
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        try:
+            sources[rel] = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            sys.stderr.write(f"{rel}: cannot read ({exc})\n")
+    return sources
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description=(
             "Require 'zh-TW' on newly added localized prompt dicts "
-            "(diff-ratchet against --base; --full scans everything)."
+            "(signature ratchet against --base; --full scans everything)."
         )
     )
     parser.add_argument(
         "--base",
         default=os.environ.get("PROMPT_ZH_TW_BASE", "origin/main"),
-        help="Base ref for the diff ratchet (default: origin/main).",
+        help="Base ref for the ratchet (default: origin/main).",
     )
     parser.add_argument(
         "--full", action="store_true",
-        help="Scan every dict, not just newly added ones.",
+        help="List every offending dict, not just newly added ones.",
     )
     parser.add_argument(
         "--count", action="store_true",
@@ -187,51 +260,61 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    disk = _sources_on_disk()
+
     if args.count:
-        total = len(_scan_all())
+        total = sum(signature_counter(disk).values())
         print(f"localized prompt dicts missing '{TRADITIONAL_KEY}': {total}")
         return 0
 
     if args.full:
-        found = _scan_all()
-        for path, lineno, present in found:
-            rel = path.relative_to(REPO_ROOT).as_posix()
-            print(f"{rel}:{lineno}: [{CODE}] missing '{TRADITIONAL_KEY}' (has: {present})")
+        found = 0
+        for path, source in sorted(disk.items()):
+            tree, lines = _parse_source(source, path)
+            if tree is None:
+                continue
+            for lineno, signature in find_violations(tree, lines):
+                present = ", ".join(sorted(k for k in signature if len(k) <= 6))
+                print(f"{path}:{lineno}: [{CODE}] missing "
+                      f"'{TRADITIONAL_KEY}' (has: {present})")
+                found += 1
         if found:
-            print(f"\n{len(found)} localized prompt dict(s) missing '{TRADITIONAL_KEY}'.")
+            print(f"\n{found} localized prompt dict(s) missing '{TRADITIONAL_KEY}'.")
             print("This is the issue #2500 backlog; --full is informational.")
         return 1 if found else 0
 
-    changed = _changed_prompt_files(args.base)
-    if not changed:
+    merge_base = _merge_base(args.base)
+    base_counter = signature_counter(_sources_at(merge_base))
+    head_counter = signature_counter(disk)
+
+    added = head_counter - base_counter
+    if not added:
         return 0
 
-    violations: list[tuple[str, int, str]] = []
-    for rel in changed:
-        path = REPO_ROOT / rel
-        if not path.is_file():
-            continue
-        tree, lines = _parse(path)
-        if tree is None:
-            continue
-        added = _added_lines(args.base, rel)
-        for lineno, present in find_violations(tree, lines):
-            if lineno in added:
-                violations.append((rel, lineno, present))
-
-    if not violations:
-        return 0
-
-    for rel, lineno, present in violations:
-        print(f"{rel}:{lineno}: [{CODE}] new localized prompt dict is missing "
-              f"'{TRADITIONAL_KEY}' (has: {present})")
+    touched = _touched_lines(merge_base)
+    total = sum(added.values())
+    for signature, count in sorted(added.items(), key=lambda kv: sorted(kv[0])):
+        present = ", ".join(sorted(k for k in signature if len(k) <= 6))
+        likely, other = locate(disk, signature, touched)
+        print(f"[{CODE}] {count} new localized prompt dict(s) with keys "
+              f"({present}) and no '{TRADITIONAL_KEY}'.")
+        if likely:
+            print(f"        in lines this change touched: {', '.join(likely)}")
+        if other:
+            print(f"        ({other} pre-existing table(s) share this key set "
+                  f"and are exempt)")
+        if not likely:
+            print("        no touched table matches — the new table may have "
+                  "moved in from elsewhere; run --full to see every offender")
     print(
-        f"\n{len(violations)} newly added localized prompt dict(s) lack "
+        f"\n{total} newly added localized prompt dict(s) lack "
         f"'{TRADITIONAL_KEY}'.\n"
         "A prompt dict with 'en' + 'zh'/'zh-CN' needs 'zh-TW' too: _loc falls "
         "back to 'en', not 'zh', so Traditional Chinese users would get an "
         "English prompt. Add the template, or put '# noqa: PROMPT_ZH_TW' on the "
         "dict's opening line if it genuinely does not need one.\n"
+        "The ratchet counts key signatures rather than source lines, so the "
+        "locations above are narrowed to the tables this change touched.\n"
         f"(Set $PROMPT_ZH_TW_BASE or pass --base to override the base ref.)"
     )
     return 1

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -88,7 +88,26 @@ ANCHOR_KEY = "en"
 
 
 def _has_noqa(line: str) -> bool:
-    return bool(re.search(rf"#\s*noqa:\s*{CODE}\b", line))
+    """True if `line` carries `# noqa` (bare) or `# noqa: ...,PROMPT_ZH_TW,...`.
+
+    Same implementation as the sibling gates (check_docstring_no_cjk.py,
+    check_prompt_hygiene.py, check_llm_budget.py) and therefore the same
+    behaviour as ruff/flake8. An earlier version anchored the code immediately
+    after ``noqa:``, which silently rejected a bare ``# noqa`` and any list where
+    this code was not first — so an author following the convention the other four
+    gates use would find their suppression ignored.
+
+    Tolerates a trailing explanatory comment, but it must start with ``#``
+    (``# noqa: CODE  # rationale``): the codes block stops only at the next ``#``
+    or end-of-line.
+    """
+    m = re.search(r"#\s*noqa\b(?:\s*:\s*([A-Za-z0-9_,\s]+?))?(?=#|$)", line)
+    if not m:
+        return False
+    raw = m.group(1)
+    if raw is None or not raw.strip():
+        return True
+    return CODE in {c.strip() for c in raw.split(",") if c.strip()}
 
 
 def resolve_keys(node: ast.AST) -> set[str] | None:
@@ -324,9 +343,19 @@ def _offending_nodes(
         if not is_offender(keys):
             continue
         lineno = node.lineno
-        if 1 <= lineno <= len(source_lines) and _has_noqa(source_lines[lineno - 1]):
-            continue
         end = getattr(node, "end_lineno", lineno) or lineno
+        # Opening *or* closing line: a suppression comment on the closing brace
+        # is a natural place to put it, and for a merge expression the node's own
+        # lineno is the left operand's line rather than the line the author would
+        # think of as the table's start. (The directive is not spelled out here —
+        # ruff would read it as a real one and warn about the bare code name.)
+        exempt = any(
+            _has_noqa(source_lines[ln - 1])
+            for ln in {lineno, end}
+            if 1 <= ln <= len(source_lines)
+        )
+        if exempt:
+            continue
         found.append((node, lineno, end))
     # _table_nodes walks depth-first off a stack, so restore source order.
     found.sort(key=lambda item: (item[1], item[2]))
@@ -339,8 +368,18 @@ def find_violations(tree: ast.Module, source_lines: list[str]) -> list[int]:
 
 
 def _parse_source(source: str, origin: str) -> tuple[ast.Module | None, list[str]]:
+    """Parse source and split it into lines that line up with AST line numbers.
+
+    Not ``str.splitlines()``: it also breaks on \\x0b \\x0c \\x1c \\x1d \\x1e
+    \\x85 U+2028 U+2029, none of which CPython treats as a line break. One of
+    those inside a string literal shifts every later line by one, so a noqa stops
+    matching its own table and starts matching a neighbour.
+
+    Not ``split("\\n")`` either — that collapses a lone-CR file into a single
+    line, which breaks noqa lookup wholesale.
+    """
     try:
-        return ast.parse(source), source.splitlines()
+        return ast.parse(source), re.split(r"\r\n|\r|\n", source)
     except SyntaxError as exc:
         sys.stderr.write(f"{origin}: syntax error ({exc})\n")
         return None, []
@@ -522,6 +561,28 @@ def _touched_lines(rev: str) -> dict[str, set[int]]:
     return touched
 
 
+def _git_visible_prompt_files() -> set[str] | None:
+    """Prompt paths git knows about: tracked plus untracked-not-ignored.
+
+    ``None`` when git cannot answer (no repo, git missing), in which case the disk
+    scan is used unfiltered — ``--count`` and ``--full`` are useful outside a
+    checkout, and the ratchet itself already needs git for its base side.
+    """
+    result = subprocess.run(
+        ["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard",
+         "--", PROMPTS_SUBDIR],
+        cwd=REPO_ROOT, capture_output=True, check=False,
+    )
+    if result.returncode != 0:
+        return None
+    out = result.stdout.decode("utf-8", errors="replace")
+    return {
+        entry.replace("\\", "/")
+        for entry in out.split("\0")
+        if entry.endswith(".py")
+    }
+
+
 def _sources_on_disk() -> dict[str, str]:
     """Read every prompt module off disk, decoding per PEP 263.
 
@@ -529,9 +590,18 @@ def _sources_on_disk() -> dict[str, str]:
     uses, so a module with a coding declaration is checked rather than skipped and
     an unreadable one is reported rather than fatal.
     """
+    known = _git_visible_prompt_files()
     sources: dict[str, str] = {}
     for path in sorted(PROMPTS_DIR.rglob("*.py")):
         rel = path.relative_to(REPO_ROOT).as_posix()
+        if known is not None and rel not in known:
+            # Both sides must draw from the same set of files. The base side comes
+            # from `git ls-tree`, so a file git does not know about — a gitignored
+            # scratch module, a build artifact — would exist only on this side and
+            # count as pure growth, failing the gate over something no PR
+            # introduced. Untracked-but-not-ignored files stay in, so a
+            # work-in-progress module is still checked locally.
+            continue
         if path.is_symlink():
             # Must match _prompt_files_at, which skips mode 120000. Reading here
             # would follow the link and scan its target, while `git show` on the

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -56,6 +56,27 @@ and passes. That is a deliberate accept — the alternative is matching dicts
 across revisions by identity, and every candidate for that identity (position,
 key set, scheme) is what the three wrong turns above already tried.
 
+What this gate promises, and what it asks of you instead
+=======================================================
+It reads the shapes prompt modules actually use -- a dict literal, ``dict()``,
+``|``, a comprehension, an iterable of pairs, ``dict.fromkeys``, and the
+statement-level backfills around them (``T["zh-TW"] = ...``, ``update()``,
+``setdefault()``, ``|=``, and the removals that undo them).
+
+It does **not** try to be a Python interpreter. When a table is assembled in a
+way it cannot prove statically, the answer is not a smarter analysis; it is one
+of two things you do to the code:
+
+  * write the table in one of the canonical shapes above, or
+  * put ``# noqa: PROMPT_ZH_TW`` on it, which is a one-line, greppable record
+    that a human decided this table is out of scope.
+
+That line is the design, not a shortfall. Every extra construct taught to the
+resolver buys a case nobody writes and costs a rule that can misfire on the
+~339 tables this gate actually watches; the escape hatch costs one comment.
+Reviewers who find a shape it does not resolve should reach for the hatch, not
+for another branch here.
+
 Scope: one expression at a time, plus one cross-statement exemption
 ==================================================================
 A table assembled across statements is not judged::
@@ -1532,8 +1553,16 @@ def main(argv: list[str] | None = None) -> int:
         "back to 'en', not 'zh', so Traditional Chinese users would get an "
         "English prompt. Add the template, or put '# noqa: PROMPT_ZH_TW' on the "
         "dict's opening or closing line if it genuinely does not need one.\n"
+        "\nThis check reads the shapes prompt modules use: a dict literal, "
+        "dict(), |, a comprehension, an iterable of pairs, dict.fromkeys, and "
+        "the statement-level backfills around them. It is not a Python "
+        "interpreter. A table assembled some other way should be rewritten in "
+        "one of those shapes or marked with the noqa above -- that is the "
+        "intended answer, not a gap to report.\n"
         "The ratchet compares totals rather than source lines, so the locations "
-        "above are narrowed to the tables this change touched.\n"
+        "above are narrowed to the tables this change touched. A change that "
+        "removes one offender and adds another nets to zero and passes; that is "
+        "an accepted blind spot, documented at the top of this script.\n"
         f"(Set $PROMPT_ZH_TW_BASE or pass --base to override the base ref.)"
     )
     return 1

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -1,0 +1,241 @@
+# -*- coding: utf-8 -*-
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Require a 'zh-TW' key on newly added i18n prompt dicts (issue #2500).
+
+A dict under config/prompts/ that has an 'en' key plus 'zh' or 'zh-CN' is a
+localized prompt table. Most of them predate Traditional Chinese support, and
+`_loc` falls back to 'en' rather than 'zh' on a missing key, so a zh-TW user
+who reaches such a dict gets an English prompt.
+
+Backfilling the existing tables is a batched effort tracked in issue #2500.
+This gate only stops the hole from growing: it is a **diff ratchet** keyed on
+the dict's own definition line, so it fires for dicts this change introduces
+and stays quiet about the ones already in the tree. Editing an existing dict's
+copy does not trip it.
+
+Usage:
+    python scripts/check_prompt_zh_tw.py [--base origin/main]
+    python scripts/check_prompt_zh_tw.py --full     # report the whole backlog
+    python scripts/check_prompt_zh_tw.py --count    # backlog size only
+
+Escape hatch: put ``# noqa: PROMPT_ZH_TW`` on the dict's opening line.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PROMPTS_DIR = REPO_ROOT / "config" / "prompts"
+
+CODE = "PROMPT_ZH_TW"
+
+SIMPLIFIED_KEYS = ("zh", "zh-CN")
+TRADITIONAL_KEY = "zh-TW"
+ANCHOR_KEY = "en"
+
+
+def _has_noqa(line: str) -> bool:
+    return bool(re.search(rf"#\s*noqa:\s*{CODE}\b", line))
+
+
+def _string_keys(node: ast.Dict) -> set[str]:
+    return {
+        k.value
+        for k in node.keys
+        if isinstance(k, ast.Constant) and isinstance(k.value, str)
+    }
+
+
+def find_violations(
+    tree: ast.Module,
+    source_lines: list[str],
+    changed_lines: set[int] | None = None,
+) -> list[tuple[int, str]]:
+    """Return (lineno, present-keys-summary) for localized dicts missing zh-TW.
+
+    ``changed_lines`` is the ratchet: when given, only a dict whose own
+    definition line is in the set is reported, so pre-existing tables are
+    exempt and editing a table's copy does not trip the gate. Pass ``None`` to
+    scan everything.
+    """
+    out: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Dict):
+            continue
+        keys = _string_keys(node)
+        if ANCHOR_KEY not in keys:
+            continue
+        if not any(k in keys for k in SIMPLIFIED_KEYS):
+            continue
+        if TRADITIONAL_KEY in keys:
+            continue
+        lineno = node.lineno
+        if changed_lines is not None and lineno not in changed_lines:
+            continue
+        if 1 <= lineno <= len(source_lines) and _has_noqa(source_lines[lineno - 1]):
+            continue
+        present = ", ".join(sorted(k for k in keys if len(k) <= 6))
+        out.append((lineno, present))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# git diff plumbing (mirrors scripts/check_docstring_no_cjk.py)
+# ---------------------------------------------------------------------------
+
+
+def _git(*args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        capture_output=True, text=True, check=False,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr)
+        sys.exit(2)
+    return result.stdout
+
+
+def _changed_prompt_files(base: str) -> list[str]:
+    out = _git("diff", "--name-only", f"{base}...HEAD")
+    return [
+        ln.strip().replace("\\", "/")
+        for ln in out.splitlines()
+        if ln.strip().startswith("config/prompts/") and ln.strip().endswith(".py")
+    ]
+
+
+_HUNK_HEADER_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+
+def _added_lines(base: str, path: str) -> set[int]:
+    """1-based line numbers in the NEW file touched by the diff."""
+    diff = _git("diff", "--unified=0", f"{base}...HEAD", "--", path)
+    lines: set[int] = set()
+    for ln in diff.splitlines():
+        m = _HUNK_HEADER_RE.match(ln)
+        if not m:
+            continue
+        start = int(m.group(1))
+        count = int(m.group(2)) if m.group(2) is not None else 1
+        lines.update(range(start, start + count))
+    return lines
+
+
+def _parse(path: Path) -> tuple[ast.Module | None, list[str]]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        sys.stderr.write(f"{path}: cannot read ({exc})\n")
+        return None, []
+    try:
+        return ast.parse(text), text.splitlines()
+    except SyntaxError as exc:
+        sys.stderr.write(f"{path}: syntax error ({exc})\n")
+        return None, []
+
+
+def _scan_all() -> list[tuple[Path, int, str]]:
+    found: list[tuple[Path, int, str]] = []
+    for path in sorted(PROMPTS_DIR.glob("*.py")):
+        tree, lines = _parse(path)
+        if tree is None:
+            continue
+        for lineno, present in find_violations(tree, lines):
+            found.append((path, lineno, present))
+    return found
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Require 'zh-TW' on newly added localized prompt dicts "
+            "(diff-ratchet against --base; --full scans everything)."
+        )
+    )
+    parser.add_argument(
+        "--base",
+        default=os.environ.get("PROMPT_ZH_TW_BASE", "origin/main"),
+        help="Base ref for the diff ratchet (default: origin/main).",
+    )
+    parser.add_argument(
+        "--full", action="store_true",
+        help="Scan every dict, not just newly added ones.",
+    )
+    parser.add_argument(
+        "--count", action="store_true",
+        help="Print the backlog size and exit 0.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.count:
+        total = len(_scan_all())
+        print(f"localized prompt dicts missing '{TRADITIONAL_KEY}': {total}")
+        return 0
+
+    if args.full:
+        found = _scan_all()
+        for path, lineno, present in found:
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            print(f"{rel}:{lineno}: [{CODE}] missing '{TRADITIONAL_KEY}' (has: {present})")
+        if found:
+            print(f"\n{len(found)} localized prompt dict(s) missing '{TRADITIONAL_KEY}'.")
+            print("This is the issue #2500 backlog; --full is informational.")
+        return 1 if found else 0
+
+    changed = _changed_prompt_files(args.base)
+    if not changed:
+        return 0
+
+    violations: list[tuple[str, int, str]] = []
+    for rel in changed:
+        path = REPO_ROOT / rel
+        if not path.is_file():
+            continue
+        tree, lines = _parse(path)
+        if tree is None:
+            continue
+        added = _added_lines(args.base, rel)
+        for lineno, present in find_violations(tree, lines):
+            if lineno in added:
+                violations.append((rel, lineno, present))
+
+    if not violations:
+        return 0
+
+    for rel, lineno, present in violations:
+        print(f"{rel}:{lineno}: [{CODE}] new localized prompt dict is missing "
+              f"'{TRADITIONAL_KEY}' (has: {present})")
+    print(
+        f"\n{len(violations)} newly added localized prompt dict(s) lack "
+        f"'{TRADITIONAL_KEY}'.\n"
+        "A prompt dict with 'en' + 'zh'/'zh-CN' needs 'zh-TW' too: _loc falls "
+        "back to 'en', not 'zh', so Traditional Chinese users would get an "
+        "English prompt. Add the template, or put '# noqa: PROMPT_ZH_TW' on the "
+        "dict's opening line if it genuinely does not need one.\n"
+        f"(Set $PROMPT_ZH_TW_BASE or pass --base to override the base ref.)"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -387,14 +387,25 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
     """
     assignments: dict[str, list[tuple[int, int]]] = {}
     for node in ast.walk(tree):
+        name: str | None = None
         if (
             isinstance(node, ast.Assign)
             and len(node.targets) == 1
             and isinstance(node.targets[0], ast.Name)
         ):
-            assignments.setdefault(node.targets[0].id, []).append(
-                (node.lineno, id(node.value))
-            )
+            name = node.targets[0].id
+        elif (
+            # `T: dict[str, str] = {...}` — an annotated binding is still a
+            # binding, and typed prompt constants are ordinary style. Missing them
+            # left the table unexempted and reported despite being compliant.
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.value is not None
+        ):
+            name = node.target.id
+        if name is None:
+            continue
+        assignments.setdefault(name, []).append((node.lineno, id(node.value)))
     for bindings in assignments.values():
         bindings.sort()
 

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -25,32 +25,36 @@ gate only stops the hole from growing.
 
 How the ratchet works
 =====================
-It counts offending dicts per Simplified-key scheme ('zh' vs 'zh-CN') at the
-merge-base and at HEAD; HEAD having more of either than the base is what fails
-the check. Source lines are not consulted for the decision.
+It counts offending dicts at the merge-base and at HEAD. HEAD having more than
+the base is what fails the check. That is the whole decision — no source lines,
+no per-dict identity, no grouping.
 
-Line-based ratcheting was tried first and is wrong in both directions:
+Getting here took three wrong turns, each of which broke a case the simple count
+handles for free:
 
-  * A pre-existing ``{'en': ..., 'ja': ...}`` table that a PR turns into a
-    localized one by adding a single ``'zh'`` line never has its own definition
-    line in the diff, so the gate this is meant to be would miss exactly the
-    case it exists for.
-  * Renaming a prompt module with no content change makes every line of the new
-    path count as added, so a rename would report the whole file's existing
-    backlog.
+  * **By diff line.** A pre-existing ``{'en': ..., 'ja': ...}`` table that a PR
+    turns into a localized one by adding a single ``'zh'`` line never has its own
+    definition line in the diff — the gate would miss the very case it exists
+    for. And renaming a module with no content change marks every line of the
+    new path as added, reporting the whole file's existing backlog.
+  * **By whole key set.** Then adding an unrelated locale (a new ``'fr'``
+    template) to a pre-existing offender reads as a brand-new table, failing a
+    PR that did not grow the backlog.
+  * **By Simplified-key scheme** ('zh' vs 'zh-CN' counted separately). Then
+    migrating a table from ``'zh'`` to ``'zh-CN'`` shows up as one scheme losing
+    a table and the other gaining one, and Counter subtraction only keeps the
+    positive side — so it reports growth that did not happen. issue #2500's own
+    endgame is exactly that rename across all ~339 tables, i.e. this gate would
+    have blocked the migration it exists to serve.
 
-Counting dodges both: a table gaining a Chinese key starts being counted, while
-renaming a file or editing a template's copy changes no count.
+A plain total is invariant under all three: renames, copy edits, added locales,
+and scheme migrations all leave it alone, while a table newly subject to the rule
+raises it.
 
-Counting *whole key sets* was the next wrong turn — then adding an unrelated
-locale (a new 'fr' template) to a pre-existing offender reads as a brand-new
-table and fails a PR that did not grow the backlog. Hence ``rule_signature``,
-which projects a key set down to just the Simplified key the rule keys on.
-
-The tradeoff that remains: a PR removing one offending table while adding
-another under the same scheme nets to zero and passes. That is a deliberate
-accept — the alternative is matching dicts across revisions by position, which
-breaks on every reformat.
+The tradeoff: a PR removing one offending table while adding another nets to zero
+and passes. That is a deliberate accept — the alternative is matching dicts
+across revisions by identity, and every candidate for that identity (position,
+key set, scheme) is what the three wrong turns above already tried.
 
 Usage:
     python scripts/check_prompt_zh_tw.py [--base origin/main]
@@ -67,7 +71,6 @@ import os
 import re
 import subprocess
 import sys
-from collections import Counter
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -116,27 +119,9 @@ def _string_keys(node: ast.AST) -> set[str]:
     return set()
 
 
-def rule_signature(keys: set[str]) -> str:
-    """The part of a key set the rule keys on: which Simplified key is used.
-
-    Deliberately *not* the whole key set. Counting whole key sets makes adding
-    an unrelated locale to a pre-existing offender (say a new ``fr`` template)
-    look like a brand-new table, which fails a PR that did not grow the backlog.
-    Projecting onto the Simplified key keeps the count equal to "how many tables
-    of this scheme still lack zh-TW", which is the quantity the ratchet is
-    about.
-    """
-    for key in SIMPLIFIED_KEYS:
-        if key in keys:
-            return key
-    return ""
-
-
-def find_violations(
-    tree: ast.Module, source_lines: list[str]
-) -> list[tuple[int, str]]:
-    """Return (lineno, rule-signature) for localized dicts with no zh-TW key."""
-    out: list[tuple[int, str]] = []
+def find_violations(tree: ast.Module, source_lines: list[str]) -> list[int]:
+    """Return the line number of every localized dict with no zh-TW key."""
+    out: list[int] = []
     for node in ast.walk(tree):
         keys = _string_keys(node)
         if not keys:
@@ -150,7 +135,7 @@ def find_violations(
         lineno = node.lineno
         if 1 <= lineno <= len(source_lines) and _has_noqa(source_lines[lineno - 1]):
             continue
-        out.append((lineno, rule_signature(keys)))
+        out.append(lineno)
     return out
 
 
@@ -162,31 +147,27 @@ def _parse_source(source: str, origin: str) -> tuple[ast.Module | None, list[str
         return None, []
 
 
-def signature_counter(sources: dict[str, str]) -> Counter[str]:
-    """Count offending key signatures across a {path: source} mapping."""
-    counter: Counter[str] = Counter()
+def count_offenders(sources: dict[str, str]) -> int:
+    """How many localized prompt tables in a {path: source} mapping lack zh-TW."""
+    total = 0
     for path, source in sorted(sources.items()):
         tree, lines = _parse_source(source, path)
         if tree is None:
             continue
-        for _lineno, signature in find_violations(tree, lines):
-            counter[signature] += 1
-    return counter
+        total += len(find_violations(tree, lines))
+    return total
 
 
-def locate(
+def locate_touched(
     sources: dict[str, str],
-    signature: str,
     touched: dict[str, set[int]] | None = None,
 ) -> tuple[list[str], int]:
-    """Locate offending dicts matching `signature`.
+    """Split offending dicts into (touched by this diff, count of the rest).
 
-    Returns (likely, other_count). A dict counts as *likely* when `touched` says
-    the diff added a line inside its body, which is only a presentation hint:
-    the pass/fail decision is the signature comparison, because line spans alone
-    both miss added-key cases and misfire on renames. Common key sets like
-    {en, zh} match dozens of pre-existing tables, so surfacing the touched ones
-    is what makes the failure actionable.
+    Purely for the error message: the pass/fail decision is the count comparison.
+    A total says *that* the backlog grew but not *where*, and 339 pre-existing
+    offenders is far too many to print, so the diff's own lines are what make the
+    failure actionable.
     """
     likely: list[str] = []
     other = 0
@@ -196,12 +177,10 @@ def locate(
             continue
         by_line = {node.lineno: node for node in ast.walk(tree)
                    if _string_keys(node)}
-        for lineno, sig in find_violations(tree, lines):
-            if sig != signature:
-                continue
+        added = (touched or {}).get(path, set())
+        for lineno in find_violations(tree, lines):
             node = by_line.get(lineno)
             span = range(lineno, (getattr(node, "end_lineno", lineno) or lineno) + 1)
-            added = (touched or {}).get(path, set())
             if added and any(ln in added for ln in span):
                 likely.append(f"{path}:{lineno}")
             else:
@@ -215,10 +194,18 @@ def locate(
 
 
 def _git(*args: str) -> str:
+    """Run git and return stdout.
+
+    ``errors="replace"`` is the base-side counterpart to ``_sources_on_disk``
+    tolerating a bad decode: ``git show`` of a non-UTF-8 prompt module would
+    otherwise raise mid-decode. A replaced source then fails ``ast.parse``, which
+    ``_parse_source`` reports and skips — same outcome as the disk side.
+    """
     result = subprocess.run(
         ["git", *args],
         cwd=REPO_ROOT,
-        capture_output=True, text=True, check=False,
+        capture_output=True, check=False,
+        text=True, encoding="utf-8", errors="replace",
     )
     if result.returncode != 0:
         sys.stderr.write(result.stderr)
@@ -272,12 +259,18 @@ def _touched_lines(rev: str) -> dict[str, set[int]]:
 
 
 def _sources_on_disk() -> dict[str, str]:
+    """Read every prompt module off disk, skipping any that cannot be decoded.
+
+    ``UnicodeDecodeError`` is a ``ValueError``, not an ``OSError``, so catching
+    only the latter would let a non-UTF-8 prompt module take the whole gate down
+    with a traceback instead of skipping that one file.
+    """
     sources: dict[str, str] = {}
     for path in sorted(PROMPTS_DIR.rglob("*.py")):
         rel = path.relative_to(REPO_ROOT).as_posix()
         try:
             sources[rel] = path.read_text(encoding="utf-8")
-        except OSError as exc:
+        except (OSError, UnicodeDecodeError) as exc:
             sys.stderr.write(f"{rel}: cannot read ({exc})\n")
     return sources
 
@@ -307,8 +300,8 @@ def main(argv: list[str] | None = None) -> int:
     disk = _sources_on_disk()
 
     if args.count:
-        total = sum(signature_counter(disk).values())
-        print(f"localized prompt dicts missing '{TRADITIONAL_KEY}': {total}")
+        print(f"localized prompt dicts missing '{TRADITIONAL_KEY}': "
+              f"{count_offenders(disk)}")
         return 0
 
     if args.full:
@@ -317,9 +310,8 @@ def main(argv: list[str] | None = None) -> int:
             tree, lines = _parse_source(source, path)
             if tree is None:
                 continue
-            for lineno, signature in find_violations(tree, lines):
-                print(f"{path}:{lineno}: [{CODE}] missing "
-                      f"'{TRADITIONAL_KEY}' (keyed by '{signature}')")
+            for lineno in find_violations(tree, lines):
+                print(f"{path}:{lineno}: [{CODE}] missing '{TRADITIONAL_KEY}'")
                 found += 1
         if found:
             print(f"\n{found} localized prompt dict(s) missing '{TRADITIONAL_KEY}'.")
@@ -327,36 +319,26 @@ def main(argv: list[str] | None = None) -> int:
         return 1 if found else 0
 
     merge_base = _merge_base(args.base)
-    base_counter = signature_counter(_sources_at(merge_base))
-    head_counter = signature_counter(disk)
-
-    added = head_counter - base_counter
-    if not added:
+    grew = count_offenders(disk) - count_offenders(_sources_at(merge_base))
+    if grew <= 0:
         return 0
 
-    touched = _touched_lines(merge_base)
-    total = sum(added.values())
-    for signature, count in sorted(added.items()):
-        likely, other = locate(disk, signature, touched)
-        print(f"[{CODE}] {count} new localized prompt dict(s) keyed by "
-              f"'{signature}' with no '{TRADITIONAL_KEY}'.")
-        if likely:
-            print(f"        in lines this change touched: {', '.join(likely)}")
-        if other:
-            print(f"        ({other} pre-existing table(s) share this key set "
-                  f"and are exempt)")
-        if not likely:
-            print("        no touched table matches — the new table may have "
-                  "moved in from elsewhere; run --full to see every offender")
+    likely, other = locate_touched(disk, _touched_lines(merge_base))
+    print(f"[{CODE}] {grew} more localized prompt dict(s) lack "
+          f"'{TRADITIONAL_KEY}' than at the merge-base.")
+    if likely:
+        print(f"        in lines this change touched: {', '.join(likely)}")
+    else:
+        print("        no touched table is missing it — the new table may have "
+              "moved in from elsewhere; run --full to see every offender")
+    print(f"        ({other} pre-existing offender(s) are exempt)")
     print(
-        f"\n{total} newly added localized prompt dict(s) lack "
-        f"'{TRADITIONAL_KEY}'.\n"
-        "A prompt dict with 'en' + 'zh'/'zh-CN' needs 'zh-TW' too: _loc falls "
+        "\nA prompt dict with 'en' + 'zh'/'zh-CN' needs 'zh-TW' too: _loc falls "
         "back to 'en', not 'zh', so Traditional Chinese users would get an "
         "English prompt. Add the template, or put '# noqa: PROMPT_ZH_TW' on the "
         "dict's opening line if it genuinely does not need one.\n"
-        "The ratchet counts key signatures rather than source lines, so the "
-        "locations above are narrowed to the tables this change touched.\n"
+        "The ratchet compares totals rather than source lines, so the locations "
+        "above are narrowed to the tables this change touched.\n"
         f"(Set $PROMPT_ZH_TW_BASE or pass --base to override the base ref.)"
     )
     return 1

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -61,7 +61,9 @@ Usage:
     python scripts/check_prompt_zh_tw.py --full     # list the whole backlog
     python scripts/check_prompt_zh_tw.py --count    # backlog size only
 
-Escape hatch: put ``# noqa: PROMPT_ZH_TW`` on the dict's opening line.
+Escape hatch: a ``noqa`` comment naming PROMPT_ZH_TW on the dict's opening or
+closing line. It may sit in a comma-separated code list in any order, and a bare
+``noqa`` suppresses everything — same behaviour as the sibling gates and ruff.
 """
 from __future__ import annotations
 
@@ -602,11 +604,16 @@ def _git_visible_prompt_files() -> set[str] | None:
     scan is used unfiltered — ``--count`` and ``--full`` are useful outside a
     checkout, and the ratchet itself already needs git for its base side.
     """
-    result = subprocess.run(
-        ["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard",
-         "--", PROMPTS_SUBDIR],
-        cwd=REPO_ROOT, capture_output=True, check=False,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard",
+             "--", PROMPTS_SUBDIR],
+            cwd=REPO_ROOT, capture_output=True, check=False,
+        )
+    except OSError:
+        # git not on PATH raises FileNotFoundError rather than returning nonzero,
+        # and a missing git is precisely one of the cases this fallback is for.
+        return None
     if result.returncode != 0:
         return None
     out = result.stdout.decode("utf-8", errors="replace")
@@ -659,7 +666,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description=(
             "Require 'zh-TW' on newly added localized prompt dicts "
-            "(signature ratchet against --base; --full scans everything)."
+            "(offender-count ratchet against --base; --full scans everything)."
         )
     )
     parser.add_argument(
@@ -725,7 +732,7 @@ def main(argv: list[str] | None = None) -> int:
         "\nA prompt dict with 'en' + 'zh'/'zh-CN' needs 'zh-TW' too: _loc falls "
         "back to 'en', not 'zh', so Traditional Chinese users would get an "
         "English prompt. Add the template, or put '# noqa: PROMPT_ZH_TW' on the "
-        "dict's opening line if it genuinely does not need one.\n"
+        "dict's opening or closing line if it genuinely does not need one.\n"
         "The ratchet compares totals rather than source lines, so the locations "
         "above are narrowed to the tables this change touched.\n"
         f"(Set $PROMPT_ZH_TW_BASE or pass --base to override the base ref.)"

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -356,8 +356,8 @@ def _merge_operands(node: ast.AST) -> list[ast.AST]:
     return []
 
 
-def _backfilled_table_nodes(tree: ast.AST) -> set[int]:
-    """ids of tables that a later mutation gives ``'zh-TW'`` to.
+def _exempt_table_nodes(tree: ast.AST) -> set[int]:
+    """ids of tables that must not be judged on their own.
 
     Covers the one cross-statement shape worth handling::
 
@@ -408,6 +408,16 @@ def _backfilled_table_nodes(tree: ast.AST) -> set[int]:
         if keys and TRADITIONAL_KEY in keys:
             backfilled.add(target)
 
+    # A name used as a merge operand is a fragment by the same argument as an
+    # inline one: `_FRAGMENT = {"en": .., "zh": ..}` / `T = {**_FRAGMENT, "zh-TW":
+    # ..}` assembles a compliant table, so reporting _FRAGMENT is a false
+    # positive. Costs a blind spot if the same name is also used as a whole table,
+    # which is the direction to err in.
+    for node in ast.walk(tree):
+        for operand in _merge_operands(node):
+            if isinstance(operand, ast.Name):
+                backfilled.add(operand.id)
+
     if not backfilled:
         return set()
     return {
@@ -441,7 +451,7 @@ def _table_nodes(tree: ast.AST) -> Iterator[tuple[ast.AST, set[str]]]:
     unresolvable one is not judged, but traversal continues through it so the
     independent tables it holds are still found.
     """
-    suppressed: set[int] = _backfilled_table_nodes(tree)
+    suppressed: set[int] = _exempt_table_nodes(tree)
     stack: list[ast.AST] = [tree]
     while stack:
         node = stack.pop()
@@ -506,22 +516,47 @@ def find_violations(tree: ast.Module, source_lines: list[str]) -> list[int]:
     return [lineno for _node, lineno, _end in _offending_nodes(tree, source_lines)]
 
 
+def _comment_lines(source: str) -> list[str]:
+    """Per-line comment text, indexed like the source's own lines.
+
+    Suppression must be read from comments only. A ``# noqa: PROMPT_ZH_TW``
+    appearing *inside* a string literal is template text, not a directive — and a
+    multiline template whose first line ends with that text would otherwise exempt
+    its own table.
+
+    Line splitting is `re.split` rather than ``str.splitlines()``: the latter also
+    breaks on \\x0b \\x0c \\x1c \\x1d \\x1e \\x85 U+2028 U+2029, none of which
+    CPython counts as a newline, so one inside a literal shifts every later line
+    and a noqa starts matching a neighbour. ``split("\\n")`` is wrong the other
+    way, collapsing a lone-CR file into one line.
+
+    On a tokenize failure every line comes back empty — no suppression rather than
+    wrong suppression, and ``ast.parse`` will have reported the syntax error.
+    """
+    blank = [""] * len(re.split(r"\r\n|\r|\n", source))
+    try:
+        for token in tokenize.generate_tokens(io.StringIO(source).readline):
+            if token.type == tokenize.COMMENT:
+                row = token.start[0]
+                if 1 <= row <= len(blank):
+                    blank[row - 1] += token.string
+    except (tokenize.TokenError, IndentationError, SyntaxError):
+        return [""] * len(blank)
+    return blank
+
+
 def _parse_source(source: str, origin: str) -> tuple[ast.Module | None, list[str]]:
-    """Parse source and split it into lines that line up with AST line numbers.
+    """Parse source, returning the tree and each line's comment text.
 
-    Not ``str.splitlines()``: it also breaks on \\x0b \\x0c \\x1c \\x1d \\x1e
-    \\x85 U+2028 U+2029, none of which CPython treats as a line break. One of
-    those inside a string literal shifts every later line by one, so a noqa stops
-    matching its own table and starts matching a neighbour.
-
-    Not ``split("\\n")`` either — that collapses a lone-CR file into a single
-    line, which breaks noqa lookup wholesale.
+    The second element feeds noqa lookup only, so it carries comments rather than
+    raw lines — see ``_comment_lines``.
     """
     try:
-        return ast.parse(source), re.split(r"\r\n|\r|\n", source)
+        tree = ast.parse(source)
     except SyntaxError as exc:
         sys.stderr.write(f"{origin}: syntax error ({exc})\n")
         return None, []
+    return tree, _comment_lines(source)
 
 
 def count_offenders(sources: dict[str, str]) -> int:

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -101,7 +101,7 @@ import subprocess
 import sys
 import tokenize
 from pathlib import Path
-from typing import Iterator
+from typing import Callable, Iterator
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PROMPTS_SUBDIR = "config/prompts"
@@ -356,7 +356,9 @@ def _merge_operands(node: ast.AST) -> list[ast.AST]:
     return []
 
 
-def _directly_visible_keys(node: ast.AST) -> set[str]:
+def _directly_visible_keys(
+    node: ast.AST, resolve_name: Callable[[str], set[str]] | None = None
+) -> set[str]:
     """Keys an expression states itself, ignoring what it merges in by name.
 
     Answers "does this construction demonstrably supply zh-TW?" — the condition for
@@ -375,7 +377,7 @@ def _directly_visible_keys(node: ast.AST) -> set[str]:
         }
         for key, value in zip(node.keys, node.values):
             if key is None:
-                keys |= _directly_visible_keys(value)
+                keys |= _directly_visible_keys(value, resolve_name)
         return keys
     if (
         isinstance(node, ast.Call)
@@ -385,15 +387,17 @@ def _directly_visible_keys(node: ast.AST) -> set[str]:
         keys = {kw.arg for kw in node.keywords if kw.arg is not None}
         for kw in node.keywords:
             if kw.arg is None:
-                keys |= _directly_visible_keys(kw.value)
+                keys |= _directly_visible_keys(kw.value, resolve_name)
         for arg in node.args:
-            keys |= _directly_visible_keys(arg)
+            keys |= _directly_visible_keys(arg, resolve_name)
             pairs = _pair_sequence_keys(arg)
             if pairs:
                 keys |= pairs
         return keys
     if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
-        return _directly_visible_keys(node.left) | _directly_visible_keys(node.right)
+        return _directly_visible_keys(node.left, resolve_name) | _directly_visible_keys(node.right, resolve_name)
+    if isinstance(node, ast.Name) and resolve_name is not None:
+        return resolve_name(node.id)
     if isinstance(node, ast.Call) and _is_dict_fromkeys(node.func) and node.args:
         # `_F | dict.fromkeys(("zh-TW",), t)` — resolve_keys handles this
         # constructor, so the visibility scan has to as well or the union looks
@@ -440,7 +444,7 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
             for target in node.targets:
                 if isinstance(target, ast.Name):
                     assignments.setdefault(target.id, []).append(
-                        (node.lineno, id(node.value))
+                        (node.lineno, node.value)
                     )
             continue
         if (
@@ -454,16 +458,36 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
             name = node.target.id
         if name is None:
             continue
-        assignments.setdefault(name, []).append((node.lineno, id(node.value)))
+        assignments.setdefault(name, []).append((node.lineno, node.value))
     for bindings in assignments.values():
-        bindings.sort()
+        bindings.sort(key=lambda item: item[0])
 
     exempt: set[int] = set()
 
-    def _exempt_binding_before(name: str, lineno: int) -> None:
-        prior = [vid for ln, vid in assignments.get(name, []) if ln <= lineno]
-        if prior:
-            exempt.add(prior[-1])
+    def _binding_before(
+        name: str, lineno: int, exclude: ast.AST | None = None
+    ) -> ast.AST | None:
+        """The value bound to `name` most recently at or before `lineno`.
+
+        ``exclude`` skips one candidate: for a self-rebinding merge like
+        ``T = T | {...}`` the new assignment registers on the same line as the
+        merge, so an inclusive line search would pick the merge's own result
+        instead of the binding its right-hand side actually reads.
+        """
+        for ln, value in reversed(assignments.get(name, [])):
+            if ln > lineno:
+                continue
+            if exclude is not None and value is exclude:
+                continue
+            return value
+        return None
+
+    def _exempt_binding_before(
+        name: str, lineno: int, exclude: ast.AST | None = None
+    ) -> None:
+        value = _binding_before(name, lineno, exclude)
+        if value is not None:
+            exempt.add(id(value))
 
     for node in ast.walk(tree):
         if (
@@ -481,11 +505,27 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
         if (
             isinstance(node, ast.Call)
             and isinstance(node.func, ast.Attribute)
-            and node.func.attr == "update"
+            and node.func.attr in ("update", "setdefault")
             and isinstance(node.func.value, ast.Name)
-            and node.args
         ):
-            target, payload = node.func.value.id, node.args[0]
+            target = node.func.value.id
+            if node.func.attr == "setdefault":
+                # `T.setdefault("zh-TW", tpl)` names the key directly.
+                first = node.args[0] if node.args else None
+                if (
+                    isinstance(first, ast.Constant)
+                    and first.value == TRADITIONAL_KEY
+                ):
+                    _exempt_binding_before(target, node.lineno)
+                continue
+            if node.args:
+                payload = node.args[0]
+            else:
+                # `T.update(**{"zh-TW": t})` — the spread carries the mapping.
+                # Named keywords are deliberately not consulted: 'zh-TW' is not a
+                # valid identifier, so it can never arrive as `update(zh-TW=...)`.
+                spread = [kw.value for kw in node.keywords if kw.arg is None]
+                payload = spread[0] if spread else None
         elif (
             isinstance(node, ast.AugAssign)
             and isinstance(node.op, ast.BitOr)
@@ -515,11 +555,22 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
         operands = _merge_operands(node)
         if not operands:
             continue
-        if TRADITIONAL_KEY not in _directly_visible_keys(node):
+
+        def _named_keys(name: str, _at: int = node.lineno, _self: ast.AST = node) -> set[str]:
+            """Keys of a name's preceding binding, so a named supplier counts.
+
+            `_TW = {"zh-TW": t}` / `T = {**_F, **_TW}` supplies zh-TW as plainly as
+            an inline literal. Following the name only ever *adds* visible keys, so
+            `U = dict(T)` still sees {en, zh} and leaves T subject to the rule.
+            """
+            bound = _binding_before(name, _at, exclude=_self)
+            return (resolve_keys(bound) or set()) if bound is not None else set()
+
+        if TRADITIONAL_KEY not in _directly_visible_keys(node, _named_keys):
             continue
         for operand in operands:
             if isinstance(operand, ast.Name):
-                _exempt_binding_before(operand.id, node.lineno)
+                _exempt_binding_before(operand.id, node.lineno, exclude=node)
 
     return exempt
 

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -356,6 +356,47 @@ def _merge_operands(node: ast.AST) -> list[ast.AST]:
     return []
 
 
+def _directly_visible_keys(node: ast.AST) -> set[str]:
+    """Keys an expression states itself, ignoring what it merges in by name.
+
+    Answers "does this construction demonstrably supply zh-TW?" — the condition for
+    treating its named inputs as fragments. ``{**T, "zh-TW": ...}`` does;
+    ``dict(T)`` and ``{**T, "ja": ...}`` do not, and their T stays subject to the
+    rule.
+
+    Unlike ``resolve_keys`` this never gives up: an unknowable part contributes
+    nothing instead of poisoning the whole result.
+    """
+    if isinstance(node, ast.Dict):
+        keys = {
+            key.value
+            for key in node.keys
+            if isinstance(key, ast.Constant) and isinstance(key.value, str)
+        }
+        for key, value in zip(node.keys, node.values):
+            if key is None:
+                keys |= _directly_visible_keys(value)
+        return keys
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "dict"
+    ):
+        keys = {kw.arg for kw in node.keywords if kw.arg is not None}
+        for kw in node.keywords:
+            if kw.arg is None:
+                keys |= _directly_visible_keys(kw.value)
+        for arg in node.args:
+            keys |= _directly_visible_keys(arg)
+            pairs = _pair_sequence_keys(arg)
+            if pairs:
+                keys |= pairs
+        return keys
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        return _directly_visible_keys(node.left) | _directly_visible_keys(node.right)
+    return set()
+
+
 def _exempt_table_nodes(tree: ast.AST) -> set[int]:
     """ids of tables that must not be judged on their own.
 
@@ -454,11 +495,21 @@ def _exempt_table_nodes(tree: ast.AST) -> set[int]:
         if keys and TRADITIONAL_KEY in keys:
             _exempt_binding_before(target, node.lineno)
 
-    # A name used as a merge operand is a fragment by the same argument as an
-    # inline one: `_FRAGMENT = {"en": .., "zh": ..}` / `T = {**_FRAGMENT, "zh-TW":
-    # ..}` assembles a compliant table, so reporting _FRAGMENT is a false positive.
+    # A name merged into a construction that *demonstrably supplies zh-TW* is a
+    # fragment of a compliant table: `_F = {"en": .., "zh": ..}` /
+    # `T = {**_F, "zh-TW": ..}` — reporting _F there is a false positive.
+    #
+    # The zh-TW condition is what keeps this from becoming a blind spot. Exempting
+    # every named operand meant `U = dict(T)` excused T, so an offender plus a copy
+    # of it counted as zero: T exempt as an "operand", U unresolvable because
+    # resolve_keys does not follow names.
     for node in ast.walk(tree):
-        for operand in _merge_operands(node):
+        operands = _merge_operands(node)
+        if not operands:
+            continue
+        if TRADITIONAL_KEY not in _directly_visible_keys(node):
+            continue
+        for operand in operands:
             if isinstance(operand, ast.Name):
                 _exempt_binding_before(operand.id, node.lineno)
 

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -25,10 +25,9 @@ gate only stops the hole from growing.
 
 How the ratchet works
 =====================
-It compares the **multiset of key signatures** of offending dicts between the
-merge-base and HEAD, rather than asking which source lines the diff touched.
-A dict contributes ``frozenset(its string keys)``; HEAD needing more copies of
-some signature than the base had is what fails the check.
+It counts offending dicts per Simplified-key scheme ('zh' vs 'zh-CN') at the
+merge-base and at HEAD; HEAD having more of either than the base is what fails
+the check. Source lines are not consulted for the decision.
 
 Line-based ratcheting was tried first and is wrong in both directions:
 
@@ -40,13 +39,17 @@ Line-based ratcheting was tried first and is wrong in both directions:
     path count as added, so a rename would report the whole file's existing
     backlog.
 
-Signatures dodge both: adding a Chinese key changes a dict's signature (and so
-increments a count), while renaming a file or editing a template's copy leaves
-every signature untouched.
+Counting dodges both: a table gaining a Chinese key starts being counted, while
+renaming a file or editing a template's copy changes no count.
 
-The tradeoff is that a PR which removes one offending table and adds another
-with the identical key set nets to zero and passes. That is a deliberate
-accept: the alternative is matching dicts across revisions by position, which
+Counting *whole key sets* was the next wrong turn — then adding an unrelated
+locale (a new 'fr' template) to a pre-existing offender reads as a brand-new
+table and fails a PR that did not grow the backlog. Hence ``rule_signature``,
+which projects a key set down to just the Simplified key the rule keys on.
+
+The tradeoff that remains: a PR removing one offending table while adding
+another under the same scheme nets to zero and passes. That is a deliberate
+accept — the alternative is matching dicts across revisions by position, which
 breaks on every reformat.
 
 Usage:
@@ -82,23 +85,62 @@ def _has_noqa(line: str) -> bool:
     return bool(re.search(rf"#\s*noqa:\s*{CODE}\b", line))
 
 
-def _string_keys(node: ast.Dict) -> set[str]:
-    return {
-        k.value
-        for k in node.keys
-        if isinstance(k, ast.Constant) and isinstance(k.value, str)
-    }
+def _string_keys(node: ast.AST) -> set[str]:
+    """String keys of a dict literal, or of a ``dict(en=..., zh=...)`` call.
+
+    The call form cannot express ``zh-CN`` or ``zh-TW`` as keywords (neither is
+    an identifier), but it can express ``zh``, so a table written that way is
+    still subject to the rule.
+
+    Returns empty — i.e. "not a table I can judge" — for a call carrying ``**``,
+    since the unpacked mapping is exactly where such a table would have to put
+    its ``'zh-TW'`` entry. Reporting it would be a false positive, and a gate
+    that cries wolf gets worked around rather than satisfied.
+    """
+    if isinstance(node, ast.Dict):
+        if any(k is None for k in node.keys):
+            return set()  # `{**other}` — same unknowable-keys problem
+        return {
+            k.value
+            for k in node.keys
+            if isinstance(k, ast.Constant) and isinstance(k.value, str)
+        }
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "dict"
+    ):
+        if any(kw.arg is None for kw in node.keywords):
+            return set()
+        return {kw.arg for kw in node.keywords if kw.arg is not None}
+    return set()
+
+
+def rule_signature(keys: set[str]) -> str:
+    """The part of a key set the rule keys on: which Simplified key is used.
+
+    Deliberately *not* the whole key set. Counting whole key sets makes adding
+    an unrelated locale to a pre-existing offender (say a new ``fr`` template)
+    look like a brand-new table, which fails a PR that did not grow the backlog.
+    Projecting onto the Simplified key keeps the count equal to "how many tables
+    of this scheme still lack zh-TW", which is the quantity the ratchet is
+    about.
+    """
+    for key in SIMPLIFIED_KEYS:
+        if key in keys:
+            return key
+    return ""
 
 
 def find_violations(
     tree: ast.Module, source_lines: list[str]
-) -> list[tuple[int, frozenset[str]]]:
-    """Return (lineno, key-signature) for localized dicts with no zh-TW key."""
-    out: list[tuple[int, frozenset[str]]] = []
+) -> list[tuple[int, str]]:
+    """Return (lineno, rule-signature) for localized dicts with no zh-TW key."""
+    out: list[tuple[int, str]] = []
     for node in ast.walk(tree):
-        if not isinstance(node, ast.Dict):
-            continue
         keys = _string_keys(node)
+        if not keys:
+            continue
         if ANCHOR_KEY not in keys:
             continue
         if not any(k in keys for k in SIMPLIFIED_KEYS):
@@ -108,7 +150,7 @@ def find_violations(
         lineno = node.lineno
         if 1 <= lineno <= len(source_lines) and _has_noqa(source_lines[lineno - 1]):
             continue
-        out.append((lineno, frozenset(keys)))
+        out.append((lineno, rule_signature(keys)))
     return out
 
 
@@ -120,9 +162,9 @@ def _parse_source(source: str, origin: str) -> tuple[ast.Module | None, list[str
         return None, []
 
 
-def signature_counter(sources: dict[str, str]) -> Counter[frozenset[str]]:
+def signature_counter(sources: dict[str, str]) -> Counter[str]:
     """Count offending key signatures across a {path: source} mapping."""
-    counter: Counter[frozenset[str]] = Counter()
+    counter: Counter[str] = Counter()
     for path, source in sorted(sources.items()):
         tree, lines = _parse_source(source, path)
         if tree is None:
@@ -134,7 +176,7 @@ def signature_counter(sources: dict[str, str]) -> Counter[frozenset[str]]:
 
 def locate(
     sources: dict[str, str],
-    signature: frozenset[str],
+    signature: str,
     touched: dict[str, set[int]] | None = None,
 ) -> tuple[list[str], int]:
     """Locate offending dicts matching `signature`.
@@ -153,7 +195,7 @@ def locate(
         if tree is None:
             continue
         by_line = {node.lineno: node for node in ast.walk(tree)
-                   if isinstance(node, ast.Dict)}
+                   if _string_keys(node)}
         for lineno, sig in find_violations(tree, lines):
             if sig != signature:
                 continue
@@ -190,11 +232,13 @@ def _merge_base(base: str) -> str:
 
 def _prompt_files_at(rev: str) -> list[str]:
     """Prompt modules present at `rev`, including any in subpackages."""
-    out = _git("ls-tree", "-r", "--name-only", rev, "--", PROMPTS_SUBDIR)
+    # -z: NUL-separated and unquoted. Without it git wraps non-ASCII paths in
+    # quotes and octal-escapes the bytes, which would not resolve as a path.
+    out = _git("ls-tree", "-r", "-z", "--name-only", rev, "--", PROMPTS_SUBDIR)
     return [
-        ln.strip().replace("\\", "/")
-        for ln in out.splitlines()
-        if ln.strip().endswith(".py")
+        entry.replace("\\", "/")
+        for entry in out.split("\0")
+        if entry.endswith(".py")
     ]
 
 
@@ -274,9 +318,8 @@ def main(argv: list[str] | None = None) -> int:
             if tree is None:
                 continue
             for lineno, signature in find_violations(tree, lines):
-                present = ", ".join(sorted(k for k in signature if len(k) <= 6))
                 print(f"{path}:{lineno}: [{CODE}] missing "
-                      f"'{TRADITIONAL_KEY}' (has: {present})")
+                      f"'{TRADITIONAL_KEY}' (keyed by '{signature}')")
                 found += 1
         if found:
             print(f"\n{found} localized prompt dict(s) missing '{TRADITIONAL_KEY}'.")
@@ -293,11 +336,10 @@ def main(argv: list[str] | None = None) -> int:
 
     touched = _touched_lines(merge_base)
     total = sum(added.values())
-    for signature, count in sorted(added.items(), key=lambda kv: sorted(kv[0])):
-        present = ", ".join(sorted(k for k in signature if len(k) <= 6))
+    for signature, count in sorted(added.items()):
         likely, other = locate(disk, signature, touched)
-        print(f"[{CODE}] {count} new localized prompt dict(s) with keys "
-              f"({present}) and no '{TRADITIONAL_KEY}'.")
+        print(f"[{CODE}] {count} new localized prompt dict(s) keyed by "
+              f"'{signature}' with no '{TRADITIONAL_KEY}'.")
         if likely:
             print(f"        in lines this change touched: {', '.join(likely)}")
         if other:

--- a/scripts/check_prompt_zh_tw.py
+++ b/scripts/check_prompt_zh_tw.py
@@ -74,6 +74,7 @@ import subprocess
 import sys
 import tokenize
 from pathlib import Path
+from typing import Iterator
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PROMPTS_SUBDIR = "config/prompts"
@@ -123,10 +124,51 @@ def _string_keys(node: ast.AST) -> set[str]:
     return set()
 
 
+def _is_merged_construction(node: ast.AST) -> bool:
+    """Whether this node assembles a mapping out of other mappings.
+
+    ``{**a, **b}``, ``dict(BASE, zh=...)`` and ``a | b`` all have keys that are
+    not statically knowable, and their component literals are *fragments* rather
+    than tables: the ``'zh-TW'`` entry may live in any one of them.
+    """
+    if isinstance(node, ast.Dict):
+        return any(k is None for k in node.keys)
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "dict"
+    ):
+        return bool(node.args) or any(kw.arg is None for kw in node.keywords)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        return True
+    return False
+
+
+def _table_nodes(tree: ast.AST) -> Iterator[ast.AST]:
+    """Yield dict-shaped nodes, pruning the innards of merged constructions.
+
+    Skipping a merged construction is not enough — ``ast.walk`` would still
+    descend into it and judge each component literal on its own, reporting the
+    fragment that happens to lack ``'zh-TW'`` even though the assembled mapping
+    carries it. So a merged construction is skipped *with its descendants*.
+
+    Ordinary nesting (``{"greeting": {"en": ..., "zh": ...}}``) is not merging:
+    the inner dict is a table in its own right and is still yielded.
+    """
+    stack: list[ast.AST] = [tree]
+    while stack:
+        node = stack.pop()
+        if _is_merged_construction(node):
+            continue
+        if isinstance(node, (ast.Dict, ast.Call)):
+            yield node
+        stack.extend(ast.iter_child_nodes(node))
+
+
 def find_violations(tree: ast.Module, source_lines: list[str]) -> list[int]:
     """Return the line number of every localized dict with no zh-TW key."""
     out: list[int] = []
-    for node in ast.walk(tree):
+    for node in _table_nodes(tree):
         keys = _string_keys(node)
         if not keys:
             continue
@@ -140,7 +182,8 @@ def find_violations(tree: ast.Module, source_lines: list[str]) -> list[int]:
         if 1 <= lineno <= len(source_lines) and _has_noqa(source_lines[lineno - 1]):
             continue
         out.append(lineno)
-    return out
+    # _table_nodes walks depth-first off a stack, so restore source order.
+    return sorted(out)
 
 
 def _parse_source(source: str, origin: str) -> tuple[ast.Module | None, list[str]]:
@@ -179,7 +222,7 @@ def locate_touched(
         tree, lines = _parse_source(source, path)
         if tree is None:
             continue
-        by_line = {node.lineno: node for node in ast.walk(tree)
+        by_line = {node.lineno: node for node in _table_nodes(tree)
                    if _string_keys(node)}
         added = (touched or {}).get(path, set())
         for lineno in find_violations(tree, lines):
@@ -291,7 +334,15 @@ def _touched_lines(rev: str) -> dict[str, set[int]]:
             continue
         start = int(match.group(1))
         count = int(match.group(2)) if match.group(2) is not None else 1
-        touched.setdefault(current, set()).update(range(start, start + count))
+        if count == 0:
+            # Deletion-only hunk (`@@ -4 +3,0 @@`): nothing was added, so a plain
+            # range() is empty and a table that just *lost* its 'zh-TW' entry —
+            # a real way for the total to grow — would have no location at all.
+            # Record the lines flanking the deletion point so the enclosing table
+            # is still recognisable.
+            touched.setdefault(current, set()).update({max(1, start), start + 1})
+        else:
+            touched.setdefault(current, set()).update(range(start, start + count))
     return touched
 
 

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -2284,3 +2284,77 @@ def test_documented_blind_spots_around_aliased_mutation(src):
     `update()`, which is None — code that cannot be doing what it looks like.
     """
     assert _violations(src) == []
+
+
+@pytest.mark.parametrize("src,expected", [
+    ('TW = {"zh-TW": "t"}\nTW.clear()\nT = {"en": "e", "zh": "s"}\nT.update(TW)', [3]),
+    ('T = {"en": "e", "zh": "s"}\nT["zh-TW"] = "t"\nT.clear()', [1]),
+    # emptied and then filled again
+    ('TW = {"zh-TW": "t"}\nTW.clear()\nTW["zh-TW"] = "t"\n'
+     + 'T = {"en": "e", "zh": "s"}\nT.update(TW)', []),
+])
+def test_clear_empties_the_timeline(src, expected):
+    """`clear()` removes everything, so it cannot be recorded as a key list.
+
+    It joins `del` and `pop` as a removal — the third spelling of the same thing,
+    and the third one this gate had to be told about separately.
+    """
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == expected
+
+
+@pytest.mark.parametrize("src,expected", [
+    ('TW = {"zh-TW": "t"}\nT = {"en": "e", "zh": "s"}\nT.update(TW.items())', []),
+    ('TW = {"zh-TW": "t"}\nT = {"en": "e", "zh": "s"}\nT.update(TW.copy())', []),
+    ('TW = {"ja": "j"}\nT = {"en": "e", "zh": "s"}\nT.update(TW.items())', [2]),
+])
+def test_a_payload_may_be_a_view_of_a_known_mapping(src, expected):
+    """`update(other.items())` is ordinary Python and hands over exactly those keys."""
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == expected
+
+
+@pytest.mark.parametrize("src", [
+    # two unrelated scopes sharing a name
+    'def a():\n    T = {"en": "e", "zh": "s"}\n\n\ndef b():\n    T["zh-TW"] = "t"',
+    # a backfill inside a function that is never called
+    'T = {"en": "e", "zh": "s"}\n\n\ndef never_called():\n    T["zh-TW"] = "t"',
+])
+def test_documented_blind_spots_around_scope_and_reachability(src):
+    """Pinned so a change here is deliberate — see the module docstring.
+
+    All three need scope or reachability analysis, which this gate states it does
+    not do: prompt modules are tables evaluated at import, not call graphs.
+    """
+    assert _violations(src) == []
+
+
+@pytest.mark.parametrize("src,expected", [
+    ('for T in ({"en": "e", "zh": "s"},):\n    T["zh-TW"] = "t"', []),
+    ('for T in [{"en": "e", "zh": "s"}, {"en": "e2", "zh": "s2"}]:\n    T["zh-TW"] = "t"', []),
+    # not a literal iterable: nothing is knowable, so nothing is bound
+    ('for T in tables():\n    T["zh-TW"] = "t"\nU = {"en": "e", "zh": "s"}', [3]),
+])
+def test_a_loop_over_a_literal_binds_its_target(src, expected):
+    """Every element of a literal iterable is a binding of the loop target.
+
+    The same pairing as unpacking, which is where the helper comes from.
+    """
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == expected
+
+
+def test_loop_alternatives_are_only_closed_over_when_one_is_exempt():
+    """Grouping says "a backfill completes them all", not "they are all fine".
+
+    Without a backfill in the body every element is still its own offender.
+    """
+    src = (
+        "for T in [\n"
+        '    {"en": "e", "zh": "s"},\n'
+        '    {"en": "e2", "zh": "s2"},\n'
+        "]:\n"
+        "    pass"
+    )
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == [2, 3]

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -74,7 +74,7 @@ def test_flags_en_plus_short_zh_without_traditional():
     out = _violations(src)
     assert len(out) == 1
     assert out[0][0] == 2
-    assert out[0][1] == frozenset({"zh", "en"})
+    assert out[0][1] == "zh"
 
 
 def test_flags_en_plus_full_zh_cn_without_traditional():
@@ -130,6 +130,27 @@ def test_ignores_non_string_keys():
     assert _violations(src) == []
 
 
+def test_flags_dict_constructor_call():
+    """`dict(en=..., zh=...)` has the same runtime shape and the same problem."""
+    out = _violations('TABLE = dict(en="english", zh="简体")')
+    assert len(out) == 1
+    assert out[0][1] == "zh"
+
+
+def test_ignores_dict_constructor_with_unpacking():
+    """`**` is where such a table would have to put 'zh-TW', so judging is unsafe.
+
+    `dict()` cannot name zh-TW as a keyword (not an identifier), so unpacking is
+    the only way to write one — reporting it would be a false positive, and a
+    gate that cries wolf gets worked around instead of satisfied.
+    """
+    assert _violations('T = dict(en="e", zh="s", **{"zh-TW": "t"})') == []
+
+
+def test_ignores_dict_literal_with_unpacking():
+    assert _violations('T = {"en": "e", "zh": "s", **OTHER_TABLE}') == []
+
+
 def test_flags_nested_and_multiple_tables():
     """Nested dicts are walked, and each offending table is reported once."""
     src = '''
@@ -170,7 +191,30 @@ def test_ratchet_flags_table_that_becomes_localized_via_added_key():
     head = {"a.py": 'T = {"en": "x", "ja": "y", "zh": "z"}'}
     added = _added(base, head)
     assert sum(added.values()) == 1
-    assert frozenset({"en", "ja", "zh"}) in added
+    assert "zh" in added
+
+
+def test_ratchet_ignores_adding_an_unrelated_locale():
+    """Adding a 'fr' template to a pre-existing offender did not grow the backlog.
+
+    This is why the signature is the Simplified key rather than the whole key
+    set: counting whole sets made {en, zh} -> {en, zh, fr} look like a new table
+    and failed PRs that only added a language.
+    """
+    base = {"a.py": 'T = {"en": "x", "zh": "y"}'}
+    head = {"a.py": 'T = {"en": "x", "zh": "y", "fr": "z"}'}
+    assert not _added(base, head)
+
+
+def test_ratchet_keeps_the_two_key_schemes_separate():
+    """A new zh-CN-scheme table is not offset by an existing zh-scheme one."""
+    base = {"a.py": 'A = {"en": "x", "zh": "y"}'}
+    head = {
+        "a.py": 'A = {"en": "x", "zh": "y"}',
+        "b.py": 'B = {"en": "p", "zh-CN": "q"}',
+    }
+    added = _added(base, head)
+    assert dict(added) == {"zh-CN": 1}
 
 
 def test_ratchet_ignores_a_pure_rename():
@@ -211,7 +255,7 @@ def test_ratchet_counts_multiplicity_not_just_presence():
     }
     added = _added(base, head)
     assert sum(added.values()) == 2
-    assert added[frozenset({"en", "zh"})] == 2
+    assert added["zh"] == 2
 
 
 def test_ratchet_documented_blind_spot_nets_to_zero():
@@ -236,7 +280,7 @@ _TWO_TABLES = {
     "new.py": 'NEW = {\n    "en": "a",\n    "zh": "b",\n}',
     "old.py": 'OLD = {\n    "en": "c",\n    "zh": "d",\n}',
 }
-_EN_ZH = frozenset({"en", "zh"})
+_EN_ZH = "zh"
 
 
 def test_locate_narrows_to_tables_the_diff_touched():
@@ -378,6 +422,25 @@ def test_main_passes_on_an_unchanged_tree(monkeypatch):
     assert MOD.main(["--base", "irrelevant"]) == 0
 
 
+def test_prompt_files_at_reads_nul_separated_paths(monkeypatch):
+    """`-z` output is NUL-separated and unquoted.
+
+    Without it git quotes non-ASCII paths and octal-escapes their bytes
+    (`"config/prompts/\\344\\270\\255.py"`), which would not resolve as a path.
+    This repo already carries such paths under tests/testbench.
+    """
+    captured: list[tuple[str, ...]] = []
+
+    def fake_git(*args: str) -> str:
+        captured.append(args)
+        return "config/prompts/a.py\0config/prompts/中文.py\0config/prompts/notes.txt\0"
+
+    monkeypatch.setattr(MOD, "_git", fake_git)
+    files = MOD._prompt_files_at("REV")
+    assert files == ["config/prompts/a.py", "config/prompts/中文.py"]
+    assert "-z" in captured[0], captured[0]
+
+
 def test_touched_lines_asks_git_for_rename_detection(monkeypatch):
     """`-M` is load-bearing: without it a rename marks every line as added.
 
@@ -414,19 +477,19 @@ def test_cli_against_head_is_clean():
     assert result.returncode == 0, result.stdout + result.stderr
 
 
-def test_cli_count_reports_backlog_and_exits_zero():
+def test_cli_count_reports_a_nonempty_backlog():
+    """--count exits 0 and reports a real number.
+
+    The non-zero assertion guards the scanner itself: the issue #2500 backlog is
+    large, so a zero means detection silently broke, not that the work finished.
+    When the backfill genuinely lands, replace this with the full-scan gate.
+
+    Deliberately one subprocess, not two: --count re-parses every prompt module
+    (prompts_proactive.py alone is ~5k lines) and the Windows CI runner shares
+    this suite with thread-timing tests on one-second budgets.
+    """
     result = _run("--count")
     assert result.returncode == 0, result.stdout + result.stderr
     assert "missing 'zh-TW'" in result.stdout
-
-
-def test_repo_backlog_is_nonempty():
-    """Guards the scanner itself: if this hits 0, detection silently broke.
-
-    The issue #2500 backlog is large. A zero here means the detector stopped
-    matching, not that the work finished — when the backfill genuinely lands,
-    replace this with the full-scan gate.
-    """
-    result = _run("--count")
     count = int(result.stdout.strip().rsplit(":", 1)[1])
     assert count > 0, "scanner found nothing; detection likely broke"

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -1,0 +1,265 @@
+# -*- coding: utf-8 -*-
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``scripts/check_prompt_zh_tw.py``.
+
+Synthetic-source coverage of ``find_violations`` (the diff-aware core): which
+dict shapes count as a localized prompt table, the ratchet on the dict's own
+definition line, and noqa suppression. The git plumbing is exercised through
+``--base HEAD`` (empty diff -> exit 0) so CI smoke-tests the CLI path without
+depending on branch state.
+"""
+from __future__ import annotations
+
+import ast
+import importlib.util
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = PROJECT_ROOT / "scripts" / "check_prompt_zh_tw.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location("check_prompt_zh_tw", SCRIPT_PATH)
+    assert spec and spec.loader, f"failed to load spec for {SCRIPT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MOD = _load_script_module()
+
+
+def _violations(source: str, changed_lines: set[int] | None = None):
+    source = textwrap.dedent(source)
+    tree = ast.parse(source)
+    return MOD.find_violations(tree, source.splitlines(), changed_lines)
+
+
+# ---------------------------------------------------------------------------
+# What counts as a localized prompt table
+# ---------------------------------------------------------------------------
+
+
+def test_flags_en_plus_short_zh_without_traditional():
+    src = '''
+    TABLE = {
+        "zh": "简体",
+        "en": "english",
+    }
+    '''
+    out = _violations(src)
+    assert len(out) == 1
+    assert out[0][0] == 2
+
+
+def test_flags_en_plus_full_zh_cn_without_traditional():
+    """The full-locale scheme (zh-CN keys) is covered too, not just short zh."""
+    src = '''
+    TABLE = {
+        "zh-CN": "简体",
+        "en": "english",
+    }
+    '''
+    assert len(_violations(src)) == 1
+
+
+def test_accepts_table_with_traditional():
+    src = '''
+    TABLE = {
+        "zh": "简体",
+        "zh-TW": "繁體",
+        "en": "english",
+    }
+    '''
+    assert _violations(src) == []
+
+
+def test_ignores_dict_without_en_anchor():
+    """Without an 'en' key it is not a localized prompt table."""
+    src = '''
+    NOT_A_TABLE = {
+        "zh": "简体",
+        "ja": "日本語",
+    }
+    '''
+    assert _violations(src) == []
+
+
+def test_ignores_dict_without_any_chinese_key():
+    src = '''
+    NOT_A_TABLE = {
+        "en": "english",
+        "ja": "japanese",
+    }
+    '''
+    assert _violations(src) == []
+
+
+def test_ignores_non_string_keys():
+    src = '''
+    LOOKUP = {
+        1: "one",
+        2: "two",
+    }
+    '''
+    assert _violations(src) == []
+
+
+def test_flags_nested_and_multiple_tables():
+    """Nested dicts are walked, and each offending table is reported once."""
+    src = '''
+    OUTER = {
+        "greeting": {
+            "zh": "你好",
+            "en": "hello",
+        },
+        "farewell": {
+            "zh": "再见",
+            "en": "bye",
+        },
+    }
+    '''
+    out = _violations(src)
+    assert len(out) == 2, out
+    assert [lineno for lineno, _ in out] == [3, 7]
+
+
+def test_reports_present_keys_in_message():
+    src = '''
+    TABLE = {"zh": "a", "en": "b", "ja": "c"}
+    '''
+    out = _violations(src)
+    assert out[0][1] == "en, ja, zh"
+
+
+# ---------------------------------------------------------------------------
+# The ratchet
+# ---------------------------------------------------------------------------
+
+
+def test_ratchet_reports_dict_whose_definition_line_changed():
+    src = '''
+    TABLE = {
+        "zh": "简体",
+        "en": "english",
+    }
+    '''
+    assert len(_violations(src, changed_lines={2})) == 1
+
+
+def test_ratchet_exempts_dict_whose_definition_line_is_untouched():
+    """Editing a table's copy must not trip the gate — only new tables do.
+
+    Line 3 is inside the dict but is not its definition line, which is what
+    keeps a copy edit on an existing table from being reported.
+    """
+    src = '''
+    TABLE = {
+        "zh": "简体",
+        "en": "english",
+    }
+    '''
+    assert _violations(src, changed_lines={3, 4}) == []
+
+
+def test_ratchet_empty_changed_set_reports_nothing():
+    src = '''
+    TABLE = {"zh": "a", "en": "b"}
+    '''
+    assert _violations(src, changed_lines=set()) == []
+
+
+def test_none_changed_lines_scans_everything():
+    """None means full scan, which is how --full and --count behave."""
+    src = '''
+    TABLE = {"zh": "a", "en": "b"}
+    '''
+    assert len(_violations(src, changed_lines=None)) == 1
+
+
+# ---------------------------------------------------------------------------
+# noqa
+# ---------------------------------------------------------------------------
+
+
+def test_noqa_on_opening_line_suppresses():
+    src = '''
+    TABLE = {  # noqa: PROMPT_ZH_TW
+        "zh": "简体",
+        "en": "english",
+    }
+    '''
+    assert _violations(src) == []
+
+
+def test_noqa_for_a_different_code_does_not_suppress():
+    src = '''
+    TABLE = {  # noqa: DOCSTRING_CJK
+        "zh": "简体",
+        "en": "english",
+    }
+    '''
+    assert len(_violations(src)) == 1
+
+
+def test_noqa_on_an_inner_line_does_not_suppress():
+    """Suppression is anchored to the dict's opening line, not any member."""
+    src = '''
+    TABLE = {
+        "zh": "简体",  # noqa: PROMPT_ZH_TW
+        "en": "english",
+    }
+    '''
+    assert len(_violations(src)) == 1
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), *args],
+        cwd=PROJECT_ROOT, capture_output=True, text=True, check=False,
+    )
+
+
+def test_cli_against_head_is_clean():
+    """--base HEAD is an empty diff, so the ratchet has nothing to report."""
+    result = _run("--base", "HEAD")
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_cli_count_reports_backlog_and_exits_zero():
+    result = _run("--count")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "missing 'zh-TW'" in result.stdout
+
+
+def test_repo_backlog_is_nonempty_and_shrinking_is_the_goal():
+    """Guards the scanner itself: if this hits 0, the scan silently broke.
+
+    The issue #2500 backlog is large. A zero here means the detector stopped
+    matching, not that the work finished — when the backfill genuinely lands,
+    replace this with the full-scan gate.
+    """
+    result = _run("--count")
+    count = int(result.stdout.strip().rsplit(":", 1)[1])
+    assert count > 0, "scanner found nothing; detection likely broke"

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -2112,8 +2112,8 @@ def test_deleting_the_key_revokes_the_backfill_exemption():
     'T = {"en": "e", "zh": "s"}\nT["zh-TW"] = "t"\ndel T["ja"]',
     # the deletion applies to the table bound on line 3, not to the one the
     # backfill completed — the first literal really was compliant while it lived
-    'T = {"en": "e", "zh": "s"}\nT["zh-TW"] = "t"\n'
-    'T = {"en": "e2", "zh": "s2", "zh-TW": "t2"}\ndel T["zh-TW"]',
+    ('T = {"en": "e", "zh": "s"}\nT["zh-TW"] = "t"\n'
+        + 'T = {"en": "e2", "zh": "s2", "zh-TW": "t2"}\ndel T["zh-TW"]'),
 ])
 def test_revocation_is_scoped_to_the_binding_it_applies_to(src):
     assert _violations(src) == []
@@ -2166,3 +2166,77 @@ def test_mutations_before_the_binding_do_not_count():
     )
     tree, comments = MOD._parse_source(src, "t.py")
     assert MOD.find_violations(tree, comments) == [4]
+
+
+@pytest.mark.parametrize("src,expected", [
+    ('T = {"en": "e", "zh": "s"}\nT["zh-TW"] = "t"\nT.pop("zh-TW")', [1]),
+    ('T = {"en": "e", "zh": "s"}\nT["zh-TW"] = "t"\nT.pop("zh-TW", None)', [1]),
+    ('T = {"en": "e", "zh": "s"}\nT["zh-TW"] = "t"\nT.pop("ja")', []),
+])
+def test_pop_removes_the_key_like_del_does(src, expected):
+    """`T.pop("zh-TW")` undoes a backfill as plainly as `del T["zh-TW"]`.
+
+    Recording one removal form and not the other is the same near-miss the rest
+    of this gate keeps producing.
+    """
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == expected
+
+
+@pytest.mark.parametrize("src", [
+    'A = {"zh-TW": "t"}\nTW = {}\nTW.update(A)\nT = {"en": "e", "zh": "s"}\nT.update(TW)',
+    'A = {"zh-TW": "t"}\nTW = {}\nTW |= A\nT = {"en": "e", "zh": "s"}\nT.update(TW)',
+    ('B = {"zh-TW": "t"}\nA = {}\nA.update(B)\nTW = {}\nTW.update(A)\n'
+        + 'T = {"en": "e", "zh": "s"}\nT.update(TW)'),
+])
+def test_a_mutation_payload_may_itself_be_a_name(src):
+    """The supplier is assembled from another name, possibly several hops out.
+
+    Resolving it while the index is being built would need the index, so the
+    reference is recorded and resolved on the way out.
+    """
+    assert _violations(src) == []
+
+
+def test_named_mutation_payload_without_zh_tw_still_reports():
+    src = (
+        'A = {"ja": "j"}\nTW = {}\nTW.update(A)\n'
+        'T = {"en": "e", "zh": "s"}\nT.update(TW)'
+    )
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == [4]
+
+
+@pytest.mark.parametrize("src,expected", [
+    ('A = {}\nA.update(A)\nT = {"en": "e", "zh": "s"}\nT.update(A)', [3]),
+     (('A = {}\nB = {}\nA.update(B)\nB.update(A)\n'
+         + 'T = {"en": "e", "zh": "s"}\nT.update(A)', [5])),
+])
+def test_self_and_mutual_mutation_payloads_terminate(src, expected):
+    """A mutation resolves its own payload through the same lookup.
+
+    Folding the mutation being resolved would recurse forever on `A.update(A)`,
+    which is why the fold stops strictly before the position it is asked about.
+    """
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == expected
+
+
+@pytest.mark.parametrize("src,expected", [
+    ('T = {k: v for [k, v] in [["en", e], ["zh", z]]}', [1]),
+    ('T = {k: v for [k, v] in [["en", e], ["zh", z], ["zh-TW", t]]}', []),
+])
+def test_comprehension_target_may_be_a_list(src, expected):
+    """Python unpacks a list target the same way it unpacks a tuple one."""
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == expected
+
+
+@pytest.mark.parametrize("src,expected", [
+    ('if (T := {"en": "e", "zh": "s"}):\n    T["zh-TW"] = "t"', []),
+    ('if (T := {"en": "e", "zh": "s"}):\n    pass', [1]),
+])
+def test_walrus_binds_a_name_to_a_table(src, expected):
+    """`if (T := {...}):` binds T as much as a statement does."""
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == expected

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -597,6 +597,59 @@ def test_merge_resolving_to_an_offender_is_reported(src):
 
 
 @pytest.mark.parametrize("src", [
+    # One template per locale off a literal locale list — a realistic way to
+    # write a localized table, so leaving it unresolved was a real blind spot.
+    'T = {loc: f"hi {loc}" for loc in ("en", "zh", "ja")}',
+    'T = {loc: 1 for loc in ["en", "zh"]}',
+    'T = {k: v for k, v in (("en", "hello"), ("zh", "你好"))}',
+])
+def test_resolvable_comprehension_is_judged(src):
+    """A comprehension over an inline literal has statically known keys."""
+    assert len(_violations(src)) == 1
+
+
+@pytest.mark.parametrize("src", [
+    'T = {loc: 1 for loc in ("en", "zh", "zh-TW")}',
+    'T = {k: v for k, v in (("en", "a"), ("zh", "b"), ("zh-TW", "c"))}',
+])
+def test_resolvable_comprehension_with_traditional_is_silent(src):
+    assert _violations(src) == []
+
+
+@pytest.mark.parametrize("src", [
+    # Following a name to its definition is deliberately out of scope: all three
+    # comprehensions under config/prompts today are of this shape, and their keys
+    # are a language list rather than templates.
+    'T = {lang: build(lang) for lang in _L10N}',
+    'T = {k: v for k, v in D.items()}',
+    # Filters, extra generators, a computed key, or a key bound to the value slot
+    # all make the key set something other than the literals in the iterable.
+    'T = {loc: 1 for loc in ("en", "zh") if loc}',
+    'T = {loc: 1 for loc in ("en", "zh") for x in y}',
+    'T = {loc.lower(): 1 for loc in ("en", "zh")}',
+    'T = {v: k for k, v in (("en", "a"), ("zh", "b"))}',
+    # The key is a free variable, not the loop target, so the literals in the
+    # iterable say nothing about the resulting key set.
+    'T = {other: 1 for loc in ("en", "zh")}',
+    'T = {other: v for k, v in (("en", "a"), ("zh", "b"))}',
+])
+def test_unresolvable_comprehension_is_not_judged(src):
+    assert _violations(src) == []
+
+
+def test_comprehension_over_a_non_sequence_iterable_does_not_crash():
+    """Restricting the iterable to literal sequences is what keeps .elts safe.
+
+    Without the type check, a name or call in the iterable position would reach
+    `gen.iter.elts` and raise AttributeError, taking the whole gate down.
+    """
+    for src in ('T = {loc: 1 for loc in SOME_NAME}',
+                'T = {loc: 1 for loc in get_locales()}',
+                'T = {loc: 1 for loc in "enzh"}'):
+        assert _violations(src) == []
+
+
+@pytest.mark.parametrize("src", [
     'T = dict(BASE, en="e", zh="s")',
     'T = {**BASE, "en": "e", "zh": "s"}',
     'T = BASE | {"en": "e", "zh": "s"}',

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -582,6 +582,32 @@ def test_merged_construction_fragments_are_not_judged(src):
     assert _violations(src) == []
 
 
+@pytest.mark.parametrize("src", [
+    'P = {**COMMON, "new": {"en": "hello", "zh": "hi"}}',
+    'P = dict(BASE, extra={"en": "a", "zh": "b"})',
+    'P = {**A, "k": {"en": "x", "zh": "y"}}',
+])
+def test_independent_tables_inside_a_merged_container_are_still_judged(src):
+    """Suppression must cover merge *operands*, not the container's whole subtree.
+
+    A value keyed normally alongside a spread is an independent table that merely
+    sits in a merged container. Pruning the subtree — the first attempt at fixing
+    the fragment false-positive — silently stopped checking these entirely.
+    """
+    assert len(_violations(src)) == 1
+
+
+def test_merge_fragment_and_independent_table_side_by_side():
+    """Only the independent table is reported when both live in one container."""
+    src = '''
+    P = {
+        **{"en": "f", "zh": "g"},
+        "ind": {"en": "x", "zh": "y"},
+    }
+    '''
+    assert _violations(src) == [4]
+
+
 def test_ordinary_nesting_is_still_judged_in_source_order():
     """Pruning merged constructions must not stop ordinary nesting being checked.
 

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -313,6 +313,41 @@ _TWO_TABLES = {
 }
 
 
+_NESTED_SHARING_A_LINE = 'T = {"en": {\n    "en": "a",\n    "zh": "b",\n  },\n  "zh": "s",\n  "other": "x",\n}'
+
+
+def test_nested_table_sharing_its_parents_opening_line():
+    """Both tables count when a nested one opens on its parent's line.
+
+    Outer resolves to {en, other, zh} and inner to {en, zh}; neither has zh-TW, so
+    both are offenders and both report line 1.
+    """
+    src = _NESTED_SHARING_A_LINE
+    assert MOD.find_violations(ast.parse(src), src.splitlines()) == [1, 1]
+
+
+def test_locate_uses_each_nodes_own_span_not_the_survivors():
+    """A nested table must not shadow its parent's span.
+
+    Keying nodes by start line let the inner table (ending line 4) evict the outer
+    one (ending line 7). Touching line 5 — inside the parent, past the child — then
+    matched against the child's shorter span and classified both as pre-existing,
+    degrading the message to "run --full".
+    """
+    src = _NESTED_SHARING_A_LINE
+    likely, other = MOD.locate_touched({"p.py": src}, {"p.py": {5}})
+    assert likely == ["p.py:1"]
+    assert other == 1
+
+
+def test_locate_deduplicates_labels_for_tables_on_one_line():
+    """Two offenders on one line render to one label, not the same line twice."""
+    src = _NESTED_SHARING_A_LINE
+    likely, other = MOD.locate_touched({"p.py": src}, {"p.py": {1}})
+    assert likely == ["p.py:1"]
+    assert other == 0
+
+
 def test_locate_narrows_to_tables_the_diff_touched():
     """A bare total says nothing about where, so the message needs the touched one.
 
@@ -606,6 +641,34 @@ def test_merge_resolving_to_an_offender_is_reported(src):
 def test_resolvable_comprehension_is_judged(src):
     """A comprehension over an inline literal has statically known keys."""
     assert len(_violations(src)) == 1
+
+
+@pytest.mark.parametrize("src", [
+    'T = dict([("en", "english"), ("zh", "s")])',
+    'T = dict((("en", "e"), ("zh", "s")))',
+])
+def test_iterable_of_pairs_constructor_is_judged(src):
+    """`dict([(k, v), ...])` is as statically known as a literal.
+
+    It reaches resolve_keys as a list, not a mapping, so without a pair-sequence
+    path it resolved to None and the table escaped entirely.
+    """
+    assert len(_violations(src)) == 1
+
+
+def test_iterable_of_pairs_with_traditional_is_silent():
+    assert _violations('T = dict([("en", "e"), ("zh", "s"), ("zh-TW", "t")])') == []
+
+
+@pytest.mark.parametrize("src", [
+    'T = dict(PAIRS)',
+    'T = dict([("en", "e"), BAD])',
+    'T = dict([("en", "e"), (VAR, "s")])',
+    'T = dict([("en", "e", "extra"), ("zh", "s", "extra")])',
+])
+def test_unresolvable_pair_sequence_is_not_judged(src):
+    """Anything but a literal sequence of two-item string-keyed pairs stays unknown."""
+    assert _violations(src) == []
 
 
 @pytest.mark.parametrize("src", [

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -2240,3 +2240,47 @@ def test_walrus_binds_a_name_to_a_table(src, expected):
     """`if (T := {...}):` binds T as much as a statement does."""
     tree, comments = MOD._parse_source(src, "t.py")
     assert MOD.find_violations(tree, comments) == expected
+
+
+@pytest.mark.parametrize("src", [
+    'A = {"zh-TW": "t"}\nTW = {}\nTW.update({**A})\nT = {"en": "e", "zh": "s"}\nT.update(TW)',
+    'A = {"zh-TW": "t"}\nTW = {}\nTW.update(dict(A))\nT = {"en": "e", "zh": "s"}\nT.update(TW)',
+])
+def test_a_mutation_payload_may_wrap_the_name(src):
+    """Recording only the names a payload *is* missed the ones it *contains*.
+
+    Keeping the payload expression itself and resolving it on the way out covers
+    both, and is less code than the name list it replaced.
+    """
+    assert _violations(src) == []
+
+
+def test_wrapped_payload_without_zh_tw_still_reports():
+    src = (
+        'A = {"ja": "j"}\nTW = {}\nTW.update({**A})\n'
+        'T = {"en": "e", "zh": "s"}\nT.update(TW)'
+    )
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == [4]
+
+
+def test_wrapped_self_referential_payload_terminates():
+    src = 'A = {}\nA.update({**A})\nT = {"en": "e", "zh": "s"}\nT.update(A)'
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == [3]
+
+
+@pytest.mark.parametrize("src", [
+    # a removal through an alias of the same object
+    'T = {"en": "e", "zh": "s"}\nA = T\nT["zh-TW"] = "t"\nA.pop("zh-TW")',
+    # a mutation buried in the right-hand side of a rebinding of the same name
+    'T = {}\nT = {"en": "e", "zh": "s", "side": T.update({"zh-TW": "t"})}',
+])
+def test_documented_blind_spots_around_aliased_mutation(src):
+    """Pinned so a change here is deliberate — see the module docstring.
+
+    The first needs alias analysis (which names share an object), not the
+    per-name timeline everything else uses. The second stores the result of
+    `update()`, which is None — code that cannot be doing what it looks like.
+    """
+    assert _violations(src) == []

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -404,6 +404,80 @@ def test_noqa_for_a_different_code_does_not_suppress():
     assert len(_violations(src)) == 1
 
 
+def _has_noqa_under_test(line: str) -> bool:
+    return MOD._has_noqa(line)
+
+
+def _sibling_has_noqa(line: str) -> bool:
+    """The shared noqa implementation, loaded from a sibling gate."""
+    spec = importlib.util.spec_from_file_location(
+        "check_docstring_no_cjk", PROJECT_ROOT / "scripts" / "check_docstring_no_cjk.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module._has_noqa(line, "PROMPT_ZH_TW")
+
+
+@pytest.mark.parametrize("line", [
+    "# noqa: PROMPT_ZH_TW",
+    "# noqa: PROMPT_ZH_TW, DOCSTRING_CJK",
+    # This code not first in the list, and a bare noqa: both were silently
+    # rejected by an implementation that anchored the code right after `noqa:`.
+    "# noqa: DOCSTRING_CJK, PROMPT_ZH_TW",
+    "# noqa: E501,PROMPT_ZH_TW",
+    "# noqa",
+    "# noqa: PROMPT_ZH_TW  # rationale",
+    "# noqa: PROMPT_ZH_TW_EXTRA",
+    "# noqa: OTHER",
+    "no comment at all",
+])
+def test_noqa_matches_the_sibling_gates(line):
+    """Suppression must behave exactly like the other four gates (and ruff).
+
+    An author who writes the form the rest of the repo uses would otherwise find
+    their suppression ignored here and nowhere else.
+    """
+    assert _has_noqa_under_test(line) == _sibling_has_noqa(line), line
+
+
+def test_noqa_on_the_closing_line_suppresses():
+    """`}  # noqa: PROMPT_ZH_TW` is a natural place to put it.
+
+    It also matters for merge expressions, whose node lineno is the left operand's
+    line rather than what an author would call the table's start.
+    """
+    assert _violations('T = {\n    "en": "e",\n    "zh": "s",\n}  # noqa: PROMPT_ZH_TW') == []
+    assert _violations('T = {\n    "en": "e",\n    "zh": "s",\n}') == [1]
+
+
+@pytest.mark.parametrize("marker", [" ", " ", "\x0c", "\x0b", ""])
+def test_line_split_matches_ast_line_numbers(marker):
+    """`str.splitlines()` breaks on characters CPython does not count as newlines.
+
+    One inside a string literal shifted every later line by one, so a noqa stopped
+    matching its own table and started matching a neighbour — here the suppressed
+    table would be reported and the real offender missed.
+    """
+    src = (
+        'A = {"en": "x' + marker + 'y", "ja": "z"}\n'
+        'B = {"en": 1, "zh": 2}  # noqa: PROMPT_ZH_TW\n'
+        'C = {"en": 1, "zh": 3}'
+    )
+    tree, lines = MOD._parse_source(src, "probe.py")
+    assert MOD.find_violations(tree, lines) == [3]
+
+
+@pytest.mark.parametrize("newline", ["\n", "\r\n", "\r"])
+def test_line_split_handles_every_python_line_ending(newline):
+    """Including a lone CR — `split("\\n")` would collapse that to one line."""
+    src = newline.join([
+        'A = {"en": 1, "zh": 2}  # noqa: PROMPT_ZH_TW',
+        'B = {"en": 1, "zh": 3}',
+    ])
+    tree, lines = MOD._parse_source(src, "probe.py")
+    assert MOD.find_violations(tree, lines) == [2]
+
+
 def test_noqa_on_an_inner_line_does_not_suppress():
     """Suppression is anchored to the dict's opening line, not any member."""
     src = '''
@@ -993,3 +1067,66 @@ def test_cli_count_reports_a_nonempty_backlog():
     assert "missing 'zh-TW'" in result.stdout
     count = int(result.stdout.strip().rsplit(":", 1)[1])
     assert count > 0, "scanner found nothing; detection likely broke"
+
+
+def test_disk_side_excludes_files_git_does_not_know(tmp_path, monkeypatch):
+    """Both sides must draw from the same file set.
+
+    The base side comes from `git ls-tree`, so a gitignored scratch module would
+    exist only on the disk side and count as pure growth — failing the gate over
+    something no PR introduced.
+    """
+    (tmp_path / "tracked.py").write_text('T = {"en": "a", "zh": "b"}', encoding="utf-8")
+    (tmp_path / "ignored.py").write_text('I = {"en": "c", "zh": "d"}', encoding="utf-8")
+    monkeypatch.setattr(MOD, "PROMPTS_DIR", tmp_path)
+    monkeypatch.setattr(MOD, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(MOD, "_git_visible_prompt_files", lambda: {"tracked.py"})
+
+    sources = MOD._sources_on_disk()
+    assert set(sources) == {"tracked.py"}
+    assert MOD.count_offenders(sources) == 1
+
+
+def test_disk_side_unfiltered_when_git_cannot_answer(tmp_path, monkeypatch):
+    """Outside a checkout the scan still works — --count/--full are useful there."""
+    (tmp_path / "a.py").write_text('T = {"en": "a", "zh": "b"}', encoding="utf-8")
+    monkeypatch.setattr(MOD, "PROMPTS_DIR", tmp_path)
+    monkeypatch.setattr(MOD, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(MOD, "_git_visible_prompt_files", lambda: None)
+    assert set(MOD._sources_on_disk()) == {"a.py"}
+
+
+def test_git_visible_prompt_files_asks_for_untracked_but_not_ignored(monkeypatch):
+    """A work-in-progress module must stay visible; an ignored one must not.
+
+    `--others --exclude-standard` is what draws that line, so losing either flag
+    changes which files the gate checks locally.
+    """
+    seen: list[list[str]] = []
+
+    class _Result:
+        returncode = 0
+        stdout = b"config/prompts/a.py\0"
+        stderr = b""
+
+    def fake_run(cmd, **_kwargs):
+        seen.append(cmd)
+        return _Result()
+
+    monkeypatch.setattr(MOD.subprocess, "run", fake_run)
+    assert MOD._git_visible_prompt_files() == {"config/prompts/a.py"}
+    argv = seen[0]
+    assert "ls-files" in argv
+    assert "--cached" in argv
+    assert "--others" in argv
+    assert "--exclude-standard" in argv
+
+
+def test_git_visible_prompt_files_returns_none_on_git_failure(monkeypatch):
+    class _Result:
+        returncode = 128
+        stdout = b""
+        stderr = b"not a git repository"
+
+    monkeypatch.setattr(MOD.subprocess, "run", lambda cmd, **kw: _Result())
+    assert MOD._git_visible_prompt_files() is None

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -566,18 +566,47 @@ def test_dict_call_with_positional_base_is_not_judged():
     'T = dict({"en": "e", "zh": "s"}, **{"zh-TW": "t"})',
     'T = {**{"en": "e", "zh": "s"}, **{"zh-TW": "t"}}',
     'T = {"en": "e", "zh": "s"} | {"zh-TW": "t"}',
-    # Positional base only, no `**`: the sole thing marking this as a merge is
-    # the positional arg, so this case is what proves that half of
-    # _is_merged_construction is load-bearing for pruning.
-    'T = dict({"en": "e", "zh": "s"}, note="x")',
     'T = dict({"en": "e", "zh": "s"}, {"zh-TW": "t"})',
 ])
-def test_merged_construction_fragments_are_not_judged(src):
-    """A table assembled from several mappings must not report its fragments.
+def test_merge_resolving_to_a_compliant_table_is_silent(src):
+    """A merge whose *result* carries zh-TW must not report its fragments.
 
-    Skipping the outer node is not enough: a plain ast.walk still descends into
-    the inner `{en, zh}` literal and flags it, even though the assembled mapping
-    does carry zh-TW. The whole subtree has to be pruned.
+    Plain ast.walk judges each half on its own and flags the `{en, zh}` literal,
+    even though the assembled mapping is compliant.
+    """
+    assert _violations(src) == []
+
+
+@pytest.mark.parametrize("src", [
+    # Neither half is a localized table; only the union is, and it lacks zh-TW.
+    'T = {"en": "e"} | {"zh": "s"}',
+    # A complete offender unioned with an empty dict.
+    'T = {"en": "e", "zh": "s"} | {}',
+    # Positional base carrying en/zh, merged with an unrelated keyword.
+    'T = dict({"en": "e", "zh": "s"}, note="x")',
+    'T = dict({"en": "e", "zh": "s"}, **{"note": "x"})',
+])
+def test_merge_resolving_to_an_offender_is_reported(src):
+    """A merge whose *result* lacks zh-TW must be caught.
+
+    Suppressing the operands without resolving the merge let these through
+    entirely: both halves were suppressed as fragments, and the enclosing BinOp is
+    not a dict node, so nothing got judged at all.
+    """
+    assert len(_violations(src)) == 1
+
+
+@pytest.mark.parametrize("src", [
+    'T = dict(BASE, en="e", zh="s")',
+    'T = {**BASE, "en": "e", "zh": "s"}',
+    'T = BASE | {"en": "e", "zh": "s"}',
+    'T = {"en": "e", "zh": "s", DYNAMIC_KEY: "x"}',
+])
+def test_unresolvable_mapping_is_not_judged(src):
+    """When any part of the key set is unknowable, stay silent.
+
+    The unknown part is exactly where a zh-TW entry could be hiding, and a gate
+    that cries wolf gets worked around rather than satisfied.
     """
     assert _violations(src) == []
 
@@ -598,14 +627,19 @@ def test_independent_tables_inside_a_merged_container_are_still_judged(src):
 
 
 def test_merge_fragment_and_independent_table_side_by_side():
-    """Only the independent table is reported when both live in one container."""
+    """The container and the independent table are each judged; the fragment isn't.
+
+    The container resolves to `{en, zh, ind}` — a localized table in its own right
+    that lacks zh-TW — so line 2 is a real offender, not the fragment on line 3
+    being double-counted. Line 4 is the independently keyed table.
+    """
     src = '''
     P = {
         **{"en": "f", "zh": "g"},
         "ind": {"en": "x", "zh": "y"},
     }
     '''
-    assert _violations(src) == [4]
+    assert _violations(src) == [2, 4]
 
 
 def test_ordinary_nesting_is_still_judged_in_source_order():
@@ -733,12 +767,53 @@ def test_prompt_files_at_reads_nul_separated_paths(monkeypatch):
 
     def fake_git(*args: str) -> str:
         captured.append(args)
-        return "config/prompts/a.py\0config/prompts/中文.py\0config/prompts/notes.txt\0"
+        return (
+            "100644 blob aaa\tconfig/prompts/a.py\0"
+            "100644 blob bbb\tconfig/prompts/中文.py\0"
+            "100644 blob ccc\tconfig/prompts/notes.txt\0"
+        )
 
     monkeypatch.setattr(MOD, "_git", fake_git)
     files = MOD._prompt_files_at("REV")
     assert files == ["config/prompts/a.py", "config/prompts/中文.py"]
     assert "-z" in captured[0], captured[0]
+    # Modes are needed to spot symlinks, so --name-only must not come back.
+    assert "--name-only" not in captured[0], captured[0]
+
+
+def test_prompt_files_at_skips_symlinks(monkeypatch, capsys):
+    """Symlinked modules are excluded on the base side.
+
+    `git show` on a symlink yields the link's *target path* as blob content, while
+    the disk side would follow the link and scan real source. Counting one and not
+    the other makes the two sides disagree about the same path forever, so every
+    later PR fails on a difference no PR introduced.
+    """
+    monkeypatch.setattr(MOD, "_git", lambda *_a: (
+        "100644 blob aaa\tconfig/prompts/real.py\0"
+        "120000 blob bbb\tconfig/prompts/linked.py\0"
+    ))
+    files = MOD._prompt_files_at("REV")
+    assert files == ["config/prompts/real.py"]
+    assert "linked.py" in capsys.readouterr().err
+
+
+def test_sources_on_disk_skips_symlinks(tmp_path, monkeypatch, capsys):
+    """The disk side must skip symlinks too — the dual of the base side."""
+    (tmp_path / "real.py").write_text('T = {"en": "a", "zh": "b"}', encoding="utf-8")
+    target = tmp_path / "target.txt"
+    target.write_text('T = {"en": "c", "zh": "d"}', encoding="utf-8")
+    link = tmp_path / "linked.py"
+    try:
+        link.symlink_to(target)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation not permitted in this environment")
+
+    monkeypatch.setattr(MOD, "PROMPTS_DIR", tmp_path)
+    monkeypatch.setattr(MOD, "REPO_ROOT", tmp_path)
+    sources = MOD._sources_on_disk()
+    assert set(sources) == {"real.py"}
+    assert "linked.py" in capsys.readouterr().err
 
 
 def test_touched_lines_asks_git_for_rename_detection(monkeypatch):

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -1971,3 +1971,68 @@ def test_rebinding_that_does_not_supply_zh_tw_still_reports():
     src = 'T = {"en": "e", "zh": "s"}\nT = T | {"ja": "j"}'
     tree, comments = MOD._parse_source(src, "t.py")
     assert MOD.find_violations(tree, comments) == [1]
+
+
+@pytest.mark.parametrize("src,expected", [
+    # the rebinding runs AFTER the backfill, so the final table really lacks zh-TW
+    ('T = {}; T["zh-TW"] = "t"; T = {"en": "e", "zh": "s"}', [1]),
+    # …and the same three statements in the compliant order must stay silent
+    ('T = {"en": "e", "zh": "s"}; T["zh-TW"] = "t"', []),
+    ('T = {}; T = {"en": "e", "zh": "s"}; T["zh-TW"] = "t"', []),
+])
+def test_bindings_are_ordered_by_column_not_only_by_line(src, expected):
+    """Semicolons put several statements on one line, so a line is not an order.
+
+    Searching by line alone picked the *last* binding on the line for a mutation
+    that runs before it, exempting a table that really does end up missing zh-TW.
+    """
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == expected
+
+
+@pytest.mark.parametrize("src", [
+    'TW = {"zh-TW": "t"}\nTW = dict(TW)\nT = {"en": "e", "zh": "s"}\nT.update(TW)',
+    'TW = {"zh-TW": "t"}\nTW = TW | {}\nT = {"en": "e", "zh": "s"}\nT |= TW',
+    'TW = {"zh-TW": "t"}\nTW = dict(TW)\nF = {"en": "e", "zh": "s"}\nT = {**F, **TW}',
+])
+def test_a_supplier_may_rebind_itself_before_being_used(src):
+    """The `TW` inside `TW = dict(TW)` reads the binding *before* that one.
+
+    Resolving it against the binding being descended into found nothing, so a
+    supplier that had merely been rebound looked empty and its target was reported.
+    """
+    assert _violations(src) == []
+
+
+def test_self_rebinding_supplier_that_drops_zh_tw_still_reports():
+    src = (
+        'TW = {"zh-TW": "t"}\n'
+        'TW = {"ja": "j"}\n'
+        'T = {"en": "e", "zh": "s"}\n'
+        "T.update(TW)"
+    )
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == [3]
+
+
+@pytest.mark.parametrize("src", [
+    'T = {"en": "e", "zh": "s"}\nT["zh-TW"], marker = "t", True',
+    'T = {"en": "e", "zh": "s"}\n(a, (T["zh-TW"], b)) = (1, ("t", 2))',
+    'T = {"en": "e", "zh": "s"}\nT["zh-TW"], *rest = "t", 1, 2',
+    # the starred slot may itself be the subscript — the key still ends up set
+    # (to a list), which is what verifying this against CPython showed
+    'T = {"en": "e", "zh": "s"}\n*T["zh-TW"], b = "t", 1',
+])
+def test_backfill_through_an_unpacking_target(src):
+    """`T["zh-TW"], flag = t, True` puts the subscript inside an ast.Tuple.
+
+    Scanning only top-level targets missed the backfill and reported a table that
+    is compliant at runtime.
+    """
+    assert _violations(src) == []
+
+
+def test_unpacking_target_for_another_key_still_reports():
+    src = 'T = {"en": "e", "zh": "s"}\nT["ja"], marker = "j", True'
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == [1]

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -2036,3 +2036,133 @@ def test_unpacking_target_for_another_key_still_reports():
     src = 'T = {"en": "e", "zh": "s"}\nT["ja"], marker = "j", True'
     tree, comments = MOD._parse_source(src, "t.py")
     assert MOD.find_violations(tree, comments) == [1]
+
+
+@pytest.mark.parametrize("src", [
+    'T, marker = ({"en": "e", "zh": "s"}, True)\nT["zh-TW"] = "t"',
+    'a, (T, b) = (1, ({"en": "e", "zh": "s"}, 2))\nT["zh-TW"] = "t"',
+])
+def test_unpacking_also_binds_a_name_to_a_table(src):
+    """`T, flag = ({...}, True)` binds T as much as `T = {...}` does.
+
+    Registering only top-level Name targets left the later backfill with no
+    binding to exempt, so the compliant table was still reported.
+    """
+    assert _violations(src) == []
+
+
+@pytest.mark.parametrize("src,expected", [
+    ('T, marker = ({"en": "e", "zh": "s"}, True)', [1]),
+    # not a literal sequence on both sides: the pairing is unknowable, and
+    # guessing would exempt whichever table happened to be nearby
+    ('T, m = f()\nT["zh-TW"] = "t"\nU = {"en": "e", "zh": "s"}', [3]),
+])
+def test_unpacking_binding_stays_narrow(src, expected):
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == expected
+
+
+@pytest.mark.parametrize("src,expected", [
+    ('T = dict([loc, build(loc)] for loc in ("en", "zh"))', [1]),
+    ('T = dict([loc, build(loc)] for loc in ("en", "zh", "zh-TW"))', []),
+])
+def test_generator_pairs_may_be_lists(src, expected):
+    """`dict` only asks for a two-item iterable, and the pair-sequence path
+    already accepted both — so the generator one has to as well."""
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == expected
+
+
+@pytest.mark.parametrize("src", [
+    'TW = {}\nTW["zh-TW"] = "t"\nT = {"en": "e", "zh": "s"}\nT.update(TW)',
+    'TW = {}\nTW.update({"zh-TW": "t"})\nT = {"en": "e", "zh": "s"}\nT.update(TW)',
+    'TW = {}\nTW.setdefault("zh-TW", "t")\nT = {"en": "e", "zh": "s"}\nT |= TW',
+])
+def test_a_supplier_may_be_assembled_in_two_steps(src):
+    """A name is not only what it was bound to.
+
+    `TW = {}` / `TW["zh-TW"] = t` is an ordinary way to build a table, and reading
+    only the literal saw an empty one — so the compliant target got reported.
+    """
+    assert _violations(src) == []
+
+
+@pytest.mark.parametrize("src,expected", [
+    ('TW = {}\nTW["ja"] = "j"\nT = {"en": "e", "zh": "s"}\nT.update(TW)', [3]),
+    # the assembly happens after the use, so it cannot have supplied anything
+    ('TW = {}\nT = {"en": "e", "zh": "s"}\nT.update(TW)\nTW["zh-TW"] = "t"', [2]),
+])
+def test_assembled_supplier_is_read_in_source_order(src, expected):
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == expected
+
+
+def test_deleting_the_key_revokes_the_backfill_exemption():
+    """The exemption claims the literal is compliant by the time it runs.
+
+    A later removal makes that false again, and a deletion creates no mapping node
+    of its own, so nothing else would have noticed.
+    """
+    src = 'T = {"en": "e", "zh": "s"}\nT["zh-TW"] = "t"\ndel T["zh-TW"]'
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == [1]
+
+
+@pytest.mark.parametrize("src", [
+    'T = {"en": "e", "zh": "s"}\nT["zh-TW"] = "t"\ndel T["ja"]',
+    # the deletion applies to the table bound on line 3, not to the one the
+    # backfill completed — the first literal really was compliant while it lived
+    'T = {"en": "e", "zh": "s"}\nT["zh-TW"] = "t"\n'
+    'T = {"en": "e2", "zh": "s2", "zh-TW": "t2"}\ndel T["zh-TW"]',
+])
+def test_revocation_is_scoped_to_the_binding_it_applies_to(src):
+    assert _violations(src) == []
+
+
+@pytest.mark.parametrize("src", [
+    # names before and after a starred slot pair from their own end, as Python does
+    'T, *rest = ({"en": "e", "zh": "s"}, 1, 2)\nT["zh-TW"] = "t"',
+    '*rest, T = (1, 2, {"en": "e", "zh": "s"})\nT["zh-TW"] = "t"',
+    'a, *rest, T = (1, 2, 3, {"en": "e", "zh": "s"})\nT["zh-TW"] = "t"',
+])
+def test_starred_unpacking_pairs_from_both_ends(src):
+    """Refusing to pair anything with a star present is a false positive.
+
+    These bindings are perfectly ordinary at runtime, so the backfill really does
+    complete the table.
+    """
+    assert _violations(src) == []
+
+
+@pytest.mark.parametrize("src,expected", [
+    # a ValueError at runtime — the gate must not guess past broken code
+    ('T, m = ({"en": "e", "zh": "s"},)\nT["zh-TW"] = "t"', [1]),
+    ('T, m, x = ({"en": "e", "zh": "s"}, 1)\nT["zh-TW"] = "t"', [1]),
+    # the starred name receives a list, never a table
+    ('*T, b = ({"en": "e", "zh": "s"}, 1)\nT["zh-TW"] = "t"', [1]),
+    # too few values for the slots around the star — also a runtime ValueError
+    ('a, *rest, T = ({"en": "e", "zh": "s"},)\nT["zh-TW"] = "t"', [1]),
+    # two starred slots parse fine but fail at compile time, so the module could
+    # never be imported; the gate still must not invent a pairing for it
+    ('*a, T, *b = (1, {"en": "e", "zh": "s"}, 2)\nT["zh-TW"] = "t"', [1]),
+])
+def test_unknowable_unpacking_binds_nothing(src, expected):
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == expected
+
+
+def test_mutations_before_the_binding_do_not_count():
+    """A rebinding wipes whatever earlier mutations had put there.
+
+    Reading the whole file's mutations for a name would carry a key across a
+    rebinding that discarded it, and exempt a target that really is missing zh-TW.
+    """
+    src = (
+        "TW = {}\n"
+        'TW["zh-TW"] = "t"\n'
+        "TW = {}\n"
+        'T = {"en": "e", "zh": "s"}\n'
+        "T.update(TW)"
+    )
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == [4]

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -1496,3 +1496,45 @@ def test_directly_visible_keys_recurses_into_spreads():
         _ast.parse('{**OTHER, **{"zh-TW": "t"}}', mode="eval").body
     )
     assert visible == {"zh-TW"}
+
+
+@pytest.mark.parametrize("src", [
+    'T = U = {"en": "e", "zh": "s"}\nT["zh-TW"] = "t"',
+    'T = U = {"en": "e", "zh": "s"}\nU["zh-TW"] = "t"',
+])
+def test_chained_binding_is_exempt_through_either_name(src):
+    """`T = U = {...}` names one object; a mutation through either completes it.
+
+    Requiring exactly one target kept chained bindings out of the lookup, so the
+    literal was reported despite being compliant at runtime.
+    """
+    assert _violations(src) == []
+
+
+def test_chained_binding_without_a_backfill_is_still_reported():
+    src = 'T = U = {"en": "e", "zh": "s"}'
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == [1]
+
+
+@pytest.mark.parametrize("src", [
+    '_F = {"en": "e", "zh": "s"}\nT = _F | dict.fromkeys(("zh-TW",), "t")',
+    '_F = {"en": "e", "zh": "s"}\nT = {**_F, **dict.fromkeys(("zh-TW",), "t")}',
+])
+def test_fromkeys_counts_as_a_visible_supplier(src):
+    """resolve_keys handles dict.fromkeys, so the visibility scan must too.
+
+    Otherwise the union looks like it supplies nothing and the named fragment is
+    reported even though the assembled table is compliant.
+    """
+    assert _violations(src) == []
+
+
+@pytest.mark.parametrize("src", [
+    '_F = {"en": "e", "zh": "s"}\nT = _F | dict.fromkeys(("ja",), "t")',
+    '_F = {"en": "e", "zh": "s"}\nT = _F | dict.fromkeys(LOCALES, "t")',
+])
+def test_fromkeys_without_zh_tw_does_not_exempt(src):
+    """Supplying some other locale, or an unresolvable list, exempts nothing."""
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == [1]

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -434,6 +434,53 @@ def test_main_passes_when_head_backfilled_an_offender(monkeypatch):
     assert MOD.main(["--base", "irrelevant"]) == 0
 
 
+def test_main_forces_utf8_on_its_own_streams(monkeypatch):
+    """The gate must not encode its output with the locale encoding.
+
+    Asserting the reconfigure call is asserting the mechanism, because the failure
+    it prevents is not reproducible in-process: when stdout is a pipe, Python picks
+    the locale encoding — cp1252 on the Windows CI runner — and printing a
+    non-ASCII path or a SyntaxError carrying CJK source raises UnicodeEncodeError
+    from inside the gate. That is exactly how this gate first went red on CI.
+    """
+    calls: list[dict[str, object]] = []
+
+    class _Stream:
+        def reconfigure(self, **kwargs):
+            calls.append(kwargs)
+
+        def write(self, _text):
+            return None
+
+        def flush(self):
+            return None
+
+    monkeypatch.setattr(sys, "stdout", _Stream())
+    monkeypatch.setattr(sys, "stderr", _Stream())
+    _stub_revisions(monkeypatch, {}, {})
+    MOD.main(["--base", "irrelevant"])
+
+    assert len(calls) == 2, calls
+    assert all(c.get("encoding") == "utf-8" for c in calls), calls
+    assert all(c.get("errors") == "replace" for c in calls), calls
+
+
+def test_main_tolerates_streams_without_reconfigure(monkeypatch):
+    """Older/wrapped streams lack reconfigure; the gate must not crash on them."""
+
+    class _Bare:
+        def write(self, _text):
+            return None
+
+        def flush(self):
+            return None
+
+    monkeypatch.setattr(sys, "stdout", _Bare())
+    monkeypatch.setattr(sys, "stderr", _Bare())
+    _stub_revisions(monkeypatch, {}, {})
+    assert MOD.main(["--base", "irrelevant"]) == 0
+
+
 def test_main_passes_on_an_unchanged_tree(monkeypatch):
     src = {"a.py": 'T = {"en": "x", "zh": "y"}'}
     _stub_revisions(monkeypatch, src, src)
@@ -457,26 +504,103 @@ def test_sources_on_disk_skips_undecodable_file(tmp_path, monkeypatch, capsys):
     assert MOD.count_offenders(sources) == 1
 
 
-def test_git_decodes_with_replacement(monkeypatch):
-    """git output is decoded with errors="replace" so a bad blob cannot crash us.
-
-    The base side reads sources through `git show`; without this it would raise
-    mid-decode where the disk side merely skips the file.
-    """
-    captured: dict[str, object] = {}
-
+def _stub_git_stdout(monkeypatch, stdout: bytes):
     class _Result:
         returncode = 0
-        stdout = "ok"
-        stderr = ""
+        stderr = b""
 
-    def fake_run(cmd, **kwargs):
-        captured.update(kwargs)
-        return _Result()
+    _Result.stdout = stdout
+    monkeypatch.setattr(MOD.subprocess, "run", lambda cmd, **kw: _Result())
 
-    monkeypatch.setattr(MOD.subprocess, "run", fake_run)
-    assert MOD._git("show", "X:y.py") == "ok"
-    assert captured.get("errors") == "replace", captured
+
+def test_git_text_decoding_survives_bad_bytes(monkeypatch):
+    """`_git` decodes git's own reporting without crashing on a bad byte.
+
+    Asserts the behavior rather than the subprocess kwargs: diff headers and path
+    lists must come back as text even when a byte is not valid UTF-8, because the
+    alternative is the gate dying mid-decode on unrelated repo content.
+    """
+    _stub_git_stdout(monkeypatch, b"ok\xff\xfe")
+    out = MOD._git("diff", "--name-only")
+    assert out.startswith("ok")
+    assert "�" in out, out
+
+
+def test_git_bytes_hands_back_raw_stdout(monkeypatch):
+    """Source blobs stay bytes so `_decode_source` can honour PEP 263.
+
+    If this decoded eagerly, a `# coding: latin-1` module would already be
+    mangled before its declaration was ever read.
+    """
+    _stub_git_stdout(monkeypatch, b"# coding: latin-1\nT = {'en': 'caf\xe9'}\n")
+    raw = MOD._git_bytes("show", "X:y.py")
+    assert isinstance(raw, bytes)
+    assert raw.endswith(b"\n")
+
+
+def test_dict_call_with_positional_base_is_not_judged():
+    """`dict(BASE, zh=...)` must be left alone: BASE may hold the zh-TW entry.
+
+    Same unknowable-keys problem as `**`, and a gate that cries wolf gets worked
+    around rather than satisfied.
+    """
+    assert _violations("T = dict(BASE, en='e', zh='s')") == []
+    assert _violations("T = dict({'zh-TW': 't'}, en='e', zh='s')") == []
+    # Keyword-only is still fully knowable, so it is still judged.
+    assert len(_violations("T = dict(en='e', zh='s')")) == 1
+
+
+def test_touched_lines_disables_git_path_quoting(monkeypatch):
+    """Non-ASCII paths must not come back C-quoted in the `+++` header.
+
+    Git's default output is `+++ "b/config/prompts/\\344\\270\\255.py"`, which
+    matches no real path and would silently drop that file's location hints.
+    """
+    seen: list[tuple[str, ...]] = []
+
+    def fake_git(*args: str) -> str:
+        seen.append(args)
+        return ""
+
+    monkeypatch.setattr(MOD, "_git", fake_git)
+    MOD._touched_lines("BASE_SHA")
+    assert seen, "no git invocation recorded"
+    args = seen[0]
+    assert "core.quotePath=false" in args, args
+    assert args.index("-c") < args.index("core.quotePath=false")
+
+
+def test_touched_lines_parses_a_non_ascii_path(monkeypatch):
+    """End of the same story: an unquoted CJK path is keyed by its real name."""
+    monkeypatch.setattr(MOD, "_git", lambda *a: (
+        "diff --git a/config/prompts/中文表.py b/config/prompts/中文表.py\n"
+        "--- a/config/prompts/中文表.py\n"
+        "+++ b/config/prompts/中文表.py\n"
+        "@@ -3,0 +4 @@\n"
+        '+    "ja": "c",\n'
+    ))
+    touched = MOD._touched_lines("BASE_SHA")
+    assert touched == {"config/prompts/中文表.py": {4}}
+
+
+def test_decode_source_honours_a_coding_declaration():
+    """A `# coding: latin-1` module is valid Python and must be checked, not skipped."""
+    raw = "# coding: latin-1\nT = {'en': 'caf\xe9', 'zh': 'x'}\n".encode("latin-1")
+    text = MOD._decode_source(raw, "legacy.py")
+    assert text is not None
+    assert "café" in text
+    assert len(_violations(text)) == 1
+
+
+def test_decode_source_defaults_to_utf8_without_a_declaration():
+    raw = "T = {'en': 'a', 'zh': '简体'}\n".encode("utf-8")
+    assert "简体" in (MOD._decode_source(raw, "plain.py") or "")
+
+
+def test_decode_source_reports_undecodable_bytes(capsys):
+    """Only genuinely broken bytes are skipped, and never silently."""
+    assert MOD._decode_source(b"# coding: utf-8\nT = '\xff\xfe'\n", "bad.py") is None
+    assert "bad.py" in capsys.readouterr().err
 
 
 def test_prompt_files_at_reads_nul_separated_paths(monkeypatch):
@@ -522,9 +646,18 @@ def test_touched_lines_asks_git_for_rename_detection(monkeypatch):
 
 
 def _run(*args: str) -> subprocess.CompletedProcess:
+    """Run the gate as a subprocess, decoding its output as UTF-8.
+
+    ``text=True`` alone decodes with the *locale* encoding, which is cp1252 on
+    the Windows CI runner — any non-ASCII byte in the gate's output then raises
+    UnicodeDecodeError inside subprocess's reader thread, and the failure surfaces
+    as an unrelated-looking assertion on returncode. The gate forces UTF-8 on its
+    own streams; this is the matching half.
+    """
     return subprocess.run(
         [sys.executable, str(SCRIPT_PATH), *args],
-        cwd=PROJECT_ROOT, capture_output=True, text=True, check=False,
+        cwd=PROJECT_ROOT, capture_output=True, check=False,
+        text=True, encoding="utf-8", errors="replace",
     )
 
 

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -1130,3 +1130,71 @@ def test_git_visible_prompt_files_returns_none_on_git_failure(monkeypatch):
 
     monkeypatch.setattr(MOD.subprocess, "run", lambda cmd, **kw: _Result())
     assert MOD._git_visible_prompt_files() is None
+
+
+@pytest.mark.parametrize("src", [
+    'T = dict.fromkeys(("en", "zh"), "tpl")',
+    'T = dict.fromkeys(["en", "zh"], "tpl")',
+])
+def test_dict_fromkeys_over_a_literal_is_judged(src):
+    """`dict.fromkeys(("en", "zh"), tpl)` — one template across a literal list.
+
+    `node.func` is an Attribute, so the `dict(...)` branch never sees it, and
+    there is no child mapping node for the walker to fall back on. The constructor
+    itself is already used under config/prompts.
+    """
+    assert _violations(src) == [1]
+
+
+def test_dict_fromkeys_with_traditional_is_silent():
+    assert _violations('T = dict.fromkeys(("en", "zh", "zh-TW"), "t")') == []
+
+
+@pytest.mark.parametrize("src", [
+    'T = dict.fromkeys(LOCALES, "t")',
+    'T = dict.fromkeys()',
+    'T = other.fromkeys(("en", "zh"), "t")',
+])
+def test_dict_fromkeys_unresolvable_is_not_judged(src):
+    assert _violations(src) == []
+
+
+@pytest.mark.parametrize("src", [
+    'T = {None: "d", "en": "e", "zh": "s"}',
+    'T = {1: "d", "en": "e", "zh": "s"}',
+    'T = dict([(None, "d"), ("en", "e"), ("zh", "s")])',
+])
+def test_constant_non_string_key_does_not_abandon_the_table(src):
+    """A None sentinel or int key cannot be 'zh-TW', so it hides nothing.
+
+    Abandoning the whole mapping over it let a real offender through; only a
+    *non-constant* key justifies giving up, because that one could be anything.
+    """
+    assert _violations(src) == [1]
+
+
+def test_constant_non_string_key_alongside_traditional_stays_silent():
+    assert _violations('T = {None: "d", "en": "e", "zh": "s", "zh-TW": "t"}') == []
+
+
+@pytest.mark.parametrize("src", [
+    'T = {DYNAMIC: "d", "en": "e", "zh": "s"}',
+    'T = dict([(VAR, "d"), ("en", "e"), ("zh", "s")])',
+])
+def test_non_constant_key_still_abandons_the_table(src):
+    """The unknown key could be 'zh-TW' itself, so stay silent."""
+    assert _violations(src) == []
+
+
+@pytest.mark.parametrize("src", [
+    'T = dict.fromkeys(("en", "zh", MAYBE_ZH_TW), "t")',
+    'T = {loc: 1 for loc in ("en", "zh", MAYBE_ZH_TW)}',
+])
+def test_non_constant_element_in_a_key_sequence_abandons_the_table(src):
+    """One unknown element makes the whole key set unknown.
+
+    Skipping it instead would resolve to {en, zh} and report an offender, when the
+    unknown element may well be the 'zh-TW' entry that makes the table compliant —
+    a false positive on code that is actually fine.
+    """
+    assert _violations(src) == []

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -2375,3 +2375,53 @@ def test_loop_alternatives_are_grouped_per_target():
     )
     tree, comments = MOD._parse_source(src, "t.py")
     assert MOD.find_violations(tree, comments) == [2, 3]
+
+
+@pytest.mark.parametrize("src,expected", [
+    ('T = {"en": "e", "zh": "s"}\nT.update({"zh-TW": "t"}.items())', []),
+    ('A = {"zh-TW": "t"}\nT = {"en": "e", "zh": "s"}\nT.update(dict(A).items())', []),
+    ('T = {"en": "e", "zh": "s"}\nT.update({"ja": "j"}.items())', [1]),
+])
+def test_a_mapping_view_may_sit_on_any_expression(src, expected):
+    """The view hands over the receiver's keys whatever the receiver is spelled as.
+
+    Requiring a bare name covered only the shape the report happened to use.
+    """
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == expected
+
+
+def test_popitem_invalidates_the_backfill():
+    """It removes a key without naming one, so nothing is left to claim.
+
+    Recorded like `clear()` — the fourth spelling of "this table lost keys" that
+    this gate had to be told about one at a time.
+    """
+    src = 'T = {"en": "e", "zh": "s"}\nT["zh-TW"] = "t"\nT.popitem()'
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == [1]
+
+
+@pytest.mark.parametrize("src,expected", [
+    # inside the body: every iteration completes its own element
+    ('for T in (\n    {"en": "e", "zh": "s"},\n    {"en": "e2", "zh": "s2"},\n):\n'
+     + '    T["zh-TW"] = "t"', []),
+    # after the loop: only whatever the last iteration left is completed
+    ('for T in (\n    {"en": "e", "zh": "s"},\n    {"en": "e2", "zh": "s2"},\n):\n'
+     + '    pass\nT["zh-TW"] = "t"', [2]),
+])
+def test_loop_closure_needs_the_backfill_inside_the_body(src, expected):
+    """Closing over the alternatives unconditionally excused the earlier elements."""
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == expected
+
+
+@pytest.mark.parametrize("src,expected", [
+    ('T = {"en": "e", "zh": "s"}\nT.update(TW := {"zh-TW": "t"})', []),
+    ('T = {"en": "e", "zh": "s"}\nT |= (P := {"zh-TW": "t"})', []),
+    ('T = {"en": "e", "zh": "s"}\nT.update(P := {"ja": "j"})', [1]),
+])
+def test_a_payload_may_be_an_assignment_expression(src, expected):
+    """A walrus evaluates to the mapping it binds."""
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == expected

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -2329,52 +2329,10 @@ def test_documented_blind_spots_around_scope_and_reachability(src):
     assert _violations(src) == []
 
 
-@pytest.mark.parametrize("src,expected", [
-    ('for T in ({"en": "e", "zh": "s"},):\n    T["zh-TW"] = "t"', []),
-    ('for T in [{"en": "e", "zh": "s"}, {"en": "e2", "zh": "s2"}]:\n    T["zh-TW"] = "t"', []),
-    # not a literal iterable: nothing is knowable, so nothing is bound
-    ('for T in tables():\n    T["zh-TW"] = "t"\nU = {"en": "e", "zh": "s"}', [3]),
-])
-def test_a_loop_over_a_literal_binds_its_target(src, expected):
-    """Every element of a literal iterable is a binding of the loop target.
-
-    The same pairing as unpacking, which is where the helper comes from.
-    """
-    tree, comments = MOD._parse_source(src, "t.py")
-    assert MOD.find_violations(tree, comments) == expected
 
 
-def test_loop_alternatives_are_only_closed_over_when_one_is_exempt():
-    """Grouping says "a backfill completes them all", not "they are all fine".
-
-    Without a backfill in the body every element is still its own offender.
-    """
-    src = (
-        "for T in [\n"
-        '    {"en": "e", "zh": "s"},\n'
-        '    {"en": "e2", "zh": "s2"},\n'
-        "]:\n"
-        "    pass"
-    )
-    tree, comments = MOD._parse_source(src, "t.py")
-    assert MOD.find_violations(tree, comments) == [2, 3]
 
 
-def test_loop_alternatives_are_grouped_per_target():
-    """`for T, U in ((a, b), (c, d))` makes a/c alternatives of T, b/d of U.
-
-    Pooling every value the loop binds would let a backfill through one target
-    excuse the tables bound to the other.
-    """
-    src = (
-        "for T, U in (\n"
-        '    ({"en": "e", "zh": "s"}, {"en": "e2", "zh": "s2"}),\n'
-        '    ({"en": "e3", "zh": "s3"}, {"en": "e4", "zh": "s4"}),\n'
-        "):\n"
-        '    T["zh-TW"] = "t"'
-    )
-    tree, comments = MOD._parse_source(src, "t.py")
-    assert MOD.find_violations(tree, comments) == [2, 3]
 
 
 @pytest.mark.parametrize("src,expected", [
@@ -2391,29 +2349,8 @@ def test_a_mapping_view_may_sit_on_any_expression(src, expected):
     assert MOD.find_violations(tree, comments) == expected
 
 
-def test_popitem_invalidates_the_backfill():
-    """It removes a key without naming one, so nothing is left to claim.
-
-    Recorded like `clear()` — the fourth spelling of "this table lost keys" that
-    this gate had to be told about one at a time.
-    """
-    src = 'T = {"en": "e", "zh": "s"}\nT["zh-TW"] = "t"\nT.popitem()'
-    tree, comments = MOD._parse_source(src, "t.py")
-    assert MOD.find_violations(tree, comments) == [1]
 
 
-@pytest.mark.parametrize("src,expected", [
-    # inside the body: every iteration completes its own element
-    ('for T in (\n    {"en": "e", "zh": "s"},\n    {"en": "e2", "zh": "s2"},\n):\n'
-     + '    T["zh-TW"] = "t"', []),
-    # after the loop: only whatever the last iteration left is completed
-    ('for T in (\n    {"en": "e", "zh": "s"},\n    {"en": "e2", "zh": "s2"},\n):\n'
-     + '    pass\nT["zh-TW"] = "t"', [2]),
-])
-def test_loop_closure_needs_the_backfill_inside_the_body(src, expected):
-    """Closing over the alternatives unconditionally excused the earlier elements."""
-    tree, comments = MOD._parse_source(src, "t.py")
-    assert MOD.find_violations(tree, comments) == expected
 
 
 @pytest.mark.parametrize("src,expected", [
@@ -2425,3 +2362,50 @@ def test_a_payload_may_be_an_assignment_expression(src, expected):
     """A walrus evaluates to the mapping it binds."""
     tree, comments = MOD._parse_source(src, "t.py")
     assert MOD.find_violations(tree, comments) == expected
+
+
+def test_popitem_is_out_of_scope():
+    """Which key it removes depends on the dict's insertion order.
+
+    Recording it as "everything is gone" reported a table that is compliant at
+    runtime, and modelling the order is the analysis this gate declines. Silence
+    is the accepted answer: the shape does not occur under config/prompts.
+    """
+    src = (
+        'T = {"en": "e", "zh": "s"}\nT["zh-TW"] = "t"\n'
+        + 'T["ja"] = "j"\nT.popitem()'
+    )
+    assert _violations(src) == []
+
+
+@pytest.mark.parametrize("src,expected", [
+    ('for T in ({"en": "e", "zh": "s"},):\n    T["zh-TW"] = "t"', [1]),
+    ('A = {"en": "e", "zh": "s"}\nB = {"en": "e2", "zh": "s2"}\n'
+     + 'for T in (A, B):\n    T["zh-TW"] = "t"', [1, 2]),
+])
+def test_loop_targets_are_out_of_scope(src, expected):
+    """Reading a `for` target needs the loop's iteration semantics.
+
+    Its bindings are alternatives, not a sequence, and only a backfill inside the
+    body reaches them all. Supporting it for one round produced two follow-up
+    defects — cross-target leakage and an after-the-loop backfill — so the gate
+    stops here. The shape does not occur under config/prompts, and what it costs
+    is one comment: see the next test.
+    """
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == expected
+
+
+@pytest.mark.parametrize("src", [
+    'for T in ({"en": "e", "zh": "s"},):  # noqa: PROMPT_ZH_TW\n    T["zh-TW"] = "t"',
+    'A = {"en": "e", "zh": "s"}  # noqa: PROMPT_ZH_TW\n'
+    + 'B = {"en": "e2", "zh": "s2"}  # noqa: PROMPT_ZH_TW\n'
+    + 'for T in (A, B):\n    T["zh-TW"] = "t"',
+])
+def test_the_escape_hatch_covers_what_is_out_of_scope(src):
+    """The hatch is the design, so it has to actually work on these shapes.
+
+    Documenting a limit without checking that the stated remedy applies would
+    leave whoever hits it with no way out.
+    """
+    assert _violations(src) == []

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -1415,3 +1415,29 @@ def test_exemption_covers_a_binding_mutated_on_the_same_line():
     src = 'T = {"en": "e", "zh": "s"}; T["zh-TW"] = "t"'
     tree, comments = MOD._parse_source(src, "t.py")
     assert MOD.find_violations(tree, comments) == []
+
+
+@pytest.mark.parametrize("src", [
+    'T: dict[str, str] = {"en": "e", "zh": "s"}\nT["zh-TW"] = "t"',
+    'T: dict = {"en": "e", "zh": "s"}\nT.update({"zh-TW": "t"})',
+    '_F: dict[str, str] = {"en": "e", "zh": "s"}\nT = {**_F, "zh-TW": "t"}',
+])
+def test_annotated_binding_is_exempt_too(src):
+    """An annotated assignment is still a binding.
+
+    Typed prompt constants are ordinary style; collecting only ast.Assign left
+    their tables unexempted and reported despite being compliant at runtime.
+    """
+    assert _violations(src) == []
+
+
+def test_annotated_binding_without_a_value_is_ignored():
+    """A bare `T: dict` declares nothing to exempt and must not crash."""
+    src = 'T: dict\nT2 = {"en": "e", "zh": "s"}'
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == [2]
+
+
+def test_annotated_offender_is_still_reported():
+    """The exemption is about mutations, not about annotations."""
+    assert _violations('T: dict[str, str] = {"en": "e", "zh": "s"}') == [1]

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -15,11 +15,12 @@
 
 """Unit tests for ``scripts/check_prompt_zh_tw.py``.
 
-Synthetic-source coverage of ``find_violations`` (the diff-aware core): which
-dict shapes count as a localized prompt table, the ratchet on the dict's own
-definition line, and noqa suppression. The git plumbing is exercised through
-``--base HEAD`` (empty diff -> exit 0) so CI smoke-tests the CLI path without
-depending on branch state.
+Two layers: which dict shapes count as a localized prompt table
+(``find_violations``), and what the signature ratchet does to a given
+base -> head transition (``signature_counter``). The ratchet layer needs no git
+because it compares two {path: source} mappings, so each scenario — added key,
+pure rename, copy edit — is expressed directly. The git plumbing is smoke-tested
+through ``--base HEAD`` (empty diff -> exit 0).
 """
 from __future__ import annotations
 
@@ -45,10 +46,17 @@ def _load_script_module():
 MOD = _load_script_module()
 
 
-def _violations(source: str, changed_lines: set[int] | None = None):
+def _violations(source: str):
     source = textwrap.dedent(source)
     tree = ast.parse(source)
-    return MOD.find_violations(tree, source.splitlines(), changed_lines)
+    return MOD.find_violations(tree, source.splitlines())
+
+
+def _added(base: dict[str, str], head: dict[str, str]):
+    """Signatures HEAD has more of than base — what the ratchet reports."""
+    base = {k: textwrap.dedent(v) for k, v in base.items()}
+    head = {k: textwrap.dedent(v) for k, v in head.items()}
+    return MOD.signature_counter(head) - MOD.signature_counter(base)
 
 
 # ---------------------------------------------------------------------------
@@ -66,6 +74,7 @@ def test_flags_en_plus_short_zh_without_traditional():
     out = _violations(src)
     assert len(out) == 1
     assert out[0][0] == 2
+    assert out[0][1] == frozenset({"zh", "en"})
 
 
 def test_flags_en_plus_full_zh_cn_without_traditional():
@@ -140,57 +149,125 @@ def test_flags_nested_and_multiple_tables():
     assert [lineno for lineno, _ in out] == [3, 7]
 
 
-def test_reports_present_keys_in_message():
-    src = '''
-    TABLE = {"zh": "a", "en": "b", "ja": "c"}
-    '''
-    out = _violations(src)
-    assert out[0][1] == "en, ja, zh"
-
-
 # ---------------------------------------------------------------------------
-# The ratchet
+# The signature ratchet
 # ---------------------------------------------------------------------------
 
 
-def test_ratchet_reports_dict_whose_definition_line_changed():
-    src = '''
-    TABLE = {
-        "zh": "简体",
-        "en": "english",
-    }
-    '''
-    assert len(_violations(src, changed_lines={2})) == 1
+def test_ratchet_flags_a_brand_new_table():
+    added = _added({"a.py": ""}, {"a.py": 'T = {"en": "x", "zh": "y"}'})
+    assert sum(added.values()) == 1
 
 
-def test_ratchet_exempts_dict_whose_definition_line_is_untouched():
-    """Editing a table's copy must not trip the gate — only new tables do.
+def test_ratchet_flags_table_that_becomes_localized_via_added_key():
+    """A pre-existing en/ja table gaining a 'zh' key must be caught.
 
-    Line 3 is inside the dict but is not its definition line, which is what
-    keeps a copy edit on an existing table from being reported.
+    This is the case a line-based ratchet misses: the dict's definition line is
+    unchanged, only a member line is added. It is also the likeliest way for the
+    backlog to grow, so missing it would defeat the gate.
+    """
+    base = {"a.py": 'T = {"en": "x", "ja": "y"}'}
+    head = {"a.py": 'T = {"en": "x", "ja": "y", "zh": "z"}'}
+    added = _added(base, head)
+    assert sum(added.values()) == 1
+    assert frozenset({"en", "ja", "zh"}) in added
+
+
+def test_ratchet_ignores_a_pure_rename():
+    """Renaming a prompt module with no content change reports nothing.
+
+    A line-based ratchet counts every line of the new path as added and would
+    report the file's whole existing backlog.
     """
     src = '''
-    TABLE = {
+    T = {
         "zh": "简体",
         "en": "english",
     }
     '''
-    assert _violations(src, changed_lines={3, 4}) == []
+    assert not _added({"old_name.py": src}, {"new_name.py": src})
 
 
-def test_ratchet_empty_changed_set_reports_nothing():
-    src = '''
-    TABLE = {"zh": "a", "en": "b"}
-    '''
-    assert _violations(src, changed_lines=set()) == []
+def test_ratchet_ignores_a_copy_edit():
+    """Editing an existing table's text must not trip the gate."""
+    base = {"a.py": 'T = {"en": "old copy", "zh": "旧文案"}'}
+    head = {"a.py": 'T = {"en": "new copy", "zh": "新文案"}'}
+    assert not _added(base, head)
 
 
-def test_none_changed_lines_scans_everything():
-    """None means full scan, which is how --full and --count behave."""
-    src = '''
-    TABLE = {"zh": "a", "en": "b"}
-    '''
-    assert len(_violations(src, changed_lines=None)) == 1
+def test_ratchet_ignores_adding_traditional_to_an_existing_table():
+    """Backfilling zh-TW removes an offender; nothing is reported as added."""
+    base = {"a.py": 'T = {"en": "x", "zh": "y"}'}
+    head = {"a.py": 'T = {"en": "x", "zh": "y", "zh-TW": "z"}'}
+    assert not _added(base, head)
+
+
+def test_ratchet_counts_multiplicity_not_just_presence():
+    """Two new tables sharing one key set still count as two."""
+    base = {"a.py": 'A = {"en": "x", "zh": "y"}'}
+    head = {
+        "a.py": 'A = {"en": "x", "zh": "y"}',
+        "b.py": 'B = {"en": "p", "zh": "q"}\nC = {"en": "r", "zh": "s"}',
+    }
+    added = _added(base, head)
+    assert sum(added.values()) == 2
+    assert added[frozenset({"en", "zh"})] == 2
+
+
+def test_ratchet_documented_blind_spot_nets_to_zero():
+    """Removing one offender while adding another with the same key set passes.
+
+    Pinned deliberately: the script's docstring calls this out as an accepted
+    tradeoff, because the alternative is matching dicts across revisions by
+    position, which breaks on any reformat. Closing it would need a different
+    identity scheme, not a tweak.
+    """
+    base = {"a.py": 'A = {"en": "x", "zh": "y"}'}
+    head = {"b.py": 'B = {"en": "p", "zh": "q"}'}
+    assert not _added(base, head)
+
+
+# ---------------------------------------------------------------------------
+# Locating the offender for the error message
+# ---------------------------------------------------------------------------
+
+
+_TWO_TABLES = {
+    "new.py": 'NEW = {\n    "en": "a",\n    "zh": "b",\n}',
+    "old.py": 'OLD = {\n    "en": "c",\n    "zh": "d",\n}',
+}
+_EN_ZH = frozenset({"en", "zh"})
+
+
+def test_locate_narrows_to_tables_the_diff_touched():
+    """Common key sets match many tables, so the message needs the touched one.
+
+    Without this, a failure on the {en, zh} signature lists every pre-existing
+    table sharing it and the developer has to guess which one is theirs.
+    """
+    likely, other = MOD.locate(_TWO_TABLES, _EN_ZH, {"new.py": {2}})
+    assert likely == ["new.py:1"]
+    assert other == 1
+
+
+def test_locate_matches_anywhere_in_the_dict_body():
+    """A key added on the dict's last line still identifies that dict."""
+    likely, _ = MOD.locate(_TWO_TABLES, _EN_ZH, {"new.py": {3}})
+    assert likely == ["new.py:1"]
+
+
+def test_locate_without_hints_reports_everything_as_pre_existing():
+    likely, other = MOD.locate(_TWO_TABLES, _EN_ZH, None)
+    assert likely == []
+    assert other == 2
+
+
+def test_locate_hint_outside_any_table_body_is_ignored():
+    """Touching an unrelated line must not mislabel a table as the new one."""
+    sources = {"a.py": 'X = 1\n\nT = {\n    "en": "a",\n    "zh": "b",\n}'}
+    likely, other = MOD.locate(sources, _EN_ZH, {"a.py": {1}})
+    assert likely == []
+    assert other == 1
 
 
 # ---------------------------------------------------------------------------
@@ -230,6 +307,96 @@ def test_noqa_on_an_inner_line_does_not_suppress():
 
 
 # ---------------------------------------------------------------------------
+# File discovery
+# ---------------------------------------------------------------------------
+
+
+def test_sources_on_disk_includes_subpackages(tmp_path, monkeypatch):
+    """--full / --count must not stop at the top level of config/prompts.
+
+    Diff mode selects files with `git ls-tree -r`, so a top-level-only glob here
+    would make the two modes disagree about what a prompt module is.
+    """
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "top.py").write_text('T = {"en": "a", "zh": "b"}', encoding="utf-8")
+    (tmp_path / "sub" / "nested.py").write_text(
+        'N = {"en": "c", "zh": "d"}', encoding="utf-8"
+    )
+    (tmp_path / "notes.txt").write_text("ignored", encoding="utf-8")
+    monkeypatch.setattr(MOD, "PROMPTS_DIR", tmp_path)
+    monkeypatch.setattr(MOD, "REPO_ROOT", tmp_path)
+
+    sources = MOD._sources_on_disk()
+    assert set(sources) == {"top.py", "sub/nested.py"}
+    assert sum(MOD.signature_counter(sources).values()) == 2
+
+
+# ---------------------------------------------------------------------------
+# main() — the ratchet's actual call site
+# ---------------------------------------------------------------------------
+
+
+def _stub_revisions(monkeypatch, base_src: dict[str, str], head_src: dict[str, str],
+                    touched: dict[str, set[int]] | None = None):
+    """Point main() at two synthetic revisions instead of git."""
+    monkeypatch.setattr(MOD, "_merge_base", lambda base: "BASE_SHA")
+    monkeypatch.setattr(MOD, "_sources_at", lambda rev: base_src)
+    monkeypatch.setattr(MOD, "_sources_on_disk", lambda: head_src)
+    monkeypatch.setattr(MOD, "_touched_lines", lambda rev: touched or {})
+
+
+def test_main_fails_when_head_gained_an_offender(monkeypatch, capsys):
+    """Covers the subtraction direction in main(), not just the helper.
+
+    Asserting on signature_counter alone lets `head - base` silently become
+    `base - head`, which never reports anything and disables the gate.
+    """
+    _stub_revisions(
+        monkeypatch,
+        {"a.py": 'T = {"en": "x", "ja": "y"}'},
+        {"a.py": 'T = {"en": "x", "ja": "y", "zh": "z"}'},
+        {"a.py": {1}},
+    )
+    assert MOD.main(["--base", "irrelevant"]) == 1
+    out = capsys.readouterr().out
+    assert "a.py:1" in out
+
+
+def test_main_passes_when_head_backfilled_an_offender(monkeypatch):
+    """The reverse transition must pass — removing an offender is the goal."""
+    _stub_revisions(
+        monkeypatch,
+        {"a.py": 'T = {"en": "x", "zh": "y"}'},
+        {"a.py": 'T = {"en": "x", "zh": "y", "zh-TW": "z"}'},
+    )
+    assert MOD.main(["--base", "irrelevant"]) == 0
+
+
+def test_main_passes_on_an_unchanged_tree(monkeypatch):
+    src = {"a.py": 'T = {"en": "x", "zh": "y"}'}
+    _stub_revisions(monkeypatch, src, src)
+    assert MOD.main(["--base", "irrelevant"]) == 0
+
+
+def test_touched_lines_asks_git_for_rename_detection(monkeypatch):
+    """`-M` is load-bearing: without it a rename marks every line as added.
+
+    The pass/fail decision would still be right (signatures are unaffected), but
+    the reported location would point at the whole renamed file.
+    """
+    seen: list[tuple[str, ...]] = []
+
+    def fake_git(*args: str) -> str:
+        seen.append(args)
+        return ""
+
+    monkeypatch.setattr(MOD, "_git", fake_git)
+    MOD._touched_lines("BASE_SHA")
+    assert seen, "no git invocation recorded"
+    assert "-M" in seen[0], seen[0]
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -242,7 +409,7 @@ def _run(*args: str) -> subprocess.CompletedProcess:
 
 
 def test_cli_against_head_is_clean():
-    """--base HEAD is an empty diff, so the ratchet has nothing to report."""
+    """--base HEAD compares HEAD to itself, so nothing is newly added."""
     result = _run("--base", "HEAD")
     assert result.returncode == 0, result.stdout + result.stderr
 
@@ -253,8 +420,8 @@ def test_cli_count_reports_backlog_and_exits_zero():
     assert "missing 'zh-TW'" in result.stdout
 
 
-def test_repo_backlog_is_nonempty_and_shrinking_is_the_goal():
-    """Guards the scanner itself: if this hits 0, the scan silently broke.
+def test_repo_backlog_is_nonempty():
+    """Guards the scanner itself: if this hits 0, detection silently broke.
 
     The issue #2500 backlog is large. A zero here means the detector stopped
     matching, not that the work finished — when the backfill genuinely lands,

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -2358,3 +2358,20 @@ def test_loop_alternatives_are_only_closed_over_when_one_is_exempt():
     )
     tree, comments = MOD._parse_source(src, "t.py")
     assert MOD.find_violations(tree, comments) == [2, 3]
+
+
+def test_loop_alternatives_are_grouped_per_target():
+    """`for T, U in ((a, b), (c, d))` makes a/c alternatives of T, b/d of U.
+
+    Pooling every value the loop binds would let a backfill through one target
+    excuse the tables bound to the other.
+    """
+    src = (
+        "for T, U in (\n"
+        '    ({"en": "e", "zh": "s"}, {"en": "e2", "zh": "s2"}),\n'
+        '    ({"en": "e3", "zh": "s3"}, {"en": "e4", "zh": "s4"}),\n'
+        "):\n"
+        '    T["zh-TW"] = "t"'
+    )
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == [2, 3]

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -1928,3 +1928,46 @@ def test_generator_of_non_pairs_is_not_treated_as_a_mapping():
     """
     src = 'T = dict((loc, x, y) for loc, x, y in (("en", 1, 2), ("zh", 3, 4)))'
     assert _violations(src) == []
+
+
+@pytest.mark.parametrize("src", [
+    'F = {"en": "e", "zh": "s"}\nF2 = F\nT = {**F2, "zh-TW": "t"}',
+    'F = {"en": "e", "zh": "s"}\nF2 = F\nF3 = F2\nT = {**F3, "zh-TW": "t"}',
+    'F = {"en": "e", "zh": "s"}\nF2 = dict(F)\nT = {**F2, "zh-TW": "t"}',
+])
+def test_exemption_follows_aliases_to_the_table_it_lands_on(src):
+    """Exempting the binding's own value node exempts the wrong thing.
+
+    For `F2 = F` that value is a bare Name; the literal bound to F is the node
+    actually judged, so it stayed subject to the rule and a compliant table still
+    grew the count.
+    """
+    assert _violations(src) == []
+
+
+def test_alias_chain_is_not_a_back_door_for_exemption():
+    """Following names must still only exempt what the merge demonstrably completes."""
+    src = 'X = {"ja": "j"}\nX2 = X\nF = {"en": "e", "zh": "s"}\nT = {**F, **X2}'
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == [3]
+
+
+@pytest.mark.parametrize("src", [
+    'T = {"en": "e", "zh": "s"}\nT = T | {"zh-TW": "t"}',
+    'T = {"en": "e", "zh": "s"}\nT = (T | {"zh-TW": "t"}) if flag else (T | {"zh-TW": "u"})',
+    'T = {"en": "e", "zh": "s"}\nT = dict(T | {"zh-TW": "t"})',
+])
+def test_self_rebinding_is_recognized_through_any_wrapper(src):
+    """The registered binding is the whole right-hand side, not the merge inside it.
+
+    Excluding the merge node by identity worked only when it *was* the right-hand
+    side; wrap it in anything and each `T` resolved to the assignment being
+    evaluated instead of the table it reads.
+    """
+    assert _violations(src) == []
+
+
+def test_rebinding_that_does_not_supply_zh_tw_still_reports():
+    src = 'T = {"en": "e", "zh": "s"}\nT = T | {"ja": "j"}'
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == [1]

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -1600,3 +1600,48 @@ def test_self_rebinding_exempts_the_previous_binding(src):
     line search picked the merge's own result and left the first literal reported.
     """
     assert _violations(src) == []
+
+
+@pytest.mark.parametrize("src", [
+    'T = {"zh-TW": "t"}\nT.update({"en": "e", "zh": "s"})',
+    'T = {"zh-TW": "t"}\nT.update(**{"en": "e", "zh": "s"})',
+])
+def test_both_update_argument_forms_are_fragments(src):
+    """`update({...})` and `update(**{...})` are the same merge.
+
+    The operand lookup required a positional argument, so the keyword-spread
+    payload was judged standalone and reported despite the target carrying zh-TW.
+    """
+    assert _violations(src) == []
+
+
+def test_update_with_no_arguments_does_not_crash():
+    assert _violations("T.update()") == []
+
+
+@pytest.mark.parametrize("src,expected", [
+    ('T = {"en": "e", "zh": "s"}\nT["zh-TW"]: str = "t"', []),
+    ('T = {"en": "e", "zh": "s"}\nT["ja"]: str = "j"', [1]),
+])
+def test_annotated_subscript_backfill(src, expected):
+    """`T["zh-TW"]: str = t` is the same mutation with an annotation.
+
+    AnnAssign carries a single `target` instead of a `targets` list, so matching
+    the subscript shape needs its own unpacking.
+    """
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == expected
+
+
+def test_lone_cr_module_keeps_comments_on_their_own_lines():
+    """A CR-only module must not shift noqa onto a neighbouring table.
+
+    io.StringIO does not treat a lone \r as a newline, so tokenize saw one line
+    while the split saw two — the comment landed on index 0, suppressing the table
+    that has no noqa and reporting the one that does. Exactly backwards.
+    """
+    src = 'A = {"en": 1, "zh": 2}\rB = {"en": 1, "zh": 3}  # noqa: PROMPT_ZH_TW'
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert comments[0] == ""
+    assert "PROMPT_ZH_TW" in comments[1]
+    assert MOD.find_violations(tree, comments) == [1]

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -1829,3 +1829,102 @@ def test_independent_table_inside_a_conditional_operand_is_still_judged():
     src = 'T = {**(A if flag else {"new": {"en": "e", "zh": "s"}}), "zh-TW": "t"}'
     tree, comments = MOD._parse_source(src, "t.py")
     assert MOD.find_violations(tree, comments) == [1]
+
+
+@pytest.mark.parametrize("src", [
+    'F = {"en": "e", "zh": "s"}\nT = {**dict(F), "zh-TW": "t"}',
+    'F = {"en": "e", "zh": "s"}\nT = {**(dict(F) | {}), "zh-TW": "t"}',
+])
+def test_named_fragment_is_exempt_through_a_nested_merge(src):
+    """`{**dict(_F), "zh-TW": t}` wraps the fragment `{**_F, "zh-TW": t}` names.
+
+    Stopping at the outer Call reported _F for a table that is compliant either way
+    it is written.
+    """
+    assert _violations(src) == []
+
+
+def test_nested_merge_without_zh_tw_still_reports_the_fragment():
+    src = 'F = {"en": "e", "zh": "s"}\nT = {**dict(F), "ja": "j"}'
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == [1]
+
+
+def test_alias_resolves_against_the_binding_it_captured():
+    """An alias holds the object bound *then*, not whatever the name means later.
+
+    Carrying the use site's line through every hop read `ALIAS` against a later
+    rebinding of its source and exempted a table that really is missing zh-TW —
+    a miss, and the one direction this exemption must never produce.
+    """
+    src = (
+        "P = {}\n"
+        "ALIAS = P\n"
+        'P = {"zh-TW": "t"}\n'
+        'T = {"en": "e", "zh": "s"}\n'
+        "T.update(ALIAS)"
+    )
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == [4]
+
+
+def test_alias_to_a_traditional_binding_still_exempts():
+    src = (
+        'P = {"zh-TW": "t"}\n'
+        "ALIAS = P\n"
+        'T = {"en": "e", "zh": "s"}\n'
+        "T.update(ALIAS)"
+    )
+    assert _violations(src) == []
+
+
+@pytest.mark.parametrize("src,expected", [
+    ('T = {k: v for k, v in ((None, d), ("en", e), ("zh", s))}', [1]),
+    ('T = {k: v for k, v in ((None, d), ("en", e), ("zh", s), ("zh-TW", t))}', []),
+])
+def test_pair_comprehension_skips_constant_non_string_keys(src, expected):
+    """A sentinel like `(None, default)` cannot be hiding zh-TW.
+
+    Abandoning the whole comprehension over one made the table unknowable and let
+    a real offender through — while the dict-literal and iterable-of-pairs paths
+    had skipped the same kind of item all along.
+    """
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == expected
+
+
+@pytest.mark.parametrize("src,expected", [
+    ('T = dict((loc, build(loc)) for loc in ("en", "zh"))', [1]),
+    ('T = dict((loc, build(loc)) for loc in ("en", "zh", "zh-TW"))', []),
+    ('T = dict((k, v) for k, v in (("en", e), ("zh", s)))', [1]),
+])
+def test_generator_constructor_resolves_like_the_comprehension(src, expected):
+    """`dict((loc, v) for loc in ...)` is a dict comprehension in other syntax.
+
+    Resolving one spelling and not the other is the kind of near-miss a gate gets
+    worked around by, so both go through `_comprehension_keys`.
+    """
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == expected
+
+
+def test_documented_blind_spot_individually_innocent_fragments():
+    """Pinned so a change here is deliberate — see the module docstring.
+
+    Judging the result would mean following names from `_table_nodes`, the reverse
+    of the union-style resolution used for the supply question: over-approximating
+    is safe there and unsafe here. Zero `NAME | NAME` merges exist under
+    config/prompts, and the shape is strictly more verbose than one dict.
+    """
+    src = 'EN = {"en": "e"}\nZH = {"zh": "s"}\nT = EN | ZH'
+    assert _violations(src) == []
+
+
+def test_generator_of_non_pairs_is_not_treated_as_a_mapping():
+    """`dict(<3-tuples>)` is a TypeError, not a table with knowable keys.
+
+    Reading the first two slots of a wider tuple would have the gate claim to know
+    the keys of something that is not a mapping at all.
+    """
+    src = 'T = dict((loc, x, y) for loc, x, y in (("en", 1, 2), ("zh", 3, 4)))'
+    assert _violations(src) == []

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -1236,3 +1236,52 @@ def test_failure_message_mentions_both_noqa_positions():
     """
     source = pathlib.Path(SCRIPT_PATH).read_text(encoding="utf-8")
     assert "opening or closing line if it genuinely does not need one" in source
+
+
+@pytest.mark.parametrize("src", [
+    'T = {"zh-TW": "t"}\nT.update({"en": "e", "zh": "s"})',
+    'T = {"zh-TW": "t"}\nT |= {"en": "e", "zh": "s"}',
+    'OTHER.update({"en": "e", "zh": "s"})',
+])
+def test_mutation_payload_is_a_fragment(src):
+    """An `update()` / `|=` payload alone says nothing about the assembled table.
+
+    Whether the result has zh-TW depends on the target, which the payload
+    expression does not show — so judging it standalone reports tables that are
+    compliant at runtime.
+    """
+    assert _violations(src) == []
+
+
+@pytest.mark.parametrize("src", [
+    'T = {"en": "e", "zh": "s"}\nT.update({"zh-TW": "t"})',
+    'T = {"en": "e", "zh": "s"}\nT["zh-TW"] = "t"',
+    'T = {"en": "e", "zh": "s"}\nT |= {"zh-TW": "t"}',
+])
+def test_table_backfilled_by_a_later_mutation_is_exempt(src):
+    """The other direction: a mutation that supplies zh-TW makes the table fine."""
+    assert _violations(src) == []
+
+
+@pytest.mark.parametrize("src", [
+    'T = {"en": "e", "zh": "s"}\nT["other"] = "x"',
+    'T = {"en": "e", "zh": "s"}\nT.update({"ja": "j"})',
+    'T = {"en": "e", "zh": "s"}\nT |= {"ja": "j"}',
+])
+def test_unrelated_mutation_does_not_exempt_the_table(src):
+    """Exemption is keyed on zh-TW actually being supplied.
+
+    Exempting on any mutation would let `T["other"] = x` excuse a real offender —
+    trading one rare false positive for a broad blind spot.
+    """
+    assert _violations(src) == [1]
+
+
+def test_backfill_exemption_is_per_name():
+    """Only the mutated name is exempt; a sibling table is still judged."""
+    src = (
+        'A = {"en": "e", "zh": "s"}\n'
+        'B = {"en": "x", "zh": "y"}\n'
+        'A["zh-TW"] = "t"'
+    )
+    assert MOD.find_violations(ast.parse(src), src.splitlines()) == [2]

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import ast
 import importlib.util
+import pathlib
 import subprocess
 import sys
 import textwrap
@@ -1198,3 +1199,40 @@ def test_non_constant_element_in_a_key_sequence_abandons_the_table(src):
     a false positive on code that is actually fine.
     """
     assert _violations(src) == []
+
+
+def test_git_visible_prompt_files_returns_none_when_git_is_missing(monkeypatch):
+    """git absent from PATH raises rather than returning nonzero.
+
+    A missing git is one of the two cases this fallback exists for, so letting
+    FileNotFoundError escape would crash --count/--full in exactly the environment
+    the fallback was written for.
+    """
+    def boom(*_args, **_kwargs):
+        raise FileNotFoundError(2, "No such file or directory", "git")
+
+    monkeypatch.setattr(MOD.subprocess, "run", boom)
+    assert MOD._git_visible_prompt_files() is None
+
+
+def test_cli_description_matches_the_implemented_ratchet():
+    """--help must not advertise a judgement the gate no longer uses.
+
+    The ratchet went through signature-based and scheme-based forms before landing
+    on a plain offender count; stale help text sends a reader looking for logic
+    that is not there.
+    """
+    result = _run("--help")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "signature ratchet" not in result.stdout
+    assert "offender-count ratchet" in result.stdout
+
+
+def test_failure_message_mentions_both_noqa_positions():
+    """The message must describe the suppression the gate actually accepts.
+
+    Suppression works on the opening *or* closing line; telling authors only about
+    the opening line makes a correct `}  # noqa: PROMPT_ZH_TW` look like a mistake.
+    """
+    source = pathlib.Path(SCRIPT_PATH).read_text(encoding="utf-8")
+    assert "opening or closing line if it genuinely does not need one" in source

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -50,9 +50,11 @@ MOD = _load_script_module()
 
 
 def _violations(source: str):
+    """Run the real parse path so noqa comes from comments, not raw lines."""
     source = textwrap.dedent(source)
-    tree = ast.parse(source)
-    return MOD.find_violations(tree, source.splitlines())
+    tree, comments = MOD._parse_source(source, 'test.py')
+    assert tree is not None
+    return MOD.find_violations(tree, comments)
 
 
 def _grew(base: dict[str, str], head: dict[str, str]) -> int:
@@ -1285,3 +1287,66 @@ def test_backfill_exemption_is_per_name():
         'A["zh-TW"] = "t"'
     )
     assert MOD.find_violations(ast.parse(src), src.splitlines()) == [2]
+
+
+@pytest.mark.parametrize("src", [
+    '_FRAGMENT = {"en": "e", "zh": "s"}\nT = {**_FRAGMENT, "zh-TW": "t"}',
+    '_F = {"en": "e", "zh": "s"}\nT = _F | {"zh-TW": "t"}',
+    '_F = {"en": "e", "zh": "s"}\nT = dict(_F, **{"zh-TW": "t"})',
+])
+def test_named_merge_input_is_a_fragment(src):
+    """A name used as a merge operand is a fragment, same as an inline literal.
+
+    The assembled table is compliant, so reporting the named half is a false
+    positive — and false positives are what get a gate worked around.
+    """
+    assert _violations(src) == []
+
+
+def test_named_fragment_exemption_is_per_name():
+    """Only the name actually merged is exempt."""
+    src = (
+        'A = {"en": "e", "zh": "s"}\n'
+        'B = {"en": "x", "zh": "y"}\n'
+        'T = {**A, "zh-TW": "t"}'
+    )
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == [2]
+
+
+def test_noqa_inside_a_string_literal_is_not_a_directive():
+    """Template text that happens to read like a directive must not suppress.
+
+    A multiline value whose first line ends with `# noqa: PROMPT_ZH_TW` sits on
+    the dict's opening line, so a raw-line scan exempted the table it belongs to.
+    """
+    src = 'T = {"en": """# noqa: PROMPT_ZH_TW\nmore text""", "zh": "s"}'
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == [1]
+
+
+def test_real_comment_still_suppresses_after_the_token_switch():
+    """The token-based lookup must not break ordinary suppression."""
+    for src in (
+        'T = {"en": "e", "zh": "s"}  # noqa: PROMPT_ZH_TW',
+        'T = {\n    "en": "e",\n    "zh": "s",\n}  # noqa: PROMPT_ZH_TW',
+        'T = {  # noqa: PROMPT_ZH_TW\n    "en": "e",\n    "zh": "s",\n}',
+    ):
+        tree, comments = MOD._parse_source(src, "t.py")
+        assert MOD.find_violations(tree, comments) == [], src
+
+
+def test_comment_lines_align_with_source_lines():
+    """The comment list is indexed by line, so lookups cannot drift."""
+    src = 'a = 1\nT = {"en": "e", "zh": "s"}  # noqa: PROMPT_ZH_TW\nb = 2  # other'
+    comments = MOD._comment_lines(src)
+    assert len(comments) == 3
+    assert comments[0] == ""
+    assert "PROMPT_ZH_TW" in comments[1]
+    assert comments[2] == "# other"
+
+
+def test_comment_lines_on_unparseable_source_suppresses_nothing():
+    """A tokenize failure must not hand back stale or wrong suppression."""
+    comments = MOD._comment_lines('T = {"en": "e"  # noqa: PROMPT_ZH_TW\n')
+    assert all(c == "" for c in comments), comments

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -16,8 +16,8 @@
 """Unit tests for ``scripts/check_prompt_zh_tw.py``.
 
 Two layers: which dict shapes count as a localized prompt table
-(``find_violations``), and what the signature ratchet does to a given
-base -> head transition (``signature_counter``). The ratchet layer needs no git
+(``find_violations``), and what the count ratchet does to a given
+base -> head transition (``count_offenders``). The ratchet layer needs no git
 because it compares two {path: source} mappings, so each scenario — added key,
 pure rename, copy edit — is expressed directly. The git plumbing is smoke-tested
 through ``--base HEAD`` (empty diff -> exit 0).
@@ -52,11 +52,11 @@ def _violations(source: str):
     return MOD.find_violations(tree, source.splitlines())
 
 
-def _added(base: dict[str, str], head: dict[str, str]):
-    """Signatures HEAD has more of than base — what the ratchet reports."""
+def _grew(base: dict[str, str], head: dict[str, str]) -> int:
+    """How many more offenders HEAD has than base — the ratchet decision."""
     base = {k: textwrap.dedent(v) for k, v in base.items()}
     head = {k: textwrap.dedent(v) for k, v in head.items()}
-    return MOD.signature_counter(head) - MOD.signature_counter(base)
+    return MOD.count_offenders(head) - MOD.count_offenders(base)
 
 
 # ---------------------------------------------------------------------------
@@ -73,8 +73,7 @@ def test_flags_en_plus_short_zh_without_traditional():
     '''
     out = _violations(src)
     assert len(out) == 1
-    assert out[0][0] == 2
-    assert out[0][1] == "zh"
+    assert out == [2]
 
 
 def test_flags_en_plus_full_zh_cn_without_traditional():
@@ -132,9 +131,7 @@ def test_ignores_non_string_keys():
 
 def test_flags_dict_constructor_call():
     """`dict(en=..., zh=...)` has the same runtime shape and the same problem."""
-    out = _violations('TABLE = dict(en="english", zh="简体")')
-    assert len(out) == 1
-    assert out[0][1] == "zh"
+    assert _violations('TABLE = dict(en="english", zh="简体")') == [1]
 
 
 def test_ignores_dict_constructor_with_unpacking():
@@ -167,17 +164,16 @@ def test_flags_nested_and_multiple_tables():
     '''
     out = _violations(src)
     assert len(out) == 2, out
-    assert [lineno for lineno, _ in out] == [3, 7]
+    assert out == [3, 7]
 
 
 # ---------------------------------------------------------------------------
-# The signature ratchet
+# The count ratchet
 # ---------------------------------------------------------------------------
 
 
 def test_ratchet_flags_a_brand_new_table():
-    added = _added({"a.py": ""}, {"a.py": 'T = {"en": "x", "zh": "y"}'})
-    assert sum(added.values()) == 1
+    assert _grew({"a.py": ""}, {"a.py": 'T = {"en": "x", "zh": "y"}'}) == 1
 
 
 def test_ratchet_flags_table_that_becomes_localized_via_added_key():
@@ -189,9 +185,7 @@ def test_ratchet_flags_table_that_becomes_localized_via_added_key():
     """
     base = {"a.py": 'T = {"en": "x", "ja": "y"}'}
     head = {"a.py": 'T = {"en": "x", "ja": "y", "zh": "z"}'}
-    added = _added(base, head)
-    assert sum(added.values()) == 1
-    assert "zh" in added
+    assert _grew(base, head) == 1
 
 
 def test_ratchet_ignores_adding_an_unrelated_locale():
@@ -203,18 +197,45 @@ def test_ratchet_ignores_adding_an_unrelated_locale():
     """
     base = {"a.py": 'T = {"en": "x", "zh": "y"}'}
     head = {"a.py": 'T = {"en": "x", "zh": "y", "fr": "z"}'}
-    assert not _added(base, head)
+    assert _grew(base, head) <= 0
 
 
-def test_ratchet_keeps_the_two_key_schemes_separate():
-    """A new zh-CN-scheme table is not offset by an existing zh-scheme one."""
+def test_ratchet_flags_a_new_table_under_either_scheme():
+    """A new zh-CN-scheme offender counts, same as a zh-scheme one."""
     base = {"a.py": 'A = {"en": "x", "zh": "y"}'}
     head = {
         "a.py": 'A = {"en": "x", "zh": "y"}',
         "b.py": 'B = {"en": "p", "zh-CN": "q"}',
     }
-    added = _added(base, head)
-    assert dict(added) == {"zh-CN": 1}
+    assert _grew(base, head) == 1
+
+
+def test_ratchet_ignores_a_scheme_migration():
+    """Renaming an offender's key from 'zh' to 'zh-CN' did not grow the backlog.
+
+    This is why the ratchet counts a plain total. Counting the two schemes
+    separately made a migration read as one scheme losing a table and the other
+    gaining one, and Counter subtraction keeps only the positive side — reporting
+    growth that never happened.
+    """
+    base = {"a.py": 'T = {"en": "x", "zh": "y"}'}
+    head = {"a.py": 'T = {"en": "x", "zh-CN": "y"}'}
+    assert _grew(base, head) == 0
+
+
+def test_ratchet_ignores_a_bulk_scheme_migration():
+    """issue #2500's endgame renames 'zh' to 'zh-CN' across every table.
+
+    A gate that failed on that would be blocking the migration it exists to
+    serve, so this pins the whole-file case, not just one table.
+    """
+    base = {"a.py": "\n".join(
+        f'T{i} = {{"en": "x", "zh": "y{i}"}}' for i in range(5)
+    )}
+    head = {"a.py": "\n".join(
+        f'T{i} = {{"en": "x", "zh-CN": "y{i}"}}' for i in range(5)
+    )}
+    assert _grew(base, head) == 0
 
 
 def test_ratchet_ignores_a_pure_rename():
@@ -229,37 +250,35 @@ def test_ratchet_ignores_a_pure_rename():
         "en": "english",
     }
     '''
-    assert not _added({"old_name.py": src}, {"new_name.py": src})
+    assert _grew({"old_name.py": src}, {"new_name.py": src}) == 0
 
 
 def test_ratchet_ignores_a_copy_edit():
     """Editing an existing table's text must not trip the gate."""
     base = {"a.py": 'T = {"en": "old copy", "zh": "旧文案"}'}
     head = {"a.py": 'T = {"en": "new copy", "zh": "新文案"}'}
-    assert not _added(base, head)
+    assert _grew(base, head) <= 0
 
 
 def test_ratchet_ignores_adding_traditional_to_an_existing_table():
     """Backfilling zh-TW removes an offender; nothing is reported as added."""
     base = {"a.py": 'T = {"en": "x", "zh": "y"}'}
     head = {"a.py": 'T = {"en": "x", "zh": "y", "zh-TW": "z"}'}
-    assert not _added(base, head)
+    assert _grew(base, head) <= 0
 
 
 def test_ratchet_counts_multiplicity_not_just_presence():
-    """Two new tables sharing one key set still count as two."""
+    """Two new offenders raise the total by two, not by one."""
     base = {"a.py": 'A = {"en": "x", "zh": "y"}'}
     head = {
         "a.py": 'A = {"en": "x", "zh": "y"}',
         "b.py": 'B = {"en": "p", "zh": "q"}\nC = {"en": "r", "zh": "s"}',
     }
-    added = _added(base, head)
-    assert sum(added.values()) == 2
-    assert added["zh"] == 2
+    assert _grew(base, head) == 2
 
 
 def test_ratchet_documented_blind_spot_nets_to_zero():
-    """Removing one offender while adding another with the same key set passes.
+    """Removing one offender while adding another nets to zero and passes.
 
     Pinned deliberately: the script's docstring calls this out as an accepted
     tradeoff, because the alternative is matching dicts across revisions by
@@ -268,7 +287,7 @@ def test_ratchet_documented_blind_spot_nets_to_zero():
     """
     base = {"a.py": 'A = {"en": "x", "zh": "y"}'}
     head = {"b.py": 'B = {"en": "p", "zh": "q"}'}
-    assert not _added(base, head)
+    assert _grew(base, head) <= 0
 
 
 # ---------------------------------------------------------------------------
@@ -280,28 +299,27 @@ _TWO_TABLES = {
     "new.py": 'NEW = {\n    "en": "a",\n    "zh": "b",\n}',
     "old.py": 'OLD = {\n    "en": "c",\n    "zh": "d",\n}',
 }
-_EN_ZH = "zh"
 
 
 def test_locate_narrows_to_tables_the_diff_touched():
-    """Common key sets match many tables, so the message needs the touched one.
+    """A bare total says nothing about where, so the message needs the touched one.
 
     Without this, a failure on the {en, zh} signature lists every pre-existing
     table sharing it and the developer has to guess which one is theirs.
     """
-    likely, other = MOD.locate(_TWO_TABLES, _EN_ZH, {"new.py": {2}})
+    likely, other = MOD.locate_touched(_TWO_TABLES, {"new.py": {2}})
     assert likely == ["new.py:1"]
     assert other == 1
 
 
 def test_locate_matches_anywhere_in_the_dict_body():
     """A key added on the dict's last line still identifies that dict."""
-    likely, _ = MOD.locate(_TWO_TABLES, _EN_ZH, {"new.py": {3}})
+    likely, _ = MOD.locate_touched(_TWO_TABLES, {"new.py": {3}})
     assert likely == ["new.py:1"]
 
 
 def test_locate_without_hints_reports_everything_as_pre_existing():
-    likely, other = MOD.locate(_TWO_TABLES, _EN_ZH, None)
+    likely, other = MOD.locate_touched(_TWO_TABLES, None)
     assert likely == []
     assert other == 2
 
@@ -309,7 +327,7 @@ def test_locate_without_hints_reports_everything_as_pre_existing():
 def test_locate_hint_outside_any_table_body_is_ignored():
     """Touching an unrelated line must not mislabel a table as the new one."""
     sources = {"a.py": 'X = 1\n\nT = {\n    "en": "a",\n    "zh": "b",\n}'}
-    likely, other = MOD.locate(sources, _EN_ZH, {"a.py": {1}})
+    likely, other = MOD.locate_touched(sources, {"a.py": {1}})
     assert likely == []
     assert other == 1
 
@@ -372,7 +390,7 @@ def test_sources_on_disk_includes_subpackages(tmp_path, monkeypatch):
 
     sources = MOD._sources_on_disk()
     assert set(sources) == {"top.py", "sub/nested.py"}
-    assert sum(MOD.signature_counter(sources).values()) == 2
+    assert MOD.count_offenders(sources) == 2
 
 
 # ---------------------------------------------------------------------------
@@ -392,7 +410,7 @@ def _stub_revisions(monkeypatch, base_src: dict[str, str], head_src: dict[str, s
 def test_main_fails_when_head_gained_an_offender(monkeypatch, capsys):
     """Covers the subtraction direction in main(), not just the helper.
 
-    Asserting on signature_counter alone lets `head - base` silently become
+    Asserting on count_offenders alone lets `head - base` silently become
     `base - head`, which never reports anything and disables the gate.
     """
     _stub_revisions(
@@ -420,6 +438,45 @@ def test_main_passes_on_an_unchanged_tree(monkeypatch):
     src = {"a.py": 'T = {"en": "x", "zh": "y"}'}
     _stub_revisions(monkeypatch, src, src)
     assert MOD.main(["--base", "irrelevant"]) == 0
+
+
+def test_sources_on_disk_skips_undecodable_file(tmp_path, monkeypatch, capsys):
+    """A non-UTF-8 prompt module is skipped, not fatal.
+
+    UnicodeDecodeError is a ValueError, not an OSError, so catching only OSError
+    would take the whole gate down with a traceback over one bad file.
+    """
+    (tmp_path / "good.py").write_text('T = {"en": "a", "zh": "b"}', encoding="utf-8")
+    (tmp_path / "bad.py").write_bytes(b'T = {"en": "\xff\xfe not utf-8"}')
+    monkeypatch.setattr(MOD, "PROMPTS_DIR", tmp_path)
+    monkeypatch.setattr(MOD, "REPO_ROOT", tmp_path)
+
+    sources = MOD._sources_on_disk()
+    assert set(sources) == {"good.py"}
+    assert "bad.py" in capsys.readouterr().err
+    assert MOD.count_offenders(sources) == 1
+
+
+def test_git_decodes_with_replacement(monkeypatch):
+    """git output is decoded with errors="replace" so a bad blob cannot crash us.
+
+    The base side reads sources through `git show`; without this it would raise
+    mid-decode where the disk side merely skips the file.
+    """
+    captured: dict[str, object] = {}
+
+    class _Result:
+        returncode = 0
+        stdout = "ok"
+        stderr = ""
+
+    def fake_run(cmd, **kwargs):
+        captured.update(kwargs)
+        return _Result()
+
+    monkeypatch.setattr(MOD.subprocess, "run", fake_run)
+    assert MOD._git("show", "X:y.py") == "ok"
+    assert captured.get("errors") == "replace", captured
 
 
 def test_prompt_files_at_reads_nul_separated_paths(monkeypatch):

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -1645,3 +1645,63 @@ def test_lone_cr_module_keeps_comments_on_their_own_lines():
     assert comments[0] == ""
     assert "PROMPT_ZH_TW" in comments[1]
     assert MOD.find_violations(tree, comments) == [1]
+
+
+@pytest.mark.parametrize("src", [
+    'T = {"en": "e", "zh": "s"}\nT.update({"ja": "j"}, **{"zh-TW": "t"})',
+    'T = {"en": "e", "zh": "s"}\nT.update(**{"ja": "j"}, **{"zh-TW": "t"})',
+])
+def test_every_update_payload_is_inspected(src):
+    """`update()` takes a positional mapping and any number of `**` spreads.
+
+    Looking at only the first payload missed zh-TW whenever it arrived in a later
+    one, and reported the compliant target's literal.
+    """
+    assert _violations(src) == []
+
+
+def test_mixed_update_payloads_without_zh_tw_still_report():
+    src = 'T = {"en": "e", "zh": "s"}\nT.update({"ja": "j"}, **{"ko": "k"})'
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == [1]
+
+
+@pytest.mark.parametrize("src", [
+    'TW = {"zh-TW": "t"}\nT = {"en": "e", "zh": "s"}\nT.update(TW)',
+    'TW = {"zh-TW": "t"}\nT = {"en": "e", "zh": "s"}\nT |= TW',
+])
+def test_named_mutation_payload_is_resolved(src):
+    """A payload can be a name bound to a mapping earlier.
+
+    Merge operands already used the preceding-binding lookup; mutation payloads
+    did not, so `T.update(TW)` left T reported. `prompts_emotion.py:573` shows the
+    `update(<name>)` shape does occur in this repo.
+    """
+    assert _violations(src) == []
+
+
+@pytest.mark.parametrize("src,expected", [
+    ('X = {"ja": "j"}\nT = {"en": "e", "zh": "s"}\nT.update(X)', [2]),
+    ('T = {"en": "e", "zh": "s"}\nT.update(UNKNOWN)', [1]),
+])
+def test_named_payload_without_zh_tw_or_unresolvable_still_reports(src, expected):
+    """Following the name only helps when it demonstrably supplies zh-TW."""
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == expected
+
+
+@pytest.mark.parametrize("src", [
+    # A copy taken before the backfill: U lacks zh-TW at runtime but is not judged.
+    'T = {"en": "e", "zh": "s"}\nU = dict(T)\nT["zh-TW"] = "t"',
+    # dict(zip(...)) — every other static constructor resolves, this one does not.
+    'T = dict(zip(("en", "zh"), (english, simplified)))',
+])
+def test_documented_miss_side_blind_spots(src):
+    """Pinned so a change here is deliberate, not accidental.
+
+    Both are on the miss side and both are called out in the module docstring:
+    ordering the exemption against each use needs statement-level data flow, and
+    `dict(zip(...))` has zero occurrences under config/prompts because splitting a
+    localized table into parallel sequences makes the template bodies unreadable.
+    """
+    assert _violations(src) == []

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -31,6 +31,8 @@ import sys
 import textwrap
 from pathlib import Path
 
+import pytest
+
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = PROJECT_ROOT / "scripts" / "check_prompt_zh_tw.py"
 
@@ -57,6 +59,16 @@ def _grew(base: dict[str, str], head: dict[str, str]) -> int:
     base = {k: textwrap.dedent(v) for k, v in base.items()}
     head = {k: textwrap.dedent(v) for k, v in head.items()}
     return MOD.count_offenders(head) - MOD.count_offenders(base)
+
+
+def _touched_from(diff: str) -> dict[str, set[int]]:
+    """Parse a diff into touched lines without invoking git."""
+    original = MOD._git
+    MOD._git = lambda *_a: diff
+    try:
+        return MOD._touched_lines("BASE_SHA")
+    finally:
+        MOD._git = original
 
 
 # ---------------------------------------------------------------------------
@@ -548,6 +560,87 @@ def test_dict_call_with_positional_base_is_not_judged():
     assert _violations("T = dict({'zh-TW': 't'}, en='e', zh='s')") == []
     # Keyword-only is still fully knowable, so it is still judged.
     assert len(_violations("T = dict(en='e', zh='s')")) == 1
+
+
+@pytest.mark.parametrize("src", [
+    'T = dict({"en": "e", "zh": "s"}, **{"zh-TW": "t"})',
+    'T = {**{"en": "e", "zh": "s"}, **{"zh-TW": "t"}}',
+    'T = {"en": "e", "zh": "s"} | {"zh-TW": "t"}',
+    # Positional base only, no `**`: the sole thing marking this as a merge is
+    # the positional arg, so this case is what proves that half of
+    # _is_merged_construction is load-bearing for pruning.
+    'T = dict({"en": "e", "zh": "s"}, note="x")',
+    'T = dict({"en": "e", "zh": "s"}, {"zh-TW": "t"})',
+])
+def test_merged_construction_fragments_are_not_judged(src):
+    """A table assembled from several mappings must not report its fragments.
+
+    Skipping the outer node is not enough: a plain ast.walk still descends into
+    the inner `{en, zh}` literal and flags it, even though the assembled mapping
+    does carry zh-TW. The whole subtree has to be pruned.
+    """
+    assert _violations(src) == []
+
+
+def test_ordinary_nesting_is_still_judged_in_source_order():
+    """Pruning merged constructions must not stop ordinary nesting being checked.
+
+    `{"a": {...}}` is not a merge — the inner dict is a table in its own right.
+    Order is asserted because the pruning walk uses a stack, which reverses it.
+    """
+    src = '''
+    OUTER = {
+        "a": {"en": "x", "zh": "y"},
+        "b": {"en": "p", "zh": "q"},
+    }
+    '''
+    assert _violations(src) == [3, 4]
+
+
+def test_touched_lines_records_a_location_for_deletion_only_hunks():
+    """Removing a table's only zh-TW entry must stay locatable.
+
+    `@@ -4 +3,0 @@` has a zero-length new side, so a plain range() is empty — and
+    that transition (a compliant table losing zh-TW) is a real way for the total
+    to grow, so having no location would send the author through all 339 entries.
+    """
+    diff = (
+        "diff --git a/p.py b/p.py\n"
+        "--- a/p.py\n"
+        "+++ b/p.py\n"
+        "@@ -4 +3,0 @@\n"
+        '-    "zh-TW": "c",\n'
+    )
+    touched = _touched_from(diff)
+    assert touched == {"p.py": {3, 4}}
+
+
+def test_deletion_at_file_start_does_not_emit_line_zero():
+    """`@@ -1 +0,0 @@` must not produce line 0 — line numbers are 1-based."""
+    diff = (
+        "diff --git a/p.py b/p.py\n"
+        "--- a/p.py\n"
+        "+++ b/p.py\n"
+        "@@ -1 +0,0 @@\n"
+        "-x\n"
+    )
+    assert _touched_from(diff) == {"p.py": {1}}
+
+
+def test_losing_zh_tw_is_located_end_to_end(monkeypatch):
+    """The deletion-hunk location actually names the table that lost zh-TW."""
+    diff = (
+        "diff --git a/p.py b/p.py\n"
+        "--- a/p.py\n"
+        "+++ b/p.py\n"
+        "@@ -4 +3,0 @@\n"
+        '-    "zh-TW": "c",\n'
+    )
+    head = {"p.py": 'T = {\n    "en": "a",\n    "zh": "b",\n}\n'}
+    monkeypatch.setattr(MOD, "_git", lambda *a: diff)
+    likely, other = MOD.locate_touched(head, MOD._touched_lines("BASE_SHA"))
+    assert likely == ["p.py:1"]
+    assert other == 0
 
 
 def test_touched_lines_disables_git_path_quoting(monkeypatch):

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -1538,3 +1538,65 @@ def test_fromkeys_without_zh_tw_does_not_exempt(src):
     """Supplying some other locale, or an unresolvable list, exempts nothing."""
     tree, comments = MOD._parse_source(src, "t.py")
     assert MOD.find_violations(tree, comments) == [1]
+
+
+@pytest.mark.parametrize("src", [
+    'T = {"en": "e", "zh": "s"}\nT.update(**{"zh-TW": "t"})',
+    'T = {"en": "e", "zh": "s"}\nT.setdefault("zh-TW", "t")',
+])
+def test_other_explicit_backfill_forms_exempt(src):
+    """`update(**{...})` and `setdefault(key, ...)` supply zh-TW just as plainly.
+
+    The detector only accepted `update()` with a positional argument, so both of
+    these left the target unexempted and its compliant literal was reported.
+    """
+    assert _violations(src) == []
+
+
+@pytest.mark.parametrize("src", [
+    'T = {"en": "e", "zh": "s"}\nT.update(**{"ja": "j"})',
+    'T = {"en": "e", "zh": "s"}\nT.setdefault("ja", "j")',
+])
+def test_other_backfill_forms_supplying_something_else_do_not_exempt(src):
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == [1]
+
+
+def test_named_traditional_supplier_exempts_the_named_fragment():
+    """Both halves of a merge can be names: `{**_F, **_TW}`.
+
+    Visibility has to follow a name to its preceding binding, or a merge whose
+    zh-TW comes from `_TW` looks like it supplies nothing.
+    """
+    src = (
+        '_F = {"en": "e", "zh": "s"}\n'
+        '_TW = {"zh-TW": "t"}\n'
+        'T = {**_F, **_TW}'
+    )
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == []
+
+
+def test_named_supplier_without_zh_tw_still_reports():
+    """Following names only adds visible keys; it must not excuse a plain copy."""
+    src = (
+        '_F = {"en": "e", "zh": "s"}\n'
+        '_X = {"ja": "j"}\n'
+        'T = {**_F, **_X}'
+    )
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == [1]
+
+
+@pytest.mark.parametrize("src", [
+    'T = {"en": "e", "zh": "s"}\nT = T | {"zh-TW": "t"}',
+    'T = {"en": "e", "zh": "s"}\nT = {**T, "zh-TW": "t"}',
+    'T = {"en": "e", "zh": "s"}\nT = dict(T, **{"zh-TW": "t"})',
+])
+def test_self_rebinding_exempts_the_previous_binding(src):
+    """`T = T | {...}` — the RHS reads the *earlier* binding.
+
+    The new assignment registers on the merge's own line, so an inclusive
+    line search picked the merge's own result and left the first literal reported.
+    """
+    assert _violations(src) == []

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -1350,3 +1350,68 @@ def test_comment_lines_on_unparseable_source_suppresses_nothing():
     """A tokenize failure must not hand back stale or wrong suppression."""
     comments = MOD._comment_lines('T = {"en": "e"  # noqa: PROMPT_ZH_TW\n')
     assert all(c == "" for c in comments), comments
+
+
+def test_exemption_lands_on_the_binding_before_the_mutation():
+    """A name reassigned after a backfill must not inherit the exemption.
+
+    The later literal is a real offender; exempting every same-named assignment
+    let it through.
+    """
+    src = (
+        'T = {"en": "e", "zh": "s"}\n'
+        'T["zh-TW"] = "t"\n'
+        'T = {"en": "e2", "zh": "s2"}'
+    )
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == [3]
+
+
+def test_exemption_does_not_reach_a_different_name():
+    src = (
+        'T = {"en": "e2", "zh": "s2"}\n'
+        'T2 = {"en": "e", "zh": "s"}\n'
+        'T2["zh-TW"] = "t"'
+    )
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == [1]
+
+
+@pytest.mark.parametrize("src", [
+    'T = {"en": "e", "zh": "s"}\nT.update([("zh-TW", "t")])',
+    'T = {"en": "e", "zh": "s"}\nT.update((("zh-TW", "t"),))',
+])
+def test_iterable_of_pairs_update_payload_counts_as_backfill(src):
+    """`update([("zh-TW", ...)])` supplies zh-TW as knowably as a dict literal.
+
+    resolve_keys says nothing about a list, so without the pair-sequence fallback
+    the target went unexempted and its compliant literal was reported.
+    """
+    assert _violations(src) == []
+
+
+def test_exemption_picks_the_nearest_preceding_binding_not_the_first():
+    """With two bindings before the mutation, only the nearest one is exempt.
+
+    The earlier literal was live until it was reassigned, and it lacks zh-TW, so it
+    is a genuine offender. Exempting the first binding instead would clear the
+    wrong one and report the compliant table.
+    """
+    src = (
+        'T = {"en": "a", "zh": "b"}\n'
+        'T = {"en": "c", "zh": "d"}\n'
+        'T["zh-TW"] = "t"'
+    )
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == [1]
+
+
+def test_exemption_covers_a_binding_mutated_on_the_same_line():
+    """`T = {...}; T["zh-TW"] = "t"` on one line still exempts the table.
+
+    The binding and the mutation share a line number, so the comparison has to be
+    inclusive.
+    """
+    src = 'T = {"en": "e", "zh": "s"}; T["zh-TW"] = "t"'
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == []

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -1705,3 +1705,127 @@ def test_documented_miss_side_blind_spots(src):
     localized table into parallel sequences makes the template bodies unreadable.
     """
     assert _violations(src) == []
+
+
+@pytest.mark.parametrize("supplier", [
+    '{loc: tpl for loc in ("zh-TW",)}',
+    'dict.fromkeys(("zh-TW",), "t")',
+    '{"zh-TW": "t"}',
+])
+def test_visible_keys_covers_every_constructor_resolve_keys_does(supplier):
+    """`_directly_visible_keys` must not lag behind `resolve_keys`.
+
+    It answers "does this merge demonstrably supply zh-TW?", so a constructor it
+    fails to read makes the union look like it supplies nothing and the fragment
+    gets reported. It re-listed constructors by hand and fell behind twice; it now
+    delegates, which is what this pins.
+    """
+    assert _violations(f'F = {{"en": "e", "zh": "s"}}\nT = F | {supplier}') == []
+
+
+def test_visible_keys_delegation_does_not_blind_the_gate():
+    src = 'F = {"en": "e", "zh": "s"}\nT = F | {loc: tpl for loc in ("ja",)}'
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == [1]
+
+
+@pytest.mark.parametrize("src", [
+    # payload named, bound to an iterable of pairs rather than a mapping
+    'P = [("zh-TW", "t")]\nT = {"en": "e", "zh": "s"}\nT.update(P)',
+    # the supplier reached through a second name
+    'TW = {"zh-TW": "t"}\nTW2 = dict(TW)\nF = {"en": "e", "zh": "s"}\nT = {**F, **TW2}',
+    'TW = {"zh-TW": "t"}\nTW2 = TW | {}\nT = {"en": "e", "zh": "s"}\nT |= TW2',
+])
+def test_name_resolution_is_uniform_across_paths(src):
+    """Mutation payloads, merge operands and aliases share one resolver.
+
+    Each grew its own partial version first — `resolve_keys` only, no
+    iterable-of-pairs, no second hop — and every gap read as "no zh-TW here".
+    """
+    assert _violations(src) == []
+
+
+@pytest.mark.parametrize("src,expected", [
+    ('X = {"ja": "j"}\nX2 = dict(X)\nF = {"en": "e", "zh": "s"}\nT = {**F, **X2}', [3]),
+    ('P = [("ja", "j")]\nT = {"en": "e", "zh": "s"}\nT.update(P)', [2]),
+])
+def test_following_names_only_ever_adds_keys(src, expected):
+    """Chasing a name must not become a way to excuse an offender."""
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == expected
+
+
+@pytest.mark.parametrize("src,expected", [
+    ("T = T\nT.update(T)\nU = {'en': 'e', 'zh': 's'}", [3]),
+    ("A = B\nB = A\nT = {'en': 'e', 'zh': 's'}\nT.update(A)", [3]),
+])
+def test_self_and_mutual_bindings_terminate(src, expected):
+    """Name hops are recursive, so they need a cycle guard.
+
+    Without one these hang the gate rather than failing it, which in CI reads as
+    an infrastructure problem rather than a bug here.
+    """
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == expected
+
+
+def test_conditional_operand_branches_are_fragments():
+    """`{**(A if flag else B), "zh-TW": t}` is one compliant table, not two.
+
+    Suppressing only the IfExp left traversal free to reach both branch dicts and
+    report each on its own — the count grew by two for a compliant table.
+    """
+    src = (
+        'T = {**({"en": "e", "zh": "s"} if flag else {"en": "e2", "zh": "s2"}),'
+        ' "zh-TW": "t"}'
+    )
+    assert _violations(src) == []
+
+
+@pytest.mark.parametrize("src", [
+    # supplied through a merge operand — in either branch, so neither may be the
+    # only one read
+    'F = {"en": "e", "zh": "s"}\nT = F | (TW if flag else {"zh-TW": "t"})',
+    'F = {"en": "e", "zh": "s"}\nT = F | ({"zh-TW": "t"} if flag else TW)',
+    # a conditional nested in a conditional is still just branches — the fragment
+    # sits in the inner one, so expanding only the outer level leaves it reported
+    'T = {**(X if f else ({"en": "e", "zh": "s"} if g else Y)), "zh-TW": "t"}',
+    # supplied through a mutation payload — the same shape on the other path
+    'TW = {"zh-TW": "t"}\nT = {"en": "e", "zh": "s"}\nT |= TW if flag else {}',
+    'T = {"en": "e", "zh": "s"}\nT.update({"ja": "j"} if flag else {"zh-TW": "t"})',
+])
+def test_conditional_operand_may_be_the_zh_tw_supplier(src):
+    """A conditional supply counts, same call as `if enabled: T["zh-TW"] = t`.
+
+    Both paths that ask "is zh-TW supplied here?" have to agree — supporting it on
+    merge operands only would report the mutation form of the same table.
+    """
+    assert _violations(src) == []
+
+
+def test_direct_keys_count_even_when_the_rest_of_the_payload_is_unknowable():
+    """`TW = {**BASE, "zh-TW": t}` supplies zh-TW whatever BASE holds.
+
+    `_mapping_keys` gives up on the table as a whole (BASE is unresolvable), so
+    without folding in the keys it states outright the payload looks empty and the
+    compliant target gets reported.
+    """
+    src = 'TW = {**BASE, "zh-TW": "t"}\nT = {"en": "e", "zh": "s"}\nT.update(TW)'
+    assert _violations(src) == []
+
+
+def test_unknowable_payload_without_direct_zh_tw_still_reports():
+    src = 'TW = {**BASE, "ja": "j"}\nT = {"en": "e", "zh": "s"}\nT.update(TW)'
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == [2]
+
+
+def test_independent_table_inside_a_conditional_operand_is_still_judged():
+    """Branches are fragments; tables merely *held* by a branch are not.
+
+    The same distinction `_merge_operands` already draws for spreads — otherwise
+    expanding branches would prune real offenders out of the walk.
+    """
+    src = 'T = {**(A if flag else {"new": {"en": "e", "zh": "s"}}), "zh-TW": "t"}'
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == [1]

--- a/tests/unit/test_check_prompt_zh_tw.py
+++ b/tests/unit/test_check_prompt_zh_tw.py
@@ -1441,3 +1441,58 @@ def test_annotated_binding_without_a_value_is_ignored():
 def test_annotated_offender_is_still_reported():
     """The exemption is about mutations, not about annotations."""
     assert _violations('T: dict[str, str] = {"en": "e", "zh": "s"}') == [1]
+
+
+@pytest.mark.parametrize("src", [
+    'T = {"en": "e", "zh": "s"}\nU = dict(T)',
+    'T = {"en": "e", "zh": "s"}\nU = {**T}',
+    'T = {"en": "e", "zh": "s"}\nU = {**T, "ja": "j"}',
+])
+def test_copying_an_offender_does_not_exempt_it(src):
+    """Being merged somewhere is not enough — the merge must supply zh-TW.
+
+    Exempting every named operand meant an offender plus a copy of it counted as
+    zero: the original was excused as an "operand" while the copy was unresolvable,
+    because resolve_keys does not follow names.
+    """
+    tree, comments = MOD._parse_source(src, "t.py")
+    assert MOD.find_violations(tree, comments) == [1]
+
+
+@pytest.mark.parametrize("src", [
+    '_F = {"en": "e", "zh": "s"}\nT = {**_F, "zh-TW": "t"}',
+    '_F = {"en": "e", "zh": "s"}\nT = _F | {"zh-TW": "t"}',
+    '_F = {"en": "e", "zh": "s"}\nT = dict(_F, **{"zh-TW": "t"})',
+    '_F = {"en": "e", "zh": "s"}\nT = dict(_F, **dict([("zh-TW", "t")]))',
+])
+def test_named_fragment_exempt_only_when_zh_tw_is_supplied(src):
+    assert _violations(src) == []
+
+
+def test_directly_visible_keys_ignores_unknowable_parts():
+    """Unlike resolve_keys, an unknowable operand contributes nothing, not None."""
+    import ast as _ast
+    visible = MOD._directly_visible_keys(
+        _ast.parse('{**UNKNOWN, "zh-TW": "t"}', mode="eval").body
+    )
+    assert visible == {"zh-TW"}
+    assert MOD._directly_visible_keys(
+        _ast.parse('dict(UNKNOWN)', mode="eval").body
+    ) == set()
+
+
+def test_zh_tw_supplied_through_a_nested_spread_still_exempts():
+    """The supplying key can itself sit inside a spread, not just be a direct key.
+
+    `{**_F, **{"zh-TW": ...}}` completes _F as surely as `{**_F, "zh-TW": ...}`
+    does, so the visibility scan has to recurse into spread values.
+    """
+    assert _violations('_F = {"en": "e", "zh": "s"}\nT = {**_F, **{"zh-TW": "t"}}') == []
+
+
+def test_directly_visible_keys_recurses_into_spreads():
+    import ast as _ast
+    visible = MOD._directly_visible_keys(
+        _ast.parse('{**OTHER, **{"zh-TW": "t"}}', mode="eval").body
+    )
+    assert visible == {"zh-TW"}


### PR DESCRIPTION
## Summary

issue #2500 第 2 步。**存量 339 个 i18n prompt dict 缺 `'zh-TW'`，而 issue 开出时是 320 —— 三天涨了 19 个**，因为没有任何东西盯着。补齐是分批的长活，这个门禁只负责让洞不再变大。

与 #2568（七处 normalizer 收口）无依赖，可独立合并。

## 规则

`config/prompts/` 下含 `'en'` 键且含 `'zh'` 或 `'zh-CN'` 的 dict 是本地化 prompt 表，必须也含 `'zh-TW'`。

理由：`_loc` 缺 key 回落 **`'en'` 而不是 `'zh'`**（`prompts_sys.py:34`），所以缺 zh-TW 的表会给繁中用户端出**英文** prompt，而不是退一步的简体。

## 棘轮就是一个总数对比

比较 merge-base 与 HEAD 上「缺 zh-TW 的表」各有多少个，**HEAD 更多就失败**。没有行号，没有 per-dict 身份，没有分组。

走到这一步试错了三轮，每一轮都被 reviewer 打回，而每一种"更精确"的判据都各自破了一个总数天然处理的场景：

| 判据 | 破在哪 |
|---|---|
| **按 diff 行** | 已有 `{en, ja}` 表加一行 `"zh"` → 定义行不在 diff 里 → **漏检**（正是门禁存在的理由）；纯重命名 → 整个文件算新增 → **误报全部存量** |
| **按整个键集合** | 给已有违规表加一个无关 locale（新 `'fr'` 模板）→ 签名变了 → 读成全新表 → **误报** |
| **按简体键 scheme**（`zh` / `zh-CN` 分桶） | `zh` → `zh-CN` 迁移 → 一桶减一、另一桶加一，而 Counter 相减只保留正数 → **误报**。而这恰恰是 issue #2500 自己的终局动作，等于门禁会挡住它本该服务的迁移 |

总数对这三种全都免疫：重命名、改文案、加 locale、scheme 迁移都不改变总数，而一个新受规则约束的表会让它 +1。

**已知盲点**（写进 docstring 并钉进测试）：删一个违规表 + 加一个违规表，净变化 0 会放行。刻意接受 —— 替代方案是跨版本按身份匹配 dict，而候选的每一种身份（位置、键集合、scheme）正是上面三轮试错。

**定位**：总数只说明"涨了"不说明"在哪"，而 339 个存量太多不能全打印。所以 diff 行号仍用作**提示**，把报错 narrow 到本次改动碰过的表：

```
[PROMPT_ZH_TW] 1 more localized prompt dict(s) lack 'zh-TW' than at the merge-base.
        in lines this change touched: config/prompts/中文表.py:1
        (339 pre-existing offender(s) are exempt)
```

判定权威是总数，行号只影响提示（`-M` 防 rename 把整个文件标成新增，`core.quotePath=false` 防非 ASCII 路径被 C-quote）。

三种模式：默认总数棘轮（CI 用）；`--full` 列全部积压；`--count` 只报数量。单表逃生用 `# noqa: PROMPT_ZH_TW` 写在开括号那行。CI 接线照 `check_docstring_no_cjk.py` 既有形态（PR-only、`BASE_REF` 间接引用以避开 zizmor 的 template-injection 告警）。

## Review 修复

**判据演进**（三轮，见上表）：Codex 报的行号漏检/rename 误报 → 键集合签名；Codex + Greptile 报的加 locale / scheme 迁移误报 → 总数对比。

**收口不彻底的三处**（本轮，均实测证实）：

- **`dict()` 位置参数**：上一轮只挡了 `**`，但 `dict(BASE, en=..., zh=...)` 的 `BASE` 同样可能是 `zh-TW` 的来源。实测被误报。现在 `node.args` 非空即放弃判断。
- **diff 的 `+++` 行仍被 C-quote**：上一轮给 `ls-tree` 加了 `-z`，漏了 patch 输出这条通道。实测 `+++ "b/config/prompts/\344\270\255...py"` 匹配不到真实路径，该文件的定位提示被静默丢弃。已加 `-c core.quotePath=false`。
- **非 UTF-8 模块被静默跳过**：`# coding: latin-1` 是合法 Python，上一轮的 `except UnicodeDecodeError` 把它整个跳过 = 不检查一个真实模块。改为读 bytes 后经 `tokenize.detect_encoding` 解码，两侧对偶（磁盘侧 `read_bytes`、base 侧新增 `_git_bytes`），只有真正损坏的字节才跳过且必有诊断。

**「什么算一个表」也收敛了四轮**，每轮修一个引入下一个：

| 遍历方案 | 破在哪 |
|---|---|
| 平铺 `ast.walk` | 把合并的每个 operand 单独判 → `{**{en,zh}, **{zh-TW}}` 误报前半 |
| 整棵剪枝 | 丢掉合成容器里按普通键放的独立表 → `{**COMMON, "new": {en,zh}}` 里的 `"new"` 从此不检查 |
| 压制 operand 但不解合并 | `BinOp` 不是 dict 节点、两个 operand 又都被压制 → `{"en"} \| {"zh"}` **整表逃检** |
| **静态求解整体** | 收敛 |

最终形态：`resolve_keys()` 递归解 mapping 表达式的键集合，穿透 dict literal 的 `**`、`dict()` 的位置参数与 `**`、以及 `|`；能解就判结果，任何一部分不可知（spread 一个 Name、动态键、`dict()` 套变量）就放弃。片段误报不再靠「压制」避免，而是因为片段的键已经算进整体结果里。operand 压制改为无条件——`BASE | {en,zh}` 整体不可解但右侧仍是片段。

**另外两处 IO 层的不对称**：

- **纯删除 hunk 定位为空**：删掉某表唯一的 `"zh-TW"` 是总数增长的真实路径，但 `@@ -4 +3,0 @@` 新侧长度 0，`range()` 为空 → 判定正确报错却定位丢失。改为记录删除点两侧（`max(1, start)` 防文件首删除产生行号 0）。
- **symlink 两侧不对称**：磁盘侧 `read_bytes()` 跟随链接读目标源码，base 侧 `git show` 拿到 symlink blob（内容即目标路径字符串）。引入 commit 净 0 过关，之后**每个 PR 都误报**。两侧一致排除（base 侧读 ls-tree 的 mode 跳过 `120000`，因此不能用 `--name-only`；磁盘侧 `is_symlink()`），都带 stderr 诊断。

**Windows CI 红**（本轮的真 bug，不是 flaky）：

```
encodings\cp1252.py → UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d
```

`subprocess` 的 `text=True` 不指定 encoding 时按 **locale** 解码，CI runner 是 cp1252（我本地是 cp936，所以本地一直绿）。而且异常发生在 subprocess 的 `_readerthread` 里，failure 伪装成 returncode 断言。两侧对偶修：测试侧 `_run()` 显式 `encoding="utf-8"`，脚本侧 `main()` 把 stdout/stderr reconfigure 成 UTF-8（stdout 是 pipe 时 `print` 同样用 locale 编码）。

## Testing

`tests/unit/test_check_prompt_zh_tw.py`（69 项）：表形状识别（含 `dict()` 调用形式三态、`**` / 位置参数放弃判断）、总数棘轮的各种转移（新表 / 加键 / 重命名 / 改文案 / 补 zh-TW / 加 locale / scheme 迁移 / 已知盲点）、定位提示 narrowing、noqa 三态、PEP 263 解码三态、`_git` 与 `_git_bytes` 的编码契约、`main()` 本身（涨→1、补齐→0、未变→0、强制 UTF-8、无 `reconfigure` 流兜底）、文件发现（子包、非 `.py`）、CLI。

**36 条变异全部被抓**，其中三条最初存活、靠变异验证才发现：

1. **`main()` 里的减法方向写反**（门禁完全失效）—— 测试 helper 自己重算了一遍减法，没走 `main()`
2. **stdout 不强制 UTF-8** —— 那正是修 Windows CI 的改动，当时零覆盖
3. **merged 判据丢掉 `dict()` 位置参数** —— 参数化 case 同时带位置参数和 `**`，后者兜住了；补两个只有位置参数的 case 后被抓

端到端复验（走真实 git 与真实文件）：非 ASCII 文件名的新增表定位到 `中文表.py:1`；latin-1 模块被检出在 `legacy_latin1.py:2` 而非静默跳过；纯重命名 exit 0；已有表加键 exit 1；子包 `--count` 计入。

`tests/unit` 全量 **8506 passed, 45 skipped**。`check_docstring_no_cjk` / `check_prompt_hygiene` / `check_module_layering` 均 exit 0，门禁对本 PR 自身 exit 0。

## 回归报告 / Regression Report

新增一个 PR-only CI 步骤和一个脚本，不改任何运行时代码。

- **Before**：prompt dict 缺 zh-TW 无人管，缺口以每三天 ~19 个的速度增长
- **After**：新增表必须带 zh-TW；存量不受影响，补齐工作照 issue #2500 分批推进
- **Risk**：低。唯一的行为面是 CI 会对新增缺 zh-TW 的表报错；误判有 `# noqa: PROMPT_ZH_TW` 逃生。直接 push 到 main 时跳过（无 diff base）

Refs #2500

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI 改进**
  * 在拉取请求中检查新增多语言提示词字典是否包含 `zh-TW`，并支持规范化的单条例外标记。
  * 优化违规数量检测，仅当缺少 `zh-TW` 的条目总数增加时阻止合并。
  * 改进错误定位，支持复杂字典结构、嵌套内容、删除变更及非 ASCII 路径。

* **测试**
  * 大幅扩展相关自动化测试，覆盖多种字典写法、编码、路径、抑制规则及 Git 变更场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->