### PR TITLE
修复小游戏退出后紧凑聊天栏占位文字不恢复的问题

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -4100,6 +4100,62 @@ describe('App', () => {
     }
   });
 
+  it('ignores an inactive game-route sync while an ordinary assistant caption is streaming', async () => {
+    vi.useFakeTimers();
+    const normalLine = '这是一条与小游戏无关的正常回复。';
+
+    try {
+      const { container } = render(<App chatSurfaceMode="compact" messages={[]} />);
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent('neko-assistant-turn-start', {
+          detail: {
+            turnId: 'ordinary-assistant-turn',
+            source: 'gemini_response_first_chunk',
+          },
+        }));
+        window.dispatchEvent(new CustomEvent('neko-compact-caption-update', {
+          detail: {
+            turnId: 'ordinary-assistant-turn',
+            segmentId: 'ordinary-assistant-turn:segment:1',
+            text: normalLine,
+          },
+        }));
+        window.dispatchEvent(new CustomEvent('neko-assistant-speech-unavailable', {
+          detail: {
+            turnId: 'ordinary-assistant-turn',
+            source: 'test',
+          },
+        }));
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000);
+      });
+      const visibleBeforeSync = container.querySelector('.compact-chat-capsule-text')?.textContent ?? '';
+      expect(visibleBeforeSync.length).toBeGreaterThan(0);
+      expect(normalLine.startsWith(visibleBeforeSync)).toBe(true);
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent('neko-game-window-state-change', {
+          detail: {
+            action: 'closed',
+            gameType: '',
+            sessionId: '',
+          },
+        }));
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(100);
+      });
+
+      const visibleAfterSync = container.querySelector('.compact-chat-capsule-text')?.textContent ?? '';
+      expect(visibleAfterSync.length).toBeGreaterThanOrEqual(visibleBeforeSync.length);
+      expect(normalLine.startsWith(visibleAfterSync)).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('does not flash the previous sentence when the next assistant sentence streams under a new turn id', async () => {
     vi.useFakeTimers();
     const firstSentence = '第一句话已经说完了，不能在第二句话开始时闪回来。';

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -4178,7 +4178,7 @@ describe('App', () => {
     }
   });
 
-  it('ignores game state events that do not belong to the current assistant caption', async () => {
+  it('does not bind an ordinary assistant caption to a stale active game session', async () => {
     vi.useFakeTimers();
     const normalLine = '这是一条与小游戏无关的正常回复。';
 
@@ -4186,6 +4186,13 @@ describe('App', () => {
       const { container } = render(<App chatSurfaceMode="compact" messages={[]} />);
 
       act(() => {
+        window.dispatchEvent(new CustomEvent('neko-game-window-state-change', {
+          detail: {
+            action: 'opened',
+            gameType: 'badminton',
+            sessionId: 'stale-game-session',
+          },
+        }));
         window.dispatchEvent(new CustomEvent('neko-assistant-turn-start', {
           detail: {
             turnId: 'ordinary-assistant-turn',

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -3998,7 +3998,7 @@ describe('App', () => {
     }
   });
 
-  it('restores the compact empty state from the real game closed event without waiting for turn-end', async () => {
+  it('restores the compact empty state when active-route sync opens after the game turn starts', async () => {
     vi.useFakeTimers();
     const gameLine = '哈，这球终于被我拿下了！';
     const gameMessage = parseChatMessage({
@@ -4023,13 +4023,6 @@ describe('App', () => {
       );
 
       act(() => {
-        window.dispatchEvent(new CustomEvent('neko-game-window-state-change', {
-          detail: {
-            action: 'opened',
-            gameType: 'badminton',
-            sessionId: 'badminton-session',
-          },
-        }));
         window.dispatchEvent(new CustomEvent('neko-assistant-turn-start', {
           detail: {
             turnId: 'badminton-exit-turn',
@@ -4037,7 +4030,20 @@ describe('App', () => {
             meta: {
               source: 'game_route',
               kind: 'badminton',
+              session_id: 'badminton-session',
+              mirror: {
+                kind: 'badminton',
+                session_id: 'badminton-session',
+                event: {},
+              },
             },
+          },
+        }));
+        window.dispatchEvent(new CustomEvent('neko-game-window-state-change', {
+          detail: {
+            action: 'opened',
+            gameType: 'badminton',
+            sessionId: 'badminton-session',
           },
         }));
       });
@@ -4053,6 +4059,71 @@ describe('App', () => {
             action: 'closed',
             gameType: 'badminton',
             sessionId: 'badminton-session',
+          },
+        }));
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+
+      expect(container.querySelector('.compact-chat-capsule-text')).toHaveTextContent(
+        DEFAULT_CHAT_EMPTY_STATE_FALLBACK,
+      );
+      expect(container.querySelector('.compact-chat-capsule-text')).not.toHaveTextContent(gameLine);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('restores the compact empty state from an identity-less reconnect close for a tracked game', async () => {
+    vi.useFakeTimers();
+    const gameLine = '比赛已经结束啦！';
+
+    try {
+      const { container } = render(<App chatSurfaceMode="compact" messages={[]} />);
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent('neko-assistant-turn-start', {
+          detail: {
+            turnId: 'reconnected-badminton-turn',
+            source: 'gemini_response_first_chunk',
+            meta: {
+              source: 'game_route',
+              kind: 'badminton',
+              session_id: 'reconnected-badminton-session',
+              mirror: {
+                kind: 'badminton',
+                session_id: 'reconnected-badminton-session',
+                event: {},
+              },
+            },
+          },
+        }));
+        window.dispatchEvent(new CustomEvent('neko-compact-caption-update', {
+          detail: {
+            turnId: 'reconnected-badminton-turn',
+            segmentId: 'reconnected-badminton-turn:segment:1',
+            text: gameLine,
+          },
+        }));
+        window.dispatchEvent(new CustomEvent('neko-assistant-speech-unavailable', {
+          detail: {
+            turnId: 'reconnected-badminton-turn',
+            source: 'test',
+          },
+        }));
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000);
+      });
+      expect(container.querySelector('.compact-chat-capsule-text')?.textContent ?? '').not.toBe('');
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent('neko-game-window-state-change', {
+          detail: {
+            action: 'closed',
+            gameType: '',
+            sessionId: '',
           },
         }));
       });

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -3998,6 +3998,108 @@ describe('App', () => {
     }
   });
 
+  it('restores the compact empty state from the real game closed event without waiting for turn-end', async () => {
+    vi.useFakeTimers();
+    const gameLine = '哈，这球终于被我拿下了！';
+    const gameMessage = parseChatMessage({
+      id: 'assistant-badminton-exit-line',
+      role: 'assistant',
+      author: 'YUI',
+      time: '12:23',
+      createdAt: 2,
+      turnId: 'badminton-exit-turn',
+      blocks: [{ type: 'text', text: gameLine }],
+      status: 'streaming',
+    });
+
+    try {
+      const { container, rerender } = render(<App chatSurfaceMode="compact" messages={[]} />);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      expect(container.querySelector('.compact-chat-capsule-text')).toHaveTextContent(
+        DEFAULT_CHAT_EMPTY_STATE_FALLBACK,
+      );
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent('neko-assistant-turn-start', {
+          detail: {
+            turnId: 'badminton-exit-turn',
+            source: 'visible_gemini_bubble',
+            meta: {
+              source: 'game_route',
+              kind: 'badminton',
+            },
+          },
+        }));
+      });
+      rerender(<App chatSurfaceMode="compact" messages={[gameMessage]} />);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20);
+      });
+      expect(container.querySelector('.compact-chat-capsule-text')?.textContent ?? '').toBe('');
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent('neko-game-window-state-change', {
+          detail: {
+            action: 'closed',
+            gameType: 'badminton',
+            sessionId: 'badminton-session',
+          },
+        }));
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+
+      expect(container.querySelector('.compact-chat-capsule-text')).toHaveTextContent(
+        DEFAULT_CHAT_EMPTY_STATE_FALLBACK,
+      );
+      expect(container.querySelector('.compact-chat-capsule-text')).not.toHaveTextContent(gameLine);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('restores the compact empty state after a text-less assistant turn fully ends', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const { container } = render(<App chatSurfaceMode="compact" messages={[]} />);
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent('neko-assistant-turn-start', {
+          detail: {
+            turnId: 'badminton-postgame-turn',
+            source: 'test',
+          },
+        }));
+        window.dispatchEvent(new CustomEvent('neko-assistant-turn-ending', {
+          detail: {
+            turnId: 'badminton-postgame-turn',
+            source: 'turn_end_flush',
+          },
+        }));
+        window.dispatchEvent(new CustomEvent('neko-assistant-turn-end', {
+          detail: {
+            turnId: 'badminton-postgame-turn',
+            source: 'turn_end',
+          },
+        }));
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+
+      expect(container.querySelector('.compact-chat-capsule-text')).toHaveTextContent(
+        DEFAULT_CHAT_EMPTY_STATE_FALLBACK,
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('does not flash the previous sentence when the next assistant sentence streams under a new turn id', async () => {
     vi.useFakeTimers();
     const firstSentence = '第一句话已经说完了，不能在第二句话开始时闪回来。';

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -4023,6 +4023,13 @@ describe('App', () => {
       );
 
       act(() => {
+        window.dispatchEvent(new CustomEvent('neko-game-window-state-change', {
+          detail: {
+            action: 'opened',
+            gameType: 'badminton',
+            sessionId: 'badminton-session',
+          },
+        }));
         window.dispatchEvent(new CustomEvent('neko-assistant-turn-start', {
           detail: {
             turnId: 'badminton-exit-turn',
@@ -4100,7 +4107,7 @@ describe('App', () => {
     }
   });
 
-  it('ignores an inactive game-route sync while an ordinary assistant caption is streaming', async () => {
+  it('ignores game state events that do not belong to the current assistant caption', async () => {
     vi.useFakeTimers();
     const normalLine = '这是一条与小游戏无关的正常回复。';
 
@@ -4151,6 +4158,30 @@ describe('App', () => {
       const visibleAfterSync = container.querySelector('.compact-chat-capsule-text')?.textContent ?? '';
       expect(visibleAfterSync.length).toBeGreaterThanOrEqual(visibleBeforeSync.length);
       expect(normalLine.startsWith(visibleAfterSync)).toBe(true);
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent('neko-game-window-state-change', {
+          detail: {
+            action: 'opened',
+            gameType: 'badminton',
+            sessionId: 'overlapping-game-session',
+          },
+        }));
+        window.dispatchEvent(new CustomEvent('neko-game-window-state-change', {
+          detail: {
+            action: 'closed',
+            gameType: 'badminton',
+            sessionId: 'overlapping-game-session',
+          },
+        }));
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(100);
+      });
+
+      const visibleAfterRealClose = container.querySelector('.compact-chat-capsule-text')?.textContent ?? '';
+      expect(visibleAfterRealClose.length).toBeGreaterThanOrEqual(visibleAfterSync.length);
+      expect(normalLine.startsWith(visibleAfterRealClose)).toBe(true);
     } finally {
       vi.useRealTimers();
     }

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -1035,6 +1035,10 @@ function CompactChatApp({
   const [compactAssistantStreamingGap, setCompactAssistantStreamingGap] = useState<{
     turnId: string;
     acceptStreaming: boolean;
+    // `turn-ending` only seals the current sentence; `turn-end` closes the
+    // whole turn. Keep those phases separate so a terminal, text-less mirror
+    // turn can release the empty-state copy without exposing stale streams.
+    turnEnded: boolean;
   } | null>(null);
   const [compactChoiceLayerPlacement, setCompactChoiceLayerPlacement] = useState<'above' | 'below'>('above');
   const [compactInputToolFanOpen, setCompactInputToolFanOpen] = useState(false);
@@ -1833,6 +1837,8 @@ function CompactChatApp({
   const compactSuppressAssistantFallback = !!compactAssistantStreamingGap
     && !compactPreviewMatchesStreamingGap
     && !compactPreservedSpeechMatchesEndingGap;
+  const compactRestoreEmptyStateAfterTurnEnd = compactSuppressAssistantFallback
+    && compactAssistantStreamingGap.turnEnded;
   const compactPreservedSpeechActive = !compactMessagePreview
     && !compactSuppressAssistantFallback
     && !!compactSpeechPreviewIdRef.current
@@ -1855,7 +1861,9 @@ function CompactChatApp({
       ? i18n('chat.companionEmptyState', getChatCompanionEmptyStateFallback())
       : i18n('chat.emptyState', getChatEmptyStateFallback());
   const compactPreviewText = compactSuppressAssistantFallback
-    ? ''
+    ? compactRestoreEmptyStateAfterTurnEnd
+      ? compactEmptyStateText
+      : ''
     : compactSpeechModeActive
       ? (
         compactMessagePreview?.isStreaming
@@ -1950,11 +1958,10 @@ function CompactChatApp({
       setCompactAssistantStreamingGap({
         turnId,
         acceptStreaming: true,
+        turnEnded: false,
       });
     };
-    const handleAssistantTurnBoundary = (event: Event) => {
-      const detail = (event as CustomEvent).detail as Record<string, unknown> | undefined;
-      const turnId = detail?.turnId ? String(detail.turnId) : `assistant-gap-ended-${Date.now()}`;
+    const settleCompactCaption = (turnId: string) => {
       setCompactCaptionState(current => (
         current?.turnId === turnId
           ? {
@@ -1963,9 +1970,44 @@ function CompactChatApp({
           }
           : current
       ));
+    };
+    const handleAssistantTurnEnding = (event: Event) => {
+      const detail = (event as CustomEvent).detail as Record<string, unknown> | undefined;
+      const turnId = detail?.turnId ? String(detail.turnId) : `assistant-gap-ended-${Date.now()}`;
+      settleCompactCaption(turnId);
       setCompactAssistantStreamingGap({
         turnId,
         acceptStreaming: false,
+        turnEnded: false,
+      });
+    };
+    const handleAssistantTurnEnd = (event: Event) => {
+      const detail = (event as CustomEvent).detail as Record<string, unknown> | undefined;
+      const turnId = detail?.turnId ? String(detail.turnId) : `assistant-gap-ended-${Date.now()}`;
+      settleCompactCaption(turnId);
+      setCompactAssistantStreamingGap({
+        turnId,
+        acceptStreaming: false,
+        turnEnded: true,
+      });
+    };
+    const handleGameWindowStateChange = (event: Event) => {
+      const detail = (event as CustomEvent).detail as Record<string, unknown> | undefined;
+      if (detail?.action !== 'closed') {
+        return;
+      }
+      const sessionId = detail.sessionId ? String(detail.sessionId) : String(Date.now());
+      setCompactCaptionState(null);
+      compactSpeechPreviewIdRef.current = '';
+      compactSpeechPreviewTextRef.current = '';
+      compactSpeechPreviewTurnIdRef.current = '';
+      // Game mirrors may intentionally omit turn-end. Install a terminal gap
+      // with a distinct id so stale game streams stay hidden while the normal
+      // empty-state copy becomes visible immediately after the window closes.
+      setCompactAssistantStreamingGap({
+        turnId: `game-closed:${sessionId}`,
+        acceptStreaming: false,
+        turnEnded: true,
       });
     };
     const handleCompactCaptionUpdate = (event: Event) => {
@@ -2036,14 +2078,16 @@ function CompactChatApp({
     };
 
     window.addEventListener('neko-assistant-turn-start', handleAssistantTurnStart);
-    window.addEventListener('neko-assistant-turn-ending', handleAssistantTurnBoundary);
-    window.addEventListener('neko-assistant-turn-end', handleAssistantTurnBoundary);
+    window.addEventListener('neko-assistant-turn-ending', handleAssistantTurnEnding);
+    window.addEventListener('neko-assistant-turn-end', handleAssistantTurnEnd);
     window.addEventListener('neko-compact-caption-update', handleCompactCaptionUpdate);
+    window.addEventListener('neko-game-window-state-change', handleGameWindowStateChange);
     return () => {
       window.removeEventListener('neko-assistant-turn-start', handleAssistantTurnStart);
-      window.removeEventListener('neko-assistant-turn-ending', handleAssistantTurnBoundary);
-      window.removeEventListener('neko-assistant-turn-end', handleAssistantTurnBoundary);
+      window.removeEventListener('neko-assistant-turn-ending', handleAssistantTurnEnding);
+      window.removeEventListener('neko-assistant-turn-end', handleAssistantTurnEnd);
       window.removeEventListener('neko-compact-caption-update', handleCompactCaptionUpdate);
+      window.removeEventListener('neko-game-window-state-change', handleGameWindowStateChange);
     };
   }, []);
 

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -1993,10 +1993,14 @@ function CompactChatApp({
     };
     const handleGameWindowStateChange = (event: Event) => {
       const detail = (event as CustomEvent).detail as Record<string, unknown> | undefined;
-      if (detail?.action !== 'closed') {
+      const sessionId = detail?.sessionId ? String(detail.sessionId).trim() : '';
+      const gameType = detail?.gameType ? String(detail.gameType).trim() : '';
+      // The WS-connect reconciliation also dispatches `closed` when no route
+      // is active; that synthetic snapshot has neither identity field and may
+      // arrive while an ordinary assistant turn is already streaming.
+      if (detail?.action !== 'closed' || !sessionId || !gameType) {
         return;
       }
-      const sessionId = detail.sessionId ? String(detail.sessionId) : String(Date.now());
       setCompactCaptionState(null);
       compactSpeechPreviewIdRef.current = '';
       compactSpeechPreviewTextRef.current = '';

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -1012,6 +1012,8 @@ function CompactChatApp({
   const compactSpeechPreviewIdRef = useRef('');
   const compactSpeechPreviewTextRef = useRef('');
   const compactSpeechPreviewTurnIdRef = useRef('');
+  const activeCompactGameSessionIdRef = useRef('');
+  const compactAssistantTurnGameSessionIdRef = useRef('');
   // Identity of the turn the speech reveal is currently walking through (the
   // preview's turnStartId). Updated when the preview re-keys (messageId change),
   // so it holds the *previous* turn's anchor at the moment a new bubble arrives
@@ -1952,6 +1954,7 @@ function CompactChatApp({
     const handleAssistantTurnStart = (event: Event) => {
       const detail = (event as CustomEvent).detail as Record<string, unknown> | undefined;
       const turnId = detail?.turnId ? String(detail.turnId) : `assistant-gap-${Date.now()}`;
+      compactAssistantTurnGameSessionIdRef.current = activeCompactGameSessionIdRef.current;
       setCompactCaptionState(current => (
         current?.turnId === turnId ? current : null
       ));
@@ -1995,12 +1998,25 @@ function CompactChatApp({
       const detail = (event as CustomEvent).detail as Record<string, unknown> | undefined;
       const sessionId = detail?.sessionId ? String(detail.sessionId).trim() : '';
       const gameType = detail?.gameType ? String(detail.gameType).trim() : '';
+      if (detail?.action === 'opened') {
+        if (sessionId && gameType) {
+          activeCompactGameSessionIdRef.current = sessionId;
+        }
+        return;
+      }
       // The WS-connect reconciliation also dispatches `closed` when no route
       // is active; that synthetic snapshot has neither identity field and may
       // arrive while an ordinary assistant turn is already streaming.
       if (detail?.action !== 'closed' || !sessionId || !gameType) {
         return;
       }
+      if (activeCompactGameSessionIdRef.current === sessionId) {
+        activeCompactGameSessionIdRef.current = '';
+      }
+      if (compactAssistantTurnGameSessionIdRef.current !== sessionId) {
+        return;
+      }
+      compactAssistantTurnGameSessionIdRef.current = '';
       setCompactCaptionState(null);
       compactSpeechPreviewIdRef.current = '';
       compactSpeechPreviewTextRef.current = '';

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -1967,8 +1967,10 @@ function CompactChatApp({
       const mirroredGameSessionId = isGameMirror && mirror?.session_id
         ? String(mirror.session_id).trim()
         : '';
-      compactAssistantTurnGameSessionIdRef.current = mirroredGameSessionId
-        || activeCompactGameSessionIdRef.current;
+      // Only explicit mirror metadata owns a game turn. The active-window ref
+      // can be stale until reconnect reconciliation completes, so inheriting it
+      // would let an ordinary assistant response be cleared as game dialogue.
+      compactAssistantTurnGameSessionIdRef.current = mirroredGameSessionId;
       setCompactCaptionState(current => (
         current?.turnId === turnId ? current : null
       ));

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -1954,7 +1954,21 @@ function CompactChatApp({
     const handleAssistantTurnStart = (event: Event) => {
       const detail = (event as CustomEvent).detail as Record<string, unknown> | undefined;
       const turnId = detail?.turnId ? String(detail.turnId) : `assistant-gap-${Date.now()}`;
-      compactAssistantTurnGameSessionIdRef.current = activeCompactGameSessionIdRef.current;
+      const meta = detail?.meta && typeof detail.meta === 'object'
+        ? detail.meta as Record<string, unknown>
+        : undefined;
+      const mirror = meta?.mirror && typeof meta.mirror === 'object'
+        ? meta.mirror as Record<string, unknown>
+        : undefined;
+      const metaSource = meta?.source ? String(meta.source).trim() : '';
+      const isGameMirror = metaSource === 'game_route'
+        || metaSource === 'game_llm'
+        || metaSource === 'game-llm-result';
+      const mirroredGameSessionId = isGameMirror && mirror?.session_id
+        ? String(mirror.session_id).trim()
+        : '';
+      compactAssistantTurnGameSessionIdRef.current = mirroredGameSessionId
+        || activeCompactGameSessionIdRef.current;
       setCompactCaptionState(current => (
         current?.turnId === turnId ? current : null
       ));
@@ -2004,16 +2018,24 @@ function CompactChatApp({
         }
         return;
       }
-      // The WS-connect reconciliation also dispatches `closed` when no route
-      // is active; that synthetic snapshot has neither identity field and may
-      // arrive while an ordinary assistant turn is already streaming.
-      if (detail?.action !== 'closed' || !sessionId || !gameType) {
+      if (detail?.action !== 'closed') {
         return;
       }
-      if (activeCompactGameSessionIdRef.current === sessionId) {
+      // A reconnect reconciliation reports an inactive route without identity.
+      // Consume that snapshot only when this component already tracks a game;
+      // the same identity-less snapshot during ordinary chat remains a no-op.
+      const trackedGameSessionId = compactAssistantTurnGameSessionIdRef.current
+        || activeCompactGameSessionIdRef.current;
+      const resolvedSessionId = sessionId && gameType
+        ? sessionId
+        : (!sessionId && !gameType ? trackedGameSessionId : '');
+      if (!resolvedSessionId) {
+        return;
+      }
+      if (activeCompactGameSessionIdRef.current === resolvedSessionId) {
         activeCompactGameSessionIdRef.current = '';
       }
-      if (compactAssistantTurnGameSessionIdRef.current !== sessionId) {
+      if (compactAssistantTurnGameSessionIdRef.current !== resolvedSessionId) {
         return;
       }
       compactAssistantTurnGameSessionIdRef.current = '';
@@ -2025,7 +2047,7 @@ function CompactChatApp({
       // with a distinct id so stale game streams stay hidden while the normal
       // empty-state copy becomes visible immediately after the window closes.
       setCompactAssistantStreamingGap({
-        turnId: `game-closed:${sessionId}`,
+        turnId: `game-closed:${resolvedSessionId}`,
         acceptStreaming: false,
         turnEnded: true,
       });

--- a/static/app/app-websocket.js
+++ b/static/app/app-websocket.js
@@ -1869,6 +1869,13 @@
                         return;
                     }
                     var isNewMessage = response.isNewMessage || false;
+                    // Ordinary responses historically expose lifecycle metadata as
+                    // `meta`, while mirror responses (including game dialogue) use
+                    // `metadata`. Preserve the legacy field when present, but let
+                    // mirror turns carry their session identity into turn-start.
+                    var assistantResponseMeta = response.meta !== undefined
+                        ? response.meta
+                        : response.metadata;
                     if (response.metadata && response.metadata.game_route) {
                         var gameMeta = response.metadata.game_route;
                         var gameEvent = gameMeta.event || {};
@@ -1908,7 +1915,7 @@
                         ensureAssistantTurnStarted(
                             'gemini_response_first_chunk',
                             response.turn_id,
-                            response.meta,
+                            assistantResponseMeta,
                             response.request_id
                         );
                     }
@@ -1929,7 +1936,7 @@
                         ensureAssistantTurnStarted(
                             'gemini_response_visible_bubble',
                             response.turn_id,
-                            response.meta,
+                            assistantResponseMeta,
                             response.request_id
                         );
                     }

--- a/static/avatar-interaction-contract.test.cjs
+++ b/static/avatar-interaction-contract.test.cjs
@@ -124,14 +124,18 @@ function interactionTurnMeta(interactionId) {
   };
 }
 
-test('assistant lifecycle forwards the backend response meta unchanged', () => {
+test('assistant lifecycle forwards legacy and mirror response metadata', () => {
   const websocketSource = fs.readFileSync(
     path.join(__dirname, 'app/app-websocket.js'),
     'utf8',
   );
   assert.match(
     websocketSource,
-    /ensureAssistantTurnStarted\(\s*'gemini_response_first_chunk',\s*response\.turn_id,\s*response\.meta\s*\)/,
+    /var assistantResponseMeta = response\.meta !== undefined\s*\? response\.meta\s*:\s*response\.metadata;/,
+  );
+  assert.match(
+    websocketSource,
+    /ensureAssistantTurnStarted\(\s*'gemini_response_first_chunk',\s*response\.turn_id,\s*assistantResponseMeta\s*,/,
   );
   assert.match(
     websocketSource,


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复小游戏退出后紧凑聊天栏占位文字不恢复的问题

## 测试 / Testing

手动测试小游戏结束后聊天框可以正确恢复


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化紧凑模式空状态恢复时机：将“句子结束”和“回合结束”分阶段处理，仅在回合真正结束后恢复，避免过早切换或错误回退。
  * 改进游戏窗口关闭与助手回合同步：仅在会话匹配时清空台词/预览并触发恢复，降低流式过程中错配导致的倒退。
  * 兼容助手回合元数据字段差异，提升生命周期事件触发稳定性。
* **Tests**
  * 新增并强化紧凑态空状态兜底与回归用例：覆盖非匹配/identity-less 关闭、无文本回合结束与复杂事件序列。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->