### PR TITLE
fix(settings): 修复跨窗口设置落盘乱序

### DIFF
--- a/docs/api/rest/config.md
+++ b/docs/api/rest/config.md
@@ -69,6 +69,17 @@ Both take the connection settings used by the setup UI and return a `success` en
 
 Preference validation failures are usually represented as `{ "success": false, "error": "..." }`. Storage maintenance mode can instead surface an HTTP service-unavailable response.
 
+`GET /api/config/conversation-settings` returns a revision in both the JSON
+body and an `ETag` header. Send that ETag back as `If-Match` on `POST`; a stale
+revision returns `412 Precondition Failed` with the current settings, revision,
+decision metadata, and ETag so the caller can merge and retry. Omitting
+`If-Match` remains supported for older clients, but current clients should use
+the conditional write.
+For `independentAsrEnabled`, the bundled UI also sends
+`X-Conversation-Settings-ASR-Decision` with its JSON
+`{writeId, writerId, value}` decision tuple; this lets the server reject an
+older window's request even when it finishes last.
+
 ## Page and language data
 
 | Method and path | Purpose |

--- a/docs/api/rest/config.md
+++ b/docs/api/rest/config.md
@@ -79,6 +79,9 @@ When `reset` is `true`, the absence of restored cloud settings is
 authoritative. Current clients materialize conversation-setting defaults before
 their conditional writeback instead of repopulating the server from stale local
 storage.
+Current clients mark full-snapshot writes with
+`X-Conversation-Settings-Full-Snapshot: 1`; partial pre-hydration writes leave
+the reset marker intact so their response can still apply defaults.
 For `independentAsrEnabled`, the bundled UI also sends
 `X-Conversation-Settings-ASR-Decision` with its JSON
 `{writeId, writerId, value}` decision tuple; this lets the server reject an

--- a/docs/api/rest/config.md
+++ b/docs/api/rest/config.md
@@ -75,6 +75,10 @@ revision returns `412 Precondition Failed` with the current settings, revision,
 decision metadata, and ETag so the caller can merge and retry. Omitting
 `If-Match` remains supported for older clients, but current clients should use
 the conditional write.
+When `reset` is `true`, the absence of restored cloud settings is
+authoritative. Current clients materialize conversation-setting defaults before
+their conditional writeback instead of repopulating the server from stale local
+storage.
 For `independentAsrEnabled`, the bundled UI also sends
 `X-Conversation-Settings-ASR-Decision` with its JSON
 `{writeId, writerId, value}` decision tuple; this lets the server reject an

--- a/docs/ja/api/rest/config.md
+++ b/docs/ja/api/rest/config.md
@@ -74,6 +74,9 @@ POST body は `coreApi`、`coreApiKey`、`assistApi` など同梱設定 UI の f
 revision が古い場合は `412 Precondition Failed` とともに現在の設定、revision、decision
 metadata、ETag が返るため、caller は merge 後に retry できます。旧 client との互換性の
 ため `If-Match` 省略も受け付けますが、現行 client は conditional write を使用します。
+`reset` が `true` の場合、cloud restore に設定が存在しないこと自体が authoritative
+です。現行 client は古い local storage から server を再投入せず、conditional
+writeback の前に会話設定の既定値を具体化します。
 `independentAsrEnabled` の更新時、bundled UI は
 `X-Conversation-Settings-ASR-Decision` に JSON
 `{writeId, writerId, value}` decision tuple も送り、古い window request が最後に完了しても

--- a/docs/ja/api/rest/config.md
+++ b/docs/ja/api/rest/config.md
@@ -77,6 +77,9 @@ metadata、ETag が返るため、caller は merge 後に retry できます。�
 `reset` が `true` の場合、cloud restore に設定が存在しないこと自体が authoritative
 です。現行 client は古い local storage から server を再投入せず、conditional
 writeback の前に会話設定の既定値を具体化します。
+現行 client は full-snapshot write に
+`X-Conversation-Settings-Full-Snapshot: 1` を付けます。pre-hydration の
+partial write は reset marker を保持し、response 側で既定値を適用できるようにします。
 `independentAsrEnabled` の更新時、bundled UI は
 `X-Conversation-Settings-ASR-Decision` に JSON
 `{writeId, writerId, value}` decision tuple も送り、古い window request が最後に完了しても

--- a/docs/ja/api/rest/config.md
+++ b/docs/ja/api/rest/config.md
@@ -69,6 +69,16 @@ POST body は `coreApi`、`coreApiKey`、`assistApi` など同梱設定 UI の f
 
 検証失敗は通常 `{ "success": false, "error": "..." }`、storage maintenance 中は HTTP service unavailable になる場合があります。
 
+`GET /api/config/conversation-settings` は JSON body と `ETag` header の
+両方で revision を返します。`POST` ではその ETag を `If-Match` として送り返してください。
+revision が古い場合は `412 Precondition Failed` とともに現在の設定、revision、decision
+metadata、ETag が返るため、caller は merge 後に retry できます。旧 client との互換性の
+ため `If-Match` 省略も受け付けますが、現行 client は conditional write を使用します。
+`independentAsrEnabled` の更新時、bundled UI は
+`X-Conversation-Settings-ASR-Decision` に JSON
+`{writeId, writerId, value}` decision tuple も送り、古い window request が最後に完了しても
+server が古い decision を拒否できるようにします。
+
 ## ページ・言語データ
 
 | メソッドとパス | 用途 |

--- a/docs/zh-CN/api/rest/config.md
+++ b/docs/zh-CN/api/rest/config.md
@@ -69,6 +69,14 @@ POST 请求体使用第一方设置页返回的字段名，例如 `coreApi`、`c
 
 偏好校验失败通常表示为 `{ "success": false, "error": "..." }`；存储维护模式可改为 HTTP 服务不可用响应。
 
+`GET /api/config/conversation-settings` 会同时在 JSON body 和 `ETag`
+响应头中返回版本。调用方应在 `POST` 时通过 `If-Match` 回传该 ETag；版本过期时服务端
+返回 `412 Precondition Failed`，并附带当前设置、版本、决策元数据和 ETag，供调用方合并后
+重试。为兼容旧客户端，省略 `If-Match` 仍可写入，但当前客户端应使用条件写入。
+写入 `independentAsrEnabled` 时，内置 UI 还会通过
+`X-Conversation-Settings-ASR-Decision` 发送 JSON
+`{writeId, writerId, value}` 决策元组，让服务端即使遇到旧窗口请求最后完成，也能拒绝旧决策。
+
 ## 页面与语言数据
 
 | 方法和路径 | 用途 |

--- a/docs/zh-CN/api/rest/config.md
+++ b/docs/zh-CN/api/rest/config.md
@@ -73,6 +73,8 @@ POST 请求体使用第一方设置页返回的字段名，例如 `coreApi`、`c
 响应头中返回版本。调用方应在 `POST` 时通过 `If-Match` 回传该 ETag；版本过期时服务端
 返回 `412 Precondition Failed`，并附带当前设置、版本、决策元数据和 ETag，供调用方合并后
 重试。为兼容旧客户端，省略 `If-Match` 仍可写入，但当前客户端应使用条件写入。
+当 `reset` 为 `true` 时，云端恢复结果中没有设置本身就是权威状态。当前客户端会先还原
+对话设置默认值再执行条件回写，而不会用过期的本地存储重新填充服务端。
 写入 `independentAsrEnabled` 时，内置 UI 还会通过
 `X-Conversation-Settings-ASR-Decision` 发送 JSON
 `{writeId, writerId, value}` 决策元组，让服务端即使遇到旧窗口请求最后完成，也能拒绝旧决策。

--- a/docs/zh-CN/api/rest/config.md
+++ b/docs/zh-CN/api/rest/config.md
@@ -75,6 +75,8 @@ POST 请求体使用第一方设置页返回的字段名，例如 `coreApi`、`c
 重试。为兼容旧客户端，省略 `If-Match` 仍可写入，但当前客户端应使用条件写入。
 当 `reset` 为 `true` 时，云端恢复结果中没有设置本身就是权威状态。当前客户端会先还原
 对话设置默认值再执行条件回写，而不会用过期的本地存储重新填充服务端。
+当前客户端会为完整快照写入附带 `X-Conversation-Settings-Full-Snapshot: 1`；水合前的部分
+写入会保留 reset 标记，使响应仍能触发默认值恢复。
 写入 `independentAsrEnabled` 时，内置 UI 还会通过
 `X-Conversation-Settings-ASR-Decision` 发送 JSON
 `{writeId, writerId, value}` 决策元组，让服务端即使遇到旧窗口请求最后完成，也能拒绝旧决策。

--- a/main_routers/config_router/preferences.py
+++ b/main_routers/config_router/preferences.py
@@ -303,7 +303,15 @@ async def save_conversation_settings(request: Request):
                 },
             )
         if not result.success:
-            return {"success": False, "error": "保存失败"}
+            return JSONResponse(
+                status_code=500,
+                headers=response_headers,
+                content={
+                    "success": False,
+                    "error": "保存失败",
+                    **response_payload,
+                },
+            )
 
         if (
             isinstance(data.get("noiseReductionEnabled"), bool)

--- a/main_routers/config_router/preferences.py
+++ b/main_routers/config_router/preferences.py
@@ -42,6 +42,7 @@ from utils.cloudsave_runtime import MaintenanceModeError
 
 _CONVERSATION_SETTINGS_ASR_DECISION_HEADER = "x-conversation-settings-asr-decision"
 _CONVERSATION_SETTINGS_ETAG_RE = re.compile(r'^(?:W/)?"conversation-settings-(\d+)"$')
+_NOISE_REDUCTION_APPLY_LOCK = asyncio.Lock()
 
 
 def _conversation_settings_etag(revision: int) -> str:
@@ -111,6 +112,18 @@ async def _apply_noise_reduction_to_active_sessions(enabled: bool):
                 )
     except Exception as e:
         logger.warning(f"Failed to apply noise reduction to active sessions: {e}")
+
+
+async def _apply_noise_reduction_if_current(enabled: bool, revision: int):
+    """Serialize runtime updates and discard revisions superseded before apply."""
+    async with _NOISE_REDUCTION_APPLY_LOCK:
+        current = await aload_global_conversation_settings_snapshot()
+        if (
+            current.revision != revision
+            or current.settings.get("noiseReductionEnabled") is not enabled
+        ):
+            return
+        await _apply_noise_reduction_to_active_sessions(enabled)
 
 
 @router.get("/preferences")
@@ -300,7 +313,10 @@ async def save_conversation_settings(request: Request):
             and result.snapshot.settings.get("noiseReductionEnabled")
             == data["noiseReductionEnabled"]
         ):
-            await _apply_noise_reduction_to_active_sessions(data['noiseReductionEnabled'])
+            await _apply_noise_reduction_if_current(
+                data["noiseReductionEnabled"],
+                result.snapshot.revision,
+            )
 
         return JSONResponse(
             headers=response_headers,

--- a/main_routers/config_router/preferences.py
+++ b/main_routers/config_router/preferences.py
@@ -182,7 +182,9 @@ async def set_preferred_model(request: Request):
         if not data or 'model_path' not in data:
             return {"success": False, "error": "无效的数据"}
         
-        if move_model_to_top(data['model_path']):
+        # move_model_to_top performs a cross-process locked read-modify-write.
+        # Keep lock waits off the application event loop.
+        if await asyncio.to_thread(move_model_to_top, data['model_path']):
             return {"success": True, "message": "首选模型已更新"}
         else:
             return {"success": False, "error": "模型不存在或更新失败"}

--- a/main_routers/config_router/preferences.py
+++ b/main_routers/config_router/preferences.py
@@ -114,14 +114,11 @@ async def _apply_noise_reduction_to_active_sessions(enabled: bool):
         logger.warning(f"Failed to apply noise reduction to active sessions: {e}")
 
 
-async def _apply_noise_reduction_if_current(enabled: bool, revision: int):
-    """Serialize runtime updates and discard revisions superseded before apply."""
+async def _apply_noise_reduction_if_current(enabled: bool):
+    """Serialize runtime updates and discard superseded noise values."""
     async with _NOISE_REDUCTION_APPLY_LOCK:
         current = await aload_global_conversation_settings_snapshot()
-        if (
-            current.revision != revision
-            or current.settings.get("noiseReductionEnabled") is not enabled
-        ):
+        if current.settings.get("noiseReductionEnabled") is not enabled:
             return
         await _apply_noise_reduction_to_active_sessions(enabled)
 
@@ -315,7 +312,6 @@ async def save_conversation_settings(request: Request):
         ):
             await _apply_noise_reduction_if_current(
                 data["noiseReductionEnabled"],
-                result.snapshot.revision,
             )
 
         return JSONResponse(

--- a/main_routers/config_router/preferences.py
+++ b/main_routers/config_router/preferences.py
@@ -66,6 +66,7 @@ def _conversation_settings_response_payload(snapshot) -> dict:
         "settings": snapshot.settings,
         "revision": snapshot.revision,
         "decisions": decisions,
+        "reset": snapshot.reset,
     }
 
 

--- a/main_routers/config_router/preferences.py
+++ b/main_routers/config_router/preferences.py
@@ -41,6 +41,7 @@ from utils.cloudsave_runtime import MaintenanceModeError
 
 
 _CONVERSATION_SETTINGS_ASR_DECISION_HEADER = "x-conversation-settings-asr-decision"
+_CONVERSATION_SETTINGS_FULL_SNAPSHOT_HEADER = "x-conversation-settings-full-snapshot"
 _CONVERSATION_SETTINGS_ETAG_RE = re.compile(r'^(?:W/)?"conversation-settings-(\d+)"$')
 _NOISE_REDUCTION_APPLY_LOCK = asyncio.Lock()
 
@@ -287,6 +288,9 @@ async def save_conversation_settings(request: Request):
             data,
             expected_revision=expected_revision,
             asr_decision=asr_decision,
+            full_snapshot=(
+                request.headers.get(_CONVERSATION_SETTINGS_FULL_SNAPSHOT_HEADER) == "1"
+            ),
         )
         response_payload = _conversation_settings_response_payload(result.snapshot)
         response_headers = {

--- a/main_routers/config_router/preferences.py
+++ b/main_routers/config_router/preferences.py
@@ -21,10 +21,50 @@ Split out of the former monolithic ``main_routers/config_router.py``.
 from ._shared import logger, router
 
 import asyncio
-from fastapi import Request
+import json
+import re
+
+from fastapi import Request, Response
+from fastapi.responses import JSONResponse
 from ..shared_state import get_session_manager
-from utils.preferences import aload_user_preferences, update_model_preferences, validate_model_preferences, move_model_to_top, aload_global_conversation_settings, save_global_conversation_settings, GLOBAL_CONVERSATION_KEY
+from utils.preferences import (
+    GLOBAL_CONVERSATION_KEY,
+    aload_global_conversation_settings_snapshot,
+    aload_user_preferences,
+    move_model_to_top,
+    save_global_conversation_settings_versioned,
+    update_model_preferences,
+    validate_model_preferences,
+)
 from utils.cloudsave_runtime import MaintenanceModeError
+
+
+_CONVERSATION_SETTINGS_ASR_DECISION_HEADER = "x-conversation-settings-asr-decision"
+_CONVERSATION_SETTINGS_ETAG_RE = re.compile(r'^(?:W/)?"conversation-settings-(\d+)"$')
+
+
+def _conversation_settings_etag(revision: int) -> str:
+    return f'"conversation-settings-{revision}"'
+
+
+def _parse_conversation_settings_if_match(value: str | None) -> int | None:
+    if value is None:
+        return None
+    match = _CONVERSATION_SETTINGS_ETAG_RE.fullmatch(value.strip())
+    if match is None:
+        raise ValueError("If-Match 格式无效")
+    return int(match.group(1))
+
+
+def _conversation_settings_response_payload(snapshot) -> dict:
+    decisions = {}
+    if snapshot.asr_decision is not None:
+        decisions["independentAsrEnabled"] = snapshot.asr_decision
+    return {
+        "settings": snapshot.settings,
+        "revision": snapshot.revision,
+        "decisions": decisions,
+    }
 
 
 async def _apply_noise_reduction_to_active_sessions(enabled: bool):
@@ -152,7 +192,7 @@ async def set_preferred_model(request: Request):
 
 
 @router.get("/conversation-settings")
-async def get_conversation_settings():
+async def get_conversation_settings(response: Response):
     """Get global conversation settings (read from the user_preferences.json synced backup).
 
     Also returns the telemetry A/B test branch, so the frontend can pick default
@@ -176,8 +216,14 @@ async def get_conversation_settings():
             # 下次 fetch 成功再决议
             logger.exception("解析 telemetry branch 失败，返回 null 让前端保留 pending marker")
             telemetry_branch = None
-        settings = await aload_global_conversation_settings()
-        return {"success": True, "settings": settings, "telemetryBranch": telemetry_branch}
+        snapshot = await aload_global_conversation_settings_snapshot()
+        response.headers["ETag"] = _conversation_settings_etag(snapshot.revision)
+        response.headers["Cache-Control"] = "no-store"
+        return {
+            "success": True,
+            **_conversation_settings_response_payload(snapshot),
+            "telemetryBranch": telemetry_branch,
+        }
     except Exception as e:
         logger.exception(f"获取对话设置失败: {e}")
         return {"success": False, "error": "Internal server error", "settings": {}}
@@ -185,19 +231,75 @@ async def get_conversation_settings():
 
 @router.post("/conversation-settings")
 async def save_conversation_settings(request: Request):
-    """Save global conversation settings (synced to the user_preferences.json backup)."""
+    """CAS-save global conversation settings with legacy-client compatibility."""
     try:
         data = await request.json()
         if not isinstance(data, dict):
             return {"success": False, "error": "请求体必须为对象"}
 
-        if not await asyncio.to_thread(save_global_conversation_settings, data):
+        asr_decision = None
+        raw_asr_decision = request.headers.get(
+            _CONVERSATION_SETTINGS_ASR_DECISION_HEADER
+        )
+        if raw_asr_decision:
+            try:
+                parsed_asr_decision = json.loads(raw_asr_decision)
+            except (TypeError, ValueError):
+                return JSONResponse(
+                    status_code=400,
+                    content={"success": False, "error": "ASR decision header 格式无效"},
+                )
+            if isinstance(parsed_asr_decision, dict):
+                asr_decision = parsed_asr_decision
+        try:
+            expected_revision = _parse_conversation_settings_if_match(
+                request.headers.get("if-match")
+            )
+        except ValueError as exc:
+            return JSONResponse(
+                status_code=400,
+                content={"success": False, "error": str(exc)},
+            )
+
+        result = await asyncio.to_thread(
+            save_global_conversation_settings_versioned,
+            data,
+            expected_revision=expected_revision,
+            asr_decision=asr_decision,
+        )
+        response_payload = _conversation_settings_response_payload(result.snapshot)
+        response_headers = {
+            "ETag": _conversation_settings_etag(result.snapshot.revision),
+            "Cache-Control": "no-store",
+        }
+        if result.conflict:
+            return JSONResponse(
+                status_code=412,
+                headers=response_headers,
+                content={
+                    "success": False,
+                    "error": "conversation settings version conflict",
+                    **response_payload,
+                },
+            )
+        if not result.success:
             return {"success": False, "error": "保存失败"}
 
-        if 'noiseReductionEnabled' in data:
+        if (
+            isinstance(data.get("noiseReductionEnabled"), bool)
+            and result.snapshot.settings.get("noiseReductionEnabled")
+            == data["noiseReductionEnabled"]
+        ):
             await _apply_noise_reduction_to_active_sessions(data['noiseReductionEnabled'])
 
-        return {"success": True, "message": "对话设置已保存"}
+        return JSONResponse(
+            headers=response_headers,
+            content={
+                "success": True,
+                "message": "对话设置已保存",
+                **response_payload,
+            },
+        )
     except MaintenanceModeError:
         raise
     except Exception as e:

--- a/main_routers/config_router/preferences.py
+++ b/main_routers/config_router/preferences.py
@@ -237,7 +237,10 @@ async def save_conversation_settings(request: Request):
     try:
         data = await request.json()
         if not isinstance(data, dict):
-            return {"success": False, "error": "请求体必须为对象"}
+            return JSONResponse(
+                status_code=400,
+                content={"success": False, "error": "请求体必须为对象"},
+            )
 
         asr_decision = None
         raw_asr_decision = request.headers.get(

--- a/main_routers/config_router/preferences.py
+++ b/main_routers/config_router/preferences.py
@@ -31,6 +31,7 @@ from utils.preferences import (
     GLOBAL_CONVERSATION_KEY,
     aload_global_conversation_settings_snapshot,
     aload_user_preferences,
+    is_valid_asr_decision,
     move_model_to_top,
     save_global_conversation_settings_versioned,
     update_model_preferences,
@@ -254,8 +255,12 @@ async def save_conversation_settings(request: Request):
                     status_code=400,
                     content={"success": False, "error": "ASR decision header 格式无效"},
                 )
-            if isinstance(parsed_asr_decision, dict):
-                asr_decision = parsed_asr_decision
+            if not is_valid_asr_decision(parsed_asr_decision):
+                return JSONResponse(
+                    status_code=400,
+                    content={"success": False, "error": "ASR decision header 格式无效"},
+                )
+            asr_decision = parsed_asr_decision
         try:
             expected_revision = _parse_conversation_settings_if_match(
                 request.headers.get("if-match")

--- a/static/app/app-audio-capture.js
+++ b/static/app/app-audio-capture.js
@@ -1132,13 +1132,13 @@
         try {
             localStorage.setItem('neko_noise_reduction', S.noiseReductionEnabled ? '1' : '0');
         } catch (e) { }
-        // 同步到后端 conversation-settings
+        // Route through the shared CAS client so cross-window toggles carry
+        // If-Match and reconcile 412 snapshots instead of bypassing ordering.
         try {
-            fetch('/api/config/conversation-settings', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ noiseReductionEnabled: S.noiseReductionEnabled })
-            });
+            if (window.appSettings
+                && typeof window.appSettings.saveSettings === 'function') {
+                window.appSettings.saveSettings();
+            }
         } catch (e) { }
     }
 

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -149,10 +149,28 @@
         const adoptedAsr = _adoptServerAsrDecision(data);
         const serverSettings = data && data.settings;
         if (!serverSettings || typeof serverSettings !== 'object') return;
+        const serverAsrDecision = _serverAsrDecision(data);
+        const preserveLocalAsrDecision = !!(_lastAsrDecision
+            && (!serverAsrDecision
+                || _asrDecisionOutranks(_lastAsrDecision, serverAsrDecision)));
+        const acceptedSettings = {};
         for (const key of Object.keys(serverSettings)) {
-            if (key === 'independentAsrEnabled' && adoptedAsr) continue;
+            if (key === 'independentAsrEnabled'
+                && (adoptedAsr || preserveLocalAsrDecision)) continue;
             if (_dirtySettingsKeys.has(key)) continue;
-            if (serverSettings[key] !== undefined) S[key] = serverSettings[key];
+            if (serverSettings[key] !== undefined) {
+                acceptedSettings[key] = serverSettings[key];
+            }
+        }
+        applySharedRuntimeSettings(acceptedSettings);
+        // Preserve server-only conversation keys that are intentionally not in
+        // the cross-window shared-settings list.
+        for (const key of Object.keys(acceptedSettings)) {
+            if (_SHARED_SETTINGS_KEYS.indexOf(key) !== -1 || key === 'userLanguage') continue;
+            S[key] = acceptedSettings[key];
+            if (Object.prototype.hasOwnProperty.call(window, key)) {
+                window[key] = S[key];
+            }
         }
         _settingsMergedFromServer = true;
         if (_settingsBaseline) {
@@ -483,6 +501,12 @@
                 S[key] = settings[key];
                 changed = true;
             }
+            // saveSettings() prefers several window.* mirrors over S. Keep every
+            // mirror already present on this window aligned with the accepted
+            // shared value so a later save cannot roll the merge back.
+            if (Object.prototype.hasOwnProperty.call(window, key)) {
+                window[key] = S[key];
+            }
         });
         if (
             Object.prototype.hasOwnProperty.call(settings, 'userLanguage') &&
@@ -490,13 +514,6 @@
         ) {
             S.userLanguage = settings.userLanguage;
             changed = true;
-        }
-        // saveSettings() builds currentSlopFilter from window.slopFilterEnabled ?? S,
-        // so a cross-window storage sync that only touched S would let a later save in
-        // this tab revert the switch from a stale window value. Mirror it here.
-        // (The other shared bool keys carry the same latent gap — pre-existing.)
-        if (Object.prototype.hasOwnProperty.call(settings, 'slopFilterEnabled')) {
-            window.slopFilterEnabled = S.slopFilterEnabled;
         }
         if (changed && S.renderQuality) {
             window.cursorFollowPerformanceLevel = U.mapRenderQualityToFollowPerf(S.renderQuality);

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -253,7 +253,13 @@
         // Persist the reconciled runtime snapshot for offline restarts and
         // notify sibling windows, but do not advertise server winners as fresh
         // user intent or enqueue another POST.
-        saveSettings({ skipServerSync: true, serverMerged: true });
+        saveSettings({
+            skipServerSync: true,
+            serverMerged: true,
+            serverAuthoritativeKeys: Object.keys(acceptedSettings).filter(
+                (key) => _SHARED_SETTINGS_KEYS.indexOf(key) !== -1
+            )
+        });
         if (changed) {
             if (typeof window.appProactive !== 'undefined'
                 && window.appProactive.scheduleProactiveChat) {
@@ -491,7 +497,12 @@
      * window that HAD merged the server value adopts it, mis-stamps its next
      * handshake, and POSTs the wrong value back on its next full sync.
      */
-    function _writeSharedSettings(snapshot, explicitKeys, pendingRecovery) {
+    function _writeSharedSettings(
+        snapshot,
+        explicitKeys,
+        pendingRecovery,
+        serverAuthoritativeKeys
+    ) {
         const payload = Object.assign({}, snapshot);
         payload[_SHARED_WRITE_META_KEY] = {
             writeId: _nextSharedWriteId(),
@@ -507,6 +518,11 @@
         };
         const ownMeta = payload[_SHARED_WRITE_META_KEY];
         _rememberSharedKeyWrites(ownMeta.changedKeys, ownMeta);
+        // Server winners need provenance too. Otherwise a sibling with any
+        // older explicit token can mistake an accepted GET/412 value for an
+        // incidental stale copy and discard it. Stamp only fields actually
+        // accepted from the response; pending/local winners stay untouched.
+        _rememberSharedKeyWrites(serverAuthoritativeKeys || [], ownMeta);
         ownMeta.knownKeyWrites = _knownSharedKeyWritesSnapshot();
         if (ownMeta.changedKeys.indexOf('independentAsrEnabled') !== -1) {
             _noteAsrDecision(ownMeta.writeId, ownMeta.writerId, snapshot.independentAsrEnabled);
@@ -1048,7 +1064,8 @@
      *   skipServerSync?: boolean,
      *   serverMerged?: boolean,
      *   pendingRecovery?: boolean,
-     *   explicitSharedKeys?: string[]
+     *   explicitSharedKeys?: string[],
+     *   serverAuthoritativeKeys?: string[]
      * }} [options]
      *   传 skipServerSync 跳过 POST；
      *   serverMerged 表示共享快照来自服务端合并，不得标记成新的用户修改。
@@ -1062,6 +1079,10 @@
         const explicitSharedKeys = options && Array.isArray(options.explicitSharedKeys)
             ? options.explicitSharedKeys
             : null;
+        const serverAuthoritativeKeys =
+            options && Array.isArray(options.serverAuthoritativeKeys)
+                ? options.serverAuthoritativeKeys
+                : [];
         // 从全局变量读取最新值（确保同步 live2d.js 中的更改）
         const currentProactive = typeof window.proactiveChatEnabled !== 'undefined'
             ? window.proactiveChatEnabled
@@ -1184,7 +1205,8 @@
             explicitSharedKeys !== null
                 ? explicitSharedKeys
                 : (serverMerged ? [] : _collectExplicitSharedKeys(settings)),
-            pendingRecovery
+            pendingRecovery,
+            serverAuthoritativeKeys
         );
 
         // 同步回共享状态，保持一致性
@@ -1537,6 +1559,7 @@
                     hasUpdate = true;
                 }
 
+                const acceptedSharedSettings = {};
                 if (serverSettings) {
                     // Field-level merge (Codex P2): apply server values to the
                     // keys the user never touched, preserve the dirty ones. A
@@ -1545,7 +1568,6 @@
                     // hydrates from the server — the old whole-merge-drop let
                     // one unrelated toggle turn the entire boot-default
                     // snapshot into the POSTed truth.
-                    const acceptedSharedSettings = {};
                     for (const key of Object.keys(serverSettings)) {
                         if (serverSettings[key] === undefined) continue;
                         if (_dirtySettingsKeys.has(key)) continue;
@@ -1610,7 +1632,12 @@
                     window.proactiveVisionInterval = S.proactiveVisionInterval;
                     window.textGuardMaxLength = S.textGuardMaxLength;
                     // 同步回 localStorage
-                    saveSettings({ serverMerged: true });
+                    saveSettings({
+                        serverMerged: true,
+                        serverAuthoritativeKeys: Object.keys(
+                            acceptedSharedSettings
+                        )
+                    });
                     // 重新初始化主动搭话调度器（使用最新标志）
                     if (typeof window.appProactive !== 'undefined' && window.appProactive.scheduleProactiveChat) {
                         window.appProactive.scheduleProactiveChat();

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -1506,6 +1506,10 @@
             // Cross-window independent-ASR flips are authoritative (Codex P2):
             // detect the flip BEFORE applySharedRuntimeSettings mutates S.
             const meta = _readSharedWriteMeta(settings);
+            const writeIdFloorBeforeIncoming = Math.max(
+                _lastSharedWriteId,
+                _lastAppliedSharedWriteId
+            );
             const asrValueDiffers =
                 Object.prototype.hasOwnProperty.call(settings, 'independentAsrEnabled') &&
                 S.independentAsrEnabled !== settings.independentAsrEnabled;
@@ -1560,7 +1564,7 @@
             }
             const serverMergePredatesLocalWrite = !!meta
                 && meta.changedKeys.length === 0
-                && meta.writeId <= _lastSharedWriteId;
+                && meta.writeId <= writeIdFloorBeforeIncoming;
             if (serverMergePredatesLocalWrite) {
                 if (incoming === settings) incoming = Object.assign({}, settings);
                 // Non-ASR server-merge fields have no per-key decision token.

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -109,7 +109,8 @@
     function _normalizeServerAsrDecision(value) {
         if (!value || typeof value !== 'object') return null;
         if (!_isValidAsrWriteId(value.writeId)) return null;
-        if (typeof value.writerId !== 'string' || !value.writerId) return null;
+        if (typeof value.writerId !== 'string'
+            || !/^[\x20-\x7E]{1,128}$/.test(value.writerId)) return null;
         if (typeof value.value !== 'boolean') return null;
         return {
             writeId: value.writeId,
@@ -1866,6 +1867,24 @@
             if (asrValueIsStale) {
                 incoming = Object.assign({}, settings);
                 delete incoming.independentAsrEnabled;
+            }
+            if (meta) {
+                for (const key of meta.changedKeys) {
+                    if (key === 'independentAsrEnabled') continue;
+                    if (!Object.prototype.hasOwnProperty.call(
+                        incoming,
+                        key
+                    )) continue;
+                    const localToken = _knownSharedKeyWrites[key];
+                    if (localToken
+                        && !_sharedWriteTokenOutranks(meta, localToken)
+                        && !_sharedWriteTokensEqual(meta, localToken)) {
+                        if (incoming === settings) {
+                            incoming = Object.assign({}, settings);
+                        }
+                        delete incoming[key];
+                    }
+                }
             }
             const serverMergePredatesLocalWrite = !!meta
                 && meta.changedKeys.length === 0

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -1640,11 +1640,13 @@
             if (pendingKeysToReassert.length > 0) {
                 // A server-merge broadcast can have been built before this
                 // window's latest pending edit reached its sender. Restore the
-                // local full snapshot without enqueueing another POST; the
+                // local full snapshot without claiming a NEW user edit: another
+                // window may already hold a newer pending choice for the same
+                // key, and must keep filtering this recovery broadcast. The
                 // already queued user sync remains the sole server writer.
                 saveSettings({
                     skipServerSync: true,
-                    explicitSharedKeys: pendingKeysToReassert
+                    serverMerged: true
                 });
             }
         } catch (error) {

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -1560,9 +1560,7 @@
             }
             const serverMergePredatesLocalWrite = !!meta
                 && meta.changedKeys.length === 0
-                && (meta.writeId < _lastSharedWriteId
-                    || (meta.writeId === _lastSharedWriteId
-                        && meta.writerId < _SHARED_WRITER_ID));
+                && meta.writeId <= _lastSharedWriteId;
             if (serverMergePredatesLocalWrite) {
                 if (incoming === settings) incoming = Object.assign({}, settings);
                 // Non-ASR server-merge fields have no per-key decision token.

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -754,15 +754,13 @@
     function _markEtagConfirmedSharedSettings(
         settingsAtSend,
         serverSettings,
-        mutationVersionAtSend,
-        payloadWasFull
+        mutationVersionAtSend
     ) {
         if (!serverSettings || typeof serverSettings !== 'object') return;
         _SHARED_SETTINGS_KEYS.forEach((key) => {
             if (!Object.prototype.hasOwnProperty.call(serverSettings, key)) return;
-            if (!payloadWasFull
-                && (!Object.prototype.hasOwnProperty.call(settingsAtSend, key)
-                    || settingsAtSend[key] !== serverSettings[key])) return;
+            if (!Object.prototype.hasOwnProperty.call(settingsAtSend, key)
+                || settingsAtSend[key] !== serverSettings[key]) return;
             _conversationSettingsEtagKeyMutationVersions[key] =
                 mutationVersionAtSend;
         });
@@ -1041,8 +1039,7 @@
                         _markEtagConfirmedSharedSettings(
                             settings,
                             data.settings,
-                            mutationVersionAtSend,
-                            mergedAtSend
+                            mutationVersionAtSend
                         );
                     }
                     const changedWhileInFlight = _settingsChangedSince(
@@ -1631,8 +1628,9 @@
                     && serverResult.revision > _conversationSettingsRevision;
                 const shouldAdoptServerVersion =
                     !Number.isInteger(_conversationSettingsRevision)
-                    || !Number.isInteger(serverResult.revision)
-                    || serverResult.revision >= _conversationSettingsRevision;
+                    || (Number.isInteger(serverResult.revision)
+                        && serverResult.revision
+                            >= _conversationSettingsRevision);
                 if (serverResult.etag && shouldAdoptServerVersion) {
                     _conversationSettingsEtag = serverResult.etag;
                     if (Number.isInteger(serverResult.revision)) {

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -753,7 +753,11 @@
                     const nextEtag = _responseEtag(response);
                     if (nextEtag) _conversationSettingsEtag = nextEtag;
                     if (response.status === 412) {
-                        _mergeConversationSettingsSnapshot(data);
+                        const preservedKeys = new Set(_pendingSettingsKeys);
+                        _settingsChangedSince(settings).forEach((key) => {
+                            preservedKeys.add(key);
+                        });
+                        _mergeConversationSettingsSnapshot(data, preservedKeys);
                         if (attempt + 1 < _CONVERSATION_SETTINGS_MAX_ATTEMPTS) {
                             continue;
                         }

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -43,6 +43,7 @@
     // the keys the writing user EXPLICITLY changed plus a monotonic write id,
     // and the listener grants ASR authority only on that evidence.
     const _SHARED_WRITE_META_KEY = '_sharedWriteMeta';
+    const _ASR_WRITE_ID_MAX_FUTURE_SKEW_MS = 365 * 24 * 60 * 60 * 1000;
     let _lastSharedWriteId = 0;
     let _lastAppliedSharedWriteId = 0;
     // Window-unique second sort key for concurrent shared-settings writes. Per
@@ -59,6 +60,13 @@
     // other each adopt the other and stay swapped forever. That needs no
     // millisecond tie at all -- a strictly older foreign write still wins.
     let _lastAsrDecision = null;
+    function _isValidAsrWriteId(value) {
+        const maxAccepted = Math.min(
+            Number.MAX_SAFE_INTEGER - 1,
+            Date.now() + _ASR_WRITE_ID_MAX_FUTURE_SKEW_MS
+        );
+        return Number.isSafeInteger(value) && value >= 0 && value <= maxAccepted;
+    }
     function _noteAsrDecision(writeId, writerId, value) {
         // A write that merely re-asserts the value already decided is not a new
         // choice: _dirtySettingsKeys is monotone, so every later save from a
@@ -97,7 +105,7 @@
     }
     function _normalizeServerAsrDecision(value) {
         if (!value || typeof value !== 'object') return null;
-        if (!Number.isSafeInteger(value.writeId) || value.writeId < 0) return null;
+        if (!_isValidAsrWriteId(value.writeId)) return null;
         if (typeof value.writerId !== 'string' || !value.writerId) return null;
         if (typeof value.value !== 'boolean') return null;
         return {
@@ -469,7 +477,7 @@
     function _readSharedWriteMeta(settings) {
         const meta = settings ? settings[_SHARED_WRITE_META_KEY] : null;
         if (!meta || typeof meta !== 'object') return null;
-        if (!Number.isSafeInteger(meta.writeId) || meta.writeId < 0) return null;
+        if (!_isValidAsrWriteId(meta.writeId)) return null;
         return {
             writeId: meta.writeId,
             // Absent on snapshots written by the previous build: '' sorts below
@@ -488,8 +496,7 @@
             // matching decision: null routes the comparison back to
             // (writeId, writerId), i.e. today's behaviour.
             asrDecision: (meta.asrDecision
-                && Number.isSafeInteger(meta.asrDecision.writeId)
-                && meta.asrDecision.writeId >= 0)
+                && _isValidAsrWriteId(meta.asrDecision.writeId))
                 ? {
                     writeId: meta.asrDecision.writeId,
                     writerId: typeof meta.asrDecision.writerId === 'string'
@@ -558,11 +565,15 @@
     function _noteCrossWindowMutations(settings, explicitKeys) {
         _SHARED_SETTINGS_KEYS.forEach((key) => {
             if (!Object.prototype.hasOwnProperty.call(settings, key)) return;
-            // A server-merge broadcast carries an empty changedKeys list and
-            // must not be mistaken for newer user intent. Metadata-less
-            // previous-build writers retain their value-change fallback.
-            if (explicitKeys && explicitKeys.indexOf(key) === -1) return;
-            if (S[key] === settings[key]) return;
+            // Metadata declares user intent per key, including a same-value
+            // choice made while a request is in flight. Server-merge broadcasts
+            // carry an empty list; metadata-less previous-build writers retain
+            // their value-change fallback.
+            if (explicitKeys) {
+                if (explicitKeys.indexOf(key) === -1) return;
+            } else if (S[key] === settings[key]) {
+                return;
+            }
             _crossWindowMutationVersion += 1;
             _crossWindowKeyMutationVersions[key] = _crossWindowMutationVersion;
         });
@@ -584,6 +595,14 @@
                 window[key] = S[key];
             }
         });
+        if (Object.prototype.hasOwnProperty.call(settings, 'noiseReductionEnabled')) {
+            try {
+                localStorage.setItem(
+                    'neko_noise_reduction',
+                    S.noiseReductionEnabled ? '1' : '0'
+                );
+            } catch (_) { }
+        }
         if (
             Object.prototype.hasOwnProperty.call(settings, 'userLanguage') &&
             S.userLanguage !== settings.userLanguage
@@ -1540,10 +1559,14 @@
                 delete incoming.independentAsrEnabled;
             }
             const pendingKeysToReassert = [];
-            if (meta && meta.changedKeys.length === 0) {
+            if (meta) {
                 // Keep this as for...of: static listener-contract tests slice
                 // at the first callback terminator.
                 for (const key of _pendingSettingsKeys) {
+                    // A full snapshot carries incidental copies of every other
+                    // key. Only a sender-declared edit may supersede local
+                    // pending intent.
+                    if (meta.changedKeys.indexOf(key) !== -1) continue;
                     if (!Object.prototype.hasOwnProperty.call(incoming, key)) continue;
                     if (incoming === settings) incoming = Object.assign({}, settings);
                     delete incoming[key];

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -131,6 +131,11 @@
         if (candidate.writeId < current.writeId) return false;
         return (candidate.writerId || '') > (current.writerId || '');
     }
+    function _sharedWriteTokensEqual(left, right) {
+        return !!left && !!right
+            && left.writeId === right.writeId
+            && (left.writerId || '') === (right.writerId || '');
+    }
     function _rememberSharedKeyWrites(keys, token, acceptedSettings) {
         if (!Array.isArray(keys) || !token) return;
         for (const key of keys) {
@@ -142,8 +147,22 @@
                 writeId: token.writeId,
                 writerId: token.writerId || ''
             };
+            if (Number.isInteger(token.confirmedRevision)
+                && token.confirmedRevision >= 0) {
+                candidate.confirmedRevision = token.confirmedRevision;
+            }
             if (_sharedWriteTokenOutranks(candidate, _knownSharedKeyWrites[key])) {
                 _knownSharedKeyWrites[key] = candidate;
+            } else if (_sharedWriteTokensEqual(
+                candidate,
+                _knownSharedKeyWrites[key]
+            ) && Number.isInteger(candidate.confirmedRevision)
+                && (!Number.isInteger(
+                    _knownSharedKeyWrites[key].confirmedRevision
+                ) || candidate.confirmedRevision
+                    > _knownSharedKeyWrites[key].confirmedRevision)) {
+                _knownSharedKeyWrites[key].confirmedRevision =
+                    candidate.confirmedRevision;
             }
         }
     }
@@ -160,8 +179,36 @@
                 writeId: _knownSharedKeyWrites[key].writeId,
                 writerId: _knownSharedKeyWrites[key].writerId
             };
+            if (Number.isInteger(
+                _knownSharedKeyWrites[key].confirmedRevision
+            )) {
+                snapshot[key].confirmedRevision =
+                    _knownSharedKeyWrites[key].confirmedRevision;
+            }
         }
         return snapshot;
+    }
+    function _confirmSharedKeyWrites(
+        payload,
+        serverSettings,
+        revision
+    ) {
+        if (!Number.isInteger(revision) || !serverSettings
+            || typeof serverSettings !== 'object') return;
+        const currentSettings = getConversationSettings();
+        for (const key of Object.keys(payload || {})) {
+            if (key === 'independentAsrEnabled') continue;
+            if (payload[key] !== serverSettings[key]) continue;
+            if (currentSettings[key] !== serverSettings[key]) continue;
+            const currentToken = _knownSharedKeyWrites[key];
+            if (!currentToken) continue;
+            currentToken.confirmedRevision = Math.max(
+                Number.isInteger(currentToken.confirmedRevision)
+                    ? currentToken.confirmedRevision
+                    : 0,
+                revision
+            );
+        }
     }
     function _serverAsrDecision(data) {
         const decisions = data && data.decisions;
@@ -516,11 +563,17 @@
         };
         const ownMeta = payload[_SHARED_WRITE_META_KEY];
         _rememberSharedKeyWrites(ownMeta.changedKeys, ownMeta);
-        // Server winners need provenance too. Otherwise a sibling with any
-        // older explicit token can mistake an accepted GET/412 value for an
-        // incidental stale copy and discard it. Stamp only fields actually
-        // accepted from the response; pending/local winners stay untouched.
-        _rememberSharedKeyWrites(serverAuthoritativeKeys || [], ownMeta);
+        // Server authority and browser write tokens are separate clocks. A
+        // server winner must carry its real revision instead of borrowing this
+        // broadcast envelope's fresh writeId, which could make an old GET look
+        // newer than an explicit edit the sender never observed.
+        if (Array.isArray(serverAuthoritativeKeys)
+            && serverAuthoritativeKeys.length > 0
+            && Number.isInteger(_conversationSettingsRevision)) {
+            ownMeta.serverRevision = _conversationSettingsRevision;
+            ownMeta.serverAuthoritativeKeys =
+                serverAuthoritativeKeys.slice();
+        }
         ownMeta.knownKeyWrites = _knownSharedKeyWritesSnapshot();
         if (ownMeta.changedKeys.indexOf('independentAsrEnabled') !== -1) {
             _noteAsrDecision(ownMeta.writeId, ownMeta.writerId, snapshot.independentAsrEnabled);
@@ -541,6 +594,12 @@
             };
         }
         localStorage.setItem('project_neko_settings', JSON.stringify(payload));
+        // The server snapshot is now the local source of truth for these keys.
+        // Keep the old token in the transmitted metadata long enough for peers
+        // to learn any confirmation revision, then discard it locally.
+        for (const key of serverAuthoritativeKeys || []) {
+            delete _knownSharedKeyWrites[key];
+        }
     }
 
     /**
@@ -567,6 +626,11 @@
                         ? token.writerId
                         : ''
                 };
+                if (Number.isInteger(token.confirmedRevision)
+                    && token.confirmedRevision >= 0) {
+                    knownKeyWrites[key].confirmedRevision =
+                        token.confirmedRevision;
+                }
             }
         }
         return {
@@ -584,6 +648,16 @@
             // changedKeys and keeps flowing through asrChangedByOtherWindow.
             asrAuthoritative: meta.asrAuthoritative === true,
             pendingRecovery: meta.pendingRecovery === true,
+            serverRevision: Number.isInteger(meta.serverRevision)
+                && meta.serverRevision >= 0
+                ? meta.serverRevision
+                : null,
+            serverAuthoritativeKeys:
+                Array.isArray(meta.serverAuthoritativeKeys)
+                    ? meta.serverAuthoritativeKeys.filter(
+                        (key) => _SHARED_SETTINGS_KEYS.indexOf(key) !== -1
+                    )
+                    : [],
             knownKeyWrites,
             knownKeyWritesPresent,
             // Absent on previous-build snapshots and on writers with no
@@ -957,6 +1031,11 @@
                         console.error('[app-settings] 同步设置到服务器失败:', data.error || '未知错误');
                         return;
                     }
+                    _confirmSharedKeyWrites(
+                        payload,
+                        data.settings,
+                        data.revision
+                    );
                     if (nextEtag) {
                         _markEtagConfirmedSharedSettings(
                             settings,
@@ -1280,6 +1359,15 @@
                 if (bootMeta) {
                     _rememberKnownSharedKeyWrites(bootMeta.knownKeyWrites, settings);
                     _rememberSharedKeyWrites(bootMeta.changedKeys, bootMeta, settings);
+                    if (Number.isInteger(bootMeta.serverRevision)) {
+                        _conversationSettingsRevision =
+                            bootMeta.serverRevision;
+                        _conversationSettingsEtag =
+                            `"conversation-settings-${bootMeta.serverRevision}"`;
+                        for (const key of bootMeta.serverAuthoritativeKeys) {
+                            delete _knownSharedKeyWrites[key];
+                        }
+                    }
                 }
                 if (bootMeta && bootMeta.asrDecision
                     && settings.independentAsrEnabled === bootMeta.asrDecision.value) {
@@ -1802,6 +1890,42 @@
                     if (!Object.prototype.hasOwnProperty.call(incoming, key)) continue;
                     const localToken = _knownSharedKeyWrites[key];
                     const mergeToken = meta.knownKeyWrites[key];
+                    const serverAuthoritative =
+                        Number.isInteger(meta.serverRevision)
+                        && meta.serverAuthoritativeKeys.indexOf(key) !== -1;
+                    if (serverAuthoritative) {
+                        let confirmedRevision = localToken
+                            && Number.isInteger(localToken.confirmedRevision)
+                            ? localToken.confirmedRevision
+                            : null;
+                        if (_sharedWriteTokensEqual(localToken, mergeToken)
+                            && Number.isInteger(
+                                mergeToken.confirmedRevision
+                            )) {
+                            confirmedRevision = Math.max(
+                                Number.isInteger(confirmedRevision)
+                                    ? confirmedRevision
+                                    : 0,
+                                mergeToken.confirmedRevision
+                            );
+                        }
+                        const serverSnapshotIsOlder =
+                            (Number.isInteger(_conversationSettingsRevision)
+                                && meta.serverRevision
+                                    < _conversationSettingsRevision)
+                            || (localToken
+                                && !Number.isInteger(confirmedRevision))
+                            || (Number.isInteger(confirmedRevision)
+                                && meta.serverRevision
+                                    < confirmedRevision);
+                        if (serverSnapshotIsOlder) {
+                            if (incoming === settings) {
+                                incoming = Object.assign({}, settings);
+                            }
+                            delete incoming[key];
+                        }
+                        continue;
+                    }
                     // The merge envelope may be newer while this particular
                     // field still predates an explicit write already accepted
                     // here. Apply only when the sender's per-key provenance is
@@ -1844,6 +1968,27 @@
             if (meta) {
                 _rememberKnownSharedKeyWrites(meta.knownKeyWrites, incoming);
                 _rememberSharedKeyWrites(meta.changedKeys, meta, incoming);
+                for (const key of meta.serverAuthoritativeKeys) {
+                    if (Object.prototype.hasOwnProperty.call(incoming, key)) {
+                        delete _knownSharedKeyWrites[key];
+                    }
+                }
+                if (Number.isInteger(meta.serverRevision)
+                    && (!Number.isInteger(_conversationSettingsRevision)
+                        || meta.serverRevision
+                            > _conversationSettingsRevision)) {
+                    _conversationSettingsRevision = meta.serverRevision;
+                    _conversationSettingsEtag =
+                        `"conversation-settings-${meta.serverRevision}"`;
+                    for (const key of meta.serverAuthoritativeKeys) {
+                        if (!Object.prototype.hasOwnProperty.call(
+                            incoming,
+                            key
+                        )) continue;
+                        _conversationSettingsEtagKeyMutationVersions[key] =
+                            _crossWindowKeyMutationVersions[key] || 0;
+                    }
+                }
             }
             if (meta && meta.asrDecision
                 && Object.prototype.hasOwnProperty.call(

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -229,9 +229,6 @@
         const decision = _normalizeServerAsrDecision(value, serverAuthoritative);
         if (!_asrDecisionOutranks(decision, _lastAsrDecision)) return false;
         _lastAsrDecision = decision;
-        if (decision.writeId > _lastAppliedSharedWriteId) {
-            _lastAppliedSharedWriteId = decision.writeId;
-        }
         return true;
     }
     function _responseEtag(response) {
@@ -246,9 +243,9 @@
     function _adoptServerAsrDecision(data) {
         const decision = _serverAsrDecision(data);
         if (!_adoptAsrDecisionTuple(decision, true)) return false;
-        // The next explicit local choice must mint above every decision this
-        // window has accepted, including cloud/server decisions whose clock is
-        // ahead of this browser's Date.now().
+        // Decision ordering is independent from localStorage envelope ordering.
+        // In particular, a server clock ahead of this browser must not raise the
+        // shared-write floor and make later envelopes invalid to sibling windows.
         const serverSettings = data && data.settings;
         if (serverSettings
             && typeof serverSettings.independentAsrEnabled === 'boolean'
@@ -556,6 +553,17 @@
         return _lastSharedWriteId;
     }
 
+    function _nextAsrDecisionWriteId(envelopeWriteId) {
+        const decisionFloor = _lastAsrDecision
+            && Number.isSafeInteger(_lastAsrDecision.writeId)
+            ? _lastAsrDecision.writeId
+            : 0;
+        if (decisionFloor >= Number.MAX_SAFE_INTEGER - 1) {
+            return envelopeWriteId;
+        }
+        return Math.max(envelopeWriteId, decisionFloor + 1);
+    }
+
     /**
      * Keys of `snapshot` this window may claim explicit user authority over:
      * still-pending keys plus keys that diverge from the current dirty-diff
@@ -628,7 +636,11 @@
         }
         ownMeta.knownKeyWrites = _knownSharedKeyWritesSnapshot();
         if (ownMeta.changedKeys.indexOf('independentAsrEnabled') !== -1) {
-            _noteAsrDecision(ownMeta.writeId, ownMeta.writerId, snapshot.independentAsrEnabled);
+            _noteAsrDecision(
+                _nextAsrDecisionWriteId(ownMeta.writeId),
+                ownMeta.writerId,
+                snapshot.independentAsrEnabled
+            );
         }
         // Stamp the ASR key with the id of the decision that PRODUCED this
         // value. _noteAsrDecision already refuses to advance the LOCAL decision
@@ -1046,6 +1058,9 @@
                 if (_conversationSettingsEtag) {
                     headers['If-Match'] = _conversationSettingsEtag;
                 }
+                if (mergedAtSend) {
+                    headers['X-Conversation-Settings-Full-Snapshot'] = '1';
+                }
                 if (requestDecision) {
                     headers['X-Conversation-Settings-ASR-Decision'] =
                         JSON.stringify(requestDecision);
@@ -1102,6 +1117,8 @@
                         mutationVersionAtSend
                     );
                     _clearAcknowledgedPendingSettings(payload);
+                    const adoptedServerAsrDecision =
+                        _adoptServerAsrDecision(data);
                     // A successful dirty-only write returns the complete
                     // authoritative snapshot. If the boot GET failed or lost
                     // the gate race, hydrate untouched fields from this response
@@ -1113,6 +1130,15 @@
                             changedWhileInFlight.add(key);
                         });
                         _mergeConversationSettingsSnapshot(data, changedWhileInFlight);
+                    } else if (adoptedServerAsrDecision) {
+                        // Re-broadcast a server-generated/confirmed tuple with
+                        // serverRevision authority. Its decision clock may be
+                        // ahead of a sibling browser's local Date.now() bound.
+                        saveSettings({
+                            skipServerSync: true,
+                            serverMerged: true,
+                            serverAuthoritativeKeys: ['independentAsrEnabled']
+                        });
                     }
                     return;
                 } catch (err) {
@@ -1669,21 +1695,32 @@
                 // nothing a full write could clobber (and the first-launch
                 // forced push below depends on it).
                 _settingsMergedFromServer = true;
-                const serverSettings = _serverSettingsForMerge(serverResult);
+                const serverSnapshotOlderThanCurrent =
+                    Number.isInteger(serverResult.revision)
+                    && Number.isInteger(_conversationSettingsRevision)
+                    && serverResult.revision < _conversationSettingsRevision;
+                const serverSettings = serverSnapshotOlderThanCurrent
+                    ? null
+                    : _serverSettingsForMerge(serverResult);
                 const telemetryBranch = serverResult.telemetryBranch;
-                const serverAsrDecision = _serverAsrDecision(serverResult);
+                const serverAsrDecision = serverSnapshotOlderThanCurrent
+                    ? null
+                    : _serverAsrDecision(serverResult);
                 // A cross-window toggle can reach localStorage before its POST
                 // reaches the server. In that window the local decision tuple is
                 // newer than the GET snapshot, so the generic field merge must
                 // not copy the older server value into S before the decision
                 // merge gets a chance to reject it.
-                const preserveLocalAsrDecision = serverResult.reset === true
+                const preserveLocalAsrDecision =
+                    !serverSnapshotOlderThanCurrent
+                    && serverResult.reset === true
                     ? false
                     : !!(_lastAsrDecision
                     && (!serverAsrDecision
                         || _asrDecisionOutranks(_lastAsrDecision, serverAsrDecision)));
                 const serverSnapshotNewerThanCurrent =
-                    serverResult.reset === true
+                    (!serverSnapshotOlderThanCurrent
+                        && serverResult.reset === true)
                     || (Number.isInteger(serverResult.revision)
                         && Number.isInteger(_conversationSettingsRevision)
                         && serverResult.revision > _conversationSettingsRevision);
@@ -1765,7 +1802,7 @@
                         window.subtitleBridge.setUserLanguage(serverSettings.userLanguage);
                     }
                 }
-                if (serverResult.decisions) {
+                if (!serverSnapshotOlderThanCurrent && serverResult.decisions) {
                     const previousAsr = S.independentAsrEnabled;
                     const adoptedAsrDecision = _adoptServerAsrDecision({
                         settings: serverSettings,
@@ -1961,8 +1998,7 @@
                     delete incoming[key];
                 }
             }
-            if (meta && meta.changedKeys.length === 0
-                && meta.knownKeyWritesPresent) {
+            if (meta && meta.knownKeyWritesPresent) {
                 for (const key of _SHARED_SETTINGS_KEYS) {
                     if (key === 'independentAsrEnabled') continue;
                     if (!Object.prototype.hasOwnProperty.call(incoming, key)) continue;
@@ -2035,9 +2071,11 @@
                             || (meta.writeId === localToken.writeId
                                 && meta.writerId === localToken.writerId));
                     if (incomingCanSupersede) continue;
-                    if (!Object.prototype.hasOwnProperty.call(incoming, key)) continue;
-                    if (incoming === settings) incoming = Object.assign({}, settings);
-                    delete incoming[key];
+                    if (!Object.prototype.hasOwnProperty.call(settings, key)) continue;
+                    if (Object.prototype.hasOwnProperty.call(incoming, key)) {
+                        if (incoming === settings) incoming = Object.assign({}, settings);
+                        delete incoming[key];
+                    }
                     pendingKeysToReassert.push(key);
                 }
             }

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -119,6 +119,15 @@
             decisions && decisions.independentAsrEnabled
         );
     }
+    function _adoptAsrDecisionTuple(value) {
+        const decision = _normalizeServerAsrDecision(value);
+        if (!_asrDecisionOutranks(decision, _lastAsrDecision)) return false;
+        _lastAsrDecision = decision;
+        if (decision.writeId > _lastAppliedSharedWriteId) {
+            _lastAppliedSharedWriteId = decision.writeId;
+        }
+        return true;
+    }
     function _responseEtag(response) {
         try {
             return response && response.headers && typeof response.headers.get === 'function'
@@ -130,14 +139,10 @@
     }
     function _adoptServerAsrDecision(data) {
         const decision = _serverAsrDecision(data);
-        if (!_asrDecisionOutranks(decision, _lastAsrDecision)) return false;
-        _lastAsrDecision = decision;
+        if (!_adoptAsrDecisionTuple(decision)) return false;
         // The next explicit local choice must mint above every decision this
         // window has accepted, including cloud/server decisions whose clock is
         // ahead of this browser's Date.now().
-        if (decision.writeId > _lastAppliedSharedWriteId) {
-            _lastAppliedSharedWriteId = decision.writeId;
-        }
         const serverSettings = data && data.settings;
         if (serverSettings
             && typeof serverSettings.independentAsrEnabled === 'boolean'
@@ -1524,6 +1529,14 @@
             }
             _noteCrossWindowMutations(incoming, meta ? meta.changedKeys : null);
             const changed = applySharedRuntimeSettings(incoming);
+            if (meta && meta.asrDecision
+                && Object.prototype.hasOwnProperty.call(
+                    incoming,
+                    'independentAsrEnabled'
+                )
+                && incoming.independentAsrEnabled === meta.asrDecision.value) {
+                _adoptAsrDecisionTuple(meta.asrDecision);
+            }
             // Roll the dirty-diff baseline for every key just adopted from
             // another window. _markUserDirtySettings diffs against this
             // baseline, so without the roll a value this window merely

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -438,14 +438,19 @@
      * window that HAD merged the server value adopts it, mis-stamps its next
      * handshake, and POSTs the wrong value back on its next full sync.
      */
-    function _writeSharedSettings(snapshot, explicitKeys) {
+    function _writeSharedSettings(snapshot, explicitKeys, pendingRecovery) {
         const payload = Object.assign({}, snapshot);
         payload[_SHARED_WRITE_META_KEY] = {
             writeId: _nextSharedWriteId(),
             writerId: _SHARED_WRITER_ID,
             changedKeys: explicitKeys || [],
             hydrated: S.settingsHydrated === true,
-            asrAuthoritative: S.independentAsrAuthoritative === true
+            asrAuthoritative: S.independentAsrAuthoritative === true,
+            // A recovery write reasserts this window's pending values after it
+            // filtered an incidental copy from another full snapshot. Another
+            // pending window must not answer it with another recovery write,
+            // or conflicting snapshots can bounce through localStorage forever.
+            pendingRecovery: pendingRecovery === true
         };
         const ownMeta = payload[_SHARED_WRITE_META_KEY];
         if (ownMeta.changedKeys.indexOf('independentAsrEnabled') !== -1) {
@@ -492,6 +497,7 @@
             // from that build still carries independentAsrEnabled in
             // changedKeys and keeps flowing through asrChangedByOtherWindow.
             asrAuthoritative: meta.asrAuthoritative === true,
+            pendingRecovery: meta.pendingRecovery === true,
             // Absent on previous-build snapshots and on writers with no
             // matching decision: null routes the comparison back to
             // (writeId, writerId), i.e. today's behaviour.
@@ -910,6 +916,7 @@
      * @param {{
      *   skipServerSync?: boolean,
      *   serverMerged?: boolean,
+     *   pendingRecovery?: boolean,
      *   explicitSharedKeys?: string[]
      * }} [options]
      *   传 skipServerSync 跳过 POST；
@@ -920,6 +927,7 @@
     function saveSettings(options) {
         const skipServerSync = !!(options && options.skipServerSync);
         const serverMerged = !!(options && options.serverMerged);
+        const pendingRecovery = !!(options && options.pendingRecovery);
         const explicitSharedKeys = options && Array.isArray(options.explicitSharedKeys)
             ? options.explicitSharedKeys
             : null;
@@ -1044,7 +1052,8 @@
             settings,
             explicitSharedKeys !== null
                 ? explicitSharedKeys
-                : (serverMerged ? [] : _collectExplicitSharedKeys(settings))
+                : (serverMerged ? [] : _collectExplicitSharedKeys(settings)),
+            pendingRecovery
         );
 
         // 同步回共享状态，保持一致性
@@ -1113,7 +1122,15 @@
                 if (bootMeta && bootMeta.writeId > _lastAppliedSharedWriteId) {
                     _lastAppliedSharedWriteId = bootMeta.writeId;
                 }
-                if (bootMeta && bootMeta.changedKeys.indexOf('independentAsrEnabled') !== -1) {
+                if (bootMeta && bootMeta.asrDecision
+                    && settings.independentAsrEnabled === bootMeta.asrDecision.value) {
+                    // A server-merge snapshot intentionally has no changedKeys:
+                    // it carries authority, not a fresh user action. Restore its
+                    // matching decision tuple anyway so reloads retain both the
+                    // ordering token and the floor for the next local choice.
+                    _adoptAsrDecisionTuple(bootMeta.asrDecision);
+                } else if (bootMeta
+                    && bootMeta.changedKeys.indexOf('independentAsrEnabled') !== -1) {
                     const bootDecision = bootMeta.asrDecision || bootMeta;
                     _noteAsrDecision(bootDecision.writeId, bootDecision.writerId, settings.independentAsrEnabled);
                 }
@@ -1655,16 +1672,18 @@
             if (changed && typeof window.scheduleProactiveChat === 'function') {
                 window.scheduleProactiveChat();
             }
-            if (pendingKeysToReassert.length > 0) {
+            if (pendingKeysToReassert.length > 0 && !(meta && meta.pendingRecovery)) {
                 // A server-merge broadcast can have been built before this
                 // window's latest pending edit reached its sender. Restore the
-                // local full snapshot without claiming a NEW user edit: another
-                // window may already hold a newer pending choice for the same
-                // key, and must keep filtering this recovery broadcast. The
-                // already queued user sync remains the sole server writer.
+                // local full snapshot without claiming a NEW user edit. Mark it
+                // as a one-hop recovery: another pending window still filters
+                // its own values, but does not answer with another recovery and
+                // start a localStorage ping-pong. The already queued user sync
+                // remains the sole server writer.
                 saveSettings({
                     skipServerSync: true,
-                    serverMerged: true
+                    serverMerged: true,
+                    pendingRecovery: true
                 });
             }
         } catch (error) {

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -63,6 +63,7 @@
     // other each adopt the other and stay swapped forever. That needs no
     // millisecond tie at all -- a strictly older foreign write still wins.
     let _lastAsrDecision = null;
+    let _asrDecisionWriteIdFloor = 0;
     function _isValidAsrWriteId(value, serverAuthoritative) {
         if (!Number.isSafeInteger(value) || value < 0
             || value > Number.MAX_SAFE_INTEGER - 1) return false;
@@ -89,6 +90,7 @@
             return;
         }
         _lastAsrDecision = { writeId: writeId, writerId: writerId || '', value: value };
+        _asrDecisionWriteIdFloor = Math.max(_asrDecisionWriteIdFloor, writeId);
     }
     function _asrWriteOutranksLocalChoice(meta) {
         if (!_lastAsrDecision) return true;
@@ -131,6 +133,12 @@
         if (candidate.writeId > current.writeId) return true;
         if (candidate.writeId < current.writeId) return false;
         return candidate.writerId > current.writerId;
+    }
+    function _asrDecisionsEqual(left, right) {
+        return !!left && !!right
+            && left.writeId === right.writeId
+            && left.writerId === right.writerId
+            && left.value === right.value;
     }
     function _sharedWriteTokenOutranks(candidate, current) {
         if (!candidate) return false;
@@ -227,9 +235,45 @@
     }
     function _adoptAsrDecisionTuple(value, serverAuthoritative) {
         const decision = _normalizeServerAsrDecision(value, serverAuthoritative);
-        if (!_asrDecisionOutranks(decision, _lastAsrDecision)) return false;
-        _lastAsrDecision = decision;
+        const alreadyCurrent = _asrDecisionsEqual(
+            decision,
+            _lastAsrDecision
+        );
+        if (!alreadyCurrent
+            && !_asrDecisionOutranks(decision, _lastAsrDecision)) return false;
+        if (!alreadyCurrent) {
+            _lastAsrDecision = decision;
+        }
+        _asrDecisionWriteIdFloor = Math.max(
+            _asrDecisionWriteIdFloor,
+            decision.writeId
+        );
         return true;
+    }
+    function _rebaseAsrDecisionForReset(serverDecision, resetValue) {
+        let floor = _asrDecisionWriteIdFloor;
+        if (_lastAsrDecision) {
+            floor = Math.max(floor, _lastAsrDecision.writeId);
+        }
+        if (serverDecision) {
+            floor = Math.max(floor, serverDecision.writeId);
+        }
+        if (floor >= Number.MAX_SAFE_INTEGER - 1) {
+            _asrDecisionWriteIdFloor = floor;
+            _lastAsrDecision = null;
+            return;
+        }
+        const writeId = Math.max(Date.now(), floor + 1);
+        // Materialize reset authority as a matching decision tuple. The reset
+        // writeback sends this tuple instead of asking the server to mint a
+        // potentially later legacy tuple; a user toggle made while that
+        // request is in flight therefore mints strictly above the response.
+        _lastAsrDecision = {
+            writeId,
+            writerId: _SHARED_WRITER_ID,
+            value: resetValue
+        };
+        _asrDecisionWriteIdFloor = writeId;
     }
     function _responseEtag(response) {
         try {
@@ -261,13 +305,29 @@
         return true;
     }
     function _mergeConversationSettingsSnapshot(data, preservedKeys) {
-        const adoptedAsr = _adoptServerAsrDecision(data);
         const serverSettings = _serverSettingsForMerge(data);
         if (!serverSettings || typeof serverSettings !== 'object') return;
         const protectedKeys = preservedKeys || _pendingSettingsKeys;
-        const serverAsrDecision = _serverAsrDecision(data);
-        const preserveLocalAsrDecision = data && data.reset === true
+        const resetSnapshot = !!(data && data.reset === true);
+        const rawServerAsrDecision = _serverAsrDecision(data);
+        const resetReplacesAsrDecision = resetSnapshot
+            && !protectedKeys.has('independentAsrEnabled')
+            && typeof serverSettings.independentAsrEnabled === 'boolean';
+        if (resetReplacesAsrDecision) {
+            _rebaseAsrDecisionForReset(
+                rawServerAsrDecision,
+                serverSettings.independentAsrEnabled
+            );
+        }
+        // A reset tombstone invalidates the persisted tuple. Preserve a pending
+        // local choice, or adopt the materialized reset default without
+        // re-adopting the stale pre-reset tuple.
+        const adoptedAsr = resetSnapshot
             ? false
+            : _adoptServerAsrDecision(data);
+        const serverAsrDecision = resetSnapshot ? null : rawServerAsrDecision;
+        const preserveLocalAsrDecision = resetSnapshot
+            ? !resetReplacesAsrDecision
             : !!(_lastAsrDecision
             && (!serverAsrDecision
                 || _asrDecisionOutranks(_lastAsrDecision, serverAsrDecision)));
@@ -377,6 +437,7 @@
     // edits that arrive after the request snapshot.
     const _conversationSettingsEtagKeyMutationVersions = Object.create(null);
     const _CONVERSATION_SETTINGS_MAX_ATTEMPTS = 3;
+    const _CONVERSATION_SETTINGS_REQUEST_TIMEOUT_MS = 15000;
     // 同步间隔（毫秒）：60秒
     const SYNC_INTERVAL_MS = 60000;
     // 「首启等 settings/telemetry 决议」专属 marker：只有 localStorage 走过首启分支才会写
@@ -554,10 +615,13 @@
     }
 
     function _nextAsrDecisionWriteId(envelopeWriteId) {
-        const decisionFloor = _lastAsrDecision
+        const decisionFloor = Math.max(
+            _asrDecisionWriteIdFloor,
+            _lastAsrDecision
             && Number.isSafeInteger(_lastAsrDecision.writeId)
             ? _lastAsrDecision.writeId
-            : 0;
+            : 0
+        );
         if (decisionFloor >= Number.MAX_SAFE_INTEGER - 1) {
             return envelopeWriteId;
         }
@@ -659,10 +723,16 @@
         }
         localStorage.setItem('project_neko_settings', JSON.stringify(payload));
         // The server snapshot is now the local source of truth for these keys.
-        // Keep the old token in the transmitted metadata long enough for peers
-        // to learn any confirmation revision, then discard it locally.
+        // Retain the broadcast envelope as a comparable browser-side floor so
+        // a delayed older explicit storage event cannot roll the accepted
+        // server value back. This marker is provenance only: changedKeys stays
+        // empty, so it is not advertised as fresh user intent.
         for (const key of serverAuthoritativeKeys || []) {
-            delete _knownSharedKeyWrites[key];
+            _knownSharedKeyWrites[key] = {
+                writeId: ownMeta.writeId,
+                writerId: ownMeta.writerId,
+                confirmedRevision: ownMeta.serverRevision
+            };
         }
     }
 
@@ -965,6 +1035,41 @@
         return null;
     }
 
+    function _fetchConversationSettingsJsonWithTimeout(url, options) {
+        const AbortControllerCtor =
+            (typeof window.AbortController === 'function'
+                && window.AbortController)
+            || (typeof AbortController === 'function' && AbortController)
+            || null;
+        const abortController = AbortControllerCtor
+            ? new AbortControllerCtor()
+            : null;
+        const requestOptions = Object.assign({}, options);
+        if (abortController) {
+            requestOptions.signal = abortController.signal;
+        }
+        let timeoutId = null;
+        const timeoutPromise = new Promise((_, reject) => {
+            timeoutId = setTimeout(() => {
+                if (abortController) abortController.abort();
+                reject(new Error('conversation settings request timed out'));
+            }, _CONVERSATION_SETTINGS_REQUEST_TIMEOUT_MS);
+            if (timeoutId && typeof timeoutId.unref === 'function') {
+                timeoutId.unref();
+            }
+        });
+        const requestPromise = (async () => {
+            const response = await fetch(url, requestOptions);
+            const data = await response.json();
+            return { response, data };
+        })();
+        return Promise.race([requestPromise, timeoutPromise]).finally(() => {
+            if (timeoutId !== null && typeof clearTimeout === 'function') {
+                clearTimeout(timeoutId);
+            }
+        });
+    }
+
     /**
      * 将对话设置同步到服务器（异步，不阻塞）
      * 用于定期备份和跨会话持久化
@@ -1066,12 +1171,15 @@
                         JSON.stringify(requestDecision);
                 }
                 try {
-                    const response = await fetch('/api/config/conversation-settings', {
-                        method: 'POST',
-                        headers,
-                        body: JSON.stringify(payload)
-                    });
-                    const data = await response.json();
+                    const { response, data } =
+                        await _fetchConversationSettingsJsonWithTimeout(
+                            '/api/config/conversation-settings',
+                            {
+                                method: 'POST',
+                                headers,
+                                body: JSON.stringify(payload)
+                            }
+                        );
                     const nextEtag = _responseEtag(response);
                     if (nextEtag) _conversationSettingsEtag = nextEtag;
                     if (Number.isInteger(data.revision)) {
@@ -1703,9 +1811,26 @@
                     ? null
                     : _serverSettingsForMerge(serverResult);
                 const telemetryBranch = serverResult.telemetryBranch;
-                const serverAsrDecision = serverSnapshotOlderThanCurrent
+                const rawServerAsrDecision = serverSnapshotOlderThanCurrent
                     ? null
                     : _serverAsrDecision(serverResult);
+                const resetReplacesAsrDecision =
+                    !serverSnapshotOlderThanCurrent
+                    && serverResult.reset === true
+                    && serverSettings
+                    && typeof serverSettings.independentAsrEnabled === 'boolean'
+                    && !_pendingSettingsKeys.has('independentAsrEnabled')
+                    && (_crossWindowKeyMutationVersions.independentAsrEnabled || 0)
+                        <= mutationVersionAtGetStart;
+                if (resetReplacesAsrDecision) {
+                    _rebaseAsrDecisionForReset(
+                        rawServerAsrDecision,
+                        serverSettings.independentAsrEnabled
+                    );
+                }
+                const serverAsrDecision = serverResult.reset === true
+                    ? null
+                    : rawServerAsrDecision;
                 // A cross-window toggle can reach localStorage before its POST
                 // reaches the server. In that window the local decision tuple is
                 // newer than the GET snapshot, so the generic field merge must
@@ -1714,7 +1839,7 @@
                 const preserveLocalAsrDecision =
                     !serverSnapshotOlderThanCurrent
                     && serverResult.reset === true
-                    ? false
+                    ? !resetReplacesAsrDecision
                     : !!(_lastAsrDecision
                     && (!serverAsrDecision
                         || _asrDecisionOutranks(_lastAsrDecision, serverAsrDecision)));
@@ -1802,7 +1927,9 @@
                         window.subtitleBridge.setUserLanguage(serverSettings.userLanguage);
                     }
                 }
-                if (!serverSnapshotOlderThanCurrent && serverResult.decisions) {
+                if (!serverSnapshotOlderThanCurrent
+                    && serverResult.reset !== true
+                    && serverResult.decisions) {
                     const previousAsr = S.independentAsrEnabled;
                     const adoptedAsrDecision = _adoptServerAsrDecision({
                         settings: serverSettings,
@@ -2086,7 +2213,11 @@
                 _rememberSharedKeyWrites(meta.changedKeys, meta, incoming);
                 for (const key of meta.serverAuthoritativeKeys) {
                     if (Object.prototype.hasOwnProperty.call(incoming, key)) {
-                        delete _knownSharedKeyWrites[key];
+                        _knownSharedKeyWrites[key] = {
+                            writeId: meta.writeId,
+                            writerId: meta.writerId,
+                            confirmedRevision: meta.serverRevision
+                        };
                     }
                 }
                 if (Number.isInteger(meta.serverRevision)) {

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -464,6 +464,8 @@
         'slopFilterEnabled',
         'proactiveChatInterval',
         'proactiveVisionInterval',
+        'subtitleEnabled',
+        'userLanguage',
         'textGuardMaxLength',
         'renderQuality',
         'targetFrameRate'
@@ -697,6 +699,16 @@
             ownMeta.serverRevision = _conversationSettingsRevision;
             ownMeta.serverAuthoritativeKeys =
                 serverAuthoritativeKeys.slice();
+            // Persist the authority floor inside knownKeyWrites as well as in
+            // memory. A reloaded window may have to reject a delayed explicit
+            // event before its boot GET returns (or when that GET is offline).
+            for (const key of ownMeta.serverAuthoritativeKeys) {
+                _knownSharedKeyWrites[key] = {
+                    writeId: ownMeta.writeId,
+                    writerId: ownMeta.writerId,
+                    confirmedRevision: ownMeta.serverRevision
+                };
+            }
         }
         ownMeta.knownKeyWrites = _knownSharedKeyWritesSnapshot();
         if (ownMeta.changedKeys.indexOf('independentAsrEnabled') !== -1) {
@@ -721,18 +733,13 @@
                 value: _lastAsrDecision.value
             };
         }
-        localStorage.setItem('project_neko_settings', JSON.stringify(payload));
-        // The server snapshot is now the local source of truth for these keys.
-        // Retain the broadcast envelope as a comparable browser-side floor so
-        // a delayed older explicit storage event cannot roll the accepted
-        // server value back. This marker is provenance only: changedKeys stays
-        // empty, so it is not advertised as fresh user intent.
-        for (const key of serverAuthoritativeKeys || []) {
-            _knownSharedKeyWrites[key] = {
-                writeId: ownMeta.writeId,
-                writerId: ownMeta.writerId,
-                confirmedRevision: ownMeta.serverRevision
-            };
+        try {
+            localStorage.setItem('project_neko_settings', JSON.stringify(payload));
+        } catch (error) {
+            // Local persistence/cross-window fan-out is best-effort. Do not
+            // abort saveSettings before its CAS sync can persist and apply the
+            // user's choice to the backend and active runtime.
+            console.warn('[app-settings] 本地设置持久化失败，继续服务器同步:', error);
         }
     }
 
@@ -1552,7 +1559,15 @@
                         _conversationSettingsEtag =
                             `"conversation-settings-${bootMeta.serverRevision}"`;
                         for (const key of bootMeta.serverAuthoritativeKeys) {
-                            delete _knownSharedKeyWrites[key];
+                            if (!Object.prototype.hasOwnProperty.call(
+                                settings,
+                                key
+                            )) continue;
+                            _rememberSharedKeyWrites([key], {
+                                writeId: bootMeta.writeId,
+                                writerId: bootMeta.writerId,
+                                confirmedRevision: bootMeta.serverRevision
+                            }, settings);
                         }
                     }
                 }

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -1203,6 +1203,15 @@
                 _settingsMergedFromServer = true;
                 const serverSettings = serverResult.settings;
                 const telemetryBranch = serverResult.telemetryBranch;
+                const serverAsrDecision = _serverAsrDecision(serverResult);
+                // A cross-window toggle can reach localStorage before its POST
+                // reaches the server. In that window the local decision tuple is
+                // newer than the GET snapshot, so the generic field merge must
+                // not copy the older server value into S before the decision
+                // merge gets a chance to reject it.
+                const preserveLocalAsrDecision = !!(_lastAsrDecision
+                    && (!serverAsrDecision
+                        || _asrDecisionOutranks(_lastAsrDecision, serverAsrDecision)));
                 if (serverResult.etag) {
                     _conversationSettingsEtag = serverResult.etag;
                 }
@@ -1235,6 +1244,7 @@
                     for (const key of Object.keys(serverSettings)) {
                         if (serverSettings[key] === undefined) continue;
                         if (_dirtySettingsKeys.has(key)) continue;
+                        if (key === 'independentAsrEnabled' && preserveLocalAsrDecision) continue;
                         if (S[key] !== serverSettings[key]) {
                             S[key] = serverSettings[key];
                             hasUpdate = true;

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -97,7 +97,7 @@
     }
     function _normalizeServerAsrDecision(value) {
         if (!value || typeof value !== 'object') return null;
-        if (typeof value.writeId !== 'number' || !isFinite(value.writeId)) return null;
+        if (!Number.isSafeInteger(value.writeId) || value.writeId < 0) return null;
         if (typeof value.writerId !== 'string' || !value.writerId) return null;
         if (typeof value.value !== 'boolean') return null;
         return {
@@ -279,6 +279,7 @@
         'mergeMessagesEnabled',
         'focusModeEnabled',
         'focusCognitionEnabled',
+        'noiseReductionEnabled',
         'independentAsrEnabled',
         'avatarReactionBubbleEnabled',
         'slopFilterEnabled',
@@ -320,6 +321,7 @@
             mergeMessagesEnabled: S.mergeMessagesEnabled,
             focusModeEnabled: S.focusModeEnabled,
             focusCognitionEnabled: S.focusCognitionEnabled,
+            noiseReductionEnabled: S.noiseReductionEnabled,
             independentAsrEnabled: S.independentAsrEnabled,
             avatarReactionBubbleEnabled: S.avatarReactionBubbleEnabled,
             slopFilterEnabled: S.slopFilterEnabled,
@@ -467,7 +469,7 @@
     function _readSharedWriteMeta(settings) {
         const meta = settings ? settings[_SHARED_WRITE_META_KEY] : null;
         if (!meta || typeof meta !== 'object') return null;
-        if (typeof meta.writeId !== 'number' || !isFinite(meta.writeId)) return null;
+        if (!Number.isSafeInteger(meta.writeId) || meta.writeId < 0) return null;
         return {
             writeId: meta.writeId,
             // Absent on snapshots written by the previous build: '' sorts below
@@ -486,8 +488,8 @@
             // matching decision: null routes the comparison back to
             // (writeId, writerId), i.e. today's behaviour.
             asrDecision: (meta.asrDecision
-                && typeof meta.asrDecision.writeId === 'number'
-                && isFinite(meta.asrDecision.writeId))
+                && Number.isSafeInteger(meta.asrDecision.writeId)
+                && meta.asrDecision.writeId >= 0)
                 ? {
                     writeId: meta.asrDecision.writeId,
                     writerId: typeof meta.asrDecision.writerId === 'string'
@@ -999,6 +1001,7 @@
             mergeMessagesEnabled: currentMerge,
             focusModeEnabled: currentFocus,
             focusCognitionEnabled: currentFocusCognition,
+            noiseReductionEnabled: S.noiseReductionEnabled,
             independentAsrEnabled: currentIndependentAsr,
             avatarReactionBubbleEnabled: currentAvatarReactionBubble,
             slopFilterEnabled: currentSlopFilter,

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -18,14 +18,11 @@
     // 周期同步因「设置未水合」被跳过时只 log 一次，避免 GET 持续失败刷屏
     let _periodicSyncSkippedUnhydratedLogged = false;
     // Field-level user authority (Codex P2): _dirtySettingsKeys records which
-    // conversation-settings keys the user explicitly changed since boot. It is
-    // intentionally monotone because a boot GET started before an acknowledged
-    // POST can still arrive later with an older snapshot; its merge must keep
-    // every user-touched key. _pendingSettingsKeys is narrower: it contains only
-    // changes not yet acknowledged by a successful POST, and is the set used by
-    // dirty-only writes plus 412 conflict merges. Keeping those roles separate
-    // prevents an acknowledged stale local value from winning a later conflict
-    // without reopening the late-boot-GET overwrite race.
+    // conversation-settings keys the user explicitly changed since boot.
+    // _pendingSettingsKeys is narrower: it contains only changes not yet
+    // acknowledged by a successful POST. A delayed boot GET preserves pending
+    // keys unconditionally and preserves acknowledged dirty keys only when the
+    // returned revision does not supersede the POST that acknowledged them.
     const _dirtySettingsKeys = new Set();
     const _pendingSettingsKeys = new Set();
     let _crossWindowMutationVersion = 0;
@@ -317,6 +314,7 @@
     // below plus the same ASR decision tuple localStorage already uses.
     let _syncChainTail = Promise.resolve();
     let _conversationSettingsEtag = null;
+    let _conversationSettingsRevision = null;
     // Cross-window mutation version represented by the current ETag. A field
     // explicitly edited after this watermark is absent from that server
     // revision even when the edit arrived before the next CAS request began.
@@ -818,6 +816,7 @@
                 settings: hasSettings ? data.settings : null,
                 telemetryBranch,
                 etag,
+                revision: Number.isInteger(data.revision) ? data.revision : null,
                 decisions: data.decisions || null
             };
         } catch (e) {
@@ -932,6 +931,9 @@
                     const data = await response.json();
                     const nextEtag = _responseEtag(response);
                     if (nextEtag) _conversationSettingsEtag = nextEtag;
+                    if (Number.isInteger(data.revision)) {
+                        _conversationSettingsRevision = data.revision;
+                    }
                     if (response.status === 412) {
                         const preservedKeys = new Set(_pendingSettingsKeys);
                         _crossWindowSettingsNewerThanEtag(
@@ -1534,8 +1536,19 @@
                 const preserveLocalAsrDecision = !!(_lastAsrDecision
                     && (!serverAsrDecision
                         || _asrDecisionOutranks(_lastAsrDecision, serverAsrDecision)));
-                if (serverResult.etag) {
+                const serverSnapshotNewerThanCurrent =
+                    Number.isInteger(serverResult.revision)
+                    && Number.isInteger(_conversationSettingsRevision)
+                    && serverResult.revision > _conversationSettingsRevision;
+                const shouldAdoptServerVersion =
+                    !Number.isInteger(_conversationSettingsRevision)
+                    || !Number.isInteger(serverResult.revision)
+                    || serverResult.revision >= _conversationSettingsRevision;
+                if (serverResult.etag && shouldAdoptServerVersion) {
                     _conversationSettingsEtag = serverResult.etag;
+                    if (Number.isInteger(serverResult.revision)) {
+                        _conversationSettingsRevision = serverResult.revision;
+                    }
                     _SHARED_SETTINGS_KEYS.forEach((key) => {
                         _conversationSettingsEtagKeyMutationVersions[key] =
                             mutationVersionAtGetStart;
@@ -1570,7 +1583,9 @@
                     // snapshot into the POSTed truth.
                     for (const key of Object.keys(serverSettings)) {
                         if (serverSettings[key] === undefined) continue;
-                        if (_dirtySettingsKeys.has(key)) continue;
+                        if (_pendingSettingsKeys.has(key)) continue;
+                        if (_dirtySettingsKeys.has(key)
+                            && !serverSnapshotNewerThanCurrent) continue;
                         if ((_crossWindowKeyMutationVersions[key] || 0)
                             > mutationVersionAtGetStart) continue;
                         if (key === 'independentAsrEnabled' && preserveLocalAsrDecision) continue;
@@ -1587,10 +1602,18 @@
                     }
                     // Subtitle bridge mirrors follow the same dirty gating so
                     // a user-changed subtitle preference survives the merge.
-                    if (serverSettings.subtitleEnabled !== undefined && !_dirtySettingsKeys.has('subtitleEnabled') && window.subtitleBridge) {
+                    if (serverSettings.subtitleEnabled !== undefined
+                        && !_pendingSettingsKeys.has('subtitleEnabled')
+                        && (!_dirtySettingsKeys.has('subtitleEnabled')
+                            || serverSnapshotNewerThanCurrent)
+                        && window.subtitleBridge) {
                         window.subtitleBridge.setSubtitleEnabled(serverSettings.subtitleEnabled);
                     }
-                    if (serverSettings.userLanguage !== undefined && !_dirtySettingsKeys.has('userLanguage') && window.subtitleBridge) {
+                    if (serverSettings.userLanguage !== undefined
+                        && !_pendingSettingsKeys.has('userLanguage')
+                        && (!_dirtySettingsKeys.has('userLanguage')
+                            || serverSnapshotNewerThanCurrent)
+                        && window.subtitleBridge) {
                         window.subtitleBridge.setUserLanguage(serverSettings.userLanguage);
                     }
                 }
@@ -1799,9 +1822,17 @@
                 // at the first callback terminator.
                 for (const key of _pendingSettingsKeys) {
                     // A full snapshot carries incidental copies of every other
-                    // key. Only a sender-declared edit may supersede local
-                    // pending intent.
-                    if (meta.changedKeys.indexOf(key) !== -1) continue;
+                    // key. A sender-declared edit supersedes local pending
+                    // intent only when its per-key token is at least as new.
+                    const localToken = _knownSharedKeyWrites[key];
+                    const incomingIsExplicit =
+                        meta.changedKeys.indexOf(key) !== -1;
+                    const incomingCanSupersede = incomingIsExplicit
+                        && (!localToken
+                            || _sharedWriteTokenOutranks(meta, localToken)
+                            || (meta.writeId === localToken.writeId
+                                && meta.writerId === localToken.writerId));
+                    if (incomingCanSupersede) continue;
                     if (!Object.prototype.hasOwnProperty.call(incoming, key)) continue;
                     if (incoming === settings) incoming = Object.assign({}, settings);
                     delete incoming[key];

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -94,6 +94,76 @@
         // build) reads as '' and loses, keeping this window's own choice.
         return (decision.writerId || '') > _lastAsrDecision.writerId;
     }
+    function _normalizeServerAsrDecision(value) {
+        if (!value || typeof value !== 'object') return null;
+        if (typeof value.writeId !== 'number' || !isFinite(value.writeId)) return null;
+        if (typeof value.writerId !== 'string' || !value.writerId) return null;
+        if (typeof value.value !== 'boolean') return null;
+        return {
+            writeId: value.writeId,
+            writerId: value.writerId,
+            value: value.value
+        };
+    }
+    function _asrDecisionOutranks(candidate, current) {
+        if (!candidate) return false;
+        if (!current) return true;
+        if (candidate.writeId > current.writeId) return true;
+        if (candidate.writeId < current.writeId) return false;
+        return candidate.writerId > current.writerId;
+    }
+    function _serverAsrDecision(data) {
+        const decisions = data && data.decisions;
+        return _normalizeServerAsrDecision(
+            decisions && decisions.independentAsrEnabled
+        );
+    }
+    function _responseEtag(response) {
+        try {
+            return response && response.headers && typeof response.headers.get === 'function'
+                ? response.headers.get('ETag')
+                : null;
+        } catch (_) {
+            return null;
+        }
+    }
+    function _adoptServerAsrDecision(data) {
+        const decision = _serverAsrDecision(data);
+        if (!_asrDecisionOutranks(decision, _lastAsrDecision)) return false;
+        _lastAsrDecision = decision;
+        const serverSettings = data && data.settings;
+        if (serverSettings
+            && typeof serverSettings.independentAsrEnabled === 'boolean'
+            && serverSettings.independentAsrEnabled === decision.value) {
+            applySharedRuntimeSettings({
+                independentAsrEnabled: serverSettings.independentAsrEnabled
+            });
+            S.settingsHydrated = true;
+            if (_settingsBaseline) {
+                _settingsBaseline.independentAsrEnabled = S.independentAsrEnabled;
+            }
+        }
+        return true;
+    }
+    function _mergeConversationSettingsConflict(data) {
+        const adoptedAsr = _adoptServerAsrDecision(data);
+        const serverSettings = data && data.settings;
+        if (!serverSettings || typeof serverSettings !== 'object') return;
+        for (const key of Object.keys(serverSettings)) {
+            if (key === 'independentAsrEnabled' && adoptedAsr) continue;
+            if (_dirtySettingsKeys.has(key)) continue;
+            if (serverSettings[key] !== undefined) S[key] = serverSettings[key];
+        }
+        _settingsMergedFromServer = true;
+        if (_settingsBaseline) {
+            for (const key of Object.keys(serverSettings)) {
+                if (_dirtySettingsKeys.has(key)) continue;
+                if (serverSettings[key] !== undefined) {
+                    _settingsBaseline[key] = S[key];
+                }
+            }
+        }
+    }
     // Bounded gate for the boot settings GET: settings POST bodies are built
     // at send time AFTER awaiting this gate, so once the GET settled the merge
     // has already run and fields the user never touched carry server truth
@@ -137,19 +207,12 @@
     // sync now queues behind this tail; runSync never rejects, so the tail
     // can never become a permanently rejected promise that stalls the chain.
     //
-    // Scope, so this is not read as more than it is (Codex P2, acknowledged and
-    // deliberately NOT fixed in this PR): the tail is per-JS-realm, so it
-    // orders one window's POSTs only. Two windows toggling during each other's
-    // in-flight request still overlap, and save_global_conversation_settings is
-    // an unversioned read-modify-write, so the older choice can land last. The
-    // windows themselves still converge on the newer choice through the
-    // localStorage decision tuple (asrDecision) -- which is localStorage
-    // metadata only: the POST body carries plain values, and the storage
-    // listener deliberately issues no corrective POST -- so the divergence
-    // surfaces only after a reload. Closing it needs a versioned write protocol
-    // on an endpoint shared by every preference and every client build, which
-    // is a wider change than this PR should carry.
+    // The tail remains per-JS-realm, so cross-window requests can overlap.
+    // Their server persistence is ordered separately by the ETag CAS protocol
+    // below plus the same ASR decision tuple localStorage already uses.
     let _syncChainTail = Promise.resolve();
+    let _conversationSettingsEtag = null;
+    const _CONVERSATION_SETTINGS_MAX_ATTEMPTS = 3;
     // 同步间隔（毫秒）：60秒
     const SYNC_INTERVAL_MS = 60000;
     // 「首启等 settings/telemetry 决议」专属 marker：只有 localStorage 走过首启分支才会写
@@ -504,10 +567,13 @@
             if (!data.success) return null;
             const hasSettings = data.settings && Object.keys(data.settings).length > 0;
             const telemetryBranch = (typeof data.telemetryBranch === 'string' && data.telemetryBranch) || null;
-            if (!hasSettings && !telemetryBranch) return null;
+            const etag = _responseEtag(response);
+            if (!hasSettings && !telemetryBranch && !etag) return null;
             return {
                 settings: hasSettings ? data.settings : null,
-                telemetryBranch
+                telemetryBranch,
+                etag,
+                decisions: data.decisions || null
             };
         } catch (e) {
             console.warn('[app-settings] 从服务器加载设置失败:', e);
@@ -579,38 +645,62 @@
             } catch (_) {
                 // keep settings sync best-effort if the tutorial controller is unavailable
             }
-            const settings = getConversationSettings();
-            // Full snapshot only once server values were actually merged. If
-            // the gate opened on its timeout instead — or the GET resolved to
-            // null and merged nothing — a full body would clobber every
-            // untouched server-persisted preference with this boot's values
-            // (and a still-pending GET would then read the overwritten file
-            // back, so the merge could not restore them). Send the dirty keys
-            // alone — the backend merges partial payloads — and let the merge
-            // writeback converge the rest if/once the GET lands.
-            const payload = _settingsMergedFromServer ? settings : _pickDirtySettings(settings);
-            if (Object.keys(payload).length === 0) {
-                // Nothing the user explicitly changed yet, and no server truth
-                // to echo back: writing anything here could only overwrite
-                // persisted preferences with pre-merge values.
-                return;
-            }
-            try {
-                const response = await fetch('/api/config/conversation-settings', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify(payload)
-                });
-                if (!response.ok) {
-                    console.error('[app-settings] 同步设置到服务器失败: HTTP', response.status);
+            for (let attempt = 0; attempt < _CONVERSATION_SETTINGS_MAX_ATTEMPTS; attempt += 1) {
+                const settings = getConversationSettings();
+                // Full snapshot only once server values were actually merged. If
+                // the gate opened on its timeout instead — or the GET resolved to
+                // null and merged nothing — a full body would clobber every
+                // untouched server-persisted preference with this boot's values.
+                // Rebuild on every CAS retry so a newer cross-window ASR decision
+                // adopted from the conflict response replaces the stale body.
+                const payload = _settingsMergedFromServer ? settings : _pickDirtySettings(settings);
+                if (Object.keys(payload).length === 0) {
                     return;
                 }
-                const data = await response.json();
-                if (!data.success) {
-                    console.error('[app-settings] 同步设置到服务器失败:', data.error || '未知错误');
+                const requestDecision = (
+                    Object.prototype.hasOwnProperty.call(payload, 'independentAsrEnabled')
+                    && _lastAsrDecision
+                    && _lastAsrDecision.value === payload.independentAsrEnabled
+                ) ? {
+                    writeId: _lastAsrDecision.writeId,
+                    writerId: _lastAsrDecision.writerId,
+                    value: _lastAsrDecision.value
+                } : null;
+                const headers = { 'Content-Type': 'application/json' };
+                if (_conversationSettingsEtag) {
+                    headers['If-Match'] = _conversationSettingsEtag;
                 }
-            } catch (err) {
-                console.error('[app-settings] 同步设置到服务器失败:', err);
+                if (requestDecision) {
+                    headers['X-Conversation-Settings-ASR-Decision'] =
+                        JSON.stringify(requestDecision);
+                }
+                try {
+                    const response = await fetch('/api/config/conversation-settings', {
+                        method: 'POST',
+                        headers,
+                        body: JSON.stringify(payload)
+                    });
+                    const data = await response.json();
+                    const nextEtag = _responseEtag(response);
+                    if (nextEtag) _conversationSettingsEtag = nextEtag;
+                    if (response.status === 412) {
+                        _mergeConversationSettingsConflict(data);
+                        if (attempt + 1 < _CONVERSATION_SETTINGS_MAX_ATTEMPTS) {
+                            continue;
+                        }
+                    }
+                    if (!response.ok) {
+                        console.error('[app-settings] 同步设置到服务器失败: HTTP', response.status);
+                        return;
+                    }
+                    if (!data.success) {
+                        console.error('[app-settings] 同步设置到服务器失败:', data.error || '未知错误');
+                    }
+                    return;
+                } catch (err) {
+                    console.error('[app-settings] 同步设置到服务器失败:', err);
+                    return;
+                }
             }
         };
         // runSync swallows its own failures, so chaining with it on both
@@ -1113,6 +1203,9 @@
                 _settingsMergedFromServer = true;
                 const serverSettings = serverResult.settings;
                 const telemetryBranch = serverResult.telemetryBranch;
+                if (serverResult.etag) {
+                    _conversationSettingsEtag = serverResult.etag;
+                }
                 let hasUpdate = false;
 
                 // 只要 server 给了 branch，本次首启决议就算完成，清掉 pending marker；下次
@@ -1154,6 +1247,16 @@
                     }
                     if (serverSettings.userLanguage !== undefined && !_dirtySettingsKeys.has('userLanguage') && window.subtitleBridge) {
                         window.subtitleBridge.setUserLanguage(serverSettings.userLanguage);
+                    }
+                }
+                if (serverResult.decisions) {
+                    const previousAsr = S.independentAsrEnabled;
+                    _adoptServerAsrDecision({
+                        settings: serverSettings,
+                        decisions: serverResult.decisions
+                    });
+                    if (S.independentAsrEnabled !== previousAsr) {
+                        hasUpdate = true;
                     }
                 }
 

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -316,7 +316,7 @@
     // revision even when the edit arrived before the next CAS request began.
     // Preserve such fields across a 412; mutationVersionAtSend alone only sees
     // edits that arrive after the request snapshot.
-    let _conversationSettingsEtagMutationVersion = 0;
+    const _conversationSettingsEtagKeyMutationVersions = Object.create(null);
     const _CONVERSATION_SETTINGS_MAX_ATTEMPTS = 3;
     // 同步间隔（毫秒）：60秒
     const SYNC_INTERVAL_MS = 60000;
@@ -642,14 +642,41 @@
         return changedKeys;
     }
 
-    function _crossWindowSettingsChangedSince(mutationVersion) {
+    function _etagKeyMutationVersionsSnapshot() {
+        const snapshot = {};
+        _SHARED_SETTINGS_KEYS.forEach((key) => {
+            snapshot[key] =
+                _conversationSettingsEtagKeyMutationVersions[key] || 0;
+        });
+        return snapshot;
+    }
+
+    function _crossWindowSettingsNewerThanEtag(etagKeyMutationVersions) {
         const changedKeys = new Set();
         _SHARED_SETTINGS_KEYS.forEach((key) => {
-            if ((_crossWindowKeyMutationVersions[key] || 0) > mutationVersion) {
+            if ((_crossWindowKeyMutationVersions[key] || 0)
+                > (etagKeyMutationVersions[key] || 0)) {
                 changedKeys.add(key);
             }
         });
         return changedKeys;
+    }
+
+    function _markEtagConfirmedSharedSettings(
+        settingsAtSend,
+        serverSettings,
+        mutationVersionAtSend,
+        payloadWasFull
+    ) {
+        if (!serverSettings || typeof serverSettings !== 'object') return;
+        _SHARED_SETTINGS_KEYS.forEach((key) => {
+            if (!Object.prototype.hasOwnProperty.call(serverSettings, key)) return;
+            if (!payloadWasFull
+                && (!Object.prototype.hasOwnProperty.call(settingsAtSend, key)
+                    || settingsAtSend[key] !== serverSettings[key])) return;
+            _conversationSettingsEtagKeyMutationVersions[key] =
+                mutationVersionAtSend;
+        });
     }
 
     function _noteCrossWindowMutations(settings, explicitKeys) {
@@ -850,8 +877,8 @@
             for (let attempt = 0; attempt < _CONVERSATION_SETTINGS_MAX_ATTEMPTS; attempt += 1) {
                 const settings = getConversationSettings();
                 const mutationVersionAtSend = _crossWindowMutationVersion;
-                const etagMutationVersionAtSend =
-                    _conversationSettingsEtagMutationVersion;
+                const etagKeyMutationVersionsAtSend =
+                    _etagKeyMutationVersionsSnapshot();
                 const mergedAtSend = _settingsMergedFromServer;
                 // Full snapshot only once server values were actually merged. If
                 // the gate opened on its timeout instead — or the GET resolved to
@@ -891,8 +918,8 @@
                     if (nextEtag) _conversationSettingsEtag = nextEtag;
                     if (response.status === 412) {
                         const preservedKeys = new Set(_pendingSettingsKeys);
-                        _crossWindowSettingsChangedSince(
-                            etagMutationVersionAtSend
+                        _crossWindowSettingsNewerThanEtag(
+                            etagKeyMutationVersionsAtSend
                         ).forEach((key) => {
                             preservedKeys.add(key);
                         });
@@ -912,9 +939,13 @@
                         console.error('[app-settings] 同步设置到服务器失败:', data.error || '未知错误');
                         return;
                     }
-                    if (nextEtag && mergedAtSend) {
-                        _conversationSettingsEtagMutationVersion =
-                            mutationVersionAtSend;
+                    if (nextEtag) {
+                        _markEtagConfirmedSharedSettings(
+                            settings,
+                            data.settings,
+                            mutationVersionAtSend,
+                            mergedAtSend
+                        );
                     }
                     const changedWhileInFlight = _settingsChangedSince(
                         settings,
@@ -926,8 +957,8 @@
                     // the gate race, hydrate untouched fields from this response
                     // while preserving edits made after the request was sent.
                     if (!mergedAtSend) {
-                        _crossWindowSettingsChangedSince(
-                            etagMutationVersionAtSend
+                        _crossWindowSettingsNewerThanEtag(
+                            _conversationSettingsEtagKeyMutationVersions
                         ).forEach((key) => {
                             changedWhileInFlight.add(key);
                         });
@@ -1483,8 +1514,10 @@
                         || _asrDecisionOutranks(_lastAsrDecision, serverAsrDecision)));
                 if (serverResult.etag) {
                     _conversationSettingsEtag = serverResult.etag;
-                    _conversationSettingsEtagMutationVersion =
-                        mutationVersionAtGetStart;
+                    _SHARED_SETTINGS_KEYS.forEach((key) => {
+                        _conversationSettingsEtagKeyMutationVersions[key] =
+                            mutationVersionAtGetStart;
+                    });
                 }
                 let hasUpdate = false;
 
@@ -1512,16 +1545,23 @@
                     // hydrates from the server — the old whole-merge-drop let
                     // one unrelated toggle turn the entire boot-default
                     // snapshot into the POSTed truth.
+                    const acceptedSharedSettings = {};
                     for (const key of Object.keys(serverSettings)) {
                         if (serverSettings[key] === undefined) continue;
                         if (_dirtySettingsKeys.has(key)) continue;
                         if ((_crossWindowKeyMutationVersions[key] || 0)
                             > mutationVersionAtGetStart) continue;
                         if (key === 'independentAsrEnabled' && preserveLocalAsrDecision) continue;
-                        if (S[key] !== serverSettings[key]) {
+                        if (_SHARED_SETTINGS_KEYS.indexOf(key) !== -1
+                            || key === 'userLanguage') {
+                            acceptedSharedSettings[key] = serverSettings[key];
+                        } else if (S[key] !== serverSettings[key]) {
                             S[key] = serverSettings[key];
                             hasUpdate = true;
                         }
+                    }
+                    if (applySharedRuntimeSettings(acceptedSharedSettings)) {
+                        hasUpdate = true;
                     }
                     // Subtitle bridge mirrors follow the same dirty gating so
                     // a user-changed subtitle preference survives the merge.
@@ -1534,11 +1574,12 @@
                 }
                 if (serverResult.decisions) {
                     const previousAsr = S.independentAsrEnabled;
-                    _adoptServerAsrDecision({
+                    const adoptedAsrDecision = _adoptServerAsrDecision({
                         settings: serverSettings,
                         decisions: serverResult.decisions
                     });
-                    if (S.independentAsrEnabled !== previousAsr) {
+                    if (adoptedAsrDecision
+                        || S.independentAsrEnabled !== previousAsr) {
                         hasUpdate = true;
                     }
                 }

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -28,6 +28,8 @@
     // without reopening the late-boot-GET overwrite race.
     const _dirtySettingsKeys = new Set();
     const _pendingSettingsKeys = new Set();
+    let _crossWindowMutationVersion = 0;
+    const _crossWindowKeyMutationVersions = Object.create(null);
     let _settingsBaseline = null;
     // Cross-window write metadata (Codex P2): saveSettings() writes EVERY
     // conversation key into the shared localStorage snapshot, so a receiving
@@ -527,7 +529,7 @@
         }
     }
 
-    function _settingsChangedSince(snapshot) {
+    function _settingsChangedSince(snapshot, mutationVersion) {
         const changedKeys = new Set();
         const current = getConversationSettings();
         const keys = new Set(Object.keys(snapshot).concat(Object.keys(current)));
@@ -538,9 +540,25 @@
             const now = Object.prototype.hasOwnProperty.call(current, key)
                 ? current[key]
                 : undefined;
-            if (before !== now) changedKeys.add(key);
+            if (before !== now
+                || (_crossWindowKeyMutationVersions[key] || 0) > mutationVersion) {
+                changedKeys.add(key);
+            }
         });
         return changedKeys;
+    }
+
+    function _noteCrossWindowMutations(settings, explicitKeys) {
+        _SHARED_SETTINGS_KEYS.forEach((key) => {
+            if (!Object.prototype.hasOwnProperty.call(settings, key)) return;
+            // A server-merge broadcast carries an empty changedKeys list and
+            // must not be mistaken for newer user intent. Metadata-less
+            // previous-build writers retain their value-change fallback.
+            if (explicitKeys && explicitKeys.indexOf(key) === -1) return;
+            if (S[key] === settings[key]) return;
+            _crossWindowMutationVersion += 1;
+            _crossWindowKeyMutationVersions[key] = _crossWindowMutationVersion;
+        });
     }
 
     function applySharedRuntimeSettings(settings) {
@@ -715,6 +733,7 @@
             }
             for (let attempt = 0; attempt < _CONVERSATION_SETTINGS_MAX_ATTEMPTS; attempt += 1) {
                 const settings = getConversationSettings();
+                const mutationVersionAtSend = _crossWindowMutationVersion;
                 const mergedAtSend = _settingsMergedFromServer;
                 // Full snapshot only once server values were actually merged. If
                 // the gate opened on its timeout instead — or the GET resolved to
@@ -754,7 +773,7 @@
                     if (nextEtag) _conversationSettingsEtag = nextEtag;
                     if (response.status === 412) {
                         const preservedKeys = new Set(_pendingSettingsKeys);
-                        _settingsChangedSince(settings).forEach((key) => {
+                        _settingsChangedSince(settings, mutationVersionAtSend).forEach((key) => {
                             preservedKeys.add(key);
                         });
                         _mergeConversationSettingsSnapshot(data, preservedKeys);
@@ -770,7 +789,10 @@
                         console.error('[app-settings] 同步设置到服务器失败:', data.error || '未知错误');
                         return;
                     }
-                    const changedWhileInFlight = _settingsChangedSince(settings);
+                    const changedWhileInFlight = _settingsChangedSince(
+                        settings,
+                        mutationVersionAtSend
+                    );
                     _clearAcknowledgedPendingSettings(payload);
                     // A successful dirty-only write returns the complete
                     // authoritative snapshot. If the boot GET failed or lost
@@ -1500,6 +1522,7 @@
                 incoming = Object.assign({}, settings);
                 delete incoming.independentAsrEnabled;
             }
+            _noteCrossWindowMutations(incoming, meta ? meta.changedKeys : null);
             const changed = applySharedRuntimeSettings(incoming);
             // Roll the dirty-diff baseline for every key just adopted from
             // another window. _markUserDirtySettings diffs against this

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -150,10 +150,11 @@
         }
         return true;
     }
-    function _mergeConversationSettingsConflict(data) {
+    function _mergeConversationSettingsSnapshot(data, preservedKeys) {
         const adoptedAsr = _adoptServerAsrDecision(data);
         const serverSettings = data && data.settings;
         if (!serverSettings || typeof serverSettings !== 'object') return;
+        const protectedKeys = preservedKeys || _pendingSettingsKeys;
         const serverAsrDecision = _serverAsrDecision(data);
         const preserveLocalAsrDecision = !!(_lastAsrDecision
             && (!serverAsrDecision
@@ -162,28 +163,43 @@
         for (const key of Object.keys(serverSettings)) {
             if (key === 'independentAsrEnabled'
                 && (adoptedAsr || preserveLocalAsrDecision)) continue;
-            if (_pendingSettingsKeys.has(key)) continue;
+            if (protectedKeys.has(key)) continue;
             if (serverSettings[key] !== undefined) {
                 acceptedSettings[key] = serverSettings[key];
             }
         }
-        applySharedRuntimeSettings(acceptedSettings);
+        let changed = applySharedRuntimeSettings(acceptedSettings);
         // Preserve server-only conversation keys that are intentionally not in
         // the cross-window shared-settings list.
         for (const key of Object.keys(acceptedSettings)) {
             if (_SHARED_SETTINGS_KEYS.indexOf(key) !== -1 || key === 'userLanguage') continue;
+            if (S[key] !== acceptedSettings[key]) changed = true;
             S[key] = acceptedSettings[key];
             if (Object.prototype.hasOwnProperty.call(window, key)) {
                 window[key] = S[key];
             }
         }
         _settingsMergedFromServer = true;
+        S.settingsHydrated = true;
+        S.independentAsrAuthoritative = true;
         if (_settingsBaseline) {
             for (const key of Object.keys(serverSettings)) {
-                if (_pendingSettingsKeys.has(key)) continue;
+                if (protectedKeys.has(key)) continue;
                 if (serverSettings[key] !== undefined) {
                     _settingsBaseline[key] = S[key];
                 }
+            }
+        }
+        // Persist the reconciled runtime snapshot for offline restarts and
+        // notify sibling windows, but do not advertise server winners as fresh
+        // user intent or enqueue another POST.
+        saveSettings({ skipServerSync: true, serverMerged: true });
+        if (changed) {
+            if (typeof window.appProactive !== 'undefined'
+                && window.appProactive.scheduleProactiveChat) {
+                window.appProactive.scheduleProactiveChat();
+            } else if (typeof window.scheduleProactiveChat === 'function') {
+                window.scheduleProactiveChat();
             }
         }
     }
@@ -511,6 +527,22 @@
         }
     }
 
+    function _settingsChangedSince(snapshot) {
+        const changedKeys = new Set();
+        const current = getConversationSettings();
+        const keys = new Set(Object.keys(snapshot).concat(Object.keys(current)));
+        keys.forEach((key) => {
+            const before = Object.prototype.hasOwnProperty.call(snapshot, key)
+                ? snapshot[key]
+                : undefined;
+            const now = Object.prototype.hasOwnProperty.call(current, key)
+                ? current[key]
+                : undefined;
+            if (before !== now) changedKeys.add(key);
+        });
+        return changedKeys;
+    }
+
     function applySharedRuntimeSettings(settings) {
         if (!settings || typeof settings !== 'object') return false;
         let changed = false;
@@ -683,6 +715,7 @@
             }
             for (let attempt = 0; attempt < _CONVERSATION_SETTINGS_MAX_ATTEMPTS; attempt += 1) {
                 const settings = getConversationSettings();
+                const mergedAtSend = _settingsMergedFromServer;
                 // Full snapshot only once server values were actually merged. If
                 // the gate opened on its timeout instead — or the GET resolved to
                 // null and merged nothing — a full body would clobber every
@@ -720,7 +753,7 @@
                     const nextEtag = _responseEtag(response);
                     if (nextEtag) _conversationSettingsEtag = nextEtag;
                     if (response.status === 412) {
-                        _mergeConversationSettingsConflict(data);
+                        _mergeConversationSettingsSnapshot(data);
                         if (attempt + 1 < _CONVERSATION_SETTINGS_MAX_ATTEMPTS) {
                             continue;
                         }
@@ -733,7 +766,15 @@
                         console.error('[app-settings] 同步设置到服务器失败:', data.error || '未知错误');
                         return;
                     }
+                    const changedWhileInFlight = _settingsChangedSince(settings);
                     _clearAcknowledgedPendingSettings(payload);
+                    // A successful dirty-only write returns the complete
+                    // authoritative snapshot. If the boot GET failed or lost
+                    // the gate race, hydrate untouched fields from this response
+                    // while preserving edits made after the request was sent.
+                    if (!mergedAtSend) {
+                        _mergeConversationSettingsSnapshot(data, changedWhileInFlight);
+                    }
                     return;
                 } catch (err) {
                     console.error('[app-settings] 同步设置到服务器失败:', err);
@@ -814,12 +855,15 @@
      * 将当前设置保存到 localStorage
      * 从 window 全局变量读取最新值（确保同步 live2d.js 中的更改）
      *
-     * @param {{ skipServerSync?: boolean }} [options] 传 skipServerSync 跳过 POST，
+     * @param {{ skipServerSync?: boolean, serverMerged?: boolean }} [options]
+     *   传 skipServerSync 跳过 POST；
+     *   serverMerged 表示共享快照来自服务端合并，不得标记成新的用户修改。
      *   首启用——避免在 loadSettingsFromServer 拿到 telemetryBranch 之前就把首启本地
      *   默认值写到服务器、回头被自己的 GET 当成「云端已有偏好」，干扰首启决议时序
      */
     function saveSettings(options) {
         const skipServerSync = !!(options && options.skipServerSync);
+        const serverMerged = !!(options && options.serverMerged);
         // 从全局变量读取最新值（确保同步 live2d.js 中的更改）
         const currentProactive = typeof window.proactiveChatEnabled !== 'undefined'
             ? window.proactiveChatEnabled
@@ -936,7 +980,10 @@
         // into the shared snapshot: every save copies independentAsrEnabled
         // along, so the receiving window needs this metadata to tell a real
         // cross-window toggle from an unrelated save's incidental copy.
-        _writeSharedSettings(settings, _collectExplicitSharedKeys(settings));
+        _writeSharedSettings(
+            settings,
+            serverMerged ? [] : _collectExplicitSharedKeys(settings)
+        );
 
         // 同步回共享状态，保持一致性
         S.proactiveChatEnabled = currentProactive;

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -886,7 +886,11 @@
      * 将当前设置保存到 localStorage
      * 从 window 全局变量读取最新值（确保同步 live2d.js 中的更改）
      *
-     * @param {{ skipServerSync?: boolean, serverMerged?: boolean }} [options]
+     * @param {{
+     *   skipServerSync?: boolean,
+     *   serverMerged?: boolean,
+     *   explicitSharedKeys?: string[]
+     * }} [options]
      *   传 skipServerSync 跳过 POST；
      *   serverMerged 表示共享快照来自服务端合并，不得标记成新的用户修改。
      *   首启用——避免在 loadSettingsFromServer 拿到 telemetryBranch 之前就把首启本地
@@ -895,6 +899,9 @@
     function saveSettings(options) {
         const skipServerSync = !!(options && options.skipServerSync);
         const serverMerged = !!(options && options.serverMerged);
+        const explicitSharedKeys = options && Array.isArray(options.explicitSharedKeys)
+            ? options.explicitSharedKeys
+            : null;
         // 从全局变量读取最新值（确保同步 live2d.js 中的更改）
         const currentProactive = typeof window.proactiveChatEnabled !== 'undefined'
             ? window.proactiveChatEnabled
@@ -1013,7 +1020,9 @@
         // cross-window toggle from an unrelated save's incidental copy.
         _writeSharedSettings(
             settings,
-            serverMerged ? [] : _collectExplicitSharedKeys(settings)
+            explicitSharedKeys !== null
+                ? explicitSharedKeys
+                : (serverMerged ? [] : _collectExplicitSharedKeys(settings))
         );
 
         // 同步回共享状态，保持一致性
@@ -1527,6 +1536,17 @@
                 incoming = Object.assign({}, settings);
                 delete incoming.independentAsrEnabled;
             }
+            const pendingKeysToReassert = [];
+            if (meta && meta.changedKeys.length === 0) {
+                // Keep this as for...of: static listener-contract tests slice
+                // at the first callback terminator.
+                for (const key of _pendingSettingsKeys) {
+                    if (!Object.prototype.hasOwnProperty.call(incoming, key)) continue;
+                    if (incoming === settings) incoming = Object.assign({}, settings);
+                    delete incoming[key];
+                    pendingKeysToReassert.push(key);
+                }
+            }
             _noteCrossWindowMutations(incoming, meta ? meta.changedKeys : null);
             const changed = applySharedRuntimeSettings(incoming);
             if (meta && meta.asrDecision
@@ -1590,6 +1610,16 @@
             stopVisionAfterPrivacyEnabled();
             if (changed && typeof window.scheduleProactiveChat === 'function') {
                 window.scheduleProactiveChat();
+            }
+            if (pendingKeysToReassert.length > 0) {
+                // A server-merge broadcast can have been built before this
+                // window's latest pending edit reached its sender. Restore the
+                // local full snapshot without enqueueing another POST; the
+                // already queued user sync remains the sole server writer.
+                saveSettings({
+                    skipServerSync: true,
+                    explicitSharedKeys: pendingKeysToReassert
+                });
             }
         } catch (error) {
             console.warn('[app-settings] 跨窗口设置同步失败:', error);

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -63,12 +63,19 @@
     // other each adopt the other and stay swapped forever. That needs no
     // millisecond tie at all -- a strictly older foreign write still wins.
     let _lastAsrDecision = null;
-    function _isValidAsrWriteId(value) {
+    function _isValidAsrWriteId(value, serverAuthoritative) {
+        if (!Number.isSafeInteger(value) || value < 0
+            || value > Number.MAX_SAFE_INTEGER - 1) return false;
+        // The server is the clock authority for persisted decision tuples.
+        // Rechecking its accepted ceiling against this browser's Date.now()
+        // makes a lagging browser reject a valid winner. Keep the clock-relative
+        // bound only for untrusted localStorage/write metadata.
+        if (serverAuthoritative === true) return true;
         const maxAccepted = Math.min(
             Number.MAX_SAFE_INTEGER - 1,
             Date.now() + _ASR_WRITE_ID_MAX_FUTURE_SKEW_MS
         );
-        return Number.isSafeInteger(value) && value >= 0 && value <= maxAccepted;
+        return value <= maxAccepted;
     }
     function _noteAsrDecision(writeId, writerId, value) {
         // A write that merely re-asserts the value already decided is not a new
@@ -106,9 +113,9 @@
         // build) reads as '' and loses, keeping this window's own choice.
         return (decision.writerId || '') > _lastAsrDecision.writerId;
     }
-    function _normalizeServerAsrDecision(value) {
+    function _normalizeServerAsrDecision(value, serverAuthoritative) {
         if (!value || typeof value !== 'object') return null;
-        if (!_isValidAsrWriteId(value.writeId)) return null;
+        if (!_isValidAsrWriteId(value.writeId, serverAuthoritative)) return null;
         if (typeof value.writerId !== 'string'
             || !/^[\x20-\x7E]{1,128}$/.test(value.writerId)) return null;
         if (typeof value.value !== 'boolean') return null;
@@ -214,11 +221,12 @@
     function _serverAsrDecision(data) {
         const decisions = data && data.decisions;
         return _normalizeServerAsrDecision(
-            decisions && decisions.independentAsrEnabled
+            decisions && decisions.independentAsrEnabled,
+            true
         );
     }
-    function _adoptAsrDecisionTuple(value) {
-        const decision = _normalizeServerAsrDecision(value);
+    function _adoptAsrDecisionTuple(value, serverAuthoritative) {
+        const decision = _normalizeServerAsrDecision(value, serverAuthoritative);
         if (!_asrDecisionOutranks(decision, _lastAsrDecision)) return false;
         _lastAsrDecision = decision;
         if (decision.writeId > _lastAppliedSharedWriteId) {
@@ -237,7 +245,7 @@
     }
     function _adoptServerAsrDecision(data) {
         const decision = _serverAsrDecision(data);
-        if (!_adoptAsrDecisionTuple(decision)) return false;
+        if (!_adoptAsrDecisionTuple(decision, true)) return false;
         // The next explicit local choice must mint above every decision this
         // window has accepted, including cloud/server decisions whose clock is
         // ahead of this browser's Date.now().
@@ -257,11 +265,13 @@
     }
     function _mergeConversationSettingsSnapshot(data, preservedKeys) {
         const adoptedAsr = _adoptServerAsrDecision(data);
-        const serverSettings = data && data.settings;
+        const serverSettings = _serverSettingsForMerge(data);
         if (!serverSettings || typeof serverSettings !== 'object') return;
         const protectedKeys = preservedKeys || _pendingSettingsKeys;
         const serverAsrDecision = _serverAsrDecision(data);
-        const preserveLocalAsrDecision = !!(_lastAsrDecision
+        const preserveLocalAsrDecision = data && data.reset === true
+            ? false
+            : !!(_lastAsrDecision
             && (!serverAsrDecision
                 || _asrDecisionOutranks(_lastAsrDecision, serverAsrDecision)));
         const acceptedSettings = {};
@@ -400,6 +410,47 @@
         'renderQuality',
         'targetFrameRate'
     ];
+
+    function _defaultConversationSettingsForReset() {
+        return {
+            proactiveChatEnabled: true,
+            proactiveVisionEnabled: _isUserRegionChina(),
+            proactiveVisionChatEnabled: true,
+            proactiveNewsChatEnabled: false,
+            proactiveVideoChatEnabled: true,
+            proactivePersonalChatEnabled: false,
+            proactiveMusicEnabled: true,
+            proactiveMemeEnabled: true,
+            proactiveMiniGameInviteEnabled: true,
+            mergeMessagesEnabled: false,
+            focusModeEnabled: false,
+            focusCognitionEnabled: true,
+            noiseReductionEnabled: true,
+            independentAsrEnabled: false,
+            avatarReactionBubbleEnabled: true,
+            slopFilterEnabled: true,
+            proactiveChatInterval: Number.isFinite(C.DEFAULT_PROACTIVE_CHAT_INTERVAL)
+                ? C.DEFAULT_PROACTIVE_CHAT_INTERVAL
+                : 15,
+            proactiveVisionInterval: Number.isFinite(C.DEFAULT_PROACTIVE_VISION_INTERVAL)
+                ? C.DEFAULT_PROACTIVE_VISION_INTERVAL
+                : 10,
+            subtitleEnabled: false,
+            userLanguage: null,
+            textGuardMaxLength: 300
+        };
+    }
+
+    function _serverSettingsForMerge(data) {
+        const settings = data && data.settings;
+        if (data && data.reset === true) {
+            return Object.assign(
+                _defaultConversationSettingsForReset(),
+                settings && typeof settings === 'object' ? settings : {}
+            );
+        }
+        return settings;
+    }
 
     function getDefaultRenderQuality() {
         return S.renderQuality || 'medium';
@@ -665,7 +716,10 @@
             // matching decision: null routes the comparison back to
             // (writeId, writerId), i.e. today's behaviour.
             asrDecision: (meta.asrDecision
-                && _isValidAsrWriteId(meta.asrDecision.writeId))
+                && _isValidAsrWriteId(
+                    meta.asrDecision.writeId,
+                    Number.isInteger(meta.serverRevision)
+                ))
                 ? {
                     writeId: meta.asrDecision.writeId,
                     writerId: typeof meta.asrDecision.writerId === 'string'
@@ -890,7 +944,8 @@
                 telemetryBranch,
                 etag,
                 revision: Number.isInteger(data.revision) ? data.revision : null,
-                decisions: data.decisions || null
+                decisions: data.decisions || null,
+                reset: data.reset === true
             };
         } catch (e) {
             console.warn('[app-settings] 从服务器加载设置失败:', e);
@@ -1373,7 +1428,10 @@
                     // it carries authority, not a fresh user action. Restore its
                     // matching decision tuple anyway so reloads retain both the
                     // ordering token and the floor for the next local choice.
-                    _adoptAsrDecisionTuple(bootMeta.asrDecision);
+                    _adoptAsrDecisionTuple(
+                        bootMeta.asrDecision,
+                        Number.isInteger(bootMeta.serverRevision)
+                    );
                 } else if (bootMeta
                     && bootMeta.changedKeys.indexOf('independentAsrEnabled') !== -1) {
                     const bootDecision = bootMeta.asrDecision || bootMeta;
@@ -1611,7 +1669,7 @@
                 // nothing a full write could clobber (and the first-launch
                 // forced push below depends on it).
                 _settingsMergedFromServer = true;
-                const serverSettings = serverResult.settings;
+                const serverSettings = _serverSettingsForMerge(serverResult);
                 const telemetryBranch = serverResult.telemetryBranch;
                 const serverAsrDecision = _serverAsrDecision(serverResult);
                 // A cross-window toggle can reach localStorage before its POST
@@ -1619,13 +1677,16 @@
                 // newer than the GET snapshot, so the generic field merge must
                 // not copy the older server value into S before the decision
                 // merge gets a chance to reject it.
-                const preserveLocalAsrDecision = !!(_lastAsrDecision
+                const preserveLocalAsrDecision = serverResult.reset === true
+                    ? false
+                    : !!(_lastAsrDecision
                     && (!serverAsrDecision
                         || _asrDecisionOutranks(_lastAsrDecision, serverAsrDecision)));
                 const serverSnapshotNewerThanCurrent =
-                    Number.isInteger(serverResult.revision)
-                    && Number.isInteger(_conversationSettingsRevision)
-                    && serverResult.revision > _conversationSettingsRevision;
+                    serverResult.reset === true
+                    || (Number.isInteger(serverResult.revision)
+                        && Number.isInteger(_conversationSettingsRevision)
+                        && serverResult.revision > _conversationSettingsRevision);
                 const shouldAdoptServerVersion =
                     !Number.isInteger(_conversationSettingsRevision)
                     || (Number.isInteger(serverResult.revision)
@@ -1990,20 +2051,22 @@
                         delete _knownSharedKeyWrites[key];
                     }
                 }
-                if (Number.isInteger(meta.serverRevision)
-                    && (!Number.isInteger(_conversationSettingsRevision)
-                        || meta.serverRevision
-                            > _conversationSettingsRevision)) {
-                    _conversationSettingsRevision = meta.serverRevision;
-                    _conversationSettingsEtag =
-                        `"conversation-settings-${meta.serverRevision}"`;
-                    for (const key of meta.serverAuthoritativeKeys) {
-                        if (!Object.prototype.hasOwnProperty.call(
-                            incoming,
-                            key
-                        )) continue;
-                        _conversationSettingsEtagKeyMutationVersions[key] =
-                            _crossWindowKeyMutationVersions[key] || 0;
+                if (Number.isInteger(meta.serverRevision)) {
+                    if (!Number.isInteger(_conversationSettingsRevision)
+                        || meta.serverRevision > _conversationSettingsRevision) {
+                        _conversationSettingsRevision = meta.serverRevision;
+                        _conversationSettingsEtag =
+                            `"conversation-settings-${meta.serverRevision}"`;
+                    }
+                    if (meta.serverRevision === _conversationSettingsRevision) {
+                        for (const key of meta.serverAuthoritativeKeys) {
+                            if (!Object.prototype.hasOwnProperty.call(
+                                incoming,
+                                key
+                            )) continue;
+                            _conversationSettingsEtagKeyMutationVersions[key] =
+                                _crossWindowKeyMutationVersions[key] || 0;
+                        }
                     }
                 }
             }
@@ -2013,7 +2076,10 @@
                     'independentAsrEnabled'
                 )
                 && incoming.independentAsrEnabled === meta.asrDecision.value) {
-                _adoptAsrDecisionTuple(meta.asrDecision);
+                _adoptAsrDecisionTuple(
+                    meta.asrDecision,
+                    Number.isInteger(meta.serverRevision)
+                );
             }
             // Roll the dirty-diff baseline for every key just adopted from
             // another window. _markUserDirtySettings diffs against this

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -311,6 +311,12 @@
     // below plus the same ASR decision tuple localStorage already uses.
     let _syncChainTail = Promise.resolve();
     let _conversationSettingsEtag = null;
+    // Cross-window mutation version represented by the current ETag. A field
+    // explicitly edited after this watermark is absent from that server
+    // revision even when the edit arrived before the next CAS request began.
+    // Preserve such fields across a 412; mutationVersionAtSend alone only sees
+    // edits that arrive after the request snapshot.
+    let _conversationSettingsEtagMutationVersion = 0;
     const _CONVERSATION_SETTINGS_MAX_ATTEMPTS = 3;
     // 同步间隔（毫秒）：60秒
     const SYNC_INTERVAL_MS = 60000;
@@ -636,6 +642,16 @@
         return changedKeys;
     }
 
+    function _crossWindowSettingsChangedSince(mutationVersion) {
+        const changedKeys = new Set();
+        _SHARED_SETTINGS_KEYS.forEach((key) => {
+            if ((_crossWindowKeyMutationVersions[key] || 0) > mutationVersion) {
+                changedKeys.add(key);
+            }
+        });
+        return changedKeys;
+    }
+
     function _noteCrossWindowMutations(settings, explicitKeys) {
         _SHARED_SETTINGS_KEYS.forEach((key) => {
             if (!Object.prototype.hasOwnProperty.call(settings, key)) return;
@@ -834,6 +850,8 @@
             for (let attempt = 0; attempt < _CONVERSATION_SETTINGS_MAX_ATTEMPTS; attempt += 1) {
                 const settings = getConversationSettings();
                 const mutationVersionAtSend = _crossWindowMutationVersion;
+                const etagMutationVersionAtSend =
+                    _conversationSettingsEtagMutationVersion;
                 const mergedAtSend = _settingsMergedFromServer;
                 // Full snapshot only once server values were actually merged. If
                 // the gate opened on its timeout instead — or the GET resolved to
@@ -873,6 +891,11 @@
                     if (nextEtag) _conversationSettingsEtag = nextEtag;
                     if (response.status === 412) {
                         const preservedKeys = new Set(_pendingSettingsKeys);
+                        _crossWindowSettingsChangedSince(
+                            etagMutationVersionAtSend
+                        ).forEach((key) => {
+                            preservedKeys.add(key);
+                        });
                         _settingsChangedSince(settings, mutationVersionAtSend).forEach((key) => {
                             preservedKeys.add(key);
                         });
@@ -889,6 +912,10 @@
                         console.error('[app-settings] 同步设置到服务器失败:', data.error || '未知错误');
                         return;
                     }
+                    if (nextEtag && mergedAtSend) {
+                        _conversationSettingsEtagMutationVersion =
+                            mutationVersionAtSend;
+                    }
                     const changedWhileInFlight = _settingsChangedSince(
                         settings,
                         mutationVersionAtSend
@@ -899,6 +926,11 @@
                     // the gate race, hydrate untouched fields from this response
                     // while preserving edits made after the request was sent.
                     if (!mergedAtSend) {
+                        _crossWindowSettingsChangedSince(
+                            etagMutationVersionAtSend
+                        ).forEach((key) => {
+                            changedWhileInFlight.add(key);
+                        });
                         _mergeConversationSettingsSnapshot(data, changedWhileInFlight);
                     }
                     return;
@@ -1451,6 +1483,8 @@
                         || _asrDecisionOutranks(_lastAsrDecision, serverAsrDecision)));
                 if (serverResult.etag) {
                     _conversationSettingsEtag = serverResult.etag;
+                    _conversationSettingsEtagMutationVersion =
+                        mutationVersionAtGetStart;
                 }
                 let hasUpdate = false;
 

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -46,6 +46,12 @@
     const _ASR_WRITE_ID_MAX_FUTURE_SKEW_MS = 365 * 24 * 60 * 60 * 1000;
     let _lastSharedWriteId = 0;
     let _lastAppliedSharedWriteId = 0;
+    // Latest explicit non-ASR write token this window has incorporated per
+    // shared key. A server-merge snapshot gets a fresh envelope writeId, but
+    // that does not prove its field values observed every earlier user edit.
+    // Carrying these per-key source tokens lets receivers compare the data's
+    // actual provenance instead of mistaking the envelope timestamp for it.
+    const _knownSharedKeyWrites = Object.create(null);
     // Window-unique second sort key for concurrent shared-settings writes. Per
     // document load; stability across reloads is not needed because every
     // comparison reads the id off the write itself, and sessionStorage would be
@@ -120,6 +126,45 @@
         if (candidate.writeId > current.writeId) return true;
         if (candidate.writeId < current.writeId) return false;
         return candidate.writerId > current.writerId;
+    }
+    function _sharedWriteTokenOutranks(candidate, current) {
+        if (!candidate) return false;
+        if (!current) return true;
+        if (candidate.writeId > current.writeId) return true;
+        if (candidate.writeId < current.writeId) return false;
+        return (candidate.writerId || '') > (current.writerId || '');
+    }
+    function _rememberSharedKeyWrites(keys, token, acceptedSettings) {
+        if (!Array.isArray(keys) || !token) return;
+        for (const key of keys) {
+            if (key === 'independentAsrEnabled') continue;
+            if (_SHARED_SETTINGS_KEYS.indexOf(key) === -1) continue;
+            if (acceptedSettings
+                && !Object.prototype.hasOwnProperty.call(acceptedSettings, key)) continue;
+            const candidate = {
+                writeId: token.writeId,
+                writerId: token.writerId || ''
+            };
+            if (_sharedWriteTokenOutranks(candidate, _knownSharedKeyWrites[key])) {
+                _knownSharedKeyWrites[key] = candidate;
+            }
+        }
+    }
+    function _rememberKnownSharedKeyWrites(knownWrites, acceptedSettings) {
+        if (!knownWrites) return;
+        for (const key of Object.keys(knownWrites)) {
+            _rememberSharedKeyWrites([key], knownWrites[key], acceptedSettings);
+        }
+    }
+    function _knownSharedKeyWritesSnapshot() {
+        const snapshot = {};
+        for (const key of Object.keys(_knownSharedKeyWrites)) {
+            snapshot[key] = {
+                writeId: _knownSharedKeyWrites[key].writeId,
+                writerId: _knownSharedKeyWrites[key].writerId
+            };
+        }
+        return snapshot;
     }
     function _serverAsrDecision(data) {
         const decisions = data && data.decisions;
@@ -404,8 +449,10 @@
 
     /**
      * Keys of `snapshot` this window may claim explicit user authority over:
-     * the monotone _dirtySettingsKeys set plus keys that diverge from the
-     * current dirty-diff baseline. The divergence term matters because the
+     * still-pending keys plus keys that diverge from the current dirty-diff
+     * baseline. Do not use the monotone _dirtySettingsKeys set here: after an
+     * acknowledged edit, a later unrelated save must not mint a fresh per-key
+     * token for an old value. The divergence term matters because the
      * independent-ASR toggle handler persists locally (saveSettings with
      * skipServerSync) BEFORE its userInitiated sync runs _markUserDirtySettings,
      * so at write time the diff is the only evidence the key was just toggled.
@@ -417,7 +464,7 @@
             const divergedFromBaseline = !!_settingsBaseline
                 && Object.prototype.hasOwnProperty.call(_settingsBaseline, key)
                 && _settingsBaseline[key] !== snapshot[key];
-            if (_dirtySettingsKeys.has(key) || divergedFromBaseline) {
+            if (_pendingSettingsKeys.has(key) || divergedFromBaseline) {
                 keys.push(key);
             }
         });
@@ -453,6 +500,8 @@
             pendingRecovery: pendingRecovery === true
         };
         const ownMeta = payload[_SHARED_WRITE_META_KEY];
+        _rememberSharedKeyWrites(ownMeta.changedKeys, ownMeta);
+        ownMeta.knownKeyWrites = _knownSharedKeyWritesSnapshot();
         if (ownMeta.changedKeys.indexOf('independentAsrEnabled') !== -1) {
             _noteAsrDecision(ownMeta.writeId, ownMeta.writerId, snapshot.independentAsrEnabled);
         }
@@ -483,6 +532,23 @@
         const meta = settings ? settings[_SHARED_WRITE_META_KEY] : null;
         if (!meta || typeof meta !== 'object') return null;
         if (!_isValidAsrWriteId(meta.writeId)) return null;
+        const knownKeyWrites = {};
+        const rawKnownKeyWrites = meta.knownKeyWrites;
+        const knownKeyWritesPresent = !!rawKnownKeyWrites
+            && typeof rawKnownKeyWrites === 'object';
+        if (knownKeyWritesPresent) {
+            for (const key of Object.keys(rawKnownKeyWrites)) {
+                const token = rawKnownKeyWrites[key];
+                if (!token || typeof token !== 'object') continue;
+                if (!_isValidAsrWriteId(token.writeId)) continue;
+                knownKeyWrites[key] = {
+                    writeId: token.writeId,
+                    writerId: typeof token.writerId === 'string'
+                        ? token.writerId
+                        : ''
+                };
+            }
+        }
         return {
             writeId: meta.writeId,
             // Absent on snapshots written by the previous build: '' sorts below
@@ -498,6 +564,8 @@
             // changedKeys and keeps flowing through asrChangedByOtherWindow.
             asrAuthoritative: meta.asrAuthoritative === true,
             pendingRecovery: meta.pendingRecovery === true,
+            knownKeyWrites,
+            knownKeyWritesPresent,
             // Absent on previous-build snapshots and on writers with no
             // matching decision: null routes the comparison back to
             // (writeId, writerId), i.e. today's behaviour.
@@ -1122,6 +1190,10 @@
                 if (bootMeta && bootMeta.writeId > _lastAppliedSharedWriteId) {
                     _lastAppliedSharedWriteId = bootMeta.writeId;
                 }
+                if (bootMeta) {
+                    _rememberKnownSharedKeyWrites(bootMeta.knownKeyWrites, settings);
+                    _rememberSharedKeyWrites(bootMeta.changedKeys, bootMeta, settings);
+                }
                 if (bootMeta && bootMeta.asrDecision
                     && settings.independentAsrEnabled === bootMeta.asrDecision.value) {
                     // A server-merge snapshot intentionally has no changedKeys:
@@ -1341,6 +1413,7 @@
         // Until the first merge lands, POST bodies stay restricted to the
         // user-dirty keys so they cannot overwrite the server-persisted
         // preferences this client has not read yet.
+        const mutationVersionAtGetStart = _crossWindowMutationVersion;
         try {
             const mergeSettled = loadSettingsFromServer().then(serverResult => {
                 if (!serverResult) return;
@@ -1408,6 +1481,8 @@
                     for (const key of Object.keys(serverSettings)) {
                         if (serverSettings[key] === undefined) continue;
                         if (_dirtySettingsKeys.has(key)) continue;
+                        if ((_crossWindowKeyMutationVersions[key] || 0)
+                            > mutationVersionAtGetStart) continue;
                         if (key === 'independentAsrEnabled' && preserveLocalAsrDecision) continue;
                         if (S[key] !== serverSettings[key]) {
                             S[key] = serverSettings[key];
@@ -1460,7 +1535,7 @@
                     window.proactiveVisionInterval = S.proactiveVisionInterval;
                     window.textGuardMaxLength = S.textGuardMaxLength;
                     // 同步回 localStorage
-                    saveSettings();
+                    saveSettings({ serverMerged: true });
                     // 重新初始化主动搭话调度器（使用最新标志）
                     if (typeof window.appProactive !== 'undefined' && window.appProactive.scheduleProactiveChat) {
                         window.appProactive.scheduleProactiveChat();
@@ -1581,16 +1656,39 @@
             }
             const serverMergePredatesLocalWrite = !!meta
                 && meta.changedKeys.length === 0
+                && !meta.knownKeyWritesPresent
                 && meta.writeId <= writeIdFloorBeforeIncoming;
             if (serverMergePredatesLocalWrite) {
                 if (incoming === settings) incoming = Object.assign({}, settings);
-                // Non-ASR server-merge fields have no per-key decision token.
-                // Once this window has written a newer snapshot, an older merge
-                // arriving late must not roll confirmed local values back. ASR
+                // Compatibility for snapshots written before knownKeyWrites:
+                // once this window has written a newer snapshot, an older merge
+                // arriving late must not roll confirmed local values back. New
+                // peers use the per-key provenance check below instead. ASR
                 // keeps its independent decision-tuple ordering above.
                 for (const key of _SHARED_SETTINGS_KEYS) {
                     if (key === 'independentAsrEnabled') continue;
                     delete incoming[key];
+                }
+            }
+            if (meta && meta.changedKeys.length === 0
+                && meta.knownKeyWritesPresent) {
+                for (const key of _SHARED_SETTINGS_KEYS) {
+                    if (key === 'independentAsrEnabled') continue;
+                    if (!Object.prototype.hasOwnProperty.call(incoming, key)) continue;
+                    const localToken = _knownSharedKeyWrites[key];
+                    const mergeToken = meta.knownKeyWrites[key];
+                    // The merge envelope may be newer while this particular
+                    // field still predates an explicit write already accepted
+                    // here. Apply only when the sender's per-key provenance is
+                    // at least as new as ours.
+                    if (localToken
+                        && !_sharedWriteTokenOutranks(mergeToken, localToken)
+                        && !(mergeToken
+                            && mergeToken.writeId === localToken.writeId
+                            && mergeToken.writerId === localToken.writerId)) {
+                        if (incoming === settings) incoming = Object.assign({}, settings);
+                        delete incoming[key];
+                    }
                 }
             }
             const pendingKeysToReassert = [];
@@ -1610,6 +1708,10 @@
             }
             _noteCrossWindowMutations(incoming, meta ? meta.changedKeys : null);
             const changed = applySharedRuntimeSettings(incoming);
+            if (meta) {
+                _rememberKnownSharedKeyWrites(meta.knownKeyWrites, incoming);
+                _rememberSharedKeyWrites(meta.changedKeys, meta, incoming);
+            }
             if (meta && meta.asrDecision
                 && Object.prototype.hasOwnProperty.call(
                     incoming,

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -131,6 +131,12 @@
         const decision = _serverAsrDecision(data);
         if (!_asrDecisionOutranks(decision, _lastAsrDecision)) return false;
         _lastAsrDecision = decision;
+        // The next explicit local choice must mint above every decision this
+        // window has accepted, including cloud/server decisions whose clock is
+        // ahead of this browser's Date.now().
+        if (decision.writeId > _lastAppliedSharedWriteId) {
+            _lastAppliedSharedWriteId = decision.writeId;
+        }
         const serverSettings = data && data.settings;
         if (serverSettings
             && typeof serverSettings.independentAsrEnabled === 'boolean'

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -49,6 +49,11 @@
     // Carrying these per-key source tokens lets receivers compare the data's
     // actual provenance instead of mistaking the envelope timestamp for it.
     const _knownSharedKeyWrites = Object.create(null);
+    // Server revision floors are deliberately separate from per-key browser
+    // write provenance. A GET/merge can prove that a server revision won, but
+    // its freshly minted localStorage envelope did not produce that field and
+    // must not become the field's source token.
+    const _knownServerKeyRevisions = Object.create(null);
     // Window-unique second sort key for concurrent shared-settings writes. Per
     // document load; stability across reloads is not needed because every
     // comparison reads the id off the write itself, and sessionStorage would be
@@ -203,6 +208,25 @@
             }
         }
         return snapshot;
+    }
+    function _rememberServerKeyRevisions(revisions, acceptedSettings) {
+        if (!revisions || typeof revisions !== 'object') return;
+        for (const key of Object.keys(revisions)) {
+            if (_SHARED_SETTINGS_KEYS.indexOf(key) === -1) continue;
+            if (acceptedSettings
+                && !Object.prototype.hasOwnProperty.call(acceptedSettings, key)) continue;
+            const revision = revisions[key];
+            if (!Number.isInteger(revision) || revision < 0) continue;
+            _knownServerKeyRevisions[key] = Math.max(
+                Number.isInteger(_knownServerKeyRevisions[key])
+                    ? _knownServerKeyRevisions[key]
+                    : 0,
+                revision
+            );
+        }
+    }
+    function _knownServerKeyRevisionsSnapshot() {
+        return Object.assign({}, _knownServerKeyRevisions);
     }
     function _confirmSharedKeyWrites(
         payload,
@@ -699,18 +723,20 @@
             ownMeta.serverRevision = _conversationSettingsRevision;
             ownMeta.serverAuthoritativeKeys =
                 serverAuthoritativeKeys.slice();
-            // Persist the authority floor inside knownKeyWrites as well as in
-            // memory. A reloaded window may have to reject a delayed explicit
-            // event before its boot GET returns (or when that GET is offline).
+            // Persist the server floor independently from source provenance. A
+            // reloaded window may need the revision before its boot GET returns,
+            // but the merge envelope did not produce any of these field values.
             for (const key of ownMeta.serverAuthoritativeKeys) {
-                _knownSharedKeyWrites[key] = {
-                    writeId: ownMeta.writeId,
-                    writerId: ownMeta.writerId,
-                    confirmedRevision: ownMeta.serverRevision
-                };
+                _knownServerKeyRevisions[key] = Math.max(
+                    Number.isInteger(_knownServerKeyRevisions[key])
+                        ? _knownServerKeyRevisions[key]
+                        : 0,
+                    ownMeta.serverRevision
+                );
             }
         }
         ownMeta.knownKeyWrites = _knownSharedKeyWritesSnapshot();
+        ownMeta.serverKeyRevisions = _knownServerKeyRevisionsSnapshot();
         if (ownMeta.changedKeys.indexOf('independentAsrEnabled') !== -1) {
             _noteAsrDecision(
                 _nextAsrDecisionWriteId(ownMeta.writeId),
@@ -753,6 +779,7 @@
         if (!meta || typeof meta !== 'object') return null;
         if (!_isValidAsrWriteId(meta.writeId)) return null;
         const knownKeyWrites = {};
+        const serverKeyRevisions = {};
         const rawKnownKeyWrites = meta.knownKeyWrites;
         const knownKeyWritesPresent = !!rawKnownKeyWrites
             && typeof rawKnownKeyWrites === 'object';
@@ -774,6 +801,49 @@
                 }
             }
         }
+        const rawServerKeyRevisions = meta.serverKeyRevisions;
+        if (rawServerKeyRevisions
+            && typeof rawServerKeyRevisions === 'object') {
+            for (const key of Object.keys(rawServerKeyRevisions)) {
+                const revision = rawServerKeyRevisions[key];
+                if (_SHARED_SETTINGS_KEYS.indexOf(key) !== -1
+                    && Number.isInteger(revision)
+                    && revision >= 0) {
+                    serverKeyRevisions[key] = revision;
+                }
+            }
+        }
+        const serverRevision = Number.isInteger(meta.serverRevision)
+            && meta.serverRevision >= 0
+            ? meta.serverRevision
+            : null;
+        const serverAuthoritativeKeys =
+            Array.isArray(meta.serverAuthoritativeKeys)
+                ? meta.serverAuthoritativeKeys.filter(
+                    (key) => _SHARED_SETTINGS_KEYS.indexOf(key) !== -1
+                )
+                : [];
+        if (serverRevision !== null) {
+            for (const key of serverAuthoritativeKeys) {
+                serverKeyRevisions[key] = Math.max(
+                    Number.isInteger(serverKeyRevisions[key])
+                        ? serverKeyRevisions[key]
+                        : 0,
+                    serverRevision
+                );
+                // Upgrade snapshots written by the previous implementation:
+                // it stamped the merge envelope itself as field provenance.
+                const token = knownKeyWrites[key];
+                if (token
+                    && token.writeId === meta.writeId
+                    && token.writerId === (
+                        typeof meta.writerId === 'string' ? meta.writerId : ''
+                    )
+                    && token.confirmedRevision === serverRevision) {
+                    delete knownKeyWrites[key];
+                }
+            }
+        }
         return {
             writeId: meta.writeId,
             // Absent on snapshots written by the previous build: '' sorts below
@@ -789,18 +859,11 @@
             // changedKeys and keeps flowing through asrChangedByOtherWindow.
             asrAuthoritative: meta.asrAuthoritative === true,
             pendingRecovery: meta.pendingRecovery === true,
-            serverRevision: Number.isInteger(meta.serverRevision)
-                && meta.serverRevision >= 0
-                ? meta.serverRevision
-                : null,
-            serverAuthoritativeKeys:
-                Array.isArray(meta.serverAuthoritativeKeys)
-                    ? meta.serverAuthoritativeKeys.filter(
-                        (key) => _SHARED_SETTINGS_KEYS.indexOf(key) !== -1
-                    )
-                    : [],
+            serverRevision,
+            serverAuthoritativeKeys,
             knownKeyWrites,
             knownKeyWritesPresent,
+            serverKeyRevisions,
             // Absent on previous-build snapshots and on writers with no
             // matching decision: null routes the comparison back to
             // (writeId, writerId), i.e. today's behaviour.
@@ -1552,6 +1615,10 @@
                 }
                 if (bootMeta) {
                     _rememberKnownSharedKeyWrites(bootMeta.knownKeyWrites, settings);
+                    _rememberServerKeyRevisions(
+                        bootMeta.serverKeyRevisions,
+                        settings
+                    );
                     _rememberSharedKeyWrites(bootMeta.changedKeys, bootMeta, settings);
                     if (Number.isInteger(bootMeta.serverRevision)) {
                         _conversationSettingsRevision =
@@ -1563,10 +1630,8 @@
                                 settings,
                                 key
                             )) continue;
-                            _rememberSharedKeyWrites([key], {
-                                writeId: bootMeta.writeId,
-                                writerId: bootMeta.writerId,
-                                confirmedRevision: bootMeta.serverRevision
+                            _rememberServerKeyRevisions({
+                                [key]: bootMeta.serverRevision
                             }, settings);
                         }
                     }
@@ -2114,9 +2179,21 @@
                         key
                     )) continue;
                     const localToken = _knownSharedKeyWrites[key];
-                    if (localToken
-                        && !_sharedWriteTokenOutranks(meta, localToken)
-                        && !_sharedWriteTokensEqual(meta, localToken)) {
+                    const incomingToken = meta.knownKeyWrites[key];
+                    const localServerRevision =
+                        _knownServerKeyRevisions[key];
+                    const incomingPredatesServerFloor =
+                        Number.isInteger(localServerRevision)
+                        && incomingToken
+                        && Number.isInteger(
+                            incomingToken.confirmedRevision
+                        )
+                        && incomingToken.confirmedRevision
+                            < localServerRevision;
+                    if (incomingPredatesServerFloor
+                        || (localToken
+                            && !_sharedWriteTokenOutranks(meta, localToken)
+                            && !_sharedWriteTokensEqual(meta, localToken))) {
                         if (incoming === settings) {
                             incoming = Object.assign({}, settings);
                         }
@@ -2165,6 +2242,8 @@
                                 mergeToken.confirmedRevision
                             );
                         }
+                        const localServerRevision =
+                            _knownServerKeyRevisions[key];
                         const serverSnapshotIsOlder =
                             (Number.isInteger(_conversationSettingsRevision)
                                 && meta.serverRevision
@@ -2173,7 +2252,10 @@
                                 && !Number.isInteger(confirmedRevision))
                             || (Number.isInteger(confirmedRevision)
                                 && meta.serverRevision
-                                    < confirmedRevision);
+                                    < confirmedRevision)
+                            || (Number.isInteger(localServerRevision)
+                                && meta.serverRevision
+                                    < localServerRevision);
                         if (serverSnapshotIsOlder) {
                             if (incoming === settings) {
                                 incoming = Object.assign({}, settings);
@@ -2225,14 +2307,16 @@
             const changed = applySharedRuntimeSettings(incoming);
             if (meta) {
                 _rememberKnownSharedKeyWrites(meta.knownKeyWrites, incoming);
+                _rememberServerKeyRevisions(
+                    meta.serverKeyRevisions,
+                    incoming
+                );
                 _rememberSharedKeyWrites(meta.changedKeys, meta, incoming);
                 for (const key of meta.serverAuthoritativeKeys) {
                     if (Object.prototype.hasOwnProperty.call(incoming, key)) {
-                        _knownSharedKeyWrites[key] = {
-                            writeId: meta.writeId,
-                            writerId: meta.writerId,
-                            confirmedRevision: meta.serverRevision
-                        };
+                        _rememberServerKeyRevisions({
+                            [key]: meta.serverRevision
+                        }, incoming);
                     }
                 }
                 if (Number.isInteger(meta.serverRevision)) {

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -18,17 +18,16 @@
     // 周期同步因「设置未水合」被跳过时只 log 一次，避免 GET 持续失败刷屏
     let _periodicSyncSkippedUnhydratedLogged = false;
     // Field-level user authority (Codex P2): _dirtySettingsKeys records which
-    // conversation-settings keys the user explicitly changed since boot. Every
-    // userInitiated sync diffs the current settings against _settingsBaseline
-    // (snapshotted right before the boot GET, rolled forward on every diff and
-    // after the server merge) and adds the keys that diverged. The boot GET's
-    // merge callback applies server values to NON-dirty keys only and
-    // preserves the dirty ones, so changing one unrelated preference while
-    // the GET is in flight no longer makes the whole boot-default snapshot
-    // authoritative (the earlier whole-merge-drop design let a boot-default
-    // independentAsrEnabled clobber the server-persisted ASR choice and later
-    // handshakes then stamped the wrong route).
+    // conversation-settings keys the user explicitly changed since boot. It is
+    // intentionally monotone because a boot GET started before an acknowledged
+    // POST can still arrive later with an older snapshot; its merge must keep
+    // every user-touched key. _pendingSettingsKeys is narrower: it contains only
+    // changes not yet acknowledged by a successful POST, and is the set used by
+    // dirty-only writes plus 412 conflict merges. Keeping those roles separate
+    // prevents an acknowledged stale local value from winning a later conflict
+    // without reopening the late-boot-GET overwrite race.
     const _dirtySettingsKeys = new Set();
+    const _pendingSettingsKeys = new Set();
     let _settingsBaseline = null;
     // Cross-window write metadata (Codex P2): saveSettings() writes EVERY
     // conversation key into the shared localStorage snapshot, so a receiving
@@ -163,7 +162,7 @@
         for (const key of Object.keys(serverSettings)) {
             if (key === 'independentAsrEnabled'
                 && (adoptedAsr || preserveLocalAsrDecision)) continue;
-            if (_dirtySettingsKeys.has(key)) continue;
+            if (_pendingSettingsKeys.has(key)) continue;
             if (serverSettings[key] !== undefined) {
                 acceptedSettings[key] = serverSettings[key];
             }
@@ -181,7 +180,7 @@
         _settingsMergedFromServer = true;
         if (_settingsBaseline) {
             for (const key of Object.keys(serverSettings)) {
-                if (_dirtySettingsKeys.has(key)) continue;
+                if (_pendingSettingsKeys.has(key)) continue;
                 if (serverSettings[key] !== undefined) {
                     _settingsBaseline[key] = S[key];
                 }
@@ -335,6 +334,7 @@
                     : undefined;
                 if (cur !== base) {
                     _dirtySettingsKeys.add(key);
+                    _pendingSettingsKeys.add(key);
                 }
             });
         }
@@ -490,12 +490,25 @@
      */
     function _pickDirtySettings(settings) {
         const partial = {};
-        _dirtySettingsKeys.forEach((key) => {
+        _pendingSettingsKeys.forEach((key) => {
             if (Object.prototype.hasOwnProperty.call(settings, key)) {
                 partial[key] = settings[key];
             }
         });
         return partial;
+    }
+
+    function _clearAcknowledgedPendingSettings(payload) {
+        const current = getConversationSettings();
+        for (const key of Object.keys(payload)) {
+            // A later local edit may have happened while this POST was in
+            // flight. Clear only keys whose current value is still exactly the
+            // value the server just acknowledged.
+            if (Object.prototype.hasOwnProperty.call(current, key)
+                && current[key] === payload[key]) {
+                _pendingSettingsKeys.delete(key);
+            }
+        }
     }
 
     function applySharedRuntimeSettings(settings) {
@@ -718,7 +731,9 @@
                     }
                     if (!data.success) {
                         console.error('[app-settings] 同步设置到服务器失败:', data.error || '未知错误');
+                        return;
                     }
+                    _clearAcknowledgedPendingSettings(payload);
                     return;
                 } catch (err) {
                     console.error('[app-settings] 同步设置到服务器失败:', err);

--- a/static/app/app-settings.js
+++ b/static/app/app-settings.js
@@ -1558,6 +1558,22 @@
                 incoming = Object.assign({}, settings);
                 delete incoming.independentAsrEnabled;
             }
+            const serverMergePredatesLocalWrite = !!meta
+                && meta.changedKeys.length === 0
+                && (meta.writeId < _lastSharedWriteId
+                    || (meta.writeId === _lastSharedWriteId
+                        && meta.writerId < _SHARED_WRITER_ID));
+            if (serverMergePredatesLocalWrite) {
+                if (incoming === settings) incoming = Object.assign({}, settings);
+                // Non-ASR server-merge fields have no per-key decision token.
+                // Once this window has written a newer snapshot, an older merge
+                // arriving late must not roll confirmed local values back. ASR
+                // keeps its independent decision-tuple ordering above.
+                for (const key of _SHARED_SETTINGS_KEYS) {
+                    if (key === 'independentAsrEnabled') continue;
+                    delete incoming[key];
+                }
+            }
             const pendingKeysToReassert = [];
             if (meta) {
                 // Keep this as for...of: static listener-contract tests slice

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -1557,8 +1557,8 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
           const reasserted = JSON.parse(ctx.store.get('project_neko_settings'));
           assert(
             reasserted.focusModeEnabled === true
-              && reasserted._sharedWriteMeta.changedKeys.indexOf('focusModeEnabled') !== -1,
-            'the pending value and intent metadata must be restored in localStorage'
+              && reasserted._sharedWriteMeta.changedKeys.length === 0,
+            'the pending value must be restored without advertising new user intent'
           );
 
           // Cross-window ABA edits do not enter this window's pending set and

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -948,7 +948,9 @@ def test_cross_window_settings_posts_use_cas_and_persist_asr_decision_order():
     assert "let _conversationSettingsEtag = null;" in settings_source
     assert "headers['If-Match'] = _conversationSettingsEtag;" in sync_fn
     assert "response.status === 412" in sync_fn
-    assert "_mergeConversationSettingsSnapshot(data);" in sync_fn
+    assert "const preservedKeys = new Set(_pendingSettingsKeys);" in sync_fn
+    assert "_settingsChangedSince(settings).forEach" in sync_fn
+    assert "_mergeConversationSettingsSnapshot(data, preservedKeys);" in sync_fn
     assert "_CONVERSATION_SETTINGS_MAX_ATTEMPTS" in sync_fn
     assert "headers['X-Conversation-Settings-ASR-Decision']" in sync_fn
     assert "JSON.stringify(requestDecision)" in sync_fn
@@ -1490,6 +1492,12 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
           ctx.mod.saveSettings();
           await tick();
           assert(ctx.postCalls.length === 2, 'the unrelated edit must POST');
+
+          // A cross-window storage update can change local state without
+          // entering this window's pending-key set. It still happened after
+          // the request snapshot and must survive the 412 reconciliation.
+          ctx.win.mergeMessagesEnabled = true;
+          ctx.S.mergeMessagesEnabled = true;
           ctx.postCalls[1].resolve(response(
             false,
             412,
@@ -1501,6 +1509,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
                 proactiveVisionEnabled: false,
                 slopFilterEnabled: false,
                 focusModeEnabled: false,
+                mergeMessagesEnabled: false,
               },
               revision: 2,
               decisions: {},
@@ -1519,6 +1528,10 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             'the still-pending local edit must survive the conflict merge'
           );
           assert(
+            retryBody.mergeMessagesEnabled === true,
+            'a non-pending edit made after send must survive the conflict merge'
+          );
+          assert(
             retryBody.proactiveVisionEnabled === false,
             'the retry must retain the server privacy winner'
           );
@@ -1532,7 +1545,8 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
           assert(
             reconciledLocal.slopFilterEnabled === false
               && reconciledLocal.focusModeEnabled === true
-              && reconciledLocal.proactiveVisionEnabled === false,
+              && reconciledLocal.proactiveVisionEnabled === false
+              && reconciledLocal.mergeMessagesEnabled === true,
             'the conflict winners and pending local edit must persist to shared localStorage'
           );
           assert(

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -831,7 +831,9 @@ def test_user_dirty_keys_survive_boot_get_merge_field_level():
     assert "!_dirtySettingsKeys.has('subtitleEnabled')" in merge_block
     assert "!_dirtySettingsKeys.has('userLanguage')" in merge_block
     roll_index = merge_block.index("_settingsBaseline = getConversationSettings();")
-    assert skip_index < roll_index < merge_block.index("saveSettings();")
+    assert skip_index < roll_index < merge_block.index(
+        "saveSettings({ serverMerged: true });"
+    )
     # The whole-merge drop is gone: no early return between the null-guard
     # and the hydration mark, and the old drop log no longer exists.
     after_null_guard = null_guard_index + len("if (!serverResult) return;")
@@ -2013,6 +2015,7 @@ def test_shared_settings_writes_carry_explicit_change_metadata():
     assert "changedKeys: explicitKeys || []," in write_fn
     assert "hydrated: S.settingsHydrated === true" in write_fn
     assert "pendingRecovery: pendingRecovery === true" in write_fn
+    assert "ownMeta.knownKeyWrites = _knownSharedKeyWritesSnapshot();" in write_fn
     assert "localStorage.setItem('project_neko_settings', JSON.stringify(payload));" in write_fn
 
     # The write id must be strictly increasing within a window and comparable
@@ -2029,13 +2032,15 @@ def test_shared_settings_writes_carry_explicit_change_metadata():
     assert "Math.max(_lastSharedWriteId, _lastAppliedSharedWriteId)" in id_fn
     assert "_lastSharedWriteId = now > idFloor ? now : idFloor + 1;" in id_fn
 
-    # Explicit keys = the monotone dirty set PLUS the divergence from the
-    # dirty-diff baseline (the ASR toggle handler persists locally before its
-    # userInitiated sync rolls that baseline).
+    # Explicit keys = still-pending writes PLUS divergence from the dirty-diff
+    # baseline (the ASR toggle handler persists locally before its userInitiated
+    # sync rolls that baseline). The monotone boot-merge dirty set must not mint
+    # a new per-key token for an already-acknowledged value.
     collect_fn = settings_source.split("function _collectExplicitSharedKeys(snapshot) {", 1)[
         1
     ].split("\n    }", 1)[0]
-    assert "_dirtySettingsKeys.has(key)" in collect_fn
+    assert "_pendingSettingsKeys.has(key)" in collect_fn
+    assert "_dirtySettingsKeys.has(key)" not in collect_fn
     assert "_settingsBaseline[key] !== snapshot[key]" in collect_fn
     # Negative: only shared keys may be claimed, never the whole snapshot.
     assert "_SHARED_SETTINGS_KEYS.forEach" in collect_fn
@@ -2053,6 +2058,7 @@ def test_shared_settings_writes_carry_explicit_change_metadata():
     assert "Date.now() + _ASR_WRITE_ID_MAX_FUTURE_SKEW_MS" in id_validator
     assert "Number.MAX_SAFE_INTEGER - 1" in id_validator
     assert "Array.isArray(meta.changedKeys) ? meta.changedKeys : []" in read_fn
+    assert "knownKeyWritesPresent" in read_fn
 
     listener_block = settings_source.split(
         "window.addEventListener('storage', function (event) {", 1
@@ -2455,6 +2461,64 @@ def test_unrelated_save_from_unhydrated_window_is_not_an_asr_toggle_harness():
             'ordinary user writes must not be marked as recovery'
           );
 
+          // ---- Scenario 9: a merge envelope minted later does not make a
+          // stale field newer than an explicit edit the sender never observed.
+          const editor = makeContext({
+            independentAsrEnabled: false,
+            focusModeEnabled: false,
+          });
+          editor.win.focusModeEnabled = true;
+          editor.mod.saveSettings({ skipServerSync: true });
+          const explicitPayload = editor.lastSharedWrite();
+          const explicitMeta = JSON.parse(explicitPayload)._sharedWriteMeta;
+
+          const observer = makeContext({
+            independentAsrEnabled: false,
+            focusModeEnabled: false,
+          });
+          observer.fireStorage(explicitPayload);
+          assert(observer.S.focusModeEnabled === true, 'observer accepts the explicit edit');
+
+          const staleMerger = makeContext({
+            independentAsrEnabled: false,
+            focusModeEnabled: false,
+          });
+          staleMerger.mod.saveSettings({
+            skipServerSync: true,
+            serverMerged: true,
+          });
+          const staleMerge = JSON.parse(staleMerger.lastSharedWrite());
+          staleMerge._sharedWriteMeta.writeId = explicitMeta.writeId + 100;
+          assert(
+            Object.keys(staleMerge._sharedWriteMeta.knownKeyWrites).length === 0,
+            'the stale sender must declare that it never observed the edit'
+          );
+          observer.fireStorage(JSON.stringify(staleMerge));
+          assert(
+            observer.S.focusModeEnabled === true,
+            'a high envelope id must not roll back a newer per-key edit'
+          );
+
+          const mergeAfterEdit = makeContext({
+            independentAsrEnabled: false,
+            focusModeEnabled: false,
+          });
+          mergeAfterEdit.fireStorage(explicitPayload);
+          mergeAfterEdit.getCalls[0].resolve({
+            ok: true,
+            json: async () => ({
+              success: true,
+              settings: { independentAsrEnabled: false, focusModeEnabled: false },
+              telemetryBranch: null,
+            }),
+          });
+          await tick();
+          await tick();
+          assert(
+            mergeAfterEdit.S.focusModeEnabled === true,
+            'a boot GET started before the cross-window edit must preserve that edit'
+          );
+
           console.log('HARNESS_OK');
           // Every sandbox timer is harness-controlled, so the process exits
           // naturally once main() returns and piped stdout is fully flushed.
@@ -2675,7 +2739,7 @@ def test_settings_get_gate_timeout_downgrades_post_to_dirty_keys_only():
         "_settingsMergedFromServer = true;"
     )
     assert merge_cb.index("_settingsMergedFromServer = true;") < merge_cb.index(
-        "saveSettings();"
+        "saveSettings({ serverMerged: true });"
     )
     # Negative: the failure paths must NOT re-enable full snapshots. The
     # finally runs for merged AND failed GETs, so it may not touch the flag;

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -933,9 +933,9 @@ def test_settings_posts_serialize_so_a_stale_body_cannot_win_persistence():
 
 def test_cross_window_settings_posts_use_cas_and_persist_asr_decision_order():
     settings_source = APP_SETTINGS_PATH.read_text(encoding="utf-8")
-    sync_fn = settings_source.split(
-        "async function syncSettingsToServer(options)", 1
-    )[1].split("function startPeriodicSync()", 1)[0]
+    sync_fn = _block_after(
+        settings_source, "async function syncSettingsToServer(options) {"
+    )
 
     assert "let _conversationSettingsEtag = null;" in settings_source
     assert "headers['If-Match'] = _conversationSettingsEtag;" in sync_fn
@@ -1094,9 +1094,14 @@ def test_rapid_asr_toggle_double_flip_persists_final_state_harness():
             },
           };
           sandbox.window = {
-            appState: { independentAsrEnabled: false, settingsHydrated: false },
+            appState: {
+              independentAsrEnabled: false,
+              slopFilterEnabled: false,
+              settingsHydrated: false,
+            },
             appConst: {},
             appUtils: { mapRenderQualityToFollowPerf() { return 'medium'; } },
+            slopFilterEnabled: false,
             addEventListener() {},
             removeEventListener() {},
           };
@@ -1309,6 +1314,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
           vm.runInContext(source, sandbox);
           return {
             S: sandbox.window.appState,
+            win: sandbox.window,
             mod: sandbox.window.appSettings,
             postCalls,
           };
@@ -1349,13 +1355,18 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             '"conversation-settings-1"',
             {
               success: false,
-              settings: { independentAsrEnabled: false },
+              settings: { independentAsrEnabled: false, slopFilterEnabled: true },
               revision: 1,
               decisions: { independentAsrEnabled: serverDecision },
             }
           ));
           await tick();
           await tick();
+          assert(ctx.S.slopFilterEnabled === true, 'conflict merge must adopt the server field');
+          assert(
+            ctx.win.slopFilterEnabled === true,
+            'conflict merge must synchronize the window mirror'
+          );
           assert(ctx.postCalls.length === 2, 'a CAS conflict must retry once');
           const retry = ctx.postCalls[1];
           const retryBody = JSON.parse(retry.opts.body);
@@ -1366,6 +1377,10 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
           assert(
             retryBody.independentAsrEnabled === !serverDecisionIsNewer,
             'retry body must use the winning decision value'
+          );
+          assert(
+            retryBody.slopFilterEnabled === true,
+            'retry must not roll the conflict-merged value back from a stale window mirror'
           );
           const retryDecision =
             JSON.parse(retry.opts.headers['X-Conversation-Settings-ASR-Decision']);

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -523,6 +523,20 @@ def test_independent_asr_toggle_awaits_server_sync_before_next_session():
     assert "var SETTINGS_SYNC_GATE_TIMEOUT_MS = 3000;" in websocket_source
 
 
+def test_noise_reduction_toggle_uses_conversation_settings_cas_client():
+    capture_source = APP_AUDIO_CAPTURE_PATH.read_text(encoding="utf-8")
+    save_block = capture_source.split(
+        "function saveNoiseReductionSetting() {",
+        1,
+    )[1].split("function loadNoiseReductionSetting()", 1)[0]
+    settings_source = APP_SETTINGS_PATH.read_text(encoding="utf-8")
+
+    assert "window.appSettings.saveSettings();" in save_block
+    assert "fetch('/api/config/conversation-settings'" not in save_block
+    assert "'noiseReductionEnabled'," in settings_source
+    assert "noiseReductionEnabled: S.noiseReductionEnabled" in settings_source
+
+
 def test_every_start_session_send_sits_behind_the_ensure_websocket_gate():
     # The settings-sync gate lives in ensureWebSocketOpen(), so it only closes
     # the toggle-vs-session-start race if every start_session send awaits
@@ -1938,7 +1952,7 @@ def test_shared_settings_writes_carry_explicit_change_metadata():
         "\n    }", 1
     )[0]
     assert "if (!meta || typeof meta !== 'object') return null;" in read_fn
-    assert "typeof meta.writeId !== 'number'" in read_fn
+    assert "!Number.isSafeInteger(meta.writeId)" in read_fn
     assert "Array.isArray(meta.changedKeys) ? meta.changedKeys : []" in read_fn
 
     listener_block = settings_source.split(
@@ -3853,7 +3867,7 @@ def test_asr_decision_tuple_survives_unrelated_saves():
     # ...the reader parses it defensively, falling back to today's behaviour...
     read_fn = _block_after(settings_source, "function _readSharedWriteMeta(settings) {")
     assert "asrDecision:" in read_fn
-    assert "typeof meta.asrDecision.writeId === 'number'" in read_fn
+    assert "Number.isSafeInteger(meta.asrDecision.writeId)" in read_fn
 
     # ...and both the boot seed and the adopted cross-window flip record the
     # ORIGINAL id, or this window re-inflates the value on its own next save.

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -1019,7 +1019,10 @@ def test_cross_window_asr_flip_marks_hydration_and_asr_dirty():
         for line in listener_block.splitlines()
         if not line.strip().startswith("//")
     )
-    assert "saveSettings" not in listener_code
+    assert "syncSettingsToServer" not in listener_code
+    assert "saveSettings();" not in listener_code
+    if "saveSettings({" in listener_code:
+        assert "skipServerSync: true" in listener_code
     assert "syncSettingsToServer" not in listener_code
     assert "fetch(" not in listener_code
 
@@ -1500,6 +1503,30 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
           ctx.mod.saveSettings();
           await tick();
           assert(ctx.postCalls.length === 2, 'the unrelated edit must POST');
+
+          // A server-merge broadcast may have been built before this pending
+          // edit. It must neither overwrite the local value nor leave its
+          // stale full snapshot in shared localStorage.
+          ctx.fireStorage(JSON.stringify({
+            focusModeEnabled: false,
+            _sharedWriteMeta: {
+              writeId: 99,
+              writerId: 'server-window',
+              changedKeys: [],
+              hydrated: true,
+              asrAuthoritative: true,
+            },
+          }));
+          assert(
+            ctx.S.focusModeEnabled === true,
+            'a server-merge broadcast must preserve a pending local edit'
+          );
+          const reasserted = JSON.parse(ctx.store.get('project_neko_settings'));
+          assert(
+            reasserted.focusModeEnabled === true
+              && reasserted._sharedWriteMeta.changedKeys.indexOf('focusModeEnabled') !== -1,
+            'the pending value and intent metadata must be restored in localStorage'
+          );
 
           // Cross-window ABA edits do not enter this window's pending set and
           // leave the final value equal to the request snapshot. The mutation

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -1317,6 +1317,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             win: sandbox.window,
             mod: sandbox.window.appSettings,
             postCalls,
+            store,
           };
         }
 
@@ -1402,6 +1403,19 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             }
           ));
           await syncPromise;
+          if (serverDecisionIsNewer) {
+            ctx.S.independentAsrEnabled = true;
+            ctx.mod.saveSettings({ skipServerSync: true });
+            const nextSharedSnapshot = JSON.parse(
+              ctx.store.get('project_neko_settings')
+            );
+            const nextDecision = nextSharedSnapshot._sharedWriteMeta.asrDecision;
+            assert(
+              nextDecision.writeId > serverDecision.writeId,
+              'the next explicit local toggle must supersede an adopted server decision'
+            );
+            assert(nextDecision.value === true, 'the superseding tuple carries the new choice');
+          }
         }
 
         async function main() {

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -1673,6 +1673,23 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
           ctx.fireStorage(JSON.stringify({
             slopFilterEnabled: false,
             _sharedWriteMeta: {
+              writeId: Math.max(
+                0,
+                acknowledgedLocal._sharedWriteMeta.writeId - 1
+              ),
+              writerId: 'window-delayed',
+              changedKeys: ['slopFilterEnabled'],
+              hydrated: true,
+              asrAuthoritative: true,
+            },
+          }));
+          assert(
+            ctx.S.slopFilterEnabled === true,
+            'an older explicit event must not roll back an acknowledged edit'
+          );
+          ctx.fireStorage(JSON.stringify({
+            slopFilterEnabled: false,
+            _sharedWriteMeta: {
               writeId: acknowledgedLocal._sharedWriteMeta.writeId,
               writerId: 'zzzzzzzzzzzzzzzz',
               changedKeys: [],
@@ -1788,19 +1805,19 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
           // Cross-window ABA edits do not enter this window's pending set and
           // leave the final value equal to the request snapshot. The mutation
           // itself must still protect the latest choice from the 412 snapshot.
-          ctx.fireStorage(JSON.stringify({
-            mergeMessagesEnabled: true,
-            _sharedWriteMeta: {
-              writeId: 100,
+              ctx.fireStorage(JSON.stringify({
+                mergeMessagesEnabled: true,
+                _sharedWriteMeta: {
+                  writeId: externalWriteId + 2,
               writerId: 'window-b',
               changedKeys: ['mergeMessagesEnabled'],
               hydrated: true,
             },
           }));
-          ctx.fireStorage(JSON.stringify({
-            mergeMessagesEnabled: false,
-            _sharedWriteMeta: {
-              writeId: 101,
+              ctx.fireStorage(JSON.stringify({
+                mergeMessagesEnabled: false,
+                _sharedWriteMeta: {
+                  writeId: externalWriteId + 3,
               writerId: 'window-b',
               changedKeys: ['mergeMessagesEnabled'],
               hydrated: true,

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -2422,23 +2422,31 @@ def test_failed_boot_get_keeps_posts_dirty_only_harness():
           if (!cond) throw new Error('ASSERT: ' + msg);
         }
 
-        function makeContext() {
+        function makeContext(initialSettings) {
           const postCalls = [];
           const getCalls = [];
           const timers = [];
           const intervals = [];
+          const storage = {};
+          if (initialSettings) {
+            storage.project_neko_settings = JSON.stringify(initialSettings);
+          }
           const sandbox = {
             console: { log() {}, warn() {}, error() {} },
             setInterval(fn, ms) { intervals.push({ fn, ms }); return 1; },
             clearInterval() {},
             setTimeout(fn, ms) { timers.push({ fn, ms }); return { unref() {} }; },
             clearTimeout() {},
-            localStorage: { getItem() { return null; }, setItem() {}, removeItem() {} },
+            localStorage: {
+              getItem(key) { return Object.prototype.hasOwnProperty.call(storage, key) ? storage[key] : null; },
+              setItem() {},
+              removeItem(key) { delete storage[key]; },
+            },
             document: { getElementById() { return null; } },
             fetch(url, opts) {
               return new Promise((resolve, reject) => {
                 if (opts && opts.method === 'POST') {
-                  postCalls.push({ url, body: opts.body, resolve, reject });
+                  postCalls.push({ url, body: opts.body, headers: opts.headers, resolve, reject });
                 } else {
                   getCalls.push({ url, resolve, reject });
                 }
@@ -2650,6 +2658,66 @@ def test_failed_boot_get_keeps_posts_dirty_only_harness():
             'the full snapshot carries the merged server value, not the boot default'
           );
           ctx4.postCalls[2].resolve(okPost);
+          await tick();
+
+          // ---- Scenario 5: a newer explicit localStorage ASR decision arrives
+          // before its origin window's POST. The boot GET is older and must not
+          // overwrite either the local value or the tuple that will accompany
+          // the next save.
+          const ctx5 = makeContext({
+            independentAsrEnabled: true,
+            _sharedWriteMeta: {
+              writeId: 20,
+              writerId: 'window-b',
+              changedKeys: ['independentAsrEnabled'],
+              hydrated: true,
+              asrAuthoritative: true,
+              asrDecision: { writeId: 20, writerId: 'window-b', value: true },
+            },
+          });
+          ctx5.getCalls[0].resolve({
+            ok: true,
+            headers: { get(name) { return name.toLowerCase() === 'etag' ? '"conversation-settings-3"' : null; } },
+            json: async () => ({
+              success: true,
+              settings: { independentAsrEnabled: false, mergeMessagesEnabled: false },
+              decisions: {
+                independentAsrEnabled: {
+                  writeId: 10,
+                  writerId: 'window-a',
+                  value: false,
+                },
+              },
+              telemetryBranch: null,
+            }),
+          });
+          await tick();
+          await tick();
+          assert(
+            ctx5.S.independentAsrEnabled === true,
+            'an older boot GET must not overwrite the newer local ASR choice'
+          );
+          assert(ctx5.postCalls.length === 0, 'preserving the local winner needs no merge writeback');
+          ctx5.win.focusModeEnabled = true;
+          ctx5.mod.saveSettings();
+          await tick();
+          await tick();
+          assert(ctx5.postCalls.length === 1, 'a later unrelated edit is persisted');
+          const afterLocalWinner = JSON.parse(ctx5.postCalls[0].body);
+          assert(
+            afterLocalWinner.independentAsrEnabled === true,
+            'the later full snapshot keeps the newer local ASR value'
+          );
+          const decisionHeader = JSON.parse(
+            ctx5.postCalls[0].headers['X-Conversation-Settings-ASR-Decision']
+          );
+          assert(
+            decisionHeader.writeId === 20
+              && decisionHeader.writerId === 'window-b'
+              && decisionHeader.value === true,
+            'the later POST carries the newer local ASR decision tuple'
+          );
+          ctx5.postCalls[0].resolve(okPost);
           await tick();
 
           console.log('HARNESS_OK');

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -2519,6 +2519,29 @@ def test_unrelated_save_from_unhydrated_window_is_not_an_asr_toggle_harness():
             'a boot GET started before the cross-window edit must preserve that edit'
           );
 
+          // ---- Scenario 10: a late recovery envelope cannot roll back a
+          // newer explicit decision for the same key.
+          const newerEditor = makeContext(JSON.parse(explicitPayload));
+          newerEditor.win.focusModeEnabled = false;
+          newerEditor.mod.saveSettings({ skipServerSync: true });
+          const newerPayload = newerEditor.lastSharedWrite();
+          const newerMeta = JSON.parse(newerPayload)._sharedWriteMeta;
+          observer.fireStorage(newerPayload);
+          assert(observer.S.focusModeEnabled === false, 'observer accepts the newer edit');
+
+          const lateRecovery = JSON.parse(explicitPayload);
+          lateRecovery._sharedWriteMeta = {
+            ...lateRecovery._sharedWriteMeta,
+            writeId: newerMeta.writeId + 100,
+            changedKeys: [],
+            pendingRecovery: true,
+          };
+          observer.fireStorage(JSON.stringify(lateRecovery));
+          assert(
+            observer.S.focusModeEnabled === false,
+            'a fresh recovery envelope must not outrank its older per-key provenance'
+          );
+
           console.log('HARNESS_OK');
           // Every sandbox timer is harness-controlled, so the process exits
           // naturally once main() returns and piped stdout is fully flushed.

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -1411,6 +1411,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
           const tupleOnly = makeContext(false, {
             success: true,
             settings: { independentAsrEnabled: false },
+            revision: 1,
             telemetryBranch: null,
             decisions: { independentAsrEnabled: tuple },
           });
@@ -1430,6 +1431,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
               independentAsrEnabled: false,
               noiseReductionEnabled: true,
             },
+            revision: 1,
             telemetryBranch: null,
             decisions: {},
           });
@@ -1446,6 +1448,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
               independentAsrEnabled: false,
               proactiveVisionEnabled: false,
             },
+            revision: 2,
             telemetryBranch: null,
             decisions: {},
           });
@@ -1455,8 +1458,10 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             serverBroadcaster.store.get('project_neko_settings')
           );
           assert(
-            serverSnapshot._sharedWriteMeta.knownKeyWrites.proactiveVisionEnabled,
-            'a server winner must receive per-key broadcast provenance'
+            serverSnapshot._sharedWriteMeta.serverRevision === 2
+              && serverSnapshot._sharedWriteMeta.serverAuthoritativeKeys
+                .includes('proactiveVisionEnabled'),
+            'a server winner must carry its real revision and authoritative fields'
           );
 
           const receiver = makeContext(true);
@@ -1474,6 +1479,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
                 proactiveVisionEnabled: {
                   writeId: 1,
                   writerId: 'window-old',
+                  confirmedRevision: 1,
                 },
               },
             },
@@ -1488,6 +1494,54 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
               && receiver.runtime.stoppedScreening === 1
               && receiver.runtime.stoppedTracks === 1,
             'the authoritative privacy disable must stop active vision runtime'
+          );
+
+          const staleReceiver = makeContext(false, {
+            success: true,
+            settings: {
+              independentAsrEnabled: false,
+              focusModeEnabled: false,
+            },
+            revision: 2,
+            telemetryBranch: null,
+            decisions: {},
+          });
+          await tick();
+          await tick();
+          staleReceiver.fireStorage(JSON.stringify({
+            focusModeEnabled: true,
+            _sharedWriteMeta: {
+              writeId: 50,
+              writerId: 'window-editor',
+              changedKeys: ['focusModeEnabled'],
+              hydrated: true,
+              asrAuthoritative: true,
+              knownKeyWrites: {
+                focusModeEnabled: {
+                  writeId: 50,
+                  writerId: 'window-editor',
+                },
+              },
+            },
+          }));
+          const staleServerSnapshot = {
+            focusModeEnabled: false,
+            _sharedWriteMeta: {
+              writeId: 500,
+              writerId: 'window-stale-server-reader',
+              changedKeys: [],
+              hydrated: true,
+              asrAuthoritative: true,
+              serverRevision: 2,
+              serverAuthoritativeKeys: ['focusModeEnabled'],
+              knownKeyWrites: {},
+            },
+          };
+          staleReceiver.fireStorage(JSON.stringify(staleServerSnapshot));
+          assert(
+            staleReceiver.S.focusModeEnabled === true,
+            'a same-revision server snapshot must not launder its envelope '
+              + 'over an unconfirmed explicit edit'
           );
         }
 
@@ -1977,6 +2031,11 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             reconciledLocal.mouseTrackingEnabled === false,
             'success reconciliation preserves local-only settings'
           );
+          assert(
+            reconciledLocal._sharedWriteMeta.knownKeyWrites.focusModeEnabled
+              .confirmedRevision === 1,
+            'the acknowledged explicit token must carry its confirmed revision'
+          );
           ctx.postCalls[1].resolve(response(
             true,
             200,
@@ -2285,6 +2344,12 @@ def test_shared_settings_writes_carry_explicit_change_metadata():
     assert "hydrated: S.settingsHydrated === true" in write_fn
     assert "pendingRecovery: pendingRecovery === true" in write_fn
     assert "ownMeta.knownKeyWrites = _knownSharedKeyWritesSnapshot();" in write_fn
+    assert "ownMeta.serverRevision = _conversationSettingsRevision;" in write_fn
+    assert "serverAuthoritativeKeys.slice()" in write_fn
+    assert (
+        "_rememberSharedKeyWrites(serverAuthoritativeKeys || [], ownMeta)"
+        not in write_fn
+    )
     assert "localStorage.setItem('project_neko_settings', JSON.stringify(payload));" in write_fn
 
     # The write id must be strictly increasing within a window and comparable

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -1412,7 +1412,9 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
 
         async function runBootMetadataScenario() {
           const tuple = {
-            writeId: Date.now() + 1000,
+            // Valid at an authority whose clock is just over one second ahead,
+            // but beyond this browser's independently measured +1 year bound.
+            writeId: Date.now() + (365 * 24 * 60 * 60 * 1000) + 1000,
             writerId: 'server-ahead',
             value: false,
           };
@@ -1432,6 +1434,51 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             JSON.stringify(persistedTuple) === JSON.stringify(tuple),
             'a newer same-value server tuple must persist for offline write-id flooring'
           );
+
+          const reset = makeContext(false, {
+            success: true,
+            settings: {},
+            revision: 10,
+            reset: true,
+            telemetryBranch: null,
+            decisions: {},
+          });
+          await tick();
+          await tick();
+          const resetVisionDefault = reset.mod._isUserRegionChina();
+          assert(
+            reset.S.slopFilterEnabled === true
+              && reset.S.proactiveVisionEnabled === resetVisionDefault
+              && reset.S.independentAsrEnabled === false,
+            'an empty authoritative restore must reset stale local values to defaults: '
+              + JSON.stringify({
+                slop: reset.S.slopFilterEnabled,
+                vision: reset.S.proactiveVisionEnabled,
+                visionDefault: resetVisionDefault,
+                asr: reset.S.independentAsrEnabled,
+              })
+          );
+          assert(reset.postCalls.length === 1, 'the reset defaults must be written back once');
+          const resetBody = JSON.parse(reset.postCalls[0].opts.body);
+          assert(
+            resetBody.slopFilterEnabled === true
+              && resetBody.proactiveVisionEnabled === resetVisionDefault
+              && resetBody.independentAsrEnabled === false,
+            'the reset writeback must not repopulate the server with stale localStorage'
+          );
+          reset.postCalls[0].resolve(response(
+            true,
+            200,
+            '"conversation-settings-11"',
+            {
+              success: true,
+              settings: resetBody,
+              revision: 11,
+              reset: false,
+              decisions: {},
+            }
+          ));
+          await tick();
 
           const noiseMerge = makeContext(false, {
             success: true,
@@ -1551,6 +1598,92 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             'a same-revision server snapshot must not launder its envelope '
               + 'over an unconfirmed explicit edit'
           );
+
+          const equalRevision = makeContext(false, {
+            success: true,
+            settings: {
+              independentAsrEnabled: false,
+              focusModeEnabled: false,
+            },
+            revision: 2,
+            telemetryBranch: null,
+            decisions: {},
+          });
+          await tick();
+          await tick();
+          equalRevision.fireStorage(JSON.stringify({
+            focusModeEnabled: true,
+            _sharedWriteMeta: {
+              writeId: 600,
+              writerId: 'window-editor',
+              changedKeys: ['focusModeEnabled'],
+              hydrated: true,
+              asrAuthoritative: true,
+              knownKeyWrites: {
+                focusModeEnabled: {
+                  writeId: 600,
+                  writerId: 'window-editor',
+                },
+              },
+            },
+          }));
+          equalRevision.fireStorage(JSON.stringify({
+            focusModeEnabled: true,
+            _sharedWriteMeta: {
+              writeId: 601,
+              writerId: 'window-server-reader',
+              changedKeys: [],
+              hydrated: true,
+              asrAuthoritative: true,
+              serverRevision: 2,
+              serverAuthoritativeKeys: ['focusModeEnabled'],
+              knownKeyWrites: {
+                focusModeEnabled: {
+                  writeId: 600,
+                  writerId: 'window-editor',
+                  confirmedRevision: 2,
+                },
+              },
+            },
+          }));
+          const equalSync = equalRevision.mod.syncSettingsToServer();
+          await tick();
+          assert(equalRevision.postCalls.length === 1, 'the confirmed view must POST');
+          equalRevision.postCalls[0].resolve(response(
+            false,
+            412,
+            '"conversation-settings-3"',
+            {
+              success: false,
+              settings: {
+                independentAsrEnabled: false,
+                focusModeEnabled: false,
+              },
+              revision: 3,
+              decisions: {},
+            }
+          ));
+          await tick();
+          await tick();
+          assert(equalRevision.postCalls.length === 2, 'the newer conflict must retry');
+          const equalRetryBody = JSON.parse(equalRevision.postCalls[1].opts.body);
+          assert(
+            equalRetryBody.focusModeEnabled === false,
+            'an equal-revision confirmation must stop the older local value '
+              + 'being preserved over revision 3'
+          );
+          equalRevision.postCalls[1].resolve(response(
+            true,
+            200,
+            '"conversation-settings-4"',
+            {
+              success: true,
+              settings: equalRetryBody,
+              revision: 4,
+              decisions: {},
+            }
+          ));
+          await equalSync;
         }
 
         async function runScenario(serverDecisionIsNewer) {
@@ -2412,10 +2545,14 @@ def test_shared_settings_writes_carry_explicit_change_metadata():
     )[0]
     assert "if (!meta || typeof meta !== 'object') return null;" in read_fn
     assert "if (!_isValidAsrWriteId(meta.writeId)) return null;" in read_fn
-    id_validator = _block_after(settings_source, "function _isValidAsrWriteId(value) {")
+    id_validator = _block_after(
+        settings_source,
+        "function _isValidAsrWriteId(value, serverAuthoritative) {",
+    )
     assert "Number.isSafeInteger(value)" in id_validator
     assert "Date.now() + _ASR_WRITE_ID_MAX_FUTURE_SKEW_MS" in id_validator
     assert "Number.MAX_SAFE_INTEGER - 1" in id_validator
+    assert "if (serverAuthoritative === true) return true;" in id_validator
     assert "Array.isArray(meta.changedKeys) ? meta.changedKeys : []" in read_fn
     assert "knownKeyWritesPresent" in read_fn
 
@@ -4638,7 +4775,9 @@ def test_asr_decision_tuple_survives_unrelated_saves():
     # ...the reader parses it defensively, falling back to today's behaviour...
     read_fn = _block_after(settings_source, "function _readSharedWriteMeta(settings) {")
     assert "asrDecision:" in read_fn
-    assert "_isValidAsrWriteId(meta.asrDecision.writeId)" in read_fn
+    assert "_isValidAsrWriteId(" in read_fn
+    assert "meta.asrDecision.writeId," in read_fn
+    assert "Number.isInteger(meta.serverRevision)" in read_fn
 
     # ...and both the boot seed and the adopted cross-window flip record the
     # ORIGINAL id, or this window re-inflates the value on its own next save.

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -815,8 +815,10 @@ def test_user_dirty_keys_survive_boot_get_merge_field_level():
     get_index = load_fn.index("loadSettingsFromServer().then(serverResult => {")
     assert snapshot_index < get_index
 
-    # (3) The merge is field-level: the per-key dirty skip runs before the S
-    # mutation, the subtitle-bridge mirrors carry the same dirty gating, and
+    # (3) The merge is field-level: pending keys are always preserved, while
+    # acknowledged dirty keys yield only to a newer server revision. Both
+    # guards run before the S mutation, the subtitle-bridge mirrors carry the
+    # same gating, and
     # the baseline is rolled to the merged state BEFORE the writeback
     # saveSettings() so server-applied values are never misattributed as
     # user-dirty by the writeback's own userInitiated diff.
@@ -826,12 +828,18 @@ def test_user_dirty_keys_survive_boot_get_merge_field_level():
     null_guard_index = merge_block.index("if (!serverResult) return;")
     hydrate_index = merge_block.index("S.settingsHydrated = true;")
     assert null_guard_index < hydrate_index
-    skip_index = merge_block.index("if (_dirtySettingsKeys.has(key)) continue;")
-    assert skip_index < merge_block.index("S[key] = serverSettings[key];")
-    assert "!_dirtySettingsKeys.has('subtitleEnabled')" in merge_block
-    assert "!_dirtySettingsKeys.has('userLanguage')" in merge_block
+    pending_skip_index = merge_block.index(
+        "if (_pendingSettingsKeys.has(key)) continue;"
+    )
+    dirty_guard_index = merge_block.index("if (_dirtySettingsKeys.has(key)")
+    mutation_index = merge_block.index("S[key] = serverSettings[key];")
+    assert pending_skip_index < dirty_guard_index < mutation_index
+    assert "&& !serverSnapshotNewerThanCurrent) continue;" in merge_block
+    assert "!_pendingSettingsKeys.has('subtitleEnabled')" in merge_block
+    assert "!_pendingSettingsKeys.has('userLanguage')" in merge_block
+    assert "serverSnapshotNewerThanCurrent" in merge_block
     roll_index = merge_block.index("_settingsBaseline = getConversationSettings();")
-    assert skip_index < roll_index < merge_block.index("saveSettings({")
+    assert pending_skip_index < roll_index < merge_block.index("saveSettings({")
     assert "serverAuthoritativeKeys: Object.keys(" in merge_block
     # The whole-merge drop is gone: no early return between the null-guard
     # and the hydration mark, and the old drop log no longer exists.
@@ -1852,6 +1860,27 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             Object.keys(firstBody).length === 1 && firstBody.focusModeEnabled === true,
             'an unmerged view must send only its pending key, got: '
               + JSON.stringify(firstBody)
+          );
+
+          ctx.fireStorage(JSON.stringify({
+            focusModeEnabled: false,
+            _sharedWriteMeta: {
+              writeId: 1,
+              writerId: 'window-old',
+              changedKeys: ['focusModeEnabled'],
+              hydrated: true,
+              asrAuthoritative: true,
+              knownKeyWrites: {
+                focusModeEnabled: {
+                  writeId: 1,
+                  writerId: 'window-old',
+                },
+              },
+            },
+          }));
+          assert(
+            ctx.S.focusModeEnabled === true,
+            'an older explicit token must not replace a newer pending edit'
           );
 
           // A later edit happens while the partial write is in flight. The
@@ -3528,7 +3557,69 @@ def test_failed_boot_get_keeps_posts_dirty_only_harness():
           ctx4.postCalls[2].resolve(okPost);
           await tick();
 
-          // ---- Scenario 5: a newer explicit localStorage ASR decision arrives
+          // ---- Scenario 5: the delayed boot GET is newer than the POST that
+          // acknowledged a local edit. The newer server snapshot must win.
+          const ctxNewer = makeContext();
+          ctxNewer.win.mergeMessagesEnabled = true;
+          ctxNewer.mod.saveSettings();
+          await tick();
+          ctxNewer.fireGateTimeout();
+          await tick();
+          await tick();
+          assert(ctxNewer.postCalls.length === 1, 'the bound releases the local edit');
+          ctxNewer.postCalls[0].resolve({
+            ok: true,
+            status: 200,
+            headers: {
+              get(name) {
+                return name.toLowerCase() === 'etag'
+                  ? '"conversation-settings-1"'
+                  : null;
+              },
+            },
+            json: async () => ({
+              success: true,
+              settings: {
+                independentAsrEnabled: false,
+                mergeMessagesEnabled: true,
+              },
+              revision: 1,
+              decisions: {},
+            }),
+          });
+          await tick();
+          await tick();
+          ctxNewer.getCalls[0].resolve({
+            ok: true,
+            headers: {
+              get(name) {
+                return name.toLowerCase() === 'etag'
+                  ? '"conversation-settings-2"'
+                  : null;
+              },
+            },
+            json: async () => ({
+              success: true,
+              settings: {
+                independentAsrEnabled: false,
+                mergeMessagesEnabled: false,
+              },
+              revision: 2,
+              decisions: {},
+              telemetryBranch: null,
+            }),
+          });
+          await tick();
+          await tick();
+          assert(
+            ctxNewer.S.mergeMessagesEnabled === false,
+            'a boot GET newer than the acknowledged POST must win'
+          );
+          assert(ctxNewer.postCalls.length === 2, 'the newer merge writes back once');
+          ctxNewer.postCalls[1].resolve(okPost);
+          await tick();
+
+          // ---- Scenario 6: a newer explicit localStorage ASR decision arrives
           // before its origin window's POST. The boot GET is older and must not
           // overwrite either the local value or the tuple that will accompany
           // the next save.

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -981,6 +981,14 @@ def test_cross_window_settings_posts_use_cas_and_persist_asr_decision_order():
     assert "_CONVERSATION_SETTINGS_MAX_ATTEMPTS" in sync_fn
     assert "headers['X-Conversation-Settings-ASR-Decision']" in sync_fn
     assert "JSON.stringify(requestDecision)" in sync_fn
+    mark_signature = re.search(
+        r"function _markEtagConfirmedSharedSettings\([^)]*\)\s*\{",
+        settings_source,
+    )
+    assert mark_signature is not None
+    mark_confirmed = _block_after(settings_source, mark_signature.group(0))
+    assert "payloadWasFull" not in mark_confirmed
+    assert "settingsAtSend[key] !== serverSettings[key]" in mark_confirmed
 
     # Both the state snapshot and the ASR token are rebuilt inside the retry
     # loop. An older window that loses the server decision comparison must not
@@ -3639,7 +3647,76 @@ def test_failed_boot_get_keeps_posts_dirty_only_harness():
           ctx4.postCalls[2].resolve(okPost);
           await tick();
 
-          // ---- Scenario 5: the delayed boot GET is newer than the POST that
+          // ---- Scenario 5: a legacy/mangled delayed GET omits revision. Once
+          // a POST established a comparable revision, its ETag must not be
+          // downgraded by the unversioned response.
+          const ctxMissingRevision = makeContext();
+          ctxMissingRevision.win.mergeMessagesEnabled = true;
+          ctxMissingRevision.mod.saveSettings();
+          await tick();
+          ctxMissingRevision.fireGateTimeout();
+          await tick();
+          await tick();
+          ctxMissingRevision.postCalls[0].resolve({
+            ok: true,
+            status: 200,
+            headers: {
+              get(name) {
+                return name.toLowerCase() === 'etag'
+                  ? '"conversation-settings-1"'
+                  : null;
+              },
+            },
+            json: async () => ({
+              success: true,
+              settings: {
+                independentAsrEnabled: false,
+                mergeMessagesEnabled: true,
+              },
+              revision: 1,
+              decisions: {},
+            }),
+          });
+          await tick();
+          await tick();
+          ctxMissingRevision.getCalls[0].resolve({
+            ok: true,
+            headers: {
+              get(name) {
+                return name.toLowerCase() === 'etag'
+                  ? '"conversation-settings-0"'
+                  : null;
+              },
+            },
+            json: async () => ({
+              success: true,
+              settings: {
+                independentAsrEnabled: false,
+                mergeMessagesEnabled: false,
+              },
+              decisions: {},
+              telemetryBranch: null,
+            }),
+          });
+          await tick();
+          await tick();
+          assert(
+            ctxMissingRevision.S.mergeMessagesEnabled === true,
+            'an unversioned late GET must preserve the acknowledged local key'
+          );
+          ctxMissingRevision.win.focusModeEnabled = true;
+          ctxMissingRevision.mod.saveSettings();
+          await tick();
+          await tick();
+          assert(
+            ctxMissingRevision.postCalls[1].headers['If-Match']
+              === '"conversation-settings-1"',
+            'an unversioned late GET must not downgrade the confirmed ETag'
+          );
+          ctxMissingRevision.postCalls[1].resolve(okPost);
+          await tick();
+
+          // ---- Scenario 6: the delayed boot GET is newer than the POST that
           // acknowledged a local edit. The newer server snapshot must win.
           const ctxNewer = makeContext();
           ctxNewer.win.mergeMessagesEnabled = true;
@@ -3701,7 +3778,7 @@ def test_failed_boot_get_keeps_posts_dirty_only_harness():
           ctxNewer.postCalls[1].resolve(okPost);
           await tick();
 
-          // ---- Scenario 6: a newer explicit localStorage ASR decision arrives
+          // ---- Scenario 7: a newer explicit localStorage ASR decision arrives
           // before its origin window's POST. The boot GET is older and must not
           // overwrite either the local value or the tuple that will accompany
           // the next save.
@@ -4540,15 +4617,21 @@ def test_asr_decision_tuple_survives_unrelated_saves():
     settings_source = APP_SETTINGS_PATH.read_text(encoding="utf-8")
 
     # The write carries the id of the decision that produced the value...
-    write_fn = _block_after(
+    signature = re.search(
+        r"function _writeSharedSettings\((?P<params>[^)]*)\)\s*\{",
         settings_source,
-        "function _writeSharedSettings(\n"
-        "        snapshot,\n"
-        "        explicitKeys,\n"
-        "        pendingRecovery,\n"
-        "        serverAuthoritativeKeys\n"
-        "    ) {",
     )
+    assert signature is not None, "_writeSharedSettings signature is missing"
+    parameter_names = {
+        parameter.strip() for parameter in signature.group("params").split(",")
+    }
+    assert {
+        "snapshot",
+        "explicitKeys",
+        "pendingRecovery",
+        "serverAuthoritativeKeys",
+    } <= parameter_names
+    write_fn = _block_after(settings_source, signature.group(0))
     assert "ownMeta.asrDecision = {" in write_fn
     assert "_lastAsrDecision.value === snapshot.independentAsrEnabled" in write_fn
 

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -965,9 +965,10 @@ def test_cross_window_settings_posts_use_cas_and_persist_asr_decision_order():
     assert "headers['If-Match'] = _conversationSettingsEtag;" in sync_fn
     assert "response.status === 412" in sync_fn
     assert "const preservedKeys = new Set(_pendingSettingsKeys);" in sync_fn
-    assert "_conversationSettingsEtagMutationVersion" in sync_fn
-    assert "_crossWindowSettingsChangedSince(" in sync_fn
-    assert "etagMutationVersionAtSend" in sync_fn
+    assert "_conversationSettingsEtagKeyMutationVersions" in sync_fn
+    assert "_crossWindowSettingsNewerThanEtag(" in sync_fn
+    assert "etagKeyMutationVersionsAtSend" in sync_fn
+    assert "_markEtagConfirmedSharedSettings(" in sync_fn
     assert "_settingsChangedSince(settings, mutationVersionAtSend).forEach" in sync_fn
     assert "_mergeConversationSettingsSnapshot(data, preservedKeys);" in sync_fn
     assert "_CONVERSATION_SETTINGS_MAX_ATTEMPTS" in sync_fn
@@ -1297,7 +1298,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
         }
         const tick = () => new Promise((resolve) => setImmediate(resolve));
 
-        function makeContext(bootFails) {
+        function makeContext(bootFails, bootData) {
           let storageListener = null;
           const runtime = {
             stoppedSpeech: 0,
@@ -1313,6 +1314,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
               mergeMessagesEnabled: false,
               mouseTrackingEnabled: false,
             })],
+            ['neko_noise_reduction', '0'],
           ]);
           const postCalls = [];
           const sandbox = {
@@ -1342,7 +1344,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
                 true,
                 200,
                 '"conversation-settings-0"',
-                {
+                bootData || {
                   success: true,
                   settings: { independentAsrEnabled: false },
                   telemetryBranch: null,
@@ -1391,6 +1393,45 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
               storageListener({ key: 'project_neko_settings', newValue });
             },
           };
+        }
+
+        async function runBootMetadataScenario() {
+          const tuple = {
+            writeId: Date.now() + 1000,
+            writerId: 'server-ahead',
+            value: false,
+          };
+          const tupleOnly = makeContext(false, {
+            success: true,
+            settings: { independentAsrEnabled: false },
+            telemetryBranch: null,
+            decisions: { independentAsrEnabled: tuple },
+          });
+          await tick();
+          await tick();
+          const persistedTuple = JSON.parse(
+            tupleOnly.store.get('project_neko_settings')
+          )._sharedWriteMeta.asrDecision;
+          assert(
+            JSON.stringify(persistedTuple) === JSON.stringify(tuple),
+            'a newer same-value server tuple must persist for offline write-id flooring'
+          );
+
+          const noiseMerge = makeContext(false, {
+            success: true,
+            settings: {
+              independentAsrEnabled: false,
+              noiseReductionEnabled: true,
+            },
+            telemetryBranch: null,
+            decisions: {},
+          });
+          await tick();
+          await tick();
+          assert(
+            noiseMerge.store.get('neko_noise_reduction') === '1',
+            'a boot merge must synchronize the legacy noise cache'
+          );
         }
 
         async function runScenario(serverDecisionIsNewer) {
@@ -1872,11 +1913,113 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
           await tick();
         }
 
+        async function runPartialConfirmedWatermarkScenario() {
+          const ctx = makeContext(true);
+          await tick();
+          await tick();
+
+          ctx.fireStorage(JSON.stringify({
+            mergeMessagesEnabled: true,
+            _sharedWriteMeta: {
+              writeId: 110,
+              writerId: 'window-b',
+              changedKeys: ['mergeMessagesEnabled'],
+              hydrated: true,
+              asrAuthoritative: true,
+            },
+          }));
+          ctx.win.focusModeEnabled = true;
+          ctx.mod.saveSettings();
+          await tick();
+          await tick();
+
+          assert(ctx.postCalls.length === 1, 'the dirty-only edit must POST');
+          const firstBody = JSON.parse(ctx.postCalls[0].opts.body);
+          assert(firstBody.focusModeEnabled === true, 'the pending key is sent');
+          assert(
+            !Object.prototype.hasOwnProperty.call(
+              firstBody,
+              'mergeMessagesEnabled'
+            ),
+            'the sibling cross-window key stays outside the partial request'
+          );
+
+          ctx.postCalls[0].resolve(response(
+            true,
+            200,
+            '"conversation-settings-1"',
+            {
+              success: true,
+              settings: {
+                independentAsrEnabled: false,
+                focusModeEnabled: true,
+                mergeMessagesEnabled: true,
+                slopFilterEnabled: false,
+              },
+              revision: 1,
+              decisions: {},
+            }
+          ));
+          await tick();
+          await tick();
+
+          ctx.win.slopFilterEnabled = true;
+          ctx.mod.saveSettings();
+          await tick();
+          await tick();
+
+          assert(ctx.postCalls.length === 2, 'the next edit sends a full snapshot');
+          ctx.postCalls[1].resolve(response(
+            false,
+            412,
+            '"conversation-settings-2"',
+            {
+              success: false,
+              settings: {
+                independentAsrEnabled: false,
+                focusModeEnabled: true,
+                mergeMessagesEnabled: false,
+                slopFilterEnabled: false,
+              },
+              revision: 2,
+              decisions: {},
+            }
+          ));
+          await tick();
+          await tick();
+
+          assert(ctx.postCalls.length === 3, 'the CAS mismatch retries once');
+          const retryBody = JSON.parse(ctx.postCalls[2].opts.body);
+          assert(
+            retryBody.mergeMessagesEnabled === false,
+            'a sibling edit confirmed by the prior response no longer masks server state'
+          );
+          assert(
+            retryBody.slopFilterEnabled === true,
+            'the still-pending local edit survives the CAS merge'
+          );
+
+          ctx.postCalls[2].resolve(response(
+            true,
+            200,
+            '"conversation-settings-3"',
+            {
+              success: true,
+              settings: retryBody,
+              revision: 3,
+              decisions: {},
+            }
+          ));
+          await tick();
+        }
+
         async function main() {
+          await runBootMetadataScenario();
           await runScenario(false);
           await runScenario(true);
           await runAcknowledgedDirtyScenario();
           await runSuccessfulPartialSnapshotScenario();
+          await runPartialConfirmedWatermarkScenario();
           console.log('CAS_HARNESS_OK');
           process.exitCode = 0;
         }

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -827,8 +827,10 @@ def test_user_dirty_keys_survive_boot_get_merge_field_level():
 
     # (4) Negative validation — non-user flows never dirty keys: the periodic
     # tick passes no options (its POST is not a user change), the boot-time
-    # skipServerSync save bypasses syncSettingsToServer entirely, and the set
-    # is monotone (no delete/clear), so a toggle-and-back stays authoritative.
+    # skipServerSync save bypasses syncSettingsToServer entirely, and the
+    # boot-merge authority set is monotone so a toggle-and-back survives a
+    # stale in-flight GET. The separate pending set is cleared only after a
+    # successful POST and only while the acknowledged value is still current.
     tick_body = settings_source.split("_syncTimerId = setInterval(() => {", 1)[1].split(
         "}, SYNC_INTERVAL_MS);", 1
     )[0]
@@ -841,6 +843,12 @@ def test_user_dirty_keys_survive_boot_get_merge_field_level():
     assert "saveSettings({ skipServerSync: true });" in first_launch_block
     assert "_dirtySettingsKeys.delete" not in settings_source
     assert "_dirtySettingsKeys.clear" not in settings_source
+    clear_fn = settings_source.split(
+        "function _clearAcknowledgedPendingSettings(payload) {", 1
+    )[1].split("function applySharedRuntimeSettings", 1)[0]
+    assert "current[key] === payload[key]" in clear_fn
+    assert "_pendingSettingsKeys.delete(key);" in clear_fn
+    assert "_clearAcknowledgedPendingSettings(payload);" in sync_fn
 
 
 def test_settings_post_snapshot_waits_bounded_for_boot_get_merge():
@@ -1097,11 +1105,13 @@ def test_rapid_asr_toggle_double_flip_persists_final_state_harness():
             appState: {
               independentAsrEnabled: false,
               slopFilterEnabled: false,
+              focusModeEnabled: false,
               settingsHydrated: false,
             },
             appConst: {},
             appUtils: { mapRenderQualityToFollowPerf() { return 'medium'; } },
             slopFilterEnabled: false,
+            focusModeEnabled: false,
             addEventListener() {},
             removeEventListener() {},
           };
@@ -1418,9 +1428,82 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
           }
         }
 
+        async function runAcknowledgedDirtyScenario() {
+          const ctx = makeContext();
+          await tick();
+          await tick();
+
+          ctx.win.slopFilterEnabled = true;
+          ctx.mod.saveSettings();
+          await tick();
+          assert(ctx.postCalls.length === 1, 'the first user edit must POST');
+          const acknowledged = JSON.parse(ctx.postCalls[0].opts.body);
+          ctx.postCalls[0].resolve(response(
+            true,
+            200,
+            '"conversation-settings-1"',
+            {
+              success: true,
+              settings: acknowledged,
+              revision: 1,
+              decisions: {},
+            }
+          ));
+          await tick();
+          await tick();
+
+          // A different local edit races a newer server revision. The earlier
+          // slopFilterEnabled=true was already acknowledged and must no longer
+          // be protected as pending during the 412 merge.
+          ctx.win.focusModeEnabled = true;
+          ctx.mod.saveSettings();
+          await tick();
+          assert(ctx.postCalls.length === 2, 'the unrelated edit must POST');
+          ctx.postCalls[1].resolve(response(
+            false,
+            412,
+            '"conversation-settings-2"',
+            {
+              success: false,
+              settings: {
+                independentAsrEnabled: false,
+                slopFilterEnabled: false,
+                focusModeEnabled: false,
+              },
+              revision: 2,
+              decisions: {},
+            }
+          ));
+          await tick();
+          await tick();
+          assert(ctx.postCalls.length === 3, 'the conflict must retry');
+          const retryBody = JSON.parse(ctx.postCalls[2].opts.body);
+          assert(
+            retryBody.slopFilterEnabled === false,
+            'the retry must adopt the newer server value for an acknowledged old edit'
+          );
+          assert(
+            retryBody.focusModeEnabled === true,
+            'the still-pending local edit must survive the conflict merge'
+          );
+          ctx.postCalls[2].resolve(response(
+            true,
+            200,
+            '"conversation-settings-3"',
+            {
+              success: true,
+              settings: retryBody,
+              revision: 3,
+              decisions: {},
+            }
+          ));
+          await tick();
+        }
+
         async function main() {
           await runScenario(false);
           await runScenario(true);
+          await runAcknowledgedDirtyScenario();
           console.log('CAS_HARNESS_OK');
           process.exitCode = 0;
         }
@@ -1860,15 +1943,10 @@ def test_unrelated_save_from_unhydrated_window_is_not_an_asr_toggle_harness():
           const pp = pending.mod.syncSettingsToServer();  // periodic-style: no dirty marking
           await tick();
           await tick();
-          assert(pending.postCalls.length === 2, 'the follow-up sync must POST');
-          const dirtyBody2 = JSON.parse(pending.postCalls[1].body);
           assert(
-            !('independentAsrEnabled' in dirtyBody2),
-            'the stale cross-window snapshot must NOT mark the ASR key user-dirty, got: '
-              + JSON.stringify(dirtyBody2)
+            pending.postCalls.length === 1,
+            'the acknowledged local key and incidental ASR copy leave no pending POST'
           );
-          assert(dirtyBody2.mergeMessagesEnabled === true, 'the genuine dirty key still posts');
-          pending.postCalls[1].resolve(okPost);
           await pp;
 
           // ---- Scenario 3: a genuine cross-window toggle stays authoritative ----
@@ -2189,12 +2267,12 @@ def test_settings_get_gate_timeout_downgrades_post_to_dirty_keys_only():
         "await fetch("
     )
 
-    # The picker copies ONLY dirty keys (negative: no fallback that would drag
-    # untouched keys back into the partial body).
+    # The picker copies ONLY pending keys (negative: acknowledged or untouched
+    # keys cannot be dragged back into the partial body).
     pick_fn = settings_source.split("function _pickDirtySettings(settings) {", 1)[1].split(
         "function applySharedRuntimeSettings", 1
     )[0]
-    assert "_dirtySettingsKeys.forEach((key) => {" in pick_fn
+    assert "_pendingSettingsKeys.forEach((key) => {" in pick_fn
     assert "Object.prototype.hasOwnProperty.call(settings, key)" in pick_fn
     assert "partial[key] = settings[key];" in pick_fn
     assert "Object.keys(settings)" not in pick_fn
@@ -2431,13 +2509,13 @@ def test_failed_boot_get_keeps_posts_dirty_only_harness():
     #
     # Pin the split: "the GET attempt finished" and "server values were merged"
     # are different facts, and only the latter licenses full snapshots.
-    # Scenario 1: HTTP-failed GET + later unrelated user edits -> every POST
-    # (including the periodic one) carries only the dirty keys, so untouched
-    # persisted values survive. Scenario 2: application-level failure
+    # Scenario 1: HTTP-failed GET + later unrelated user edits -> each new
+    # pending edit POST carries only that key, while an acknowledged key is not
+    # resent and an idle periodic pass sends nothing. Scenario 2: application-level failure
     # (success:false) + ASR toggle -> the toggle IS persisted. Scenario 3:
-    # network-error GET -> still dirty-only, and the periodic timer only POSTs
-    # (it never re-fetches), which is why the chosen recovery model is "stay
-    # dirty-only for this session" — safe because the backend merges partial
+    # network-error GET -> still pending-only, and the periodic timer does not
+    # re-fetch or resend an acknowledged key. The recovery model remains "stay
+    # partial-write-only for this session" — safe because the backend merges partial
     # payloads per key. Scenario 4 (recovery): a GET that fails the bound but
     # eventually SUCCEEDS flips back to full snapshots on its merge.
     harness = textwrap.dedent(
@@ -2547,7 +2625,7 @@ def test_failed_boot_get_keeps_posts_dirty_only_harness():
           await tick();
 
           // The restriction does not decay: a LATER, second edit is still
-          // dirty-only (both touched keys, nothing else).
+          // pending-only. The first key was acknowledged and must not be resent.
           ctx.win.focusModeEnabled = true;
           ctx.mod.saveSettings();
           await tick();
@@ -2555,26 +2633,20 @@ def test_failed_boot_get_keeps_posts_dirty_only_harness():
           assert(ctx.postCalls.length === 2, 'the second user edit is persisted too');
           const body2 = JSON.parse(ctx.postCalls[1].body);
           assert(body2.focusModeEnabled === true, 'the newly dirtied key is persisted');
-          assert(body2.mergeMessagesEnabled === true, 'the earlier dirty key stays authoritative');
+          assert(!('mergeMessagesEnabled' in body2), 'the acknowledged key is no longer pending');
           assert(
-            Object.keys(body2).length === 2,
-            'still only user-touched keys, got: ' + JSON.stringify(body2)
+            Object.keys(body2).length === 1,
+            'only the new pending key travels, got: ' + JSON.stringify(body2)
           );
           ctx.postCalls[1].resolve(okPost);
           await tick();
 
-          // ... and the periodic sync (no userInitiated) never widens the body
-          // either, and never rejects.
+          // ... and the periodic sync (no userInitiated) neither widens nor
+          // resends an already acknowledged body, and never rejects.
           const pp = ctx.mod.syncSettingsToServer();
           await tick();
           await tick();
-          assert(ctx.postCalls.length === 3, 'the periodic-style sync still writes the dirty keys');
-          const body3 = JSON.parse(ctx.postCalls[2].body);
-          assert(
-            Object.keys(body3).length === 2,
-            'the periodic sync must not widen the body, got: ' + JSON.stringify(body3)
-          );
-          ctx.postCalls[2].resolve(okPost);
+          assert(ctx.postCalls.length === 2, 'the periodic-style sync has no pending keys to write');
           await pp;
 
           // ---- Scenario 2: application-level failure + the ASR toggle.
@@ -2628,13 +2700,7 @@ def test_failed_boot_get_keeps_posts_dirty_only_harness():
             'no path re-fetches the settings GET, so dirty-only must be permanently safe '
               + 'rather than a temporary state (recovery is a fresh page load)'
           );
-          assert(ctx3.postCalls.length === 2, 'the periodic tick still POSTs (persistence never blocks)');
-          assert(
-            Object.keys(JSON.parse(ctx3.postCalls[1].body)).length === 1,
-            'the periodic tick stays dirty-only after a failed GET'
-          );
-          ctx3.postCalls[1].resolve(okPost);
-          await tick();
+          assert(ctx3.postCalls.length === 1, 'the periodic tick does not resend an acknowledged key');
 
           // ---- Scenario 4 (recovery): the bound elapses, the POST goes out
           // dirty-only, and the GET LATER succeeds -> full snapshots resume.

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -931,6 +931,35 @@ def test_settings_posts_serialize_so_a_stale_body_cannot_win_persistence():
     assert sync_fn.index("_markUserDirtySettings();") < run_sync_index
 
 
+def test_cross_window_settings_posts_use_cas_and_persist_asr_decision_order():
+    settings_source = APP_SETTINGS_PATH.read_text(encoding="utf-8")
+    sync_fn = settings_source.split(
+        "async function syncSettingsToServer(options)", 1
+    )[1].split("function startPeriodicSync()", 1)[0]
+
+    assert "let _conversationSettingsEtag = null;" in settings_source
+    assert "headers['If-Match'] = _conversationSettingsEtag;" in sync_fn
+    assert "response.status === 412" in sync_fn
+    assert "_mergeConversationSettingsConflict(data);" in sync_fn
+    assert "_CONVERSATION_SETTINGS_MAX_ATTEMPTS" in sync_fn
+    assert "headers['X-Conversation-Settings-ASR-Decision']" in sync_fn
+    assert "JSON.stringify(requestDecision)" in sync_fn
+
+    # Both the state snapshot and the ASR token are rebuilt inside the retry
+    # loop. An older window that loses the server decision comparison must not
+    # resend its stale pre-conflict body.
+    retry_loop = sync_fn.split(
+        "for (let attempt = 0; attempt < _CONVERSATION_SETTINGS_MAX_ATTEMPTS;",
+        1,
+    )[1]
+    assert retry_loop.index("const settings = getConversationSettings();") < retry_loop.index(
+        "await fetch("
+    )
+    assert retry_loop.index("const requestDecision = (") < retry_loop.index(
+        "await fetch("
+    )
+
+
 def test_cross_window_asr_flip_marks_hydration_and_asr_dirty():
     # Codex P2: a cross-window independent-ASR toggle arrives via the
     # 'storage' listener, which used to copy the value into S without marking
@@ -1205,6 +1234,181 @@ def test_rapid_asr_toggle_double_flip_persists_final_state_harness():
         f"stderr:\n{result.stderr}"
     )
     assert "HARNESS_OK" in result.stdout
+
+
+def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness():
+    harness = textwrap.dedent(
+        """
+        const fs = require('node:fs');
+        const vm = require('node:vm');
+        const source = fs.readFileSync(__APP_SETTINGS_PATH__, 'utf8');
+
+        function assert(cond, msg) {
+          if (!cond) throw new Error('ASSERT: ' + msg);
+        }
+        function response(ok, status, etag, data) {
+          return {
+            ok,
+            status,
+            headers: {
+              get(name) { return name.toLowerCase() === 'etag' ? etag : null; },
+            },
+            json: async () => data,
+          };
+        }
+        const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+        function makeContext() {
+          const store = new Map([
+            ['project_neko_settings', JSON.stringify({ independentAsrEnabled: false })],
+          ]);
+          const postCalls = [];
+          const sandbox = {
+            console: { log() {}, warn() {}, error() {} },
+            setInterval() { return 0; },
+            clearInterval() {},
+            setTimeout(fn, ms) {
+              const timer = setTimeout(fn, ms);
+              if (timer && typeof timer.unref === 'function') timer.unref();
+              return timer;
+            },
+            clearTimeout,
+            localStorage: {
+              getItem(key) { return store.has(key) ? store.get(key) : null; },
+              setItem(key, value) { store.set(key, String(value)); },
+              removeItem(key) { store.delete(key); },
+            },
+            document: { getElementById() { return null; } },
+            fetch(url, opts) {
+              if (opts && opts.method === 'POST') {
+                return new Promise((resolve) => {
+                  postCalls.push({ url, opts, resolve });
+                });
+              }
+              return Promise.resolve(response(
+                true,
+                200,
+                '"conversation-settings-0"',
+                {
+                  success: true,
+                  settings: { independentAsrEnabled: false },
+                  telemetryBranch: null,
+                  decisions: {},
+                }
+              ));
+            },
+          };
+          sandbox.window = {
+            appState: { independentAsrEnabled: false, settingsHydrated: false },
+            appConst: {},
+            appUtils: { mapRenderQualityToFollowPerf() { return 'medium'; } },
+            addEventListener() {},
+            removeEventListener() {},
+          };
+          vm.createContext(sandbox);
+          vm.runInContext(source, sandbox);
+          return {
+            S: sandbox.window.appState,
+            mod: sandbox.window.appSettings,
+            postCalls,
+          };
+        }
+
+        async function runScenario(serverDecisionIsNewer) {
+          const ctx = makeContext();
+          await tick();
+          await tick();
+          assert(ctx.S.settingsHydrated === true, 'boot GET must hydrate settings');
+
+          ctx.S.independentAsrEnabled = true;
+          ctx.mod.saveSettings({ skipServerSync: true });
+          const syncPromise = ctx.mod.syncSettingsToServer({ userInitiated: true });
+          await tick();
+          assert(ctx.postCalls.length === 1, 'first CAS POST must be issued');
+          const first = ctx.postCalls[0];
+          const firstBody = JSON.parse(first.opts.body);
+          const localDecision = JSON.parse(
+            first.opts.headers['X-Conversation-Settings-ASR-Decision']
+          );
+          assert(
+            first.opts.headers['If-Match'] === '"conversation-settings-0"',
+            'boot ETag must guard the first POST'
+          );
+          assert(localDecision.value === true, 'first request carries local ASR intent');
+
+          const serverDecision = {
+            writeId: serverDecisionIsNewer
+              ? localDecision.writeId + 1
+              : Math.max(0, localDecision.writeId - 1),
+            writerId: serverDecisionIsNewer ? 'window-z' : 'window-a',
+            value: false,
+          };
+          first.resolve(response(
+            false,
+            412,
+            '"conversation-settings-1"',
+            {
+              success: false,
+              settings: { independentAsrEnabled: false },
+              revision: 1,
+              decisions: { independentAsrEnabled: serverDecision },
+            }
+          ));
+          await tick();
+          await tick();
+          assert(ctx.postCalls.length === 2, 'a CAS conflict must retry once');
+          const retry = ctx.postCalls[1];
+          const retryBody = JSON.parse(retry.opts.body);
+          assert(
+            retry.opts.headers['If-Match'] === '"conversation-settings-1"',
+            'retry must use the conflict response ETag'
+          );
+          assert(
+            retryBody.independentAsrEnabled === !serverDecisionIsNewer,
+            'retry body must use the winning decision value'
+          );
+          const retryDecision =
+            JSON.parse(retry.opts.headers['X-Conversation-Settings-ASR-Decision']);
+          assert(
+            retryDecision.writeId === (
+              serverDecisionIsNewer ? serverDecision.writeId : localDecision.writeId
+            ),
+            'retry must carry the winning decision token'
+          );
+          retry.resolve(response(
+            true,
+            200,
+            '"conversation-settings-2"',
+            {
+              success: true,
+              settings: { independentAsrEnabled: retryBody.independentAsrEnabled },
+              revision: 2,
+              decisions: { independentAsrEnabled: retryDecision },
+            }
+          ));
+          await syncPromise;
+        }
+
+        async function main() {
+          await runScenario(false);
+          await runScenario(true);
+          console.log('CAS_HARNESS_OK');
+          process.exitCode = 0;
+        }
+        main().catch((err) => {
+          console.error(err && err.stack ? err.stack : String(err));
+          process.exitCode = 1;
+        });
+        """
+    ).replace("__APP_SETTINGS_PATH__", json.dumps(str(APP_SETTINGS_PATH)))
+
+    result = _run_settings_node_harness(harness)
+    assert result.returncode == 0, (
+        "settings CAS harness failed\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    assert "CAS_HARNESS_OK" in result.stdout
 
 
 def test_cross_window_asr_flip_authoritative_over_pending_get_harness():

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -831,9 +831,8 @@ def test_user_dirty_keys_survive_boot_get_merge_field_level():
     assert "!_dirtySettingsKeys.has('subtitleEnabled')" in merge_block
     assert "!_dirtySettingsKeys.has('userLanguage')" in merge_block
     roll_index = merge_block.index("_settingsBaseline = getConversationSettings();")
-    assert skip_index < roll_index < merge_block.index(
-        "saveSettings({ serverMerged: true });"
-    )
+    assert skip_index < roll_index < merge_block.index("saveSettings({")
+    assert "serverAuthoritativeKeys: Object.keys(" in merge_block
     # The whole-merge drop is gone: no early return between the null-guard
     # and the hydration mark, and the old drop log no longer exists.
     after_null_guard = null_guard_index + len("if (!serverResult) return;")
@@ -1431,6 +1430,56 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
           assert(
             noiseMerge.store.get('neko_noise_reduction') === '1',
             'a boot merge must synchronize the legacy noise cache'
+          );
+
+          const serverBroadcaster = makeContext(false, {
+            success: true,
+            settings: {
+              independentAsrEnabled: false,
+              proactiveVisionEnabled: false,
+            },
+            telemetryBranch: null,
+            decisions: {},
+          });
+          await tick();
+          await tick();
+          const serverSnapshot = JSON.parse(
+            serverBroadcaster.store.get('project_neko_settings')
+          );
+          assert(
+            serverSnapshot._sharedWriteMeta.knownKeyWrites.proactiveVisionEnabled,
+            'a server winner must receive per-key broadcast provenance'
+          );
+
+          const receiver = makeContext(true);
+          await tick();
+          await tick();
+          receiver.fireStorage(JSON.stringify({
+            proactiveVisionEnabled: true,
+            _sharedWriteMeta: {
+              writeId: 1,
+              writerId: 'window-old',
+              changedKeys: ['proactiveVisionEnabled'],
+              hydrated: true,
+              asrAuthoritative: true,
+              knownKeyWrites: {
+                proactiveVisionEnabled: {
+                  writeId: 1,
+                  writerId: 'window-old',
+                },
+              },
+            },
+          }));
+          receiver.fireStorage(JSON.stringify(serverSnapshot));
+          assert(
+            receiver.S.proactiveVisionEnabled === false,
+            'a newer authoritative server winner must outrank an older local token'
+          );
+          assert(
+            receiver.runtime.stoppedSpeech === 1
+              && receiver.runtime.stoppedScreening === 1
+              && receiver.runtime.stoppedTracks === 1,
+            'the authoritative privacy disable must stop active vision runtime'
           );
         }
 
@@ -2200,7 +2249,7 @@ def test_shared_settings_writes_carry_explicit_change_metadata():
     assert "_writeSharedSettings(settings, []);" in settings_source
 
     write_fn = settings_source.split(
-        "function _writeSharedSettings(snapshot, explicitKeys, pendingRecovery) {", 1
+        "function _writeSharedSettings(", 1
     )[1].split("\n    }", 1)[0]
     assert "writeId: _nextSharedWriteId()," in write_fn
     assert "changedKeys: explicitKeys || []," in write_fn
@@ -2953,8 +3002,9 @@ def test_settings_get_gate_timeout_downgrades_post_to_dirty_keys_only():
         "_settingsMergedFromServer = true;"
     )
     assert merge_cb.index("_settingsMergedFromServer = true;") < merge_cb.index(
-        "saveSettings({ serverMerged: true });"
+        "saveSettings({"
     )
+    assert "serverAuthoritativeKeys: Object.keys(" in merge_cb
     # Negative: the failure paths must NOT re-enable full snapshots. The
     # finally runs for merged AND failed GETs, so it may not touch the flag;
     # neither may the synchronous-throw catch, where nothing was ever read.
@@ -4319,7 +4369,12 @@ def test_asr_decision_tuple_survives_unrelated_saves():
     # The write carries the id of the decision that produced the value...
     write_fn = _block_after(
         settings_source,
-        "function _writeSharedSettings(snapshot, explicitKeys, pendingRecovery) {",
+        "function _writeSharedSettings(\n"
+        "        snapshot,\n"
+        "        explicitKeys,\n"
+        "        pendingRecovery,\n"
+        "        serverAuthoritativeKeys\n"
+        "    ) {",
     )
     assert "ownMeta.asrDecision = {" in write_fn
     assert "_lastAsrDecision.value === snapshot.independentAsrEnabled" in write_fn

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -669,7 +669,9 @@ def test_settings_hydration_marked_on_server_merge_and_user_change():
     assert "S.settingsHydrated = true;" in user_initiated_gate, (
         "the hydration mark must sit inside the userInitiated gate"
     )
-    assert sync_fn.index("S.settingsHydrated = true;") < sync_fn.index("await fetch(")
+    assert sync_fn.index("S.settingsHydrated = true;") < sync_fn.index(
+        "await _fetchConversationSettingsJsonWithTimeout("
+    )
 
     # The independent-ASR toggle handler reaches that marker via
     # syncSettingsToServer({ userInitiated: true }); the saveSettings call it
@@ -713,7 +715,8 @@ def test_periodic_sync_skips_post_and_never_marks_hydration_while_unhydrated():
 
     # Both GET-failure paths do start the periodic task — that is exactly why
     # the tick itself must carry the guard.
-    finally_block = settings_source.split(".finally(() => {", 1)[1].split(
+    load_fn = settings_source.split("function loadSettings()", 1)[1]
+    finally_block = load_fn.split("}).finally(() => {", 1)[1].split(
         "});", 1
     )[0]
     assert "startPeriodicSync();" in finally_block
@@ -805,7 +808,9 @@ def test_user_dirty_keys_survive_boot_get_merge_field_level():
     assert sync_fn.count("_markUserDirtySettings();") == 1
     user_initiated_gate = _block_after(sync_fn, "if (userInitiated) {")
     assert "_markUserDirtySettings();" in user_initiated_gate
-    assert sync_fn.index("_markUserDirtySettings();") < sync_fn.index("await fetch(")
+    assert sync_fn.index("_markUserDirtySettings();") < sync_fn.index(
+        "await _fetchConversationSettingsJsonWithTimeout("
+    )
 
     # (2) loadSettings snapshots the pre-GET settings as the diff baseline
     # before issuing the GET, so keys changed while it is pending diverge
@@ -896,7 +901,9 @@ def test_settings_post_snapshot_waits_bounded_for_boot_get_merge():
     run_sync_body = sync_fn.split("const runSync = async () =>", 1)[1]
     gate_index = run_sync_body.index("await _settingsGetGate;")
     snapshot_index = run_sync_body.index("const settings = getConversationSettings();")
-    fetch_index = run_sync_body.index("await fetch(")
+    fetch_index = run_sync_body.index(
+        "await _fetchConversationSettingsJsonWithTimeout("
+    )
     assert gate_index < snapshot_index < fetch_index
 
     # The gate is armed at GET issue time as a race between the settled merge
@@ -952,7 +959,9 @@ def test_settings_posts_serialize_so_a_stale_body_cannot_win_persistence():
     # after the predecessor completed — not at call time.
     run_sync_index = sync_fn.index("const runSync = async () =>")
     snapshot_index = sync_fn.index("const settings = getConversationSettings();")
-    fetch_index = sync_fn.index("await fetch(")
+    fetch_index = sync_fn.index(
+        "await _fetchConversationSettingsJsonWithTimeout("
+    )
     assert run_sync_index < snapshot_index < fetch_index
 
     # Negative: the synchronous hydration mark and dirty-key recording stay
@@ -998,10 +1007,10 @@ def test_cross_window_settings_posts_use_cas_and_persist_asr_decision_order():
         1,
     )[1]
     assert retry_loop.index("const settings = getConversationSettings();") < retry_loop.index(
-        "await fetch("
+        "await _fetchConversationSettingsJsonWithTimeout("
     )
     assert retry_loop.index("const requestDecision = (") < retry_loop.index(
-        "await fetch("
+        "await _fetchConversationSettingsJsonWithTimeout("
     )
 
 
@@ -1117,6 +1126,7 @@ def test_rapid_asr_toggle_double_flip_persists_final_state_harness():
           // look only at the POST calls.
           const postCalls = [];
           const getCalls = [];
+          const timeoutCallbacks = [];
           const sandbox = {
             console: { log() {}, warn() {}, error() {} },
             setInterval() { return 0; },
@@ -1126,6 +1136,7 @@ def test_rapid_asr_toggle_double_flip_persists_final_state_harness():
               // the harness then exits naturally and stdout always flushes.
               const t = setTimeout(fn, ms);
               if (t && typeof t.unref === 'function') t.unref();
+              timeoutCallbacks.push({ fn, ms, timer: t });
               return t;
             },
             clearTimeout,
@@ -1134,7 +1145,7 @@ def test_rapid_asr_toggle_double_flip_persists_final_state_harness():
             fetch(url, opts) {
               return new Promise((resolve, reject) => {
                 if (opts && opts.method === 'POST') {
-                  postCalls.push({ url, body: opts.body, resolve, reject });
+                  postCalls.push({ url, body: opts.body, opts, resolve, reject });
                 } else {
                   getCalls.push({ url, resolve, reject });
                 }
@@ -1160,7 +1171,13 @@ def test_rapid_asr_toggle_double_flip_persists_final_state_harness():
           // The harness drives hydration and the toggle state explicitly from
           // a clean baseline.
           sandbox.window.appState.settingsHydrated = false;
-          return { postCalls, getCalls, S: sandbox.window.appState, mod: sandbox.window.appSettings };
+          return {
+            postCalls,
+            getCalls,
+            timeoutCallbacks,
+            S: sandbox.window.appState,
+            mod: sandbox.window.appSettings,
+          };
         }
 
         const okResponse = { ok: true, json: async () => ({ success: true }) };
@@ -1221,6 +1238,37 @@ def test_rapid_asr_toggle_double_flip_persists_final_state_harness():
           postCalls[3].resolve(okResponse);
           await p3;
           await p4;
+
+          // A transport that never settles must time out and release the
+          // serialization tail so the later user state can still be sent.
+          const timeoutCountBeforeStall = ctx.timeoutCallbacks.length;
+          S.independentAsrEnabled = true;
+          const p5 = mod.syncSettingsToServer({ userInitiated: true });
+          await tick();
+          S.independentAsrEnabled = false;
+          const p6 = mod.syncSettingsToServer({ userInitiated: true });
+          await tick();
+          assert(postCalls.length === 5, 'fifth sync in flight, sixth queued');
+          const requestTimeout = ctx.timeoutCallbacks
+            .slice(timeoutCountBeforeStall)
+            .find(
+              (timer) => timer.ms === 15000
+          );
+          assert(requestTimeout, 'the in-flight request must have a bounded timeout');
+          requestTimeout.fn();
+          await tick();
+          await tick();
+          assert(
+            postCalls.length === 6,
+            'a timed-out predecessor must release the queued sync'
+          );
+          assert(
+            JSON.parse(postCalls[5].body).independentAsrEnabled === false,
+            'the post-timeout sync must rebuild from the final state'
+          );
+          postCalls[5].resolve(okResponse);
+          await p5;
+          await p6;
 
           // Negative: a non-userInitiated (periodic-style) call never marks
           // hydration — and after a FAILED boot GET, with nothing the user
@@ -1471,9 +1519,16 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
               })
           );
           assert(reset.postCalls.length === 1, 'the reset defaults must be written back once');
+          const resetWritebackDecision = JSON.parse(
+            reset.postCalls[0].opts.headers[
+              'X-Conversation-Settings-ASR-Decision'
+            ]
+          );
           assert(
-            !('X-Conversation-Settings-ASR-Decision' in reset.postCalls[0].opts.headers),
-            'a reset writeback must not attach the stale opposite ASR tuple'
+            resetWritebackDecision.value === false
+              && resetWritebackDecision.writeId
+                > resetPriorDecision.writeId,
+            'a reset writeback must rebase the stale tuple onto the reset default'
           );
           assert(
             reset.postCalls[0].opts.headers['X-Conversation-Settings-Full-Snapshot'] === '1',
@@ -1496,11 +1551,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
               revision: 11,
               reset: false,
               decisions: {
-                independentAsrEnabled: {
-                  writeId: resetPriorDecision.writeId + 1,
-                  writerId: 'server-legacy',
-                  value: false,
-                },
+                independentAsrEnabled: resetWritebackDecision,
               },
             }
           ));
@@ -1513,6 +1564,99 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
               && resetPersisted._sharedWriteMeta.serverRevision === 11,
             'a full-write success must adopt and rebroadcast the generated server ASR tuple'
           );
+
+          const resetRace = makeContext(false, {
+            success: true,
+            settings: {},
+            revision: 10,
+            reset: true,
+            telemetryBranch: null,
+            decisions: { independentAsrEnabled: resetPriorDecision },
+          });
+          await tick();
+          await tick();
+          assert(
+            resetRace.postCalls.length === 1,
+            'the reset-race writeback must start'
+          );
+          const resetRaceBaselineDecision = JSON.parse(
+            resetRace.postCalls[0].opts.headers[
+              'X-Conversation-Settings-ASR-Decision'
+            ]
+          );
+          resetRace.S.independentAsrEnabled = true;
+          resetRace.mod.saveSettings({
+            skipServerSync: true,
+            explicitSharedKeys: ['independentAsrEnabled'],
+          });
+          const resetToggleSync = resetRace.mod.syncSettingsToServer({
+            userInitiated: true,
+          });
+          await tick();
+          assert(
+            resetRace.postCalls.length === 1,
+            'the user toggle must queue behind the reset writeback'
+          );
+          const resetToggleDecision = JSON.parse(
+            resetRace.store.get('project_neko_settings')
+          )._sharedWriteMeta.asrDecision;
+          assert(
+            resetToggleDecision.value === true
+              && resetToggleDecision.writeId
+                > resetRaceBaselineDecision.writeId,
+            'a toggle during reset must mint above the rebased reset decision'
+          );
+          resetRace.postCalls[0].resolve(response(
+            true,
+            200,
+            '"conversation-settings-11"',
+            {
+              success: true,
+              settings: {
+                independentAsrEnabled: false,
+                slopFilterEnabled: true,
+              },
+              revision: 11,
+              reset: false,
+              decisions: {
+                independentAsrEnabled: resetRaceBaselineDecision,
+              },
+            }
+          ));
+          await tick();
+          await tick();
+          assert(
+            resetRace.S.independentAsrEnabled === true
+              && resetRace.postCalls.length === 2,
+            'the older reset response must not overwrite the queued toggle'
+          );
+          const resetToggleBody = JSON.parse(resetRace.postCalls[1].opts.body);
+          const resetToggleHeader = JSON.parse(
+            resetRace.postCalls[1].opts.headers[
+              'X-Conversation-Settings-ASR-Decision'
+            ]
+          );
+          assert(
+            resetToggleBody.independentAsrEnabled === true
+              && JSON.stringify(resetToggleHeader)
+                === JSON.stringify(resetToggleDecision),
+            'the queued sync must persist the newer toggle tuple'
+          );
+          resetRace.postCalls[1].resolve(response(
+            true,
+            200,
+            '"conversation-settings-12"',
+            {
+              success: true,
+              settings: resetToggleBody,
+              revision: 12,
+              reset: false,
+              decisions: {
+                independentAsrEnabled: resetToggleDecision,
+              },
+            }
+          ));
+          await resetToggleSync;
 
           const noiseMerge = makeContext(false, {
             success: true,
@@ -1552,6 +1696,26 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
                 .includes('proactiveVisionEnabled'),
             'a server winner must carry its real revision and authoritative fields'
           );
+          serverBroadcaster.fireStorage(JSON.stringify({
+            proactiveVisionEnabled: true,
+            _sharedWriteMeta: {
+              writeId: 1,
+              writerId: 'window-old',
+              changedKeys: ['proactiveVisionEnabled'],
+              hydrated: true,
+              asrAuthoritative: true,
+              knownKeyWrites: {
+                proactiveVisionEnabled: {
+                  writeId: 1,
+                  writerId: 'window-old',
+                },
+              },
+            },
+          }));
+          assert(
+            serverBroadcaster.S.proactiveVisionEnabled === false,
+            'the broadcasting window must retain its own server-authority floor'
+          );
 
           const receiver = makeContext(true);
           await tick();
@@ -1583,6 +1747,49 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
               && receiver.runtime.stoppedScreening === 1
               && receiver.runtime.stoppedTracks === 1,
             'the authoritative privacy disable must stop active vision runtime'
+          );
+          receiver.fireStorage(JSON.stringify({
+            proactiveVisionEnabled: true,
+            _sharedWriteMeta: {
+              writeId: 1,
+              writerId: 'window-old',
+              changedKeys: ['proactiveVisionEnabled'],
+              hydrated: true,
+              asrAuthoritative: true,
+              knownKeyWrites: {
+                proactiveVisionEnabled: {
+                  writeId: 1,
+                  writerId: 'window-old',
+                  confirmedRevision: 1,
+                },
+              },
+            },
+          }));
+          assert(
+            receiver.S.proactiveVisionEnabled === false,
+            'an accepted server winner must retain a floor against delayed old events'
+          );
+          const newerVisionWriteId =
+            serverSnapshot._sharedWriteMeta.writeId + 1;
+          receiver.fireStorage(JSON.stringify({
+            proactiveVisionEnabled: true,
+            _sharedWriteMeta: {
+              writeId: newerVisionWriteId,
+              writerId: 'window-new',
+              changedKeys: ['proactiveVisionEnabled'],
+              hydrated: true,
+              asrAuthoritative: true,
+              knownKeyWrites: {
+                proactiveVisionEnabled: {
+                  writeId: newerVisionWriteId,
+                  writerId: 'window-new',
+                },
+              },
+            },
+          }));
+          assert(
+            receiver.S.proactiveVisionEnabled === true,
+            'a genuinely newer explicit event must still supersede the server floor'
           );
 
           const staleReceiver = makeContext(false, {
@@ -3395,13 +3602,13 @@ def test_settings_get_gate_timeout_downgrades_post_to_dirty_keys_only():
         run_sync_body.index("await _settingsGetGate;")
         < run_sync_body.index("const settings = getConversationSettings();")
         < run_sync_body.index("const payload =")
-        < run_sync_body.index("await fetch(")
+        < run_sync_body.index("await _fetchConversationSettingsJsonWithTimeout(")
     )
     # An empty dirty set means nothing user-authoritative exists yet: skip the
     # POST entirely rather than write pre-merge values.
     assert "if (Object.keys(payload).length === 0) {" in run_sync_body
     assert run_sync_body.index("if (Object.keys(payload).length === 0) {") < run_sync_body.index(
-        "await fetch("
+        "await _fetchConversationSettingsJsonWithTimeout("
     )
 
     # The picker copies ONLY pending keys (negative: acknowledged or untouched

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -1510,6 +1510,24 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
           await tick();
           await tick();
 
+          const acknowledgedLocal = JSON.parse(
+            ctx.store.get('project_neko_settings')
+          );
+          ctx.fireStorage(JSON.stringify({
+            slopFilterEnabled: false,
+            _sharedWriteMeta: {
+              writeId: acknowledgedLocal._sharedWriteMeta.writeId - 1,
+              writerId: 'window-a',
+              changedKeys: [],
+              hydrated: true,
+              asrAuthoritative: true,
+            },
+          }));
+          assert(
+            ctx.S.slopFilterEnabled === true,
+            'a delayed older server merge must not roll back an acknowledged local edit'
+          );
+
           // A different local edit races a newer server revision. The earlier
           // slopFilterEnabled=true was already acknowledged and must no longer
           // be protected as pending during the 412 merge.

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -1430,18 +1430,30 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
           const persistedTuple = JSON.parse(
             tupleOnly.store.get('project_neko_settings')
           )._sharedWriteMeta.asrDecision;
+          const tupleEnvelope = JSON.parse(
+            tupleOnly.store.get('project_neko_settings')
+          )._sharedWriteMeta.writeId;
           assert(
             JSON.stringify(persistedTuple) === JSON.stringify(tuple),
             'a newer same-value server tuple must persist for offline write-id flooring'
           );
+          assert(
+            tupleEnvelope < tuple.writeId,
+            'a server ASR floor must not inflate the localStorage envelope id'
+          );
 
+          const resetPriorDecision = {
+            writeId: Date.now() + 1000,
+            writerId: 'server-before-reset',
+            value: true,
+          };
           const reset = makeContext(false, {
             success: true,
             settings: {},
             revision: 10,
             reset: true,
             telemetryBranch: null,
-            decisions: {},
+            decisions: { independentAsrEnabled: resetPriorDecision },
           });
           await tick();
           await tick();
@@ -1459,6 +1471,14 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
               })
           );
           assert(reset.postCalls.length === 1, 'the reset defaults must be written back once');
+          assert(
+            !('X-Conversation-Settings-ASR-Decision' in reset.postCalls[0].opts.headers),
+            'a reset writeback must not attach the stale opposite ASR tuple'
+          );
+          assert(
+            reset.postCalls[0].opts.headers['X-Conversation-Settings-Full-Snapshot'] === '1',
+            'a reset writeback must declare that it can clear the tombstone'
+          );
           const resetBody = JSON.parse(reset.postCalls[0].opts.body);
           assert(
             resetBody.slopFilterEnabled === true
@@ -1475,10 +1495,24 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
               settings: resetBody,
               revision: 11,
               reset: false,
-              decisions: {},
+              decisions: {
+                independentAsrEnabled: {
+                  writeId: resetPriorDecision.writeId + 1,
+                  writerId: 'server-legacy',
+                  value: false,
+                },
+              },
             }
           ));
           await tick();
+          const resetPersisted = JSON.parse(
+            reset.store.get('project_neko_settings')
+          );
+          assert(
+            resetPersisted._sharedWriteMeta.asrDecision.value === false
+              && resetPersisted._sharedWriteMeta.serverRevision === 11,
+            'a full-write success must adopt and rebroadcast the generated server ASR tuple'
+          );
 
           const noiseMerge = makeContext(false, {
             success: true,
@@ -1810,6 +1844,34 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
 
           const acknowledgedLocal = JSON.parse(
             ctx.store.get('project_neko_settings')
+          );
+          const acknowledgedSlopToken =
+            acknowledgedLocal._sharedWriteMeta.knownKeyWrites.slopFilterEnabled;
+          ctx.fireStorage(JSON.stringify({
+            slopFilterEnabled: false,
+            proactiveMusicEnabled: false,
+            _sharedWriteMeta: {
+              writeId: acknowledgedLocal._sharedWriteMeta.writeId + 20,
+              writerId: 'window-unrelated-editor',
+              changedKeys: ['proactiveMusicEnabled'],
+              hydrated: true,
+              asrAuthoritative: true,
+              knownKeyWrites: {
+                slopFilterEnabled: {
+                  writeId: Math.max(0, acknowledgedSlopToken.writeId - 1),
+                  writerId: 'window-stale',
+                },
+                proactiveMusicEnabled: {
+                  writeId: acknowledgedLocal._sharedWriteMeta.writeId + 20,
+                  writerId: 'window-unrelated-editor',
+                },
+              },
+            },
+          }));
+          assert(
+            ctx.S.slopFilterEnabled === true
+              && ctx.S.proactiveMusicEnabled === false,
+            'an unrelated explicit snapshot must filter a stale incidental field'
           );
           ctx.fireStorage(JSON.stringify({
             slopFilterEnabled: false,
@@ -2208,6 +2270,51 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
           await tick();
         }
 
+        async function runPartialResetSnapshotScenario() {
+          const ctx = makeContext(true);
+          await tick();
+          await tick();
+          assert(ctx.S.slopFilterEnabled === false, 'the harness starts with stale local slop');
+
+          ctx.win.focusModeEnabled = true;
+          ctx.mod.saveSettings();
+          await tick();
+          await tick();
+          assert(ctx.postCalls.length === 1, 'the pre-hydration edit must POST');
+          assert(
+            !('X-Conversation-Settings-Full-Snapshot' in ctx.postCalls[0].opts.headers),
+            'a dirty-only pre-hydration write must not clear the reset tombstone'
+          );
+
+          ctx.postCalls[0].resolve(response(
+            true,
+            200,
+            '"conversation-settings-1"',
+            {
+              success: true,
+              settings: { focusModeEnabled: true },
+              revision: 1,
+              reset: true,
+              decisions: {},
+            }
+          ));
+          await tick();
+          await tick();
+
+          assert(
+            ctx.S.focusModeEnabled === true
+              && ctx.S.slopFilterEnabled === true
+              && ctx.S.independentAsrEnabled === false,
+            'a partial reset response must materialize defaults without losing the edit'
+          );
+          const restoredLocal = JSON.parse(ctx.store.get('project_neko_settings'));
+          assert(
+            restoredLocal.focusModeEnabled === true
+              && restoredLocal.slopFilterEnabled === true,
+            'the partial reset response must replace stale localStorage values'
+          );
+        }
+
         async function runPartialConfirmedWatermarkScenario() {
           const ctx = makeContext(true);
           await tick();
@@ -2314,6 +2421,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
           await runScenario(true);
           await runAcknowledgedDirtyScenario();
           await runSuccessfulPartialSnapshotScenario();
+          await runPartialResetSnapshotScenario();
           await runPartialConfirmedWatermarkScenario();
           console.log('CAS_HARNESS_OK');
           process.exitCode = 0;
@@ -3915,7 +4023,74 @@ def test_failed_boot_get_keeps_posts_dirty_only_harness():
           ctxNewer.postCalls[1].resolve(okPost);
           await tick();
 
-          // ---- Scenario 7: a newer explicit localStorage ASR decision arrives
+          // ---- Scenario 7: a timeout-released partial POST advances the server
+          // revision before the captured boot GET returns. The older GET must
+          // not roll back even fields that were never locally dirty.
+          const ctxOlder = makeContext();
+          ctxOlder.win.mergeMessagesEnabled = true;
+          ctxOlder.mod.saveSettings();
+          await tick();
+          ctxOlder.fireGateTimeout();
+          await tick();
+          await tick();
+          ctxOlder.postCalls[0].resolve({
+            ok: true,
+            status: 200,
+            headers: {
+              get(name) {
+                return name.toLowerCase() === 'etag'
+                  ? '"conversation-settings-2"'
+                  : null;
+              },
+            },
+            json: async () => ({
+              success: true,
+              settings: {
+                independentAsrEnabled: false,
+                mergeMessagesEnabled: true,
+                slopFilterEnabled: true,
+              },
+              revision: 2,
+              decisions: {},
+            }),
+          });
+          await tick();
+          await tick();
+          assert(ctxOlder.S.slopFilterEnabled === true, 'the POST response hydrates rev2');
+          ctxOlder.getCalls[0].resolve({
+            ok: true,
+            headers: {
+              get(name) {
+                return name.toLowerCase() === 'etag'
+                  ? '"conversation-settings-1"'
+                  : null;
+              },
+            },
+            json: async () => ({
+              success: true,
+              settings: {
+                independentAsrEnabled: false,
+                mergeMessagesEnabled: false,
+                slopFilterEnabled: false,
+              },
+              revision: 1,
+              decisions: {},
+              telemetryBranch: null,
+            }),
+          });
+          await tick();
+          await tick();
+          assert(
+            ctxOlder.S.mergeMessagesEnabled === true
+              && ctxOlder.S.slopFilterEnabled === true,
+            'a delayed older GET must not merge any stale settings fields'
+          );
+          assert(
+            ctxOlder.postCalls.length === 1,
+            'discarding an older GET must not trigger a stale writeback'
+          );
+
+          // ---- Scenario 8: a newer explicit localStorage ASR decision arrives
           // before its origin window's POST. The boot GET is older and must not
           // overwrite either the local value or the tuple that will accompany
           // the next save.
@@ -4676,7 +4851,8 @@ def test_concurrent_asr_toggles_are_totally_ordered_not_swapped():
     write_fn = settings_source.split("function _writeSharedSettings(", 1)[1].split(
         "\n    }", 1
     )[0]
-    assert "_noteAsrDecision(ownMeta.writeId, ownMeta.writerId," in write_fn
+    assert "_nextAsrDecisionWriteId(ownMeta.writeId)" in write_fn
+    assert "_noteAsrDecision(" in write_fn
 
     # Refusing authority alone is not enough: applySharedRuntimeSettings copies
     # independentAsrEnabled unconditionally, so the losing write must also be

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -1723,13 +1723,16 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             },
           }));
           assert(
-            serverBroadcaster.S.proactiveVisionEnabled === false,
-            'the broadcasting window must retain its own server-authority floor'
+            serverBroadcaster.S.proactiveVisionEnabled === true,
+            'an unconfirmed explicit edit must outrank a server snapshot '
+              + 'that did not observe it'
           );
           assert(
-            serverSnapshot._sharedWriteMeta.knownKeyWrites
-              .proactiveVisionEnabled.confirmedRevision === 2,
-            'the server-authority floor must be serialized for reloads'
+            !serverSnapshot._sharedWriteMeta.knownKeyWrites
+              .proactiveVisionEnabled
+              && serverSnapshot._sharedWriteMeta.serverKeyRevisions
+                .proactiveVisionEnabled === 2,
+            'the server floor must be serialized without forging a source token'
           );
           const reloadedServerWinner = makeContext(
             true,
@@ -1755,8 +1758,9 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             },
           }));
           assert(
-            reloadedServerWinner.S.proactiveVisionEnabled === false,
-            'reload must reconstruct the server floor before its boot GET succeeds'
+            reloadedServerWinner.S.proactiveVisionEnabled === true,
+            'reload must not let the persisted server floor suppress '
+              + 'an unconfirmed explicit edit'
           );
 
           const receiver = makeContext(true);

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -1528,6 +1528,36 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             'a delayed same-id server merge must not roll back an acknowledged local edit'
           );
 
+          // A newer explicit value may only have been received from another
+          // window, so it advances the applied floor without minting a local
+          // write id. A delayed merge must respect that floor too.
+          const externalWriteId =
+            acknowledgedLocal._sharedWriteMeta.writeId + 10;
+          ctx.fireStorage(JSON.stringify({
+            mergeMessagesEnabled: true,
+            _sharedWriteMeta: {
+              writeId: externalWriteId,
+              writerId: 'window-c',
+              changedKeys: ['mergeMessagesEnabled'],
+              hydrated: true,
+              asrAuthoritative: true,
+            },
+          }));
+          ctx.fireStorage(JSON.stringify({
+            mergeMessagesEnabled: false,
+            _sharedWriteMeta: {
+              writeId: externalWriteId,
+              writerId: 'window-d',
+              changedKeys: [],
+              hydrated: true,
+              asrAuthoritative: true,
+            },
+          }));
+          assert(
+            ctx.S.mergeMessagesEnabled === true,
+            'a delayed merge must not roll back a newer externally applied value'
+          );
+
           // A different local edit races a newer server revision. The earlier
           // slopFilterEnabled=true was already acknowledged and must no longer
           // be protected as pending during the 412 merge.

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -1516,8 +1516,8 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
           ctx.fireStorage(JSON.stringify({
             slopFilterEnabled: false,
             _sharedWriteMeta: {
-              writeId: acknowledgedLocal._sharedWriteMeta.writeId - 1,
-              writerId: 'window-a',
+              writeId: acknowledgedLocal._sharedWriteMeta.writeId,
+              writerId: 'zzzzzzzzzzzzzzzz',
               changedKeys: [],
               hydrated: true,
               asrAuthoritative: true,
@@ -1525,7 +1525,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
           }));
           assert(
             ctx.S.slopFilterEnabled === true,
-            'a delayed older server merge must not roll back an acknowledged local edit'
+            'a delayed same-id server merge must not roll back an acknowledged local edit'
           );
 
           // A different local edit races a newer server revision. The earlier

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -948,7 +948,7 @@ def test_cross_window_settings_posts_use_cas_and_persist_asr_decision_order():
     assert "let _conversationSettingsEtag = null;" in settings_source
     assert "headers['If-Match'] = _conversationSettingsEtag;" in sync_fn
     assert "response.status === 412" in sync_fn
-    assert "_mergeConversationSettingsConflict(data);" in sync_fn
+    assert "_mergeConversationSettingsSnapshot(data);" in sync_fn
     assert "_CONVERSATION_SETTINGS_MAX_ATTEMPTS" in sync_fn
     assert "headers['X-Conversation-Settings-ASR-Decision']" in sync_fn
     assert "JSON.stringify(requestDecision)" in sync_fn
@@ -1273,9 +1273,20 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
         }
         const tick = () => new Promise((resolve) => setImmediate(resolve));
 
-        function makeContext() {
+        function makeContext(bootFails) {
+          const runtime = {
+            stoppedSpeech: 0,
+            stoppedScreening: 0,
+            stoppedTracks: 0,
+            scheduled: 0,
+          };
           const store = new Map([
-            ['project_neko_settings', JSON.stringify({ independentAsrEnabled: false })],
+            ['project_neko_settings', JSON.stringify({
+              independentAsrEnabled: false,
+              proactiveVisionEnabled: true,
+              slopFilterEnabled: false,
+              mouseTrackingEnabled: false,
+            })],
           ]);
           const postCalls = [];
           const sandbox = {
@@ -1300,6 +1311,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
                   postCalls.push({ url, opts, resolve });
                 });
               }
+              if (bootFails) return Promise.resolve({ ok: false, status: 500 });
               return Promise.resolve(response(
                 true,
                 200,
@@ -1314,9 +1326,26 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             },
           };
           sandbox.window = {
-            appState: { independentAsrEnabled: false, settingsHydrated: false },
+            appState: {
+              independentAsrEnabled: false,
+              proactiveVisionEnabled: true,
+              slopFilterEnabled: false,
+              focusModeEnabled: false,
+              settingsHydrated: false,
+              screenCaptureStream: {
+                getTracks() {
+                  return [{ stop() { runtime.stoppedTracks += 1; } }];
+                },
+              },
+            },
             appConst: {},
             appUtils: { mapRenderQualityToFollowPerf() { return 'medium'; } },
+            proactiveVisionEnabled: true,
+            slopFilterEnabled: false,
+            focusModeEnabled: false,
+            stopProactiveVisionDuringSpeech() { runtime.stoppedSpeech += 1; },
+            stopScreening() { runtime.stoppedScreening += 1; },
+            scheduleProactiveChat() { runtime.scheduled += 1; },
             addEventListener() {},
             removeEventListener() {},
           };
@@ -1328,6 +1357,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             mod: sandbox.window.appSettings,
             postCalls,
             store,
+            runtime,
           };
         }
 
@@ -1435,6 +1465,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
 
           ctx.win.slopFilterEnabled = true;
           ctx.mod.saveSettings();
+          assert(ctx.S.slopFilterEnabled === true, 'the first edit updates shared state immediately');
           await tick();
           assert(ctx.postCalls.length === 1, 'the first user edit must POST');
           const acknowledged = JSON.parse(ctx.postCalls[0].opts.body);
@@ -1467,6 +1498,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
               success: false,
               settings: {
                 independentAsrEnabled: false,
+                proactiveVisionEnabled: false,
                 slopFilterEnabled: false,
                 focusModeEnabled: false,
               },
@@ -1486,6 +1518,31 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             retryBody.focusModeEnabled === true,
             'the still-pending local edit must survive the conflict merge'
           );
+          assert(
+            retryBody.proactiveVisionEnabled === false,
+            'the retry must retain the server privacy winner'
+          );
+          assert(
+            ctx.runtime.stoppedSpeech === 1
+              && ctx.runtime.stoppedScreening === 1
+              && ctx.runtime.stoppedTracks === 1,
+            'the privacy winner must stop every active vision runtime path'
+          );
+          const reconciledLocal = JSON.parse(ctx.store.get('project_neko_settings'));
+          assert(
+            reconciledLocal.slopFilterEnabled === false
+              && reconciledLocal.focusModeEnabled === true
+              && reconciledLocal.proactiveVisionEnabled === false,
+            'the conflict winners and pending local edit must persist to shared localStorage'
+          );
+          assert(
+            reconciledLocal.mouseTrackingEnabled === false,
+            'server reconciliation must preserve local-only settings'
+          );
+          assert(
+            reconciledLocal._sharedWriteMeta.changedKeys.length === 0,
+            'server winners must not be advertised as new user intent'
+          );
           ctx.postCalls[2].resolve(response(
             true,
             200,
@@ -1500,10 +1557,104 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
           await tick();
         }
 
+        async function runSuccessfulPartialSnapshotScenario() {
+          const ctx = makeContext(true);
+          await tick();
+          await tick();
+          assert(ctx.S.settingsHydrated === false, 'failed boot GET stays unhydrated');
+
+          ctx.win.focusModeEnabled = true;
+          ctx.mod.saveSettings();
+          await tick();
+          assert(ctx.postCalls.length === 1, 'the first pending edit must POST');
+          const firstBody = JSON.parse(ctx.postCalls[0].opts.body);
+          assert(
+            Object.keys(firstBody).length === 1 && firstBody.focusModeEnabled === true,
+            'an unmerged view must send only its pending key, got: '
+              + JSON.stringify(firstBody)
+          );
+
+          // A later edit happens while the partial write is in flight. The
+          // successful response snapshot is authoritative for untouched keys,
+          // but must not overwrite this still-pending local value.
+          ctx.win.slopFilterEnabled = true;
+          ctx.mod.saveSettings();
+          assert(ctx.S.slopFilterEnabled === true, 'the in-flight edit updates shared state');
+          await tick();
+          assert(ctx.postCalls.length === 1, 'the later edit queues behind the first POST');
+
+          ctx.postCalls[0].resolve(response(
+            true,
+            200,
+            '"conversation-settings-1"',
+            {
+              success: true,
+              settings: {
+                independentAsrEnabled: true,
+                proactiveVisionEnabled: false,
+                slopFilterEnabled: false,
+                focusModeEnabled: true,
+              },
+              revision: 1,
+              decisions: {},
+            }
+          ));
+          await tick();
+          await tick();
+
+          assert(ctx.S.settingsHydrated === true, 'the complete success snapshot hydrates the view');
+          assert(
+            ctx.S.independentAsrEnabled === true,
+            'an untouched field hydrates from the successful partial-write response'
+          );
+          assert(
+            ctx.S.slopFilterEnabled === true,
+            'an edit made while the request was in flight remains pending'
+          );
+          assert(
+            ctx.runtime.stoppedSpeech === 1
+              && ctx.runtime.stoppedScreening === 1
+              && ctx.runtime.stoppedTracks === 1,
+            'hydrating the privacy winner stops active vision runtime'
+          );
+          assert(ctx.postCalls.length === 2, 'the queued edit runs after hydration');
+          const secondBody = JSON.parse(ctx.postCalls[1].opts.body);
+          assert(
+            secondBody.independentAsrEnabled === true
+              && secondBody.proactiveVisionEnabled === false
+              && secondBody.slopFilterEnabled === true,
+            'the queued retry uses the reconciled full snapshot plus the pending edit'
+          );
+          const reconciledLocal = JSON.parse(ctx.store.get('project_neko_settings'));
+          assert(
+            reconciledLocal.independentAsrEnabled === true
+              && reconciledLocal.proactiveVisionEnabled === false
+              && reconciledLocal.slopFilterEnabled === true,
+            'the reconciled success snapshot persists for offline restart'
+          );
+          assert(
+            reconciledLocal.mouseTrackingEnabled === false,
+            'success reconciliation preserves local-only settings'
+          );
+          ctx.postCalls[1].resolve(response(
+            true,
+            200,
+            '"conversation-settings-2"',
+            {
+              success: true,
+              settings: secondBody,
+              revision: 2,
+              decisions: {},
+            }
+          ));
+          await tick();
+        }
+
         async function main() {
           await runScenario(false);
           await runScenario(true);
           await runAcknowledgedDirtyScenario();
+          await runSuccessfulPartialSnapshotScenario();
           console.log('CAS_HARNESS_OK');
           process.exitCode = 0;
         }
@@ -1676,10 +1827,9 @@ def test_shared_settings_writes_carry_explicit_change_metadata():
         not in settings_source
     )
     assert settings_source.count("_writeSharedSettings(") == 3  # 1 def + 2 writes
-    assert (
-        "_writeSharedSettings(settings, _collectExplicitSharedKeys(settings));"
-        in settings_source
-    )
+    save_fn = _block_after(settings_source, "function saveSettings(options) {")
+    assert "serverMerged ? [] : _collectExplicitSharedKeys(settings)" in save_fn
+    assert "const serverMerged = !!(options && options.serverMerged);" in save_fn
     # The pre-hydration migration write is explicitly non-authoritative.
     assert "_writeSharedSettings(settings, []);" in settings_source
 
@@ -3192,7 +3342,8 @@ def test_asr_authority_is_per_key_not_granted_by_unrelated_setting_change():
     # S.independentAsrEnabled is still the boot default false at that moment, so
     # a global-only gate would let the next start_session stamp false over the
     # backend's persisted true. Authority for that one key must therefore be
-    # tracked separately and granted by exactly three events.
+    # tracked separately and granted only by explicit ASR edits/cross-window
+    # choices or an authoritative server snapshot.
     settings_source = APP_SETTINGS_PATH.read_text(encoding="utf-8")
 
     user_gate = _block_after(settings_source, "if (userInitiated) {")
@@ -3213,14 +3364,22 @@ def test_asr_authority_is_per_key_not_granted_by_unrelated_setting_change():
         "startPeriodicSync();", 1
     )[0]
 
-    # (2) A cross-window ASR flip grants authority, next to the dirty-key add.
+    # (2) A full snapshot from a successful partial POST or 412 grants the same
+    # server authority when the boot GET was unavailable.
+    snapshot_merge = _block_after(
+        settings_source, "function _mergeConversationSettingsSnapshot(data, preservedKeys) {"
+    )
+    assert "S.independentAsrAuthoritative = true;" in snapshot_merge
+
+    # (3) A cross-window ASR flip grants authority, next to the dirty-key add.
     cross_window = _block_after(
         settings_source, "_dirtySettingsKeys.add('independentAsrEnabled');"
     )
     assert "S.independentAsrAuthoritative = true;" in cross_window
 
-    # (3) Nothing else in the file grants it: exactly three assignment sites.
-    assert settings_source.count("S.independentAsrAuthoritative = true;") == 3
+    # No unrelated path grants it: exactly these four assignment sites (the
+    # conditional local-user gate plus the three authoritative sources above).
+    assert settings_source.count("S.independentAsrAuthoritative = true;") == 4
 
 
 def test_text_session_start_stops_an_active_microphone():

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -965,6 +965,9 @@ def test_cross_window_settings_posts_use_cas_and_persist_asr_decision_order():
     assert "headers['If-Match'] = _conversationSettingsEtag;" in sync_fn
     assert "response.status === 412" in sync_fn
     assert "const preservedKeys = new Set(_pendingSettingsKeys);" in sync_fn
+    assert "_conversationSettingsEtagMutationVersion" in sync_fn
+    assert "_crossWindowSettingsChangedSince(" in sync_fn
+    assert "etagMutationVersionAtSend" in sync_fn
     assert "_settingsChangedSince(settings, mutationVersionAtSend).forEach" in sync_fn
     assert "_mergeConversationSettingsSnapshot(data, preservedKeys);" in sync_fn
     assert "_CONVERSATION_SETTINGS_MAX_ATTEMPTS" in sync_fn
@@ -1560,6 +1563,25 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             'a delayed merge must not roll back a newer externally applied value'
           );
 
+          // This explicit edit arrives after the boot ETag but before the next
+          // CAS request starts. It is already present in that request snapshot,
+          // so mutationVersionAtSend alone cannot detect it later; the ETag's
+          // cross-window watermark must preserve it across the 412.
+          ctx.fireStorage(JSON.stringify({
+            avatarReactionBubbleEnabled: true,
+            _sharedWriteMeta: {
+              writeId: externalWriteId + 1,
+              writerId: 'window-c',
+              changedKeys: ['avatarReactionBubbleEnabled'],
+              hydrated: true,
+              asrAuthoritative: true,
+            },
+          }));
+          assert(
+            ctx.S.avatarReactionBubbleEnabled === true,
+            'the pre-request cross-window edit must be accepted locally'
+          );
+
           // A different local edit races a newer server revision. The earlier
           // slopFilterEnabled=true was already acknowledged and must no longer
           // be protected as pending during the 412 merge.
@@ -1644,6 +1666,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
                 slopFilterEnabled: false,
                 focusModeEnabled: false,
                 mergeMessagesEnabled: true,
+                avatarReactionBubbleEnabled: false,
               },
               revision: 2,
               decisions: {},
@@ -1666,6 +1689,10 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             'a non-pending ABA edit made after send must survive the conflict merge'
           );
           assert(
+            retryBody.avatarReactionBubbleEnabled === true,
+            'an explicit cross-window edit after the ETag but before send must survive'
+          );
+          assert(
             retryBody.proactiveVisionEnabled === false,
             'the retry must retain the server privacy winner'
           );
@@ -1680,7 +1707,8 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             reconciledLocal.slopFilterEnabled === false
               && reconciledLocal.focusModeEnabled === true
               && reconciledLocal.proactiveVisionEnabled === false
-              && reconciledLocal.mergeMessagesEnabled === false,
+              && reconciledLocal.mergeMessagesEnabled === false
+              && reconciledLocal.avatarReactionBubbleEnabled === true,
             'the conflict winners and pending local edit must persist to shared localStorage'
           );
           assert(
@@ -1710,6 +1738,20 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
           await tick();
           await tick();
           assert(ctx.S.settingsHydrated === false, 'failed boot GET stays unhydrated');
+
+          // A cross-window edit arrives before this partial request starts.
+          // It is not this window's pending key and therefore is absent from
+          // the dirty-only payload, but the success snapshot must not erase it.
+          ctx.fireStorage(JSON.stringify({
+            avatarReactionBubbleEnabled: true,
+            _sharedWriteMeta: {
+              writeId: 101,
+              writerId: 'window-b',
+              changedKeys: ['avatarReactionBubbleEnabled'],
+              hydrated: true,
+              asrAuthoritative: true,
+            },
+          }));
 
           ctx.win.focusModeEnabled = true;
           ctx.mod.saveSettings();
@@ -1758,6 +1800,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
                 focusModeEnabled: true,
                 mergeMessagesEnabled: true,
                 noiseReductionEnabled: true,
+                avatarReactionBubbleEnabled: false,
               },
               revision: 1,
               decisions: {},
@@ -1780,6 +1823,10 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             'a same-value explicit cross-window edit survives the delayed response'
           );
           assert(
+            ctx.S.avatarReactionBubbleEnabled === true,
+            'a pre-request cross-window edit absent from the partial body survives'
+          );
+          assert(
             ctx.store.get('neko_noise_reduction') === '1',
             'accepted shared noise reduction mirrors into the legacy cache'
           );
@@ -1796,7 +1843,8 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
               && secondBody.proactiveVisionEnabled === false
               && secondBody.slopFilterEnabled === true
               && secondBody.mergeMessagesEnabled === false
-              && secondBody.noiseReductionEnabled === true,
+              && secondBody.noiseReductionEnabled === true
+              && secondBody.avatarReactionBubbleEnabled === true,
             'the queued retry uses the reconciled full snapshot plus the pending edit'
           );
           const reconciledLocal = JSON.parse(ctx.store.get('project_neko_settings'));

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -949,7 +949,7 @@ def test_cross_window_settings_posts_use_cas_and_persist_asr_decision_order():
     assert "headers['If-Match'] = _conversationSettingsEtag;" in sync_fn
     assert "response.status === 412" in sync_fn
     assert "const preservedKeys = new Set(_pendingSettingsKeys);" in sync_fn
-    assert "_settingsChangedSince(settings).forEach" in sync_fn
+    assert "_settingsChangedSince(settings, mutationVersionAtSend).forEach" in sync_fn
     assert "_mergeConversationSettingsSnapshot(data, preservedKeys);" in sync_fn
     assert "_CONVERSATION_SETTINGS_MAX_ATTEMPTS" in sync_fn
     assert "headers['X-Conversation-Settings-ASR-Decision']" in sync_fn
@@ -1276,6 +1276,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
         const tick = () => new Promise((resolve) => setImmediate(resolve));
 
         function makeContext(bootFails) {
+          let storageListener = null;
           const runtime = {
             stoppedSpeech: 0,
             stoppedScreening: 0,
@@ -1287,6 +1288,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
               independentAsrEnabled: false,
               proactiveVisionEnabled: true,
               slopFilterEnabled: false,
+              mergeMessagesEnabled: false,
               mouseTrackingEnabled: false,
             })],
           ]);
@@ -1332,6 +1334,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
               independentAsrEnabled: false,
               proactiveVisionEnabled: true,
               slopFilterEnabled: false,
+              mergeMessagesEnabled: false,
               focusModeEnabled: false,
               settingsHydrated: false,
               screenCaptureStream: {
@@ -1348,7 +1351,9 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             stopProactiveVisionDuringSpeech() { runtime.stoppedSpeech += 1; },
             stopScreening() { runtime.stoppedScreening += 1; },
             scheduleProactiveChat() { runtime.scheduled += 1; },
-            addEventListener() {},
+            addEventListener(type, listener) {
+              if (type === 'storage') storageListener = listener;
+            },
             removeEventListener() {},
           };
           vm.createContext(sandbox);
@@ -1360,6 +1365,9 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             postCalls,
             store,
             runtime,
+            fireStorage(newValue) {
+              storageListener({ key: 'project_neko_settings', newValue });
+            },
           };
         }
 
@@ -1493,11 +1501,27 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
           await tick();
           assert(ctx.postCalls.length === 2, 'the unrelated edit must POST');
 
-          // A cross-window storage update can change local state without
-          // entering this window's pending-key set. It still happened after
-          // the request snapshot and must survive the 412 reconciliation.
-          ctx.win.mergeMessagesEnabled = true;
-          ctx.S.mergeMessagesEnabled = true;
+          // Cross-window ABA edits do not enter this window's pending set and
+          // leave the final value equal to the request snapshot. The mutation
+          // itself must still protect the latest choice from the 412 snapshot.
+          ctx.fireStorage(JSON.stringify({
+            mergeMessagesEnabled: true,
+            _sharedWriteMeta: {
+              writeId: 100,
+              writerId: 'window-b',
+              changedKeys: ['mergeMessagesEnabled'],
+              hydrated: true,
+            },
+          }));
+          ctx.fireStorage(JSON.stringify({
+            mergeMessagesEnabled: false,
+            _sharedWriteMeta: {
+              writeId: 101,
+              writerId: 'window-b',
+              changedKeys: ['mergeMessagesEnabled'],
+              hydrated: true,
+            },
+          }));
           ctx.postCalls[1].resolve(response(
             false,
             412,
@@ -1509,7 +1533,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
                 proactiveVisionEnabled: false,
                 slopFilterEnabled: false,
                 focusModeEnabled: false,
-                mergeMessagesEnabled: false,
+                mergeMessagesEnabled: true,
               },
               revision: 2,
               decisions: {},
@@ -1528,8 +1552,8 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             'the still-pending local edit must survive the conflict merge'
           );
           assert(
-            retryBody.mergeMessagesEnabled === true,
-            'a non-pending edit made after send must survive the conflict merge'
+            retryBody.mergeMessagesEnabled === false,
+            'a non-pending ABA edit made after send must survive the conflict merge'
           );
           assert(
             retryBody.proactiveVisionEnabled === false,
@@ -1546,7 +1570,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             reconciledLocal.slopFilterEnabled === false
               && reconciledLocal.focusModeEnabled === true
               && reconciledLocal.proactiveVisionEnabled === false
-              && reconciledLocal.mergeMessagesEnabled === true,
+              && reconciledLocal.mergeMessagesEnabled === false,
             'the conflict winners and pending local edit must persist to shared localStorage'
           );
           assert(

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -2002,15 +2002,17 @@ def test_shared_settings_writes_carry_explicit_change_metadata():
     save_fn = _block_after(settings_source, "function saveSettings(options) {")
     assert "serverMerged ? [] : _collectExplicitSharedKeys(settings)" in save_fn
     assert "const serverMerged = !!(options && options.serverMerged);" in save_fn
+    assert "const pendingRecovery = !!(options && options.pendingRecovery);" in save_fn
     # The pre-hydration migration write is explicitly non-authoritative.
     assert "_writeSharedSettings(settings, []);" in settings_source
 
-    write_fn = settings_source.split("function _writeSharedSettings(snapshot, explicitKeys) {", 1)[
-        1
-    ].split("\n    }", 1)[0]
+    write_fn = settings_source.split(
+        "function _writeSharedSettings(snapshot, explicitKeys, pendingRecovery) {", 1
+    )[1].split("\n    }", 1)[0]
     assert "writeId: _nextSharedWriteId()," in write_fn
     assert "changedKeys: explicitKeys || []," in write_fn
     assert "hydrated: S.settingsHydrated === true" in write_fn
+    assert "pendingRecovery: pendingRecovery === true" in write_fn
     assert "localStorage.setItem('project_neko_settings', JSON.stringify(payload));" in write_fn
 
     # The write id must be strictly increasing within a window and comparable
@@ -2112,12 +2114,13 @@ def test_unrelated_save_from_unhydrated_window_is_not_an_asr_toggle_harness():
           if (!cond) throw new Error('ASSERT: ' + msg);
         }
 
-        function makeContext() {
+        function makeContext(initialSettings) {
           const postCalls = [];
           const getCalls = [];
           const listeners = [];
           const timers = [];
           const writes = [];
+          let savedShared = initialSettings ? JSON.stringify(initialSettings) : null;
           const sandbox = {
             console: { log() {}, warn() {}, error() {} },
             setInterval() { return 0; },
@@ -2129,8 +2132,13 @@ def test_unrelated_save_from_unhydrated_window_is_not_an_asr_toggle_harness():
             },
             clearTimeout() {},
             localStorage: {
-              getItem() { return null; },
-              setItem(key, value) { writes.push({ key, value }); },
+              getItem(key) {
+                return key === 'project_neko_settings' ? savedShared : null;
+              },
+              setItem(key, value) {
+                if (key === 'project_neko_settings') savedShared = value;
+                writes.push({ key, value });
+              },
               removeItem() {},
             },
             document: { getElementById() { return null; } },
@@ -2162,6 +2170,9 @@ def test_unrelated_save_from_unhydrated_window_is_not_an_asr_toggle_harness():
             S: sandbox.window.appState,
             win: sandbox.window,
             mod: sandbox.window.appSettings,
+            sharedWrites() {
+              return writes.filter((w) => w.key === 'project_neko_settings');
+            },
             lastSharedWrite() {
               const shared = writes.filter((w) => w.key === 'project_neko_settings');
               assert(shared.length > 0, 'the module must persist the shared settings snapshot');
@@ -2369,6 +2380,79 @@ def test_unrelated_save_from_unhydrated_window_is_not_an_asr_toggle_harness():
           assert(
             JSON.stringify(resharedMeta.asrDecision) === JSON.stringify(serverDecision),
             'an unrelated save must retain the accepted server decision tuple'
+          );
+
+          // ---- Scenario 7: a persisted server-merge tuple survives reload.
+          // changedKeys is intentionally empty because this is authority from
+          // the server, not a new browser user action.
+          const bootDecision = {
+            writeId: Date.now() + 1000,
+            writerId: 'server-ahead',
+            value: false,
+          };
+          const reloaded = makeContext({
+            independentAsrEnabled: false,
+            _sharedWriteMeta: {
+              writeId: bootDecision.writeId - 1,
+              writerId: 'merging-window',
+              changedKeys: [],
+              hydrated: true,
+              asrAuthoritative: true,
+              asrDecision: bootDecision,
+            },
+          });
+          reloaded.win.mergeMessagesEnabled = true;
+          reloaded.mod.saveSettings({ skipServerSync: true });
+          const afterReloadMeta = JSON.parse(reloaded.lastSharedWrite())._sharedWriteMeta;
+          assert(
+            JSON.stringify(afterReloadMeta.asrDecision) === JSON.stringify(bootDecision),
+            'reload must restore and retain a matching server-merge ASR tuple'
+          );
+          reloaded.S.independentAsrEnabled = true;
+          reloaded.mod.saveSettings({ skipServerSync: true });
+          const nextLocalDecision = JSON.parse(
+            reloaded.lastSharedWrite()
+          )._sharedWriteMeta.asrDecision;
+          assert(
+            nextLocalDecision.writeId > bootDecision.writeId,
+            'the first local toggle after reload must supersede the persisted server tuple'
+          );
+
+          // ---- Scenario 8: pending recovery writes terminate instead of
+          // bouncing between two windows with different pending keys.
+          const pendingA = makeContext();
+          pendingA.win.focusModeEnabled = true;
+          pendingA.mod.saveSettings();
+          const pendingAPayload = pendingA.lastSharedWrite();
+
+          const pendingB = makeContext({
+            independentAsrEnabled: false,
+            focusModeEnabled: false,
+          });
+          pendingB.win.mergeMessagesEnabled = true;
+          pendingB.mod.saveSettings();
+          const pendingBPayload = pendingB.lastSharedWrite();
+
+          pendingA.fireStorage(pendingBPayload);
+          const recoveryPayload = pendingA.lastSharedWrite();
+          const recoveryMeta = JSON.parse(recoveryPayload)._sharedWriteMeta;
+          assert(
+            recoveryMeta.pendingRecovery === true,
+            'the reasserted full snapshot must be marked as pending recovery'
+          );
+          const writesBeforeRecovery = pendingB.sharedWrites().length;
+          pendingB.fireStorage(recoveryPayload);
+          assert(
+            pendingB.sharedWrites().length === writesBeforeRecovery,
+            'a pending window must not answer a recovery with another recovery write'
+          );
+          assert(
+            pendingB.S.mergeMessagesEnabled === true,
+            'the receiving window must still preserve its pending runtime value'
+          );
+          assert(
+            JSON.parse(pendingAPayload)._sharedWriteMeta.pendingRecovery !== true,
+            'ordinary user writes must not be marked as recovery'
           );
 
           console.log('HARNESS_OK');
@@ -3956,7 +4040,8 @@ def test_asr_decision_tuple_survives_unrelated_saves():
 
     # The write carries the id of the decision that produced the value...
     write_fn = _block_after(
-        settings_source, "function _writeSharedSettings(snapshot, explicitKeys) {"
+        settings_source,
+        "function _writeSharedSettings(snapshot, explicitKeys, pendingRecovery) {",
     )
     assert "ownMeta.asrDecision = {" in write_fn
     assert "_lastAsrDecision.value === snapshot.independentAsrEnabled" in write_fn

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -1518,6 +1518,25 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
           await tick();
           assert(ctx.postCalls.length === 2, 'the unrelated edit must POST');
 
+          // A sibling's unrelated explicit edit still carries a full snapshot.
+          // Its incidental copy of this window's pending key must not replace
+          // the pending value merely because changedKeys is nonempty.
+          ctx.fireStorage(JSON.stringify({
+            focusModeEnabled: false,
+            mergeMessagesEnabled: true,
+            _sharedWriteMeta: {
+              writeId: 98,
+              writerId: 'window-b',
+              changedKeys: ['mergeMessagesEnabled'],
+              hydrated: true,
+              asrAuthoritative: true,
+            },
+          }));
+          assert(
+            ctx.S.focusModeEnabled === true && ctx.S.mergeMessagesEnabled === true,
+            'a nonempty explicit broadcast preserves unrelated pending keys'
+          );
+
           // A server-merge broadcast may have been built before this pending
           // edit. It must neither overwrite the local value nor leave its
           // stale full snapshot in shared localStorage.
@@ -1662,6 +1681,20 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
           await tick();
           assert(ctx.postCalls.length === 1, 'the later edit queues behind the first POST');
 
+          // The other window explicitly chooses the value this stale local
+          // view already holds. The metadata still represents a newer user
+          // mutation and must protect the key from the delayed response.
+          ctx.fireStorage(JSON.stringify({
+            mergeMessagesEnabled: false,
+            _sharedWriteMeta: {
+              writeId: 102,
+              writerId: 'window-b',
+              changedKeys: ['mergeMessagesEnabled'],
+              hydrated: true,
+              asrAuthoritative: true,
+            },
+          }));
+
           ctx.postCalls[0].resolve(response(
             true,
             200,
@@ -1673,6 +1706,8 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
                 proactiveVisionEnabled: false,
                 slopFilterEnabled: false,
                 focusModeEnabled: true,
+                mergeMessagesEnabled: true,
+                noiseReductionEnabled: true,
               },
               revision: 1,
               decisions: {},
@@ -1691,6 +1726,14 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             'an edit made while the request was in flight remains pending'
           );
           assert(
+            ctx.S.mergeMessagesEnabled === false,
+            'a same-value explicit cross-window edit survives the delayed response'
+          );
+          assert(
+            ctx.store.get('neko_noise_reduction') === '1',
+            'accepted shared noise reduction mirrors into the legacy cache'
+          );
+          assert(
             ctx.runtime.stoppedSpeech === 1
               && ctx.runtime.stoppedScreening === 1
               && ctx.runtime.stoppedTracks === 1,
@@ -1701,7 +1744,9 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
           assert(
             secondBody.independentAsrEnabled === true
               && secondBody.proactiveVisionEnabled === false
-              && secondBody.slopFilterEnabled === true,
+              && secondBody.slopFilterEnabled === true
+              && secondBody.mergeMessagesEnabled === false
+              && secondBody.noiseReductionEnabled === true,
             'the queued retry uses the reconciled full snapshot plus the pending edit'
           );
           const reconciledLocal = JSON.parse(ctx.store.get('project_neko_settings'));
@@ -1952,7 +1997,11 @@ def test_shared_settings_writes_carry_explicit_change_metadata():
         "\n    }", 1
     )[0]
     assert "if (!meta || typeof meta !== 'object') return null;" in read_fn
-    assert "!Number.isSafeInteger(meta.writeId)" in read_fn
+    assert "if (!_isValidAsrWriteId(meta.writeId)) return null;" in read_fn
+    id_validator = _block_after(settings_source, "function _isValidAsrWriteId(value) {")
+    assert "Number.isSafeInteger(value)" in id_validator
+    assert "Date.now() + _ASR_WRITE_ID_MAX_FUTURE_SKEW_MS" in id_validator
+    assert "Number.MAX_SAFE_INTEGER - 1" in id_validator
     assert "Array.isArray(meta.changedKeys) ? meta.changedKeys : []" in read_fn
 
     listener_block = settings_source.split(
@@ -3867,7 +3916,7 @@ def test_asr_decision_tuple_survives_unrelated_saves():
     # ...the reader parses it defensively, falling back to today's behaviour...
     read_fn = _block_after(settings_source, "function _readSharedWriteMeta(settings) {")
     assert "asrDecision:" in read_fn
-    assert "Number.isSafeInteger(meta.asrDecision.writeId)" in read_fn
+    assert "_isValidAsrWriteId(meta.asrDecision.writeId)" in read_fn
 
     # ...and both the boot seed and the adopted cross-window flip record the
     # ORIGINAL id, or this window re-inflates the value on its own next save.

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -2198,6 +2198,41 @@ def test_unrelated_save_from_unhydrated_window_is_not_an_asr_toggle_harness():
           );
           assert(legacy.postCalls.length === 0, 'legacy fallback still never POSTs from the listener');
 
+          // ---- Scenario 6: an authoritative server-merge broadcast updates
+          // the decision tuple even though changedKeys is intentionally empty.
+          const sibling = makeContext();
+          await hydrateFromServer(sibling, { independentAsrEnabled: false });
+          sibling.S.independentAsrEnabled = true;
+          sibling.mod.saveSettings({ skipServerSync: true });
+          const localToggleMeta = JSON.parse(sibling.lastSharedWrite())._sharedWriteMeta;
+          const serverDecision = {
+            writeId: localToggleMeta.asrDecision.writeId + 10,
+            writerId: 'server-legacy',
+            value: false,
+          };
+          sibling.fireStorage(JSON.stringify({
+            independentAsrEnabled: false,
+            _sharedWriteMeta: {
+              writeId: serverDecision.writeId,
+              writerId: 'server-window',
+              changedKeys: [],
+              hydrated: true,
+              asrAuthoritative: true,
+              asrDecision: serverDecision,
+            },
+          }));
+          assert(
+            sibling.S.independentAsrEnabled === false,
+            'the authoritative server broadcast must replace the old local toggle'
+          );
+          sibling.win.mergeMessagesEnabled = true;
+          sibling.mod.saveSettings({ skipServerSync: true });
+          const resharedMeta = JSON.parse(sibling.lastSharedWrite())._sharedWriteMeta;
+          assert(
+            JSON.stringify(resharedMeta.asrDecision) === JSON.stringify(serverDecision),
+            'an unrelated save must retain the accepted server decision tuple'
+          );
+
           console.log('HARNESS_OK');
           // Every sandbox timer is harness-controlled, so the process exits
           // naturally once main() returns and piped stdout is fully flushed.

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -1361,7 +1361,12 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
         }
         const tick = () => new Promise((resolve) => setImmediate(resolve));
 
-        function makeContext(bootFails, bootData) {
+        function makeContext(
+          bootFails,
+          bootData,
+          initialProjectSettings,
+          failSharedStorageWrites
+        ) {
           let storageListener = null;
           const runtime = {
             stoppedSpeech: 0,
@@ -1370,7 +1375,7 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             scheduled: 0,
           };
           const store = new Map([
-            ['project_neko_settings', JSON.stringify({
+            ['project_neko_settings', JSON.stringify(initialProjectSettings || {
               independentAsrEnabled: false,
               proactiveVisionEnabled: true,
               slopFilterEnabled: false,
@@ -1392,7 +1397,12 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             clearTimeout,
             localStorage: {
               getItem(key) { return store.has(key) ? store.get(key) : null; },
-              setItem(key, value) { store.set(key, String(value)); },
+              setItem(key, value) {
+                if (failSharedStorageWrites && key === 'project_neko_settings') {
+                  throw new Error('shared localStorage unavailable');
+                }
+                store.set(key, String(value));
+              },
               removeItem(key) { store.delete(key); },
             },
             document: { getElementById() { return null; } },
@@ -1716,6 +1726,38 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             serverBroadcaster.S.proactiveVisionEnabled === false,
             'the broadcasting window must retain its own server-authority floor'
           );
+          assert(
+            serverSnapshot._sharedWriteMeta.knownKeyWrites
+              .proactiveVisionEnabled.confirmedRevision === 2,
+            'the server-authority floor must be serialized for reloads'
+          );
+          const reloadedServerWinner = makeContext(
+            true,
+            null,
+            serverSnapshot
+          );
+          await tick();
+          await tick();
+          reloadedServerWinner.fireStorage(JSON.stringify({
+            proactiveVisionEnabled: true,
+            _sharedWriteMeta: {
+              writeId: 1,
+              writerId: 'window-old-after-reload',
+              changedKeys: ['proactiveVisionEnabled'],
+              hydrated: true,
+              asrAuthoritative: true,
+              knownKeyWrites: {
+                proactiveVisionEnabled: {
+                  writeId: 1,
+                  writerId: 'window-old-after-reload',
+                },
+              },
+            },
+          }));
+          assert(
+            reloadedServerWinner.S.proactiveVisionEnabled === false,
+            'reload must reconstruct the server floor before its boot GET succeeds'
+          );
 
           const receiver = makeContext(true);
           await tick();
@@ -1791,6 +1833,91 @@ def test_settings_cas_conflict_rebuilds_body_from_winning_asr_decision_harness()
             receiver.S.proactiveVisionEnabled === true,
             'a genuinely newer explicit event must still supersede the server floor'
           );
+
+          const subtitleReceiver = makeContext(true);
+          await tick();
+          await tick();
+          subtitleReceiver.fireStorage(JSON.stringify({
+            subtitleEnabled: false,
+            userLanguage: null,
+            _sharedWriteMeta: {
+              writeId: 700,
+              writerId: 'window-subtitle-editor',
+              changedKeys: ['subtitleEnabled', 'userLanguage'],
+              hydrated: true,
+              asrAuthoritative: false,
+              knownKeyWrites: {
+                subtitleEnabled: {
+                  writeId: 700,
+                  writerId: 'window-subtitle-editor',
+                },
+                userLanguage: {
+                  writeId: 700,
+                  writerId: 'window-subtitle-editor',
+                },
+              },
+            },
+          }));
+          subtitleReceiver.fireStorage(JSON.stringify({
+            subtitleEnabled: true,
+            userLanguage: 'ja',
+            _sharedWriteMeta: {
+              writeId: 800,
+              writerId: 'window-stale-server-reader',
+              changedKeys: [],
+              hydrated: true,
+              asrAuthoritative: false,
+              serverRevision: 1,
+              serverAuthoritativeKeys: [
+                'subtitleEnabled',
+                'userLanguage',
+              ],
+              knownKeyWrites: {},
+            },
+          }));
+          assert(
+            subtitleReceiver.S.subtitleEnabled === false
+              && subtitleReceiver.S.userLanguage === null,
+            'same-value subtitle intent must enter per-key ordering and survive '
+              + 'a delayed stale server merge'
+          );
+
+          const noSharedStorage = makeContext(
+            false,
+            {
+              success: true,
+              settings: {},
+              revision: 0,
+              telemetryBranch: null,
+              decisions: {},
+            },
+            null,
+            true
+          );
+          await tick();
+          await tick();
+          noSharedStorage.S.noiseReductionEnabled = false;
+          noSharedStorage.mod.saveSettings();
+          await tick();
+          await tick();
+          assert(
+            noSharedStorage.postCalls.length === 1
+              && JSON.parse(
+                noSharedStorage.postCalls[0].opts.body
+              ).noiseReductionEnabled === false,
+            'a failed shared localStorage write must not suppress the noise CAS POST'
+          );
+          noSharedStorage.postCalls[0].resolve(response(
+            true,
+            200,
+            '"conversation-settings-1"',
+            {
+              success: true,
+              settings: { noiseReductionEnabled: false },
+              revision: 1,
+              decisions: {},
+            }
+          ));
 
           const staleReceiver = makeContext(false, {
             success: true,

--- a/tests/unit/test_preferences_concurrency.py
+++ b/tests/unit/test_preferences_concurrency.py
@@ -1,5 +1,7 @@
+import asyncio
 import json
 import threading
+from types import SimpleNamespace
 
 import pytest
 from fastapi import Response
@@ -7,6 +9,8 @@ from fastapi import Response
 from main_routers.config_router import preferences as preferences_router
 from utils import preferences
 from utils import token_tracker
+from utils.cloudsave_runtime import bindings as cloudsave_bindings
+from tests.fake_clock import patch_module_clock
 
 
 class _FakeConfigManager:
@@ -381,3 +385,114 @@ async def test_conversation_settings_route_validates_contract_and_keeps_legacy_w
     assert legacy_write.status_code == 200
     payload = json.loads(legacy_write.body)
     assert payload["settings"]["focusModeEnabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_noise_reduction_runtime_updates_follow_persisted_revision(monkeypatch):
+    current = SimpleNamespace(
+        revision=1,
+        settings={"noiseReductionEnabled": True},
+    )
+    old_apply_started = asyncio.Event()
+    allow_old_apply = asyncio.Event()
+    calls = []
+
+    async def fake_snapshot():
+        return current
+
+    async def fake_apply(enabled):
+        calls.append(("start", enabled))
+        if enabled:
+            old_apply_started.set()
+            await allow_old_apply.wait()
+        calls.append(("end", enabled))
+
+    monkeypatch.setattr(
+        preferences_router,
+        "_NOISE_REDUCTION_APPLY_LOCK",
+        asyncio.Lock(),
+    )
+    monkeypatch.setattr(
+        preferences_router,
+        "aload_global_conversation_settings_snapshot",
+        fake_snapshot,
+    )
+    monkeypatch.setattr(
+        preferences_router,
+        "_apply_noise_reduction_to_active_sessions",
+        fake_apply,
+    )
+
+    old_apply = asyncio.create_task(
+        preferences_router._apply_noise_reduction_if_current(True, 1)
+    )
+    await old_apply_started.wait()
+    current = SimpleNamespace(
+        revision=2,
+        settings={"noiseReductionEnabled": False},
+    )
+    new_apply = asyncio.create_task(
+        preferences_router._apply_noise_reduction_if_current(False, 2)
+    )
+    await asyncio.sleep(0)
+    assert calls == [("start", True)]
+
+    allow_old_apply.set()
+    await asyncio.gather(old_apply, new_apply)
+    assert calls == [
+        ("start", True),
+        ("end", True),
+        ("start", False),
+        ("end", False),
+    ]
+
+    await preferences_router._apply_noise_reduction_if_current(True, 1)
+    assert calls[-1] == ("end", False)
+
+
+def test_cloud_restore_rebases_asr_decision_and_revision(monkeypatch, tmp_path):
+    path = tmp_path / "user_preferences.json"
+    path.write_text(
+        json.dumps(
+            [
+                {
+                    "model_path": preferences.GLOBAL_CONVERSATION_KEY,
+                    "independentAsrEnabled": True,
+                    "_conversation_settings_revision": 9,
+                    "_independent_asr_decision": {
+                        "writeId": 200,
+                        "writerId": "window-before-restore",
+                        "value": True,
+                    },
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    manager = _FakeConfigManager(path)
+    patch_module_clock(
+        monkeypatch,
+        cloudsave_bindings,
+        time_ns=lambda: 150_000_000,
+    )
+
+    payload = cloudsave_bindings._build_runtime_preferences_payload(
+        manager,
+        {
+            "independentAsrEnabled": False,
+            "_conversation_settings_revision": 2,
+        },
+    )
+    restored = next(
+        entry
+        for entry in payload
+        if entry.get("model_path") == preferences.GLOBAL_CONVERSATION_KEY
+    )
+
+    assert restored["independentAsrEnabled"] is False
+    assert restored["_conversation_settings_revision"] == 10
+    assert restored["_independent_asr_decision"] == {
+        "writeId": 201,
+        "writerId": "server-cloud-restore",
+        "value": False,
+    }

--- a/tests/unit/test_preferences_concurrency.py
+++ b/tests/unit/test_preferences_concurrency.py
@@ -202,18 +202,26 @@ def test_model_update_and_conversation_write_share_one_rmw_lock(monkeypatch, tmp
 
 
 class _Request:
-    def __init__(self, body, if_match=None, asr_decision=None):
+    def __init__(
+        self,
+        body,
+        if_match=None,
+        asr_decision=None,
+        raw_asr_decision=None,
+    ):
         self._body = body
         self.headers = {}
         if if_match is not None:
             self.headers["if-match"] = if_match
-        if asr_decision is not None:
+        if raw_asr_decision is not None:
+            self.headers["x-conversation-settings-asr-decision"] = raw_asr_decision
+        elif asr_decision is not None:
             self.headers["x-conversation-settings-asr-decision"] = json.dumps(
                 asr_decision
             )
 
     async def json(self):
-        return dict(self._body)
+        return dict(self._body) if isinstance(self._body, dict) else self._body
 
 
 @pytest.mark.asyncio
@@ -280,3 +288,36 @@ async def test_set_preferred_model_offloads_locked_write(monkeypatch):
     assert result["success"] is True
     assert calls[0] == ("to_thread", fake_move_model_to_top, ("model-a",))
     assert calls[1] == ("move", "model-a")
+
+
+@pytest.mark.asyncio
+async def test_conversation_settings_route_validates_contract_and_keeps_legacy_write(
+    monkeypatch,
+    tmp_path,
+):
+    _use_preferences_file(monkeypatch, tmp_path)
+
+    non_object = await preferences_router.save_conversation_settings(
+        _Request(["not", "an", "object"])
+    )
+    assert non_object.status_code == 400
+
+    malformed_if_match = await preferences_router.save_conversation_settings(
+        _Request({"focusModeEnabled": True}, if_match='"wrong-etag"')
+    )
+    assert malformed_if_match.status_code == 400
+
+    malformed_decision = await preferences_router.save_conversation_settings(
+        _Request(
+            {"independentAsrEnabled": True},
+            raw_asr_decision="{not-json",
+        )
+    )
+    assert malformed_decision.status_code == 400
+
+    legacy_write = await preferences_router.save_conversation_settings(
+        _Request({"focusModeEnabled": True})
+    )
+    assert legacy_write.status_code == 200
+    payload = json.loads(legacy_write.body)
+    assert payload["settings"]["focusModeEnabled"] is True

--- a/tests/unit/test_preferences_concurrency.py
+++ b/tests/unit/test_preferences_concurrency.py
@@ -1,0 +1,258 @@
+import json
+import threading
+
+import pytest
+from fastapi import Response
+
+from main_routers.config_router import preferences as preferences_router
+from utils import preferences
+from utils import token_tracker
+
+
+class _FakeConfigManager:
+    def __init__(self, path):
+        self.path = path
+
+    def ensure_config_directory(self):
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def get_runtime_config_path(self, _name):
+        return self.path
+
+    def get_config_path(self, _name):
+        return self.path
+
+
+def _use_preferences_file(monkeypatch, tmp_path, initial=None):
+    path = tmp_path / "user_preferences.json"
+    path.write_text(json.dumps(initial or []), encoding="utf-8")
+    manager = _FakeConfigManager(path)
+    monkeypatch.setattr(preferences, "_config_manager", manager)
+    monkeypatch.setattr(preferences, "PREFERENCES_FILE", str(path))
+    monkeypatch.setattr(
+        preferences,
+        "assert_cloudsave_writable",
+        lambda *_args, **_kwargs: None,
+    )
+    return path
+
+
+def test_versioned_save_rejects_stale_revision_and_asr_decision(monkeypatch, tmp_path):
+    _use_preferences_file(monkeypatch, tmp_path)
+
+    newer = {
+        "writeId": 20,
+        "writerId": "window-b",
+        "value": True,
+    }
+    first = preferences.save_global_conversation_settings_versioned(
+        {"independentAsrEnabled": True},
+        expected_revision=0,
+        asr_decision=newer,
+    )
+    assert first.success is True
+    assert first.snapshot.revision == 1
+
+    stale_revision = preferences.save_global_conversation_settings_versioned(
+        {"focusModeEnabled": True},
+        expected_revision=0,
+    )
+    assert stale_revision.conflict is True
+    assert stale_revision.snapshot.settings["independentAsrEnabled"] is True
+
+    stale_decision = preferences.save_global_conversation_settings_versioned(
+        {"independentAsrEnabled": False},
+        expected_revision=1,
+        asr_decision={
+            "writeId": 10,
+            "writerId": "window-a",
+            "value": False,
+        },
+    )
+    assert stale_decision.conflict is True
+    assert stale_decision.snapshot.settings["independentAsrEnabled"] is True
+    assert stale_decision.snapshot.asr_decision == newer
+
+
+def test_locked_partial_writes_preserve_both_concurrent_changes(monkeypatch, tmp_path):
+    path = _use_preferences_file(
+        monkeypatch,
+        tmp_path,
+        [
+            {
+                "model_path": preferences.GLOBAL_CONVERSATION_KEY,
+                "focusModeEnabled": False,
+                "subtitleEnabled": False,
+            }
+        ],
+    )
+    original_atomic_write = preferences.atomic_write_json
+    first_at_write = threading.Event()
+    allow_first_write = threading.Event()
+    second_at_write = threading.Event()
+
+    def controlled_atomic_write(target, data, **kwargs):
+        if threading.current_thread().name == "first-writer":
+            first_at_write.set()
+            assert allow_first_write.wait(5)
+        else:
+            second_at_write.set()
+        original_atomic_write(target, data, **kwargs)
+
+    monkeypatch.setattr(preferences, "atomic_write_json", controlled_atomic_write)
+    results = []
+
+    first = threading.Thread(
+        name="first-writer",
+        target=lambda: results.append(
+            preferences.save_global_conversation_settings({"focusModeEnabled": True})
+        ),
+    )
+    second = threading.Thread(
+        name="second-writer",
+        target=lambda: results.append(
+            preferences.save_global_conversation_settings({"subtitleEnabled": True})
+        ),
+    )
+    first.start()
+    assert first_at_write.wait(5)
+    second.start()
+    assert second_at_write.wait(0.1) is False
+    allow_first_write.set()
+    first.join(5)
+    second.join(5)
+
+    assert sorted(results) == [True, True]
+    saved = json.loads(path.read_text(encoding="utf-8"))
+    global_entry = next(
+        entry
+        for entry in saved
+        if entry.get("model_path") == preferences.GLOBAL_CONVERSATION_KEY
+    )
+    assert global_entry["focusModeEnabled"] is True
+    assert global_entry["subtitleEnabled"] is True
+    assert global_entry["_conversation_settings_revision"] == 2
+
+
+def test_model_update_and_conversation_write_share_one_rmw_lock(monkeypatch, tmp_path):
+    path = _use_preferences_file(
+        monkeypatch,
+        tmp_path,
+        [
+            {
+                "model_path": "model-a",
+                "position": {"x": 0, "y": 0},
+                "scale": {"x": 1, "y": 1},
+            },
+            {
+                "model_path": preferences.GLOBAL_CONVERSATION_KEY,
+                "focusModeEnabled": False,
+            },
+        ],
+    )
+    original_atomic_write = preferences.atomic_write_json
+    model_at_write = threading.Event()
+    allow_model_write = threading.Event()
+    conversation_at_write = threading.Event()
+
+    def controlled_atomic_write(target, data, **kwargs):
+        if threading.current_thread().name == "model-writer":
+            model_at_write.set()
+            assert allow_model_write.wait(5)
+        else:
+            conversation_at_write.set()
+        original_atomic_write(target, data, **kwargs)
+
+    monkeypatch.setattr(preferences, "atomic_write_json", controlled_atomic_write)
+    results = []
+    model_writer = threading.Thread(
+        name="model-writer",
+        target=lambda: results.append(
+            preferences.update_model_preferences(
+                "model-a",
+                {"x": 5, "y": 6},
+                {"x": 2, "y": 2},
+            )
+        ),
+    )
+    conversation_writer = threading.Thread(
+        name="conversation-writer",
+        target=lambda: results.append(
+            preferences.save_global_conversation_settings({"focusModeEnabled": True})
+        ),
+    )
+    model_writer.start()
+    assert model_at_write.wait(5)
+    conversation_writer.start()
+    assert conversation_at_write.wait(0.1) is False
+    allow_model_write.set()
+    model_writer.join(5)
+    conversation_writer.join(5)
+
+    assert sorted(results) == [True, True]
+    saved = json.loads(path.read_text(encoding="utf-8"))
+    model_entry = next(entry for entry in saved if entry.get("model_path") == "model-a")
+    global_entry = next(
+        entry
+        for entry in saved
+        if entry.get("model_path") == preferences.GLOBAL_CONVERSATION_KEY
+    )
+    assert model_entry["position"] == {"x": 5, "y": 6}
+    assert global_entry["focusModeEnabled"] is True
+
+
+class _Request:
+    def __init__(self, body, if_match=None, asr_decision=None):
+        self._body = body
+        self.headers = {}
+        if if_match is not None:
+            self.headers["if-match"] = if_match
+        if asr_decision is not None:
+            self.headers["x-conversation-settings-asr-decision"] = json.dumps(
+                asr_decision
+            )
+
+    async def json(self):
+        return dict(self._body)
+
+
+@pytest.mark.asyncio
+async def test_conversation_settings_route_returns_etag_and_412_snapshot(
+    monkeypatch,
+    tmp_path,
+):
+    _use_preferences_file(monkeypatch, tmp_path)
+    first_response = await preferences_router.save_conversation_settings(
+        _Request(
+            {"independentAsrEnabled": True},
+            if_match='"conversation-settings-0"',
+            asr_decision={
+                "writeId": 20,
+                "writerId": "window-b",
+                "value": True,
+            },
+        )
+    )
+    assert first_response.status_code == 200
+    assert first_response.headers["etag"] == '"conversation-settings-1"'
+    assert first_response.headers["cache-control"] == "no-store"
+
+    monkeypatch.setattr(token_tracker, "get_telemetry_branch", lambda: "main")
+    get_response = Response()
+    get_payload = await preferences_router.get_conversation_settings(get_response)
+    assert get_response.headers["etag"] == '"conversation-settings-1"'
+    assert get_response.headers["cache-control"] == "no-store"
+    assert get_payload["revision"] == 1
+    assert get_payload["settings"]["independentAsrEnabled"] is True
+
+    conflict_response = await preferences_router.save_conversation_settings(
+        _Request(
+            {"independentAsrEnabled": False},
+            if_match='"conversation-settings-0"',
+        )
+    )
+    assert conflict_response.status_code == 412
+    assert conflict_response.headers["etag"] == '"conversation-settings-1"'
+    payload = json.loads(conflict_response.body)
+    assert payload["settings"]["independentAsrEnabled"] is True
+    assert payload["decisions"]["independentAsrEnabled"]["writeId"] == 20

--- a/tests/unit/test_preferences_concurrency.py
+++ b/tests/unit/test_preferences_concurrency.py
@@ -452,6 +452,18 @@ async def test_conversation_settings_route_validates_contract_and_keeps_legacy_w
     )
     assert unsafe_decision.status_code == 400
 
+    non_ascii_writer = await preferences_router.save_conversation_settings(
+        _Request(
+            {"independentAsrEnabled": True},
+            asr_decision={
+                "writeId": 1,
+                "writerId": "\U00010000-client",
+                "value": True,
+            },
+        )
+    )
+    assert non_ascii_writer.status_code == 400
+
     ceiling_decision = await preferences_router.save_conversation_settings(
         _Request(
             {"independentAsrEnabled": True},
@@ -614,6 +626,24 @@ def test_cloud_restore_empty_settings_still_advances_revision(tmp_path):
         "model_path": preferences.GLOBAL_CONVERSATION_KEY,
         "_conversation_settings_revision": 10,
     }
+
+
+def test_cloud_restore_rejects_unsafe_conversation_settings_revision(tmp_path):
+    path = tmp_path / "user_preferences.json"
+    path.write_text("[]", encoding="utf-8")
+
+    with pytest.raises(
+        ValueError,
+        match="conversation settings revision cannot advance safely",
+    ):
+        cloudsave_bindings._build_runtime_preferences_payload(
+            _FakeConfigManager(path),
+            {
+                "focusModeEnabled": True,
+                "_conversation_settings_revision":
+                    preferences.MAX_SAFE_CONVERSATION_SETTINGS_REVISION + 1,
+            },
+        )
 
 
 def test_cloud_restore_ignores_out_of_range_asr_decision_floor(

--- a/tests/unit/test_preferences_concurrency.py
+++ b/tests/unit/test_preferences_concurrency.py
@@ -114,6 +114,47 @@ def test_legacy_asr_change_mints_decision_after_modern_token(monkeypatch, tmp_pa
     assert stale_modern.snapshot.asr_decision == legacy.snapshot.asr_decision
 
 
+def test_legacy_asr_decision_stays_within_future_skew_ceiling(
+    monkeypatch,
+    tmp_path,
+):
+    now_ms = 1_000
+    ceiling_write_id = now_ms + preferences.ASR_WRITE_ID_MAX_FUTURE_SKEW_MS
+    _use_preferences_file(
+        monkeypatch,
+        tmp_path,
+        [
+            {
+                "model_path": preferences.GLOBAL_CONVERSATION_KEY,
+                "independentAsrEnabled": True,
+                "_conversation_settings_revision": 1,
+                "_independent_asr_decision": {
+                    "writeId": ceiling_write_id,
+                    "writerId": "api-client",
+                    "value": True,
+                },
+            }
+        ],
+    )
+    patch_module_clock(
+        monkeypatch,
+        preferences,
+        time_ns=lambda: now_ms * 1_000_000,
+    )
+
+    legacy = preferences.save_global_conversation_settings_versioned(
+        {"independentAsrEnabled": False},
+        expected_revision=1,
+    )
+
+    assert legacy.success is True
+    assert legacy.snapshot.asr_decision == {
+        "writeId": ceiling_write_id,
+        "writerId": "server-legacy",
+        "value": False,
+    }
+
+
 def test_locked_partial_writes_preserve_both_concurrent_changes(monkeypatch, tmp_path):
     path = _use_preferences_file(
         monkeypatch,

--- a/tests/unit/test_preferences_concurrency.py
+++ b/tests/unit/test_preferences_concurrency.py
@@ -256,3 +256,27 @@ async def test_conversation_settings_route_returns_etag_and_412_snapshot(
     payload = json.loads(conflict_response.body)
     assert payload["settings"]["independentAsrEnabled"] is True
     assert payload["decisions"]["independentAsrEnabled"]["writeId"] == 20
+
+
+@pytest.mark.asyncio
+async def test_set_preferred_model_offloads_locked_write(monkeypatch):
+    calls = []
+
+    def fake_move_model_to_top(model_path):
+        calls.append(("move", model_path))
+        return True
+
+    async def fake_to_thread(func, *args):
+        calls.append(("to_thread", func, args))
+        return func(*args)
+
+    monkeypatch.setattr(preferences_router, "move_model_to_top", fake_move_model_to_top)
+    monkeypatch.setattr(preferences_router.asyncio, "to_thread", fake_to_thread)
+
+    result = await preferences_router.set_preferred_model(
+        _Request({"model_path": "model-a"})
+    )
+
+    assert result["success"] is True
+    assert calls[0] == ("to_thread", fake_move_model_to_top, ("model-a",))
+    assert calls[1] == ("move", "model-a")

--- a/tests/unit/test_preferences_concurrency.py
+++ b/tests/unit/test_preferences_concurrency.py
@@ -363,6 +363,18 @@ async def test_conversation_settings_route_validates_contract_and_keeps_legacy_w
     )
     assert unsafe_decision.status_code == 400
 
+    ceiling_decision = await preferences_router.save_conversation_settings(
+        _Request(
+            {"independentAsrEnabled": True},
+            asr_decision={
+                "writeId": preferences.MAX_SAFE_ASR_WRITE_ID,
+                "writerId": "api-client",
+                "value": True,
+            },
+        )
+    )
+    assert ceiling_decision.status_code == 400
+
     legacy_write = await preferences_router.save_conversation_settings(
         _Request({"focusModeEnabled": True})
     )

--- a/tests/unit/test_preferences_concurrency.py
+++ b/tests/unit/test_preferences_concurrency.py
@@ -737,6 +737,42 @@ def test_cloud_restore_non_conversation_only_settings_still_emit_reset(tmp_path)
     assert snapshot.reset is True
 
 
+def test_cloud_restore_partial_conversation_settings_reset_omitted_fields(tmp_path):
+    path = tmp_path / "user_preferences.json"
+    path.write_text(
+        json.dumps(
+            [
+                {
+                    "model_path": preferences.GLOBAL_CONVERSATION_KEY,
+                    "focusModeEnabled": True,
+                    "slopFilterEnabled": False,
+                    "_conversation_settings_revision": 9,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    payload = cloudsave_bindings._build_runtime_preferences_payload(
+        _FakeConfigManager(path),
+        {"focusModeEnabled": False},
+    )
+    restored = next(
+        entry
+        for entry in payload
+        if entry.get("model_path") == preferences.GLOBAL_CONVERSATION_KEY
+    )
+
+    assert restored["focusModeEnabled"] is False
+    assert "slopFilterEnabled" not in restored
+    assert restored["_conversation_settings_revision"] == 10
+    assert restored["_conversation_settings_reset"] is True
+    snapshot = preferences._snapshot_from_preferences_data(payload)
+    assert snapshot.settings == {"focusModeEnabled": False}
+    assert snapshot.revision == 10
+    assert snapshot.reset is True
+
+
 def test_partial_save_preserves_cloud_restore_reset_tombstone(monkeypatch, tmp_path):
     path = _use_preferences_file(
         monkeypatch,

--- a/tests/unit/test_preferences_concurrency.py
+++ b/tests/unit/test_preferences_concurrency.py
@@ -351,6 +351,18 @@ async def test_conversation_settings_route_validates_contract_and_keeps_legacy_w
     )
     assert malformed_decision.status_code == 400
 
+    unsafe_decision = await preferences_router.save_conversation_settings(
+        _Request(
+            {"independentAsrEnabled": True},
+            asr_decision={
+                "writeId": preferences.MAX_SAFE_ASR_WRITE_ID + 1,
+                "writerId": "api-client",
+                "value": True,
+            },
+        )
+    )
+    assert unsafe_decision.status_code == 400
+
     legacy_write = await preferences_router.save_conversation_settings(
         _Request({"focusModeEnabled": True})
     )

--- a/tests/unit/test_preferences_concurrency.py
+++ b/tests/unit/test_preferences_concurrency.py
@@ -333,6 +333,7 @@ class _Request:
         if_match=None,
         asr_decision=None,
         raw_asr_decision=None,
+        full_snapshot=False,
     ):
         self._body = body
         self.headers = {}
@@ -344,6 +345,8 @@ class _Request:
             self.headers["x-conversation-settings-asr-decision"] = json.dumps(
                 asr_decision
             )
+        if full_snapshot:
+            self.headers["x-conversation-settings-full-snapshot"] = "1"
 
     async def json(self):
         return dict(self._body) if isinstance(self._body, dict) else self._body
@@ -423,6 +426,39 @@ async def test_conversation_settings_route_returns_versioned_500_on_save_failure
     assert payload["error"] == "保存失败"
     assert payload["revision"] == 7
     assert payload["settings"]["focusModeEnabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_conversation_settings_route_forwards_full_snapshot_marker(monkeypatch):
+    captured = {}
+    snapshot = preferences.ConversationSettingsSnapshot(
+        settings={"focusModeEnabled": False},
+        revision=11,
+        asr_decision=None,
+    )
+
+    def fake_save(settings, **kwargs):
+        captured["settings"] = settings
+        captured.update(kwargs)
+        return preferences.ConversationSettingsWriteResult(
+            success=True,
+            conflict=False,
+            snapshot=snapshot,
+        )
+
+    monkeypatch.setattr(
+        preferences_router,
+        "save_global_conversation_settings_versioned",
+        fake_save,
+    )
+
+    response = await preferences_router.save_conversation_settings(
+        _Request({"focusModeEnabled": False}, full_snapshot=True)
+    )
+
+    assert response.status_code == 200
+    assert captured["settings"] == {"focusModeEnabled": False}
+    assert captured["full_snapshot"] is True
 
 
 @pytest.mark.asyncio
@@ -667,7 +703,7 @@ def test_cloud_restore_empty_settings_emits_reset_and_advances_revision(tmp_path
     assert snapshot.reset is True
 
 
-def test_versioned_save_clears_cloud_restore_reset_tombstone(monkeypatch, tmp_path):
+def test_partial_save_preserves_cloud_restore_reset_tombstone(monkeypatch, tmp_path):
     path = _use_preferences_file(
         monkeypatch,
         tmp_path,
@@ -683,6 +719,38 @@ def test_versioned_save_clears_cloud_restore_reset_tombstone(monkeypatch, tmp_pa
     result = preferences.save_global_conversation_settings_versioned(
         {"focusModeEnabled": False},
         expected_revision=10,
+    )
+
+    assert result.success is True
+    assert result.snapshot.revision == 11
+    assert result.snapshot.reset is True
+    assert result.snapshot.settings == {"focusModeEnabled": False}
+    saved = json.loads(path.read_text(encoding="utf-8"))
+    global_entry = next(
+        entry
+        for entry in saved
+        if entry.get("model_path") == preferences.GLOBAL_CONVERSATION_KEY
+    )
+    assert global_entry["_conversation_settings_reset"] is True
+
+
+def test_full_snapshot_save_clears_cloud_restore_reset_tombstone(monkeypatch, tmp_path):
+    path = _use_preferences_file(
+        monkeypatch,
+        tmp_path,
+        [
+            {
+                "model_path": preferences.GLOBAL_CONVERSATION_KEY,
+                "_conversation_settings_revision": 10,
+                "_conversation_settings_reset": True,
+            }
+        ],
+    )
+
+    result = preferences.save_global_conversation_settings_versioned(
+        {"focusModeEnabled": False, "slopFilterEnabled": True},
+        expected_revision=10,
+        full_snapshot=True,
     )
 
     assert result.success is True

--- a/tests/unit/test_preferences_concurrency.py
+++ b/tests/unit/test_preferences_concurrency.py
@@ -651,3 +651,43 @@ def test_cloud_restore_ignores_out_of_range_asr_decision_floor(
         "writerId": "server-cloud-restore",
         "value": False,
     }
+
+
+def test_cloud_restore_rejects_unadvanceable_asr_decision_floor(
+    monkeypatch,
+    tmp_path,
+):
+    path = tmp_path / "user_preferences.json"
+    now_ms = 150
+    ceiling = now_ms + preferences.ASR_WRITE_ID_MAX_FUTURE_SKEW_MS
+    path.write_text(
+        json.dumps(
+            [
+                {
+                    "model_path": preferences.GLOBAL_CONVERSATION_KEY,
+                    "independentAsrEnabled": True,
+                    "_conversation_settings_revision": 4,
+                    "_independent_asr_decision": {
+                        "writeId": ceiling,
+                        "writerId": "zzzz-current",
+                        "value": True,
+                    },
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    patch_module_clock(
+        monkeypatch,
+        cloudsave_bindings,
+        time_ns=lambda: now_ms * 1_000_000,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="cloud restore ASR decision cannot advance the accepted floor",
+    ):
+        cloudsave_bindings._build_runtime_preferences_payload(
+            _FakeConfigManager(path),
+            {"independentAsrEnabled": False},
+        )

--- a/tests/unit/test_preferences_concurrency.py
+++ b/tests/unit/test_preferences_concurrency.py
@@ -155,6 +155,50 @@ def test_legacy_asr_decision_stays_within_future_skew_ceiling(
     }
 
 
+def test_legacy_asr_change_rejects_unadvanceable_ceiling_token(
+    monkeypatch,
+    tmp_path,
+):
+    now_ms = 1_000
+    ceiling_write_id = now_ms + preferences.ASR_WRITE_ID_MAX_FUTURE_SKEW_MS
+    _use_preferences_file(
+        monkeypatch,
+        tmp_path,
+        [
+            {
+                "model_path": preferences.GLOBAL_CONVERSATION_KEY,
+                "independentAsrEnabled": True,
+                "_conversation_settings_revision": 1,
+                "_independent_asr_decision": {
+                    "writeId": ceiling_write_id,
+                    "writerId": "zzzz-client",
+                    "value": True,
+                },
+            }
+        ],
+    )
+    patch_module_clock(
+        monkeypatch,
+        preferences,
+        time_ns=lambda: now_ms * 1_000_000,
+    )
+
+    legacy = preferences.save_global_conversation_settings_versioned(
+        {"independentAsrEnabled": False},
+        expected_revision=1,
+    )
+
+    assert legacy.success is False
+    assert legacy.conflict is True
+    assert legacy.snapshot.revision == 1
+    assert legacy.snapshot.settings["independentAsrEnabled"] is True
+    assert legacy.snapshot.asr_decision == {
+        "writeId": ceiling_write_id,
+        "writerId": "zzzz-client",
+        "value": True,
+    }
+
+
 def test_locked_partial_writes_preserve_both_concurrent_changes(monkeypatch, tmp_path):
     path = _use_preferences_file(
         monkeypatch,

--- a/tests/unit/test_preferences_concurrency.py
+++ b/tests/unit/test_preferences_concurrency.py
@@ -74,6 +74,42 @@ def test_versioned_save_rejects_stale_revision_and_asr_decision(monkeypatch, tmp
     assert stale_decision.snapshot.asr_decision == newer
 
 
+def test_legacy_asr_change_mints_decision_after_modern_token(monkeypatch, tmp_path):
+    _use_preferences_file(monkeypatch, tmp_path)
+    modern = {
+        "writeId": 20,
+        "writerId": "window-b",
+        "value": True,
+    }
+    first = preferences.save_global_conversation_settings_versioned(
+        {"independentAsrEnabled": True},
+        expected_revision=0,
+        asr_decision=modern,
+    )
+    assert first.success is True
+
+    legacy = preferences.save_global_conversation_settings_versioned(
+        {"independentAsrEnabled": False},
+        expected_revision=1,
+    )
+    assert legacy.success is True
+    assert legacy.snapshot.revision == 2
+    assert legacy.snapshot.asr_decision is not None
+    assert legacy.snapshot.asr_decision["value"] is False
+    assert preferences._asr_decision_key(
+        legacy.snapshot.asr_decision
+    ) > preferences._asr_decision_key(modern)
+
+    stale_modern = preferences.save_global_conversation_settings_versioned(
+        {"independentAsrEnabled": True},
+        expected_revision=2,
+        asr_decision=modern,
+    )
+    assert stale_modern.conflict is True
+    assert stale_modern.snapshot.settings["independentAsrEnabled"] is False
+    assert stale_modern.snapshot.asr_decision == legacy.snapshot.asr_decision
+
+
 def test_locked_partial_writes_preserve_both_concurrent_changes(monkeypatch, tmp_path):
     path = _use_preferences_file(
         monkeypatch,

--- a/tests/unit/test_preferences_concurrency.py
+++ b/tests/unit/test_preferences_concurrency.py
@@ -465,30 +465,32 @@ async def test_noise_reduction_runtime_updates_follow_persisted_revision(monkeyp
     )
 
     old_apply = asyncio.create_task(
-        preferences_router._apply_noise_reduction_if_current(True, 1)
+        preferences_router._apply_noise_reduction_if_current(True)
     )
     await old_apply_started.wait()
     current = SimpleNamespace(
         revision=2,
-        settings={"noiseReductionEnabled": False},
+        settings={
+            "noiseReductionEnabled": True,
+            "focusModeEnabled": True,
+        },
     )
-    new_apply = asyncio.create_task(
-        preferences_router._apply_noise_reduction_if_current(False, 2)
-    )
-    await asyncio.sleep(0)
-    assert calls == [("start", True)]
-
     allow_old_apply.set()
-    await asyncio.gather(old_apply, new_apply)
+    await old_apply
     assert calls == [
         ("start", True),
         ("end", True),
-        ("start", False),
-        ("end", False),
     ]
 
-    await preferences_router._apply_noise_reduction_if_current(True, 1)
-    assert calls[-1] == ("end", False)
+    current = SimpleNamespace(
+        revision=3,
+        settings={"noiseReductionEnabled": False},
+    )
+    await preferences_router._apply_noise_reduction_if_current(True)
+    assert calls == [("start", True), ("end", True)]
+
+    await preferences_router._apply_noise_reduction_if_current(False)
+    assert calls[-2:] == [("start", False), ("end", False)]
 
 
 def test_cloud_restore_rebases_asr_decision_and_revision(monkeypatch, tmp_path):
@@ -534,6 +536,74 @@ def test_cloud_restore_rebases_asr_decision_and_revision(monkeypatch, tmp_path):
     assert restored["_conversation_settings_revision"] == 10
     assert restored["_independent_asr_decision"] == {
         "writeId": 201,
+        "writerId": "server-cloud-restore",
+        "value": False,
+    }
+
+
+def test_cloud_restore_empty_settings_still_advances_revision(tmp_path):
+    path = tmp_path / "user_preferences.json"
+    path.write_text(
+        json.dumps(
+            [
+                {
+                    "model_path": preferences.GLOBAL_CONVERSATION_KEY,
+                    "focusModeEnabled": True,
+                    "_conversation_settings_revision": 9,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    payload = cloudsave_bindings._build_runtime_preferences_payload(
+        _FakeConfigManager(path),
+        {},
+    )
+    restored = next(
+        entry
+        for entry in payload
+        if entry.get("model_path") == preferences.GLOBAL_CONVERSATION_KEY
+    )
+
+    assert restored == {
+        "model_path": preferences.GLOBAL_CONVERSATION_KEY,
+        "_conversation_settings_revision": 10,
+    }
+
+
+def test_cloud_restore_ignores_out_of_range_asr_decision_floor(
+    monkeypatch,
+    tmp_path,
+):
+    path = tmp_path / "user_preferences.json"
+    path.write_text("[]", encoding="utf-8")
+    now_ms = 150
+    patch_module_clock(
+        monkeypatch,
+        cloudsave_bindings,
+        time_ns=lambda: now_ms * 1_000_000,
+    )
+
+    payload = cloudsave_bindings._build_runtime_preferences_payload(
+        _FakeConfigManager(path),
+        {
+            "independentAsrEnabled": False,
+            "_independent_asr_decision": {
+                "writeId": preferences.MAX_SAFE_ASR_WRITE_ID + 1,
+                "writerId": "malformed-cloud",
+                "value": False,
+            },
+        },
+    )
+    restored = next(
+        entry
+        for entry in payload
+        if entry.get("model_path") == preferences.GLOBAL_CONVERSATION_KEY
+    )
+
+    assert restored["_independent_asr_decision"] == {
+        "writeId": now_ms,
         "writerId": "server-cloud-restore",
         "value": False,
     }

--- a/tests/unit/test_preferences_concurrency.py
+++ b/tests/unit/test_preferences_concurrency.py
@@ -377,6 +377,7 @@ async def test_conversation_settings_route_returns_etag_and_412_snapshot(
     assert get_response.headers["cache-control"] == "no-store"
     assert get_payload["revision"] == 1
     assert get_payload["settings"]["independentAsrEnabled"] is True
+    assert get_payload["reset"] is False
 
     conflict_response = await preferences_router.save_conversation_settings(
         _Request(
@@ -630,7 +631,7 @@ def test_cloud_restore_rebases_asr_decision_and_revision(monkeypatch, tmp_path):
     }
 
 
-def test_cloud_restore_empty_settings_still_advances_revision(tmp_path):
+def test_cloud_restore_empty_settings_emits_reset_and_advances_revision(tmp_path):
     path = tmp_path / "user_preferences.json"
     path.write_text(
         json.dumps(
@@ -658,7 +659,42 @@ def test_cloud_restore_empty_settings_still_advances_revision(tmp_path):
     assert restored == {
         "model_path": preferences.GLOBAL_CONVERSATION_KEY,
         "_conversation_settings_revision": 10,
+        "_conversation_settings_reset": True,
     }
+    snapshot = preferences._snapshot_from_preferences_data(payload)
+    assert snapshot.settings == {}
+    assert snapshot.revision == 10
+    assert snapshot.reset is True
+
+
+def test_versioned_save_clears_cloud_restore_reset_tombstone(monkeypatch, tmp_path):
+    path = _use_preferences_file(
+        monkeypatch,
+        tmp_path,
+        [
+            {
+                "model_path": preferences.GLOBAL_CONVERSATION_KEY,
+                "_conversation_settings_revision": 10,
+                "_conversation_settings_reset": True,
+            }
+        ],
+    )
+
+    result = preferences.save_global_conversation_settings_versioned(
+        {"focusModeEnabled": False},
+        expected_revision=10,
+    )
+
+    assert result.success is True
+    assert result.snapshot.revision == 11
+    assert result.snapshot.reset is False
+    saved = json.loads(path.read_text(encoding="utf-8"))
+    global_entry = next(
+        entry
+        for entry in saved
+        if entry.get("model_path") == preferences.GLOBAL_CONVERSATION_KEY
+    )
+    assert "_conversation_settings_reset" not in global_entry
 
 
 def test_cloud_restore_rejects_unsafe_conversation_settings_revision(tmp_path):

--- a/tests/unit/test_preferences_concurrency.py
+++ b/tests/unit/test_preferences_concurrency.py
@@ -703,6 +703,40 @@ def test_cloud_restore_empty_settings_emits_reset_and_advances_revision(tmp_path
     assert snapshot.reset is True
 
 
+def test_cloud_restore_non_conversation_only_settings_still_emit_reset(tmp_path):
+    path = tmp_path / "user_preferences.json"
+    path.write_text(
+        json.dumps(
+            [
+                {
+                    "model_path": preferences.GLOBAL_CONVERSATION_KEY,
+                    "focusModeEnabled": True,
+                    "_conversation_settings_revision": 9,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    payload = cloudsave_bindings._build_runtime_preferences_payload(
+        _FakeConfigManager(path),
+        {"uiLanguage": "zh-CN"},
+    )
+    restored = next(
+        entry
+        for entry in payload
+        if entry.get("model_path") == preferences.GLOBAL_CONVERSATION_KEY
+    )
+
+    assert restored["uiLanguage"] == "zh-CN"
+    assert restored["_conversation_settings_revision"] == 10
+    assert restored["_conversation_settings_reset"] is True
+    snapshot = preferences._snapshot_from_preferences_data(payload)
+    assert snapshot.settings == {}
+    assert snapshot.revision == 10
+    assert snapshot.reset is True
+
+
 def test_partial_save_preserves_cloud_restore_reset_tombstone(monkeypatch, tmp_path):
     path = _use_preferences_file(
         monkeypatch,

--- a/tests/unit/test_preferences_concurrency.py
+++ b/tests/unit/test_preferences_concurrency.py
@@ -392,6 +392,39 @@ async def test_conversation_settings_route_returns_etag_and_412_snapshot(
 
 
 @pytest.mark.asyncio
+async def test_conversation_settings_route_returns_versioned_500_on_save_failure(
+    monkeypatch,
+):
+    snapshot = preferences.ConversationSettingsSnapshot(
+        settings={"focusModeEnabled": True},
+        revision=7,
+        asr_decision=None,
+    )
+    monkeypatch.setattr(
+        preferences_router,
+        "save_global_conversation_settings_versioned",
+        lambda *_args, **_kwargs: preferences.ConversationSettingsWriteResult(
+            success=False,
+            conflict=False,
+            snapshot=snapshot,
+        ),
+    )
+
+    response = await preferences_router.save_conversation_settings(
+        _Request({"focusModeEnabled": False})
+    )
+
+    assert response.status_code == 500
+    assert response.headers["etag"] == '"conversation-settings-7"'
+    assert response.headers["cache-control"] == "no-store"
+    payload = json.loads(response.body)
+    assert payload["success"] is False
+    assert payload["error"] == "保存失败"
+    assert payload["revision"] == 7
+    assert payload["settings"]["focusModeEnabled"] is True
+
+
+@pytest.mark.asyncio
 async def test_set_preferred_model_offloads_locked_write(monkeypatch):
     calls = []
 

--- a/utils/cloudsave_runtime/bindings.py
+++ b/utils/cloudsave_runtime/bindings.py
@@ -29,6 +29,7 @@ from typing import Any
 
 from config import CHARACTER_RESERVED_FIELDS
 from utils.conversation_settings_constants import (
+    ALLOWED_CONVERSATION_SETTINGS as _ALLOWED_CONVERSATION_SETTINGS,
     ASR_WRITE_ID_MAX_FUTURE_SKEW_MS as _ASR_WRITE_ID_MAX_FUTURE_SKEW_MS,
     CONVERSATION_SETTINGS_RESET_KEY as _CONVERSATION_SETTINGS_RESET_KEY,
     MAX_SAFE_ASR_WRITE_ID as _MAX_SAFE_ASR_WRITE_ID,
@@ -96,11 +97,7 @@ def _build_runtime_preferences_payload(config_manager, conversation_settings: di
         for key, value in (conversation_settings or {}).items()
         if key != "model_path"
     }
-    restored_setting_keys = set(filtered_settings) - {
-        _CONVERSATION_SETTINGS_REVISION_KEY,
-        _CONVERSATION_SETTINGS_ASR_DECISION_KEY,
-        _CONVERSATION_SETTINGS_RESET_KEY,
-    }
+    restored_setting_keys = set(filtered_settings) & _ALLOWED_CONVERSATION_SETTINGS
     if restored_setting_keys:
         filtered_settings.pop(_CONVERSATION_SETTINGS_RESET_KEY, None)
     else:

--- a/utils/cloudsave_runtime/bindings.py
+++ b/utils/cloudsave_runtime/bindings.py
@@ -42,6 +42,7 @@ _CONVERSATION_SETTINGS_REVISION_KEY = "_conversation_settings_revision"
 _CONVERSATION_SETTINGS_ASR_DECISION_KEY = "_independent_asr_decision"
 _CLOUD_RESTORE_ASR_WRITER_ID = "server-cloud-restore"
 _MAX_SAFE_ASR_WRITE_ID = 9_007_199_254_740_991
+_MAX_SAFE_CONVERSATION_SETTINGS_REVISION = 9_007_199_254_740_991
 _ASR_WRITE_ID_MAX_FUTURE_SKEW_MS = 365 * 24 * 60 * 60 * 1000
 
 
@@ -95,6 +96,15 @@ def _build_runtime_preferences_payload(config_manager, conversation_settings: di
     }
     current_revision = current_global.get(_CONVERSATION_SETTINGS_REVISION_KEY)
     imported_revision = filtered_settings.get(_CONVERSATION_SETTINGS_REVISION_KEY)
+    for revision in (current_revision, imported_revision):
+        if (
+            isinstance(revision, int)
+            and not isinstance(revision, bool)
+            and revision >= _MAX_SAFE_CONVERSATION_SETTINGS_REVISION
+        ):
+            raise ValueError(
+                "cloud restore conversation settings revision cannot advance safely"
+            )
     filtered_settings[_CONVERSATION_SETTINGS_REVISION_KEY] = max(
         current_revision
         if isinstance(current_revision, int) and not isinstance(current_revision, bool)
@@ -125,6 +135,8 @@ def _build_runtime_preferences_payload(config_manager, conversation_settings: di
                 and 0 <= write_id <= max_accepted_write_id
                 and isinstance(writer_id, str)
                 and 0 < len(writer_id) <= 128
+                and writer_id.isascii()
+                and writer_id.isprintable()
                 and isinstance(decision_value, bool)
                 and entry.get("independentAsrEnabled") is decision_value
             ):

--- a/utils/cloudsave_runtime/bindings.py
+++ b/utils/cloudsave_runtime/bindings.py
@@ -28,6 +28,12 @@ from pathlib import Path
 from typing import Any
 
 from config import CHARACTER_RESERVED_FIELDS
+from utils.conversation_settings_constants import (
+    ASR_WRITE_ID_MAX_FUTURE_SKEW_MS as _ASR_WRITE_ID_MAX_FUTURE_SKEW_MS,
+    MAX_SAFE_ASR_WRITE_ID as _MAX_SAFE_ASR_WRITE_ID,
+    MAX_SAFE_CONVERSATION_SETTINGS_REVISION
+    as _MAX_SAFE_CONVERSATION_SETTINGS_REVISION,
+)
 
 from ._shared import GLOBAL_CONVERSATION_KEY, _utc_now_iso
 from .legacy_migration import _normalize_catgirl_payload
@@ -41,11 +47,6 @@ from .staging import (
 _CONVERSATION_SETTINGS_REVISION_KEY = "_conversation_settings_revision"
 _CONVERSATION_SETTINGS_ASR_DECISION_KEY = "_independent_asr_decision"
 _CLOUD_RESTORE_ASR_WRITER_ID = "server-cloud-restore"
-_MAX_SAFE_ASR_WRITE_ID = 9_007_199_254_740_991
-_MAX_SAFE_CONVERSATION_SETTINGS_REVISION = 9_007_199_254_740_991
-_ASR_WRITE_ID_MAX_FUTURE_SKEW_MS = 365 * 24 * 60 * 60 * 1000
-
-
 def _load_user_preferences_entries(config_manager) -> list[dict[str, Any]]:
     preferences_path = Path(config_manager.get_config_path("user_preferences.json"))
     if not preferences_path.exists():

--- a/utils/cloudsave_runtime/bindings.py
+++ b/utils/cloudsave_runtime/bindings.py
@@ -41,6 +41,8 @@ from .staging import (
 _CONVERSATION_SETTINGS_REVISION_KEY = "_conversation_settings_revision"
 _CONVERSATION_SETTINGS_ASR_DECISION_KEY = "_independent_asr_decision"
 _CLOUD_RESTORE_ASR_WRITER_ID = "server-cloud-restore"
+_MAX_SAFE_ASR_WRITE_ID = 9_007_199_254_740_991
+_ASR_WRITE_ID_MAX_FUTURE_SKEW_MS = 365 * 24 * 60 * 60 * 1000
 
 
 def _load_user_preferences_entries(config_manager) -> list[dict[str, Any]]:
@@ -91,41 +93,60 @@ def _build_runtime_preferences_payload(config_manager, conversation_settings: di
         for key, value in (conversation_settings or {}).items()
         if key != "model_path"
     }
-    if filtered_settings:
-        current_revision = current_global.get(_CONVERSATION_SETTINGS_REVISION_KEY)
-        imported_revision = filtered_settings.get(_CONVERSATION_SETTINGS_REVISION_KEY)
-        filtered_settings[_CONVERSATION_SETTINGS_REVISION_KEY] = max(
-            current_revision
-            if isinstance(current_revision, int) and not isinstance(current_revision, bool)
-            else 0,
-            imported_revision
-            if isinstance(imported_revision, int) and not isinstance(imported_revision, bool)
-            else 0,
-        ) + 1
+    current_revision = current_global.get(_CONVERSATION_SETTINGS_REVISION_KEY)
+    imported_revision = filtered_settings.get(_CONVERSATION_SETTINGS_REVISION_KEY)
+    filtered_settings[_CONVERSATION_SETTINGS_REVISION_KEY] = max(
+        current_revision
+        if isinstance(current_revision, int) and not isinstance(current_revision, bool)
+        else 0,
+        imported_revision
+        if isinstance(imported_revision, int) and not isinstance(imported_revision, bool)
+        else 0,
+    ) + 1
 
-        restored_asr_value = filtered_settings.get("independentAsrEnabled")
-        if isinstance(restored_asr_value, bool):
-            known_write_ids = []
-            for entry in (current_global, filtered_settings):
-                decision = entry.get(_CONVERSATION_SETTINGS_ASR_DECISION_KEY)
-                write_id = decision.get("writeId") if isinstance(decision, dict) else None
-                if isinstance(write_id, int) and not isinstance(write_id, bool) and write_id >= 0:
-                    known_write_ids.append(write_id)
-            filtered_settings[_CONVERSATION_SETTINGS_ASR_DECISION_KEY] = {
-                "writeId": max([
-                    time.time_ns() // 1_000_000,
+    restored_asr_value = filtered_settings.get("independentAsrEnabled")
+    if isinstance(restored_asr_value, bool):
+        now_ms = time.time_ns() // 1_000_000
+        max_accepted_write_id = min(
+            _MAX_SAFE_ASR_WRITE_ID - 1,
+            now_ms + _ASR_WRITE_ID_MAX_FUTURE_SKEW_MS,
+        )
+        known_write_ids = []
+        for entry in (current_global, filtered_settings):
+            decision = entry.get(_CONVERSATION_SETTINGS_ASR_DECISION_KEY)
+            if not isinstance(decision, dict):
+                continue
+            write_id = decision.get("writeId")
+            writer_id = decision.get("writerId")
+            decision_value = decision.get("value")
+            if (
+                isinstance(write_id, int)
+                and not isinstance(write_id, bool)
+                and 0 <= write_id <= max_accepted_write_id
+                and isinstance(writer_id, str)
+                and 0 < len(writer_id) <= 128
+                and isinstance(decision_value, bool)
+                and entry.get("independentAsrEnabled") is decision_value
+            ):
+                known_write_ids.append(write_id)
+        filtered_settings[_CONVERSATION_SETTINGS_ASR_DECISION_KEY] = {
+            "writeId": min(
+                max([
+                    now_ms,
                     *(write_id + 1 for write_id in known_write_ids),
                 ]),
-                "writerId": _CLOUD_RESTORE_ASR_WRITER_ID,
-                "value": restored_asr_value,
-            }
-        else:
-            filtered_settings.pop(_CONVERSATION_SETTINGS_ASR_DECISION_KEY, None)
+                max_accepted_write_id,
+            ),
+            "writerId": _CLOUD_RESTORE_ASR_WRITER_ID,
+            "value": restored_asr_value,
+        }
+    else:
+        filtered_settings.pop(_CONVERSATION_SETTINGS_ASR_DECISION_KEY, None)
 
-        preferences.append({
-            "model_path": GLOBAL_CONVERSATION_KEY,
-            **filtered_settings,
-        })
+    preferences.append({
+        "model_path": GLOBAL_CONVERSATION_KEY,
+        **filtered_settings,
+    })
     return preferences
 
 

--- a/utils/cloudsave_runtime/bindings.py
+++ b/utils/cloudsave_runtime/bindings.py
@@ -111,7 +111,7 @@ def _build_runtime_preferences_payload(config_manager, conversation_settings: di
             _MAX_SAFE_ASR_WRITE_ID - 1,
             now_ms + _ASR_WRITE_ID_MAX_FUTURE_SKEW_MS,
         )
-        known_write_ids = []
+        known_decision_keys = []
         for entry in (current_global, filtered_settings):
             decision = entry.get(_CONVERSATION_SETTINGS_ASR_DECISION_KEY)
             if not isinstance(decision, dict):
@@ -128,18 +128,30 @@ def _build_runtime_preferences_payload(config_manager, conversation_settings: di
                 and isinstance(decision_value, bool)
                 and entry.get("independentAsrEnabled") is decision_value
             ):
-                known_write_ids.append(write_id)
-        filtered_settings[_CONVERSATION_SETTINGS_ASR_DECISION_KEY] = {
+                known_decision_keys.append((write_id, writer_id))
+        restored_decision = {
             "writeId": min(
                 max([
                     now_ms,
-                    *(write_id + 1 for write_id in known_write_ids),
+                    *(write_id + 1 for write_id, _writer_id in known_decision_keys),
                 ]),
                 max_accepted_write_id,
             ),
             "writerId": _CLOUD_RESTORE_ASR_WRITER_ID,
             "value": restored_asr_value,
         }
+        if (
+            known_decision_keys
+            and (
+                restored_decision["writeId"],
+                restored_decision["writerId"],
+            )
+            <= max(known_decision_keys)
+        ):
+            raise ValueError(
+                "cloud restore ASR decision cannot advance the accepted floor"
+            )
+        filtered_settings[_CONVERSATION_SETTINGS_ASR_DECISION_KEY] = restored_decision
     else:
         filtered_settings.pop(_CONVERSATION_SETTINGS_ASR_DECISION_KEY, None)
 

--- a/utils/cloudsave_runtime/bindings.py
+++ b/utils/cloudsave_runtime/bindings.py
@@ -98,13 +98,14 @@ def _build_runtime_preferences_payload(config_manager, conversation_settings: di
         if key != "model_path"
     }
     restored_setting_keys = set(filtered_settings) & _ALLOWED_CONVERSATION_SETTINGS
-    if restored_setting_keys:
+    if restored_setting_keys == _ALLOWED_CONVERSATION_SETTINGS:
         filtered_settings.pop(_CONVERSATION_SETTINGS_RESET_KEY, None)
     else:
-        # A revision-only entry preserves CAS ordering but cannot tell browsers
-        # that the archived absence is authoritative. Persist an explicit
-        # tombstone so clients reset missing fields instead of reposting stale
-        # localStorage values over the restore.
+        # The global entry is rebuilt solely from the archive, so every omitted
+        # conversation field is authoritative absence, not "leave the current
+        # value untouched". Persist a tombstone for empty and partial archives;
+        # clients materialize defaults plus the restored overrides before their
+        # first full CAS writeback.
         filtered_settings[_CONVERSATION_SETTINGS_RESET_KEY] = True
     current_revision = current_global.get(_CONVERSATION_SETTINGS_REVISION_KEY)
     imported_revision = filtered_settings.get(_CONVERSATION_SETTINGS_REVISION_KEY)

--- a/utils/cloudsave_runtime/bindings.py
+++ b/utils/cloudsave_runtime/bindings.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import json
 import os
+import time
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
@@ -36,6 +37,10 @@ from .staging import (
     _sha256_bytes,
     _sha256_file,
 )
+
+_CONVERSATION_SETTINGS_REVISION_KEY = "_conversation_settings_revision"
+_CONVERSATION_SETTINGS_ASR_DECISION_KEY = "_independent_asr_decision"
+_CLOUD_RESTORE_ASR_WRITER_ID = "server-cloud-restore"
 
 
 def _load_user_preferences_entries(config_manager) -> list[dict[str, Any]]:
@@ -66,9 +71,19 @@ def _extract_conversation_settings(config_manager) -> dict[str, Any]:
 
 
 def _build_runtime_preferences_payload(config_manager, conversation_settings: dict[str, Any]) -> list[dict[str, Any]]:
+    existing_preferences = _load_user_preferences_entries(config_manager)
+    current_global = next(
+        (
+            entry
+            for entry in existing_preferences
+            if isinstance(entry, dict)
+            and entry.get("model_path") == GLOBAL_CONVERSATION_KEY
+        ),
+        {},
+    )
     preferences = [
         entry
-        for entry in _load_user_preferences_entries(config_manager)
+        for entry in existing_preferences
         if not isinstance(entry, dict) or entry.get("model_path") != GLOBAL_CONVERSATION_KEY
     ]
     filtered_settings = {
@@ -77,6 +92,36 @@ def _build_runtime_preferences_payload(config_manager, conversation_settings: di
         if key != "model_path"
     }
     if filtered_settings:
+        current_revision = current_global.get(_CONVERSATION_SETTINGS_REVISION_KEY)
+        imported_revision = filtered_settings.get(_CONVERSATION_SETTINGS_REVISION_KEY)
+        filtered_settings[_CONVERSATION_SETTINGS_REVISION_KEY] = max(
+            current_revision
+            if isinstance(current_revision, int) and not isinstance(current_revision, bool)
+            else 0,
+            imported_revision
+            if isinstance(imported_revision, int) and not isinstance(imported_revision, bool)
+            else 0,
+        ) + 1
+
+        restored_asr_value = filtered_settings.get("independentAsrEnabled")
+        if isinstance(restored_asr_value, bool):
+            known_write_ids = []
+            for entry in (current_global, filtered_settings):
+                decision = entry.get(_CONVERSATION_SETTINGS_ASR_DECISION_KEY)
+                write_id = decision.get("writeId") if isinstance(decision, dict) else None
+                if isinstance(write_id, int) and not isinstance(write_id, bool) and write_id >= 0:
+                    known_write_ids.append(write_id)
+            filtered_settings[_CONVERSATION_SETTINGS_ASR_DECISION_KEY] = {
+                "writeId": max([
+                    time.time_ns() // 1_000_000,
+                    *(write_id + 1 for write_id in known_write_ids),
+                ]),
+                "writerId": _CLOUD_RESTORE_ASR_WRITER_ID,
+                "value": restored_asr_value,
+            }
+        else:
+            filtered_settings.pop(_CONVERSATION_SETTINGS_ASR_DECISION_KEY, None)
+
         preferences.append({
             "model_path": GLOBAL_CONVERSATION_KEY,
             **filtered_settings,

--- a/utils/cloudsave_runtime/bindings.py
+++ b/utils/cloudsave_runtime/bindings.py
@@ -30,6 +30,7 @@ from typing import Any
 from config import CHARACTER_RESERVED_FIELDS
 from utils.conversation_settings_constants import (
     ASR_WRITE_ID_MAX_FUTURE_SKEW_MS as _ASR_WRITE_ID_MAX_FUTURE_SKEW_MS,
+    CONVERSATION_SETTINGS_RESET_KEY as _CONVERSATION_SETTINGS_RESET_KEY,
     MAX_SAFE_ASR_WRITE_ID as _MAX_SAFE_ASR_WRITE_ID,
     MAX_SAFE_CONVERSATION_SETTINGS_REVISION
     as _MAX_SAFE_CONVERSATION_SETTINGS_REVISION,
@@ -95,6 +96,19 @@ def _build_runtime_preferences_payload(config_manager, conversation_settings: di
         for key, value in (conversation_settings or {}).items()
         if key != "model_path"
     }
+    restored_setting_keys = set(filtered_settings) - {
+        _CONVERSATION_SETTINGS_REVISION_KEY,
+        _CONVERSATION_SETTINGS_ASR_DECISION_KEY,
+        _CONVERSATION_SETTINGS_RESET_KEY,
+    }
+    if restored_setting_keys:
+        filtered_settings.pop(_CONVERSATION_SETTINGS_RESET_KEY, None)
+    else:
+        # A revision-only entry preserves CAS ordering but cannot tell browsers
+        # that the archived absence is authoritative. Persist an explicit
+        # tombstone so clients reset missing fields instead of reposting stale
+        # localStorage values over the restore.
+        filtered_settings[_CONVERSATION_SETTINGS_RESET_KEY] = True
     current_revision = current_global.get(_CONVERSATION_SETTINGS_REVISION_KEY)
     imported_revision = filtered_settings.get(_CONVERSATION_SETTINGS_REVISION_KEY)
     for revision in (current_revision, imported_revision):

--- a/utils/conversation_settings_constants.py
+++ b/utils/conversation_settings_constants.py
@@ -14,6 +14,30 @@
 
 """Protocol constants shared by conversation-settings persistence paths."""
 
+ALLOWED_CONVERSATION_SETTINGS = frozenset({
+    "proactiveChatEnabled",
+    "proactiveVisionEnabled",
+    "proactiveVisionChatEnabled",
+    "proactiveNewsChatEnabled",
+    "proactiveVideoChatEnabled",
+    "proactivePersonalChatEnabled",
+    "proactiveMusicEnabled",
+    "proactiveMemeEnabled",
+    "proactiveMiniGameInviteEnabled",
+    "mergeMessagesEnabled",
+    "focusModeEnabled",
+    "focusCognitionEnabled",
+    "avatarReactionBubbleEnabled",
+    "slopFilterEnabled",
+    "proactiveChatInterval",
+    "proactiveVisionInterval",
+    "subtitleEnabled",
+    "userLanguage",
+    "textGuardMaxLength",
+    "noiseReductionEnabled",
+    "independentAsrEnabled",
+    "voiceInputResourceOptimizationEnabled",
+})
 MAX_SAFE_ASR_WRITE_ID = 9_007_199_254_740_991
 MAX_SAFE_CONVERSATION_SETTINGS_REVISION = 9_007_199_254_740_991
 ASR_WRITE_ID_MAX_FUTURE_SKEW_MS = 365 * 24 * 60 * 60 * 1000

--- a/utils/conversation_settings_constants.py
+++ b/utils/conversation_settings_constants.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Ordering bounds shared by conversation-settings persistence paths."""
+"""Protocol constants shared by conversation-settings persistence paths."""
 
 MAX_SAFE_ASR_WRITE_ID = 9_007_199_254_740_991
 MAX_SAFE_CONVERSATION_SETTINGS_REVISION = 9_007_199_254_740_991
 ASR_WRITE_ID_MAX_FUTURE_SKEW_MS = 365 * 24 * 60 * 60 * 1000
+CONVERSATION_SETTINGS_RESET_KEY = "_conversation_settings_reset"

--- a/utils/conversation_settings_constants.py
+++ b/utils/conversation_settings_constants.py
@@ -1,0 +1,19 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ordering bounds shared by conversation-settings persistence paths."""
+
+MAX_SAFE_ASR_WRITE_ID = 9_007_199_254_740_991
+MAX_SAFE_CONVERSATION_SETTINGS_REVISION = 9_007_199_254_740_991
+ASR_WRITE_ID_MAX_FUTURE_SKEW_MS = 365 * 24 * 60 * 60 * 1000

--- a/utils/preferences.py
+++ b/utils/preferences.py
@@ -28,6 +28,7 @@ from utils.config_manager import get_config_manager
 from utils.cloudsave_runtime import MaintenanceModeError, assert_cloudsave_writable
 from utils.conversation_settings_constants import (
     ASR_WRITE_ID_MAX_FUTURE_SKEW_MS,
+    CONVERSATION_SETTINGS_RESET_KEY,
     MAX_SAFE_ASR_WRITE_ID,
     MAX_SAFE_CONVERSATION_SETTINGS_REVISION,
 )
@@ -405,6 +406,7 @@ class ConversationSettingsSnapshot:
     settings: Dict[str, Any]
     revision: int
     asr_decision: Optional[Dict[str, Any]]
+    reset: bool = False
 
 
 @dataclass(frozen=True)
@@ -510,6 +512,7 @@ def _snapshot_from_preferences_data(data: Any) -> ConversationSettingsSnapshot:
                         pref.get(_CONVERSATION_SETTINGS_REVISION_KEY)
                     ),
                     asr_decision=decision,
+                    reset=pref.get(CONVERSATION_SETTINGS_RESET_KEY) is True,
                 )
     return ConversationSettingsSnapshot(settings={}, revision=0, asr_decision=None)
 
@@ -712,6 +715,8 @@ def save_global_conversation_settings_versioned(
             global_pref = data[global_index].copy() if global_index >= 0 else {}
             previous_asr_value = global_pref.get("independentAsrEnabled")
             changed = global_index < 0
+            if global_pref.pop(CONVERSATION_SETTINGS_RESET_KEY, None) is not None:
+                changed = True
             for key, value in validated.items():
                 if global_pref.get(key) != value:
                     changed = True

--- a/utils/preferences.py
+++ b/utils/preferences.py
@@ -19,6 +19,7 @@ import json
 import os
 from pathlib import Path
 import threading
+import time
 from typing import Dict, Any, Optional, List
 
 import portalocker
@@ -393,6 +394,7 @@ _ALLOWED_CONVERSATION_SETTINGS = {
 }
 _CONVERSATION_SETTINGS_REVISION_KEY = "_conversation_settings_revision"
 _CONVERSATION_SETTINGS_ASR_DECISION_KEY = "_independent_asr_decision"
+_LEGACY_ASR_DECISION_WRITER_ID = "server-legacy"
 
 
 @dataclass(frozen=True)
@@ -440,6 +442,18 @@ def _normalize_asr_decision(value: Any) -> Optional[Dict[str, Any]]:
 
 def _asr_decision_key(decision: Dict[str, Any]) -> tuple[int, str]:
     return decision["writeId"], decision["writerId"]
+
+
+def _next_legacy_asr_decision(
+    current: Optional[Dict[str, Any]],
+    value: bool,
+) -> Dict[str, Any]:
+    current_write_id = current["writeId"] if current is not None else -1
+    return {
+        "writeId": max(time.time_ns() // 1_000_000, current_write_id + 1),
+        "writerId": _LEGACY_ASR_DECISION_WRITER_ID,
+        "value": value,
+    }
 
 
 def _snapshot_from_preferences_data(data: Any) -> ConversationSettingsSnapshot:
@@ -683,9 +697,16 @@ def save_global_conversation_settings_versioned(
                         changed = True
                     global_pref[_CONVERSATION_SETTINGS_ASR_DECISION_KEY] = incoming_decision
                 elif previous_asr_value != validated["independentAsrEnabled"]:
-                    if _CONVERSATION_SETTINGS_ASR_DECISION_KEY in global_pref:
+                    legacy_decision = _next_legacy_asr_decision(
+                        current.asr_decision,
+                        validated["independentAsrEnabled"],
+                    )
+                    if (
+                        global_pref.get(_CONVERSATION_SETTINGS_ASR_DECISION_KEY)
+                        != legacy_decision
+                    ):
                         changed = True
-                        global_pref.pop(_CONVERSATION_SETTINGS_ASR_DECISION_KEY, None)
+                    global_pref[_CONVERSATION_SETTINGS_ASR_DECISION_KEY] = legacy_decision
 
             global_pref["model_path"] = GLOBAL_CONVERSATION_KEY
             if changed:

--- a/utils/preferences.py
+++ b/utils/preferences.py
@@ -13,15 +13,24 @@
 # limitations under the License.
 
 import asyncio
+from contextlib import contextmanager
+from dataclasses import dataclass
 import json
 import os
+from pathlib import Path
+import threading
 from typing import Dict, Any, Optional, List
+
+import portalocker
+
 from utils.config_manager import get_config_manager
 from utils.cloudsave_runtime import MaintenanceModeError, assert_cloudsave_writable
 from utils.file_utils import atomic_write_json
 
 # 初始化配置管理器
 _config_manager = get_config_manager()
+_PREFERENCES_THREAD_LOCK = threading.RLock()
+_PREFERENCES_LOCK_TIMEOUT_SECONDS = 10
 
 
 def _get_preferences_read_path() -> str:
@@ -37,6 +46,20 @@ def _get_active_preferences_path() -> str:
     if os.path.exists(write_path):
         return write_path
     return _get_preferences_read_path()
+
+
+@contextmanager
+def _locked_preferences_store():
+    """Serialize every user_preferences.json read-modify-write."""
+    write_path = Path(_get_preferences_write_path())
+    write_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = write_path.with_name(f"{write_path.name}.lock")
+    with _PREFERENCES_THREAD_LOCK, portalocker.Lock(
+        str(lock_path),
+        mode="a+",
+        timeout=_PREFERENCES_LOCK_TIMEOUT_SECONDS,
+    ):
+        yield
 
 
 # 用户偏好文件路径（从配置管理器获取）
@@ -80,6 +103,13 @@ async def aload_user_preferences() -> List[Dict[str, Any]]:
     return await asyncio.to_thread(_sync_load)
 
 
+def _save_user_preferences_unlocked(preferences: List[Dict[str, Any]]) -> None:
+    """Write an already-prepared preference list while the caller holds the lock."""
+    global PREFERENCES_FILE
+    PREFERENCES_FILE = _get_preferences_write_path()
+    atomic_write_json(PREFERENCES_FILE, preferences, ensure_ascii=False, indent=2)
+
+
 def save_user_preferences(preferences: List[Dict[str, Any]]) -> bool:
     """
     Save user preferences
@@ -94,11 +124,8 @@ def save_user_preferences(preferences: List[Dict[str, Any]]) -> bool:
         assert_cloudsave_writable(_config_manager, operation="save", target="user_preferences.json")
         # 确保配置目录存在
         _config_manager.ensure_config_directory()
-        # 更新路径（可能已迁移）
-        global PREFERENCES_FILE
-        PREFERENCES_FILE = _get_preferences_write_path()
-        
-        atomic_write_json(PREFERENCES_FILE, preferences, ensure_ascii=False, indent=2)
+        with _locked_preferences_store():
+            _save_user_preferences_unlocked(preferences)
         return True
     except MaintenanceModeError:
         raise
@@ -107,6 +134,23 @@ def save_user_preferences(preferences: List[Dict[str, Any]]) -> bool:
         return False
 
 def update_model_preferences(model_path: str, position: Dict[str, float], scale: Dict[str, float], parameters: Optional[Dict[str, float]] = None, display: Optional[Dict[str, float]] = None, rotation: Optional[Dict[str, float]] = None, viewport: Optional[Dict[str, float]] = None, camera_position: Optional[Dict[str, float]] = None) -> bool:
+    """Update one model without racing another preference-file writer."""
+    try:
+        assert_cloudsave_writable(_config_manager, operation="save", target="user_preferences.json")
+        _config_manager.ensure_config_directory()
+        with _locked_preferences_store():
+            return _update_model_preferences_unlocked(
+                model_path, position, scale, parameters, display, rotation,
+                viewport, camera_position,
+            )
+    except MaintenanceModeError:
+        raise
+    except Exception as e:
+        print(f"更新模型偏好失败: {e}")
+        return False
+
+
+def _update_model_preferences_unlocked(model_path: str, position: Dict[str, float], scale: Dict[str, float], parameters: Optional[Dict[str, float]] = None, display: Optional[Dict[str, float]] = None, rotation: Optional[Dict[str, float]] = None, viewport: Optional[Dict[str, float]] = None, camera_position: Optional[Dict[str, float]] = None) -> bool:
     """
     Update preferences of the given model
 
@@ -202,8 +246,9 @@ def update_model_preferences(model_path: str, position: Dict[str, float], scale:
             # 添加新模型的偏好到列表开头（作为首选）
             current_preferences.insert(0, new_model_pref)
         
-        # 保存更新后的偏好
-        return save_user_preferences(current_preferences)
+        # 保存更新后的偏好；外层持有覆盖 load→save 的锁。
+        _save_user_preferences_unlocked(current_preferences)
+        return True
     except Exception as e:
         if isinstance(e, MaintenanceModeError):
             raise
@@ -282,6 +327,20 @@ def validate_model_preferences(preferences: Dict[str, Any]) -> bool:
     return True
 
 def move_model_to_top(model_path: str) -> bool:
+    """Move a model while holding the same lock as conversation settings."""
+    try:
+        assert_cloudsave_writable(_config_manager, operation="save", target="user_preferences.json")
+        _config_manager.ensure_config_directory()
+        with _locked_preferences_store():
+            return _move_model_to_top_unlocked(model_path)
+    except MaintenanceModeError:
+        raise
+    except Exception as e:
+        print(f"移动模型到顶部失败: {e}")
+        return False
+
+
+def _move_model_to_top_unlocked(model_path: str) -> bool:
     """
     Move the given model to the top of the list (make it preferred)
     
@@ -305,7 +364,8 @@ def move_model_to_top(model_path: str) -> bool:
             # 将模型移动到顶部
             model_pref = preferences.pop(model_index)
             preferences.insert(0, model_pref)
-            return save_user_preferences(preferences)
+            _save_user_preferences_unlocked(preferences)
+            return True
         else:
             # 如果模型不存在，返回False
             return False
@@ -331,6 +391,137 @@ _ALLOWED_CONVERSATION_SETTINGS = {
     'textGuardMaxLength', 'noiseReductionEnabled', 'independentAsrEnabled',
     'voiceInputResourceOptimizationEnabled'
 }
+_CONVERSATION_SETTINGS_REVISION_KEY = "_conversation_settings_revision"
+_CONVERSATION_SETTINGS_ASR_DECISION_KEY = "_independent_asr_decision"
+
+
+@dataclass(frozen=True)
+class ConversationSettingsSnapshot:
+    settings: Dict[str, Any]
+    revision: int
+    asr_decision: Optional[Dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class ConversationSettingsWriteResult:
+    success: bool
+    conflict: bool
+    snapshot: ConversationSettingsSnapshot
+
+
+def _normalize_conversation_settings_revision(value: Any) -> int:
+    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+        return value
+    return 0
+
+
+def _normalize_asr_decision(value: Any) -> Optional[Dict[str, Any]]:
+    if not isinstance(value, dict):
+        return None
+    write_id = value.get("writeId")
+    writer_id = value.get("writerId")
+    decision_value = value.get("value")
+    if (
+        not isinstance(write_id, int)
+        or isinstance(write_id, bool)
+        or write_id < 0
+        or not isinstance(writer_id, str)
+        or not writer_id
+        or len(writer_id) > 128
+        or not isinstance(decision_value, bool)
+    ):
+        return None
+    return {
+        "writeId": write_id,
+        "writerId": writer_id,
+        "value": decision_value,
+    }
+
+
+def _asr_decision_key(decision: Dict[str, Any]) -> tuple[int, str]:
+    return decision["writeId"], decision["writerId"]
+
+
+def _snapshot_from_preferences_data(data: Any) -> ConversationSettingsSnapshot:
+    if isinstance(data, dict):
+        data = [data]
+    if isinstance(data, list):
+        for pref in data:
+            if isinstance(pref, dict) and pref.get("model_path") == GLOBAL_CONVERSATION_KEY:
+                settings = {
+                    key: value
+                    for key, value in pref.items()
+                    if key in _ALLOWED_CONVERSATION_SETTINGS
+                }
+                decision = _normalize_asr_decision(
+                    pref.get(_CONVERSATION_SETTINGS_ASR_DECISION_KEY)
+                )
+                if (
+                    decision is not None
+                    and settings.get("independentAsrEnabled") != decision["value"]
+                ):
+                    decision = None
+                return ConversationSettingsSnapshot(
+                    settings=settings,
+                    revision=_normalize_conversation_settings_revision(
+                        pref.get(_CONVERSATION_SETTINGS_REVISION_KEY)
+                    ),
+                    asr_decision=decision,
+                )
+    return ConversationSettingsSnapshot(settings={}, revision=0, asr_decision=None)
+
+
+def _validate_conversation_settings(settings: Dict[str, Any]) -> Dict[str, Any]:
+    filtered_settings = {
+        key: value
+        for key, value in settings.items()
+        if key in _ALLOWED_CONVERSATION_SETTINGS
+    }
+    bool_fields = {
+        'proactiveChatEnabled', 'proactiveVisionEnabled', 'proactiveVisionChatEnabled',
+        'proactiveNewsChatEnabled', 'proactiveVideoChatEnabled', 'proactivePersonalChatEnabled',
+        'proactiveMusicEnabled', 'proactiveMemeEnabled', 'proactiveMiniGameInviteEnabled',
+        'mergeMessagesEnabled', 'focusModeEnabled', 'focusCognitionEnabled',
+        'avatarReactionBubbleEnabled', 'slopFilterEnabled', 'subtitleEnabled',
+        'noiseReductionEnabled', 'independentAsrEnabled',
+        'voiceInputResourceOptimizationEnabled'
+    }
+    int_interval_fields = {'proactiveChatInterval', 'proactiveVisionInterval'}
+    string_fields = {'userLanguage'}
+    int_limit_fields = {'textGuardMaxLength'}
+
+    validated = {}
+    for key, value in filtered_settings.items():
+        if key in bool_fields:
+            if isinstance(value, bool):
+                validated[key] = value
+        elif key in int_interval_fields:
+            if isinstance(value, int) and not isinstance(value, bool) and 1 <= value <= 3600:
+                validated[key] = value
+        elif key in string_fields:
+            if isinstance(value, str) and value:
+                validated[key] = value
+        elif key in int_limit_fields:
+            if isinstance(value, int) and not isinstance(value, bool) and 0 <= value <= 2000:
+                validated[key] = value
+    return validated
+
+
+def load_global_conversation_settings_snapshot(
+    *, strict: bool = False
+) -> ConversationSettingsSnapshot:
+    """Load settings together with the server revision and ASR decision token."""
+    try:
+        global PREFERENCES_FILE
+        PREFERENCES_FILE = _get_active_preferences_path()
+        if os.path.exists(PREFERENCES_FILE):
+            with open(PREFERENCES_FILE, 'r', encoding='utf-8') as f:
+                return _snapshot_from_preferences_data(json.load(f))
+    except Exception as e:
+        if strict:
+            raise
+        print(f"加载全局对话设置失败: {e}")
+    return ConversationSettingsSnapshot(settings={}, revision=0, asr_decision=None)
 
 
 def load_global_conversation_settings(*, strict: bool = False) -> Dict[str, Any]:
@@ -351,27 +542,22 @@ def load_global_conversation_settings(*, strict: bool = False) -> Dict[str, Any]
     Returns:
         Dict[str, Any]: conversation settings dict; empty dict when absent
     """
-    try:
-        global PREFERENCES_FILE
-        PREFERENCES_FILE = _get_active_preferences_path()
-        if os.path.exists(PREFERENCES_FILE):
-            with open(PREFERENCES_FILE, 'r', encoding='utf-8') as f:
-                data = json.load(f)
-                if isinstance(data, list):
-                    for pref in data:
-                        if pref.get('model_path') == GLOBAL_CONVERSATION_KEY:
-                            # 提取对话设置：仅返回白名单字段，防止泄露无关数据
-                            return {k: v for k, v in pref.items() if k in _ALLOWED_CONVERSATION_SETTINGS}
-    except Exception as e:
-        if strict:
-            raise
-        print(f"加载全局对话设置失败: {e}")
-    return {}
+    return load_global_conversation_settings_snapshot(strict=strict).settings
 
 
 async def aload_global_conversation_settings(*, strict: bool = False) -> Dict[str, Any]:
     """Async version of load_global_conversation_settings: for async paths, offloading sync IO."""
     return await asyncio.to_thread(load_global_conversation_settings, strict=strict)
+
+
+async def aload_global_conversation_settings_snapshot(
+    *, strict: bool = False
+) -> ConversationSettingsSnapshot:
+    """Async wrapper for the versioned conversation-settings read."""
+    return await asyncio.to_thread(
+        load_global_conversation_settings_snapshot,
+        strict=strict,
+    )
 
 
 def load_ui_language_override() -> Optional[str]:
@@ -417,112 +603,118 @@ async def ais_privacy_mode_enabled() -> bool:
     return not settings.get('proactiveVisionEnabled', True)
 
 
-def save_global_conversation_settings(settings: Dict[str, Any]) -> bool:
-    """
-    Save global conversation settings (written into the global entry of user_preferences.json)
-    Uses whitelist filtering, saving only allowed fields; model_path is pinned to the sentinel value
+def _load_preferences_data_for_write_unlocked() -> List[Dict[str, Any]]:
+    """Load the latest write-root snapshot while the caller holds the lock."""
+    global PREFERENCES_FILE
+    write_path = _get_preferences_write_path()
+    read_path = _get_preferences_read_path()
+    if os.path.exists(write_path):
+        PREFERENCES_FILE = write_path
+        with open(write_path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+    elif os.path.exists(read_path):
+        with open(read_path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        PREFERENCES_FILE = write_path
+    else:
+        PREFERENCES_FILE = write_path
+        data = []
 
-    Args:
-        settings (Dict[str, Any]): conversation settings dict to save
+    if isinstance(data, dict):
+        return [data]
+    if isinstance(data, list):
+        return data
+    return []
 
-    Returns:
-        bool: True on success, False on failure
-    """
+
+def save_global_conversation_settings_versioned(
+    settings: Dict[str, Any],
+    *,
+    expected_revision: Optional[int] = None,
+    asr_decision: Optional[Dict[str, Any]] = None,
+) -> ConversationSettingsWriteResult:
+    """Compare-and-set a partial conversation-settings update."""
+    empty_snapshot = ConversationSettingsSnapshot(
+        settings={}, revision=0, asr_decision=None
+    )
     try:
         assert_cloudsave_writable(_config_manager, operation="save", target="user_preferences.json")
-        # 确保配置目录存在，并使用最新路径（与 save_user_preferences 保持一致）
         _config_manager.ensure_config_directory()
-        global PREFERENCES_FILE
+        validated = _validate_conversation_settings(settings)
+        incoming_decision = _normalize_asr_decision(asr_decision)
+        if (
+            incoming_decision is not None
+            and validated.get("independentAsrEnabled") != incoming_decision["value"]
+        ):
+            incoming_decision = None
 
-        write_path = _get_preferences_write_path()
-        read_path = _get_preferences_read_path()
+        with _locked_preferences_store():
+            data = _load_preferences_data_for_write_unlocked()
+            current = _snapshot_from_preferences_data(data)
+            if expected_revision is not None and expected_revision != current.revision:
+                return ConversationSettingsWriteResult(
+                    success=False, conflict=True, snapshot=current
+                )
 
-        # 优先从写路径读取；若不存在则回退读路径（迁移旧版只读偏好数据）
-        if os.path.exists(write_path):
-            PREFERENCES_FILE = write_path
-            with open(PREFERENCES_FILE, 'r', encoding='utf-8') as f:
-                data = json.load(f)
-        elif os.path.exists(read_path):
-            with open(read_path, 'r', encoding='utf-8') as f:
-                data = json.load(f)
-            PREFERENCES_FILE = write_path
-        else:
-            PREFERENCES_FILE = write_path
-            data = []
+            if incoming_decision is not None and current.asr_decision is not None:
+                incoming_key = _asr_decision_key(incoming_decision)
+                current_key = _asr_decision_key(current.asr_decision)
+                if incoming_key < current_key or (
+                    incoming_key == current_key
+                    and incoming_decision["value"] != current.asr_decision["value"]
+                ):
+                    return ConversationSettingsWriteResult(
+                        success=False, conflict=True, snapshot=current
+                    )
 
-        if isinstance(data, dict):
-            # 兼容旧 dict 格式：包装为列表
-            data = [data]
-        elif not isinstance(data, list):
-            data = []
+            global_index = -1
+            for index, pref in enumerate(data):
+                if isinstance(pref, dict) and pref.get("model_path") == GLOBAL_CONVERSATION_KEY:
+                    global_index = index
+                    break
+            global_pref = data[global_index].copy() if global_index >= 0 else {}
+            previous_asr_value = global_pref.get("independentAsrEnabled")
+            changed = global_index < 0
+            for key, value in validated.items():
+                if global_pref.get(key) != value:
+                    changed = True
+                global_pref[key] = value
 
-        # 查找全局对话设置条目的索引
-        global_index = -1
-        for i, pref in enumerate(data):
-            if pref.get('model_path') == GLOBAL_CONVERSATION_KEY:
-                global_index = i
-                break
+            if "independentAsrEnabled" in validated:
+                if incoming_decision is not None:
+                    if (
+                        global_pref.get(_CONVERSATION_SETTINGS_ASR_DECISION_KEY)
+                        != incoming_decision
+                    ):
+                        changed = True
+                    global_pref[_CONVERSATION_SETTINGS_ASR_DECISION_KEY] = incoming_decision
+                elif previous_asr_value != validated["independentAsrEnabled"]:
+                    if _CONVERSATION_SETTINGS_ASR_DECISION_KEY in global_pref:
+                        changed = True
+                        global_pref.pop(_CONVERSATION_SETTINGS_ASR_DECISION_KEY, None)
 
-        # 白名单过滤：只保留允许的字段，防止恶意覆盖
-        filtered_settings = {k: v for k, v in settings.items() if k in _ALLOWED_CONVERSATION_SETTINGS}
+            global_pref["model_path"] = GLOBAL_CONVERSATION_KEY
+            if changed:
+                global_pref[_CONVERSATION_SETTINGS_REVISION_KEY] = current.revision + 1
+                if global_index >= 0:
+                    data[global_index] = global_pref
+                else:
+                    data.append(global_pref)
+                _save_user_preferences_unlocked(data)
 
-        # 值级别验证：确保字段类型和范围正确
-        _BOOL_FIELDS = {
-            'proactiveChatEnabled', 'proactiveVisionEnabled', 'proactiveVisionChatEnabled',
-            'proactiveNewsChatEnabled', 'proactiveVideoChatEnabled', 'proactivePersonalChatEnabled',
-            'proactiveMusicEnabled', 'proactiveMemeEnabled', 'proactiveMiniGameInviteEnabled',
-            'mergeMessagesEnabled', 'focusModeEnabled', 'focusCognitionEnabled',
-            'avatarReactionBubbleEnabled', 'slopFilterEnabled', 'subtitleEnabled',
-            'noiseReductionEnabled', 'independentAsrEnabled',
-            'voiceInputResourceOptimizationEnabled'
-        }
-        _INT_INTERVAL_FIELDS = {'proactiveChatInterval', 'proactiveVisionInterval'}
-        _STRING_FIELDS = {'userLanguage'}
-        _INT_LIMIT_FIELDS = {'textGuardMaxLength'}
-
-        validated = {}
-        for k, v in filtered_settings.items():
-            if k in _BOOL_FIELDS:
-                if isinstance(v, bool):
-                    validated[k] = v
-            elif k in _INT_INTERVAL_FIELDS:
-                # 单位：秒，与前端 ``app-state.js`` 的 S.proactive*Interval 一致；
-                # 前端使用时再 ×1000 转毫秒喂给 setTimeout。
-                if isinstance(v, int) and not isinstance(v, bool) and 1 <= v <= 3600:
-                    validated[k] = v
-            elif k in _STRING_FIELDS:
-                if isinstance(v, str) and v:
-                    validated[k] = v
-            elif k in _INT_LIMIT_FIELDS:
-                if isinstance(v, int) and not isinstance(v, bool) and 0 <= v <= 2000:
-                    validated[k] = v
-        filtered_settings = validated
-
-        # 合并到现有全局对话设置条目（保留未传入的字段，model_path 固定不可篡改）
-        if global_index >= 0:
-            global_pref = data[global_index].copy()
-        else:
-            global_pref = {}
-        global_pref['model_path'] = GLOBAL_CONVERSATION_KEY
-        global_pref.update(filtered_settings)
-
-        if global_index >= 0:
-            # 更新现有条目（保留其他模型偏好不变）
-            data[global_index] = global_pref
-        else:
-            # 添加新条目到列表末尾
-            data.append(global_pref)
-
-        atomic_write_json(PREFERENCES_FILE, data, ensure_ascii=False, indent=2)
-        # 注意：settings_state telemetry **不**在这里打。instrument_counters 按
-        # (stat_date, device_id, metric_key) 累加 UPSERT，若每次 save 都打点，
-        # 同一设备一天内切几次设置就会给多个 settings_state|... key 各 +1，
-        # dashboard 看到的是"观测次数"而非"用户当前/惯用设置"（CodeRabbit 指出）。
-        # 改为只在 record_app_start 打一次启动快照——"用户本次启动时的设置"，
-        # 跨多次启动按 device 看 mode 即可反推惯用档，语义干净得多。
-        return True
+            snapshot = _snapshot_from_preferences_data(data) if changed else current
+            return ConversationSettingsWriteResult(
+                success=True, conflict=False, snapshot=snapshot
+            )
     except MaintenanceModeError:
         raise
     except Exception as e:
         print(f"保存全局对话设置失败: {e}")
-        return False
+        return ConversationSettingsWriteResult(
+            success=False, conflict=False, snapshot=empty_snapshot
+        )
+
+
+def save_global_conversation_settings(settings: Dict[str, Any]) -> bool:
+    """Backward-compatible unconditional wrapper for internal writers."""
+    return save_global_conversation_settings_versioned(settings).success

--- a/utils/preferences.py
+++ b/utils/preferences.py
@@ -396,6 +396,7 @@ _CONVERSATION_SETTINGS_REVISION_KEY = "_conversation_settings_revision"
 _CONVERSATION_SETTINGS_ASR_DECISION_KEY = "_independent_asr_decision"
 _LEGACY_ASR_DECISION_WRITER_ID = "server-legacy"
 MAX_SAFE_ASR_WRITE_ID = 9_007_199_254_740_991
+ASR_WRITE_ID_MAX_FUTURE_SKEW_MS = 365 * 24 * 60 * 60 * 1000
 
 
 @dataclass(frozen=True)
@@ -424,11 +425,15 @@ def _normalize_asr_decision(value: Any) -> Optional[Dict[str, Any]]:
     write_id = value.get("writeId")
     writer_id = value.get("writerId")
     decision_value = value.get("value")
+    max_accepted_write_id = min(
+        MAX_SAFE_ASR_WRITE_ID - 1,
+        time.time_ns() // 1_000_000 + ASR_WRITE_ID_MAX_FUTURE_SKEW_MS,
+    )
     if (
         not isinstance(write_id, int)
         or isinstance(write_id, bool)
         or write_id < 0
-        or write_id > MAX_SAFE_ASR_WRITE_ID
+        or write_id > max_accepted_write_id
         or not isinstance(writer_id, str)
         or not writer_id
         or len(writer_id) > 128

--- a/utils/preferences.py
+++ b/utils/preferences.py
@@ -460,8 +460,16 @@ def _next_legacy_asr_decision(
     value: bool,
 ) -> Dict[str, Any]:
     current_write_id = current["writeId"] if current is not None else -1
+    now_ms = time.time_ns() // 1_000_000
+    max_accepted_write_id = min(
+        MAX_SAFE_ASR_WRITE_ID - 1,
+        now_ms + ASR_WRITE_ID_MAX_FUTURE_SKEW_MS,
+    )
     return {
-        "writeId": max(time.time_ns() // 1_000_000, current_write_id + 1),
+        "writeId": min(
+            max(now_ms, current_write_id + 1),
+            max_accepted_write_id,
+        ),
         "writerId": _LEGACY_ASR_DECISION_WRITER_ID,
         "value": value,
     }

--- a/utils/preferences.py
+++ b/utils/preferences.py
@@ -395,6 +395,7 @@ _ALLOWED_CONVERSATION_SETTINGS = {
 _CONVERSATION_SETTINGS_REVISION_KEY = "_conversation_settings_revision"
 _CONVERSATION_SETTINGS_ASR_DECISION_KEY = "_independent_asr_decision"
 _LEGACY_ASR_DECISION_WRITER_ID = "server-legacy"
+MAX_SAFE_ASR_WRITE_ID = 9_007_199_254_740_991
 
 
 @dataclass(frozen=True)
@@ -427,6 +428,7 @@ def _normalize_asr_decision(value: Any) -> Optional[Dict[str, Any]]:
         not isinstance(write_id, int)
         or isinstance(write_id, bool)
         or write_id < 0
+        or write_id > MAX_SAFE_ASR_WRITE_ID
         or not isinstance(writer_id, str)
         or not writer_id
         or len(writer_id) > 128
@@ -438,6 +440,10 @@ def _normalize_asr_decision(value: Any) -> Optional[Dict[str, Any]]:
         "writerId": writer_id,
         "value": decision_value,
     }
+
+
+def is_valid_asr_decision(value: Any) -> bool:
+    return _normalize_asr_decision(value) is not None
 
 
 def _asr_decision_key(decision: Dict[str, Any]) -> tuple[int, str]:

--- a/utils/preferences.py
+++ b/utils/preferences.py
@@ -672,6 +672,7 @@ def save_global_conversation_settings_versioned(
     *,
     expected_revision: Optional[int] = None,
     asr_decision: Optional[Dict[str, Any]] = None,
+    full_snapshot: bool = False,
 ) -> ConversationSettingsWriteResult:
     """Compare-and-set a partial conversation-settings update."""
     empty_snapshot = ConversationSettingsSnapshot(
@@ -715,7 +716,10 @@ def save_global_conversation_settings_versioned(
             global_pref = data[global_index].copy() if global_index >= 0 else {}
             previous_asr_value = global_pref.get("independentAsrEnabled")
             changed = global_index < 0
-            if global_pref.pop(CONVERSATION_SETTINGS_RESET_KEY, None) is not None:
+            if (
+                full_snapshot
+                and global_pref.pop(CONVERSATION_SETTINGS_RESET_KEY, None) is not None
+            ):
                 changed = True
             for key, value in validated.items():
                 if global_pref.get(key) != value:

--- a/utils/preferences.py
+++ b/utils/preferences.py
@@ -477,18 +477,12 @@ def _validate_conversation_settings(settings: Dict[str, Any]) -> Dict[str, Any]:
         for key, value in settings.items()
         if key in _ALLOWED_CONVERSATION_SETTINGS
     }
-    bool_fields = {
-        'proactiveChatEnabled', 'proactiveVisionEnabled', 'proactiveVisionChatEnabled',
-        'proactiveNewsChatEnabled', 'proactiveVideoChatEnabled', 'proactivePersonalChatEnabled',
-        'proactiveMusicEnabled', 'proactiveMemeEnabled', 'proactiveMiniGameInviteEnabled',
-        'mergeMessagesEnabled', 'focusModeEnabled', 'focusCognitionEnabled',
-        'avatarReactionBubbleEnabled', 'slopFilterEnabled', 'subtitleEnabled',
-        'noiseReductionEnabled', 'independentAsrEnabled',
-        'voiceInputResourceOptimizationEnabled'
-    }
     int_interval_fields = {'proactiveChatInterval', 'proactiveVisionInterval'}
     string_fields = {'userLanguage'}
     int_limit_fields = {'textGuardMaxLength'}
+    bool_fields = _ALLOWED_CONVERSATION_SETTINGS - (
+        int_interval_fields | string_fields | int_limit_fields
+    )
 
     validated = {}
     for key, value in filtered_settings.items():

--- a/utils/preferences.py
+++ b/utils/preferences.py
@@ -26,6 +26,11 @@ import portalocker
 
 from utils.config_manager import get_config_manager
 from utils.cloudsave_runtime import MaintenanceModeError, assert_cloudsave_writable
+from utils.conversation_settings_constants import (
+    ASR_WRITE_ID_MAX_FUTURE_SKEW_MS,
+    MAX_SAFE_ASR_WRITE_ID,
+    MAX_SAFE_CONVERSATION_SETTINGS_REVISION,
+)
 from utils.file_utils import atomic_write_json
 
 # 初始化配置管理器
@@ -395,11 +400,6 @@ _ALLOWED_CONVERSATION_SETTINGS = {
 _CONVERSATION_SETTINGS_REVISION_KEY = "_conversation_settings_revision"
 _CONVERSATION_SETTINGS_ASR_DECISION_KEY = "_independent_asr_decision"
 _LEGACY_ASR_DECISION_WRITER_ID = "server-legacy"
-MAX_SAFE_ASR_WRITE_ID = 9_007_199_254_740_991
-MAX_SAFE_CONVERSATION_SETTINGS_REVISION = 9_007_199_254_740_991
-ASR_WRITE_ID_MAX_FUTURE_SKEW_MS = 365 * 24 * 60 * 60 * 1000
-
-
 @dataclass(frozen=True)
 class ConversationSettingsSnapshot:
     settings: Dict[str, Any]

--- a/utils/preferences.py
+++ b/utils/preferences.py
@@ -458,14 +458,14 @@ def _asr_decision_key(decision: Dict[str, Any]) -> tuple[int, str]:
 def _next_legacy_asr_decision(
     current: Optional[Dict[str, Any]],
     value: bool,
-) -> Dict[str, Any]:
+) -> Optional[Dict[str, Any]]:
     current_write_id = current["writeId"] if current is not None else -1
     now_ms = time.time_ns() // 1_000_000
     max_accepted_write_id = min(
         MAX_SAFE_ASR_WRITE_ID - 1,
         now_ms + ASR_WRITE_ID_MAX_FUTURE_SKEW_MS,
     )
-    return {
+    decision = {
         "writeId": min(
             max(now_ms, current_write_id + 1),
             max_accepted_write_id,
@@ -473,6 +473,9 @@ def _next_legacy_asr_decision(
         "writerId": _LEGACY_ASR_DECISION_WRITER_ID,
         "value": value,
     }
+    if current is not None and _asr_decision_key(decision) <= _asr_decision_key(current):
+        return None
+    return decision
 
 
 def _snapshot_from_preferences_data(data: Any) -> ConversationSettingsSnapshot:
@@ -720,6 +723,12 @@ def save_global_conversation_settings_versioned(
                         current.asr_decision,
                         validated["independentAsrEnabled"],
                     )
+                    if legacy_decision is None:
+                        return ConversationSettingsWriteResult(
+                            success=False,
+                            conflict=True,
+                            snapshot=current,
+                        )
                     if (
                         global_pref.get(_CONVERSATION_SETTINGS_ASR_DECISION_KEY)
                         != legacy_decision

--- a/utils/preferences.py
+++ b/utils/preferences.py
@@ -27,6 +27,7 @@ import portalocker
 from utils.config_manager import get_config_manager
 from utils.cloudsave_runtime import MaintenanceModeError, assert_cloudsave_writable
 from utils.conversation_settings_constants import (
+    ALLOWED_CONVERSATION_SETTINGS as _ALLOWED_CONVERSATION_SETTINGS,
     ASR_WRITE_ID_MAX_FUTURE_SKEW_MS,
     CONVERSATION_SETTINGS_RESET_KEY,
     MAX_SAFE_ASR_WRITE_ID,
@@ -387,17 +388,6 @@ def _move_model_to_top_unlocked(model_path: str) -> bool:
 
 GLOBAL_CONVERSATION_KEY = "__global_conversation__"
 
-# 全局对话设置允许的字段（白名单）
-_ALLOWED_CONVERSATION_SETTINGS = {
-    'proactiveChatEnabled', 'proactiveVisionEnabled', 'proactiveVisionChatEnabled',
-    'proactiveNewsChatEnabled', 'proactiveVideoChatEnabled', 'proactivePersonalChatEnabled',
-    'proactiveMusicEnabled', 'proactiveMemeEnabled', 'proactiveMiniGameInviteEnabled',
-    'mergeMessagesEnabled', 'focusModeEnabled', 'focusCognitionEnabled',
-    'avatarReactionBubbleEnabled', 'slopFilterEnabled',
-    'proactiveChatInterval', 'proactiveVisionInterval', 'subtitleEnabled', 'userLanguage',
-    'textGuardMaxLength', 'noiseReductionEnabled', 'independentAsrEnabled',
-    'voiceInputResourceOptimizationEnabled'
-}
 _CONVERSATION_SETTINGS_REVISION_KEY = "_conversation_settings_revision"
 _CONVERSATION_SETTINGS_ASR_DECISION_KEY = "_independent_asr_decision"
 _LEGACY_ASR_DECISION_WRITER_ID = "server-legacy"

--- a/utils/preferences.py
+++ b/utils/preferences.py
@@ -396,6 +396,7 @@ _CONVERSATION_SETTINGS_REVISION_KEY = "_conversation_settings_revision"
 _CONVERSATION_SETTINGS_ASR_DECISION_KEY = "_independent_asr_decision"
 _LEGACY_ASR_DECISION_WRITER_ID = "server-legacy"
 MAX_SAFE_ASR_WRITE_ID = 9_007_199_254_740_991
+MAX_SAFE_CONVERSATION_SETTINGS_REVISION = 9_007_199_254_740_991
 ASR_WRITE_ID_MAX_FUTURE_SKEW_MS = 365 * 24 * 60 * 60 * 1000
 
 
@@ -414,7 +415,11 @@ class ConversationSettingsWriteResult:
 
 
 def _normalize_conversation_settings_revision(value: Any) -> int:
-    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+    if (
+        isinstance(value, int)
+        and not isinstance(value, bool)
+        and 0 <= value <= MAX_SAFE_CONVERSATION_SETTINGS_REVISION
+    ):
         return value
     return 0
 
@@ -437,6 +442,8 @@ def _normalize_asr_decision(value: Any) -> Optional[Dict[str, Any]]:
         or not isinstance(writer_id, str)
         or not writer_id
         or len(writer_id) > 128
+        or not writer_id.isascii()
+        or not writer_id.isprintable()
         or not isinstance(decision_value, bool)
     ):
         return None
@@ -738,6 +745,12 @@ def save_global_conversation_settings_versioned(
 
             global_pref["model_path"] = GLOBAL_CONVERSATION_KEY
             if changed:
+                if current.revision >= MAX_SAFE_CONVERSATION_SETTINGS_REVISION:
+                    return ConversationSettingsWriteResult(
+                        success=False,
+                        conflict=True,
+                        snapshot=current,
+                    )
                 global_pref[_CONVERSATION_SETTINGS_REVISION_KEY] = current.revision + 1
                 if global_index >= 0:
                     data[global_index] = global_pref


### PR DESCRIPTION
## 改动概述 / Summary

Fixes #2538。

- 为 `/api/config/conversation-settings` 增加 revision + ETag/If-Match 条件写入；冲突返回 `412` 和当前权威快照。
- 复用前端已有的 `(writeId, writerId, value)` ASR 决策全序，并通过请求头持久化到服务端，避免较旧窗口请求最后完成时覆盖较新选择。
- 客户端收到冲突后合并服务端赢家、重建请求并有界重试；请求体继续只包含原有设置字段。
- 用同一线程锁和 `portalocker` 跨进程锁覆盖 `user_preferences.json` 的完整 read-modify-write，同时保护模型偏好、主动搭话和内部设置写入，避免不同字段互相丢失。
- 补充英文、简中、日文 API 文档以及确定性并发、HTTP 契约和 Node 行为回归测试。

## 回归报告 / Regression Report

不适用：未修改 `app/`、`main_logic/` 或 `memory/`。

## 不拆分理由 / Why Not Split

不适用：计入上限的文件数不超过 20；服务端 CAS、浏览器重试和共享存储锁共同构成同一个原子修复，拆开会留下竞态窗口。

## 测试 / Testing

- `uv run ruff check utils/preferences.py main_routers/config_router/preferences.py tests/unit/test_preferences_concurrency.py`
- `uv run pytest tests/unit/test_preferences_concurrency.py tests/unit/test_app_websocket_static.py tests/unit/test_preferences_strict_read.py tests/unit/test_cloudsave_config_manager.py tests/unit/test_cloudsave_runtime.py tests/unit/test_proactive_interval_20s_rollback.py tests/unit/test_proactive_service_boundary.py tests/unit/test_core_independent_asr.py -q`
- 结果：436 passed，3 个既有 warning。
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 会话/偏好设置加入 ETag/If-Match 条件写入；冲突返回 `412` 并携带快照以支持合并后自动重试。
  - 独立 ASR 的跨窗口同步增加决策元组校验，并细化跨窗口“待确认/已确认/恢复”一致性机制。
- **改进/修复**
  - 噪声抑制等设置持久化改为走共享 CAS，减少乱序覆盖；首选模型更新使用非阻塞异步处理。
- **文档**
  - 更新中/日 API 文档，补充并发控制、`412` 响应与重试/条件写入约定。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->