### PR TITLE
fix(tests): tests/unit 的 Windows 定时假设收口为确定性同步点（#2528 第 1 步）

### DIFF
--- a/tests/unit/test_asr_voice_turn_adapter.py
+++ b/tests/unit/test_asr_voice_turn_adapter.py
@@ -287,6 +287,8 @@ async def test_silent_audio_does_not_extend_smart_turn_warm_ttl() -> None:
     await _eventually(lambda: coordinator.unload_calls == 1, timeout=2.0)
 
     await adapter.reset(generation=1, buffer_epoch=1, utterance_id=3)
+    armed = adapter._smart_turn_unload_task   # reset() 排下的这一轮 TTL 卸载
+    assert armed is not None
     await adapter.push_audio(
         generation=1,
         buffer_epoch=1,
@@ -295,8 +297,13 @@ async def test_silent_audio_does_not_extend_smart_turn_warm_ttl() -> None:
     )
     await _eventually(lambda: len(gate.feed_calls) == 1)
     # wait_idle 排空队列，保证这帧静音音频已被完整消费——若消费路径错误地
-    # 取消了 TTL 卸载，此刻取消就已经发生了，下面的轮询不会变成空过判定。
+    # 取消了 TTL 卸载，此刻取消就已经发生了，下面的断言不会变成空过判定。
     await adapter.wait_idle()
+    # 本用例的主张是「静音音频不给 TTL 续期」，光数 unload_calls 到 2 证明不了它：
+    # 续期就是 _cancel_smart_turn_unload + _schedule_smart_turn_unload，计数照样会
+    # 到 2、只是晚一轮 TTL。所以要断言 reset() 排下的**同一个**任务还挂着、没被取消。
+    assert adapter._smart_turn_unload_task is armed, "静音音频重排了 TTL 卸载任务"
+    assert not armed.cancelled()
     # 不能用固定 sleep 等 TTL 到点：Windows 事件循环 15.625ms 的时钟粒度下
     # sleep(0.03) 可能只等零毫秒（断言提前落地）。
     await _eventually(lambda: coordinator.unload_calls == 2, timeout=2.0)

--- a/tests/unit/test_asr_voice_turn_adapter.py
+++ b/tests/unit/test_asr_voice_turn_adapter.py
@@ -275,12 +275,16 @@ async def test_silent_audio_does_not_extend_smart_turn_warm_ttl() -> None:
         gate=gate,
         coordinator=coordinator,
         on_commit=_noop_commit,
-        smart_turn_warm_seconds=0.01,
+        # TTL 必须远大于「一帧音频被消费完」所需的时间：取 0.01s 时卸载往往在
+        # 音频进入消费路径之前就已触发，断言就证明不了「静音音频没有续期」。
+        smart_turn_warm_seconds=0.2,
     )
     await adapter.start()
 
     await adapter.reset(generation=1, buffer_epoch=1, utterance_id=2)
-    await _eventually(lambda: coordinator.unload_calls == 1)
+    # TTL 现在是 0.2s，默认 1.0s 的 deadline 只有 5 倍余量，CI 比本机慢一到两个
+    # 数量级，显式给到 2.0s。
+    await _eventually(lambda: coordinator.unload_calls == 1, timeout=2.0)
 
     await adapter.reset(generation=1, buffer_epoch=1, utterance_id=3)
     await adapter.push_audio(
@@ -290,7 +294,12 @@ async def test_silent_audio_does_not_extend_smart_turn_warm_ttl() -> None:
         pcm16=b"\x01\x00",
     )
     await _eventually(lambda: len(gate.feed_calls) == 1)
-    await asyncio.sleep(0.03)
+    # wait_idle 排空队列，保证这帧静音音频已被完整消费——若消费路径错误地
+    # 取消了 TTL 卸载，此刻取消就已经发生了，下面的轮询不会变成空过判定。
+    await adapter.wait_idle()
+    # 不能用固定 sleep 等 TTL 到点：Windows 事件循环 15.625ms 的时钟粒度下
+    # sleep(0.03) 可能只等零毫秒（断言提前落地）。
+    await _eventually(lambda: coordinator.unload_calls == 2, timeout=2.0)
 
     assert coordinator.unload_calls == 2
     await adapter.close()
@@ -752,9 +761,11 @@ async def test_required_incomplete_rechecks_and_only_complete_commits() -> None:
         gate=_FakeGate([(SpeechActivityEvent.CANDIDATE_PAUSE,)]),
         coordinator=coordinator,
         on_commit=commit,
-        continuation_timeout_seconds=0.02,
+        # 复查窗口取 0.5s（原为 0.02s）：Windows 时钟粒度 15.625ms，窗口太窄时
+        # 「还没复查」的断言点和复查定时器会落在同一格 ready，靠回调顺序决定输赢。
+        continuation_timeout_seconds=0.5,
         smart_turn_required=True,
-        max_endpoint_wait_seconds=0.2,
+        max_endpoint_wait_seconds=5.0,
     )
     await adapter.start()
 
@@ -762,10 +773,12 @@ async def test_required_incomplete_rechecks_and_only_complete_commits() -> None:
         generation=21, buffer_epoch=22, utterance_id=23, pcm16=b"\x01\x00"
     )
     await _eventually(lambda: coordinator.evaluate_calls == 1)
-    await asyncio.sleep(0.01)
+    # wait_idle 是确定性同步点：队列排空 + 评估任务与 commit 回调都已跑完，
+    # 所以 incomplete 若被错误地 commit，此刻 commits 一定非空——断言不会空过。
+    await adapter.wait_idle()
     assert commits == []
-    await _eventually(lambda: coordinator.evaluate_calls == 2)
-    await _eventually(lambda: commits == [(21, 22, 23)])
+    await _eventually(lambda: coordinator.evaluate_calls == 2, timeout=3.0)
+    await _eventually(lambda: commits == [(21, 22, 23)], timeout=3.0)
     assert commits == [(21, 22, 23)]
     await adapter.close()
 

--- a/tests/unit/test_core_independent_asr.py
+++ b/tests/unit/test_core_independent_asr.py
@@ -1347,7 +1347,11 @@ async def test_provider_final_watchdog_blocks_only_independent_asr() -> None:
     runtime._asr_detector = _ReadyDetector()
 
     await _start_and_seal_turn(runtime)
-    await asyncio.sleep(0.03)
+    # 10ms 超时跟 Windows 的 15.6ms 定时器分辨率同量级，固定 sleep 到底睡多久
+    # 完全看运气；守护任务跑完才是「已开火」的权威信号，直接等它。
+    watchdog = runtime._asr_final_watchdog_task
+    assert watchdog is not None
+    await asyncio.wait_for(watchdog, 5)
 
     assert runtime._asr_route_mode == "blocked"
     runtime.handle_input_transcript.assert_not_awaited()
@@ -1365,7 +1369,9 @@ async def test_provider_final_watchdog_honors_per_provider_policy_timeout() -> N
     # default; scale both down so the watchdog must track the policy value.
     policy = replace(
         resolve_provider_policy("glm", "manual"),
-        provider_final_timeout_ms=80,
+        # 500ms 而不是 80ms：下面「还没到点」那半只能靠时间证明，被测窗口必须
+        # 远大于 Windows 的 15.6ms 定时器分辨率，否则余量不到一个 tick。
+        provider_final_timeout_ms=500,
     )
     assert resolve_provider_policy("glm", "manual").provider_final_timeout_ms == 40_000
     runtime._asr_lifecycle = VoiceInputLifecycleController(
@@ -1376,13 +1382,21 @@ async def test_provider_final_watchdog_honors_per_provider_policy_timeout() -> N
     runtime._asr_detector = _ReadyDetector()
 
     await _start_and_seal_turn(runtime, "glm")
-    await asyncio.sleep(0.03)
+    watchdog = runtime._asr_final_watchdog_task
+    assert watchdog is not None
 
+    # 单个 sleep 睡了多久在 Windows 上不可信（15.6ms 分辨率，既会提前弹出也会
+    # 超发），所以只信真实时钟：轮询到确实过了 150ms —— 远超一个 tick，也远小于
+    # 上面的 500ms 窗口。
     # A watchdog stuck on the shared default (10 ms in the scaled test above)
     # would have fired by now; the per-provider override keeps it armed.
-    assert runtime._asr_route_mode == "independent"
+    deadline = time.monotonic() + 0.15
+    while time.monotonic() < deadline:
+        await asyncio.sleep(0.005)
+        assert runtime._asr_route_mode == "independent"
 
-    await asyncio.sleep(0.09)
+    # 正向那半不猜时间：守护任务自己跑完（内部 await 完错误处理才结束）即同步点。
+    await asyncio.wait_for(watchdog, 5)
 
     assert runtime._asr_route_mode == "blocked"
 
@@ -2175,7 +2189,11 @@ async def test_initial_ready_transport_also_expires_from_local_listen() -> None:
     runtime._asr_lifecycle.open(route_mode=VoiceRouteMode.INDEPENDENT)
 
     runtime._schedule_transport_warm_expiry(runtime._asr_session_epoch)
-    await asyncio.sleep(0.03)
+    # 同上：10ms TTL 落在 Windows 定时器分辨率的量级里，固定 sleep 赌不起；
+    # 到期任务本身就是「已过期并关闭」的同步点。
+    expiry = runtime._asr_warm_expiry_task
+    assert expiry is not None
+    await asyncio.wait_for(expiry, 5)
 
     assert runtime._asr_session is None
     assert runtime._asr_lifecycle.snapshot.state is VoiceLifecycleState.DEEP_SLEEP

--- a/tests/unit/test_core_independent_asr.py
+++ b/tests/unit/test_core_independent_asr.py
@@ -1382,6 +1382,7 @@ async def test_provider_final_watchdog_honors_per_provider_policy_timeout() -> N
     runtime._asr_detector = _ReadyDetector()
 
     await _start_and_seal_turn(runtime, "glm")
+    armed_at = time.monotonic()
     watchdog = runtime._asr_final_watchdog_task
     assert watchdog is not None
 
@@ -1392,7 +1393,7 @@ async def test_provider_final_watchdog_honors_per_provider_policy_timeout() -> N
     # 先断言就会把「事后才发生」误报成「窗口内提前开火」。
     # A watchdog stuck on the shared default (10 ms in the scaled test above)
     # would have fired by now; the per-provider override keeps it armed.
-    deadline = time.monotonic() + 0.15
+    deadline = armed_at + 0.15
     while True:
         await asyncio.sleep(0.005)
         if time.monotonic() >= deadline:
@@ -1401,8 +1402,15 @@ async def test_provider_final_watchdog_honors_per_provider_policy_timeout() -> N
 
     # 正向那半不猜时间：守护任务自己跑完（内部 await 完错误处理才结束）即同步点。
     await asyncio.wait_for(watchdog, 5)
+    elapsed = time.monotonic() - armed_at
 
     assert runtime._asr_route_mode == "blocked"
+    # 上界也必须钉住，否则这条用例只主张「五秒内会开火」：把 per-provider 超时写成
+    # 常量 2s、或者把 ms 当成 s 换算错的回归，在 150ms 观察窗口里同样还是
+    # independent，然后在 5s 内跑完，照样通过。配置是 500ms，给 3 倍余量。
+    assert elapsed < 1.5, (
+        f"守护任务没有按 per-provider 的 500ms 超时开火，实际 {elapsed:.3f}s"
+    )
 
 
 async def test_optimization_disabled_continuously_uploads_with_smart_turn() -> None:

--- a/tests/unit/test_core_independent_asr.py
+++ b/tests/unit/test_core_independent_asr.py
@@ -1387,12 +1387,16 @@ async def test_provider_final_watchdog_honors_per_provider_policy_timeout() -> N
 
     # 单个 sleep 睡了多久在 Windows 上不可信（15.6ms 分辨率，既会提前弹出也会
     # 超发），所以只信真实时钟：轮询到确实过了 150ms —— 远超一个 tick，也远小于
-    # 上面的 500ms 窗口。
+    # 上面的 500ms 窗口。醒来后必须先复查挂钟再断言：这一觉可能被别的任务拖长而
+    # 睡过了观察窗口（甚至睡过 500ms 守护窗口），那时守护任务改成 blocked 是合法的，
+    # 先断言就会把「事后才发生」误报成「窗口内提前开火」。
     # A watchdog stuck on the shared default (10 ms in the scaled test above)
     # would have fired by now; the per-provider override keeps it armed.
     deadline = time.monotonic() + 0.15
-    while time.monotonic() < deadline:
+    while True:
         await asyncio.sleep(0.005)
+        if time.monotonic() >= deadline:
+            break
         assert runtime._asr_route_mode == "independent"
 
     # 正向那半不猜时间：守护任务自己跑完（内部 await 完错误处理才结束）即同步点。

--- a/tests/unit/test_event_log.py
+++ b/tests/unit/test_event_log.py
@@ -424,6 +424,15 @@ def test_serialization_oracle_rejects_unlocked_mode(tmp_path):
     log = _fresh_log(str(tmp_path))
     # Replace per-character lock with a no-op context manager
     log._get_lock = lambda name: nullcontext()
+    # 锁一拆，record_and_save 收尾那句哨兵落盘也跟着失去串行化，5 个线程会同时
+    # os.replace 到同一个 events_applied.json —— Windows 上直接 WinError 5。哨兵
+    # 落盘不是本用例的被测对象（上一条正向 oracle 才覆盖它），所以给每个线程一个
+    # 独立的哨兵文件名：真实写盘路径照跑，只是不再互抢同一个目标。
+    _real_sentinel_path = log._sentinel_path
+    log._sentinel_path = lambda name: os.path.join(
+        os.path.dirname(_real_sentinel_path(name)),
+        f"events_applied_{real_threading.get_ident()}.json",
+    )
 
     num_workers = 5
     mutable_view = {"value": 0}
@@ -483,7 +492,14 @@ def test_concurrent_append_during_compact_preserves_events(tmp_path):
 
     t = real_threading.Thread(target=appender, daemon=True)
     t.start()
-    time.sleep(0.02)  # let appender get going
+    # 不能用固定 sleep 猜「线程起来了没」：线程启动延迟不受控，而 Windows 上
+    # sleep 的实际时长又是 15.6ms 粒度的抛硬币；睡短了 compact 会在第一次并发
+    # append 之前就跑完，用例静默退化成非并发、断言恒真。改成轮询到确实已经
+    # 写出一条事件，并发前提才是确定的。
+    _deadline = time.monotonic() + 5.0
+    while not appended_ids and not append_errors and time.monotonic() < _deadline:
+        time.sleep(0.001)
+    assert appended_ids or append_errors, "appender 线程 5s 内一条都没写出，并发前提不成立"
 
     with patch("memory.event_log._COMPACT_LINES_THRESHOLD", 1):
         log.compact_if_needed("小天", lambda: [(EVT_FACT_ADDED, {"seed": "kept"})])

--- a/tests/unit/test_minimax_tts_worker.py
+++ b/tests/unit/test_minimax_tts_worker.py
@@ -501,17 +501,19 @@ def test_minimax_worker_incremental_synthesis_on_punctuation(monkeypatch):
     )
     assert audio_item[1] == "speech-1"
 
+    # 第二次合成由 worker 线程在收到 (None, None) 后发起，跨线程边界，睡固定时长
+    # 在 Windows 上等于抛硬币（时钟精度 15.6ms，忙循环里 sleep 可能等于零等待）。
+    # close() 的停止哨兵是 put 到 FIFO 队尾的，先前的 (None, None) 必然先被处理完，
+    # 所以 join 返回即代表两次合成都已发出——这是确定性的收尾点。
+    request_queue.close()
+    thread.join(timeout=3.0)
+    assert not thread.is_alive()
+
     # 应该有两个合成请求：一个是句号切分的，一个是 flush 的
-    # 等待 flush 合成也完成（第二个音频块）
-    time.sleep(0.5)
     synth_requests = [r for r in transport.requests if r.get("stream")]
     assert len(synth_requests) == 2
     assert synth_requests[0]["text"] == "你好世界。"
     assert synth_requests[1]["text"] == "今天天气"
-
-    request_queue.close()
-    thread.join(timeout=3.0)
-    assert not thread.is_alive()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_proactive_agent_trigger.py
+++ b/tests/unit/test_proactive_agent_trigger.py
@@ -310,12 +310,23 @@ def test_proactive_openclaw_dispatch_uses_default_sender(monkeypatch):
         {"role": "assistant", "content": "我帮你查下天气"},
     ]
 
+    async def _settle_dispatch(task_id):
+        # 不能靠固定 sleep 收尾 run_instruction：Windows 事件循环时钟精度 15.625ms，
+        # 循环里还挂着这个后台任务时 sleep(0.02) 会被提前弹出、实测等于零等待，任务就
+        # 留到 asyncio.run 关闭时才被取消 —— 取消分支会往真实的 _task_tracker 写一条
+        # cancelled 记录，污染进程内共享状态。dispatch 自己把句柄登记在
+        # task_async_handles 里，直接等它才是确定的同步点（已跑完则 done_callback
+        # 已把句柄摘掉，取不到即代表已收尾）。
+        handle = oc._shared.Modules.task_async_handles.get(task_id)
+        if handle is not None:
+            await asyncio.gather(handle, return_exceptions=True)
+
     async def _drive():
         await oc.dispatch(
             _Result(), messages=msgs, lanlan_name="lan",
             conversation_id="c", trigger_user_msg_sig=None, proactive=True,
         )
-        await asyncio.sleep(0.02)  # let the spawned run_instruction task settle
+        await _settle_dispatch(_Result.task_id)
 
     asyncio.run(_drive())
     assert captured.get("sender_id") == "DEFAULT_SENDER"
@@ -328,7 +339,7 @@ def test_proactive_openclaw_dispatch_uses_default_sender(monkeypatch):
             _Result(), messages=msgs, lanlan_name="lan",
             conversation_id="c", trigger_user_msg_sig=None, proactive=False,
         )
-        await asyncio.sleep(0.02)
+        await _settle_dispatch(_Result.task_id)
 
     asyncio.run(_drive_user())
     assert captured.get("sender_id") == "USER_A"

--- a/tests/unit/test_proactive_delivery.py
+++ b/tests/unit/test_proactive_delivery.py
@@ -49,19 +49,19 @@ async def _wait_until(predicate, *, timeout=5.0, what="condition"):
         await asyncio.sleep(0.005)
 
 
-async def _stays_true(predicate, *, seconds, what="condition"):
-    # 按真实时钟走满一段窗口，期间每圈复查。"窗口内还没发生"这类负向断言只在
-    # 一瞬间取样是没有牙齿的：被测窗口被误缩短十倍时单点取样照样通过（实测过），
+async def _stays_true(predicate, *, until, what="condition"):
+    # 按真实时钟走到 until（绝对时刻），期间每圈复查。"窗口内还没发生"这类负向断言
+    # 只在一瞬间取样是没有牙齿的：被测窗口被误缩短十倍时单点取样照样通过（实测过），
     # 只有按真实时钟走一段才测得出窗口本身还在。
+    # until 必须是绝对时刻而不是时长：相对时长会在前面的等待被拖长时把观察窗口推到
+    # 被测窗口之外，那时发生的放行是合法的，断言就变成假红。
     loop = asyncio.get_running_loop()
-    deadline = loop.time() + seconds
     while True:
         await asyncio.sleep(0.005)
-        # 醒来后先复查挂钟再断言。这一觉可能被别的任务拖长而睡过了窗口，此时窗口
-        # 外发生的放行是合法的，先断言就会把「事后才发生」误报成「窗口内破了」。
-        if loop.time() >= deadline:
+        # 醒来后先复查挂钟再断言。这一觉可能被别的任务拖长而睡过了窗口。
+        if loop.time() >= until:
             return
-        assert predicate(), f"{what} broke within {seconds}s"
+        assert predicate(), f"{what} broke before {until}"
 
 
 def test_effective_priority_normalisation():
@@ -188,15 +188,20 @@ async def test_min_gap_delays_release():
     delivered = []
     # min-gap 抬到 1.0s：负向断言必须落在窗口内，而 Windows 上 sleep 和 pump 各
     # 自会超发一格时钟（15.625ms），0.2s 的窗口给"还没到点"留的余量不足十倍。
-    mgr = _make(delivered, min_gap_s=1.0)
+    min_gap = 1.0
+    mgr = _make(delivered, min_gap_s=min_gap)
+    loop = asyncio.get_running_loop()
     mgr.on_playback_start()
     mgr.submit({"id": "x"}, priority=1)
     mgr.on_playback_end()           # records last_play_end; gap not elapsed
+    window_end = loop.time() + min_gap
     # 不能先 _settle() 再裸断言：那是 5 次不受检的真实 sleep，被拖长到超过 min-gap
-    # 之后放行是合法的，裸断言就会假红。直接交给 _stays_true —— 它每次醒来先复查挂钟，
-    # 而第一次醒来（约 5ms）时 call_later(0) 那轮 pump 早已跑过，所以「不受 min-gap
-    # 约束就会立刻放行」这个回归照样会被第一次断言抓住。走满 min-gap 的 40%。
-    await _stays_true(lambda: delivered == [], seconds=0.4, what="min-gap window")
+    # 之后放行是合法的，裸断言就会假红。交给 _stays_true 并给它**绝对**的窗口终点，
+    # 第一次醒来（约 5ms）时 call_later(0) 那轮 pump 早已跑过，所以「不受 min-gap
+    # 约束就会立刻放行」这个回归照样会被第一次断言抓住。走到窗口的 80% 处收手。
+    await _stays_true(
+        lambda: delivered == [], until=window_end - 0.2, what="min-gap window"
+    )
     await _wait_until(lambda: bool(delivered), what="min-gap release")
     assert [c["id"] for c in delivered] == ["x"]
 
@@ -205,20 +210,28 @@ async def test_playing_watchdog_recovers_missing_play_end():
     # voice_play_start with no matching voice_play_end (frontend disconnect)
     # must not wedge the queue forever — the max_play watchdog re-opens it.
     delivered = []
-    mgr = _make(delivered, max_play_s=0.5)
+    max_play = 0.5
+    mgr = _make(delivered, max_play_s=max_play)
+    loop = asyncio.get_running_loop()
     mgr.on_playback_start()          # ...and voice_play_end never arrives
+    window_end = loop.time() + max_play
     mgr.submit({"id": "x"}, priority=1)
     armed = mgr._pump_handle         # the call_later(0) submit just scheduled
     # 负向那半不睡固定时长：0.05s 的 sleep 在 Windows 上实际耗 62.5ms，离窗口边界
     # 只剩几格时钟，随时滑过看门狗变假红。改成等这一轮 pump 真的跑完——它没有放
     # 行，而是把自己重排到看门狗到点（handle 被换掉），这才是"窗口内"的确定证据。
     await _wait_until(lambda: mgr._pump_handle is not armed, what="first pump run")
-    assert delivered == []           # still within max_play window
-    assert mgr._playing              # 闸门确实还关着，正向断言才不会空过
-    assert mgr._pump_handle is not None  # 看门狗自己会到点，不靠外部再踢一脚
-    # 走满 max_play 的 40%：上面几条只是窗口内某一瞬的取样，看门狗窗口被误缩短
-    # 时它们照样通过，只有按真实时钟走一段才能证明窗口本身还在。
-    await _stays_true(lambda: delivered == [], seconds=0.2, what="max_play window")
+    # 但要先确认这一轮 pump 仍落在看门狗窗口内才有资格断言「还没放行」：事件循环被
+    # 拖到窗口之后才跑第一轮 pump 时，那一轮直接走看门狗分支放行是**正确行为**。
+    if loop.time() < window_end:
+        assert delivered == []           # still within max_play window
+        assert mgr._playing              # 闸门确实还关着，正向断言才不会空过
+        assert mgr._pump_handle is not None  # 看门狗自己会到点，不靠外部再踢一脚
+        # 上面几条只是窗口内某一瞬的取样，看门狗窗口被误缩短时它们照样通过；
+        # 只有按真实时钟走到窗口的 80% 处才能证明窗口本身还在。
+        await _stays_true(
+            lambda: delivered == [], until=window_end - 0.1, what="max_play window"
+        )
     await _wait_until(lambda: bool(delivered), what="watchdog release")
     assert [c["id"] for c in delivered] == ["x"]
 

--- a/tests/unit/test_proactive_delivery.py
+++ b/tests/unit/test_proactive_delivery.py
@@ -37,6 +37,29 @@ async def _settle():
         await asyncio.sleep(0.01)
 
 
+async def _wait_until(predicate, *, timeout=5.0, what="condition"):
+    # 轮询到条件成立，超时才报错。不能用固定 sleep 等后台跑完：Windows 事件
+    # 循环时钟精度 15.625ms，短于一格的 sleep 会在下一轮循环立刻返回（等于零
+    # 等待），长于一格的又成倍超发，等多久完全取决于与被测逻辑无关的其它活动。
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while not predicate():
+        if loop.time() >= deadline:
+            raise AssertionError(f"{what} not satisfied within {timeout}s")
+        await asyncio.sleep(0.005)
+
+
+async def _stays_true(predicate, *, seconds, what="condition"):
+    # 按真实时钟走满一段窗口，期间每圈复查。"窗口内还没发生"这类负向断言只在
+    # 一瞬间取样是没有牙齿的：被测窗口被误缩短十倍时单点取样照样通过（实测过），
+    # 只有按真实时钟走一段才测得出窗口本身还在。
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + seconds
+    while loop.time() < deadline:
+        await asyncio.sleep(0.005)
+        assert predicate(), f"{what} broke within {seconds}s"
+
+
 def test_effective_priority_normalisation():
     # HIGHER = more important; unspecified / invalid → 0 (least important).
     assert effective_priority(1) == 1
@@ -159,13 +182,17 @@ async def test_noop_release_frees_inflight_slot_immediately():
 
 async def test_min_gap_delays_release():
     delivered = []
-    mgr = _make(delivered, min_gap_s=0.2)
+    # min-gap 抬到 1.0s：负向断言必须落在窗口内，而 Windows 上 sleep 和 pump 各
+    # 自会超发一格时钟（15.625ms），0.2s 的窗口给"还没到点"留的余量不足十倍。
+    mgr = _make(delivered, min_gap_s=1.0)
     mgr.on_playback_start()
     mgr.submit({"id": "x"}, priority=1)
     mgr.on_playback_end()           # records last_play_end; gap not elapsed
-    await asyncio.sleep(0.05)
+    await _settle()                 # 不受 min-gap 约束的话 call_later(0) 早放行了
     assert delivered == []          # still inside min-gap
-    await asyncio.sleep(0.3)
+    # 走满 min-gap 的 40%：只取一瞬间的样证明不了 min-gap 还在生效。
+    await _stays_true(lambda: delivered == [], seconds=0.4, what="min-gap window")
+    await _wait_until(lambda: bool(delivered), what="min-gap release")
     assert [c["id"] for c in delivered] == ["x"]
 
 
@@ -173,12 +200,21 @@ async def test_playing_watchdog_recovers_missing_play_end():
     # voice_play_start with no matching voice_play_end (frontend disconnect)
     # must not wedge the queue forever — the max_play watchdog re-opens it.
     delivered = []
-    mgr = _make(delivered, max_play_s=0.1)
+    mgr = _make(delivered, max_play_s=0.5)
     mgr.on_playback_start()          # ...and voice_play_end never arrives
     mgr.submit({"id": "x"}, priority=1)
-    await asyncio.sleep(0.05)
+    armed = mgr._pump_handle         # the call_later(0) submit just scheduled
+    # 负向那半不睡固定时长：0.05s 的 sleep 在 Windows 上实际耗 62.5ms，离窗口边界
+    # 只剩几格时钟，随时滑过看门狗变假红。改成等这一轮 pump 真的跑完——它没有放
+    # 行，而是把自己重排到看门狗到点（handle 被换掉），这才是"窗口内"的确定证据。
+    await _wait_until(lambda: mgr._pump_handle is not armed, what="first pump run")
     assert delivered == []           # still within max_play window
-    await asyncio.sleep(0.2)         # exceed watchdog
+    assert mgr._playing              # 闸门确实还关着，正向断言才不会空过
+    assert mgr._pump_handle is not None  # 看门狗自己会到点，不靠外部再踢一脚
+    # 走满 max_play 的 40%：上面几条只是窗口内某一瞬的取样，看门狗窗口被误缩短
+    # 时它们照样通过，只有按真实时钟走一段才能证明窗口本身还在。
+    await _stays_true(lambda: delivered == [], seconds=0.2, what="max_play window")
+    await _wait_until(lambda: bool(delivered), what="watchdog release")
     assert [c["id"] for c in delivered] == ["x"]
 
 

--- a/tests/unit/test_proactive_delivery.py
+++ b/tests/unit/test_proactive_delivery.py
@@ -55,8 +55,12 @@ async def _stays_true(predicate, *, seconds, what="condition"):
     # 只有按真实时钟走一段才测得出窗口本身还在。
     loop = asyncio.get_running_loop()
     deadline = loop.time() + seconds
-    while loop.time() < deadline:
+    while True:
         await asyncio.sleep(0.005)
+        # 醒来后先复查挂钟再断言。这一觉可能被别的任务拖长而睡过了窗口，此时窗口
+        # 外发生的放行是合法的，先断言就会把「事后才发生」误报成「窗口内破了」。
+        if loop.time() >= deadline:
+            return
         assert predicate(), f"{what} broke within {seconds}s"
 
 

--- a/tests/unit/test_proactive_delivery.py
+++ b/tests/unit/test_proactive_delivery.py
@@ -192,9 +192,10 @@ async def test_min_gap_delays_release():
     mgr.on_playback_start()
     mgr.submit({"id": "x"}, priority=1)
     mgr.on_playback_end()           # records last_play_end; gap not elapsed
-    await _settle()                 # 不受 min-gap 约束的话 call_later(0) 早放行了
-    assert delivered == []          # still inside min-gap
-    # 走满 min-gap 的 40%：只取一瞬间的样证明不了 min-gap 还在生效。
+    # 不能先 _settle() 再裸断言：那是 5 次不受检的真实 sleep，被拖长到超过 min-gap
+    # 之后放行是合法的，裸断言就会假红。直接交给 _stays_true —— 它每次醒来先复查挂钟，
+    # 而第一次醒来（约 5ms）时 call_later(0) 那轮 pump 早已跑过，所以「不受 min-gap
+    # 约束就会立刻放行」这个回归照样会被第一次断言抓住。走满 min-gap 的 40%。
     await _stays_true(lambda: delivered == [], seconds=0.4, what="min-gap window")
     await _wait_until(lambda: bool(delivered), what="min-gap release")
     assert [c["id"] for c in delivered] == ["x"]

--- a/tests/unit/test_topic_pipeline.py
+++ b/tests/unit/test_topic_pipeline.py
@@ -2105,8 +2105,14 @@ async def test_topic_pool_does_not_trigger_second_topic_immediately_after_first(
     pool.note_user_message("妮可", "第一轮认真聊一个深话题，里面有足够多的具体背景、现实纠结、近期计划和反复提到的细节", lang="zh-CN")
     await pool.process_now("妮可")
     # 首投在后台 trigger task 里落地，固定 sleep 是抛硬币；等它真的投出来。
+    # 光等 delivered 不够：fake_trigger 在 _run_trigger_when_available 走到
+    # to_thread 落盘、清掉当前 pending material 之前就已经 append 了，此时第二次
+    # process_now 会撞上「已有 pending material」的提前返回，第二个话题根本不会被
+    # 分析，下面等 deferred_delays 就只能超时。所以要等 trigger task 自己收尾。
     deadline = time.monotonic() + 5.0
-    while not delivered and time.monotonic() < deadline:
+    while (
+        not delivered or pool._trigger_tasks.get("妮可")
+    ) and time.monotonic() < deadline:
         await asyncio.sleep(0.01)
     assert delivered == ["凯迪拉克预算压力"]
 

--- a/tests/unit/test_topic_pipeline.py
+++ b/tests/unit/test_topic_pipeline.py
@@ -728,10 +728,14 @@ async def test_topic_pool_preserves_post_candidate_signals_after_delivery():
 
     # 投递后的 signal 清理挂在 to_thread flush 之后，固定 sleep 只是在赌它做完了；
     # 轮询这条链的终点，超时后照旧交给下面的断言报错。
+    # 内存里的 signal 被摘掉只是链条的中段——_discard_delivered_signals_async 先同步
+    # 摘除、之后才 await flush，所以还要等 trigger task 本身收尾，否则用例会在它仍在
+    # 飞的时候返回，落到 pytest teardown 去取消它。
     deadline = time.monotonic() + 5.0
     while (
         not delivered
         or "旧话题" in pool._signal_store.format_global_signals("妮可", lang="zh-CN")
+        or pool._trigger_tasks.get("妮可")
     ) and time.monotonic() < deadline:
         await asyncio.sleep(0.01)
 
@@ -2092,8 +2096,9 @@ async def test_topic_pool_does_not_trigger_second_topic_immediately_after_first(
         topic_trigger=fake_trigger,
         trigger_delay_seconds=0.01,
         # 0.2s 的间隔只比一个 Windows 定时器 tick（约 15.6ms，且 sleep 会超发 20%+）
-        # 大一个量级，抬到 0.5s 让「窗口还没过」这件事有十倍以上余量。
-        min_trigger_gap_seconds=0.5,
+        # 大一个量级；抬到 1.0s 既让「窗口还没过」有余量，也给下面那条改期延迟的
+        # 断言留出「从首投到第二次 gap 检查之间过去了多久」的不可控开销。
+        min_trigger_gap_seconds=1.0,
         min_user_turns_for_topic=1,
     )
 
@@ -2123,9 +2128,12 @@ async def test_topic_pool_does_not_trigger_second_topic_immediately_after_first(
     while not deferred_delays and time.monotonic() < deadline:
         await asyncio.sleep(0.01)
     assert deferred_delays, "第二个话题的 trigger 没有被 min trigger gap 改期"
-    # 改期这件事本身还不够：min gap 被误缩短时 trigger 照样会改期一小段，
-    # 断言就成了恒真。改期的延迟必须接近整个 gap，才说明 gap 真的在生效。
-    assert deferred_delays[0] > 0.4, f"min trigger gap 没有生效: {deferred_delays}"
+    # 改期这件事本身还不够：min gap 被误缩短时 trigger 照样会改期一小段，断言就成了
+    # 恒真。但也不能拿延迟去跟整个 gap 比——延迟是「gap 减去已经过去的时间」，而从
+    # 首投到第二次 gap 检查之间过去多久不受控（中间夹着轮询、又一次 process_now、
+    # to_thread 交接）。取一个既远大于「gap 被误缩十倍」后的上限（0.1s）、又给挂钟
+    # 留出 0.85s 余量的门槛。
+    assert deferred_delays[0] > 0.15, f"min trigger gap 没有生效: {deferred_delays}"
     assert delivered == ["凯迪拉克预算压力"]
 
     deadline = time.monotonic() + 5.0

--- a/tests/unit/test_topic_pipeline.py
+++ b/tests/unit/test_topic_pipeline.py
@@ -716,11 +716,24 @@ async def test_topic_pool_preserves_post_candidate_signals_after_delivery():
         min_user_turns_for_topic=1,
     )
     pool.note_user_message("妮可", "旧话题：我最近一直在纠结买车是不是代表生活进入新阶段")
+    # 候选的 signal cutoff 就是这条 turn 的时间戳，新 turn 只有严格晚于它才该被保留。
+    # Windows 上 time.time() 粒度可达 15ms，固定 sleep 要么不够（新 turn 撞上 cutoff
+    # 被一起清掉）要么白等，所以直接等挂钟走过 cutoff 再记这条新 turn。
+    cutoff = pool._signal_store.last_turn_at("妮可")
 
     await pool.process_now("妮可")
-    await asyncio.sleep(0.03)
+    while time.time() <= cutoff:
+        await asyncio.sleep(0.005)
     pool.note_user_message("妮可", "新话题：我后来又开始纠结换工作和现实压力怎么平衡")
-    await asyncio.sleep(0.18)
+
+    # 投递后的 signal 清理挂在 to_thread flush 之后，固定 sleep 只是在赌它做完了；
+    # 轮询这条链的终点，超时后照旧交给下面的断言报错。
+    deadline = time.monotonic() + 5.0
+    while (
+        not delivered
+        or "旧话题" in pool._signal_store.format_global_signals("妮可", lang="zh-CN")
+    ) and time.monotonic() < deadline:
+        await asyncio.sleep(0.01)
 
     signals = pool._signal_store.format_global_signals("妮可", lang="zh-CN")
     assert delivered == ["旧话题"]
@@ -801,7 +814,11 @@ async def test_topic_pool_release_predicate_ignores_new_turns_during_delivery():
     )
     pool.note_user_message("妮可", "一个已经成熟、准备排队投递的话题", lang="zh-CN")
     await pool.process_now("妮可")
-    await asyncio.sleep(0.03)
+    # 两次 release 检查都在 trigger 内部完成，固定 sleep 在 Windows 上可能等于零等待；
+    # 等这两条真的出现再断言（retry delay 60s，不会冒出第三条）。
+    deadline = time.monotonic() + 5.0
+    while len(release_checks) < 2 and time.monotonic() < deadline:
+        await asyncio.sleep(0.01)
 
     assert release_checks == [True, True]
 
@@ -1067,8 +1084,20 @@ async def test_topic_pool_clears_durable_signals_after_successful_delivery(tmp_p
     pool.note_user_message("妮可", "这段候选证据投递完成后不该继续留在磁盘", lang="zh-CN")
     await pool.process_now("妮可")
     await asyncio.wait_for(delivered.wait(), timeout=1.0)
-    for _ in range(20):
-        if not pool._trigger_tasks.get("妮可"):
+
+    def _persisted_turns() -> list:
+        if not path.exists():
+            return []
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        return payload.get("characters", {}).get("妮可", [])
+
+    # 原来是 `for _ in range(20): await asyncio.sleep(0.01)`——计次而没有挂钟
+    # deadline。Windows 上忙循环里的 sleep(0.01) 会立刻返回，20 次迭代能在不到 1ms
+    # 内跑完，这个"等 200ms"实际等于没等（CI run 30479947756 就是这么红的）。
+    # 而且 _trigger_tasks 空掉离"盘上真的清了"还隔着一次落盘，只能盯真实产物。
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        if not pool._trigger_tasks.get("妮可") and not _persisted_turns():
             break
         await asyncio.sleep(0.01)
 
@@ -2062,21 +2091,46 @@ async def test_topic_pool_does_not_trigger_second_topic_immediately_after_first(
         enable_online_enrichment=False,
         topic_trigger=fake_trigger,
         trigger_delay_seconds=0.01,
-        min_trigger_gap_seconds=0.2,
+        # 0.2s 的间隔只比一个 Windows 定时器 tick（约 15.6ms，且 sleep 会超发 20%+）
+        # 大一个量级，抬到 0.5s 让「窗口还没过」这件事有十倍以上余量。
+        min_trigger_gap_seconds=0.5,
         min_user_turns_for_topic=1,
     )
 
     pool.note_user_message("妮可", "第一轮认真聊一个深话题，里面有足够多的具体背景、现实纠结、近期计划和反复提到的细节", lang="zh-CN")
     await pool.process_now("妮可")
-    await asyncio.sleep(0.03)
+    # 首投在后台 trigger task 里落地，固定 sleep 是抛硬币；等它真的投出来。
+    deadline = time.monotonic() + 5.0
+    while not delivered and time.monotonic() < deadline:
+        await asyncio.sleep(0.01)
     assert delivered == ["凯迪拉克预算压力"]
+
+    # 「第二个话题被 min gap 挡住」这条负向断言不能靠 sleep 猜窗口：sleep 超发就会
+    # 越过窗口变假红，改短又会让 trigger 根本没机会跑、断言恒真。这里盯住
+    # 「trigger 跑了一遍并主动改期」这个确定性事件，再断言它没有投递。
+    deferred_delays = []
+    original_reschedule = pool._reschedule_trigger_after_delay
+
+    def spy_reschedule(name, material, lang, delay):
+        deferred_delays.append(delay)
+        original_reschedule(name, material, lang, delay)
+
+    pool._reschedule_trigger_after_delay = spy_reschedule
 
     pool.note_user_message("妮可", "第二轮又聊出另一个深话题，依然有明确场景、具体选择、近期困扰和可以继续展开的细节", lang="zh-CN")
     await pool.process_now("妮可")
-    await asyncio.sleep(0.05)
+    deadline = time.monotonic() + 5.0
+    while not deferred_delays and time.monotonic() < deadline:
+        await asyncio.sleep(0.01)
+    assert deferred_delays, "第二个话题的 trigger 没有被 min trigger gap 改期"
+    # 改期这件事本身还不够：min gap 被误缩短时 trigger 照样会改期一小段，
+    # 断言就成了恒真。改期的延迟必须接近整个 gap，才说明 gap 真的在生效。
+    assert deferred_delays[0] > 0.4, f"min trigger gap 没有生效: {deferred_delays}"
     assert delivered == ["凯迪拉克预算压力"]
 
-    await asyncio.sleep(0.2)
+    deadline = time.monotonic() + 5.0
+    while len(delivered) < 2 and time.monotonic() < deadline:
+        await asyncio.sleep(0.01)
     assert delivered == ["凯迪拉克预算压力", "海边旅行计划"]
 
 

--- a/tests/unit/test_vmc_sender.py
+++ b/tests/unit/test_vmc_sender.py
@@ -38,6 +38,18 @@ def _enabled_sender() -> tuple[VmcSender, _RecordingOscClient]:
     return sender, client
 
 
+def _poll_until(predicate, *, timeout: float = 1.0, interval: float = 0.005):
+    """Poll until predicate is truthy; on timeout hand the last value back to the caller."""
+    # Windows 的事件循环时钟精度只有 ~15ms，固定 sleep 既可能等于零等待也可能超发
+    # 一倍，等不出「后台已经做完」这个确定性，只能轮询 + deadline。
+    deadline = time.monotonic() + timeout
+    while True:
+        value = predicate()
+        if value or time.monotonic() >= deadline:
+            return value
+        time.sleep(interval)
+
+
 @pytest.mark.unit
 def test_frame_is_encoded_with_vmc_names_coordinates_and_zero_blends():
     sender, client = _enabled_sender()
@@ -594,10 +606,12 @@ def test_disconnected_publisher_sends_terminal_state_after_grace(
 @pytest.mark.unit
 def test_reconnect_during_grace_cancels_terminal_state(vmc_client, monkeypatch):
     client, sender = vmc_client
+    # 宽限期给 1.0s 而不是 0.1s：successor 的握手+认证耗时不受本测试控制，
+    # 一旦它比宽限期还慢，终态就先发出去了，红的原因跟被测逻辑无关。
     monkeypatch.setattr(
         vmc_router,
         "_PUBLISHER_DISCONNECT_GRACE_SECONDS",
-        0.1,
+        1.0,
     )
     headers = {"Origin": "http://testserver"}
     auth = {"type": "auth", "csrf_token": "vmc-test-token"}
@@ -606,10 +620,19 @@ def test_reconnect_during_grace_cancels_terminal_state(vmc_client, monkeypatch):
         primary.send_json(auth)
         assert primary.receive_json() == {"type": "ready"}
 
+    # 断开由事件循环异步收尾，任务不是立刻挂上的；拿到句柄才能证明它后来被取消。
+    pending_terminal = _poll_until(lambda: vmc_router._pending_terminal_task)
+    assert pending_terminal is not None
+
     with client.websocket_connect("/api/vmc/ws", headers=headers) as successor:
         successor.send_json(auth)
         assert successor.receive_json() == {"type": "ready"}
-        time.sleep(0.2)
+        # 路由在回 ready 之前就调了 _cancel_pending_terminal_task，所以这里不必靠固定
+        # sleep 去赌「宽限期是否已过」（Windows 定时器精度 ~15ms，赌不出确定性）：
+        # 任务在远小于宽限期的时间里结束，只能是被取消掉的。
+        assert _poll_until(pending_terminal.done, timeout=0.4), (
+            "宽限期内的重连没有取消掉待发终态任务"
+        )
         assert sender.terminal_generations == []
 
 


### PR DESCRIPTION
#2528 报的「`atomic_write_json` 在 Windows CI 上偶发失败（`os.replace`）」查下来是**两个不同根因，都不在 `os.replace`**。这个 PR 处理真正会随机打红 CI 的那个：测试侧的固定 sleep。详细的归因更正见 issue 里的评论。

## 平台层根因

比「CI runner 慢」更硬。Windows `ProactorEventLoop._clock_resolution = 15.625ms`，而 CPython `base_events._run_once` 用 `end_time = self.time() + self._clock_resolution` **提前**弹出定时器。实测：

| 语句 | 循环忙（有 pending 活动） | 循环空闲 |
|---|---|---|
| `await asyncio.sleep(0.005/0.01/0.015)` | **100% 在 0.01ms 内返回（等于零等待）** | ~15.6ms |
| `await asyncio.sleep(0.02)` | 15.6ms | 31ms |
| `await asyncio.sleep(0.05)` | ~62ms（**超发 24%**） | ~62ms |

「循环忙」正是这些用例的前提 —— 它们在等后台任务。所以「睡一小会儿等后台做完」是 0~31ms 之间抛硬币，方向取决于与被测逻辑无关的其它任务活动：**正向断言**因零等待提前落地变假红，**负向断言**因超发越过窗口变假红。

## 有 CI 铁证的一处

run 30479947756（2026-07-29，在 966d6e115 之后）：

```
FAILED tests/unit/test_topic_pipeline.py::test_topic_pool_clears_durable_signals_after_successful_delivery
  - AssertionError: assert not True  where True = is_ready('妮可')
```

```python
    for _ in range(20):
        if not pool._trigger_tasks.get("妮可"):
            break
        await asyncio.sleep(0.01)
```

**计次而没有挂钟 deadline** —— 忙循环里 20 次迭代可以在不到 1ms 内跑完，这个「等 200ms」实际等于没等。而且它盯的是 `_trigger_tasks` 空掉，离盘上真的清了还隔着一次落盘。

## 改法

按优先级：已有的确定性同步点（`join` / `close` / `wait_idle` / 等任务本身）> 轮询 + deadline > 把被测窗口抬到远大于一个 tick > 断言内部状态。

8 个文件、15 处站点。`test_geoip_region_gate.py` 评估后**未改**：被计时区间是「已缓存 import + 一次类属性 return」，没有 sleep/await/线程/网络，`0.1s` 阈值对 `3s` connect 是跨数量级粗判，不是 timing flake。

## 顺带修掉三处既有的断言空过

这三处不是本次引入的，是变异测试暴露出来的：

- `test_silent_audio_does_not_extend_smart_turn_warm_ttl` 的 warm TTL 只有 `0.01s`，卸载在音频帧被消费**之前**就触发 —— 用例其实没检验它命名的那个主张（变异「feed 之后取消 TTL 卸载」在旧版是绿的）。
- `test_concurrent_append_during_compact_preserves_events` 的 `sleep(0.02)` 睡短了，compact 会在第一次并发 append 之前跑完，用例静默退化成非并发。
- `test_reconnect_during_grace_cancels_terminal_state` 的旧断言对「忘了取消」零诊断力（`_send_terminal_after_disconnect` 里有 publisher 兜底 return），变异 `_cancel_pending_terminal_task` → no-op 在旧版是绿的。

## `test_serialization_oracle_rejects_unlocked_mode`：#2528「目击 1」的来源

那条用例故意把 `log._get_lock` 换成 `nullcontext()`（这是它作为负向控制组的设计意图 —— 证明前一条 oracle 不靠调度巧合通过）。副作用是 `record_and_save` 收尾那句哨兵落盘也跟着失去串行化：5 个线程同时 `os.replace` 到同一个 `events_applied.json`，Windows 上直接 `PermissionError [WinError 5]`。

**扫了 18 个有 Windows 日志的失败 CI run，18/18 都有这条 `PytestUnhandledThreadExceptionWarning`** —— 它是每轮必现的常态噪声，不是「偶发」。本机 8 连跑复现 7 次。

哨兵落盘不是该用例的被测对象（上一条正向 oracle 才覆盖它），所以改成给每个线程独立的哨兵文件名：真实写盘路径照跑，只是不再互抢同一个目标。断言 `mutable_view["value"] < num_workers` 一字未动。

本机 8 连跑 `-W error::pytest.PytestUnhandledThreadExceptionWarning`：**7/8 复现 → 0/8**。

## 变异验证

每处改动都验过断言没被弱化成恒真：

| 变异 | 结果 |
|---|---|
| `proactive_delivery` 的 `max_play_s` / `min_gap_s` 各缩十倍 | 两条负向断言变红 |
| `topic` 的 `min_trigger_gap_seconds` 缩十倍 | 改期延迟断言变红 |
| `signals.clear_until` 改成不清 | 上面那条 CI 铁证用例变红 |
| adapter 的 `INCOMPLETE` 也 commit | `assert commits == []` 变红 |
| adapter 的 feed 之后取消 TTL 卸载 | `unload_calls == 2` 变红（旧版绿） |
| `_cancel_pending_terminal_task` → no-op | 新断言变红（旧版绿） |
| `_asr_final_watchdog` 窗口缩十倍 | 边走边断言的循环变红 |

## 验证

- 9 个文件 `557 passed` 连跑 3 次（28.8 / 29.4 / 29.9s）
- `check_docstring_no_cjk.py --base origin/main` exit=0
- **生产代码零改动**（`git diff --name-only` 全在 `tests/unit/` 下）

耗时代价：`test_asr_voice_turn_adapter` 0.98s → 1.83s、`test_proactive_delivery` 3.17s → ~4.3s（抬宽窗口 + 按真实时钟走满窗口的一部分）；`test_minimax_tts_worker` 2.65s → 2.15s、`test_vmc_sender` 2.26s → 1.85s（删掉固定 sleep 反而更快）。

## 不在本 PR 范围

#2528 挖出来的另外三摊各自单独 PR：`file_utils` 自身的收尾（`except` 分支吞异常 + tmp 泄漏 + 零专测）、生产里真实存在的同目标并发写缺锁（`advance_sentinel` 等六处）、以及同一失效域里的两条数据正确性问题（facts 归档半提交、recent 丢写）。

Closes 部分 #2528

🤖 Generated with [Claude Code](https://claude.com/claude-code)
