### PR TITLE
重构：将语音评估脚本收口到 scripts

### DIFF
--- a/.github/workflows/build-desktop-linux.yml
+++ b/.github/workflows/build-desktop-linux.yml
@@ -207,7 +207,7 @@ jobs:
 
       - name: Prepare verified voice-turn assets
         shell: bash
-        run: uv run --no-sync python tools/voice_eval/prepare_voice_turn_assets.py
+        run: uv run --no-sync python scripts/prepare_voice_turn_assets.py
 
       # --- Warm tiktoken o200k_base cache for offline use (PR #929) ---
       # tiktoken downloads encoding blobs (~1.5 MB each) on first use into
@@ -407,7 +407,7 @@ jobs:
             echo "::error::data/tiktoken_cache empty in bundle (o200k_base would re-download at runtime)"
             missing=1
           fi
-          uv run --no-sync python tools/voice_eval/prepare_voice_turn_assets.py \
+          uv run --no-sync python scripts/prepare_voice_turn_assets.py \
             --asset-dir dist/Xiao8/data/vad_models --offline || missing=1
           [ "$missing" -eq 0 ]
 

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -245,7 +245,7 @@ jobs:
 
       - name: Prepare verified voice-turn assets
         shell: bash
-        run: uv run --no-sync python tools/voice_eval/prepare_voice_turn_assets.py
+        run: uv run --no-sync python scripts/prepare_voice_turn_assets.py
 
       # --- Warm tiktoken o200k_base cache for offline use (PR #929) ---
       # tiktoken downloads encoding blobs (~1.5 MB each) on first use into
@@ -627,7 +627,7 @@ jobs:
             echo "::error::data/tiktoken_cache empty in bundle (o200k_base would re-download at runtime)"
             missing=1
           fi
-          uv run --no-sync python tools/voice_eval/prepare_voice_turn_assets.py \
+          uv run --no-sync python scripts/prepare_voice_turn_assets.py \
             --asset-dir "$NEKO_NUITKA_RUNTIME_DIR"/data/vad_models --offline || missing=1
           [ "$missing" -eq 0 ]
 

--- a/.github/workflows/docker-multi-arch.yml
+++ b/.github/workflows/docker-multi-arch.yml
@@ -202,7 +202,7 @@ jobs:
           key: voice-turn-models-${{ runner.os }}-${{ hashFiles('data/vad_models/manifest.json') }}
 
       - name: Prepare verified voice-turn assets
-        run: python3 tools/voice_eval/prepare_voice_turn_assets.py
+        run: python3 scripts/prepare_voice_turn_assets.py
 
       - name: Check if Dockerfile exists
         id: check-dockerfile
@@ -359,7 +359,7 @@ jobs:
           key: voice-turn-models-${{ runner.os }}-${{ hashFiles('data/vad_models/manifest.json') }}
 
       - name: Prepare verified voice-turn assets
-        run: python3 tools/voice_eval/prepare_voice_turn_assets.py
+        run: python3 scripts/prepare_voice_turn_assets.py
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -183,7 +183,7 @@ RUN cd /app && \
 RUN cd /app && \
     if [ -n "$HTTP_PROXY" ]; then export http_proxy=$HTTP_PROXY; fi; \
     if [ -n "$HTTPS_PROXY" ]; then export https_proxy=$HTTPS_PROXY; fi; \
-    python3 tools/voice_eval/prepare_voice_turn_assets.py && \
+    python3 scripts/prepare_voice_turn_assets.py && \
     unset http_proxy && \
     unset https_proxy
 

--- a/docker/Dockerfile.full
+++ b/docker/Dockerfile.full
@@ -252,7 +252,7 @@ RUN cd /app && \
 RUN cd /app && \
     if [ -n "$HTTP_PROXY" ]; then export http_proxy=$HTTP_PROXY; fi; \
     if [ -n "$HTTPS_PROXY" ]; then export https_proxy=$HTTPS_PROXY; fi; \
-    python3 tools/voice_eval/prepare_voice_turn_assets.py && \
+    python3 scripts/prepare_voice_turn_assets.py && \
     unset http_proxy && \
     unset https_proxy
 

--- a/docs/design/smart-turn-v3-provider-neutral.md
+++ b/docs/design/smart-turn-v3-provider-neutral.md
@@ -115,7 +115,7 @@ continues to own the turn boundary.
 licenses, and SHA-256 digests. Run:
 
 ```text
-uv run python tools/voice_eval/prepare_voice_turn_assets.py
+uv run python scripts/prepare_voice_turn_assets.py
 ```
 
 The runtime is lazy and is loaded on the first candidate turn only for a
@@ -166,7 +166,7 @@ Existing human-speech tests show that English and Japanese sentence-internal
 pauses still need tuning. The current acceptance target is reliable recovery;
 it does not claim to eliminate every roughly 500 ms premature split.
 Before treating the integrated routes as product-quality, maintainers must run
-`tools/voice_eval/evaluate_smart_turn_v3.py` on an authorized labelled set that
+`scripts/evaluate_smart_turn_v3.py` on an authorized labelled set that
 includes sentence-internal pauses, hesitation followed by continuation,
 complete turns, keyboard noise, and barge-in. The report always includes all
 four confusion-matrix cells and per-sample probabilities.

--- a/scripts/evaluate_smart_turn_v3.py
+++ b/scripts/evaluate_smart_turn_v3.py
@@ -15,7 +15,7 @@ from typing import Protocol
 import numpy as np
 
 
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 

--- a/scripts/prepare_voice_turn_assets.py
+++ b/scripts/prepare_voice_turn_assets.py
@@ -14,7 +14,7 @@ from urllib.error import URLError
 from pathlib import Path
 
 
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 def _load_asset_manifest_module():

--- a/tests/unit/voice_turn/test_build_contracts.py
+++ b/tests/unit/voice_turn/test_build_contracts.py
@@ -24,7 +24,7 @@ def test_nuitka_workflows_prepare_bundle_and_verify_voice_turn_assets():
     )
 
     for workflow in (desktop_workflow, linux_workflow):
-        assert "tools/voice_eval/prepare_voice_turn_assets.py" in workflow
+        assert "scripts/prepare_voice_turn_assets.py" in workflow
         assert "--include-data-dir=data/vad_models=data/vad_models" in workflow
         assert "hashFiles('data/vad_models/manifest.json')" in workflow
 
@@ -43,7 +43,7 @@ def test_docker_workflow_prepares_and_caches_voice_turn_assets():
     # Both build jobs (standard + full) must pre-fetch the weights on the
     # native runner so they ride into the build context for every platform.
     assert (
-        workflow.count("run: python3 tools/voice_eval/prepare_voice_turn_assets.py")
+        workflow.count("run: python3 scripts/prepare_voice_turn_assets.py")
         == 2
     )
     assert workflow.count("path: data/vad_models/*.onnx") == 2
@@ -59,12 +59,12 @@ def test_docker_workflow_prepares_and_caches_voice_turn_assets():
 def test_dockerfiles_verify_voice_turn_assets_in_image():
     for name in ("Dockerfile", "Dockerfile.full"):
         dockerfile = (ROOT / "docker" / name).read_text(encoding="utf-8")
-        assert "python3 tools/voice_eval/prepare_voice_turn_assets.py" in dockerfile, name
+        assert "python3 scripts/prepare_voice_turn_assets.py" in dockerfile, name
         # The verify step must run after the project lands in the image but
         # before ownership is fixed up for the runtime user.
         copy_index = dockerfile.index("COPY --chown=neko:neko . /app")
         prepare_index = dockerfile.index(
-            "python3 tools/voice_eval/prepare_voice_turn_assets.py"
+            "python3 scripts/prepare_voice_turn_assets.py"
         )
         chown_index = dockerfile.index("chown -R neko:neko /app", copy_index)
         assert copy_index < prepare_index < chown_index, name

--- a/tests/unit/voice_turn/test_evaluation_tool.py
+++ b/tests/unit/voice_turn/test_evaluation_tool.py
@@ -4,7 +4,7 @@ import wave
 import numpy as np
 import pytest
 
-from tools.voice_eval.evaluate_smart_turn_v3 import evaluate_cases, load_cases
+from scripts.evaluate_smart_turn_v3 import evaluate_cases, load_cases
 
 
 def _wav(path, samples):

--- a/tests/unit/voice_turn/test_prepare_assets.py
+++ b/tests/unit/voice_turn/test_prepare_assets.py
@@ -8,14 +8,12 @@ from pathlib import Path
 import pytest
 
 import main_logic.voice_turn.asset_manifest as asset_manifest
-import tools.voice_eval.prepare_voice_turn_assets as preparer
+import scripts.prepare_voice_turn_assets as preparer
 from main_logic.voice_turn.asset_manifest import AssetManifestError
-from tools.voice_eval.prepare_voice_turn_assets import prepare_assets
+from scripts.prepare_voice_turn_assets import prepare_assets
 
 
-SCRIPT_PATH = (
-    Path(__file__).resolve().parents[3] / "tools" / "voice_eval" / "prepare_voice_turn_assets.py"
-)
+SCRIPT_PATH = Path(__file__).resolve().parents[3] / "scripts" / "prepare_voice_turn_assets.py"
 
 # Runs the preparer on a bare interpreter (-I -S: no site-packages, no env
 # influence) with NumPy imports force-blocked, mirroring the Docker build
@@ -132,7 +130,7 @@ def test_preparer_dynamic_load_first_shares_exception_identity():
         """
         import sys
 
-        import tools.voice_eval.prepare_voice_turn_assets as preparer
+        import scripts.prepare_voice_turn_assets as preparer
 
         assert "main_logic.voice_turn.asset_manifest" in sys.modules, (
             "preparer import must register the path-loaded manifest module"
@@ -146,7 +144,7 @@ def test_preparer_dynamic_load_first_shares_exception_identity():
     )
     result = subprocess.run(
         [sys.executable, "-c", driver],
-        cwd=str(SCRIPT_PATH.parents[2]),
+        cwd=str(SCRIPT_PATH.parents[1]),
         capture_output=True,
         text=True,
         check=False,

--- a/tests/unit/voice_turn/test_prepare_assets.py
+++ b/tests/unit/voice_turn/test_prepare_assets.py
@@ -8,9 +8,11 @@ from pathlib import Path
 import pytest
 
 import main_logic.voice_turn.asset_manifest as asset_manifest
-import scripts.prepare_voice_turn_assets as preparer
 from main_logic.voice_turn.asset_manifest import AssetManifestError
-from scripts.prepare_voice_turn_assets import prepare_assets
+from scripts.prepare_voice_turn_assets import (
+    AssetManifestError as PreparerAssetManifestError,
+    prepare_assets,
+)
 
 
 SCRIPT_PATH = Path(__file__).resolve().parents[3] / "scripts" / "prepare_voice_turn_assets.py"
@@ -117,7 +119,7 @@ def test_preparer_exception_identity_matches_package_module():
     # The script loads asset_manifest by file path; the sys.modules
     # registration must keep a single class identity so AssetManifestError
     # raised by the script is catchable via the package import.
-    assert preparer.AssetManifestError is asset_manifest.AssetManifestError
+    assert PreparerAssetManifestError is asset_manifest.AssetManifestError
     assert sys.modules["main_logic.voice_turn.asset_manifest"] is asset_manifest
 
 


### PR DESCRIPTION
## 摘要

- 将 `tools/voice_eval/prepare_voice_turn_assets.py` 平铺迁移为 `scripts/prepare_voice_turn_assets.py`
- 将 `tools/voice_eval/evaluate_smart_turn_v3.py` 平铺迁移为 `scripts/evaluate_smart_turn_v3.py`
- 同步桌面构建、Docker、设计文档及测试中的所有调用路径
- 仅调整脚本归属与项目根解析，不修改模型目录、manifest 模块、下载/校验逻辑或运行时行为

## 风险与边界

这是可独立回滚的纯路径整理。GitNexus 评估为 LOW，未命中任何生产执行流。后续 endpointing 与模型资产迁移将作为堆叠的独立 PR 提交，避免在本 PR 留下半迁移状态。

## 验证状态

- 相关构建合同、裸 Python preparer、评估脚本单测：17/17 通过
- 两个脚本 `--help`：通过
- Ruff、`git diff --check`：通过
- 全仓旧路径扫描：`tools/voice_eval` 与 `tools.voice_eval` 零残留
- 根目录全量 pytest 被仓库既有的两个同名插件 `test_smoke.py` 收集冲突阻断；项目主测试树已另行启动，最终结果将随 CI 一并跟进

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改进**
  - 优化语音回合（VAD + Smart Turn）离线资源的准备与打包流程。
  - 提升桌面与 Docker 镜像构建时资源校验的一致性与稳定性。
  - Smart Turn v3 评估工具可在新的项目结构下正常使用。
- **文档**
  - 更新 Smart Turn v3 资源准备与评估流程说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->