### PR TITLE
test(realtime): arbiter 纯 native 回归 T1-T8 + fail-close 可观测 + swap prime 口径（#2515 收尾）

### DIFF
--- a/main_logic/core/lifecycle.py
+++ b/main_logic/core/lifecycle.py
@@ -2173,8 +2173,20 @@ class LifecycleMixin:
                 _extras_for_budget = _selected
                 try:
                     await self.pending_session.prime_context(final_prime_text, skipped=False)
-                except (web_exceptions.ConnectionClosed, AttributeError) as e:
-                    # pending_session 连接已关闭或websocket为None，放弃整个 swap 操作
+                except (
+                    web_exceptions.ConnectionClosed,
+                    AttributeError,
+                    ConnectionError,
+                    RuntimeError,
+                    asyncio.TimeoutError,
+                ) as e:
+                    # pending_session 连接已关闭或websocket为None，放弃整个 swap 操作。
+                    # skipped=False 的 prime 走 create_response → response arbiter，
+                    # ticket 失败以 ConnectionError / RuntimeError / TimeoutError 浮出
+                    # （派发被打断、连接不可用、终态超时等）——这些同样意味着"本次
+                    # prime 没有送达、放弃本次 swap、老会话继续用"，必须走本分支的
+                    # 定向收尾，而不是落到外层兜底把良性放弃当 INTERNAL_UPDATE_FAILED
+                    # 报给前端。
                     logger.error(f"💥 Final Swap Sequence: pending_session不可用，放弃swap操作: {e}")
                     await self._cleanup_pending_session_resources()
                     await self._reset_preparation_state(clear_main_cache=True)
@@ -2212,8 +2224,16 @@ class LifecycleMixin:
                         final_prime_text += "\n" + _passive_swap_text
                 try:
                     await self.pending_session.prime_context(final_prime_text, skipped=True)
-                except (web_exceptions.ConnectionClosed, AttributeError) as e:
-                    # pending_session 连接已关闭或websocket为None，放弃整个 swap 操作
+                except (
+                    web_exceptions.ConnectionClosed,
+                    AttributeError,
+                    ConnectionError,
+                    RuntimeError,
+                    asyncio.TimeoutError,
+                ) as e:
+                    # 与上方 skipped=False 分支同款收窄→放宽（对偶）：Gemini 的
+                    # skipped=True prime 走 SDK send，同样以 RuntimeError /
+                    # ConnectionError 浮出；良性"放弃本次 swap"不该落外层兜底。
                     logger.error(f"💥 Final Swap Sequence: pending_session不可用，放弃swap操作: {e}")
                     await self._cleanup_pending_session_resources()
                     await self._reset_preparation_state(clear_main_cache=True)

--- a/main_logic/omni_realtime_client/_response_arbiter.py
+++ b/main_logic/omni_realtime_client/_response_arbiter.py
@@ -838,6 +838,24 @@ class RealtimeResponseArbiter:
             self._queue.task_done()
 
     async def _fail_closed(self, reason: str) -> None:
+        # This is the only chokepoint through which the arbiter tears down the
+        # transport, and to the rest of the system the result is
+        # indistinguishable from a provider-side disconnect (the receive loop
+        # errors first, then host cleanup runs). Log the initiator, the reason
+        # and the lane state here so a field disconnect can be attributed —
+        # see issue #2561, where the absence of exactly this line forced a
+        # build-provenance investigation to rule the arbiter out.
+        current = self._current
+        owner = self._response_owner
+        logger.warning(
+            "response arbiter failing closed: %s "
+            "(current=%s owner=%s queue_depth=%d server_vad_pending=%s)",
+            reason,
+            current.source if current is not None else None,
+            owner.source if owner is not None else None,
+            self._queue.qsize(),
+            self._server_vad_response_pending,
+        )
         self._mark_connection_lost(reason, fail_current_tickets=False)
         if self._abort_transport is None:
             return

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -912,8 +912,12 @@ class _TransportMixin:
 
         self._is_responding = False
         # Keep the cancelled response identity until its terminal event arrives.
-        # Clearing it here makes the stale-event filter drop that response.done,
-        # leaving the arbiter busy until a later response happens to complete.
+        # Clearing it here makes the stale-event filter classify that
+        # response.done as stale. The filter still forwards stale terminals to
+        # the arbiter (the lane would reopen either way), but the rest of the
+        # done handling is skipped for the turn: the done counters and usage
+        # recording, the _interrupted reset, the transcript flush and the
+        # on_response_done callback all silently miss one turn.
         self._current_item_id = None
         # 清空转录buffer和重置标志，防止打断后的错位
         self._output_transcript_buffer = ""

--- a/tests/unit/test_hot_swap_cancellation.py
+++ b/tests/unit/test_hot_swap_cancellation.py
@@ -904,3 +904,90 @@ async def test_final_swap_restore_excludes_extra_delivered_after_promote():
     assert mgr.session is new_session
     assert mgr.pending_extra_replies == [extra_kept], \
         "an extra whose callback was consumed inside the window must not be re-queued"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# prime_context dispatch failures (#2515 T2): since #2345 the skipped=False
+# prime dispatches through the response arbiter, whose ticket surfaces
+# failures as RuntimeError / ConnectionError / TimeoutError — none of them in
+# the targeted handler's legacy (ConnectionClosed, AttributeError) tuple.
+# Nothing leaked before this fix: the swap's OUTER except Exception caught
+# them and ran the same cleanup. What was wrong is the ENVELOPE — the outer
+# handler reports INTERNAL_UPDATE_FAILED to the frontend, while a failed
+# prime is the benign "abandon this swap, keep the old session" case the
+# targeted handler exists for. These tests pin the envelope, one per prime
+# branch (each guards its own except site).
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class _PrimeDispatchFails(_FakeSession):
+    """prime_context raises the way an arbiter ticket failure surfaces."""
+
+    async def prime_context(self, text, *, skipped=False):
+        await super().prime_context(text, skipped=skipped)
+        raise RuntimeError(
+            "response dispatch interrupted by pending server VAD response"
+        )
+
+
+@pytest.mark.asyncio
+async def test_prime_dispatch_failure_takes_the_targeted_abort_not_the_generic_handler():
+    """skipped=False branch (announce prime, the arbiter-queued one)."""
+    mgr = _make_swap_manager()
+    statuses = []
+
+    async def _send_status(payload):
+        statuses.append(payload)
+
+    mgr.send_status = _send_status
+    old_session = _FakeSession("old")
+    new_session = _PrimeDispatchFails("pending")
+    mgr.session = old_session
+    mgr.pending_session = new_session
+    mgr.is_hot_swap_imminent = True
+    mgr.message_handler_task = None
+    # A queued extra forces the skipped=False announce-prime branch.
+    mgr.pending_extra_replies = [_extra_entry("id-a", "task A finished")]
+
+    await mgr._perform_final_swap_sequence()
+
+    assert new_session.prime_calls and new_session.prime_calls[0][1] is False, \
+        "the failing prime must be the skipped=False announce prime"
+    assert mgr.session is old_session, "an abandoned swap keeps the old session"
+    assert new_session.closed, "the targeted abort must close the pending session"
+    assert mgr.pending_session is None
+    assert mgr.is_hot_swap_imminent is False
+    assert not any("INTERNAL_UPDATE_FAILED" in s for s in statuses), (
+        "a failed prime dispatch is a benign swap abort — it must take the "
+        "targeted handler, not fall through to the generic one that alarms "
+        "the frontend with INTERNAL_UPDATE_FAILED"
+    )
+
+
+@pytest.mark.asyncio
+async def test_prime_dispatch_failure_on_the_skipped_branch_takes_the_targeted_abort():
+    """skipped=True branch (instruction prime) — guards the second except site."""
+    mgr = _make_swap_manager()
+    statuses = []
+
+    async def _send_status(payload):
+        statuses.append(payload)
+
+    mgr.send_status = _send_status
+    old_session = _FakeSession("old")
+    new_session = _PrimeDispatchFails("pending")
+    mgr.session = old_session
+    mgr.pending_session = new_session
+    mgr.is_hot_swap_imminent = True
+    mgr.message_handler_task = None
+    mgr.pending_extra_replies = []  # no extras → the skipped=True branch
+
+    await mgr._perform_final_swap_sequence()
+
+    assert new_session.prime_calls and new_session.prime_calls[0][1] is True, \
+        "the failing prime must be the skipped=True instruction prime"
+    assert mgr.session is old_session
+    assert new_session.closed
+    assert mgr.pending_session is None
+    assert mgr.is_hot_swap_imminent is False
+    assert not any("INTERNAL_UPDATE_FAILED" in s for s in statuses)

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -205,6 +205,74 @@ def _make_voice_sess(*, is_responding=False, inject=None):
     return sess
 
 
+def _make_voice_sess_with_real_gate():
+    """``_make_voice_sess`` variant that keeps the REAL ``is_active_response``.
+
+    The stock fixture pins ``is_active_response`` to ``_is_responding`` alone,
+    which silently erases the other half of the production gate — since #2345
+    it is ``bool(self._is_responding or self._ensure_response_arbiter()
+    .is_busy)``. Every test built on the stock fixture is structurally blind
+    to arbiter-held busyness (queued tickets, a live server response, a
+    pending server-VAD response). Keep using the stock fixture for SM contract
+    tests; use THIS variant when the assertion is about the gate itself.
+
+    Deleting the instance attribute re-exposes the class method, whose
+    ``_ensure_response_arbiter()`` lazily builds a real arbiter on the
+    ``__new__``-built double (its ``send_event`` bound method exists and is
+    never called by these tests).
+    """
+    sess = _make_voice_sess()
+    del sess.is_active_response
+    return sess
+
+
+async def test_voice_gate_sees_arbiter_busyness_not_just_the_responding_flag():
+    """A live server-side response makes the arbiter busy while
+    ``_is_responding`` is still False (the flag flips on response.created via
+    the transport, which these doubles never run). The proactive gate must
+    defer on arbiter busyness alone — and deliver once the lane clears, so
+    the deferral is attributable to the gate rather than to any other
+    precondition. Mutation check: reverting ``is_active_response`` to
+    ``bool(self._is_responding)`` turns the first half red while every test
+    on the stock fixture stays green — that enduring green is the fixture
+    blind spot documented on ``_make_voice_sess_with_real_gate``."""
+    sess = _make_voice_sess_with_real_gate()
+    mgr = _make_mgr(session=sess)
+    cb = {
+        "_callback_delivery_id": "id-arbiter-busy",
+        "status": "completed",
+        "summary": "task done",
+    }
+    mgr.pending_agent_callbacks = [cb]
+
+    assert sess._is_responding is False
+    sess._ensure_response_arbiter().notify_response_created(
+        {"type": "response.created", "response": {"id": "srv-1"}}
+    )
+    assert sess.is_active_response() is True
+
+    delivered = await core_module.LLMSessionManager.trigger_agent_callbacks(mgr)
+
+    assert delivered is False
+    assert sess.inject_calls == 0, (
+        "the gate must defer while the arbiter holds a live server response"
+    )
+    assert mgr.pending_agent_callbacks == [cb], "deferred callbacks must be retained"
+
+    # The dual: once the lane clears the very same delivery goes through,
+    # proving the deferral above was the arbiter gate and nothing else.
+    sess._response_arbiter.notify_response_terminal(
+        {"type": "response.done", "response": {"id": "srv-1"}}
+    )
+    assert sess.is_active_response() is False
+
+    delivered = await core_module.LLMSessionManager.trigger_agent_callbacks(mgr)
+
+    assert delivered is True
+    assert sess.inject_calls == 1
+    assert mgr.pending_agent_callbacks == []
+
+
 async def test_voice_nudge_waits_for_callback_inject_lock():
     sess = _make_voice_sess()
     sess._proactive_inject_awaiting_outcome = False

--- a/tests/unit/test_realtime_arbiter_native_path.py
+++ b/tests/unit/test_realtime_arbiter_native_path.py
@@ -37,11 +37,14 @@ and would hit every user.
 
 import asyncio
 import json
+import logging
 
 import pytest
 
 from main_logic.omni_realtime_client import OmniRealtimeClient
+from main_logic.omni_realtime_client import _response_arbiter as _arbiter_module
 from main_logic.omni_realtime_client._response_arbiter import RealtimeResponseArbiter
+from main_logic.tool_calling import ToolResult
 
 
 def _native_client(api_type: str = "qwen", model: str = "qwen-omni-turbo-realtime"):
@@ -391,3 +394,651 @@ async def test_a_native_create_response_runs_through_the_arbiter_end_to_end():
 
     socket.finish()
     await asyncio.wait_for(receive_loop, timeout=1)
+
+
+def _wired_client(api_type: str = "qwen", model: str = "qwen-omni-turbo-realtime"):
+    """A native client attached to a recording socket, ready for its real
+    receive loop. The caller owns creating/joining the ``handle_messages``
+    task so a failed assertion cannot leak an unawaited loop silently."""
+
+    client = _native_client(api_type=api_type, model=model)
+    socket = _RecordingSocket()
+    client.ws = socket
+    return client, socket
+
+
+async def _finish_loop(socket: _RecordingSocket, receive_loop: asyncio.Task) -> None:
+    socket.finish()
+    await asyncio.wait_for(receive_loop, timeout=1)
+
+
+async def _ack_item_and_expect_create(socket: _RecordingSocket, index: int) -> None:
+    """Acknowledge the conversation item at ``socket.sent[index]`` and wait for
+    the arbiter to put the paired response.create on the wire."""
+
+    item_id = socket.sent[index]["item"]["id"]
+    socket.feed(
+        {
+            "type": "conversation.item.created",
+            "item": {"id": item_id, "role": "user", "type": "message"},
+        }
+    )
+    await _settle()
+    assert socket.types[index + 1] == "response.create"
+
+
+# ---------------------------------------------------------------------------
+# T1 — the server-VAD lane close every native voice turn walks (speech_stopped
+# → notify_server_vad_response_pending → arm backstop). Until now the two-phase
+# call had zero native-side assertions: arm_server_vad_response_pending_timeout
+# had no test anywhere in the repo.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_user_speech_preempts_an_inflight_native_request():
+    # The contract, stated once: the user's voice always wins. An explicit
+    # native request that has not finished dispatching when the user's
+    # utterance ends must be failed promptly — not raced against the server's
+    # automatic response.
+    client, socket = _wired_client()
+    receive_loop = asyncio.create_task(client.handle_messages())
+
+    create = asyncio.create_task(client.create_response("hello"))
+    await _settle()
+    # Parked on the item-ack barrier: item out, response.create withheld.
+    assert socket.types == ["conversation.item.create"]
+
+    socket.feed({"type": "input_audio_buffer.speech_stopped"})
+    await _settle()
+
+    assert create.done(), (
+        "an utterance ending must fail the in-flight explicit request "
+        "immediately, not leave it racing the automatic VAD response"
+    )
+    with pytest.raises(RuntimeError, match="pending server VAD response"):
+        await create
+    assert "response.create" not in socket.types, (
+        "the losing explicit request must never emit its response.create"
+    )
+
+    # The automatic response runs its own lifecycle; afterwards the lane must
+    # be clean for the next native turn — no residue from the failed request.
+    socket.feed({"type": "response.created", "response": {"id": "vad-1"}})
+    socket.feed({"type": "response.done", "response": {"id": "vad-1"}})
+    await _settle()
+
+    follow_up = asyncio.create_task(client.create_response("next turn"))
+    await _settle()
+    assert socket.types[-1] == "conversation.item.create"
+    await _ack_item_and_expect_create(socket, len(socket.sent) - 1)
+    socket.feed({"type": "response.created", "response": {"id": "resp-2"}})
+    socket.feed({"type": "response.done", "response": {"id": "resp-2"}})
+    await _settle()
+    await asyncio.wait_for(follow_up, timeout=1)
+    await client._response_arbiter.wait_until_idle(timeout=1)
+    assert client.is_active_response() is False
+    assert socket.closed is False
+
+    await _finish_loop(socket, receive_loop)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_missing_created_backstop_arms_only_after_receive_handling_resumes():
+    # _transport feeds the arbiter in two phases on speech_stopped: mark the
+    # pending VAD response BEFORE the on_new_message callback, arm the
+    # missing-created backstop AFTER it (in a finally). The comment in
+    # _transport.py explains why: response.created cannot be observed while
+    # the receive loop is blocked inside the callback, so arming earlier would
+    # let a slow callback expire a perfectly real VAD response. This is the
+    # first test to pin that ordering.
+    client, socket = _wired_client()
+    observations: list[tuple[bool, bool]] = []
+
+    async def _on_new_message() -> None:
+        arbiter = client._response_arbiter
+        observations.append(
+            (
+                arbiter._server_vad_response_pending,
+                arbiter._server_vad_pending_handle is not None,
+            )
+        )
+
+    client.on_new_message = _on_new_message
+    receive_loop = asyncio.create_task(client.handle_messages())
+
+    socket.feed({"type": "input_audio_buffer.speech_stopped"})
+    await _settle()
+
+    # Inside the callback: pending already marked, backstop NOT yet armed.
+    assert observations == [(True, False)]
+    # After the callback returned: the finally armed the backstop.
+    arbiter = client._response_arbiter
+    assert arbiter._server_vad_pending_handle is not None
+
+    # The real VAD response arriving disarms the backstop and takes the lane.
+    socket.feed({"type": "response.created", "response": {"id": "vad-1"}})
+    await _settle()
+    assert arbiter._server_vad_pending_handle is None
+    socket.feed({"type": "response.done", "response": {"id": "vad-1"}})
+    await _settle()
+    await arbiter.wait_until_idle(timeout=1)
+
+    await _finish_loop(socket, receive_loop)
+
+
+# ---------------------------------------------------------------------------
+# T3 — the missing-created backstop itself (_SERVER_VAD_RESPONSE_STARTED_
+# TIMEOUT). Zero hits in tests/ before this: if it silently stopped firing,
+# a provider-side pre-creation failure would wedge every queued native turn;
+# if it ever tore the transport instead, a benign expiry would disconnect the
+# user.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_vad_backstop_expiry_reopens_the_lane_without_tearing_the_transport(
+    monkeypatch,
+):
+    monkeypatch.setattr(_arbiter_module, "_SERVER_VAD_RESPONSE_STARTED_TIMEOUT", 0.05)
+    client, socket = _wired_client()
+    receive_loop = asyncio.create_task(client.handle_messages())
+
+    socket.feed({"type": "input_audio_buffer.speech_stopped"})
+    await _settle()
+
+    queued = asyncio.create_task(
+        client.create_response("queued behind a response that never starts")
+    )
+    await _settle()
+    assert socket.types == [], (
+        "queued work must hold while the announced VAD response is pending"
+    )
+
+    # No response.created ever arrives. The backstop must reopen the lane…
+    await asyncio.sleep(0.2)
+    await _settle()
+    assert socket.types == ["conversation.item.create"], (
+        "backstop expiry must release the lane so queued native work dispatches"
+    )
+    # …and it must do so by releasing, never by tearing the connection down.
+    assert socket.closed is False
+
+    await _ack_item_and_expect_create(socket, 0)
+    socket.feed({"type": "response.created", "response": {"id": "resp-1"}})
+    socket.feed({"type": "response.done", "response": {"id": "resp-1"}})
+    await _settle()
+    await asyncio.wait_for(queued, timeout=1)
+    await client._response_arbiter.wait_until_idle(timeout=1)
+    assert client.is_active_response() is False
+
+    await _finish_loop(socket, receive_loop)
+
+
+# ---------------------------------------------------------------------------
+# T4 — the real native barge-in. Everywhere else in the suite
+# handle_interruption is an AsyncMock; here the actual transport handler runs:
+# speech_started → handle_interruption → a bare response.cancel on the wire
+# (native interruption does NOT route through arbiter.cancel_current — that
+# API's only production caller is the independent-ASR prepare path).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_native_barge_in_cancels_on_the_wire_and_the_cancelled_done_still_settles():
+    client, socket = _wired_client()
+    done_callbacks: list[bool] = []
+
+    async def _on_done() -> None:
+        done_callbacks.append(True)
+
+    client.on_response_done = _on_done
+    receive_loop = asyncio.create_task(client.handle_messages())
+
+    create = asyncio.create_task(client.create_response("hello"))
+    await _settle()
+    await _ack_item_and_expect_create(socket, 0)
+    await asyncio.wait_for(create, timeout=1)
+    socket.feed({"type": "response.created", "response": {"id": "resp-1"}})
+    await _settle()
+    assert client._is_responding is True
+    done_total_before = client._response_done_total
+
+    # The user starts speaking over her.
+    socket.feed({"type": "input_audio_buffer.speech_started"})
+    await _settle()
+    assert socket.types[-1] == "response.cancel", (
+        "a native barge-in must physically tell the server to stop talking"
+    )
+    assert client._is_responding is False
+    # #2345 deliberately KEEPS the cancelled response identity so the terminal
+    # below is processed as this turn's done rather than dropped stale.
+    assert client._current_response_id == "resp-1"
+
+    socket.feed(
+        {"type": "response.done", "response": {"id": "resp-1", "status": "cancelled"}}
+    )
+    await _settle()
+    # The cancelled turn's terminal must take the NON-stale path: counters,
+    # the on_response_done callback and the _interrupted reset all belong to
+    # this turn. (The stale filter would still forward the terminal to the
+    # arbiter, so lane release alone cannot distinguish the two paths — these
+    # two assertions can.)
+    assert client._response_done_total == done_total_before + 1
+    assert done_callbacks, (
+        "on_response_done must fire for the cancelled turn's terminal"
+    )
+    assert client._interrupted is False
+
+    # And the lane is open for the follow-up turn.
+    follow_up = asyncio.create_task(client.create_response("next"))
+    await _settle()
+    assert socket.types[-1] == "conversation.item.create"
+    await _ack_item_and_expect_create(socket, len(socket.sent) - 1)
+    socket.feed({"type": "response.created", "response": {"id": "resp-2"}})
+    socket.feed({"type": "response.done", "response": {"id": "resp-2"}})
+    await _settle()
+    await asyncio.wait_for(follow_up, timeout=1)
+    await client._response_arbiter.wait_until_idle(timeout=1)
+    assert socket.closed is False
+
+    await _finish_loop(socket, receive_loop)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_stale_filtered_terminal_still_reaches_the_arbiter_and_frees_the_lane():
+    # Crossed lifecycles: a newer response.created becomes current before the
+    # owner's terminal arrives, so the transport's stale filter classifies
+    # that terminal as stale. The filter must still forward it to the arbiter
+    # (the explicitly-commented branch in handle_messages) or the owner holds
+    # the lane until its 60s staleness bound — every queued native turn hangs.
+    client, socket = _wired_client()
+    receive_loop = asyncio.create_task(client.handle_messages())
+
+    create = asyncio.create_task(client.create_response("hello"))
+    await _settle()
+    await _ack_item_and_expect_create(socket, 0)
+    await asyncio.wait_for(create, timeout=1)
+    socket.feed({"type": "response.created", "response": {"id": "resp-a"}})
+    await _settle()
+
+    # A server-initiated response crosses in before resp-a's terminal.
+    socket.feed({"type": "response.created", "response": {"id": "resp-b"}})
+    await _settle()
+    assert client._current_response_id == "resp-b"
+
+    # resp-a's terminal is now stale by id — but it must free resp-a's owner.
+    socket.feed({"type": "response.done", "response": {"id": "resp-a"}})
+    socket.feed({"type": "response.done", "response": {"id": "resp-b"}})
+    await _settle()
+
+    follow_up = asyncio.create_task(client.create_response("next"))
+    await _settle()
+    assert socket.types[-1] == "conversation.item.create", (
+        "both terminals delivered means the lane must be open again"
+    )
+    await _ack_item_and_expect_create(socket, len(socket.sent) - 1)
+    socket.feed({"type": "response.created", "response": {"id": "resp-c"}})
+    socket.feed({"type": "response.done", "response": {"id": "resp-c"}})
+    await _settle()
+    await asyncio.wait_for(follow_up, timeout=1)
+    await client._response_arbiter.wait_until_idle(timeout=1)
+
+    await _finish_loop(socket, receive_loop)
+
+
+# ---------------------------------------------------------------------------
+# T5 — tool results. The existing tool-calling tests drive a __new__-built
+# client with no receive loop and only count wire events, which stays green
+# under a direct-send bypass; these run the real path.
+# ---------------------------------------------------------------------------
+
+
+def _tool_result(call_id: str = "call-1") -> ToolResult:
+    return ToolResult(call_id=call_id, name="get_weather", output={"ok": True})
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_consecutive_tool_results_serialize_on_the_wire():
+    client, socket = _wired_client()
+    receive_loop = asyncio.create_task(client.handle_messages())
+
+    first = asyncio.create_task(client._send_tool_result_openai_realtime(_tool_result()))
+    await _settle()
+    # No ack barrier on tool results: item and response.create go out together.
+    assert socket.types == ["conversation.item.create", "response.create"]
+    assert socket.sent[0]["item"]["type"] == "function_call_output"
+    await asyncio.wait_for(first, timeout=1)
+    socket.feed({"type": "response.created", "response": {"id": "resp-t1"}})
+    await _settle()
+
+    second = asyncio.create_task(
+        client._send_tool_result_openai_realtime(_tool_result("call-2"))
+    )
+    await _settle()
+    assert len(socket.sent) == 2, (
+        "the second tool result must not put a single byte on the wire while "
+        "the first tool response is still live"
+    )
+
+    socket.feed({"type": "response.done", "response": {"id": "resp-t1"}})
+    await _settle()
+    assert socket.types == [
+        "conversation.item.create",
+        "response.create",
+        "conversation.item.create",
+        "response.create",
+    ]
+    await asyncio.wait_for(second, timeout=1)
+    socket.feed({"type": "response.created", "response": {"id": "resp-t2"}})
+    socket.feed({"type": "response.done", "response": {"id": "resp-t2"}})
+    await _settle()
+    await client._response_arbiter.wait_until_idle(timeout=1)
+    assert socket.closed is False
+
+    await _finish_loop(socket, receive_loop)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_tool_result_outranks_earlier_queued_injected_text():
+    # priority=5 in _tools.py is the repo's only priority-5 enqueue. Its
+    # meaning: a tool result (the model is mid-conversation waiting on it)
+    # beats queued priority-10 text injection even when the text was
+    # submitted first. Both are enqueued before the worker selects, which is
+    # exactly the state _next_queued's priority ordering exists for.
+    client, socket = _wired_client()
+    receive_loop = asyncio.create_task(client.handle_messages())
+
+    text_task = asyncio.create_task(client.create_response("catch-up text"))
+    tool_task = asyncio.create_task(
+        client._send_tool_result_openai_realtime(_tool_result())
+    )
+    await _settle()
+
+    assert socket.sent[0]["item"]["type"] == "function_call_output", (
+        "the tool result (priority 5) must be selected over the "
+        "earlier-queued injected text (priority 10)"
+    )
+    assert socket.types[:2] == ["conversation.item.create", "response.create"]
+    await asyncio.wait_for(tool_task, timeout=1)
+    socket.feed({"type": "response.created", "response": {"id": "resp-t1"}})
+    socket.feed({"type": "response.done", "response": {"id": "resp-t1"}})
+    await _settle()
+
+    # Now the text dispatches, behind its ack barrier.
+    assert socket.types[2] == "conversation.item.create"
+    assert socket.sent[2]["item"]["type"] == "message"
+    await _ack_item_and_expect_create(socket, 2)
+    socket.feed({"type": "response.created", "response": {"id": "resp-2"}})
+    socket.feed({"type": "response.done", "response": {"id": "resp-2"}})
+    await _settle()
+    await asyncio.wait_for(text_task, timeout=1)
+    await client._response_arbiter.wait_until_idle(timeout=1)
+
+    await _finish_loop(socket, receive_loop)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_async_tool_rejection_frees_the_lane_without_tearing_the_transport():
+    # Pre-#2345 a rejected tool response.create had no observer at all (not
+    # even on_rejected): the turn just died silently. Now the error event is
+    # routed to the owning ticket via notify_error, which must free the lane
+    # promptly — not leave the next turn waiting for the 5s started-timeout,
+    # and never escalate a routed rejection into a transport teardown.
+    client, socket = _wired_client()
+    receive_loop = asyncio.create_task(client.handle_messages())
+
+    tool_task = asyncio.create_task(
+        client._send_tool_result_openai_realtime(_tool_result())
+    )
+    await _settle()
+    assert socket.types == ["conversation.item.create", "response.create"]
+    await asyncio.wait_for(tool_task, timeout=1)
+
+    create_event_id = socket.sent[1]["event_id"]
+    socket.feed(
+        {
+            "type": "error",
+            "error": {
+                "message": "response.create rejected by provider",
+                "event_id": create_event_id,
+            },
+        }
+    )
+    await _settle()
+
+    # The lane must be free NOW — a follow-up dispatches within a settle, not
+    # after the started-timeout backstop.
+    follow_up = asyncio.create_task(client.create_response("still alive"))
+    await _settle()
+    assert socket.types[-1] == "conversation.item.create", (
+        "a routed rejection must free the lane immediately"
+    )
+    assert socket.closed is False, (
+        "a routed rejection is not a transport failure"
+    )
+    await _ack_item_and_expect_create(socket, len(socket.sent) - 1)
+    socket.feed({"type": "response.created", "response": {"id": "resp-2"}})
+    socket.feed({"type": "response.done", "response": {"id": "resp-2"}})
+    await _settle()
+    await asyncio.wait_for(follow_up, timeout=1)
+    await client._response_arbiter.wait_until_idle(timeout=1)
+
+    await _finish_loop(socket, receive_loop)
+
+
+# ---------------------------------------------------------------------------
+# T2 — hot-swap prime_context(skipped=False). Its production trigger is the
+# final swap sequence in main_logic/core/lifecycle.py; every pre-existing
+# prime_context test used skipped=True or Gemini, neither of which enters the
+# arbiter. NOTE the model here must be non-qwen: _responses.py carves qwen out
+# of the create_response path (update_session instead), so a qwen client would
+# make this test pass without touching the queue.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_hot_swap_prime_runs_the_item_ack_barrier():
+    client, socket = _wired_client(api_type="free", model="free-model")
+    receive_loop = asyncio.create_task(client.handle_messages())
+
+    prime = asyncio.create_task(
+        client.prime_context("[context] the task finished", skipped=False)
+    )
+    await _settle()
+    assert socket.types == ["conversation.item.create"], (
+        "prime must persist the context item and wait for its ack before "
+        "requesting the announce response"
+    )
+    await _ack_item_and_expect_create(socket, 0)
+    socket.feed({"type": "response.created", "response": {"id": "resp-prime"}})
+    socket.feed({"type": "response.done", "response": {"id": "resp-prime"}})
+    await _settle()
+    await asyncio.wait_for(prime, timeout=1)
+    await client._response_arbiter.wait_until_idle(timeout=1)
+
+    await _finish_loop(socket, receive_loop)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_prime_dispatch_failure_surfaces_a_type_the_swap_must_catch():
+    # The final swap sequence wraps prime_context in a TARGETED except whose
+    # job is "abandon this swap, keep the old session". A dispatch failure
+    # surfaces from the arbiter ticket as RuntimeError (or ConnectionError /
+    # TimeoutError) — none of which is websockets' ConnectionClosed or
+    # AttributeError. This pins the surfaced type family so the lifecycle
+    # handler's tuple visibly must include it (see the paired test in
+    # test_hot_swap_cancellation.py for the handler side).
+    from websockets import exceptions as web_exceptions
+
+    client, socket = _wired_client(api_type="free", model="free-model")
+    receive_loop = asyncio.create_task(client.handle_messages())
+
+    prime = asyncio.create_task(
+        client.prime_context("[context] the task finished", skipped=False)
+    )
+    await _settle()
+    assert socket.types == ["conversation.item.create"]
+
+    item_event_id = socket.sent[0]["event_id"]
+    socket.feed(
+        {
+            "type": "error",
+            "error": {"message": "invalid item payload", "event_id": item_event_id},
+        }
+    )
+    await _settle()
+
+    assert prime.done(), "a routed rejection must fail the prime promptly"
+    exc = prime.exception()
+    assert isinstance(exc, RuntimeError)
+    assert not isinstance(exc, (web_exceptions.ConnectionClosed, AttributeError)), (
+        "the surfaced dispatch failure is NOT in the swap handler's legacy "
+        "except tuple — the handler must list these types explicitly"
+    )
+
+    await client._response_arbiter.wait_until_idle(timeout=1)
+    await _finish_loop(socket, receive_loop)
+
+
+# ---------------------------------------------------------------------------
+# T8 — the protect-her-speech contract, stated directly: program-initiated
+# text (proactive chat) queues behind a live response instead of preempting
+# it. Until now this held only implicitly through lane semantics; no test
+# asserted it as a contract.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_queued_proactive_text_never_preempts_a_live_response():
+    client, socket = _wired_client()
+    receive_loop = asyncio.create_task(client.handle_messages())
+
+    # She is mid-answer: a live (server-side) response holds the lane.
+    socket.feed({"type": "response.created", "response": {"id": "live-1"}})
+    await _settle()
+    assert client.is_active_response() is True
+
+    inject = asyncio.create_task(
+        client.inject_text_and_request_response("proactive nudge")
+    )
+    await _settle()
+    assert socket.types == [], (
+        "not a single byte of the proactive inject may reach the wire while "
+        "she is still speaking"
+    )
+
+    socket.feed({"type": "response.done", "response": {"id": "live-1"}})
+    await _settle()
+    assert socket.types[0] == "conversation.item.create", (
+        "the queued inject dispatches only after the live response finished"
+    )
+    await _ack_item_and_expect_create(socket, 0)
+    socket.feed({"type": "response.created", "response": {"id": "resp-inject"}})
+    socket.feed({"type": "response.done", "response": {"id": "resp-inject"}})
+    await _settle()
+    ticket = await asyncio.wait_for(inject, timeout=1)
+    assert ticket is not None
+    await client._response_arbiter.wait_until_idle(timeout=1)
+    assert client.is_active_response() is False
+
+    await _finish_loop(socket, receive_loop)
+
+
+# ---------------------------------------------------------------------------
+# T7 — the fail-close chokepoint. All six _fail_closed call sites tear the
+# transport down through one function; that function now logs the initiator,
+# the reason and the lane state. Issue #2561 is the motivating incident: an
+# unattributable disconnect had to be ruled out via build provenance because
+# exactly this log line did not exist.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fail_close_logs_initiator_reason_and_lane_state(caplog):
+    aborted: list[str] = []
+
+    async def _send(event: dict) -> None:
+        return None
+
+    async def _abort(reason: str) -> None:
+        aborted.append(reason)
+
+    arbiter = RealtimeResponseArbiter(_send, abort_transport=_abort)
+    ticket = await arbiter.enqueue(source="native")
+    await asyncio.wait_for(ticket.sent, timeout=1)
+    arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "resp-1"}}
+    )
+
+    with caplog.at_level(
+        logging.WARNING, logger="main_logic.omni_realtime_client._response_arbiter"
+    ):
+        # No terminal ever arrives for the cancelled response; cancel_current
+        # fails closed and re-raises the timeout to its caller.
+        with pytest.raises(asyncio.TimeoutError):
+            await arbiter.cancel_current(timeout=0.05)
+
+    assert aborted, "the cancel-terminal timeout must fail closed"
+    fail_close_logs = [
+        record.getMessage()
+        for record in caplog.records
+        if "failing closed" in record.getMessage()
+    ]
+    assert fail_close_logs, (
+        "the fail-close chokepoint must log BEFORE tearing the transport, or "
+        "a field disconnect cannot be attributed to the arbiter at all"
+    )
+    message = fail_close_logs[0]
+    assert "response cancellation terminal event timed out" in message
+    assert "queue_depth" in message
+    assert "owner=native" in message
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cancel_whose_terminal_arrives_in_time_never_fails_closed(caplog):
+    # The dual of the test above: the same cancel path with a timely terminal
+    # must neither abort the transport nor emit the fail-close log line.
+    aborted: list[str] = []
+
+    async def _send(event: dict) -> None:
+        return None
+
+    async def _abort(reason: str) -> None:
+        aborted.append(reason)
+
+    arbiter = RealtimeResponseArbiter(_send, abort_transport=_abort)
+    ticket = await arbiter.enqueue(source="native")
+    await asyncio.wait_for(ticket.sent, timeout=1)
+    arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "resp-1"}}
+    )
+
+    with caplog.at_level(
+        logging.WARNING, logger="main_logic.omni_realtime_client._response_arbiter"
+    ):
+        cancel_task = asyncio.create_task(arbiter.cancel_current(timeout=1))
+        await _settle()
+        arbiter.notify_response_terminal(
+            {"type": "response.cancelled", "response": {"id": "resp-1"}}
+        )
+        await asyncio.wait_for(cancel_task, timeout=1)
+
+    assert aborted == []
+    assert not any(
+        "failing closed" in record.getMessage() for record in caplog.records
+    )
+    await arbiter.wait_until_idle(timeout=1)

--- a/tests/unit/test_realtime_arbiter_native_path.py
+++ b/tests/unit/test_realtime_arbiter_native_path.py
@@ -457,8 +457,9 @@ async def test_user_speech_preempts_an_inflight_native_request():
         "an utterance ending must fail the in-flight explicit request "
         "immediately, not leave it racing the automatic VAD response"
     )
-    with pytest.raises(RuntimeError, match="pending server VAD response"):
-        await create
+    exc = create.exception()
+    assert isinstance(exc, RuntimeError)
+    assert "pending server VAD response" in str(exc)
     assert "response.create" not in socket.types, (
         "the losing explicit request must never emit its response.create"
     )


### PR DESCRIPTION
## 背景

#2515 决议后的收尾（决议：不拆 arbiter，改为补纯 native 回归 + 可观测性）。RealtimeResponseArbiter 随 #2345 进入**所有存量用户**的默认路径，但 native 视角的断言此前接近零：`arm_server_vad_response_pending_timeout` 全仓 0 命中、`handle_interruption` 只有 3 处 AsyncMock 替身从未真跑、热切换 `prime_context(skipped=False)` 零覆盖、核心层主动搭话测试被夹具桩挡在 `is_active_response` 新语义之外。

本 PR 按 #2515 的 T1-T8 清单补齐，并带三处小的生产改动（见下）。

## 生产改动（3 处，~40 行）

1. **`main_logic/core/lifecycle.py` 两处 prime_context 窄 except 放宽**（`ConnectionClosed, AttributeError` → 追加 `ConnectionError, RuntimeError, asyncio.TimeoutError`）。
   自 #2345 起 `skipped=False` 的 prime 经 arbiter 排队，ticket 失败以这三类异常浮出——都不在旧 tuple 里。**没有泄漏**：外层 `except Exception`（:2471 附近）会兜住并做同样的清理；错的是**口径**——良性的"放弃本次 swap、老会话继续用"会被外层兜底当成 `INTERNAL_UPDATE_FAILED` 报给前端。修后走定向分支，不惊动用户。
2. **`_response_arbiter.py` 的 `_fail_closed` chokepoint 加 warning 日志**（reason + current/owner 来源 + 队列深度 + VAD pending）。六个拆连接点全部流经此函数，此前唯一日志是一句只在 abort 本身也失败时才打的 debug——#2561 那次断线排查被迫走构建溯源，就是因为缺这一行。
3. **`_transport.py` `handle_interruption` 里的过期注释改写**。旧注释声称清掉 `_current_response_id` 会让 arbiter 一直 busy；实际 stale 分支有显式的 terminal 转发兜着，真实后果是丢掉该轮 done 的整段处理（计数、usage、`_interrupted` 复位、`on_response_done`）。注释按真实因果重写（M6/M7 变异分别证明了两半）。

## 新增测试（T1-T8，3 个文件，~850 行）

除注明外全部驱动**真 client + 真 receive loop**（`_RecordingSocket`），不手戳 arbiter 内部：

| # | 用例 | 钉住什么 |
|---|---|---|
| T1 | `test_user_speech_preempts_an_inflight_native_request` | **用户开口无条件赢**：utterance 结束立即打掉在飞显式请求，其 `response.create` 永不上线 |
| T1 | `test_missing_created_backstop_arms_only_after_receive_handling_resumes` | speech_stopped 两阶段：callback 内 pending 已标/backstop 未武装，callback 返回后才武装 |
| T2 | `test_hot_swap_prime_runs_the_item_ack_barrier` | 热切换 prime（非 qwen！qwen 有 carve-out 会假绿）走 item-ack 栅栏 |
| T2 | `test_prime_dispatch_failure_surfaces_a_type_the_swap_must_catch` | ticket 失败浮出的异常类型不在旧 except tuple 里 |
| T2 | `test_prime_dispatch_failure_takes_the_targeted_abort_not_the_generic_handler`（+skipped 分支对偶） | swap 口径：清理照做且**不发** `INTERNAL_UPDATE_FAILED` |
| T3 | `test_vad_backstop_expiry_reopens_the_lane_without_tearing_the_transport` | 5s 兜底=放开 lane，绝不拆连接（全仓首个触达该常量的用例） |
| T4 | `test_native_barge_in_cancels_on_the_wire_and_the_cancelled_done_still_settles` | 真打断链：`response.cancel` 真上线、identity 保留、cancelled done 走非 stale 处理 |
| T4 | `test_stale_filtered_terminal_still_reaches_the_arbiter_and_frees_the_lane` | 交叉 created 下 stale terminal 仍到 arbiter、lane 不楔死 |
| T5 | `test_consecutive_tool_results_serialize_on_the_wire` | 第二条工具结果在第一条 done 前零字节上线 |
| T5 | `test_a_tool_result_outranks_earlier_queued_injected_text` | priority=5（全仓唯一）语义 |
| T5 | `test_async_tool_rejection_frees_the_lane_without_tearing_the_transport` | 被拒即放 lane（不等 5s started 超时）、不拆连接 |
| T6 | `test_voice_gate_sees_arbiter_busyness_not_just_the_responding_flag` + `_make_voice_sess_with_real_gate` 变体 | 主动搭话闸门看得见 arbiter busy；**现有 31 条 stock-fixture 用例保持不动** |
| T7 | `test_fail_close_logs_initiator_reason_and_lane_state` + healthy 对偶 | 拆连接前必留痕；健康取消不拆连接不留痕 |
| T8 | `test_queued_proactive_text_never_preempts_a_live_response` | **保护 AI 说话**：程序文本注入排队等 done，一个字节不抢先 |

## 变异验证（16/16）

每条断言都用「改坏对应生产行 → 必红 → 复原」证明过捕捉力，含四组定向对偶（红一半时另一半必须仍绿，证明两条用例钉的是不同站点）：

M1-M3 speech_stopped 通知/时序/finally；M4-M5 兜底 no-op/改拆连接；**M6/M7** 打断清 id ↔ stale 转发（互为对偶绿）；M8-M9 priority/直发 bypass；M10 notify_error 路由删除；M11 create_response 直发 bypass（连既有 e2e 一起红）；**M12/M13** 两处 except 各自回收（互为对偶绿）；M14 `is_active_response` 回退旧语义（新用例红、**全文件其余用例仍绿**=夹具盲区实证）；M15 删日志；M16 inject 直发 bypass。

## 回归报告

- **改动面**：生产仅 3 处（上表）；其中唯一的行为改动是 lifecycle 的异常口径（prime 失败从「外层兜底+前端弹 INTERNAL_UPDATE_FAILED」变为「定向放弃 swap、不惊动前端」），清理动作两条路径完全相同。arbiter 日志与 transport 注释零行为影响。
- **必要性**：这批路径每个 native 用户每轮语音都在走，而三条默认分发渠道（v0.8.3 / nightly / docker latest）都还不含 arbiter——这批测试是下次发版前唯一的安全信号。
- **改前/改后**：改前 prime ticket 失败 → 外层兜底 → 前端收到内部错误提示；改后 → 定向分支 → 日志 + 静默放弃本次 swap（老会话继续用，下次热切换重试）。改前 arbiter 拆连接无任何可归因日志；改后单点 warning 带 reason/来源/队列深度。
- **潜在回归**：except 放宽只包住单条 `await prime_context(...)`，无邻近语句被误捕；`RuntimeError` 在该 await 内的全部来源（派发打断/owner 冲突/notify_error 路由）语义上都是「本次 prime 未送达」，归入放弃-swap 口径正确。M12/M13 变异证明两站点各自受各自用例保护。fail-close 日志在 caplog 下由 T7 对偶用例保证健康路径零输出。

## 相关

- Closes 无；Refs #2515（收尾清单 T1-T8 全部落地）、#2561（fail-close 可归因）、#2345、#2562

🤖 Generated with [Claude Code](https://claude.com/claude-code)
