### PR TITLE
fix(auth): use environment-specific OAuth client

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -512,6 +512,18 @@ uv run python -m app.agent_server
 # 5. 访问 http://localhost:48911 配置 API Key 并开始使用
 ```
 
+社区登录需要按环境选择对应的启动入口：
+
+```bash
+# 开发环境：使用 neko-servers-desktop-dev
+./scripts/start-dev.sh
+
+# 生产环境：使用 neko-servers-desktop-prod
+./scripts/start-prod.sh
+```
+
+不要直接使用 `python3 launcher.py` 启动需要连接生产 Auth 平台的实例，否则会回落到开发 Client。
+
 **调试聊天界面形态（full / compact）**：Web 端默认 `full`（完整聊天窗口），Electron 端默认 `compact`（悬浮对话条）。在浏览器控制台用 localStorage 切换测试（硬刷新生效）：
 
 ```js

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -58,7 +58,11 @@ Build both frontend projects on the first checkout or after frontend changes:
 Start the supported service suite:
 
 ```bash
-uv run python launcher.py
+# Development Auth environment
+./scripts/start-dev.sh
+
+# Production Auth environment
+# ./scripts/start-prod.sh
 ```
 
 Open `http://127.0.0.1:48911`. See [development setup](guide/dev-setup.md) and [quick start](guide/quick-start.md) before splitting services manually.

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -7,10 +7,16 @@ Complete [Development Setup](./dev-setup) first.
 ## 1. Launch
 
 ```bash
-uv run python launcher.py
+# Development Auth environment
+./scripts/start-dev.sh
+
+# Production Auth environment
+# ./scripts/start-prod.sh
 ```
 
 The launcher starts the cooperating services and reports selected ports. Use the reported main URL; `http://127.0.0.1:48911` is only the preferred default.
+
+Use `start-dev.sh` with the development Auth client and `start-prod.sh` with the production Auth client. Do not launch this flow with a bare `python3 launcher.py`, because it defaults to the development client.
 
 ## 2. Configure providers
 

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+cd "${script_dir}/.."
+
+export NEKO_SERVERS_DESKTOP_CLIENT_ID="neko-servers-desktop-dev"
+exec python3 launcher.py "$@"

--- a/scripts/start-prod.sh
+++ b/scripts/start-prod.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+cd "${script_dir}/.."
+
+export NEKO_SERVERS_DESKTOP_CLIENT_ID="neko-servers-desktop-prod"
+exec python3 launcher.py "$@"


### PR DESCRIPTION
## 改动概述 / Summary

为猫娘社区 OAuth 增加开发环境与生产环境独立的 N.E.K.O 启动入口：

- `scripts/start-dev.sh` 固定使用 `neko-servers-desktop-dev`。
- `scripts/start-prod.sh` 固定使用 `neko-servers-desktop-prod`。
- 同步更新中英文源码启动文档，避免生产环境继续直接运行 `python3 launcher.py`。

根因是 N.E.K.O 默认使用开发 Client `neko-servers-desktop-dev`，但生产 Auth Platform 注册的是 `neko-servers-desktop-prod`。生产 Auth 收到开发 Client 后返回 OAuth `invalid_client` 错误页，页面表现为 404。

## 回归报告 / Regression Report

不适用。本 PR 未修改 `app/`、`main_logic/`、`main_routers/` 或 `memory/` 下的 Python 文件，也未修改 OAuth 业务逻辑；仅增加环境明确的启动入口并更新文档。

## 不拆分理由 / Why Not Split

不适用。按仓库规则计入文件数为 3 个，未超过 20 个；新增启动脚本不计入该上限。

## 测试 / Testing

- `bash -n scripts/start-dev.sh scripts/start-prod.sh`：通过。
- `uv run pytest -q tests/unit/test_community_oauth.py`：30 passed。
- 使用 `./scripts/start-prod.sh` 实际重启 N.E.K.O：启动成功，`/health` 返回正常。
- 调用本地 `/api/card-drop/oauth/start` 验证实际生成的 `client_id` 为 `neko-servers-desktop-prod`。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增开发环境与生产环境的独立启动脚本。
  * 启动脚本会自动配置对应的登录环境，并支持传递启动参数。

* **文档**
  * 更新快速开始指南，补充不同环境的启动方式及访问地址。
  * 增加启动注意事项，避免使用不适用的直接启动命令。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->