### PR TITLE
fix(file_utils): 清理失败不再盖掉真实写盘错误，并清扫崩后残留 tmp（#2528 第 2 步）

### DIFF
--- a/plugin/server/application/install_source/manager.py
+++ b/plugin/server/application/install_source/manager.py
@@ -266,7 +266,11 @@ def _atomic_write(lock_path: Path, payload: bytes) -> None:
         assert last_exc is not None
         raise last_exc
     except BaseException:
-        with suppress(FileNotFoundError):
+        # suppress(OSError) 而不是只吞 FileNotFoundError：目标被句柄占着时
+        # os.replace 抛 PermissionError，紧随其后的 unlink 往往被同一个原因拒掉，
+        # 只吞 FileNotFoundError 就会让调用方看到 unlink 的异常、真实原因退到
+        # __context__ 里。与 utils/file_utils.atomic_write_text 保持一致。
+        with suppress(OSError):
             tmp_path.unlink()
         raise
 

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -46,6 +46,11 @@ def _tmp_siblings(target: Path) -> list[Path]:
     )
 
 
+def _abandoned_tmp(target: Path, rand: str = "deadbeef") -> Path:
+    """A temp file shaped exactly like the ones this module leaves behind."""
+    return target.parent / f".{target.name}.{file_utils._TMP_OWNER_TAG}{rand}.tmp"
+
+
 def _age(path: Path, seconds: float) -> None:
     stamp = time.time() - seconds
     os.utime(path, (stamp, stamp))
@@ -190,7 +195,7 @@ def test_unserializable_payload_never_touches_the_target(tmp_path):
 
 def test_stale_temp_from_a_hard_kill_is_swept(tmp_path):
     target = tmp_path / "state.json"
-    leftover = tmp_path / f".{target.name}.deadbeef.tmp"
+    leftover = _abandoned_tmp(target)
     leftover.write_text("half-written garbage", encoding="utf-8")
     _age(leftover, file_utils._STALE_TMP_MIN_AGE_S + 60)
 
@@ -204,7 +209,7 @@ def test_temp_file_of_a_live_writer_is_not_swept(tmp_path):
     # 另一个进程正在写同一个目标时，它的 tmp 只有几毫秒岁数；扫掉就等于把
     # 别人写了一半的数据删了。年龄门槛就是为了这个。
     target = tmp_path / "state.json"
-    inflight = tmp_path / f".{target.name}.inflight.tmp"
+    inflight = _abandoned_tmp(target, "inflight")
     inflight.write_text("someone else is mid-write", encoding="utf-8")
 
     atomic_write_json(target, {"v": 1})
@@ -217,7 +222,7 @@ def test_sweep_also_clears_other_targets_abandoned_temps(tmp_path):
     # 垃圾。按目标记账会漏掉「写完就沉底、再也不会被写第二次」的目标（归档分片就是
     # 这种），那些残留永远扫不到。
     target = tmp_path / "state.json"
-    other_target_tmp = tmp_path / ".other.json.deadbeef.tmp"
+    other_target_tmp = _abandoned_tmp(tmp_path / "other.json")
     other_target_tmp.write_text("garbage from a crash", encoding="utf-8")
     _age(other_target_tmp, file_utils._STALE_TMP_MIN_AGE_S + 60)
 
@@ -226,17 +231,19 @@ def test_sweep_also_clears_other_targets_abandoned_temps(tmp_path):
     assert not other_target_tmp.exists()
 
 
-def test_sweep_only_matches_the_shape_this_module_creates(tmp_path):
-    # 按目录扫就得靠形状认自己的 tmp：mkstemp 产出的是
-    # `.<目标名>.<8 个 [a-z0-9_]>.tmp`。形状不匹配一律不碰 —— 方向是少删不误删。
+def test_sweep_only_touches_files_it_can_prove_it_owns(tmp_path):
+    # 按目录扫的前提是能**证明**所有权：光靠「形状像 + 够老」会把别的程序、插件或
+    # 用户放在同一个目录里的旧文件永久删掉。所以自己的 tmp 名里嵌了所有权标记，
+    # 没有这个标记的一律不碰 —— 包括本模块早先版本留下的无标记 tmp（宁可漏清）。
     target = tmp_path / "state.json"
+    tag = file_utils._TMP_OWNER_TAG
     keepers = [
-        tmp_path / f".{target.name}.deadbeef.bak",   # 不是 .tmp
-        tmp_path / f"{target.name}.deadbeef.tmp",    # 没有前导点
-        tmp_path / ".state.json.short.tmp",          # 随机段不是 8 位
-        tmp_path / ".state.json.deadbeefx.tmp",      # 随机段是 9 位
-        tmp_path / ".state.json.DEADBEEF.tmp",       # 随机段字符集不对（大写）
-        tmp_path / ".notes.tmp",                     # 用户自己的文件
+        tmp_path / f".{target.name}.{tag}deadbeef.bak",  # 不是 .tmp
+        tmp_path / f"{target.name}.{tag}deadbeef.tmp",   # 没有前导点
+        tmp_path / f".{target.name}.deadbeef.tmp",       # 没有所有权标记（旧版残留）
+        tmp_path / f".{target.name}.{tag.upper()}deadbeef.tmp",  # 标记大小写不对
+        tmp_path / ".rsync-ish.abcdef.tmp",              # 别的工具的临时文件
+        tmp_path / ".notes.tmp",                         # 用户自己的文件
     ]
     for path in keepers:
         path.write_text("keep me", encoding="utf-8")
@@ -247,13 +254,33 @@ def test_sweep_only_matches_the_shape_this_module_creates(tmp_path):
     assert [p.name for p in keepers if not p.exists()] == []
 
 
+def test_the_temp_files_this_module_creates_carry_the_owner_tag(tmp_path, monkeypatch):
+    # 所有权标记只有在**创建**时也带上才有意义：只改清扫器的正则、不改 mkstemp 的
+    # 前缀，就会变成「以后再也扫不到任何东西」的静默失效。
+    target = tmp_path / "state.json"
+    seen = {}
+    real_mkstemp = tempfile.mkstemp
+
+    def spy(*args, **kwargs):
+        fd, path = real_mkstemp(*args, **kwargs)
+        seen["name"] = Path(path).name
+        return fd, path
+
+    monkeypatch.setattr(tempfile, "mkstemp", spy)
+    atomic_write_json(target, {"v": 1})
+
+    assert file_utils._STALE_TMP_RE.match(seen["name"]), (
+        f"创建出来的 tmp 名 {seen['name']!r} 不被清扫器的所有权正则认领"
+    )
+
+
 def test_sweep_is_amortised_per_directory(tmp_path):
     # 摊销是有意的：残留由崩溃产生，而崩溃结束了那个进程，所以长寿进程反复扫目录
     # 没有意义。这条把「扫干净之后就不再扫」钉下来，免得后来有人改成每次写都扫。
     target = tmp_path / "state.json"
     atomic_write_json(target, {"v": 1})
 
-    appeared_later = tmp_path / f".{target.name}.deadbeef.tmp"
+    appeared_later = _abandoned_tmp(target)
     appeared_later.write_text("garbage", encoding="utf-8")
     _age(appeared_later, file_utils._STALE_TMP_MIN_AGE_S + 60)
 
@@ -279,7 +306,7 @@ def test_a_failed_scan_does_not_consume_every_attempt(tmp_path, monkeypatch):
     # 瞬时 OSError（目录被短暂锁住、网络盘抖动）不该把这个目录的机会一次用光，
     # 否则残留会一直留到进程退出。
     target = tmp_path / "state.json"
-    leftover = tmp_path / f".{target.name}.deadbeef.tmp"
+    leftover = _abandoned_tmp(target)
     leftover.write_text("garbage", encoding="utf-8")
     _age(leftover, file_utils._STALE_TMP_MIN_AGE_S + 60)
 
@@ -415,7 +442,7 @@ def test_a_temp_file_that_cannot_be_removed_leaves_a_retry(tmp_path, monkeypatch
     # 删不掉一个 tmp 不代表整个目录扫过了：Windows 上活写者的句柄还开着就会撞这个，
     # 句柄一放开就该能扫掉。所以「没扫干净」不记成完成，留给后续写盘重试。
     target = tmp_path / "state.json"
-    leftover = tmp_path / f".{target.name}.deadbeef.tmp"
+    leftover = _abandoned_tmp(target)
     leftover.write_text("garbage", encoding="utf-8")
     _age(leftover, file_utils._STALE_TMP_MIN_AGE_S + 60)
 
@@ -458,7 +485,7 @@ def test_sweep_cannot_steal_a_temp_file_that_is_still_open(tmp_path):
 
 def test_sweep_survives_a_temp_file_that_cannot_be_removed(tmp_path, monkeypatch):
     target = tmp_path / "state.json"
-    leftover = tmp_path / f".{target.name}.deadbeef.tmp"
+    leftover = _abandoned_tmp(target)
     leftover.write_text("garbage", encoding="utf-8")
     _age(leftover, file_utils._STALE_TMP_MIN_AGE_S + 60)
 

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -1,0 +1,425 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for utils.file_utils atomic write primitives.
+
+These are the repo's single funnel for putting JSON/text on disk (~430 call
+sites across memory, config, topic signals and plugin storage), so the
+guarantees they must keep are:
+
+- the target file is replaced, never written in place;
+- a failed write leaves the previous target content intact;
+- a failure during cleanup never masks the failure that caused it;
+- temp files left behind by a hard kill get swept eventually;
+- the async twins do their blocking work off the event loop.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from utils import file_utils
+from utils.file_utils import (
+    atomic_write_json,
+    atomic_write_json_async,
+    atomic_write_text,
+    atomic_write_text_async,
+    read_json,
+    read_json_async,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _tmp_siblings(target: Path) -> list[Path]:
+    """Temp files this module would have created next to ``target``."""
+    prefix = f".{target.name}."
+    return sorted(
+        p for p in target.parent.iterdir()
+        if p.name.startswith(prefix) and p.name.endswith(".tmp")
+    )
+
+
+def _age(path: Path, seconds: float) -> None:
+    stamp = time.time() - seconds
+    os.utime(path, (stamp, stamp))
+
+
+# ── happy path ──────────────────────────────────────────────────────────
+
+
+def test_atomic_write_text_creates_missing_parents(tmp_path):
+    target = tmp_path / "deep" / "nested" / "state.txt"
+
+    atomic_write_text(target, "hello")
+
+    assert target.read_text(encoding="utf-8") == "hello"
+
+
+def test_atomic_write_json_roundtrips_unicode_without_escaping(tmp_path):
+    target = tmp_path / "state.json"
+
+    atomic_write_json(target, {"名字": "妮可", "n": 1})
+
+    raw = target.read_text(encoding="utf-8")
+    assert "妮可" in raw, "ensure_ascii should default to False"
+    assert read_json(target) == {"名字": "妮可", "n": 1}
+
+
+def test_atomic_write_json_forwards_dumps_options(tmp_path):
+    target = tmp_path / "state.json"
+
+    atomic_write_json(target, {"b": 1, "a": 2}, indent=None, sort_keys=True)
+
+    assert target.read_text(encoding="utf-8") == '{"a": 2, "b": 1}'
+
+
+def test_atomic_write_text_honours_encoding(tmp_path):
+    target = tmp_path / "state.txt"
+
+    atomic_write_text(target, "妮可", encoding="utf-16")
+
+    assert target.read_bytes() != "妮可".encode("utf-8")
+    assert target.read_text(encoding="utf-16") == "妮可"
+
+
+def test_successful_write_leaves_no_temp_file_behind(tmp_path):
+    target = tmp_path / "state.json"
+
+    atomic_write_json(target, {"v": 1})
+    atomic_write_json(target, {"v": 2})
+
+    assert _tmp_siblings(target) == []
+    assert read_json(target) == {"v": 2}
+
+
+def test_target_holds_previous_content_until_the_rename(tmp_path, monkeypatch):
+    # 这是「原子」的实际含义：新内容先完整落到 tmp（写满 + fsync），目标文件在
+    # os.replace 之前一直是旧的完整内容 —— 读者永远看不到半截文件。
+    target = tmp_path / "state.json"
+    atomic_write_json(target, {"v": 1})
+
+    observed: dict[str, str] = {}
+    real_replace = os.replace
+
+    def spy(src, dst):
+        observed["target_before"] = Path(dst).read_text(encoding="utf-8")
+        observed["staged"] = Path(src).read_text(encoding="utf-8")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(os, "replace", spy)
+    atomic_write_json(target, {"v": 2})
+
+    assert json.loads(observed["target_before"]) == {"v": 1}
+    assert json.loads(observed["staged"]) == {"v": 2}
+    assert read_json(target) == {"v": 2}
+
+
+# ── failure handling ────────────────────────────────────────────────────
+
+
+def test_failed_replace_removes_temp_and_keeps_old_target(tmp_path, monkeypatch):
+    target = tmp_path / "state.json"
+    atomic_write_json(target, {"v": 1})
+
+    def boom(src, dst):
+        raise OSError("replace refused")
+
+    monkeypatch.setattr(os, "replace", boom)
+    with pytest.raises(OSError, match="replace refused"):
+        atomic_write_json(target, {"v": 2})
+
+    assert read_json(target) == {"v": 1}, "failed write must not corrupt the target"
+    assert _tmp_siblings(target) == [], "temp file should be cleaned up"
+
+
+def test_cleanup_failure_does_not_mask_the_real_error(tmp_path, monkeypatch):
+    # 回归点：目标被别的句柄占着时，os.replace 和紧随其后的 os.remove 会被同一个
+    # 原因一起拒掉（Windows 上都是 WinError 5）。清理异常绝不能顶替真实原因，
+    # 否则日志里只剩「删不掉临时文件」，完全指不到病根。
+    target = tmp_path / "state.json"
+
+    def replace_denied(src, dst):
+        raise PermissionError("the real reason: target is held open")
+
+    def remove_denied(path):
+        raise PermissionError("cleanup also denied")
+
+    monkeypatch.setattr(os, "replace", replace_denied)
+    monkeypatch.setattr(os, "remove", remove_denied)
+
+    with pytest.raises(PermissionError) as excinfo:
+        atomic_write_json(target, {"v": 1})
+
+    assert "the real reason" in str(excinfo.value)
+    assert "cleanup also denied" not in str(excinfo.value)
+
+
+def test_missing_temp_file_during_cleanup_is_tolerated(tmp_path, monkeypatch):
+    target = tmp_path / "state.json"
+
+    def replace_and_vanish(src, dst):
+        os.unlink(src)
+        raise OSError("replace refused after the temp file vanished")
+
+    monkeypatch.setattr(os, "replace", replace_and_vanish)
+    with pytest.raises(OSError, match="replace refused"):
+        atomic_write_json(target, {"v": 1})
+
+
+def test_unserializable_payload_never_touches_the_target(tmp_path):
+    # json.dumps 在 atomic_write_text 之前跑，所以连 tmp 都不该出现。
+    target = tmp_path / "state.json"
+    atomic_write_json(target, {"v": 1})
+
+    with pytest.raises(TypeError):
+        atomic_write_json(target, {"bad": object()})
+
+    assert read_json(target) == {"v": 1}
+    assert _tmp_siblings(target) == []
+
+
+# ── stale temp sweeping ─────────────────────────────────────────────────
+
+
+def test_stale_temp_from_a_hard_kill_is_swept(tmp_path):
+    target = tmp_path / "state.json"
+    leftover = tmp_path / f".{target.name}.deadbeef.tmp"
+    leftover.write_text("half-written garbage", encoding="utf-8")
+    _age(leftover, file_utils._STALE_TMP_MIN_AGE_S + 60)
+
+    atomic_write_json(target, {"v": 1})
+
+    assert not leftover.exists()
+    assert read_json(target) == {"v": 1}
+
+
+def test_temp_file_of_a_live_writer_is_not_swept(tmp_path):
+    # 另一个进程正在写同一个目标时，它的 tmp 只有几毫秒岁数；扫掉就等于把
+    # 别人写了一半的数据删了。年龄门槛就是为了这个。
+    target = tmp_path / "state.json"
+    inflight = tmp_path / f".{target.name}.inflight.tmp"
+    inflight.write_text("someone else is mid-write", encoding="utf-8")
+
+    atomic_write_json(target, {"v": 1})
+
+    assert inflight.exists()
+
+
+def test_sweep_ignores_files_that_are_not_this_target_s_temps(tmp_path):
+    target = tmp_path / "state.json"
+    other_target_tmp = tmp_path / ".other.json.deadbeef.tmp"
+    not_a_tmp = tmp_path / f".{target.name}.deadbeef.bak"
+    for path in (other_target_tmp, not_a_tmp):
+        path.write_text("keep me", encoding="utf-8")
+        _age(path, file_utils._STALE_TMP_MIN_AGE_S + 60)
+
+    atomic_write_json(target, {"v": 1})
+
+    assert other_target_tmp.exists()
+    assert not_a_tmp.exists()
+
+
+def test_sweep_runs_once_per_target_per_process(tmp_path):
+    # 摊销是有意的：残留由崩溃产生，而崩溃结束了那个进程，所以长寿进程反复扫
+    # 目录没有意义。这条把「只扫一次」钉下来，免得后来有人把它改成每次写都扫。
+    target = tmp_path / "state.json"
+    atomic_write_json(target, {"v": 1})
+
+    appeared_later = tmp_path / f".{target.name}.deadbeef.tmp"
+    appeared_later.write_text("garbage", encoding="utf-8")
+    _age(appeared_later, file_utils._STALE_TMP_MIN_AGE_S + 60)
+
+    atomic_write_json(target, {"v": 2})
+
+    assert appeared_later.exists()
+
+
+def test_sweep_survives_an_unreadable_directory(tmp_path, monkeypatch):
+    target = tmp_path / "state.json"
+
+    def denied(_path):
+        raise PermissionError("cannot list this directory")
+
+    monkeypatch.setattr(os, "scandir", denied)
+    atomic_write_json(target, {"v": 1})
+
+    assert read_json(target) == {"v": 1}
+
+
+def test_sweep_survives_a_temp_file_that_cannot_be_removed(tmp_path, monkeypatch):
+    target = tmp_path / "state.json"
+    leftover = tmp_path / f".{target.name}.deadbeef.tmp"
+    leftover.write_text("garbage", encoding="utf-8")
+    _age(leftover, file_utils._STALE_TMP_MIN_AGE_S + 60)
+
+    real_unlink = os.unlink
+
+    def unlink_denied(path):
+        if str(path) == str(leftover):
+            raise PermissionError("cannot remove leftover")
+        return real_unlink(path)
+
+    monkeypatch.setattr(os, "unlink", unlink_denied)
+    atomic_write_json(target, {"v": 1})
+
+    assert read_json(target) == {"v": 1}, "sweeping is best-effort, never fatal"
+
+
+# ── async twins ─────────────────────────────────────────────────────────
+
+
+async def test_async_text_twin_writes_off_the_event_loop(tmp_path, monkeypatch):
+    # 落盘含 fsync，跑在事件循环线程上会卡住所有协程。async 孪生的唯一职责就是
+    # 把它挪到 worker 线程，这条把它钉住。
+    target = tmp_path / "state.txt"
+    loop_thread = threading.get_ident()
+    seen: dict[str, int] = {}
+    real_write = file_utils.atomic_write_text
+
+    def spy(path, content, **kwargs):
+        seen["thread"] = threading.get_ident()
+        return real_write(path, content, **kwargs)
+
+    monkeypatch.setattr(file_utils, "atomic_write_text", spy)
+    await atomic_write_text_async(target, "hello")
+
+    assert seen["thread"] != loop_thread
+    assert target.read_text(encoding="utf-8") == "hello"
+
+
+async def test_async_json_twin_writes_off_the_event_loop(tmp_path, monkeypatch):
+    target = tmp_path / "state.json"
+    loop_thread = threading.get_ident()
+    seen: dict[str, int] = {}
+    real_write = file_utils.atomic_write_json
+
+    def spy(path, data, **kwargs):
+        seen["thread"] = threading.get_ident()
+        return real_write(path, data, **kwargs)
+
+    monkeypatch.setattr(file_utils, "atomic_write_json", spy)
+    await atomic_write_json_async(target, {"v": 1}, indent=None)
+
+    assert seen["thread"] != loop_thread
+    assert target.read_text(encoding="utf-8") == '{"v": 1}'
+
+
+async def test_async_read_twin_reads_off_the_event_loop(tmp_path, monkeypatch):
+    target = tmp_path / "state.json"
+    atomic_write_json(target, {"v": 7})
+    loop_thread = threading.get_ident()
+    seen: dict[str, int] = {}
+    real_read = file_utils.read_json
+
+    def spy(path, **kwargs):
+        seen["thread"] = threading.get_ident()
+        return real_read(path, **kwargs)
+
+    monkeypatch.setattr(file_utils, "read_json", spy)
+
+    assert await read_json_async(target) == {"v": 7}
+    assert seen["thread"] != loop_thread
+
+
+async def test_async_twin_propagates_write_failures(tmp_path, monkeypatch):
+    target = tmp_path / "state.json"
+
+    def boom(src, dst):
+        raise OSError("replace refused")
+
+    monkeypatch.setattr(os, "replace", boom)
+    with pytest.raises(OSError, match="replace refused"):
+        await atomic_write_json_async(target, {"v": 1})
+
+    assert not target.exists()
+
+
+# ── same-target concurrency ─────────────────────────────────────────────
+
+
+def test_concurrent_writers_never_leave_a_partial_target(tmp_path):
+    # 同目标并发写在 Windows 上会让 os.replace 抛 PermissionError（这是 #2528 的
+    # 真实议题，修法在写者侧加锁，不在这里）。这条只钉住底线：无论哪些写失败，
+    # 目标文件要么是某一个写者的完整内容，要么根本没被创建 —— 绝不会是半截。
+    target = tmp_path / "state.json"
+    payloads = [{"writer": i, "pad": "x" * 4096} for i in range(6)]
+    start = threading.Barrier(len(payloads))
+    failures: list[BaseException] = []
+
+    def writer(payload):
+        start.wait(timeout=5)
+        for _ in range(20):
+            try:
+                atomic_write_json(target, payload)
+            except Exception as exc:  # noqa: BLE001 - 并发失败是本用例的已知前提
+                failures.append(exc)
+
+    threads = [threading.Thread(target=writer, args=(p,)) for p in payloads]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+        assert not thread.is_alive()
+
+    assert target.exists()
+    assert read_json(target) in payloads, (
+        f"target was left partial or interleaved; {len(failures)} writes failed"
+    )
+    assert _tmp_siblings(target) == [], "every failed write cleaned up its temp file"
+
+
+def test_sweeper_is_thread_safe_for_the_same_target(tmp_path):
+    # _sweep_stale_tmp_once 的记账是模块级共享状态，多线程同时首写同一目标时
+    # 不许重复扫、也不许抛。
+    target = tmp_path / "state.json"
+    start = threading.Barrier(8)
+    errors: list[BaseException] = []
+
+    def writer():
+        try:
+            start.wait(timeout=5)
+            file_utils._sweep_stale_tmp_once(target)
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=writer) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert errors == []
+
+
+# ── read side ───────────────────────────────────────────────────────────
+
+
+def test_read_json_raises_on_missing_file(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        read_json(tmp_path / "absent.json")
+
+
+async def test_async_read_raises_on_missing_file(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        await read_json_async(tmp_path / "absent.json")
+
+
+def test_read_json_reports_the_path_of_corrupt_content(tmp_path):
+    target = tmp_path / "state.json"
+    target.write_text("{not json", encoding="utf-8")
+
+    with pytest.raises(json.JSONDecodeError):
+        read_json(target)
+
+
+def test_asyncio_module_is_used_for_the_thread_hop():
+    # 防回退：async 孪生一旦改成同步直调，上面那三条 off-the-loop 断言会红，
+    # 但这条更直接——它们必须经过 asyncio 的线程池。
+    assert asyncio.iscoroutinefunction(atomic_write_text_async)
+    assert asyncio.iscoroutinefunction(atomic_write_json_async)
+    assert asyncio.iscoroutinefunction(read_json_async)

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -349,6 +349,26 @@ def test_a_temp_file_leaked_by_this_write_rearms_the_sweep(tmp_path, monkeypatch
     assert _tmp_siblings(target) == [], "重扫必须把泄漏的 tmp 清掉"
 
 
+def test_a_concurrent_rearm_survives_a_clean_sweep(tmp_path, monkeypatch):
+    # 同一目录两个首写并发扫描时，慢的那个「扫干净了」不许覆盖掉快的那个
+    # 「泄漏了、撤记账」—— 撤记账对应一个真实泄漏，被抹掉就等于永远不清。
+    target = tmp_path / "state.json"
+    real_scandir = os.scandir
+
+    def scandir_then_rearm(path):
+        entries = list(real_scandir(path))
+        # 模拟另一个写者在本次扫描期间泄漏 tmp 并撤掉记账
+        file_utils._rearm_tmp_sweep(target)
+        return entries
+
+    monkeypatch.setattr(os, "scandir", scandir_then_rearm)
+    atomic_write_json(target, {"v": 1})
+
+    assert str(tmp_path) not in file_utils._swept_tmp_dirs, (
+        "扫干净的收尾不能把并发发生的撤记账覆盖掉"
+    )
+
+
 def test_fork_child_gets_a_fresh_sweep_lock(tmp_path):
     # app/main_server/__init__.py:56 选的是 fork 启动方式，而 fork 只复制调用它的那
     # 一个线程：别的线程正持着这把锁时，子进程继承到的是一把永远锁着的 mutex，子进程

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -16,8 +16,10 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import tempfile
 import threading
 import time
+from contextlib import suppress
 from pathlib import Path
 
 import pytest
@@ -347,8 +349,6 @@ def test_sweep_cannot_steal_a_temp_file_that_is_still_open(tmp_path):
     # 年龄门槛本身不能证明 tmp 没有主人（写者理论上可以在 mkstemp 之后被冻结很久）。
     # Windows 上还有一道 OS 级兜底：活写者的句柄一直开着，unlink 会被拒（WinError
     # 32），清扫器物理上抢不走。这条把那道兜底钉住。
-    import tempfile
-
     target = tmp_path / "state.json"
     fd, inflight = tempfile.mkstemp(
         prefix=f".{target.name}.", suffix=".tmp", dir=str(tmp_path)
@@ -359,7 +359,7 @@ def test_sweep_cannot_steal_a_temp_file_that_is_still_open(tmp_path):
         assert Path(inflight).exists(), "an open temp file must survive the sweep"
     finally:
         os.close(fd)
-        with __import__("contextlib").suppress(OSError):
+        with suppress(OSError):
             os.unlink(inflight)
 
 
@@ -461,7 +461,7 @@ def test_concurrent_writers_never_leave_a_partial_target(tmp_path):
     target = tmp_path / "state.json"
     payloads = [{"writer": i, "pad": "x" * 4096} for i in range(6)]
     start = threading.Barrier(len(payloads))
-    failures: list[BaseException] = []
+    failures: list[Exception] = []
 
     def writer(payload):
         start.wait(timeout=5)
@@ -490,13 +490,13 @@ def test_sweeper_is_thread_safe_for_the_same_target(tmp_path):
     # 不许重复扫、也不许抛。
     target = tmp_path / "state.json"
     start = threading.Barrier(8)
-    errors: list[BaseException] = []
+    errors: list[Exception] = []
 
     def writer():
         try:
             start.wait(timeout=5)
             file_utils._sweep_stale_tmp_once(target)
-        except BaseException as exc:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001 - 线程体里任何异常都要交回主线程
             errors.append(exc)
 
     threads = [threading.Thread(target=writer) for _ in range(8)]

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -51,6 +51,15 @@ def _abandoned_tmp(target: Path, rand: str = "deadbeef") -> Path:
     return target.parent / f".{target.name}.{file_utils._TMP_OWNER_TAG}{rand}.tmp"
 
 
+def _expire_sweep_throttle() -> None:
+    """Pretend the per-directory sweep interval has elapsed for every known directory."""
+    with file_utils._swept_tmp_dirs_lock:
+        for key in list(file_utils._swept_tmp_dirs):
+            file_utils._swept_tmp_dirs[key] -= (
+                file_utils._STALE_TMP_SWEEP_INTERVAL_S + 1
+            )
+
+
 def _age(path: Path, seconds: float) -> None:
     stamp = time.time() - seconds
     os.utime(path, (stamp, stamp))
@@ -274,22 +283,6 @@ def test_the_temp_files_this_module_creates_carry_the_owner_tag(tmp_path, monkey
     )
 
 
-def test_sweep_is_amortised_per_directory(tmp_path):
-    # 摊销是有意的：残留由崩溃产生，而崩溃结束了那个进程，所以长寿进程反复扫目录
-    # 没有意义。这条把「扫干净之后就不再扫」钉下来，免得后来有人改成每次写都扫。
-    target = tmp_path / "state.json"
-    atomic_write_json(target, {"v": 1})
-
-    appeared_later = _abandoned_tmp(target)
-    appeared_later.write_text("garbage", encoding="utf-8")
-    _age(appeared_later, file_utils._STALE_TMP_MIN_AGE_S + 60)
-
-    atomic_write_json(target, {"v": 2})
-    atomic_write_json(tmp_path / "another.json", {"v": 1})  # 同目录的另一个目标也不重扫
-
-    assert appeared_later.exists()
-
-
 def test_sweep_survives_an_unreadable_directory(tmp_path, monkeypatch):
     target = tmp_path / "state.json"
 
@@ -302,55 +295,65 @@ def test_sweep_survives_an_unreadable_directory(tmp_path, monkeypatch):
     assert read_json(target) == {"v": 1}
 
 
-def test_a_failed_scan_does_not_consume_every_attempt(tmp_path, monkeypatch):
-    # 瞬时 OSError（目录被短暂锁住、网络盘抖动）不该把这个目录的机会一次用光，
-    # 否则残留会一直留到进程退出。
+def test_sweep_is_throttled_per_directory(tmp_path, monkeypatch):
+    # 节流是有意的：清扫是清理型的副业，不能让每次写盘都白搭一次全目录 scandir。
+    # 同一个目录在一个间隔内只扫一次，同目录的别的目标也共享这个窗口。
+    scans = []
+    real_scandir = os.scandir
+    monkeypatch.setattr(os, "scandir", lambda p: scans.append(str(p)) or real_scandir(p))
+
+    atomic_write_json(tmp_path / "state.json", {"v": 1})
+    atomic_write_json(tmp_path / "state.json", {"v": 2})
+    atomic_write_json(tmp_path / "another.json", {"v": 1})
+
+    assert len(scans) == 1
+
+
+def test_sweep_runs_again_once_the_interval_elapses(tmp_path):
+    # 「只扫一次」是错的不变量：本次写自己泄漏的 tmp（清扫跑在 mkstemp 之前）、扫描当时
+    # 还太年轻的 tmp、扫描本身瞬时失败的目录，都得靠下一个窗口兜住。
+    target = tmp_path / "state.json"
+    atomic_write_json(target, {"v": 1})
+
+    appeared_later = _abandoned_tmp(target)
+    appeared_later.write_text("garbage", encoding="utf-8")
+    _age(appeared_later, file_utils._STALE_TMP_MIN_AGE_S + 60)
+
+    atomic_write_json(target, {"v": 2})
+    assert appeared_later.exists(), "还在节流窗口内，不该重扫"
+
+    _expire_sweep_throttle()
+    atomic_write_json(target, {"v": 3})
+
+    assert not appeared_later.exists(), "过了间隔就必须重扫"
+
+
+def test_a_failed_scan_is_retried_after_the_interval(tmp_path, monkeypatch):
+    # 瞬时 OSError（目录被短暂锁住、网络盘抖动）不该让这个目录永久失去清扫。
     target = tmp_path / "state.json"
     leftover = _abandoned_tmp(target)
     leftover.write_text("garbage", encoding="utf-8")
     _age(leftover, file_utils._STALE_TMP_MIN_AGE_S + 60)
 
     real_scandir = os.scandir
-
-    def transiently_denied(path):
-        raise PermissionError("directory momentarily locked")
-
-    monkeypatch.setattr(os, "scandir", transiently_denied)
+    monkeypatch.setattr(
+        os, "scandir", lambda p: (_ for _ in ()).throw(PermissionError("locked"))
+    )
     atomic_write_json(target, {"v": 1})
-    assert leftover.exists(), "first write could not scan, so nothing is swept yet"
+    assert leftover.exists(), "扫不动，这一轮什么都没清"
 
     monkeypatch.setattr(os, "scandir", real_scandir)
+    _expire_sweep_throttle()
     atomic_write_json(target, {"v": 2})
 
-    assert not leftover.exists(), "the retry after a failed scan must sweep"
+    assert not leftover.exists(), "下一个窗口必须重试"
 
 
-def test_sweep_gives_up_after_a_bounded_number_of_attempts(tmp_path, monkeypatch):
-    # 重试必须有界。永久性失败（只读文件、ACL 拒绝）不能让每一次写盘都白搭一次
-    # 全目录 scandir —— 那就把 O(1) 的摊销变回了 O(每次写)。
-    target = tmp_path / "state.json"
-    scans = []
-    real_scandir = os.scandir
-
-    def counted_then_denied(path):
-        scans.append(str(path))
-        raise PermissionError("permanently unreadable")
-
-    monkeypatch.setattr(os, "scandir", counted_then_denied)
-    for i in range(file_utils._STALE_TMP_SWEEP_ATTEMPTS + 3):
-        atomic_write_json(target, {"v": i})
-
-    assert len(scans) == file_utils._STALE_TMP_SWEEP_ATTEMPTS
-    monkeypatch.setattr(os, "scandir", real_scandir)
-    assert read_json(target) == {"v": file_utils._STALE_TMP_SWEEP_ATTEMPTS + 2}
-
-
-def test_a_temp_file_leaked_by_this_write_rearms_the_sweep(tmp_path, monkeypatch):
+def test_a_temp_file_leaked_by_this_write_is_swept_by_a_later_window(tmp_path, monkeypatch):
     # 清扫跑在 mkstemp 之前，所以本次调用自己泄漏出来的 tmp（replace 失败且兜底的
-    # remove 也被拒 —— 正是这个模块要容忍的 Windows 场景）落在已经记账为「扫过」的
-    # 目录里。不撤记账的话，长寿进程（桌面端一开一整天）里它就是永久泄漏。
+    # remove 也被拒 —— 正是这个模块要容忍的 Windows 场景）这一轮清不掉。它必须被下一个
+    # 窗口兜住，否则长寿进程（桌面端一开一整天）里就是永久泄漏。
     target = tmp_path / "state.json"
-    atomic_write_json(target, {"v": 1})   # 这一次把目录记账成「扫干净了」
 
     def replace_denied(src, dst):
         raise PermissionError("target held open")
@@ -361,39 +364,56 @@ def test_a_temp_file_leaked_by_this_write_rearms_the_sweep(tmp_path, monkeypatch
     monkeypatch.setattr(os, "replace", replace_denied)
     monkeypatch.setattr(os, "remove", remove_denied)
     with pytest.raises(PermissionError, match="target held open"):
-        atomic_write_json(target, {"v": 2})
+        atomic_write_json(target, {"v": 1})
 
     leaked = _tmp_siblings(target)
     assert len(leaked) == 1, "这一次写确实泄漏了一个 tmp"
-    assert str(tmp_path) not in file_utils._swept_tmp_dirs, (
-        "泄漏之后必须撤掉记账，否则本进程再也不会清它"
-    )
 
     monkeypatch.undo()
     _age(leaked[0], file_utils._STALE_TMP_MIN_AGE_S + 60)
-    atomic_write_json(target, {"v": 3})
+    _expire_sweep_throttle()
+    atomic_write_json(target, {"v": 2})
 
-    assert _tmp_siblings(target) == [], "重扫必须把泄漏的 tmp 清掉"
+    assert _tmp_siblings(target) == [], "下一个窗口必须把泄漏的 tmp 清掉"
 
 
-def test_a_concurrent_rearm_survives_a_clean_sweep(tmp_path, monkeypatch):
-    # 同一目录两个首写并发扫描时，慢的那个「扫干净了」不许覆盖掉快的那个
-    # 「泄漏了、撤记账」—— 撤记账对应一个真实泄漏，被抹掉就等于永远不清。
-    target = tmp_path / "state.json"
-    real_scandir = os.scandir
+def test_the_sweep_memo_stays_bounded(tmp_path):
+    # cloudsave 的 staging 每次导出都 mkdtemp 出一批新目录（含 per-character 子目录），
+    # 记账永久留着会随操作次数无界增长。
+    limit = file_utils._STALE_TMP_MEMO_MAX
+    for i in range(limit + 40):
+        atomic_write_json(tmp_path / f"d{i}" / "state.json", {"v": i})
 
-    def scandir_then_rearm(path):
-        entries = list(real_scandir(path))
-        # 模拟另一个写者在本次扫描期间泄漏 tmp 并撤掉记账
-        file_utils._rearm_tmp_sweep(target)
-        return entries
+    assert len(file_utils._swept_tmp_dirs) <= limit
 
-    monkeypatch.setattr(os, "scandir", scandir_then_rearm)
-    atomic_write_json(target, {"v": 1})
 
-    assert str(tmp_path) not in file_utils._swept_tmp_dirs, (
-        "扫干净的收尾不能把并发发生的撤记账覆盖掉"
-    )
+def test_temp_name_stays_within_the_filesystem_name_limit(tmp_path, monkeypatch):
+    # 前缀里嵌完整目标名是为了可诊断，但 basename 本身合法（多数文件系统 NAME_MAX 是
+    # 255 字节）时，不能因为加了所有权标记就把 tmp 名顶过限制、让原本能写的目标写不动。
+    # `.` + 名字 + `.` + 标记 + 随机(8) + `.tmp`(4)
+    overhead = 8 + len(".tmp")
+    for basename in ("state.json", "a" * 240 + ".json", "妮" * 200 + ".json"):
+        prefix = file_utils._tmp_prefix(basename)
+        assert len(prefix.encode("utf-8")) + overhead <= 255, basename
+        # 截断之后仍然要被清扫器认领，否则这些目标的残留就永远扫不到了
+        assert file_utils._STALE_TMP_RE.match(f"{prefix}abcdefgh.tmp"), basename
+
+    # 上面是纯函数，还得钉住 atomic_write_text 真的走了它（只测谓词不测调用点是本仓库
+    # 反复踩的坑）。用 CJK 名字：79 个汉字 = 237 字节，不截断的话 tmp 名 257 字节就超了
+    # NAME_MAX，但**字符数**只有 98，不会先撞 Windows 的 MAX_PATH(260)。
+    seen = {}
+    real_mkstemp = tempfile.mkstemp
+
+    def spy(*args, **kwargs):
+        fd, path = real_mkstemp(*args, **kwargs)
+        seen["name"] = Path(path).name
+        return fd, path
+
+    monkeypatch.setattr(tempfile, "mkstemp", spy)
+    atomic_write_json(tmp_path / ("妮" * 79 + ".json"), {"v": 1})
+
+    assert len(seen["name"].encode("utf-8")) <= 255, seen["name"]
+    assert file_utils._STALE_TMP_RE.match(seen["name"])
 
 
 def test_fork_child_gets_a_fresh_sweep_lock(tmp_path):
@@ -438,40 +458,15 @@ def test_the_fork_hook_is_registered_at_import(monkeypatch):
     assert calls[0].get("after_in_child") is probe._reset_tmp_sweep_state_after_fork
 
 
-def test_a_temp_file_that_cannot_be_removed_leaves_a_retry(tmp_path, monkeypatch):
-    # 删不掉一个 tmp 不代表整个目录扫过了：Windows 上活写者的句柄还开着就会撞这个，
-    # 句柄一放开就该能扫掉。所以「没扫干净」不记成完成，留给后续写盘重试。
-    target = tmp_path / "state.json"
-    leftover = _abandoned_tmp(target)
-    leftover.write_text("garbage", encoding="utf-8")
-    _age(leftover, file_utils._STALE_TMP_MIN_AGE_S + 60)
-
-    real_unlink = os.unlink
-    denied = {"on": True}
-
-    def unlink_maybe_denied(path):
-        if denied["on"] and str(path) == str(leftover):
-            raise PermissionError("held open by a live writer")
-        return real_unlink(path)
-
-    monkeypatch.setattr(os, "unlink", unlink_maybe_denied)
-    atomic_write_json(target, {"v": 1})
-    assert leftover.exists()
-
-    denied["on"] = False
-    atomic_write_json(target, {"v": 2})
-
-    assert not leftover.exists(), "the retry must sweep once the handle is released"
-
-
-@pytest.mark.skipif(os.name != "nt", reason="Windows-only handle semantics")
 def test_sweep_cannot_steal_a_temp_file_that_is_still_open(tmp_path):
     # 年龄门槛本身不能证明 tmp 没有主人（写者理论上可以在 mkstemp 之后被冻结很久）。
     # Windows 上还有一道 OS 级兜底：活写者的句柄一直开着，unlink 会被拒（WinError
     # 32），清扫器物理上抢不走。这条把那道兜底钉住。
     target = tmp_path / "state.json"
     fd, inflight = tempfile.mkstemp(
-        prefix=f".{target.name}.", suffix=".tmp", dir=str(tmp_path)
+        # 必须带所有权标记，否则清扫器在 unlink 之前就把它按「不是我的」拒了，
+        # 这条用例就变成恒真、验不到 Windows 的句柄语义。
+        prefix=file_utils._tmp_prefix(target.name), suffix=".tmp", dir=str(tmp_path)
     )
     try:
         _age(Path(inflight), file_utils._STALE_TMP_MIN_AGE_S + 60)
@@ -606,7 +601,7 @@ def test_concurrent_writers_never_leave_a_partial_target(tmp_path):
 
 
 def test_sweeper_is_thread_safe_for_the_same_target(tmp_path):
-    # _sweep_stale_tmp_once 的记账是模块级共享状态，多线程同时首写同一目标时
+    # _sweep_stale_tmp_if_due 的记账是模块级共享状态，多线程同时首写同一目录时
     # 不许重复扫、也不许抛。
     target = tmp_path / "state.json"
     start = threading.Barrier(8)
@@ -615,7 +610,7 @@ def test_sweeper_is_thread_safe_for_the_same_target(tmp_path):
     def writer():
         try:
             start.wait(timeout=5)
-            file_utils._sweep_stale_tmp_once(target)
+            file_utils._sweep_stale_tmp_if_due(target)
         except Exception as exc:  # noqa: BLE001 - 线程体里任何异常都要交回主线程
             errors.append(exc)
 

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -210,23 +210,44 @@ def test_temp_file_of_a_live_writer_is_not_swept(tmp_path):
     assert inflight.exists()
 
 
-def test_sweep_ignores_files_that_are_not_this_target_s_temps(tmp_path):
+def test_sweep_also_clears_other_targets_abandoned_temps(tmp_path):
+    # 清扫按目录而不是按目标：同一个目录里别的目标留下的残留同样是这个原语产生的
+    # 垃圾。按目标记账会漏掉「写完就沉底、再也不会被写第二次」的目标（归档分片就是
+    # 这种），那些残留永远扫不到。
     target = tmp_path / "state.json"
     other_target_tmp = tmp_path / ".other.json.deadbeef.tmp"
-    not_a_tmp = tmp_path / f".{target.name}.deadbeef.bak"
-    for path in (other_target_tmp, not_a_tmp):
+    other_target_tmp.write_text("garbage from a crash", encoding="utf-8")
+    _age(other_target_tmp, file_utils._STALE_TMP_MIN_AGE_S + 60)
+
+    atomic_write_json(target, {"v": 1})
+
+    assert not other_target_tmp.exists()
+
+
+def test_sweep_only_matches_the_shape_this_module_creates(tmp_path):
+    # 按目录扫就得靠形状认自己的 tmp：mkstemp 产出的是
+    # `.<目标名>.<8 个 [a-z0-9_]>.tmp`。形状不匹配一律不碰 —— 方向是少删不误删。
+    target = tmp_path / "state.json"
+    keepers = [
+        tmp_path / f".{target.name}.deadbeef.bak",   # 不是 .tmp
+        tmp_path / f"{target.name}.deadbeef.tmp",    # 没有前导点
+        tmp_path / ".state.json.short.tmp",          # 随机段不是 8 位
+        tmp_path / ".state.json.deadbeefx.tmp",      # 随机段是 9 位
+        tmp_path / ".state.json.DEADBEEF.tmp",       # 随机段字符集不对（大写）
+        tmp_path / ".notes.tmp",                     # 用户自己的文件
+    ]
+    for path in keepers:
         path.write_text("keep me", encoding="utf-8")
         _age(path, file_utils._STALE_TMP_MIN_AGE_S + 60)
 
     atomic_write_json(target, {"v": 1})
 
-    assert other_target_tmp.exists()
-    assert not_a_tmp.exists()
+    assert [p.name for p in keepers if not p.exists()] == []
 
 
-def test_sweep_runs_once_per_target_per_process(tmp_path):
-    # 摊销是有意的：残留由崩溃产生，而崩溃结束了那个进程，所以长寿进程反复扫
-    # 目录没有意义。这条把「只扫一次」钉下来，免得后来有人把它改成每次写都扫。
+def test_sweep_is_amortised_per_directory(tmp_path):
+    # 摊销是有意的：残留由崩溃产生，而崩溃结束了那个进程，所以长寿进程反复扫目录
+    # 没有意义。这条把「扫干净之后就不再扫」钉下来，免得后来有人改成每次写都扫。
     target = tmp_path / "state.json"
     atomic_write_json(target, {"v": 1})
 
@@ -235,6 +256,7 @@ def test_sweep_runs_once_per_target_per_process(tmp_path):
     _age(appeared_later, file_utils._STALE_TMP_MIN_AGE_S + 60)
 
     atomic_write_json(target, {"v": 2})
+    atomic_write_json(tmp_path / "another.json", {"v": 1})  # 同目录的另一个目标也不重扫
 
     assert appeared_later.exists()
 
@@ -249,6 +271,96 @@ def test_sweep_survives_an_unreadable_directory(tmp_path, monkeypatch):
     atomic_write_json(target, {"v": 1})
 
     assert read_json(target) == {"v": 1}
+
+
+def test_a_failed_scan_does_not_consume_every_attempt(tmp_path, monkeypatch):
+    # 瞬时 OSError（目录被短暂锁住、网络盘抖动）不该把这个目录的机会一次用光，
+    # 否则残留会一直留到进程退出。
+    target = tmp_path / "state.json"
+    leftover = tmp_path / f".{target.name}.deadbeef.tmp"
+    leftover.write_text("garbage", encoding="utf-8")
+    _age(leftover, file_utils._STALE_TMP_MIN_AGE_S + 60)
+
+    real_scandir = os.scandir
+
+    def transiently_denied(path):
+        raise PermissionError("directory momentarily locked")
+
+    monkeypatch.setattr(os, "scandir", transiently_denied)
+    atomic_write_json(target, {"v": 1})
+    assert leftover.exists(), "first write could not scan, so nothing is swept yet"
+
+    monkeypatch.setattr(os, "scandir", real_scandir)
+    atomic_write_json(target, {"v": 2})
+
+    assert not leftover.exists(), "the retry after a failed scan must sweep"
+
+
+def test_sweep_gives_up_after_a_bounded_number_of_attempts(tmp_path, monkeypatch):
+    # 重试必须有界。永久性失败（只读文件、ACL 拒绝）不能让每一次写盘都白搭一次
+    # 全目录 scandir —— 那就把 O(1) 的摊销变回了 O(每次写)。
+    target = tmp_path / "state.json"
+    scans = []
+    real_scandir = os.scandir
+
+    def counted_then_denied(path):
+        scans.append(str(path))
+        raise PermissionError("permanently unreadable")
+
+    monkeypatch.setattr(os, "scandir", counted_then_denied)
+    for i in range(file_utils._STALE_TMP_SWEEP_ATTEMPTS + 3):
+        atomic_write_json(target, {"v": i})
+
+    assert len(scans) == file_utils._STALE_TMP_SWEEP_ATTEMPTS
+    monkeypatch.setattr(os, "scandir", real_scandir)
+    assert read_json(target) == {"v": file_utils._STALE_TMP_SWEEP_ATTEMPTS + 2}
+
+
+def test_a_temp_file_that_cannot_be_removed_leaves_a_retry(tmp_path, monkeypatch):
+    # 删不掉一个 tmp 不代表整个目录扫过了：Windows 上活写者的句柄还开着就会撞这个，
+    # 句柄一放开就该能扫掉。所以「没扫干净」不记成完成，留给后续写盘重试。
+    target = tmp_path / "state.json"
+    leftover = tmp_path / f".{target.name}.deadbeef.tmp"
+    leftover.write_text("garbage", encoding="utf-8")
+    _age(leftover, file_utils._STALE_TMP_MIN_AGE_S + 60)
+
+    real_unlink = os.unlink
+    denied = {"on": True}
+
+    def unlink_maybe_denied(path):
+        if denied["on"] and str(path) == str(leftover):
+            raise PermissionError("held open by a live writer")
+        return real_unlink(path)
+
+    monkeypatch.setattr(os, "unlink", unlink_maybe_denied)
+    atomic_write_json(target, {"v": 1})
+    assert leftover.exists()
+
+    denied["on"] = False
+    atomic_write_json(target, {"v": 2})
+
+    assert not leftover.exists(), "the retry must sweep once the handle is released"
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows-only handle semantics")
+def test_sweep_cannot_steal_a_temp_file_that_is_still_open(tmp_path):
+    # 年龄门槛本身不能证明 tmp 没有主人（写者理论上可以在 mkstemp 之后被冻结很久）。
+    # Windows 上还有一道 OS 级兜底：活写者的句柄一直开着，unlink 会被拒（WinError
+    # 32），清扫器物理上抢不走。这条把那道兜底钉住。
+    import tempfile
+
+    target = tmp_path / "state.json"
+    fd, inflight = tempfile.mkstemp(
+        prefix=f".{target.name}.", suffix=".tmp", dir=str(tmp_path)
+    )
+    try:
+        _age(Path(inflight), file_utils._STALE_TMP_MIN_AGE_S + 60)
+        atomic_write_json(target, {"v": 1})
+        assert Path(inflight).exists(), "an open temp file must survive the sweep"
+    finally:
+        os.close(fd)
+        with __import__("contextlib").suppress(OSError):
+            os.unlink(inflight)
 
 
 def test_sweep_survives_a_temp_file_that_cannot_be_removed(tmp_path, monkeypatch):

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -318,6 +318,79 @@ def test_sweep_gives_up_after_a_bounded_number_of_attempts(tmp_path, monkeypatch
     assert read_json(target) == {"v": file_utils._STALE_TMP_SWEEP_ATTEMPTS + 2}
 
 
+def test_a_temp_file_leaked_by_this_write_rearms_the_sweep(tmp_path, monkeypatch):
+    # 清扫跑在 mkstemp 之前，所以本次调用自己泄漏出来的 tmp（replace 失败且兜底的
+    # remove 也被拒 —— 正是这个模块要容忍的 Windows 场景）落在已经记账为「扫过」的
+    # 目录里。不撤记账的话，长寿进程（桌面端一开一整天）里它就是永久泄漏。
+    target = tmp_path / "state.json"
+    atomic_write_json(target, {"v": 1})   # 这一次把目录记账成「扫干净了」
+
+    def replace_denied(src, dst):
+        raise PermissionError("target held open")
+
+    def remove_denied(path):
+        raise PermissionError("cannot clean up the temp file either")
+
+    monkeypatch.setattr(os, "replace", replace_denied)
+    monkeypatch.setattr(os, "remove", remove_denied)
+    with pytest.raises(PermissionError, match="target held open"):
+        atomic_write_json(target, {"v": 2})
+
+    leaked = _tmp_siblings(target)
+    assert len(leaked) == 1, "这一次写确实泄漏了一个 tmp"
+    assert str(tmp_path) not in file_utils._swept_tmp_dirs, (
+        "泄漏之后必须撤掉记账，否则本进程再也不会清它"
+    )
+
+    monkeypatch.undo()
+    _age(leaked[0], file_utils._STALE_TMP_MIN_AGE_S + 60)
+    atomic_write_json(target, {"v": 3})
+
+    assert _tmp_siblings(target) == [], "重扫必须把泄漏的 tmp 清掉"
+
+
+def test_fork_child_gets_a_fresh_sweep_lock(tmp_path):
+    # app/main_server/__init__.py:56 选的是 fork 启动方式，而 fork 只复制调用它的那
+    # 一个线程：别的线程正持着这把锁时，子进程继承到的是一把永远锁着的 mutex，子进程
+    # 里任何一次落盘都会死锁。这条直接验 after_in_child 钩子（Windows 上没有 fork，
+    # 所以只能直接调它，但要守的不变量是平台无关的）。
+    atomic_write_json(tmp_path / "state.json", {"v": 1})
+    assert file_utils._swept_tmp_dirs, "先造出一些继承过来的记账"
+
+    inherited = file_utils._swept_tmp_dirs_lock
+    inherited.acquire()                      # 模拟「fork 时别的线程正持着锁」
+    try:
+        file_utils._reset_tmp_sweep_state_after_fork()
+        assert file_utils._swept_tmp_dirs_lock is not inherited
+        assert not file_utils._swept_tmp_dirs_lock.locked()
+        assert file_utils._swept_tmp_dirs == {}
+        # 子进程里落盘不该死锁
+        atomic_write_json(tmp_path / "child.json", {"v": 1})
+    finally:
+        inherited.release()
+
+
+def test_the_fork_hook_is_registered_at_import(monkeypatch):
+    # 上一条只验了钩子函数本身干得对；这条验它真的被挂上去了 —— 否则函数写得再对也
+    # 不会在 fork 时跑（护栏测试最常见的失效就是只测谓词、不测调用点）。
+    # 独立加载一份模块来观察注册动作，不动已经导入的那份。Windows 上 os 本来没有
+    # register_at_fork，raising=False 会把它加上，于是那个 hasattr 分支也会走到。
+    import importlib.util
+
+    calls = []
+    monkeypatch.setattr(
+        os, "register_at_fork", lambda **kw: calls.append(kw), raising=False
+    )
+    spec = importlib.util.spec_from_file_location(
+        "_file_utils_fork_probe", file_utils.__file__
+    )
+    probe = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(probe)
+
+    assert calls, "模块导入时必须注册 after_in_child 钩子"
+    assert calls[0].get("after_in_child") is probe._reset_tmp_sweep_state_after_fork
+
+
 def test_a_temp_file_that_cannot_be_removed_leaves_a_retry(tmp_path, monkeypatch):
     # 删不掉一个 tmp 不代表整个目录扫过了：Windows 上活写者的句柄还开着就会撞这个，
     # 句柄一放开就该能扫掉。所以「没扫干净」不记成完成，留给后续写盘重试。

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -458,6 +458,7 @@ def test_the_fork_hook_is_registered_at_import(monkeypatch):
     assert calls[0].get("after_in_child") is probe._reset_tmp_sweep_state_after_fork
 
 
+@pytest.mark.skipif(os.name != "nt", reason="Windows-only handle semantics")
 def test_sweep_cannot_steal_a_temp_file_that_is_still_open(tmp_path):
     # 年龄门槛本身不能证明 tmp 没有主人（写者理论上可以在 mkstemp 之后被冻结很久）。
     # Windows 上还有一道 OS 级兜底：活写者的句柄一直开着，unlink 会被拒（WinError

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -38,17 +38,17 @@ pytestmark = pytest.mark.unit
 
 
 def _tmp_siblings(target: Path) -> list[Path]:
-    """Temp files this module would have created next to ``target``."""
-    prefix = f".{target.name}."
+    """Temp files this module would have created in ``target``'s directory."""
+    # 名字里不带目标 basename（见 file_utils 里的注释），所以这是「目录级」而不是
+    # 「目标级」的查询 —— 用例各自用独立的 tmp_path，不会互相看到。
     return sorted(
-        p for p in target.parent.iterdir()
-        if p.name.startswith(prefix) and p.name.endswith(".tmp")
+        p for p in target.parent.iterdir() if file_utils._STALE_TMP_RE.match(p.name)
     )
 
 
 def _abandoned_tmp(target: Path, rand: str = "deadbeef") -> Path:
     """A temp file shaped exactly like the ones this module leaves behind."""
-    return target.parent / f".{target.name}.{file_utils._TMP_OWNER_TAG}{rand}.tmp"
+    return target.parent / f".{file_utils._TMP_OWNER_TAG}{rand}.tmp"
 
 
 def _expire_sweep_throttle() -> None:
@@ -175,6 +175,22 @@ def test_cleanup_failure_does_not_mask_the_real_error(tmp_path, monkeypatch):
     assert "cleanup also denied" not in str(excinfo.value)
 
 
+def test_a_base_exception_mid_write_still_cleans_up_the_temp_file(tmp_path, monkeypatch):
+    # Ctrl-C / SystemExit 落在 write/fsync 上很常见，而它们不是 Exception 的子类：失败
+    # 分支只收 Exception 的话 tmp 直接留盘，要等下一个清扫窗口 + 24h 才清掉。
+    # install_source/manager.py 的 _atomic_write 用的也是 BaseException，保持对偶。
+    target = tmp_path / "state.json"
+
+    def interrupted(src, dst):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(os, "replace", interrupted)
+    with pytest.raises(KeyboardInterrupt):
+        atomic_write_json(target, {"v": 1})
+
+    assert _tmp_siblings(target) == [], "BaseException 也必须清掉临时文件"
+
+
 def test_missing_temp_file_during_cleanup_is_tolerated(tmp_path, monkeypatch):
     target = tmp_path / "state.json"
 
@@ -226,18 +242,33 @@ def test_temp_file_of_a_live_writer_is_not_swept(tmp_path):
     assert inflight.exists()
 
 
-def test_sweep_also_clears_other_targets_abandoned_temps(tmp_path):
-    # 清扫按目录而不是按目标：同一个目录里别的目标留下的残留同样是这个原语产生的
-    # 垃圾。按目标记账会漏掉「写完就沉底、再也不会被写第二次」的目标（归档分片就是
-    # 这种），那些残留永远扫不到。
+def test_sweep_clears_every_abandoned_temp_in_the_directory(tmp_path):
+    # 清扫按目录而不是按目标 —— 同一个目录里的残留不管当初是哪个目标写的都是这个原语
+    # 产生的垃圾。按目标记账/按目标名匹配会漏掉「写完就沉底、再也不会被写第二次」的
+    # 目标（归档分片就是这种），那些残留永远扫不到。
     target = tmp_path / "state.json"
-    other_target_tmp = _abandoned_tmp(tmp_path / "other.json")
-    other_target_tmp.write_text("garbage from a crash", encoding="utf-8")
-    _age(other_target_tmp, file_utils._STALE_TMP_MIN_AGE_S + 60)
+    leftovers = [_abandoned_tmp(target, r) for r in ("deadbeef", "cafef00d")]
+    for path in leftovers:
+        path.write_text("garbage from a crash", encoding="utf-8")
+        _age(path, file_utils._STALE_TMP_MIN_AGE_S + 60)
 
     atomic_write_json(target, {"v": 1})
 
-    assert not other_target_tmp.exists()
+    assert [p.name for p in leftovers if p.exists()] == []
+
+
+def test_sweep_claims_its_temps_whatever_the_random_segment_looks_like(tmp_path):
+    # 随机段的字符集是 tempfile._RandomNameSequence 的实现细节。正则里硬编码
+    # [a-z0-9_] 的话，CPython 哪天往里加个大写字母，自己产的 tmp 就再也不被认领 ——
+    # 而且是静默失效（清扫悄悄变成 no-op，没有任何报错）。
+    target = tmp_path / "state.json"
+    exotic = tmp_path / f".{file_utils._TMP_OWNER_TAG}AB12cd_xYZ-9.tmp"
+    exotic.write_text("garbage", encoding="utf-8")
+    _age(exotic, file_utils._STALE_TMP_MIN_AGE_S + 60)
+
+    atomic_write_json(target, {"v": 1})
+
+    assert not exotic.exists()
 
 
 def test_sweep_only_touches_files_it_can_prove_it_owns(tmp_path):
@@ -247,12 +278,12 @@ def test_sweep_only_touches_files_it_can_prove_it_owns(tmp_path):
     target = tmp_path / "state.json"
     tag = file_utils._TMP_OWNER_TAG
     keepers = [
-        tmp_path / f".{target.name}.{tag}deadbeef.bak",  # 不是 .tmp
-        tmp_path / f"{target.name}.{tag}deadbeef.tmp",   # 没有前导点
-        tmp_path / f".{target.name}.deadbeef.tmp",       # 没有所有权标记（旧版残留）
-        tmp_path / f".{target.name}.{tag.upper()}deadbeef.tmp",  # 标记大小写不对
-        tmp_path / ".rsync-ish.abcdef.tmp",              # 别的工具的临时文件
-        tmp_path / ".notes.tmp",                         # 用户自己的文件
+        tmp_path / f".{tag}deadbeef.bak",          # 不是 .tmp
+        tmp_path / f"{tag}deadbeef.tmp",           # 没有前导点
+        tmp_path / f".{target.name}.deadbeef.tmp",  # 没有所有权标记（旧版残留）
+        tmp_path / f".{tag.upper()}deadbeef.tmp",  # 标记大小写不对
+        tmp_path / ".rsync-ish.abcdef.tmp",        # 别的工具的临时文件
+        tmp_path / ".notes.tmp",                   # 用户自己的文件
     ]
     for path in keepers:
         path.write_text("keep me", encoding="utf-8")
@@ -387,33 +418,29 @@ def test_the_sweep_memo_stays_bounded(tmp_path):
     assert len(file_utils._swept_tmp_dirs) <= limit
 
 
-def test_temp_name_stays_within_the_filesystem_name_limit(tmp_path, monkeypatch):
-    # 前缀里嵌完整目标名是为了可诊断，但 basename 本身合法（多数文件系统 NAME_MAX 是
-    # 255 字节）时，不能因为加了所有权标记就把 tmp 名顶过限制、让原本能写的目标写不动。
-    # `.` + 名字 + `.` + 标记 + 随机(8) + `.tmp`(4)
-    overhead = 8 + len(".tmp")
-    for basename in ("state.json", "a" * 240 + ".json", "妮" * 200 + ".json"):
-        prefix = file_utils._tmp_prefix(basename)
-        assert len(prefix.encode("utf-8")) + overhead <= 255, basename
-        # 截断之后仍然要被清扫器认领，否则这些目标的残留就永远扫不到了
-        assert file_utils._STALE_TMP_RE.match(f"{prefix}abcdefgh.tmp"), basename
-
-    # 上面是纯函数，还得钉住 atomic_write_text 真的走了它（只测谓词不测调用点是本仓库
-    # 反复踩的坑）。用 CJK 名字：79 个汉字 = 237 字节，不截断的话 tmp 名 257 字节就超了
-    # NAME_MAX，但**字符数**只有 98，不会先撞 Windows 的 MAX_PATH(260)。
-    seen = {}
+def test_temp_name_is_a_short_constant_shape(tmp_path, monkeypatch):
+    # tmp 名里不嵌目标 basename，所以长度是常量。这条钉住两件事：名字远小于 NAME_MAX
+    # （eCryptfs 这类只给 143 字节的文件系统也够），以及它比改动前的
+    # `.<basename>.<8>.tmp` 严格更短 —— 否则原本能写的长名字目标会因为 ENAMETOOLONG
+    # 写不动。顺便：不嵌 basename 不影响诊断，os.replace 失败的回显自带目标路径。
+    seen = []
     real_mkstemp = tempfile.mkstemp
 
     def spy(*args, **kwargs):
         fd, path = real_mkstemp(*args, **kwargs)
-        seen["name"] = Path(path).name
+        seen.append(Path(path).name)
         return fd, path
 
     monkeypatch.setattr(tempfile, "mkstemp", spy)
-    atomic_write_json(tmp_path / ("妮" * 79 + ".json"), {"v": 1})
+    for basename in ("s.json", "妮" * 60 + ".json"):
+        atomic_write_json(tmp_path / basename, {"v": 1})
 
-    assert len(seen["name"].encode("utf-8")) <= 255, seen["name"]
-    assert file_utils._STALE_TMP_RE.match(seen["name"])
+    assert len({len(n) for n in seen}) == 1, f"名字长度应该与目标名无关: {seen}"
+    for name, basename in zip(seen, ("s.json", "妮" * 60 + ".json")):
+        assert len(name.encode("utf-8")) < 143, name
+        legacy = len(f".{basename}.abcdefgh.tmp".encode("utf-8"))
+        assert len(name.encode("utf-8")) <= legacy, (name, basename)
+        assert file_utils._STALE_TMP_RE.match(name), name
 
 
 def test_fork_child_gets_a_fresh_sweep_lock(tmp_path):
@@ -467,7 +494,7 @@ def test_sweep_cannot_steal_a_temp_file_that_is_still_open(tmp_path):
     fd, inflight = tempfile.mkstemp(
         # 必须带所有权标记，否则清扫器在 unlink 之前就把它按「不是我的」拒了，
         # 这条用例就变成恒真、验不到 Windows 的句柄语义。
-        prefix=file_utils._tmp_prefix(target.name), suffix=".tmp", dir=str(tmp_path)
+        prefix=f".{file_utils._TMP_OWNER_TAG}", suffix=".tmp", dir=str(tmp_path)
     )
     try:
         _age(Path(inflight), file_utils._STALE_TMP_MIN_AGE_S + 60)

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -19,7 +19,10 @@ import json
 import os
 import re
 import tempfile
+import threading
+import time
 import unicodedata
+from contextlib import suppress
 from pathlib import Path
 from typing import Any, Callable
 
@@ -496,10 +499,45 @@ def robust_json_loads(raw: str) -> Any:
     return _normalize_overescaped_newlines(json.loads(s))  # 让最终错误带完整上下文抛出
 
 
+# 崩后残留 tmp 的清扫。mkstemp 与 os.replace 之间被硬杀（taskkill、断电、OOM）会留下
+# 一个 `.<目标名>.<随机>.tmp`：没人读它，但会一直攒在用户的 config / memory 目录里。
+# 摊销策略是「每个目标文件在本进程内扫一次」——残留是崩溃造成的，而崩溃结束了那个
+# 进程，所以长寿进程反复扫没有意义。年龄门槛是防误删：正常写盘是毫秒级，比这更老的
+# tmp 不可能还有活着的写者（包括另一个进程的）在用它。
+_STALE_TMP_MIN_AGE_S = 3600.0
+_swept_tmp_targets: set[str] = set()
+_swept_tmp_targets_lock = threading.Lock()
+
+
+def _sweep_stale_tmp_once(target_path: Path) -> None:
+    """Best-effort removal of this target's abandoned temp files. Never fatal."""
+    key = f"{target_path.parent}\x00{target_path.name}"
+    with _swept_tmp_targets_lock:
+        if key in _swept_tmp_targets:
+            return
+        _swept_tmp_targets.add(key)
+
+    # 用 scandir 前缀匹配而不是 glob：目标名里出现 `[` `?` `*` 时 glob 会把它们当
+    # 通配符，匹配范围会跑偏（config 目录下的文件名不是我们能控制的）。
+    prefix = f".{target_path.name}."
+    cutoff = time.time() - _STALE_TMP_MIN_AGE_S
+    try:
+        entries = list(os.scandir(target_path.parent))
+    except OSError:
+        return
+    for entry in entries:
+        if not (entry.name.startswith(prefix) and entry.name.endswith(".tmp")):
+            continue
+        with suppress(OSError):
+            if entry.stat().st_mtime < cutoff:
+                os.unlink(entry.path)
+
+
 def atomic_write_text(path: str | os.PathLike[str], content: str, *, encoding: str = "utf-8") -> None:
     """Atomically replace a text file in the same directory."""
     target_path = Path(path)
     target_path.parent.mkdir(parents=True, exist_ok=True)
+    _sweep_stale_tmp_once(target_path)
 
     fd, temp_path = tempfile.mkstemp(
         prefix=f".{target_path.name}.",
@@ -514,10 +552,12 @@ def atomic_write_text(path: str | os.PathLike[str], content: str, *, encoding: s
             os.fsync(temp_file.fileno())
         os.replace(temp_path, target_path)
     except Exception:
-        try:
+        # 清理失败不许盖掉真正的失败原因。只吞 FileNotFoundError 时有一个具体的坑：
+        # 目标被别的句柄占着（杀软扫描、资源管理器预览）会让 os.replace 抛
+        # PermissionError，而紧随其后的 os.remove 往往被同一个原因拒掉，于是调用方
+        # 看到的是 remove 的异常、真实原因退到 __context__ 里去了，同时 tmp 还是留盘。
+        with suppress(OSError):
             os.remove(temp_path)
-        except FileNotFoundError:
-            pass
         raise
 
 

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -506,9 +506,12 @@ def robust_json_loads(raw: str) -> Any:
 # 的目标），而且一个「再也不会被写第二次」的目标（写完就沉底的老分片）留下的残留
 # 永远扫不到。
 #
-# 按目录扫就得靠形状而不是靠目标名来认自己的 tmp。mkstemp 产出的形状是
-# `.<目标名>.<8 个 [a-z0-9_]>.tmp`（前缀由本模块给，随机段由 tempfile 给，长度和字符集
-# 固定）。形状不匹配时的方向是安全的：少删，不会误删。
+# 按目录扫就不能再靠目标名来认自己的 tmp，而"形状 + mtime"证明不了所有权：别的程序、
+# 插件或用户在同一个目录里放的旧文件只要撞上同一个形状就会被永久删掉（Greptile P1）。
+# 所以给自己的 tmp 名里嵌一个所有权标记 `_TMP_OWNER_TAG`，只清带这个标记的文件 ——
+# 这是可证明的所有权，不是概率论。install_source 的 `plugins.lock.json.<pid>.<uuid>.tmp`
+# 是同一个思路。代价：本次改动之前的旧版留下的 tmp 没有标记，永远扫不到；宁可漏清，
+# 也不能删自己证明不了归属的文件。
 #
 # 记账允许有界重试：瞬时失败（目录被短暂锁住、某个 tmp 一时删不掉）不该把这个目录的
 # 唯一机会用掉，但也不能每次写都重扫——永久性失败（只读文件、ACL）会变成每次写盘都
@@ -521,7 +524,10 @@ def robust_json_loads(raw: str) -> Any:
 #   - POSIX 上 unlink 会成功，但后果是那次写的 os.replace 抛 FileNotFoundError，
 #     一个诚实的异常，不是静默损坏。门槛取 24h 是让这个场景（写盘中途被冻结一整天）
 #     退到不现实的量级；代价是崩溃残留最多多留一天才被清掉。
-_STALE_TMP_RE = re.compile(r"^\..+\.[a-z0-9_]{8}\.tmp$")
+# 只有本模块产出的 tmp 会带这个标记。带了标记之后随机段的长度和字符集就不重要了，
+# 不必再依赖 tempfile._RandomNameSequence 的实现细节（8 位 [a-z0-9_]）。
+_TMP_OWNER_TAG = "nkatmp"
+_STALE_TMP_RE = re.compile(rf"^\..+\.{_TMP_OWNER_TAG}[a-z0-9_]+\.tmp$")
 _STALE_TMP_MIN_AGE_S = 86400.0
 _STALE_TMP_SWEEP_ATTEMPTS = 3
 _swept_tmp_dirs: dict[str, int] = {}
@@ -594,7 +600,8 @@ def atomic_write_text(path: str | os.PathLike[str], content: str, *, encoding: s
     _sweep_stale_tmp_once(target_path)
 
     fd, temp_path = tempfile.mkstemp(
-        prefix=f".{target_path.name}.",
+        # 前缀里带所有权标记：清扫器靠它证明这个 tmp 是本模块产的，而不是靠猜形状。
+        prefix=f".{target_path.name}.{_TMP_OWNER_TAG}",
         suffix=".tmp",
         dir=str(target_path.parent),
     )

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -522,9 +522,10 @@ def robust_json_loads(raw: str) -> Any:
 # PermissionError winerror=32）—— 物理上抢不走；POSIX 上 unlink 会成功，但后果是那次
 # 写的 os.replace 抛 FileNotFoundError，一个诚实的异常而不是静默损坏。
 _TMP_OWNER_TAG = "nkatmp"
-# 带了所有权标记之后随机段的长度和字符集就不重要了，不必再依赖
-# tempfile._RandomNameSequence 的实现细节（8 位 [a-z0-9_]）。
-_STALE_TMP_RE = re.compile(rf"^\..+\.{_TMP_OWNER_TAG}[a-z0-9_]+\.tmp$")
+# 随机段写成 [^.]+ 而不是 [a-z0-9_]+：有了所有权标记之后它的长度和字符集就不重要了，
+# 硬编码字符集等于又依赖回 tempfile._RandomNameSequence 的实现细节 —— CPython 哪天往
+# 里加个大写字母，自己产的 tmp 就再也不被认领，而且是静默失效。
+_STALE_TMP_RE = re.compile(rf"^\.{_TMP_OWNER_TAG}[^.]+\.tmp$")
 _STALE_TMP_MIN_AGE_S = 86400.0
 _STALE_TMP_SWEEP_INTERVAL_S = 3600.0
 # 记账容量上限：cloudsave 的 staging 每次导出都 mkdtemp 出一批新目录（含 per-character
@@ -533,18 +534,11 @@ _STALE_TMP_SWEEP_INTERVAL_S = 3600.0
 _STALE_TMP_MEMO_MAX = 512
 _swept_tmp_dirs: dict[str, float] = {}
 _swept_tmp_dirs_lock = threading.Lock()
-# tmp 名里嵌完整目标名是为了可诊断（os.replace 失败的回显能直接看出是哪个目标），但要
-# 给 NAME_MAX（多数文件系统 255 字节）留余量：`.` + 名字 + `.` + 标记(6) + 随机(8) +
-# `.tmp`(4)。按 UTF-8 字节截断而不是字符 —— CJK 一个字符占 3 字节，按字符截会超。
-_TMP_NAME_MAX_BYTES = 200
-
-
-def _tmp_prefix(target_name: str) -> str:
-    """mkstemp prefix carrying the owner tag, truncated to stay under NAME_MAX."""
-    encoded = target_name.encode("utf-8", "surrogatepass")
-    if len(encoded) > _TMP_NAME_MAX_BYTES:
-        target_name = encoded[:_TMP_NAME_MAX_BYTES].decode("utf-8", "ignore")
-    return f".{target_name}.{_TMP_OWNER_TAG}"
+# tmp 名里**不**嵌目标 basename。原来嵌是为了可诊断，但那是多余的：os.replace 失败时
+# OSError 自带 filename+filename2，回显本来就是 `'<tmp>' -> '<目标>'`，目标名一直在。
+# 不嵌换来两件事：名字长度变成常量（约 19 字节），比改动前的 `.<basename>.<8>.tmp` 严格
+# 更短，于是 ENAMETOOLONG 这一类彻底消失 —— 不需要按目标文件系统探 NAME_MAX（eCryptfs
+# 这类只允许 143 字节的文件系统上，固定的字节上限照样会算错）；正则也简单一档。
 
 
 def _sweep_stale_tmp_if_due(target_path: Path) -> None:
@@ -599,7 +593,7 @@ def atomic_write_text(path: str | os.PathLike[str], content: str, *, encoding: s
 
     fd, temp_path = tempfile.mkstemp(
         # 前缀里带所有权标记：清扫器靠它证明这个 tmp 是本模块产的，而不是靠猜形状。
-        prefix=_tmp_prefix(target_path.name),
+        prefix=f".{_TMP_OWNER_TAG}",
         suffix=".tmp",
         dir=str(target_path.parent),
     )
@@ -610,7 +604,10 @@ def atomic_write_text(path: str | os.PathLike[str], content: str, *, encoding: s
             temp_file.flush()
             os.fsync(temp_file.fileno())
         os.replace(temp_path, target_path)
-    except Exception:
+    except BaseException:
+        # BaseException 而不是 Exception：Ctrl-C / SystemExit 落在 write/fsync 上很常见，
+        # 只收 Exception 的话 tmp 直接留盘（要等到下一个清扫窗口 + 24h 才清）。
+        # install_source/manager.py 的 _atomic_write 用的也是 BaseException，保持对偶。
         # 清理失败不许盖掉真正的失败原因。只吞 FileNotFoundError 时有一个具体的坑：
         # 目标被别的句柄占着（杀软扫描、资源管理器预览）会让 os.replace 抛
         # PermissionError，而紧随其后的 os.remove 往往被同一个原因拒掉，于是调用方

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -532,9 +532,11 @@ def _sweep_stale_tmp_once(target_path: Path) -> None:
     """Best-effort removal of abandoned temp files in this target's directory. Never fatal."""
     parent = str(target_path.parent)
     with _swept_tmp_dirs_lock:
-        if _swept_tmp_dirs.get(parent, 0) >= _STALE_TMP_SWEEP_ATTEMPTS:
+        attempts = _swept_tmp_dirs.get(parent, 0)
+        if attempts >= _STALE_TMP_SWEEP_ATTEMPTS:
             return
-        _swept_tmp_dirs[parent] = _swept_tmp_dirs.get(parent, 0) + 1
+        claimed = attempts + 1
+        _swept_tmp_dirs[parent] = claimed
 
     try:
         entries = list(os.scandir(parent))
@@ -553,7 +555,12 @@ def _sweep_stale_tmp_once(target_path: Path) -> None:
             swept_clean = False
     if swept_clean:
         with _swept_tmp_dirs_lock:
-            _swept_tmp_dirs[parent] = _STALE_TMP_SWEEP_ATTEMPTS
+            # 只在记账还是自己刚占下的那个值时才写「已扫干净」。本次扫描期间别的写者
+            # 可能泄漏了一个 tmp 并调 _rearm_tmp_sweep 撤掉记账 —— 无条件覆盖会把那次
+            # 撤记账（对应一个真实泄漏）抹掉，泄漏就永远不会被清。CAS 失败最多是白扫
+            # 一轮（上限 3 次照旧），代价远小于漏清。
+            if _swept_tmp_dirs.get(parent) == claimed:
+                _swept_tmp_dirs[parent] = _STALE_TMP_SWEEP_ATTEMPTS
 
 
 def _rearm_tmp_sweep(target_path: Path) -> None:

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -22,6 +22,7 @@ import tempfile
 import threading
 import time
 import unicodedata
+from contextlib import suppress
 from pathlib import Path
 from typing import Any, Callable
 
@@ -499,84 +500,81 @@ def robust_json_loads(raw: str) -> Any:
 
 
 # 崩后残留 tmp 的清扫。mkstemp 与 os.replace 之间被硬杀（taskkill、断电、OOM）会留下
-# 一个 `.<目标名>.<随机>.tmp`：没人读它，但会一直攒在用户的 config / memory 目录里。
+# 一个 tmp：没人读它，但会一直攒在用户的 config / memory 目录里。
 #
-# 摊销策略是「每个**目录**在本进程内扫一次」，而不是每个目标一次。按目标记账有两个
-# 毛病：同一目录下每多一个目标就多扫一遍整个目录（归档分片是一个目录几百个各自独立
-# 的目标），而且一个「再也不会被写第二次」的目标（写完就沉底的老分片）留下的残留
-# 永远扫不到。
+# 按**目录节流**，不是「每个目录一辈子扫一次」。清理型 sweeper 的正确不变量是「隔一段
+# 时间再看一眼」而不是「只看一次」：只看一次的话，本次写自己泄漏的 tmp（清扫跑在
+# mkstemp 之前）、扫描当时还太年轻的 tmp、以及扫描本身瞬时失败的目录，都会留到进程
+# 退出。换成「上次扫描时刻 + 最小间隔」之后这三类自然都被下一个窗口兜住，泄漏存活
+# 时间有上界（≤ 年龄门槛 + 间隔），而且不需要撤记账 / CAS / 重试计数这一串补丁。
+# 按目录而不是按目标记账：同一目录下每多一个目标就多扫一遍整个目录（archive_shards
+# 是一个目录几百个各自独立的目标，cloudsave 的 bindings/<角色>.json 同理），而且
+# 「写完就沉底、再也不会被写第二次」的目标留下的残留按目标记账永远扫不到。
 #
-# 按目录扫就不能再靠目标名来认自己的 tmp，而"形状 + mtime"证明不了所有权：别的程序、
-# 插件或用户在同一个目录里放的旧文件只要撞上同一个形状就会被永久删掉（Greptile P1）。
-# 所以给自己的 tmp 名里嵌一个所有权标记 `_TMP_OWNER_TAG`，只清带这个标记的文件 ——
-# 这是可证明的所有权，不是概率论。install_source 的 `plugins.lock.json.<pid>.<uuid>.tmp`
-# 是同一个思路。代价：本次改动之前的旧版留下的 tmp 没有标记，永远扫不到；宁可漏清，
-# 也不能删自己证明不了归属的文件。
+# 按目录扫就不能靠目标名认自己的 tmp，而「形状 + mtime」证明不了所有权：别的程序、
+# 插件或用户放在同一个目录里的旧文件只要撞上同一个形状就会被永久删掉。所以自己的
+# tmp 名里嵌一个所有权标记，只清带标记的文件 —— 可证明的所有权，不是概率论。
+# install_source 的 `plugins.lock.json.<pid>.<uuid>.tmp` 是同一个思路。代价：本次改动
+# 之前的旧版残留没有标记、永远扫不到；宁可漏清，也不删自己证明不了归属的文件。
 #
-# 记账允许有界重试：瞬时失败（目录被短暂锁住、某个 tmp 一时删不掉）不该把这个目录的
-# 唯一机会用掉，但也不能每次写都重扫——永久性失败（只读文件、ACL）会变成每次写盘都
-# 多一次 scandir。所以最多扫 _STALE_TMP_SWEEP_ATTEMPTS 次，扫干净了就提前收工。
-#
-# 年龄门槛是防误删。它不能证明 tmp 已经没有主人（一个写者理论上可以在 mkstemp 之后
-# 被冻结超过这个时长），所以还有两道兜底：
-#   - Windows 上活写者的 tmp 句柄一直开着，unlink 会被拒（实测 WinError 32），
-#     下面的 except OSError 直接跳过它 —— 物理上抢不走；
-#   - POSIX 上 unlink 会成功，但后果是那次写的 os.replace 抛 FileNotFoundError，
-#     一个诚实的异常，不是静默损坏。门槛取 24h 是让这个场景（写盘中途被冻结一整天）
-#     退到不现实的量级；代价是崩溃残留最多多留一天才被清掉。
-# 只有本模块产出的 tmp 会带这个标记。带了标记之后随机段的长度和字符集就不重要了，
-# 不必再依赖 tempfile._RandomNameSequence 的实现细节（8 位 [a-z0-9_]）。
+# 年龄门槛防误删。它不能证明 tmp 没有主人（写者理论上能在 mkstemp 之后被冻结很久），
+# 所以还有两道兜底：Windows 上活写者的句柄一直开着，unlink 会被拒（实测
+# PermissionError winerror=32）—— 物理上抢不走；POSIX 上 unlink 会成功，但后果是那次
+# 写的 os.replace 抛 FileNotFoundError，一个诚实的异常而不是静默损坏。
 _TMP_OWNER_TAG = "nkatmp"
+# 带了所有权标记之后随机段的长度和字符集就不重要了，不必再依赖
+# tempfile._RandomNameSequence 的实现细节（8 位 [a-z0-9_]）。
 _STALE_TMP_RE = re.compile(rf"^\..+\.{_TMP_OWNER_TAG}[a-z0-9_]+\.tmp$")
 _STALE_TMP_MIN_AGE_S = 86400.0
-_STALE_TMP_SWEEP_ATTEMPTS = 3
-_swept_tmp_dirs: dict[str, int] = {}
+_STALE_TMP_SWEEP_INTERVAL_S = 3600.0
+# 记账容量上限：cloudsave 的 staging 每次导出都 mkdtemp 出一批新目录（含 per-character
+# 子目录），永久留着会随操作次数无界增长。丢掉一条记账最坏只是多扫一次，所以到顶之后
+# 直接丢一半最旧的。
+_STALE_TMP_MEMO_MAX = 512
+_swept_tmp_dirs: dict[str, float] = {}
 _swept_tmp_dirs_lock = threading.Lock()
+# tmp 名里嵌完整目标名是为了可诊断（os.replace 失败的回显能直接看出是哪个目标），但要
+# 给 NAME_MAX（多数文件系统 255 字节）留余量：`.` + 名字 + `.` + 标记(6) + 随机(8) +
+# `.tmp`(4)。按 UTF-8 字节截断而不是字符 —— CJK 一个字符占 3 字节，按字符截会超。
+_TMP_NAME_MAX_BYTES = 200
 
 
-def _sweep_stale_tmp_once(target_path: Path) -> None:
+def _tmp_prefix(target_name: str) -> str:
+    """mkstemp prefix carrying the owner tag, truncated to stay under NAME_MAX."""
+    encoded = target_name.encode("utf-8", "surrogatepass")
+    if len(encoded) > _TMP_NAME_MAX_BYTES:
+        target_name = encoded[:_TMP_NAME_MAX_BYTES].decode("utf-8", "ignore")
+    return f".{target_name}.{_TMP_OWNER_TAG}"
+
+
+def _sweep_stale_tmp_if_due(target_path: Path) -> None:
     """Best-effort removal of abandoned temp files in this target's directory. Never fatal."""
     parent = str(target_path.parent)
+    now = time.monotonic()
     with _swept_tmp_dirs_lock:
-        attempts = _swept_tmp_dirs.get(parent, 0)
-        if attempts >= _STALE_TMP_SWEEP_ATTEMPTS:
+        last = _swept_tmp_dirs.get(parent)
+        if last is not None and now - last < _STALE_TMP_SWEEP_INTERVAL_S:
             return
-        claimed = attempts + 1
-        _swept_tmp_dirs[parent] = claimed
+        # 先记账再扫：并发的两个首写只有一个会真扫，另一个直接跳过；扫描失败也照样
+        # 记账，下一个间隔到了自然重试，不需要单独的重试计数。
+        _swept_tmp_dirs[parent] = now
+        if len(_swept_tmp_dirs) > _STALE_TMP_MEMO_MAX:
+            oldest = sorted(_swept_tmp_dirs, key=_swept_tmp_dirs.__getitem__)
+            for stale in oldest[: _STALE_TMP_MEMO_MAX // 2]:
+                _swept_tmp_dirs.pop(stale, None)
 
     try:
         entries = list(os.scandir(parent))
     except OSError:
-        return  # 本次尝试已计数，下次写这个目录里的任何目标时还会再试
+        return
 
     cutoff = time.time() - _STALE_TMP_MIN_AGE_S
-    swept_clean = True
     for entry in entries:
         if not _STALE_TMP_RE.match(entry.name):
             continue
-        try:
+        with suppress(OSError):
             if entry.stat().st_mtime < cutoff:
                 os.unlink(entry.path)
-        except OSError:
-            swept_clean = False
-    if swept_clean:
-        with _swept_tmp_dirs_lock:
-            # 只在记账还是自己刚占下的那个值时才写「已扫干净」。本次扫描期间别的写者
-            # 可能泄漏了一个 tmp 并调 _rearm_tmp_sweep 撤掉记账 —— 无条件覆盖会把那次
-            # 撤记账（对应一个真实泄漏）抹掉，泄漏就永远不会被清。CAS 失败最多是白扫
-            # 一轮（上限 3 次照旧），代价远小于漏清。
-            if _swept_tmp_dirs.get(parent) == claimed:
-                _swept_tmp_dirs[parent] = _STALE_TMP_SWEEP_ATTEMPTS
-
-
-def _rearm_tmp_sweep(target_path: Path) -> None:
-    """Undo the sweep bookkeeping for this directory so a later write scans again."""
-    # 清扫发生在 mkstemp **之前**，所以本次调用自己泄漏出来的 tmp（replace 失败且
-    # 兜底的 remove 也被拒 —— 正是本模块要容忍的那个 Windows 场景）落在已经记账为
-    # 「扫过」的目录里，本进程再也不会去清它。长寿进程（桌面端一开一整天）里这就是
-    # 永久泄漏。这里把记账撤掉，让后续任何一次写这个目录时重扫。
-    with _swept_tmp_dirs_lock:
-        _swept_tmp_dirs.pop(str(target_path.parent), None)
 
 
 def _reset_tmp_sweep_state_after_fork() -> None:
@@ -597,11 +595,11 @@ def atomic_write_text(path: str | os.PathLike[str], content: str, *, encoding: s
     """Atomically replace a text file in the same directory."""
     target_path = Path(path)
     target_path.parent.mkdir(parents=True, exist_ok=True)
-    _sweep_stale_tmp_once(target_path)
+    _sweep_stale_tmp_if_due(target_path)
 
     fd, temp_path = tempfile.mkstemp(
         # 前缀里带所有权标记：清扫器靠它证明这个 tmp 是本模块产的，而不是靠猜形状。
-        prefix=f".{target_path.name}.{_TMP_OWNER_TAG}",
+        prefix=_tmp_prefix(target_path.name),
         suffix=".tmp",
         dir=str(target_path.parent),
     )
@@ -617,13 +615,10 @@ def atomic_write_text(path: str | os.PathLike[str], content: str, *, encoding: s
         # 目标被别的句柄占着（杀软扫描、资源管理器预览）会让 os.replace 抛
         # PermissionError，而紧随其后的 os.remove 往往被同一个原因拒掉，于是调用方
         # 看到的是 remove 的异常、真实原因退到 __context__ 里去了，同时 tmp 还是留盘。
-        try:
+        # 删不掉就成了残留：清扫跑在本次写之前，所以清不了这一个。它会被这个目录的
+        # 下一个清扫窗口兜住（这正是把「只扫一次」换成「按间隔节流」的原因之一）。
+        with suppress(OSError):
             os.remove(temp_path)
-        except OSError:
-            # tmp 删不掉（目标/tmp 被句柄占着、权限不足），它就成了残留。清扫在本次
-            # 写之前已经跑过并把这个目录记账为「扫过」，所以要撤掉记账，否则本进程
-            # 再也不会清它。
-            _rearm_tmp_sweep(target_path)
         raise
 
 

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -501,36 +501,60 @@ def robust_json_loads(raw: str) -> Any:
 
 # 崩后残留 tmp 的清扫。mkstemp 与 os.replace 之间被硬杀（taskkill、断电、OOM）会留下
 # 一个 `.<目标名>.<随机>.tmp`：没人读它，但会一直攒在用户的 config / memory 目录里。
-# 摊销策略是「每个目标文件在本进程内扫一次」——残留是崩溃造成的，而崩溃结束了那个
-# 进程，所以长寿进程反复扫没有意义。年龄门槛是防误删：正常写盘是毫秒级，比这更老的
-# tmp 不可能还有活着的写者（包括另一个进程的）在用它。
-_STALE_TMP_MIN_AGE_S = 3600.0
-_swept_tmp_targets: set[str] = set()
-_swept_tmp_targets_lock = threading.Lock()
+#
+# 摊销策略是「每个**目录**在本进程内扫一次」，而不是每个目标一次。按目标记账有两个
+# 毛病：同一目录下每多一个目标就多扫一遍整个目录（归档分片是一个目录几百个各自独立
+# 的目标），而且一个「再也不会被写第二次」的目标（写完就沉底的老分片）留下的残留
+# 永远扫不到。
+#
+# 按目录扫就得靠形状而不是靠目标名来认自己的 tmp。mkstemp 产出的形状是
+# `.<目标名>.<8 个 [a-z0-9_]>.tmp`（前缀由本模块给，随机段由 tempfile 给，长度和字符集
+# 固定）。形状不匹配时的方向是安全的：少删，不会误删。
+#
+# 记账允许有界重试：瞬时失败（目录被短暂锁住、某个 tmp 一时删不掉）不该把这个目录的
+# 唯一机会用掉，但也不能每次写都重扫——永久性失败（只读文件、ACL）会变成每次写盘都
+# 多一次 scandir。所以最多扫 _STALE_TMP_SWEEP_ATTEMPTS 次，扫干净了就提前收工。
+#
+# 年龄门槛是防误删。它不能证明 tmp 已经没有主人（一个写者理论上可以在 mkstemp 之后
+# 被冻结超过这个时长），所以还有两道兜底：
+#   - Windows 上活写者的 tmp 句柄一直开着，unlink 会被拒（实测 WinError 32），
+#     下面的 except OSError 直接跳过它 —— 物理上抢不走；
+#   - POSIX 上 unlink 会成功，但后果是那次写的 os.replace 抛 FileNotFoundError，
+#     一个诚实的异常，不是静默损坏。门槛取 24h 是让这个场景（写盘中途被冻结一整天）
+#     退到不现实的量级；代价是崩溃残留最多多留一天才被清掉。
+_STALE_TMP_RE = re.compile(r"^\..+\.[a-z0-9_]{8}\.tmp$")
+_STALE_TMP_MIN_AGE_S = 86400.0
+_STALE_TMP_SWEEP_ATTEMPTS = 3
+_swept_tmp_dirs: dict[str, int] = {}
+_swept_tmp_dirs_lock = threading.Lock()
 
 
 def _sweep_stale_tmp_once(target_path: Path) -> None:
-    """Best-effort removal of this target's abandoned temp files. Never fatal."""
-    key = f"{target_path.parent}\x00{target_path.name}"
-    with _swept_tmp_targets_lock:
-        if key in _swept_tmp_targets:
+    """Best-effort removal of abandoned temp files in this target's directory. Never fatal."""
+    parent = str(target_path.parent)
+    with _swept_tmp_dirs_lock:
+        if _swept_tmp_dirs.get(parent, 0) >= _STALE_TMP_SWEEP_ATTEMPTS:
             return
-        _swept_tmp_targets.add(key)
+        _swept_tmp_dirs[parent] = _swept_tmp_dirs.get(parent, 0) + 1
 
-    # 用 scandir 前缀匹配而不是 glob：目标名里出现 `[` `?` `*` 时 glob 会把它们当
-    # 通配符，匹配范围会跑偏（config 目录下的文件名不是我们能控制的）。
-    prefix = f".{target_path.name}."
-    cutoff = time.time() - _STALE_TMP_MIN_AGE_S
     try:
-        entries = list(os.scandir(target_path.parent))
+        entries = list(os.scandir(parent))
     except OSError:
-        return
+        return  # 本次尝试已计数，下次写这个目录里的任何目标时还会再试
+
+    cutoff = time.time() - _STALE_TMP_MIN_AGE_S
+    swept_clean = True
     for entry in entries:
-        if not (entry.name.startswith(prefix) and entry.name.endswith(".tmp")):
+        if not _STALE_TMP_RE.match(entry.name):
             continue
-        with suppress(OSError):
+        try:
             if entry.stat().st_mtime < cutoff:
                 os.unlink(entry.path)
+        except OSError:
+            swept_clean = False
+    if swept_clean:
+        with _swept_tmp_dirs_lock:
+            _swept_tmp_dirs[parent] = _STALE_TMP_SWEEP_ATTEMPTS
 
 
 def atomic_write_text(path: str | os.PathLike[str], content: str, *, encoding: str = "utf-8") -> None:

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -22,7 +22,6 @@ import tempfile
 import threading
 import time
 import unicodedata
-from contextlib import suppress
 from pathlib import Path
 from typing import Any, Callable
 
@@ -557,6 +556,30 @@ def _sweep_stale_tmp_once(target_path: Path) -> None:
             _swept_tmp_dirs[parent] = _STALE_TMP_SWEEP_ATTEMPTS
 
 
+def _rearm_tmp_sweep(target_path: Path) -> None:
+    """Undo the sweep bookkeeping for this directory so a later write scans again."""
+    # 清扫发生在 mkstemp **之前**，所以本次调用自己泄漏出来的 tmp（replace 失败且
+    # 兜底的 remove 也被拒 —— 正是本模块要容忍的那个 Windows 场景）落在已经记账为
+    # 「扫过」的目录里，本进程再也不会去清它。长寿进程（桌面端一开一整天）里这就是
+    # 永久泄漏。这里把记账撤掉，让后续任何一次写这个目录时重扫。
+    with _swept_tmp_dirs_lock:
+        _swept_tmp_dirs.pop(str(target_path.parent), None)
+
+
+def _reset_tmp_sweep_state_after_fork() -> None:
+    """Re-create the sweep lock in a forked child and drop inherited bookkeeping."""
+    # app/main_server/__init__.py:56 选的是 fork 启动方式，而 fork 只复制调用它的那
+    # 一个线程：如果别的线程正持着这把锁，子进程继承到的就是一把永远锁着的 mutex，
+    # 子进程里任何一次落盘都会死锁。记账也一并清掉——子进程是新进程，本来就该重扫。
+    global _swept_tmp_dirs_lock
+    _swept_tmp_dirs_lock = threading.Lock()
+    _swept_tmp_dirs.clear()
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_tmp_sweep_state_after_fork)
+
+
 def atomic_write_text(path: str | os.PathLike[str], content: str, *, encoding: str = "utf-8") -> None:
     """Atomically replace a text file in the same directory."""
     target_path = Path(path)
@@ -580,8 +603,13 @@ def atomic_write_text(path: str | os.PathLike[str], content: str, *, encoding: s
         # 目标被别的句柄占着（杀软扫描、资源管理器预览）会让 os.replace 抛
         # PermissionError，而紧随其后的 os.remove 往往被同一个原因拒掉，于是调用方
         # 看到的是 remove 的异常、真实原因退到 __context__ 里去了，同时 tmp 还是留盘。
-        with suppress(OSError):
+        try:
             os.remove(temp_path)
+        except OSError:
+            # tmp 删不掉（目标/tmp 被句柄占着、权限不足），它就成了残留。清扫在本次
+            # 写之前已经跑过并把这个目录记账为「扫过」，所以要撤掉记账，否则本进程
+            # 再也不会清它。
+            _rearm_tmp_sweep(target_path)
         raise
 
 


### PR DESCRIPTION
#2528 提议给 `os.replace` 加 Windows-only 有界重试，**不采纳**（理由见 [issue 评论](https://github.com/Project-N-E-K-O/N.E.K.O/issues/2528#issuecomment-5128580550)）。这个 PR 修的是同一失效域里被顺带挖出来、比缺重试更该先修的两件事，外加把这个模块的第一份专测补上。

> 五轮 review 共 15 条已全部处理（含一条 P1/security）。设计相比初版有两次实质变化：清扫从「按目标」改成「按目录」，记账从「本进程只扫一次 + 撤记账 + CAS + 重试计数」改成**按时间节流**。下面是**最终状态**。

## 为什么不加那个重试

`winerror 5` 在 `os.replace` 上同时覆盖「目标是目录」「目标只读」「ACL 拒绝」「目标被句柄占着」，前三种永不自愈 —— `{5,32,33}` 过滤分不出瞬时故障，实测一次注定失败的 0/50/100/200ms 阶梯要烧 **352.5ms** 才抛（正常路径 p99 是 0.5ms）。而 `record_and_save` 是**在 per-character 锁内**写哨兵，重试阶梯会把锁多持 350ms，在竞争场景下放大而非缓解。仓库里的先例也不是两处而是三处（`install_source/manager.py` 早就在做同一件事，注释说 WinError **32**，跟 `core_config.py` 说 **5** 打对台），且一处都删不掉。

## 1. `except` 分支的 `os.remove` 只吞 `FileNotFoundError`

本机实测：让 `os.replace` 抛 winerror 5、**同时**让 `os.remove` 也被拒（这正是 issue 假设的「杀软持着句柄」该有的样子），调用方看到的异常来自 `os.remove`，真实的 replace 错误退到 `__context__` 里去了，tmp 还留盘。也就是说在最需要诊断信息的场景下，日志里只剩「删不掉临时文件」。

改成保留原异常抛出。`install_source/manager.py` 的 `_atomic_write` 有一模一样的形状，一起改，保持对偶。

## 2. 崩后残留的 tmp 没有清扫器

`mkstemp` 与 `os.replace` 之间被硬杀（taskkill、断电、OOM）会留下 `.<目标名>.<随机>.tmp`。没人读它们，但会一直攒在用户的 config / memory 目录里。`install_source` 那边早就有 `_sweep_stale_tmp_files`，`file_utils` 没有对偶物。

**按目录摊销，不是按目标。** 按目标记账有两个毛病：同一目录下每多一个目标就多扫一遍整个目录（`memory/archive_shards.py` 是一个目录几百个各自独立的目标，`export_local_cloudsave_snapshot` 的 `bindings/<角色>.json` 同理，N 个角色就是 O(N²)），而且一个「写完就沉底、再也不会被写第二次」的目标（老分片）留下的残留**永远扫不到**。

**靠可证明的所有权认自己的 tmp，不是靠形状。** 光靠「形状像 + 够老」会把别的程序、插件或用户放在同一个目录里的旧文件永久删掉（Greptile 的 P1）。所以 `mkstemp` 前缀里嵌一个所有权标记 `_TMP_OWNER_TAG = "nkatmp"`，清扫器只认 `^\.(.+)\.nkatmp[a-z0-9_]+\.tmp$` —— `install_source` 的 `plugins.lock.json.<pid>.<uuid>.tmp` 是同一思路。附带好处：随机段长度/字符集不再重要，不必依赖 `tempfile._RandomNameSequence` 的实现细节。代价：本次改动之前的旧版残留没有标记、永远扫不到 —— 宁可漏清，不删自己证明不了归属的文件。

**按时间节流，不是「一辈子扫一次」。** 这是这个 PR 走过最长的一段弯路：先是「每目录只扫一次」，然后为了补洞陆续加了「泄漏撤记账」「收尾 CAS」「有界重试计数」三个补丁 —— 三个补丁都在补同一个洞，**「只扫一次」对一个清理型 sweeper 是错的不变量**。最终改成记「上次扫描的单调时刻」，同目录最多每小时扫一次，那三个补丁全部删掉。三类漏清（本次写自己泄漏的 tmp、扫描当时还太年轻的 tmp、扫描本身瞬时失败的目录）自然都被下一个窗口兜住，泄漏存活时间从「直到重启」变成有上界（≤ 24h + 1h）。间隔用 `time.monotonic()`（免疫系统时钟跳变），mtime 比较仍用 `time.time()`。记账带容量上限（512，到顶丢一半最旧的）—— `cloudsave_runtime/staging.py` 每次导出都 `mkdtemp` 一批新目录，永久留着会随操作次数无界增长。

**tmp 名长度。** 前缀里嵌完整目标 basename 是为了可诊断（`os.replace` 失败的回显能直接看出是哪个目标），但原来的 `.<target>.<8>.tmp` 对 236–241 字节的 basename 是合法的，加 6 字节标记就越过 `NAME_MAX` 了 —— 这是加标记时引入的回归。抽出 `_tmp_prefix()` 按 **UTF-8 字节**截断到 200（CJK 一个字符 3 字节，按字符截会超）。

**年龄门槛 24h。** 它不能证明 tmp 没有主人，所以还有两道兜底：Windows 上活写者的句柄一直开着，`unlink` 直接被拒（实测 `PermissionError winerror=32`）—— 物理上抢不走；POSIX 上 `unlink` 会成功，但后果是那次写的 `os.replace` 抛 `FileNotFoundError`，一个诚实的异常，不是静默损坏。24h 让「写盘中途被冻结一整天」退到不现实的量级。


**fork 子进程重建锁。** `app/main_server/__init__.py:56` 是 `set_start_method("fork")`，fork 只复制调用线程；别的线程持着清扫锁时子进程会拿到一把永远锁着、没有持有者的 mutex，子进程里任何一次落盘都无限阻塞。`os.register_at_fork(after_in_child=...)` 重建锁并清掉继承来的记账。

## 3. 补 `tests/unit/test_file_utils.py`（36 条）

这个模块有约 **430 处调用点**（memory / config / topic signals / plugin storage 全走它），此前 `tests/` 下一个专测都没有。覆盖：

- 原子性语义：目标在 rename 之前一直是**旧的完整内容**，读者看不到半截
- 失败不污染目标；序列化失败时连 tmp 都不该出现
- **清理失败不盖真实错误**
- 清扫：年龄门槛、按目录摊销、**所有权标记**的六个反例（非 `.tmp` / 无前导点 / 无标记的旧版残留 / 标记大小写不对 / 别的工具的 `.rsync-ish.abcdef.tmp` / 用户自己的 `.notes.tmp`）、创建侧也必须带标记、失败扫描不吃光机会、超上限后不再扫（断言 `scandir` 调用次数）、`unlink` 失败留重试、**开着的 tmp 抢不走**（Windows-only）
- 本次写泄漏 tmp 后撤记账并能重扫清掉
- fork 钩子：函数本身干得对，**以及它真的被注册了**
- async 孪生确实跑在 worker 线程上（落盘含 fsync，跑在事件循环线程会卡住所有协程）
- 同目标并发写的底线：无论哪些写失败，目标要么是某一个写者的完整内容、要么根本没被创建

## 回归报告

**改动**：`utils/file_utils.py` 的失败分支保留原异常；新增按目录摊销、形状匹配、有界重试的 stale tmp 清扫，含泄漏撤记账与 fork 钩子；`install_source/manager.py` 同形修正；新增 34 条专测。

**必要性**：`atomic_write_text` 是全仓库落盘的唯一漏斗，而它此前零专测。失败分支会用清理错误顶替真实原因，恰好发生在最需要诊断的场景（句柄占用）；tmp 泄漏是用户可见的目录污染。

**改动前 → 改动后**：

- 前：`os.replace` 抛 winerror 5 且 `os.remove` 同样被拒 → 调用方收到 `os.remove` 的异常，真实原因只在 `__context__`，tmp 留盘。后：原异常原样抛出。
- 前：崩后残留永久累积。后：写这个目录时清掉超过 24h 的残留（同目录每小时最多扫一次）。
- 未改动的行为：**没有加任何重试**，`os.replace` 失败仍然第一次就抛；成功路径的写入语义、编码、参数转发、异常类型全部不变。

**潜在回归**：

1. 失败分支现在会吞掉 `os.remove` 的 `OSError`（此前只吞 `FileNotFoundError`）—— tmp 删不掉时静默留盘。这是有意的：留一个 tmp 比丢掉真实错误原因轻，且清扫器会兜掉它。
2. 清扫给每个**目录**每小时增加一次 `os.scandir`。全量 `tests/unit` 238s，与改动前同量级。
3. 按目录扫意味着会清掉同目录下**别的目标**的残留。它们同样是这个原语产生的垃圾，这是有意扩大；形状匹配 + 24h 门槛 + Windows 句柄保护三道闸挡住误删，六个反例的专测钉住范围。
4. 年龄门槛用 mtime。系统时钟大幅回跳会把本该扫的残留判成「未来的文件」而留下 —— 只影响清理，不影响正确性。
5. `os.register_at_fork` 在 POSIX 上多注册一个钩子。钩子只重建锁 + 清 dict，不做 IO。

## 变异验证（12 处全部被抓）

cleanup 回退成只吞 `FileNotFoundError` / 不调清扫器 / 去掉年龄门槛 / 节流改成「一辈子只扫一次」/ 节流取消（每次写都扫）/ 记账不设上限 / 清扫正则去掉所有权标记 / **`mkstemp` 前缀不带标记**（只改正则不改创建 = 静默失效）/ 前缀不做字节截断 / fork 钩子只清记账不换锁 / **不注册 fork 钩子** / 原子写改成原地写。

最后那条一开始是**漏的** —— 只验钩子函数本身的那版，「不注册钩子」的变异照样 34 passed。这正是本仓库反复出现的「只测谓词不测调用点」，补了一条用 `importlib` 独立加载模块、观察注册动作的用例。

## 验证

- `tests/unit/test_file_utils.py` 36 passed
- 全量 `tests/unit`：**8482 passed, 45 skipped**（238s，pytest 自身退出码 0）
- `install_source` 相关 23 passed
- `check_docstring_no_cjk.py --base origin/main` exit=0；`ruff check` 通过

（全量输出里那条 `WinError 5` 的 `PytestUnhandledThreadExceptionWarning` 来自 `test_event_log.py` 那条故意拆锁的负向控制组用例，是 #2528「目击 1」本身，修在 #2575，不在本 PR。）

## 不在本 PR 范围

生产里真实存在的同目标并发写缺锁（`advance_sentinel`、reconcile 的 apply handler、`idle_maintenance_state.json`、`recent.json`、proactive source history、live2d 的 GET 写回）另开 PR —— 那才是 #2528 直觉对的那部分，修法是加锁不是重试。

Refs #2528

🤖 Generated with [Claude Code](https://claude.com/claude-code)
