### PR TITLE
feat(memory): 补齐 fact 抽取的繁中 prompt 模板（#2500 第 3 步·第一批）

### DIFF
--- a/config/prompts/prompts_memory.py
+++ b/config/prompts/prompts_memory.py
@@ -1160,17 +1160,7 @@ def _localized_fact_extraction_prompt(templates: dict[str, str], lang: str | Non
     just the user code-switching mid-conversation, and forcing a translation
     risked mangling proper nouns / titles / quoted wording.
     """
-    lang_key = _normalize_memory_prompt_lang(lang)
-    # Fact extraction predates a full Traditional-Chinese template. Reuse the
-    # Chinese instructions for zh-TW.
-    #
-    # This collapse is per-call-site, not module-wide: the rename-event dicts
-    # below do carry 'zh-TW', so _normalize_memory_prompt_lang keeps it. Delete
-    # this line in the change that adds 'zh-TW' to FACT_EXTRACTION_PROMPT and
-    # FACT_EXTRACTION_AI_AWARE_PROMPT — fact text is persisted and indexed, so
-    # issue #2500 wants those templates first.
-    template_key = "zh" if lang_key == "zh-TW" else lang_key
-    return _loc(templates, template_key)
+    return _loc(templates, _normalize_memory_prompt_lang(lang))
 
 
 def render_profile_rename_event_context(
@@ -1239,6 +1229,44 @@ event_when（可选 — 事件发生时间，一律用相对时间，绝不写�
 请以 JSON 数组格式返回（如果没有值得提取的事实，返回空数组 []）：
 [
   {"text": "事实描述", "importance": 7, "entity": "master", "event_when": null},
+  ...
+]""",
+    # The ======以下为对话====== / ======以上为对话====== pair stays Simplified in
+    # every locale, this one included: it is the safety watermark, a fixed literal
+    # the runtime matches on, not user-facing copy. See docs/contributing/
+    # developer-notes.md "Prompt watermark".
+    "zh-TW": """從以下對話中擷取關於 {LANLAN_NAME} 和 {MASTER_NAME} 的重要事實資訊。
+
+要求：
+- 只擷取重要且明確的事實（偏好、習慣、身分、關係動態等）
+- 忽略閒聊、寒暄、模糊的內容
+- 忽略 AI 幻覺、胡言亂語(gibberish)、無意義的編造內容，只擷取對話中有真實依據的事實
+- 每條事實必須是一個獨立的原子陳述
+- entity 標註為 "master"(關於{MASTER_NAME})、"neko"(關於{LANLAN_NAME})或 "relationship"(關於兩人關係)
+
+importance 評分 1-10，評分指引（請按此打分，不要泛泛都打 7）：
+- **10**：關鍵長期資訊——姓名、暱稱、生日、身分、核心關係節點；使用者明確表示「請{LANLAN_NAME}記住 X」/「這個你一定要記得」；或者 {LANLAN_NAME} 自己特別希望記住的重要相處細節。這些會被快速沉澱為長期記憶。
+- **8-9**：長期穩定的核心偏好 / 固定習慣（不是一時興起）
+- **6-7**：普通偏好、日常習慣、近期動態
+- **5**：次要但有紀錄價值的觀察
+- **1-4**：弱相關或不確定的線索（仍請回傳，下游按情境過濾；不要在此處預先丟棄）
+
+event_when（選填 — 事件發生時間，一律用相對時間，絕不寫絕對日期）：
+- 如果事實裡提到具體時間線索（「昨天」、「上週一」、「三月份」、「今早」），用 event_when 標註
+- 格式 {"start": {"offset": <整數>, "unit": "<單位>"}, "end": {"offset": <整數>, "unit": "<單位>"}}
+- offset 負值=過去、0=當下、正值=未來；unit ∈ minute | hour | day | week | month | year
+- **粒度可以粗，不要求精確**——「幾天前」→ day、「上週」→ week、「幾個月前」→ month 即可，不必精確到 minute/hour（沒有具體數字的話，可以根據上下文猜測一個數字）
+- 沒有時間線索就直接省略 event_when 欄位，或寫 null
+- 例 1：使用者說「昨天晚上沒睡好」→ event_when = {"start": {"offset": -1, "unit": "day"}, "end": null}
+- 例 2：使用者說「喜歡喝咖啡」（長期偏好，無時間）→ 不寫 event_when
+
+======以下为对话======
+{CONVERSATION}
+======以上为对话======
+
+請以 JSON 陣列格式回傳（如果沒有值得擷取的事實，回傳空陣列 []）：
+[
+  {"text": "事實描述", "importance": 7, "entity": "master", "event_when": null},
   ...
 ]""",
     "en": """Extract important factual information about {LANLAN_NAME} and {MASTER_NAME} from the following conversation.
@@ -1496,6 +1524,40 @@ FACT_EXTRACTION_AI_AWARE_PROMPT = {
 [
   {"text": "事实描述", "importance": 7, "entity": "master", "event_when": null, "source": "user_observation"},
   {"text": "事实描述", "importance": 7, "entity": "neko", "event_when": null, "source": "ai_disclosure"},
+  ...
+]""",
+    # Known-facts-pool delimiters ARE localized (every locale translates them);
+    # only the ======以下为对话====== pair stays Simplified, being the watermark.
+    "zh-TW": """從以下對話中擷取關於 {LANLAN_NAME} 和 {MASTER_NAME} 的重要事實資訊。
+
+⚠️ 本次擷取的特殊點（與基礎擷取不同）：
+- 對話包含 {MASTER_NAME} 和 {LANLAN_NAME} 雙方發言，形如 "{MASTER_NAME} | ..." / "{LANLAN_NAME} | ..."
+- 另一通道已經從 {MASTER_NAME} 單邊發言抽過一遍 fact（見下面「已知事實池」），**請只補抓那一通道漏掉的內容**——特別是 {LANLAN_NAME} 自己披露的特徵、{LANLAN_NAME} 引入的螢幕/活動上下文 grounded fact
+- 每條 fact 必須輸出 `source` 欄位標註 trust-tier：
+  - `"user_observation"`：主要從 {MASTER_NAME} 的發言推出（如果發現「已知池」漏抓的，歸這一類）
+  - `"ai_disclosure"`：主要從 {LANLAN_NAME} 自己的發言推出，且 {MASTER_NAME} 在鄰近 turn 內沒明確反對/否認。例："{LANLAN_NAME} | 我今天突然覺得自己挺喜歡秋天的" → fact text "{LANLAN_NAME} 覺得自己挺喜歡秋天" + source=ai_disclosure
+
+要求：
+- 只擷取重要且明確的事實（偏好、習慣、身分、關係動態等）
+- 忽略閒聊、寒暄、模糊的內容
+- 忽略 AI 幻覺、胡言亂語(gibberish)、無意義的編造內容，只擷取對話中有真實依據的事實
+- 每條事實必須是一個獨立的原子陳述
+- entity 標註為 "master"(關於{MASTER_NAME})、"neko"(關於{LANLAN_NAME})或 "relationship"(關於兩人關係)
+- importance 1-10，規則與基礎擷取一致（10 = 關鍵長期資訊；8-9 = 長期穩定核心；6-7 = 普通偏好/日常；5 = 次要觀察；1-4 = 弱相關線索）
+- event_when 選填，相對時間格式 `{"start": {"offset": <int>, "unit": "<unit>"}, "end": {...}}`；無時間線索寫 null
+
+======以下為已知事實池（已被另一通道擷取，避免重複擷取相同內容）======
+{KNOWN_POOL}
+======以上為已知事實池======
+
+======以下为对话======
+{CONVERSATION}
+======以上为对话======
+
+請以 JSON 陣列格式回傳（如果沒有值得補抓的事實，回傳空陣列 []）：
+[
+  {"text": "事實描述", "importance": 7, "entity": "master", "event_when": null, "source": "user_observation"},
+  {"text": "事實描述", "importance": 7, "entity": "neko", "event_when": null, "source": "ai_disclosure"},
   ...
 ]""",
     "en": """Extract important factual information about {LANLAN_NAME} and {MASTER_NAME} from the following conversation.

--- a/tests/unit/test_fact_extraction_zh_tw.py
+++ b/tests/unit/test_fact_extraction_zh_tw.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Traditional Chinese fact-extraction prompts (issue #2500, batch 1).
+
+Fact text is persisted to facts.json and indexed for BM25/embedding recall, so
+these two templates were the first to backfill: a wrong-language instruction here
+contaminates stored data rather than just one reply.
+
+The call sites in memory/facts.py already pass ``get_global_language_full()``, so a
+zh-TW user's language code reaches these getters intact — what used to collapse it
+was a per-call-site line inside ``_localized_fact_extraction_prompt``. These tests
+pin both that the templates exist and that nothing reintroduces the collapse.
+"""
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from config.prompts.prompts_memory import (
+    FACT_EXTRACTION_AI_AWARE_PROMPT,
+    FACT_EXTRACTION_PROMPT,
+    get_fact_extraction_ai_aware_prompt,
+    get_fact_extraction_prompt,
+)
+
+TABLES = {
+    "basic": FACT_EXTRACTION_PROMPT,
+    "ai_aware": FACT_EXTRACTION_AI_AWARE_PROMPT,
+}
+GETTERS = {
+    "basic": get_fact_extraction_prompt,
+    "ai_aware": get_fact_extraction_ai_aware_prompt,
+}
+
+# The conversation watermark stays Simplified in every locale — it is a fixed
+# literal the runtime matches on, not user-facing copy. See
+# docs/contributing/developer-notes.md "Prompt watermark".
+WATERMARK_OPEN = "======以下为对话======"
+WATERMARK_CLOSE = "======以上为对话======"
+
+# Characters that differ between the scripts, used to tell them apart without
+# depending on any particular sentence surviving a copy edit.
+TRADITIONAL_MARKERS = ("擷取", "資訊", "陣列", "關於", "實")
+SIMPLIFIED_MARKERS = ("提取", "信息", "数组", "关于", "实")
+
+
+@pytest.mark.parametrize("name", sorted(TABLES))
+def test_traditional_template_exists(name):
+    assert "zh-TW" in TABLES[name], f"{name} still has no zh-TW template"
+
+
+@pytest.mark.parametrize("name", sorted(TABLES))
+def test_traditional_template_is_actually_traditional(name):
+    """Not a copy of the Simplified one, and not English either."""
+    table = TABLES[name]
+    traditional = table["zh-TW"]
+    assert traditional != table["zh"]
+    assert traditional != table["en"]
+    for marker in TRADITIONAL_MARKERS:
+        assert marker in traditional, f"{name} zh-TW missing {marker!r}"
+
+
+@pytest.mark.parametrize("name", sorted(TABLES))
+def test_simplified_template_is_untouched(name):
+    """Backfilling Traditional must not have rewritten the Simplified copy."""
+    simplified = TABLES[name]["zh"]
+    for marker in SIMPLIFIED_MARKERS:
+        assert marker in simplified, f"{name} zh lost {marker!r}"
+
+
+@pytest.mark.parametrize("name", sorted(GETTERS))
+def test_full_locale_resolves_to_traditional(name):
+    """A zh-TW code must reach the Traditional template, not collapse to zh.
+
+    This is the regression this batch exists to prevent: the collapse used to live
+    in ``_localized_fact_extraction_prompt`` and was invisible from the call sites,
+    which have been passing the full locale all along.
+    """
+    resolved = GETTERS[name]("zh-TW")
+    assert resolved == TABLES[name]["zh-TW"]
+    assert resolved != TABLES[name]["zh"]
+
+
+@pytest.mark.parametrize("name", sorted(GETTERS))
+@pytest.mark.parametrize("code", ["zh-TW", "zh-Hant", "zh-HK", "tchinese", "zh_TW"])
+def test_traditional_variants_all_resolve_to_traditional(name, code):
+    """Every spelling the normalizer folds into zh-TW gets the Traditional text."""
+    assert GETTERS[name](code) == TABLES[name]["zh-TW"], code
+
+
+@pytest.mark.parametrize("name", sorted(GETTERS))
+@pytest.mark.parametrize("code", ["zh", "zh-CN", "zh-Hans", "schinese"])
+def test_simplified_variants_still_resolve_to_simplified(name, code):
+    assert GETTERS[name](code) == TABLES[name]["zh"], code
+
+
+@pytest.mark.parametrize("name", sorted(TABLES))
+def test_watermark_stays_simplified_in_every_locale(name):
+    """Including zh-TW: the watermark is a matched literal, not translated copy."""
+    for locale, text in TABLES[name].items():
+        assert WATERMARK_OPEN in text, f"{name}/{locale} lost the opening watermark"
+        assert WATERMARK_CLOSE in text, f"{name}/{locale} lost the closing watermark"
+
+
+@pytest.mark.parametrize("name", sorted(TABLES))
+def test_traditional_template_keeps_every_placeholder(name):
+    """Placeholders are filled by str.replace, so a missing one silently no-ops."""
+    table = TABLES[name]
+    placeholders = lambda text: set(re.findall(r"\{[A-Z_]+\}", text))
+    assert placeholders(table["zh-TW"]) == placeholders(table["zh"])
+
+
+@pytest.mark.parametrize("name", sorted(TABLES))
+def test_machine_readable_tokens_stay_ascii(name):
+    """JSON field names and enum values must not be translated.
+
+    The extractor parses these back out, so localizing `entity` or
+    `user_observation` would break parsing rather than change wording.
+    """
+    traditional = TABLES[name]["zh-TW"]
+    for token in ("importance", "entity", "event_when", "offset", "unit",
+                  "master", "neko", "relationship"):
+        assert token in traditional, f"{name} zh-TW lost {token!r}"
+    if name == "ai_aware":
+        for token in ("source", "user_observation", "ai_disclosure"):
+            assert token in traditional, f"{name} zh-TW lost {token!r}"
+
+
+@pytest.mark.parametrize("name", sorted(GETTERS))
+def test_other_locales_are_unaffected(name):
+    for locale in ("en", "ja", "ko", "ru", "es", "pt"):
+        assert GETTERS[name](locale) == TABLES[name][locale], locale

--- a/tests/unit/test_memory_language_resolution.py
+++ b/tests/unit/test_memory_language_resolution.py
@@ -139,8 +139,18 @@ def test_fact_extraction_prompts_resolve_per_locale(locale):
         assert "======以上为对话======" in prompt
 
 
-def test_zh_tw_fact_extraction_reuses_zh_template_body():
-    # zh-TW has no dedicated template and must resolve to the zh body verbatim,
-    # with nothing prepended that would make the two diverge.
-    assert get_fact_extraction_prompt("zh-TW") == get_fact_extraction_prompt("zh")
-    assert get_fact_extraction_ai_aware_prompt("zh-TW") == get_fact_extraction_ai_aware_prompt("zh")
+def test_zh_tw_fact_extraction_uses_its_own_template():
+    """zh-TW now has dedicated fact templates (issue #2500, batch 1).
+
+    This assertion used to run the other way — zh-TW resolved to the zh body
+    verbatim — because no Traditional template existed. What it was really
+    guarding is still guarded below: nothing may be *prepended* to a Simplified
+    body to fake Traditional output, which is the approach #1542 tried and
+    reverted. So the Traditional prompt has to be its own text rather than the zh
+    body with something bolted on.
+    """
+    for getter in (get_fact_extraction_prompt, get_fact_extraction_ai_aware_prompt):
+        traditional = getter("zh-TW")
+        simplified = getter("zh")
+        assert traditional != simplified
+        assert simplified not in traditional, "Traditional must not wrap the zh body"


### PR DESCRIPTION
## Summary

issue #2500 第 3 步第一批。选 fact 抽取打头是因为它的输出**会长期落盘**（`facts.json`）并进 BM25/embedding 检索——指令语言错了污染的是存量数据，而不只是一次回复。

积压 **339 → 337**。基于已合并的 #2568。

## 一个和 issue 描述不同的事实

issue 说「fact 抽取回到短码」，对这条路径**不准确**。`memory/facts.py:605` 和 `:2136` 一直在传 `get_global_language_full()`：

```python
get_fact_extraction_prompt(get_global_language_full())
    .replace('{CONVERSATION}', conversation_text)
```

繁中用户的 `zh-TW` 完整抵达 getter，被塌掉的地方是 `_localized_fact_extraction_prompt` 里一行 per-call-site 的：

```python
template_key = "zh" if lang_key == "zh-TW" else lang_key
```

从调用点看不见。所以**本批不需要改任何传参**——只补模板 + 删那行（那行的注释是 #2568 留的路标，明确写了「补完模板就删」）。这也让本批的风险面比 issue 预估的小得多：不涉及「改传参导致行为突变」。

## 两处翻译约定

**conversation watermark 保持简体。** `======以下为对话======` / `======以上为对话======` 在全部 7 个既有 locale 里都是简体字面量——`en`/`ja`/`ko`/`ru`/`es`/`pt` 也一样。它是 runtime 匹配的固定标记而非面向用户的文案，`developer-notes.md` 的 "Prompt watermark" 规则说的就是这个。写之前我先核对了所有 locale 才确认。

**已知事实池分隔符照常翻译。** AI-aware 模板里那对分隔符每个 locale 都本地化了（日文用日文、俄文用俄文），所以繁中版也翻。

## 台湾用语而非纯字形转换

`資訊` / `擷取` / `陣列` / `回傳` / `暱稱` / `螢幕` / `使用者` / `紀錄` / `沉澱` / `通道`。

JSON 欄位名与枚举值（`entity`、`event_when`、`importance`、`user_observation`、`ai_disclosure`、`master`/`neko`/`relationship`、`minute`/`hour`/`day`…）保持 ASCII——抽取器要把它们解析回来，翻掉会坏解析而不是改措辞。

## Testing

`tests/unit/test_fact_extraction_zh_tw.py`（34 项）：

- 模板存在，且**确实是繁体**（既不是 zh 副本也不是 en）
- zh 模板未被改动（回填不该顺手重写简体）
- 全码解析到繁体；五种繁中变体（`zh-TW`/`zh-Hant`/`zh-HK`/`tchinese`/`zh_TW`）都命中；四种简中变体仍命中简体
- watermark 在**每个** locale 都是简体那对
- 占位符集合与 zh 一致（`.replace()` 填充，少一个就静默 no-op）
- 机读 token 保持 ASCII
- 其余 6 个 locale 不受影响

**六条变异全部被抓**：恢复塌回行（12 红）、zh-TW 段里 `擷取`→`提取` / `資訊`→`信息`、watermark 改成繁体、丢掉 `{CONVERSATION}`、把 `entity` 翻译掉。

`check_docstring_no_cjk` / `check_prompt_hygiene` / `check_module_layering` 均 exit 0。

## 回归报告 / Regression Report

只改 `config/prompts/prompts_memory.py`（加两个模板键 + 删一行塌回）与新增测试，不触 `app/` `main_logic/` `main_routers/`。

- **Before**：繁中用户的 fact 抽取拿到**简体**指令（传参是全码，但被 per-call-site 塌回）
- **After**：拿到繁体指令；简中与其余 6 个 locale 逐字不变
- **Risk**：低。变化局限于 zh-TW 这一个 locale 的两个模板

## 不拆分理由 / Why Not Split

两个模板 + 删那一行是同一个动作：模板不补就不能删塌回（繁中会掉英文），删了塌回不补模板同理。#2568 的路标注释就是按这个顺序写的。

## 存量数据说明

fact 的 `text` 字段**不**由模板语言决定——这两个模板里没有任何强制输出语言的指令，`_localized_fact_extraction_prompt` 的 docstring 也写明这是刻意的（用户中途切语言就该照实记）。所以繁简混存不是本批引入的，它取决于用户对话语言，现在就在发生。

已知的相关缺陷：BM25 用字符 2/3-gram（`memory/hybrid_recall.py:66`），繁简同义文本 token 近乎零重叠（实测 Jaccard 0.00–0.27），所以跨繁简的 fact 去重会失配。这是**既有**问题，与本批无关，建议单独开 issue 跟踪（在 tokenizer 层做繁简归一）。

Refs #2500

🤖 Generated with [Claude Code](https://claude.com/claude-code)
