### PR TITLE
feat(memory): QQ 群记忆召回改为 recall_memory tool call（免费线路回落每轮召回）

### DIFF
--- a/main_logic/omni_offline_client/__init__.py
+++ b/main_logic/omni_offline_client/__init__.py
@@ -86,6 +86,7 @@ from ._genai_support import (  # noqa: F401 - preserve the legacy module namespa
     _genai_parts_from_content,
     _genai_types,
     _should_use_genai_sdk,
+    route_supports_tool_calls,
 )
 from ._lifecycle import (  # noqa: F401 - preserve the legacy module namespace
     _slop_reduced_for_genai,

--- a/main_logic/omni_offline_client/_genai_support.py
+++ b/main_logic/omni_offline_client/_genai_support.py
@@ -275,6 +275,39 @@ def _should_use_genai_sdk(model: str, base_url: str | None) -> bool:
     return bool(_GENAI_AVAILABLE)
 
 
+# 免费路由的两个特征：base_url 落在 lanlan 免费域（lanlan.tech 国内 /
+# lanlan.app 海外，含 www. 等子域），或模型名是免费路由固定的 free-model。
+# 两个信号各自独立成立（区域改写只动 URL，模型名由配置层固定），任一命中
+# 即视为免费路由。
+_FREE_ROUTE_BASE_URL_HINTS = ("lanlan.app", "lanlan.tech")
+_FREE_ROUTE_MODEL_NAME = "free-model"
+
+
+def route_supports_tool_calls(model: str, base_url: str | None) -> bool:
+    """Whether tool definitions handed to ``OmniOfflineClient`` on this
+    route actually reach the model.
+
+    The native google-genai path supports tools. Standard OpenAI-compat
+    endpoints honour the ``tools`` param. The known exception is the free
+    proxy (lanlan.app international / lanlan.tech domestic, fixed model
+    name ``free-model``): it exposes only the OpenAI-compat surface and
+    silently DROPS ``tools`` (see ``_should_use_genai_sdk``'s exclusion
+    note). Callers that depend on a tool being callable (e.g. the QQ
+    plugin's ``recall_memory``) must check this and fall back to a
+    host-driven path, otherwise those users lose the feature silently.
+    The domestic free proxy's tool support is undocumented, so it is
+    treated as unsupported too — the fallback keeps working either way.
+    """
+    if _should_use_genai_sdk(model, base_url):
+        return True
+    bl = (base_url or "").lower()
+    if any(hint in bl for hint in _FREE_ROUTE_BASE_URL_HINTS):
+        return False
+    if (model or "").strip().lower() == _FREE_ROUTE_MODEL_NAME:
+        return False
+    return True
+
+
 class _GenaiMixin:
     async def _astream_genai_with_tools(self, messages, **overrides):
         """google-genai streaming with tool support. Yields

--- a/main_logic/omni_offline_client/_genai_support.py
+++ b/main_logic/omni_offline_client/_genai_support.py
@@ -283,6 +283,27 @@ _FREE_ROUTE_BASE_URL_HINTS = ("lanlan.app", "lanlan.tech")
 _FREE_ROUTE_MODEL_NAME = "free-model"
 
 
+def _is_free_route_host(base_url: str | None) -> bool:
+    """Whether ``base_url``'s HOST is a lanlan free-proxy domain.
+
+    Host-parsed on purpose (same discipline as the voice registry's
+    free-route check): a custom endpoint whose path or query merely
+    mentions ``lanlan.app`` must not be misread as the free proxy."""
+    from urllib.parse import urlparse
+
+    bl = (base_url or "").strip()
+    if not bl:
+        return False
+    parsed = urlparse(bl if "//" in bl else "//" + bl)
+    host = (parsed.hostname or "").lower()
+    if not host:
+        return False
+    return any(
+        host == hint or host.endswith("." + hint)
+        for hint in _FREE_ROUTE_BASE_URL_HINTS
+    )
+
+
 def route_supports_tool_calls(model: str, base_url: str | None) -> bool:
     """Whether tool definitions handed to ``OmniOfflineClient`` on this
     route actually reach the model.
@@ -300,8 +321,7 @@ def route_supports_tool_calls(model: str, base_url: str | None) -> bool:
     """
     if _should_use_genai_sdk(model, base_url):
         return True
-    bl = (base_url or "").lower()
-    if any(hint in bl for hint in _FREE_ROUTE_BASE_URL_HINTS):
+    if _is_free_route_host(base_url):
         return False
     if (model or "").strip().lower() == _FREE_ROUTE_MODEL_NAME:
         return False

--- a/plugin/plugins/qq_auto_reply/__init__.py
+++ b/plugin/plugins/qq_auto_reply/__init__.py
@@ -48,6 +48,7 @@ from .group_permission import GroupPermissionManager
 from .handler_runtime_service import QQHandlerRuntimeService
 from .message_dispatcher import QQMessageDispatcher
 from .memory_bridge import QQMemoryBridge
+from .memory_tool_service import QQMemoryToolService
 from .napcat_service import QQNapcatService
 from .permission import PermissionManager
 from .prompt_builder import QQPromptBuilder
@@ -119,6 +120,7 @@ class QQAutoReplyPlugin(QQAutoReplySessionMixin, QQAutoReplyPromptingMixin, QQAu
         self.attention_service = QQAttentionService(self)
         self.prompt_builder = QQPromptBuilder(self)
         self.memory_bridge = QQMemoryBridge(self)
+        self.memory_tool_service = QQMemoryToolService(self)
         self.relay_service = QQRelayService(self)
         self.reply_generation_service = QQReplyGenerationService(self)
         self.reply_decision_node = QQReplyDecisionNode(self)

--- a/plugin/plugins/qq_auto_reply/memory_bridge.py
+++ b/plugin/plugins/qq_auto_reply/memory_bridge.py
@@ -109,9 +109,14 @@ class QQMemoryBridge:
         timeout: float = 5.0,
         limit: int = 5,
         subjects: list[dict[str, str]] | None = None,
+        time_spec: str = "",
     ) -> QQMemoryQueryResult:
+        # ``time_spec`` mirrors the endpoint's optional ``time`` field: alone
+        # it recalls by event-time proximity; combined with a query it runs
+        # the joint semantic + time search. Empty keeps the legacy shape.
         normalized_query = str(query or "").strip()
-        if not normalized_query:
+        normalized_time = str(time_spec or "").strip()
+        if not normalized_query and not normalized_time:
             return QQMemoryQueryResult()
         # ``None`` means the legacy private caller omitted an authorization
         # boundary. An explicit empty list means the caller has no authorized
@@ -119,6 +124,8 @@ class QQMemoryBridge:
         if subjects == []:
             return QQMemoryQueryResult()
         request_payload: dict[str, Any] = {"query": normalized_query}
+        if normalized_time:
+            request_payload["time"] = normalized_time
         if subjects is not None:
             request_payload["subjects"] = subjects
         client = self._client()

--- a/plugin/plugins/qq_auto_reply/memory_bridge.py
+++ b/plugin/plugins/qq_auto_reply/memory_bridge.py
@@ -12,6 +12,10 @@ class QQMemoryQueryResult:
     hit_count: int = 0
     elapsed_ms: float = 0.0
     raw_results: list[dict[str, Any]] = field(default_factory=list)
+    # text 里实际渲染出的条目数（预算截断后）：hit_count 是检索命中数，
+    # 两者在预算丢弃尾部条目时会不同。消费方给模型报条数必须用它——
+    # 记忆原文可含 "N. " 开头的行，从 text 反解会数错。
+    rendered_count: int = 0
 
 
 class QQMemoryBridge:
@@ -144,8 +148,10 @@ class QQMemoryBridge:
         # 切不开的超长 chunk 是二次退化，同步跑在事件循环上会连带卡住这
         # 个进程里其它群的回复。渲染函数本身保持同步（本体侧同构、测试
         # 直调），offload 放在唯一的 async 调用点。
+        kept_count_out: list[int] = []
         rendered = await asyncio.to_thread(
             self.render_relevant_memory, memory_items[:limit],
+            kept_count_out=kept_count_out,
         )
         elapsed_ms = response_payload.get("elapsed_ms", 0.0) if isinstance(response_payload, dict) else 0.0
         try:
@@ -157,9 +163,15 @@ class QQMemoryBridge:
             hit_count=len(memory_items),
             elapsed_ms=normalized_elapsed,
             raw_results=memory_items,
+            rendered_count=kept_count_out[0] if kept_count_out else 0,
         )
 
-    def render_relevant_memory(self, results: list[dict[str, Any]]) -> str:
+    def render_relevant_memory(
+        self,
+        results: list[dict[str, Any]],
+        *,
+        kept_count_out: list[int] | None = None,
+    ) -> str:
         # tier / entity 是内部枚举（scoped 条目的 entity 恒等于 subject.kind），
         # 裸拼会让 `[fact/group_chat]` 出现在中文 prompt 里。与本体侧
         # main_logic/core/tool_calling.py 的召回渲染同一张标签表。
@@ -206,6 +218,10 @@ class QQMemoryBridge:
         kept, dropped = take_lines_within_token_budget(
             lines, RECALL_RENDER_TOTAL_MAX_TOKENS,
         )
+        if kept_count_out is not None:
+            # out-param 而非改返回签名（与 reply_context_node 的
+            # used_member_subject_out 同模式）：既有直调方不受影响。
+            kept_count_out.append(len(kept))
         logger = getattr(self.plugin, "logger", None)
         if dropped and logger is not None:
             # 诊断行不该成为渲染的硬依赖：这个函数此前对 plugin 对象零依赖，

--- a/plugin/plugins/qq_auto_reply/memory_tool_service.py
+++ b/plugin/plugins/qq_auto_reply/memory_tool_service.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+from typing import Any
+
+from config.prompts.prompts_sys import _loc
+from config.prompts.prompts_memory import (
+    RECALL_MEMORY_TOOL_DESCRIPTION,
+    RECALL_MEMORY_TOOL_QUERY_DESCRIPTION,
+    RECALL_MEMORY_TOOL_TIME_DESCRIPTION,
+    RECALL_MEMORY_TOOL_NO_RESULT,
+    RECALL_MEMORY_TOOL_FOUND_HEADER,
+)
+from main_logic.tool_calling import ToolDefinition
+from utils.language_utils import get_global_language, normalize_language_code
+
+from .pipeline_models import is_synthetic_source
+
+RECALL_TOOL_NAME = "recall_memory"
+# 召回 HTTP 的单次预算：也是生成服务给工具轮扩超时时计入的量。
+RECALL_TOOL_HTTP_TIMEOUT_SECONDS = 5.0
+
+
+def resolve_group_recall_subjects(
+    plugin: Any, *, group_id: str, memory_sender_id: str,
+) -> tuple[list[dict[str, str]], bool]:
+    """One place for the group read path's subject list.
+
+    Shared by the per-turn fallback recall and the recall_memory tool
+    handler: the two paths must authorize exactly the same scopes, or a
+    provider switch would silently change what a group turn can read.
+    Returns ``(subjects, used_member_subject)``.
+    """
+    bridge = plugin.memory_bridge
+    subjects = [bridge.group_subject(group_id)]
+    member_sender = str(memory_sender_id or "").strip()
+    if member_sender and bool(
+        (getattr(plugin, "_qq_settings", {}) or {}).get(
+            "group_member_memory_enabled", False,
+        )
+    ):
+        # 实时复检（对偶群开关的读点复检）：member 记忆关掉后不得再召回
+        # participant 域。sender 规范化与写侧一致，避免读写落进不同桶。
+        subjects.append(
+            bridge.group_participant_subject(group_id, member_sender)
+        )
+    return subjects, len(subjects) > 1
+
+
+class QQMemoryToolService:
+    """The model-driven recall channel for QQ sessions.
+
+    The recall_memory tool schema exposes ONLY ``query`` / ``time``.
+    Subjects are resolved host-side from the turn context — the server
+    treats an omitted ``subjects`` field as the legacy PRIVATE corpus, so
+    letting any model-controlled input reach the subject list would leak
+    the admin's private memories into group replies.
+    """
+
+    def __init__(self, plugin: Any):
+        self.plugin = plugin
+
+    @staticmethod
+    def _short_lang() -> str:
+        return normalize_language_code(
+            get_global_language(), format="short",
+        ) or "en"
+
+    def build_recall_tool_definition(self) -> ToolDefinition:
+        """The recall_memory ToolDefinition for QQ generation sessions.
+
+        Same name / schema as the core builtin so the character card's
+        "call the recall_memory tool" instruction holds verbatim. No
+        ``handler``: dispatch goes through the per-turn closure installed
+        via ``set_tool_call_handler`` (the subject scope changes with the
+        speaker, so a registry-style static handler would be wrong).
+        """
+        lang = self._short_lang()
+        return ToolDefinition(
+            name=RECALL_TOOL_NAME,
+            description=_loc(RECALL_MEMORY_TOOL_DESCRIPTION, lang),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": _loc(
+                            RECALL_MEMORY_TOOL_QUERY_DESCRIPTION, lang,
+                        ),
+                    },
+                    "time": {
+                        "type": "string",
+                        "description": _loc(
+                            RECALL_MEMORY_TOOL_TIME_DESCRIPTION, lang,
+                        ),
+                    },
+                },
+                # query / time 至少给一个：与本体 handler 同约定，两者都空
+                # 时 execute_recall 早退回"没有找到相关记忆"。
+                "required": [],
+            },
+            metadata={"source": "qq_auto_reply"},
+        )
+
+    def _live_settings(self) -> dict:
+        return (getattr(self.plugin, "_qq_settings", {}) or {})
+
+    def _turn_memory_sender(self, context: Any) -> str:
+        # 与 reply_context_node.build 的 memory_sender_id 同判据：合成轮的
+        # 名义 sender 不是真实发言人；member 快照取消息接收边界，生成期间
+        # 才切 ON 的轮不得回溯读成员域。
+        if is_synthetic_source(getattr(context, "source_kind", "")):
+            return ""
+        if not getattr(context, "member_memory_enabled", False):
+            return ""
+        return str(getattr(context, "sender_id", "") or "").strip()
+
+    async def execute_recall(
+        self, *, context: Any, arguments: dict[str, Any],
+    ) -> tuple[str, dict[str, bool]]:
+        """Run one recall_memory call under this turn's authorization.
+
+        Returns ``(model_facing_output, consumed_consent)``.
+        ``consumed_consent`` names the switches this read actually relied
+        on (only when scoped content was returned to the model) — the
+        generation service merges it into the runtime consent record so
+        the post-generation and pre-send revocation gates cover reads
+        that happened MID-generation, where the old "is the section still
+        in the prompt" judgement no longer exists.
+        """
+        lang = self._short_lang()
+        no_result = _loc(RECALL_MEMORY_TOOL_NO_RESULT, lang)
+        args = arguments if isinstance(arguments, dict) else {}
+        raw_query = args.get("query")
+        query = raw_query.strip() if isinstance(raw_query, str) else ""
+        raw_time = args.get("time")
+        time_spec = raw_time.strip() if isinstance(raw_time, str) else ""
+        if not query and not time_spec:
+            # 空入参早退（与本体对偶）：省一次 HTTP。
+            return no_result, {}
+        if not getattr(context, "use_memory_context", False):
+            # 构建时刻的记忆政策关着（不该被挂上工具；fail-closed 兜底）。
+            return no_result, {}
+
+        is_group = bool(getattr(context, "is_group", False))
+        subjects: list[dict[str, str]] | None = None
+        used_member = False
+        if is_group:
+            if not bool(self._live_settings().get("group_memory_enabled", False)):
+                # handler 入口复检：授权在模型决定调用与真正执行之间被撤销
+                # 时，一行都不读。
+                return no_result, {}
+            group_id = str(getattr(context, "group_id", "") or "").strip()
+            if not group_id:
+                # 畸形群轮缺 group_id：绝不能让 subjects 退化成 None——
+                # None 的语义是 legacy 私聊主人语料。
+                return no_result, {}
+            subjects, used_member = resolve_group_recall_subjects(
+                self.plugin,
+                group_id=group_id,
+                memory_sender_id=self._turn_memory_sender(context),
+            )
+        # 私聊（use_memory_context 已按政策解析，默认 admin-only）：
+        # subjects=None 走 legacy 私聊主人语料，与回落路径一致。
+
+        try:
+            result = await self.plugin.memory_bridge.query_relevant_memory(
+                getattr(context, "her_name", "") or "",
+                query,
+                subjects=subjects,
+                time_spec=time_spec,
+                timeout=RECALL_TOOL_HTTP_TIMEOUT_SECONDS,
+            )
+        except Exception as exc:
+            # 与本体对偶：召回失败绝不向 wire 抛异常（一次失败的 tool call
+            # 会把模型整轮卡死），回"没有找到相关记忆"让对话继续。
+            self.plugin.logger.warning(
+                f"recall_memory 工具召回失败（返回空结果）: {exc}"
+            )
+            return no_result, {}
+
+        if is_group:
+            live = self._live_settings()
+            if used_member and not bool(
+                live.get("group_member_memory_enabled", False)
+            ):
+                # member 侧读后复检：结果混合群域与 participant 域、事后无法
+                # 拆分，opt-out 落在 HTTP 飞行期间时整体丢弃，不交给模型。
+                return no_result, {}
+            if not bool(live.get("group_memory_enabled", False)):
+                # 群侧读后复检：同上，数据已读回也要丢弃。
+                return no_result, {}
+
+        # INFO 只落元数据（命中数/耗时/是否带 time），原始 query 与召回原文
+        # 走 DEBUG——与本体 handler 的隐私分层一致。
+        self.plugin.logger.info(
+            "recall_memory 工具召回完成: group=%s hits=%s elapsed=%.0fms has_time=%s",
+            is_group, result.hit_count, result.elapsed_ms, bool(time_spec),
+        )
+        self.plugin.logger.debug(
+            "recall_memory args=%r query=%r time=%r", args, query, time_spec,
+        )
+
+        if not result.text:
+            # 本体在 query+time 双条件 0 命中时回"放宽条件重试"的提示，但
+            # 插件会话 max_tool_iterations=1：本轮的工具预算已经用完，封顶
+            # 后的 forced-finalize 会摘掉 tools——提示模型去做一件做不到的
+            # 事只会逼它输出"我再查查"之类的空头承诺。统一回"没有找到"。
+            return no_result, {}
+
+        consumed: dict[str, bool] = {}
+        if is_group:
+            # 只有真的把 scoped 内容交给模型时才记依赖：空结果不构成
+            # 消费，撤销与它无关。
+            consumed["group_memory_enabled"] = True
+            if used_member:
+                consumed["group_member_memory_enabled"] = True
+        rendered_lines = result.text.count("\n") + 1
+        header = _loc(RECALL_MEMORY_TOOL_FOUND_HEADER, lang).format(
+            n=rendered_lines,
+        )
+        return f"{header}\n{result.text}", consumed

--- a/plugin/plugins/qq_auto_reply/memory_tool_service.py
+++ b/plugin/plugins/qq_auto_reply/memory_tool_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from config.prompts.prompts_sys import _loc
@@ -19,6 +20,11 @@ from .prompt_fragment_templates import LONG_TERM_MEMORY_SECTION
 RECALL_TOOL_NAME = "recall_memory"
 # 召回 HTTP 的单次预算：也是生成服务给工具轮扩超时时计入的量。
 RECALL_TOOL_HTTP_TIMEOUT_SECONDS = 5.0
+
+# bridge 渲染的每条召回恒以 "N. " 开行（render_relevant_memory 的
+# f"{index}. {tag} ..."）。header 的条数按它数，不能拿换行数当替身——
+# 记忆原文可含内嵌换行，一条多行 reflection 会把 header 吹成"找到 20 条"。
+_RECALL_ENTRY_PREFIX_RE = re.compile(r"^\d+\. ", re.MULTILINE)
 
 
 def resolve_group_recall_subjects(
@@ -250,8 +256,8 @@ class QQMemoryToolService:
             # 轻量测试 context 可能不可写：回填是 fallback 增强，绝不让
             # 它连累主路径的 tool 结果返回。
             pass
-        rendered_lines = result.text.count("\n") + 1
+        rendered_entries = len(_RECALL_ENTRY_PREFIX_RE.findall(result.text)) or 1
         header = _loc(RECALL_MEMORY_TOOL_FOUND_HEADER, lang).format(
-            n=rendered_lines,
+            n=rendered_entries,
         )
         return f"{header}\n{result.text}", consumed

--- a/plugin/plugins/qq_auto_reply/memory_tool_service.py
+++ b/plugin/plugins/qq_auto_reply/memory_tool_service.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 from typing import Any
 
 from config.prompts.prompts_sys import _loc
@@ -20,11 +19,6 @@ from .prompt_fragment_templates import LONG_TERM_MEMORY_SECTION
 RECALL_TOOL_NAME = "recall_memory"
 # 召回 HTTP 的单次预算：也是生成服务给工具轮扩超时时计入的量。
 RECALL_TOOL_HTTP_TIMEOUT_SECONDS = 5.0
-
-# bridge 渲染的每条召回恒以 "N. " 开行（render_relevant_memory 的
-# f"{index}. {tag} ..."）。header 的条数按它数，不能拿换行数当替身——
-# 记忆原文可含内嵌换行，一条多行 reflection 会把 header 吹成"找到 20 条"。
-_RECALL_ENTRY_PREFIX_RE = re.compile(r"^\d+\. ", re.MULTILINE)
 
 
 def resolve_group_recall_subjects(
@@ -250,14 +244,19 @@ class QQMemoryToolService:
             context.recalled_memory_text = LONG_TERM_MEMORY_SECTION.format(
                 memory_context=result.text,
             )
+            # 与 consent 解耦：私聊 legacy 召回没有群开关依赖（consumed
+            # 恒空），但"模型消费了召回结果"这件事发生了——trace/实验
+            # 读的就是这个标志。
+            context.recalled_memory_used = True
             if used_member:
                 context.used_member_subject = True
         except Exception:
             # 轻量测试 context 可能不可写：回填是 fallback 增强，绝不让
             # 它连累主路径的 tool 结果返回。
             pass
-        rendered_entries = len(_RECALL_ENTRY_PREFIX_RE.findall(result.text)) or 1
+        # 条数用渲染器带出的 kept 计数：记忆原文逐字保留，可能自带
+        # "N. " 开头的行，从 text 反解必然数错。
         header = _loc(RECALL_MEMORY_TOOL_FOUND_HEADER, lang).format(
-            n=rendered_entries,
+            n=result.rendered_count or 1,
         )
         return f"{header}\n{result.text}", consumed

--- a/plugin/plugins/qq_auto_reply/memory_tool_service.py
+++ b/plugin/plugins/qq_auto_reply/memory_tool_service.py
@@ -14,6 +14,7 @@ from main_logic.tool_calling import ToolDefinition
 from utils.language_utils import get_global_language, normalize_language_code
 
 from .pipeline_models import is_synthetic_source
+from .prompt_fragment_templates import LONG_TERM_MEMORY_SECTION
 
 RECALL_TOOL_NAME = "recall_memory"
 # 召回 HTTP 的单次预算：也是生成服务给工具轮扩超时时计入的量。
@@ -101,6 +102,29 @@ class QQMemoryToolService:
             metadata={"source": "qq_auto_reply"},
         )
 
+    def no_result_text(self) -> str:
+        return _loc(RECALL_MEMORY_TOOL_NO_RESULT, self._short_lang())
+
+    @staticmethod
+    def _normalized_recall_arguments(arguments: Any) -> tuple[str, str]:
+        """The (query, time) pair execute_recall actually acts on.
+
+        One extraction shared with ``has_recall_arguments`` so the
+        generation service's one-recall-per-turn latch and the executor
+        can never disagree about what counts as a substantive call."""
+        args = arguments if isinstance(arguments, dict) else {}
+        raw_query = args.get("query")
+        query = raw_query.strip() if isinstance(raw_query, str) else ""
+        raw_time = args.get("time")
+        time_spec = raw_time.strip() if isinstance(raw_time, str) else ""
+        return query, time_spec
+
+    @classmethod
+    def has_recall_arguments(cls, arguments: Any) -> bool:
+        """Whether this call would actually cost a recall HTTP round-trip."""
+        query, time_spec = cls._normalized_recall_arguments(arguments)
+        return bool(query or time_spec)
+
     def _live_settings(self) -> dict:
         return (getattr(self.plugin, "_qq_settings", {}) or {})
 
@@ -130,10 +154,7 @@ class QQMemoryToolService:
         lang = self._short_lang()
         no_result = _loc(RECALL_MEMORY_TOOL_NO_RESULT, lang)
         args = arguments if isinstance(arguments, dict) else {}
-        raw_query = args.get("query")
-        query = raw_query.strip() if isinstance(raw_query, str) else ""
-        raw_time = args.get("time")
-        time_spec = raw_time.strip() if isinstance(raw_time, str) else ""
+        query, time_spec = self._normalized_recall_arguments(args)
         if not query and not time_spec:
             # 空入参早退（与本体对偶）：省一次 HTTP。
             return no_result, {}
@@ -214,6 +235,21 @@ class QQMemoryToolService:
             consumed["group_memory_enabled"] = True
             if used_member:
                 consumed["group_member_memory_enabled"] = True
+        # 回填给 direct fallback：主会话空回复时 fallback 只带
+        # context.recalled_memory_text——本轮模型真的调过工具、读到了内容，
+        # 这份召回就该跟着 fallback 一起用（内容仍来自 tool call，不是
+        # 宿主的自动召回）。used_member_subject 一并置位：member 撤销时
+        # _sanitize_for_live_consent 才会把这段从 fallback prompt 里撤掉。
+        try:
+            context.recalled_memory_text = LONG_TERM_MEMORY_SECTION.format(
+                memory_context=result.text,
+            )
+            if used_member:
+                context.used_member_subject = True
+        except Exception:
+            # 轻量测试 context 可能不可写：回填是 fallback 增强，绝不让
+            # 它连累主路径的 tool 结果返回。
+            pass
         rendered_lines = result.text.count("\n") + 1
         header = _loc(RECALL_MEMORY_TOOL_FOUND_HEADER, lang).format(
             n=rendered_lines,

--- a/plugin/plugins/qq_auto_reply/pipeline_models.py
+++ b/plugin/plugins/qq_auto_reply/pipeline_models.py
@@ -173,6 +173,10 @@ class QQReplyContext:
     # core memory 段是否含 participant 域：member 授权在生成前被撤销时
     # 该段（及混合域召回）要一并撤除。
     used_member_subject: bool = False
+    # 本轮召回通道：True=挂 recall_memory 工具、模型自主决定何时查（此时
+    # 构建期不做同步召回，recalled_memory_text 恒空）；False=线路不支持
+    # tool call（免费代理会静默丢 tools），回落到宿主生成前同步召回。
+    recall_via_tool: bool = False
     # 本轮上下文的唯一标识：投递钩子的幂等键。绝不能用 id(context)——
     # CPython 会把刚释放的同尺寸对象原样发回，下一轮的 context 常常拿到
     # 同一地址，幂等扫描会把新一轮的行误判成"已经补过了"。

--- a/plugin/plugins/qq_auto_reply/reply_context_node.py
+++ b/plugin/plugins/qq_auto_reply/reply_context_node.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from typing import Any, Optional
 
+from main_logic.omni_offline_client import route_supports_tool_calls
 from utils.config_manager import get_config_manager
 
+from .memory_tool_service import resolve_group_recall_subjects
 from .pipeline_models import is_synthetic_source, QQInstructionBundle, QQPipelineStageTrace, QQReplyContext
 from .prompt_fragment_templates import LONG_TERM_MEMORY_SECTION
 
@@ -50,23 +52,14 @@ class QQReplyContextNode:
             return ""
         try:
             subjects = None
+            used_member_subject = False
             if is_group and group_id:
-                subjects = [self.plugin.memory_bridge.group_subject(group_id)]
-                member_sender = str(sender_id or "").strip()
-                if member_sender and bool(
-                    (getattr(self.plugin, "_qq_settings", {}) or {}).get(
-                        "group_member_memory_enabled", False,
-                    )
-                ):
-                    # 实时复检（对偶群开关的读点复检）：构建期间关掉成员
-                    # 记忆后不得再召回 participant 域。sender 规范化与写侧
-                    # 一致，避免读写落进不同桶。
-                    subjects.append(
-                        self.plugin.memory_bridge.group_participant_subject(
-                            group_id, member_sender,
-                        )
-                    )
-            used_member_subject = bool(subjects and len(subjects) > 1)
+                # subject 组装与 recall_memory 工具 handler 共用一处（含
+                # member 开关的读点实时复检、sender 规范化）：两条召回通道
+                # 授权的域必须一致，线路切换不得悄悄改变群轮能读什么。
+                subjects, used_member_subject = resolve_group_recall_subjects(
+                    self.plugin, group_id=group_id, memory_sender_id=sender_id,
+                )
             if used_member_subject and used_member_subject_out is not None:
                 # 回传给调用方：召回是否真的带上了 participant 域。绑定
                 # bootstrap 段是否非空是错的——bootstrap 为空、召回命中
@@ -378,24 +371,47 @@ class QQReplyContextNode:
         core_memory_text = instruction_bundle.core_memory_text
         memory_context_used = instruction_bundle.memory_context_used
         recall_used_member: list = []
-        recalled_memory_text = await self._build_recalled_memory_text(
-            used_member_subject_out=recall_used_member,
-            her_name=her_name,
-            message=message,
-            should_use_memory_context=should_use_memory_context,
-            attachments=attachments,
-            is_group=is_group,
-            group_id=group_id,
-            sender_id=memory_sender_id,
-        )
+        recall_via_tool = False
+        if should_use_memory_context:
+            # 召回通道决策：线路支持 tool call 就把召回交给模型自主决定
+            # （reply_generation_service 按轮挂载 recall_memory 工具，构建
+            # 期不再同步召回）；免费代理只暴露 OpenAI-compat 且会静默丢
+            # tools，那批用户回落到构建期同步召回，否则群记忆会静默归零。
+            # 判定出错按回落处理——回落路径至少确定生效。
+            try:
+                conversation_config = config_manager.get_model_api_config(
+                    "conversation",
+                )
+                recall_via_tool = route_supports_tool_calls(
+                    str(conversation_config.get("model") or ""),
+                    str(conversation_config.get("base_url") or ""),
+                )
+            except Exception:
+                recall_via_tool = False
+        recalled_memory_text = ""
+        if not recall_via_tool:
+            recalled_memory_text = await self._build_recalled_memory_text(
+                used_member_subject_out=recall_used_member,
+                her_name=her_name,
+                message=message,
+                should_use_memory_context=should_use_memory_context,
+                attachments=attachments,
+                is_group=is_group,
+                group_id=group_id,
+                sender_id=memory_sender_id,
+            )
         recalled_memory_used = bool(recalled_memory_text)
         traces.append(
             QQPipelineStageTrace(
                 stage="context_memory_recall",
-                status="used" if recalled_memory_used else "skipped",
+                status=(
+                    "tool_deferred" if recall_via_tool
+                    else ("used" if recalled_memory_used else "skipped")
+                ),
                 metadata={
                     "recalled_memory_used": recalled_memory_used,
                     "recalled_memory_length": len(recalled_memory_text),
+                    "recall_via_tool": recall_via_tool,
                 },
             )
         )
@@ -486,6 +502,7 @@ class QQReplyContextNode:
             force_reply=force_reply,
             source_kind=source_kind,
             member_memory_enabled=member_memory_snapshot,
+            recall_via_tool=recall_via_tool,
             cross_group_section=(
                 getattr(instruction_bundle, "cross_group_section", "")
                 if cross_group_alive else ""

--- a/plugin/plugins/qq_auto_reply/reply_context_node.py
+++ b/plugin/plugins/qq_auto_reply/reply_context_node.py
@@ -244,10 +244,26 @@ class QQReplyContextNode:
                 from .session_bootstrap_service import (
                     generation_session_is_reusable,
                 )
+                # 线路指纹与 bootstrap 的重建触发保持同一组判据（helper
+                # docstring 的硬约束）。此处读的是**落定前**的配置快照：
+                # 免费线路的区域改写可能让它与会话存的指纹假错配，方向是
+                # 安全的——多预测一次"要重建"只是多等一次区域落定。
+                _prediction_route = None
+                try:
+                    _prediction_config = config_manager.get_model_api_config(
+                        "conversation",
+                    )
+                    _prediction_route = (
+                        str(_prediction_config.get("base_url") or ""),
+                        str(_prediction_config.get("model") or ""),
+                    )
+                except Exception:
+                    _prediction_route = None
                 session_cached = generation_session_is_reusable(
                     entry,
                     login_self_id=login_self_id,
                     her_name=config_manager.get_character_data()[1],
+                    conversation_route=_prediction_route,
                 )
             except Exception:
                 session_cached = False

--- a/plugin/plugins/qq_auto_reply/reply_generation_service.py
+++ b/plugin/plugins/qq_auto_reply/reply_generation_service.py
@@ -4,9 +4,12 @@ import asyncio
 from types import SimpleNamespace
 from typing import Any, Optional
 
+from main_logic.omni_offline_client import route_supports_tool_calls
+from main_logic.tool_calling import ToolResult
 from utils.llm_client import SystemMessage, create_chat_llm_async
 from utils.token_tracker import set_call_type
 
+from .memory_tool_service import RECALL_TOOL_HTTP_TIMEOUT_SECONDS
 from .pipeline_models import (
     QQInstructionBundle,
     QQModelResult,
@@ -264,10 +267,31 @@ class QQReplyGenerationService:
                     )
                 ),
             )
+            # recall_memory 工具按轮挂载：群会话是全群共享一个 client，而
+            # participant subject 随发言人变——handler 闭包必须在会话锁内按
+            # 本轮 context 重建，绝不能在建会话时冻结（那会让所有人都用首
+            # 个发言者的 subject）。consent_before 传给闭包：工具读发生在
+            # 生成中途，运行时记录要能被生成结束的撤销比对看到。
+            armed_recall_tool = self._arm_recall_tool(
+                context=context,
+                user_session=user_session,
+                reply_chunks=reply_chunks,
+                consent_before=consent_before,
+            )
             try:
+                turn_timeout = self.plugin._ai_turn_timeout_seconds
+                if armed_recall_tool:
+                    # 工具轮的最坏路径是 2 次完整 LLM 流（初始流 + 封顶后的
+                    # forced-finalize；插件会话 max_tool_iterations=1）加一次
+                    # 召回 HTTP。沿用单流预算会把"慢但会成功"的工具轮变成
+                    # 超时——而这条路径超时的代价不是丢一轮，是丢弃整个共享
+                    # 群会话再打粘性标记。
+                    turn_timeout = (
+                        turn_timeout * 2 + RECALL_TOOL_HTTP_TIMEOUT_SECONDS
+                    )
                 await asyncio.wait_for(
                     user_session.stream_text(context.prompt_message),
-                    timeout=self.plugin._ai_turn_timeout_seconds,
+                    timeout=turn_timeout,
                 )
 
                 completed = await self.plugin._wait_session_response_complete(user_session)
@@ -275,8 +299,10 @@ class QQReplyGenerationService:
                     # 生成期间授权被撤销：这条回复的 prompt 里带着已撤销的
                     # 内容，不能送出——清空出站文本只挡住了发送，stream_text
                     # 早已把 ai 行写进共享历史，留着它等于让被撤销的内容既
-                    # 进 digest 又进后续轮次的上下文。本轮追加的 ai 行直接
-                    # 从历史里摘掉（human 行是用户自己的发言，保留）。
+                    # 进 digest 又进后续轮次的上下文。本轮追加的 ai 行与
+                    # tool 轮的裸 dict 行（assistant tool_calls / role=tool，
+                    # content 里是召回原文）一并摘掉（human 行是用户自己的
+                    # 发言，保留）。
                     self.plugin.logger.warning(
                         f"生成期间记忆授权被撤销，丢弃本轮回复 ({session_key})"
                     )
@@ -285,7 +311,10 @@ class QQReplyGenerationService:
                     if isinstance(history, list):
                         while (
                             len(history) > history_before
-                            and getattr(history[-1], "type", "") == "ai"
+                            and (
+                                getattr(history[-1], "type", "") == "ai"
+                                or self._is_tool_round_row(history[-1])
+                            )
                         ):
                             history.pop()
                 if not completed:
@@ -295,8 +324,25 @@ class QQReplyGenerationService:
                     self.plugin.logger.warning(f"会话 {session_key} 响应超时，关闭并丢弃该会话")
                     raise asyncio.TimeoutError
             finally:
+                if armed_recall_tool:
+                    # 按轮挂载的对偶收尾：工具与 handler 不得越轮存活——
+                    # 同一 client 上的其他生成路径（proactive 的
+                    # prompt_ephemeral 等）绝不能带着本轮的 subject 闭包
+                    # 发起召回。
+                    try:
+                        user_session.set_tools(None)
+                        user_session.set_tool_call_handler(None)
+                    except Exception:
+                        pass
                 restore_session_prompt()
                 history_now = getattr(user_session, "_conversation_history", []) or []
+                if isinstance(history_now, list):
+                    # tool 轮写进共享历史的裸 dict 行随轮清理：召回原文是按
+                    # consent 域临时授权给本轮的，语义与旧管线的"prompt 注入
+                    # + restore"一致——留在共享历史里会进 digest、进后续每轮
+                    # 的上下文，member 撤销后也无法再摘除。模型的最终回答行
+                    # （引用了召回结论的那条 ai 行）照常保留。
+                    self._strip_tool_round_rows(history_now, history_before)
                 appended = list(history_now)[history_before:]
                 user_data["human_row_accepted"] = any(
                     getattr(row, "type", "") == "human" for row in appended
@@ -319,6 +365,135 @@ class QQReplyGenerationService:
                     )
 
             return "".join(reply_chunks)
+
+    def _arm_recall_tool(
+        self,
+        *,
+        context: Any,
+        user_session: Any,
+        reply_chunks: list[str],
+        consent_before: dict,
+    ) -> bool:
+        """Install this turn's recall_memory tool + handler on the client.
+
+        Returns whether the tool is actually armed. The capability check
+        runs against the SESSION CLIENT's frozen route, not the current
+        config: a cached session can outlive a provider switch, and a
+        route that silently drops ``tools`` must not count as armed (the
+        turn would think it has a recall channel it does not have).
+        """
+        if not getattr(context, "recall_via_tool", False):
+            return False
+        if not getattr(context, "use_memory_context", False):
+            return False
+        set_tools = getattr(user_session, "set_tools", None)
+        set_handler = getattr(user_session, "set_tool_call_handler", None)
+        if not callable(set_tools) or not callable(set_handler):
+            return False
+        if not route_supports_tool_calls(
+            str(getattr(user_session, "model", "") or ""),
+            str(getattr(user_session, "base_url", "") or ""),
+        ):
+            self.plugin.logger.warning(
+                "缓存会话的线路不支持 tool call，本轮无召回（会话重建后恢复）"
+            )
+            return False
+        try:
+            set_tools([
+                self.plugin.memory_tool_service.build_recall_tool_definition()
+            ])
+            set_handler(self._build_recall_tool_handler(
+                context=context,
+                reply_chunks=reply_chunks,
+                consent_before=consent_before,
+            ))
+            return True
+        except Exception as exc:
+            self.plugin.logger.warning(
+                f"recall_memory 工具挂载失败（本轮无召回）: {exc}"
+            )
+            try:
+                set_tools(None)
+                set_handler(None)
+            except Exception:
+                pass
+            return False
+
+    def _build_recall_tool_handler(
+        self, *, context: Any, reply_chunks: list[str], consent_before: dict,
+    ):
+        """This turn's recall_memory execution closure.
+
+        Subjects never come from the model: ``execute_recall`` derives
+        them from the turn context (the server reads an omitted subjects
+        field as the legacy PRIVATE corpus). The closure also owns two
+        pieces of turn plumbing — outbound-text hygiene and the runtime
+        consent record.
+        """
+
+        async def _handle_recall_tool(tool_call: Any) -> ToolResult:
+            # pre-tool 文本（"我查一下"之类）不得外发：走到这里说明本轮
+            # 进入了 tool 轮，之前流出的增量已由客户端写进 history 的
+            # assistant tool_calls 行（随后与本轮其余 tool 行一并清理），
+            # 出站文本只保留 post-tool 的最终回答。
+            reply_chunks.clear()
+            output, consumed = await self.plugin.memory_tool_service.execute_recall(
+                context=context,
+                arguments=getattr(tool_call, "arguments", None) or {},
+            )
+            if consumed:
+                # consent 判据从"prompt 里有没有那段字"换成"运行时有没有
+                # 真的发生这次读"：写进本轮的 consent_before（生成结束的
+                # 撤销比对读它），并合入 context.consent_snapshot（发送前
+                # 与 buffer 的撤销闸读它）。
+                for key, was_enabled in consumed.items():
+                    consent_before[key] = (
+                        bool(consent_before.get(key)) or bool(was_enabled)
+                    )
+                self._store_consent_snapshot(context, consumed)
+                try:
+                    context.recalled_memory_used = True
+                except Exception:
+                    pass
+            return ToolResult(
+                call_id=getattr(tool_call, "call_id", "") or "",
+                name=getattr(tool_call, "name", "") or "recall_memory",
+                output=output,
+            )
+
+        return _handle_recall_tool
+
+    @staticmethod
+    def _is_tool_round_row(row: Any) -> bool:
+        """A bare dict row the client's tool loop appended to history.
+
+        Two shapes (OpenAI-compat and genai paths both append these):
+        the assistant turn announcing tool_calls, and the role=tool
+        result row carrying the recalled text.
+        """
+        if not isinstance(row, dict):
+            return False
+        role = row.get("role")
+        return role == "tool" or (
+            role == "assistant" and bool(row.get("tool_calls"))
+        )
+
+    @classmethod
+    def _strip_tool_round_rows(cls, history: list, start_index: int) -> int:
+        """Remove this turn's tool-round dict rows from shared history.
+
+        Only rows appended at or after ``start_index`` are considered —
+        the rows sit BETWEEN the human row and the final ai row, so this
+        scans by index instead of popping from the tail. A repetition
+        guard can reset the history to shorter than ``start_index``; the
+        range is then empty and nothing is touched.
+        """
+        removed = 0
+        for index in range(len(history) - 1, max(start_index, 0) - 1, -1):
+            if cls._is_tool_round_row(history[index]):
+                del history[index]
+                removed += 1
+        return removed
 
     async def _run_memory_housekeeping(
         self, session_key: str, user_data: dict[str, Any],

--- a/plugin/plugins/qq_auto_reply/reply_generation_service.py
+++ b/plugin/plugins/qq_auto_reply/reply_generation_service.py
@@ -471,18 +471,14 @@ class QQReplyGenerationService:
                 # consent 判据从"prompt 里有没有那段字"换成"运行时有没有
                 # 真的发生这次读"：写进本轮的 consent_before（生成结束的
                 # 撤销比对读它），并合入 context.consent_snapshot（发送前
-                # 与 buffer 的撤销闸读它）。
+                # 与 buffer 的撤销闸读它）。recalled_memory_used 不在这里
+                # 记——它跟的是"召回内容被消费"而非"消费了群授权"，私聊
+                # legacy 召回 consumed 恒空，由 execute_recall 在回填点记。
                 for key, was_enabled in consumed.items():
                     consent_before[key] = (
                         bool(consent_before.get(key)) or bool(was_enabled)
                     )
                 self._store_consent_snapshot(context, consumed)
-                try:
-                    context.recalled_memory_used = True
-                except Exception:
-                    # trace 用的布尔而已：合成调用方可能传只读轻量对象，
-                    # 写不进去不影响 consent 记录与工具结果。
-                    pass
             return ToolResult(
                 call_id=getattr(tool_call, "call_id", "") or "",
                 name=getattr(tool_call, "name", "") or "recall_memory",

--- a/plugin/plugins/qq_auto_reply/reply_generation_service.py
+++ b/plugin/plugins/qq_auto_reply/reply_generation_service.py
@@ -333,6 +333,8 @@ class QQReplyGenerationService:
                         user_session.set_tools(None)
                         user_session.set_tool_call_handler(None)
                     except Exception:
+                        # 卸载失败不能连累收尾（下面还有历史清理与成员轮
+                        # 记录），下一轮挂载会整体覆盖这两个槽位。
                         pass
                 restore_session_prompt()
                 history_now = getattr(user_session, "_conversation_history", []) or []
@@ -416,6 +418,8 @@ class QQReplyGenerationService:
                 set_tools(None)
                 set_handler(None)
             except Exception:
+                # 挂载半途失败后的兜底清理：清不掉也只影响本轮（返回
+                # False 已宣布未挂载），finally 不会再动这两个槽位。
                 pass
             return False
 
@@ -431,15 +435,37 @@ class QQReplyGenerationService:
         consent record.
         """
 
+        # 一轮一次召回的闸在 handler 层：max_tool_iterations=1 只限 LLM/
+        # tool 循环轮数，模型在同一个 assistant 回复里可以并排发多个
+        # recall_memory 调用（客户端会逐个执行），流内重试也会再次进
+        # tool 轮——每次都是一段 5s HTTP，会击穿超时预算里"一次召回"的
+        # 假设，而这条路径超时的代价是丢弃整个共享群会话。空参试探
+        # （execute_recall 本就不发 HTTP）不烧额度。
+        recall_executed = [False]
+
         async def _handle_recall_tool(tool_call: Any) -> ToolResult:
             # pre-tool 文本（"我查一下"之类）不得外发：走到这里说明本轮
             # 进入了 tool 轮，之前流出的增量已由客户端写进 history 的
             # assistant tool_calls 行（随后与本轮其余 tool 行一并清理），
             # 出站文本只保留 post-tool 的最终回答。
             reply_chunks.clear()
-            output, consumed = await self.plugin.memory_tool_service.execute_recall(
+            tool_service = self.plugin.memory_tool_service
+            arguments = getattr(tool_call, "arguments", None) or {}
+            substantive = tool_service.has_recall_arguments(arguments)
+            if substantive and recall_executed[0]:
+                self.plugin.logger.info(
+                    "recall_memory 本轮已执行过，追加调用返回空结果"
+                )
+                return ToolResult(
+                    call_id=getattr(tool_call, "call_id", "") or "",
+                    name=getattr(tool_call, "name", "") or "recall_memory",
+                    output=tool_service.no_result_text(),
+                )
+            if substantive:
+                recall_executed[0] = True
+            output, consumed = await tool_service.execute_recall(
                 context=context,
-                arguments=getattr(tool_call, "arguments", None) or {},
+                arguments=arguments,
             )
             if consumed:
                 # consent 判据从"prompt 里有没有那段字"换成"运行时有没有
@@ -454,6 +480,8 @@ class QQReplyGenerationService:
                 try:
                     context.recalled_memory_used = True
                 except Exception:
+                    # trace 用的布尔而已：合成调用方可能传只读轻量对象，
+                    # 写不进去不影响 consent 记录与工具结果。
                     pass
             return ToolResult(
                 call_id=getattr(tool_call, "call_id", "") or "",

--- a/plugin/plugins/qq_auto_reply/session_bootstrap_service.py
+++ b/plugin/plugins/qq_auto_reply/session_bootstrap_service.py
@@ -11,7 +11,11 @@ from .pipeline_models import QQReplyContext
 
 
 def generation_session_is_reusable(
-    entry: Optional[dict[str, Any]], *, login_self_id: Any, her_name: Any,
+    entry: Optional[dict[str, Any]],
+    *,
+    login_self_id: Any,
+    her_name: Any,
+    conversation_route: tuple[str, str] | None = None,
 ) -> bool:
     """Whether this turn keeps an existing session instead of rebuilding it.
 
@@ -19,7 +23,18 @@ def generation_session_is_reusable(
     that rebuilds must await region resolution *before* the persona is
     assembled, and that prediction is only correct while it enumerates the
     same triggers as the rebuild below. Keeping two copies is how the wait
-    silently stopped covering the character-switch and retry paths."""
+    silently stopped covering the character-switch and retry paths.
+
+    ``conversation_route`` is the CURRENT config's ``(base_url, model)``.
+    It is compared against the route the entry was CREATED with (stored on
+    the entry — never read off the live client, whose model may have been
+    legitimately vision-switched mid-session). A stale-route session would
+    keep answering on the retired provider indefinitely in a busy group,
+    and after a free→tool-capable switch it would leave the turn with NO
+    recall channel at all: the context skips the synchronous recall per
+    the new config while the arm step refuses the old client's route.
+    Entries without a stored route (pre-upgrade / lightweight callers)
+    skip the comparison."""
     if not entry:
         return False
     if entry.get("login_self_id") != login_self_id:
@@ -27,6 +42,13 @@ def generation_session_is_reusable(
     if her_name is not None and entry.get("her_name") != her_name:
         return False
     if entry.get("pending_identity_discard"):
+        return False
+    stored_route = entry.get("conversation_route")
+    if (
+        conversation_route is not None
+        and stored_route is not None
+        and tuple(stored_route) != tuple(conversation_route)
+    ):
         return False
     return True
 
@@ -40,10 +62,28 @@ class QQSessionBootstrapService:
             self.plugin._user_sessions = {}
 
         existing_session = None if context.ephemeral_session else self.plugin._user_sessions.get(session_key)
+        current_route: tuple[str, str] | None = None
+        if existing_session is not None:
+            # 线路指纹核对要用当前配置：先落定区域再读（免费线路的 URL 会被
+            # 区域改写，未落定就比对会拿 pre-rewrite 快照造出假错配）。已落定
+            # 零开销；fail-open，落定失败按"线路未知"跳过核对。
+            try:
+                await get_config_manager().aensure_region_resolved()
+            except Exception as _geo_err:
+                self.plugin.logger.warning(f"[GeoIP] 线路核对前区域落定失败，跳过错配检查: {_geo_err}")
+            try:
+                _route_config = get_config_manager().get_model_api_config("conversation")
+                current_route = (
+                    str(_route_config.get("base_url") or ""),
+                    str(_route_config.get("model") or ""),
+                )
+            except Exception:
+                current_route = None
         if existing_session and not generation_session_is_reusable(
             existing_session,
             login_self_id=context.login_self_id,
             her_name=getattr(context, "her_name", None),
+            conversation_route=current_route,
         ):
             # her_name 失配=活跃角色切换：旧会话的 scoped 缓冲仍属旧角色，
             # discard 内的集中抢救会以旧 her_name 结算——新角色的对话绝不
@@ -51,7 +91,7 @@ class QQSessionBootstrapService:
             character_changed = existing_session.get("her_name") != getattr(
                 context, "her_name", existing_session.get("her_name"),
             )
-            discarded = await self.plugin.session_runtime_service.discard_session(session_key, reason="登录身份变化")
+            discarded = await self.plugin.session_runtime_service.discard_session(session_key, reason="登录身份/角色/线路变化")
             if discarded is False:
                 # 粘性标记：prime 会把 login_self_id 刷成新值，若只靠 id
                 # 不匹配做重试条件，下一轮就再也进不来这里了。
@@ -113,6 +153,10 @@ class QQSessionBootstrapService:
                 "session": user_session,
                 "reply_chunks": reply_chunks,
                 "her_name": context.her_name,
+                # 创建时刻的会话线路指纹：复用判据拿它与当前配置比对（绝不
+                # 读 client 现值——图片轮会把 client 合法地切到 vision 模型，
+                # 按现值比对会让每个看过图的会话每轮都被误重建）。
+                "conversation_route": (str(base_url or ""), str(model or "")),
                 "character_fields": context.character_card_fields,
                 "last_synced_index": 0,
                 "last_activity_at": time.time(),
@@ -258,6 +302,9 @@ class QQSessionBootstrapService:
                 "session": user_session,
                 "reply_chunks": reply_chunks,
                 "her_name": her_name,
+                # 与 ensure_generation_session 对偶：回复路径会复用这里建的
+                # 条目，缺指纹就等于对这批会话永久关闭线路错配重建。
+                "conversation_route": (str(base_url or ""), str(model or "")),
                 "character_fields": character_card_fields,
                 "last_synced_index": 0,
                 "last_activity_at": time.time(),

--- a/plugin/plugins/qq_auto_reply/session_bootstrap_service.py
+++ b/plugin/plugins/qq_auto_reply/session_bootstrap_service.py
@@ -219,10 +219,45 @@ class QQSessionBootstrapService:
                         self.plugin.logger.warning(f"关闭登录身份已变化的主动会话失败: {close_error}")
                 existing = None
             else:
-                existing["login_status"] = current_login_status
-                existing["login_self_id"] = current_login_self_id
-                existing["login_nickname"] = current_login_nickname
-                return existing
+                # 线路指纹核对（与 ensure_generation_session 对偶）：主动
+                # 路径复用的条目同样可能跨过一次 provider 切换，只靠回复
+                # 路径兜底会漏掉纯主动流量的会话。核对前先落定区域（免费
+                # 线路的区域改写不得造出假错配）；走 discard_session 而非
+                # 裸 pop+close——群会话的 scoped 缓冲要先集中抢救。
+                stored_route = existing.get("conversation_route")
+                if stored_route is not None:
+                    try:
+                        await get_config_manager().aensure_region_resolved()
+                    except Exception as _geo_err:
+                        self.plugin.logger.warning(f"[GeoIP] 线路核对前区域落定失败，跳过错配检查: {_geo_err}")
+                    current_route = None
+                    try:
+                        _route_config = get_config_manager().get_model_api_config("conversation")
+                        current_route = (
+                            str(_route_config.get("base_url") or ""),
+                            str(_route_config.get("model") or ""),
+                        )
+                    except Exception:
+                        current_route = None
+                    if (
+                        current_route is not None
+                        and tuple(stored_route) != current_route
+                    ):
+                        discarded = await self.plugin.session_runtime_service.discard_session(
+                            session_key, reason="登录身份/角色/线路变化",
+                        )
+                        if discarded is False:
+                            # 结算失败被有意保留：打粘性标记让回复路径的
+                            # 复用判据接手重试，本轮沿用旧会话（销毁唯一
+                            # 缓冲副本比线路滞后一轮更糟）。
+                            existing["pending_identity_discard"] = True
+                        else:
+                            existing = None
+                if existing is not None:
+                    existing["login_status"] = current_login_status
+                    existing["login_self_id"] = current_login_self_id
+                    existing["login_nickname"] = current_login_nickname
+                    return existing
 
         try:
             config_manager = get_config_manager()

--- a/plugin/plugins/qq_auto_reply/session_bootstrap_service.py
+++ b/plugin/plugins/qq_auto_reply/session_bootstrap_service.py
@@ -98,6 +98,11 @@ class QQSessionBootstrapService:
                 api_key=api_key,
                 model=model,
                 on_text_delta=on_text_delta,
+                # 一轮只允许一次召回：与旧的每轮同步召回同预算，也压住
+                # 工具轮的最坏超时（每多一次迭代就多一整段 LLM 流，而这里
+                # 超时的代价是丢弃整个共享群会话）。封顶后 forced-finalize
+                # 会摘掉 tools 逼出最终文本，召回结果不会白拿。
+                max_tool_iterations=1,
             )
             await asyncio.wait_for(
                 user_session.connect(instructions=context.system_prompt),
@@ -212,6 +217,9 @@ class QQSessionBootstrapService:
                 api_key=api_key,
                 model=model,
                 on_text_delta=on_text_delta,
+                # 与 ensure_generation_session 对偶：主动会话与回复会话共用
+                # _user_sessions 缓存，回复轮可能复用这里建的 client。
+                max_tool_iterations=1,
             )
 
             login_status, login_self_id, login_nickname = self.plugin._normalize_login_identity(

--- a/tests/unit/test_group_memory_recall_tool.py
+++ b/tests/unit/test_group_memory_recall_tool.py
@@ -1154,6 +1154,109 @@ async def test_bootstrap_rebuilds_stale_route_session(monkeypatch):
     discard.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_proactive_reuse_also_checks_the_stored_route(monkeypatch):
+    """ensure_session_for_user is the proactive twin of the generation
+    bootstrap: a session serving only proactive traffic would otherwise
+    never hit the reply path's route check and stay on the retired
+    provider forever. Mismatch goes through discard_session (scoped
+    buffers get salvaged), not a bare pop+close."""
+    from plugin.plugins.qq_auto_reply import session_bootstrap_service as sbs
+
+    new_route = (TOOL_CAPABLE_BASE_URL, TOOL_CAPABLE_MODEL)
+
+    class _StubClient:
+        def __init__(self, **kwargs):
+            self.base_url = kwargs.get("base_url")
+            self.model = kwargs.get("model")
+
+        async def connect(self, instructions=""):
+            return None
+
+    monkeypatch.setattr(sbs, "OmniOfflineClient", _StubClient)
+    monkeypatch.setattr(
+        sbs, "get_config_manager",
+        lambda: SimpleNamespace(
+            aensure_region_resolved=AsyncMock(),
+            get_model_api_config=lambda kind: {
+                "base_url": new_route[0], "model": new_route[1], "api_key": "k",
+            },
+            get_character_data=lambda: (
+                "Master", "Neko", None, {}, None, {}, None, None, None,
+            ),
+        ),
+    )
+
+    stale_entry = {
+        "login_self_id": "10000",
+        "her_name": "Neko",
+        "conversation_route": ("https://www.lanlan.app/text/v1", "free-model"),
+        "session": SimpleNamespace(),
+        "session_key": "group:7788",
+        "sender_id": "2046",
+        "is_group": True,
+        "group_id": "7788",
+        "user_title": "群友",
+        "permission_level": "user",
+        "lock": asyncio.Lock(),
+    }
+    discard = AsyncMock(side_effect=lambda key, reason: (
+        plugin._user_sessions.pop(key, None) is not None
+    ))
+    plugin = SimpleNamespace(
+        _user_sessions={"group:7788": stale_entry},
+        _ai_connect_timeout_seconds=5,
+        logger=MagicMock(),
+        i18n=SimpleNamespace(t=lambda key, default="", **kw: default),
+        session_runtime_service=SimpleNamespace(discard_session=discard),
+        _normalize_login_identity=lambda payload: ("online", "10000", "Neko"),
+        _fetch_login_status_payload=AsyncMock(return_value={}),
+        _build_character_card_fields=lambda *a, **k: {},
+        _build_qq_session_instructions=AsyncMock(
+            return_value=SimpleNamespace(
+                system_prompt="系统提示词", memory_context_used=False,
+            )
+        ),
+    )
+    service = sbs.QQSessionBootstrapService(plugin)
+    created = await service.ensure_session_for_user({
+        "session_key": "group:7788", "sender_id": "2046",
+        "permission_level": "user", "is_group": True, "group_id": "7788",
+        "user_title": "群友",
+    })
+    discard.assert_awaited_once()
+    assert created is not stale_entry
+    assert created["conversation_route"] == new_route
+
+    # 线路一致：原样复用——比对的是创建期指纹，vision 切换过的 client
+    # 现值不同也不得触发重建。
+    created["session"] = SimpleNamespace(
+        model="vision-x", base_url="https://vision.example.com/v1",
+    )
+    discard.reset_mock()
+    reused = await service.ensure_session_for_user({
+        "session_key": "group:7788", "sender_id": "2046",
+        "permission_level": "user", "is_group": True, "group_id": "7788",
+        "user_title": "群友",
+    })
+    assert reused is created
+    discard.assert_not_awaited()
+
+    # 结算失败（discard 返回 False）：保留旧会话 + 粘性标记交回复路径重试，
+    # 绝不销毁缓冲唯一副本。
+    created["conversation_route"] = ("https://old.example.com/v1", "old-model")
+    discard.reset_mock()
+    discard.side_effect = None
+    discard.return_value = False
+    kept = await service.ensure_session_for_user({
+        "session_key": "group:7788", "sender_id": "2046",
+        "permission_level": "user", "is_group": True, "group_id": "7788",
+        "user_title": "群友",
+    })
+    assert kept is created
+    assert kept["pending_identity_discard"] is True
+
+
 # ---------------------------------------------------------------------------
 # Bridge: time passthrough
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_group_memory_recall_tool.py
+++ b/tests/unit/test_group_memory_recall_tool.py
@@ -264,9 +264,11 @@ async def test_private_admin_recall_uses_legacy_corpus():
     assert kwargs["subjects"] is None
     assert kwargs["time_spec"] == "2026-05"
     assert kwargs["timeout"] == RECALL_TOOL_HTTP_TIMEOUT_SECONDS
-    # 私聊 legacy 语料不受群开关管辖：无运行时 consent 依赖要记。
+    # 私聊 legacy 语料不受群开关管辖：无运行时 consent 依赖要记——
+    # 但"召回被消费"的标志与 consent 解耦，私聊命中也要记 used。
     assert consumed == {}
     assert "群规是不剧透" in output
+    assert context.recalled_memory_used is True
 
 
 # ---------------------------------------------------------------------------
@@ -859,15 +861,19 @@ def test_route_capability_predicate_knows_the_free_proxy():
 @pytest.mark.asyncio
 async def test_recall_header_counts_entries_not_lines():
     """A single multiline reflection must not inflate the header into
-    "found N memories": entries are counted by their rendered "N. "
-    prefixes, never by newline characters."""
+    "found N memories". Memory text is preserved verbatim and can itself
+    contain lines shaped like "2. ..." — so the count comes from the
+    renderer's kept-entry tally, never from re-parsing the rendered
+    text."""
     from config.prompts.prompts_memory import RECALL_MEMORY_TOOL_FOUND_HEADER
     from config.prompts.prompts_sys import _loc
 
     plugin = _tool_plugin()
+    # 对抗样例：一条 reflection 的原文自带 "2. " 开头的行。
     plugin.memory_bridge.query_relevant_memory = AsyncMock(
         return_value=QQMemoryQueryResult(
-            text="1. [事实] 第一行\n第二行\n第三行", hit_count=1,
+            text="1. [事实] 第一行\n2. 原文里的编号行\n第三行",
+            hit_count=1, rendered_count=1,
         ),
     )
     output, _ = await plugin.memory_tool_service.execute_recall(
@@ -877,6 +883,20 @@ async def test_recall_header_counts_entries_not_lines():
     assert output.startswith(
         _loc(RECALL_MEMORY_TOOL_FOUND_HEADER, lang).format(n=1)
     )
+
+    # 渲染器侧：kept 计数经 out-param 带出（预算丢弃尾部条目时与
+    # hit_count 不同），多行原文只算一条。
+    bridge = QQMemoryBridge(SimpleNamespace(logger=MagicMock()))
+    kept_out: list = []
+    rendered = bridge.render_relevant_memory(
+        [
+            {"text": "第一行\n2. 原文里的编号行", "tier": "fact"},
+            {"text": "另一条", "tier": "fact"},
+        ],
+        kept_count_out=kept_out,
+    )
+    assert kept_out == [2]
+    assert rendered.startswith("1. ")
 
 
 def _build_stub_plugin(bridge):

--- a/tests/unit/test_group_memory_recall_tool.py
+++ b/tests/unit/test_group_memory_recall_tool.py
@@ -1,0 +1,997 @@
+"""recall_memory tool-call recall channel for QQ group memory.
+
+The per-turn host-side recall became a model-driven tool call (the free
+proxy routes keep the old synchronous recall as a fallback). These tests
+pin the six load-bearing pieces of that migration:
+
+1. the handler closure is re-pointed EVERY turn (a shared group session
+   must never freeze the first speaker's subject);
+2. subjects never appear in the tool schema and model-supplied arguments
+   cannot influence them (omitted subjects = the admin's PRIVATE corpus
+   server-side);
+3. consent becomes a runtime record — what was actually read mid-stream —
+   instead of "is the section still in the prompt";
+4. the in-handler entry / post-fetch revocation gates;
+5. tool-round dict rows never survive in the shared history (neither on
+   normal turns nor through the revocation rollback);
+6. pre-tool text never reaches the outbound message, and routes that
+   silently drop ``tools`` fall back to the synchronous recall.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from plugin.plugins.qq_auto_reply.memory_bridge import (
+    QQMemoryBridge,
+    QQMemoryQueryResult,
+)
+from plugin.plugins.qq_auto_reply.memory_tool_service import (
+    QQMemoryToolService,
+    RECALL_TOOL_HTTP_TIMEOUT_SECONDS,
+    resolve_group_recall_subjects,
+)
+from plugin.plugins.qq_auto_reply.reply_generation_service import (
+    QQReplyGenerationService,
+)
+
+TOOL_CAPABLE_MODEL = "qwen3.7-plus"
+TOOL_CAPABLE_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+
+
+def _mock_bridge(recall_text="群规是不剧透"):
+    bridge = MagicMock()
+    bridge.group_subject.side_effect = QQMemoryBridge.group_subject
+    bridge.group_participant_subject.side_effect = (
+        QQMemoryBridge.group_participant_subject
+    )
+    bridge.query_relevant_memory = AsyncMock(
+        return_value=QQMemoryQueryResult(text=recall_text, hit_count=1),
+    )
+    return bridge
+
+
+def _tool_plugin(bridge=None, settings=None):
+    plugin = SimpleNamespace(
+        memory_bridge=bridge if bridge is not None else _mock_bridge(),
+        logger=MagicMock(),
+        _qq_settings=settings if settings is not None else {
+            "group_memory_enabled": True,
+            "group_member_memory_enabled": True,
+        },
+        _queue_attachment_images=AsyncMock(return_value=0),
+        _wait_session_response_complete=AsyncMock(return_value=True),
+        _ai_turn_timeout_seconds=5,
+    )
+    plugin.memory_tool_service = QQMemoryToolService(plugin)
+    return plugin
+
+
+def _group_context(sender_id="2046", **overrides):
+    fields = dict(
+        is_group=True,
+        group_id="7788",
+        sender_id=sender_id,
+        her_name="Neko",
+        attachments=None,
+        prompt_message="hi",
+        system_prompt="系统提示词",
+        recalled_memory_text="",
+        recalled_memory_used=False,
+        core_memory_text="",
+        cross_group_section="",
+        cross_session_section="",
+        used_member_subject=False,
+        use_memory_context=True,
+        recall_via_tool=True,
+        member_memory_enabled=True,
+        source_kind="",
+        permission_level="user",
+        consent_snapshot=None,
+    )
+    fields.update(overrides)
+    return SimpleNamespace(**fields)
+
+
+class _RecallToolClient:
+    """A stand-in for OmniOfflineClient's tool loop.
+
+    ``stream_text`` runs the provided script, which can emit pre-tool
+    deltas, invoke whatever handler is CURRENTLY installed (exactly like
+    the real loop does), append the tool-round dict rows the real client
+    persists, and emit the final answer.
+    """
+
+    def __init__(self, script, *, model=TOOL_CAPABLE_MODEL,
+                 base_url=TOOL_CAPABLE_BASE_URL):
+        self._script = script
+        self.model = model
+        self.base_url = base_url
+        self._conversation_history: list = []
+        self.tools: list = []
+        self.on_tool_call = None
+        self.armed_tool_names: list[list[str]] = []
+
+    def set_tools(self, tool_definitions):
+        self.tools = list(tool_definitions or [])
+        self.armed_tool_names.append([t.name for t in self.tools])
+
+    def set_tool_call_handler(self, handler):
+        self.on_tool_call = handler
+
+    async def stream_text(self, message):
+        await self._script(self, message)
+
+
+def _generation_service(plugin):
+    service = QQReplyGenerationService.__new__(QQReplyGenerationService)
+    service.plugin = plugin
+    return service
+
+
+def _recall_tool_call(arguments):
+    return SimpleNamespace(
+        name="recall_memory", arguments=arguments, call_id="call_1",
+    )
+
+
+def _tool_round_rows(recall_output):
+    return [
+        {
+            "role": "assistant",
+            "content": "我查一下",
+            "tool_calls": [{
+                "id": "call_1", "type": "function",
+                "function": {"name": "recall_memory", "arguments": "{}"},
+            }],
+        },
+        {
+            "role": "tool", "tool_call_id": "call_1", "name": "recall_memory",
+            "content": recall_output,
+        },
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Schema / subject isolation
+# ---------------------------------------------------------------------------
+
+
+def test_recall_tool_schema_exposes_only_query_and_time():
+    """Subjects must be host-injected: the server reads an omitted
+    subjects field as the legacy PRIVATE corpus, so a subjects (or any
+    scope-shaped) parameter in the schema would hand the model a lever
+    over what a group turn is allowed to read."""
+    definition = _tool_plugin().memory_tool_service.build_recall_tool_definition()
+    assert definition.name == "recall_memory"
+    assert set(definition.parameters["properties"].keys()) == {"query", "time"}
+    assert definition.parameters.get("required") == []
+    serialized = json.dumps(definition.parameters, ensure_ascii=False)
+    assert "subject" not in serialized
+    # 分发走按轮闭包（set_tool_call_handler），不走 registry 静态 handler。
+    assert definition.handler is None
+
+
+@pytest.mark.asyncio
+async def test_model_supplied_subjects_cannot_influence_scope():
+    """Behavioural twin of the schema assert: even if the model hallucinates
+    subject-shaped arguments, the HTTP call carries only the host-derived
+    subjects for this turn."""
+    plugin = _tool_plugin()
+    context = _group_context()
+    output, consumed = await plugin.memory_tool_service.execute_recall(
+        context=context,
+        arguments={
+            "query": "群规",
+            "subjects": [{"subject_kind": "legacy", "subject_id": "master"}],
+            "subject_id": "master",
+            "include_legacy_private": True,
+        },
+    )
+    kwargs = plugin.memory_bridge.query_relevant_memory.await_args.kwargs
+    assert kwargs["subjects"] == [
+        QQMemoryBridge.group_subject("7788"),
+        QQMemoryBridge.group_participant_subject("7788", "2046"),
+    ]
+    assert "群规是不剧透" in output
+    assert consumed == {
+        "group_memory_enabled": True,
+        "group_member_memory_enabled": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_execute_recall_missing_group_id_fails_closed():
+    """A malformed group turn without group_id must return nothing —
+    subjects=None means the legacy private corpus server-side, so falling
+    through would recall the admin's private memories into a group."""
+    plugin = _tool_plugin()
+    context = _group_context(group_id="   ")
+    output, consumed = await plugin.memory_tool_service.execute_recall(
+        context=context, arguments={"query": "群规"},
+    )
+    plugin.memory_bridge.query_relevant_memory.assert_not_awaited()
+    assert "群规是不剧透" not in output
+    assert consumed == {}
+
+
+@pytest.mark.asyncio
+async def test_participant_subject_gating_matches_write_side():
+    """Synthetic turns / receipt-time-off member snapshots / a live member
+    opt-out all drop the participant subject — same predicate set as the
+    fallback recall and the write side."""
+    plugin = _tool_plugin()
+
+    for context in (
+        _group_context(source_kind="rapid_fire_flush"),
+        _group_context(member_memory_enabled=False),
+    ):
+        plugin.memory_bridge.query_relevant_memory.reset_mock()
+        await plugin.memory_tool_service.execute_recall(
+            context=context, arguments={"query": "群规"},
+        )
+        kwargs = plugin.memory_bridge.query_relevant_memory.await_args.kwargs
+        assert kwargs["subjects"] == [QQMemoryBridge.group_subject("7788")]
+
+    # Live member switch off (snapshot on): the read-point recheck drops
+    # the participant scope too.
+    plugin._qq_settings["group_member_memory_enabled"] = False
+    plugin.memory_bridge.query_relevant_memory.reset_mock()
+    output, consumed = await plugin.memory_tool_service.execute_recall(
+        context=_group_context(), arguments={"query": "群规"},
+    )
+    kwargs = plugin.memory_bridge.query_relevant_memory.await_args.kwargs
+    assert kwargs["subjects"] == [QQMemoryBridge.group_subject("7788")]
+    # 只读了群域：consumed 不得把 member 开关也记成依赖。
+    assert consumed == {"group_memory_enabled": True}
+
+
+@pytest.mark.asyncio
+async def test_private_admin_recall_uses_legacy_corpus():
+    plugin = _tool_plugin()
+    context = _group_context(
+        is_group=False, group_id=None, permission_level="admin",
+    )
+    output, consumed = await plugin.memory_tool_service.execute_recall(
+        context=context, arguments={"query": "上次的旅行计划", "time": "2026-05"},
+    )
+    kwargs = plugin.memory_bridge.query_relevant_memory.await_args.kwargs
+    assert kwargs["subjects"] is None
+    assert kwargs["time_spec"] == "2026-05"
+    assert kwargs["timeout"] == RECALL_TOOL_HTTP_TIMEOUT_SECONDS
+    # 私聊 legacy 语料不受群开关管辖：无运行时 consent 依赖要记。
+    assert consumed == {}
+    assert "群规是不剧透" in output
+
+
+# ---------------------------------------------------------------------------
+# In-handler revocation gates (连带 #4)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handler_entry_gate_blocks_revoked_group_read():
+    plugin = _tool_plugin(settings={
+        "group_memory_enabled": False,
+        "group_member_memory_enabled": True,
+    })
+    output, consumed = await plugin.memory_tool_service.execute_recall(
+        context=_group_context(), arguments={"query": "群规"},
+    )
+    plugin.memory_bridge.query_relevant_memory.assert_not_awaited()
+    assert "群规是不剧透" not in output
+    assert consumed == {}
+
+
+@pytest.mark.asyncio
+async def test_handler_postfetch_gate_drops_inflight_optout():
+    """The opt-out lands while the recall HTTP is on the wire: data already
+    read back must be discarded whole, never handed to the model."""
+    plugin = _tool_plugin()
+
+    async def _recall_then_revoke(*args, **kwargs):
+        plugin._qq_settings["group_memory_enabled"] = False
+        return QQMemoryQueryResult(text="群规是不剧透", hit_count=1)
+
+    plugin.memory_bridge.query_relevant_memory = AsyncMock(
+        side_effect=_recall_then_revoke,
+    )
+    output, consumed = await plugin.memory_tool_service.execute_recall(
+        context=_group_context(), arguments={"query": "群规"},
+    )
+    assert "群规是不剧透" not in output
+    assert consumed == {}
+
+    # Member-only opt-out during flight: the result mixes group and
+    # participant scopes and cannot be split afterwards — drop it whole.
+    plugin._qq_settings["group_memory_enabled"] = True
+    plugin._qq_settings["group_member_memory_enabled"] = True
+
+    async def _recall_then_revoke_member(*args, **kwargs):
+        plugin._qq_settings["group_member_memory_enabled"] = False
+        return QQMemoryQueryResult(text="成员私密偏好", hit_count=1)
+
+    plugin.memory_bridge.query_relevant_memory = AsyncMock(
+        side_effect=_recall_then_revoke_member,
+    )
+    output, consumed = await plugin.memory_tool_service.execute_recall(
+        context=_group_context(), arguments={"query": "偏好"},
+    )
+    assert "成员私密偏好" not in output
+    assert consumed == {}
+
+
+@pytest.mark.asyncio
+async def test_recall_failure_returns_no_result_without_raising():
+    plugin = _tool_plugin()
+    plugin.memory_bridge.query_relevant_memory = AsyncMock(
+        side_effect=RuntimeError("memory server down"),
+    )
+    output, consumed = await plugin.memory_tool_service.execute_recall(
+        context=_group_context(), arguments={"query": "群规"},
+    )
+    assert output
+    assert consumed == {}
+
+
+@pytest.mark.asyncio
+async def test_zero_hits_never_suggest_an_impossible_retry():
+    """The core handler hints "loosen the filter and query again" on a
+    query+time miss — but plugin sessions cap max_tool_iterations at 1,
+    so by the time the model reads any tool result its tool budget is
+    spent and the forced-finalize strips ``tools``. Echoing that hint
+    here would coach the model into promising a lookup it cannot do."""
+    plugin = _tool_plugin()
+    plugin.memory_bridge.query_relevant_memory = AsyncMock(
+        return_value=QQMemoryQueryResult(),
+    )
+    output, consumed = await plugin.memory_tool_service.execute_recall(
+        context=_group_context(), arguments={"query": "旅行", "time": "2026-05"},
+    )
+    assert output
+    assert "旅行" not in output  # 不回显"再查一次"式提示
+    assert consumed == {}
+
+    # Empty arguments never cost an HTTP round-trip.
+    plugin.memory_bridge.query_relevant_memory.reset_mock()
+    await plugin.memory_tool_service.execute_recall(
+        context=_group_context(), arguments={},
+    )
+    plugin.memory_bridge.query_relevant_memory.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Per-turn handler re-pointing on the shared group session (连带 #1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_shared_session_rebinds_recall_subjects_every_turn():
+    """The group session client is shared by the whole group while the
+    participant subject follows the speaker. Two consecutive speakers on
+    the SAME client: the second turn's recall must carry the second
+    speaker's subject — a handler frozen at session-creation time (or a
+    'keep the existing handler' shortcut) would recall speaker A's
+    private facts while answering speaker B."""
+    plugin = _tool_plugin()
+    service = _generation_service(plugin)
+
+    async def _script(client, message):
+        handler = client.on_tool_call
+        assert handler is not None, "本轮没有挂载 recall handler"
+        result = await handler(_recall_tool_call({"query": "偏好"}))
+        client._conversation_history.append(
+            SimpleNamespace(type="human", content=message)
+        )
+        client._conversation_history.extend(
+            _tool_round_rows(result.output_as_json_string())
+        )
+        client._conversation_history.append(
+            SimpleNamespace(type="ai", content="回复")
+        )
+
+    client = _RecallToolClient(_script)
+    user_data = {"lock": asyncio.Lock()}
+
+    for sender in ("2046", "9999"):
+        reply_chunks: list = []
+        await service._run_session_generation(
+            context=_group_context(sender_id=sender),
+            session_key="group:7788",
+            user_data=user_data,
+            user_session=client,
+            reply_chunks=reply_chunks,
+        )
+
+    calls = plugin.memory_bridge.query_relevant_memory.await_args_list
+    assert [
+        call.kwargs["subjects"][1]["subject_id"] for call in calls
+    ] == ["qq:7788:2046", "qq:7788:9999"]
+
+
+@pytest.mark.asyncio
+async def test_recall_tool_disarmed_after_every_turn():
+    """The per-turn arm has a symmetric disarm: other generation paths on
+    the same client (proactive prompt_ephemeral) must never inherit this
+    turn's subject closure — even when the stream raises."""
+    plugin = _tool_plugin()
+    service = _generation_service(plugin)
+
+    async def _quiet(client, message):
+        client._conversation_history.append(
+            SimpleNamespace(type="human", content=message)
+        )
+
+    client = _RecallToolClient(_quiet)
+    await service._run_session_generation(
+        context=_group_context(),
+        session_key="group:7788",
+        user_data={"lock": asyncio.Lock()},
+        user_session=client,
+        reply_chunks=[],
+    )
+    assert client.armed_tool_names[0] == ["recall_memory"]
+    assert client.tools == []
+    assert client.on_tool_call is None
+
+    async def _boom(client, message):
+        raise RuntimeError("stream died")
+
+    client = _RecallToolClient(_boom)
+    with pytest.raises(RuntimeError):
+        await service._run_session_generation(
+            context=_group_context(),
+            session_key="group:7788",
+            user_data={"lock": asyncio.Lock()},
+            user_session=client,
+            reply_chunks=[],
+        )
+    assert client.tools == []
+    assert client.on_tool_call is None
+
+
+@pytest.mark.asyncio
+async def test_arm_respects_the_session_clients_frozen_route():
+    """Arming binds to the CLIENT's route, not the current config: a
+    cached session can outlive a provider switch, and a route that
+    silently drops ``tools`` must not count as armed."""
+    plugin = _tool_plugin()
+    service = _generation_service(plugin)
+
+    free_client = _RecallToolClient(
+        AsyncMock(), model="free-model",
+        base_url="https://www.lanlan.app/text/v1",
+    )
+    assert service._arm_recall_tool(
+        context=_group_context(),
+        user_session=free_client,
+        reply_chunks=[],
+        consent_before={},
+    ) is False
+    assert free_client.armed_tool_names == []
+
+    # recall_via_tool=False（构建期决定走回落）：连 set_tools 都不碰。
+    capable_client = _RecallToolClient(AsyncMock())
+    assert service._arm_recall_tool(
+        context=_group_context(recall_via_tool=False),
+        user_session=capable_client,
+        reply_chunks=[],
+        consent_before={},
+    ) is False
+    assert capable_client.armed_tool_names == []
+
+    # A legacy client stub without the tooling surface degrades quietly.
+    assert service._arm_recall_tool(
+        context=_group_context(),
+        user_session=SimpleNamespace(model=TOOL_CAPABLE_MODEL,
+                                     base_url=TOOL_CAPABLE_BASE_URL),
+        reply_chunks=[],
+        consent_before={},
+    ) is False
+
+    assert service._arm_recall_tool(
+        context=_group_context(),
+        user_session=capable_client,
+        reply_chunks=[],
+        consent_before={},
+    ) is True
+    assert capable_client.armed_tool_names[-1] == ["recall_memory"]
+    assert capable_client.on_tool_call is not None
+
+
+# ---------------------------------------------------------------------------
+# Runtime consent record (连带 #3) + rollback across tool rows (连带 #5)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tool_read_records_runtime_consent_for_all_gates():
+    """The old judgement — "is the recall section still in the prompt" —
+    no longer exists on the tool path. What replaces it: the handler
+    records the switches the read actually relied on, into both the
+    generation-scope snapshot (post-generation discard) and
+    context.consent_snapshot (pre-send / buffer gates)."""
+    plugin = _tool_plugin()
+    service = _generation_service(plugin)
+    context = _group_context()
+
+    async def _script(client, message):
+        result = await client.on_tool_call(_recall_tool_call({"query": "群规"}))
+        client._conversation_history.append(
+            SimpleNamespace(type="human", content=message)
+        )
+        client._conversation_history.extend(
+            _tool_round_rows(result.output_as_json_string())
+        )
+        client._conversation_history.append(
+            SimpleNamespace(type="ai", content="按群规是不剧透哦")
+        )
+        client.reply_chunks_ref.append("按群规是不剧透哦")
+
+    client = _RecallToolClient(_script)
+    reply_chunks: list = []
+    client.reply_chunks_ref = reply_chunks
+    result = await service._run_session_generation(
+        context=context,
+        session_key="group:7788",
+        user_data={"lock": asyncio.Lock()},
+        user_session=client,
+        reply_chunks=reply_chunks,
+    )
+    assert result == "按群规是不剧透哦"
+    assert context.consent_snapshot == {
+        "group_memory_enabled": True,
+        "group_member_memory_enabled": True,
+    }
+    assert context.recalled_memory_used is True
+    # 工具轮 dict 行不随轮存活；最终回答行保留。
+    assert [getattr(row, "type", "") for row in client._conversation_history] \
+        == ["human", "ai"]
+
+
+@pytest.mark.asyncio
+async def test_armed_but_uncalled_tool_creates_no_consent_dependency():
+    """The dependency is the READ, not the arming: an armed turn where the
+    model never calls the tool consumed nothing, so a mid-stream opt-out
+    must not discard its (memory-free) reply. Recording consent at arm
+    time would silently drop innocent replies on every settings flip."""
+    plugin = _tool_plugin()
+    service = _generation_service(plugin)
+    context = _group_context()
+
+    async def _script(client, message):
+        client._conversation_history.append(
+            SimpleNamespace(type="human", content=message)
+        )
+        client._conversation_history.append(
+            SimpleNamespace(type="ai", content="不查记忆也能回")
+        )
+        client.reply_chunks_ref.append("不查记忆也能回")
+        # 生成期间开关被关掉——但本轮没读过任何 scoped 内容。
+        plugin._qq_settings["group_memory_enabled"] = False
+
+    client = _RecallToolClient(_script)
+    reply_chunks: list = []
+    client.reply_chunks_ref = reply_chunks
+    result = await service._run_session_generation(
+        context=context,
+        session_key="group:7788",
+        user_data={"lock": asyncio.Lock()},
+        user_session=client,
+        reply_chunks=reply_chunks,
+    )
+    assert result == "不查记忆也能回"
+    assert [getattr(row, "type", "") for row in client._conversation_history] \
+        == ["human", "ai"]
+    plugin.memory_bridge.query_relevant_memory.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_revocation_after_tool_read_discards_reply_and_tool_rows():
+    """Revoked between the tool read and the end of the stream: the reply
+    was generated FROM the recalled content, so it is discarded — and the
+    rollback must walk PAST the tool-round dict rows (a type=='ai'-only
+    loop stops at the first dict and leaves the recalled text in the
+    shared history, feeding the digest and every later turn)."""
+    plugin = _tool_plugin()
+    service = _generation_service(plugin)
+    context = _group_context()
+
+    async def _script(client, message):
+        result = await client.on_tool_call(_recall_tool_call({"query": "群规"}))
+        client._conversation_history.append(
+            SimpleNamespace(type="human", content=message)
+        )
+        client._conversation_history.extend(
+            _tool_round_rows(result.output_as_json_string())
+        )
+        client._conversation_history.append(
+            SimpleNamespace(type="ai", content="按群规是不剧透哦")
+        )
+        client.reply_chunks_ref.append("按群规是不剧透哦")
+        # ……生成收尾前，管理员把群记忆关掉。
+        plugin._qq_settings["group_memory_enabled"] = False
+
+    client = _RecallToolClient(_script)
+    reply_chunks: list = []
+    client.reply_chunks_ref = reply_chunks
+    user_data = {"lock": asyncio.Lock()}
+    result = await service._run_session_generation(
+        context=context,
+        session_key="group:7788",
+        user_data=user_data,
+        user_session=client,
+        reply_chunks=reply_chunks,
+    )
+    assert not result
+    assert reply_chunks == []
+    # 历史回滚到 history_before + 本轮 human 行（用户自己的发言保留）；
+    # 任何一行都不得再含召回原文。
+    history = client._conversation_history
+    assert [getattr(row, "type", "") for row in history] == ["human"]
+    assert all(
+        "群规是不剧透" not in str(getattr(row, "content", "") or "")
+        and "群规是不剧透" not in json.dumps(row, ensure_ascii=False, default=str)
+        for row in history
+    )
+    assert user_data["current_turn_ai_row"] is None
+
+
+# ---------------------------------------------------------------------------
+# Outbound hygiene (连带 #6) and timeout budget (连带 #7)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pre_tool_text_never_reaches_the_outbound_message():
+    """The model says "我查一下" before calling the tool. That segment is
+    persisted by the client into the assistant tool_calls row (and swept
+    with it) — the QQ message the group receives must contain only the
+    post-tool answer."""
+    plugin = _tool_plugin()
+    service = _generation_service(plugin)
+
+    async def _script(client, message):
+        client.reply_chunks_ref.append("我查一下")
+        result = await client.on_tool_call(_recall_tool_call({"query": "群规"}))
+        client._conversation_history.append(
+            SimpleNamespace(type="human", content=message)
+        )
+        client._conversation_history.extend(
+            _tool_round_rows(result.output_as_json_string())
+        )
+        client._conversation_history.append(
+            SimpleNamespace(type="ai", content="查到了，是不剧透")
+        )
+        client.reply_chunks_ref.append("查到了，是不剧透")
+
+    client = _RecallToolClient(_script)
+    reply_chunks: list = []
+    client.reply_chunks_ref = reply_chunks
+    result = await service._run_session_generation(
+        context=_group_context(),
+        session_key="group:7788",
+        user_data={"lock": asyncio.Lock()},
+        user_session=client,
+        reply_chunks=reply_chunks,
+    )
+    assert result == "查到了，是不剧透"
+    assert "我查一下" not in result
+
+
+@pytest.mark.asyncio
+async def test_tool_turn_timeout_covers_the_whole_tool_loop(monkeypatch):
+    """An armed turn's worst case is two full LLM streams (initial +
+    forced-finalize, max_tool_iterations=1) plus one recall HTTP. Keeping
+    the single-stream budget would turn slow-but-succeeding tool turns
+    into timeouts — and a timeout here discards the whole shared group
+    session."""
+    import plugin.plugins.qq_auto_reply.reply_generation_service as rgs
+
+    captured: list = []
+    original_wait_for = asyncio.wait_for
+
+    async def _capture_wait_for(awaitable, timeout=None):
+        captured.append(timeout)
+        return await original_wait_for(awaitable, timeout=timeout)
+
+    monkeypatch.setattr(rgs.asyncio, "wait_for", _capture_wait_for)
+
+    plugin = _tool_plugin()
+    service = _generation_service(plugin)
+
+    async def _quiet(client, message):
+        client._conversation_history.append(
+            SimpleNamespace(type="human", content=message)
+        )
+
+    await service._run_session_generation(
+        context=_group_context(),
+        session_key="group:7788",
+        user_data={"lock": asyncio.Lock()},
+        user_session=_RecallToolClient(_quiet),
+        reply_chunks=[],
+    )
+    assert captured[0] == 5 * 2 + RECALL_TOOL_HTTP_TIMEOUT_SECONDS
+
+    captured.clear()
+    await service._run_session_generation(
+        context=_group_context(recall_via_tool=False),
+        session_key="group:7788",
+        user_data={"lock": asyncio.Lock()},
+        user_session=_RecallToolClient(_quiet),
+        reply_chunks=[],
+    )
+    assert captured[0] == 5
+
+
+def test_plugin_session_clients_cap_tool_iterations_to_one():
+    """One recall per turn: same budget as the old per-turn synchronous
+    recall, and it bounds the armed-turn worst case the timeout above is
+    sized for. The forced-finalize after the cap still feeds the recall
+    result back, so the read is never wasted."""
+    import inspect
+
+    from plugin.plugins.qq_auto_reply import session_bootstrap_service as sbs
+
+    source = inspect.getsource(sbs)
+    constructions = source.count("OmniOfflineClient(")
+    assert constructions == source.count("max_tool_iterations=1"), (
+        "每个 OmniOfflineClient 构造点都必须显式 max_tool_iterations=1——"
+        "漏掉的那个会话的工具轮最坏耗时是超时预算的 3 倍"
+    )
+    assert constructions >= 2
+
+
+# ---------------------------------------------------------------------------
+# Route capability fallback (连带 #8)
+# ---------------------------------------------------------------------------
+
+
+def test_route_capability_predicate_knows_the_free_proxy():
+    from main_logic.omni_offline_client import route_supports_tool_calls
+
+    assert route_supports_tool_calls(
+        "free-model", "https://www.lanlan.app/text/v1",
+    ) is False
+    assert route_supports_tool_calls(
+        "free-model", "https://lanlan.tech/text/v1",
+    ) is False
+    # 区域改写只动 URL：模型名单独命中也算免费路由。
+    assert route_supports_tool_calls("free-model", "https://example.com/v1") is False
+    assert route_supports_tool_calls(
+        TOOL_CAPABLE_MODEL, TOOL_CAPABLE_BASE_URL,
+    ) is True
+    assert route_supports_tool_calls("", "") is True
+
+
+def _build_stub_plugin(bridge):
+    from tests.unit.test_group_memory_scopes import _default_i18n
+
+    return SimpleNamespace(
+        logger=MagicMock(),
+        _emit_log=lambda *a, **k: None,
+        _qq_settings={
+            "group_memory_enabled": True,
+            "group_member_memory_enabled": True,
+        },
+        i18n=_default_i18n(),
+        permission_mgr=SimpleNamespace(
+            get_user_title=lambda *a, **k: "",
+            get_nickname=lambda *a, **k: None,
+        ),
+        qq_client=SimpleNamespace(needs_attention=False),
+        memory_bridge=bridge,
+        _build_user_title=lambda *a, **k: "",
+        _build_character_card_fields=lambda *a, **k: {},
+        _should_use_memory_context=lambda *a, **k: True,
+        _should_persist_memory=lambda *a, **k: True,
+        _should_skip_direct_llm_fallback_for_images=lambda **kw: False,
+        _fetch_login_status_payload=AsyncMock(return_value={}),
+        _normalize_login_identity=lambda payload: ("online", "10000", "Neko"),
+        _build_qq_session_instructions=AsyncMock(
+            return_value=SimpleNamespace(
+                system_prompt="系统提示词", core_memory_text="",
+                cross_group_section="", cross_session_section="",
+                used_member_subject=False,
+                memory_context_used=False, scene_mode="group_directed",
+            )
+        ),
+        _build_prompt_message=lambda *a, **k: "用户消息",
+    )
+
+
+def _build_config_manager(model, base_url):
+    return SimpleNamespace(
+        get_character_data=lambda: (
+            "Master", "Neko", None, {}, None, {}, None, None, None,
+        ),
+        get_model_api_config=lambda kind: {
+            "model": model, "base_url": base_url, "api_key": "k",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_free_route_falls_back_to_synchronous_recall(monkeypatch):
+    """Providers that silently drop ``tools`` (the free proxy) must keep
+    the pre-generation synchronous recall — flipping them to tool-call
+    mode would zero group memory for those users with no error anywhere."""
+    from plugin.plugins.qq_auto_reply import reply_context_node as rcn
+
+    bridge = _mock_bridge()
+    plugin = _build_stub_plugin(bridge)
+    monkeypatch.setattr(
+        rcn, "get_config_manager",
+        lambda: _build_config_manager(
+            "free-model", "https://www.lanlan.app/text/v1",
+        ),
+    )
+    node = rcn.QQReplyContextNode.__new__(rcn.QQReplyContextNode)
+    node.plugin = plugin
+
+    context = await node.build(
+        message="群规是什么？",
+        permission_level="user",
+        sender_id="2046",
+        is_group=True,
+        group_id="7788",
+        use_memory_context=True,
+    )
+    assert context.recall_via_tool is False
+    bridge.query_relevant_memory.assert_awaited_once()
+    assert "群规是不剧透" in context.recalled_memory_text
+
+    # 回落路径的 consent 复检依旧生效：构建期间已 opt-out 的群不发起召回。
+    bridge.query_relevant_memory.reset_mock()
+    plugin._qq_settings["group_memory_enabled"] = False
+    context = await node.build(
+        message="群规是什么？",
+        permission_level="user",
+        sender_id="2046",
+        is_group=True,
+        group_id="7788",
+        use_memory_context=True,
+    )
+    bridge.query_relevant_memory.assert_not_awaited()
+    assert context.recalled_memory_text == ""
+
+
+@pytest.mark.asyncio
+async def test_tool_capable_route_defers_recall_to_the_model(monkeypatch):
+    from plugin.plugins.qq_auto_reply import reply_context_node as rcn
+
+    bridge = _mock_bridge()
+    plugin = _build_stub_plugin(bridge)
+    monkeypatch.setattr(
+        rcn, "get_config_manager",
+        lambda: _build_config_manager(TOOL_CAPABLE_MODEL, TOOL_CAPABLE_BASE_URL),
+    )
+    node = rcn.QQReplyContextNode.__new__(rcn.QQReplyContextNode)
+    node.plugin = plugin
+
+    context = await node.build(
+        message="群规是什么？",
+        permission_level="user",
+        sender_id="2046",
+        is_group=True,
+        group_id="7788",
+        use_memory_context=True,
+    )
+    assert context.recall_via_tool is True
+    bridge.query_relevant_memory.assert_not_awaited()
+    assert context.recalled_memory_text == ""
+    assert context.recalled_memory_used is False
+
+
+@pytest.mark.asyncio
+async def test_capability_probe_failure_degrades_to_fallback(monkeypatch):
+    """When the route cannot be determined, choose the channel that is
+    KNOWN to work — the synchronous recall."""
+    from plugin.plugins.qq_auto_reply import reply_context_node as rcn
+
+    bridge = _mock_bridge()
+    plugin = _build_stub_plugin(bridge)
+
+    def _boom(kind):
+        raise RuntimeError("config store busy")
+
+    config_manager = SimpleNamespace(
+        get_character_data=lambda: (
+            "Master", "Neko", None, {}, None, {}, None, None, None,
+        ),
+        get_model_api_config=_boom,
+    )
+    monkeypatch.setattr(rcn, "get_config_manager", lambda: config_manager)
+    node = rcn.QQReplyContextNode.__new__(rcn.QQReplyContextNode)
+    node.plugin = plugin
+
+    context = await node.build(
+        message="群规是什么？",
+        permission_level="user",
+        sender_id="2046",
+        is_group=True,
+        group_id="7788",
+        use_memory_context=True,
+    )
+    assert context.recall_via_tool is False
+    bridge.query_relevant_memory.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Bridge: time passthrough
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bridge_forwards_time_spec_and_allows_time_only():
+    bridge = QQMemoryBridge(SimpleNamespace(logger=MagicMock()))
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.json = MagicMock(return_value={"results": [], "elapsed_ms": 1.0})
+    client = MagicMock()
+    client.post = AsyncMock(return_value=response)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(QQMemoryBridge, "_client", staticmethod(lambda: client))
+        await bridge.query_relevant_memory(
+            "Neko", "旅行", subjects=[QQMemoryBridge.group_subject("7788")],
+            time_spec="2026-05",
+        )
+        payload = client.post.await_args.kwargs["json"]
+        assert payload["time"] == "2026-05"
+        assert payload["query"] == "旅行"
+
+        # time-only（纯时间回溯）也要放行。
+        client.post.reset_mock()
+        await bridge.query_relevant_memory(
+            "Neko", "", subjects=[QQMemoryBridge.group_subject("7788")],
+            time_spec="2026-05-01",
+        )
+        payload = client.post.await_args.kwargs["json"]
+        assert payload["time"] == "2026-05-01"
+
+        # 空 subjects 列表照旧 fail-closed，不因带了 time 而放行。
+        client.post.reset_mock()
+        result = await bridge.query_relevant_memory(
+            "Neko", "旅行", subjects=[], time_spec="2026-05",
+        )
+        client.post.assert_not_awaited()
+        assert result.text == ""
+
+
+# ---------------------------------------------------------------------------
+# Shared subject resolver: the two read channels must agree
+# ---------------------------------------------------------------------------
+
+
+def test_fallback_recall_shares_the_subject_resolver():
+    """The fallback recall and the tool handler must authorize identical
+    scopes — enforced by both calling resolve_group_recall_subjects. A
+    re-inlined copy in either path is where the scopes would drift."""
+    import inspect
+
+    from plugin.plugins.qq_auto_reply import memory_tool_service as mts
+    from plugin.plugins.qq_auto_reply import reply_context_node as rcn
+
+    assert "resolve_group_recall_subjects" in inspect.getsource(
+        rcn.QQReplyContextNode._build_recalled_memory_text
+    )
+    assert "resolve_group_recall_subjects" in inspect.getsource(
+        mts.QQMemoryToolService.execute_recall
+    )
+
+    plugin = _tool_plugin()
+    subjects, used_member = resolve_group_recall_subjects(
+        plugin, group_id="7788", memory_sender_id="  2046  ",
+    )
+    assert subjects == [
+        QQMemoryBridge.group_subject("7788"),
+        QQMemoryBridge.group_participant_subject("7788", "2046"),
+    ]
+    assert used_member is True

--- a/tests/unit/test_group_memory_recall_tool.py
+++ b/tests/unit/test_group_memory_recall_tool.py
@@ -555,6 +555,85 @@ async def test_tool_read_records_runtime_consent_for_all_gates():
 
 
 @pytest.mark.asyncio
+async def test_one_turn_executes_at_most_one_recall_http():
+    """max_tool_iterations=1 caps LLM/tool cycles, not calls per cycle: a
+    model can emit several recall_memory calls in one assistant response
+    and each would cost a sequential 5s HTTP — blowing the one-recall
+    assumption the turn timeout is sized for, where the overrun discards
+    the shared group session. The handler latch allows one substantive
+    execution per turn; empty-argument probes (no HTTP anyway) must not
+    burn the turn's only budget."""
+    plugin = _tool_plugin()
+    service = _generation_service(plugin)
+    outputs: list = []
+
+    async def _script(client, message):
+        # 模型在同一个回复里连发：空参试探 + 两个实质查询。
+        for arguments in ({}, {"query": "群规"}, {"query": "再查一次"}):
+            result = await client.on_tool_call(_recall_tool_call(arguments))
+            outputs.append(result.output_as_json_string())
+        client._conversation_history.append(
+            SimpleNamespace(type="human", content=message)
+        )
+        client._conversation_history.append(
+            SimpleNamespace(type="ai", content="回复")
+        )
+
+    client = _RecallToolClient(_script)
+    await service._run_session_generation(
+        context=_group_context(),
+        session_key="group:7788",
+        user_data={"lock": asyncio.Lock()},
+        user_session=client,
+        reply_chunks=[],
+    )
+    plugin.memory_bridge.query_relevant_memory.assert_awaited_once()
+    assert plugin.memory_bridge.query_relevant_memory.await_args.args[1] == "群规"
+    assert "群规是不剧透" in outputs[1]
+    assert "群规是不剧透" not in outputs[2]
+
+
+@pytest.mark.asyncio
+async def test_tool_recall_backfills_the_direct_fallback_text():
+    """The direct fallback sends only context.recalled_memory_text to a
+    bare LLM. When the model actually recalled something this turn, that
+    content must ride along (it still originated from a tool call) — and
+    used_member_subject must flip so a member opt-out strips it from the
+    fallback prompt via the existing sanitizer."""
+    plugin = _tool_plugin()
+    context = _group_context()
+    output, consumed = await plugin.memory_tool_service.execute_recall(
+        context=context, arguments={"query": "群规"},
+    )
+    assert "群规是不剧透" in context.recalled_memory_text
+    assert "长期记忆" in context.recalled_memory_text  # 走统一的包装段
+    assert context.used_member_subject is True
+
+    # 只读到群域（member 关闭）：不得虚标 participant 依赖。
+    plugin = _tool_plugin(settings={
+        "group_memory_enabled": True,
+        "group_member_memory_enabled": False,
+    })
+    context = _group_context()
+    await plugin.memory_tool_service.execute_recall(
+        context=context, arguments={"query": "群规"},
+    )
+    assert "群规是不剧透" in context.recalled_memory_text
+    assert context.used_member_subject is False
+
+    # 零命中：不回填，fallback 维持无召回。
+    plugin = _tool_plugin()
+    plugin.memory_bridge.query_relevant_memory = AsyncMock(
+        return_value=QQMemoryQueryResult(),
+    )
+    context = _group_context()
+    await plugin.memory_tool_service.execute_recall(
+        context=context, arguments={"query": "群规"},
+    )
+    assert context.recalled_memory_text == ""
+
+
+@pytest.mark.asyncio
 async def test_armed_but_uncalled_tool_creates_no_consent_dependency():
     """The dependency is the READ, not the arming: an armed turn where the
     model never calls the tool consumed nothing, so a mid-stream opt-out
@@ -691,8 +770,6 @@ async def test_tool_turn_timeout_covers_the_whole_tool_loop(monkeypatch):
     the single-stream budget would turn slow-but-succeeding tool turns
     into timeouts — and a timeout here discards the whole shared group
     session."""
-    import plugin.plugins.qq_auto_reply.reply_generation_service as rgs
-
     captured: list = []
     original_wait_for = asyncio.wait_for
 
@@ -700,7 +777,8 @@ async def test_tool_turn_timeout_covers_the_whole_tool_loop(monkeypatch):
         captured.append(timeout)
         return await original_wait_for(awaitable, timeout=timeout)
 
-    monkeypatch.setattr(rgs.asyncio, "wait_for", _capture_wait_for)
+    # reply_generation_service 模块内引用的就是全局 asyncio 模块。
+    monkeypatch.setattr(asyncio, "wait_for", _capture_wait_for)
 
     plugin = _tool_plugin()
     service = _generation_service(plugin)
@@ -921,6 +999,128 @@ async def test_capability_probe_failure_degrades_to_fallback(monkeypatch):
     )
     assert context.recall_via_tool is False
     bridge.query_relevant_memory.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Stale-route sessions rebuild onto the current provider
+# ---------------------------------------------------------------------------
+
+
+def test_session_reuse_compares_the_stored_creation_route():
+    """A cached session outliving a provider switch answers on the retired
+    provider indefinitely (busy groups never idle out) — and after a
+    free→tool-capable switch the turn has NO recall channel at all: the
+    context skips the synchronous recall per the new config while the arm
+    step refuses the old client's route. The reuse predicate must compare
+    the CURRENT config route against the route stored at creation time —
+    never the live client's attributes, which a vision turn legitimately
+    switches mid-session."""
+    from plugin.plugins.qq_auto_reply.session_bootstrap_service import (
+        generation_session_is_reusable,
+    )
+
+    free_route = ("https://www.lanlan.app/text/v1", "free-model")
+    new_route = (TOOL_CAPABLE_BASE_URL, TOOL_CAPABLE_MODEL)
+    entry = {
+        "login_self_id": "10000",
+        "her_name": "Neko",
+        "conversation_route": free_route,
+        # 图片轮把 client 合法切到 vision 模型：现值≠创建线路。
+        "session": SimpleNamespace(
+            model="vision-x", base_url="https://vision.example.com/v1",
+        ),
+    }
+    common = dict(login_self_id="10000", her_name="Neko")
+
+    assert generation_session_is_reusable(
+        entry, conversation_route=new_route, **common,
+    ) is False
+    assert generation_session_is_reusable(
+        entry, conversation_route=free_route, **common,
+    ) is True  # 指纹比对用创建线路，vision 切换过的 client 不被误重建
+    # 线路未知（配置读取失败 / 旧条目没存指纹）：跳过比对，不误杀。
+    assert generation_session_is_reusable(
+        entry, conversation_route=None, **common,
+    ) is True
+    legacy_entry = {"login_self_id": "10000", "her_name": "Neko"}
+    assert generation_session_is_reusable(
+        legacy_entry, conversation_route=new_route, **common,
+    ) is True
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_rebuilds_stale_route_session(monkeypatch):
+    from plugin.plugins.qq_auto_reply import session_bootstrap_service as sbs
+
+    new_route = (TOOL_CAPABLE_BASE_URL, TOOL_CAPABLE_MODEL)
+    built = []
+
+    class _StubClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.base_url = kwargs.get("base_url")
+            self.model = kwargs.get("model")
+            built.append(self)
+
+        async def connect(self, instructions=""):
+            return None
+
+    monkeypatch.setattr(sbs, "OmniOfflineClient", _StubClient)
+    monkeypatch.setattr(
+        sbs, "get_config_manager",
+        lambda: SimpleNamespace(
+            aensure_region_resolved=AsyncMock(),
+            get_model_api_config=lambda kind: {
+                "base_url": new_route[0], "model": new_route[1], "api_key": "k",
+            },
+        ),
+    )
+
+    stale_entry = {
+        "login_self_id": "10000",
+        "her_name": "Neko",
+        "conversation_route": ("https://www.lanlan.app/text/v1", "free-model"),
+        "session": SimpleNamespace(model="free-model"),
+    }
+    discard = AsyncMock(side_effect=lambda key, reason: (
+        plugin._user_sessions.pop(key, None) is not None
+    ))
+    plugin = SimpleNamespace(
+        _user_sessions={"group:7788": stale_entry},
+        _ai_connect_timeout_seconds=5,
+        logger=MagicMock(),
+        session_runtime_service=SimpleNamespace(discard_session=discard),
+    )
+    context = SimpleNamespace(
+        ephemeral_session=False,
+        login_self_id="10000",
+        her_name="Neko",
+        system_prompt="系统提示词",
+        character_card_fields={},
+        persist_memory=True,
+        memory_context_used=False,
+        sender_id="2046",
+        permission_level="user",
+        is_group=True,
+        group_id="7788",
+        user_title="群友",
+        user_nickname=None,
+        login_status="online",
+        login_nickname="Neko",
+    )
+    service = sbs.QQSessionBootstrapService(plugin)
+    created = await service.ensure_generation_session(context, "group:7788")
+    # 旧线路会话被结算丢弃，新会话建在当前线路上、存了新指纹。
+    discard.assert_awaited_once()
+    assert created is not stale_entry
+    assert created["conversation_route"] == new_route
+    assert built and built[-1].base_url == new_route[0]
+
+    # 线路一致的下一轮：原样复用，不再重建。
+    discard.reset_mock()
+    reused = await service.ensure_generation_session(context, "group:7788")
+    assert reused is created
+    discard.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_group_memory_recall_tool.py
+++ b/tests/unit/test_group_memory_recall_tool.py
@@ -242,7 +242,7 @@ async def test_participant_subject_gating_matches_write_side():
     # the participant scope too.
     plugin._qq_settings["group_member_memory_enabled"] = False
     plugin.memory_bridge.query_relevant_memory.reset_mock()
-    output, consumed = await plugin.memory_tool_service.execute_recall(
+    _, consumed = await plugin.memory_tool_service.execute_recall(
         context=_group_context(), arguments={"query": "群规"},
     )
     kwargs = plugin.memory_bridge.query_relevant_memory.await_args.kwargs
@@ -602,7 +602,7 @@ async def test_tool_recall_backfills_the_direct_fallback_text():
     fallback prompt via the existing sanitizer."""
     plugin = _tool_plugin()
     context = _group_context()
-    output, consumed = await plugin.memory_tool_service.execute_recall(
+    await plugin.memory_tool_service.execute_recall(
         context=context, arguments={"query": "群规"},
     )
     assert "群规是不剧透" in context.recalled_memory_text
@@ -846,6 +846,37 @@ def test_route_capability_predicate_knows_the_free_proxy():
         TOOL_CAPABLE_MODEL, TOOL_CAPABLE_BASE_URL,
     ) is True
     assert route_supports_tool_calls("", "") is True
+    # 免费域按 host 判，不是子串：路径/查询串里提到 lanlan.* 的自配端点
+    # 不是免费代理（与 voice registry 的免费路由判法同口径）。
+    assert route_supports_tool_calls(
+        TOOL_CAPABLE_MODEL, "https://custom.example/v1/lanlan.tech",
+    ) is True
+    assert route_supports_tool_calls(
+        TOOL_CAPABLE_MODEL, "https://api.lanlan.app/v1",
+    ) is False
+
+
+@pytest.mark.asyncio
+async def test_recall_header_counts_entries_not_lines():
+    """A single multiline reflection must not inflate the header into
+    "found N memories": entries are counted by their rendered "N. "
+    prefixes, never by newline characters."""
+    from config.prompts.prompts_memory import RECALL_MEMORY_TOOL_FOUND_HEADER
+    from config.prompts.prompts_sys import _loc
+
+    plugin = _tool_plugin()
+    plugin.memory_bridge.query_relevant_memory = AsyncMock(
+        return_value=QQMemoryQueryResult(
+            text="1. [事实] 第一行\n第二行\n第三行", hit_count=1,
+        ),
+    )
+    output, _ = await plugin.memory_tool_service.execute_recall(
+        context=_group_context(), arguments={"query": "群规"},
+    )
+    lang = plugin.memory_tool_service._short_lang()
+    assert output.startswith(
+        _loc(RECALL_MEMORY_TOOL_FOUND_HEADER, lang).format(n=1)
+    )
 
 
 def _build_stub_plugin(bridge):

--- a/tests/unit/test_group_memory_recall_tool.py
+++ b/tests/unit/test_group_memory_recall_tool.py
@@ -728,10 +728,10 @@ async def test_revocation_after_tool_read_discards_reply_and_tool_rows():
 
 @pytest.mark.asyncio
 async def test_pre_tool_text_never_reaches_the_outbound_message():
-    """The model says "我查一下" before calling the tool. That segment is
-    persisted by the client into the assistant tool_calls row (and swept
-    with it) — the QQ message the group receives must contain only the
-    post-tool answer."""
+    """The model announces a lookup ("let me check") before calling the
+    tool. That segment is persisted by the client into the assistant
+    tool_calls row (and swept with it) — the QQ message the group
+    receives must contain only the post-tool answer."""
     plugin = _tool_plugin()
     service = _generation_service(plugin)
 

--- a/tests/unit/test_group_memory_scopes.py
+++ b/tests/unit/test_group_memory_scopes.py
@@ -541,6 +541,11 @@ async def test_qq_private_bootstrap_keeps_legacy_behavior():
 
 @pytest.mark.asyncio
 async def test_qq_group_recall_passes_group_and_member_subjects():
+    """Fallback recall channel (routes that silently drop ``tools``, i.e.
+    the free proxy): the pre-generation synchronous recall must authorize
+    exactly the group (+ participant) scopes. Tool-capable routes recall
+    via the recall_memory tool instead — the two channels share the
+    subject resolver, covered in test_group_memory_recall_tool.py."""
     from plugin.plugins.qq_auto_reply.memory_bridge import (
         QQMemoryBridge,
         QQMemoryQueryResult,
@@ -643,6 +648,8 @@ async def test_qq_group_recall_passes_group_and_member_subjects():
 
 @pytest.mark.asyncio
 async def test_qq_group_recall_omits_phantom_member_for_empty_sender():
+    """Fallback recall channel: an empty sender must not fabricate a
+    phantom participant subject (the tool channel shares the resolver)."""
     from plugin.plugins.qq_auto_reply.memory_bridge import (
         QQMemoryBridge,
         QQMemoryQueryResult,
@@ -4214,10 +4221,12 @@ def test_generation_strips_scoped_sections_when_group_revoked():
 
 @pytest.mark.asyncio
 async def test_recall_reports_participant_usage_to_caller():
-    """The recall reports whether it actually queried the participant
-    subject, and build() ORs that into the context flag — binding the flag
-    to a nonempty bootstrap section would miss the empty-bootstrap +
-    participant-hit combination."""
+    """Fallback recall channel: the recall reports whether it actually
+    queried the participant subject, and build() ORs that into the
+    context flag — binding the flag to a nonempty bootstrap section would
+    miss the empty-bootstrap + participant-hit combination. (On the tool
+    channel the equivalent record is the handler's runtime consent
+    entry, covered in test_group_memory_recall_tool.py.)"""
     import inspect
 
     from plugin.plugins.qq_auto_reply.memory_bridge import QQMemoryQueryResult
@@ -4284,10 +4293,12 @@ async def test_recall_reports_participant_usage_to_caller():
 
 
 def test_sanitizer_drops_recall_when_member_revoked_without_bootstrap():
-    """Participant authorization must be tracked from the recall itself:
-    an empty scoped bootstrap (no core-memory section) with a participant
-    recall hit still has to lose that recall when member memory is
-    revoked before generation."""
+    """Fallback recall channel: participant authorization must be tracked
+    from the recall itself — an empty scoped bootstrap (no core-memory
+    section) with a participant recall hit still has to lose that recall
+    when member memory is revoked before generation. (The tool channel
+    has no pre-composed recall section; its dual is the in-handler
+    entry/post-fetch gate pair.)"""
     from plugin.plugins.qq_auto_reply.reply_generation_service import (
         QQReplyGenerationService,
     )
@@ -4322,7 +4333,10 @@ def test_sanitizer_drops_recall_when_member_revoked_without_bootstrap():
 async def test_generation_recheck_wiring_drops_scoped_prompt():
     """Wiring guard for the generation-time recheck: the stripped prompt
     and the emptied recall must actually reach _apply_turn_memory_context
-    (a correct helper nobody calls is dead code)."""
+    (a correct helper nobody calls is dead code). The recalled-text leg
+    only exists on the fallback recall channel — tool-channel turns carry
+    an empty recalled_memory_text and rely on the runtime consent record
+    instead."""
     from plugin.plugins.qq_auto_reply.reply_generation_service import (
         QQReplyGenerationService,
     )
@@ -4475,7 +4489,10 @@ async def test_delivered_fallback_reply_enters_shared_history():
 async def test_generation_discards_reply_when_consent_revoked_mid_stream():
     """The model already saw the scoped prompt; if the switch goes off
     while streaming, the reply still carries that content — it must be
-    discarded rather than delivered."""
+    discarded rather than delivered. This drives the prompt-section
+    (fallback-channel) dependency shape; the tool channel's runtime-record
+    twin — including rolling back THROUGH tool-round dict rows — lives in
+    test_group_memory_recall_tool.py."""
     from plugin.plugins.qq_auto_reply.reply_generation_service import (
         QQReplyGenerationService,
     )
@@ -5395,7 +5412,10 @@ async def test_scoped_reads_recheck_live_policy_before_fetch():
     (login fetch, first memory call) while the admin opts the group out:
     both scoped read points must recheck the live setting immediately
     before fetching — persistence is already re-gated at prime time, reads
-    must not inject scoped context into a reply after opt-out."""
+    must not inject scoped context into a reply after opt-out. The recall
+    leg here is the fallback channel; the tool channel's read-point
+    rechecks live inside the handler (entry + post-fetch), covered in
+    test_group_memory_recall_tool.py."""
     from plugin.plugins.qq_auto_reply.reply_context_node import (
         QQReplyContextNode,
     )
@@ -6976,7 +6996,9 @@ def test_persona_view_authorizes_scoped_entries_per_entry():
 async def test_fallback_reply_dropped_when_consent_revoked_during_call(monkeypatch):
     """The direct fallback sanitizes once, then awaits an LLM for up to a
     minute: a switch turned off during that call leaves the returned text
-    carrying memory the user just revoked."""
+    carrying memory the user just revoked. (Tool-channel turns reach this
+    path with an empty recalled_memory_text — their dependency, if any,
+    was already unioned into context.consent_snapshot by the handler.)"""
     import plugin.plugins.qq_auto_reply.reply_generation_service as rgs
 
     plugin = SimpleNamespace(


### PR DESCRIPTION
## 目标

群记忆系列第三个 PR。按既定要求：**/query_memory 不允许每轮自动召回，只允许 tool call 调用**——不加本地判定门，由模型自己决定何时查记忆。

QQ 插件此前每轮无条件发起混合检索（BM25 + cosine + RRF），命中段拼在 system prompt 末尾。本 PR 之后：

- **线路支持 tool call**：按轮给共享会话 client 挂 `recall_memory` 工具（schema 与本体一致：只有 `query` / `time`），模型自主决定何时调用；构建期不再同步召回。
- **线路不支持 tool call**（lanlan 免费代理只暴露 OpenAI-compat、会静默丢 `tools`）：回落到原来的构建期同步召回，行为与现状完全一致。判定新增 core 层 `route_supports_tool_calls()`（main_logic/omni_offline_client/_genai_support.py）；国内免费线路的 tool 支持无文档，一并按不支持处理——回落路径至少确定生效。

客户端能力零新增：走的就是 `OmniOfflineClient` 现成的 `set_tools` / `set_tool_call_handler` / 多轮 tool 循环 / ToolLeakFilter / forced-finalize。QQ 路径只是从来没调过 `set_tools`。

## 六条连带（拆开做会留下不安全的中间状态）

1. **handler 按轮重指向**：群会话全群共享一个 client，participant subject 随发言人变。`_arm_recall_tool` 在会话锁内按本轮 context 重建闭包并挂载，finally 对偶卸载（`set_tools(None)` + handler 置空）——同一 client 上的 proactive 等其他路径绝不会带着上一轮的 subject 闭包召回。挂载校验的是**会话 client 冻结的线路**而非当前配置（缓存会话可能跨过一次线路切换）。
2. **subjects 绝不进 schema**：schema 只有 `query`/`time`；subjects 由 `execute_recall` 从 context 推导（群 → group_subject + 可选 participant；私聊 admin → 省略 = legacy 语料）。模型给的任何参数都影响不了 subjects——服务端把「省略 subjects」定义为 legacy 私聊主人语料，照搬本体实现等于把主人私聊记忆泄进群里。subject 组装与回落路径共用 `resolve_group_recall_subjects`（含 member 开关读点复检、sender 规范化、合成轮过滤）。
3. **consent 判据改运行时记录**：召回内容不再在建 prompt 时就位，「prompt 里有没有那段字」的判据失效。handler 在**真的把 scoped 内容交给模型时**记录依赖的开关（群域 / participant 域），写进本轮 `consent_before`（生成结束的撤销比对）并 union 进 `context.consent_snapshot`（发送前与 buffer 撤销闸复用现有机制，无需改动下游）。只挂载没调用、或调用了零命中：不记依赖，中途关开关不误伤无记忆回复。
4. **撤销闸下沉进 handler**：入口复检（模型决定调用与真正执行之间被撤销 → 一行不读）+ HTTP 返回后复检（opt-out 落在飞行期间 → 结果整体丢弃，不交给模型），对偶原回落路径的读前/读后复检。
5. **历史回滚穿过 tool 行**：撤销回滚的 pop 循环扩展到 tool 轮的裸 dict 行（assistant tool_calls / role=tool）；并且 finally 里**无条件**把本轮 tool dict 行从共享历史清掉——召回原文是按 consent 域临时授权给本轮的，与旧管线「prompt 注入 + restore」同语义，绝不进 digest、不进后续轮次上下文。模型引用了召回结论的最终 ai 行照常保留。
6. **pre-tool 文本不外发**：handler 边界清 `reply_chunks`——「我查一下」之类的 pre-tool 段不会出现在发到群里的消息里（该段由客户端持久化进 assistant tool_calls 行，随第 5 条一并清理）。
7. **超时预算重定**：插件会话 `max_tool_iterations=1`（一轮一次召回，与旧的每轮召回同预算；封顶后 forced-finalize 摘掉 tools 逼出最终文本，召回结果不白拿）。挂载了工具的轮把 `wait_for` 超时扩为 `2×单流 + 召回 HTTP(5s)`——这条路径超时的代价不是丢一轮，是丢弃整个共享群会话再打粘性标记，不能让「慢但会成功」的工具轮撞上单流预算。同时因 cap=1 摘掉了「放宽条件再查一次」的零命中提示（工具预算已用完，提示模型做做不到的事只会逼出空头承诺）。
8. **provider 降级兜底**：见上文回落设计。判定失败（配置读不到等）也按回落处理。

顺带：config/prompts/prompts_chara.py:121 角色卡里「should call the recall_memory tool FIRST」这条指示在 tool-capable 线路上自然成立了（工具名、query/time 语义均对得上）；免费线路维持现状（与本体同样的既有状况）。

## 回归报告

**改了什么、为什么**：如上。核心动机是用户明确要求召回改为模型自主 tool call，不接受任何「每轮都召回」或「本地门判定」。

**改动前后行为**：
- 免费线路（free-model / lanlan.app / lanlan.tech）：行为不变（每轮同步召回，全部既有 consent 闸原样生效）。
- 自配线路：构建期不再发召回 HTTP；模型按需调用 `recall_memory`（每轮至多一次），结果以 tool result 形式进上下文、轮末从共享历史清除。私聊 admin 轮同样改走工具（legacy 语料，与本体 handler 行为一致）。
- 群共享历史在任何路径下都不会残留 tool 轮 dict 行；digest / 成员轮收集 / 未投递打标的既有索引语义不受影响（清理发生在 finally 内、所有读点之前）。

**潜在回归与缓解**：
- 模型不调用工具 → 该轮无召回。这正是需求本身（模型决定），角色卡已有明确的调用指示。
- 缓存会话跨线路切换：复用判据现在比对「创建时存的 conversation_route」与当前配置（review 首轮 Greptile P1 的修复），线路切换后的缓存会话下一轮走既有 discard（含集中抢救）+ 重建，召回通道随即一致；比对创建期指纹而非 client 现值，vision 切换不误伤。挂载点按 client 线路复核的兜底保留，错配窗口收敛到「同一轮内配置恰好变更」。
- 工具轮超时扩到 ~125s（默认配置）：仅影响真的进入工具轮且极慢的轮次；换来的是共享群会话不被误杀。
- `main_logic` 侧仅新增只读判定函数与 export，一处行为都没改。

**一处有意的冗余**（诚实说明）：撤销回滚 pop 循环的 dict 行扩展，在今天所有可达的行序下都被 finally 的无条件清理兜住（ai 行永远在 dict 行之上）。留着它是防未来出现「ai 行在 dict 行之下」的排布；测试钉的是不变量（回滚后无任何行含召回原文、长度回到 history_before+human），不是机制。

## 测试与变异验证

- 新增 `tests/unit/test_group_memory_recall_tool.py`（24 条）：两发言人连续发言的 handler 重指向（本 PR 最易错点）、schema 结构 + 模型参数影响不了 subjects 的行为断言、入口/读后双撤销、tool dict 行回滚与常规轮清理、pre-tool 文本不外发、免费线路回落（含回落 consent 复检）、挂载不产生依赖、超时扩容、iterations cap、bridge time 透传、双通道共用 subject 解析器。
- 既有 12 条相关测试重新框定为**回落通道**守卫（行为断言原样保留，docstring 指明 tool 通道的对偶测试位置）。
- **变异验证 20/20 全部被杀死**（git archive 隔离副本逐一实验）：handler 冻结、subjects 透传、入口/读后闸移除、consent 不记/记进副本/挂载即记、reply_chunks 不清、finally 清理移除、线路判定恒真、双通道双跑、schema 混入 subjects、构造点漏 cap、bridge 丢 time、group_id fail-closed 移除、合成轮过滤移除等。
- `tests/unit` 受影响集 485 passed；`plugin/tests` 独立进程 2752 passed（一次 galgame 无关用例 flake，重跑与单跑均绿，干净 main 上同套件也绿）。
- docstring 禁 CJK 门 `--base origin/main` 通过。

## Review 轮次追加（三家 bot 意见的处理）

- **一轮一次召回闸**（Codex）：handler 闭包内 latch——`max_tool_iterations=1` 只限轮数不限单轮内 call 数，多发 call 会击穿超时预算；空参试探不烧额度。
- **fallback 召回回填**（Codex）：模型真调过工具且有命中的轮，把召回块回填 `context.recalled_memory_text` 并置位 `used_member_subject`，direct fallback 经既有 consent 闸拿到同一份召回；没调用的轮 fallback 维持无召回（内容始终来自 tool call）。
- **免费域按 hostname 判**、**召回 header 按条目前缀计数**（Codex 二轮）。
- 反驳未采纳两条：Codex「任意自配模型可能拒绝/忽略 tools」（与主程序共享配置，主程序的 recall_memory 早已无条件注册，非本 PR 新增暴露面；静默忽略远程不可探测）；Greptile「consent 残留丢弃干净 fallback」（origin/main 同场景同结果，union-True 是既定 fail-closed 设计）。
- 追加变异验证 7/7 杀死（指纹比对移除/改比 client 现值/不存指纹/闸移除/空参烧额度/不回填/不置位 member 标志）。

## 后续 PR 的接口预留

「批抽取 + 读侧多 subject」要改的就是 `execute_recall` 里这一次 `query_relevant_memory` 调用：subjects 列表已是宿主侧单点组装（`resolve_group_recall_subjects`），一次带 1 群 + 4 成员只需扩这个解析器，schema / handler / consent 记录形状均不用动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
