### PR TITLE
优化模型设置与语音控制 UI，将主动搭话和隐私模式改为滑块；完善麦克风与屏幕分享快捷按钮、入场动画及状态同步；重做分享开关蓝色波纹与星光效…

### DIFF
--- a/static/app/app-audio-capture.js
+++ b/static/app/app-audio-capture.js
@@ -398,6 +398,12 @@
 
         async function handleToggleClick(event) {
             event.stopPropagation();
+            var startPending = typeof window.isScreenSharingStartPending === 'function'
+                && window.isScreenSharingStartPending();
+            if (startPending && typeof window.stopScreenSharing === 'function') {
+                await window.stopScreenSharing();
+                return;
+            }
             if (button._nekoShareBusy) return;
             var active = isScreenShareActive();
             console.log('[屏幕共享开关] 点击, 当前状态:', active ? '共享中' : '未共享', ', 语音会话:', !!window.isRecording);

--- a/static/app/app-audio-capture.js
+++ b/static/app/app-audio-capture.js
@@ -396,20 +396,53 @@
             }
         };
 
+        var shareToggleOperationGeneration = 0;
+
+        function setShareToggleBusy(busy) {
+            button._nekoShareBusy = busy;
+            if (busy) {
+                button.classList.add('is-busy');
+                button.setAttribute('aria-busy', 'true');
+            } else {
+                button.classList.remove('is-busy');
+                button.setAttribute('aria-busy', 'false');
+            }
+        }
+
+        function finishShareToggleOperation(generation) {
+            // A cancelled browser picker can settle after a replacement start.
+            // Its old finally must not clear the replacement operation's state.
+            if (shareToggleOperationGeneration !== generation) return;
+            setShareToggleBusy(false);
+            syncShareToggleButtons(false);
+        }
+
         async function handleToggleClick(event) {
             event.stopPropagation();
             var startPending = typeof window.isScreenSharingStartPending === 'function'
                 && window.isScreenSharingStartPending();
             if (startPending && typeof window.stopScreenSharing === 'function') {
-                await window.stopScreenSharing();
+                if (button._nekoShareCancelBusy) return;
+                var cancelGeneration = ++shareToggleOperationGeneration;
+                button._nekoShareCancelBusy = true;
+                setShareToggleBusy(true);
+                try {
+                    await window.stopScreenSharing();
+                } catch (e) {
+                    console.warn('[屏幕共享开关] 取消待处理启动失败:', e);
+                } finally {
+                    if (shareToggleOperationGeneration === cancelGeneration) {
+                        button._nekoShareCancelBusy = false;
+                    }
+                    finishShareToggleOperation(cancelGeneration);
+                }
                 return;
             }
             if (button._nekoShareBusy) return;
             var active = isScreenShareActive();
             console.log('[屏幕共享开关] 点击, 当前状态:', active ? '共享中' : '未共享', ', 语音会话:', !!window.isRecording);
-            button._nekoShareBusy = true;
-            button.classList.add('is-busy');
-            button.setAttribute('aria-busy', 'true');
+            var operationGeneration = ++shareToggleOperationGeneration;
+            setShareToggleBusy(true);
             try {
                 if (active && typeof window.stopScreenSharing === 'function') {
                     await window.stopScreenSharing();
@@ -431,10 +464,7 @@
                     await window.startScreenSharing();
                 }
             } finally {
-                button._nekoShareBusy = false;
-                button.classList.remove('is-busy');
-                button.setAttribute('aria-busy', 'false');
-                syncShareToggleButtons(false);
+                finishShareToggleOperation(operationGeneration);
             }
         }
 

--- a/static/app/app-audio-capture.js
+++ b/static/app/app-audio-capture.js
@@ -161,7 +161,7 @@
 
     // ======================== 屏幕共享开关按钮（设置面板内嵌） ========================
     // 开关按钮从屏幕源子窗口底部移到「屏幕共享」与「选择麦克风」两个设置项中间；
-    // 启用时播放像素扫过动画（参考视频按钮的像素填充效果）。
+    // 启用时由滑块起点扩散蓝色波面，填满后浮出少量四角星光。
     // 共享状态以隐藏的 #screenButton 的 .active class 为准（见 common_ui.js）。
 
     var shareToggleButtonRegistry = [];
@@ -179,196 +179,150 @@
         style.id = 'neko-share-toggle-styles';
         style.textContent = [
             // 未启用：白色胶囊轨道（仿参考视频）
-            '.neko-share-toggle-btn{position:relative;overflow:hidden;width:100%;box-sizing:border-box;min-height:44px;padding:10px 48px;margin:4px 0 6px;border:1px solid rgba(0,0,0,.07);border-radius:999px;background:#f4f4f7;color:var(--neko-popup-text,#333);cursor:pointer;font-size:14px;font-weight:600;pointer-events:auto;transition:color .2s ease,box-shadow .2s ease,transform .1s ease;}',
+            '.neko-share-toggle-btn{position:relative;isolation:isolate;overflow:visible;width:100%;box-sizing:border-box;min-height:44px;padding:10px 48px;margin:4px 0 6px;border:1px solid rgba(0,0,0,.07);border-radius:999px;background:#f4f4f7;color:var(--neko-popup-text,#333);cursor:pointer;font-size:14px;font-weight:600;pointer-events:auto;transition:color .2s ease,box-shadow .2s ease,transform .1s ease;--neko-share-wave-x:20px;--neko-share-wave-radius:148%;}',
             '.neko-share-toggle-btn:hover{box-shadow:inset 0 0 0 1px rgba(0,0,0,.05);}',
+            '.neko-share-toggle-btn:focus-visible{outline:2px solid var(--neko-popup-accent,#44b7fe);outline-offset:2px;}',
             '.neko-share-toggle-btn:active{transform:scale(.97);}',
             '.neko-share-toggle-btn:disabled{opacity:.6;cursor:default;}',
             // 未开语音会话时点击的抖动提示（明确反馈「点到了但不能用」）
             '@keyframes nekoShareToggleNudge{0%,100%{transform:translateX(0);}25%{transform:translateX(-3px);}75%{transform:translateX(3px);}}',
             '.neko-share-toggle-btn.is-nudged{animation:nekoShareToggleNudge .12s ease 2;}',
             '.neko-share-toggle-btn.is-active{color:#fff;}',
-            // 右端的紫色目标点
-            '.neko-share-toggle-btn .neko-share-toggle-goal{position:absolute;z-index:0;top:50%;right:16px;width:6px;height:6px;margin-top:-3px;border-radius:50%;background:#8a5ce8;pointer-events:none;}',
+            // 蓝色波面：以未开启时滑块中心为圆心，向外扩散并填满整个胶囊。
+            '.neko-share-toggle-btn .neko-share-toggle-wave{position:absolute;inset:0;z-index:0;border-radius:inherit;background:linear-gradient(105deg,#61ccff 0%,#44b7fe 52%,#269fe8 100%);clip-path:circle(0 at var(--neko-share-wave-x) 50%);pointer-events:none;transition:clip-path .64s cubic-bezier(.4,0,.2,1);}',
+            '.neko-share-toggle-btn.is-active .neko-share-toggle-wave{clip-path:circle(var(--neko-share-wave-radius) at var(--neko-share-wave-x) 50%);}',
             '.neko-share-toggle-btn .neko-share-toggle-label{position:relative;z-index:1;display:block;text-align:center;pointer-events:none;transition:color .2s ease;}',
-            // 文字延迟变白：等像素填充波前扫到中部再切换，避免白字落在白轨道上
-            '.neko-share-toggle-btn.is-active .neko-share-toggle-label{transition:color .3s ease .35s;}',
-            // 白色滑块：默认在左端，启用后滑到右端（始终盖在像素层之上）
-            '.neko-share-toggle-btn .neko-share-toggle-knob{position:absolute;z-index:2;top:4px;bottom:4px;left:4px;width:32px;border-radius:10px;background:#fff;box-shadow:0 1px 3px rgba(0,0,0,.18);pointer-events:none;transition:left .4s ease;}',
+            '.neko-share-toggle-btn.is-active .neko-share-toggle-label{transition:color .2s ease .16s;}',
+            // 白色滑块：默认在左端，启用后滑到右端。
+            '.neko-share-toggle-btn .neko-share-toggle-knob{position:absolute;z-index:3;top:4px;bottom:4px;left:4px;width:32px;border-radius:10px;background:#fff;box-shadow:0 1px 3px rgba(0,0,0,.18);pointer-events:none;transition:left .46s cubic-bezier(.4,0,.2,1);}',
             '.neko-share-toggle-btn.is-active .neko-share-toggle-knob{left:calc(100% - 36px);}',
-            // 像素填充画布：低分辨率画布经 CSS 放大 + pixelated，呈现马赛克块感
-            '.neko-share-toggle-btn canvas.neko-share-toggle-fill{position:absolute;inset:0;z-index:0;width:100%;height:100%;pointer-events:none;opacity:0;transition:opacity .12s linear;image-rendering:pixelated;}',
-            '.neko-share-toggle-btn.is-active canvas.neko-share-toggle-fill{opacity:1;}',
+            // 四角星光：波面填满后从背景中向上浮出，SVG 轮廓参考产品给定的星型。
+            '.neko-share-toggle-btn .neko-share-toggle-sparkles{position:absolute;inset:0;z-index:2;overflow:visible;pointer-events:none;}',
+            '.neko-share-toggle-btn .neko-share-toggle-spark{position:absolute;left:var(--neko-spark-x);bottom:var(--neko-spark-y);width:var(--neko-spark-size);height:var(--neko-spark-size);opacity:0;pointer-events:none;}',
+            '.neko-share-toggle-btn .neko-share-toggle-spark svg{display:block;width:100%;height:100%;overflow:visible;}',
+            '@keyframes nekoShareSparkRise{0%{opacity:0;transform:translate3d(0,4px,0) scale(.2) rotate(0deg);}18%{opacity:1;}68%{opacity:.92;}100%{opacity:0;transform:translate3d(var(--neko-spark-drift),var(--neko-spark-rise),0) scale(.92) rotate(18deg);}}',
+            '.neko-share-toggle-btn.is-sparkling .neko-share-toggle-spark{animation:nekoShareSparkRise var(--neko-spark-duration) cubic-bezier(.16,.8,.25,1) var(--neko-spark-delay) both;}',
             // 迷你版：嵌在「屏幕共享」设置行右侧的行内胶囊开关（未开启为灰色轨道 + 白色旋钮）
-            '.neko-share-toggle-btn.neko-share-toggle-mini{display:inline-block;width:64px;min-height:26px;height:26px;padding:0;margin:0;flex-shrink:0;align-self:center;cursor:pointer;background:#e2e2e8;border-color:rgba(0,0,0,.05);}',
+            '.neko-share-toggle-btn.neko-share-toggle-mini{display:inline-block;width:64px;min-height:26px;height:26px;padding:0;margin:0;flex-shrink:0;align-self:center;cursor:pointer;background:#e2e2e8;border-color:rgba(0,0,0,.05);--neko-share-wave-x:12px;--neko-share-wave-radius:116%;}',
             '.neko-share-toggle-mini .neko-share-toggle-label{display:none;}',
             '.neko-share-toggle-mini .neko-share-toggle-knob{width:18px;top:3px;bottom:3px;left:3px;border-radius:7px;}',
             '.neko-share-toggle-mini.is-active .neko-share-toggle-knob{left:calc(100% - 21px);}',
-            '.neko-share-toggle-mini .neko-share-toggle-goal{right:8px;width:5px;height:5px;margin-top:-2.5px;}',
+            '.neko-share-toggle-btn.is-instant .neko-share-toggle-wave,.neko-share-toggle-btn.is-instant .neko-share-toggle-label,.neko-share-toggle-btn.is-instant .neko-share-toggle-knob{transition:none!important;}',
+            '@media (prefers-reduced-motion:reduce){.neko-share-toggle-btn .neko-share-toggle-wave,.neko-share-toggle-btn .neko-share-toggle-label,.neko-share-toggle-btn .neko-share-toggle-knob{transition:none!important;}.neko-share-toggle-btn.is-sparkling .neko-share-toggle-spark{animation:none!important;}}',
             '.neko-share-toggle-btn.is-busy{opacity:.6;cursor:default;}'
         ].join('\n');
         document.head.appendChild(style);
     }
 
-    // ---- 像素溶解引擎：仿参考视频的随机马赛克扫过效果 ----
-    // 色板以中深紫为主，浅紫仅作零星高光（与参考视频一致）
-    var SHARE_PIXEL_PALETTE = ['#8a5ce8', '#8f63ec', '#9772f0', '#9772f0', '#a181f5', '#a181f5', '#b79fff', '#cdbdff'];
-    var SHARE_PIXEL_CELL_PX = 3;      // 每个像素块的 CSS 尺寸
-    var SHARE_PIXEL_JITTER = 0.2;     // 填充前沿的随机抖动幅度（产生锯齿边缘与前置散点）
-    var SHARE_PIXEL_FADE = 0.15;      // 前沿软过渡宽度（像素透明度渐显，形成渐变边）
-    var SHARE_PIXEL_MIN_ALPHA = 0.3;  // 左端最终透明度上限（形成视频的浅紫渐变尾）
-    var SHARE_PIXEL_FILL_MS = 1300;   // 启用扫过时长
-    var SHARE_PIXEL_SHIMMER_MS = 100; // 填满后像素闪烁间隔
+    var SHARE_WAVE_FILL_MS = 640;
+    var SHARE_SPARKLE_LIFETIME_MS = 1200;
+    var SHARE_SPARKLE_CONFIGS = [
+        { x: '8%', y: '4px', size: '8px', drift: '-4px', rise: '-21px', delay: '0ms', duration: '760ms' },
+        { x: '28%', y: '10px', size: '6px', drift: '1px', rise: '-28px', delay: '110ms', duration: '800ms' },
+        { x: '48%', y: '3px', size: '10px', drift: '-2px', rise: '-24px', delay: '40ms', duration: '820ms' },
+        { x: '68%', y: '7px', size: '7px', drift: '3px', rise: '-30px', delay: '150ms', duration: '780ms' },
+        { x: '88%', y: '4px', size: '9px', drift: '1px', rise: '-22px', delay: '80ms', duration: '840ms' }
+    ];
 
-    function createSharePixelFx(canvas) {
-        var ctx = canvas.getContext('2d');
-        var cols = 0;
-        var rows = 0;
-        var seeds = null;   // 前沿抖动随机数
-        var tints = null;   // 每格颜色索引
-        var spans = null;   // 少量格子画成 2x2，模拟视频里大小不一的块
-        var progress = 0;
-        var rafId = null;
-        var shimmerTimer = null;
+    function createShareSparkleLayer() {
+        var layer = document.createElement('span');
+        layer.className = 'neko-share-toggle-sparkles';
+        layer.setAttribute('aria-hidden', 'true');
 
-        function resize() {
-            var host = canvas.parentElement;
-            var w = host ? host.clientWidth : 0;
-            var h = host ? host.clientHeight : 0;
-            var nextCols = Math.max(1, Math.round(w / SHARE_PIXEL_CELL_PX));
-            var nextRows = Math.max(1, Math.round(h / SHARE_PIXEL_CELL_PX));
-            if (nextCols === cols && nextRows === rows && seeds) return;
-            cols = nextCols;
-            rows = nextRows;
-            canvas.width = cols;
-            canvas.height = rows;
-            var count = cols * rows;
-            seeds = new Float32Array(count);
-            tints = new Uint8Array(count);
-            spans = new Uint8Array(count);
-            for (var i = 0; i < count; i++) {
-                seeds[i] = Math.random();
-                tints[i] = (Math.random() * SHARE_PIXEL_PALETTE.length) | 0;
-                spans[i] = Math.random() < 0.12 ? 1 : 0;
+        SHARE_SPARKLE_CONFIGS.forEach(function (config) {
+            var sparkle = document.createElement('span');
+            sparkle.className = 'neko-share-toggle-spark';
+            sparkle.style.setProperty('--neko-spark-x', config.x);
+            sparkle.style.setProperty('--neko-spark-y', config.y);
+            sparkle.style.setProperty('--neko-spark-size', config.size);
+            sparkle.style.setProperty('--neko-spark-drift', config.drift);
+            sparkle.style.setProperty('--neko-spark-rise', config.rise);
+            sparkle.style.setProperty('--neko-spark-delay', config.delay);
+            sparkle.style.setProperty('--neko-spark-duration', config.duration);
+
+            var svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+            svg.setAttribute('viewBox', '0 0 24 24');
+            var path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+            path.setAttribute('d', 'M12 1.5C13.6 7.9 16.1 10.4 22.5 12C16.1 13.6 13.6 16.1 12 22.5C10.4 16.1 7.9 13.6 1.5 12C7.9 10.4 10.4 7.9 12 1.5Z');
+            path.setAttribute('fill', 'rgba(255,255,255,0.96)');
+            path.setAttribute('stroke', '#00aeef');
+            path.setAttribute('stroke-width', '0.9');
+            path.setAttribute('stroke-linejoin', 'round');
+            path.setAttribute('vector-effect', 'non-scaling-stroke');
+            svg.appendChild(path);
+            sparkle.appendChild(svg);
+            layer.appendChild(sparkle);
+        });
+
+        return layer;
+    }
+
+    function createShareWaveFx(button) {
+        var sparkleStartTimer = null;
+        var sparkleCleanupTimer = null;
+
+        function prefersReducedMotion() {
+            return typeof window.matchMedia === 'function'
+                && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        }
+
+        function stopSparkles() {
+            if (sparkleStartTimer) { clearTimeout(sparkleStartTimer); sparkleStartTimer = null; }
+            if (sparkleCleanupTimer) { clearTimeout(sparkleCleanupTimer); sparkleCleanupTimer = null; }
+            button.classList.remove('is-sparkling');
+        }
+
+        function startSparkles() {
+            sparkleStartTimer = null;
+            if (!button.isConnected || !button._nekoShareActive || prefersReducedMotion()) return;
+            button.classList.remove('is-sparkling');
+            void button.offsetWidth;
+            button.classList.add('is-sparkling');
+            sparkleCleanupTimer = setTimeout(function () {
+                sparkleCleanupTimer = null;
+                button.classList.remove('is-sparkling');
+            }, SHARE_SPARKLE_LIFETIME_MS);
+        }
+
+        function setActiveClass(active, instant) {
+            if (instant) button.classList.add('is-instant');
+            button.classList.toggle('is-active', active);
+            if (instant) {
+                void button.offsetWidth;
+                button.classList.remove('is-instant');
             }
-        }
-
-        function draw() {
-            resize();
-            ctx.clearRect(0, 0, cols, rows);
-            if (progress <= 0) return;
-            var spread = 1 - SHARE_PIXEL_JITTER;
-            for (var y = 0; y < rows; y++) {
-                for (var x = 0; x < cols; x++) {
-                    var i = y * cols + x;
-                    var xNorm = cols <= 1 ? 1 : x / (cols - 1);
-                    // 从右向左推进；阈值叠加随机抖动形成不规则前沿
-                    var threshold = (1 - xNorm) * spread + seeds[i] * SHARE_PIXEL_JITTER;
-                    // 前沿软过渡：刚越线的像素半透明，逐渐加深（视频的渐变边）
-                    var fade = (progress - threshold) / SHARE_PIXEL_FADE;
-                    if (fade > 0) {
-                        var alpha = fade >= 1 ? 1 : fade;
-                        // 越靠左透明度越低，填满后左端保留浅紫渐变尾
-                        alpha *= SHARE_PIXEL_MIN_ALPHA + (1 - SHARE_PIXEL_MIN_ALPHA) * xNorm;
-                        ctx.globalAlpha = alpha;
-                        ctx.fillStyle = SHARE_PIXEL_PALETTE[tints[i]];
-                        var big = spans[i];
-                        ctx.fillRect(x, y, big ? 2 : 1, big ? 2 : 1);
-                    }
-                }
-            }
-            ctx.globalAlpha = 1;
-        }
-
-        function stopShimmer() {
-            if (shimmerTimer) { clearInterval(shimmerTimer); shimmerTimer = null; }
-        }
-
-        function startShimmer() {
-            stopShimmer();
-            // 闪烁点随机出现，但整体沿一个从右向左移动的波前依次点亮（仿参考视频）
-            var sweepX = cols - 1;
-            var band = Math.max(2, Math.round(cols * 0.15));
-            shimmerTimer = setInterval(function () {
-                if (!canvas.isConnected) { stopShimmer(); return; }
-                // 随机改写少量格子的色阶，形成填满后的闪烁感（位置集中在波前附近）
-                var twinkles = Math.max(1, Math.round(cols * rows * 0.025));
-                for (var n = 0; n < twinkles; n++) {
-                    var x = sweepX + ((Math.random() * band) | 0);
-                    if (x >= cols) x = cols - 1;
-                    var y = (Math.random() * rows) | 0;
-                    var i = y * cols + x;
-                    tints[i] = (Math.random() * SHARE_PIXEL_PALETTE.length) | 0;
-                }
-                draw();
-                sweepX -= Math.max(1, Math.round(cols * 0.12));
-                if (sweepX < 0) sweepX = cols - 1;
-            }, SHARE_PIXEL_SHIMMER_MS);
-        }
-
-        function cancelAnimation() {
-            if (rafId) { cancelAnimationFrame(rafId); rafId = null; }
-        }
-
-        function animateTo(target, done) {
-            cancelAnimation();
-            var from = progress;
-            var distance = Math.abs(target - from);
-            if (distance <= 0) { if (done) done(); return; }
-            var duration = SHARE_PIXEL_FILL_MS * distance;
-            var startTime = null;
-            function frame(now) {
-                if (!canvas.isConnected) { rafId = null; return; }
-                if (startTime === null) startTime = now;
-                var t = Math.min(1, (now - startTime) / duration);
-                progress = from + (target - from) * t;
-                draw();
-                if (t < 1) {
-                    rafId = requestAnimationFrame(frame);
-                } else {
-                    rafId = null;
-                    if (done) done();
-                }
-            }
-            rafId = requestAnimationFrame(frame);
         }
 
         return {
             activate: function (instant) {
-                resize();
-                stopShimmer();
-                if (instant) {
-                    cancelAnimation();
-                    progress = 1;
-                    draw();
-                    startShimmer();
-                } else {
-                    animateTo(1, startShimmer);
+                stopSparkles();
+                setActiveClass(true, instant);
+                if (!instant && !prefersReducedMotion()) {
+                    sparkleStartTimer = setTimeout(startSparkles, SHARE_WAVE_FILL_MS);
                 }
             },
-            deactivate: function (instant, done) {
-                stopShimmer();
-                if (instant) {
-                    cancelAnimation();
-                    progress = 0;
-                    draw();
-                    if (done) done();
-                } else {
-                    animateTo(0, done);
-                }
+            deactivate: function (instant) {
+                stopSparkles();
+                setActiveClass(false, instant);
             },
-            // 已处于开启状态时再次点击：从头重播一次开启扫过动画
-            replay: function () {
-                resize();
-                stopShimmer();
-                progress = 0;
-                draw();
-                animateTo(1, startShimmer);
-            }
+            cleanup: stopSparkles
         };
     }
 
+    function pruneShareToggleButtons() {
+        var connectedButtons = [];
+        shareToggleButtonRegistry.forEach(function (btn) {
+            if (btn.isConnected) {
+                connectedButtons.push(btn);
+            } else if (typeof btn._nekoShareFxCleanup === 'function') {
+                btn._nekoShareFxCleanup();
+            }
+        });
+        shareToggleButtonRegistry = connectedButtons;
+    }
+
     function syncShareToggleButtons(instant) {
-        shareToggleButtonRegistry = shareToggleButtonRegistry.filter(function (btn) { return btn.isConnected; });
+        pruneShareToggleButtons();
         var active = isScreenShareActive();
         shareToggleButtonRegistry.forEach(function (btn) {
             if (typeof btn._nekoSetShareActive === 'function') btn._nekoSetShareActive(active, !!instant);
@@ -401,46 +355,44 @@
         button.className = 'neko-share-toggle-btn' + (mini ? ' neko-share-toggle-mini' : '');
         button.setAttribute('role', 'button');
         button.setAttribute('tabindex', '0');
+        button.setAttribute('aria-busy', 'false');
         button.dataset.nekoScreenShareAction = 'toggle';
 
-        var fill = document.createElement('canvas');
-        fill.className = 'neko-share-toggle-fill';
-        fill.setAttribute('aria-hidden', 'true');
-
-        var goal = document.createElement('span');
-        goal.className = 'neko-share-toggle-goal';
-        goal.setAttribute('aria-hidden', 'true');
+        var wave = document.createElement('span');
+        wave.className = 'neko-share-toggle-wave';
+        wave.setAttribute('aria-hidden', 'true');
 
         var label = document.createElement('span');
         label.className = 'neko-share-toggle-label';
+
+        var sparkles = createShareSparkleLayer();
 
         var knob = document.createElement('span');
         knob.className = 'neko-share-toggle-knob';
         knob.setAttribute('aria-hidden', 'true');
 
-        button.appendChild(fill);
-        button.appendChild(goal);
+        button.appendChild(wave);
         button.appendChild(label);
+        button.appendChild(sparkles);
         button.appendChild(knob);
 
         function shareLabel() { return window.t ? window.t('buttons.screenShare') : 'Screen Share'; }
         function stopLabel() { return window.t ? window.t('voiceControl.stopShare') : 'Stop Sharing'; }
 
-        var pixelFx = createSharePixelFx(fill);
+        var waveFx = createShareWaveFx(button);
+        button._nekoShareFxCleanup = waveFx.cleanup;
         button._nekoSetShareActive = function (active, instant) {
-            label.textContent = active ? stopLabel() : shareLabel();
+            var accessibleLabel = active ? stopLabel() : shareLabel();
+            label.textContent = accessibleLabel;
+            button.title = accessibleLabel;
+            button.setAttribute('aria-label', accessibleLabel);
             button.setAttribute('aria-pressed', active ? 'true' : 'false');
             if (button._nekoShareActive === active) return;
             button._nekoShareActive = active;
             if (active) {
-                button.classList.add('is-active');
-                pixelFx.activate(!!instant);
+                waveFx.activate(!!instant);
             } else {
-                // 反向溶解期间保持画布可见，结束后再隐藏
-                pixelFx.deactivate(!!instant, function () {
-                    if (!button._nekoShareActive) button.classList.remove('is-active');
-                });
-                if (instant) button.classList.remove('is-active');
+                waveFx.deactivate(!!instant);
             }
         };
 
@@ -449,12 +401,9 @@
             if (button._nekoShareBusy) return;
             var active = isScreenShareActive();
             console.log('[屏幕共享开关] 点击, 当前状态:', active ? '共享中' : '未共享', ', 语音会话:', !!window.isRecording);
-            if (active) {
-                // 开启状态下每次点击都重播一次开启时的像素扫过动画
-                pixelFx.replay();
-            }
             button._nekoShareBusy = true;
             button.classList.add('is-busy');
+            button.setAttribute('aria-busy', 'true');
             try {
                 if (active && typeof window.stopScreenSharing === 'function') {
                     await window.stopScreenSharing();
@@ -478,6 +427,7 @@
             } finally {
                 button._nekoShareBusy = false;
                 button.classList.remove('is-busy');
+                button.setAttribute('aria-busy', 'false');
                 syncShareToggleButtons(false);
             }
         }
@@ -490,7 +440,7 @@
             }
         });
 
-        shareToggleButtonRegistry = shareToggleButtonRegistry.filter(function (btn) { return btn.isConnected; });
+        pruneShareToggleButtons();
         shareToggleButtonRegistry.push(button);
         // 每次重新显示（弹窗重渲染）时，若共享处于开启状态则重播一次开启动画；未开启则直接落位
         button._nekoSetShareActive(isScreenShareActive(), !isScreenShareActive());
@@ -3129,13 +3079,15 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
 
                 var titleWrap = document.createElement('div');
                 Object.assign(titleWrap.style, { display: 'flex', alignItems: 'center', gap: '6px', minWidth: '0', color: '#4f8cff', fontSize: '13px', fontWeight: '600' });
-                var icon = document.createElement('span');
-                icon.textContent = iconText;
-                icon.style.fontSize = '14px';
                 var titleEl = document.createElement('span');
                 titleEl.textContent = title;
                 Object.assign(titleEl.style, { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' });
-                titleWrap.appendChild(icon);
+                if (iconText) {
+                    var icon = document.createElement('span');
+                    icon.textContent = iconText;
+                    icon.style.fontSize = '14px';
+                    titleWrap.appendChild(icon);
+                }
                 titleWrap.appendChild(titleEl);
 
                 var closeBtn = document.createElement('button');
@@ -3203,10 +3155,8 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
                     textAlign: 'left',
                     transition: 'background 0.2s ease'
                 });
-                var icon = document.createElement('span');
-                icon.textContent = iconText;
-                icon.style.fontSize = '15px';
                 var textWrap = document.createElement('span');
+                textWrap.className = 'neko-mic-action-text';
                 Object.assign(textWrap.style, { display: 'flex', flexDirection: 'column', minWidth: '0', width: '0', maxWidth: '100%', flex: '1 1 0%', overflow: 'hidden' });
                 var labelEl = document.createElement('span');
                 labelEl.textContent = label;
@@ -3226,7 +3176,12 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
                 });
                 textWrap.appendChild(labelEl);
                 if (subLabel) textWrap.appendChild(subEl);
-                button.appendChild(icon);
+                if (iconText) {
+                    var icon = document.createElement('span');
+                    icon.textContent = iconText;
+                    icon.style.fontSize = '15px';
+                    button.appendChild(icon);
+                }
                 button.appendChild(textWrap);
                 button.appendChild(arrow);
 
@@ -3281,7 +3236,7 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
             async function openMicDeviceSubwindow() {
                 var panel = createMicSubwindow(
                     window.t ? window.t('microphone.deviceTitle') : 'Select Microphone',
-                    '\uD83C\uDFA4',
+                    null,
                     '280px'
                 );
                 panel.classList.add('neko-mic-device-subwindow');
@@ -3328,7 +3283,7 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
             async function openScreenSourceSubwindow() {
                 var panel = createMicSubwindow(
                     window.t ? window.t('buttons.screenShare') : 'Screen Share',
-                    '\uD83D\uDDA5\uFE0F',
+                    null,
                     '360px'
                 );
                 var panelBody = panel._nekoMicSubwindowBody || panel;
@@ -3365,7 +3320,7 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
                 return !!(toggle && toggle.matches(':hover'));
             }
             var screenActionButton = createMainActionButton(
-                '\uD83D\uDDA5\uFE0F',
+                null,
                 screenButtonLabel,
                 window.t ? window.t('app.screenSource.screens') : 'Screens',
                 'screen',
@@ -3380,14 +3335,14 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
             screenActionButton.replaceChild(shareToggleButton, screenActionButton.lastChild);
             // 屏幕共享行：标题允许换行显示（去掉省略号截断），
             // 保证葡语 "Compartilhamento de tela"、俄语 "Демонстрация экрана" 等长文案也能完整显示
-            var screenTextWrap = screenActionButton.children[1];
+            var screenTextWrap = screenActionButton.querySelector('.neko-mic-action-text');
             if (screenTextWrap && screenTextWrap.firstChild) {
                 screenTextWrap.firstChild.style.whiteSpace = 'normal';
                 screenTextWrap.firstChild.style.lineHeight = '1.2';
                 screenTextWrap.firstChild.style.overflow = 'visible';
             }
             var micActionButton = createMainActionButton(
-                '\uD83C\uDFA4',
+                null,
                 deviceButtonLabel,
                 currentMicLabel,
                 'device',

--- a/static/app/app-screen.js
+++ b/static/app/app-screen.js
@@ -972,25 +972,81 @@
     mod.getMobileCameraStream = getMobileCameraStream;
 
     // ======================== startScreenSharing ========================
-    // 所有入口共享同一个启动 Promise，避免授权弹窗未返回时重复创建捕获流。
-    var screenSharingStartPromise = null;
-    async function startScreenSharing() {
-        if (screenSharingStartPromise) {
-            return screenSharingStartPromise;
+    // 所有入口共享同一次启动尝试，避免授权弹窗未返回时重复创建捕获流。
+    // attempt 上的 cancelled 标记让“停止”可以否决尚未返回的系统授权弹窗；
+    // getDisplayMedia 本身不可中断，因此晚到的流会在返回后立即释放。
+    var screenSharingStartAttempt = null;
+
+    function isScreenSharingStartPending() {
+        return !!screenSharingStartAttempt;
+    }
+    mod.isScreenSharingStartPending = isScreenSharingStartPending;
+
+    function rememberScreenSharingAttemptStream(attempt, stream) {
+        if (attempt && stream && stream !== attempt.initialStream) {
+            attempt.acquiredStream = stream;
+        }
+        return stream;
+    }
+
+    function discardCancelledScreenSharingStart(attempt) {
+        if (!attempt || !attempt.cancelled) {
+            return false;
         }
 
-        var pendingStart = startScreenSharingOnce();
-        screenSharingStartPromise = pendingStart;
+        var stream = attempt.acquiredStream;
+        if (stream && stream !== attempt.initialStream) {
+            try {
+                var videoTrack = stream.getVideoTracks && stream.getVideoTracks()[0];
+                if (videoTrack) videoTrack.onended = null;
+                if (typeof stream.getTracks === 'function') {
+                    stream.getTracks().forEach(function (track) {
+                        try { track.stop(); } catch (e) { }
+                    });
+                }
+            } catch (e) {
+                console.warn(
+                    safeT('console.screenShareStopTracksFailed', '屏幕共享停止轨道失败'),
+                    e
+                );
+            }
+
+            if (S.screenCaptureStream === stream) {
+                S.screenCaptureStream = attempt.initialStream || null;
+                S.screenCaptureStreamLastUsed = null;
+                if (S.screenCaptureStreamIdleTimer) {
+                    clearTimeout(S.screenCaptureStreamIdleTimer);
+                    S.screenCaptureStreamIdleTimer = null;
+                }
+            }
+            attempt.acquiredStream = null;
+        }
+        return true;
+    }
+
+    async function startScreenSharing() {
+        if (screenSharingStartAttempt) {
+            return screenSharingStartAttempt.promise;
+        }
+
+        var attempt = {
+            cancelled: false,
+            initialStream: S.screenCaptureStream,
+            acquiredStream: null,
+            promise: null
+        };
+        attempt.promise = startScreenSharingOnce(attempt);
+        screenSharingStartAttempt = attempt;
         try {
-            return await pendingStart;
+            return await attempt.promise;
         } finally {
-            if (screenSharingStartPromise === pendingStart) {
-                screenSharingStartPromise = null;
+            if (screenSharingStartAttempt === attempt) {
+                screenSharingStartAttempt = null;
             }
         }
     }
 
-    async function startScreenSharingOnce() {
+    async function startScreenSharingOnce(attempt) {
         // 检查是否在录音状态
         if (!S.isRecording) {
             window.showStatusToast(window.t ? window.t('app.micRequired') : '请先开启麦克风录音！', 3000);
@@ -999,9 +1055,14 @@
 
         try {
             var nativeCapture = null;
+            // Capture into a local reference first. A cancelled browser picker may
+            // return after proactive vision has already installed another stream;
+            // it must never overwrite that newer global stream.
+            var captureStream = attempt.initialStream;
 
             // 初始化音频播放上下文
             if (window.showCurrentModel) await window.showCurrentModel(); // 智能显示当前模型
+            if (discardCancelledScreenSharingStart(attempt)) return;
             if (!S.audioPlayerContext) {
                 S.audioPlayerContext = new (window.AudioContext || window.webkitAudioContext)();
                 window.syncAudioGlobals();
@@ -1010,14 +1071,15 @@
             // 如果上下文被暂停，则恢复它
             if (S.audioPlayerContext.state === 'suspended') {
                 await S.audioPlayerContext.resume();
+                if (discardCancelledScreenSharingStart(attempt)) return;
             }
 
-            if (S.screenCaptureStream == null) {
+            if (captureStream == null) {
                 if (isMobile()) {
                     // 移动端使用摄像头
                     var tmp = await getMobileCameraStream();
                     if (tmp instanceof MediaStream) {
-                        S.screenCaptureStream = tmp;
+                        captureStream = rememberScreenSharingAttemptStream(attempt, tmp);
                     } else {
                         // 保持原有错误处理路径：让 catch 去接手
                         throw (tmp instanceof Error ? tmp : new Error('无法获取摄像头流'));
@@ -1042,6 +1104,7 @@
                         } catch (initialSourceError) {
                             console.warn('[屏幕源] 无法取得原生默认屏幕源:', initialSourceError);
                         }
+                        if (discardCancelledScreenSharingStart(attempt)) return;
                     }
 
                     if (selectedSourceId && desktopProvider
@@ -1079,6 +1142,7 @@
                         } catch (validateErr) {
                             console.warn('[屏幕源] 验证源可用性失败，继续尝试使用保存的源:', validateErr);
                         }
+                        if (discardCancelledScreenSharingStart(attempt)) return;
                     }
 
                     if (selectedSourceId && isNativeFrameProvider(desktopProvider)) {
@@ -1090,7 +1154,7 @@
                     } else if (selectedSourceId && desktopProvider) {
                         // Electron uses the selected Chromium desktop source.
                         try {
-                            S.screenCaptureStream = await navigator.mediaDevices.getUserMedia({
+                            captureStream = rememberScreenSharingAttemptStream(attempt, await navigator.mediaDevices.getUserMedia({
                                 audio: false,
                                 video: {
                                     mandatory: {
@@ -1099,8 +1163,9 @@
                                         maxFrameRate: 1
                                     }
                                 }
-                            });
+                            }));
                         } catch (captureErr) {
+                            if (discardCancelledScreenSharingStart(attempt)) return;
                             console.warn('[屏幕源] 指定源捕获失败，尝试回退:', captureErr);
                             var fallbackSucceeded = false;
 
@@ -1110,8 +1175,9 @@
                                     types: ['screen'],
                                     thumbnailSize: { width: 1, height: 1 }
                                 });
+                                if (discardCancelledScreenSharingStart(attempt)) return;
                                 if (fallbackSources.length > 0) {
-                                    S.screenCaptureStream = await navigator.mediaDevices.getUserMedia({
+                                    captureStream = rememberScreenSharingAttemptStream(attempt, await navigator.mediaDevices.getUserMedia({
                                         audio: false,
                                         video: {
                                             mandatory: {
@@ -1120,7 +1186,7 @@
                                                 maxFrameRate: 1
                                             }
                                         }
-                                    });
+                                    }));
                                     S.selectedScreenSourceId = fallbackSources[0].id;
                                     try { localStorage.setItem('selectedScreenSourceId', fallbackSources[0].id); } catch (e) { }
                                     pushSelectedSourceToMain(fallbackSources[0].id);
@@ -1136,12 +1202,13 @@
 
                             // 回退策略2: chromeMediaSource 在该系统上完全不可用，降级到 getDisplayMedia
                             if (!fallbackSucceeded) {
+                                if (discardCancelledScreenSharingStart(attempt)) return;
                                 try {
                                     console.log('[屏幕源] chromeMediaSource 不可用，降级到 getDisplayMedia');
-                                    S.screenCaptureStream = await navigator.mediaDevices.getDisplayMedia({
+                                    captureStream = rememberScreenSharingAttemptStream(attempt, await navigator.mediaDevices.getDisplayMedia({
                                         video: { cursor: 'always', frameRate: 1 },
                                         audio: false,
-                                    });
+                                    }));
                                     S.selectedScreenSourceId = null;
                                     try { localStorage.removeItem('selectedScreenSourceId'); } catch (e) { }
                                     pushSelectedSourceToMain(null);
@@ -1155,20 +1222,21 @@
                                 console.warn('[屏幕源] 所有前端流方式均失败，将尝试后端轮询兜底');
                             }
                         }
-                        if (S.screenCaptureStream) {
+                        if (captureStream) {
                             console.log(window.t('console.screenShareUsingSource'), selectedSourceId);
                         }
                     } else if (!isNativeFrameProvider(desktopProvider)) {
                         // 使用标准的getDisplayMedia（显示系统选择器）
                         try {
-                            S.screenCaptureStream = await navigator.mediaDevices.getDisplayMedia({
+                            captureStream = rememberScreenSharingAttemptStream(attempt, await navigator.mediaDevices.getDisplayMedia({
                                 video: {
                                     cursor: 'always',
                                     frameRate: 1,
                                 },
                                 audio: false,
-                            });
+                            }));
                         } catch (displayErr) {
+                            if (discardCancelledScreenSharingStart(attempt)) return;
                             // 用户主动取消则直接抛出，不兜底
                             if (displayErr.name === 'NotAllowedError') throw displayErr;
                             console.warn('[屏幕源] getDisplayMedia 失败，将尝试后端轮询兜底:', displayErr);
@@ -1177,16 +1245,25 @@
                 }
             }
 
+            if (discardCancelledScreenSharingStart(attempt)) return;
+            if (captureStream !== attempt.initialStream) {
+                S.screenCaptureStream = captureStream;
+            }
+
             if (nativeCapture) {
                 var nativeStreamStarted = await startNativeScreenStreaming(
                     nativeCapture.provider,
                     nativeCapture.sourceId,
                     'screen'
                 );
+                if (discardCancelledScreenSharingStart(attempt)) {
+                    stopScreening();
+                    return;
+                }
                 if (!nativeStreamStarted) {
                     return;
                 }
-            } else if (S.screenCaptureStream) {
+            } else if (captureStream) {
                 // 用户手势成功获取了流，重置自动弹窗失败标记
                 S.screenCaptureAutoPromptFailed = false;
                 // 正常流模式
@@ -1197,6 +1274,7 @@
                 if (await stopLiveVisionStreamIfBlocked(streamInputType)) {
                     return;
                 }
+                if (discardCancelledScreenSharingStart(attempt)) return;
                 startScreenVideoStreaming(S.screenCaptureStream, streamInputType);
 
                 // 当用户停止共享屏幕时
@@ -1221,6 +1299,7 @@
             } else {
                 // 回退策略3: 后端 pyautogui 轮询模式（所有前端流方式均失败）
                 var result = await fetchBackendScreenshot();
+                if (discardCancelledScreenSharingStart(attempt)) return;
                 var backendTest = result.dataUrl;
                 if (!backendTest) {
                     throw new Error(
@@ -1231,6 +1310,7 @@
                 if (await stopLiveVisionStreamIfBlocked('screen')) {
                     return;
                 }
+                if (discardCancelledScreenSharingStart(attempt)) return;
                 console.log('[屏幕源] 进入后端 pyautogui 轮询模式');
 
                 // 立即发送第一帧
@@ -1253,6 +1333,11 @@
                         console.warn('[屏幕源] 后端轮询帧失败:', e);
                     }
                 }, 1000);
+            }
+
+            if (discardCancelledScreenSharingStart(attempt)) {
+                stopScreening();
+                return;
             }
 
             micButton().disabled = true;
@@ -1280,6 +1365,7 @@
 
             if (!S.isRecording) window.showStatusToast(window.t ? window.t('app.micNotOpen') : '没开麦啊喂！', 3000);
         } catch (err) {
+            if (discardCancelledScreenSharingStart(attempt)) return;
             console.error(isMobile() ? window.t('console.cameraAccessFailed') : window.t('console.screenShareFailed'), err);
             console.error(window.t('console.startupFailed'), err);
             var hint = '';
@@ -1317,6 +1403,9 @@
      * @param {boolean} forceRelease - 是否强制释放流。false时若主动视觉仍活跃则保留缓存流。
      */
     async function stopScreenSharing(forceRelease) {
+        if (screenSharingStartAttempt) {
+            screenSharingStartAttempt.cancelled = true;
+        }
         stopScreening();
 
         // 判断主动视觉是否活跃
@@ -1379,7 +1468,9 @@
 
     // ======================== switchScreenSharing ========================
     window.switchScreenSharing = async function () {
-        if (stopButton().disabled) {
+        if (isScreenSharingStartPending()) {
+            await stopScreenSharing();
+        } else if (stopButton().disabled) {
             // 检查是否在录音状态
             if (!S.isRecording) {
                 window.showStatusToast(window.t ? window.t('app.micRequired') : '请先开启麦克风录音！', 3000);
@@ -1963,6 +2054,7 @@
     // ======================== Backward-compat window exports ========================
     window.startScreenSharing = startScreenSharing;
     window.stopScreenSharing = stopScreenSharing;
+    window.isScreenSharingStartPending = isScreenSharingStartPending;
     window.selectScreenSource = selectScreenSource;
     window.getScreenSourceDisplayName = getScreenSourceDisplayName;
     window.captureCanvasFrame = captureCanvasFrame;

--- a/static/app/app-screen.js
+++ b/static/app/app-screen.js
@@ -659,12 +659,22 @@
     // ======================== syncFloatingScreenButtonState ========================
     function syncFloatingScreenButtonState(isActive) {
         // 更新所有存在的 manager 的按钮状态
-        var managers = [window.live2dManager, window.vrmManager, window.mmdManager];
+        var managers = [window.live2dManager, window.vrmManager, window.mmdManager, window.pngtuberManager];
 
         for (var i = 0; i < managers.length; i++) {
             var manager = managers[i];
-            if (manager && manager._floatingButtons && manager._floatingButtons.screen) {
-                var ref = manager._floatingButtons.screen;
+            if (!manager || !manager._floatingButtons) continue;
+            var screenRef = manager._floatingButtons.screen;
+            var quickRef = manager._floatingButtons['screen-share-quick'];
+            if (!screenRef && !quickRef) continue;
+
+            if (typeof manager.setButtonActive === 'function') {
+                manager.setButtonActive('screen', isActive);
+                continue;
+            }
+
+            if (screenRef) {
+                var ref = screenRef;
                 var button = ref.button;
                 var imgOff = ref.imgOff;
                 var imgOn = ref.imgOn;
@@ -678,6 +688,9 @@
                         manager.updateSeparatePopupTriggerIcon('screen');
                     }
                 }
+            }
+            if (quickRef && typeof quickRef.updateState === 'function') {
+                quickRef.updateState(isActive);
             }
         }
     }
@@ -959,7 +972,25 @@
     mod.getMobileCameraStream = getMobileCameraStream;
 
     // ======================== startScreenSharing ========================
+    // 所有入口共享同一个启动 Promise，避免授权弹窗未返回时重复创建捕获流。
+    var screenSharingStartPromise = null;
     async function startScreenSharing() {
+        if (screenSharingStartPromise) {
+            return screenSharingStartPromise;
+        }
+
+        var pendingStart = startScreenSharingOnce();
+        screenSharingStartPromise = pendingStart;
+        try {
+            return await pendingStart;
+        } finally {
+            if (screenSharingStartPromise === pendingStart) {
+                screenSharingStartPromise = null;
+            }
+        }
+    }
+
+    async function startScreenSharingOnce() {
         // 检查是否在录音状态
         if (!S.isRecording) {
             window.showStatusToast(window.t ? window.t('app.micRequired') : '请先开启麦克风录音！', 3000);

--- a/static/app/app-screen.js
+++ b/static/app/app-screen.js
@@ -780,8 +780,15 @@
 
     // ======================== startScreenVideoStreaming ========================
     function startScreenVideoStreaming(stream, input_type) {
+        var generation = nativeCaptureGeneration;
+
+        function isCurrentStream() {
+            return generation === nativeCaptureGeneration
+                && stream === S.screenCaptureStream;
+        }
+
         // 更新最后使用时间并调度闲置检查
-        if (stream === S.screenCaptureStream) {
+        if (isCurrentStream()) {
             S.screenCaptureStreamLastUsed = Date.now();
             scheduleScreenCaptureIdleCheck();
         }
@@ -795,9 +802,11 @@
 
         // 定时抓取当前帧并编码为jpeg（使用统一的 captureCanvasFrame）
         video.play().then(async function () {
+            if (!isCurrentStream()) return;
             if (await stopLiveVisionStreamIfBlocked(input_type)) {
                 return;
             }
+            if (!isCurrentStream()) return;
             if (video.videoWidth && video.videoHeight) {
                 var vw = video.videoWidth, vh = video.videoHeight;
                 if (vw > C.MAX_SCREENSHOT_WIDTH || vh > C.MAX_SCREENSHOT_HEIGHT) {
@@ -806,20 +815,33 @@
                 }
             }
 
-            S.videoSenderInterval = setInterval(async function () {
+            var senderInterval = setInterval(async function () {
+                if (!isCurrentStream()) {
+                    clearInterval(senderInterval);
+                    if (S.videoSenderInterval === senderInterval) {
+                        S.videoSenderInterval = null;
+                    }
+                    return;
+                }
                 if (await stopLiveVisionStreamIfBlocked(input_type)) {
                     return;
                 }
+                if (!isCurrentStream()) return;
                 var frame = captureCanvasFrame(video, 0.8);
                 if (frame && frame.dataUrl && S.socket && S.socket.readyState === WebSocket.OPEN) {
                     S.socket.send(JSON.stringify(buildStreamDataMessage(frame.dataUrl, input_type)));
 
                     // 刷新最后使用时间，防止活跃屏幕分享被误释放
-                    if (stream === S.screenCaptureStream) {
+                    if (isCurrentStream()) {
                         S.screenCaptureStreamLastUsed = Date.now();
                     }
                 }
             }, 1000);
+            if (!isCurrentStream()) {
+                clearInterval(senderInterval);
+                return;
+            }
+            S.videoSenderInterval = senderInterval;
         }); // 每1000ms一帧
     }
     mod.startScreenVideoStreaming = startScreenVideoStreaming;
@@ -978,9 +1000,26 @@
     var screenSharingStartAttempt = null;
 
     function isScreenSharingStartPending() {
-        return !!screenSharingStartAttempt;
+        return !!screenSharingStartAttempt && !screenSharingStartAttempt.cancelled;
     }
     mod.isScreenSharingStartPending = isScreenSharingStartPending;
+
+    function cancelPendingScreenSharingStart() {
+        var attempt = screenSharingStartAttempt;
+        if (!attempt) return false;
+
+        attempt.cancelled = true;
+        // If acquisition already completed but activation is still awaiting a
+        // guard, release that attempt's stream before another start can reuse it.
+        discardCancelledScreenSharingStart(attempt);
+        // Detach immediately so the user can retry without waiting for an
+        // already-open browser chooser that JavaScript cannot dismiss.
+        if (screenSharingStartAttempt === attempt) {
+            screenSharingStartAttempt = null;
+        }
+        return true;
+    }
+    mod.cancelPendingScreenSharingStart = cancelPendingScreenSharingStart;
 
     function rememberScreenSharingAttemptStream(attempt, stream) {
         if (attempt && stream && stream !== attempt.initialStream) {
@@ -1025,8 +1064,13 @@
     }
 
     async function startScreenSharing() {
-        if (screenSharingStartAttempt) {
+        if (isScreenSharingStartPending()) {
             return screenSharingStartAttempt.promise;
+        }
+        // Defensive cleanup for attempts created before immediate detaching was
+        // introduced. Their own finally/cleanup still retains the attempt object.
+        if (screenSharingStartAttempt && screenSharingStartAttempt.cancelled) {
+            screenSharingStartAttempt = null;
         }
 
         var attempt = {
@@ -1187,6 +1231,7 @@
                                             }
                                         }
                                     }));
+                                    if (discardCancelledScreenSharingStart(attempt)) return;
                                     S.selectedScreenSourceId = fallbackSources[0].id;
                                     try { localStorage.setItem('selectedScreenSourceId', fallbackSources[0].id); } catch (e) { }
                                     pushSelectedSourceToMain(fallbackSources[0].id);
@@ -1209,6 +1254,7 @@
                                         video: { cursor: 'always', frameRate: 1 },
                                         audio: false,
                                     }));
+                                    if (discardCancelledScreenSharingStart(attempt)) return;
                                     S.selectedScreenSourceId = null;
                                     try { localStorage.removeItem('selectedScreenSourceId'); } catch (e) { }
                                     pushSelectedSourceToMain(null);
@@ -1256,10 +1302,7 @@
                     nativeCapture.sourceId,
                     'screen'
                 );
-                if (discardCancelledScreenSharingStart(attempt)) {
-                    stopScreening();
-                    return;
-                }
+                if (discardCancelledScreenSharingStart(attempt)) return;
                 if (!nativeStreamStarted) {
                     return;
                 }
@@ -1267,33 +1310,48 @@
                 // 用户手势成功获取了流，重置自动弹窗失败标记
                 S.screenCaptureAutoPromptFailed = false;
                 // 正常流模式
-                S.screenCaptureStreamLastUsed = Date.now();
-                scheduleScreenCaptureIdleCheck();
+                if (S.screenCaptureStream === captureStream) {
+                    S.screenCaptureStreamLastUsed = Date.now();
+                    scheduleScreenCaptureIdleCheck();
+                }
 
                 var streamInputType = isMobile() ? 'camera' : 'screen';
                 if (await stopLiveVisionStreamIfBlocked(streamInputType)) {
                     return;
                 }
                 if (discardCancelledScreenSharingStart(attempt)) return;
-                startScreenVideoStreaming(S.screenCaptureStream, streamInputType);
+                if (S.screenCaptureStream !== captureStream) return;
+                startScreenVideoStreaming(captureStream, streamInputType);
 
                 // 当用户停止共享屏幕时
-                S.screenCaptureStream.getVideoTracks()[0].onended = function () {
+                captureStream.getVideoTracks()[0].onended = function () {
+                    if (S.screenCaptureStream !== captureStream) {
+                        if (typeof captureStream.getTracks === 'function') {
+                            captureStream.getTracks().forEach(function (track) {
+                                try { track.stop(); } catch (e) { }
+                            });
+                        }
+                        return;
+                    }
+
                     stopScreening();
                     screenButton().classList.remove('active');
                     syncFloatingScreenButtonState(false);
 
-                    if (S.screenCaptureStream && typeof S.screenCaptureStream.getTracks === 'function') {
-                        S.screenCaptureStream.getTracks().forEach(function (track) {
+                    if (typeof captureStream.getTracks === 'function') {
+                        captureStream.getTracks().forEach(function (track) {
                             try { track.stop(); } catch (e) { }
                         });
                     }
-                    S.screenCaptureStream = null;
-                    S.screenCaptureStreamLastUsed = null;
 
-                    if (S.screenCaptureStreamIdleTimer) {
-                        clearTimeout(S.screenCaptureStreamIdleTimer);
-                        S.screenCaptureStreamIdleTimer = null;
+                    if (S.screenCaptureStream === captureStream) {
+                        S.screenCaptureStream = null;
+                        S.screenCaptureStreamLastUsed = null;
+
+                        if (S.screenCaptureStreamIdleTimer) {
+                            clearTimeout(S.screenCaptureStreamIdleTimer);
+                            S.screenCaptureStreamIdleTimer = null;
+                        }
                     }
                 };
             } else {
@@ -1335,10 +1393,7 @@
                 }, 1000);
             }
 
-            if (discardCancelledScreenSharingStart(attempt)) {
-                stopScreening();
-                return;
-            }
+            if (discardCancelledScreenSharingStart(attempt)) return;
 
             micButton().disabled = true;
             muteButton().disabled = false;
@@ -1403,9 +1458,7 @@
      * @param {boolean} forceRelease - 是否强制释放流。false时若主动视觉仍活跃则保留缓存流。
      */
     async function stopScreenSharing(forceRelease) {
-        if (screenSharingStartAttempt) {
-            screenSharingStartAttempt.cancelled = true;
-        }
+        cancelPendingScreenSharingStart();
         stopScreening();
 
         // 判断主动视觉是否活跃

--- a/static/app/app-ui/bootstrap-goodbye-and-toasts.js
+++ b/static/app/app-ui/bootstrap-goodbye-and-toasts.js
@@ -1391,7 +1391,7 @@ I.mod = window.appUi;
 
     // --- syncFloatingMicButtonState ---
     I.syncFloatingMicButtonState = function syncFloatingMicButtonState(isActive) {
-        const managers = [window.live2dManager, window.vrmManager, window.mmdManager];
+        const managers = [window.live2dManager, window.vrmManager, window.mmdManager, window.pngtuberManager];
 
         for (const manager of managers) {
             if (manager && manager._floatingButtons && manager._floatingButtons.mic) {
@@ -1420,23 +1420,34 @@ I.mod = window.appUi;
 
     // --- syncFloatingScreenButtonState ---
     I.syncFloatingScreenButtonState = function syncFloatingScreenButtonState(isActive) {
-        const managers = [window.live2dManager, window.vrmManager, window.mmdManager];
+        const managers = [window.live2dManager, window.vrmManager, window.mmdManager, window.pngtuberManager];
 
         for (const manager of managers) {
-            if (manager && manager._floatingButtons && manager._floatingButtons.screen) {
+            if (
+                manager
+                && manager._floatingButtons
+                && (manager._floatingButtons.screen || manager._floatingButtons['screen-share-quick'])
+            ) {
                 if (typeof manager.setButtonActive === 'function') {
                     manager.setButtonActive('screen', isActive);
                 } else {
-                    const { button, imgOff, imgOn } = manager._floatingButtons.screen;
-                    if (button) {
-                        button.dataset.active = isActive ? 'true' : 'false';
-                        if (imgOff && imgOn) {
-                            imgOff.style.opacity = isActive ? '0' : '0.75';
-                            imgOn.style.opacity = isActive ? '1' : '0';
+                    const screenRef = manager._floatingButtons.screen;
+                    const quickRef = manager._floatingButtons['screen-share-quick'];
+                    if (screenRef) {
+                        const { button, imgOff, imgOn } = screenRef;
+                        if (button) {
+                            button.dataset.active = isActive ? 'true' : 'false';
+                            if (imgOff && imgOn) {
+                                imgOff.style.opacity = isActive ? '0' : '0.75';
+                                imgOn.style.opacity = isActive ? '1' : '0';
+                            }
+                            if (typeof manager.updateSeparatePopupTriggerIcon === 'function') {
+                                manager.updateSeparatePopupTriggerIcon('screen');
+                            }
                         }
-                        if (typeof manager.updateSeparatePopupTriggerIcon === 'function') {
-                            manager.updateSeparatePopupTriggerIcon('screen');
-                        }
+                    }
+                    if (quickRef && typeof quickRef.updateState === 'function') {
+                        quickRef.updateState(isActive);
                     }
                 }
             }

--- a/static/avatar/avatar-ui-buttons/methods-setup.js
+++ b/static/avatar/avatar-ui-buttons/methods-setup.js
@@ -1,6 +1,17 @@
 Object.assign(AvatarButtonMixin.methods, {
     setup(ManagerPrototype, prefix, options) {
         ManagerPrototype.setupFloatingButtonsBase = function(model) {
+            // 同一 manager 重建时，先释放各按钮持有的 Observer / window listener。
+            // 仅移除旧 DOM 不会触发这些私有资源的清理。
+            if (this._floatingButtons) {
+                Object.values(this._floatingButtons).forEach((buttonData) => {
+                    if (buttonData && typeof buttonData.cleanup === 'function') {
+                        buttonData.cleanup();
+                    }
+                });
+            }
+            this._floatingButtons = {};
+
             // 清理旧事件监听
             if (!this._uiWindowHandlers) {
                 this._uiWindowHandlers = [];

--- a/static/avatar/avatar-ui-buttons/methods-state-and-cleanup.js
+++ b/static/avatar/avatar-ui-buttons/methods-state-and-cleanup.js
@@ -1,5 +1,109 @@
 Object.assign(AvatarButtonMixin.methods, {
     stateAndCleanup(ManagerPrototype, prefix, options) {
+        const getVoiceSessionQuickControlsRail = (btnWrapper) => {
+            if (btnWrapper._nekoVoiceSessionQuickControlsRail) {
+                return btnWrapper._nekoVoiceSessionQuickControlsRail;
+            }
+            const rail = document.createElement('div');
+            rail.className = `${prefix}-voice-session-quick-controls`;
+            rail.dataset.nekoVoiceSessionQuickControls = 'true';
+            Object.assign(rail.style, {
+                position: 'absolute',
+                left: '-24px',
+                top: '0',
+                width: '22px',
+                height: '48px',
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: '4px',
+                pointerEvents: 'none',
+                zIndex: '1'
+            });
+            btnWrapper.appendChild(rail);
+            btnWrapper._nekoVoiceSessionQuickControlsRail = rail;
+            return rail;
+        };
+
+        const createVoiceSessionQuickControlSlot = (button) => {
+            const slot = document.createElement('div');
+            slot.className = `${prefix}-voice-session-quick-control-slot`;
+            slot.dataset.nekoVoiceSessionQuickControlSlot = 'true';
+            Object.assign(slot.style, {
+                width: '22px',
+                height: '0',
+                minHeight: '0',
+                flex: '0 0 0px',
+                display: 'none',
+                alignItems: 'center',
+                justifyContent: 'center',
+                overflow: 'hidden',
+                borderRadius: '11px',
+                pointerEvents: 'none'
+            });
+            slot.appendChild(button);
+            button._nekoVoiceSessionQuickControlSlot = slot;
+            return slot;
+        };
+
+        const setVoiceSessionQuickButtonVisible = (button, visible, delay = 0) => {
+            const slot = button._nekoVoiceSessionQuickControlSlot;
+            if (!slot) {
+                button.style.display = visible ? 'flex' : 'none';
+                return;
+            }
+
+            const wasVisible = slot.style.display !== 'none';
+            if (!visible) {
+                slot._nekoQuickControlVisibilityGeneration =
+                    (slot._nekoQuickControlVisibilityGeneration || 0) + 1;
+                if (typeof slot.getAnimations === 'function') {
+                    slot.getAnimations().forEach((animation) => animation.cancel());
+                }
+                slot.style.display = 'none';
+                slot.style.height = '0';
+                slot.style.flexBasis = '0px';
+                slot.style.overflow = 'hidden';
+                button.style.display = 'none';
+                return;
+            }
+
+            slot.style.display = 'flex';
+            slot.style.height = '22px';
+            slot.style.flexBasis = '22px';
+            button.style.display = 'flex';
+            if (wasVisible) return;
+
+            const visibilityGeneration =
+                (slot._nekoQuickControlVisibilityGeneration || 0) + 1;
+            slot._nekoQuickControlVisibilityGeneration = visibilityGeneration;
+            slot.style.overflow = 'hidden';
+
+            const reduceMotion = typeof window.matchMedia === 'function'
+                && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+            if (reduceMotion || typeof slot.animate !== 'function') {
+                slot.style.overflow = 'visible';
+                return;
+            }
+
+            const animation = slot.animate([
+                { height: '0px', flexBasis: '0px' },
+                { height: '22px', flexBasis: '22px' }
+            ], {
+                duration: 220,
+                delay,
+                easing: 'cubic-bezier(0.2, 0.8, 0.2, 1)',
+                fill: 'backwards'
+            });
+            animation.finished.then(() => {
+                if (slot._nekoQuickControlVisibilityGeneration === visibilityGeneration
+                    && slot.style.display !== 'none') {
+                    slot.style.overflow = 'visible';
+                }
+            }).catch(() => {});
+        };
+
         ManagerPrototype.createMicMuteButton = function(btnWrapper) {
             const opts = this._avatarButtonOptions;
             const prefix = this._avatarPrefix;
@@ -16,7 +120,9 @@ Object.assign(AvatarButtonMixin.methods, {
             muteSvg.setAttribute('height', '16');
             Object.assign(muteSvg.style, {
                 pointerEvents: 'none',
-                display: 'block'
+                display: 'block',
+                transition: 'transform 0.1s ease',
+                transform: 'scale(1)'
             });
 
             const micPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
@@ -46,18 +152,17 @@ Object.assign(AvatarButtonMixin.methods, {
             muteBtn.appendChild(muteSvg);
 
             Object.assign(muteBtn.style, {
-                width: '24px', height: '24px', borderRadius: '50%',
+                width: '22px', height: '22px', minWidth: '22px', minHeight: '22px', borderRadius: '50%',
                 background: 'var(--neko-btn-bg, rgba(255,255,255,0.65))',
                 backdropFilter: 'saturate(180%) blur(20px)',
                 border: 'var(--neko-btn-border, 1px solid rgba(255,255,255,0.18))',
-                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                display: 'none', alignItems: 'center', justifyContent: 'center',
                 cursor: 'pointer', userSelect: 'none',
                 boxShadow: 'var(--neko-btn-shadow, 0 2px 4px rgba(0,0,0,0.04), 0 4px 8px rgba(0,0,0,0.08))',
-                transition: 'all 0.1s ease', pointerEvents: 'auto',
-                position: 'absolute',
-                left: '-28px',
-                top: '50%',
-                transform: 'translateY(-50%)'
+                transition: 'background 0.1s ease, box-shadow 0.1s ease', pointerEvents: 'auto',
+                position: 'relative',
+                flex: '0 0 22px',
+                boxSizing: 'border-box'
             });
 
             const stopMuteEvent = (e) => { e.stopPropagation(); };
@@ -79,11 +184,8 @@ Object.assign(AvatarButtonMixin.methods, {
                 }
             };
 
-            const isRecording = window.isRecording || false;
-            muteBtn.style.display = isRecording ? 'flex' : 'none';
-
             const updateMuteButtonVisibility = (visible) => {
-                muteBtn.style.display = visible ? 'flex' : 'none';
+                setVoiceSessionQuickButtonVisible(muteBtn, Boolean(visible));
             };
 
             if (typeof window.isMicMuted === 'function') {
@@ -91,7 +193,7 @@ Object.assign(AvatarButtonMixin.methods, {
             }
 
             muteBtn.addEventListener('mouseenter', () => {
-                muteBtn.style.transform = 'translateY(-50%) scale(1.1)';
+                muteSvg.style.transform = 'scale(1.08)';
                 muteBtn.style.boxShadow = 'var(--neko-btn-shadow-hover, 0 4px 8px rgba(0,0,0,0.08), 0 8px 16px rgba(0,0,0,0.08))';
                 const isMuted = typeof window.isMicMuted === 'function' && window.isMicMuted();
                 if (!isMuted) {
@@ -100,7 +202,7 @@ Object.assign(AvatarButtonMixin.methods, {
             });
 
             muteBtn.addEventListener('mouseleave', () => {
-                muteBtn.style.transform = 'translateY(-50%) scale(1)';
+                muteSvg.style.transform = 'scale(1)';
                 muteBtn.style.boxShadow = 'var(--neko-btn-shadow, 0 2px 4px rgba(0,0,0,0.04), 0 4px 8px rgba(0,0,0,0.08))';
                 const isMuted = typeof window.isMicMuted === 'function' && window.isMicMuted();
                 updateMuteButtonState(isMuted);
@@ -128,7 +230,8 @@ Object.assign(AvatarButtonMixin.methods, {
                 target: window
             });
 
-            btnWrapper.appendChild(muteBtn);
+            getVoiceSessionQuickControlsRail(btnWrapper).appendChild(createVoiceSessionQuickControlSlot(muteBtn));
+            updateMuteButtonVisibility(Boolean(window.isRecording));
 
             const muteData = {
                 button: muteBtn,
@@ -144,6 +247,191 @@ Object.assign(AvatarButtonMixin.methods, {
             }
 
             return muteData;
+        };
+
+        /**
+         * 创建屏幕分享快捷按钮（附加在麦克风按钮的外侧快捷轨道）
+         * @param {HTMLElement} btnWrapper - 麦克风按钮的包装器
+         * @returns {Object|null} 屏幕分享按钮数据
+         */
+        ManagerPrototype.createScreenShareQuickButton = function(btnWrapper) {
+            const opts = this._avatarButtonOptions;
+            const prefix = this._avatarPrefix;
+
+            const previousQuickButton = this._floatingButtons && this._floatingButtons['screen-share-quick'];
+            if (previousQuickButton && typeof previousQuickButton.cleanup === 'function') {
+                previousQuickButton.cleanup();
+            }
+
+            const screenShareBtn = document.createElement('div');
+            screenShareBtn.id = `${prefix}-btn-screen-share-quick`;
+            screenShareBtn.className = `${opts.buttonClassPrefix} ${prefix}-screen-share-quick-btn neko-screen-share-quick-btn`;
+            screenShareBtn.setAttribute('role', 'button');
+            screenShareBtn.setAttribute('tabindex', '0');
+
+            const monitorSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+            monitorSvg.setAttribute('viewBox', '0 0 24 24');
+            monitorSvg.setAttribute('width', '15');
+            monitorSvg.setAttribute('height', '15');
+            monitorSvg.setAttribute('aria-hidden', 'true');
+            Object.assign(monitorSvg.style, {
+                display: 'block',
+                pointerEvents: 'none',
+                transition: 'transform 0.1s ease',
+                transform: 'scale(1)'
+            });
+
+            const monitorFrame = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+            monitorFrame.setAttribute('x', '3');
+            monitorFrame.setAttribute('y', '4');
+            monitorFrame.setAttribute('width', '18');
+            monitorFrame.setAttribute('height', '13');
+            monitorFrame.setAttribute('rx', '2');
+            monitorFrame.setAttribute('fill', 'none');
+            monitorFrame.setAttribute('stroke', 'currentColor');
+            monitorFrame.setAttribute('stroke-width', '2');
+
+            const monitorStand = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+            monitorStand.setAttribute('d', 'M8 21h8M12 17v4');
+            monitorStand.setAttribute('fill', 'none');
+            monitorStand.setAttribute('stroke', 'currentColor');
+            monitorStand.setAttribute('stroke-width', '2');
+            monitorStand.setAttribute('stroke-linecap', 'round');
+
+            monitorSvg.appendChild(monitorFrame);
+            monitorSvg.appendChild(monitorStand);
+            screenShareBtn.appendChild(monitorSvg);
+
+            Object.assign(screenShareBtn.style, {
+                width: '22px', height: '22px', minWidth: '22px', minHeight: '22px', borderRadius: '50%',
+                background: 'var(--neko-btn-bg, rgba(255,255,255,0.65))',
+                backdropFilter: 'saturate(180%) blur(20px)',
+                border: 'var(--neko-btn-border, 1px solid rgba(255,255,255,0.18))',
+                display: 'none', alignItems: 'center', justifyContent: 'center',
+                color: '#4a90d9', cursor: 'pointer', userSelect: 'none',
+                boxShadow: 'var(--neko-btn-shadow, 0 2px 4px rgba(0,0,0,0.04), 0 4px 8px rgba(0,0,0,0.08))',
+                transition: 'background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease',
+                pointerEvents: 'auto', position: 'relative', flex: '0 0 22px', boxSizing: 'border-box'
+            });
+
+            let screenShareActive = false;
+            let voiceSessionActive = false;
+
+            const updateScreenShareButtonVisibility = () => {
+                const visible = voiceSessionActive || screenShareActive;
+                setVoiceSessionQuickButtonVisible(screenShareBtn, visible, 45);
+            };
+
+            const currentScreenShareState = () => {
+                const hiddenScreenButton = document.getElementById('screenButton');
+                return !!(hiddenScreenButton && hiddenScreenButton.classList.contains('active'));
+            };
+
+            const updateScreenShareState = (active) => {
+                screenShareActive = Boolean(active);
+                screenShareBtn.dataset.active = screenShareActive ? 'true' : 'false';
+                screenShareBtn.setAttribute('aria-pressed', screenShareActive ? 'true' : 'false');
+                const titleKey = screenShareActive ? 'voiceControl.stopShare' : 'buttons.screenShare';
+                const title = screenShareActive
+                    ? (window.t ? window.t(titleKey) : '停止屏幕分享')
+                    : (window.t ? window.t(titleKey) : '屏幕分享');
+                screenShareBtn.title = title;
+                screenShareBtn.setAttribute('aria-label', title);
+                screenShareBtn.setAttribute('data-i18n-title', titleKey);
+                screenShareBtn.setAttribute('data-i18n-aria', titleKey);
+                screenShareBtn.style.color = screenShareActive ? '#fff' : '#4a90d9';
+                screenShareBtn.style.background = screenShareActive
+                    ? '#44b7fe'
+                    : 'var(--neko-btn-bg, rgba(255,255,255,0.65))';
+                screenShareBtn.style.boxShadow = 'var(--neko-btn-shadow, 0 2px 4px rgba(0,0,0,0.04), 0 4px 8px rgba(0,0,0,0.08))';
+                updateScreenShareButtonVisibility();
+            };
+
+            const updateVoiceSessionState = (active) => {
+                voiceSessionActive = Boolean(active);
+                screenShareBtn.dataset.voiceSessionActive = voiceSessionActive ? 'true' : 'false';
+                updateScreenShareButtonVisibility();
+            };
+
+            const stopQuickButtonEvent = (event) => { event.stopPropagation(); };
+            ['pointerdown', 'mousedown', 'touchstart'].forEach((eventName) => {
+                screenShareBtn.addEventListener(eventName, stopQuickButtonEvent);
+            });
+
+            const activateScreenShareQuickButton = (event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                if (typeof window.toggleScreenShare === 'function') {
+                    window.toggleScreenShare();
+                }
+            };
+
+            screenShareBtn.addEventListener('click', activateScreenShareQuickButton);
+            screenShareBtn.addEventListener('keydown', (event) => {
+                if (!event.repeat && (event.key === 'Enter' || event.key === ' ')) {
+                    activateScreenShareQuickButton(event);
+                }
+            });
+            screenShareBtn.addEventListener('mouseenter', () => {
+                monitorSvg.style.transform = 'scale(1.08)';
+                if (!screenShareActive) {
+                    screenShareBtn.style.background = 'var(--neko-btn-bg-hover, rgba(255,255,255,0.8))';
+                    screenShareBtn.style.boxShadow = 'var(--neko-btn-shadow-hover, 0 4px 8px rgba(0,0,0,0.08), 0 8px 16px rgba(0,0,0,0.08))';
+                }
+            });
+            screenShareBtn.addEventListener('mouseleave', () => {
+                monitorSvg.style.transform = 'scale(1)';
+                updateScreenShareState(screenShareActive);
+            });
+
+            const hiddenScreenButton = document.getElementById('screenButton');
+            let screenStateObserver = null;
+            if (hiddenScreenButton && typeof MutationObserver !== 'undefined') {
+                screenStateObserver = new MutationObserver(() => {
+                    updateScreenShareState(currentScreenShareState());
+                });
+                screenStateObserver.observe(hiddenScreenButton, { attributes: true, attributeFilter: ['class'] });
+            }
+
+            const micToggleHandler = (event) => {
+                const active = Boolean(event && event.detail && event.detail.active);
+                const muteButtonData = this._floatingButtons && this._floatingButtons['mic-mute'];
+                if (muteButtonData && typeof muteButtonData.updateVisibility === 'function') {
+                    muteButtonData.updateVisibility(active);
+                }
+                updateVoiceSessionState(active);
+            };
+            window.addEventListener('live2d-mic-toggle', micToggleHandler);
+
+            getVoiceSessionQuickControlsRail(btnWrapper).appendChild(createVoiceSessionQuickControlSlot(screenShareBtn));
+            updateScreenShareState(currentScreenShareState());
+            updateVoiceSessionState(Boolean(window.isRecording));
+
+            const screenShareData = {
+                button: screenShareBtn,
+                svg: monitorSvg,
+                updateState: updateScreenShareState,
+                updateVoiceSessionState: updateVoiceSessionState,
+                cleanup: () => {
+                    if (screenStateObserver) screenStateObserver.disconnect();
+                    window.removeEventListener('live2d-mic-toggle', micToggleHandler);
+                    const slot = screenShareBtn._nekoVoiceSessionQuickControlSlot;
+                    if (slot) slot.remove();
+                    else screenShareBtn.remove();
+                }
+            };
+
+            if (this._floatingButtons) {
+                this._floatingButtons['screen-share-quick'] = screenShareData;
+            }
+
+            return screenShareData;
+        };
+
+        ManagerPrototype.createVoiceSessionQuickControls = function(btnWrapper) {
+            const screenShare = this.createScreenShareQuickButton(btnWrapper);
+            const mute = this.createMicMuteButton(btnWrapper);
+            return { screenShare, mute };
         };
 
         /**
@@ -176,8 +464,30 @@ Object.assign(AvatarButtonMixin.methods, {
          * 设置按钮激活状态
          */
         ManagerPrototype.setButtonActive = function(buttonId, active) {
+            if (buttonId === 'screen') {
+                const screenShareQuickData = this._floatingButtons && this._floatingButtons['screen-share-quick'];
+                if (screenShareQuickData && typeof screenShareQuickData.updateState === 'function') {
+                    screenShareQuickData.updateState(active);
+                }
+            }
+            if (buttonId === 'mic') {
+                const muteButtonData = this._floatingButtons && this._floatingButtons['mic-mute'];
+                if (muteButtonData && muteButtonData.updateVisibility) {
+                    muteButtonData.updateVisibility(active);
+                }
+                const screenShareQuickData = this._floatingButtons && this._floatingButtons['screen-share-quick'];
+                if (screenShareQuickData && typeof screenShareQuickData.updateVoiceSessionState === 'function') {
+                    screenShareQuickData.updateVoiceSessionState(active);
+                }
+            }
+
             const buttonData = this._floatingButtons && this._floatingButtons[buttonId];
             if (!buttonData || !buttonData.button) return;
+
+            if (typeof buttonData.updateState === 'function') {
+                buttonData.updateState(active);
+                return;
+            }
 
             buttonData.button.dataset.active = active ? 'true' : 'false';
             buttonData.button.style.background = active
@@ -193,13 +503,6 @@ Object.assign(AvatarButtonMixin.methods, {
 
             this.updateSeparatePopupTriggerIcon(buttonId);
 
-            // 同步静音按钮的显示状态
-            if (buttonId === 'mic') {
-                const muteButtonData = this._floatingButtons && this._floatingButtons['mic-mute'];
-                if (muteButtonData && muteButtonData.updateVisibility) {
-                    muteButtonData.updateVisibility(active);
-                }
-            }
         };
 
         /**
@@ -225,9 +528,10 @@ Object.assign(AvatarButtonMixin.methods, {
             }
 
             // 桌面槽位由 social 取代，但移动布局仍有独立的 screen 按钮。
-            // 以隐藏的 #screenButton 为真实状态，避免重建按钮后保留乐观状态。
+            // 桌面快捷按钮与移动端完整按钮都以隐藏的 #screenButton 为真实状态，
+            // 避免重建按钮后保留乐观状态。
             const screenButton = document.getElementById('screenButton');
-            if (this._floatingButtons.screen && screenButton) {
+            if ((this._floatingButtons.screen || this._floatingButtons['screen-share-quick']) && screenButton) {
                 this.setButtonActive('screen', screenButton.classList.contains('active'));
             }
         };
@@ -243,6 +547,14 @@ Object.assign(AvatarButtonMixin.methods, {
             if (this._returnButtonDragHandlers &&
                 typeof this._returnButtonDragHandlers.cleanup === 'function') {
                 this._returnButtonDragHandlers.cleanup();
+            }
+
+            if (this._floatingButtons) {
+                Object.values(this._floatingButtons).forEach((buttonData) => {
+                    if (buttonData && typeof buttonData.cleanup === 'function') {
+                        buttonData.cleanup();
+                    }
+                });
             }
 
             // 停止 RAF 循环

--- a/static/avatar/avatar-ui-popup.js
+++ b/static/avatar/avatar-ui-popup.js
@@ -231,6 +231,40 @@ function injectPopupStyles(prefix) {
         .${prefix}-toggle-indicator[aria-checked="true"] .${prefix}-toggle-checkmark {
             opacity: 1;
         }
+        .${prefix}-toggle-item.${prefix}-toggle-item-slider {
+            gap: 12px;
+        }
+        .${prefix}-toggle-item-slider .${prefix}-toggle-label {
+            flex: 1 1 auto;
+            min-width: 0;
+        }
+        .${prefix}-toggle-indicator.${prefix}-toggle-slider {
+            box-sizing: border-box;
+            width: 36px;
+            min-width: 36px;
+            height: 20px;
+            border-width: 1px;
+            border-radius: 999px;
+            background-color: var(--neko-popup-accent-bg, rgba(42, 123, 196, 0.05));
+            overflow: visible;
+            transition: background-color 0.2s ease, border-color 0.2s ease;
+        }
+        .${prefix}-toggle-slider .${prefix}-toggle-thumb {
+            position: absolute;
+            top: 1px;
+            left: 1px;
+            width: 16px;
+            height: 16px;
+            border-radius: 50%;
+            background: #fff;
+            box-shadow: 0 1px 3px rgba(15, 23, 42, 0.24);
+            opacity: 1;
+            transform: translateX(0);
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+        .${prefix}-toggle-slider[aria-checked="true"] .${prefix}-toggle-thumb {
+            transform: translateX(16px);
+        }
         .${prefix}-toggle-label {
             cursor: pointer;
             user-select: none;
@@ -414,8 +448,8 @@ function createSettingsPopupContent(manager, prefix, popup) {
 
     // 4. 主动搭话和自主视觉（角色设置已移至分隔线下方的导航菜单区域）
     const settingsToggles = [
-        { id: 'proactive-chat', label: window.t ? window.t('settings.toggles.proactiveChat') : '主动搭话', labelKey: 'settings.toggles.proactiveChat', storageKey: 'proactiveChatEnabled', hasInterval: true, intervalKey: 'proactiveChatInterval', defaultInterval: 15 },
-        { id: 'proactive-vision', label: window.t ? window.t('settings.toggles.proactiveVision') : '隐私模式', labelKey: 'settings.toggles.proactiveVision', tooltipKey: 'settings.toggles.proactiveVisionTooltip', storageKey: 'proactiveVisionEnabled', hasInterval: true, intervalKey: 'proactiveVisionInterval', defaultInterval: 15, inverted: true }
+        { id: 'proactive-chat', label: window.t ? window.t('settings.toggles.proactiveChat') : '主动搭话', labelKey: 'settings.toggles.proactiveChat', storageKey: 'proactiveChatEnabled', hasInterval: true, intervalKey: 'proactiveChatInterval', defaultInterval: 15, controlStyle: 'slider' },
+        { id: 'proactive-vision', label: window.t ? window.t('settings.toggles.proactiveVision') : '隐私模式', labelKey: 'settings.toggles.proactiveVision', tooltipKey: 'settings.toggles.proactiveVisionTooltip', storageKey: 'proactiveVisionEnabled', hasInterval: true, intervalKey: 'proactiveVisionInterval', defaultInterval: 15, inverted: true, controlStyle: 'slider' }
     ];
 
     settingsToggles.forEach(toggle => {
@@ -2189,11 +2223,15 @@ function createToggleItem(manager, prefix, toggle, popup) {
  * 创建设置开关项
  */
 function createSettingsToggleItem(manager, prefix, toggle) {
+    const usesSliderControl = toggle.controlStyle === 'slider';
     const toggleItem = document.createElement('div');
     toggleItem.className = `${prefix}-toggle-item`;
     markAvatarPopupActionElement(toggleItem, 'settings-toggle');
     if (toggle.alwaysTinted) {
         toggleItem.classList.add(`${prefix}-toggle-item-static`);
+    }
+    if (usesSliderControl) {
+        toggleItem.classList.add(`${prefix}-toggle-item-slider`);
     }
     toggleItem.id = `${prefix}-toggle-${toggle.id}`;
     toggleItem.setAttribute('role', 'switch');
@@ -2252,16 +2290,33 @@ function createSettingsToggleItem(manager, prefix, toggle) {
 
     const indicator = document.createElement('div');
     indicator.className = `${prefix}-toggle-indicator`;
+    if (usesSliderControl) {
+        indicator.classList.add(`${prefix}-toggle-slider`);
+    }
     indicator.setAttribute('role', 'presentation');
     indicator.setAttribute('aria-hidden', 'true');
 
     const checkmark = document.createElement('div');
     checkmark.className = `${prefix}-toggle-checkmark`;
+    if (usesSliderControl) {
+        checkmark.classList.add(`${prefix}-toggle-thumb`);
+    }
     checkmark.setAttribute('aria-hidden', 'true');
-    checkmark.innerHTML = '✓';
+    checkmark.textContent = usesSliderControl ? '' : '✓';
     indicator.appendChild(checkmark);
 
     const updateIndicatorStyle = (checked) => {
+        if (usesSliderControl) {
+            const activeColor = 'var(--neko-popup-accent, #44b7fe)';
+            indicator.style.backgroundColor = checked
+                ? activeColor
+                : 'var(--neko-popup-accent-bg, rgba(42, 123, 196, 0.05))';
+            indicator.style.borderColor = checked
+                ? activeColor
+                : 'var(--neko-popup-indicator-border, #ccc)';
+            checkmark.style.opacity = '1';
+            return;
+        }
         if (checked) {
             const activeColor = 'var(--neko-popup-accent, #44b7fe)';
             indicator.style.backgroundColor = activeColor;
@@ -2275,6 +2330,7 @@ function createSettingsToggleItem(manager, prefix, toggle) {
     };
 
     const label = document.createElement('label');
+    label.className = `${prefix}-toggle-label`;
     label.innerText = toggle.label;
     if (toggle.labelKey) {
         label.setAttribute('data-i18n', toggle.labelKey);
@@ -2324,8 +2380,13 @@ function createSettingsToggleItem(manager, prefix, toggle) {
     updateStyle();
 
     toggleItem.appendChild(checkbox);
-    toggleItem.appendChild(indicator);
-    toggleItem.appendChild(label);
+    if (usesSliderControl) {
+        toggleItem.appendChild(label);
+        toggleItem.appendChild(indicator);
+    } else {
+        toggleItem.appendChild(indicator);
+        toggleItem.appendChild(label);
+    }
 
     toggleItem.addEventListener('mouseenter', () => {
         updateStyle();

--- a/static/common_ui.js
+++ b/static/common_ui.js
@@ -1194,11 +1194,14 @@ window.toggleScreenShare = function () {
     // 当前共享状态以隐藏的 #screenButton 的 .active class 为准。
     const screenBtn = document.getElementById('screenButton');
     const isActive = !!(screenBtn && screenBtn.classList.contains('active'));
+    const isStartPending = typeof window.isScreenSharingStartPending === 'function'
+        && window.isScreenSharingStartPending();
+    const isActiveOrPending = isActive || isStartPending;
     const isRecording = window.isRecording || false;
 
     // 屏幕分享仅在语音会话中有效
     // 如果尝试开启屏幕分享但语音会话未开启，显示提示并阻止操作
-    if (!isActive && !isRecording) {
+    if (!isActiveOrPending && !isRecording) {
         console.log('[Electron Shortcut] toggleScreenShare: blocked - voice session not active');
         if (typeof window.showStatusToast === 'function') {
             window.showStatusToast(
@@ -1211,11 +1214,11 @@ window.toggleScreenShare = function () {
 
     // 派发切换事件
     const event = new CustomEvent('live2d-screen-toggle', {
-        detail: { active: !isActive }
+        detail: { active: !isActiveOrPending }
     });
     window.dispatchEvent(event);
 
-    console.log('[Electron Shortcut] toggleScreenShare:', !isActive ? 'start' : 'stop');
+    console.log('[Electron Shortcut] toggleScreenShare:', !isActiveOrPending ? 'start' : 'stop');
 };
 
 /**

--- a/static/live2d/live2d-ui-buttons.js
+++ b/static/live2d/live2d-ui-buttons.js
@@ -474,10 +474,11 @@ Live2DManager.prototype.setupFloatingButtons = function(model) {
 
         btnWrapper.appendChild(btn);
 
-        // 麦克风静音按钮（仅非手机模式下的麦克风按钮）
+        // 语音会话快捷控制（仅非手机模式下的麦克风按钮）
         if (config.id === 'mic' && config.hasPopup && config.separatePopupTrigger && !isMobileWidth()) {
-            const muteData = this.createMicMuteButton(btnWrapper);
-            // 监听麦克风切换事件以更新静音按钮可见性
+            const quickControls = this.createVoiceSessionQuickControls(btnWrapper);
+            const muteData = quickControls && quickControls.mute;
+            // 监听麦克风切换事件以更新静音按钮可见性；屏幕分享快捷按钮在共享工厂中自行同步。
             const micToggleHandler = (e) => {
                 if (muteData && muteData.updateVisibility) {
                     muteData.updateVisibility(e.detail.active);

--- a/static/mmd/mmd-ui-buttons.js
+++ b/static/mmd/mmd-ui-buttons.js
@@ -175,9 +175,9 @@ MMDManager.prototype.setupFloatingButtons = function() {
 
         btnWrapper.appendChild(btn);
 
-        // 麦克风静音按钮（仅非手机模式下的麦克风按钮）
+        // 语音会话快捷控制（仅非手机模式下的麦克风按钮）
         if (config.id === 'mic' && config.hasPopup && config.separatePopupTrigger && !(window.isMobileWidth && window.isMobileWidth())) {
-            this.createMicMuteButton(btnWrapper);
+            this.createVoiceSessionQuickControls(btnWrapper);
         }
 
         // 处理弹窗

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -3962,7 +3962,7 @@
 
                 btnWrapper.appendChild(btn);
                 if (config.id === 'mic' && config.hasPopup && config.separatePopupTrigger && !(window.isMobileWidth && window.isMobileWidth())) {
-                    this.createMicMuteButton(btnWrapper);
+                    this.createVoiceSessionQuickControls(btnWrapper);
                 }
 
                 let triggerBtn = null;

--- a/static/vrm/vrm-ui-buttons.js
+++ b/static/vrm/vrm-ui-buttons.js
@@ -207,9 +207,9 @@ VRMManager.prototype.setupFloatingButtons = function() {
         // 先将主按钮添加到包装器（所有按钮都需要）
         btnWrapper.appendChild(btn);
 
-        // 麦克风静音按钮（仅非手机模式下的麦克风按钮）
+        // 语音会话快捷控制（仅非手机模式下的麦克风按钮）
         if (config.id === 'mic' && config.hasPopup && config.separatePopupTrigger && !window.isMobileWidth()) {
-            this.createMicMuteButton(btnWrapper);
+            this.createVoiceSessionQuickControls(btnWrapper);
         }
 
         // 处理弹窗

--- a/tests/unit/test_avatar_controls_static.py
+++ b/tests/unit/test_avatar_controls_static.py
@@ -58,6 +58,92 @@ def test_mobile_screen_share_state_reconciles_after_capture_attempts():
     )
 
 
+def test_desktop_avatar_toolbar_exposes_screen_share_quick_control_for_every_renderer():
+    state_source = _read(
+        "static/avatar/avatar-ui-buttons/methods-state-and-cleanup.js"
+    )
+    setup_source = _read("static/avatar/avatar-ui-buttons/methods-setup.js")
+    screen_source = _read("static/app/app-screen.js")
+    bootstrap_source = _read("static/app/app-ui/bootstrap-goodbye-and-toasts.js")
+
+    assert "ManagerPrototype.createScreenShareQuickButton = function(btnWrapper)" in state_source
+    assert "ManagerPrototype.createVoiceSessionQuickControls = function(btnWrapper)" in state_source
+    assert "createVoiceSessionQuickControlSlot(screenShareBtn)" in state_source
+    assert "createVoiceSessionQuickControlSlot(muteBtn)" in state_source
+    assert "`${opts.buttonClassPrefix} ${prefix}-screen-share-quick-btn neko-screen-share-quick-btn`" in state_source
+    assert "screenShareBtn.setAttribute('role', 'button');" in state_source
+    assert "screenShareBtn.setAttribute('aria-pressed'" in state_source
+    assert "!event.repeat && (event.key === 'Enter' || event.key === ' ')" in state_source
+    assert "window.toggleScreenShare();" in state_source
+    assert "new MutationObserver" in state_source
+    assert "screenStateObserver.disconnect();" in state_source
+    assert "previousQuickButton.cleanup();" in state_source
+    assert "screenShareBtn.remove();" in state_source
+    assert "nekoScreenShareQuickHint" not in state_source
+    assert "nekoScreenShareQuickBreathe" not in state_source
+    assert "conic-gradient(" not in state_source
+    assert "radial-gradient(" not in state_source
+    assert "linear-gradient(145deg" not in state_source
+    assert "? '#44b7fe'" in state_source
+    assert "screenShareActive ? '#fff' : '#4a90d9'" in state_source
+    assert "const visible = voiceSessionActive || screenShareActive;" in state_source
+    assert "setVoiceSessionQuickButtonVisible(screenShareBtn, visible, 45);" in state_source
+    assert "setVoiceSessionQuickButtonVisible(muteBtn, Boolean(visible));" in state_source
+    assert "muteButtonData.updateVisibility(active);" in state_source
+    visibility_animation = state_source.split(
+        "const setVoiceSessionQuickButtonVisible =", 1
+    )[1].split("ManagerPrototype.createMicMuteButton", 1)[0]
+    assert "slot.animate([" in visibility_animation
+    assert "{ height: '0px', flexBasis: '0px' }" in visibility_animation
+    assert "{ height: '22px', flexBasis: '22px' }" in visibility_animation
+    assert "button.animate" not in visibility_animation
+    assert "opacity:" not in visibility_animation
+    assert "transform:" not in visibility_animation
+    assert "_nekoQuickControlVisibilityGeneration" in visibility_animation
+    assert "animation.finished.then" in visibility_animation
+    assert "slot.style.overflow = 'visible';" in visibility_animation
+    assert "duration: 220" in state_source
+    assert "fill: 'backwards'" in state_source
+    assert "prefers-reduced-motion: reduce" in state_source
+    quick_button_styles = state_source.split("Object.assign(screenShareBtn.style, {", 1)[1].split(
+        "let screenShareActive = false;", 1
+    )[0]
+    assert "display: 'none'" in quick_button_styles
+    assert "transform:" not in quick_button_styles
+    assert "transformOrigin" not in quick_button_styles
+    assert "saturate(180%) blur(20px)" in quick_button_styles
+    mute_button_styles = state_source.split("Object.assign(muteBtn.style, {", 1)[1].split(
+        "const stopMuteEvent", 1
+    )[0]
+    assert "transform:" not in mute_button_styles
+    assert "transition: 'all" not in mute_button_styles
+    assert "saturate(180%) blur(20px)" in mute_button_styles
+    assert "muteSvg.style.transform = 'scale(1.08)'" in state_source
+    assert "monitorSvg.style.transform = 'scale(1.08)'" in state_source
+    assert "if (slot) slot.remove();" in state_source
+    assert "#8a5ce8" not in state_source
+    assert "linear-gradient(135deg, #4a90d9" not in state_source
+    assert "screenShareBtn.setAttribute('data-i18n-aria', titleKey);" in state_source
+
+    rebuild_cleanup = setup_source.index("Object.values(this._floatingButtons).forEach")
+    rebuild_reset = setup_source.index("this._floatingButtons = {};")
+    old_dom_removal = setup_source.index("document.querySelectorAll(`#${options.containerElementId}")
+    assert rebuild_cleanup < rebuild_reset < old_dom_removal
+
+    renderer_sources = [
+        _read("static/live2d/live2d-ui-buttons.js"),
+        _read("static/vrm/vrm-ui-buttons.js"),
+        _read("static/mmd/mmd-ui-buttons.js"),
+        _read("static/pngtuber-core.js"),
+    ]
+    for source in renderer_sources:
+        assert "this.createVoiceSessionQuickControls(btnWrapper)" in source
+
+    for source in (screen_source, bootstrap_source):
+        assert "window.pngtuberManager" in source
+        assert "['screen-share-quick']" in source
+
+
 def test_live2d_click_actions_are_not_dispatched_by_the_generic_listener_twice():
     source = _read("static/live2d/live2d-ui-buttons.js")
 

--- a/tests/unit/test_avatar_floating_button_layout_static.py
+++ b/tests/unit/test_avatar_floating_button_layout_static.py
@@ -38,8 +38,8 @@ def test_avatar_floating_button_rows_keep_fixed_height_when_aux_controls_toggle(
     )
 
     # Live2D positions the toolbar from five 48px rows plus four 12px gaps.
-    # The row wrapper must keep that height even when the mic mute button or
-    # popup trigger is shown, otherwise the vertical toolbar visibly contracts.
+    # The row wrapper must keep that height even when the voice-session quick
+    # controls or popup trigger are shown, otherwise the vertical toolbar visibly contracts.
     assert "const LIVE2D_FLOATING_BUTTON_SIZE = 48;" in live2d_source
     assert "const LIVE2D_FLOATING_BUTTON_GAP = 12;" in live2d_source
     assert "const LIVE2D_FLOATING_BUTTON_COUNT = 5;" in live2d_source
@@ -49,15 +49,41 @@ def test_avatar_floating_button_rows_keep_fixed_height_when_aux_controls_toggle(
     assert "flex: '0 0 48px'" in wrapper_block
     assert "boxSizing: 'border-box'" in wrapper_block
 
+    quick_controls_rail_block = _source_slice_between(
+        avatar_source,
+        "const rail = document.createElement('div');",
+        "btnWrapper.appendChild(rail);",
+        "voice-session quick controls rail",
+    )
+    assert "position: 'absolute'" in quick_controls_rail_block
+    assert "left: '-24px'" in quick_controls_rail_block
+    assert "width: '22px'" in quick_controls_rail_block
+    assert "height: '48px'" in quick_controls_rail_block
+    assert "flexDirection: 'column'" in quick_controls_rail_block
+    assert "gap: '4px'" in quick_controls_rail_block
+
+    quick_control_slot_block = _source_slice_between(
+        avatar_source,
+        "const slot = document.createElement('div');",
+        "slot.appendChild(button);",
+        "voice-session quick control slot",
+    )
+    assert "width: '22px'" in quick_control_slot_block
+    assert "height: '0'" in quick_control_slot_block
+    assert "flex: '0 0 0px'" in quick_control_slot_block
+    assert "overflow: 'hidden'" in quick_control_slot_block
+    assert "pointerEvents: 'none'" in quick_control_slot_block
+
     mute_button_block = _source_slice_between(
         avatar_source,
         "Object.assign(muteBtn.style, {",
         "const stopMuteEvent = (e) => { e.stopPropagation(); };",
         "mic mute button styles",
     )
-    assert "position: 'absolute'" in mute_button_block
-    assert "top: '50%'" in mute_button_block
-    assert "transform: 'translateY(-50%)'" in mute_button_block
+    assert "width: '22px'" in mute_button_block
+    assert "height: '22px'" in mute_button_block
+    assert "position: 'relative'" in mute_button_block
+    assert "position: 'absolute'" not in mute_button_block
 
 
 def test_live2d_lock_icon_tracks_the_floating_toolbar_scale():

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -147,6 +147,33 @@ def test_chat_settings_auto_cat_and_cat_audio_toggles_are_independent():
     assert zh_tw_locale["settings"]["toggles"]["catAudio"] == "貓貓音效"
 
 
+def test_model_settings_proactive_controls_use_right_aligned_sliders():
+    source = AVATAR_UI_POPUP_PATH.read_text(encoding="utf-8")
+    settings_toggles_block = source.split("const settingsToggles = [", 1)[1].split("];", 1)[0]
+
+    assert settings_toggles_block.count("controlStyle: 'slider'") == 2
+    assert "id: 'proactive-chat'" in settings_toggles_block
+    assert "id: 'proactive-vision'" in settings_toggles_block
+
+    assert ".${prefix}-toggle-item.${prefix}-toggle-item-slider" in source
+    assert ".${prefix}-toggle-indicator.${prefix}-toggle-slider" in source
+    assert "width: 36px;" in source
+    assert "height: 20px;" in source
+    assert ".${prefix}-toggle-slider[aria-checked=\"true\"] .${prefix}-toggle-thumb" in source
+    assert "transform: translateX(16px);" in source
+
+    settings_item_block = source.split("function createSettingsToggleItem", 1)[1].split(
+        "function createMenuItem", 1
+    )[0]
+    slider_order_block = settings_item_block.split("toggleItem.appendChild(checkbox);", 1)[1].split(
+        "toggleItem.addEventListener('mouseenter'", 1
+    )[0]
+    assert "if (usesSliderControl)" in slider_order_block
+    assert slider_order_block.index("toggleItem.appendChild(label);") < slider_order_block.index(
+        "toggleItem.appendChild(indicator);"
+    )
+
+
 def test_index_game_window_state_pauses_hidden_avatar_rendering():
     source = INDEX_TEMPLATE_PATH.read_text(encoding="utf-8")
     block = source.split("var pngtuberHiddenForGameWindow = false;", 1)[1].split(

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -151,11 +151,19 @@ def test_model_settings_proactive_controls_use_right_aligned_sliders():
     source = AVATAR_UI_POPUP_PATH.read_text(encoding="utf-8")
     settings_toggles_block = source.split("const settingsToggles = [", 1)[1].split("];", 1)[0]
 
-    assert settings_toggles_block.count("controlStyle: 'slider'") == 2
-    assert "id: 'proactive-chat'" in settings_toggles_block
-    assert "id: 'proactive-vision'" in settings_toggles_block
+    for toggle_id in ("proactive-chat", "proactive-vision"):
+        toggle_object = re.search(
+            rf"\{{[^{{}}]*id:\s*'{re.escape(toggle_id)}'[^{{}}]*\}}",
+            settings_toggles_block,
+        )
+        assert toggle_object, f"missing settings toggle object for {toggle_id}"
+        assert "controlStyle: 'slider'" in toggle_object.group(0)
 
     assert ".${prefix}-toggle-item.${prefix}-toggle-item-slider" in source
+    slider_label_style = source.split(
+        ".${prefix}-toggle-item-slider .${prefix}-toggle-label {", 1
+    )[1].split("}", 1)[0]
+    assert "flex: 1 1 auto;" in slider_label_style
     assert ".${prefix}-toggle-indicator.${prefix}-toggle-slider" in source
     assert "width: 36px;" in source
     assert "height: 20px;" in source

--- a/tests/unit/test_voice_start_failure_static.py
+++ b/tests/unit/test_voice_start_failure_static.py
@@ -410,6 +410,7 @@ def test_screen_share_start_is_single_flight_across_ui_entry_points():
     source = _read(APP_SCREEN_PATH)
     wrapper = "async " + _js_function_block(source, "startScreenSharing")
     pending_check = _js_function_block(source, "isScreenSharingStartPending")
+    cancel_start = _js_function_block(source, "cancelPendingScreenSharingStart")
     assert "var screenSharingStartAttempt = null;" in source
 
     node_harness = f"""
@@ -418,12 +419,18 @@ const S = {{ screenCaptureStream: null }};
 let screenSharingStartAttempt = null;
 let startCalls = 0;
 let releaseStart;
+let discardCalls = 0;
+function discardCancelledScreenSharingStart(attempt) {{
+  discardCalls += 1;
+  return attempt.cancelled;
+}}
 async function startScreenSharingOnce(attempt) {{
   startCalls += 1;
   await new Promise((resolve) => {{ releaseStart = resolve; }});
   return attempt.cancelled ? 'cancelled' : 'started';
 }}
 {pending_check}
+{cancel_start}
 {wrapper}
 
 async function run() {{
@@ -436,17 +443,37 @@ async function run() {{
   assert.deepStrictEqual(await Promise.all([first, second]), ['started', 'started']);
   assert.strictEqual(isScreenSharingStartPending(), false, 'the attempt must clear after settling');
 
-  let releaseRestart;
+  let releaseCancelled;
   startScreenSharingOnce = async function (attempt) {{
     startCalls += 1;
-    await new Promise((resolve) => {{ releaseRestart = resolve; }});
-    return attempt.cancelled ? 'cancelled' : 'restarted';
+    await new Promise((resolve) => {{ releaseCancelled = resolve; }});
+    return attempt.cancelled ? 'cancelled' : 'unexpected';
   }};
-  const third = startScreenSharing();
+  const cancelledStart = startScreenSharing();
   await Promise.resolve();
   assert.strictEqual(startCalls, 2, 'the guard must clear after the first attempt settles');
-  releaseRestart();
-  assert.strictEqual(await third, 'restarted');
+  assert.strictEqual(cancelPendingScreenSharingStart(), true);
+  assert.strictEqual(discardCalls, 1, 'cancellation must immediately clean any already-acquired stream');
+  assert.strictEqual(isScreenSharingStartPending(), false, 'a cancelled chooser must stop blocking retries immediately');
+
+  let releaseReplacement;
+  startScreenSharingOnce = async function (attempt) {{
+    startCalls += 1;
+    await new Promise((resolve) => {{ releaseReplacement = resolve; }});
+    return attempt.cancelled ? 'cancelled' : 'restarted';
+  }};
+  const replacement = startScreenSharing();
+  await Promise.resolve();
+  assert.strictEqual(startCalls, 3, 'a replacement start must not reuse the cancelled chooser');
+  assert.strictEqual(isScreenSharingStartPending(), true);
+
+  releaseCancelled();
+  assert.strictEqual(await cancelledStart, 'cancelled');
+  assert.strictEqual(isScreenSharingStartPending(), true, 'the old finally must not clear the replacement attempt');
+
+  releaseReplacement();
+  assert.strictEqual(await replacement, 'restarted');
+  assert.strictEqual(isScreenSharingStartPending(), false);
 }}
 
 run().catch((error) => {{
@@ -484,10 +511,13 @@ def test_pending_screen_share_cancellation_releases_the_late_stream():
     node_harness = f"""
 const assert = require('assert');
 const window = {{ t: (key) => key }};
+const safeT = (key, fallback) => fallback;
+const idleTimer = setTimeout(() => {{}}, 1000);
+idleTimer.unref();
 const S = {{
   screenCaptureStream: null,
   screenCaptureStreamLastUsed: 123,
-  screenCaptureStreamIdleTimer: setTimeout(() => {{}}, 10000),
+  screenCaptureStreamIdleTimer: idleTimer,
 }};
 {remember_stream}
 {discard_start}
@@ -536,6 +566,19 @@ S.screenCaptureStream = cachedStream;
 assert.strictEqual(discardCancelledScreenSharingStart(cachedAttempt), true);
 assert.strictEqual(cachedTrack.stopCalls, 0, 'cancellation must preserve a pre-existing cached stream');
 assert.strictEqual(S.screenCaptureStream, cachedStream);
+
+const throwingTrack = {{ onended: () => {{}}, stop() {{ throw new Error('stop failed'); }} }};
+const throwingStream = {{
+  getVideoTracks: () => [throwingTrack],
+  getTracks: () => [throwingTrack],
+}};
+const throwingAttempt = {{ cancelled: true, initialStream: null, acquiredStream: throwingStream }};
+S.screenCaptureStream = throwingStream;
+S.screenCaptureStreamLastUsed = 456;
+assert.strictEqual(discardCancelledScreenSharingStart(throwingAttempt), true);
+assert.strictEqual(S.screenCaptureStream, null, 'track stop errors must not prevent rollback');
+assert.strictEqual(S.screenCaptureStreamLastUsed, null);
+assert.strictEqual(throwingAttempt.acquiredStream, null);
 """
     result = run_node_stdin(
         node_executable,
@@ -551,6 +594,77 @@ assert.strictEqual(S.screenCaptureStream, cachedStream);
         )
 
 
+def test_stale_screen_video_play_cannot_replace_the_new_sender():
+    node_executable = shutil.which("node")
+    if node_executable is None:
+        pytest.skip("node not found")
+
+    source = _read(APP_SCREEN_PATH)
+    start_streaming = _js_function_block(source, "startScreenVideoStreaming")
+
+    node_harness = f"""
+const assert = require('assert');
+let nativeCaptureGeneration = 4;
+let releasePlay;
+let intervalCreations = 0;
+const video = {{
+  videoWidth: 0,
+  videoHeight: 0,
+  play: () => new Promise((resolve) => {{ releasePlay = resolve; }}),
+}};
+const document = {{ createElement: () => video }};
+const oldTrack = {{}};
+const oldStream = {{ getVideoTracks: () => [oldTrack] }};
+const replacementStream = {{ getVideoTracks: () => [{{}}] }};
+const S = {{
+  screenCaptureStream: oldStream,
+  screenCaptureStreamLastUsed: null,
+  screenCaptureStreamIdleTimer: null,
+  videoTrack: null,
+  videoSenderInterval: null,
+  socket: null,
+}};
+const C = {{ MAX_SCREENSHOT_WIDTH: 1280, MAX_SCREENSHOT_HEIGHT: 720 }};
+const WebSocket = {{ OPEN: 1 }};
+function scheduleScreenCaptureIdleCheck() {{}}
+async function stopLiveVisionStreamIfBlocked() {{ return false; }}
+function captureCanvasFrame() {{ throw new Error('stale stream must not capture'); }}
+function buildStreamDataMessage() {{ throw new Error('stale stream must not send'); }}
+function setInterval() {{ intervalCreations += 1; return {{ id: intervalCreations }}; }}
+function clearInterval() {{}}
+{start_streaming}
+
+async function run() {{
+  startScreenVideoStreaming(oldStream, 'screen');
+  S.screenCaptureStream = replacementStream;
+  nativeCaptureGeneration += 1;
+  releasePlay();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.strictEqual(intervalCreations, 0, 'a stale video.play continuation must not create a sender');
+  assert.strictEqual(S.videoSenderInterval, null);
+  assert.strictEqual(S.screenCaptureStream, replacementStream);
+}}
+
+run().catch((error) => {{
+  console.error(error);
+  process.exitCode = 1;
+}});
+"""
+    result = run_node_stdin(
+        node_executable,
+        node_harness,
+        capture_output=True,
+        check=False,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            "Node stale screen-video continuation scenario failed:\n"
+            f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+        )
+
+
 def test_every_screen_share_toggle_treats_a_pending_start_as_on():
     screen_source = _read(APP_SCREEN_PATH)
     common_ui_source = _read(COMMON_UI_PATH)
@@ -560,7 +674,7 @@ def test_every_screen_share_toggle_treats_a_pending_start_as_on():
     switch = screen_source.split(
         "window.switchScreenSharing = async function () {", 1
     )[1].split("\n    };", 1)[0]
-    assert "screenSharingStartAttempt.cancelled = true;" in stop
+    assert "cancelPendingScreenSharingStart();" in stop
     assert "if (isScreenSharingStartPending())" in switch
 
     toggle = common_ui_source.split(
@@ -574,13 +688,24 @@ def test_every_screen_share_toggle_treats_a_pending_start_as_on():
     assert inner_toggle.index("if (startPending") < inner_toggle.index(
         "if (button._nekoShareBusy) return;"
     )
+    assert "if (button._nekoShareCancelBusy) return;" in inner_toggle
+    assert "finishShareToggleOperation(cancelGeneration);" in inner_toggle
     assert "await window.stopScreenSharing();" in inner_toggle
+    assert "取消待处理启动失败" in inner_toggle
 
     start_once = "async " + _js_function_block(
         screen_source, "startScreenSharingOnce"
     )
     assert "rememberScreenSharingAttemptStream(attempt" in start_once
     assert "var captureStream = attempt.initialStream;" in start_once
+    assert "startScreenVideoStreaming(captureStream, streamInputType);" in start_once
+    assert "captureStream.getVideoTracks()[0].onended" in start_once
+    onended = start_once.index("captureStream.getVideoTracks()[0].onended")
+    stale_guard = start_once.index(
+        "if (S.screenCaptureStream !== captureStream)", onended
+    )
+    onended_stop = start_once.index("stopScreening();", onended)
+    assert stale_guard < onended_stop
     activate = start_once.index("screenButton().classList.add('active')")
     activation_guard = start_once.rfind(
         "discardCancelledScreenSharingStart(attempt)", 0, activate

--- a/tests/unit/test_voice_start_failure_static.py
+++ b/tests/unit/test_voice_start_failure_static.py
@@ -14,6 +14,7 @@ APP_AUDIO_CAPTURE_PATH = PROJECT_ROOT / "static" / "app" / "app-audio-capture.js
 APP_SCREEN_PATH = PROJECT_ROOT / "static" / "app" / "app-screen.js"
 APP_BUTTONS_PATH = PROJECT_ROOT / "static" / "app" / "app-buttons.js"
 APP_UI_PATH = PROJECT_ROOT / "static" / "app" / "app-ui"
+COMMON_UI_PATH = PROJECT_ROOT / "static" / "common_ui.js"
 
 
 def _read(path: Path) -> str:
@@ -408,18 +409,21 @@ def test_screen_share_start_is_single_flight_across_ui_entry_points():
 
     source = _read(APP_SCREEN_PATH)
     wrapper = "async " + _js_function_block(source, "startScreenSharing")
-    assert "var screenSharingStartPromise = null;" in source
+    pending_check = _js_function_block(source, "isScreenSharingStartPending")
+    assert "var screenSharingStartAttempt = null;" in source
 
     node_harness = f"""
 const assert = require('assert');
-let screenSharingStartPromise = null;
+const S = {{ screenCaptureStream: null }};
+let screenSharingStartAttempt = null;
 let startCalls = 0;
 let releaseStart;
-async function startScreenSharingOnce() {{
+async function startScreenSharingOnce(attempt) {{
   startCalls += 1;
   await new Promise((resolve) => {{ releaseStart = resolve; }});
-  return 'started';
+  return attempt.cancelled ? 'cancelled' : 'started';
 }}
+{pending_check}
 {wrapper}
 
 async function run() {{
@@ -427,14 +431,16 @@ async function run() {{
   const second = startScreenSharing();
   await Promise.resolve();
   assert.strictEqual(startCalls, 1, 'concurrent starts must share one capture attempt');
+  assert.strictEqual(isScreenSharingStartPending(), true, 'the shared attempt must be observable while pending');
   releaseStart();
   assert.deepStrictEqual(await Promise.all([first, second]), ['started', 'started']);
+  assert.strictEqual(isScreenSharingStartPending(), false, 'the attempt must clear after settling');
 
   let releaseRestart;
-  startScreenSharingOnce = async function () {{
+  startScreenSharingOnce = async function (attempt) {{
     startCalls += 1;
     await new Promise((resolve) => {{ releaseRestart = resolve; }});
-    return 'restarted';
+    return attempt.cancelled ? 'cancelled' : 'restarted';
   }};
   const third = startScreenSharing();
   await Promise.resolve();
@@ -460,6 +466,132 @@ run().catch((error) => {{
             "Node screen-share single-flight scenario failed:\n"
             f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
         )
+
+
+def test_pending_screen_share_cancellation_releases_the_late_stream():
+    node_executable = shutil.which("node")
+    if node_executable is None:
+        pytest.skip("node not found")
+
+    source = _read(APP_SCREEN_PATH)
+    remember_stream = _js_function_block(
+        source, "rememberScreenSharingAttemptStream"
+    )
+    discard_start = _js_function_block(
+        source, "discardCancelledScreenSharingStart"
+    )
+
+    node_harness = f"""
+const assert = require('assert');
+const window = {{ t: (key) => key }};
+const S = {{
+  screenCaptureStream: null,
+  screenCaptureStreamLastUsed: 123,
+  screenCaptureStreamIdleTimer: setTimeout(() => {{}}, 10000),
+}};
+{remember_stream}
+{discard_start}
+
+const track = {{ stopCalls: 0, onended: () => {{}}, stop() {{ this.stopCalls += 1; }} }};
+const lateStream = {{
+  getVideoTracks: () => [track],
+  getTracks: () => [track],
+}};
+const attempt = {{ cancelled: true, initialStream: null, acquiredStream: null }};
+S.screenCaptureStream = rememberScreenSharingAttemptStream(attempt, lateStream);
+
+assert.strictEqual(discardCancelledScreenSharingStart(attempt), true);
+assert.strictEqual(track.stopCalls, 1, 'a stream returned after cancellation must be stopped');
+assert.strictEqual(track.onended, null, 'late stream cleanup must not run the normal onended path');
+assert.strictEqual(S.screenCaptureStream, null);
+assert.strictEqual(S.screenCaptureStreamLastUsed, null);
+assert.strictEqual(S.screenCaptureStreamIdleTimer, null);
+assert.strictEqual(attempt.acquiredStream, null);
+
+const proactiveTrack = {{ stopCalls: 0, stop() {{ this.stopCalls += 1; }} }};
+const proactiveStream = {{
+  getVideoTracks: () => [proactiveTrack],
+  getTracks: () => [proactiveTrack],
+}};
+const lateTrack = {{ stopCalls: 0, stop() {{ this.stopCalls += 1; }} }};
+const secondLateStream = {{
+  getVideoTracks: () => [lateTrack],
+  getTracks: () => [lateTrack],
+}};
+const racedAttempt = {{ cancelled: true, initialStream: null, acquiredStream: null }};
+rememberScreenSharingAttemptStream(racedAttempt, secondLateStream);
+S.screenCaptureStream = proactiveStream;
+assert.strictEqual(discardCancelledScreenSharingStart(racedAttempt), true);
+assert.strictEqual(lateTrack.stopCalls, 1);
+assert.strictEqual(S.screenCaptureStream, proactiveStream, 'a concurrent proactive stream must be preserved');
+assert.strictEqual(proactiveTrack.stopCalls, 0);
+
+const cachedTrack = {{ stopCalls: 0, stop() {{ this.stopCalls += 1; }} }};
+const cachedStream = {{
+  getVideoTracks: () => [cachedTrack],
+  getTracks: () => [cachedTrack],
+}};
+const cachedAttempt = {{ cancelled: true, initialStream: cachedStream, acquiredStream: cachedStream }};
+S.screenCaptureStream = cachedStream;
+assert.strictEqual(discardCancelledScreenSharingStart(cachedAttempt), true);
+assert.strictEqual(cachedTrack.stopCalls, 0, 'cancellation must preserve a pre-existing cached stream');
+assert.strictEqual(S.screenCaptureStream, cachedStream);
+"""
+    result = run_node_stdin(
+        node_executable,
+        node_harness,
+        capture_output=True,
+        check=False,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            "Node pending screen-share cancellation scenario failed:\n"
+            f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+        )
+
+
+def test_every_screen_share_toggle_treats_a_pending_start_as_on():
+    screen_source = _read(APP_SCREEN_PATH)
+    common_ui_source = _read(COMMON_UI_PATH)
+    audio_capture_source = _read(APP_AUDIO_CAPTURE_PATH)
+
+    stop = _js_function_block(screen_source, "stopScreenSharing")
+    switch = screen_source.split(
+        "window.switchScreenSharing = async function () {", 1
+    )[1].split("\n    };", 1)[0]
+    assert "screenSharingStartAttempt.cancelled = true;" in stop
+    assert "if (isScreenSharingStartPending())" in switch
+
+    toggle = common_ui_source.split(
+        "window.toggleScreenShare = function () {", 1
+    )[1].split("\n};", 1)[0]
+    assert "window.isScreenSharingStartPending()" in toggle
+    assert "const isActiveOrPending = isActive || isStartPending;" in toggle
+    assert "detail: { active: !isActiveOrPending }" in toggle
+
+    inner_toggle = _js_function_block(audio_capture_source, "handleToggleClick")
+    assert inner_toggle.index("if (startPending") < inner_toggle.index(
+        "if (button._nekoShareBusy) return;"
+    )
+    assert "await window.stopScreenSharing();" in inner_toggle
+
+    start_once = "async " + _js_function_block(
+        screen_source, "startScreenSharingOnce"
+    )
+    assert "rememberScreenSharingAttemptStream(attempt" in start_once
+    assert "var captureStream = attempt.initialStream;" in start_once
+    activate = start_once.index("screenButton().classList.add('active')")
+    activation_guard = start_once.rfind(
+        "discardCancelledScreenSharingStart(attempt)", 0, activate
+    )
+    assert activation_guard > start_once.index("fetchBackendScreenshot()")
+    commit_stream = start_once.index("S.screenCaptureStream = captureStream;")
+    first_post_capture_guard = start_once.index(
+        "if (discardCancelledScreenSharingStart(attempt)) return;",
+        start_once.index("// 使用标准的getDisplayMedia"),
+    )
+    assert first_post_capture_guard < commit_stream
 
 
 def test_screen_share_toggle_has_blue_wave_and_four_point_sparkles():

--- a/tests/unit/test_voice_start_failure_static.py
+++ b/tests/unit/test_voice_start_failure_static.py
@@ -11,6 +11,7 @@ from tests.node_harness import run_node_stdin
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 APP_AUDIO_CAPTURE_PATH = PROJECT_ROOT / "static" / "app" / "app-audio-capture.js"
+APP_SCREEN_PATH = PROJECT_ROOT / "static" / "app" / "app-screen.js"
 APP_BUTTONS_PATH = PROJECT_ROOT / "static" / "app" / "app-buttons.js"
 APP_UI_PATH = PROJECT_ROOT / "static" / "app" / "app-ui"
 
@@ -376,13 +377,16 @@ def test_floating_mic_popup_exposes_screen_share_start_and_stop_action():
     assert "window.t('app.screenShareRequiresVoice')" in toggle_factory
     assert toggle_factory.index(voice_guard) < toggle_factory.index(start_call)
 
-    # 启用动画：像素扫过填充（参考视频按钮的像素动画）
-    assert "neko-share-toggle-fill" in toggle_factory
+    # Activation animation: a blue wave fills from the knob, followed by sparkles.
+    assert "neko-share-toggle-wave" in toggle_factory
+    assert "createShareSparkleLayer()" in toggle_factory
     assert "isScreenShareActive()" in toggle_factory
-    cleanup = "shareToggleButtonRegistry = shareToggleButtonRegistry.filter(function (btn) { return btn.isConnected; });"
+    cleanup = "pruneShareToggleButtons();"
     register = "shareToggleButtonRegistry.push(button);"
     assert cleanup in toggle_factory
     assert toggle_factory.index(cleanup) < toggle_factory.index(register)
+    assert "button.setAttribute('aria-label', accessibleLabel);" in toggle_factory
+    assert "button.setAttribute('aria-busy', 'true');" in toggle_factory
 
     # 合并为一行：迷你胶囊开关嵌在「屏幕共享」设置行右侧（替换 chevron）
     render_start = source.index("window.renderFloatingMicList = async function")
@@ -397,42 +401,117 @@ def test_floating_mic_popup_exposes_screen_share_start_and_stop_action():
     assert "leftColumn.insertBefore(shareToggleButton, firstContent);" not in render
 
 
-def test_screen_share_toggle_has_pixel_sweep_animation():
+def test_screen_share_start_is_single_flight_across_ui_entry_points():
+    node_executable = shutil.which("node")
+    if node_executable is None:
+        pytest.skip("node not found")
+
+    source = _read(APP_SCREEN_PATH)
+    wrapper = "async " + _js_function_block(source, "startScreenSharing")
+    assert "var screenSharingStartPromise = null;" in source
+
+    node_harness = f"""
+const assert = require('assert');
+let screenSharingStartPromise = null;
+let startCalls = 0;
+let releaseStart;
+async function startScreenSharingOnce() {{
+  startCalls += 1;
+  await new Promise((resolve) => {{ releaseStart = resolve; }});
+  return 'started';
+}}
+{wrapper}
+
+async function run() {{
+  const first = startScreenSharing();
+  const second = startScreenSharing();
+  await Promise.resolve();
+  assert.strictEqual(startCalls, 1, 'concurrent starts must share one capture attempt');
+  releaseStart();
+  assert.deepStrictEqual(await Promise.all([first, second]), ['started', 'started']);
+
+  let releaseRestart;
+  startScreenSharingOnce = async function () {{
+    startCalls += 1;
+    await new Promise((resolve) => {{ releaseRestart = resolve; }});
+    return 'restarted';
+  }};
+  const third = startScreenSharing();
+  await Promise.resolve();
+  assert.strictEqual(startCalls, 2, 'the guard must clear after the first attempt settles');
+  releaseRestart();
+  assert.strictEqual(await third, 'restarted');
+}}
+
+run().catch((error) => {{
+  console.error(error);
+  process.exitCode = 1;
+}});
+"""
+    result = run_node_stdin(
+        node_executable,
+        node_harness,
+        capture_output=True,
+        check=False,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            "Node screen-share single-flight scenario failed:\n"
+            f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+        )
+
+
+def test_screen_share_toggle_has_blue_wave_and_four_point_sparkles():
     source = _read(APP_AUDIO_CAPTURE_PATH)
     styles = _js_function_block(source, "injectShareToggleStyles")
 
-    # 画布像素层：低分辨率画布 + pixelated 放大呈现马赛克块
-    assert "canvas.neko-share-toggle-fill" in styles
-    assert "image-rendering:pixelated;" in styles
-    assert ".neko-share-toggle-btn.is-active canvas.neko-share-toggle-fill" in styles
+    # The fill is clipped from the resting knob centre and settles on a blue background.
+    assert ".neko-share-toggle-btn .neko-share-toggle-wave" in styles
+    assert "clip-path:circle(0 at var(--neko-share-wave-x) 50%)" in styles
+    assert "clip-path:circle(var(--neko-share-wave-radius) at var(--neko-share-wave-x) 50%)" in styles
+    assert "#61ccff" in styles and "#44b7fe" in styles and "#269fe8" in styles
+    assert "#8a5ce8" not in source
+    assert "neko-share-toggle-goal" not in source
+    assert "neko-share-toggle-fill" not in source
+    assert "image-rendering:pixelated" not in source
 
-    # 像素溶解引擎：随机马赛克从右向左扫过 + 填满后闪烁
-    fx = _js_function_block(source, "createSharePixelFx")
-    assert "SHARE_PIXEL_PALETTE" in fx
-    assert "SHARE_PIXEL_JITTER" in fx
-    assert "requestAnimationFrame" in fx
-    assert "activate" in fx and "deactivate" in fx
-    assert "startShimmer" in fx
+    # Stars start only after the wave completes and are removed after one pass.
+    fx = _js_function_block(source, "createShareWaveFx")
+    assert "SHARE_WAVE_FILL_MS" in fx
+    assert "setTimeout(startSparkles, SHARE_WAVE_FILL_MS)" in fx
+    assert "is-sparkling" in fx
+    assert "prefersReducedMotion" in fx
+    assert "setInterval" not in fx
+    sparkle_factory = _js_function_block(source, "createShareSparkleLayer")
+    assert "http://www.w3.org/2000/svg" in sparkle_factory
+    assert "M12 1.5C13.6 7.9" in sparkle_factory
+    assert "#00aeef" in sparkle_factory
+    assert "rgba(255,255,255,0.96)" in sparkle_factory
 
-    # 按钮使用画布填充层 + 滑块/紫色目标点（复刻参考视频，灰点按需求不实现）
+    # The real toggle uses the wave/sparkle layers; stopping never replays activation.
     toggle_factory = _js_function_block(source, "createScreenShareToggleButton")
-    assert "document.createElement('canvas')" in toggle_factory
+    assert "document.createElement('canvas')" not in toggle_factory
+    assert "neko-share-toggle-wave" in toggle_factory
     assert "neko-share-toggle-knob" in toggle_factory
-    assert "neko-share-toggle-dots" not in toggle_factory
-    assert "neko-share-toggle-goal" in toggle_factory
-    assert "pixelFx.activate" in toggle_factory
-    assert "pixelFx.deactivate" in toggle_factory
+    assert "waveFx.activate" in toggle_factory
+    assert "waveFx.deactivate" in toggle_factory
+    assert ".replay(" not in toggle_factory
 
-    # 滑块默认在左端，启用后滑到右端；像素前沿带软过渡与左端渐变尾；含迷你行内变体
-    styles = _js_function_block(source, "injectShareToggleStyles")
+    # Full and inline variants keep matching knob positions and wave origins.
     assert ".neko-share-toggle-btn.is-active .neko-share-toggle-knob{left:calc(100% - 36px);}" in styles
     assert ".neko-share-toggle-btn.neko-share-toggle-mini" in styles
     assert ".neko-share-toggle-mini.is-active .neko-share-toggle-knob{left:calc(100% - 21px);}" in styles
-    fx = _js_function_block(source, "createSharePixelFx")
-    assert "SHARE_PIXEL_FADE" in fx
-    assert "SHARE_PIXEL_MIN_ALPHA" in fx
+    assert "--neko-share-wave-x:20px" in styles
+    assert "--neko-share-wave-x:12px" in styles
+    assert "--neko-share-wave-radius:148%" in styles
+    assert "--neko-share-wave-radius:116%" in styles
+    assert "prefers-reduced-motion:reduce" in styles
 
-    # 状态与隐藏 #screenButton 的 .active class 同步
+    prune = _js_function_block(source, "pruneShareToggleButtons")
+    assert "btn._nekoShareFxCleanup()" in prune
+
+    # State remains sourced from the hidden #screenButton .active class.
     assert "isScreenShareActive" in source
     assert "MutationObserver" in source
     assert "syncShareToggleButtons" in source
@@ -453,6 +532,22 @@ def test_mic_main_action_matches_settings_chevron_and_hover_expands():
     assert "openScreenSourceSubwindow" in source
     assert "MIC_ACTION_HOVER_COLLAPSE_MS = 260" in source
     assert "wireMicSubwindowHoverBridge" in source
+    assert "textWrap.className = 'neko-mic-action-text';" in action_button
+    assert "if (iconText) {" in action_button
+    assert "screenActionButton.querySelector('.neko-mic-action-text')" in source
+    assert "var screenActionButton = createMainActionButton(\n                null," in source
+    assert "var micActionButton = createMainActionButton(\n                null," in source
+    subwindow = _js_function_block(source, "createMicSubwindow")
+    assert "if (iconText) {" in subwindow
+    assert "titleWrap.appendChild(icon);" in subwindow
+    assert (
+        "window.t ? window.t('microphone.deviceTitle') : 'Select Microphone',\n"
+        "                    null,"
+    ) in source
+    assert (
+        "window.t ? window.t('buttons.screenShare') : 'Screen Share',\n"
+        "                    null,"
+    ) in source
 
 
 def test_mic_device_subwindow_retries_permission_when_device_cache_is_empty():


### PR DESCRIPTION
…果，并移除相关菜单表情图标

<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

优化模型设置与语音控制 UI；完善麦克风与屏幕分享快捷按钮、入场动画及状态同步；重做分享开关动画效果

## 测试 / Testing

手动测试新UI确保正常使用

## 对比

改动前：
<img width="255" height="114" alt="image" src="https://github.com/user-attachments/assets/88dceca6-542a-4a04-855a-723054e90885" />
<img width="1098" height="705" alt="image" src="https://github.com/user-attachments/assets/4f9c9d8b-0ccf-43d9-92c9-132d1417ed73" />



改动后：
<img width="243" height="111" alt="image" src="https://github.com/user-attachments/assets/7948377e-8269-4ac6-a586-9b1aa099a889" />
<img width="1056" height="678" alt="image" src="https://github.com/user-attachments/assets/0b10e6ad-542e-47fd-a2dc-8568976570b1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 优化屏幕共享开关为蓝色波纹与星光动效，并增强无障碍状态提示（如 aria-busy/aria-label）。
  * 新增语音会话快捷控件，统一麦克风静音与屏幕分享的快捷操作（覆盖不同渲染器）。
  * 设置中的主动聊天/主动视觉开关支持滑块样式。
* **改进**
  * 屏幕共享启动/切换加入防重复与取消保护，减少等待中卡住、状态错乱；快捷按钮显隐与长文案换行更顺畅。
* **Bug 修复**
  * 强化快捷/浮动按钮重建与销毁的清理，降低残留监听与异常行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->