### PR TITLE
fix(lock): 主动搭话来源历史落盘挪进锁内，live2d 砍掉 GET 上的落盘并给 POST 加 per-file 锁（#2528 第 3 步）

### DIFF
--- a/docs/api/rest/live2d.md
+++ b/docs/api/rest/live2d.md
@@ -31,7 +31,7 @@ These 17 routes back N.E.K.O.'s first-party Live2D model manager and parameter e
 
 ## Configuration and emotion mappings
 
-The configuration `GET` routes return `{ "success": true, "config": {...} }`. If a readable `.model3.json` lacks `FileReferences.Motions` or `FileReferences.Expressions`, the handler adds the missing containers and attempts to write them back.
+The configuration `GET` routes return `{ "success": true, "config": {...} }`. If a readable `.model3.json` lacks `FileReferences.Motions` or `FileReferences.Expressions`, the handler adds the missing containers **to the response only** — these routes never write to disk. Persisting a repaired configuration is the `POST` routes' job.
 
 The configuration `POST` routes accept a JSON object shaped like Cubism configuration, but deliberately persist only:
 

--- a/docs/ja/api/rest/live2d.md
+++ b/docs/ja/api/rest/live2d.md
@@ -31,7 +31,7 @@
 
 ## 設定と感情マッピング
 
-設定 `GET` は `{ "success": true, "config": {...} }` を返します。読み取れる `.model3.json` に `FileReferences.Motions` または `FileReferences.Expressions` がない場合、ハンドラーはコンテナを追加して書き戻しを試みます。
+設定 `GET` は `{ "success": true, "config": {...} }` を返します。読み取れる `.model3.json` に `FileReferences.Motions` または `FileReferences.Expressions` がない場合、ハンドラーは不足しているコンテナを**レスポンスにのみ**追加します。これらのルートがディスクに書き込むことはありません。修復した設定の永続化は `POST` ルートの役割です。
 
 設定 `POST` は Cubism 設定形式の JSON を受け取りますが、永続化するのは次だけです：
 

--- a/docs/zh-CN/api/rest/live2d.md
+++ b/docs/zh-CN/api/rest/live2d.md
@@ -31,7 +31,7 @@
 
 ## 配置与情绪映射
 
-配置 `GET` 路由返回 `{ "success": true, "config": {...} }`。如果可读的 `.model3.json` 缺少 `FileReferences.Motions` 或 `FileReferences.Expressions`，处理器会补上容器并尝试写回。
+配置 `GET` 路由返回 `{ "success": true, "config": {...} }`。如果可读的 `.model3.json` 缺少 `FileReferences.Motions` 或 `FileReferences.Expressions`，处理器只会把缺失的容器补进**响应**里 —— 这些路由不写磁盘。把修补后的配置落盘是 `POST` 路由的职责。
 
 配置 `POST` 接受类似 Cubism 配置的 JSON，但只持久化：
 

--- a/main_logic/proactive_chat/state.py
+++ b/main_logic/proactive_chat/state.py
@@ -195,7 +195,19 @@ async def _record_source_used(
         # 这是个跨角色的单文件，多个投递并发时锁只盖内存不盖落盘等于没盖。
         # 写本身仍在 to_thread 里跑（atomic_write_json_async 内部），持的是 asyncio.Lock
         # 不是 threading.Lock，所以事件循环在等待期间照样服务别的请求。
-        await _persist_source_history_unlocked(memory_dir=memory_dir)
+        #
+        # to_thread 一旦交出去就取消不掉 —— 线程会一直跑到 os.replace 结束。所以不能直接
+        # await：这里被 cancel（退出时最常见）时 async with 会在 CancelledError 穿过的
+        # 一刻就把锁放掉，而那次 os.replace 还在飞，「写在锁内」的不变量就破了。shield 让
+        # 取消落在外层、写盘任务照跑；再显式等它收尾之后才让 CancelledError 继续往上走。
+        writer = asyncio.ensure_future(
+            _persist_source_history_unlocked(memory_dir=memory_dir)
+        )
+        try:
+            await asyncio.shield(writer)
+        except asyncio.CancelledError:
+            await asyncio.wait({writer})
+            raise
 
 
 # --- 主动搭话近期记录暂存区 ---

--- a/main_logic/proactive_chat/state.py
+++ b/main_logic/proactive_chat/state.py
@@ -137,6 +137,31 @@ async def _ensure_source_history_loaded(
         _source_history_loaded_path = path
 
 
+async def _persist_source_history_unlocked(
+    *, memory_dir: str | Path | None = None
+) -> None:
+    """Persist the in-memory source history. The caller must hold _source_history_lock."""
+    # 快照故意在这里、在锁内自己取，而不是由调用方传进来：调用方取完快照再到锁外落盘，
+    # 两次投递抵达 os.replace 的顺序可以和取快照的顺序反过来，把新历史写回旧值；
+    # Windows 上两个并发 os.replace 打同一个目标还会互相 PermissionError(WinError 5)。
+    # 不接 snapshot 参数，这个反转窗口就从代码里消失，而不是靠调用约定维持。
+    try:
+        await atomic_write_json_async(
+            _source_history_path(memory_dir=memory_dir),
+            {
+                "v": _SOURCE_HISTORY_SCHEMA_VERSION,
+                "entries": dict(_source_history),
+            },
+        )
+    except Exception as exc:
+        logger.warning(
+            "落盘 %s 失败: %s: %s",
+            _SOURCE_HISTORY_FILENAME,
+            type(exc).__name__,
+            exc,
+        )
+
+
 async def _record_source_used(
     *,
     url: str,
@@ -166,21 +191,11 @@ async def _record_source_used(
         ]
         for existing_hash in forgotten:
             _source_history.pop(existing_hash, None)
-        snapshot = {
-            "v": _SOURCE_HISTORY_SCHEMA_VERSION,
-            "entries": dict(_source_history),
-        }
-    try:
-        await atomic_write_json_async(
-            _source_history_path(memory_dir=memory_dir), snapshot
-        )
-    except Exception as exc:
-        logger.warning(
-            "落盘 %s 失败: %s: %s",
-            _SOURCE_HISTORY_FILENAME,
-            type(exc).__name__,
-            exc,
-        )
+        # 落盘也在锁内，对偶于 _increment_proactive_chat_total 调 _persist_totals_unlocked：
+        # 这是个跨角色的单文件，多个投递并发时锁只盖内存不盖落盘等于没盖。
+        # 写本身仍在 to_thread 里跑（atomic_write_json_async 内部），持的是 asyncio.Lock
+        # 不是 threading.Lock，所以事件循环在等待期间照样服务别的请求。
+        await _persist_source_history_unlocked(memory_dir=memory_dir)
 
 
 # --- 主动搭话近期记录暂存区 ---

--- a/main_logic/proactive_chat/state.py
+++ b/main_logic/proactive_chat/state.py
@@ -20,6 +20,7 @@ import difflib
 import hashlib
 import re
 import time
+from contextlib import suppress
 from collections import deque
 from pathlib import Path
 from typing import Any
@@ -206,7 +207,11 @@ async def _record_source_used(
         try:
             await asyncio.shield(writer)
         except asyncio.CancelledError:
-            await asyncio.wait({writer})
+            # 循环而不是等一次：第二次取消（退出时最常见）会把这次 asyncio.wait 本身也
+            # 打断，锁又提前放了。writer 是 to_thread，线程一定会跑完，循环必然终止。
+            while not writer.done():
+                with suppress(asyncio.CancelledError):
+                    await asyncio.wait({writer})
             raise
 
 

--- a/main_routers/live2d_router.py
+++ b/main_routers/live2d_router.py
@@ -43,7 +43,7 @@ from fastapi.responses import JSONResponse
 
 from .shared_state import get_config_manager
 from .workshop_router import get_subscribed_workshop_items
-from utils.file_utils import atomic_write_json, atomic_write_json_async, read_json_async
+from utils.file_utils import atomic_write_json_async, read_json_async
 from utils.frontend_utils import find_models, find_model_directory, find_workshop_item_by_id
 from utils.logger_config import get_module_logger
 from utils.url_utils import encode_url_path
@@ -51,6 +51,42 @@ from utils.workshop_utils import get_workshop_path
 
 router = APIRouter(prefix="/api/live2d", tags=["live2d"])
 logger = get_module_logger(__name__, "Main")
+
+
+# 同一个 .model3.json 会被三个 POST 改写：/model_config/{name}、
+# /model_config_by_id/{id}、/emotion_mapping/{name}。三者都是「读盘→改→整覆盖」，
+# 不做 merge，所以无锁并发时后写者会静默丢掉前写者的整段编辑；而且 Windows 上
+# 两个并发 os.replace 打同一个目标会互相 PermissionError(WinError 5)。
+# 因此临界区必须从「读」之前开始 —— 只把写包起来是没用的，丢写窗口是读到写的整段。
+#
+# 按「解析后的文件路径」分桶而不是按 model_name / model_id：by-name 与 by-id
+# 两条路由可以落到同一个文件上，按入参分桶等于没互斥。
+#
+# 为什么这里用 asyncio.Lock 而不是 threading.Lock（本仓库另几处同型修复选的是后者）：
+# 判据是「所有写者是否都在事件循环上」。这里成立 —— 三个写者全是 async 端点，而两个
+# 同步 GET（跑在 anyio 线程池里）已经不再落盘。反过来说，只要 GET 还要写盘，就必须整体
+# 切到 threading.Lock + asyncio.to_thread：在 worker 线程里 acquire 一把 asyncio.Lock
+# 是不允许的（它不是线程安全的），混用两种锁是伪修复。
+# ⚠️ 代价：模块级 asyncio.Lock 一旦被争用就绑死在当时的事件循环上。生产上只有一个
+# 循环（merged 单进程），但测试要制造争用就必须在用例之间清掉这个字典，否则
+# function-scope 的 loop 换掉之后第二个用例会 RuntimeError。
+#
+# 锁活在模块级而不是挂在 router 实例上：模块只 import 一次，重建 APIRouter /
+# 重新 include_router 都不会造出第二套互斥域。字典只在事件循环线程上被读写，
+# 从查找到插入之间没有 await，所以 get-or-create 是原子的，不需要额外 guard 锁。
+_MODEL_CONFIG_WRITE_LOCKS: dict[str, asyncio.Lock] = {}
+
+
+def _model_config_write_lock(model_json_path: str | os.PathLike) -> asyncio.Lock:
+    """Return the per-file write lock for a resolved ``.model3.json``."""
+    # realpath 折掉 junction/symlink 与 "." 之类的写法差异，normcase 折掉 Windows 的大小写，
+    # 让同一个文件的不同拼法落到同一把锁上。
+    key = os.path.normcase(os.path.realpath(os.fspath(model_json_path)))
+    lock = _MODEL_CONFIG_WRITE_LOCKS.get(key)
+    if lock is None:
+        lock = asyncio.Lock()
+        _MODEL_CONFIG_WRITE_LOCKS[key] = lock
+    return lock
 
 
 def _normalize_model_path(path: str) -> str:
@@ -370,31 +406,19 @@ def get_model_config(model_name: str):
         with open(model_json_path, 'r', encoding='utf-8') as f:
             config_data = json.load(f)
         
-        # 检查并自动添加缺失的配置
-        config_updated = False
-        
-        # 确保FileReferences存在
-        if 'FileReferences' not in config_data:
-            config_data['FileReferences'] = {}
-            config_updated = True
-        
-        # 确保Motions存在
-        if 'Motions' not in config_data['FileReferences']:
-            config_data['FileReferences']['Motions'] = {}
-            config_updated = True
-        
-        # 确保Expressions存在
-        if 'Expressions' not in config_data['FileReferences']:
-            config_data['FileReferences']['Expressions'] = []
-            config_updated = True
-        
-        # 如果配置有更新，保存到文件（写入失败时不影响读取结果）
-        if config_updated:
-            try:
-                atomic_write_json(model_json_path, config_data, ensure_ascii=False, indent=4)
-                logger.info(f"已为模型 {model_name} 自动添加缺失的配置项")
-            except Exception as write_err:
-                logger.warning(f"无法写回模型配置（可能受Windows安全策略/反勒索防护保护）: {write_err}")
+        # 检查并自动添加缺失的配置。只补在内存里、随 response 返回，不写盘。
+        #
+        # 这个端点是同步 def，跑在 anyio 线程池里；在这儿落盘就等于让读流量变成写流量，
+        # 而且它和三个 POST 的 asyncio 锁不在同一个互斥域里（asyncio.Lock 非线程安全，
+        # worker 线程不能碰）。两个窗口同时首次拉同一个老模型，就是两个线程 os.replace
+        # 同一个目标 → Windows 上互相 PermissionError(WinError 5)。落盘归 POST。
+        #
+        # 补的全是空默认值，仓库里每个消费者都已按可缺省读取（本文件 get_emotion_mapping、
+        # app/monitor.py 的 `.get('FileReferences', {}) or {}`、三个 POST 的 setdefault），
+        # 没有任何一处依赖它们在盘上存在；docs/api/rest/live2d.md 也把本端点写成只读。
+        file_refs = config_data.setdefault('FileReferences', {})
+        file_refs.setdefault('Motions', {})
+        file_refs.setdefault('Expressions', [])
 
         return {"success": True, "config": config_data}
     except Exception as e:
@@ -425,17 +449,20 @@ async def update_model_config(model_name: str, request: Request):
         if not model_json_path or not os.path.exists(model_json_path):
             return JSONResponse(status_code=404, content={"success": False, "error": "模型配置文件不存在"})
         
-        # 为了安全，只允许修改 Motions 和 Expressions
-        current_config = await read_json_async(model_json_path)
+        # 为了安全，只允许修改 Motions 和 Expressions。
+        # 读→改→写整段在锁内：只把写包起来，两个并发请求照样读到同一份底稿，
+        # 后写者整篇覆盖、静默丢掉前写者的编辑。
+        async with _model_config_write_lock(model_json_path):
+            current_config = await read_json_async(model_json_path)
 
-        file_refs = current_config.setdefault("FileReferences", {})
-        if 'FileReferences' in data and 'Motions' in data['FileReferences']:
-            file_refs['Motions'] = data['FileReferences']['Motions']
-            
-        if 'FileReferences' in data and 'Expressions' in data['FileReferences']:
-            file_refs['Expressions'] = data['FileReferences']['Expressions']
+            file_refs = current_config.setdefault("FileReferences", {})
+            if 'FileReferences' in data and 'Motions' in data['FileReferences']:
+                file_refs['Motions'] = data['FileReferences']['Motions']
 
-        await atomic_write_json_async(model_json_path, current_config, ensure_ascii=False, indent=4)  # 使用 indent=4 保持格式
+            if 'FileReferences' in data and 'Expressions' in data['FileReferences']:
+                file_refs['Expressions'] = data['FileReferences']['Expressions']
+
+            await atomic_write_json_async(model_json_path, current_config, ensure_ascii=False, indent=4)  # 使用 indent=4 保持格式
 
         return {"success": True, "message": "模型配置已更新"}
     except Exception as e:
@@ -538,72 +565,75 @@ async def update_emotion_mapping(model_name: str, request: Request):
         if not model_json_path or not os.path.exists(model_json_path):
             return JSONResponse(status_code=404, content={"success": False, "error": "模型配置文件不存在"})
 
-        config_data = await read_json_async(model_json_path)
+        # 读→改→写整段在锁内，同 update_model_config。下面那段 Cubism 结构变换是纯 CPU、
+        # 内部没有 await，整块套进锁不改变任何逻辑（评审用 git diff -w 看，是纯缩进）。
+        async with _model_config_write_lock(model_json_path):
+            config_data = await read_json_async(model_json_path)
 
-        # 统一写入到标准 Cubism 结构（FileReferences.Motions / FileReferences.Expressions）
-        file_refs = config_data.setdefault('FileReferences', {})
+            # 统一写入到标准 Cubism 结构（FileReferences.Motions / FileReferences.Expressions）
+            file_refs = config_data.setdefault('FileReferences', {})
 
-        # 处理 motions: data 结构为 { motions: { emotion: ["motions/xxx.motion3.json", ...] }, expressions: {...} }
-        motions_input = (data.get('motions') if isinstance(data, dict) else None) or {}
-        motions_output = {}
-        for group_name, files in motions_input.items():
-            # 禁止在"常驻"组配置任何motion
-            if group_name == '常驻':
-                logger.info("忽略常驻组中的motion配置（只允许expression）")
-                continue
-            items = []
-            for file_path in files or []:
-                if not isinstance(file_path, str):
+            # 处理 motions: data 结构为 { motions: { emotion: ["motions/xxx.motion3.json", ...] }, expressions: {...} }
+            motions_input = (data.get('motions') if isinstance(data, dict) else None) or {}
+            motions_output = {}
+            for group_name, files in motions_input.items():
+                # 禁止在"常驻"组配置任何motion
+                if group_name == '常驻':
+                    logger.info("忽略常驻组中的motion配置（只允许expression）")
                     continue
-                normalized = file_path.replace('\\', '/')
-                p = pathlib.PurePosixPath(normalized)
-                if p.is_absolute() or ".." in p.parts:
-                    continue
-                normalized = str(p)
+                items = []
+                for file_path in files or []:
+                    if not isinstance(file_path, str):
+                        continue
+                    normalized = file_path.replace('\\', '/')
+                    p = pathlib.PurePosixPath(normalized)
+                    if p.is_absolute() or ".." in p.parts:
+                        continue
+                    normalized = str(p)
 
-                items.append({"File": normalized})
-            motions_output[group_name] = items
-        file_refs['Motions'] = motions_output
+                    items.append({"File": normalized})
+                motions_output[group_name] = items
+            file_refs['Motions'] = motions_output
 
-        # 处理 expressions: 将按 emotion 前缀生成扁平列表，Name 采用 "{emotion}_{basename}" 的约定
-        expressions_input = (data.get('expressions') if isinstance(data, dict) else None) or {}
+            # 处理 expressions: 将按 emotion 前缀生成扁平列表，Name 采用 "{emotion}_{basename}" 的约定
+            expressions_input = (data.get('expressions') if isinstance(data, dict) else None) or {}
 
-        # 先保留不属于我们情感前缀的原始表达（避免覆盖用户自定义）
-        existing_expressions = file_refs.get('Expressions', []) or []
-        emotion_prefixes = set(expressions_input.keys())
-        preserved_expressions = []
-        for item in existing_expressions:
-            try:
-                name = (item.get('Name') or '') if isinstance(item, dict) else ''
-                prefix = name.split('_', 1)[0] if '_' in name else None
-                if not prefix or prefix not in emotion_prefixes:
+            # 先保留不属于我们情感前缀的原始表达（避免覆盖用户自定义）
+            existing_expressions = file_refs.get('Expressions', []) or []
+            emotion_prefixes = set(expressions_input.keys())
+            preserved_expressions = []
+            for item in existing_expressions:
+                try:
+                    name = (item.get('Name') or '') if isinstance(item, dict) else ''
+                    prefix = name.split('_', 1)[0] if '_' in name else None
+                    if not prefix or prefix not in emotion_prefixes:
+                        preserved_expressions.append(item)
+                except Exception:
                     preserved_expressions.append(item)
-            except Exception:
-                preserved_expressions.append(item)
 
-        new_expressions = []
-        for emotion, files in expressions_input.items():
-            for file_path in files or []:
-                if not isinstance(file_path, str):
-                    continue
-                normalized = file_path.replace('\\', '/')
-                p = pathlib.PurePosixPath(normalized)
-                if p.is_absolute() or ".." in p.parts:
-                    continue
-                normalized = str(p)
+            new_expressions = []
+            for emotion, files in expressions_input.items():
+                for file_path in files or []:
+                    if not isinstance(file_path, str):
+                        continue
+                    normalized = file_path.replace('\\', '/')
+                    p = pathlib.PurePosixPath(normalized)
+                    if p.is_absolute() or ".." in p.parts:
+                        continue
+                    normalized = str(p)
 
-                base = os.path.basename(normalized)
-                base_no_ext = base.replace('.exp3.json', '')
-                name = f"{emotion}_{base_no_ext}"
-                new_expressions.append({"Name": name, "File": normalized})
+                    base = os.path.basename(normalized)
+                    base_no_ext = base.replace('.exp3.json', '')
+                    name = f"{emotion}_{base_no_ext}"
+                    new_expressions.append({"Name": name, "File": normalized})
 
-        file_refs['Expressions'] = preserved_expressions + new_expressions
+            file_refs['Expressions'] = preserved_expressions + new_expressions
 
-        # 同时保留一份 EmotionMapping（供管理器读取与向后兼容）
-        config_data['EmotionMapping'] = data
+            # 同时保留一份 EmotionMapping（供管理器读取与向后兼容）
+            config_data['EmotionMapping'] = data
 
-        # 保存配置到文件
-        await atomic_write_json_async(model_json_path, config_data, ensure_ascii=False, indent=2)
+            # 保存配置到文件
+            await atomic_write_json_async(model_json_path, config_data, ensure_ascii=False, indent=2)
 
         logger.info(f"模型 {model_name} 的情绪映射配置已更新（已同步到 FileReferences）")
         return {"success": True, "message": "情绪映射配置已保存"}
@@ -848,29 +878,13 @@ def get_model_config_by_id(model_id: str):
         with open(model_json_path, 'r', encoding='utf-8') as f:
             config_data = json.load(f)
         
-        # 检查并自动添加缺失的配置
-        config_updated = False
-        
-        # 确保FileReferences存在
-        if 'FileReferences' not in config_data:
-            config_data['FileReferences'] = {}
-            config_updated = True
-        
-        # 确保Motions存在
-        if 'Motions' not in config_data['FileReferences']:
-            config_data['FileReferences']['Motions'] = {}
-            config_updated = True
-        
-        # 确保Expressions存在
-        if 'Expressions' not in config_data['FileReferences']:
-            config_data['FileReferences']['Expressions'] = []
-            config_updated = True
-        
-        # 如果配置有更新，保存到文件
-        if config_updated:
-            atomic_write_json(model_json_path, config_data, ensure_ascii=False, indent=4)
-            logger.info(f"已为模型 {model_id} 自动添加缺失的配置项")
-            
+        # 检查并自动添加缺失的配置。只补在内存里、随 response 返回，不写盘，理由同
+        # get_model_config。这条尤其急：它原先连 try/except 都没有，创意工坊安装目录只读
+        # 或被反勒索防护挡住时，一个「读」端点会因为写不进去而整个 500。
+        file_refs = config_data.setdefault('FileReferences', {})
+        file_refs.setdefault('Motions', {})
+        file_refs.setdefault('Expressions', [])
+
         return {"success": True, "config": config_data}
     except Exception as e:
         logger.error(f"获取模型配置失败: {e}")
@@ -912,17 +926,20 @@ async def update_model_config_by_id(model_id: str, request: Request):
         if not model_json_path or not os.path.exists(model_json_path):
             return JSONResponse(status_code=404, content={"success": False, "error": "模型配置文件不存在"})
         
-        # 为了安全，只允许修改 Motions 和 Expressions
-        current_config = await read_json_async(model_json_path)
+        # 为了安全，只允许修改 Motions 和 Expressions。读→改→写整段在锁内，
+        # 与 update_model_config 对偶；锁键是解析后的文件路径，所以 by-name 与 by-id
+        # 打到同一个创意工坊模型时共用同一把锁。
+        async with _model_config_write_lock(model_json_path):
+            current_config = await read_json_async(model_json_path)
 
-        file_refs = current_config.setdefault("FileReferences", {})
-        if 'FileReferences' in data and 'Motions' in data['FileReferences']:
-            file_refs['Motions'] = data['FileReferences']['Motions']
+            file_refs = current_config.setdefault("FileReferences", {})
+            if 'FileReferences' in data and 'Motions' in data['FileReferences']:
+                file_refs['Motions'] = data['FileReferences']['Motions']
 
-        if 'FileReferences' in data and 'Expressions' in data['FileReferences']:
-            file_refs['Expressions'] = data['FileReferences']['Expressions']
+            if 'FileReferences' in data and 'Expressions' in data['FileReferences']:
+                file_refs['Expressions'] = data['FileReferences']['Expressions']
 
-        await atomic_write_json_async(model_json_path, current_config, ensure_ascii=False, indent=4)  # 使用 indent=4 保持格式
+            await atomic_write_json_async(model_json_path, current_config, ensure_ascii=False, indent=4)  # 使用 indent=4 保持格式
 
         return {"success": True, "message": "模型配置已更新"}
     except Exception as e:

--- a/main_routers/live2d_router.py
+++ b/main_routers/live2d_router.py
@@ -77,6 +77,23 @@ logger = get_module_logger(__name__, "Main")
 _MODEL_CONFIG_WRITE_LOCKS: dict[str, asyncio.Lock] = {}
 
 
+async def _persist_model_config(model_json_path, config, *, indent: int) -> None:
+    """Write the config out without letting cancellation release the caller's lock early."""
+    # to_thread 一旦交出去就取消不掉 —— 线程会一直跑到 os.replace 结束。直接 await 的话，
+    # 这个请求被 cancel（客户端断开、超时中间件）时 async with 会在 CancelledError 穿过的
+    # 一刻就把 per-file 锁放掉，而那次 os.replace 还在飞：两个 handler 就又可能同时
+    # replace 同一个目标（Windows 上互相 WinError 5），也就是这个 PR 要修的东西本身。
+    # shield 让取消落在外层、写盘任务照跑，再显式等它收尾之后才让 CancelledError 上浮。
+    writer = asyncio.ensure_future(
+        atomic_write_json_async(model_json_path, config, ensure_ascii=False, indent=indent)
+    )
+    try:
+        await asyncio.shield(writer)
+    except asyncio.CancelledError:
+        await asyncio.wait({writer})
+        raise
+
+
 def _model_config_write_lock(model_json_path: str | os.PathLike) -> asyncio.Lock:
     """Return the per-file write lock for a resolved ``.model3.json``."""
     # realpath 折掉 junction/symlink 与 "." 之类的写法差异，normcase 折掉 Windows 的大小写，
@@ -462,7 +479,7 @@ async def update_model_config(model_name: str, request: Request):
             if 'FileReferences' in data and 'Expressions' in data['FileReferences']:
                 file_refs['Expressions'] = data['FileReferences']['Expressions']
 
-            await atomic_write_json_async(model_json_path, current_config, ensure_ascii=False, indent=4)  # 使用 indent=4 保持格式
+            await _persist_model_config(model_json_path, current_config, indent=4)  # indent=4 保持格式
 
         return {"success": True, "message": "模型配置已更新"}
     except Exception as e:
@@ -633,7 +650,7 @@ async def update_emotion_mapping(model_name: str, request: Request):
             config_data['EmotionMapping'] = data
 
             # 保存配置到文件
-            await atomic_write_json_async(model_json_path, config_data, ensure_ascii=False, indent=2)
+            await _persist_model_config(model_json_path, config_data, indent=2)
 
         logger.info(f"模型 {model_name} 的情绪映射配置已更新（已同步到 FileReferences）")
         return {"success": True, "message": "情绪映射配置已保存"}
@@ -939,7 +956,7 @@ async def update_model_config_by_id(model_id: str, request: Request):
             if 'FileReferences' in data and 'Expressions' in data['FileReferences']:
                 file_refs['Expressions'] = data['FileReferences']['Expressions']
 
-            await atomic_write_json_async(model_json_path, current_config, ensure_ascii=False, indent=4)  # 使用 indent=4 保持格式
+            await _persist_model_config(model_json_path, current_config, indent=4)  # indent=4 保持格式
 
         return {"success": True, "message": "模型配置已更新"}
     except Exception as e:

--- a/main_routers/live2d_router.py
+++ b/main_routers/live2d_router.py
@@ -43,6 +43,8 @@ from fastapi.responses import JSONResponse
 
 from .shared_state import get_config_manager
 from .workshop_router import get_subscribed_workshop_items
+from contextlib import suppress
+
 from utils.file_utils import atomic_write_json_async, read_json_async
 from utils.frontend_utils import find_models, find_model_directory, find_workshop_item_by_id
 from utils.logger_config import get_module_logger
@@ -90,7 +92,12 @@ async def _persist_model_config(model_json_path, config, *, indent: int) -> None
     try:
         await asyncio.shield(writer)
     except asyncio.CancelledError:
-        await asyncio.wait({writer})
+        # 循环而不是等一次：第二次取消（超时取消之后再来一次应用退出）会把这次
+        # asyncio.wait 本身也打断，锁又提前放了。writer 是 to_thread，线程一定会跑完，
+        # 所以这个循环必然终止。
+        while not writer.done():
+            with suppress(asyncio.CancelledError):
+                await asyncio.wait({writer})
         raise
 
 

--- a/tests/unit/test_live2d_model_config_write_locking.py
+++ b/tests/unit/test_live2d_model_config_write_locking.py
@@ -262,9 +262,15 @@ async def test_cancelling_a_post_does_not_release_the_lock_before_the_write_ends
     assert lock.locked(), "前置条件：写在飞的时候锁是持有状态"
 
     task.cancel()
-    for _ in range(5):
-        await asyncio.sleep(0)
-    assert lock.locked(), "写还在飞，锁不许因为取消就提前放掉"
+    # 不靠「固定 yield 几次」猜取消传播完没有：按真实时钟走一小段，期间每圈都复查。
+    # 顺带把重复取消也覆盖掉 —— 超时取消之后再来一次应用退出，是真实会发生的组合。
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + 0.1
+    while loop.time() < deadline:
+        await asyncio.sleep(0.005)
+        task.cancel()
+        assert lock.locked(), "写还在飞，锁不许因为取消就提前放掉"
+        assert not task.done(), "写还没放行，任务不该已经收尾"
 
     let_write_finish.set()
     with pytest.raises(asyncio.CancelledError):

--- a/tests/unit/test_live2d_model_config_write_locking.py
+++ b/tests/unit/test_live2d_model_config_write_locking.py
@@ -1,0 +1,282 @@
+"""Concurrent-write protection for ``<model>.model3.json``."""
+
+# 原先同一个文件被 5 个端点写、无锁，其中两个还是同步 GET（补齐缺省配置项后写回）。
+# 把写挂在 GET 上意味着读流量变写流量，而且同步 GET 跑在 anyio 线程池里、和 async POST
+# 的 asyncio 锁不在同一个互斥域 —— 两个线程 os.replace 同一目标在 Windows 上互相
+# PermissionError(WinError 5)。这里钉三件事：GET 不再落盘、三个 POST 的读→改→写整段
+# 互斥、锁按解析后的文件路径分桶。
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from main_routers import live2d_router
+
+_ROUTER_SOURCE = Path(live2d_router.__file__)
+
+_BASE_CONFIG = {
+    "Version": 3,
+    "FileReferences": {
+        "Moc": "m.moc3",
+        "Textures": ["m.2048/texture_00.png"],
+        "Motions": {},
+        "Expressions": [],
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def _clear_model_config_write_locks():
+    """Clear the lock registry between tests: an awaited asyncio.Lock binds to its loop."""
+    # pytest.ini 是 asyncio_mode=auto + function-scope loop，用例之间循环会换掉；留着
+    # 上一个用例争用过的锁，下一个用例 await 它就 RuntimeError（loop 不匹配）。生产上
+    # 只有一个循环（merged 单进程），所以这是测试侧的约束、不是设计缺陷。
+    live2d_router._MODEL_CONFIG_WRITE_LOCKS.clear()
+    yield
+    live2d_router._MODEL_CONFIG_WRITE_LOCKS.clear()
+
+
+def _make_model_dir(tmp_path: Path, *, name: str = "m", config: dict | None = None) -> Path:
+    model_dir = tmp_path / name
+    model_dir.mkdir(parents=True, exist_ok=True)
+    payload = json.loads(json.dumps(config if config is not None else _BASE_CONFIG))
+    (model_dir / f"{name}.model3.json").write_text(
+        json.dumps(payload, ensure_ascii=False, indent=4), encoding="utf-8"
+    )
+    return model_dir
+
+
+class _FakeRequest:
+    """Minimal stand-in: the handlers only use ``await request.json()``."""
+
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+
+    async def json(self) -> dict:
+        return self._payload
+
+
+# --- (1) 两个同步 GET 不得落盘 ---------------------------------------------------
+#
+# 主断言用「目标文件字节逐字节相同」而不是 spy `live2d_router.atomic_write_json`：
+# 修复之后那个名字在文件里已经没有调用点（import 也删掉了），spy 目标会消失，
+# 测试会因为 AttributeError 报错而不是因为断言失败。字节比对不依赖任何内部符号。
+
+
+def test_get_model_config_never_writes_disk(monkeypatch, tmp_path) -> None:
+    # 盘上是「老模型」：连 FileReferences 都没有，原实现一定会触发写回。
+    model_dir = _make_model_dir(tmp_path, config={"Version": 3})
+    model_json = model_dir / "m.model3.json"
+    before = model_json.read_bytes()
+    monkeypatch.setattr(
+        live2d_router, "find_model_directory", lambda name: (str(model_dir), "/user_live2d/m")
+    )
+
+    result = live2d_router.get_model_config("m")
+
+    assert model_json.read_bytes() == before, "GET 不得写盘"
+    # 补齐逻辑本身必须留着——它是这个端点对前端的契约，别被顺手清理掉。
+    assert result["success"] is True
+    assert result["config"]["FileReferences"]["Motions"] == {}
+    assert result["config"]["FileReferences"]["Expressions"] == []
+
+
+def test_get_model_config_by_id_never_writes_disk(monkeypatch, tmp_path) -> None:
+    model_dir = _make_model_dir(tmp_path, config={"Version": 3})
+    model_json = model_dir / "m.model3.json"
+    before = model_json.read_bytes()
+    monkeypatch.setattr(
+        live2d_router,
+        "find_workshop_item_by_id",
+        lambda model_id: (str(model_dir), "/workshop/123"),
+    )
+
+    result = live2d_router.get_model_config_by_id("123")
+
+    assert model_json.read_bytes() == before, "GET 不得写盘"
+    assert result["success"] is True
+    assert result["config"]["FileReferences"]["Motions"] == {}
+    assert result["config"]["FileReferences"]["Expressions"] == []
+
+
+def test_no_get_handler_writes_model_config() -> None:
+    """Auto-discovering ratchet: no ``@router.get`` endpoint may write to disk."""
+    # 不写死函数名清单 —— 遍历装饰器，新增的 GET 端点自动进入覆盖范围（清单式的守卫
+    # 迟早漏项）。同步 GET 跑在 anyio 线程池里，与三个 POST 的 asyncio 锁不在同一个
+    # 互斥域，任何新的 GET 落盘都会重新引入 WinError 5。
+    writers = {
+        "atomic_write_json",
+        "atomic_write_json_async",
+        "write_json",
+        "write_text",
+        "write_bytes",
+    }
+    tree = ast.parse(_ROUTER_SOURCE.read_text(encoding="utf-8"))
+
+    checked: list[str] = []
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        is_get = any(
+            isinstance(dec, ast.Call)
+            and isinstance(dec.func, ast.Attribute)
+            and dec.func.attr == "get"
+            and isinstance(dec.func.value, ast.Name)
+            and dec.func.value.id == "router"
+            for dec in node.decorator_list
+        )
+        if not is_get:
+            continue
+        checked.append(node.name)
+        for call in ast.walk(node):
+            if not isinstance(call, ast.Call):
+                continue
+            func = call.func
+            name = (
+                func.attr
+                if isinstance(func, ast.Attribute)
+                else (func.id if isinstance(func, ast.Name) else "")
+            )
+            if name in writers:
+                offenders.append(f"{node.name}:{call.lineno} 调用 {name}")
+            elif (
+                name == "replace"
+                and isinstance(func, ast.Attribute)
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "os"
+            ):
+                # 只认 os.replace；str.replace 在这个文件里到处都是。
+                offenders.append(f"{node.name}:{call.lineno} 调用 os.replace")
+            elif name == "open":
+                mode = None
+                if len(call.args) > 1 and isinstance(call.args[1], ast.Constant):
+                    mode = call.args[1].value
+                for keyword in call.keywords:
+                    if keyword.arg == "mode" and isinstance(keyword.value, ast.Constant):
+                        mode = keyword.value.value
+                if mode and any(flag in str(mode) for flag in "wax+"):
+                    offenders.append(f"{node.name}:{call.lineno} open(mode={mode!r})")
+
+    # 先证明遍历真的找到了端点，否则「无违规」可能只是没扫到东西。
+    assert "get_model_config" in checked
+    assert "get_model_config_by_id" in checked
+    assert len(checked) >= 8
+    assert offenders == []
+
+
+# --- (2) 三个 POST 的读→改→写整段互斥 -------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_model_config_posts_do_not_lose_each_others_edits(
+    monkeypatch, tmp_path
+) -> None:
+    """Two different POSTs racing on one model3.json: both edits must survive."""
+    # 真文件、真 handler、不 mock 写。两个改动落在互不相交的键上（emotion_mapping 传空
+    # expressions → emotion_prefixes 为空 → 现存 Expressions 全部 preserved；
+    # model_config 的 payload 里没有 Motions → Motions 不动），所以和执行顺序无关 ——
+    # 串行化之后两个都该在。
+    model_dir = _make_model_dir(tmp_path)
+    model_json = model_dir / "m.model3.json"
+    monkeypatch.setattr(
+        live2d_router, "find_model_directory", lambda name: (str(model_dir), "/user_live2d/m")
+    )
+
+    real_read = live2d_router.read_json_async
+
+    async def slow_read(path, **kwargs):
+        data = await real_read(path, **kwargs)
+        # 撑开「读到写」的窗口：丢写发生在这一段，只锁 os.replace 抓不到。
+        await asyncio.sleep(0.02)
+        return data
+
+    monkeypatch.setattr(live2d_router, "read_json_async", slow_read)
+
+    results = await asyncio.gather(
+        live2d_router.update_emotion_mapping(
+            "m", _FakeRequest({"motions": {"happy": ["motions/a.motion3.json"]}, "expressions": {}})
+        ),
+        live2d_router.update_model_config(
+            "m",
+            _FakeRequest(
+                {
+                    "FileReferences": {
+                        "Expressions": [{"Name": "x_1", "File": "expressions/x.exp3.json"}]
+                    }
+                }
+            ),
+        ),
+    )
+    assert all(item.get("success") for item in results), results
+
+    final = json.loads(model_json.read_text(encoding="utf-8"))
+    file_refs = final["FileReferences"]
+    assert "happy" in file_refs["Motions"], "emotion_mapping 的编辑被覆盖了"
+    assert any(
+        isinstance(item, dict) and item.get("Name") == "x_1" for item in file_refs["Expressions"]
+    ), "model_config 的编辑被覆盖了"
+
+
+@pytest.mark.asyncio
+async def test_by_name_and_by_id_posts_share_one_lock(monkeypatch, tmp_path) -> None:
+    """by-name and by-id hitting the same file must share one lock."""
+    # 按入参（model_name / model_id）分桶就会漏：两条路由可以落到同一个文件上。
+    model_dir = _make_model_dir(tmp_path)
+    model_json = model_dir / "m.model3.json"
+    monkeypatch.setattr(
+        live2d_router, "find_model_directory", lambda name: (str(model_dir), "/user_live2d/m")
+    )
+    monkeypatch.setattr(
+        live2d_router,
+        "find_workshop_item_by_id",
+        lambda model_id: (str(model_dir), "/workshop/123"),
+    )
+
+    in_flight = 0
+    max_in_flight = 0
+    real_write = live2d_router.atomic_write_json_async
+
+    async def tracking_write(path, data, **kwargs):
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        await asyncio.sleep(0)
+        await real_write(path, data, **kwargs)
+        in_flight -= 1
+
+    monkeypatch.setattr(live2d_router, "atomic_write_json_async", tracking_write)
+
+    await asyncio.gather(
+        live2d_router.update_model_config(
+            "m", _FakeRequest({"FileReferences": {"Motions": {"a": []}}})
+        ),
+        live2d_router.update_model_config_by_id(
+            "123", _FakeRequest({"FileReferences": {"Motions": {"b": []}}})
+        ),
+    )
+
+    assert max_in_flight == 1, "两条路由落到同一个文件却没被同一把锁串起来"
+    assert model_json.exists()
+
+
+def test_write_lock_is_keyed_on_the_resolved_file(tmp_path) -> None:
+    first = _make_model_dir(tmp_path, name="one") / "one.model3.json"
+    second = _make_model_dir(tmp_path, name="two") / "two.model3.json"
+
+    lock = live2d_router._model_config_write_lock(first)
+    # 同一个文件的另一种拼法（realpath 折掉 "."）必须拿到同一把锁。
+    aliased = live2d_router._model_config_write_lock(first.parent / "." / first.name)
+    assert aliased is lock
+    if os.name == "nt":
+        # Windows 大小写不敏感，normcase 必须把它折平。
+        assert live2d_router._model_config_write_lock(str(first).upper()) is lock
+
+    # 不同文件必须是不同的锁对象（退化成一把全局锁时这条红）。
+    assert live2d_router._model_config_write_lock(second) is not lock

--- a/tests/unit/test_live2d_model_config_write_locking.py
+++ b/tests/unit/test_live2d_model_config_write_locking.py
@@ -225,6 +225,54 @@ async def test_concurrent_model_config_posts_do_not_lose_each_others_edits(
 
 
 @pytest.mark.asyncio
+async def test_cancelling_a_post_does_not_release_the_lock_before_the_write_ends(
+    monkeypatch, tmp_path
+) -> None:
+    """A cancelled POST must keep the per-file lock until its in-flight write finishes."""
+    # atomic_write_json_async 内部是 asyncio.to_thread，交出去就取消不掉：线程会一直跑到
+    # os.replace 结束。如果 async with 在 CancelledError 穿过的一刻就放锁（直接 await 就是
+    # 这样），第二个 handler 会在第一次 replace 还在飞的时候进临界区 —— 正是本 PR 要修的
+    # 那个并发 replace。请求被客户端断开或超时中间件取消是常态，不是边角情况。
+    model_dir = _make_model_dir(tmp_path)
+    model_json = model_dir / "m.model3.json"
+    monkeypatch.setattr(
+        live2d_router, "find_model_directory", lambda name: (str(model_dir), "/user_live2d/m")
+    )
+
+    write_started = asyncio.Event()
+    let_write_finish = asyncio.Event()
+
+    async def blocked_write(path, data, **kwargs):
+        write_started.set()
+        await let_write_finish.wait()
+
+    monkeypatch.setattr(live2d_router, "atomic_write_json_async", blocked_write)
+
+    task = asyncio.create_task(
+        live2d_router.update_model_config(
+            "m",
+            _FakeRequest(
+                {"FileReferences": {"Expressions": [{"Name": "x", "File": "e.exp3.json"}]}}
+            ),
+        )
+    )
+    await asyncio.wait_for(write_started.wait(), timeout=5)
+
+    lock = live2d_router._model_config_write_lock(model_json)
+    assert lock.locked(), "前置条件：写在飞的时候锁是持有状态"
+
+    task.cancel()
+    for _ in range(5):
+        await asyncio.sleep(0)
+    assert lock.locked(), "写还在飞，锁不许因为取消就提前放掉"
+
+    let_write_finish.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert not lock.locked(), "写收尾之后锁必须放掉"
+
+
+@pytest.mark.asyncio
 async def test_by_name_and_by_id_posts_share_one_lock(monkeypatch, tmp_path) -> None:
     """by-name and by-id hitting the same file must share one lock."""
     # 按入参（model_name / model_id）分桶就会漏：两条路由可以落到同一个文件上。

--- a/tests/unit/test_proactive_source_history_locking.py
+++ b/tests/unit/test_proactive_source_history_locking.py
@@ -116,9 +116,15 @@ async def test_cancelling_a_record_does_not_release_the_lock_before_the_write_en
     assert state._source_history_lock.locked(), "前置条件：写在飞的时候锁是持有状态"
 
     task.cancel()
-    for _ in range(5):
-        await asyncio.sleep(0)
-    assert state._source_history_lock.locked(), "写还在飞，锁不许因为取消就提前放掉"
+    # 不靠「固定 yield 几次」猜取消传播完没有：按真实时钟走一小段，期间每圈都复查。
+    # 顺带把重复取消也覆盖掉 —— 超时取消之后再来一次应用退出，是真实会发生的组合。
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + 0.1
+    while loop.time() < deadline:
+        await asyncio.sleep(0.005)
+        task.cancel()
+        assert state._source_history_lock.locked(), "写还在飞，锁不许因为取消就提前放掉"
+        assert not task.done(), "写还没放行，任务不该已经收尾"
 
     let_write_finish.set()
     with pytest.raises(asyncio.CancelledError):

--- a/tests/unit/test_proactive_source_history_locking.py
+++ b/tests/unit/test_proactive_source_history_locking.py
@@ -1,0 +1,100 @@
+"""proactive_source_history.json must be persisted inside _source_history_lock."""
+
+# 这是个跨角色的单文件：锁只盖内存不盖落盘时，(a) 两个并发投递会同时 os.replace 同一个
+# 目标（Windows 上互相 PermissionError/WinError 5），(b) 快照在锁内取、写在锁外发，两次
+# 投递抵达磁盘的顺序可以和取快照的顺序反过来，把新历史写回旧值。这里两条都钉住。
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from main_logic.proactive_chat import state
+
+
+@pytest.fixture(autouse=True)
+def _isolate_source_history():
+    """Restore the module-level history between tests so cases cannot leak into each other."""
+    saved = dict(state._source_history)
+    saved_loaded = state._source_history_loaded
+    saved_path = state._source_history_loaded_path
+    state._source_history.clear()
+    state._source_history_loaded = True  # _record_source_used 本身不加载，这里只是别让它看起来是冷的
+    yield
+    state._source_history.clear()
+    state._source_history.update(saved)
+    state._source_history_loaded = saved_loaded
+    state._source_history_loaded_path = saved_path
+
+
+@pytest.mark.asyncio
+async def test_source_history_write_happens_inside_the_lock(monkeypatch, tmp_path) -> None:
+    observed: list[tuple[bool, frozenset[str]]] = []
+
+    async def fake_write(path, payload, **kwargs):
+        # 这个用例里 _source_history_lock 只可能有一个持有者，locked() 是有效代理。
+        observed.append((state._source_history_lock.locked(), frozenset(payload["entries"])))
+
+    monkeypatch.setattr(state, "atomic_write_json_async", fake_write)
+
+    await state._record_source_used(
+        url="https://example.test/a",
+        kind="web",
+        title="a",
+        memory_dir=tmp_path,
+    )
+
+    expected_hash = state._source_hash("https://example.test/a", "a")
+    assert observed == [(True, frozenset({expected_hash}))]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_source_records_serialize_and_never_reorder(
+    monkeypatch, tmp_path
+) -> None:
+    in_flight = 0
+    max_in_flight = 0
+    landed: list[frozenset[str]] = []
+
+    async def fake_write(path, payload, **kwargs):
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        # 让出事件循环：落盘在锁外时，另一个投递会在这里挤进来。
+        await asyncio.sleep(0)
+        landed.append(frozenset(payload["entries"]))
+        in_flight -= 1
+
+    monkeypatch.setattr(state, "atomic_write_json_async", fake_write)
+
+    await asyncio.gather(
+        *[
+            state._record_source_used(
+                url=f"https://example.test/{index}",
+                kind="web",
+                title=f"t{index}",
+                memory_dir=tmp_path,
+            )
+            for index in range(5)
+        ]
+    )
+
+    # (a) 串行化：任一时刻只有一个写者在飞 → 不会有两个并发 os.replace 打同一目标。
+    assert max_in_flight == 1
+    # (b) 不反转：后落盘的必须是前一次的严格超集。写成「最终文件有 5 条」是恒真的，
+    #     抓不到「快照顺序与写入顺序反过来」这个形态。
+    assert len(landed) == 5
+    for previous, current in zip(landed, landed[1:]):
+        assert previous < current, f"落盘顺序反转: {sorted(previous)} 之后落了 {sorted(current)}"
+    assert len(landed[-1]) == 5
+
+
+def test_source_history_persist_helper_takes_its_own_snapshot() -> None:
+    """The persist helper takes no snapshot argument: snapshot and write are inseparable."""
+    # 一旦有人给它加回 snapshot 形参，调用方就又能在锁内取快照、到锁外去写，顺序反转
+    # 窗口重新出现。这条守卫的是那个设计决定本身，不是某一次的行为。
+    import inspect
+
+    parameters = inspect.signature(state._persist_source_history_unlocked).parameters
+    assert set(parameters) == {"memory_dir"}

--- a/tests/unit/test_proactive_source_history_locking.py
+++ b/tests/unit/test_proactive_source_history_locking.py
@@ -90,6 +90,42 @@ async def test_concurrent_source_records_serialize_and_never_reorder(
     assert len(landed[-1]) == 5
 
 
+@pytest.mark.asyncio
+async def test_cancelling_a_record_does_not_release_the_lock_before_the_write_ends(
+    monkeypatch, tmp_path
+) -> None:
+    """A cancelled _record_source_used must keep the lock until its in-flight write finishes."""
+    # atomic_write_json_async 内部是 asyncio.to_thread，交出去就取消不掉。直接 await 的话，
+    # 退出时的 cancel 会让 async with 在 CancelledError 穿过的一刻放锁，而那次 os.replace
+    # 还在飞 —— 另一个投递就能进临界区并发 replace 同一个目标。
+    write_started = asyncio.Event()
+    let_write_finish = asyncio.Event()
+
+    async def blocked_write(path, payload, **kwargs):
+        write_started.set()
+        await let_write_finish.wait()
+
+    monkeypatch.setattr(state, "atomic_write_json_async", blocked_write)
+
+    task = asyncio.create_task(
+        state._record_source_used(
+            url="https://example.test/a", kind="web", title="a", memory_dir=tmp_path
+        )
+    )
+    await asyncio.wait_for(write_started.wait(), timeout=5)
+    assert state._source_history_lock.locked(), "前置条件：写在飞的时候锁是持有状态"
+
+    task.cancel()
+    for _ in range(5):
+        await asyncio.sleep(0)
+    assert state._source_history_lock.locked(), "写还在飞，锁不许因为取消就提前放掉"
+
+    let_write_finish.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert not state._source_history_lock.locked(), "写收尾之后锁必须放掉"
+
+
 def test_source_history_persist_helper_takes_its_own_snapshot() -> None:
     """The persist helper takes no snapshot argument: snapshot and write are inseparable."""
     # 一旦有人给它加回 snapshot 形参，调用方就又能在锁内取快照、到锁外去写，顺序反转


### PR DESCRIPTION
#2528 提议给 `os.replace` 加 Windows-only 重试，**不采纳**（理由见 [issue 评论](https://github.com/Project-N-E-K-O/N.E.K.O/issues/2528#issuecomment-5128580550)）。但那次审计确认生产里**真的**存在「多写者并发 `atomic_write_*` 到同一个目标文件」—— 缺的是锁，不是重试。这个 PR 收其中两处。

实测依据：5 线程 Barrier 对齐并发 `atomic_write_text` 打同一目标，1000 次写 **345 次** `PermissionError(WinError 5)`；同机同目标把锁装回去，**0/1000**。

## 一、`main_logic/proactive_chat/state.py`：锁只盖内存不盖落盘

`_record_source_used` 在 `async with _source_history_lock` 内改内存并取 snapshot，锁结束**之后**才 `atomic_write_json_async`。目标是**跨角色的单文件**，后果两层：

1. 两个并发投递同时 `os.replace` 同一目标；
2. 快照在锁内取、写在锁外发 —— 两次投递抵达磁盘的**顺序可以和取快照的顺序反过来**，把新历史写回旧值。

同一个文件里就有写对了的对照组：`_increment_proactive_chat_total` 把 `_persist_totals_unlocked` 的落盘放在锁内。照这个对偶修。

**关键设计**：新 helper **不接 `snapshot` 参数**，自己在锁内 `dict()` —— 顺序反转窗口从代码里消失，而不是靠「调用方记得在锁内取快照」这种约定维持。有一条测试专门守这个设计决定（断言签名里没有 `snapshot` 形参）。

## 二、`main_routers/live2d_router.py`：写流量等于读流量

同一个 `<模型>.model3.json` 被 5 个端点写、无锁，其中**两个是同步 GET**（补齐缺失配置项后写回）。而且同步 GET 跑在 anyio 线程池里，和 async POST 的 asyncio 锁**不在同一个互斥域**（`asyncio.Lock` 非线程安全，worker 线程不能碰），混用两种锁是伪修复。文件里原本就有一条「无法写回模型配置（可能受 Windows 安全策略/反勒索防护保护）」的 warning，说明它本来就在偶发失败。

1. **两个 GET 不再落盘** —— 缺省项只在内存里补齐、随 response 返回。核实过补的全是空默认值（`FileReferences` / `Motions` / `Expressions`），仓库里每个消费者都按可缺省读取（本文件的 `get_emotion_mapping`、`app/monitor.py` 的 `.get('FileReferences', {}) or {}`、三个 POST 的 `setdefault`），没有任何一处依赖它们**在盘上**存在。（`docs/api/rest/live2d.md` 原本写的是「the handler adds the missing containers and attempts to write them back」，也就是**承诺了**写回 —— 这句本 PR 一并改成「to the response only — these routes never write to disk」。感谢 Greptile 指出我最初这里描述反了。）
2. 三个 POST 加 per-file `asyncio` 锁，**临界区从「读」之前开始** —— 它们都是「读盘→改→整覆盖」不做 merge，只把写包起来没用，丢写窗口是**读到写的整段**。
3. 锁按 **`normcase(realpath(路径))`** 分桶，不按 `model_name` / `model_id`：by-name 与 by-id 两条路由可以落到同一个文件上，按入参分桶等于没互斥；`realpath` 折掉 junction/symlink，`normcase` 折掉 Windows 大小写。

**取消路径上也要真的把写关在锁内。** `atomic_write_json_async` 内部是 `asyncio.to_thread`，交出去就取消不掉（线程会跑到 `os.replace` 结束）；直接 `await` 的话，协程被 cancel 时 `async with` 会在 `CancelledError` 穿过的一刻放锁，而那次 replace 还在飞 —— 另一个写者就能并发 replace 同一个目标，正是本 PR 要修的东西。所以写盘包成 task、`await asyncio.shield(task)`，捕获 `CancelledError` 后先 `await asyncio.wait({task})` 等它收尾才让取消上浮。请求被客户端断开 / 超时中间件取消、服务退出取消后台投递都是常态。

**为什么这里用 `asyncio.Lock`** 而 #2528 另几摊同型修复选 `threading.Lock`：判据是「所有写者是否都在事件循环上」。这里成立 —— 但**只因为砍掉了 GET 落盘**。代价是模块级 `asyncio.Lock` 一旦被争用就绑死在当时的事件循环上；生产上只有一个循环（merged 单进程），但测试要制造争用就必须在用例之间清掉锁字典，否则 function-scope loop 换掉后第二个用例会 `RuntimeError` —— 已加 autouse fixture 并把理由写在旁边。

## 测试（11 条）

`test_proactive_source_history_locking.py`（4）：落盘时锁必须是持有状态；5 个并发投递的 `max_in_flight == 1` 且落盘 payload **单调增长**（不反转）；helper 签名里不能有 `snapshot` 形参；**取消不变量** —— 写在飞的时候 `cancel()`，锁必须仍是持有状态。

`test_live2d_model_config_write_locking.py`（7）：两个 GET 前后目标文件 `read_bytes()` **逐字节相同**（不用 spy —— 改动之后 `atomic_write_json` 这个名字在文件里可能没有调用点了，spy 目标会消失）；GET 仍返回补齐后的默认值；**自动发现式棘轮** —— 遍历 `@router.get` 装饰器断言没有任何 GET 端点调落盘函数（不写死函数名清单，新增 GET 自动进入覆盖范围）；两个不同 POST 并发改同一文件两个改动都活下来；by-name 与 by-id 共用一把锁；锁 key 对 junction / 大小写不敏感；**取消不变量**（同上）。

## 变异验证（4 处全部被抓）

| 变异 | 结果 |
|---|---|
| 落盘挪回锁外 | 2 failed |
| 拿掉一个 POST 的 per-file 锁 | 2 failed |
| GET 里恢复写盘 | 2 failed |
| 锁按入参原样分桶（不 `realpath`+`normcase`） | 1 failed |
| 写盘回退成直接 `await`（取消时提前放锁） | 各 1 failed（两处） |

## 回归报告

**改动**：`_record_source_used` 的落盘从锁外挪进锁内并抽出 `_persist_source_history_unlocked`（不接 snapshot）；`live2d_router` 两个 GET 端点去掉自动写回、三个 POST 端点包 per-file `asyncio` 锁（临界区含读）；新增 9 条专测。

**必要性**：两处都是「多写者并发写同一目标文件」，Windows 上互相 `PermissionError(WinError 5)`，且都会互相丢写（读→改→整覆盖不 merge）。live2d 那处的写回还挂在 GET 上，写流量等于读流量。

**改动前 → 改动后**：

- 前：`proactive_source_history.json` 的写在锁外，多投递并发时可能撞车、可能顺序反转把新历史写回旧值。后：写在锁内，`max_in_flight == 1`，落盘内容单调增长。
- 前：GET `/api/live2d/model_config/*` 在发现缺失键时把补齐结果**写回磁盘**。后：只在内存里补齐并随 response 返回，**磁盘一字节不动**。
- 前：三个 POST 的读→改→写无互斥，后写者静默丢掉前写者的整段编辑。后：同一文件上串行化，两个改动都活下来。
- 未改动的行为：GET 的**响应体**不变（仍带补齐后的默认值）；三个 POST 的语义、字段白名单、`indent` 都不变。

**潜在回归**：

1. **老模型的 `.model3.json` 不再被 GET 自动补齐并落盘**。如果站外/插件有直接读文件（不走本 API）且假设那三个键在盘上存在的消费者，它们会看到缺键。仓库内已逐个核实无此依赖，但站外调用方**无法从仓库内证伪** —— 这是本 PR 最需要人眼确认的一条。缓解：任意一次 POST 仍会把补齐结果写盘。
2. 三个 POST 在同一文件上串行化，并发改同一模型时第二个请求会等第一个（临界区含一次读盘 + 一次写盘，毫秒级）。跨模型无影响。
3. 模块级 `asyncio.Lock` 字典随访问过的模型文件数增长（每个 model3.json 一把锁，数量级是用户装的模型数）。
4. `_record_source_used` 的临界区多含一次落盘（`atomic_write_json_async` 内部走 `to_thread`，事件循环在等待期间照常服务别的请求）。

## 验证

- 两个测试文件 **11 passed**
- 全量 `tests/unit`：**8686 passed, 45 skipped**，另有 **1 failed** 是 `origin/main` 上刚合的 `test_realtime_arbiter_native_path.py::test_prime_dispatch_failure_surfaces_a_type_the_swap_must_catch` 的**顺序依赖假红**：隔离下 1 passed，不 import 本 PR 改的任何模块；本 PR 只是新增了测试文件、扰动了 `pytest-randomly` 的顺序把它暴露出来。它的断言 `isinstance(exc, RuntimeError)` 拿到的是 `ConnectionError('realtime client closed')` —— 说明 prime 是被客户端关闭而不是被那条 routed rejection 弄失败的，`prime.done()` 为真但**理由错了**。另开 PR 处理，不在本 PR 范围。
- `ruff check` 通过；`check_docstring_no_cjk.py --base origin/main` exit=0

## 不在本 PR 范围

- `_record_source_used` **从不 await `_ensure_source_history_loaded`** —— 历史还没从盘上加载进来时就可能整段覆盖写。同一个文件但不同议题（加载时序，不是锁），另开。
- #2528 的其余几摊：`event_log.advance_sentinel` 与 reconcile 的 apply handler、`idle_maintenance_state.json`、`recent.json`、facts 归档半提交。

Refs #2528

🤖 Generated with [Claude Code](https://claude.com/claude-code)
