### PR TITLE
refactor(realtime): 把 response.done 的 per-turn 清理抽成共享函数并补测试

### DIFF
--- a/docs/config/environment-vars.md
+++ b/docs/config/environment-vars.md
@@ -86,8 +86,25 @@ response arbiter failing closed: <reason> (current=... owner=... queue_depth=...
 
 That line is what distinguishes an arbiter-initiated teardown from an upstream
 provider disconnect — absent it, the disconnect came from somewhere else and
-this variable will not help. With fail-open enabled the same escalations log
-`response arbiter failing open, transport kept: ...` instead.
+this variable will not help.
+
+With fail-open enabled, escalations normally log
+`response arbiter failing open, transport kept: ...` instead. **They do not
+always**: the hatch stands down and still tears the transport down whenever
+its premise — that the connection is usable and the abandoned turn is
+separable — does not hold. Seeing `failing closed` with the variable set is
+therefore expected behaviour, not a broken switch. The three trailing log
+fields say which condition applied:
+
+| Field | Meaning when `True` |
+| --- | --- |
+| `worker_send_in_flight` | The queue consumer is suspended inside a transport write. Nothing the arbiter does to its own state unwinds that await, and closing the transport is what releases it. |
+| `transport_write_failed` | The cancellation write raised moments earlier, so the transport just refused a send — on the fatal branch it has already dropped its socket. |
+| `uncorrelatable_owner` | The abandoned turn reached `response.created` without a response id, so its late terminal cannot be told apart from the next turn's. |
+
+If every escalation in your logs carries one of these, the variable is working
+as designed and the disconnects have a different cause — attach those lines to
+the report rather than assuming the switch had no effect.
 
 ## Storage and local vectors
 

--- a/docs/config/environment-vars.md
+++ b/docs/config/environment-vars.md
@@ -65,6 +65,30 @@ Keep multi-process mode for development, independent service supervision, or
 agent-failure isolation. `NEKO_MERGED=0` is the immediate rollback for packaged
 deployments.
 
+## Realtime voice escape hatches
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NEKO_REALTIME_ARBITER_FAIL_OPEN` | unset (off) | Changes what the realtime response arbiter does when a response lifecycle cannot reach a terminal state. By default it tears the realtime WebSocket down, which the user sees as a disconnect and session rebuild. Set to `1`, `true`, `yes`, or `on` to instead drop only the stuck turn and keep the connection. Read once when a voice session's client is constructed, so a change needs a restart. |
+
+Leave this unset unless you are actually hitting the failure. The default
+exists because the arbiter escalates precisely when its own bookkeeping about
+which response owns the connection has become untrustworthy, and continuing on
+a connection in that state can produce overlapping responses. Fail-open trades
+that safety for availability: one turn is lost instead of the session.
+
+The symptom worth setting it for is repeated disconnect-and-rebuild during
+voice conversation, with backend logs carrying:
+
+```
+response arbiter failing closed: <reason> (current=... owner=... queue_depth=... server_vad_pending=...)
+```
+
+That line is what distinguishes an arbiter-initiated teardown from an upstream
+provider disconnect — absent it, the disconnect came from somewhere else and
+this variable will not help. With fail-open enabled the same escalations log
+`response arbiter failing open, transport kept: ...` instead.
+
 ## Storage and local vectors
 
 | Variable | Meaning |

--- a/main_logic/omni_realtime_client/_client.py
+++ b/main_logic/omni_realtime_client/_client.py
@@ -27,6 +27,7 @@ from ._shared import (
     TurnDetectionMode,
     _IMAGE_ANALYSIS_PENDING_DESCRIPTION,
     asyncio,
+    response_arbiter_fail_open_enabled,
     soxr,
 )
 
@@ -140,6 +141,7 @@ class OmniRealtimeClient(_ToolingMixin, _AudioMixin, _TransportMixin, _ResponseM
         self._response_arbiter = RealtimeResponseArbiter(
             self.send_event,
             abort_transport=self._abort_failed_transport,
+            fail_open=response_arbiter_fail_open_enabled(),
         )
         # Track printing state for input and output transcripts
         self._is_first_text_chunk = False

--- a/main_logic/omni_realtime_client/_client.py
+++ b/main_logic/omni_realtime_client/_client.py
@@ -142,6 +142,7 @@ class OmniRealtimeClient(_ToolingMixin, _AudioMixin, _TransportMixin, _ResponseM
             self.send_event,
             abort_transport=self._abort_failed_transport,
             fail_open=response_arbiter_fail_open_enabled(),
+            on_stuck_release=self._on_arbiter_stuck_release,
         )
         # Track printing state for input and output transcripts
         self._is_first_text_chunk = False

--- a/main_logic/omni_realtime_client/_response_arbiter.py
+++ b/main_logic/omni_realtime_client/_response_arbiter.py
@@ -60,6 +60,11 @@ _DEFAULT_RESPONSE_DONE_TIMEOUT = 60.0
 # provider-side pre-creation failure cannot wedge the lane until the much
 # longer running-response timeout tears down an otherwise healthy connection.
 _SERVER_VAD_RESPONSE_STARTED_TIMEOUT = 5.0
+# Ceiling on the host's abandoned-turn finalization. Escalations raised inside
+# ``_process`` run it on the sole queue consumer, so an unbounded callback
+# would stall every later dispatch; short because the work it fronts (ending a
+# turn, rotating a speech id) is local bookkeeping plus one frontend send.
+_STUCK_RELEASE_NOTIFY_TIMEOUT = 2.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -931,9 +936,26 @@ class RealtimeResponseArbiter:
         # would spend the connection we just saved: the host would treat the
         # session as busy, and on providers without server VAD it would also
         # never rotate the speech id, which silently drops all later TTS text.
+        #
+        # Bounded, because escalations originating in ``_process`` run this on
+        # the sole queue consumer: an unbounded host callback (the wired one
+        # reaches a frontend send) would block every later dispatch right after
+        # the lane was marked idle — the same wedge the stalled-write guard
+        # exists to prevent, just moved into project code. Awaited rather than
+        # detached so the host has finished ending this turn before the next
+        # one dispatches; the bound is what keeps that from becoming a hang.
         if self._on_stuck_release is not None:
             try:
-                await self._on_stuck_release(reason)
+                await asyncio.wait_for(
+                    self._on_stuck_release(reason),
+                    _STUCK_RELEASE_NOTIFY_TIMEOUT,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "stuck-release host notification exceeded %.1fs; "
+                    "continuing without it",
+                    _STUCK_RELEASE_NOTIFY_TIMEOUT,
+                )
             except Exception as exc:
                 logger.debug(
                     "stuck-release host notification failed: %s",
@@ -967,7 +989,13 @@ class RealtimeResponseArbiter:
         # still streaming — so a third response.create overlaps it. Providers
         # that omit response ids are explicitly supported elsewhere in this
         # module, so this is a real shape, not a hypothetical one.
-        uncorrelatable_owner = (
+        # A pending server-VAD response is the same shape without an owner:
+        # it has been announced but has not yet supplied an id, and its
+        # ``cancel_current`` timeout (3s) is shorter than the missing-created
+        # backstop (5s), so an escalation can land while it is still
+        # uncorrelated. Releasing there would credit its later created/done to
+        # whichever ticket dispatches next.
+        uncorrelatable_owner = self._server_vad_response_pending or (
             owner is not None
             and owner.ticket.started.done()
             and owner.response_id is None

--- a/main_logic/omni_realtime_client/_response_arbiter.py
+++ b/main_logic/omni_realtime_client/_response_arbiter.py
@@ -25,7 +25,7 @@ from typing import Any, Awaitable, Callable
 
 SendEvent = Callable[[dict[str, Any]], Awaitable[None]]
 AbortTransport = Callable[[str], Awaitable[None]]
-OnStuckRelease = Callable[[str], None]
+OnStuckRelease = Callable[[str], Awaitable[None]]
 logger = logging.getLogger(__name__)
 
 # Server-initiated response ids are remembered so their terminal events are
@@ -881,7 +881,7 @@ class RealtimeResponseArbiter:
         finally:
             self._worker_send_in_flight = False
 
-    def _release_stuck_lifecycle(self, reason: str) -> None:
+    async def _release_stuck_lifecycle(self, reason: str) -> None:
         """Drop the stuck turn but keep the connection (the fail-open policy).
 
         Deliberately narrower than ``_mark_connection_lost``, which exists for
@@ -925,15 +925,15 @@ class RealtimeResponseArbiter:
         self._cancel_stale_release_timer()
         self._idle.set()
         # Last, because it is the only step that hands control to project code.
-        # The host keeps its own view of "a response is in progress" that only
-        # this connection's own terminal events normally clear, and the turn
-        # whose terminal we just gave up on is exactly the one that would have
-        # cleared it. Leaving it set would spend the connection we just saved:
-        # the host would treat the session as busy and hold back the work
-        # fail-open exists to keep serving.
+        # The host keeps its own end-of-turn bookkeeping that only this
+        # connection's terminal events normally drive, and the terminal we just
+        # gave up on is exactly the one that would have driven it. Skipping it
+        # would spend the connection we just saved: the host would treat the
+        # session as busy, and on providers without server VAD it would also
+        # never rotate the speech id, which silently drops all later TTS text.
         if self._on_stuck_release is not None:
             try:
-                self._on_stuck_release(reason)
+                await self._on_stuck_release(reason)
             except Exception as exc:
                 logger.debug(
                     "stuck-release host notification failed: %s",
@@ -960,6 +960,18 @@ class RealtimeResponseArbiter:
 
         current = self._current
         owner = self._response_owner
+        # An owner that reached response.created without an id leaves nothing
+        # to quarantine its late terminal by. Releasing there would let that
+        # terminal be credited to the NEXT id-less owner: its ticket resolves
+        # early, ownership clears, and the lane reopens while its response is
+        # still streaming — so a third response.create overlaps it. Providers
+        # that omit response ids are explicitly supported elsewhere in this
+        # module, so this is a real shape, not a hypothetical one.
+        uncorrelatable_owner = (
+            owner is not None
+            and owner.ticket.started.done()
+            and owner.response_id is None
+        )
         lane_state = (
             reason,
             current.source if current is not None else None,
@@ -968,6 +980,7 @@ class RealtimeResponseArbiter:
             self._server_vad_response_pending,
             self._worker_send_in_flight,
             transport_write_failed,
+            uncorrelatable_owner,
         )
         # Fail-open rests on one premise: the transport is still usable. Two
         # things falsify it, and each makes the hatch decline.
@@ -987,11 +1000,15 @@ class RealtimeResponseArbiter:
         # connection that cannot carry it. Callers whose escalation follows a
         # failed write say so explicitly.
         #
-        # Worst case in both is exactly today's shipped default, never worse.
+        # A third: an owner whose terminal cannot be correlated, above.
+        #
+        # Worst case in all three is exactly today's shipped default, never
+        # worse.
         if (
             self._fail_open
             and not self._worker_send_in_flight
             and not transport_write_failed
+            and not uncorrelatable_owner
         ):
             # Wording differs on purpose: the fail-closed line below is the
             # documented grep target for attributing a field disconnect, and
@@ -999,15 +1016,17 @@ class RealtimeResponseArbiter:
             logger.warning(
                 "response arbiter failing open, transport kept: %s "
                 "(current=%s owner=%s queue_depth=%d server_vad_pending=%s "
-                "worker_send_in_flight=%s transport_write_failed=%s)",
+                "worker_send_in_flight=%s transport_write_failed=%s "
+                "uncorrelatable_owner=%s)",
                 *lane_state,
             )
-            self._release_stuck_lifecycle(reason)
+            await self._release_stuck_lifecycle(reason)
             return
         logger.warning(
             "response arbiter failing closed: %s "
             "(current=%s owner=%s queue_depth=%d server_vad_pending=%s "
-            "worker_send_in_flight=%s transport_write_failed=%s)",
+            "worker_send_in_flight=%s transport_write_failed=%s "
+            "uncorrelatable_owner=%s)",
             *lane_state,
         )
         self._mark_connection_lost(reason, fail_current_tickets=False)

--- a/main_logic/omni_realtime_client/_response_arbiter.py
+++ b/main_logic/omni_realtime_client/_response_arbiter.py
@@ -25,6 +25,7 @@ from typing import Any, Awaitable, Callable
 
 SendEvent = Callable[[dict[str, Any]], Awaitable[None]]
 AbortTransport = Callable[[str], Awaitable[None]]
+OnStuckRelease = Callable[[str], None]
 logger = logging.getLogger(__name__)
 
 # Server-initiated response ids are remembered so their terminal events are
@@ -135,15 +136,27 @@ class RealtimeResponseArbiter:
         *,
         abort_transport: AbortTransport | None = None,
         fail_open: bool = False,
+        on_stuck_release: OnStuckRelease | None = None,
     ) -> None:
         self._send_event = send_event
         self._abort_transport = abort_transport
+        # Notified after a fail-open release, so the host can drop whatever
+        # parallel response state it keeps. Dual to ``abort_transport``: the
+        # arbiter still holds no project-internal reference of its own, and a
+        # default of None keeps bare constructions working.
+        self._on_stuck_release = on_stuck_release
         # Escalation policy for a response lifecycle that cannot reach a
         # terminal state. Default (False) tears the transport down, which is
         # what every release so far has shipped. True keeps the connection and
         # drops only the stuck turn — an opt-in escape hatch, injected by the
         # construction site so this module reads no configuration itself.
         self._fail_open = fail_open
+        # True while the queue consumer is suspended inside a transport write.
+        # Only the worker's own sends set it; sends issued from caller tasks
+        # do not, because those cannot block the consumer. See
+        # _fail_stuck_lifecycle for why fail-open refuses to apply in that
+        # state.
+        self._worker_send_in_flight = False
         self._queue: asyncio.PriorityQueue[_QueuedResponse] = asyncio.PriorityQueue()
         self._queued_by_ticket: dict[int, _QueuedResponse] = {}
         self._sequence = itertools.count()
@@ -850,6 +863,24 @@ class RealtimeResponseArbiter:
                 queued.completed.set_result(None)
             self._queue.task_done()
 
+    async def _worker_send(self, event: dict[str, Any]) -> None:
+        """Send from the queue consumer, flagged for the duration of the write.
+
+        Interrupt flags and failed futures do not unwind an await that is
+        parked inside the transport, and ``_run`` is the only consumer — so a
+        write that never returns wedges every later request no matter what the
+        escalation path does to the arbiter's own state. The flag lets
+        ``_fail_stuck_lifecycle`` notice that situation; only sends issued by
+        the worker itself qualify, since a caller-task send blocking hurts
+        only that caller.
+        """
+
+        self._worker_send_in_flight = True
+        try:
+            await self._send_event(event)
+        finally:
+            self._worker_send_in_flight = False
+
     def _release_stuck_lifecycle(self, reason: str) -> None:
         """Drop the stuck turn but keep the connection (the fail-open policy).
 
@@ -893,6 +924,21 @@ class RealtimeResponseArbiter:
         self._cancel_server_vad_pending_timer()
         self._cancel_stale_release_timer()
         self._idle.set()
+        # Last, because it is the only step that hands control to project code.
+        # The host keeps its own view of "a response is in progress" that only
+        # this connection's own terminal events normally clear, and the turn
+        # whose terminal we just gave up on is exactly the one that would have
+        # cleared it. Leaving it set would spend the connection we just saved:
+        # the host would treat the session as busy and hold back the work
+        # fail-open exists to keep serving.
+        if self._on_stuck_release is not None:
+            try:
+                self._on_stuck_release(reason)
+            except Exception as exc:
+                logger.debug(
+                    "stuck-release host notification failed: %s",
+                    type(exc).__name__,
+                )
 
     async def _fail_stuck_lifecycle(self, reason: str) -> None:
         """Escalate a response lifecycle that cannot reach a terminal state.
@@ -915,21 +961,33 @@ class RealtimeResponseArbiter:
             owner.source if owner is not None else None,
             self._queue.qsize(),
             self._server_vad_response_pending,
+            self._worker_send_in_flight,
         )
-        if self._fail_open:
+        # Fail-open rests on one premise: the transport is still usable. A
+        # queue consumer parked inside a transport write is that premise being
+        # falsified — and nothing this function does to the arbiter's own
+        # state can unwind that await, so keeping the connection would leave
+        # the sole consumer wedged while telling every later caller the lane
+        # had recovered. Tearing the transport down is what unblocks the write
+        # (the transport's close wakes its drain waiter), so in that state the
+        # escape hatch deliberately declines to apply. Worst case is exactly
+        # today's shipped default, never worse.
+        if self._fail_open and not self._worker_send_in_flight:
             # Wording differs on purpose: the fail-closed line below is the
             # documented grep target for attributing a field disconnect, and
             # this path did not disconnect anyone.
             logger.warning(
                 "response arbiter failing open, transport kept: %s "
-                "(current=%s owner=%s queue_depth=%d server_vad_pending=%s)",
+                "(current=%s owner=%s queue_depth=%d server_vad_pending=%s "
+                "worker_send_in_flight=%s)",
                 *lane_state,
             )
             self._release_stuck_lifecycle(reason)
             return
         logger.warning(
             "response arbiter failing closed: %s "
-            "(current=%s owner=%s queue_depth=%d server_vad_pending=%s)",
+            "(current=%s owner=%s queue_depth=%d server_vad_pending=%s "
+            "worker_send_in_flight=%s)",
             *lane_state,
         )
         self._mark_connection_lost(reason, fail_current_tickets=False)
@@ -1062,7 +1120,7 @@ class RealtimeResponseArbiter:
             for event in queued.events_before_response:
                 if queued.interrupted:
                     raise RuntimeError("response dispatch interrupted")
-                await self._send_event(event)
+                await self._worker_send(event)
 
             if queued.item_ack is not None:
                 try:
@@ -1092,7 +1150,7 @@ class RealtimeResponseArbiter:
             self._response_owner = queued
             queued.response_send_started = True
             try:
-                await self._send_event(queued.response_event)
+                await self._worker_send(queued.response_event)
             except Exception:
                 if self._response_owner is queued:
                     self._response_owner = None
@@ -1121,7 +1179,7 @@ class RealtimeResponseArbiter:
                     "response dispatch interrupted by pending server VAD response"
                 )
             if queued.interrupted:
-                await self._send_event({"type": "response.cancel"})
+                await self._worker_send({"type": "response.cancel"})
                 try:
                     await asyncio.wait_for(
                         asyncio.shield(queued.terminal), queued.cancel_timeout
@@ -1215,7 +1273,7 @@ class RealtimeResponseArbiter:
         self, queued: _QueuedResponse, original_timeout: asyncio.TimeoutError
     ) -> None:
         try:
-            await self._send_event({"type": "response.cancel"})
+            await self._worker_send({"type": "response.cancel"})
             assert queued.terminal is not None
             await asyncio.wait_for(
                 asyncio.shield(queued.terminal), queued.cancel_timeout

--- a/main_logic/omni_realtime_client/_response_arbiter.py
+++ b/main_logic/omni_realtime_client/_response_arbiter.py
@@ -5,6 +5,12 @@ pause lands while an item is being selected, that item is returned to the
 queue without consuming any fairness allowance. After resolving a ticket's
 ``sent`` future, the worker explicitly yields to its waiter before selecting
 more work so that an external-turn hand-off can restore a newer pause.
+
+A response lifecycle that cannot reach a terminal state escalates through the
+single ``_fail_stuck_lifecycle`` chokepoint. Its policy is chosen by the
+``fail_open`` constructor argument: the default tears the transport down,
+while the opt-in alternative drops only the stuck turn. This module reads no
+configuration of its own — the construction site decides.
 """
 
 from __future__ import annotations
@@ -128,9 +134,16 @@ class RealtimeResponseArbiter:
         send_event: SendEvent,
         *,
         abort_transport: AbortTransport | None = None,
+        fail_open: bool = False,
     ) -> None:
         self._send_event = send_event
         self._abort_transport = abort_transport
+        # Escalation policy for a response lifecycle that cannot reach a
+        # terminal state. Default (False) tears the transport down, which is
+        # what every release so far has shipped. True keeps the connection and
+        # drops only the stuck turn — an opt-in escape hatch, injected by the
+        # construction site so this module reads no configuration itself.
+        self._fail_open = fail_open
         self._queue: asyncio.PriorityQueue[_QueuedResponse] = asyncio.PriorityQueue()
         self._queued_by_ticket: dict[int, _QueuedResponse] = {}
         self._sequence = itertools.count()
@@ -281,7 +294,7 @@ class RealtimeResponseArbiter:
             try:
                 await self.wait_until_idle(timeout)
             except asyncio.TimeoutError as original_timeout:
-                await self._fail_closed(
+                await self._fail_stuck_lifecycle(
                     "response cancellation terminal event timed out"
                 )
                 raise original_timeout
@@ -300,7 +313,7 @@ class RealtimeResponseArbiter:
         try:
             await asyncio.wait_for(asyncio.shield(current.completed), timeout)
         except asyncio.TimeoutError as original_timeout:
-            await self._fail_closed("response cancellation terminal event timed out")
+            await self._fail_stuck_lifecycle("response cancellation terminal event timed out")
             raise original_timeout
 
     async def cancel_ticket(
@@ -341,7 +354,7 @@ class RealtimeResponseArbiter:
         try:
             await asyncio.wait_for(asyncio.shield(queued.completed), timeout)
         except asyncio.TimeoutError as original_timeout:
-            await self._fail_closed("targeted response cancellation timed out")
+            await self._fail_stuck_lifecycle("targeted response cancellation timed out")
             raise original_timeout
         return True
 
@@ -837,24 +850,87 @@ class RealtimeResponseArbiter:
                 queued.completed.set_result(None)
             self._queue.task_done()
 
-    async def _fail_closed(self, reason: str) -> None:
-        # This is the only chokepoint through which the arbiter tears down the
-        # transport, and to the rest of the system the result is
-        # indistinguishable from a provider-side disconnect (the receive loop
-        # errors first, then host cleanup runs). Log the initiator, the reason
-        # and the lane state here so a field disconnect can be attributed —
-        # see issue #2561, where the absence of exactly this line forced a
-        # build-provenance investigation to rule the arbiter out.
+    def _release_stuck_lifecycle(self, reason: str) -> None:
+        """Drop the stuck turn but keep the connection (the fail-open policy).
+
+        Deliberately narrower than ``_mark_connection_lost``, which exists for
+        a connection that is actually gone. Four things it must NOT do here:
+
+        - clear ``_connection_available``: the transport is still usable, and
+          clearing it would reject every later ``enqueue`` until a reconnect.
+        - bump ``_connection_generation`` / cancel pending cancel-sends: there
+          is no replacement connection, so those sends are still aimed at the
+          right one and still worth delivering.
+        - set ``_dispatch_allowed``: an external-ASR turn's pause must survive
+          an unrelated stuck response, or queued proactive work could win the
+          race against the user's own turn.
+        - fail the queue: everything behind this turn is still viable and
+          dispatches normally once the lane reopens.
+
+        What it does do is give up on the bookkeeping it just declared
+        untrustworthy. Leaving the owner or the remembered server response ids
+        in place would hold the lane closed waiting for terminals we have
+        stopped expecting — the exact wedge the caller escalated about.
+        """
+
+        exc = RuntimeError(reason)
+        owner = self._response_owner
+        current = self._current
+        seen: set[int] = set()
+        for target in (owner, current):
+            if target is None or id(target) in seen:
+                continue
+            seen.add(id(target))
+            # Waking the in-flight request unwinds ``_process`` now instead of
+            # letting it park until its own timeout escalates a second time.
+            target.interrupted = True
+            target.interrupt_event.set()
+            self._wake_current_with_error(target, exc)
+        self._response_owner = None
+        self._server_response_active = False
+        self._server_vad_response_pending = False
+        self._server_response_ids.clear()
+        self._cancel_server_vad_pending_timer()
+        self._cancel_stale_release_timer()
+        self._idle.set()
+
+    async def _fail_stuck_lifecycle(self, reason: str) -> None:
+        """Escalate a response lifecycle that cannot reach a terminal state.
+
+        Every escalation in this module funnels through here, and the policy is
+        chosen by ``fail_open`` at construction. Under the default the arbiter
+        tears the transport down, and to the rest of the system that is
+        indistinguishable from a provider-side disconnect (the receive loop
+        errors first, then host cleanup runs) — so the initiator, the reason
+        and the lane state are logged either way. See issue #2561, where the
+        absence of exactly this line forced a build-provenance investigation to
+        rule the arbiter out.
+        """
+
         current = self._current
         owner = self._response_owner
-        logger.warning(
-            "response arbiter failing closed: %s "
-            "(current=%s owner=%s queue_depth=%d server_vad_pending=%s)",
+        lane_state = (
             reason,
             current.source if current is not None else None,
             owner.source if owner is not None else None,
             self._queue.qsize(),
             self._server_vad_response_pending,
+        )
+        if self._fail_open:
+            # Wording differs on purpose: the fail-closed line below is the
+            # documented grep target for attributing a field disconnect, and
+            # this path did not disconnect anyone.
+            logger.warning(
+                "response arbiter failing open, transport kept: %s "
+                "(current=%s owner=%s queue_depth=%d server_vad_pending=%s)",
+                *lane_state,
+            )
+            self._release_stuck_lifecycle(reason)
+            return
+        logger.warning(
+            "response arbiter failing closed: %s "
+            "(current=%s owner=%s queue_depth=%d server_vad_pending=%s)",
+            *lane_state,
         )
         self._mark_connection_lost(reason, fail_current_tickets=False)
         if self._abort_transport is None:
@@ -952,7 +1028,7 @@ class RealtimeResponseArbiter:
                 return_when=asyncio.FIRST_COMPLETED,
             )
             if not done:
-                await self._fail_closed("realtime response idle wait timed out")
+                await self._fail_stuck_lifecycle("realtime response idle wait timed out")
                 raise asyncio.TimeoutError("realtime response idle wait timed out")
         finally:
             for waiter in waiters:
@@ -1053,7 +1129,7 @@ class RealtimeResponseArbiter:
                 except Exception:
                     if not queued.terminal.done():
                         queued.terminal.cancel()
-                    await self._fail_closed(
+                    await self._fail_stuck_lifecycle(
                         "interrupted response could not reach a terminal state"
                     )
                 raise RuntimeError("response dispatch interrupted")
@@ -1147,7 +1223,7 @@ class RealtimeResponseArbiter:
         except Exception:
             if queued.terminal is not None and not queued.terminal.done():
                 queued.terminal.cancel()
-            await self._fail_closed(
+            await self._fail_stuck_lifecycle(
                 "response lifecycle could not reach a terminal state"
             )
         raise original_timeout

--- a/main_logic/omni_realtime_client/_response_arbiter.py
+++ b/main_logic/omni_realtime_client/_response_arbiter.py
@@ -940,7 +940,12 @@ class RealtimeResponseArbiter:
                     type(exc).__name__,
                 )
 
-    async def _fail_stuck_lifecycle(self, reason: str) -> None:
+    async def _fail_stuck_lifecycle(
+        self,
+        reason: str,
+        *,
+        transport_write_failed: bool = False,
+    ) -> None:
         """Escalate a response lifecycle that cannot reach a terminal state.
 
         Every escalation in this module funnels through here, and the policy is
@@ -962,24 +967,39 @@ class RealtimeResponseArbiter:
             self._queue.qsize(),
             self._server_vad_response_pending,
             self._worker_send_in_flight,
+            transport_write_failed,
         )
-        # Fail-open rests on one premise: the transport is still usable. A
-        # queue consumer parked inside a transport write is that premise being
-        # falsified — and nothing this function does to the arbiter's own
-        # state can unwind that await, so keeping the connection would leave
-        # the sole consumer wedged while telling every later caller the lane
-        # had recovered. Tearing the transport down is what unblocks the write
-        # (the transport's close wakes its drain waiter), so in that state the
-        # escape hatch deliberately declines to apply. Worst case is exactly
-        # today's shipped default, never worse.
-        if self._fail_open and not self._worker_send_in_flight:
+        # Fail-open rests on one premise: the transport is still usable. Two
+        # things falsify it, and each makes the hatch decline.
+        #
+        # A consumer parked inside a transport write: nothing this function
+        # does to the arbiter's own state unwinds that await, and ``_run`` is
+        # the only consumer, so keeping the connection would leave it wedged
+        # while telling every later caller the lane had recovered. Tearing the
+        # transport down is what unblocks the write (its close wakes the drain
+        # waiter).
+        #
+        # A write that just raised: ``_worker_send`` clears its flag in a
+        # ``finally``, so by the time the caller escalates the first condition
+        # already reads False even though the transport refused the write
+        # moments ago — and on the fatal branch it has already dropped its
+        # socket. Reopening the lane there would dispatch queued work onto a
+        # connection that cannot carry it. Callers whose escalation follows a
+        # failed write say so explicitly.
+        #
+        # Worst case in both is exactly today's shipped default, never worse.
+        if (
+            self._fail_open
+            and not self._worker_send_in_flight
+            and not transport_write_failed
+        ):
             # Wording differs on purpose: the fail-closed line below is the
             # documented grep target for attributing a field disconnect, and
             # this path did not disconnect anyone.
             logger.warning(
                 "response arbiter failing open, transport kept: %s "
                 "(current=%s owner=%s queue_depth=%d server_vad_pending=%s "
-                "worker_send_in_flight=%s)",
+                "worker_send_in_flight=%s transport_write_failed=%s)",
                 *lane_state,
             )
             self._release_stuck_lifecycle(reason)
@@ -987,7 +1007,7 @@ class RealtimeResponseArbiter:
         logger.warning(
             "response arbiter failing closed: %s "
             "(current=%s owner=%s queue_depth=%d server_vad_pending=%s "
-            "worker_send_in_flight=%s)",
+            "worker_send_in_flight=%s transport_write_failed=%s)",
             *lane_state,
         )
         self._mark_connection_lost(reason, fail_current_tickets=False)
@@ -1272,8 +1292,16 @@ class RealtimeResponseArbiter:
     async def _cancel_after_timeout(
         self, queued: _QueuedResponse, original_timeout: asyncio.TimeoutError
     ) -> None:
+        cancel_write_failed = False
         try:
-            await self._worker_send({"type": "response.cancel"})
+            try:
+                await self._worker_send({"type": "response.cancel"})
+            except Exception:
+                # Remember it: _worker_send's finally has already lowered the
+                # in-flight flag, so the escalation below would otherwise read
+                # a usable transport a moment after this one refused a write.
+                cancel_write_failed = True
+                raise
             assert queued.terminal is not None
             await asyncio.wait_for(
                 asyncio.shield(queued.terminal), queued.cancel_timeout
@@ -1282,6 +1310,7 @@ class RealtimeResponseArbiter:
             if queued.terminal is not None and not queued.terminal.done():
                 queued.terminal.cancel()
             await self._fail_stuck_lifecycle(
-                "response lifecycle could not reach a terminal state"
+                "response lifecycle could not reach a terminal state",
+                transport_write_failed=cancel_write_failed,
             )
         raise original_timeout

--- a/main_logic/omni_realtime_client/_responses.py
+++ b/main_logic/omni_realtime_client/_responses.py
@@ -62,6 +62,7 @@ class _ResponseMixin:
                 self.send_event,
                 abort_transport=getattr(self, "_abort_failed_transport", None),
                 fail_open=response_arbiter_fail_open_enabled(),
+                on_stuck_release=getattr(self, "_on_arbiter_stuck_release", None),
             )
             self._response_arbiter = arbiter
         return arbiter

--- a/main_logic/omni_realtime_client/_responses.py
+++ b/main_logic/omni_realtime_client/_responses.py
@@ -21,6 +21,7 @@ from ._shared import (
     Optional,
     asyncio,
     logger,
+    response_arbiter_fail_open_enabled,
     time,
     uuid,
 )
@@ -60,6 +61,7 @@ class _ResponseMixin:
             arbiter = RealtimeResponseArbiter(
                 self.send_event,
                 abort_transport=getattr(self, "_abort_failed_transport", None),
+                fail_open=response_arbiter_fail_open_enabled(),
             )
             self._response_arbiter = arbiter
         return arbiter

--- a/main_logic/omni_realtime_client/_shared.py
+++ b/main_logic/omni_realtime_client/_shared.py
@@ -15,6 +15,8 @@
 
 import asyncio  # noqa: F401 - compatibility export and sibling dependency
 
+import os  # noqa: F401 - compatibility export and sibling dependency
+
 import uuid  # noqa: F401 - compatibility export and sibling dependency
 
 import websockets  # noqa: F401 - compatibility export and sibling dependency
@@ -76,3 +78,24 @@ _IMAGE_ANALYSIS_PENDING_DESCRIPTION = "[实时屏幕截图或相机画面正在�
 class TurnDetectionMode(Enum):
     SERVER_VAD = "server_vad"
     MANUAL = "manual"
+
+
+# Opt-in escape hatch for the response arbiter's escalation policy (issue
+# #2583). When a response lifecycle cannot reach a terminal state the arbiter
+# tears the realtime WebSocket down by default — safe, but a provider-side
+# event-timing quirk in the field would then present as repeated
+# disconnect-and-rebuild for the affected users, with no server-side switch to
+# reach them. Setting this makes the arbiter drop only the stuck turn and keep
+# the connection.
+#
+# An environment variable on purpose, not a settings-UI toggle: the support
+# path is "set this, restart, tell us if it helped". It is read once per client
+# construction, so a change needs a restart.
+_ARBITER_FAIL_OPEN_ENV_VAR = "NEKO_REALTIME_ARBITER_FAIL_OPEN"
+
+
+def response_arbiter_fail_open_enabled() -> bool:
+    """Read the arbiter fail-open escape hatch. Default off."""
+
+    raw = os.getenv(_ARBITER_FAIL_OPEN_ENV_VAR, "").strip().lower()
+    return raw in ("1", "true", "yes", "on")

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -906,10 +906,15 @@ class _TransportMixin:
         the rest of the session — silencing proactive chat on a connection the
         escape hatch just kept alive.
 
-        Deliberately narrow. It does NOT touch:
+        ``_skip_until_next_response`` is cleared for the same reason, in the
+        same direction: it suppresses output until the owning turn's
+        ``response.done``, and that terminal is precisely what has been given
+        up on. Note the asymmetry — SETTING it here would be wrong (it would
+        mute the next healthy turn), clearing it is right (the suppression
+        belonged to the turn being abandoned).
 
-        - ``_skip_until_next_response``: only ``response.done`` clears it, so
-          setting it here would mute the whole NEXT turn's text and audio.
+        Deliberately narrow otherwise. It does NOT touch:
+
         - ``_interrupted``: the AI-activity timestamps are recorded inside the
           same guard it gates, and proactive delivery leans on those to avoid
           talking over audio the provider is still streaming.
@@ -917,13 +922,14 @@ class _TransportMixin:
           ``handle_interruption`` keeps it.
         """
 
-        if not self._is_responding:
+        if not self._is_responding and not self._skip_until_next_response:
             return
         logger.info(
             "Clearing client response state after arbiter fail-open release: %s",
             reason,
         )
         self._is_responding = False
+        self._skip_until_next_response = False
 
     async def handle_interruption(self):
         """Handle user interruption of the current response."""

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -896,6 +896,35 @@ class _TransportMixin:
 
         return False
 
+    def _on_arbiter_stuck_release(self, reason: str) -> None:
+        """Drop the client-side "a response is in progress" flag after fail-open.
+
+        ``_is_responding`` is set on ``response.created`` and cleared only by
+        that response's own ``response.done`` or by an interruption. When the
+        arbiter gives up on a turn whose terminal never arrived, nothing else
+        will ever clear it, and ``is_active_response()`` then reports busy for
+        the rest of the session — silencing proactive chat on a connection the
+        escape hatch just kept alive.
+
+        Deliberately narrow. It does NOT touch:
+
+        - ``_skip_until_next_response``: only ``response.done`` clears it, so
+          setting it here would mute the whole NEXT turn's text and audio.
+        - ``_interrupted``: the AI-activity timestamps are recorded inside the
+          same guard it gates, and proactive delivery leans on those to avoid
+          talking over audio the provider is still streaming.
+        - ``_current_response_id``: kept for terminal attribution, same reason
+          ``handle_interruption`` keeps it.
+        """
+
+        if not self._is_responding:
+            return
+        logger.info(
+            "Clearing client response state after arbiter fail-open release: %s",
+            reason,
+        )
+        self._is_responding = False
+
     async def handle_interruption(self):
         """Handle user interruption of the current response."""
         if not self._is_responding:

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -896,8 +896,8 @@ class _TransportMixin:
 
         return False
 
-    def _on_arbiter_stuck_release(self, reason: str) -> None:
-        """Drop the client-side "a response is in progress" flag after fail-open.
+    async def _on_arbiter_stuck_release(self, reason: str) -> None:
+        """Finalize a turn the arbiter abandoned, the way its terminal would.
 
         ``_is_responding`` is set on ``response.created`` and cleared only by
         that response's own ``response.done`` or by an interruption. When the
@@ -906,7 +906,24 @@ class _TransportMixin:
         the rest of the session — silencing proactive chat on a connection the
         escape hatch just kept alive.
 
-        Deliberately narrow. It does NOT touch:
+        Flipping ``_is_responding`` alone is not enough: the host's end-of-turn
+        work is driven by ``response.done``, and that is the event being given
+        up on. Two consequences matter, so both hooks the terminal path calls
+        are called here.
+
+        - ``on_response_done`` finalizes the turn (turn end, TTS close). Its
+          absence leaves the host holding an open turn on a connection the
+          escape hatch just kept alive.
+        - ``on_sid_rotate`` under the same ``not _has_server_vad`` condition
+          the terminal path uses. Providers without server VAD never emit
+          ``speech_stopped``, so this is their only rotation point; without it
+          the speech id never advances and TTS upstream silently drops every
+          later turn's text. Reachable here because the lanlan.app free route
+          and livestream mode are both ``_is_free_proxy`` yet not
+          ``_is_gemini``, so they are arbitrated — this is not a Gemini-only
+          concern, and Gemini itself never reaches the arbiter at all.
+
+        Deliberately still narrow. It does NOT touch:
 
         - ``_interrupted``: the AI-activity timestamps are recorded inside the
           guard it gates, and proactive delivery leans on those — the 3s
@@ -928,10 +945,27 @@ class _TransportMixin:
         if not self._is_responding:
             return
         logger.info(
-            "Clearing client response state after arbiter fail-open release: %s",
+            "Finalizing abandoned turn after arbiter fail-open release: %s",
             reason,
         )
         self._is_responding = False
+        # Each hook is isolated: a host that raises while closing one turn
+        # must not stop the other hook from running, and neither may
+        # propagate into the arbiter's release path.
+        if self.on_response_done:
+            try:
+                await self.on_response_done()
+            except Exception as exc:
+                logger.warning(
+                    "abandoned-turn finalization failed: %s", exc
+                )
+        if not self._has_server_vad and self.on_sid_rotate:
+            try:
+                await self.on_sid_rotate()
+            except Exception as exc:
+                logger.warning(
+                    "abandoned-turn speech-id rotation failed: %s", exc
+                )
 
     async def handle_interruption(self):
         """Handle user interruption of the current response."""

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -896,6 +896,39 @@ class _TransportMixin:
 
         return False
 
+    def _reset_per_turn_output_state(self) -> None:
+        """Clear the transport state scoped to one response.
+
+        Shared by ``response.done`` and by the abandoned-turn path, because
+        every one of these leaks into the NEXT turn if the terminal never
+        arrives: a stale ``_image_sent_this_turn`` makes ``stream_image``
+        suppress the next turn's visual context entirely, a stale transcript
+        buffer gets flushed against the wrong turn, and ``_audio_delta_count``
+        drives the "did this turn actually speak" checks.
+
+        Kept as one function on purpose — four review rounds each found
+        another field the abandoned path had forgotten, which is what
+        re-deriving this list in two places produces.
+        """
+
+        self._audio_delta_count = 0
+        # 确保 buffer 被清空
+        self._output_transcript_buffer = ""
+        self._print_input_transcript = False
+        if self._supports_native_image:
+            self._image_recognized_this_turn = False
+        elif (
+            self._latest_image_b64 is None
+            or self._proactive_image_consumed
+        ):
+            # Standard StepFun analyzes only while this sentinel is
+            # present. Rearm after a consumed/absent frame, but keep
+            # a completed annotation generation-bound to an
+            # unconsumed cached frame across unrelated responses.
+            self._image_recognized_this_turn = False
+            self._image_description = _IMAGE_ANALYSIS_PENDING_DESCRIPTION
+        self._image_sent_this_turn = False
+
     async def _on_arbiter_stuck_release(self, reason: str) -> None:
         """Finalize a turn the arbiter abandoned, the way its terminal would.
 
@@ -949,6 +982,11 @@ class _TransportMixin:
             reason,
         )
         self._is_responding = False
+        # The same per-turn reset the terminal path performs. Skipping it
+        # leaks this turn's state into the next one — most visibly
+        # ``_image_sent_this_turn``, which would make ``stream_image``
+        # withhold the next turn's visual context for its whole duration.
+        self._reset_per_turn_output_state()
         # Each hook is isolated: a host that raises while closing one turn
         # must not stop the other hook from running, and neither may
         # propagate into the arbiter's release path.
@@ -1229,23 +1267,7 @@ class _TransportMixin:
                             self._output_transcript_buffer, self._is_first_transcript_chunk
                         )
                         self._is_first_transcript_chunk = False
-                    self._audio_delta_count = 0
-                    # 确保 buffer 被清空
-                    self._output_transcript_buffer = ""
-                    self._print_input_transcript = False
-                    if self._supports_native_image:
-                        self._image_recognized_this_turn = False
-                    elif (
-                        self._latest_image_b64 is None
-                        or self._proactive_image_consumed
-                    ):
-                        # Standard StepFun analyzes only while this sentinel is
-                        # present. Rearm after a consumed/absent frame, but keep
-                        # a completed annotation generation-bound to an
-                        # unconsumed cached frame across unrelated responses.
-                        self._image_recognized_this_turn = False
-                        self._image_description = _IMAGE_ANALYSIS_PENDING_DESCRIPTION
-                    self._image_sent_this_turn = False
+                    self._reset_per_turn_output_state()
                     if self.on_response_done:
                         await self.on_response_done()
                     # No-server-VAD providers (Gemini-proxy: lanlan.app+free /

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -906,30 +906,32 @@ class _TransportMixin:
         the rest of the session — silencing proactive chat on a connection the
         escape hatch just kept alive.
 
-        ``_skip_until_next_response`` is cleared for the same reason, in the
-        same direction: it suppresses output until the owning turn's
-        ``response.done``, and that terminal is precisely what has been given
-        up on. Note the asymmetry — SETTING it here would be wrong (it would
-        mute the next healthy turn), clearing it is right (the suppression
-        belonged to the turn being abandoned).
-
-        Deliberately narrow otherwise. It does NOT touch:
+        Deliberately narrow. It does NOT touch:
 
         - ``_interrupted``: the AI-activity timestamps are recorded inside the
-          same guard it gates, and proactive delivery leans on those to avoid
-          talking over audio the provider is still streaming.
+          guard it gates, and proactive delivery leans on those — the 3s
+          window in ``prompt_ephemeral`` is what keeps a proactive line from
+          landing on top of audio the provider is still streaming for the
+          turn we just abandoned.
         - ``_current_response_id``: kept for terminal attribution, same reason
           ``handle_interruption`` keeps it.
+        - ``_skip_until_next_response``: it is a single global flag with no
+          association to a turn, so this handler cannot tell "the abandoned
+          turn raised it" from "a turn queued behind it raised it". Clearing
+          would strip the queued turn's suppression; leaving it raised would
+          mute the next healthy turn. Neither is reachable today — no caller
+          passes ``skipped=True`` down the ``create_response`` path, and
+          ``prime_context(skipped=True)`` goes to ``update_session`` instead —
+          so the fix belongs with per-turn suppression rather than here.
         """
 
-        if not self._is_responding and not self._skip_until_next_response:
+        if not self._is_responding:
             return
         logger.info(
             "Clearing client response state after arbiter fail-open release: %s",
             reason,
         )
         self._is_responding = False
-        self._skip_until_next_response = False
 
     async def handle_interruption(self):
         """Handle user interruption of the current response."""

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -708,6 +708,31 @@ async def test_the_release_clears_an_abandoned_turns_output_suppression(client_r
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_suppression_is_lifted_even_when_no_response_ever_started(client_rig):
+    # The skipped turn raises the flag at request time, before any
+    # response.created. If it gets stuck in that window, _is_responding is
+    # still False while the flag is up — so a release handler that returns
+    # early on _is_responding alone would leave the suppression raised and
+    # mute the next healthy turn.
+    client_rig.client._skip_until_next_response = True
+    client_rig.client._is_responding = False
+
+    ticket = await client_rig.arbiter.enqueue(source="native")
+    await asyncio.wait_for(ticket.sent, timeout=1)
+    try:
+        await client_rig.arbiter.cancel_current(timeout=0.05)
+    except Exception:  # noqa: BLE001 - the escalation is the point
+        pass
+    await _settle()
+
+    assert client_rig.client._skip_until_next_response is False, (
+        "the release must lift suppression even for a turn that never "
+        "reached response.created"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_the_release_notification_touches_nothing_else(client_rig):
     # Both of these would be tempting to reset here and both would be wrong:
     # _skip_until_next_response is cleared only by response.done, so setting it

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -788,6 +788,62 @@ async def test_a_stalled_worker_send_makes_fail_open_stand_down(
         await asyncio.wait_for(later.sent, timeout=1)
 
 
+class _RaisingHarness(_Harness):
+    """Harness whose FIRST response.create write fails; later ones succeed.
+
+    Only the first, so the test can go on to prove the arbiter still works
+    afterwards rather than just proving the stub keeps raising.
+    """
+
+    def __init__(self, *, fail_open: bool) -> None:
+        super().__init__(fail_open=fail_open)
+        self.refusals = 0
+
+    async def _send(self, event: dict) -> None:
+        self.sent.append(event)
+        if event.get("type") == "response.create" and self.refusals == 0:
+            self.refusals += 1
+            raise RuntimeError("transport write refused")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_failed_worker_send_does_not_latch_the_stand_down_flag():
+    # The stand-down flag is set around the write and must come back down on
+    # EVERY exit, not just the successful one. A write that raises is an
+    # ordinary path (the ticket fails and the worker moves on); if the flag
+    # stayed up, fail-open would be silently disabled for the rest of this
+    # arbiter's life and every later escalation would tear the transport down
+    # while the log still blamed a send that finished long ago.
+    harness = _RaisingHarness(fail_open=True)
+    try:
+        failed = await harness.arbiter.enqueue(source="native-doomed")
+        with pytest.raises(RuntimeError):
+            await asyncio.wait_for(failed.sent, timeout=1)
+        await _settle()
+
+        assert harness.arbiter._worker_send_in_flight is False, (
+            "the flag must clear even when the write raises"
+        )
+
+        # And fail-open still applies afterwards: a fresh stuck turn releases
+        # instead of tearing the transport down.
+        harness.sent.clear()
+        ticket = await harness.arbiter.enqueue(source="native")
+        await asyncio.wait_for(ticket.sent, timeout=1)
+        harness.arbiter.notify_response_created(
+            {"type": "response.created", "response": {"id": "resp-1"}}
+        )
+        raised = await _stick_a_cancel(harness)
+        assert isinstance(raised, asyncio.TimeoutError)
+        assert harness.aborted == [], (
+            "a previously failed write must not permanently disable fail-open"
+        )
+        assert harness.arbiter._connection_available is True
+    finally:
+        await harness.arbiter.shutdown("test teardown")
+
+
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_the_stalled_send_outcome_is_identical_under_both_policies(

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -803,6 +803,120 @@ async def test_a_server_vad_route_is_not_rotated_by_the_release(monkeypatch):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_the_release_resets_per_turn_transport_state(client_rig):
+    # Codex P2 on PR #2592. The abandoned turn's per-turn state leaks into the
+    # next one unless the release performs the same reset the terminal path
+    # performs. _image_sent_this_turn is the visible one: left raised, the
+    # stream_image gate withholds the NEXT turn's visual context for its whole
+    # duration, so that response answers about a screen it cannot see.
+    client_rig.client._image_sent_this_turn = True
+    client_rig.client._audio_delta_count = 7
+    client_rig.client._output_transcript_buffer = "leftover"
+    client_rig.client._print_input_transcript = True
+
+    raised = await client_rig.drive_to_escalation()
+    assert isinstance(raised, asyncio.TimeoutError)
+    await _settle()
+
+    assert client_rig.client._image_sent_this_turn is False, (
+        "a stale image flag silently blinds the next turn"
+    )
+    assert client_rig.client._audio_delta_count == 0
+    assert client_rig.client._output_transcript_buffer == ""
+    assert client_rig.client._print_input_transcript is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_slow_host_callback_cannot_wedge_the_queue_consumer(caplog):
+    # Codex P2 on PR #2592, and a defect this PR introduced in its previous
+    # round: making the release notification awaitable put it on the sole
+    # queue consumer for escalations raised inside _process. An unbounded host
+    # callback there blocks every later dispatch right after the lane was
+    # marked idle — the stalled-write wedge again, moved into project code.
+    released = asyncio.Event()
+
+    async def _never_returns(reason: str) -> None:
+        await released.wait()
+
+    sent: list[dict] = []
+
+    async def _send(event: dict) -> None:
+        sent.append(event)
+
+    arbiter = RealtimeResponseArbiter(
+        _send,
+        abort_transport=None,
+        fail_open=True,
+        on_stuck_release=_never_returns,
+    )
+    monkeypatched = 0.05
+    import main_logic.omni_realtime_client._response_arbiter as arbiter_module
+
+    original = arbiter_module._STUCK_RELEASE_NOTIFY_TIMEOUT
+    arbiter_module._STUCK_RELEASE_NOTIFY_TIMEOUT = monkeypatched
+    try:
+        # response_started_timeout drives the _process-side escalation, so the
+        # notification really does run on the consumer.
+        stuck = await arbiter.enqueue(
+            source="native",
+            response_started_timeout=0.05,
+            cancel_timeout=0.05,
+        )
+        await asyncio.wait_for(stuck.sent, timeout=1)
+
+        with caplog.at_level(logging.WARNING, logger=ARBITER_LOGGER):
+            with pytest.raises(Exception):
+                await asyncio.wait_for(stuck.done, timeout=2)
+            await _settle()
+
+        assert any(
+            "exceeded" in record.getMessage() for record in caplog.records
+        ), "the bound must be visible, not silently swallowed"
+
+        # The consumer is free: the next request dispatches while the host
+        # callback is still hanging.
+        follow_up = await arbiter.enqueue(source="native-after")
+        await asyncio.wait_for(follow_up.sent, timeout=1)
+        assert sent[-1]["type"] == "response.create"
+    finally:
+        arbiter_module._STUCK_RELEASE_NOTIFY_TIMEOUT = original
+        released.set()
+        await arbiter.shutdown("test teardown")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_pending_server_vad_response_makes_fail_open_stand_down(caplog):
+    # Codex P2 on PR #2592. A pending server-VAD response is announced but has
+    # not supplied an id yet, and cancel_current's 3s bound is shorter than the
+    # 5s missing-created backstop — so an escalation can land while it is still
+    # uncorrelated. Releasing there would credit its later created/done to
+    # whichever ticket dispatches next.
+    harness = _Harness(fail_open=True)
+    try:
+        harness.arbiter.notify_server_vad_response_pending()
+        await _settle()
+        assert harness.arbiter._server_vad_response_pending is True
+
+        with caplog.at_level(logging.WARNING, logger=ARBITER_LOGGER):
+            raised = await _stick_a_cancel(harness)
+
+        assert isinstance(raised, asyncio.TimeoutError)
+        assert harness.aborted, (
+            "fail-open must decline while an announced VAD response has no id"
+        )
+        assert harness.arbiter._connection_available is False
+        assert any(
+            "uncorrelatable_owner=True" in record.getMessage()
+            for record in caplog.records
+        )
+    finally:
+        await harness.arbiter.shutdown("test teardown")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_an_uncorrelatable_owner_makes_fail_open_stand_down(caplog):
     # Codex P2 on PR #2592. An owner that reached response.created without an
     # id leaves nothing to quarantine its late terminal by: after release, that

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -828,7 +828,9 @@ async def test_the_release_resets_per_turn_transport_state(client_rig):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_a_slow_host_callback_cannot_wedge_the_queue_consumer(caplog):
+async def test_a_slow_host_callback_cannot_wedge_the_queue_consumer(
+    caplog, monkeypatch
+):
     # Codex P2 on PR #2592, and a defect this PR introduced in its previous
     # round: making the release notification awaitable put it on the sole
     # queue consumer for escalations raised inside _process. An unbounded host
@@ -850,11 +852,11 @@ async def test_a_slow_host_callback_cannot_wedge_the_queue_consumer(caplog):
         fail_open=True,
         on_stuck_release=_never_returns,
     )
-    monkeypatched = 0.05
-    import main_logic.omni_realtime_client._response_arbiter as arbiter_module
-
-    original = arbiter_module._STUCK_RELEASE_NOTIFY_TIMEOUT
-    arbiter_module._STUCK_RELEASE_NOTIFY_TIMEOUT = monkeypatched
+    monkeypatch.setattr(
+        "main_logic.omni_realtime_client._response_arbiter"
+        "._STUCK_RELEASE_NOTIFY_TIMEOUT",
+        0.05,
+    )
     try:
         # response_started_timeout drives the _process-side escalation, so the
         # notification really does run on the consumer.
@@ -880,7 +882,8 @@ async def test_a_slow_host_callback_cannot_wedge_the_queue_consumer(caplog):
         await asyncio.wait_for(follow_up.sent, timeout=1)
         assert sent[-1]["type"] == "response.create"
     finally:
-        arbiter_module._STUCK_RELEASE_NOTIFY_TIMEOUT = original
+        # Release the hanging callback BEFORE shutdown: it is still awaiting
+        # this event, and shutdown reaps the worker.
         released.set()
         await arbiter.shutdown("test teardown")
 

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -748,6 +748,61 @@ async def test_the_release_finalizes_the_abandoned_turn(monkeypatch):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_a_server_vad_route_is_not_rotated_by_the_release(monkeypatch):
+    # The dual of the case above. Routes WITH server VAD rotate the speech id
+    # from speech_stopped, so rotating here as well would be a second,
+    # unpaired rotation on a live turn. The finalization must carry the same
+    # condition the terminal path carries, not rotate unconditionally.
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    monkeypatch.setenv(FAIL_OPEN_ENV_VAR, "1")
+    done_calls: list[str] = []
+    rotations: list[str] = []
+
+    async def _on_done() -> None:
+        done_calls.append("done")
+
+    async def _on_rotate() -> None:
+        rotations.append("rotate")
+
+    client = OmniRealtimeClient(
+        "wss://example.invalid/realtime",
+        "test-key",
+        model="free-model",
+        api_type="free",
+        on_response_done=_on_done,
+        on_sid_rotate=_on_rotate,
+    )
+    assert client._has_server_vad is True, "this route rotates on speech_stopped"
+
+    async def _send(event: dict) -> None:
+        return None
+
+    arbiter = client._response_arbiter
+    arbiter._send_event = _send
+    try:
+        ticket = await arbiter.enqueue(source="native")
+        await asyncio.wait_for(ticket.sent, timeout=1)
+        arbiter.notify_response_created(
+            {"type": "response.created", "response": {"id": "resp-1"}}
+        )
+        client._is_responding = True
+
+        with pytest.raises(asyncio.TimeoutError):
+            await arbiter.cancel_current(timeout=0.05)
+        await _settle()
+
+        assert done_calls == ["done"], "the turn is still finalized"
+        assert rotations == [], (
+            "a server-VAD route already rotates from speech_stopped; a second "
+            "rotation here would land on a live turn"
+        )
+    finally:
+        await arbiter.shutdown("test teardown")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_an_uncorrelatable_owner_makes_fail_open_stand_down(caplog):
     # Codex P2 on PR #2592. An owner that reached response.created without an
     # id leaves nothing to quarantine its late terminal by: after release, that
@@ -778,6 +833,34 @@ async def test_an_uncorrelatable_owner_makes_fail_open_stand_down(caplog):
         )
     finally:
         await harness.arbiter.shutdown("test teardown")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_an_owner_that_never_started_is_not_treated_as_uncorrelatable(
+    make_harness,
+):
+    # The stand-down asks whether a LIVE response's terminal could be confused
+    # with the next one's. An owner still waiting for its response.created has
+    # no live response at all, so there is no terminal to confuse — dropping
+    # the started() half of the condition would make the hatch decline here
+    # too. That direction is safe rather than wrong, which is exactly why it
+    # needs a test: nothing else would notice the hatch quietly narrowing.
+    harness = make_harness(fail_open=True)
+    ticket = await harness.arbiter.enqueue(source="native")
+    await asyncio.wait_for(ticket.sent, timeout=1)
+    # No response.created is fed, so started is pending and response_id is None.
+    assert harness.arbiter._response_owner is not None
+    assert harness.arbiter._response_owner.ticket.started.done() is False
+
+    raised = await _stick_a_cancel(harness)
+
+    assert isinstance(raised, asyncio.TimeoutError)
+    assert harness.aborted == [], (
+        "a turn that never started cannot emit a confusable terminal, so the "
+        "hatch should still apply"
+    )
+    assert harness.arbiter._connection_available is True
 
 
 @pytest.mark.unit

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -371,6 +371,13 @@ async def test_fail_open_clears_the_bookkeeping_it_gave_up_on(make_harness):
     assert isinstance(raised, asyncio.TimeoutError)
     await _settle()
 
+    # Pin the policy first. Clearing this bookkeeping is something BOTH
+    # policies do (fail-closed reaches it through _mark_connection_lost), so
+    # without these two lines the test would stay green against a switch
+    # hardwired to fail-closed — asserting less than its own name claims.
+    assert harness.aborted == []
+    assert harness.arbiter._connection_available is True
+
     assert harness.arbiter._server_response_ids == {}
     assert harness.arbiter._server_response_active is False
     assert harness.arbiter._server_vad_response_pending is False

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -682,57 +682,6 @@ async def test_the_lazily_built_arbiter_gets_the_same_notification(client_rig):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_the_release_clears_an_abandoned_turns_output_suppression(client_rig):
-    # Codex P2 on PR #2592, and the exact dual of the case below: a turn
-    # requested with skipped=True raises _skip_until_next_response, and only
-    # that turn's own response.done lowers it — the terminal fail-open just
-    # gave up on. Left raised, the transport suppresses the NEXT healthy
-    # response's text and audio until its own done, so the hatch silently
-    # costs a second turn.
-    #
-    # The flag is set explicitly here rather than through create_response
-    # because no production caller passes skipped=True on this path today;
-    # the guard is defensive, and a test that did not raise the flag first
-    # would assert nothing at all.
-    client_rig.client._skip_until_next_response = True
-
-    raised = await client_rig.drive_to_escalation()
-    assert isinstance(raised, asyncio.TimeoutError)
-    await _settle()
-
-    assert client_rig.client._skip_until_next_response is False, (
-        "the abandoned turn's output suppression must be lifted with it"
-    )
-    assert client_rig.client._is_responding is False
-
-
-@pytest.mark.unit
-@pytest.mark.asyncio
-async def test_suppression_is_lifted_even_when_no_response_ever_started(client_rig):
-    # The skipped turn raises the flag at request time, before any
-    # response.created. If it gets stuck in that window, _is_responding is
-    # still False while the flag is up — so a release handler that returns
-    # early on _is_responding alone would leave the suppression raised and
-    # mute the next healthy turn.
-    client_rig.client._skip_until_next_response = True
-    client_rig.client._is_responding = False
-
-    ticket = await client_rig.arbiter.enqueue(source="native")
-    await asyncio.wait_for(ticket.sent, timeout=1)
-    try:
-        await client_rig.arbiter.cancel_current(timeout=0.05)
-    except Exception:  # noqa: BLE001 - the escalation is the point
-        pass
-    await _settle()
-
-    assert client_rig.client._skip_until_next_response is False, (
-        "the release must lift suppression even for a turn that never "
-        "reached response.created"
-    )
-
-
-@pytest.mark.unit
-@pytest.mark.asyncio
 async def test_the_release_notification_touches_nothing_else(client_rig):
     # Both of these would be tempting to reset here and both would be wrong:
     # _skip_until_next_response is cleared only by response.done, so setting it

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -682,6 +682,32 @@ async def test_the_lazily_built_arbiter_gets_the_same_notification(client_rig):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_the_release_clears_an_abandoned_turns_output_suppression(client_rig):
+    # Codex P2 on PR #2592, and the exact dual of the case below: a turn
+    # requested with skipped=True raises _skip_until_next_response, and only
+    # that turn's own response.done lowers it — the terminal fail-open just
+    # gave up on. Left raised, the transport suppresses the NEXT healthy
+    # response's text and audio until its own done, so the hatch silently
+    # costs a second turn.
+    #
+    # The flag is set explicitly here rather than through create_response
+    # because no production caller passes skipped=True on this path today;
+    # the guard is defensive, and a test that did not raise the flag first
+    # would assert nothing at all.
+    client_rig.client._skip_until_next_response = True
+
+    raised = await client_rig.drive_to_escalation()
+    assert isinstance(raised, asyncio.TimeoutError)
+    await _settle()
+
+    assert client_rig.client._skip_until_next_response is False, (
+        "the abandoned turn's output suppression must be lifted with it"
+    )
+    assert client_rig.client._is_responding is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_the_release_notification_touches_nothing_else(client_rig):
     # Both of these would be tempting to reset here and both would be wrong:
     # _skip_until_next_response is cleared only by response.done, so setting it
@@ -840,6 +866,95 @@ async def test_a_failed_worker_send_does_not_latch_the_stand_down_flag():
             "a previously failed write must not permanently disable fail-open"
         )
         assert harness.arbiter._connection_available is True
+    finally:
+        await harness.arbiter.shutdown("test teardown")
+
+
+class _CancelRefusingHarness(_Harness):
+    """Harness that accepts response.create but refuses response.cancel."""
+
+    async def _send(self, event: dict) -> None:
+        self.sent.append(event)
+        if event.get("type") == "response.cancel":
+            raise RuntimeError("1006 abnormal close")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_refused_cancel_write_forces_the_fail_closed_path(caplog):
+    # Codex P2 on PR #2592. _worker_send lowers its in-flight flag in a
+    # finally, so by the time _cancel_after_timeout escalates, the "consumer
+    # is mid-write" guard already reads False — even though the transport
+    # refused that very write, and on the fatal branch has already dropped its
+    # socket. Reopening the lane there would dispatch queued work onto a
+    # connection that cannot carry it, so the escalation has to carry the
+    # write's outcome with it.
+    harness = _CancelRefusingHarness(fail_open=True)
+    try:
+        # response_started_timeout drives _cancel_after_timeout: the create
+        # goes out, response.created never arrives, so the worker cancels —
+        # and that cancel write is the one the transport refuses.
+        ticket = await harness.arbiter.enqueue(
+            source="native",
+            response_started_timeout=0.05,
+            cancel_timeout=0.05,
+        )
+        await asyncio.wait_for(ticket.sent, timeout=1)
+
+        with caplog.at_level(logging.WARNING, logger=ARBITER_LOGGER):
+            with pytest.raises(Exception):
+                await asyncio.wait_for(ticket.done, timeout=2)
+            await _settle()
+
+        assert harness.types == ["response.create", "response.cancel"]
+        assert harness.aborted, (
+            "an escalation that follows a refused write must fail closed, not "
+            "reopen the lane on a transport that just rejected a send"
+        )
+        assert harness.arbiter._connection_available is False
+        messages = [record.getMessage() for record in caplog.records]
+        assert any("failing closed" in message for message in messages)
+        assert any(
+            "transport_write_failed=True" in message for message in messages
+        ), "the log must record why an opted-in session failed closed"
+
+        later = await harness.arbiter.enqueue(source="native-after")
+        with pytest.raises(ConnectionError):
+            await asyncio.wait_for(later.sent, timeout=1)
+    finally:
+        await harness.arbiter.shutdown("test teardown")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_terminal_timeout_with_a_healthy_cancel_still_fails_open(caplog):
+    # The dual: same escalation site, same code path, but the cancel write is
+    # accepted — only the terminal never arrives. That is the ordinary stuck
+    # lifecycle the hatch exists for, and it must still release. Without this
+    # pair, forcing fail-closed on every _cancel_after_timeout escalation
+    # would look correct.
+    harness = _Harness(fail_open=True)
+    try:
+        ticket = await harness.arbiter.enqueue(
+            source="native",
+            response_started_timeout=0.05,
+            cancel_timeout=0.05,
+        )
+        await asyncio.wait_for(ticket.sent, timeout=1)
+
+        with caplog.at_level(logging.WARNING, logger=ARBITER_LOGGER):
+            with pytest.raises(Exception):
+                await asyncio.wait_for(ticket.done, timeout=2)
+            await _settle()
+
+        assert harness.aborted == []
+        assert harness.arbiter._connection_available is True
+        assert any(
+            "failing open" in record.getMessage() for record in caplog.records
+        )
+
+        revived = await harness.arbiter.enqueue(source="native-after")
+        await asyncio.wait_for(revived.sent, timeout=1)
     finally:
         await harness.arbiter.shutdown("test teardown")
 

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -682,6 +682,121 @@ async def test_the_lazily_built_arbiter_gets_the_same_notification(client_rig):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_the_release_finalizes_the_abandoned_turn(monkeypatch):
+    # Codex P2 on PR #2592. Flipping _is_responding alone leaves the host
+    # holding an open turn: response.done is what normally ends it and rotates
+    # the speech id, and that is the event being given up on. The rotation half
+    # matters on any route without server VAD — the lanlan.app free route and
+    # livestream mode are both _is_free_proxy yet NOT _is_gemini, so they are
+    # arbitrated. Without it the speech id never advances and TTS upstream
+    # drops every later turn's text.
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    monkeypatch.setenv(FAIL_OPEN_ENV_VAR, "1")
+    done_calls: list[str] = []
+    rotations: list[str] = []
+
+    async def _on_done() -> None:
+        done_calls.append("done")
+
+    async def _on_rotate() -> None:
+        rotations.append("rotate")
+
+    client = OmniRealtimeClient(
+        "wss://lanlan.app/api/v1/realtime",
+        "test-key",
+        model="free-model",
+        api_type="free",
+        on_response_done=_on_done,
+        on_sid_rotate=_on_rotate,
+    )
+    assert client._has_server_vad is False, (
+        "this route is the one whose only rotation point is response.done"
+    )
+    assert client._is_gemini is False, "and it really does reach the arbiter"
+
+    sent: list[dict] = []
+
+    async def _send(event: dict) -> None:
+        sent.append(event)
+
+    arbiter = client._response_arbiter
+    arbiter._send_event = _send
+    try:
+        ticket = await arbiter.enqueue(source="native")
+        await asyncio.wait_for(ticket.sent, timeout=1)
+        arbiter.notify_response_created(
+            {"type": "response.created", "response": {"id": "resp-1"}}
+        )
+        client._is_responding = True
+
+        with pytest.raises(asyncio.TimeoutError):
+            await arbiter.cancel_current(timeout=0.05)
+        await _settle()
+
+        assert client._is_responding is False
+        assert done_calls == ["done"], (
+            "the abandoned turn must be finalized, not left open"
+        )
+        assert rotations == ["rotate"], (
+            "without rotation the speech id never advances and TTS upstream "
+            "silently drops every later turn"
+        )
+    finally:
+        await arbiter.shutdown("test teardown")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_an_uncorrelatable_owner_makes_fail_open_stand_down(caplog):
+    # Codex P2 on PR #2592. An owner that reached response.created without an
+    # id leaves nothing to quarantine its late terminal by: after release, that
+    # terminal would be credited to the NEXT id-less owner, resolving its
+    # ticket early and reopening the lane while its response is still
+    # streaming. Providers that omit response ids are explicitly supported
+    # elsewhere in this module, so this is a real shape.
+    harness = _Harness(fail_open=True)
+    try:
+        ticket = await harness.arbiter.enqueue(source="native")
+        await asyncio.wait_for(ticket.sent, timeout=1)
+        # created WITHOUT an id — the id-less proxy shape.
+        harness.arbiter.notify_response_created({"type": "response.created"})
+        await _settle()
+
+        with caplog.at_level(logging.WARNING, logger=ARBITER_LOGGER):
+            raised = await _stick_a_cancel(harness)
+
+        assert isinstance(raised, asyncio.TimeoutError)
+        assert harness.aborted, (
+            "fail-open must decline when the abandoned turn's terminal cannot "
+            "be told apart from the next turn's"
+        )
+        assert harness.arbiter._connection_available is False
+        assert any(
+            "uncorrelatable_owner=True" in record.getMessage()
+            for record in caplog.records
+        )
+    finally:
+        await harness.arbiter.shutdown("test teardown")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_an_id_bearing_owner_still_fails_open(make_harness):
+    # The dual: same escalation, same site, but the provider supplied an id —
+    # the terminal is correlatable, so the hatch applies. Without this pair,
+    # standing down unconditionally would look correct.
+    harness = make_harness(fail_open=True)
+    await harness.own_a_live_response("resp-with-id")
+
+    raised = await _stick_a_cancel(harness)
+    assert isinstance(raised, asyncio.TimeoutError)
+    assert harness.aborted == []
+    assert harness.arbiter._connection_available is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_the_release_notification_touches_nothing_else(client_rig):
     # Both of these would be tempting to reset here and both would be wrong:
     # _skip_until_next_response is cleared only by response.done, so setting it

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -120,16 +120,21 @@ async def make_harness():
         await harness.arbiter.shutdown("test teardown")
 
 
-async def _stick_a_cancel(harness: _Harness) -> BaseException | None:
+async def _stick_a_cancel(harness: _Harness) -> Exception | None:
     """Cancel the live response whose terminal never arrives; return the raise.
 
     This drives the ``cancel_current`` escalation site, which is the one a
-    barge-in reaches in production.
+    barge-in reaches in production. Catching ``Exception`` rather than
+    ``BaseException`` is deliberate and sufficient: the expected raise is
+    ``asyncio.TimeoutError``, which is the builtin ``TimeoutError`` on 3.11 and
+    therefore an ``Exception``. A ``CancelledError`` here would mean the test
+    itself was cancelled, which should propagate rather than be reported as
+    the escalation's result.
     """
 
     try:
         await harness.arbiter.cancel_current(timeout=0.05)
-    except BaseException as exc:  # noqa: BLE001 - the raise itself is asserted
+    except Exception as exc:  # noqa: BLE001 - the raise itself is asserted
         return exc
     return None
 
@@ -387,6 +392,129 @@ async def test_fail_open_clears_the_bookkeeping_it_gave_up_on(make_harness):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_a_late_created_after_fail_open_closes_the_lane_on_purpose(make_harness):
+    # Greptile P1 on PR #2592: after fail-open drops the abandoned ids, a
+    # delayed response.created is recorded as a server-initiated response and
+    # closes the lane again.
+    #
+    # That is deliberate, and the alternative is the defect the arbiter exists
+    # to prevent: the provider has just said a response IS live, so dispatching
+    # the next response.create would collide with it (response_already_active).
+    # Abandoning our own ticket never made the server's response go away.
+    #
+    # What must hold is that it is a PAUSE, not a wedge — its terminal reopens
+    # the lane normally. The no-terminal case is the test below.
+    harness = make_harness(fail_open=True)
+    await harness.own_a_live_response("resp-abandoned")
+
+    raised = await _stick_a_cancel(harness)
+    assert isinstance(raised, asyncio.TimeoutError)
+    await _settle()
+    assert harness.arbiter.is_busy is False
+
+    # The abandoned response finally announces itself, THEN the next turn is
+    # submitted — that ordering is the one Greptile's scenario is about.
+    harness.arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "resp-abandoned"}}
+    )
+    await _settle()
+    assert harness.arbiter.is_busy is True, (
+        "a live provider response must hold the lane even though we gave up "
+        "on our own ticket for it"
+    )
+
+    dispatched_before = harness.dispatch_count
+    queued = await harness.arbiter.enqueue(source="native-next")
+    await _settle()
+    assert harness.dispatch_count == dispatched_before, (
+        "dispatching under a live provider response is exactly the "
+        "response_already_active collision the arbiter exists to prevent"
+    )
+
+    # Its terminal releases the lane through the ordinary path — no second
+    # escalation, no teardown.
+    harness.arbiter.notify_response_terminal(
+        {"type": "response.done", "response": {"id": "resp-abandoned"}}
+    )
+    await _settle()
+    assert harness.dispatch_count == dispatched_before + 1
+    assert harness.aborted == []
+    harness.arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "resp-next"}}
+    )
+    harness.arbiter.notify_response_terminal(
+        {"type": "response.done", "response": {"id": "resp-next"}}
+    )
+    await asyncio.wait_for(queued.done, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_late_created_with_no_terminal_reopens_on_the_staleness_bound(
+    make_harness, caplog
+):
+    # The other half of the Greptile P1: if that late response's terminal never
+    # arrives either, recovery must NOT require a second escalation. Recording
+    # the id arms the staleness timer (_remember_server_response_id ->
+    # _arm_stale_release_timer), and that timer reopens the lane on its own.
+    harness = make_harness(fail_open=True)
+    await harness.own_a_live_response("resp-abandoned")
+
+    raised = await _stick_a_cancel(harness)
+    assert isinstance(raised, asyncio.TimeoutError)
+    await _settle()
+
+    # Shrink the bound BEFORE the id is recorded: the timer's deadline is
+    # computed from the value in force at that moment. Deliberately nothing is
+    # enqueued while the timer runs — ``enqueue`` ratchets
+    # ``_server_response_max_age`` up to the ticket's own
+    # ``response_done_timeout`` (60s by default), which would push the deadline
+    # back out of unit-test range. That ratchet is by design and is what makes
+    # the staleness release beat a later ticket's own idle-wait timeout: the
+    # timer is armed from the created timestamp, the ticket's deadline only
+    # starts once it reaches the idle wait, so the release always lands first.
+    harness.arbiter._server_response_max_age = 0.05
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger=ARBITER_LOGGER):
+        harness.arbiter.notify_response_created(
+            {"type": "response.created", "response": {"id": "resp-abandoned"}}
+        )
+        await _settle()
+        assert harness.arbiter.is_busy is True
+        assert harness.arbiter._stale_release_handle is not None, (
+            "recording a server response id must arm the staleness timer — "
+            "that timer IS the recovery path when its terminal never comes"
+        )
+
+        # No terminal ever comes for the late response.
+        await asyncio.sleep(0.2)
+        await _settle()
+
+    assert harness.arbiter._server_response_ids == {}
+    assert harness.arbiter.is_busy is False, (
+        "the staleness bound must reopen the lane by itself"
+    )
+    assert harness.aborted == [], "recovery must not cost the connection"
+    assert not any(
+        "failing open" in record.getMessage()
+        or "failing closed" in record.getMessage()
+        for record in caplog.records
+    ), "recovery must not need a second escalation"
+
+    # And the reopened lane really serves the next turn.
+    revived = await harness.arbiter.enqueue(source="native-next")
+    await asyncio.wait_for(revived.sent, timeout=1)
+    harness.arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "resp-next"}}
+    )
+    harness.arbiter.notify_response_terminal(
+        {"type": "response.done", "response": {"id": "resp-next"}}
+    )
+    await asyncio.wait_for(revived.done, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_fail_open_survives_a_stuck_idle_wait_and_serves_the_next_turn(make_harness):
     # The idle-wait site is the most valuable fail-open case: a queued request
     # waited out its whole allowance for a lane held by bookkeeping that never
@@ -445,6 +573,254 @@ async def test_default_policy_kills_the_connection_on_the_same_stuck_idle_wait(m
     dead = await harness.arbiter.enqueue(source="native-after")
     with pytest.raises(ConnectionError):
         await asyncio.wait_for(dead.sent, timeout=1)
+
+
+# ---------------------------------------------------------------------------
+# The host's own response state has to be released too (Codex P2 on PR #2592).
+#
+# ``_is_responding`` lives on the client, is set on response.created, and is
+# cleared only by that response's own response.done or an interruption. The
+# turn fail-open abandons is precisely the one whose terminal never comes — so
+# without a notification the client reports busy forever and the proactive
+# gates hold back exactly the work the kept-alive connection was for.
+#
+# These use a REAL client on purpose: _Harness has no _is_responding at all,
+# which is why every other case in this file is blind to the defect.
+# ---------------------------------------------------------------------------
+
+
+class _ClientRig:
+    """A real OmniRealtimeClient whose arbiter can be driven to escalate."""
+
+    def __init__(self) -> None:
+        from main_logic.omni_realtime_client import OmniRealtimeClient
+
+        self.sent: list[dict] = []
+        self.client = OmniRealtimeClient(
+            "wss://example.invalid/realtime",
+            "test-key",
+            model="free-model",
+            api_type="free",
+        )
+
+        async def _send(event: dict) -> None:
+            self.sent.append(event)
+
+        # Replace the transport write, not the arbiter: the point is to drive
+        # the production arbiter the client built for itself. A non-suspending
+        # stub is required — a stalling one would trip the worker-send guard
+        # above and make the policy stand down instead of releasing.
+        self.client._response_arbiter._send_event = _send
+
+    @property
+    def arbiter(self):
+        return self.client._response_arbiter
+
+    async def drive_to_escalation(self) -> Exception | None:
+        ticket = await self.arbiter.enqueue(source="native")
+        await asyncio.wait_for(ticket.sent, timeout=1)
+        # Go through the transport's own handler so _is_responding is set the
+        # way production sets it, not by assignment.
+        self.client._response_arbiter.notify_response_created(
+            {"type": "response.created", "response": {"id": "resp-1"}}
+        )
+        self.client._current_response_id = "resp-1"
+        self.client._is_responding = True
+        try:
+            await self.arbiter.cancel_current(timeout=0.05)
+        except Exception as exc:  # noqa: BLE001 - the raise itself is asserted
+            return exc
+        return None
+
+
+@pytest.fixture
+async def client_rig(monkeypatch):
+    monkeypatch.setenv(FAIL_OPEN_ENV_VAR, "1")
+    rig = _ClientRig()
+    yield rig
+    await rig.arbiter.shutdown("test teardown")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fail_open_release_clears_the_clients_response_state(client_rig):
+    assert client_rig.arbiter._fail_open is True
+    raised = await client_rig.drive_to_escalation()
+    assert isinstance(raised, asyncio.TimeoutError)
+    await _settle()
+
+    assert client_rig.arbiter.is_busy is False
+    assert client_rig.client._is_responding is False, (
+        "the host must stop reporting a response in progress, or the "
+        "connection fail-open kept alive is useless to proactive chat"
+    )
+    assert client_rig.client.is_active_response() is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_the_lazily_built_arbiter_gets_the_same_notification(client_rig):
+    # _responses.py builds an arbiter on demand when one is missing. That is a
+    # second, independent injection point; wiring only the eager one leaves the
+    # lazy path silently unnotified.
+    del client_rig.client._response_arbiter
+    rebuilt = client_rig.client._ensure_response_arbiter()
+
+    async def _send(event: dict) -> None:
+        client_rig.sent.append(event)
+
+    rebuilt._send_event = _send
+    assert rebuilt._on_stuck_release is not None, (
+        "the lazy construction point must inject the host notification too"
+    )
+
+    raised = await client_rig.drive_to_escalation()
+    assert isinstance(raised, asyncio.TimeoutError)
+    await _settle()
+    assert client_rig.client._is_responding is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_the_release_notification_touches_nothing_else(client_rig):
+    # Both of these would be tempting to reset here and both would be wrong:
+    # _skip_until_next_response is cleared only by response.done, so setting it
+    # would mute the entire next turn; _interrupted gates the AI-activity
+    # timestamps that proactive delivery uses to avoid talking over audio the
+    # provider is still streaming.
+    client_rig.client._skip_until_next_response = False
+    client_rig.client._interrupted = False
+
+    raised = await client_rig.drive_to_escalation()
+    assert isinstance(raised, asyncio.TimeoutError)
+    await _settle()
+
+    assert client_rig.client._is_responding is False
+    assert client_rig.client._skip_until_next_response is False, (
+        "setting this would silence the next turn's text and audio entirely"
+    )
+    assert client_rig.client._interrupted is False, (
+        "setting this would suppress the AI-activity timestamps proactive "
+        "delivery depends on"
+    )
+    assert client_rig.client._current_response_id == "resp-1", (
+        "response identity is kept for terminal attribution, same as "
+        "handle_interruption keeps it"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fail-open declines to apply while the queue consumer is parked inside a
+# transport write (Codex P2 on PR #2592). Fail-open's whole premise is "the
+# transport is still usable"; a write that never returns IS that premise being
+# falsified. Nothing the escalation does to the arbiter's own state unwinds
+# that await, and _run is the only consumer — so keeping the connection would
+# wedge every later request while reporting the lane recovered. Tearing the
+# transport down is what unblocks the write, so the hatch stands down.
+# ---------------------------------------------------------------------------
+
+
+class _StallingHarness(_Harness):
+    """Harness whose response.create write parks until the test releases it."""
+
+    def __init__(self, *, fail_open: bool) -> None:
+        super().__init__(fail_open=fail_open)
+        self.gate = asyncio.Event()
+
+    async def _send(self, event: dict) -> None:
+        self.sent.append(event)
+        if event.get("type") == "response.create":
+            await self.gate.wait()
+
+
+@pytest.fixture
+async def make_stalling_harness():
+    built: list[_StallingHarness] = []
+
+    def _factory(*, fail_open: bool) -> _StallingHarness:
+        harness = _StallingHarness(fail_open=fail_open)
+        built.append(harness)
+        return harness
+
+    yield _factory
+
+    for harness in built:
+        # Open the gate BEFORE shutdown: the worker is parked inside the write,
+        # and shutdown awaits it. Reaping without releasing reproduces the very
+        # hang this test is about, in the teardown.
+        harness.gate.set()
+        await harness.arbiter.shutdown("test teardown")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_stalled_worker_send_makes_fail_open_stand_down(
+    make_stalling_harness, caplog
+):
+    harness = make_stalling_harness(fail_open=True)
+    stuck = await harness.arbiter.enqueue(source="native")
+    await _settle()
+    # The worker is now parked inside the response.create write.
+    assert harness.types == ["response.create"]
+    assert not stuck.sent.done()
+    assert harness.arbiter._worker_send_in_flight is True
+
+    with caplog.at_level(logging.WARNING, logger=ARBITER_LOGGER):
+        raised = await _stick_a_cancel(harness)
+
+    assert isinstance(raised, asyncio.TimeoutError)
+    # (a) it tore the transport down after all...
+    assert harness.aborted == [
+        "response cancellation terminal event timed out"
+    ], "fail-open must decline while the only consumer is stuck in a write"
+    # (b) ...and latched the connection shut, which is what unblocks the write
+    assert harness.arbiter._connection_available is False
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("failing closed" in message for message in messages)
+    assert any("worker_send_in_flight=True" in message for message in messages), (
+        "the log must say WHY an opted-in session failed closed anyway, or the "
+        "field cannot tell this apart from a plain fail-closed session"
+    )
+
+    # (c) later work fails fast instead of queueing behind a wedged consumer
+    later = await harness.arbiter.enqueue(source="native-after")
+    with pytest.raises(ConnectionError):
+        await asyncio.wait_for(later.sent, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_the_stalled_send_outcome_is_identical_under_both_policies(
+    make_stalling_harness,
+):
+    # The dual: having stood down, fail-open converges on exactly the default
+    # terminal state. That equivalence is the argument that the stand-down can
+    # never be worse than what ships today.
+    outcomes = {}
+    for fail_open in (False, True):
+        harness = make_stalling_harness(fail_open=fail_open)
+        stuck = await harness.arbiter.enqueue(source="native")
+        await _settle()
+        assert not stuck.sent.done()
+
+        raised = await _stick_a_cancel(harness)
+        later = await harness.arbiter.enqueue(source="native-after")
+        later_error = None
+        try:
+            await asyncio.wait_for(later.sent, timeout=1)
+        except Exception as exc:  # noqa: BLE001 - the type is the assertion
+            later_error = type(exc).__name__
+
+        outcomes[fail_open] = (
+            type(raised).__name__,
+            tuple(harness.aborted),
+            harness.arbiter._connection_available,
+            later_error,
+        )
+
+    assert outcomes[True] == outcomes[False], (
+        f"stalled-send terminal state must not depend on the policy: {outcomes}"
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -1,0 +1,466 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The arbiter's escalation policy: fail-closed by default, fail-open opt-in.
+
+When a response lifecycle cannot reach a terminal state, the arbiter escalates
+through one chokepoint. Historically that always tore the realtime WebSocket
+down — correct when the bookkeeping is untrustworthy, but a provider-side
+event-timing quirk in the field would present as repeated
+disconnect-and-rebuild with no way to reach the affected users except a hotfix
+build. Issue #2583 adds an opt-in escape hatch: drop only the stuck turn.
+
+Two halves are pinned here, and the second is the one that earns its keep:
+
+1. The DEFAULT is unchanged. Nothing about this PR may alter what today's
+   users get, so the fail-closed assertions are repeated against an explicitly
+   default-constructed arbiter (``test_realtime_arbiter_native_path.py`` covers
+   the same ground through the real client).
+2. Fail-open is genuinely narrower than a connection loss. It must drop the
+   stuck turn AND keep four things intact: the connection's usability, an
+   external-ASR dispatch pause, the queued work behind the stuck turn, and the
+   connection generation guarding in-flight cancel sends. Getting any of those
+   wrong turns a benign escape hatch into a worse bug than the one it dodges —
+   silently dead dispatch, or a proactive turn stealing the user's voice turn.
+"""
+
+import asyncio
+import logging
+
+import pytest
+
+from main_logic.omni_realtime_client._response_arbiter import RealtimeResponseArbiter
+from main_logic.omni_realtime_client._shared import (
+    response_arbiter_fail_open_enabled,
+)
+
+ARBITER_LOGGER = "main_logic.omni_realtime_client._response_arbiter"
+FAIL_OPEN_ENV_VAR = "NEKO_REALTIME_ARBITER_FAIL_OPEN"
+
+
+async def _settle(times: int = 50) -> None:
+    for _ in range(times):
+        await asyncio.sleep(0)
+
+
+class _Harness:
+    """Records what reached the wire and whether the transport was aborted."""
+
+    def __init__(self, *, fail_open: bool) -> None:
+        self.sent: list[dict] = []
+        self.aborted: list[str] = []
+        self.arbiter = RealtimeResponseArbiter(
+            self._send,
+            abort_transport=self._abort,
+            fail_open=fail_open,
+        )
+
+    async def _send(self, event: dict) -> None:
+        self.sent.append(event)
+
+    async def _abort(self, reason: str) -> None:
+        self.aborted.append(reason)
+
+    @property
+    def types(self) -> list[str]:
+        return [event.get("type") for event in self.sent]
+
+    @property
+    def dispatch_count(self) -> int:
+        """How many response.create events reached the wire.
+
+        Asserted instead of the whole event list: ``cancel_current`` also puts
+        a legitimate ``response.cancel`` on the wire, and a test about
+        dispatch permission should not be coupled to that.
+        """
+
+        return self.types.count("response.create")
+
+    async def own_a_live_response(self, response_id: str = "resp-1"):
+        """Dispatch one request and let it become the live lane owner."""
+
+        ticket = await self.arbiter.enqueue(source="native")
+        await asyncio.wait_for(ticket.sent, timeout=1)
+        self.arbiter.notify_response_created(
+            {"type": "response.created", "response": {"id": response_id}}
+        )
+        return ticket
+
+
+@pytest.fixture
+async def make_harness():
+    """Build harnesses and guarantee their worker tasks are reaped.
+
+    Under fail-open ``_connection_available`` deliberately stays True, so the
+    queue consumer keeps running after the assertions are done. Left alone it
+    outlives the test and pollutes whatever runs next in the same session; the
+    explicit ``shutdown`` here is what keeps this file self-contained.
+    """
+
+    built: list[_Harness] = []
+
+    def _factory(*, fail_open: bool) -> _Harness:
+        harness = _Harness(fail_open=fail_open)
+        built.append(harness)
+        return harness
+
+    yield _factory
+
+    for harness in built:
+        await harness.arbiter.shutdown("test teardown")
+
+
+async def _stick_a_cancel(harness: _Harness) -> BaseException | None:
+    """Cancel the live response whose terminal never arrives; return the raise.
+
+    This drives the ``cancel_current`` escalation site, which is the one a
+    barge-in reaches in production.
+    """
+
+    try:
+        await harness.arbiter.cancel_current(timeout=0.05)
+    except BaseException as exc:  # noqa: BLE001 - the raise itself is asserted
+        return exc
+    return None
+
+
+# ---------------------------------------------------------------------------
+# The environment-variable reader. Off unless explicitly turned on: a typo or
+# an empty value must not silently change the shipped policy.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_fail_open_is_off_unless_explicitly_enabled(monkeypatch):
+    monkeypatch.delenv(FAIL_OPEN_ENV_VAR, raising=False)
+    assert response_arbiter_fail_open_enabled() is False
+
+    for truthy in ("1", "true", "TRUE", " yes ", "on", "On"):
+        monkeypatch.setenv(FAIL_OPEN_ENV_VAR, truthy)
+        assert response_arbiter_fail_open_enabled() is True, truthy
+
+    # Anything else keeps the shipped default, including the words a user might
+    # reasonably type to turn it OFF.
+    for falsy in ("", "   ", "0", "false", "no", "off", "maybe", "2"):
+        monkeypatch.setenv(FAIL_OPEN_ENV_VAR, falsy)
+        assert response_arbiter_fail_open_enabled() is False, falsy
+
+
+@pytest.mark.unit
+def test_the_arbiter_defaults_to_fail_closed_without_being_told():
+    # The constructor default is the shipped policy; a construction site that
+    # forgets to pass the flag must not accidentally opt users in.
+    arbiter = RealtimeResponseArbiter(lambda event: asyncio.sleep(0))
+    assert arbiter._fail_open is False
+
+
+@pytest.mark.unit
+def test_client_construction_honours_the_environment_switch(monkeypatch):
+    # The whole escape hatch is worthless if the wiring from variable to
+    # arbiter is missing: the reader could be perfect and every policy branch
+    # correct while real clients still get the default. Build the actual client
+    # both ways and read the policy off the arbiter it constructed.
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    def _build() -> OmniRealtimeClient:
+        return OmniRealtimeClient(
+            "wss://example.invalid/realtime",
+            "test-key",
+            model="free-model",
+            api_type="free",
+        )
+
+    monkeypatch.delenv(FAIL_OPEN_ENV_VAR, raising=False)
+    assert _build()._response_arbiter._fail_open is False
+
+    monkeypatch.setenv(FAIL_OPEN_ENV_VAR, "1")
+    assert _build()._response_arbiter._fail_open is True, (
+        "the construction site must pass the environment policy through, or "
+        "the escape hatch cannot be reached by any real session"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Half 1: the default policy is untouched.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_default_policy_still_tears_the_transport_down(caplog, make_harness):
+    harness = make_harness(fail_open=False)
+    await harness.own_a_live_response()
+
+    with caplog.at_level(logging.WARNING, logger=ARBITER_LOGGER):
+        raised = await _stick_a_cancel(harness)
+
+    assert isinstance(raised, asyncio.TimeoutError)
+    assert harness.aborted == ["response cancellation terminal event timed out"]
+    messages = [record.getMessage() for record in caplog.records]
+    # The documented grep target for attributing a field disconnect must keep
+    # its exact wording (issue #2561 / PR #2577).
+    assert any("response arbiter failing closed" in message for message in messages)
+    assert not any("failing open" in message for message in messages)
+
+    # And the connection is latched shut: later work fails fast rather than
+    # queueing against a socket that is gone.
+    dead = await harness.arbiter.enqueue(source="native-after")
+    with pytest.raises(ConnectionError):
+        await asyncio.wait_for(dead.sent, timeout=1)
+
+
+# ---------------------------------------------------------------------------
+# Half 2: fail-open drops the turn and nothing else.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fail_open_keeps_the_transport_and_reopens_the_lane(caplog, make_harness):
+    harness = make_harness(fail_open=True)
+    stuck = await harness.own_a_live_response()
+
+    with caplog.at_level(logging.WARNING, logger=ARBITER_LOGGER):
+        raised = await _stick_a_cancel(harness)
+
+    # The caller still learns the cancellation did not settle...
+    assert isinstance(raised, asyncio.TimeoutError)
+    # ...but nobody hung up.
+    assert harness.aborted == []
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(
+        "response arbiter failing open, transport kept" in message
+        for message in messages
+    ), "an escape-hatch escalation must still be attributable in the log"
+    assert not any("failing closed" in message for message in messages), (
+        "fail-open must not emit the disconnect grep target — that string is "
+        "what tells an operator the arbiter hung up on the user"
+    )
+
+    # The stuck turn's caller is not left waiting forever.
+    await _settle()
+    assert stuck.done.done(), "the stuck ticket must be terminated, not orphaned"
+    with pytest.raises(Exception):
+        stuck.done.result()
+
+    # The lane is usable again on the same connection.
+    assert harness.arbiter.is_busy is False
+    revived = await harness.arbiter.enqueue(source="native-after")
+    await asyncio.wait_for(revived.sent, timeout=1)
+    assert harness.types[-1] == "response.create"
+    harness.arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "resp-2"}}
+    )
+    harness.arbiter.notify_response_terminal(
+        {"type": "response.done", "response": {"id": "resp-2"}}
+    )
+    await asyncio.wait_for(revived.done, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fail_open_keeps_queued_work_instead_of_failing_it(make_harness):
+    # A connection loss fails the whole queue because nothing can be sent. Here
+    # the connection is fine, so work queued behind the stuck turn is still
+    # viable and must simply dispatch once the lane reopens. Failing it would
+    # silently drop a user's next turn.
+    harness = make_harness(fail_open=True)
+    await harness.own_a_live_response()
+    queued = await harness.arbiter.enqueue(source="native-queued")
+    await _settle()
+    assert harness.dispatch_count == 1, "queued work waits behind the owner"
+
+    raised = await _stick_a_cancel(harness)
+    assert isinstance(raised, asyncio.TimeoutError)
+    await _settle()
+
+    assert not queued.sent.cancelled()
+    assert queued.sent.done() and queued.sent.exception() is None, (
+        "queued work must survive a fail-open escalation and dispatch"
+    )
+    assert harness.dispatch_count == 2
+    harness.arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "resp-q"}}
+    )
+    harness.arbiter.notify_response_terminal(
+        {"type": "response.done", "response": {"id": "resp-q"}}
+    )
+    await asyncio.wait_for(queued.done, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fail_open_does_not_release_an_external_turn_pause(make_harness):
+    # pause_dispatch() is how an external-ASR turn holds queued proactive work
+    # back until the user's own text is in. _mark_connection_lost force-sets
+    # the dispatch gate (safe when the socket is dead, since nothing can be
+    # sent anyway); on a live connection the same move would let proactive
+    # chat win the race against the user's voice turn.
+    harness = make_harness(fail_open=True)
+    await harness.own_a_live_response()
+    harness.arbiter.pause_dispatch()
+    proactive = await harness.arbiter.enqueue(source="proactive", priority=20)
+
+    raised = await _stick_a_cancel(harness)
+    assert isinstance(raised, asyncio.TimeoutError)
+    await _settle()
+
+    assert harness.dispatch_count == 1, (
+        "the paused proactive request must NOT dispatch: the user's external "
+        "turn still owns dispatch permission"
+    )
+    assert not proactive.sent.done()
+
+    # Releasing the pause the normal way still works — the gate was untouched,
+    # not broken.
+    harness.arbiter.resume_dispatch()
+    await asyncio.wait_for(proactive.sent, timeout=1)
+    harness.arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "resp-p"}}
+    )
+    harness.arbiter.notify_response_terminal(
+        {"type": "response.done", "response": {"id": "resp-p"}}
+    )
+    await asyncio.wait_for(proactive.done, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fail_open_does_not_bump_the_connection_generation(make_harness):
+    # The generation counter exists so a cancel-send that outlives its
+    # connection cannot fire into the replacement. Fail-open has no
+    # replacement connection, so bumping it would cancel sends that are still
+    # correctly aimed at the live one.
+    harness = make_harness(fail_open=True)
+    await harness.own_a_live_response()
+    generation_before = harness.arbiter._connection_generation
+
+    raised = await _stick_a_cancel(harness)
+    assert isinstance(raised, asyncio.TimeoutError)
+
+    assert harness.arbiter._connection_generation == generation_before
+    assert harness.arbiter._connection_available is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fail_open_clears_the_bookkeeping_it_gave_up_on(make_harness):
+    # The escalation says "I no longer expect this response's terminal". If the
+    # remembered server response ids survived, _release_lane_if_clear would
+    # keep the lane shut waiting for exactly that terminal — the wedge the
+    # caller escalated about, now without even a disconnect to end it.
+    harness = make_harness(fail_open=True)
+    await harness.own_a_live_response("resp-live")
+    # A second, server-initiated response is also being tracked.
+    harness.arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "srv-1"}}
+    )
+    assert harness.arbiter._server_response_ids
+
+    raised = await _stick_a_cancel(harness)
+    assert isinstance(raised, asyncio.TimeoutError)
+    await _settle()
+
+    assert harness.arbiter._server_response_ids == {}
+    assert harness.arbiter._server_response_active is False
+    assert harness.arbiter._server_vad_response_pending is False
+    assert harness.arbiter._server_vad_pending_handle is None
+    assert harness.arbiter.is_busy is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fail_open_survives_a_stuck_idle_wait_and_serves_the_next_turn(make_harness):
+    # The idle-wait site is the most valuable fail-open case: a queued request
+    # waited out its whole allowance for a lane held by bookkeeping that never
+    # resolved. Under the default that kills the connection; here it costs one
+    # turn.
+    harness = make_harness(fail_open=True)
+    # A live server response nobody owns holds the lane shut.
+    harness.arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "srv-wedged"}}
+    )
+
+    starved = await harness.arbiter.enqueue(
+        source="native-starved",
+        response_done_timeout=0.05,
+    )
+    await asyncio.sleep(0.2)
+    await _settle()
+
+    assert harness.aborted == [], "a wedged lane must not cost the connection"
+    assert starved.sent.done() and starved.sent.exception() is not None, (
+        "the starved request itself is the turn that gets dropped"
+    )
+
+    # The next request goes through on the same connection.
+    revived = await harness.arbiter.enqueue(source="native-after")
+    await asyncio.wait_for(revived.sent, timeout=1)
+    assert harness.types == ["response.create"]
+    harness.arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "resp-2"}}
+    )
+    harness.arbiter.notify_response_terminal(
+        {"type": "response.done", "response": {"id": "resp-2"}}
+    )
+    await asyncio.wait_for(revived.done, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_default_policy_kills_the_connection_on_the_same_stuck_idle_wait(make_harness):
+    # The dual of the test above, so the pair proves the policy switch is what
+    # changes the outcome rather than the scenario being unreachable.
+    harness = make_harness(fail_open=False)
+    harness.arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "srv-wedged"}}
+    )
+
+    starved = await harness.arbiter.enqueue(
+        source="native-starved",
+        response_done_timeout=0.05,
+    )
+    await asyncio.sleep(0.2)
+    await _settle()
+
+    assert harness.aborted == ["realtime response idle wait timed out"]
+    assert starved.sent.done() and starved.sent.exception() is not None
+    dead = await harness.arbiter.enqueue(source="native-after")
+    with pytest.raises(ConnectionError):
+        await asyncio.wait_for(dead.sent, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_healthy_turn_escalates_under_neither_policy(caplog, make_harness):
+    # Neither policy may fire on a turn that simply works. Parameterised over
+    # both so a future change to one branch cannot quietly start escalating.
+    for fail_open in (False, True):
+        harness = make_harness(fail_open=fail_open)
+        caplog.clear()
+        with caplog.at_level(logging.WARNING, logger=ARBITER_LOGGER):
+            ticket = await harness.own_a_live_response()
+            harness.arbiter.notify_response_terminal(
+                {"type": "response.done", "response": {"id": "resp-1"}}
+            )
+            await asyncio.wait_for(ticket.done, timeout=1)
+            await harness.arbiter.wait_until_idle(timeout=1)
+            await _settle()
+
+        assert harness.aborted == [], fail_open
+        assert harness.types == ["response.create"], fail_open
+        assert not any(
+            "failing closed" in record.getMessage()
+            or "failing open" in record.getMessage()
+            for record in caplog.records
+        ), fail_open

--- a/tests/unit/test_realtime_arbiter_native_path.py
+++ b/tests/unit/test_realtime_arbiter_native_path.py
@@ -979,34 +979,41 @@ async def test_fail_close_logs_initiator_reason_and_lane_state(caplog):
         aborted.append(reason)
 
     arbiter = RealtimeResponseArbiter(_send, abort_transport=_abort)
-    ticket = await arbiter.enqueue(source="native")
-    await asyncio.wait_for(ticket.sent, timeout=1)
-    arbiter.notify_response_created(
-        {"type": "response.created", "response": {"id": "resp-1"}}
-    )
+    # try/finally, not a bare sequence: failing closed is what lets the queue
+    # consumer exit on its own here, so any regression that stops it from
+    # firing leaves the worker running and the test hanging on teardown
+    # instead of reporting the failure it just found.
+    try:
+        ticket = await arbiter.enqueue(source="native")
+        await asyncio.wait_for(ticket.sent, timeout=1)
+        arbiter.notify_response_created(
+            {"type": "response.created", "response": {"id": "resp-1"}}
+        )
 
-    with caplog.at_level(
-        logging.WARNING, logger="main_logic.omni_realtime_client._response_arbiter"
-    ):
-        # No terminal ever arrives for the cancelled response; cancel_current
-        # fails closed and re-raises the timeout to its caller.
-        with pytest.raises(asyncio.TimeoutError):
-            await arbiter.cancel_current(timeout=0.05)
+        with caplog.at_level(
+            logging.WARNING, logger="main_logic.omni_realtime_client._response_arbiter"
+        ):
+            # No terminal ever arrives for the cancelled response; cancel_current
+            # fails closed and re-raises the timeout to its caller.
+            with pytest.raises(asyncio.TimeoutError):
+                await arbiter.cancel_current(timeout=0.05)
 
-    assert aborted, "the cancel-terminal timeout must fail closed"
-    fail_close_logs = [
-        record.getMessage()
-        for record in caplog.records
-        if "failing closed" in record.getMessage()
-    ]
-    assert fail_close_logs, (
-        "the fail-close chokepoint must log BEFORE tearing the transport, or "
-        "a field disconnect cannot be attributed to the arbiter at all"
-    )
-    message = fail_close_logs[0]
-    assert "response cancellation terminal event timed out" in message
-    assert "queue_depth" in message
-    assert "owner=native" in message
+        assert aborted, "the cancel-terminal timeout must fail closed"
+        fail_close_logs = [
+            record.getMessage()
+            for record in caplog.records
+            if "failing closed" in record.getMessage()
+        ]
+        assert fail_close_logs, (
+            "the fail-close chokepoint must log BEFORE tearing the transport, or "
+            "a field disconnect cannot be attributed to the arbiter at all"
+        )
+        message = fail_close_logs[0]
+        assert "response cancellation terminal event timed out" in message
+        assert "queue_depth" in message
+        assert "owner=native" in message
+    finally:
+        await arbiter.shutdown("test teardown")
 
 
 @pytest.mark.unit
@@ -1023,24 +1030,30 @@ async def test_cancel_whose_terminal_arrives_in_time_never_fails_closed(caplog):
         aborted.append(reason)
 
     arbiter = RealtimeResponseArbiter(_send, abort_transport=_abort)
-    ticket = await arbiter.enqueue(source="native")
-    await asyncio.wait_for(ticket.sent, timeout=1)
-    arbiter.notify_response_created(
-        {"type": "response.created", "response": {"id": "resp-1"}}
-    )
-
-    with caplog.at_level(
-        logging.WARNING, logger="main_logic.omni_realtime_client._response_arbiter"
-    ):
-        cancel_task = asyncio.create_task(arbiter.cancel_current(timeout=1))
-        await _settle()
-        arbiter.notify_response_terminal(
-            {"type": "response.cancelled", "response": {"id": "resp-1"}}
+    try:
+        ticket = await arbiter.enqueue(source="native")
+        await asyncio.wait_for(ticket.sent, timeout=1)
+        arbiter.notify_response_created(
+            {"type": "response.created", "response": {"id": "resp-1"}}
         )
-        await asyncio.wait_for(cancel_task, timeout=1)
 
-    assert aborted == []
-    assert not any(
-        "failing closed" in record.getMessage() for record in caplog.records
-    )
-    await arbiter.wait_until_idle(timeout=1)
+        with caplog.at_level(
+            logging.WARNING, logger="main_logic.omni_realtime_client._response_arbiter"
+        ):
+            cancel_task = asyncio.create_task(arbiter.cancel_current(timeout=1))
+            await _settle()
+            arbiter.notify_response_terminal(
+                {"type": "response.cancelled", "response": {"id": "resp-1"}}
+            )
+            await asyncio.wait_for(cancel_task, timeout=1)
+
+        assert aborted == []
+        assert not any(
+            "failing closed" in record.getMessage() for record in caplog.records
+        )
+        await arbiter.wait_until_idle(timeout=1)
+    finally:
+        # This one never escalates, so nothing ever clears
+        # ``_connection_available`` for it — the worker outlives the test
+        # unless it is reaped here.
+        await arbiter.shutdown("test teardown")

--- a/tests/unit/test_realtime_arbiter_native_path.py
+++ b/tests/unit/test_realtime_arbiter_native_path.py
@@ -175,11 +175,11 @@ async def test_native_turns_serialize_in_submission_order():
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_a_working_native_turn_never_aborts_the_transport():
-    # _fail_closed() physically closes the websocket and latches
-    # _fatal_error_occurred. Before this PR no client-side timer could kill a
-    # realtime socket at all, so a spurious fire is a new and total failure
-    # mode for every native user. A turn that completes normally must not
-    # arm it.
+    # Under the default policy _fail_stuck_lifecycle() physically closes the
+    # websocket and latches _fatal_error_occurred. Before this PR no
+    # client-side timer could kill a realtime socket at all, so a spurious
+    # fire is a new and total failure mode for every native user. A turn that
+    # completes normally must not arm it.
     aborted: list[str] = []
 
     async def _send(event: dict) -> None:
@@ -958,11 +958,12 @@ async def test_queued_proactive_text_never_preempts_a_live_response():
 
 
 # ---------------------------------------------------------------------------
-# T7 — the fail-close chokepoint. All six _fail_closed call sites tear the
-# transport down through one function; that function now logs the initiator,
-# the reason and the lane state. Issue #2561 is the motivating incident: an
+# T7 — the escalation chokepoint. All six escalation sites funnel through
+# _fail_stuck_lifecycle, which logs the initiator, the reason and the lane
+# state before acting. Issue #2561 is the motivating incident: an
 # unattributable disconnect had to be ruled out via build provenance because
-# exactly this log line did not exist.
+# exactly this log line did not exist. The policy the chokepoint then applies
+# is covered by test_realtime_arbiter_fail_open.py (issue #2583).
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/test_realtime_arbiter_native_path.py
+++ b/tests/unit/test_realtime_arbiter_native_path.py
@@ -396,6 +396,41 @@ async def test_a_native_create_response_runs_through_the_arbiter_end_to_end():
     await asyncio.wait_for(receive_loop, timeout=1)
 
 
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_terminal_resets_the_per_turn_output_state():
+    # PR #2592 extracted this reset so the abandoned-turn path could share it,
+    # and a mutation showed the terminal side had no coverage at all — deleting
+    # its call turned nothing red. That makes the extraction unverifiable from
+    # the terminal side, which is the side every user is on. Drive a real turn
+    # to response.done through the receive loop and assert the fields it owns.
+    client = _native_client()
+    socket = _RecordingSocket()
+    client.ws = socket
+    receive_loop = asyncio.create_task(client.handle_messages())
+
+    client._audio_delta_count = 5
+    client._output_transcript_buffer = "leftover"
+    client._print_input_transcript = True
+    client._image_sent_this_turn = True
+
+    socket.feed({"type": "response.created", "response": {"id": "resp-1"}})
+    await _settle()
+    socket.feed({"type": "response.done", "response": {"id": "resp-1"}})
+    await _settle()
+
+    assert client._audio_delta_count == 0
+    assert client._output_transcript_buffer == ""
+    assert client._print_input_transcript is False
+    assert client._image_sent_this_turn is False, (
+        "a stale image flag makes stream_image withhold the next turn's "
+        "visual context for its whole duration"
+    )
+
+    socket.finish()
+    await asyncio.wait_for(receive_loop, timeout=1)
+
+
 def _wired_client(api_type: str = "qwen", model: str = "qwen-omni-turbo-realtime"):
     """A native client attached to a recording socket, ready for its real
     receive loop. The caller owns creating/joining the ``handle_messages``


### PR DESCRIPTION
## 这个 PR 已缩范围

原本它是 #2583 的 fail-open 逃生阀。七轮自动评审在那条 release 路径上累计发现 20+ 条 P2，其中两条由前一轮的修复自己引入，还有一条是我把错误契约写进了测试。

结构性结论：**release 路径变成了「轮次终结」的第二套实现**，而轮次终结不是一个函数，是散布在 arbiter 状态、transport per-turn 状态、宿主回调、身份归属、派发顺序上的一组不变量。逐轮打补丁没有收敛迹象。

经维护者拍板：**fail-open 从本 PR 撤出，按单一实现（`_finalize_turn(reason, identity)`）在新 PR 重做**；本 PR 只保留那期间唯一独立成立、且行为中性的部分。

## 现在改了什么

把 `response.done` 里那段 per-turn 清理提成 `_reset_per_turn_output_state()`，从原处调用。**同一段代码、同一顺序、同样的条件判断 —— 零行为变化。**

值得命名的理由是这份清单很容易被少抄一项，而每一项漏掉都会串到下一轮：

- `_image_sent_this_turn` 残留 → `stream_image` 把**下一整轮**的视觉上下文压住，那轮在答一个它看不见的屏幕
- `_output_transcript_buffer` 残留 → 被冲到错误的轮次上
- `_audio_delta_count` 残留 → 「这轮到底出没出声」的判断失真

## 顺带补上它从未有过的覆盖

⚠️ 这段清理**此前零测试** —— 整块删掉，全套测试没有一条变红。对一次抽取来说这是最差的起点：搬错了没人会知道。

新增 `test_a_terminal_resets_the_per_turn_output_state`（真 client + 真 receive loop 驱动一整轮到 `response.done`），5 条变异各自打红：删掉调用、以及分别删掉 helper 清的四个字段。

⚠️ 该用例第一版有一处**空断言**：我在喂 `response.created` **之前**设脏值，而 created 处理器自己会清 `_output_transcript_buffer` —— 于是「buffer 被清空」这条断言不需要被测代码做任何事就成立。变异 M3 抓到了，已把脏值挪到 created 之后。

## 回归报告

- **改动面**：2 文件、+73/-17。生产侧是纯移动，无行为变化；测试侧新增 1 条用例。
- **必要性**：抽取本身为后续的 `_finalize_turn` 铺路（那条路径需要同一份清理）；补测试是因为这段代码此前完全裸奔。
- **改前/改后**：行为逐字节相同。`response.done` 走到同一组赋值，只是经由一次函数调用。
- **潜在回归**：抽取可能少搬/错序 —— 由 5 条变异逐字段挡住。`_supports_native_image` 的 if/elif 分支结构原样保留（elif 里那两行只在非原生图像且帧已消费/缺失时执行，顺序不能改）。相关既有测试全绿：508 passed / 4 skipped。
- **不在范围**：fail-open 开关、三个 stand-down 条件、宿主收尾回调、`NEKO_REALTIME_ARBITER_FAIL_OPEN` 环境变量与其文档 —— 全部撤出，改由新 PR 按 `_finalize_turn` 重做。

## 相关

- #2583（保持 open，指向即将开的重做 PR）
- #2594 / #2595（七轮评审挖出的既有缺陷，与本 PR 正交）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
