### PR TITLE
fix(lock): idle_maintenance_state.json 的 10 个写点收口到唯一加锁入口（#2528 第 4 步）

### DIFF
--- a/app/memory_server/__init__.py
+++ b/app/memory_server/__init__.py
@@ -47,7 +47,8 @@ Note for tests: ``monkeypatch.setattr`` must target the submodule that
 ``gates._ais_powerful_memory_enabled``), not this package facade --
 re-exports are snapshots, they do not rebind submodule globals. Rebindable
 submodule state (the ``runtime`` component singletons and init flags,
-``gates._maint_state`` / ``gates._last_activity_time``,
+``gates._maint_state`` (read it via ``gates._maint_view``) /
+``gates._last_activity_time``,
 ``outbox_infra._replay_semaphore``, ``evidence_loops._RECHECK_RR_CURSOR``,
 ``runtime.enable_shutdown``) is deliberately NOT re-exported: a facade
 snapshot would silently go stale after the first in-place rebind.
@@ -93,10 +94,11 @@ from .gates import (  # noqa: F401
     _ais_powerful_memory_enabled,
     _ais_review_enabled,
     _aload_maint_state,
-    _asave_maint_state,
+    _amutate_maint_state,
     _is_idle,
     _is_review_clean,
     _maint_state_path,
+    _maint_view,
     _touch_activity,
 )
 from .rows import (  # noqa: F401

--- a/app/memory_server/evidence_loops.py
+++ b/app/memory_server/evidence_loops.py
@@ -417,7 +417,7 @@ async def _periodic_idle_maintenance_loop():
        by the recent_memory_auto_review switch or REVIEW_SKIP_HISTORY_LEN: persona corrections
        don't read recent history; they are an independent contradiction-resolution pipeline and
        shouldn't be blanket-disabled by the review switch.
-    3. Memory tidy-up review — skipped when review_clean; subject to the REVIEW_MIN_INTERVAL
+    3. Memory tidy-up review — subject to the REVIEW_MIN_INTERVAL
        minimum interval; skipped when history < REVIEW_SKIP_HISTORY_LEN or review_enabled is off.
     """
     await asyncio.sleep(_INITIAL_DELAY_IDLE_MAINT)

--- a/app/memory_server/gates.py
+++ b/app/memory_server/gates.py
@@ -209,7 +209,12 @@ async def _aload_maint_state() -> None:
             await asyncio.to_thread(_rebind_maint_state_locked, data)
             logger.debug(f"[IdleMaint] 已加载维护状态: {len(data)} 个角色")
             return
-    except (json.JSONDecodeError, OSError) as e:
+    except (json.JSONDecodeError, UnicodeDecodeError, OSError) as e:
+        # UnicodeDecodeError 必须单列：read_json 是 open(encoding='utf-8') + json.load，
+        # 文件被外部工具按 GBK/UTF-16 写过、或断电写了半截多字节序列时抛的是它，
+        # 而它是 ValueError 的子类——既不是 JSONDecodeError 也不是 OSError。漏掉就会
+        # 从这里冒到唯一的调用点 ensure_memory_server_runtime_initialized（那次 await
+        # 没有 try），把整个 memory_server 的 runtime 初始化打断。
         logger.warning(f"[IdleMaint] 维护状态文件加载失败: {e}")
     await asyncio.to_thread(_rebind_maint_state_locked, {})
 

--- a/app/memory_server/gates.py
+++ b/app/memory_server/gates.py
@@ -16,26 +16,41 @@
 """Cross-loop gating state for the memory_server package.
 
 Dependency leaf shared by every background loop and every session endpoint:
-  - persisted maintenance state (``_maint_state`` + load/save/clear helpers)
+  - persisted maintenance state (``_maint_view`` to read,
+    ``_amutate_maint_state`` to write, ``_aload_maint_state`` at startup)
   - hot-reloadable feature switches (``_ais_review_enabled`` /
     ``_ais_powerful_memory_enabled``)
   - idle detection (``_touch_activity`` / ``_is_idle``) and the loop
     scheduling constants (poll intervals, staggered initial delays)
 
+``idle_maintenance_state.json`` is the one process-wide (not per-character)
+file this package owns, and roughly ten call sites across request handlers and
+background tasks update it. ``_amutate_maint_state`` is the ONLY write entry
+point: it runs read → mutate → persist as a single critical section. Reads go
+through ``_maint_view``, which hands back a read-only snapshot, so ``_maint_state``
+itself must not be named outside this module (there is a guard test for that) —
+see the block comment above the lock for the full contract.
+
 ``_maint_state`` and ``_last_activity_time`` are REBOUND in place (not just
-mutated), so consumers must access them as ``gates._maint_state`` /
-``gates._last_activity_time`` module attributes — a from-import snapshot goes
-stale after the first ``_aload_maint_state`` / ``_touch_activity`` call.
-For the same reason tests must monkeypatch these names (and the switch
-helpers) on THIS module, not on the package facade.
+mutated), so in-module code must access them as module globals rather than via a
+from-import snapshot, which goes stale after the first ``_aload_maint_state`` /
+``_touch_activity`` call. For the same reason tests must monkeypatch these names
+(and the switch helpers) on THIS module, not on the package facade.
 """
 
 import asyncio
 import json
 import os
+import threading
 from datetime import datetime
+from types import MappingProxyType
+from typing import Any, Callable, Mapping
 
 from utils.config_manager import get_config_manager
+# 模块级 import（本文件其他 file_utils 用法是函数内 import）：atomic_write_json 会在
+# _maint_state_lock 临界区内被调，函数内 import 会把一次 import machinery 关进临界区。
+# utils/file_utils 只依赖标准库，且 utils.config_manager 已经在模块级导入它，没有环。
+from utils.file_utils import atomic_write_json
 
 from ._shared import logger
 
@@ -69,51 +84,158 @@ _INITIAL_DELAY_REFLECTION_SYNTHESIS = 200  # REFLECTION_SYNTHESIS 首次（错�
 # ── 持久化维护状态（跨重启保留 review_clean 标记） ──────────────────
 _maint_state: dict[str, dict] = {}   # {角色名: {"review_clean": bool, "last_review_ts": str}}
 
+# ── 维护状态的唯一加锁写入口 ────────────────────────────────────────
+# 这个文件是本包唯一一个不分角色的进程级文件，写点横跨 /cache /process /renew
+# /settle 四个 handler、review 后台 task 和 compress 兜底 task。重构前每个写点都是
+# 「裸读模块级 dict → 改字段 → 整体覆盖落盘」且全程无锁，两层后果：
+#   (a) 两个协程各自 to_thread → 两个 worker 线程同时 os.replace 同一个文件，
+#       Windows 上直接 PermissionError(WinError 5)；
+#   (b) 更重的一层：各自的 json.dumps 发生在不同时刻，而 os.replace 的落地顺序可以
+#       和 dumps 顺序反过来 → 后落地的内容更旧，把对方刚写的退避计数 /
+#       review_clean 标记抹掉。
+#
+# 为什么是 threading.Lock + 整段临界区丢进一个 to_thread，而不是 asyncio.Lock：
+# 1) 这是本仓库写盘的既有正确范式 —— memory/event_log.py 的 record_and_save 明写
+#    「五步放进一个 per-character threading.Lock，整体包进一个 asyncio.to_thread，
+#    绝不跨 await 持锁」。本包里那些 asyncio.Lock（_settle_locks /
+#    _review_spawn_locks）保的是 loop 内的编排不变量，不是文件。
+# 2) 模块级 asyncio.Lock 一旦真发生争用就绑定当时的 event loop；本仓库 pytest 是
+#    asyncio_mode=auto + function-scope loop，第二个有争用的用例会直接
+#    RuntimeError（绑到了别的 loop），而且失败后锁的内部状态还残留成已持有。
+# 3) threading.Lock 把 json.dumps 也关进临界区（atomic_write_json 是先 dumps 再
+#    写）。asyncio.Lock 的版本 dumps 跑在 worker 线程里，任何残留的锁外 mutation
+#    都可能撞出 "dictionary changed size during iteration"。
+#
+# 取消安全：整段临界区在**一个** asyncio.to_thread 里跑完，锁的 acquire/release 都
+# 发生在 worker 线程内部。asyncio.to_thread 交出去就取消不掉——等它的协程被 cancel
+# 时线程照样跑完、照样释放锁，所以既不会漏掉落盘、也不会把锁泄漏成永久持有。正因如此
+# 这里不需要 shield + 等收尾：本模块任何地方都没有「持锁跨 await」。
+_maint_state_lock = threading.Lock()
+
+# mutator 契约：**同步**函数，入参是本角色的可变 sub-dict，返回 (dirty, value)。
+#   - dirty=False → 跳过落盘（调用方本来就不该无脑写；_aclear_review_clean 每轮
+#     /cache、/process 都调，标记本来是 False 时不该白付一次 fsync+replace）。
+#   - value 原样回传给调用方，用来把「锁内做出的判定」带出来（如 dead-letter）。
+# 故意要求同步：这样「锁内 await」「锁内再取别的锁」在语法上就写不出来，
+# 临界区结构性地只剩纯 CPU + 一次落盘。
+# 故意不用 RLock：RLock 会让嵌套 RMW 的内层落盘把外层改了一半的状态写进磁盘。
+MaintStateMutator = Callable[[dict], tuple[bool, Any]]
+
+_EMPTY_MAINT_VIEW: Mapping[str, Any] = MappingProxyType({})
+
 
 def _maint_state_path() -> str:
     return os.path.join(str(_config_manager.memory_dir), 'idle_maintenance_state.json')
 
 
+def _maint_view(lanlan_name: str) -> Mapping[str, Any]:
+    """Read-only SNAPSHOT of one character's maintenance state.
+
+    The proxy wraps a copy, not the live sub-dict, so the result is safe to
+    iterate and to hold across an ``await``: a worker thread running a mutator
+    can ``setdefault`` new keys at any moment, and iterating a live mapping
+    while that happens raises "dictionary changed size during iteration".
+    Copying is one C-level ``dict()`` call over a handful of scalars, so it is
+    cheaper than the alternative of taking the lock. The per-character sub-dict
+    only ever holds scalars, hence a shallow copy is a genuine seal: callers
+    cannot reach a mutable handle and must go through ``_amutate_maint_state``.
+
+    Deliberately lock-free. Every field read is advisory — the mutator
+    re-checks whatever it depends on inside the critical section — and blocking
+    the event loop on another writer's fsync would cost far more than reading a
+    value that is a few milliseconds stale.
+    """
+    entry = _maint_state.get(lanlan_name)
+    if entry is None:
+        return _EMPTY_MAINT_VIEW
+    return MappingProxyType(dict(entry))
+
+
+def _persist_maint_state_locked() -> None:
+    """Write the whole maintenance map to disk. Caller MUST hold ``_maint_state_lock``."""
+    atomic_write_json(_maint_state_path(), _maint_state,
+                      indent=2, ensure_ascii=False)
+
+
+def _rebind_maint_state_locked(data: dict[str, dict]) -> None:
+    """Replace the whole maintenance map. Acquires ``_maint_state_lock`` itself."""
+    global _maint_state
+    with _maint_state_lock:
+        _maint_state = data
+
+
+def _mutate_maint_state_locked(lanlan_name: str, mutator: MaintStateMutator) -> Any:
+    """Read → mutate → persist as one critical section. Run me inside a worker thread."""
+    with _maint_state_lock:
+        # sub-dict 必须在锁内取：_aload_maint_state 会 global 重绑定 _maint_state，
+        # 锁外取到的 sub-dict 可能已经从新 dict 上掉下来变成孤儿——改了它既不会被
+        # 落盘、也不会被后续的读看到。
+        state = _maint_state.setdefault(lanlan_name, {})
+        dirty, value = mutator(state)
+        if not dirty:
+            return value
+        try:
+            _persist_maint_state_locked()
+        except Exception as e:
+            # 与重构前的 _asave_maint_state 一致：落盘失败只告警，内存态保留、不往
+            # 上抛。/cache /process /renew /settle 四个 handler 都在 try 里调
+            # _aclear_review_clean，让写盘抖动冒出去会把整轮请求变成
+            # {"status": "error"}，进而卡住 cross_server 的 last_synced_index。
+            logger.warning(f"[IdleMaint] 维护状态保存失败: {e}")
+        return value
+
+
+async def _amutate_maint_state(lanlan_name: str, mutator: MaintStateMutator) -> Any:
+    """The single write entry point for ``idle_maintenance_state.json``.
+
+    Hands the whole read-mutate-persist sequence to one worker thread so that
+    concurrent writers cannot interleave (see the block comment above
+    ``_maint_state_lock`` for why the lock is a ``threading.Lock`` and why the
+    mutator must be synchronous).
+    """
+    return await asyncio.to_thread(_mutate_maint_state_locked, lanlan_name, mutator)
+
+
 async def _aload_maint_state() -> None:
     """Load maintenance state from disk at startup."""
     from utils.file_utils import read_json_async
-    global _maint_state
     path = _maint_state_path()
     if not await asyncio.to_thread(os.path.exists, path):
-        _maint_state = {}
+        await asyncio.to_thread(_rebind_maint_state_locked, {})
         return
     try:
         data = await read_json_async(path)
         if isinstance(data, dict):
-            _maint_state = data
-            logger.debug(f"[IdleMaint] 已加载维护状态: {len(_maint_state)} 个角色")
+            await asyncio.to_thread(_rebind_maint_state_locked, data)
+            logger.debug(f"[IdleMaint] 已加载维护状态: {len(data)} 个角色")
             return
     except (json.JSONDecodeError, OSError) as e:
         logger.warning(f"[IdleMaint] 维护状态文件加载失败: {e}")
-    _maint_state = {}
-
-
-async def _asave_maint_state() -> None:
-    """Persist maintenance state to disk."""
-    from utils.file_utils import atomic_write_json_async
-    try:
-        await atomic_write_json_async(_maint_state_path(), _maint_state,
-                                      indent=2, ensure_ascii=False)
-    except Exception as e:
-        logger.warning(f"[IdleMaint] 维护状态保存失败: {e}")
+    await asyncio.to_thread(_rebind_maint_state_locked, {})
 
 
 def _is_review_clean(lanlan_name: str) -> bool:
     """Check whether the character is in the review_clean state (reviewed and no new conversation)."""
-    return _maint_state.get(lanlan_name, {}).get('review_clean', False)
+    return _maint_view(lanlan_name).get('review_clean', False)
+
+
+def _mutate_clear_review_clean(state: dict) -> tuple[bool, None]:
+    """Mutator: drop the review_clean flag, no-op when it is already clear."""
+    if not state.get('review_clean'):
+        return False, None
+    state['review_clean'] = False
+    return True, None
 
 
 async def _aclear_review_clean(lanlan_name: str) -> None:
     """Clear the review_clean flag when a new human message arrives."""
-    state = _maint_state.get(lanlan_name, {})
-    if state.get('review_clean'):
-        state['review_clean'] = False
-        await _asave_maint_state()
+    # 锁外快筛：/cache 和 /process 每轮都调这里，而标记绝大多数时候本来就是 False。
+    # 没有这一层，热路径上每条 user 消息都要白切一次线程。快筛读到的值可能过期，
+    # 但无害——真正的判定在 _mutate_clear_review_clean 里锁内又做了一次，所以
+    # 「假阴性」只会让本轮少写一次（下一条消息立刻会补上），不会写坏状态。
+    if not _is_review_clean(lanlan_name):
+        return
+    await _amutate_maint_state(lanlan_name, _mutate_clear_review_clean)
 
 
 async def _ais_review_enabled() -> bool:

--- a/app/memory_server/review.py
+++ b/app/memory_server/review.py
@@ -73,8 +73,22 @@ def _clear_review_output_exhaustion_state(state: dict) -> bool:
     return changed
 
 
-def _mutate_clear_output_exhaustion(state: dict) -> tuple[bool, None]:
-    """Mutator: clear the output-exhaustion breaker (Gate 6a recovery)."""
+def _mutate_clear_output_exhaustion(
+    state: dict, *, seen_attempts: int, seen_min_tokens: int
+) -> tuple[bool, None]:
+    """Mutator: clear the output-exhaustion breaker, unless a newer failure was armed."""
+    # Gate 6a 的恢复判定必须在锁外做（token 计数是 async，进不了同步 mutator），所以
+    # 锁内要复查它依赖的那份输入还在不在：另一个后台 review 可能在那次 await 期间刚写下
+    # 一次**新的**输出耗尽失败（带着新的 attempts / min_context_tokens）。无条件清零会把
+    # 刚 armed 的断路器抹掉，于是那条已经证明压不动的 context 又会被放行重烧一轮。
+    # 与 _mutate_reset_review_fail_backoff 的锁内复查同构。
+    try:
+        current_min = int(state.get('review_output_exhaustion_min_context_tokens') or 0)
+    except (TypeError, ValueError):
+        current_min = 0
+    current_attempts = state.get('review_output_exhaustion_attempts', 0) or 0
+    if current_min != seen_min_tokens or current_attempts != seen_attempts:
+        return False, None
     return _clear_review_output_exhaustion_state(state), None
 
 
@@ -190,7 +204,14 @@ async def maybe_spawn_review(name: str) -> None:
                     f"失败最小值 {failed_min_tokens})，跳过本轮"
                 )
                 return
-            await gates._amutate_maint_state(name, _mutate_clear_output_exhaustion)
+            await gates._amutate_maint_state(
+                name,
+                functools.partial(
+                    _mutate_clear_output_exhaustion,
+                    seen_attempts=exhaustion_attempts,
+                    seen_min_tokens=failed_min_tokens,
+                ),
+            )
             logger.info(
                 f"[Review/spawn] {name}: context 已缩短 "
                 f"({current_tokens} < {failed_min_tokens})，恢复历史审阅"

--- a/app/memory_server/review.py
+++ b/app/memory_server/review.py
@@ -75,7 +75,7 @@ def _clear_review_output_exhaustion_state(state: dict) -> bool:
 
 def _mutate_clear_output_exhaustion(
     state: dict, *, seen_attempts: int, seen_min_tokens: int
-) -> tuple[bool, None]:
+) -> tuple[bool, bool]:
     """Mutator: clear the output-exhaustion breaker, unless a newer failure was armed."""
     # Gate 6a 的恢复判定必须在锁外做（token 计数是 async，进不了同步 mutator），所以
     # 锁内要复查它依赖的那份输入还在不在：另一个后台 review 可能在那次 await 期间刚写下
@@ -88,8 +88,11 @@ def _mutate_clear_output_exhaustion(
         current_min = 0
     current_attempts = state.get('review_output_exhaustion_attempts', 0) or 0
     if current_min != seen_min_tokens or current_attempts != seen_attempts:
-        return False, None
-    return _clear_review_output_exhaustion_state(state), None
+        return False, False
+    _clear_review_output_exhaustion_state(state)
+    # value 把「恢复是否成立」带给调用方（这正是 (dirty, value) 里 value 的用途）。
+    # dirty 恒 True：走到这里说明观测到的断路器确实还在，清零一定改变了状态。
+    return True, True
 
 
 def _get_review_spawn_lock(name: str) -> asyncio.Lock:
@@ -204,7 +207,7 @@ async def maybe_spawn_review(name: str) -> None:
                     f"失败最小值 {failed_min_tokens})，跳过本轮"
                 )
                 return
-            await gates._amutate_maint_state(
+            cleared = await gates._amutate_maint_state(
                 name,
                 functools.partial(
                     _mutate_clear_output_exhaustion,
@@ -212,6 +215,15 @@ async def maybe_spawn_review(name: str) -> None:
                     seen_min_tokens=failed_min_tokens,
                 ),
             )
+            if not cleared:
+                # 锁内复查发现断路器已经被换成更新的一份（在 await token 计数期间又失败
+                # 了一次）。恢复判定已经过期，本轮必须跟着放弃 —— 只是不清零却继续往下
+                # spawn 的话，等于拿一个过期的判定绕过了刚 armed 的断路器。
+                logger.debug(
+                    f"[Review/spawn] {name}: 恢复判定已过期"
+                    f"（断路器在 token 计数期间被并发写者更新），跳过本轮"
+                )
+                return
             logger.info(
                 f"[Review/spawn] {name}: context 已缩短 "
                 f"({current_tokens} < {failed_min_tokens})，恢复历史审阅"

--- a/app/memory_server/review.py
+++ b/app/memory_server/review.py
@@ -19,10 +19,18 @@ Owns the review/correction task registries (``correction_tasks`` /
 ``correction_cancel_flags`` / ``compress_backup_tasks``) and the per-name
 spawn locks, co-located with the unified ``maybe_spawn_review`` gate chain
 (Phase C), the background review runner and the compression-failure backup
-path. Failure-backoff bookkeeping persists via ``gates._maint_state``.
+path.
+
+Failure-backoff bookkeeping lives in ``idle_maintenance_state.json``. Every
+update in this module goes through ``gates._amutate_maint_state`` with a
+synchronous mutator (``_mutate_*`` below) so that read-modify-write runs as one
+critical section; reads go through the read-only ``gates._maint_view``. Anything
+that needs an ``await`` (token counting, fingerprinting a snapshot) is computed
+before the mutator is handed over.
 """
 
 import asyncio
+import functools
 from datetime import datetime
 
 from . import gates, runtime
@@ -46,10 +54,28 @@ correction_cancel_flags = {}  # {lanlan_name: asyncio.Event}
 _review_spawn_locks: dict[str, asyncio.Lock] = {}
 
 
-def _clear_review_output_exhaustion_state(state: dict) -> None:
+def _clear_review_output_exhaustion_state(state: dict) -> bool:
+    """Zero the output-exhaustion breaker in place; returns whether anything changed.
+
+    Mutator helper — always call it with the sub-dict handed to a mutator, never
+    with a ``gates._maint_view`` result.
+    """
+    # 三个键无条件写回（保持重构前的内存形状），但 dirty 只按「原本是否非默认值」
+    # 算：全是默认值时把键补齐一遍不需要落盘，磁盘上缺这三个键与三个默认值等价。
+    changed = (
+        bool(state.get('review_output_exhaustion_attempts'))
+        or state.get('review_output_exhaustion_min_context_tokens') is not None
+        or bool(state.get('review_output_exhaustion_blocked'))
+    )
     state['review_output_exhaustion_attempts'] = 0
     state['review_output_exhaustion_min_context_tokens'] = None
     state['review_output_exhaustion_blocked'] = False
+    return changed
+
+
+def _mutate_clear_output_exhaustion(state: dict) -> tuple[bool, None]:
+    """Mutator: clear the output-exhaustion breaker (Gate 6a recovery)."""
+    return _clear_review_output_exhaustion_state(state), None
 
 
 def _get_review_spawn_lock(name: str) -> asyncio.Lock:
@@ -69,7 +95,7 @@ def _count_new_user_msgs_since_last_review(name: str, current_history: list) -> 
     plenty, allowed through (should re-review ASAP to rebuild the fingerprint).
     """
     from memory.recent import _find_fingerprint_position
-    fp = gates._maint_state.get(name, {}).get('last_reviewed_cutoff_tail')
+    fp = gates._maint_view(name).get('last_reviewed_cutoff_tail')
     if not fp:
         return float('inf')
     cutoff_idx = _find_fingerprint_position(current_history, fp)
@@ -113,7 +139,7 @@ async def maybe_spawn_review(name: str) -> None:
         if len(history) < REVIEW_SKIP_HISTORY_LEN:
             return
         # Gate 4: min interval
-        last_review = gates._maint_state.get(name, {}).get('last_review_ts')
+        last_review = gates._maint_view(name).get('last_review_ts')
         if last_review:
             try:
                 elapsed = (datetime.now() - datetime.fromisoformat(last_review)).total_seconds()
@@ -143,18 +169,19 @@ async def maybe_spawn_review(name: str) -> None:
         # 最小值才恢复。
         from config import MEMORY_REVIEW_OUTPUT_EXHAUSTION_MAX_ATTEMPTS
         from memory.recent import review_context_token_count
-        state = gates._maint_state.setdefault(name, {})
-        exhaustion_attempts = state.get('review_output_exhaustion_attempts', 0) or 0
-        exhaustion_blocked = bool(state.get('review_output_exhaustion_blocked'))
+        view = gates._maint_view(name)
+        exhaustion_attempts = view.get('review_output_exhaustion_attempts', 0) or 0
+        exhaustion_blocked = bool(view.get('review_output_exhaustion_blocked'))
         if (
             exhaustion_blocked
             or exhaustion_attempts >= MEMORY_REVIEW_OUTPUT_EXHAUSTION_MAX_ATTEMPTS
         ):
-            failed_min_tokens = state.get('review_output_exhaustion_min_context_tokens')
+            failed_min_tokens = view.get('review_output_exhaustion_min_context_tokens')
             try:
                 failed_min_tokens = int(failed_min_tokens or 0)
             except (TypeError, ValueError):
                 failed_min_tokens = 0
+            # token 计数是 async（可能走 tiktoken），必须留在临界区外算完再进 mutator。
             current_tokens = await review_context_token_count(history)
             if failed_min_tokens > 0 and current_tokens >= failed_min_tokens:
                 logger.debug(
@@ -163,8 +190,7 @@ async def maybe_spawn_review(name: str) -> None:
                     f"失败最小值 {failed_min_tokens})，跳过本轮"
                 )
                 return
-            _clear_review_output_exhaustion_state(state)
-            await gates._asave_maint_state()
+            await gates._amutate_maint_state(name, _mutate_clear_output_exhaustion)
             logger.info(
                 f"[Review/spawn] {name}: context 已缩短 "
                 f"({current_tokens} < {failed_min_tokens})，恢复历史审阅"
@@ -179,20 +205,26 @@ async def maybe_spawn_review(name: str) -> None:
         # 主动给死循环续命，本闸门要能压过它（用户审计 #1：实锤的整夜无限重烧）。
         from config import MEMORY_LIVENESS_MAX_ATTEMPTS
         from memory.recent import build_review_fingerprint
-        fail_attempts = state.get('review_fail_attempts', 0) or 0
+        # Gate 6a 可能刚落过盘，重新取一次 view（旧的可能还是空角色的 _EMPTY 视图）。
+        view = gates._maint_view(name)
+        fail_attempts = view.get('review_fail_attempts', 0) or 0
         if fail_attempts >= MEMORY_LIVENESS_MAX_ATTEMPTS:
             cur_fp = build_review_fingerprint(history)
-            if state.get('review_fail_fp') == cur_fp:
+            # dead-letter 判定本身也进临界区：判定和复位是同一次 RMW，别的写者不可能
+            # 在「读到输入已变」和「把计数清零」之间插进来。
+            decision = await gates._amutate_maint_state(
+                name,
+                functools.partial(
+                    _mutate_reset_review_fail_backoff, cur_fp, MEMORY_LIVENESS_MAX_ATTEMPTS,
+                ),
+            )
+            if decision == 'dead_letter':
                 logger.debug(
                     f"[Review/spawn] {name}: 失败退避 dead-letter "
                     f"(连续失败 {fail_attempts} 次 ≥ {MEMORY_LIVENESS_MAX_ATTEMPTS} "
                     f"且输入未变)，跳过本轮"
                 )
                 return
-            # 输入已变 → 旧失败计数过期，复位后放行重试
-            state['review_fail_attempts'] = 0
-            state['review_fail_fp'] = None
-            await gates._asave_maint_state()
         # 全过 → spawn
         logger.info(f"[Review/spawn] {name}: 触发 review (history_len={len(history)})")
         cancel_event = asyncio.Event()
@@ -204,35 +236,59 @@ async def maybe_spawn_review(name: str) -> None:
         correction_tasks[name] = task
 
 
+def _mutate_reset_review_fail_backoff(cur_fp, max_attempts: int, state: dict) -> tuple[bool, str]:
+    """Mutator: re-check Gate 6b under lock and expire the backoff if the input changed.
+
+    Returns ``'dead_letter'`` (caller must skip this spawn) or ``'proceed'``.
+    """
+    # 配置常量由调用方在锁外取好传进来：mutator 跑在临界区里，不该在里面碰 import
+    # machinery（本仓库这些 config import 都是函数内 lazy import）。
+    attempts = state.get('review_fail_attempts', 0) or 0
+    if attempts < max_attempts:
+        # 锁外快筛之后另一个写者已经把计数清了（如成功的 review）→ 直接放行。
+        return False, 'proceed'
+    if state.get('review_fail_fp') == cur_fp:
+        return False, 'dead_letter'
+    state['review_fail_attempts'] = 0
+    state['review_fail_fp'] = None
+    return True, 'proceed'
+
+
+def _mutate_record_review_failure(cur_fp, state: dict) -> tuple[bool, int]:
+    """Mutator: bump the review failure counter and break the output-exhaustion streak."""
+    if state.get('review_fail_fp') != cur_fp:
+        state['review_fail_attempts'] = 0
+    state['review_fail_attempts'] = (state.get('review_fail_attempts', 0) or 0) + 1
+    state['review_fail_fp'] = cur_fp
+    # 普通失败会中断"连续输出耗尽"序列，不能让两类失败交错累计后误开断路器。这一步
+    # 必须和 bump 同在一个临界区、同一次落盘里：重构前它靠调用方先改内存、再靠本函数
+    # 的 save 顺带持久化，拆成两次落盘会留下"清了但没写"的窗口。
+    _clear_review_output_exhaustion_state(state)
+    return True, state['review_fail_attempts']
+
+
 async def _record_review_failure(lanlan_name: str, snapshot: list) -> int:
     """Record one review failure into the failure-backoff counter (used by Gate 6); returns the cumulative count.
 
     If the input fingerprint differs from the last failure record → zero the
     budget first, then +1, so each history tail gets its own independent budget of
-    N attempts instead of accumulating across inputs (Codex P2). The 'failed'
-    return branch and the except branch share this function to keep the two paths
-    from drifting apart.
+    N attempts instead of accumulating across inputs (Codex P2).
+
+    Also clears the output-exhaustion breaker in the same critical section: a
+    generic failure breaks the "consecutive output exhaustion" streak, and the two
+    updates must land in one write.
     """
     from memory.recent import build_review_fingerprint
-    state = gates._maint_state.setdefault(lanlan_name, {})
     cur_fp = build_review_fingerprint(snapshot)
-    if state.get('review_fail_fp') != cur_fp:
-        state['review_fail_attempts'] = 0
-    state['review_fail_attempts'] = (state.get('review_fail_attempts', 0) or 0) + 1
-    state['review_fail_fp'] = cur_fp
-    await gates._asave_maint_state()
-    return state['review_fail_attempts']
+    return await gates._amutate_maint_state(
+        lanlan_name, functools.partial(_mutate_record_review_failure, cur_fp),
+    )
 
 
-async def _record_review_output_exhaustion(
-    lanlan_name: str, snapshot: list,
-) -> tuple[int, int, int]:
-    """Record one output-limit failure across growing/changed tail fingerprints."""
-    from config import MEMORY_REVIEW_OUTPUT_EXHAUSTION_MAX_ATTEMPTS
-    from memory.recent import review_context_token_count
-
-    state = gates._maint_state.setdefault(lanlan_name, {})
-    current_tokens = await review_context_token_count(snapshot)
+def _mutate_record_output_exhaustion(
+    current_tokens: int, max_attempts: int, state: dict,
+) -> tuple[bool, tuple[int, int]]:
+    """Mutator: fold one output-limit failure into the breaker, tracking the minimum context."""
     previous_min = state.get('review_output_exhaustion_min_context_tokens')
     try:
         previous_min = int(previous_min or 0)
@@ -249,10 +305,27 @@ async def _record_review_output_exhaustion(
     attempts += 1
     state['review_output_exhaustion_attempts'] = attempts
     state['review_output_exhaustion_min_context_tokens'] = minimum_tokens
-    state['review_output_exhaustion_blocked'] = (
-        attempts >= MEMORY_REVIEW_OUTPUT_EXHAUSTION_MAX_ATTEMPTS
+    state['review_output_exhaustion_blocked'] = attempts >= max_attempts
+    return True, (attempts, minimum_tokens)
+
+
+async def _record_review_output_exhaustion(
+    lanlan_name: str, snapshot: list,
+) -> tuple[int, int, int]:
+    """Record one output-limit failure across growing/changed tail fingerprints."""
+    from config import MEMORY_REVIEW_OUTPUT_EXHAUSTION_MAX_ATTEMPTS
+    from memory.recent import review_context_token_count
+
+    # token 计数是 async，必须在进临界区前算完（mutator 是同步函数，写不出 await）。
+    current_tokens = await review_context_token_count(snapshot)
+    attempts, minimum_tokens = await gates._amutate_maint_state(
+        lanlan_name,
+        functools.partial(
+            _mutate_record_output_exhaustion,
+            current_tokens,
+            MEMORY_REVIEW_OUTPUT_EXHAUSTION_MAX_ATTEMPTS,
+        ),
     )
-    await gates._asave_maint_state()
     return attempts, current_tokens, minimum_tokens
 
 
@@ -265,6 +338,15 @@ async def _record_review_output_exhaustion(
 compress_backup_tasks: dict[str, asyncio.Task] = {}
 
 
+def _mutate_record_compress_backup_failure(cur_fp, state: dict) -> tuple[bool, int]:
+    """Mutator: bump the backup-compression failure counter for this input fingerprint."""
+    if state.get('compress_backup_fail_fp') != cur_fp:
+        state['compress_backup_fail_attempts'] = 0
+    state['compress_backup_fail_attempts'] = (state.get('compress_backup_fail_attempts', 0) or 0) + 1
+    state['compress_backup_fail_fp'] = cur_fp
+    return True, state['compress_backup_fail_attempts']
+
+
 async def _record_compress_backup_failure(lanlan_name: str, snapshot: list) -> int:
     """Record one backup-compression failure and return the current attempt count.
 
@@ -272,23 +354,52 @@ async def _record_compress_backup_failure(lanlan_name: str, snapshot: list) -> i
     its own budget, matching the review-failure backoff shape.
     """
     from memory.recent import build_review_fingerprint
-    state = gates._maint_state.setdefault(lanlan_name, {})
     cur_fp = build_review_fingerprint(snapshot)
-    if state.get('compress_backup_fail_fp') != cur_fp:
-        state['compress_backup_fail_attempts'] = 0
-    state['compress_backup_fail_attempts'] = (state.get('compress_backup_fail_attempts', 0) or 0) + 1
-    state['compress_backup_fail_fp'] = cur_fp
-    await gates._asave_maint_state()
-    return state['compress_backup_fail_attempts']
+    return await gates._amutate_maint_state(
+        lanlan_name, functools.partial(_mutate_record_compress_backup_failure, cur_fp),
+    )
+
+
+def _mutate_clear_compress_backup_failure(state: dict) -> tuple[bool, None]:
+    """Mutator: clear the backup-compression backoff, no-op when already clear."""
+    if not (state.get('compress_backup_fail_attempts') or state.get('compress_backup_fail_fp')):
+        return False, None
+    state['compress_backup_fail_attempts'] = 0
+    state['compress_backup_fail_fp'] = None
+    return True, None
 
 
 async def _clear_compress_backup_failure(lanlan_name: str) -> None:
     """Clear the backup-compression failure backoff counter."""
-    state = gates._maint_state.setdefault(lanlan_name, {})
-    if state.get('compress_backup_fail_attempts') or state.get('compress_backup_fail_fp'):
-        state['compress_backup_fail_attempts'] = 0
-        state['compress_backup_fail_fp'] = None
-        await gates._asave_maint_state()
+    # 锁外快筛，与 gates._aclear_review_clean 对偶。调用点 _on_compress_done 的
+    # ok=True 分支每次主路径压缩成功都会走到这里，而它由 memory/recent.py 的
+    # _notify_compress_done 触发 —— /renew、/settle 是持着 settle lock 调
+    # update_history 的，该回调的 docstring 自己写明 "must not block"。退避计数
+    # 绝大多数时候本来就是空的，没有这一层就等于每次压缩成功都在 settle lock 内
+    # 白排一次 default executor。快筛读到的值可能过期，但无害——真正的判定在
+    # _mutate_clear_compress_backup_failure 里锁内又做了一次，「假阴性」只会让本轮
+    # 少写一次（下次压缩成功立刻会补上），不会写坏状态。
+    view = gates._maint_view(lanlan_name)
+    if not (view.get('compress_backup_fail_attempts') or view.get('compress_backup_fail_fp')):
+        return
+    await gates._amutate_maint_state(lanlan_name, _mutate_clear_compress_backup_failure)
+
+
+def _mutate_reset_compress_backup_backoff(
+    cur_fp, max_attempts: int, state: dict,
+) -> tuple[bool, str]:
+    """Mutator: re-check the compress-backup dead-letter under lock and expire it if the input changed.
+
+    Returns ``'dead_letter'`` (caller must not spawn) or ``'proceed'``.
+    """
+    attempts = state.get('compress_backup_fail_attempts', 0) or 0
+    if attempts < max_attempts:
+        return False, 'proceed'
+    if state.get('compress_backup_fail_fp') == cur_fp:
+        return False, 'dead_letter'
+    state['compress_backup_fail_attempts'] = 0
+    state['compress_backup_fail_fp'] = None
+    return True, 'proceed'
 
 
 async def _run_backup_compress(lanlan_name: str, snapshot: list, detailed: bool):
@@ -359,11 +470,20 @@ async def _on_compress_done(lanlan_name: str, snapshot: list, ok: bool, detailed
     # 防 summary 模型持续故障时每轮都起一个注定失败的后台任务空烧。
     from config import MEMORY_LIVENESS_MAX_ATTEMPTS
     from memory.recent import build_review_fingerprint
-    state = gates._maint_state.setdefault(lanlan_name, {})
-    fail_attempts = state.get('compress_backup_fail_attempts', 0) or 0
+    fail_attempts = gates._maint_view(lanlan_name).get('compress_backup_fail_attempts', 0) or 0
     if fail_attempts >= MEMORY_LIVENESS_MAX_ATTEMPTS:
         cur_fp = build_review_fingerprint(snapshot)
-        if state.get('compress_backup_fail_fp') == cur_fp:
+        # dead-letter 判定与复位是同一次 RMW（见 _mutate_reset_compress_backup_backoff）。
+        # mutator 是同步函数，所以它既不可能在锁内 await、也不可能在锁内去取
+        # _get_settle_lock —— 本回调可能已经在 /renew·/settle 的 settle lock 内被调，
+        # 这条结构性约束正是它不会反向死锁的原因。
+        decision = await gates._amutate_maint_state(
+            lanlan_name,
+            functools.partial(
+                _mutate_reset_compress_backup_backoff, cur_fp, MEMORY_LIVENESS_MAX_ATTEMPTS,
+            ),
+        )
+        if decision == 'dead_letter':
             logger.debug(
                 f"[CompressBackup] {lanlan_name} 失败退避 dead-letter"
                 f"（连续失败 {fail_attempts} 次且输入未变），跳过"
@@ -373,13 +493,33 @@ async def _on_compress_done(lanlan_name: str, snapshot: list, ok: bool, detailed
             # enforce_hard_cap 是 best-effort 写。
             await runtime.recent_history_manager.enforce_hard_cap(lanlan_name)
             return
-        # 输入变了 → 旧计数过期，复位放行
-        state['compress_backup_fail_attempts'] = 0
-        state['compress_backup_fail_fp'] = None
-        await gates._asave_maint_state()
     task = runtime._spawn_background_task(_run_backup_compress(lanlan_name, list(snapshot), detailed))
     compress_backup_tasks[lanlan_name] = task
     logger.info(f"[CompressBackup] {lanlan_name} 主路径压缩失败，已起后台兜底压缩任务")
+
+
+def _mutate_review_patched(fingerprint, state: dict) -> tuple[bool, None]:
+    """Mutator: record a successful review and clear every backoff it invalidates."""
+    state['review_clean'] = True
+    state['last_review_ts'] = datetime.now().isoformat()
+    state['last_reviewed_cutoff_tail'] = fingerprint
+    # 成功 → 清掉失败退避计数（Gate 6）
+    state['review_fail_attempts'] = 0
+    state['review_fail_fp'] = None
+    _clear_review_output_exhaustion_state(state)
+    return True, None
+
+
+def _mutate_review_white(state: dict) -> tuple[bool, None]:
+    """Mutator: record a white review — drop the anchor, keep ``last_review_ts`` stale."""
+    state['last_reviewed_cutoff_tail'] = None
+    # 故意不更新 last_review_ts：让下轮 gate 4 用旧 ts（通常已过 30/60s）
+    # 直接放行，配合 fingerprint=None 触发 gate 5 的 ∞ 通行 → 立即重 review。
+    # 白 review 是 cutoff 失配（输入实际已变）而非失败，清退避计数允许立即重建锚点。
+    state['review_fail_attempts'] = 0
+    state['review_fail_fp'] = None
+    _clear_review_output_exhaustion_state(state)
+    return True, None
 
 
 async def _run_review_in_background(
@@ -434,29 +574,16 @@ async def _run_review_in_background(
         else:
             status, fingerprint = ('failed', None)
 
-        state = gates._maint_state.setdefault(lanlan_name, {})
         if status == 'patched':
             logger.info(f"✅ {lanlan_name} 的记忆整理任务完成")
-            state['review_clean'] = True
-            state['last_review_ts'] = datetime.now().isoformat()
-            state['last_reviewed_cutoff_tail'] = fingerprint
-            # 成功 → 清掉失败退避计数（Gate 6）
-            state['review_fail_attempts'] = 0
-            state['review_fail_fp'] = None
-            _clear_review_output_exhaustion_state(state)
-            await gates._asave_maint_state()
+            await gates._amutate_maint_state(
+                lanlan_name, functools.partial(_mutate_review_patched, fingerprint),
+            )
         elif status == 'white':
             logger.info(
                 f"⚠️ {lanlan_name} 白 review（cutoff 失配），fingerprint 清空、不刷 ts，允许立即重试"
             )
-            state['last_reviewed_cutoff_tail'] = None
-            # 故意不更新 last_review_ts：让下轮 gate 4 用旧 ts（通常已过 30/60s）
-            # 直接放行，配合 fingerprint=None 触发 gate 5 的 ∞ 通行 → 立即重 review。
-            # 白 review 是 cutoff 失配（输入实际已变）而非失败，清退避计数允许立即重建锚点。
-            state['review_fail_attempts'] = 0
-            state['review_fail_fp'] = None
-            _clear_review_output_exhaustion_state(state)
-            await gates._asave_maint_state()
+            await gates._amutate_maint_state(lanlan_name, _mutate_review_white)
         elif cancel_event.is_set():
             # review_history 在 cancel_event 置位时也返回 ('failed', None)，但这是
             # 主动取消（cancel_correction：记忆编辑后立即生效）而非失败，不能计入
@@ -482,8 +609,8 @@ async def _run_review_in_background(
             # 'failed'：LLM 持续失败 / 超时 / 格式错误。bump 失败退避计数 + 记下
             # 本次失败的输入 fingerprint，供 Gate 6 在输入不变时 dead-letter，避免
             # correction 模型一直超时 + 长挂机 bypass 续命导致整夜空烧（用户审计 #1）。
-            # 普通失败会中断“连续输出耗尽”序列，不能让两类失败交错累计后误开断路器。
-            _clear_review_output_exhaustion_state(state)
+            # 普通失败中断“连续输出耗尽”序列这一步已并进 _record_review_failure 的
+            # mutator：清计数与 bump 必须落在同一次写里，不能拆成两次。
             attempts = await _record_review_failure(lanlan_name, snapshot)
             logger.info(
                 f"ℹ️ {lanlan_name} 的记忆整理未执行（被跳过或失败），"

--- a/tests/unit/test_memory_maint_state_lock.py
+++ b/tests/unit/test_memory_maint_state_lock.py
@@ -147,8 +147,11 @@ async def test_clear_review_clean_does_not_even_switch_threads_when_flag_absent(
     """No flag → no worker thread at all, not merely no disk write."""
     clean_state["角色"] = {"review_clean": False}
 
-    real_to_thread = asyncio.to_thread
-    with patch.object(gates.asyncio, "to_thread", wraps=real_to_thread) as thread_spy, \
+    # spy 收在写入口本身，而不是 patch 全局的 asyncio.to_thread：后者会把整个
+    # 进程的 to_thread 换掉，被测路径将来多一次无关的线程跳、或者测试并行化之后，
+    # 这里的 call_count 断言就会莫名其妙地飘。
+    real_amutate = gates._amutate_maint_state
+    with patch.object(gates, "_amutate_maint_state", wraps=real_amutate) as thread_spy, \
          patch.object(gates, "_mutate_maint_state_locked") as locked_spy, \
          patch.object(gates, "_persist_maint_state_locked", MagicMock()) as persist:
         await gates._aclear_review_clean("角色")
@@ -166,8 +169,11 @@ async def test_clear_review_clean_does_persist_when_flag_is_set(clean_state):
     """Dual of the skip test: a set flag must actually go through the entry point."""
     clean_state["角色"] = {"review_clean": True}
 
-    real_to_thread = asyncio.to_thread
-    with patch.object(gates.asyncio, "to_thread", wraps=real_to_thread) as thread_spy, \
+    # spy 收在写入口本身，而不是 patch 全局的 asyncio.to_thread：后者会把整个
+    # 进程的 to_thread 换掉，被测路径将来多一次无关的线程跳、或者测试并行化之后，
+    # 这里的 call_count 断言就会莫名其妙地飘。
+    real_amutate = gates._amutate_maint_state
+    with patch.object(gates, "_amutate_maint_state", wraps=real_amutate) as thread_spy, \
          patch.object(gates, "_persist_maint_state_locked", MagicMock()) as persist:
         await gates._aclear_review_clean("角色")
 
@@ -191,8 +197,11 @@ async def test_clear_compress_backup_failure_does_not_even_switch_threads_when_b
     """
     clean_state["角色"] = {"compress_backup_fail_attempts": 0, "compress_backup_fail_fp": None}
 
-    real_to_thread = asyncio.to_thread
-    with patch.object(gates.asyncio, "to_thread", wraps=real_to_thread) as thread_spy, \
+    # spy 收在写入口本身，而不是 patch 全局的 asyncio.to_thread：后者会把整个
+    # 进程的 to_thread 换掉，被测路径将来多一次无关的线程跳、或者测试并行化之后，
+    # 这里的 call_count 断言就会莫名其妙地飘。
+    real_amutate = gates._amutate_maint_state
+    with patch.object(gates, "_amutate_maint_state", wraps=real_amutate) as thread_spy, \
          patch.object(gates, "_mutate_maint_state_locked") as locked_spy, \
          patch.object(gates, "_persist_maint_state_locked", MagicMock()) as persist:
         await review._clear_compress_backup_failure("角色")
@@ -210,8 +219,11 @@ async def test_clear_compress_backup_failure_does_persist_when_backoff_present(c
     """Dual of the skip test: a non-empty backoff must actually go through the entry point."""
     clean_state["角色"] = {"compress_backup_fail_attempts": 2, "compress_backup_fail_fp": "fp"}
 
-    real_to_thread = asyncio.to_thread
-    with patch.object(gates.asyncio, "to_thread", wraps=real_to_thread) as thread_spy, \
+    # spy 收在写入口本身，而不是 patch 全局的 asyncio.to_thread：后者会把整个
+    # 进程的 to_thread 换掉，被测路径将来多一次无关的线程跳、或者测试并行化之后，
+    # 这里的 call_count 断言就会莫名其妙地飘。
+    real_amutate = gates._amutate_maint_state
+    with patch.object(gates, "_amutate_maint_state", wraps=real_amutate) as thread_spy, \
          patch.object(gates, "_persist_maint_state_locked", MagicMock()) as persist:
         await review._clear_compress_backup_failure("角色")
 
@@ -478,6 +490,42 @@ async def test_load_rebind_is_mutually_exclusive_with_mutators(tmp_path, monkeyp
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payload", "what_is_wrong"),
+    [
+        (b'{"\xff\xfe": {"review_clean": true}}', "undecodable-bytes"),
+        ('{"角色": {"review_clean": true}}'.encode("utf-16"), "wrong-codec"),
+        (b'{"\xe8\xa7", "truncated"}', "truncated-multibyte"),
+    ],
+    ids=["undecodable-bytes", "wrong-codec", "truncated-multibyte"],
+)
+async def test_load_falls_back_to_empty_state_on_a_mis_encoded_file(
+    payload: bytes, what_is_wrong: str, tmp_path, monkeypatch, clean_state,
+):
+    """A state file that is not valid UTF-8 must degrade to empty state, not abort startup.
+
+    ``read_json`` is ``open(encoding='utf-8')`` + ``json.load``, so undecodable
+    bytes raise ``UnicodeDecodeError`` — a ``ValueError`` subclass that is neither
+    ``json.JSONDecodeError`` nor ``OSError``. The sole caller
+    (``ensure_memory_server_runtime_initialized``) does not wrap this await, so an
+    escaping exception takes the whole memory_server runtime init down instead of
+    losing one advisory maintenance flag.
+    """
+    target = tmp_path / "idle_maintenance_state.json"
+    target.write_bytes(payload)
+    monkeypatch.setattr(gates, "_maint_state_path", lambda: str(target))
+    # 预置一条残留，确保下面的空断言不是「本来就空」蒙对的。
+    clean_state["上一轮残留"] = {"review_clean": True}
+
+    await gates._aload_maint_state()
+
+    assert gates._maint_state == {}, (
+        f"坏编码（{what_is_wrong}）没有回落到空状态"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_mutator_takes_the_sub_dict_inside_the_lock(clean_state, monkeypatch):
     """The sub-dict must be fetched after the lock, or a rebind orphans the mutation.
 
@@ -565,7 +613,6 @@ async def test_generic_failure_lands_both_updates_in_one_write(clean_state):
         "review_output_exhaustion_blocked": False,
     }
     fake_mgr = MagicMock()
-    fake_mgr.review_history = MagicMock()
 
     landed: list[dict] = []
 
@@ -713,7 +760,8 @@ def test_gate6a_recovery_clears_when_the_observed_breaker_is_still_current() -> 
         state, seen_attempts=2, seen_min_tokens=1000
     )
 
-    assert (dirty, value) == (True, None)
+    # value=True 是给调用方的信号「恢复成立、可以继续 spawn」。
+    assert (dirty, value) == (True, True)
     assert state['review_output_exhaustion_attempts'] == 0
     assert state['review_output_exhaustion_min_context_tokens'] is None
     assert state['review_output_exhaustion_blocked'] is False
@@ -752,5 +800,7 @@ def test_gate6a_recovery_keeps_a_breaker_armed_by_a_concurrent_writer(
         newer_state, seen_attempts=2, seen_min_tokens=1000
     )
 
-    assert (dirty, value) == (False, None), f"{what_changed} 变了就不该清零"
+    # value=False 是给调用方的信号「恢复判定已过期、本轮必须放弃」——只是不清零而
+    # 继续 spawn 的话，等于拿过期判定绕过刚 armed 的断路器。
+    assert (dirty, value) == (False, False), f"{what_changed} 变了就不该清零"
     assert newer_state == before, "复查失败时一个字段都不许动"

--- a/tests/unit/test_memory_maint_state_lock.py
+++ b/tests/unit/test_memory_maint_state_lock.py
@@ -1,0 +1,694 @@
+# -*- coding: utf-8 -*-
+"""Regression suite for the single locked writer of ``idle_maintenance_state.json``.
+
+Before this change, ten write sites (``_aclear_review_clean`` from four request
+handlers plus the review / compress-backup backoff bookkeeping) each did
+"read the module-level dict → edit a field → overwrite the whole file" with no
+lock at all. Two layers of damage:
+
+  (a) two coroutines each hand a write to ``asyncio.to_thread``, so two worker
+      threads call ``os.replace`` on the same path — PermissionError (WinError 5)
+      on Windows;
+  (b) each writer's ``json.dumps`` happens at a different moment while the
+      ``os.replace`` landing order can be reversed, so the content that lands
+      last may be the older one, wiping out the backoff counter or the
+      ``review_clean`` flag the other writer just recorded.
+
+The fix: ``gates._amutate_maint_state`` is the only write entry point, running
+read → mutate → persist as one ``threading.Lock`` critical section inside a
+single ``asyncio.to_thread``.
+"""
+from __future__ import annotations
+
+import ast
+import asyncio
+import copy
+import json
+import pathlib
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.memory_server import gates, review
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+PACKAGE_ROOT = REPO_ROOT / "app" / "memory_server"
+GATES_PATH = PACKAGE_ROOT / "gates.py"
+
+
+@pytest.fixture
+def clean_state():
+    """Drop every maintenance entry before and after the test."""
+    gates._maint_state.clear()
+    yield gates._maint_state
+    gates._maint_state.clear()
+
+
+# ── 1. 串行化：并发写者不会同时落盘、RMW 不丢写 ──────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_concurrent_writes_never_overlap_on_disk(clean_state):
+    """Two writers must never be inside the persist step at the same time."""
+    inflight = 0
+    max_inflight = 0
+    guard = threading.Lock()
+
+    def _slow_persist():
+        nonlocal inflight, max_inflight
+        with guard:
+            inflight += 1
+            max_inflight = max(max_inflight, inflight)
+        # 真实落盘是 dumps + fsync + replace，用 sleep 把那段窗口放大到可观测。
+        time.sleep(0.01)
+        with guard:
+            inflight -= 1
+
+    def _mutator(state: dict) -> tuple[bool, None]:
+        state["n"] = (state.get("n") or 0) + 1
+        return True, None
+
+    with patch.object(gates, "_persist_maint_state_locked", _slow_persist):
+        await asyncio.gather(*[
+            gates._amutate_maint_state("角色", _mutator) for _ in range(8)
+        ])
+
+    assert max_inflight == 1, (
+        f"同一目标文件出现 {max_inflight} 个并发写者——os.replace 会在 Windows 上"
+        "报 PermissionError(WinError 5)"
+    )
+    assert gates._maint_state["角色"]["n"] == 8
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_concurrent_read_modify_write_loses_no_update(clean_state):
+    """The whole read-modify-write must be atomic, not just the disk write."""
+    def _mutator(state: dict) -> tuple[bool, None]:
+        # 读 → 慢 → 写：无锁时两个写者都会读到同一个旧值，其中一个的 +1 被吞掉。
+        seen = state.get("review_fail_attempts") or 0
+        time.sleep(0.005)
+        state["review_fail_attempts"] = seen + 1
+        return True, None
+
+    with patch.object(gates, "_persist_maint_state_locked", MagicMock()):
+        await asyncio.gather(*[
+            gates._amutate_maint_state("角色", _mutator) for _ in range(10)
+        ])
+
+    assert gates._maint_state["角色"]["review_fail_attempts"] == 10, (
+        "RMW 没有整段串行化：有写者读到了别人已经改过之前的旧值，+1 被吞"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_concurrent_real_writes_produce_no_write_errors(clean_state, tmp_path, monkeypatch):
+    """Real fsync+replace under concurrency must not raise (WinError 5 regression)."""
+    target = tmp_path / "idle_maintenance_state.json"
+    monkeypatch.setattr(gates, "_maint_state_path", lambda: str(target))
+
+    errors: list[BaseException] = []
+    real_persist = gates._persist_maint_state_locked
+
+    def _watch_persist():
+        # _mutate_maint_state_locked 会把写盘异常收在临界区里只告警，所以这里自己
+        # 把异常记下来再放行，否则并发 os.replace 失败会被静静吞掉、断言空过。
+        try:
+            real_persist()
+        except BaseException as exc:  # noqa: BLE001 - 记录后原样放行
+            errors.append(exc)
+            raise
+
+    def _mutator(index: int, state: dict) -> tuple[bool, None]:
+        state[f"k{index}"] = index
+        return True, None
+
+    with patch.object(gates, "_persist_maint_state_locked", _watch_persist):
+        await asyncio.gather(*[
+            gates._amutate_maint_state("角色", lambda st, i=i: _mutator(i, st))
+            for i in range(20)
+        ])
+
+    assert errors == [], f"并发落盘报错（Windows 上典型为 PermissionError）: {errors}"
+    landed = json.loads(target.read_text(encoding="utf-8"))
+    assert landed == gates._maint_state, "最后落地的内容与内存态不一致（落地顺序反转）"
+
+
+# ── 2. 不无脑落盘：外层快筛 + mutator 的 dirty 约定，两层各自有牙 ────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_clear_review_clean_does_not_even_switch_threads_when_flag_absent(clean_state):
+    """No flag → no worker thread at all, not merely no disk write."""
+    clean_state["角色"] = {"review_clean": False}
+
+    real_to_thread = asyncio.to_thread
+    with patch.object(gates.asyncio, "to_thread", wraps=real_to_thread) as thread_spy, \
+         patch.object(gates, "_mutate_maint_state_locked") as locked_spy, \
+         patch.object(gates, "_persist_maint_state_locked", MagicMock()) as persist:
+        await gates._aclear_review_clean("角色")
+
+    # 断言"连线程都没切"，而不是只断言"没落盘"：只留 mutator 里的 dirty 返回、
+    # 删掉 _aclear_review_clean 的锁外快筛，落盘次数照样是 0，那样的断言会空过。
+    assert thread_spy.call_count == 0, "标记本来就是 False，却仍然切了一次 worker 线程"
+    assert locked_spy.call_count == 0
+    assert persist.call_count == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_clear_review_clean_does_persist_when_flag_is_set(clean_state):
+    """Dual of the skip test: a set flag must actually go through the entry point."""
+    clean_state["角色"] = {"review_clean": True}
+
+    real_to_thread = asyncio.to_thread
+    with patch.object(gates.asyncio, "to_thread", wraps=real_to_thread) as thread_spy, \
+         patch.object(gates, "_persist_maint_state_locked", MagicMock()) as persist:
+        await gates._aclear_review_clean("角色")
+
+    assert thread_spy.call_count == 1
+    assert persist.call_count == 1
+    assert clean_state["角色"]["review_clean"] is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_clear_compress_backup_failure_does_not_even_switch_threads_when_backoff_empty(
+    clean_state,
+):
+    """Dual of the review_clean skip test — the backoff-clear path needs the same fast filter.
+
+    Its caller ``_on_compress_done`` runs on every successful main-path
+    compression and may already be holding the settle lock (/renew, /settle),
+    where its own docstring promises not to block. The counter is empty almost
+    always, so paying a default-executor hop each time is exactly what the
+    lock-free pre-check exists to avoid.
+    """
+    clean_state["角色"] = {"compress_backup_fail_attempts": 0, "compress_backup_fail_fp": None}
+
+    real_to_thread = asyncio.to_thread
+    with patch.object(gates.asyncio, "to_thread", wraps=real_to_thread) as thread_spy, \
+         patch.object(gates, "_mutate_maint_state_locked") as locked_spy, \
+         patch.object(gates, "_persist_maint_state_locked", MagicMock()) as persist:
+        await review._clear_compress_backup_failure("角色")
+
+    # 同样断言"连线程都没切"：只留 mutator 里的 dirty 返回时落盘次数照样是 0，
+    # 那种断言抓不到锁外快筛被删掉。
+    assert thread_spy.call_count == 0, "退避计数本来就是空的，却仍然切了一次 worker 线程"
+    assert locked_spy.call_count == 0
+    assert persist.call_count == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_clear_compress_backup_failure_does_persist_when_backoff_present(clean_state):
+    """Dual of the skip test: a non-empty backoff must actually go through the entry point."""
+    clean_state["角色"] = {"compress_backup_fail_attempts": 2, "compress_backup_fail_fp": "fp"}
+
+    real_to_thread = asyncio.to_thread
+    with patch.object(gates.asyncio, "to_thread", wraps=real_to_thread) as thread_spy, \
+         patch.object(gates, "_persist_maint_state_locked", MagicMock()) as persist:
+        await review._clear_compress_backup_failure("角色")
+
+    assert thread_spy.call_count == 1
+    assert persist.call_count == 1
+    assert clean_state["角色"]["compress_backup_fail_attempts"] == 0
+    assert clean_state["角色"]["compress_backup_fail_fp"] is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_mutator_dirty_recheck_skips_the_redundant_second_clear(clean_state):
+    """The in-mutator dirty re-check must be pinned independently of the outer fast filter.
+
+    Driven straight through ``_amutate_maint_state`` on purpose: going via
+    ``_aclear_review_clean`` would let the fast filter absorb the second call, so
+    the assertion would pass even with the re-check deleted.
+    """
+    clean_state["角色"] = {"review_clean": True}
+
+    with patch.object(gates, "_persist_maint_state_locked", MagicMock()) as persist:
+        await gates._amutate_maint_state("角色", gates._mutate_clear_review_clean)
+        assert persist.call_count == 1, "标记为 True 时应当落盘一次"
+        # 标记已经是 False：mutator 必须返回 dirty=False，锁内不再落盘。
+        await gates._amutate_maint_state("角色", gates._mutate_clear_review_clean)
+
+    assert persist.call_count == 1, (
+        f"标记本来就是 False 却又落盘了（累计 {persist.call_count} 次），"
+        "mutator 的 dirty 复查没生效"
+    )
+    assert clean_state["角色"]["review_clean"] is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_compress_backup_mutator_dirty_recheck_skips_the_redundant_second_clear(clean_state):
+    """Same two-layer split for the compress-backup mutator's own dirty re-check.
+
+    Also driven straight through ``_amutate_maint_state``: routing via
+    ``_clear_compress_backup_failure`` lets the lock-free fast filter absorb the
+    second call, which would leave the in-mutator guard unpinned.
+    """
+    clean_state["角色"] = {"compress_backup_fail_attempts": 2, "compress_backup_fail_fp": "fp"}
+
+    with patch.object(gates, "_persist_maint_state_locked", MagicMock()) as persist:
+        await gates._amutate_maint_state("角色", review._mutate_clear_compress_backup_failure)
+        assert persist.call_count == 1, "退避计数非空时应当落盘一次"
+        # 计数已经清空：mutator 必须返回 dirty=False，锁内不再落盘。
+        await gates._amutate_maint_state("角色", review._mutate_clear_compress_backup_failure)
+
+    assert persist.call_count == 1, (
+        f"退避计数本来就是空的却又落盘了（累计 {persist.call_count} 次），"
+        "mutator 的 dirty 复查没生效"
+    )
+    assert clean_state["角色"]["compress_backup_fail_attempts"] == 0
+    assert clean_state["角色"]["compress_backup_fail_fp"] is None
+
+
+# ── 3. 读侧只读视图 + 单一写入口的结构守卫 ───────────────────────────
+
+
+@pytest.mark.unit
+def test_maint_view_is_read_only(clean_state):
+    """_maint_view must hand back a mapping that cannot be written through."""
+    clean_state["角色"] = {"review_clean": True}
+    view = gates._maint_view("角色")
+
+    assert view["review_clean"] is True
+    with pytest.raises(TypeError):
+        view["review_clean"] = False
+    assert not hasattr(view, "setdefault")
+    assert not hasattr(view, "pop")
+    # 缺失角色也必须给只读视图，不能返回一个新建的可写 dict 让调用方误以为改得动。
+    with pytest.raises(TypeError):
+        gates._maint_view("不存在的角色")["x"] = 1
+
+
+@pytest.mark.unit
+def test_maint_view_is_a_snapshot_not_a_live_proxy(clean_state):
+    """The view must be detached from the live sub-dict, so it is safe to iterate.
+
+    A proxy over the live entry stays correct for single ``.get()`` reads (those
+    are atomic under the GIL) but breaks the moment a caller iterates it, because
+    a mutator running in a worker thread can add a key at any point — CPython
+    raises "dictionary changed size during iteration". Copying up front costs one
+    C-level ``dict()`` over a handful of scalars.
+    """
+    entry = clean_state.setdefault("角色", {})
+    entry["review_clean"] = True
+    view = gates._maint_view("角色")
+
+    # 模拟读者还攥着 view 时，worker 线程里的 mutator 往活 sub-dict 里加了新键。
+    entry["review_fail_attempts"] = 1
+    assert "review_fail_attempts" not in view, "视图跟着活 sub-dict 变了，不是快照"
+    assert dict(view) == {"review_clean": True}
+
+    iterator = iter(view)
+    next(iterator)
+    entry["compress_backup_fail_attempts"] = 1
+    assert list(iterator) == [], "迭代期间被并发写打断（活代理会抛 RuntimeError）"
+
+
+@pytest.mark.unit
+def test_gates_exposes_no_second_save_helper():
+    """The unlocked ``_asave_maint_state`` must be gone, not merely unused."""
+    assert not hasattr(gates, "_asave_maint_state"), (
+        "无锁的整体覆盖写 helper 还在——只要它存在，新写点就会重新绕过单一入口"
+    )
+    from app import memory_server
+    assert not hasattr(memory_server, "_asave_maint_state")
+
+
+def _iter_app_modules():
+    for path in sorted((REPO_ROOT / "app").rglob("*.py")):
+        if path == GATES_PATH:
+            continue
+        yield path
+
+
+@pytest.mark.unit
+def test_no_module_outside_gates_names_the_maint_state_container():
+    """No module under app/ other than gates.py may name ``_maint_state``.
+
+    This is deliberately narrower than "no write site bypasses the single entry
+    point": an AST scan cannot see ``st = <mutable handle>; st['x'] = 1`` split
+    across two statements. What actually seals field writes is ``_maint_view``
+    returning a ``MappingProxyType`` over a copy of a scalar-only sub-dict (see
+    ``test_maint_view_is_read_only`` and ``test_maint_view_is_a_snapshot_not_a_live_proxy``)
+    — a shallow snapshot IS a real seal here.
+    This test closes the remaining hole: the only way back to a mutable handle
+    is to name the container again, and naming it anywhere outside gates.py
+    fails here. Module list is discovered by walking app/, so a new module
+    cannot slip past by not being listed.
+    """
+    offenders: list[str] = []
+    for path in _iter_app_modules():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            named = (
+                (isinstance(node, ast.Attribute) and node.attr == "_maint_state")
+                or (isinstance(node, ast.Name) and node.id == "_maint_state")
+                or (isinstance(node, ast.alias)
+                    and node.name in ("_maint_state", "_asave_maint_state"))
+            )
+            if named:
+                line = getattr(node, "lineno", "?")
+                offenders.append(f"{path.relative_to(REPO_ROOT).as_posix()}:{line}")
+
+    assert offenders == [], (
+        "这些位置重新拿到了维护状态容器本身；请改走 gates._maint_view（读）/ "
+        f"gates._amutate_maint_state（写）: {offenders}"
+    )
+
+
+def _dotted_name(node) -> str:
+    """Flatten a Name/Attribute expression to its dotted source text ('' if it is neither)."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        base = _dotted_name(node.value)
+        return f"{base}.{node.attr}" if base else ""
+    return ""
+
+
+def _collect_mutate_defs() -> tuple[dict[str, str], dict[str, str]]:
+    """Map every ``_mutate_*`` def under app/memory_server/ to 'path:line' — (sync, async)."""
+    sync_defs: dict[str, str] = {}
+    async_defs: dict[str, str] = {}
+    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if not node.name.startswith("_mutate_"):
+                continue
+            where = f"{path.relative_to(REPO_ROOT).as_posix()}:{node.lineno} {node.name}"
+            bucket = async_defs if isinstance(node, ast.AsyncFunctionDef) else sync_defs
+            bucket[node.name] = where
+    return sync_defs, async_defs
+
+
+def _collect_mutator_call_sites() -> tuple[list[str], list[str]]:
+    """Read the mutator argument off every ``_amutate_maint_state`` call — (names, unresolved)."""
+    names: list[str] = []
+    unresolved: list[str] = []
+    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if _dotted_name(node.func).split(".")[-1] != "_amutate_maint_state":
+                continue
+            where = f"{path.relative_to(REPO_ROOT).as_posix()}:{node.lineno}"
+            arg = node.args[1] if len(node.args) >= 2 else None
+            # functools.partial(mutator, ...) 是本包绑定额外入参的唯一写法，剥一层
+            # 拿到真正的 mutator。
+            if isinstance(arg, ast.Call) and _dotted_name(arg.func).split(".")[-1] == "partial":
+                arg = arg.args[0] if arg.args else None
+            resolved = _dotted_name(arg).split(".")[-1] if arg is not None else ""
+            if resolved:
+                names.append(resolved)
+            else:
+                unresolved.append(where)
+    return names, unresolved
+
+
+@pytest.mark.unit
+def test_every_mutator_handed_to_the_write_entry_point_is_synchronous():
+    """Mutators must stay ``def``, never ``async def``.
+
+    A synchronous mutator is what makes "await inside the critical section" and
+    "grab a second lock inside the critical section" impossible to even write —
+    the whole reentrancy argument rests on it.
+
+    Scope comes from the ``_amutate_maint_state`` call sites themselves plus the
+    ``_mutate_*`` defs of this package, never from a hand-kept list nor from a
+    ``found >= N`` floor: an unrelated subsystem elsewhere under ``app/`` cannot
+    fail this file, and the two halves keep each other honest — a call site whose
+    argument is not a discovered ``_mutate_*`` def shows up as ``unknown``, so the
+    discovery cannot silently stop finding things.
+    """
+    sync_defs, async_defs = _collect_mutate_defs()
+    call_site_names, unresolved = _collect_mutator_call_sites()
+
+    assert unresolved == [], (
+        f"这些写入口调用点的 mutator 实参不是具名函数（lambda / 闭包 / 变量）: {unresolved}"
+    )
+    assert call_site_names, (
+        "在 app/memory_server/ 里一个 _amutate_maint_state 调用点都没扫到——"
+        "解析规则已经失效，本用例形同虚设"
+    )
+    unknown = sorted({n for n in call_site_names if n not in sync_defs and n not in async_defs})
+    assert unknown == [], (
+        f"这些 mutator 实参在包内找不到 _mutate_* 定义，自动发现覆盖不到它们: {unknown}"
+    )
+    assert async_defs == {}, f"mutator 必须是同步函数: {sorted(async_defs.values())}"
+
+
+# ── 4. 载入时的整体重绑定必须与 mutator 互斥 ─────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_load_rebind_is_mutually_exclusive_with_mutators(tmp_path, monkeypatch, clean_state):
+    """``_aload_maint_state`` rebinds the whole map, so it must wait for the lock."""
+    monkeypatch.setattr(
+        gates, "_maint_state_path", lambda: str(tmp_path / "idle_maintenance_state.json"),
+    )
+
+    gates._maint_state_lock.acquire()
+    try:
+        task = asyncio.create_task(gates._aload_maint_state())
+        await asyncio.sleep(0.1)
+        assert not task.done(), (
+            "有 mutator 持锁时 _aload_maint_state 仍然完成了重绑定——它可能把某个"
+            "mutator 正在改的 sub-dict 变成孤儿"
+        )
+    finally:
+        gates._maint_state_lock.release()
+
+    await asyncio.wait_for(task, timeout=5)
+    assert gates._maint_state == {}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_mutator_takes_the_sub_dict_inside_the_lock(clean_state, monkeypatch):
+    """The sub-dict must be fetched after the lock, or a rebind orphans the mutation.
+
+    Recreates the exact window: a writer is already queued on the lock when
+    ``_aload_maint_state`` swaps the whole map. Fetching the sub-dict before the
+    lock hands the mutator an entry that has fallen off the live map — the change
+    is neither persisted nor visible to later reads.
+    """
+    old_map = gates._maint_state
+    old_map["角色"] = {"review_fail_attempts": 7}
+    started = threading.Event()
+
+    def _mutator(state: dict) -> tuple[bool, None]:
+        started.set()
+        state["review_fail_attempts"] = (state.get("review_fail_attempts") or 0) + 1
+        return True, None
+
+    new_map = {"角色": {"review_fail_attempts": 1}}
+    with patch.object(gates, "_persist_maint_state_locked", MagicMock()):
+        gates._maint_state_lock.acquire()
+        try:
+            task = asyncio.create_task(gates._amutate_maint_state("角色", _mutator))
+            await asyncio.sleep(0.05)
+            assert not started.is_set(), "锁被占用时 mutator 就跑了"
+            # 直接赋值模拟 _aload_maint_state 的整体重绑定；不走
+            # _rebind_maint_state_locked 是因为它要拿本用例正持着的那把锁。
+            monkeypatch.setattr(gates, "_maint_state", new_map)
+        finally:
+            gates._maint_state_lock.release()
+        await asyncio.wait_for(task, timeout=5)
+
+    assert new_map["角色"]["review_fail_attempts"] == 2, (
+        "改动落在了重绑定前那份 dict 上（孤儿条目），活着的 map 没被更新"
+    )
+    assert old_map["角色"]["review_fail_attempts"] == 7
+
+
+# ── 5. 取消路径：to_thread 交出去就取消不掉，锁不能泄漏 ───────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cancelling_the_awaiting_coroutine_still_releases_the_lock(clean_state):
+    """Cancelling the awaiter must not leave the lock held or the write half-done."""
+    started = threading.Event()
+
+    def _slow_persist():
+        started.set()
+        time.sleep(0.2)
+
+    def _mutator(state: dict) -> tuple[bool, None]:
+        state["review_clean"] = True
+        return True, None
+
+    with patch.object(gates, "_persist_maint_state_locked", _slow_persist):
+        task = asyncio.create_task(gates._amutate_maint_state("角色", _mutator))
+        await asyncio.to_thread(started.wait, 5)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        # to_thread 的 worker 取消不掉，它会跑完并释放锁。等一个后续写者拿到锁，
+        # 就同时证明了「锁没泄漏成永久持有」和「不需要 shield」。
+        with patch.object(gates, "_persist_maint_state_locked", MagicMock()):
+            await asyncio.wait_for(
+                gates._amutate_maint_state("角色", _mutator), timeout=5,
+            )
+
+    assert gates._maint_state["角色"]["review_clean"] is True
+    assert not gates._maint_state_lock.locked()
+
+
+# ── 6. 「清退避 + 断掉输出耗尽序列」必须落在同一次写里 ────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_generic_failure_lands_both_updates_in_one_write(clean_state):
+    """The failure bump and the exhaustion-streak reset must share one snapshot."""
+    from app import memory_server
+
+    name = "同一次写"
+    clean_state[name] = {
+        "review_output_exhaustion_attempts": 2,
+        "review_output_exhaustion_min_context_tokens": 1000,
+        "review_output_exhaustion_blocked": False,
+    }
+    fake_mgr = MagicMock()
+    fake_mgr.review_history = MagicMock()
+
+    landed: list[dict] = []
+
+    def _record_persist():
+        landed.append(copy.deepcopy(gates._maint_state))
+
+    async def _failed(*_a, **_k):
+        return ("failed", None)
+
+    fake_mgr.review_history = _failed
+    with patch.object(memory_server.runtime, "recent_history_manager", fake_mgr), \
+         patch.object(gates, "_persist_maint_state_locked", _record_persist):
+        await memory_server._run_review_in_background(name, [], asyncio.Event())
+
+    assert len(landed) == 1, (
+        f"'failed' 分支落了 {len(landed)} 次盘；清输出耗尽序列与 bump 退避被拆开了，"
+        "中间会留下「清了但没写」的窗口"
+    )
+    snapshot = landed[0][name]
+    assert snapshot["review_fail_attempts"] == 1
+    assert snapshot["review_output_exhaustion_attempts"] == 0
+    assert snapshot["review_output_exhaustion_min_context_tokens"] is None
+    assert snapshot["review_output_exhaustion_blocked"] is False
+
+
+# ── 7. 锁内复查：dead-letter 判定的三条分支 ──────────────────────────
+# 直接同步调 mutator，不经 _amutate_maint_state：这两个 mutator 的价值全在「判定
+# 被搬进临界区」，而判定结果只从返回值出来。经调用点驱动的话，锁外快筛（attempts
+# 不足时压根不进 mutator）会把 'proceed' 早退分支整个遮住，断言就空过了。
+
+_BACKOFF_RECHECK_MUTATORS = [
+    pytest.param(
+        review._mutate_reset_review_fail_backoff,
+        "review_fail_attempts",
+        "review_fail_fp",
+        id="review",
+    ),
+    pytest.param(
+        review._mutate_reset_compress_backup_backoff,
+        "compress_backup_fail_attempts",
+        "compress_backup_fail_fp",
+        id="compress-backup",
+    ),
+]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(("mutator", "attempts_key", "fp_key"), _BACKOFF_RECHECK_MUTATORS)
+def test_backoff_recheck_proceeds_when_another_writer_already_cleared_the_counter(
+    mutator, attempts_key, fp_key,
+):
+    """Under lock the counter may already be below threshold — that must proceed, not dead-letter.
+
+    The caller only reads the counter outside the lock; by the time the mutator
+    runs, a successful review (or a successful compression) may have zeroed it.
+    The fingerprint deliberately matches, so dropping this early return turns the
+    call into a dead-letter and skips a spawn that should have gone ahead.
+    """
+    state = {attempts_key: 1, fp_key: "same-fp"}
+
+    assert mutator("same-fp", 3, state) == (False, "proceed")
+    # 早退不写任何字段：dirty=False 时 _mutate_maint_state_locked 会跳过落盘，
+    # 这里要确认它跳过的确实是一次「什么都没改」的调用。
+    assert state == {attempts_key: 1, fp_key: "same-fp"}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(("mutator", "attempts_key", "fp_key"), _BACKOFF_RECHECK_MUTATORS)
+def test_backoff_recheck_dead_letters_when_the_input_is_unchanged(
+    mutator, attempts_key, fp_key,
+):
+    """Budget exhausted on an unchanged input → dead-letter, and the counter is preserved."""
+    state = {attempts_key: 3, fp_key: "same-fp"}
+
+    assert mutator("same-fp", 3, state) == (False, "dead_letter")
+    assert state == {attempts_key: 3, fp_key: "same-fp"}, (
+        "dead-letter 分支改了状态——退避计数必须原样留着，否则下一轮又白试一次"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(("mutator", "attempts_key", "fp_key"), _BACKOFF_RECHECK_MUTATORS)
+def test_backoff_recheck_expires_the_budget_when_the_input_changed(
+    mutator, attempts_key, fp_key,
+):
+    """A changed input fingerprint expires the old budget: reset, mark dirty, proceed."""
+    state = {attempts_key: 3, fp_key: "old-fp"}
+
+    assert mutator("new-fp", 3, state) == (True, "proceed")
+    assert state[attempts_key] == 0
+    assert state[fp_key] is None
+
+
+# ── 8. 落盘失败必须被收在临界区里（承重语义，不是疏忽）─────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_persist_failure_is_swallowed_and_memory_state_still_updated(clean_state):
+    """A failed disk write must not propagate out of the write entry point.
+
+    /cache, /process, /renew and /settle all call into this path inside their
+    request try-block. Letting a transient write error escape would turn the
+    whole round into ``{"status": "error"}``, which in turn stalls cross_server's
+    ``last_synced_index`` — far worse than a maintenance flag that is only on
+    disk one round late. The in-memory update and the caller's return value must
+    survive.
+    """
+    def _boom():
+        raise OSError("disk full")
+
+    def _mutator(state: dict) -> tuple[bool, str]:
+        state["review_clean"] = True
+        return True, "carried-out"
+
+    fake_logger = MagicMock()
+    with patch.object(gates, "_persist_maint_state_locked", _boom), \
+         patch.object(gates, "logger", fake_logger):
+        value = await gates._amutate_maint_state("角色", _mutator)
+
+    assert value == "carried-out", "落盘失败时 mutator 的返回值没有原样带出来"
+    assert clean_state["角色"]["review_clean"] is True, "落盘失败把内存态也回滚了"
+    assert fake_logger.warning.call_count == 1, (
+        "落盘失败被完全静默——吞异常的前提是至少留一条告警"
+    )
+    assert not gates._maint_state_lock.locked(), "落盘抛异常后锁没释放"

--- a/tests/unit/test_memory_maint_state_lock.py
+++ b/tests/unit/test_memory_maint_state_lock.py
@@ -692,3 +692,65 @@ async def test_persist_failure_is_swallowed_and_memory_state_still_updated(clean
         "落盘失败被完全静默——吞异常的前提是至少留一条告警"
     )
     assert not gates._maint_state_lock.locked(), "落盘抛异常后锁没释放"
+
+
+# ── Gate 6a recovery: the in-lock recheck ───────────────────────────────
+# 恢复判定必须在锁外做（token 计数是 async，进不了同步 mutator），所以锁内要复查它依赖的
+# 那份输入还在不在。否则另一个后台 review 在那次 await 期间刚 armed 的新断路器会被抹掉，
+# 那条已经证明压不动的 context 又被放行重烧一轮。
+
+
+@pytest.mark.unit
+def test_gate6a_recovery_clears_when_the_observed_breaker_is_still_current() -> None:
+    """The Gate 6a mutator clears the breaker when nobody armed a newer one."""
+    state = {
+        'review_output_exhaustion_attempts': 2,
+        'review_output_exhaustion_min_context_tokens': 1000,
+        'review_output_exhaustion_blocked': True,
+    }
+
+    dirty, value = review._mutate_clear_output_exhaustion(
+        state, seen_attempts=2, seen_min_tokens=1000
+    )
+
+    assert (dirty, value) == (True, None)
+    assert state['review_output_exhaustion_attempts'] == 0
+    assert state['review_output_exhaustion_min_context_tokens'] is None
+    assert state['review_output_exhaustion_blocked'] is False
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("newer_state", "what_changed"),
+    [
+        (
+            {
+                'review_output_exhaustion_attempts': 2,
+                'review_output_exhaustion_min_context_tokens': 4000,
+                'review_output_exhaustion_blocked': True,
+            },
+            "min_context_tokens",
+        ),
+        (
+            {
+                'review_output_exhaustion_attempts': 3,
+                'review_output_exhaustion_min_context_tokens': 1000,
+                'review_output_exhaustion_blocked': True,
+            },
+            "attempts",
+        ),
+    ],
+    ids=["newer-min-tokens", "newer-attempts"],
+)
+def test_gate6a_recovery_keeps_a_breaker_armed_by_a_concurrent_writer(
+    newer_state: dict, what_changed: str
+) -> None:
+    """A breaker armed while the async token count ran must survive the recovery clear."""
+    before = dict(newer_state)
+
+    dirty, value = review._mutate_clear_output_exhaustion(
+        newer_state, seen_attempts=2, seen_min_tokens=1000
+    )
+
+    assert (dirty, value) == (False, None), f"{what_changed} 变了就不该清零"
+    assert newer_state == before, "复查失败时一个字段都不许动"

--- a/tests/unit/test_memory_review_backoff.py
+++ b/tests/unit/test_memory_review_backoff.py
@@ -44,7 +44,7 @@ async def test_run_review_failed_bumps_backoff():
     cancel_event = asyncio.Event()  # 未置位 → 真失败
 
     with patch.object(memory_server.runtime, "recent_history_manager", fake_mgr), \
-         patch.object(memory_server.gates, "_asave_maint_state", AsyncMock()):
+         patch.object(memory_server.gates, "_persist_maint_state_locked", MagicMock()):
         await memory_server._run_review_in_background(name, snapshot, cancel_event)
 
     state = memory_server.gates._maint_state[name]
@@ -69,7 +69,7 @@ async def test_run_review_cancelled_does_not_bump():
     cancel_event.set()  # 模拟 cancel_correction 已置位
 
     with patch.object(memory_server.runtime, "recent_history_manager", fake_mgr), \
-         patch.object(memory_server.gates, "_asave_maint_state", AsyncMock()):
+         patch.object(memory_server.gates, "_persist_maint_state_locked", MagicMock()):
         await memory_server._run_review_in_background(name, snapshot, cancel_event)
 
     state = memory_server.gates._maint_state.get(name, {})
@@ -95,7 +95,7 @@ async def test_run_review_patched_clears_backoff():
     cancel_event = asyncio.Event()
 
     with patch.object(memory_server.runtime, "recent_history_manager", fake_mgr), \
-         patch.object(memory_server.gates, "_asave_maint_state", AsyncMock()):
+         patch.object(memory_server.gates, "_persist_maint_state_locked", MagicMock()):
         await memory_server._run_review_in_background(name, snapshot, cancel_event)
 
     state = memory_server.gates._maint_state[name]
@@ -117,11 +117,14 @@ async def test_run_review_patched_save_failure_does_not_bump():
     fake_mgr.review_history = AsyncMock(return_value=("patched", [{"type": "ai", "content": "x"}]))
     cancel_event = asyncio.Event()
 
+    persist = MagicMock(side_effect=RuntimeError("disk full"))
     with patch.object(memory_server.runtime, "recent_history_manager", fake_mgr), \
-         patch.object(memory_server.gates, "_asave_maint_state",
-                      AsyncMock(side_effect=RuntimeError("disk full"))):
+         patch.object(memory_server.gates, "_persist_maint_state_locked", persist):
         await memory_server._run_review_in_background(name, snapshot, cancel_event)
 
+    # 先确认注入的失败真的被触发过——否则本用例会在「patched 分支根本不落盘」时
+    # 空过（断言弱于主张）。
+    assert persist.call_count >= 1, "patched 分支没有落盘，注入的写盘失败被绕过了"
     state = memory_server.gates._maint_state.get(name, {})
     assert state.get("review_fail_attempts", 0) == 0, (
         "成功 review 的 save 失败被外层 except 当成 review 失败 bump 了"
@@ -142,12 +145,14 @@ async def test_run_review_failed_save_failure_counts_once():
     fake_mgr.review_history = AsyncMock(return_value=("failed", None))
     cancel_event = asyncio.Event()
 
+    persist = MagicMock(side_effect=RuntimeError("disk full"))
     with patch.object(memory_server.runtime, "recent_history_manager", fake_mgr), \
-         patch.object(memory_server.gates, "_asave_maint_state",
-                      AsyncMock(side_effect=RuntimeError("disk full"))):
+         patch.object(memory_server.gates, "_persist_maint_state_locked", persist):
         await memory_server._run_review_in_background(name, snapshot, cancel_event)
 
-    # _record_review_failure 在落盘前已把内存计数 +1；外层 except 不再重复 bump
+    assert persist.call_count >= 1, "'failed' 分支没有落盘，注入的写盘失败被绕过了"
+    # _record_review_failure 的 mutator 在落盘前已把内存计数 +1；写盘失败被
+    # _mutate_maint_state_locked 收在临界区里（只告警不抛），外层 except 不会重复 bump
     assert memory_server.gates._maint_state.get(name, {}).get("review_fail_attempts", 0) == 1, (
         "save 失败导致 _record_review_failure 抛出后被外层 except 重复计数了"
     )
@@ -164,7 +169,7 @@ async def _drive_spawn(memory_server, name, history):
     with patch.object(memory_server.runtime, "recent_history_manager", fake_mgr), \
          patch.object(memory_server.gates, "_ais_review_enabled", AsyncMock(return_value=True)), \
          patch.object(memory_server.review, "_count_new_user_msgs_since_last_review", return_value=999), \
-         patch.object(memory_server.gates, "_asave_maint_state", AsyncMock()):
+         patch.object(memory_server.gates, "_persist_maint_state_locked", MagicMock()):
         await memory_server.maybe_spawn_review(name)
 
 
@@ -240,7 +245,7 @@ async def test_failed_resets_budget_on_input_change():
     cancel_event = asyncio.Event()
 
     with patch.object(memory_server.runtime, "recent_history_manager", fake_mgr), \
-         patch.object(memory_server.gates, "_asave_maint_state", AsyncMock()):
+         patch.object(memory_server.gates, "_persist_maint_state_locked", MagicMock()):
         for n in (8, 10, 12):  # 三段 tail fingerprint 互不相同的输入
             await memory_server._run_review_in_background(name, _history(n), cancel_event)
 
@@ -266,7 +271,7 @@ async def test_run_review_exception_bumps_backoff():
     cancel_event = asyncio.Event()
 
     with patch.object(memory_server.runtime, "recent_history_manager", fake_mgr), \
-         patch.object(memory_server.gates, "_asave_maint_state", AsyncMock()):
+         patch.object(memory_server.gates, "_persist_maint_state_locked", MagicMock()):
         await memory_server._run_review_in_background(name, snapshot, cancel_event)
 
     state = memory_server.gates._maint_state[name]
@@ -289,7 +294,7 @@ async def test_failed_same_input_accumulates_budget():
     cancel_event = asyncio.Event()
 
     with patch.object(memory_server.runtime, "recent_history_manager", fake_mgr), \
-         patch.object(memory_server.gates, "_asave_maint_state", AsyncMock()):
+         patch.object(memory_server.gates, "_persist_maint_state_locked", MagicMock()):
         for _ in range(3):
             await memory_server._run_review_in_background(name, same, cancel_event)
 

--- a/tests/unit/test_memory_review_output_exhaustion.py
+++ b/tests/unit/test_memory_review_output_exhaustion.py
@@ -101,7 +101,7 @@ async def test_three_output_exhaustions_block_across_growing_contexts():
 
     with (
         patch.object(memory_server.runtime, "recent_history_manager", fake_manager),
-        patch.object(memory_server.gates, "_asave_maint_state", AsyncMock()),
+        patch.object(memory_server.gates, "_persist_maint_state_locked", MagicMock()),
         patch(
             "memory.recent.review_context_token_count",
             side_effect=lambda rows: len(rows) * 100,
@@ -141,7 +141,7 @@ async def _drive_review_gate(memory_server, name: str, history: list) -> None:
             "_count_new_user_msgs_since_last_review",
             return_value=999,
         ),
-        patch.object(memory_server.gates, "_asave_maint_state", AsyncMock()),
+        patch.object(memory_server.gates, "_persist_maint_state_locked", MagicMock()),
         patch(
             "memory.recent.review_context_token_count",
             side_effect=lambda rows: len(rows) * 100,
@@ -202,7 +202,7 @@ async def test_success_clears_output_exhaustion_state():
 
     with (
         patch.object(memory_server.runtime, "recent_history_manager", fake_manager),
-        patch.object(memory_server.gates, "_asave_maint_state", AsyncMock()),
+        patch.object(memory_server.gates, "_persist_maint_state_locked", MagicMock()),
     ):
         await memory_server._run_review_in_background(
             name,
@@ -214,6 +214,54 @@ async def test_success_clears_output_exhaustion_state():
     assert state["review_output_exhaustion_attempts"] == 0
     assert state["review_output_exhaustion_min_context_tokens"] is None
     assert state["review_output_exhaustion_blocked"] is False
+    memory_server.gates._maint_state.pop(name, None)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_white_review_clears_output_exhaustion_state():
+    """Mirror of the patched-branch case: a white review must reset the breaker too.
+
+    A white review means the cutoff anchor no longer matches, i.e. the input has
+    actually changed, so the previous "context is too long to summarise" verdict
+    no longer describes the current input. Leaving the breaker armed would keep
+    blocking reviews on an input that was never the one that exhausted the
+    output budget.
+    """
+    from app import memory_server
+
+    name = "output-limit-white"
+    memory_server.gates._maint_state[name] = {
+        "review_output_exhaustion_attempts": 2,
+        "review_output_exhaustion_min_context_tokens": 1000,
+        "review_output_exhaustion_blocked": True,
+        "review_fail_attempts": 3,
+        "review_fail_fp": "old-fp",
+        "last_reviewed_cutoff_tail": "old-anchor",
+    }
+    fake_manager = MagicMock()
+    fake_manager.review_history = AsyncMock(return_value=("white", None))
+
+    with (
+        patch.object(memory_server.runtime, "recent_history_manager", fake_manager),
+        patch.object(memory_server.gates, "_persist_maint_state_locked", MagicMock()),
+    ):
+        await memory_server._run_review_in_background(
+            name,
+            _history(10),
+            asyncio.Event(),
+        )
+
+    state = memory_server.gates._maint_state[name]
+    assert state["review_output_exhaustion_attempts"] == 0
+    assert state["review_output_exhaustion_min_context_tokens"] is None
+    assert state["review_output_exhaustion_blocked"] is False
+    # 顺带钉住白 review 的既有语义：清锚点、清失败退避、故意不刷 last_review_ts
+    # （下轮 gate 4 用旧 ts 直接放行 + fingerprint=None 触发 gate 5 的 ∞ 通行）。
+    assert state["last_reviewed_cutoff_tail"] is None
+    assert state["review_fail_attempts"] == 0
+    assert state["review_fail_fp"] is None
+    assert "last_review_ts" not in state
     memory_server.gates._maint_state.pop(name, None)
 
 
@@ -233,7 +281,7 @@ async def test_generic_failure_breaks_output_exhaustion_streak():
 
     with (
         patch.object(memory_server.runtime, "recent_history_manager", fake_manager),
-        patch.object(memory_server.gates, "_asave_maint_state", AsyncMock()),
+        patch.object(memory_server.gates, "_persist_maint_state_locked", MagicMock()),
     ):
         await memory_server._run_review_in_background(
             name,

--- a/tests/unit/test_memory_review_output_exhaustion.py
+++ b/tests/unit/test_memory_review_output_exhaustion.py
@@ -124,7 +124,9 @@ async def test_three_output_exhaustions_block_across_growing_contexts():
     memory_server.gates._maint_state.pop(name, None)
 
 
-async def _drive_review_gate(memory_server, name: str, history: list) -> None:
+async def _drive_review_gate(
+    memory_server, name: str, history: list, token_count=None
+) -> None:
     fake_manager = MagicMock()
     fake_manager.aget_recent_history = AsyncMock(return_value=history)
     fake_manager.review_history = AsyncMock(return_value=("white", None))
@@ -144,7 +146,7 @@ async def _drive_review_gate(memory_server, name: str, history: list) -> None:
         patch.object(memory_server.gates, "_persist_maint_state_locked", MagicMock()),
         patch(
             "memory.recent.review_context_token_count",
-            side_effect=lambda rows: len(rows) * 100,
+            side_effect=token_count or (lambda rows: len(rows) * 100),
         ),
     ):
         await memory_server.maybe_spawn_review(name)
@@ -294,4 +296,52 @@ async def test_generic_failure_breaks_output_exhaustion_streak():
     assert state["review_output_exhaustion_min_context_tokens"] is None
     assert state["review_output_exhaustion_blocked"] is False
     assert state["review_fail_attempts"] == 1
+    memory_server.gates._maint_state.pop(name, None)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_recovery_that_loses_the_race_does_not_spawn_a_review():
+    """A breaker armed while the async token count ran must still block the spawn."""
+    # Gate 6a 的恢复判定只能在锁外做（review_context_token_count 是 async，进不了同步
+    # mutator），锁内复查会拒绝清零。但**拒绝清零还不够** —— 调用方必须跟着放弃本轮，
+    # 否则等于拿一个已经过期的判定绕过了刚 armed 的断路器，那条已经证明压不动的
+    # context 又被放行重烧一轮。这条钉的是调用点，不是 mutator 的返回值。
+    from app import memory_server
+    from config import MEMORY_REVIEW_OUTPUT_EXHAUSTION_MAX_ATTEMPTS
+
+    name = "output-limit-lost-race"
+    memory_server.correction_tasks.pop(name, None)
+    memory_server.gates._maint_state[name] = {
+        "review_output_exhaustion_attempts": (
+            MEMORY_REVIEW_OUTPUT_EXHAUSTION_MAX_ATTEMPTS
+        ),
+        "review_output_exhaustion_min_context_tokens": 1000,
+        "review_output_exhaustion_blocked": True,
+    }
+
+    def count_while_a_concurrent_writer_arms_a_newer_breaker(rows):
+        # 模拟另一个后台 review 在这次 async 计数期间又失败了一次，写下更新的断路器。
+        memory_server.gates._maint_state[name][
+            "review_output_exhaustion_min_context_tokens"
+        ] = 400
+        return len(rows) * 100
+
+    # 8 行 → 800 tokens，与**锁外观测到的** 1000 相比像是「context 已缩短、可以恢复」。
+    await _drive_review_gate(
+        memory_server,
+        name,
+        _history(8),
+        token_count=count_while_a_concurrent_writer_arms_a_newer_breaker,
+    )
+
+    assert name not in memory_server.correction_tasks, "恢复判定过期时不许 spawn"
+    state = memory_server.gates._maint_state[name]
+    assert state["review_output_exhaustion_min_context_tokens"] == 400, (
+        "并发写者刚 armed 的断路器必须留着"
+    )
+    assert state["review_output_exhaustion_attempts"] == (
+        MEMORY_REVIEW_OUTPUT_EXHAUSTION_MAX_ATTEMPTS
+    )
+    assert state["review_output_exhaustion_blocked"] is True
     memory_server.gates._maint_state.pop(name, None)

--- a/tests/unit/test_recent_compress_backup.py
+++ b/tests/unit/test_recent_compress_backup.py
@@ -48,7 +48,7 @@ async def test_on_compress_done_failure_spawns_backup():
     fake_mgr.compress_history = _slow_compress
 
     with patch.object(memory_server.runtime, "recent_history_manager", fake_mgr), \
-         patch.object(memory_server.gates, "_asave_maint_state", AsyncMock()):
+         patch.object(memory_server.gates, "_persist_maint_state_locked", MagicMock()):
         await memory_server._on_compress_done(name, snapshot, ok=False, detailed=False)
         task = memory_server.compress_backup_tasks.get(name)
         assert task is not None and not task.done()  # 起了后台兜底
@@ -67,7 +67,7 @@ async def test_on_compress_done_success_cancels_backup():
     task.done.return_value = False
     memory_server.compress_backup_tasks[name] = task
 
-    with patch.object(memory_server.gates, "_asave_maint_state", AsyncMock()):
+    with patch.object(memory_server.gates, "_persist_maint_state_locked", MagicMock()):
         await memory_server._on_compress_done(name, [], ok=True, detailed=False)
 
     task.cancel.assert_called_once()  # 主路径成功 → cancel 在跑的后台
@@ -89,7 +89,7 @@ async def test_on_compress_done_in_flight_guard():
     fake_mgr = MagicMock()
     fake_mgr.compress_history = AsyncMock(return_value=None)
     with patch.object(memory_server.runtime, "recent_history_manager", fake_mgr), \
-         patch.object(memory_server.gates, "_asave_maint_state", AsyncMock()):
+         patch.object(memory_server.gates, "_persist_maint_state_locked", MagicMock()):
         await memory_server._on_compress_done(name, _history(6), ok=False, detailed=False)
 
     # 同角色已有后台在跑 → 不重复起，仍是原 task
@@ -115,7 +115,7 @@ async def test_on_compress_done_deadletter_skips_spawn():
     fake_mgr = MagicMock()
     fake_mgr.enforce_hard_cap = AsyncMock()
     with patch.object(memory_server.runtime, "recent_history_manager", fake_mgr), \
-         patch.object(memory_server.gates, "_asave_maint_state", AsyncMock()):
+         patch.object(memory_server.gates, "_persist_maint_state_locked", MagicMock()):
         await memory_server._on_compress_done(name, snapshot, ok=False, detailed=False)
 
     # 连续失败 ≥ N 且输入未变 → dead-letter，不再起后台；但仍裁剪兜底
@@ -145,7 +145,7 @@ async def test_on_compress_done_deadletter_resets_when_input_changed():
     fake_mgr = MagicMock()
     fake_mgr.compress_history = _slow_compress
     with patch.object(memory_server.runtime, "recent_history_manager", fake_mgr), \
-         patch.object(memory_server.gates, "_asave_maint_state", AsyncMock()):
+         patch.object(memory_server.gates, "_persist_maint_state_locked", MagicMock()):
         await memory_server._on_compress_done(name, new_snapshot, ok=False, detailed=False)
         # 输入变了 → 复位放行，起了后台
         task = memory_server.compress_backup_tasks.get(name)
@@ -169,7 +169,7 @@ async def test_run_backup_compress_failure_bumps_backoff():
     fake_mgr.compress_history = AsyncMock(return_value=None)
     fake_mgr.enforce_hard_cap = AsyncMock()
     with patch.object(memory_server.runtime, "recent_history_manager", fake_mgr), \
-         patch.object(memory_server.gates, "_asave_maint_state", AsyncMock()):
+         patch.object(memory_server.gates, "_persist_maint_state_locked", MagicMock()):
         await memory_server._run_backup_compress(name, snapshot, False)
 
     state = memory_server.gates._maint_state[name]
@@ -191,7 +191,7 @@ async def test_run_backup_compress_merges_and_clears_backoff():
     fake_mgr.compress_history = AsyncMock(return_value=(SystemMessage(content="memo"), "memo"))
     fake_mgr.merge_backup_memo = AsyncMock(return_value="merged")
     with patch.object(memory_server.runtime, "recent_history_manager", fake_mgr), \
-         patch.object(memory_server.gates, "_asave_maint_state", AsyncMock()):
+         patch.object(memory_server.gates, "_persist_maint_state_locked", MagicMock()):
         await memory_server._run_backup_compress(name, snapshot, False)
 
     fake_mgr.merge_backup_memo.assert_awaited_once()  # 成功 → 合并写回


### PR DESCRIPTION

#2528 提议给 os.replace 加重试，不采纳（见 issue 评论）。但审计确认生产里**真的**有
「多写者并发 atomic_write_* 到同一个目标文件」——缺的是锁不是重试。这个 PR 收 gates 这处。

实测依据：5 线程 Barrier 对齐并发 atomic_write_text 打同一目标，1000 次写 345 次
PermissionError(WinError 5)；同机同目标把锁装回去 0/1000。

## 病灶

app/memory_server/gates.py 的 idle_maintenance_state.json 是本包唯一一个**不分角色的
进程级文件**，共享内存态 _maint_state 是裸的模块级 dict，_asave_maint_state 整体覆盖写、
**全程无锁**，10 个写点横跨 /cache /process /renew /settle 四个 handler、review 后台 task
和 compress 兜底 task。后果两层，第二层更重：

(a) 两个协程各自 to_thread → 两个 worker 线程同时 os.replace 同一个文件；
(b) 各自的 json.dumps 发生在不同时刻，而 os.replace 的落地顺序可以和 dumps 顺序**反过来**
    → 后落地的内容更旧，把对方刚写的退避计数 / review_clean 标记抹掉。

## 修法

唯一加锁写入口 gates._amutate_maint_state(name, mutator)：把「锁内取 sub-dict → 同步
mutator 改字段 → 落盘」整段丢进**一个** asyncio.to_thread，临界区由模块级 threading.Lock
保护。读侧走 _maint_view()，返回 MappingProxyType(dict(entry)) 的**快照**。
旧的无锁 _asave_maint_state 删除。

三个设计约束写进了代码注释：

- **mutator 强制同步**：这样「锁内 await」「锁内再取别的锁」在语法上就写不出来，
  临界区结构性地只剩纯 CPU + 一次落盘。故意不用 RLock（RLock 会让嵌套 RMW 的内层落盘
  把外层改了一半的状态写进磁盘）。
- **返回 (dirty, value)**：dirty=False 跳过落盘（_aclear_review_clean 每轮 /cache、
  /process 都调，标记本来是 False 时不该白付一次 fsync+replace）；value 用来把「锁内做出
  的判定」（dead-letter）带出来。
- **为什么 threading.Lock 而不是 asyncio.Lock**：本仓库写盘的既有范式就是它
  （memory/event_log.py 的 record_and_save 明写「绝不跨 await 持锁」）；而模块级
  asyncio.Lock 一旦真争用就绑定当时的 event loop，本仓库 pytest 是 asyncio_mode=auto +
  function-scope loop，第二个有争用的用例会直接 RuntimeError。
  取消安全也由此免费得到：整段临界区在一个 to_thread 里跑完，锁的 acquire/release 都在
  worker 线程内部，等它的协程被 cancel 时线程照样跑完、照样释放锁。

顺带修掉一个隐性耦合：原来 _run_review_in_background 的 'failed' 分支先清 output-exhaustion
改内存、再靠 _record_review_failure 的 save 顺带持久化 —— 拆成两次写会留下「清了但没写」
的窗口。现在两步并进同一个 mutator、同一次落盘。

## 一轮对抗性审提出 6 条，全部落地

审的价值在于**每条都附了变异证据**而不是「我觉得」：

1. **_clear_compress_backup_failure 丢了锁外快筛**，跟 _aclear_review_clean 不对偶。
   在意的理由：它的调用点 _on_compress_done(ok=True) 由 memory/recent.py 的
   _notify_compress_done 触发，而 /renew、/settle 是**持着 settle lock** 调 update_history
   的，该回调 docstring 自己写着 "must not block"。变异「删掉那个 mutator 的 dirty 守卫」
   → 61 passed 全绿，连「干净时不落盘」都没被钉住。
2. 两处「把 dead-letter 判定搬进 mutator」的加强项（自报的主要改进）一条测试都没有。
3. 被长篇论证为「承重」的吞异常语义没被钉住 —— 既有的两条 save-failure 用例还绿，
   是因为 mutator 在落盘**之前**就把内存改好了、异常又被外层 except Exception 吃掉。
4. AST 守卫扫的是 app/ 全量，将来任何无关子系统写个 async def _mutate_xxx 都会误挂；
   found >= 8 也是会漂移的魔数。重写成「从 _amutate_maint_state 的调用点解析实参名」，
   四条断言臂各被一种变异打中（async 定义 / 无关子系统 / lambda 实参 / 非 _mutate_ 前缀）。
5. _maint_view 返回活代理，对 .get() 安全但对迭代不安全。改成快照。
6. white 分支的 output-exhaustion 清理没被钉住（历史空白，顺手补）。

## 测试

新增 tests/unit/test_memory_maint_state_lock.py（23 条）+ 既有文件 20 处 patch 目标替换
（_asave_maint_state/AsyncMock → _persist_maint_state_locked/MagicMock）+ white 分支镜像用例。

变异验证共 23 处全部被抓，其中值得一提的两条：
- 「只把 persist 包进锁、RMW 留在锁外」这个最可能的半吊子修法 → 红 2 条；
- 真实并发 os.replace（指向 tmp_path 跑 20 次真 fsync+replace）在去掉锁之后直接报
  PermissionError —— 这是 WinError 5 的直接回归。

自查发现并修掉一条自己的弱测试：dirty 复查那条第一版用 asyncio.gather 并发驱动，
变异下**没红**（能否观测到取决于 worker 线程与后续协程的调度时序），改成直接连调两次。

## 回归报告

**改动**：gates.py 新增锁 + 唯一写入口 + 只读快照视图，删除 _asave_maint_state；
review.py 9 个写点改走单一入口（新增 9 个同步 mutator）、5 个读点改走 _maint_view；
包门面同步 re-export；新增 23 条专测，既有 3 个测试文件替换 patch 目标。

**必要性**：进程内唯一的全局状态文件，10 个写点全程无锁，既会并发 os.replace 撞车、
又会互相抹掉退避计数和 review_clean 标记（后者会让 review 熔断失效）。

**改动前 → 改动后**：
- 前：10 个写点各自「裸读 dict → 改 → 整体覆盖落盘」，无互斥。后：RMW 整段串行化，
  并发下最大并发落盘数 == 1，10 个并发写者的计数正好是 10（不丢更新）。
- 前：读点直接拿到可变 sub-dict。后：只读快照，误写抛 TypeError。
- 前：'failed' 分支的两处更新分两次写盘。后：并进同一次落盘。
- 未改动的行为：落盘失败仍被吞并只告警（与重构前 _asave_maint_state 一致，理由是让写盘
  抖动冒出去会把整轮请求变成 status=error、卡住 cross_server 的 last_synced_index）；
  各 gate 的判定语义不变。

**潜在回归**：
1. 每次写从「直接 await 落盘」变成「多一次 to_thread 交接」。两处热路径
   （_aclear_review_clean、_clear_compress_backup_failure）都保留了锁外快筛，标记为空时
   连线程都不切（有断言 to_thread.call_count == 0 钉住）。
2. 读点改成快照，读到的值可能比锁内新状态旧几毫秒。所有读点都是 advisory 的，mutator 在
   锁内会重新判定；这一点写进了 _maint_view 的 docstring。
3. mutator 必须同步，将来有人想在里面 await 会直接写不出来 —— 这是有意的约束，
   有 AST 守卫（从调用点解析实参名）钉住。
4. 临界区包含 json.dumps + fsync + replace。这个文件很小（每角色几个标量）。

## 验证

- 相关测试 52 passed 连跑 3 次；memory_server 相关 39 个测试文件 1108 passed / 14 skipped
- 全量 tests/unit：**8808 passed, 45 skipped**（253s，pytest 自身退出码 0）
- ruff check 通过；check_docstring_no_cjk.py --full 通过

Refs #2528

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 提升维护状态、评审退避及压缩备份状态的并发一致性，减少状态丢失、回滚或重复更新。
  * 优化失败重试、输出耗尽及死信处理，确保相关状态能够可靠恢复和持久化。
  * 持久化失败时保留内存状态并记录告警，避免影响后续操作。

* **Tests**
  * 新增并完善并发写入、取消任务、失败恢复及状态快照等回归测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->