### PR TITLE
fix(ci): 修两条 Windows 间歇性失败的既有测试（含一条产品侧真竞态）

### DIFF
--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -44,6 +44,32 @@ from ._shared import (
 _ATTACHED_TRANSPORT = object()
 
 
+# `error` 事件的致命性判定是一串子串匹配（'429' / '1008' / '503' / 'quota' ...）。它
+# 过去匹配在 `str(event['error'])` 上，也就是整个 dict 的 repr —— 里面回显着我们自己
+# 生成的客户端相关性 id（`event_user_item_<uuid4().hex>` 之类）。hex 的字符集是
+# 0-9a-f，'429' 这三个字符全在里面：32 位 hex 串里随机出现 '429' 的概率约 0.7%，
+# '1008' 约 0.04%，'503' 约 0.7%。撞上一次，一次普通的「这条事件被拒」就被误判成配额 /
+# 策略致命错误，直接 close() 掉整条 realtime 连接 —— 用户话说到一半，连接没了，而且
+# 无法复现。id 只是相关性标识，不携带任何分类信息，所以分类前先把它们剔干净。
+#
+# 只剔 id 字段，不动 message / code / type / param：`code: 1008`、`"HTTP 429"` 这些
+# 真信号一个不少。剔掉的字段照样进日志和 on_connection_error，诊断信息没有损失。
+def _is_correlation_key(key: str) -> bool:
+    lowered = key.lower()
+    return lowered == "id" or lowered.endswith("_id")
+
+
+def _error_classification_text(error: Any) -> str:
+    """Build the keyword-matching text for an ``error`` event, minus correlation ids."""
+    if isinstance(error, dict):
+        return " ".join(
+            str(value)
+            for key, value in error.items()
+            if value is not None and not _is_correlation_key(str(key))
+        )
+    return str(error or "")
+
+
 class RealtimeImagePayloadTooLargeError(RuntimeError):
     """A callback image cannot fit the provider's WebSocket frame limit."""
 
@@ -959,8 +985,14 @@ class _TransportMixin:
                     self._route_inject_rejection(err_event_id, error_msg)
                     self._response_arbiter.notify_error(err_event_id, error_msg)
 
+                    # 致命性判定只看语义字段，绝不看回显的 event_id（见
+                    # _error_classification_text 的注释）。日志、路由和
+                    # on_connection_error 继续用完整的 error_msg。
+                    classify_text = _error_classification_text(event.get('error'))
+                    classify_lower = classify_text.lower()
+
                     # 检测503过载错误，触发backpressure节流
-                    if '503' in error_msg or 'overloaded' in error_msg.lower():
+                    if '503' in classify_text or 'overloaded' in classify_lower:
                         self._is_throttled = True
                         self._throttle_until = time.time() + self._throttle_duration
                         self._server_busy_count += 1
@@ -970,19 +1002,17 @@ class _TransportMixin:
                             await self.on_status_message(json.dumps({"code": "SERVER_BUSY_THROTTLE"}))
                         continue
 
-                    error_msg_lower = error_msg.lower()
-
                     # Idle timeout — Qwen 约 25s 无操作断连
-                    if 'too long without operation' in error_msg_lower or 'idle' in error_msg_lower:
+                    if 'too long without operation' in classify_lower or 'idle' in classify_lower:
                         logger.warning("⏰ Idle timeout from API: %s", error_msg)
                         if self.on_connection_error:
                             await self.on_connection_error(json.dumps({"code": "API_IDLE_TIMEOUT", "details": {"msg": error_msg}}))
                         await self.close()
                         continue
 
-                    if ('欠费' in error_msg or 'standing' in error_msg_lower or 'time limit' in error_msg_lower or
-                        'policy violation' in error_msg_lower or '1008' in error_msg_lower or
-                        '429' in error_msg_lower or 'quota' in error_msg_lower or 'too many' in error_msg_lower):
+                    if ('欠费' in classify_text or 'standing' in classify_lower or 'time limit' in classify_lower or
+                        'policy violation' in classify_lower or '1008' in classify_lower or
+                        '429' in classify_lower or 'quota' in classify_lower or 'too many' in classify_lower):
                         if self.on_connection_error:
                             await self.on_connection_error(error_msg)
                         await self.close()

--- a/tests/atomic_read.py
+++ b/tests/atomic_read.py
@@ -1,0 +1,107 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Read an artifact that a background writer may be replacing right now.
+
+Production writes go through ``utils.file_utils.atomic_write_*``: stage a temp
+file, then ``os.replace`` it onto the target. On Windows that replace and a
+concurrent ``open()`` of the same target are mutually exclusive -- whoever
+loses gets ``PermissionError`` (WinError 5 / 32, surfaced to ``open()`` as
+errno 13). The writer side already backs off (see ``_replace_with_busy_retry``
+in ``utils/file_utils.py``); a test that reads the artifact while a
+``to_thread`` worker is persisting it needs the same courtesy, or it fails on a
+millisecond-wide window a few runs in a thousand -- which is what reddened CI
+run 30549810820 on an unrelated PR.
+
+``path.exists()`` is NOT a usable gate here: it can report True while the
+replace is still in flight, and the read right behind it still loses. The only
+reliable signal that the artifact is there is a read that actually succeeded.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+# 与写入侧同一个量级：撞上的是毫秒级窗口，不是长期占用。总预算保持在亚秒级，
+# 免得一个真的写不出来的用例要靠超时才失败。
+_RETRY_ATTEMPTS = 6
+_RETRY_BACKOFF_S = 0.005
+
+
+def read_text_tolerating_replace(
+    path: str | os.PathLike[str],
+    *,
+    encoding: str = "utf-8",
+    attempts: int = _RETRY_ATTEMPTS,
+    backoff: float = _RETRY_BACKOFF_S,
+) -> str:
+    """Read a file that a background thread may be atomically replacing.
+
+    The file must already exist; a missing file raises straight through. Only
+    the transient "the target is busy" refusal is retried, and the final
+    attempt re-raises the real error rather than a wrapped one.
+    """
+    target = Path(path)
+    for attempt in range(attempts):
+        try:
+            return target.read_text(encoding=encoding)
+        except PermissionError:
+            if attempt == attempts - 1:
+                raise
+        time.sleep(backoff)
+    raise AssertionError("unreachable")
+
+
+async def read_text_when_readable(
+    path: str | os.PathLike[str],
+    *,
+    encoding: str = "utf-8",
+    timeout: float = 5.0,
+    poll: float = 0.01,
+) -> str:
+    """Await until the artifact exists AND opens, then return its text.
+
+    Subsumes the "poll exists(), then read" idiom: a loaded CI runner needs
+    more than a fixed sleep just to hand the write off to its worker thread,
+    and existence alone does not mean readable.
+    """
+    target = Path(path)
+    deadline = time.monotonic() + timeout
+    last: OSError | None = None
+    while True:
+        try:
+            return target.read_text(encoding=encoding)
+        except (FileNotFoundError, PermissionError) as exc:
+            last = exc
+        if time.monotonic() >= deadline:
+            raise AssertionError(
+                f"{target} never became readable within {timeout}s (last: {last!r})"
+            )
+        await asyncio.sleep(poll)
+
+
+async def read_json_when_readable(
+    path: str | os.PathLike[str],
+    *,
+    encoding: str = "utf-8",
+    timeout: float = 5.0,
+    poll: float = 0.01,
+) -> Any:
+    """``read_text_when_readable`` plus a JSON parse."""
+    return json.loads(
+        await read_text_when_readable(path, encoding=encoding, timeout=timeout, poll=poll)
+    )

--- a/tests/unit/test_atomic_read.py
+++ b/tests/unit/test_atomic_read.py
@@ -1,0 +1,93 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Guards for the test-side reader that tolerates an in-flight atomic replace.
+
+The race these helpers exist for is Windows-only and millisecond-wide, so no
+test can trigger it on demand. Without these guards, "simplifying" either
+helper back to a plain read would look green everywhere and quietly restore the
+flake on Windows CI.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.atomic_read import (
+    read_json_when_readable,
+    read_text_tolerating_replace,
+    read_text_when_readable,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _fail_then_succeed(monkeypatch, failures: int, exc_factory):
+    """Make the first ``failures`` reads raise; count every attempt."""
+    real_read_text = Path.read_text
+    attempts: list[int] = []
+
+    def flaky(self, *args, **kwargs):
+        attempts.append(1)
+        if len(attempts) <= failures:
+            raise exc_factory()
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", flaky)
+    return attempts
+
+
+def test_sync_read_retries_a_busy_target_and_returns_the_content(tmp_path, monkeypatch):
+    target = tmp_path / "state.json"
+    target.write_text('{"v": 1}', encoding="utf-8")
+    attempts = _fail_then_succeed(monkeypatch, 2, lambda: PermissionError(13, "denied"))
+
+    assert read_text_tolerating_replace(target, backoff=0) == '{"v": 1}'
+    assert len(attempts) == 3
+
+
+def test_sync_read_surfaces_a_target_that_stays_locked(tmp_path, monkeypatch):
+    target = tmp_path / "state.json"
+    target.write_text("{}", encoding="utf-8")
+    attempts = _fail_then_succeed(monkeypatch, 99, lambda: PermissionError(13, "denied"))
+
+    with pytest.raises(PermissionError):
+        read_text_tolerating_replace(target, attempts=4, backoff=0)
+    assert len(attempts) == 4, "重试次数必须有硬上界，且最后一次原样抛出"
+
+
+def test_sync_read_does_not_swallow_a_missing_file(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        read_text_tolerating_replace(tmp_path / "never-written.json", backoff=0)
+
+
+@pytest.mark.asyncio
+async def test_async_read_waits_through_both_absence_and_a_busy_target(
+    tmp_path, monkeypatch
+):
+    # 这两种失败要一视同仁：文件还没被 replace 上来（FileNotFoundError），和文件
+    # 在盘上但此刻打不开（PermissionError）—— 后者正是 `exists()` 门守不住的那个。
+    target = tmp_path / "state.json"
+    target.write_text('{"v": 7}', encoding="utf-8")
+    errors = iter([FileNotFoundError(2, "nope"), PermissionError(13, "denied")])
+    attempts = _fail_then_succeed(monkeypatch, 2, lambda: next(errors))
+
+    assert await read_json_when_readable(target, poll=0) == {"v": 7}
+    assert len(attempts) == 3
+
+
+@pytest.mark.asyncio
+async def test_async_read_fails_loudly_when_the_artifact_never_shows_up(tmp_path):
+    with pytest.raises(AssertionError, match="never became readable"):
+        await read_text_when_readable(tmp_path / "never.json", timeout=0.05, poll=0.01)

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -203,6 +203,144 @@ def test_missing_temp_file_during_cleanup_is_tolerated(tmp_path, monkeypatch):
         atomic_write_json(target, {"v": 1})
 
 
+# ── Windows: the target is momentarily busy ─────────────────────────────
+
+
+def _busy_error(winerror: int) -> PermissionError:
+    """A PermissionError shaped like Windows' "the target is open elsewhere"."""
+    exc = PermissionError(13, "Access is denied")
+    exc.winerror = winerror
+    return exc
+
+
+class _SleepSpy:
+    """Stands in for ``file_utils.time``: records sleeps, proxies the rest.
+
+    Scoped to the module under test on purpose — patching the global
+    ``time.sleep`` would silently un-sleep every other thread alive in this
+    process for the duration of the test.
+    """
+
+    def __init__(self) -> None:
+        self.delays: list[float] = []
+
+    def __getattr__(self, name):
+        return getattr(time, name)
+
+    def sleep(self, delay: float) -> None:
+        self.delays.append(delay)
+
+
+def test_a_busy_target_is_retried_until_the_other_handle_goes_away(tmp_path, monkeypatch):
+    # Windows 独有的一段窗口：目标此刻被别的句柄打开时 os.replace 被拒（WinError
+    # 5/32）。制造它的不止杀软扫描和资源管理器预览 —— 本进程自己就够了，落盘跑在
+    # to_thread 的工作线程里，另一个线程正好在读同一个文件。窗口是毫秒级的，退避重试
+    # 之后这次写就该成功，而不是把一次瞬时冲突报成落盘失败。
+    target = tmp_path / "state.json"
+    atomic_write_json(target, {"v": 1})
+
+    real_replace = os.replace
+    attempts: list[str] = []
+    spy = _SleepSpy()
+
+    def busy_twice(src, dst):
+        attempts.append(src)
+        if len(attempts) == 1:
+            raise _busy_error(32)
+        if len(attempts) == 2:
+            raise _busy_error(5)
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(os, "replace", busy_twice)
+    monkeypatch.setattr(file_utils, "time", spy)
+
+    atomic_write_json(target, {"v": 2})
+
+    assert read_json(target) == {"v": 2}
+    assert len(attempts) == 3
+    assert spy.delays == [0.005, 0.01], "只在被拒之后退避，且必须递增"
+    assert _tmp_siblings(target) == []
+
+
+def test_a_target_that_stays_busy_raises_the_real_replace_error(tmp_path, monkeypatch):
+    # 重试的上界必须是硬的，而且用尽之后抛出来的要是 os.replace 那次真实的异常 ——
+    # 不是一个包装过的「重试失败」。目标被永久占着（只读、别的进程长期持有）时，行为
+    # 和加重试之前完全一样：抛错、旧内容不动、tmp 清掉，只是晚了 155ms。
+    target = tmp_path / "state.json"
+    atomic_write_json(target, {"v": 1})
+
+    attempts: list[str] = []
+    spy = _SleepSpy()
+
+    def always_busy(src, dst):
+        attempts.append(src)
+        raise _busy_error(32)
+
+    monkeypatch.setattr(os, "replace", always_busy)
+    monkeypatch.setattr(file_utils, "time", spy)
+
+    with pytest.raises(PermissionError) as excinfo:
+        atomic_write_json(target, {"v": 2})
+
+    assert excinfo.value.winerror == 32, "抛的必须是那次真实的 replace 异常"
+    assert "Access is denied" in str(excinfo.value)
+    assert len(attempts) == len(file_utils._REPLACE_RETRY_BACKOFF_S) + 1
+    assert spy.delays == list(file_utils._REPLACE_RETRY_BACKOFF_S)
+    assert sum(spy.delays) < 0.2, "重试预算必须留在亚秒级"
+    assert read_json(target) == {"v": 1}, "失败的写不许动到目标"
+    assert _tmp_siblings(target) == []
+
+
+@pytest.mark.parametrize(
+    "make_error",
+    [
+        pytest.param(lambda: _busy_error(2), id="another-winerror"),
+        pytest.param(lambda: OSError(28, "No space left on device"), id="no-winerror"),
+    ],
+)
+def test_only_the_busy_winerrors_are_retried(tmp_path, monkeypatch, make_error):
+    # 判据是 OS 给的错误码，不是消息文本。磁盘满、路径不存在这类错误一次都不重试；
+    # 非 Windows 平台的 OSError 根本没有 winerror 属性，于是整段退避在那里恒等于
+    # 「直接抛」—— 这条用例就是在任何平台上钉住这一点。
+    target = tmp_path / "state.json"
+    attempts: list[str] = []
+    spy = _SleepSpy()
+
+    def refuse(src, dst):
+        attempts.append(src)
+        raise make_error()
+
+    monkeypatch.setattr(os, "replace", refuse)
+    monkeypatch.setattr(file_utils, "time", spy)
+
+    with pytest.raises(OSError):
+        atomic_write_json(target, {"v": 1})
+
+    assert len(attempts) == 1, "非 busy 错误必须第一次就抛出来"
+    assert spy.delays == []
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows-only handle semantics")
+def test_windows_really_refuses_to_replace_a_target_held_open(tmp_path):
+    # 这条钉的是重试列表的**前提**：Windows 上「目标被打开着」到底报哪个码。哪天
+    # CPython 换了 open 的共享模式、或者系统换了码，这条会红，而不是让退避悄悄地
+    # 永远不触发。
+    target = tmp_path / "state.json"
+    atomic_write_json(target, {"v": 1})
+
+    fd, temp_path = tempfile.mkstemp(dir=str(tmp_path))
+    os.close(fd)
+    try:
+        with open(target, "r", encoding="utf-8"):
+            with pytest.raises(PermissionError) as excinfo:
+                os.replace(temp_path, target)
+    finally:
+        with suppress(OSError):
+            os.unlink(temp_path)
+
+    assert excinfo.value.winerror in file_utils._REPLACE_BUSY_WINERRORS
+
+
 def test_unserializable_payload_never_touches_the_target(tmp_path):
     # json.dumps 在 atomic_write_text 之前跑，所以连 tmp 都不该出现。
     target = tmp_path / "state.json"

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -320,6 +320,59 @@ def test_only_the_busy_winerrors_are_retried(tmp_path, monkeypatch, make_error):
     assert spy.delays == []
 
 
+@pytest.mark.asyncio
+async def test_the_backoff_never_sleeps_on_the_event_loop(tmp_path, monkeypatch):
+    # 二十多处 `async def` 在裸调同步的 atomic_write_*（memory/anti_repeat.py 与
+    # memory/user_directives.py 甚至是 per-turn 的，跟音频同在一条循环上）。在那里
+    # 睡 155ms 就是掐音频；scripts/check_async_blocking.py 也早就把 time.sleep 列为
+    # 禁止出现在 async 可达路径上的调用。上环调用者必须拿到改动前的行为：第一次
+    # busy 就抛，一次 sleep 都不许有。
+    target = tmp_path / "state.json"
+    attempts: list[str] = []
+    spy = _SleepSpy()
+
+    def always_busy(src, dst):
+        attempts.append(src)
+        raise _busy_error(32)
+
+    monkeypatch.setattr(os, "replace", always_busy)
+    monkeypatch.setattr(file_utils, "time", spy)
+
+    with pytest.raises(PermissionError):
+        atomic_write_json(target, {"v": 1})
+
+    assert len(attempts) == 1, "事件循环上不许重试"
+    assert spy.delays == [], "事件循环上一次 sleep 都不许有"
+    assert _tmp_siblings(target) == []
+
+
+@pytest.mark.asyncio
+async def test_a_worker_thread_still_gets_the_full_backoff(tmp_path, monkeypatch):
+    # 对偶面，也是本次 flake 修复真正落地的地方：制造 flake 的落盘全部跑在
+    # to_thread 的工作线程里，那里没有 running loop，退避必须原样生效。
+    target = tmp_path / "state.json"
+    atomic_write_json(target, {"v": 1})
+
+    real_replace = os.replace
+    attempts: list[str] = []
+    spy = _SleepSpy()
+
+    def busy_twice(src, dst):
+        attempts.append(src)
+        if len(attempts) <= 2:
+            raise _busy_error(32)
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(os, "replace", busy_twice)
+    monkeypatch.setattr(file_utils, "time", spy)
+
+    await asyncio.to_thread(atomic_write_json, target, {"v": 2})
+
+    assert read_json(target) == {"v": 2}
+    assert len(attempts) == 3
+    assert spy.delays == [0.005, 0.01]
+
+
 @pytest.mark.skipif(os.name != "nt", reason="Windows-only handle semantics")
 def test_windows_really_refuses_to_replace_a_target_held_open(tmp_path):
     # 这条钉的是重试列表的**前提**：Windows 上「目标被打开着」到底报哪个码。哪天

--- a/tests/unit/test_realtime_arbiter_native_path.py
+++ b/tests/unit/test_realtime_arbiter_native_path.py
@@ -912,6 +912,124 @@ async def test_prime_dispatch_failure_surfaces_a_type_the_swap_must_catch():
     await _finish_loop(socket, receive_loop)
 
 
+class _RiggedUUIDModule:
+    """A ``uuid`` stand-in whose hex always embeds ``needle``.
+
+    Every client event_id in ``_responses`` is ``<prefix>_<uuid4().hex>``, and
+    hex is 0-9a-f -- so '429', '1008' and '503' are all spellable by chance.
+    Rigging the id is not inventing an exotic input; it is pinning one of the
+    ~0.7%-per-error draws that CI kept hitting.
+    """
+
+    def __init__(self, needle: str) -> None:
+        self._needle = needle
+        self._counter = 0
+
+    def uuid4(self):
+        self._counter += 1
+        rigged = (f"{self._counter:08x}" + self._needle).ljust(32, "0")[:32]
+
+        class _U:
+            hex = rigged
+
+        return _U()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("needle", ["429", "1008", "503"])
+async def test_a_rejection_id_that_spells_a_quota_code_never_kills_the_transport(
+    needle, monkeypatch
+):
+    # The fatal-error classifier used to substring-match on str(event['error']),
+    # which echoes OUR OWN client event_id. A uuid4 hex that happens to contain
+    # '429'/'1008' turned an ordinary single-event rejection into a full
+    # connection teardown -- she goes silent mid-sentence, and it reproduces
+    # roughly once in 140 rejections. It was also the whole story behind two
+    # Windows CI flakes in this very file (run 30549810820): the prime failed
+    # with ConnectionError('realtime client closed') instead of the RuntimeError
+    # the swap handler is written against.
+    from main_logic.omni_realtime_client import _responses as responses_mod
+
+    monkeypatch.setattr(responses_mod, "uuid", _RiggedUUIDModule(needle))
+
+    connection_errors: list[str] = []
+
+    async def _on_connection_error(msg) -> None:
+        connection_errors.append(msg)
+
+    client, socket = _wired_client(api_type="free", model="free-model")
+    client.on_connection_error = _on_connection_error
+    receive_loop = asyncio.create_task(client.handle_messages())
+
+    prime = asyncio.create_task(
+        client.prime_context("[context] the task finished", skipped=False)
+    )
+    await _settle()
+    item_event_id = socket.sent[0]["event_id"]
+    assert needle in item_event_id, "the rigged id must actually spell the code"
+
+    socket.feed(
+        {
+            "type": "error",
+            "error": {"message": "invalid item payload", "event_id": item_event_id},
+        }
+    )
+    await _settle()
+
+    assert prime.done()
+    assert isinstance(prime.exception(), RuntimeError)
+    assert not isinstance(prime.exception(), ConnectionError), (
+        "a rejection whose event_id merely spells a quota code must not be "
+        "escalated into a transport teardown"
+    )
+    assert socket.closed is False
+    assert client.ws is socket, "the transport must stay attached"
+    assert connection_errors == [], "no fatal error was reported by the provider"
+    assert client._is_throttled is False, "nor is this a 503 backpressure signal"
+
+    await _finish_loop(socket, receive_loop)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error_payload",
+    [
+        {"message": "HTTP 429 Too Many Requests"},
+        {"message": "rejected", "code": 1008},
+        {"message": "your account is not in good standing"},
+    ],
+)
+async def test_a_real_quota_error_still_closes_the_transport(error_payload):
+    # The other half of the contract: dropping correlation ids from the
+    # classifier must not blunt it. A code carried in a semantic field --
+    # message, code, type -- is still fatal and still tears the session down.
+    connection_errors: list[str] = []
+
+    async def _on_connection_error(msg) -> None:
+        connection_errors.append(msg)
+
+    client, socket = _wired_client(api_type="free", model="free-model")
+    client.on_connection_error = _on_connection_error
+    receive_loop = asyncio.create_task(client.handle_messages())
+
+    create = asyncio.create_task(client.create_response("hello"))
+    await _settle()
+    payload = dict(error_payload)
+    payload["event_id"] = socket.sent[0]["event_id"]
+    socket.feed({"type": "error", "error": payload})
+    await _settle()
+
+    assert socket.closed is True, "a genuine quota/policy error must fail closed"
+    assert client.ws is None
+    assert connection_errors, "the frontend must be told the session died"
+
+    assert create.done()
+    socket.finish()
+    await asyncio.wait_for(receive_loop, timeout=1)
+
+
 # ---------------------------------------------------------------------------
 # T8 — the protect-her-speech contract, stated directly: program-initiated
 # text (proactive chat) queues behind a live response instead of preempting

--- a/tests/unit/test_topic_pipeline.py
+++ b/tests/unit/test_topic_pipeline.py
@@ -14,6 +14,7 @@ from main_logic.topic.pipeline import (
     _record_weight,
 )
 from main_logic.topic.signals import TopicSignalStore
+from tests.atomic_read import read_text_tolerating_replace, read_text_when_readable
 from tests.fake_clock import patch_module_clock
 
 
@@ -1004,18 +1005,17 @@ async def test_topic_pool_restored_signals_respect_persisted_used_history(tmp_pa
     pool.note_user_message("妮可", "先投递一次，建立今天已经用过 deep topic 的节流历史", lang="zh-CN")
     await pool.process_now("妮可", lang="zh-CN")
     used_path = path.with_name("topic_signals.used_topics.json")
-    # The trigger writes this file from a worker thread (to_thread), so a
-    # fixed sleep is a race: a loaded CI runner needs more than 20ms just to
-    # hand the write off. Wait for the artifact itself.
-    deadline = time.monotonic() + 5.0
-    while not used_path.exists() and time.monotonic() < deadline:
-        await asyncio.sleep(0.01)
-    assert used_path.exists(), "used-topics file was never persisted"
+    # The trigger writes this file from a worker thread (to_thread), so a fixed
+    # sleep is a race: a loaded CI runner needs more than 20ms just to hand the
+    # write off. Polling `exists()` is not enough either — on Windows it flips
+    # True while os.replace is still in flight and the read right behind it
+    # loses with PermissionError (CI run 30549810820). Wait for readable, and
+    # read once: the two assertions below must see the same snapshot anyway.
+    used_text = await read_text_when_readable(used_path)
 
     assert delivered == ["买车"]
-    used_payload = json.loads(used_path.read_text(encoding="utf-8"))
+    used_payload = json.loads(used_text)
     assert used_payload["characters"]["妮可"][0]["used_at"] > 0
-    used_text = used_path.read_text(encoding="utf-8")
     assert used_payload["characters"]["妮可"][0]["interest_hash"]
     assert used_payload["characters"]["妮可"][0]["keyword_hashes"] == []
     assert "买车" not in used_text
@@ -1092,7 +1092,9 @@ async def test_topic_pool_clears_durable_signals_after_successful_delivery(tmp_p
     def _persisted_turns() -> list:
         if not path.exists():
             return []
-        payload = json.loads(path.read_text(encoding="utf-8"))
+        # 这个轮询和还在跑的 trigger 任务并发：它们经 to_thread 落盘同一个文件，
+        # Windows 上 os.replace 和这里的 open() 互斥，谁输谁吃 PermissionError。
+        payload = json.loads(read_text_tolerating_replace(path))
         return payload.get("characters", {}).get("妮可", [])
 
     # 原来是 `for _ in range(20): await asyncio.sleep(0.01)`——计次而没有挂钟

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -585,6 +585,38 @@ if hasattr(os, "register_at_fork"):
     os.register_at_fork(after_in_child=_reset_tmp_sweep_state_after_fork)
 
 
+# Windows 上 os.replace 会因为「目标此刻正被别的句柄打开」而失败，抛 PermissionError，
+# winerror 是 5（ACCESS_DENIED）或 32（SHARING_VIOLATION）。制造这个窗口的不只是杀软扫描
+# 和资源管理器预览 —— 本进程自己就够了：落盘常跑在 to_thread 的工作线程里，同一时刻另一
+# 个线程（或测试）正 open() 读同一个文件，replace 就被拒。POSIX 的 rename 不受读者影响，
+# 这段窗口是 Windows 独有的，而且几乎总是毫秒级：对方句柄一关就没了。
+#
+# 所以这里退避重试。它不会掩盖真实错误，四条理由：
+#   * 判据是 OS 给的错误码，不是消息文本猜测。POSIX 的 OSError 根本没有 winerror 属性，
+#     getattr 取到 None，整段在非 Windows 上恒等于「直接抛」。
+#   * 别的错误码一次都不重试：磁盘满、路径过长、跨卷、目标是目录，第一次就原样抛出。
+#   * 最后一次尝试写在循环外，所以重试用尽后抛出的就是那次真实的 os.replace 异常，带着
+#     完整的 filename/filename2，不是一个被包装过的「重试失败」。
+#   * 上界是固定的（5 次退避，累计 155ms）。目标要是被永久占着（只读、被别的进程长期
+#     持有），行为和改动前完全一样是抛错，只是晚 155ms —— 拿这点延迟换掉绝大多数
+#     毫秒级窗口造成的偶发写失败。
+_REPLACE_BUSY_WINERRORS = frozenset({5, 32})
+_REPLACE_RETRY_BACKOFF_S = (0.005, 0.01, 0.02, 0.04, 0.08)
+
+
+def _replace_with_busy_retry(temp_path: str, target_path: Path) -> None:
+    """Replace the target, briefly retrying Windows' "target is busy" errors."""
+    for delay in _REPLACE_RETRY_BACKOFF_S:
+        try:
+            os.replace(temp_path, target_path)
+            return
+        except OSError as exc:
+            if getattr(exc, "winerror", None) not in _REPLACE_BUSY_WINERRORS:
+                raise
+        time.sleep(delay)
+    os.replace(temp_path, target_path)
+
+
 def atomic_write_text(path: str | os.PathLike[str], content: str, *, encoding: str = "utf-8") -> None:
     """Atomically replace a text file in the same directory."""
     target_path = Path(path)
@@ -603,7 +635,7 @@ def atomic_write_text(path: str | os.PathLike[str], content: str, *, encoding: s
             temp_file.write(content)
             temp_file.flush()
             os.fsync(temp_file.fileno())
-        os.replace(temp_path, target_path)
+        _replace_with_busy_retry(temp_path, target_path)
     except BaseException:
         # BaseException 而不是 Exception：Ctrl-C / SystemExit 落在 write/fsync 上很常见，
         # 只收 Exception 的话 tmp 直接留盘（要等到下一个清扫窗口 + 24h 才清）。

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -600,8 +600,34 @@ if hasattr(os, "register_at_fork"):
 #   * 上界是固定的（5 次退避，累计 155ms）。目标要是被永久占着（只读、被别的进程长期
 #     持有），行为和改动前完全一样是抛错，只是晚 155ms —— 拿这点延迟换掉绝大多数
 #     毫秒级窗口造成的偶发写失败。
+#
+# 但退避绝不在事件循环上跑。本模块是全仓库共用的落盘原语，而仓库里有二十多处在
+# `async def` 里裸调同步的 atomic_write_*（其中 memory/anti_repeat.py 与
+# memory/user_directives.py 是 per-turn 的，跟音频同在一条循环上）。在那些地方睡
+# 155ms 就是掐音频。而且这不只是量级问题：scripts/check_async_blocking.py 把
+# `time.sleep` 明文列进 RISKY_ATTR_PAIRS，本来就禁止它出现在 async 可达路径上 ——
+# 该守卫此刻不报，只是因为它文档里写明的 depth-1 限制看不到这里（sleep 在
+# atomic_write_text → _replace_with_busy_retry 的深度 2），不是这段代码合规。
+#
+# 所以有运行中的事件循环时，第一次 busy 就抛：上环调用者拿到的**恰好是改动前的
+# 行为**，一个字节的回归都没有。而制造这个 flake 的落盘全部跑在 to_thread 的工作
+# 线程里（那里没有 running loop），完整退避原样保留 —— 修复的收益一分不少。
+#
+# 代价要说清楚：那二十多处上环调用点因此继续吃不到这份保护，撞上占用时照旧丢一次
+# 写（它们的调用方多半是 `except Exception: logger.warning`，所以丢得是静默的）。
+# 这不该靠原语在循环上偷偷睡来补 —— 正确的收口是把那些调用点改成
+# atomic_write_json_async（已存在，仓库里已有 77 处在用），那是独立的一份工作。
 _REPLACE_BUSY_WINERRORS = frozenset({5, 32})
 _REPLACE_RETRY_BACKOFF_S = (0.005, 0.01, 0.02, 0.04, 0.08)
+
+
+def _running_on_event_loop() -> bool:
+    """Whether this thread is currently inside a running asyncio event loop."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return False
+    return True
 
 
 def _replace_with_busy_retry(temp_path: str, target_path: Path) -> None:
@@ -612,6 +638,10 @@ def _replace_with_busy_retry(temp_path: str, target_path: Path) -> None:
             return
         except OSError as exc:
             if getattr(exc, "winerror", None) not in _REPLACE_BUSY_WINERRORS:
+                raise
+            # 只在真的撞上 busy 之后才问「我是不是在循环上」：happy path 一条
+            # 指令都不多。
+            if _running_on_event_loop():
                 raise
         time.sleep(delay)
     os.replace(temp_path, target_path)


### PR DESCRIPTION
## 改动概述 / Summary

修两条在 Windows CI 上间歇性失败的**既有**测试。它们与任何在飞的 PR 无关，是 main 上就有的 flake，反复把无关 PR 的 CI 染红。

诊断证据来自 PR #2569 的 run 30549810820 / job 90895224620（commit 33f51ff57），以及更早的 job 90845995211。

其中一条查下来是**产品侧的真 bug**，不是测试写得太紧。

---

### 一、realtime `error` 事件的致命性判定误伤随机 event_id

**原本啥样：** `handle_messages` 里 `error` 事件的致命性判定是一串子串匹配（`'429'` / `'1008'` / `'503'` / `'quota'` / `'standing'` ...），匹配对象是 `str(event['error'])` —— 整个 dict 的 repr。而这个 dict 里回显着**我们自己生成的客户端相关性 id**：`event_user_item_<uuid4().hex>`、`event_inject_resp_<uuid4().hex>` 等等。

hex 的字符集是 `0-9a-f`，`'429'` 三个字符全在里面。32 位 hex 串里随机出现：

| 子串 | 每条 error 的命中概率 |
|---|---|
| `429` | ≈ 0.73%（约 1/137） |
| `503` | ≈ 0.73% |
| `1008` | ≈ 0.044% |

撞上一次，一次普通的「这条事件被服务端拒了」就被误判成配额 / 策略致命错误，直接 `close()` 掉整条 realtime 连接 —— **用户话说到一半连接没了，且完全无法复现**。撞上 `503` 则是无端进入 30s backpressure 节流。

**CI 上的表现**（同一个根因，两种症状）：

- `test_prime_dispatch_failure_surfaces_a_type_the_swap_must_catch` 拿到 `ConnectionError('realtime client closed')` 而不是期望的 `RuntimeError`。时序是：`notify_error` 只把异常挂到 item_ack 上，要经一次任务跳转才传播到 ticket；而 `close()` → `arbiter.shutdown()` 在接收循环里同步紧跟其后，抢先把 ticket 设成 `ConnectionError`。
- 更早的 job 90845995211 上是同文件 `test_async_tool_rejection_frees_the_lane_without_tearing_the_transport` 的 `a routed rejection must free the lane immediately` —— 连接被拆了，后续 create 自然发不出去。

**确定性复现**（把 uuid4 的 hex 钉成含 `429`）：

```
needle='429'  → prime 失败于 ConnectionError('realtime client closed')，socket.closed=True
needle='1008' → 同上
needle='abc'  → prime 失败于 RuntimeError，socket.closed=False   ← 正确行为
```

**修法：** 分类前先把相关性 id 剔掉（新增 `_error_classification_text`，只剔 `id` / `*_id` 字段），`message` / `code` / `type` / `param` 一个不动 —— `code: 1008`、`"HTTP 429 Too Many Requests"` 这些真信号照常判致命。被剔掉的字段仍然完整进日志和 `on_connection_error`，诊断信息零损失。

**没有弱化断言：** `test_prime_dispatch_failure...` 里的 `isinstance(exc, RuntimeError)` 原样保留 —— 它本来就是对的，错的是产品代码。arbiter 契约（「程序排队、用户永远赢」）不受影响：这条改动只关系到「一次单事件拒绝该不该升级成拆连接」，不碰车道语义。

### 二、Windows 上 `os.replace` 与并发 `open()` 互斥

**原本啥样：** used-topics 由工作线程经 `atomic_write_json` → `os.replace` 落盘；测试轮询 `used_path.exists()` 通过后立刻 `read_text`，正撞在 replace 中间：

```
>       used_payload = json.loads(used_path.read_text(encoding="utf-8"))
E       PermissionError: [Errno 13] Permission denied: '...\topic_signals.used_topics.json'
```

`exists()` **不是可用的门**：replace 在飞的时候它可以是 True，而 `open()` 仍然被拒。

同一次 run 里 `test_event_log.py` 伴随的 `PytestUnhandledThreadExceptionWarning`（栈底 `file_utils.py` 的 `os.replace` 抛 `PermissionError: [WinError 5]`）是同一段窗口的**另一侧** —— 写入侧被读者挡住。本地实测确认前提：

```
open(target) 持有句柄时 os.replace(tmp, target)
  → PermissionError winerror=5 [WinError 5] Access is denied
```

**两侧都修：**

- **写入侧** `utils/file_utils.py`：`os.replace` 加有限次退避重试（5 次，5/10/20/40/80ms，累计 155ms），**但退避绝不在事件循环上跑**（见下）。
- **读侧**：新增 `tests/atomic_read.py`，把「poll `exists()` 再读」换成「等到真的读得出来」。同文件里另一处与 trigger 任务并发读同一文件的轮询（`_persisted_turns`）一并收口。

#### 退避为什么带事件循环守卫（评审后追加，commit `b073ba7`）

`atomic_write_*` 是全仓库共用的落盘原语。扫描确认有 **26 处**在 `async def` 里裸调同步版本，其中两处是 per-turn 的 —— `memory/user_directives.py:238`（每条用户发言）和 `memory/anti_repeat.py:352`（每条 assistant 回复，经 `omni_offline_client/_lifecycle.py:441`）。后者跟音频同在一条事件循环上，155ms 停顿是听得出来的。

还有一条更硬的：仓库自己的 `scripts/check_async_blocking.py` 把 `time.sleep` 明文列进 `RISKY_ATTR_PAIRS`（`("time","sleep")`），`DEFAULT_PATHS` 覆盖 `utils/` `memory/` `main_routers/`。守卫此刻不报（实跑 exit 0），唯一原因是它文档写死的 **depth-1** 限制看不到 `atomic_write_text → _replace_with_busy_retry` 这条深度 2 的链 —— 是守卫看不见，不是这段代码合规。

所以有运行中事件循环时，第一次 busy 就抛：

| | 改动前 | 无条件退避 | 带守卫（最终） |
|---|---|---|---|
| `to_thread` 工作线程（flake 实际路径） | 撞占用即失败 | 完整退避 | **完整退避** |
| 事件循环上的 26 处调用点 | 撞占用即失败 | 最多 155ms 循环停顿 | **与改动前完全一致** |
| happy path | —— | 零成本 | 零成本（`get_running_loop()` 只在真撞 busy 后才求值） |

用 `get_running_loop()` 而非 `get_event_loop()`：后者在某些版本的主线程上会静默创建新 loop，会让守卫在非 async 上下文里误判。

**要说清楚的代价**：那 26 处上环调用点因此继续吃不到这份保护，撞上占用时照旧丢一次写（调用方多半是 `except Exception: logger.warning`，所以丢得是静默的）。这不该靠原语在循环上偷偷睡来补 —— 正确的收口是把调用点改成 `atomic_write_json_async`（已存在，仓库里已有 77 处在用）。那是**先于本 PR 存在**的问题，另行处理。

## 回归报告 / Regression Report

**改动了什么**

1. `main_logic/omni_realtime_client/_transport.py`：新增模块级 `_is_correlation_key` / `_error_classification_text`；`error` 分支的三处关键词判定（503 节流、idle 超时、配额/策略致命）改为匹配剔除了 id 字段的分类文本。`error_msg` 本身不变，日志、`_route_inject_rejection`、`notify_error`、`on_connection_error` 收到的仍是完整原文。
2. `utils/file_utils.py`：`atomic_write_text` 的 `os.replace` 换成 `_replace_with_busy_retry`（只对 winerror 5/32 退避），并新增 `_running_on_event_loop()` 守卫 —— 有运行中事件循环时第一次 busy 就抛，退避只在工作线程里生效。

**理由 / 必要性**

1. 第 1 条是用户可见的线上缺陷：约每 137 次「服务端拒绝单个事件」就有一次会把健康的 realtime 连接拆掉，用户体验是说话说到一半断线，而且因为随机性完全无法复现和归因。它同时是本次 CI flake 的根因。
2. 第 2 条是全仓库共用的落盘原语在 Windows 上的固有缺口：目标被任何句柄打开（杀软扫描、资源管理器预览、搜索索引，以及本进程另一个线程正在读）时 `os.replace` 会被拒，而这个窗口通常只有毫秒级。此前每一次这样的瞬时冲突都是一次真实的落盘失败。

**改动前后的表现对比**

| 场景 | 改动前 | 改动后 |
|---|---|---|
| error 回显的 event_id 里恰好含 `429`/`1008` | `close()` 拆连接，ticket 报 `ConnectionError` | 只失败这一个 ticket（`RuntimeError`），连接保持 |
| error 回显的 event_id 里恰好含 `503` | 进入 30s backpressure 节流 | 不节流 |
| error 的 `message`/`code` 里真有 `429`/`1008`/`quota`/`standing` | fail-close | 不变，仍 fail-close |
| Windows 上目标被别的句柄短暂占住（**工作线程**，flake 实际路径） | 落盘失败抛 `PermissionError` | 退避重试后成功 |
| Windows 上目标被别的句柄短暂占住（**事件循环上**的 26 处调用点） | 落盘失败抛 `PermissionError` | 不变，仍第一次就抛，零 sleep |
| Windows 上目标被永久占住（只读/长期持有，工作线程） | 抛 `PermissionError` | 不变，仍抛同一个异常，只是晚 155ms |
| POSIX | —— | 完全无行为变化（`OSError` 没有 `winerror` 属性，`getattr` 取到 `None`，退避恒等于直接抛） |

**为什么写入侧的重试不会掩盖真实错误**（这是全仓库共用的原语，逐条说明）

- 判据是 **OS 给的错误码**（winerror 5 / 32），不是消息文本猜测。
- 别的错误码**一次都不重试**：磁盘满、路径过长、跨卷、目标是目录，第一次就原样抛出。
- **最后一次尝试写在循环外**，所以重试用尽后抛出的就是 `os.replace` 那次真实的异常，带着完整的 `filename` / `filename2`，不是一个被包装过的「重试失败」。
- **上界是硬的**：5 次退避，累计 155ms，亚秒级；而且这个上界只可能落在工作线程上，事件循环上恒为 0。
- 与既有的失败路径不冲突：`except BaseException` 的 tmp 清理、「清理失败不许盖掉真实原因」（#2580）、崩后残留 tmp 清扫全部保持原样；`FileNotFoundError`（清扫器在 POSIX 上抢走 tmp 的那条路径）不在重试列表里，仍然是一个诚实的异常。

**潜在回归点 / 怎么验证的**

- *致命错误检测被削弱* → 新增 `test_a_real_quota_error_still_closes_the_transport`，参数化覆盖 `message` 里的 `429`、`code: 1008`、`message` 里的 `standing`，断言仍然 `close()` + 通知前端。变异验证：把 `message`/`code` 从分类文本里去掉 → 3 条全红。
- *落盘延迟* → 只在 Windows、OS 明确报 busy、且不在事件循环上时才产生，上界 155ms，用例断言了退避序列与总预算；事件循环上的行为与改动前逐字节一致（`test_the_backoff_never_sleeps_on_the_event_loop`）。
- *realtime 全链路* → realtime 相关 14 个测试文件全绿（530 passed, 4 skipped）。
- *落盘原语的所有下游* → 所有引用 `file_utils` / `atomic_write` 的用例全绿（608 passed）。

## 不拆分理由 / Why Not Split

不适用（计入上限的文件 2 个）。

## 测试 / Testing

**新增用例（全部做了变异验证）**

| 用例 | 变异 | 结果 |
|---|---|---|
| `test_a_rejection_id_that_spells_a_quota_code_never_kills_the_transport`（×3 参数） | 把分类文本换回 `str(event['error'])` | 3 红 ✅ |
| `test_a_real_quota_error_still_closes_the_transport`（×3 参数） | 从分类文本里去掉 `message`/`code` | 3 红 ✅ |
| `test_a_busy_target_is_retried_until_the_other_handle_goes_away`<br>`test_a_target_that_stays_busy_raises_the_real_replace_error` | 撤掉 `_replace_with_busy_retry` | 2 红 ✅ |
| `test_the_backoff_never_sleeps_on_the_event_loop` | 删掉 `if _running_on_event_loop(): raise` | 1 红 ✅ |
| `test_a_worker_thread_still_gets_the_full_backoff` | —— 钉对偶面：`to_thread` 里退避原样生效 | |
| `test_only_the_busy_winerrors_are_retried`（×2 参数） | —— 钉「非 busy 错误一次都不重试」 | |
| `test_windows_really_refuses_to_replace_a_target_held_open` | —— 钉重试列表的**前提**：Windows 上到底报哪个码。CPython 换共享模式或系统换码时这条会红，而不是让退避悄悄永远不触发 | |
| `tests/unit/test_atomic_read.py`（5 条） | 把两个读辅助改回裸读 | 3 红 ✅ |

**回归面**

- 两条原 flake 本地 Windows 连跑 20 轮：**0 失败**。
- `tests/unit` 全量本地跑过两轮：加重试 8861 passed / 加守卫后 8863 passed，均 45 skipped。
- `scripts/check_async_blocking.py`：exit 0。
- realtime 相关 14 个文件：530 passed, 4 skipped。
- 引用 `file_utils` 的 21 个文件：608 passed。
- 本次改动的 4 个文件：142 passed。
- `scripts/check_docstring_no_cjk.py --base origin/main`：exit 0。

**顺带一个发现（本 PR 未动）**

`pytest-randomly` 并没有安装（`uv pip list` 确认），所以手打的 `-p no:randomly` 是空操作。不过仓库里搜不到这个 flag 的任何出现（`pytest.ini` 的 `addopts` 是 `-p no:anyio`），所以没有可清理的东西 —— 只是手动敲的时候它什么也没做。要不要反过来把 `pytest-randomly` 装上是个取舍，留给维护者决定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
