### PR TITLE
fix(async): 把事件循环上的同步落盘收口，并给这一类加 CI 守卫

### DIFF
--- a/app/main_server/workshop_runtime.py
+++ b/app/main_server/workshop_runtime.py
@@ -26,7 +26,7 @@ from main_routers.workshop_router import (
     warmup_ugc_cache,
 )
 from utils.cloudsave_runtime import is_write_fence_active
-from utils.workshop_utils import get_workshop_path, get_workshop_root
+from utils.workshop_utils import get_workshop_path_async, get_workshop_root_async
 
 from ._shared import runtime
 
@@ -127,7 +127,7 @@ async def _init_and_mount_workshop():
             subscribed_items = workshop_items_result.get("items", [])
 
         # 3. 调用 utils 层函数获取/计算路径（路径会被持久化到 config）
-        workshop_path = get_workshop_root(subscribed_items)
+        workshop_path = await get_workshop_root_async(subscribed_items)
 
         # 4. 挂载静态文件目录
         if (
@@ -149,7 +149,7 @@ async def _init_and_mount_workshop():
     except Exception as e:
         logger.error(f"初始化创意工坊目录时出错: {e}")
         # 降级：确保至少有一个默认路径可用
-        workshop_path = get_workshop_path()
+        workshop_path = await get_workshop_path_async()
         logger.info(f"使用配置中的默认路径: {workshop_path}")
         if (
             workshop_path

--- a/brain/task_executor.py
+++ b/brain/task_executor.py
@@ -427,7 +427,18 @@ class DirectTaskExecutor:
         finally:
             self._short_desc_prewarm_inflight -= pids
             # 把本批生成的（贵的）条目落盘，下次启动直接复用、不再现生成。
-            self._persist_generated_short_descriptions(generated)
+            # 这里刻意保留同步落盘（不改 await asyncio.to_thread），两个原因：
+            # 1) _persist_generated_short_descriptions 内部是「读盘—合并—写盘」，
+            #    全程没有锁；今天靠「整段同步、不让出事件循环」才保证两批并发
+            #    prewarm 不互相覆盖（见该函数里 re-read 那行注释）。挪进线程后，
+            #    两批会各自在自己的 worker 线程里 load→merge→write 交错，先写的
+            #    那批条目会被后写的整份 payload 盖掉。
+            # 2) 这是 finally，而本协程绝大部分时间挂在 llm.ainvoke 上——事件循环
+            #    收尾时它正是会被 cancel 的 pending task。在取消路径的 finally 里
+            #    await，落盘可能被直接跳过，白白丢掉花了 LLM 调用生成的条目。
+            # 代价可控：每批 prewarm 只写一次小 JSON，发生在插件加载期，不在
+            # analyze 热路径上。
+            self._persist_generated_short_descriptions(generated)  # noqa: ASYNC_BLOCK — 无锁读-改-写 + 取消路径 finally，加 await 会引入互相覆盖/漏落盘
 
     async def plugin_list_provider(self, force_refresh: bool = True) -> List[Dict[str, Any]]:
         # return cached list when allowed

--- a/docs/api/rest/workshop.md
+++ b/docs/api/rest/workshop.md
@@ -77,6 +77,10 @@ Synchronization may report skipped/conflicting cards, missing installs, or a sto
 
 These routes package reference material; they do not clone or register a local TTS voice themselves.
 
+::: info Content-folder exclusivity
+Publishing hands the whole content folder to Steam until the upload finishes. While a folder is publishing, `upload-reference-audio`, `remove-reference-audio` and `cleanup-temp-folder` answer `409` instead of modifying bytes that Steam is consuming. The exclusion also works in reverse: `publish` answers `409` while a reference-audio write is in flight.
+:::
+
 ## Implementation-verified route inventory
 
 ```text

--- a/docs/ja/api/rest/workshop.md
+++ b/docs/ja/api/rest/workshop.md
@@ -77,6 +77,10 @@ Sync は skip/conflict、missing install、storage write fence を JSON で報�
 
 Reference material を package するだけで、local TTS voice の clone/register は行いません。
 
+::: info Content folder の排他
+publish は upload 完了まで content folder 全体を Steam に渡します。その間は `upload-reference-audio`、`remove-reference-audio`、`cleanup-temp-folder` が待たずに `409` を返し、Steam が使用中の bytes を変更しません。逆方向も同じで、reference audio の書き込み中は `publish` が `409` を返します。
+:::
+
 ## 実装で確認した route 一覧
 
 ```text

--- a/docs/zh-CN/api/rest/workshop.md
+++ b/docs/zh-CN/api/rest/workshop.md
@@ -77,6 +77,10 @@ macOS arm64 上当前 Steamworks 绑定存在 callback 崩溃风险，因此原�
 
 这些接口只打包参考材料，不会自行克隆或注册本地 TTS 声音。
 
+::: info 内容目录互斥
+发布会在上传结束前把整个内容目录交给 Steam。一个目录正在发布时，`upload-reference-audio`、`remove-reference-audio` 和 `cleanup-temp-folder` 直接返回 `409`，不会改动 Steam 正在读取的内容；反过来也一样，参考语音还在写入时，`publish` 返回 `409`。
+:::
+
 ## 经实现核对的路由清单
 
 ```text

--- a/docs/zh-CN/api/rest/workshop.md
+++ b/docs/zh-CN/api/rest/workshop.md
@@ -78,7 +78,7 @@ macOS arm64 上当前 Steamworks 绑定存在 callback 崩溃风险，因此原�
 这些接口只打包参考材料，不会自行克隆或注册本地 TTS 声音。
 
 ::: info 内容目录互斥
-发布会在上传结束前把整个内容目录交给 Steam。一个目录正在发布时，`upload-reference-audio`、`remove-reference-audio` 和 `cleanup-temp-folder` 直接返回 `409`，不会改动 Steam 正在读取的内容；反过来也一样，参考语音还在写入时，`publish` 返回 `409`。
+发布会在上传结束前把整个内容目录交给 Steam。一个目录正在发布时，`upload-reference-audio`、`remove-reference-audio` 和 `cleanup-temp-folder` 直接返回 `409`，不会改动 Steam 正在读取的内容；反过来也一样，参考声音还在写入时，`publish` 返回 `409`。
 :::
 
 ## 经实现核对的路由清单

--- a/main_logic/core/notify.py
+++ b/main_logic/core/notify.py
@@ -203,7 +203,9 @@ class NotifyMixin:
         try:
             from memory.anti_repeat import get_anti_repeat_corpus
             from config.prompts.prompts_directives import render_recent_topics_block
-            topics = get_anti_repeat_corpus().top_recent_topics(_directives_key)
+            anti_repeat_corpus = get_anti_repeat_corpus()
+            await anti_repeat_corpus.apreload(_directives_key)
+            topics = anti_repeat_corpus.top_recent_topics(_directives_key)
             prompt += render_recent_topics_block(topics, _lang)
         except Exception as _exc:  # pragma: no cover - defensive
             logger.debug(

--- a/main_logic/core/proactive.py
+++ b/main_logic/core/proactive.py
@@ -534,11 +534,16 @@ class ProactiveMixin:
                 # Turn-end push is best-effort; the client may have gone away.
                 pass
 
-            # 落盘排在所有收尾信号之后（内存更新已经在投递后立刻做了，见上）。
+            # 落盘排在所有收尾信号之后（内存更新已经在投递后立刻做了，见上），而且
+            # **摘下来不 await**：到这里这一轮对用户已经发生完了，但下面那句
+            # `return True` 才是调用方的记账凭据（break reminder / 小游戏邀请看它决定
+            # 要不要把这条来源标记成已消费）。在这里 await 就等于把一个取消点插在
+            # 「已投递」和「报告已投递」之间 —— CancelledError 是 BaseException，
+            # 下面的 except Exception 接不住，同一条提醒会被再发一次。
             if staged_anti_repeat is not None:
                 try:
                     from memory.anti_repeat import get_anti_repeat_corpus
-                    await get_anti_repeat_corpus().aflush_staged(staged_anti_repeat)
+                    get_anti_repeat_corpus().flush_staged_detached(staged_anti_repeat)
                 except Exception as _exc:  # pragma: no cover
                     logger.debug("[AntiRepeat] flush proactive skipped: %s", _exc)
         # proactive 原文不写 logger（隐私）；本地 print 兜底

--- a/main_logic/core/proactive.py
+++ b/main_logic/core/proactive.py
@@ -490,7 +490,9 @@ class ProactiveMixin:
                 if source_tag not in ANTI_REPEAT_EXEMPT_SOURCE_TAGS:
                     try:
                         from memory.anti_repeat import get_anti_repeat_corpus
-                        get_anti_repeat_corpus().record_output(
+                        # 落盘走 async 孪生：同步版尾部是 atomic_write_json
+                        # （含无上界的 fsync），压在会话循环上就是掐音频。
+                        await get_anti_repeat_corpus().arecord_output(
                             self.lanlan_name,
                             full_text,
                             is_proactive=True,

--- a/main_logic/core/proactive.py
+++ b/main_logic/core/proactive.py
@@ -483,6 +483,28 @@ class ProactiveMixin:
                 # 绝不会为未投递的轮次暂存截图。
                 if hasattr(self.session, "set_proactive_screenshot"):
                     self.session.set_proactive_screenshot(vision_screenshot_b64)
+
+            # 防复读 corpus 拆成两半：内存更新在收尾信号**之前**（同步、无 await，
+            # 所以不是取消点），落盘在之后。用户可能对着主动搭话立刻回一句，那一轮
+            # 打分必须已经看得到刚投递的这段；而落盘那个 await 一旦被取消就会跳过
+            # TTS 收尾和两处 turn end。两个要求方向相反，只有拆开才能同时满足。
+            #
+            # LLM 给自己的元数据备忘，不算复读对象。素材推送类 channel（推歌）
+            # 的台词天生模板化，录进 corpus 会污染 FG 窗、漂移其它 channel 的
+            # 复读基线，故按 ANTI_REPEAT_EXEMPT_SOURCE_TAGS 豁免（与出口的
+            # BM25 评分豁免对偶）。
+            staged_anti_repeat = None
+            if source_tag not in ANTI_REPEAT_EXEMPT_SOURCE_TAGS:
+                try:
+                    from memory.anti_repeat import get_anti_repeat_corpus
+                    staged_anti_repeat = get_anti_repeat_corpus().stage_output(
+                        self.lanlan_name,
+                        full_text,
+                        is_proactive=True,
+                        now=publication_times[0] if publication_times else None,
+                    )
+                except Exception as _exc:  # pragma: no cover
+                    logger.debug("[AntiRepeat] stage proactive skipped: %s", _exc)
                 # LLM 给自己的元数据备忘，不算复读对象。素材推送类 channel（推歌）
                 # 的台词天生模板化，录进 corpus 会污染 FG 窗、漂移其它 channel 的
                 # 复读基线，故按 ANTI_REPEAT_EXEMPT_SOURCE_TAGS 豁免（与出口的
@@ -504,28 +526,13 @@ class ProactiveMixin:
                 # Turn-end push is best-effort; the client may have gone away.
                 pass
 
-            # 防复读 corpus 排在**所有收尾信号之后**。落盘走 async 孪生（同步版
-            # 尾部是 atomic_write_json，含无上界 fsync，压在会话循环上就是掐音
-            # 频），但那个 await 也是个取消点：文本此刻已经投递出去了，被取消的
-            # 话 CancelledError 是 BaseException、下面的 except Exception 接不住，
-            # TTS 收尾和两处 turn end 就全被跳过 —— 用户看得见的一轮没有终止信号，
-            # 比漏录一条语料严重得多。与 omni_offline_client/_lifecycle.py 同款处置。
-            #
-            # LLM 给自己的元数据备忘，不算复读对象。素材推送类 channel（推歌）
-            # 的台词天生模板化，录进 corpus 会污染 FG 窗、漂移其它 channel 的
-            # 复读基线，故按 ANTI_REPEAT_EXEMPT_SOURCE_TAGS 豁免（与出口的
-            # BM25 评分豁免对偶）。
-            if source_tag not in ANTI_REPEAT_EXEMPT_SOURCE_TAGS:
+            # 落盘排在所有收尾信号之后（内存更新已经在投递后立刻做了，见上）。
+            if staged_anti_repeat is not None:
                 try:
                     from memory.anti_repeat import get_anti_repeat_corpus
-                    await get_anti_repeat_corpus().arecord_output(
-                        self.lanlan_name,
-                        full_text,
-                        is_proactive=True,
-                        now=publication_times[0] if publication_times else None,
-                    )
+                    await get_anti_repeat_corpus().aflush_staged(staged_anti_repeat)
                 except Exception as _exc:  # pragma: no cover
-                    logger.debug("[AntiRepeat] record proactive skipped: %s", _exc)
+                    logger.debug("[AntiRepeat] flush proactive skipped: %s", _exc)
         # proactive 原文不写 logger（隐私）；本地 print 兜底
         logger.info("[%s] Proactive stream delivered (text_len=%d)", self.lanlan_name, len(full_text or ""))
         print(f"[{self.lanlan_name}] Proactive stream delivered: {(full_text or '')[:40]}…")

--- a/main_logic/core/proactive.py
+++ b/main_logic/core/proactive.py
@@ -487,24 +487,6 @@ class ProactiveMixin:
                 # 的台词天生模板化，录进 corpus 会污染 FG 窗、漂移其它 channel 的
                 # 复读基线，故按 ANTI_REPEAT_EXEMPT_SOURCE_TAGS 豁免（与出口的
                 # BM25 评分豁免对偶）。
-                if source_tag not in ANTI_REPEAT_EXEMPT_SOURCE_TAGS:
-                    try:
-                        from memory.anti_repeat import get_anti_repeat_corpus
-                        # 落盘走 async 孪生：同步版尾部是 atomic_write_json
-                        # （含无上界的 fsync），压在会话循环上就是掐音频。
-                        await get_anti_repeat_corpus().arecord_output(
-                            self.lanlan_name,
-                            full_text,
-                            is_proactive=True,
-                            now=(
-                                publication_times[0]
-                                if publication_times
-                                else None
-                            ),
-                        )
-                    except Exception as _exc:  # pragma: no cover
-                        logger.debug("[AntiRepeat] record proactive skipped: %s", _exc)
-
             if self.use_tts and self.tts_thread and self.tts_thread.is_alive() and not self._tts_done_queued_for_turn:
                 try:
                     await self._request_tts_done_for_turn("finish_proactive_delivery")
@@ -521,6 +503,29 @@ class ProactiveMixin:
             except Exception:
                 # Turn-end push is best-effort; the client may have gone away.
                 pass
+
+            # 防复读 corpus 排在**所有收尾信号之后**。落盘走 async 孪生（同步版
+            # 尾部是 atomic_write_json，含无上界 fsync，压在会话循环上就是掐音
+            # 频），但那个 await 也是个取消点：文本此刻已经投递出去了，被取消的
+            # 话 CancelledError 是 BaseException、下面的 except Exception 接不住，
+            # TTS 收尾和两处 turn end 就全被跳过 —— 用户看得见的一轮没有终止信号，
+            # 比漏录一条语料严重得多。与 omni_offline_client/_lifecycle.py 同款处置。
+            #
+            # LLM 给自己的元数据备忘，不算复读对象。素材推送类 channel（推歌）
+            # 的台词天生模板化，录进 corpus 会污染 FG 窗、漂移其它 channel 的
+            # 复读基线，故按 ANTI_REPEAT_EXEMPT_SOURCE_TAGS 豁免（与出口的
+            # BM25 评分豁免对偶）。
+            if source_tag not in ANTI_REPEAT_EXEMPT_SOURCE_TAGS:
+                try:
+                    from memory.anti_repeat import get_anti_repeat_corpus
+                    await get_anti_repeat_corpus().arecord_output(
+                        self.lanlan_name,
+                        full_text,
+                        is_proactive=True,
+                        now=publication_times[0] if publication_times else None,
+                    )
+                except Exception as _exc:  # pragma: no cover
+                    logger.debug("[AntiRepeat] record proactive skipped: %s", _exc)
         # proactive 原文不写 logger（隐私）；本地 print 兜底
         logger.info("[%s] Proactive stream delivered (text_len=%d)", self.lanlan_name, len(full_text or ""))
         print(f"[{self.lanlan_name}] Proactive stream delivered: {(full_text or '')[:40]}…")

--- a/main_logic/core/proactive.py
+++ b/main_logic/core/proactive.py
@@ -260,6 +260,14 @@ class ProactiveMixin:
             if self.state.is_proactive_preempted():
                 logger.info("[%s] prepare_proactive_delivery: preempted during auto-start", self.lanlan_name)
                 return False
+        # ``finish_proactive_delivery`` must stage the committed text before
+        # terminal signals and cannot insert an await there. Pay the first
+        # corpus read here, before the proactive turn is claimed or visible.
+        try:
+            from memory.anti_repeat import get_anti_repeat_corpus
+            await get_anti_repeat_corpus().apreload(self.lanlan_name)
+        except Exception as exc:  # pragma: no cover - best-effort cache
+            logger.debug("[AntiRepeat] proactive preload skipped: %s", exc)
         async with self.lock:
             # lock 内二次复查：USER_INPUT 在 self.lock 内 rotate sid，sticky preempt
             # flag 先于 sid mutation 翻起；此处若已被抢占则不写 current_speech_id。

--- a/main_logic/omni_offline_client/_lifecycle.py
+++ b/main_logic/omni_offline_client/_lifecycle.py
@@ -461,10 +461,13 @@ class _LifecycleMixin:
                     await self.on_response_done()
                 # 只录常规 reply（completion_mode == "response"）。proactive 路径
                 # 已经在 ``core.finish_proactive_delivery`` 上录，这里再录会双写。
+                # 与 core.finish_proactive_delivery 同因同治：摘下来不 await。下面的
+                # `return content_committed` 是调用方判断这轮有没有提交的依据，在它
+                # 之前留一个取消点，就会让一次已经发出去的回复被记成没发。
                 if staged_anti_repeat is not None:
                     try:
                         from memory.anti_repeat import get_anti_repeat_corpus
-                        await get_anti_repeat_corpus().aflush_staged(staged_anti_repeat)
+                        get_anti_repeat_corpus().flush_staged_detached(staged_anti_repeat)
                     except Exception as _exc:  # pragma: no cover
                         logger.debug(
                             "[AntiRepeat] flush reply skipped: %s", _exc,

--- a/main_logic/omni_offline_client/_lifecycle.py
+++ b/main_logic/omni_offline_client/_lifecycle.py
@@ -432,30 +432,32 @@ class _LifecycleMixin:
                     logger.exception("prompt_ephemeral on_committed callback failed")
             if content_committed and persist_response:
                 self._conversation_history.append(AIMessage(content=assistant_message))
+            # 防复读 corpus 拆成两半：内存更新在收尾信号**之前**（同步，不含 await，
+            # 所以不是取消点），落盘在**之后**。客户端看到 turn end 就可能立刻发下一
+            # 条，那一轮的打分必须已经看得到刚提交的这句；而落盘那个 await 一旦被取消
+            # 就会跳过 on_response_done 里的 TTS 收尾 / turn 结束 / request-id 清理。
+            # 两个要求方向相反，只有拆开才能同时满足。
+            staged_anti_repeat = None
+            if completion_mode == "response" and content_committed and persist_response:
+                try:
+                    from memory.anti_repeat import get_anti_repeat_corpus
+                    staged_anti_repeat = get_anti_repeat_corpus().stage_output(
+                        self.lanlan_name, committed_text, is_proactive=False,
+                    )
+                except Exception as _exc:  # pragma: no cover
+                    logger.debug("[AntiRepeat] stage reply skipped: %s", _exc)
             if completion_mode == "response":
                 if self.on_response_done:
                     await self.on_response_done()
-                # 防复读 corpus：只录常规 reply（completion_mode == "response"）。
-                # proactive 路径已经在 ``core.finish_proactive_delivery`` 上录，
-                # 这里再录会双写——这两条路径都接得到同一段 assistant 文本。
-                #
-                # ⚠️ 必须排在 on_response_done **之后**。落盘走 async 孪生（同步版
-                # 尾部是 atomic_write_json，含无上界的 fsync，而这条路径每条回复都
-                # 走一次，压在会话循环上就是掐音频），但那个 await 也就成了一个取消
-                # 点：文本已经提交、历史已经写上，此时被取消的话 CancelledError 是
-                # BaseException，下面的 except Exception 接不住，on_response_done
-                # 里的 TTS 收尾 / turn 结束 / request-id 清理就全被跳过 —— 一次
-                # 已提交的回复没有终止信号，比漏录一条防复读语料严重得多。
-                # 排在后面，收尾信号先落地，corpus 只是尽力而为。
-                if content_committed and persist_response:
+                # 只录常规 reply（completion_mode == "response"）。proactive 路径
+                # 已经在 ``core.finish_proactive_delivery`` 上录，这里再录会双写。
+                if staged_anti_repeat is not None:
                     try:
                         from memory.anti_repeat import get_anti_repeat_corpus
-                        await get_anti_repeat_corpus().arecord_output(
-                            self.lanlan_name, committed_text, is_proactive=False,
-                        )
+                        await get_anti_repeat_corpus().aflush_staged(staged_anti_repeat)
                     except Exception as _exc:  # pragma: no cover
                         logger.debug(
-                            "[AntiRepeat] record reply skipped: %s", _exc,
+                            "[AntiRepeat] flush reply skipped: %s", _exc,
                         )
             else:
                 proactive_done_cb = getattr(self, "on_proactive_done", None)

--- a/main_logic/omni_offline_client/_lifecycle.py
+++ b/main_logic/omni_offline_client/_lifecycle.py
@@ -438,7 +438,10 @@ class _LifecycleMixin:
                 if completion_mode == "response":
                     try:
                         from memory.anti_repeat import get_anti_repeat_corpus
-                        get_anti_repeat_corpus().record_output(
+                        # 落盘走 async 孪生：同步版尾部是 atomic_write_json
+                        # （含无上界的 fsync），而这条路径每条 assistant 回复都
+                        # 走一次，压在会话循环上就是掐音频。
+                        await get_anti_repeat_corpus().arecord_output(
                             self.lanlan_name, committed_text, is_proactive=False,
                         )
                     except Exception as _exc:  # pragma: no cover

--- a/main_logic/omni_offline_client/_lifecycle.py
+++ b/main_logic/omni_offline_client/_lifecycle.py
@@ -432,15 +432,24 @@ class _LifecycleMixin:
                     logger.exception("prompt_ephemeral on_committed callback failed")
             if content_committed and persist_response:
                 self._conversation_history.append(AIMessage(content=assistant_message))
+            if completion_mode == "response":
+                if self.on_response_done:
+                    await self.on_response_done()
                 # 防复读 corpus：只录常规 reply（completion_mode == "response"）。
                 # proactive 路径已经在 ``core.finish_proactive_delivery`` 上录，
                 # 这里再录会双写——这两条路径都接得到同一段 assistant 文本。
-                if completion_mode == "response":
+                #
+                # ⚠️ 必须排在 on_response_done **之后**。落盘走 async 孪生（同步版
+                # 尾部是 atomic_write_json，含无上界的 fsync，而这条路径每条回复都
+                # 走一次，压在会话循环上就是掐音频），但那个 await 也就成了一个取消
+                # 点：文本已经提交、历史已经写上，此时被取消的话 CancelledError 是
+                # BaseException，下面的 except Exception 接不住，on_response_done
+                # 里的 TTS 收尾 / turn 结束 / request-id 清理就全被跳过 —— 一次
+                # 已提交的回复没有终止信号，比漏录一条防复读语料严重得多。
+                # 排在后面，收尾信号先落地，corpus 只是尽力而为。
+                if content_committed and persist_response:
                     try:
                         from memory.anti_repeat import get_anti_repeat_corpus
-                        # 落盘走 async 孪生：同步版尾部是 atomic_write_json
-                        # （含无上界的 fsync），而这条路径每条 assistant 回复都
-                        # 走一次，压在会话循环上就是掐音频。
                         await get_anti_repeat_corpus().arecord_output(
                             self.lanlan_name, committed_text, is_proactive=False,
                         )
@@ -448,9 +457,6 @@ class _LifecycleMixin:
                         logger.debug(
                             "[AntiRepeat] record reply skipped: %s", _exc,
                         )
-            if completion_mode == "response":
-                if self.on_response_done:
-                    await self.on_response_done()
             else:
                 proactive_done_cb = getattr(self, "on_proactive_done", None)
                 if proactive_done_cb:

--- a/main_logic/omni_offline_client/_lifecycle.py
+++ b/main_logic/omni_offline_client/_lifecycle.py
@@ -183,6 +183,16 @@ class _LifecycleMixin:
         if not instruction or not instruction.strip():
             return False
 
+        # A regular visible response stages anti-repeat memory immediately
+        # before terminal callbacks. That commit boundary cannot gain an await,
+        # so perform the first disk-backed load before generation starts.
+        if completion_mode == "response" and persist_response:
+            try:
+                from memory.anti_repeat import get_anti_repeat_corpus
+                await get_anti_repeat_corpus().apreload(self.lanlan_name)
+            except Exception as exc:  # pragma: no cover - best-effort cache
+                logger.debug("[AntiRepeat] response preload skipped: %s", exc)
+
         # 临时注入：instruction 已由调用方用 ======== 格式封装，作为 HumanMessage 发送，
         # 不持久化到 _conversation_history，避免污染长期上下文。
         # Proactive media is passed EXPLICITLY via ``images`` (per-callback,

--- a/main_logic/proactive_chat/break_reminders.py
+++ b/main_logic/proactive_chat/break_reminders.py
@@ -309,6 +309,11 @@ async def _deliver_break_reminder_via_llm(
     if not await mgr.prepare_proactive_delivery(min_idle_secs=10.0):
         return BreakReminderDeliveryResult()
 
+    try:
+        await get_anti_repeat_corpus().apreload(lanlan_name)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("[AntiRepeat] break-reminder preload skipped: %s", exc)
+
     silence_since_before_generation = _break_reminder_silence_since(mgr)
     proactive_sid = mgr.current_speech_id
     from main_logic.session_state import SessionEvent as _SE

--- a/main_logic/proactive_chat/generation.py
+++ b/main_logic/proactive_chat/generation.py
@@ -1180,6 +1180,7 @@ async def _guard_phase2_output(
         from memory.anti_repeat import get_anti_repeat_corpus
 
         anti_repeat_corpus = get_anti_repeat_corpus()
+        await anti_repeat_corpus.apreload(lanlan_name)
     except Exception as exc:  # pragma: no cover - defensive
         active_logger.debug("[AntiRepeat] corpus unavailable: %s", exc)
         anti_repeat_corpus = None

--- a/main_routers/storage_location_router.py
+++ b/main_routers/storage_location_router.py
@@ -86,6 +86,30 @@ router = APIRouter(prefix="/api/storage/location", tags=["storage_location"])
 logger = logging.getLogger(__name__)
 _storage_mutation_lock = asyncio.Lock()
 
+# _STORAGE_MUTATION_STAYS_ON_LOOP
+#
+# 本文件里所有写存储状态的调用**刻意**留在事件循环上（各处 noqa: ASYNC_BLOCK 指向
+# 这里）。落盘本身是同步的、带无上界的 fsync，按理该挪进 to_thread —— 但这里有两条
+# 独立的理由压过它，任缺其一都会造成比循环卡顿严重得多的后果。
+#
+# 一、这些写是**取消原子**的序列，而它们之间今天一个 await 都没有。
+#     典型形状：delete_storage_migration → save_storage_policy → set_root_mode。
+#     任何一处插进 await，请求超时或应用关闭产生的 CancelledError 就能落在中间：
+#     恢复检查点已删、策略已写，而 root mode 还是旧值。CancelledError 是
+#     BaseException，外层 `except Exception` 接不住，也就没人回滚 —— 用户会得到
+#     一个「恢复闸自相矛盾」的盘上状态。
+#
+# 二、root_state 有一个**不在锁里**的写者。
+#     build_storage_location_bootstrap_payload → _reconcile_legacy_cleanup_pending_
+#     root_state（utils/storage/location_bootstrap.py:191）会 save_root_state，它挂在
+#     GET /bootstrap、/status、/diagnostics、/retained-source 和 POST /exit 上，这些
+#     都不在 _storage_mutation_lock 覆盖下。今天让「GET 侧 reconcile」和「变更路由的
+#     写」互斥的不是锁，是**它们都跑在同一条事件循环线程上**。把任何一个 root_state
+#     写者挪进 worker，前端存储页每 500ms 的 /status 轮询就能把它整份盖掉。
+#
+# 真正的收口是给 root_state 一把真锁，并让 GET 路由别在读路径上写盘。在那之前，
+# 这个文件宁可让罕见的存储变更请求同步落盘。
+
 
 class StorageLocationSelectionRequest(BaseModel):
     selected_root: str = Field(..., min_length=1, max_length=4096)
@@ -1323,14 +1347,7 @@ async def _post_storage_location_retained_source_cleanup_locked(
         updated_payload["retained_source_mode"] = "cleaned"
         updated_payload["updated_at"] = _utc_now_iso()
         updated_payload["cleanup_completed_at"] = _utc_now_iso()
-        # 调用方 post_storage_location_retained_source_cleanup 已持 _storage_mutation_lock，
-        # 读-改-写的读发生在上面几行，写是本段最后一步，让出点不会被别的写者插队。
-        await asyncio.to_thread(
-            save_storage_migration,
-            config_manager,
-            updated_payload,
-            anchor_root=anchor_root,
-        )
+        save_storage_migration(config_manager, updated_payload, anchor_root=anchor_root)  # noqa: ASYNC_BLOCK — 见 _STORAGE_MUTATION_STAYS_ON_LOOP
 
     try:
         root_state = config_manager.load_root_state()
@@ -1430,8 +1447,7 @@ async def _post_storage_location_select_locked(
                 # 整个 _post_storage_location_select_locked 都跑在 _storage_mutation_lock 里，
                 # 下面紧跟着的 set_root_mode / 解除启动闸也已经是 await，多一个让出点不改变
                 # 「失败即整体回滚 state_snapshot」的语义。
-                policy_payload = await asyncio.to_thread(
-                    save_storage_policy,
+                policy_payload = save_storage_policy(  # noqa: ASYNC_BLOCK — 见 _STORAGE_MUTATION_STAYS_ON_LOOP
                     config_manager,
                     selected_root=current_root,
                     selection_source=payload.selection_source,
@@ -1466,8 +1482,7 @@ async def _post_storage_location_select_locked(
                 }
 
             state_snapshot = _snapshot_storage_mutation_state(config_manager, anchor_root=anchor_root)
-            policy_payload = await asyncio.to_thread(
-                save_storage_policy,
+            policy_payload = save_storage_policy(  # noqa: ASYNC_BLOCK — 见 _STORAGE_MUTATION_STAYS_ON_LOOP
                 config_manager,
                 selected_root=current_root,
                 selection_source=payload.selection_source,
@@ -1501,8 +1516,7 @@ async def _post_storage_location_select_locked(
                 "selection_source": policy_payload["selection_source"],
             }
         state_snapshot = _snapshot_storage_mutation_state(config_manager, anchor_root=anchor_root)
-        policy_payload = await asyncio.to_thread(
-            save_storage_policy,
+        policy_payload = save_storage_policy(  # noqa: ASYNC_BLOCK — 见 _STORAGE_MUTATION_STAYS_ON_LOOP
             config_manager,
             selected_root=current_root,
             selection_source=payload.selection_source,
@@ -1762,8 +1776,7 @@ async def _post_storage_location_restart_locked(
             delete_storage_migration(config_manager, anchor_root=anchor_root)
             # 同样在 _storage_mutation_lock 里；这一段本来就以 await _request_app_shutdown
             # 收尾，多出来的让出点仍被同一个 try/except 的 state_snapshot 回滚覆盖。
-            await asyncio.to_thread(
-                save_storage_policy,
+            save_storage_policy(  # noqa: ASYNC_BLOCK — 见 _STORAGE_MUTATION_STAYS_ON_LOOP
                 config_manager,
                 selected_root=normalized_selected_root,
                 selection_source=payload.selection_source,
@@ -1848,14 +1861,7 @@ async def _post_storage_location_restart_locked(
     except Exception as exc:
         try:
             if isinstance(previous_migration_payload, dict):
-                # 同上：关闭没起来才会走这条回滚分支，进程还活着；锁未释放，
-                # 让出期间不会有第二个存储变更请求进来抢写迁移检查点。
-                await asyncio.to_thread(
-                    save_storage_migration,
-                    config_manager,
-                    previous_migration_payload,
-                    anchor_root=anchor_root,
-                )
+                save_storage_migration(config_manager, previous_migration_payload, anchor_root=anchor_root)  # noqa: ASYNC_BLOCK — 见 _STORAGE_MUTATION_STAYS_ON_LOOP
             else:
                 delete_storage_migration(config_manager, anchor_root=anchor_root)
         except Exception:

--- a/main_routers/storage_location_router.py
+++ b/main_routers/storage_location_router.py
@@ -234,7 +234,23 @@ async def _release_storage_startup_barrier_or_rollback(
         await _release_storage_startup_barrier_if_needed(reason=reason)
     except Exception:
         try:
-            _restore_storage_mutation_state(config_manager, snapshot, anchor_root=anchor_root)
+            # 这一处**刻意**留在事件循环上。_restore_storage_mutation_state 的最后
+            # 一步是 config_manager.save_root_state()，而 root_state 还有另一个写者：
+            # build_storage_location_bootstrap_payload → _reconcile_legacy_cleanup_
+            # pending_root_state（utils/storage/location_bootstrap.py:191）也会
+            # save_root_state，它挂在 GET /bootstrap、/status、/diagnostics、
+            # /retained-source 和 POST /exit 上 —— 这几条**都不在
+            # _storage_mutation_lock 覆盖下**（锁只包 cleanup / select / restart 三条）。
+            #
+            # 今天让这两个「读 root_state — 改 — 写回」互斥的，不是锁，而是「它们都跑在
+            # 同一条事件循环线程上」。把回滚搬进 worker 就恰好打破这个不变量：前端存储页
+            # 每 500ms 轮询 /status，回滚写 root_state 的同时那边正拿着读到的旧 dict 往
+            # 回写，回滚会被整份盖掉 —— 迁移检查点和策略回滚了、root_state 没有，下次启动
+            # recovery_required 直接算成 False，恢复闸被跳过。
+            #
+            # 正确的收口是给 root_state 一把真锁、并让 GET 路由别在读路径上写盘，那是
+            # 独立的一份工作。在那之前，宁可让这条罕见的回滚路径同步落盘。
+            _restore_storage_mutation_state(config_manager, snapshot, anchor_root=anchor_root)  # noqa: ASYNC_BLOCK — 末步 save_root_state 与无锁 GET 路由的 root_state 读改写互斥，只靠「同在循环线程」保证
         except Exception:
             logger.exception(
                 "failed to rollback storage mutation state after startup barrier release failed",
@@ -1307,7 +1323,14 @@ async def _post_storage_location_retained_source_cleanup_locked(
         updated_payload["retained_source_mode"] = "cleaned"
         updated_payload["updated_at"] = _utc_now_iso()
         updated_payload["cleanup_completed_at"] = _utc_now_iso()
-        save_storage_migration(config_manager, updated_payload, anchor_root=anchor_root)
+        # 调用方 post_storage_location_retained_source_cleanup 已持 _storage_mutation_lock，
+        # 读-改-写的读发生在上面几行，写是本段最后一步，让出点不会被别的写者插队。
+        await asyncio.to_thread(
+            save_storage_migration,
+            config_manager,
+            updated_payload,
+            anchor_root=anchor_root,
+        )
 
     try:
         root_state = config_manager.load_root_state()
@@ -1404,7 +1427,11 @@ async def _post_storage_location_select_locked(
 
                 state_snapshot = _snapshot_storage_mutation_state(config_manager, anchor_root=anchor_root)
                 delete_storage_migration(config_manager, anchor_root=anchor_root)
-                policy_payload = save_storage_policy(
+                # 整个 _post_storage_location_select_locked 都跑在 _storage_mutation_lock 里，
+                # 下面紧跟着的 set_root_mode / 解除启动闸也已经是 await，多一个让出点不改变
+                # 「失败即整体回滚 state_snapshot」的语义。
+                policy_payload = await asyncio.to_thread(
+                    save_storage_policy,
                     config_manager,
                     selected_root=current_root,
                     selection_source=payload.selection_source,
@@ -1439,7 +1466,8 @@ async def _post_storage_location_select_locked(
                 }
 
             state_snapshot = _snapshot_storage_mutation_state(config_manager, anchor_root=anchor_root)
-            policy_payload = save_storage_policy(
+            policy_payload = await asyncio.to_thread(
+                save_storage_policy,
                 config_manager,
                 selected_root=current_root,
                 selection_source=payload.selection_source,
@@ -1473,7 +1501,8 @@ async def _post_storage_location_select_locked(
                 "selection_source": policy_payload["selection_source"],
             }
         state_snapshot = _snapshot_storage_mutation_state(config_manager, anchor_root=anchor_root)
-        policy_payload = save_storage_policy(
+        policy_payload = await asyncio.to_thread(
+            save_storage_policy,
             config_manager,
             selected_root=current_root,
             selection_source=payload.selection_source,
@@ -1731,7 +1760,10 @@ async def _post_storage_location_restart_locked(
         state_snapshot = _snapshot_storage_mutation_state(config_manager, anchor_root=anchor_root)
         try:
             delete_storage_migration(config_manager, anchor_root=anchor_root)
-            save_storage_policy(
+            # 同样在 _storage_mutation_lock 里；这一段本来就以 await _request_app_shutdown
+            # 收尾，多出来的让出点仍被同一个 try/except 的 state_snapshot 回滚覆盖。
+            await asyncio.to_thread(
+                save_storage_policy,
                 config_manager,
                 selected_root=normalized_selected_root,
                 selection_source=payload.selection_source,
@@ -1746,7 +1778,10 @@ async def _post_storage_location_restart_locked(
             await _request_app_shutdown(request_app_shutdown)
         except Exception as exc:
             try:
-                _restore_storage_mutation_state(config_manager, state_snapshot, anchor_root=anchor_root)
+                # 与 _release_storage_startup_barrier_or_rollback 里那处同因同治：
+                # 这个 helper 末步 save_root_state，而无锁的 GET 路由也在事件循环上
+                # 读改写同一份 root_state，两者今天只靠「同在循环线程」互斥。详见那处注释。
+                _restore_storage_mutation_state(config_manager, state_snapshot, anchor_root=anchor_root)  # noqa: ASYNC_BLOCK — 同上：root_state 读改写的互斥依赖「同在循环线程」
             except Exception:
                 logger.exception(
                     "failed to rollback storage mutation state after restart scheduling failed",
@@ -1813,7 +1848,14 @@ async def _post_storage_location_restart_locked(
     except Exception as exc:
         try:
             if isinstance(previous_migration_payload, dict):
-                save_storage_migration(config_manager, previous_migration_payload, anchor_root=anchor_root)
+                # 同上：关闭没起来才会走这条回滚分支，进程还活着；锁未释放，
+                # 让出期间不会有第二个存储变更请求进来抢写迁移检查点。
+                await asyncio.to_thread(
+                    save_storage_migration,
+                    config_manager,
+                    previous_migration_payload,
+                    anchor_root=anchor_root,
+                )
             else:
                 delete_storage_migration(config_manager, anchor_root=anchor_root)
         except Exception:

--- a/main_routers/system_router/prompt_flows.py
+++ b/main_routers/system_router/prompt_flows.py
@@ -51,8 +51,11 @@ async def _run_serialized_in_worker(lock: asyncio.Lock, func, /, *args, **kwargs
     # concurrent request first would make all waiters occupy default-executor
     # slots while only one can progress. asyncio.Lock suspends waiters without
     # blocking the event loop; the worker is allocated only to the active call.
+    submitted = asyncio.Event()
+
     async def _run_owned_operation():
         async with lock:
+            submitted.set()
             return await asyncio.to_thread(func, *args, **kwargs)
 
     # The child owns both queue position and submit-lock lifetime. Shielding it
@@ -62,6 +65,15 @@ async def _run_serialized_in_worker(lock: asyncio.Lock, func, /, *args, **kwargs
     try:
         return await asyncio.shield(operation)
     except asyncio.CancelledError:
+        # 但只有「worker 已经在跑」才值得保住。还排在锁上的那些没有任何不可取消的
+        # 东西，留着它们只会在客户端早就走了之后再去做一次陈旧的读/写；前面一次慢
+        # 文件操作 + 客户端反复超时重试，就能攒出一条无界队列挡住还活着的请求。
+        #
+        # 这个判断是原子的：submitted.set() 和它后面那个 await 之间没有让出点，所以
+        # 此刻子任务要么挂在 `async with lock`（没 set，取消安全），要么挂在
+        # to_thread（已 set，取消会提前放锁 —— 正是 shield 要防的）。不存在中间态。
+        if not submitted.is_set():
+            operation.cancel()
         operation.add_done_callback(_consume_detached_operation_result)
         raise
 

--- a/main_routers/system_router/prompt_flows.py
+++ b/main_routers/system_router/prompt_flows.py
@@ -39,14 +39,31 @@ _SEVEN_DAY_SUBMIT_LOCK = asyncio.Lock()
 _AUTOSTART_SUBMIT_LOCK = asyncio.Lock()
 
 
+def _consume_detached_operation_result(task: asyncio.Task) -> None:
+    """Retrieve a detached operation's exception after its waiter is cancelled."""
+    if not task.cancelled():
+        task.exception()
+
+
 async def _run_serialized_in_worker(lock: asyncio.Lock, func, /, *args, **kwargs):
     """Queue one state-family operation before it consumes an executor worker."""
     # The sync helpers also serialize on a threading.RLock. Submitting every
     # concurrent request first would make all waiters occupy default-executor
     # slots while only one can progress. asyncio.Lock suspends waiters without
     # blocking the event loop; the worker is allocated only to the active call.
-    async with lock:
-        return await asyncio.to_thread(func, *args, **kwargs)
+    async def _run_owned_operation():
+        async with lock:
+            return await asyncio.to_thread(func, *args, **kwargs)
+
+    # The child owns both queue position and submit-lock lifetime. Shielding it
+    # lets a cancelled HTTP waiter leave promptly without releasing the lock
+    # while its non-cancellable worker thread is still running.
+    operation = asyncio.create_task(_run_owned_operation())
+    try:
+        return await asyncio.shield(operation)
+    except asyncio.CancelledError:
+        operation.add_done_callback(_consume_detached_operation_result)
+        raise
 
 
 @router.get("/seven-day-tutorial/state")

--- a/main_routers/system_router/prompt_flows.py
+++ b/main_routers/system_router/prompt_flows.py
@@ -35,6 +35,19 @@ from utils.seven_day_tutorial_state import (
     replace_seven_day_tutorial_state,
 )
 
+_SEVEN_DAY_SUBMIT_LOCK = asyncio.Lock()
+_AUTOSTART_SUBMIT_LOCK = asyncio.Lock()
+
+
+async def _run_serialized_in_worker(lock: asyncio.Lock, func, /, *args, **kwargs):
+    """Queue one state-family operation before it consumes an executor worker."""
+    # The sync helpers also serialize on a threading.RLock. Submitting every
+    # concurrent request first would make all waiters occupy default-executor
+    # slots while only one can progress. asyncio.Lock suspends waiters without
+    # blocking the event loop; the worker is allocated only to the active call.
+    async with lock:
+        return await asyncio.to_thread(func, *args, **kwargs)
+
 
 @router.get("/seven-day-tutorial/state")
 async def get_seven_day_tutorial_state():
@@ -47,7 +60,8 @@ async def get_seven_day_tutorial_state():
     #    worker，而 file_utils 的「事件循环上绝不退避」保护是**按线程**判断的：worker
     #    里撞上 Windows busy 会重新启用那 155ms 退避，且是持着 RLock 睡的。只要循环
     #    线程还会去抢这把锁，退避就会经由锁重新传回循环。两边都挪走，这条路径才真的断。
-    return await asyncio.to_thread(
+    return await _run_serialized_in_worker(
+        _SEVEN_DAY_SUBMIT_LOCK,
         get_seven_day_tutorial_state_response,
         config_manager=get_config_manager(),
     )
@@ -64,7 +78,8 @@ async def put_seven_day_tutorial_state(request: Request):
         # 整个「读 revision — 比对 — 落盘」都在 helper 内部的 _STATE_LOCK（threading.RLock）
         # 里完成，临界区不跨 await，所以把整次调用挪进线程不会引入竞态；并发请求由那把
         # RLock 在工作线程上排队，事件循环不再被 atomic_write_json 的 fsync 堵住。
-        store = await asyncio.to_thread(
+        store = await _run_serialized_in_worker(
+            _SEVEN_DAY_SUBMIT_LOCK,
             replace_seven_day_tutorial_state,
             payload.get("state"),
             expected_revision=payload.get("expectedRevision"),
@@ -88,7 +103,8 @@ async def get_autostart_prompt_state():
     # 会落一次 save_autostart_prompt_state（utils/prompt_state/autostart.py:236），
     # 而且它在循环线程上持 _AUTOSTART_STATE_LOCK —— 下面三个 POST 已挪进 worker，
     # 这一条不挪，退避就会经由这把锁把 155ms 传回事件循环。
-    return await asyncio.to_thread(
+    return await _run_serialized_in_worker(
+        _AUTOSTART_SUBMIT_LOCK,
         get_autostart_prompt_state_response,
         config_manager=get_config_manager(),
     )
@@ -105,7 +121,8 @@ async def post_autostart_prompt_heartbeat(request: Request):
     # 同上：读状态、算 eligibility、落盘全在 _AUTOSTART_STATE_LOCK（threading.RLock）
     # 内部完成，临界区不跨 await。这个端点是前端轮询的，每次可能触发一次 atomic_write_json，
     # 必须挪出事件循环。
-    return await asyncio.to_thread(
+    return await _run_serialized_in_worker(
+        _AUTOSTART_SUBMIT_LOCK,
         process_autostart_prompt_heartbeat,
         payload,
         config_manager=get_config_manager(),
@@ -123,7 +140,8 @@ async def post_autostart_prompt_shown(request: Request):
 
     try:
         # 同上：读—改—写整段在 _AUTOSTART_STATE_LOCK 内，挪进线程安全。
-        return await asyncio.to_thread(
+        return await _run_serialized_in_worker(
+            _AUTOSTART_SUBMIT_LOCK,
             record_autostart_prompt_shown,
             payload,
             config_manager=get_config_manager(),
@@ -143,7 +161,8 @@ async def post_autostart_prompt_decision(request: Request):
 
     try:
         # 同上：读—改—写整段在 _AUTOSTART_STATE_LOCK 内，挪进线程安全。
-        return await asyncio.to_thread(
+        return await _run_serialized_in_worker(
+            _AUTOSTART_SUBMIT_LOCK,
             record_autostart_prompt_decision,
             payload,
             config_manager=get_config_manager(),

--- a/main_routers/system_router/prompt_flows.py
+++ b/main_routers/system_router/prompt_flows.py
@@ -19,6 +19,7 @@ Split out of the former monolithic ``main_routers/system_router.py``.
 """
 
 from ._shared import _read_json_object, _validate_local_mutation_request, router
+import asyncio
 from fastapi import Request
 from fastapi.responses import JSONResponse
 from ..shared_state import get_config_manager
@@ -38,7 +39,18 @@ from utils.seven_day_tutorial_state import (
 @router.get("/seven-day-tutorial/state")
 async def get_seven_day_tutorial_state():
     """Return the authoritative Day 1-7 tutorial progress."""
-    return get_seven_day_tutorial_state_response(config_manager=get_config_manager())
+    # 这个 GET 也要挪出循环，两个理由：
+    # 1) 它不是纯读 —— load_seven_day_tutorial_store 在 store 还没 initialized 时会
+    #    走 _migrate_legacy_tutorial_state，那里面是一次带 fsync 的 atomic_write_json
+    #    （老用户升级后第一次拉进度必然命中）。
+    # 2) 更要紧的是它在循环线程上 acquire 与下面 PUT 相同的 _STATE_LOCK。PUT 已经挪进
+    #    worker，而 file_utils 的「事件循环上绝不退避」保护是**按线程**判断的：worker
+    #    里撞上 Windows busy 会重新启用那 155ms 退避，且是持着 RLock 睡的。只要循环
+    #    线程还会去抢这把锁，退避就会经由锁重新传回循环。两边都挪走，这条路径才真的断。
+    return await asyncio.to_thread(
+        get_seven_day_tutorial_state_response,
+        config_manager=get_config_manager(),
+    )
 
 
 @router.put("/seven-day-tutorial/state")
@@ -49,7 +61,11 @@ async def put_seven_day_tutorial_state(request: Request):
     if validation_error is not None:
         return validation_error
     try:
-        store = replace_seven_day_tutorial_state(
+        # 整个「读 revision — 比对 — 落盘」都在 helper 内部的 _STATE_LOCK（threading.RLock）
+        # 里完成，临界区不跨 await，所以把整次调用挪进线程不会引入竞态；并发请求由那把
+        # RLock 在工作线程上排队，事件循环不再被 atomic_write_json 的 fsync 堵住。
+        store = await asyncio.to_thread(
+            replace_seven_day_tutorial_state,
             payload.get("state"),
             expected_revision=payload.get("expectedRevision"),
             config_manager=get_config_manager(),
@@ -68,7 +84,14 @@ async def put_seven_day_tutorial_state(request: Request):
 @router.get("/autostart-prompt/state")
 async def get_autostart_prompt_state():
     """Return a snapshot of the autostart prompt state."""
-    return get_autostart_prompt_state_response(config_manager=get_config_manager())
+    # 与 seven-day 的 GET 同因同治：load_autostart_prompt_state 在只剩 legacy 文件时
+    # 会落一次 save_autostart_prompt_state（utils/prompt_state/autostart.py:236），
+    # 而且它在循环线程上持 _AUTOSTART_STATE_LOCK —— 下面三个 POST 已挪进 worker，
+    # 这一条不挪，退避就会经由这把锁把 155ms 传回事件循环。
+    return await asyncio.to_thread(
+        get_autostart_prompt_state_response,
+        config_manager=get_config_manager(),
+    )
 
 
 @router.post("/autostart-prompt/heartbeat")
@@ -79,7 +102,14 @@ async def post_autostart_prompt_heartbeat(request: Request):
     if validation_error is not None:
         return validation_error
 
-    return process_autostart_prompt_heartbeat(payload, config_manager=get_config_manager())
+    # 同上：读状态、算 eligibility、落盘全在 _AUTOSTART_STATE_LOCK（threading.RLock）
+    # 内部完成，临界区不跨 await。这个端点是前端轮询的，每次可能触发一次 atomic_write_json，
+    # 必须挪出事件循环。
+    return await asyncio.to_thread(
+        process_autostart_prompt_heartbeat,
+        payload,
+        config_manager=get_config_manager(),
+    )
 
 
 @router.post("/autostart-prompt/shown")
@@ -92,7 +122,12 @@ async def post_autostart_prompt_shown(request: Request):
     payload = await _read_json_object(request)
 
     try:
-        return record_autostart_prompt_shown(payload, config_manager=get_config_manager())
+        # 同上：读—改—写整段在 _AUTOSTART_STATE_LOCK 内，挪进线程安全。
+        return await asyncio.to_thread(
+            record_autostart_prompt_shown,
+            payload,
+            config_manager=get_config_manager(),
+        )
     except ValueError as exc:
         return JSONResponse(status_code=400, content={"ok": False, "error": str(exc)})
 
@@ -107,6 +142,11 @@ async def post_autostart_prompt_decision(request: Request):
     payload = await _read_json_object(request)
 
     try:
-        return record_autostart_prompt_decision(payload, config_manager=get_config_manager())
+        # 同上：读—改—写整段在 _AUTOSTART_STATE_LOCK 内，挪进线程安全。
+        return await asyncio.to_thread(
+            record_autostart_prompt_decision,
+            payload,
+            config_manager=get_config_manager(),
+        )
     except ValueError as exc:
         return JSONResponse(status_code=400, content={"ok": False, "error": str(exc)})

--- a/main_routers/system_router/steam.py
+++ b/main_routers/system_router/steam.py
@@ -27,7 +27,7 @@ from urllib.parse import unquote
 from fastapi import Request
 from fastapi.responses import JSONResponse, Response
 from ..shared_state import ensure_steamworks as get_steamworks
-from utils.workshop_utils import get_workshop_path
+from utils.workshop_utils import get_workshop_path_async
 
 
 # Progress Stat for timed achievements. Steamworks Partner must bind
@@ -314,7 +314,9 @@ async def proxy_image(image_path: str):
         
         # 添加get_workshop_path()返回的路径作为允许目录，支持相对路径解析
         try:
-            workshop_base_dir = os.path.abspath(os.path.normpath(get_workshop_path()))
+            workshop_base_dir = os.path.abspath(
+                os.path.normpath(await get_workshop_path_async())
+            )
             if os.path.exists(workshop_base_dir):
                 real_workshop_dir = os.path.realpath(workshop_base_dir)
                 if real_workshop_dir not in allowed_dirs:
@@ -434,7 +436,9 @@ async def proxy_image(image_path: str):
         # 尝试相对于默认创意工坊目录的路径处理
         if final_path is None:
             try:
-                workshop_base_dir = os.path.abspath(os.path.normpath(get_workshop_path()))
+                workshop_base_dir = os.path.abspath(
+                    os.path.normpath(await get_workshop_path_async())
+                )
                 
                 # 尝试将解码路径作为相对于创意工坊目录的路径
                 rel_workshop_path = os.path.join(workshop_base_dir, decoded_path)

--- a/main_routers/workshop_router/config_files.py
+++ b/main_routers/workshop_router/config_files.py
@@ -69,7 +69,7 @@ async def save_workshop_config_api(config_data: dict):
         # 导入与get_workshop_config相同路径的函数，保持一致性
         from utils.workshop_utils import load_workshop_config, save_workshop_config, ensure_workshop_folder_exists
 
-        def _apply_config_transaction() -> tuple[dict, bool | None]:
+        def _apply_config_transaction() -> tuple[dict, str, bool]:
             with get_config_manager().workshop_config_lock():
                 # 读也放进锁里：不然两个请求各自读到同一份旧配置、各写各的合并结果，
                 # 后写的那次会把前一次的字段整份盖掉。
@@ -78,15 +78,26 @@ async def save_workshop_config_api(config_data: dict):
                     if key in config_data:
                         merged[key] = config_data[key]
                 save_workshop_config(merged)
-                folder_ready: bool | None = None
-                if merged.get('auto_create_folder', True):
-                    # 优先使用user_mod_folder，如果没有则使用default_workshop_folder
-                    folder_path = merged.get('user_mod_folder') or merged.get('default_workshop_folder')
-                    if folder_path:
-                        folder_ready = bool(ensure_workshop_folder_exists(folder_path))
-                return merged, folder_ready
+                auto_create = bool(merged.get('auto_create_folder', True))
+                # 优先使用user_mod_folder，如果没有则使用default_workshop_folder
+                folder_path = ''
+                if auto_create:
+                    folder_path = merged.get('user_mod_folder') or merged.get('default_workshop_folder') or ''
+            # ⚠️ 建目录在**锁外**做。它可能是网络盘 / 可移动盘上的 exists + makedirs，
+            # 慢得没有上界；而事件循环上还有 handler 裸调 get_workshop_path()。持着锁
+            # 做这件事就是把整条循环挂在那儿。策略（auto_create + 目标路径）已经在锁内
+            # 定死并显式传进去，所以 ensure 不会重读到别人的配置。
+            return merged, folder_path, auto_create
 
-        workshop_config_data, folder_ready = await asyncio.to_thread(_apply_config_transaction)
+        workshop_config_data, folder_path, auto_create = await asyncio.to_thread(
+            _apply_config_transaction
+        )
+        folder_ready: bool | None = None
+        if auto_create and folder_path:
+            folder_ready = await asyncio.to_thread(
+                ensure_workshop_folder_exists, folder_path, auto_create=True,
+            )
+            folder_ready = bool(folder_ready)
 
         # ensure_workshop_folder_exists 把创建失败（只读盘、权限不足）吞成返回 False。
         # 配置确实存下来了，所以 success 仍然是 True —— 但不能因此告诉用户目录也准备

--- a/main_routers/workshop_router/config_files.py
+++ b/main_routers/workshop_router/config_files.py
@@ -69,6 +69,17 @@ async def save_workshop_config_api(config_data: dict):
         # 导入与get_workshop_config相同路径的函数，保持一致性
         from utils.workshop_utils import load_workshop_config, save_workshop_config, ensure_workshop_folder_exists
 
+        # 落盘前先校验类型。前端塞个 {} 或 list 进来的话，这里不拦就直接写进配置文件，
+        # 之后 ensure_workshop_folder_exists 在 os.path.isabs() 上抛出来才报错 —— 配置
+        # 已经被写坏了，后续 get_workshop_path() 会把这个对象原样返回，凡是拿它去
+        # os.path.join() 的 workshop 调用全部失败，直到用户手工修好。
+        for key in ('default_workshop_folder', 'user_mod_folder'):
+            if key in config_data and not isinstance(config_data[key], str):
+                return {
+                    "success": False,
+                    "error": f"{key} 必须是字符串路径",
+                }
+
         def _apply_config_transaction() -> tuple[dict, str, bool]:
             with get_config_manager().workshop_config_lock():
                 # 读也放进锁里：不然两个请求各自读到同一份旧配置、各写各的合并结果，

--- a/main_routers/workshop_router/config_files.py
+++ b/main_routers/workshop_router/config_files.py
@@ -20,10 +20,10 @@ Split out of the former monolithic ``main_routers/workshop_router.py``.
 """
 
 from ._shared import logger, router
+from ..shared_state import get_config_manager
 
 import os
 import asyncio
-import threading
 from urllib.parse import unquote
 from fastapi.responses import JSONResponse
 from utils.workshop_utils import (
@@ -48,15 +48,19 @@ async def get_workshop_config():
 #
 # 这几步现在都跑在 worker 线程上（落盘含无上界 fsync，ensure 还可能对着网络盘或
 # 可移动盘做 exists / makedirs，留在事件循环上会卡住所有协程）。但一挪进线程，两个
-# 并发的 /config 请求就能真交错，而 ensure_workshop_folder_exists 会**重新读一次
-# 配置文件**来决定 auto_create（utils/workshop_utils.py:53 与 :75）：A 存下
-# auto_create=true + 目录 A，B 紧接着存下 auto_create=false，A 的 ensure 读到的是
-# B 的配置于是拒绝建目录，而 A 照样返回 success —— 用户看到"保存成功"但目录没建。
-# 改动前这一整段同步跑在循环线程上，物理上交错不了。
+# 并发请求就能真交错：
 #
-# 锁覆盖到 ensure 之内，所以它那次重读看到的一定是本次事务自己刚写的配置，不需要
-# 去改 ensure_workshop_folder_exists 这个公共 util 的签名。
-_WORKSHOP_CONFIG_TRANSACTION_LOCK = threading.Lock()
+# * 两个 /config 之间 —— ensure_workshop_folder_exists 会**重新读一次配置文件**来
+#   决定 auto_create（utils/workshop_utils.py:53 与 :75）：A 存下 auto_create=true +
+#   目录 A，B 紧接着存下 auto_create=false，A 的 ensure 读到 B 的配置于是拒绝建目录，
+#   而 A 照样返回 success。
+# * /config 与 GET /config 之间 —— load_workshop_config 那条路径**不是只读**：存储
+#   迁移之后 _rebase_workshop_config_after_storage_migration 会把自愈结果 save 回去。
+#   GET 可以「事务之前读、事务之后写」，把用户刚提交的设置整份盖掉。
+#
+# 所以用的是 ConfigManager 自己那把 _workshop_config_lock（经 workshop_config_lock()
+# 拿），而不是本模块私有的一把 —— 自愈写走的就是它，两边必须是同一把才挡得住。
+# 它是 RLock，所以持着它再调 load_workshop_config 不会自死锁。
 
 
 @router.post('/config')
@@ -66,7 +70,7 @@ async def save_workshop_config_api(config_data: dict):
         from utils.workshop_utils import load_workshop_config, save_workshop_config, ensure_workshop_folder_exists
 
         def _apply_config_transaction() -> tuple[dict, bool | None]:
-            with _WORKSHOP_CONFIG_TRANSACTION_LOCK:
+            with get_config_manager().workshop_config_lock():
                 # 读也放进锁里：不然两个请求各自读到同一份旧配置、各写各的合并结果，
                 # 后写的那次会把前一次的字段整份盖掉。
                 merged = load_workshop_config() or {}

--- a/main_routers/workshop_router/config_files.py
+++ b/main_routers/workshop_router/config_files.py
@@ -65,7 +65,7 @@ async def save_workshop_config_api(config_data: dict):
         # 导入与get_workshop_config相同路径的函数，保持一致性
         from utils.workshop_utils import load_workshop_config, save_workshop_config, ensure_workshop_folder_exists
 
-        def _apply_config_transaction() -> dict:
+        def _apply_config_transaction() -> tuple[dict, bool | None]:
             with _WORKSHOP_CONFIG_TRANSACTION_LOCK:
                 # 读也放进锁里：不然两个请求各自读到同一份旧配置、各写各的合并结果，
                 # 后写的那次会把前一次的字段整份盖掉。
@@ -74,16 +74,25 @@ async def save_workshop_config_api(config_data: dict):
                     if key in config_data:
                         merged[key] = config_data[key]
                 save_workshop_config(merged)
+                folder_ready: bool | None = None
                 if merged.get('auto_create_folder', True):
                     # 优先使用user_mod_folder，如果没有则使用default_workshop_folder
                     folder_path = merged.get('user_mod_folder') or merged.get('default_workshop_folder')
                     if folder_path:
-                        ensure_workshop_folder_exists(folder_path)
-                return merged
+                        folder_ready = bool(ensure_workshop_folder_exists(folder_path))
+                return merged, folder_ready
 
-        workshop_config_data = await asyncio.to_thread(_apply_config_transaction)
+        workshop_config_data, folder_ready = await asyncio.to_thread(_apply_config_transaction)
 
-        return {"success": True, "config": workshop_config_data}
+        # ensure_workshop_folder_exists 把创建失败（只读盘、权限不足）吞成返回 False。
+        # 配置确实存下来了，所以 success 仍然是 True —— 但不能因此告诉用户目录也准备
+        # 好了：那条路径接下来根本用不了。两件事分开报。
+        response = {"success": True, "config": workshop_config_data}
+        if folder_ready is not None:
+            response["folder_ready"] = folder_ready
+            if not folder_ready:
+                response["warning"] = "配置已保存，但指定的工坊目录无法创建（路径只读或权限不足）"
+        return response
     except Exception as e:
         logger.error(f"保存创意工坊配置失败: {str(e)}")
         return {"success": False, "error": str(e)}

--- a/main_routers/workshop_router/config_files.py
+++ b/main_routers/workshop_router/config_files.py
@@ -103,6 +103,28 @@ async def save_workshop_config_api(config_data: dict):
                     "success": False,
                     "error": f"{key} 必须是绝对路径",
                 }
+            # 正向校验：这个串必须真的能被 os.path 当路径处理。嵌了 NUL 的值能过
+            # isabs（它只看前缀），但之后每一次 os.path.* 都会抛 ValueError —— 而配置
+            # 那时已经写进去了，接口只是「先落盘再报错」，之后所有 workshop 文件操作
+            # 都对着这个毒值抛，直到用户再存一次才好。
+            #
+            # 不逐个字符类去补（NUL、控制字符、超长……）：让 OS 自己判「能不能用」，
+            # 一条规则关掉整类，而不是想到哪个补哪个。
+            try:
+                os.stat(value)
+            except ValueError as exc:
+                # OS 层根本收不下这个串（嵌 NUL 是典型）。注意纯路径函数判不出来：
+                # os.path.isdir 会把 ValueError 吞成 False，normpath / realpath 原样
+                # 返回 —— 只有真正下到系统调用才暴露。不拦的话这个值会被写进配置，
+                # 之后每次 _assert_under_base → os.path.realpath → 实际 IO 都炸，
+                # 直到用户再存一次才好。
+                return {
+                    "success": False,
+                    "error": f"{key} 不是合法路径: {exc}",
+                }
+            except OSError:
+                # 不存在 / 无权限不是格式问题，交给后面的 ensure 去处理。
+                pass
         if 'auto_create_folder' in config_data and not isinstance(
             config_data['auto_create_folder'], bool
         ):

--- a/main_routers/workshop_router/config_files.py
+++ b/main_routers/workshop_router/config_files.py
@@ -86,7 +86,12 @@ async def save_workshop_config_api(config_data: dict):
             # 解析它并报 folder_ready: true，而 get_workshop_path() 原样返回那个相对
             # 串、后续 _assert_under_base 又按服务进程的工作目录解析 —— 两边指向不同
             # 的地方，而我们已经告诉用户「建好了」。宁可让调用方给绝对路径。
-            if value.strip() and not os.path.isabs(value):
+            if not value.strip():
+                return {
+                    "success": False,
+                    "error": f"{key} 不能是空白",
+                }
+            if not os.path.isabs(value):
                 return {
                     "success": False,
                     "error": f"{key} 必须是绝对路径",

--- a/main_routers/workshop_router/config_files.py
+++ b/main_routers/workshop_router/config_files.py
@@ -74,13 +74,34 @@ async def save_workshop_config_api(config_data: dict):
         # 已经被写坏了，后续 get_workshop_path() 会把这个对象原样返回，凡是拿它去
         # os.path.join() 的 workshop 调用全部失败，直到用户手工修好。
         for key in ('default_workshop_folder', 'user_mod_folder'):
-            if key in config_data and not isinstance(config_data[key], str):
+            if key not in config_data:
+                continue
+            value = config_data[key]
+            if not isinstance(value, str):
                 return {
                     "success": False,
                     "error": f"{key} 必须是字符串路径",
                 }
+            # 相对路径直接拒，不做「猜一个 base 再normalize」。ensure 会按用户主目录
+            # 解析它并报 folder_ready: true，而 get_workshop_path() 原样返回那个相对
+            # 串、后续 _assert_under_base 又按服务进程的工作目录解析 —— 两边指向不同
+            # 的地方，而我们已经告诉用户「建好了」。宁可让调用方给绝对路径。
+            if value.strip() and not os.path.isabs(value):
+                return {
+                    "success": False,
+                    "error": f"{key} 必须是绝对路径",
+                }
+        if 'auto_create_folder' in config_data and not isinstance(
+            config_data['auto_create_folder'], bool
+        ):
+            # 字符串 "false" 是 truthy —— 不拦就会在用户明确说「别建」的时候建目录，
+            # 而且把这个畸形值留在盘上。
+            return {
+                "success": False,
+                "error": "auto_create_folder 必须是布尔值",
+            }
 
-        def _apply_config_transaction() -> tuple[dict, str, bool]:
+        def _apply_config_transaction() -> tuple[dict, bool | None]:
             with get_config_manager().workshop_config_lock():
                 # 读也放进锁里：不然两个请求各自读到同一份旧配置、各写各的合并结果，
                 # 后写的那次会把前一次的字段整份盖掉。
@@ -94,21 +115,27 @@ async def save_workshop_config_api(config_data: dict):
                 folder_path = ''
                 if auto_create:
                     folder_path = merged.get('user_mod_folder') or merged.get('default_workshop_folder') or ''
-            # ⚠️ 建目录在**锁外**做。它可能是网络盘 / 可移动盘上的 exists + makedirs，
-            # 慢得没有上界；而事件循环上还有 handler 裸调 get_workshop_path()。持着锁
-            # 做这件事就是把整条循环挂在那儿。策略（auto_create + 目标路径）已经在锁内
-            # 定死并显式传进去，所以 ensure 不会重读到别人的配置。
-            return merged, folder_path, auto_create
+            # ⚠️ 建目录在**锁外、但仍在同一个 worker 里**做。
+            #
+            # 锁外：它可能是网络盘 / 可移动盘上的 exists + makedirs，慢得没有上界；
+            # 而事件循环上还有 handler 裸调 get_workshop_path()，持锁做这件事就是把
+            # 整条循环挂在那儿。策略（auto_create + 目标路径）已经在锁内定死并显式
+            # 传进去，所以 ensure 不会重读到别人的配置。
+            #
+            # 同一个 worker：拆成两次 to_thread 的话，取消会落在两者之间 ——
+            # asyncio.to_thread 不会停掉已经开跑的 worker，但 CancelledError 会让
+            # handler 再也走不到第二次调用，于是「配置写了、目录没建」。请求超时和
+            # 应用关闭都会走到这条路径。
+            folder_ready = None
+            if auto_create and folder_path:
+                folder_ready = bool(
+                    ensure_workshop_folder_exists(folder_path, auto_create=True)
+                )
+            return merged, folder_ready
 
-        workshop_config_data, folder_path, auto_create = await asyncio.to_thread(
+        workshop_config_data, folder_ready = await asyncio.to_thread(
             _apply_config_transaction
         )
-        folder_ready: bool | None = None
-        if auto_create and folder_path:
-            folder_ready = await asyncio.to_thread(
-                ensure_workshop_folder_exists, folder_path, auto_create=True,
-            )
-            folder_ready = bool(folder_ready)
 
         # ensure_workshop_folder_exists 把创建失败（只读盘、权限不足）吞成返回 False。
         # 配置确实存下来了，所以 success 仍然是 True —— 但不能因此告诉用户目录也准备

--- a/main_routers/workshop_router/config_files.py
+++ b/main_routers/workshop_router/config_files.py
@@ -23,6 +23,7 @@ from ._shared import logger, router
 
 import os
 import asyncio
+import threading
 from urllib.parse import unquote
 from fastapi.responses import JSONResponse
 from utils.workshop_utils import (
@@ -43,40 +44,45 @@ async def get_workshop_config():
 
 # 保存创意工坊配置
 
+# 整个「读 → 合并 → 落盘 → 建目录」是一次事务，必须串行。
+#
+# 这几步现在都跑在 worker 线程上（落盘含无上界 fsync，ensure 还可能对着网络盘或
+# 可移动盘做 exists / makedirs，留在事件循环上会卡住所有协程）。但一挪进线程，两个
+# 并发的 /config 请求就能真交错，而 ensure_workshop_folder_exists 会**重新读一次
+# 配置文件**来决定 auto_create（utils/workshop_utils.py:53 与 :75）：A 存下
+# auto_create=true + 目录 A，B 紧接着存下 auto_create=false，A 的 ensure 读到的是
+# B 的配置于是拒绝建目录，而 A 照样返回 success —— 用户看到"保存成功"但目录没建。
+# 改动前这一整段同步跑在循环线程上，物理上交错不了。
+#
+# 锁覆盖到 ensure 之内，所以它那次重读看到的一定是本次事务自己刚写的配置，不需要
+# 去改 ensure_workshop_folder_exists 这个公共 util 的签名。
+_WORKSHOP_CONFIG_TRANSACTION_LOCK = threading.Lock()
+
+
 @router.post('/config')
 async def save_workshop_config_api(config_data: dict):
     try:
         # 导入与get_workshop_config相同路径的函数，保持一致性
         from utils.workshop_utils import load_workshop_config, save_workshop_config, ensure_workshop_folder_exists
-        
-        # 先加载现有配置，避免使用全局变量导致的不一致问题
-        workshop_config_data = await asyncio.to_thread(load_workshop_config) or {}
-        
-        # 更新配置
-        if 'default_workshop_folder' in config_data:
-            workshop_config_data['default_workshop_folder'] = config_data['default_workshop_folder']
-        if 'auto_create_folder' in config_data:
-            workshop_config_data['auto_create_folder'] = config_data['auto_create_folder']
-        # 支持用户mod路径配置
-        if 'user_mod_folder' in config_data:
-            workshop_config_data['user_mod_folder'] = config_data['user_mod_folder']
-        
-        # 落盘 + 建目录一起交给同一个 worker。ensure_workshop_folder_exists 自己
-        # 还要再读一次配置文件、exists 一把、可能 os.makedirs —— 目标是网络盘或可
-        # 移动盘时这几下同样能把事件循环卡住，而且它必须排在保存之后（读的是刚写
-        # 进去的配置）。收成一个单元既保住次序，也不留半截在环上。
-        folder_path = ''
-        if workshop_config_data.get('auto_create_folder', True):
-            # 优先使用user_mod_folder，如果没有则使用default_workshop_folder
-            folder_path = workshop_config_data.get('user_mod_folder') or workshop_config_data.get('default_workshop_folder') or ''
 
-        def _save_and_ensure() -> None:
-            save_workshop_config(workshop_config_data)
-            if folder_path:
-                ensure_workshop_folder_exists(folder_path)
+        def _apply_config_transaction() -> dict:
+            with _WORKSHOP_CONFIG_TRANSACTION_LOCK:
+                # 读也放进锁里：不然两个请求各自读到同一份旧配置、各写各的合并结果，
+                # 后写的那次会把前一次的字段整份盖掉。
+                merged = load_workshop_config() or {}
+                for key in ('default_workshop_folder', 'auto_create_folder', 'user_mod_folder'):
+                    if key in config_data:
+                        merged[key] = config_data[key]
+                save_workshop_config(merged)
+                if merged.get('auto_create_folder', True):
+                    # 优先使用user_mod_folder，如果没有则使用default_workshop_folder
+                    folder_path = merged.get('user_mod_folder') or merged.get('default_workshop_folder')
+                    if folder_path:
+                        ensure_workshop_folder_exists(folder_path)
+                return merged
 
-        await asyncio.to_thread(_save_and_ensure)
-        
+        workshop_config_data = await asyncio.to_thread(_apply_config_transaction)
+
         return {"success": True, "config": workshop_config_data}
     except Exception as e:
         logger.error(f"保存创意工坊配置失败: {str(e)}")

--- a/main_routers/workshop_router/config_files.py
+++ b/main_routers/workshop_router/config_files.py
@@ -86,10 +86,17 @@ async def save_workshop_config_api(config_data: dict):
             # 解析它并报 folder_ready: true，而 get_workshop_path() 原样返回那个相对
             # 串、后续 _assert_under_base 又按服务进程的工作目录解析 —— 两边指向不同
             # 的地方，而我们已经告诉用户「建好了」。宁可让调用方给绝对路径。
+            # 空串是**清除覆盖**的官方写法：get_workshop_path() 用
+            # `if config.get("user_mod_folder"):` 判断，空串 falsy 就回落到
+            # Steam / 缓存 / 默认（utils/config_manager/workshop.py:417）。上一版
+            # 一并拦掉它，等于用户只能设置和替换、再也无法通过接口清除，只能手改
+            # JSON。全空白（"   "）仍然拒 —— 那不是清除，是个会被当成真路径的值。
+            if value == "":
+                continue
             if not value.strip():
                 return {
                     "success": False,
-                    "error": f"{key} 不能是空白",
+                    "error": f"{key} 不能是空白（清除请传空字符串）",
                 }
             if not os.path.isabs(value):
                 return {

--- a/main_routers/workshop_router/config_files.py
+++ b/main_routers/workshop_router/config_files.py
@@ -62,7 +62,9 @@ async def save_workshop_config_api(config_data: dict):
             workshop_config_data['user_mod_folder'] = config_data['user_mod_folder']
         
         # 保存配置到文件，传递完整的配置数据作为参数
-        save_workshop_config(workshop_config_data)
+        # 整份配置由 atomic_write_json 整体替换；加载配置那步（上面）本来就是 await，
+        # 「读—改—写」之间早已存在让出点，这里挪到线程里不会新增竞态窗口。
+        await asyncio.to_thread(save_workshop_config, workshop_config_data)
         
         # 如果启用了自动创建文件夹且提供了路径，则确保文件夹存在
         if workshop_config_data.get('auto_create_folder', True):

--- a/main_routers/workshop_router/config_files.py
+++ b/main_routers/workshop_router/config_files.py
@@ -110,21 +110,7 @@ async def save_workshop_config_api(config_data: dict):
             #
             # 不逐个字符类去补（NUL、控制字符、超长……）：让 OS 自己判「能不能用」，
             # 一条规则关掉整类，而不是想到哪个补哪个。
-            try:
-                os.stat(value)
-            except ValueError as exc:
-                # OS 层根本收不下这个串（嵌 NUL 是典型）。注意纯路径函数判不出来：
-                # os.path.isdir 会把 ValueError 吞成 False，normpath / realpath 原样
-                # 返回 —— 只有真正下到系统调用才暴露。不拦的话这个值会被写进配置，
-                # 之后每次 _assert_under_base → os.path.realpath → 实际 IO 都炸，
-                # 直到用户再存一次才好。
-                return {
-                    "success": False,
-                    "error": f"{key} 不是合法路径: {exc}",
-                }
-            except OSError:
-                # 不存在 / 无权限不是格式问题，交给后面的 ensure 去处理。
-                pass
+
         if 'auto_create_folder' in config_data and not isinstance(
             config_data['auto_create_folder'], bool
         ):
@@ -136,6 +122,23 @@ async def save_workshop_config_api(config_data: dict):
             }
 
         def _apply_config_transaction() -> tuple[dict, bool | None]:
+            # 「OS 收不收得下这个串」的探针必须下到真正的系统调用（纯路径函数判不
+            # 出嵌 NUL：os.path.isdir 把 ValueError 吞成 False，normpath / realpath
+            # 原样返回）。而系统调用意味着 I/O —— 目标是慢速 UNC / 网络盘 / 可移动盘
+            # 时它可能挂很久，所以只能在 worker 里做，不能留在事件循环上。
+            # 抛出去由外层 except 收成 {"success": false, ...}；此刻还没写任何东西。
+            for probe_key in ('default_workshop_folder', 'user_mod_folder'):
+                probe = config_data.get(probe_key)
+                if not isinstance(probe, str) or probe == '':
+                    continue
+                try:
+                    os.stat(probe)
+                except ValueError as exc:
+                    raise ValueError(f"{probe_key} 不是合法路径: {exc}") from exc
+                except OSError:
+                    # 不存在 / 无权限不是格式问题，交给后面的 ensure 去处理。
+                    pass
+
             with get_config_manager().workshop_config_lock():
                 # 读也放进锁里：不然两个请求各自读到同一份旧配置、各写各的合并结果，
                 # 后写的那次会把前一次的字段整份盖掉。

--- a/main_routers/workshop_router/config_files.py
+++ b/main_routers/workshop_router/config_files.py
@@ -61,17 +61,21 @@ async def save_workshop_config_api(config_data: dict):
         if 'user_mod_folder' in config_data:
             workshop_config_data['user_mod_folder'] = config_data['user_mod_folder']
         
-        # 保存配置到文件，传递完整的配置数据作为参数
-        # 整份配置由 atomic_write_json 整体替换；加载配置那步（上面）本来就是 await，
-        # 「读—改—写」之间早已存在让出点，这里挪到线程里不会新增竞态窗口。
-        await asyncio.to_thread(save_workshop_config, workshop_config_data)
-        
-        # 如果启用了自动创建文件夹且提供了路径，则确保文件夹存在
+        # 落盘 + 建目录一起交给同一个 worker。ensure_workshop_folder_exists 自己
+        # 还要再读一次配置文件、exists 一把、可能 os.makedirs —— 目标是网络盘或可
+        # 移动盘时这几下同样能把事件循环卡住，而且它必须排在保存之后（读的是刚写
+        # 进去的配置）。收成一个单元既保住次序，也不留半截在环上。
+        folder_path = ''
         if workshop_config_data.get('auto_create_folder', True):
             # 优先使用user_mod_folder，如果没有则使用default_workshop_folder
-            folder_path = workshop_config_data.get('user_mod_folder') or workshop_config_data.get('default_workshop_folder')
+            folder_path = workshop_config_data.get('user_mod_folder') or workshop_config_data.get('default_workshop_folder') or ''
+
+        def _save_and_ensure() -> None:
+            save_workshop_config(workshop_config_data)
             if folder_path:
                 ensure_workshop_folder_exists(folder_path)
+
+        await asyncio.to_thread(_save_and_ensure)
         
         return {"success": True, "config": workshop_config_data}
     except Exception as e:

--- a/main_routers/workshop_router/config_files.py
+++ b/main_routers/workshop_router/config_files.py
@@ -23,11 +23,13 @@ from ._shared import logger, router
 from ..shared_state import get_config_manager
 
 import os
+import errno
+import stat
 import asyncio
 from urllib.parse import unquote
 from fastapi.responses import JSONResponse
 from utils.workshop_utils import (
-    get_workshop_path,
+    get_workshop_path_async,
 )
 
 
@@ -92,7 +94,12 @@ async def save_workshop_config_api(config_data: dict):
             # 一并拦掉它，等于用户只能设置和替换、再也无法通过接口清除，只能手改
             # JSON。全空白（"   "）仍然拒 —— 那不是清除，是个会被当成真路径的值。
             if value == "":
-                continue
+                if key == 'user_mod_folder':
+                    continue
+                return {
+                    "success": False,
+                    "error": "default_workshop_folder 不能为空",
+                }
             if not value.strip():
                 return {
                     "success": False,
@@ -132,12 +139,34 @@ async def save_workshop_config_api(config_data: dict):
                 if not isinstance(probe, str) or probe == '':
                     continue
                 try:
-                    os.stat(probe)
+                    probe_stat = os.stat(probe)
                 except ValueError as exc:
                     raise ValueError(f"{probe_key} 不是合法路径: {exc}") from exc
-                except OSError:
-                    # 不存在 / 无权限不是格式问题，交给后面的 ensure 去处理。
-                    pass
+                except OSError as exc:
+                    # 只放行「语法成立、但此刻不存在/不可访问」的形状。此前把所有
+                    # OSError 都吞掉，ENAMETOOLONG / EINVAL 也会被写进配置；之后每个
+                    # workshop 调用都对着毒路径失败，直到用户再保存一次。
+                    allowed_errnos = {errno.ENOENT, errno.EACCES, errno.EPERM}
+                    allowed_winerrors = {
+                        2,    # ERROR_FILE_NOT_FOUND
+                        3,    # ERROR_PATH_NOT_FOUND
+                        5,    # ERROR_ACCESS_DENIED
+                        21,   # ERROR_NOT_READY (removable drive)
+                        53,   # ERROR_BAD_NETPATH
+                        64,   # ERROR_NETNAME_DELETED
+                        67,   # ERROR_BAD_NET_NAME
+                        121,  # ERROR_SEM_TIMEOUT
+                    }
+                    if (
+                        getattr(exc, 'errno', None) not in allowed_errnos
+                        and getattr(exc, 'winerror', None) not in allowed_winerrors
+                    ):
+                        raise ValueError(
+                            f"{probe_key} 不是合法路径: {exc}"
+                        ) from exc
+                else:
+                    if not stat.S_ISDIR(probe_stat.st_mode):
+                        raise ValueError(f"{probe_key} 必须指向目录")
 
             with get_config_manager().workshop_config_lock():
                 # 读也放进锁里：不然两个请求各自读到同一份旧配置、各写各的合并结果，
@@ -204,7 +233,9 @@ async def read_workshop_file(path: str):
         
         # 解码URL编码的路径
         decoded_path = unquote(path)
-        decoded_path = _assert_under_base(decoded_path, get_workshop_path())
+        decoded_path = _assert_under_base(
+            decoded_path, await get_workshop_path_async()
+        )
         logger.info(f"解码后的路径: {decoded_path}")
         
         # 检查文件是否存在
@@ -248,7 +279,9 @@ async def list_chara_files(directory: str):
         logger.info(f"列出创意工坊目录下的角色卡文件请求，目录: {directory}")
         
         # 解码URL编码的路径
-        decoded_dir = _assert_under_base(unquote(directory), get_workshop_path())
+        decoded_dir = _assert_under_base(
+            unquote(directory), await get_workshop_path_async()
+        )
         logger.info(f"解码后的目录路径: {decoded_dir}")
         
         # 检查目录是否存在
@@ -281,7 +314,9 @@ async def list_audio_files(directory: str):
         logger.info(f"列出创意工坊目录下的音频文件请求，目录: {directory}")
         
         # 解码URL编码的路径并验证是否在workshop目录下
-        decoded_dir = _assert_under_base(unquote(directory), get_workshop_path())
+        decoded_dir = _assert_under_base(
+            unquote(directory), await get_workshop_path_async()
+        )
         logger.info(f"解码后的目录路径: {decoded_dir}")
         
         # 检查目录是否存在

--- a/main_routers/workshop_router/content_gate.py
+++ b/main_routers/workshop_router/content_gate.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Non-blocking ownership for Workshop content folders.
+
+Steam consumes the whole folder from ``SetItemContent`` until the upload
+finishes. Reference-audio writes and folder cleanup must therefore be excluded
+for that entire span, not just while the preflight reads the manifest.
+
+Claims are bookkeeping, never wait queues. Both claim and release belong to
+the worker-thread unit that performs the blocking work so cancellation of its
+awaiting coroutine cannot release a folder while that worker is still using it.
+"""
+
+import os
+import threading
+from contextlib import contextmanager
+from typing import Iterator
+
+
+class ContentFolderBusy(RuntimeError):
+    """The requested content folder is already owned by another operation."""
+
+
+PUBLISH_PURPOSE = '发布'
+CLEANUP_PURPOSE = '清理'
+
+_CLAIM_GUARD = threading.Lock()
+_EXCLUSIVE: dict[str, str] = {}
+_PAIR_WRITERS: dict[str, int] = {}
+
+
+def _claim_key(content_folder: str) -> str:
+    """Collapse aliases, symlinks and Windows junctions to one ownership key."""
+    return os.path.normcase(os.path.realpath(content_folder))
+
+
+@contextmanager
+def claim_content_folder(content_folder: str, *, purpose: str) -> Iterator[None]:
+    """Take a non-blocking exclusive claim for publish or folder deletion."""
+    key = _claim_key(content_folder)
+    with _CLAIM_GUARD:
+        holder = _EXCLUSIVE.get(key)
+        if holder is not None:
+            raise ContentFolderBusy(f'该内容目录正在{holder}，请等这次操作结束后再试')
+        if _PAIR_WRITERS.get(key):
+            raise ContentFolderBusy('参考语音正在写入，请稍后再试')
+        _EXCLUSIVE[key] = purpose
+    try:
+        yield
+    finally:
+        with _CLAIM_GUARD:
+            _EXCLUSIVE.pop(key, None)
+
+
+@contextmanager
+def claim_reference_pair(content_folder: str) -> Iterator[None]:
+    """Take a shared pair-write claim, excluded by whole-folder operations."""
+    key = _claim_key(content_folder)
+    with _CLAIM_GUARD:
+        holder = _EXCLUSIVE.get(key)
+        if holder is not None:
+            raise ContentFolderBusy(f'该物品正在{holder}，等这次操作结束后再修改参考语音')
+        _PAIR_WRITERS[key] = _PAIR_WRITERS.get(key, 0) + 1
+    try:
+        yield
+    finally:
+        with _CLAIM_GUARD:
+            remaining = _PAIR_WRITERS.get(key, 0) - 1
+            if remaining > 0:
+                _PAIR_WRITERS[key] = remaining
+            else:
+                _PAIR_WRITERS.pop(key, None)

--- a/main_routers/workshop_router/publish.py
+++ b/main_routers/workshop_router/publish.py
@@ -24,7 +24,7 @@ from .config_files import _assert_under_base
 from .meta import calculate_content_hash, read_workshop_meta, write_workshop_meta
 from .preview_cards import find_preview_image_in_folder
 from .ugc import get_subscribed_workshop_items
-from .voice_manifest import _resolve_workshop_voice_reference
+from .voice_manifest import resolve_voice_reference_serialized
 
 import os
 import sys
@@ -603,7 +603,10 @@ async def publish_to_workshop(request: Request):
                             logger.warning(f'继续使用原始预览图片路径: {preview_image}')
 
         try:
-            voice_ref = await asyncio.to_thread(_resolve_workshop_voice_reference, content_folder)
+            # 走串行化版本：上传的 swap 现在跑在 worker 上，裸读可能正好落在
+            # 「旧的已删、新的还没写」的中间，发布就会以「参考语音清单无效」失败，
+            # 而其实替换随后就完成了。这个调用点本来就在 to_thread 里，拿锁不碰循环。
+            voice_ref = await asyncio.to_thread(resolve_voice_reference_serialized, content_folder)
             if voice_ref:
                 logger.info(f"检测到参考语音清单: {voice_ref['manifest']['reference_audio']}")
         except (ValueError, FileNotFoundError) as e:

--- a/main_routers/workshop_router/publish.py
+++ b/main_routers/workshop_router/publish.py
@@ -21,6 +21,12 @@ Split out of the former monolithic ``main_routers/workshop_router.py``.
 
 from ._shared import logger, router
 from .config_files import _assert_under_base
+from .content_gate import (
+    CLEANUP_PURPOSE,
+    PUBLISH_PURPOSE,
+    ContentFolderBusy,
+    claim_content_folder,
+)
 from .meta import calculate_content_hash, read_workshop_meta, write_workshop_meta
 from .preview_cards import find_preview_image_in_folder
 from .ugc import get_subscribed_workshop_items
@@ -38,7 +44,7 @@ from fastapi.responses import JSONResponse
 from ..shared_state import ensure_steamworks as get_steamworks, get_config_manager
 from utils.file_utils import atomic_write_json_async, read_json_async
 from utils.workshop_utils import (
-    get_workshop_path,
+    get_workshop_path_async,
 )
 
 
@@ -57,7 +63,9 @@ async def check_upload_status(item_path: str = None):
             }, status_code=400)
         
         # 安全检查：使用get_workshop_path()作为基础目录
-        base_workshop_folder = os.path.abspath(os.path.normpath(get_workshop_path()))
+        base_workshop_folder = os.path.abspath(
+            os.path.normpath(await get_workshop_path_async())
+        )
         
         # Windows路径处理：确保路径分隔符正确
         if os.name == 'nt':  # Windows系统
@@ -193,7 +201,7 @@ async def prepare_workshop_upload(request: Request):
                 }, status_code=400)
         
         # 获取workshop基础路径
-        base_workshop_path = get_workshop_path()
+        base_workshop_path = await get_workshop_path_async()
         workshop_export_dir = os.path.join(base_workshop_path, 'WorkshopExport')
         
         # 确保WorkshopExport目录存在
@@ -384,13 +392,20 @@ async def prepare_workshop_upload(request: Request):
         }, status_code=500)
 
 
+def _delete_content_folder(temp_folder: str) -> None:
+    """Delete a temp folder only when no publisher or pair writer owns it."""
+    import shutil
+
+    with claim_content_folder(temp_folder, purpose=CLEANUP_PURPOSE):
+        shutil.rmtree(temp_folder, ignore_errors=True)
+
+
 @router.post('/cleanup-temp-folder')
 async def cleanup_temp_folder(request: Request):
     """
     Clean up the temporary upload directory.
     """
     try:
-        import shutil
         data = await request.json()
         temp_folder = data.get('temp_folder')
         
@@ -401,7 +416,7 @@ async def cleanup_temp_folder(request: Request):
             }, status_code=400)
         
         # 安全检查：确保临时目录在WorkshopExport下
-        base_workshop_path = get_workshop_path()
+        base_workshop_path = await get_workshop_path_async()
         workshop_export_dir = os.path.join(base_workshop_path, 'WorkshopExport')
         
         # 规范化路径（使用realpath处理符号链接和相对路径）
@@ -425,7 +440,7 @@ async def cleanup_temp_folder(request: Request):
         
         # 删除临时目录
         if os.path.exists(temp_folder):
-            await asyncio.to_thread(shutil.rmtree, temp_folder, ignore_errors=True)
+            await asyncio.to_thread(_delete_content_folder, temp_folder)
             logger.info(f"临时目录已删除: {temp_folder}")
             return JSONResponse({
                 "success": True,
@@ -437,6 +452,12 @@ async def cleanup_temp_folder(request: Request):
                 "error": "临时目录不存在"
             }, status_code=404)
             
+    except ContentFolderBusy as e:
+        logger.warning(f"临时目录正被占用，拒绝删除: {e}")
+        return JSONResponse({
+            "success": False,
+            "error": str(e)
+        }, status_code=409)
     except Exception as e:
         logger.error(f"清理临时目录失败: {e}")
         return JSONResponse({
@@ -481,7 +502,9 @@ async def publish_to_workshop(request: Request):
         content_folder = unquote(content_folder)
         # 安全检查：验证content_folder是否在允许的范围内
         try:
-            content_folder = _assert_under_base(content_folder, get_workshop_path())
+            content_folder = _assert_under_base(
+                content_folder, await get_workshop_path_async()
+            )
         except PermissionError:
             return JSONResponse(content={
                 "success": False,
@@ -602,20 +625,6 @@ async def publish_to_workshop(request: Request):
                             # 如果重命名失败，继续使用原始路径
                             logger.warning(f'继续使用原始预览图片路径: {preview_image}')
 
-        try:
-            # 走串行化版本：上传的 swap 现在跑在 worker 上，裸读可能正好落在
-            # 「旧的已删、新的还没写」的中间，发布就会以「参考语音清单无效」失败，
-            # 而其实替换随后就完成了。这个调用点本来就在 to_thread 里，拿锁不碰循环。
-            voice_ref = await asyncio.to_thread(resolve_voice_reference_serialized, content_folder)
-            if voice_ref:
-                logger.info(f"检测到参考语音清单: {voice_ref['manifest']['reference_audio']}")
-        except (ValueError, FileNotFoundError) as e:
-            return JSONResponse(content={
-                "success": False,
-                "error": "参考语音清单无效",
-                "message": str(e)
-            }, status_code=400)
-        
         # 记录将要上传的内容信息
         logger.info(f"准备发布创意工坊物品: {title}")
         logger.info(f"内容文件夹: {content_folder}")
@@ -637,13 +646,26 @@ async def publish_to_workshop(request: Request):
         
         # 使用线程池执行Steamworks API调用（因为这些是阻塞操作）
         loop = asyncio.get_event_loop()
-        published_file_id = await loop.run_in_executor(
-            None, 
-            lambda: _publish_workshop_item(
-                steamworks, title, description, content_folder, 
-                preview_image, visibility, tags, change_note, character_card_name
+        try:
+            published_file_id = await loop.run_in_executor(
+                None,
+                lambda: _preflight_and_publish(
+                    steamworks, title, description, content_folder,
+                    preview_image, visibility, tags, change_note, character_card_name
+                )
             )
-        )
+        except _VoicePreflightError as e:
+            return JSONResponse(content={
+                "success": False,
+                "error": "参考语音清单无效",
+                "message": str(e)
+            }, status_code=400)
+        except ContentFolderBusy as e:
+            return JSONResponse(content={
+                "success": False,
+                "error": "内容目录正被占用",
+                "message": str(e)
+            }, status_code=409)
         
         logger.info(f"成功发布创意工坊物品，ID: {published_file_id}")
         
@@ -717,6 +739,44 @@ async def publish_to_workshop(request: Request):
     except Exception as e:
         logger.error(f"发布到创意工坊失败: {e}")
         return JSONResponse(content={"success": False, "error": str(e)}, status_code=500)
+
+
+class _VoicePreflightError(Exception):
+    """The reference pair is invalid, so publishing must not start."""
+
+
+def _preflight_and_publish(
+    steamworks,
+    title,
+    description,
+    content_folder,
+    preview_image,
+    visibility,
+    tags,
+    change_note,
+    character_card_name=None,
+):
+    """Validate and publish one immutable view of the content directory."""
+    with claim_content_folder(content_folder, purpose=PUBLISH_PURPOSE):
+        try:
+            voice_ref = resolve_voice_reference_serialized(content_folder)
+        except (ValueError, FileNotFoundError) as e:
+            raise _VoicePreflightError(str(e)) from e
+        if voice_ref:
+            logger.info(
+                f"检测到参考语音清单: {voice_ref['manifest']['reference_audio']}"
+            )
+        return _publish_workshop_item(
+            steamworks,
+            title,
+            description,
+            content_folder,
+            preview_image,
+            visibility,
+            tags,
+            change_note,
+            character_card_name,
+        )
 
 
 def _publish_workshop_item(steamworks, title, description, content_folder, preview_image, visibility, tags, change_note, character_card_name=None):

--- a/main_routers/workshop_router/voice_manifest.py
+++ b/main_routers/workshop_router/voice_manifest.py
@@ -30,6 +30,9 @@ import threading
 WORKSHOP_VOICE_MANIFEST_NAME = 'voice_manifest.json'
 
 
+WORKSHOP_MANAGED_REFERENCE_AUDIO_KEY = '_neko_managed_reference_audio'
+
+
 WORKSHOP_REFERENCE_AUDIO_EXTENSIONS = {'.mp3', '.wav'}
 
 
@@ -90,7 +93,7 @@ def _normalize_workshop_voice_manifest(raw_manifest: dict, *, default_prefix: st
     except (TypeError, ValueError):
         version = 1
 
-    return {
+    normalized = {
         'version': version,
         'reference_audio': reference_audio,
         'prefix': prefix,
@@ -98,6 +101,16 @@ def _normalize_workshop_voice_manifest(raw_manifest: dict, *, default_prefix: st
         'display_name': display_name,
         'provider_hint': provider_hint,
     }
+    # This private marker is ownership metadata, not merely a second spelling
+    # of reference_audio. Only upload-reference-audio writes it. Cleanup may
+    # delete an audio file only when the marker and live reference agree, so a
+    # hand-edited/imported manifest cannot claim an unrelated user-owned file.
+    managed_reference = str(
+        raw_manifest.get(WORKSHOP_MANAGED_REFERENCE_AUDIO_KEY, '') or ''
+    ).strip()
+    if managed_reference == reference_audio:
+        normalized[WORKSHOP_MANAGED_REFERENCE_AUDIO_KEY] = managed_reference
+    return normalized
 
 
 # 按内容目录串行化「整对替换」与「读取整对」。写侧两次上传的 swap 跑在不同 worker
@@ -184,8 +197,14 @@ def _cleanup_workshop_voice_reference(content_folder: str) -> None:
         voice_ref = None
 
     if voice_ref:
+        manifest = voice_ref.get('manifest') or {}
         audio_path = voice_ref.get('audio_path')
-        if audio_path and os.path.exists(audio_path):
+        managed_audio = manifest.get(WORKSHOP_MANAGED_REFERENCE_AUDIO_KEY)
+        if (
+            managed_audio == manifest.get('reference_audio')
+            and audio_path
+            and os.path.exists(audio_path)
+        ):
             try:
                 os.remove(audio_path)
             except OSError as e:

--- a/main_routers/workshop_router/voice_manifest.py
+++ b/main_routers/workshop_router/voice_manifest.py
@@ -126,9 +126,15 @@ def voice_reference_lock(content_folder: str) -> threading.Lock:
 def resolve_voice_reference_serialized(item_dir: str) -> dict | None:
     """``_resolve_workshop_voice_reference`` that cannot observe a half-swap.
 
-    For readers running OUTSIDE the swap. Callers already inside the lock
-    (``_cleanup_workshop_voice_reference``) must keep using the unlocked form —
-    ``threading.Lock`` is not reentrant.
+    The rule this file follows: **everyone who reads or writes the pair in a
+    directory takes that directory's lock.** Stating it that way — rather than
+    "only the publish reader needs it, because the other readers happen to look
+    at Steam's install tree while uploads only ever write under
+    WorkshopExport" — keeps it from rotting the day those paths converge.
+
+    One exception, and it is structural: callers already inside the lock
+    (``_cleanup_workshop_voice_reference``, reached from the swap) must keep
+    using the unlocked form. ``threading.Lock`` is not reentrant.
     """
     with voice_reference_lock(item_dir):
         return _resolve_workshop_voice_reference(item_dir)
@@ -188,7 +194,9 @@ def _cleanup_workshop_voice_reference(content_folder: str) -> None:
 
 def _build_workshop_voice_reference_summary(install_folder: str) -> dict | None:
     try:
-        voice_ref = _resolve_workshop_voice_reference(install_folder)
+        # 走串行化读：见 resolve_voice_reference_serialized 的注释。这个函数只从
+        # ugc.py 的列表流程调用（已在 to_thread 里），不在锁内，不存在重入问题。
+        voice_ref = resolve_voice_reference_serialized(install_folder)
     except FileNotFoundError:
         return None
     except Exception as e:

--- a/main_routers/workshop_router/voice_manifest.py
+++ b/main_routers/workshop_router/voice_manifest.py
@@ -114,7 +114,12 @@ _VOICE_REFERENCE_LOCKS_GUARD = threading.Lock()
 
 
 def voice_reference_lock(content_folder: str) -> threading.Lock:
-    key = os.path.normcase(os.path.abspath(content_folder))
+    # realpath 而不是 abspath：abspath 只做词法规范化，不解析 symlink / junction。
+    # 写侧的 content_folder 来自 _assert_under_base 规范过的路径，读侧的
+    # install_folder 直接来自 Steam 的订阅项元数据 —— 同一个目录经由不同路径进来时
+    # 会各拿一把锁，串行化**静默**失效，而且不报任何错。Windows 上 Steam 库跨盘常用
+    # junction，这不是假想。realpath 对不存在的路径退化成词法规范化，不会抛。
+    key = os.path.normcase(os.path.realpath(content_folder))
     with _VOICE_REFERENCE_LOCKS_GUARD:
         lock = _VOICE_REFERENCE_LOCKS.get(key)
         if lock is None:

--- a/main_routers/workshop_router/voice_manifest.py
+++ b/main_routers/workshop_router/voice_manifest.py
@@ -24,6 +24,7 @@ from .config_files import _assert_under_base
 
 import os
 import json
+import threading
 
 
 WORKSHOP_VOICE_MANIFEST_NAME = 'voice_manifest.json'
@@ -97,6 +98,40 @@ def _normalize_workshop_voice_manifest(raw_manifest: dict, *, default_prefix: st
         'display_name': display_name,
         'provider_hint': provider_hint,
     }
+
+
+# 按内容目录串行化「整对替换」与「读取整对」。写侧两次上传的 swap 跑在不同 worker
+# 上，OS 层面会真交错（A 写音频、B 写音频、A 写 manifest → 盘上是 B 的音频配 A 的
+# manifest）；读侧同理，发布流程可能正好读在「旧的已删、新的还没写」的中间。改动前
+# 这些步骤都在事件循环线程上、彼此之间没有 await，物理上碰不到一起；挪进线程之后
+# 就得自己补上这个序列化。
+#
+# 锁只在 worker 线程里被持有：写侧走 asyncio.to_thread，读侧的 publish 调用点本来
+# 就是 await asyncio.to_thread(...)。事件循环从不去抢它，所以不会有「worker 持锁、
+# 循环等锁」那类传导。
+_VOICE_REFERENCE_LOCKS: dict[str, threading.Lock] = {}
+_VOICE_REFERENCE_LOCKS_GUARD = threading.Lock()
+
+
+def voice_reference_lock(content_folder: str) -> threading.Lock:
+    key = os.path.normcase(os.path.abspath(content_folder))
+    with _VOICE_REFERENCE_LOCKS_GUARD:
+        lock = _VOICE_REFERENCE_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _VOICE_REFERENCE_LOCKS[key] = lock
+    return lock
+
+
+def resolve_voice_reference_serialized(item_dir: str) -> dict | None:
+    """``_resolve_workshop_voice_reference`` that cannot observe a half-swap.
+
+    For readers running OUTSIDE the swap. Callers already inside the lock
+    (``_cleanup_workshop_voice_reference``) must keep using the unlocked form —
+    ``threading.Lock`` is not reentrant.
+    """
+    with voice_reference_lock(item_dir):
+        return _resolve_workshop_voice_reference(item_dir)
 
 
 def _resolve_workshop_voice_reference(item_dir: str) -> dict | None:

--- a/main_routers/workshop_router/voice_manifest.py
+++ b/main_routers/workshop_router/voice_manifest.py
@@ -36,6 +36,41 @@ WORKSHOP_MANAGED_REFERENCE_AUDIO_KEY = '_neko_managed_reference_audio'
 WORKSHOP_REFERENCE_AUDIO_EXTENSIONS = {'.mp3', '.wav'}
 
 
+# 冻结的存量兼容集：marker 出现之前，upload 写的参考音频是固定名 voice_sample<ext>，
+# 这两个字面量是旧代码**唯一**写过的名字。存量用户盘上的 manifest 没有 marker，不认
+# 它们就会在升级后第一次换/移除参考语音时把自己生成的录音永远留在内容目录里（publish
+# 是把整个目录交给 SetItemContent 的，它会跟着发出去）。
+# ⚠️ 这是「保持改动前已有的删除行为」，不是「按名字形状猜所有权」。永远不要把它放宽成
+# 前缀或通配（voice_sample*）—— 内容目录是用户自己的目录，那样他放进去的同前缀文件就会
+# 被静默删掉，而那正是 marker 要终结的东西。
+WORKSHOP_LEGACY_MANAGED_REFERENCE_NAMES = frozenset(
+    f'voice_sample{ext}' for ext in WORKSHOP_REFERENCE_AUDIO_EXTENSIONS
+)
+
+
+def _reference_is_managed(manifest: dict) -> bool:
+    """Whether this module may delete the audio the manifest points at.
+
+    Deletion needs proof of ownership, not merely a usable reference: imported
+    and hand-edited manifests routinely point at the user's own assets.
+
+    Two things count as proof, and nothing else. The private marker, written
+    only when this route commits a file it generated, and a frozen two-name
+    legacy set for manifests written before the marker existed. A manifest that
+    carries a marker is not pre-marker, so a mismatched marker never falls
+    through to the legacy branch.
+    """
+    reference = manifest.get('reference_audio')
+    if not isinstance(reference, str) or not reference:
+        return False
+    if manifest.get(WORKSHOP_MANAGED_REFERENCE_AUDIO_KEY) == reference:
+        return True
+    return (
+        WORKSHOP_MANAGED_REFERENCE_AUDIO_KEY not in manifest
+        and reference in WORKSHOP_LEGACY_MANAGED_REFERENCE_NAMES
+    )
+
+
 WORKSHOP_REFERENCE_AUDIO_CONTENT_TYPES = {
     'audio/mpeg': '.mp3',
     'audio/mp3': '.mp3',
@@ -102,14 +137,19 @@ def _normalize_workshop_voice_manifest(raw_manifest: dict, *, default_prefix: st
         'provider_hint': provider_hint,
     }
     # This private marker is ownership metadata, not merely a second spelling
-    # of reference_audio. Only upload-reference-audio writes it. Cleanup may
-    # delete an audio file only when the marker and live reference agree, so a
-    # hand-edited/imported manifest cannot claim an unrelated user-owned file.
-    managed_reference = str(
-        raw_manifest.get(WORKSHOP_MANAGED_REFERENCE_AUDIO_KEY, '') or ''
-    ).strip()
-    if managed_reference == reference_audio:
-        normalized[WORKSHOP_MANAGED_REFERENCE_AUDIO_KEY] = managed_reference
+    # of reference_audio. Only upload-reference-audio writes it, and only
+    # ``_reference_is_managed`` interprets it.
+    #
+    # Presence is carried through even when the value disagrees with the live
+    # reference. Dropping a mismatched marker here would erase the difference
+    # between "written before the marker existed" and "carries a marker that
+    # does not match", and the first of those is the only one the legacy
+    # allowlist may forgive. Keeping it makes the predicate read the same on a
+    # raw manifest and on a normalized one.
+    if WORKSHOP_MANAGED_REFERENCE_AUDIO_KEY in raw_manifest:
+        normalized[WORKSHOP_MANAGED_REFERENCE_AUDIO_KEY] = str(
+            raw_manifest.get(WORKSHOP_MANAGED_REFERENCE_AUDIO_KEY) or ''
+        ).strip()
     return normalized
 
 
@@ -199,12 +239,7 @@ def _cleanup_workshop_voice_reference(content_folder: str) -> None:
     if voice_ref:
         manifest = voice_ref.get('manifest') or {}
         audio_path = voice_ref.get('audio_path')
-        managed_audio = manifest.get(WORKSHOP_MANAGED_REFERENCE_AUDIO_KEY)
-        if (
-            managed_audio == manifest.get('reference_audio')
-            and audio_path
-            and os.path.exists(audio_path)
-        ):
+        if _reference_is_managed(manifest) and audio_path and os.path.exists(audio_path):
             try:
                 os.remove(audio_path)
             except OSError as e:

--- a/main_routers/workshop_router/voice_refs.py
+++ b/main_routers/workshop_router/voice_refs.py
@@ -35,20 +35,61 @@ from .voice_manifest import (
 
 import os
 import asyncio
+import threading
 import mimetypes
 from urllib.parse import unquote
 from fastapi import Request
 from fastapi.responses import FileResponse, JSONResponse
-from utils.file_utils import atomic_write_json_async
+from utils.file_utils import atomic_write_json
 from utils.workshop_utils import (
     get_workshop_path,
 )
 
 
-def _write_bytes(path: str, data: bytes) -> None:
-    """Write bytes to path, overwriting any existing file."""
-    with open(path, 'wb') as f:
-        f.write(data)
+# 按内容目录串行化整次替换。两次上传打到同一个目录时，它们各自的 swap 跑在不同的
+# worker 线程上，OS 层面会真交错：A 写音频、B 写音频、A 写 manifest —— 最终盘上是
+# B 的音频配 A 的 manifest（prefix / 语言 / display_name 全是另一次请求的）。改动前
+# 这两步都跑在事件循环线程上、中间没有 await，物理上交错不了；挪进线程就必须自己
+# 补上这个序列化。锁只在 worker 里被持有，事件循环从不去抢它。
+_VOICE_REFERENCE_LOCKS: dict[str, threading.Lock] = {}
+_VOICE_REFERENCE_LOCKS_GUARD = threading.Lock()
+
+
+def _voice_reference_lock(content_folder: str) -> threading.Lock:
+    key = os.path.normcase(os.path.abspath(content_folder))
+    with _VOICE_REFERENCE_LOCKS_GUARD:
+        lock = _VOICE_REFERENCE_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _VOICE_REFERENCE_LOCKS[key] = lock
+    return lock
+
+
+def _replace_voice_reference(
+    content_folder: str,
+    audio_path: str,
+    audio_bytes: bytes,
+    manifest_path: str,
+    manifest: dict,
+) -> None:
+    """Swap in a new reference-audio/manifest pair as one blocking unit.
+
+    Kept synchronous on purpose so the caller can hand the whole swap to a
+    single worker thread: the three steps have no await between them, so a
+    cancelled request can never observe a half-replaced pair. The per-folder
+    lock covers the other direction — two workers racing the same folder.
+    """
+    with _voice_reference_lock(content_folder):
+        _cleanup_workshop_voice_reference(content_folder)
+        with open(audio_path, 'wb') as f:
+            f.write(audio_bytes)
+        atomic_write_json(manifest_path, manifest, ensure_ascii=False, indent=2)
+
+
+def _remove_voice_reference(content_folder: str) -> None:
+    """Drop the reference pair under the same per-folder lock as the swap."""
+    with _voice_reference_lock(content_folder):
+        _cleanup_workshop_voice_reference(content_folder)
 
 
 @router.post('/upload-reference-audio')
@@ -110,13 +151,7 @@ async def upload_reference_audio(request: Request):
         if provider_hint not in WORKSHOP_REFERENCE_PROVIDER_HINTS:
             provider_hint = 'cosyvoice'
 
-        _cleanup_workshop_voice_reference(content_folder)
-
         reference_audio_name = f'voice_sample{file_ext}'
-        reference_audio_path = os.path.join(content_folder, reference_audio_name)
-        # 上传的音频可能有几 MB，写盘挪到线程里，别压在事件循环上
-        await asyncio.to_thread(_write_bytes, reference_audio_path, await file.read())
-
         manifest = _normalize_workshop_voice_manifest({
             'version': 1,
             'reference_audio': reference_audio_name,
@@ -125,11 +160,27 @@ async def upload_reference_audio(request: Request):
             'display_name': display_name,
             'provider_hint': provider_hint,
         }, default_prefix=prefix, default_display_name=display_name)
-        await atomic_write_json_async(
+
+        # 先把整个请求体读完，再一次性把「删旧 → 写音频 → 写 manifest」交给一个
+        # 线程。这样做不只是为了别在循环上写几 MB：
+        #
+        # 这三步必须成对成套，而它们之间的任何一个 await 都是取消点 ——
+        # 客户端一断开，FastAPI 就取消 handler，CancelledError 是 BaseException，
+        # 下面那个 `except Exception` 接不住，也就没人回滚。改动前这里是
+        # 「删旧（同步）→ await file.read() → 写音频 → 写 manifest（同步）」，
+        # 取消落在那个 read 上就会留下「旧的删了、新的没写」。
+        #
+        # 收成一个 to_thread 单元之后，唯一的取消点落在任何写盘之前：线程一旦
+        # 启动，取消等待方并不会杀掉线程，三步照样跑完。中间态从此不可达 ——
+        # 比改动前更严格，不只是把新引入的那个窗口补回去。
+        audio_bytes = await file.read()
+        await asyncio.to_thread(
+            _replace_voice_reference,
+            content_folder,
+            os.path.join(content_folder, reference_audio_name),
+            audio_bytes,
             os.path.join(content_folder, WORKSHOP_VOICE_MANIFEST_NAME),
             manifest,
-            ensure_ascii=False,
-            indent=2,
         )
 
         return JSONResponse({
@@ -167,7 +218,10 @@ async def remove_reference_audio(request: Request):
             }, status_code=403)
 
         if os.path.exists(content_folder) and os.path.isdir(content_folder):
-            _cleanup_workshop_voice_reference(content_folder)
+            # 也走同一把 per-folder 锁：上传的 swap 现在跑在 worker 上，删除要是
+            # 留在事件循环上做，就能插进「写音频」和「写 manifest」之间，留下一个
+            # 指不到文件的 manifest。
+            await asyncio.to_thread(_remove_voice_reference, content_folder)
 
         return JSONResponse({
             "success": True,

--- a/main_routers/workshop_router/voice_refs.py
+++ b/main_routers/workshop_router/voice_refs.py
@@ -20,6 +20,7 @@ Split out of the former monolithic ``main_routers/workshop_router.py``.
 
 from ._shared import logger, router
 from .config_files import _assert_under_base
+from .content_gate import ContentFolderBusy, claim_reference_pair
 from .ugc import _find_subscribed_item_by_id
 from .voice_manifest import (
     WORKSHOP_REFERENCE_AUDIO_CONTENT_TYPES,
@@ -46,60 +47,8 @@ from fastapi import Request
 from fastapi.responses import FileResponse, JSONResponse
 from utils.file_utils import atomic_write_json
 from utils.workshop_utils import (
-    get_workshop_path,
+    get_workshop_path_async,
 )
-
-
-def _replace_voice_reference(
-    content_folder: str,
-    audio_path: str,
-    audio_bytes: bytes,
-    manifest_path: str,
-    manifest: dict,
-) -> None:
-    """Swap in a new reference-audio/manifest pair as one blocking unit.
-
-    Kept synchronous on purpose so the caller can hand the whole swap to a
-    single worker thread: the steps have no await between them, so a cancelled
-    request can never observe a half-replaced pair. The per-folder lock covers
-    the other direction — two workers racing the same folder.
-
-    The manifest write is the single commit point. The new audio goes to its
-    own filename, so nothing that the current manifest points at is ever
-    overwritten or deleted before that commit: any failure up to it leaves the
-    previous pair byte-for-byte intact, and any state after it is the complete
-    new pair. There is no window in which the two halves come from different
-    uploads, so there is nothing to roll back.
-    """
-    with voice_reference_lock(content_folder):
-        # 1) 新音频先落到同目录的 tmp，fsync 之后再 os.replace 到它**自己的**文件名。
-        #    这个名字不会是当前 manifest 指着的那个（handler 每次生成新 token），
-        #    所以这一步不覆盖、不删除任何在用的东西。
-        fd, temp_audio = tempfile.mkstemp(dir=content_folder, suffix='.tmp')
-        try:
-            with os.fdopen(fd, 'wb') as f:
-                f.write(audio_bytes)
-                f.flush()
-                os.fsync(f.fileno())
-            os.replace(temp_audio, audio_path)
-
-            # 2) 唯一的提交点。atomic_write_json 是 tmp + os.replace，要么整份旧
-            #    manifest，要么整份新 manifest —— 这一步之前失败，盘上还是完完整整的
-            #    旧一对。
-            atomic_write_json(manifest_path, manifest, ensure_ascii=False, indent=2)
-        except BaseException:
-            with suppress(OSError):
-                os.remove(temp_audio)
-            # 没提交成功就把刚落下的新音频也清掉：它没人引用，但 publish 是把整个
-            # 内容目录交给 SetItemContent 的，留着会让一次「报了失败」的上传照样被
-            # 发布出去。删不掉也只是个孤儿，下次成功替换时会被扫走。
-            with suppress(OSError):
-                os.remove(audio_path)
-            raise
-
-        # 3) 提交之后再扫掉所有没人引用的参考音频（上一次的、以及之前失败留下的
-        #    孤儿）。删失败只是占点磁盘，不影响这对引用可用，所以吞掉。
-        _sweep_unreferenced_audio(content_folder, keep=audio_path)
 
 
 def _current_reference_audio_path(content_folder: str) -> str | None:
@@ -161,7 +110,7 @@ def _replace_voice_reference(
     new pair. There is no window in which the two halves come from different
     uploads, so there is nothing to roll back.
     """
-    with voice_reference_lock(content_folder):
+    with claim_reference_pair(content_folder), voice_reference_lock(content_folder):
         # 进来时这个目录里「属于我们」的音频，就是当前 manifest 指着的那一个 ——
         # 这是**可证明**的所有权。按名字形状猜（voice_sample*、甚至
         # voice_sample_<12 位 hex>）都还是概率论：内容目录是用户自己的目录，他放一个
@@ -210,8 +159,8 @@ def _replace_voice_reference(
 
 
 def _remove_voice_reference(content_folder: str) -> None:
-    """Drop the reference pair under the same per-folder lock as the swap."""
-    with voice_reference_lock(content_folder):
+    """Drop the reference pair while no whole-folder consumer owns the item."""
+    with claim_reference_pair(content_folder), voice_reference_lock(content_folder):
         _cleanup_workshop_voice_reference(content_folder)
 
 
@@ -222,7 +171,9 @@ async def upload_reference_audio(request: Request):
         form = await request.form()
         file = form.get('file')
         content_folder = unquote(str(form.get('content_folder', '') or '').strip())
-        workshop_export_dir = os.path.join(get_workshop_path(), 'WorkshopExport')
+        workshop_export_dir = os.path.join(
+            await get_workshop_path_async(), 'WorkshopExport'
+        )
 
         if not file:
             return JSONResponse({
@@ -314,6 +265,11 @@ async def upload_reference_audio(request: Request):
             "manifest": manifest,
             "message": "参考语音已写入工坊内容目录",
         })
+    except ContentFolderBusy as e:
+        return JSONResponse({
+            "success": False,
+            "error": str(e),
+        }, status_code=409)
     except Exception as e:
         logger.error(f"上传参考语音失败: {e}")
         return JSONResponse({
@@ -328,7 +284,9 @@ async def remove_reference_audio(request: Request):
     try:
         data = await request.json()
         content_folder = unquote(str(data.get('content_folder', '') or '').strip())
-        workshop_export_dir = os.path.join(get_workshop_path(), 'WorkshopExport')
+        workshop_export_dir = os.path.join(
+            await get_workshop_path_async(), 'WorkshopExport'
+        )
         if not content_folder:
             return JSONResponse({
                 "success": False,
@@ -353,6 +311,11 @@ async def remove_reference_audio(request: Request):
             "success": True,
             "message": "参考语音已清理",
         })
+    except ContentFolderBusy as e:
+        return JSONResponse({
+            "success": False,
+            "error": str(e),
+        }, status_code=409)
     except Exception as e:
         logger.error(f"删除参考语音失败: {e}")
         return JSONResponse({

--- a/main_routers/workshop_router/voice_refs.py
+++ b/main_routers/workshop_router/voice_refs.py
@@ -39,10 +39,16 @@ import mimetypes
 from urllib.parse import unquote
 from fastapi import Request
 from fastapi.responses import FileResponse, JSONResponse
-from utils.file_utils import atomic_write_json
+from utils.file_utils import atomic_write_json_async
 from utils.workshop_utils import (
     get_workshop_path,
 )
+
+
+def _write_bytes(path: str, data: bytes) -> None:
+    """Write bytes to path, overwriting any existing file."""
+    with open(path, 'wb') as f:
+        f.write(data)
 
 
 @router.post('/upload-reference-audio')
@@ -108,8 +114,8 @@ async def upload_reference_audio(request: Request):
 
         reference_audio_name = f'voice_sample{file_ext}'
         reference_audio_path = os.path.join(content_folder, reference_audio_name)
-        with open(reference_audio_path, 'wb') as f:
-            f.write(await file.read())
+        # 上传的音频可能有几 MB，写盘挪到线程里，别压在事件循环上
+        await asyncio.to_thread(_write_bytes, reference_audio_path, await file.read())
 
         manifest = _normalize_workshop_voice_manifest({
             'version': 1,
@@ -119,7 +125,7 @@ async def upload_reference_audio(request: Request):
             'display_name': display_name,
             'provider_hint': provider_hint,
         }, default_prefix=prefix, default_display_name=display_name)
-        atomic_write_json(
+        await atomic_write_json_async(
             os.path.join(content_folder, WORKSHOP_VOICE_MANIFEST_NAME),
             manifest,
             ensure_ascii=False,

--- a/main_routers/workshop_router/voice_refs.py
+++ b/main_routers/workshop_router/voice_refs.py
@@ -118,6 +118,12 @@ def _current_reference_audio_path(content_folder: str) -> str | None:
     reference = manifest.get('reference_audio') if isinstance(manifest, dict) else None
     if not isinstance(reference, str) or not reference:
         return None
+    # manifest 里写的不一定是音频。手改或畸形的 manifest 指向同目录的 preview.png
+    # 这类资产时，下面那次 os.remove 就会把用户的工坊素材删掉 —— 扩展名不对就当它
+    # 不是我们的东西。
+    if os.path.splitext(reference)[1].lower() not in WORKSHOP_REFERENCE_AUDIO_EXTENSIONS:
+        logger.warning('voice_manifest 的 reference_audio 不是支持的音频格式，拒绝清理: %r', reference)
+        return None
     # ⚠️ manifest 的内容不可信 —— 它可能是订阅来的、手改过的，`reference_audio` 里
     # 写个绝对路径或 `../../x` 就能让下面那次 os.remove 删到内容目录**外面**去。
     # 删任何东西之前先证明它在这个目录里。

--- a/main_routers/workshop_router/voice_refs.py
+++ b/main_routers/workshop_router/voice_refs.py
@@ -121,6 +121,12 @@ def _current_reference_audio_path(content_folder: str) -> str | None:
     # manifest 里写的不一定是音频。手改或畸形的 manifest 指向同目录的 preview.png
     # 这类资产时，下面那次 os.remove 就会把用户的工坊素材删掉 —— 扩展名不对就当它
     # 不是我们的东西。
+    # 带目录分量的引用永远不是我们的：本模块只往内容目录**直接**写
+    # voice_sample_<hex>.<ext>。`assets/theme.mp3` 这种能过下面的 containment
+    # 校验，但删的是用户放在子目录里的素材。
+    if os.path.basename(reference) != reference:
+        logger.warning('voice_manifest 的 reference_audio 带目录分量，拒绝清理: %r', reference)
+        return None
     if os.path.splitext(reference)[1].lower() not in WORKSHOP_REFERENCE_AUDIO_EXTENSIONS:
         logger.warning('voice_manifest 的 reference_audio 不是支持的音频格式，拒绝清理: %r', reference)
         return None

--- a/main_routers/workshop_router/voice_refs.py
+++ b/main_routers/workshop_router/voice_refs.py
@@ -91,17 +91,29 @@ def _replace_voice_reference(
             # 2) manifest 也是原子替换。走到这里新的一对才算完整可用。
             atomic_write_json(manifest_path, manifest, ensure_ascii=False, indent=2)
         except BaseException:
-            # 回滚到进来时的状态：旧音频挪回原位，旧 manifest 本来就没动过。
-            if backup_audio is not None and os.path.exists(backup_audio):
-                with suppress(OSError):
-                    os.replace(backup_audio, audio_path)
             with suppress(OSError):
                 os.remove(temp_audio)
-            raise
-        finally:
+            # 回滚到进来时的状态：旧音频挪回原位，旧 manifest 本来就没动过。
             if backup_audio is not None:
-                with suppress(OSError):
-                    os.remove(backup_audio)
+                try:
+                    os.replace(backup_audio, audio_path)
+                except OSError as restore_error:
+                    # ⚠️ 恢复也失败了（Windows 上目标仍被占着是最常见的原因）。
+                    # 此刻这个 .bak 是旧音频**唯一**的副本，绝不能删 —— 删了就是
+                    # 永久丢数据。留着它并把两个路径打进日志，至少还能人工恢复。
+                    logger.error(
+                        '参考语音回滚失败，旧音频保留在备份路径未删除: %s -> %s (%s)',
+                        backup_audio, audio_path, restore_error,
+                    )
+                else:
+                    with suppress(OSError):
+                        os.remove(backup_audio)
+            raise
+
+        # 成功路径：manifest 已经提交，备份到这里才可以删。
+        if backup_audio is not None:
+            with suppress(OSError):
+                os.remove(backup_audio)
 
         # 3) 最后才清掉「换了扩展名」留下的旧音频（mp3 → wav 这种）。同名的那次
         #    已经被上面的 os.replace 顶掉了。删失败只是留个孤儿文件，不影响这对

--- a/main_routers/workshop_router/voice_refs.py
+++ b/main_routers/workshop_router/voice_refs.py
@@ -35,6 +35,7 @@ from .voice_manifest import (
 )
 
 import os
+import re
 import asyncio
 import uuid
 import tempfile
@@ -101,17 +102,26 @@ def _replace_voice_reference(
         _sweep_unreferenced_audio(content_folder, keep=audio_path)
 
 
+# 只认自己生成的名字，不认「叫得像」的。内容目录是用户自己的目录，里面完全可能有
+# 一个他自己放的 voice_sample_demo.mp3 —— 按前缀扫就会把它删掉。所以匹配写死成
+# 这次上传生成的形状（voice_sample_<12 位 hex>.<ext>）加上历史遗留的裸
+# voice_sample.<ext>。跟 file_utils 里 tmp 用所有权标记而不是猜形状是同一条原则：
+# 可证明的所有权，不是概率论。
+_GENERATED_REFERENCE_AUDIO_RE = re.compile(r'^voice_sample(_[0-9a-f]{12})?$')
+
+
 def _sweep_unreferenced_audio(content_folder: str, *, keep: str) -> None:
-    """Delete reference-audio files that no manifest points at any more."""
+    """Delete reference-audio files this module generated and no longer references."""
     keep_real = os.path.normcase(os.path.abspath(keep))
     try:
         entries = os.listdir(content_folder)
     except OSError:
         return
     for name in entries:
-        if not name.startswith('voice_sample'):
+        stem, ext = os.path.splitext(name)
+        if not _GENERATED_REFERENCE_AUDIO_RE.match(stem):
             continue
-        if os.path.splitext(name)[1].lower() not in WORKSHOP_REFERENCE_AUDIO_EXTENSIONS:
+        if ext.lower() not in WORKSHOP_REFERENCE_AUDIO_EXTENSIONS:
             continue
         candidate = os.path.join(content_folder, name)
         if os.path.normcase(os.path.abspath(candidate)) == keep_real:

--- a/main_routers/workshop_router/voice_refs.py
+++ b/main_routers/workshop_router/voice_refs.py
@@ -36,6 +36,8 @@ from .voice_manifest import (
 
 import os
 import asyncio
+import tempfile
+from contextlib import suppress
 import mimetypes
 from urllib.parse import unquote
 from fastapi import Request
@@ -56,15 +58,43 @@ def _replace_voice_reference(
     """Swap in a new reference-audio/manifest pair as one blocking unit.
 
     Kept synchronous on purpose so the caller can hand the whole swap to a
-    single worker thread: the three steps have no await between them, so a
-    cancelled request can never observe a half-replaced pair. The per-folder
-    lock covers the other direction — two workers racing the same folder.
+    single worker thread: the steps have no await between them, so a cancelled
+    request can never observe a half-replaced pair. The per-folder lock covers
+    the other direction — two workers racing the same folder.
+
+    Nothing is deleted until the replacement is durable. Writing the new audio
+    first (staged, fsynced, then renamed into place) means a disk-full or
+    permission failure leaves the previous pair exactly as it was, instead of
+    destroying a reference the user cannot get back.
     """
     with voice_reference_lock(content_folder):
-        _cleanup_workshop_voice_reference(content_folder)
-        with open(audio_path, 'wb') as f:
-            f.write(audio_bytes)
+        # 1) 新音频先落到同目录的 tmp，fsync 之后再 os.replace 上去。
+        #    失败的话旧的一对纹丝不动 —— 这一步之前不删任何东西。
+        fd, temp_audio = tempfile.mkstemp(dir=content_folder, suffix='.tmp')
+        try:
+            with os.fdopen(fd, 'wb') as f:
+                f.write(audio_bytes)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(temp_audio, audio_path)
+        except BaseException:
+            with suppress(OSError):
+                os.remove(temp_audio)
+            raise
+
+        # 2) manifest 也是原子替换。走到这里新的一对已经完整可用。
         atomic_write_json(manifest_path, manifest, ensure_ascii=False, indent=2)
+
+        # 3) 最后才清掉「换了扩展名」留下的旧音频（mp3 → wav 这种）。同名的那次
+        #    已经被上面的 os.replace 顶掉了。删失败只是留个孤儿文件，不影响这对
+        #    引用可用，所以吞掉。
+        for ext in WORKSHOP_REFERENCE_AUDIO_EXTENSIONS:
+            stale = os.path.join(content_folder, f'voice_sample{ext}')
+            if os.path.abspath(stale) == os.path.abspath(audio_path):
+                continue
+            if os.path.exists(stale):
+                with suppress(OSError):
+                    os.remove(stale)
 
 
 def _remove_voice_reference(content_folder: str) -> None:

--- a/main_routers/workshop_router/voice_refs.py
+++ b/main_routers/workshop_router/voice_refs.py
@@ -118,7 +118,14 @@ def _current_reference_audio_path(content_folder: str) -> str | None:
     reference = manifest.get('reference_audio') if isinstance(manifest, dict) else None
     if not isinstance(reference, str) or not reference:
         return None
-    return os.path.join(content_folder, reference)
+    # ⚠️ manifest 的内容不可信 —— 它可能是订阅来的、手改过的，`reference_audio` 里
+    # 写个绝对路径或 `../../x` 就能让下面那次 os.remove 删到内容目录**外面**去。
+    # 删任何东西之前先证明它在这个目录里。
+    try:
+        return _assert_under_base(os.path.join(content_folder, reference), content_folder)
+    except (PermissionError, ValueError, OSError):
+        logger.warning('voice_manifest 的 reference_audio 指向内容目录之外，拒绝清理: %r', reference)
+        return None
 
 
 def _replace_voice_reference(

--- a/main_routers/workshop_router/voice_refs.py
+++ b/main_routers/workshop_router/voice_refs.py
@@ -68,22 +68,40 @@ def _replace_voice_reference(
     destroying a reference the user cannot get back.
     """
     with voice_reference_lock(content_folder):
-        # 1) 新音频先落到同目录的 tmp，fsync 之后再 os.replace 上去。
-        #    失败的话旧的一对纹丝不动 —— 这一步之前不删任何东西。
+        # 1) 新音频先落到同目录的 tmp，fsync 之后再 os.replace 顶上去。
         fd, temp_audio = tempfile.mkstemp(dir=content_folder, suffix='.tmp')
+        backup_audio = None
         try:
             with os.fdopen(fd, 'wb') as f:
                 f.write(audio_bytes)
                 f.flush()
                 os.fsync(f.fileno())
+
+            # 同扩展名替换时，os.replace 会把旧音频原地顶掉 —— 而 manifest 还没写。
+            # 万一第 2 步失败，盘上就是「新音频 + 旧 manifest」，偏偏文件名没变，
+            # _resolve_workshop_voice_reference 会认为这对有效：新音频配旧的
+            # prefix / 语言 / display_name / provider，而用户收到的是 500。静默的
+            # 不一致比响亮的失败糟得多，所以先把旧音频原子挪到一边留作回滚。
+            if os.path.exists(audio_path):
+                backup_audio = f'{temp_audio}.bak'
+                os.replace(audio_path, backup_audio)
+
             os.replace(temp_audio, audio_path)
+
+            # 2) manifest 也是原子替换。走到这里新的一对才算完整可用。
+            atomic_write_json(manifest_path, manifest, ensure_ascii=False, indent=2)
         except BaseException:
+            # 回滚到进来时的状态：旧音频挪回原位，旧 manifest 本来就没动过。
+            if backup_audio is not None and os.path.exists(backup_audio):
+                with suppress(OSError):
+                    os.replace(backup_audio, audio_path)
             with suppress(OSError):
                 os.remove(temp_audio)
             raise
-
-        # 2) manifest 也是原子替换。走到这里新的一对已经完整可用。
-        atomic_write_json(manifest_path, manifest, ensure_ascii=False, indent=2)
+        finally:
+            if backup_audio is not None:
+                with suppress(OSError):
+                    os.remove(backup_audio)
 
         # 3) 最后才清掉「换了扩展名」留下的旧音频（mp3 → wav 这种）。同名的那次
         #    已经被上面的 os.replace 顶掉了。删失败只是留个孤儿文件，不影响这对

--- a/main_routers/workshop_router/voice_refs.py
+++ b/main_routers/workshop_router/voice_refs.py
@@ -29,7 +29,7 @@ from .voice_manifest import (
     WORKSHOP_VOICE_MANIFEST_NAME,
     _cleanup_workshop_voice_reference,
     _normalize_workshop_voice_manifest,
-    _resolve_workshop_voice_reference,
+    resolve_voice_reference_serialized,
     _sanitize_voice_prefix,
     voice_reference_lock,
 )
@@ -243,7 +243,7 @@ async def get_workshop_voice_reference(item_id: str):
         }, status_code=404)
 
     try:
-        voice_ref = await asyncio.to_thread(_resolve_workshop_voice_reference, install_folder)
+        voice_ref = await asyncio.to_thread(resolve_voice_reference_serialized, install_folder)
     except FileNotFoundError as e:
         return JSONResponse({
             "success": False,
@@ -299,7 +299,7 @@ async def get_workshop_voice_reference_audio(item_id: str):
         }, status_code=404)
 
     try:
-        voice_ref = await asyncio.to_thread(_resolve_workshop_voice_reference, install_folder)
+        voice_ref = await asyncio.to_thread(resolve_voice_reference_serialized, install_folder)
     except FileNotFoundError as e:
         return JSONResponse({
             "success": False,

--- a/main_routers/workshop_router/voice_refs.py
+++ b/main_routers/workshop_router/voice_refs.py
@@ -36,6 +36,7 @@ from .voice_manifest import (
 
 import os
 import asyncio
+import uuid
 import tempfile
 from contextlib import suppress
 import mimetypes
@@ -62,69 +63,61 @@ def _replace_voice_reference(
     request can never observe a half-replaced pair. The per-folder lock covers
     the other direction — two workers racing the same folder.
 
-    Nothing is deleted until the replacement is durable. Writing the new audio
-    first (staged, fsynced, then renamed into place) means a disk-full or
-    permission failure leaves the previous pair exactly as it was, instead of
-    destroying a reference the user cannot get back.
+    The manifest write is the single commit point. The new audio goes to its
+    own filename, so nothing that the current manifest points at is ever
+    overwritten or deleted before that commit: any failure up to it leaves the
+    previous pair byte-for-byte intact, and any state after it is the complete
+    new pair. There is no window in which the two halves come from different
+    uploads, so there is nothing to roll back.
     """
     with voice_reference_lock(content_folder):
-        # 1) 新音频先落到同目录的 tmp，fsync 之后再 os.replace 顶上去。
+        # 1) 新音频先落到同目录的 tmp，fsync 之后再 os.replace 到它**自己的**文件名。
+        #    这个名字不会是当前 manifest 指着的那个（handler 每次生成新 token），
+        #    所以这一步不覆盖、不删除任何在用的东西。
         fd, temp_audio = tempfile.mkstemp(dir=content_folder, suffix='.tmp')
-        backup_audio = None
         try:
             with os.fdopen(fd, 'wb') as f:
                 f.write(audio_bytes)
                 f.flush()
                 os.fsync(f.fileno())
-
-            # 同扩展名替换时，os.replace 会把旧音频原地顶掉 —— 而 manifest 还没写。
-            # 万一第 2 步失败，盘上就是「新音频 + 旧 manifest」，偏偏文件名没变，
-            # _resolve_workshop_voice_reference 会认为这对有效：新音频配旧的
-            # prefix / 语言 / display_name / provider，而用户收到的是 500。静默的
-            # 不一致比响亮的失败糟得多，所以先把旧音频原子挪到一边留作回滚。
-            if os.path.exists(audio_path):
-                backup_audio = f'{temp_audio}.bak'
-                os.replace(audio_path, backup_audio)
-
             os.replace(temp_audio, audio_path)
 
-            # 2) manifest 也是原子替换。走到这里新的一对才算完整可用。
+            # 2) 唯一的提交点。atomic_write_json 是 tmp + os.replace，要么整份旧
+            #    manifest，要么整份新 manifest —— 这一步之前失败，盘上还是完完整整的
+            #    旧一对。
             atomic_write_json(manifest_path, manifest, ensure_ascii=False, indent=2)
         except BaseException:
             with suppress(OSError):
                 os.remove(temp_audio)
-            # 回滚到进来时的状态：旧音频挪回原位，旧 manifest 本来就没动过。
-            if backup_audio is not None:
-                try:
-                    os.replace(backup_audio, audio_path)
-                except OSError as restore_error:
-                    # ⚠️ 恢复也失败了（Windows 上目标仍被占着是最常见的原因）。
-                    # 此刻这个 .bak 是旧音频**唯一**的副本，绝不能删 —— 删了就是
-                    # 永久丢数据。留着它并把两个路径打进日志，至少还能人工恢复。
-                    logger.error(
-                        '参考语音回滚失败，旧音频保留在备份路径未删除: %s -> %s (%s)',
-                        backup_audio, audio_path, restore_error,
-                    )
-                else:
-                    with suppress(OSError):
-                        os.remove(backup_audio)
+            # 没提交成功就把刚落下的新音频也清掉：它没人引用，但 publish 是把整个
+            # 内容目录交给 SetItemContent 的，留着会让一次「报了失败」的上传照样被
+            # 发布出去。删不掉也只是个孤儿，下次成功替换时会被扫走。
+            with suppress(OSError):
+                os.remove(audio_path)
             raise
 
-        # 成功路径：manifest 已经提交，备份到这里才可以删。
-        if backup_audio is not None:
-            with suppress(OSError):
-                os.remove(backup_audio)
+        # 3) 提交之后再扫掉所有没人引用的参考音频（上一次的、以及之前失败留下的
+        #    孤儿）。删失败只是占点磁盘，不影响这对引用可用，所以吞掉。
+        _sweep_unreferenced_audio(content_folder, keep=audio_path)
 
-        # 3) 最后才清掉「换了扩展名」留下的旧音频（mp3 → wav 这种）。同名的那次
-        #    已经被上面的 os.replace 顶掉了。删失败只是留个孤儿文件，不影响这对
-        #    引用可用，所以吞掉。
-        for ext in WORKSHOP_REFERENCE_AUDIO_EXTENSIONS:
-            stale = os.path.join(content_folder, f'voice_sample{ext}')
-            if os.path.abspath(stale) == os.path.abspath(audio_path):
-                continue
-            if os.path.exists(stale):
-                with suppress(OSError):
-                    os.remove(stale)
+
+def _sweep_unreferenced_audio(content_folder: str, *, keep: str) -> None:
+    """Delete reference-audio files that no manifest points at any more."""
+    keep_real = os.path.normcase(os.path.abspath(keep))
+    try:
+        entries = os.listdir(content_folder)
+    except OSError:
+        return
+    for name in entries:
+        if not name.startswith('voice_sample'):
+            continue
+        if os.path.splitext(name)[1].lower() not in WORKSHOP_REFERENCE_AUDIO_EXTENSIONS:
+            continue
+        candidate = os.path.join(content_folder, name)
+        if os.path.normcase(os.path.abspath(candidate)) == keep_real:
+            continue
+        with suppress(OSError):
+            os.remove(candidate)
 
 
 def _remove_voice_reference(content_folder: str) -> None:
@@ -192,7 +185,10 @@ async def upload_reference_audio(request: Request):
         if provider_hint not in WORKSHOP_REFERENCE_PROVIDER_HINTS:
             provider_hint = 'cosyvoice'
 
-        reference_audio_name = f'voice_sample{file_ext}'
+        # 每次上传都用一个新的文件名：这样写新音频永远不会覆盖当前 manifest 指着的
+        # 那个文件，manifest 写才能成为唯一的提交点（见 _replace_voice_reference）。
+        # 消费侧一律从 manifest 的 reference_audio 取名字，不认死 voice_sample.<ext>。
+        reference_audio_name = f'voice_sample_{uuid.uuid4().hex[:12]}{file_ext}'
         manifest = _normalize_workshop_voice_manifest({
             'version': 1,
             'reference_audio': reference_audio_name,

--- a/main_routers/workshop_router/voice_refs.py
+++ b/main_routers/workshop_router/voice_refs.py
@@ -35,7 +35,7 @@ from .voice_manifest import (
 )
 
 import os
-import re
+import json
 import asyncio
 import uuid
 import tempfile
@@ -102,32 +102,84 @@ def _replace_voice_reference(
         _sweep_unreferenced_audio(content_folder, keep=audio_path)
 
 
-# 只认自己生成的名字，不认「叫得像」的。内容目录是用户自己的目录，里面完全可能有
-# 一个他自己放的 voice_sample_demo.mp3 —— 按前缀扫就会把它删掉。所以匹配写死成
-# 这次上传生成的形状（voice_sample_<12 位 hex>.<ext>）加上历史遗留的裸
-# voice_sample.<ext>。跟 file_utils 里 tmp 用所有权标记而不是猜形状是同一条原则：
-# 可证明的所有权，不是概率论。
-_GENERATED_REFERENCE_AUDIO_RE = re.compile(r'^voice_sample(_[0-9a-f]{12})?$')
+def _current_reference_audio_path(content_folder: str) -> str | None:
+    """The audio path the folder's manifest currently points at, if any.
 
-
-def _sweep_unreferenced_audio(content_folder: str, *, keep: str) -> None:
-    """Delete reference-audio files this module generated and no longer references."""
-    keep_real = os.path.normcase(os.path.abspath(keep))
+    Best-effort and never raises: a missing or malformed manifest just means
+    "nothing is claimed", which is the safe answer for a caller about to
+    delete something.
+    """
+    manifest_path = os.path.join(content_folder, WORKSHOP_VOICE_MANIFEST_NAME)
     try:
-        entries = os.listdir(content_folder)
-    except OSError:
-        return
-    for name in entries:
-        stem, ext = os.path.splitext(name)
-        if not _GENERATED_REFERENCE_AUDIO_RE.match(stem):
-            continue
-        if ext.lower() not in WORKSHOP_REFERENCE_AUDIO_EXTENSIONS:
-            continue
-        candidate = os.path.join(content_folder, name)
-        if os.path.normcase(os.path.abspath(candidate)) == keep_real:
-            continue
-        with suppress(OSError):
-            os.remove(candidate)
+        with open(manifest_path, 'r', encoding='utf-8') as f:
+            manifest = json.load(f)
+    except Exception:
+        return None
+    reference = manifest.get('reference_audio') if isinstance(manifest, dict) else None
+    if not isinstance(reference, str) or not reference:
+        return None
+    return os.path.join(content_folder, reference)
+
+
+def _replace_voice_reference(
+    content_folder: str,
+    audio_path: str,
+    audio_bytes: bytes,
+    manifest_path: str,
+    manifest: dict,
+) -> None:
+    """Swap in a new reference-audio/manifest pair as one blocking unit.
+
+    Kept synchronous on purpose so the caller can hand the whole swap to a
+    single worker thread: the steps have no await between them, so a cancelled
+    request can never observe a half-replaced pair. The per-folder lock covers
+    the other direction — two workers racing the same folder.
+
+    The manifest write is the single commit point. The new audio goes to its
+    own filename, so nothing the current manifest points at is ever
+    overwritten or deleted before that commit: any failure up to it leaves the
+    previous pair byte-for-byte intact, and any state after it is the complete
+    new pair. There is no window in which the two halves come from different
+    uploads, so there is nothing to roll back.
+    """
+    with voice_reference_lock(content_folder):
+        # 进来时这个目录里「属于我们」的音频，就是当前 manifest 指着的那一个 ——
+        # 这是**可证明**的所有权。按名字形状猜（voice_sample*、甚至
+        # voice_sample_<12 位 hex>）都还是概率论：内容目录是用户自己的目录，他放一个
+        # 同形状的文件进来就会被静默删掉。跟 file_utils 里 tmp 用所有权标记的理由一样。
+        previous_audio = _current_reference_audio_path(content_folder)
+
+        # 1) 新音频先落到同目录的 tmp，fsync 之后再 os.replace 到它**自己的**文件名。
+        #    这个名字不会是当前 manifest 指着的那个（handler 每次生成新 token），
+        #    所以这一步不覆盖、不删除任何在用的东西。
+        fd, temp_audio = tempfile.mkstemp(dir=content_folder, suffix='.tmp')
+        try:
+            with os.fdopen(fd, 'wb') as f:
+                f.write(audio_bytes)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(temp_audio, audio_path)
+
+            # 2) 唯一的提交点。atomic_write_json 是 tmp + os.replace，要么整份旧
+            #    manifest，要么整份新 manifest —— 这一步之前失败，盘上还是完完整整的
+            #    旧一对。
+            atomic_write_json(manifest_path, manifest, ensure_ascii=False, indent=2)
+        except BaseException:
+            with suppress(OSError):
+                os.remove(temp_audio)
+            # 没提交成功就把刚落下的新音频也清掉：它没人引用，但 publish 是把整个
+            # 内容目录交给 SetItemContent 的，留着会让一次「报了失败」的上传照样被
+            # 发布出去。
+            with suppress(OSError):
+                os.remove(audio_path)
+            raise
+
+        # 3) 提交之后，上一份 manifest 指着的那个音频才失去引用，这时才能删。
+        #    换了扩展名（mp3 → wav）时它跟新文件不同名；理论上同名的话上面的
+        #    os.replace 已经顶掉了，这里跳过。删失败只是占点磁盘。
+        if previous_audio and os.path.normcase(os.path.abspath(previous_audio)) != os.path.normcase(os.path.abspath(audio_path)):
+            with suppress(OSError):
+                os.remove(previous_audio)
 
 
 def _remove_voice_reference(content_folder: str) -> None:

--- a/main_routers/workshop_router/voice_refs.py
+++ b/main_routers/workshop_router/voice_refs.py
@@ -31,6 +31,7 @@ from .voice_manifest import (
     WORKSHOP_VOICE_MANIFEST_NAME,
     _cleanup_workshop_voice_reference,
     _normalize_workshop_voice_manifest,
+    _reference_is_managed,
     resolve_voice_reference_serialized,
     _sanitize_voice_prefix,
     voice_reference_lock,
@@ -68,7 +69,7 @@ def _current_reference_audio_path(content_folder: str) -> str | None:
     reference = manifest.get('reference_audio') if isinstance(manifest, dict) else None
     if not isinstance(reference, str) or not reference:
         return None
-    if manifest.get(WORKSHOP_MANAGED_REFERENCE_AUDIO_KEY) != reference:
+    if not _reference_is_managed(manifest):
         # A manifest is valid input for playback/publishing, but it is not by
         # itself proof that this process created (and therefore owns) the file.
         # Imported and hand-edited manifests commonly point at user assets.

--- a/main_routers/workshop_router/voice_refs.py
+++ b/main_routers/workshop_router/voice_refs.py
@@ -197,8 +197,16 @@ def _replace_voice_reference(
         #    换了扩展名（mp3 → wav）时它跟新文件不同名；理论上同名的话上面的
         #    os.replace 已经顶掉了，这里跳过。删失败只是占点磁盘。
         if previous_audio and os.path.normcase(os.path.abspath(previous_audio)) != os.path.normcase(os.path.abspath(audio_path)):
-            with suppress(OSError):
+            try:
                 os.remove(previous_audio)
+            except OSError as exc:
+                # 删不掉（杀软扫描、索引器、别的句柄占着）不影响这对引用可用 ——
+                # 但也别让它静默：那份被顶替的旧录音还留在内容目录里，publish 是把
+                # 整个目录交给 SetItemContent 的，会跟着发出去。打日志让它可查。
+                logger.warning(
+                    '被顶替的旧参考语音删除失败，仍留在内容目录里: %s (%s)',
+                    previous_audio, exc,
+                )
 
 
 def _remove_voice_reference(content_folder: str) -> None:

--- a/main_routers/workshop_router/voice_refs.py
+++ b/main_routers/workshop_router/voice_refs.py
@@ -31,11 +31,11 @@ from .voice_manifest import (
     _normalize_workshop_voice_manifest,
     _resolve_workshop_voice_reference,
     _sanitize_voice_prefix,
+    voice_reference_lock,
 )
 
 import os
 import asyncio
-import threading
 import mimetypes
 from urllib.parse import unquote
 from fastapi import Request
@@ -44,25 +44,6 @@ from utils.file_utils import atomic_write_json
 from utils.workshop_utils import (
     get_workshop_path,
 )
-
-
-# 按内容目录串行化整次替换。两次上传打到同一个目录时，它们各自的 swap 跑在不同的
-# worker 线程上，OS 层面会真交错：A 写音频、B 写音频、A 写 manifest —— 最终盘上是
-# B 的音频配 A 的 manifest（prefix / 语言 / display_name 全是另一次请求的）。改动前
-# 这两步都跑在事件循环线程上、中间没有 await，物理上交错不了；挪进线程就必须自己
-# 补上这个序列化。锁只在 worker 里被持有，事件循环从不去抢它。
-_VOICE_REFERENCE_LOCKS: dict[str, threading.Lock] = {}
-_VOICE_REFERENCE_LOCKS_GUARD = threading.Lock()
-
-
-def _voice_reference_lock(content_folder: str) -> threading.Lock:
-    key = os.path.normcase(os.path.abspath(content_folder))
-    with _VOICE_REFERENCE_LOCKS_GUARD:
-        lock = _VOICE_REFERENCE_LOCKS.get(key)
-        if lock is None:
-            lock = threading.Lock()
-            _VOICE_REFERENCE_LOCKS[key] = lock
-    return lock
 
 
 def _replace_voice_reference(
@@ -79,7 +60,7 @@ def _replace_voice_reference(
     cancelled request can never observe a half-replaced pair. The per-folder
     lock covers the other direction — two workers racing the same folder.
     """
-    with _voice_reference_lock(content_folder):
+    with voice_reference_lock(content_folder):
         _cleanup_workshop_voice_reference(content_folder)
         with open(audio_path, 'wb') as f:
             f.write(audio_bytes)
@@ -88,7 +69,7 @@ def _replace_voice_reference(
 
 def _remove_voice_reference(content_folder: str) -> None:
     """Drop the reference pair under the same per-folder lock as the swap."""
-    with _voice_reference_lock(content_folder):
+    with voice_reference_lock(content_folder):
         _cleanup_workshop_voice_reference(content_folder)
 
 

--- a/main_routers/workshop_router/voice_refs.py
+++ b/main_routers/workshop_router/voice_refs.py
@@ -27,6 +27,7 @@ from .voice_manifest import (
     WORKSHOP_REFERENCE_AUDIO_EXTENSIONS,
     WORKSHOP_REFERENCE_LANGUAGES,
     WORKSHOP_REFERENCE_PROVIDER_HINTS,
+    WORKSHOP_MANAGED_REFERENCE_AUDIO_KEY,
     WORKSHOP_VOICE_MANIFEST_NAME,
     _cleanup_workshop_voice_reference,
     _normalize_workshop_voice_manifest,
@@ -66,6 +67,11 @@ def _current_reference_audio_path(content_folder: str) -> str | None:
         return None
     reference = manifest.get('reference_audio') if isinstance(manifest, dict) else None
     if not isinstance(reference, str) or not reference:
+        return None
+    if manifest.get(WORKSHOP_MANAGED_REFERENCE_AUDIO_KEY) != reference:
+        # A manifest is valid input for playback/publishing, but it is not by
+        # itself proof that this process created (and therefore owns) the file.
+        # Imported and hand-edited manifests commonly point at user assets.
         return None
     # manifest 里写的不一定是音频。手改或畸形的 manifest 指向同目录的 preview.png
     # 这类资产时，下面那次 os.remove 就会把用户的工坊素材删掉 —— 扩展名不对就当它
@@ -232,6 +238,7 @@ async def upload_reference_audio(request: Request):
         manifest = _normalize_workshop_voice_manifest({
             'version': 1,
             'reference_audio': reference_audio_name,
+            WORKSHOP_MANAGED_REFERENCE_AUDIO_KEY: reference_audio_name,
             'prefix': prefix,
             'ref_language': ref_language,
             'display_name': display_name,

--- a/memory/anti_repeat.py
+++ b/memory/anti_repeat.py
@@ -67,6 +67,7 @@ Not extracted
 """  # noqa: DOCSTRING_CJK
 from __future__ import annotations
 
+import asyncio
 import json
 import math
 import os
@@ -401,6 +402,40 @@ class AntiRepeatCorpus:
                 del window[: len(window) - ANTI_REPEAT_BG_WINDOW]
             self._cache[name] = window
             self._save_unlocked(name)
+
+    async def arecord_output(
+        self,
+        name: str,
+        text: str,
+        *,
+        is_proactive: bool = False,
+        now: Optional[float] = None,
+    ) -> None:
+        """Off-loop twin of ``record_output`` for callers inside a coroutine.
+
+        ``record_output`` ends in an ``atomic_write_json``, which runs mkdir,
+        a stale-temp directory scan, mkstemp, write and an unbounded
+        ``os.fsync`` on the calling thread. This corpus is written on EVERY
+        committed assistant reply, so on the realtime session's loop that
+        physical flush lands between audio chunks.
+
+        The whole call is handed to a worker thread rather than only the
+        write: the read-modify-write runs under ``_get_lock(name)``, and a
+        ``threading.Lock`` serializes the loop thread against workers just as
+        well as it serializes workers against each other. Splitting the
+        critical section across the thread boundary would be the only way to
+        break that.
+        """
+        # now 在这里定好而不是留给 worker：两次 arecord_output 之间的线程调度
+        # 顺序不保证，时间戳必须钉在调用发生的那一刻。
+        stamped = float(now if now is not None else _now())
+        await asyncio.to_thread(
+            self.record_output,
+            name,
+            text,
+            is_proactive=is_proactive,
+            now=stamped,
+        )
 
     @staticmethod
     def _split_fg_bg(

--- a/memory/anti_repeat.py
+++ b/memory/anti_repeat.py
@@ -415,7 +415,19 @@ class AntiRepeatCorpus:
         with self._get_lock(name):
             if name in self._cache:
                 return
-        window = await asyncio.to_thread(self._read_window_from_disk, name)
+        try:
+            window = await asyncio.to_thread(self._read_window_from_disk, name)
+        except Exception as exc:
+            # Do not let a failed off-loop warmup send the same slow/unavailable
+            # path lookup back through _load_unlocked on the event loop. An
+            # empty cached window is the safe degraded state for this process;
+            # later records still populate and persist it normally.
+            logger.warning(
+                "[AntiRepeat] preload failed for %s, starting empty: %s",
+                name,
+                exc,
+            )
+            window = []
         with self._get_lock(name):
             self._cache.setdefault(name, window)
 

--- a/memory/anti_repeat.py
+++ b/memory/anti_repeat.py
@@ -293,6 +293,10 @@ class AntiRepeatCorpus:
         self._cache: Dict[str, List[Dict[str, Any]]] = {}
         self._locks: Dict[str, threading.Lock] = {}
         self._locks_guard = threading.Lock()
+        # 落盘用的第二把锁，和数据锁分开 —— 见 _flush_snapshot 的注释。
+        self._write_locks: Dict[str, threading.Lock] = {}
+        self._staged_seq: Dict[str, int] = {}
+        self._written_seq: Dict[str, int] = {}
 
     # ── path / lock ────────────────────────────────────────
 
@@ -309,6 +313,53 @@ class AntiRepeatCorpus:
                 if name not in self._locks:
                     self._locks[name] = threading.Lock()
         return self._locks[name]
+
+    def _get_write_lock(self, name: str) -> threading.Lock:
+        if name not in self._write_locks:
+            with self._locks_guard:
+                if name not in self._write_locks:
+                    self._write_locks[name] = threading.Lock()
+        return self._write_locks[name]
+
+    def _stage_snapshot_unlocked(self, name: str) -> Tuple[Dict[str, Any], int]:
+        """Take a numbered copy of the in-memory window. Caller holds the data lock."""
+        seq = self._staged_seq.get(name, 0) + 1
+        self._staged_seq[name] = seq
+        payload = {
+            "version": _SCHEMA_VERSION,
+            "window": list(self._cache.get(name, [])),
+        }
+        return payload, seq
+
+    def _flush_snapshot(self, name: str, payload: Dict[str, Any], seq: int) -> None:
+        """Write a staged snapshot to disk **without** holding the data lock.
+
+        The data lock must not be held across the write. ``arecord_output``
+        runs the whole record on a worker thread, while the scoring paths
+        (``score_draft`` / ``score_unanswered_proactive_draft`` /
+        ``top_recent_topics``) still take that lock synchronously on the event
+        loop. Holding it across ``atomic_write_json`` — whose tail is an
+        unbounded fsync — would make those readers block the loop waiting on a
+        worker, which is the exact stall this off-loading exists to remove.
+        Same shape as the RLock transitivity fixed in
+        ``main_routers/system_router/prompt_flows.py``.
+
+        Writers instead serialize on a second, writer-only lock. Ordering is
+        settled by the staged sequence number rather than by which worker wins
+        the lock: a snapshot older than what is already on disk is dropped, so
+        a late writer can never resurrect a stale window.
+        """
+        with self._get_write_lock(name):
+            if seq <= self._written_seq.get(name, 0):
+                return
+            try:
+                atomic_write_json(
+                    self._file_path(name), payload, indent=2, ensure_ascii=False,
+                )
+            except Exception as exc:
+                logger.warning("[AntiRepeat] save failed for %s: %s", name, exc)
+                return
+            self._written_seq[name] = seq
 
     # ── load / save (锁由调用方持有) ───────────────────────
 
@@ -342,17 +393,6 @@ class AntiRepeatCorpus:
             window = window[-ANTI_REPEAT_BG_WINDOW:]
         self._cache[name] = window
         return window
-
-    def _save_unlocked(self, name: str) -> None:
-        path = self._file_path(name)
-        payload = {
-            "version": _SCHEMA_VERSION,
-            "window": self._cache.get(name, []),
-        }
-        try:
-            atomic_write_json(path, payload, indent=2, ensure_ascii=False)
-        except Exception as exc:
-            logger.warning("[AntiRepeat] save failed for %s: %s", name, exc)
 
     # ── public API ─────────────────────────────────────────
 
@@ -396,12 +436,18 @@ class AntiRepeatCorpus:
         with self._get_lock(name):
             window = self._load_unlocked(name)
             window.append(entry)
-            # 滚动：超 BG_WINDOW 弹最老（按 ts 排序保险——理论上 append 时序就单调）
+            # 每次都按 ts 排序，不再只在超窗时排。原来「append 时序天然单调」的假设
+            # 靠的是调用方串行；arecord_output 把整次记录交给 worker 之后，两次记录
+            # 拿到锁的先后不再等于调用先后，而打分侧是拿尾部切片当「最近几条」的
+            # （_split_fg_bg），错序会让旧回复被当成更新的。窗口只有 ~100 条，
+            # 每次排一遍的代价可以忽略。
+            window.sort(key=lambda e: float(e.get("ts", 0)))
             if len(window) > ANTI_REPEAT_BG_WINDOW:
-                window.sort(key=lambda e: float(e.get("ts", 0)))
                 del window[: len(window) - ANTI_REPEAT_BG_WINDOW]
             self._cache[name] = window
-            self._save_unlocked(name)
+            payload, seq = self._stage_snapshot_unlocked(name)
+        # 落盘在数据锁**之外**——见 _flush_snapshot。
+        self._flush_snapshot(name, payload, seq)
 
     async def arecord_output(
         self,
@@ -635,7 +681,10 @@ class AntiRepeatCorpus:
         name = _resolve_name(name)
         with self._get_lock(name):
             self._cache[name] = []
-            self._save_unlocked(name)
+            payload, seq = self._stage_snapshot_unlocked(name)
+        # 与 record_output 同款：落盘不许在数据锁里做，否则事件循环上的打分调用
+        # 会卡在这次 fsync 上。清空也走 seq，免得它被一次在飞的旧快照写盖回去。
+        self._flush_snapshot(name, payload, seq)
 
 
 # ── 进程级单例 ─────────────────────────────────────────────

--- a/memory/anti_repeat.py
+++ b/memory/anti_repeat.py
@@ -470,6 +470,39 @@ class AntiRepeatCorpus:
             payload, seq = self._stage_snapshot_unlocked(name)
         return name, payload, seq
 
+    def stage_output(
+        self,
+        name: str,
+        text: str,
+        *,
+        is_proactive: bool = False,
+        now: Optional[float] = None,
+    ) -> Optional[Tuple[str, Dict[str, Any], int]]:
+        """Apply one record in memory now; return a handle to flush later.
+
+        For callers that must satisfy two conflicting orderings at once. The
+        in-memory half has to land BEFORE the turn's terminal signals: the
+        client can send its next message the instant it sees turn-end, and
+        scoring that message against a corpus still missing the reply just
+        committed is how the same line gets said twice. The disk half has to
+        land AFTER them: it is an ``await``, and a cancellation there would
+        otherwise skip the terminal signals entirely, leaving a visible turn
+        with no completion.
+
+        Splitting the two satisfies both — this call takes no await, so it
+        cannot be a cancellation point. Returns None when the text is skipped.
+        """
+        return self._record_in_memory(name, text, is_proactive=is_proactive, now=now)
+
+    async def aflush_staged(
+        self, staged: Optional[Tuple[str, Dict[str, Any], int]],
+    ) -> None:
+        """Write a snapshot staged by ``stage_output`` off the event loop."""
+        if staged is None:
+            return
+        name, payload, seq = staged
+        await asyncio.to_thread(self._flush_snapshot, name, payload, seq)
+
     async def arecord_output(
         self,
         name: str,

--- a/memory/anti_repeat.py
+++ b/memory/anti_repeat.py
@@ -363,9 +363,8 @@ class AntiRepeatCorpus:
 
     # ── load / save (锁由调用方持有) ───────────────────────
 
-    def _load_unlocked(self, name: str) -> List[Dict[str, Any]]:
-        if name in self._cache:
-            return self._cache[name]
+    def _read_window_from_disk(self, name: str) -> List[Dict[str, Any]]:
+        """Read and normalize one corpus window without taking the data lock."""
         window: List[Dict[str, Any]] = []
         path = self._file_path(name)
         if os.path.exists(path):
@@ -391,10 +390,34 @@ class AntiRepeatCorpus:
         if len(window) > ANTI_REPEAT_BG_WINDOW:
             window.sort(key=lambda e: float(e.get("ts", 0)))
             window = window[-ANTI_REPEAT_BG_WINDOW:]
+        return window
+
+    def _load_unlocked(self, name: str) -> List[Dict[str, Any]]:
+        if name in self._cache:
+            return self._cache[name]
+        window = self._read_window_from_disk(name)
         self._cache[name] = window
         return window
 
     # ── public API ─────────────────────────────────────────
+
+    async def apreload(self, name: str) -> None:
+        """Populate the first disk-backed window before synchronous loop use.
+
+        Scoring and staging stay synchronous because they sit on commit/order
+        boundaries where adding an await would reopen cancellation races. Their
+        first cache miss must therefore be paid earlier. Disk I/O happens
+        without the data lock; after it completes, installation is a tiny
+        in-memory critical section. ``setdefault`` preserves a window another
+        caller may have populated while this read was in flight.
+        """
+        name = _resolve_name(name)
+        with self._get_lock(name):
+            if name in self._cache:
+                return
+        window = await asyncio.to_thread(self._read_window_from_disk, name)
+        with self._get_lock(name):
+            self._cache.setdefault(name, window)
 
     def record_output(
         self,
@@ -519,12 +542,9 @@ class AntiRepeatCorpus:
         committed assistant reply, so on the realtime session's loop that
         physical flush lands between audio chunks.
 
-        The whole call is handed to a worker thread rather than only the
-        write: the read-modify-write runs under ``_get_lock(name)``, and a
-        ``threading.Lock`` serializes the loop thread against workers just as
-        well as it serializes workers against each other. Splitting the
-        critical section across the thread boundary would be the only way to
-        break that.
+        Callers that run this on an event loop must preload the first disk read
+        with ``apreload``. The in-memory update remains on the caller so the
+        next turn sees it immediately; only persistence is off-loaded.
         """
         # 内存更新留在调用线程上，只有落盘去 worker。整次记录都丢进 worker 的话，
         # 在那个 job 排队 / 算 ngram 的这段时间里，事件循环上的 score_draft /

--- a/memory/anti_repeat.py
+++ b/memory/anti_repeat.py
@@ -297,6 +297,9 @@ class AntiRepeatCorpus:
         self._write_locks: Dict[str, threading.Lock] = {}
         self._staged_seq: Dict[str, int] = {}
         self._written_seq: Dict[str, int] = {}
+        # 已摘下的落盘 task。只被局部变量引用的 task 会被 GC 回收，事件循环不保证
+        # 跑完它 —— 必须由这里持强引用到完成为止。见 flush_staged_detached。
+        self._detached_flushes: set = set()
 
     # ── path / lock ────────────────────────────────────────
 
@@ -537,6 +540,50 @@ class AntiRepeatCorpus:
             return
         name, payload, seq = staged
         await asyncio.to_thread(self._flush_snapshot, name, payload, seq)
+
+    def flush_staged_detached(
+        self, staged: Optional[Tuple[str, Dict[str, Any], int]],
+    ) -> None:
+        """Schedule the disk half without adding a cancellation point.
+
+        Use this wherever the caller still has to report a commit after the
+        flush. ``aflush_staged`` is an ``await``, and by the time it runs the
+        reply is already visible and the turn's terminal signals are already
+        out — the turn has happened no matter what the caller's task does next.
+        A ``CancelledError`` raised at that await is a ``BaseException``, so it
+        slips past the caller's ``except Exception`` and past the ``return``
+        that records the delivery. The caller's bookkeeping then reports "not
+        delivered" for a turn the user watched, and the same proactive line
+        becomes eligible to be sent a second time.
+
+        Detaching keeps that stretch free of cancellation points. Ordering
+        survives losing the caller: ``_flush_snapshot`` discards any snapshot
+        older than what is already on disk.
+        """
+        if staged is None:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # 没有循环可挂（同步调用方，或循环已经关停）。落盘是 best-effort，放弃它
+            # 比在这里同步 fsync 更安全 —— 后者正是这轮改动要移出事件循环的东西。
+            logger.debug("[AntiRepeat] detached flush skipped: no running loop")
+            return
+
+        task = loop.create_task(self.aflush_staged(staged))
+        self._detached_flushes.add(task)
+
+        def _done(finished: "asyncio.Task") -> None:
+            self._detached_flushes.discard(finished)
+            if finished.cancelled():
+                return
+            exc = finished.exception()
+            if exc is not None:
+                # 摘下来之后没人 await 它了，异常不主动取一次会变成
+                # "Task exception was never retrieved"。
+                logger.debug("[AntiRepeat] detached flush failed: %s", exc)
+
+        task.add_done_callback(_done)
 
     async def arecord_output(
         self,

--- a/memory/anti_repeat.py
+++ b/memory/anti_repeat.py
@@ -416,8 +416,32 @@ class AntiRepeatCorpus:
           user_directives sink / injection path); otherwise BM25 / soft hints would
           break entirely under an empty lanlan_name config (codex P2)
         """  # noqa: DOCSTRING_CJK
-        if not text or not text.strip():
+        staged = self._record_in_memory(name, text, is_proactive=is_proactive, now=now)
+        if staged is None:
             return
+        resolved, payload, seq = staged
+        # 落盘在数据锁**之外**——见 _flush_snapshot。
+        self._flush_snapshot(resolved, payload, seq)
+
+    def _record_in_memory(
+        self,
+        name: str,
+        text: str,
+        *,
+        is_proactive: bool,
+        now: Optional[float],
+    ) -> Optional[Tuple[str, Dict[str, Any], int]]:
+        """Apply one record to the in-memory window and stage it for the disk.
+
+        Returns the resolved name plus the staged snapshot, or None when the
+        text is skipped. Split out of ``record_output`` so the async twin can
+        run this part inline and off-load only the write: the scoring paths
+        read ``_cache``, so deferring the in-memory update to a worker would
+        let the very next turn score against a corpus that is missing the
+        reply just committed.
+        """
+        if not text or not text.strip():
+            return None
         name = _resolve_name(name)
         ngrams = _ngrams(text)
         min_tokens = (
@@ -426,7 +450,7 @@ class AntiRepeatCorpus:
             else ANTI_REPEAT_MIN_DRAFT_TOKENS
         )
         if len(ngrams) < min_tokens:
-            return
+            return None
         ts = float(now if now is not None else _now())
         entry = {
             "ts": ts,
@@ -437,17 +461,14 @@ class AntiRepeatCorpus:
             window = self._load_unlocked(name)
             window.append(entry)
             # 每次都按 ts 排序，不再只在超窗时排。原来「append 时序天然单调」的假设
-            # 靠的是调用方串行；arecord_output 把整次记录交给 worker 之后，两次记录
-            # 拿到锁的先后不再等于调用先后，而打分侧是拿尾部切片当「最近几条」的
-            # （_split_fg_bg），错序会让旧回复被当成更新的。窗口只有 ~100 条，
-            # 每次排一遍的代价可以忽略。
+            # 靠的是调用方串行；打分侧是拿尾部切片当「最近几条」的（_split_fg_bg），
+            # 错序会让旧回复被当成更新的。窗口只有 ~100 条，每次排一遍可以忽略。
             window.sort(key=lambda e: float(e.get("ts", 0)))
             if len(window) > ANTI_REPEAT_BG_WINDOW:
                 del window[: len(window) - ANTI_REPEAT_BG_WINDOW]
             self._cache[name] = window
             payload, seq = self._stage_snapshot_unlocked(name)
-        # 落盘在数据锁**之外**——见 _flush_snapshot。
-        self._flush_snapshot(name, payload, seq)
+        return name, payload, seq
 
     async def arecord_output(
         self,
@@ -472,16 +493,19 @@ class AntiRepeatCorpus:
         critical section across the thread boundary would be the only way to
         break that.
         """
-        # now 在这里定好而不是留给 worker：两次 arecord_output 之间的线程调度
-        # 顺序不保证，时间戳必须钉在调用发生的那一刻。
+        # 内存更新留在调用线程上，只有落盘去 worker。整次记录都丢进 worker 的话，
+        # 在那个 job 排队 / 算 ngram 的这段时间里，事件循环上的 score_draft /
+        # top_recent_topics 会读到还没加进这条回复的旧 _cache —— 紧接着的下一轮
+        # 就可能把刚说过的话又说一遍。数据锁此刻只覆盖几微秒的内存操作（落盘已经
+        # 挪出去了，见 _flush_snapshot），所以在循环上取它是安全的。
         stamped = float(now if now is not None else _now())
-        await asyncio.to_thread(
-            self.record_output,
-            name,
-            text,
-            is_proactive=is_proactive,
-            now=stamped,
+        staged = self._record_in_memory(
+            name, text, is_proactive=is_proactive, now=stamped,
         )
+        if staged is None:
+            return
+        resolved, payload, seq = staged
+        await asyncio.to_thread(self._flush_snapshot, resolved, payload, seq)
 
     @staticmethod
     def _split_fg_bg(

--- a/scripts/check_async_blocking.py
+++ b/scripts/check_async_blocking.py
@@ -59,12 +59,13 @@ our model). A second pass addresses exactly that class:
    ``await asyncio.to_thread(...)``*.
 
 We deliberately stop at depth 1 — tracing deeper chains needs type
-inference and/or module-level import resolution, and name-based
-heuristics past depth 1 produce more noise than signal. Imports are not
-resolved; a helper re-exported or aliased at import time will slip
-through. That is a known trade-off — easy to add later, hard to make
-quiet today. False positives from name collisions can be silenced per
-line with ``# noqa: ASYNC_BLOCK — <reason>``.
+inference and name-based heuristics past depth 1 produce more noise than
+signal. General imports are not resolved. The two ``utils.file_utils``
+atomic writers are the narrow exception: their direct aliases and module
+aliases are resolved because letting import spelling bypass this PR's
+central fsync guard would defeat the rule. False positives from name
+collisions can be silenced per line with
+``# noqa: ASYNC_BLOCK — <reason>``.
 
 Every violation prints as ``path:line:col  CODE  message``. Exit status
 is 1 when any violation is found, 0 otherwise.
@@ -136,6 +137,10 @@ RISKY_ATTR_PAIRS: dict[tuple[str, str], str] = {
     # 正常的 import 风格开了后门。
     ("file_utils", "atomic_write_text"): "utils.file_utils.atomic_write_text",
     ("file_utils", "atomic_write_json"): "utils.file_utils.atomic_write_json",
+    # Resolves workshop_config.json and may read/retry/rebase it. Calling it
+    # from an async handler was the source of several lock/I/O relays in this
+    # PR; route code must use its async twin.
+    ("workshop_utils", "get_workshop_path"): "utils.workshop_utils.get_workshop_path",
     # PIL
     ("Image", "open"): "PIL.Image.open",
     ("_PILImage", "open"): "PIL.Image.open",
@@ -211,7 +216,43 @@ RISKY_BARE_CALLS: dict[str, str] = {
     # 已有 77 处在用；缺的从来不是异步安全层，是调用点纪律。
     "atomic_write_text": "utils.file_utils.atomic_write_text",
     "atomic_write_json": "utils.file_utils.atomic_write_json",
+    "get_workshop_path": "utils.workshop_utils.get_workshop_path",
 }
+
+_ATOMIC_WRITE_LABELS = {
+    "atomic_write_text": "utils.file_utils.atomic_write_text",
+    "atomic_write_json": "utils.file_utils.atomic_write_json",
+}
+
+
+def _collect_atomic_write_aliases(
+    tree: ast.Module,
+) -> tuple[dict[str, str], set[str]]:
+    """Return direct-name aliases and module aliases for ``utils.file_utils``.
+
+    This intentionally resolves only the two atomic writers. General import
+    resolution would turn the checker's name-based depth-1 pass into a much
+    larger cross-module analysis problem; these two names are high-signal and
+    are the guard this PR is specifically adding.
+    """
+    direct: dict[str, str] = {}
+    modules: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom):
+            if node.module == "utils.file_utils":
+                for alias in node.names:
+                    label = _ATOMIC_WRITE_LABELS.get(alias.name)
+                    if label is not None:
+                        direct[alias.asname or alias.name] = label
+            elif node.module == "utils":
+                for alias in node.names:
+                    if alias.name == "file_utils":
+                        modules.add(alias.asname or alias.name)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "utils.file_utils" and alias.asname:
+                    modules.add(alias.asname)
+    return direct, modules
 
 # 太通用、不足以靠名字认人的 helper 名，不进 depth-1 风险索引。
 #
@@ -257,7 +298,10 @@ def _tail_name(node: ast.expr) -> str:
     return ""
 
 
-def _describe_blocking_call(call: ast.Call) -> str | None:
+def _describe_blocking_call(
+    call: ast.Call,
+    atomic_aliases: tuple[dict[str, str], set[str]] | None = None,
+) -> str | None:
     """If the call matches a known blocking stdlib operation, return a
     short human-readable description; otherwise ``None``.
 
@@ -268,6 +312,14 @@ def _describe_blocking_call(call: ast.Call) -> str | None:
     if isinstance(func, ast.Attribute):
         receiver_tail = _tail_name(func.value)
         attr = func.attr
+        if atomic_aliases is not None:
+            _direct_aliases, module_aliases = atomic_aliases
+            if (
+                isinstance(func.value, ast.Name)
+                and func.value.id in module_aliases
+                and attr in _ATOMIC_WRITE_LABELS
+            ):
+                return _ATOMIC_WRITE_LABELS[attr]
         label = RISKY_ATTR_PAIRS.get((receiver_tail, attr))
         if label is not None:
             return label
@@ -288,6 +340,11 @@ def _describe_blocking_call(call: ast.Call) -> str | None:
             return f"blocking socket.{attr}()"
         return None
     if isinstance(func, ast.Name):
+        if atomic_aliases is not None:
+            direct_aliases, _module_aliases = atomic_aliases
+            label = direct_aliases.get(func.id)
+            if label is not None:
+                return label
         return RISKY_BARE_CALLS.get(func.id)
     return None
 
@@ -307,20 +364,32 @@ class RiskySyncDefIndexer(ast.NodeVisitor):
         # Filled by module-level driver.
         self.risky: dict[str, tuple[str, int, str]] = {}
 
-    def index_module(self, tree: ast.Module, path: Path) -> None:
+    def index_module(
+        self,
+        tree: ast.Module,
+        path: Path,
+        atomic_aliases: tuple[dict[str, str], set[str]] | None = None,
+    ) -> None:
+        if atomic_aliases is None:
+            atomic_aliases = _collect_atomic_write_aliases(tree)
         for node in tree.body:
             if isinstance(node, ast.FunctionDef):
-                self._consider_def(node, path)
+                self._consider_def(node, path, atomic_aliases)
             elif isinstance(node, ast.ClassDef):
                 for item in node.body:
                     if isinstance(item, ast.FunctionDef):
-                        self._consider_def(item, path)
+                        self._consider_def(item, path, atomic_aliases)
 
-    def _consider_def(self, node: ast.FunctionDef, path: Path) -> None:
+    def _consider_def(
+        self,
+        node: ast.FunctionDef,
+        path: Path,
+        atomic_aliases: tuple[dict[str, str], set[str]],
+    ) -> None:
         if node.name in GENERIC_HELPER_NAMES:
             # 名字太泛，认不出人——见 GENERIC_HELPER_NAMES 的注释。
             return
-        reason = _sync_body_has_blocking_call(node)
+        reason = _sync_body_has_blocking_call(node, atomic_aliases)
         if reason is None:
             return
         # First-wins: if two helpers share a name, keep the first so the
@@ -349,7 +418,10 @@ def _collect_async_def_names(tree: ast.Module) -> set[str]:
     return names
 
 
-def _sync_body_has_blocking_call(func: ast.FunctionDef) -> str | None:
+def _sync_body_has_blocking_call(
+    func: ast.FunctionDef,
+    atomic_aliases: tuple[dict[str, str], set[str]] | None = None,
+) -> str | None:
     """Scan ``func``'s body for a known-blocking call, descending into
     control-flow (if/for/with/try) but NOT into nested functions or
     lambdas — a nested function's code only runs when invoked, which by
@@ -362,7 +434,7 @@ def _sync_body_has_blocking_call(func: ast.FunctionDef) -> str | None:
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
             continue  # prune nested scope
         if isinstance(node, ast.Call):
-            reason = _describe_blocking_call(node)
+            reason = _describe_blocking_call(node, atomic_aliases)
             if reason is not None:
                 return reason
         for child in ast.iter_child_nodes(node):
@@ -377,6 +449,7 @@ class AsyncBlockingChecker(ast.NodeVisitor):
         source: str,
         risky_helpers: dict[str, tuple[str, int, str]] | None = None,
         ambiguous_async_names: set[str] | None = None,
+        atomic_aliases: tuple[dict[str, str], set[str]] | None = None,
     ) -> None:
         self.path = path
         self.source_lines = source.splitlines()
@@ -393,6 +466,7 @@ class AsyncBlockingChecker(ast.NodeVisitor):
         # separate bug and the sync variant is the only one that
         # runs-and-blocks when called unawaited.
         self._ambiguous_async_names = ambiguous_async_names or set()
+        self._atomic_aliases = atomic_aliases or ({}, set())
         # ids of Call nodes that are the direct target of an ``await`` —
         # suppresses ONLY the queue/thread/socket tail-name heuristics in
         # ``_check_attribute_call``. Those heuristics guess at the
@@ -478,7 +552,7 @@ class AsyncBlockingChecker(ast.NodeVisitor):
         anything blocking-enough to mark a sync helper as risky is also
         blocking when written inline.
         """
-        reason = _describe_blocking_call(call)
+        reason = _describe_blocking_call(call, self._atomic_aliases)
         if reason is None:
             return
         # Avoid duplicating with the existing queue/thread/socket flags —
@@ -626,12 +700,16 @@ def check_file(
     tree: ast.Module,
     risky_helpers: dict[str, tuple[str, int, str]] | None = None,
     ambiguous_async_names: set[str] | None = None,
+    atomic_aliases: tuple[dict[str, str], set[str]] | None = None,
 ) -> list[tuple[int, int, str]]:
+    if atomic_aliases is None:
+        atomic_aliases = _collect_atomic_write_aliases(tree)
     checker = AsyncBlockingChecker(
         path,
         source,
         risky_helpers=risky_helpers,
         ambiguous_async_names=ambiguous_async_names,
+        atomic_aliases=atomic_aliases,
     )
     checker.visit(tree)
     return checker.violations
@@ -663,7 +741,11 @@ def main(argv: list[str] | None = None) -> int:
         # Re-seed indexer.risky entries with the relative path for nicer
         # error messages, but preserve first-wins.
         local_indexer = RiskySyncDefIndexer()
-        local_indexer.index_module(tree, rel)
+        local_indexer.index_module(
+            tree,
+            rel,
+            atomic_aliases=_collect_atomic_write_aliases(tree),
+        )
         for name, info in local_indexer.risky.items():
             indexer.risky.setdefault(name, info)
         async_names |= _collect_async_def_names(tree)

--- a/scripts/check_async_blocking.py
+++ b/scripts/check_async_blocking.py
@@ -130,6 +130,12 @@ SOCKET_SUFFIX = ("_sock", "_socket")
 # collapses to ``y.save``, which disambiguates ``fernet.encrypt`` vs.
 # ``self.encrypt``. Overly generic pairs are deliberately omitted.
 RISKY_ATTR_PAIRS: dict[tuple[str, str], str] = {
+    # utils/file_utils 的原子落盘，模块限定写法。`from utils import file_utils`
+    # 之后 `file_utils.atomic_write_json(...)` 是 attribute 调用，走不到下面
+    # RISKY_BARE_CALLS 那条（那条只看 ast.Name），不补这两条就等于给一种完全
+    # 正常的 import 风格开了后门。
+    ("file_utils", "atomic_write_text"): "utils.file_utils.atomic_write_text",
+    ("file_utils", "atomic_write_json"): "utils.file_utils.atomic_write_json",
     # PIL
     ("Image", "open"): "PIL.Image.open",
     ("_PILImage", "open"): "PIL.Image.open",

--- a/scripts/check_async_blocking.py
+++ b/scripts/check_async_blocking.py
@@ -47,7 +47,11 @@ our model). A second pass addresses exactly that class:
    recognised blocking stdlib call (``PIL.Image.open``, Fernet
    encrypt/decrypt, ``shutil.*``, ``time.sleep``, ``requests.*``,
    ``subprocess.run``/``call``/``check_*``, ``urllib.request.urlopen``,
-   plus the queue/thread/socket tail-name heuristics above).
+   ``utils.file_utils.atomic_write_text`` / ``atomic_write_json``, plus
+   the queue/thread/socket tail-name heuristics above). Helpers whose
+   own name is too generic to identify by name alone (``save``,
+   ``load``, ``run``, …) are deliberately NOT indexed — see
+   ``GENERIC_HELPER_NAMES``.
 2. Walk every ``async def`` body again, and for each bare ``foo(...)``
    or ``obj.foo(...)`` call match the tail name against the risky index.
    A hit is reported as: *blocking sync helper '<name>' ... called
@@ -193,7 +197,33 @@ RISKY_BARE_CALLS: dict[str, str] = {
     # is an attribute call (``asyncio.sleep``) so it won't be confused with
     # this bare ``sleep`` form.
     "sleep": "time.sleep",
+    # utils/file_utils 的原子落盘。名字够独特，不会跟别的东西撞。一次
+    # atomic_write 在调用线程上串着 mkdir、崩后残留 tmp 的整目录 scandir、
+    # mkstemp、write，以及**没有上界**的 os.fsync —— 放在事件循环上就是拿一次
+    # 物理刷盘的时间去堵住所有别的协程。异步孪生 atomic_write_json_async /
+    # atomic_write_text_async 早就存在（asyncio.to_thread 包一层），非测试代码里
+    # 已有 77 处在用；缺的从来不是异步安全层，是调用点纪律。
+    "atomic_write_text": "utils.file_utils.atomic_write_text",
+    "atomic_write_json": "utils.file_utils.atomic_write_json",
 }
+
+# 太通用、不足以靠名字认人的 helper 名，不进 depth-1 风险索引。
+#
+# 索引是按**名字**匹配的：pass 1 记下「某个同步 def 的体内有阻塞调用」，pass 2 在
+# async def 里看到同名调用就报。名字够独特时这招很准（save_storage_policy 只可能是
+# 那一个），名字是个通用动词时就全是噪声 —— 实测把 atomic_write_* 加进来之后，一个
+# 叫 `save` 的 helper 让 `img.save(png_path)`（PIL）和
+# `TokenTracker.get_instance().save()` 全部中招，而它们跟那个 helper 毫无关系。
+#
+# 这跟本文件对 queue/thread/socket 接收者尾名的既有取舍是同一条原则：名字太泛的
+# 一律不猜，宁可漏报也不制造假阳性。代价是漏掉真的叫 `save` 的阻塞 helper —— 那类
+# 只能靠 review 或者以后引入类型推断。
+GENERIC_HELPER_NAMES = frozenset({
+    "save", "load", "read", "write", "flush", "close", "open", "dump",
+    "update", "apply", "run", "start", "stop", "reset", "clear", "sync",
+    "commit", "persist", "get", "set", "add", "append", "remove", "delete",
+    "copy", "move", "send", "put", "wait", "join", "process", "handle",
+})
 
 
 def _tail_matches(tail: str, exact: set[str], suffix: tuple[str, ...]) -> bool:
@@ -281,6 +311,9 @@ class RiskySyncDefIndexer(ast.NodeVisitor):
                         self._consider_def(item, path)
 
     def _consider_def(self, node: ast.FunctionDef, path: Path) -> None:
+        if node.name in GENERIC_HELPER_NAMES:
+            # 名字太泛，认不出人——见 GENERIC_HELPER_NAMES 的注释。
+            return
         reason = _sync_body_has_blocking_call(node)
         if reason is None:
             return
@@ -396,6 +429,12 @@ class AsyncBlockingChecker(ast.NodeVisitor):
         lineno = getattr(node, "lineno", 0)
         col = getattr(node, "col_offset", 0) + 1
         if self._line_has_noqa(lineno):
+            return
+        # 同一个调用点只报一次。直接规则和 depth-1 传递规则会在同一处双双命中
+        # （`atomic_write_json(...)` 既是已知阻塞调用，本身又是一个体内含
+        # atomic_write_text 的同步 def），报两条只是噪声——留下先命中的那条，
+        # 也就是更精确的直接规则。
+        if any(pos == (lineno, col) for pos in ((v[0], v[1]) for v in self.violations)):
             return
         self.violations.append((lineno, col, message))
 

--- a/tests/unit/test_anti_repeat.py
+++ b/tests/unit/test_anti_repeat.py
@@ -655,10 +655,33 @@ async def test_apreload_reads_without_holding_the_data_lock(tmp_path, monkeypatc
     if acquired:
         lock.release()
     release.set()
-    await preload
+    assert await preload is None
 
     assert acquired, "the worker held the data lock while performing disk I/O"
     assert store._cache["妮可"] == []
+
+
+@pytest.mark.asyncio
+async def test_apreload_caches_empty_window_after_disk_lookup_failure(
+    tmp_path, monkeypatch
+):
+    """A failed warmup must not make the event loop retry the same disk read."""
+    store = _build_store(tmp_path)
+    calls = 0
+
+    def _failed_read(_name):
+        nonlocal calls
+        calls += 1
+        raise OSError("memory root unavailable")
+
+    monkeypatch.setattr(store, "_read_window_from_disk", _failed_read)
+
+    await store.apreload("妮可")
+    staged = store.stage_output("妮可", LONG_TIGER, now=1.0)
+
+    assert store._cache["妮可"]
+    assert staged is not None
+    assert calls == 1, "stage_output retried disk I/O synchronously after warmup failed"
 
 
 def test_the_per_turn_callers_use_the_async_twin():

--- a/tests/unit/test_anti_repeat.py
+++ b/tests/unit/test_anti_repeat.py
@@ -16,6 +16,7 @@ scorer + soft-hint prompt 注入。
 """  # noqa: DOCSTRING_CJK
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import threading
@@ -729,3 +730,52 @@ def test_entries_stay_ordered_by_timestamp(tmp_path):
 
     window = store._load_unlocked("妮可")
     assert [entry["ts"] for entry in window] == [100.0, 200.0]
+
+
+class _GatedAsyncio:
+    """Stands in for ``anti_repeat.asyncio``: parks at the to_thread boundary."""
+
+    def __init__(self, reached: "asyncio.Event", release: "asyncio.Event") -> None:
+        self._reached = reached
+        self._release = release
+
+    def __getattr__(self, name):
+        return getattr(asyncio, name)
+
+    async def to_thread(self, fn, *args, **kwargs):
+        self._reached.set()
+        await self._release.wait()
+        return await asyncio.to_thread(fn, *args, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_the_corpus_is_updated_before_arecord_output_yields(tmp_path, monkeypatch):
+    """Scoring must never miss the reply that was just committed.
+
+    Only the disk write is off-loaded; the in-memory update runs on the
+    caller's thread, before the coroutine yields at all. Deferring the whole
+    record to a worker leaves a window in which the loop runs the next turn's
+    score_draft / top_recent_topics against a corpus that is still missing
+    this reply — and repeats it.
+
+    Observed exactly at the to_thread boundary: that is the first instant the
+    loop can run anything else, and it is where the two designs differ.
+    """
+    from memory import anti_repeat as anti_repeat_module
+
+    store = _build_store(tmp_path)
+    reached = asyncio.Event()
+    release = asyncio.Event()
+    monkeypatch.setattr(
+        anti_repeat_module, "asyncio", _GatedAsyncio(reached, release),
+    )
+
+    task = asyncio.create_task(store.arecord_output("妮可", LONG_TIGER, now=1.0))
+    await asyncio.wait_for(reached.wait(), timeout=5)
+
+    # 协程刚让出，落盘还没开始 —— 但 corpus 必须已经含有这条。
+    total, _terms = store.score_draft("妮可", LONG_TIGER, now=1.0)
+    assert total > 0, "协程让出时 corpus 还没更新，下一轮打分会漏掉刚说过的这句"
+
+    release.set()
+    await asyncio.wait_for(task, timeout=5)

--- a/tests/unit/test_anti_repeat.py
+++ b/tests/unit/test_anti_repeat.py
@@ -17,6 +17,7 @@ scorer + soft-hint prompt 注入。
 from __future__ import annotations
 
 import os
+import threading
 from unittest.mock import MagicMock
 
 import pytest
@@ -561,3 +562,93 @@ def test_recent_topics_block_falls_back_to_en():
     """未支持的 lang 走 en 回退；返回不空字符串即可。"""
     out = render_recent_topics_block(["foo"], "und")
     assert "foo" in out
+
+
+# ── 8. arecord_output：落盘必须离开事件循环 ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_arecord_output_persists_off_the_event_loop(tmp_path, monkeypatch):
+    """The corpus write must not run on the caller's event loop thread.
+
+    record_output ends in atomic_write_json, whose tail is an unbounded
+    os.fsync. This corpus is written on EVERY committed assistant reply, so
+    on the realtime session's loop that physical flush lands between audio
+    chunks. Asserting on the writing thread pins the property itself, not
+    the mere presence of an asyncio.to_thread call.
+    """
+    import memory.anti_repeat as anti_repeat_module
+
+    store = _build_store(tmp_path)
+    loop_thread = threading.get_ident()
+    write_threads: list[int] = []
+    real_write = anti_repeat_module.atomic_write_json
+
+    def _spy(*args, **kwargs):
+        write_threads.append(threading.get_ident())
+        return real_write(*args, **kwargs)
+
+    monkeypatch.setattr(anti_repeat_module, "atomic_write_json", _spy)
+
+    await store.arecord_output("妮可", LONG_TIGER, is_proactive=False)
+
+    assert write_threads, "arecord_output 必须真的落盘"
+    assert loop_thread not in write_threads, (
+        "落盘跑在了事件循环线程上——fsync 会掐住音频"
+    )
+    assert store._load_unlocked("妮可"), "内容必须真的进了 corpus"
+
+
+@pytest.mark.asyncio
+async def test_arecord_output_stamps_time_at_the_call_site(tmp_path, monkeypatch):
+    """The timestamp is read when the coroutine is called, not whenever the
+    worker thread happens to get scheduled.
+
+    Two back-to-back records can reach the pool in either order, and the
+    window is trimmed by ts — so the clock has to be read on the caller's
+    side. Asserting on the *thread* that reads it is what distinguishes the
+    two designs; asserting on the value alone cannot.
+    """
+    import memory.anti_repeat as anti_repeat_module
+
+    store = _build_store(tmp_path)
+    loop_thread = threading.get_ident()
+    clock_threads: list[int] = []
+
+    def _clock() -> float:
+        clock_threads.append(threading.get_ident())
+        return 1234.5
+
+    monkeypatch.setattr(anti_repeat_module, "_now", _clock)
+
+    await store.arecord_output("妮可", LONG_TIGER, is_proactive=True)
+
+    assert clock_threads, "时间戳必须真的取过"
+    assert clock_threads[0] == loop_thread, (
+        "时间戳在 worker 线程里取的——两次投递的先后顺序就不再可信"
+    )
+    window = store._load_unlocked("妮可")
+    assert [entry["ts"] for entry in window] == [1234.5]
+    assert window[0]["is_proactive"] is True
+
+
+def test_the_per_turn_callers_use_the_async_twin():
+    """The two per-turn call sites must not fall back to the sync writer.
+
+    Both run inside a coroutine on the realtime session's loop; a plain
+    record_output there puts an unbounded fsync on that loop. The guard in
+    scripts/check_async_blocking.py cannot see this pair (its documented
+    depth-1 limit stops one hop short), so it is pinned here instead.
+    """
+    import pathlib
+
+    repo_root = pathlib.Path(__file__).resolve().parents[2]
+    for rel in (
+        "main_logic/omni_offline_client/_lifecycle.py",
+        "main_logic/core/proactive.py",
+    ):
+        source = (repo_root / rel).read_text(encoding="utf-8")
+        assert "arecord_output(" in source, f"{rel} 应当调用 async 孪生"
+        assert ".record_output(" not in source, (
+            f"{rel} 回退到了同步 record_output —— 那会把 fsync 压在会话循环上"
+        )

--- a/tests/unit/test_anti_repeat.py
+++ b/tests/unit/test_anti_repeat.py
@@ -695,17 +695,56 @@ def test_the_per_turn_callers_use_the_async_twin():
     import pathlib
 
     repo_root = pathlib.Path(__file__).resolve().parents[2]
-    for rel in (
-        "main_logic/omni_offline_client/_lifecycle.py",
-        "main_logic/core/proactive.py",
-    ):
+    for rel in _PER_TURN_CALL_SITES:
         source = (repo_root / rel).read_text(encoding="utf-8")
-        assert "stage_output(" in source and "aflush_staged(" in source, (
-            f"{rel} 必须走两段式：内存更新在收尾信号之前，落盘在之后"
+        assert "stage_output(" in source and "flush_staged_detached(" in source, (
+            f"{rel} 必须走两段式：内存更新在收尾信号之前，落盘摘出去"
         )
         assert ".record_output(" not in source, (
             f"{rel} 回退到了同步 record_output —— 那会把 fsync 压在会话循环上"
         )
+
+
+_PER_TURN_CALL_SITES = (
+    "main_logic/omni_offline_client/_lifecycle.py",
+    "main_logic/core/proactive.py",
+)
+
+
+def test_the_per_turn_callers_never_await_the_flush():
+    """Nothing cancellable may sit between "delivered" and "report delivered".
+
+    Both call sites flush after the turn's terminal signals are already out,
+    and both then return the value their caller uses as the record that the
+    turn committed. An ``await`` in that stretch reintroduces a cancellation
+    point past the point of no return: ``CancelledError`` is a
+    ``BaseException``, so it skips the surrounding ``except Exception`` and the
+    ``return``, and the caller books an already-visible turn as undelivered.
+    """
+    import ast
+    import pathlib
+
+    repo_root = pathlib.Path(__file__).resolve().parents[2]
+    offenders = []
+    for rel in _PER_TURN_CALL_SITES:
+        tree = ast.parse((repo_root / rel).read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Await):
+                continue
+            call = node.value
+            if not isinstance(call, ast.Call):
+                continue
+            func = call.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
+            if name in {"aflush_staged", "arecord_output"}:
+                offenders.append(f"{rel}:{node.lineno} await {name}(...)")
+
+    assert not offenders, (
+        "这些 per-turn 调用点又把落盘 await 回了提交路径上：\n  "
+        + "\n  ".join(offenders)
+        + "\n用 flush_staged_detached() —— 到这一步这轮对用户已经发生完了，"
+        "取消不该把「已投递」倒回成「没投递」"
+    )
 
 
 def test_the_data_lock_is_never_held_across_the_disk_write(tmp_path):
@@ -831,3 +870,103 @@ async def test_the_corpus_is_updated_before_arecord_output_yields(tmp_path, monk
 
     release.set()
     await asyncio.wait_for(task, timeout=5)
+
+
+# ── 9. flush_staged_detached：提交路径上不许有取消点 ──────────
+
+
+@pytest.mark.asyncio
+async def test_detached_flush_still_reaches_disk(tmp_path):
+    """Detaching must not turn the write into a no-op."""
+    store = _build_store(tmp_path)
+    staged = store.stage_output("妮可", LONG_TIGER, now=1.0)
+    assert staged is not None
+
+    store.flush_staged_detached(staged)
+    for _ in range(200):
+        await asyncio.sleep(0.01)
+        if not store._detached_flushes:
+            break
+    assert not store._detached_flushes, "摘下来的落盘 task 没跑完"
+
+    reloaded = _build_store(tmp_path)
+    total, _terms = reloaded.score_draft("妮可", LONG_TIGER, now=1.0)
+    assert total > 0, "落盘没到盘上，重启后这条就丢了"
+
+
+@pytest.mark.asyncio
+async def test_cancelling_the_caller_cannot_rewind_a_delivered_turn(tmp_path):
+    """The caller must reach its `return` even when cancelled at the flush.
+
+    This is the whole reason the flush is detached. The turn's terminal
+    signals are already out by this point, so the delivery has happened; if
+    cancellation could still unwind past the return, the caller would book it
+    as undelivered and the same proactive line could be sent again.
+    """
+    from memory import anti_repeat as anti_repeat_module
+
+    store = _build_store(tmp_path)
+    terminal_signals = asyncio.Event()
+    reached_return = asyncio.Event()
+
+    # 把落盘卡死在 to_thread 上。这样「落盘是不是取消点」就是确定性的差异，不用赌
+    # 一次 to_thread 往返能不能在某个 sleep(0) 里跑完。
+    reached_disk = asyncio.Event()
+    release_disk = asyncio.Event()
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(
+        anti_repeat_module, "asyncio", _GatedAsyncio(reached_disk, release_disk),
+    )
+    try:
+        async def _deliver() -> bool:
+            staged = store.stage_output("妮可", LONG_TIGER, now=1.0)
+            await terminal_signals.wait()   # 模拟 TTS 收尾 + 两处 turn end
+            store.flush_staged_detached(staged)
+            reached_return.set()
+            return True
+
+        task = asyncio.create_task(_deliver())
+        await asyncio.sleep(0)
+        terminal_signals.set()
+        await asyncio.sleep(0)
+
+        # 收尾信号一发完，协程就该已经跑到 return 了：落盘摘出去之后，这段里再没有
+        # 挂起点。谁要是把 aflush_staged await 回来，协程此刻还挂在落盘上。
+        assert reached_return.is_set(), (
+            "收尾信号之后仍有挂起点 —— 落盘被 await 回了提交路径上"
+        )
+
+        # 取消请求这时才到。已经没有挂起点可以让它落进去，凭据必须照常返回。
+        task.cancel()
+        assert await task is True
+    finally:
+        release_disk.set()
+        for _ in range(200):
+            await asyncio.sleep(0.01)
+            if not store._detached_flushes:
+                break
+        monkeypatch.undo()
+
+    assert not store._detached_flushes, "摘出去的落盘 task 没跑完就泄漏了"
+
+
+def test_detached_flush_without_a_running_loop_is_a_no_op(tmp_path):
+    """No loop to attach to must degrade quietly, never fsync inline."""
+    # 同步调用方 / 循环已关停时，回退成「就地同步落盘」会把这轮改动移走的 fsync
+    # 又搬回来。best-effort 的东西宁可丢。
+    store = _build_store(tmp_path)
+    staged = store.stage_output("妮可", LONG_TIGER, now=1.0)
+
+    store.flush_staged_detached(staged)
+
+    assert not store._detached_flushes
+    assert not os.path.exists(store._file_path("妮可")), (
+        "没有事件循环时不该就地落盘"
+    )
+
+
+def test_detached_flush_ignores_a_none_handle(tmp_path):
+    """stage_output returns None for skipped text; that must stay harmless."""
+    store = _build_store(tmp_path)
+    store.flush_staged_detached(None)
+    assert not store._detached_flushes

--- a/tests/unit/test_anti_repeat.py
+++ b/tests/unit/test_anti_repeat.py
@@ -650,7 +650,9 @@ def test_the_per_turn_callers_use_the_async_twin():
         "main_logic/core/proactive.py",
     ):
         source = (repo_root / rel).read_text(encoding="utf-8")
-        assert "arecord_output(" in source, f"{rel} 应当调用 async 孪生"
+        assert "stage_output(" in source and "aflush_staged(" in source, (
+            f"{rel} 必须走两段式：内存更新在收尾信号之前，落盘在之后"
+        )
         assert ".record_output(" not in source, (
             f"{rel} 回退到了同步 record_output —— 那会把 fsync 压在会话循环上"
         )

--- a/tests/unit/test_anti_repeat.py
+++ b/tests/unit/test_anti_repeat.py
@@ -634,6 +634,33 @@ async def test_arecord_output_stamps_time_at_the_call_site(tmp_path, monkeypatch
     assert window[0]["is_proactive"] is True
 
 
+@pytest.mark.asyncio
+async def test_apreload_reads_without_holding_the_data_lock(tmp_path, monkeypatch):
+    """A slow first read must not make loop-side scorers wait on a worker lock."""
+    store = _build_store(tmp_path)
+    started = threading.Event()
+    release = threading.Event()
+
+    def _slow_read(_name):
+        started.set()
+        assert release.wait(timeout=5)
+        return []
+
+    monkeypatch.setattr(store, "_read_window_from_disk", _slow_read)
+    preload = asyncio.create_task(store.apreload("妮可"))
+    assert await asyncio.to_thread(started.wait, 5)
+
+    lock = store._get_lock("妮可")
+    acquired = lock.acquire(blocking=False)
+    if acquired:
+        lock.release()
+    release.set()
+    await preload
+
+    assert acquired, "the worker held the data lock while performing disk I/O"
+    assert store._cache["妮可"] == []
+
+
 def test_the_per_turn_callers_use_the_async_twin():
     """The two per-turn call sites must not fall back to the sync writer.
 

--- a/tests/unit/test_anti_repeat.py
+++ b/tests/unit/test_anti_repeat.py
@@ -16,6 +16,7 @@ scorer + soft-hint prompt 注入。
 """  # noqa: DOCSTRING_CJK
 from __future__ import annotations
 
+import json
 import os
 import threading
 from unittest.mock import MagicMock
@@ -577,7 +578,7 @@ async def test_arecord_output_persists_off_the_event_loop(tmp_path, monkeypatch)
     chunks. Asserting on the writing thread pins the property itself, not
     the mere presence of an asyncio.to_thread call.
     """
-    import memory.anti_repeat as anti_repeat_module
+    from memory import anti_repeat as anti_repeat_module
 
     store = _build_store(tmp_path)
     loop_thread = threading.get_ident()
@@ -609,7 +610,7 @@ async def test_arecord_output_stamps_time_at_the_call_site(tmp_path, monkeypatch
     side. Asserting on the *thread* that reads it is what distinguishes the
     two designs; asserting on the value alone cannot.
     """
-    import memory.anti_repeat as anti_repeat_module
+    from memory import anti_repeat as anti_repeat_module
 
     store = _build_store(tmp_path)
     loop_thread = threading.get_ident()
@@ -652,3 +653,79 @@ def test_the_per_turn_callers_use_the_async_twin():
         assert ".record_output(" not in source, (
             f"{rel} 回退到了同步 record_output —— 那会把 fsync 压在会话循环上"
         )
+
+
+def test_the_data_lock_is_never_held_across_the_disk_write(tmp_path):
+    """Scoring runs on the event loop and takes the same per-name lock.
+
+    ``arecord_output`` hands the whole record to a worker; if that worker held
+    the data lock across ``atomic_write_json`` (tail: an unbounded fsync), a
+    concurrent ``score_draft`` on the loop would block on the worker — exactly
+    the stall the off-loading exists to remove. So the write must happen with
+    the data lock released.
+    """
+    from memory import anti_repeat as anti_repeat_module
+
+    store = _build_store(tmp_path)
+    store.record_output("妮可", LONG_TIGER, now=1.0)  # 建好锁与缓存
+    held_during_write: list[bool] = []
+    real_write = anti_repeat_module.atomic_write_json
+
+    def _spy(*args, **kwargs):
+        lock = store._get_lock("妮可")
+        acquired = lock.acquire(blocking=False)
+        held_during_write.append(not acquired)
+        if acquired:
+            lock.release()
+        return real_write(*args, **kwargs)
+
+    monkeypatch = pytest.MonkeyPatch()
+    try:
+        monkeypatch.setattr(anti_repeat_module, "atomic_write_json", _spy)
+        store.record_output("妮可", LONG_FRUIT, now=2.0)
+    finally:
+        monkeypatch.undo()
+
+    assert held_during_write == [False], (
+        "落盘时数据锁还握着——事件循环上的 score_draft 会卡在这次 fsync 上"
+    )
+
+
+def test_a_stale_snapshot_never_overwrites_a_newer_one(tmp_path):
+    """Workers can reach the disk out of order; the older window must lose.
+
+    Writes no longer happen under the data lock, so two records can be staged
+    in caller order yet reach ``atomic_write_json`` in the opposite order. The
+    staged sequence number, not the winner of the write lock, decides.
+    """
+    store = _build_store(tmp_path)
+    store.record_output("妮可", LONG_TIGER, now=1.0)
+    store.record_output("妮可", LONG_FRUIT, now=2.0)
+
+    fresh = json.loads(
+        (tmp_path / "妮可" / "anti_repeat_corpus.json").read_text(encoding="utf-8")
+    )
+    newest_seq = store._staged_seq["妮可"]
+
+    # 一次「迟到的」旧快照：seq 比已落盘的小，必须被丢掉。
+    store._flush_snapshot("妮可", {"version": 1, "window": []}, newest_seq - 1)
+
+    after = json.loads(
+        (tmp_path / "妮可" / "anti_repeat_corpus.json").read_text(encoding="utf-8")
+    )
+    assert after == fresh, "陈旧快照把新窗口盖回去了"
+    assert len(after["window"]) == 2
+
+
+def test_entries_stay_ordered_by_timestamp(tmp_path):
+    """Out-of-order arrivals must not make an older reply look like the newest.
+
+    Scoring takes the trailing slice of the window as "the most recent
+    entries", so ordering has to hold even when workers land out of order.
+    """
+    store = _build_store(tmp_path)
+    store.record_output("妮可", LONG_FRUIT, now=200.0)
+    store.record_output("妮可", LONG_TIGER, now=100.0)  # 迟到的更早那条
+
+    window = store._load_unlocked("妮可")
+    assert [entry["ts"] for entry in window] == [100.0, 200.0]

--- a/tests/unit/test_check_async_blocking.py
+++ b/tests/unit/test_check_async_blocking.py
@@ -98,6 +98,39 @@ def test_a_named_sync_helper_that_writes_is_flagged_through_one_hop():
     assert "save_storage_policy" in out[0][2]
 
 
+def test_the_module_qualified_form_is_flagged():
+    # `from utils import file_utils` 之后 `file_utils.atomic_write_json(...)` 是
+    # attribute 调用，走不到 RISKY_BARE_CALLS（那条只看 ast.Name）。不认这种写法
+    # 等于给一种完全正常的 import 风格开了后门。
+    out = _violations("""
+    async def handler(payload):
+        file_utils.atomic_write_json(path, payload)
+    """)
+    assert len(out) == 1
+    assert "atomic_write_json" in out[0][2]
+
+
+def test_the_module_qualified_form_is_flagged_through_one_hop():
+    out = _violations("""
+    def save_storage_policy(policy):
+        file_utils.atomic_write_text(path, dumps(policy))
+
+    async def handler(policy):
+        save_storage_policy(policy)
+    """)
+    assert len(out) == 1
+    assert "save_storage_policy" in out[0][2]
+
+
+def test_an_unrelated_receiver_with_the_same_attr_is_not_flagged():
+    # 反证：认的是 (file_utils, atomic_write_*) 这一对，不是光看方法名。
+    out = _violations("""
+    async def handler(payload):
+        my_own_writer.atomic_write_json(path, payload)
+    """)
+    assert out == []
+
+
 def test_the_offloaded_form_is_not_flagged():
     out = _violations('''
     def save_storage_policy(policy):

--- a/tests/unit/test_check_async_blocking.py
+++ b/tests/unit/test_check_async_blocking.py
@@ -1,0 +1,185 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for ``scripts/check_async_blocking.py``'s atomic-write rule.
+
+Synthetic-source coverage of the three things that rule has to get right:
+it must catch a synchronous ``atomic_write_*`` reachable from a coroutine
+(directly, or through one named sync helper); it must NOT fire on helpers
+whose name is too generic to identify by name alone; and one call site
+must be reported once, not once per matching rule.
+"""
+from __future__ import annotations
+
+import ast
+import importlib.util
+import textwrap
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = PROJECT_ROOT / "scripts" / "check_async_blocking.py"
+
+pytestmark = pytest.mark.unit
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location("check_async_blocking", SCRIPT_PATH)
+    assert spec and spec.loader, f"failed to load spec for {SCRIPT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MOD = _load_script_module()
+
+
+def _violations(source: str) -> list[tuple[int, int, str]]:
+    """Run both passes over one synthetic module, as ``main()`` would."""
+    source = textwrap.dedent(source)
+    tree = ast.parse(source)
+    indexer = MOD.RiskySyncDefIndexer()
+    indexer.index_module(tree, Path("synthetic.py"))
+    async_names = MOD._collect_async_def_names(tree)
+    return list(
+        MOD.check_file(
+            Path("synthetic.py"),
+            source,
+            tree,
+            risky_helpers=indexer.risky,
+            ambiguous_async_names=async_names & set(indexer.risky),
+        )
+    )
+
+
+# ── detection ───────────────────────────────────────────────────────────
+
+
+def test_a_direct_atomic_write_in_a_coroutine_is_flagged():
+    out = _violations('''
+    async def handler(payload):
+        atomic_write_json(path, payload)
+    ''')
+    assert len(out) == 1
+    assert "atomic_write_json" in out[0][2]
+
+
+def test_atomic_write_text_is_flagged_too():
+    out = _violations('''
+    async def handler(payload):
+        atomic_write_text(path, payload)
+    ''')
+    assert len(out) == 1
+    assert "atomic_write_text" in out[0][2]
+
+
+def test_a_named_sync_helper_that_writes_is_flagged_through_one_hop():
+    # 这是绝大多数真实调用点的形状：协程调一个同步的 save_xxx，落盘藏在
+    # helper 体内。
+    out = _violations('''
+    def save_storage_policy(policy):
+        atomic_write_json(path, policy)
+
+    async def handler(policy):
+        save_storage_policy(policy)
+    ''')
+    assert len(out) == 1
+    assert "save_storage_policy" in out[0][2]
+
+
+def test_the_offloaded_form_is_not_flagged():
+    out = _violations('''
+    def save_storage_policy(policy):
+        atomic_write_json(path, policy)
+
+    async def handler(policy):
+        await asyncio.to_thread(save_storage_policy, policy)
+    ''')
+    assert out == []
+
+
+def test_a_sync_caller_is_not_flagged():
+    # 规则只管事件循环上的调用；同步上下文里落盘本来就没问题。
+    out = _violations('''
+    def save_storage_policy(policy):
+        atomic_write_json(path, policy)
+
+    def sync_caller(policy):
+        save_storage_policy(policy)
+    ''')
+    assert out == []
+
+
+# ── 通用名去噪 ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("generic", ["save", "load", "write", "flush", "update"])
+def test_a_generic_helper_name_is_not_indexed(generic):
+    # 索引是按名字匹配的，`save` 这种通用动词会撞上 PIL 的 img.save() 和
+    # TokenTracker.save() 之类毫无关系的东西。宁可漏报也不制造假阳性 ——
+    # 与本文件对 queue/thread/socket 尾名的既有取舍同一条原则。
+    out = _violations(f'''
+    def {generic}(payload):
+        atomic_write_json(path, payload)
+
+    async def handler(payload):
+        obj.{generic}(payload)
+    ''')
+    assert out == []
+
+
+def test_the_denylist_is_about_the_helper_name_not_the_write():
+    # 反证：同一个 helper 体，换成一个够独特的名字就必须被抓到。这条保证
+    # 上面那组绿不是因为规则整个失效了。
+    out = _violations('''
+    def save_workshop_config(payload):
+        atomic_write_json(path, payload)
+
+    async def handler(payload):
+        cm.save_workshop_config(payload)
+    ''')
+    assert len(out) == 1
+
+
+# ── 报告形状 ────────────────────────────────────────────────────────────
+
+
+def test_one_call_site_is_reported_once():
+    # `atomic_write_json` 既是已知阻塞调用，本身又是一个体内含
+    # atomic_write_text 的同步 def —— 直接规则和传递规则会双双命中同一处。
+    out = _violations('''
+    def atomic_write_json(path, data):
+        atomic_write_text(path, dumps(data))
+
+    async def handler(payload):
+        atomic_write_json(path, payload)
+    ''')
+    positions = [(lineno, col) for lineno, col, _ in out]
+    assert len(positions) == len(set(positions)) == 1
+
+
+def test_noqa_suppresses_the_call_site():
+    out = _violations('''
+    async def handler(payload):
+        atomic_write_json(path, payload)  # noqa: ASYNC_BLOCK — shutdown flush
+    ''')
+    assert out == []
+
+
+# ── 真实仓库：这条规则必须是绿的 ─────────────────────────────────────────
+
+
+def test_the_repo_itself_has_no_on_loop_atomic_writes():
+    """The whole point of the rule: keep the tree clean going forward."""
+    assert MOD.main([]) == 0

--- a/tests/unit/test_check_async_blocking.py
+++ b/tests/unit/test_check_async_blocking.py
@@ -122,6 +122,52 @@ def test_the_module_qualified_form_is_flagged_through_one_hop():
     assert "save_storage_policy" in out[0][2]
 
 
+def test_an_imported_writer_alias_is_flagged():
+    out = _violations("""
+    from utils.file_utils import atomic_write_json as write_json
+
+    async def handler(payload):
+        write_json(path, payload)
+    """)
+    assert len(out) == 1
+    assert "atomic_write_json" in out[0][2]
+
+
+def test_a_file_utils_module_alias_is_flagged():
+    out = _violations("""
+    from utils import file_utils as fu
+
+    async def handler(payload):
+        fu.atomic_write_text(path, payload)
+    """)
+    assert len(out) == 1
+    assert "atomic_write_text" in out[0][2]
+
+
+def test_an_imported_alias_is_flagged_through_one_hop():
+    out = _violations("""
+    from utils.file_utils import atomic_write_json as write_json
+
+    def save_storage_policy(payload):
+        write_json(path, payload)
+
+    async def handler(payload):
+        save_storage_policy(payload)
+    """)
+    assert len(out) == 1
+    assert "save_storage_policy" in out[0][2]
+
+
+def test_an_unrelated_import_alias_is_not_flagged():
+    out = _violations("""
+    from elsewhere import atomic_write_json as write_json
+
+    async def handler(payload):
+        write_json(path, payload)
+    """)
+    assert out == []
+
+
 def test_an_unrelated_receiver_with_the_same_attr_is_not_flagged():
     # 反证：认的是 (file_utils, atomic_write_*) 这一对，不是光看方法名。
     out = _violations("""
@@ -139,6 +185,23 @@ def test_the_offloaded_form_is_not_flagged():
     async def handler(policy):
         await asyncio.to_thread(save_storage_policy, policy)
     ''')
+    assert out == []
+
+
+def test_workshop_path_config_read_is_flagged_on_the_event_loop():
+    out = _violations("""
+    async def handler():
+        return get_workshop_path()
+    """)
+    assert len(out) == 1
+    assert "get_workshop_path" in out[0][2]
+
+
+def test_workshop_path_async_twin_is_allowed():
+    out = _violations("""
+    async def handler():
+        return await get_workshop_path_async()
+    """)
     assert out == []
 
 

--- a/tests/unit/test_proactive_sid_guard.py
+++ b/tests/unit/test_proactive_sid_guard.py
@@ -391,7 +391,10 @@ async def test_finish_records_proactive_at_sync_publication_time(monkeypatch):
     mgr.last_user_engagement_time = None
     mgr.session = MagicMock()
     mgr.session._conversation_history = []
+    # arecord_output 必须是 AsyncMock：调用点 await 它，而 MagicMock 的返回值
+    # 不可 await —— 那会被调用点的 except 吞掉，这条用例就变成永远绿的空断言。
     corpus = MagicMock()
+    corpus.arecord_output = AsyncMock()
     monkeypatch.setattr(
         anti_repeat,
         "get_anti_repeat_corpus",
@@ -413,12 +416,13 @@ async def test_finish_records_proactive_at_sync_publication_time(monkeypatch):
     )
 
     assert result is True
-    corpus.record_output.assert_called_once_with(
+    corpus.arecord_output.assert_awaited_once_with(
         "Test",
         "delivered before immediate reply",
         is_proactive=True,
         now=100.0,
     )
+    corpus.record_output.assert_not_called()
 
 
 async def test_finish_proactive_delivery_sid_mismatch_skips_all_writes():

--- a/tests/unit/test_proactive_sid_guard.py
+++ b/tests/unit/test_proactive_sid_guard.py
@@ -391,10 +391,12 @@ async def test_finish_records_proactive_at_sync_publication_time(monkeypatch):
     mgr.last_user_engagement_time = None
     mgr.session = MagicMock()
     mgr.session._conversation_history = []
-    # arecord_output 必须是 AsyncMock：调用点 await 它，而 MagicMock 的返回值
-    # 不可 await —— 那会被调用点的 except 吞掉，这条用例就变成永远绿的空断言。
+    # 两段式：stage_output 是同步的（在收尾信号之前），aflush_staged 是 async 的
+    # （在之后）。aflush 必须是 AsyncMock —— 用 MagicMock 的话 await 会抛，被调用点
+    # 的 except 吞掉，这条用例就变成永远绿的空断言。
     corpus = MagicMock()
-    corpus.arecord_output = AsyncMock()
+    corpus.stage_output = MagicMock(return_value=("Test", {"window": []}, 1))
+    corpus.aflush_staged = AsyncMock()
     monkeypatch.setattr(
         anti_repeat,
         "get_anti_repeat_corpus",
@@ -416,12 +418,13 @@ async def test_finish_records_proactive_at_sync_publication_time(monkeypatch):
     )
 
     assert result is True
-    corpus.arecord_output.assert_awaited_once_with(
+    corpus.stage_output.assert_called_once_with(
         "Test",
         "delivered before immediate reply",
         is_proactive=True,
         now=100.0,
     )
+    corpus.aflush_staged.assert_awaited_once()
     corpus.record_output.assert_not_called()
 
 

--- a/tests/unit/test_proactive_sid_guard.py
+++ b/tests/unit/test_proactive_sid_guard.py
@@ -391,11 +391,14 @@ async def test_finish_records_proactive_at_sync_publication_time(monkeypatch):
     mgr.last_user_engagement_time = None
     mgr.session = MagicMock()
     mgr.session._conversation_history = []
-    # 两段式：stage_output 是同步的（在收尾信号之前），aflush_staged 是 async 的
-    # （在之后）。aflush 必须是 AsyncMock —— 用 MagicMock 的话 await 会抛，被调用点
-    # 的 except 吞掉，这条用例就变成永远绿的空断言。
+    # 两段式：stage_output 在收尾信号之前，落盘在之后。落盘走 flush_staged_detached
+    # ——同步返回、内部自己起 task——所以这一段里没有挂起点，取消不能把已经投递出去
+    # 的一轮倒回成「没投递」（见 test_anti_repeat 的对偶用例）。
+    # aflush_staged 仍留 AsyncMock：万一有人把它 await 回来，MagicMock 会让 await 抛、
+    # 被调用点的 except 吞掉，这条用例就变成永远绿的空断言。
     corpus = MagicMock()
     corpus.stage_output = MagicMock(return_value=("Test", {"window": []}, 1))
+    corpus.flush_staged_detached = MagicMock()
     corpus.aflush_staged = AsyncMock()
     monkeypatch.setattr(
         anti_repeat,
@@ -424,7 +427,10 @@ async def test_finish_records_proactive_at_sync_publication_time(monkeypatch):
         is_proactive=True,
         now=100.0,
     )
-    corpus.aflush_staged.assert_awaited_once()
+    corpus.flush_staged_detached.assert_called_once_with(
+        corpus.stage_output.return_value
+    )
+    corpus.aflush_staged.assert_not_awaited()
     corpus.record_output.assert_not_called()
 
 

--- a/tests/unit/test_proactive_unanswered_repeat.py
+++ b/tests/unit/test_proactive_unanswered_repeat.py
@@ -351,6 +351,7 @@ async def test_break_reminder_applies_unanswered_repeat_regen_before_delivery(
         best_similarity=0.91 if regen_still_repeats else 0.1,
     )
     corpus = MagicMock()
+    corpus.apreload = AsyncMock()
     corpus.score_unanswered_proactive_draft.side_effect = [
         first_signal,
         regen_signal,
@@ -567,6 +568,7 @@ async def test_guard_regenerates_then_drops_still_unanswered_repeat(monkeypatch)
         repeated_terms=("屏幕", "按钮"),
     )
     corpus = MagicMock()
+    corpus.apreload = AsyncMock()
     corpus.score_unanswered_proactive_draft.side_effect = [
         initial_signal,
         regen_signal,
@@ -634,6 +636,7 @@ async def test_guard_regenerates_then_drops_still_unanswered_repeat(monkeypatch)
 async def test_unanswered_score_failure_keeps_bm25_guard_active(monkeypatch):
     """A new-signal failure must not disable the established BM25 fallback."""
     corpus = MagicMock()
+    corpus.apreload = AsyncMock()
     corpus.score_unanswered_proactive_draft.side_effect = RuntimeError(
         "synthetic unanswered scorer failure"
     )
@@ -700,6 +703,7 @@ async def test_unanswered_score_failure_keeps_bm25_guard_active(monkeypatch):
 async def test_regenerated_fresh_music_recomputes_text_exemption(monkeypatch):
     """A rewrite that selects fresh material skips every textual recheck."""
     corpus = MagicMock()
+    corpus.apreload = AsyncMock()
     corpus.score_unanswered_proactive_draft.return_value = (
         anti_repeat_module.UnansweredProactiveRepeatSignal(
             triggered=True,
@@ -787,6 +791,7 @@ async def test_regenerated_music_without_material_keeps_text_rechecks(monkeypatc
         repeated_terms=("旧话题",),
     )
     corpus = MagicMock()
+    corpus.apreload = AsyncMock()
     corpus.score_unanswered_proactive_draft.side_effect = [
         initial_signal,
         regenerated_signal,
@@ -848,6 +853,7 @@ async def test_regenerated_music_without_material_keeps_text_rechecks(monkeypatc
 async def test_initial_music_without_material_keeps_text_rechecks(monkeypatch):
     """A bare initial MUSIC tag cannot exempt ordinary chat text."""
     corpus = MagicMock()
+    corpus.apreload = AsyncMock()
     corpus.score_unanswered_proactive_draft.return_value = (
         anti_repeat_module.UnansweredProactiveRepeatSignal(
             triggered=False,
@@ -931,6 +937,7 @@ async def test_regenerated_delivery_aborts_when_engagement_cutoff_advances(
         best_similarity=0.0,
     )
     corpus = MagicMock()
+    corpus.apreload = AsyncMock()
     corpus.score_unanswered_proactive_draft.side_effect = [
         initial_signal,
         regenerated_signal,
@@ -1003,6 +1010,7 @@ async def test_regenerated_delivery_aborts_when_engagement_cutoff_advances(
 async def test_fresh_music_material_skips_unanswered_text_scoring(monkeypatch):
     """Fresh material keeps its established exemption from every text repeat guard."""
     corpus = MagicMock()
+    corpus.apreload = AsyncMock()
     corpus.score_unanswered_proactive_draft.return_value = (
         anti_repeat_module.UnansweredProactiveRepeatSignal(
             triggered=True,

--- a/tests/unit/test_prompt_flow_router.py
+++ b/tests/unit/test_prompt_flow_router.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib
 from pathlib import Path
 
@@ -32,6 +33,45 @@ class DummyConfig:
 
     def get_config_path(self, filename):
         return self.config_dir / filename
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_serialization_happens_before_an_executor_worker_is_allocated(
+    monkeypatch,
+):
+    """Concurrent state calls must not consume workers while waiting on one RLock."""
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    active = 0
+    max_active = 0
+    submissions = 0
+
+    async def _fake_to_thread(func, *args, **kwargs):
+        nonlocal active, max_active, submissions
+        submissions += 1
+        active += 1
+        max_active = max(max_active, active)
+        entered.set()
+        await release.wait()
+        active -= 1
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(system_router_module.asyncio, "to_thread", _fake_to_thread)
+    lock = asyncio.Lock()
+    first = asyncio.create_task(
+        system_router_module._run_serialized_in_worker(lock, lambda: "first")
+    )
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    second = asyncio.create_task(
+        system_router_module._run_serialized_in_worker(lock, lambda: "second")
+    )
+    await asyncio.sleep(0)
+
+    assert submissions == 1, "the waiter reached the executor before its turn"
+    release.set()
+    assert await asyncio.gather(first, second) == ["first", "second"]
+    assert max_active == 1
 
 
 @pytest.fixture

--- a/tests/unit/test_prompt_flow_router.py
+++ b/tests/unit/test_prompt_flow_router.py
@@ -104,7 +104,7 @@ async def test_cancelled_waiter_does_not_release_the_submit_lock_early(
 
     first.cancel()
     with pytest.raises(asyncio.CancelledError):
-        await first
+        _ = await first
 
     second = asyncio.create_task(
         system_router_module._run_serialized_in_worker(lock, lambda: "second")

--- a/tests/unit/test_prompt_flow_router.py
+++ b/tests/unit/test_prompt_flow_router.py
@@ -74,6 +74,51 @@ async def test_serialization_happens_before_an_executor_worker_is_allocated(
     assert max_active == 1
 
 
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cancelled_waiter_does_not_release_the_submit_lock_early(
+    monkeypatch,
+):
+    """Cancellation cannot let a retry allocate a worker behind live work."""
+    first_entered = asyncio.Event()
+    release_first = asyncio.Event()
+    second_entered = asyncio.Event()
+    submissions = 0
+
+    async def _fake_to_thread(func, *args, **kwargs):
+        nonlocal submissions
+        submissions += 1
+        if submissions == 1:
+            first_entered.set()
+            await release_first.wait()
+        else:
+            second_entered.set()
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(system_router_module.asyncio, "to_thread", _fake_to_thread)
+    lock = asyncio.Lock()
+    first = asyncio.create_task(
+        system_router_module._run_serialized_in_worker(lock, lambda: "first")
+    )
+    await asyncio.wait_for(first_entered.wait(), timeout=1)
+
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first
+
+    second = asyncio.create_task(
+        system_router_module._run_serialized_in_worker(lock, lambda: "second")
+    )
+    await asyncio.sleep(0)
+    assert submissions == 1
+    assert not second_entered.is_set()
+
+    release_first.set()
+    await asyncio.wait_for(second_entered.wait(), timeout=1)
+    assert await second == "second"
+    assert submissions == 2
+
+
 @pytest.fixture
 def prompt_flow_client(tmp_path, monkeypatch):
     config = DummyConfig(tmp_path)

--- a/tests/unit/test_prompt_flow_router.py
+++ b/tests/unit/test_prompt_flow_router.py
@@ -288,3 +288,53 @@ def test_seven_day_tutorial_put_rejects_missing_local_mutation_credentials(
 
     assert response.status_code == 403
     assert response.json()["error_code"] == "csrf_validation_failed"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_waiter_cancelled_before_submission_leaves_the_queue(monkeypatch):
+    """Only a running worker is worth keeping; a queued one must not linger."""
+    # 一次慢文件操作 + 客户端反复超时重试，会在锁上攒出一条无界队列。那些子任务里
+    # 没有任何不可取消的东西 —— 保住它们只会在客户端早就走了之后再做一次陈旧的写，
+    # 并且挡住还活着的请求。
+    first_entered = asyncio.Event()
+    release_first = asyncio.Event()
+    submissions = 0
+    ran = []
+
+    async def _fake_to_thread(func, *args, **kwargs):
+        nonlocal submissions
+        submissions += 1
+        if submissions == 1:
+            first_entered.set()
+            await release_first.wait()
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(system_router_module.asyncio, "to_thread", _fake_to_thread)
+    lock = asyncio.Lock()
+
+    first = asyncio.create_task(
+        system_router_module._run_serialized_in_worker(lock, lambda: "first")
+    )
+    await asyncio.wait_for(first_entered.wait(), timeout=1)
+
+    # 这一个还排在锁上，从没进过 worker。
+    queued = asyncio.create_task(
+        system_router_module._run_serialized_in_worker(
+            lock, lambda: ran.append("queued") or "queued",
+        )
+    )
+    await asyncio.sleep(0)
+    assert submissions == 1
+
+    queued.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        _ = await queued
+
+    # 放行第一个。被取消的那个绝不该在这之后还去拿锁、占 worker、做一次陈旧的写。
+    release_first.set()
+    assert await asyncio.wait_for(first, timeout=1) == "first"
+    for _ in range(5):
+        await asyncio.sleep(0)
+    assert submissions == 1, "被取消的等待者事后仍然占用了一个 executor worker"
+    assert ran == [], "客户端早就走了，这次陈旧的写还是执行了"

--- a/tests/unit/test_workshop_cloudsave_disabled.py
+++ b/tests/unit/test_workshop_cloudsave_disabled.py
@@ -1045,9 +1045,13 @@ class _RecordingLogger:
 
     def __init__(self):
         self.errors = []
+        self.warnings = []
 
     def error(self, *args, **kwargs):
         self.errors.append(args)
+
+    def warning(self, *args, **kwargs):
+        self.warnings.append(args)
 
     def __getattr__(self, _name):
         return lambda *a, **kw: None
@@ -1108,6 +1112,10 @@ def test_a_persistent_access_denial_stops_looking_transient(tmp_path, monkeypatc
     clock.now += 100.0
     assert cm.load_workshop_config()["user_mod_folder"] == "/user/mods"
     assert len(recorder.errors) == 1, "每次读失败都报一遍 ERROR，日志会被刷爆"
+
+    # warning 同理：这个端点被 get_workshop_path 之类反复调用，持续故障下每次一条
+    # warning 会把上面那条真正要人看的 ERROR 埋掉。只在第一次失败时说一句。
+    assert len(recorder.warnings) == 1, "持续故障下每次读失败都打 warning，日志会被刷爆"
 
 
 @pytest.mark.unit

--- a/tests/unit/test_workshop_cloudsave_disabled.py
+++ b/tests/unit/test_workshop_cloudsave_disabled.py
@@ -755,3 +755,38 @@ def test_the_fallback_does_not_mask_a_genuinely_broken_config(tmp_path, monkeypa
         "配置真坏了却拿缓存盖住了——upload/publish 会一直对着旧根目录干活"
     )
     assert broken["default_workshop_folder"] == str(cm.workshop_dir)
+
+
+def test_the_cache_compare_and_set_is_atomic():
+    """A save landing between the generation check and the assignment must win.
+
+    Without holding a lock across both, an old read can pass the comparison,
+    get preempted while a save bumps the generation and stores the new
+    snapshot, and then assign its stale one on top.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    from utils.config_manager import workshop as workshop_mixin
+
+    tree = ast.parse(
+        textwrap.dedent(
+            inspect.getsource(workshop_mixin.WorkshopMixin._remember_good_workshop_config)
+        )
+    )
+    withs = [n for n in ast.walk(tree) if isinstance(n, ast.With)]
+    assert withs, "比较和赋值没有被任何锁圈住"
+    guarded = withs[0]
+    body_ops = [n for n in ast.walk(guarded)]
+    has_compare = any(
+        isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == "getattr"
+        for n in body_ops
+    )
+    has_assign = any(
+        isinstance(n, ast.Attribute) and n.attr == "_last_good_workshop_config"
+        for n in body_ops
+    )
+    assert has_compare and has_assign, (
+        "代数比较和缓存赋值必须在同一个 with 里，否则中间可以被一次 save 插入"
+    )

--- a/tests/unit/test_workshop_cloudsave_disabled.py
+++ b/tests/unit/test_workshop_cloudsave_disabled.py
@@ -562,3 +562,101 @@ def test_the_replace_tolerant_read_never_sleeps_on_the_event_loop():
         "读重试没有事件循环守卫 —— get_workshop_path() 这类同步读就挂在 async "
         "handler 上，会在循环上睡满退避预算"
     )
+
+
+def test_a_save_refreshes_the_last_good_config(tmp_path, monkeypatch):
+    """The fallback must not hand back the state from before this very save.
+
+    `POST /config` loads the old config, writes the new one, and the cache is
+    only refreshed on successful *reads* — so a transient read failure right
+    after would return the pre-change configuration, which is harder to spot
+    than falling back to defaults.
+    """
+    from utils.config_manager import workshop as workshop_mixin
+
+    config_path = tmp_path / "workshop_config.json"
+    config_path.write_text(json.dumps({"user_mod_folder": "/old"}), encoding="utf-8")
+
+    class _CM(workshop_mixin.WorkshopMixin):
+        def __init__(self):
+            import threading
+
+            self._workshop_config_lock = threading.RLock()
+            self.workshop_dir = tmp_path / "default"
+
+        def get_workshop_config_path(self):
+            return config_path
+
+        def get_runtime_config_path(self, name):
+            return config_path
+
+        def ensure_config_directory(self):
+            return None
+
+        def _rebase_workshop_config_after_storage_migration(self, config):
+            return config
+
+    cm = _CM()
+    assert cm.load_workshop_config()["user_mod_folder"] == "/old"
+    monkeypatch.setattr(
+        "utils.cloudsave_runtime.assert_cloudsave_writable", lambda *a, **kw: None
+    )
+    cm.save_workshop_config({"user_mod_folder": "/new"})
+
+    busy = PermissionError(13, "Access is denied")
+    busy.winerror = 32
+    monkeypatch.setattr(
+        workshop_mixin, "read_json_tolerating_replace",
+        lambda *a, **kw: (_ for _ in ()).throw(busy),
+    )
+
+    assert cm.load_workshop_config()["user_mod_folder"] == "/new", (
+        "读失败回落到了保存**之前**的配置"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_blank_folder_value_is_rejected(monkeypatch):
+    """`"   "` must not slip past the absolute-path check and get persisted."""
+    _stub_config_manager_lock(monkeypatch)
+
+    from main_routers.workshop_router import config_files
+    from utils import workshop_utils
+
+    saved: list[dict] = []
+    monkeypatch.setattr(workshop_utils, "load_workshop_config", lambda: {})
+    monkeypatch.setattr(workshop_utils, "save_workshop_config", lambda cfg: saved.append(cfg))
+    monkeypatch.setattr(workshop_utils, "ensure_workshop_folder_exists", lambda f, **kw: True)
+
+    result = await config_files.save_workshop_config_api({"user_mod_folder": "   "})
+    assert result["success"] is False
+    assert "空白" in result["error"]
+    assert saved == []
+
+
+def test_the_missing_config_branch_is_lock_free_on_the_loop():
+    """The first POST /config holds the lock while creating the file.
+
+    Until it commits, the target does not exist — so a loop-side
+    `get_workshop_path()` takes the "missing" branch, and if that branch waits
+    on the writer lock the whole loop waits with it. Returning defaults needs
+    no mutual exclusion.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    from utils.config_manager import workshop as workshop_mixin
+
+    tree = ast.parse(
+        textwrap.dedent(inspect.getsource(workshop_mixin.WorkshopMixin.load_workshop_config))
+    )
+    guards = [
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        and node.func.id == "running_on_event_loop"
+    ]
+    assert guards, (
+        "缺配置分支没有事件循环守卫 —— 首次 POST /config 创建文件期间，"
+        "循环上的 get_workshop_path() 会卡在写者锁上"
+    )

--- a/tests/unit/test_workshop_cloudsave_disabled.py
+++ b/tests/unit/test_workshop_cloudsave_disabled.py
@@ -335,3 +335,75 @@ def test_a_path_naming_a_file_is_not_a_ready_folder(tmp_path):
     blocked = tmp_path / "not-allowed"
     assert ensure_workshop_folder_exists(str(blocked), auto_create=False) is False
     assert not blocked.exists()
+
+
+@pytest.mark.asyncio
+async def test_a_non_string_folder_value_is_rejected_before_it_is_persisted(monkeypatch):
+    """A `{}` or list for a folder field must not reach the config file.
+
+    Persisting it corrupts the config: `get_workshop_path()` later hands the
+    object straight to `os.path.join()` in every workshop handler, and the user
+    cannot recover without editing the file by hand.
+    """
+    _stub_config_manager_lock(monkeypatch)
+
+    from main_routers.workshop_router import config_files
+    from utils import workshop_utils
+
+    saved: list[dict] = []
+    monkeypatch.setattr(workshop_utils, "load_workshop_config", lambda: {})
+    monkeypatch.setattr(workshop_utils, "save_workshop_config", lambda cfg: saved.append(cfg))
+    monkeypatch.setattr(workshop_utils, "ensure_workshop_folder_exists", lambda f, **kw: True)
+
+    for bad in ({}, ["a"], 5):
+        result = await config_files.save_workshop_config_api({"user_mod_folder": bad})
+        assert result["success"] is False, f"{bad!r} 被接受了"
+        assert "user_mod_folder" in result["error"]
+
+    assert saved == [], "校验失败的请求不该写盘"
+
+    ok = await config_files.save_workshop_config_api({"user_mod_folder": "C:/mods"})
+    assert ok["success"] is True
+    assert saved and saved[-1]["user_mod_folder"] == "C:/mods"
+
+
+@pytest.mark.asyncio
+async def test_the_self_healing_write_is_skipped_on_the_event_loop(monkeypatch, tmp_path):
+    """`get_workshop_path()` runs on the loop; its self-heal must not take the lock.
+
+    The rebase only fires after a storage migration, but when it does the write
+    would acquire the same lock a worker may hold across an fsync — stalling the
+    whole loop. The corrected paths are still returned to this caller; only the
+    persistence waits for a reader that runs off-loop.
+    """
+    from utils.config_manager import workshop as workshop_mixin
+
+    class _CM(workshop_mixin.WorkshopMixin):
+        def __init__(self):
+            import threading
+
+            self._workshop_config_lock = threading.RLock()
+            self.app_docs_dir = str(tmp_path)
+            self.saves: list[dict] = []
+
+        def load_root_state(self):
+            return {"last_migration_source": str(tmp_path / "old")}
+
+        def _read_workshop_config_file(self):
+            # 必须返回真东西：否则没有守卫时也会在这里抛、被外层 except 吞掉，
+            # 两种实现都「没落盘」，用例就分辨不出来了。
+            return {"user_mod_folder": "old"}
+
+        def save_workshop_config(self, config):
+            self.saves.append(dict(config))
+
+    cm = _CM()
+    monkeypatch.setattr(
+        "utils.storage_path_rewrite.rebase_runtime_bound_workshop_config_paths",
+        lambda cfg, **kw: {**cfg, "user_mod_folder": "rebased"},
+    )
+
+    rebased = cm._rebase_workshop_config_after_storage_migration({"user_mod_folder": "old"})
+
+    assert rebased["user_mod_folder"] == "rebased", "调用方仍然要拿到修正后的路径"
+    assert cm.saves == [], "在事件循环上不许落盘——那会去抢 worker 可能持着的锁"

--- a/tests/unit/test_workshop_cloudsave_disabled.py
+++ b/tests/unit/test_workshop_cloudsave_disabled.py
@@ -141,22 +141,26 @@ def _stub_config_manager_lock(monkeypatch):
     return lock
 
 @pytest.mark.asyncio
-async def test_concurrent_config_saves_do_not_cross_transactions(tmp_path, monkeypatch):
-    """Two overlapping /config requests must not read each other's half-state.
+async def test_a_transaction_hands_ensure_its_own_policy(tmp_path, monkeypatch):
+    """The auto-create decision must come from the transaction, not a reload.
 
-    The save now runs in a worker thread, so two of them interleave at the OS
-    level. `ensure_workshop_folder_exists` re-reads the config file to decide
-    `auto_create_folder`, so without serialization request A's ensure can see
-    request B's freshly-saved config and decline to create A's folder while A
-    still answers `success`.
+    `ensure_workshop_folder_exists` used to re-read the config file to decide
+    `auto_create`, so an overlapping request could flip it in between: A saves
+    auto_create=true for folder A, B saves auto_create=false, A's ensure reads
+    B's config and declines to create A — while A answers success.
+
+    The policy is now decided under the lock and passed in explicitly, which is
+    also what lets the (possibly very slow) directory work happen outside the
+    lock. Asserted on the argument ensure actually receives.
     """
     _stub_config_manager_lock(monkeypatch)
     import threading
 
     from main_routers.workshop_router import config_files
+    from utils import workshop_utils
 
     stored: dict = {"auto_create_folder": True}
-    order: list[str] = []
+    seen: list[str] = []
     b_saved = threading.Event()
 
     def _load():
@@ -168,14 +172,12 @@ async def test_concurrent_config_saves_do_not_cross_transactions(tmp_path, monke
         if cfg.get("user_mod_folder") == "B":
             b_saved.set()
 
-    def _ensure(folder):
-        # A 到这里时故意让 B 有机会先写完；没有锁的话 A 就会读到 B 的配置。
+    def _ensure(folder, **kwargs):
         if folder == "A":
+            # 让 B 一定先写完，构造出「重读就会读到别人配置」的时刻。
             b_saved.wait(timeout=1.0)
-        order.append(f"ensure:{folder}:auto={_load().get('auto_create_folder')}")
+        seen.append(f"{folder}:auto={kwargs.get('auto_create')}")
         return True
-
-    from utils import workshop_utils
 
     monkeypatch.setattr(workshop_utils, "load_workshop_config", _load)
     monkeypatch.setattr(workshop_utils, "save_workshop_config", _save)
@@ -194,117 +196,106 @@ async def test_concurrent_config_saves_do_not_cross_transactions(tmp_path, monke
     )
     await asyncio.gather(a, b)
 
-    a_ensures = [entry for entry in order if entry.startswith("ensure:A")]
-    assert a_ensures == ["ensure:A:auto=True"], (
-        f"A 的 ensure 读到了别人的配置：{order}"
+    assert "A:auto=True" in seen, (
+        f"A 的 ensure 拿到的不是本次事务定下的策略：{seen}"
+    )
+    assert not any(entry.startswith("B:") for entry in seen), (
+        "auto_create=false 的那次不该去建目录"
     )
 
 
-@pytest.mark.asyncio
-async def test_a_folder_that_cannot_be_created_is_reported(monkeypatch):
-    """Saving a read-only path must not be reported as fully successful.
-
-    ``ensure_workshop_folder_exists`` swallows the creation failure and returns
-    False. The config itself did persist, so ``success`` stays True — but the
-    response has to say the folder is not usable, or the user is told an
-    unusable workshop path was set up fine.
-    """
-    _stub_config_manager_lock(monkeypatch)
-    from main_routers.workshop_router import config_files
-    from utils import workshop_utils
-
-    monkeypatch.setattr(workshop_utils, "load_workshop_config", lambda: {})
-    monkeypatch.setattr(workshop_utils, "save_workshop_config", lambda cfg: None)
-    monkeypatch.setattr(workshop_utils, "ensure_workshop_folder_exists", lambda folder: False)
-
-    result = await config_files.save_workshop_config_api(
-        {"user_mod_folder": "R:/read-only", "auto_create_folder": True}
-    )
-
-    assert result["success"] is True, "配置本身确实存下来了"
-    assert result["folder_ready"] is False
-    assert "warning" in result
-
-
-@pytest.mark.asyncio
-async def test_a_created_folder_reports_ready(monkeypatch):
-    _stub_config_manager_lock(monkeypatch)
-    from main_routers.workshop_router import config_files
-    from utils import workshop_utils
-
-    monkeypatch.setattr(workshop_utils, "load_workshop_config", lambda: {})
-    monkeypatch.setattr(workshop_utils, "save_workshop_config", lambda cfg: None)
-    monkeypatch.setattr(workshop_utils, "ensure_workshop_folder_exists", lambda folder: True)
-
-    result = await config_files.save_workshop_config_api(
-        {"user_mod_folder": "C:/mods", "auto_create_folder": True}
-    )
-
-    assert result["folder_ready"] is True
-    assert "warning" not in result
-
-
-def test_every_read_modify_write_holds_the_config_lock():
-    """No path may load workshop_config.json, change it, and save it unlocked.
-
-    Two such paths exist beyond the obvious save: the self-healing rebase
-    inside ``load_workshop_config`` (it writes after a storage migration) and
-    ``persist_user_workshop_folder`` at startup. Either one running unlocked
-    can read before the POST transaction and save after it, silently
-    overwriting the folder settings the user just submitted while POST reports
-    success.
-
-    Checked as "any function calling both load and save must do so inside the
-    lock" rather than by naming the two known offenders — a third one added
-    later has to fail this instead of slipping through.
-    """
+def _mixin_tree():
     import ast
     import inspect
     import textwrap
 
     from utils.config_manager import workshop as workshop_mixin
 
-    tree = ast.parse(textwrap.dedent(inspect.getsource(workshop_mixin.WorkshopMixin)))
+    return ast.parse(textwrap.dedent(inspect.getsource(workshop_mixin.WorkshopMixin)))
 
-    def _calls(node) -> set[str]:
-        return {
-            child.func.attr
-            for child in ast.walk(node)
-            if isinstance(child, ast.Call) and isinstance(child.func, ast.Attribute)
-        }
 
-    WRITERS = {"save_workshop_config", "_rebase_workshop_config_after_storage_migration"}
+def _fn(tree, name):
+    import ast
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return node
+    raise AssertionError(f"找不到 {name}，这条守卫需要跟着更新")
+
+
+def test_every_write_of_the_workshop_config_holds_the_lock():
+    """A save must never race the POST transaction's read-modify-write.
+
+    Checked as "every save_workshop_config call site is inside the lock"
+    rather than by naming the known writers — a new one added later has to
+    fail this instead of slipping through.
+    """
+    import ast
+
+    tree = _mixin_tree()
     offenders = []
     for fn in ast.walk(tree):
         if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
-        if fn.name in {"save_workshop_config", "_rebase_workshop_config_after_storage_migration"}:
+        if fn.name == "save_workshop_config":
             continue  # 叶子写入本身，由调用方持锁
-        called = _calls(fn)
-        if not (called & WRITERS):
+        saves = {
+            call.lineno for call in ast.walk(fn)
+            if isinstance(call, ast.Call) and isinstance(call.func, ast.Attribute)
+            and call.func.attr == "save_workshop_config"
+        }
+        if not saves:
             continue
-        # 该函数体内所有「写」调用都必须落在某个持 _workshop_config_lock 的 with 里
-        guarded_lines = {
+        guarded = {
             call.lineno
             for node in ast.walk(fn) if isinstance(node, ast.With)
             for item in node.items
             if "_workshop_config_lock" in ast.unparse(item.context_expr)
             for call in ast.walk(node)
             if isinstance(call, ast.Call) and isinstance(call.func, ast.Attribute)
-            and call.func.attr in WRITERS
+            and call.func.attr == "save_workshop_config"
         }
-        all_lines = {
-            call.lineno
-            for call in ast.walk(fn)
-            if isinstance(call, ast.Call) and isinstance(call.func, ast.Attribute)
-            and call.func.attr in WRITERS
-        }
-        if all_lines - guarded_lines:
-            offenders.append(f"{fn.name}(相对行 {sorted(all_lines - guarded_lines)})")
+        if saves - guarded:
+            offenders.append(f"{fn.name}(相对行 {sorted(saves - guarded)})")
 
     assert not offenders, (
         f"这些地方在锁外写 workshop 配置：{offenders} —— "
         "读改写不整段持锁就能盖掉刚提交的配置"
+    )
+
+
+def test_the_config_read_path_never_takes_the_lock():
+    """The dual invariant, and the one that keeps biting.
+
+    `get_workshop_path()` goes through `load_workshop_config()`, and several
+    async handlers (voice_refs upload/remove, publish) call it straight from
+    the event loop. If that read had to acquire the lock, any worker holding
+    it across an fsync — or across a makedirs on a network path — would stall
+    the whole loop. The self-healing write serializes itself instead, inside
+    `_rebase_workshop_config_after_storage_migration`.
+    """
+    import ast
+
+    tree = _mixin_tree()
+    load_fn = _fn(tree, "load_workshop_config")
+    locked = [
+        node.lineno
+        for node in ast.walk(load_fn) if isinstance(node, ast.With)
+        for item in node.items
+        if "_workshop_config_lock" in ast.unparse(item.context_expr)
+    ]
+    # 「文件不存在」那条分支写默认配置，持锁是对的；有文件的读路径不许持锁。
+    read_branch = _fn(tree, "_read_workshop_config_file")
+    read_locked = [
+        node.lineno
+        for node in ast.walk(read_branch) if isinstance(node, ast.With)
+        for item in node.items
+        if "_workshop_config_lock" in ast.unparse(item.context_expr)
+    ]
+    assert read_locked == [], "裸读路径不许拿锁——事件循环上的 get_workshop_path() 会跟着等"
+    assert len(locked) <= 1, (
+        f"load_workshop_config 里出现了不止一处持锁（相对行 {locked}）——"
+        "有文件的读路径必须保持无锁"
     )
 
 

--- a/tests/unit/test_workshop_cloudsave_disabled.py
+++ b/tests/unit/test_workshop_cloudsave_disabled.py
@@ -822,3 +822,37 @@ async def test_an_empty_string_clears_the_override(monkeypatch):
 
     blank = await config_files.save_workshop_config_api({"user_mod_folder": "  "})
     assert blank["success"] is False, "全空白不该被当成清除"
+
+
+def test_the_cache_lock_is_created_exactly_once_under_concurrency(tmp_path):
+    """Two threads racing the lazy init must not end up with different locks.
+
+    A lock that each caller creates for itself guards nothing: the reader and
+    the saver would enter the compare-and-set section independently, which is
+    exactly the interleaving the lock was added to prevent.
+    """
+    import threading
+
+    from utils.config_manager import workshop as workshop_mixin
+
+    class _CM(workshop_mixin.WorkshopMixin):
+        pass
+
+    cm = _CM()
+    seen: list = []
+    start = threading.Barrier(8)
+
+    def _grab():
+        start.wait(timeout=5)
+        seen.append(cm._last_good_workshop_config_lock)
+
+    threads = [threading.Thread(target=_grab) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5)
+
+    assert len(seen) == 8
+    assert len({id(lock) for lock in seen}) == 1, (
+        "并发懒创建造出了多把锁——那这把锁等于不存在"
+    )

--- a/tests/unit/test_workshop_cloudsave_disabled.py
+++ b/tests/unit/test_workshop_cloudsave_disabled.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 from utils.cloudsave_runtime import CLOUDSAVE_DISABLED_ENV
@@ -115,4 +117,63 @@ def test_the_workshop_config_route_can_import_what_it_uses():
         ensure_workshop_folder_exists,
         load_workshop_config,
         save_workshop_config,
+    )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_config_saves_do_not_cross_transactions(tmp_path, monkeypatch):
+    """Two overlapping /config requests must not read each other's half-state.
+
+    The save now runs in a worker thread, so two of them interleave at the OS
+    level. `ensure_workshop_folder_exists` re-reads the config file to decide
+    `auto_create_folder`, so without serialization request A's ensure can see
+    request B's freshly-saved config and decline to create A's folder while A
+    still answers `success`.
+    """
+    import threading
+
+    from main_routers.workshop_router import config_files
+
+    stored: dict = {"auto_create_folder": True}
+    order: list[str] = []
+    b_saved = threading.Event()
+
+    def _load():
+        return dict(stored)
+
+    def _save(cfg):
+        stored.clear()
+        stored.update(cfg)
+        if cfg.get("user_mod_folder") == "B":
+            b_saved.set()
+
+    def _ensure(folder):
+        # A 到这里时故意让 B 有机会先写完；没有锁的话 A 就会读到 B 的配置。
+        if folder == "A":
+            b_saved.wait(timeout=1.0)
+        order.append(f"ensure:{folder}:auto={_load().get('auto_create_folder')}")
+        return True
+
+    import utils.workshop_utils as workshop_utils
+
+    monkeypatch.setattr(workshop_utils, "load_workshop_config", _load)
+    monkeypatch.setattr(workshop_utils, "save_workshop_config", _save)
+    monkeypatch.setattr(workshop_utils, "ensure_workshop_folder_exists", _ensure)
+
+    a = asyncio.create_task(
+        config_files.save_workshop_config_api(
+            {"user_mod_folder": "A", "auto_create_folder": True}
+        )
+    )
+    await asyncio.sleep(0)
+    b = asyncio.create_task(
+        config_files.save_workshop_config_api(
+            {"user_mod_folder": "B", "auto_create_folder": False}
+        )
+    )
+    await asyncio.gather(a, b)
+
+    a_ensures = [entry for entry in order if entry.startswith("ensure:A")]
+    assert a_ensures == ["ensure:A:auto=True"], (
+        f"A 的 ensure 读到了别人的配置：{order}"
     )

--- a/tests/unit/test_workshop_cloudsave_disabled.py
+++ b/tests/unit/test_workshop_cloudsave_disabled.py
@@ -309,3 +309,29 @@ def test_the_workshop_config_lock_is_reentrant():
     assert isinstance(lock, type(threading.RLock())), (
         "必须是 RLock：事务持着它再调 load_workshop_config，不可重入就是自死锁"
     )
+
+
+def test_a_path_naming_a_file_is_not_a_ready_folder(tmp_path):
+    """`exists()` is true for regular files; the workshop root must be a dir.
+
+    Reporting ready for a file persists it as the workshop root, and every
+    later `os.path.join(root, 'WorkshopExport')` fails against it.
+    """
+    from utils.workshop_utils import ensure_workshop_folder_exists
+
+    a_file = tmp_path / "not-a-folder.txt"
+    a_file.write_text("x", encoding="utf-8")
+
+    assert ensure_workshop_folder_exists(str(a_file), auto_create=True) is False
+
+    a_dir = tmp_path / "real-folder"
+    a_dir.mkdir()
+    assert ensure_workshop_folder_exists(str(a_dir), auto_create=True) is True
+
+    fresh = tmp_path / "created-on-demand"
+    assert ensure_workshop_folder_exists(str(fresh), auto_create=True) is True
+    assert fresh.is_dir()
+
+    blocked = tmp_path / "not-allowed"
+    assert ensure_workshop_folder_exists(str(blocked), auto_create=False) is False
+    assert not blocked.exists()

--- a/tests/unit/test_workshop_cloudsave_disabled.py
+++ b/tests/unit/test_workshop_cloudsave_disabled.py
@@ -1013,3 +1013,139 @@ def test_the_path_probe_runs_in_the_worker_not_on_the_loop():
     assert not outside, (
         f"os.stat 留在了协程体里（相对行 {outside}）——慢速网络盘会把事件循环挂住"
     )
+
+
+def _make_workshop_cm(tmp_path, config_path):
+    from utils.config_manager import workshop as workshop_mixin
+
+    class _CM(workshop_mixin.WorkshopMixin):
+        def __init__(self):
+            import threading
+
+            self._workshop_config_lock = threading.RLock()
+            self.workshop_dir = tmp_path / "default"
+
+        def get_workshop_config_path(self):
+            return config_path
+
+        def _rebase_workshop_config_after_storage_migration(self, config):
+            return config
+
+    return _CM()
+
+
+class _RecordingLogger:
+    """Capture .error() without caplog.
+
+    这个模块的 logger 由项目日志初始化关掉了 propagate，caplog 的 handler 挂在 root
+    上，所以它收不到 —— 单独跑绿、跟整个文件一起跑红。注入替身没有这个顺序依赖。
+    """
+
+    def __init__(self):
+        self.errors = []
+
+    def error(self, *args, **kwargs):
+        self.errors.append(args)
+
+    def __getattr__(self, _name):
+        return lambda *a, **kw: None
+
+
+class _FakeClock:
+    def __init__(self):
+        self.now = 1000.0
+
+    def monotonic(self):
+        return self.now
+
+
+@pytest.mark.unit
+def test_a_persistent_access_denial_stops_looking_transient(tmp_path, monkeypatch):
+    """winerror 5 is ambiguous, so persistence is what separates the two cases.
+
+    ACCESS_DENIED is what Windows raises for the millisecond-wide window where
+    os.replace holds the target open AND for a permanent revocation. The
+    fallback keeps serving the last good value either way, because that is the
+    user's real workshop root and defaults would relocate every upload. What
+    must not happen is that a permanent failure stays a debug-level shrug.
+    """
+    from utils.config_manager import workshop as workshop_mixin
+
+    config_path = tmp_path / "workshop_config.json"
+    config_path.write_text(
+        json.dumps({"user_mod_folder": "/user/mods", "auto_create_folder": True}),
+        encoding="utf-8",
+    )
+    cm = _make_workshop_cm(tmp_path, config_path)
+    assert cm.load_workshop_config()["user_mod_folder"] == "/user/mods"
+
+    clock = _FakeClock()
+    monkeypatch.setattr(workshop_mixin, "time", clock)
+    denied = PermissionError(13, "Access is denied")
+    denied.winerror = 5           # ← 与 os.replace 瞬时窗口同码
+    monkeypatch.setattr(
+        workshop_mixin, "read_json_tolerating_replace",
+        lambda *a, **kw: (_ for _ in ()).throw(denied),
+    )
+
+    recorder = _RecordingLogger()
+    monkeypatch.setattr(workshop_mixin, "logger", recorder)
+
+    # 宽限期内：照常沿用 last-good，不吵。
+    assert cm.load_workshop_config()["user_mod_folder"] == "/user/mods"
+    clock.now += workshop_mixin._WORKSHOP_CONFIG_FALLBACK_GRACE_S - 0.1
+    assert cm.load_workshop_config()["user_mod_folder"] == "/user/mods"
+    assert not recorder.errors, "还在瞬时窗口内就报 ERROR，会把正常的 replace 竞态吵成故障"
+
+    # 撑过宽限期：值照给，但必须留下一条能查的 ERROR。
+    clock.now += 0.2
+    assert cm.load_workshop_config()["user_mod_folder"] == "/user/mods"
+    assert len(recorder.errors) == 1, "持续读不出来却始终只有 debug 级日志，没人会发现"
+
+    # 只报一次，别把日志刷爆。
+    clock.now += 100.0
+    assert cm.load_workshop_config()["user_mod_folder"] == "/user/mods"
+    assert len(recorder.errors) == 1, "每次读失败都报一遍 ERROR，日志会被刷爆"
+
+
+@pytest.mark.unit
+def test_a_successful_read_resets_the_fallback_streak(tmp_path, monkeypatch):
+    """A replace race that clears must not count toward the persistence budget."""
+    from utils.config_manager import workshop as workshop_mixin
+
+    config_path = tmp_path / "workshop_config.json"
+    config_path.write_text(
+        json.dumps({"user_mod_folder": "/user/mods", "auto_create_folder": True}),
+        encoding="utf-8",
+    )
+    cm = _make_workshop_cm(tmp_path, config_path)
+    assert cm.load_workshop_config()["user_mod_folder"] == "/user/mods"
+
+    clock = _FakeClock()
+    monkeypatch.setattr(workshop_mixin, "time", clock)
+    recorder = _RecordingLogger()
+    monkeypatch.setattr(workshop_mixin, "logger", recorder)
+
+    real_read = workshop_mixin.read_json_tolerating_replace
+    denied = PermissionError(13, "Access is denied")
+    denied.winerror = 5
+    fail = {"on": True}
+
+    def _maybe_fail(*args, **kwargs):
+        if fail["on"]:
+            raise denied
+        return real_read(*args, **kwargs)
+
+    monkeypatch.setattr(workshop_mixin, "read_json_tolerating_replace", _maybe_fail)
+
+    cm.load_workshop_config()                 # 开始计时
+    clock.now += workshop_mixin._WORKSHOP_CONFIG_FALLBACK_GRACE_S - 0.1
+    fail["on"] = False
+    cm.load_workshop_config()                 # 竞态过去了，读成功
+    fail["on"] = True
+    clock.now += 0.2                          # 从头算的话还没到宽限期
+    cm.load_workshop_config()
+
+    assert not recorder.errors, (
+        "一次读成功没有把连续失败时长清零 —— 间歇性的 replace 竞态会被误判成持续故障"
+    )

--- a/tests/unit/test_workshop_cloudsave_disabled.py
+++ b/tests/unit/test_workshop_cloudsave_disabled.py
@@ -85,3 +85,34 @@ def test_workshop_tombstone_write_still_saves_when_cloudsave_is_enabled(monkeypa
     assert saved_payloads == [{"version": 1, "tombstones": [{"character_name": "恢复角色"}]}]
     assert _session_deleted_names == {"恢复角色"}
     _session_deleted_names.clear()
+
+
+def test_workshop_utils_reexports_the_config_saver():
+    """POST /api/steam/workshop/config imports its saver from utils.workshop_utils.
+
+    That module re-exports the config_manager helpers, and `save_workshop_config`
+    was missing from the list — so the handler's own `from utils.workshop_utils
+    import ... save_workshop_config ...` raised ImportError on every request,
+    was swallowed by the handler's `except Exception`, and the endpoint answered
+    HTTP 200 with `{"success": false}` while never writing a single byte.
+    """
+    import utils.workshop_utils as workshop_utils
+
+    assert hasattr(workshop_utils, "save_workshop_config"), (
+        "save_workshop_config 必须能从 utils.workshop_utils 导入 —— "
+        "保存 workshop 配置的接口就是从这里拿它的"
+    )
+
+
+def test_the_workshop_config_route_can_import_what_it_uses():
+    """The route's own import line must actually resolve.
+
+    Pinned as the route writes it (a local import inside the handler), so a
+    future re-shuffle of utils.workshop_utils breaks this test instead of
+    silently turning the endpoint into a no-op again.
+    """
+    from utils.workshop_utils import (  # noqa: F401
+        ensure_workshop_folder_exists,
+        load_workshop_config,
+        save_workshop_config,
+    )

--- a/tests/unit/test_workshop_cloudsave_disabled.py
+++ b/tests/unit/test_workshop_cloudsave_disabled.py
@@ -177,3 +177,45 @@ async def test_concurrent_config_saves_do_not_cross_transactions(tmp_path, monke
     assert a_ensures == ["ensure:A:auto=True"], (
         f"A 的 ensure 读到了别人的配置：{order}"
     )
+
+
+@pytest.mark.asyncio
+async def test_a_folder_that_cannot_be_created_is_reported(monkeypatch):
+    """Saving a read-only path must not be reported as fully successful.
+
+    ``ensure_workshop_folder_exists`` swallows the creation failure and returns
+    False. The config itself did persist, so ``success`` stays True — but the
+    response has to say the folder is not usable, or the user is told an
+    unusable workshop path was set up fine.
+    """
+    from main_routers.workshop_router import config_files
+    from utils import workshop_utils
+
+    monkeypatch.setattr(workshop_utils, "load_workshop_config", lambda: {})
+    monkeypatch.setattr(workshop_utils, "save_workshop_config", lambda cfg: None)
+    monkeypatch.setattr(workshop_utils, "ensure_workshop_folder_exists", lambda folder: False)
+
+    result = await config_files.save_workshop_config_api(
+        {"user_mod_folder": "R:/read-only", "auto_create_folder": True}
+    )
+
+    assert result["success"] is True, "配置本身确实存下来了"
+    assert result["folder_ready"] is False
+    assert "warning" in result
+
+
+@pytest.mark.asyncio
+async def test_a_created_folder_reports_ready(monkeypatch):
+    from main_routers.workshop_router import config_files
+    from utils import workshop_utils
+
+    monkeypatch.setattr(workshop_utils, "load_workshop_config", lambda: {})
+    monkeypatch.setattr(workshop_utils, "save_workshop_config", lambda cfg: None)
+    monkeypatch.setattr(workshop_utils, "ensure_workshop_folder_exists", lambda folder: True)
+
+    result = await config_files.save_workshop_config_api(
+        {"user_mod_folder": "C:/mods", "auto_create_folder": True}
+    )
+
+    assert result["folder_ready"] is True
+    assert "warning" not in result

--- a/tests/unit/test_workshop_cloudsave_disabled.py
+++ b/tests/unit/test_workshop_cloudsave_disabled.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 
 import pytest
 
@@ -169,14 +170,14 @@ async def test_a_transaction_hands_ensure_its_own_policy(tmp_path, monkeypatch):
     def _save(cfg):
         stored.clear()
         stored.update(cfg)
-        if cfg.get("user_mod_folder") == "B":
+        if str(cfg.get("user_mod_folder", "")).endswith("B"):
             b_saved.set()
 
     def _ensure(folder, **kwargs):
-        if folder == "A":
+        if folder.endswith("A"):
             # 让 B 一定先写完，构造出「重读就会读到别人配置」的时刻。
             b_saved.wait(timeout=1.0)
-        seen.append(f"{folder}:auto={kwargs.get('auto_create')}")
+        seen.append(f"{os.path.basename(folder)}:auto={kwargs.get('auto_create')}")
         return True
 
     monkeypatch.setattr(workshop_utils, "load_workshop_config", _load)
@@ -185,13 +186,13 @@ async def test_a_transaction_hands_ensure_its_own_policy(tmp_path, monkeypatch):
 
     a = asyncio.create_task(
         config_files.save_workshop_config_api(
-            {"user_mod_folder": "A", "auto_create_folder": True}
+            {"user_mod_folder": os.path.join(os.sep, "tmp", "A"), "auto_create_folder": True}
         )
     )
     await asyncio.sleep(0)
     b = asyncio.create_task(
         config_files.save_workshop_config_api(
-            {"user_mod_folder": "B", "auto_create_folder": False}
+            {"user_mod_folder": os.path.join(os.sep, "tmp", "B"), "auto_create_folder": False}
         )
     )
     await asyncio.gather(a, b)
@@ -362,9 +363,9 @@ async def test_a_non_string_folder_value_is_rejected_before_it_is_persisted(monk
 
     assert saved == [], "校验失败的请求不该写盘"
 
-    ok = await config_files.save_workshop_config_api({"user_mod_folder": "C:/mods"})
+    ok = await config_files.save_workshop_config_api({"user_mod_folder": os.path.join(os.sep, "mods")})
     assert ok["success"] is True
-    assert saved and saved[-1]["user_mod_folder"] == "C:/mods"
+    assert saved and saved[-1]["user_mod_folder"] == os.path.join(os.sep, "mods")
 
 
 @pytest.mark.asyncio
@@ -407,3 +408,81 @@ async def test_the_self_healing_write_is_skipped_on_the_event_loop(monkeypatch, 
 
     assert rebased["user_mod_folder"] == "rebased", "调用方仍然要拿到修正后的路径"
     assert cm.saves == [], "在事件循环上不许落盘——那会去抢 worker 可能持着的锁"
+
+
+@pytest.mark.asyncio
+async def test_a_relative_folder_is_rejected(monkeypatch):
+    """A relative path resolves differently in every consumer; refuse it.
+
+    `ensure_workshop_folder_exists` resolves it against the user's home and can
+    report ready, while `get_workshop_path()` hands the raw string to
+    `_assert_under_base`, which resolves it against the server's working
+    directory. Two different places, and we already told the user it was ready.
+    """
+    _stub_config_manager_lock(monkeypatch)
+
+    from main_routers.workshop_router import config_files
+    from utils import workshop_utils
+
+    saved: list[dict] = []
+    monkeypatch.setattr(workshop_utils, "load_workshop_config", lambda: {})
+    monkeypatch.setattr(workshop_utils, "save_workshop_config", lambda cfg: saved.append(cfg))
+    monkeypatch.setattr(workshop_utils, "ensure_workshop_folder_exists", lambda f, **kw: True)
+
+    result = await config_files.save_workshop_config_api({"user_mod_folder": "mods"})
+    assert result["success"] is False
+    assert "绝对路径" in result["error"]
+    assert saved == []
+
+
+@pytest.mark.asyncio
+async def test_a_non_boolean_auto_create_is_rejected(monkeypatch):
+    """`"false"` is a truthy string; taking it at face value creates folders."""
+    _stub_config_manager_lock(monkeypatch)
+
+    from main_routers.workshop_router import config_files
+    from utils import workshop_utils
+
+    saved: list[dict] = []
+    monkeypatch.setattr(workshop_utils, "load_workshop_config", lambda: {})
+    monkeypatch.setattr(workshop_utils, "save_workshop_config", lambda cfg: saved.append(cfg))
+    monkeypatch.setattr(workshop_utils, "ensure_workshop_folder_exists", lambda f, **kw: True)
+
+    result = await config_files.save_workshop_config_api({"auto_create_folder": "false"})
+    assert result["success"] is False
+    assert "布尔" in result["error"]
+    assert saved == []
+
+
+def test_the_save_and_the_folder_creation_share_one_worker_job():
+    """Cancellation must not be able to land between them.
+
+    `asyncio.to_thread` does not stop a worker that already started, but the
+    handler stops at the await — so a second `to_thread` for the directory work
+    would simply never run, leaving an auto-create configuration persisted with
+    its directory missing. Both side effects live in one job.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    from main_routers.workshop_router import config_files
+
+    tree = ast.parse(
+        textwrap.dedent(inspect.getsource(config_files.save_workshop_config_api))
+    )
+    to_thread_calls = [
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "to_thread"
+    ]
+    assert len(to_thread_calls) == 1, (
+        f"保存与建目录必须在同一个 worker job 里，现在有 {len(to_thread_calls)} 次 to_thread"
+    )
+    inner = _fn(tree, "_apply_config_transaction")
+    called = {
+        c.func.id for c in ast.walk(inner)
+        if isinstance(c, ast.Call) and isinstance(c.func, ast.Name)
+    }
+    assert {"save_workshop_config", "ensure_workshop_folder_exists"} <= called

--- a/tests/unit/test_workshop_cloudsave_disabled.py
+++ b/tests/unit/test_workshop_cloudsave_disabled.py
@@ -856,3 +856,38 @@ def test_the_cache_lock_is_created_exactly_once_under_concurrency(tmp_path):
     assert len({id(lock) for lock in seen}) == 1, (
         "并发懒创建造出了多把锁——那这把锁等于不存在"
     )
+
+
+@pytest.mark.asyncio
+async def test_a_path_the_os_cannot_parse_is_rejected_before_saving(monkeypatch):
+    """Validate positively — the value must actually work as a path.
+
+    An embedded NUL passes `isabs` (it only inspects the prefix) but makes
+    every later `os.path.*` raise, and the config is already on disk by then:
+    the endpoint reports failure *after* committing a value that poisons every
+    workshop file operation until the user saves again.
+
+    Checked by asking the OS whether the string is usable rather than by
+    enumerating bad character classes, so the whole class is closed at once.
+    """
+    _stub_config_manager_lock(monkeypatch)
+
+    from main_routers.workshop_router import config_files
+    from utils import workshop_utils
+
+    saved: list[dict] = []
+    monkeypatch.setattr(workshop_utils, "load_workshop_config", lambda: {})
+    monkeypatch.setattr(workshop_utils, "save_workshop_config", lambda cfg: saved.append(cfg))
+    monkeypatch.setattr(workshop_utils, "ensure_workshop_folder_exists", lambda f, **kw: True)
+
+    poisoned = os.path.join(os.sep, "tmp", "workshop\x00x")
+    result = await config_files.save_workshop_config_api({"user_mod_folder": poisoned})
+
+    assert result["success"] is False, "带 NUL 的路径被接受了"
+    assert "不是合法路径" in result["error"]
+    assert saved == [], "校验失败的值不该写盘"
+
+    ok = await config_files.save_workshop_config_api(
+        {"user_mod_folder": os.path.join(os.sep, "tmp", "workshop")}
+    )
+    assert ok["success"] is True

--- a/tests/unit/test_workshop_cloudsave_disabled.py
+++ b/tests/unit/test_workshop_cloudsave_disabled.py
@@ -154,7 +154,7 @@ async def test_concurrent_config_saves_do_not_cross_transactions(tmp_path, monke
         order.append(f"ensure:{folder}:auto={_load().get('auto_create_folder')}")
         return True
 
-    import utils.workshop_utils as workshop_utils
+    from utils import workshop_utils
 
     monkeypatch.setattr(workshop_utils, "load_workshop_config", _load)
     monkeypatch.setattr(workshop_utils, "save_workshop_config", _save)

--- a/tests/unit/test_workshop_cloudsave_disabled.py
+++ b/tests/unit/test_workshop_cloudsave_disabled.py
@@ -244,13 +244,19 @@ async def test_a_created_folder_reports_ready(monkeypatch):
     assert "warning" not in result
 
 
-def test_the_self_healing_read_shares_the_transaction_lock():
-    """`load_workshop_config` is not read-only; it must take the same lock.
+def test_every_read_modify_write_holds_the_config_lock():
+    """No path may load workshop_config.json, change it, and save it unlocked.
 
-    After a storage migration it rebases paths and saves the result. If that
-    write happens outside the lock the POST transaction uses, a concurrent GET
-    can read before the transaction and save after it, silently overwriting
-    the folder settings the user just submitted while POST reports success.
+    Two such paths exist beyond the obvious save: the self-healing rebase
+    inside ``load_workshop_config`` (it writes after a storage migration) and
+    ``persist_user_workshop_folder`` at startup. Either one running unlocked
+    can read before the POST transaction and save after it, silently
+    overwriting the folder settings the user just submitted while POST reports
+    success.
+
+    Checked as "any function calling both load and save must do so inside the
+    lock" rather than by naming the two known offenders — a third one added
+    later has to fail this instead of slipping through.
     """
     import ast
     import inspect
@@ -258,32 +264,47 @@ def test_the_self_healing_read_shares_the_transaction_lock():
 
     from utils.config_manager import workshop as workshop_mixin
 
-    # 方法源码带类体缩进，直接 ast.parse 会 IndentationError。
-    tree = ast.parse(
-        textwrap.dedent(inspect.getsource(workshop_mixin.WorkshopMixin.load_workshop_config))
-    )
-    rebase_calls = [
-        node for node in ast.walk(tree)
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and node.func.attr == "_rebase_workshop_config_after_storage_migration"
-    ]
-    assert rebase_calls, "自愈读的调用点不见了，这条守卫需要跟着更新"
+    tree = ast.parse(textwrap.dedent(inspect.getsource(workshop_mixin.WorkshopMixin)))
 
-    guarded = {
-        call.lineno
-        for node in ast.walk(tree) if isinstance(node, ast.With)
-        for item in node.items
-        if "_workshop_config_lock" in ast.unparse(item.context_expr)
-        for call in ast.walk(node)
-        if isinstance(call, ast.Call)
-        and isinstance(call.func, ast.Attribute)
-        and call.func.attr == "_rebase_workshop_config_after_storage_migration"
-    }
-    unguarded = {call.lineno for call in rebase_calls} - guarded
-    assert not unguarded, (
-        f"这些自愈读没有进 _workshop_config_lock（相对行号 {sorted(unguarded)}）——"
-        "它会写盘，不进锁就能盖掉刚提交的配置"
+    def _calls(node) -> set[str]:
+        return {
+            child.func.attr
+            for child in ast.walk(node)
+            if isinstance(child, ast.Call) and isinstance(child.func, ast.Attribute)
+        }
+
+    WRITERS = {"save_workshop_config", "_rebase_workshop_config_after_storage_migration"}
+    offenders = []
+    for fn in ast.walk(tree):
+        if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if fn.name in {"save_workshop_config", "_rebase_workshop_config_after_storage_migration"}:
+            continue  # 叶子写入本身，由调用方持锁
+        called = _calls(fn)
+        if not (called & WRITERS):
+            continue
+        # 该函数体内所有「写」调用都必须落在某个持 _workshop_config_lock 的 with 里
+        guarded_lines = {
+            call.lineno
+            for node in ast.walk(fn) if isinstance(node, ast.With)
+            for item in node.items
+            if "_workshop_config_lock" in ast.unparse(item.context_expr)
+            for call in ast.walk(node)
+            if isinstance(call, ast.Call) and isinstance(call.func, ast.Attribute)
+            and call.func.attr in WRITERS
+        }
+        all_lines = {
+            call.lineno
+            for call in ast.walk(fn)
+            if isinstance(call, ast.Call) and isinstance(call.func, ast.Attribute)
+            and call.func.attr in WRITERS
+        }
+        if all_lines - guarded_lines:
+            offenders.append(f"{fn.name}(相对行 {sorted(all_lines - guarded_lines)})")
+
+    assert not offenders, (
+        f"这些地方在锁外写 workshop 配置：{offenders} —— "
+        "读改写不整段持锁就能盖掉刚提交的配置"
     )
 
 

--- a/tests/unit/test_workshop_cloudsave_disabled.py
+++ b/tests/unit/test_workshop_cloudsave_disabled.py
@@ -716,3 +716,42 @@ def test_an_in_flight_read_cannot_clobber_the_cache_with_a_stale_snapshot(tmp_pa
     assert cm.load_workshop_config()["user_mod_folder"] == "/new", (
         "在飞的旧读把缓存盖回了保存之前的配置"
     )
+
+
+def test_the_fallback_does_not_mask_a_genuinely_broken_config(tmp_path, monkeypatch):
+    """Only the transient replace-busy error may fall back to the cache.
+
+    Masking every failure means malformed JSON or a revoked permission leaves
+    upload and publish silently working against the previous workshop root
+    forever, instead of surfacing the broken configuration.
+    """
+    from utils.config_manager import workshop as workshop_mixin
+
+    config_path = tmp_path / "workshop_config.json"
+    config_path.write_text(json.dumps({"user_mod_folder": "/good"}), encoding="utf-8")
+
+    class _CM(workshop_mixin.WorkshopMixin):
+        def __init__(self):
+            import threading
+
+            self._workshop_config_lock = threading.RLock()
+            self.workshop_dir = tmp_path / "default"
+
+        def get_workshop_config_path(self):
+            return config_path
+
+        def _rebase_workshop_config_after_storage_migration(self, config):
+            return config
+
+    cm = _CM()
+    assert cm.load_workshop_config()["user_mod_folder"] == "/good"
+
+    monkeypatch.setattr(
+        workshop_mixin, "read_json_tolerating_replace",
+        lambda *a, **kw: (_ for _ in ()).throw(ValueError("malformed json")),
+    )
+    broken = cm.load_workshop_config()
+    assert "user_mod_folder" not in broken, (
+        "配置真坏了却拿缓存盖住了——upload/publish 会一直对着旧根目录干活"
+    )
+    assert broken["default_workshop_folder"] == str(cm.workshop_dir)

--- a/tests/unit/test_workshop_cloudsave_disabled.py
+++ b/tests/unit/test_workshop_cloudsave_disabled.py
@@ -790,3 +790,35 @@ def test_the_cache_compare_and_set_is_atomic():
     assert has_compare and has_assign, (
         "代数比较和缓存赋值必须在同一个 with 里，否则中间可以被一次 save 插入"
     )
+
+
+@pytest.mark.asyncio
+async def test_an_empty_string_clears_the_override(monkeypatch):
+    """`""` is how this merge-style API clears `user_mod_folder`.
+
+    `get_workshop_path()` treats an empty value as "fall through to Steam /
+    cache / default", so rejecting it alongside whitespace leaves users able to
+    set and replace the override but never to clear it without hand-editing
+    the JSON. Whitespace-only stays rejected — that is not a clear, it is a
+    value that would be taken for a real path.
+    """
+    _stub_config_manager_lock(monkeypatch)
+
+    from main_routers.workshop_router import config_files
+    from utils import workshop_utils
+
+    saved: list[dict] = []
+    monkeypatch.setattr(
+        workshop_utils, "load_workshop_config",
+        lambda: {"user_mod_folder": os.path.join(os.sep, "previous")},
+    )
+    monkeypatch.setattr(workshop_utils, "save_workshop_config", lambda cfg: saved.append(cfg))
+    monkeypatch.setattr(workshop_utils, "ensure_workshop_folder_exists", lambda f, **kw: True)
+
+    result = await config_files.save_workshop_config_api({"user_mod_folder": ""})
+
+    assert result["success"] is True, result.get("error")
+    assert saved and saved[-1]["user_mod_folder"] == "", "清除没有落盘"
+
+    blank = await config_files.save_workshop_config_api({"user_mod_folder": "  "})
+    assert blank["success"] is False, "全空白不该被当成清除"

--- a/tests/unit/test_workshop_cloudsave_disabled.py
+++ b/tests/unit/test_workshop_cloudsave_disabled.py
@@ -1,4 +1,5 @@
 import asyncio
+import errno
 import json
 import os
 
@@ -822,6 +823,96 @@ async def test_an_empty_string_clears_the_override(monkeypatch):
 
     blank = await config_files.save_workshop_config_api({"user_mod_folder": "  "})
     assert blank["success"] is False, "全空白不该被当成清除"
+
+
+@pytest.mark.asyncio
+async def test_an_empty_default_folder_is_rejected(monkeypatch):
+    """Only the user override has empty-string clearing semantics."""
+    _stub_config_manager_lock(monkeypatch)
+
+    from main_routers.workshop_router import config_files
+    from utils import workshop_utils
+
+    saved: list[dict] = []
+    monkeypatch.setattr(workshop_utils, "load_workshop_config", lambda: {})
+    monkeypatch.setattr(
+        workshop_utils, "save_workshop_config", lambda cfg: saved.append(cfg)
+    )
+    monkeypatch.setattr(
+        workshop_utils, "ensure_workshop_folder_exists", lambda f, **kw: True
+    )
+
+    result = await config_files.save_workshop_config_api(
+        {"default_workshop_folder": ""}
+    )
+
+    assert result["success"] is False
+    assert "default_workshop_folder" in result["error"]
+    assert saved == []
+
+
+@pytest.mark.asyncio
+async def test_path_format_oserrors_are_rejected_before_saving(monkeypatch):
+    """Format and length failures are not equivalent to a missing directory."""
+    _stub_config_manager_lock(monkeypatch)
+
+    from main_routers.workshop_router import config_files
+    from utils import workshop_utils
+
+    saved: list[dict] = []
+    monkeypatch.setattr(workshop_utils, "load_workshop_config", lambda: {})
+    monkeypatch.setattr(
+        workshop_utils, "save_workshop_config", lambda cfg: saved.append(cfg)
+    )
+    monkeypatch.setattr(
+        workshop_utils, "ensure_workshop_folder_exists", lambda f, **kw: True
+    )
+
+    too_long = OSError("path too long")
+    too_long.errno = errno.ENAMETOOLONG
+
+    def _raise_too_long(_path):
+        raise too_long
+
+    monkeypatch.setattr(config_files.os, "stat", _raise_too_long)
+
+    result = await config_files.save_workshop_config_api(
+        {"user_mod_folder": os.path.join(os.sep, "too-long")}
+    )
+
+    assert result["success"] is False
+    assert "合法路径" in result["error"]
+    assert saved == []
+
+
+@pytest.mark.asyncio
+async def test_an_existing_file_is_rejected_as_a_workshop_folder(
+    monkeypatch, tmp_path,
+):
+    """A path that already names a file can never become a workshop directory."""
+    _stub_config_manager_lock(monkeypatch)
+
+    from main_routers.workshop_router import config_files
+    from utils import workshop_utils
+
+    saved: list[dict] = []
+    path = tmp_path / "not-a-directory"
+    path.write_text("x", encoding="utf-8")
+    monkeypatch.setattr(workshop_utils, "load_workshop_config", lambda: {})
+    monkeypatch.setattr(
+        workshop_utils, "save_workshop_config", lambda cfg: saved.append(cfg)
+    )
+    monkeypatch.setattr(
+        workshop_utils, "ensure_workshop_folder_exists", lambda f, **kw: True
+    )
+
+    result = await config_files.save_workshop_config_api(
+        {"user_mod_folder": str(path)}
+    )
+
+    assert result["success"] is False
+    assert "目录" in result["error"]
+    assert saved == []
 
 
 def test_the_cache_lock_is_created_exactly_once_under_concurrency(tmp_path):

--- a/tests/unit/test_workshop_cloudsave_disabled.py
+++ b/tests/unit/test_workshop_cloudsave_disabled.py
@@ -1037,8 +1037,10 @@ def _make_workshop_cm(tmp_path, config_path):
 class _RecordingLogger:
     """Capture .error() without caplog.
 
-    这个模块的 logger 由项目日志初始化关掉了 propagate，caplog 的 handler 挂在 root
-    上，所以它收不到 —— 单独跑绿、跟整个文件一起跑红。注入替身没有这个顺序依赖。
+    The project's logging setup turns off propagation on this module's logger,
+    and caplog installs its handler on the root, so caplog sees nothing — which
+    shows up as a test that passes alone and fails with the rest of the file.
+    Injecting a stand-in has no such ordering dependency.
     """
 
     def __init__(self):

--- a/tests/unit/test_workshop_cloudsave_disabled.py
+++ b/tests/unit/test_workshop_cloudsave_disabled.py
@@ -120,6 +120,26 @@ def test_the_workshop_config_route_can_import_what_it_uses():
     )
 
 
+def _stub_config_manager_lock(monkeypatch):
+    """Give the transaction a real reentrant lock without booting shared state.
+
+    The route deliberately borrows ConfigManager's own workshop lock — the
+    self-healing write inside load_workshop_config takes the same one — so the
+    test has to supply something lock-shaped rather than bypass it.
+    """
+    import threading
+
+    from main_routers.workshop_router import config_files
+
+    lock = threading.RLock()
+
+    class _CM:
+        def workshop_config_lock(self):
+            return lock
+
+    monkeypatch.setattr(config_files, "get_config_manager", lambda: _CM())
+    return lock
+
 @pytest.mark.asyncio
 async def test_concurrent_config_saves_do_not_cross_transactions(tmp_path, monkeypatch):
     """Two overlapping /config requests must not read each other's half-state.
@@ -130,6 +150,7 @@ async def test_concurrent_config_saves_do_not_cross_transactions(tmp_path, monke
     request B's freshly-saved config and decline to create A's folder while A
     still answers `success`.
     """
+    _stub_config_manager_lock(monkeypatch)
     import threading
 
     from main_routers.workshop_router import config_files
@@ -188,6 +209,7 @@ async def test_a_folder_that_cannot_be_created_is_reported(monkeypatch):
     response has to say the folder is not usable, or the user is told an
     unusable workshop path was set up fine.
     """
+    _stub_config_manager_lock(monkeypatch)
     from main_routers.workshop_router import config_files
     from utils import workshop_utils
 
@@ -206,6 +228,7 @@ async def test_a_folder_that_cannot_be_created_is_reported(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_a_created_folder_reports_ready(monkeypatch):
+    _stub_config_manager_lock(monkeypatch)
     from main_routers.workshop_router import config_files
     from utils import workshop_utils
 
@@ -219,3 +242,58 @@ async def test_a_created_folder_reports_ready(monkeypatch):
 
     assert result["folder_ready"] is True
     assert "warning" not in result
+
+
+def test_the_self_healing_read_shares_the_transaction_lock():
+    """`load_workshop_config` is not read-only; it must take the same lock.
+
+    After a storage migration it rebases paths and saves the result. If that
+    write happens outside the lock the POST transaction uses, a concurrent GET
+    can read before the transaction and save after it, silently overwriting
+    the folder settings the user just submitted while POST reports success.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    from utils.config_manager import workshop as workshop_mixin
+
+    # 方法源码带类体缩进，直接 ast.parse 会 IndentationError。
+    tree = ast.parse(
+        textwrap.dedent(inspect.getsource(workshop_mixin.WorkshopMixin.load_workshop_config))
+    )
+    rebase_calls = [
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "_rebase_workshop_config_after_storage_migration"
+    ]
+    assert rebase_calls, "自愈读的调用点不见了，这条守卫需要跟着更新"
+
+    guarded = {
+        call.lineno
+        for node in ast.walk(tree) if isinstance(node, ast.With)
+        for item in node.items
+        if "_workshop_config_lock" in ast.unparse(item.context_expr)
+        for call in ast.walk(node)
+        if isinstance(call, ast.Call)
+        and isinstance(call.func, ast.Attribute)
+        and call.func.attr == "_rebase_workshop_config_after_storage_migration"
+    }
+    unguarded = {call.lineno for call in rebase_calls} - guarded
+    assert not unguarded, (
+        f"这些自愈读没有进 _workshop_config_lock（相对行号 {sorted(unguarded)}）——"
+        "它会写盘，不进锁就能盖掉刚提交的配置"
+    )
+
+
+def test_the_workshop_config_lock_is_reentrant():
+    """The transaction holds it and then calls load_workshop_config underneath."""
+    import threading
+
+    from utils.config_manager import get_config_manager
+
+    lock = get_config_manager().workshop_config_lock()
+    assert isinstance(lock, type(threading.RLock())), (
+        "必须是 RLock：事务持着它再调 load_workshop_config，不可重入就是自死锁"
+    )

--- a/tests/unit/test_workshop_cloudsave_disabled.py
+++ b/tests/unit/test_workshop_cloudsave_disabled.py
@@ -891,3 +891,34 @@ async def test_a_path_the_os_cannot_parse_is_rejected_before_saving(monkeypatch)
         {"user_mod_folder": os.path.join(os.sep, "tmp", "workshop")}
     )
     assert ok["success"] is True
+
+
+def test_the_path_probe_runs_in_the_worker_not_on_the_loop():
+    """`os.stat` is a real syscall; on a slow UNC share it must not block the loop.
+
+    Detecting an embedded NUL requires going all the way down to a system
+    call — the pure path helpers cannot see it — and that means I/O against
+    whatever the value points at. Keeping it in the coroutine body would stall
+    every other coroutine on an unreachable network or removable path.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    from main_routers.workshop_router import config_files
+
+    tree = ast.parse(
+        textwrap.dedent(inspect.getsource(config_files.save_workshop_config_api))
+    )
+    worker = _fn(tree, "_apply_config_transaction")
+    worker_lines = {n.lineno for n in ast.walk(worker) if hasattr(n, "lineno")}
+    stats = [
+        node.lineno for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "stat"
+    ]
+    assert stats, "路径探针不见了，这条守卫需要跟着更新"
+    outside = [line for line in stats if line not in worker_lines]
+    assert not outside, (
+        f"os.stat 留在了协程体里（相对行 {outside}）——慢速网络盘会把事件循环挂住"
+    )

--- a/tests/unit/test_workshop_cloudsave_disabled.py
+++ b/tests/unit/test_workshop_cloudsave_disabled.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import os
 
 import pytest
@@ -486,3 +487,78 @@ def test_the_save_and_the_folder_creation_share_one_worker_job():
         if isinstance(c, ast.Call) and isinstance(c.func, ast.Name)
     }
     assert {"save_workshop_config", "ensure_workshop_folder_exists"} <= called
+
+
+@pytest.mark.asyncio
+async def test_a_transient_read_failure_falls_back_to_the_last_good_config(tmp_path, monkeypatch):
+    """A Windows sharing violation must not silently swap in the default root.
+
+    Persistence runs in a worker now, so an event-loop read can land mid
+    `os.replace`. The loop is not allowed to back off (that would stall it), so
+    the read raises — and returning defaults there would hand `upload` and
+    `publish` the default workshop root while the user's config is perfectly
+    fine on disk.
+    """
+    from utils.config_manager import workshop as workshop_mixin
+
+    config_path = tmp_path / "workshop_config.json"
+    config_path.write_text(
+        json.dumps({"user_mod_folder": "/user/mods", "auto_create_folder": True}),
+        encoding="utf-8",
+    )
+
+    class _CM(workshop_mixin.WorkshopMixin):
+        def __init__(self):
+            import threading
+
+            self._workshop_config_lock = threading.RLock()
+            self.workshop_dir = tmp_path / "default"
+
+        def get_workshop_config_path(self):
+            return config_path
+
+        def _rebase_workshop_config_after_storage_migration(self, config):
+            return config
+
+    cm = _CM()
+    assert cm.load_workshop_config()["user_mod_folder"] == "/user/mods"
+
+    busy = PermissionError(13, "Access is denied")
+    busy.winerror = 32
+    monkeypatch.setattr(
+        workshop_mixin, "read_json_tolerating_replace",
+        lambda *a, **kw: (_ for _ in ()).throw(busy),
+    )
+
+    fallback = cm.load_workshop_config()
+    assert fallback["user_mod_folder"] == "/user/mods", (
+        "瞬时读失败退回了默认配置——upload/publish 会拿着默认工坊根目录干活"
+    )
+
+
+def test_the_replace_tolerant_read_never_sleeps_on_the_event_loop():
+    """Same rule as the write side: no backoff on the loop, ever."""
+    import ast
+    import inspect
+    import textwrap
+
+    from utils import file_utils
+
+    tree = ast.parse(
+        textwrap.dedent(inspect.getsource(file_utils.read_json_tolerating_replace))
+    )
+    guards = [
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        and node.func.id == "running_on_event_loop"
+    ]
+    sleeps = [
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "sleep"
+    ]
+    assert sleeps, "这条守卫是冲着退避去的，没有 sleep 就该更新它"
+    assert guards, (
+        "读重试没有事件循环守卫 —— get_workshop_path() 这类同步读就挂在 async "
+        "handler 上，会在循环上睡满退避预算"
+    )

--- a/tests/unit/test_workshop_cloudsave_disabled.py
+++ b/tests/unit/test_workshop_cloudsave_disabled.py
@@ -660,3 +660,59 @@ def test_the_missing_config_branch_is_lock_free_on_the_loop():
         "缺配置分支没有事件循环守卫 —— 首次 POST /config 创建文件期间，"
         "循环上的 get_workshop_path() 会卡在写者锁上"
     )
+
+
+def test_an_in_flight_read_cannot_clobber_the_cache_with_a_stale_snapshot(tmp_path, monkeypatch):
+    """A read that started before a save must not cache its pre-save snapshot.
+
+    The read runs outside the lock, so it can begin before `POST /config`
+    commits and return after it. Letting it refresh last-known-good would make
+    a later transient-read fallback hand back the configuration from *before*
+    the change — harder to notice than falling back to defaults.
+    """
+    from utils.config_manager import workshop as workshop_mixin
+
+    config_path = tmp_path / "workshop_config.json"
+    config_path.write_text(json.dumps({"user_mod_folder": "/old"}), encoding="utf-8")
+
+    class _CM(workshop_mixin.WorkshopMixin):
+        def __init__(self):
+            import threading
+
+            self._workshop_config_lock = threading.RLock()
+            self.workshop_dir = tmp_path / "default"
+
+        def get_workshop_config_path(self):
+            return config_path
+
+        def get_runtime_config_path(self, name):
+            return config_path
+
+        def ensure_config_directory(self):
+            return None
+
+        def _rebase_workshop_config_after_storage_migration(self, config):
+            return config
+
+    cm = _CM()
+    monkeypatch.setattr(
+        "utils.cloudsave_runtime.assert_cloudsave_writable", lambda *a, **kw: None
+    )
+
+    # 模拟「读开始 → 中途发生一次 save → 读才回来」：读到的是旧内容。
+    def _slow_read(*args, **kwargs):
+        cm.save_workshop_config({"user_mod_folder": "/new"})
+        return {"user_mod_folder": "/old"}
+
+    monkeypatch.setattr(workshop_mixin, "read_json_tolerating_replace", _slow_read)
+    assert cm.load_workshop_config()["user_mod_folder"] == "/old"
+
+    busy = PermissionError(13, "Access is denied")
+    busy.winerror = 32
+    monkeypatch.setattr(
+        workshop_mixin, "read_json_tolerating_replace",
+        lambda *a, **kw: (_ for _ in ()).throw(busy),
+    )
+    assert cm.load_workshop_config()["user_mod_folder"] == "/new", (
+        "在飞的旧读把缓存盖回了保存之前的配置"
+    )

--- a/tests/unit/test_workshop_cloudsave_disabled.py
+++ b/tests/unit/test_workshop_cloudsave_disabled.py
@@ -96,7 +96,7 @@ def test_workshop_utils_reexports_the_config_saver():
     was swallowed by the handler's `except Exception`, and the endpoint answered
     HTTP 200 with `{"success": false}` while never writing a single byte.
     """
-    import utils.workshop_utils as workshop_utils
+    from utils import workshop_utils
 
     assert hasattr(workshop_utils, "save_workshop_config"), (
         "save_workshop_config 必须能从 utils.workshop_utils 导入 —— "

--- a/tests/unit/test_workshop_content_gate.py
+++ b/tests/unit/test_workshop_content_gate.py
@@ -1,0 +1,174 @@
+# -*- coding: utf-8 -*-
+
+import threading
+
+import pytest
+
+from main_routers.workshop_router.content_gate import (
+    CLEANUP_PURPOSE,
+    PUBLISH_PURPOSE,
+    ContentFolderBusy,
+    claim_content_folder,
+    claim_reference_pair,
+)
+from main_routers.workshop_router import publish
+
+
+def test_exclusive_claim_rejects_another_exclusive_claim(tmp_path):
+    with claim_content_folder(str(tmp_path), purpose=PUBLISH_PURPOSE):
+        with pytest.raises(ContentFolderBusy, match='正在发布'):
+            with claim_content_folder(str(tmp_path), purpose=CLEANUP_PURPOSE):
+                pass
+
+
+def test_exclusive_claim_rejects_reference_writer(tmp_path):
+    with claim_content_folder(str(tmp_path), purpose=PUBLISH_PURPOSE):
+        with pytest.raises(ContentFolderBusy, match='正在发布'):
+            with claim_reference_pair(str(tmp_path)):
+                pass
+
+
+def test_reference_writer_rejects_exclusive_claim(tmp_path):
+    with claim_reference_pair(str(tmp_path)):
+        with pytest.raises(ContentFolderBusy, match='参考语音正在写入'):
+            with claim_content_folder(str(tmp_path), purpose=PUBLISH_PURPOSE):
+                pass
+
+
+def test_reference_writers_remain_shared(tmp_path):
+    with claim_reference_pair(str(tmp_path)):
+        with claim_reference_pair(str(tmp_path)):
+            pass
+
+
+def test_claim_releases_after_exception(tmp_path):
+    with pytest.raises(RuntimeError, match='boom'):
+        with claim_content_folder(str(tmp_path), purpose=PUBLISH_PURPOSE):
+            raise RuntimeError('boom')
+
+    with claim_content_folder(str(tmp_path), purpose=PUBLISH_PURPOSE):
+        pass
+
+
+def test_reference_claim_releases_after_exception(tmp_path):
+    with pytest.raises(RuntimeError, match='boom'):
+        with claim_reference_pair(str(tmp_path)):
+            raise RuntimeError('boom')
+
+    with claim_content_folder(str(tmp_path), purpose=PUBLISH_PURPOSE):
+        pass
+
+
+def test_claim_key_collapses_relative_aliases(tmp_path, monkeypatch):
+    child = tmp_path / 'item'
+    child.mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    with claim_content_folder(str(child), purpose=PUBLISH_PURPOSE):
+        with pytest.raises(ContentFolderBusy):
+            with claim_reference_pair('item'):
+                pass
+
+
+def test_unrelated_folders_do_not_block_each_other(tmp_path):
+    first = tmp_path / 'first'
+    second = tmp_path / 'second'
+    first.mkdir()
+    second.mkdir()
+
+    with claim_content_folder(str(first), purpose=PUBLISH_PURPOSE):
+        with claim_content_folder(str(second), purpose=PUBLISH_PURPOSE):
+            pass
+
+
+def test_concurrent_loser_gets_busy_instead_of_waiting(tmp_path):
+    entered = threading.Event()
+    release = threading.Event()
+
+    def hold_folder():
+        with claim_content_folder(str(tmp_path), purpose=PUBLISH_PURPOSE):
+            entered.set()
+            assert release.wait(timeout=2)
+
+    worker = threading.Thread(target=hold_folder)
+    worker.start()
+    assert entered.wait(timeout=2)
+    try:
+        with pytest.raises(ContentFolderBusy):
+            with claim_reference_pair(str(tmp_path)):
+                pass
+    finally:
+        release.set()
+        worker.join(timeout=2)
+
+    assert not worker.is_alive()
+
+
+def test_publish_holds_the_folder_across_preflight_and_steam_upload(
+    tmp_path, monkeypatch
+):
+    observed = []
+
+    def resolve(folder):
+        observed.append(('preflight', folder))
+        with pytest.raises(ContentFolderBusy):
+            with claim_reference_pair(folder):
+                pass
+        return None
+
+    def upload(*args):
+        folder = args[3]
+        observed.append(('upload', folder))
+        with pytest.raises(ContentFolderBusy):
+            with claim_reference_pair(folder):
+                pass
+        return 123
+
+    monkeypatch.setattr(publish, 'resolve_voice_reference_serialized', resolve)
+    monkeypatch.setattr(publish, '_publish_workshop_item', upload)
+
+    result = publish._preflight_and_publish(
+        object(), 'title', 'description', str(tmp_path), '', 0, [], 'note'
+    )
+
+    assert result == 123
+    assert observed == [
+        ('preflight', str(tmp_path)),
+        ('upload', str(tmp_path)),
+    ]
+    with claim_reference_pair(str(tmp_path)):
+        pass
+
+
+def test_failed_publish_releases_the_folder(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        publish, 'resolve_voice_reference_serialized', lambda _folder: None
+    )
+
+    def fail(*_args):
+        raise RuntimeError('upload failed')
+
+    monkeypatch.setattr(publish, '_publish_workshop_item', fail)
+
+    with pytest.raises(RuntimeError, match='upload failed'):
+        publish._preflight_and_publish(
+            object(), 'title', 'description', str(tmp_path), '', 0, [], 'note'
+        )
+
+    with claim_reference_pair(str(tmp_path)):
+        pass
+
+
+def test_rejected_voice_preflight_releases_the_folder(tmp_path, monkeypatch):
+    def reject(_folder):
+        raise ValueError('bad manifest')
+
+    monkeypatch.setattr(publish, 'resolve_voice_reference_serialized', reject)
+
+    with pytest.raises(publish._VoicePreflightError, match='bad manifest'):
+        publish._preflight_and_publish(
+            object(), 'title', 'description', str(tmp_path), '', 0, [], 'note'
+        )
+
+    with claim_content_folder(str(tmp_path), purpose=PUBLISH_PURPOSE):
+        pass

--- a/tests/unit/test_workshop_content_gate.py
+++ b/tests/unit/test_workshop_content_gate.py
@@ -14,6 +14,11 @@ from main_routers.workshop_router.content_gate import (
 from main_routers.workshop_router import publish
 
 
+def _raise_inside(claim):
+    with claim:
+        raise RuntimeError('boom')
+
+
 def test_exclusive_claim_rejects_another_exclusive_claim(tmp_path):
     with claim_content_folder(str(tmp_path), purpose=PUBLISH_PURPOSE):
         with pytest.raises(ContentFolderBusy, match='正在发布'):
@@ -43,20 +48,20 @@ def test_reference_writers_remain_shared(tmp_path):
 
 def test_claim_releases_after_exception(tmp_path):
     with pytest.raises(RuntimeError, match='boom'):
-        with claim_content_folder(str(tmp_path), purpose=PUBLISH_PURPOSE):
-            raise RuntimeError('boom')
+        _raise_inside(
+            claim_content_folder(str(tmp_path), purpose=PUBLISH_PURPOSE)
+        )
 
-    with claim_content_folder(str(tmp_path), purpose=PUBLISH_PURPOSE):
-        pass
+    with claim_content_folder(str(tmp_path), purpose=PUBLISH_PURPOSE) as token:
+        assert token is None
 
 
 def test_reference_claim_releases_after_exception(tmp_path):
     with pytest.raises(RuntimeError, match='boom'):
-        with claim_reference_pair(str(tmp_path)):
-            raise RuntimeError('boom')
+        _raise_inside(claim_reference_pair(str(tmp_path)))
 
-    with claim_content_folder(str(tmp_path), purpose=PUBLISH_PURPOSE):
-        pass
+    with claim_content_folder(str(tmp_path), purpose=PUBLISH_PURPOSE) as token:
+        assert token is None
 
 
 def test_claim_key_collapses_relative_aliases(tmp_path, monkeypatch):

--- a/tests/unit/test_workshop_voice_refs.py
+++ b/tests/unit/test_workshop_voice_refs.py
@@ -249,7 +249,7 @@ async def test_a_reader_never_observes_a_half_swapped_pair(tmp_path, monkeypatch
     """Publishing resolves the reference while an upload may be mid-swap.
 
     A bare read can land between "old pair deleted" and "new manifest
-    committed" and fail the publish with "参考语音清单无效", even though the
+    committed" and fail the publish as an invalid manifest, even though the
     replacement completes right after. The serialized reader takes the same
     per-folder lock — and it already runs in a worker thread, so no event-loop
     code ever waits on it.

--- a/tests/unit/test_workshop_voice_refs.py
+++ b/tests/unit/test_workshop_voice_refs.py
@@ -584,3 +584,36 @@ def test_nothing_is_deleted_when_no_manifest_claims_anything(tmp_path):
     )
 
     assert (tmp_path / "voice_sample.wav").read_bytes() == b"user-file"
+
+
+def test_a_manifest_pointing_outside_the_folder_deletes_nothing(tmp_path):
+    """`reference_audio` is untrusted input; never delete outside the folder.
+
+    The manifest can arrive from a subscribed item or be hand-edited. An
+    absolute path or `../../x` in `reference_audio` would otherwise make the
+    post-commit cleanup remove a file elsewhere on disk.
+    """
+    from main_routers.workshop_router import voice_refs
+
+    content = tmp_path / "content"
+    content.mkdir()
+    outsider = tmp_path / "precious.wav"
+    outsider.write_bytes(b"not-ours")
+
+    for hostile in ("../precious.wav", str(outsider)):
+        (content / WORKSHOP_VOICE_MANIFEST_NAME).write_text(
+            json.dumps({"version": 1, "reference_audio": hostile, "prefix": "old"}),
+            encoding="utf-8",
+        )
+        assert voice_refs._current_reference_audio_path(str(content)) is None, (
+            f"{hostile!r} 被当成了可删除的目标"
+        )
+
+        voice_refs._replace_voice_reference(
+            str(content),
+            str(content / "voice_sample_bbbbbbbbbbbb.wav"),
+            b"new-audio",
+            str(content / WORKSHOP_VOICE_MANIFEST_NAME),
+            {"version": 1, "reference_audio": "voice_sample_bbbbbbbbbbbb.wav", "prefix": "new"},
+        )
+        assert outsider.read_bytes() == b"not-ours", f"{hostile!r} 让清理删到了目录外面"

--- a/tests/unit/test_workshop_voice_refs.py
+++ b/tests/unit/test_workshop_voice_refs.py
@@ -170,11 +170,20 @@ def test_every_mutation_lives_in_the_offloaded_unit():
     from main_routers.workshop_router import voice_refs
 
     module = ast.parse(inspect.getsource(voice_refs))
-    by_name = {
-        node.name: node
-        for node in module.body
+    definitions = [
+        node for node in module.body
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-    }
+    ]
+    # ⚠️ 先查重名再建字典。按名字建字典会静默留下最后一个定义 —— 一个被遮蔽的重复
+    # 实现就此对本守卫隐形，而 Python 同样只跑后一个：改到前一个副本上的修复完全
+    # 不生效，测试却照绿。这个仓库真出过（见 PR #2598 的评审）。
+    names = [node.name for node in definitions]
+    duplicated = sorted({name for name in names if names.count(name) > 1})
+    assert not duplicated, (
+        f"这些函数被定义了不止一次：{duplicated} —— 后一个静默覆盖前一个，"
+        "改到前面那份上的修复不会生效"
+    )
+    by_name = {node.name: node for node in definitions}
 
     def _called_names(node: ast.AST) -> set[str]:
         names = set()

--- a/tests/unit/test_workshop_voice_refs.py
+++ b/tests/unit/test_workshop_voice_refs.py
@@ -1,0 +1,225 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The reference-audio swap must be all-or-nothing under cancellation.
+
+``upload_reference_audio`` replaces a pair of files: the audio sample and
+the manifest that points at it. A client disconnect cancels the handler,
+and ``CancelledError`` is a ``BaseException`` — the route's ``except
+Exception`` never sees it, so nothing rolls back. Any ``await`` between
+the first and last mutation is therefore a window where the pair can be
+observed half-replaced.
+
+The swap is a single ``asyncio.to_thread`` unit for exactly that reason:
+cancelling the awaiting coroutine does not kill the worker thread, so the
+three steps still run to completion.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import threading
+
+import pytest
+
+from main_routers.workshop_router.voice_manifest import WORKSHOP_VOICE_MANIFEST_NAME
+from main_routers.workshop_router.voice_refs import _replace_voice_reference
+
+pytestmark = pytest.mark.unit
+
+
+def _seed_existing_reference(folder, audio_name: str = "voice_sample.mp3") -> None:
+    (folder / audio_name).write_bytes(b"old-audio")
+    (folder / WORKSHOP_VOICE_MANIFEST_NAME).write_text(
+        json.dumps({"version": 1, "reference_audio": audio_name, "prefix": "old"}),
+        encoding="utf-8",
+    )
+
+
+def _manifest(folder) -> dict:
+    return json.loads((folder / WORKSHOP_VOICE_MANIFEST_NAME).read_text(encoding="utf-8"))
+
+
+def test_the_swap_replaces_both_halves(tmp_path):
+    _seed_existing_reference(tmp_path)
+
+    _replace_voice_reference(
+        str(tmp_path),
+        str(tmp_path / "voice_sample.wav"),
+        b"new-audio",
+        str(tmp_path / WORKSHOP_VOICE_MANIFEST_NAME),
+        {"version": 1, "reference_audio": "voice_sample.wav", "prefix": "new"},
+    )
+
+    assert (tmp_path / "voice_sample.wav").read_bytes() == b"new-audio"
+    assert _manifest(tmp_path)["reference_audio"] == "voice_sample.wav"
+    assert not (tmp_path / "voice_sample.mp3").exists(), (
+        "换扩展名时旧音频必须被清掉，否则留下孤儿文件"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancelling_the_upload_cannot_leave_a_half_replaced_pair(tmp_path):
+    """Cancel the awaiting coroutine mid-swap; the pair must still be whole.
+
+    This is the property the reviewer asked about, asserted directly rather
+    than by inspecting how the handler is written.
+    """
+    _seed_existing_reference(tmp_path)
+    started = asyncio.Event()
+    release = asyncio.Event()
+    loop = asyncio.get_running_loop()
+
+    def _slow_swap(*args):
+        # 让取消**一定**落在 swap 已经开始之后。
+        loop.call_soon_threadsafe(started.set)
+        asyncio.run_coroutine_threadsafe(_wait_release(), loop).result(timeout=5)
+        _replace_voice_reference(*args)
+
+    async def _wait_release() -> None:
+        await release.wait()
+
+    task = asyncio.create_task(
+        asyncio.to_thread(
+            _slow_swap,
+            str(tmp_path),
+            str(tmp_path / "voice_sample.wav"),
+            b"new-audio",
+            str(tmp_path / WORKSHOP_VOICE_MANIFEST_NAME),
+            {"version": 1, "reference_audio": "voice_sample.wav", "prefix": "new"},
+        )
+    )
+    await asyncio.wait_for(started.wait(), timeout=5)
+
+    task.cancel()
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # 等 worker 自己跑完——取消的是等待方，不是线程。
+    deadline = loop.time() + 5.0
+    while loop.time() < deadline and not (tmp_path / "voice_sample.wav").exists():
+        await asyncio.sleep(0.01)
+
+    assert (tmp_path / "voice_sample.wav").read_bytes() == b"new-audio"
+    assert _manifest(tmp_path)["reference_audio"] == "voice_sample.wav", (
+        "manifest 必须跟音频一起换掉——半套状态意味着用户拿到一个指不到文件的引用"
+    )
+    assert not (tmp_path / "voice_sample.mp3").exists()
+
+
+def test_every_mutation_lives_in_the_offloaded_unit():
+    """No mutation may sit in the handler body, where an await can split it.
+
+    The pair is only atomic because all three steps are inside the one
+    synchronous helper. Moving any of them back into the coroutine — even
+    "just the cleanup" — reopens the window, and nothing else would fail.
+    """
+    # 用 AST 而不是文本匹配：注释和 docstring 里出现 "await" / "open(" 这些词
+    # 是常事，按子串判会把散文当代码。
+    import ast
+    import inspect
+
+    from main_routers.workshop_router import voice_refs
+
+    module = ast.parse(inspect.getsource(voice_refs))
+    by_name = {
+        node.name: node
+        for node in module.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+    def _called_names(node: ast.AST) -> set[str]:
+        names = set()
+        for child in ast.walk(node):
+            if isinstance(child, ast.Call):
+                func = child.func
+                if isinstance(func, ast.Name):
+                    names.add(func.id)
+                elif isinstance(func, ast.Attribute):
+                    names.add(func.attr)
+        return names
+
+    MUTATIONS = {"_cleanup_workshop_voice_reference", "open", "atomic_write_json"}
+
+    handler = by_name["upload_reference_audio"]
+    leaked = MUTATIONS & _called_names(handler)
+    assert not leaked, (
+        f"{sorted(leaked)} 回到了协程体里——它和其余两步之间的 await 就是可观测的半套窗口"
+    )
+    assert "to_thread" in _called_names(handler)
+
+    unit = by_name["_replace_voice_reference"]
+    assert isinstance(unit, ast.FunctionDef), "这个单元必须是同步 def"
+    assert MUTATIONS <= _called_names(unit), "三步必须都在这个同步单元里"
+    assert not any(isinstance(n, ast.Await) for n in ast.walk(unit)), (
+        "这个单元里出现 await 就说明它不再是不可分割的"
+    )
+
+
+@pytest.mark.asyncio
+async def test_two_uploads_to_one_folder_never_mix_halves(tmp_path, monkeypatch):
+    """Concurrent swaps must not leave B's audio next to A's manifest.
+
+    Each swap is atomic against the event loop, but two of them run on two
+    worker threads and interleave at the OS level. Before the offload both ran
+    on the loop thread and could not; the per-folder lock restores that.
+
+    The interleaving is forced rather than raced for: the first swap is parked
+    inside its manifest write until the second one has had its chance to run.
+    A version without the lock therefore fails every time instead of once in a
+    hundred runs.
+    """
+    from main_routers.workshop_router import voice_refs
+
+    _seed_existing_reference(tmp_path)
+    audio_path = str(tmp_path / "voice_sample.wav")
+    manifest_path = str(tmp_path / WORKSHOP_VOICE_MANIFEST_NAME)
+
+    at_gate = threading.Event()
+    release = threading.Event()
+    real_write = voice_refs.atomic_write_json
+    first = {"seen": False}
+
+    def _gated_write(*args, **kwargs):
+        if not first["seen"]:
+            first["seen"] = True
+            at_gate.set()
+            release.wait(timeout=5)
+        return real_write(*args, **kwargs)
+
+    monkeypatch.setattr(voice_refs, "atomic_write_json", _gated_write)
+
+    async def _swap(tag: str) -> None:
+        await asyncio.to_thread(
+            voice_refs._replace_voice_reference,
+            str(tmp_path),
+            audio_path,
+            f"audio-{tag}".encode(),
+            manifest_path,
+            {"version": 1, "reference_audio": "voice_sample.wav", "prefix": tag},
+        )
+
+    a = asyncio.create_task(_swap("a"))
+    await asyncio.to_thread(at_gate.wait, 5)   # A 已经卡在写 manifest 里
+    b = asyncio.create_task(_swap("b"))
+    await asyncio.sleep(0.05)                  # 给 B 一个真正插进来的机会
+    release.set()
+    await asyncio.gather(a, b)
+
+    audio = (tmp_path / "voice_sample.wav").read_bytes().decode()
+    prefix = _manifest(tmp_path)["prefix"]
+    assert audio == f"audio-{prefix}", (
+        f"音频来自 {audio}、manifest 来自 {prefix} —— 两半来自不同请求"
+    )

--- a/tests/unit/test_workshop_voice_refs.py
+++ b/tests/unit/test_workshop_voice_refs.py
@@ -38,6 +38,7 @@ import pytest
 from tests.atomic_read import read_text_tolerating_replace
 
 from main_routers.workshop_router.voice_manifest import (
+    WORKSHOP_MANAGED_REFERENCE_AUDIO_KEY,
     WORKSHOP_VOICE_MANIFEST_NAME,
     resolve_voice_reference_serialized,
 )
@@ -63,7 +64,12 @@ def test_voice_refs_has_exactly_one_swap_implementation():
 def _seed_existing_reference(folder, audio_name: str = "voice_sample.mp3") -> None:
     (folder / audio_name).write_bytes(b"old-audio")
     (folder / WORKSHOP_VOICE_MANIFEST_NAME).write_text(
-        json.dumps({"version": 1, "reference_audio": audio_name, "prefix": "old"}),
+        json.dumps({
+            "version": 1,
+            "reference_audio": audio_name,
+            WORKSHOP_MANAGED_REFERENCE_AUDIO_KEY: audio_name,
+            "prefix": "old",
+        }),
         encoding="utf-8",
     )
 
@@ -553,13 +559,13 @@ def test_the_lock_key_resolves_symlinks(tmp_path):
 
 
 def test_only_the_previously_referenced_audio_is_deleted(tmp_path):
-    """Ownership is proven by the manifest, never guessed from the filename.
+    """Ownership needs the private marker, never a guessed filename shape.
 
     A content folder is the user's own publish directory. Matching by name
     shape — even the exact `voice_sample_<12 hex>.<ext>` this feature
     generates — is still probability: a user file that happens to fit the
-    shape gets silently deleted. The one file this module can prove it owns is
-    the one the outgoing manifest pointed at.
+    shape gets silently deleted. The marker is written only when this route
+    commits a generated file and must agree with the live reference.
     """
     from main_routers.workshop_router import voice_refs
 
@@ -571,6 +577,7 @@ def test_only_the_previously_referenced_audio_is_deleted(tmp_path):
         json.dumps({
             "version": 1,
             "reference_audio": "voice_sample_aaaaaaaaaaaa.mp3",
+            WORKSHOP_MANAGED_REFERENCE_AUDIO_KEY: "voice_sample_aaaaaaaaaaaa.mp3",
             "prefix": "old",
         }),
         encoding="utf-8",
@@ -581,7 +588,12 @@ def test_only_the_previously_referenced_audio_is_deleted(tmp_path):
         str(tmp_path / "voice_sample_bbbbbbbbbbbb.wav"),
         b"new-audio",
         str(tmp_path / WORKSHOP_VOICE_MANIFEST_NAME),
-        {"version": 1, "reference_audio": "voice_sample_bbbbbbbbbbbb.wav", "prefix": "new"},
+        {
+            "version": 1,
+            "reference_audio": "voice_sample_bbbbbbbbbbbb.wav",
+            WORKSHOP_MANAGED_REFERENCE_AUDIO_KEY: "voice_sample_bbbbbbbbbbbb.wav",
+            "prefix": "new",
+        },
     )
 
     remaining = sorted(p.name for p in tmp_path.iterdir())
@@ -592,6 +604,64 @@ def test_only_the_previously_referenced_audio_is_deleted(tmp_path):
         "voice_sample_cccccccccccc.wav",
         "voice_sample_theme.mp3",
     ], f"删了不属于自己的文件，或者没删掉上一份引用：{remaining}"
+
+
+def test_an_unmanaged_root_audio_reference_is_never_deleted(tmp_path):
+    """A valid playback reference is not automatically an ownership claim."""
+    from main_routers.workshop_router import voice_refs
+
+    user_audio = tmp_path / "personal_recording.mp3"
+    user_audio.write_bytes(b"user-owned")
+    (tmp_path / WORKSHOP_VOICE_MANIFEST_NAME).write_text(
+        json.dumps({
+            "version": 1,
+            "reference_audio": user_audio.name,
+            "prefix": "imported",
+        }),
+        encoding="utf-8",
+    )
+
+    assert voice_refs._current_reference_audio_path(str(tmp_path)) is None
+
+    new_name = "voice_sample_bbbbbbbbbbbb.wav"
+    voice_refs._replace_voice_reference(
+        str(tmp_path),
+        str(tmp_path / new_name),
+        b"new-audio",
+        str(tmp_path / WORKSHOP_VOICE_MANIFEST_NAME),
+        {
+            "version": 1,
+            "reference_audio": new_name,
+            WORKSHOP_MANAGED_REFERENCE_AUDIO_KEY: new_name,
+            "prefix": "new",
+        },
+    )
+
+    assert user_audio.read_bytes() == b"user-owned"
+
+
+def test_explicit_remove_preserves_audio_without_the_managed_marker(tmp_path):
+    """Removing an imported manifest must detach, not delete, the user asset."""
+    from main_routers.workshop_router.voice_manifest import (
+        _cleanup_workshop_voice_reference,
+    )
+
+    user_audio = tmp_path / "personal_recording.wav"
+    user_audio.write_bytes(b"user-owned")
+    manifest_path = tmp_path / WORKSHOP_VOICE_MANIFEST_NAME
+    manifest_path.write_text(
+        json.dumps({
+            "version": 1,
+            "reference_audio": user_audio.name,
+            "prefix": "imported",
+        }),
+        encoding="utf-8",
+    )
+
+    _cleanup_workshop_voice_reference(str(tmp_path))
+
+    assert user_audio.read_bytes() == b"user-owned"
+    assert not manifest_path.exists()
 
 
 def test_nothing_is_deleted_when_no_manifest_claims_anything(tmp_path):

--- a/tests/unit/test_workshop_voice_refs.py
+++ b/tests/unit/test_workshop_voice_refs.py
@@ -647,3 +647,35 @@ def test_a_manifest_naming_a_non_audio_asset_deletes_nothing(tmp_path):
     assert (tmp_path / "preview.png").read_bytes() == b"user-artwork", (
         "清理把用户的工坊素材删了"
     )
+
+
+def test_a_nested_reference_is_not_treated_as_owned(tmp_path):
+    """This module only ever writes directly into the content folder.
+
+    `assets/theme.mp3` passes containment and the audio-extension check, but a
+    reference with a directory component was never written by us — and
+    `_normalize_workshop_voice_manifest` basenames it anyway, so no normal
+    reader resolves it to the nested file either. Deleting it would remove
+    unrelated user content from a subdirectory.
+    """
+    from main_routers.workshop_router import voice_refs
+
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    (assets / "theme.mp3").write_bytes(b"user-track")
+    (tmp_path / WORKSHOP_VOICE_MANIFEST_NAME).write_text(
+        json.dumps({"version": 1, "reference_audio": "assets/theme.mp3", "prefix": "old"}),
+        encoding="utf-8",
+    )
+
+    assert voice_refs._current_reference_audio_path(str(tmp_path)) is None
+
+    voice_refs._replace_voice_reference(
+        str(tmp_path),
+        str(tmp_path / "voice_sample_bbbbbbbbbbbb.wav"),
+        b"new-audio",
+        str(tmp_path / WORKSHOP_VOICE_MANIFEST_NAME),
+        {"version": 1, "reference_audio": "voice_sample_bbbbbbbbbbbb.wav", "prefix": "new"},
+    )
+
+    assert (assets / "theme.mp3").read_bytes() == b"user-track", "删了子目录里的用户素材"

--- a/tests/unit/test_workshop_voice_refs.py
+++ b/tests/unit/test_workshop_voice_refs.py
@@ -420,9 +420,9 @@ def test_a_failed_manifest_write_never_touches_the_live_pair(tmp_path, monkeypat
     """
     from main_routers.workshop_router import voice_refs
 
-    (tmp_path / "voice_sample_old.wav").write_bytes(b"old-audio")
+    (tmp_path / "voice_sample_aaaaaaaaaaaa.wav").write_bytes(b"old-audio")
     (tmp_path / WORKSHOP_VOICE_MANIFEST_NAME).write_text(
-        json.dumps({"version": 1, "reference_audio": "voice_sample_old.wav", "prefix": "old"}),
+        json.dumps({"version": 1, "reference_audio": "voice_sample_aaaaaaaaaaaa.wav", "prefix": "old"}),
         encoding="utf-8",
     )
 
@@ -434,15 +434,15 @@ def test_a_failed_manifest_write_never_touches_the_live_pair(tmp_path, monkeypat
     with pytest.raises(OSError):
         voice_refs._replace_voice_reference(
             str(tmp_path),
-            str(tmp_path / "voice_sample_new.wav"),
+            str(tmp_path / "voice_sample_bbbbbbbbbbbb.wav"),
             b"new-audio",
             str(tmp_path / WORKSHOP_VOICE_MANIFEST_NAME),
-            {"version": 1, "reference_audio": "voice_sample_new.wav", "prefix": "new"},
+            {"version": 1, "reference_audio": "voice_sample_bbbbbbbbbbbb.wav", "prefix": "new"},
         )
 
-    assert (tmp_path / "voice_sample_old.wav").read_bytes() == b"old-audio"
+    assert (tmp_path / "voice_sample_aaaaaaaaaaaa.wav").read_bytes() == b"old-audio"
     assert _manifest(tmp_path)["prefix"] == "old", "旧 manifest 必须原样还在"
-    assert (tmp_path / "voice_sample_old.wav").exists(), (
+    assert (tmp_path / "voice_sample_aaaaaaaaaaaa.wav").exists(), (
         "提交点之前不许动当前 manifest 指着的那个文件"
     )
 
@@ -451,21 +451,21 @@ def test_a_successful_replace_leaves_no_staging_behind(tmp_path):
     """No temp file may outlive a successful swap."""
     from main_routers.workshop_router import voice_refs
 
-    (tmp_path / "voice_sample_old.wav").write_bytes(b"old-audio")
+    (tmp_path / "voice_sample_aaaaaaaaaaaa.wav").write_bytes(b"old-audio")
     (tmp_path / WORKSHOP_VOICE_MANIFEST_NAME).write_text(
-        json.dumps({"version": 1, "reference_audio": "voice_sample_old.wav", "prefix": "old"}),
+        json.dumps({"version": 1, "reference_audio": "voice_sample_aaaaaaaaaaaa.wav", "prefix": "old"}),
         encoding="utf-8",
     )
 
     voice_refs._replace_voice_reference(
         str(tmp_path),
-        str(tmp_path / "voice_sample_new.wav"),
+        str(tmp_path / "voice_sample_bbbbbbbbbbbb.wav"),
         b"new-audio",
         str(tmp_path / WORKSHOP_VOICE_MANIFEST_NAME),
-        {"version": 1, "reference_audio": "voice_sample_new.wav", "prefix": "new"},
+        {"version": 1, "reference_audio": "voice_sample_bbbbbbbbbbbb.wav", "prefix": "new"},
     )
 
-    assert (tmp_path / "voice_sample_new.wav").read_bytes() == b"new-audio"
+    assert (tmp_path / "voice_sample_bbbbbbbbbbbb.wav").read_bytes() == b"new-audio"
     assert _manifest(tmp_path)["prefix"] == "new"
     leftovers = sorted(p.name for p in tmp_path.iterdir() if ".tmp" in p.name)
     assert leftovers == [], f"成功路径留下了暂存文件：{leftovers}"
@@ -505,23 +505,23 @@ def test_an_orphan_from_an_earlier_failure_is_swept_after_the_commit(tmp_path):
     """A failed upload leaves an unreferenced audio file; the next one clears it."""
     from main_routers.workshop_router import voice_refs
 
-    (tmp_path / "voice_sample_orphan.wav").write_bytes(b"orphan")
-    (tmp_path / "voice_sample_old.mp3").write_bytes(b"old-audio")
+    (tmp_path / "voice_sample_0123456789ab.wav").write_bytes(b"orphan")
+    (tmp_path / "voice_sample_aaaaaaaaaaaa.mp3").write_bytes(b"old-audio")
     (tmp_path / WORKSHOP_VOICE_MANIFEST_NAME).write_text(
-        json.dumps({"version": 1, "reference_audio": "voice_sample_old.mp3", "prefix": "old"}),
+        json.dumps({"version": 1, "reference_audio": "voice_sample_aaaaaaaaaaaa.mp3", "prefix": "old"}),
         encoding="utf-8",
     )
 
     voice_refs._replace_voice_reference(
         str(tmp_path),
-        str(tmp_path / "voice_sample_new.wav"),
+        str(tmp_path / "voice_sample_bbbbbbbbbbbb.wav"),
         b"new-audio",
         str(tmp_path / WORKSHOP_VOICE_MANIFEST_NAME),
-        {"version": 1, "reference_audio": "voice_sample_new.wav", "prefix": "new"},
+        {"version": 1, "reference_audio": "voice_sample_bbbbbbbbbbbb.wav", "prefix": "new"},
     )
 
     remaining = sorted(p.name for p in tmp_path.iterdir())
-    assert remaining == [WORKSHOP_VOICE_MANIFEST_NAME, "voice_sample_new.wav"], (
+    assert remaining == [WORKSHOP_VOICE_MANIFEST_NAME, "voice_sample_bbbbbbbbbbbb.wav"], (
         f"提交后应该只剩新的一对：{remaining}"
     )
 
@@ -546,3 +546,31 @@ def test_the_lock_key_resolves_symlinks(tmp_path):
     assert voice_reference_lock(str(real_dir)) is voice_reference_lock(str(link_dir)), (
         "同一个目录经由 symlink 进来时拿到了两把锁——串行化会静默失效"
     )
+
+
+def test_the_sweep_only_touches_names_this_module_generates(tmp_path):
+    """A content folder is the user's own directory; do not guess ownership.
+
+    The folder can hold an unrelated `voice_sample_demo.mp3` the user put
+    there. Matching by prefix would delete it. The sweep matches the exact
+    shape uploads generate (`voice_sample_<12 hex>.<ext>`) plus the legacy bare
+    `voice_sample.<ext>` — provable ownership, not probability, same rule as
+    the temp-file owner tag in utils/file_utils.py.
+    """
+    from main_routers.workshop_router import voice_refs
+
+    (tmp_path / "voice_sample_demo.mp3").write_bytes(b"user-file")
+    (tmp_path / "voice_sample_notes.wav").write_bytes(b"user-file")
+    (tmp_path / "voice_sample.mp3").write_bytes(b"legacy")
+    (tmp_path / "voice_sample_cccccccccccc.wav").write_bytes(b"generated")
+    keep = tmp_path / "voice_sample_dddddddddddd.wav"
+    keep.write_bytes(b"current")
+
+    voice_refs._sweep_unreferenced_audio(str(tmp_path), keep=str(keep))
+
+    remaining = sorted(p.name for p in tmp_path.iterdir())
+    assert remaining == [
+        "voice_sample_dddddddddddd.wav",
+        "voice_sample_demo.mp3",
+        "voice_sample_notes.wav",
+    ], f"扫过头或者漏扫了：{remaining}"

--- a/tests/unit/test_workshop_voice_refs.py
+++ b/tests/unit/test_workshop_voice_refs.py
@@ -28,12 +28,16 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
 import threading
 
 import pytest
 
-from main_routers.workshop_router.voice_manifest import WORKSHOP_VOICE_MANIFEST_NAME
+from tests.atomic_read import read_text_tolerating_replace
+
+from main_routers.workshop_router.voice_manifest import (
+    WORKSHOP_VOICE_MANIFEST_NAME,
+    resolve_voice_reference_serialized,
+)
 from main_routers.workshop_router.voice_refs import _replace_voice_reference
 
 pytestmark = pytest.mark.unit
@@ -48,7 +52,9 @@ def _seed_existing_reference(folder, audio_name: str = "voice_sample.mp3") -> No
 
 
 def _manifest(folder) -> dict:
-    return json.loads((folder / WORKSHOP_VOICE_MANIFEST_NAME).read_text(encoding="utf-8"))
+    # 走容忍 replace 的读法：Windows 上 atomic_write_json 的 os.replace 与并发
+    # open() 互斥，裸 read_text 会偶发 PermissionError（见 tests/atomic_read.py）。
+    return json.loads(read_text_tolerating_replace(folder / WORKSHOP_VOICE_MANIFEST_NAME))
 
 
 def test_the_swap_replaces_both_halves(tmp_path):
@@ -108,12 +114,25 @@ async def test_cancelling_the_upload_cannot_leave_a_half_replaced_pair(tmp_path)
         await task
 
     # 等 worker 自己跑完——取消的是等待方，不是线程。
+    #
+    # ⚠️ 完成信号必须盯 manifest，不能盯音频：manifest 是 swap 的**最后**一步，
+    # 音频出现时它可能还没写。盯错产物这条用例会在 CI 上间歇红（实测 run
+    # 30570157903 就是这么挂的）——和 PR #2596 修的是同一类错误。
     deadline = loop.time() + 5.0
-    while loop.time() < deadline and not (tmp_path / "voice_sample.wav").exists():
+    swapped = None
+    while loop.time() < deadline:
+        try:
+            candidate = _manifest(tmp_path)
+        except (FileNotFoundError, PermissionError, json.JSONDecodeError):
+            candidate = None
+        if candidate and candidate.get("prefix") == "new":
+            swapped = candidate
+            break
         await asyncio.sleep(0.01)
 
+    assert swapped is not None, "worker 在 5s 内没有把 swap 跑完"
     assert (tmp_path / "voice_sample.wav").read_bytes() == b"new-audio"
-    assert _manifest(tmp_path)["reference_audio"] == "voice_sample.wav", (
+    assert swapped["reference_audio"] == "voice_sample.wav", (
         "manifest 必须跟音频一起换掉——半套状态意味着用户拿到一个指不到文件的引用"
     )
     assert not (tmp_path / "voice_sample.mp3").exists()
@@ -223,3 +242,52 @@ async def test_two_uploads_to_one_folder_never_mix_halves(tmp_path, monkeypatch)
     assert audio == f"audio-{prefix}", (
         f"音频来自 {audio}、manifest 来自 {prefix} —— 两半来自不同请求"
     )
+
+
+@pytest.mark.asyncio
+async def test_a_reader_never_observes_a_half_swapped_pair(tmp_path, monkeypatch):
+    """Publishing resolves the reference while an upload may be mid-swap.
+
+    A bare read can land between "old pair deleted" and "new manifest
+    committed" and fail the publish with "参考语音清单无效", even though the
+    replacement completes right after. The serialized reader takes the same
+    per-folder lock — and it already runs in a worker thread, so no event-loop
+    code ever waits on it.
+    """
+    from main_routers.workshop_router import voice_refs
+
+    _seed_existing_reference(tmp_path)
+    mid_swap = threading.Event()
+    release = threading.Event()
+    real_write = voice_refs.atomic_write_json
+
+    def _park_before_manifest(*args, **kwargs):
+        mid_swap.set()
+        release.wait(timeout=5)
+        return real_write(*args, **kwargs)
+
+    monkeypatch.setattr(voice_refs, "atomic_write_json", _park_before_manifest)
+
+    swap = asyncio.create_task(
+        asyncio.to_thread(
+            voice_refs._replace_voice_reference,
+            str(tmp_path),
+            str(tmp_path / "voice_sample.wav"),
+            b"new-audio",
+            str(tmp_path / WORKSHOP_VOICE_MANIFEST_NAME),
+            {"version": 1, "reference_audio": "voice_sample.wav", "prefix": "new"},
+        )
+    )
+    await asyncio.to_thread(mid_swap.wait, 5)   # 旧的已删、新 manifest 还没写
+
+    reader = asyncio.create_task(
+        asyncio.to_thread(resolve_voice_reference_serialized, str(tmp_path))
+    )
+    await asyncio.sleep(0.05)
+    assert not reader.done(), "读者没被锁挡住，正读在半套状态上"
+
+    release.set()
+    await asyncio.gather(swap, reader)
+    voice_ref = reader.result()
+    assert voice_ref is not None
+    assert voice_ref["manifest"]["prefix"] == "new"

--- a/tests/unit/test_workshop_voice_refs.py
+++ b/tests/unit/test_workshop_voice_refs.py
@@ -406,3 +406,67 @@ def test_a_failed_audio_write_stages_nothing(tmp_path, monkeypatch):
     assert (tmp_path / "voice_sample.mp3").read_bytes() == b"old-audio"
     leftovers = [p.name for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
     assert leftovers == [], f"失败路径留下了暂存文件：{leftovers}"
+
+
+def test_a_same_extension_replace_rolls_back_when_the_manifest_fails(tmp_path, monkeypatch):
+    """New audio must not survive under the old manifest.
+
+    Replacing a .wav with another .wav reuses the filename, so os.replace
+    overwrites the old audio before the manifest is written. If the manifest
+    write then fails, resolution still finds a "valid" pair — new audio wearing
+    the old prefix / language / provider — while the upload answered 500. A
+    silent mismatch is worse than a loud failure, so the previous audio is
+    staged aside and restored.
+    """
+    from main_routers.workshop_router import voice_refs
+
+    (tmp_path / "voice_sample.wav").write_bytes(b"old-audio")
+    (tmp_path / WORKSHOP_VOICE_MANIFEST_NAME).write_text(
+        json.dumps({"version": 1, "reference_audio": "voice_sample.wav", "prefix": "old"}),
+        encoding="utf-8",
+    )
+
+    def _boom(*args, **kwargs):
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(voice_refs, "atomic_write_json", _boom)
+
+    with pytest.raises(OSError):
+        voice_refs._replace_voice_reference(
+            str(tmp_path),
+            str(tmp_path / "voice_sample.wav"),
+            b"new-audio",
+            str(tmp_path / WORKSHOP_VOICE_MANIFEST_NAME),
+            {"version": 1, "reference_audio": "voice_sample.wav", "prefix": "new"},
+        )
+
+    assert (tmp_path / "voice_sample.wav").read_bytes() == b"old-audio", (
+        "新音频留在了旧 manifest 底下——同名替换失败后必须回滚"
+    )
+    assert _manifest(tmp_path)["prefix"] == "old"
+    leftovers = sorted(p.name for p in tmp_path.iterdir() if ".tmp" in p.name)
+    assert leftovers == [], f"失败路径留下了暂存/备份文件：{leftovers}"
+
+
+def test_a_successful_replace_leaves_no_backup_behind(tmp_path):
+    """The staged backup must not outlive a successful swap."""
+    from main_routers.workshop_router import voice_refs
+
+    (tmp_path / "voice_sample.wav").write_bytes(b"old-audio")
+    (tmp_path / WORKSHOP_VOICE_MANIFEST_NAME).write_text(
+        json.dumps({"version": 1, "reference_audio": "voice_sample.wav", "prefix": "old"}),
+        encoding="utf-8",
+    )
+
+    voice_refs._replace_voice_reference(
+        str(tmp_path),
+        str(tmp_path / "voice_sample.wav"),
+        b"new-audio",
+        str(tmp_path / WORKSHOP_VOICE_MANIFEST_NAME),
+        {"version": 1, "reference_audio": "voice_sample.wav", "prefix": "new"},
+    )
+
+    assert (tmp_path / "voice_sample.wav").read_bytes() == b"new-audio"
+    assert _manifest(tmp_path)["prefix"] == "new"
+    leftovers = sorted(p.name for p in tmp_path.iterdir() if ".tmp" in p.name)
+    assert leftovers == [], f"成功路径留下了暂存/备份文件：{leftovers}"

--- a/tests/unit/test_workshop_voice_refs.py
+++ b/tests/unit/test_workshop_voice_refs.py
@@ -470,3 +470,51 @@ def test_a_successful_replace_leaves_no_backup_behind(tmp_path):
     assert _manifest(tmp_path)["prefix"] == "new"
     leftovers = sorted(p.name for p in tmp_path.iterdir() if ".tmp" in p.name)
     assert leftovers == [], f"成功路径留下了暂存/备份文件：{leftovers}"
+
+
+def test_a_failed_rollback_keeps_the_only_copy_of_the_old_audio(tmp_path, monkeypatch, caplog):
+    """If the restore itself fails, the backup is the last copy — keep it.
+
+    Deleting it unconditionally in a finally would turn a recoverable failure
+    into permanent data loss: the rollback rename can fail on Windows when the
+    destination is still held open, and at that moment the .bak file is the
+    only remaining copy of the audio the user uploaded earlier.
+    """
+    from main_routers.workshop_router import voice_refs
+
+    (tmp_path / "voice_sample.wav").write_bytes(b"old-audio")
+    (tmp_path / WORKSHOP_VOICE_MANIFEST_NAME).write_text(
+        json.dumps({"version": 1, "reference_audio": "voice_sample.wav", "prefix": "old"}),
+        encoding="utf-8",
+    )
+
+    real_replace = os.replace
+    calls: list[tuple[str, str]] = []
+
+    def _replace_but_fail_the_restore(src, dst):
+        calls.append((str(src), str(dst)))
+        # 第三次调用是回滚（backup -> audio_path），让它失败。
+        if len(calls) >= 3:
+            raise OSError(13, "Permission denied")
+        return real_replace(src, dst)
+
+    def _boom(*args, **kwargs):
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(os, "replace", _replace_but_fail_the_restore)
+    monkeypatch.setattr(voice_refs, "atomic_write_json", _boom)
+
+    with pytest.raises(OSError):
+        voice_refs._replace_voice_reference(
+            str(tmp_path),
+            str(tmp_path / "voice_sample.wav"),
+            b"new-audio",
+            str(tmp_path / WORKSHOP_VOICE_MANIFEST_NAME),
+            {"version": 1, "reference_audio": "voice_sample.wav", "prefix": "new"},
+        )
+
+    monkeypatch.setattr(os, "replace", real_replace)
+
+    backups = [p for p in tmp_path.iterdir() if p.name.endswith(".bak")]
+    assert len(backups) == 1, "回滚失败后备份被删了——旧音频永久丢失"
+    assert backups[0].read_bytes() == b"old-audio"

--- a/tests/unit/test_workshop_voice_refs.py
+++ b/tests/unit/test_workshop_voice_refs.py
@@ -664,6 +664,116 @@ def test_explicit_remove_preserves_audio_without_the_managed_marker(tmp_path):
     assert not manifest_path.exists()
 
 
+def _seed_legacy_reference(folder, audio_name: str) -> None:
+    """Write the exact manifest shape shipped before the marker existed."""
+    # 改动前 upload 写的是固定名 voice_sample<ext>（见 main 的 voice_refs.py:109），
+    # manifest 里没有 marker。存量用户盘上就是这个样子。
+    (folder / audio_name).write_bytes(b"legacy-audio")
+    (folder / WORKSHOP_VOICE_MANIFEST_NAME).write_text(
+        json.dumps({
+            "version": 1,
+            "reference_audio": audio_name,
+            "prefix": "legacy",
+        }),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize("audio_name", ["voice_sample.wav", "voice_sample.mp3"])
+def test_replacement_still_cleans_up_a_pre_marker_reference(tmp_path, audio_name):
+    """Upgrading an existing install must not orphan the audio it already owns."""
+    # 没有这条兼容，存量用户升级后第一次换参考语音会把旧的 voice_sample.<ext> 永远留在
+    # 内容目录里；publish 是把整个目录交给 SetItemContent 的，它会跟着发出去。
+    from main_routers.workshop_router import voice_refs
+
+    _seed_legacy_reference(tmp_path, audio_name)
+    new_name = "voice_sample_cccccccccccc.wav"
+
+    voice_refs._replace_voice_reference(
+        str(tmp_path),
+        str(tmp_path / new_name),
+        b"new-audio",
+        str(tmp_path / WORKSHOP_VOICE_MANIFEST_NAME),
+        {
+            "version": 1,
+            "reference_audio": new_name,
+            WORKSHOP_MANAGED_REFERENCE_AUDIO_KEY: new_name,
+            "prefix": "new",
+        },
+    )
+
+    assert not (tmp_path / audio_name).exists(), (
+        f"{audio_name} 是改动前本模块自己生成的名字，换参考语音后不该留在目录里"
+    )
+    assert (tmp_path / new_name).read_bytes() == b"new-audio"
+
+
+@pytest.mark.parametrize("audio_name", ["voice_sample.wav", "voice_sample.mp3"])
+def test_explicit_remove_still_deletes_a_pre_marker_reference(tmp_path, audio_name):
+    """Remove must delete the recording an upgraded install already owned."""
+    from main_routers.workshop_router.voice_manifest import (
+        _cleanup_workshop_voice_reference,
+    )
+
+    _seed_legacy_reference(tmp_path, audio_name)
+
+    _cleanup_workshop_voice_reference(str(tmp_path))
+
+    assert not (tmp_path / audio_name).exists(), (
+        "用户点了「移除」，那份录音必须真的从盘上消失，否则它还会被 publish 带出去"
+    )
+    assert not (tmp_path / WORKSHOP_VOICE_MANIFEST_NAME).exists()
+
+
+def test_the_legacy_allowlist_is_exactly_the_two_names_the_old_code_wrote(tmp_path):
+    """The compatibility set is frozen at two literals; it never widens."""
+    # 这条兼容是「保持 main 已有的删除行为」，不是「按名字形状猜所有权」。一旦有人
+    # 把它放宽成前缀/通配（voice_sample*），用户自己放进内容目录的同前缀文件就会被
+    # 静默删掉 —— 那正是 marker 要终结的东西。
+    from main_routers.workshop_router import voice_refs
+
+    for near_miss in ("voice_sample_extra.wav", "voice_sample.WAV.wav", "my_voice_sample.wav"):
+        folder = tmp_path / near_miss.replace(".", "_")
+        folder.mkdir()
+        _seed_legacy_reference(folder, near_miss)
+        assert voice_refs._current_reference_audio_path(str(folder)) is None, (
+            f"{near_miss} 不是旧代码写过的名字，不该被当成本模块托管的文件"
+        )
+
+
+def test_a_mismatched_marker_never_falls_through_to_the_legacy_allowlist(tmp_path):
+    """Carrying a marker proves the manifest is not pre-marker, match or not."""
+    # 存量兼容只赦免「marker 出现之前写的」manifest。带着一个对不上的 marker 又正好
+    # 叫 voice_sample.wav 的，不算存量 —— 否则伪造一个不匹配的 marker 就能重新拿到
+    # 那条无条件删除的老路径。
+    # ⚠️ 两条路径要一起验：_current_reference_audio_path 读的是**生 manifest**，
+    # _cleanup_workshop_voice_reference 拿到的是 _normalize_... 归一化之后的。归一化
+    # 若把对不上的 marker 丢掉，后者就会把这份 manifest 误判成「没有 marker」。
+    from main_routers.workshop_router import voice_refs
+    from main_routers.workshop_router.voice_manifest import (
+        _cleanup_workshop_voice_reference,
+    )
+
+    audio = tmp_path / "voice_sample.wav"
+    audio.write_bytes(b"disputed")
+    (tmp_path / WORKSHOP_VOICE_MANIFEST_NAME).write_text(
+        json.dumps({
+            "version": 1,
+            "reference_audio": audio.name,
+            WORKSHOP_MANAGED_REFERENCE_AUDIO_KEY: "something_else.wav",
+            "prefix": "forged",
+        }),
+        encoding="utf-8",
+    )
+
+    assert voice_refs._current_reference_audio_path(str(tmp_path)) is None
+
+    _cleanup_workshop_voice_reference(str(tmp_path))
+    assert audio.read_bytes() == b"disputed", (
+        "归一化把对不上的 marker 丢掉了，这份 manifest 被误判成 pre-marker"
+    )
+
+
 def test_nothing_is_deleted_when_no_manifest_claims_anything(tmp_path):
     """A folder with no manifest claims nothing; the swap must add, not remove."""
     from main_routers.workshop_router import voice_refs

--- a/tests/unit/test_workshop_voice_refs.py
+++ b/tests/unit/test_workshop_voice_refs.py
@@ -27,9 +27,11 @@ three steps still run to completion.
 from __future__ import annotations
 
 import asyncio
+import ast
 import json
 import os
 import threading
+from pathlib import Path
 
 import pytest
 
@@ -42,6 +44,20 @@ from main_routers.workshop_router.voice_manifest import (
 from main_routers.workshop_router.voice_refs import _replace_voice_reference
 
 pytestmark = pytest.mark.unit
+
+
+def test_voice_refs_has_exactly_one_swap_implementation():
+    """A duplicate definition silently shadows the implementation under review."""
+    from main_routers.workshop_router import voice_refs
+
+    tree = ast.parse(Path(voice_refs.__file__).read_text(encoding="utf-8"))
+    definitions = [
+        node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == "_replace_voice_reference"
+    ]
+    assert len(definitions) == 1
 
 
 def _seed_existing_reference(folder, audio_name: str = "voice_sample.mp3") -> None:

--- a/tests/unit/test_workshop_voice_refs.py
+++ b/tests/unit/test_workshop_voice_refs.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import threading
 
 import pytest
@@ -170,18 +171,23 @@ def test_every_mutation_lives_in_the_offloaded_unit():
                     names.add(func.attr)
         return names
 
-    MUTATIONS = {"_cleanup_workshop_voice_reference", "open", "atomic_write_json"}
+    MUTATIONS = {
+        "_cleanup_workshop_voice_reference", "open", "fdopen", "mkstemp",
+        "atomic_write_json", "replace", "remove",
+    }
 
     handler = by_name["upload_reference_audio"]
     leaked = MUTATIONS & _called_names(handler)
     assert not leaked, (
-        f"{sorted(leaked)} 回到了协程体里——它和其余两步之间的 await 就是可观测的半套窗口"
+        f"{sorted(leaked)} 回到了协程体里——它和其余步骤之间的 await 就是可观测的半套窗口"
     )
     assert "to_thread" in _called_names(handler)
 
     unit = by_name["_replace_voice_reference"]
     assert isinstance(unit, ast.FunctionDef), "这个单元必须是同步 def"
-    assert MUTATIONS <= _called_names(unit), "三步必须都在这个同步单元里"
+    assert {"mkstemp", "replace", "atomic_write_json"} <= _called_names(unit), (
+        "暂存音频 → os.replace 顶上去 → 原子写 manifest，三步必须都在这个同步单元里"
+    )
     assert not any(isinstance(n, ast.Await) for n in ast.walk(unit)), (
         "这个单元里出现 await 就说明它不再是不可分割的"
     )
@@ -341,3 +347,62 @@ def test_every_reader_outside_the_swap_takes_the_lock():
     assert not offenders, (
         f"这些地方绕过了 voice_reference_lock 直接裸读：{offenders}"
     )
+
+
+def test_a_failed_write_leaves_the_previous_pair_intact(tmp_path, monkeypatch):
+    """A failed upload must not destroy the reference the user already had.
+
+    The swap writes the new audio to a staged file and renames it into place
+    before anything is deleted, so a disk-full / permission failure on either
+    write leaves the previous pair exactly as it was. Deleting first — which is
+    what the code did before — turns one failed upload into lost data the user
+    cannot get back.
+    """
+    from main_routers.workshop_router import voice_refs
+
+    _seed_existing_reference(tmp_path)          # voice_sample.mp3 + manifest(prefix=old)
+
+    def _boom(*args, **kwargs):
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(voice_refs, "atomic_write_json", _boom)
+
+    with pytest.raises(OSError):
+        voice_refs._replace_voice_reference(
+            str(tmp_path),
+            str(tmp_path / "voice_sample.wav"),
+            b"new-audio",
+            str(tmp_path / WORKSHOP_VOICE_MANIFEST_NAME),
+            {"version": 1, "reference_audio": "voice_sample.wav", "prefix": "new"},
+        )
+
+    assert (tmp_path / "voice_sample.mp3").read_bytes() == b"old-audio", (
+        "写失败把用户原来的参考语音删掉了"
+    )
+    assert _manifest(tmp_path)["prefix"] == "old", "旧 manifest 也必须还在"
+
+
+def test_a_failed_audio_write_stages_nothing(tmp_path, monkeypatch):
+    """The staged temp file must not survive a failure either."""
+    from main_routers.workshop_router import voice_refs
+
+    _seed_existing_reference(tmp_path)
+    real_replace = os.replace
+
+    def _boom(src, dst):
+        raise OSError(13, "Permission denied")
+
+    monkeypatch.setattr(os, "replace", _boom)
+    with pytest.raises(OSError):
+        voice_refs._replace_voice_reference(
+            str(tmp_path),
+            str(tmp_path / "voice_sample.wav"),
+            b"new-audio",
+            str(tmp_path / WORKSHOP_VOICE_MANIFEST_NAME),
+            {"version": 1, "reference_audio": "voice_sample.wav", "prefix": "new"},
+        )
+    monkeypatch.setattr(os, "replace", real_replace)
+
+    assert (tmp_path / "voice_sample.mp3").read_bytes() == b"old-audio"
+    leftovers = [p.name for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+    assert leftovers == [], f"失败路径留下了暂存文件：{leftovers}"

--- a/tests/unit/test_workshop_voice_refs.py
+++ b/tests/unit/test_workshop_voice_refs.py
@@ -501,29 +501,6 @@ def test_each_upload_gets_its_own_audio_filename(tmp_path):
     )
 
 
-def test_an_orphan_from_an_earlier_failure_is_swept_after_the_commit(tmp_path):
-    """A failed upload leaves an unreferenced audio file; the next one clears it."""
-    from main_routers.workshop_router import voice_refs
-
-    (tmp_path / "voice_sample_0123456789ab.wav").write_bytes(b"orphan")
-    (tmp_path / "voice_sample_aaaaaaaaaaaa.mp3").write_bytes(b"old-audio")
-    (tmp_path / WORKSHOP_VOICE_MANIFEST_NAME).write_text(
-        json.dumps({"version": 1, "reference_audio": "voice_sample_aaaaaaaaaaaa.mp3", "prefix": "old"}),
-        encoding="utf-8",
-    )
-
-    voice_refs._replace_voice_reference(
-        str(tmp_path),
-        str(tmp_path / "voice_sample_bbbbbbbbbbbb.wav"),
-        b"new-audio",
-        str(tmp_path / WORKSHOP_VOICE_MANIFEST_NAME),
-        {"version": 1, "reference_audio": "voice_sample_bbbbbbbbbbbb.wav", "prefix": "new"},
-    )
-
-    remaining = sorted(p.name for p in tmp_path.iterdir())
-    assert remaining == [WORKSHOP_VOICE_MANIFEST_NAME, "voice_sample_bbbbbbbbbbbb.wav"], (
-        f"提交后应该只剩新的一对：{remaining}"
-    )
 
 
 def test_the_lock_key_resolves_symlinks(tmp_path):
@@ -548,29 +525,62 @@ def test_the_lock_key_resolves_symlinks(tmp_path):
     )
 
 
-def test_the_sweep_only_touches_names_this_module_generates(tmp_path):
-    """A content folder is the user's own directory; do not guess ownership.
 
-    The folder can hold an unrelated `voice_sample_demo.mp3` the user put
-    there. Matching by prefix would delete it. The sweep matches the exact
-    shape uploads generate (`voice_sample_<12 hex>.<ext>`) plus the legacy bare
-    `voice_sample.<ext>` — provable ownership, not probability, same rule as
-    the temp-file owner tag in utils/file_utils.py.
+
+def test_only_the_previously_referenced_audio_is_deleted(tmp_path):
+    """Ownership is proven by the manifest, never guessed from the filename.
+
+    A content folder is the user's own publish directory. Matching by name
+    shape — even the exact `voice_sample_<12 hex>.<ext>` this feature
+    generates — is still probability: a user file that happens to fit the
+    shape gets silently deleted. The one file this module can prove it owns is
+    the one the outgoing manifest pointed at.
     """
     from main_routers.workshop_router import voice_refs
 
-    (tmp_path / "voice_sample_demo.mp3").write_bytes(b"user-file")
-    (tmp_path / "voice_sample_notes.wav").write_bytes(b"user-file")
-    (tmp_path / "voice_sample.mp3").write_bytes(b"legacy")
-    (tmp_path / "voice_sample_cccccccccccc.wav").write_bytes(b"generated")
-    keep = tmp_path / "voice_sample_dddddddddddd.wav"
-    keep.write_bytes(b"current")
+    (tmp_path / "voice_sample_aaaaaaaaaaaa.mp3").write_bytes(b"ours-previous")
+    (tmp_path / "voice_sample_cccccccccccc.wav").write_bytes(b"user-file-same-shape")
+    (tmp_path / "voice_sample.mp3").write_bytes(b"user-file-legacy-shape")
+    (tmp_path / "voice_sample_theme.mp3").write_bytes(b"user-file")
+    (tmp_path / WORKSHOP_VOICE_MANIFEST_NAME).write_text(
+        json.dumps({
+            "version": 1,
+            "reference_audio": "voice_sample_aaaaaaaaaaaa.mp3",
+            "prefix": "old",
+        }),
+        encoding="utf-8",
+    )
 
-    voice_refs._sweep_unreferenced_audio(str(tmp_path), keep=str(keep))
+    voice_refs._replace_voice_reference(
+        str(tmp_path),
+        str(tmp_path / "voice_sample_bbbbbbbbbbbb.wav"),
+        b"new-audio",
+        str(tmp_path / WORKSHOP_VOICE_MANIFEST_NAME),
+        {"version": 1, "reference_audio": "voice_sample_bbbbbbbbbbbb.wav", "prefix": "new"},
+    )
 
     remaining = sorted(p.name for p in tmp_path.iterdir())
     assert remaining == [
-        "voice_sample_dddddddddddd.wav",
-        "voice_sample_demo.mp3",
-        "voice_sample_notes.wav",
-    ], f"扫过头或者漏扫了：{remaining}"
+        WORKSHOP_VOICE_MANIFEST_NAME,
+        "voice_sample.mp3",
+        "voice_sample_bbbbbbbbbbbb.wav",
+        "voice_sample_cccccccccccc.wav",
+        "voice_sample_theme.mp3",
+    ], f"删了不属于自己的文件，或者没删掉上一份引用：{remaining}"
+
+
+def test_nothing_is_deleted_when_no_manifest_claims_anything(tmp_path):
+    """A folder with no manifest claims nothing; the swap must add, not remove."""
+    from main_routers.workshop_router import voice_refs
+
+    (tmp_path / "voice_sample.wav").write_bytes(b"user-file")
+
+    voice_refs._replace_voice_reference(
+        str(tmp_path),
+        str(tmp_path / "voice_sample_bbbbbbbbbbbb.wav"),
+        b"new-audio",
+        str(tmp_path / WORKSHOP_VOICE_MANIFEST_NAME),
+        {"version": 1, "reference_audio": "voice_sample_bbbbbbbbbbbb.wav", "prefix": "new"},
+    )
+
+    assert (tmp_path / "voice_sample.wav").read_bytes() == b"user-file"

--- a/tests/unit/test_workshop_voice_refs.py
+++ b/tests/unit/test_workshop_voice_refs.py
@@ -617,3 +617,33 @@ def test_a_manifest_pointing_outside_the_folder_deletes_nothing(tmp_path):
             {"version": 1, "reference_audio": "voice_sample_bbbbbbbbbbbb.wav", "prefix": "new"},
         )
         assert outsider.read_bytes() == b"not-ours", f"{hostile!r} 让清理删到了目录外面"
+
+
+def test_a_manifest_naming_a_non_audio_asset_deletes_nothing(tmp_path):
+    """`reference_audio` must look like reference audio before we own it.
+
+    A hand-edited manifest naming an in-folder asset such as `preview.png`
+    would otherwise make an ordinary upload permanently remove unrelated
+    workshop content from the publish directory.
+    """
+    from main_routers.workshop_router import voice_refs
+
+    (tmp_path / "preview.png").write_bytes(b"user-artwork")
+    (tmp_path / WORKSHOP_VOICE_MANIFEST_NAME).write_text(
+        json.dumps({"version": 1, "reference_audio": "preview.png", "prefix": "old"}),
+        encoding="utf-8",
+    )
+
+    assert voice_refs._current_reference_audio_path(str(tmp_path)) is None
+
+    voice_refs._replace_voice_reference(
+        str(tmp_path),
+        str(tmp_path / "voice_sample_bbbbbbbbbbbb.wav"),
+        b"new-audio",
+        str(tmp_path / WORKSHOP_VOICE_MANIFEST_NAME),
+        {"version": 1, "reference_audio": "voice_sample_bbbbbbbbbbbb.wav", "prefix": "new"},
+    )
+
+    assert (tmp_path / "preview.png").read_bytes() == b"user-artwork", (
+        "清理把用户的工坊素材删了"
+    )

--- a/tests/unit/test_workshop_voice_refs.py
+++ b/tests/unit/test_workshop_voice_refs.py
@@ -408,21 +408,21 @@ def test_a_failed_audio_write_stages_nothing(tmp_path, monkeypatch):
     assert leftovers == [], f"失败路径留下了暂存文件：{leftovers}"
 
 
-def test_a_same_extension_replace_rolls_back_when_the_manifest_fails(tmp_path, monkeypatch):
-    """New audio must not survive under the old manifest.
+def test_a_failed_manifest_write_never_touches_the_live_pair(tmp_path, monkeypatch):
+    """The commit point is the manifest; nothing before it may be destructive.
 
-    Replacing a .wav with another .wav reuses the filename, so os.replace
-    overwrites the old audio before the manifest is written. If the manifest
-    write then fails, resolution still finds a "valid" pair — new audio wearing
-    the old prefix / language / provider — while the upload answered 500. A
-    silent mismatch is worse than a loud failure, so the previous audio is
-    staged aside and restored.
+    The new audio lands under its own filename, so the file the current
+    manifest points at is never overwritten. A failed manifest write therefore
+    leaves the previous pair byte-for-byte intact — the earlier "overwrite then
+    restore from a backup" shape had a window where the pair came from two
+    different uploads, and every rollback path was one more thing that could
+    itself fail.
     """
     from main_routers.workshop_router import voice_refs
 
-    (tmp_path / "voice_sample.wav").write_bytes(b"old-audio")
+    (tmp_path / "voice_sample_old.wav").write_bytes(b"old-audio")
     (tmp_path / WORKSHOP_VOICE_MANIFEST_NAME).write_text(
-        json.dumps({"version": 1, "reference_audio": "voice_sample.wav", "prefix": "old"}),
+        json.dumps({"version": 1, "reference_audio": "voice_sample_old.wav", "prefix": "old"}),
         encoding="utf-8",
     )
 
@@ -434,87 +434,115 @@ def test_a_same_extension_replace_rolls_back_when_the_manifest_fails(tmp_path, m
     with pytest.raises(OSError):
         voice_refs._replace_voice_reference(
             str(tmp_path),
-            str(tmp_path / "voice_sample.wav"),
+            str(tmp_path / "voice_sample_new.wav"),
             b"new-audio",
             str(tmp_path / WORKSHOP_VOICE_MANIFEST_NAME),
-            {"version": 1, "reference_audio": "voice_sample.wav", "prefix": "new"},
+            {"version": 1, "reference_audio": "voice_sample_new.wav", "prefix": "new"},
         )
 
-    assert (tmp_path / "voice_sample.wav").read_bytes() == b"old-audio", (
-        "新音频留在了旧 manifest 底下——同名替换失败后必须回滚"
+    assert (tmp_path / "voice_sample_old.wav").read_bytes() == b"old-audio"
+    assert _manifest(tmp_path)["prefix"] == "old", "旧 manifest 必须原样还在"
+    assert (tmp_path / "voice_sample_old.wav").exists(), (
+        "提交点之前不许动当前 manifest 指着的那个文件"
     )
-    assert _manifest(tmp_path)["prefix"] == "old"
-    leftovers = sorted(p.name for p in tmp_path.iterdir() if ".tmp" in p.name)
-    assert leftovers == [], f"失败路径留下了暂存/备份文件：{leftovers}"
 
 
-def test_a_successful_replace_leaves_no_backup_behind(tmp_path):
-    """The staged backup must not outlive a successful swap."""
+def test_a_successful_replace_leaves_no_staging_behind(tmp_path):
+    """No temp file may outlive a successful swap."""
     from main_routers.workshop_router import voice_refs
 
-    (tmp_path / "voice_sample.wav").write_bytes(b"old-audio")
+    (tmp_path / "voice_sample_old.wav").write_bytes(b"old-audio")
     (tmp_path / WORKSHOP_VOICE_MANIFEST_NAME).write_text(
-        json.dumps({"version": 1, "reference_audio": "voice_sample.wav", "prefix": "old"}),
+        json.dumps({"version": 1, "reference_audio": "voice_sample_old.wav", "prefix": "old"}),
         encoding="utf-8",
     )
 
     voice_refs._replace_voice_reference(
         str(tmp_path),
-        str(tmp_path / "voice_sample.wav"),
+        str(tmp_path / "voice_sample_new.wav"),
         b"new-audio",
         str(tmp_path / WORKSHOP_VOICE_MANIFEST_NAME),
-        {"version": 1, "reference_audio": "voice_sample.wav", "prefix": "new"},
+        {"version": 1, "reference_audio": "voice_sample_new.wav", "prefix": "new"},
     )
 
-    assert (tmp_path / "voice_sample.wav").read_bytes() == b"new-audio"
+    assert (tmp_path / "voice_sample_new.wav").read_bytes() == b"new-audio"
     assert _manifest(tmp_path)["prefix"] == "new"
     leftovers = sorted(p.name for p in tmp_path.iterdir() if ".tmp" in p.name)
-    assert leftovers == [], f"成功路径留下了暂存/备份文件：{leftovers}"
+    assert leftovers == [], f"成功路径留下了暂存文件：{leftovers}"
 
 
-def test_a_failed_rollback_keeps_the_only_copy_of_the_old_audio(tmp_path, monkeypatch, caplog):
-    """If the restore itself fails, the backup is the last copy — keep it.
+def test_each_upload_gets_its_own_audio_filename(tmp_path):
+    """The handler must never reuse the filename the live manifest points at.
 
-    Deleting it unconditionally in a finally would turn a recoverable failure
-    into permanent data loss: the rollback rename can fail on Windows when the
-    destination is still held open, and at that moment the .bak file is the
-    only remaining copy of the audio the user uploaded earlier.
+    That is what makes the manifest write the single commit point: if the new
+    audio could land on the live filename, a failure between the two writes
+    would leave new audio wearing old metadata, and the resolver — which checks
+    only the manifest-named file's existence — would accept the mismatched
+    pair as valid.
     """
+    import ast
+    import inspect
+
     from main_routers.workshop_router import voice_refs
 
-    (tmp_path / "voice_sample.wav").write_bytes(b"old-audio")
+    tree = ast.parse(inspect.getsource(voice_refs.upload_reference_audio))
+    assigned = [
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(t, ast.Name) and t.id == "reference_audio_name"
+            for t in node.targets
+        )
+    ]
+    assert len(assigned) == 1
+    source = ast.unparse(assigned[0].value)
+    assert "uuid" in source, (
+        f"参考音频文件名不再是每次唯一的（{source}）——manifest 写就不再是唯一提交点"
+    )
+
+
+def test_an_orphan_from_an_earlier_failure_is_swept_after_the_commit(tmp_path):
+    """A failed upload leaves an unreferenced audio file; the next one clears it."""
+    from main_routers.workshop_router import voice_refs
+
+    (tmp_path / "voice_sample_orphan.wav").write_bytes(b"orphan")
+    (tmp_path / "voice_sample_old.mp3").write_bytes(b"old-audio")
     (tmp_path / WORKSHOP_VOICE_MANIFEST_NAME).write_text(
-        json.dumps({"version": 1, "reference_audio": "voice_sample.wav", "prefix": "old"}),
+        json.dumps({"version": 1, "reference_audio": "voice_sample_old.mp3", "prefix": "old"}),
         encoding="utf-8",
     )
 
-    real_replace = os.replace
-    calls: list[tuple[str, str]] = []
+    voice_refs._replace_voice_reference(
+        str(tmp_path),
+        str(tmp_path / "voice_sample_new.wav"),
+        b"new-audio",
+        str(tmp_path / WORKSHOP_VOICE_MANIFEST_NAME),
+        {"version": 1, "reference_audio": "voice_sample_new.wav", "prefix": "new"},
+    )
 
-    def _replace_but_fail_the_restore(src, dst):
-        calls.append((str(src), str(dst)))
-        # 第三次调用是回滚（backup -> audio_path），让它失败。
-        if len(calls) >= 3:
-            raise OSError(13, "Permission denied")
-        return real_replace(src, dst)
+    remaining = sorted(p.name for p in tmp_path.iterdir())
+    assert remaining == [WORKSHOP_VOICE_MANIFEST_NAME, "voice_sample_new.wav"], (
+        f"提交后应该只剩新的一对：{remaining}"
+    )
 
-    def _boom(*args, **kwargs):
-        raise OSError(28, "No space left on device")
 
-    monkeypatch.setattr(os, "replace", _replace_but_fail_the_restore)
-    monkeypatch.setattr(voice_refs, "atomic_write_json", _boom)
+def test_the_lock_key_resolves_symlinks(tmp_path):
+    """The same physical directory must map to one lock, however it is reached.
 
-    with pytest.raises(OSError):
-        voice_refs._replace_voice_reference(
-            str(tmp_path),
-            str(tmp_path / "voice_sample.wav"),
-            b"new-audio",
-            str(tmp_path / WORKSHOP_VOICE_MANIFEST_NAME),
-            {"version": 1, "reference_audio": "voice_sample.wav", "prefix": "new"},
-        )
+    `abspath` is purely lexical, so a junction/symlink pointing at the same
+    folder would silently hand out two different locks and the serialization
+    would stop working with no error anywhere.
+    """
+    from main_routers.workshop_router.voice_manifest import voice_reference_lock
 
-    monkeypatch.setattr(os, "replace", real_replace)
+    real_dir = tmp_path / "content"
+    real_dir.mkdir()
+    link_dir = tmp_path / "linked"
+    try:
+        os.symlink(real_dir, link_dir, target_is_directory=True)
+    except (OSError, NotImplementedError, AttributeError) as exc:
+        pytest.skip(f"这个环境不允许建符号链接: {exc}")
 
-    backups = [p for p in tmp_path.iterdir() if p.name.endswith(".bak")]
-    assert len(backups) == 1, "回滚失败后备份被删了——旧音频永久丢失"
-    assert backups[0].read_bytes() == b"old-audio"
+    assert voice_reference_lock(str(real_dir)) is voice_reference_lock(str(link_dir)), (
+        "同一个目录经由 symlink 进来时拿到了两把锁——串行化会静默失效"
+    )

--- a/tests/unit/test_workshop_voice_refs.py
+++ b/tests/unit/test_workshop_voice_refs.py
@@ -291,3 +291,53 @@ async def test_a_reader_never_observes_a_half_swapped_pair(tmp_path, monkeypatch
     voice_ref = reader.result()
     assert voice_ref is not None
     assert voice_ref["manifest"]["prefix"] == "new"
+
+
+def test_every_reader_outside_the_swap_takes_the_lock():
+    """The rule is uniform: readers and writers of a pair share its lock.
+
+    Pinned structurally because the alternative argument — "these particular
+    readers look at Steam's install tree, and uploads only ever write under
+    WorkshopExport, so they cannot collide" — is true today and invisible
+    tomorrow. A reader that quietly switches back to the unlocked helper would
+    otherwise fail nothing.
+
+    The one legitimate unlocked caller is the cleanup reached from inside the
+    swap: threading.Lock is not reentrant, so it must stay unlocked.
+    """
+    import ast
+    import inspect
+
+    from main_routers.workshop_router import ugc, voice_manifest, voice_refs
+
+    allowed_unlocked = {
+        # 在锁内被调用，必须保持不加锁，否则死锁
+        ("voice_manifest", "_cleanup_workshop_voice_reference"),
+        # 串行化包装自己就是那把锁
+        ("voice_manifest", "resolve_voice_reference_serialized"),
+    }
+
+    offenders = []
+    for module in (voice_refs, voice_manifest, ugc):
+        tree = ast.parse(inspect.getsource(module))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            key = (module.__name__.rsplit(".", 1)[-1], node.name)
+            if key in allowed_unlocked:
+                continue
+            for child in ast.walk(node):
+                if not isinstance(child, ast.Call):
+                    continue
+                func = child.func
+                name = (
+                    func.id if isinstance(func, ast.Name)
+                    else func.attr if isinstance(func, ast.Attribute)
+                    else None
+                )
+                if name == "_resolve_workshop_voice_reference":
+                    offenders.append(f"{key[0]}.{node.name}:{child.lineno}")
+
+    assert not offenders, (
+        f"这些地方绕过了 voice_reference_lock 直接裸读：{offenders}"
+    )

--- a/utils/config_manager/storage_roots.py
+++ b/utils/config_manager/storage_roots.py
@@ -172,7 +172,11 @@ class StorageRootsMixin:
         self._user_workshop_folder_persisted = False
         self.chara_dir = self.app_docs_dir / "character_cards"
         self.card_faces_dir = self.app_docs_dir / "card_faces"
-        self._workshop_config_lock = threading.Lock()
+        # RLock 而不是 Lock：workshop 配置的「整段事务」（读→合并→写→建目录，见
+        # main_routers/workshop_router/config_files.py）要持着它再调 load_workshop_config，
+        # 而 load 自己在某些分支也拿这把锁 —— 不可重入就是自死锁。可重入只放宽同线程
+        # 再取，跨线程仍然严格串行，对既有用法没有任何削弱。
+        self._workshop_config_lock = threading.RLock()
 
         self._characters_cache: dict | None = None
         self._characters_cache_mtime: float | None = None

--- a/utils/config_manager/workshop.py
+++ b/utils/config_manager/workshop.py
@@ -268,9 +268,13 @@ class WorkshopMixin:
         if not workshop_path or not os.path.isdir(workshop_path):
             return
         try:
-            config = self.load_workshop_config()
-            config["user_workshop_folder"] = workshop_path
-            self.save_workshop_config(config)
+            # 读—改—写整段持锁：不然启动期这次持久化可以「用户保存配置之前读、之后
+            # 写」，用自己那份陈旧快照把用户刚提交的目录设置整份盖掉。锁是 RLock，
+            # 所以里面的 load_workshop_config 再取一次不会自死锁。
+            with self._workshop_config_lock:
+                config = self.load_workshop_config()
+                config["user_workshop_folder"] = workshop_path
+                self.save_workshop_config(config)
             self._user_workshop_folder_persisted = True
             logger.info(f"已持久化Steam创意工坊路径到配置文件: {workshop_path}")
         except Exception as e:

--- a/utils/config_manager/workshop.py
+++ b/utils/config_manager/workshop.py
@@ -21,7 +21,11 @@ root path resolution.
 import json
 import os
 
-from utils.file_utils import atomic_write_json, running_on_event_loop
+from utils.file_utils import (
+    atomic_write_json,
+    read_json_tolerating_replace,
+    running_on_event_loop,
+)
 
 from ._shared import logger
 
@@ -122,8 +126,7 @@ class WorkshopMixin:
         try:
             if not os.path.exists(config_path):
                 return None
-            with open(config_path, 'r', encoding='utf-8') as f:
-                return json.load(f)
+            return read_json_tolerating_replace(config_path)
         except Exception:
             return None
 
@@ -229,8 +232,11 @@ class WorkshopMixin:
                 # 甚至跨网络盘 makedirs）的锁，就等于把整条循环挂在那儿 —— 同一个锁
                 # 传导陷阱在这个 PR 里已经踩过两次。自愈写的串行化由
                 # _rebase_workshop_config_after_storage_migration 自己在锁内完成。
-                with open(config_path, 'r', encoding='utf-8') as f:
-                    config = json.load(f)
+                # ⚠️ 容忍 os.replace 的读：落盘现在跑在 worker 上，Windows 上并发
+                # open() 会撞到 replace 中间吃 PermissionError。下面那个 except 会把
+                # 它当成「配置读不出来」而退回默认配置 —— 于是 upload / publish 拿着
+                # 默认的工坊根目录去干活，而用户的配置明明好好的。
+                config = read_json_tolerating_replace(config_path)
                 config = self._rebase_workshop_config_after_storage_migration(config)
                 logger.debug(f"成功加载workshop配置: {config}")
                 return config
@@ -238,8 +244,7 @@ class WorkshopMixin:
                 # 配置不存在时直接返回默认值，避免只读查询链路隐式写入配置文件。
                 with self._workshop_config_lock:
                     if os.path.exists(config_path):
-                        with open(config_path, 'r', encoding='utf-8') as f:
-                            config = json.load(f)
+                        config = read_json_tolerating_replace(config_path)
                         config = self._rebase_workshop_config_after_storage_migration(config)
                         logger.debug(f"成功加载workshop配置: {config}")
                         return config

--- a/utils/config_manager/workshop.py
+++ b/utils/config_manager/workshop.py
@@ -180,12 +180,15 @@ class WorkshopMixin:
         now = time.monotonic()
         with self._last_good_workshop_config_lock:
             since = getattr(self, "_workshop_config_fallback_since", None)
+            escalated = getattr(self, "_workshop_config_fallback_escalated", False)
             if since is None:
                 self._workshop_config_fallback_since = now
+                logger.warning("加载workshop配置失败，沿用上一次成功读到的配置: %s", exc)
                 return
-            if getattr(self, "_workshop_config_fallback_escalated", False):
-                return
-            if now - since < _WORKSHOP_CONFIG_FALLBACK_GRACE_S:
+            if escalated or now - since < _WORKSHOP_CONFIG_FALLBACK_GRACE_S:
+                # 这个端点会被反复调用（get_workshop_path 之类）。持续故障下每次都打
+                # 一条 warning 会把日志刷爆，反而埋掉下面那条真正要人看的 ERROR。
+                logger.debug("workshop 配置仍读不出来，继续沿用 last-good: %s", exc)
                 return
             self._workshop_config_fallback_escalated = True
         logger.error(
@@ -374,7 +377,9 @@ class WorkshopMixin:
             busy_code = getattr(e, "winerror", None) in _REPLACE_BUSY_WINERRORS
             last_good = getattr(self, "_last_good_workshop_config", None)
             if busy_code and last_good is not None:
-                logger.warning("加载workshop配置失败，沿用上一次成功读到的配置: %s", e)
+                # 日志分级整个交给它：首次 warning，宽限期内 debug，撑过宽限期 ERROR
+                # 一次，之后回落到 debug。这个端点被反复调用，每次一条 warning 会把
+                # 真正要人看的那条埋掉。
                 self._note_workshop_config_fallback(e)
                 return dict(last_good)
             error_msg = f"加载workshop配置失败: {e}"

--- a/utils/config_manager/workshop.py
+++ b/utils/config_manager/workshop.py
@@ -22,6 +22,7 @@ import json
 import os
 
 from utils.file_utils import (
+    _REPLACE_BUSY_WINERRORS,
     atomic_write_json,
     read_json_tolerating_replace,
     running_on_event_loop,
@@ -292,8 +293,12 @@ class WorkshopMixin:
             # （见 read_json_tolerating_replace），于是这里会收到一个瞬时的
             # PermissionError。直接退回默认配置的话，upload / publish 就拿着默认的
             # 工坊根目录去干活，而用户的配置明明好好的 —— 静默换根目录比报错糟得多。
+            # ⚠️ 只对「瞬时 busy」回落。缓存一旦建立就把**所有**读失败都盖掉的话，
+            # JSON 被改坏、权限被收走这类真故障就永远不会暴露，upload / publish 会
+            # 一直对着旧根目录干活。判据同写入侧：OS 给的 winerror，不是消息猜测。
+            transient = getattr(e, "winerror", None) in _REPLACE_BUSY_WINERRORS
             last_good = getattr(self, "_last_good_workshop_config", None)
-            if last_good is not None:
+            if transient and last_good is not None:
                 logger.warning("加载workshop配置失败，沿用上一次成功读到的配置: %s", e)
                 return dict(last_good)
             error_msg = f"加载workshop配置失败: {e}"

--- a/utils/config_manager/workshop.py
+++ b/utils/config_manager/workshop.py
@@ -239,6 +239,7 @@ class WorkshopMixin:
                 config = read_json_tolerating_replace(config_path)
                 config = self._rebase_workshop_config_after_storage_migration(config)
                 logger.debug(f"成功加载workshop配置: {config}")
+                self._last_good_workshop_config = dict(config)
                 return config
             else:
                 # 配置不存在时直接返回默认值，避免只读查询链路隐式写入配置文件。
@@ -256,6 +257,15 @@ class WorkshopMixin:
                     logger.debug(f"workshop配置不存在，返回默认配置: {default_config}")
                     return default_config
         except Exception as e:
+            # ⚠️ 先看有没有「上一次成功读到的」。落盘现在跑在 worker 上，Windows 上
+            # 事件循环里的一次读可能正撞在 os.replace 中间；而循环上不许退避重试
+            # （见 read_json_tolerating_replace），于是这里会收到一个瞬时的
+            # PermissionError。直接退回默认配置的话，upload / publish 就拿着默认的
+            # 工坊根目录去干活，而用户的配置明明好好的 —— 静默换根目录比报错糟得多。
+            last_good = getattr(self, "_last_good_workshop_config", None)
+            if last_good is not None:
+                logger.warning("加载workshop配置失败，沿用上一次成功读到的配置: %s", e)
+                return dict(last_good)
             error_msg = f"加载workshop配置失败: {e}"
             logger.error(error_msg)
             print(error_msg)

--- a/utils/config_manager/workshop.py
+++ b/utils/config_manager/workshop.py
@@ -243,6 +243,19 @@ class WorkshopMixin:
                 return config
             else:
                 # 配置不存在时直接返回默认值，避免只读查询链路隐式写入配置文件。
+                #
+                # ⚠️ 事件循环上不拿这把锁。首次 POST /config 正在创建这个文件时，
+                # 目标一直不存在、而 worker 持着锁在写 —— 循环上的 get_workshop_path()
+                # 就会卡在这儿。这条分支本来就只是「读不到就给默认值」，不需要互斥。
+                if running_on_event_loop():
+                    if os.path.exists(config_path):
+                        config = read_json_tolerating_replace(config_path)
+                        config = self._rebase_workshop_config_after_storage_migration(config)
+                        return config
+                    return {
+                        "default_workshop_folder": str(self.workshop_dir),
+                        "auto_create_folder": True
+                    }
                 with self._workshop_config_lock:
                     if os.path.exists(config_path):
                         config = read_json_tolerating_replace(config_path)
@@ -293,7 +306,13 @@ class WorkshopMixin:
             
             # 保存配置
             atomic_write_json(config_path, config_data, indent=4, ensure_ascii=False)
-            
+
+            # 写成功之后同步 last-known-good。只在读成功时更新的话，POST /config
+            # 存下新配置后缓存里还是它进来时读到的旧值 —— 之后一次瞬时读失败就会
+            # 回落到**改动之前**的配置，比回落到默认值更难查。
+            if isinstance(config_data, dict):
+                self._last_good_workshop_config = dict(config_data)
+
             logger.info(f"成功保存workshop配置: {config_data}")
         except Exception as e:
             error_msg = f"保存workshop配置失败: {e}"

--- a/utils/config_manager/workshop.py
+++ b/utils/config_manager/workshop.py
@@ -20,6 +20,7 @@ root path resolution.
 """
 import json
 import os
+import threading
 
 from utils.file_utils import (
     _REPLACE_BUSY_WINERRORS,
@@ -131,6 +132,15 @@ class WorkshopMixin:
         except Exception:
             return None
 
+    @property
+    def _last_good_workshop_config_lock(self):
+        """Tiny lock guarding only the cache compare-and-set (never any I/O)."""
+        lock = getattr(self, "_last_good_lock_obj", None)
+        if lock is None:
+            lock = threading.Lock()
+            self._last_good_lock_obj = lock
+        return lock
+
     def _remember_good_workshop_config(self, config, generation) -> None:
         """Cache a successful read, unless a save landed while it was in flight.
 
@@ -141,9 +151,14 @@ class WorkshopMixin:
         """
         if not isinstance(config, dict):
             return
-        if getattr(self, "_workshop_config_generation", 0) != generation:
-            return
-        self._last_good_workshop_config = dict(config)
+        snapshot = dict(config)
+        # 比较和赋值必须是一个原子步：中间被抢占的话，一次 save 可以在这两步之间
+        # 把代数推上去并写好新缓存，然后这条旧读再把它盖回去。这把锁只圈住两行内存
+        # 操作、不含任何 I/O，所以拿它不会有「持锁跨 fsync」那类问题。
+        with self._last_good_workshop_config_lock:
+            if getattr(self, "_workshop_config_generation", 0) != generation:
+                return
+            self._last_good_workshop_config = snapshot
 
     def workshop_config_lock(self):
         """The lock that serializes every read-modify-write of workshop_config.json.
@@ -333,10 +348,12 @@ class WorkshopMixin:
             # 存下新配置后缓存里还是它进来时读到的旧值 —— 之后一次瞬时读失败就会
             # 回落到**改动之前**的配置，比回落到默认值更难查。
             if isinstance(config_data, dict):
-                self._workshop_config_generation = (
-                    getattr(self, "_workshop_config_generation", 0) + 1
-                )
-                self._last_good_workshop_config = dict(config_data)
+                snapshot = dict(config_data)
+                with self._last_good_workshop_config_lock:
+                    self._workshop_config_generation = (
+                        getattr(self, "_workshop_config_generation", 0) + 1
+                    )
+                    self._last_good_workshop_config = snapshot
 
             logger.info(f"成功保存workshop配置: {config_data}")
         except Exception as e:

--- a/utils/config_manager/workshop.py
+++ b/utils/config_manager/workshop.py
@@ -130,6 +130,20 @@ class WorkshopMixin:
         except Exception:
             return None
 
+    def _remember_good_workshop_config(self, config, generation) -> None:
+        """Cache a successful read, unless a save landed while it was in flight.
+
+        The read happens outside the lock, so it can start before a save and
+        return after it. Writing that snapshot into the cache would make a
+        later transient-read fallback hand back the configuration from *before*
+        the change — harder to notice than falling back to defaults.
+        """
+        if not isinstance(config, dict):
+            return
+        if getattr(self, "_workshop_config_generation", 0) != generation:
+            return
+        self._last_good_workshop_config = dict(config)
+
     def workshop_config_lock(self):
         """The lock that serializes every read-modify-write of workshop_config.json.
 
@@ -224,6 +238,9 @@ class WorkshopMixin:
             dict: workshop config data
         """
         config_path = self.get_workshop_config_path()
+        # 读之前先记下代数。这次读是在锁外做的，可能在一次 save 之前就开始了却在它
+        # 之后才回来 —— 那样把结果写进 last-known-good 就是拿旧快照盖掉新配置。
+        generation = getattr(self, "_workshop_config_generation", 0)
         try:
             if os.path.exists(config_path):
                 # ⚠️ 这条读路径**不许拿 _workshop_config_lock**。get_workshop_path()
@@ -239,7 +256,7 @@ class WorkshopMixin:
                 config = read_json_tolerating_replace(config_path)
                 config = self._rebase_workshop_config_after_storage_migration(config)
                 logger.debug(f"成功加载workshop配置: {config}")
-                self._last_good_workshop_config = dict(config)
+                self._remember_good_workshop_config(config, generation)
                 return config
             else:
                 # 配置不存在时直接返回默认值，避免只读查询链路隐式写入配置文件。
@@ -311,6 +328,9 @@ class WorkshopMixin:
             # 存下新配置后缓存里还是它进来时读到的旧值 —— 之后一次瞬时读失败就会
             # 回落到**改动之前**的配置，比回落到默认值更难查。
             if isinstance(config_data, dict):
+                self._workshop_config_generation = (
+                    getattr(self, "_workshop_config_generation", 0) + 1
+                )
                 self._last_good_workshop_config = dict(config_data)
 
             logger.info(f"成功保存workshop配置: {config_data}")

--- a/utils/config_manager/workshop.py
+++ b/utils/config_manager/workshop.py
@@ -116,6 +116,17 @@ class WorkshopMixin:
         for candidate in candidates:
             self._cleanup_invalid_workshop_config_file(candidate)
 
+    def _read_workshop_config_file(self):
+        """Read workshop_config.json as-is, without the self-healing rebase."""
+        config_path = self.get_workshop_config_path()
+        try:
+            if not os.path.exists(config_path):
+                return None
+            with open(config_path, 'r', encoding='utf-8') as f:
+                return json.load(f)
+        except Exception:
+            return None
+
     def workshop_config_lock(self):
         """The lock that serializes every read-modify-write of workshop_config.json.
 
@@ -169,8 +180,25 @@ class WorkshopMixin:
         if rebased_config is config:
             return config
 
+        # 走到这里才需要写盘 —— 也只有这里需要锁。锁内**重读一次**再决定：调用方那份
+        # 快照是在锁外读的，直接写回去就可能把并发事务刚提交的配置整份盖掉（正是
+        # POST /config 与 GET /config 之间那个竞态）。重读之后没得可改就什么都不做。
         try:
-            self.save_workshop_config(rebased_config)
+            with self._workshop_config_lock:
+                fresh = self._read_workshop_config_file()
+                if fresh is None:
+                    return rebased_config
+                rebased_fresh = fresh
+                for source_root in candidate_source_roots:
+                    rebased_fresh = rebase_runtime_bound_workshop_config_paths(
+                        rebased_fresh,
+                        source_root=source_root,
+                        target_root=self.app_docs_dir,
+                    )
+                if rebased_fresh is fresh:
+                    return fresh
+                self.save_workshop_config(rebased_fresh)
+                return rebased_fresh
         except Exception as exc:
             logger.warning("保存迁移后的 workshop 配置路径自愈结果失败: %s", exc)
         return rebased_config
@@ -185,14 +213,15 @@ class WorkshopMixin:
         config_path = self.get_workshop_config_path()
         try:
             if os.path.exists(config_path):
-                # 这条路径**不是只读**：_rebase_workshop_config_after_storage_migration
-                # 在存储迁移之后会把自愈结果 save 回去。不进锁的话，一次并发的
-                # GET /config 可以「事务之前读、事务之后写」，把用户刚提交的目录设置
-                # 用自己那份陈旧快照整份盖掉，而 POST 还报 success。
-                with self._workshop_config_lock:
-                    with open(config_path, 'r', encoding='utf-8') as f:
-                        config = json.load(f)
-                    config = self._rebase_workshop_config_after_storage_migration(config)
+                # ⚠️ 这条读路径**不许拿 _workshop_config_lock**。get_workshop_path()
+                # 走的就是这里，而 voice_refs / publish 等 async handler 在事件循环上
+                # 裸调 get_workshop_path()。让它去抢一把 worker 可能正持着（跨 fsync、
+                # 甚至跨网络盘 makedirs）的锁，就等于把整条循环挂在那儿 —— 同一个锁
+                # 传导陷阱在这个 PR 里已经踩过两次。自愈写的串行化由
+                # _rebase_workshop_config_after_storage_migration 自己在锁内完成。
+                with open(config_path, 'r', encoding='utf-8') as f:
+                    config = json.load(f)
+                config = self._rebase_workshop_config_after_storage_migration(config)
                 logger.debug(f"成功加载workshop配置: {config}")
                 return config
             else:

--- a/utils/config_manager/workshop.py
+++ b/utils/config_manager/workshop.py
@@ -116,6 +116,15 @@ class WorkshopMixin:
         for candidate in candidates:
             self._cleanup_invalid_workshop_config_file(candidate)
 
+    def workshop_config_lock(self):
+        """The lock that serializes every read-modify-write of workshop_config.json.
+
+        Exposed so a caller that needs load → merge → save → side effects to be
+        one transaction can hold it across the whole sequence. Reentrant, so
+        the nested ``load_workshop_config`` inside such a transaction is fine.
+        """
+        return self._workshop_config_lock
+
     def repair_workshop_configs(self):
         """Explicitly repair the workshop config file; runs only when the caller explicitly allows writing to disk."""
         with self._workshop_config_lock:
@@ -176,9 +185,14 @@ class WorkshopMixin:
         config_path = self.get_workshop_config_path()
         try:
             if os.path.exists(config_path):
-                with open(config_path, 'r', encoding='utf-8') as f:
-                    config = json.load(f)
-                config = self._rebase_workshop_config_after_storage_migration(config)
+                # 这条路径**不是只读**：_rebase_workshop_config_after_storage_migration
+                # 在存储迁移之后会把自愈结果 save 回去。不进锁的话，一次并发的
+                # GET /config 可以「事务之前读、事务之后写」，把用户刚提交的目录设置
+                # 用自己那份陈旧快照整份盖掉，而 POST 还报 success。
+                with self._workshop_config_lock:
+                    with open(config_path, 'r', encoding='utf-8') as f:
+                        config = json.load(f)
+                    config = self._rebase_workshop_config_after_storage_migration(config)
                 logger.debug(f"成功加载workshop配置: {config}")
                 return config
             else:

--- a/utils/config_manager/workshop.py
+++ b/utils/config_manager/workshop.py
@@ -31,6 +31,9 @@ from utils.file_utils import (
 
 from ._shared import logger
 
+# 守护上面那把「last-good 缓存微锁」的懒创建，见 _last_good_workshop_config_lock。
+_LAST_GOOD_LOCK_GUARD = threading.Lock()
+
 # Workshop配置相关常量 - 将在ConfigManager实例化时使用self.workshop_dir
 
 
@@ -136,9 +139,15 @@ class WorkshopMixin:
     def _last_good_workshop_config_lock(self):
         """Tiny lock guarding only the cache compare-and-set (never any I/O)."""
         lock = getattr(self, "_last_good_lock_obj", None)
-        if lock is None:
-            lock = threading.Lock()
-            self._last_good_lock_obj = lock
+        if lock is not None:
+            return lock
+        # 懒创建本身也要串行：两个线程同时进来会各造一把锁、各自守着不同的东西，
+        # 那这把锁就等于不存在。用模块级 guard 做双检。
+        with _LAST_GOOD_LOCK_GUARD:
+            lock = getattr(self, "_last_good_lock_obj", None)
+            if lock is None:
+                lock = threading.Lock()
+                self._last_good_lock_obj = lock
         return lock
 
     def _remember_good_workshop_config(self, config, generation) -> None:

--- a/utils/config_manager/workshop.py
+++ b/utils/config_manager/workshop.py
@@ -21,6 +21,7 @@ root path resolution.
 import json
 import os
 import threading
+import time
 
 from utils.file_utils import (
     _REPLACE_BUSY_WINERRORS,
@@ -33,6 +34,10 @@ from ._shared import logger
 
 # 守护上面那把「last-good 缓存微锁」的懒创建，见 _last_good_workshop_config_lock。
 _LAST_GOOD_LOCK_GUARD = threading.Lock()
+
+# 读侧回落「还算瞬时」的上限。读侧重试预算约 155ms，os.replace 的窗口是个位数毫秒；
+# 取 5 秒是它的几十倍，撑过这个时长的 ACCESS_DENIED 就不是那条竞态了。
+_WORKSHOP_CONFIG_FALLBACK_GRACE_S = 5.0
 
 # Workshop配置相关常量 - 将在ConfigManager实例化时使用self.workshop_dir
 
@@ -150,6 +155,46 @@ class WorkshopMixin:
                 self._last_good_lock_obj = lock
         return lock
 
+    def _clear_workshop_config_fallback_streak(self) -> None:
+        """Forget an in-progress fallback streak; the file just read fine."""
+        with self._last_good_workshop_config_lock:
+            self._workshop_config_fallback_since = None
+            self._workshop_config_fallback_escalated = False
+
+    def _note_workshop_config_fallback(self, exc) -> None:
+        """Escalate once when the read-side fallback stops looking transient.
+
+        ``winerror`` 5 is ACCESS_DENIED, which Windows raises both for the
+        millisecond-wide window where ``os.replace`` has the target open and
+        for a permanent revocation (an ACL change, Controlled Folder Access, a
+        path that is now a directory). The code cannot tell those apart, so
+        persistence is the only usable signal: the read-side retry budget is
+        about 155ms, and a replace race clears in single-digit milliseconds,
+        so anything still failing seconds later is not that race.
+
+        The value keeps being served either way — it is the user's real
+        workshop root, and swapping to defaults would silently relocate every
+        upload. What changes is that the failure stops being a debug-level
+        shrug nobody will ever find.
+        """
+        now = time.monotonic()
+        with self._last_good_workshop_config_lock:
+            since = getattr(self, "_workshop_config_fallback_since", None)
+            if since is None:
+                self._workshop_config_fallback_since = now
+                return
+            if getattr(self, "_workshop_config_fallback_escalated", False):
+                return
+            if now - since < _WORKSHOP_CONFIG_FALLBACK_GRACE_S:
+                return
+            self._workshop_config_fallback_escalated = True
+        logger.error(
+            "workshop 配置已连续 %.0f 秒读不出来，仍在沿用上一次成功读到的配置。"
+            "这已经不像 os.replace 的瞬时窗口，请检查 workshop_config.json 的权限"
+            "（ACL / 受控文件夹访问）或它是否被换成了目录: %s",
+            _WORKSHOP_CONFIG_FALLBACK_GRACE_S, exc,
+        )
+
     def _remember_good_workshop_config(self, config, generation) -> None:
         """Cache a successful read, unless a save landed while it was in flight.
 
@@ -161,6 +206,9 @@ class WorkshopMixin:
         if not isinstance(config, dict):
             return
         snapshot = dict(config)
+        # 读成功就把「回落连续时长」清零 —— 即使下面因为代数不符不采纳这份快照，
+        # 文件本身是读得到的，那就不是持续故障。
+        self._clear_workshop_config_fallback_streak()
         # 比较和赋值必须是一个原子步：中间被抢占的话，一次 save 可以在这两步之间
         # 把代数推上去并写好新缓存，然后这条旧读再把它盖回去。这把锁只圈住两行内存
         # 操作、不含任何 I/O，所以拿它不会有「持锁跨 fsync」那类问题。
@@ -318,12 +366,16 @@ class WorkshopMixin:
             # PermissionError。直接退回默认配置的话，upload / publish 就拿着默认的
             # 工坊根目录去干活，而用户的配置明明好好的 —— 静默换根目录比报错糟得多。
             # ⚠️ 只对「瞬时 busy」回落。缓存一旦建立就把**所有**读失败都盖掉的话，
-            # JSON 被改坏、权限被收走这类真故障就永远不会暴露，upload / publish 会
-            # 一直对着旧根目录干活。判据同写入侧：OS 给的 winerror，不是消息猜测。
-            transient = getattr(e, "winerror", None) in _REPLACE_BUSY_WINERRORS
+            # JSON 被改坏这类真故障就永远不会暴露，upload / publish 会一直对着旧根
+            # 目录干活。判据同写入侧：OS 给的 winerror，不是消息猜测。
+            # ⚠️ 但 winerror 5（ACCESS_DENIED）本身是**二义**的：os.replace 的瞬时
+            # 窗口和「权限被永久收走」给的是同一个码，光看码分不开。所以再叠一层按
+            # **持续时长**的判据 —— 见 _note_workshop_config_fallback。
+            busy_code = getattr(e, "winerror", None) in _REPLACE_BUSY_WINERRORS
             last_good = getattr(self, "_last_good_workshop_config", None)
-            if transient and last_good is not None:
+            if busy_code and last_good is not None:
                 logger.warning("加载workshop配置失败，沿用上一次成功读到的配置: %s", e)
+                self._note_workshop_config_fallback(e)
                 return dict(last_good)
             error_msg = f"加载workshop配置失败: {e}"
             logger.error(error_msg)

--- a/utils/config_manager/workshop.py
+++ b/utils/config_manager/workshop.py
@@ -21,7 +21,7 @@ root path resolution.
 import json
 import os
 
-from utils.file_utils import atomic_write_json
+from utils.file_utils import atomic_write_json, running_on_event_loop
 
 from ._shared import logger
 
@@ -180,9 +180,19 @@ class WorkshopMixin:
         if rebased_config is config:
             return config
 
-        # 走到这里才需要写盘 —— 也只有这里需要锁。锁内**重读一次**再决定：调用方那份
-        # 快照是在锁外读的，直接写回去就可能把并发事务刚提交的配置整份盖掉（正是
-        # POST /config 与 GET /config 之间那个竞态）。重读之后没得可改就什么都不做。
+        # ⚠️ 在事件循环上就**不写**，直接把改好的结果返回给调用方。
+        # get_workshop_path() 走的就是这条读路径，而 voice_refs / publish 的 async
+        # handler 在循环上裸调它 —— 去抢一把 worker 可能正持着（跨 fsync）的锁，就是
+        # 把整条循环挂在那儿。自愈只是把盘上的路径修正过来，晚一点写没有任何损失：
+        # 下一次跑在 worker 线程上的读（GET /config 走 to_thread、POST 事务、启动期
+        # 的 persist）就会落地。这一趟的调用方拿到的路径已经是对的。
+        if running_on_event_loop():
+            logger.debug("在事件循环上，跳过 workshop 配置路径自愈的落盘，留给下一次线程内读取")
+            return rebased_config
+
+        # 只有这里需要锁。锁内**重读一次**再决定：调用方那份快照是在锁外读的，直接
+        # 写回去就可能把并发事务刚提交的配置整份盖掉（正是 POST /config 与
+        # GET /config 之间那个竞态）。重读之后没得可改就什么都不做。
         try:
             with self._workshop_config_lock:
                 fresh = self._read_workshop_config_file()

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -700,6 +700,32 @@ def atomic_write_json(
     atomic_write_text(path, content, encoding=encoding)
 
 
+def read_json_tolerating_replace(
+    path: str | os.PathLike[str],
+    *,
+    encoding: str = "utf-8",
+) -> Any:
+    """``read_json`` that rides out a concurrent ``os.replace`` on Windows.
+
+    The write side already backs off when the target is busy; this is the same
+    window seen from the reader. Without it a caller that swallows exceptions
+    turns a transient sharing violation into "the file is unreadable" and falls
+    back to defaults, which is far worse than waiting a few milliseconds.
+
+    Only the Windows "target is busy" codes are retried, the budget is the same
+    bounded one as the write side, and the final attempt re-raises the real
+    error rather than a wrapped one.
+    """
+    for delay in _REPLACE_RETRY_BACKOFF_S:
+        try:
+            return read_json(path, encoding=encoding)
+        except OSError as exc:
+            if getattr(exc, "winerror", None) not in _REPLACE_BUSY_WINERRORS:
+                raise
+        time.sleep(delay)
+    return read_json(path, encoding=encoding)
+
+
 def read_json(path: str | os.PathLike[str], *, encoding: str = "utf-8") -> Any:
     with open(path, "r", encoding=encoding) as f:
         return json.load(f)

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -722,6 +722,12 @@ def read_json_tolerating_replace(
         except OSError as exc:
             if getattr(exc, "winerror", None) not in _REPLACE_BUSY_WINERRORS:
                 raise
+            # 与写入侧同一条铁律：绝不在事件循环上 sleep。读路径尤其容易踩 ——
+            # get_workshop_path() 这类同步读就挂在 async handler 上。上环调用者
+            # 拿到的是「第一次就抛」，由调用方决定怎么降级（见
+            # ConfigManager.load_workshop_config 的 last-known-good 回落）。
+            if running_on_event_loop():
+                raise
         time.sleep(delay)
     return read_json(path, encoding=encoding)
 

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -621,7 +621,7 @@ _REPLACE_BUSY_WINERRORS = frozenset({5, 32})
 _REPLACE_RETRY_BACKOFF_S = (0.005, 0.01, 0.02, 0.04, 0.08)
 
 
-def _running_on_event_loop() -> bool:
+def running_on_event_loop() -> bool:
     """Whether this thread is currently inside a running asyncio event loop."""
     try:
         asyncio.get_running_loop()
@@ -641,7 +641,7 @@ def _replace_with_busy_retry(temp_path: str, target_path: Path) -> None:
                 raise
             # 只在真的撞上 busy 之后才问「我是不是在循环上」：happy path 一条
             # 指令都不多。
-            if _running_on_event_loop():
+            if running_on_event_loop():
                 raise
         time.sleep(delay)
     os.replace(temp_path, target_path)

--- a/utils/workshop_utils.py
+++ b/utils/workshop_utils.py
@@ -33,6 +33,7 @@ logger = get_module_logger(__name__)
 # 从config_manager导入workshop配置相关功能
 from utils.config_manager import (
     load_workshop_config,
+    save_workshop_config,
     save_workshop_path,
     persist_user_workshop_folder,
     get_workshop_path

--- a/utils/workshop_utils.py
+++ b/utils/workshop_utils.py
@@ -73,8 +73,11 @@ def ensure_workshop_folder_exists(
     
     logger.info(f'ensure_workshop_folder_exists - 最终处理的目标文件夹: {target_folder}')
     
-    # 如果文件夹存在，直接返回True
-    if os.path.exists(target_folder):
+    # isdir 而不是 exists：路径指向一个**普通文件**时 exists 也为真，于是这里报
+    # 「目录已就绪」，配置把那个文件存成了工坊根目录，后面凡是往它上面拼
+    # WorkshopExport 的调用全部失败。指着文件就当没就绪 —— 下面 makedirs 会抛
+    # FileExistsError，被 except 收成 False，正是想要的结论。
+    if os.path.isdir(target_folder):
         return True
     
     # 如果文件夹不存在，检查是否允许自动创建

--- a/utils/workshop_utils.py
+++ b/utils/workshop_utils.py
@@ -21,6 +21,7 @@ All configured paths come uniformly from config_manager
 Dependency hierarchy: utils layer -> config layer (one-way; no dependency on the main layer)
 """
 
+import asyncio
 import os
 import pathlib
 from typing import Optional, List, Dict, Any
@@ -38,6 +39,12 @@ from utils.config_manager import (
     persist_user_workshop_folder,
     get_workshop_path
 )
+
+
+async def get_workshop_path_async() -> str:
+    """Resolve the configured workshop root without blocking the event loop."""
+    return await asyncio.to_thread(get_workshop_path)
+
 
 def ensure_workshop_folder_exists(
     folder_path: Optional[str] = None,
@@ -178,6 +185,13 @@ def get_workshop_root(subscribed_items: Optional[List[Dict[str, Any]]] = None) -
     # 确保路径存在
     ensure_workshop_folder_exists(workshop_path)
     return workshop_path
+
+
+async def get_workshop_root_async(
+    subscribed_items: Optional[List[Dict[str, Any]]] = None,
+) -> str:
+    """Resolve and persist the workshop root without blocking the event loop."""
+    return await asyncio.to_thread(get_workshop_root, subscribed_items)
 
 
 def get_default_workshop_folder() -> Optional[str]:

--- a/utils/workshop_utils.py
+++ b/utils/workshop_utils.py
@@ -39,7 +39,11 @@ from utils.config_manager import (
     get_workshop_path
 )
 
-def ensure_workshop_folder_exists(folder_path: Optional[str] = None) -> bool:
+def ensure_workshop_folder_exists(
+    folder_path: Optional[str] = None,
+    *,
+    auto_create: Optional[bool] = None,
+) -> bool:
     """
     Ensure the local mod folder (formerly the Workshop folder) exists, creating it if missing
     
@@ -49,8 +53,10 @@ def ensure_workshop_folder_exists(folder_path: Optional[str] = None) -> bool:
     Returns:
         bool: whether the folder exists or was created successfully
     """
-    # 确定目标文件夹路径
-    config = load_workshop_config()
+    # auto_create 由调用方给定时**不重读配置**：读改写事务里，重读会看到并发事务刚写
+    # 的那份，从而对着别人的策略做决定（Codex P2）；而且把这次重读留在事务的锁里会
+    # 让事件循环上的 get_workshop_path() 跟着一起等（同一个锁传导陷阱）。
+    config = {} if auto_create is not None else load_workshop_config()
     # 使用get_workshop_path()函数获取路径，该函数已更新为优先使用user_mod_folder
     raw_folder = folder_path or get_workshop_path()
     
@@ -72,7 +78,8 @@ def ensure_workshop_folder_exists(folder_path: Optional[str] = None) -> bool:
         return True
     
     # 如果文件夹不存在，检查是否允许自动创建
-    auto_create = config.get("auto_create_folder", True)
+    if auto_create is None:
+        auto_create = config.get("auto_create_folder", True)
     
     # 如果不允许自动创建，明确返回False
     if not auto_create:


### PR DESCRIPTION
## 改动概述 / Summary

#2596 的后续。那个 PR 在 `atomic_write_text` 里加退避时，为了不在事件循环上 sleep 加了 `_running_on_event_loop()` 守卫，并在正文里点名了「全仓库有一批地方在 `async def` 里裸调同步 `atomic_write_*`」这个**先于那个 PR 存在**的问题。这个 PR 收口它，并给这一类加 CI 守卫。

`atomic_write_text` 在调用线程上串着 `mkdir` → 崩后残留 tmp 的整目录 `os.scandir` + 逐项 stat → `mkstemp` → `write` → **无上界的 `os.fsync`**。放在事件循环上就是拿一次物理刷盘的时间堵住所有别的协程 —— 包括语音会话的音频协程。异步孪生 `atomic_write_json_async` / `atomic_write_text_async` 早就存在（`asyncio.to_thread` 包一层），非测试代码里已有 **77 处**在用；缺的从来不是异步安全层，是调用点纪律。

---

### 一、守卫：`scripts/check_async_blocking.py`

- `atomic_write_text` / `atomic_write_json` 进 `RISKY_BARE_CALLS`。名字够独特，直接调用和经一层同步 helper 的调用都能抓到。
- **新增 `GENERIC_HELPER_NAMES` 去噪。** 索引是按**名字**匹配的（pass 1 记下「某个同步 def 体内有阻塞调用」，pass 2 在 async def 里看到同名调用就报）。名字够独特时很准，是通用动词时全是噪声 —— 实测加上 `atomic_write_*` 之后，一个叫 `save` 的 helper 让 `img.save(png_path)`（PIL）和 `TokenTracker.get_instance().save()` 全部中招，而它们跟那个 helper 毫无关系。

  | | 报告数 | 假阳性 |
  |---|---|---|
  | 只加 `atomic_write_*` | 19 | 5（PIL ×2、TokenTracker ×3） |
  | 加上去噪之后 | 13 | **0** |

  这跟本文件对 queue/thread/socket 接收者尾名的既有取舍是同一条原则（文件自己的话：名字太泛的「noise is not worth the signal」）。代价是漏掉真的叫 `save` 的阻塞 helper。

- 同一个调用点只报一次：`atomic_write_json` 既是已知阻塞调用、本身又是一个体内含 `atomic_write_text` 的同步 def，直接规则和 depth-1 传递规则会双双命中。

### 二、收口的调用点（12 处）

| 文件 | 处数 | 说明 |
|---|---|---|
| `main_routers/system_router/prompt_flows.py` | 6 | 4 个 POST（含被前端轮询的 `/autostart-prompt/heartbeat`）+ 2 个 GET |
| `main_routers/workshop_router/` | 8 | 上传（含一处几 MB 的裸 `open().write()`）、remove、config 事务、3 个读点 |

**workshop 的 voice reference 遵循一条统一规则：读写这对文件（音频 + manifest）的都拿同一把 per-folder 锁。**

写侧收成一个 `to_thread` 单元（删旧 → 写音频 → 写 manifest），唯一的取消点落在任何写盘之前 —— 线程一旦启动，取消等待方不会杀掉它，所以中间态不可达。**比 HEAD 更严格**：HEAD 上「旧的删了、新的没写」本来就可达（`await file.read()` 夹在中间）。

读侧全部走 `resolve_voice_reference_serialized`。其中只有 `publish.py:606` 今天真会撞（它读的是上传写的那个 `content_folder`）；另外三个读的是 Steam 安装树的 `install_folder`，两棵树不重叠。全改是因为「读写都拿锁」这条规则比「这两棵树永不重叠」这个隐式前提更耐放，而它们本来就在 worker 里、加锁代价为零。唯一例外是 swap 内部那次 cleanup 读 —— `threading.Lock` 不可重入。

`POST /config` 的 load→merge→save→ensure 也收成一次串行事务：`ensure_workshop_folder_exists` 会**重新读配置文件**决定 `auto_create`（`utils/workshop_utils.py:53` 与 `:75`），不串起来的话 A 的 ensure 会读到 B 刚写的配置、拒绝建目录而 A 照样返回 success。

`main_routers/storage_location_router.py` 初版改了 6 处，**评审后全部回退**（见下节）。

⚠️ **那两个 GET 端点必须一起挪，不是顺手。** #2596 加的「事件循环上绝不退避」保护是**按线程**判断的：写盘挪进 worker 之后，那 155ms 的 Windows busy 退避被重新启用，而且是**持着 `threading.RLock` 睡的**。只要事件循环线程上还有 handler 去 acquire 同一把锁，那 155ms 就经由锁传回循环 —— 实测阻塞 **164.2ms**（改前同场景是「立即抛 winerror=32、0 次 sleep」，循环上结构性不可能出现这个停顿）。

**同一把锁的所有入口，要么都挪进 worker，要么都不挪。** 这两个 GET 本身也不是纯读：`load_seven_day_tutorial_store` / `load_autostart_prompt_state` 在只剩 legacy 文件时会落一次带 fsync 的迁移写。

### 三、刻意保留同步的部分（各带具体 noqa 理由）

⚠️ **`storage_location_router` 整个文件的写全部保留同步**（初版改了 6 处，评审后全部回退）。两条独立理由，任缺其一都会造成比循环卡顿严重得多的后果。

**理由一：这些写是取消原子的序列，而它们之间今天一个 await 都没有。** 典型形状是 `delete_storage_migration → save_storage_policy → set_root_mode`。插进任何 await，请求超时或应用关闭产生的 `CancelledError` 就能落在中间：恢复检查点已删、策略已写，而 root mode 还是旧值。`CancelledError` 是 `BaseException`，外层 `except Exception` 接不住，也就没人回滚。

**理由二（两处回滚 `_restore_storage_mutation_state` 也因此不能挪）：** 它末步是 `config_manager.save_root_state()`。而 `root_state` 还有**另一个不在锁里的写者**：`build_storage_location_bootstrap_payload()` → `_reconcile_legacy_cleanup_pending_root_state()`（`utils/storage/location_bootstrap.py:191`）也会 `save_root_state()`，它挂在 `GET /bootstrap`、`GET /status`、`GET /diagnostics`、`GET /retained-source`、`POST /exit` 上 —— 这些**都不在 `_storage_mutation_lock` 覆盖下**（那把 `asyncio.Lock` 只包 cleanup / select / restart 三条）。

**今天让这两个「读 root_state — 改 — 写回」互斥的不是锁，是「它们都跑在同一条事件循环线程上」。** 把回滚搬进 worker 恰好打破这个不变量：

> `/select` 走 failed-migration 恢复分支 → `set_root_mode(NORMAL)` 已落盘 → 解除启动闸抛异常 → 进回滚。同一时刻前端存储页的 500ms 轮询打进 `GET /status`。交错：① 循环线程 `load_root_state` 读到 `mode='normal'`；② worker 写回快照的 `mode='deferred_init'`；③ 循环线程把①读到的陈旧 dict 加上 `legacy_cleanup_pending` 写回 → mode 又变回 `'normal'`。
>
> 结果：迁移检查点和策略回滚了、`root_state` 没有。接口返回 503，但下次启动 `recovery_required = (root_mode == ROOT_MODE_DEFERRED_INIT)` 算成 `False`，**恢复闸被跳过**。

正确的收口是给 `root_state` 一把真锁、并让 GET 路由别在读路径上写盘 —— 那是独立的一份工作。在那之前，宁可让这些罕见的存储变更请求同步落盘。代码里写成 `_STORAGE_MUTATION_STAYS_ON_LOOP` 说明块，各处 `noqa` 指向它。

**`brain/task_executor.py` 的落盘保留同步。** `_persist_generated_short_descriptions` 是**无锁**的「re-read → merge → write」（函数里那句 `Re-read so concurrent prewarm batches don't clobber each other's entries` 就是它依赖的不变量），而且在 `finally` 里、本协程绝大部分时间挂在 `llm.ainvoke` 上、是事件循环收尾时会被 cancel 的 pending task。加 `await` 两头都会坏：并发批次互相覆盖，以及取消路径上落盘被直接跳过。

### 四、per-turn 的写：`memory/anti_repeat.py`

每条 assistant 回复都写一次 corpus（`omni_offline_client/_lifecycle.py:441`），每次主动搭话投递也写一次（`core/proactive.py:493`），跟音频同在一条循环上。新增 `arecord_output` 异步孪生。

三个设计决定：

1. **整个 `record_output` 进 `to_thread`，而不是只包那句写。** 读改写在 `_get_lock(name)` 下，`threading.Lock` 序列化循环线程和 worker 与序列化 worker 之间一样有效。
2. **落盘必须在数据锁之外**（评审后加）。`score_draft` / `score_unanswered_proactive_draft` / `top_recent_topics` 仍在**事件循环上**拿同一把 `_get_lock(name)`；worker 持锁跑 `atomic_write_json`（尾部无上界 fsync）时这些读者就卡在循环上 —— 正是这次挪线程想消掉的停顿换了条路径回来，**和上面 `prompt_flows` 的 RLock 传导是同一个形状**。现在数据锁内只做内存改动并 stage 一份带序号的快照，落盘在锁外、由第二把 writer-only 锁串行；顺序由 stage 序号而非抢锁先后决定，比已落盘序号旧的快照直接丢弃。
3. **时间戳在调用侧 stamp，且每次 append 后都按 ts 排序**（后半段评审后加）。原代码只在超窗时才排，注释写的是「理论上 append 时序就单调」——那个前提靠调用方串行，走 worker 之后不成立，而 `_split_fg_bg` 是拿尾部切片当「最近几条」的。
4. **内存更新留在调用线程，只有 fsync 去 worker**（评审后加）。上一版把整次 record 都丢进 worker，那个 job 排队 / 算 ngram 期间，循环上的 `score_draft` 读到的还是不含这条回复的旧 `_cache` —— 下一轮就可能把刚说过的话再说一遍。这是把「挪线程」做过头了。
5. **两个 per-turn 调用点的 corpus 记录都排在收尾信号之后**（评审后加）。那个 `await` 是取消点，而 `CancelledError` 是 `BaseException`、`except Exception` 接不住：文本已提交却跳过 `on_response_done` / TTS done / turn end，等于一次可见的回复没有终止信号。比漏录一条语料严重得多。

`memory/user_directives.py` **没动**：它的写在插件事件总线的同步 fan-out 里（`dispatch_user_utterance` 的契约就是同步，改它会把第三方插件 handler 挪到 worker 线程），而且只在 directive 正则真的命中时才落盘。留作后续。

### 五、顺带修的既存 bug

`utils/workshop_utils.py` 漏转出 `save_workshop_config`（它只 import 了 `load_workshop_config`）。于是 `POST /api/steam/workshop/config` 的 handler 里那行 local import 每次都抛 `ImportError`，被 handler 的 `except Exception` 吞成 HTTP 200 `{"success": false}` —— **这个接口从来没存过盘**。

实测：`hasattr(utils.workshop_utils, 'save_workshop_config') == False`。是本 PR 给那一行加守卫规则时顺着查出来的：守卫报的那个调用点，其实是一行死代码。

## 回归报告 / Regression Report

**改动了什么**

1. `scripts/check_async_blocking.py`：加 atomic-write 规则、通用名去噪、同点去重。
2. 12 处 `async def` 里的同步落盘改成 `await asyncio.to_thread(...)` / `await atomic_write_json_async(...)`。
3. `storage_location_router` 全文件 + `brain/task_executor.py` 保留同步并加 `# noqa: ASYNC_BLOCK — <理由>`。
4. `memory/anti_repeat.py` 新增 `arecord_output`；`main_logic/core/proactive.py` 与 `main_logic/omni_offline_client/_lifecycle.py` 两个 per-turn 调用点改为 await 它。
5. `utils/workshop_utils.py` 补一行 re-export。

**理由 / 必要性**

事件循环被一次 fsync 堵住，在这个产品上不是抽象的性能问题：`anti_repeat` 的写每条 assistant 回复都发生，而同一条循环上跑着音频。机械盘或 Windows CFA 兜底路径下单次 fsync 几十到几百毫秒，表现就是说话卡一下 —— 且无法复现。守卫是为了让这类回归不再靠 review 抓。

**改动前后的表现对比**

| 场景 | 改动前 | 改动后 |
|---|---|---|
| 每条 assistant 回复的 anti_repeat 落盘 | 在会话循环上做完整 fsync | worker 线程，循环不阻塞 |
| `/autostart-prompt/heartbeat`（被轮询） | 循环上落盘 | worker |
| `GET /seven-day-tutorial/state`（老用户首次） | 循环上做一次迁移写（含 fsync） | worker |
| worker 持锁退避 155ms 时，循环上 GET 抢同一把锁 | ——（改前不存在这条路径） | 也在 worker，循环不参与抢锁 |
| storage 回滚路径 | 循环上同步落盘 | **不变**（见上：改了会丢回滚） |
| `POST /api/steam/workshop/config` | 恒 `{"success": false}`，一个字节不写 | 正常保存 |
| 新的上环同步落盘 | 无人拦 | CI 红 |

**潜在回归点 / 怎么验证的**

- *新增 `await` 引入让出点破坏原子性* → 每一处都单独判过：storage 的 6 处全在 `_storage_mutation_lock`（**`asyncio.Lock`**，不是 threading）的临界区内，3 条变更路由都是「薄壳拿锁 + `_locked` 协程干活」；prompt_flows 的 6 处读-改-写整段在各自的 `threading.RLock` **内部**完成、临界区不跨 await；workshop 的写是无条件覆盖、且改前就已经有 `await file.read()` 让出点。**并且对每个文件的 diff 都跑了一轮对抗式复核**，正是它推翻了 storage 那两处回滚的安全论证（详见第三节）。
- *守卫误报把人逼去加假 noqa* → 去噪后 13 条零假阳性；`test_the_repo_itself_has_no_on_loop_atomic_writes` 让整棵树保持绿。
- *守卫漏报被当成合规* → 守卫文档写明只做 **depth-1**。`save_root_state` / `set_root_mode` / `delete_storage_migration` 都在深度 2，抓不到，本 PR 未处理（storage 那几处仍在循环上）。这是已知边界，不是「已经干净了」。
- *anti_repeat 换 API 打断既有测试* → `test_proactive_sid_guard.py` 那条钉「按发布时刻记录」的用例已同步改成 `assert_awaited_once_with`，并加了 `corpus.record_output.assert_not_called()`。⚠️ mock 必须是 `AsyncMock`，否则 `await MagicMock()` 抛错会被调用点的 `except` 吞掉，用例变成永远绿的空断言 —— 已在注释里写明。
- 全量 `tests/unit`：**8940 passed, 45 skipped**。

## 不拆分理由 / Why Not Split

不适用（计入上限的文件 10 个）。

## 测试 / Testing

**新增用例**

| 用例 | 变异 | 结果 |
|---|---|---|
| `test_check_async_blocking.py`（14 条：直接调用 / 一跳 helper / to_thread 形式不报 / 同步调用方不报 / 5 个通用名不报 / 独特名要报 / 去重 / noqa / 真实仓库全绿） | —— | |
| `test_arecord_output_persists_off_the_event_loop` | 去掉 `to_thread` | 红 ✅ |
| `test_arecord_output_stamps_time_at_the_call_site` | 时间戳挪进 worker | 红 ✅ |
| `test_the_per_turn_callers_use_the_async_twin` | 调用点退回同步版 | 红 ✅ |
| `test_the_data_lock_is_never_held_across_the_disk_write` | 落盘放回数据锁内 | 红 ✅ |
| `test_a_stale_snapshot_never_overwrites_a_newer_one` | 去掉 seq 守卫 | 红 ✅ |
| `test_entries_stay_ordered_by_timestamp` | 去掉每次排序 | 红 ✅ |
| `test_workshop_voice_refs.py`（6 条：整对替换 / 取消中途不留半套 / AST 钉住变更全在同步单元 / 两次上传不混半套 / 读者不见半套 / AST 钉住读者都拿锁） | cleanup 挪回协程体 → 3 红；去掉 per-folder 锁 → 1 红；读者改回裸读 → 2 红 | ✅ |
| `test_the_corpus_is_updated_before_arecord_output_yields` | 整次 record 丢回 worker | 红 ✅ |
| `test_concurrent_config_saves_do_not_cross_transactions` | 去掉事务锁 | 红 ✅ |
| `test_check_async_blocking.py` 增 3 条模块限定形式 | 撤掉 `RISKY_ATTR_PAIRS` 两条 | 红 ✅ |
| `test_workshop_utils_reexports_the_config_saver`<br>`test_the_workshop_config_route_can_import_what_it_uses` | 撤掉 re-export | 双红 ✅ |

「落盘发生在哪个线程」「时钟在哪个线程读」「取消之后盘上是不是整对」都是直接断言属性本身，不是断言 `to_thread` 这个调用存在 —— 后者换个写法就绕过去了。

⚠️ 并发那条的**第一版抓不住变异**：去掉 per-folder 锁它照样绿，因为真交错窗口太窄。改成把第一次 swap 卡在 manifest 写里、强制第二次插进来，现在是确定性的。

**回归面**

- 全量 `tests/unit`：8940 passed, 45 skipped。
- `scripts/check_async_blocking.py`：exit 0。
- `scripts/check_docstring_no_cjk.py --base origin/main`：exit 0。
- `ruff check`：全过。
- 相关面：storage_location ×3 文件、prompt_flow / autostart / seven-day-tutorial、workshop ×4、anti_repeat / proactive ×4、brain/agent ×5，全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **性能与稳定性**
  * 优化教程、自启动提示及相关状态操作，减少界面响应阻塞。
  * 改进重复内容记录与后台保存，提升并发、取消及失败场景下的数据一致性。
* **工坊功能**
  * 配置保存支持并发安全处理，并明确提示目录创建结果。
  * 参考语音上传、删除和发布读取更加可靠，避免音频与清单不匹配。
  * 发布期间相关内容操作会返回 409，避免文件冲突。
* **质量改进**
  * 扩充异步操作、并发场景及失败恢复的测试覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->