### PR TITLE
fix(memory): 归档半提交不再留永久重复，熔断计数不再写进它要防的那个文件（#2528 第 5 步）

### DIFF
--- a/main_logic/card_forge_facts.py
+++ b/main_logic/card_forge_facts.py
@@ -577,9 +577,16 @@ async def build_forge_facts_payload(
         "archiveFilteredCount": 0,
     }
     if limit >= 5 and raw_archive:
-        active_ids = {str(item.get("id") or "") for item in facts if item.get("id")}
+        # 排除集取自**全部**活跃 facts，而不是这次抽中的那几条：归档的两文件
+        # 提交（先 facts_archive.json 再 facts.json）被打断时同一行会同时留在
+        # 两个文件里，最长到下一次成功归档才收敛。只按抽中的几条排除的话，
+        # 那种行只要这轮没被抽中，就会作为"久远记忆"发出去，而它其实还活着。
+        active_source = [item for item in raw if isinstance(item, dict)]
+        active_ids = {
+            str(item.get("id") or "") for item in active_source if item.get("id")
+        }
         active_hashes = {
-            str(item.get("hash") or "") for item in facts if item.get("hash")
+            str(item.get("hash") or "") for item in active_source if item.get("hash")
         }
         archive_fact, archive_stats = await asyncio.to_thread(
             _select_archive_distant_fact,

--- a/main_logic/topic/pipeline.py
+++ b/main_logic/topic/pipeline.py
@@ -1131,7 +1131,12 @@ class TopicHookPool:
                 path.parent.mkdir(parents=True, exist_ok=True)
                 atomic_write_json(path, payload, ensure_ascii=False, indent=2)
             except Exception:
-                logger.debug("topic used-history persistence failed", exc_info=True)
+                # 不上抛、不重试是有意的：失败后果只是跨重启丢一次 used-topic
+                # 历史（同话题重启后可能再投一次），而把失败上抛会在只读盘上
+                # 直接压掉 topic 投递，明显更糟，也没有现成的重试通道值得为它
+                # 新建。但 debug 在生产默认 INFO 下等于不可见，一个永久不可写的
+                # state 目录现在完全无法诊断。调用频率低（投递 + purge），不刷屏。
+                logger.warning("topic used-history persistence failed", exc_info=True)
 
 
 def _default_topic_trigger():

--- a/main_logic/topic/signals.py
+++ b/main_logic/topic/signals.py
@@ -8,6 +8,7 @@ few chat turns.
 from __future__ import annotations
 
 import json
+import logging
 import time
 import threading
 import atexit
@@ -22,12 +23,28 @@ from utils.file_utils import atomic_write_json
 from utils.tokenize import truncate_to_tokens
 
 
+logger = logging.getLogger("N.E.K.O.Main.topic.signals")
+
+
 # Per-turn evidence cap in tokens. The topic candidate prompt feeds this slow
 # evidence as its only conversation input, so the per-turn budget lives here.
 _MAX_SIGNAL_TOKENS_PER_TURN = 500
 _TOKEN_PRECAP_CHARS_PER_TOKEN = 8
 _MAX_GLOBAL_TURNS = 60
 _SIGNAL_RETENTION_SECONDS = 12 * 60 * 60
+# 落盘失败的自愈重试预算。只约束 flush 的重试链 —— _request_persist 那条链按
+# 对话 / 剪枝节奏触发（retention 12h，剪枝极稀疏），本身不构成热循环。
+# base=persistence_flush_delay_seconds，生产走默认 1.0 → 序列 1/2/4/8/16s
+# （合计 ~31s）；耗尽后保持 dirty，等下一次真实数据变更或显式 flush 再试一次，
+# 所以短暂故障仍会在下一条消息时自愈，而永久性写失败不会退化成每秒一次的静默
+# 重试。
+_PERSIST_MAX_RETRIES = 5
+# 单次退避上限。生产默认 base 下末项正好等于它、min() 不改变任何一项；它管的是
+# 调用方把 flush delay 配大（>4s）的情况——没有它，base=60 会让最后一次重试排到
+# 16 分钟之后，早已跟"自愈"无关。base=0 是另一头：退避塌成 5 个零延迟 timer，
+# 仍然有界（次数封顶在 _PERSIST_MAX_RETRIES），不额外加下限，免得再多一个生产
+# 路径上永不生效的旋钮。
+_PERSIST_RETRY_BACKOFF_CAP_SECONDS = 16.0
 _FILLER_TEXTS = {
     "你好",
     "啊",
@@ -170,12 +187,18 @@ class TopicSignalStore:
         self._persist_write_lock = threading.Lock()
         self._persist_timer: threading.Timer | None = None
         self._persist_dirty = False
+        # 连续落盘失败次数（成功即清零）+ 退出标记，见 flush 的失败分支。
+        # 寿命：这个 store 由模块级单例 _GLOBAL_TOPIC_POOL 持有、没有 reload
+        # 路径会造第二个实例，所以预算实际上是 per-process 的 —— 已有的
+        # _persist_write_lock 也是实例级、靠同一个理由才真的串起了所有写者。
+        self._persist_retry_count = 0
+        self._shutting_down = False
         self._turns: dict[str, deque[TopicTurnSignal]] = defaultdict(
             lambda: deque(maxlen=self._max_turns)
         )
         self._load()
         if self._persistence_path is not None:
-            atexit.register(self.flush)
+            atexit.register(self._atexit_flush)
 
     def note_turn(
         self,
@@ -390,15 +413,42 @@ class TopicSignalStore:
 
             write_result = self._write_payload(payload)
         if write_result is not False:
+            with self._persist_lock:
+                self._persist_retry_count = 0
             return
 
         with self._persist_lock:
             self._persist_dirty = True
-            if self._persistence_path is not None and self._persist_timer is None:
-                timer = threading.Timer(self._persistence_flush_delay_seconds, self.flush)
-                timer.daemon = True
-                self._persist_timer = timer
-                timer.start()
+            if self._shutting_down:
+                # 退出路径上排 timer 是自欺：atexit 里起的 daemon Timer 不抛异常、
+                # is_alive() 也为 True，但解释器在 delay 到达前就 finalize 了，
+                # 回调永不执行。如实报告丢盘，不假装排了重试。
+                logger.warning(
+                    "topic signal state not persisted at exit; the in-memory "
+                    "window is lost (path=%s)", self._persistence_path,
+                )
+                return
+            if self._persistence_path is None or self._persist_timer is not None:
+                return
+            if self._persist_retry_count >= _PERSIST_MAX_RETRIES:
+                # 有界：永久性写失败（只读盘 / ACL）原来会变成每秒一次的静默
+                # 写盘尝试，无次数上限也无退避。
+                logger.warning(
+                    "topic signal persistence failed %d times in a row; giving "
+                    "up the retry chain, state stays dirty and the next real "
+                    "change retries once (path=%s)",
+                    self._persist_retry_count, self._persistence_path,
+                )
+                return
+            delay = min(
+                self._persistence_flush_delay_seconds * (2 ** self._persist_retry_count),
+                _PERSIST_RETRY_BACKOFF_CAP_SECONDS,
+            )
+            self._persist_retry_count += 1
+            timer = threading.Timer(delay, self.flush)
+            timer.daemon = True
+            self._persist_timer = timer
+            timer.start()
 
     def _request_persist(self) -> None:
         path = self._persistence_path
@@ -406,7 +456,9 @@ class TopicSignalStore:
             return
         with self._persist_lock:
             self._persist_dirty = True
-            if self._persist_timer is not None:
+            # 退出中到来的 note_turn 不该再排一个跑不了的 timer（与 flush 失败
+            # 分支的守卫对偶）。
+            if self._shutting_down or self._persist_timer is not None:
                 return
             timer = threading.Timer(self._persistence_flush_delay_seconds, self.flush)
             timer.daemon = True
@@ -442,7 +494,29 @@ class TopicSignalStore:
             atomic_write_json(path, payload, ensure_ascii=False, indent=2)
             return True
         except Exception:
+            # 原来异常被整个吞掉，连原因都留不下。分级：每次尝试记 debug（避免
+            # 退避期间刷 warning），give-up 和退出丢盘才由 flush 记 warning。
+            logger.debug(
+                "topic signal persistence write failed (path=%s)",
+                path, exc_info=True,
+            )
             return False
+
+    def _atexit_flush(self) -> None:
+        """atexit entry point: flush once, never schedule a retry.
+
+        Registered instead of ``flush`` itself so the failure branch can tell
+        "the process is on its way out" from a normal delayed flush. A daemon
+        Timer started from here can never fire — the interpreter finalizes long
+        before the delay elapses — so pretending to schedule one turns a
+        reportable failure into a silent loss.
+
+        Deliberately does not retry synchronously: blocking atexit slows
+        shutdown, and the one thing already proven unavailable here is time.
+        """
+        with self._persist_lock:
+            self._shutting_down = True
+        self.flush()
 
 
 def _is_meaningful_turn(text: str) -> bool:

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -155,8 +155,65 @@ def _readable_fact_id(entry: dict):
     return fact_id
 
 
+def _merge_archive_entries(existing: list, incoming: list) -> list[dict]:
+    """Merge archive rows keyed by id: later occurrence wins, first slot kept.
+
+    facts_archive.json is appended by a two-file commit (archive first, then
+    facts.json — see ``_archive_absorbed``). An interrupted commit leaves a row
+    in BOTH files, so the next archive pass re-appends it. Keying on
+    ``_readable_fact_id`` makes that append idempotent, and merging ``existing``
+    against itself also heals duplicates an earlier half-commit already wrote to
+    a user's disk.
+
+    Later wins because ``incoming`` is the live copy being archived right now —
+    it may carry flag updates the older archived copy predates.
+
+    Rows with an unusable id are all kept: there is no key to compare them on,
+    and folding them together would trade a duplicate for silent data loss (the
+    same call ``_readable_fact_id`` already makes).
+    """
+    out: list[dict] = []
+    pos: dict = {}
+    for entry in list(existing) + list(incoming):
+        if not isinstance(entry, dict):
+            continue
+        fid = _readable_fact_id(entry)
+        if fid is None:
+            out.append(entry)
+            continue
+        if fid in pos:
+            out[pos[fid]] = entry
+        else:
+            pos[fid] = len(out)
+            out.append(entry)
+    return out
+
+
+# 惰性创建 recheck 镜像时的互斥（见 FactStore._recheck_mem）。放模块级而不是
+# 实例级，是因为它要保护的正是「实例上还没有那把锁」的那一瞬间。只护创建的
+# 那几行，不参与后续读写。
+_RECHECK_MEM_BOOTSTRAP = threading.Lock()
+
+
 class FactStore:
     """Manages raw fact extraction, deduplication, and persistence."""
+
+    # legacy fact 重判的失败计数「进程内镜像」：{name: {fid: {"n", "at"}}}。
+    # session 内它是权威工作副本，facts.json 里那两栏只是持久化 + 重启恢复。
+    # 对齐 ReflectionEngine._synth_backoff_mem（memory/reflection/manager.py:79）：
+    # 计数器如果只活在「那个写不进去的文件」里，只读 FS / 权限 / 维护态下熔断
+    # 永远不会触发。
+    #
+    # class 级默认 None + 惰性创建（不是只在 __init__ 里赋值）：仓库里有多处
+    # `FactStore.__new__(FactStore)` 绕过 __init__ 造实例
+    # （tests/unit/test_ai_aware_stage1_path_b.py、tests/unit/test_group_memory_scopes.py），
+    # 那些实例一碰镜像就会 AttributeError。
+    #
+    # 刻意用实例级而不是模块级状态：它是 liveness 兜底不是持久状态，热重载
+    # （app/memory_server/runtime.py 重建 FactStore）丢掉只是让卡住的 fact 多跑
+    # 几轮，而模块单例会在 pytest 用例之间串状态。
+    _recheck_attempts_mem: dict | None = None
+    _recheck_mem_guard: threading.Lock | None = None
 
     def __init__(self, *, time_indexed_memory: TimeIndexedMemory | None = None):
         self._config_manager = get_config_manager()
@@ -242,7 +299,14 @@ class FactStore:
         archive via this loader before any per-day isolation, so a non-UTF-8
         archive must degrade here instead of aborting the whole import — Codex
         P2). ``UnicodeDecodeError`` is a ``ValueError`` subclass, distinct from
-        ``JSONDecodeError``, so it is listed explicitly."""
+        ``JSONDecodeError``, so it is listed explicitly.
+
+        Rows whose id also exists among the active facts are dropped, keeping
+        the active copy. That is not an optional extra guard — it is the read
+        half of ``_archive_absorbed``'s two-file commit protocol, whose write
+        order deliberately prefers "the row is in both files" over "the row is
+        in neither". Something has to collapse "in both", and a warning makes
+        this a backstop with a detector rather than a cover-up."""
         active = self.load_facts(name)
         archive_path = self._facts_archive_path(name)
         if not os.path.exists(archive_path):
@@ -255,7 +319,30 @@ class FactStore:
             return list(active)
         if not isinstance(archived, list):
             return list(active)
-        return list(active) + [f for f in archived if isinstance(f, dict)]
+        # active 与 archive 的 id 重叠 = 归档两文件提交被打断后还没收敛的残留。
+        # 收敛到 active 那份：它至少和归档副本一样新，且 absorbed /
+        # signal_processed 之类的 monotonic 标记以它为准。
+        merged = list(active)
+        active_ids = {
+            fid for fid in (
+                _readable_fact_id(f) for f in merged if isinstance(f, dict)
+            ) if fid is not None
+        }
+        dropped = 0
+        for f in archived:
+            if not isinstance(f, dict):
+                continue
+            fid = _readable_fact_id(f)
+            if fid is not None and fid in active_ids:
+                dropped += 1
+                continue
+            merged.append(f)
+        if dropped:
+            logger.warning(
+                f"[FactStore] {name}: active/archive 存在 {dropped} 条 id 重叠，"
+                f"已按 active 收敛（多半是上一次归档两文件提交被打断）"
+            )
+        return merged
 
     async def aload_facts_full(self, name: str) -> list[dict]:
         return await asyncio.to_thread(self.load_facts_full, name)
@@ -393,12 +480,44 @@ class FactStore:
                     mtime = datetime.fromtimestamp(os.path.getmtime(marker_path))
                     if (datetime.now() - mtime).total_seconds() < _ARCHIVE_COOLDOWN_HOURS * 3600:
                         return
-                self._archive_absorbed(name)
-                # 更新 marker（无论归档是否有实际条目都 touch 一次）
-                with open(marker_path, 'w', encoding='utf-8') as f:
-                    f.write(datetime.now().isoformat())
+                # 只在归档「真跑过」（跑完或真失败）时才 touch marker。维护态是
+                # 预期跳过、不该消耗归档窗口：否则维护期间每次 save 都把冷却续
+                # 24h，维护结束后要再等一整天才归档。
+                archive_ran = True
+                try:
+                    self._archive_absorbed(name)
+                except MaintenanceModeError as exc:
+                    # 对齐 load_facts 里的迁移分支：维护态跳过走 debug。
+                    #
+                    # 窄但不是死代码：save_facts 顶部的 assert_cloudsave_writable
+                    # 已经判过一次维护态，稳态维护期根本进不到这里。能走到的只有
+                    # 「顶部那次判定放行之后、_archive_absorbed 里那次判定之前
+                    # 进入维护态」这一窄窗——两次判定之间没有跨进程锁，root_state
+                    # 由别的进程/线程改。所以别按"不可达"把 archive_ran 一并删掉：
+                    # 真踩上时它决定了不消耗 24h 归档窗口。
+                    archive_ran = False
+                    logger.debug(f"[FactStore] {name}: 维护态跳过归档: {exc}")
+                except Exception:
+                    # 归档失败不能让调用方的 save 失败（facts.json 本身已经落盘
+                    # 成功了），但必须留痕：原来是裸 pass，两文件半提交在生产里
+                    # 完全不可见。marker 照常 touch —— archive 那次写就失败时
+                    # archive 的 mtime 不变、冷却不生效，不 touch 就会每次 save
+                    # 都重跑一遍必然失败的归档。
+                    logger.warning(
+                        f"[FactStore] {name}: 归档失败，facts.json 已落盘，"
+                        f"{_ARCHIVE_COOLDOWN_HOURS}h 后重试",
+                        exc_info=True,
+                    )
+                if archive_ran:
+                    # 更新 marker（无论归档是否有实际条目都 touch 一次）
+                    with open(marker_path, 'w', encoding='utf-8') as f:
+                        f.write(datetime.now().isoformat())
             except Exception:
-                pass
+                # 冷却判定 / marker 落盘本身出错：不影响已成功的 facts.json 保存，
+                # 但不再整个吞掉。
+                logger.debug(
+                    f"[FactStore] {name}: 归档冷却判定失败", exc_info=True,
+                )
 
     async def asave_facts(self, name: str) -> None:
         await asyncio.to_thread(self.save_facts, name)
@@ -443,13 +562,32 @@ class FactStore:
                 # 归档文件损坏 → 放弃本次归档，避免覆盖丢数据
                 logger.warning(f"[FactStore] {name}: 读取归档文件失败，跳过本次归档: {e}")
                 return 0
-        existing_archive.extend(to_archive)
+        # 追加按 id 幂等合并：半提交（archive 写成功、facts.json 没写成）之后
+        # 下一轮归档会把同一批 fact 再送进来一次，extend 会让它在归档里永久存在
+        # 两份。顺带修好已经落在用户盘上的历史重复。
+        existing_archive = _merge_archive_entries(existing_archive, to_archive)
         atomic_write_json(archive_path, existing_archive, indent=2, ensure_ascii=False)
-        # 原地更新活跃列表（保持对象引用不变，避免外部持有旧引用导致修改丢失）
-        facts.clear()
-        facts.extend(active)
-        atomic_write_json(self._facts_path(name), facts, indent=2, ensure_ascii=False)
-        logger.info(f"[FactStore] {name}: 归档 {len(to_archive)} 条已吸收的旧 facts，剩余 {len(active)} 条")
+        # 两文件提交顺序固定为「先 archive 再 facts.json」：中断窗口的状态是
+        # 「两边都有」（重复 —— 读侧 load_facts_full 按 id 收敛、下轮归档按 id
+        # 幂等追加），而不是「两边都没有」（永久丢已归档 fact，连带丢 daily
+        # import 的指纹 → 整天重导）。顺序不要反过来。
+        atomic_write_json(self._facts_path(name), active, indent=2, ensure_ascii=False)
+        # 缓存只在 facts.json 落盘成功之后才动 —— 对齐 event_log.record_and_save
+        # 已经写明的纪律（cache only changes after the disk write）。原来是先改
+        # 缓存再写盘，写盘失败就留下「缓存少 k 条 / 磁盘多 k 条」的半提交，而
+        # save_facts 的 evict 只挂在前一个 try 上、这里不触发。
+        #
+        # 原地更新活跃列表（保持对象引用不变，避免外部持有旧引用导致修改丢失）。
+        # 按身份剔除已归档的那几条，而不是拿函数开头算的 active 快照整体替换：
+        # add_facts 在 aload_facts 之后直接 append，并不持 _get_lock（本仓库既有
+        # 约定），快照整体替换会把「快照之后、这里之前」append 进来的 fact 一起
+        # 抹掉，而写序重排把这个窗口从一次写盘拉长成了两次。
+        # 用 id() 作键是安全的：to_archive 全程持有这些 dict 的强引用，它们不会
+        # 在此期间被回收、id 也就不会被别的对象复用。
+        archived_identities = {id(f) for f in to_archive}
+        facts[:] = [f for f in facts if id(f) not in archived_identities]
+        # 剩余数报缓存实际长度而不是 active 快照长度：并发 append 进来的行也还在。
+        logger.info(f"[FactStore] {name}: 归档 {len(to_archive)} 条已吸收的旧 facts，剩余 {len(facts)} 条")
         return len(to_archive)
 
     # ── extraction ───────────────────────────────────────────────────
@@ -2289,30 +2427,175 @@ class FactStore:
     async def amark_signal_processed(self, name: str, fact_ids: list[str]) -> None:
         await asyncio.to_thread(self.mark_signal_processed, name, fact_ids)
 
+    def _recheck_mem(self) -> tuple[dict, threading.Lock]:
+        """Return the recheck failure mirror and its guard, creating them once.
+
+        Lazy rather than ``__init__``-only because several call sites build a
+        ``FactStore`` through ``object.__new__``, which never runs ``__init__``;
+        a plain instance attribute would make those instances raise
+        ``AttributeError`` the moment the recheck path touches the mirror.
+        Creation is serialised by a module-level lock — the thing that has to be
+        protected here is precisely the window in which the instance has no lock
+        of its own yet.
+        """
+        mem = self._recheck_attempts_mem
+        guard = self._recheck_mem_guard
+        if mem is not None and guard is not None:
+            return mem, guard
+        with _RECHECK_MEM_BOOTSTRAP:
+            if self._recheck_attempts_mem is None:
+                # 赋到实例上（不是 class 上）：镜像必须是 per-instance，否则会变成
+                # 跨实例 / 跨 pytest 用例的单例。
+                self._recheck_attempts_mem = {}
+            if self._recheck_mem_guard is None:
+                self._recheck_mem_guard = threading.Lock()
+            return self._recheck_attempts_mem, self._recheck_mem_guard
+
+    def _note_recheck_attempt(
+        self, name: str, fid: str, *, base: dict | None,
+    ) -> tuple[int, str]:
+        """Record one recheck failure in the in-process mirror; returns (n, at).
+
+        The mirror stores the failure timestamp as well as the count on
+        purpose: ``cooldown_elapsed(None, …)`` returns True, so a count-only
+        mirror would let the dead-letter self-heal branch re-admit the entry on
+        the very next round — the breaker would look implemented and still
+        never bite.
+
+        On first entry for a fact the count resumes from the on-disk column so
+        a restart does not reset the budget to zero.
+
+        Concurrency contract: writers always replace an entry wholesale
+        (``per_char[fid] = {...}``) instead of mutating its fields in place, so
+        the lock-free reader in ``arecheck_one_legacy_fact`` can never observe a
+        half-written entry. Keep it that way.
+
+        No entry cap, unlike ``_abump_synth_backoff``'s 64: that map is keyed by
+        content-derived synth keys (unbounded key space), this one by fact id
+        (bounded by facts.json rows, which the archive sweep itself caps). A cap
+        here would evict entries already frozen at MAX and un-freeze them.
+        """
+        stamp = datetime.now().isoformat()
+        mem, guard = self._recheck_mem()
+        with guard:
+            per_char = mem.setdefault(name, {})
+            prev = per_char.get(fid)
+            if prev is not None:
+                n = safe_int_field(prev, 'n') + 1
+            else:
+                n = (safe_int_field(base, 'recheck_attempts') if base else 0) + 1
+            per_char[fid] = {"n": n, "at": stamp}
+        return n, stamp
+
+    def _clear_recheck_attempt(self, name: str, fid: str) -> None:
+        """Drop a fact's failure record after it migrates successfully.
+
+        Dual of ``_note_recheck_attempt``, mirroring
+        ``ReflectionEngine._aclear_synth_backoff``: without it the mirror would
+        only ever grow, and a migrated fact carrying a stale failure count is
+        unexplainable state even though the schema filter already excludes it.
+        """
+        mem = self._recheck_attempts_mem
+        if not mem:
+            return
+        _, guard = self._recheck_mem()
+        with guard:
+            mem.get(name, {}).pop(fid, None)
+
+    def _recheck_budget_open(self, mem_entry: dict | None, fact: dict) -> bool:
+        """Whether this legacy fact may still consume a recheck slot.
+
+        The in-process mirror wins over the two on-disk columns. When
+        facts.json cannot be written (read-only FS / permissions / maintenance
+        mode) ``recheck_attempts`` stays 0 and ``last_recheck_attempt_at`` stays
+        ``None`` on disk forever, and ``cooldown_elapsed(None, …)`` returns
+        True — reading disk only would mean neither the breaker nor the
+        self-heal gate ever bites, which is exactly the situation both were
+        added for.
+
+        ``safe_int_field`` rather than ``(… or 0)``: both columns come out of
+        hand-editable JSON, and a dirty value like ``""`` / ``[]`` would raise
+        inside the comparison and stall the whole drain loop.
+
+        A mirror entry always carries both fields — ``_note_recheck_attempt``
+        is its only writer and stamps ``at`` on every write — so this reads
+        ``at`` straight, with no on-disk fallback that could never run.
+        """
+        from config import (
+            MEMORY_RECHECK_MAX_ATTEMPTS,
+            MEMORY_DEAD_LETTER_SELF_HEAL_SECONDS,
+        )
+        from memory.temporal import cooldown_elapsed
+
+        if mem_entry is not None:
+            attempts = safe_int_field(mem_entry, 'n')
+            last_at = mem_entry.get('at')
+        else:
+            attempts = safe_int_field(fact, 'recheck_attempts')
+            last_at = fact.get('last_recheck_attempt_at')
+        if attempts < MEMORY_RECHECK_MAX_ATTEMPTS:
+            return True
+        # 时间自愈：达上限的 entry 过 MEMORY_DEAD_LETTER_SELF_HEAL_SECONDS 后放行
+        # 一次 probe，让一次性写盘/网络故障恢复后自愈。
+        return cooldown_elapsed(last_at, MEMORY_DEAD_LETTER_SELF_HEAL_SECONDS)
+
     def _bump_fact_recheck_attempts(self, name: str, fid: str, reason: str) -> None:
-        """Increment the given fact's ``recheck_attempts`` counter.
+        """Increment the given fact's recheck failure count.
 
         Once failures reach the ``MEMORY_RECHECK_MAX_ATTEMPTS`` cap, the
         candidates filter excludes the fact so the loop gives its slot to other
-        v1 entries. Directly mutates the cached list + save_facts (mirroring the
-        mark_absorbed style; save_facts takes its own lock).
-        Best-effort — save failures don't raise.
+        v1 entries.
+
+        The count lands in the in-process mirror first, then best-effort on
+        disk. The old version only wrote facts.json — the very file whose
+        failure it was supposed to count — so in the read-only FS / permission
+        case named in ``arecheck_one_legacy_fact``'s comment the counter never
+        moved (``save_facts`` even evicts the cache on failure, discarding the
+        just-incremented value), and the same fact was re-judged, at the cost of
+        one LLM call, every 30s forever.
+
+        A failed persist logs at WARNING — "the mirror moved but the disk
+        counter did not" has no other visible signal in production — except
+        under maintenance mode, an expected write ban that the archive block in
+        ``save_facts`` also keeps at debug.
         """
+        target: dict | None = None
         try:
-            current = self.load_facts(name)
-            for f in current:
-                if f.get('id') == fid:
-                    f['recheck_attempts'] = (f.get('recheck_attempts') or 0) + 1
-                    # 戳失败时刻供 dead-letter 时间自愈（cooldown_elapsed）
-                    f['last_recheck_attempt_at'] = datetime.now().isoformat()
-                    self.save_facts(name)
-                    logger.debug(
-                        f"[Recheck-Fact] {name} {fid}: "
-                        f"recheck_attempts → {f['recheck_attempts']} ({reason})"
-                    )
-                    return
+            for f in self.load_facts(name):
+                if isinstance(f, dict) and f.get('id') == fid:
+                    target = f
+                    break
         except Exception as e:
-            logger.debug(f"[Recheck-Fact] {name} {fid}: bump attempts 失败: {e}")
+            logger.debug(f"[Recheck-Fact] {name} {fid}: 读 facts 失败: {e}")
+        if target is None and fid not in (self._recheck_attempts_mem or {}).get(name, {}):
+            # fact 已经不在库里、镜像里也没有历史计数 → 无需记账。
+            return
+        # 1) 先更新进程内镜像（纯内存，不可能失败）。
+        attempts, stamp = self._note_recheck_attempt(name, fid, base=target)
+        if target is not None:
+            # 2) 再尽力持久化。写失败只 WARN 不抛 —— 镜像已经生效，熔断不受影响；
+            #    对齐 ReflectionEngine._asave_synth_backoff 的口径。
+            target['recheck_attempts'] = attempts
+            # 戳失败时刻供 dead-letter 时间自愈（cooldown_elapsed）
+            target['last_recheck_attempt_at'] = stamp
+            try:
+                self.save_facts(name)
+            except MaintenanceModeError as e:
+                # 维护态是预期的写禁止（save_facts 顶部的闸），不是故障。对齐
+                # save_facts 里的归档分支：那里也把维护态从 WARNING 降到 debug，
+                # 否则维护期间每一次重判失败都在日志里报一条"落盘失败"。
+                logger.debug(
+                    f"[Recheck-Fact] {name} {fid}: 维护态跳过 recheck_attempts "
+                    f"落盘（进程内镜像仍生效）: {e}"
+                )
+            except Exception as e:
+                logger.warning(
+                    f"[Recheck-Fact] {name} {fid}: recheck_attempts 落盘失败"
+                    f"（进程内镜像仍生效，熔断不受影响）: {e}"
+                )
+        logger.debug(
+            f"[Recheck-Fact] {name} {fid}: recheck_attempts → {attempts} ({reason})"
+        )
 
     async def arecheck_one_legacy_fact(self, name: str) -> bool:
         """Schema v1 → v2 slow recheck (processes only 1 fact per call).
@@ -2326,31 +2609,23 @@ class FactStore:
         Returns: True when one fact was processed successfully; False when no
         candidate was found or processing failed.
         """
-        from config import (
-            MEMORY_RECHECK_MAX_ATTEMPTS,
-            MEMORY_DEAD_LETTER_SELF_HEAL_SECONDS,
-        )
         from config.prompts.prompts_memory import MEMORY_RECHECK_FACT_PROMPT
         from memory.temporal import (
             normalize_event_when as _norm_when,
             compute_event_timestamps as _compute_ts,
-            cooldown_elapsed,
         )
 
         facts = await self.aload_facts(name)
+        # 无锁单次读：写侧整体替换条目 dict，读者不会看到半写状态
+        # （契约见 _note_recheck_attempt）。
+        recheck_mem = (self._recheck_attempts_mem or {}).get(name, {})
         candidates = [
             f for f in facts
             if (f.get('schema_version') or 1) < MEMORY_SCHEMA_VERSION_CURRENT
             # 重试预算：LLM 持续失败的 entry 累计达上限后不再阻塞队列
             # (Codex review on PR #1316 P2，对齐 reflection 同样写法)。
-            # 时间自愈：达上限的 entry 过 MEMORY_DEAD_LETTER_SELF_HEAL_SECONDS
-            # 后放行一次 probe，让一次性写盘/网络故障恢复后自愈。
-            and (
-                (f.get('recheck_attempts') or 0) < MEMORY_RECHECK_MAX_ATTEMPTS
-                or cooldown_elapsed(
-                    f.get('last_recheck_attempt_at'),
-                    MEMORY_DEAD_LETTER_SELF_HEAL_SECONDS,
-                )
+            and self._recheck_budget_open(
+                recheck_mem.get(_readable_fact_id(f)), f,
             )
         ]
         if not candidates:
@@ -2467,6 +2742,7 @@ class FactStore:
             )
             return False
         if ok:
+            self._clear_recheck_attempt(name, fid)
             logger.info(
                 f"[Recheck-Fact] {name} {fid}: v1→v{MEMORY_SCHEMA_VERSION_CURRENT} "
                 f"when={event_when_raw}"

--- a/memory/hybrid_recall.py
+++ b/memory/hybrid_recall.py
@@ -23,6 +23,8 @@ Pool composition
 - **BM25 pool**:      facts (active) + reflections (active) + facts_archive
   BM25 is cheap on small corpora; including archive lets the model surface
   long-tail keyword hits that have aged out of the live working set.
+  Archived rows whose id is still active are dropped first — an interrupted
+  archive commit leaves the row in both files (see ``_drop_archive_overlap``).
 
 - **Embedding pool**: facts (active) + reflections (active)
   Excludes archive (cost + recency window) and *persona* (already rendered
@@ -406,6 +408,61 @@ async def _aload_archive_facts(fact_store, lanlan_name: str) -> list[dict]:
         return []
 
 
+def _drop_archive_overlap(
+    archive_rows: list[dict], active_rows: list[dict], lanlan_name: str,
+) -> list[dict]:
+    """Drop archived rows whose id is still present among the active facts.
+
+    ``FactStore._archive_absorbed`` commits two files that cannot be written
+    atomically together (facts_archive.json, then facts.json) and deliberately
+    prefers the "row is in both files" interruption state over "row is in
+    neither". Collapsing that overlap is therefore every archive reader's job,
+    not an optional extra guard; ``FactStore.load_facts_full`` does the same
+    thing for its own callers.
+
+    Here the overlap distorts scoring, not just row counts: ``_rrf_fuse`` adds
+    ``1/(k+rank)`` for every occurrence of an id, so the duplicated row scores
+    twice, and each copy also occupies one of the ``HYBRID_RECALL_BUDGET_EACH``
+    slots, pushing a genuine candidate out of the fused result.
+    ``recall_by_time`` has no fusion step at all and would simply return the
+    same memory twice.
+
+    Active wins for the same reason it wins in ``load_facts_full``: it is at
+    least as fresh as the archived copy, and monotonic flags (``absorbed`` /
+    ``signal_processed``) are authoritative there.
+    """
+    if not archive_rows:
+        return []
+    # 复用 facts.py 的「可用 id」判定：手改 / 老库里的 id 可能缺失、为空串或是
+    # list/dict，两边判得不一样就会各自留下对方以为已收敛的行。惰性导入沿用本
+    # 文件对 memory.* 的一贯写法（避免启动期循环导入）。
+    from memory.facts import _readable_fact_id
+
+    active_ids = set()
+    for row in active_rows or []:
+        if not isinstance(row, dict):
+            continue
+        fid = _readable_fact_id(row)
+        if fid is not None:
+            active_ids.add(fid)
+    if not active_ids:
+        return list(archive_rows)
+    out: list[dict] = []
+    dropped = 0
+    for row in archive_rows:
+        if isinstance(row, dict) and _readable_fact_id(row) in active_ids:
+            dropped += 1
+            continue
+        out.append(row)
+    if dropped:
+        logger.warning(
+            "[hybrid_recall] %s: facts_archive 有 %d 条 id 与活跃 facts 重叠，"
+            "已按活跃副本收敛（多半是上一次归档两文件提交被打断）",
+            lanlan_name, dropped,
+        )
+    return out
+
+
 def _tag_tier(items: list[dict], tier: str) -> list[dict]:
     """Shallow-copy each item and stamp ``_tier`` + ``target_type`` for
     downstream hard_filter + result formatting. Doesn't mutate originals.
@@ -558,10 +615,13 @@ async def hybrid_recall(
     )
     active_facts = active_facts or []
     active_reflections = active_reflections or []
+    archive_facts = _drop_archive_overlap(
+        archive_facts or [], active_facts, lanlan_name,
+    )
 
     facts_tagged = _tag_tier(active_facts, 'fact')
     refl_tagged = _tag_tier(active_reflections, 'reflection')
-    arch_tagged = _tag_tier(archive_facts or [], 'fact_archive')
+    arch_tagged = _tag_tier(archive_facts, 'fact_archive')
 
     # Security boundary: scope filtering happens before any BM25/cosine/RRF
     # scoring. A group caller never searches the private/global corpus and then
@@ -734,10 +794,14 @@ async def recall_by_time(
         reflection_engine.aload_reflections(lanlan_name),
         _aload_archive_facts(fact_store, lanlan_name),
     )
+    active_facts = active_facts or []
     pool_raw = (
-        _tag_tier(active_facts or [], 'fact')
+        _tag_tier(active_facts, 'fact')
         + _tag_tier(active_reflections or [], 'reflection')
-        + _tag_tier(archive_facts or [], 'fact_archive')
+        + _tag_tier(
+            _drop_archive_overlap(archive_facts or [], active_facts, lanlan_name),
+            'fact_archive',
+        )
     )
     from memory.scopes import filter_entries_for_subjects
     pool_raw = filter_entries_for_subjects(

--- a/tests/unit/test_card_drop_session_facts.py
+++ b/tests/unit/test_card_drop_session_facts.py
@@ -2385,3 +2385,56 @@ def test_callback_access_logs_suppress_sensitive_query_parameters(caplog):
     assert "secret-code" not in caplog.text
     assert "secret-state" not in caplog.text
     assert "secret-token" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_archive_pick_excludes_rows_still_present_in_active_facts(
+    tmp_path, monkeypatch
+):
+    """A half-committed row must not be offered as a "distant" archive memory.
+
+    ``FactStore._archive_absorbed`` writes facts_archive.json before
+    facts.json, so an interrupted commit leaves the row in both files until
+    the next successful archive pass. The exclusion set therefore has to come
+    from the whole active file, not from the handful of facts this call
+    happened to pick: any row that was not picked would otherwise come back
+    through the archive branch while still being live.
+    """
+    facts_path = tmp_path / "facts.json"
+    archive_path = tmp_path / "facts_archive.json"
+    active = [
+        {
+            "id": f"f{i}",
+            "text": f"fact {i}",
+            "importance": 8,
+            "hash": f"h{i}",
+            "created_at": "2020-01-01T00:00:00Z",
+        }
+        for i in range(6)
+    ]
+    facts_path.write_text(json.dumps(active), encoding="utf-8")
+    # 归档里是全部 6 条的副本 = 最坏情况的半提交：无论这次抽中哪 5 条，
+    # 剩下那条都会从归档侧漏回来。
+    archive_path.write_text(json.dumps(active), encoding="utf-8")
+
+    async def fake_context(*_args, **_kwargs):
+        return ActiveNekoContext(
+            master_name="Master",
+            lanlan_name="Lanlan",
+            memory_dir=tmp_path,
+            facts_path=facts_path,
+            source="test",
+        )
+
+    monkeypatch.setattr(F, "resolve_active_neko_context", fake_context)
+    payload = await build_forge_facts_payload(
+        runtime_character_hint="Lanlan",
+        min_importance=0,
+        limit=5,
+    )
+
+    assert payload["returnedCount"] == 5
+    assert payload["archiveRawCount"] == 6
+    assert payload["archiveFilteredCount"] == 0, payload["archiveFilteredCount"]
+    sources = [fact["sourceCollection"] for fact in payload["facts"]]
+    assert "facts_archive" not in sources, sources

--- a/tests/unit/test_evidence_archive.py
+++ b/tests/unit/test_evidence_archive.py
@@ -1785,3 +1785,315 @@ async def test_asave_persona_evicts_cache_on_cloudsave_gate_raise(tmp_path):
         f"asave_persona (round-7 Major regression): "
         f"got {entry_after['text']!r}"
     )
+
+
+# ── facts archive: two-file commit half-commit regressions (issue #2528) ──
+#
+# `_archive_absorbed` commits two files that cannot be written atomically
+# together: facts_archive.json then facts.json. These tests pin the three
+# properties that make an interrupted commit converge instead of leaving a
+# permanent duplicate: cache follows the durable write, the append is
+# idempotent by id, and the reader collapses the overlap.
+
+
+import contextlib
+import logging
+
+
+class _RecordSink(logging.Handler):
+    def __init__(self):
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+    def at_least(self, level: int) -> list[str]:
+        return [r.getMessage() for r in self.records if r.levelno >= level]
+
+
+@contextlib.contextmanager
+def _capture_logger(name: str):
+    """Collect records straight off the named logger.
+
+    Attaches a handler to the logger itself instead of relying on ``caplog``:
+    the project sets ``propagate=False`` somewhere in its logger hierarchy
+    depending on import order, so propagation-based capture silently records
+    nothing (see the same note in tests/unit/test_callback_instruction_origin.py).
+    """
+    log = logging.getLogger(name)
+    sink = _RecordSink()
+    prior_level = log.level
+    log.addHandler(sink)
+    log.setLevel(logging.DEBUG)
+    try:
+        yield sink
+    finally:
+        log.removeHandler(sink)
+        log.setLevel(prior_level)
+
+
+_FACTS_LOGGER = "N.E.K.O.Memory.memory.facts"
+
+
+def _archive_fact_store(tmpdir: str):
+    from memory.facts import FactStore
+    cm = _mock_cm(tmpdir)
+    with patch("memory.facts.get_config_manager", return_value=cm):
+        fs = FactStore()
+        fs._config_manager = cm
+    return fs
+
+
+def _old_absorbed_fact(tag: str, **extra):
+    old = (datetime.now() - timedelta(days=30)).isoformat()
+    entry = {
+        "id": tag, "text": f"t-{tag}", "importance": 5, "entity": "master",
+        "tags": [], "hash": f"h-{tag}", "created_at": old, "absorbed": True,
+    }
+    entry.update(extra)
+    return entry
+
+
+def _live_fact(fid: str = "live"):
+    return {
+        "id": fid, "text": f"t-{fid}", "importance": 5, "entity": "master",
+        "tags": [], "hash": f"h-{fid}",
+        "created_at": datetime.now().isoformat(), "absorbed": False,
+    }
+
+
+def _ids(rows):
+    return [r.get("id") for r in rows]
+
+
+def _read_json(path):
+    with open(path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _fail_facts_json_after_archive():
+    """Patch context: let the archive write through, blow up on facts.json.
+
+    Reproduces the exact interruption point — the second write of the two-file
+    commit — without touching the first (plain `save_facts`) write.
+    """
+    import memory.facts as facts_mod
+    real = facts_mod.atomic_write_json
+    state = {"archive_written": False}
+
+    def _guard(path, data, **kw):
+        text = str(path)
+        if text.endswith("facts_archive.json"):
+            state["archive_written"] = True
+            return real(path, data, **kw)
+        if state["archive_written"] and text.endswith("facts.json"):
+            raise OSError("simulated facts.json write failure")
+        return real(path, data, **kw)
+
+    return patch("memory.facts.atomic_write_json", side_effect=_guard)
+
+
+def test_archive_does_not_touch_cache_until_facts_json_is_durable(tmp_path):
+    fs = _archive_fact_store(str(tmp_path))
+    name = "小天"
+    fs._facts[name] = [
+        _old_absorbed_fact("old1"), _old_absorbed_fact("old2"), _live_fact(),
+    ]
+
+    with _fail_facts_json_after_archive():
+        fs.save_facts(name)  # archive failure must not fail the save itself
+
+    disk = _read_json(fs._facts_path(name))
+    assert _ids(disk) == ["old1", "old2", "live"]
+    # 缓存不能领先耐久文件：save_facts 的 evict 兜底只覆盖前一个 try，
+    # 这里分叉后会一直活到重启，重启后就读成重复。
+    assert _ids(fs._facts[name]) == _ids(disk)
+    assert _ids(_read_json(fs._facts_archive_path(name))) == ["old1", "old2"]
+
+
+def test_archive_keeps_a_fact_appended_during_the_two_file_commit(tmp_path):
+    fs = _archive_fact_store(str(tmp_path))
+    name = "小天"
+    fs._facts[name] = [_old_absorbed_fact("old1"), _live_fact()]
+    newcomer = _live_fact("concurrent")
+
+    import memory.facts as facts_mod
+    real = facts_mod.atomic_write_json
+    state = {"archive_written": False}
+
+    def _guard(path, data, **kw):
+        text = str(path)
+        if text.endswith("facts_archive.json"):
+            state["archive_written"] = True
+        elif state["archive_written"] and text.endswith("facts.json"):
+            # add_facts 走 aload_facts 后直接 append，全程不持 _get_lock（仓库
+            # 既有约定），所以它能落在归档这两次写盘中间。
+            fs._facts[name].append(newcomer)
+        return real(path, data, **kw)
+
+    with patch("memory.facts.atomic_write_json", side_effect=_guard):
+        fs.save_facts(name)
+
+    # 拿函数开头算的 active 快照整体替换缓存，会把这条新 fact 一起抹掉；
+    # 按身份剔除已归档行则只动该动的那几条。
+    assert _ids(fs._facts[name]) == ["live", "concurrent"], _ids(fs._facts[name])
+    # 磁盘上这轮只写快照（新 fact 由下一次 save 落盘），归档照常。
+    assert _ids(_read_json(fs._facts_path(name))) == ["live"]
+    assert _ids(_read_json(fs._facts_archive_path(name))) == ["old1"]
+
+
+def test_archive_retry_is_idempotent_by_id(tmp_path):
+    fs = _archive_fact_store(str(tmp_path))
+    name = "小天"
+    fs._facts[name] = [
+        _old_absorbed_fact("old1"), _old_absorbed_fact("old2"), _live_fact(),
+    ]
+    with _fail_facts_json_after_archive():
+        fs.save_facts(name)
+
+    archive_path = fs._facts_archive_path(name)
+    stale = (datetime.now() - timedelta(hours=48)).timestamp()
+    os.utime(archive_path, (stale, stale))
+    os.utime(archive_path + ".last_attempt", (stale, stale))
+
+    # 换新 store = 重启：磁盘是唯一真相。
+    fs2 = _archive_fact_store(str(tmp_path))
+    fs2.load_facts(name)
+    fs2.save_facts(name)
+
+    assert _ids(_read_json(archive_path)) == ["old1", "old2"]
+    assert _ids(_read_json(fs2._facts_path(name))) == ["live"]
+
+
+def test_archive_heals_duplicates_already_on_disk(tmp_path):
+    fs = _archive_fact_store(str(tmp_path))
+    name = "小天"
+    archive_path = fs._facts_archive_path(name)
+    os.makedirs(os.path.dirname(archive_path), exist_ok=True)
+    with open(archive_path, "w", encoding="utf-8") as fh:
+        json.dump([_old_absorbed_fact("old1"), _old_absorbed_fact("old1")], fh)
+    stale = (datetime.now() - timedelta(hours=48)).timestamp()
+    os.utime(archive_path, (stale, stale))
+
+    fs._facts[name] = [_old_absorbed_fact("old2"), _live_fact()]
+    fs.save_facts(name)
+
+    # 盯「防新不治旧」的半吊子实现：只拿 existing 的 id 过滤 incoming 会留下
+    # 盘上已有的那对重复。
+    assert _ids(_read_json(archive_path)) == ["old1", "old2"]
+
+
+def test_archive_replay_keeps_the_incoming_copy_of_a_duplicate(tmp_path):
+    fs = _archive_fact_store(str(tmp_path))
+    name = "小天"
+    archive_path = fs._facts_archive_path(name)
+    os.makedirs(os.path.dirname(archive_path), exist_ok=True)
+    with open(archive_path, "w", encoding="utf-8") as fh:
+        json.dump([_old_absorbed_fact(
+            "old1", signal_processed=False, note="archived",
+        )], fh)
+    stale = (datetime.now() - timedelta(hours=48)).timestamp()
+    os.utime(archive_path, (stale, stale))
+
+    # 重放那份带着旧副本没有的 flag 更新：半提交之后活跃那份很可能已经被
+    # mark_absorbed / mark_signal_processed 改过。方向反成 first-wins 就是把
+    # 新 flag 写回旧值（两行内容完全相同的用例测不出方向）。
+    fs._facts[name] = [
+        _old_absorbed_fact("old1", signal_processed=True, note="live"),
+        _live_fact(),
+    ]
+    fs.save_facts(name)
+
+    archived = _read_json(archive_path)
+    assert _ids(archived) == ["old1"]
+    assert archived[0]["signal_processed"] is True, archived[0]
+    assert archived[0]["note"] == "live", archived[0]
+
+
+def test_archive_keeps_every_row_without_a_usable_id(tmp_path):
+    fs = _archive_fact_store(str(tmp_path))
+    name = "小天"
+    fs._facts[name] = [
+        _old_absorbed_fact("old1"),
+        _old_absorbed_fact("ok", id=None),
+        _old_absorbed_fact("ok2", id=""),
+        _live_fact(),
+    ]
+    fs.save_facts(name)
+
+    archived = _read_json(fs._facts_archive_path(name))
+    assert len(archived) == 3, (
+        "rows without a usable id share no key, so folding them together "
+        f"trades a duplicate for data loss: {_ids(archived)}"
+    )
+    assert sorted(r["hash"] for r in archived) == ["h-ok", "h-ok2", "h-old1"]
+
+
+def test_archive_failure_warns_and_touches_the_marker(tmp_path):
+    fs = _archive_fact_store(str(tmp_path))
+    name = "小天"
+    fs._facts[name] = [_old_absorbed_fact("old1"), _live_fact()]
+
+    import memory.facts as facts_mod
+    real = facts_mod.atomic_write_json
+
+    def _guard(path, data, **kw):
+        if str(path).endswith("facts_archive.json"):
+            raise OSError("simulated archive write failure")
+        return real(path, data, **kw)
+
+    with _capture_logger(_FACTS_LOGGER) as sink:
+        with patch("memory.facts.atomic_write_json", side_effect=_guard):
+            fs.save_facts(name)  # 不许连坐：facts.json 本身已经落盘成功
+
+    warnings = sink.at_least(logging.WARNING)
+    assert any("归档失败" in m and name in m for m in warnings), warnings
+    # archive 写就失败时 archive 的 mtime 没动，不 touch marker 的话每次 save
+    # 都会重跑一遍必然失败的归档。
+    assert os.path.exists(fs._facts_archive_path(name) + ".last_attempt")
+    assert _ids(_read_json(fs._facts_path(name))) == ["old1", "live"]
+
+
+def test_maintenance_mode_archive_skip_is_not_warned(tmp_path):
+    from utils.cloudsave_runtime import MaintenanceModeError
+
+    fs = _archive_fact_store(str(tmp_path))
+    name = "小天"
+    fs._facts[name] = [_old_absorbed_fact("old1"), _live_fact()]
+
+    def _gate(_cm, *, operation: str, target: str):
+        if operation == "archive":
+            raise MaintenanceModeError("simulated maintenance")
+
+    with _capture_logger(_FACTS_LOGGER) as sink:
+        with patch("memory.facts.assert_cloudsave_writable", side_effect=_gate):
+            fs.save_facts(name)
+
+    warnings = sink.at_least(logging.WARNING)
+    assert warnings == [], f"maintenance skip is an expected path: {warnings}"
+    # 维护态也不该消耗归档窗口：在这里 touch marker 等于每次 save 都把 24h
+    # 冷却续一次，维护结束后要再等一整天才归档。
+    assert not os.path.exists(fs._facts_archive_path(name) + ".last_attempt")
+
+
+def test_load_facts_full_converges_id_overlap_to_the_active_copy(tmp_path):
+    fs = _archive_fact_store(str(tmp_path))
+    name = "小天"
+    facts_path = fs._facts_path(name)
+    with open(facts_path, "w", encoding="utf-8") as fh:
+        json.dump([
+            _old_absorbed_fact("old1", note="active"), _live_fact(),
+        ], fh)
+    with open(fs._facts_archive_path(name), "w", encoding="utf-8") as fh:
+        json.dump([_old_absorbed_fact("old1", note="archived")], fh)
+
+    with _capture_logger(_FACTS_LOGGER) as sink:
+        full = fs.load_facts_full(name)
+
+    ids = _ids(full)
+    assert ids == ["old1", "live"], ids
+    survivor = next(f for f in full if f["id"] == "old1")
+    assert survivor["note"] == "active"
+    warnings = sink.at_least(logging.WARNING)
+    assert any("id 重叠" in m for m in warnings), warnings

--- a/tests/unit/test_hybrid_recall.py
+++ b/tests/unit/test_hybrid_recall.py
@@ -520,5 +520,129 @@ class TestRecallByTime(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(res["results"], [])
 
 
+# ── archive half-commit overlap (issue #2528) ─────────────────────────
+
+
+class TestArchiveHalfCommitOverlap(unittest.IsolatedAsyncioTestCase):
+    """A row present in both facts.json and facts_archive.json scores once.
+
+    ``FactStore._archive_absorbed`` writes facts_archive.json before
+    facts.json on purpose: an interrupted commit leaves the row in *both*
+    files rather than in neither. The archive-side cooldown then keeps that
+    state around for up to ``_ARCHIVE_COOLDOWN_HOURS``, so every archive
+    reader has to collapse the overlap — ``FactStore.load_facts_full`` does
+    it for its callers, these two do it for the recall pools.
+    """
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.archive_path = os.path.join(self.tmpdir, "facts_archive.json")
+
+    def _write_archive(self, rows):
+        with open(self.archive_path, "w", encoding="utf-8") as f:
+            json.dump(rows, f)
+
+    def _make_stores(self, active_facts):
+        fact_store = MagicMock()
+        fact_store.aload_facts = AsyncMock(return_value=active_facts)
+        fact_store._facts_archive_path = MagicMock(return_value=self.archive_path)
+        reflection_engine = MagicMock()
+        reflection_engine.aload_reflections = AsyncMock(return_value=[])
+        return fact_store, reflection_engine
+
+    async def test_half_committed_row_neither_double_scores_nor_evicts(self):
+        """A half-committed row scores once and takes one budget slot."""
+        dup = {"id": "dup", "score": 1.0,
+               "text": "博士 博士 博士 博士最喜欢的游戏 游戏 游戏 The Witness"}
+        solo = {"id": "solo", "score": 1.0, "text": "博士喜欢的游戏是别的"}
+        self._write_archive([dict(dup)])
+        fact_store, reflection_engine = self._make_stores([dup, solo])
+
+        with patch("memory.hybrid_recall._cosine_rank", new=AsyncMock(return_value=[])), \
+             patch("memory.hybrid_recall.HYBRID_RECALL_BM25_THRESHOLD", 0.0), \
+             patch("memory.hybrid_recall.HYBRID_RECALL_BUDGET_EACH", 2):
+            res = await hybrid_recall(
+                lanlan_name="testcat", query="博士 游戏",
+                fact_store=fact_store, reflection_engine=reflection_engine,
+                config_manager=MagicMock(),
+            )
+
+        ids = [r["id"] for r in res["results"]]
+        self.assertEqual(ids.count("dup"), 1, ids)
+        # 名额：两份 dup 会把 BM25 的 top-2 占满，solo 本该被召回却被挤掉。
+        self.assertIn("solo", ids, ids)
+        # 计分：RRF 对同一 id 的每次出现都累加 1/(k+rank)，重复行会拿双倍分。
+        dup_score = next(r["score"] for r in res["results"] if r["id"] == "dup")
+        self.assertAlmostEqual(dup_score, 1.0 / 61, places=6)
+        # 活跃副本胜出（它至少和归档副本一样新，monotonic 标记以它为准）。
+        self.assertEqual(
+            next(r["tier"] for r in res["results"] if r["id"] == "dup"), "fact",
+        )
+
+    async def test_recall_by_time_returns_a_half_committed_row_once(self):
+        """``recall_by_time`` has no fusion step: a duplicate row would
+        simply be returned twice."""
+        from memory.hybrid_recall import recall_by_time
+        dup = {"id": "dup", "text": "五月一号通宵", "score": 1.0,
+               "event_start_at": "2026-05-01T22:00:00"}
+        self._write_archive([dict(dup)])
+        fact_store, reflection_engine = self._make_stores([dup])
+
+        res = await recall_by_time(
+            lanlan_name="testcat", time_spec="2026-05-01",
+            fact_store=fact_store, reflection_engine=reflection_engine,
+        )
+
+        ids = [r["id"] for r in res["results"]]
+        self.assertEqual(ids, ["dup"], ids)
+        self.assertEqual(res["results"][0]["tier"], "fact")
+
+    async def test_archive_only_rows_still_reach_the_pool(self):
+        """Only overlapping ids are collapsed; archive-only rows still recall."""
+        active = [{"id": "act", "text": "博士今天在写代码", "score": 1.0}]
+        self._write_archive([
+            {"id": "arch_only", "text": "博士曾经养过一只猫", "score": 1.0},
+        ])
+        fact_store, reflection_engine = self._make_stores(active)
+
+        with patch("memory.hybrid_recall._cosine_rank", new=AsyncMock(return_value=[])), \
+             patch("memory.hybrid_recall.HYBRID_RECALL_BM25_THRESHOLD", 0.0):
+            res = await hybrid_recall(
+                lanlan_name="testcat", query="博士 猫",
+                fact_store=fact_store, reflection_engine=reflection_engine,
+                config_manager=MagicMock(),
+            )
+
+        ids = [r["id"] for r in res["results"]]
+        self.assertIn("arch_only", ids, ids)
+
+    def test_rows_without_a_usable_id_are_never_folded(self):
+        """Rows without a usable id share no key, so folding them would trade
+        a duplicate for silent data loss."""
+        from memory.hybrid_recall import _drop_archive_overlap
+        # 活跃侧同样可能有手改 / 老库留下的坏 id：把它们原样塞进集合会在
+        # list/dict 上抛 TypeError（unhashable），一条坏行带挂整次召回。
+        active = [
+            {"id": "", "text": "空 id 的活跃行"},
+            {"id": None, "text": "没有 id 的活跃行"},
+            {"id": ["unhashable"], "text": "id 是 list 的活跃行"},
+            {"id": 0, "text": "id 为 0 的 legacy 活跃行"},
+            {"id": "real", "text": "x"},
+        ]
+        archive = [
+            {"id": "", "text": "空 id 的归档行"},
+            {"id": None, "text": "没有 id 的归档行"},
+            {"id": ["unhashable"], "text": "id 是 list 的归档行"},
+            {"id": "real", "text": "真重叠"},
+            {"id": 0, "text": "id 为 0 的 legacy 重叠行"},
+        ]
+        kept = _drop_archive_overlap(archive, active, "testcat")
+        texts = [r["text"] for r in kept]
+        self.assertEqual(len(kept), 3, texts)
+        self.assertNotIn("真重叠", texts)
+        # id 为 0 是完全可用的键（`not fact_id` 会把它误判成没有 id）。
+        self.assertNotIn("id 为 0 的 legacy 重叠行", texts)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_memory_temporal.py
+++ b/tests/unit/test_memory_temporal.py
@@ -12,6 +12,8 @@ Covered:
 """
 from __future__ import annotations
 
+import contextlib
+import logging
 import random
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
@@ -872,3 +874,308 @@ async def test_followup_weighted_enabled_varies_picks(tmp_path):
             picks = await re.aget_followup_topics('小天')
             seen.add(tuple(sorted(r['id'] for r in picks)))
     assert len(seen) >= 2, f"weighted sampling produced only {len(seen)} unique combos"
+
+
+# ── legacy fact recheck: the breaker must work when facts.json is unwritable ──
+#
+# `_bump_fact_recheck_attempts` used to record failures only in facts.json —
+# the very file whose write failure it was counting. In the read-only FS /
+# permission case named in `arecheck_one_legacy_fact`'s own comment the counter
+# never moved, so the same fact was re-judged (one LLM call each time) forever.
+
+
+def _recheck_store(tmpdir: str):
+    from memory.facts import FactStore
+    cm = _mock_cm(tmpdir)
+    with patch("memory.facts.get_config_manager", return_value=cm):
+        fs = FactStore()
+        fs._config_manager = cm
+    return fs
+
+
+def _legacy_fact(fid: str = "f-legacy", **extra):
+    entry = {
+        "id": fid, "text": "用户上周一去爬山了", "importance": 6,
+        "entity": "master", "tags": [], "hash": f"h-{fid}",
+        "created_at": "2026-05-01T00:00:00", "absorbed": False,
+    }
+    entry.update(extra)
+    return entry
+
+
+def _counting_llm(counter: list, *, content: str | None = None):
+    """Fake chat client that tallies every ainvoke; raises when content is None."""
+    async def _ainvoke(*_a, **_k):
+        counter.append(1)
+        if content is None:
+            raise RuntimeError("simulated LLM failure")
+        resp = MagicMock()
+        resp.content = content
+        return resp
+
+    async def _aclose():
+        return None
+
+    llm = MagicMock()
+    llm.ainvoke = _ainvoke
+    llm.aclose = _aclose
+    return llm
+
+
+def _valid_when_json():
+    import json
+    return json.dumps(
+        {"event_when": {"start": {"offset": -1, "unit": "week"}, "end": None}}
+    )
+
+
+def _readonly_writes():
+    """Patch context: every atomic_write_json under memory.facts fails."""
+    def _boom(*_a, **_k):
+        raise OSError("simulated read-only filesystem")
+    return patch("memory.facts.atomic_write_json", side_effect=_boom)
+
+
+@pytest.mark.asyncio
+async def test_recheck_breaker_trips_when_facts_json_is_unwritable(tmp_path):
+    from config import MEMORY_RECHECK_MAX_ATTEMPTS
+    fs = _recheck_store(str(tmp_path))
+    fs._facts.setdefault("小天", []).append(_legacy_fact())
+    await fs.asave_facts("小天")
+
+    calls: list = []
+    llm = _counting_llm(calls, content=_valid_when_json())
+    rounds = MEMORY_RECHECK_MAX_ATTEMPTS + 3
+    with _readonly_writes(), patch("utils.llm_client.create_chat_llm", return_value=llm):
+        results = [await fs.arecheck_one_legacy_fact("小天") for _ in range(rounds)]
+
+    assert len(calls) == MEMORY_RECHECK_MAX_ATTEMPTS, (
+        f"breaker never tripped: {len(calls)} LLM calls over {rounds} rounds"
+    )
+    assert results[-3:] == [False, False, False]
+
+
+@pytest.mark.asyncio
+async def test_recheck_mirror_records_the_failure_timestamp(tmp_path):
+    fs = _recheck_store(str(tmp_path))
+    fs._facts.setdefault("小天", []).append(_legacy_fact())
+    await fs.asave_facts("小天")
+
+    calls: list = []
+    llm = _counting_llm(calls, content=_valid_when_json())
+    with _readonly_writes(), patch("utils.llm_client.create_chat_llm", return_value=llm):
+        await fs.arecheck_one_legacy_fact("小天")
+
+    entry = fs._recheck_attempts_mem["小天"]["f-legacy"]
+    assert entry["n"] == 1
+    # 只补计数不补时刻等于白修：cooldown_elapsed(None, …) 恒为 True，
+    # 刚冻结的条目会被 5h 自愈分支立刻放回队列。
+    stamped = datetime.fromisoformat(entry["at"])
+    assert abs((datetime.now() - stamped).total_seconds()) < 60
+
+
+@pytest.mark.asyncio
+async def test_recheck_breaker_self_heals_once_per_cooldown_window(tmp_path):
+    from config import (
+        MEMORY_RECHECK_MAX_ATTEMPTS,
+        MEMORY_DEAD_LETTER_SELF_HEAL_SECONDS,
+    )
+    fs = _recheck_store(str(tmp_path))
+    fs._facts.setdefault("小天", []).append(_legacy_fact())
+    await fs.asave_facts("小天")
+
+    calls: list = []
+    llm = _counting_llm(calls, content=_valid_when_json())
+    with _readonly_writes(), patch("utils.llm_client.create_chat_llm", return_value=llm):
+        for _ in range(MEMORY_RECHECK_MAX_ATTEMPTS + 1):
+            await fs.arecheck_one_legacy_fact("小天")
+        assert len(calls) == MEMORY_RECHECK_MAX_ATTEMPTS  # frozen
+
+        aged = datetime.now() - timedelta(
+            seconds=MEMORY_DEAD_LETTER_SELF_HEAL_SECONDS + 60
+        )
+        entry = dict(fs._recheck_attempts_mem["小天"]["f-legacy"])
+        entry["at"] = aged.isoformat()
+        fs._recheck_attempts_mem["小天"]["f-legacy"] = entry
+
+        for _ in range(3):
+            await fs.arecheck_one_legacy_fact("小天")
+
+    assert len(calls) == MEMORY_RECHECK_MAX_ATTEMPTS + 1, (
+        "self-heal must let exactly one probe through per cooldown window, "
+        f"got {len(calls) - MEMORY_RECHECK_MAX_ATTEMPTS} over 3 rounds"
+    )
+
+
+@pytest.mark.asyncio
+async def test_recheck_counter_resumes_from_the_persisted_value(tmp_path):
+    import json
+    import os
+    from config import MEMORY_RECHECK_MAX_ATTEMPTS
+    fs = _recheck_store(str(tmp_path))
+    facts_path = fs._facts_path("小天")
+    os.makedirs(os.path.dirname(facts_path), exist_ok=True)
+    with open(facts_path, "w", encoding="utf-8") as fh:
+        json.dump([_legacy_fact(
+            recheck_attempts=MEMORY_RECHECK_MAX_ATTEMPTS - 1,
+            last_recheck_attempt_at=datetime.now().isoformat(),
+        )], fh)
+
+    calls: list = []
+    llm = _counting_llm(calls, content=_valid_when_json())
+    with _readonly_writes(), patch("utils.llm_client.create_chat_llm", return_value=llm):
+        for _ in range(3):
+            await fs.arecheck_one_legacy_fact("小天")
+
+    assert len(calls) == 1, (
+        "the mirror must resume from the on-disk count, not restart at 0 "
+        f"after a restart: {len(calls)} calls"
+    )
+
+
+@pytest.mark.asyncio
+async def test_persisted_bump_is_not_double_counted(tmp_path):
+    from config import MEMORY_RECHECK_MAX_ATTEMPTS
+    fs = _recheck_store(str(tmp_path))
+    fs._facts.setdefault("小天", []).append(_legacy_fact())
+    await fs.asave_facts("小天")
+
+    calls: list = []
+    llm = _counting_llm(calls, content=None)  # LLM 失败，但磁盘可写
+    rounds = MEMORY_RECHECK_MAX_ATTEMPTS + 2
+    with patch("utils.llm_client.create_chat_llm", return_value=llm):
+        for _ in range(rounds):
+            await fs.arecheck_one_legacy_fact("小天")
+
+    # 磁盘写得进去时，两处计数必须是同一个数：读侧若把磁盘和镜像相加，熔断会
+    # 提前一倍触发，等于凭空砍掉一半重试预算。
+    assert len(calls) == MEMORY_RECHECK_MAX_ATTEMPTS, len(calls)
+    on_disk = (await fs.aload_facts("小天"))[0]
+    assert on_disk["recheck_attempts"] == MEMORY_RECHECK_MAX_ATTEMPTS
+    assert (
+        fs._recheck_attempts_mem["小天"]["f-legacy"]["n"]
+        == MEMORY_RECHECK_MAX_ATTEMPTS
+    )
+
+
+@pytest.mark.asyncio
+async def test_successful_recheck_clears_the_mirror_entry(tmp_path):
+    fs = _recheck_store(str(tmp_path))
+    fs._facts.setdefault("小天", []).append(_legacy_fact())
+    await fs.asave_facts("小天")
+
+    failing: list = []
+    with patch("utils.llm_client.create_chat_llm",
+               return_value=_counting_llm(failing, content=None)):
+        await fs.arecheck_one_legacy_fact("小天")
+        await fs.arecheck_one_legacy_fact("小天")
+    assert fs._recheck_attempts_mem["小天"]["f-legacy"]["n"] == 2
+
+    ok_calls: list = []
+    with patch("utils.llm_client.create_chat_llm",
+               return_value=_counting_llm(ok_calls, content=_valid_when_json())):
+        assert await fs.arecheck_one_legacy_fact("小天") is True
+
+    # 对齐 _aclear_synth_backoff：成功落地后镜像必须收回，否则只增不减。
+    assert "f-legacy" not in fs._recheck_attempts_mem.get("小天", {})
+    assert (await fs.aload_facts("小天"))[0]["schema_version"] == 2
+
+
+def test_recheck_mirror_survives_instances_built_without_init():
+    """`FactStore.__new__` bypasses `__init__`; the mirror must still work.
+
+    Four such construction sites exist in this test suite alone, so an
+    instance-attribute-only mirror would raise AttributeError the first time
+    one of them reached the recheck path.
+    """
+    from memory.facts import FactStore
+    fs = FactStore.__new__(FactStore)
+    n, stamp = fs._note_recheck_attempt("小天", "f-legacy", base=None)
+    assert (n, bool(stamp)) == (1, True)
+    assert fs._recheck_attempts_mem["小天"]["f-legacy"]["n"] == 1
+    # 实例级而不是模块级：别的实例不该看见这条计数。
+    other = FactStore.__new__(FactStore)
+    assert (other._recheck_attempts_mem or {}) == {}
+
+
+class _RecheckLogSink(logging.Handler):
+    def __init__(self):
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+    def at_least(self, level: int) -> list[str]:
+        return [r.getMessage() for r in self.records if r.levelno >= level]
+
+
+@contextlib.contextmanager
+def _capture_facts_logger():
+    """Collect records straight off the facts logger.
+
+    Attaches a handler to the logger itself instead of relying on ``caplog``:
+    this project's logging setup breaks propagation to root depending on
+    import order, so propagation-based capture silently records nothing.
+    """
+    log = logging.getLogger("N.E.K.O.Memory.memory.facts")
+    sink = _RecheckLogSink()
+    prior = log.level
+    log.addHandler(sink)
+    log.setLevel(logging.DEBUG)
+    try:
+        yield sink
+    finally:
+        log.removeHandler(sink)
+        log.setLevel(prior)
+
+
+def test_recheck_counter_persist_failure_is_visible_in_logs(tmp_path):
+    """"Mirror moved, disk counter did not" has no other production signal.
+
+    Same standard this PR sets for signals / pipeline (see
+    ``test_persistence_failure_is_visible_in_logs`` and
+    ``test_used_topics_persist_failure_is_visible``): a silent failure has to
+    leave a trace, and the level has to be pinned — accepting DEBUG here would
+    stay green when someone downgrades the call back to ``logger.debug``.
+    """
+    fs = _recheck_store(str(tmp_path))
+    fs._facts.setdefault("小天", []).append(_legacy_fact())
+    fs.save_facts("小天")
+
+    with _capture_facts_logger() as sink:
+        with _readonly_writes():
+            fs._bump_fact_recheck_attempts("小天", "f-legacy", "llm_failed")
+
+    warnings = sink.at_least(logging.WARNING)
+    assert any("f-legacy" in m and "落盘失败" in m for m in warnings), warnings
+    # 留痕的前提是熔断计数真的记在了镜像里。
+    assert fs._recheck_attempts_mem["小天"]["f-legacy"]["n"] == 1
+
+
+def test_recheck_counter_persist_skipped_in_maintenance_is_not_warned(tmp_path):
+    """Maintenance mode is an expected write ban, not a failure.
+
+    The gate at the top of ``save_facts`` raises ``MaintenanceModeError``; a
+    bare ``except Exception`` turns every recheck failure during maintenance
+    into a WARNING. The archive block deliberately keeps that case at debug,
+    and this path has to match it.
+    """
+    from utils.cloudsave_runtime import MaintenanceModeError
+
+    fs = _recheck_store(str(tmp_path))
+    fs._facts.setdefault("小天", []).append(_legacy_fact())
+    fs.save_facts("小天")
+
+    def _gate(_cm, *, operation: str, target: str):
+        if operation == "save":
+            raise MaintenanceModeError("simulated maintenance")
+
+    with _capture_facts_logger() as sink:
+        with patch("memory.facts.assert_cloudsave_writable", side_effect=_gate):
+            fs._bump_fact_recheck_attempts("小天", "f-legacy", "llm_failed")
+
+    warnings = sink.at_least(logging.WARNING)
+    assert warnings == [], f"maintenance skip is an expected path: {warnings}"
+    # 降级不许连带把熔断也降级掉：镜像照记，只读盘/维护态下才有熔断可言。
+    assert fs._recheck_attempts_mem["小天"]["f-legacy"]["n"] == 1

--- a/tests/unit/test_topic_pipeline.py
+++ b/tests/unit/test_topic_pipeline.py
@@ -2430,3 +2430,56 @@ async def test_deepen_material_idempotent_and_respects_disable(monkeypatch):
     assert derive_calls == [1]
     assert len(enrich_calls) == 2
     assert m2["deep_search_done"] is True
+
+
+# ── used-topic persistence failure visibility (issue #2528) ──────────────
+#
+# `_persist_used_topics` deliberately neither retries nor re-raises: losing
+# one restart's worth of used-topic history only risks re-offering the same
+# topic once, whereas raising would kill topic delivery outright on a
+# read-only disk. But it logged at DEBUG, i.e. invisible at the production
+# default of INFO, so a permanently unwritable state dir could not be
+# diagnosed at all.
+
+
+def test_used_topics_persist_failure_is_visible(tmp_path):
+    import logging
+    from unittest.mock import patch
+
+    class _Sink(logging.Handler):
+        def __init__(self):
+            super().__init__(level=logging.DEBUG)
+            self.records = []
+
+        def emit(self, record):
+            self.records.append(record)
+
+    pool = TopicHookPool(
+        auto_schedule=False,
+        min_user_turns_for_topic=1,
+        signal_store_path=tmp_path / "state" / "topic_signals.json",
+    )
+    assert pool._used_topics_path is not None
+    with pool._used_topics_lock:
+        pool._used_topics["妮可"].append({
+            "used_at": time.time(), "hook_id_hash": "h", "interest_hash": "i",
+        })
+
+    log = logging.getLogger("N.E.K.O.Main.topic.pipeline")
+    sink = _Sink()
+    prior = log.level
+    log.addHandler(sink)
+    log.setLevel(logging.DEBUG)
+    try:
+        with patch("main_logic.topic.pipeline.atomic_write_json",
+                   side_effect=OSError("simulated read-only state dir")):
+            pool._persist_used_topics()  # 必须不抛
+    finally:
+        log.removeHandler(sink)
+        log.setLevel(prior)
+
+    # 断言必须卡在 WARNING 上：收 DEBUG 的话 logger.debug 的回归也会绿。
+    warnings = [
+        r.getMessage() for r in sink.records if r.levelno >= logging.WARNING
+    ]
+    assert any("used-history" in m for m in warnings), warnings

--- a/tests/unit/test_topic_signals.py
+++ b/tests/unit/test_topic_signals.py
@@ -134,3 +134,258 @@ def test_topic_signal_store_persists_runtime_retention_prune(tmp_path):
         for item in payload["characters"]["妮可"]
     ]
     assert texts == ["仍在窗口内的新证据"]
+
+
+# ── persistence failure handling (issue #2528) ────────────────────────────
+#
+# `_write_payload` returns False on any write error; `flush` used to answer
+# that with a fixed 1s `threading.Timer`, with no attempt cap and no backoff,
+# so a permanently unwritable state dir became one silent write attempt per
+# second forever. And `flush` is the atexit hook: a daemon Timer started there
+# can never fire, so the exit path was pretending to schedule a retry while
+# actually dropping the window silently.
+
+import contextlib
+import logging
+from unittest.mock import patch
+
+from main_logic.topic.signals import (
+    _PERSIST_MAX_RETRIES,
+    TopicSignalStore,
+)
+
+
+_SIGNALS_LOGGER = "N.E.K.O.Main.topic.signals"
+
+
+class _FakeTimer:
+    """Records (delay, fn) and never starts a thread.
+
+    Real timers are unusable here: the retry chain under test is exactly the
+    thing that would leak background threads into later tests, and driving the
+    chain by hand is the only way to observe the delay sequence.
+    """
+
+    def __init__(self, delay, fn, *args, **kwargs):
+        self.delay = float(delay)
+        self.fn = fn
+        self.daemon = False
+        self.started = False
+        self.cancelled = False
+
+    def start(self):
+        self.started = True
+
+    def cancel(self):
+        self.cancelled = True
+
+    def is_alive(self):
+        return self.started and not self.cancelled
+
+
+@contextlib.contextmanager
+def _fake_timers():
+    """Swap threading.Timer as seen by signals.py, collecting every instance."""
+    created: list[_FakeTimer] = []
+
+    def _make(delay, fn, *args, **kwargs):
+        timer = _FakeTimer(delay, fn, *args, **kwargs)
+        created.append(timer)
+        return timer
+
+    with patch("main_logic.topic.signals.threading.Timer", _make):
+        yield created
+
+
+@contextlib.contextmanager
+def _write_gate():
+    """Control whether atomic_write_json succeeds; ``gate['fail']`` toggles it."""
+    gate = {"fail": True, "writes": 0}
+
+    def _write(*_args, **_kwargs):
+        gate["writes"] += 1
+        if gate["fail"]:
+            raise OSError("simulated read-only state dir")
+
+    with patch("main_logic.topic.signals.atomic_write_json", side_effect=_write):
+        yield gate
+
+
+class _RecordSink(logging.Handler):
+    def __init__(self):
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+    def at_least(self, level):
+        return [r for r in self.records if r.levelno >= level]
+
+
+@contextlib.contextmanager
+def _capture_logger(name: str):
+    """Attach a handler straight to the logger.
+
+    ``caplog`` relies on propagation to root, which this project's logging
+    setup breaks depending on import order (same note as
+    tests/unit/test_callback_instruction_origin.py).
+    """
+    log = logging.getLogger(name)
+    sink = _RecordSink()
+    prior = log.level
+    log.addHandler(sink)
+    log.setLevel(logging.DEBUG)
+    try:
+        yield sink
+    finally:
+        log.removeHandler(sink)
+        log.setLevel(prior)
+
+
+def _persistent_store(tmp_path, flush_delay=1.0):
+    # atexit.register 在这里会把 store 挂到解释器退出钩子上、污染整个测试进程。
+    with patch("main_logic.topic.signals.atexit.register"):
+        return TopicSignalStore(
+            min_user_turns_for_topic=1,
+            persistence_path=tmp_path / "state" / "topic_signals.json",
+            persistence_flush_delay_seconds=flush_delay,
+        )
+
+
+def _drive(created, *, start=0, limit=20):
+    """Fire recorded timers in order, up to a hard cap.
+
+    The cap is load-bearing: an unbounded retry chain would otherwise keep
+    appending work to this very loop and the test would hang instead of
+    failing.
+    """
+    idx = start
+    for _ in range(limit):
+        if idx >= len(created):
+            break
+        timer = created[idx]
+        idx += 1
+        timer.fn()
+
+
+def test_flush_retry_chain_is_bounded_with_exponential_backoff(tmp_path):
+    with _fake_timers() as created, _write_gate():
+        store = _persistent_store(tmp_path)
+        store.note_turn("neko", actor="user", text="我一直在想要不要换个城市")
+        # 第一个 timer 来自 _request_persist（delay=base），不是重试。
+        assert len(created) == 1 and created[0].delay == 1.0
+
+        _drive(created)
+
+    delays = [t.delay for t in created]
+    assert len(created) <= 1 + _PERSIST_MAX_RETRIES, delays
+    assert delays[1:] == [1.0, 2.0, 4.0, 8.0, 16.0], delays
+
+
+def test_backoff_delay_stops_growing_at_the_cap(tmp_path):
+    """The cap only bites once the configured flush delay is large enough.
+
+    A base of 1.0 cannot reach ``min()`` at all: 1/2/4/8/16 ends exactly on the
+    cap, so dropping the call changes nothing. This case configures the flush
+    delay to 5.0 so 20/40/80 are actually clamped back to 16 — without that the
+    last retry would land more than a minute out, which is no longer self-heal.
+    """
+    with _fake_timers() as created, _write_gate():
+        store = _persistent_store(tmp_path, flush_delay=5.0)
+        store.note_turn("neko", actor="user", text="我一直在想要不要换个城市")
+        assert len(created) == 1 and created[0].delay == 5.0
+
+        _drive(created)
+
+    delays = [t.delay for t in created]
+    assert len(created) == 1 + _PERSIST_MAX_RETRIES, delays
+    assert delays[1:] == [5.0, 10.0, 16.0, 16.0, 16.0], delays
+
+
+def test_zero_flush_delay_still_bounds_the_retry_chain(tmp_path):
+    """A zero debounce collapses the backoff but not the attempt budget.
+
+    ``persistence_flush_delay_seconds`` is only clamped at the bottom by
+    ``max(0.0, …)``, so a caller may configure 0 and turn the backoff into a
+    run of zero-delay timers. That is deliberately not floored — the chain is
+    bounded by ``_PERSIST_MAX_RETRIES`` either way, and a floor would be one
+    more knob that never fires on the production path.
+    """
+    with _fake_timers() as created, _write_gate() as gate:
+        store = _persistent_store(tmp_path, flush_delay=0.0)
+        store.note_turn("neko", actor="user", text="我一直在想要不要换个城市")
+        _drive(created)
+
+    assert [t.delay for t in created] == [0.0] * (1 + _PERSIST_MAX_RETRIES)
+    # 每个 timer 都真的试过写一次，不是空转。
+    assert gate["writes"] == 1 + _PERSIST_MAX_RETRIES
+
+
+def test_successful_write_resets_the_retry_budget(tmp_path):
+    with _fake_timers() as created, _write_gate() as gate:
+        store = _persistent_store(tmp_path)
+        store.note_turn("neko", actor="user", text="我一直在想要不要换个城市")
+        for _ in range(3):
+            created[-1].fn()
+        assert [t.delay for t in created] == [1.0, 1.0, 2.0, 4.0]
+
+        gate["fail"] = False
+        created[-1].fn()          # succeeds -> budget clears, no new timer
+        assert len(created) == 4
+
+        gate["fail"] = True
+        store.note_turn("neko", actor="user", text="另一条证据")
+        assert len(created) == 5  # _request_persist again
+        _drive(created, start=4)
+
+    delays_after_success = [t.delay for t in created[5:]]
+    assert delays_after_success == [1.0, 2.0, 4.0, 8.0, 16.0], delays_after_success
+
+
+def test_atexit_flush_does_not_schedule_a_timer_it_cannot_run(tmp_path):
+    with _fake_timers() as created, _write_gate():
+        store = _persistent_store(tmp_path)
+        store.note_turn("neko", actor="user", text="我一直在想要不要换个城市")
+        assert len(created) == 1
+
+        with _capture_logger(_SIGNALS_LOGGER) as sink:
+            store._atexit_flush()
+            # 退出中到来的 turn 也不该再排一个跑不了的 timer。
+            store.note_turn("neko", actor="user", text="退出途中还在说话")
+
+    assert len(created) == 1, [t.delay for t in created]
+    assert store._persist_timer is None
+    messages = [r.getMessage() for r in sink.at_least(logging.WARNING)]
+    assert any("at exit" in m and "lost" in m for m in messages), messages
+
+
+def test_atexit_registers_the_shutdown_wrapper_not_flush(tmp_path):
+    registered: list = []
+    with patch("main_logic.topic.signals.atexit.register", side_effect=registered.append):
+        TopicSignalStore(
+            min_user_turns_for_topic=1,
+            persistence_path=tmp_path / "state" / "topic_signals.json",
+            persistence_flush_delay_seconds=1.0,
+        )
+
+    assert len(registered) == 1
+    # 盯调用点本身：只测被调函数的行为，把注册改回 flush 的回归照样绿。
+    assert registered[0].__func__ is TopicSignalStore._atexit_flush
+
+
+def test_persistence_failure_is_visible_in_logs(tmp_path):
+    with _fake_timers() as created, _write_gate():
+        store = _persistent_store(tmp_path)
+        with _capture_logger(_SIGNALS_LOGGER) as sink:
+            store.note_turn("neko", actor="user", text="我一直在想要不要换个城市")
+            _drive(created)
+
+    attempts = [
+        r for r in sink.records
+        if r.levelno == logging.DEBUG and "write failed" in r.getMessage()
+    ]
+    assert len(attempts) == 1 + _PERSIST_MAX_RETRIES, len(attempts)
+    assert all(r.exc_info for r in attempts)
+    warnings = [r.getMessage() for r in sink.at_least(logging.WARNING)]
+    assert any("giving up" in m for m in warnings), warnings


### PR DESCRIPTION

#2528 的审计在「落盘失败的善后」这一族里挖到三条真缺陷。它们不是并发问题，
但属于同一失效域。

## (a) facts 归档半提交 → facts_archive.json 永久重复

save_facts 用 `except Exception: pass`（**连日志都没有**）包住 _archive_absorbed，
而后者是两个文件的非原子提交：先写 facts_archive.json，再原地改缓存，最后写 facts.json。
第二次写失败时：缓存少 k 条 / 磁盘多 k 条 / archive 多 k 条，而这一路的缓存 evict 只挂在
前一个 try 上、此处不触发。归档 marker 也没写、冷却不生效 → 下次 save_facts 立刻重试归档
→ existing_archive.extend 再追一遍 → 同一条 fact 在 archive 里永久两份。

修法四段：

1. **合并代替追加**：新增 _merge_archive_entries()，按 id 幂等合并（later wins、无 id 的行
   全留）。既让重试幂等，也顺手修好已经落在用户盘上的历史重复。
2. **改缓存挪到写盘之后**：写 facts.json 直接用 active，失败时缓存与 facts.json 仍然一致，
   只剩 archive 多 k 条这一个可收敛偏差。
   关于「要不要反过来先写 facts.json」：**保持现顺序**。两文件非原子提交只能选中断窗口的
   方向 —— 现顺序的窗口是「两边都有」（重复，读侧可收敛、下轮归档幂等吸收）；反过来是
   「两边都没有」（永久丢已归档 fact，连带丢 daily import 指纹 → 整天重导），不可收敛。
3. **读侧收敛**：archive 有四个读者，逐个处理。load_facts_full 按 id 收敛到 active 并
   WARNING；hybrid_recall 与 recall_by_time 新增 _drop_archive_overlap（_rrf_fuse 对同一 id
   的每次出现累加 1/(k+rank)，两份还各占一个 HYBRID_RECALL_BUDGET_EACH 名额 → 半提交行
   拿双倍分挤掉真条目）；card_forge 的排除集从「这次抽中的 facts」改成「全部活跃 raw」
   （原来只要这轮没抽中，半提交行就会作为『久远记忆』发出去）。第四个 _aarchived_by_id
   只在 facts_by_id 未命中时才查归档、active 天然优先，不需要改。
   这不是「顺手加的防御」——它是这套提交协议的读侧另一半，没有它顺序 A 就不安全。
4. **失败可见**：裸 except 拆成 MaintenanceModeError(debug，且**不 touch marker**，
   维护态是预期跳过，touch 了等于每次 save 续 24h 冷却) / 真失败(warning + exc_info，
   照常 touch marker，否则每次 save 都重跑必然失败的归档) / 外层冷却判定失败(debug)。

顺带把 facts.clear()/extend(active) 换成按身份剔除已归档行：add_facts 在 aload_facts 之后
直接 append 且不持 _get_lock（仓库既有约定），用快照整体替换会吞掉这期间并发 append 进来
的行，而新写序把这个窗口从一次写盘拉长到两次。按身份剔除让窗口归零。

## (b) legacy fact 重判的熔断计数在它要防的场景下必然失效

_bump_fact_recheck_attempts 调 save_facts 写的是**同一个** facts.json —— 只读 FS / 权限下
必然同样失败；而且 save_facts 失败时会 self._facts.pop(name) 把刚 +1 的改动一起扔掉。
磁盘和缓存上计数都停在 0，于是每 30s 一次 LLM 调用 + 一次失败写盘，永不停。
注释里写的「否则持续写盘失败会让熔断永不触发」正好描述了它自己。

照本仓库已有的正确范式（ReflectionEngine._synth_backoff_mem）加进程内镜像：先记镜像
（不可能失败）再尽力落盘，写失败只 WARN。镜像必须**同时带时刻** —— cooldown_elapsed(None,…)
返回 True，只补计数会被 5h 自愈分支立刻放回队列，等于白修。
用 class 级默认 None + 惰性访问器（仓库有 4 处 FactStore.__new__ 绕过 __init__），
另配一把模块级 bootstrap 锁——惰性创建「那把 guard 锁」本身是有竞争的。

## (c) topic signals 的无界重试 + atexit 上注定跑不了的 timer

flush() 的固定 1s 无上限重试改成有界指数退避（base×2^n，cap 16s，5 次，成功即清预算），
耗尽后保持 dirty 等下一次真实数据变更再试。atexit.register(self.flush) 换成 _atexit_flush()
包装：退出路径失败时**不排 timer**、如实 WARNING 报告丢盘（daemon Timer 在 atexit 里
delay 到达前进程就 finalize 了，回调永不执行 —— 原代码等于「假装安排了重试」）。
模块原来完全没有 logger，这是它能静默重试和静默丢盘的一半原因。

pipeline._persist_used_topics —— 如实结论：**不加重试、不上抛**。失败后果只是跨重启丢一次
used-topic 历史（同话题可能重投一次），而上抛会在只读盘上直接压掉 topic 投递、明显更糟。
唯一改的是 logger.debug → warning：debug 在生产默认 INFO 下等于不可见。

## 一轮对抗性审跑了 29 个变异，25 红 4 存活，7 条意见全部处理

存活的 4 条各自指向一条「写了实现但没人验」的主张，都补了测试：
- later-wins 的**方向**没测（原用例用两行完全相同的数据，测不出方向）；
- 熔断计数落盘失败的 WARNING 没测，且真维护态下会误报（已降级 debug）；
- 退避 cap 在生产默认 base 下恰好等于末项、min() 永不生效，测试也硬编码了 base；
- _recheck_budget_open 的 at 回落分支不可达 → 删掉，改由「镜像必带 at」这条不变量兜
  （5 条测试钉住，比原来那个测不到的 or 强）。

最重的一条是读侧收敛只覆盖了四个 reader 中的一个（见上面 (a).3），审阅给了实测对照：
半提交后 hybrid bm25 pool 里同一 id 出现两次。而新写序把这个缺口的暴露时间从「下一次
save」（秒级）拉长到「下一次成功归档」（被 archive mtime + marker 双重门到 ≥24h）。

本轮新做 12 个变异，全部红。

验证：相关测试 504 passed 连跑 3 次；全量 tests/unit 8876 passed, 45 skipped（269s，
pytest 自身退出码 0）；ruff 与 docstring 禁 CJK 门（--base origin/main）均通过。

Refs #2528

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


## 回归报告

**改动**：`memory/facts.py` 的归档提交协议（合并代替追加、改缓存挪到写盘之后、按身份剔除、失败分级可见）+ 熔断计数改走进程内镜像；`memory/hybrid_recall.py` 与 `main_logic/card_forge_facts.py` 补读侧收敛；`main_logic/topic/signals.py` 的重试改成有界退避 + atexit 路径不排注定跑不了的 timer；`main_logic/topic/pipeline.py` 一处日志级别。新增/扩充 6 个测试文件。

**必要性**：(a) 会在用户磁盘上留**永久重复数据**，重复行进 RRF 召回时拿双倍分并占两个预算名额、进 card_forge 时作为「久远记忆」重复发出；(b) 熔断计数写进它自己要防的那个写不进去的文件，只读盘上变成每 30s 一次 LLM 调用 + 一次失败写盘、永不停；(c) 每秒一次静默写盘尝试 + 退出时假装安排了重试实际静默丢盘。

**改动前 → 改动后**：

- 前：归档重试 `extend` 追加 → 同一条 fact 在 archive 里永久两份。后：按 id 幂等合并，且**顺带修好已经落在用户盘上的历史重复**。
- 前：半提交后缓存少 k 条、磁盘多 k 条、archive 多 k 条。后：缓存与 `facts.json` 始终一致，只剩 archive 多 k 条这一个可收敛偏差，四个读者里需要收敛的三个都收敛了。
- 前：归档失败完全静默（连日志都没有）。后：真失败 warning + `exc_info`，维护态 debug 且不消耗 24h 归档窗口。
- 前：只读盘上 recheck 熔断永不触发。后：镜像先记（不可能失败）再尽力落盘，熔断按 `MAX_ATTEMPTS` 正常冻结，5h 自愈窗口每轮只放行一次。
- 前：signals 每秒一次无上限静默重试；退出时起一个永不执行的 daemon timer。后：5 次指数退避（cap 16s）后 give-up 并保持 dirty（下一次真实数据变更仍会再试）；退出路径如实 WARNING 报告丢盘。
- 未改动的行为：归档的触发条件、冷却窗口、`save_facts` 的 read-merge 语义、`_persist_used_topics` 的吞异常（只改了日志级别）。

**潜在回归**：

1. `load_facts_full` / `hybrid_recall` / `recall_by_time` 会丢弃「id 已在 active」的 archive 行。收敛到 active 是因为它至少一样新（`absorbed` / `signal_processed` 等 monotonic 标记以它为准），且每次都带 WARNING —— 是**带探测器的兜底**而不是把上游 bug 盖住。
2. `card_forge` 的排除集从「抽中的 facts」扩大到「全部活跃 raw」，会让「久远记忆」候选池变小一点。这是有意的：活跃 fact 本来就不该以「久远记忆」的身份再发一次。
3. 熔断镜像是进程内状态，重启后从磁盘那栏起算（首次进镜像时读盘上的 `recheck_attempts`），所以跨重启不会清零；但**磁盘写不进去时重启确实会丢已累计的部分** —— 这是「镜像兜底」这个模式的固有代价，比原来「永远停在 0」好。
4. signals 的退避在 `flush_delay=0` 时塌成 5 个零延迟 timer（仍有界，有测试钉住）。
5. 按身份剔除（`id(f)`）依赖 `to_archive` 在函数返回前持有强引用 —— 已核对生命周期。

**验证**：全量 `tests/unit` **8876 passed, 45 skipped**；相关测试 504 passed 连跑 3 次；`ruff check` 全仓库通过；`check_docstring_no_cjk.py --base origin/main` 退出码 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
