### PR TITLE
refactor(realtime): 把 response.done 的 per-turn 清理抽成共享函数并补测试

### DIFF
--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -922,6 +922,40 @@ class _TransportMixin:
 
         return False
 
+    def _reset_per_turn_output_state(self) -> None:
+        """Clear the transport state scoped to one response.
+
+        Extracted from the ``response.done`` handler so any future path that
+        ends a turn without its terminal event has one place to call rather
+        than a list to re-derive. Every field here leaks into the NEXT turn if
+        it is missed: a stale ``_image_sent_this_turn`` makes ``stream_image``
+        withhold that turn's visual context for its whole duration, a stale
+        transcript buffer is flushed against the wrong turn, and
+        ``_audio_delta_count`` drives the "did this turn actually speak"
+        checks.
+
+        Behaviour is unchanged — this is the same block, in the same order,
+        with the same conditions.
+        """
+
+        self._audio_delta_count = 0
+        # 确保 buffer 被清空
+        self._output_transcript_buffer = ""
+        self._print_input_transcript = False
+        if self._supports_native_image:
+            self._image_recognized_this_turn = False
+        elif (
+            self._latest_image_b64 is None
+            or self._proactive_image_consumed
+        ):
+            # Standard StepFun analyzes only while this sentinel is
+            # present. Rearm after a consumed/absent frame, but keep
+            # a completed annotation generation-bound to an
+            # unconsumed cached frame across unrelated responses.
+            self._image_recognized_this_turn = False
+            self._image_description = _IMAGE_ANALYSIS_PENDING_DESCRIPTION
+        self._image_sent_this_turn = False
+
     async def handle_interruption(self):
         """Handle user interruption of the current response."""
         if not self._is_responding:
@@ -1188,23 +1222,7 @@ class _TransportMixin:
                             self._output_transcript_buffer, self._is_first_transcript_chunk
                         )
                         self._is_first_transcript_chunk = False
-                    self._audio_delta_count = 0
-                    # 确保 buffer 被清空
-                    self._output_transcript_buffer = ""
-                    self._print_input_transcript = False
-                    if self._supports_native_image:
-                        self._image_recognized_this_turn = False
-                    elif (
-                        self._latest_image_b64 is None
-                        or self._proactive_image_consumed
-                    ):
-                        # Standard StepFun analyzes only while this sentinel is
-                        # present. Rearm after a consumed/absent frame, but keep
-                        # a completed annotation generation-bound to an
-                        # unconsumed cached frame across unrelated responses.
-                        self._image_recognized_this_turn = False
-                        self._image_description = _IMAGE_ANALYSIS_PENDING_DESCRIPTION
-                    self._image_sent_this_turn = False
+                    self._reset_per_turn_output_state()
                     if self.on_response_done:
                         await self.on_response_done()
                     # No-server-VAD providers (Gemini-proxy: lanlan.app+free /

--- a/tests/unit/test_realtime_arbiter_native_path.py
+++ b/tests/unit/test_realtime_arbiter_native_path.py
@@ -307,6 +307,47 @@ async def test_reconnect_restores_dispatch_for_a_native_client():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_a_terminal_resets_the_per_turn_output_state():
+    # The per-turn cleanup in the response.done handler had no coverage at
+    # all: deleting the whole block turned nothing red. It is worth pinning on
+    # its own — _image_sent_this_turn in particular, because a stale one makes
+    # stream_image withhold the NEXT turn's visual context for its whole
+    # duration, so that response answers about a screen it cannot see.
+    #
+    # It is also the safety net for the extraction this commit performs: a
+    # helper nobody tests can be moved wrong without anything noticing.
+    client = _native_client()
+    socket = _RecordingSocket()
+    client.ws = socket
+    receive_loop = asyncio.create_task(client.handle_messages())
+
+    socket.feed({"type": "response.created", "response": {"id": "resp-1"}})
+    await _settle()
+    # Dirty the state AFTER response.created: that handler clears the
+    # transcript buffer itself, so seeding before it would leave this test
+    # asserting a value nobody had to produce.
+    client._audio_delta_count = 5
+    client._output_transcript_buffer = "leftover"
+    client._print_input_transcript = True
+    client._image_sent_this_turn = True
+
+    socket.feed({"type": "response.done", "response": {"id": "resp-1"}})
+    await _settle()
+
+    assert client._audio_delta_count == 0
+    assert client._output_transcript_buffer == ""
+    assert client._print_input_transcript is False
+    assert client._image_sent_this_turn is False, (
+        "a stale image flag makes stream_image withhold the next turn's "
+        "visual context for its whole duration"
+    )
+
+    socket.finish()
+    await asyncio.wait_for(receive_loop, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_the_client_wires_an_arbiter_for_every_native_user():
     # The premise of this whole file: the arbiter is not opt-in. If it ever
     # becomes gated, these tests would pass vacuously against a bypass.

--- a/tests/unit/test_realtime_arbiter_native_path.py
+++ b/tests/unit/test_realtime_arbiter_native_path.py
@@ -44,6 +44,9 @@ import pytest
 from main_logic.omni_realtime_client import OmniRealtimeClient
 from main_logic.omni_realtime_client import _response_arbiter as _arbiter_module
 from main_logic.omni_realtime_client._response_arbiter import RealtimeResponseArbiter
+from main_logic.omni_realtime_client._shared import (
+    _IMAGE_ANALYSIS_PENDING_DESCRIPTION,
+)
 from main_logic.tool_calling import ToolResult
 
 
@@ -325,11 +328,14 @@ async def test_a_terminal_resets_the_per_turn_output_state():
     await _settle()
     # Dirty the state AFTER response.created: that handler clears the
     # transcript buffer itself, so seeding before it would leave this test
-    # asserting a value nobody had to produce.
+    # asserting a value nobody had to produce. Every field the helper clears
+    # is seeded — a field left at its default makes its reset deletable
+    # without this test noticing.
     client._audio_delta_count = 5
     client._output_transcript_buffer = "leftover"
     client._print_input_transcript = True
     client._image_sent_this_turn = True
+    client._image_recognized_this_turn = True
 
     socket.feed({"type": "response.done", "response": {"id": "resp-1"}})
     await _settle()
@@ -340,6 +346,40 @@ async def test_a_terminal_resets_the_per_turn_output_state():
     assert client._image_sent_this_turn is False, (
         "a stale image flag makes stream_image withhold the next turn's "
         "visual context for its whole duration"
+    )
+    assert client._image_recognized_this_turn is False
+
+    socket.finish()
+    await asyncio.wait_for(receive_loop, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_terminal_rearms_analysis_on_a_non_native_image_provider():
+    # The helper has two branches and the case above only exercises one.
+    # Standard StepFun is the sole provider without native image input: it
+    # re-arms the pending sentinel instead, and only while the cached frame is
+    # absent or already consumed. Without this, the elif could be deleted
+    # wholesale and the suite would stay green.
+    client = _native_client(api_type="step", model="step-realtime")
+    assert client._supports_native_image is False, "this is the elif branch"
+    socket = _RecordingSocket()
+    client.ws = socket
+    receive_loop = asyncio.create_task(client.handle_messages())
+
+    socket.feed({"type": "response.created", "response": {"id": "resp-1"}})
+    await _settle()
+    client._image_recognized_this_turn = True
+    client._image_description = "an analysis from the turn being ended"
+    client._latest_image_b64 = None  # absent frame -> re-arm
+
+    socket.feed({"type": "response.done", "response": {"id": "resp-1"}})
+    await _settle()
+
+    assert client._image_recognized_this_turn is False
+    assert client._image_description == _IMAGE_ANALYSIS_PENDING_DESCRIPTION, (
+        "StepFun analyzes only while the sentinel is present, so ending a "
+        "turn with no cached frame has to re-arm it"
     )
 
     socket.finish()


### PR DESCRIPTION
## 这个 PR 已缩范围

原本它是 #2583 的 fail-open 逃生阀。七轮自动评审在那条 release 路径上累计发现 20+ 条 P2，其中两条由前一轮的修复自己引入，还有一条是我把错误契约写进了测试。

结构性结论：**release 路径变成了「轮次终结」的第二套实现**，而轮次终结不是一个函数，是散布在 arbiter 状态、transport per-turn 状态、宿主回调、身份归属、派发顺序上的一组不变量。逐轮打补丁没有收敛迹象。

经维护者拍板：**fail-open 从本 PR 撤出，按单一实现（`_finalize_turn(reason, identity)`）在新 PR 重做**；本 PR 只保留那期间唯一独立成立、且行为中性的部分。

## 现在改了什么

把 `response.done` 里那段 per-turn 清理提成 `_reset_per_turn_output_state()`，从原处调用。**同一段代码、同一顺序、同样的条件判断 —— 零行为变化。**

值得命名的理由是这份清单很容易被少抄一项，而每一项漏掉都会串到下一轮：

- `_image_sent_this_turn` 残留 → `stream_image` 把**下一整轮**的视觉上下文压住，那轮在答一个它看不见的屏幕
- `_output_transcript_buffer` 残留 → 被冲到错误的轮次上
- `_audio_delta_count` 残留 → 「这轮到底出没出声」的判断失真

## 顺带补上它从未有过的覆盖

⚠️ 这段清理**此前零测试** —— 整块删掉，全套测试没有一条变红。对一次抽取来说这是最差的起点：搬错了没人会知道。

新增 `test_a_terminal_resets_the_per_turn_output_state`（真 client + 真 receive loop 驱动一整轮到 `response.done`），5 条变异各自打红：删掉调用、以及分别删掉 helper 清的四个字段。

⚠️ 该用例第一版有一处**空断言**：我在喂 `response.created` **之前**设脏值，而 created 处理器自己会清 `_output_transcript_buffer` —— 于是「buffer 被清空」这条断言不需要被测代码做任何事就成立。变异 M3 抓到了，已把脏值挪到 created 之后。

## 回归报告

- **改动面**：2 文件、+73/-17。生产侧是纯移动，无行为变化；测试侧新增 1 条用例。
- **必要性**：抽取本身为后续的 `_finalize_turn` 铺路（那条路径需要同一份清理）；补测试是因为这段代码此前完全裸奔。
- **改前/改后**：行为逐字节相同。`response.done` 走到同一组赋值，只是经由一次函数调用。
- **潜在回归**：抽取可能少搬/错序 —— 由 5 条变异逐字段挡住。`_supports_native_image` 的 if/elif 分支结构原样保留（elif 里那两行只在非原生图像且帧已消费/缺失时执行，顺序不能改）。相关既有测试全绿：508 passed / 4 skipped。
- **不在范围**：fail-open 开关、三个 stand-down 条件、宿主收尾回调、`NEKO_REALTIME_ARBITER_FAIL_OPEN` 环境变量与其文档 —— 全部撤出，改由新 PR 按 `_finalize_turn` 重做。

## 相关

- #2583（保持 open，指向即将开的重做 PR）
- #2594 / #2595（七轮评审挖出的既有缺陷，与本 PR 正交）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 优化实时响应每轮结束后的状态清理，确保音频增量、转录信息及图像分析状态能够正确重置。
  * 修复特定图像分析场景下缓存帧缺失时的状态恢复问题，提升连续多轮交互的稳定性。

* **测试**
  * 增加实时响应处理及图像分析状态重置的回归测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->