### PR TITLE
修复角色返回时空闲计时未及时重置，导致自动变猫被连续触发的问题，并补充回归测试

### DIFF
--- a/static/app/app-auto-goodbye.js
+++ b/static/app/app-auto-goodbye.js
@@ -694,6 +694,23 @@
                 reason: state.lastReason,
             },
         }));
+        if (!isGoodbyeActive()) {
+            const rejectedReason = state.lastReason;
+            state.autoGoodbyeTriggered = false;
+            state.goodbyeEnteredAt = 0;
+            state.goodbyeWasAuto = false;
+            state.lastReason = 'auto-goodbye-rejected';
+            clearDragTierMemory();
+            setVisualTier(TIER_NONE, {
+                source: 'auto-goodbye-rejected',
+                reason: rejectedReason,
+            });
+            syncGoodbyeSilentState(false, 'auto-goodbye-rejected');
+            emitStateChange('auto-goodbye-rejected', {
+                reason: rejectedReason,
+            });
+            return false;
+        }
         emitStateChange('auto-goodbye-triggered', {
             reason: state.lastReason,
         });

--- a/static/app/app-auto-goodbye.js
+++ b/static/app/app-auto-goodbye.js
@@ -890,7 +890,15 @@
             if (detail.autoGoodbye === true) {
                 state.autoGoodbyeTriggered = true;
                 state.lastReason = typeof detail.reason === 'string' ? detail.reason : 'idle-timeout';
-                syncVisualTierFromCurrentState('goodbye-event');
+                // The surface listener applies its manager-level goodbye flags after this
+                // controller in some Electron startup orders. Derive the tier from the
+                // idle clock directly so a not-yet-applied UI flag cannot clear the
+                // auto-goodbye latch in the same dispatch.
+                const targetTier = getTargetTierForElapsed(getVisualTierElapsedForCurrentState());
+                setVisualTier(targetTier === TIER_NONE ? TIER_CAT1 : targetTier, {
+                    source: 'goodbye-event',
+                    reason: state.lastReason,
+                });
             } else {
                 const isStartupDefaultCat = detail.startupDefaultForm === 'cat';
                 state.autoGoodbyeTriggered = false;
@@ -915,6 +923,10 @@
             // Returning is an explicit user override of any startup request still waiting for avatar readiness.
             cancelStartupDefaultCatRequest(true);
             syncGoodbyeSilentState(false, 'return-click');
+            // Commit is the first accepted user-return boundary. Refresh the idle
+            // clock here rather than waiting for the asynchronous model settle so
+            // the interval cannot dispatch another goodbye during that gap.
+            markIdleBaseline('return-click');
             if (!state.pendingReturnSnapshot) {
                 state.pendingReturnSnapshot = {
                     hadCatCycle: detail.hadCatCycle === true,

--- a/tests/unit/test_app_auto_goodbye_phase1.py
+++ b/tests/unit/test_app_auto_goodbye_phase1.py
@@ -199,14 +199,17 @@ def test_app_auto_goodbye_phase1_harness():
           }};
 
           // Simulate the existing goodbye / return base chain.
-          win.addEventListener('live2d-goodbye-click', (event) => {{
+          const applySurfaceGoodbye = (event) => {{
             if (options.applyGoodbyeImmediately !== false) {{
               win.live2dManager._goodbyeClicked = true;
               win.vrmManager._goodbyeClicked = true;
               win.mmdManager._goodbyeClicked = true;
             }}
             goodbyeEvents.push(event.detail || {{}});
-          }});
+          }};
+          if (options.goodbyeListenerOrder !== 'after-controller') {{
+            win.addEventListener('live2d-goodbye-click', applySurfaceGoodbye);
+          }}
           win.addEventListener('live2d-return-click', () => {{
             win.live2dManager._goodbyeClicked = false;
             win.vrmManager._goodbyeClicked = false;
@@ -238,6 +241,9 @@ def test_app_auto_goodbye_phase1_harness():
 
           vm.createContext(context);
           vm.runInContext(source, context);
+          if (options.goodbyeListenerOrder === 'after-controller') {{
+            win.addEventListener('live2d-goodbye-click', applySurfaceGoodbye);
+          }}
 
           return {{
             win,
@@ -393,7 +399,7 @@ def test_app_auto_goodbye_phase1_harness():
           // The auto latch must survive until the surface applies its manager flags.
           const deferredGoodbye = createHarness('/', {{
             barrierResolved: true,
-            applyGoodbyeImmediately: false
+            goodbyeListenerOrder: 'after-controller'
           }});
           await deferredGoodbye.flush();
           deferredGoodbye.setSocketOpen(true);
@@ -404,6 +410,28 @@ def test_app_auto_goodbye_phase1_harness():
           assert(deferredGoodbye.goodbyeEvents.length === 1, 'deferred surface should receive one auto-goodbye request');
           assert(beforeSurfaceGoodbyeApply.autoGoodbyeTriggered === true, 'surface listener order must not clear the auto latch');
           assert(beforeSurfaceGoodbyeApply.visualTier === 'cat1', 'surface listener order must not clear the auto tier');
+
+          // A busy model-to-cat transition can reject the surface request. The
+          // controller must roll back its latch and silent state so a later tick retries.
+          const rejectedGoodbye = createHarness('/', {{
+            barrierResolved: true,
+            goodbyeListenerOrder: 'after-controller',
+            applyGoodbyeImmediately: false
+          }});
+          await rejectedGoodbye.flush();
+          rejectedGoodbye.setSocketOpen(true);
+          rejectedGoodbye.tickAll();
+          rejectedGoodbye.advance(AUTO_GOODBYE_MS);
+          rejectedGoodbye.tickAll();
+          const afterRejectedGoodbye = rejectedGoodbye.win.nekoAutoGoodbye.getState();
+          assert(rejectedGoodbye.goodbyeEvents.length === 1, 'surface should receive the rejected auto-goodbye request');
+          assert(afterRejectedGoodbye.autoGoodbyeTriggered === false, 'rejected surface request should clear the auto latch');
+          assert(afterRejectedGoodbye.visualTier === 'none', 'rejected surface request should clear the speculative cat tier');
+          const rejectedSilentStates = rejectedGoodbye.sentMessages.filter((message) => message && message.action === 'goodbye_state');
+          assert(rejectedSilentStates.at(-1).active === false, 'rejected surface request should restore goodbye silence to inactive');
+          rejectedGoodbye.advance(500);
+          rejectedGoodbye.tickAll();
+          assert(rejectedGoodbye.goodbyeEvents.length === 2, 'a later idle tick should retry after surface rejection');
 
           // Desktop can keep conversation/system blockers alive after the model is hidden;
           // those blockers must not freeze the goodbye cat in CAT1.

--- a/tests/unit/test_app_auto_goodbye_phase1.py
+++ b/tests/unit/test_app_auto_goodbye_phase1.py
@@ -200,9 +200,11 @@ def test_app_auto_goodbye_phase1_harness():
 
           // Simulate the existing goodbye / return base chain.
           win.addEventListener('live2d-goodbye-click', (event) => {{
-            win.live2dManager._goodbyeClicked = true;
-            win.vrmManager._goodbyeClicked = true;
-            win.mmdManager._goodbyeClicked = true;
+            if (options.applyGoodbyeImmediately !== false) {{
+              win.live2dManager._goodbyeClicked = true;
+              win.vrmManager._goodbyeClicked = true;
+              win.mmdManager._goodbyeClicked = true;
+            }}
             goodbyeEvents.push(event.detail || {{}});
           }});
           win.addEventListener('live2d-return-click', () => {{
@@ -242,6 +244,9 @@ def test_app_auto_goodbye_phase1_harness():
             doc,
             goodbyeEvents,
             sentMessages,
+            now() {{
+              return now;
+            }},
             advance(ms) {{
               now += ms;
             }},
@@ -384,6 +389,22 @@ def test_app_auto_goodbye_phase1_harness():
           assert(home.goodbyeEvents[0].autoGoodbye === true, 'auto-goodbye detail should be preserved');
           assert(home.win.nekoAutoGoodbye.getState().visualTier === 'cat1', 'auto-goodbye should move to cat1');
 
+          // Electron can register the auto controller before the surface listener.
+          // The auto latch must survive until the surface applies its manager flags.
+          const deferredGoodbye = createHarness('/', {{
+            barrierResolved: true,
+            applyGoodbyeImmediately: false
+          }});
+          await deferredGoodbye.flush();
+          deferredGoodbye.setSocketOpen(true);
+          deferredGoodbye.tickAll();
+          deferredGoodbye.advance(AUTO_GOODBYE_MS);
+          deferredGoodbye.tickAll();
+          const beforeSurfaceGoodbyeApply = deferredGoodbye.win.nekoAutoGoodbye.getState();
+          assert(deferredGoodbye.goodbyeEvents.length === 1, 'deferred surface should receive one auto-goodbye request');
+          assert(beforeSurfaceGoodbyeApply.autoGoodbyeTriggered === true, 'surface listener order must not clear the auto latch');
+          assert(beforeSurfaceGoodbyeApply.visualTier === 'cat1', 'surface listener order must not clear the auto tier');
+
           // Desktop can keep conversation/system blockers alive after the model is hidden;
           // those blockers must not freeze the goodbye cat in CAT1.
           home.setAppState({{ isRecording: true }});
@@ -456,12 +477,34 @@ def test_app_auto_goodbye_phase1_harness():
           const afterReturnCommit = home.win.nekoAutoGoodbye.getState();
           assert(afterReturnCommit.visualTier === 'cat3', 'return commit should preserve visual tier until completion');
           assert(afterReturnCommit.autoGoodbyeTriggered === true, 'return commit should preserve auto flag until completion');
+          assert(afterReturnCommit.lastInteractionAt === home.now(), 'return commit should immediately refresh the idle baseline');
           home.win.dispatchEvent(new CustomEventLike('neko:cat-return-complete', {{
             detail: {{ source: 'live2d-return-click' }}
           }}));
           const returned = home.win.nekoAutoGoodbye.getState();
           assert(returned.visualTier === 'none', 'return should clear visual tier');
           assert(returned.autoGoodbyeTriggered === false, 'return should clear auto flag');
+
+          // A manual goodbye has no auto latch to mask the return-settle race.
+          // Commit must still prevent a new idle goodbye before completion.
+          const manualReturnRace = createHarness('/', {{ barrierResolved: true }});
+          await manualReturnRace.flush();
+          manualReturnRace.setSocketOpen(true);
+          manualReturnRace.tickAll();
+          manualReturnRace.advance(AUTO_GOODBYE_MS + 1000);
+          manualReturnRace.win.dispatchEvent(new CustomEventLike('live2d-goodbye-click', {{
+            detail: {{ source: 'manual-goodbye' }}
+          }}));
+          manualReturnRace.win.dispatchEvent(new CustomEventLike('live2d-return-click'));
+          manualReturnRace.win.dispatchEvent(new CustomEventLike('neko:cat-return-commit', {{
+            detail: {{ source: 'live2d-return-click', hadCatCycle: true }}
+          }}));
+          manualReturnRace.advance(1500);
+          manualReturnRace.tickAll();
+          assert(manualReturnRace.goodbyeEvents.length === 1, 'return settle gap must not dispatch another goodbye');
+          manualReturnRace.win.dispatchEvent(new CustomEventLike('neko:cat-return-complete', {{
+            detail: {{ source: 'live2d-return-click' }}
+          }}));
 
           // Running / queued tasks block; terminal tasks do not.
           const blocked = createHarness('/', {{ barrierResolved: true }});


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复角色返回时空闲计时未及时重置，导致自动变猫被连续触发的问题，并补充回归测试
修复长时间挂机自动变猫后请她回来有可能立即自动离开的情况

## 测试 / Testing

调整挂机变猫时间，测试已经修复后恢复为原来的10分钟


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复自动告别请求被拒绝后状态未正确回滚的问题。
  * 优化空闲时长与视觉层级同步，避免状态更新延迟导致误触发或状态丢失。
  * 用户确认返回后立即刷新空闲计时，避免恢复过程中重复触发自动告别。
  * 防止手动告别返回结算期间再次触发自动告别。

* **Tests**
  * 补充自动告别延迟状态、拒绝回滚、计时基线刷新及重复触发场景的测试覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->