### PR TITLE
feat(realtime): arbiter 卡死逃生阀重做——按不变量分组，而非逐条打补丁（#2583）

### DIFF
--- a/docs/config/environment-vars.md
+++ b/docs/config/environment-vars.md
@@ -79,7 +79,7 @@ a connection in that state can produce overlapping responses.
 The symptom worth setting it for is repeated disconnect-and-rebuild during
 voice conversation, with backend logs carrying:
 
-```
+```text
 response arbiter failing closed: <reason> (current=... owner=... queue_depth=...)
 ```
 
@@ -93,7 +93,7 @@ Keeping the connection is only defensible when the transport is still usable
 **and** the arbiter can still tell whose events are whose. When either half
 fails it tears down anyway and logs why:
 
-```
+```text
 response arbiter cannot keep the connection (<blocker>); failing closed despite the escape hatch
 ```
 
@@ -111,6 +111,23 @@ The blockers are:
 If every escalation in your logs carries one of these, the variable is working
 as designed and the disconnects have a different cause — attach those lines to
 the report rather than assuming the switch had no effect.
+
+### A third line: kept, but nothing was released
+
+Some escalations are raised over a response the arbiter never owned — a
+server-initiated one it can only cancel blindly. There is no turn to give up
+there, so the transport survives but the lane stays held by that response:
+
+```text
+response arbiter kept the transport but had no lifecycle to release: <reason> (lane held by server response ids: ..., queue_depth=N); the lane reopens when their terminal events arrive, or after 60s if none do
+```
+
+This is a delay, not a wedge, and in the common case a short one — the lane
+reopens the moment that response's terminal arrives. The full 60s only elapses
+when the terminal is lost outright. The ids are not retired early on purpose:
+the arbiter has no per-response activity signal, so it cannot tell a lost
+terminal from a response that is simply still speaking, and dispatching over a
+live one costs a silently dropped turn.
 
 ## Storage and local vectors
 

--- a/docs/config/environment-vars.md
+++ b/docs/config/environment-vars.md
@@ -106,6 +106,7 @@ The blockers are:
 | a transport write just failed | The connection refused a send moments earlier; on the fatal branch it has already dropped its socket. |
 | the abandoned response has no id to attribute later events by | Its `response.create` reached the provider, so it may still be announced — and without an id that announcement is indistinguishable from the next turn's. |
 | an announced server-VAD response has no id yet | The same, for a response the provider announced but has not yet identified. |
+| an unowned response is live with no id at all | A response nobody requested announced itself without an id. Nothing identifies it, so its terminal cannot be told from the next turn's and would end whichever turn holds the lane by then. |
 
 If every escalation in your logs carries one of these, the variable is working
 as designed and the disconnects have a different cause — attach those lines to

--- a/docs/config/environment-vars.md
+++ b/docs/config/environment-vars.md
@@ -112,6 +112,25 @@ If every escalation in your logs carries one of these, the variable is working
 as designed and the disconnects have a different cause — attach those lines to
 the report rather than assuming the switch had no effect.
 
+### What it cannot protect you from
+
+The blockers above cover what the arbiter can *see*. One thing it cannot:
+whether the events that follow will carry a response id at all.
+
+A provider that identifies its `response.created` but omits the id from the
+events after it puts the arbiter in a position with no good answer. The
+abandoned response's late audio, text and — worst — tool calls are then
+indistinguishable from the next turn's, so they are delivered as the next
+turn's. Keeping the connection is what exposes this: the default teardown
+takes the socket with it, and those late events never arrive.
+
+Nothing in the arbiter can pre-empt it, because the events it would have to
+judge are the ones it has not received yet, and suppressing id-less events
+after a release would suppress the successor's too — on such a provider they
+are id-less as well. So if you enable this on a provider whose streaming
+events lack `response_id`, treat a stuck turn as possibly leaking into the
+next one. Tracked in issue #2611.
+
 ### A third line: kept, but nothing was released
 
 Some escalations are raised over a response the arbiter never owned — a

--- a/docs/config/environment-vars.md
+++ b/docs/config/environment-vars.md
@@ -124,12 +124,28 @@ indistinguishable from the next turn's, so they are delivered as the next
 turn's. Keeping the connection is what exposes this: the default teardown
 takes the socket with it, and those late events never arrive.
 
-Nothing in the arbiter can pre-empt it, because the events it would have to
-judge are the ones it has not received yet, and suppressing id-less events
-after a release would suppress the successor's too — on such a provider they
-are id-less as well. So if you enable this on a provider whose streaming
-events lack `response_id`, treat a stuck turn as possibly leaking into the
-next one. Tracked in issue #2611.
+The window is bounded, though — an earlier version of this note claimed it
+could not be narrowed at all, and that was wrong. A release only happens when
+the abandoned response HAD an id, and ids come only from `response.created`,
+so any provider that can reach this state does announce identified responses.
+The successor's own announcement therefore always arrives before the
+successor's id-less events, on one ordered socket. The leak is confined to the
+gap between the release and that announcement.
+
+Tool calls are gated in exactly that gap, because a leaked sentence is wrong
+words while a leaked tool call is a side effect executed for a turn nobody is
+having. You will see:
+
+```text
+quarantined an id-less tool call arriving after a stuck-turn release
+```
+
+Audio and text are deliberately NOT gated there: suppressing them risks a mute
+host on a provider that never announces the successor, which is a worse
+failure than a stray half-sentence. So if you enable this on a provider whose
+streaming events lack `response_id`, still treat a stuck turn as possibly
+leaking its remaining words into the next one — just not its side effects.
+Tracked in issue #2611.
 
 ### A third line: kept, but nothing was released
 

--- a/docs/config/environment-vars.md
+++ b/docs/config/environment-vars.md
@@ -65,6 +65,52 @@ Keep multi-process mode for development, independent service supervision, or
 agent-failure isolation. `NEKO_MERGED=0` is the immediate rollback for packaged
 deployments.
 
+## Realtime voice escape hatches
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NEKO_REALTIME_ARBITER_FAIL_OPEN` | unset (off) | Changes what the realtime response arbiter does when a response cannot reach a terminal state. By default it tears the realtime WebSocket down, which the user sees as a disconnect and session rebuild. Set to `1`, `true`, `yes`, or `on` to end only the stuck turn and keep the connection. Read once when a voice session's client is constructed, so a change needs a restart. |
+
+Leave this unset unless you are actually hitting the failure. The default
+exists because the arbiter escalates precisely when its own bookkeeping about
+which response owns the connection has become untrustworthy, and continuing on
+a connection in that state can produce overlapping responses.
+
+The symptom worth setting it for is repeated disconnect-and-rebuild during
+voice conversation, with backend logs carrying:
+
+```
+response arbiter failing closed: <reason> (current=... owner=... queue_depth=...)
+```
+
+That line distinguishes an arbiter-initiated teardown from an upstream
+provider disconnect — absent it, the disconnect came from somewhere else and
+this variable will not help.
+
+### It still tears down sometimes, on purpose
+
+Keeping the connection is only defensible when the transport is still usable
+**and** the arbiter can still tell whose events are whose. When either half
+fails it tears down anyway and logs why:
+
+```
+response arbiter cannot keep the connection (<blocker>); failing closed despite the escape hatch
+```
+
+Seeing that with the variable set is expected behaviour, not a broken switch.
+The blockers are:
+
+| Blocker | Meaning |
+| --- | --- |
+| the queue consumer is suspended inside a transport write | Nothing the arbiter does to its own state unwinds that wait, and closing the transport is what releases it. |
+| a transport write just failed | The connection refused a send moments earlier; on the fatal branch it has already dropped its socket. |
+| the abandoned response has no id to attribute later events by | Its `response.create` reached the provider, so it may still be announced — and without an id that announcement is indistinguishable from the next turn's. |
+| an announced server-VAD response has no id yet | The same, for a response the provider announced but has not yet identified. |
+
+If every escalation in your logs carries one of these, the variable is working
+as designed and the disconnects have a different cause — attach those lines to
+the report rather than assuming the switch had no effect.
+
 ## Storage and local vectors
 
 | Variable | Meaning |

--- a/main_logic/omni_realtime_client/_client.py
+++ b/main_logic/omni_realtime_client/_client.py
@@ -174,6 +174,12 @@ class OmniRealtimeClient(_ToolingMixin, _AudioMixin, _TransportMixin, _ResponseM
         self._input_audio_committed_total = 0  # diagnostic: audio buffer commits observed
         self._last_input_audio_committed_time = 0.0
         self._response_created_total = 0  # diagnostic: response.created events observed
+        # Raised by a fail-open release, lowered by the next response.created.
+        # Inside that window an id-less event cannot be told apart from the
+        # successor's, and a tool call is the one kind whose leak has side
+        # effects rather than merely wrong words. Never set on the default
+        # fail-closed path, which has no release.
+        self._idless_quarantine = False
         self._last_response_created_time = 0.0
         self._response_done_total = 0  # diagnostic: response.done events observed
         # Response ids whose token usage has already been booked, so a

--- a/main_logic/omni_realtime_client/_client.py
+++ b/main_logic/omni_realtime_client/_client.py
@@ -146,6 +146,14 @@ class OmniRealtimeClient(_ToolingMixin, _AudioMixin, _TransportMixin, _ResponseM
         # an interrupted response's own terminal must still be able to finish
         # the turn it belongs to.
         self._turn_epoch = 0
+        # The value ``_turn_epoch`` had when the response ``_current_response_id``
+        # names began. A release must compare against THIS, not against the
+        # epoch it happens to read on entry: a barge-in advances ``_turn_epoch``
+        # at ``speech_stopped`` without clearing the tracked response id, so a
+        # release starting after that barge-in would otherwise adopt the
+        # successor's epoch as its own baseline and find itself trivially
+        # current.
+        self._current_turn_epoch = 0
         self._response_arbiter = RealtimeResponseArbiter(
             self.send_event,
             abort_transport=self._abort_failed_transport,

--- a/main_logic/omni_realtime_client/_client.py
+++ b/main_logic/omni_realtime_client/_client.py
@@ -27,6 +27,7 @@ from ._shared import (
     TurnDetectionMode,
     _IMAGE_ANALYSIS_PENDING_DESCRIPTION,
     asyncio,
+    response_arbiter_fail_open_enabled,
     soxr,
 )
 
@@ -140,6 +141,8 @@ class OmniRealtimeClient(_ToolingMixin, _AudioMixin, _TransportMixin, _ResponseM
         self._response_arbiter = RealtimeResponseArbiter(
             self.send_event,
             abort_transport=self._abort_failed_transport,
+            fail_open=response_arbiter_fail_open_enabled(),
+            on_stuck_release=self._on_arbiter_stuck_release,
         )
         # Track printing state for input and output transcripts
         self._is_first_text_chunk = False

--- a/main_logic/omni_realtime_client/_client.py
+++ b/main_logic/omni_realtime_client/_client.py
@@ -138,6 +138,14 @@ class OmniRealtimeClient(_ToolingMixin, _AudioMixin, _TransportMixin, _ResponseM
         self._current_response_id = None
         self._current_item_id = None
         self._is_responding = False
+        # Advanced once per turn START, by every writer that begins one. A
+        # fail-open release captures it and stops the moment it changes: an
+        # abandoned turn's end-of-turn hooks must not land on whatever turn is
+        # live by the time the host gets around to them. Nothing that ENDS a
+        # turn touches it — "this turn ended" is not "a new turn started", and
+        # an interrupted response's own terminal must still be able to finish
+        # the turn it belongs to.
+        self._turn_epoch = 0
         self._response_arbiter = RealtimeResponseArbiter(
             self.send_event,
             abort_transport=self._abort_failed_transport,

--- a/main_logic/omni_realtime_client/_client.py
+++ b/main_logic/omni_realtime_client/_client.py
@@ -168,6 +168,9 @@ class OmniRealtimeClient(_ToolingMixin, _AudioMixin, _TransportMixin, _ResponseM
         self._response_created_total = 0  # diagnostic: response.created events observed
         self._last_response_created_time = 0.0
         self._response_done_total = 0  # diagnostic: response.done events observed
+        # Response ids whose token usage has already been booked, so a
+        # repeated response.done cannot count the same turn twice.
+        self._usage_recorded_ids: list[str] = []
         self._last_response_done_time = 0.0
         self._last_response_transcript = ""
         self._speech_started_total = 0  # diagnostic: server VAD start events observed

--- a/main_logic/omni_realtime_client/_gemini_support.py
+++ b/main_logic/omni_realtime_client/_gemini_support.py
@@ -555,6 +555,7 @@ class _GeminiMixin:
                         or not _still_within_ai_window
                     )
                     self._is_responding = True
+                    self._turn_epoch += 1
                     if _is_new_turn and _can_clear_interrupted:
                         # Gemini has no response.created event; clear stale interrupt state only
                         # after SDK transcription or a quiet gap proves this is not a canceled tail.

--- a/main_logic/omni_realtime_client/_gemini_support.py
+++ b/main_logic/omni_realtime_client/_gemini_support.py
@@ -554,6 +554,20 @@ class _GeminiMixin:
                         or self._gemini_user_transcript_after_interrupt
                         or not _still_within_ai_window
                     )
+                    # The epoch bump below has no reader on this path today: a
+                    # Gemini client never enqueues through the arbiter (every
+                    # entry point takes an ``_is_gemini`` branch first), so
+                    # ``_on_arbiter_stuck_release`` — the epoch's only consumer
+                    # — cannot fire here. Maintained anyway because the
+                    # invariant is "every turn start advances the epoch", not
+                    # "every turn start something currently reads": once a turn
+                    # start stops advancing it, a release that DOES run cannot
+                    # tell that turn from its successor.
+                    #
+                    # Kept above the assignment, not between it and the bump:
+                    # ``test_every_turn_start_advances_the_epoch`` discovers
+                    # turn starts by proximity, so a comment wedged in there
+                    # reads as a missing bump.
                     self._is_responding = True
                     self._turn_epoch += 1
                     self._current_turn_epoch = self._turn_epoch

--- a/main_logic/omni_realtime_client/_gemini_support.py
+++ b/main_logic/omni_realtime_client/_gemini_support.py
@@ -556,6 +556,7 @@ class _GeminiMixin:
                     )
                     self._is_responding = True
                     self._turn_epoch += 1
+                    self._current_turn_epoch = self._turn_epoch
                     if _is_new_turn and _can_clear_interrupted:
                         # Gemini has no response.created event; clear stale interrupt state only
                         # after SDK transcription or a quiet gap proves this is not a canceled tail.

--- a/main_logic/omni_realtime_client/_response_arbiter.py
+++ b/main_logic/omni_realtime_client/_response_arbiter.py
@@ -1062,15 +1062,18 @@ class RealtimeResponseArbiter:
         # never resolve its ticket.
         released_owner = owner
         released_id = owner.response_id if owner is not None else None
-        # cancel_current()'s unowned branch escalates over a server-initiated
-        # response the arbiter never owned. There is no lifecycle to give up
-        # there, and the host must not be told to end a turn: it is tracking
-        # that server response, whose id this release deliberately keeps
-        # because the response may still be streaming. Telling the host to
-        # finalize would discard the turn on one side while the other side
-        # goes on tracking it, and the response's own later events would then
-        # be stale-filtered against an identity the host no longer holds.
-        had_lifecycle = current is not None or released_owner is not None
+        # Only a released OWNER is a turn the host should end. Two escalation
+        # routes reach here without one — cancel_current()'s unowned branch,
+        # and an idle-wait timeout on a request that is still queued — and in
+        # both the host may nonetheless be tracking a live server-initiated
+        # response, because ``response.created`` is what sets its identity and
+        # that event does not care who asked. Telling the host to finalize
+        # then discards the turn on one side while this release deliberately
+        # keeps that response's id on the other, and the response's own later
+        # deltas are stale-filtered against an identity the host no longer
+        # holds. A queued ``_current`` is not a turn: nothing of it has
+        # reached the provider under its own name.
+        had_lifecycle = released_owner is not None
         try:
             if self._on_stuck_release is not None and had_lifecycle:
                 await asyncio.wait_for(

--- a/main_logic/omni_realtime_client/_response_arbiter.py
+++ b/main_logic/omni_realtime_client/_response_arbiter.py
@@ -915,6 +915,14 @@ class RealtimeResponseArbiter:
                 observed.terminal is not None
                 and observed.terminal.done()
                 and not observed.terminal.cancelled()
+                # Completed WITH A RESULT. notify_error finishes this same
+                # future with set_exception when the provider reports a
+                # correlated error — during the cancel grace period, that is
+                # the ordinary way a stuck lifecycle ends — and an error is
+                # not an arrival. Treating it as one skipped the recovery
+                # entirely: no teardown, no release, and the lane left owned
+                # until some later timeout noticed.
+                and observed.terminal.exception() is None
             ):
                 # Its terminal actually arrived while this caller's timeout was
                 # firing. ``notify_response_terminal`` clears

--- a/main_logic/omni_realtime_client/_response_arbiter.py
+++ b/main_logic/omni_realtime_client/_response_arbiter.py
@@ -1368,8 +1368,20 @@ class RealtimeResponseArbiter:
                     "response dispatch interrupted by pending server VAD response"
                 )
             if queued.interrupted:
-                await self._worker_send({"type": "response.cancel"})
+                # Same shape as ``_cancel_after_timeout`` below, and for the
+                # same reason: with the send outside the try, a transport that
+                # refused this cancel raised straight past the escalation, so
+                # the connection that had just failed a write was never torn
+                # down. ``_worker_send``'s finally has already lowered the
+                # in-flight flag by then, which is why the failure has to be
+                # remembered rather than re-read.
+                cancel_write_failed = False
                 try:
+                    try:
+                        await self._worker_send({"type": "response.cancel"})
+                    except Exception:
+                        cancel_write_failed = True
+                        raise
                     await asyncio.wait_for(
                         asyncio.shield(queued.terminal), queued.cancel_timeout
                     )
@@ -1379,6 +1391,7 @@ class RealtimeResponseArbiter:
                     await self._escalate(
                         "interrupted response could not reach a terminal state",
                         observed=queued,
+                        transport_write_failed=cancel_write_failed,
                     )
                 raise RuntimeError("response dispatch interrupted")
             if not queued.ticket.sent.done():

--- a/main_logic/omni_realtime_client/_response_arbiter.py
+++ b/main_logic/omni_realtime_client/_response_arbiter.py
@@ -1091,7 +1091,16 @@ class RealtimeResponseArbiter:
             # rather than by force — it already knows to keep the lane closed
             # while a live server response is being tracked, and to arm the
             # staleness timer that eventually retires one.
-            self._release_lane_if_clear()
+            #
+            # It does NOT know about owners, though: every other caller either
+            # has just cleared the owner or guards on there being none. So does
+            # this one, because the owner here may not be the one it captured —
+            # a successor can take the lane while the host is being notified,
+            # and opening it over that successor is what lets the next
+            # response.create overlap a live response. Its own terminal path
+            # re-runs this check, exactly as the staleness timer's does.
+            if self._response_owner is None:
+                self._release_lane_if_clear()
             if current is None and released_owner is None:
                 # cancel_current()'s unowned branch escalates over a
                 # server-initiated response the arbiter never owned, so there

--- a/main_logic/omni_realtime_client/_response_arbiter.py
+++ b/main_logic/omni_realtime_client/_response_arbiter.py
@@ -112,6 +112,10 @@ class _QueuedResponse:
         default_factory=asyncio.Event,
         compare=False,
     )
+    # Set once this request's lifecycle has been escalated over. Several
+    # callers can be waiting on the same stuck request, and each of their
+    # timeouts fires independently; only the first escalation is meaningful.
+    escalated: bool = field(default=False, compare=False)
 
 
 class RealtimeResponseArbiter:
@@ -300,7 +304,10 @@ class RealtimeResponseArbiter:
         try:
             await asyncio.wait_for(asyncio.shield(current.completed), timeout)
         except asyncio.TimeoutError as original_timeout:
-            await self._fail_closed("response cancellation terminal event timed out")
+            await self._fail_closed(
+                "response cancellation terminal event timed out",
+                observed=current,
+            )
             raise original_timeout
 
     async def cancel_ticket(
@@ -341,7 +348,9 @@ class RealtimeResponseArbiter:
         try:
             await asyncio.wait_for(asyncio.shield(queued.completed), timeout)
         except asyncio.TimeoutError as original_timeout:
-            await self._fail_closed("targeted response cancellation timed out")
+            await self._fail_closed(
+                "targeted response cancellation timed out", observed=queued
+            )
             raise original_timeout
         return True
 
@@ -837,7 +846,56 @@ class RealtimeResponseArbiter:
                 queued.completed.set_result(None)
             self._queue.task_done()
 
-    async def _fail_closed(self, reason: str) -> None:
+    async def _fail_closed(
+        self,
+        reason: str,
+        *,
+        observed: _QueuedResponse | None = None,
+    ) -> None:
+        """Tear the transport down over a lifecycle that cannot terminate.
+
+        ``observed`` is the request whose failure the caller actually watched.
+        Escalation is scoped to it, and happens at most once:
+
+        - **Not current any more** — every caller here waited on one specific
+          request, and by the time its timeout fires the arbiter may already
+          have moved on: the stuck lifecycle completed, the worker selected
+          the next queued item, and ``_current``/``_response_owner`` now name
+          a perfectly healthy turn. Acting on "whatever is current" would tear
+          down that healthy turn instead.
+        - **Already escalated** — several callers can be waiting on the same
+          stuck request and their timeouts fire independently. Only the first
+          escalation is meaningful; repeating it would repeat every effect it
+          has, which for anything beyond a transport teardown means doing it
+          twice to the same turn.
+
+        Callers with nothing to name (an unowned server response) pass
+        nothing and keep the unscoped behaviour.
+        """
+
+        if observed is not None:
+            if observed.escalated:
+                logger.debug(
+                    "skipping duplicate escalation for %s (%s)",
+                    observed.source,
+                    reason,
+                )
+                return
+            if (
+                observed is not self._current
+                and observed is not self._response_owner
+            ):
+                logger.debug(
+                    "skipping stale escalation for %s (%s): that lifecycle is "
+                    "no longer current",
+                    observed.source,
+                    reason,
+                )
+                return
+            observed.escalated = True
+        await self._fail_closed_unscoped(reason)
+
+    async def _fail_closed_unscoped(self, reason: str) -> None:
         # This is the only chokepoint through which the arbiter tears down the
         # transport, and to the rest of the system the result is
         # indistinguishable from a provider-side disconnect (the receive loop
@@ -952,7 +1010,9 @@ class RealtimeResponseArbiter:
                 return_when=asyncio.FIRST_COMPLETED,
             )
             if not done:
-                await self._fail_closed("realtime response idle wait timed out")
+                await self._fail_closed(
+                    "realtime response idle wait timed out", observed=queued
+                )
                 raise asyncio.TimeoutError("realtime response idle wait timed out")
         finally:
             for waiter in waiters:
@@ -1054,7 +1114,8 @@ class RealtimeResponseArbiter:
                     if not queued.terminal.done():
                         queued.terminal.cancel()
                     await self._fail_closed(
-                        "interrupted response could not reach a terminal state"
+                        "interrupted response could not reach a terminal state",
+                        observed=queued,
                     )
                 raise RuntimeError("response dispatch interrupted")
             if not queued.ticket.sent.done():
@@ -1148,6 +1209,7 @@ class RealtimeResponseArbiter:
             if queued.terminal is not None and not queued.terminal.done():
                 queued.terminal.cancel()
             await self._fail_closed(
-                "response lifecycle could not reach a terminal state"
+                "response lifecycle could not reach a terminal state",
+                observed=queued,
             )
         raise original_timeout

--- a/main_logic/omni_realtime_client/_response_arbiter.py
+++ b/main_logic/omni_realtime_client/_response_arbiter.py
@@ -1092,14 +1092,33 @@ class RealtimeResponseArbiter:
             # while a live server response is being tracked, and to arm the
             # staleness timer that eventually retires one.
             self._release_lane_if_clear()
-            logger.warning(
-                "response arbiter failing open, transport kept: %s "
-                "(current=%s owner=%s queue_depth=%d)",
-                reason,
-                current.source if current is not None else None,
-                released_owner.source if released_owner is not None else None,
-                self._queue.qsize(),
-            )
+            if current is None and released_owner is None:
+                # cancel_current()'s unowned branch escalates over a
+                # server-initiated response the arbiter never owned, so there
+                # was no lifecycle here to release: the transport survives but
+                # nothing was given up, and the lane is still held by whatever
+                # server response ids are tracked. Saying "failing open" here
+                # reads as though a turn was dropped and the lane reopened,
+                # which sent people looking for the wrong thing.
+                logger.warning(
+                    "response arbiter kept the transport but had no lifecycle "
+                    "to release: %s (lane held by server response ids: %s, "
+                    "queue_depth=%d); the lane reopens when their terminal "
+                    "events arrive, or after %.0fs if none do",
+                    reason,
+                    ", ".join(self._server_response_ids) or "none",
+                    self._queue.qsize(),
+                    self._server_response_max_age,
+                )
+            else:
+                logger.warning(
+                    "response arbiter failing open, transport kept: %s "
+                    "(current=%s owner=%s queue_depth=%d)",
+                    reason,
+                    current.source if current is not None else None,
+                    released_owner.source if released_owner is not None else None,
+                    self._queue.qsize(),
+                )
 
     async def _tear_down_transport(self, reason: str) -> None:
         # This is the only chokepoint through which the arbiter tears down the

--- a/main_logic/omni_realtime_client/_response_arbiter.py
+++ b/main_logic/omni_realtime_client/_response_arbiter.py
@@ -911,6 +911,30 @@ class RealtimeResponseArbiter:
                     reason,
                 )
                 return
+            if (
+                observed.terminal is not None
+                and observed.terminal.done()
+                and not observed.terminal.cancelled()
+            ):
+                # Its terminal actually arrived while this caller's timeout was
+                # firing. ``notify_response_terminal`` clears
+                # ``_response_owner`` synchronously but the worker has not run
+                # its ``finally`` yet, so ``_current`` still names a request
+                # that is, in fact, done. Escalating here would end a completed
+                # turn a second time — duplicate host finalization under
+                # fail-open, and a teardown over a terminal that just landed
+                # under the default.
+                #
+                # ``cancelled()`` is excluded on purpose: the escalation paths
+                # themselves cancel this future immediately before calling in,
+                # so treating that as an arrival would suppress every real
+                # escalation.
+                logger.debug(
+                    "skipping escalation for %s (%s): its terminal arrived",
+                    observed.source,
+                    reason,
+                )
+                return
             observed.escalated = True
 
         blocker = self._cannot_keep_the_connection(
@@ -1035,16 +1059,18 @@ class RealtimeResponseArbiter:
                     "stuck-release host notification failed: %s", exc_host
                 )
 
-        # Give up on the bookkeeping just declared untrustworthy: leaving the
-        # owner or the remembered ids in place would hold the lane closed
-        # waiting for terminals nobody expects any more.
+        # Give up on THIS turn's bookkeeping, and only this turn's. The
+        # remembered server response ids belong to separately initiated
+        # responses that are still tracking normally: clearing them would
+        # discard a live response's identity, and the next queued create would
+        # then overlap it. Nothing about the abandoned owner makes those
+        # untrustworthy.
         self._response_owner = None
-        self._server_response_active = False
-        self._server_vad_response_pending = False
-        self._server_response_ids.clear()
-        self._cancel_server_vad_pending_timer()
-        self._cancel_stale_release_timer()
-        self._idle.set()
+        # Which is why the lane reopens through the ordinary release check
+        # rather than by force — it already knows to keep the lane closed
+        # while a live server response is being tracked, and to arm the
+        # staleness timer that eventually retires one.
+        self._release_lane_if_clear()
         logger.warning(
             "response arbiter failing open, transport kept: %s "
             "(current=%s owner=%s queue_depth=%d)",

--- a/main_logic/omni_realtime_client/_response_arbiter.py
+++ b/main_logic/omni_realtime_client/_response_arbiter.py
@@ -1062,8 +1062,17 @@ class RealtimeResponseArbiter:
         # never resolve its ticket.
         released_owner = owner
         released_id = owner.response_id if owner is not None else None
+        # cancel_current()'s unowned branch escalates over a server-initiated
+        # response the arbiter never owned. There is no lifecycle to give up
+        # there, and the host must not be told to end a turn: it is tracking
+        # that server response, whose id this release deliberately keeps
+        # because the response may still be streaming. Telling the host to
+        # finalize would discard the turn on one side while the other side
+        # goes on tracking it, and the response's own later events would then
+        # be stale-filtered against an identity the host no longer holds.
+        had_lifecycle = current is not None or released_owner is not None
         try:
-            if self._on_stuck_release is not None:
+            if self._on_stuck_release is not None and had_lifecycle:
                 await asyncio.wait_for(
                     self._on_stuck_release(reason, released_id),
                     _STUCK_RELEASE_NOTIFY_TIMEOUT,

--- a/main_logic/omni_realtime_client/_response_arbiter.py
+++ b/main_logic/omni_realtime_client/_response_arbiter.py
@@ -949,7 +949,7 @@ class RealtimeResponseArbiter:
             transport_write_failed=transport_write_failed
         )
         if self._fail_open and blocker is None:
-            await self._release_stuck_lifecycle(reason)
+            await self._release_stuck_lifecycle(reason, observed=observed)
             return
         if self._fail_open:
             logger.warning(
@@ -1028,7 +1028,9 @@ class RealtimeResponseArbiter:
         finally:
             self._worker_send_in_flight = False
 
-    async def _release_stuck_lifecycle(self, reason: str) -> None:
+    async def _release_stuck_lifecycle(
+        self, reason: str, *, observed: _QueuedResponse | None = None
+    ) -> None:
         """Drop the stuck turn and keep the connection.
 
         Deliberately narrower than ``_mark_connection_lost``, which is for a
@@ -1050,16 +1052,23 @@ class RealtimeResponseArbiter:
         exc = RuntimeError(reason)
         owner = self._response_owner
         current = self._current
-        seen: set[int] = set()
-        for target in (owner, current):
-            if target is None or id(target) in seen:
-                continue
-            seen.add(id(target))
-            # Unwinds ``_process`` now rather than letting it park until its
-            # own timeout escalates a second time.
-            target.interrupted = True
-            target.interrupt_event.set()
-            self._wake_current_with_error(target, exc)
+        # Wake the request the CALLER watched, and only that one. The scoping
+        # check in ``_escalate`` has already established it is still the
+        # current or the owning lifecycle, so this both unwinds ``_process``
+        # now — rather than letting it park until its own timeout escalates a
+        # second time — and cannot reach anything else.
+        #
+        # "Anything else" is not hypothetical: ``cancel_current``'s unowned
+        # branch names nothing, because what is stuck there is a
+        # server-initiated response that has no ticket at all. A request
+        # enqueued while that cancellation waits becomes ``_current`` as the
+        # worker parks behind the live server response — undispatched, and
+        # nothing to do with the stuck lifecycle. Failing it would drain
+        # queued work, which ``cancel_current`` documents that it never does.
+        if observed is not None:
+            observed.interrupted = True
+            observed.interrupt_event.set()
+            self._wake_current_with_error(observed, exc)
 
         # Everything below straddles an await, so the release is scoped to
         # what was captured before it and finishes even if this task is

--- a/main_logic/omni_realtime_client/_response_arbiter.py
+++ b/main_logic/omni_realtime_client/_response_arbiter.py
@@ -19,6 +19,7 @@ from typing import Any, Awaitable, Callable
 
 SendEvent = Callable[[dict[str, Any]], Awaitable[None]]
 AbortTransport = Callable[[str], Awaitable[None]]
+OnStuckRelease = Callable[[str], Awaitable[None]]
 logger = logging.getLogger(__name__)
 
 # Server-initiated response ids are remembered so their terminal events are
@@ -53,6 +54,11 @@ _DEFAULT_RESPONSE_DONE_TIMEOUT = 60.0
 # provider-side pre-creation failure cannot wedge the lane until the much
 # longer running-response timeout tears down an otherwise healthy connection.
 _SERVER_VAD_RESPONSE_STARTED_TIMEOUT = 5.0
+# Ceiling on the host's end-of-turn notification during a fail-open release.
+# Escalations raised inside ``_process`` run it on the sole queue consumer,
+# so an unbounded host callback would stall every later dispatch; short
+# because the work it fronts is local bookkeeping plus one frontend send.
+_STUCK_RELEASE_NOTIFY_TIMEOUT = 2.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -132,9 +138,21 @@ class RealtimeResponseArbiter:
         send_event: SendEvent,
         *,
         abort_transport: AbortTransport | None = None,
+        fail_open: bool = False,
+        on_stuck_release: OnStuckRelease | None = None,
     ) -> None:
         self._send_event = send_event
         self._abort_transport = abort_transport
+        # Escalation policy. The default tears the transport down, which is
+        # what every release so far has shipped. Injected by the
+        # construction site so this module reads no configuration itself.
+        self._fail_open = fail_open
+        # Notified that a turn ended, so the host can run the same end-of-turn
+        # work its terminal event drives. Dual to ``abort_transport``.
+        self._on_stuck_release = on_stuck_release
+        # True while the queue consumer is suspended inside a transport
+        # write; only the worker's own sends set it.
+        self._worker_send_in_flight = False
         self._queue: asyncio.PriorityQueue[_QueuedResponse] = asyncio.PriorityQueue()
         self._queued_by_ticket: dict[int, _QueuedResponse] = {}
         self._sequence = itertools.count()
@@ -285,7 +303,7 @@ class RealtimeResponseArbiter:
             try:
                 await self.wait_until_idle(timeout)
             except asyncio.TimeoutError as original_timeout:
-                await self._fail_closed(
+                await self._escalate(
                     "response cancellation terminal event timed out"
                 )
                 raise original_timeout
@@ -304,7 +322,7 @@ class RealtimeResponseArbiter:
         try:
             await asyncio.wait_for(asyncio.shield(current.completed), timeout)
         except asyncio.TimeoutError as original_timeout:
-            await self._fail_closed(
+            await self._escalate(
                 "response cancellation terminal event timed out",
                 observed=current,
             )
@@ -348,7 +366,7 @@ class RealtimeResponseArbiter:
         try:
             await asyncio.wait_for(asyncio.shield(queued.completed), timeout)
         except asyncio.TimeoutError as original_timeout:
-            await self._fail_closed(
+            await self._escalate(
                 "targeted response cancellation timed out", observed=queued
             )
             raise original_timeout
@@ -846,13 +864,14 @@ class RealtimeResponseArbiter:
                 queued.completed.set_result(None)
             self._queue.task_done()
 
-    async def _fail_closed(
+    async def _escalate(
         self,
         reason: str,
         *,
         observed: _QueuedResponse | None = None,
+        transport_write_failed: bool = False,
     ) -> None:
-        """Tear the transport down over a lifecycle that cannot terminate.
+        """Give up on a lifecycle that cannot reach a terminal state.
 
         ``observed`` is the request whose failure the caller actually watched.
         Escalation is scoped to it, and happens at most once:
@@ -893,9 +912,149 @@ class RealtimeResponseArbiter:
                 )
                 return
             observed.escalated = True
-        await self._fail_closed_unscoped(reason)
 
-    async def _fail_closed_unscoped(self, reason: str) -> None:
+        blocker = self._cannot_keep_the_connection(
+            transport_write_failed=transport_write_failed
+        )
+        if self._fail_open and blocker is None:
+            await self._release_stuck_lifecycle(reason)
+            return
+        if self._fail_open:
+            logger.warning(
+                "response arbiter cannot keep the connection (%s); "
+                "failing closed despite the escape hatch",
+                blocker,
+            )
+        await self._tear_down_transport(reason)
+
+    def _cannot_keep_the_connection(
+        self, *, transport_write_failed: bool
+    ) -> str | None:
+        """Answer the single question fail-open rests on, and name the blocker.
+
+        Keeping the connection is only defensible when it is still usable AND
+        the arbiter can still tell whose events are whose. Anything that
+        falsifies either half belongs here, so the policy has one place to
+        read rather than a list of conditions to keep in sync.
+
+        Returns the blocker's description, or ``None`` when the connection can
+        be kept.
+        """
+
+        if self._worker_send_in_flight:
+            # Nothing this class does to its own state unwinds an await parked
+            # in the transport, and ``_run`` is the only consumer — keeping the
+            # connection would leave it wedged while reporting recovery. The
+            # transport's close is what wakes that write.
+            return "the queue consumer is suspended inside a transport write"
+        if transport_write_failed:
+            # The caller's own write raised moments ago; on the fatal branch
+            # the transport has already dropped its socket.
+            return "a transport write just failed"
+        owner = self._response_owner
+        if owner is not None and owner.response_send_started and (
+            owner.response_id is None
+        ):
+            # The create reached the wire, so the provider may still announce
+            # this response later. Without an id there is nothing to tell that
+            # announcement apart from the next turn's, and it would be credited
+            # to whichever ticket dispatches next.
+            #
+            # The criterion is deliberately "did the create go out", not "did
+            # response.created come back": a request whose create is on the
+            # wire is exactly the one that can still surprise us.
+            return "the abandoned response has no id to attribute later events by"
+        if self._server_vad_response_pending:
+            # Same shape without an owner: announced by speech_stopped, no id
+            # until its response.created arrives.
+            return "an announced server-VAD response has no id yet"
+        return None
+
+    async def _worker_send(self, event: dict[str, Any]) -> None:
+        """Send from the queue consumer, flagged for the duration of the write.
+
+        Only the worker's sends qualify: a caller-task send that blocks hurts
+        only that caller, while a blocked consumer stops every later request.
+        The flag is what lets the policy notice that "the connection is
+        usable" has stopped being true.
+        """
+
+        self._worker_send_in_flight = True
+        try:
+            await self._send_event(event)
+        finally:
+            self._worker_send_in_flight = False
+
+    async def _release_stuck_lifecycle(self, reason: str) -> None:
+        """Drop the stuck turn and keep the connection.
+
+        Deliberately narrower than ``_mark_connection_lost``, which is for a
+        connection that is actually gone. It does NOT clear
+        ``_connection_available`` (the transport still works), bump
+        ``_connection_generation`` (there is no replacement connection to
+        protect in-flight cancels from), set ``_dispatch_allowed`` (an
+        external-ASR turn's pause must survive an unrelated stuck response),
+        or fail the queue (that work is still viable).
+
+        Order matters. The host is told the turn is over BEFORE the lane
+        opens: the notification ends the turn on the host's side, and letting
+        the next request dispatch first would have it rotate the speech id and
+        finalize shared turn state underneath a response that had already
+        started. Awaiting on a caller task alone does not serialize anything —
+        the worker is a separate task and only a closed lane holds it.
+        """
+
+        exc = RuntimeError(reason)
+        owner = self._response_owner
+        current = self._current
+        seen: set[int] = set()
+        for target in (owner, current):
+            if target is None or id(target) in seen:
+                continue
+            seen.add(id(target))
+            # Unwinds ``_process`` now rather than letting it park until its
+            # own timeout escalates a second time.
+            target.interrupted = True
+            target.interrupt_event.set()
+            self._wake_current_with_error(target, exc)
+
+        if self._on_stuck_release is not None:
+            try:
+                await asyncio.wait_for(
+                    self._on_stuck_release(reason),
+                    _STUCK_RELEASE_NOTIFY_TIMEOUT,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "stuck-release host notification exceeded %.1fs; opening "
+                    "the lane anyway",
+                    _STUCK_RELEASE_NOTIFY_TIMEOUT,
+                )
+            except Exception as exc_host:
+                logger.warning(
+                    "stuck-release host notification failed: %s", exc_host
+                )
+
+        # Give up on the bookkeeping just declared untrustworthy: leaving the
+        # owner or the remembered ids in place would hold the lane closed
+        # waiting for terminals nobody expects any more.
+        self._response_owner = None
+        self._server_response_active = False
+        self._server_vad_response_pending = False
+        self._server_response_ids.clear()
+        self._cancel_server_vad_pending_timer()
+        self._cancel_stale_release_timer()
+        self._idle.set()
+        logger.warning(
+            "response arbiter failing open, transport kept: %s "
+            "(current=%s owner=%s queue_depth=%d)",
+            reason,
+            current.source if current is not None else None,
+            owner.source if owner is not None else None,
+            self._queue.qsize(),
+        )
+
+    async def _tear_down_transport(self, reason: str) -> None:
         # This is the only chokepoint through which the arbiter tears down the
         # transport, and to the rest of the system the result is
         # indistinguishable from a provider-side disconnect (the receive loop
@@ -1010,7 +1169,7 @@ class RealtimeResponseArbiter:
                 return_when=asyncio.FIRST_COMPLETED,
             )
             if not done:
-                await self._fail_closed(
+                await self._escalate(
                     "realtime response idle wait timed out", observed=queued
                 )
                 raise asyncio.TimeoutError("realtime response idle wait timed out")
@@ -1046,7 +1205,7 @@ class RealtimeResponseArbiter:
             for event in queued.events_before_response:
                 if queued.interrupted:
                     raise RuntimeError("response dispatch interrupted")
-                await self._send_event(event)
+                await self._worker_send(event)
 
             if queued.item_ack is not None:
                 try:
@@ -1076,7 +1235,7 @@ class RealtimeResponseArbiter:
             self._response_owner = queued
             queued.response_send_started = True
             try:
-                await self._send_event(queued.response_event)
+                await self._worker_send(queued.response_event)
             except Exception:
                 if self._response_owner is queued:
                     self._response_owner = None
@@ -1105,7 +1264,7 @@ class RealtimeResponseArbiter:
                     "response dispatch interrupted by pending server VAD response"
                 )
             if queued.interrupted:
-                await self._send_event({"type": "response.cancel"})
+                await self._worker_send({"type": "response.cancel"})
                 try:
                     await asyncio.wait_for(
                         asyncio.shield(queued.terminal), queued.cancel_timeout
@@ -1113,7 +1272,7 @@ class RealtimeResponseArbiter:
                 except Exception:
                     if not queued.terminal.done():
                         queued.terminal.cancel()
-                    await self._fail_closed(
+                    await self._escalate(
                         "interrupted response could not reach a terminal state",
                         observed=queued,
                     )
@@ -1199,8 +1358,16 @@ class RealtimeResponseArbiter:
     async def _cancel_after_timeout(
         self, queued: _QueuedResponse, original_timeout: asyncio.TimeoutError
     ) -> None:
+        cancel_write_failed = False
         try:
-            await self._send_event({"type": "response.cancel"})
+            try:
+                await self._worker_send({"type": "response.cancel"})
+            except Exception:
+                # ``_worker_send``'s finally has already lowered the in-flight
+                # flag, so without remembering this the escalation below would
+                # read a usable transport moments after this one refused a write.
+                cancel_write_failed = True
+                raise
             assert queued.terminal is not None
             await asyncio.wait_for(
                 asyncio.shield(queued.terminal), queued.cancel_timeout
@@ -1208,8 +1375,9 @@ class RealtimeResponseArbiter:
         except Exception:
             if queued.terminal is not None and not queued.terminal.done():
                 queued.terminal.cancel()
-            await self._fail_closed(
+            await self._escalate(
                 "response lifecycle could not reach a terminal state",
                 observed=queued,
+                transport_write_failed=cancel_write_failed,
             )
         raise original_timeout

--- a/main_logic/omni_realtime_client/_response_arbiter.py
+++ b/main_logic/omni_realtime_client/_response_arbiter.py
@@ -10,11 +10,12 @@ more work so that an external-turn hand-off can restore a newer pause.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import itertools
 import logging
 import uuid
 from dataclasses import dataclass, field
-from typing import Any, Awaitable, Callable
+from typing import Any, Awaitable, Callable, Iterator
 
 
 SendEvent = Callable[[dict[str, Any]], Awaitable[None]]
@@ -54,6 +55,15 @@ _DEFAULT_RESPONSE_DONE_TIMEOUT = 60.0
 # provider-side pre-creation failure cannot wedge the lane until the much
 # longer running-response timeout tears down an otherwise healthy connection.
 _SERVER_VAD_RESPONSE_STARTED_TIMEOUT = 5.0
+# Fraction of a wait's bound past which the wait is reported even when it
+# succeeds. Every fail-close bound in this file was chosen without field data
+# about how long real providers actually take, and the only evidence a bound
+# is too tight is a teardown that already happened. A near-miss line turns
+# ordinary use into the measurement: grep for it over a few sessions and the
+# distribution of "how close did we come" is there without anyone running an
+# experiment. Half is deliberately generous — the point is to see the shape of
+# the tail, not to warn about a healthy wait.
+_WAIT_MARGIN_REPORT_FRACTION = 0.5
 # Ceiling on the host's end-of-turn notification during a fail-open release.
 # Escalations raised inside ``_process`` run it on the sole queue consumer,
 # so an unbounded host callback would stall every later dispatch; short
@@ -301,7 +311,8 @@ class RealtimeResponseArbiter:
                 return
             await self._send_event({"type": "response.cancel"})
             try:
-                await self.wait_until_idle(timeout)
+                with self._report_wait_margin("unowned cancel", timeout):
+                    await self.wait_until_idle(timeout)
             except asyncio.TimeoutError as original_timeout:
                 await self._escalate(
                     "response cancellation terminal event timed out"
@@ -320,7 +331,11 @@ class RealtimeResponseArbiter:
             await self._send_event({"type": "response.cancel"})
         assert current.completed is not None
         try:
-            await asyncio.wait_for(asyncio.shield(current.completed), timeout)
+            # The barge-in bound. Every user interruption of a speaking turn
+            # arrives here, so this is the wait whose real-world margin matters
+            # most and the one no synthetic provider can answer.
+            with self._report_wait_margin("barge-in cancel", timeout):
+                await asyncio.wait_for(asyncio.shield(current.completed), timeout)
         except asyncio.TimeoutError as original_timeout:
             await self._escalate(
                 "response cancellation terminal event timed out",
@@ -364,7 +379,8 @@ class RealtimeResponseArbiter:
             return True
         assert queued.completed is not None
         try:
-            await asyncio.wait_for(asyncio.shield(queued.completed), timeout)
+            with self._report_wait_margin("targeted cancel", timeout):
+                await asyncio.wait_for(asyncio.shield(queued.completed), timeout)
         except asyncio.TimeoutError as original_timeout:
             await self._escalate(
                 "targeted response cancellation timed out", observed=queued
@@ -984,6 +1000,16 @@ class RealtimeResponseArbiter:
             # the transport has already dropped its socket.
             return "a transport write just failed"
         owner = self._response_owner
+        # NOTE: ``response_send_started`` is currently implied by ``owner is
+        # not None`` — ``_process`` assigns the owner on the statement before
+        # it sets the flag, with no await between them, and that is the only
+        # assignment that makes an owner. The conjunct is kept explicit anyway:
+        # it names the criterion this blocker actually rests on, so reordering
+        # those two statements later cannot silently change what is being
+        # tested. It also means this cell cannot discriminate the two candidate
+        # criteria on its own — the discriminating case is an owner whose
+        # create IS on the wire with no announcement back, covered by
+        # ``test_a_create_on_the_wire_without_an_announcement_stands_the_hatch_down``.
         if owner is not None and owner.response_send_started and (
             owner.response_id is None
         ):
@@ -1012,6 +1038,34 @@ class RealtimeResponseArbiter:
             # then.
             return "an unowned response is live with no id at all"
         return None
+
+    @contextlib.contextmanager
+    def _report_wait_margin(self, label: str, timeout: float) -> Iterator[None]:
+        """Report how close a bounded lifecycle wait came to its bound.
+
+        Wraps the wait rather than replacing it: the control flow, the
+        exception raised and the escalation that follows are all unchanged,
+        so this cannot alter what the arbiter does — it only records what it
+        saw. A wait that times out reports at 100% and pairs with the
+        escalation line that follows it; a wait that succeeds late is the more
+        interesting record, because nothing else in the system would ever
+        mention it.
+        """
+
+        loop = asyncio.get_running_loop()
+        started = loop.time()
+        try:
+            yield
+        finally:
+            elapsed = loop.time() - started
+            if timeout > 0 and elapsed >= timeout * _WAIT_MARGIN_REPORT_FRACTION:
+                logger.info(
+                    "realtime %s waited %.2fs of its %.1fs bound (%.0f%%)",
+                    label,
+                    elapsed,
+                    timeout,
+                    100.0 * elapsed / timeout,
+                )
 
     async def _worker_send(self, event: dict[str, Any]) -> None:
         """Send from the queue consumer, flagged for the duration of the write.
@@ -1398,16 +1452,26 @@ class RealtimeResponseArbiter:
                 queued.ticket.sent.set_result(None)
 
             try:
-                await asyncio.wait_for(
-                    asyncio.shield(queued.ticket.started),
-                    queued.response_started_timeout,
-                )
+                # How long the provider takes to announce a response it has
+                # accepted. On a congested shared route this is the bound most
+                # likely to be wrong, and a queued create is invisible to every
+                # other log line.
+                with self._report_wait_margin(
+                    "response announcement", queued.response_started_timeout
+                ):
+                    await asyncio.wait_for(
+                        asyncio.shield(queued.ticket.started),
+                        queued.response_started_timeout,
+                    )
             except asyncio.TimeoutError as started_timeout:
                 await self._cancel_after_timeout(queued, started_timeout)
             try:
-                await asyncio.wait_for(
-                    asyncio.shield(queued.terminal), queued.response_done_timeout
-                )
+                with self._report_wait_margin(
+                    "response completion", queued.response_done_timeout
+                ):
+                    await asyncio.wait_for(
+                        asyncio.shield(queued.terminal), queued.response_done_timeout
+                    )
             except asyncio.TimeoutError as done_timeout:
                 await self._cancel_after_timeout(queued, done_timeout)
 
@@ -1486,9 +1550,10 @@ class RealtimeResponseArbiter:
                 cancel_write_failed = True
                 raise
             assert queued.terminal is not None
-            await asyncio.wait_for(
-                asyncio.shield(queued.terminal), queued.cancel_timeout
-            )
+            with self._report_wait_margin("cancel grace", queued.cancel_timeout):
+                await asyncio.wait_for(
+                    asyncio.shield(queued.terminal), queued.cancel_timeout
+                )
         except Exception:
             if queued.terminal is not None and not queued.terminal.done():
                 queued.terminal.cancel()

--- a/main_logic/omni_realtime_client/_response_arbiter.py
+++ b/main_logic/omni_realtime_client/_response_arbiter.py
@@ -19,7 +19,7 @@ from typing import Any, Awaitable, Callable
 
 SendEvent = Callable[[dict[str, Any]], Awaitable[None]]
 AbortTransport = Callable[[str], Awaitable[None]]
-OnStuckRelease = Callable[[str], Awaitable[None]]
+OnStuckRelease = Callable[[str, "str | None"], Awaitable[None]]
 logger = logging.getLogger(__name__)
 
 # Server-initiated response ids are remembered so their terminal events are
@@ -992,6 +992,17 @@ class RealtimeResponseArbiter:
             # Same shape without an owner: announced by speech_stopped, no id
             # until its response.created arrives.
             return "an announced server-VAD response has no id yet"
+        if (
+            self._server_response_active
+            and self._response_owner is None
+            and not self._server_response_ids
+        ):
+            # A response is live, nobody owns it, and it supplied no id — an
+            # id-less proxy's orphan. Nothing identifies it, so neither its
+            # deltas nor its terminal can be told from the next turn's, and a
+            # late id-less terminal would complete whoever owns the lane by
+            # then.
+            return "an unowned response is live with no id at all"
         return None
 
     async def _worker_send(self, event: dict[str, Any]) -> None:
@@ -1042,43 +1053,53 @@ class RealtimeResponseArbiter:
             target.interrupt_event.set()
             self._wake_current_with_error(target, exc)
 
-        if self._on_stuck_release is not None:
-            try:
+        # Everything below straddles an await, so the release is scoped to
+        # what was captured before it and finishes even if this task is
+        # cancelled. The world can move while the host is being notified: the
+        # abandoned response's terminal can land, the worker can wake and take
+        # a queued request as the new owner. Writing "the owner" unconditionally
+        # afterwards would erase that new owner, whose terminal could then
+        # never resolve its ticket.
+        released_owner = owner
+        released_id = owner.response_id if owner is not None else None
+        try:
+            if self._on_stuck_release is not None:
                 await asyncio.wait_for(
-                    self._on_stuck_release(reason),
+                    self._on_stuck_release(reason, released_id),
                     _STUCK_RELEASE_NOTIFY_TIMEOUT,
                 )
-            except asyncio.TimeoutError:
-                logger.warning(
-                    "stuck-release host notification exceeded %.1fs; opening "
-                    "the lane anyway",
-                    _STUCK_RELEASE_NOTIFY_TIMEOUT,
-                )
-            except Exception as exc_host:
-                logger.warning(
-                    "stuck-release host notification failed: %s", exc_host
-                )
-
-        # Give up on THIS turn's bookkeeping, and only this turn's. The
-        # remembered server response ids belong to separately initiated
-        # responses that are still tracking normally: clearing them would
-        # discard a live response's identity, and the next queued create would
-        # then overlap it. Nothing about the abandoned owner makes those
-        # untrustworthy.
-        self._response_owner = None
-        # Which is why the lane reopens through the ordinary release check
-        # rather than by force — it already knows to keep the lane closed
-        # while a live server response is being tracked, and to arm the
-        # staleness timer that eventually retires one.
-        self._release_lane_if_clear()
-        logger.warning(
-            "response arbiter failing open, transport kept: %s "
-            "(current=%s owner=%s queue_depth=%d)",
-            reason,
-            current.source if current is not None else None,
-            owner.source if owner is not None else None,
-            self._queue.qsize(),
-        )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "stuck-release host notification exceeded %.1fs; opening "
+                "the lane anyway",
+                _STUCK_RELEASE_NOTIFY_TIMEOUT,
+            )
+        except Exception as exc_host:
+            logger.warning(
+                "stuck-release host notification failed: %s", exc_host
+            )
+        finally:
+            # Give up on THIS turn's bookkeeping, and only this turn's. The
+            # remembered server response ids belong to separately initiated
+            # responses that are still tracking normally: clearing them would
+            # discard a live response's identity, and the next queued create
+            # would then overlap it. Nothing about the abandoned owner makes
+            # those untrustworthy.
+            if self._response_owner is released_owner:
+                self._response_owner = None
+            # Which is why the lane reopens through the ordinary release check
+            # rather than by force — it already knows to keep the lane closed
+            # while a live server response is being tracked, and to arm the
+            # staleness timer that eventually retires one.
+            self._release_lane_if_clear()
+            logger.warning(
+                "response arbiter failing open, transport kept: %s "
+                "(current=%s owner=%s queue_depth=%d)",
+                reason,
+                current.source if current is not None else None,
+                released_owner.source if released_owner is not None else None,
+                self._queue.qsize(),
+            )
 
     async def _tear_down_transport(self, reason: str) -> None:
         # This is the only chokepoint through which the arbiter tears down the

--- a/main_logic/omni_realtime_client/_responses.py
+++ b/main_logic/omni_realtime_client/_responses.py
@@ -21,6 +21,7 @@ from ._shared import (
     Optional,
     asyncio,
     logger,
+    response_arbiter_fail_open_enabled,
     time,
     uuid,
 )
@@ -60,6 +61,8 @@ class _ResponseMixin:
             arbiter = RealtimeResponseArbiter(
                 self.send_event,
                 abort_transport=getattr(self, "_abort_failed_transport", None),
+                fail_open=response_arbiter_fail_open_enabled(),
+                on_stuck_release=getattr(self, "_on_arbiter_stuck_release", None),
             )
             self._response_arbiter = arbiter
         return arbiter

--- a/main_logic/omni_realtime_client/_shared.py
+++ b/main_logic/omni_realtime_client/_shared.py
@@ -15,6 +15,8 @@
 
 import asyncio  # noqa: F401 - compatibility export and sibling dependency
 
+import os  # noqa: F401 - compatibility export and sibling dependency
+
 import uuid  # noqa: F401 - compatibility export and sibling dependency
 
 import websockets  # noqa: F401 - compatibility export and sibling dependency
@@ -76,3 +78,24 @@ _IMAGE_ANALYSIS_PENDING_DESCRIPTION = "[实时屏幕截图或相机画面正在�
 class TurnDetectionMode(Enum):
     SERVER_VAD = "server_vad"
     MANUAL = "manual"
+
+
+# Opt-in escape hatch for the response arbiter's escalation policy (issue
+# #2583). When a response lifecycle cannot reach a terminal state the arbiter
+# tears the realtime WebSocket down by default — safe, but a provider-side
+# event-timing quirk in the field would then present as repeated
+# disconnect-and-rebuild, with no server-side switch to reach those users.
+# Setting this makes the arbiter end only the stuck turn and keep the
+# connection, whenever it can still tell whose events are whose.
+#
+# An environment variable on purpose, not a settings-UI toggle: the support
+# path is "set this, restart, tell us if it helped". Read once per client
+# construction, so a change needs a restart.
+_ARBITER_FAIL_OPEN_ENV_VAR = "NEKO_REALTIME_ARBITER_FAIL_OPEN"
+
+
+def response_arbiter_fail_open_enabled() -> bool:
+    """Read the arbiter fail-open escape hatch. Default off."""
+
+    raw = os.getenv(_ARBITER_FAIL_OPEN_ENV_VAR, "").strip().lower()
+    return raw in ("1", "true", "yes", "on")

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -987,6 +987,33 @@ class _TransportMixin:
             self._take_pending_output_transcript()
         )
 
+    def _record_response_usage(self, resp_data: Any) -> None:
+        """Book the provider's token counts for one finished response.
+
+        Shared by the terminal path and the stale-terminal path, because a
+        response's cost does not depend on whose turn the host thinks is
+        current when its ``response.done`` finally arrives.
+        """
+
+        if not isinstance(resp_data, dict):
+            return
+        try:
+            usage = resp_data.get("usage")
+            if not usage:
+                return
+            from utils.token_tracker import TokenTracker
+
+            TokenTracker.get_instance().record(
+                model=resp_data.get("model", self.model or "realtime"),
+                prompt_tokens=usage.get("input_tokens", 0),
+                completion_tokens=usage.get("output_tokens", 0),
+                total_tokens=usage.get("total_tokens", 0),
+                call_type="conversation_realtime",
+                source="main_logic/omni_realtime_client",
+            )
+        except Exception:
+            pass
+
     def _take_response_transcript(self) -> str:
         """Close the books on what this turn actually said.
 
@@ -1415,6 +1442,18 @@ class _TransportMixin:
                             # owner. Content of the stale response stays
                             # filtered below.
                             self._response_arbiter.notify_response_terminal(event)
+                            # The tokens were spent whoever the turn belonged
+                            # to, and this is the ONLY path a fail-open
+                            # released turn's terminal can take: the release
+                            # clears _current_response_id on purpose, so its
+                            # real terminal always lands here. Quarantining
+                            # the host finalization must not also quarantine
+                            # the accounting, or every recovered turn vanishes
+                            # from usage stats even though the provider sent
+                            # exact counts. Counted here and only here — the
+                            # branch continues, so nothing double-counts.
+                            self._response_done_total += 1
+                            self._record_response_usage(event.get("response"))
                         logger.info(
                             "Dropping stale response event type=%s response_id=%s current_response_id=%s",
                             event_type,
@@ -1502,22 +1541,8 @@ class _TransportMixin:
                     self._response_arbiter.notify_response_terminal(event)
                     self._response_done_total += 1
                     self._last_response_done_time = time.time()
-                    resp_data = event.get("response", {})
                     # 解析实时 API 返回的 token 用量
-                    try:
-                        _rt_usage = resp_data.get("usage")
-                        if _rt_usage:
-                            from utils.token_tracker import TokenTracker
-                            TokenTracker.get_instance().record(
-                                model=resp_data.get("model", self.model or "realtime"),
-                                prompt_tokens=_rt_usage.get("input_tokens", 0),
-                                completion_tokens=_rt_usage.get("output_tokens", 0),
-                                total_tokens=_rt_usage.get("total_tokens", 0),
-                                call_type="conversation_realtime",
-                                source="main_logic/omni_realtime_client",
-                            )
-                    except Exception:
-                        pass
+                    self._record_response_usage(event.get("response"))
                     self._clear_turn_response_state()
                     # 响应完成，检测重复度
                     await self._record_response_repetition(

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -972,12 +972,25 @@ class _TransportMixin:
         is what clears the buffer.
         """
 
+        await self._emit_pending_output_transcript(
+            self._take_pending_output_transcript()
+        )
+
+    def _take_pending_output_transcript(self) -> tuple[str, bool] | None:
+        """Decide what the fallback flush owes the host, and settle the state.
+
+        Split from the sending half so a caller that must not be interrupted
+        mid-cleanup can commit every synchronous write first, then await. The
+        turn's remaining state is consistent the moment this returns, whether
+        or not the emit that follows ever completes.
+        """
+
         if not (
             self._output_transcript_buffer
             and self.on_output_transcript
             and self._audio_delta_count > 0
         ):
-            return
+            return None
         # 「有声无字」是反复出现的问题（见 ISSUE4b），留一条 debug 日志方便下次
         # 诊断时确认是这条兜底生效、还是 streaming/transcript.done 路径生效。
         # audio_delta_count 此处尚未清零，记录的是本轮真实值。
@@ -987,10 +1000,19 @@ class _TransportMixin:
             self._audio_delta_count,
             self._is_first_transcript_chunk,
         )
-        await self.on_output_transcript(
-            self._output_transcript_buffer, self._is_first_transcript_chunk
-        )
+        pending = (self._output_transcript_buffer, self._is_first_transcript_chunk)
         self._is_first_transcript_chunk = False
+        return pending
+
+    async def _emit_pending_output_transcript(
+        self, pending: tuple[str, bool] | None
+    ) -> None:
+        """Send what ``_take_pending_output_transcript`` decided was owed."""
+
+        if pending is None or not self.on_output_transcript:
+            return
+        text, is_first = pending
+        await self.on_output_transcript(text, is_first)
 
     def _clear_turn_response_state(self) -> None:
         """Drop the flags that say "a response is in progress".
@@ -1043,7 +1065,9 @@ class _TransportMixin:
             except Exception as exc:
                 logger.warning("turn-finished speech-id rotation failed: %s", exc)
 
-    async def _on_arbiter_stuck_release(self, reason: str) -> None:
+    async def _on_arbiter_stuck_release(
+        self, reason: str, response_id: str | None = None
+    ) -> None:
         """End a turn the arbiter gave up on, exactly as its terminal would.
 
         The same three steps ``response.done`` runs, in the same order. That
@@ -1057,17 +1081,44 @@ class _TransportMixin:
         finalizes a second time. Note this is the opposite of what
         ``handle_interruption`` wants, which keeps the identity precisely so
         the cancelled response's own terminal still ends the turn.
+
+        ``response_id`` names the response the arbiter abandoned, and this
+        finalizes only that one. The turn being tracked here is not always it:
+        an owned response can overlap a server-initiated one, and it is the
+        server response's ``response.created`` that last wrote
+        ``_current_response_id``. Ending "the current turn" would then close a
+        response that is still streaming, and its own terminal would find
+        nothing left to close. A ``None`` id means the arbiter had nothing to
+        name — it never learned one — and the tracked turn is finalized as
+        before.
+
+        The synchronous state is settled before the first await on purpose.
+        Both remaining awaits reach host code that can block past the
+        arbiter's notification bound, and being cancelled there must not leave
+        this turn's flags half-cleared for the next turn to inherit.
         """
 
+        if response_id is not None and self._current_response_id not in (
+            None,
+            response_id,
+        ):
+            logger.info(
+                "Arbiter released %s but this turn is tracking %s; leaving it "
+                "alone",
+                response_id,
+                self._current_response_id,
+            )
+            return
         if not self._is_responding and self._current_response_id is None:
             return
         logger.info("Ending abandoned turn after arbiter release: %s", reason)
-        self._clear_turn_response_state()
-        # Before the reset, which is what clears the buffer: a stalled
+        # Captured before the reset, which is what clears the buffer: a stalled
         # lifecycle is exactly the case where the terminal that would normally
         # flush it never arrives.
-        await self._flush_pending_output_transcript()
+        pending_transcript = self._take_pending_output_transcript()
+        self._clear_turn_response_state()
         self._reset_per_turn_output_state()
+        await self._emit_pending_output_transcript(pending_transcript)
         await self._notify_turn_finished()
 
     async def handle_interruption(self):

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -1007,6 +1007,29 @@ class _TransportMixin:
             except Exception as exc:
                 logger.warning("turn-finished speech-id rotation failed: %s", exc)
 
+    async def _on_arbiter_stuck_release(self, reason: str) -> None:
+        """End a turn the arbiter gave up on, exactly as its terminal would.
+
+        The same three steps ``response.done`` runs, in the same order. That
+        is the entire point: a second way to end a turn is a second thing to
+        keep correct, and the withdrawn #2592 spent seven review rounds
+        discovering, one at a time, which parts its own version had left out.
+
+        Clearing the identity here is what quarantines the abandoned
+        response's later events — the stale-event filter then routes its
+        terminal to the arbiter alone, so the lane still releases but nothing
+        finalizes a second time. Note this is the opposite of what
+        ``handle_interruption`` wants, which keeps the identity precisely so
+        the cancelled response's own terminal still ends the turn.
+        """
+
+        if not self._is_responding and self._current_response_id is None:
+            return
+        logger.info("Ending abandoned turn after arbiter release: %s", reason)
+        self._clear_turn_response_state()
+        self._reset_per_turn_output_state()
+        await self._notify_turn_finished()
+
     async def handle_interruption(self):
         """Handle user interruption of the current response."""
         if not self._is_responding:

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -1296,7 +1296,6 @@ class _TransportMixin:
             return
         if not self._is_responding and self._current_response_id is None:
             return
-        logger.info("Ending abandoned turn after arbiter release: %s", reason)
         # The epoch this response began in, not the one the callback happens to
         # find. Between them a barge-in can have advanced _turn_epoch at
         # speech_stopped — which does not clear _current_response_id, so the id
@@ -1307,6 +1306,27 @@ class _TransportMixin:
         def _still_ours() -> bool:
             return self._turn_epoch == released_epoch
 
+        if not _still_ours():
+            # A turn already started before this release even ran, so NOTHING
+            # here belongs to it — not the awaited hooks, and not the
+            # synchronous cleanup ahead of them either. Both have side effects
+            # on the live turn: `_clear_turn_response_state` resets
+            # `_interrupted`, which on a provider whose late deltas carry no id
+            # is the only thing keeping the abandoned response's audio out of
+            # the new turn; and `_check_repetition` can fire
+            # `on_repetition_detected`, whose host resets the shared focus
+            # scorer and emotion state rather than merely recording history.
+            #
+            # Leaving this turn's per-turn flags for the successor's own
+            # terminal to clear is the lesser harm, and the successor's
+            # `response.created` overwrites the identity fields regardless.
+            logger.info(
+                "a turn already started before this release ran (%s); leaving "
+                "the host alone",
+                reason,
+            )
+            return
+        logger.info("Ending abandoned turn after arbiter release: %s", reason)
         # Captured before the reset, which is what clears the buffer: a stalled
         # lifecycle is exactly the case where the terminal that would normally
         # flush it never arrives.

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -1511,6 +1511,14 @@ class _TransportMixin:
                     self._response_arbiter.notify_server_vad_response_pending(
                         arm_timeout=False
                     )
+                    # The user's turn starts HERE on a server-VAD provider, not
+                    # at response.created: on_new_message assigns the new
+                    # speech id and fires USER_INPUT, and the provider's
+                    # response.created only follows some time later. A release
+                    # suspended in a host callback would otherwise resume in
+                    # that gap, still believe the turn is its own, and finalize
+                    # against the speech id this user turn just took.
+                    self._turn_epoch += 1
                     try:
                         if self.on_new_message:
                             await self.on_new_message()

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -54,6 +54,11 @@ _ATTACHED_TRANSPORT = object()
 # when the coroutine returns, and the outer budget still reaches the rotation.
 _STUCK_RELEASE_STEP_TIMEOUT = 0.5
 
+# How many finished response ids to remember for usage deduplication. A repeat
+# arrives right behind its original, so this only has to outlive the events
+# interleaved between them; it is a leak guard, not a history.
+_USAGE_RECORDED_ID_LIMIT = 32
+
 
 # `error` 事件的致命性判定是一串子串匹配（'429' / '1008' / '503' / 'quota' ...）。它
 # 过去匹配在 `str(event['error'])` 上，也就是整个 dict 的 repr —— 里面回显着我们自己
@@ -988,11 +993,20 @@ class _TransportMixin:
         )
 
     def _record_response_usage(self, resp_data: Any) -> None:
-        """Book the provider's token counts for one finished response.
+        """Book the provider's token counts for one finished response, once.
 
         Shared by the terminal path and the stale-terminal path, because a
         response's cost does not depend on whose turn the host thinks is
         current when its ``response.done`` finally arrives.
+
+        Which is exactly why it has to deduplicate. The transport already
+        tolerates a repeated ``response.done`` without finalizing the turn
+        twice — and a repeat necessarily takes the stale branch, because the
+        first one cleared ``_current_response_id`` — so counting on both paths
+        without a guard would overstate usage for a case the transport
+        supports on purpose. Keyed by response id; a terminal with no id
+        never reaches the stale branch (that filter needs an id to compare),
+        so it can only be counted once anyway.
         """
 
         if not isinstance(resp_data, dict):
@@ -1001,6 +1015,13 @@ class _TransportMixin:
             usage = resp_data.get("usage")
             if not usage:
                 return
+            response_id = resp_data.get("id")
+            if response_id is not None:
+                if response_id in self._usage_recorded_ids:
+                    return
+                self._usage_recorded_ids.append(response_id)
+                if len(self._usage_recorded_ids) > _USAGE_RECORDED_ID_LIMIT:
+                    self._usage_recorded_ids.pop(0)
             from utils.token_tracker import TokenTracker
 
             TokenTracker.get_instance().record(
@@ -1299,26 +1320,44 @@ class _TransportMixin:
             )
         except Exception as exc:
             logger.warning("stuck-release repetition check failed: %s", exc)
-        # Best-effort, and the only step that is. A host that blocks or raises
-        # while taking this turn's last half-sentence must not take the
-        # rotation behind it down as well. Not epoch-guarded: this is the
-        # first await, nothing can have moved since the synchronous block, and
-        # the text belongs to the released turn either way.
-        try:
-            await asyncio.wait_for(
-                self._emit_pending_output_transcript(pending_transcript),
-                _STUCK_RELEASE_STEP_TIMEOUT,
+        # Epoch-guarded, unlike the repetition check above it. That one is
+        # bookkeeping about the released turn's own text and lands nowhere
+        # else; this one goes out through ``handle_output_transcript``, which
+        # publishes and queues TTS under whatever speech id is CURRENT — so
+        # once a successor has started, flushing here speaks the abandoned
+        # turn's half-sentence as part of the successor's. The released turn's
+        # trailing text is worth losing to prevent that; it is the same
+        # "lands on that turn or not at all" rule the end-of-turn hooks follow.
+        #
+        # The repetition check ahead of it can yield (on_repetition_detected),
+        # which is what makes this reachable — an earlier version of this
+        # comment said the flush was the first await and therefore safe, and
+        # inserting that step in front of it quietly made that false.
+        #
+        # Best-effort besides: a host that blocks or raises while taking the
+        # last half-sentence must not take the rotation behind it down too.
+        if _still_ours():
+            try:
+                await asyncio.wait_for(
+                    self._emit_pending_output_transcript(pending_transcript),
+                    _STUCK_RELEASE_STEP_TIMEOUT,
+                )
+            except asyncio.CancelledError:
+                raise
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "stuck-release transcript flush exceeded %.1fs; ending the "
+                    "turn anyway",
+                    _STUCK_RELEASE_STEP_TIMEOUT,
+                )
+            except Exception as exc:
+                logger.warning("stuck-release transcript flush failed: %s", exc)
+        elif pending_transcript is not None:
+            logger.info(
+                "a new turn started before the abandoned turn's trailing "
+                "transcript could be sent; dropping it rather than speaking "
+                "it as the new turn's"
             )
-        except asyncio.CancelledError:
-            raise
-        except asyncio.TimeoutError:
-            logger.warning(
-                "stuck-release transcript flush exceeded %.1fs; ending the "
-                "turn anyway",
-                _STUCK_RELEASE_STEP_TIMEOUT,
-            )
-        except Exception as exc:
-            logger.warning("stuck-release transcript flush failed: %s", exc)
         await self._notify_turn_finished(
             step_timeout=_STUCK_RELEASE_STEP_TIMEOUT,
             still_ours=_still_ours,

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -1379,8 +1379,19 @@ class _TransportMixin:
             # successor has not announced itself yet, so it has produced no
             # output of its own to erase.
             self._reset_per_turn_output_state()
+            # Both release paths raise it: the abandoned response may still be
+            # streaming, and from here until the next response.created nothing
+            # id-less can be attributed. Clearing _current_response_id above
+            # quarantines its ID-BEARING events; this covers the rest.
+            self._idless_quarantine = True
             return
         logger.info("Ending abandoned turn after arbiter release: %s", reason)
+        # Both release paths raise it: the abandoned response may still be
+        # streaming, and from here until the next response.created nothing
+        # id-less can be attributed. Clearing _current_response_id above
+        # quarantines its ID-BEARING events; this covers the rest.
+        self._idless_quarantine = True
+
         # Captured before the reset, which is what clears the buffer: a stalled
         # lifecycle is exactly the case where the terminal that would normally
         # flush it never arrives.
@@ -1618,6 +1629,30 @@ class _TransportMixin:
                         if delta:
                             slot["arguments"] += delta
                 elif event_type == "response.function_call_arguments.done":
+                    if self._idless_quarantine and not event.get("response_id"):
+                        # A fail-open release abandoned a turn, and this event
+                        # names no response — so it cannot be told apart from
+                        # the successor's. Content that leaks is a wrong
+                        # sentence; a tool call that leaks is a side effect
+                        # executed on behalf of a turn nobody is having.
+                        #
+                        # Bounded, not blanket: the window closes at the next
+                        # response.created (see below), which on the only
+                        # providers that can reach here is guaranteed to carry
+                        # an id — a release requires the abandoned response to
+                        # have had one, and ids are written only from
+                        # response.created. The successor's announcement
+                        # therefore always precedes its own id-less events on
+                        # this single ordered socket, so nothing of the
+                        # successor's is ever suppressed.
+                        logger.warning(
+                            "quarantined an id-less tool call arriving after a "
+                            "stuck-turn release (call_id=%s name=%s)",
+                            event.get("call_id") or "?",
+                            event.get("name") or "?",
+                        )
+                        self._inflight_tool_args.pop(event.get("call_id") or "", None)
+                        continue
                     name = event.get("name") or ""
                     raw_args = event.get("arguments") or ""
                     call_id = event.get("call_id") or ""
@@ -1697,6 +1732,13 @@ class _TransportMixin:
                     self._turn_epoch += 1
                     self._current_turn_epoch = self._turn_epoch
                     self._interrupted = False  # Clear interruption flag on new response
+                    # Closes the id-less quarantine a fail-open release opened.
+                    # Safe as the sole exit: a release only happens when the
+                    # abandoned response HAD an id, ids are written only here,
+                    # and this socket is consumed by one ordered ``async for`` —
+                    # so a successor's announcement always precedes its own
+                    # id-less events and none of them are ever suppressed.
+                    self._idless_quarantine = False
                     self._is_first_text_chunk = self._is_first_transcript_chunk = True
                     # 清空转录 buffer，防止累积旧内容
                     self._output_transcript_buffer = ""

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -47,10 +47,11 @@ _ATTACHED_TRANSPORT = object()
 # The arbiter bounds the WHOLE notification with one shared budget
 # (_STUCK_RELEASE_NOTIFY_TIMEOUT, 2.0s); without a per-step ceiling the first
 # await consumes it and everything after it is cancelled where it stands.
-# Two bounded steps x 0.5s leaves the rest of the arbiter's budget for the
-# speech-id rotation, which is deliberately NOT bounded. This is a necessary
-# condition, not a guarantee: asyncio.wait_for bounds when the cancellation is
-# DELIVERED, not when the coroutine returns.
+# Three bounded steps x 0.5s leaves the rest of the arbiter's budget for the
+# speech-id rotation, which gets no ceiling of its own because it is last —
+# nothing behind it can be starved. That is a necessary condition, not a
+# guarantee: asyncio.wait_for bounds when the cancellation is DELIVERED, not
+# when the coroutine returns, and the outer budget still reaches the rotation.
 _STUCK_RELEASE_STEP_TIMEOUT = 0.5
 
 
@@ -986,6 +987,50 @@ class _TransportMixin:
             self._take_pending_output_transcript()
         )
 
+    def _take_response_transcript(self) -> str:
+        """Close the books on what this turn actually said.
+
+        Split from the repetition check that consumes it for the same reason
+        as the output-transcript pair below: the release path has to commit
+        every synchronous write before its first await, or a cancellation
+        strands this turn's state for the next one to inherit.
+
+        Reads ``_audio_delta_count`` for its log line, so it must run BEFORE
+        the per-turn reset zeroes it.
+        """
+
+        transcript = self._current_response_transcript
+        if transcript:
+            self._last_response_transcript = transcript
+            print(
+                f"OmniRealtimeClient: response.done - 当前转录: "
+                f"'{transcript[:50]}...' | audio_deltas={self._audio_delta_count}"
+            )
+            self._current_response_transcript = ""
+        else:
+            self._last_response_transcript = ""
+            print(
+                "OmniRealtimeClient: response.done - 没有转录文本 | "
+                f"audio_deltas={self._audio_delta_count}"
+            )
+        return transcript
+
+    async def _record_response_repetition(self, transcript: str) -> None:
+        """Add what this turn said to the repetition history.
+
+        Ending a turn has to do this on EVERY path, not just the terminal one.
+        A provider that repeatedly loses its ``response.done`` — the case the
+        fail-open hatch exists for — would otherwise never contribute an
+        audible reply to ``_recent_responses``, so three identical turns in a
+        row could not trigger ``on_repetition_detected`` at all.
+
+        The history is recorded before ``_check_repetition``'s only await, so
+        a bounded caller that cuts the host callback short still keeps it.
+        """
+
+        if transcript:
+            await self._check_repetition(transcript)
+
     def _take_pending_output_transcript(self) -> tuple[str, bool] | None:
         """Decide what the fallback flush owes the host, and settle the state.
 
@@ -1052,9 +1097,17 @@ class _TransportMixin:
 
         Both keywords belong to the fail-open release path, and both default
         to the terminal path's behaviour so this stays one implementation
-        rather than two. ``still_ours`` is re-checked before EACH hook,
-        because both can block on the same frontend socket and a new turn can
-        start between them.
+        rather than two.
+
+        ``still_ours`` gates the PAIR, once, rather than each hook. They are
+        not independent: ``on_response_done`` queues this turn's TTS-done
+        sentinel, which closes its speech id, and ``on_sid_rotate`` is what
+        hands out the next one. Re-checking between them lets a turn that
+        starts mid-notification split the pair — the old sid closed, no new
+        one issued — and on a provider without server VAD the successor then
+        speaks under a closed sid and has its text silently dropped, which is
+        the failure this hook exists to prevent. So either the release still
+        owns the turn and finishes ending it, or it never started.
 
         ``on_sid_rotate`` gets no step bound of its own, because it is the
         last step — there is nothing behind it for a slow hook to starve. That
@@ -1091,7 +1144,13 @@ class _TransportMixin:
         the turn cannot skip the rotation that follows it.
         """
 
-        if self.on_response_done and (still_ours is None or still_ours()):
+        if still_ours is not None and not still_ours():
+            logger.info(
+                "a new turn started before this one could be ended; leaving "
+                "both end-of-turn hooks to it"
+            )
+            return
+        if self.on_response_done:
             try:
                 if step_timeout is None:
                     await self.on_response_done()
@@ -1109,11 +1168,7 @@ class _TransportMixin:
                 )
             except Exception as exc:
                 logger.warning("turn-finished notification failed: %s", exc)
-        if (
-            not self._has_server_vad
-            and self.on_sid_rotate
-            and (still_ours is None or still_ours())
-        ):
+        if not self._has_server_vad and self.on_sid_rotate:
             try:
                 await self.on_sid_rotate()
             except asyncio.CancelledError:
@@ -1193,8 +1248,26 @@ class _TransportMixin:
         # lifecycle is exactly the case where the terminal that would normally
         # flush it never arrives.
         pending_transcript = self._take_pending_output_transcript()
+        pending_response = self._take_response_transcript()
         self._clear_turn_response_state()
         self._reset_per_turn_output_state()
+        # Same order the terminal path uses: repetition history first, then
+        # the fallback transcript flush.
+        try:
+            await asyncio.wait_for(
+                self._record_response_repetition(pending_response),
+                _STUCK_RELEASE_STEP_TIMEOUT,
+            )
+        except asyncio.CancelledError:
+            raise
+        except asyncio.TimeoutError:
+            logger.warning(
+                "stuck-release repetition check exceeded %.1fs; ending the "
+                "turn anyway",
+                _STUCK_RELEASE_STEP_TIMEOUT,
+            )
+        except Exception as exc:
+            logger.warning("stuck-release repetition check failed: %s", exc)
         # Best-effort, and the only step that is. A host that blocks or raises
         # while taking this turn's last half-sentence must not take the
         # rotation behind it down as well. Not epoch-guarded: this is the
@@ -1447,14 +1520,9 @@ class _TransportMixin:
                         pass
                     self._clear_turn_response_state()
                     # 响应完成，检测重复度
-                    if self._current_response_transcript:
-                        self._last_response_transcript = self._current_response_transcript
-                        print(f"OmniRealtimeClient: response.done - 当前转录: '{self._current_response_transcript[:50]}...' | audio_deltas={self._audio_delta_count}")
-                        await self._check_repetition(self._current_response_transcript)
-                        self._current_response_transcript = ""
-                    else:
-                        self._last_response_transcript = ""
-                        print(f"OmniRealtimeClient: response.done - 没有转录文本 | audio_deltas={self._audio_delta_count}")
+                    await self._record_response_repetition(
+                        self._take_response_transcript()
+                    )
                     # [有声无字兜底] 部分 provider（如 lanlan.app Gemini 语音代理）只发
                     # response.audio_transcript.delta、从不发 response.audio_transcript.done，
                     # 输出转录全靠下面 streaming 分支（_print_input_transcript=True）实时送出。

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -1235,8 +1235,15 @@ class _TransportMixin:
             except asyncio.TimeoutError:
                 # Kept ahead of the bare Exception arm even though TimeoutError
                 # is one: "took too long" and "raised" are different diagnoses.
+                #
+                # ``%s``, not ``%.1f``: the terminal path calls in with
+                # ``step_timeout=None`` and awaits the hook directly, so this
+                # arm is also how a TimeoutError raised BY the host surfaces
+                # there. Formatting None with %.1f raises inside logging and
+                # destroys the record — the one diagnosis this arm exists to
+                # give.
                 logger.warning(
-                    "turn-finished notification exceeded its %.1fs step bound; "
+                    "turn-finished notification exceeded its %ss step bound; "
                     "rotating anyway",
                     step_timeout,
                 )

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -1297,7 +1297,12 @@ class _TransportMixin:
         if not self._is_responding and self._current_response_id is None:
             return
         logger.info("Ending abandoned turn after arbiter release: %s", reason)
-        released_epoch = self._turn_epoch
+        # The epoch this response began in, not the one the callback happens to
+        # find. Between them a barge-in can have advanced _turn_epoch at
+        # speech_stopped — which does not clear _current_response_id, so the id
+        # guard above still passes — and reading the live value here would make
+        # the check compare the successor's epoch with itself.
+        released_epoch = self._current_turn_epoch
 
         def _still_ours() -> bool:
             return self._turn_epoch == released_epoch
@@ -1616,6 +1621,7 @@ class _TransportMixin:
                     self._current_response_id = event.get("response", {}).get("id")
                     self._is_responding = True
                     self._turn_epoch += 1
+                    self._current_turn_epoch = self._turn_epoch
                     self._interrupted = False  # Clear interruption flag on new response
                     self._is_first_text_chunk = self._is_first_transcript_chunk = True
                     # 清空转录 buffer，防止累积旧内容

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -43,6 +43,16 @@ from ._shared import (
 
 _ATTACHED_TRANSPORT = object()
 
+# Ceiling on each host step inside a fail-open release that may be cut short.
+# The arbiter bounds the WHOLE notification with one shared budget
+# (_STUCK_RELEASE_NOTIFY_TIMEOUT, 2.0s); without a per-step ceiling the first
+# await consumes it and everything after it is cancelled where it stands.
+# Two bounded steps x 0.5s leaves the rest of the arbiter's budget for the
+# speech-id rotation, which is deliberately NOT bounded. This is a necessary
+# condition, not a guarantee: asyncio.wait_for bounds when the cancellation is
+# DELIVERED, not when the coroutine returns.
+_STUCK_RELEASE_STEP_TIMEOUT = 0.5
+
 
 # `error` 事件的致命性判定是一串子串匹配（'429' / '1008' / '503' / 'quota' ...）。它
 # 过去匹配在 `str(event['error'])` 上，也就是整个 dict 的 repr —— 里面回显着我们自己
@@ -1030,10 +1040,29 @@ class _TransportMixin:
         # 确保中断标志在响应结束时清除，防止阻塞下一轮 text.delta
         self._interrupted = False
 
-    async def _notify_turn_finished(self) -> None:
+    async def _notify_turn_finished(
+        self,
+        *,
+        step_timeout: float | None = None,
+        still_ours: Callable[[], bool] | None = None,
+    ) -> None:
         """Tell the host this turn is over.
 
         The two hooks the terminal path fires, in the order it fires them.
+
+        Both keywords belong to the fail-open release path, and both default
+        to the terminal path's behaviour so this stays one implementation
+        rather than two. ``still_ours`` is re-checked before EACH hook,
+        because both can block on the same frontend socket and a new turn can
+        start between them.
+
+        ``on_sid_rotate`` is never bounded, on purpose:
+        ``rotate_speech_id_for_response_done`` clears
+        ``_tts_done_queued_for_turn`` and ``_tts_done_pending_until_ready``
+        and only THEN takes the session lock, so cancelling it at that lock
+        leaves the host half-rotated — the flags say a fresh turn, the speech
+        id still says the old one. A skipped rotation is recoverable by the
+        next turn's terminal; a half-applied one is not.
 
         ``on_sid_rotate`` is conditional because providers WITH server VAD
         rotate the speech id from ``speech_stopped`` instead; firing here too
@@ -1050,14 +1079,29 @@ class _TransportMixin:
         the turn cannot skip the rotation that follows it.
         """
 
-        if self.on_response_done:
+        if self.on_response_done and (still_ours is None or still_ours()):
             try:
-                await self.on_response_done()
+                if step_timeout is None:
+                    await self.on_response_done()
+                else:
+                    await asyncio.wait_for(self.on_response_done(), step_timeout)
             except asyncio.CancelledError:
                 raise
+            except asyncio.TimeoutError:
+                # Kept ahead of the bare Exception arm even though TimeoutError
+                # is one: "took too long" and "raised" are different diagnoses.
+                logger.warning(
+                    "turn-finished notification exceeded its %.1fs step bound; "
+                    "rotating anyway",
+                    step_timeout,
+                )
             except Exception as exc:
                 logger.warning("turn-finished notification failed: %s", exc)
-        if not self._has_server_vad and self.on_sid_rotate:
+        if (
+            not self._has_server_vad
+            and self.on_sid_rotate
+            and (still_ours is None or still_ours())
+        ):
             try:
                 await self.on_sid_rotate()
             except asyncio.CancelledError:
@@ -1092,16 +1136,32 @@ class _TransportMixin:
         name — it never learned one — and the tracked turn is finalized as
         before.
 
+        A tracked id of ``None`` is not a wildcard either. ``response_id``
+        comes from the owner's own ``response.created`` — the event that wrote
+        ``_current_response_id`` three lines later in the same handler — so a
+        named release implies the host once tracked that exact id. Seeing
+        ``None`` now means a later, id-less ``response.created`` overwrote it:
+        an overlapping response that is still streaming, and not this
+        release's to end.
+
         The synchronous state is settled before the first await on purpose.
         Both remaining awaits reach host code that can block past the
         arbiter's notification bound, and being cancelled there must not leave
         this turn's flags half-cleared for the next turn to inherit.
+
+        Identity has to survive those awaits, not merely precede them. The
+        lane can reopen mid-notification — the abandoned response's own
+        terminal can land and release it — and the next turn can be live
+        before the transcript flush returns. The arbiter cannot prevent that
+        from its side (the user's own turn starts through
+        ``handle_new_message``, which never consults the lane), so the check
+        lives here: the release captures ``_turn_epoch`` and abandons the rest
+        of its work the moment a new turn has started. The rotation it skips
+        is deferred rather than lost — the turn that took over ends through
+        its own terminal, which rotates.
         """
 
-        if response_id is not None and self._current_response_id not in (
-            None,
-            response_id,
-        ):
+        if response_id is not None and self._current_response_id != response_id:
             logger.info(
                 "Arbiter released %s but this turn is tracking %s; leaving it "
                 "alone",
@@ -1112,14 +1172,41 @@ class _TransportMixin:
         if not self._is_responding and self._current_response_id is None:
             return
         logger.info("Ending abandoned turn after arbiter release: %s", reason)
+        released_epoch = self._turn_epoch
+
+        def _still_ours() -> bool:
+            return self._turn_epoch == released_epoch
+
         # Captured before the reset, which is what clears the buffer: a stalled
         # lifecycle is exactly the case where the terminal that would normally
         # flush it never arrives.
         pending_transcript = self._take_pending_output_transcript()
         self._clear_turn_response_state()
         self._reset_per_turn_output_state()
-        await self._emit_pending_output_transcript(pending_transcript)
-        await self._notify_turn_finished()
+        # Best-effort, and the only step that is. A host that blocks or raises
+        # while taking this turn's last half-sentence must not take the
+        # rotation behind it down as well. Not epoch-guarded: this is the
+        # first await, nothing can have moved since the synchronous block, and
+        # the text belongs to the released turn either way.
+        try:
+            await asyncio.wait_for(
+                self._emit_pending_output_transcript(pending_transcript),
+                _STUCK_RELEASE_STEP_TIMEOUT,
+            )
+        except asyncio.CancelledError:
+            raise
+        except asyncio.TimeoutError:
+            logger.warning(
+                "stuck-release transcript flush exceeded %.1fs; ending the "
+                "turn anyway",
+                _STUCK_RELEASE_STEP_TIMEOUT,
+            )
+        except Exception as exc:
+            logger.warning("stuck-release transcript flush failed: %s", exc)
+        await self._notify_turn_finished(
+            step_timeout=_STUCK_RELEASE_STEP_TIMEOUT,
+            still_ours=_still_ours,
+        )
 
     async def handle_interruption(self):
         """Handle user interruption of the current response."""
@@ -1374,6 +1461,7 @@ class _TransportMixin:
                     self._last_response_created_time = time.time()
                     self._current_response_id = event.get("response", {}).get("id")
                     self._is_responding = True
+                    self._turn_epoch += 1
                     self._interrupted = False  # Clear interruption flag on new response
                     self._is_first_text_chunk = self._is_first_transcript_chunk = True
                     # 清空转录 buffer，防止累积旧内容

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -1302,12 +1302,20 @@ class _TransportMixin:
         its own terminal, which rotates.
         """
 
-        if response_id is not None and self._current_response_id != response_id:
+        tracked_id = self._current_response_id
+        # Compared as text on both sides. The arbiter normalises ids through
+        # `_event_response_id` (`str(...)`), while this side stores whatever
+        # the JSON carried — so a provider using a numeric id made every
+        # comparison here false ("123" != 123) and the release silently
+        # finalized and quarantined nothing, on every turn.
+        if response_id is not None and (
+            tracked_id is None or str(tracked_id) != str(response_id)
+        ):
             logger.info(
                 "Arbiter released %s but this turn is tracking %s; leaving it "
                 "alone",
                 response_id,
-                self._current_response_id,
+                tracked_id,
             )
             return
         if not self._is_responding and self._current_response_id is None:
@@ -1354,6 +1362,16 @@ class _TransportMixin:
             )
             self._current_response_id = None
             self._current_item_id = None
+            # The per-response output accounting belongs to the dead turn as
+            # well, and nothing else will clear it: `response.created` resets
+            # the transcript buffers but not `_image_sent_this_turn` or
+            # `_audio_delta_count`, so a successor would spend its whole
+            # duration withholding its own visual context and counting the
+            # previous turn's audio. Safe here because reaching this line
+            # means the tracked id still named the abandoned response — the
+            # successor has not announced itself yet, so it has produced no
+            # output of its own to erase.
+            self._reset_per_turn_output_state()
             return
         logger.info("Ending abandoned turn after arbiter release: %s", reason)
         # Captured before the reset, which is what clears the buffer: a stalled

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -108,6 +108,12 @@ class _TransportMixin:
         # provider branch so it covers both Gemini and the WS providers.
         self._recent_tool_call_times = []
 
+        # Same reason, same lifetime: response ids are scoped to a connection,
+        # so a provider that restarts its numbering (or simply reuses an id)
+        # after a reconnect would otherwise have the new session's first turns
+        # suppressed as already-billed duplicates.
+        self._usage_recorded_ids = []
+
         # ``close()`` releases RNNoise/soxr state. The client object is reused
         # across sessions, so recreate that session-owned processor on demand.
         if self._audio_processor is None:

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -956,6 +956,57 @@ class _TransportMixin:
             self._image_description = _IMAGE_ANALYSIS_PENDING_DESCRIPTION
         self._image_sent_this_turn = False
 
+    def _clear_turn_response_state(self) -> None:
+        """Drop the flags that say "a response is in progress".
+
+        Extracted from the ``response.done`` handler alongside
+        ``_notify_turn_finished`` so that ending a turn is one implementation
+        rather than a sequence any second caller has to reproduce. Behaviour
+        is unchanged — same assignments, same order.
+        """
+
+        self._is_responding = False
+        self._current_response_id = None
+        self._current_item_id = None
+        self._skip_until_next_response = False
+        # 确保中断标志在响应结束时清除，防止阻塞下一轮 text.delta
+        self._interrupted = False
+
+    async def _notify_turn_finished(self) -> None:
+        """Tell the host this turn is over.
+
+        The two hooks the terminal path fires, in the order it fires them.
+
+        ``on_sid_rotate`` is conditional because providers WITH server VAD
+        rotate the speech id from ``speech_stopped`` instead; firing here too
+        would be a second, unpaired rotation on a live turn. Providers without
+        it never emit ``speech_stopped`` (the Gemini proxy: lanlan.app+free,
+        and livestream), so this is their only rotation point — and without it
+        TTS upstream silently drops every later turn's text once the first
+        ``tts.response.done`` closes the initial sid. The lightweight
+        rotate-only path is deliberate: a full ``handle_new_message`` would
+        clip trailing TTS audio and mis-fire USER_INPUT, since no user input
+        actually happened.
+
+        Each hook is awaited independently so a host that raises while closing
+        the turn cannot skip the rotation that follows it.
+        """
+
+        if self.on_response_done:
+            try:
+                await self.on_response_done()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning("turn-finished notification failed: %s", exc)
+        if not self._has_server_vad and self.on_sid_rotate:
+            try:
+                await self.on_sid_rotate()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning("turn-finished speech-id rotation failed: %s", exc)
+
     async def handle_interruption(self):
         """Handle user interruption of the current response."""
         if not self._is_responding:
@@ -1181,11 +1232,7 @@ class _TransportMixin:
                             )
                     except Exception:
                         pass
-                    self._is_responding = False
-                    self._current_response_id = None
-                    self._current_item_id = None
-                    self._skip_until_next_response = False
-                    self._interrupted = False  # 确保中断标志在响应结束时清除，防止阻塞下一轮 text.delta
+                    self._clear_turn_response_state()
                     # 响应完成，检测重复度
                     if self._current_response_transcript:
                         self._last_response_transcript = self._current_response_transcript
@@ -1223,21 +1270,7 @@ class _TransportMixin:
                         )
                         self._is_first_transcript_chunk = False
                     self._reset_per_turn_output_state()
-                    if self.on_response_done:
-                        await self.on_response_done()
-                    # No-server-VAD providers (Gemini-proxy: lanlan.app+free /
-                    # livestream) never emit input_audio_buffer.speech_stopped,
-                    # so handle_messages' on_new_message path on speech_stopped
-                    # never fires and current_speech_id never rotates between
-                    # turns. Without rotation, TTS upstream silently drops text
-                    # after the first tts.response.done closes the initial sid.
-                    # Hook here at response.done (Gemini's turn_complete, the
-                    # only reliable end-of-AI-turn signal in those proxies) and
-                    # call the lightweight rotate-only path — full
-                    # handle_new_message would clip trailing TTS audio and
-                    # mis-fire USER_INPUT (no user input actually happened).
-                    if not self._has_server_vad and self.on_sid_rotate:
-                        await self.on_sid_rotate()
+                    await self._notify_turn_finished()
                 elif event_type == "response.created":
                     self._response_arbiter.notify_response_created(event)
                     self._response_created_total += 1

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -1336,11 +1336,24 @@ class _TransportMixin:
             # Leaving this turn's per-turn flags for the successor's own
             # terminal to clear is the lesser harm, and the successor's
             # `response.created` overwrites the identity fields regardless.
+            # One thing does still have to happen: give up the identity. The
+            # stale-event filter keys on `_current_response_id`, so leaving it
+            # naming the abandoned response makes that response's LATER
+            # id-bearing events match and pass — a delayed
+            # `function_call_arguments.done` would execute its tool, and its
+            # `response.done` would run a full finalization against the user's
+            # new turn. Clearing it is what quarantines them, and it is the one
+            # piece of `_clear_turn_response_state` that belongs to the dead
+            # turn rather than the live one: `_is_responding`, `_interrupted`
+            # and the per-turn flags are the successor's now.
             logger.info(
-                "a turn already started before this release ran (%s); leaving "
-                "the host alone",
+                "a turn already started before this release ran (%s); "
+                "quarantining %s and leaving the rest of the host alone",
                 reason,
+                self._current_response_id,
             )
+            self._current_response_id = None
+            self._current_item_id = None
             return
         logger.info("Ending abandoned turn after arbiter release: %s", reason)
         # Captured before the reset, which is what clears the buffer: a stalled

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -1056,13 +1056,25 @@ class _TransportMixin:
         because both can block on the same frontend socket and a new turn can
         start between them.
 
-        ``on_sid_rotate`` is never bounded, on purpose:
-        ``rotate_speech_id_for_response_done`` clears
-        ``_tts_done_queued_for_turn`` and ``_tts_done_pending_until_ready``
-        and only THEN takes the session lock, so cancelling it at that lock
-        leaves the host half-rotated — the flags say a fresh turn, the speech
-        id still says the old one. A skipped rotation is recoverable by the
-        next turn's terminal; a half-applied one is not.
+        ``on_sid_rotate`` gets no step bound of its own, because it is the
+        last step — there is nothing behind it for a slow hook to starve. That
+        is NOT the same as being uncancellable, and an earlier version of this
+        comment claimed it was: the arbiter bounds the whole notification, so
+        the rotation can still be cancelled at its only await, taking the
+        session lock. Today that leaves the host half-rotated — the TTS flags
+        say a fresh turn while the speech id still says the old one — because
+        ``rotate_speech_id_for_response_done`` writes those flags before it
+        takes the lock.
+
+        Measured, that state is repaired by the next turn's terminal, which
+        rotates unconditionally; it is not the permanent silence the earlier
+        comment described. It also is not this path's to fix: the rotation has
+        two other callers that are cancelled just as ordinarily and with no
+        escape hatch involved
+        ([_responses.py](main_logic/omni_realtime_client/_responses.py) and
+        [proactive.py](main_logic/core/proactive.py), both inside
+        fire-and-forget tasks), so making the rotation all-or-nothing belongs
+        in the rotation itself. Tracked separately.
 
         ``on_sid_rotate`` is conditional because providers WITH server VAD
         rotate the speech id from ``speech_stopped`` instead; firing here too

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -911,7 +911,9 @@ class _TransportMixin:
             logger.error(f"Error streaming image: {e}")
             raise e
 
-    async def _check_repetition(self, response: str) -> bool:
+    async def _check_repetition(
+        self, response: str, should_recover: Callable[[], bool] | None = None
+    ) -> bool:
         """
         Check whether the reply is highly repetitive of recent replies.
         Returns True and triggers the callback if 3 consecutive turns are highly repetitive.
@@ -937,6 +939,18 @@ class _TransportMixin:
             self._recent_responses.clear()
 
             # 触发回调
+            if should_recover is not None and not should_recover():
+                # Recording history is about the text this turn produced and
+                # lands nowhere else. The RECOVERY is not: the host clears the
+                # focus state, resets the emotion scorer and warns the user, so
+                # firing it once a new turn has started applies a dead turn's
+                # remedy to a live one. Checked here rather than at the caller
+                # because ``wait_for`` yields before this body runs.
+                logger.info(
+                    "repetition detected on a turn that is no longer current; "
+                    "recording it but skipping the recovery"
+                )
+                return True
             if self.on_repetition_detected:
                 await self.on_repetition_detected()
 
@@ -1073,7 +1087,9 @@ class _TransportMixin:
             )
         return transcript
 
-    async def _record_response_repetition(self, transcript: str) -> None:
+    async def _record_response_repetition(
+        self, transcript: str, should_recover: Callable[[], bool] | None = None
+    ) -> None:
         """Add what this turn said to the repetition history.
 
         Ending a turn has to do this on EVERY path, not just the terminal one.
@@ -1087,7 +1103,7 @@ class _TransportMixin:
         """
 
         if transcript:
-            await self._check_repetition(transcript)
+            await self._check_repetition(transcript, should_recover)
 
     def _take_pending_output_transcript(self) -> tuple[str, bool] | None:
         """Decide what the fallback flush owes the host, and settle the state.
@@ -1338,7 +1354,7 @@ class _TransportMixin:
         # the fallback transcript flush.
         try:
             await asyncio.wait_for(
-                self._record_response_repetition(pending_response),
+                self._record_response_repetition(pending_response, _still_ours),
                 _STUCK_RELEASE_STEP_TIMEOUT,
             )
         except asyncio.CancelledError:

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -1011,8 +1011,12 @@ class _TransportMixin:
                 call_type="conversation_realtime",
                 source="main_logic/omni_realtime_client",
             )
-        except Exception:
-            pass
+        except Exception as exc:
+            # Accounting is bookkeeping, and it runs on the receive loop. A
+            # tracker that is unavailable, or a provider whose usage payload
+            # has an unexpected shape, must not take the voice session down
+            # with it — the turn itself already happened either way.
+            logger.debug("realtime usage accounting skipped: %s", exc)
 
     def _take_response_transcript(self) -> str:
         """Close the books on what this turn actually said.

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -956,6 +956,42 @@ class _TransportMixin:
             self._image_description = _IMAGE_ANALYSIS_PENDING_DESCRIPTION
         self._image_sent_this_turn = False
 
+    async def _flush_pending_output_transcript(self) -> None:
+        """Forward transcript text this turn produced but never flushed.
+
+        Some providers (the lanlan.app Gemini proxy among them) emit
+        ``response.audio_transcript.delta`` and no transcript-done event, so
+        the buffer is normally drained by the streaming branch. In a turn that
+        used tools, the tool round's terminal clears
+        ``_print_input_transcript``, and the real reply's transcript then
+        accumulates in the buffer with nothing left to flush it — resetting
+        per-turn state would drop it and the frontend shows audio with no text.
+
+        Fires only when this turn actually spoke, so a normal turn is a no-op
+        and nothing is sent twice. Must run BEFORE the per-turn reset, which
+        is what clears the buffer.
+        """
+
+        if not (
+            self._output_transcript_buffer
+            and self.on_output_transcript
+            and self._audio_delta_count > 0
+        ):
+            return
+        # 「有声无字」是反复出现的问题（见 ISSUE4b），留一条 debug 日志方便下次
+        # 诊断时确认是这条兜底生效、还是 streaming/transcript.done 路径生效。
+        # audio_delta_count 此处尚未清零，记录的是本轮真实值。
+        logger.debug(
+            "turn-end 兜底 flush 输出转录: buffer_len=%d audio_deltas=%d is_first=%s",
+            len(self._output_transcript_buffer),
+            self._audio_delta_count,
+            self._is_first_transcript_chunk,
+        )
+        await self.on_output_transcript(
+            self._output_transcript_buffer, self._is_first_transcript_chunk
+        )
+        self._is_first_transcript_chunk = False
+
     def _clear_turn_response_state(self) -> None:
         """Drop the flags that say "a response is in progress".
 
@@ -1027,6 +1063,10 @@ class _TransportMixin:
             return
         logger.info("Ending abandoned turn after arbiter release: %s", reason)
         self._clear_turn_response_state()
+        # Before the reset, which is what clears the buffer: a stalled
+        # lifecycle is exactly the case where the terminal that would normally
+        # flush it never arrives.
+        await self._flush_pending_output_transcript()
         self._reset_per_turn_output_state()
         await self._notify_turn_finished()
 
@@ -1274,24 +1314,7 @@ class _TransportMixin:
                     # 就在这里被直接清空 → 前端有声无字。这里在清空前补一次 flush：只要本轮真
                     # 出过声（audio_delta_count>0）且 buffer 仍有残留就补发。streaming 分支每次都
                     # 会清空 buffer，故正常轮此处为 no-op，不会重复发送。
-                    if (
-                        self._output_transcript_buffer
-                        and self.on_output_transcript
-                        and self._audio_delta_count > 0
-                    ):
-                        # 「有声无字」是反复出现的问题（见上方 ISSUE4b），留一条 debug
-                        # 日志方便下次诊断时确认是这条兜底生效、还是 streaming/transcript.done
-                        # 路径生效。audio_delta_count 此处尚未清零，记录的是本轮真实值。
-                        logger.debug(
-                            "response.done 兜底 flush 输出转录: buffer_len=%d audio_deltas=%d is_first=%s",
-                            len(self._output_transcript_buffer),
-                            self._audio_delta_count,
-                            self._is_first_transcript_chunk,
-                        )
-                        await self.on_output_transcript(
-                            self._output_transcript_buffer, self._is_first_transcript_chunk
-                        )
-                        self._is_first_transcript_chunk = False
+                    await self._flush_pending_output_transcript()
                     self._reset_per_turn_output_state()
                     await self._notify_turn_finished()
                 elif event_type == "response.created":

--- a/scripts/realtime_arbiter_probe.py
+++ b/scripts/realtime_arbiter_probe.py
@@ -1,0 +1,608 @@
+#!/usr/bin/env python
+# -- coding: utf-8 --
+"""Measure how much margin a real provider leaves the arbiter's fail-close bounds.
+
+Every bound in ``main_logic/omni_realtime_client/_response_arbiter.py`` was
+chosen without field data, and each one tears the realtime WebSocket down when
+it expires — which the user experiences as a disconnect and session rebuild.
+Unit tests cannot settle whether a bound is right, because the provider in a
+unit test is one we wrote. This probe asks the provider instead.
+
+It drives the real ``OmniRealtimeClient`` rather than hand-rolling the wire
+protocol. That is not incidental: the Lanlan free routes fingerprint the first
+packet and reject anything that is not the application ("Invalid first packet:
+you are not using Lanlan"), and more importantly the numbers are only worth
+having if they came from the same handshake, session config and event sequence
+production uses. A tap on the socket records every frame with a timestamp; the
+client's own behaviour is untouched.
+
+The arbiter's constants are imported rather than copied, so the margin table
+stays honest if a bound is ever retuned.
+
+Deliberately an opt-in development probe. Nothing imports it and no test runs
+it. The free routes are sponsored capacity — the defaults here are small on
+purpose; raise ``--turns`` deliberately, not by habit.
+
+Scenarios
+---------
+baseline     N ordinary turns: create -> created -> done latencies.
+bargein      ``cancel_response(wait=True)`` mid-reply, which is what a user
+             talking over the answer triggers. Highest-frequency fail-close
+             entry in production, and the one with the tightest bound (3s).
+idle-cancel  Cancel with nothing running: what comes back, and does it carry
+             an event_id the arbiter could have correlated?
+soak         Long run counting turns whose ``response.done`` never arrived.
+
+Usage
+-----
+    uv run python scripts/realtime_arbiter_probe.py --route tech
+    uv run python scripts/realtime_arbiter_probe.py --route app --scenario bargein
+    uv run python scripts/realtime_arbiter_probe.py --route tech --scenario soak \
+        --soak-minutes 30 --json-out probe-tech.json
+
+``--route tech`` is www.lanlan.tech (China free, StepFun-backed, server VAD);
+``--route app`` is www.lanlan.app (international free, Gemini proxy, NO server
+VAD — the only route where the deliberately unbounded speech-id rotation runs).
+They exercise different arbiter paths and both are worth a run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import statistics
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from main_logic.omni_realtime_client import OmniRealtimeClient  # noqa: E402
+from main_logic.omni_realtime_client._response_arbiter import (  # noqa: E402
+    _DEFAULT_RESPONSE_DONE_TIMEOUT,
+    _SERVER_VAD_RESPONSE_STARTED_TIMEOUT,
+)
+
+
+# The per-ticket defaults ``enqueue`` applies unless a caller overrides them.
+# Kept as a table because they are keyword defaults on a method signature; the
+# two that are module constants are imported so they cannot drift silently.
+_ARBITER_BOUNDS: dict[str, float] = {
+    "item_ack": 1.5,
+    "response_started": 5.0,
+    "response_done": _DEFAULT_RESPONSE_DONE_TIMEOUT,
+    "cancel": 3.0,
+    "server_vad_started": _SERVER_VAD_RESPONSE_STARTED_TIMEOUT,
+}
+
+_ROUTES = {
+    "tech": {
+        "url": "wss://www.lanlan.tech/core",
+        "label": "lanlan.tech (China free, StepFun proxy, server VAD)",
+        "expects_server_vad": True,
+    },
+    "app": {
+        "url": "wss://www.lanlan.app/core",
+        "label": "lanlan.app (international free, Gemini proxy, no server VAD)",
+        "expects_server_vad": False,
+    },
+}
+
+_FREE_API_KEY = "free-access"
+_FREE_MODEL = "free-model"
+
+# Short, boring and identical every turn: the point is to time the protocol,
+# not to explore the model. A varying prompt makes latencies incomparable.
+_PROMPT = "用一句话说说今天的天气。"
+_INSTRUCTIONS = "你是一个简短作答的助手，每次回答控制在一句话以内。"
+
+
+@dataclass
+class _Turn:
+    """One request's observed lifecycle, in seconds since the probe started."""
+
+    label: str
+    sent_at: float
+    created_at: float | None = None
+    done_at: float | None = None
+    item_acked_at: float | None = None
+    first_delta_at: float | None = None
+    cancel_sent_at: float | None = None
+    response_id: str | None = None
+    status: str | None = None
+    # An id-less streaming provider is the case the escape hatch documents as
+    # unprotectable (issue #2611). It is a property of the provider, so only a
+    # run like this one can establish whether that case is real here.
+    stream_events: int = 0
+    stream_events_with_id: int = 0
+
+    @staticmethod
+    def _delta(a: float | None, b: float | None) -> float | None:
+        if a is None or b is None:
+            return None
+        return b - a
+
+
+@dataclass
+class _Observations:
+    route: str
+    scenario: str
+    turns: list[_Turn] = field(default_factory=list)
+    errors: list[dict[str, Any]] = field(default_factory=list)
+    idle_cancel_replies: list[dict[str, Any]] = field(default_factory=list)
+    server_vad_seen: bool = False
+    connection_errors: list[str] = field(default_factory=list)
+    # Set when the arbiter itself decided to drop the transport. This is what
+    # the whole probe exists to detect, so it is reported whether or not any
+    # latency was interesting.
+    teardown: str | None = None
+    frames_in: int = 0
+
+
+class _TappedSocket:
+    """Pass-through wrapper that timestamps every inbound frame.
+
+    ``handle_messages`` consumes the socket with ``async for message in
+    self.ws``, so overriding ``__aiter__`` is enough to see everything the
+    client sees, in the order it sees it, without changing what it does.
+    Everything else is delegated, including ``send`` and ``close``.
+    """
+
+    def __init__(self, inner: Any, on_frame: Any) -> None:
+        self._inner = inner
+        self._on_frame = on_frame
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
+
+    async def __aiter__(self):
+        async for message in self._inner:
+            self._on_frame(message)
+            yield message
+
+
+class _Probe:
+    def __init__(self, route: str, verbose: bool) -> None:
+        self._route = route
+        self._verbose = verbose
+        self._obs = _Observations(route=route, scenario="")
+        self._t0 = time.monotonic()
+        self._client: OmniRealtimeClient | None = None
+        self._pump: asyncio.Task | None = None
+        self._by_response_id: dict[str, _Turn] = {}
+        self._open: _Turn | None = None
+        self._announced = asyncio.Event()
+        self._terminal = asyncio.Event()
+        self._first_delta = asyncio.Event()
+        self._idle_cancel_watch: list[dict[str, Any]] | None = None
+
+    # -- plumbing ---------------------------------------------------------
+
+    @property
+    def observations(self) -> _Observations:
+        return self._obs
+
+    def _stamp(self) -> float:
+        return time.monotonic() - self._t0
+
+    def _log(self, message: str) -> None:
+        if self._verbose:
+            print(f"[{self._stamp():7.3f}s] {message}", flush=True)
+
+    async def connect(self, url_override: str | None = None) -> None:
+        spec = _ROUTES[self._route]
+        url = url_override or spec["url"]
+
+        async def _on_connection_error(reason: str) -> None:
+            self._obs.connection_errors.append(f"{self._stamp():.3f}s {reason}")
+            self._log(f"!! connection error: {reason}")
+
+        client = OmniRealtimeClient(
+            url,
+            _FREE_API_KEY,
+            model=_FREE_MODEL,
+            api_type="free",
+            on_connection_error=_on_connection_error,
+        )
+        await client.connect(_INSTRUCTIONS)
+        client.ws = _TappedSocket(client.ws, self._on_frame)
+        self._client = client
+        self._pump = asyncio.create_task(client.handle_messages())
+        # The provider acknowledges session.update asynchronously; let that
+        # settle so it does not show up as first-turn latency.
+        await asyncio.sleep(1.5)
+
+    async def close(self) -> None:
+        if self._pump is not None:
+            self._pump.cancel()
+            try:
+                await self._pump
+            except BaseException:
+                pass
+        if self._client is not None:
+            try:
+                await self._client.close()
+            except BaseException:
+                pass
+
+    # -- observation ------------------------------------------------------
+
+    def _on_frame(self, raw: Any) -> None:
+        self._obs.frames_in += 1
+        try:
+            event = json.loads(raw)
+        except (TypeError, ValueError):
+            return
+        if not isinstance(event, dict):
+            return
+        self._record(event)
+
+    def _record(self, event: dict[str, Any]) -> None:
+        etype = str(event.get("type") or "")
+        now = self._stamp()
+        response_id = self._response_id_of(event)
+
+        if etype.startswith("input_audio_buffer.speech_"):
+            self._obs.server_vad_seen = True
+            return
+
+        if etype == "conversation.item.created":
+            if self._open is not None and self._open.item_acked_at is None:
+                self._open.item_acked_at = now
+            return
+
+        if etype == "response.created":
+            self._log(f"<- response.created id={response_id}")
+            if self._open is not None and self._open.created_at is None:
+                self._open.created_at = now
+                self._open.response_id = response_id
+                if response_id:
+                    self._by_response_id[response_id] = self._open
+                self._announced.set()
+            return
+
+        if etype == "response.done":
+            response = event.get("response")
+            status = ""
+            if isinstance(response, dict):
+                status = str(response.get("status") or "")
+            self._log(f"<- response.done id={response_id} status={status or '(none)'}")
+            turn = self._resolve(response_id)
+            if turn is not None:
+                turn.done_at = now
+                turn.status = status or None
+            self._terminal.set()
+            return
+
+        if etype == "error":
+            err = event.get("error") if isinstance(event.get("error"), dict) else {}
+            record = {
+                "at": now,
+                "message": str(event.get("error"))[:400],
+                # Whether the provider echoes the offending client event_id is
+                # what decides whether an arbiter could ever correlate this
+                # error back to the request it belongs to.
+                "echoed_event_id": err.get("event_id") or event.get("event_id"),
+                "code": err.get("code") or err.get("type"),
+            }
+            self._log(f"<- error code={record['code']} echo={record['echoed_event_id']}")
+            self._obs.errors.append(record)
+            if self._idle_cancel_watch is not None:
+                self._idle_cancel_watch.append(record)
+            self._terminal.set()
+            return
+
+        if etype.startswith("response."):
+            turn = self._resolve(response_id)
+            if turn is not None:
+                turn.stream_events += 1
+                if response_id:
+                    turn.stream_events_with_id += 1
+                if turn.first_delta_at is None:
+                    turn.first_delta_at = now
+            self._first_delta.set()
+
+    @staticmethod
+    def _response_id_of(event: dict[str, Any]) -> str | None:
+        direct = event.get("response_id")
+        if direct:
+            return str(direct)
+        response = event.get("response")
+        if isinstance(response, dict) and response.get("id"):
+            return str(response["id"])
+        return None
+
+    def _resolve(self, response_id: str | None) -> _Turn | None:
+        if response_id and response_id in self._by_response_id:
+            return self._by_response_id[response_id]
+        return self._open
+
+    # -- scenarios --------------------------------------------------------
+
+    async def run_turn(self, label: str, *, barge_in: bool = False) -> _Turn:
+        """Drive one create -> created -> done cycle, optionally cancelling it."""
+
+        assert self._client is not None
+        turn = _Turn(label=label, sent_at=self._stamp())
+        self._open = turn
+        self._announced.clear()
+        self._terminal.clear()
+        self._first_delta.clear()
+
+        try:
+            await self._client.create_response(_PROMPT)
+        except ConnectionError as exc:
+            # The headline observation, not an error to crash on: the arbiter
+            # gave up on a lifecycle and tore the transport down, which the
+            # user experiences as a disconnect and session rebuild. Record what
+            # it said and stop — the socket is gone, so every later turn would
+            # only re-report the same corpse.
+            self._obs.teardown = f"{self._stamp():.2f}s {exc}"
+            self._log(f"!! arbiter tore the transport down: {exc}")
+            self._open = None
+            self._obs.turns.append(turn)
+            return turn
+
+        # Deliberately generous: the probe measures how long things take, so
+        # its own waits must never be what expires. The comparison against the
+        # arbiter's bound happens in the report, not here.
+        try:
+            await asyncio.wait_for(
+                self._announced.wait(), max(_ARBITER_BOUNDS["response_started"] * 4, 20.0)
+            )
+        except asyncio.TimeoutError:
+            self._log("!! no response.created")
+
+        if barge_in:
+            try:
+                await asyncio.wait_for(self._first_delta.wait(), 15.0)
+            except asyncio.TimeoutError:
+                self._log("!! nothing streaming to barge in on")
+            turn.cancel_sent_at = self._stamp()
+            # Exactly what the production barge-in does: cancel_response(wait=True)
+            # is cancel_current(), the 3s bound whose expiry tears the socket down.
+            # Swallow its TimeoutError here — that IS the measurement.
+            try:
+                await self._client.cancel_response(wait=True)
+            except asyncio.TimeoutError:
+                self._log("!! cancel_current timed out — this is a fail-close in production")
+            except Exception as exc:  # noqa: BLE001 - probe records, never fails
+                self._log(f"!! cancel raised {type(exc).__name__}: {exc}")
+
+        try:
+            await asyncio.wait_for(
+                self._terminal.wait(), max(_ARBITER_BOUNDS["response_done"], 30.0)
+            )
+        except asyncio.TimeoutError:
+            self._log("!! no terminal event")
+
+        self._open = None
+        self._obs.turns.append(turn)
+        return turn
+
+    async def run_idle_cancel(self) -> None:
+        """Cancel with nothing running and record exactly what comes back.
+
+        This is the reply the arbiter cannot correlate today: ``response.cancel``
+        goes out unstamped by any ticket, so an error echoing its event_id
+        matches no ticket's ``event_ids``. Whether that matters at all depends
+        on what this provider actually answers.
+        """
+
+        assert self._client is not None
+        watch: list[dict[str, Any]] = []
+        self._idle_cancel_watch = watch
+        try:
+            # wait=False: send the bare cancel without entering the 3s wait, so
+            # what is measured is the provider's reply, not our own bound.
+            await self._client.cancel_response(wait=False)
+            deadline = self._stamp() + 8.0
+            while self._stamp() < deadline and not watch:
+                await asyncio.sleep(0.25)
+        finally:
+            self._idle_cancel_watch = None
+        if not watch:
+            watch.append(
+                {
+                    "message": "(no reply at all within 8s)",
+                    "echoed_event_id": None,
+                    "code": None,
+                }
+            )
+        self._obs.idle_cancel_replies.extend(watch)
+
+
+def _summarize(values: list[float | None]) -> dict[str, float] | None:
+    clean = [v for v in values if v is not None]
+    if not clean:
+        return None
+    ordered = sorted(clean)
+    index = min(len(ordered) - 1, int(round(0.95 * (len(ordered) - 1))))
+    return {
+        "n": float(len(ordered)),
+        "p50": statistics.median(ordered),
+        "p95": ordered[index],
+        "max": ordered[-1],
+    }
+
+
+def _margin_line(name: str, stats: dict[str, float] | None, bound: float) -> str:
+    if stats is None:
+        return f"  {name:<22} (no observations){' ' * 30}bound={bound:>5.1f}s"
+    worst = stats["max"]
+    pct = 100.0 * worst / bound if bound else 0.0
+    verdict = "OK" if pct < 50 else ("TIGHT" if pct < 100 else "OVER")
+    return (
+        f"  {name:<22} n={int(stats['n']):<3d} p50={stats['p50']:6.2f}s "
+        f"p95={stats['p95']:6.2f}s max={worst:6.2f}s  bound={bound:>5.1f}s "
+        f"worst={pct:5.1f}%  {verdict}"
+    )
+
+
+def _report(obs: _Observations) -> dict[str, Any]:
+    announce = [_Turn._delta(t.sent_at, t.created_at) for t in obs.turns]
+    complete = [_Turn._delta(t.created_at, t.done_at) for t in obs.turns]
+    item_ack = [_Turn._delta(t.sent_at, t.item_acked_at) for t in obs.turns]
+    cancel = [
+        _Turn._delta(t.cancel_sent_at, t.done_at)
+        for t in obs.turns
+        if t.cancel_sent_at is not None
+    ]
+    missing = [t.label for t in obs.turns if t.done_at is None]
+    idless = [t.label for t in obs.turns if t.stream_events and not t.stream_events_with_id]
+
+    stats = {
+        "item_ack": _summarize(item_ack),
+        "response_started": _summarize(announce),
+        "response_done": _summarize(complete),
+        "cancel": _summarize(cancel),
+    }
+
+    print()
+    print("=" * 80)
+    print(f"route     {_ROUTES[obs.route]['label']}")
+    print(f"scenario  {obs.scenario}   turns={len(obs.turns)}   frames={obs.frames_in}")
+    print("-" * 80)
+    print("margin against the arbiter's fail-close bounds")
+    print(_margin_line("item ack", stats["item_ack"], _ARBITER_BOUNDS["item_ack"]))
+    print(_margin_line("response announce", stats["response_started"], _ARBITER_BOUNDS["response_started"]))
+    print(_margin_line("response complete", stats["response_done"], _ARBITER_BOUNDS["response_done"]))
+    print(_margin_line("cancel -> terminal", stats["cancel"], _ARBITER_BOUNDS["cancel"]))
+    print("-" * 80)
+    print(f"terminals never received : {len(missing)} / {len(obs.turns)}")
+    if missing:
+        print(f"  a lost terminal holds the lane {_DEFAULT_RESPONSE_DONE_TIMEOUT:.0f}s: {missing}")
+    print(
+        f"server VAD frames seen   : {obs.server_vad_seen} "
+        f"(expected {_ROUTES[obs.route]['expects_server_vad']})"
+    )
+    print(
+        f"turns with id-less stream: {len(idless)}"
+        f"{'   <- issue #2611 applies on this route' if idless else ''}"
+    )
+    if obs.teardown:
+        print(f"ARBITER TORE DOWN THE SOCKET : {obs.teardown}")
+        print("  this is the user-visible disconnect the escape hatch exists for")
+    else:
+        print("arbiter teardown         : none")
+    for reason in obs.connection_errors:
+        print(f"  connection error: {reason}")
+    if obs.idle_cancel_replies:
+        print("-" * 80)
+        print("reply to a cancel with nothing running:")
+        for record in obs.idle_cancel_replies:
+            print(f"  code={record.get('code')} echoed_event_id={record.get('echoed_event_id')}")
+            print(f"    {str(record.get('message'))[:220]}")
+    if obs.errors:
+        print("-" * 80)
+        print(f"provider errors          : {len(obs.errors)}")
+        for record in obs.errors[:5]:
+            print(f"  {record['at']:.2f}s code={record['code']} {record['message'][:140]}")
+    print("=" * 80)
+
+    return {
+        "route": obs.route,
+        "scenario": obs.scenario,
+        "bounds": _ARBITER_BOUNDS,
+        "stats": stats,
+        "teardown": obs.teardown,
+        "missing_terminal": missing,
+        "idless_stream_turns": idless,
+        "server_vad_seen": obs.server_vad_seen,
+        "connection_errors": obs.connection_errors,
+        "idle_cancel_replies": obs.idle_cancel_replies,
+        "errors": obs.errors,
+        "turns": [
+            {
+                "label": t.label,
+                "response_id": t.response_id,
+                "status": t.status,
+                "announce_s": _Turn._delta(t.sent_at, t.created_at),
+                "complete_s": _Turn._delta(t.created_at, t.done_at),
+                "cancel_s": _Turn._delta(t.cancel_sent_at, t.done_at),
+                "stream_events": t.stream_events,
+                "stream_events_with_id": t.stream_events_with_id,
+            }
+            for t in obs.turns
+        ],
+    }
+
+
+async def _run(args: argparse.Namespace) -> dict[str, Any]:
+    probe = _Probe(args.route, verbose=not args.quiet)
+    probe.observations.scenario = args.scenario
+    await probe.connect(args.url)
+    obs = probe.observations
+    try:
+        if args.scenario in ("baseline", "all"):
+            for index in range(args.turns):
+                await probe.run_turn(f"baseline-{index + 1}")
+                if obs.teardown:
+                    break
+                await asyncio.sleep(args.gap)
+
+        if args.scenario in ("bargein", "all") and not obs.teardown:
+            for index in range(args.turns):
+                await probe.run_turn(f"bargein-{index + 1}", barge_in=True)
+                if obs.teardown:
+                    break
+                await asyncio.sleep(args.gap)
+
+        if args.scenario in ("idle-cancel", "all") and not obs.teardown:
+            await probe.run_idle_cancel()
+
+        if args.scenario == "soak":
+            deadline = time.monotonic() + args.soak_minutes * 60
+            index = 0
+            while time.monotonic() < deadline and not obs.teardown:
+                index += 1
+                await probe.run_turn(f"soak-{index}")
+                await asyncio.sleep(args.gap)
+    finally:
+        await probe.close()
+
+    return _report(probe.observations)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Realtime arbiter provider probe")
+    parser.add_argument("--route", choices=sorted(_ROUTES), default="tech")
+    parser.add_argument(
+        "--url",
+        default=None,
+        help=(
+            "override the route's websocket URL. Use for a self-hosted or "
+            "livestream upstream, or to point the probe at a local stub while "
+            "validating the probe itself. --route still selects which "
+            "server-VAD expectation the report checks against."
+        ),
+    )
+    parser.add_argument(
+        "--scenario",
+        choices=["baseline", "bargein", "idle-cancel", "soak", "all"],
+        default="all",
+    )
+    parser.add_argument("--turns", type=int, default=5, help="turns per scenario")
+    parser.add_argument("--gap", type=float, default=2.0, help="seconds between turns")
+    parser.add_argument("--soak-minutes", type=float, default=30.0)
+    parser.add_argument("--json-out", type=Path, default=None)
+    parser.add_argument("--quiet", action="store_true", help="suppress the event trace")
+    args = parser.parse_args()
+
+    try:
+        result = asyncio.run(_run(args))
+    except KeyboardInterrupt:
+        print("interrupted", file=sys.stderr)
+        return 130
+
+    if args.json_out is not None:
+        args.json_out.write_text(json.dumps(result, ensure_ascii=False, indent=2))
+        print(f"wrote {args.json_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/realtime_arbiter_probe.py
+++ b/scripts/realtime_arbiter_probe.py
@@ -104,7 +104,27 @@ _FREE_MODEL = "free-model"
 # produce numbers that are precise about the wrong traffic. Not a user-facing
 # prompt: it never leaves this dev probe.
 _PROMPT = "用一句话说说今天的天气。"  # noqa: INLINE_PROMPT_NON_EN  # measurement realism, see above
-_INSTRUCTIONS = "你是一个简短作答的助手，每次回答控制在一句话以内。"  # noqa: INLINE_PROMPT_NON_EN
+
+# The Lanlan free routes admit a client by watermark: the session instructions
+# must carry this line from the character system prompt
+# (config/prompts/prompts_chara.py, <Context Awareness>). It is what tells the
+# proxy the connection is N.E.K.O rather than a third party reselling sponsored
+# capacity — without it the socket is closed with
+# ``1008 Invalid first packet: you are not using Lanlan``.
+#
+# Reproduced with {LANLAN_NAME} already substituted: update_session runs
+# llm_prompt_leak_check over the payload and asserts on any unrendered
+# {placeholder}.
+_WATERMARK = (
+    "- System Info: The system periodically sends some useful information to "
+    "Neko. Neko can leverage this information to better understand the context."
+)
+_INSTRUCTIONS = (
+    "You are a terse assistant. Answer in one short sentence.\n"
+    "<Context Awareness>\n"
+    f"{_WATERMARK}\n"
+    "</Context Awareness>"
+)
 
 
 @dataclass

--- a/scripts/realtime_arbiter_probe.py
+++ b/scripts/realtime_arbiter_probe.py
@@ -96,8 +96,15 @@ _FREE_MODEL = "free-model"
 
 # Short, boring and identical every turn: the point is to time the protocol,
 # not to explore the model. A varying prompt makes latencies incomparable.
-_PROMPT = "用一句话说说今天的天气。"
-_INSTRUCTIONS = "你是一个简短作答的助手，每次回答控制在一句话以内。"
+#
+# Chinese on purpose, and the reason is the measurement itself. What is being
+# timed is how long `response.done` takes, and that is driven by how much the
+# model says and how long its audio runs — both language-dependent. These are
+# the routes a Chinese-language product ships on, so an English prompt would
+# produce numbers that are precise about the wrong traffic. Not a user-facing
+# prompt: it never leaves this dev probe.
+_PROMPT = "用一句话说说今天的天气。"  # noqa: INLINE_PROMPT_NON_EN  # measurement realism, see above
+_INSTRUCTIONS = "你是一个简短作答的助手，每次回答控制在一句话以内。"  # noqa: INLINE_PROMPT_NON_EN
 
 
 @dataclass

--- a/tests/unit/test_realtime_arbiter_escalation_scope.py
+++ b/tests/unit/test_realtime_arbiter_escalation_scope.py
@@ -160,6 +160,63 @@ async def test_an_unnamed_escalation_still_acts(harness):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_an_escalation_whose_terminal_just_arrived_does_nothing(harness, caplog):
+    # The race a timeout cannot avoid: notify_response_terminal clears
+    # _response_owner synchronously, but the worker has not run its finally,
+    # so _current still names a request that is in fact finished. Identity
+    # alone would call that stuck.
+    ticket = await harness.arbiter.enqueue(source="turn-a")
+    await asyncio.wait_for(ticket.sent, timeout=1)
+    harness.arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "resp-a"}}
+    )
+    observed = harness.arbiter._current
+    assert observed is not None
+
+    harness.arbiter.notify_response_terminal(
+        {"type": "response.done", "response": {"id": "resp-a"}}
+    )
+    # Deliberately no settle: the worker has not unwound, so _current still
+    # points at the finished request — exactly the window being tested.
+    assert harness.arbiter._current is observed
+    assert observed.terminal is not None and observed.terminal.done()
+
+    with caplog.at_level(logging.DEBUG, logger=ARBITER_LOGGER):
+        await harness.arbiter._escalate("racing escalation", observed=observed)
+
+    assert harness.aborted == [], (
+        "a request whose terminal just landed is finished, not stuck"
+    )
+    assert harness.arbiter._connection_available is True
+    assert any(
+        "its terminal arrived" in record.getMessage() for record in caplog.records
+    )
+    await asyncio.wait_for(ticket.done, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_an_escalation_after_its_own_cancel_still_acts(harness):
+    # The dual, and the reason the check excludes cancelled futures: the
+    # escalation paths cancel the terminal themselves immediately before
+    # calling in. Treating that as an arrival would suppress every real
+    # escalation — which is what a first attempt at this guard did.
+    ticket = await harness.arbiter.enqueue(
+        source="turn-a", response_started_timeout=0.05, cancel_timeout=0.05
+    )
+    await asyncio.wait_for(ticket.sent, timeout=1)
+
+    with pytest.raises(Exception):
+        await asyncio.wait_for(ticket.done, timeout=2)
+    await _settle()
+
+    assert harness.aborted, (
+        "a terminal cancelled by the escalation path is not an arrival"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_two_concurrent_cancellers_cost_only_the_stuck_turn(harness):
     # The user-visible shape of the same defect, driven through the public
     # API instead of the private one: two callers cancel the same stuck

--- a/tests/unit/test_realtime_arbiter_escalation_scope.py
+++ b/tests/unit/test_realtime_arbiter_escalation_scope.py
@@ -238,3 +238,62 @@ async def test_two_concurrent_cancellers_cost_only_the_stuck_turn(harness):
     assert len(harness.aborted) == 1, (
         f"a second canceller must not escalate again: {harness.aborted}"
     )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_terminal_that_failed_is_not_mistaken_for_one_that_arrived(harness):
+    # The guard above says "its terminal actually arrived". But notify_error
+    # finishes that SAME future with set_exception when the provider reports a
+    # correlated error — during the cancel grace period that is the ordinary
+    # way a stuck lifecycle ends — and an error is not an arrival. Treating it
+    # as one skipped the recovery outright: no teardown, no release, and the
+    # lane left owned until some later timeout noticed.
+    ticket = await harness.arbiter.enqueue(source="turn-a")
+    await asyncio.wait_for(ticket.sent, timeout=1)
+    harness.arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "resp-a"}}
+    )
+    observed = harness.arbiter._response_owner
+    assert observed is not None
+
+    harness.arbiter.notify_error(None, "response_already_active")
+    assert observed.terminal is not None and observed.terminal.done()
+    assert observed.terminal.exception() is not None, (
+        "notify_error finishes the terminal future with an exception"
+    )
+
+    await harness.arbiter._escalate("terminal never arrived", observed=observed)
+
+    assert harness.aborted == ["terminal never arrived"], (
+        "a lifecycle whose terminal FAILED is stuck, not finished"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_terminal_that_arrived_with_a_result_still_suppresses_escalation(
+    harness,
+):
+    # The dual, and the case the guard exists for: notify_response_terminal
+    # completes the future with a RESULT, and escalating then would end an
+    # already-completed turn a second time.
+    ticket = await harness.arbiter.enqueue(source="turn-a")
+    await asyncio.wait_for(ticket.sent, timeout=1)
+    harness.arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "resp-a"}}
+    )
+    observed = harness.arbiter._current
+    assert observed is not None
+
+    harness.arbiter.notify_response_terminal(
+        {"type": "response.done", "response": {"id": "resp-a"}}
+    )
+    assert observed.terminal is not None and observed.terminal.done()
+    assert observed.terminal.exception() is None
+
+    await harness.arbiter._escalate("racing escalation", observed=observed)
+
+    assert harness.aborted == []
+    assert harness.arbiter._connection_available is True
+    await asyncio.wait_for(ticket.done, timeout=1)

--- a/tests/unit/test_realtime_arbiter_escalation_scope.py
+++ b/tests/unit/test_realtime_arbiter_escalation_scope.py
@@ -104,7 +104,7 @@ async def test_an_escalation_for_a_finished_request_does_nothing(harness, caplog
     assert harness.arbiter._response_owner is not observed
 
     with caplog.at_level(logging.DEBUG, logger=ARBITER_LOGGER):
-        await harness.arbiter._fail_closed("late escalation", observed=observed)
+        await harness.arbiter._escalate("late escalation", observed=observed)
 
     assert harness.aborted == [], (
         "an escalation naming a finished request must not tear down the "
@@ -137,7 +137,7 @@ async def test_an_escalation_for_the_running_request_still_acts(harness):
     observed = harness.arbiter._response_owner
     assert observed is not None
 
-    await harness.arbiter._fail_closed("real escalation", observed=observed)
+    await harness.arbiter._escalate("real escalation", observed=observed)
 
     assert harness.aborted == ["real escalation"]
     assert harness.arbiter._connection_available is False
@@ -152,7 +152,7 @@ async def test_an_unnamed_escalation_still_acts(harness):
         {"type": "response.created", "response": {"id": "srv-1"}}
     )
 
-    await harness.arbiter._fail_closed("unowned server response stuck")
+    await harness.arbiter._escalate("unowned server response stuck")
 
     assert harness.aborted == ["unowned server response stuck"]
     assert harness.arbiter._connection_available is False

--- a/tests/unit/test_realtime_arbiter_escalation_scope.py
+++ b/tests/unit/test_realtime_arbiter_escalation_scope.py
@@ -1,0 +1,183 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Escalation is scoped to the lifecycle its caller observed.
+
+The contract, stated so it can be falsified:
+
+    An escalation acts on the request whose failure its caller watched, at
+    most once. If that request is no longer the one the arbiter is running,
+    or has already been escalated over, the escalation does nothing — no
+    transport teardown, no lane release, no ticket failed.
+
+The "at most once" half is not decoration: several callers can be waiting on
+the same stuck request and their timeouts fire independently. Under today's
+teardown a repeat is merely noise, but every effect an escalation grows from
+here — releasing a lane, finalizing a host turn — is one that must not happen
+twice to the same turn.
+
+Every escalation site in the arbiter is reached by waiting on one specific
+request's timeout. By the time that timeout fires the arbiter may have moved
+on: the stuck lifecycle finished, the worker picked up the next queued item,
+and ``_current``/``_response_owner`` now name a healthy turn. Escalating on
+"whatever is current" then tears down that healthy turn instead — which is
+how two concurrent cancellers cost an extra request each time.
+
+This was the structural gap behind several findings on PR #2592 (see
+#2583 for the full catalogue): patching individual state conditions could not
+fix it, because the state is shared and the request is the real scope.
+"""
+
+import asyncio
+import logging
+
+import pytest
+
+from main_logic.omni_realtime_client._response_arbiter import RealtimeResponseArbiter
+
+ARBITER_LOGGER = "main_logic.omni_realtime_client._response_arbiter"
+
+
+async def _settle(times: int = 50) -> None:
+    for _ in range(times):
+        await asyncio.sleep(0)
+
+
+class _Harness:
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+        self.aborted: list[str] = []
+        self.arbiter = RealtimeResponseArbiter(self._send, abort_transport=self._abort)
+
+    async def _send(self, event: dict) -> None:
+        self.sent.append(event)
+
+    async def _abort(self, reason: str) -> None:
+        self.aborted.append(reason)
+
+    @property
+    def dispatch_count(self) -> int:
+        return [e.get("type") for e in self.sent].count("response.create")
+
+
+@pytest.fixture
+async def harness():
+    built = _Harness()
+    yield built
+    await built.arbiter.shutdown("test teardown")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_an_escalation_for_a_finished_request_does_nothing(harness, caplog):
+    # The core case. A caller watches request A, A's cancellation times out —
+    # but by then A has completed and the worker is running B. The late
+    # escalation must not touch B.
+    first = await harness.arbiter.enqueue(source="turn-a")
+    await asyncio.wait_for(first.sent, timeout=1)
+    harness.arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "resp-a"}}
+    )
+    observed = harness.arbiter._current
+
+    # A finishes and B takes the lane.
+    harness.arbiter.notify_response_terminal(
+        {"type": "response.done", "response": {"id": "resp-a"}}
+    )
+    await asyncio.wait_for(first.done, timeout=1)
+    second = await harness.arbiter.enqueue(source="turn-b")
+    await asyncio.wait_for(second.sent, timeout=1)
+    harness.arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "resp-b"}}
+    )
+    assert harness.arbiter._response_owner is not None
+    assert harness.arbiter._response_owner is not observed
+
+    with caplog.at_level(logging.DEBUG, logger=ARBITER_LOGGER):
+        await harness.arbiter._fail_closed("late escalation", observed=observed)
+
+    assert harness.aborted == [], (
+        "an escalation naming a finished request must not tear down the "
+        "transport the next turn is using"
+    )
+    assert harness.arbiter._connection_available is True
+    assert harness.arbiter._response_owner is not None, (
+        "the healthy turn must keep its ownership"
+    )
+    assert not second.done.done(), "and its ticket must not be failed"
+    assert any(
+        "no longer current" in record.getMessage() for record in caplog.records
+    ), "a skipped escalation must say so, or it looks like nothing happened"
+
+    harness.arbiter.notify_response_terminal(
+        {"type": "response.done", "response": {"id": "resp-b"}}
+    )
+    await asyncio.wait_for(second.done, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_an_escalation_for_the_running_request_still_acts(harness):
+    # The dual. Without it, "never escalate" would pass the test above.
+    ticket = await harness.arbiter.enqueue(source="turn-a")
+    await asyncio.wait_for(ticket.sent, timeout=1)
+    harness.arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "resp-a"}}
+    )
+    observed = harness.arbiter._response_owner
+    assert observed is not None
+
+    await harness.arbiter._fail_closed("real escalation", observed=observed)
+
+    assert harness.aborted == ["real escalation"]
+    assert harness.arbiter._connection_available is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_an_unnamed_escalation_still_acts(harness):
+    # cancel_current's no-current branch escalates over an unowned server
+    # response and has nothing to name. That path must keep working.
+    harness.arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "srv-1"}}
+    )
+
+    await harness.arbiter._fail_closed("unowned server response stuck")
+
+    assert harness.aborted == ["unowned server response stuck"]
+    assert harness.arbiter._connection_available is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_two_concurrent_cancellers_cost_only_the_stuck_turn(harness):
+    # The user-visible shape of the same defect, driven through the public
+    # API instead of the private one: two callers cancel the same stuck
+    # request. The first escalation is legitimate. The second must not go on
+    # to tear down whatever the arbiter picked up next.
+    stuck = await harness.arbiter.enqueue(source="stuck")
+    await asyncio.wait_for(stuck.sent, timeout=1)
+    harness.arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "resp-stuck"}}
+    )
+
+    first = asyncio.create_task(harness.arbiter.cancel_current(timeout=0.05))
+    second = asyncio.create_task(harness.arbiter.cancel_current(timeout=0.05))
+    results = await asyncio.gather(first, second, return_exceptions=True)
+
+    assert all(isinstance(r, asyncio.TimeoutError) for r in results)
+    # Both watched the same request, so at most one teardown is warranted and
+    # the second must not add another.
+    assert len(harness.aborted) == 1, (
+        f"a second canceller must not escalate again: {harness.aborted}"
+    )

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -2267,9 +2267,14 @@ async def test_a_barge_in_before_the_release_is_not_adopted_as_its_own_turn():
         "clearing the interruption suppression is what lets the abandoned "
         "response's id-less deltas through under the new turn's speech id"
     )
-    assert client._image_sent_this_turn is True, (
-        "per-turn state belongs to whoever owns the turn now; the successor's "
-        "own terminal clears it"
+    assert client._image_sent_this_turn is False, (
+        "per-response output accounting belongs to the DEAD turn, and nothing "
+        "else clears it — response.created resets the transcript buffers but "
+        "not this, so a successor would withhold its own visual context for "
+        "its whole duration"
+    )
+    assert client._audio_delta_count == 0, (
+        "and would count the previous turn's audio as its own"
     )
     assert client._recent_responses == [], (
         "and the repetition check must not run either — its host callback "
@@ -2492,3 +2497,47 @@ async def test_a_quarantined_response_cannot_run_its_tool_afterwards():
         "an abandoned response's tool call must not run under the turn that "
         "replaced it"
     )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_numeric_response_id_still_matches_the_released_one():
+    # Codex P2. The arbiter normalises ids through _event_response_id
+    # (`str(...)`); this side stores whatever the JSON carried. So on a
+    # provider that numbers its responses, every comparison here was false
+    # ("123" != 123) and the release silently finalized nothing and
+    # quarantined nothing — on every single turn, not as a race.
+    done_calls: list[str] = []
+
+    async def _on_done() -> None:
+        done_calls.append("done")
+
+    client = _free_client(on_response_done=_on_done)
+    _begin_response(client, 123)  # what json.loads gives for a numeric id
+    assert client._current_response_id == 123
+
+    await client._on_arbiter_stuck_release("abandoned", "123")
+
+    assert done_calls == ["done"], (
+        "the arbiter's stringified id names the same response the host is "
+        "tracking"
+    )
+    assert client._current_response_id is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_genuinely_different_id_is_still_rejected():
+    # The dual: normalising must not turn the guard into "always match".
+    done_calls: list[str] = []
+
+    async def _on_done() -> None:
+        done_calls.append("done")
+
+    client = _free_client(on_response_done=_on_done)
+    _begin_response(client, 456)
+
+    await client._on_arbiter_stuck_release("abandoned", "123")
+
+    assert done_calls == [], "a different response is not this release's to end"
+    assert client._current_response_id == 456

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -2165,3 +2165,27 @@ async def test_an_undisturbed_release_still_flushes_its_trailing_transcript():
     await client._on_arbiter_stuck_release("abandoned resp-1", "resp-1")
 
     assert transcripts == [("旧轮没送出的半句", True)]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_reconnecting_forgets_which_responses_were_already_billed():
+    # Codex P2, self-inflicted by the previous commit. Response ids are scoped
+    # to a connection, and connect() reuses the same client object across
+    # sessions — so a provider that restarts its numbering after a reconnect
+    # would have the new session's first turns suppressed as already-billed
+    # duplicates. This cache belongs with the other per-connection state
+    # connect() clears before it reaches the provider branch.
+    client = _free_client()
+    client._usage_recorded_ids = ["resp-1", "resp-2"]
+
+    try:
+        await client.connect(instructions="", native_audio=False)
+    except Exception:
+        # There is no provider to reach; the reset happens before any of that.
+        pass
+
+    assert client._usage_recorded_ids == [], (
+        "usage deduplication is scoped to one connection, like the tool-call "
+        "flood window it sits beside"
+    )

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -153,6 +153,52 @@ async def _stick_a_cancel(harness: _Harness) -> Exception | None:
     return None
 
 
+def _free_client(**hooks):
+    """A client on a provider WITHOUT server VAD, where sid rotation matters.
+
+    The lanlan.app host is load-bearing, not decoration: ``_is_free_proxy``
+    keys on it, and that is what makes ``_has_server_vad`` False. With any
+    other host the same ``api_type="free"`` client HAS server VAD, rotates
+    from ``speech_stopped`` instead, and these tests would pass without ever
+    reaching the hook they are about.
+    """
+
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    client = OmniRealtimeClient(
+        "wss://lanlan.app/realtime",
+        "test-key",
+        model="free-model",
+        api_type="free",
+        **hooks,
+    )
+    assert client._has_server_vad is False, (
+        "this fixture exists to cover the providers whose only sid rotation "
+        "point is the turn-finished hook"
+    )
+    return client
+
+
+def _released_client(**hooks):
+    """A fail-open client whose arbiter writes to a list instead of a socket.
+
+    Returns ``(client, arbiter, sent)``. Every test that drives a real release
+    through a real client needs exactly this trio, and hand-rolling it made
+    the one line that actually differs between them hard to find.
+    """
+
+    client = _free_client(**hooks)
+    sent: list[dict] = []
+
+    async def _send(event: dict) -> None:
+        sent.append(event)
+
+    arbiter = client._response_arbiter
+    arbiter._send_event = _send
+    arbiter._fail_open = True
+    return client, arbiter, sent
+
+
 # ---------------------------------------------------------------------------
 # Contract 1: the shipped default is untouched.
 # ---------------------------------------------------------------------------
@@ -704,20 +750,7 @@ async def test_the_release_flushes_transcript_the_turn_never_got_to_send():
     async def _on_output_transcript(text: str, is_first: bool) -> None:
         transcripts.append((text, is_first))
 
-    client = OmniRealtimeClient(
-        "wss://example.invalid/realtime",
-        "test-key",
-        model="free-model",
-        api_type="free",
-        on_output_transcript=_on_output_transcript,
-    )
-
-    async def _send(event: dict) -> None:
-        return None
-
-    arbiter = client._response_arbiter
-    arbiter._send_event = _send
-    arbiter._fail_open = True
+    client, arbiter, sent = _released_client(on_output_transcript=_on_output_transcript)
     try:
         ticket = await arbiter.enqueue(source="native")
         await asyncio.wait_for(ticket.sent, timeout=1)
@@ -757,20 +790,7 @@ async def test_the_release_does_not_flush_a_turn_that_never_spoke():
     async def _on_output_transcript(text: str, is_first: bool) -> None:
         transcripts.append((text, is_first))
 
-    client = OmniRealtimeClient(
-        "wss://example.invalid/realtime",
-        "test-key",
-        model="free-model",
-        api_type="free",
-        on_output_transcript=_on_output_transcript,
-    )
-
-    async def _send(event: dict) -> None:
-        return None
-
-    arbiter = client._response_arbiter
-    arbiter._send_event = _send
-    arbiter._fail_open = True
+    client, arbiter, sent = _released_client(on_output_transcript=_on_output_transcript)
     try:
         ticket = await arbiter.enqueue(source="native")
         await asyncio.wait_for(ticket.sent, timeout=1)
@@ -803,21 +823,7 @@ async def test_the_release_runs_the_hosts_own_end_of_turn_work():
     async def _on_done() -> None:
         done_calls.append("done")
 
-    client = OmniRealtimeClient(
-        "wss://example.invalid/realtime",
-        "test-key",
-        model="free-model",
-        api_type="free",
-        on_response_done=_on_done,
-    )
-    sent: list[dict] = []
-
-    async def _send(event: dict) -> None:
-        sent.append(event)
-
-    arbiter = client._response_arbiter
-    arbiter._send_event = _send
-    arbiter._fail_open = True
+    client, arbiter, sent = _released_client(on_response_done=_on_done)
     try:
         ticket = await arbiter.enqueue(source="native")
         await asyncio.wait_for(ticket.sent, timeout=1)
@@ -883,8 +889,11 @@ async def test_a_cancelled_release_still_finishes_its_bookkeeping(make_harness):
     owner = await harness.own_a_live_response("resp-1")
     assert owner is not None
 
+    observed = harness.arbiter._response_owner
     release = asyncio.create_task(
-        harness.arbiter._release_stuck_lifecycle("cancelled mid-notify")
+        harness.arbiter._release_stuck_lifecycle(
+            observed=observed, reason="cancelled mid-notify"
+        )
     )
     await asyncio.wait_for(entered.wait(), timeout=1)
     release.cancel()
@@ -921,8 +930,11 @@ async def test_the_release_does_not_erase_an_owner_that_arrived_meanwhile(
     harness = make_harness(fail_open=True, on_stuck_release=_hands_control_back)
     first = await harness.own_a_live_response("resp-1")
 
+    observed = harness.arbiter._response_owner
     release = asyncio.create_task(
-        harness.arbiter._release_stuck_lifecycle("overtaken by a new owner")
+        harness.arbiter._release_stuck_lifecycle(
+            observed=observed, reason="overtaken by a new owner"
+        )
     )
     await asyncio.wait_for(notified.wait(), timeout=1)
 
@@ -986,7 +998,9 @@ async def test_an_undisturbed_release_still_clears_its_own_owner(make_harness):
     assert harness.arbiter._response_owner is None, "the worker dropped it"
     harness.arbiter._response_owner = owner
 
-    await harness.arbiter._release_stuck_lifecycle("ordinary release")
+    await harness.arbiter._release_stuck_lifecycle(
+        observed=owner, reason="ordinary release"
+    )
 
     assert harness.arbiter._response_owner is None, (
         "an undisturbed release must give up the owner it captured"
@@ -1008,7 +1022,10 @@ async def test_the_release_tells_the_host_which_response_it_abandoned(make_harne
     harness = make_harness(fail_open=True, on_stuck_release=_record)
     await harness.own_a_live_response("resp-abandoned")
 
-    await harness.arbiter._release_stuck_lifecycle("named release")
+    observed = harness.arbiter._response_owner
+    await harness.arbiter._release_stuck_lifecycle(
+        observed=observed, reason="named release"
+    )
     await _settle()
 
     assert seen == [("named release", "resp-abandoned")], (
@@ -1237,32 +1254,6 @@ async def test_a_blocked_transcript_flush_cannot_strand_this_turns_state():
 # arbiter cannot serialize against a turn the user starts through
 # handle_new_message, because that path never consults the lane.
 # --------------------------------------------------------------------------
-
-
-def _free_client(**hooks):
-    """A client on a provider WITHOUT server VAD, where sid rotation matters.
-
-    The lanlan.app host is load-bearing, not decoration: ``_is_free_proxy``
-    keys on it, and that is what makes ``_has_server_vad`` False. With any
-    other host the same ``api_type="free"`` client HAS server VAD, rotates
-    from ``speech_stopped`` instead, and these tests would pass without ever
-    reaching the hook they are about.
-    """
-
-    from main_logic.omni_realtime_client import OmniRealtimeClient
-
-    client = OmniRealtimeClient(
-        "wss://lanlan.app/realtime",
-        "test-key",
-        model="free-model",
-        api_type="free",
-        **hooks,
-    )
-    assert client._has_server_vad is False, (
-        "this fixture exists to cover the providers whose only sid rotation "
-        "point is the turn-finished hook"
-    )
-    return client
 
 
 @pytest.mark.unit
@@ -1570,8 +1561,11 @@ async def test_the_release_leaves_the_lane_to_a_successor_that_took_over(make_ha
     harness = make_harness(fail_open=True, on_stuck_release=_hands_control_back)
     first = await harness.own_a_live_response("resp-1")
 
+    observed = harness.arbiter._response_owner
     release = asyncio.create_task(
-        harness.arbiter._release_stuck_lifecycle("overtaken by a new owner")
+        harness.arbiter._release_stuck_lifecycle(
+            observed=observed, reason="overtaken by a new owner"
+        )
     )
     await asyncio.wait_for(notified.wait(), timeout=1)
     with pytest.raises(RuntimeError):
@@ -1638,21 +1632,7 @@ async def test_a_release_with_nothing_to_release_does_not_end_a_host_turn():
     async def _on_done() -> None:
         done_calls.append("done")
 
-    client = OmniRealtimeClient(
-        "wss://lanlan.app/realtime",
-        "test-key",
-        model="free-model",
-        api_type="free",
-        on_response_done=_on_done,
-    )
-    sent: list[dict] = []
-
-    async def _send(event: dict) -> None:
-        sent.append(event)
-
-    arbiter = client._response_arbiter
-    arbiter._send_event = _send
-    arbiter._fail_open = True
+    client, arbiter, sent = _released_client(on_response_done=_on_done)
     try:
         # A server-initiated response the arbiter never owned, with an id.
         arbiter.notify_response_created(
@@ -1695,21 +1675,7 @@ async def test_a_release_that_gave_up_a_lifecycle_still_ends_the_host_turn():
     async def _on_done() -> None:
         done_calls.append("done")
 
-    client = OmniRealtimeClient(
-        "wss://lanlan.app/realtime",
-        "test-key",
-        model="free-model",
-        api_type="free",
-        on_response_done=_on_done,
-    )
-    sent: list[dict] = []
-
-    async def _send(event: dict) -> None:
-        sent.append(event)
-
-    arbiter = client._response_arbiter
-    arbiter._send_event = _send
-    arbiter._fail_open = True
+    client, arbiter, sent = _released_client(on_response_done=_on_done)
     try:
         ticket = await arbiter.enqueue(source="native")
         await asyncio.wait_for(ticket.sent, timeout=1)
@@ -2189,3 +2155,49 @@ async def test_reconnecting_forgets_which_responses_were_already_billed():
         "usage deduplication is scoped to one connection, like the tool-call "
         "flood window it sits beside"
     )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_an_unowned_cancellation_does_not_fail_work_queued_behind_it(
+    make_harness,
+):
+    # Codex P2. cancel_current() documents that it cancels only the active or
+    # pre-created request and never drains the queue. On its unowned branch
+    # what is stuck is a server-initiated response with no ticket at all — but
+    # a request enqueued while that cancellation waits becomes `_current` as
+    # the worker parks behind the live server response, and the release used
+    # to wake "owner and current" by state rather than by what the caller
+    # actually watched. That failed an undispatched request with a
+    # RuntimeError: draining queued work, which is what the method promises
+    # not to do.
+    harness = make_harness(fail_open=True)
+    harness.arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "srv-1"}}
+    )
+
+    cancelling = asyncio.create_task(harness.arbiter.cancel_current(timeout=0.2))
+    await _settle()
+    # Queued while the cancellation waits; the worker parks it behind srv-1.
+    queued = await harness.arbiter.enqueue(source="queued-behind")
+    await _settle()
+    assert harness.arbiter._current is not None, (
+        "the worker must have taken it as current for this to be the case "
+        "under test"
+    )
+    assert not queued.sent.done(), "and it must not have dispatched yet"
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(cancelling, timeout=2)
+    await _settle()
+
+    assert not queued.done.done(), (
+        "a request that never reached the provider is not part of the stuck "
+        "lifecycle; cancel_current does not drain the queue"
+    )
+
+    # And it still runs once the server response ends.
+    harness.arbiter.notify_response_terminal(
+        {"type": "response.done", "response": {"id": "srv-1"}}
+    )
+    await asyncio.wait_for(queued.sent, timeout=1)

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -36,9 +36,13 @@ Contracts, written so each can be falsified:
     end-of-turn work its terminal event drives — because it is the same
     implementation, not a second one.
 
-4.  **The host is told before the lane opens.** Ending the turn has to finish
-    before the next request can start one, or the next turn gets its speech id
-    rotated and its shared turn state finalized underneath it.
+4.  **A released turn's end-of-turn work lands on that turn, or not at all.**
+    The lane can reopen mid-notification — the abandoned response's own
+    terminal releases it — and the host's own turn can start from outside the
+    arbiter entirely. So the guarantee is identity, not ordering: the host
+    takes the released turn's id and its turn epoch, and stops the moment a
+    new turn has started. The release still opens the lane last, which is why
+    the ordering holds in the ordinary case.
 
 The previous attempt (withdrawn PR #2592) grew these as separate boolean
 conditions patched in over seven review rounds; see #2583 for how the 20
@@ -1223,3 +1227,325 @@ async def test_a_blocked_transcript_flush_cannot_strand_this_turns_state():
     assert client._image_recognized_this_turn is False
     assert client._audio_delta_count == 0
     assert client._output_transcript_buffer == ""
+
+
+# --------------------------------------------------------------------------
+# Contract 4, restated: identity survives the release's own awaits.
+#
+# The previous round scoped the release against the ARBITER's state. These pin
+# it against the HOST's, which is where turn identity actually lives — the
+# arbiter cannot serialize against a turn the user starts through
+# handle_new_message, because that path never consults the lane.
+# --------------------------------------------------------------------------
+
+
+def _free_client(**hooks):
+    """A client on a provider WITHOUT server VAD, where sid rotation matters.
+
+    The lanlan.app host is load-bearing, not decoration: ``_is_free_proxy``
+    keys on it, and that is what makes ``_has_server_vad`` False. With any
+    other host the same ``api_type="free"`` client HAS server VAD, rotates
+    from ``speech_stopped`` instead, and these tests would pass without ever
+    reaching the hook they are about.
+    """
+
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    client = OmniRealtimeClient(
+        "wss://lanlan.app/realtime",
+        "test-key",
+        model="free-model",
+        api_type="free",
+        **hooks,
+    )
+    assert client._has_server_vad is False, (
+        "this fixture exists to cover the providers whose only sid rotation "
+        "point is the turn-finished hook"
+    )
+    return client
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_an_id_less_overlap_is_not_the_releases_to_end():
+    # Codex P2. An owned response resp-1 is overlapped by a server-initiated
+    # response.created carrying NO id, which overwrites _current_response_id
+    # with None. Treating None as "matches every abandoned id" finalizes that
+    # overlapping response while it is still streaming: its half-sentence goes
+    # out as a separate transcript, its audio counter is zeroed, and the turn
+    # is ended a second time when its own terminal arrives.
+    done_calls: list[str] = []
+    transcripts: list[tuple[str, bool]] = []
+
+    async def _on_done() -> None:
+        done_calls.append("done")
+
+    async def _on_transcript(text: str, is_first: bool) -> None:
+        transcripts.append((text, is_first))
+
+    client = _free_client(
+        on_response_done=_on_done, on_output_transcript=_on_transcript
+    )
+    # The owner announced itself with an id...
+    client._current_response_id = "resp-1"
+    client._is_responding = True
+    client._turn_epoch += 1
+    # ...then an id-less response.created took the turn over.
+    client._current_response_id = None
+    client._turn_epoch += 1
+    client._output_transcript_buffer = "第二个响应正在说"
+    client._audio_delta_count = 2
+
+    await client._on_arbiter_stuck_release("abandoned resp-1", "resp-1")
+
+    assert client._is_responding is True, "the overlapping response is still live"
+    assert client._audio_delta_count == 2, "and its audio accounting is untouched"
+    assert client._output_transcript_buffer == "第二个响应正在说", (
+        "its half-sentence stays buffered for its own terminal to flush whole"
+    )
+    assert transcripts == [], "nothing of its text is sent early"
+    assert done_calls == [], "and no turn end is announced under it"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_named_release_still_ends_the_turn_it_named():
+    # The dual, both ways: the named id matches, and an unnamed release (the
+    # arbiter never learned an id, as on Gemini) still finalizes.
+    for named_id in ("resp-1", None):
+        done_calls: list[str] = []
+
+        async def _on_done() -> None:
+            done_calls.append("done")
+
+        client = _free_client(on_response_done=_on_done)
+        client._current_response_id = "resp-1"
+        client._is_responding = True
+        client._turn_epoch += 1
+
+        await client._on_arbiter_stuck_release("abandoned", named_id)
+
+        assert client._is_responding is False, f"named_id={named_id}"
+        assert client._current_response_id is None, f"named_id={named_id}"
+        assert done_calls == ["done"], f"named_id={named_id}"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_turn_that_started_mid_release_keeps_its_speech_id():
+    # The damage the lane barrier was meant to prevent, closed from the side
+    # that owns turn identity instead. The release parks in the host's
+    # transcript flush; the abandoned response's real terminal lands, the lane
+    # reopens, a successor dispatches and announces itself. The dead turn's
+    # remaining hooks must not fire on it — on_sid_rotate above all, since
+    # throwing away the successor's speech id makes TTS drop its text.
+    entered = asyncio.Event()
+    proceed = asyncio.Event()
+    done_calls: list[int] = []
+    rotations: list[int] = []
+
+    async def _blocks(text: str, is_first: bool) -> None:
+        entered.set()
+        await proceed.wait()
+
+    async def _on_done() -> None:
+        done_calls.append(client._turn_epoch)
+
+    async def _on_rotate() -> None:
+        rotations.append(client._turn_epoch)
+
+    client = _free_client(
+        on_output_transcript=_blocks,
+        on_response_done=_on_done,
+        on_sid_rotate=_on_rotate,
+    )
+    client._current_response_id = "resp-1"
+    client._is_responding = True
+    client._turn_epoch += 1
+    client._output_transcript_buffer = "旧轮说了半句"
+    client._audio_delta_count = 1
+
+    release = asyncio.create_task(
+        client._on_arbiter_stuck_release("abandoned resp-1", "resp-1")
+    )
+    await asyncio.wait_for(entered.wait(), timeout=1)
+
+    # A successor turn starts while the release is parked in the flush.
+    client._current_response_id = "resp-2"
+    client._is_responding = True
+    client._turn_epoch += 1
+
+    proceed.set()
+    await asyncio.wait_for(release, timeout=2)
+
+    assert rotations == [], (
+        "rotating here would throw away the speech id the live turn is using"
+    )
+    assert done_calls == [], "and the live turn has not ended"
+    assert client._current_response_id == "resp-2", "the successor is untouched"
+    assert client._is_responding is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_an_undisturbed_release_still_runs_both_hooks():
+    # The dual. "Stop when the epoch moves" must not become "never run".
+    order: list[str] = []
+
+    async def _on_done() -> None:
+        order.append("done")
+
+    async def _on_rotate() -> None:
+        order.append("rotate")
+
+    client = _free_client(on_response_done=_on_done, on_sid_rotate=_on_rotate)
+    client._current_response_id = "resp-1"
+    client._is_responding = True
+    client._turn_epoch += 1
+
+    await client._on_arbiter_stuck_release("abandoned resp-1", "resp-1")
+
+    assert order == ["done", "rotate"], (
+        "an undisturbed release runs both hooks, in the terminal path's order"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_blocked_transcript_flush_cannot_cost_the_speech_id_rotation():
+    # For a provider without server VAD this hook is the ONLY rotation point,
+    # and losing it silently drops every later turn's text at TTS. A host that
+    # parks in on_output_transcript must not consume the whole notification
+    # budget: the flush is best-effort and bounded, the rotation is neither.
+    rotations: list[str] = []
+
+    async def _never_returns(text: str, is_first: bool) -> None:
+        await asyncio.Event().wait()
+
+    async def _on_rotate() -> None:
+        rotations.append("rotate")
+
+    client = _free_client(
+        on_output_transcript=_never_returns, on_sid_rotate=_on_rotate
+    )
+    client._current_response_id = "resp-1"
+    client._is_responding = True
+    client._turn_epoch += 1
+    client._output_transcript_buffer = "说了半句"
+    client._audio_delta_count = 1
+
+    await asyncio.wait_for(
+        client._on_arbiter_stuck_release("abandoned resp-1", "resp-1"),
+        timeout=5,
+    )
+
+    assert rotations == ["rotate"], (
+        "the rotation must survive a transcript callback that never returns"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_raising_transcript_flush_cannot_cost_the_rotation_either():
+    # The same contract with no timing involved: the emit had no exception
+    # guard at all, so a raising host callback skipped the rotation outright.
+    rotations: list[str] = []
+
+    async def _raises(text: str, is_first: bool) -> None:
+        raise RuntimeError("frontend socket is gone")
+
+    async def _on_rotate() -> None:
+        rotations.append("rotate")
+
+    client = _free_client(on_output_transcript=_raises, on_sid_rotate=_on_rotate)
+    client._current_response_id = "resp-1"
+    client._is_responding = True
+    client._turn_epoch += 1
+    client._output_transcript_buffer = "说了半句"
+    client._audio_delta_count = 1
+
+    await client._on_arbiter_stuck_release("abandoned resp-1", "resp-1")
+
+    assert rotations == ["rotate"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_blocked_done_hook_cannot_cost_the_rotation():
+    # The third trigger, and the one a bound on the transcript flush alone
+    # misses entirely: on_response_done is the hook that blocks.
+    rotations: list[str] = []
+
+    async def _never_returns() -> None:
+        await asyncio.Event().wait()
+
+    async def _on_rotate() -> None:
+        rotations.append("rotate")
+
+    client = _free_client(on_response_done=_never_returns, on_sid_rotate=_on_rotate)
+    client._current_response_id = "resp-1"
+    client._is_responding = True
+    client._turn_epoch += 1
+
+    await asyncio.wait_for(
+        client._on_arbiter_stuck_release("abandoned resp-1", "resp-1"),
+        timeout=5,
+    )
+
+    assert rotations == ["rotate"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_the_terminal_path_leaves_the_hooks_unbounded():
+    # The other half of "one implementation, not two": the release passes its
+    # bounds in, and the ordinary response.done path must not inherit them. A
+    # slow host there is slow, not cut off — no arbiter budget is being shared.
+    from main_logic.omni_realtime_client import _transport
+
+    finished: list[str] = []
+
+    async def _slower_than_the_step_bound() -> None:
+        await asyncio.sleep(_transport._STUCK_RELEASE_STEP_TIMEOUT * 3)
+        finished.append("done")
+
+    client = _free_client(on_response_done=_slower_than_the_step_bound)
+
+    await client._notify_turn_finished()
+
+    assert finished == ["done"], (
+        "the terminal path must await the host, not bound it"
+    )
+
+
+@pytest.mark.unit
+def test_every_turn_start_advances_the_epoch():
+    # A completeness guard, not a checklist. The epoch is only sound while
+    # every place that STARTS a turn bumps it, and a new provider path is
+    # exactly where that gets forgotten. Discover the writers instead of
+    # listing them, so a new one fails here rather than silently weakening the
+    # release guard.
+    import pathlib
+    import re
+
+    import main_logic.omni_realtime_client as package
+
+    root = pathlib.Path(package.__file__).parent
+    starts = 0
+    offenders: list[str] = []
+    for path in sorted(root.glob("*.py")):
+        lines = path.read_text(encoding="utf-8").split("\n")
+        for index, line in enumerate(lines):
+            if not re.match(r"^\s*self\._is_responding\s*=\s*True\s*$", line):
+                continue
+            starts += 1
+            if "self._turn_epoch += 1" not in "\n".join(lines[index : index + 3]):
+                offenders.append(f"{path.name}:{index + 1}")
+    assert starts >= 2, (
+        "expected to find the turn-start sites; the search stopped matching, "
+        f"which makes this guard vacuous (found {starts})"
+    )
+    assert offenders == [], (
+        "every turn start must advance _turn_epoch within the next line or "
+        f"two; these start a turn without it: {offenders}"
+    )

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -1,0 +1,639 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The arbiter's escalation policy: tear down by default, keep the connection
+only when that is defensible.
+
+Contracts, written so each can be falsified:
+
+1.  **The default never changes.** Without the environment switch the arbiter
+    behaves exactly as it always has, including the
+    ``response arbiter failing closed`` line that attributes a field
+    disconnect (issue #2561).
+
+2.  **Fail-open applies only when the connection can be kept.** That means
+    both halves: the transport is still usable, AND the arbiter can still
+    tell whose events are whose. Four things falsify it, each with a paired
+    case here so "always stand down" cannot pass for correct:
+
+    - the queue consumer is suspended inside a transport write
+    - a transport write just failed
+    - the abandoned response has no id to attribute its later events by
+    - an announced server-VAD response has no id yet
+
+3.  **A released turn is ended, not merely dropped.** The host runs the same
+    end-of-turn work its terminal event drives — because it is the same
+    implementation, not a second one.
+
+4.  **The host is told before the lane opens.** Ending the turn has to finish
+    before the next request can start one, or the next turn gets its speech id
+    rotated and its shared turn state finalized underneath it.
+
+The previous attempt (withdrawn PR #2592) grew these as separate boolean
+conditions patched in over seven review rounds; see #2583 for how the 20
+findings collapse into five invariants once they are read together.
+"""
+
+import asyncio
+import logging
+
+import pytest
+
+from main_logic.omni_realtime_client._response_arbiter import RealtimeResponseArbiter
+from main_logic.omni_realtime_client._shared import (
+    response_arbiter_fail_open_enabled,
+)
+
+ARBITER_LOGGER = "main_logic.omni_realtime_client._response_arbiter"
+FAIL_OPEN_ENV_VAR = "NEKO_REALTIME_ARBITER_FAIL_OPEN"
+
+
+async def _settle(times: int = 50) -> None:
+    for _ in range(times):
+        await asyncio.sleep(0)
+
+
+class _Harness:
+    """Records what reached the wire and whether the transport was torn down."""
+
+    send_behaviour = "ok"
+
+    def __init__(self, *, fail_open: bool, on_stuck_release=None) -> None:
+        self.sent: list[dict] = []
+        self.aborted: list[str] = []
+        self.gate = asyncio.Event()
+        self.refusals = 0
+        self.arbiter = RealtimeResponseArbiter(
+            self._send,
+            abort_transport=self._abort,
+            fail_open=fail_open,
+            on_stuck_release=on_stuck_release,
+        )
+
+    async def _send(self, event: dict) -> None:
+        self.sent.append(event)
+        if self.send_behaviour == "stall" and event.get("type") == "response.create":
+            await self.gate.wait()
+        if self.send_behaviour == "refuse_cancel" and (
+            event.get("type") == "response.cancel"
+        ):
+            raise RuntimeError("1006 abnormal close")
+
+    async def _abort(self, reason: str) -> None:
+        self.aborted.append(reason)
+
+    @property
+    def dispatch_count(self) -> int:
+        return [e.get("type") for e in self.sent].count("response.create")
+
+    async def own_a_live_response(self, response_id: str | None = "resp-1"):
+        ticket = await self.arbiter.enqueue(source="native")
+        await asyncio.wait_for(ticket.sent, timeout=1)
+        event: dict = {"type": "response.created"}
+        if response_id is not None:
+            event["response"] = {"id": response_id}
+        self.arbiter.notify_response_created(event)
+        return ticket
+
+
+class _StallingHarness(_Harness):
+    send_behaviour = "stall"
+
+
+class _CancelRefusingHarness(_Harness):
+    send_behaviour = "refuse_cancel"
+
+
+@pytest.fixture
+async def make_harness():
+    """Build harnesses and reap their workers.
+
+    Under fail-open ``_connection_available`` deliberately stays True, so the
+    queue consumer keeps running after the assertions are done. The gate is
+    opened first because a stalled worker is parked inside the write that
+    ``shutdown`` waits on.
+    """
+
+    built: list[_Harness] = []
+
+    def _factory(cls=_Harness, *, fail_open: bool, on_stuck_release=None) -> _Harness:
+        harness = cls(fail_open=fail_open, on_stuck_release=on_stuck_release)
+        built.append(harness)
+        return harness
+
+    yield _factory
+
+    for harness in built:
+        harness.gate.set()
+        await harness.arbiter.shutdown("test teardown")
+
+
+async def _stick_a_cancel(harness: _Harness) -> Exception | None:
+    """Cancel a live response whose terminal never arrives; return the raise."""
+
+    try:
+        await harness.arbiter.cancel_current(timeout=0.05)
+    except Exception as exc:  # noqa: BLE001 - the raise itself is asserted
+        return exc
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Contract 1: the shipped default is untouched.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_the_switch_is_off_unless_explicitly_enabled(monkeypatch):
+    monkeypatch.delenv(FAIL_OPEN_ENV_VAR, raising=False)
+    assert response_arbiter_fail_open_enabled() is False
+
+    for truthy in ("1", "true", "TRUE", " yes ", "on", "On"):
+        monkeypatch.setenv(FAIL_OPEN_ENV_VAR, truthy)
+        assert response_arbiter_fail_open_enabled() is True, truthy
+
+    # Including the words someone would type to turn it OFF.
+    for falsy in ("", "   ", "0", "false", "no", "off", "maybe", "2"):
+        monkeypatch.setenv(FAIL_OPEN_ENV_VAR, falsy)
+        assert response_arbiter_fail_open_enabled() is False, falsy
+
+
+@pytest.mark.unit
+def test_the_arbiter_defaults_to_tearing_down_without_being_told():
+    arbiter = RealtimeResponseArbiter(lambda event: asyncio.sleep(0))
+    assert arbiter._fail_open is False
+
+
+@pytest.mark.unit
+def test_both_construction_sites_honour_the_switch(monkeypatch):
+    # The reader can be perfect and every branch correct while real clients
+    # still get the default, so pin the wiring itself — through the eager
+    # constructor and through the lazy one in _responses.py.
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    def _build() -> OmniRealtimeClient:
+        return OmniRealtimeClient(
+            "wss://example.invalid/realtime",
+            "test-key",
+            model="free-model",
+            api_type="free",
+        )
+
+    monkeypatch.delenv(FAIL_OPEN_ENV_VAR, raising=False)
+    assert _build()._response_arbiter._fail_open is False
+
+    monkeypatch.setenv(FAIL_OPEN_ENV_VAR, "1")
+    eager = _build()
+    assert eager._response_arbiter._fail_open is True
+    assert eager._response_arbiter._on_stuck_release is not None
+
+    del eager._response_arbiter
+    lazy = eager._ensure_response_arbiter()
+    assert lazy._fail_open is True
+    assert lazy._on_stuck_release is not None, (
+        "the lazy construction point must inject the host notification too"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_the_default_still_tears_the_transport_down(make_harness, caplog):
+    harness = make_harness(fail_open=False)
+    await harness.own_a_live_response()
+
+    with caplog.at_level(logging.WARNING, logger=ARBITER_LOGGER):
+        raised = await _stick_a_cancel(harness)
+
+    assert isinstance(raised, asyncio.TimeoutError)
+    assert harness.aborted == ["response cancellation terminal event timed out"]
+    messages = [record.getMessage() for record in caplog.records]
+    # The documented grep target for attributing a field disconnect.
+    assert any("response arbiter failing closed" in m for m in messages)
+    assert not any("failing open" in m for m in messages)
+
+    dead = await harness.arbiter.enqueue(source="native-after")
+    with pytest.raises(ConnectionError):
+        await asyncio.wait_for(dead.sent, timeout=1)
+
+
+# ---------------------------------------------------------------------------
+# Contract 2: fail-open applies only when the connection can be kept.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fail_open_keeps_the_transport_and_reopens_the_lane(
+    make_harness, caplog
+):
+    harness = make_harness(fail_open=True)
+    stuck = await harness.own_a_live_response()
+
+    with caplog.at_level(logging.WARNING, logger=ARBITER_LOGGER):
+        raised = await _stick_a_cancel(harness)
+
+    assert isinstance(raised, asyncio.TimeoutError)
+    assert harness.aborted == []
+    assert harness.arbiter._connection_available is True
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("failing open, transport kept" in m for m in messages)
+    assert not any("failing closed" in m for m in messages), (
+        "that string is what tells an operator the arbiter hung up"
+    )
+
+    await _settle()
+    assert stuck.done.done(), "the stuck ticket must be terminated, not orphaned"
+    with pytest.raises(Exception):
+        stuck.done.result()
+
+    assert harness.arbiter.is_busy is False
+    revived = await harness.arbiter.enqueue(source="native-after")
+    await asyncio.wait_for(revived.sent, timeout=1)
+    harness.arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "resp-2"}}
+    )
+    harness.arbiter.notify_response_terminal(
+        {"type": "response.done", "response": {"id": "resp-2"}}
+    )
+    await asyncio.wait_for(revived.done, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fail_open_keeps_queued_work_and_an_external_turn_pause(make_harness):
+    # A connection loss fails the whole queue and force-opens dispatch, because
+    # nothing can be sent anyway. Here the connection is fine: queued work is
+    # still viable, and an external-ASR turn's pause is still holding proactive
+    # work back on purpose.
+    harness = make_harness(fail_open=True)
+    await harness.own_a_live_response()
+    harness.arbiter.pause_dispatch()
+    proactive = await harness.arbiter.enqueue(source="proactive", priority=20)
+
+    raised = await _stick_a_cancel(harness)
+    assert isinstance(raised, asyncio.TimeoutError)
+    await _settle()
+
+    assert harness.dispatch_count == 1, (
+        "the paused request must not dispatch: the user's external turn still "
+        "owns dispatch permission"
+    )
+    assert not proactive.sent.done()
+    assert harness.arbiter._connection_generation == 0, (
+        "there is no replacement connection to protect in-flight cancels from"
+    )
+
+    harness.arbiter.resume_dispatch()
+    await asyncio.wait_for(proactive.sent, timeout=1)
+    harness.arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "resp-p"}}
+    )
+    harness.arbiter.notify_response_terminal(
+        {"type": "response.done", "response": {"id": "resp-p"}}
+    )
+    await asyncio.wait_for(proactive.done, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_stalled_consumer_write_stands_the_hatch_down(make_harness, caplog):
+    # Nothing the arbiter does to its own state unwinds an await parked in the
+    # transport, and _run is the only consumer — keeping the connection would
+    # leave it wedged while reporting recovery. The transport's close is what
+    # wakes that write.
+    harness = make_harness(_StallingHarness, fail_open=True)
+    stuck = await harness.arbiter.enqueue(source="native")
+    await _settle()
+    assert harness.dispatch_count == 1
+    assert not stuck.sent.done()
+    assert harness.arbiter._worker_send_in_flight is True
+
+    with caplog.at_level(logging.WARNING, logger=ARBITER_LOGGER):
+        raised = await _stick_a_cancel(harness)
+
+    assert isinstance(raised, asyncio.TimeoutError)
+    assert harness.aborted, "the hatch must stand down while the consumer is stuck"
+    assert harness.arbiter._connection_available is False
+    assert any(
+        "suspended inside a transport write" in record.getMessage()
+        for record in caplog.records
+    ), "the log must say WHY an opted-in session tore down anyway"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_failed_consumer_write_does_not_latch_the_stand_down():
+    # The flag is set around the write and must come down on every exit. If it
+    # latched, fail-open would be silently disabled for this arbiter's whole
+    # life while the log blamed a send that finished long ago.
+    class _RefuseOnce(_Harness):
+        async def _send(self, event: dict) -> None:
+            self.sent.append(event)
+            if event.get("type") == "response.create" and self.refusals == 0:
+                self.refusals += 1
+                raise RuntimeError("transport write refused")
+
+    harness = _RefuseOnce(fail_open=True)
+    try:
+        doomed = await harness.arbiter.enqueue(source="native-doomed")
+        with pytest.raises(RuntimeError):
+            await asyncio.wait_for(doomed.sent, timeout=1)
+        await _settle()
+        assert harness.arbiter._worker_send_in_flight is False
+
+        await harness.own_a_live_response()
+        raised = await _stick_a_cancel(harness)
+        assert isinstance(raised, asyncio.TimeoutError)
+        assert harness.aborted == [], (
+            "a write that failed earlier must not disable the hatch forever"
+        )
+    finally:
+        await harness.arbiter.shutdown("test teardown")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_refused_cancel_write_stands_the_hatch_down(make_harness, caplog):
+    # _worker_send lowers its flag in a finally, so by the time the escalation
+    # runs the "mid-write" condition already reads False — even though the
+    # transport refused that very write and may have dropped its socket.
+    harness = make_harness(_CancelRefusingHarness, fail_open=True)
+    ticket = await harness.arbiter.enqueue(
+        source="native", response_started_timeout=0.05, cancel_timeout=0.05
+    )
+    await asyncio.wait_for(ticket.sent, timeout=1)
+
+    with caplog.at_level(logging.WARNING, logger=ARBITER_LOGGER):
+        with pytest.raises(Exception):
+            await asyncio.wait_for(ticket.done, timeout=2)
+        await _settle()
+
+    assert harness.aborted, "an escalation after a refused write must tear down"
+    assert harness.arbiter._connection_available is False
+    assert any(
+        "a transport write just failed" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_healthy_cancel_write_still_fails_open(make_harness, caplog):
+    # The dual of the case above: same escalation site, same code path, but the
+    # cancel write is accepted and only the terminal never comes. Without this
+    # pair, standing down on every _cancel_after_timeout would look correct.
+    #
+    # Driven through the DONE timeout, not the started one. A started-timeout
+    # escalation is id-less by construction — no response.created means no id
+    # — so it can only ever exercise the stand-down. Reaching this site with an
+    # attributable response requires the announcement to have arrived first.
+    harness = make_harness(fail_open=True)
+    ticket = await harness.arbiter.enqueue(
+        source="native", response_done_timeout=0.05, cancel_timeout=0.05
+    )
+    await asyncio.wait_for(ticket.sent, timeout=1)
+    harness.arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "resp-1"}}
+    )
+
+    with caplog.at_level(logging.WARNING, logger=ARBITER_LOGGER):
+        with pytest.raises(Exception):
+            await asyncio.wait_for(ticket.done, timeout=2)
+        await _settle()
+
+    assert harness.aborted == []
+    assert harness.arbiter._connection_available is True
+    assert any(
+        "failing open" in record.getMessage() for record in caplog.records
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_an_id_less_abandoned_response_stands_the_hatch_down(
+    make_harness, caplog
+):
+    # The create is on the wire, so the provider may still announce this
+    # response later. Without an id there is nothing to tell that announcement
+    # apart from the next turn's.
+    harness = make_harness(fail_open=True)
+    await harness.own_a_live_response(response_id=None)
+
+    with caplog.at_level(logging.WARNING, logger=ARBITER_LOGGER):
+        raised = await _stick_a_cancel(harness)
+
+    assert isinstance(raised, asyncio.TimeoutError)
+    assert harness.aborted, "an unattributable abandoned response must tear down"
+    assert any(
+        "no id to attribute later events by" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_an_id_bearing_abandoned_response_still_fails_open(make_harness):
+    # The dual: the provider supplied an id, so its later events are
+    # attributable and the hatch applies.
+    harness = make_harness(fail_open=True)
+    await harness.own_a_live_response(response_id="resp-with-id")
+
+    raised = await _stick_a_cancel(harness)
+
+    assert isinstance(raised, asyncio.TimeoutError)
+    assert harness.aborted == []
+    assert harness.arbiter._connection_available is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_request_whose_create_never_went_out_still_fails_open(make_harness):
+    # The criterion is "did the create reach the wire", not "did
+    # response.created come back". A request still waiting for dispatch has no
+    # live response at all, so nothing of its can surprise us later.
+    #
+    # The withdrawn #2592 wrote this the other way round — keyed on
+    # ticket.started — and pinned the wrong contract with a passing test.
+    harness = make_harness(fail_open=True)
+    harness.arbiter.pause_dispatch()
+    queued = await harness.arbiter.enqueue(source="native")
+    await _settle()
+    assert harness.dispatch_count == 0
+    assert not queued.sent.done()
+
+    harness.arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "srv-1"}}
+    )
+    raised = await _stick_a_cancel(harness)
+
+    assert isinstance(raised, asyncio.TimeoutError)
+    assert harness.aborted == [], (
+        "a request whose create never went out cannot emit a confusable "
+        "announcement"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_pending_server_vad_response_stands_the_hatch_down(
+    make_harness, caplog
+):
+    # Announced by speech_stopped, no id until its response.created arrives —
+    # and cancel_current's bound is shorter than the missing-created backstop,
+    # so an escalation can land inside that window.
+    harness = make_harness(fail_open=True)
+    harness.arbiter.notify_server_vad_response_pending()
+    await _settle()
+    assert harness.arbiter._server_vad_response_pending is True
+
+    with caplog.at_level(logging.WARNING, logger=ARBITER_LOGGER):
+        raised = await _stick_a_cancel(harness)
+
+    assert isinstance(raised, asyncio.TimeoutError)
+    assert harness.aborted, "an unattributable VAD response must tear down"
+    assert any(
+        "server-VAD response has no id yet" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+# ---------------------------------------------------------------------------
+# Contracts 3 and 4: the released turn is ended, and the host is told first.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_the_release_ends_the_turn_before_the_lane_opens(make_harness):
+    # Ordering, not just occurrence. If the lane opened first, the next
+    # request could dispatch while the host was still closing the previous
+    # turn — and end up with that turn's speech id rotated underneath it.
+    lane_open_at_notify: list[bool] = []
+
+    async def _on_release(reason: str) -> None:
+        lane_open_at_notify.append(harness.arbiter._idle.is_set())
+
+    harness = make_harness(fail_open=True, on_stuck_release=_on_release)
+    await harness.own_a_live_response()
+
+    raised = await _stick_a_cancel(harness)
+    assert isinstance(raised, asyncio.TimeoutError)
+    await _settle()
+
+    assert lane_open_at_notify == [False], (
+        "the host must finish ending the turn while the lane is still closed"
+    )
+    assert harness.arbiter._idle.is_set() is True, "and the lane opens after"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_hanging_host_notification_cannot_wedge_the_consumer(
+    make_harness, caplog, monkeypatch
+):
+    # Escalations raised inside _process run the notification on the sole queue
+    # consumer. An unbounded host callback there would block every later
+    # dispatch — the stalled-write wedge again, moved into project code.
+    monkeypatch.setattr(
+        "main_logic.omni_realtime_client._response_arbiter"
+        "._STUCK_RELEASE_NOTIFY_TIMEOUT",
+        0.05,
+    )
+    released = asyncio.Event()
+
+    async def _never_returns(reason: str) -> None:
+        await released.wait()
+
+    harness = make_harness(fail_open=True, on_stuck_release=_never_returns)
+    try:
+        stuck = await harness.arbiter.enqueue(
+            source="native", response_done_timeout=0.05, cancel_timeout=0.05
+        )
+        await asyncio.wait_for(stuck.sent, timeout=1)
+        # An attributable response, so the escalation actually reaches the
+        # release path where the notification runs.
+        harness.arbiter.notify_response_created(
+            {"type": "response.created", "response": {"id": "resp-1"}}
+        )
+
+        with caplog.at_level(logging.WARNING, logger=ARBITER_LOGGER):
+            with pytest.raises(Exception):
+                await asyncio.wait_for(stuck.done, timeout=2)
+            await _settle()
+
+        assert any(
+            "exceeded" in record.getMessage() for record in caplog.records
+        ), "the bound must be visible, not silently swallowed"
+
+        follow_up = await harness.arbiter.enqueue(source="native-after")
+        await asyncio.wait_for(follow_up.sent, timeout=1)
+    finally:
+        released.set()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_the_release_runs_the_hosts_own_end_of_turn_work():
+    # Contract 3, through the real client: the released turn goes through the
+    # same three steps response.done drives, because it is the same code.
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    done_calls: list[str] = []
+
+    async def _on_done() -> None:
+        done_calls.append("done")
+
+    client = OmniRealtimeClient(
+        "wss://example.invalid/realtime",
+        "test-key",
+        model="free-model",
+        api_type="free",
+        on_response_done=_on_done,
+    )
+    sent: list[dict] = []
+
+    async def _send(event: dict) -> None:
+        sent.append(event)
+
+    arbiter = client._response_arbiter
+    arbiter._send_event = _send
+    arbiter._fail_open = True
+    try:
+        ticket = await arbiter.enqueue(source="native")
+        await asyncio.wait_for(ticket.sent, timeout=1)
+        arbiter.notify_response_created(
+            {"type": "response.created", "response": {"id": "resp-1"}}
+        )
+        client._current_response_id = "resp-1"
+        client._is_responding = True
+        client._image_sent_this_turn = True
+
+        with pytest.raises(asyncio.TimeoutError):
+            await arbiter.cancel_current(timeout=0.05)
+        await _settle()
+
+        assert client._is_responding is False, (
+            "the host must stop reporting a response in progress, or the "
+            "connection the hatch saved is useless to proactive chat"
+        )
+        assert client._current_response_id is None, (
+            "clearing the identity is what quarantines the abandoned "
+            "response's later events"
+        )
+        assert client._image_sent_this_turn is False, (
+            "per-turn state must not leak into the next turn"
+        )
+        assert done_calls == ["done"]
+        assert client.is_active_response() is False
+    finally:
+        await arbiter.shutdown("test teardown")

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -1549,3 +1549,74 @@ def test_every_turn_start_advances_the_epoch():
         "every turn start must advance _turn_epoch within the next line or "
         f"two; these start a turn without it: {offenders}"
     )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_the_release_leaves_the_lane_to_a_successor_that_took_over(make_harness):
+    # Greptile P1. Scoping the owner assignment stopped the release ERASING a
+    # successor, but it still called _release_lane_if_clear() unconditionally —
+    # and that helper knows nothing about owners. Every other caller of it
+    # either just cleared the owner or guards on there being none; this was the
+    # one site that could open the lane over a response it never observed,
+    # letting the next response.create overlap a live one.
+    resumed = asyncio.Event()
+    notified = asyncio.Event()
+
+    async def _hands_control_back(reason: str, response_id: str | None) -> None:
+        notified.set()
+        await resumed.wait()
+
+    harness = make_harness(fail_open=True, on_stuck_release=_hands_control_back)
+    first = await harness.own_a_live_response("resp-1")
+
+    release = asyncio.create_task(
+        harness.arbiter._release_stuck_lifecycle("overtaken by a new owner")
+    )
+    await asyncio.wait_for(notified.wait(), timeout=1)
+    with pytest.raises(RuntimeError):
+        await asyncio.wait_for(first.done, timeout=1)
+    harness.arbiter.notify_response_terminal(
+        {"type": "response.done", "response": {"id": "resp-1"}}
+    )
+    await _settle()
+    second = await harness.arbiter.enqueue(source="native-next")
+    await asyncio.wait_for(second.sent, timeout=1)
+    harness.arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "resp-2"}}
+    )
+    dispatched = harness.dispatch_count
+
+    resumed.set()
+    await asyncio.wait_for(release, timeout=1)
+    await _settle()
+
+    # Assert the lane state itself. `is_busy` is not the observable here — it
+    # reports True off `_response_owner` alone, so it stays True whether or not
+    # the lane was opened, and an earlier version of this test asserted it and
+    # passed with the guard deleted.
+    assert harness.arbiter._idle.is_set() is False, (
+        "the successor holds the lane; the release must not open it underneath"
+    )
+    assert harness.arbiter._server_response_active is True, (
+        "nor declare no response live while the successor is streaming"
+    )
+
+    # And the successor's own terminal is what opens it, as everywhere else in
+    # the arbiter.
+    harness.arbiter.notify_response_terminal(
+        {"type": "response.done", "response": {"id": "resp-2"}}
+    )
+    await asyncio.wait_for(second.done, timeout=1)
+    await _settle()
+    assert harness.arbiter._idle.is_set() is True
+    third = await harness.arbiter.enqueue(source="native-third")
+    await asyncio.wait_for(third.sent, timeout=1)
+    assert harness.dispatch_count == dispatched + 1
+    harness.arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "resp-3"}}
+    )
+    harness.arbiter.notify_response_terminal(
+        {"type": "response.done", "response": {"id": "resp-3"}}
+    )
+    await asyncio.wait_for(third.done, timeout=1)

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -87,10 +87,14 @@ class _Harness:
 
     async def _send(self, event: dict) -> None:
         self.sent.append(event)
-        if self.send_behaviour == "stall" and event.get("type") == "response.create":
+        if event.get("type") == "response.create" and self.send_behaviour in (
+            "stall",
+            "stall_refuse_cancel",
+        ):
             await self.gate.wait()
-        if self.send_behaviour == "refuse_cancel" and (
-            event.get("type") == "response.cancel"
+        if event.get("type") == "response.cancel" and self.send_behaviour in (
+            "refuse_cancel",
+            "stall_refuse_cancel",
         ):
             raise RuntimeError("1006 abnormal close")
 
@@ -117,6 +121,17 @@ class _StallingHarness(_Harness):
 
 class _CancelRefusingHarness(_Harness):
     send_behaviour = "refuse_cancel"
+
+
+class _StallThenRefuseCancelHarness(_Harness):
+    """Stalls the create, then refuses the cancel that follows it.
+
+    The only way to reach ``_process``'s interrupted branch: the interrupt has
+    to land while the ``response.create`` send is still in flight, so the
+    worker returns from that send and finds the request already cancelled.
+    """
+
+    send_behaviour = "stall_refuse_cancel"
 
 
 @pytest.fixture
@@ -2314,3 +2329,108 @@ async def test_response_created_records_the_epoch_its_turn_began_in():
         "and the response records which epoch it began in, which is what a "
         "release compares against instead of the live value"
     )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_an_interrupted_response_whose_cancel_write_fails_tears_down(
+    make_harness, caplog
+):
+    # CodeRabbit, and the same shape _cancel_after_timeout already handles a
+    # hundred lines below: the interrupted branch sent its response.cancel
+    # OUTSIDE the try, so a transport that refused the write raised straight
+    # past the escalation and the connection that had just failed a write was
+    # never torn down.
+    #
+    # Reaching that branch needs the interrupt to land while the create send
+    # is still in flight, which is what the stalling harness arranges.
+    harness = make_harness(_StallThenRefuseCancelHarness, fail_open=True)
+    ticket = await harness.arbiter.enqueue(source="native")
+    await _settle()
+    assert not ticket.sent.done(), "the worker must be parked in the create send"
+
+    caplog.set_level(logging.WARNING, logger=ARBITER_LOGGER)
+    cancelling = asyncio.create_task(harness.arbiter.cancel_current(timeout=0.2))
+    await _settle()
+    harness.gate.set()
+    # Whether the caller sees an error is not the point here — this path
+    # resolves `completed` as the worker unwinds — so tolerate either.
+    try:
+        await asyncio.wait_for(cancelling, timeout=2)
+    except Exception:  # noqa: BLE001 - the escalation is what is asserted
+        pass
+    await _settle()
+
+    # Assert WHICH escalation, not merely that one happened: other routes
+    # (the cancel timeout, the started-timeout backstop) escalate on this
+    # sequence too, so `aborted` being non-empty says nothing about the branch
+    # under test. An earlier version of this test asserted exactly that and
+    # passed with the fix reverted.
+    assert "interrupted response could not reach a terminal state" in harness.aborted, (
+        "a cancel the transport refused must reach THIS branch's escalation"
+    )
+    # And that it carried the write failure, which is what makes it fail
+    # CLOSED even with the hatch on: nothing the arbiter does to its own state
+    # fixes a socket that will not take a send.
+    assert any(
+        "a transport write just failed" in record.getMessage()
+        for record in caplog.records
+    ), "and report the refused write as the blocker"
+    assert harness.arbiter._connection_available is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_turn_starting_during_the_repetition_step_keeps_its_recovery():
+    # Codex P2. The entry gate covers a turn that started BEFORE the release.
+    # The repetition step is awaited through wait_for, which yields before its
+    # body runs — so a successor can start inside that yield, and the recovery
+    # callback would then apply a dead turn's remedy to the live one: the host
+    # clears focus state, resets the emotion scorer and warns the user.
+    recoveries: list[str] = []
+
+    async def _on_repetition() -> None:
+        recoveries.append("recovered")
+
+    client = _free_client(on_repetition_detected=_on_repetition)
+    client._repetition_threshold = 0.5
+    client._recent_responses = ["一样的话", "一样的话"]
+    _begin_response(client, "resp-1")
+    client._current_response_transcript = "一样的话"
+    client._audio_delta_count = 1
+
+    async def _successor_starts() -> None:
+        # Runs on the first yield, which is the one wait_for takes.
+        client._turn_epoch += 1
+
+    asyncio.get_running_loop().create_task(_successor_starts())
+    await client._on_arbiter_stuck_release("abandoned resp-1", "resp-1")
+
+    assert recoveries == [], (
+        "the recovery belongs to the turn that repeated itself, not to "
+        "whichever turn is live when the check finally runs"
+    )
+    assert client._last_response_transcript == "一样的话", (
+        "the text itself is still recorded — only the remedy is withheld"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_an_undisturbed_repetition_still_triggers_its_recovery():
+    # The dual: nothing intervenes, so the recovery fires as it always has.
+    recoveries: list[str] = []
+
+    async def _on_repetition() -> None:
+        recoveries.append("recovered")
+
+    client = _free_client(on_repetition_detected=_on_repetition)
+    client._repetition_threshold = 0.5
+    client._recent_responses = ["一样的话", "一样的话"]
+    _begin_response(client, "resp-1")
+    client._current_response_transcript = "一样的话"
+    client._audio_delta_count = 1
+
+    await client._on_arbiter_stuck_release("abandoned resp-1", "resp-1")
+
+    assert recoveries == ["recovered"]

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -199,6 +199,22 @@ def _released_client(**hooks):
     return client, arbiter, sent
 
 
+def _begin_response(client, response_id="resp-1"):
+    """Put the host exactly where ``response.created`` leaves it.
+
+    Hand-rolling this trio is how fixtures drift away from the branch they
+    stand in for — one earlier version forgot ``_is_first_transcript_chunk``
+    and another would have missed ``_current_turn_epoch``, which is the very
+    thing several of these tests exist to check.
+    """
+
+    client._current_response_id = response_id
+    client._is_responding = True
+    client._turn_epoch += 1
+    client._current_turn_epoch = client._turn_epoch
+    client._is_first_text_chunk = client._is_first_transcript_chunk = True
+
+
 # ---------------------------------------------------------------------------
 # Contract 1: the shipped default is untouched.
 # ---------------------------------------------------------------------------
@@ -1278,9 +1294,7 @@ async def test_an_id_less_overlap_is_not_the_releases_to_end():
         on_response_done=_on_done, on_output_transcript=_on_transcript
     )
     # The owner announced itself with an id...
-    client._current_response_id = "resp-1"
-    client._is_responding = True
-    client._turn_epoch += 1
+    _begin_response(client, "resp-1")
     # ...then an id-less response.created took the turn over.
     client._current_response_id = None
     client._turn_epoch += 1
@@ -1310,9 +1324,7 @@ async def test_a_named_release_still_ends_the_turn_it_named():
             done_calls.append("done")
 
         client = _free_client(on_response_done=_on_done)
-        client._current_response_id = "resp-1"
-        client._is_responding = True
-        client._turn_epoch += 1
+        _begin_response(client, "resp-1")
 
         await client._on_arbiter_stuck_release("abandoned", named_id)
 
@@ -1350,9 +1362,7 @@ async def test_a_turn_that_started_mid_release_keeps_its_speech_id():
         on_response_done=_on_done,
         on_sid_rotate=_on_rotate,
     )
-    client._current_response_id = "resp-1"
-    client._is_responding = True
-    client._turn_epoch += 1
+    _begin_response(client, "resp-1")
     client._output_transcript_buffer = "旧轮说了半句"
     client._audio_delta_count = 1
 
@@ -1362,9 +1372,7 @@ async def test_a_turn_that_started_mid_release_keeps_its_speech_id():
     await asyncio.wait_for(entered.wait(), timeout=1)
 
     # A successor turn starts while the release is parked in the flush.
-    client._current_response_id = "resp-2"
-    client._is_responding = True
-    client._turn_epoch += 1
+    _begin_response(client, "resp-2")
 
     proceed.set()
     await asyncio.wait_for(release, timeout=2)
@@ -1390,9 +1398,7 @@ async def test_an_undisturbed_release_still_runs_both_hooks():
         order.append("rotate")
 
     client = _free_client(on_response_done=_on_done, on_sid_rotate=_on_rotate)
-    client._current_response_id = "resp-1"
-    client._is_responding = True
-    client._turn_epoch += 1
+    _begin_response(client, "resp-1")
 
     await client._on_arbiter_stuck_release("abandoned resp-1", "resp-1")
 
@@ -1419,9 +1425,7 @@ async def test_a_blocked_transcript_flush_cannot_cost_the_speech_id_rotation():
     client = _free_client(
         on_output_transcript=_never_returns, on_sid_rotate=_on_rotate
     )
-    client._current_response_id = "resp-1"
-    client._is_responding = True
-    client._turn_epoch += 1
+    _begin_response(client, "resp-1")
     client._output_transcript_buffer = "说了半句"
     client._audio_delta_count = 1
 
@@ -1449,9 +1453,7 @@ async def test_a_raising_transcript_flush_cannot_cost_the_rotation_either():
         rotations.append("rotate")
 
     client = _free_client(on_output_transcript=_raises, on_sid_rotate=_on_rotate)
-    client._current_response_id = "resp-1"
-    client._is_responding = True
-    client._turn_epoch += 1
+    _begin_response(client, "resp-1")
     client._output_transcript_buffer = "说了半句"
     client._audio_delta_count = 1
 
@@ -1474,9 +1476,7 @@ async def test_a_blocked_done_hook_cannot_cost_the_rotation():
         rotations.append("rotate")
 
     client = _free_client(on_response_done=_never_returns, on_sid_rotate=_on_rotate)
-    client._current_response_id = "resp-1"
-    client._is_responding = True
-    client._turn_epoch += 1
+    _begin_response(client, "resp-1")
 
     await asyncio.wait_for(
         client._on_arbiter_stuck_release("abandoned resp-1", "resp-1"),
@@ -1530,8 +1530,14 @@ def test_every_turn_start_advances_the_epoch():
             if not re.match(r"^\s*self\._is_responding\s*=\s*True\s*$", line):
                 continue
             starts += 1
-            if "self._turn_epoch += 1" not in "\n".join(lines[index : index + 3]):
-                offenders.append(f"{path.name}:{index + 1}")
+            window = "\n".join(lines[index : index + 4])
+            if "self._turn_epoch += 1" not in window:
+                offenders.append(f"{path.name}:{index + 1} (no epoch bump)")
+            elif "self._current_turn_epoch = self._turn_epoch" not in window:
+                # A response turn must also record WHICH epoch it began in.
+                # Without that, a release compares the live epoch against
+                # itself and its guard is vacuous — the exact defect this pins.
+                offenders.append(f"{path.name}:{index + 1} (epoch not recorded)")
     assert starts >= 2, (
         "expected to find the turn-start sites; the search stopped matching, "
         f"which makes this guard vacuous (found {starts})"
@@ -1795,9 +1801,7 @@ async def test_the_release_adds_what_the_turn_said_to_the_repetition_history():
     # _recent_responses, so three identical turns in a row could not trigger
     # on_repetition_detected at all.
     client = _free_client()
-    client._current_response_id = "resp-1"
-    client._is_responding = True
-    client._turn_epoch += 1
+    _begin_response(client, "resp-1")
     client._current_response_transcript = "一模一样的回答"
     client._audio_delta_count = 2
 
@@ -1860,9 +1864,7 @@ async def test_a_turn_starting_inside_the_done_hook_still_gets_a_speech_id():
         rotations.append("rotate")
 
     client = _free_client(on_response_done=_on_done, on_sid_rotate=_on_rotate)
-    client._current_response_id = "resp-1"
-    client._is_responding = True
-    client._turn_epoch += 1
+    _begin_response(client, "resp-1")
 
     release = asyncio.create_task(
         client._on_arbiter_stuck_release("abandoned resp-1", "resp-1")
@@ -2083,9 +2085,7 @@ async def test_the_abandoned_transcript_is_dropped_rather_than_spoken_as_the_suc
     client._repetition_threshold = 0.5
     # Two prior identical turns so the third trips detection and parks there.
     client._recent_responses = ["一样的话", "一样的话"]
-    client._current_response_id = "resp-1"
-    client._is_responding = True
-    client._turn_epoch += 1
+    _begin_response(client, "resp-1")
     client._current_response_transcript = "一样的话"
     client._output_transcript_buffer = "旧轮没送出的半句"
     client._audio_delta_count = 1
@@ -2119,9 +2119,7 @@ async def test_an_undisturbed_release_still_flushes_its_trailing_transcript():
         transcripts.append((text, is_first))
 
     client = _free_client(on_output_transcript=_on_transcript)
-    client._current_response_id = "resp-1"
-    client._is_responding = True
-    client._turn_epoch += 1
+    _begin_response(client, "resp-1")
     # What response.created sets, so the flag the host receives is the one a
     # real turn would have produced.
     client._is_first_transcript_chunk = True
@@ -2201,3 +2199,101 @@ async def test_an_unowned_cancellation_does_not_fail_work_queued_behind_it(
         {"type": "response.done", "response": {"id": "srv-1"}}
     )
     await asyncio.wait_for(queued.sent, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_barge_in_before_the_release_is_not_adopted_as_its_own_turn():
+    # Codex P2, against the epoch fix two rounds ago. Advancing _turn_epoch at
+    # speech_stopped protects a release that is ALREADY running. A release
+    # that starts afterwards read the live value as its baseline, so the guard
+    # compared the successor's epoch with itself and passed trivially.
+    #
+    # The barge-in is what makes it reachable: speech_stopped advances the
+    # epoch and on_new_message takes the new speech id, but it does NOT clear
+    # _current_response_id — so the id guard still matches the abandoned
+    # response, and the hooks then queue TTS-done and emit turn end against
+    # the user's brand-new turn.
+    done_calls: list[str] = []
+    rotations: list[str] = []
+
+    async def _on_done() -> None:
+        done_calls.append("done")
+
+    async def _on_rotate() -> None:
+        rotations.append("rotate")
+
+    client = _free_client(on_response_done=_on_done, on_sid_rotate=_on_rotate)
+    _begin_response(client, "resp-1")
+
+    # The user barges in. This is exactly what the speech_stopped branch does:
+    # a new turn starts, and the tracked response id is left alone.
+    client._turn_epoch += 1
+    assert client._current_response_id == "resp-1", (
+        "speech_stopped does not clear the tracked response, which is why the "
+        "id guard alone cannot catch this"
+    )
+
+    await client._on_arbiter_stuck_release("abandoned resp-1", "resp-1")
+
+    assert done_calls == [], (
+        "the user's turn started first; ending a turn under it is what the "
+        "epoch is for"
+    )
+    assert rotations == [], (
+        "and rotating would throw away the speech id on_new_message just "
+        "assigned to that turn"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_release_with_no_barge_in_still_ends_its_own_turn():
+    # The dual: without an intervening turn start, the captured epoch and the
+    # live one agree and the release finishes normally. Without this pair,
+    # "never run the hooks" would pass for correct.
+    done_calls: list[str] = []
+    rotations: list[str] = []
+
+    async def _on_done() -> None:
+        done_calls.append("done")
+
+    async def _on_rotate() -> None:
+        rotations.append("rotate")
+
+    client = _free_client(on_response_done=_on_done, on_sid_rotate=_on_rotate)
+    _begin_response(client, "resp-1")
+
+    await client._on_arbiter_stuck_release("abandoned resp-1", "resp-1")
+
+    assert done_calls == ["done"]
+    assert rotations == ["rotate"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_response_created_records_the_epoch_its_turn_began_in():
+    # Through the real receive loop, not the fixture that stands in for it.
+    # _begin_response sets _current_turn_epoch directly, so it cannot tell
+    # whether the branch it imitates still does — and that branch is what the
+    # release's guard depends on.
+    import json
+    from unittest.mock import AsyncMock
+
+    client = _free_client()
+    client.ws = AsyncMock()
+    client.ws.__aiter__.return_value = [
+        json.dumps({"type": "response.created", "response": {"id": "resp-1"}}),
+    ]
+    before = client._turn_epoch
+
+    try:
+        await client.handle_messages()
+    finally:
+        await client._response_arbiter.shutdown("test teardown")
+
+    assert client._turn_epoch == before + 1, "the turn started"
+    assert client._current_turn_epoch == client._turn_epoch, (
+        "and the response records which epoch it began in, which is what a "
+        "release compares against instead of the live value"
+    )

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -957,19 +957,35 @@ async def test_the_release_does_not_erase_an_owner_that_arrived_meanwhile(
 @pytest.mark.asyncio
 async def test_an_undisturbed_release_still_clears_its_own_owner(make_harness):
     # The dual. "Only clear what you captured" must not become "never clear":
-    # in the ordinary case nothing intervenes and the owner is still the one
+    # in the ordinary case nothing intervened and the owner is still the one
     # captured, so it goes.
+    #
+    # The worker clears ownership on its own way out too (_process's unwind),
+    # which is enough to satisfy a naive assertion here — the first version of
+    # this test passed even with the release's clear deleted. So the worker is
+    # retired first and the same owner reinstalled by hand: with nothing else
+    # running, the release is the only thing that can clear it.
     async def _returns_promptly(reason: str, response_id: str | None) -> None:
         return None
 
     harness = make_harness(fail_open=True, on_stuck_release=_returns_promptly)
-    await harness.own_a_live_response("resp-1")
+    ticket = await harness.own_a_live_response("resp-1")
+    owner = harness.arbiter._response_owner
+    assert owner is not None
+
+    harness.arbiter.notify_response_terminal(
+        {"type": "response.done", "response": {"id": "resp-1"}}
+    )
+    await asyncio.wait_for(ticket.done, timeout=1)
+    await _settle()
+    assert harness.arbiter._response_owner is None, "the worker dropped it"
+    harness.arbiter._response_owner = owner
 
     await harness.arbiter._release_stuck_lifecycle("ordinary release")
-    await _settle()
 
-    assert harness.arbiter._response_owner is None
-    assert harness.arbiter.is_busy is False
+    assert harness.arbiter._response_owner is None, (
+        "an undisturbed release must give up the owner it captured"
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -1040,6 +1040,59 @@ async def test_an_id_less_orphan_response_stands_the_hatch_down(make_harness, ca
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_a_release_with_nothing_to_release_says_so(make_harness, caplog):
+    # Codex P2 on this PR, partially accepted. cancel_current()'s unowned
+    # branch escalates over a server response the arbiter never owned, so the
+    # release gives nothing up and the lane stays held by that response's id.
+    # The generic line claims a turn was dropped and the lane reopened, which
+    # is the opposite of what happened — and it is the line #2561 points field
+    # reports at, so a wrong reading here costs a diagnosis.
+    #
+    # The finding's actual proposal (retire the id so the lane reopens) is
+    # declined: test_the_release_keeps_the_lane_closed_under_a_live_server_response
+    # pins the opposite, because the response may still be streaming.
+    harness = make_harness(fail_open=True)
+    harness.arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "srv-1"}}
+    )
+    assert harness.arbiter._response_owner is None
+
+    with caplog.at_level(logging.WARNING, logger=ARBITER_LOGGER):
+        raised = await _stick_a_cancel(harness)
+
+    assert isinstance(raised, asyncio.TimeoutError)
+    assert harness.aborted == [], "the transport is kept"
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("had no lifecycle to release" in message for message in messages), (
+        "a release that released nothing must not report a dropped turn"
+    )
+    assert any("srv-1" in message for message in messages), (
+        "and must name what is actually holding the lane"
+    )
+    assert not any(
+        "failing open, transport kept" in message for message in messages
+    ), "the two cases must not be reported with the same wording"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_release_that_gave_up_a_turn_still_says_that(make_harness, caplog):
+    # The dual: when there really was a lifecycle to release, the wording
+    # #2561 established stays exactly as it was.
+    harness = make_harness(fail_open=True)
+    await harness.own_a_live_response("resp-owned")
+
+    with caplog.at_level(logging.WARNING, logger=ARBITER_LOGGER):
+        raised = await _stick_a_cancel(harness)
+
+    assert isinstance(raised, asyncio.TimeoutError)
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("failing open, transport kept" in message for message in messages)
+    assert not any("had no lifecycle to release" in message for message in messages)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_an_id_bearing_orphan_response_still_fails_open(make_harness):
     # The dual: the same unowned server response, but identified. Its later
     # events are attributable, so the hatch applies and the lane stays closed

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -2276,6 +2276,17 @@ async def test_a_barge_in_before_the_release_is_not_adopted_as_its_own_turn():
         "resets the shared focus scorer and emotion state, which would land "
         "on the live turn"
     )
+    # But the identity IS given up: the stale-event filter keys on it, so
+    # leaving it would let the abandoned response's later id-bearing events
+    # through — including a delayed function_call_arguments.done, which
+    # executes a tool.
+    assert client._current_response_id is None, (
+        "the dead turn's identity is the one piece of the cleanup that does "
+        "not belong to the successor"
+    )
+    assert client._is_responding is True, (
+        "while everything that IS the successor's stays untouched"
+    )
 
 
 @pytest.mark.unit
@@ -2434,3 +2445,50 @@ async def test_an_undisturbed_repetition_still_triggers_its_recovery():
     await client._on_arbiter_stuck_release("abandoned resp-1", "resp-1")
 
     assert recoveries == ["recovered"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_quarantined_response_cannot_run_its_tool_afterwards():
+    # The consequence the identity clearing exists for, driven through the
+    # real receive loop: after a barge-in release quarantines resp-1, that
+    # response's own later id-bearing events must not be acted on. A delayed
+    # function_call_arguments.done would otherwise execute its tool under the
+    # user's new turn.
+    import json
+    from unittest.mock import AsyncMock
+
+    tool_calls: list[str] = []
+
+    async def _on_tool_call(name, arguments, call_id=None):
+        tool_calls.append(name)
+        return {"ok": True}
+
+    client = _free_client(on_tool_call=_on_tool_call)
+    _begin_response(client, "resp-1")
+    client._turn_epoch += 1  # the user barges in
+
+    await client._on_arbiter_stuck_release("abandoned resp-1", "resp-1")
+    assert client._current_response_id is None
+
+    client.ws = AsyncMock()
+    client.ws.__aiter__.return_value = [
+        json.dumps(
+            {
+                "type": "response.function_call_arguments.done",
+                "response_id": "resp-1",
+                "call_id": "call-1",
+                "name": "some_tool",
+                "arguments": "{}",
+            }
+        ),
+    ]
+    try:
+        await client.handle_messages()
+    finally:
+        await client._response_arbiter.shutdown("test teardown")
+
+    assert tool_calls == [], (
+        "an abandoned response's tool call must not run under the turn that "
+        "replaced it"
+    )

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -1830,9 +1830,7 @@ async def test_the_release_repeats_the_terminal_paths_repetition_bookkeeping():
     client._repetition_threshold = 0.5
 
     for turn in range(3):
-        client._current_response_id = f"resp-{turn}"
-        client._is_responding = True
-        client._turn_epoch += 1
+        _begin_response(client, f"resp-{turn}")
         client._current_response_transcript = "完全相同的一句话"
         client._audio_delta_count = 1
         await client._on_arbiter_stuck_release(f"abandoned resp-{turn}", f"resp-{turn}")
@@ -2225,6 +2223,10 @@ async def test_a_barge_in_before_the_release_is_not_adopted_as_its_own_turn():
 
     client = _free_client(on_response_done=_on_done, on_sid_rotate=_on_rotate)
     _begin_response(client, "resp-1")
+    client._interrupted = True
+    client._image_sent_this_turn = True
+    client._current_response_transcript = "被放弃那一轮说的话"
+    client._audio_delta_count = 1
 
     # The user barges in. This is exactly what the speech_stopped branch does:
     # a new turn starts, and the tracked response id is left alone.
@@ -2243,6 +2245,21 @@ async def test_a_barge_in_before_the_release_is_not_adopted_as_its_own_turn():
     assert rotations == [], (
         "and rotating would throw away the speech id on_new_message just "
         "assigned to that turn"
+    )
+    # And not just the awaited hooks: the synchronous cleanup ahead of them
+    # has side effects on the live turn too.
+    assert client._interrupted is True, (
+        "clearing the interruption suppression is what lets the abandoned "
+        "response's id-less deltas through under the new turn's speech id"
+    )
+    assert client._image_sent_this_turn is True, (
+        "per-turn state belongs to whoever owns the turn now; the successor's "
+        "own terminal clears it"
+    )
+    assert client._recent_responses == [], (
+        "and the repetition check must not run either — its host callback "
+        "resets the shared focus scorer and emotion state, which would land "
+        "on the live turn"
     )
 
 

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -2007,3 +2007,161 @@ async def test_a_current_turns_terminal_is_accounted_for_exactly_once():
 
     assert tracker.record.call_count == 1
     assert tracker.record.call_args.kwargs["total_tokens"] == 11
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_repeated_terminal_is_not_billed_twice():
+    # Codex P2, self-inflicted by the previous commit. Recording usage on the
+    # stale branch made a REPEATED response.done — which the transport
+    # tolerates on purpose without finalizing the turn twice — bill the same
+    # turn twice: the first takes the normal branch and clears
+    # _current_response_id, so the duplicate necessarily takes the stale one.
+    import json
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    client = _free_client()
+    done = {
+        "type": "response.done",
+        "response": {
+            "id": "resp-1",
+            "model": "free-model",
+            "usage": {"input_tokens": 7, "output_tokens": 8, "total_tokens": 15},
+        },
+    }
+    client.ws = AsyncMock()
+    client.ws.__aiter__.return_value = [
+        json.dumps({"type": "response.created", "response": {"id": "resp-1"}}),
+        json.dumps(done),
+        json.dumps(done),  # the provider repeats it
+    ]
+
+    tracker = MagicMock()
+    with patch("utils.token_tracker.TokenTracker.get_instance", return_value=tracker):
+        try:
+            await client.handle_messages()
+        finally:
+            await client._response_arbiter.shutdown("test teardown")
+
+    assert tracker.record.call_count == 1, (
+        "a repeated terminal is the same turn; billing it again overstates "
+        "usage for a case the transport supports on purpose"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_two_different_turns_are_billed_separately():
+    # The dual: deduplication must key on identity, not collapse everything.
+    import json
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    def _done(rid: str, total: int) -> str:
+        return json.dumps(
+            {
+                "type": "response.done",
+                "response": {
+                    "id": rid,
+                    "model": "free-model",
+                    "usage": {
+                        "input_tokens": 1,
+                        "output_tokens": total - 1,
+                        "total_tokens": total,
+                    },
+                },
+            }
+        )
+
+    client = _free_client()
+    client.ws = AsyncMock()
+    client.ws.__aiter__.return_value = [
+        json.dumps({"type": "response.created", "response": {"id": "resp-1"}}),
+        _done("resp-1", 10),
+        json.dumps({"type": "response.created", "response": {"id": "resp-2"}}),
+        _done("resp-2", 20),
+    ]
+
+    tracker = MagicMock()
+    with patch("utils.token_tracker.TokenTracker.get_instance", return_value=tracker):
+        try:
+            await client.handle_messages()
+        finally:
+            await client._response_arbiter.shutdown("test teardown")
+
+    assert tracker.record.call_count == 2
+    assert [c.kwargs["total_tokens"] for c in tracker.record.call_args_list] == [10, 20]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_the_abandoned_transcript_is_dropped_rather_than_spoken_as_the_successors():
+    # Codex P2, also self-inflicted: inserting the repetition check ahead of
+    # the transcript flush gave the flush an await in front of it, so a
+    # successor can start before it runs. handle_output_transcript publishes
+    # and queues TTS under whatever speech id is CURRENT, so flushing then
+    # speaks the abandoned turn's half-sentence as part of the successor's.
+    entered = asyncio.Event()
+    proceed = asyncio.Event()
+    transcripts: list[tuple[str, bool]] = []
+
+    async def _on_repetition() -> None:
+        entered.set()
+        await proceed.wait()
+
+    async def _on_transcript(text: str, is_first: bool) -> None:
+        transcripts.append((text, is_first))
+
+    client = _free_client(
+        on_repetition_detected=_on_repetition, on_output_transcript=_on_transcript
+    )
+    client._repetition_threshold = 0.5
+    # Two prior identical turns so the third trips detection and parks there.
+    client._recent_responses = ["一样的话", "一样的话"]
+    client._current_response_id = "resp-1"
+    client._is_responding = True
+    client._turn_epoch += 1
+    client._current_response_transcript = "一样的话"
+    client._output_transcript_buffer = "旧轮没送出的半句"
+    client._audio_delta_count = 1
+
+    release = asyncio.create_task(
+        client._on_arbiter_stuck_release("abandoned resp-1", "resp-1")
+    )
+    await asyncio.wait_for(entered.wait(), timeout=1)
+
+    # A successor takes the turn while the repetition callback is parked.
+    client._turn_epoch += 1
+
+    proceed.set()
+    await asyncio.wait_for(release, timeout=2)
+
+    assert transcripts == [], (
+        "the abandoned turn's trailing text must not go out under the "
+        "successor's speech id"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_an_undisturbed_release_still_flushes_its_trailing_transcript():
+    # The dual. Dropping it is only correct once a successor exists; a normal
+    # release must still deliver what the turn already said, which is the
+    # whole point of the fallback flush (audio with no text otherwise).
+    transcripts: list[tuple[str, bool]] = []
+
+    async def _on_transcript(text: str, is_first: bool) -> None:
+        transcripts.append((text, is_first))
+
+    client = _free_client(on_output_transcript=_on_transcript)
+    client._current_response_id = "resp-1"
+    client._is_responding = True
+    client._turn_epoch += 1
+    # What response.created sets, so the flag the host receives is the one a
+    # real turn would have produced.
+    client._is_first_transcript_chunk = True
+    client._output_transcript_buffer = "旧轮没送出的半句"
+    client._audio_delta_count = 1
+
+    await client._on_arbiter_stuck_release("abandoned resp-1", "resp-1")
+
+    assert transcripts == [("旧轮没送出的半句", True)]

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -23,13 +23,14 @@ Contracts, written so each can be falsified:
 
 2.  **Fail-open applies only when the connection can be kept.** That means
     both halves: the transport is still usable, AND the arbiter can still
-    tell whose events are whose. Four things falsify it, each with a paired
+    tell whose events are whose. Five things falsify it, each with a paired
     case here so "always stand down" cannot pass for correct:
 
     - the queue consumer is suspended inside a transport write
     - a transport write just failed
     - the abandoned response has no id to attribute its later events by
     - an announced server-VAD response has no id yet
+    - an unowned response is live with no id at all
 
 3.  **A released turn is ended, not merely dropped.** The host runs the same
     end-of-turn work its terminal event drives — because it is the same
@@ -884,7 +885,7 @@ async def test_a_cancelled_release_still_finishes_its_bookkeeping(make_harness):
     await asyncio.wait_for(entered.wait(), timeout=1)
     release.cancel()
     with pytest.raises(asyncio.CancelledError):
-        await release
+        await asyncio.wait_for(release, timeout=1)
     await _settle()
 
     assert harness.arbiter._response_owner is None, (
@@ -940,7 +941,7 @@ async def test_the_release_does_not_erase_an_owner_that_arrived_meanwhile(
     assert successor is not None and successor.source == "native-next"
 
     resumed.set()
-    await release
+    await asyncio.wait_for(release, timeout=1)
     await _settle()
 
     assert harness.arbiter._response_owner is successor, (
@@ -1159,7 +1160,7 @@ async def test_a_blocked_transcript_flush_cannot_strand_this_turns_state():
     await asyncio.wait_for(entered.wait(), timeout=1)
     release.cancel()
     with pytest.raises(asyncio.CancelledError):
-        await release
+        await asyncio.wait_for(release, timeout=1)
 
     assert client._is_responding is False
     assert client._current_response_id is None

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -577,18 +577,37 @@ async def test_a_create_on_the_wire_without_an_announcement_stands_the_hatch_dow
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_a_request_whose_create_never_went_out_still_fails_open(make_harness):
-    # The criterion is "did the create reach the wire", not "did
-    # response.created come back". A request still waiting for dispatch has no
-    # live response at all, so nothing of its can surprise us later.
+    # The DUAL of the criterion, not a discriminator for it — and the
+    # difference matters, because getting that backwards is how #2592 shipped a
+    # wrong contract under a passing test.
     #
-    # The withdrawn #2592 wrote this the other way round — keyed on
-    # ticket.started — and pinned the wrong contract with a passing test.
+    # A request still waiting for dispatch has no live response at all, so
+    # nothing of its can surprise us later and the hatch must hold. But note
+    # WHY it holds: this request is neither ``_current`` nor
+    # ``_response_owner``, so the blocker never looks at it under EITHER
+    # candidate criterion. Keyed on ticket.started this test is just as green,
+    # which is exactly why it cannot be the one that pins the criterion — that
+    # job belongs to
+    # ``test_a_create_on_the_wire_without_an_announcement_stands_the_hatch_down``,
+    # the one cell where the two criteria disagree.
+    #
+    # What this test does pin is that the blocker is not "always fires":
+    # without it, a stand-down on every escalation would pass the whole
+    # criterion suite.
     harness = make_harness(fail_open=True)
     harness.arbiter.pause_dispatch()
     queued = await harness.arbiter.enqueue(source="native")
     await _settle()
     assert harness.dispatch_count == 0
     assert not queued.sent.done()
+    # Pin the mechanism this test actually rests on, so a future change that
+    # makes an undispatched request visible to the blocker fails here rather
+    # than silently turning the assertion below into a different claim.
+    assert harness.arbiter._response_owner is None, (
+        "an undispatched request owns nothing, which is why the blocker "
+        "cannot see it"
+    )
+    assert harness.arbiter._current is not queued
 
     harness.arbiter.notify_response_created(
         {"type": "response.created", "response": {"id": "srv-1"}}
@@ -1228,6 +1247,63 @@ async def test_the_host_ends_the_turn_it_was_actually_tracking():
         assert client._current_response_id is None, f"named_id={named_id}"
         assert client._image_sent_this_turn is False, f"named_id={named_id}"
         assert done_calls == ["done"], f"named_id={named_id}"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_blocked_repetition_hook_cannot_strand_this_turns_state():
+    # The FIRST await, not the last one. Its sibling below cancels at the
+    # transcript flush, which is the second host hook — so with the whole
+    # synchronous reset moved to sit between the two, that sibling stays green
+    # and the property "settle every synchronous write before the FIRST await"
+    # goes unpinned. This is the case that distinguishes the two placements.
+    #
+    # The repetition hook is reached before anything else the release awaits,
+    # and a host that blocks in it gets the release cancelled right there —
+    # the arbiter's own bound is what eventually cuts it. If the reset ran
+    # afterwards, this turn's _image_sent_this_turn and _audio_delta_count
+    # would survive into the next turn.
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    entered = asyncio.Event()
+
+    async def _blocks() -> None:
+        entered.set()
+        await asyncio.Event().wait()
+
+    client = OmniRealtimeClient(
+        "wss://example.invalid/realtime",
+        "test-key",
+        model="free-model",
+        api_type="free",
+        on_repetition_detected=_blocks,
+    )
+    client._current_response_id = "resp-1"
+    client._is_responding = True
+    client._image_sent_this_turn = True
+    client._image_recognized_this_turn = True
+    client._audio_delta_count = 3
+    # Two identical predecessors put this turn's text at the third strike, so
+    # _check_repetition reaches on_repetition_detected — the release's first
+    # await — instead of returning without awaiting anything.
+    client._current_response_transcript = "一模一样的一句话"
+    client._recent_responses = ["一模一样的一句话", "一模一样的一句话"]
+
+    release = asyncio.create_task(client._on_arbiter_stuck_release("stalled", "resp-1"))
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    release.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(release, timeout=1)
+
+    assert client._is_responding is False
+    assert client._current_response_id is None
+    assert client._image_sent_this_turn is False, (
+        "the next turn would withhold its own visual context"
+    )
+    assert client._image_recognized_this_turn is False
+    assert client._audio_delta_count == 0, (
+        "the next turn would count this turn's audio"
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -1528,9 +1528,9 @@ def test_every_turn_start_advances_the_epoch():
     import pathlib
     import re
 
-    import main_logic.omni_realtime_client as package
+    from main_logic.omni_realtime_client import _transport
 
-    root = pathlib.Path(package.__file__).parent
+    root = pathlib.Path(_transport.__file__).parent
     starts = 0
     offenders: list[str] = []
     for path in sorted(root.glob("*.py")):

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -1914,3 +1914,96 @@ async def test_a_turn_starting_inside_the_done_hook_still_gets_a_speech_id():
         "the rotation repairs the speech id the done hook just closed; "
         "skipping it strands the successor on a dead one"
     )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_released_turns_late_terminal_is_still_accounted_for():
+    # Codex P2. The release clears _current_response_id on purpose, so the
+    # released response's real terminal always takes the stale-event branch.
+    # That branch forwarded it to the arbiter and dropped everything else,
+    # including the provider's exact token counts — so every turn the hatch
+    # recovered vanished from usage statistics.
+    import json
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    client = _free_client()
+    client.ws = AsyncMock()
+    client.ws.__aiter__.return_value = [
+        json.dumps({"type": "response.created", "response": {"id": "resp-2"}}),
+        # The released turn's real terminal, arriving after a successor
+        # became current — which is what the release guarantees.
+        json.dumps(
+            {
+                "type": "response.done",
+                "response": {
+                    "id": "resp-1",
+                    "model": "free-model",
+                    "usage": {
+                        "input_tokens": 11,
+                        "output_tokens": 22,
+                        "total_tokens": 33,
+                    },
+                },
+            }
+        ),
+    ]
+
+    tracker = MagicMock()
+    with patch(
+        "utils.token_tracker.TokenTracker.get_instance", return_value=tracker
+    ):
+        try:
+            await client.handle_messages()
+        finally:
+            await client._response_arbiter.shutdown("test teardown")
+
+    assert tracker.record.call_count == 1, (
+        "a stale terminal still cost tokens; quarantining the host "
+        "finalization must not quarantine the accounting"
+    )
+    booked = tracker.record.call_args.kwargs
+    assert booked["prompt_tokens"] == 11
+    assert booked["completion_tokens"] == 22
+    assert booked["total_tokens"] == 33
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_current_turns_terminal_is_accounted_for_exactly_once():
+    # The dual, both ways: the ordinary path still books its usage, and the
+    # shared helper does not let a terminal be counted twice.
+    import json
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    client = _free_client()
+    client.ws = AsyncMock()
+    client.ws.__aiter__.return_value = [
+        json.dumps({"type": "response.created", "response": {"id": "resp-1"}}),
+        json.dumps(
+            {
+                "type": "response.done",
+                "response": {
+                    "id": "resp-1",
+                    "model": "free-model",
+                    "usage": {
+                        "input_tokens": 5,
+                        "output_tokens": 6,
+                        "total_tokens": 11,
+                    },
+                },
+            }
+        ),
+    ]
+
+    tracker = MagicMock()
+    with patch(
+        "utils.token_tracker.TokenTracker.get_instance", return_value=tracker
+    ):
+        try:
+            await client.handle_messages()
+        finally:
+            await client._response_arbiter.shutdown("test teardown")
+
+    assert tracker.record.call_count == 1
+    assert tracker.record.call_args.kwargs["total_tokens"] == 11

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -457,6 +457,43 @@ async def test_an_id_bearing_abandoned_response_still_fails_open(make_harness):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_a_create_on_the_wire_without_an_announcement_stands_the_hatch_down(
+    make_harness, caplog
+):
+    # The case that separates the two candidate criteria, and the one the
+    # withdrawn #2592 got backwards.
+    #
+    # Here response.create has reached the provider but response.created has
+    # not come back. Keyed on "did the create go out" this is a blocker — the
+    # provider may still announce this response, and without an id that
+    # announcement is indistinguishable from the next turn's. Keyed on "did
+    # response.created come back" it looks safe, which is exactly wrong: a
+    # request that never started cannot surprise anyone, but one whose create
+    # is already out is the only kind that can.
+    harness = make_harness(fail_open=True)
+    ticket = await harness.arbiter.enqueue(source="native")
+    await asyncio.wait_for(ticket.sent, timeout=1)
+    owner = harness.arbiter._response_owner
+    assert owner is not None
+    assert owner.response_send_started is True, "the create reached the wire"
+    assert owner.ticket.started.done() is False, "but nothing came back"
+
+    with caplog.at_level(logging.WARNING, logger=ARBITER_LOGGER):
+        raised = await _stick_a_cancel(harness)
+
+    assert isinstance(raised, asyncio.TimeoutError)
+    assert harness.aborted, (
+        "a response whose create is on the wire but unannounced cannot be "
+        "told apart from the next one, so the hatch must stand down"
+    )
+    assert any(
+        "no id to attribute later events by" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_a_request_whose_create_never_went_out_still_fails_open(make_harness):
     # The criterion is "did the create reach the wire", not "did
     # response.created come back". A request still waiting for dispatch has no

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -623,7 +623,7 @@ async def test_the_release_ends_the_turn_before_the_lane_opens(make_harness):
     # turn — and end up with that turn's speech id rotated underneath it.
     lane_open_at_notify: list[bool] = []
 
-    async def _on_release(reason: str) -> None:
+    async def _on_release(reason: str, response_id: str | None) -> None:
         lane_open_at_notify.append(harness.arbiter._idle.is_set())
 
     harness = make_harness(fail_open=True, on_stuck_release=_on_release)
@@ -654,7 +654,7 @@ async def test_a_hanging_host_notification_cannot_wedge_the_consumer(
     )
     released = asyncio.Event()
 
-    async def _never_returns(reason: str) -> None:
+    async def _never_returns(reason: str, response_id: str | None) -> None:
         await released.wait()
 
     harness = make_harness(fail_open=True, on_stuck_release=_never_returns)
@@ -842,3 +842,314 @@ async def test_the_release_runs_the_hosts_own_end_of_turn_work():
         assert client.is_active_response() is False
     finally:
         await arbiter.shutdown("test teardown")
+
+
+# --------------------------------------------------------------------------
+# Contract 5: the release is scoped across its own await.
+#
+# Notifying the host before opening the lane (contract 4) puts an await in the
+# middle of the release. Three things can happen there that cannot happen in
+# straight-line code: this task can be cancelled, the abandoned response's
+# terminal can land, and the worker can wake and take a new owner. The release
+# must act only on what it captured before that await, and must finish its
+# bookkeeping either way.
+#
+# All four cases below were raised by Codex against the first version of this
+# ordering — the fix for one invariant opening a window on another, which is
+# the failure mode #2583 was reorganised to stop repeating.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_cancelled_release_still_finishes_its_bookkeeping(make_harness):
+    # Without this, a cancellation mid-notification leaves `escalated` set on
+    # the owner while the owner is never cleared: every later escalation sees
+    # a duplicate and returns, and the lane never reopens. The connection the
+    # hatch "saved" would then accept no further turns at all — strictly worse
+    # than the teardown it replaced.
+    entered = asyncio.Event()
+
+    async def _blocks_forever(reason: str, response_id: str | None) -> None:
+        entered.set()
+        await asyncio.Event().wait()
+
+    harness = make_harness(fail_open=True, on_stuck_release=_blocks_forever)
+    owner = await harness.own_a_live_response("resp-1")
+    assert owner is not None
+
+    release = asyncio.create_task(
+        harness.arbiter._release_stuck_lifecycle("cancelled mid-notify")
+    )
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    release.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await release
+    await _settle()
+
+    assert harness.arbiter._response_owner is None, (
+        "a release cancelled mid-notification must still give up the owner"
+    )
+    assert harness.arbiter.is_busy is False, "and still reopen the lane"
+    revived = await harness.arbiter.enqueue(source="native-after")
+    await asyncio.wait_for(revived.sent, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_the_release_does_not_erase_an_owner_that_arrived_meanwhile(
+    make_harness,
+):
+    # The abandoned response's terminal can still land while the host is being
+    # notified — the arbiter gave up on it, the provider did not. That clears
+    # the owner and reopens the lane, so the next queued request dispatches and
+    # installs itself as the new owner, all before the release resumes.
+    # Clearing "the owner" unconditionally at that point erases a healthy
+    # turn's ownership, and its terminal would arrive with nothing to resolve.
+    resumed = asyncio.Event()
+    notified = asyncio.Event()
+
+    async def _hands_control_back(reason: str, response_id: str | None) -> None:
+        notified.set()
+        await resumed.wait()
+
+    harness = make_harness(fail_open=True, on_stuck_release=_hands_control_back)
+    first = await harness.own_a_live_response("resp-1")
+
+    release = asyncio.create_task(
+        harness.arbiter._release_stuck_lifecycle("overtaken by a new owner")
+    )
+    await asyncio.wait_for(notified.wait(), timeout=1)
+
+    # The world moves while the notification is outstanding. The release
+    # already woke this ticket, so its failure is expected; what matters is
+    # that the terminal frees the ownership behind it.
+    with pytest.raises(RuntimeError):
+        await asyncio.wait_for(first.done, timeout=1)
+    harness.arbiter.notify_response_terminal(
+        {"type": "response.done", "response": {"id": "resp-1"}}
+    )
+    await _settle()
+    assert harness.arbiter._response_owner is None
+    second = await harness.arbiter.enqueue(source="native-next")
+    await asyncio.wait_for(second.sent, timeout=1)
+    harness.arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "resp-2"}}
+    )
+    successor = harness.arbiter._response_owner
+    assert successor is not None and successor.source == "native-next"
+
+    resumed.set()
+    await release
+    await _settle()
+
+    assert harness.arbiter._response_owner is successor, (
+        "the release must not clear an owner it never observed"
+    )
+    harness.arbiter.notify_response_terminal(
+        {"type": "response.done", "response": {"id": "resp-2"}}
+    )
+    # And its terminal still resolves, which is what the ownership was for.
+    await asyncio.wait_for(second.done, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_an_undisturbed_release_still_clears_its_own_owner(make_harness):
+    # The dual. "Only clear what you captured" must not become "never clear":
+    # in the ordinary case nothing intervenes and the owner is still the one
+    # captured, so it goes.
+    async def _returns_promptly(reason: str, response_id: str | None) -> None:
+        return None
+
+    harness = make_harness(fail_open=True, on_stuck_release=_returns_promptly)
+    await harness.own_a_live_response("resp-1")
+
+    await harness.arbiter._release_stuck_lifecycle("ordinary release")
+    await _settle()
+
+    assert harness.arbiter._response_owner is None
+    assert harness.arbiter.is_busy is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_the_release_tells_the_host_which_response_it_abandoned(make_harness):
+    # The host cannot finalize "the current turn" on trust: an owned response
+    # can overlap a server-initiated one, and it is the server response's
+    # response.created that last wrote the host's tracked id. The reason
+    # string alone does not say which response died, so the id travels with it.
+    seen: list[tuple[str, str | None]] = []
+
+    async def _record(reason: str, response_id: str | None) -> None:
+        seen.append((reason, response_id))
+
+    harness = make_harness(fail_open=True, on_stuck_release=_record)
+    await harness.own_a_live_response("resp-abandoned")
+
+    await harness.arbiter._release_stuck_lifecycle("named release")
+    await _settle()
+
+    assert seen == [("named release", "resp-abandoned")], (
+        "the abandoned response's identity must reach the host"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_an_id_less_orphan_response_stands_the_hatch_down(make_harness, caplog):
+    # The gap the four existing blockers left open. A server-initiated
+    # response.created arrives with no id and nobody owns it: there is no
+    # owner to inspect, no remembered id, and no speech_stopped marker, so all
+    # four blockers pass and the lane opens over a response that may still be
+    # streaming. Its terminal will arrive id-less too, and complete whoever
+    # holds the lane by then.
+    harness = make_harness(fail_open=True)
+    harness.arbiter.notify_response_created({"type": "response.created"})
+    assert harness.arbiter._server_response_active is True
+    assert harness.arbiter._server_response_ids == {}
+    assert harness.arbiter._response_owner is None
+
+    with caplog.at_level(logging.WARNING, logger=ARBITER_LOGGER):
+        await harness.arbiter._escalate("orphan with no id")
+
+    assert harness.aborted == ["orphan with no id"], (
+        "an unidentifiable live response must tear the transport down"
+    )
+    assert any(
+        "no id at all" in record.getMessage() for record in caplog.records
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_an_id_bearing_orphan_response_still_fails_open(make_harness):
+    # The dual: the same unowned server response, but identified. Its later
+    # events are attributable, so the hatch applies and the lane stays closed
+    # only until that response retires.
+    harness = make_harness(fail_open=True)
+    harness.arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "srv-1"}}
+    )
+
+    await harness.arbiter._escalate("orphan with an id")
+
+    assert harness.aborted == []
+    assert harness.arbiter._connection_available is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_the_host_leaves_a_different_live_response_alone():
+    # The host half of the same contract. The arbiter abandoned resp-1, but a
+    # server-initiated resp-2 announced itself afterwards and is what the
+    # transport is tracking. Finalizing "the current turn" would close resp-2
+    # mid-stream: its audio keeps arriving with _is_responding already false,
+    # and its own terminal finds nothing left to end.
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    done_calls: list[str] = []
+
+    async def _on_done() -> None:
+        done_calls.append("done")
+
+    client = OmniRealtimeClient(
+        "wss://example.invalid/realtime",
+        "test-key",
+        model="free-model",
+        api_type="free",
+        on_response_done=_on_done,
+    )
+    client._current_response_id = "resp-2"
+    client._is_responding = True
+    client._image_sent_this_turn = True
+
+    await client._on_arbiter_stuck_release("abandoned resp-1", "resp-1")
+
+    assert client._is_responding is True, (
+        "the live response must keep streaming"
+    )
+    assert client._current_response_id == "resp-2"
+    assert client._image_sent_this_turn is True, (
+        "and keep the per-turn state it is still using"
+    )
+    assert done_calls == [], "no turn ended, so nothing announces one"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_the_host_ends_the_turn_it_was_actually_tracking():
+    # The dual, in both directions: the named response IS the tracked one, and
+    # an unnamed release (the arbiter never learned an id) still finalizes.
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    for named_id in ("resp-1", None):
+        done_calls: list[str] = []
+
+        async def _on_done() -> None:
+            done_calls.append("done")
+
+        client = OmniRealtimeClient(
+            "wss://example.invalid/realtime",
+            "test-key",
+            model="free-model",
+            api_type="free",
+            on_response_done=_on_done,
+        )
+        client._current_response_id = "resp-1"
+        client._is_responding = True
+        client._image_sent_this_turn = True
+
+        await client._on_arbiter_stuck_release("abandoned", named_id)
+
+        assert client._is_responding is False, f"named_id={named_id}"
+        assert client._current_response_id is None, f"named_id={named_id}"
+        assert client._image_sent_this_turn is False, f"named_id={named_id}"
+        assert done_calls == ["done"], f"named_id={named_id}"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_blocked_transcript_flush_cannot_strand_this_turns_state():
+    # The host callbacks run under the arbiter's 2s bound, so a host that
+    # blocks in on_output_transcript gets its release cancelled at that await.
+    # If the per-turn reset ran after it, this turn's flags would survive into
+    # the next one — _image_sent_this_turn being the one that changes what the
+    # model is told. Settling every synchronous write before the first await
+    # makes the leak impossible rather than merely unlikely.
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    entered = asyncio.Event()
+
+    async def _blocks(text: str, is_first: bool) -> None:
+        entered.set()
+        await asyncio.Event().wait()
+
+    client = OmniRealtimeClient(
+        "wss://example.invalid/realtime",
+        "test-key",
+        model="free-model",
+        api_type="free",
+        on_output_transcript=_blocks,
+    )
+    client._current_response_id = "resp-1"
+    client._is_responding = True
+    client._image_sent_this_turn = True
+    client._image_recognized_this_turn = True
+    client._output_transcript_buffer = "已经说出口的半句"
+    client._audio_delta_count = 3
+
+    release = asyncio.create_task(client._on_arbiter_stuck_release("stalled", "resp-1"))
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    release.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await release
+
+    assert client._is_responding is False
+    assert client._current_response_id is None
+    assert client._image_sent_this_turn is False, (
+        "a turn interrupted while flushing must not leak its image flags"
+    )
+    assert client._image_recognized_this_turn is False
+    assert client._audio_delta_count == 0
+    assert client._output_transcript_buffer == ""

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -551,6 +551,72 @@ async def test_a_pending_server_vad_response_stands_the_hatch_down(
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_the_release_keeps_the_lane_closed_under_a_live_server_response(
+    make_harness,
+):
+    # Greptile P1 on this PR. The abandoned turn's bookkeeping is what became
+    # untrustworthy — a separately initiated server response tracked alongside
+    # it is still tracking fine, and it is still RUNNING. Discarding its
+    # identity and forcing the lane open would put the next create straight on
+    # top of it (response_already_active, or two live responses).
+    harness = make_harness(fail_open=True)
+    await harness.own_a_live_response("resp-owned")
+    # A server-initiated response starts and is tracked separately.
+    harness.arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "srv-live"}}
+    )
+    assert "srv-live" in harness.arbiter._server_response_ids
+
+    raised = await _stick_a_cancel(harness)
+    assert isinstance(raised, asyncio.TimeoutError)
+    await _settle()
+
+    assert harness.aborted == [], "the connection itself is fine"
+    assert "srv-live" in harness.arbiter._server_response_ids, (
+        "a live server response's identity is not this turn's to discard"
+    )
+    dispatched_before = harness.dispatch_count
+    queued = await harness.arbiter.enqueue(source="native-after")
+    await _settle()
+    assert harness.dispatch_count == dispatched_before, (
+        "and the lane stays closed while it runs"
+    )
+
+    # Its own terminal releases the lane through the ordinary path.
+    harness.arbiter.notify_response_terminal(
+        {"type": "response.done", "response": {"id": "srv-live"}}
+    )
+    await _settle()
+    assert harness.dispatch_count == dispatched_before + 1
+    harness.arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "resp-next"}}
+    )
+    harness.arbiter.notify_response_terminal(
+        {"type": "response.done", "response": {"id": "resp-next"}}
+    )
+    await asyncio.wait_for(queued.done, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_the_release_opens_the_lane_when_nothing_else_is_running(make_harness):
+    # The dual: with no other live response, the release must actually reopen
+    # the lane. Without this pair, never reopening would look correct.
+    harness = make_harness(fail_open=True)
+    await harness.own_a_live_response("resp-owned")
+    assert harness.arbiter._server_response_ids == {}
+
+    raised = await _stick_a_cancel(harness)
+    assert isinstance(raised, asyncio.TimeoutError)
+    await _settle()
+
+    assert harness.arbiter.is_busy is False
+    revived = await harness.arbiter.enqueue(source="native-after")
+    await asyncio.wait_for(revived.sent, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_the_release_ends_the_turn_before_the_lane_opens(make_harness):
     # Ordering, not just occurrence. If the lane opened first, the next
     # request could dispatch while the host was still closing the previous
@@ -616,6 +682,108 @@ async def test_a_hanging_host_notification_cannot_wedge_the_consumer(
         await asyncio.wait_for(follow_up.sent, timeout=1)
     finally:
         released.set()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_the_release_flushes_transcript_the_turn_never_got_to_send():
+    # Codex P2 on this PR. Some providers emit transcript deltas and no
+    # transcript-done, so the buffer is drained by response.done's fallback
+    # flush — and a stalled lifecycle is precisely the case where that
+    # terminal never comes. Resetting per-turn state without flushing first
+    # loses whatever the turn already said: audio the user heard, with no text.
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    transcripts: list[tuple[str, bool]] = []
+
+    async def _on_output_transcript(text: str, is_first: bool) -> None:
+        transcripts.append((text, is_first))
+
+    client = OmniRealtimeClient(
+        "wss://example.invalid/realtime",
+        "test-key",
+        model="free-model",
+        api_type="free",
+        on_output_transcript=_on_output_transcript,
+    )
+
+    async def _send(event: dict) -> None:
+        return None
+
+    arbiter = client._response_arbiter
+    arbiter._send_event = _send
+    arbiter._fail_open = True
+    try:
+        ticket = await arbiter.enqueue(source="native")
+        await asyncio.wait_for(ticket.sent, timeout=1)
+        arbiter.notify_response_created(
+            {"type": "response.created", "response": {"id": "resp-1"}}
+        )
+        client._current_response_id = "resp-1"
+        client._is_responding = True
+        # The turn spoke, and its transcript is still buffered.
+        client._audio_delta_count = 3
+        client._output_transcript_buffer = "half a sentence"
+
+        with pytest.raises(asyncio.TimeoutError):
+            await arbiter.cancel_current(timeout=0.05)
+        await _settle()
+
+        # The contract is that the buffered text reaches the frontend. The
+        # is_first flag is transport bookkeeping driven by response.created,
+        # which this test does not go through, so it is not asserted here.
+        assert [text for text, _ in transcripts] == ["half a sentence"], (
+            "text the user already heard must not be dropped by the release"
+        )
+        assert client._output_transcript_buffer == ""
+    finally:
+        await arbiter.shutdown("test teardown")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_the_release_does_not_flush_a_turn_that_never_spoke():
+    # The dual: the flush is conditional on the turn having produced audio, so
+    # a silent turn must not push a stray transcript at the frontend.
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    transcripts: list[tuple[str, bool]] = []
+
+    async def _on_output_transcript(text: str, is_first: bool) -> None:
+        transcripts.append((text, is_first))
+
+    client = OmniRealtimeClient(
+        "wss://example.invalid/realtime",
+        "test-key",
+        model="free-model",
+        api_type="free",
+        on_output_transcript=_on_output_transcript,
+    )
+
+    async def _send(event: dict) -> None:
+        return None
+
+    arbiter = client._response_arbiter
+    arbiter._send_event = _send
+    arbiter._fail_open = True
+    try:
+        ticket = await arbiter.enqueue(source="native")
+        await asyncio.wait_for(ticket.sent, timeout=1)
+        arbiter.notify_response_created(
+            {"type": "response.created", "response": {"id": "resp-1"}}
+        )
+        client._current_response_id = "resp-1"
+        client._is_responding = True
+        client._audio_delta_count = 0
+        client._output_transcript_buffer = "never spoken"
+
+        with pytest.raises(asyncio.TimeoutError):
+            await arbiter.cancel_current(timeout=0.05)
+        await _settle()
+
+        assert transcripts == []
+    finally:
+        await arbiter.shutdown("test teardown")
 
 
 @pytest.mark.unit

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -1779,3 +1779,138 @@ async def test_a_user_turn_starting_on_server_vad_advances_the_epoch():
         "and before on_new_message runs, since that is what takes the new "
         "speech id a suspended release must not finalize against"
     )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_queued_request_is_not_a_turn_the_host_should_end(make_harness):
+    # Codex P2, the second route into the same defect. An idle-wait timeout
+    # escalates over a request that is still QUEUED — _current is set, but
+    # nothing of it reached the provider under its own name, so there is no
+    # owner. Meanwhile the host can be tracking a live server-initiated
+    # response, because response.created is what sets its identity and that
+    # event does not care who asked. Treating _current as a released turn
+    # tells the host to finalize that live response.
+    seen: list[tuple[str, str | None]] = []
+
+    async def _record(reason: str, response_id: str | None) -> None:
+        seen.append((reason, response_id))
+
+    harness = make_harness(fail_open=True, on_stuck_release=_record)
+    # A server response holds the lane; the queued request never became an
+    # owner.
+    harness.arbiter.notify_response_created(
+        {"type": "response.created", "response": {"id": "srv-1"}}
+    )
+    ticket = await harness.arbiter.enqueue(source="native")
+    await _settle()
+    assert harness.arbiter._response_owner is None
+    harness.arbiter._current = harness.arbiter._queued_by_ticket.get(id(ticket))
+
+    await harness.arbiter._release_stuck_lifecycle("idle wait timed out")
+    await _settle()
+
+    assert seen == [], (
+        "a queued request is not a turn; ending one would finalize the live "
+        "server response the host is actually tracking"
+    )
+    assert "srv-1" in harness.arbiter._server_response_ids, (
+        "which this release deliberately keeps, because it may still be "
+        "streaming"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_the_release_adds_what_the_turn_said_to_the_repetition_history():
+    # Codex P2. Ending a turn has to record its reply on EVERY path. A
+    # provider that keeps losing response.done — precisely what the hatch
+    # exists for — would otherwise never contribute an audible reply to
+    # _recent_responses, so three identical turns in a row could not trigger
+    # on_repetition_detected at all.
+    client = _free_client()
+    client._current_response_id = "resp-1"
+    client._is_responding = True
+    client._turn_epoch += 1
+    client._current_response_transcript = "一模一样的回答"
+    client._audio_delta_count = 2
+
+    await client._on_arbiter_stuck_release("abandoned resp-1", "resp-1")
+
+    assert client._recent_responses == ["一模一样的回答"], (
+        "the released turn's reply must reach the repetition history"
+    )
+    assert client._last_response_transcript == "一模一样的回答"
+    assert client._current_response_transcript == "", "and be consumed once"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_the_release_repeats_the_terminal_paths_repetition_bookkeeping():
+    # The dual, and the point of contract 3: both paths run the SAME work
+    # because it is the same implementation. Drive three identical turns
+    # through the ordinary terminal path and through releases, and the
+    # detection fires either way.
+    repetitions: list[str] = []
+
+    async def _on_repetition() -> None:
+        repetitions.append("detected")
+
+    client = _free_client(on_repetition_detected=_on_repetition)
+    client._repetition_threshold = 0.5
+
+    for turn in range(3):
+        client._current_response_id = f"resp-{turn}"
+        client._is_responding = True
+        client._turn_epoch += 1
+        client._current_response_transcript = "完全相同的一句话"
+        client._audio_delta_count = 1
+        await client._on_arbiter_stuck_release(f"abandoned resp-{turn}", f"resp-{turn}")
+
+    assert repetitions == ["detected"], (
+        "three released turns saying the same thing must trigger detection, "
+        "exactly as three terminal turns would"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_turn_starting_inside_the_done_hook_still_gets_a_speech_id():
+    # Codex P2. The two hooks are not independent: on_response_done queues
+    # this turn's TTS-done sentinel, which CLOSES its speech id, and
+    # on_sid_rotate is what hands out the next one. Re-checking the epoch
+    # between them let a successor split the pair — old sid closed, no new one
+    # issued — and on a provider without server VAD the successor then speaks
+    # under a closed sid and its text is silently dropped.
+    entered = asyncio.Event()
+    proceed = asyncio.Event()
+    rotations: list[str] = []
+
+    async def _on_done() -> None:
+        entered.set()
+        await proceed.wait()
+
+    async def _on_rotate() -> None:
+        rotations.append("rotate")
+
+    client = _free_client(on_response_done=_on_done, on_sid_rotate=_on_rotate)
+    client._current_response_id = "resp-1"
+    client._is_responding = True
+    client._turn_epoch += 1
+
+    release = asyncio.create_task(
+        client._on_arbiter_stuck_release("abandoned resp-1", "resp-1")
+    )
+    await asyncio.wait_for(entered.wait(), timeout=1)
+
+    # The successor announces itself while the done hook is still running —
+    # after that hook has already closed the old speech id.
+    client._turn_epoch += 1
+
+    proceed.set()
+    await asyncio.wait_for(release, timeout=2)
+
+    assert rotations == ["rotate"], (
+        "the rotation repairs the speech id the done hook just closed; "
+        "skipping it strands the successor on a dead one"
+    )

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -1620,3 +1620,162 @@ async def test_the_release_leaves_the_lane_to_a_successor_that_took_over(make_ha
         {"type": "response.done", "response": {"id": "resp-3"}}
     )
     await asyncio.wait_for(third.done, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_release_with_nothing_to_release_does_not_end_a_host_turn():
+    # Codex P2. cancel_current()'s unowned branch escalates over a server
+    # response the arbiter never owned. It keeps that response's id on purpose
+    # — the response may still be streaming — so telling the host to finalize
+    # discards the turn on one side while the other goes on tracking it, and
+    # the response's own later events are then stale-filtered against an
+    # identity the host no longer holds.
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    done_calls: list[str] = []
+
+    async def _on_done() -> None:
+        done_calls.append("done")
+
+    client = OmniRealtimeClient(
+        "wss://lanlan.app/realtime",
+        "test-key",
+        model="free-model",
+        api_type="free",
+        on_response_done=_on_done,
+    )
+    sent: list[dict] = []
+
+    async def _send(event: dict) -> None:
+        sent.append(event)
+
+    arbiter = client._response_arbiter
+    arbiter._send_event = _send
+    arbiter._fail_open = True
+    try:
+        # A server-initiated response the arbiter never owned, with an id.
+        arbiter.notify_response_created(
+            {"type": "response.created", "response": {"id": "srv-1"}}
+        )
+        client._current_response_id = "srv-1"
+        client._is_responding = True
+        assert arbiter._response_owner is None and arbiter._current is None
+
+        with pytest.raises(asyncio.TimeoutError):
+            await arbiter.cancel_current(timeout=0.05)
+        await _settle()
+
+        assert done_calls == [], (
+            "no lifecycle was released, so no turn ended"
+        )
+        assert client._is_responding is True, (
+            "the server response may still be streaming; the host must keep "
+            "tracking it"
+        )
+        assert client._current_response_id == "srv-1", (
+            "and keep the identity its later events are matched against"
+        )
+        assert "srv-1" in arbiter._server_response_ids, (
+            "the two halves must agree about what is live"
+        )
+    finally:
+        await arbiter.shutdown("test teardown")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_release_that_gave_up_a_lifecycle_still_ends_the_host_turn():
+    # The dual: when there really was a lifecycle, the host still finalizes.
+    # Without this pair, "never notify" would pass for correct.
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    done_calls: list[str] = []
+
+    async def _on_done() -> None:
+        done_calls.append("done")
+
+    client = OmniRealtimeClient(
+        "wss://lanlan.app/realtime",
+        "test-key",
+        model="free-model",
+        api_type="free",
+        on_response_done=_on_done,
+    )
+    sent: list[dict] = []
+
+    async def _send(event: dict) -> None:
+        sent.append(event)
+
+    arbiter = client._response_arbiter
+    arbiter._send_event = _send
+    arbiter._fail_open = True
+    try:
+        ticket = await arbiter.enqueue(source="native")
+        await asyncio.wait_for(ticket.sent, timeout=1)
+        arbiter.notify_response_created(
+            {"type": "response.created", "response": {"id": "resp-1"}}
+        )
+        client._current_response_id = "resp-1"
+        client._is_responding = True
+
+        with pytest.raises(asyncio.TimeoutError):
+            await arbiter.cancel_current(timeout=0.05)
+        await _settle()
+
+        assert done_calls == ["done"]
+        assert client._is_responding is False
+        assert client._current_response_id is None
+    finally:
+        await arbiter.shutdown("test teardown")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_user_turn_starting_on_server_vad_advances_the_epoch():
+    # Codex P2. On a server-VAD provider the user's turn starts at
+    # speech_stopped — on_new_message assigns the new speech id and fires
+    # USER_INPUT right there — and the provider's response.created only
+    # follows later. Advancing the epoch only at response.created leaves that
+    # whole gap open: a release suspended in a host callback resumes, still
+    # believes the turn is its own, and finalizes against the speech id the
+    # user turn just took.
+    import json
+    from unittest.mock import AsyncMock
+
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    rotations: list[int] = []
+
+    async def _on_new_message() -> None:
+        rotations.append(client._turn_epoch)
+
+    client = OmniRealtimeClient(
+        "wss://example.invalid/realtime",
+        "test-key",
+        model="qwen-omni-turbo-realtime",
+        api_type="qwen",
+        on_new_message=_on_new_message,
+    )
+    assert client._has_server_vad is True, (
+        "this case is about the providers that DO emit speech_stopped"
+    )
+    client.ws = AsyncMock()
+    client.ws.__aiter__.return_value = [
+        json.dumps({"type": "input_audio_buffer.speech_stopped"}),
+    ]
+    before = client._turn_epoch
+
+    try:
+        await client.handle_messages()
+    finally:
+        await client._response_arbiter.shutdown("test teardown")
+
+    assert client._turn_epoch == before + 1, (
+        "the user's turn boundary must advance the epoch, not only the "
+        "provider's response.created"
+    )
+    assert rotations == [before + 1], (
+        "and before on_new_message runs, since that is what takes the new "
+        "speech id a suspended release must not finalize against"
+    )

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -50,6 +50,7 @@ findings collapse into five invariants once they are read together.
 """
 
 import asyncio
+import json
 import logging
 
 import pytest
@@ -2617,3 +2618,89 @@ async def test_a_genuinely_different_id_is_still_rejected():
 
     assert done_calls == [], "a different response is not this release's to end"
     assert client._current_response_id == 456
+
+
+class _ScriptedSocket:
+    """Feeds a fixed frame list through the real receive loop, then stops."""
+
+    def __init__(self, frames):
+        self._frames = frames
+        self.sent = []
+
+    async def __aiter__(self):
+        for frame in self._frames:
+            yield json.dumps(frame)
+            await asyncio.sleep(0)
+        # Park instead of ending: a stream that ends fails every in-flight
+        # ticket with ConnectionError, which would drown the assertion under a
+        # harness artifact. The caller bounds this with wait_for.
+        await asyncio.Event().wait()
+
+    async def send(self, *_args, **_kwargs):
+        return None
+
+    async def close(self, *_args, **_kwargs):
+        return None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_an_id_less_tool_call_after_a_release_is_quarantined():
+    # The escape hatch keeps a connection alive after abandoning a turn, and on
+    # a provider whose streaming events carry no response id the abandoned
+    # response's late events cannot be told from the successor's. A leaked
+    # sentence is wrong words; a leaked tool call is a side effect executed for
+    # a turn nobody is having.
+    #
+    # The window is bounded by the next response.created — which such a release
+    # guarantees exists, because a release only happens when the abandoned
+    # response HAD an id and ids come only from that event. So the successor's
+    # own tool calls are never suppressed, and the second half of this test is
+    # what pins that.
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    executed = []
+
+    async def _on_tool_call(call):
+        executed.append(call.name)
+        return {"ok": True}
+
+    client = OmniRealtimeClient(
+        "wss://example.invalid/realtime",
+        "test-key",
+        model="free-model",
+        api_type="free",
+        on_tool_call=_on_tool_call,
+    )
+    client._idless_quarantine = True
+    client._fatal_error_occurred = False
+    client.ws = _ScriptedSocket(
+        [
+            {
+                "type": "response.function_call_arguments.done",
+                "name": "leaked_tool",
+                "arguments": "{}",
+                "call_id": "call-leaked",
+            },
+            {"type": "response.created", "response": {"id": "resp-successor"}},
+            {
+                "type": "response.function_call_arguments.done",
+                "name": "successor_tool",
+                "arguments": "{}",
+                "call_id": "call-successor",
+            },
+        ]
+    )
+    try:
+        await asyncio.wait_for(client.handle_messages(), 2)
+    except (asyncio.TimeoutError, Exception):
+        pass
+    await asyncio.sleep(0.05)
+
+    assert "leaked_tool" not in executed, (
+        "an id-less tool call inside the release window must not execute"
+    )
+    assert "successor_tool" in executed, (
+        "response.created closes the window; the successor's own tools must run"
+    )
+    assert client._idless_quarantine is False

--- a/tests/unit/test_realtime_arbiter_native_path.py
+++ b/tests/unit/test_realtime_arbiter_native_path.py
@@ -355,6 +355,136 @@ async def test_a_terminal_resets_the_per_turn_output_state():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_a_terminal_clears_the_in_progress_flags():
+    # The other half of ending a turn: the flags that say a response is in
+    # flight. Untested before this, same as the per-turn reset was.
+    client = _native_client()
+    socket = _RecordingSocket()
+    client.ws = socket
+    receive_loop = asyncio.create_task(client.handle_messages())
+
+    socket.feed({"type": "response.created", "response": {"id": "resp-1"}})
+    await _settle()
+    assert client._is_responding is True
+    client._current_item_id = "item-1"
+    client._skip_until_next_response = True
+    client._interrupted = True
+
+    socket.feed({"type": "response.done", "response": {"id": "resp-1"}})
+    await _settle()
+
+    assert client._is_responding is False
+    assert client._current_response_id is None
+    assert client._current_item_id is None
+    assert client._skip_until_next_response is False, (
+        "left raised, the next turn's text and audio are suppressed"
+    )
+    assert client._interrupted is False
+
+    socket.finish()
+    await asyncio.wait_for(receive_loop, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_terminal_notifies_the_host_and_rotates_only_without_server_vad():
+    # The host-facing half. Rotation is conditional: routes WITH server VAD
+    # rotate from speech_stopped, so firing here too would be a second,
+    # unpaired rotation on a live turn.
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    async def _build(base: str):
+        done: list[str] = []
+        rotations: list[str] = []
+
+        async def _on_done() -> None:
+            done.append("done")
+
+        async def _on_rotate() -> None:
+            rotations.append("rotate")
+
+        client = OmniRealtimeClient(
+            base,
+            "test-key",
+            model="free-model",
+            api_type="free",
+            on_response_done=_on_done,
+            on_sid_rotate=_on_rotate,
+        )
+        socket = _RecordingSocket()
+        client.ws = socket
+        loop_task = asyncio.create_task(client.handle_messages())
+        socket.feed({"type": "response.created", "response": {"id": "r"}})
+        await _settle()
+        socket.feed({"type": "response.done", "response": {"id": "r"}})
+        await _settle()
+        socket.finish()
+        await asyncio.wait_for(loop_task, timeout=1)
+        return client, done, rotations
+
+    # lanlan.app free is _is_free_proxy and NOT _is_gemini: arbitrated, and
+    # response.done is its only rotation point.
+    proxy, proxy_done, proxy_rotations = await _build(
+        "wss://lanlan.app/api/v1/realtime"
+    )
+    assert proxy._has_server_vad is False
+    assert proxy_done == ["done"]
+    assert proxy_rotations == ["rotate"], (
+        "without this the speech id never advances and TTS upstream drops "
+        "every later turn's text"
+    )
+
+    direct, direct_done, direct_rotations = await _build(
+        "wss://example.invalid/realtime"
+    )
+    assert direct._has_server_vad is True
+    assert direct_done == ["done"]
+    assert direct_rotations == [], (
+        "a server-VAD route already rotates from speech_stopped"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_raising_host_hook_does_not_skip_the_rotation():
+    # The hooks are independent: a host that blows up ending the turn must
+    # not take the speech-id rotation down with it, or the failure silently
+    # mutes every later turn on a no-server-VAD route.
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    rotations: list[str] = []
+
+    async def _on_done() -> None:
+        raise RuntimeError("frontend went away")
+
+    async def _on_rotate() -> None:
+        rotations.append("rotate")
+
+    client = OmniRealtimeClient(
+        "wss://lanlan.app/api/v1/realtime",
+        "test-key",
+        model="free-model",
+        api_type="free",
+        on_response_done=_on_done,
+        on_sid_rotate=_on_rotate,
+    )
+    socket = _RecordingSocket()
+    client.ws = socket
+    receive_loop = asyncio.create_task(client.handle_messages())
+
+    socket.feed({"type": "response.created", "response": {"id": "r"}})
+    await _settle()
+    socket.feed({"type": "response.done", "response": {"id": "r"}})
+    await _settle()
+
+    assert rotations == ["rotate"]
+
+    socket.finish()
+    await asyncio.wait_for(receive_loop, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_a_terminal_rearms_analysis_on_a_non_native_image_provider():
     # The helper has two branches and the case above only exercises one.
     # Standard StepFun is the sole provider without native image input: it

--- a/tests/unit/test_realtime_arbiter_native_path.py
+++ b/tests/unit/test_realtime_arbiter_native_path.py
@@ -446,6 +446,56 @@ async def test_a_terminal_notifies_the_host_and_rotates_only_without_server_vad(
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_a_second_terminal_for_a_finished_turn_does_not_finalize_it_again():
+    # Ending a turn clears _current_response_id, which is what makes a late
+    # terminal for that same response read as stale: the filter forwards it to
+    # the arbiter (so the lane still releases) and drops it otherwise.
+    #
+    # Worth pinning because the temptation runs the other way. handle_
+    # interruption deliberately KEEPS the identity, so the cancelled
+    # response's own terminal still finalizes the turn — the opposite need.
+    # A path that ends a turn early and keeps the identity would let the late
+    # terminal finalize a second time, over whatever turn came next.
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    done_calls: list[str] = []
+
+    async def _on_done() -> None:
+        done_calls.append("done")
+
+    client = OmniRealtimeClient(
+        "wss://example.invalid/realtime",
+        "test-key",
+        model="qwen-omni-turbo-realtime",
+        api_type="qwen",
+        on_response_done=_on_done,
+    )
+    socket = _RecordingSocket()
+    client.ws = socket
+    receive_loop = asyncio.create_task(client.handle_messages())
+
+    socket.feed({"type": "response.created", "response": {"id": "resp-a"}})
+    await _settle()
+    socket.feed({"type": "response.done", "response": {"id": "resp-a"}})
+    await _settle()
+    assert done_calls == ["done"]
+    assert client._current_response_id is None
+
+    # The provider repeats itself, or a buffered duplicate lands late.
+    socket.feed({"type": "response.done", "response": {"id": "resp-a"}})
+    await _settle()
+
+    assert done_calls == ["done"], (
+        "a turn already finalized must not be finalized again by its own "
+        "late terminal"
+    )
+
+    socket.finish()
+    await asyncio.wait_for(receive_loop, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_a_raising_host_hook_does_not_skip_the_rotation():
     # The hooks are independent: a host that blows up ending the turn must
     # not take the speech-id rotation down with it, or the failure silently


### PR DESCRIPTION
## 这是 #2583 的重做

第一版（PR #2592，已关闭）走的是「在 arbiter 释放路径上逐条补齐宿主收尾」的路子。七轮自动评审在那条路径上累计 20 条 P2，**其中两条由前一轮的修复自己引入，一条是把错误契约写进测试并让变异「确认」了它**。经维护者拍板撤回重做。

把那 20 条按**各自维护哪条不变量**重排（清单在 [#2583](https://github.com/Project-N-E-K-O/N.E.K.O/issues/2583)），它们是 5 组，不是 20 个独立缺陷。本 PR 按组设计，不按条打补丁。

## 五个 commit，一组一步

| commit | 组 | 做了什么 |
|---|---|---|
| `a7d1b4488` | **D 并发作用域** | 升级带上调用方观察到的那张 ticket，且至多一次 |
| `becf98f46` | **B 收尾完整性** | 结束一轮成为单一实现（`_clear_turn_response_state` + `_reset_per_turn_output_state` + `_notify_turn_finished`） |
| `d8409fd12` | **A 身份归属** | 钉住「已收尾的一轮不会被自己的迟到 terminal 再收一次」 |
| `de235b55d` | **C 连接可用性** | fail-open 策略：一个问题、一个回答点、四个 blocker |
| `2d8c0393c` | 文档 + 判据第三格 | |

### D 是根，所以先做

第一版的 `_fail_closed` 读的是**当前状态**，而每个调用点等的是**某一张 ticket**。状态共享、ticket 才是作用域 —— 所以并发下第二个 canceller 会把另一条**健康**的生命周期当卡死的拆掉。第一版每补一个状态条件就开一个新面，根在这里。

⚠️ 写这一步的测试时，**契约陈述本身被证伪了一次**：我最初只写「不是 current 就不动」，但两个 canceller 观察的是同一条请求、它确实还是 current，两次升级按那个陈述都合法。fail-closed 下只是噪音，加了 fail-open 就是**双重通知宿主**。契约补成「至多一次」。

### B 消解了 A 的一大半

结束一轮变成单一实现之后，`response.done` 与放弃路径必然做同样的事 —— 「哪条路径漏了哪一项」这个问题不再存在。而清 `_current_response_id` 正是隔离机制：迟到的 terminal 因此落进 stale 分支、只到 arbiter，不再触发第二次收尾。

第一版刻意**保留** id「供归属」—— 那是 `handle_interruption` 的需求（它要让被取消响应自己的 terminal 仍然收尾），不是放弃路径的。方向正好相反。

### C 是一个问题，不是一串布尔量

`_cannot_keep_the_connection()` 回答一句话：**连接还能用、且 arbiter 还分得清谁的事件是谁的吗？** 返回 blocker 描述或 `None`。四个 blocker：消费者悬在传输写里、写刚失败、被放弃的响应无 id 可归属其后续事件、已宣告的 server-VAD 响应尚无 id。

日志因此自解释，也没有一串条件要各处同步。

### 判据修正

「能否归属」的判据是 **`response_send_started`（create 有没有上线）**，不是 `ticket.started`（provider 有没有回应）。**第一版写反了，并用一条通过的测试把它钉死了。**

两者只在一个格子里分歧 —— create 已上线、announcement 未回 —— 而那正是危险格：还没派发的请求不会给任何人惊喜，create 已经出去的才会。三个格子现在各有一条用例。

### 顺序：先通知宿主，后开车道

结束这一轮必须在下一轮能开始之前完成，否则下一轮会被轮换掉 speech id、被收掉共享轮次状态。第一版是反过来的（先开车道再 await 回调），而在调用方 task 上 await 根本不串行化任何东西 —— worker 是另一个 task，只有关着的车道能拦住它。

通知有界（2s），因为 `_process` 内发起的升级会让它跑在唯一消费者身上。

## 评审两轮之后（c353d6161 / c25a7816c）

自动评审在开 PR 后又提了 9 条 P2，**其中 8 条同一个根**，而且那个根是我自己上一轮修 D 组时开的：

「先通知宿主、后开车道」这个顺序把一个 await 塞进了释放路径中间。跨越它，直线代码里不会发生的三件事都会发生 —— 本 task 被取消、被放弃响应的 terminal 落地、worker 醒来接管并装上新 owner。而释放两侧都没有作用域，于是：

| 现象 | 根 |
|---|---|
| 取消发生在通知里 → `escalated` 已置位而 owner 从不清 → 之后每次升级都被当重复吞掉，车道**永久卡死** | 记账不在 `finally` |
| terminal 落地 + worker 装上新 owner → 无条件 `_response_owner = None` **抹掉健康轮次**的归属 | 清的不是自己捕获的那个 |
| 宿主只收到 reason，于是收尾 `_current_response_id` 指的那个 —— owned 与 server-initiated 重叠时那是**另一条还在流的响应** | 身份没随通知传出去 |
| 宿主 `on_output_transcript` 阻塞超过 2s 上限 → 在那个 await 上被取消 → reset 与 notify 都不跑，`_image_sent_this_turn` 漏进下一轮 | 同步写排在 await 之后 |

所以是**一处结构改动**，不是四个补丁：释放先捕获 owner 与其 id，把 id 交给宿主，记账放进 `finally`，且只清自己观察到的那个 owner；宿主侧把所有同步写挪到第一个 await 之前（`_take_pending_output_transcript` 定夺并落定，emit 只负责发）。

第 9 条是 A 组我漏枚举的一个状态：**无人认领、且完全没有 id** 的 `response.created`。没有 owner 可查、没有记住的 id、没有 VAD 标记 —— 四个 blocker 全部放行，车道就开在一条可能还在流的响应上，而它同样 id-less 的 terminal 会去收掉那时持有车道的任何一轮。补成第五个 blocker。

## 第 5 轮：三条同一个根，一条驳回（cd59f4224 / 962ca5bc8）

自动评审又提了 5 条 P2。其中三条是同一个缺陷换了三件衣服：**释放的收尾工作会落到一个不是它捕获时那一轮的轮次上。**

| 现象 | 机制 |
|---|---|
| 被 id-less `response.created` 覆盖后，重叠的**活着的**响应被当成已放弃那条收尾（半句单独 flush、audio 计数清零、它自己的 terminal 到达时再收一次） | 守卫把 `_current_response_id is None` 当成「匹配任何 id」 |
| 车道在通知期间被真 terminal 打开 → 后继派发 → 死掉那轮的 `on_sid_rotate` 把**活着的**轮次的 speech id 丢掉（无 server VAD 的 provider 上，此后 TTS 整条连接都不出字） | 身份没有跨越 await 存活 |
| 宿主在 `on_output_transcript` 里阻塞**或抛异常**、或在 `on_response_done` 里阻塞 → 吃掉 arbiter 那 2s 共享预算 → 后面的 rotation 就地被取消 | 一个易碎步骤能拖垮它后面的所有步骤 |

**改法是一个不变量，不是三个补丁**：`_turn_epoch` 由每个**开始**一轮的写点递增（两处，都紧贴 `_is_responding = True`；测试**自动发现**这些写点而不是列清单），释放前捕获、每个 hook 前重查；两个易碎步骤各自设界。

⚠️ **rotation 刻意不设界**。`rotate_speech_id_for_response_done` 先清 `_tts_done_queued_for_turn` / `_tts_done_pending_until_ready`，**然后**才 `async with self.lock` —— 在锁上被取消 = flags 说新一轮、sid 还是旧的，半旋转不可恢复；漏一次 rotation 下一轮 terminal 会补。宁可漏，不可半做。

### 为什么不做「车道屏障」（评审建议的那个修法）

看起来显然该在 arbiter 侧加个屏障，把车道在整个释放期间关着。不做，三条理由：

1. **它挡不住真正的来源。** 用户自己的轮次从 `handle_new_message` 起，那条路径**从不查询车道**。实测 `fail_open=False`、零 escalation 时同样复现。
2. **它的失败态比断线更糟。** 一个会 latch 的车道标志，在最自然的实现变体下会产生**永久且跨重连存活**的车道关闭 —— 而这个开关存在的意义就是替代断线。
3. **它要花掉一条既有测试**，并把另一条降格成同义反复。

所以契约 4 从「宿主先被通知、车道后开」重述为「**身份，不是顺序**」。零 arbiter 改动。

### 驳回的两条

- **退休孤儿 server response id**（让车道立刻重开）。它和本 PR 自己的护栏测试 `test_the_release_keeps_the_lane_closed_under_a_live_server_response`（为 Greptile 的 P1 加的）直接对立。实测：退休之后下一条 create 压在还活着的响应上（dispatch 1→2），provider 的 `response_already_active` 落在 `ticket.done` 上，而用户 ASR 轮只 `await ticket.sent`（`submit_external_voice_turn` 连 ticket 都丢弃）→ **静默丢轮**。而且「卡 60s」的前提也不准：实测 terminal 4s 到达时车道同 tick 就开，60s 是天花板不是等待时长。**只接受其中日志名不副实那半**（962ca5bc8）。
- **在释放里退休滞留的 cancel-send**。`_wait_for_idle_or_interrupt` 那条 escalation 路线上释放**自己一条 cancel 都没发过**，退休掉就是拿走被放弃响应唯一收到的那条 `response.cancel`，反而给后继铺好 `response_already_active`。现有测试零覆盖，回归会静默落地。

## 验证

- **9379 passed / 28 skipped**（unit 全量，`16ba4d99` 后；唯一的红是长期环境性的 `test_runtime_memory_soak`，与本 PR 无关）。默认路径**行为等价**——见下方回归报告里列明的两处刻意改动
- **43 条变异，43/43 捕捉**（本轮 10 + 上轮 3 + 此前 30），每条都成对

⚠️ 变异过程中又抓到两处**我自己的**问题：R7（判据换成 `ticket.started` 竟然不红 → 说明测试没能区分两个判据，已补第三格用例）；以及两条 stand-down 用例原本用 started 超时驱动，而**那条路径按定义永远 id-less**，所以只能走 stand-down、测不到对偶 —— 改用 done 超时驱动。

⚠️ 本轮变异又抓到一条**断言弱于主张**：`test_an_undisturbed_release_still_clears_its_own_owner` 在「释放自己那句清 owner 被删掉」时**依然绿** —— 因为 `_process` 退栈时自己也会清 owner，断言实际观察的是 worker 而不是释放。改成先让 worker 退干净、再手工把同一个 owner 装回去，这才只剩释放能清它。

## 回归报告

- **改动面**：生产 4 文件（`_response_arbiter.py`、`_transport.py`、`_client.py`、`_responses.py`、`_shared.py`）+ 文档 1 + 测试 3。默认行为不变，含 `response arbiter failing closed` 这条 #2561 定的断线归因 grep 目标。
- **必要性**：正式包 / nightly / docker latest 三条渠道尚未包含 arbiter，下次发版是存量用户一次性全量首曝；届时若出现 provider 事件时序问题，没有服务端开关可以够到那批用户。
- **改前/改后**：不设环境变量时**行为等价，但不是逐字节不变**——第 7 轮复审逐行比对 merge-base 后确认默认路径有两处刻意改动，都是改进且都有默认模式测试钉住：(1) 回合结束的宿主回调异常由裸 await 改为记 warning 后吞掉（旧路径抛出后走 `_close_failed_transport` 并 raise，从不调 `on_connection_error`，前端本来就收不到任何东西；且 Gemini 路径改前就已经吞了）；(2) 迟到 terminal 的 stale 分支现在照常记 token usage 并 bump `_response_done_total`，由 `_usage_recorded_ids` 保证 exactly-once。设了环境变量之后，能安全保住连接时只丢这一轮；五个 blocker 任一成立仍照常拆连接并说明原因。
- **潜在回归**：策略只有一个回答点、由 43 条变异守住；`_escalate` 的作用域化对健康路径是 no-op（unit 全量 9335 条全绿）；宿主收尾复用终端路径同一实现，两侧都有变异守住。
- **不在范围**：#2594（抑制标志缺轮次归属、迟到 created 归属规则两个洞）、#2595（cancel-send 归属），以及第 5 轮核查中新发现的三条 —— 全部在 `fail_open=False` 默认 arbiter、零 escalation 下复现过，与本开关正交，单独开 issue。

## 第 7 轮：6 维对抗复审 + 四条残留（`16ba4d99` / `cf3733d3`）

对 `ef5263e0` 做了一次 26 个 agent、6 个维度的复审（并发身份 / blocker 判据 / 收尾完整性 / 默认路径零回归 / 测试诚实性 / 集成）。每条 finding 由两个不同视角的 agent 先证伪，证伪靠实跑——30+ 处源码变异逐一跑完全部用例再还原，多个探针测试驱动真实 `handle_messages` 接收循环。

**10 条 finding，0 条在双证伪下存活。** 但证伪本身立住了四件该做的事，都不改变 arbiter 的行为：

| # | 残留 | 处置 |
|---|---|---|
| 1 | `_notify_turn_finished` 的 TimeoutError 分支用 `%.1f` 格式化 `step_timeout`，而终端路径传的是 `None` | 改 `%s`。今天不可达（要宿主自己抛 TimeoutError），但真触发时格式化异常会毁掉这条分支唯一的产出 |
| 2 | `test_a_request_whose_create_never_went_out_still_fails_open` **自称**是防 #2592 反向判据的那条钉子，其实不是 | 它构造的请求既不是 `_current` 也不是 `_response_owner`，blocker 在 `owner is not None` 就短路，换成错误判据它一样绿。改成说实话：它的职责是对偶（证明 blocker 不是「永远触发」），并指向真正做区分的那条 |
| 3 | 「所有同步写排在第一个 await 之前」**完全没被钉住** | 把整个 per-turn reset 挪到第一个 await 之后，108/108 全绿。既有那条取消测试阻塞在 `on_output_transcript`（第二个 hook）。新增一条阻塞在重复检测 hook（第一个），对该变异会红 |
| 4 | Gemini 的 turn-start epoch 自增在生产中无人读 | 保留 + 注明。不变量是「每个 turn start 都推进 epoch」，不是「每个当前有人读的 turn start」。顺带记下注释为什么必须写在赋值上方——那条发现式测试按邻近性找 turn start |

另加：`_report_wait_margin` 把每个有界等待花掉的比例记下来（超过一半就出一行）。这些 fail-close 阈值全部是在没有现场数据的情况下定的，而一个阈值太紧的唯一证据就是「已经拆过一次连接了」；包一层不碰控制流，让日常使用自己产出分布，不用专门做实验。

`scripts/realtime_arbiter_probe.py` 是同一件事的另一半：驱动真实 `OmniRealtimeClient` 打免费路由，把观测到的 p50/p95/max 直接对着阈值列表报，另外回答三个只有 provider 能回答的问题——terminal 丢失率、流式事件带不带 `response_id`（#2611 那格）、无活跃响应时 cancel 回什么。已用本地打桩（注入已知延迟）端到端验证，能完整复现并**报告**拆连接链路而不是死在上面。

## 相关

- #2583（本 issue，含 20 条评审归成 5 组的设计输入）
- #2592（已关闭的第一版，15 条 thread 是本次设计的输入）
- #2601（per-turn 清理抽取，已合并，本 PR 在其之上）
- #2594 / #2595（既有缺陷，正交）

🤖 Generated with [Claude Code](https://claude.com/claude-code)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增实时语音会话的“故障开放”配置，可在部分响应卡住时结束当前回合并保持连接。
  - 支持通过环境变量启用该行为，并提供适用场景、日志及限制说明。

- **问题修复**
  - 改善响应超时、重复结束事件、转录收尾和回合切换处理。
  - 避免重复记录同一响应的用量，并提升重连后的后续请求恢复能力。

- **测试**
  - 新增实时响应故障恢复、连接保留、回合隔离及重复事件处理的回归测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
