### PR TITLE
fix(tutorial): preserve Niri spotlight layout coordinates

### DIFF
--- a/static/app/app-interpage/guide-overlay.js
+++ b/static/app/app-interpage/guide-overlay.js
@@ -524,6 +524,13 @@
             metrics
             && metrics.coordinateSpace === 'screen-dip'
             && metrics.renderBounds
+            && (
+                metrics.renderBoundsCoordinateSpace === 'screen-dip'
+                || (
+                    metrics.niriPetPhysicalCrop === true
+                    && metrics.originSource === 'niri-pet-physical-crop-virtual-bounds'
+                )
+            )
         ) {
             return metrics.renderBounds;
         }

--- a/static/app/app-interpage/guide-overlay.js
+++ b/static/app/app-interpage/guide-overlay.js
@@ -583,7 +583,11 @@
             if (!api || typeof api !== 'object') {
                 return null;
             }
-            if (typeof api.isActive === 'function' && !api.isActive()) {
+            if (
+                typeof api.isActive === 'function'
+                && !api.isActive()
+                && typeof api.getLayoutState !== 'function'
+            ) {
                 return null;
             }
             return api;
@@ -618,8 +622,14 @@
                 metrics.niriPetPhysicalCropBounds || metrics.contentBounds || metrics.bounds
             );
             var metricVirtualBounds = normalizeYuiGuideNiriPetPhysicalCropBounds(metrics.niriPetPhysicalCropVirtualBounds);
-            var metricOffsetX = Number(metrics.niriPetPhysicalCropOffsetX);
-            var metricOffsetY = Number(metrics.niriPetPhysicalCropOffsetY);
+            var metricLayoutOffsetX = Number(metrics.niriPetPhysicalCropLayoutOffsetX);
+            var metricLayoutOffsetY = Number(metrics.niriPetPhysicalCropLayoutOffsetY);
+            var metricOffsetX = Number.isFinite(metricLayoutOffsetX)
+                ? metricLayoutOffsetX
+                : Number(metrics.niriPetPhysicalCropOffsetX);
+            var metricOffsetY = Number.isFinite(metricLayoutOffsetY)
+                ? metricLayoutOffsetY
+                : Number(metrics.niriPetPhysicalCropOffsetY);
             return metricCropBounds ? {
                 cropBounds: metricCropBounds,
                 virtualBounds: metricVirtualBounds,
@@ -634,10 +644,11 @@
             if (!api || typeof api !== 'object') {
                 return null;
             }
-            if (typeof api.isActive === 'function' && !api.isActive()) {
+            var layoutState = typeof api.getLayoutState === 'function' ? api.getLayoutState() : null;
+            var state = layoutState || (typeof api.getState === 'function' ? api.getState() : null);
+            if (!state && typeof api.isActive === 'function' && !api.isActive()) {
                 return null;
             }
-            var state = typeof api.getState === 'function' ? api.getState() : null;
             var cropBounds = normalizeYuiGuideNiriPetPhysicalCropBounds(state && state.cropBounds);
             var virtualBounds = normalizeYuiGuideNiriPetPhysicalCropBounds(state && state.virtualBounds);
             if (!cropBounds) {
@@ -664,11 +675,16 @@
 
     function toYuiGuideNiriPetPhysicalCropVirtualPoint(x, y) {
         var api = getYuiGuideNiriPetPhysicalCropApi();
-        if (!api || typeof api.toVirtualPoint !== 'function') {
+        var converter = api && (
+            typeof api.toLayoutVirtualPoint === 'function'
+                ? api.toLayoutVirtualPoint
+                : api.toVirtualPoint
+        );
+        if (typeof converter !== 'function') {
             return null;
         }
         try {
-            return normalizeYuiGuideNiriPetPhysicalCropPoint(api.toVirtualPoint({
+            return normalizeYuiGuideNiriPetPhysicalCropPoint(converter.call(api, {
                 x: Number(x || 0),
                 y: Number(y || 0)
             }));
@@ -679,11 +695,16 @@
 
     function toYuiGuideNiriPetPhysicalCropVirtualRect(rect) {
         var api = getYuiGuideNiriPetPhysicalCropApi();
-        if (!api || typeof api.toVirtualRect !== 'function') {
+        var converter = api && (
+            typeof api.toLayoutVirtualRect === 'function'
+                ? api.toLayoutVirtualRect
+                : api.toVirtualRect
+        );
+        if (typeof converter !== 'function') {
             return null;
         }
         try {
-            var virtualRect = normalizeYuiGuideNiriPetPhysicalCropRect(api.toVirtualRect({
+            var virtualRect = normalizeYuiGuideNiriPetPhysicalCropRect(converter.call(api, {
                 x: Number(rect.left || 0),
                 y: Number(rect.top || 0),
                 width: Number(rect.width || 0),
@@ -701,30 +722,37 @@
     }
 
     function toYuiGuideNiriPetPhysicalCropVirtualPointWithState(x, y, cropState) {
-        if (cropState && cropState.metricsVirtualized) {
+        // Virtualized window metrics describe the overlay window bounds. DOM
+        // client coordinates still live in the physically cropped layout and
+        // must always cross the crop offset exactly once. Prefer this captured
+        // state over a second live API read so prepare/commit generations
+        // cannot be mixed inside one conversion.
+        if (cropState) {
             return {
-                x: Number(x || 0),
-                y: Number(y || 0)
+                x: Number(x || 0) + Number(cropState.offsetX || 0),
+                y: Number(y || 0) + Number(cropState.offsetY || 0)
             };
         }
         return toYuiGuideNiriPetPhysicalCropVirtualPoint(x, y) || {
-            x: Number(x || 0) + Number(cropState && cropState.offsetX || 0),
-            y: Number(y || 0) + Number(cropState && cropState.offsetY || 0)
+            x: Number(x || 0),
+            y: Number(y || 0)
         };
     }
 
     function toYuiGuideNiriPetPhysicalCropVirtualRectWithState(rect, cropState) {
-        if (cropState && cropState.metricsVirtualized) {
+        // getBoundingClientRect() is crop-local even when renderer metrics
+        // already expose virtual desktop bounds.
+        if (cropState) {
             return {
-                left: Number(rect.left || 0),
-                top: Number(rect.top || 0),
+                left: Number(rect.left || 0) + Number(cropState.offsetX || 0),
+                top: Number(rect.top || 0) + Number(cropState.offsetY || 0),
                 width: rect.width,
                 height: rect.height
             };
         }
         return toYuiGuideNiriPetPhysicalCropVirtualRect(rect) || {
-            left: Number(rect.left || 0) + Number(cropState && cropState.offsetX || 0),
-            top: Number(rect.top || 0) + Number(cropState && cropState.offsetY || 0),
+            left: Number(rect.left || 0),
+            top: Number(rect.top || 0),
             width: rect.width,
             height: rect.height
         };

--- a/static/app/app-interpage/guide-targets.js
+++ b/static/app/app-interpage/guide-targets.js
@@ -61,13 +61,8 @@
         return entry && entry.shape ? entry.shape : 'rounded-rect';
     }
 
-    function shouldAlignYuiGuideChatSpotlightToCapsuleText(kind, variant, metrics) {
-        if (kind === 'input' && variant === 'plain-capsule') {
-            return true;
-        }
-        return kind === 'capsule-input'
-            && !!metrics
-            && metrics.waylandWorkAreaCarrier === true;
+    function shouldAlignYuiGuideChatSpotlightToCapsuleText(kind, variant) {
+        return kind === 'input' && variant === 'plain-capsule';
     }
 
     var YUI_GUIDE_CHAT_CAPSULE_TEXT_ALIGNMENT_RATIO = 0.6;
@@ -127,14 +122,14 @@
         };
     }
 
-    function getYuiGuideChatSpotlightSourceRect(kind, variant, rect, metrics) {
+    function getYuiGuideChatSpotlightSourceRect(kind, variant, rect) {
         var sourceRect = {
             left: rect.left,
             top: rect.top,
             width: rect.width,
             height: rect.height
         };
-        if (shouldAlignYuiGuideChatSpotlightToCapsuleText(kind, variant, metrics)) {
+        if (shouldAlignYuiGuideChatSpotlightToCapsuleText(kind, variant)) {
             var anchor = getYuiGuideChatCapsuleTextAnchor();
             var anchorRect = anchor && anchor.rect;
             if (
@@ -649,7 +644,7 @@
             ? target.getBoundingClientRect()
             : null;
         var sourceRectInfo = rect
-            ? getYuiGuideChatSpotlightSourceRect(kind, I.yuiGuideChatSpotlightVariant, rect, pcWindowMetrics)
+            ? getYuiGuideChatSpotlightSourceRect(kind, I.yuiGuideChatSpotlightVariant, rect)
             : null;
         var sourceRect = sourceRectInfo ? sourceRectInfo.rect : rect;
 

--- a/static/app/app-interpage/guide-targets.js
+++ b/static/app/app-interpage/guide-targets.js
@@ -61,8 +61,14 @@
         return entry && entry.shape ? entry.shape : 'rounded-rect';
     }
 
-    function shouldAlignYuiGuideChatSpotlightToCapsuleText(kind, variant) {
-        return kind === 'input' && variant === 'plain-capsule';
+    function shouldAlignYuiGuideChatSpotlightToCapsuleText(kind, variant, metrics) {
+        if (kind === 'input' && variant === 'plain-capsule') {
+            return true;
+        }
+        return kind === 'capsule-input'
+            && !!metrics
+            && metrics.waylandWorkAreaCarrier === true
+            && metrics.niriWaylandRuntime !== true;
     }
 
     var YUI_GUIDE_CHAT_CAPSULE_TEXT_ALIGNMENT_RATIO = 0.6;
@@ -122,14 +128,14 @@
         };
     }
 
-    function getYuiGuideChatSpotlightSourceRect(kind, variant, rect) {
+    function getYuiGuideChatSpotlightSourceRect(kind, variant, rect, metrics) {
         var sourceRect = {
             left: rect.left,
             top: rect.top,
             width: rect.width,
             height: rect.height
         };
-        if (shouldAlignYuiGuideChatSpotlightToCapsuleText(kind, variant)) {
+        if (shouldAlignYuiGuideChatSpotlightToCapsuleText(kind, variant, metrics)) {
             var anchor = getYuiGuideChatCapsuleTextAnchor();
             var anchorRect = anchor && anchor.rect;
             if (
@@ -644,7 +650,7 @@
             ? target.getBoundingClientRect()
             : null;
         var sourceRectInfo = rect
-            ? getYuiGuideChatSpotlightSourceRect(kind, I.yuiGuideChatSpotlightVariant, rect)
+            ? getYuiGuideChatSpotlightSourceRect(kind, I.yuiGuideChatSpotlightVariant, rect, pcWindowMetrics)
             : null;
         var sourceRect = sourceRectInfo ? sourceRectInfo.rect : rect;
 

--- a/static/tutorial/yui-guide/director/director-core.js
+++ b/static/tutorial/yui-guide/director/director-core.js
@@ -2260,7 +2260,11 @@
                 if (!api || typeof api !== 'object') {
                     return null;
                 }
-                if (typeof api.isActive === 'function' && !api.isActive()) {
+                if (
+                    typeof api.isActive === 'function'
+                    && !api.isActive()
+                    && typeof api.getLayoutState !== 'function'
+                ) {
                     return null;
                 }
                 return api;
@@ -2295,8 +2299,14 @@
                     metrics.niriPetPhysicalCropBounds || metrics.contentBounds || metrics.bounds
                 );
                 const virtualBounds = this.normalizeNiriPetPhysicalCropBounds(metrics.niriPetPhysicalCropVirtualBounds);
-                const offsetX = Number(metrics.niriPetPhysicalCropOffsetX);
-                const offsetY = Number(metrics.niriPetPhysicalCropOffsetY);
+                const layoutOffsetX = Number(metrics.niriPetPhysicalCropLayoutOffsetX);
+                const layoutOffsetY = Number(metrics.niriPetPhysicalCropLayoutOffsetY);
+                const offsetX = Number.isFinite(layoutOffsetX)
+                    ? layoutOffsetX
+                    : Number(metrics.niriPetPhysicalCropOffsetX);
+                const offsetY = Number.isFinite(layoutOffsetY)
+                    ? layoutOffsetY
+                    : Number(metrics.niriPetPhysicalCropOffsetY);
                 return cropBounds ? {
                     cropBounds,
                     virtualBounds,
@@ -2311,10 +2321,11 @@
                 if (!api || typeof api !== 'object') {
                     return null;
                 }
-                if (typeof api.isActive === 'function' && !api.isActive()) {
+                const layoutState = typeof api.getLayoutState === 'function' ? api.getLayoutState() : null;
+                const state = layoutState || (typeof api.getState === 'function' ? api.getState() : null);
+                if (!state && typeof api.isActive === 'function' && !api.isActive()) {
                     return null;
                 }
-                const state = typeof api.getState === 'function' ? api.getState() : null;
                 const cropBounds = this.normalizeNiriPetPhysicalCropBounds(state && state.cropBounds);
                 const virtualBounds = this.normalizeNiriPetPhysicalCropBounds(state && state.virtualBounds);
                 if (!cropBounds) {
@@ -2341,11 +2352,16 @@
 
         toNiriPetPhysicalCropVirtualPoint(point) {
             const api = this.getNiriPetPhysicalCropApi();
-            if (!api || typeof api.toVirtualPoint !== 'function') {
+            const converter = api && (
+                typeof api.toLayoutVirtualPoint === 'function'
+                    ? api.toLayoutVirtualPoint
+                    : api.toVirtualPoint
+            );
+            if (typeof converter !== 'function') {
                 return null;
             }
             try {
-                return this.normalizeNiriPetPhysicalCropPoint(api.toVirtualPoint(point));
+                return this.normalizeNiriPetPhysicalCropPoint(converter.call(api, point));
             } catch (_) {
                 return null;
             }
@@ -2353,39 +2369,49 @@
 
         toNiriPetPhysicalCropLocalPoint(point) {
             const api = this.getNiriPetPhysicalCropApi();
-            if (!api || typeof api.toLocalPoint !== 'function') {
+            const converter = api && (
+                typeof api.toLayoutLocalPoint === 'function'
+                    ? api.toLayoutLocalPoint
+                    : api.toLocalPoint
+            );
+            if (typeof converter !== 'function') {
                 return null;
             }
             try {
-                return this.normalizeNiriPetPhysicalCropPoint(api.toLocalPoint(point));
+                return this.normalizeNiriPetPhysicalCropPoint(converter.call(api, point));
             } catch (_) {
                 return null;
             }
         }
 
         toNiriPetPhysicalCropVirtualPointWithState(point, cropState) {
-            if (cropState && cropState.metricsVirtualized) {
+            // Window metrics can already be virtual while the DOM point is
+            // still crop-local. Use the captured state so a live API read
+            // cannot switch coordinate generations midway through this call.
+            if (cropState) {
                 return {
-                    x: Number(point && point.x || 0),
-                    y: Number(point && point.y || 0)
+                    x: Number(point && point.x || 0) + Number(cropState.offsetX || 0),
+                    y: Number(point && point.y || 0) + Number(cropState.offsetY || 0)
                 };
             }
             return this.toNiriPetPhysicalCropVirtualPoint(point) || {
-                x: Number(point && point.x || 0) + Number(cropState && cropState.offsetX || 0),
-                y: Number(point && point.y || 0) + Number(cropState && cropState.offsetY || 0)
+                x: Number(point && point.x || 0),
+                y: Number(point && point.y || 0)
             };
         }
 
         toNiriPetPhysicalCropLocalPointWithState(point, cropState) {
-            if (cropState && cropState.metricsVirtualized) {
+            // Reverse the same DOM-layout transform when restoring a screen
+            // point to renderer-local coordinates.
+            if (cropState) {
                 return {
-                    x: Number(point && point.x || 0),
-                    y: Number(point && point.y || 0)
+                    x: Number(point && point.x || 0) - Number(cropState.offsetX || 0),
+                    y: Number(point && point.y || 0) - Number(cropState.offsetY || 0)
                 };
             }
             return this.toNiriPetPhysicalCropLocalPoint(point) || {
-                x: Number(point && point.x || 0) - Number(cropState && cropState.offsetX || 0),
-                y: Number(point && point.y || 0) - Number(cropState && cropState.offsetY || 0)
+                x: Number(point && point.x || 0),
+                y: Number(point && point.y || 0)
             };
         }
 
@@ -2401,6 +2427,13 @@
         }
 
         getGuideScreenCoordinateBounds(metrics) {
+            if (
+                metrics
+                && metrics.coordinateSpace === 'screen-dip'
+                && metrics.renderBounds
+            ) {
+                return metrics.renderBounds;
+            }
             return metrics && (metrics.bounds || metrics.contentBounds) || null;
         }
 

--- a/static/tutorial/yui-guide/director/director-core.js
+++ b/static/tutorial/yui-guide/director/director-core.js
@@ -2431,6 +2431,13 @@
                 metrics
                 && metrics.coordinateSpace === 'screen-dip'
                 && metrics.renderBounds
+                && (
+                    metrics.renderBoundsCoordinateSpace === 'screen-dip'
+                    || (
+                        metrics.niriPetPhysicalCrop === true
+                        && metrics.originSource === 'niri-pet-physical-crop-virtual-bounds'
+                    )
+                )
             ) {
                 return metrics.renderBounds;
             }

--- a/static/tutorial/yui-guide/overlay.js
+++ b/static/tutorial/yui-guide/overlay.js
@@ -305,6 +305,13 @@
             metrics
             && metrics.coordinateSpace === 'screen-dip'
             && metrics.renderBounds
+            && (
+                metrics.renderBoundsCoordinateSpace === 'screen-dip'
+                || (
+                    metrics.niriPetPhysicalCrop === true
+                    && metrics.originSource === 'niri-pet-physical-crop-virtual-bounds'
+                )
+            )
                 ? metrics.renderBounds
                 : metrics && (metrics.bounds || metrics.contentBounds) || { x: 0, y: 0 }
         );

--- a/static/tutorial/yui-guide/overlay.js
+++ b/static/tutorial/yui-guide/overlay.js
@@ -302,7 +302,11 @@
             };
         };
         const getScreenCoordinateBounds = (metrics) => (
-            metrics && (metrics.bounds || metrics.contentBounds) || { x: 0, y: 0 }
+            metrics
+            && metrics.coordinateSpace === 'screen-dip'
+            && metrics.renderBounds
+                ? metrics.renderBounds
+                : metrics && (metrics.bounds || metrics.contentBounds) || { x: 0, y: 0 }
         );
 
         const normalizeNiriPetPhysicalCropBounds = (bounds) => {
@@ -350,7 +354,11 @@
                 if (!api || typeof api !== 'object') {
                     return null;
                 }
-                if (typeof api.isActive === 'function' && !api.isActive()) {
+                if (
+                    typeof api.isActive === 'function'
+                    && !api.isActive()
+                    && typeof api.getLayoutState !== 'function'
+                ) {
                     return null;
                 }
                 return api;
@@ -385,8 +393,14 @@
                     metrics.niriPetPhysicalCropBounds || metrics.contentBounds || metrics.bounds
                 );
                 const metricVirtualBounds = normalizeNiriPetPhysicalCropBounds(metrics.niriPetPhysicalCropVirtualBounds);
-                const metricOffsetX = Number(metrics.niriPetPhysicalCropOffsetX);
-                const metricOffsetY = Number(metrics.niriPetPhysicalCropOffsetY);
+                const metricLayoutOffsetX = Number(metrics.niriPetPhysicalCropLayoutOffsetX);
+                const metricLayoutOffsetY = Number(metrics.niriPetPhysicalCropLayoutOffsetY);
+                const metricOffsetX = Number.isFinite(metricLayoutOffsetX)
+                    ? metricLayoutOffsetX
+                    : Number(metrics.niriPetPhysicalCropOffsetX);
+                const metricOffsetY = Number.isFinite(metricLayoutOffsetY)
+                    ? metricLayoutOffsetY
+                    : Number(metrics.niriPetPhysicalCropOffsetY);
                 return metricCropBounds ? {
                     cropBounds: metricCropBounds,
                     virtualBounds: metricVirtualBounds,
@@ -401,10 +415,11 @@
                 if (!api || typeof api !== 'object') {
                     return null;
                 }
-                if (typeof api.isActive === 'function' && !api.isActive()) {
+                const layoutState = typeof api.getLayoutState === 'function' ? api.getLayoutState() : null;
+                const state = layoutState || (typeof api.getState === 'function' ? api.getState() : null);
+                if (!state && typeof api.isActive === 'function' && !api.isActive()) {
                     return null;
                 }
-                const state = typeof api.getState === 'function' ? api.getState() : null;
                 const cropBounds = normalizeNiriPetPhysicalCropBounds(state && state.cropBounds);
                 const virtualBounds = normalizeNiriPetPhysicalCropBounds(state && state.virtualBounds);
                 if (!cropBounds) {
@@ -430,11 +445,16 @@
         };
         const toNiriPetPhysicalCropVirtualPoint = (x, y) => {
             const api = getNiriPetPhysicalCropApi();
-            if (!api || typeof api.toVirtualPoint !== 'function') {
+            const converter = api && (
+                typeof api.toLayoutVirtualPoint === 'function'
+                    ? api.toLayoutVirtualPoint
+                    : api.toVirtualPoint
+            );
+            if (typeof converter !== 'function') {
                 return null;
             }
             try {
-                return normalizeNiriPetPhysicalCropPoint(api.toVirtualPoint({
+                return normalizeNiriPetPhysicalCropPoint(converter.call(api, {
                     x: Number(x || 0),
                     y: Number(y || 0)
                 }));
@@ -444,11 +464,16 @@
         };
         const toNiriPetPhysicalCropVirtualRect = (rect) => {
             const api = getNiriPetPhysicalCropApi();
-            if (!api || typeof api.toVirtualRect !== 'function') {
+            const converter = api && (
+                typeof api.toLayoutVirtualRect === 'function'
+                    ? api.toLayoutVirtualRect
+                    : api.toVirtualRect
+            );
+            if (typeof converter !== 'function') {
                 return null;
             }
             try {
-                const virtualRect = normalizeNiriPetPhysicalCropRect(api.toVirtualRect({
+                const virtualRect = normalizeNiriPetPhysicalCropRect(converter.call(api, {
                     x: Number(rect.left || 0),
                     y: Number(rect.top || 0),
                     width: Number(rect.width || 0),
@@ -465,25 +490,27 @@
             }
         };
         const toNiriPetPhysicalCropVirtualPointWithState = (x, y, cropState) => (
-            cropState && cropState.metricsVirtualized ? {
+            // Virtualized metrics apply to window bounds, not DOM client points.
+            // Use one captured state throughout a conversion to avoid mixing
+            // physical-crop prepare and commit generations.
+            cropState ? {
+                x: Number(x || 0) + Number(cropState.offsetX || 0),
+                y: Number(y || 0) + Number(cropState.offsetY || 0)
+            } : toNiriPetPhysicalCropVirtualPoint(x, y) || {
                 x: Number(x || 0),
                 y: Number(y || 0)
-            } :
-            toNiriPetPhysicalCropVirtualPoint(x, y) || {
-                x: Number(x || 0) + Number(cropState && cropState.offsetX || 0),
-                y: Number(y || 0) + Number(cropState && cropState.offsetY || 0)
             }
         );
         const toNiriPetPhysicalCropVirtualRectWithState = (rect, cropState) => (
-            cropState && cropState.metricsVirtualized ? {
-                left: Number(rect.left || 0),
-                top: Number(rect.top || 0),
+            // getBoundingClientRect() remains crop-local under physical crop.
+            cropState ? {
+                left: Number(rect.left || 0) + Number(cropState.offsetX || 0),
+                top: Number(rect.top || 0) + Number(cropState.offsetY || 0),
                 width: rect.width,
                 height: rect.height
-            } :
-            toNiriPetPhysicalCropVirtualRect(rect) || {
-                left: Number(rect.left || 0) + Number(cropState && cropState.offsetX || 0),
-                top: Number(rect.top || 0) + Number(cropState && cropState.offsetY || 0),
+            } : toNiriPetPhysicalCropVirtualRect(rect) || {
+                left: Number(rect.left || 0),
+                top: Number(rect.top || 0),
                 width: rect.width,
                 height: rect.height
             }

--- a/static/yui-guide-common.test.cjs
+++ b/static/yui-guide-common.test.cjs
@@ -1258,18 +1258,19 @@ test('interpage consumes common tutorial geometry before chat bridge scripts run
     assert.match(appInterpageSource, /getYuiGuideChatTargetShape\(kind\)/);
     assert.match(appInterpageSource, /getYuiGuideChatTargetShape\(kind\) === 'circle'/);
     const shouldAlignFunctionStart = appInterpageSource.indexOf(
-        'function shouldAlignYuiGuideChatSpotlightToCapsuleText(kind, variant, metrics)'
+        'function shouldAlignYuiGuideChatSpotlightToCapsuleText(kind, variant)'
     );
     const sourceRectFunctionStart = appInterpageSource.indexOf(
-        'function getYuiGuideChatSpotlightSourceRect(kind, variant, rect, metrics)'
+        'function getYuiGuideChatSpotlightSourceRect(kind, variant, rect)'
     );
     assert.notEqual(shouldAlignFunctionStart, -1);
     assert.notEqual(sourceRectFunctionStart, -1);
     const shouldAlignFunction = getBalancedBlockFrom(appInterpageSource, shouldAlignFunctionStart);
     const sourceRectFunction = getBalancedBlockFrom(appInterpageSource, sourceRectFunctionStart);
-    // 修改原因：普通 input 保留旧 plain-capsule 逻辑；capsule-input 仅在桌面宿主明确声明
-    // Wayland work-area carrier 时对齐文字，避免改变 X11/macOS 的 registry 几何。
-    assert.match(shouldAlignFunction, /kind === 'capsule-input'[\s\S]*metrics\.waylandWorkAreaCarrier === true/);
+    // 修改原因：普通 input 保留旧 plain-capsule 文字对齐；capsule-input 已有 registry
+    // capsuleBody 作为完整几何真值，所有平台都不得再按文字起点平移。
+    assert.match(shouldAlignFunction, /return kind === 'input' && variant === 'plain-capsule';/);
+    assert.doesNotMatch(shouldAlignFunction, /capsule-input|waylandWorkAreaCarrier/);
     assert.match(sourceRectFunction, /anchorOffsetX \* YUI_GUIDE_CHAT_CAPSULE_TEXT_ALIGNMENT_RATIO/);
     assert.match(sourceRectFunction, /width:\s*rect\.width/);
     assert.doesNotMatch(sourceRectFunction, /sourceRect\.width = Math\.max\(1, rect\.left \+ rect\.width - sourceRect\.left\)/);

--- a/static/yui-guide-common.test.cjs
+++ b/static/yui-guide-common.test.cjs
@@ -1258,19 +1258,19 @@ test('interpage consumes common tutorial geometry before chat bridge scripts run
     assert.match(appInterpageSource, /getYuiGuideChatTargetShape\(kind\)/);
     assert.match(appInterpageSource, /getYuiGuideChatTargetShape\(kind\) === 'circle'/);
     const shouldAlignFunctionStart = appInterpageSource.indexOf(
-        'function shouldAlignYuiGuideChatSpotlightToCapsuleText(kind, variant)'
+        'function shouldAlignYuiGuideChatSpotlightToCapsuleText(kind, variant, metrics)'
     );
     const sourceRectFunctionStart = appInterpageSource.indexOf(
-        'function getYuiGuideChatSpotlightSourceRect(kind, variant, rect)'
+        'function getYuiGuideChatSpotlightSourceRect(kind, variant, rect, metrics)'
     );
     assert.notEqual(shouldAlignFunctionStart, -1);
     assert.notEqual(sourceRectFunctionStart, -1);
     const shouldAlignFunction = getBalancedBlockFrom(appInterpageSource, shouldAlignFunctionStart);
     const sourceRectFunction = getBalancedBlockFrom(appInterpageSource, sourceRectFunctionStart);
-    // 修改原因：普通 input 保留旧 plain-capsule 文字对齐；capsule-input 已有 registry
-    // capsuleBody 作为完整几何真值，所有平台都不得再按文字起点平移。
-    assert.match(shouldAlignFunction, /return kind === 'input' && variant === 'plain-capsule';/);
-    assert.doesNotMatch(shouldAlignFunction, /capsule-input|waylandWorkAreaCarrier/);
+    // 修改原因：Niri 的 capsuleBody 使用已提交布局坐标，不再叠加文字起点平移；
+    // 标准 Wayland 和普通 input + plain-capsule 保留既有视觉契约。
+    assert.match(shouldAlignFunction, /metrics\.waylandWorkAreaCarrier === true/);
+    assert.match(shouldAlignFunction, /metrics\.niriWaylandRuntime !== true/);
     assert.match(sourceRectFunction, /anchorOffsetX \* YUI_GUIDE_CHAT_CAPSULE_TEXT_ALIGNMENT_RATIO/);
     assert.match(sourceRectFunction, /width:\s*rect\.width/);
     assert.doesNotMatch(sourceRectFunction, /sourceRect\.width = Math\.max\(1, rect\.left \+ rect\.width - sourceRect\.left\)/);

--- a/static/yui-guide-day1-round-structure.test.cjs
+++ b/static/yui-guide-day1-round-structure.test.cjs
@@ -263,10 +263,10 @@ test('Day1 return control cursor moves to the capsule primary target before the 
   assert.match(targetGeometryRegistrySource, /'chat-capsule-input': Object\.freeze\(\{[\s\S]*externalKind: 'capsule-input'[\s\S]*data-compact-geometry-part="capsuleBody"/);
   assert.match(appInterpageSource, /getYuiGuideChatTargetRegistryEntryByExternalKind\(kind\)[\s\S]*entry\.localSelectors\.some/);
   const shouldAlignStart = appInterpageSource.indexOf(
-    'function shouldAlignYuiGuideChatSpotlightToCapsuleText(kind, variant, metrics)'
+    'function shouldAlignYuiGuideChatSpotlightToCapsuleText(kind, variant)'
   );
   const sourceRectStart = appInterpageSource.indexOf(
-    'function getYuiGuideChatSpotlightSourceRect(kind, variant, rect, metrics)'
+    'function getYuiGuideChatSpotlightSourceRect(kind, variant, rect)'
   );
   const spotlightUpdateStart = appInterpageSource.indexOf(
     'function updateYuiGuideChatSpotlight(kind, pcOverlayRunId)'
@@ -277,14 +277,15 @@ test('Day1 return control cursor moves to the capsule primary target before the 
   const shouldAlignBlock = getBalancedBlockFrom(appInterpageSource, shouldAlignStart);
   const sourceRectBlock = getBalancedBlockFrom(appInterpageSource, sourceRectStart);
   const spotlightUpdateBlock = getBalancedBlockFrom(appInterpageSource, spotlightUpdateStart);
-  // 修改原因：胶囊目标只在桌面宿主明确声明 Wayland work-area carrier 时平移；
-  // 平移后仍保留完整宽度，与 macOS 视觉契约一致。
-  assert.match(shouldAlignBlock, /metrics\.waylandWorkAreaCarrier === true/);
+  // 修改原因：registry 已将 capsule-input 解析到完整 capsuleBody，不能再用文字锚点
+  // 二次平移；只有旧的 input + plain-capsule 视觉形态保留文字对齐。
+  assert.match(shouldAlignBlock, /return kind === 'input' && variant === 'plain-capsule';/);
+  assert.doesNotMatch(shouldAlignBlock, /capsule-input|waylandWorkAreaCarrier/);
   assert.match(sourceRectBlock, /anchorOffsetX \* YUI_GUIDE_CHAT_CAPSULE_TEXT_ALIGNMENT_RATIO/);
   assert.match(sourceRectBlock, /width:\s*rect\.width/);
   assert.doesNotMatch(sourceRectBlock, /sourceRect\.width = Math\.max\(1, rect\.left \+ rect\.width - sourceRect\.left\)/);
   assert.match(spotlightUpdateBlock, /var pcOverlayAvailable = isYuiGuidePcOverlayAvailable\(\);/);
-  assert.match(spotlightUpdateBlock, /var sourceRectInfo = rect\s*\?\s*getYuiGuideChatSpotlightSourceRect\(kind, yuiGuideChatSpotlightVariant, rect, pcWindowMetrics\)\s*:\s*null;/);
+  assert.match(spotlightUpdateBlock, /var sourceRectInfo = rect\s*\?\s*getYuiGuideChatSpotlightSourceRect\(kind, yuiGuideChatSpotlightVariant, rect\)\s*:\s*null;/);
   assert.match(spotlightUpdateBlock, /sendYuiGuidePcOverlayPatch\(\{ spotlights: pcRects \}, false, patchOptions\);/);
   assert.doesNotMatch(appInterpageSource, /function renderYuiGuideChatSpotlight/);
   assert.doesNotMatch(appInterpageSource, /function isYuiGuideInputLikeChatTarget/);

--- a/static/yui-guide-day1-round-structure.test.cjs
+++ b/static/yui-guide-day1-round-structure.test.cjs
@@ -263,10 +263,10 @@ test('Day1 return control cursor moves to the capsule primary target before the 
   assert.match(targetGeometryRegistrySource, /'chat-capsule-input': Object\.freeze\(\{[\s\S]*externalKind: 'capsule-input'[\s\S]*data-compact-geometry-part="capsuleBody"/);
   assert.match(appInterpageSource, /getYuiGuideChatTargetRegistryEntryByExternalKind\(kind\)[\s\S]*entry\.localSelectors\.some/);
   const shouldAlignStart = appInterpageSource.indexOf(
-    'function shouldAlignYuiGuideChatSpotlightToCapsuleText(kind, variant)'
+    'function shouldAlignYuiGuideChatSpotlightToCapsuleText(kind, variant, metrics)'
   );
   const sourceRectStart = appInterpageSource.indexOf(
-    'function getYuiGuideChatSpotlightSourceRect(kind, variant, rect)'
+    'function getYuiGuideChatSpotlightSourceRect(kind, variant, rect, metrics)'
   );
   const spotlightUpdateStart = appInterpageSource.indexOf(
     'function updateYuiGuideChatSpotlight(kind, pcOverlayRunId)'
@@ -277,15 +277,15 @@ test('Day1 return control cursor moves to the capsule primary target before the 
   const shouldAlignBlock = getBalancedBlockFrom(appInterpageSource, shouldAlignStart);
   const sourceRectBlock = getBalancedBlockFrom(appInterpageSource, sourceRectStart);
   const spotlightUpdateBlock = getBalancedBlockFrom(appInterpageSource, spotlightUpdateStart);
-  // 修改原因：registry 已将 capsule-input 解析到完整 capsuleBody，不能再用文字锚点
-  // 二次平移；只有旧的 input + plain-capsule 视觉形态保留文字对齐。
-  assert.match(shouldAlignBlock, /return kind === 'input' && variant === 'plain-capsule';/);
-  assert.doesNotMatch(shouldAlignBlock, /capsule-input|waylandWorkAreaCarrier/);
+  // 修改原因：Niri 的 registry capsuleBody 已处于正确布局坐标，不能再用文字锚点
+  // 二次平移；标准 Wayland 保留 #2533 的原行为，避免平台修复向外扩散。
+  assert.match(shouldAlignBlock, /metrics\.waylandWorkAreaCarrier === true/);
+  assert.match(shouldAlignBlock, /metrics\.niriWaylandRuntime !== true/);
   assert.match(sourceRectBlock, /anchorOffsetX \* YUI_GUIDE_CHAT_CAPSULE_TEXT_ALIGNMENT_RATIO/);
   assert.match(sourceRectBlock, /width:\s*rect\.width/);
   assert.doesNotMatch(sourceRectBlock, /sourceRect\.width = Math\.max\(1, rect\.left \+ rect\.width - sourceRect\.left\)/);
   assert.match(spotlightUpdateBlock, /var pcOverlayAvailable = isYuiGuidePcOverlayAvailable\(\);/);
-  assert.match(spotlightUpdateBlock, /var sourceRectInfo = rect\s*\?\s*getYuiGuideChatSpotlightSourceRect\(kind, yuiGuideChatSpotlightVariant, rect\)\s*:\s*null;/);
+  assert.match(spotlightUpdateBlock, /var sourceRectInfo = rect\s*\?\s*getYuiGuideChatSpotlightSourceRect\(kind, yuiGuideChatSpotlightVariant, rect, pcWindowMetrics\)\s*:\s*null;/);
   assert.match(spotlightUpdateBlock, /sendYuiGuidePcOverlayPatch\(\{ spotlights: pcRects \}, false, patchOptions\);/);
   assert.doesNotMatch(appInterpageSource, /function renderYuiGuideChatSpotlight/);
   assert.doesNotMatch(appInterpageSource, /function isYuiGuideInputLikeChatTarget/);

--- a/static/yui-guide-wayland-overlay-regression.test.cjs
+++ b/static/yui-guide-wayland-overlay-regression.test.cjs
@@ -63,7 +63,7 @@ result = getYuiGuideChatSpotlightSourceRect(
   );
 });
 
-test('capsule target keeps its registered body rect instead of shifting toward its text anchor', () => {
+test('Niri capsule target keeps its body rect while standard Wayland preserves text alignment', () => {
   const functionSource = extractFunction(
     targetSource,
     'getYuiGuideChatSpotlightSourceRect',
@@ -83,20 +83,41 @@ test('capsule target keeps its registered body rect instead of shifting toward i
   vm.runInNewContext(
     `${shouldAlignSource}
 ${functionSource}
-capsuleShouldAlign = shouldAlignYuiGuideChatSpotlightToCapsuleText('capsule-input', '');
-plainCapsuleShouldAlign = shouldAlignYuiGuideChatSpotlightToCapsuleText('input', 'plain-capsule');
-capsuleResult = getYuiGuideChatSpotlightSourceRect(
+niriShouldAlign = shouldAlignYuiGuideChatSpotlightToCapsuleText(
   'capsule-input',
   '',
-  { left: 100, top: 10, width: 400, height: 60 }
+  { waylandWorkAreaCarrier: true, niriWaylandRuntime: true }
+);
+waylandShouldAlign = shouldAlignYuiGuideChatSpotlightToCapsuleText(
+  'capsule-input',
+  '',
+  { waylandWorkAreaCarrier: true, niriWaylandRuntime: false }
+);
+plainCapsuleShouldAlign = shouldAlignYuiGuideChatSpotlightToCapsuleText('input', 'plain-capsule', null);
+niriResult = getYuiGuideChatSpotlightSourceRect(
+  'capsule-input',
+  '',
+  { left: 100, top: 10, width: 400, height: 60 },
+  { waylandWorkAreaCarrier: true, niriWaylandRuntime: true }
+);
+waylandResult = getYuiGuideChatSpotlightSourceRect(
+  'capsule-input',
+  '',
+  { left: 100, top: 10, width: 400, height: 60 },
+  { waylandWorkAreaCarrier: true, niriWaylandRuntime: false }
 );`,
     context,
   );
-  assert.equal(context.capsuleShouldAlign, false);
+  assert.equal(context.niriShouldAlign, false);
+  assert.equal(context.waylandShouldAlign, true);
   assert.equal(context.plainCapsuleShouldAlign, true);
   assert.deepEqual(
-    JSON.parse(JSON.stringify(context.capsuleResult.rect)),
+    JSON.parse(JSON.stringify(context.niriResult.rect)),
     { left: 100, top: 10, width: 400, height: 60 },
+  );
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(context.waylandResult.rect)),
+    { left: 130, top: 10, width: 400, height: 60 },
   );
 });
 

--- a/static/yui-guide-wayland-overlay-regression.test.cjs
+++ b/static/yui-guide-wayland-overlay-regression.test.cjs
@@ -18,6 +18,14 @@ const managerSource = fs.readFileSync(
   path.join(repoRoot, 'static/tutorial/core/universal-manager.js'),
   'utf8',
 );
+const overlaySource = fs.readFileSync(
+  path.join(repoRoot, 'static/tutorial/yui-guide/overlay.js'),
+  'utf8',
+);
+const directorSource = fs.readFileSync(
+  path.join(repoRoot, 'static/tutorial/yui-guide/director/director-core.js'),
+  'utf8',
+);
 
 function extractFunction(source, name, nextName) {
   const start = source.indexOf(`    function ${name}(`);
@@ -55,7 +63,7 @@ result = getYuiGuideChatSpotlightSourceRect(
   );
 });
 
-test('Wayland work-area capsule alignment matches macOS width while correcting the left origin', () => {
+test('capsule target keeps its registered body rect instead of shifting toward its text anchor', () => {
   const functionSource = extractFunction(
     targetSource,
     'getYuiGuideChatSpotlightSourceRect',
@@ -75,29 +83,21 @@ test('Wayland work-area capsule alignment matches macOS width while correcting t
   vm.runInNewContext(
     `${shouldAlignSource}
 ${functionSource}
-waylandResult = getYuiGuideChatSpotlightSourceRect(
+capsuleShouldAlign = shouldAlignYuiGuideChatSpotlightToCapsuleText('capsule-input', '');
+plainCapsuleShouldAlign = shouldAlignYuiGuideChatSpotlightToCapsuleText('input', 'plain-capsule');
+capsuleResult = getYuiGuideChatSpotlightSourceRect(
   'capsule-input',
   '',
-  { left: 100, top: 10, width: 400, height: 60 },
-  { waylandWorkAreaCarrier: true }
-);
-x11Result = getYuiGuideChatSpotlightSourceRect(
-  'capsule-input',
-  '',
-  { left: 100, top: 10, width: 400, height: 60 },
-  { waylandWorkAreaCarrier: false }
+  { left: 100, top: 10, width: 400, height: 60 }
 );`,
     context,
   );
+  assert.equal(context.capsuleShouldAlign, false);
+  assert.equal(context.plainCapsuleShouldAlign, true);
   assert.deepEqual(
-    JSON.parse(JSON.stringify(context.waylandResult.rect)),
-    { left: 130, top: 10, width: 400, height: 60 },
-  );
-  assert.deepEqual(
-    JSON.parse(JSON.stringify(context.x11Result.rect)),
+    JSON.parse(JSON.stringify(context.capsuleResult.rect)),
     { left: 100, top: 10, width: 400, height: 60 },
   );
-  assert.equal(context.waylandResult.rect.width, context.x11Result.rect.width);
 });
 
 test('PC overlay skip mirrors localized state and relays only through the active lifecycle', () => {
@@ -159,4 +159,122 @@ test('screen conversion prefers an explicitly declared render coordinate space',
     interpageSource,
     /return metrics && \(metrics\.bounds \|\| metrics\.contentBounds\) \|\| \{ x: 0, y: 0 \};/,
   );
+  assert.match(
+    overlaySource,
+    /metrics\.coordinateSpace === 'screen-dip'[\s\S]*metrics\.renderBounds/,
+  );
+  assert.match(
+    directorSource,
+    /getGuideScreenCoordinateBounds\(metrics\)[\s\S]*metrics\.coordinateSpace === 'screen-dip'[\s\S]*return metrics\.renderBounds;/,
+  );
+});
+
+test('physical-crop DOM coordinates still receive the layout offset when metrics are virtualized', () => {
+  const pointSource = extractFunction(
+    interpageSource,
+    'toYuiGuideNiriPetPhysicalCropVirtualPointWithState',
+    'toYuiGuideNiriPetPhysicalCropVirtualRectWithState',
+  );
+  const rectSource = extractFunction(
+    interpageSource,
+    'toYuiGuideNiriPetPhysicalCropVirtualRectWithState',
+    'shouldApplyYuiGuideVisualViewportOffset',
+  );
+  const screenPointStart = interpageSource.indexOf(
+    '    function toYuiGuideScreenVirtualPoint(',
+  );
+  const screenPointEnd = interpageSource.indexOf(
+    '    I.toYuiGuideScreenPoint =',
+    screenPointStart,
+  );
+  assert.notEqual(screenPointStart, -1);
+  assert.notEqual(screenPointEnd, -1);
+  const screenPointSource = interpageSource.slice(screenPointStart, screenPointEnd);
+  const context = {
+    toYuiGuideNiriPetPhysicalCropVirtualPoint: () => null,
+    toYuiGuideNiriPetPhysicalCropVirtualRect: () => null,
+  };
+  vm.runInNewContext(
+    `${pointSource}
+${rectSource}
+${screenPointSource}
+pointResult = toYuiGuideNiriPetPhysicalCropVirtualPointWithState(
+  55,
+  55,
+  { offsetX: 863, offsetY: 323, metricsVirtualized: true }
+);
+rectResult = toYuiGuideNiriPetPhysicalCropVirtualRectWithState(
+  { left: 55, top: 55, width: 98, height: 62 },
+  { offsetX: 863, offsetY: 323, metricsVirtualized: true }
+);
+screenResult = toYuiGuideScreenVirtualPoint(
+  pointResult.x,
+  pointResult.y,
+  {
+    virtualBounds: { x: 1, y: 1, width: 1706, height: 1066 },
+    cropBounds: { x: 864, y: 324, width: 192, height: 432 }
+  }
+);`,
+    context,
+  );
+
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(context.pointResult)),
+    { x: 918, y: 378 },
+  );
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(context.rectResult)),
+    { left: 918, top: 378, width: 98, height: 62 },
+  );
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(context.screenResult)),
+    { x: 919, y: 379 },
+  );
+});
+
+test('all three tutorial coordinate paths use the DOM layout generation symmetrically', () => {
+  const appPointBlock = extractFunction(
+    interpageSource,
+    'toYuiGuideNiriPetPhysicalCropVirtualPointWithState',
+    'toYuiGuideNiriPetPhysicalCropVirtualRectWithState',
+  );
+  const appRectBlock = extractFunction(
+    interpageSource,
+    'toYuiGuideNiriPetPhysicalCropVirtualRectWithState',
+    'shouldApplyYuiGuideVisualViewportOffset',
+  );
+  const overlayPointStart = overlaySource.indexOf(
+    '        const toNiriPetPhysicalCropVirtualPointWithState =',
+  );
+  const overlayPointEnd = overlaySource.indexOf(
+    '        const shouldApplyVisualViewportOffset =',
+    overlayPointStart,
+  );
+  const directorPointStart = directorSource.indexOf(
+    '        toNiriPetPhysicalCropVirtualPointWithState(',
+  );
+  const directorPointEnd = directorSource.indexOf(
+    '        getGuideWindowMetricsSync()',
+    directorPointStart,
+  );
+  assert.notEqual(overlayPointStart, -1);
+  assert.notEqual(overlayPointEnd, -1);
+  assert.notEqual(directorPointStart, -1);
+  assert.notEqual(directorPointEnd, -1);
+  const overlayPointBlock = overlaySource.slice(overlayPointStart, overlayPointEnd);
+  const directorPointBlock = directorSource.slice(directorPointStart, directorPointEnd);
+
+  for (const block of [appPointBlock, appRectBlock, overlayPointBlock, directorPointBlock]) {
+    assert.doesNotMatch(
+      block,
+      /cropState\s*&&\s*cropState\.metricsVirtualized/,
+      'virtualized window bounds must not skip crop-local DOM conversion',
+    );
+  }
+  for (const source of [interpageSource, overlaySource, directorSource]) {
+    assert.match(source, /niriPetPhysicalCropLayoutOffsetX/);
+    assert.match(source, /niriPetPhysicalCropLayoutOffsetY/);
+    assert.match(source, /toLayoutVirtualPoint/);
+    assert.match(source, /getLayoutState/);
+  }
 });

--- a/static/yui-guide-wayland-overlay-regression.test.cjs
+++ b/static/yui-guide-wayland-overlay-regression.test.cjs
@@ -171,10 +171,10 @@ I.setYuiGuidePcOverlaySkipControl(true, '跳过');`, context);
   );
 });
 
-test('screen conversion prefers an explicitly declared render coordinate space', () => {
+test('screen conversion rejects workspace-view render bounds without screen provenance', () => {
   assert.match(
     interpageSource,
-    /metrics\.coordinateSpace === 'screen-dip'[\s\S]*return metrics\.renderBounds;/,
+    /metrics\.renderBoundsCoordinateSpace === 'screen-dip'[\s\S]*metrics\.originSource === 'niri-pet-physical-crop-virtual-bounds'[\s\S]*return metrics\.renderBounds;/,
   );
   assert.match(
     interpageSource,
@@ -182,11 +182,53 @@ test('screen conversion prefers an explicitly declared render coordinate space',
   );
   assert.match(
     overlaySource,
-    /metrics\.coordinateSpace === 'screen-dip'[\s\S]*metrics\.renderBounds/,
+    /metrics\.renderBoundsCoordinateSpace === 'screen-dip'[\s\S]*metrics\.originSource === 'niri-pet-physical-crop-virtual-bounds'[\s\S]*metrics\.renderBounds/,
   );
   assert.match(
     directorSource,
-    /getGuideScreenCoordinateBounds\(metrics\)[\s\S]*metrics\.coordinateSpace === 'screen-dip'[\s\S]*return metrics\.renderBounds;/,
+    /getGuideScreenCoordinateBounds\(metrics\)[\s\S]*metrics\.renderBoundsCoordinateSpace === 'screen-dip'[\s\S]*metrics\.originSource === 'niri-pet-physical-crop-virtual-bounds'[\s\S]*return metrics\.renderBounds;/,
+  );
+
+  const functionSource = extractFunction(
+    interpageSource,
+    'getYuiGuideScreenCoordinateBounds',
+    'normalizeYuiGuideNiriPetPhysicalCropBounds',
+  );
+  const context = vm.createContext({});
+  vm.runInNewContext(
+    `${functionSource}
+workspaceResult = getYuiGuideScreenCoordinateBounds({
+  coordinateSpace: 'screen-dip',
+  bounds: { x: 100, y: 50, width: 800, height: 600 },
+  renderBounds: { x: -320, y: 20, width: 800, height: 600 },
+  renderBoundsCoordinateSpace: 'workspace-view-dip'
+});
+screenResult = getYuiGuideScreenCoordinateBounds({
+  coordinateSpace: 'screen-dip',
+  bounds: { x: 100, y: 50, width: 800, height: 600 },
+  renderBounds: { x: 140, y: 70, width: 800, height: 600 },
+  renderBoundsCoordinateSpace: 'screen-dip'
+});
+legacyCropResult = getYuiGuideScreenCoordinateBounds({
+  coordinateSpace: 'screen-dip',
+  bounds: { x: 100, y: 50, width: 800, height: 600 },
+  renderBounds: { x: 1, y: 1, width: 1200, height: 800 },
+  niriPetPhysicalCrop: true,
+  originSource: 'niri-pet-physical-crop-virtual-bounds'
+});`,
+    context,
+  );
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(context.workspaceResult)),
+    { x: 100, y: 50, width: 800, height: 600 },
+  );
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(context.screenResult)),
+    { x: 140, y: 70, width: 800, height: 600 },
+  );
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(context.legacyCropResult)),
+    { x: 1, y: 1, width: 1200, height: 800 },
   );
 });
 

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -5534,7 +5534,7 @@ def test_externalized_chat_capsule_spotlight_keeps_last_rect_when_target_tempora
 
 
 @pytest.mark.frontend
-def test_externalized_chat_capsule_input_spotlight_uses_capsule_body_rect_on_wayland_and_x11(mock_page: Page):
+def test_externalized_chat_capsule_input_spotlight_scopes_text_alignment_away_from_niri(mock_page: Page):
     _bootstrap_page(
         mock_page,
         setup_js="""
@@ -5542,11 +5542,13 @@ def test_externalized_chat_capsule_input_spotlight_uses_capsule_body_rect_on_way
             window.localStorage.setItem('yuiGuidePcOverlayRunId', 'test-run');
             window.__externalChatOverlayUpdates = [];
             window.__waylandWorkAreaCarrier = true;
+            window.__niriWaylandRuntime = true;
             window.nekoTutorialOverlay = {
                 getWindowMetricsSync: () => ({
                     bounds: { x: 100, y: 50, width: 1200, height: 800 },
                     contentBounds: { x: 100, y: 50, width: 1200, height: 800 },
                     waylandWorkAreaCarrier: window.__waylandWorkAreaCarrier,
+                    niriWaylandRuntime: window.__niriWaylandRuntime,
                     zoomFactor: 1,
                 }),
                 update: (payload) => {
@@ -5594,28 +5596,37 @@ def test_externalized_chat_capsule_input_spotlight_uses_capsule_body_rect_on_way
             const timestamp = Date.now();
             sendSpotlight(timestamp);
             await new Promise((resolve) => setTimeout(resolve, 160));
+            const niriUpdates = (window.__externalChatOverlayUpdates || [])
+                .filter((entry) => entry.payload && entry.payload.spotlights);
+            const niriSpotlight = niriUpdates[niriUpdates.length - 1].payload.spotlights[0];
+
+            window.__niriWaylandRuntime = false;
+            sendSpotlight(timestamp + 1);
+            await new Promise((resolve) => setTimeout(resolve, 160));
             const waylandUpdates = (window.__externalChatOverlayUpdates || [])
                 .filter((entry) => entry.payload && entry.payload.spotlights);
             const waylandSpotlight = waylandUpdates[waylandUpdates.length - 1].payload.spotlights[0];
 
             window.__waylandWorkAreaCarrier = false;
-            sendSpotlight(timestamp + 1);
+            sendSpotlight(timestamp + 2);
             await new Promise((resolve) => setTimeout(resolve, 160));
             const x11Updates = (window.__externalChatOverlayUpdates || [])
                 .filter((entry) => entry.payload && entry.payload.spotlights);
             const x11Spotlight = x11Updates[x11Updates.length - 1].payload.spotlights[0];
-            return { waylandSpotlight, x11Spotlight };
+            return { niriSpotlight, waylandSpotlight, x11Spotlight };
         }
         """
     )
 
     assert result
-    assert result["waylandSpotlight"]["id"] == "external-chat-capsule-input"
-    assert result["waylandSpotlight"]["x"] == 692
+    assert result["niriSpotlight"]["id"] == "external-chat-capsule-input"
+    assert result["niriSpotlight"]["x"] == 692
+    assert result["niriSpotlight"]["width"] == 446
+    assert result["waylandSpotlight"]["x"] == 722
     assert result["waylandSpotlight"]["width"] == 446
     assert result["x11Spotlight"]["x"] == 692
     assert result["x11Spotlight"]["width"] == 446
-    assert result["waylandSpotlight"] == result["x11Spotlight"]
+    assert result["niriSpotlight"] == result["x11Spotlight"]
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -5534,7 +5534,7 @@ def test_externalized_chat_capsule_spotlight_keeps_last_rect_when_target_tempora
 
 
 @pytest.mark.frontend
-def test_externalized_chat_capsule_input_spotlight_aligns_only_for_wayland_workarea_carrier(mock_page: Page):
+def test_externalized_chat_capsule_input_spotlight_uses_capsule_body_rect_on_wayland_and_x11(mock_page: Page):
     _bootstrap_page(
         mock_page,
         setup_js="""
@@ -5611,11 +5611,11 @@ def test_externalized_chat_capsule_input_spotlight_aligns_only_for_wayland_worka
 
     assert result
     assert result["waylandSpotlight"]["id"] == "external-chat-capsule-input"
-    assert result["waylandSpotlight"]["x"] == 722
+    assert result["waylandSpotlight"]["x"] == 692
     assert result["waylandSpotlight"]["width"] == 446
     assert result["x11Spotlight"]["x"] == 692
     assert result["x11Spotlight"]["width"] == 446
-    assert result["waylandSpotlight"]["width"] == result["x11Spotlight"]["width"]
+    assert result["waylandSpotlight"] == result["x11Spotlight"]
 
 
 @pytest.mark.frontend

--- a/tests/unit/test_avatar_floating_day1_round_contracts.py
+++ b/tests/unit/test_avatar_floating_day1_round_contracts.py
@@ -639,11 +639,15 @@ def test_pc_overlay_screen_coordinates_use_niri_virtual_origin_and_crop_safe_are
     assert "var screenBounds = cropState.virtualBounds || cropState.cropBounds;" in interpage_source
     assert "x: Number(screenBounds.x || 0) + Number(x || 0)" in interpage_source
     assert "y: Number(screenBounds.y || 0) + Number(y || 0)" in interpage_source
-    assert "api.toVirtualPoint({" in interpage_source
-    assert "api.toVirtualRect({" in interpage_source
+    assert "typeof api.toLayoutVirtualPoint === 'function'" in interpage_source
+    assert "? api.toLayoutVirtualPoint" in interpage_source
+    assert ": api.toVirtualPoint" in interpage_source
+    assert "typeof api.toLayoutVirtualRect === 'function'" in interpage_source
+    assert "? api.toLayoutVirtualRect" in interpage_source
+    assert ": api.toVirtualRect" in interpage_source
     assert "toYuiGuideNiriPetPhysicalCropVirtualPointWithState" in interpage_source
-    assert "if (cropState && cropState.metricsVirtualized) {" in interpage_source
-    assert "Number(cropState && cropState.offsetY || 0)" in interpage_source
+    assert "if (cropState) {" in interpage_source
+    assert "Number(cropState.offsetY || 0)" in interpage_source
     assert "var viewport = shouldApplyYuiGuideVisualViewportOffset(metrics) ? (window.visualViewport || null) : null;" in interpage_source
     assert "if (metrics && (metrics.contentBounds || metrics.bounds))" in overlay_source
     assert "const getNiriPetPhysicalCropState = (metrics) => {" in overlay_source
@@ -655,11 +659,15 @@ def test_pc_overlay_screen_coordinates_use_niri_virtual_origin_and_crop_safe_are
     assert "const screenBounds = cropState.virtualBounds || cropState.cropBounds;" in overlay_source
     assert "x: Number(screenBounds.x || 0) + Number(x || 0)" in overlay_source
     assert "y: Number(screenBounds.y || 0) + Number(y || 0)" in overlay_source
-    assert "api.toVirtualPoint({" in overlay_source
-    assert "api.toVirtualRect({" in overlay_source
+    assert "typeof api.toLayoutVirtualPoint === 'function'" in overlay_source
+    assert "? api.toLayoutVirtualPoint" in overlay_source
+    assert ": api.toVirtualPoint" in overlay_source
+    assert "typeof api.toLayoutVirtualRect === 'function'" in overlay_source
+    assert "? api.toLayoutVirtualRect" in overlay_source
+    assert ": api.toVirtualRect" in overlay_source
     assert "toNiriPetPhysicalCropVirtualPointWithState" in overlay_source
-    assert "cropState && cropState.metricsVirtualized ? {" in overlay_source
-    assert "Number(cropState && cropState.offsetY || 0)" in overlay_source
+    assert "cropState ? {" in overlay_source
+    assert "Number(cropState.offsetY || 0)" in overlay_source
     assert "let lastLocalSpotlightEntries = [];" in overlay_source
     assert "window.addEventListener('neko:niri-pet-physical-crop-state-applied', refreshSpotlightsForCropState);" in overlay_source
     assert "const viewport = shouldApplyVisualViewportOffset(metrics) ? (window.visualViewport || null) : null;" in overlay_source
@@ -668,12 +676,16 @@ def test_pc_overlay_screen_coordinates_use_niri_virtual_origin_and_crop_safe_are
     assert "metrics.niriPetPhysicalCropMetricsVirtualized === true" in director_source
     assert "metrics.niriPetPhysicalCropBounds || metrics.contentBounds || metrics.bounds" in director_source
     assert "const api = typeof window !== 'undefined' ? window.__nekoNiriPetPhysicalCrop : null;" in director_source
-    assert "api.toVirtualPoint(point)" in director_source
-    assert "api.toLocalPoint(point)" in director_source
+    assert "typeof api.toLayoutVirtualPoint === 'function'" in director_source
+    assert "? api.toLayoutVirtualPoint" in director_source
+    assert ": api.toVirtualPoint" in director_source
+    assert "typeof api.toLayoutLocalPoint === 'function'" in director_source
+    assert "? api.toLayoutLocalPoint" in director_source
+    assert ": api.toLocalPoint" in director_source
     assert "toNiriPetPhysicalCropVirtualPointWithState(point, cropState)" in director_source
     assert "toNiriPetPhysicalCropLocalPointWithState(virtualPoint, cropState)" in director_source
-    assert "if (cropState && cropState.metricsVirtualized) {" in director_source
-    assert "- Number(cropState && cropState.offsetY || 0)" in director_source
+    assert "if (cropState) {" in director_source
+    assert "- Number(cropState.offsetY || 0)" in director_source
     assert "x: point.x - Number(screenBounds.x || 0)" in director_source
     assert "y: point.y - Number(screenBounds.y || 0)" in director_source
     assert "x: Number(screenBounds.x || 0) + virtualPoint.x" in director_source

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -1397,8 +1397,9 @@ def test_externalized_chat_input_spotlight_uses_global_overlay_only():
     assert "var pcOverlayAvailable = isYuiGuidePcOverlayAvailable();" in update_block
     assert "if (pcOverlayAvailable) {" in update_block
     assert "var pcWindowMetrics = pcOverlayAvailable && typeof getYuiGuideWindowMetrics === 'function'" in update_block
-    assert "getYuiGuideChatSpotlightSourceRect(kind, yuiGuideChatSpotlightVariant, rect, pcWindowMetrics)" in update_block
-    assert "metrics.waylandWorkAreaCarrier === true" in script
+    assert "getYuiGuideChatSpotlightSourceRect(kind, yuiGuideChatSpotlightVariant, rect)" in update_block
+    assert "getYuiGuideChatSpotlightSourceRect(kind, yuiGuideChatSpotlightVariant, rect, pcWindowMetrics)" not in update_block
+    assert "metrics.waylandWorkAreaCarrier === true" not in script
     assert "var sourceRect = sourceRectInfo ? sourceRectInfo.rect : rect;" in update_block
     assert "toYuiGuideScreenRect({" in update_block
     assert "}, kind, yuiGuideChatSpotlightVariant, pcWindowMetrics)" in update_block

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -1397,9 +1397,9 @@ def test_externalized_chat_input_spotlight_uses_global_overlay_only():
     assert "var pcOverlayAvailable = isYuiGuidePcOverlayAvailable();" in update_block
     assert "if (pcOverlayAvailable) {" in update_block
     assert "var pcWindowMetrics = pcOverlayAvailable && typeof getYuiGuideWindowMetrics === 'function'" in update_block
-    assert "getYuiGuideChatSpotlightSourceRect(kind, yuiGuideChatSpotlightVariant, rect)" in update_block
-    assert "getYuiGuideChatSpotlightSourceRect(kind, yuiGuideChatSpotlightVariant, rect, pcWindowMetrics)" not in update_block
-    assert "metrics.waylandWorkAreaCarrier === true" not in script
+    assert "getYuiGuideChatSpotlightSourceRect(kind, yuiGuideChatSpotlightVariant, rect, pcWindowMetrics)" in update_block
+    assert "metrics.waylandWorkAreaCarrier === true" in script
+    assert "metrics.niriWaylandRuntime !== true" in script
     assert "var sourceRect = sourceRectInfo ? sourceRectInfo.rect : rect;" in update_block
     assert "toYuiGuideScreenRect({" in update_block
     assert "}, kind, yuiGuideChatSpotlightVariant, pcWindowMetrics)" in update_block


### PR DESCRIPTION
## 问题

Niri 下新手教程的聚光灯与 Chat UI 目标发生水平偏移。结合日志和代码确认，Chat UI 本身没有左移；偏移发生在教程层把 DOM 布局坐标转换为屏幕坐标时。

## 根因

这是 **N.E.K.O.-PC #384 比 #387 晚合并**造成的坐标契约回归：

- #387 的教程覆盖层坐标转换假设窗口指标与 DOM 布局属于同一代；
- #384 后合并并引入 Niri 物理裁剪 prepare / commit 双阶段以及虚拟窗口指标；
- DOM `getBoundingClientRect()` 仍对应最后一次已提交布局，但教程路径读取到了最新事件/虚拟裁剪指标；
- 两代坐标混用后，聚光灯被额外平移。#2533 修复完成时验收正常，是因为当时这个后合并改动尚未破坏该假设。

## 修复

- app-interpage、overlay、director 三条教程路径统一消费 PC 暴露的布局态偏移；
- `renderBoundsCoordinateSpace` 明确声明 `screen-dip` 时才采用 `renderBounds`；
- 物理裁剪指标被虚拟化时，DOM 坐标仍补偿其真实布局偏移；
- Niri 的 `capsule-input` 使用 registry 的完整 `capsuleBody`，不再叠加旧文字锚点偏移。
- 兼容旧版 PC 的物理裁剪来源，同时拒绝把 Niri `workspace-view-dip` 当作全局屏幕原点。

## 平台影响与污染评估

审计中发现，若直接移除旧胶囊文字对齐会污染普通 Wayland，因此已额外收窄：

- 仅 `niriWaylandRuntime === true` 使用完整胶囊坐标；
- 普通 Wayland 保留 #2533 的既有文字对齐行为；
- X11、Windows、macOS 不进入 Niri 裁剪分支；
- 三条教程路径保持对称实现，并有静态契约防止以后只修一处再次回归。

## 验证

- 本次坐标回归 Node 测试：7/7 通过；
- Core 静态 Python 契约：89/89 通过；
- 前端构建已执行，产物一致性校验通过；
- `git diff --check` 通过；
- Playwright 浏览器用例已补充，但本机缺少浏览器二进制，因此被测试框架明确跳过。

基线说明：最新 `main` 的完整旧静态套件仍有与本 PR 未改动逻辑有关的历史断言失败（跨页消息/监听等）；本 PR 新增和相关坐标用例均通过。

PC 配套 PR：https://github.com/Project-N-E-K-O/N.E.K.O.-PC/pull/401


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进 Niri Wayland 环境下的物理裁剪与坐标转换，提升覆盖层、引导页和跨应用页面的位置准确性。
  * 修复屏幕坐标边界及布局偏移处理，确保虚拟化状态下坐标转换一致。
  * 调整胶囊输入对齐逻辑，避免 Niri Wayland 使用不适用的文本偏移。

* **Tests**
  * 扩展 Wayland、Niri 及虚拟化裁剪场景的回归测试，覆盖点、矩形和屏幕坐标转换。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->