### PR TITLE
fix(memory): reconcile 独占启动窗口，重放的崩溃修复不再被静默吞掉（#2528 第 6 步）

### DIFF
--- a/app/memory_server/runtime.py
+++ b/app/memory_server/runtime.py
@@ -547,11 +547,6 @@ async def ensure_memory_server_runtime_initialized(*, reason: str = "") -> bool:
         except Exception as e:
             logger.warning(f"[Memory] Persona 迁移检查失败: {e}")
 
-        try:
-            await outbox_infra._replay_pending_outbox()
-        except Exception as e:
-            logger.warning(f"[Outbox] 启动补跑顶层失败: {e}")
-
         async def _reconcile_one(n: str):
             try:
                 applied = await reconciler.areconcile(n)
@@ -560,11 +555,29 @@ async def ensure_memory_server_runtime_initialized(*, reason: str = "") -> bool:
             except Exception as e:
                 logger.warning(f"[Memory] reconciler {n} replay 失败: {e}")
 
+        # 顺序要求：reconcile 必须整体跑完，才允许 outbox 补跑起任何 op。
+        # 两边都写同一批 view 文件，但它们的读点不对称：reconcile 的 handler
+        # 是在 EventLog 锁内 load→改→save 的，而 reflection/persona 的 live
+        # writer 是在锁**外**先把整份快照读进内存，再交给 record_and_save 写回
+        # （见 memory/reflection/evidence_flow.py）。所以只要两者重叠，就存在
+        # 「live writer 用重放之前的快照整覆盖掉刚修好的结果」的窗口 —— 而哨兵
+        # 此时已经越过那条事件，之后再也不会重放，是静默永久丢失。
+        # 补跑侧是 fire-and-forget 的后台 task（_replay_pending_outbox 只 await
+        # 扫描），reconcile 这边是 await 到底的：先跑 reconcile 就没有重叠。
+        # 反向依赖不存在：补跑的 op 走 record_and_save，append+apply+save 一体，
+        # 不需要 reconcile 再补应用一次；RFC 也明写了「不得依赖 outbox 副作用先
+        # 可见」（docs/design/memory-event-log-rfc.md 启动恢复一节）。
+        # 顺带的好处：补跑 op 读到的是已经修复完的 view，而不是崩溃残留态。
         if catgirl_names:
             await asyncio.gather(
                 *(_reconcile_one(n) for n in catgirl_names),
                 return_exceptions=True,
             )
+
+        try:
+            await outbox_infra._replay_pending_outbox()
+        except Exception as e:
+            logger.warning(f"[Outbox] 启动补跑顶层失败: {e}")
 
         async def _migrate_one(n: str):
             try:

--- a/docs/design/memory-event-log-rfc.md
+++ b/docs/design/memory-event-log-rfc.md
@@ -105,18 +105,27 @@ During memory-server startup, the runtime:
 
 1. creates the managers, `EventLog`, and `Reconciler`;
 2. registers the current evidence/lifecycle handlers;
-3. scans pending outbox work and spawns replay tasks;
-4. begins reconciliation for each configured character without awaiting those
-   spawned tasks;
+3. reconciles every configured character, awaited to completion;
+4. scans pending outbox work and spawns replay tasks;
 5. runs evidence and archive migrations, then starts the staggered background
    loops.
 
-Steps 3 through 5 are not a strict completion order. Outbox handlers may overlap
-reconciliation, migrations, and early loop activity, so code must not depend on
-an outbox side effect being visible first. `_replay_pending_outbox()` returns the
-spawned task list, but the current startup caller does not await it. If serialized
-recovery becomes a requirement, startup must explicitly await that list before
-reconciliation; the current implementation provides no such guarantee.
+Reconciliation before outbox replay is deliberate and load-bearing. Both write the
+same view files, but their read points are asymmetric: a replay handler loads,
+mutates, and saves inside the `EventLog` lock, while the reflection and persona
+live writers load the whole snapshot *outside* that lock and only then hand it to
+`record_and_save`. Any overlap therefore leaves a window where a live writer saves
+a pre-replay snapshot back over a just-completed repair, with the sentinel already
+past the event — silent, permanent loss. Resumed outbox operations are background
+tasks, and reconciliation is fully awaited, so running reconciliation first removes
+the overlap entirely.
+
+The reverse dependency does not exist: a resumed operation emits its own events
+through `record_and_save`, which appends, applies, and saves as one step, so
+reconciliation never has to apply them afterwards. Code still must not depend on an
+outbox side effect being visible to any later startup step: `_replay_pending_outbox()`
+returns the spawned task list, and the startup caller does not await it, so those
+operations may overlap migrations and early loop activity.
 
 The reconciler reads events after `last_applied_event_id` and applies them in file
 order. A handler must load, idempotently apply, and persist its view before it
@@ -161,6 +170,14 @@ policy. Operators should not assume deployed journals are automatically compacte
   lock or multi-writer protocol.
 - View files remain authoritative for normal reads and may still be repaired or
   migrated directly by dedicated code.
+- The sentinel write is an unconditional overwrite. Event ids are UUIDs, so no
+  writer can tell from two ids which is newer; the only order that exists is the
+  position in the journal. `record_and_save` is safe by construction, since it
+  writes the id it just appended. Replay cannot make that assumption, so it
+  compares the on-disk sentinel against the value its round started from and
+  refuses to write when they differ — a rewound sentinel returns another writer's
+  events to the tail, and one without a registered handler wedges every later
+  boot. The rest of that round's tail is still applied, only the sentinel freezes.
 - Outbox recovery and event replay solve different failure windows: the outbox
   retries background operations; the journal repairs covered mutations after the
   operation has chosen a concrete state transition.

--- a/docs/design/memory-event-log-rfc.md
+++ b/docs/design/memory-event-log-rfc.md
@@ -172,12 +172,34 @@ policy. Operators should not assume deployed journals are automatically compacte
   migrated directly by dedicated code.
 - The sentinel write is an unconditional overwrite. Event ids are UUIDs, so no
   writer can tell from two ids which is newer; the only order that exists is the
-  position in the journal. `record_and_save` is safe by construction, since it
-  writes the id it just appended. Replay cannot make that assumption, so it
-  compares the on-disk sentinel against the value its round started from and
-  refuses to write when they differ — a rewound sentinel returns another writer's
-  events to the tail, and one without a registered handler wedges every later
-  boot. The rest of that round's tail is still applied, only the sentinel freezes.
+  position in the journal. `record_and_save` can never rewind it, since it writes
+  the id it just appended. Replay cannot make that assumption, so it compares the
+  on-disk sentinel against the value its round started from — before it runs the
+  handler, not after — and neither applies the event nor writes the sentinel when
+  they differ.
+- A replay round that loses that comparison does not stop, and does not keep
+  applying the list it was holding. Either would lose data. The list is now
+  *behind* another writer's sentinel, so applying it as-is pushes older payloads
+  over that writer's values, and the newer event sits ahead of the frozen sentinel
+  where no later boot replays it. Stopping instead abandons repairs that the same
+  sentinel write has already made unreplayable. So the round re-reads the journal
+  from its own last-applied position through to the end of the file and replays
+  that range in journal order: the queued repairs land, the other writer's events
+  land after them, and the newest payload for any given entry wins. The sentinel
+  stays frozen — rewinding it would return the other writer's events to the tail,
+  and one without a registered handler wedges every later boot — and needs no
+  final write, because that writer already parked it at the journal end. Replaying
+  an already-applied event is harmless for the same reason a missing sentinel
+  triggers a full replay: handlers carry full snapshots and are idempotent.
+- **Known limitation, not fixed here.** Advancing the sentinel to the journal end
+  asserts that every earlier event was applied, and `record_and_save` never checks
+  that. Whenever an unapplied tail is on disk — replay paused on an unregistered
+  event type or a raising handler — the next live write silently orphans it. This
+  is unrelated to reconciliation running concurrently, and startup ordering does
+  not help. Closing it requires the sentinel to stop being "an event id": either a
+  full journal scan on every write, or a position/applied-set with an on-disk
+  format migration. Until then, do not read "the sentinel only moves forward" as
+  "no event can be skipped".
 - Outbox recovery and event replay solve different failure windows: the outbox
   retries background operations; the journal repairs covered mutations after the
   operation has chosen a concrete state transition.

--- a/docs/design/memory-event-log-rfc.md
+++ b/docs/design/memory-event-log-rfc.md
@@ -191,6 +191,16 @@ policy. Operators should not assume deployed journals are automatically compacte
   final write, because that writer already parked it at the journal end. Replaying
   an already-applied event is harmless for the same reason a missing sentinel
   triggers a full replay: handlers carry full snapshots and are idempotent.
+- That "end of the file" is a snapshot, and writers keep appending past it. An
+  event landing after the snapshot is absent from the range being replayed, while
+  the stale payloads queued ahead of it are not: replaying those pushes older
+  values over the view that writer just saved, and the sentinel now parked on its
+  id means no later boot replays it back. So the frozen pass re-probes from its
+  own last-applied position each time it drains, and only returns once a probe
+  comes back empty. The probe count is bounded (`_MAX_FROZEN_RESCANS`) so that
+  unbroken write traffic ends the round instead of stalling startup; hitting the
+  bound is logged, because whatever is left unreplayed sits behind the sentinel
+  and no later boot picks it up.
 - **Known limitation, not fixed here.** Advancing the sentinel to the journal end
   asserts that every earlier event was applied, and `record_and_save` never checks
   that. Whenever an unapplied tail is on disk — replay paused on an unregistered

--- a/memory/event_log.py
+++ b/memory/event_log.py
@@ -730,6 +730,12 @@ class EventLog:
 
 # ── Reconciler scaffolding (RFC §3.5) ─────────────────────────────────────
 
+# 哨兵冻结之后每扫完一轮就再朝日志末尾探一次，这是探的次数上限。只有「上一轮扫描
+# 期间又有写者落地」才会消耗一次，所以正常启动一次都用不到；给 8 次是为了让写入
+# 停下来的那一刻能收尾，同时不至于在持续写入下让启动永远卡在这里。
+_MAX_FROZEN_RESCANS = 8
+
+
 class Reconciler:
     """Applies event-log tail onto views on startup.
 
@@ -806,8 +812,14 @@ class Reconciler:
             other writer's events to the tail, and one of them without a
             registered handler would wedge every future boot. Nothing needs
             to be written at the end either — the other writer already
-            parked the sentinel at the journal end, which is where this
-            round now stops.
+            parked the sentinel at the journal end.
+            That end is a snapshot, so the frozen pass re-probes for newly
+            appended events every time it drains, up to _MAX_FROZEN_RESCANS
+            times. An event landing after the snapshot is not in the tail,
+            yet the stale payloads queued ahead of it still are: replaying
+            those would push older values over the view it just wrote, and
+            with the sentinel now parked on its id no later boot replays it
+            back.
           - the sentinel write failed (IO). The handler already persisted;
             only the progress marker is behind, so the event replays
             idempotently next boot. Logged as such, not as a handler fault.
@@ -828,8 +840,35 @@ class Reconciler:
         # 一旦发现哨兵已经不归本轮 replay 管，就冻结哨兵，同时把待办重新从日志里
         # 取一遍（见下面 except 分支）：手上这份尾巴已经陈旧，不能照原样应用。
         sentinel_frozen = False
+        # 冻结之后哨兵不再前进，于是「重扫到日志末尾」这句话里的「末尾」是一次快照，
+        # 而写者还在往后追加。快照之后落地的那条事件不在手上这份 tail 里，可它前面
+        # 的陈旧 payload 却还在等着被重放 —— 重放下去就是拿旧值盖掉它刚写好的 view，
+        # 而哨兵此刻停在**它**的 id 上，下次开机 read_since 从它之后开始读，那条事件
+        # 不会被重放回来纠正。丢的不是这一轮的进度，是那个写者的内容，永久性的。
+        # 所以扫完一轮要再朝末尾探一次，直到探不到新东西为止。
+        rescans_left = _MAX_FROZEN_RESCANS
         i = 0
-        while i < len(tail):
+        while True:
+            if i >= len(tail):
+                if not sentinel_frozen:
+                    return applied_count
+                extra = await self._event_log.aread_since(name, expected_sentinel)
+                if not extra:
+                    return applied_count
+                if rescans_left <= 0:
+                    # 写入一直不停时必须有个头，否则这一轮永远收不了尾、启动卡死。
+                    # 停下来是有代价的（剩下那些在哨兵前面，下次开机也不会重放），
+                    # 所以报出来，而不是静悄悄地截断。
+                    logger.warning(
+                        f"[Reconciler] {name}: 哨兵冻结后连续 {_MAX_FROZEN_RESCANS} 轮"
+                        f"都有新事件追加，停止重扫；仍有 {len(extra)} 条未重放且位于"
+                        f"哨兵之前，下次开机不会自动补上"
+                    )
+                    return applied_count
+                rescans_left -= 1
+                tail = extra
+                i = 0
+                continue
             event = tail[i]
             event_type = event.get('type')
             event_id = event.get('event_id')
@@ -906,4 +945,3 @@ class Reconciler:
                     f"保留 sentinel 在上一条位置，下次重试"
                 )
                 return applied_count
-        return applied_count

--- a/memory/event_log.py
+++ b/memory/event_log.py
@@ -139,10 +139,36 @@ SyncSaveView = Callable[[str, object], None]     # (character_name, view_obj) ->
 # change while marking the event as applied.
 #
 # Handlers MUST be synchronous (no async/await) and use the sync IO helpers
-# (atomic_write_json, not its a-twin): Reconciler.areconcile calls them
-# directly without await. An async handler would return a coroutine that
-# never runs, silently breaking reconciliation.
+# (atomic_write_json, not its a-twin): Reconciler.areconcile runs them on a
+# worker thread via EventLog.apply_and_advance, without await. An async
+# handler would return a coroutine that never runs (and would be truthy, so
+# the sentinel would advance over an event that was never applied), silently
+# breaking reconciliation. A handler must also never touch an asyncio
+# primitive (it is off the event loop) nor call back into EventLog: it runs
+# under the per-character lock, which is a plain non-reentrant threading.Lock.
 ApplyHandler = Callable[[str, dict], bool]
+
+
+class SentinelAdvanceError(RuntimeError):
+    """The apply handler already succeeded, but the sentinel could not move.
+
+    Raised only by apply_and_advance, and only after apply_fn returned — so
+    it is never a handler failure and must not be reported as one. On-disk
+    state is "view updated, sentinel not advanced", i.e. the event replays
+    again on the next boot (handlers are idempotent).
+    """
+
+
+class SentinelConflictError(SentinelAdvanceError):
+    """Another writer moved the sentinel while this replay was in flight.
+
+    The replay's view of the sentinel was read before its apply; writing our
+    own event_id now would move the sentinel BACKWARDS over events that the
+    other writer already claimed as applied. Those events would return to the
+    tail, and any of them without a registered handler would then pause replay
+    on every subsequent boot — a permanently stuck reconciler. Refusing the
+    write is the safe branch; the apply itself already happened and stands.
+    """
 
 
 class EventLog:
@@ -301,12 +327,120 @@ class EventLog:
             return None
         return last
 
-    def advance_sentinel(self, name: str, event_id: str | None) -> None:
-        """Persist the new sentinel atomically."""
+    def _write_sentinel_unlocked(self, name: str, event_id: str | None) -> None:
+        """Unconditionally overwrite events_applied.json. Caller holds the lock.
+
+        Unconditional means exactly that: this helper does NOT enforce
+        monotonicity, and cannot. event_id is a uuid4 — two ids carry no
+        order relative to each other; the only ordering that exists is the
+        position in events.ndjson, which this helper never reads. Writers
+        that must not move the sentinel backwards have to establish the
+        ordering themselves (see apply_and_advance's compare-and-set).
+        """
         atomic_write_json(
             self._sentinel_path(name),
             {'last_applied_event_id': event_id, 'ts': datetime.now().isoformat()},
         )
+
+    def advance_sentinel(self, name: str, event_id: str | None) -> None:
+        """Persist the new sentinel atomically, under the per-character lock.
+
+        Sentinel writers must serialise against record_and_save, which
+        rewrites the same file at the tail of its own critical section.
+        Callers that already hold the lock must use _write_sentinel_unlocked
+        instead — threading.Lock is not reentrant.
+
+        Guarantees mutual exclusion only, NOT monotonicity: the write is
+        still unconditional, so a caller holding a stale event_id can move
+        the sentinel backwards. record_and_save is safe because the id it
+        writes is the one it just appended (the newest event by
+        construction); everyone else has to reason about it.
+        """
+        # 这个公开方法在生产里已无调用方（reconcile 走 apply_and_advance，
+        # record_and_save 走 _write_sentinel_unlocked），锁留在这里是为了
+        # 「默认安全」：将来任何新调用点都不会再意外造出一个无锁写者。
+        with self._get_lock(name):
+            self._write_sentinel_unlocked(name, event_id)
+
+    def apply_and_advance(
+        self,
+        name: str,
+        event_id: str | None,
+        apply_fn: Callable[[], bool],
+        *,
+        expected_sentinel: str | None,
+        advance: bool = True,
+    ) -> bool:
+        """Run one replay apply and advance the sentinel in ONE critical section.
+
+        apply_fn is a reconciler apply-handler already bound to its
+        (character, payload); it loads → mutates → persists its own view.
+        expected_sentinel is the sentinel value the replay based its tail
+        on — the previous event's id, or the value read when the round
+        started. advance=False applies without touching the sentinel at all
+        (no compare-and-set either): the caller has already learned the
+        sentinel is no longer theirs to move, but the repairs still have to
+        land. Running the pair here — inside the same per-character lock
+        record_and_save uses, on a worker thread — buys three things:
+
+          1. Once a live writer has entered record_and_save's critical
+             section, its read-modify-write can no longer interleave with
+             the handler's read-modify-write on the same view file. This is
+             a partial guarantee, and the boundary matters: the reflection
+             and persona write paths load their view snapshot BEFORE
+             entering (memory/reflection/evidence_flow.py loads, then hands
+             the snapshot to record_and_save as sync_load_view), so a live
+             writer parked between its own load and its own lock acquisition
+             can still save a pre-replay snapshot over the repair. What keeps
+             that from happening in production is the startup ordering —
+             reconciliation completes before any live writer is resumed (see
+             app/memory_server/runtime.py) — and this lock is the second
+             line of defence, not the first.
+          2. The sentinel write joins the handler in the same critical
+             section: the pair is atomic with respect to other writers, and
+             the sentinel can never advance without the handler's write
+             having landed first.
+          3. The handler's file IO leaves the event loop, which is what
+             makes it eligible for file_utils' busy-retry backoff (that
+             backoff is deliberately disabled on the loop) and stops its
+             fsync from blocking the loop.
+
+        Returns whatever apply_fn returned (True = the view actually
+        changed). Raises:
+          - whatever apply_fn raised, with the sentinel untouched — the
+            caller's pause-and-retry semantics;
+          - SentinelConflictError if the on-disk sentinel is no longer
+            expected_sentinel (someone advanced it while this replay was in
+            flight): the write is refused rather than rolled backwards;
+          - SentinelAdvanceError if the sentinel write itself fails, so the
+            caller can tell an IO problem from a handler problem.
+        """
+        with self._get_lock(name):
+            changed = apply_fn()
+            if not advance:
+                return bool(changed)
+            # 单调性 compare-and-set：event_id 是 uuid4，无法互相比大小，
+            # 「新的哨兵是否更靠后」只能靠「盘上哨兵还是我出发时那个」来判。
+            # 不判就会出现审阅复现的死局：live writer 追加了一条本进程没注册
+            # handler 的事件并把哨兵推过去，重放再把哨兵写回旧 id → 那条事件
+            # 回到尾巴 → 之后每次开机都撞「未注册事件类型，暂停 replay」。
+            current = self.read_sentinel(name)
+            if current != expected_sentinel:
+                raise SentinelConflictError(
+                    f"{name}: sentinel moved to {current!r} while replaying "
+                    f"{event_id!r} (expected {expected_sentinel!r}); refusing "
+                    f"to move it backwards"
+                )
+            try:
+                self._write_sentinel_unlocked(name, event_id)
+            except Exception as e:
+                # handler 已经落盘了，这里失败纯粹是哨兵写的 IO 问题。
+                # 包成专用异常，免得调用方把它记成「handler 失败」。
+                raise SentinelAdvanceError(
+                    f"{name}: apply of {event_id!r} persisted but the sentinel "
+                    f"write failed: {e}"
+                ) from e
+        return bool(changed)
 
     # ── compaction (RFC §3.6) ───────────────────────────────────
 
@@ -475,11 +609,9 @@ class EventLog:
             sync_mutate_view(view)
             sync_save_view(name, view)
             # Inline sentinel write: still under the lock, still on this
-            # worker thread — safe to use atomic_write_json sync.
-            atomic_write_json(
-                self._sentinel_path(name),
-                {'last_applied_event_id': event_id, 'ts': datetime.now().isoformat()},
-            )
+            # worker thread — the unlocked helper, because advance_sentinel
+            # takes the same non-reentrant lock we are already holding.
+            self._write_sentinel_unlocked(name, event_id)
         return event_id
 
     # ── async duals ─────────────────────────────────────────────
@@ -495,6 +627,20 @@ class EventLog:
 
     async def aadvance_sentinel(self, name: str, event_id: str | None) -> None:
         await asyncio.to_thread(self.advance_sentinel, name, event_id)
+
+    async def aapply_and_advance(
+        self,
+        name: str,
+        event_id: str | None,
+        apply_fn: Callable[[], bool],
+        *,
+        expected_sentinel: str | None,
+        advance: bool = True,
+    ) -> bool:
+        return await asyncio.to_thread(
+            self.apply_and_advance, name, event_id, apply_fn,
+            expected_sentinel=expected_sentinel, advance=advance,
+        )
 
     async def ashould_compact(self, name: str) -> bool:
         return await asyncio.to_thread(self.should_compact, name)
@@ -557,6 +703,21 @@ class Reconciler:
         lose the change. Modeled off record_and_save — the per-event-type
         equivalent is per-handler responsibility.
 
+        Concurrency: the primary guarantee is exclusivity, not locking.
+        The only production caller (app/memory_server/runtime.py) awaits
+        this loop to completion BEFORE it resumes the outbox, so no live
+        writer is running while the tail is replayed. That ordering is what
+        closes the loss window, because a live writer that loaded its view
+        snapshot before the replay would otherwise save it back over the
+        repair — with the sentinel already past the event, so no later boot
+        replays it again: silent, permanent loss.
+
+        Underneath, handler-call and sentinel-advance are one critical
+        section (EventLog.apply_and_advance) on the per-character lock that
+        record_and_save uses, on a worker thread. That is defence in depth
+        for the residual window (writers that already read their snapshot)
+        and for any future caller that reconciles outside the startup path.
+
         Failure semantics (intentional): if a handler raises, we STOP the
         whole reconcile loop for this character and leave the sentinel on
         the last successfully-applied event. Rationale — compound
@@ -571,10 +732,29 @@ class Reconciler:
         ALL_EVENT_TYPES check, so an unknown type here means a rollback
         to an older binary — operator must upgrade back or manually
         surgery the log.
+
+        Two things that are NOT handler failures and are handled apart from
+        them, because they leave different state on disk:
+          - the sentinel moved under us (another writer advanced it past
+            what this round assumed). The round keeps applying the rest of
+            the tail — those repairs still belong on disk — but stops
+            touching the sentinel. Writing our older id back would return
+            the other writer's events to the tail, and one of them without a
+            registered handler would wedge every future boot.
+          - the sentinel write failed (IO). The handler already persisted;
+            only the progress marker is behind, so the event replays
+            idempotently next boot. Logged as such, not as a handler fault.
         """
         last_applied = await self._event_log.aread_sentinel(name)
         tail = await self._event_log.aread_since(name, last_applied)
         applied_count = 0
+        # 每条事件推进哨兵时都要 CAS 一次：expected 是「本轮 replay 认为盘上
+        # 哨兵应该处在的位置」，第一条是出发时读到的 last_applied，之后是上一条
+        # 刚写进去的 event_id。对不上说明有别的写者动过哨兵，见 apply_and_advance。
+        expected_sentinel = last_applied
+        # 一旦发现哨兵已经不归本轮 replay 管，就冻结哨兵、继续把剩下的尾巴应用完：
+        # 修复该落盘还是要落盘，只是不再由我们来记录进度。
+        sentinel_frozen = False
         for event in tail:
             event_type = event.get('type')
             event_id = event.get('event_id')
@@ -586,16 +766,44 @@ class Reconciler:
                 )
                 return applied_count
             handler = self._handlers[event_type]
+            payload = event.get('payload') or {}
             try:
                 # Handler自己 load → apply → save，见 ApplyHandler 契约。
-                changed = handler(name, event.get('payload') or {})
+                # 整段（handler + 哨兵推进）交给 apply_and_advance：在
+                # per-character 锁内、worker 线程上跑完，与 record_and_save
+                # 收口成同一个写者。handler 抛出时锁内的哨兵写不会执行，
+                # 异常穿过 to_thread 由下面的 except 接住 —— 失败语义不变。
+                changed = await self._event_log.aapply_and_advance(
+                    name, event_id, lambda: handler(name, payload),
+                    expected_sentinel=expected_sentinel,
+                    advance=not sentinel_frozen,
+                )
                 if changed:
                     applied_count += 1
+                expected_sentinel = event_id
+            except SentinelConflictError as e:
+                # 不是失败：别的写者已经把哨兵推到更靠后的位置了（它写哨兵时
+                # 就等于声称在它之前的都已应用）。这一条的 handler 已经跑完，
+                # 剩下的尾巴照常应用，但从此不再碰哨兵 —— 写回旧 id 会让那个
+                # 写者的事件回到尾巴，其中任何一条没注册 handler 的都会让此后
+                # 每次开机都停在「未注册事件类型」上，该角色再也 reconcile 不了。
+                sentinel_frozen = True
+                logger.warning(
+                    f"[Reconciler] {name}/{event_type}/{event_id}: 哨兵已被其他写者"
+                    f"推进，本轮剩余事件照常应用但不再推进哨兵（不回写旧哨兵）: {e}"
+                )
+            except SentinelAdvanceError as e:
+                # handler 成功、哨兵写失败。归因必须和 handler 失败分开：盘上
+                # 是「view 已改、哨兵没动」，下次开机幂等重放这一条。
+                logger.warning(
+                    f"[Reconciler] {name}/{event_type}/{event_id} 哨兵写入失败"
+                    f"（handler 已成功应用）: {e}；下次开机重放该条"
+                )
+                return applied_count
             except Exception as e:
                 logger.warning(
                     f"[Reconciler] {name}/{event_type}/{event_id} handler 失败: {e}；"
                     f"保留 sentinel 在上一条位置，下次重试"
                 )
                 return applied_count
-            await self._event_log.aadvance_sentinel(name, event_id)
         return applied_count

--- a/memory/event_log.py
+++ b/memory/event_log.py
@@ -159,15 +159,35 @@ class SentinelAdvanceError(RuntimeError):
     """
 
 
-class SentinelConflictError(SentinelAdvanceError):
+class SentinelConflictError(RuntimeError):
     """Another writer moved the sentinel while this replay was in flight.
 
-    The replay's view of the sentinel was read before its apply; writing our
-    own event_id now would move the sentinel BACKWARDS over events that the
-    other writer already claimed as applied. Those events would return to the
-    tail, and any of them without a registered handler would then pause replay
-    on every subsequent boot — a permanently stuck reconciler. Refusing the
-    write is the safe branch; the apply itself already happened and stands.
+    Deliberately NOT a SentinelAdvanceError. That class means "the view is
+    already repaired, only the progress marker is behind"; this one is
+    raised BEFORE apply_fn runs, so nothing was applied and nothing on disk
+    changed. Catching the two together would report a round that has done
+    nothing as a round whose write landed.
+
+    Two facts follow from the conflict, and both matter:
+
+      - Writing our own event_id now would move the sentinel BACKWARDS over
+        events the other writer already claimed as applied. Those events
+        would return to the tail, and any of them without a registered
+        handler would pause replay on every subsequent boot — a permanently
+        stuck reconciler.
+      - The tail this round was holding is now behind the other writer's
+        sentinel. record_and_save writes the id of the line it just
+        appended, i.e. the end of the journal, and does so unconditionally
+        (see its docstring): the events still queued in this round were
+        declared "already applied" by that write even though they were not.
+        Replaying them as-is would push older payloads over the newer
+        writer's values, and the newer event would not be replayed again to
+        correct it.
+
+    The caller's job on this error is therefore not "stop" and not "keep
+    going with the stale list" — it is to re-derive the work from the
+    journal so the newer events are replayed on top, in journal order. See
+    Reconciler.areconcile.
     """
 
 
@@ -377,11 +397,13 @@ class EventLog:
         (character, payload); it loads → mutates → persists its own view.
         expected_sentinel is the sentinel value the replay based its tail
         on — the previous event's id, or the value read when the round
-        started. advance=False applies without touching the sentinel at all
-        (no compare-and-set either): the caller has already learned the
-        sentinel is no longer theirs to move, but the repairs still have to
-        land. Running the pair here — inside the same per-character lock
-        record_and_save uses, on a worker thread — buys three things:
+        started. It is checked against the on-disk sentinel BEFORE apply_fn
+        runs, so a stale event is never applied (see the conflict branch
+        below). advance=False skips both the check and the write: the caller
+        has already learned the sentinel is no longer theirs to move and has
+        re-derived its work list from the journal, so re-checking would only
+        raise again. Running the pair here — inside the same per-character
+        lock record_and_save uses, on a worker thread — buys three things:
 
           1. Once a live writer has entered record_and_save's critical
              section, its read-modify-write can no longer interleave with
@@ -407,30 +429,41 @@ class EventLog:
 
         Returns whatever apply_fn returned (True = the view actually
         changed). Raises:
+          - SentinelConflictError, before apply_fn is called at all, if the
+            on-disk sentinel is no longer expected_sentinel (someone
+            advanced it while this replay was in flight). Nothing is applied
+            and the sentinel is left alone;
           - whatever apply_fn raised, with the sentinel untouched — the
             caller's pause-and-retry semantics;
-          - SentinelConflictError if the on-disk sentinel is no longer
-            expected_sentinel (someone advanced it while this replay was in
-            flight): the write is refused rather than rolled backwards;
           - SentinelAdvanceError if the sentinel write itself fails, so the
             caller can tell an IO problem from a handler problem.
         """
         with self._get_lock(name):
+            if advance:
+                # 单调性 compare-and-set：event_id 是 uuid4，无法互相比大小，
+                # 「新的哨兵是否更靠后」只能靠「盘上哨兵还是我出发时那个」来判。
+                # 不判就会出现审阅复现的死局：live writer 追加了一条本进程没注册
+                # handler 的事件并把哨兵推过去，重放再把哨兵写回旧 id → 那条事件
+                # 回到尾巴 → 之后每次开机都撞「未注册事件类型，暂停 replay」。
+                #
+                # 判定必须排在 apply_fn **之前**。handler 是「读盘 → 改目标条目的
+                # 字段 → 整覆盖」，先跑一遍就已经把这条陈旧事件的字段写进 view 了；
+                # 如果那个更新的写者动过同一条目的同一批字段，就是拿旧值盖新值，
+                # 等 CAS 事后报冲突已经晚了（而且它那条更新的事件在哨兵后面，
+                # 不会再被重放回来纠正）。
+                # 检查和 apply 之间不会被进程内的写者插进来：record_and_save /
+                # compact_if_needed / advance_sentinel 全都要拿这把锁，而这两步
+                # 都在我们已经握住它的这段临界区里。
+                current = self.read_sentinel(name)
+                if current != expected_sentinel:
+                    raise SentinelConflictError(
+                        f"{name}: sentinel moved to {current!r} before replaying "
+                        f"{event_id!r} (expected {expected_sentinel!r}); refusing "
+                        f"to apply a tail the sentinel already passed"
+                    )
             changed = apply_fn()
             if not advance:
                 return bool(changed)
-            # 单调性 compare-and-set：event_id 是 uuid4，无法互相比大小，
-            # 「新的哨兵是否更靠后」只能靠「盘上哨兵还是我出发时那个」来判。
-            # 不判就会出现审阅复现的死局：live writer 追加了一条本进程没注册
-            # handler 的事件并把哨兵推过去，重放再把哨兵写回旧 id → 那条事件
-            # 回到尾巴 → 之后每次开机都撞「未注册事件类型，暂停 replay」。
-            current = self.read_sentinel(name)
-            if current != expected_sentinel:
-                raise SentinelConflictError(
-                    f"{name}: sentinel moved to {current!r} while replaying "
-                    f"{event_id!r} (expected {expected_sentinel!r}); refusing "
-                    f"to move it backwards"
-                )
             try:
                 self._write_sentinel_unlocked(name, event_id)
             except Exception as e:
@@ -595,6 +628,31 @@ class EventLog:
         ALREADY on a worker thread (the _arecord_and_save a-twin hops us
         into one), and using async twins would pointlessly re-schedule
         through asyncio.to_thread and risk event-loop locking anti-patterns.
+
+        KNOWN LIMITATION — the sentinel write is an unconditional claim.
+        The final step writes the sentinel to the id just appended, which
+        by definition is the last line of the journal, so this method can
+        never move the sentinel backwards. What it does not check is
+        whether everything BEFORE that line was applied. Setting the
+        sentinel to the journal end asserts exactly that, and the assertion
+        is false whenever an unapplied tail is still sitting on disk: those
+        events fall behind the sentinel and no later boot replays them.
+        Whoever hits that has lost them silently.
+
+        It is reachable. Replay pauses (and leaves a tail) on an
+        unregistered event type or a raising handler; the very next live
+        write then orphans whatever was left. Startup ordering does not
+        help — this has nothing to do with reconciliation running
+        concurrently.
+
+        Closing it properly means the sentinel can no longer be "an event
+        id": a writer would have to know whether the journal ahead of its
+        own line is drained, which is a full scan on every write, or the
+        sentinel has to become a position/applied-set with an on-disk
+        format migration. Both are RFC-level changes
+        (docs/design/memory-event-log-rfc.md, concurrency section) and are
+        deliberately out of scope here. Do NOT read "the sentinel only ever
+        moves forward" as "no event can be skipped".
         """
         with self._get_lock(name):
             view = sync_load_view(name)
@@ -736,26 +794,43 @@ class Reconciler:
         Two things that are NOT handler failures and are handled apart from
         them, because they leave different state on disk:
           - the sentinel moved under us (another writer advanced it past
-            what this round assumed). The round keeps applying the rest of
-            the tail — those repairs still belong on disk — but stops
-            touching the sentinel. Writing our older id back would return
-            the other writer's events to the tail, and one of them without a
-            registered handler would wedge every future boot.
+            what this round assumed). The tail this round is carrying is
+            now stale: it sits behind that writer's sentinel, and applying
+            it as-is would push older payloads over newer values with no
+            later replay to correct them. So the round re-reads the journal
+            from its own last-applied position through to the END of the
+            file and replays that, in journal order — the queued repairs
+            still land, and the other writer's events land after them, so
+            the newest payload for any given entry wins. The sentinel is
+            frozen from then on: writing our older id back would return the
+            other writer's events to the tail, and one of them without a
+            registered handler would wedge every future boot. Nothing needs
+            to be written at the end either — the other writer already
+            parked the sentinel at the journal end, which is where this
+            round now stops.
           - the sentinel write failed (IO). The handler already persisted;
             only the progress marker is behind, so the event replays
             idempotently next boot. Logged as such, not as a handler fault.
+
+        Re-applying events that were already applied is safe by the same
+        property the whole design leans on elsewhere (read_since falls back
+        to a full replay when the sentinel is missing or compacted away):
+        handlers carry full-snapshot payloads and are idempotent.
         """
         last_applied = await self._event_log.aread_sentinel(name)
         tail = await self._event_log.aread_since(name, last_applied)
         applied_count = 0
-        # 每条事件推进哨兵时都要 CAS 一次：expected 是「本轮 replay 认为盘上
-        # 哨兵应该处在的位置」，第一条是出发时读到的 last_applied，之后是上一条
-        # 刚写进去的 event_id。对不上说明有别的写者动过哨兵，见 apply_and_advance。
+        # 每条事件都要 CAS 一次，而且是在跑 handler **之前**：expected 是「本轮
+        # replay 认为盘上哨兵应该处在的位置」，第一条是出发时读到的 last_applied，
+        # 之后是上一条刚写进去的 event_id。对不上说明有别的写者动过哨兵，这时
+        # 手上的尾巴已经陈旧，一条都不能应用，见 apply_and_advance。
         expected_sentinel = last_applied
-        # 一旦发现哨兵已经不归本轮 replay 管，就冻结哨兵、继续把剩下的尾巴应用完：
-        # 修复该落盘还是要落盘，只是不再由我们来记录进度。
+        # 一旦发现哨兵已经不归本轮 replay 管，就冻结哨兵，同时把待办重新从日志里
+        # 取一遍（见下面 except 分支）：手上这份尾巴已经陈旧，不能照原样应用。
         sentinel_frozen = False
-        for event in tail:
+        i = 0
+        while i < len(tail):
+            event = tail[i]
             event_type = event.get('type')
             event_id = event.get('event_id')
             if event_type not in self._handlers:
@@ -781,17 +856,42 @@ class Reconciler:
                 if changed:
                     applied_count += 1
                 expected_sentinel = event_id
+                i += 1
             except SentinelConflictError as e:
-                # 不是失败：别的写者已经把哨兵推到更靠后的位置了（它写哨兵时
-                # 就等于声称在它之前的都已应用）。这一条的 handler 已经跑完，
-                # 剩下的尾巴照常应用，但从此不再碰哨兵 —— 写回旧 id 会让那个
-                # 写者的事件回到尾巴，其中任何一条没注册 handler 的都会让此后
-                # 每次开机都停在「未注册事件类型」上，该角色再也 reconcile 不了。
+                # 不是失败，而且这一条并没有被应用（冲突判定排在 handler 之前）。
+                # 别的写者已经把哨兵推到更靠后的位置了 —— 它写哨兵时就等于声称
+                # 在它之前的都已应用，而手上这份尾巴恰恰在它后面，所以这份尾巴
+                # 现在是陈旧的：照原样应用会拿旧 payload 盖掉它刚写好的值，而它
+                # 那条更新的事件在哨兵前面，不会再被重放回来纠正。
+                #
+                # 所以不是「停下」也不是「照旧应用」，而是按日志顺序重取待办：
+                # 从本轮自己的已应用位置（expected_sentinel）一直读到文件末尾。
+                # 这样排队的修复照样落盘，那个写者的事件排在它们后面被重放一遍，
+                # 同一条目的最新 payload 最后写入 —— 顺序由日志里的行位置决定，
+                # 正是事件日志本来的语义。重复应用无害：handler 是全量快照赋值、
+                # 幂等，read_since 在哨兵丢失时本来就会全量重放。
+                #
+                # 哨兵从此冻结（advance=False）。写回旧 id 会让那个写者的事件回到
+                # 尾巴，其中任何一条没注册 handler 的都会让此后每次开机都停在
+                # 「未注册事件类型」上，该角色再也 reconcile 不了。收尾也不用补写：
+                # 对方已经把哨兵停在日志末尾，正是本轮重扫的终点。
+                if sentinel_frozen:
+                    # 结构上到不了：冻结之后 advance=False，apply_and_advance
+                    # 不再做 CAS，也就不会再抛这个异常。留一条兜底，免得将来
+                    # 有人改动 advance 的语义时把这里变成死循环。
+                    logger.warning(
+                        f"[Reconciler] {name}/{event_type}/{event_id}: 哨兵冻结后"
+                        f"仍报冲突，停止本轮 replay: {e}"
+                    )
+                    return applied_count
                 sentinel_frozen = True
                 logger.warning(
                     f"[Reconciler] {name}/{event_type}/{event_id}: 哨兵已被其他写者"
-                    f"推进，本轮剩余事件照常应用但不再推进哨兵（不回写旧哨兵）: {e}"
+                    f"推进，手上的尾巴已陈旧；改为从本轮已应用位置重扫到日志末尾并"
+                    f"按日志顺序重放，此后不再推进哨兵: {e}"
                 )
+                tail = await self._event_log.aread_since(name, expected_sentinel)
+                i = 0
             except SentinelAdvanceError as e:
                 # handler 成功、哨兵写失败。归因必须和 handler 失败分开：盘上
                 # 是「view 已改、哨兵没动」，下次开机幂等重放这一条。

--- a/tests/integration/test_reconcile_write_race.py
+++ b/tests/integration/test_reconcile_write_race.py
@@ -1,0 +1,191 @@
+# -*- coding: utf-8 -*-
+"""
+Regression: a crash-repair replayed by the Reconciler must survive a live
+writer that is already inside record_and_save's critical section.
+
+Scope, precisely. Production no longer overlaps the two at all: startup
+awaits reconciliation to completion before it resumes any outbox operation
+(app/memory_server/runtime.py). This file covers the second line of defence
+— the per-character lock — for the residual case where a live writer does
+run concurrently: another caller of areconcile, or a future startup edit
+that reintroduces the overlap.
+
+It does NOT cover the window that the lock cannot close: the reflection and
+persona paths load their whole view snapshot *before* entering the critical
+section, so a writer parked between its own load and its own lock
+acquisition still overwrites a repair that landed in between. Only the
+startup ordering keeps that from happening.
+
+The damage being guarded against is silent and permanent: the reconciler's
+apply-handler rewrites reflections.json, then a live writer saves its own
+stale snapshot back over it. The repair is gone from disk while the
+sentinel has already advanced past the event, so no later boot ever replays
+it again — and not a single exception is raised anywhere.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import threading
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+NAME = "小天"
+_NOW = "2026-04-22T10:00:00"
+
+
+def _mock_cm(tmpdir: str):
+    cm = MagicMock()
+    cm.memory_dir = tmpdir
+    cm.aget_character_data = AsyncMock(return_value=(
+        "主人", "小天", {}, {}, {"human": "主人", "system": "SYS"}, {}, {}, {}, {},
+    ))
+    cm.get_character_data = MagicMock(return_value=(
+        "主人", "小天", {}, {}, {"human": "主人", "system": "SYS"}, {}, {}, {}, {},
+    ))
+    return cm
+
+
+def _boot_real_stack(tmpdir: str):
+    """Same component wiring as memory_server startup (no FastAPI)."""
+    from memory.event_log import EventLog, Reconciler
+    from memory.evidence_handlers import register_evidence_handlers
+    from memory.facts import FactStore
+    from memory.persona import PersonaManager
+    from memory.reflection import ReflectionEngine
+
+    cm = _mock_cm(tmpdir)
+    with patch("memory.event_log.get_config_manager", return_value=cm), \
+         patch("memory.facts.get_config_manager", return_value=cm), \
+         patch("memory.persona.manager.get_config_manager", return_value=cm), \
+         patch("memory.reflection.manager.get_config_manager", return_value=cm):
+        event_log = EventLog()
+        event_log._config_manager = cm
+        fs = FactStore()
+        fs._config_manager = cm
+        pm = PersonaManager(event_log=event_log)
+        pm._config_manager = cm
+        engine = ReflectionEngine(fs, pm, event_log=event_log)
+        engine._config_manager = cm
+        rec = Reconciler(event_log)
+        register_evidence_handlers(rec, pm, engine)
+    return event_log, pm, engine, rec
+
+
+def _seed_two_reflections():
+    return [
+        {"id": "A", "text": "A条", "entity": "master", "status": "pending",
+         "source_fact_ids": ["f1"], "created_at": _NOW, "feedback": None,
+         "next_eligible_at": _NOW, "reinforcement": 0.0, "disputation": 0.0},
+        {"id": "B", "text": "B条", "entity": "master", "status": "pending",
+         "source_fact_ids": ["f2"], "created_at": _NOW, "feedback": None,
+         "next_eligible_at": _NOW, "reinforcement": 0.0, "disputation": 0.0},
+    ]
+
+
+def _read_reflections(tmpdir: str) -> dict[str, dict]:
+    with open(os.path.join(tmpdir, NAME, "reflections.json"), encoding="utf-8") as f:
+        return {r["id"]: r for r in json.load(f)}
+
+
+async def test_replayed_repair_survives_live_writer_inside_critical_section(tmp_path):
+    """Reconciler replay of A must not be clobbered by a live signal on B.
+
+    The interleaving is forced, not raced:
+      1. the reconciler reads its tail (nothing applied yet);
+      2. a live writer then enters record_and_save and parks inside the
+         critical section, mid event-append — its in-memory view snapshot
+         predates the replay and will be written to disk when it resumes;
+      3. only then is the reconciler let go.
+
+    Whoever runs the apply-handler must therefore wait for that critical
+    section to finish, or the handler's write lands in the middle of it
+    and is overwritten seconds later while the sentinel has already moved
+    past the event. Note the writer is parked *after* acquiring the lock:
+    park it one step earlier, between its own view load and the lock, and
+    no lock can save the repair — that case is the startup ordering's job.
+    """
+    from memory.event_log import EVT_REFLECTION_EVIDENCE_UPDATED
+
+    tmpdir = str(tmp_path)
+    ev, _pm, engine, rec = _boot_real_stack(tmpdir)
+    await engine.asave_reflections(NAME, _seed_two_reflections())
+
+    # 尾巴上留一条"append 之后崩在 view save 之前"的事件：A 的
+    # reinforcement 应该是 7.0，但 view 里还是 0.0，哨兵为空。
+    event_id = ev.append(NAME, EVT_REFLECTION_EVIDENCE_UPDATED, {
+        "reflection_id": "A", "reinforcement": 7.0, "disputation": 0.0,
+        "rein_last_signal_at": _NOW, "disp_last_signal_at": None,
+        "sub_zero_days": 0, "user_fact_reinforce_count": 0,
+        "source": "user_confirm",
+    })
+    assert _read_reflections(tmpdir)["A"]["reinforcement"] == 0.0
+
+    tail_read = asyncio.Event()
+    released = asyncio.Event()
+    real_aread_since = ev.aread_since
+
+    async def _paused_aread_since(name, after_event_id):
+        # 尾巴读完（read_since 内部的锁也已释放），停在"还没 apply"的位置，
+        # 把舞台让给 live writer。停顿点在事件循环上，不占任何锁。
+        tail = await real_aread_since(name, after_event_id)
+        tail_read.set()
+        await released.wait()
+        return tail
+
+    parked = threading.Event()
+    real_write_line = ev._write_line_unlocked
+
+    def _parked_write_line(path, line):
+        # 模拟一次慢 fsync：live writer 此刻持有 per-character 锁，事件还没
+        # 落盘、view 更没保存 —— 正是 handler 修复前会挤进去的那段空隙。
+        parked.set()
+        time.sleep(0.4)
+        return real_write_line(path, line)
+
+    pending: list[asyncio.Task] = []
+    with patch.object(ev, "aread_since", _paused_aread_since), \
+            patch.object(ev, "_write_line_unlocked", _parked_write_line):
+        try:
+            reconcile_task = asyncio.create_task(rec.areconcile(NAME))
+            pending.append(reconcile_task)
+            await asyncio.wait_for(tail_read.wait(), timeout=10)
+
+            live_write = asyncio.create_task(
+                engine.aapply_signal(NAME, "B", {"reinforcement": 3.0},
+                                     source="user_confirm"),
+            )
+            pending.append(live_write)
+            entered = await asyncio.to_thread(parked.wait, 10.0)
+            assert entered, "live writer never entered its critical section; 并发前提不成立"
+
+            released.set()
+            await asyncio.wait_for(reconcile_task, timeout=30)
+            assert await asyncio.wait_for(live_write, timeout=30) is True
+        finally:
+            # 断言中途失败也别把协程/线程留在飞：放行卡住的 reconcile，
+            # 再把还没结束的 task 收干净，免得污染后续用例。
+            released.set()
+            for task in pending:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*pending, return_exceptions=True)
+
+    final = _read_reflections(tmpdir)
+    assert final["A"]["reinforcement"] == 7.0, (
+        "replayed crash repair for A was overwritten by the concurrent "
+        "live write — this is the silent permanent data loss"
+    )
+    assert final["B"]["reinforcement"] == 3.0, "live signal on B was lost"
+    # 重放那条事件必须已经越过哨兵 —— 它不会再被重放，所以只要 A 的修复没落盘
+    # 就是永久丢失，而不是"下次开机重试"。哨兵的具体位置由谁最后写决定：live
+    # writer 在临界区里推到了自己那条（在 A 之后），重放侧发现哨兵已被推进就
+    # 冻结不回写，两种情况下 A 都在哨兵之前。
+    remaining = [r.get("event_id") for r in ev.read_since(NAME, ev.read_sentinel(NAME))]
+    assert event_id not in remaining, "A 的事件还在尾巴里，本用例的永久丢失前提不成立"

--- a/tests/integration/test_reconcile_write_race.py
+++ b/tests/integration/test_reconcile_write_race.py
@@ -186,6 +186,7 @@ async def test_replayed_repair_survives_live_writer_inside_critical_section(tmp_
     # 重放那条事件必须已经越过哨兵 —— 它不会再被重放，所以只要 A 的修复没落盘
     # 就是永久丢失，而不是"下次开机重试"。哨兵的具体位置由谁最后写决定：live
     # writer 在临界区里推到了自己那条（在 A 之后），重放侧发现哨兵已被推进就
-    # 冻结不回写，两种情况下 A 都在哨兵之前。
+    # 冻结不回写（改从自己的已应用位置重扫到日志末尾，按日志顺序补完 A 和 B
+    # 那两条），两种情况下 A 都在哨兵之前。
     remaining = [r.get("event_id") for r in ev.read_since(NAME, ev.read_sentinel(NAME))]
     assert event_id not in remaining, "A 的事件还在尾巴里，本用例的永久丢失前提不成立"

--- a/tests/unit/test_event_log.py
+++ b/tests/unit/test_event_log.py
@@ -518,6 +518,238 @@ def test_concurrent_append_during_compact_preserves_events(tmp_path):
     assert len(seed_ids) == 1, f"expected exactly one compact seed, got {seed_ids}"
 
 
+def test_apply_and_advance_does_not_interleave_with_record_and_save(tmp_path):
+    """Replay-apply + sentinel-advance is one critical section, shared with
+    record_and_save's.
+
+    Both sides do read-modify-write on the same view file, so a live writer
+    that starts mid-replay must not slip its own load/mutate/save between the
+    handler's write and the sentinel write (or vice versa) — that is exactly
+    how a replayed crash-repair gets silently overwritten while the sentinel
+    marks it as applied.
+    """
+    import time
+    import threading as real_threading
+    from itertools import groupby
+    from memory.event_log import EVT_FACT_ADDED
+
+    log = _fresh_log(str(tmp_path))
+    timeline: list[tuple[str, str]] = []   # (thread name, step)
+
+    def mark(step: str) -> None:
+        # list.append 在 GIL 下是原子的，两个线程共写一条时间线是安全的
+        timeline.append((real_threading.current_thread().name, step))
+
+    import memory.event_log as event_log_module
+    real_write_json = event_log_module.atomic_write_json
+
+    def tracking_write_json(*args, **kwargs):
+        # 哨兵写是两条路径的最后一步，必须也落在各自的临界区里
+        mark("sentinel")
+        return real_write_json(*args, **kwargs)
+
+    apply_running = real_threading.Event()
+
+    def apply_fn() -> bool:
+        mark("apply_start")
+        apply_running.set()
+        time.sleep(0.3)
+        mark("apply_end")
+        return True
+
+    def load(name):
+        mark("record_load")
+        return {"facts": []}
+
+    def mutate(view):
+        mark("record_mutate")
+
+    def save(name, view):
+        mark("record_save")
+
+    with patch("memory.event_log.atomic_write_json", tracking_write_json):
+        t_apply = real_threading.Thread(
+            target=lambda: log.apply_and_advance(
+                "小天", "evt-replayed", apply_fn, expected_sentinel=None,
+            ),
+            name="APPLY",
+        )
+        t_apply.start()
+        assert apply_running.wait(5.0), "apply handler 5s 内没跑起来，并发前提不成立"
+        t_record = real_threading.Thread(
+            target=lambda: log.record_and_save(
+                "小天", EVT_FACT_ADDED, {"fact_id": "f1"},
+                sync_load_view=load, sync_mutate_view=mutate, sync_save_view=save,
+            ),
+            name="RECORD",
+        )
+        t_record.start()
+        t_apply.join(20.0)
+        t_record.join(20.0)
+
+    assert not t_apply.is_alive() and not t_record.is_alive(), "线程没收干净"
+
+    runs = [name for name, _ in groupby(name for name, _ in timeline)]
+    assert runs == ["APPLY", "RECORD"], f"临界区交错了: {timeline}"
+    assert [s for n, s in timeline if n == "APPLY"] == [
+        "apply_start", "apply_end", "sentinel",
+    ]
+    assert [s for n, s in timeline if n == "RECORD"] == [
+        "record_load", "record_mutate", "record_save", "sentinel",
+    ]
+
+
+def test_apply_and_advance_keeps_sentinel_when_apply_raises(tmp_path):
+    """Sentinel must not move if the apply handler blew up — the caller's
+    pause-and-retry semantics depend on the event staying in the tail."""
+    log = _fresh_log(str(tmp_path))
+    log.advance_sentinel("小天", "evt-previous")
+
+    def boom() -> bool:
+        raise RuntimeError("simulated apply failure")
+
+    with pytest.raises(RuntimeError, match="simulated apply failure"):
+        log.apply_and_advance(
+            "小天", "evt-new", boom, expected_sentinel="evt-previous",
+        )
+
+    assert log.read_sentinel("小天") == "evt-previous"
+
+
+def test_advance_sentinel_does_not_interleave_with_record_and_save(tmp_path):
+    """The public sentinel writer takes the same per-character lock.
+
+    Twin of the apply_and_advance interleaving test. advance_sentinel has no
+    production caller today, so nothing else would notice if the lock were
+    dropped — yet it rewrites the very file record_and_save rewrites at the
+    tail of its own critical section, and a torn/overtaken sentinel write is
+    how replayed events get lost or re-applied forever.
+    """
+    import time
+    import threading as real_threading
+    from memory.event_log import EVT_FACT_ADDED
+
+    log = _fresh_log(str(tmp_path))
+    timeline: list[tuple[str, str]] = []
+
+    def mark(step: str) -> None:
+        timeline.append((real_threading.current_thread().name, step))
+
+    import memory.event_log as event_log_module
+    real_write_json = event_log_module.atomic_write_json
+
+    def tracking_write_json(*args, **kwargs):
+        mark("sentinel")
+        return real_write_json(*args, **kwargs)
+
+    record_inside = real_threading.Event()
+
+    def load(name):
+        mark("record_load")
+        record_inside.set()
+        # 临界区故意撑开 0.3s：无锁的 advance_sentinel 会在这段里插进来
+        time.sleep(0.3)
+        return {"facts": []}
+
+    def mutate(view):
+        mark("record_mutate")
+
+    def save(name, view):
+        mark("record_save")
+
+    def _advance():
+        mark("advance_enter")
+        log.advance_sentinel("小天", "evt-from-other-writer")
+
+    with patch("memory.event_log.atomic_write_json", tracking_write_json):
+        t_record = real_threading.Thread(
+            target=lambda: log.record_and_save(
+                "小天", EVT_FACT_ADDED, {"fact_id": "f1"},
+                sync_load_view=load, sync_mutate_view=mutate, sync_save_view=save,
+            ),
+            name="RECORD",
+        )
+        t_record.start()
+        assert record_inside.wait(5.0), "record_and_save 5s 内没进临界区，并发前提不成立"
+        t_advance = real_threading.Thread(target=_advance, name="ADVANCE")
+        t_advance.start()
+        t_record.join(20.0)
+        t_advance.join(20.0)
+
+    assert not t_record.is_alive() and not t_advance.is_alive(), "线程没收干净"
+
+    # 非空过证明：ADVANCE 确实是在 RECORD 还没写完 view 的时候就开跑了
+    assert timeline.index(("ADVANCE", "advance_enter")) < \
+        timeline.index(("RECORD", "record_save")), \
+        f"ADVANCE 没赶在 RECORD 临界区里启动，测试是空过的: {timeline}"
+    # 互斥证明：它的哨兵写仍然排在 RECORD 自己的哨兵写之后
+    record_sentinel = [i for i, e in enumerate(timeline) if e == ("RECORD", "sentinel")]
+    advance_sentinel = [i for i, e in enumerate(timeline) if e == ("ADVANCE", "sentinel")]
+    assert len(record_sentinel) == 1 and len(advance_sentinel) == 1, f"哨兵写次数不对: {timeline}"
+    assert advance_sentinel[0] > record_sentinel[0], \
+        f"advance_sentinel 插进了 record_and_save 的临界区: {timeline}"
+    assert log.read_sentinel("小天") == "evt-from-other-writer"
+
+
+def test_apply_and_advance_refuses_to_move_the_sentinel_backwards(tmp_path):
+    """A replay must never overwrite a sentinel that someone else moved.
+
+    event_id is a uuid4, so "is the new id newer" cannot be answered by
+    comparing ids; the replay carries the sentinel value it started from and
+    the write is a compare-and-set against it. Rolling backwards would return
+    the other writer's events to the tail, and any of them without a
+    registered handler would then pause replay on every future boot.
+    """
+    from memory.event_log import SentinelConflictError
+
+    log = _fresh_log(str(tmp_path))
+    log.advance_sentinel("小天", "evt-live-writer")
+
+    applied = {"n": 0}
+
+    def apply_fn() -> bool:
+        applied["n"] += 1
+        return True
+
+    with pytest.raises(SentinelConflictError):
+        log.apply_and_advance(
+            "小天", "evt-replayed", apply_fn, expected_sentinel="evt-stale",
+        )
+
+    assert applied["n"] == 1, "冲突判定必须在 handler 之后（handler 是幂等的，白跑无害）"
+    assert log.read_sentinel("小天") == "evt-live-writer", "哨兵被写回了旧位置"
+
+
+def test_apply_and_advance_reports_sentinel_write_failure_separately(tmp_path):
+    """A failed sentinel write is not a failed handler.
+
+    The handler already persisted its view; only the sentinel is behind. The
+    caller has to be able to tell the two apart, because they mean different
+    things on disk and get different log lines.
+    """
+    from memory.event_log import SentinelAdvanceError
+
+    log = _fresh_log(str(tmp_path))
+    applied = {"n": 0}
+
+    def apply_fn() -> bool:
+        applied["n"] += 1
+        return True
+
+    def boom_write(*args, **kwargs):
+        raise OSError(13, "simulated sentinel write failure")
+
+    with patch("memory.event_log.atomic_write_json", boom_write):
+        with pytest.raises(SentinelAdvanceError) as excinfo:
+            log.apply_and_advance(
+                "小天", "evt-replayed", apply_fn, expected_sentinel=None,
+            )
+
+    assert applied["n"] == 1
+    assert isinstance(excinfo.value.__cause__, OSError)
+    assert log.read_sentinel("小天") is None
+
+
 # ── Reconciler scaffolding ──────────────────────────────────────────
 
 
@@ -605,6 +837,136 @@ async def test_reconciler_handler_exception_preserves_sentinel(tmp_path):
     assert applied == 1
     # Sentinel is advanced only past the successful event
     assert log.read_sentinel("小天") == eid1
+
+
+@pytest.mark.asyncio
+async def test_reconciler_runs_handlers_off_the_loop_under_the_lock(tmp_path):
+    """Apply handlers must run on a worker thread, inside the per-character lock.
+
+    Both properties are load-bearing and neither is visible from the outside:
+      - off the event loop, because handlers do blocking file IO (and
+        file_utils' busy-retry backoff is deliberately disabled on the loop);
+      - under the lock that record_and_save uses, because the handler and the
+        sentinel write have to be one critical section against live writers.
+    Asserted from inside the handler, so moving the call back onto the loop —
+    or out of the lock — fails here rather than only in the integration suite
+    that CI does not run.
+    """
+    import asyncio as real_asyncio
+    import threading as real_threading
+    from memory.event_log import EVT_FACT_ADDED
+
+    log, rec = _fresh_reconciler(str(tmp_path))
+    eid = log.append("小天", EVT_FACT_ADDED, {"fact_id": "f1"})
+    seen: dict[str, object] = {}
+
+    def handler(name, payload):
+        seen["thread"] = real_threading.current_thread()
+        seen["lock_held"] = log._get_lock(name).locked()
+        try:
+            real_asyncio.get_running_loop()
+        except RuntimeError:
+            seen["on_loop"] = False
+        else:
+            seen["on_loop"] = True
+        return True
+
+    rec.register(EVT_FACT_ADDED, handler)
+    assert await rec.areconcile("小天") == 1
+
+    assert seen["on_loop"] is False, "handler 跑在事件循环上（阻塞 IO + 退避失效）"
+    assert seen["thread"] is not real_threading.main_thread(), \
+        "handler 跑在主线程上，说明没经过 to_thread"
+    assert seen["lock_held"] is True, "handler 没在 per-character 锁内跑"
+    assert log.read_sentinel("小天") == eid
+
+
+@pytest.mark.asyncio
+async def test_reconciler_freezes_instead_of_rewinding_a_moved_sentinel(tmp_path):
+    """Regression: a rewound sentinel can wedge a character's replay forever.
+
+    The reconciler reads its tail, then a live writer appends an event this
+    binary has no handler for and advances the sentinel onto it. Writing our
+    own (older) event_id back would put that event into the tail again, and
+    every future boot would stop on "unregistered event type" before applying
+    anything — the character never reconciles again.
+
+    Freezing, not aborting: the rest of the tail is still applied. Those are
+    crash repairs, and the sentinel is now ahead of them, so skipping them
+    would lose them for good.
+    """
+    from memory.event_log import EVT_FACT_ADDED, EVT_FACT_ABSORBED
+
+    log, rec = _fresh_reconciler(str(tmp_path))
+    eid1 = log.append("小天", EVT_FACT_ADDED, {"fact_id": "f1"})
+    log.append("小天", EVT_FACT_ADDED, {"fact_id": "f2"})
+
+    live_event_id: dict[str, str] = {}
+    real_aread_since = log.aread_since
+
+    async def _tail_then_live_write(name, after_event_id):
+        # 读完尾巴之后、apply 之前插一个 live writer：追加一条本进程没注册
+        # handler 的事件并把哨兵推过去（record_and_save 的收尾就是这两步）。
+        tail = await real_aread_since(name, after_event_id)
+        live_event_id["id"] = log.append(name, EVT_FACT_ABSORBED, {"fact_id": "f9"})
+        log.advance_sentinel(name, live_event_id["id"])
+        return tail
+
+    applied_calls: list[str] = []
+
+    def handler(name, payload):
+        applied_calls.append(payload.get("fact_id"))
+        return True
+
+    rec.register(EVT_FACT_ADDED, handler)
+
+    with patch.object(log, "aread_since", _tail_then_live_write):
+        await rec.areconcile("小天")
+
+    assert applied_calls == ["f1", "f2"], \
+        "尾巴剩下的修复也必须落盘（哨兵已经越过它们，跳过就是丢）"
+    assert log.read_sentinel("小天") == live_event_id["id"], \
+        f"哨兵被写回旧位置（{eid1} 那一带），没 handler 的事件会回到尾巴卡死后续 replay"
+    # 卡死判据：尾巴必须是空的，否则下一次开机会撞未注册事件类型并原地不动。
+    assert log.read_since("小天", log.read_sentinel("小天")) == []
+    assert await rec.areconcile("小天") == 0
+
+
+@pytest.mark.asyncio
+async def test_reconciler_blames_the_sentinel_write_not_the_handler(tmp_path):
+    """A sentinel write failure must not be logged as a handler failure.
+
+    On disk the two are different states — "view unchanged, retry next boot"
+    versus "view already repaired, only the sentinel is behind" — and the
+    warning is the only signal an operator gets.
+    """
+    import memory.event_log as event_log_module
+    from memory.event_log import EVT_FACT_ADDED
+
+    log, rec = _fresh_reconciler(str(tmp_path))
+    log.append("小天", EVT_FACT_ADDED, {"fact_id": "f1"})
+
+    handler_calls = {"n": 0}
+
+    def handler(name, payload):
+        handler_calls["n"] += 1
+        return True
+
+    rec.register(EVT_FACT_ADDED, handler)
+
+    def boom_write(*args, **kwargs):
+        raise OSError(13, "simulated sentinel write failure")
+
+    with patch("memory.event_log.atomic_write_json", boom_write), \
+            patch.object(event_log_module.logger, "warning") as warn:
+        applied = await rec.areconcile("小天")
+
+    assert applied == 0
+    assert handler_calls["n"] == 1, "handler 本身是成功跑完的"
+    messages = [str(c.args[0]) for c in warn.call_args_list]
+    assert len(messages) == 1, f"该只有一条告警: {messages}"
+    assert "哨兵写入失败" in messages[0], f"归因错了: {messages[0]}"
+    assert "handler 失败" not in messages[0], f"哨兵 IO 失败被记成 handler 失败: {messages[0]}"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_event_log.py
+++ b/tests/unit/test_event_log.py
@@ -691,17 +691,61 @@ def test_advance_sentinel_does_not_interleave_with_record_and_save(tmp_path):
     assert log.read_sentinel("小天") == "evt-from-other-writer"
 
 
-def test_apply_and_advance_refuses_to_move_the_sentinel_backwards(tmp_path):
-    """A replay must never overwrite a sentinel that someone else moved.
+def test_apply_and_advance_detects_the_conflict_before_running_the_handler(tmp_path):
+    """A replay must not APPLY an event the sentinel has already passed.
 
-    event_id is a uuid4, so "is the new id newer" cannot be answered by
-    comparing ids; the replay carries the sentinel value it started from and
-    the write is a compare-and-set against it. Rolling backwards would return
-    the other writer's events to the tail, and any of them without a
-    registered handler would then pause replay on every future boot.
+    The compare-and-set is against the sentinel value this round started
+    from (event_id is a uuid4, so "which id is newer" cannot be answered by
+    comparing ids). It has to run BEFORE the handler, not after. Handlers
+    load the view and assign full-snapshot fields onto the target entry, so
+    running one first has already written the stale payload — and the newer
+    writer's event sits ahead of the sentinel, where no later boot replays
+    it back over the top. Detecting afterwards only reports damage that has
+    already been done.
+
+    Nothing can move the sentinel between the check and the apply either:
+    record_and_save, compact_if_needed and advance_sentinel all take the
+    per-character lock, which this method holds across both steps.
+
+    Refusing the sentinel write matters for a second reason: rolling it
+    backwards would return the other writer's events to the tail, and any
+    of them without a registered handler would pause replay on every
+    future boot.
     """
     from memory.event_log import SentinelConflictError
 
+    log = _fresh_log(str(tmp_path))
+    log.advance_sentinel("小天", "evt-live-writer")
+
+    # 更新的写者刚写好的值；陈旧事件的 payload 会把它打回 archived
+    view = {"status": "promoted"}
+    applied = {"n": 0}
+
+    def apply_fn() -> bool:
+        applied["n"] += 1
+        view["status"] = "archived"
+        return True
+
+    with pytest.raises(SentinelConflictError):
+        log.apply_and_advance(
+            "小天", "evt-replayed", apply_fn, expected_sentinel="evt-stale",
+        )
+
+    assert applied["n"] == 0, "冲突判定跑在 handler 之后了"
+    assert view == {"status": "promoted"}, \
+        "陈旧事件已经落进 view，把更新的写者刚写好的值盖掉了"
+    assert log.read_sentinel("小天") == "evt-live-writer", "哨兵被写回了旧位置"
+
+
+def test_apply_and_advance_without_advance_neither_checks_nor_writes(tmp_path):
+    """The frozen-sentinel mode used by the post-conflict rescan.
+
+    Once a round knows the sentinel is not its to move, it re-derives its
+    work from the journal and replays it with advance=False. That mode must
+    skip the compare-and-set too — the sentinel deliberately no longer
+    matches what this round started from, so still checking would raise on
+    every remaining event and the repairs would never land.
+    """
     log = _fresh_log(str(tmp_path))
     log.advance_sentinel("小天", "evt-live-writer")
 
@@ -711,13 +755,14 @@ def test_apply_and_advance_refuses_to_move_the_sentinel_backwards(tmp_path):
         applied["n"] += 1
         return True
 
-    with pytest.raises(SentinelConflictError):
-        log.apply_and_advance(
-            "小天", "evt-replayed", apply_fn, expected_sentinel="evt-stale",
-        )
+    changed = log.apply_and_advance(
+        "小天", "evt-replayed", apply_fn,
+        expected_sentinel="evt-stale", advance=False,
+    )
 
-    assert applied["n"] == 1, "冲突判定必须在 handler 之后（handler 是幂等的，白跑无害）"
-    assert log.read_sentinel("小天") == "evt-live-writer", "哨兵被写回了旧位置"
+    assert changed is True
+    assert applied["n"] == 1, "冻结模式下 handler 必须照跑，否则修复永远落不了盘"
+    assert log.read_sentinel("小天") == "evt-live-writer", "冻结模式动了哨兵"
 
 
 def test_apply_and_advance_reports_sentinel_write_failure_separately(tmp_path):
@@ -882,7 +927,116 @@ async def test_reconciler_runs_handlers_off_the_loop_under_the_lock(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_reconciler_freezes_instead_of_rewinding_a_moved_sentinel(tmp_path):
+async def test_reconciler_rescans_in_journal_order_after_a_sentinel_conflict(tmp_path):
+    """Main regression for the conflict branch. Rules out both wrong answers.
+
+    Setup: a crash left two unapplied events (r1 and r2 get "repair"). The
+    reconciler reads that tail, and only then a live writer commits through
+    record_and_save — it writes r2="live" from its pre-replay snapshot and
+    claims the sentinel for its own event, which is the last line of the
+    journal. Everything the reconciler is still holding is now behind that
+    sentinel.
+
+    Neither obvious branch is acceptable:
+      - keep applying the list we hold: r2 is rolled back from "live" to
+        "repair", and the live event is ahead of the frozen sentinel, so no
+        later boot ever corrects it. Silent, permanent regression of state
+        the user just produced;
+      - stop the round: r1's repair is dropped, and it is behind the
+        sentinel too, so it is equally unreplayable. Silent, permanent loss
+        of a crash repair.
+
+    The round instead re-reads from its own last-applied position to the end
+    of the journal and replays that in journal order, so both survive: the
+    repair lands, and the live event replays on top of the stale one that
+    collides with it. Handler order is asserted because that IS the
+    mechanism — last write wins by journal position.
+    """
+    from memory.event_log import EVT_REFLECTION_STATE_CHANGED
+
+    log, rec = _fresh_reconciler(str(tmp_path))
+    view_path = os.path.join(str(tmp_path), "小天", "view.json")
+    os.makedirs(os.path.dirname(view_path), exist_ok=True)
+
+    def _write_view(data: dict) -> None:
+        with open(view_path, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+    def _read_view() -> dict:
+        with open(view_path, encoding="utf-8") as f:
+            return json.load(f)
+
+    _write_view({"r1": "old", "r2": "old"})
+
+    # 崩溃遗留的尾巴：两条都没应用进 view
+    log.append("小天", EVT_REFLECTION_STATE_CHANGED, {"rid": "r1", "to": "repair"})
+    log.append("小天", EVT_REFLECTION_STATE_CHANGED, {"rid": "r2", "to": "repair"})
+
+    applied_calls: list[tuple[str, str]] = []
+
+    def handler(name, payload):
+        # 与 make_reflection_evidence_handler 同形：读盘 → 改目标条目 → 写回
+        applied_calls.append((payload["rid"], payload["to"]))
+        data = _read_view()
+        if data.get(payload["rid"]) == payload["to"]:
+            return False
+        data[payload["rid"]] = payload["to"]
+        _write_view(data)
+        return True
+
+    rec.register(EVT_REFLECTION_STATE_CHANGED, handler)
+
+    live_event_id: dict[str, str] = {}
+    real_aread_since = log.aread_since
+    live_write_done = {"yes": False}
+
+    async def _tail_then_live_write(name, after_event_id):
+        tail = await real_aread_since(name, after_event_id)
+        if live_write_done["yes"]:
+            # 重扫时不再插第二次写：本用例要的是「一次 live 写 + 一次重扫」
+            return tail
+        live_write_done["yes"] = True
+        # 真 record_and_save：view 用的是重放之前那份快照（r1 还是 old），
+        # 收尾无条件把哨兵推到自己这条（日志最后一行）。
+        live_event_id["id"] = log.record_and_save(
+            name, EVT_REFLECTION_STATE_CHANGED, {"rid": "r2", "to": "live"},
+            sync_load_view=lambda n: {"r1": "old", "r2": "live"},
+            sync_mutate_view=lambda v: None,
+            sync_save_view=lambda n, v: _write_view(v),
+        )
+        return tail
+
+    from memory import event_log as event_log_module
+
+    with patch.object(log, "aread_since", _tail_then_live_write), \
+            patch.object(event_log_module.logger, "warning") as warn:
+        await rec.areconcile("小天")
+
+    # 归因：冲突是「待办陈旧、改为重扫」，不是「handler 失败」也不是「哨兵写
+    # 失败（view 已修好）」—— 后两句会让运维以为盘上是完全不同的状态。
+    messages = [str(c.args[0]) for c in warn.call_args_list]
+    assert len(messages) == 1, f"该只有一条告警: {messages}"
+    assert "重扫" in messages[0], f"归因错了: {messages[0]}"
+    assert "handler 失败" not in messages[0] and "哨兵写入失败" not in messages[0], \
+        f"冲突被记成了 handler / 哨兵 IO 失败: {messages[0]}"
+
+    final = _read_view()
+    assert final["r2"] == "live", (
+        "陈旧的 r2 事件盖掉了 live writer 刚写好的值 —— 它那条事件在哨兵前面，"
+        "不会再被重放回来纠正，是静默永久回退"
+    )
+    assert final["r1"] == "repair", (
+        "尾巴上的修复被丢掉了 —— 哨兵已经越过它，之后任何一次开机都不会再重放"
+    )
+    # 机制断言：重扫后按日志顺序重放，live 那条排在与它冲突的陈旧事件之后。
+    assert applied_calls == [
+        ("r1", "repair"), ("r2", "repair"), ("r2", "live"),
+    ], f"重放顺序不是日志顺序: {applied_calls}"
+    assert log.read_sentinel("小天") == live_event_id["id"], "哨兵被写回了旧位置"
+
+
+@pytest.mark.asyncio
+async def test_reconciler_never_rewinds_a_sentinel_onto_an_unhandled_event(tmp_path):
     """Regression: a rewound sentinel can wedge a character's replay forever.
 
     The reconciler reads its tail, then a live writer appends an event this
@@ -891,9 +1045,9 @@ async def test_reconciler_freezes_instead_of_rewinding_a_moved_sentinel(tmp_path
     every future boot would stop on "unregistered event type" before applying
     anything — the character never reconciles again.
 
-    Freezing, not aborting: the rest of the tail is still applied. Those are
-    crash repairs, and the sentinel is now ahead of them, so skipping them
-    would lose them for good.
+    The post-conflict rescan reaches that unhandled event too and pauses on
+    it, which is the normal forward-compat behaviour. What must not happen is
+    the sentinel moving back in front of it.
     """
     from memory.event_log import EVT_FACT_ADDED, EVT_FACT_ABSORBED
 
@@ -908,8 +1062,9 @@ async def test_reconciler_freezes_instead_of_rewinding_a_moved_sentinel(tmp_path
         # 读完尾巴之后、apply 之前插一个 live writer：追加一条本进程没注册
         # handler 的事件并把哨兵推过去（record_and_save 的收尾就是这两步）。
         tail = await real_aread_since(name, after_event_id)
-        live_event_id["id"] = log.append(name, EVT_FACT_ABSORBED, {"fact_id": "f9"})
-        log.advance_sentinel(name, live_event_id["id"])
+        if "id" not in live_event_id:
+            live_event_id["id"] = log.append(name, EVT_FACT_ABSORBED, {"fact_id": "f9"})
+            log.advance_sentinel(name, live_event_id["id"])
         return tail
 
     applied_calls: list[str] = []

--- a/tests/unit/test_event_log.py
+++ b/tests/unit/test_event_log.py
@@ -1036,6 +1036,143 @@ async def test_reconciler_rescans_in_journal_order_after_a_sentinel_conflict(tmp
 
 
 @pytest.mark.asyncio
+async def test_frozen_rescan_picks_up_events_that_land_after_its_snapshot(tmp_path):
+    """A writer arriving after the rescan's snapshot must not be overwritten."""
+    # 上一条用例钉的是「冲突之后改为重扫」。这条钉的是重扫本身的边界：它读到的
+    # 「日志末尾」是一次快照，而写者还在往后追加。
+    #
+    # 时序（每一步都由 patch 掉的 aread_since 精确制造）：
+    #   1. 崩溃遗留 r1/r2/r3 三条 repair 没应用；
+    #   2. reconciler 读初始尾巴时，写者 A 提交 r2="live" 并把哨兵抢到自己那条
+    #      → 第一次 CAS 就冲突，哨兵冻结、改为重扫；
+    #   3. **重扫取快照的那一刻**，写者 B 提交 r3="live2"，它的事件排在快照之后；
+    #   4. 快照里排在前面的陈旧 e3（r3="repair"）被重放，把 B 刚写好的值盖掉。
+    #
+    # 此时哨兵停在 B 那条上，下次开机 read_since 从它**之后**开始读，B 的事件
+    # 不会被重放回来纠正 —— 丢的不是这一轮的进度，是用户刚产生的内容，永久性的。
+    # 所以扫完一轮必须再朝末尾探一次，直到探不到新东西。
+    from memory.event_log import EVT_REFLECTION_STATE_CHANGED
+
+    log, rec = _fresh_reconciler(str(tmp_path))
+    view_path = os.path.join(str(tmp_path), "小天", "view.json")
+    os.makedirs(os.path.dirname(view_path), exist_ok=True)
+
+    def _write_view(data: dict) -> None:
+        with open(view_path, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+    def _read_view() -> dict:
+        with open(view_path, encoding="utf-8") as f:
+            return json.load(f)
+
+    _write_view({"r1": "old", "r2": "old", "r3": "old"})
+    for rid in ("r1", "r2", "r3"):
+        log.append("小天", EVT_REFLECTION_STATE_CHANGED, {"rid": rid, "to": "repair"})
+
+    applied_calls: list[tuple[str, str]] = []
+
+    def handler(name, payload):
+        applied_calls.append((payload["rid"], payload["to"]))
+        data = _read_view()
+        if data.get(payload["rid"]) == payload["to"]:
+            return False
+        data[payload["rid"]] = payload["to"]
+        _write_view(data)
+        return True
+
+    rec.register(EVT_REFLECTION_STATE_CHANGED, handler)
+
+    real_aread_since = log.aread_since
+    written: dict[str, str] = {}
+    # 只在前两次读之后各插一个写者：第 1 次制造冲突，第 2 次（重扫取快照）制造
+    # 「快照之后才落地」。之后的探测读不再插，否则这一轮永远收不了尾。
+    pending_writers = [("A", "r2", "live"), ("B", "r3", "live2")]
+
+    async def _tail_then_writer(name, after_event_id):
+        # 先取尾巴再写：返回的这份**不含**紧接着落地的那条，正是要复现的形状。
+        tail = await real_aread_since(name, after_event_id)
+        if pending_writers:
+            who, rid, to = pending_writers.pop(0)
+            snapshot = _read_view()
+            snapshot[rid] = to
+            written[who] = log.record_and_save(
+                name, EVT_REFLECTION_STATE_CHANGED, {"rid": rid, "to": to},
+                sync_load_view=lambda n, s=snapshot: dict(s),
+                sync_mutate_view=lambda v: None,
+                sync_save_view=lambda n, v: _write_view(v),
+            )
+        return tail
+
+    with patch.object(log, "aread_since", _tail_then_writer):
+        await rec.areconcile("小天")
+
+    final = _read_view()
+    assert final["r3"] == "live2", (
+        "写者 B 的事件在重扫取完快照之后才落地，快照里排在它前面的陈旧事件把它"
+        "盖掉了；而哨兵此刻停在 B 那条上，下次开机不会重放它 —— 静默永久丢失"
+    )
+    assert final["r2"] == "live", "写者 A 的值也不许被陈旧事件盖掉"
+    assert final["r1"] == "repair", "崩溃遗留的修复不许被丢"
+    # 机制断言：B 那条是在快照重放**之后**补扫回来的，不是碰巧混在中间。
+    assert applied_calls == [
+        ("r1", "repair"), ("r2", "repair"), ("r3", "repair"),
+        ("r2", "live"), ("r3", "live2"),
+    ], f"重放顺序不对: {applied_calls}"
+    assert log.read_sentinel("小天") == written["B"], "哨兵被写回了旧位置"
+
+
+@pytest.mark.asyncio
+async def test_frozen_rescan_stops_after_a_bounded_number_of_probes(tmp_path):
+    """Endless appends must end the round loudly, not spin the boot forever."""
+    # 补扫是「探到没有新东西为止」，那就必须有个头：写入一直不停时启动不能卡死。
+    # 停下来是有代价的（剩下那些位于哨兵之前，下次开机也不会自动补上），所以这条
+    # 同时钉住「必须报出来」——静悄悄地截断会让人以为 reconcile 干净地跑完了。
+    import asyncio
+
+    from memory.event_log import EVT_REFLECTION_STATE_CHANGED
+    from memory import event_log as event_log_module
+
+    log, rec = _fresh_reconciler(str(tmp_path))
+    view_path = os.path.join(str(tmp_path), "小天", "view.json")
+    os.makedirs(os.path.dirname(view_path), exist_ok=True)
+
+    def _write_view(data: dict) -> None:
+        with open(view_path, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+    _write_view({})
+    log.append("小天", EVT_REFLECTION_STATE_CHANGED, {"rid": "r0", "to": "repair"})
+    rec.register(EVT_REFLECTION_STATE_CHANGED, lambda name, payload: True)
+
+    real_aread_since = log.aread_since
+    reads = {"n": 0}
+
+    async def _tail_then_endless_writer(name, after_event_id):
+        tail = await real_aread_since(name, after_event_id)
+        reads["n"] += 1
+        # 每一次读之后都追加，永不停歇。
+        log.record_and_save(
+            name, EVT_REFLECTION_STATE_CHANGED, {"rid": f"w{reads['n']}", "to": "live"},
+            sync_load_view=lambda n: {},
+            sync_mutate_view=lambda v: None,
+            sync_save_view=lambda n, v: _write_view(v),
+        )
+        return tail
+
+    with patch.object(log, "aread_since", _tail_then_endless_writer), \
+            patch.object(event_log_module.logger, "warning") as warn:
+        await asyncio.wait_for(rec.areconcile("小天"), timeout=20)
+
+    assert reads["n"] <= event_log_module._MAX_FROZEN_RESCANS + 3, (
+        f"补扫没有上界，读了 {reads['n']} 次"
+    )
+    messages = [str(c.args[0]) for c in warn.call_args_list]
+    assert any("停止重扫" in m and "不会自动补上" in m for m in messages), (
+        f"截断了却没报出来: {messages}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_reconciler_never_rewinds_a_sentinel_onto_an_unhandled_event(tmp_path):
     """Regression: a rewound sentinel can wedge a character's replay forever.
 

--- a/tests/unit/test_event_log.py
+++ b/tests/unit/test_event_log.py
@@ -540,7 +540,7 @@ def test_apply_and_advance_does_not_interleave_with_record_and_save(tmp_path):
         # list.append 在 GIL 下是原子的，两个线程共写一条时间线是安全的
         timeline.append((real_threading.current_thread().name, step))
 
-    import memory.event_log as event_log_module
+    from memory import event_log as event_log_module
     real_write_json = event_log_module.atomic_write_json
 
     def tracking_write_json(*args, **kwargs):
@@ -635,7 +635,7 @@ def test_advance_sentinel_does_not_interleave_with_record_and_save(tmp_path):
     def mark(step: str) -> None:
         timeline.append((real_threading.current_thread().name, step))
 
-    import memory.event_log as event_log_module
+    from memory import event_log as event_log_module
     real_write_json = event_log_module.atomic_write_json
 
     def tracking_write_json(*args, **kwargs):
@@ -940,7 +940,7 @@ async def test_reconciler_blames_the_sentinel_write_not_the_handler(tmp_path):
     versus "view already repaired, only the sentinel is behind" — and the
     warning is the only signal an operator gets.
     """
-    import memory.event_log as event_log_module
+    from memory import event_log as event_log_module
     from memory.event_log import EVT_FACT_ADDED
 
     log, rec = _fresh_reconciler(str(tmp_path))

--- a/tests/unit/test_outbox_wiring.py
+++ b/tests/unit/test_outbox_wiring.py
@@ -419,3 +419,91 @@ async def test_append_pending_failure_falls_back_to_in_memory(tmp_path):
     noop.assert_called_once()
     # 没有 pending 记录产生（写盘本来就失败了）
     assert not os.path.exists(ob._outbox_path("小天"))
+
+
+# ── startup ordering: reconcile must finish before the outbox is resumed ──
+
+
+def _startup_function_ast():
+    """AST of ensure_memory_server_runtime_initialized (the startup sequencer)."""
+    import ast
+    import pathlib
+
+    source = (pathlib.Path(__file__).resolve().parents[2]
+              / 'app' / 'memory_server' / 'runtime.py')
+    tree = ast.parse(source.read_text(encoding='utf-8'))
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.AsyncFunctionDef)
+                and node.name == 'ensure_memory_server_runtime_initialized'):
+            return ast, node
+    raise AssertionError('未找到 ensure_memory_server_runtime_initialized，断言失效')
+
+
+def _calls_named(ast, node, name):
+    return [c for c in ast.walk(node)
+            if isinstance(c, ast.Call) and getattr(c.func, 'attr', None) == name]
+
+
+def _reconcile_gathers(ast, node):
+    """gather(...) calls whose arguments mention the per-character reconcile."""
+    out = []
+    for call in _calls_named(ast, node, 'gather'):
+        names = {n.id for n in ast.walk(call) if isinstance(n, ast.Name)}
+        if '_reconcile_one' in names:
+            out.append(call)
+    return out
+
+
+def test_startup_reconciles_before_it_resumes_the_outbox():
+    """Reconciliation must be complete before any outbox op is resumed.
+
+    Both write the same view files, but their read points are asymmetric: a
+    replay handler loads/mutates/saves inside the EventLog lock, while the
+    reflection and persona live writers load their whole snapshot outside it
+    and only then hand it to record_and_save. Any overlap leaves a window
+    where a resumed op saves a pre-replay snapshot over a just-completed
+    repair — and the sentinel is already past that event, so no later boot
+    replays it again. Resumed ops are fire-and-forget background tasks, so
+    the only thing separating them from the replay is this ordering.
+    """
+    ast, fn = _startup_function_ast()
+
+    replay_calls = _calls_named(ast, fn, '_replay_pending_outbox')
+    assert replay_calls, 'startup 里找不到 outbox 补跑调用，断言失效'
+    gathers = _reconcile_gathers(ast, fn)
+    assert gathers, 'startup 里找不到 per-character reconcile 的 gather，断言失效'
+
+    # reconcile 必须是 await 到底的：换成 create_task / spawn 就又重叠了
+    awaited = {id(a.value) for a in ast.walk(fn) if isinstance(a, ast.Await)}
+    assert all(id(g) in awaited for g in gathers), \
+        'reconcile 的 gather 没有被 await，补跑会和重放重叠'
+
+    replay_lines = {c.lineno for c in replay_calls}
+    gather_lines = {g.lineno for g in gathers}
+
+    def _covers(stmt, lines):
+        return any(getattr(n, 'lineno', None) in lines for n in ast.walk(stmt))
+
+    # 在语句序列层面比先后，而不是比行号：谁被包在 try/if 里都不影响判定
+    checked = 0
+    for node in ast.walk(fn):
+        for field in ('body', 'orelse', 'finalbody'):
+            block = getattr(node, field, None)
+            if not isinstance(block, list) or not block:
+                continue
+            if not all(isinstance(s, ast.stmt) for s in block):
+                continue
+            idx_replay = [i for i, s in enumerate(block) if _covers(s, replay_lines)]
+            idx_gather = [i for i, s in enumerate(block) if _covers(s, gather_lines)]
+            if not idx_replay or not idx_gather:
+                continue
+            if set(idx_replay) & set(idx_gather):
+                # 两者落在同一条语句里 = 这是个外层容器（async with / try），
+                # 它只说明"都在里面"，判不了先后，继续往内层找。
+                continue
+            checked += 1
+            assert max(idx_gather) < min(idx_replay), (
+                'outbox 补跑排在了 reconcile 前面：补跑的 op 是后台 task，'
+                '会和重放并发写同一批 view 文件，重放结果可能被静默整覆盖'
+            )
+    assert checked, 'reconcile 与 outbox 补跑不在同一层语句序列里，前后顺序无从判定'


### PR DESCRIPTION

这是 #2528「目击 1」在生产里的对偶。但**定性跟 issue 原文不一样**，先说清楚：

## 不是 Windows 的 os.replace 撞车

仓库刚合的 #2596 给 utils/file_utils.py 加了 _replace_with_busy_retry（工作线程重试 5 次、
事件循环上直接抛）。实测：纯工作线程侧并发 replace 已经 0/1000 不再抛。issue 里那份
「345/1000」是退避重试落地之前的数。

## 真正的伤害是静默丢写，而且是永久的

Reconciler.areconcile 里 `handler(name, payload)` 是**同步调用、直接跑在事件循环线程上**，
EventLog 锁和 _get_alock 两把都不取；而它写的 reflections.json / persona.json 是
「读盘→改→整覆盖」不做 merge。启动期 outbox 补跑（runtime.py 只 await 了扫描，op 是
fire-and-forget 的后台 task）与 areconcile 必然交错。

实测（真 Reconciler + 真 ReflectionEngine，60 轮）：reconciler 重放的崩溃修复存活 **0/60**，
其中 **59/60 永久丢失** —— 哨兵已经推过那条事件，以后任何一次开机都不会再重放它。
**全程 0 个异常**。反向起跑顺序 + 错开 0/2/5ms 各 20 轮，结果一样：这不是窄缝概率事件，
是两个读-改-写区间大面积重叠。

用户视角：被否掉或归档的反思又活过来了，或者某条记忆的确认次数莫名归零。
事件日志这套机制存在的全部意义就是防崩溃丢状态，这里恰好被自己的启动时序绕过去了。

## 主修：让 reconcile 独占启动窗口

app/memory_server/runtime.py 把 per-character reconcile 的 gather 挪到
`_replay_pending_outbox()` **之前**。补跑的 op 是 fire-and-forget 的后台 task，
reconcile 是 await 到底的 —— 先跑 reconcile 就没有重叠。

安全性三条核实：
1. 无反向依赖：outbox 唯一注册的 op 类型是 OP_POST_TURN_SIGNALS，它产生的是**新**事件、
   走 record_and_save 的 append+apply+save 一体路径，不需要 reconcile 再补应用一次；
   reconcile 重放的是上次崩溃遗留在盘上的尾巴，两者是不相交的事件集。
2. 补跑的效果不会被重放覆盖：重排后 reconcile 在补跑起任何 task 之前就 await 完；
   反过来先跑 reconcile 还更正确 —— 补跑 op 读到的是修复完的 view 而不是崩溃残留态。
3. 没有别的东西依赖旧顺序：docs/design/memory-event-log-rfc.md 启动恢复一节原文就写着
   「code must not depend on an outbox side effect being visible first」；区域预热仍在最前
   （既有的顺序断言不受影响）；两边的异常处理互不传染。

对照实验（唯一变量是启动顺序，各 20 轮）：旧顺序永久丢失 20/20 → 新顺序 0/20。

## 纵深：apply handler + 哨兵推进收进同一个临界区

新增 EventLog.apply_and_advance / aapply_and_advance：在 self._get_lock(name) 内跑完
handler 再写哨兵，整段丢进一个 asyncio.to_thread。handler 由此跟 record_and_save 落在
同一把 per-character 锁上，也从事件循环挪到了 worker 线程（顺带拿到 #2596 的退避重试 ——
全链路唯一拿不到重试的写恰好就是它）。

哨兵写抽成 _write_sentinel_unlocked；公开的 advance_sentinel 自己加锁（默认安全，
生产已无调用方），两个锁内调用点走不加锁的内部版本，杜绝 threading.Lock 自锁。

**为什么两条都要**：锁只覆盖「live writer 进入临界区之后」—— 它的**读**在锁外
（evidence_flow 先 _aload_reflections_full 再把预读快照原样交给 _sync_load），
卡在「已读盘、还没拿锁」的空隙里仍能覆盖。所以主保证是启动顺序，锁是第二道防线，
且覆盖将来万一有人给 areconcile 加运行期调用点的情况。这一点写进了 docstring ——
上一版那句「a replayed crash-repair can't be silently overwritten」按字面读是**错的**，
已改成只承诺临界区内互斥。

## 顺带修的两条（都不是本 PR 引入，但新注释会让人以为已经安全）

**哨兵倒退 → 该角色 replay 永久卡死**：reconciler 读完 tail 后，live writer 追加一条
没有 handler 的事件（register_evidence_handlers 只注册 15 种里的 5 种）并把哨兵推到它，
reconciler 随后无条件写回旧 id → 哨兵倒退 → 那条事件回到尾巴 → 此后每次开机都撞
「未注册事件类型，暂停 replay」→ 再也不前进。
修法用 CAS 而不是「按 id 定序」：event_id 是 uuid4，彼此没有可比性，唯一的顺序是在
events.ndjson 里的行位置，而把位置判定塞进 _write_sentinel_unlocked 会给每次
record_and_save 加一次全文件扫描。所以 replay 侧拿本轮出发时的哨兵值做 compare-and-set，
generic writer 侧只在 docstring 里说清「只保证互斥、不保证单调」。
冲突时**冻结哨兵但继续应用剩余尾巴**，而不是中止 —— 中止的话尾巴剩下那些修复既不会
本轮应用、又因为哨兵已经在它们前面而永远不会再被重放，等于新造一个丢失。

**哨兵写失败被误报成 handler 失败**：改造后哨兵写落进了 handler 的 try 里。
现在单独 except + SentinelAdvanceError（__cause__ 保留原 OSError），日志文案分开。

## 一轮对抗性审提了 6 条，全部处理

其中最重要的是「唯一能抓住核心回归的测试不在 CI 里」：.github/ 里没有任何
tests/integration，变异「完整回退本 PR」→ 集成测试红、tests/unit 全绿、CI 放行。
补了一条 tests/unit 断言（handler 内部同时断言：不在事件循环上、确实过了 to_thread、
确实在 per-character 锁内），现在同一变异在 tests/unit 就红。
（把 tests/integration 纳入 CI 是独立决策，不塞进本 PR。）

审阅还纠正了我一个错误预期：它的 adv_residual_window.py 直接驱动 areconcile、
完全绕开 runtime.py，所以启动顺序的重排按构造不可能改变它的结论 —— 上面那个
「唯一变量是启动顺序」的对照实验才是能证明重排有效的实验。

变异验证：删临界区的锁 / handler 挪回事件循环 / 哨兵写挪出临界区 / 哨兵写提到 apply 之前 /
apply 用另一把独立锁 / handler 失败后补推哨兵 / try-finally 强推哨兵 / CAS 永真 /
冲突改成中止 / 哨兵 IO 异常裸穿 / advance_sentinel 去锁 / 启动顺序换回去 /
reconcile 改成不 await —— 全部打红对应断言。

验证：全量 tests/unit 9292 passed, 45 skipped；tests/integration 16 passed；
相关集合连跑 3 次 301 passed；ruff 与 docstring 禁 CJK 门均通过。

Refs #2528

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


## 回归报告

**改动**：`app/memory_server/runtime.py` 把 per-character reconcile 挪到 outbox 补跑之前；`memory/event_log.py` 新增 `apply_and_advance` / `aapply_and_advance`（handler + 哨兵推进在同一个 per-character 临界区、跑在 worker 线程）、哨兵写收口到 `_write_sentinel_unlocked`、`advance_sentinel` 自身加锁、replay 侧哨兵 CAS、哨兵写失败单独归因；RFC 文档同步；新增 5 条 `tests/unit` + 1 个 `tests/integration` 回归文件。

**必要性**：实测 60 轮，reconciler 重放的崩溃修复存活 **0/60**、其中 **59/60 永久丢失**，且**全程零异常零日志**。事件日志这套机制存在的全部意义就是防崩溃丢状态，而它被自己的启动时序绕过去了。

**改动前 → 改动后**：

- 前：outbox 补跑（fire-and-forget 后台 task）与 `areconcile` 在启动期必然交错，handler 在事件循环上无锁写 view。后：reconcile 先 `await` 到底，补跑之后才起 —— 对照实验（唯一变量是顺序）永久丢失 20/20 → 0/20。
- 前：handler 跑在事件循环线程，是全链路唯一拿不到 `_replace_with_busy_retry` 退避的写。后：跑在 worker 线程、在 per-character 锁内。
- 前：`advance_sentinel` 无条件覆盖 → 哨兵可倒退 → 撞上没有 handler 的事件类型就**每次开机都暂停 replay**、该角色永久卡死。后：replay 侧 CAS，冲突时冻结哨兵但继续应用剩余尾巴。
- 前：哨兵写失败被记成「handler 失败」。后：单独归因，`__cause__` 保留原异常。
- 未改动的行为：handler 抛异常 → 不推哨兵 + 暂停该角色 replay + WARN；未注册事件类型 → 同样暂停且不推哨兵（这两条逐条对过 `git show origin/main:memory/event_log.py`，变异验证也钉住了）。

**潜在回归**：

1. **启动顺序变了**。reconcile 现在阻塞 outbox 补跑。reconcile 只在有崩溃残留尾巴时才真做事（正常收尾 tail 为空、读完两个文件就返回），所以稳态启动几乎零额外延迟；有尾巴时才会多花重放那几十毫秒 × 事件数。
2. **临界区变长**：启动期每条重放事件多持锁一小段（archive 分支扫分片 + 读写分片 + 重写 view，几十毫秒），期间同角色的 `record_and_save` 会被阻塞。这正是想要的串行化，且 `areconcile` 只在启动跑。**但如果哪天有人给 `areconcile` 加了运行期调用点，这条结论要重估。**
3. **handler 从事件循环挪到 worker 线程**，丢了一层隐式原子性：`evidence_handlers` 里 `persona_manager._personas[name] = persona` 以前对其他协程不可打断，现在可在任意字节码边界插入。构造不出实际触发（persona 侧共用同一个缓存实例），标为「结构上的新窗口，未验证」。关掉它要给 `_personas` 加锁，超出本 PR。
4. 哨兵 CAS 冲突时会冻结哨兵，那一轮已应用的事件下次开机会**重复应用一次**。handler 都是全量快照幂等赋值，重复应用无副作用。

**明确不覆盖的**（写进了 docstring 和集成测试的 scope 声明，避免下一个人基于错误前提做决定）：live writer 的**读**在 EventLog 锁外（`evidence_flow.py` 先 `_aload_reflections_full` 再把预读快照交给 `_sync_load`），所以锁只保证「live writer 进入临界区之后」互斥。真正关掉这一类的是启动顺序；锁是第二道防线。

**验证**：全量 `tests/unit` **9292 passed, 45 skipped**；`tests/integration` 16 passed；相关集合连跑 3 次 301 passed；13 个变异全部打红对应断言；`ruff check` 与 `check_docstring_no_cjk.py` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
