### PR TITLE
fix(proactive): 读盘失败不再让空内存冒充权威，一次瞬时 IO 错误不再截掉整段来源历史

### DIFF
--- a/main_logic/proactive_chat/state.py
+++ b/main_logic/proactive_chat/state.py
@@ -53,6 +53,13 @@ _source_history: dict[str, dict[str, Any]] = {}
 _source_history_lock = asyncio.Lock()
 _source_history_loaded = False
 _source_history_loaded_path: Path | None = None
+# 内存里那份能不能被**读路径**当权威。跟 _source_history_loaded 不是一回事：
+# 后者说的是「内存代表 _source_history_loaded_path 那个根」，而这个说的是「内存代表
+# 刚才那次请求要的那个根」。两者只在「换了根、而新根读失败」时分叉——那时内存里装的
+# 还是上一个根的历史，写侧靠返回值挡住了，读侧（_should_skip_source）却会拿 A 的
+# 历史去压 B 的候选，表现为她对这个角色明明没聊过的素材闭口不谈。
+# 读侧宁可漏抑制（顶多把某个素材再聊一遍）也不能跨根抑制，所以这里 fail-open。
+_source_history_authoritative = False
 # 连续失败计数，只用于给日志降频。一次性的读失败和「永久停摆」在单条 warning 里
 # 长得一模一样，靠的就是这两个累计数把它们区分开。任何一次成功都清零。
 _source_history_read_failures = 0
@@ -105,8 +112,14 @@ def _source_skip_probability(age: float, half_life: float) -> float:
 
 
 def _get_source_history_entry(url_hash: str) -> dict[str, Any] | None:
-    """Return the current in-memory source record for a stable hash."""
+    """Return the in-memory source record, or None when it is not authoritative."""
     if not url_hash:
+        return None
+    if not _source_history_authoritative:
+        # 上一次加载失败过，内存里可能装着**别的根**的历史。签名里没有 memory_dir，
+        # 加一个要串 _should_skip_source → candidate_selection / decisions /
+        # service 两处 / system_router 再导出，共五个调用点，为一条 fail-open 的
+        # 判据不值得。改成让加载侧把结论落在这个标记上，读侧只查标记。
         return None
     return _source_history.get(url_hash)
 
@@ -124,12 +137,14 @@ async def _ensure_source_history_loaded(
     # 无论哪种，被当成「已加载」都会让下一次记录把盘上整段历史截掉或换掉。所以
     # 「内存现在能不能代表 memory_dir 那份」必须是这个函数说了算，而不是让调用方去猜。
     global _source_history_loaded, _source_history_loaded_path
-    global _source_history_read_failures
+    global _source_history_read_failures, _source_history_authoritative
     path = _source_history_path(memory_dir=memory_dir)
     if _source_history_loaded and _source_history_loaded_path == path:
+        _source_history_authoritative = True
         return True
     async with _source_history_lock:
         if _source_history_loaded and _source_history_loaded_path == path:
+            _source_history_authoritative = True
             return True
         # 全程解析进这个局部 dict，只有走到函数末尾才整体换入 _source_history。
         # 这样「异常 / 取消」与「全局状态」彻底解耦：
@@ -145,11 +160,16 @@ async def _ensure_source_history_loaded(
             # 文件本来就不存在（首启 / 被清理过）= 正常的空历史，不是失败。
             # 照旧标记已加载，下一次记录会把文件创建出来。
             data = None
-        except (ValueError, TypeError) as exc:
+        except (ValueError, TypeError, RecursionError) as exc:
             # 整个文件读不成结构（JSONDecodeError / UnicodeDecodeError 都是 ValueError
             # 子类）：盘上那份已经不是可用的历史了，没有值得保护的东西，而且重试永远
             # 失败。按空历史起步、让后续覆盖写自愈——否则一个坏文件会让「我用过这个
             # 素材」永久停止记录。
+            #
+            # RecursionError 也归这里：json 解码器对足够深的嵌套（`[[[[...]]]]`）抛的
+            # 是它，而它既不是 ValueError 也不是 OSError。落到下面那个「瞬时失败」分支
+            # 就成了最坏的组合——由内容导致、因而**永远**失败的东西被当成「下次重试」，
+            # 于是记录永久停摆，而这正是自愈路径本来要消灭的状态。
             logger.warning(
                 "%s 内容损坏，按空历史起步并等待覆盖重建: %s: %s",
                 _SOURCE_HISTORY_FILENAME,
@@ -172,6 +192,10 @@ async def _ensure_source_history_loaded(
                     exc,
                     _source_history_read_failures,
                 )
+            # 内存原样保留（清掉会让「flag=已加载 / path=旧根 / 内存空」这个状态复活，
+            # 下一次针对旧根的记录就会拿空内存全量覆盖写），但读侧从这一刻起不许再用它，
+            # 否则旧根的历史会去压新根的候选。
+            _source_history_authoritative = False
             return False
         entries = data.get('entries') if isinstance(data, dict) else None
         if isinstance(entries, dict):
@@ -186,9 +210,11 @@ async def _ensure_source_history_loaded(
                         age,
                         _half_life_for(entry.get('kind', 'web')),
                     )
-                except (ValueError, TypeError):
+                except (ValueError, TypeError, OverflowError):
                     # 逐条跳过而不是整份作废：ts 是字符串抛 ValueError、kind 不可 hash
-                    # 抛 TypeError，都只说明**这一条**坏了。半损坏（几百条里坏一条）
+                    # 抛 TypeError、ts 是个几百位的大整数 float() 抛 OverflowError
+                    # （它是 ArithmeticError 而不是 ValueError 的子类，漏掉就会一路
+                    # 逃出本函数，让每一次主动搭话都炸），都只说明**这一条**坏了。半损坏（几百条里坏一条）
                     # 比整份 JSON 坏掉常见得多，把其余合法条目一起丢掉就是白白让她把
                     # 那些素材再聊一遍。坏的那条本来就该被遗忘，丢掉它没有代价。
                     damaged += 1
@@ -208,6 +234,7 @@ async def _ensure_source_history_loaded(
         _source_history_loaded = True
         _source_history_loaded_path = path
         _source_history_read_failures = 0
+        _source_history_authoritative = True
         return True
 
 

--- a/main_logic/proactive_chat/state.py
+++ b/main_logic/proactive_chat/state.py
@@ -53,6 +53,19 @@ _source_history: dict[str, dict[str, Any]] = {}
 _source_history_lock = asyncio.Lock()
 _source_history_loaded = False
 _source_history_loaded_path: Path | None = None
+# 连续失败计数，只用于给日志降频。一次性的读失败和「永久停摆」在单条 warning 里
+# 长得一模一样，靠的就是这两个累计数把它们区分开。任何一次成功都清零。
+_source_history_read_failures = 0
+_source_history_skipped_records = 0
+
+
+def _should_log_repeated_failure(count: int) -> bool:
+    """Report the first few consecutive failures, then back off to every 50th."""
+    # 永久性读失败（比如文件的读 ACL 坏了但目录仍可写，os.replace 照样成功）会让每
+    # 一次记录都走到失败/跳过分支。每次刷一条 warning 只会变成噪音，把「她已经不再
+    # 记录用过的素材了」这件事本身淹掉。前几次照报（偶发时看得见），之后按 50 次一报
+    # 并带上累计数——一条日志就能分辨这是抖了一下还是彻底停摆。
+    return count <= 3 or count % 50 == 0
 
 
 def _resolve_memory_dir(memory_dir: str | Path | None) -> Path:
@@ -100,42 +113,102 @@ def _get_source_history_entry(url_hash: str) -> dict[str, Any] | None:
 
 async def _ensure_source_history_loaded(
     *, memory_dir: str | Path | None = None
-) -> None:
-    """Load source history once without blocking the event loop."""
+) -> bool:
+    """Load source history once without blocking the event loop.
+
+    Returns whether the in-memory history is authoritative for *memory_dir*.
+    A false return means the read failed and nothing may be overwritten yet.
+    """
+    # 返回值不是装饰：_record_source_used 是**全量覆盖写**（entries 就是整个
+    # _source_history）。读盘失败时内存里要么是空的、要么装着上一个 root 的东西，
+    # 无论哪种，被当成「已加载」都会让下一次记录把盘上整段历史截掉或换掉。所以
+    # 「内存现在能不能代表 memory_dir 那份」必须是这个函数说了算，而不是让调用方去猜。
     global _source_history_loaded, _source_history_loaded_path
+    global _source_history_read_failures
     path = _source_history_path(memory_dir=memory_dir)
     if _source_history_loaded and _source_history_loaded_path == path:
-        return
+        return True
     async with _source_history_lock:
         if _source_history_loaded and _source_history_loaded_path == path:
-            return
-        _source_history.clear()
+            return True
+        # 全程解析进这个局部 dict，只有走到函数末尾才整体换入 _source_history。
+        # 这样「异常 / 取消」与「全局状态」彻底解耦：
+        #   * 取消（唯一挂起点是下面那次 to_thread，CancelledError 是 BaseException，
+        #     两个 except 都接不住）不再留下「flag=True、path=旧 root、内存空」——
+        #     那正是这次要消灭的状态，之后一次完全正常的记录就会拿空内存全量覆盖写。
+        #   * 读失败时旧 root 的内存原样保留，仍然与 flag/path 自洽，不用清标记。
+        # 换句话说：全局三件套（flag / path / 内存）要么一起前进，要么一动不动。
+        loaded: dict[str, dict[str, Any]] = {}
         try:
             data = await asyncio.to_thread(read_json, path)
-            entries = data.get('entries') if isinstance(data, dict) else None
-            if isinstance(entries, dict):
-                now = time.time()
-                for source_hash, entry in entries.items():
-                    if not isinstance(entry, dict):
-                        continue
+        except FileNotFoundError:
+            # 文件本来就不存在（首启 / 被清理过）= 正常的空历史，不是失败。
+            # 照旧标记已加载，下一次记录会把文件创建出来。
+            data = None
+        except (ValueError, TypeError) as exc:
+            # 整个文件读不成结构（JSONDecodeError / UnicodeDecodeError 都是 ValueError
+            # 子类）：盘上那份已经不是可用的历史了，没有值得保护的东西，而且重试永远
+            # 失败。按空历史起步、让后续覆盖写自愈——否则一个坏文件会让「我用过这个
+            # 素材」永久停止记录。
+            logger.warning(
+                "%s 内容损坏，按空历史起步并等待覆盖重建: %s: %s",
+                _SOURCE_HISTORY_FILENAME,
+                type(exc).__name__,
+                exc,
+            )
+            data = None
+        except Exception as exc:
+            # 真正的读失败（IO / 权限 / 文件被杀软或索引器短暂占住）：盘上那份大概率
+            # 还是完整的，只是这一刻读不到。绝不能标记「已加载」——那会让空内存冒充
+            # 权威，下一次全量覆盖写直接把整段历史截掉。什么都不动，让下次调用重试。
+            #
+            # 每次调用都会重来一遍，所以永久性失败在这里同样会刷屏，跟着连续计数降频。
+            _source_history_read_failures += 1
+            if _should_log_repeated_failure(_source_history_read_failures):
+                logger.warning(
+                    "加载 %s 失败，本次不视为已加载（下次重试）: %s: %s，连续失败 %d 次",
+                    _SOURCE_HISTORY_FILENAME,
+                    type(exc).__name__,
+                    exc,
+                    _source_history_read_failures,
+                )
+            return False
+        entries = data.get('entries') if isinstance(data, dict) else None
+        if isinstance(entries, dict):
+            now = time.time()
+            damaged = 0
+            for source_hash, entry in entries.items():
+                if not isinstance(entry, dict):
+                    continue
+                try:
                     age = now - float(entry.get('ts', 0.0) or 0.0)
                     probability = _source_skip_probability(
                         age,
                         _half_life_for(entry.get('kind', 'web')),
                     )
-                    if probability >= PROACTIVE_SOURCE_FORGET_P:
-                        _source_history[source_hash] = entry
-        except FileNotFoundError:
-            pass
-        except Exception as exc:
-            logger.warning(
-                "加载 %s 失败，按空历史处理: %s: %s",
-                _SOURCE_HISTORY_FILENAME,
-                type(exc).__name__,
-                exc,
-            )
+                except (ValueError, TypeError):
+                    # 逐条跳过而不是整份作废：ts 是字符串抛 ValueError、kind 不可 hash
+                    # 抛 TypeError，都只说明**这一条**坏了。半损坏（几百条里坏一条）
+                    # 比整份 JSON 坏掉常见得多，把其余合法条目一起丢掉就是白白让她把
+                    # 那些素材再聊一遍。坏的那条本来就该被遗忘，丢掉它没有代价。
+                    damaged += 1
+                    continue
+                if probability >= PROACTIVE_SOURCE_FORGET_P:
+                    loaded[source_hash] = entry
+            if damaged:
+                # 一次加载只汇总一条，别按条刷屏。
+                logger.warning(
+                    "%s 有 %d 条记录无法解析，已跳过（其余 %d 条正常载入）",
+                    _SOURCE_HISTORY_FILENAME,
+                    damaged,
+                    len(loaded),
+                )
+        _source_history.clear()
+        _source_history.update(loaded)
         _source_history_loaded = True
         _source_history_loaded_path = path
+        _source_history_read_failures = 0
+        return True
 
 
 async def _persist_source_history_unlocked(
@@ -171,10 +244,64 @@ async def _record_source_used(
     memory_dir: str | Path | None = None,
 ) -> None:
     """Update, prune and persist one consumed source record."""
+    global _source_history_skipped_records
     source_hash = _source_hash(url, title)
     if not source_hash:
         return
+    # 加载放在进锁之前：_ensure_source_history_loaded 自己要取同一把
+    # _source_history_lock，锁内再调必定自锁。已加载时它只是一次 flag+path 比较，
+    # 代价可忽略。
+    #
+    # 为什么要在这里再加载一次：「记录之前一定先加载过」此前只由
+    # handle_proactive_chat 里的语句顺序维持——加载在 try-body 第 53 条，两处记录在
+    # 第 115/170 条，中间隔着上千行和几十个 await。谁把某个投递分支提前一点，就会
+    # 拿空内存做全量覆盖写、静默抹掉整段历史，而且没有任何测试会红。把不变量收进
+    # 函数自己，行号就不再是它的唯一保障。
+    # memory_dir 原样往下传，加载与落盘都经 _source_history_path(memory_dir=...)
+    # 解析，两边用的一定是同一个根。
+    if not await _ensure_source_history_loaded(memory_dir=memory_dir):
+        # 读不出来就不写。本函数是全量覆盖写，拿一份空内存去写等于把盘上整段历史
+        # 截成 1 条。丢这一次记录的代价是这条素材以后可能被再聊一遍；截库的代价是
+        # 所有素材都可能被再聊一遍——量级差着整个清单。
+        #
+        # 这不会变成「读不出来就再也不记录了」：加载在每次调用时都重试，盘一恢复
+        # 就继续记；而「内容坏掉」那类永久性失败已经在加载侧按空历史放行，由覆盖
+        # 写自愈，不会落到这个分支里。
+        #
+        # 但「盘永远读不回来」这种情况确实存在（读 ACL 坏了而目录可写），那时记录就
+        # 永久停摆，而且对用户只表现为她反复聊同一个东西。日志是这件事唯一的出口，
+        # 所以带上累计次数并降频——既不刷屏，也不让停摆无声无息。
+        _source_history_skipped_records += 1
+        if _should_log_repeated_failure(_source_history_skipped_records):
+            logger.warning(
+                "%s 未能加载，跳过本次 source 记录以免覆盖写截断盘上历史: "
+                "kind=%s, 连续跳过 %d 次",
+                _SOURCE_HISTORY_FILENAME,
+                kind,
+                _source_history_skipped_records,
+            )
+        return
+    # 加载成功就把连跳计数清零：降频只针对「连续失败」，偶发的一两次不该攒起来
+    # 把后面真正的停摆推到 50 次之后才第一次报出来。
+    _source_history_skipped_records = 0
     async with _source_history_lock:
+        # 护栏判定在锁外（_ensure 自己要取这把锁，锁内再调必定自锁），覆盖写在锁内，
+        # 中间隔着一个窗口：_ensure 走 IO 分支时是持锁 await 的，它放锁之后、本协程
+        # 拿到锁之前，另一个 root 的 _ensure 能插进来把内存整个换掉。这里再做一次纯
+        # 内存复核——不调 _ensure（不会自锁、不产生额外 IO），只确认此刻内存仍然代表
+        # 本次要写的那个 root。不等就什么都不写：拿 root_b 的内容去全量覆盖 root_a 的
+        # 文件，比漏记一条严重得多。
+        if not (
+            _source_history_loaded
+            and _source_history_loaded_path
+            == _source_history_path(memory_dir=memory_dir)
+        ):
+            logger.warning(
+                "%s 在加载与写入之间被换成了别的根，跳过本次 source 记录: kind=%s",
+                _SOURCE_HISTORY_FILENAME,
+                kind,
+            )
+            return
         _source_history[source_hash] = {
             "ts": time.time(),
             "kind": kind,

--- a/main_routers/system_router/proactive_sources.py
+++ b/main_routers/system_router/proactive_sources.py
@@ -51,8 +51,12 @@ def _source_history_path():
     return _state._source_history_path(memory_dir=_legacy_memory_dir())
 
 
-async def _ensure_source_history_loaded() -> None:
-    await _state._ensure_source_history_loaded(memory_dir=_legacy_memory_dir())
+async def _ensure_source_history_loaded() -> bool:
+    # 透传返回值而不是吞掉：false 表示这次没读出来、内存不可代表盘上那份，
+    # 这个信号对 legacy 路径同样有意义。
+    return await _state._ensure_source_history_loaded(
+        memory_dir=_legacy_memory_dir()
+    )
 
 
 async def _record_source_used(

--- a/tests/unit/test_proactive_source_history_load_failure.py
+++ b/tests/unit/test_proactive_source_history_load_failure.py
@@ -28,6 +28,7 @@ def _isolate_source_history_globals():
     saved_path = state._source_history_loaded_path
     saved_skipped = state._source_history_skipped_records
     saved_failures = state._source_history_read_failures
+    saved_authoritative = state._source_history_authoritative
     # 本文件里有几条会真的把 _source_history_lock 抢起来的用例。asyncio.Lock 只在
     # 「有竞争」那条路上才 _get_loop()，一旦绑定就跟那个事件循环绑死；pytest-asyncio
     # 每个用例一个新循环，模块级那把锁被这里绑上之后，别处的并发用例就会撞
@@ -40,6 +41,7 @@ def _isolate_source_history_globals():
     state._source_history_loaded_path = None
     state._source_history_skipped_records = 0
     state._source_history_read_failures = 0
+    state._source_history_authoritative = False
     yield
     state._source_history.clear()
     state._source_history.update(saved_history)
@@ -47,6 +49,7 @@ def _isolate_source_history_globals():
     state._source_history_loaded_path = saved_path
     state._source_history_skipped_records = saved_skipped
     state._source_history_read_failures = saved_failures
+    state._source_history_authoritative = saved_authoritative
     state._source_history_lock = saved_lock
 
 
@@ -432,3 +435,121 @@ async def test_permanent_read_failure_logs_at_a_throttled_rate(
     )
     assert [line for line in warnings if "连续跳过 1 次" in line], warnings
     assert [line for line in warnings if "连续失败 1 次" in line], warnings
+
+
+# --- 三条评审发现：损坏内容抛的不是 ValueError / 读失败后旧根仍被读路径看见 ---
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_an_oversized_timestamp_only_drops_that_one_entry(tmp_path):
+    # float() 对几百位的大整数抛 OverflowError，而它是 ArithmeticError 的子类、
+    # 不是 ValueError 的。逐条跳过的 except 元组漏掉它，异常就会一路逃出
+    # _ensure_source_history_loaded、逃出 _record_source_used，让**每一次**主动搭话
+    # 都炸在这里——而这份文件本来就是「可能被写坏」的前提下才有逐条跳过这套东西。
+    root = tmp_path / "mem"
+    root.mkdir()
+    good = {"ts": time.time(), "kind": "web", "title": "good"}
+    _history_path(root).write_text(
+        json.dumps(
+            {
+                "v": state._SOURCE_HISTORY_SCHEMA_VERSION,
+                "entries": {
+                    "goodhash": good,
+                    # JSON 允许任意精度整数，float() 转不过去。
+                    "hugehash": {"ts": int("9" * 400), "kind": "web", "title": "huge"},
+                },
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    assert await state._ensure_source_history_loaded(memory_dir=root) is True
+    assert set(state._source_history) == {"goodhash"}, "坏的那条该丢，好的那条不该陪葬"
+    assert state._source_history["goodhash"] == good
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_recursion_error_from_the_decoder_is_treated_as_corrupt_not_transient(
+    tmp_path,
+):
+    # 深嵌套 JSON 让解码器抛 RecursionError。它既不是 ValueError 也不是 OSError，
+    # 落进「瞬时失败」分支就是最坏的组合：由内容导致、因而永远失败的东西被当成
+    # 「下次重试」，于是 _record_source_used 永久拒绝写入、永远等不到自愈。
+    root = tmp_path / "mem"
+    root.mkdir()
+
+    def recursing_read(path):
+        raise RecursionError("maximum recursion depth exceeded while decoding a JSON object")
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(state, "read_json", recursing_read)
+        assert await state._ensure_source_history_loaded(memory_dir=root) is True, (
+            "内容坏掉必须按空历史放行、由覆盖写自愈，不能挂在瞬时失败上"
+        )
+    assert state._source_history == {}
+    assert state._source_history_loaded is True
+    assert state._source_history_loaded_path == _history_path(root)
+
+    # 自愈的落点：下一次记录必须真的把文件写出来。
+    await state._record_source_used(
+        url="https://example.test/heal", kind="web", title="heal", memory_dir=root
+    )
+    written = json.loads(_history_path(root).read_text(encoding="utf-8"))
+    assert list(written["entries"]) == [state._source_hash("https://example.test/heal", "heal")]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_failed_reload_hides_the_previous_root_from_readers(tmp_path):
+    # 换根 + 新根读失败：写侧靠返回值挡住了，但内存里还留着 root_a 的历史。
+    # _should_skip_source 是同步读、拿不到 memory_dir，于是 root_b 的这次请求会被
+    # root_a 的「我聊过这个」压掉候选——她对这个角色明明没提过的素材闭口不谈。
+    root_a = tmp_path / "a"
+    root_b = tmp_path / "b"
+    root_b.mkdir()
+    seeded_a = _seed_history(root_a, 3)
+    hash_a = next(iter(seeded_a))
+
+    assert await state._ensure_source_history_loaded(memory_dir=root_a) is True
+    assert state._get_source_history_entry(hash_a) == seeded_a[hash_a]
+
+    def exploding_read(path):
+        raise OSError("root_b is unreadable right now")
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(state, "read_json", exploding_read)
+        assert await state._ensure_source_history_loaded(memory_dir=root_b) is False
+
+    # 内存本身不许被清（清了会让「flag=已加载 / path=root_a / 内存空」复活，
+    # 下一次对 root_a 的记录就拿空内存全量覆盖写），但读路径不许再看见它。
+    assert state._source_history, "内存不该被清空"
+    assert state._get_source_history_entry(hash_a) is None, (
+        "读失败之后，上一个根的历史不许再被读路径当权威"
+    )
+
+    # 回到 root_a（走已加载快路径）必须重新可读——fail-open 不是单向闸门。
+    assert await state._ensure_source_history_loaded(memory_dir=root_a) is True
+    assert state._get_source_history_entry(hash_a) == seeded_a[hash_a]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_readers_stay_open_when_the_very_first_load_fails(tmp_path):
+    # 首次加载就失败时内存是空的，读侧本来就查不到东西；这条钉的是方向：
+    # 标记必须是 fail-open（查不到 → 不抑制），而不是 fail-closed（抑制一切）。
+    root = tmp_path / "mem"
+    root.mkdir()
+
+    def exploding_read(path):
+        raise OSError("nope")
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(state, "read_json", exploding_read)
+        assert await state._ensure_source_history_loaded(memory_dir=root) is False
+
+    from main_logic.proactive_chat.decisions import _should_skip_source
+
+    assert _should_skip_source("anyhash") is False, "读不出历史时必须放行候选，不是全压掉"

--- a/tests/unit/test_proactive_source_history_load_failure.py
+++ b/tests/unit/test_proactive_source_history_load_failure.py
@@ -1,0 +1,434 @@
+"""A failed source-history load must never be mistaken for a loaded one."""
+
+# _record_source_used 是全量覆盖写（entries 就是整个 _source_history）。所以
+# 「内存现在能不能代表盘上那份」是个安全属性：一次读盘失败之后内存是空的，若被
+# 标记成「已加载」，紧接着的一次记录就把盘上整段历史截成 1 条。
+# proactive_source_history.json 是「这个素材我已经用过」的清单，截掉之后她会把刚
+# 聊过的东西再聊一遍。这些用例全部走真实磁盘断言，不看内部标志代替文件内容。
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from main_logic.proactive_chat import state
+from utils.file_utils import read_json as _real_read_json
+
+
+@pytest.fixture(autouse=True)
+def _isolate_source_history_globals():
+    """Restore module-level history globals so cases cannot leak into each other."""
+    saved_history = dict(state._source_history)
+    saved_loaded = state._source_history_loaded
+    saved_path = state._source_history_loaded_path
+    saved_skipped = state._source_history_skipped_records
+    saved_failures = state._source_history_read_failures
+    # 本文件里有几条会真的把 _source_history_lock 抢起来的用例。asyncio.Lock 只在
+    # 「有竞争」那条路上才 _get_loop()，一旦绑定就跟那个事件循环绑死；pytest-asyncio
+    # 每个用例一个新循环，模块级那把锁被这里绑上之后，别处的并发用例就会撞
+    # "bound to a different event loop"。整个用例期间换一把新锁，跑完还回去——被测代码
+    # 取的是 state 模块的全局名，换掉之后走的仍然是同一条真实临界区。
+    saved_lock = state._source_history_lock
+    state._source_history_lock = asyncio.Lock()
+    state._source_history.clear()
+    state._source_history_loaded = False
+    state._source_history_loaded_path = None
+    state._source_history_skipped_records = 0
+    state._source_history_read_failures = 0
+    yield
+    state._source_history.clear()
+    state._source_history.update(saved_history)
+    state._source_history_loaded = saved_loaded
+    state._source_history_loaded_path = saved_path
+    state._source_history_skipped_records = saved_skipped
+    state._source_history_read_failures = saved_failures
+    state._source_history_lock = saved_lock
+
+
+def _history_path(root: Path) -> Path:
+    return root / state._SOURCE_HISTORY_FILENAME
+
+
+def _seed_history(root: Path, count: int) -> dict[str, dict]:
+    """Write *count* fresh entries to disk and return them."""
+    # ts=now → _source_skip_probability 返回 1.0，既不会被加载时的遗忘过滤掉，
+    # 也不会被 _record_source_used 的 prune 扫掉；断言里的「一条不少」才成立。
+    root.mkdir(parents=True, exist_ok=True)
+    now = time.time()
+    entries = {
+        f"seedhash{index:02d}": {"ts": now, "kind": "web", "title": f"seed-{index}"}
+        for index in range(count)
+    }
+    _history_path(root).write_text(
+        json.dumps(
+            {"v": state._SOURCE_HISTORY_SCHEMA_VERSION, "entries": entries},
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    return entries
+
+
+def _disk_entries(root: Path) -> dict[str, dict]:
+    return json.loads(_history_path(root).read_text(encoding="utf-8"))["entries"]
+
+
+@pytest.mark.asyncio
+async def test_transient_read_failure_never_truncates_disk_history(
+    monkeypatch, tmp_path
+) -> None:
+    """One unreadable read must not let the next record overwrite the file."""
+    # 主回归。Windows 上杀软/索引器短暂占住文件正是 #2528 这一族的现场：读一次
+    # PermissionError，历史就被下一次记录截成 1 条。
+    root = tmp_path / "memory"
+    seeded = _seed_history(root, 7)
+
+    def exploding_read(path):
+        raise PermissionError(13, "file used by another process")
+
+    monkeypatch.setattr(state, "read_json", exploding_read)
+
+    await state._record_source_used(
+        url="https://example.test/fresh",
+        kind="web",
+        title="fresh",
+        memory_dir=root,
+    )
+
+    # 逐字等值而不是 len>=1：既挡住「截成 1 条」，也挡住「盲目追加一条」——后者
+    # 意味着覆盖写照样发生过，只是这一轮内存恰好不空。
+    assert _disk_entries(root) == seeded
+    assert state._source_history_loaded is False, "读失败不许被标记成已加载"
+    assert state._source_history_loaded_path is None
+
+
+@pytest.mark.asyncio
+async def test_missing_file_is_a_normal_empty_history(tmp_path) -> None:
+    """A file that never existed is an ordinary empty history, not a failure."""
+    # 别把 FileNotFoundError 一起改坏：首启 / 清理过缓存时文件本就不在，
+    # 这条路径必须照旧标记已加载并正常记录，否则第一条记录永远写不下去。
+    root = tmp_path / "memory"
+    root.mkdir()
+    assert not _history_path(root).exists()
+
+    assert await state._ensure_source_history_loaded(memory_dir=root) is True
+    assert state._source_history_loaded is True
+    assert state._source_history_loaded_path == _history_path(root)
+
+    url = "https://example.test/first"
+    await state._record_source_used(
+        url=url, kind="web", title="first", memory_dir=root
+    )
+
+    assert set(_disk_entries(root)) == {state._source_hash(url, "first")}
+
+
+@pytest.mark.asyncio
+async def test_recording_without_an_explicit_load_keeps_disk_history_intact(
+    tmp_path,
+) -> None:
+    """_record_source_used must load by itself, not rely on the caller's line order."""
+    # 护栏。此前「记录之前一定先加载过」只由 handle_proactive_chat 的语句顺序维持
+    # （加载第 53 条、记录第 115/170 条，中间上千行）。这里完全不预先加载，直接记录。
+    root = tmp_path / "memory"
+    seeded = _seed_history(root, 7)
+
+    url = "https://example.test/fresh"
+    await state._record_source_used(
+        url=url, kind="web", title="fresh", memory_dir=root
+    )
+
+    after = _disk_entries(root)
+    assert set(after) == set(seeded) | {state._source_hash(url, "fresh")}
+    assert len(after) == 8
+
+
+@pytest.mark.asyncio
+async def test_records_resume_once_the_read_recovers(monkeypatch, tmp_path) -> None:
+    """Skipping one record must not degrade into never recording again."""
+    # 「读不出来就跳过」的代价必须是一次性的：加载在每次调用时重试，盘一恢复就继续记。
+    root = tmp_path / "memory"
+    seeded = _seed_history(root, 7)
+    failing = {"now": True}
+
+    def flaky_read(path):
+        if failing["now"]:
+            raise OSError(5, "access denied")
+        return _real_read_json(path)
+
+    monkeypatch.setattr(state, "read_json", flaky_read)
+
+    url = "https://example.test/fresh"
+    await state._record_source_used(
+        url=url, kind="web", title="fresh", memory_dir=root
+    )
+    assert _disk_entries(root) == seeded, "读失败这一轮不该动盘"
+
+    failing["now"] = False
+    await state._record_source_used(
+        url=url, kind="web", title="fresh", memory_dir=root
+    )
+
+    after = _disk_entries(root)
+    assert set(after) == set(seeded) | {state._source_hash(url, "fresh")}
+
+
+@pytest.mark.asyncio
+async def test_corrupt_content_starts_empty_and_self_heals(tmp_path) -> None:
+    """Unparseable content has nothing worth protecting, so recording must go on."""
+    # 内容坏掉与「暂时读不到」必须分流：坏内容重试永远失败，若也走重试分支，
+    # 一个坏文件就让记录永久停摆。这里钉住它按空历史放行、由覆盖写重建。
+    root = tmp_path / "memory"
+    root.mkdir()
+    _history_path(root).write_text("{ this is not json", encoding="utf-8")
+
+    assert await state._ensure_source_history_loaded(memory_dir=root) is True
+
+    url = "https://example.test/fresh"
+    await state._record_source_used(
+        url=url, kind="web", title="fresh", memory_dir=root
+    )
+
+    assert set(_disk_entries(root)) == {state._source_hash(url, "fresh")}
+
+
+@pytest.mark.asyncio
+async def test_failed_reload_leaves_the_previous_root_fully_intact(
+    monkeypatch, tmp_path
+) -> None:
+    """A failed reload of another root must not disturb the root already in memory."""
+    # 同一个截断缺陷的另一扇门：切根时读失败。解析进局部 dict 之后，失败的那次加载
+    # 一个全局都不碰，于是「flag / path / 内存」三件套仍然自洽地描述着 root_a——
+    # 这比「把标记清掉」更强：既不会拿空内存去覆盖 root_a，也不用为 root_b 的一次
+    # 读失败白白丢掉 root_a 已经读好的历史。
+    root_a = tmp_path / "a"
+    root_b = tmp_path / "b"
+    seeded_a = _seed_history(root_a, 7)
+    root_b.mkdir()
+
+    await state._ensure_source_history_loaded(memory_dir=root_a)
+    assert set(state._source_history) == set(seeded_a)
+
+    def exploding_read(path):
+        raise OSError(5, "access denied")
+
+    monkeypatch.setattr(state, "read_json", exploding_read)
+
+    assert await state._ensure_source_history_loaded(memory_dir=root_b) is False
+    # 三件套逐项钉死：谁被动过，root_a 的下一次记录就会写错东西。
+    assert state._source_history_loaded is True
+    assert state._source_history_loaded_path == _history_path(root_a)
+    assert set(state._source_history) == set(seeded_a)
+
+    url = "https://example.test/fresh"
+    await state._record_source_used(
+        url=url, kind="web", title="fresh", memory_dir=root_a
+    )
+
+    # root_a 的记录照常进行（内存本来就是它的），一条不丢、正常追加。
+    after = _disk_entries(root_a)
+    assert set(after) == set(seeded_a) | {state._source_hash(url, "fresh")}
+    assert {key: after[key] for key in seeded_a} == seeded_a
+    assert not _history_path(root_b).exists(), "读失败的那个根不许被写出文件"
+
+
+@pytest.mark.asyncio
+async def test_cancelling_a_load_leaves_no_poisoned_state(monkeypatch, tmp_path) -> None:
+    """A cancelled load must not leave an empty memory wearing the previous root's flag."""
+    # CancelledError 是 BaseException，两个 except 都接不住，而 to_thread 那次读是本
+    # 函数唯一的挂起点。旧写法在 try 之前就 _source_history.clear()，于是取消会留下
+    # 「flag=True、path=root_a、内存空」——之后一次读盘完全正常的 record(root_a) 就把
+    # 7 条截成 1 条。解析进局部 dict 之后，取消什么都改不到。
+    root_a = tmp_path / "a"
+    root_b = tmp_path / "b"
+    seeded_a = _seed_history(root_a, 7)
+    _seed_history(root_b, 3)
+
+    await state._ensure_source_history_loaded(memory_dir=root_a)
+    assert set(state._source_history) == set(seeded_a)
+
+    read_started = threading.Event()
+    release_read = threading.Event()
+
+    def blocking_read(path):
+        read_started.set()
+        assert release_read.wait(5), "读线程没被放行"
+        return _real_read_json(path)
+
+    monkeypatch.setattr(state, "read_json", blocking_read)
+
+    task = asyncio.create_task(state._ensure_source_history_loaded(memory_dir=root_b))
+    await asyncio.to_thread(read_started.wait, 5)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    # 放行读线程并等它真的收尾，免得它跑到别的用例里去。
+    release_read.set()
+    await asyncio.sleep(0)
+
+    assert state._source_history_loaded is True
+    assert state._source_history_loaded_path == _history_path(root_a)
+    assert set(state._source_history) == set(seeded_a), "取消不许把内存清空"
+
+    monkeypatch.setattr(state, "read_json", _real_read_json)
+    url = "https://example.test/fresh"
+    await state._record_source_used(
+        url=url, kind="web", title="fresh", memory_dir=root_a
+    )
+
+    after = _disk_entries(root_a)
+    assert set(after) == set(seeded_a) | {state._source_hash(url, "fresh")}
+    assert len(after) == 8
+
+
+@pytest.mark.asyncio
+async def test_one_unparseable_entry_does_not_take_the_rest_down(tmp_path) -> None:
+    """A single damaged entry must be skipped, not turned into a whole-file wipe."""
+    # 半损坏（几百条里坏一条）比整份 JSON 坏掉常见得多。解析循环里 float(ts) 抛
+    # ValueError、_half_life_for(kind) 对不可 hash 的 kind 抛 TypeError，若让它们冒到
+    # 「内容损坏」分支并清空内存，合法条目就会被紧接着的覆盖写从盘上一起抹掉。
+    root = tmp_path / "memory"
+    seeded = _seed_history(root, 7)
+    raw = json.loads(_history_path(root).read_text(encoding="utf-8"))
+    raw["entries"]["seedhash03"]["ts"] = "not-a-number"
+    raw["entries"]["seedhash05"]["kind"] = ["unhashable"]
+    _history_path(root).write_text(json.dumps(raw, ensure_ascii=False), encoding="utf-8")
+
+    assert await state._ensure_source_history_loaded(memory_dir=root) is True
+    survivors = set(seeded) - {"seedhash03", "seedhash05"}
+    assert set(state._source_history) == survivors
+
+    url = "https://example.test/fresh"
+    await state._record_source_used(
+        url=url, kind="web", title="fresh", memory_dir=root
+    )
+
+    # 逐字等值：坏的两条该被遗忘，其余五条一条不许少（旧行为只剩新写的那 1 条）。
+    assert set(_disk_entries(root)) == survivors | {state._source_hash(url, "fresh")}
+
+
+@pytest.mark.asyncio
+async def test_root_swapped_between_load_and_write_aborts_the_record(
+    monkeypatch, tmp_path
+) -> None:
+    """Another root swapping the memory mid-flight must abort the overwrite, not ride it."""
+    # 护栏判定在锁外（_ensure 自己要取这把锁），覆盖写在锁内，中间有窗口：_ensure 走
+    # IO 分支时持锁 await，放锁之后本协程还没拿到锁，另一个 root 的 _ensure 能插进来
+    # 把内存整个换掉。没有锁内复核的话，root_a 的文件会被写成 root_b 的内容。
+    root_a = tmp_path / "a"
+    root_b = tmp_path / "b"
+    seeded_a = _seed_history(root_a, 7)
+    seeded_b = _seed_history(root_b, 3)
+
+    a_read_started = threading.Event()
+    release_a_read = threading.Event()
+
+    def controlled_read(path):
+        if path == _history_path(root_a):
+            a_read_started.set()
+            assert release_a_read.wait(5), "root_a 的读线程没被放行"
+        return _real_read_json(path)
+
+    monkeypatch.setattr(state, "read_json", controlled_read)
+
+    url = "https://example.test/fresh"
+    recorder = asyncio.create_task(
+        state._record_source_used(
+            url=url, kind="web", title="fresh", memory_dir=root_a
+        )
+    )
+    # 等 recorder 的 _ensure(root_a) 进临界区并卡在读盘上。
+    await asyncio.to_thread(a_read_started.wait, 5)
+
+    swapper = asyncio.create_task(
+        state._ensure_source_history_loaded(memory_dir=root_b)
+    )
+    # 让 swapper 跑到「排队等 _source_history_lock」为止：它必须排在 recorder 的
+    # 写入取锁之前（asyncio.Lock 是 FIFO），才复现出那个窗口。
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+    release_a_read.set()
+    assert await swapper is True
+    await recorder
+
+    # 内存此刻属于 root_b，于是 root_a 的那次覆盖写必须被放弃。
+    assert state._source_history_loaded_path == _history_path(root_b)
+    assert _disk_entries(root_a) == seeded_a, "root_a 的历史不许被别的根的内容覆盖"
+    assert _disk_entries(root_b) == seeded_b, "root_b 只是被加载，不该被写"
+    assert state._source_hash(url, "fresh") not in _disk_entries(root_a)
+
+
+@pytest.mark.asyncio
+async def test_permanent_read_failure_logs_at_a_throttled_rate(
+    monkeypatch, tmp_path
+) -> None:
+    """A permanently unreadable history must stay visible without one warning per record."""
+    # 「读不出来就跳过」的代价可能是永久的：文件的读 ACL 坏掉而目录仍可写时，记录会
+    # 一直停摆，对用户只表现为她反复聊同一个东西。日志是这件事唯一的出口，所以既不能
+    # 每次刷一条把自己淹掉，也不能安静到看不见。
+    root = tmp_path / "memory"
+    _seed_history(root, 7)
+
+    def exploding_read(path):
+        raise PermissionError(13, "file used by another process")
+
+    monkeypatch.setattr(state, "read_json", exploding_read)
+
+    warnings: list[str] = []
+
+    class _Recorder:
+        def warning(self, fmt, *args):
+            warnings.append(fmt % args)
+
+        def __getattr__(self, name):
+            return lambda *a, **k: None
+
+    monkeypatch.setattr(state, "logger", _Recorder())
+
+    for _ in range(60):
+        await state._record_source_used(
+            url="https://example.test/fresh",
+            kind="web",
+            title="fresh",
+            memory_dir=root,
+        )
+
+    skips = [line for line in warnings if "跳过本次 source 记录" in line]
+    reads = [line for line in warnings if "本次不视为已加载" in line]
+    # 前 3 次 + 第 50 次 = 4 条。写成「< 60」不够：那样把节流退化成「每 2 次报一次」
+    # 也算过，而那依然是刷屏。
+    assert len(skips) == 4, warnings
+    # 加载侧同样每次调用都重来一遍。只降记录侧的频，日志里照样是 60 行，「停摆」
+    # 一样被淹掉 —— 两侧必须一起降。
+    assert len(reads) == 4, warnings
+    assert len(warnings) == 8, warnings
+    assert "连续跳过 50 次" in skips[-1], "降频之后的日志必须带累计数，否则看不出是停摆"
+    assert "连续失败 50 次" in reads[-1]
+
+    # 盘上一条没少 —— 降频只改日志，不改「宁可漏记也不截库」这个取舍。
+    assert len(_disk_entries(root)) == 7
+
+    # 读恢复 → 记录成功 → 连跳计数清零；再坏掉时必须立刻重新报，而不是接着上一轮的
+    # 节流继续数到 100 才吭声。
+    monkeypatch.setattr(state, "read_json", _real_read_json)
+    await state._record_source_used(
+        url="https://example.test/ok", kind="web", title="ok", memory_dir=root
+    )
+    assert state._source_history_skipped_records == 0
+    assert state._source_history_read_failures == 0
+
+    monkeypatch.setattr(state, "read_json", exploding_read)
+    state._source_history_loaded = False
+    state._source_history_loaded_path = None
+    warnings.clear()
+    await state._record_source_used(
+        url="https://example.test/again", kind="web", title="again", memory_dir=root
+    )
+    assert [line for line in warnings if "连续跳过 1 次" in line], warnings
+    assert [line for line in warnings if "连续失败 1 次" in line], warnings

--- a/tests/unit/test_proactive_source_history_locking.py
+++ b/tests/unit/test_proactive_source_history_locking.py
@@ -20,7 +20,11 @@ def _isolate_source_history():
     saved_loaded = state._source_history_loaded
     saved_path = state._source_history_loaded_path
     state._source_history.clear()
-    state._source_history_loaded = True  # _record_source_used 本身不加载，这里只是别让它看起来是冷的
+    # 从「完全没加载过」起步：_record_source_used 现在自己会先
+    # _ensure_source_history_loaded，用例的 tmp_path 下没有历史文件，那次加载走
+    # FileNotFoundError（正常的空历史），落到临界区的仍然只有本用例写进去的条目。
+    state._source_history_loaded = False
+    state._source_history_loaded_path = None
     yield
     state._source_history.clear()
     state._source_history.update(saved)


### PR DESCRIPTION

## 缺陷

`main_logic/proactive_chat/state.py` 的 `_ensure_source_history_loaded` 读盘失败时走
`except Exception: logger.warning(...)`，然后**照样**置 `_source_history_loaded = True`。
于是内存是空的、却被标记「已加载」。而 `_record_source_used` 是**全量覆盖写**
（`entries: dict(_source_history)`），下一次记录就把盘上整段历史截断成 1 条。

触发只需要**一次瞬时读盘失败** —— Windows 杀软/索引器短暂占住文件，正是 #2528 这一族的
场景。实测：盘上 7 条 → **1 条**。

`proactive_source_history.json` 是「这个素材我已经用过」的清单，丢了她就会把刚聊过的
东西再聊一遍。

## 这条是证伪一个错误假设时挖出来的

原本怀疑的是「`_record_source_used` 从不 await 加载」。查下来**证伪了**：AST 分析
`handle_proactive_chat` 的 try-body 语句序，加载是第 53 条、无条件执行，两处记录是
第 115 / 170 条，中间没有能绕开加载的分支；memory_dir 也一致。机制成立但生产不可达。

真正可达的是上面这条 —— 根因不是「加载顺序」，是「加载失败按空历史处理 + 全量覆盖写」
这个组合。

## 修法

按失败类型分三类，而不是一刀切：

1. `FileNotFoundError`（首启 / 被清理）= **正常**的空历史，照旧标记已加载。
2. 内容损坏（`ValueError` / `TypeError`，含 JSONDecodeError、UnicodeDecodeError）=
   盘上那份已经不是可用历史，重试永远失败 → 按空历史起步、标记已加载，由后续覆盖写自愈。
   否则一个坏文件会让记录**永久停摆**，比原 bug 更糟。
3. 真正的读失败（IO / 权限 / 被占住）→ 不标记已加载，让下一次调用重试。

返回类型 `None` → `bool`（「内存现在能不能代表盘上那份」）。这个信号不是装饰：
全量覆盖写必须有人明确回答这个问题，不能让调用方去猜。

**解析进局部 dict、成功后才整体换入**。三件套（flag / path / 内存）要么一起前进、
要么一动不动。这一条同时关掉三个洞：
- 取消：`CancelledError` 是 `BaseException`，两个 except 都接不住；原写法
  `_source_history.clear()` 在 try 之前，于是取消会留下「flag=True、path=旧 root、内存空」
  —— 正是本 PR 要消灭的状态。
- 局部损坏：解析循环里单条 `ts` / `kind` 坏就抛 ValueError/TypeError，原写法会把循环里
  **已经解析好的合法条目一并丢掉**。现在逐条 try/except 跳过坏条目（坏的那条本来就该被
  遗忘），其余照常存活。实测 7 条里坏 2 条：存活 5 条 + 新条目。
- 顺带消掉一行死代码。

**护栏：把不变量变成局部自明。** 「记录之前一定先加载过」此前只靠行号维持（加载和记录
之间隔约 1000 行、几十个 await），谁把投递分支提前就静默抹库且无测试会红。
现在 `_record_source_used` 进锁**之前**自己 await 一次加载（`_ensure` 自己要取同一把锁，
锁内调必自锁），进锁**之后**再做一次纯内存复核 —— 因为 `_ensure` 走 IO 分支时会持锁
await，释放后另一个 root 的 `_ensure` 能插进来把内存换掉。实测：不复核的话 root_a 的
7 条会被换成 root_b 的 3 条 + 新条目。

**加载失败时整条跳过记录**（不进锁、不改内存、不写盘）。取舍是量级不对等：丢这一次记录
= 这条素材可能被再聊一遍；拿空内存全量覆盖 = **所有**素材都可能被再聊一遍。
它不会退化成「读不出来就再也不记录了」：加载每次调用都重试，盘一恢复下一次就正常落地；
唯一「永远读不出来」的一类（内容损坏）已经在加载侧分流成自愈路径。

**可见性**：读失败侧与跳过侧各有一个连续计数，共享降频闸（前 3 次照报、之后每 50 次一报，
消息里带累计数），任何一次成功都清零。否则「彻底停摆」会淹没在每次 record 一条 warning 的
噪音里，跟「抖了一下」分不出来。

## 两轮对抗性审共 6 条，全部处理

其中最有价值的一条指出**我的第一版在某个场景下比改动前更糟**：局部损坏时新加的
`clear()` 会把已解析好的合法条目陪葬（改动前还能救回 4 条，第一版只剩 1 条）。
`clear()` 放在 try 之前那个位置同时制造了三个问题，说明位置本身就选错了。

变异验证 16 处全部被杀、0 存活。

验证：相关测试 24 passed 连跑 3 次；`tests/unit -k proactive` 780 passed；
全量 tests/unit **9449 passed, 45 skipped**；ruff 与 docstring 禁 CJK 门均通过。

Refs #2528

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


## 回归报告

**改动**：`main_logic/proactive_chat/state.py` 的 `_ensure_source_history_loaded`（失败分类、局部 dict 换入、逐条跳过坏条目、返回 bool）与 `_record_source_used`（进锁前自加载、进锁后纯内存复核、加载失败整条跳过、降频日志）；`main_routers/system_router/proactive_sources.py` 门面透传返回值；新增 1 个测试文件、修正 1 处反向注释。

**必要性**：一次瞬时读盘失败就把用户的整段「已用素材」清单截成 1 条，且**完全静默**。

**改动前 → 改动后**：

- 前：读盘失败 → 空内存被标记「已加载」→ 下一次记录全量覆盖 → 盘上 7 条变 1 条。后：不标记已加载，下一次调用重试；记录整条跳过。
- 前：取消落在读盘那次 await 上 → 留下「flag=True / path=旧 root / 内存空」。后：三件套只在成功换入时一起前进。
- 前：单条 `ts` 坏 → 整份作废。后：跳过坏的那条，其余存活。
- 前：「记录前先加载」只靠 `service.py` 里相隔约 1000 行的语句顺序。后：`_record_source_used` 自己保证，且进锁后复核换根。
- 未改动的行为：正常路径的 IO 次数（已加载时是快速返回；显式传 `memory_dir` 时不碰单例，既有的 `reads == [expected_path]` 断言仍绿）；`_should_skip_source` 的降级逻辑。

**潜在回归**：

1. **永久读失败下记录会一直跳过**（盘上一条不写）。取舍见上：截库比漏记严重得多。有降频日志 + 累计数让它可见。**但有一个反例我只做了逻辑推演、没在真实 Windows ACL 上验证**：文件读 ACL 坏掉但目录可写时 `os.replace` 能成功 —— 这种情况旧代码会截断一次然后自愈，新代码永远停摆。
2. `except (ValueError, TypeError)` 把「内容损坏」分流成自愈路径。若将来 `read_json` 换实现、把某类 IO 错误包成 `ValueError`，会被误判成损坏而允许覆盖写。当前 `utils/file_utils.read_json` 是 `open()+json.load()`，OSError 家族不会退化成 ValueError。
3. 每次记录多一次加载调用（已加载时是 O(1) 快速返回）+ 进锁后一次纯内存比较。
4. 降频阈值（前 3 次 + 每 50 次）是拍的，没有依据；改阈值要同步改测试断言。

**测试侧值得一提**：新加的两条并发用例撞上了仓库既有的一个坑 —— `asyncio.Lock` 只在**有竞争**那条路上才绑定事件循环，而 pytest-asyncio 每个用例一个新循环，所以模块级锁被某个并发用例争用过之后，后面的并发用例会撞 `bound to a different event loop`。这里用 autouse fixture 换锁绕开了。这个坑不是本 PR 引入的，但**只要仓库里出现第二个碰同一把模块级 asyncio.Lock 的并发用例就会重现** —— 值得在 conftest 里统一收口，不在本 PR 范围。

**验证**：全量 `tests/unit` **9449 passed, 45 skipped**；`-k proactive` 780 passed；相关测试 24 passed 连跑 3 次；**16 个变异全部被杀、0 存活**；`ruff` 与 `check_docstring_no_cjk.py` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
