### PR TITLE
test(ci): 接入 pytest-randomly；fix(storage): 收口 root_state 上环同步落盘

### DIFF
--- a/.github/workflows/random-order-tests.yml
+++ b/.github/workflows/random-order-tests.yml
@@ -1,0 +1,79 @@
+name: Random Order Tests
+
+# 用随机 seed 跑一遍 tests/unit，专门抓用例之间的顺序依赖。
+#
+# 为什么单独开一个定时 job，而不是让 PR CI 直接随机跑：随机顺序本身就是一个 flake
+# 源——同一个 commit 两次跑可能一红一绿，而红的原因跟这个 PR 的改动毫无关系。
+# unit-tests.yml 因此在 pytest.ini 里钉死 seed 保持确定性，把"持续找新的顺序依赖"
+# 这件事挪到这里：它不是任何 PR 的必需检查，红了是一条独立信号，不挡任何人合并。
+#
+# 失败怎么办：日志头部会打印 `Using --randomly-seed=<N>`，拿那个数字本地复现
+#   uv run pytest tests/unit -q --randomly-seed=<N>
+# 顺序依赖的典型形态是"产品代码里的进程级可变全局被前一条用例写脏"，修法通常是给
+# 那个模块加一条 autouse fixture 做前后清理（见 tests/unit/test_music_router.py 的
+# _reset_music_proxy_cache）。
+on:
+  schedule:
+    # 18:37 UTC ≈ 次日 02:37 北京时间。错开整点，避开 GitHub 定时任务高峰。
+    - cron: '37 18 * * *'
+  workflow_dispatch:
+    inputs:
+      seed:
+        description: 'pytest-randomly seed（留空 = 随机取一个）'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: random-order-tests-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  random-order-pytest:
+    name: Unit pytest, random order (Windows)
+    # 与 unit-tests.yml 同平台：换平台会引入与顺序无关的差异，那样红了没法判断
+    # 是顺序依赖还是平台差异。
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Install pyclipper (in-tree rapidocr fork)
+        # 与 unit-tests.yml 同一个理由和同一个 pin：那边不装这个 wheel 会让
+        # deps/rapidocr_pillow 的四条用例 skip 掉，这边同样需要它们真的跑。
+        run: uv pip install pyclipper==1.4.0
+
+      - name: Run unit test suite in a random order
+        shell: pwsh
+        env:
+          # 经 env 传，不要在 run: 里直接 ${{ inputs.seed }} 插值——
+          # workflow_dispatch 的输入是外部可控字符串，插值等于让它参与拼脚本。
+          SEED_INPUT: ${{ inputs.seed }}
+        # pytest.ini 的 addopts 里钉着 --randomly-seed=<固定值>，命令行上再给一次
+        # 会覆盖它（同名选项后者生效）。不要改成 `-p no:randomly` 去关插件——插件
+        # 被屏蔽后 addopts 里的 --randomly-seed 会变成无法识别的参数直接报错。
+        run: |
+          $seed = $env:SEED_INPUT
+          if ([string]::IsNullOrWhiteSpace($seed)) {
+            $seed = Get-Random -Minimum 1 -Maximum 2147483647
+          }
+          elseif ($seed -notmatch '^\d+$') {
+            throw "seed 必须是十进制整数，收到: $seed"
+          }
+          Write-Host "randomly-seed = $seed"
+          uv run pytest tests/unit -q --randomly-seed=$seed

--- a/app/main_server/__init__.py
+++ b/app/main_server/__init__.py
@@ -1021,15 +1021,19 @@ async def _ensure_main_server_runtime_initialized(*, reason: str) -> bool:
 async def release_storage_startup_barrier(
     *, reason: str = "storage_selection_continue_current_session"
 ) -> dict[str, Any]:
-    await _request_memory_server_continue_startup(reason)
     try:
+        # The continue request has an ambiguous cancellation outcome: memory_server
+        # may have applied it even when this client never receives the response.
+        # Keep the request itself inside the compensation boundary so every failed
+        # exit re-establishes both admission guards before storage state rolls back.
+        await _request_memory_server_continue_startup(reason)
         initialized = await _ensure_main_server_runtime_initialized(reason=reason)
     except BaseException:
-        # Once memory_server has accepted continue-startup, every failed exit from
-        # main initialization must put its admission guard back before the storage
-        # router restores a blocking root_state snapshot.  CancelledError is a
-        # BaseException, so an Exception-only handler leaves initialized memory
-        # writable against the rolled-back storage state.
+        # Once memory_server may have accepted continue-startup, every failed exit
+        # must put its admission guard back before the storage router restores a
+        # blocking root_state snapshot. CancelledError is a BaseException, so an
+        # Exception-only handler leaves initialized memory writable against the
+        # rolled-back storage state.
         _enable_main_storage_limited_mode("runtime_initialization_failed")
 
         # Re-blocking is compensating work, not part of the cancelled request.  A

--- a/app/main_server/__init__.py
+++ b/app/main_server/__init__.py
@@ -930,7 +930,15 @@ async def _ensure_main_server_runtime_initialized(*, reason: str) -> bool:
                     )
             elif should_write_root_mode_normal_after_startup(current_root_state):
                 try:
-                    set_root_mode(
+                    # 挪进工作线程有两个理由，缺一不可：
+                    # 1) set_root_mode 是同步落盘（mkstemp + fsync + os.replace）；
+                    # 2) 它拿 root_state 的写者锁，而 storage_location 那几条变更路由
+                    #    现在在工作线程里持同一把锁。受限启动期存储页跟这段是可以
+                    #    重叠的，留在循环上就等于把工作线程那次 fsync（撞上 Windows
+                    #    占用还要加最多 155ms 退避）接回循环。同一把锁的所有入口要么
+                    #    都在工作线程，要么都不在。
+                    await asyncio.to_thread(
+                        set_root_mode,
                         _config_manager,
                         ROOT_MODE_NORMAL,
                         current_root=str(_config_manager.app_docs_dir),

--- a/app/main_server/__init__.py
+++ b/app/main_server/__init__.py
@@ -1024,18 +1024,55 @@ async def release_storage_startup_barrier(
     await _request_memory_server_continue_startup(reason)
     try:
         initialized = await _ensure_main_server_runtime_initialized(reason=reason)
-    except Exception:
+    except BaseException:
+        # Once memory_server has accepted continue-startup, every failed exit from
+        # main initialization must put its admission guard back before the storage
+        # router restores a blocking root_state snapshot.  CancelledError is a
+        # BaseException, so an Exception-only handler leaves initialized memory
+        # writable against the rolled-back storage state.
         _enable_main_storage_limited_mode("runtime_initialization_failed")
-        try:
-            await _request_memory_server_block_startup(
+
+        # Re-blocking is compensating work, not part of the cancelled request.  A
+        # second cancellation (for example server shutdown following a client
+        # disconnect) must not interrupt it halfway through.  Keep the request in
+        # this handler until the HTTP call has really finished, then re-raise the
+        # original exception below.
+        block_task = asyncio.ensure_future(
+            _request_memory_server_block_startup(
                 f"{reason}:main_server_init_failed"
             )
+        )
+        try:
+            await asyncio.shield(block_task)
+        except asyncio.CancelledError:
+            while not block_task.done():
+                try:
+                    await asyncio.wait({block_task})
+                except asyncio.CancelledError:
+                    continue
         except Exception as revert_exc:
             logger.warning(
                 "main_server 初始化失败后恢复 memory_server limited-mode 失败: %s",
                 revert_exc,
                 exc_info=True,
             )
+            # ``shield`` already retrieved this exception; do not call result()
+            # below and log the same failure a second time.
+            block_task = None
+        else:
+            # ``shield`` returns the task result, so there is nothing left to
+            # retrieve on the ordinary path.
+            block_task = None
+
+        if block_task is not None and block_task.done() and not block_task.cancelled():
+            try:
+                block_task.result()
+            except Exception as revert_exc:
+                logger.warning(
+                    "main_server 初始化取消后恢复 memory_server limited-mode 失败: %s",
+                    revert_exc,
+                    exc_info=True,
+                )
         raise
     _disable_main_storage_limited_mode()
     _start_neko_servers_integration_workers()

--- a/app/main_server/__init__.py
+++ b/app/main_server/__init__.py
@@ -118,6 +118,7 @@ from utils.cloudsave_runtime import (
     should_write_root_mode_normal_after_startup,
 )
 from utils.config_manager import get_config_manager, get_reserved  # noqa
+from utils.root_state_lock import root_state_transaction
 from utils.storage_location_bootstrap import get_storage_startup_blocking_reason
 
 # 将日志初始化提前，确保导入阶段异常也能落盘
@@ -929,24 +930,43 @@ async def _ensure_main_server_runtime_initialized(*, reason: str) -> bool:
                         "跳过 ROOT_MODE_NORMAL 写入：root_state 缺失或读取失败"
                     )
             elif should_write_root_mode_normal_after_startup(current_root_state):
+                # 挪进工作线程有两个理由，缺一不可：
+                # 1) set_root_mode 是同步落盘（mkstemp + fsync + os.replace）；
+                # 2) 它拿 root_state 的写者锁，而 storage_location 那几条变更路由
+                #    现在在工作线程里持同一把锁。受限启动期存储页跟这段是可以
+                #    重叠的，留在循环上就等于把工作线程那次 fsync（撞上 Windows
+                #    占用还要加最多 155ms 退避）接回循环。同一把锁的所有入口要么
+                #    都在工作线程，要么都不在。
+                #
+                # ⚠️ 上面那次 should_write_root_mode_normal_after_startup 判定是在
+                # 循环上做的，跟这次落盘之间隔了一个 await。job 排队期间，存储变更
+                # 路由的工作线程完全可能刚提交 ROOT_MODE_MAINTENANCE_READONLY（用户
+                # 正在发起重启迁移）——那时无脑写 NORMAL 就是把它的受限态踩掉。
+                # 所以判定跟着写一起进锁内重做一遍，恢复"检查和写不可分割"这条原本
+                # 靠"同在循环线程"隐式成立的性质。
+                def _mark_startup_successful() -> bool:
+                    with root_state_transaction():
+                        state = _config_manager.load_root_state()
+                        if not isinstance(state, dict):
+                            return False
+                        if not should_write_root_mode_normal_after_startup(state):
+                            return False
+                        set_root_mode(
+                            _config_manager,
+                            ROOT_MODE_NORMAL,
+                            current_root=str(_config_manager.app_docs_dir),
+                            last_known_good_root=str(_config_manager.app_docs_dir),
+                            last_successful_boot_at=datetime.now(timezone.utc)
+                            .isoformat()
+                            .replace("+00:00", "Z"),
+                        )
+                        return True
+
                 try:
-                    # 挪进工作线程有两个理由，缺一不可：
-                    # 1) set_root_mode 是同步落盘（mkstemp + fsync + os.replace）；
-                    # 2) 它拿 root_state 的写者锁，而 storage_location 那几条变更路由
-                    #    现在在工作线程里持同一把锁。受限启动期存储页跟这段是可以
-                    #    重叠的，留在循环上就等于把工作线程那次 fsync（撞上 Windows
-                    #    占用还要加最多 155ms 退避）接回循环。同一把锁的所有入口要么
-                    #    都在工作线程，要么都不在。
-                    await asyncio.to_thread(
-                        set_root_mode,
-                        _config_manager,
-                        ROOT_MODE_NORMAL,
-                        current_root=str(_config_manager.app_docs_dir),
-                        last_known_good_root=str(_config_manager.app_docs_dir),
-                        last_successful_boot_at=datetime.now(timezone.utc)
-                        .isoformat()
-                        .replace("+00:00", "Z"),
-                    )
+                    if not await asyncio.to_thread(_mark_startup_successful):
+                        logger.info(
+                            "跳过 ROOT_MODE_NORMAL 写入：落盘前 root_state 已被改成阻断态"
+                        )
                 except Exception as e:
                     logger.error(
                         "写入 main_server 启动成功标记失败，启动不会标记为成功: %s", e

--- a/app/memory_server/runtime.py
+++ b/app/memory_server/runtime.py
@@ -60,6 +60,7 @@ from utils.cloudsave_runtime import (
     should_write_root_mode_normal_after_startup,
 )
 from utils.config_manager import get_config_manager
+from utils.root_state_lock import root_state_transaction
 from utils.storage_location_bootstrap import get_storage_startup_blocking_reason
 from utils.asgi_body_limit import InboundBodySizeLimitMiddleware
 from utils.host_origin_guard import HostOriginGuardMiddleware
@@ -596,23 +597,29 @@ async def ensure_memory_server_runtime_initialized(*, reason: str = "") -> bool:
             )
 
         if bootstrap_ok:
-            current_root_state = _config_manager.load_root_state()
-            if should_write_root_mode_normal_after_startup(current_root_state):
-                try:
-                    set_root_mode(
-                        _config_manager,
-                        ROOT_MODE_NORMAL,
-                        current_root=str(_config_manager.app_docs_dir),
-                        last_known_good_root=str(_config_manager.app_docs_dir),
-                        last_successful_boot_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            # ⚠️ 判定和写必须在同一个锁内事务里。它们以前靠"中间没有 await"隐式原子，
+            # 但那只挡得住同一条事件循环上的协程 —— merged 模式下存储变更路由跟这段同
+            # 进程，而它的写现在跑在工作线程上，完全可以插在判定和写之间提交
+            # ROOT_MODE_MAINTENANCE_READONLY，随后被这里无条件写回 NORMAL，留下一个
+            # 没有写闸的待迁移。
+            with root_state_transaction():
+                current_root_state = _config_manager.load_root_state()
+                if should_write_root_mode_normal_after_startup(current_root_state):
+                    try:
+                        set_root_mode(
+                            _config_manager,
+                            ROOT_MODE_NORMAL,
+                            current_root=str(_config_manager.app_docs_dir),
+                            last_known_good_root=str(_config_manager.app_docs_dir),
+                            last_successful_boot_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                        )
+                    except Exception as e:
+                        logger.warning(f"[Memory] 写入启动成功标记失败: {e}")
+                else:
+                    logger.info(
+                        "[Memory] 跳过 ROOT_MODE_NORMAL 写入，当前仍处于阻断态: %s",
+                        current_root_state.get("mode") or ROOT_MODE_NORMAL,
                     )
-                except Exception as e:
-                    logger.warning(f"[Memory] 写入启动成功标记失败: {e}")
-            else:
-                logger.info(
-                    "[Memory] 跳过 ROOT_MODE_NORMAL 写入，当前仍处于阻断态: %s",
-                    current_root_state.get("mode") or ROOT_MODE_NORMAL,
-                )
         else:
             logger.warning("[Memory] 跳过 ROOT_MODE_NORMAL 写入：cloudsave bootstrap 未成功")
 

--- a/launcher_core/runtime.py
+++ b/launcher_core/runtime.py
@@ -58,6 +58,7 @@ from utils.port_utils import (
     is_port_in_excluded_range,
     set_port_probe_reuse,
 )
+from utils.root_state_lock import root_state_transaction
 from utils.cloudsave_runtime import (
     CLOUDSAVE_DISABLED_ENV,
     CLOUDSAVE_DISABLED_LOCAL_STATE_UNAVAILABLE,
@@ -646,16 +647,19 @@ def _maybe_schedule_storage_restart() -> bool:
 
 
 def _persist_post_startup_root_state(config_manager) -> None:
-    current_root_state = config_manager.load_root_state()
-    if should_write_root_mode_normal_after_startup(current_root_state):
-        set_root_mode(
-            config_manager,
-            ROOT_MODE_NORMAL,
-            current_root=str(config_manager.app_docs_dir),
-            last_known_good_root=str(config_manager.app_docs_dir),
-            last_successful_boot_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
-        )
-        return
+    # 判定和写进同一个锁内事务，理由同 app/memory_server/runtime.py 那处：
+    # "中间没有 await"只挡得住同一循环上的协程，挡不住工作线程上的存储变更写。
+    with root_state_transaction():
+        current_root_state = config_manager.load_root_state()
+        if should_write_root_mode_normal_after_startup(current_root_state):
+            set_root_mode(
+                config_manager,
+                ROOT_MODE_NORMAL,
+                current_root=str(config_manager.app_docs_dir),
+                last_known_good_root=str(config_manager.app_docs_dir),
+                last_successful_boot_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            )
+            return
 
     print(
         "[Launcher] Preserving non-normal root_state after startup: "
@@ -2837,17 +2841,19 @@ def _prepare_cloudsave_runtime_for_launch() -> dict:
             fence_already_active=True,
         )
 
-    load_root_state = getattr(config_manager, "load_root_state", None)
-    current_root_state = load_root_state() if callable(load_root_state) else {"mode": ROOT_MODE_NORMAL}
-    if should_write_root_mode_normal_after_startup(current_root_state):
-        root_state = set_root_mode(
-            config_manager,
-            ROOT_MODE_NORMAL,
-            current_root=str(config_manager.app_docs_dir),
-            last_known_good_root=str(config_manager.app_docs_dir),
-        )
-    else:
-        root_state = current_root_state
+    # 同上：判定和写不能被别的线程插进来，整段进锁。
+    with root_state_transaction():
+        load_root_state = getattr(config_manager, "load_root_state", None)
+        current_root_state = load_root_state() if callable(load_root_state) else {"mode": ROOT_MODE_NORMAL}
+        if should_write_root_mode_normal_after_startup(current_root_state):
+            root_state = set_root_mode(
+                config_manager,
+                ROOT_MODE_NORMAL,
+                current_root=str(config_manager.app_docs_dir),
+                last_known_good_root=str(config_manager.app_docs_dir),
+            )
+        else:
+            root_state = current_root_state
     root_mode = str(root_state.get("mode") or "")
     root_state_event_payload = {
         "mode": root_mode,

--- a/main_routers/storage_location_router.py
+++ b/main_routers/storage_location_router.py
@@ -293,8 +293,14 @@ async def _run_locked_storage_job(job: Callable[[], Any]) -> Any:
     try:
         return await asyncio.shield(task)
     except asyncio.CancelledError:
-        with suppress(asyncio.CancelledError):
-            await asyncio.wait({task})
+        # 循环等到 worker 真的结束，而不是"suppress 一次就走"。第二次 cancel（典型
+        # 组合：请求先被取消，紧接着服务器关闭又取消一次）会让下面这个 await 再抛一
+        # 次；只 suppress 一次的话就会在 worker 还在写的时候把 _storage_mutation_lock
+        # 让出去，等于这段防护白做。worker 是一次有界的落盘（最坏再加 155ms 退避），
+        # 所以这个循环一定会停。
+        while not task.done():
+            with suppress(asyncio.CancelledError):
+                await asyncio.wait({task})
         # 取回异常再走人：没人 retrieve 的话 asyncio 会在 GC 时打
         # "Task exception was never retrieved"，把一次落盘失败变成一条谁也对不上的
         # 日志。这里只是消费掉它——取消已经发生，原来的 CancelledError 才是要传出去的。

--- a/main_routers/storage_location_router.py
+++ b/main_routers/storage_location_router.py
@@ -345,7 +345,11 @@ async def _release_storage_startup_barrier_or_rollback(
 ) -> None:
     try:
         await _release_storage_startup_barrier_if_needed(reason=reason)
-    except Exception:
+    except BaseException:
+        # BaseException 而不是 Exception：客户端断连时这里收到的是 CancelledError，
+        # 只接 Exception 就会正好跳过这段回滚——而"写已落盘、屏障没解除"恰恰是最需要
+        # 回滚的那个状态。下面无条件 raise，所以 KeyboardInterrupt / SystemExit 的
+        # 语义不变。
         try:
             # 这一处**刻意**留在事件循环上。_restore_storage_mutation_state 的最后
             # 一步是 config_manager.save_root_state()，而 root_state 还有另一个写者：
@@ -1932,6 +1936,17 @@ async def _post_storage_location_restart_locked(
                 write=_rebind_to_selected_root,
             )
             await _request_app_shutdown(request_app_shutdown)
+        except asyncio.CancelledError:
+            # 取消也必须回滚。工作线程已经跑完（_run_locked_storage_job 保证了这点），
+            # 也就是说检查点 / 策略 / maintenance_readonly 都已经落盘，而
+            # _request_app_shutdown 没发出去——留着就是把应用钉死在受限态，用户看到
+            # 一个永远不重启的"正在迁移"。
+            # CancelledError 是 BaseException，下面的 except Exception 接不住，所以
+            # 必须单列。回滚本身是同步的，不会再被取消。
+            if state_snapshot:
+                with suppress(Exception):
+                    _restore_storage_mutation_state(config_manager, state_snapshot, anchor_root=anchor_root)
+            raise
         except Exception as exc:
             try:
                 # 与 _release_storage_startup_barrier_or_rollback 那处同因同治：回滚
@@ -2014,6 +2029,21 @@ async def _post_storage_location_restart_locked(
     try:
         migration_payload = await _run_locked_storage_job(_schedule_pending_migration)
         await _request_app_shutdown(request_app_shutdown)
+    except asyncio.CancelledError:
+        # 同上：写已落盘、shutdown 没发出去，不回滚就会留下一个没人执行的待迁移
+        # 检查点 + maintenance_readonly。rollback_state 为空 = 什么都还没写。
+        if rollback_state:
+            previous_root_state = rollback_state.get("root_state")
+            previous_migration_payload = rollback_state.get("migration")
+            with suppress(Exception):
+                if isinstance(previous_migration_payload, dict):
+                    save_storage_migration(config_manager, previous_migration_payload, anchor_root=anchor_root)
+                else:
+                    delete_storage_migration(config_manager, anchor_root=anchor_root)
+            with suppress(Exception):
+                if isinstance(previous_root_state, dict):
+                    config_manager.save_root_state(previous_root_state)
+        raise
     except Exception as exc:
         # rollback_state 为空 = 两份 pre-image 还没读到，也就意味着
         # create_pending_storage_migration 一行都还没跑，没有东西需要回滚。这时候

--- a/main_routers/storage_location_router.py
+++ b/main_routers/storage_location_router.py
@@ -295,6 +295,14 @@ async def _run_locked_storage_job(job: Callable[[], Any]) -> Any:
     except asyncio.CancelledError:
         with suppress(asyncio.CancelledError):
             await asyncio.wait({task})
+        # 取回异常再走人：没人 retrieve 的话 asyncio 会在 GC 时打
+        # "Task exception was never retrieved"，把一次落盘失败变成一条谁也对不上的
+        # 日志。这里只是消费掉它——取消已经发生，原来的 CancelledError 才是要传出去的。
+        if task.done() and not task.cancelled() and task.exception() is not None:
+            logger.warning(
+                "storage write job failed after the request was cancelled: %s",
+                task.exception(),
+            )
         raise
 
 

--- a/main_routers/storage_location_router.py
+++ b/main_routers/storage_location_router.py
@@ -335,9 +335,13 @@ async def _apply_storage_mutation_writes(
     """
 
     def _job() -> Any:
-        snapshot_out.clear()
-        snapshot_out.update(_snapshot_storage_mutation_state(config_manager, anchor_root=anchor_root))
-        return write()
+        # The rollback pre-image and the mutation must observe one root-state
+        # transaction. In particular, do not snapshot the temporary mode held
+        # by cloud_apply_fence and then replay it after that fence has exited.
+        with root_state_transaction():
+            snapshot_out.clear()
+            snapshot_out.update(_snapshot_storage_mutation_state(config_manager, anchor_root=anchor_root))
+            return write()
 
     return await _run_locked_storage_job(_job)
 
@@ -2008,28 +2012,32 @@ async def _post_storage_location_restart_locked(
     rollback_state: dict[str, Any] = {}
 
     def _schedule_pending_migration() -> dict[str, Any]:
-        # 两份 pre-image 都读到之后再一起记进 rollback_state，这样
-        # "rollback_state 非空" 就等价于 "两份都在手上"。分两次记的话，第二次读
-        # 抛异常会留下 migration 键缺失，回滚分支就会把一份本来就存在的检查点删掉。
-        previous_root_state = config_manager.load_root_state()
-        previous_migration = load_storage_migration(config_manager, anchor_root=anchor_root)
-        rollback_state["root_state"] = previous_root_state
-        rollback_state["migration"] = previous_migration
-        pending_payload = create_pending_storage_migration(
-            config_manager,
-            source_root=current_root,
-            target_root=normalized_selected_root,
-            selection_source=payload.selection_source,
-            anchor_root=anchor_root,
-            confirmed_existing_target_content=bool(payload.confirm_existing_target_content),
-        )
-        set_root_mode(
-            config_manager,
-            ROOT_MODE_MAINTENANCE_READONLY,
-            last_migration_source=str(current_root),
-            last_migration_result=f"restart_pending:{normalized_selected_root}",
-        )
-        return pending_payload
+        # The pre-images cannot be captured while cloud_apply_fence exposes a
+        # temporary root mode. Keep them in the same transaction as both writes
+        # so rollback always restores the state immediately preceding this job.
+        with root_state_transaction():
+            # 两份 pre-image 都读到之后再一起记进 rollback_state，这样
+            # "rollback_state 非空" 就等价于 "两份都在手上"。分两次记的话，第二次读
+            # 抛异常会留下 migration 键缺失，回滚分支就会把一份本来就存在的检查点删掉。
+            previous_root_state = config_manager.load_root_state()
+            previous_migration = load_storage_migration(config_manager, anchor_root=anchor_root)
+            rollback_state["root_state"] = previous_root_state
+            rollback_state["migration"] = previous_migration
+            pending_payload = create_pending_storage_migration(
+                config_manager,
+                source_root=current_root,
+                target_root=normalized_selected_root,
+                selection_source=payload.selection_source,
+                anchor_root=anchor_root,
+                confirmed_existing_target_content=bool(payload.confirm_existing_target_content),
+            )
+            set_root_mode(
+                config_manager,
+                ROOT_MODE_MAINTENANCE_READONLY,
+                last_migration_source=str(current_root),
+                last_migration_result=f"restart_pending:{normalized_selected_root}",
+            )
+            return pending_payload
 
     migration_payload = None
     try:

--- a/main_routers/storage_location_router.py
+++ b/main_routers/storage_location_router.py
@@ -1951,7 +1951,7 @@ async def _post_storage_location_restart_locked(
             # 必须单列。回滚本身是同步的，不会再被取消。
             if state_snapshot:
                 with suppress(Exception):
-                    _restore_storage_mutation_state(config_manager, state_snapshot, anchor_root=anchor_root)
+                    _restore_storage_mutation_state(config_manager, state_snapshot, anchor_root=anchor_root)  # noqa: ASYNC_BLOCK — 回滚不能变成取消点，见 _STORAGE_MUTATION_OFFLOAD_CONTRACT
             raise
         except Exception as exc:
             try:
@@ -2043,7 +2043,7 @@ async def _post_storage_location_restart_locked(
             previous_migration_payload = rollback_state.get("migration")
             with suppress(Exception):
                 if isinstance(previous_migration_payload, dict):
-                    save_storage_migration(config_manager, previous_migration_payload, anchor_root=anchor_root)
+                    save_storage_migration(config_manager, previous_migration_payload, anchor_root=anchor_root)  # noqa: ASYNC_BLOCK — 回滚不能变成取消点，见 _STORAGE_MUTATION_OFFLOAD_CONTRACT
                 else:
                     delete_storage_migration(config_manager, anchor_root=anchor_root)
             with suppress(Exception):
@@ -2059,7 +2059,7 @@ async def _post_storage_location_restart_locked(
             previous_migration_payload = rollback_state.get("migration")
             try:
                 if isinstance(previous_migration_payload, dict):
-                    save_storage_migration(config_manager, previous_migration_payload, anchor_root=anchor_root)
+                    save_storage_migration(config_manager, previous_migration_payload, anchor_root=anchor_root)  # noqa: ASYNC_BLOCK — 回滚不能变成取消点，见 _STORAGE_MUTATION_OFFLOAD_CONTRACT
                 else:
                     delete_storage_migration(config_manager, anchor_root=anchor_root)
             except Exception:

--- a/main_routers/storage_location_router.py
+++ b/main_routers/storage_location_router.py
@@ -34,6 +34,7 @@ import shutil
 import sys
 import inspect
 import subprocess
+from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -81,34 +82,38 @@ from utils.storage_policy import (
     validate_selected_root,
 )
 from utils.config_manager import get_config_manager as get_runtime_config_manager
+from utils.root_state_lock import root_state_transaction
 
 router = APIRouter(prefix="/api/storage/location", tags=["storage_location"])
 logger = logging.getLogger(__name__)
 _storage_mutation_lock = asyncio.Lock()
 
-# _STORAGE_MUTATION_STAYS_ON_LOOP
+# _STORAGE_MUTATION_OFFLOAD_CONTRACT
 #
-# 本文件里所有写存储状态的调用**刻意**留在事件循环上（各处 noqa: ASYNC_BLOCK 指向
-# 这里）。落盘本身是同步的、带无上界的 fsync，按理该挪进 to_thread —— 但这里有两条
-# 独立的理由压过它，任缺其一都会造成比循环卡顿严重得多的后果。
+# 这个文件的存储状态写序列**已经挪进工作线程**（#2598 之前写的
+# _STORAGE_MUTATION_STAYS_ON_LOOP 说明作废）。#2598 当时列的两条阻塞理由不是被无视
+# 了，是被逐条解掉的，改动前请先确认它们仍然成立：
 #
-# 一、这些写是**取消原子**的序列，而它们之间今天一个 await 都没有。
-#     典型形状：delete_storage_migration → save_storage_policy → set_root_mode。
-#     任何一处插进 await，请求超时或应用关闭产生的 CancelledError 就能落在中间：
-#     恢复检查点已删、策略已写，而 root mode 还是旧值。CancelledError 是
-#     BaseException，外层 `except Exception` 接不住，也就没人回滚 —— 用户会得到
-#     一个「恢复闸自相矛盾」的盘上状态。
+# 一、取消原子性 —— 靠"整条序列进同一个 to_thread job"保住。
+#     delete_storage_migration → save_storage_policy → set_root_mode 之间依旧一个
+#     await 都没有：它们现在同在一个同步闭包里，由 _apply_storage_mutation_writes /
+#     _run_locked_storage_job 送进 worker。to_thread 被取消时线程照样跑完，所以序列
+#     不会被切成两半。守卫：tests/unit/test_root_state_write_lock.py 的
+#     test_storage_write_primitives_never_sit_directly_in_an_async_body。
 #
-# 二、root_state 有一个**不在锁里**的写者。
-#     build_storage_location_bootstrap_payload → _reconcile_legacy_cleanup_pending_
-#     root_state（utils/storage/location_bootstrap.py:191）会 save_root_state，它挂在
-#     GET /bootstrap、/status、/diagnostics、/retained-source 和 POST /exit 上，这些
-#     都不在 _storage_mutation_lock 覆盖下。今天让「GET 侧 reconcile」和「变更路由的
-#     写」互斥的不是锁，是**它们都跑在同一条事件循环线程上**。把任何一个 root_state
-#     写者挪进 worker，前端存储页每 500ms 的 /status 轮询就能把它整份盖掉。
+#     另外 _run_locked_storage_job 在取消时会**循环等到 worker 结束**再放
+#     CancelledError 出去，否则 _storage_mutation_lock 会在工作线程还在写的时候松开，
+#     下一个变更请求就能跟它交错。
 #
-# 真正的收口是给 root_state 一把真锁，并让 GET 路由别在读路径上写盘。在那之前，
-# 这个文件宁可让罕见的存储变更请求同步落盘。
+# 二、root_state 的无锁写者 —— 已经不存在了。
+#     build_storage_location_bootstrap_payload 现在默认 persist_reconcile=False，
+#     GET /bootstrap、/status、/diagnostics、/retained-source、POST /exit 全是纯读；
+#     只有已经拿着 _storage_mutation_lock 的 *_locked 路由才 opt-in 落盘。另外
+#     root_state 有了真锁（utils/root_state_lock.py），读—改—写整段进锁、锁内重读。
+#
+# 仍然刻意留在循环上的只有**回滚**（_restore_storage_mutation_state 及
+# /restart 的两处内联回滚）：它们全在 except handler 里，await 会让回滚自己变成取消
+# 点，而 CancelledError 是 BaseException，外层 except Exception 接不住。
 
 
 class StorageLocationSelectionRequest(BaseModel):
@@ -224,6 +229,19 @@ def _restore_storage_mutation_state(
     *,
     anchor_root: Path,
 ) -> None:
+    """Roll three storage state files back to a snapshot. Stays synchronous.
+
+    This one deliberately does NOT move to a worker thread even though the other
+    write sequences in this module did. Every caller is an ``except`` handler, and
+    the whole point is that the rollback runs to completion; awaiting inside an
+    except handler makes it a cancellation point, and ``CancelledError`` is a
+    ``BaseException`` that the surrounding ``except Exception`` cannot catch — a
+    client disconnect during the rollback would leave the three files
+    half-reverted with nothing to finish the job.
+
+    The cost is bounded: this only runs when a mutation has already failed, and
+    the routes that call it are already about to return an error response.
+    """
     previous_migration = snapshot.get("migration")
     if isinstance(previous_migration, dict):
         save_storage_migration(config_manager, previous_migration, anchor_root=anchor_root)
@@ -245,6 +263,36 @@ def _restore_storage_mutation_state(
     previous_root_state = snapshot.get("root_state")
     if isinstance(previous_root_state, dict):
         config_manager.save_root_state(previous_root_state)
+
+
+async def _apply_storage_mutation_writes(
+    config_manager,
+    *,
+    anchor_root: Path,
+    snapshot_out: dict[str, Any],
+    write: Callable[[], Any],
+) -> Any:
+    """Take the rollback snapshot and run one storage-state write sequence off the loop.
+
+    Snapshot and writes go into a single worker job on purpose. The sequences
+    these routes run — ``delete_storage_migration`` → ``save_storage_policy`` →
+    ``set_root_mode`` — have no await between them today, and that is load
+    bearing: an await in the middle is a cancellation point that can leave the
+    migration checkpoint deleted while root mode still says maintenance. One job
+    keeps the sequence indivisible from the caller's point of view, because a
+    cancelled ``to_thread`` still lets the worker run to completion.
+
+    ``snapshot_out`` is filled in place rather than returned so the rollback
+    snapshot survives a write that fails halfway through; returning it would
+    lose it on exactly the path that needs it.
+    """
+
+    def _job() -> Any:
+        snapshot_out.clear()
+        snapshot_out.update(_snapshot_storage_mutation_state(config_manager, anchor_root=anchor_root))
+        return write()
+
+    return await asyncio.to_thread(_job)
 
 
 async def _release_storage_startup_barrier_or_rollback(
@@ -274,7 +322,7 @@ async def _release_storage_startup_barrier_or_rollback(
             #
             # 正确的收口是给 root_state 一把真锁、并让 GET 路由别在读路径上写盘，那是
             # 独立的一份工作。在那之前，宁可让这条罕见的回滚路径同步落盘。
-            _restore_storage_mutation_state(config_manager, snapshot, anchor_root=anchor_root)  # noqa: ASYNC_BLOCK — 末步 save_root_state 与无锁 GET 路由的 root_state 读改写互斥，只靠「同在循环线程」保证
+            _restore_storage_mutation_state(config_manager, snapshot, anchor_root=anchor_root)  # noqa: ASYNC_BLOCK — 回滚必须跑完，await 会让它自己变成取消点，见 _STORAGE_MUTATION_OFFLOAD_CONTRACT
         except Exception:
             logger.exception(
                 "failed to rollback storage mutation state after startup barrier release failed",
@@ -1025,11 +1073,17 @@ def _build_completed_migration_notice(
     *,
     bootstrap_payload: dict[str, Any] | None = None,
     require_existing_retained_root: bool = False,
+    persist_reconcile: bool = False,
 ) -> dict[str, Any]:
+    # persist_reconcile 只有已经拿着 _storage_mutation_lock 的调用方能传 True，
+    # 见 build_storage_location_bootstrap_payload 的说明。
     bootstrap = (
         bootstrap_payload
         if isinstance(bootstrap_payload, dict)
-        else build_storage_location_bootstrap_payload(config_manager)
+        else build_storage_location_bootstrap_payload(
+            config_manager,
+            persist_reconcile=persist_reconcile,
+        )
     )
     migration_payload = bootstrap.get("migration") if isinstance(bootstrap.get("migration"), dict) else {}
     if str(migration_payload.get("status") or "").strip() != STORAGE_MIGRATION_STATUS_COMPLETED:
@@ -1301,6 +1355,7 @@ async def _post_storage_location_retained_source_cleanup_locked(
     notice = _build_completed_migration_notice(
         config_manager,
         require_existing_retained_root=True,
+        persist_reconcile=True,
     )
     if notice.get("completed") is not True:
         response.status_code = 404
@@ -1339,26 +1394,35 @@ async def _post_storage_location_retained_source_cleanup_locked(
             "error": f"清理旧数据保留目录失败: {exc}",
         }
 
-    migration_payload = load_storage_migration(config_manager, anchor_root=anchor_root) or {}
-    if isinstance(migration_payload, dict):
-        updated_payload = dict(migration_payload)
-        updated_payload["backup_root"] = ""
-        updated_payload["retained_source_root"] = ""
-        updated_payload["retained_source_mode"] = "cleaned"
-        updated_payload["updated_at"] = _utc_now_iso()
-        updated_payload["cleanup_completed_at"] = _utc_now_iso()
-        save_storage_migration(config_manager, updated_payload, anchor_root=anchor_root)  # noqa: ASYNC_BLOCK — 见 _STORAGE_MUTATION_STAYS_ON_LOOP
+    def _persist_cleanup_result() -> None:
+        # 迁移检查点和 root_state 两次落盘放同一个 job：中间插一个 await 就能造出
+        # "检查点已标记 cleaned、root_state 还挂着 legacy_cleanup_pending" 的窗口，
+        # 而这个窗口正好会被存储页那条 1200ms 的轮询看到。
+        migration_payload = load_storage_migration(config_manager, anchor_root=anchor_root) or {}
+        if isinstance(migration_payload, dict):
+            updated_payload = dict(migration_payload)
+            updated_payload["backup_root"] = ""
+            updated_payload["retained_source_root"] = ""
+            updated_payload["retained_source_mode"] = "cleaned"
+            updated_payload["updated_at"] = _utc_now_iso()
+            updated_payload["cleanup_completed_at"] = _utc_now_iso()
+            save_storage_migration(config_manager, updated_payload, anchor_root=anchor_root)
 
-    try:
-        root_state = config_manager.load_root_state()
-        if isinstance(root_state, dict):
-            updated_root_state = dict(root_state)
-            updated_root_state["legacy_cleanup_pending"] = False
-            if paths_equal(updated_root_state.get("last_migration_backup") or "", expected_retained_root):
-                updated_root_state["last_migration_backup"] = ""
-            config_manager.save_root_state(updated_root_state)
-    except Exception:
-        pass
+        # root_state 这一半保持 best-effort（与改动前一致）：清理已经真的做完了，
+        # 标记没落上不该把整个请求判失败。
+        try:
+            with root_state_transaction():
+                root_state = config_manager.load_root_state()
+                if isinstance(root_state, dict):
+                    updated_root_state = dict(root_state)
+                    updated_root_state["legacy_cleanup_pending"] = False
+                    if paths_equal(updated_root_state.get("last_migration_backup") or "", expected_retained_root):
+                        updated_root_state["last_migration_backup"] = ""
+                    config_manager.save_root_state(updated_root_state)
+        except Exception:
+            pass
+
+    await asyncio.to_thread(_persist_cleanup_result)
 
     return {
         "ok": True,
@@ -1405,7 +1469,10 @@ async def _post_storage_location_select_locked(
             "error": exc.message,
         }
 
-    blocking_bootstrap = build_storage_location_bootstrap_payload(config_manager)
+    blocking_bootstrap = build_storage_location_bootstrap_payload(
+        config_manager,
+        persist_reconcile=True,
+    )
     selected_root_missing_recovery = _is_selected_root_missing_recovery(
         config_manager,
         current_root=current_root,
@@ -1442,23 +1509,29 @@ async def _post_storage_location_select_locked(
                         "error": "当前存储状态仍需恢复或迁移，暂时不能继续当前会话。",
                     }
 
-                state_snapshot = _snapshot_storage_mutation_state(config_manager, anchor_root=anchor_root)
-                delete_storage_migration(config_manager, anchor_root=anchor_root)
-                # 整个 _post_storage_location_select_locked 都跑在 _storage_mutation_lock 里，
-                # 下面紧跟着的 set_root_mode / 解除启动闸也已经是 await，多一个让出点不改变
-                # 「失败即整体回滚 state_snapshot」的语义。
-                policy_payload = save_storage_policy(  # noqa: ASYNC_BLOCK — 见 _STORAGE_MUTATION_STAYS_ON_LOOP
+                def _recover_from_failed_migration() -> dict[str, Any]:
+                    delete_storage_migration(config_manager, anchor_root=anchor_root)
+                    recovered_policy = save_storage_policy(
+                        config_manager,
+                        selected_root=current_root,
+                        selection_source=payload.selection_source,
+                        anchor_root=anchor_root,
+                    )
+                    set_root_mode(
+                        config_manager,
+                        ROOT_MODE_NORMAL,
+                        current_root=str(current_root),
+                        last_known_good_root=str(current_root),
+                        last_migration_result=f"recovered:failed_migration:{migration_payload.get('error_code') or 'unknown'}",
+                    )
+                    return recovered_policy
+
+                state_snapshot: dict[str, Any] = {}
+                policy_payload = await _apply_storage_mutation_writes(
                     config_manager,
-                    selected_root=current_root,
-                    selection_source=payload.selection_source,
                     anchor_root=anchor_root,
-                )
-                set_root_mode(
-                    config_manager,
-                    ROOT_MODE_NORMAL,
-                    current_root=str(current_root),
-                    last_known_good_root=str(current_root),
-                    last_migration_result=f"recovered:failed_migration:{migration_payload.get('error_code') or 'unknown'}",
+                    snapshot_out=state_snapshot,
+                    write=_recover_from_failed_migration,
                 )
                 try:
                     await _release_storage_startup_barrier_or_rollback(
@@ -1481,19 +1554,28 @@ async def _post_storage_location_select_locked(
                     "selection_source": policy_payload["selection_source"],
                 }
 
-            state_snapshot = _snapshot_storage_mutation_state(config_manager, anchor_root=anchor_root)
-            policy_payload = save_storage_policy(  # noqa: ASYNC_BLOCK — 见 _STORAGE_MUTATION_STAYS_ON_LOOP
+            def _recover_from_unavailable_selected_root() -> dict[str, Any]:
+                recovered_policy = save_storage_policy(
+                    config_manager,
+                    selected_root=current_root,
+                    selection_source=payload.selection_source,
+                    anchor_root=anchor_root,
+                )
+                set_root_mode(
+                    config_manager,
+                    ROOT_MODE_NORMAL,
+                    current_root=str(current_root),
+                    last_known_good_root=str(current_root),
+                    last_migration_result=f"recovered:selected_root_unavailable:{committed_selected_root}",
+                )
+                return recovered_policy
+
+            state_snapshot = {}
+            policy_payload = await _apply_storage_mutation_writes(
                 config_manager,
-                selected_root=current_root,
-                selection_source=payload.selection_source,
                 anchor_root=anchor_root,
-            )
-            set_root_mode(
-                config_manager,
-                ROOT_MODE_NORMAL,
-                current_root=str(current_root),
-                last_known_good_root=str(current_root),
-                last_migration_result=f"recovered:selected_root_unavailable:{committed_selected_root}",
+                snapshot_out=state_snapshot,
+                write=_recover_from_unavailable_selected_root,
             )
             try:
                 await _release_storage_startup_barrier_or_rollback(
@@ -1515,12 +1597,20 @@ async def _post_storage_location_select_locked(
                 "selected_root": str(current_root),
                 "selection_source": policy_payload["selection_source"],
             }
-        state_snapshot = _snapshot_storage_mutation_state(config_manager, anchor_root=anchor_root)
-        policy_payload = save_storage_policy(  # noqa: ASYNC_BLOCK — 见 _STORAGE_MUTATION_STAYS_ON_LOOP
+        def _persist_current_root_selection() -> dict[str, Any]:
+            return save_storage_policy(
+                config_manager,
+                selected_root=current_root,
+                selection_source=payload.selection_source,
+                anchor_root=anchor_root,
+            )
+
+        state_snapshot = {}
+        policy_payload = await _apply_storage_mutation_writes(
             config_manager,
-            selected_root=current_root,
-            selection_source=payload.selection_source,
             anchor_root=anchor_root,
+            snapshot_out=state_snapshot,
+            write=_persist_current_root_selection,
         )
         try:
             await _release_storage_startup_barrier_or_rollback(
@@ -1720,7 +1810,10 @@ async def _post_storage_location_restart_locked(
             "error": "当前实例暂时无法执行受控关闭，请稍后重试。",
         }
 
-    blocking_bootstrap = build_storage_location_bootstrap_payload(config_manager)
+    blocking_bootstrap = build_storage_location_bootstrap_payload(
+        config_manager,
+        persist_reconcile=True,
+    )
     if bool(blocking_bootstrap.get("migration_pending")):
         response.status_code = 409
         return {
@@ -1771,12 +1864,9 @@ async def _post_storage_location_restart_locked(
                 **restart_preflight,
             }
 
-        state_snapshot = _snapshot_storage_mutation_state(config_manager, anchor_root=anchor_root)
-        try:
+        def _rebind_to_selected_root() -> None:
             delete_storage_migration(config_manager, anchor_root=anchor_root)
-            # 同样在 _storage_mutation_lock 里；这一段本来就以 await _request_app_shutdown
-            # 收尾，多出来的让出点仍被同一个 try/except 的 state_snapshot 回滚覆盖。
-            save_storage_policy(  # noqa: ASYNC_BLOCK — 见 _STORAGE_MUTATION_STAYS_ON_LOOP
+            save_storage_policy(
                 config_manager,
                 selected_root=normalized_selected_root,
                 selection_source=payload.selection_source,
@@ -1788,13 +1878,21 @@ async def _post_storage_location_restart_locked(
                 last_migration_source=str(normalized_selected_root),
                 last_migration_result=f"restart_rebind:{normalized_selected_root}",
             )
+
+        state_snapshot = {}
+        try:
+            await _apply_storage_mutation_writes(
+                config_manager,
+                anchor_root=anchor_root,
+                snapshot_out=state_snapshot,
+                write=_rebind_to_selected_root,
+            )
             await _request_app_shutdown(request_app_shutdown)
         except Exception as exc:
             try:
-                # 与 _release_storage_startup_barrier_or_rollback 里那处同因同治：
-                # 这个 helper 末步 save_root_state，而无锁的 GET 路由也在事件循环上
-                # 读改写同一份 root_state，两者今天只靠「同在循环线程」互斥。详见那处注释。
-                _restore_storage_mutation_state(config_manager, state_snapshot, anchor_root=anchor_root)  # noqa: ASYNC_BLOCK — 同上：root_state 读改写的互斥依赖「同在循环线程」
+                # 与 _release_storage_startup_barrier_or_rollback 那处同因同治：回滚
+                # 必须跑完，挪成 await 就会让它自己变成取消点。
+                _restore_storage_mutation_state(config_manager, state_snapshot, anchor_root=anchor_root)  # noqa: ASYNC_BLOCK — 回滚不能变成取消点，见 _STORAGE_MUTATION_OFFLOAD_CONTRACT
             except Exception:
                 logger.exception(
                     "failed to rollback storage mutation state after restart scheduling failed",
@@ -1839,40 +1937,61 @@ async def _post_storage_location_restart_locked(
             **restart_preflight,
         }
 
-    previous_root_state = config_manager.load_root_state()
-    previous_migration_payload = load_storage_migration(config_manager, anchor_root=anchor_root)
-    migration_payload = create_pending_storage_migration(
-        config_manager,
-        source_root=current_root,
-        target_root=normalized_selected_root,
-        selection_source=payload.selection_source,
-        anchor_root=anchor_root,
-        confirmed_existing_target_content=bool(payload.confirm_existing_target_content),
-    )
+    # 回滚要用的两份 pre-image 与两次写同在一个 job 里：create_pending_storage_migration
+    # 落检查点、set_root_mode 切 maintenance，中间一旦有 await，取消就能停在
+    # "检查点已建、root mode 还是 normal" 上——启动时会当成一次凭空出现的待迁移。
+    rollback_state: dict[str, Any] = {}
 
-    try:
+    def _schedule_pending_migration() -> dict[str, Any]:
+        # 两份 pre-image 都读到之后再一起记进 rollback_state，这样
+        # "rollback_state 非空" 就等价于 "两份都在手上"。分两次记的话，第二次读
+        # 抛异常会留下 migration 键缺失，回滚分支就会把一份本来就存在的检查点删掉。
+        previous_root_state = config_manager.load_root_state()
+        previous_migration = load_storage_migration(config_manager, anchor_root=anchor_root)
+        rollback_state["root_state"] = previous_root_state
+        rollback_state["migration"] = previous_migration
+        pending_payload = create_pending_storage_migration(
+            config_manager,
+            source_root=current_root,
+            target_root=normalized_selected_root,
+            selection_source=payload.selection_source,
+            anchor_root=anchor_root,
+            confirmed_existing_target_content=bool(payload.confirm_existing_target_content),
+        )
         set_root_mode(
             config_manager,
             ROOT_MODE_MAINTENANCE_READONLY,
             last_migration_source=str(current_root),
             last_migration_result=f"restart_pending:{normalized_selected_root}",
         )
+        return pending_payload
+
+    migration_payload = None
+    try:
+        migration_payload = await asyncio.to_thread(_schedule_pending_migration)
         await _request_app_shutdown(request_app_shutdown)
     except Exception as exc:
-        try:
-            if isinstance(previous_migration_payload, dict):
-                save_storage_migration(config_manager, previous_migration_payload, anchor_root=anchor_root)  # noqa: ASYNC_BLOCK — 见 _STORAGE_MUTATION_STAYS_ON_LOOP
-            else:
-                delete_storage_migration(config_manager, anchor_root=anchor_root)
-        except Exception:
+        # rollback_state 为空 = 两份 pre-image 还没读到，也就意味着
+        # create_pending_storage_migration 一行都还没跑，没有东西需要回滚。这时候
+        # 走下面的分支反而会把一份本来就在盘上的检查点删掉。
+        if rollback_state:
+            previous_root_state = rollback_state.get("root_state")
+            previous_migration_payload = rollback_state.get("migration")
             try:
-                delete_storage_migration(config_manager, anchor_root=anchor_root)
+                if isinstance(previous_migration_payload, dict):
+                    save_storage_migration(config_manager, previous_migration_payload, anchor_root=anchor_root)
+                else:
+                    delete_storage_migration(config_manager, anchor_root=anchor_root)
+            except Exception:
+                try:
+                    delete_storage_migration(config_manager, anchor_root=anchor_root)
+                except Exception:
+                    pass
+            try:
+                if isinstance(previous_root_state, dict):
+                    config_manager.save_root_state(previous_root_state)
             except Exception:
                 pass
-        try:
-            config_manager.save_root_state(previous_root_state)
-        except Exception:
-            pass
         response.status_code = 500
         return {
             "ok": False,

--- a/main_routers/storage_location_router.py
+++ b/main_routers/storage_location_router.py
@@ -1229,10 +1229,28 @@ async def _release_storage_startup_barrier_if_needed(*, reason: str) -> None:
         await result
 
 
+class _ShutdownAcceptedCancellation(asyncio.CancelledError):
+    """Cancellation delivered after the shutdown callback completed successfully."""
+
+
 async def _request_app_shutdown(request_app_shutdown) -> None:
     result = request_app_shutdown()
     if inspect.isawaitable(result):
-        await result
+        # Keep a handle so a cancellation queued after callback completion but
+        # before this waiter resumes can be distinguished from cancellation of
+        # an in-flight request. The former means shutdown is already committed
+        # and the pending migration must not be rolled back.
+        shutdown_task = asyncio.ensure_future(result)
+        try:
+            await shutdown_task
+        except asyncio.CancelledError as exc:
+            if (
+                shutdown_task.done()
+                and not shutdown_task.cancelled()
+                and shutdown_task.exception() is None
+            ):
+                raise _ShutdownAcceptedCancellation(*exc.args) from exc
+            raise
 
 
 @router.get("/bootstrap")
@@ -1946,11 +1964,14 @@ async def _post_storage_location_restart_locked(
                 write=_rebind_to_selected_root,
             )
             await _request_app_shutdown(request_app_shutdown)
+        except _ShutdownAcceptedCancellation:
+            # Shutdown 已经被 launcher 接受；保留本次写入，让退出后的接力流程执行。
+            raise
         except asyncio.CancelledError:
             # 取消也必须回滚。工作线程已经跑完（_run_locked_storage_job 保证了这点），
-            # 也就是说检查点 / 策略 / maintenance_readonly 都已经落盘，而
-            # _request_app_shutdown 没发出去——留着就是把应用钉死在受限态，用户看到
-            # 一个永远不重启的"正在迁移"。
+            # 也就是说检查点 / 策略 / maintenance_readonly 都已经落盘，而 shutdown
+            # 尚未被接受——留着就是把应用钉死在受限态，用户看到一个永远不重启的
+            # "正在迁移"。
             # CancelledError 是 BaseException，下面的 except Exception 接不住，所以
             # 必须单列。回滚本身是同步的，不会再被取消。
             if state_snapshot:
@@ -2043,9 +2064,12 @@ async def _post_storage_location_restart_locked(
     try:
         migration_payload = await _run_locked_storage_job(_schedule_pending_migration)
         await _request_app_shutdown(request_app_shutdown)
+    except _ShutdownAcceptedCancellation:
+        # Shutdown 已经被 launcher 接受；待迁移检查点正是退出后的接力依据。
+        raise
     except asyncio.CancelledError:
-        # 同上：写已落盘、shutdown 没发出去，不回滚就会留下一个没人执行的待迁移
-        # 检查点 + maintenance_readonly。rollback_state 为空 = 什么都还没写。
+        # 同上：写已落盘、shutdown 尚未被接受，不回滚就会留下一个没人执行的
+        # 待迁移检查点 + maintenance_readonly。rollback_state 为空 = 什么都还没写。
         if rollback_state:
             previous_root_state = rollback_state.get("root_state")
             previous_migration_payload = rollback_state.get("migration")

--- a/main_routers/storage_location_router.py
+++ b/main_routers/storage_location_router.py
@@ -35,6 +35,7 @@ import sys
 import inspect
 import subprocess
 from collections.abc import Callable
+from contextlib import suppress
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -242,6 +243,15 @@ def _restore_storage_mutation_state(
     The cost is bounded: this only runs when a mutation has already failed, and
     the routes that call it are already about to return an error response.
     """
+    # ⚠️ 空快照绝不能往下走。下面的分支把"没有 migration / policy 键"读作"这两个文件
+    # 本来就不存在"，于是删检查点、unlink 策略文件。而快照一旦真的取到，
+    # _snapshot_storage_mutation_state 必定三个键齐全（值可以是 None）——所以
+    # 「空 dict」只可能意味着快照压根没取成（例如 load_root_state 撞上 I/O 错误），
+    # 这时候没有任何写发生过，回滚只会毁掉本来好好的文件。
+    if not snapshot:
+        logger.warning("skipping storage mutation rollback: snapshot was never taken")
+        return
+
     previous_migration = snapshot.get("migration")
     if isinstance(previous_migration, dict):
         save_storage_migration(config_manager, previous_migration, anchor_root=anchor_root)
@@ -263,6 +273,29 @@ def _restore_storage_mutation_state(
     previous_root_state = snapshot.get("root_state")
     if isinstance(previous_root_state, dict):
         config_manager.save_root_state(previous_root_state)
+
+
+async def _run_locked_storage_job(job: Callable[[], Any]) -> Any:
+    """Run one storage job in a worker without letting the mutation lock slip.
+
+    ``asyncio.to_thread`` cancellation only cancels the awaiting future — the
+    worker keeps writing. Plain ``await asyncio.to_thread(...)`` therefore lets a
+    client disconnect unwind the route's ``async with _storage_mutation_lock``
+    while the worker is still mid-write, and the next mutation request walks
+    straight into the lock and interleaves with it on the same three files.
+    Before these writes moved off the loop they were uncancellable, so the lock
+    really did cover them; this restores that.
+
+    On cancellation we keep waiting for the worker and only then let the
+    cancellation continue, so the lock is held for the worker's whole lifetime.
+    """
+    task = asyncio.ensure_future(asyncio.to_thread(job))
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        with suppress(asyncio.CancelledError):
+            await asyncio.wait({task})
+        raise
 
 
 async def _apply_storage_mutation_writes(
@@ -292,7 +325,7 @@ async def _apply_storage_mutation_writes(
         snapshot_out.update(_snapshot_storage_mutation_state(config_manager, anchor_root=anchor_root))
         return write()
 
-    return await asyncio.to_thread(_job)
+    return await _run_locked_storage_job(_job)
 
 
 async def _release_storage_startup_barrier_or_rollback(
@@ -1379,12 +1412,14 @@ async def _post_storage_location_retained_source_cleanup_locked(
     current_root = normalize_runtime_root(config_manager.app_docs_dir)
     anchor_root = compute_anchor_root(config_manager, current_root=current_root)
     try:
-        await asyncio.to_thread(
-            _cleanup_retained_runtime_root,
-            retained_path,
-            current_root=current_root,
-            anchor_root=anchor_root,
-            target_root=notice.get("target_root") or "",
+        # 这一步 rmtree 保留目录，同样不能在取消时把 _storage_mutation_lock 让出去
+        await _run_locked_storage_job(
+            lambda: _cleanup_retained_runtime_root(
+                retained_path,
+                current_root=current_root,
+                anchor_root=anchor_root,
+                target_root=notice.get("target_root") or "",
+            )
         )
     except Exception as exc:
         response.status_code = 500
@@ -1420,9 +1455,10 @@ async def _post_storage_location_retained_source_cleanup_locked(
                         updated_root_state["last_migration_backup"] = ""
                     config_manager.save_root_state(updated_root_state)
         except Exception:
+            # best-effort：清理本身已经做完了，标记没落上不该把整个请求判失败
             pass
 
-    await asyncio.to_thread(_persist_cleanup_result)
+    await _run_locked_storage_job(_persist_cleanup_result)
 
     return {
         "ok": True,
@@ -1968,7 +2004,7 @@ async def _post_storage_location_restart_locked(
 
     migration_payload = None
     try:
-        migration_payload = await asyncio.to_thread(_schedule_pending_migration)
+        migration_payload = await _run_locked_storage_job(_schedule_pending_migration)
         await _request_app_shutdown(request_app_shutdown)
     except Exception as exc:
         # rollback_state 为空 = 两份 pre-image 还没读到，也就意味着
@@ -1991,6 +2027,7 @@ async def _post_storage_location_restart_locked(
                 if isinstance(previous_root_state, dict):
                     config_manager.save_root_state(previous_root_state)
             except Exception:
+                # 回滚本身失败就只能到此为止：外层已经在返回 500，再抛只会盖掉原因
                 pass
         response.status_code = 500
         return {

--- a/memory/user_directives.py
+++ b/memory/user_directives.py
@@ -229,13 +229,34 @@ class UserDirectivesManager:
         return directives
 
     def _save_unlocked(self, name: str) -> None:
+        # 这次落盘是同步的，跑在事件循环线程上，而且是**有意保留**的：
+        #
+        # 调用链是 `async def _process_stream_data_internal`
+        #   → _publish_user_utterance_to_plugin_bus（同步）
+        #   → dispatch_user_utterance（同步 fan-out）
+        #   → _on_user_utterance → record_from_text → 这里。
+        # `dispatch_user_utterance` 的契约就是同步 fan-out，链上还挂着第三方插件的
+        # handler（plugin.core.state / quota.dropper）。把这一段改成 async 等于把所有
+        # 插件 handler 一起挪到工作线程 —— 那是事件总线的架构取舍，不该由一条落盘
+        # 顺带决定。
+        #
+        # 代价可接受：只有 directive 正则真命中时才写（用户说"别提 X"这种），
+        # 一次会话个位数，payload 是几百字节的 JSON。
+        #
+        # 若要改，正确形状是 memory/anti_repeat.py 那对 stage/aflush 拆分：内存更新
+        # 留在调用线程（否则同轮的读会看到旧 cache），只把 fsync 挪走，并在 turn
+        # 生命周期里补一个 flush 点。
+        #
+        # noqa 现在其实没有对应的告警可压 —— scripts/check_async_blocking.py 只做
+        # depth-1，看不到深度 6 的这里。留着是为了可 grep，以及守卫哪天加深时不用
+        # 重新考古。
         path = self._file_path(name)
         payload = {
             "version": _SCHEMA_VERSION,
             "directives": self._cache.get(name, []),
         }
         try:
-            atomic_write_json(path, payload, indent=2, ensure_ascii=False)
+            atomic_write_json(path, payload, indent=2, ensure_ascii=False)  # noqa: ASYNC_BLOCK — 同步 fan-out 契约，见上
         except Exception as exc:
             logger.warning("[UserDirectives] save failed for %s: %s", name, exc)
 

--- a/plugin/tests/pytest.ini
+++ b/plugin/tests/pytest.ini
@@ -1,6 +1,8 @@
 [pytest]
 asyncio_mode = auto
-addopts = -p no:anyio --basetemp=../.pytest-run
+# Seed 与根 pytest.ini 保持一致——这个目录不继承根 ini，漏掉就等于让 plugin 闸门
+# 每次跑一个随机顺序。为什么钉死而不是随机，见根 pytest.ini 里的说明。
+addopts = -p no:anyio --basetemp=../.pytest-run --randomly-seed=20260731
 cache_dir = ../../.pytest-cache-plugin
 testpaths =
     unit/server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,10 @@ dev = [
     "pytest-asyncio>=1.3.0",
     "pytest-cov>=7.1.0",
     "pytest-playwright>=0.7.2",
+    # 打乱用例顺序，暴露隐藏的用例间顺序依赖。日常 CI 用 pytest.ini 里钉死的
+    # seed 跑（确定性），另有 .github/workflows/random-order-tests.yml 定时用
+    # 随机 seed 单独跑、单独报，不挡任何人的 PR。
+    "pytest-randomly>=4.1.0",
     "ruff>=0.15.4",
 ]
 # galgame_plugin native deps. NOT installed by default `uv sync` — keeps dev

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,20 @@
 [pytest]
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
-addopts = -p no:anyio
+# pytest-randomly 打乱用例顺序来暴露用例间的顺序依赖，但这里把 seed 钉死：
+# 日常 CI（unit-tests.yml / plugin-tests.yml）必须是确定性的，否则一次随机重排就能
+# 让一个跟改动无关的 PR 变红——那正是要消除的噪声，不是要引入的。持续的随机压力由
+# .github/workflows/random-order-tests.yml 定时跑随机 seed 提供，它不挡任何 PR。
+#
+# 注意：换掉这个数字 = 换一套顺序，可能顺带暴露新的顺序依赖，属于有意为之的动作。
+# 另外用例集合本身变化（新增/删除用例）也会让洗牌结果变，所以"确定性"的含义是
+# "同一个 commit 上可复现"，不是"跨 commit 顺序不变"。
+#
+# 调试用逃生阀：`--randomly-dont-reorganize` 恢复文件内定义顺序，
+# `--randomly-dont-reset-seed` 关掉每条用例重置 random.seed()。
+# 不要用 `-p no:randomly`——插件被屏蔽后 addopts 里的 --randomly-seed 会变成
+# 无法识别的参数，pytest 直接报错退出。
+addopts = -p no:anyio --randomly-seed=20260731
 norecursedirs = .* venv build dist node_modules .pytest_cache __pycache__ *.egg local_server .codex-* .codex-tmp .codex_pytest_tmp .codex_manual_checks pytest-cache-files-* tmp-pytest N.E.K.O
 markers =
     unit: mark a test as a unit test.

--- a/tests/unit/test_cloudsave_lifecycle_flow.py
+++ b/tests/unit/test_cloudsave_lifecycle_flow.py
@@ -732,6 +732,65 @@ async def test_release_storage_startup_barrier_restores_memory_limited_mode_when
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_release_storage_startup_barrier_reblocks_memory_before_propagating_cancellation():
+    """Cancellation must not expose initialized memory against rolled-back storage."""
+    from app import main_server
+
+    init_started = asyncio.Event()
+    block_started = asyncio.Event()
+    allow_block = asyncio.Event()
+
+    async def _wait_for_cancel(*, reason: str):
+        init_started.set()
+        await asyncio.Event().wait()
+
+    async def _block_memory(reason: str):
+        block_started.set()
+        await allow_block.wait()
+
+    with patch.object(
+        main_server,
+        "_request_memory_server_continue_startup",
+        AsyncMock(return_value=None),
+    ), patch.object(
+        main_server,
+        "_ensure_main_server_runtime_initialized",
+        side_effect=_wait_for_cancel,
+    ), patch.object(
+        main_server,
+        "_request_memory_server_block_startup",
+        side_effect=_block_memory,
+    ) as mock_block, patch.object(
+        main_server,
+        "_main_runtime_limited_mode_enabled",
+        False,
+    ), patch.object(
+        main_server,
+        "_main_runtime_limited_mode_reason",
+        "",
+    ):
+        task = asyncio.create_task(
+            main_server.release_storage_startup_barrier(reason="unit_test")
+        )
+        await init_started.wait()
+        task.cancel()
+        await block_started.wait()
+
+        # A second cancellation must not let the storage router roll back its
+        # blocking snapshot before memory_server has restored its own guard.
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+
+        allow_block.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    mock_block.assert_awaited_once_with("unit_test:main_server_init_failed")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_memory_server_continue_startup_preserves_409_blocking_payload():
     import httpx
     from app import main_server

--- a/tests/unit/test_cloudsave_lifecycle_flow.py
+++ b/tests/unit/test_cloudsave_lifecycle_flow.py
@@ -791,6 +791,60 @@ async def test_release_storage_startup_barrier_reblocks_memory_before_propagatin
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_release_storage_startup_barrier_compensates_ambiguous_continue_cancellation():
+    """A cancelled continue response may hide an already-applied server request."""
+    from app import main_server
+
+    continue_applied = asyncio.Event()
+    block_started = asyncio.Event()
+
+    async def _continue_without_response(reason: str):
+        continue_applied.set()
+        await asyncio.Event().wait()
+
+    async def _block_memory(reason: str):
+        block_started.set()
+
+    with patch.object(
+        main_server,
+        "_request_memory_server_continue_startup",
+        side_effect=_continue_without_response,
+    ), patch.object(
+        main_server,
+        "_ensure_main_server_runtime_initialized",
+        AsyncMock(),
+    ) as mock_ensure, patch.object(
+        main_server,
+        "_request_memory_server_block_startup",
+        side_effect=_block_memory,
+    ) as mock_block, patch.object(
+        main_server,
+        "_main_runtime_limited_mode_enabled",
+        False,
+    ), patch.object(
+        main_server,
+        "_main_runtime_limited_mode_reason",
+        "",
+    ):
+        task = asyncio.create_task(
+            main_server.release_storage_startup_barrier(reason="unit_test")
+        )
+        await continue_applied.wait()
+        task.cancel()
+
+        [outcome] = await asyncio.gather(task, return_exceptions=True)
+        assert isinstance(outcome, asyncio.CancelledError)
+
+        assert block_started.is_set()
+        assert main_server._main_runtime_limited_mode_enabled is True
+        assert main_server._main_runtime_limited_mode_reason == "runtime_initialization_failed"
+
+    mock_ensure.assert_not_awaited()
+    mock_block.assert_awaited_once_with("unit_test:main_server_init_failed")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_memory_server_continue_startup_preserves_409_blocking_payload():
     import httpx
     from app import main_server

--- a/tests/unit/test_cloudsave_runtime.py
+++ b/tests/unit/test_cloudsave_runtime.py
@@ -916,6 +916,47 @@ def test_cloud_apply_fence_releases_lock_when_mode_restore_fails(tmp_path):
 
 
 @pytest.mark.unit
+def test_cloud_apply_fence_does_not_restore_over_a_concurrent_storage_mode_write(tmp_path):
+    """A storage worker's blocking mode must land after the cloud fence exits."""
+    import threading
+
+    cm = _make_config_manager(tmp_path)
+
+    from utils.cloudsave_runtime import (
+        ROOT_MODE_MAINTENANCE_READONLY,
+        cloud_apply_fence,
+        get_root_mode,
+        set_root_mode,
+    )
+
+    started = threading.Event()
+    finished = threading.Event()
+
+    def _storage_writer() -> None:
+        started.set()
+        set_root_mode(
+            cm,
+            ROOT_MODE_MAINTENANCE_READONLY,
+            last_migration_result="restart_pending:test-target",
+        )
+        finished.set()
+
+    with cloud_apply_fence(cm, reason="unit_test"):
+        writer = threading.Thread(target=_storage_writer)
+        writer.start()
+        assert started.wait(5)
+        assert not finished.wait(0.1), (
+            "storage writer escaped the cloud fence lifecycle lock and can be "
+            "overwritten by its stale mode restore"
+        )
+
+    writer.join(timeout=5)
+    assert not writer.is_alive()
+    assert finished.is_set()
+    assert get_root_mode(cm) == ROOT_MODE_MAINTENANCE_READONLY
+
+
+@pytest.mark.unit
 def test_local_cloudsave_round_trip_restores_runtime_truth(tmp_path):
     cm = _make_config_manager(tmp_path)
 

--- a/tests/unit/test_music_router.py
+++ b/tests/unit/test_music_router.py
@@ -6,6 +6,26 @@ from starlette.requests import Request
 from main_routers import music_router
 
 
+@pytest.fixture(autouse=True)
+def _reset_music_proxy_cache():
+    """Isolate every test in this module from ``music_router.MUSIC_PROXY_CACHE``.
+
+    The cache is a process-wide ``TTLCache`` living in product code, and
+    ``proxy_music`` serves a hit before it validates anything. Tests here reuse
+    a handful of URLs, so a test that leaves an entry behind makes a later test
+    on the same URL take the cache branch and never reach the code it asserts
+    on. Autouse + module-wide so new tests are covered without opting in.
+    """
+    # 具体触发：test_music_proxy_streams_small_file_then_caches_complete_body 会把
+    # https://freemusicarchive.org/song.mp3 写进缓存，随机顺序下排到
+    # test_music_proxy_rejects_unsafe_redirect 之前，后者拿到 200 HIT 而不是 403。
+    music_router.MUSIC_PROXY_CACHE.clear()
+    try:
+        yield
+    finally:
+        music_router.MUSIC_PROXY_CACHE.clear()
+
+
 async def _read_streaming_body(response):
     body = bytearray()
     async for chunk in response.body_iterator:
@@ -253,7 +273,6 @@ async def test_music_proxy_yields_first_chunk_before_upstream_finishes(monkeypat
             return None
 
     monkeypatch.setattr(music_router.httpx, "AsyncClient", FakeClient)
-    music_router.MUSIC_PROXY_CACHE.clear()
     request = Request({"type": "http", "method": "GET", "path": "/api/music/proxy", "headers": []})
 
     response = await music_router.proxy_music("https://freemusicarchive.org/song.mp3", request)
@@ -301,7 +320,6 @@ async def test_music_proxy_streams_small_file_then_caches_complete_body(monkeypa
             return None
 
     monkeypatch.setattr(music_router.httpx, "AsyncClient", FakeClient)
-    music_router.MUSIC_PROXY_CACHE.clear()
     url = "https://freemusicarchive.org/song.mp3"
     request = Request({"type": "http", "method": "GET", "path": "/api/music/proxy", "headers": []})
 
@@ -354,7 +372,6 @@ async def test_music_proxy_does_not_cache_large_or_interrupted_stream(monkeypatc
 
     monkeypatch.setattr(music_router.httpx, "AsyncClient", FakeClient)
     monkeypatch.setattr(music_router, "STREAMING_SIZE_THRESHOLD", 4)
-    music_router.MUSIC_PROXY_CACHE.clear()
     request = Request({"type": "http", "method": "GET", "path": "/api/music/proxy", "headers": []})
 
     large_url = "https://freemusicarchive.org/large.mp3"

--- a/tests/unit/test_root_state_write_lock.py
+++ b/tests/unit/test_root_state_write_lock.py
@@ -760,7 +760,7 @@ async def test_storage_snapshot_waits_for_cloud_fence_transaction(tmp_path, monk
 
     fence_entered = threading.Event()
     release_fence = threading.Event()
-    fence_errors: list[BaseException] = []
+    fence_errors: list[Exception] = []
 
     def _hold_cloud_fence() -> None:
         try:
@@ -772,7 +772,7 @@ async def test_storage_snapshot_waits_for_cloud_fence_transaction(tmp_path, monk
                 fence_entered.set()
                 if not release_fence.wait(5):
                     raise TimeoutError("test did not release cloud fence")
-        except BaseException as exc:
+        except Exception as exc:
             fence_errors.append(exc)
 
     fence_thread = threading.Thread(target=_hold_cloud_fence)

--- a/tests/unit/test_root_state_write_lock.py
+++ b/tests/unit/test_root_state_write_lock.py
@@ -13,6 +13,7 @@ green" cannot mean "the guard never ran":
    await — and therefore no cancellation point — can be introduced between them.
 """
 import ast
+import asyncio
 import threading
 import time
 from pathlib import Path
@@ -26,7 +27,11 @@ from main_routers import storage_location_router as router_module
 from main_routers.shared_state import init_shared_state
 from utils import root_state_lock
 from utils import storage_location_bootstrap as bootstrap_module
+from utils.cloudsave_runtime import ROOT_MODE_MAINTENANCE_READONLY, ROOT_MODE_NORMAL
+from utils.cloudsave_runtime import fence as fence_module
 from utils.config_manager import ConfigManager
+from utils.storage_migration import get_storage_migration_path, save_storage_migration
+from utils.storage_policy import get_storage_policy_path, save_storage_policy
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -80,6 +85,16 @@ def _build_client(config_manager) -> TestClient:
     app = FastAPI()
     app.include_router(router_module.router)
     return TestClient(app)
+
+
+def _called_name(call: ast.Call) -> str:
+    """``f(...)`` -> ``"f"``; ``a.b.f(...)`` -> ``"f"``; anything else -> ``""``."""
+    func = call.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return ""
 
 
 def _iter_project_python_files():
@@ -283,7 +298,204 @@ def test_persist_reconcile_opt_in_only_happens_behind_the_mutation_lock():
     )
 
 
-# ── 3. 写序列保持原子（不许被 await 切开） ────────────────────────────
+@pytest.mark.unit
+def test_stale_mode_recovery_keeps_a_concurrent_writers_fields(tmp_path, monkeypatch):
+    """The caller's pre-image is read outside the lock; the write must not use it."""
+    config_manager = _make_real_config_manager(tmp_path)
+    initial = dict(config_manager.build_default_root_state())
+    initial["mode"] = ROOT_MODE_MAINTENANCE_READONLY
+    initial["last_known_good_root"] = "OLD"
+    config_manager.save_root_state(initial)
+
+    # 调用方（bootstrap）在拿锁之前读到的那一份
+    stale_pre_image = config_manager.load_root_state()
+
+    # 另一个写者在"调用方读完"和"自愈写入"之间提交了一轮
+    committed = dict(config_manager.load_root_state())
+    committed["last_known_good_root"] = "NEW"
+    config_manager.save_root_state(committed)
+
+    monkeypatch.setattr(fence_module, "_should_preserve_write_blocking_mode", lambda *_a, **_k: False)
+    monkeypatch.setattr(fence_module, "_process_holds_cloud_apply_lock", lambda: False)
+    monkeypatch.setattr(fence_module, "acquire_cloud_apply_lock", lambda _cm: True)
+    monkeypatch.setattr(fence_module, "release_cloud_apply_lock", lambda _cm: None)
+
+    recovered, did_recover = fence_module._recover_stale_write_blocking_mode(
+        config_manager, stale_pre_image
+    )
+
+    assert did_recover is True
+    assert recovered["mode"] == ROOT_MODE_NORMAL
+    on_disk = config_manager.load_root_state()
+    assert on_disk["mode"] == ROOT_MODE_NORMAL, "自愈没生效"
+    assert on_disk["last_known_good_root"] == "NEW", (
+        "自愈把并发写者已提交的字段盖回了锁外读到的旧值"
+    )
+
+
+@pytest.mark.unit
+def test_cloudsave_bootstrap_keeps_a_write_that_lands_mid_flight(tmp_path, monkeypatch):
+    """Guard the caller too, not just the helper Greptile pointed at.
+
+    ``bootstrap_local_cloudsave_environment`` loads root_state, does a pile of
+    work, then edits and saves it. Fixing only
+    ``_recover_stale_write_blocking_mode`` would have been pointless: this
+    function overwrites with its own stale pre-image two lines later.
+    """
+    from utils.cloudsave_runtime import bootstrap as cloudsave_bootstrap
+
+    config_manager = _make_real_config_manager(tmp_path)
+    base = dict(config_manager.build_default_root_state())
+    base["last_migration_source"] = "OLD"
+    config_manager.save_root_state(base)
+
+    def _commit_midway(cm):
+        # 强制交错：bootstrap 已经读过 root_state、还没写回去，此刻另一个写者提交一轮
+        state = dict(cm.load_root_state())
+        state["last_migration_source"] = "NEW"
+        cm.save_root_state(state)
+        return {
+            "migrated": False,
+            "source": "",
+            "copied_paths": [],
+            "backup_path": "",
+            "repair_reason": "",
+            "result": "",
+        }
+
+    monkeypatch.setattr(
+        cloudsave_bootstrap, "import_legacy_runtime_root_if_needed", _commit_midway
+    )
+
+    cloudsave_bootstrap.bootstrap_local_cloudsave_environment(config_manager)
+
+    assert config_manager.load_root_state()["last_migration_source"] == "NEW", (
+        "bootstrap 用锁外读到的 pre-image 把中途提交的那一轮盖掉了"
+    )
+
+
+@pytest.mark.unit
+def test_every_locked_write_reloads_root_state_inside_the_block():
+    """A transaction that writes must also read *inside* the block.
+
+    Taking the lock only serializes writers. If the value being written was
+    derived from a pre-image loaded before the lock, the write still clobbers
+    whatever another writer committed in between — the lock makes it orderly,
+    not correct. Greptile caught exactly this in
+    ``_recover_stale_write_blocking_mode`` after the first round of this PR.
+
+    Deliberate snapshot restores (``_restore_storage_mutation_state``, the
+    ``/restart`` rollback) are outside this rule by construction: they do not
+    open a transaction at all, they lean on the lock inside ``save_root_state``,
+    and writing a stale pre-image is precisely their job.
+    """
+    reads = {"load_root_state", "get_root_state"}
+    writes = {"save_root_state"}
+    offenders: list[str] = []
+
+    for path in _iter_project_python_files():
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.With):
+                continue
+            opens_transaction = any(
+                isinstance(item.context_expr, ast.Call)
+                and _called_name(item.context_expr) == "root_state_transaction"
+                for item in node.items
+            )
+            if not opens_transaction:
+                continue
+
+            called = {
+                _called_name(child)
+                for child in ast.walk(node)
+                if isinstance(child, ast.Call)
+            }
+            if called & writes and not (called & reads):
+                offenders.append(
+                    f"{path.relative_to(_REPO_ROOT).as_posix()}:{node.lineno}"
+                )
+
+    assert not offenders, (
+        "这些 root_state_transaction 块里写了盘却没在块内重读——写回去的是锁外读到的"
+        "pre-image，会把这期间别人提交的字段整份盖掉：\n  " + "\n  ".join(offenders)
+    )
+
+
+# ── 3. offload 不许把 _storage_mutation_lock 提前让出去 ───────────────
+
+
+@pytest.mark.unit
+async def test_cancelled_storage_job_waits_for_the_worker_before_unwinding():
+    """Cancellation must not hand the mutation lock to the next request mid-write.
+
+    ``asyncio.to_thread`` cancellation only cancels the awaiting future; the
+    worker keeps going. If the await returned immediately, the route's
+    ``async with _storage_mutation_lock`` would unwind while the worker was
+    still writing, and a second mutation could interleave with it. Before these
+    writes moved off the loop they were uncancellable, so this restores what the
+    lock used to guarantee.
+    """
+    started = threading.Event()
+    finished = threading.Event()
+
+    def _job() -> str:
+        started.set()
+        time.sleep(0.3)
+        finished.set()
+        return "done"
+
+    task = asyncio.ensure_future(router_module._run_locked_storage_job(_job))
+    assert await asyncio.get_running_loop().run_in_executor(None, started.wait, 5)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert finished.is_set(), (
+        "取消让 await 立刻返回了——工作线程还在写，_storage_mutation_lock 已经松开，"
+        "下一个变更请求会跟它在同一批文件上交错"
+    )
+
+
+@pytest.mark.unit
+def test_empty_snapshot_never_deletes_storage_state(tmp_path):
+    """An un-taken snapshot must not be replayed as "these files did not exist".
+
+    ``_restore_storage_mutation_state`` reads a missing ``migration`` / ``policy``
+    key as proof the file was absent and deletes it. A real snapshot always has
+    all three keys, so an empty dict can only mean the snapshot itself failed —
+    in which case no write happened and there is nothing to roll back.
+    """
+    config_manager = _make_real_config_manager(tmp_path)
+    anchor_root = Path(config_manager.anchor_root)
+
+    save_storage_policy(
+        config_manager,
+        selected_root=config_manager.app_docs_dir,
+        anchor_root=anchor_root,
+        selection_source="test",
+    )
+    save_storage_migration(
+        config_manager,
+        {"status": "completed", "source_root": "", "target_root": ""},
+        anchor_root=anchor_root,
+    )
+    policy_path = get_storage_policy_path(config_manager, anchor_root=anchor_root)
+    migration_path = get_storage_migration_path(config_manager, anchor_root=anchor_root)
+    assert policy_path.exists() and migration_path.exists()
+
+    router_module._restore_storage_mutation_state(config_manager, {}, anchor_root=anchor_root)
+
+    assert policy_path.exists(), "空快照回滚把存储策略文件 unlink 了"
+    assert migration_path.exists(), "空快照回滚把迁移检查点删了"
+
+
+# ── 4. 写序列保持原子（不许被 await 切开） ────────────────────────────
 
 
 @pytest.mark.unit

--- a/tests/unit/test_root_state_write_lock.py
+++ b/tests/unit/test_root_state_write_lock.py
@@ -16,6 +16,7 @@ import ast
 import asyncio
 import threading
 import time
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
 
@@ -27,7 +28,12 @@ from main_routers import storage_location_router as router_module
 from main_routers.shared_state import init_shared_state
 from utils import root_state_lock
 from utils import storage_location_bootstrap as bootstrap_module
-from utils.cloudsave_runtime import ROOT_MODE_MAINTENANCE_READONLY, ROOT_MODE_NORMAL
+from utils.cloudsave_runtime import (
+    ROOT_MODE_BOOTSTRAP_IMPORTING,
+    ROOT_MODE_MAINTENANCE_READONLY,
+    ROOT_MODE_NORMAL,
+    set_root_mode,
+)
 from utils.cloudsave_runtime import fence as fence_module
 from utils.config_manager import ConfigManager
 from utils.storage_migration import get_storage_migration_path, save_storage_migration
@@ -743,6 +749,80 @@ async def test_repeatedly_cancelled_storage_job_still_waits_for_the_worker():
     assert finished.is_set(), (
         "第二次取消让 await 提前返回了——worker 还在写，锁已经松开"
     )
+
+
+@pytest.mark.unit
+async def test_storage_snapshot_waits_for_cloud_fence_transaction(tmp_path, monkeypatch):
+    """A rollback snapshot must never capture a cloud fence's temporary mode."""
+    config_manager = _make_real_config_manager(tmp_path)
+    anchor_root = Path(config_manager.anchor_root)
+    set_root_mode(config_manager, ROOT_MODE_NORMAL)
+
+    fence_entered = threading.Event()
+    release_fence = threading.Event()
+    fence_errors: list[BaseException] = []
+
+    def _hold_cloud_fence() -> None:
+        try:
+            with fence_module.cloud_apply_fence(
+                config_manager,
+                mode=ROOT_MODE_BOOTSTRAP_IMPORTING,
+                reason="test_snapshot_transaction",
+            ):
+                fence_entered.set()
+                if not release_fence.wait(5):
+                    raise TimeoutError("test did not release cloud fence")
+        except BaseException as exc:
+            fence_errors.append(exc)
+
+    fence_thread = threading.Thread(target=_hold_cloud_fence)
+    fence_thread.start()
+    assert await asyncio.get_running_loop().run_in_executor(None, fence_entered.wait, 5)
+
+    transaction_attempted = threading.Event()
+    snapshot_attempted = threading.Event()
+    real_transaction = router_module.root_state_transaction
+    real_snapshot = router_module._snapshot_storage_mutation_state
+
+    @contextmanager
+    def _observed_transaction():
+        transaction_attempted.set()
+        with real_transaction():
+            yield
+
+    def _observed_snapshot(*args, **kwargs):
+        snapshot_attempted.set()
+        return real_snapshot(*args, **kwargs)
+
+    monkeypatch.setattr(router_module, "root_state_transaction", _observed_transaction)
+    monkeypatch.setattr(router_module, "_snapshot_storage_mutation_state", _observed_snapshot)
+
+    snapshot: dict[str, object] = {}
+    task = asyncio.create_task(
+        router_module._apply_storage_mutation_writes(
+            config_manager,
+            anchor_root=anchor_root,
+            snapshot_out=snapshot,
+            write=lambda: set_root_mode(config_manager, ROOT_MODE_MAINTENANCE_READONLY),
+        )
+    )
+    assert await asyncio.get_running_loop().run_in_executor(None, transaction_attempted.wait, 5)
+    assert not snapshot_attempted.is_set(), (
+        "snapshot ran before cloud_apply_fence released its root-state transaction"
+    )
+
+    release_fence.set()
+    try:
+        await task
+    finally:
+        release_fence.set()
+        fence_thread.join(timeout=5)
+
+    assert not fence_thread.is_alive()
+    assert not fence_errors
+    assert snapshot_attempted.is_set()
+    assert snapshot["root_state"]["mode"] == ROOT_MODE_NORMAL
+    assert config_manager.load_root_state()["mode"] == ROOT_MODE_MAINTENANCE_READONLY
 
 
 @pytest.mark.unit

--- a/tests/unit/test_root_state_write_lock.py
+++ b/tests/unit/test_root_state_write_lock.py
@@ -555,9 +555,11 @@ def test_startup_marker_keeps_its_eligibility_check_in_the_writing_scope():
     inserted an await between them, so a storage mutation worker could commit
     ``ROOT_MODE_MAINTENANCE_READONLY`` in the gap and get stomped back to normal.
 
-    The rule is shape-based: a ``set_root_mode`` call whose own scope lacks the
-    check while an *enclosing* scope has it means the check got left behind.
-    Sites that simply do not use the check (launcher paths) are untouched.
+    The rule is shape-based: any scope that does the check *and* the write itself
+    must hold both inside one ``root_state_transaction()``. In practice that means
+    nobody hand-rolls the pair — they call ``mark_startup_successful``, which is
+    the single scope that legitimately does both (under the lock). Sites that only
+    read the predicate, or only write, are untouched.
     """
     check = "should_write_root_mode_normal_after_startup"
     offenders: list[str] = []
@@ -568,32 +570,42 @@ def test_startup_marker_keeps_its_eligibility_check_in_the_writing_scope():
         except (SyntaxError, UnicodeDecodeError):
             continue
 
-        def _walk(scope: ast.AST, outer_has_check: bool) -> None:
+        for scope in ast.walk(tree):
+            if not isinstance(scope, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
             own_calls = [n for n in _own_nodes(scope) if isinstance(n, ast.Call)]
             names = {_called_name(c) for c in own_calls}
-            has_check = check in names
-            if "set_root_mode" in names and not has_check and outer_has_check:
-                offenders.append(
-                    f"{path.relative_to(_REPO_ROOT).as_posix()}:{scope.lineno} "
-                    f"{getattr(scope, 'name', '<module>')}()"
-                )
-            for node in ast.walk(scope):
-                if node is scope:
-                    continue
-                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                    _walk(node, outer_has_check or has_check)
+            if not ({check, "set_root_mode"} <= names):
+                continue
 
-        for top in ast.iter_child_nodes(tree):
-            if isinstance(top, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                _walk(top, False)
-            elif isinstance(top, ast.ClassDef):
-                for member in ast.iter_child_nodes(top):
-                    if isinstance(member, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                        _walk(member, False)
+            guarded = False
+            for block in _own_nodes(scope):
+                if not isinstance(block, ast.With):
+                    continue
+                if not any(
+                    isinstance(item.context_expr, ast.Call)
+                    and _called_name(item.context_expr) == "root_state_transaction"
+                    for item in block.items
+                ):
+                    continue
+                inner = {
+                    _called_name(c)
+                    for c in _own_nodes(block)
+                    if isinstance(c, ast.Call)
+                }
+                if {check, "set_root_mode"} <= inner:
+                    guarded = True
+                    break
+            if not guarded:
+                offenders.append(
+                    f"{path.relative_to(_REPO_ROOT).as_posix()}:{scope.lineno} {scope.name}()"
+                )
 
     assert not offenders, (
-        "这些作用域写了启动成功标记，但判定留在了外层作用域——中间隔着 await，"
-        "判定和写就不再是不可分割的一步：\n  " + "\n  ".join(offenders)
+        "这些作用域自己拼了「判定 + 写启动标记」，却没把两步收进同一个 "
+        "root_state_transaction()。中间没有 await 只挡得住同一循环上的协程，挡不住"
+        "工作线程——存储变更路由的写现在就在工作线程上。改调 mark_startup_successful："
+        "\n  " + "\n  ".join(offenders)
     )
 
 

--- a/tests/unit/test_root_state_write_lock.py
+++ b/tests/unit/test_root_state_write_lock.py
@@ -1,0 +1,331 @@
+"""Guards for the root_state writer lock and the read-path no-write rule.
+
+Three invariants are pinned here, each with its dual so that "the guard is
+green" cannot mean "the guard never ran":
+
+1. writes take ``utils.root_state_lock``; reads never do (and a worker holding
+   the lock cannot stall a read);
+2. ``build_storage_location_bootstrap_payload`` only persists a reconciled
+   ``legacy_cleanup_pending`` when the caller opts in, and every opt-in call
+   site sits behind ``_storage_mutation_lock``;
+3. the ``delete_storage_migration`` → ``save_storage_policy`` →
+   ``set_root_mode`` write sequences stay inside synchronous functions, so no
+   await — and therefore no cancellation point — can be introduced between them.
+"""
+import ast
+import threading
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from main_routers import storage_location_router as router_module
+from main_routers.shared_state import init_shared_state
+from utils import root_state_lock
+from utils import storage_location_bootstrap as bootstrap_module
+from utils.config_manager import ConfigManager
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# 这几个是 storage 状态的"写原语"。它们两两之间没有 await 是当前实现的硬前提：
+# 中间插一个 await 就能被取消停在"检查点已删、root mode 未改"上。
+_STORAGE_WRITE_PRIMITIVES = frozenset(
+    {
+        "delete_storage_migration",
+        "save_storage_migration",
+        "save_storage_policy",
+        "set_root_mode",
+        "create_pending_storage_migration",
+    }
+)
+
+
+class _RecordingLock:
+    """A lock that counts how many times it was entered."""
+
+    def __init__(self) -> None:
+        self._inner = threading.RLock()
+        self.entered = 0
+
+    def __enter__(self):
+        self.entered += 1
+        return self._inner.__enter__()
+
+    def __exit__(self, *exc_info):
+        return self._inner.__exit__(*exc_info)
+
+
+def _make_real_config_manager(tmp_path: Path) -> ConfigManager:
+    standard_root = tmp_path / "anchor-base"
+    with (
+        patch.object(ConfigManager, "_get_documents_directory", return_value=tmp_path / "runtime-parent"),
+        patch.object(ConfigManager, "_get_standard_data_directory_candidates", return_value=[standard_root]),
+    ):
+        config_manager = ConfigManager("N.E.K.O")
+    config_manager._get_standard_data_directory_candidates = lambda: [standard_root]
+    return config_manager
+
+
+def _build_client(config_manager) -> TestClient:
+    init_shared_state(
+        role_state={},
+        steamworks=None,
+        templates=None,
+        config_manager=config_manager,
+        logger=None,
+    )
+    app = FastAPI()
+    app.include_router(router_module.router)
+    return TestClient(app)
+
+
+def _iter_project_python_files():
+    """Every non-test project .py file, discovered rather than listed.
+
+    A hardcoded list would only ever cover the call sites that existed when it
+    was written; the whole point of these guards is to catch the next one.
+    """
+    skip_parts = {
+        ".git", ".venv", "node_modules", "__pycache__", "tests", "build", "dist",
+        ".claude", ".codex-tmp", "frontend", "deps", "docs",
+    }
+    for path in _REPO_ROOT.rglob("*.py"):
+        if any(part in skip_parts for part in path.parts):
+            continue
+        yield path
+
+
+# ── 1. 写者拿锁 / 读者不拿锁（对偶） ──────────────────────────────────
+
+
+@pytest.mark.unit
+def test_save_root_state_takes_the_writer_lock(tmp_path, monkeypatch):
+    config_manager = _make_real_config_manager(tmp_path)
+    recorder = _RecordingLock()
+    monkeypatch.setattr(root_state_lock, "_ROOT_STATE_WRITE_LOCK", recorder)
+
+    config_manager.save_root_state(config_manager.build_default_root_state())
+
+    assert recorder.entered >= 1, (
+        "save_root_state 没拿写者锁：两个写者会各自读到同一份 pre-image，"
+        "后写的那个把先写的字段整份盖掉"
+    )
+
+
+@pytest.mark.unit
+def test_load_root_state_does_not_take_the_writer_lock(tmp_path, monkeypatch):
+    config_manager = _make_real_config_manager(tmp_path)
+    config_manager.save_root_state(config_manager.build_default_root_state())
+
+    recorder = _RecordingLock()
+    monkeypatch.setattr(root_state_lock, "_ROOT_STATE_WRITE_LOCK", recorder)
+
+    config_manager.load_root_state()
+
+    assert recorder.entered == 0, (
+        "读路径拿了写者锁。存储页在按 STORAGE_STATUS_POLL_INTERVAL_MS 轮询 GET /status，"
+        "写在工作线程里持锁时这个读就会被卡住——阻塞经由锁原路传回事件循环"
+    )
+
+
+@pytest.mark.unit
+def test_read_is_not_blocked_while_a_worker_holds_the_writer_lock(tmp_path):
+    """The interleaving is forced, not hoped for: probability finds nothing here."""
+    config_manager = _make_real_config_manager(tmp_path)
+    config_manager.save_root_state(config_manager.build_default_root_state())
+
+    holding = threading.Event()
+    release = threading.Event()
+    hold_seconds = 3.0
+
+    def _hold_the_lock() -> None:
+        with root_state_lock.root_state_transaction():
+            holding.set()
+            release.wait(hold_seconds)
+
+    worker = threading.Thread(target=_hold_the_lock, daemon=True)
+    worker.start()
+    try:
+        assert holding.wait(5), "worker 没能拿到锁"
+        started = time.perf_counter()
+        state = config_manager.load_root_state()
+        elapsed = time.perf_counter() - started
+    finally:
+        release.set()
+        worker.join(timeout=5)
+
+    # join 超时只是返回，不会让用例红——显式断言线程真的收了
+    assert not worker.is_alive()
+    assert isinstance(state, dict)
+    assert elapsed < hold_seconds / 2, (
+        f"读路径等了 {elapsed:.3f}s，说明它在等工作线程手里那把写者锁"
+    )
+
+
+# ── 2. 读路径不写 root_state（对偶 + 调用点） ─────────────────────────
+
+
+@pytest.mark.unit
+def test_bootstrap_payload_does_not_persist_reconcile_by_default(tmp_path, monkeypatch):
+    config_manager = _make_real_config_manager(tmp_path)
+    base_state = dict(config_manager.build_default_root_state())
+    base_state["legacy_cleanup_pending"] = False
+    config_manager.save_root_state(base_state)
+
+    monkeypatch.setattr(bootstrap_module, "_derive_legacy_cleanup_pending", lambda **_kwargs: True)
+
+    payload = bootstrap_module.build_storage_location_bootstrap_payload(config_manager)
+
+    assert payload["legacy_cleanup_pending"] is True, "派生值应该照常出现在 payload 里"
+    assert config_manager.load_root_state().get("legacy_cleanup_pending") is False, (
+        "默认参数下把 reconcile 落盘了：这条路径挂在被持续轮询的 GET /status 上，"
+        "会跟变更路由的回滚互相盖"
+    )
+
+
+@pytest.mark.unit
+def test_bootstrap_payload_persists_reconcile_when_opted_in(tmp_path, monkeypatch):
+    config_manager = _make_real_config_manager(tmp_path)
+    base_state = dict(config_manager.build_default_root_state())
+    base_state["legacy_cleanup_pending"] = False
+    config_manager.save_root_state(base_state)
+
+    monkeypatch.setattr(bootstrap_module, "_derive_legacy_cleanup_pending", lambda **_kwargs: True)
+
+    bootstrap_module.build_storage_location_bootstrap_payload(config_manager, persist_reconcile=True)
+
+    assert config_manager.load_root_state().get("legacy_cleanup_pending") is True, (
+        "显式 opt-in 也没落盘，那 reconcile 这条自愈路径就整个没了"
+    )
+
+
+@pytest.mark.unit
+def test_storage_location_read_routes_leave_root_state_untouched(tmp_path, monkeypatch):
+    """Drive the real read endpoints, not just the helper they call.
+
+    Testing only ``build_storage_location_bootstrap_payload``'s default would
+    stay green if a route started passing ``persist_reconcile=True``.
+    """
+    config_manager = _make_real_config_manager(tmp_path)
+    monkeypatch.setattr(bootstrap_module, "_derive_legacy_cleanup_pending", lambda **_kwargs: True)
+
+    read_paths = sorted(
+        route.path
+        for route in router_module.router.routes
+        if "GET" in getattr(route, "methods", set()) and "{" not in route.path
+    )
+    assert read_paths, "一条 GET 路由都没发现，说明发现逻辑坏了，不是真的没有"
+
+    client = _build_client(config_manager)
+    for path in read_paths + ["/api/storage/location/exit"]:
+        base_state = dict(config_manager.build_default_root_state())
+        base_state["legacy_cleanup_pending"] = False
+        config_manager.save_root_state(base_state)
+
+        if path.endswith("/exit"):
+            response = client.post(path, headers={"X-Neko-Storage-Action": "exit"})
+        else:
+            response = client.get(path)
+
+        # 500 = 未处理异常，说明路由根本没跑通；其余状态码（含 /exit 在没有
+        # shutdown 回调时的 503）都算真的跑到了业务分支。
+        assert response.status_code != 500, f"{path} -> {response.status_code}"
+        assert config_manager.load_root_state().get("legacy_cleanup_pending") is False, (
+            f"{path} 在读路径上写了 root_state"
+        )
+
+
+@pytest.mark.unit
+def test_persist_reconcile_opt_in_only_happens_behind_the_mutation_lock():
+    """Every ``persist_reconcile=True`` must sit in a ``*_locked`` helper.
+
+    ``_storage_mutation_lock`` is only ever taken by the thin route wrappers that
+    delegate to ``_..._locked``; that naming is the machine-checkable shape of
+    "this call holds the lock".
+    """
+    offenders: list[str] = []
+    for path in _iter_project_python_files():
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+
+        enclosing: list[ast.AST] = []
+
+        def _visit(node: ast.AST) -> None:
+            is_function = isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            if is_function:
+                enclosing.append(node)
+            if isinstance(node, ast.Call):
+                for keyword in node.keywords:
+                    if keyword.arg != "persist_reconcile":
+                        continue
+                    if not (isinstance(keyword.value, ast.Constant) and keyword.value.value is True):
+                        continue
+                    owner = enclosing[-1].name if enclosing else "<module>"
+                    if not owner.endswith("_locked"):
+                        offenders.append(
+                            f"{path.relative_to(_REPO_ROOT).as_posix()}:{node.lineno} in {owner}()"
+                        )
+            for child in ast.iter_child_nodes(node):
+                _visit(child)
+            if is_function:
+                enclosing.pop()
+
+        _visit(tree)
+
+    assert not offenders, (
+        "这些调用点在没拿 _storage_mutation_lock 的地方要求把 reconcile 落盘：\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+# ── 3. 写序列保持原子（不许被 await 切开） ────────────────────────────
+
+
+@pytest.mark.unit
+def test_storage_write_primitives_never_sit_directly_in_an_async_body():
+    """Keep the write sequences indivisible by keeping them out of async bodies.
+
+    Rollbacks are the one exception and they are recognised by shape rather than
+    by name: they all live inside an ``except`` handler and are deliberately
+    synchronous, because awaiting in an except handler makes the rollback itself
+    cancellable (``CancelledError`` is a ``BaseException``, so the surrounding
+    ``except Exception`` would not catch it).
+    """
+    source_path = _REPO_ROOT / "main_routers" / "storage_location_router.py"
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    offenders: list[str] = []
+
+    def _walk(node: ast.AST, *, async_owner: str | None, in_except: bool) -> None:
+        if isinstance(node, ast.AsyncFunctionDef):
+            for child in ast.iter_child_nodes(node):
+                _walk(child, async_owner=node.name, in_except=False)
+            return
+        if isinstance(node, ast.FunctionDef):
+            # 同步函数体就是我们想要的形状：里面插不进 await
+            for child in ast.iter_child_nodes(node):
+                _walk(child, async_owner=None, in_except=False)
+            return
+        if isinstance(node, ast.ExceptHandler):
+            for child in ast.iter_child_nodes(node):
+                _walk(child, async_owner=async_owner, in_except=True)
+            return
+        if isinstance(node, ast.Call) and async_owner is not None and not in_except:
+            func = node.func
+            name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", "")
+            if name in _STORAGE_WRITE_PRIMITIVES:
+                offenders.append(f"{name}() at line {node.lineno} in async {async_owner}()")
+        for child in ast.iter_child_nodes(node):
+            _walk(child, async_owner=async_owner, in_except=in_except)
+
+    for top in ast.iter_child_nodes(tree):
+        _walk(top, async_owner=None, in_except=False)
+
+    assert not offenders, (
+        "这些 storage 写原语直接躺在 async 函数体里，等于给写序列留了插 await 的位置：\n  "
+        + "\n  ".join(offenders)
+    )

--- a/tests/unit/test_root_state_write_lock.py
+++ b/tests/unit/test_root_state_write_lock.py
@@ -97,20 +97,77 @@ def _called_name(call: ast.Call) -> str:
     return ""
 
 
+def _own_nodes(scope: ast.AST):
+    """Descendants of ``scope`` excluding anything inside a nested function.
+
+    Nested defs are their own scope — a closure's re-read does not make its
+    enclosing route safe, and vice versa.
+    """
+    for child in ast.iter_child_nodes(scope):
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            continue
+        yield child
+        yield from _own_nodes(child)
+
+
+def _is_root_state_write(call: ast.Call) -> bool:
+    return _called_name(call) == "save_root_state"
+
+
+def _is_root_state_read(call: ast.Call) -> bool:
+    name = _called_name(call)
+    if name in {"load_root_state", "get_root_state"}:
+        return True
+    # 间接读，例如 self._load_json_file(self.root_state_path, default_value={})。
+    # 只认名字里带 load/read 的，免得把 _save_local_state_json_file(self.root_state_path…)
+    # 也算成读。
+    lowered = name.lower()
+    if "load" not in lowered and "read" not in lowered:
+        return False
+    operands = list(call.args) + [keyword.value for keyword in call.keywords]
+    return any(
+        isinstance(operand, ast.Attribute) and operand.attr == "root_state_path"
+        for operand in operands
+    )
+
+
+_SKIP_DIRS = {
+    ".git", ".venv", "node_modules", "__pycache__", "tests", "build", "dist",
+    ".claude", ".codex-tmp", "frontend", "deps", "docs",
+}
+
+# 这三条 AST 护栏靠 _iter_project_python_files 供料，扫不到文件就等于全绿。
+# 主仓库当前有 1000+ 个在扫描范围内的 .py，取一个远低于它、又远高于 0 的下界。
+_MIN_SCANNED_FILES = 200
+
+
 def _iter_project_python_files():
     """Every non-test project .py file, discovered rather than listed.
 
     A hardcoded list would only ever cover the call sites that existed when it
     was written; the whole point of these guards is to catch the next one.
+
+    ⚠️ The skip list is matched against the path **relative to the repo root**,
+    never the absolute path. Matching the absolute path made every one of these
+    guards scan zero files when the checkout itself lives under a directory
+    named in the list — which is exactly what happened in a
+    ``.claude/worktrees/...`` worktree: locally vacuous, green in CI (whose
+    checkout path has no such component), so nothing ever reported it.
     """
-    skip_parts = {
-        ".git", ".venv", "node_modules", "__pycache__", "tests", "build", "dist",
-        ".claude", ".codex-tmp", "frontend", "deps", "docs",
-    }
     for path in _REPO_ROOT.rglob("*.py"):
-        if any(part in skip_parts for part in path.parts):
+        if any(part in _SKIP_DIRS for part in path.relative_to(_REPO_ROOT).parts):
             continue
         yield path
+
+
+def _project_python_files() -> list[Path]:
+    """``_iter_project_python_files`` plus the "did we actually scan anything" check."""
+    paths = list(_iter_project_python_files())
+    assert len(paths) >= _MIN_SCANNED_FILES, (
+        f"只扫到 {len(paths)} 个文件（下界 {_MIN_SCANNED_FILES}）——发现逻辑坏了，"
+        "下面所有 AST 护栏都会假绿"
+    )
+    return paths
 
 
 # ── 1. 写者拿锁 / 读者不拿锁（对偶） ──────────────────────────────────
@@ -262,7 +319,7 @@ def test_persist_reconcile_opt_in_only_happens_behind_the_mutation_lock():
     "this call holds the lock".
     """
     offenders: list[str] = []
-    for path in _iter_project_python_files():
+    for path in _project_python_files():
         try:
             tree = ast.parse(path.read_text(encoding="utf-8"))
         except (SyntaxError, UnicodeDecodeError):
@@ -389,11 +446,9 @@ def test_every_locked_write_reloads_root_state_inside_the_block():
     open a transaction at all, they lean on the lock inside ``save_root_state``,
     and writing a stale pre-image is precisely their job.
     """
-    reads = {"load_root_state", "get_root_state"}
-    writes = {"save_root_state"}
     offenders: list[str] = []
 
-    for path in _iter_project_python_files():
+    for path in _project_python_files():
         try:
             tree = ast.parse(path.read_text(encoding="utf-8"))
         except (SyntaxError, UnicodeDecodeError):
@@ -410,12 +465,12 @@ def test_every_locked_write_reloads_root_state_inside_the_block():
             if not opens_transaction:
                 continue
 
-            called = {
-                _called_name(child)
-                for child in ast.walk(node)
-                if isinstance(child, ast.Call)
-            }
-            if called & writes and not (called & reads):
+            # 用同一对 shape 谓词，别退回按名字比对：storage_roots 那处的读是
+            # self._load_json_file(self.root_state_path, ...)，名字对不上但确实是读。
+            calls = [child for child in ast.walk(node) if isinstance(child, ast.Call)]
+            if any(_is_root_state_write(c) for c in calls) and not any(
+                _is_root_state_read(c) for c in calls
+            ):
                 offenders.append(
                     f"{path.relative_to(_REPO_ROOT).as_posix()}:{node.lineno}"
                 )
@@ -423,6 +478,188 @@ def test_every_locked_write_reloads_root_state_inside_the_block():
     assert not offenders, (
         "这些 root_state_transaction 块里写了盘却没在块内重读——写回去的是锁外读到的"
         "pre-image，会把这期间别人提交的字段整份盖掉：\n  " + "\n  ".join(offenders)
+    )
+
+
+@pytest.mark.unit
+def test_read_modify_write_of_root_state_happens_inside_one_transaction():
+    """A function that both reads and writes root_state must do both under the lock.
+
+    The sibling guard above only inspects code already inside a transaction, so a
+    site that never opens one is invisible to it — which is exactly how
+    ``_persist_selected_root_unavailable_recovery_state`` slipped through (it read
+    the file directly, then called ``save_root_state``, whose internal lock covers
+    only the write). This rule keys on shape, not on a list of names:
+
+    * reads-and-writes  -> both must sit in one ``root_state_transaction()`` block
+    * writes only       -> a snapshot restore / a create-if-missing default; the
+                           stale pre-image *is* the payload, so there is nothing
+                           to re-read and nothing to guard
+    * reads only        -> harmless
+    """
+    offenders: list[str] = []
+
+    for path in _project_python_files():
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+
+            own = list(_own_nodes(node))
+            calls = [n for n in own if isinstance(n, ast.Call)]
+            if not any(_is_root_state_write(c) for c in calls):
+                continue
+            if not any(_is_root_state_read(c) for c in calls):
+                continue
+
+            guarded = False
+            for block in own:
+                if not isinstance(block, ast.With):
+                    continue
+                if not any(
+                    isinstance(item.context_expr, ast.Call)
+                    and _called_name(item.context_expr) == "root_state_transaction"
+                    for item in block.items
+                ):
+                    continue
+                inner = [n for n in _own_nodes(block) if isinstance(n, ast.Call)]
+                if any(_is_root_state_read(c) for c in inner) and any(
+                    _is_root_state_write(c) for c in inner
+                ):
+                    guarded = True
+                    break
+
+            if not guarded:
+                offenders.append(
+                    f"{path.relative_to(_REPO_ROOT).as_posix()}:{node.lineno} {node.name}()"
+                )
+
+    assert not offenders, (
+        "这些函数既读又写 root_state，但读和写没有落在同一个 root_state_transaction() "
+        "块里——锁只包住写的话，另一个写者提交的字段会被这份 pre-image 盖掉：\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+@pytest.mark.unit
+def test_startup_marker_keeps_its_eligibility_check_in_the_writing_scope():
+    """Offloading the write must not leave its precondition behind on the loop.
+
+    ``should_write_root_mode_normal_after_startup`` decides whether the startup
+    marker may be written. While that decision and the write sat next to each
+    other on the event loop they were indivisible; putting the write in a worker
+    inserted an await between them, so a storage mutation worker could commit
+    ``ROOT_MODE_MAINTENANCE_READONLY`` in the gap and get stomped back to normal.
+
+    The rule is shape-based: a ``set_root_mode`` call whose own scope lacks the
+    check while an *enclosing* scope has it means the check got left behind.
+    Sites that simply do not use the check (launcher paths) are untouched.
+    """
+    check = "should_write_root_mode_normal_after_startup"
+    offenders: list[str] = []
+
+    for path in _project_python_files():
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+
+        def _walk(scope: ast.AST, outer_has_check: bool) -> None:
+            own_calls = [n for n in _own_nodes(scope) if isinstance(n, ast.Call)]
+            names = {_called_name(c) for c in own_calls}
+            has_check = check in names
+            if "set_root_mode" in names and not has_check and outer_has_check:
+                offenders.append(
+                    f"{path.relative_to(_REPO_ROOT).as_posix()}:{scope.lineno} "
+                    f"{getattr(scope, 'name', '<module>')}()"
+                )
+            for node in ast.walk(scope):
+                if node is scope:
+                    continue
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    _walk(node, outer_has_check or has_check)
+
+        for top in ast.iter_child_nodes(tree):
+            if isinstance(top, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                _walk(top, False)
+            elif isinstance(top, ast.ClassDef):
+                for member in ast.iter_child_nodes(top):
+                    if isinstance(member, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                        _walk(member, False)
+
+    assert not offenders, (
+        "这些作用域写了启动成功标记，但判定留在了外层作用域——中间隔着 await，"
+        "判定和写就不再是不可分割的一步：\n  " + "\n  ".join(offenders)
+    )
+
+
+@pytest.mark.unit
+def test_rollback_on_exception_also_rolls_back_on_cancellation():
+    """If a try bothers to roll back, it must roll back on cancellation too.
+
+    ``CancelledError`` is a ``BaseException``, so ``except Exception`` does not
+    see it. Any async ``try`` that undoes its work in an ``except Exception``
+    handler therefore has a hole: a client disconnect skips exactly the cleanup
+    the handler exists for. Scoped to async bodies — synchronous code cannot be
+    cancelled this way.
+    """
+    rollback_calls = {
+        "_restore_storage_mutation_state",
+        "save_root_state",
+        "save_storage_migration",
+        "delete_storage_migration",
+    }
+    offenders: list[str] = []
+
+    for path in _project_python_files():
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+
+        for scope in ast.walk(tree):
+            if not isinstance(scope, ast.AsyncFunctionDef):
+                continue
+            # 回滚 handler 内部那些 best-effort 的 try/except 不算：它们已经在异常
+            # 处理里了，再要求它们处理取消既没有意义也无处可退。
+            inside_handler = {
+                nested
+                for node in ast.walk(scope)
+                if isinstance(node, ast.ExceptHandler)
+                for nested in ast.walk(node)
+                if isinstance(nested, ast.Try)
+            }
+            for node in _own_nodes(scope):
+                if not isinstance(node, ast.Try) or node in inside_handler:
+                    continue
+                rolls_back = any(
+                    _called_name(c) in rollback_calls
+                    for handler in node.handlers
+                    for c in ast.walk(handler)
+                    if isinstance(c, ast.Call)
+                )
+                if not rolls_back:
+                    continue
+                # CancelledError 显式接，或者干脆接 BaseException——两者都能兜住取消。
+                handles_cancel = any(
+                    "CancelledError" in ast.dump(handler.type)
+                    or "BaseException" in ast.dump(handler.type)
+                    for handler in node.handlers
+                    if handler.type is not None
+                )
+                if not handles_cancel:
+                    offenders.append(
+                        f"{path.relative_to(_REPO_ROOT).as_posix()}:{node.lineno} in {scope.name}()"
+                    )
+
+    assert not offenders, (
+        "这些 async try 在 except 里做了回滚，却没有处理 CancelledError——"
+        "它是 BaseException，except Exception 接不住，客户端断连就正好跳过回滚：\n  "
+        + "\n  ".join(offenders)
     )
 
 

--- a/tests/unit/test_root_state_write_lock.py
+++ b/tests/unit/test_root_state_write_lock.py
@@ -700,6 +700,40 @@ async def test_cancelled_storage_job_waits_for_the_worker_before_unwinding():
 
 
 @pytest.mark.unit
+async def test_repeatedly_cancelled_storage_job_still_waits_for_the_worker():
+    """One suppressed cancellation is not enough.
+
+    A request cancellation followed by a server-shutdown cancellation lands the
+    second ``CancelledError`` on the handler's own await. Suppressing a single
+    one and unwinding would release the mutation lock with the worker still
+    writing — the exact hole this helper exists to close.
+    """
+    started = threading.Event()
+    finished = threading.Event()
+
+    def _job() -> str:
+        started.set()
+        time.sleep(0.4)
+        finished.set()
+        return "done"
+
+    task = asyncio.ensure_future(router_module._run_locked_storage_job(_job))
+    assert await asyncio.get_running_loop().run_in_executor(None, started.wait, 5)
+
+    task.cancel()
+    # 让 handler 真的跑到"等 worker"那一步，第二次取消才打得中
+    await asyncio.sleep(0.05)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert finished.is_set(), (
+        "第二次取消让 await 提前返回了——worker 还在写，锁已经松开"
+    )
+
+
+@pytest.mark.unit
 def test_empty_snapshot_never_deletes_storage_state(tmp_path):
     """An un-taken snapshot must not be replayed as "these files did not exist".
 

--- a/tests/unit/test_storage_location_router.py
+++ b/tests/unit/test_storage_location_router.py
@@ -1209,6 +1209,46 @@ def test_storage_location_restart_awaits_async_shutdown_callback(tmp_path):
 
 
 @pytest.mark.unit
+@pytest.mark.asyncio
+async def test_restart_keeps_checkpoint_when_cancelled_after_shutdown_is_accepted(tmp_path):
+    """Late cancellation must not erase work already handed to the launcher."""
+    config_manager = _DummyConfigManager(tmp_path)
+    target_root = tmp_path / "new-storage" / "N.E.K.O"
+    route_task = asyncio.current_task()
+    assert route_task is not None
+    shutdown_accepted = asyncio.Event()
+
+    async def request_app_shutdown():
+        shutdown_accepted.set()
+        # The callback succeeds, but cancellation reaches its waiter first.
+        asyncio.get_running_loop().call_soon(route_task.cancel)
+
+    init_shared_state(
+        role_state={},
+        steamworks=None,
+        templates=None,
+        config_manager=config_manager,
+        logger=None,
+        request_app_shutdown=request_app_shutdown,
+    )
+    payload = storage_location_router_module.StorageLocationSelectionRequest(
+        selected_root=str(target_root),
+        selection_source="recommended",
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await storage_location_router_module._post_storage_location_restart_locked(
+            payload,
+            Response(),
+        )
+
+    assert shutdown_accepted.is_set()
+    migration_payload = load_storage_migration(config_manager)
+    assert migration_payload["target_root"] == str(target_root.resolve())
+    assert config_manager.load_root_state()["mode"] == ROOT_MODE_MAINTENANCE_READONLY
+
+
+@pytest.mark.unit
 def test_storage_location_restart_restores_previous_migration_when_shutdown_fails(tmp_path):
     config_manager = _DummyConfigManager(tmp_path)
     target_root = tmp_path / "new-storage" / "N.E.K.O"

--- a/utils/cloudsave_runtime/bootstrap.py
+++ b/utils/cloudsave_runtime/bootstrap.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 from typing import Any
 
 from utils.file_utils import atomic_write_json
+from utils.root_state_lock import root_state_transaction
 
 from ._shared import (
     ROOT_MODE_DEFERRED_INIT,
@@ -164,31 +165,46 @@ def bootstrap_local_cloudsave_environment(config_manager) -> dict[str, Any]:
 
     legacy_import = import_legacy_runtime_root_if_needed(config_manager)
     root_state, recovered_stale_mode = _recover_stale_write_blocking_mode(config_manager, root_state)
-    root_changed = False
-    app_root = str(config_manager.app_docs_dir)
-    if root_state.get("current_root") != app_root:
-        root_state["current_root"] = app_root
-        root_changed = True
-    if not root_state.get("last_known_good_root"):
-        root_state["last_known_good_root"] = app_root
-        root_changed = True
-    if not root_state.get("last_successful_boot_at"):
-        root_state["last_successful_boot_at"] = ""
-        root_changed = True
-    if legacy_import.get("source"):
-        root_state["last_migration_source"] = str(legacy_import["source"])
-        root_state["last_migration_result"] = str(legacy_import.get("result") or "")
-        root_changed = True
-        if legacy_import.get("backup_path"):
-            root_state["last_migration_backup"] = str(legacy_import["backup_path"])
+
+    # 下面这串编辑 + 末尾的 save_root_state 是一次读—改—写，必须整段进锁。
+    #
+    # 锁从这里才开始，故意不往上包：import_legacy_runtime_root_if_needed 可能整目录
+    # 拷贝，_recover_stale_write_blocking_mode 会去拿跨进程的 cloud apply 锁——把
+    # root_state 锁包在它外面会让锁序变成 root_state → cloud_apply，跟
+    # cloud_apply_fence 的方向相反。全仓统一 cloud_apply_lock → root_state_transaction。
+    with root_state_transaction():
+        # 锁内重读：上面 load_root_state 那次到这里之间，storage_location 的变更路由
+        # （现在跑在工作线程上）可能已经提交过一轮，拿旧 pre-image 编辑再存回去会把
+        # 那一轮整份盖掉。
+        latest_state = config_manager.load_root_state()
+        if isinstance(latest_state, dict):
+            root_state = latest_state
+
+        root_changed = False
+        app_root = str(config_manager.app_docs_dir)
+        if root_state.get("current_root") != app_root:
+            root_state["current_root"] = app_root
             root_changed = True
-    elif recovered_stale_mode:
-        root_changed = True
-    elif not root_state.get("last_migration_result"):
-        root_state["last_migration_result"] = str(legacy_import.get("result") or "bootstrap_initialized")
-        root_changed = True
-    if root_changed:
-        config_manager.save_root_state(root_state)
+        if not root_state.get("last_known_good_root"):
+            root_state["last_known_good_root"] = app_root
+            root_changed = True
+        if not root_state.get("last_successful_boot_at"):
+            root_state["last_successful_boot_at"] = ""
+            root_changed = True
+        if legacy_import.get("source"):
+            root_state["last_migration_source"] = str(legacy_import["source"])
+            root_state["last_migration_result"] = str(legacy_import.get("result") or "")
+            root_changed = True
+            if legacy_import.get("backup_path"):
+                root_state["last_migration_backup"] = str(legacy_import["backup_path"])
+                root_changed = True
+        elif recovered_stale_mode:
+            root_changed = True
+        elif not root_state.get("last_migration_result"):
+            root_state["last_migration_result"] = str(legacy_import.get("result") or "bootstrap_initialized")
+            root_changed = True
+        if root_changed:
+            config_manager.save_root_state(root_state)
 
     cloud_state = config_manager.load_cloudsave_local_state()
     cloud_changed = False

--- a/utils/cloudsave_runtime/fence.py
+++ b/utils/cloudsave_runtime/fence.py
@@ -34,6 +34,7 @@ from typing import Any
 # ``cloud_apply_fence`` must see that patch, so the helper is resolved
 # through the facade at call time instead of via this module's globals.
 from utils import cloudsave_runtime as _facade
+from utils.root_state_lock import root_state_transaction
 
 from ._shared import (
     MaintenanceModeError,
@@ -69,13 +70,16 @@ def should_write_root_mode_normal_after_startup(root_state: dict[str, Any] | Non
 
 
 def set_root_mode(config_manager, mode: str, **updates: Any) -> dict[str, Any]:
-    state = get_root_state(config_manager)
-    state["mode"] = str(mode or ROOT_MODE_NORMAL)
-    for key, value in updates.items():
-        if value is not None:
-            state[key] = value
-    config_manager.save_root_state(state)
-    return state
+    # 读—改—写整段进锁：只让最后那次 save 原子是不够的，两个写者各自读到同一份
+    # pre-image 时，后写的那个会把先写的字段整份盖掉。
+    with root_state_transaction():
+        state = get_root_state(config_manager)
+        state["mode"] = str(mode or ROOT_MODE_NORMAL)
+        for key, value in updates.items():
+            if value is not None:
+                state[key] = value
+        config_manager.save_root_state(state)
+        return state
 
 
 def is_write_fence_active(config_manager) -> bool:
@@ -234,11 +238,14 @@ def _recover_stale_write_blocking_mode(config_manager, root_state: dict[str, Any
         return root_state, False
 
     try:
-        recovered_state = dict(root_state)
-        recovered_state["mode"] = ROOT_MODE_NORMAL
-        recovered_state["last_migration_result"] = f"recovered_stale_mode:{current_mode}"
-        config_manager.save_root_state(recovered_state)
-        return recovered_state, True
+        # 与 set_root_mode 同一把锁：这里也是读—改—写（root_state 是调用方读的）。
+        # 跨进程那把 cloud apply 锁挡不住同进程内的另一个写者。
+        with root_state_transaction():
+            recovered_state = dict(root_state)
+            recovered_state["mode"] = ROOT_MODE_NORMAL
+            recovered_state["last_migration_result"] = f"recovered_stale_mode:{current_mode}"
+            config_manager.save_root_state(recovered_state)
+            return recovered_state, True
     finally:
         release_cloud_apply_lock(config_manager)
 

--- a/utils/cloudsave_runtime/fence.py
+++ b/utils/cloudsave_runtime/fence.py
@@ -238,12 +238,29 @@ def _recover_stale_write_blocking_mode(config_manager, root_state: dict[str, Any
         return root_state, False
 
     try:
-        # 与 set_root_mode 同一把锁：这里也是读—改—写（root_state 是调用方读的）。
-        # 跨进程那把 cloud apply 锁挡不住同进程内的另一个写者。
+        # 与 set_root_mode 同一把锁：这里也是读—改—写，而且 root_state 是**调用方在
+        # 锁外**读的。跨进程那把 cloud apply 锁挡不住同进程内的另一个写者，所以必须
+        # 锁内重读——直接 dict(root_state) 回写会把这期间别人提交的 mode /
+        # current_root / last_known_good_root 整份盖掉（Greptile P1）。
+        #
+        # 锁序固定为 cloud_apply_lock → root_state_transaction，与 cloud_apply_fence
+        # 一致；任何地方都不许反过来。
         with root_state_transaction():
-            recovered_state = dict(root_state)
+            latest_state = config_manager.load_root_state()
+            if not isinstance(latest_state, dict):
+                latest_state = root_state
+
+            # 判定"该不该自愈"也要按锁内这份重来：锁外那次判断到这里之间，别人可能
+            # 已经把它恢复了，或者刚建了一个真的 pending 迁移。
+            latest_mode = str(latest_state.get("mode") or ROOT_MODE_NORMAL)
+            if latest_mode not in WRITE_BLOCKING_MODES:
+                return latest_state, False
+            if _should_preserve_write_blocking_mode(config_manager, latest_state):
+                return latest_state, False
+
+            recovered_state = dict(latest_state)
             recovered_state["mode"] = ROOT_MODE_NORMAL
-            recovered_state["last_migration_result"] = f"recovered_stale_mode:{current_mode}"
+            recovered_state["last_migration_result"] = f"recovered_stale_mode:{latest_mode}"
             config_manager.save_root_state(recovered_state)
             return recovered_state, True
     finally:

--- a/utils/cloudsave_runtime/fence.py
+++ b/utils/cloudsave_runtime/fence.py
@@ -272,8 +272,6 @@ def cloud_apply_fence(config_manager, *, mode: str = ROOT_MODE_MAINTENANCE_READO
     """Acquire the global cloud apply lock and switch root_state into maintenance."""
     _ensure_local_state_directory_or_raise(config_manager, "entering cloud_apply_fence")
 
-    previous_state = get_root_state(config_manager)
-    previous_mode = str(previous_state.get("mode") or ROOT_MODE_NORMAL)
     if not acquire_cloud_apply_lock(config_manager):
         raise MaintenanceModeError(
             get_root_mode(config_manager),
@@ -281,14 +279,29 @@ def cloud_apply_fence(config_manager, *, mode: str = ROOT_MODE_MAINTENANCE_READO
             target="cloud_apply_lock",
         )
     try:
-        _facade.set_root_mode(
-            config_manager,
-            mode,
-            last_migration_result=reason or previous_state.get("last_migration_result", ""),
-        )
-        yield get_root_state(config_manager)
+        # Hold the process-wide root_state transaction for the *whole* fence
+        # lifetime, not only for its enter/exit writes. Storage-location writes
+        # now run in worker threads; without this lifecycle lock they can commit
+        # MAINTENANCE_READONLY while a cloud operation is active, only for the
+        # fence's stale exit snapshot to restore NORMAL over the pending migration.
+        #
+        # Lock order stays cloud_apply_lock -> root_state_transaction everywhere.
+        # The transaction is an RLock because fence bodies legitimately call
+        # ConfigManager writers on the same thread.
+        with root_state_transaction():
+            # Read the pre-image only after both locks are held. Reading it before
+            # acquire_cloud_apply_lock would still allow a storage writer to land
+            # between the read and the acquisition and make this snapshot stale.
+            previous_state = get_root_state(config_manager)
+            previous_mode = str(previous_state.get("mode") or ROOT_MODE_NORMAL)
+            _facade.set_root_mode(
+                config_manager,
+                mode,
+                last_migration_result=reason or previous_state.get("last_migration_result", ""),
+            )
+            try:
+                yield get_root_state(config_manager)
+            finally:
+                _facade.set_root_mode(config_manager, previous_mode)
     finally:
-        try:
-            _facade.set_root_mode(config_manager, previous_mode)
-        finally:
-            release_cloud_apply_lock(config_manager)
+        release_cloud_apply_lock(config_manager)

--- a/utils/config_manager/storage_roots.py
+++ b/utils/config_manager/storage_roots.py
@@ -30,6 +30,7 @@ from pathlib import Path
 
 from config import APP_NAME, CONFIG_FILES
 from utils.file_utils import atomic_write_json
+from utils.root_state_lock import root_state_transaction
 
 from ._shared import LocalStateDirectoryError, logger
 
@@ -995,9 +996,11 @@ class StorageRootsMixin:
 
     def save_root_state(self, data):
         """Save root_state."""
-        if not self.ensure_local_state_directory():
-            self._raise_local_state_directory_error("saving root_state")
-        self._save_local_state_json_file(self.root_state_path, data, "saving root_state")
+        # 注意 load_root_state 故意不拿这把锁，理由见 utils/root_state_lock.py。
+        with root_state_transaction():
+            if not self.ensure_local_state_directory():
+                self._raise_local_state_directory_error("saving root_state")
+            self._save_local_state_json_file(self.root_state_path, data, "saving root_state")
 
     def load_cloudsave_local_state(self, default_value=None):
         """Load cloudsave_local_state; returns a default with a stable field structure when missing."""

--- a/utils/config_manager/storage_roots.py
+++ b/utils/config_manager/storage_roots.py
@@ -296,14 +296,22 @@ class StorageRootsMixin:
         return str(self.committed_selected_root) in self.__class__._selected_root_unavailable_recovery_override_roots
 
     def _persist_selected_root_unavailable_recovery_state(self):
-        state: dict = {}
-        try:
-            loaded = self._load_json_file(self.root_state_path, default_value={})
-            if isinstance(loaded, dict):
-                state = loaded
-        except Exception:
-            state = {}
-        self.save_root_state(self._build_selected_root_unavailable_recovery_state(state))
+        # 读—改—写整段进锁，而且读必须在锁内。
+        #
+        # "跑在 __init__ 里所以是单线程"不成立：受限启动期 storage_location_router
+        # 会临时构造一个兜底 ConfigManager（get_runtime_config_manager(APP_NAME,
+        # migrate=False)），而那一刻变更路由的写序列已经在工作线程上跑了。拿锁外读到
+        # 的 pre-image 去存，会把它刚提交的 mode / current_root / 迁移字段整份盖掉。
+        with root_state_transaction():
+            state: dict = {}
+            try:
+                loaded = self._load_json_file(self.root_state_path, default_value={})
+                if isinstance(loaded, dict):
+                    state = loaded
+            except Exception:
+                # 读不出来就按空状态重建恢复态——这条路径本来就是给"root 不可用"兜底的
+                state = {}
+            self.save_root_state(self._build_selected_root_unavailable_recovery_state(state))
     
     def _log(self, msg):
         """Print debug info only in the main process"""

--- a/utils/root_state_lock.py
+++ b/utils/root_state_lock.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The writer lock for ``root_state.json``.
+
+Its own module, with no project imports, for two reasons. The lock guards a
+*file*, not a ``ConfigManager`` instance — several managers can coexist in one
+process (the shared singleton main_server publishes, plus the
+``get_runtime_config_manager(APP_NAME, migrate=False)`` fallback the storage
+router takes during limited startup) and they all point at the same file, so a
+per-instance lock would not serialize them. And hanging it off the manager
+would put it in the duck-typed surface every test double has to grow.
+
+⚠️ Writers only. The read path (``load_root_state``) must never take this lock.
+The storage-location writes run in ``asyncio.to_thread`` workers, and
+``utils.file_utils`` re-enables its 155ms ``os.replace`` backoff off the event
+loop; if reads took the lock too, the storage page's ``GET /status`` poll
+(``STORAGE_STATUS_POLL_INTERVAL_MS``) would stall behind a worker and the
+blocking would come straight back to the loop through the lock. Reads do not
+need it: writes land via ``os.replace``, so a reader sees either the old file
+or the new one, never a half-written one.
+"""
+from __future__ import annotations
+
+import threading
+from contextlib import contextmanager
+from typing import Iterator
+
+_ROOT_STATE_WRITE_LOCK = threading.RLock()
+
+
+@contextmanager
+def root_state_transaction() -> Iterator[None]:
+    """Hold the root_state writer lock across one read-modify-write sequence.
+
+    Callers that load root_state, edit it and save it back must wrap the whole
+    sequence. Locking only inside ``save_root_state`` makes the final write
+    atomic but still lets two writers read the same pre-image and have the
+    later one clobber the earlier one's fields.
+
+    Reentrant on purpose: ``ConfigManager.save_root_state`` takes the same lock,
+    so it nests inside this block.
+    """
+    with _ROOT_STATE_WRITE_LOCK:
+        yield

--- a/utils/storage/location_bootstrap.py
+++ b/utils/storage/location_bootstrap.py
@@ -30,6 +30,7 @@ from .migration import (
     load_storage_migration,
 )
 from utils.logger_config import get_module_logger
+from utils.root_state_lock import root_state_transaction
 
 logger = get_module_logger(__name__)
 
@@ -185,11 +186,21 @@ def _reconcile_legacy_cleanup_pending_root_state(
     if bool(root_state.get("legacy_cleanup_pending")) == bool(derived_legacy_cleanup_pending):
         return root_state
 
-    updated_root_state = dict(root_state)
-    updated_root_state["legacy_cleanup_pending"] = bool(derived_legacy_cleanup_pending)
     try:
-        config_manager.save_root_state(updated_root_state)
-        return updated_root_state
+        with root_state_transaction():
+            # 锁内重读一次，别拿调用方手里那份 pre-image 去盖。调用方 load 到这里之间
+            # 变更路由可能已经写过一轮 root_state（回滚就是典型），直接 dict(root_state)
+            # 会把那一轮整份抹掉——PR #2598 里"回滚被 /status 盖掉"就是这个形状。
+            current_state = config_manager.load_root_state()
+            if not isinstance(current_state, dict):
+                current_state = root_state
+            if bool(current_state.get("legacy_cleanup_pending")) == bool(derived_legacy_cleanup_pending):
+                return current_state
+
+            updated_root_state = dict(current_state)
+            updated_root_state["legacy_cleanup_pending"] = bool(derived_legacy_cleanup_pending)
+            config_manager.save_root_state(updated_root_state)
+            return updated_root_state
     except Exception as exc:
         logger.warning(
             "_reconcile_legacy_cleanup_pending_root_state: config_manager.save_root_state failed: %s",
@@ -210,7 +221,25 @@ def _should_require_selection(config_manager, *, current_root: Path, anchor_root
     )
 
 
-def build_storage_location_bootstrap_payload(config_manager) -> dict[str, Any]:
+def build_storage_location_bootstrap_payload(
+    config_manager,
+    *,
+    persist_reconcile: bool = False,
+) -> dict[str, Any]:
+    """Build the storage-location bootstrap payload.
+
+    ``persist_reconcile`` decides whether a drifted ``legacy_cleanup_pending``
+    flag is written back to root_state.json. It defaults to False so that read
+    endpoints stay read-only: this payload backs ``GET /bootstrap``,
+    ``GET /status`` (the storage page polls it on a 1200ms timer), ``GET /diagnostics``,
+    ``GET /retained-source`` and ``POST /exit``, none of which hold
+    ``_storage_mutation_lock``. A write from there races the mutation routes'
+    rollback and can clobber it wholesale, which is what stopped the offload in
+    PR #2598. Only callers already holding that lock pass True.
+
+    The returned payload carries the freshly derived flag either way — turning
+    persistence off changes what lands on disk, not what the client sees.
+    """
     current_root = Path(config_manager.app_docs_dir).expanduser().resolve(strict=False)
     display_current_root = Path(
         getattr(config_manager, "reported_current_root", current_root)
@@ -264,11 +293,12 @@ def build_storage_location_bootstrap_payload(config_manager) -> dict[str, Any]:
         current_root=current_root,
         anchor_root=anchor_root,
     )
-    root_state = _reconcile_legacy_cleanup_pending_root_state(
-        config_manager,
-        root_state=root_state,
-        derived_legacy_cleanup_pending=legacy_cleanup_pending,
-    )
+    if persist_reconcile:
+        root_state = _reconcile_legacy_cleanup_pending_root_state(
+            config_manager,
+            root_state=root_state,
+            derived_legacy_cleanup_pending=legacy_cleanup_pending,
+        )
 
     return {
         "current_root": _normalize_path(display_current_root),

--- a/uv.lock
+++ b/uv.lock
@@ -657,8 +657,8 @@ name = "dxcam"
 version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "comtypes" },
-    { name = "numpy" },
+    { name = "comtypes", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "numpy", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/de/b7/b3d3e3fa42f347ac4b37fd639634935b4eefff1d5d61bdf72a6d8b906919/dxcam-0.3.0.tar.gz", hash = "sha256:d524da45adf70e044865e7d4e9098e655d6734951781155dda50c1292e20d8bd", size = 48742, upload-time = "2026-03-12T02:52:17.298Z" }
 wheels = [
@@ -1150,7 +1150,7 @@ name = "jinxed"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ansicon" },
+    { name = "ansicon", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/d0/59b2b80e7a52d255f9e0ad040d2e826342d05580c4b1d7d7747cfb8db731/jinxed-1.3.0.tar.gz", hash = "sha256:1593124b18a41b7a3da3b078471442e51dbad3d77b4d4f2b0c26ab6f7d660dbf", size = 80981, upload-time = "2024-07-31T22:39:18.854Z" }
 wheels = [
@@ -1274,7 +1274,7 @@ name = "macholib"
 version = "1.16.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "altgraph" },
+    { name = "altgraph", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
 wheels = [
@@ -1506,6 +1506,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-playwright" },
+    { name = "pytest-randomly" },
     { name = "ruff" },
 ]
 galgame = [
@@ -1582,6 +1583,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-playwright", specifier = ">=0.7.2" },
+    { name = "pytest-randomly", specifier = ">=4.1.0" },
     { name = "ruff", specifier = ">=0.15.4" },
 ]
 galgame = [{ name = "rapidocr-pillow", directory = "deps/rapidocr_pillow" }]
@@ -4567,6 +4569,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-randomly"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/b3/36192dacc0f470ac2cc516f73e01739c9a48a8224f76beada4f85e1c8a89/pytest_randomly-4.1.0.tar.gz", hash = "sha256:47f1d9746c3bc3efabd53ae1ebfb8bb385cf3d4df4b505b6d58d9c97a3dfe70f", size = 14302, upload-time = "2026-04-20T13:01:51.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/db/2df9a1fca597a273f957a559c20c2d95d629928384507b2afa43ba6909d1/pytest_randomly-4.1.0-py3-none-any.whl", hash = "sha256:f55e89e53367b090c0c053697d7f9d77595543d0e0516c93978b50c0f6b252f9", size = 8353, upload-time = "2026-04-20T13:01:50.382Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -4635,7 +4649,7 @@ name = "python-xlib"
 version = "0.33"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "six" },
+    { name = "six", marker = "sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/86/f5/8c0653e5bb54e0cbdfe27bf32d41f27bc4e12faa8742778c17f2a71be2c0/python-xlib-0.33.tar.gz", hash = "sha256:55af7906a2c75ce6cb280a584776080602444f75815a7aff4d287bb2d7018b32", size = 269068, upload-time = "2022-12-25T18:53:00.824Z" }
 wheels = [
@@ -4706,10 +4720,10 @@ name = "pywinauto"
 version = "0.6.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "comtypes" },
-    { name = "python-xlib", marker = "python_version < '0'" },
-    { name = "pywin32" },
-    { name = "six" },
+    { name = "comtypes", marker = "sys_platform == 'win32'" },
+    { name = "python-xlib", marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "six", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2c/85/cc65e3b64e7473cc86c07f0b5c415d509402c03ef19dadc39c583835eb5f/pywinauto-0.6.9.tar.gz", hash = "sha256:94d710bfa796df245250f952ffa65d97233d9807bcd42e052b71b81af469b6de", size = 434734, upload-time = "2025-01-06T11:30:01.801Z" }
 wheels = [


### PR DESCRIPTION
## 改动概述 / Summary

两件事，一个 PR：

**(A) 装上 `pytest-randomly`。** 它此前根本没装（`uv run python -c "import pytest_randomly"` 直接 ModuleNotFoundError），所以用例顺序完全由文件顺序决定，用例间的顺序依赖不会被任何东西发现。

> 顺带更正一条前提：仓库里**没有**任何 `-p no:randomly`。`git grep` 全仓一处都没有，`pytest.ini` 的 `addopts` 只有 `-p no:anyio`。所以"装上之后这些 flag 会从空操作变成真的关掉插件"这个清理项不存在，无事可做。

装上随机跑一轮立刻抓到一条，而且是安全相关的：`test_music_proxy_rejects_unsafe_redirect`（断言"重定向目标不在白名单 → 403"）在某些顺序下拿到 200。

**(B) 收口 `root_state` 这批还留在事件循环上的同步落盘。** 先给它一把真锁 + 让读路径不再写盘，再把变更路由的写序列整条挪进工作线程。`user_directives` 那处判定为**保持同步**，理由见下。

---

## 顺序依赖的根因：在测试侧，不是产品缺陷

确定性复现（不需要随机，指定顺序即可）：

```bash
uv run pytest "tests/unit/test_music_router.py::test_music_proxy_streams_small_file_then_caches_complete_body" "tests/unit/test_music_router.py::test_music_proxy_rejects_unsafe_redirect" -q
```

→ 改动前 `2 failed`，`assert 200 == 403`。

链条：前一条用例把 `https://freemusicarchive.org/song.mp3` 写进 `music_router.MUSIC_PROXY_CACHE`（产品里的进程级 `TTLCache`）且不清理；`proxy_music` 的缓存命中分支在**任何校验之前**返回。两条用例用同一个 URL，后者一旦排在前者之后就走缓存分支，根本到不了它断言的那段代码。文件顺序下一直绿，只是因为中间恰好夹了一条会 `.clear()` 的用例。

**为什么判定是测试侧而不是产品侧：** 缓存条目只在一次通过完整校验（https + 域名白名单 + 逐跳重定向白名单 + content-type + 大小上限）的 200 响应**流完**之后才写入，key 就是那个已校验的 URL；`MUSIC_SOURCE_DOMAINS` 是 `utils/music_crawlers.py` 里的静态 `set`，不存在"白名单变了但缓存还在放行"的路径。所以命中缓存并不绕过任何检查——被污染的是共享全局，污染源是没有还原它的测试。

修法：给该文件加 autouse fixture 前后清缓存（新增用例自动受保护），并删掉三处现在被它完全覆盖的行内 `.clear()`。

## pytest-randomly 的配置取向

按"CI 日常固定 seed + 定时 job 随机"落的：

- `pytest.ini` 与 `plugin/tests/pytest.ini` 都钉死 `--randomly-seed=20260731`。**两个都要**：plugin 目录不继承根 ini，漏掉就等于让 plugin 闸门每次跑一个随机顺序。
- 新增 `.github/workflows/random-order-tests.yml`：每天 18:37 UTC 用随机 seed 跑一遍 `tests/unit`，支持 `workflow_dispatch` 指定 seed 复现。它不是任何 PR 的必需检查。
- 失败日志头部有 `Using --randomly-seed=<N>`，照抄即可本地复现。

两条要写清楚的注意事项（都写进了 `pytest.ini` 注释）：

1. 固定 seed 的"确定性"是**同一个 commit 内**的。用例集合变化（新增/删除用例）会改变洗牌结果，所以增删测试的 PR 有可能因为重排暴露出一条既存的顺序依赖。这时它是一个**可复现**的红（同 commit + 同 seed 必然重现），不是 flake，但确实会落在一个无关的 PR 上——这是这个取向的已知代价。
2. 逃生阀是 `--randomly-dont-reorganize`（恢复文件内定义顺序），**不是** `-p no:randomly`：插件被屏蔽后 `addopts` 里的 `--randomly-seed` 会变成无法识别的参数，pytest 直接报错退出。

全局 RNG：全仓测试里没有任何 `random.seed` / `np.random.seed` / `getstate`，per-test 重新播种不影响谁；钉死 seed 的全量跑也印证了这一点。

## (B) root_state：三步走

之前挡住 offload 的不是工作量，是一条没人写下来的不变量——让"GET 侧 reconcile"和"变更路由的回滚"互斥的**不是锁，是它们都跑在同一条事件循环线程上**。所以顺序必须是：先拆掉对这条不变量的依赖，再 offload。

**1）读路径不再写 root_state。** `build_storage_location_bootstrap_payload` 新增 `persist_reconcile`，默认 `False`。它挂在 `GET /bootstrap`、`GET /status`（存储页按 `STORAGE_STATUS_POLL_INTERVAL_MS` = 1200ms 持续轮询）、`GET /diagnostics`、`GET /retained-source`、`POST /exit` 以及 `system_router` 的 `/status` 上，这些都不在 `_storage_mutation_lock` 覆盖下。只有已经拿着那把锁的 `*_locked` 路由传 `True`。派生值照常出现在 payload 里——改的是**落盘**，不是客户端看到的东西。reconcile 自身也改成锁内重读一次再写，不拿调用方手里那份 pre-image 去盖。

**2）一把真锁。** 新增 `utils/root_state_lock.py`（模块级 `RLock` + `root_state_transaction()`）。放自己的模块而不是挂在 `ConfigManager` 上有两个理由：锁保护的是**文件**不是实例（一个进程里可能同时存在共享单例和受限启动期 `get_runtime_config_manager(..., migrate=False)` 的兜底实例，指向同一份 root_state.json，per-instance 的锁挡不住它们互相盖）；挂在 manager 上还会逼每个测试替身长出这个方法。读—改—写整段进锁：`set_root_mode`、`_recover_stale_write_blocking_mode`、reconcile、cleanup 路由。

> ⚠️ **只有写者拿这把锁，`load_root_state` 绝不拿。** 写要挪进工作线程，而 `file_utils` 那段 155ms `os.replace` 退避恰恰只在工作线程里启用；读路径一旦也拿锁，那条 `GET /status` 轮询就会在工作线程持锁期间被卡住——阻塞经由锁原路传回循环，等于白挪。读不需要锁：写走 `os.replace`，读只会看到旧版本或新版本。

**3）offload，且写序列保持原子。** `delete_storage_migration → save_storage_policy → set_root_mode` 之间原本零 `await`，插一个就能造出"检查点已删、root mode 未改"的取消窗口。所以每条序列进**同一个** `to_thread` job（新 helper `_apply_storage_mutation_writes`），不是三个。快照用 `snapshot_out` 就地填而不是返回值——否则写到一半失败时，快照恰好丢在最需要它的路径上。

同时把 `app/main_server` 启动那次 `set_root_mode` 也挪进工作线程：它在循环上抢同一把锁，留着就等于把工作线程的 fsync 接回循环。**同一把锁的所有入口要么都在工作线程，要么都不在。**

`_restore_storage_mutation_state` **刻意保持同步**：调用方全是 `except` handler，在那里 `await` 会让回滚自己变成取消点，而 `CancelledError` 是 `BaseException`、外层 `except Exception` 接不住——客户端断连就能留下三个文件回滚一半、没人收尾。

**没改 `scripts/check_async_blocking.py`：** 把 `atomic_write_*` 加进 `RISKY_BARE_CALLS` 是 PR #2598 的改动（当前 main 上还没有），在这里重做会跟它冲突，那个文件有 17 条守卫测试盯着。等 #2598 合入后再单独扩深度分析。

## (B-1) `memory/user_directives.py`：判定保持同步

调用链是 `async def _process_stream_data_internal` → `_publish_user_utterance_to_plugin_bus`（同步）→ `dispatch_user_utterance`（同步 fan-out）→ sink → `record_from_text` → `_save_unlocked`。

`dispatch_user_utterance` 的契约就是同步 fan-out，链上还挂着第三方插件的 handler（`plugin.core.state` / `quota.dropper`）。改成 async 等于把所有插件 handler 一起挪到工作线程——**那是事件总线的架构取舍，不该由一条落盘顺带决定**。而这条只在 directive 正则真命中时才写（用户说"别提 X"这种），一次会话个位数，payload 几百字节。

所以保持同步，在 `_save_unlocked` 就地写清楚理由、代价、以及将来真要改时的正确形状（`anti_repeat` 那对 stage/aflush 拆分：内存更新留在调用线程，只挪 fsync，并在 turn 生命周期补 flush 点），并附 `# noqa: ASYNC_BLOCK` 便于 grep。注释里也点明了这个 noqa 现在没有对应告警可压——守卫只做 depth-1，看不到深度 6 的这里。

---

## 回归报告 / Regression Report

### 改动了什么

| 文件 | 改动 |
| --- | --- |
| `app/main_server/__init__.py` | 启动那次 `set_root_mode` 改走 `asyncio.to_thread` |
| `memory/user_directives.py` | 仅注释 + 一个 `# noqa`，行为零变化 |
| `main_routers/storage_location_router.py` | 读路径不再要求落盘 reconcile；四条写序列各自收进一个 `to_thread` job；`/restart` pending 分支的回滚加了 pre-image 判据 |
| `utils/storage/location_bootstrap.py` | `persist_reconcile` 参数（默认 False）；reconcile 锁内重读 |
| `utils/config_manager/storage_roots.py` | `save_root_state` 进写者锁 |
| `utils/cloudsave_runtime/fence.py` | `set_root_mode` / `_recover_stale_write_blocking_mode` 读改写整段进锁 |
| `utils/root_state_lock.py`（新） | 写者锁本体 |

### 理由 / 必要性

`root_state.json` 有一个**不在任何锁里的写者**：`build_storage_location_bootstrap_payload()` → `_reconcile_legacy_cleanup_pending_root_state()` 会 `save_root_state()`，而它挂在五个不受 `_storage_mutation_lock` 保护的端点上，其中 `/status` 被存储页按 `STORAGE_STATUS_POLL_INTERVAL_MS`（1200ms）持续轮询。今天它们不打架纯粹是因为都在同一条线程上——这条不变量既没被写下来，也拦不住任何人往里加一个 `await`。

### 改动前后表现对比

- **前**：`GET /status` 轮询在 `legacy_cleanup_pending` 漂移时会写 root_state；变更路由的回滚若挪出循环就会被这个写整份盖掉，下次启动 `recovery_required` 算成 False、恢复闸被跳过。写序列全部在事件循环线程上做 fsync。
- **后**：读路径纯读，一个字节都不落盘（payload 内容不变）；写者互斥由显式的锁保证，不再依赖"碰巧同线程"；变更路由的 fsync 不再占用事件循环；`delete → policy → root_mode` 仍然是不可分割的一步。
- **接口/响应**：`GET`/`POST` 的响应体、状态码、字段全部不变。唯一可观察的差异是 root_state.json 不再被读请求改写。

### 潜在回归点 & 怎么验的

1. **reconcile 自愈能力变弱？** 它只可能把 `legacy_cleanup_pending` 从 False 改成 True（`_derive_legacy_cleanup_pending` 在持久化值为 True 时直接返回 True，所以 True→False 这条分支不可达），而权威写入本来就在 `utils/storage/migration.py` 迁移完成时。现在四条变更路由仍会 opt-in 触发它。已加对偶用例覆盖"默认不落盘 / opt-in 才落盘"。
2. **锁传导（PR #2598 踩了七次的那个）**：读路径不拿锁 + 循环上唯一剩下的写者（`main_server` 启动）也挪进了工作线程。已加**强制交错**用例：工作线程用 `threading.Event` 卡住持锁，主线程的读必须立刻返回（变异成"读也拿锁"时该用例转红）。
3. **新增取消窗口**：写序列现在有一个 `await`，但它落在整条序列之外——序列本身在一个 worker job 里，取消不会把它切一半（`to_thread` 被取消后线程照样跑完）。取消发生在"写完但还没 `_request_app_shutdown`"这个位置，而这个窗口在改动前就已经存在于原有的 `await _request_app_shutdown` 上，只是宽了一次线程切换。用 AST 守卫钉住"写原语不许直接躺在 async 函数体里"。
4. **回滚路径**：`_restore_storage_mutation_state` 保持同步（理由见上）；`/restart` pending 分支原来的写法在"读 pre-image 本身失败"时会执行 `delete_storage_migration`，**删掉一份本来就在盘上的检查点**——顺带修了，现在 pre-image 没取到就什么都不回滚。
5. **`main_server` 启动多一个 await**：位于既有 startup 序列中，其后的错误处理与 `raise RuntimeError` 语义未变；`tests/unit` 全量三轮通过。

## 不拆分理由 / Why Not Split

不适用（计入上限的文件 8 个）。

## 测试 / Testing

- **全量 `tests/unit`**：钉死 seed `10348 passed / 38 skipped`（5m24s）；另跑随机 seed 4242 与 987654 各一轮做交叉确认。
- **全量 `plugin/tests`**：钉死 seed，`2752 passed / 20 skipped`。
- **定向**：`test_storage_location_router` / `test_storage_location_bootstrap` / `test_storage_layout` / `test_storage_migration` / `test_system_status_router` / `test_user_directives` / `test_music_router` / 全部 cloudsave 与 config_manager 相关文件。
- **静态门**：`ruff`、`check_async_blocking`、`check_module_layering`、`check_startup_import_lazy`、`check_core_contracts`、`check_api_trailing_slash`、`check_no_tkinter`、`check_no_loguru`、`check_prompt_hygiene`、`check_prompt_zh_tw`，以及 `check_docstring_no_cjk --base origin/main`（提交后跑）——全部 exit=0。
- **新增守卫 7 条，逐条变异验证**（把被守护的实现改坏 → 确认该用例转红 → 字节级还原）：

  | 变异 | 结果 |
  | --- | --- |
  | `save_root_state` 不再拿写者锁 | 转红 |
  | `load_root_state` 也去拿写者锁 | 转红（含强制交错那条） |
  | `persist_reconcile` 默认改回 True | 转红 |
  | 去掉 `persist_reconcile` 闸门 | 转红 |
  | `GET /bootstrap` 传 `persist_reconcile=True` | 转红 |
  | 把 rebind 写序列摊回 async 函数体 | 转红 |
  | 移除 music proxy 缓存隔离 fixture | 转红 |

  守卫刻意做成**发现式**而非清单式：GET 路由从 `router.routes` 自动枚举、`persist_reconcile=True` 全仓扫描、回滚豁免按"是否在 `except` handler 内"这个**形状**判定而不是列名字白名单。最后一条当场抓到我自己漏改的一处 `save_storage_policy`（`_post_storage_location_select_locked` 里）。

- **`uv.lock`**：`uv lock` 顺带把 `dxcam` / `jinxed` / `macholib` 三处 marker 重新解析了（本机 uv 版本与上次 lock 时不同），与本 PR 无关但属于重新锁定的正常产物，没有手工回退以免 CI 再解析出别的结果。

---

## 评审收口（第一轮，3 条真缺陷 + 2 条注释）

三条都成立，其中**两条是这个 PR 自己引入的回归**，不是既存问题：

**1. 锁内仍写锁外读到的 pre-image（Greptile P1，`fence.py`）。** 我在那一行的注释里写了"这里也是读—改—写"，却只加了锁没改写法。拿锁只让写者排队，不让读—改—写正确。改成锁内重读，并且把"该不该自愈"的判定也按锁内那份重来。

> ⚠️ **同一个缺陷在上一层还有一份**：`bootstrap_local_cloudsave_environment` 在 `:136` 读 root_state，在 `:191` 拿同一份 pre-image 编辑再存回去——两行之后就会把 fence 刚修好的结果盖掉。只修 fence 等于没修。那段整段进了 `root_state_transaction()` 并锁内重读；锁**故意只从那里开始**（`import_legacy_runtime_root_if_needed` 可能整目录拷贝，自愈要拿跨进程 cloud apply 锁，包在外面会让锁序反向）。全仓统一 `cloud_apply_lock → root_state_transaction`。

**2. offload 之后取消会提前松开 `_storage_mutation_lock`（Codex P1）。** 写还是同步的时候它们不是取消点，锁确实覆盖整段写；挪进 `to_thread` 后，取消只取消等待的 future、工作线程照写，而 `async with` 已经退栈——下一个变更请求能直接进锁跟它在同一批文件上交错。新增 `_run_locked_storage_job()`（shield + 取消时先等工作线程跑完再放行 `CancelledError`）。顺带把同一路由里既有的 `_cleanup_retained_runtime_root`（同一把锁下 rmtree）也换过去。

**3. 空快照触发破坏性回滚（Codex P1）。** 快照原本在 `try` 外，取失败直接 500；我挪进 `_apply_storage_mutation_writes` 后，快照失败会带着空 dict 走进回滚，而 `_restore_storage_mutation_state` 把"没有 `migration`/`policy` 键"读作"文件本来就不存在"→ 删检查点、`unlink` 策略文件。修在收口处 `if not snapshot: return`，判据精确（真跑过的快照必定三键齐全）。同一形状我在 `/restart` pending 分支处理过，rebind 这条漏了。

另外补了两处 empty except 的解释性注释（github-code-quality）。

**新增守卫 5 条，逐条变异验证转红**：并发写者强制交错 ×2（fence / bootstrap 各一）、全仓 AST 扫描"`root_state_transaction()` 块只要写盘就必须块内读"、取消后断言工作线程已跑完、空快照回滚不删文件。第三条是把**这一类**堵死而不是只修这两处。

## 评审收口（第二轮）

⚠️ **先说最要紧的一条：我上一轮加的三条 AST 护栏，此前一个文件都没扫过。**

`_iter_project_python_files` 的 skip 清单拿**绝对路径**匹配，而这个开发用的 worktree 本身就在 `.claude/` 下面 → `rglob` 出来的每个文件都被 `.claude` 命中跳过，**扫描量为 0**。CI 的 checkout 路径不含 `.claude`，所以 CI 也是绿的——本地绿、CI 绿，两边都没有信号。是这一轮给 `storage_roots` 补护栏、变异却"存活"才暴露的。

修法两条：skip 清单改成匹配**相对仓库根**的路径；加 `_project_python_files()` 自检，扫到的文件数低于下界直接判失败——让"喂料被掐断"本身变成一条会红的用例。

连带纠正了变异验证的方法论：之前一条变异传多个 test id，只要有一条红就算通过，于是运行时用例的红掩盖了 AST 护栏的假绿。现在**一条变异只打一个 test id**（顺序依赖那条除外——它的主张本来就是"成对"，必须带上污染源一起跑）。全部 22 条重跑，逐条确认。

三条真缺陷：

1. **Greptile P1 #2 —— 锁外 pre-image 的第三处**（`_persist_selected_root_unavailable_recovery_state`）。我自己扫的时候看到过它，判断成"跑在 `__init__` 里所以单线程"就放过了；这个判断不成立（受限启动期会临时构造兜底 `ConfigManager`）。整段进锁 + 锁内读。新增 `test_read_modify_write_of_root_state_happens_inside_one_transaction` 堵住"根本没开 transaction"这个盲区——原护栏只看已经开了 transaction 的块，这处正是从那里漏过去的。

2. **Codex P1 —— 启动标记的判定和写不再原子**。`should_write_root_mode_normal_after_startup` 留在循环上、`set_root_mode` 挪进了工作线程，中间隔着一个 await；job 排队期间存储变更路由可能刚提交 `ROOT_MODE_MAINTENANCE_READONLY`，然后被无脑写回 NORMAL。判定跟着写一起进锁内重做。

3. **Codex P1 —— 取消不回滚**。`/restart` 两条分支写已落盘、`_request_app_shutdown` 没发出去，留着就是把应用钉死在受限态；`CancelledError` 是 `BaseException`，原来的 `except Exception` 接不住。两条各补 `except asyncio.CancelledError`。新护栏顺带抓出第三处同类：`_release_storage_startup_barrier_or_rollback` 改接 `BaseException`。

**新增护栏 4 条**（含前述自检），全部单 test id 变异验证。其中 `test_rollback_on_exception_also_rolls_back_on_cancellation` 是通用规则：**async `try` 只要在 `except` 里做了回滚，就必须同时兜住取消**——回滚 handler 内部的 best-effort try 按 shape 排除。

一条没改：github-code-quality 报 `await task`（在 `pytest.raises` 里）"statement has no effect"，是误报，已在 thread 里说明。

最终全量 `tests/unit`：**10356 passed / 38 skipped / 0 failed**。
