### PR TITLE
fix(workshop): 阻止预览图绕过目录所有权并改为原子写

### DIFF
--- a/main_routers/workshop_router/content_gate.py
+++ b/main_routers/workshop_router/content_gate.py
@@ -47,15 +47,41 @@ def _claim_key(content_folder: str) -> str:
     return os.path.normcase(os.path.realpath(content_folder))
 
 
+def _claim_keys_overlap(first: str, second: str) -> bool:
+    """Whether either claimed folder contains the other."""
+    try:
+        common = os.path.commonpath((first, second))
+    except ValueError:
+        return False
+    return common == first or common == second
+
+
+def _exclusive_holder_for(key: str) -> str | None:
+    """Return the purpose of an overlapping exclusive claim, if any."""
+    return next((
+        purpose
+        for claimed_key, purpose in _EXCLUSIVE.items()
+        if _claim_keys_overlap(key, claimed_key)
+    ), None)
+
+
+def _has_partial_writer_for(key: str) -> bool:
+    """Whether an overlapping folder has an active partial writer."""
+    return any(
+        count and _claim_keys_overlap(key, claimed_key)
+        for claimed_key, count in _PARTIAL_WRITERS.items()
+    )
+
+
 @contextmanager
 def claim_content_folder(content_folder: str, *, purpose: str) -> Iterator[None]:
     """Take a non-blocking exclusive claim for publish or folder deletion."""
     key = _claim_key(content_folder)
     with _CLAIM_GUARD:
-        holder = _EXCLUSIVE.get(key)
+        holder = _exclusive_holder_for(key)
         if holder is not None:
             raise ContentFolderBusy(f'该内容目录正在{holder}，请等这次操作结束后再试')
-        if _PARTIAL_WRITERS.get(key):
+        if _has_partial_writer_for(key):
             raise ContentFolderBusy('该内容目录有局部文件正在写入，请稍后再试')
         _EXCLUSIVE[key] = purpose
     try:
@@ -74,7 +100,7 @@ def claim_partial_writer(
     """Take a shared local-write claim excluded by whole-folder operations."""
     key = _claim_key(content_folder)
     with _CLAIM_GUARD:
-        holder = _EXCLUSIVE.get(key)
+        holder = _exclusive_holder_for(key)
         if holder is not None:
             raise ContentFolderBusy(f'该物品正在{holder}，等这次操作结束后再{purpose}')
         _PARTIAL_WRITERS[key] = _PARTIAL_WRITERS.get(key, 0) + 1

--- a/main_routers/workshop_router/content_gate.py
+++ b/main_routers/workshop_router/content_gate.py
@@ -16,8 +16,8 @@
 """Non-blocking ownership for Workshop content folders.
 
 Steam consumes the whole folder from ``SetItemContent`` until the upload
-finishes. Reference-audio writes and folder cleanup must therefore be excluded
-for that entire span, not just while the preflight reads the manifest.
+finishes. Local file writes and folder cleanup must therefore be excluded for
+that entire span, not just while the preflight reads the manifest.
 
 Claims are bookkeeping, never wait queues. Both claim and release belong to
 the worker-thread unit that performs the blocking work so cancellation of its
@@ -39,7 +39,7 @@ CLEANUP_PURPOSE = '清理'
 
 _CLAIM_GUARD = threading.Lock()
 _EXCLUSIVE: dict[str, str] = {}
-_PAIR_WRITERS: dict[str, int] = {}
+_PARTIAL_WRITERS: dict[str, int] = {}
 
 
 def _claim_key(content_folder: str) -> str:
@@ -55,8 +55,8 @@ def claim_content_folder(content_folder: str, *, purpose: str) -> Iterator[None]
         holder = _EXCLUSIVE.get(key)
         if holder is not None:
             raise ContentFolderBusy(f'该内容目录正在{holder}，请等这次操作结束后再试')
-        if _PAIR_WRITERS.get(key):
-            raise ContentFolderBusy('参考语音正在写入，请稍后再试')
+        if _PARTIAL_WRITERS.get(key):
+            raise ContentFolderBusy('该内容目录有局部文件正在写入，请稍后再试')
         _EXCLUSIVE[key] = purpose
     try:
         yield
@@ -66,20 +66,27 @@ def claim_content_folder(content_folder: str, *, purpose: str) -> Iterator[None]
 
 
 @contextmanager
-def claim_reference_pair(content_folder: str) -> Iterator[None]:
-    """Take a shared pair-write claim, excluded by whole-folder operations."""
+def claim_partial_writer(
+    content_folder: str,
+    *,
+    purpose: str = '修改参考语音',
+) -> Iterator[None]:
+    """Take a shared local-write claim excluded by whole-folder operations."""
     key = _claim_key(content_folder)
     with _CLAIM_GUARD:
         holder = _EXCLUSIVE.get(key)
         if holder is not None:
-            raise ContentFolderBusy(f'该物品正在{holder}，等这次操作结束后再修改参考语音')
-        _PAIR_WRITERS[key] = _PAIR_WRITERS.get(key, 0) + 1
+            raise ContentFolderBusy(f'该物品正在{holder}，等这次操作结束后再{purpose}')
+        _PARTIAL_WRITERS[key] = _PARTIAL_WRITERS.get(key, 0) + 1
     try:
         yield
     finally:
         with _CLAIM_GUARD:
-            remaining = _PAIR_WRITERS.get(key, 0) - 1
+            remaining = _PARTIAL_WRITERS.get(key, 0) - 1
             if remaining > 0:
-                _PAIR_WRITERS[key] = remaining
+                _PARTIAL_WRITERS[key] = remaining
             else:
-                _PAIR_WRITERS.pop(key, None)
+                _PARTIAL_WRITERS.pop(key, None)
+
+
+claim_reference_pair = claim_partial_writer

--- a/main_routers/workshop_router/preview_cards.py
+++ b/main_routers/workshop_router/preview_cards.py
@@ -21,15 +21,19 @@ Split out of the former monolithic ``main_routers/workshop_router.py``.
 
 from ._shared import logger, router
 
+import asyncio
 import os
 import json
 import tempfile
+from contextlib import nullcontext
 from datetime import datetime
 from pathlib import Path
 from fastapi import Request
 from fastapi.responses import JSONResponse
-from utils.file_utils import atomic_write_json
+from utils.file_utils import atomic_write_bytes, atomic_write_json
 from utils.config_manager import get_reserved
+
+from .content_gate import ContentFolderBusy, claim_partial_writer
 
 
 WORKSHOP_CARD_FACE_SIZE = (768, 1024)
@@ -472,6 +476,21 @@ def _ensure_workshop_card_face_meta(config_mgr, chara_name: str, item: dict) -> 
     return True
 
 
+def _write_preview_image(
+    content_folder: str | None,
+    preview_image_path: str,
+    image_bytes: bytes,
+) -> None:
+    """Hold local ownership and atomically persist preview bytes in one worker."""
+    claim = (
+        claim_partial_writer(content_folder, purpose='上传预览图')
+        if content_folder
+        else nullcontext()
+    )
+    with claim:
+        atomic_write_bytes(preview_image_path, image_bytes)
+
+
 @router.post('/upload-preview-image')
 async def upload_preview_image(request: Request):
     """
@@ -534,15 +553,25 @@ async def upload_preview_image(request: Request):
             temp_folder = tempfile.gettempdir()
             preview_image_path = os.path.join(temp_folder, f'preview{file_extension}')
         
-        # 保存文件到指定路径
-        with open(preview_image_path, 'wb') as f:
-            f.write(await file.read())
+        # 先在异步上传对象上读完，再把完整的原子落盘单元交给 worker。
+        image_bytes = await file.read()
+        await asyncio.to_thread(
+            _write_preview_image,
+            content_folder,
+            preview_image_path,
+            image_bytes,
+        )
         
         return JSONResponse({
             "success": True,
             "file_path": preview_image_path,
             "message": "文件上传成功"
         })
+    except ContentFolderBusy as e:
+        return JSONResponse({
+            "success": False,
+            "error": str(e),
+        }, status_code=409)
     except Exception as e:
         logger.error(f"上传预览图片时出错: {e}")
         return JSONResponse({

--- a/main_routers/workshop_router/preview_cards.py
+++ b/main_routers/workshop_router/preview_cards.py
@@ -36,6 +36,10 @@ from utils.config_manager import get_reserved
 from .content_gate import ContentFolderBusy, claim_partial_writer
 
 
+class _PreviewContentFolderMissing(RuntimeError):
+    """The accepted content folder disappeared before its worker could write."""
+
+
 WORKSHOP_CARD_FACE_SIZE = (768, 1024)
 
 
@@ -488,6 +492,10 @@ def _write_preview_image(
         else nullcontext()
     )
     with claim:
+        if content_folder and not os.path.isdir(content_folder):
+            raise _PreviewContentFolderMissing(
+                '内容目录已被清理，请重新开始上传'
+            )
         atomic_write_bytes(preview_image_path, image_bytes)
 
 
@@ -567,10 +575,11 @@ async def upload_preview_image(request: Request):
             "file_path": preview_image_path,
             "message": "文件上传成功"
         })
-    except ContentFolderBusy as e:
+    except (ContentFolderBusy, _PreviewContentFolderMissing) as e:
         return JSONResponse({
             "success": False,
             "error": str(e),
+            "message": str(e),
         }, status_code=409)
     except Exception as e:
         logger.error(f"上传预览图片时出错: {e}")

--- a/scripts/check_async_blocking.py
+++ b/scripts/check_async_blocking.py
@@ -47,7 +47,8 @@ our model). A second pass addresses exactly that class:
    recognised blocking stdlib call (``PIL.Image.open``, Fernet
    encrypt/decrypt, ``shutil.*``, ``time.sleep``, ``requests.*``,
    ``subprocess.run``/``call``/``check_*``, ``urllib.request.urlopen``,
-   ``utils.file_utils.atomic_write_text`` / ``atomic_write_json``, plus
+   ``utils.file_utils.atomic_write_text`` / ``atomic_write_bytes`` /
+   ``atomic_write_json``, plus
    the queue/thread/socket tail-name heuristics above). Helpers whose
    own name is too generic to identify by name alone (``save``,
    ``load``, ``run``, …) are deliberately NOT indexed — see
@@ -133,9 +134,10 @@ SOCKET_SUFFIX = ("_sock", "_socket")
 RISKY_ATTR_PAIRS: dict[tuple[str, str], str] = {
     # utils/file_utils 的原子落盘，模块限定写法。`from utils import file_utils`
     # 之后 `file_utils.atomic_write_json(...)` 是 attribute 调用，走不到下面
-    # RISKY_BARE_CALLS 那条（那条只看 ast.Name），不补这两条就等于给一种完全
+    # RISKY_BARE_CALLS 那条（那条只看 ast.Name），不补这些就等于给一种完全
     # 正常的 import 风格开了后门。
     ("file_utils", "atomic_write_text"): "utils.file_utils.atomic_write_text",
+    ("file_utils", "atomic_write_bytes"): "utils.file_utils.atomic_write_bytes",
     ("file_utils", "atomic_write_json"): "utils.file_utils.atomic_write_json",
     # Resolves workshop_config.json and may read/retry/rebase it. Calling it
     # from an async handler was the source of several lock/I/O relays in this
@@ -215,12 +217,14 @@ RISKY_BARE_CALLS: dict[str, str] = {
     # atomic_write_text_async 早就存在（asyncio.to_thread 包一层），非测试代码里
     # 已有 77 处在用；缺的从来不是异步安全层，是调用点纪律。
     "atomic_write_text": "utils.file_utils.atomic_write_text",
+    "atomic_write_bytes": "utils.file_utils.atomic_write_bytes",
     "atomic_write_json": "utils.file_utils.atomic_write_json",
     "get_workshop_path": "utils.workshop_utils.get_workshop_path",
 }
 
 _ATOMIC_WRITE_LABELS = {
     "atomic_write_text": "utils.file_utils.atomic_write_text",
+    "atomic_write_bytes": "utils.file_utils.atomic_write_bytes",
     "atomic_write_json": "utils.file_utils.atomic_write_json",
 }
 
@@ -230,9 +234,9 @@ def _collect_atomic_write_aliases(
 ) -> tuple[dict[str, str], set[str]]:
     """Return direct-name aliases and module aliases for ``utils.file_utils``.
 
-    This intentionally resolves only the two atomic writers. General import
+    This intentionally resolves only the atomic-write family. General import
     resolution would turn the checker's name-based depth-1 pass into a much
-    larger cross-module analysis problem; these two names are high-signal and
+    larger cross-module analysis problem; these names are high-signal and
     are the guard this PR is specifically adding.
     """
     direct: dict[str, str] = {}

--- a/tests/unit/test_check_async_blocking.py
+++ b/tests/unit/test_check_async_blocking.py
@@ -84,6 +84,15 @@ def test_atomic_write_text_is_flagged_too():
     assert "atomic_write_text" in out[0][2]
 
 
+def test_atomic_write_bytes_is_flagged_too():
+    out = _violations('''
+    async def handler(payload):
+        atomic_write_bytes(path, payload)
+    ''')
+    assert len(out) == 1
+    assert "atomic_write_bytes" in out[0][2]
+
+
 def test_a_named_sync_helper_that_writes_is_flagged_through_one_hop():
     # 这是绝大多数真实调用点的形状：协程调一个同步的 save_xxx，落盘藏在
     # helper 体内。

--- a/tests/unit/test_workshop_content_gate.py
+++ b/tests/unit/test_workshop_content_gate.py
@@ -9,6 +9,7 @@ from main_routers.workshop_router.content_gate import (
     PUBLISH_PURPOSE,
     ContentFolderBusy,
     claim_content_folder,
+    claim_partial_writer,
     claim_reference_pair,
 )
 from main_routers.workshop_router import publish
@@ -35,14 +36,14 @@ def test_exclusive_claim_rejects_reference_writer(tmp_path):
 
 def test_reference_writer_rejects_exclusive_claim(tmp_path):
     with claim_reference_pair(str(tmp_path)):
-        with pytest.raises(ContentFolderBusy, match='参考语音正在写入'):
+        with pytest.raises(ContentFolderBusy, match='局部文件正在写入'):
             with claim_content_folder(str(tmp_path), purpose=PUBLISH_PURPOSE):
                 pass
 
 
-def test_reference_writers_remain_shared(tmp_path):
+def test_partial_writers_remain_shared(tmp_path):
     with claim_reference_pair(str(tmp_path)):
-        with claim_reference_pair(str(tmp_path)):
+        with claim_partial_writer(str(tmp_path), purpose='上传预览图'):
             pass
 
 

--- a/tests/unit/test_workshop_content_gate.py
+++ b/tests/unit/test_workshop_content_gate.py
@@ -47,6 +47,21 @@ def test_partial_writers_remain_shared(tmp_path):
             pass
 
 
+def test_parent_and_descendant_claims_conflict_in_both_directions(tmp_path):
+    child = tmp_path / 'nested'
+    child.mkdir()
+
+    with claim_content_folder(str(tmp_path), purpose=PUBLISH_PURPOSE):
+        with pytest.raises(ContentFolderBusy):
+            with claim_partial_writer(str(child), purpose='上传预览图'):
+                pass
+
+    with claim_partial_writer(str(child), purpose='上传预览图'):
+        with pytest.raises(ContentFolderBusy):
+            with claim_content_folder(str(tmp_path), purpose=PUBLISH_PURPOSE):
+                pass
+
+
 def test_claim_releases_after_exception(tmp_path):
     with pytest.raises(RuntimeError, match='boom'):
         _raise_inside(

--- a/tests/unit/test_workshop_preview_upload.py
+++ b/tests/unit/test_workshop_preview_upload.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import shutil
 import threading
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -138,4 +140,30 @@ def test_upload_preview_returns_409_while_the_folder_is_publishing(tmp_path):
     assert response.status_code == 409
     assert payload['success'] is False
     assert '正在发布' in payload['error']
+    assert payload['message'] == payload['error']
     assert not (tmp_path / 'preview.png').exists()
+
+
+def test_upload_preview_does_not_recreate_a_folder_removed_before_claim(
+    tmp_path, monkeypatch
+):
+    @contextmanager
+    def cleanup_before_claim(content_folder, *, purpose):
+        assert purpose == '上传预览图'
+        shutil.rmtree(content_folder)
+        yield
+
+    monkeypatch.setattr(
+        preview_cards,
+        'claim_partial_writer',
+        cleanup_before_claim,
+    )
+
+    response = asyncio.run(
+        preview_cards.upload_preview_image(_Request(tmp_path))
+    )
+
+    payload = json.loads(response.body)
+    assert response.status_code == 409
+    assert payload['message'] == '内容目录已被清理，请重新开始上传'
+    assert not tmp_path.exists()

--- a/tests/unit/test_workshop_preview_upload.py
+++ b/tests/unit/test_workshop_preview_upload.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import threading
+from pathlib import Path
+
+import pytest
+
+from main_routers.workshop_router import preview_cards
+from main_routers.workshop_router.content_gate import (
+    PUBLISH_PURPOSE,
+    ContentFolderBusy,
+    claim_content_folder,
+    claim_reference_pair,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _Upload:
+    content_type = 'image/png'
+
+    async def read(self) -> bytes:
+        return b'new-preview-bytes'
+
+
+class _Request:
+    def __init__(self, content_folder: Path) -> None:
+        self._content_folder = content_folder
+
+    async def form(self) -> dict[str, object]:
+        return {
+            'file': _Upload(),
+            'content_folder': str(self._content_folder),
+        }
+
+
+def test_upload_preview_image_replaces_atomically_from_a_worker(
+    tmp_path, monkeypatch
+):
+    target = tmp_path / 'preview.png'
+    target.write_bytes(b'old-complete-preview')
+    event_loop_thread = threading.get_ident()
+    observed: dict[str, object] = {}
+    real_replace = os.replace
+
+    def spy_replace(src, dst):
+        observed['thread'] = threading.get_ident()
+        observed['target_before_replace'] = Path(dst).read_bytes()
+        observed['staged_bytes'] = Path(src).read_bytes()
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(os, 'replace', spy_replace)
+
+    response = asyncio.run(preview_cards.upload_preview_image(_Request(tmp_path)))
+
+    assert response.status_code == 200
+    assert json.loads(response.body)['success'] is True
+    assert observed['target_before_replace'] == b'old-complete-preview'
+    assert observed['staged_bytes'] == b'new-preview-bytes'
+    assert observed['thread'] != event_loop_thread
+    assert target.read_bytes() == b'new-preview-bytes'
+
+
+def test_upload_preview_claim_survives_a_cancelled_waiter(
+    tmp_path, monkeypatch
+):
+    writer_entered = threading.Event()
+    release_writer = threading.Event()
+    writer_finished = threading.Event()
+
+    def blocking_write(_path, _content):
+        writer_entered.set()
+        try:
+            assert release_writer.wait(timeout=2)
+        finally:
+            writer_finished.set()
+
+    monkeypatch.setattr(preview_cards, 'atomic_write_bytes', blocking_write)
+
+    async def scenario():
+        task = asyncio.create_task(
+            preview_cards.upload_preview_image(_Request(tmp_path))
+        )
+        try:
+            for _ in range(200):
+                if writer_entered.is_set():
+                    break
+                await asyncio.sleep(0.005)
+            assert writer_entered.is_set()
+
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+            with pytest.raises(ContentFolderBusy):
+                with claim_content_folder(str(tmp_path), purpose=PUBLISH_PURPOSE):
+                    pass
+        finally:
+            task.cancel()
+            release_writer.set()
+
+        for _ in range(200):
+            if writer_finished.is_set():
+                break
+            await asyncio.sleep(0.005)
+        assert writer_finished.is_set()
+
+        with claim_content_folder(str(tmp_path), purpose=PUBLISH_PURPOSE):
+            pass
+
+    try:
+        asyncio.run(scenario())
+    finally:
+        release_writer.set()
+
+
+def test_upload_preview_shares_the_folder_with_reference_audio(tmp_path):
+    with claim_reference_pair(str(tmp_path)):
+        response = asyncio.run(
+            preview_cards.upload_preview_image(_Request(tmp_path))
+        )
+
+    assert response.status_code == 200
+    assert (tmp_path / 'preview.png').read_bytes() == b'new-preview-bytes'
+
+
+def test_upload_preview_returns_409_while_the_folder_is_publishing(tmp_path):
+    with claim_content_folder(str(tmp_path), purpose=PUBLISH_PURPOSE):
+        response = asyncio.run(
+            preview_cards.upload_preview_image(_Request(tmp_path))
+        )
+
+    payload = json.loads(response.body)
+    assert response.status_code == 409
+    assert payload['success'] is False
+    assert '正在发布' in payload['error']
+    assert not (tmp_path / 'preview.png').exists()

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -681,6 +681,30 @@ def atomic_write_text(path: str | os.PathLike[str], content: str, *, encoding: s
         raise
 
 
+def atomic_write_bytes(path: str | os.PathLike[str], content: bytes) -> None:
+    """Atomically replace a binary file in the same directory."""
+    target_path = Path(path)
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    _sweep_stale_tmp_if_due(target_path)
+
+    fd, temp_path = tempfile.mkstemp(
+        prefix=f".{_TMP_OWNER_TAG}",
+        suffix=".tmp",
+        dir=str(target_path.parent),
+    )
+
+    try:
+        with os.fdopen(fd, "wb") as temp_file:
+            temp_file.write(content)
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        _replace_with_busy_retry(temp_path, target_path)
+    except BaseException:
+        with suppress(OSError):
+            os.remove(temp_path)
+        raise
+
+
 def atomic_write_json(
     path: str | os.PathLike[str],
     data: Any,


### PR DESCRIPTION
## 改动概述 / Summary

修复 `POST /api/steam/workshop/upload-preview-image` 的目录所有权绕过、非原子覆盖和事件循环同步写盘。

- 将内容目录的共享局部写抽象为 `claim_partial_writer`，保留 `claim_reference_pair` 兼容别名。
- 预览图写入与参考声音写入保持共享；发布、清理等整目录操作会排斥所有局部写。
- 新增二进制原子写原语 `atomic_write_bytes`，完整写入同目录临时文件并 fsync 后再 replace。
- 上传文件读完后，将「持有 claim + 原子落盘」作为一个同步单元交给 worker；等待协程取消不会提前释放目录。
- 将 `atomic_write_bytes` 纳入现有 async-blocking 静态守卫。

## 回归报告 / Regression Report

### 改动了什么

`upload_preview_image` 不再直接 `open(path, 'wb')` 覆盖目标文件，而是在 worker 中取得共享局部写 claim，再通过 `atomic_write_bytes` 原子替换。发布期间取得 claim 失败会返回 HTTP 409。

### 理由 / 必要性

Steam 发布会把整个内容目录交给 `SetItemContent`。旧实现不经过 `content_gate`，可在发布读取目录时改写 `preview.png`；同时裸写会暴露半截文件，并把同步磁盘 I/O 压在事件循环线程上。

### 改动前后的表现对比

| 场景 | 改动前 | 改动后 |
|---|---|---|
| 发布期间上传预览图 | 继续写盘并返回成功 | 返回 409，不改目录 |
| 预览图覆盖过程 | 目标路径可见半截内容 | replace 前保持旧完整文件，之后一次切到新文件 |
| 磁盘写入线程 | 事件循环线程 | worker 线程 |
| 与参考声音同时写入 | 无统一所有权语义 | 共享局部写，可并行且共同排斥整目录操作 |
| 等待请求被取消 | 无 claim | worker 完成写入前 claim 不释放 |

### 潜在回归点与验证

- claim 抽象可能误伤参考声音共享语义：保留旧名别名，并验证预览图与参考声音可同时持有局部写 claim。
- 取消可能让协程早于 worker 退出：确定性阻塞 worker，取消等待方后验证发布仍被拒绝，worker 结束后 claim 才释放。
- 原子替换或线程卸载可能被退回：在 `os.replace` 边界直接断言旧/新完整内容与执行线程。
- 宽泛禁止所有 `async def` 中的写模式 `open()` 会命中 14 处无关既存调用，本 PR 不扩大范围；仅把新增的高信号 `atomic_write_bytes` 纳入守卫。

## 不拆分理由 / Why Not Split

不适用：改动范围为 6 个既有文件和 1 个新增测试文件。

## 测试 / Testing

- `uv run pytest tests/unit/test_workshop_preview_upload.py tests/unit/test_workshop_content_gate.py tests/unit/test_workshop_voice_refs.py tests/unit/test_check_async_blocking.py -q`：66 passed。
- `uv run ruff check`（本 PR 相关文件）：通过。
- `uv run python scripts/check_async_blocking.py`：通过。
- `uv run python scripts/check_docstring_no_cjk.py --base origin/main`：通过。
- 变异验证：移除 `to_thread`、退回裸写、移除 preview claim、改用独占 claim、绕过发布期 claim、删除 `atomic_write_bytes` 守卫识别时，对应测试均转红。