### PR TITLE
优化 PNGTuber 渲染及拖动保存性能，并修复猫爪面板首次打开时状态一直停留在检查中的问题

### DIFF
--- a/app/agent_server/api_routes.py
+++ b/app/agent_server/api_routes.py
@@ -328,12 +328,20 @@ async def openclaw_availability():
         return status
     reason = reasons[0] if reasons else ""
     was_openclaw_enabled = bool(Modules.agent_flags.get("openclaw_enabled"))
-    was_ready = bool(((Modules.capability_cache or {}).get("openclaw") or {}).get("ready"))
+    previous_capability = dict((Modules.capability_cache or {}).get("openclaw") or {})
+    was_ready = bool(previous_capability.get("ready"))
     _set_capability("openclaw", False, reason)
     if was_openclaw_enabled:
         Modules.agent_flags["openclaw_enabled"] = False
         Modules.notification = _openclaw_notification("AGENT_OPENCLAW_CAPABILITY_LOST", reasons)
-    if was_openclaw_enabled or was_ready:
+    # The popup requests the state snapshot and this availability probe in
+    # parallel.  When the snapshot wins the race it contains the startup
+    # PENDING value, so every terminal transition must be pushed even if the
+    # disabled capability was never previously ready.
+    capability_changed = previous_capability != (
+        (Modules.capability_cache or {}).get("openclaw") or {}
+    )
+    if was_openclaw_enabled or was_ready or capability_changed:
         await _emit_agent_status_update()
     return status
 

--- a/app/agent_server/api_runtime.py
+++ b/app/agent_server/api_runtime.py
@@ -582,6 +582,7 @@ async def startup():
             if not adapter.init_ok:
                 logger.warning("[OpenFang] not reachable after 30s")
                 _set_capability("openfang", False, "OPENFANG_DAEMON_UNREACHABLE")
+                await _emit_agent_status_update()
                 return
 
             # 同步 API Key + 写 config.toml（允许失败 — 用户可能尚未配置 Key）
@@ -627,9 +628,11 @@ async def startup():
             _set_capability("openfang", True, "")
             logger.info("[OpenFang] Ready (init_ok=%s, agent=%s, tools=%d)",
                         adapter.init_ok, agent_id, adapter._cached_tools_count or 0)
+            await _emit_agent_status_update()
         except Exception as exc:
             logger.error("[OpenFang] background init failed: %s", exc)
             _set_capability("openfang", False, str(exc))
+            await _emit_agent_status_update()
 
     # BrowserUse stays unloaded until its toggle, availability endpoint, or
     # direct run is requested.  OpenFang remains an independent background

--- a/main_routers/characters_router/live2d_models.py
+++ b/main_routers/characters_router/live2d_models.py
@@ -507,6 +507,10 @@ async def update_catgirl_l2d(name: str, request: Request):
     """Update the specified catgirl's model settings (supports Live2D and VRM)."""
     try:
         data = await request.json()
+        apply_runtime = _config_value_is_enabled(data.get('apply_runtime', True))
+        query_params = getattr(request, 'query_params', {})
+        if 'apply_runtime' in query_params:
+            apply_runtime = _config_value_is_enabled(query_params.get('apply_runtime'))
         live2d_model = data.get('live2d')
         vrm_model = data.get('vrm')
         mmd_model = data.get('mmd')
@@ -878,7 +882,8 @@ async def update_catgirl_l2d(name: str, request: Request):
         await _config_manager.asave_characters(characters)
         # Fast path：只刷新被编辑角色的 session_manager（avatar 配置），不遍历其它 N-1 个。
         init_one_catgirl = get_init_one_catgirl()
-        await init_one_catgirl(name, is_new=False)
+        if apply_runtime:
+            await init_one_catgirl(name, is_new=False)
 
 
         if model_type_str == 'live3d':
@@ -892,7 +897,8 @@ async def update_catgirl_l2d(name: str, request: Request):
 
         return JSONResponse(content={
             'success': True,
-            'message': message
+            'message': message,
+            'applied_runtime': apply_runtime,
         })
 
     except MaintenanceModeError:

--- a/static/js/agent_ui_v2.js
+++ b/static/js/agent_ui_v2.js
@@ -654,7 +654,15 @@
         window.addEventListener('neko-popup-opening', async () => {
             state.popupOpen = true;
             render('popup');
-            refreshOpenClawAvailability().catch(() => {});
+            refreshOpenClawAvailability()
+                .catch(() => {})
+                .finally(() => {
+                    // The initial state request can beat the availability probe
+                    // and preserve its startup PENDING value.  Fetch the terminal
+                    // snapshot once the probe settles instead of requiring the
+                    // user to close and reopen the popup.
+                    if (state.popupOpen) fetchSnapshot().catch(() => {});
+                });
             if (!state.snapshot) {
                 await fetchSnapshot().catch(() => render('popup'));
                 return;

--- a/static/js/card_maker.js
+++ b/static/js/card_maker.js
@@ -1093,7 +1093,7 @@
     /**
      * 获取当前活跃模型的渲染画布
      */
-    function getModelCanvas() {
+    function getModelCanvas(options = {}) {
         if (currentModelType === 'live2d') {
             const mgr = window.live2dManager;
             if (mgr?.pixi_app?.renderer?.view) return mgr.pixi_app.renderer.view;
@@ -1110,6 +1110,11 @@
             return document.getElementById('mmd-canvas');
         }
         if (currentModelType === 'pngtuber') {
+            const mgr = window.cardMakerPNGTuberManager;
+            if (options.fullResolution && mgr?.isLayeredActive?.()) {
+                const snapshot = mgr.renderLayeredSnapshotCanvas?.();
+                if (snapshot) return snapshot;
+            }
             return getPNGTuberDrawableSource();
         }
         return null;
@@ -1528,7 +1533,7 @@
         }
         ensureRender();
 
-        const srcCanvas = getModelCanvas();
+        const srcCanvas = getModelCanvas({ fullResolution: currentModelType === 'pngtuber' });
         const srcSize = getDrawableSourceSize(srcCanvas);
         if (!srcCanvas || srcSize.width <= 0 || srcSize.height <= 0) {
             if (activeModelSourceScale !== previousSourceScale) {

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -2393,13 +2393,32 @@
                 || (Number(a.order || 0) - Number(b.order || 0));
         }
 
-        drawLayeredState(stateName = this.state || 'idle', timestamp = performance.now()) {
+        renderLayeredSnapshotCanvas(stateName = this.state || 'idle', timestamp = performance.now()) {
+            if (!this.isLayeredActive()) return null;
+            const canvas = document.createElement('canvas');
+            canvas.width = Math.max(1, Math.round(Number(this.layeredCanvasLogicalWidth) || 1));
+            canvas.height = Math.max(1, Math.round(Number(this.layeredCanvasLogicalHeight) || 1));
+            const drawn = this.drawLayeredState(stateName, timestamp, {
+                canvas,
+                scaleX: 1,
+                scaleY: 1
+            });
+            return drawn ? canvas : null;
+        }
+
+        drawLayeredState(stateName = this.state || 'idle', timestamp = performance.now(), renderTarget = null) {
             if (!this.isLayeredActive() || !this.canvasElement) return false;
-            const canvas = this.canvasElement;
+            const canvas = renderTarget?.canvas || this.canvasElement;
             const ctx = canvas.getContext('2d');
             if (!ctx) return false;
-            const renderScaleX = Math.max(0.0001, Number(this.layeredCanvasScaleX) || 1);
-            const renderScaleY = Math.max(0.0001, Number(this.layeredCanvasScaleY) || 1);
+            const renderScaleX = Math.max(
+                0.0001,
+                Number(renderTarget?.scaleX ?? this.layeredCanvasScaleX) || 1
+            );
+            const renderScaleY = Math.max(
+                0.0001,
+                Number(renderTarget?.scaleY ?? this.layeredCanvasScaleY) || 1
+            );
             ctx.setTransform(1, 0, 0, 1, 0, 0);
             ctx.clearRect(0, 0, canvas.width, canvas.height);
             ctx.setTransform(renderScaleX, 0, 0, renderScaleY, 0, 0);

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -23,6 +23,7 @@
     const REMIX_LAYERED_CANVAS_PADDING_RATIO = 0.12;
     const REMIX_LAYERED_CANVAS_PADDING_MIN = 48;
     const REMIX_LAYERED_CANVAS_PADDING_MAX = 160;
+    const PNGTUBER_LAYERED_CANVAS_MAX_RENDER_EDGE = 1024;
     const REMIX_MESH_DEFORM_STRENGTH = 0.28;
     const PNGTUBER_PLUS_VISIBLE_VALUES = new Set([0, 10, 20, 30, 1, 21, 12, 32, 3, 13, 4, 15, 26, 36, 27, 38]);
     // 空闲低频驱动（对齐 live2d-core.js round-2 模式）：呼吸是 0.32Hz 正弦、
@@ -154,6 +155,10 @@
             this.layeredAnimationFrame = null;
             this.layeredAnimationStart = 0;
             this.layeredCanvasPadding = 0;
+            this.layeredCanvasLogicalWidth = 1;
+            this.layeredCanvasLogicalHeight = 1;
+            this.layeredCanvasScaleX = 1;
+            this.layeredCanvasScaleY = 1;
             this.layeredBreathingFrame = null;
             this.layeredBreathingStart = 0;
             this.layeredPhysicsByLayer = new Map();
@@ -863,6 +868,10 @@
             this.layeredToggleVisibility = new Map();
             this.layeredLayerById = new Map();
             this.layeredCanvasPadding = 0;
+            this.layeredCanvasLogicalWidth = 1;
+            this.layeredCanvasLogicalHeight = 1;
+            this.layeredCanvasScaleX = 1;
+            this.layeredCanvasScaleY = 1;
             this.layeredPhysicsByLayer = new Map();
             this.remixModelMotionState = null;
             this.layeredDragVelocity = { x: 0, y: 0, at: 0 };
@@ -901,9 +910,28 @@
                         Math.ceil(Math.max(baseCanvasWidth, baseCanvasHeight) * REMIX_LAYERED_CANVAS_PADDING_RATIO)
                     )
                 );
-                canvas.width = baseCanvasWidth + this.layeredCanvasPadding * 2;
-                canvas.height = baseCanvasHeight + this.layeredCanvasPadding * 2;
-                canvas.style.aspectRatio = `${canvas.width} / ${canvas.height}`;
+                const logicalWidth = baseCanvasWidth + this.layeredCanvasPadding * 2;
+                const logicalHeight = baseCanvasHeight + this.layeredCanvasPadding * 2;
+                const renderScale = Math.min(
+                    1,
+                    PNGTUBER_LAYERED_CANVAS_MAX_RENDER_EDGE / Math.max(logicalWidth, logicalHeight)
+                );
+                const renderWidth = Math.max(1, Math.round(logicalWidth * renderScale));
+                const renderHeight = Math.max(1, Math.round(logicalHeight * renderScale));
+                this.layeredCanvasLogicalWidth = logicalWidth;
+                this.layeredCanvasLogicalHeight = logicalHeight;
+                this.layeredCanvasScaleX = renderWidth / logicalWidth;
+                this.layeredCanvasScaleY = renderHeight / logicalHeight;
+                canvas.width = renderWidth;
+                canvas.height = renderHeight;
+                const maxHeightVh = isModelManagerPage() ? 92 : 82;
+                const heightLimitedWidthVh = (maxHeightVh * logicalWidth) / logicalHeight;
+                const viewportWidthLimits = isModelManagerPage()
+                    ? `80vw, ${heightLimitedWidthVh}vh`
+                    : `56vw, 560px, ${heightLimitedWidthVh}vh`;
+                canvas.style.width = `min(${logicalWidth}px, ${viewportWidthLimits})`;
+                canvas.style.height = 'auto';
+                canvas.style.aspectRatio = `${logicalWidth} / ${logicalHeight}`;
                 this.startLayeredBlinkLoop();
                 this.restartLayeredAnimationLoop();
                 this.attachLayeredHotkeys();
@@ -915,6 +943,10 @@
                 this.layeredMetadata = null;
                 this.layeredImages = new Map();
                 this.layeredCanvasPadding = 0;
+                this.layeredCanvasLogicalWidth = 1;
+                this.layeredCanvasLogicalHeight = 1;
+                this.layeredCanvasScaleX = 1;
+                this.layeredCanvasScaleY = 1;
                 this.layeredToggleVisibility = new Map();
                 this.layeredLayerById = new Map();
                 this.detachLayeredPointerTracking();
@@ -1627,8 +1659,8 @@
                 ? this.canvasElement.getBoundingClientRect()
                 : null;
             if (!rect || !rect.width || !rect.height) return pointer;
-            const canvasWidth = Math.max(1, Number(this.canvasElement.width) || Number(this.layeredMetadata?.canvas?.width) || 1);
-            const canvasHeight = Math.max(1, Number(this.canvasElement.height) || Number(this.layeredMetadata?.canvas?.height) || 1);
+            const canvasWidth = Math.max(1, Number(this.layeredCanvasLogicalWidth) || Number(this.layeredMetadata?.canvas?.width) || 1);
+            const canvasHeight = Math.max(1, Number(this.layeredCanvasLogicalHeight) || Number(this.layeredMetadata?.canvas?.height) || 1);
             const padding = Number(this.layeredCanvasPadding) || 0;
             const frameWidth = Number(frame?.dw || layerState?.frame_width || layer?.width) || 1;
             const frameHeight = Number(frame?.dh || layerState?.frame_height || layer?.height) || 1;
@@ -2366,7 +2398,11 @@
             const canvas = this.canvasElement;
             const ctx = canvas.getContext('2d');
             if (!ctx) return false;
+            const renderScaleX = Math.max(0.0001, Number(this.layeredCanvasScaleX) || 1);
+            const renderScaleY = Math.max(0.0001, Number(this.layeredCanvasScaleY) || 1);
+            ctx.setTransform(1, 0, 0, 1, 0, 0);
             ctx.clearRect(0, 0, canvas.width, canvas.height);
+            ctx.setTransform(renderScaleX, 0, 0, renderScaleY, 0, 0);
             const layers = Array.isArray(this.layeredMetadata.layers) ? this.layeredMetadata.layers : [];
             if (this.isLayeredPlusModel()) {
                 return this.drawPlusLayerTree(ctx, layers, stateName, timestamp);
@@ -2974,7 +3010,8 @@
                 }
                 const payload = {
                     model_type: 'pngtuber',
-                    pngtuber: Object.assign({}, this.config)
+                    pngtuber: Object.assign({}, this.config),
+                    apply_runtime: false
                 };
                 const response = await fetch(`/api/characters/catgirl/l2d/${encodeURIComponent(name)}`, {
                     method: 'PUT',

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -3605,6 +3605,27 @@ def test_agent_llm_check_marks_browser_use_unloaded_instead_of_pending():
     assert '_set_capability("browser_use", False, "AGENT_BU_MODULE_NOT_LOADED")' in func_src
 
 
+def test_openfang_startup_capability_transitions_emit_status_snapshots():
+    source, func = _find_agent_server_function("startup", ast.AsyncFunctionDef)
+    func_src = ast.get_source_segment(source, func) or ""
+    init_src = func_src.split("async def _init_openfang_background():", 1)[1].split(
+        "_openfang_task = asyncio.create_task", 1
+    )[0]
+
+    assert init_src.count("await _emit_agent_status_update()") == 3
+
+
+def test_agent_popup_refetches_snapshot_after_openclaw_probe_settles():
+    source = Path("static/js/agent_ui_v2.js").read_text(encoding="utf-8")
+    popup_src = source.split(
+        "window.addEventListener('neko-popup-opening'", 1
+    )[1].split("window.addEventListener('neko-popup-closed'", 1)[0]
+
+    assert "refreshOpenClawAvailability()" in popup_src
+    assert ".finally(() => {" in popup_src
+    assert "if (state.popupOpen) fetchSnapshot().catch(() => {});" in popup_src
+
+
 def test_agent_ui_v2_free_warning_accepts_command_gate_shape():
     source = Path("static/js/agent_ui_v2.js").read_text(encoding="utf-8")
 

--- a/tests/unit/test_agent_runtime_intent.py
+++ b/tests/unit/test_agent_runtime_intent.py
@@ -694,6 +694,41 @@ async def test_openclaw_availability_loss_emits_after_disabling_flag(
 
 
 @pytest.mark.asyncio
+async def test_openclaw_availability_pending_failure_emits_terminal_snapshot(
+    agent_state_isolation, monkeypatch: pytest.MonkeyPatch
+):
+    """A first-open PENDING snapshot must be replaced without reopening the popup."""
+    srv = agent_state_isolation
+    emitted: list[str | None] = []
+
+    class _UnavailableOpenClaw:
+        def is_available(self):
+            return {"ready": False, "reasons": ["AGENT_CONNECTIVITY_FAILED"]}
+
+    async def _capture_emit(lanlan_name=None):
+        emitted.append(lanlan_name)
+
+    monkeypatch.setattr(srv.Modules, "openclaw", _UnavailableOpenClaw())
+    monkeypatch.setattr(srv, "_openclaw_pending", lambda: False)
+    monkeypatch.setattr(srv, "_emit_agent_status_update", _capture_emit)
+
+    srv.Modules.agent_flags["openclaw_enabled"] = False
+    srv.Modules.capability_cache["openclaw"] = {
+        "ready": False,
+        "reason": "AGENT_PRECHECK_PENDING",
+    }
+
+    status = await srv.openclaw_availability()
+
+    assert status == {"ready": False, "reasons": ["AGENT_CONNECTIVITY_FAILED"]}
+    assert srv.Modules.capability_cache["openclaw"] == {
+        "ready": False,
+        "reason": "AGENT_CONNECTIVITY_FAILED",
+    }
+    assert emitted == [None]
+
+
+@pytest.mark.asyncio
 async def test_gate_fail_preserves_user_plugin_enabled(
     agent_state_isolation, isolated_intent_store: Path
 ):

--- a/tests/unit/test_card_maker_static_contracts.py
+++ b/tests/unit/test_card_maker_static_contracts.py
@@ -334,6 +334,22 @@ def test_card_maker_rejects_remote_pngtuber_assets_before_export():
     assert "assertExportablePNGTuberDrawable(source);" in script
 
 
+def test_card_maker_uses_full_resolution_layered_pngtuber_snapshot_for_final_export():
+    script = CARD_MAKER_JS.read_text(encoding="utf-8")
+    get_canvas_block = script[
+        script.index("    function getModelCanvas(options = {})"):
+        script.index("    /**\n     * 在截图前确保渲染器输出最新帧")
+    ]
+    export_block = script[
+        script.index("    async function renderFinalPortrait(options = {})"):
+        script.index("    async function renderFullCard(options = {})")
+    ]
+
+    assert "if (options.fullResolution && mgr?.isLayeredActive?.())" in get_canvas_block
+    assert "mgr.renderLayeredSnapshotCanvas?.()" in get_canvas_block
+    assert "getModelCanvas({ fullResolution: currentModelType === 'pngtuber' })" in export_block
+
+
 def test_model_manager_parameter_save_restores_unsaved_and_offers_card_face():
     script = read_model_manager_source()
     parameter_editor = (PROJECT_ROOT / "static" / "js" / "live2d_parameter_editor.js").read_text(encoding="utf-8")

--- a/tests/unit/test_card_maker_static_contracts.py
+++ b/tests/unit/test_card_maker_static_contracts.py
@@ -347,6 +347,7 @@ def test_card_maker_uses_full_resolution_layered_pngtuber_snapshot_for_final_exp
 
     assert "if (options.fullResolution && mgr?.isLayeredActive?.())" in get_canvas_block
     assert "mgr.renderLayeredSnapshotCanvas?.()" in get_canvas_block
+    assert "if (snapshot) return snapshot;" in get_canvas_block
     assert "getModelCanvas({ fullResolution: currentModelType === 'pngtuber' })" in export_block
 
 

--- a/tests/unit/test_characters_router_model_settings.py
+++ b/tests/unit/test_characters_router_model_settings.py
@@ -93,13 +93,15 @@ def _build_characters_fixture():
     }
 
 
-async def _call_update(monkeypatch, payload, characters=None):
+async def _call_update(monkeypatch, payload, characters=None, init_calls=None):
     config_manager = DummyConfigManager(characters or _build_characters_fixture())
 
     async def _noop_initialize():
         return None
 
     async def _noop_init_one(name, *, is_new=False):
+        if init_calls is not None:
+            init_calls.append((name, is_new))
         return None
 
     monkeypatch.setattr(characters_router_module, 'get_config_manager', lambda: config_manager)
@@ -169,6 +171,54 @@ async def test_pngtuber_save_defaults_missing_mobile_layout_fields(monkeypatch):
     assert pngtuber['mobile_scale'] == 1
     assert pngtuber['mobile_offset_x'] == 0
     assert pngtuber['mobile_offset_y'] == 0
+
+
+@pytest.mark.asyncio
+async def test_pngtuber_position_save_can_skip_runtime_refresh(monkeypatch):
+    init_calls = []
+    response, body, saved = await _call_update(
+        monkeypatch,
+        {
+            'model_type': 'pngtuber',
+            'pngtuber': {
+                'idle_image': '/static/pngtuber/default/idle.png',
+                'scale': 1.5,
+                'offset_x': 24,
+                'offset_y': -36,
+            },
+            'apply_runtime': False,
+        },
+        init_calls=init_calls,
+    )
+
+    assert response.status_code == 200
+    assert body['success'] is True
+    assert body['applied_runtime'] is False
+    assert init_calls == []
+    catgirl = _single_saved_catgirl(saved)
+    assert get_reserved(catgirl, 'avatar', 'pngtuber', 'offset_x') == 24
+    assert get_reserved(catgirl, 'avatar', 'pngtuber', 'offset_y') == -36
+
+
+@pytest.mark.asyncio
+async def test_model_update_refreshes_runtime_by_default(monkeypatch):
+    init_calls = []
+    response, body, _saved = await _call_update(
+        monkeypatch,
+        {
+            'model_type': 'pngtuber',
+            'pngtuber': {
+                'idle_image': '/static/pngtuber/default/idle.png',
+            },
+        },
+        init_calls=init_calls,
+    )
+
+    assert response.status_code == 200
+    assert body['success'] is True
+    assert body['applied_runtime'] is True
+    assert len(init_calls) == 1
+    assert init_calls[0][1] is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -92,6 +92,7 @@ def test_pngtuber_transform_and_interactions_use_active_layout_fields():
     assert "this.config.mobile_offset_y" in save_block
     assert "this.config.mobile_scale" in save_block
     assert "this.config.position_anchor" in save_block
+    assert "apply_runtime: false" in save_block
 
 
 def test_pngtuber_model_manager_preview_centering_does_not_mutate_saved_offsets():
@@ -227,6 +228,36 @@ def test_layered_pngtuber_motion_requires_explicit_runtime_feature_flags():
     assert "layerMotionEnabled ? this.motionValue(layerState.yAmp, layerState.yFrq" in draw_block
     assert "const wiggleDegrees = layerMotionEnabled" in draw_block
     assert "this.motionValue(layerState.wiggle_amp, layerState.wiggle_freq || layerState.rot_frq" in draw_block
+
+
+def test_layered_pngtuber_caps_render_resolution_without_changing_logical_coordinates():
+    source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
+    setup_block = source[
+        source.index("        async setupLayeredAdapter()"):
+        source.index("        hasBlinkLayers()")
+    ]
+    pointer_block = source[
+        source.index("        layeredPointerForLayer("):
+        source.index("        layeredPointerNeedsFrame(")
+    ]
+    draw_block = source[
+        source.index("        drawLayeredState(stateName"):
+        source.index("        showTransientImage(")
+    ]
+
+    assert "const PNGTUBER_LAYERED_CANVAS_MAX_RENDER_EDGE = 1024;" in source
+    assert "PNGTUBER_LAYERED_CANVAS_MAX_RENDER_EDGE / Math.max(logicalWidth, logicalHeight)" in setup_block
+    assert "this.layeredCanvasLogicalWidth = logicalWidth;" in setup_block
+    assert "this.layeredCanvasLogicalHeight = logicalHeight;" in setup_block
+    assert "this.layeredCanvasScaleX = renderWidth / logicalWidth;" in setup_block
+    assert "this.layeredCanvasScaleY = renderHeight / logicalHeight;" in setup_block
+    assert "const heightLimitedWidthVh = (maxHeightVh * logicalWidth) / logicalHeight;" in setup_block
+    assert "canvas.style.width = `min(${logicalWidth}px, ${viewportWidthLimits})`;" in setup_block
+    assert "canvas.style.height = 'auto';" in setup_block
+    assert "Number(this.layeredCanvasLogicalWidth)" in pointer_block
+    assert "Number(this.layeredCanvasLogicalHeight)" in pointer_block
+    assert "ctx.clearRect(0, 0, canvas.width, canvas.height);" in draw_block
+    assert "ctx.setTransform(renderScaleX, 0, 0, renderScaleY, 0, 0);" in draw_block
 
 
 def test_layered_pngtuber_alt_one_cycles_states_without_imported_hotkeys():

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -277,6 +277,8 @@ def test_layered_pngtuber_can_render_full_resolution_snapshot_without_resizing_r
     assert "this.drawLayeredState(stateName, timestamp, {" in snapshot_block
     assert "scaleX: 1" in snapshot_block
     assert "scaleY: 1" in snapshot_block
+    assert "return drawn ? canvas : null;" in snapshot_block
+    assert "this.canvasElement =" not in snapshot_block
     assert "renderTarget?.canvas || this.canvasElement" in draw_block
     assert "renderTarget?.scaleX ?? this.layeredCanvasScaleX" in draw_block
     assert "renderTarget?.scaleY ?? this.layeredCanvasScaleY" in draw_block

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -260,6 +260,28 @@ def test_layered_pngtuber_caps_render_resolution_without_changing_logical_coordi
     assert "ctx.setTransform(renderScaleX, 0, 0, renderScaleY, 0, 0);" in draw_block
 
 
+def test_layered_pngtuber_can_render_full_resolution_snapshot_without_resizing_runtime_canvas():
+    source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
+    snapshot_block = source[
+        source.index("        renderLayeredSnapshotCanvas("):
+        source.index("        drawLayeredState(stateName")
+    ]
+    draw_block = source[
+        source.index("        drawLayeredState(stateName"):
+        source.index("        showTransientImage(")
+    ]
+
+    assert "document.createElement('canvas')" in snapshot_block
+    assert "Number(this.layeredCanvasLogicalWidth)" in snapshot_block
+    assert "Number(this.layeredCanvasLogicalHeight)" in snapshot_block
+    assert "this.drawLayeredState(stateName, timestamp, {" in snapshot_block
+    assert "scaleX: 1" in snapshot_block
+    assert "scaleY: 1" in snapshot_block
+    assert "renderTarget?.canvas || this.canvasElement" in draw_block
+    assert "renderTarget?.scaleX ?? this.layeredCanvasScaleX" in draw_block
+    assert "renderTarget?.scaleY ?? this.layeredCanvasScaleY" in draw_block
+
+
 def test_layered_pngtuber_alt_one_cycles_states_without_imported_hotkeys():
     source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
     attach_block = source[


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

<!-- 这个 PR 做了什么。若有对应 Issue 可关联（如 Closes #123），非必须。 -->
优化 PNGTuber 渲染分辨率，避免高分辨率模型导致帧率严重下降。
拖动 PNGTuber 时仅保存位置，不再重复重建角色运行时及 WebSocket 连接。
修复猫爪面板首次打开后一直显示“连接检查中”的状态同步问题。
猫爪总开关行为保持不变。
相关issues：[使用pngtuber模型的情况下猫爪总开关前端无法点击](https://github.com/Project-N-E-K-O/N.E.K.O/issues/2545)

## 回归报告 / Regression Report

<!--
仅当本 PR 触碰 app/、main_logic/、memory/ 时必填。请逐项说明：
  - 改动了什么
  - 理由 / 必要性
  - 改动前后的表现对比
  - 潜在回归点（影响哪些链路、怎么验证的）
未触碰这三个模块：写「不适用」或删除本节。
-->
### 改动内容及必要性
- app/agent_server：补充 OpenClaw、OpenFang 能力检查结束后的状态快照广播。
- OpenClaw 首次检查存在竞态：前端可能先取得 PENDING 快照，而检查结束后未广播失败终态，导致必须关闭面板再打开。
- OpenFang 后台初始化也存在终态只写入缓存、未通知前端的问题。
### 改动前后表现
- 改动前：首次打开猫爪面板可能长期显示“连接检查中”，重新打开后才恢复正常。
- 改动后：能力检查完成后会主动推送终态；前端同时进行一次最终快照补取，无需重新打开面板。
- PNGTuber 拖动前会频繁重建运行时并产生大量连接恢复日志；改动后仅持久化坐标。
- 高分辨率 PNGTuber 模型的绘制画布会按上限缩放，同时保持原有逻辑尺寸和鼠标坐标映射。
### 潜在回归点及验证
- Agent 能力状态广播：验证 OpenClaw 的 pending、ready、failure 转换及 OpenFang 启动终态。
- PNGTuber 渲染：验证缩放后的画面比例、指针映射和不同尺寸模型。
- PNGTuber 位置保存：验证坐标正常持久化，并且不会重新初始化角色运行时。
- 未修改猫爪总开关的切换逻辑。

## 测试 / Testing

<!-- 怎么验证的：跑了哪些测试、手动验证了哪些场景。 -->
Agent 状态及生命周期相关测试：85 passed。
Agent 最终针对性回归：43 passed。
PNGTuber、角色设置及路由相关测试：91 passed，3 skipped。
JavaScript 语法检查通过。
Python 编译检查通过。
git diff --check 通过。
高分辨率测试模型的实际绘制画布由 3849×4435 限制为 889×1024，平均绘制耗时约 0.50 ms，P95 约 0.8 ms。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 更新角色配置时，可选择仅保存设置而不立即刷新运行时，并返回实际应用状态。
  * PNGTuber 画布支持更稳定的缩放显示、指针定位及高分辨率导出。
* **问题修复**
  * 改进 OpenClaw 与 OpenFang 状态同步，能力状态变化会及时更新。
  * 打开 Agent 弹窗后，将在可用性检测完成时刷新最新状态。
* **测试**
  * 增加 Agent 状态通知、角色运行时刷新及 PNGTuber 渲染相关回归测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->