### PR TITLE
修复模型锁图标被浮动面板遮挡时仍可点击的问题，并覆盖全部模型类型

### DIFF
--- a/static/avatar/avatar-popup-common.js
+++ b/static/avatar/avatar-popup-common.js
@@ -15,12 +15,17 @@
         _sidePanels.delete(panel);
     }
 
-    function isOverlayVisible(element) {
-        if (!element) return false;
+    function getVisibleOverlayRect(element) {
+        if (!element) return null;
         const style = window.getComputedStyle(element);
-        if (style.display === 'none' || style.visibility === 'hidden') return false;
+        const opacity = Number.parseFloat(style.opacity || '1');
+        if (style.display === 'none' || style.visibility === 'hidden' || opacity <= 0) return null;
         const rect = element.getBoundingClientRect();
-        return rect.width > 0 && rect.height > 0;
+        return rect.width > 0 && rect.height > 0 ? rect : null;
+    }
+
+    function isOverlayVisible(element) {
+        return getVisibleOverlayRect(element) !== null;
     }
 
     function hasVisiblePopup(ownerPrefix = '') {
@@ -39,6 +44,22 @@
 
     function hasVisibleOverlay(ownerPrefix = '') {
         return hasVisiblePopup(ownerPrefix) || hasVisibleSidePanel(ownerPrefix);
+    }
+
+    function isRectOverlappedByVisibleOverlay(rect, ownerPrefix = '') {
+        if (!rect) return false;
+        const popupSelector = ownerPrefix
+            ? `[id^="${ownerPrefix}-popup-"]`
+            : '[id*="-popup-"]';
+        const sidePanelSelector = ownerPrefix
+            ? `[data-neko-sidepanel-owner^="${ownerPrefix}-popup-"]`
+            : '[data-neko-sidepanel-owner]';
+        return Array.from(document.querySelectorAll(`${popupSelector}, ${sidePanelSelector}`)).some(element => {
+            const overlayRect = getVisibleOverlayRect(element);
+            return overlayRect &&
+                rect.right > overlayRect.left && rect.left < overlayRect.right &&
+                rect.bottom > overlayRect.top && rect.top < overlayRect.bottom;
+        });
     }
 
     function clearSidePanelTimers(panel) {
@@ -601,6 +622,7 @@
         formatSidePanelTransform,
         hasVisiblePopup,
         hasVisibleSidePanel,
-        hasVisibleOverlay
+        hasVisibleOverlay,
+        isRectOverlappedByVisibleOverlay
     };
 })();

--- a/static/avatar/avatar-popup-common.js
+++ b/static/avatar/avatar-popup-common.js
@@ -18,8 +18,10 @@
     function getVisibleOverlayRect(element) {
         if (!element) return null;
         const style = window.getComputedStyle(element);
-        const opacity = Number.parseFloat(style.opacity || '1');
-        if (style.display === 'none' || style.visibility === 'hidden' || opacity <= 0) return null;
+        const computedOpacity = Number.parseFloat(style.opacity || '1');
+        const targetOpacity = Number.parseFloat(element.style.opacity || style.opacity || '1');
+        if (style.display === 'none' || style.visibility === 'hidden' ||
+            (computedOpacity <= 0 && targetOpacity <= 0)) return null;
         const rect = element.getBoundingClientRect();
         return rect.width > 0 && rect.height > 0 ? rect : null;
     }
@@ -75,6 +77,10 @@
         if (panel._hoverCollapseTimer) {
             clearTimeout(panel._hoverCollapseTimer);
             panel._hoverCollapseTimer = null;
+        }
+        if (panel._visibilitySettledTimer) {
+            clearTimeout(panel._visibilitySettledTimer);
+            panel._visibilitySettledTimer = null;
         }
         if (typeof panel._stopHoverPointerTracking === 'function') {
             panel._stopHoverPointerTracking();

--- a/static/avatar/avatar-ui-popup.js
+++ b/static/avatar/avatar-ui-popup.js
@@ -61,6 +61,7 @@ function clearAvatarSidePanelHoverState(panel) {
     if (!panel) return;
     if (panel._collapseTimeout) { clearTimeout(panel._collapseTimeout); panel._collapseTimeout = null; }
     if (panel._hoverCollapseTimer) { clearTimeout(panel._hoverCollapseTimer); panel._hoverCollapseTimer = null; }
+    if (panel._visibilitySettledTimer) { clearTimeout(panel._visibilitySettledTimer); panel._visibilitySettledTimer = null; }
     if (typeof panel._stopHoverPointerTracking === 'function') panel._stopHoverPointerTracking();
 }
 
@@ -576,6 +577,16 @@ function dispatchAvatarSidePanelVisibilityChanged(sidePanel) {
     const popupMarkerIndex = ownerId.indexOf('-popup-');
     const prefix = popupMarkerIndex > 0 ? ownerId.slice(0, popupMarkerIndex) : '';
     dispatchAvatarOverlayVisibilityChanged(prefix);
+}
+
+function scheduleAvatarSidePanelVisibilitySettled(sidePanel, visibilityRevision) {
+    if (!sidePanel) return;
+    if (sidePanel._visibilitySettledTimer) clearTimeout(sidePanel._visibilitySettledTimer);
+    sidePanel._visibilitySettledTimer = setTimeout(() => {
+        sidePanel._visibilitySettledTimer = null;
+        if (sidePanel._visibilityRevision !== visibilityRevision) return;
+        dispatchAvatarSidePanelVisibilityChanged(sidePanel);
+    }, AVATAR_POPUP_ANIMATION_DURATION_MS);
 }
 
 function dispatchAvatarPopupNavigateEvent(item, finalUrl, windowName, source) {
@@ -1654,6 +1665,7 @@ function createSidePanelContainer(manager, prefix, options = {}) {
         }
         if (container._collapseTimeout) { clearTimeout(container._collapseTimeout); container._collapseTimeout = null; }
         if (container._interactionGuardTimer) { clearTimeout(container._interactionGuardTimer); container._interactionGuardTimer = null; }
+        if (container._visibilitySettledTimer) { clearTimeout(container._visibilitySettledTimer); container._visibilitySettledTimer = null; }
 
         container.style.display = 'flex';
         container.style.pointerEvents = alreadyVisible ? 'auto' : 'none';
@@ -1686,6 +1698,7 @@ function createSidePanelContainer(manager, prefix, options = {}) {
             container.style.opacity = '1';
             applyAvatarSidePanelTransform(container, 'none');
             dispatchAvatarSidePanelVisibilityChanged(container);
+            scheduleAvatarSidePanelVisibilitySettled(container, visibilityRevision);
             if (alreadyVisible) {
                 container.style.pointerEvents = 'auto';
                 return;
@@ -1713,6 +1726,7 @@ function createSidePanelContainer(manager, prefix, options = {}) {
         }
         if (container._collapseTimeout) { clearTimeout(container._collapseTimeout); container._collapseTimeout = null; }
         if (container._interactionGuardTimer) { clearTimeout(container._interactionGuardTimer); container._interactionGuardTimer = null; }
+        if (container._visibilitySettledTimer) { clearTimeout(container._visibilitySettledTimer); container._visibilitySettledTimer = null; }
         container.style.pointerEvents = 'none';
         container.style.opacity = '0';
         applyAvatarSidePanelTransform(container, getAvatarSidePanelExitMotion(container));
@@ -1720,6 +1734,7 @@ function createSidePanelContainer(manager, prefix, options = {}) {
         container._collapseTimeout = setTimeout(() => {
             if (container._visibilityRevision === visibilityRevision && container.style.opacity === '0') {
                 container.style.display = 'none';
+                dispatchAvatarSidePanelVisibilityChanged(container);
             }
             container._collapseTimeout = null;
         }, AVATAR_POPUP_ANIMATION_DURATION_MS);
@@ -2009,6 +2024,7 @@ function createIntervalControl(manager, prefix, toggle) {
             container._expandFrameId = null;
         }
         if (container._collapseTimeout) { clearTimeout(container._collapseTimeout); container._collapseTimeout = null; }
+        if (container._visibilitySettledTimer) { clearTimeout(container._visibilitySettledTimer); container._visibilitySettledTimer = null; }
 
         container.style.display = 'flex';
         container.style.pointerEvents = 'none';
@@ -2036,6 +2052,7 @@ function createIntervalControl(manager, prefix, toggle) {
             container.style.opacity = '1';
             applyAvatarSidePanelTransform(container, 'none');
             dispatchAvatarSidePanelVisibilityChanged(container);
+            scheduleAvatarSidePanelVisibilitySettled(container, visibilityRevision);
         });
     };
 
@@ -2048,11 +2065,15 @@ function createIntervalControl(manager, prefix, toggle) {
             container._expandFrameId = null;
         }
         if (container._collapseTimeout) { clearTimeout(container._collapseTimeout); container._collapseTimeout = null; }
+        if (container._visibilitySettledTimer) { clearTimeout(container._visibilitySettledTimer); container._visibilitySettledTimer = null; }
         container.style.opacity = '0';
         applyAvatarSidePanelTransform(container, getAvatarSidePanelExitMotion(container));
         dispatchAvatarSidePanelVisibilityChanged(container);
         container._collapseTimeout = setTimeout(() => {
-            if (container._visibilityRevision === visibilityRevision && container.style.opacity === '0') container.style.display = 'none';
+            if (container._visibilityRevision === visibilityRevision && container.style.opacity === '0') {
+                container.style.display = 'none';
+                dispatchAvatarSidePanelVisibilityChanged(container);
+            }
             container._collapseTimeout = null;
         }, AVATAR_POPUP_ANIMATION_DURATION_MS);
     };

--- a/static/avatar/avatar-ui-popup.js
+++ b/static/avatar/avatar-ui-popup.js
@@ -557,6 +557,25 @@ function dispatchAvatarPopupLifecycleEvent(eventName, buttonId, popup, prefix) {
             }
         }));
     } catch (_) {}
+    dispatchAvatarOverlayVisibilityChanged(prefix);
+}
+
+function dispatchAvatarOverlayVisibilityChanged(prefix) {
+    if (typeof window === 'undefined' || typeof window.dispatchEvent !== 'function') return;
+    try {
+        window.dispatchEvent(new CustomEvent('neko-avatar-overlay-visibility-changed', {
+            detail: { prefix: prefix || '' }
+        }));
+    } catch (_) {}
+}
+
+function dispatchAvatarSidePanelVisibilityChanged(sidePanel) {
+    const ownerId = sidePanel && typeof sidePanel.getAttribute === 'function'
+        ? (sidePanel.getAttribute('data-neko-sidepanel-owner') || '')
+        : '';
+    const popupMarkerIndex = ownerId.indexOf('-popup-');
+    const prefix = popupMarkerIndex > 0 ? ownerId.slice(0, popupMarkerIndex) : '';
+    dispatchAvatarOverlayVisibilityChanged(prefix);
 }
 
 function dispatchAvatarPopupNavigateEvent(item, finalUrl, windowName, source) {
@@ -1655,6 +1674,7 @@ function createSidePanelContainer(manager, prefix, options = {}) {
             container.style.display = 'none';
             container.style.pointerEvents = 'none';
             container._visibilityRevision = visibilityRevision + 1;
+            dispatchAvatarSidePanelVisibilityChanged(container);
             return false;
         }
 
@@ -1665,6 +1685,7 @@ function createSidePanelContainer(manager, prefix, options = {}) {
             }
             container.style.opacity = '1';
             applyAvatarSidePanelTransform(container, 'none');
+            dispatchAvatarSidePanelVisibilityChanged(container);
             if (alreadyVisible) {
                 container.style.pointerEvents = 'auto';
                 return;
@@ -1695,6 +1716,7 @@ function createSidePanelContainer(manager, prefix, options = {}) {
         container.style.pointerEvents = 'none';
         container.style.opacity = '0';
         applyAvatarSidePanelTransform(container, getAvatarSidePanelExitMotion(container));
+        dispatchAvatarSidePanelVisibilityChanged(container);
         container._collapseTimeout = setTimeout(() => {
             if (container._visibilityRevision === visibilityRevision && container.style.opacity === '0') {
                 container.style.display = 'none';
@@ -2013,6 +2035,7 @@ function createIntervalControl(manager, prefix, toggle) {
             container.style.pointerEvents = 'auto';
             container.style.opacity = '1';
             applyAvatarSidePanelTransform(container, 'none');
+            dispatchAvatarSidePanelVisibilityChanged(container);
         });
     };
 
@@ -2027,6 +2050,7 @@ function createIntervalControl(manager, prefix, toggle) {
         if (container._collapseTimeout) { clearTimeout(container._collapseTimeout); container._collapseTimeout = null; }
         container.style.opacity = '0';
         applyAvatarSidePanelTransform(container, getAvatarSidePanelExitMotion(container));
+        dispatchAvatarSidePanelVisibilityChanged(container);
         container._collapseTimeout = setTimeout(() => {
             if (container._visibilityRevision === visibilityRevision && container.style.opacity === '0') container.style.display = 'none';
             container._collapseTimeout = null;

--- a/static/avatar/avatar-ui-popup.js
+++ b/static/avatar/avatar-ui-popup.js
@@ -2066,6 +2066,7 @@ function createIntervalControl(manager, prefix, toggle) {
         }
         if (container._collapseTimeout) { clearTimeout(container._collapseTimeout); container._collapseTimeout = null; }
         if (container._visibilitySettledTimer) { clearTimeout(container._visibilitySettledTimer); container._visibilitySettledTimer = null; }
+        container.style.pointerEvents = 'none';
         container.style.opacity = '0';
         applyAvatarSidePanelTransform(container, getAvatarSidePanelExitMotion(container));
         dispatchAvatarSidePanelVisibilityChanged(container);

--- a/static/live2d/live2d-ui-buttons.js
+++ b/static/live2d/live2d-ui-buttons.js
@@ -194,6 +194,7 @@ Live2DManager.prototype.setupHTMLLockIcon = function(model) {
     this._lockIconLastTop = undefined;
     this._lockIconLastTransform = undefined;
     this._lockIconLastOpacity = undefined;
+    this._lockIconLastPointerEvents = undefined;
     this._lockIconLastOverlapScanAt = 0;
     this._lockIconElement = lockIcon;
     this._lockIconImages = {
@@ -311,6 +312,11 @@ Live2DManager.prototype.setupHTMLLockIcon = function(model) {
             if (nextOpacity !== this._lockIconLastOpacity) {
                 this._lockIconLastOpacity = nextOpacity;
                 lockIcon.style.opacity = nextOpacity;
+            }
+            const nextPointerEvents = isOverlapped ? 'none' : 'auto';
+            if (nextPointerEvents !== this._lockIconLastPointerEvents) {
+                this._lockIconLastPointerEvents = nextPointerEvents;
+                lockIcon.style.pointerEvents = nextPointerEvents;
             }
         } catch (_) {}
     };

--- a/static/live2d/live2d-ui-buttons.js
+++ b/static/live2d/live2d-ui-buttons.js
@@ -269,40 +269,31 @@ Live2DManager.prototype.setupHTMLLockIcon = function(model) {
                 lockIcon.style.top = `${clampedTop}px`;
             }
 
-            // 重叠检测节流到 250ms：纯装饰性淡出（opacity 0.3），不需要逐帧
-            // 扫两遍 DOM。矩形用已知坐标 + 缩放后的实际尺寸推算，避免每帧
-            // getBoundingClientRect 强制布局。
+            // 指针拦截逐帧刷新，避免弹窗刚出现时短暂穿透；装饰性淡出仍节流到 250ms。
+            // 锁图标矩形使用已知坐标和缩放尺寸，避免额外读取自身布局。
+            const lockRect = {
+                left: clampedLeft,
+                top: clampedTop,
+                right: clampedLeft + actualLockIconSize,
+                bottom: clampedTop + actualLockIconSize
+            };
+            const popupUi = window.AvatarPopupUI || null;
+            const isPointerOverlapped = popupUi && typeof popupUi.isRectOverlappedByVisibleOverlay === 'function'
+                ? popupUi.isRectOverlappedByVisibleOverlay(lockRect, 'live2d')
+                : Array.from(document.querySelectorAll('[id^="live2d-popup-"], [data-neko-sidepanel-owner^="live2d-popup-"]')).some(element => {
+                    const style = window.getComputedStyle(element);
+                    const opacity = Number.parseFloat(style.opacity || '1');
+                    if (style.display === 'none' || style.visibility === 'hidden' || opacity <= 0) return false;
+                    const overlayRect = element.getBoundingClientRect();
+                    return lockRect.right > overlayRect.left && lockRect.left < overlayRect.right &&
+                        lockRect.bottom > overlayRect.top && lockRect.top < overlayRect.bottom;
+                });
+
             const nowTs = performance.now();
             let isOverlapped = this._lockIconLastOverlapped === true;
             if (!this._lockIconLastOverlapScanAt || nowTs - this._lockIconLastOverlapScanAt >= 250) {
                 this._lockIconLastOverlapScanAt = nowTs;
-                const lockRect = {
-                    left: clampedLeft,
-                    top: clampedTop,
-                    right: clampedLeft + actualLockIconSize,
-                    bottom: clampedTop + actualLockIconSize
-                };
-                isOverlapped = false;
-                document.querySelectorAll('[id^="live2d-popup-"]').forEach(popup => {
-                    if (popup.style.display === 'flex' && popup.style.opacity === '1') {
-                        const popupRect = popup.getBoundingClientRect();
-                        if (lockRect.right > popupRect.left && lockRect.left < popupRect.right &&
-                            lockRect.bottom > popupRect.top && lockRect.top < popupRect.bottom) {
-                            isOverlapped = true;
-                        }
-                    }
-                });
-                if (!isOverlapped) {
-                    document.querySelectorAll('[data-neko-sidepanel]').forEach(panel => {
-                        if (panel.style.display !== 'none' && parseFloat(panel.style.opacity) > 0) {
-                            const panelRect = panel.getBoundingClientRect();
-                            if (lockRect.right > panelRect.left && lockRect.left < panelRect.right &&
-                                lockRect.bottom > panelRect.top && lockRect.top < panelRect.bottom) {
-                                isOverlapped = true;
-                            }
-                        }
-                    });
-                }
+                isOverlapped = isPointerOverlapped;
                 this._lockIconLastOverlapped = isOverlapped;
             }
             // 与角色形象半透明状态完全同步：容器加了 locked-hover-fade 类(opacity 0.12)时，锁图标也淡到同一透明度
@@ -313,7 +304,7 @@ Live2DManager.prototype.setupHTMLLockIcon = function(model) {
                 this._lockIconLastOpacity = nextOpacity;
                 lockIcon.style.opacity = nextOpacity;
             }
-            const nextPointerEvents = isOverlapped ? 'none' : 'auto';
+            const nextPointerEvents = isPointerOverlapped ? 'none' : 'auto';
             if (nextPointerEvents !== this._lockIconLastPointerEvents) {
                 this._lockIconLastPointerEvents = nextPointerEvents;
                 lockIcon.style.pointerEvents = nextPointerEvents;

--- a/static/live2d/live2d-ui-buttons.js
+++ b/static/live2d/live2d-ui-buttons.js
@@ -282,8 +282,10 @@ Live2DManager.prototype.setupHTMLLockIcon = function(model) {
                 ? popupUi.isRectOverlappedByVisibleOverlay(lockRect, 'live2d')
                 : Array.from(document.querySelectorAll('[id^="live2d-popup-"], [data-neko-sidepanel-owner^="live2d-popup-"]')).some(element => {
                     const style = window.getComputedStyle(element);
-                    const opacity = Number.parseFloat(style.opacity || '1');
-                    if (style.display === 'none' || style.visibility === 'hidden' || opacity <= 0) return false;
+                    const computedOpacity = Number.parseFloat(style.opacity || '1');
+                    const targetOpacity = Number.parseFloat(element.style.opacity || style.opacity || '1');
+                    if (style.display === 'none' || style.visibility === 'hidden' ||
+                        (computedOpacity <= 0 && targetOpacity <= 0)) return false;
                     const overlayRect = element.getBoundingClientRect();
                     return lockRect.right > overlayRect.left && lockRect.left < overlayRect.right &&
                         lockRect.bottom > overlayRect.top && lockRect.top < overlayRect.bottom;

--- a/static/mmd/mmd-ui-buttons.js
+++ b/static/mmd/mmd-ui-buttons.js
@@ -888,6 +888,7 @@ MMDManager.prototype._startUIUpdateLoop = function() {
                         lockIcon.style.opacity = (Number.isFinite(mmdFadeOpacity) && mmdFadeOpacity < 1)
                             ? String(mmdFadeOpacity)
                             : (isLockOverlapped ? '0.3' : '');
+                        lockIcon.style.pointerEvents = isLockOverlapped ? 'none' : 'auto';
                     }
                 }
                 buttonsContainer.style.transform = `scale(${scale})`;

--- a/static/mmd/mmd-ui-buttons.js
+++ b/static/mmd/mmd-ui-buttons.js
@@ -871,17 +871,24 @@ MMDManager.prototype._startUIUpdateLoop = function() {
                         lockIcon.style.visibility = shouldShowLock ? 'visible' : 'hidden';
                         lockIcon.style.opacity = shouldShowLock ? '' : '0';
 
+                    }
+                }
+                if (lockIcon) {
+                    const isLockVisible = !this._isInReturnState &&
+                        lockIcon.style.display !== 'none' && lockIcon.style.visibility !== 'hidden';
+                    if (isLockVisible) {
                         const lockRect = lockIcon.getBoundingClientRect();
-                        let isLockOverlapped = false;
-                        document.querySelectorAll('[id^="mmd-popup-"]').forEach(popup => {
-                            if (popup.style.display === 'flex' && popup.style.opacity === '1') {
-                                const popupRect = popup.getBoundingClientRect();
-                                if (lockRect.right > popupRect.left && lockRect.left < popupRect.right &&
-                                    lockRect.bottom > popupRect.top && lockRect.top < popupRect.bottom) {
-                                    isLockOverlapped = true;
-                                }
-                            }
-                        });
+                        const popupUi = window.AvatarPopupUI || null;
+                        const isLockOverlapped = popupUi && typeof popupUi.isRectOverlappedByVisibleOverlay === 'function'
+                            ? popupUi.isRectOverlappedByVisibleOverlay(lockRect, 'mmd')
+                            : Array.from(document.querySelectorAll('[id^="mmd-popup-"], [data-neko-sidepanel-owner^="mmd-popup-"]')).some(element => {
+                                const style = window.getComputedStyle(element);
+                                const opacity = Number.parseFloat(style.opacity || '1');
+                                if (style.display === 'none' || style.visibility === 'hidden' || opacity <= 0) return false;
+                                const overlayRect = element.getBoundingClientRect();
+                                return lockRect.right > overlayRect.left && lockRect.left < overlayRect.right &&
+                                    lockRect.bottom > overlayRect.top && lockRect.top < overlayRect.bottom;
+                            });
                         // 与角色形象半透明状态完全同步：容器淡化(opacity<1)时锁图标镜像同一透明度
                         const mmdFadeContainer = document.getElementById('mmd-container');
                         const mmdFadeOpacity = mmdFadeContainer ? parseFloat(mmdFadeContainer.style.opacity) : NaN;
@@ -889,6 +896,8 @@ MMDManager.prototype._startUIUpdateLoop = function() {
                             ? String(mmdFadeOpacity)
                             : (isLockOverlapped ? '0.3' : '');
                         lockIcon.style.pointerEvents = isLockOverlapped ? 'none' : 'auto';
+                    } else {
+                        lockIcon.style.pointerEvents = 'none';
                     }
                 }
                 buttonsContainer.style.transform = `scale(${scale})`;

--- a/static/mmd/mmd-ui-buttons.js
+++ b/static/mmd/mmd-ui-buttons.js
@@ -883,8 +883,10 @@ MMDManager.prototype._startUIUpdateLoop = function() {
                             ? popupUi.isRectOverlappedByVisibleOverlay(lockRect, 'mmd')
                             : Array.from(document.querySelectorAll('[id^="mmd-popup-"], [data-neko-sidepanel-owner^="mmd-popup-"]')).some(element => {
                                 const style = window.getComputedStyle(element);
-                                const opacity = Number.parseFloat(style.opacity || '1');
-                                if (style.display === 'none' || style.visibility === 'hidden' || opacity <= 0) return false;
+                                const computedOpacity = Number.parseFloat(style.opacity || '1');
+                                const targetOpacity = Number.parseFloat(element.style.opacity || style.opacity || '1');
+                                if (style.display === 'none' || style.visibility === 'hidden' ||
+                                    (computedOpacity <= 0 && targetOpacity <= 0)) return false;
                                 const overlayRect = element.getBoundingClientRect();
                                 return lockRect.right > overlayRect.left && lockRect.left < overlayRect.right &&
                                     lockRect.bottom > overlayRect.top && lockRect.top < overlayRect.bottom;

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -2908,27 +2908,17 @@
             lockIcon.style.visibility = 'visible';
 
             const lockRect = lockIcon.getBoundingClientRect();
-            let isOverlapped = false;
-            document.querySelectorAll('[id^="pngtuber-popup-"]').forEach((popup) => {
-                if (popup.style.display === 'flex' && popup.style.opacity === '1') {
-                    const popupRect = popup.getBoundingClientRect();
-                    if (lockRect.right > popupRect.left && lockRect.left < popupRect.right &&
-                        lockRect.bottom > popupRect.top && lockRect.top < popupRect.bottom) {
-                        isOverlapped = true;
-                    }
-                }
-            });
-            if (!isOverlapped) {
-                document.querySelectorAll('[data-neko-sidepanel]').forEach((panel) => {
-                    if (panel.style.display !== 'none' && parseFloat(panel.style.opacity) > 0) {
-                        const panelRect = panel.getBoundingClientRect();
-                        if (lockRect.right > panelRect.left && lockRect.left < panelRect.right &&
-                            lockRect.bottom > panelRect.top && lockRect.top < panelRect.bottom) {
-                            isOverlapped = true;
-                        }
-                    }
+            const popupUi = window.AvatarPopupUI || null;
+            const isOverlapped = popupUi && typeof popupUi.isRectOverlappedByVisibleOverlay === 'function'
+                ? popupUi.isRectOverlappedByVisibleOverlay(lockRect, 'pngtuber')
+                : Array.from(document.querySelectorAll('[id^="pngtuber-popup-"], [data-neko-sidepanel-owner^="pngtuber-popup-"]')).some(element => {
+                    const style = window.getComputedStyle(element);
+                    const opacity = Number.parseFloat(style.opacity || '1');
+                    if (style.display === 'none' || style.visibility === 'hidden' || opacity <= 0) return false;
+                    const overlayRect = element.getBoundingClientRect();
+                    return lockRect.right > overlayRect.left && lockRect.left < overlayRect.right &&
+                        lockRect.bottom > overlayRect.top && lockRect.top < overlayRect.bottom;
                 });
-            }
             const shouldFade = this.container && this.container.classList.contains('locked-hover-fade');
             lockIcon.style.opacity = shouldFade ? '0.12' : (isOverlapped ? '0.3' : '');
             lockIcon.style.pointerEvents = isOverlapped ? 'none' : 'auto';
@@ -4046,12 +4036,19 @@
                 applyResponsiveFloatingLayout();
                 this.updateLockIconPosition();
             });
+            const refreshLockForOverlayVisibility = (event) => {
+                const eventPrefix = event && event.detail ? event.detail.prefix : '';
+                if (eventPrefix && eventPrefix !== prefix) return;
+                this.updateLockIconPosition();
+            };
             this._uiWindowHandlers.push({ event: 'resize', handler: scheduleLayout, target: window });
             this._uiWindowHandlers.push({ event: 'orientationchange', handler: scheduleLayout, target: window });
             this._uiWindowHandlers.push({ event: 'neko:yui-guide-floating-toolbar-suppression-change', handler: scheduleLayout, target: window });
+            this._uiWindowHandlers.push({ event: 'neko-avatar-overlay-visibility-changed', handler: refreshLockForOverlayVisibility, target: window });
             window.addEventListener('resize', scheduleLayout);
             window.addEventListener('orientationchange', scheduleLayout);
             window.addEventListener('neko:yui-guide-floating-toolbar-suppression-change', scheduleLayout);
+            window.addEventListener('neko-avatar-overlay-visibility-changed', refreshLockForOverlayVisibility);
             if (this.image) {
                 this.image.addEventListener('load', scheduleLayout);
                 this.image.addEventListener('pointerenter', handleImagePointerEnter);

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -2931,6 +2931,7 @@
             }
             const shouldFade = this.container && this.container.classList.contains('locked-hover-fade');
             lockIcon.style.opacity = shouldFade ? '0.12' : (isOverlapped ? '0.3' : '');
+            lockIcon.style.pointerEvents = isOverlapped ? 'none' : 'auto';
         }
 
         async resolveCurrentLanlanName() {

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -2913,8 +2913,10 @@
                 ? popupUi.isRectOverlappedByVisibleOverlay(lockRect, 'pngtuber')
                 : Array.from(document.querySelectorAll('[id^="pngtuber-popup-"], [data-neko-sidepanel-owner^="pngtuber-popup-"]')).some(element => {
                     const style = window.getComputedStyle(element);
-                    const opacity = Number.parseFloat(style.opacity || '1');
-                    if (style.display === 'none' || style.visibility === 'hidden' || opacity <= 0) return false;
+                    const computedOpacity = Number.parseFloat(style.opacity || '1');
+                    const targetOpacity = Number.parseFloat(element.style.opacity || style.opacity || '1');
+                    if (style.display === 'none' || style.visibility === 'hidden' ||
+                        (computedOpacity <= 0 && targetOpacity <= 0)) return false;
                     const overlayRect = element.getBoundingClientRect();
                     return lockRect.right > overlayRect.left && lockRect.left < overlayRect.right &&
                         lockRect.bottom > overlayRect.top && lockRect.top < overlayRect.bottom;

--- a/static/vrm/vrm-ui-buttons.js
+++ b/static/vrm/vrm-ui-buttons.js
@@ -770,6 +770,7 @@ VRMManager.prototype._startUIUpdateLoop = function() {
                         lockIcon.style.opacity = (Number.isFinite(vrmFadeOpacity) && vrmFadeOpacity < 1)
                             ? String(vrmFadeOpacity)
                             : (isLockOverlapped ? '0.3' : '');
+                        lockIcon.style.pointerEvents = isLockOverlapped ? 'none' : 'auto';
                     }
                 }
                 buttonsContainer.style.transform = `scale(${scale})`;

--- a/static/vrm/vrm-ui-buttons.js
+++ b/static/vrm/vrm-ui-buttons.js
@@ -753,17 +753,24 @@ VRMManager.prototype._startUIUpdateLoop = function() {
                         lockIcon.style.visibility = shouldShowLock ? 'visible' : 'hidden';
                         lockIcon.style.opacity = shouldShowLock ? '' : '0';
 
+                    }
+                }
+                if (lockIcon) {
+                    const isLockVisible = !this._isInReturnState &&
+                        lockIcon.style.display !== 'none' && lockIcon.style.visibility !== 'hidden';
+                    if (isLockVisible) {
                         const lockRect = lockIcon.getBoundingClientRect();
-                        let isLockOverlapped = false;
-                        document.querySelectorAll('[id^="vrm-popup-"]').forEach(popup => {
-                            if (popup.style.display === 'flex' && popup.style.opacity === '1') {
-                                const popupRect = popup.getBoundingClientRect();
-                                if (lockRect.right > popupRect.left && lockRect.left < popupRect.right &&
-                                    lockRect.bottom > popupRect.top && lockRect.top < popupRect.bottom) {
-                                    isLockOverlapped = true;
-                                }
-                            }
-                        });
+                        const popupUi = window.AvatarPopupUI || null;
+                        const isLockOverlapped = popupUi && typeof popupUi.isRectOverlappedByVisibleOverlay === 'function'
+                            ? popupUi.isRectOverlappedByVisibleOverlay(lockRect, 'vrm')
+                            : Array.from(document.querySelectorAll('[id^="vrm-popup-"], [data-neko-sidepanel-owner^="vrm-popup-"]')).some(element => {
+                                const style = window.getComputedStyle(element);
+                                const opacity = Number.parseFloat(style.opacity || '1');
+                                if (style.display === 'none' || style.visibility === 'hidden' || opacity <= 0) return false;
+                                const overlayRect = element.getBoundingClientRect();
+                                return lockRect.right > overlayRect.left && lockRect.left < overlayRect.right &&
+                                    lockRect.bottom > overlayRect.top && lockRect.top < overlayRect.bottom;
+                            });
                         // 与角色形象半透明状态完全同步：容器淡化(opacity<1)时锁图标镜像同一透明度
                         const vrmFadeContainer = document.getElementById('vrm-container');
                         const vrmFadeOpacity = vrmFadeContainer ? parseFloat(vrmFadeContainer.style.opacity) : NaN;
@@ -771,6 +778,8 @@ VRMManager.prototype._startUIUpdateLoop = function() {
                             ? String(vrmFadeOpacity)
                             : (isLockOverlapped ? '0.3' : '');
                         lockIcon.style.pointerEvents = isLockOverlapped ? 'none' : 'auto';
+                    } else {
+                        lockIcon.style.pointerEvents = 'none';
                     }
                 }
                 buttonsContainer.style.transform = `scale(${scale})`;

--- a/static/vrm/vrm-ui-buttons.js
+++ b/static/vrm/vrm-ui-buttons.js
@@ -765,8 +765,10 @@ VRMManager.prototype._startUIUpdateLoop = function() {
                             ? popupUi.isRectOverlappedByVisibleOverlay(lockRect, 'vrm')
                             : Array.from(document.querySelectorAll('[id^="vrm-popup-"], [data-neko-sidepanel-owner^="vrm-popup-"]')).some(element => {
                                 const style = window.getComputedStyle(element);
-                                const opacity = Number.parseFloat(style.opacity || '1');
-                                if (style.display === 'none' || style.visibility === 'hidden' || opacity <= 0) return false;
+                                const computedOpacity = Number.parseFloat(style.opacity || '1');
+                                const targetOpacity = Number.parseFloat(element.style.opacity || style.opacity || '1');
+                                if (style.display === 'none' || style.visibility === 'hidden' ||
+                                    (computedOpacity <= 0 && targetOpacity <= 0)) return false;
                                 const overlayRect = element.getBoundingClientRect();
                                 return lockRect.right > overlayRect.left && lockRect.left < overlayRect.right &&
                                     lockRect.bottom > overlayRect.top && lockRect.top < overlayRect.bottom;

--- a/tests/unit/test_avatar_floating_button_layout_static.py
+++ b/tests/unit/test_avatar_floating_button_layout_static.py
@@ -204,6 +204,11 @@ def test_model_lock_icons_ignore_pointer_input_while_avatar_overlays_overlap():
         "                dispatchAvatarSidePanelVisibilityChanged(container);"
     ) == 2
     assert "if (panel._visibilitySettledTimer)" in popup_source
+    interval_control = popup_source[popup_source.index("function createIntervalControl") :]
+    interval_collapse = interval_control[interval_control.index("container._collapse = () => {") :]
+    assert interval_collapse.index("container.style.pointerEvents = 'none';") < (
+        interval_collapse.index("container.style.opacity = '0';")
+    )
 
 
 def test_shared_avatar_overlay_overlap_detects_owned_sidepanels_by_geometry():
@@ -221,7 +226,7 @@ const vrmPopup = {{
 }};
 const vrmSidePanel = {{
   style: {{ display: 'flex', visibility: 'visible', opacity: '1' }},
-  computedStyle: {{ display: 'flex', visibility: 'visible', opacity: '0' }},
+  computedStyle: {{ display: 'flex', visibility: 'visible', opacity: '1' }},
   getBoundingClientRect: () => ({{ left: 30, top: 30, right: 80, bottom: 80, width: 50, height: 50 }})
 }};
 const overlaysByPrefix = {{ vrm: [vrmPopup, vrmSidePanel], mmd: [] }};

--- a/tests/unit/test_avatar_floating_button_layout_static.py
+++ b/tests/unit/test_avatar_floating_button_layout_static.py
@@ -108,6 +108,35 @@ def test_live2d_lock_icon_tracks_the_floating_toolbar_scale():
     assert "bottom: clampedTop + actualLockIconSize" in lock_icon_block
 
 
+def test_model_lock_icons_ignore_pointer_input_while_avatar_popups_overlap():
+    renderer_contracts = [
+        (
+            "static/live2d/live2d-ui-buttons.js",
+            "lockIcon.style.pointerEvents = nextPointerEvents;",
+        ),
+        (
+            "static/vrm/vrm-ui-buttons.js",
+            "lockIcon.style.pointerEvents = isLockOverlapped ? 'none' : 'auto';",
+        ),
+        (
+            "static/mmd/mmd-ui-buttons.js",
+            "lockIcon.style.pointerEvents = isLockOverlapped ? 'none' : 'auto';",
+        ),
+        (
+            "static/pngtuber-core.js",
+            "lockIcon.style.pointerEvents = isOverlapped ? 'none' : 'auto';",
+        ),
+    ]
+
+    for relative_path, pointer_guard in renderer_contracts:
+        source = (PROJECT_ROOT / relative_path).read_text(encoding="utf-8")
+        assert pointer_guard in source
+
+    live2d_source = (PROJECT_ROOT / renderer_contracts[0][0]).read_text(encoding="utf-8")
+    assert "const nextPointerEvents = isOverlapped ? 'none' : 'auto';" in live2d_source
+    assert "this._lockIconLastPointerEvents = undefined;" in live2d_source
+
+
 def test_interpage_restore_keeps_floating_button_containers_in_flex_layout():
     source = read_js_parts(APP_INTERPAGE_PATH)
     restore_block = _source_slice_between(

--- a/tests/unit/test_avatar_floating_button_layout_static.py
+++ b/tests/unit/test_avatar_floating_button_layout_static.py
@@ -1,4 +1,10 @@
+import json
+import shutil
 from pathlib import Path
+
+import pytest
+
+from tests.node_harness import run_node_stdin
 from tests.static_app_parts import read_js_parts
 
 from tests.unit.avatar_ui_buttons_source import read_avatar_ui_buttons_source
@@ -15,6 +21,20 @@ def _read_avatar_ui_buttons_source() -> str:
 LIVE2D_UI_BUTTONS_PATH = PROJECT_ROOT / "static" / "live2d" / "live2d-ui-buttons.js"
 APP_INTERPAGE_PATH = PROJECT_ROOT / "static" / "app" / "app-interpage"
 INDEX_CSS_PATH = PROJECT_ROOT / "static" / "css" / "index.css"
+
+
+def _run_node_harness(script: str):
+    node_executable = shutil.which("node")
+    if node_executable is None:
+        pytest.skip("node not found")
+    return run_node_stdin(
+        node_executable,
+        script,
+        capture_output=True,
+        cwd=PROJECT_ROOT,
+        timeout=10,
+        check=False,
+    )
 
 
 def _source_slice_between(source, start_marker, end_marker, block_name):
@@ -108,7 +128,7 @@ def test_live2d_lock_icon_tracks_the_floating_toolbar_scale():
     assert "bottom: clampedTop + actualLockIconSize" in lock_icon_block
 
 
-def test_model_lock_icons_ignore_pointer_input_while_avatar_popups_overlap():
+def test_model_lock_icons_ignore_pointer_input_while_avatar_overlays_overlap():
     renderer_contracts = [
         (
             "static/live2d/live2d-ui-buttons.js",
@@ -133,8 +153,94 @@ def test_model_lock_icons_ignore_pointer_input_while_avatar_popups_overlap():
         assert pointer_guard in source
 
     live2d_source = (PROJECT_ROOT / renderer_contracts[0][0]).read_text(encoding="utf-8")
-    assert "const nextPointerEvents = isOverlapped ? 'none' : 'auto';" in live2d_source
+    assert "const nextPointerEvents = isPointerOverlapped ? 'none' : 'auto';" in live2d_source
     assert "this._lockIconLastPointerEvents = undefined;" in live2d_source
+    assert live2d_source.index("const isPointerOverlapped =") < live2d_source.index(
+        "if (!this._lockIconLastOverlapScanAt"
+    )
+
+    popup_common_source = (
+        PROJECT_ROOT / "static/avatar/avatar-popup-common.js"
+    ).read_text(encoding="utf-8")
+    assert "isRectOverlappedByVisibleOverlay" in popup_common_source
+    assert '`[id^="${ownerPrefix}-popup-"]`' in popup_common_source
+    assert '`[data-neko-sidepanel-owner^="${ownerPrefix}-popup-"]`' in popup_common_source
+
+    for renderer, prefix in (("vrm", "vrm"), ("mmd", "mmd")):
+        source = (
+            PROJECT_ROOT / f"static/{renderer}/{renderer}-ui-buttons.js"
+        ).read_text(encoding="utf-8")
+        layout_start = source.index("const visibleCount = getVisibleButtonCount();")
+        mobile_branch = source.index("if (isMobile) {", layout_start)
+        common_visibility_guard = source.index(
+            "const isLockVisible = !this._isInReturnState", mobile_branch
+        )
+        shared_guard = source.index(
+            f"popupUi.isRectOverlappedByVisibleOverlay(lockRect, '{prefix}')",
+            common_visibility_guard,
+        )
+        assert common_visibility_guard > source.index("} else {", mobile_branch)
+        assert shared_guard < source.index(
+            "buttonsContainer.style.transform = `scale(${scale})`;", shared_guard
+        )
+        assert f'[data-neko-sidepanel-owner^="{prefix}-popup-"]' in source
+
+    pngtuber_source = (PROJECT_ROOT / "static/pngtuber-core.js").read_text(
+        encoding="utf-8"
+    )
+    popup_source = (
+        PROJECT_ROOT / "static/avatar/avatar-ui-popup.js"
+    ).read_text(encoding="utf-8")
+    overlay_event = "neko-avatar-overlay-visibility-changed"
+    assert f"window.addEventListener('{overlay_event}'" in pngtuber_source
+    assert "this.updateLockIconPosition();" in pngtuber_source
+    assert f"new CustomEvent('{overlay_event}'" in popup_source
+    assert "dispatchAvatarSidePanelVisibilityChanged(container);" in popup_source
+
+
+def test_shared_avatar_overlay_overlap_detects_owned_sidepanels_by_geometry():
+    source = (PROJECT_ROOT / "static/avatar/avatar-popup-common.js").read_text(
+        encoding="utf-8"
+    )
+    script = rf"""
+const assert = require('node:assert/strict');
+const source = {json.dumps(source)};
+const lockRect = {{ left: 10, top: 10, right: 42, bottom: 42 }};
+const vrmPopup = {{
+  style: {{ display: 'flex', visibility: 'visible', opacity: '0' }},
+  getBoundingClientRect: () => ({{ left: 0, top: 0, right: 50, bottom: 50, width: 50, height: 50 }})
+}};
+const vrmSidePanel = {{
+  style: {{ display: 'flex', visibility: 'visible', opacity: '1' }},
+  getBoundingClientRect: () => ({{ left: 30, top: 30, right: 80, bottom: 80, width: 50, height: 50 }})
+}};
+const overlaysByPrefix = {{ vrm: [vrmPopup, vrmSidePanel], mmd: [] }};
+const queriedSelectors = [];
+global.document = {{
+  querySelectorAll(selector) {{
+    queriedSelectors.push(selector);
+    if (selector.includes('vrm-popup-')) return overlaysByPrefix.vrm;
+    if (selector.includes('mmd-popup-')) return overlaysByPrefix.mmd;
+    return [];
+  }},
+  getElementById() {{ return null; }},
+  querySelector() {{ return null; }}
+}};
+global.window = {{
+  getComputedStyle(element) {{ return element.style; }},
+  innerWidth: 1920,
+  innerHeight: 1080
+}};
+eval(source);
+assert.equal(window.AvatarPopupUI.isRectOverlappedByVisibleOverlay(lockRect, 'vrm'), true);
+assert.equal(window.AvatarPopupUI.isRectOverlappedByVisibleOverlay(lockRect, 'mmd'), false);
+assert.match(queriedSelectors[0], /\[id\^="vrm-popup-"\]/);
+assert.match(queriedSelectors[0], /data-neko-sidepanel-owner\^="vrm-popup-"/);
+vrmSidePanel.style.opacity = '0';
+assert.equal(window.AvatarPopupUI.isRectOverlappedByVisibleOverlay(lockRect, 'vrm'), false);
+"""
+    result = _run_node_harness(script)
+    assert result.returncode == 0, result.stderr or result.stdout
 
 
 def test_interpage_restore_keeps_floating_button_containers_in_flex_layout():

--- a/tests/unit/test_avatar_floating_button_layout_static.py
+++ b/tests/unit/test_avatar_floating_button_layout_static.py
@@ -196,6 +196,14 @@ def test_model_lock_icons_ignore_pointer_input_while_avatar_overlays_overlap():
     assert "this.updateLockIconPosition();" in pngtuber_source
     assert f"new CustomEvent('{overlay_event}'" in popup_source
     assert "dispatchAvatarSidePanelVisibilityChanged(container);" in popup_source
+    assert popup_source.count(
+        "scheduleAvatarSidePanelVisibilitySettled(container, visibilityRevision);"
+    ) == 2
+    assert popup_source.count(
+        "container.style.display = 'none';\n"
+        "                dispatchAvatarSidePanelVisibilityChanged(container);"
+    ) == 2
+    assert "if (panel._visibilitySettledTimer)" in popup_source
 
 
 def test_shared_avatar_overlay_overlap_detects_owned_sidepanels_by_geometry():
@@ -208,10 +216,12 @@ const source = {json.dumps(source)};
 const lockRect = {{ left: 10, top: 10, right: 42, bottom: 42 }};
 const vrmPopup = {{
   style: {{ display: 'flex', visibility: 'visible', opacity: '0' }},
+  computedStyle: {{ display: 'flex', visibility: 'visible', opacity: '0' }},
   getBoundingClientRect: () => ({{ left: 0, top: 0, right: 50, bottom: 50, width: 50, height: 50 }})
 }};
 const vrmSidePanel = {{
   style: {{ display: 'flex', visibility: 'visible', opacity: '1' }},
+  computedStyle: {{ display: 'flex', visibility: 'visible', opacity: '0' }},
   getBoundingClientRect: () => ({{ left: 30, top: 30, right: 80, bottom: 80, width: 50, height: 50 }})
 }};
 const overlaysByPrefix = {{ vrm: [vrmPopup, vrmSidePanel], mmd: [] }};
@@ -227,7 +237,7 @@ global.document = {{
   querySelector() {{ return null; }}
 }};
 global.window = {{
-  getComputedStyle(element) {{ return element.style; }},
+  getComputedStyle(element) {{ return element.computedStyle || element.style; }},
   innerWidth: 1920,
   innerHeight: 1080
 }};
@@ -237,6 +247,9 @@ assert.equal(window.AvatarPopupUI.isRectOverlappedByVisibleOverlay(lockRect, 'mm
 assert.match(queriedSelectors[0], /\[id\^="vrm-popup-"\]/);
 assert.match(queriedSelectors[0], /data-neko-sidepanel-owner\^="vrm-popup-"/);
 vrmSidePanel.style.opacity = '0';
+vrmSidePanel.computedStyle.opacity = '1';
+assert.equal(window.AvatarPopupUI.isRectOverlappedByVisibleOverlay(lockRect, 'vrm'), true);
+vrmSidePanel.computedStyle.opacity = '0';
 assert.equal(window.AvatarPopupUI.isRectOverlappedByVisibleOverlay(lockRect, 'vrm'), false);
 """
     result = _run_node_harness(script)


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复模型锁图标被浮动面板遮挡时仍可点击的问题，并覆盖全部模型类型

## 测试 / Testing

手动测试面板展开时锁按钮正常所有的


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复头像锁定图标与弹窗或侧边栏重叠时仍拦截鼠标操作的问题。
  * 锁定图标现在会根据覆盖层的可见性和重叠状态自动调整透明度，并禁用或恢复交互。

* **Tests**
  * 新增回归测试，覆盖 Live2D、VRM、MMD 和 PNGTuber 模式下的锁定图标交互行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->