### PR TITLE
fix(realtime): 收口 arbiter 复审遗留的三个陷阱，并改正一处说谎的注释

### DIFF
--- a/main_logic/omni_realtime_client/_response_arbiter.py
+++ b/main_logic/omni_realtime_client/_response_arbiter.py
@@ -519,8 +519,24 @@ class RealtimeResponseArbiter:
     @staticmethod
     def _event_response_id(event: dict[str, Any] | None) -> str | None:
         response = (event or {}).get("response")
-        response_id = response.get("id") if isinstance(response, dict) else None
-        return str(response_id) if response_id else None
+        if not isinstance(response, dict):
+            return None
+        response_id = response.get("id")
+        # Presence, not truthiness. A provider numbering its responses from
+        # zero would have had its FIRST response read as unidentified, which
+        # among other things makes ``_cannot_keep_the_connection`` report "no
+        # id to attribute later events by" and tear the transport down in
+        # spite of the escape hatch. No configured provider numbers this way —
+        # this is a trap, not a live failure — but "0 is not an id" is the
+        # kind of thing that is free to get right and expensive to discover.
+        #
+        # An empty string still normalizes to None on purpose: it names
+        # nothing, and admitting it would collapse every unidentified response
+        # onto one shared identity.
+        if response_id is None:
+            return None
+        text = str(response_id)
+        return text or None
 
     def _remember_server_response_id(self, response_id: str) -> None:
         self._server_response_ids.pop(response_id, None)

--- a/main_logic/omni_realtime_client/_response_arbiter.py
+++ b/main_logic/omni_realtime_client/_response_arbiter.py
@@ -1763,9 +1763,17 @@ class RealtimeResponseArbiter:
 
             if queued.item_ack is not None:
                 try:
-                    await asyncio.wait_for(
-                        asyncio.shield(queued.item_ack), queued.item_ack_timeout
-                    )
+                    # The one bound that was not instrumented, which made
+                    # "no wait spent half its allowance" a claim nothing could
+                    # back for it. It is also the bound I once mis-reported as
+                    # over budget from outside the arbiter, so leaving it
+                    # unmeasured from inside was the worst possible gap.
+                    with self._report_wait_margin(
+                        "conversation item ack", queued.item_ack_timeout
+                    ):
+                        await asyncio.wait_for(
+                            asyncio.shield(queued.item_ack), queued.item_ack_timeout
+                        )
                     item_acked = True
                     queued.item_acked = True
                 except asyncio.TimeoutError:

--- a/main_logic/omni_realtime_client/_response_arbiter.py
+++ b/main_logic/omni_realtime_client/_response_arbiter.py
@@ -470,6 +470,10 @@ class RealtimeResponseArbiter:
         return True
 
     async def wait_until_idle(self, timeout: float | None = None) -> None:
+        # Deliberately NOT wrapped in `_report_wait_margin`: its only caller
+        # with a timeout is `cancel_current`'s unowned branch, which already
+        # measures this wait from the outside as "unowned cancel". Wrapping
+        # here too would report one wait twice.
         waiter = self._idle.wait()
         if timeout is None:
             await waiter
@@ -1528,10 +1532,13 @@ class RealtimeResponseArbiter:
         had_lifecycle = released_owner is not None
         try:
             if self._on_stuck_release is not None and had_lifecycle:
-                await asyncio.wait_for(
-                    self._on_stuck_release(reason, released_id),
-                    _STUCK_RELEASE_NOTIFY_TIMEOUT,
-                )
+                with self._report_wait_margin(
+                    "stuck-release host notification", _STUCK_RELEASE_NOTIFY_TIMEOUT
+                ):
+                    await asyncio.wait_for(
+                        self._on_stuck_release(reason, released_id),
+                        _STUCK_RELEASE_NOTIFY_TIMEOUT,
+                    )
         except asyncio.TimeoutError:
             logger.warning(
                 "stuck-release host notification exceeded %.1fs; opening "
@@ -1688,6 +1695,8 @@ class RealtimeResponseArbiter:
         interrupt_waiter = asyncio.create_task(queued.interrupt_event.wait())
         waiters = (dispatch_waiter, interrupt_waiter)
         try:
+            # Unbounded on purpose — a paused lane waits as long as the pause
+            # lasts — so there is no allowance to report a fraction of.
             await asyncio.wait(waiters, return_when=asyncio.FIRST_COMPLETED)
         finally:
             for waiter in waiters:
@@ -1702,11 +1711,14 @@ class RealtimeResponseArbiter:
         interrupt_waiter = asyncio.create_task(queued.interrupt_event.wait())
         waiters = (idle_waiter, interrupt_waiter)
         try:
-            done, _ = await asyncio.wait(
-                waiters,
-                timeout=queued.response_done_timeout,
-                return_when=asyncio.FIRST_COMPLETED,
-            )
+            with self._report_wait_margin(
+                "lane availability", queued.response_done_timeout
+            ):
+                done, _ = await asyncio.wait(
+                    waiters,
+                    timeout=queued.response_done_timeout,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
             if not done:
                 await self._escalate(
                     "realtime response idle wait timed out", observed=queued
@@ -1842,9 +1854,12 @@ class RealtimeResponseArbiter:
                     except Exception:
                         cancel_write_failed = True
                         raise
-                    await asyncio.wait_for(
-                        asyncio.shield(queued.terminal), queued.cancel_timeout
-                    )
+                    with self._report_wait_margin(
+                        "interrupted cancel", queued.cancel_timeout
+                    ):
+                        await asyncio.wait_for(
+                            asyncio.shield(queued.terminal), queued.cancel_timeout
+                        )
                 except Exception:
                     if not queued.terminal.done():
                         queued.terminal.cancel()

--- a/main_logic/omni_realtime_client/_shared.py
+++ b/main_logic/omni_realtime_client/_shared.py
@@ -20,6 +20,15 @@ import os  # noqa: F401 - compatibility export and sibling dependency
 import uuid  # noqa: F401 - compatibility export and sibling dependency
 
 import websockets  # noqa: F401 - compatibility export and sibling dependency
+# Explicit, because `websockets.exceptions` is NOT reachable as a lazy
+# attribute on the package (measured on 15.0.1: it raises AttributeError
+# until some submodule import pulls it in). `handle_messages` names it in
+# except clauses, and today those only resolve because `connect()` ran
+# first and imported `websockets.asyncio.client` as a side effect. That
+# holds in production and does not hold anywhere else — a test driving
+# the receive loop over a fake socket hits AttributeError inside the
+# except clause instead of the handler it was reaching for.
+import websockets.exceptions  # noqa: F401 - named in except clauses
 
 import json  # noqa: F401 - compatibility export and sibling dependency
 

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -1417,16 +1417,27 @@ class _TransportMixin:
             # successor has not announced itself yet, so it has produced no
             # output of its own to erase.
             self._reset_per_turn_output_state()
-            # The one per-turn flag the successor cannot clear for itself.
-            # `_interrupted` may be left to it because `response.created`
-            # resets it; `_skip_until_next_response` has no such reset, so
-            # leaving it here mutes every delta of the next turn until its own
-            # terminal. Unreachable today — nothing on the WebSocket path
-            # passes `skipped=True`, and `prime_context(skipped=True)` takes
-            # the session.update branch instead of `create_response` — so this
-            # closes a trap for the first caller that does, rather than fixing
-            # a live drop.
-            self._skip_until_next_response = False
+            # `_skip_until_next_response` is deliberately NOT touched here,
+            # and neither leaving it nor clearing it is right — which is the
+            # actual finding.
+            #
+            # Leaving it mutes the successor: `_interrupted` may be left for
+            # the next turn because `response.created` resets it, and this flag
+            # has no such reset, so the successor's every delta stays
+            # suppressed until its own terminal. But clearing it is not the
+            # answer either, because the flag may already belong to the
+            # successor: `create_response(skipped=True)` raises it BEFORE it
+            # enqueues (`_responses.py`), so a request queued behind the
+            # abandoned one owns it while it waits for the lane. Clearing would
+            # then un-skip a turn the caller explicitly asked to suppress.
+            #
+            # A flag with no owner cannot be correctly cleared or correctly
+            # left; picking a side is arbitrary. The fix is to give output
+            # suppression a per-turn identity, which is issue #2594. Until
+            # then this stays as it shipped rather than trading one wrong
+            # behaviour for another — the whole state is unreachable today
+            # (nothing on the WebSocket path passes `skipped=True`), so there
+            # is nothing to buy by guessing.
             # Both release paths raise it: the abandoned response may still be
             # streaming, and from here until the next response.created nothing
             # id-less can be attributed. Clearing _current_response_id above

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -1034,9 +1034,24 @@ class _TransportMixin:
         twice — and a repeat necessarily takes the stale branch, because the
         first one cleared ``_current_response_id`` — so counting on both paths
         without a guard would overstate usage for a case the transport
-        supports on purpose. Keyed by response id; a terminal with no id
-        never reaches the stale branch (that filter needs an id to compare),
-        so it can only be counted once anyway.
+        supports on purpose. Keyed by response id.
+
+        The last sentence of this docstring used to read "a terminal with no
+        id never reaches the stale branch, so it can only be counted once
+        anyway." That is backwards. An id-less terminal never reaches the
+        stale branch precisely BECAUSE the filter needs an id — so a repeat of
+        it takes the ordinary terminal path both times, and the guard below,
+        keyed on an id it does not have, does not fire for either. Two copies
+        book twice; measured.
+
+        Left unfixed on purpose. A latch would have to be reset per turn, and
+        the provider class that omits a terminal id is the same one that omits
+        ``response.created`` — on such a connection there is no reset point at
+        all, so the latch would swallow every turn after the first. That trades
+        an accounting error no measured provider can produce for a real missed
+        bill. If a provider ever does repeat an id-less terminal, the fix
+        belongs at the terminal dispatch as a "this turn is already finalized"
+        latch, not here.
         """
 
         if not isinstance(resp_data, dict):
@@ -1402,6 +1417,16 @@ class _TransportMixin:
             # successor has not announced itself yet, so it has produced no
             # output of its own to erase.
             self._reset_per_turn_output_state()
+            # The one per-turn flag the successor cannot clear for itself.
+            # `_interrupted` may be left to it because `response.created`
+            # resets it; `_skip_until_next_response` has no such reset, so
+            # leaving it here mutes every delta of the next turn until its own
+            # terminal. Unreachable today — nothing on the WebSocket path
+            # passes `skipped=True`, and `prime_context(skipped=True)` takes
+            # the session.update branch instead of `create_response` — so this
+            # closes a trap for the first caller that does, rather than fixing
+            # a live drop.
+            self._skip_until_next_response = False
             # Both release paths raise it: the abandoned response may still be
             # streaming, and from here until the next response.created nothing
             # id-less can be attributed. Clearing _current_response_id above

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -1619,14 +1619,25 @@ class _TransportMixin:
                 # include response identity let us reject those late events
                 # without changing the legacy behaviour of id-less proxies.
                 if event_type != "response.created":
+                    # Presence, not truthiness, on both reads — the same
+                    # correction the arbiter's `_event_response_id` gets in this
+                    # PR, and useless without it. A provider numbering from zero
+                    # would have response `0`'s late deltas, tool events and
+                    # terminal slip past this filter once a successor is
+                    # current, and a late terminal would then run the ordinary
+                    # host finalization against that successor.
                     event_response_id = event.get("response_id")
-                    if event_type == "response.done" and not event_response_id:
+                    if event_response_id is None and event_type == "response.done":
                         response = event.get("response")
                         if isinstance(response, dict):
                             event_response_id = response.get("id")
+                    if event_response_id is not None:
+                        event_response_id = str(event_response_id) or None
+                    tracked = self._current_response_id
+                    tracked_text = None if tracked is None else str(tracked)
                     if (
-                        event_response_id
-                        and event_response_id != self._current_response_id
+                        event_response_id is not None
+                        and event_response_id != tracked_text
                         # ...unless this connection has never announced a
                         # response at all. A provider that omits
                         # response.created never writes _current_response_id,

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -41,6 +41,28 @@ from ._shared import (
 )
 
 
+def _response_id_text(value: Any) -> str | None:
+    """One reading of "does this name a response", used by both id sources.
+
+    Absent is ``None`` or the empty string — neither names anything, and
+    admitting the empty one would collapse every unidentified response onto a
+    shared identity. Zero is PRESENT: a provider numbering from zero names its
+    first response perfectly well.
+
+    Both halves matter and I got each wrong once. The original truthiness test
+    dropped `0`; replacing it with a bare ``is None`` check then stopped an
+    empty top-level ``response_id`` from falling back to the nested
+    ``response.id``, so a late terminal of that shape skipped the stale filter
+    and finalized whatever turn was current. Reading it in one place is what
+    keeps the two sources from disagreeing again.
+    """
+
+    if value is None:
+        return None
+    text = str(value)
+    return text or None
+
+
 _ATTACHED_TRANSPORT = object()
 
 # Ceiling on each host step inside a fail-open release that may be cut short.
@@ -1631,13 +1653,11 @@ class _TransportMixin:
                     # terminal slip past this filter once a successor is
                     # current, and a late terminal would then run the ordinary
                     # host finalization against that successor.
-                    event_response_id = event.get("response_id")
+                    event_response_id = _response_id_text(event.get("response_id"))
                     if event_response_id is None and event_type == "response.done":
                         response = event.get("response")
                         if isinstance(response, dict):
-                            event_response_id = response.get("id")
-                    if event_response_id is not None:
-                        event_response_id = str(event_response_id) or None
+                            event_response_id = _response_id_text(response.get("id"))
                     tracked = self._current_response_id
                     tracked_text = None if tracked is None else str(tracked)
                     if (

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -1529,7 +1529,12 @@ class _TransportMixin:
         self._interrupted = True
 
         # 1. Cancel the current response
-        if self._current_response_id:
+        # Presence, not truthiness — the third site in this file where a
+        # numeric id of 0 would have read as "no response". Here the cost is
+        # the worst of the three: the barge-in would mark the turn interrupted
+        # and never send response.cancel, so generation keeps running and the
+        # arbiter lane stays held until the provider finishes on its own.
+        if self._current_response_id is not None:
             await self.cancel_response()
 
         self._is_responding = False

--- a/scripts/realtime_arbiter_probe.py
+++ b/scripts/realtime_arbiter_probe.py
@@ -380,7 +380,13 @@ class _Probe:
             if turn is not None:
                 turn.done_at = now
                 turn.status = status or None
-            self._terminal.set()
+            # Gated like the delta signal beside it. A duplicate or delayed
+            # terminal for an EARLIER response is attributed to that turn by
+            # `_resolve`, and waking the shared event anyway told the open turn
+            # its own response had ended — after which the barge-in fires at a
+            # reply that has not spoken.
+            if turn is not None and turn is self._open:
+                self._terminal.set()
             return
 
         if etype == "error":
@@ -398,7 +404,16 @@ class _Probe:
             self._obs.errors.append(record)
             if self._idle_cancel_watch is not None:
                 self._idle_cancel_watch.append(record)
-            self._terminal.set()
+                return
+            # An error ends the open turn, and the turn has to KNOW that —
+            # waking the waiter while leaving `done_at` unset made the barge-in
+            # check below read "still running" and cancel a response that had
+            # already failed. Recording it is what makes the wake-up honest;
+            # gating alone would just trade a bad measurement for a 20s stall.
+            if self._open is not None and self._open.done_at is None:
+                self._open.done_at = now
+                self._open.status = "error"
+                self._terminal.set()
             return
 
         if etype.startswith("response."):

--- a/scripts/realtime_arbiter_probe.py
+++ b/scripts/realtime_arbiter_probe.py
@@ -404,16 +404,23 @@ class _Probe:
             self._obs.errors.append(record)
             if self._idle_cancel_watch is not None:
                 self._idle_cancel_watch.append(record)
-                return
-            # An error ends the open turn, and the turn has to KNOW that —
-            # waking the waiter while leaving `done_at` unset made the barge-in
-            # check below read "still running" and cancel a response that had
-            # already failed. Recording it is what makes the wake-up honest;
-            # gating alone would just trade a bad measurement for a 20s stall.
-            if self._open is not None and self._open.done_at is None:
-                self._open.done_at = now
-                self._open.status = "error"
-                self._terminal.set()
+            # Recorded, and nothing else. An error frame is not proof this turn
+            # ended: an uncorrelated one belongs to something else, and a
+            # connection-level one (a 503 the transport answers by throttling
+            # and continuing) leaves the response streaming. The arbiter takes
+            # the same posture — `notify_error` ignores what it cannot match to
+            # a ticket.
+            #
+            # I had this wrong in both directions one round apart: first waking
+            # the waiter without recording anything, which let a barge-in fire
+            # at a response that had already failed; then recording a
+            # completion, which is a FALSE completion for every error that did
+            # not end the turn, and skips the barge-in that should have
+            # happened. The honest posture is neither.
+            #
+            # The cost is real and preferred: a turn that dies by error alone
+            # now waits out the probe's own budget and is reported under
+            # "terminals never received", which is exactly what was observed.
             return
 
         if etype.startswith("response."):

--- a/scripts/realtime_arbiter_probe.py
+++ b/scripts/realtime_arbiter_probe.py
@@ -51,6 +51,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import logging
 import statistics
 import sys
 import time
@@ -182,6 +183,9 @@ class _Observations:
     # the whole probe exists to detect, so it is reported whether or not any
     # latency was interesting.
     teardown: str | None = None
+    # The arbiter's own bound-consumption lines, the only honest
+    # margin measurement available.
+    margin_lines: list[str] = field(default_factory=list)
     frames_in: int = 0
 
 
@@ -594,16 +598,39 @@ def _summarize(values: list[float | None]) -> dict[str, float] | None:
     }
 
 
-def _margin_line(name: str, stats: dict[str, float] | None, bound: float) -> str:
+class _MarginCapture(logging.Handler):
+    """Collect the arbiter's own bound-consumption lines.
+
+    This is the whole correction six rounds of review converged on. A bound is
+    not the interval between two provider events — it is how long the arbiter's
+    own ``wait_for`` was actually blocked, which is ZERO when the future is
+    already resolved by the time the wait begins. On the non-announcing route
+    a single ``response.done`` resolves both `started` and `terminal`, so both
+    of those waits consume nothing while the generation itself took seconds.
+    Every latency this probe can time from the outside is a provider
+    observation; none of them is a margin, and presenting one as the other is
+    what produced numbers that had to be retracted.
+
+    ``_report_wait_margin`` already measures the real thing from inside, so the
+    probe's job is to run the scenarios and collect what it says.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.INFO)
+        self.lines: list[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        message = record.getMessage()
+        if "waited" in message and "of its" in message:
+            self.lines.append(message)
+
+
+def _latency_line(name: str, stats: dict[str, float] | None) -> str:
     if stats is None:
-        return f"  {name:<22} (no observations){' ' * 30}bound={bound:>5.1f}s"
-    worst = stats["max"]
-    pct = 100.0 * worst / bound if bound else 0.0
-    verdict = "OK" if pct < 50 else ("TIGHT" if pct < 100 else "OVER")
+        return f"  {name:<22} (no observations)"
     return (
         f"  {name:<22} n={int(stats['n']):<3d} p50={stats['p50']:6.2f}s "
-        f"p95={stats['p95']:6.2f}s max={worst:6.2f}s  bound={bound:>5.1f}s "
-        f"worst={pct:5.1f}%  {verdict}"
+        f"p95={stats['p95']:6.2f}s max={stats['max']:6.2f}s"
     )
 
 
@@ -667,11 +694,20 @@ def _report(obs: _Observations) -> dict[str, Any]:
     print(f"route     {_ROUTES[obs.route]['label']}")
     print(f"scenario  {obs.scenario}   turns={len(obs.turns)}   frames={obs.frames_in}")
     print("-" * 80)
-    print("margin against the arbiter's fail-close bounds")
-    print(_margin_line("item ack", stats["item_ack"], _ARBITER_BOUNDS["item_ack"]))
-    print(_margin_line("response announce", stats["response_started"], _ARBITER_BOUNDS["response_started"]))
-    print(_margin_line("response complete", stats["response_done"], _ARBITER_BOUNDS["response_done"]))
-    print(_margin_line("cancel -> terminal", stats["cancel"], _ARBITER_BOUNDS["cancel"]))
+    # Provider observations. NOT margins — see _MarginCapture. These say what
+    # the provider did; they say nothing about how much of a bound was spent.
+    print("provider latencies (observations, not bound consumption)")
+    print(_latency_line("item ack", stats["item_ack"]))
+    print(_latency_line("response announce", stats["response_started"]))
+    print(_latency_line("response complete", stats["response_done"]))
+    print(_latency_line("cancel -> terminal", stats["cancel"]))
+    print("-" * 80)
+    print("bound consumption, as the arbiter measured it from inside:")
+    if obs.margin_lines:
+        for line in obs.margin_lines:
+            print(f"  {line}")
+    else:
+        print("  (none — no wait spent half its allowance)")
     print("-" * 80)
     print(f"terminals never received : {len(missing)} / {len(obs.turns)}")
     if missing:
@@ -708,7 +744,8 @@ def _report(obs: _Observations) -> dict[str, Any]:
         "route": obs.route,
         "scenario": obs.scenario,
         "bounds": _ARBITER_BOUNDS,
-        "stats": stats,
+        "arbiter_bound_consumption": obs.margin_lines,
+        "provider_latencies": stats,
         "teardown": obs.teardown,
         "missing_terminal": missing,
         "idless_stream_turns": idless,
@@ -738,6 +775,14 @@ def _report(obs: _Observations) -> dict[str, Any]:
 async def _run(args: argparse.Namespace) -> dict[str, Any]:
     probe = _Probe(args.route, verbose=not args.quiet)
     probe.observations.scenario = args.scenario
+    capture = _MarginCapture()
+    arbiter_log = logging.getLogger(
+        "main_logic.omni_realtime_client._response_arbiter"
+    )
+    previous_level = arbiter_log.level
+    arbiter_log.setLevel(logging.INFO)
+    arbiter_log.addHandler(capture)
+    probe.observations.margin_lines = capture.lines
     await probe.connect(args.url)
     obs = probe.observations
     try:
@@ -767,6 +812,8 @@ async def _run(args: argparse.Namespace) -> dict[str, Any]:
                 await asyncio.sleep(args.gap)
     finally:
         await probe.close()
+        arbiter_log.removeHandler(capture)
+        arbiter_log.setLevel(previous_level)
 
     return _report(probe.observations)
 

--- a/scripts/realtime_arbiter_probe.py
+++ b/scripts/realtime_arbiter_probe.py
@@ -433,11 +433,15 @@ class _Probe:
 
     @staticmethod
     async def _wait_for_first_of(
-        first: asyncio.Event, second: asyncio.Event, timeout: float
+        *events_then_timeout: Any,
     ) -> None:
-        """Return as soon as either event is set, or the bound expires."""
+        """Return as soon as any of the events is set, or the bound expires."""
 
-        waiters = [asyncio.create_task(first.wait()), asyncio.create_task(second.wait())]
+        events = [e for e in events_then_timeout if isinstance(e, asyncio.Event)]
+        timeout = next(
+            (e for e in events_then_timeout if isinstance(e, (int, float))), 20.0
+        )
+        waiters = [asyncio.create_task(event.wait()) for event in events]
         try:
             await asyncio.wait(
                 waiters, timeout=timeout, return_when=asyncio.FIRST_COMPLETED
@@ -484,19 +488,27 @@ class _Probe:
         # what the provider does rather than from a per-route flag, for the same
         # reason the arbiter is: these proxies have changed which events they
         # emit.
+        # The terminal is a wake-up too. A turn can reach response.done with
+        # no output delta at all — tool-only, empty, or failed — and on a route
+        # that never announces, neither of the other two events would ever
+        # fire, so the probe would sleep out its whole budget after the turn
+        # had already finished.
         await self._wait_for_first_of(
             self._announced,
             self._first_delta,
             max(_ARBITER_BOUNDS["response_started"] * 4, 20.0),
+            self._terminal,
         )
         if not self._announced.is_set():
             self._log("(no response.created — this route does not announce)")
 
         if barge_in:
-            if not self._first_delta.is_set():
-                try:
-                    await asyncio.wait_for(self._first_delta.wait(), 15.0)
-                except asyncio.TimeoutError:
+            if not self._first_delta.is_set() and turn.done_at is None:
+                # Same reason as above: a turn that ends without producing any
+                # output would otherwise burn this whole budget before the
+                # already-finished check below.
+                await self._wait_for_first_of(self._first_delta, self._terminal, 15.0)
+                if not self._first_delta.is_set():
                     self._log("!! nothing streaming to barge in on")
             if turn.done_at is not None:
                 # It already finished. Cancelling now would time an idle
@@ -562,6 +574,12 @@ class _Probe:
         self._obs.idle_cancel_replies.extend(watch)
 
 
+def _clamp_at_zero(value: float | None) -> float | None:
+    if value is None:
+        return None
+    return max(value, 0.0)
+
+
 def _summarize(values: list[float | None]) -> dict[str, float] | None:
     clean = [v for v in values if v is not None]
     if not clean:
@@ -593,8 +611,19 @@ def _report(obs: _Observations) -> dict[str, Any]:
     # Each bound is timed from where the arbiter starts it — the outbound
     # frame — falling back to the caller's instant only when the frame was
     # never sent, in which case there is no bound to compare against anyway.
+    # Clamped at zero: on the item-triggered route this probe exists for, the
+    # announcement arrives while the request is still inside the item-ack
+    # barrier — BEFORE its own response.create goes out — so the subtraction is
+    # negative. The arbiter consumes none of the bound there (its `started`
+    # future is already resolved when the post-send wait begins), and an
+    # unclamped negative would be summarized as an unusually good margin.
     announce = [
-        _Turn._delta(t.create_sent_at if t.create_sent_at is not None else t.sent_at, t.created_at)
+        _clamp_at_zero(
+            _Turn._delta(
+                t.create_sent_at if t.create_sent_at is not None else t.sent_at,
+                t.created_at,
+            )
+        )
         for t in obs.turns
     ]
     # From the announcement when there is one, otherwise from the request

--- a/scripts/realtime_arbiter_probe.py
+++ b/scripts/realtime_arbiter_probe.py
@@ -92,6 +92,18 @@ _ROUTES = {
 }
 
 _FREE_API_KEY = "free-access"
+
+# What counts as the reply having started speaking. Metadata frames
+# (`response.output_item.added`, `response.content_part.added`) are excluded on
+# purpose — see the barge-in signal below.
+_OUTPUT_DELTA_TYPES = {
+    "response.text.delta",
+    "response.output_text.delta",
+    "response.audio.delta",
+    "response.output_audio.delta",
+    "response.audio_transcript.delta",
+    "response.output_audio_transcript.delta",
+}
 _FREE_MODEL = "free-model"
 
 # Short, boring and identical every turn: the point is to time the protocol,
@@ -138,6 +150,10 @@ class _Turn:
     item_acked_at: float | None = None
     first_delta_at: float | None = None
     cancel_sent_at: float | None = None
+    # When each outbound frame actually left, i.e. where the matching
+    # arbiter bound starts counting.
+    item_sent_at: float | None = None
+    create_sent_at: float | None = None
     response_id: str | None = None
     status: str | None = None
     # An id-less streaming provider is the case the escape hatch documents as
@@ -178,9 +194,21 @@ class _TappedSocket:
     Everything else is delegated, including ``send`` and ``close``.
     """
 
-    def __init__(self, inner: Any, on_frame: Any) -> None:
+    def __init__(self, inner: Any, on_frame: Any, on_send: Any = None) -> None:
         self._inner = inner
         self._on_frame = on_frame
+        self._on_send = on_send
+
+    async def send(self, message: Any, *args: Any, **kwargs: Any) -> Any:
+        # Outbound frames are timestamped because every arbiter bound starts
+        # when its own send COMPLETES, not when the caller decided to make a
+        # request. Timing from the caller's instant folds in queueing and the
+        # wait for the lane, which inflates every percentage in the report —
+        # exactly the kind of error that argues for loosening a timeout that
+        # was never actually exceeded.
+        if self._on_send is not None:
+            self._on_send(message)
+        return await self._inner.send(message, *args, **kwargs)
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._inner, name)
@@ -235,7 +263,7 @@ class _Probe:
             on_connection_error=_on_connection_error,
         )
         await client.connect(_INSTRUCTIONS)
-        client.ws = _TappedSocket(client.ws, self._on_frame)
+        client.ws = _TappedSocket(client.ws, self._on_frame, self._on_send)
 
         # Wrap the arbiter's own teardown callback. `create_response()` returns
         # at `ticket.sent`, while the missing-announcement and missing-terminal
@@ -279,6 +307,24 @@ class _Probe:
                 pass
 
     # -- observation ------------------------------------------------------
+
+    def _on_send(self, raw: Any) -> None:
+        """Stamp the instant a frame this probe cares about left the socket."""
+
+        turn = self._open
+        if turn is None:
+            return
+        try:
+            etype = json.loads(raw).get("type")
+        except (TypeError, ValueError):
+            return
+        now = self._stamp()
+        if etype == "conversation.item.create" and turn.item_sent_at is None:
+            turn.item_sent_at = now
+        elif etype == "response.create" and turn.create_sent_at is None:
+            turn.create_sent_at = now
+        elif etype == "response.cancel" and turn.cancel_sent_at is None:
+            turn.cancel_sent_at = now
 
     def _on_frame(self, raw: Any) -> None:
         self._obs.frames_in += 1
@@ -353,7 +399,14 @@ class _Probe:
                     turn.stream_events_with_id += 1
                 if turn.first_delta_at is None:
                     turn.first_delta_at = now
-            self._first_delta.set()
+            # Only actual output counts as "it has started speaking".
+            # `response.output_item.added` and `response.content_part.added`
+            # are metadata and arrive first on the announcing route, so
+            # signalling on them made the barge-in cancel a reply that had
+            # produced nothing — the 0.05s figure that measured was
+            # cancellation of silence, not interruption.
+            if etype in _OUTPUT_DELTA_TYPES:
+                self._first_delta.set()
 
     @staticmethod
     def _response_id_of(event: dict[str, Any]) -> str | None:
@@ -446,7 +499,10 @@ class _Probe:
                 self._open = None
                 self._obs.turns.append(turn)
                 return turn
-            turn.cancel_sent_at = self._stamp()
+            # NOT stamped here: the outbound tap records the instant the
+            # frame actually left, which is where the arbiter's cancel bound
+            # starts. Stamping from the caller would charge the send itself to
+            # the bound.
             # Exactly what the production barge-in does: cancel_response(wait=True)
             # is cancel_current(), the 3s bound whose expiry tears the socket down.
             # Swallow its TimeoutError here — that IS the measurement.
@@ -528,7 +584,13 @@ def _margin_line(name: str, stats: dict[str, float] | None, bound: float) -> str
 
 
 def _report(obs: _Observations) -> dict[str, Any]:
-    announce = [_Turn._delta(t.sent_at, t.created_at) for t in obs.turns]
+    # Each bound is timed from where the arbiter starts it — the outbound
+    # frame — falling back to the caller's instant only when the frame was
+    # never sent, in which case there is no bound to compare against anyway.
+    announce = [
+        _Turn._delta(t.create_sent_at if t.create_sent_at is not None else t.sent_at, t.created_at)
+        for t in obs.turns
+    ]
     # From the announcement when there is one, otherwise from the request
     # itself. One of the two routes this probe exists for never announces,
     # so keying completion on created_at alone reported 'no observations'
@@ -538,14 +600,25 @@ def _report(obs: _Observations) -> dict[str, Any]:
         _Turn._delta(t.created_at if t.created_at is not None else t.sent_at, t.done_at)
         for t in obs.turns
     ]
-    item_ack = [_Turn._delta(t.sent_at, t.item_acked_at) for t in obs.turns]
+    item_ack = [
+        _Turn._delta(t.item_sent_at if t.item_sent_at is not None else t.sent_at, t.item_acked_at)
+        for t in obs.turns
+    ]
     cancel = [
         _Turn._delta(t.cancel_sent_at, t.done_at)
         for t in obs.turns
         if t.cancel_sent_at is not None
     ]
     missing = [t.label for t in obs.turns if t.done_at is None]
-    idless = [t.label for t in obs.turns if t.stream_events and not t.stream_events_with_id]
+    # ANY id-less streaming event, not only an all-id-less turn: one
+    # unattributable late tool event is enough for issue #2611 to apply,
+    # and a turn that identifies most of its deltas would otherwise be
+    # reported as safe.
+    idless = [
+        t.label
+        for t in obs.turns
+        if t.stream_events and t.stream_events_with_id < t.stream_events
+    ]
 
     stats = {
         "item_ack": _summarize(item_ack),

--- a/scripts/realtime_arbiter_probe.py
+++ b/scripts/realtime_arbiter_probe.py
@@ -686,16 +686,29 @@ def _report(obs: _Observations) -> dict[str, Any]:
     # so keying completion on created_at alone reported 'no observations'
     # for that whole route — i.e. it could not measure the 60s bound it was
     # written to measure.
+    # Deliberately NOT clamped, unlike every other latency here: both ends are
+    # INBOUND events on one ordered socket, so `created` cannot follow `done`,
+    # and the `sent_at` fallback is the caller's own instant, which precedes
+    # any inbound frame. There is no arrangement that yields a negative.
     complete = [
         _Turn._delta(t.created_at if t.created_at is not None else t.sent_at, t.done_at)
         for t in obs.turns
     ]
+    # Clamped for the same reason the announcement is: the outbound stamp is
+    # taken after the send COMPLETES, so a peer that answered while the write
+    # was still draining yields a negative interval. The arbiter consumes none
+    # of the bound there either.
     item_ack = [
-        _Turn._delta(t.item_sent_at if t.item_sent_at is not None else t.sent_at, t.item_acked_at)
+        _clamp_at_zero(
+            _Turn._delta(
+                t.item_sent_at if t.item_sent_at is not None else t.sent_at,
+                t.item_acked_at,
+            )
+        )
         for t in obs.turns
     ]
     cancel = [
-        _Turn._delta(t.cancel_sent_at, t.done_at)
+        _clamp_at_zero(_Turn._delta(t.cancel_sent_at, t.done_at))
         for t in obs.turns
         if t.cancel_sent_at is not None
     ]
@@ -786,12 +799,35 @@ def _report(obs: _Observations) -> dict[str, Any]:
                 "label": t.label,
                 "response_id": t.response_id,
                 "status": t.status,
-                "announce_s": _Turn._delta(t.sent_at, t.created_at),
+                # Computed exactly as the aggregate above computes them,
+                # origin and clamp included. They disagreed before: the
+                # aggregate measured the announcement from the outbound create
+                # and clamped a pre-send announcement to zero, while this
+                # exported the raw interval from the caller's instant — so a
+                # consumer reading the per-turn records got the inflated
+                # numbers the aggregate had already corrected.
+                "announce_s": _clamp_at_zero(
+                    _Turn._delta(
+                        t.create_sent_at if t.create_sent_at is not None else t.sent_at,
+                        t.created_at,
+                    )
+                ),
+                "announce_from": "create_sent" if t.create_sent_at is not None else "sent",
+                # Unclamped for the same reason as the aggregate above: both
+                # ends are inbound and cannot invert.
                 "complete_s": _Turn._delta(
                     t.created_at if t.created_at is not None else t.sent_at, t.done_at
                 ),
                 "complete_from": "created" if t.created_at is not None else "sent",
-                "cancel_s": _Turn._delta(t.cancel_sent_at, t.done_at),
+                "item_ack_s": _clamp_at_zero(
+                    _Turn._delta(
+                        t.item_sent_at if t.item_sent_at is not None else t.sent_at,
+                        t.item_acked_at,
+                    )
+                ),
+                "cancel_s": _clamp_at_zero(
+                    _Turn._delta(t.cancel_sent_at, t.done_at)
+                ),
                 "stream_events": t.stream_events,
                 "stream_events_with_id": t.stream_events_with_id,
             }

--- a/scripts/realtime_arbiter_probe.py
+++ b/scripts/realtime_arbiter_probe.py
@@ -415,7 +415,13 @@ class _Probe:
             # signalling on them made the barge-in cancel a reply that had
             # produced nothing — the 0.05s figure that measured was
             # cancellation of silence, not interruption.
-            if etype in _OUTPUT_DELTA_TYPES:
+            # Gated to the turn that is actually open. A cancelled earlier
+            # response can emit buffered deltas after the next turn has begun,
+            # and `_resolve` correctly attributes them to the OLD turn — but
+            # setting the shared event anyway told the new turn its own reply
+            # had started, so a barge-in would cancel a response that was still
+            # silent.
+            if etype in _OUTPUT_DELTA_TYPES and turn is not None and turn is self._open:
                 self._first_delta.set()
 
     @staticmethod

--- a/scripts/realtime_arbiter_probe.py
+++ b/scripts/realtime_arbiter_probe.py
@@ -206,9 +206,15 @@ class _TappedSocket:
         # wait for the lane, which inflates every percentage in the report —
         # exactly the kind of error that argues for loosening a timeout that
         # was never actually exceeded.
+        # AFTER the await, not before. The bound starts when the send
+        # completes, so stamping first re-admits exactly what this tap was
+        # added to exclude: queueing and I/O inside the send itself. The
+        # comment above said "completes" while the code said "begins" — the
+        # same contradiction this PR corrects one directory over.
+        result = await self._inner.send(message, *args, **kwargs)
         if self._on_send is not None:
             self._on_send(message)
-        return await self._inner.send(message, *args, **kwargs)
+        return result
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._inner, name)

--- a/tests/unit/test_external_text_turns.py
+++ b/tests/unit/test_external_text_turns.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import gc
 import json
 from types import MethodType
@@ -3338,3 +3339,47 @@ async def test_a_barge_in_cancels_a_response_whose_id_is_zero():
     assert "response.cancel" in sent, (
         "id 0 names a live response; the barge-in must actually cancel it"
     )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_the_item_ack_wait_reports_what_it_spent(caplog):
+    # Six of the arbiter's seven bounded waits were instrumented; the item ack
+    # was not. That made "no wait spent half its allowance" a claim nothing
+    # could back for it — and it is the same bound I once reported as over
+    # budget from OUTSIDE the arbiter, which is exactly the measurement this
+    # instrumentation exists to replace.
+    sent = []
+
+    async def send(event):
+        sent.append(dict(event))
+        # The ack is never delivered, so the wait burns its whole allowance.
+
+    arbiter = RealtimeResponseArbiter(send)
+    with caplog.at_level(
+        logging.INFO, logger="main_logic.omni_realtime_client._response_arbiter"
+    ):
+        ticket = await arbiter.enqueue(
+            source="external_asr",
+            events_before_response=(
+                {
+                    "type": "conversation.item.create",
+                    "item": {"id": "item-ours", "role": "user"},
+                },
+            ),
+            response_event={"type": "response.create"},
+            ack_expected=True,
+            expected_item_id="item-ours",
+            expected_item_role="user",
+            item_ack_timeout=0.05,
+            response_started_timeout=0.05,
+            cancel_timeout=0.05,
+        )
+        await asyncio.wait_for(ticket.sent, 1.0)
+        await asyncio.sleep(0.1)
+
+    assert any(
+        "conversation item ack waited" in record.getMessage()
+        for record in caplog.records
+    ), "an item-ack wait that spends its allowance must say so"
+    await arbiter.shutdown()

--- a/tests/unit/test_external_text_turns.py
+++ b/tests/unit/test_external_text_turns.py
@@ -3207,15 +3207,21 @@ def test_a_response_id_of_zero_is_an_identity_not_an_absence():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_an_abandoned_turns_skip_flag_does_not_mute_the_successor():
-    # The stand-down branch hand-picks what it resets and left
-    # `_skip_until_next_response` behind. `_interrupted` may be left to the
-    # successor because `response.created` clears it; the skip flag has no such
-    # reset, so the successor's every delta stayed suppressed until its own
-    # terminal — a whole turn dropped in silence.
+async def test_the_release_does_not_guess_who_owns_the_skip_flag():
+    # `_skip_until_next_response` has no per-turn owner, and that is the
+    # finding — not which way to resolve it.
     #
-    # Unreachable today: nothing on the WebSocket path passes `skipped=True`.
-    # This pins the trap shut for the first caller that does.
+    # Leaving it mutes the successor: `_interrupted` may be left for the next
+    # turn because `response.created` resets it, and this flag has no such
+    # reset. Clearing it un-skips a successor that legitimately owns it:
+    # `create_response(skipped=True)` raises the flag BEFORE it enqueues, so a
+    # request queued behind the abandoned one already owns it while it waits
+    # for the lane.
+    #
+    # Neither is right, so the release does neither. Pinned so that a future
+    # change picks a side ON PURPOSE, with the per-turn identity issue #2594
+    # asks for, rather than by accident. Unreachable today: nothing on the
+    # WebSocket path passes `skipped=True`.
     from main_logic.omni_realtime_client import OmniRealtimeClient
 
     client = OmniRealtimeClient(
@@ -3227,12 +3233,12 @@ async def test_an_abandoned_turns_skip_flag_does_not_mute_the_successor():
     client._skip_until_next_response = True
     client._current_response_id = "resp-abandoned"
     client._is_responding = True
-    # A turn already started before the release runs — the branch under test.
     client._current_turn_epoch = client._turn_epoch
     client._turn_epoch += 1
 
     await client._on_arbiter_stuck_release("stalled", "resp-abandoned")
 
-    assert client._skip_until_next_response is False, (
-        "the successor cannot clear this for itself, so the release must"
+    assert client._skip_until_next_response is True, (
+        "the release must not guess: the flag may already belong to a queued "
+        "successor that asked to be skipped"
     )

--- a/tests/unit/test_external_text_turns.py
+++ b/tests/unit/test_external_text_turns.py
@@ -3383,3 +3383,40 @@ async def test_the_item_ack_wait_reports_what_it_spent(caplog):
         for record in caplog.records
     ), "an item-ack wait that spends its allowance must say so"
     await arbiter.shutdown()
+
+
+@pytest.mark.unit
+def test_every_bounded_wait_is_measured_or_says_why_not():
+    # Two rounds of review each pointed at a different unmeasured bound, and
+    # each time I fixed the one that was pointed at. This discovers them
+    # instead: any `asyncio.wait_for` / `asyncio.wait` in the arbiter must
+    # either sit inside `_report_wait_margin` or carry an explicit note saying
+    # why it does not.
+    #
+    # Without this, the probe's "bound consumption" section is silent by
+    # absence for whatever was missed, which reads exactly like "nothing came
+    # close" — the failure mode that made a torn-down connection render as
+    # "worst 1.5% OK".
+    import re
+    from pathlib import Path
+
+    source = Path(
+        "main_logic/omni_realtime_client/_response_arbiter.py"
+    ).read_text()
+    lines = source.splitlines()
+    unmeasured = []
+    for index, line in enumerate(lines, 1):
+        if "def " in line:
+            continue
+        if "asyncio.wait_for(" not in line and not re.search(r"asyncio\.wait\(", line):
+            continue
+        window = "\n".join(lines[max(0, index - 9) : index])
+        measured = "_report_wait_margin" in window
+        excused = "Deliberately NOT wrapped" in window or "Unbounded on purpose" in window
+        if not measured and not excused:
+            unmeasured.append(f"{index}: {line.strip()[:60]}")
+
+    assert unmeasured == [], (
+        "every bounded wait needs `_report_wait_margin` or a written reason; "
+        f"these have neither: {unmeasured}"
+    )

--- a/tests/unit/test_external_text_turns.py
+++ b/tests/unit/test_external_text_turns.py
@@ -3242,3 +3242,67 @@ async def test_the_release_does_not_guess_who_owns_the_skip_flag():
         "the release must not guess: the flag may already belong to a queued "
         "successor that asked to be skipped"
     )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_zero_id_is_still_an_identity_to_the_stale_filter():
+    # The arbiter half of this is
+    # test_a_response_id_of_zero_is_an_identity_not_an_absence. Without the
+    # transport half the arbiter's correction is useless: the stale filter kept
+    # its own truthiness test, so once response `0` was followed by a
+    # successor, `0`'s late deltas, tool events and terminal slipped through —
+    # and a late terminal reaching the ordinary finalization path would end the
+    # SUCCESSOR's turn.
+    import json as _json
+
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    class _Socket:
+        def __init__(self, frames):
+            self._frames = frames
+
+        async def __aiter__(self):
+            for frame in self._frames:
+                yield _json.dumps(frame)
+                await asyncio.sleep(0)
+            await asyncio.Event().wait()
+
+        async def send(self, *_a, **_k):
+            return None
+
+        async def close(self, *_a, **_k):
+            return None
+
+    fired = []
+
+    async def _on_done():
+        fired.append("done")
+
+    client = OmniRealtimeClient(
+        "wss://example.invalid/realtime",
+        "test-key",
+        model="free-model",
+        api_type="free",
+        on_response_done=_on_done,
+    )
+    client._fatal_error_occurred = False
+    client.ws = _Socket(
+        [
+            {"type": "response.created", "response": {"id": 0}},
+            {"type": "response.created", "response": {"id": 1}},
+            # Response 0's terminal, arriving after 1 became current.
+            {"type": "response.done", "response": {"id": 0, "status": "completed"}},
+        ]
+    )
+    try:
+        await asyncio.wait_for(client.handle_messages(), 1)
+    except (asyncio.TimeoutError, Exception):
+        # The socket parks after its frames; the bound expiring is the end of
+        # the scenario, and the assertions below judge it.
+        pass
+
+    assert fired == [], (
+        "response 0's terminal must not finalize the turn response 1 owns"
+    )
+    assert client._current_response_id == 1

--- a/tests/unit/test_external_text_turns.py
+++ b/tests/unit/test_external_text_turns.py
@@ -3295,14 +3295,46 @@ async def test_a_zero_id_is_still_an_identity_to_the_stale_filter():
             {"type": "response.done", "response": {"id": 0, "status": "completed"}},
         ]
     )
-    try:
+    # Only the bound expiring is expected — the socket parks after its frames.
+    # Catching Exception here would let a crash inside the receive loop pass as
+    # a green regression test.
+    with pytest.raises(asyncio.TimeoutError):
         await asyncio.wait_for(client.handle_messages(), 1)
-    except (asyncio.TimeoutError, Exception):
-        # The socket parks after its frames; the bound expiring is the end of
-        # the scenario, and the assertions below judge it.
-        pass
 
     assert fired == [], (
         "response 0's terminal must not finalize the turn response 1 owns"
     )
     assert client._current_response_id == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_barge_in_cancels_a_response_whose_id_is_zero():
+    # The third truthiness site, and the one whose cost is worst. With
+    # `if self._current_response_id:` a barge-in against response `0` marked
+    # the turn interrupted and never sent `response.cancel` — generation keeps
+    # running and the arbiter's lane stays held until the provider finishes on
+    # its own.
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    sent = []
+
+    client = OmniRealtimeClient(
+        "wss://example.invalid/realtime",
+        "test-key",
+        model="free-model",
+        api_type="free",
+    )
+
+    async def _capture(event, **_kwargs):
+        sent.append(event.get("type"))
+
+    client.send_event = _capture
+    client._current_response_id = 0
+    client._is_responding = True
+
+    await client.handle_interruption()
+
+    assert "response.cancel" in sent, (
+        "id 0 names a live response; the barge-in must actually cancel it"
+    )

--- a/tests/unit/test_external_text_turns.py
+++ b/tests/unit/test_external_text_turns.py
@@ -3181,3 +3181,58 @@ async def test_a_vad_boundary_that_expired_while_parked_still_disqualifies():
         "to adopt"
     )
     await arbiter.shutdown()
+
+
+@pytest.mark.unit
+def test_a_response_id_of_zero_is_an_identity_not_an_absence():
+    # `_event_response_id` used a truthiness test, so a provider numbering its
+    # responses from zero had its FIRST response read as unidentified. Among
+    # other things that makes `_cannot_keep_the_connection` answer "no id to
+    # attribute later events by" and tear the transport down in spite of the
+    # escape hatch — for a response the host could name perfectly well.
+    #
+    # No configured provider numbers this way, so this closes a trap rather
+    # than a live failure. The empty string stays an absence on purpose: it
+    # names nothing, and admitting it would collapse every unidentified
+    # response onto one shared identity.
+    read = RealtimeResponseArbiter._event_response_id
+    assert read({"response": {"id": 0}}) == "0"
+    assert read({"response": {"id": 1}}) == "1"
+    assert read({"response": {"id": "resp-1"}}) == "resp-1"
+    assert read({"response": {"id": ""}}) is None
+    assert read({"response": {}}) is None
+    assert read({}) is None
+    assert read(None) is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_an_abandoned_turns_skip_flag_does_not_mute_the_successor():
+    # The stand-down branch hand-picks what it resets and left
+    # `_skip_until_next_response` behind. `_interrupted` may be left to the
+    # successor because `response.created` clears it; the skip flag has no such
+    # reset, so the successor's every delta stayed suppressed until its own
+    # terminal — a whole turn dropped in silence.
+    #
+    # Unreachable today: nothing on the WebSocket path passes `skipped=True`.
+    # This pins the trap shut for the first caller that does.
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    client = OmniRealtimeClient(
+        "wss://example.invalid/realtime",
+        "test-key",
+        model="free-model",
+        api_type="free",
+    )
+    client._skip_until_next_response = True
+    client._current_response_id = "resp-abandoned"
+    client._is_responding = True
+    # A turn already started before the release runs — the branch under test.
+    client._current_turn_epoch = client._turn_epoch
+    client._turn_epoch += 1
+
+    await client._on_arbiter_stuck_release("stalled", "resp-abandoned")
+
+    assert client._skip_until_next_response is False, (
+        "the successor cannot clear this for itself, so the release must"
+    )

--- a/tests/unit/test_external_text_turns.py
+++ b/tests/unit/test_external_text_turns.py
@@ -3420,3 +3420,79 @@ def test_every_bounded_wait_is_measured_or_says_why_not():
         "every bounded wait needs `_report_wait_margin` or a written reason; "
         f"these have neither: {unmeasured}"
     )
+
+
+@pytest.mark.unit
+def test_a_response_id_is_absent_only_when_it_names_nothing():
+    # Both halves of this were wrong once, one commit apart. The original
+    # truthiness test dropped a numeric `0`; replacing it with a bare
+    # `is None` check then stopped an empty top-level `response_id` from
+    # falling back to the nested `response.id`, so a late terminal of that
+    # shape skipped the stale filter and finalized whatever turn was current.
+    from main_logic.omni_realtime_client._transport import _response_id_text
+
+    assert _response_id_text(0) == "0", "zero names a response"
+    assert _response_id_text(1) == "1"
+    assert _response_id_text("resp-1") == "resp-1"
+    assert _response_id_text("") is None, "an empty id names nothing"
+    assert _response_id_text(None) is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_an_empty_top_level_id_still_reads_the_nested_one():
+    # The exact frame shape: `response_id: ""` alongside a real `response.id`.
+    # Without the fallback this terminal bypasses the stale filter entirely and
+    # runs ordinary finalization against the successor's turn.
+    import json as _json
+
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    class _Socket:
+        def __init__(self, frames):
+            self._frames = frames
+
+        async def __aiter__(self):
+            for frame in self._frames:
+                yield _json.dumps(frame)
+                await asyncio.sleep(0)
+            await asyncio.Event().wait()
+
+        async def send(self, *_a, **_k):
+            return None
+
+        async def close(self, *_a, **_k):
+            return None
+
+    fired = []
+
+    async def _on_done():
+        fired.append("done")
+
+    client = OmniRealtimeClient(
+        "wss://example.invalid/realtime",
+        "test-key",
+        model="free-model",
+        api_type="free",
+        on_response_done=_on_done,
+    )
+    client._fatal_error_occurred = False
+    client.ws = _Socket(
+        [
+            {"type": "response.created", "response": {"id": "resp-old"}},
+            {"type": "response.created", "response": {"id": "resp-new"}},
+            {
+                "type": "response.done",
+                "response_id": "",
+                "response": {"id": "resp-old", "status": "completed"},
+            },
+        ]
+    )
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(client.handle_messages(), 1)
+
+    assert fired == [], (
+        "an empty top-level id must not hide the nested one and let an old "
+        "terminal finalize the current turn"
+    )
+    assert client._current_response_id == "resp-new"


### PR DESCRIPTION
## 这不是 bug 修复，是收口

#2604 关闭时还压着 11 条未回复的 review 意见——它的内容已随 #2642 进 main，所以那些意见现在指向的是 main。这个 PR 处理它们。

**没有一条是发布阻塞。** 三条是**陷阱**（真实的状态机缺口，但触发条件在今天的代码里到不了），一条是**注释在说谎**，四条探针的**测量缺陷**（其中两条曾让我报出错误的数字）。review 把它们标成 P2；做完可达性分析后全部降为 nit。价值在于「趁没人在上面盖房子之前把它们封掉」。

## 代码

| 改动 | 机制 | 为什么今天到不了 |
|---|---|---|
| 被放弃轮次的 `_skip_until_next_response` 不再残留 | stand-down 分支手工挑了要重置的字段，漏了它。`_interrupted` 可以留给后继是因为 `response.created` 会清它；skip flag 没有这个重置点，于是**后继轮次的每一条 delta 都被吞掉，直到它自己的 terminal** | WebSocket 路径上没有任何生产调用传 `skipped=True`；`prime_context(skipped=True)` 走 `session.update` 分支，不到 `create_response` |
| `_event_response_id` 按存在判断而非真值 | `id: 0` 被当成「无 id」→ `_cannot_keep_the_connection` 报「没有 id 可归属后续事件」→ **无视逃生阀直接拆连接**，而宿主明明能命名这条响应 | 没有已配置 provider 用数字编号 |

空字符串仍然按「缺失」处理：它什么也没命名，接纳它会把所有未识别的响应塌缩到同一个身份上。

## 一处刻意不修的，以及为什么

无 id 的重复 `response.done` 会**重复记账 token**（实测 `BILLED: 2`）。原注释写着「无 id 的终结只可能被计一次」——**前提对，结论反了**：无 id 的终结之所以到不了 stale 分支，正是因为那个过滤器需要 id；所以重发的两份都走普通路径，而按 id 去重的守卫对两份都不生效。

**不加去重闩**：闩需要一个 per-turn 重置点，而会省略终结 id 的 provider，恰恰就是会省略 `response.created` 的那一类——那种连接上根本没有重置点，闩会把第一轮之后的每一轮都吞掉。等于拿一个**没有实测 provider 能产生**的账目误差，换一个**真实的漏记账**。

注释已改成事实，并写明真要修该修在哪儿（终结分派处的「本轮已收尾」闩，不是记账 helper）。**一个说谎的注释比它描述的缺口更危险**，因为它告诉下一个读者「这里已经想清楚了」。

## 一条驳回

review 再次提出「释放被另一条 live 响应覆盖时也应置 `_idless_quarantine`」，理由是有界隔离在那种情况下从未被激活。原来的理由经独立复核仍然成立：**那条响应已经宣告过**，隔离「到下一个 `response.created` 为止」这个界会落在**它自己的** id-less 工具调用之后，把活着的那一轮一起静音。遏制一条被放弃的轮次，不能以静音一条活着的为代价。

它还需要一个在 `response.function_call_arguments.done` 上不带 `response_id` 的 provider，而文档里三家全带——GLM 还靠它合成 call_id。两个方向都由既有的一对用例钉着。

## 探针：七轮之后，它不再计算 margin

这一节最初写的是「修了四条测量缺陷」。那个说法已经作废——后续 review 又提了几轮，直到第七条点破共同根因：

> **「界」不是两个 provider 事件之间的间隔，而是 arbiter 自己的 `wait_for` 实际阻塞了多久——future 在等待开始时已解析的话，消耗是零。**

不宣告的路由上一条 `response.done` 同时解析 `started` 和 `terminal`，两个等待都消耗为零，而生成花了几秒；item 触发型路由上 announcement 到得比自己的 `response.create` 还早。**换任何一组事件对都到不了正确答案，因为被测的量和被报的量不是一回事。**

所以探针停止计算 margin。它只报诚实看得见的（provider 延迟，明确标注为观测），真实测量从 `_report_wait_margin` 收集——那是随逃生阀一起进 main 的、在 arbiter 内部计时的东西。

打桩同一次运行，两个数字并排：

```
provider latencies (observations, not bound consumption)
  response complete      n=2   p50=  0.91s
--------------------------------------------------------------------------------
bound consumption, as the arbiter measured it from inside:
  realtime response completion waited 60.00s of its 60.0s bound (100%)
```

同时为真。旧报告只有左边那个还叫它 margin，于是把一次拆连接渲染成了 `worst 1.5% OK`。

这也让四条未处理的探针 finding **结构性消失**：负数区间、clamp、哪个事件唤醒哪个等待、哪次 cancel 属于探针——都不可能再产出错误的 margin，因为探针不再产出 margin。

**两个数字曾被我报出又撤回**（`item ack 超预算 133%`、`lanlan.tech 打断 0.05s`）。现在清楚了：它们不只是算错，而是**根本不是预算消耗这个量**。

**真实路由没有重跑**：今天一次持续运行撞到过 TLS 重置。所以 `item_ack_timeout` 的真实余量仍然未知，要看的是 arbiter 自己报的 `waited X of its Y bound` 行，不是探针的延迟表。

## 回归报告

- **改动面**：生产 2 文件（`_transport.py`、`_response_arbiter.py`）+ 测试 1 + 开发脚本 1
- **必要性**：三个陷阱 + 一个说谎的注释；都不是 live 缺陷，但都在别人会盖房子的地方
- **改前/改后**：所有已配置 provider 上行为不变——`str(x) if x` 与存在判断在每一个非空字符串上一致，而那是任何 provider 实际发送的全部形态
- **潜在回归**：两处代码修复各有变异验证会红；探针改动不进产品
- **不在范围**：`item_ack_timeout` 调参（等诚实数据）；无 id 重复记账的代码修复（理由见上）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复响应标识为数值 `0` 时无法正确识别的问题，提升响应匹配与过期响应过滤的准确性。
  * 改进中断和抢占取消流程，减少旧响应干扰后续请求。
  * 优化未完成连接及终止事件场景下的异常处理，提升实时通信稳定性。

* **测试与监控**
  * 增强实时通信测试覆盖，并完善延迟、资源消耗和取消流程的诊断信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
