### PR TITLE
测试：收窄 CAM++ legacy 路径守卫

### DIFF
--- a/tests/unit/asr_client/speaker_shadow/test_campplus_distribution_contracts.py
+++ b/tests/unit/asr_client/speaker_shadow/test_campplus_distribution_contracts.py
@@ -99,7 +99,9 @@ def test_ignore_rules_keep_only_reviewable_campplus_metadata() -> None:
 
 
 def test_legacy_voice_identity_and_model_locations_are_absent() -> None:
-    assert not (ROOT / "main_logic" / "voice_identity").exists()
+    voice_identity = ROOT / "main_logic" / "voice_identity"
+    assert not (voice_identity / "runtime.py").exists()
+    assert not (voice_identity / "campplus.py").exists()
     assert not (ROOT / "data" / "speaker_models").exists()
     assert not (ROOT / "tools" / "voice_eval").exists()
     assert not (ROOT / "main_logic" / "asr_client" / "campplus.py").exists()


### PR DESCRIPTION
## 改动概述

#2450 的分发合同测试将整个 `main_logic/voice_identity/` 目录判定为 legacy，因而阻止 #2459 引入 provider-neutral 的内存身份、引用与 Profile 合同。本 PR 将该断言收窄为只禁止已废弃的 `voice_identity/runtime.py` 与 `voice_identity/campplus.py`。

原有对 `data/speaker_models`、`tools/voice_eval` 以及旧 ASR CAM++ 入口的守卫保持不变。

## 风险与边界

仅修改测试断言，不改变生产代码、打包逻辑或运行时行为。允许的是合同层包目录本身；具体 CAM++ 实现和运行时接线仍不得回到该目录。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 更新遗留路径检查，分别验证指定的旧版运行时和模型文件不存在。
  * 保留其他旧模型及工具路径的校验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->