### PR TITLE
fix(realtime): Lanlan 端点必须带 www——一个探针在裸域名上真连

### DIFF
--- a/scripts/test_tts_websocket_probe.py
+++ b/scripts/test_tts_websocket_probe.py
@@ -16,7 +16,7 @@
 """
 Probe lanlan.app free TTS WebSocket and log raw handshake failures.
 
-Default URL is hardcoded to wss://lanlan.app/tts (no GeoIP / lanlan.tech switching).
+Default URL is hardcoded to wss://www.lanlan.app/tts (no GeoIP / www.lanlan.tech switching).
 
 Use when debugging HTTP 503 (or other non-101) during the WebSocket upgrade: the
 ``websockets`` library raises InvalidStatus with the full HTTP response attached.
@@ -50,7 +50,12 @@ from websockets.exceptions import InvalidStatus
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # Fixed probe target (do not route via ConfigManager GeoIP).
-DEFAULT_TTS_WSS_URL = "wss://lanlan.app/tts"
+#
+# The `www.` is required: the bare apex does not serve these endpoints, so a
+# probe pointed at it reports a handshake failure caused by its own URL rather
+# than by the service — which is the one thing a script whose whole purpose is
+# "log raw handshake failures" must not do.
+DEFAULT_TTS_WSS_URL = "wss://www.lanlan.app/tts"
 
 
 def _setup_logging(log_path: Path | None) -> logging.Logger:

--- a/scripts/test_tts_websocket_probe.py
+++ b/scripts/test_tts_websocket_probe.py
@@ -24,7 +24,7 @@ Use when debugging HTTP 503 (or other non-101) during the WebSocket upgrade: the
 Examples:
   python scripts/test_tts_websocket_probe.py --token free-access --no-proxy
   python scripts/test_tts_websocket_probe.py --from-config --no-proxy
-  python scripts/test_tts_websocket_probe.py --from-config --no-proxy --protocol-roundtrip --text "测试"
+  python scripts/test_tts_websocket_probe.py --from-config --no-proxy --protocol-roundtrip --text "测试"  # noqa: DOCSTRING_CJK
 
 Env (optional): TTS_PROBE_TOKEN, AUDIO_API_KEY. Override URL only with --url if you must.
 """

--- a/tests/testbench/pipeline/chat_runner.py
+++ b/tests/testbench/pipeline/chat_runner.py
@@ -208,7 +208,7 @@ def resolve_group_config(session: Session, group: GroupKey) -> ModelGroupConfig:
 #   任意一个都会被 400 拦住:
 #       {"error": "Invalid request: you are not using Lanlan. STOP ABUSE THE API."}
 #   2026-04 实测结果 (详见 docs/AGENT_NOTES.md #12): 只有**老域名无 www 前
-#   缀**的 `https://lanlan.app/text/v1` 未启用该校验, 返回正常的 OpenAI
+#   缀**的 `https://www.lanlan.app/text/v1` 未启用该校验, 返回正常的 OpenAI
 #   兼容 completion 数据. 主程序 `utils.config_manager._adjust_free_api_url`
 #   只把 `lanlan.tech → lanlan.app`, 不动 `www.` 前缀, 所以主程序靠 GeoIP
 #   路由能得到 `www.lanlan.app` / `lanlan.tech` 两种形态, 但它**本身已经**
@@ -216,7 +216,7 @@ def resolve_group_config(session: Session, group: GroupKey) -> ModelGroupConfig:
 #
 # 策略
 #   在 testbench 这一侧, 当 ``cfg.base_url`` 命中任意一个被拦截的 lanlan 免
-#   费域时, 统一重写为 `https://lanlan.app/text/v1` 再交给下游 openai SDK.
+#   费域时, 统一重写为 `https://www.lanlan.app/text/v1` 再交给下游 openai SDK.
 #   这是**纯测试生态补丁**, 不写回 session.model_config (summary 页面展示
 #   的仍是用户/预设原始 URL, 避免视觉欺骗), 也不动 `config/api_providers
 #   .json` (那是主程序财产, 按规则不能动). 后续若 lanlan 服务端把老域名

--- a/tests/testbench/pipeline/chat_runner.py
+++ b/tests/testbench/pipeline/chat_runner.py
@@ -208,7 +208,7 @@ def resolve_group_config(session: Session, group: GroupKey) -> ModelGroupConfig:
 #   任意一个都会被 400 拦住:
 #       {"error": "Invalid request: you are not using Lanlan. STOP ABUSE THE API."}
 #   2026-04 实测结果 (详见 docs/AGENT_NOTES.md #12): 只有**老域名无 www 前
-#   缀**的 `https://www.lanlan.app/text/v1` 未启用该校验, 返回正常的 OpenAI
+#   缀**的 `https://lanlan.app/text/v1` 未启用该校验, 返回正常的 OpenAI
 #   兼容 completion 数据. 主程序 `utils.config_manager._adjust_free_api_url`
 #   只把 `lanlan.tech → lanlan.app`, 不动 `www.` 前缀, 所以主程序靠 GeoIP
 #   路由能得到 `www.lanlan.app` / `lanlan.tech` 两种形态, 但它**本身已经**
@@ -216,7 +216,7 @@ def resolve_group_config(session: Session, group: GroupKey) -> ModelGroupConfig:
 #
 # 策略
 #   在 testbench 这一侧, 当 ``cfg.base_url`` 命中任意一个被拦截的 lanlan 免
-#   费域时, 统一重写为 `https://www.lanlan.app/text/v1` 再交给下游 openai SDK.
+#   费域时, 统一重写为 `https://lanlan.app/text/v1` 再交给下游 openai SDK.
 #   这是**纯测试生态补丁**, 不写回 session.model_config (summary 页面展示
 #   的仍是用户/预设原始 URL, 避免视觉欺骗), 也不动 `config/api_providers
 #   .json` (那是主程序财产, 按规则不能动). 后续若 lanlan 服务端把老域名
@@ -240,12 +240,16 @@ def resolve_group_config(session: Session, group: GroupKey) -> ModelGroupConfig:
 #   + API key; 免费 Lanlan 预设仅对 NEKO 主程序自身可用。
 #   (绝大多数 smoke 用 mock, 不受影响; 仅真实对话/记忆/评分的手测需要可用 key。)
 
-_LANLAN_FREE_BLOCKED_HOSTS: tuple[str, ...] = (
-    "www.lanlan.tech",
-    "lanlan.tech",
-    "www.lanlan.app",
-)
-_LANLAN_FREE_OPEN_HOST = "lanlan.app"
+# 2026-08-01: 裸 `lanlan.app` 已**下线** (维护者确认), 不只是像 6 月那样被反滥
+#   用校验拦掉。旁路目标不复存在, 所以旁路本身必须停用: 继续重写只会把一个能
+#   给出 "STOP ABUSE THE API" 的 400 (它至少说明了原因) 换成一个 DNS/连接失败
+#   (它什么也不说明), 诊断信息只会更差。
+#
+#   保留常量而非删除函数: 它记录了这条路曾经存在、为何存在、以及为何不再可用,
+#   而空元组让重写循环自然成为 no-op —— base_url 原样交给下游, 免费预设在
+#   testbench 里以服务端自己的话失败。
+_LANLAN_FREE_BLOCKED_HOSTS: tuple[str, ...] = ()
+_LANLAN_FREE_OPEN_HOST = ""
 
 
 def _rewrite_lanlan_free_base_url(cfg: ModelGroupConfig) -> ModelGroupConfig:

--- a/tests/unit/test_gemini_realtime_voice_routing.py
+++ b/tests/unit/test_gemini_realtime_voice_routing.py
@@ -137,11 +137,11 @@ def test_validate_keeps_free_native_voice_on_lanlan_app_route():
     mgr.get_voices_for_current_api = lambda for_listing=False: {}
     mgr.get_model_api_config = lambda model_type: {
         "api_type": "free",
-        "base_url": "wss://lanlan.app/realtime",
+        "base_url": "wss://www.lanlan.app/realtime",
     }
     mgr.get_core_config = lambda: {
         "CORE_API_TYPE": "free",
-        "CORE_URL": "wss://lanlan.app/realtime",
+        "CORE_URL": "wss://www.lanlan.app/realtime",
     }
 
     assert ConfigManager.validate_voice_id(mgr, "qingchunshaonv") is True
@@ -177,10 +177,10 @@ def test_native_preview_provider_respects_custom_voice_collision():
 
 
 def test_step_native_preview_provider_respects_custom_voice_collision():
-    native_mgr = _FakeCharactersRouterConfigManager("free", "wss://lanlan.tech/realtime")
+    native_mgr = _FakeCharactersRouterConfigManager("free", "wss://www.lanlan.tech/realtime")
     colliding_mgr = _FakeCharactersRouterConfigManager(
         "free",
-        "wss://lanlan.tech/realtime",
+        "wss://www.lanlan.tech/realtime",
         stored_voice_ids={"qingchunshaonv"},
     )
 
@@ -220,7 +220,7 @@ async def test_free_voice_catalog_on_lanlan_app_shows_free_intl(monkeypatch):
         "get_config_manager",
         lambda: _FakeCharactersRouterConfigManager(
             "free",
-            "wss://lanlan.app/realtime",
+            "wss://www.lanlan.app/realtime",
         ),
     )
 
@@ -231,7 +231,7 @@ async def test_free_voice_catalog_on_lanlan_app_shows_free_intl(monkeypatch):
         "get_config_manager",
         lambda: _FakeCharactersRouterConfigManager(
             "free",
-            "wss://lanlan.tech/realtime",
+            "wss://www.lanlan.tech/realtime",
         ),
     )
 
@@ -260,7 +260,7 @@ async def test_free_intl_pin_hidden_when_voice_id_collides_with_clone(monkeypatc
         "get_config_manager",
         lambda: _FakeCharactersRouterConfigManager(
             "free",
-            "wss://lanlan.app/realtime",
+            "wss://www.lanlan.app/realtime",
             stored_voice_ids={"yui"},
         ),
     )
@@ -279,7 +279,7 @@ async def test_free_intl_native_entry_hidden_when_voice_id_collides(monkeypatch)
         "get_config_manager",
         lambda: _FakeCharactersRouterConfigManager(
             "free",
-            "wss://lanlan.app/realtime",
+            "wss://www.lanlan.app/realtime",
             stored_voice_ids={"Leda"},
         ),
     )
@@ -299,24 +299,24 @@ def test_free_intl_remaps_gemini_and_yui_native_on_lanlan_app_route():
 
     # Gemini 音色 / yui → 海外 free 路由认 native
     assert resolve_native_voice_for_routing(
-        "free", "Puck", voice_id_exists, realtime_base_url="wss://lanlan.app/realtime",
+        "free", "Puck", voice_id_exists, realtime_base_url="wss://www.lanlan.app/realtime",
     ) == ("Puck", True)
     assert resolve_native_voice_for_routing(
         "free", "  yui  ", voice_id_exists, realtime_base_url="wss://edge.lanlan.app/realtime",
     ) == ("yui", True)
     # default 别名 → Leda
     assert resolve_native_voice_for_routing(
-        "free", "default", voice_id_exists, realtime_base_url="wss://lanlan.app/realtime",
+        "free", "default", voice_id_exists, realtime_base_url="wss://www.lanlan.app/realtime",
     ) == ("Leda", True)
 
     # 国内 free（lanlan.tech）：阶跃目录不识别 Gemini 音色
     assert resolve_native_voice_for_routing(
-        "free", "Puck", voice_id_exists, realtime_base_url="wss://lanlan.tech/realtime",
+        "free", "Puck", voice_id_exists, realtime_base_url="wss://www.lanlan.tech/realtime",
     ) == ("Puck", False)
 
     # 海外 free：阶跃预设不在 free_intl 目录 → 非 native
     assert resolve_native_voice_for_routing(
-        "free", "qingchunshaonv", voice_id_exists, realtime_base_url="wss://lanlan.app/realtime",
+        "free", "qingchunshaonv", voice_id_exists, realtime_base_url="wss://www.lanlan.app/realtime",
     ) == ("qingchunshaonv", False)
 
 
@@ -401,13 +401,13 @@ def test_non_livestream_free_preset_still_skips_tts_only_on_lanlan_tech(monkeypa
 
     assert (
         LLMSessionManager._resolve_session_use_tts(
-            mgr, "audio", {"base_url": "wss://lanlan.tech/realtime"}, core_config,
+            mgr, "audio", {"base_url": "wss://www.lanlan.tech/realtime"}, core_config,
         )
         is False
     )
     assert (
         LLMSessionManager._resolve_session_use_tts(
-            mgr, "audio", {"base_url": "wss://lanlan.app/realtime"}, core_config,
+            mgr, "audio", {"base_url": "wss://www.lanlan.app/realtime"}, core_config,
         )
         is True
     )

--- a/tests/unit/test_geoip_region_gate.py
+++ b/tests/unit/test_geoip_region_gate.py
@@ -969,7 +969,7 @@ def test_custom_url_merely_containing_the_brand_string_is_not_a_free_route():
     assert ConfigManager._config_needs_region(
         {'CORE_URL': 'https://custom.example/v1/lanlan.tech'}) is False
     assert ConfigManager._config_needs_region(
-        {'CORE_URL': 'https://lanlan.tech.evil.example/core'}) is False
+        {'CORE_URL': 'https://www.lanlan.tech.evil.example/core'}) is False
     assert ConfigManager._config_needs_region(
         {'CORE_URL': 'wss://www.lanlan.tech/core'}) is True
 

--- a/tests/unit/test_group_memory_recall_tool.py
+++ b/tests/unit/test_group_memory_recall_tool.py
@@ -1559,7 +1559,7 @@ def test_route_capability_predicate_knows_the_free_proxy():
         "free-model", "https://www.lanlan.app/text/v1",
     ) is False
     assert route_supports_tool_calls(
-        "free-model", "https://lanlan.tech/text/v1",
+        "free-model", "https://www.lanlan.tech/text/v1",
     ) is False
     # 区域改写只动 URL：模型名单独命中也算免费路由。
     assert route_supports_tool_calls("free-model", "https://example.com/v1") is False

--- a/tests/unit/test_native_voice_registry.py
+++ b/tests/unit/test_native_voice_registry.py
@@ -169,10 +169,10 @@ def test_active_realtime_base_is_route_agnostic_on_lanlan_app():
     class _CM:
         def get_model_api_config(self, model_type):
             assert model_type == "realtime"
-            return {"api_type": "free", "base_url": "wss://lanlan.app/realtime"}
+            return {"api_type": "free", "base_url": "wss://www.lanlan.app/realtime"}
 
         def get_core_config(self):
-            return {"CORE_API_TYPE": "free", "CORE_URL": "wss://lanlan.app/realtime"}
+            return {"CORE_API_TYPE": "free", "CORE_URL": "wss://www.lanlan.app/realtime"}
 
     assert get_active_realtime_native_provider(_CM()) == "free"
 
@@ -181,10 +181,10 @@ def test_active_realtime_for_ui_remaps_free_to_free_intl_on_lanlan_app_route():
     class _CM:
         def get_model_api_config(self, model_type):
             assert model_type == "realtime"
-            return {"api_type": "free", "base_url": "wss://lanlan.app/realtime"}
+            return {"api_type": "free", "base_url": "wss://www.lanlan.app/realtime"}
 
         def get_core_config(self):
-            return {"CORE_API_TYPE": "free", "CORE_URL": "wss://lanlan.app/realtime"}
+            return {"CORE_API_TYPE": "free", "CORE_URL": "wss://www.lanlan.app/realtime"}
 
     assert get_active_realtime_native_provider_for_ui(_CM()) == "free_intl"
 
@@ -217,10 +217,10 @@ def test_active_realtime_for_ui_keeps_free_provider_on_lanlan_tech_route():
     class _CM:
         def get_model_api_config(self, model_type):
             assert model_type == "realtime"
-            return {"api_type": "free", "base_url": "wss://lanlan.tech/realtime"}
+            return {"api_type": "free", "base_url": "wss://www.lanlan.tech/realtime"}
 
         def get_core_config(self):
-            return {"CORE_API_TYPE": "free", "CORE_URL": "wss://lanlan.tech/realtime"}
+            return {"CORE_API_TYPE": "free", "CORE_URL": "wss://www.lanlan.tech/realtime"}
 
     assert get_active_realtime_native_provider_for_ui(_CM()) == "free"
 
@@ -233,7 +233,7 @@ def test_active_realtime_for_ui_falls_back_to_core_url_when_base_url_empty():
             return {"api_type": "free", "base_url": ""}
 
         def get_core_config(self):
-            return {"CORE_API_TYPE": "free", "CORE_URL": "wss://lanlan.app/realtime"}
+            return {"CORE_API_TYPE": "free", "CORE_URL": "wss://www.lanlan.app/realtime"}
 
     assert get_active_realtime_native_provider_for_ui(_CM()) == "free_intl"
 

--- a/tests/unit/test_realtime_arbiter_fail_open.py
+++ b/tests/unit/test_realtime_arbiter_fail_open.py
@@ -183,7 +183,7 @@ def _free_client(**hooks):
     from main_logic.omni_realtime_client import OmniRealtimeClient
 
     client = OmniRealtimeClient(
-        "wss://lanlan.app/realtime",
+        "wss://www.lanlan.app/realtime",
         "test-key",
         model="free-model",
         api_type="free",

--- a/tests/unit/test_realtime_arbiter_native_path.py
+++ b/tests/unit/test_realtime_arbiter_native_path.py
@@ -425,7 +425,7 @@ async def test_a_terminal_notifies_the_host_and_rotates_only_without_server_vad(
     # lanlan.app free is _is_free_proxy and NOT _is_gemini: arbitrated, and
     # response.done is its only rotation point.
     proxy, proxy_done, proxy_rotations = await _build(
-        "wss://lanlan.app/api/v1/realtime"
+        "wss://www.lanlan.app/api/v1/realtime"
     )
     assert proxy._has_server_vad is False
     assert proxy_done == ["done"]
@@ -511,7 +511,7 @@ async def test_a_raising_host_hook_does_not_skip_the_rotation():
         rotations.append("rotate")
 
     client = OmniRealtimeClient(
-        "wss://lanlan.app/api/v1/realtime",
+        "wss://www.lanlan.app/api/v1/realtime",
         "test-key",
         model="free-model",
         api_type="free",

--- a/tests/unit/test_voice_session.py
+++ b/tests/unit/test_voice_session.py
@@ -669,8 +669,8 @@ async def test_connect_step_manual_vad_sends_null_turn_detection():
 @pytest.mark.parametrize(
     "proxy_url",
     [
-        "wss://lanlan.tech/realtime",  # StepFun proxy
-        "wss://lanlan.app/realtime",   # Vertex Gemini proxy
+        "wss://www.lanlan.tech/realtime",  # StepFun proxy
+        "wss://www.lanlan.app/realtime",   # Vertex Gemini proxy
     ],
 )
 async def test_connect_free_proxy_routes_manual_vad_per_backend(proxy_url):
@@ -969,11 +969,11 @@ _VAD_PROVIDER_MATRIX = [
     ("glm", "glm-realtime", "wss://example.test/realtime", "glm", True),
     ("step", "step-1o-audio", "wss://example.test/realtime", "step", True),
     # lanlan.tech (China free, StepFun proxy) — has server VAD by default
-    ("free_stepfun", "free-model", "wss://lanlan.tech/realtime", "free", True),
+    ("free_stepfun", "free-model", "wss://www.lanlan.tech/realtime", "free", True),
     # lanlan.app (international free, Vertex Gemini proxy) — __init__ already
     # treats this as client-VAD only (False), so MANUAL has nothing to flip.
     # Included to verify we don't accidentally re-enable server VAD.
-    ("free_vertex", "free-model", "wss://lanlan.app/realtime", "free", False),
+    ("free_vertex", "free-model", "wss://www.lanlan.app/realtime", "free", False),
 ]
 
 

--- a/tests/unit/test_yui_free_api_default_voice.py
+++ b/tests/unit/test_yui_free_api_default_voice.py
@@ -138,7 +138,7 @@ async def test_overseas_free_binds_yui_sentinel_voice(monkeypatch):
 
     changed = await ensure_default_yui_voice_for_free_api(
         config_manager,
-        {"coreApi": "free", "assistApi": "free", "CORE_URL": "wss://lanlan.app/realtime"},
+        {"coreApi": "free", "assistApi": "free", "CORE_URL": "wss://www.lanlan.app/realtime"},
     )
 
     assert changed is True


### PR DESCRIPTION
## 起因

维护者指出：`lanlan.tech` / `lanlan.app` 的裸顶级域**不提供**这些端点，必须带 `www.`。

## 生产不受影响（改动前先核过）

- `config/api_providers.json`、`config/api_profiles.py` 里配置的 URL **全部已带 `www.`**
- 海外区域改写是对 netloc 的子串替换（`utils/config_manager/core_config.py`：`netloc.lower().replace('lanlan.tech', 'lanlan.app')`），所以 `www.lanlan.tech` → `www.lanlan.app`，**前缀完整保留**

## 一个真缺陷

`scripts/test_tts_websocket_probe.py` 把 `wss://lanlan.app/tts`（裸域名）写死为默认地址，而它会真的 `websockets.connect`。

它文件头写明的用途是「log raw handshake failures」——所以它报出的握手失败，会是**它自己的 URL 造成的**，而不是服务的问题。一个测量自己缺陷的仪表。

## 其余 33 处

都是**从不发起连接**的测试 fixture，没有任何测试因此失败。仍然一并扫掉，理由是：上面那个 TTS 默认值，正是一个错误写法在测试套件里扩散之后的产物——被抄进了一个**真的会连**的地方。不是假设，已经发生过一次。

## 刻意保留

`tests/unit/test_api_config_manager.py` 保留两处裸域名：`test_normalize_agent_url_by_region` 钉的正是「**用户自己填的** URL 原样透传、不被改写」。改掉它们等于破坏这条契约本身。

## 回归报告

- **改动面**：开发脚本 1 + 测试 9。**生产代码零改动。**
- **必要性**：一个会真连的探针指向了不存在的主机；其余是防止同一写法继续扩散
- **改前/改后**：生产行为完全不变；测试全部仍绿——没有任何一处在钉裸域名（钉的那两处已排除）
- **潜在回归**：无。纯字符串替换，全量套件 11436 passed（唯一红是长期环境性的 `test_runtime_memory_soak`）
- **不在范围**：`test_api_config_manager.py` 的两处（见上）
