### PR TITLE
fix(memory): 收口 #2616 遗留的 locale 解析不对称

### DIFF
--- a/app/memory_server/routes.py
+++ b/app/memory_server/routes.py
@@ -87,14 +87,37 @@ async def _resolve_foreground_memory_language(
     lanlan_name: str,
     language: str | None,
 ) -> str:
-    """Resolve foreground prompt locale without persisting a process guess."""
+    """Resolve foreground prompt locale without persisting a process guess.
+
+    Fail-soft on a durable-state read error. ``_load_locale_state_unlocked``
+    raises ``PromptLocalePersistenceError`` on a transient ``OSError`` on
+    purpose — a *writer* must never cache that as empty state or it would
+    discard the real durable causal order. But this is a read for rendering
+    only: a temporarily unreadable sidecar must not turn into a 500 that drops
+    the caller's whole turn. Degrade to the request/process locale instead.
+    """
     if is_supported_language_code(language):
         return _activate_request_language(language)
-    durable_language = await asyncio.to_thread(
-        locale_state.get_character_prompt_locale,
-        lanlan_name,
-    )
+    try:
+        durable_language = await asyncio.to_thread(
+            locale_state.get_character_prompt_locale,
+            lanlan_name,
+        )
+    except locale_state.PromptLocalePersistenceError:
+        logger.warning(
+            "[PromptLocale] %s: durable locale unreadable, rendering with the "
+            "process locale for this request",
+            lanlan_name,
+        )
+        return _activate_request_language(None)
     return _activate_request_language(durable_language)
+
+
+#: Upper bound on how many subjects one request may cost in durable-locale
+#: lookups. Matches the scoped endpoints' documented ``1..8`` subject contract,
+#: but is enforced independently so the resolver stays bounded even when it
+#: runs ahead of an endpoint's own validation.
+_SCOPED_LOCALE_LOOKUP_LIMIT = 8
 
 
 async def _resolve_scoped_memory_language(
@@ -112,7 +135,12 @@ async def _resolve_scoped_memory_language(
     """
     if is_supported_language_code(language):
         return _activate_request_language(language)
-    for subject in subjects or []:
+    # Bounded on purpose: this resolver runs before the endpoint's own
+    # ``1..8 subjects`` rejection, so an oversized list would otherwise
+    # schedule one thread-pool lookup per supplied item on its way to a 422.
+    # Bounding here (rather than requiring every caller to validate first)
+    # keeps the work bound a property of the resolver itself.
+    for subject in (subjects or [])[:_SCOPED_LOCALE_LOOKUP_LIMIT]:
         descriptor = (
             subject.model_dump()
             if hasattr(subject, "model_dump")
@@ -123,6 +151,16 @@ async def _resolve_scoped_memory_language(
                 lanlan_name,
                 descriptor,
             )
+        except locale_state.PromptLocalePersistenceError:
+            # Same fail-soft contract as the character-level resolver: a
+            # transient sidecar read error must not bubble out of a rendering
+            # lookup and break the caller's fail-soft response contract.
+            logger.warning(
+                "[PromptLocale] %s: scoped locale unreadable, falling through "
+                "to the character locale for this request",
+                lanlan_name,
+            )
+            break
         except ValueError:
             # A malformed descriptor fails closed downstream (coerce_subject);
             # locale lookup must not be the thing that rejects the request.

--- a/app/memory_server/routes.py
+++ b/app/memory_server/routes.py
@@ -97,6 +97,41 @@ async def _resolve_foreground_memory_language(
     return _activate_request_language(durable_language)
 
 
+async def _resolve_scoped_memory_language(
+    lanlan_name: str,
+    subjects,
+    language: str | None,
+) -> str:
+    """Resolve scoped prompt locale: explicit request > subject > character.
+
+    ``subjects`` arrives in the caller's own priority order (see
+    ``_get_scoped_context``), so the first one carrying a durable locale wins.
+    Without this chain a group request falls straight through to the calling
+    process's locale, and the per-subject durable state is never read — which
+    is the whole point of storing it.
+    """
+    if is_supported_language_code(language):
+        return _activate_request_language(language)
+    for subject in subjects or []:
+        descriptor = (
+            subject.model_dump()
+            if hasattr(subject, "model_dump")
+            else subject
+        )
+        try:
+            durable = await locale_state.aget_subject_prompt_locale(
+                lanlan_name,
+                descriptor,
+            )
+        except ValueError:
+            # A malformed descriptor fails closed downstream (coerce_subject);
+            # locale lookup must not be the thing that rejects the request.
+            continue
+        if is_supported_language_code(durable):
+            return _activate_request_language(durable)
+    return await _resolve_foreground_memory_language(lanlan_name, None)
+
+
 class ExternalMemoryImportRequest(BaseModel):
     character_name: str
     source_format: str
@@ -603,7 +638,15 @@ async def cache_conversation(request: HistoryRequest, lanlan_name: str):
         if is_supported_language_code(request.language)
         else None
     )
-    memory_language = _activate_request_language(request.language)
+    # Same resolution as the sibling /process /renew /settle endpoints. Today
+    # /cache runs update_history(compress=False), so nothing inside this
+    # context reaches a prompt and the asymmetry is invisible — but any future
+    # prompt work moved in here would silently render in the caller's process
+    # locale instead of the character's durable one.
+    memory_language = await _resolve_foreground_memory_language(
+        lanlan_name,
+        request.language,
+    )
     with language_context(memory_language):
         gates._touch_activity()
         try:
@@ -1395,7 +1438,16 @@ async def _process_scoped_history_segments(
 
 @app.post("/internal/memory/{lanlan_name}/scoped_context")
 async def get_scoped_context(lanlan_name: str, req: ScopedContextRequest):
-    with language_context(_activate_request_language(req.language)):
+    # Validate before the locale lookup: it keys per-character state files by
+    # this name, so it must not run on an unvalidated path component. The
+    # inner handler validates again — the helper is idempotent.
+    lanlan_name = validate_lanlan_name(lanlan_name)
+    resolved_language = await _resolve_scoped_memory_language(
+        lanlan_name,
+        req.subjects,
+        req.language,
+    )
+    with language_context(resolved_language):
         return await _get_scoped_context(lanlan_name, req)
 
 
@@ -1661,6 +1713,14 @@ async def query_memory(lanlan_name: str, req: QueryMemoryRequest):
             detail="subjects must be omitted (legacy private) or contain 1..8 items",
         )
     subjects = [subject.to_domain() for subject in (req.subjects or [])]
+    # Recall renders tier/entity tags and rerank prompts, so it needs the
+    # subject's own durable locale when the caller has none — not whichever
+    # locale the calling process happens to sit in.
+    resolved_language = await _resolve_scoped_memory_language(
+        lanlan_name,
+        subjects,
+        req.language,
+    )
     try:
         # Import 移进 try：若 memory.hybrid_recall 自身 import 失败（循环
         # import / 依赖缺失），仍然走下面的兜底返回空 results，避免端点
@@ -1677,7 +1737,7 @@ async def query_memory(lanlan_name: str, req: QueryMemoryRequest):
             elif not query_text:
                 # 只给 time、没 query → 按时间邻近返回最接近的若干条。
                 from memory.hybrid_recall import recall_by_time
-                with language_context(_activate_request_language(req.language)):
+                with language_context(resolved_language):
                     return await recall_by_time(
                         lanlan_name=lanlan_name,
                         time_spec=time_spec,
@@ -1688,7 +1748,7 @@ async def query_memory(lanlan_name: str, req: QueryMemoryRequest):
         # query（+ 可选 time_window）→ 语义检索；time_window 非空即"语义 +
         # 时间"联合检索（窗口内按 query 排序）。
         from memory.hybrid_recall import hybrid_recall
-        with language_context(_activate_request_language(req.language)):
+        with language_context(resolved_language):
             return await hybrid_recall(
                 lanlan_name=lanlan_name,
                 query=query_text,

--- a/memory/fact_dedup.py
+++ b/memory/fact_dedup.py
@@ -107,12 +107,19 @@ def cosine_similarity(left, right) -> float:
     return implementation(left, right)
 
 
-# Cosine cutoff for "candidate is *probably* a paraphrase". 0.85 is
-# the design number from the P2 plan — empirically what the default
-# local profile emits for "主人喜欢猫" vs "对猫咪很感兴趣" (≈0.88)
-# without false-positives between "主人喜欢猫" / "主人讨厌猫" (≈0.78). Tunable per
-# deploy via the constant; lower values flood the LLM, higher misses
-# real paraphrases.
+# Cosine cutoff for "candidate is *probably* a paraphrase". 0.85 is the design
+# number from the P2 plan: it was calibrated so a paraphrase pair clears the
+# bar while an antonym pair ("主人喜欢猫" / "主人讨厌猫") does not.
+#
+# ⚠️ This comment used to quote absolute scores (≈0.88 paraphrase / ≈0.78
+# antonym) as if they were current. They were measured on the embedding
+# profile of the time and were never re-taken after the model changed, so
+# they no longer describe what this deployment emits — re-measure before
+# citing any number here. What the threshold rests on is the *ordering*
+# (paraphrase > antonym), not those two values. Lower values flood the LLM,
+# higher ones miss real paraphrases; retune against freshly measured pairs on
+# the profile you actually ship, and note that Matryoshka truncation makes the
+# scale dimension-dependent (see memory/_embeddings/hardware.py).
 FACT_DEDUP_COSINE_THRESHOLD = 0.85
 
 # Cap how many candidate pairs go into a single LLM call. The prompt

--- a/plugin/plugins/qq_auto_reply/memory_bridge.py
+++ b/plugin/plugins/qq_auto_reply/memory_bridge.py
@@ -188,11 +188,20 @@ class QQMemoryBridge:
             request_payload["time"] = normalized_time
         if subjects is not None:
             request_payload["subjects"] = subjects
-        # No language field: QQ has no explicit per-conversation locale, and
-        # this method has no caller-supplied one either. Sending the host
-        # process fallback would outrank the durable per-subject locale the
-        # server can restore on its own (same contract as the sibling
-        # bootstrap/history methods).
+        from utils.language_utils import get_global_language_full
+
+        # Deliberately still sends the process locale, unlike the sibling
+        # bootstrap/history methods. The difference is who renders: those
+        # receive server-rendered text, so omitting the field lets the server
+        # use the durable per-subject locale end to end. This one receives
+        # *structured* rows and renders the tier/entity tags locally (see
+        # render_relevant_memory), so omitting it here would only move the
+        # server half to the subject locale while the tags stayed on this
+        # process's — worse than today's self-consistent pair. Moving this
+        # path onto the subject locale needs the resolved locale returned in
+        # the response (or the tags rendered server-side); that is a response
+        # contract change and belongs in its own PR.
+        request_payload["language"] = get_global_language_full()
         client = self._client()
         response = await client.post(
             f"{self._base_url()}/query_memory/{her_name}",

--- a/plugin/plugins/qq_auto_reply/memory_bridge.py
+++ b/plugin/plugins/qq_auto_reply/memory_bridge.py
@@ -105,20 +105,19 @@ class QQMemoryBridge:
     ) -> str:
         if not subjects:
             return ""
-        from utils.language_utils import (
-            get_global_language_full,
-            is_supported_language_code,
-        )
+        from utils.language_utils import is_supported_language_code
 
-        prompt_language = (
-            language
-            if is_supported_language_code(language)
-            else get_global_language_full()
-        )
+        # Same contract as the sibling methods: only a caller-supplied locale
+        # has explicit provenance. Omitting the field lets the server restore
+        # the durable per-subject locale, which the host process fallback
+        # would otherwise overwrite with a coarser guess.
+        payload: dict[str, Any] = {"subjects": subjects}
+        if is_supported_language_code(language):
+            payload["language"] = language
         client = self._client()
         response = await client.post(
             f"{self._base_url()}/internal/memory/{her_name}/scoped_context",
-            json={"subjects": subjects, "language": prompt_language},
+            json=payload,
             timeout=timeout,
         )
         response.raise_for_status()
@@ -189,9 +188,11 @@ class QQMemoryBridge:
             request_payload["time"] = normalized_time
         if subjects is not None:
             request_payload["subjects"] = subjects
-        from utils.language_utils import get_global_language_full
-
-        request_payload["language"] = get_global_language_full()
+        # No language field: QQ has no explicit per-conversation locale, and
+        # this method has no caller-supplied one either. Sending the host
+        # process fallback would outrank the durable per-subject locale the
+        # server can restore on its own (same contract as the sibling
+        # bootstrap/history methods).
         client = self._client()
         response = await client.post(
             f"{self._base_url()}/query_memory/{her_name}",

--- a/plugin/plugins/qq_auto_reply/session_instruction_service.py
+++ b/plugin/plugins/qq_auto_reply/session_instruction_service.py
@@ -587,6 +587,11 @@ class QQSessionInstructionService:
         is_group: bool = False,
         group_id: str | None = None,
         sender_id: str = "",
+        # Kept on the signature (callers and their tests pass it), but no
+        # longer forwarded to the memory bridge: what reaches here is this
+        # process's default locale, and sending that would outrank the memory
+        # server's durable per-subject locale. Wire it through again only if
+        # QQ ever gains a real per-conversation locale.
         locale: str = "",
         used_member_subject_out: list | None = None,
         participant_memory: bool = False,
@@ -626,7 +631,11 @@ class QQSessionInstructionService:
                 memory_context = await self.plugin.memory_bridge.fetch_scoped_bootstrap_memory(
                     her_name,
                     subjects=subjects,
-                    language=locale,
+                    # No language: ``locale`` here is this process's default
+                    # (get_global_language_full), not a per-conversation
+                    # locale — QQ has none. Forwarding it would outrank the
+                    # memory server's durable per-subject locale, which is
+                    # exactly what post_memory_history already avoids.
                 )
                 if not bool(
                     (getattr(self.plugin, "_qq_settings", {}) or {}).get(
@@ -653,7 +662,11 @@ class QQSessionInstructionService:
                 memory_context = await self.plugin.memory_bridge.fetch_scoped_bootstrap_memory(
                     her_name,
                     subjects=subjects,
-                    language=locale,
+                    # No language: ``locale`` here is this process's default
+                    # (get_global_language_full), not a per-conversation
+                    # locale — QQ has none. Forwarding it would outrank the
+                    # memory server's durable per-subject locale, which is
+                    # exactly what post_memory_history already avoids.
                 )
                 if not bool(
                     (getattr(self.plugin, "_qq_settings", {}) or {}).get(

--- a/plugin/server/application/messages/memory_query_service.py
+++ b/plugin/server/application/messages/memory_query_service.py
@@ -7,7 +7,6 @@ import httpx
 
 from plugin.logging_config import get_logger
 from plugin.server.domain.errors import ServerDomainError
-from utils.language_utils import get_global_language_full
 
 logger = get_logger("server.application.messages.memory_query")
 
@@ -63,11 +62,13 @@ class MemoryQueryService:
                 lanlan_name=normalized_lanlan_name,
                 query=normalized_query,
             )
+            # No language param: this GET is a deprecated placeholder endpoint
+            # (semantic recall was removed from it long ago) and the plugin
+            # server has no session locale to contribute. Letting the memory
+            # server resolve its own locale keeps the plugin process's
+            # fallback from propagating across the boundary.
             async with httpx.AsyncClient(timeout=normalized_timeout, proxy=None, trust_env=False) as client:
-                response = await client.get(
-                    url,
-                    params={"language": get_global_language_full()},
-                )
+                response = await client.get(url)
                 response.raise_for_status()
                 result = response.json()
             return {"result": result}

--- a/tests/unit/test_group_memory_scopes.py
+++ b/tests/unit/test_group_memory_scopes.py
@@ -494,7 +494,6 @@ async def test_qq_group_bootstrap_never_reads_legacy_private_memory():
             QQMemoryBridge.group_subject("7788"),
             QQMemoryBridge.group_participant_subject("7788", "2046"),
         ],
-        language="",
     )
 
     # Member memory OFF gates this read too (dual of the recall path):
@@ -513,7 +512,6 @@ async def test_qq_group_bootstrap_never_reads_legacy_private_memory():
     bridge.fetch_scoped_bootstrap_memory.assert_awaited_once_with(
         "Neko",
         subjects=[QQMemoryBridge.group_subject("7788")],
-        language="",
     )
 
 

--- a/tests/unit/test_memory_zh_tw.py
+++ b/tests/unit/test_memory_zh_tw.py
@@ -1505,6 +1505,100 @@ async def test_scoped_context_falls_through_subject_to_character_locale(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_scoped_locale_read_failure_degrades_instead_of_raising(monkeypatch):
+    """A transient sidecar read error must not escape as a 500.
+
+    ``_load_locale_state_unlocked`` raises ``PromptLocalePersistenceError`` on a
+    transient OSError deliberately — a *writer* caching that as empty state
+    would discard the real durable causal order. But these lookups are for
+    rendering, and the endpoints they sit in have their own fail-soft
+    contracts, so the read must degrade to the process locale instead.
+    """
+    from app.memory_server import locale_state, routes
+
+    rendered = []
+
+    async def render(_name, _req):
+        rendered.append(True)
+        return "ok"
+
+    async def broken_subject_locale(_name, _subject):
+        raise locale_state.PromptLocalePersistenceError("transient read failure")
+
+    def broken_character_locale(_name):
+        raise locale_state.PromptLocalePersistenceError("transient read failure")
+
+    monkeypatch.setattr(routes, "_get_scoped_context", render)
+    monkeypatch.setattr(
+        locale_state, "aget_subject_prompt_locale", broken_subject_locale,
+    )
+    monkeypatch.setattr(
+        locale_state, "get_character_prompt_locale", broken_character_locale,
+    )
+
+    request = routes.ScopedContextRequest(
+        subjects=[{"subject_kind": "group_chat", "subject_id": "qq:7788"}],
+    )
+
+    assert await routes.get_scoped_context("Neko", request) == "ok"
+    assert rendered == [True]
+
+
+@pytest.mark.asyncio
+async def test_character_locale_read_failure_degrades_instead_of_raising(monkeypatch):
+    """Same fail-soft contract on the character-level resolver (/cache path)."""
+    from app.memory_server import locale_state, routes
+
+    def broken_character_locale(_name):
+        raise locale_state.PromptLocalePersistenceError("transient read failure")
+
+    monkeypatch.setattr(
+        locale_state, "get_character_prompt_locale", broken_character_locale,
+    )
+
+    resolved = await routes._resolve_foreground_memory_language("Neko", None)
+    assert resolved  # a usable locale, not an exception
+
+
+@pytest.mark.asyncio
+async def test_scoped_locale_lookup_is_bounded_for_oversized_requests(monkeypatch):
+    """An oversized subject list must not cost one durable lookup per item.
+
+    The resolver runs ahead of the endpoint's own ``1..8 subjects`` rejection,
+    so without its own bound an out-of-contract request would schedule one
+    thread-pool lookup per supplied subject on the way to a 422.
+    """
+    from app.memory_server import locale_state, routes
+
+    lookups = []
+
+    async def counting_subject_locale(_name, subject):
+        lookups.append(subject)
+        return None
+
+    async def render(_name, _req):
+        return "ok"
+
+    monkeypatch.setattr(routes, "_get_scoped_context", render)
+    monkeypatch.setattr(
+        locale_state, "aget_subject_prompt_locale", counting_subject_locale,
+    )
+    monkeypatch.setattr(
+        locale_state, "get_character_prompt_locale", lambda _name: "zh-TW",
+    )
+
+    oversized = [
+        {"subject_kind": "group_chat", "subject_id": f"qq:{index}"}
+        for index in range(40)
+    ]
+    request = routes.ScopedContextRequest(subjects=oversized)
+
+    assert await routes.get_scoped_context("Neko", request) == "ok"
+    assert len(lookups) == routes._SCOPED_LOCALE_LOOKUP_LIMIT
+    assert len(lookups) < len(oversized)
+
+
+@pytest.mark.asyncio
 async def test_scoped_history_activates_request_locale(monkeypatch):
     from app.memory_server import routes
     from utils.language_utils import get_global_language_full

--- a/tests/unit/test_memory_zh_tw.py
+++ b/tests/unit/test_memory_zh_tw.py
@@ -1428,6 +1428,83 @@ async def test_scoped_context_activates_request_locale(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_scoped_context_without_request_locale_uses_subject_durable(monkeypatch):
+    """No request locale → the subject's durable locale beats the process one.
+
+    The QQ bridge deliberately omits ``language`` when it has no caller-supplied
+    locale, so this fallback is the only thing that reads the per-subject state
+    the scoped locale writer maintains.
+    """
+    from app.memory_server import locale_state, routes
+    from utils.language_utils import get_global_language_full
+
+    observed = []
+    lookups = []
+
+    async def render(name, req):
+        observed.append((name, req.language, get_global_language_full()))
+        return "ok"
+
+    async def fake_subject_locale(name, subject):
+        lookups.append((name, subject))
+        return "zh-TW"
+
+    def unreachable_character_locale(name):
+        raise AssertionError(
+            "the subject locale must be consumed before the character fallback"
+        )
+
+    monkeypatch.setattr(routes, "_get_scoped_context", render)
+    monkeypatch.setattr(
+        locale_state, "aget_subject_prompt_locale", fake_subject_locale,
+    )
+    monkeypatch.setattr(
+        locale_state, "get_character_prompt_locale", unreachable_character_locale,
+    )
+
+    request = routes.ScopedContextRequest(
+        subjects=[{"subject_kind": "group_chat", "subject_id": "qq:7788"}],
+    )
+
+    assert await routes.get_scoped_context("Neko", request) == "ok"
+    # The endpoint renders under the subject locale even though the request
+    # carried none — this is the assertion the old code failed.
+    assert observed == [("Neko", None, "zh-TW")]
+    assert [name for name, _subject in lookups] == ["Neko"]
+
+
+@pytest.mark.asyncio
+async def test_scoped_context_falls_through_subject_to_character_locale(monkeypatch):
+    """A subject with no durable locale yet falls through to the character's."""
+    from app.memory_server import locale_state, routes
+    from utils.language_utils import get_global_language_full
+
+    observed = []
+
+    async def render(name, req):
+        observed.append((name, req.language, get_global_language_full()))
+        return "ok"
+
+    async def empty_subject_locale(_name, _subject):
+        return None
+
+    monkeypatch.setattr(routes, "_get_scoped_context", render)
+    monkeypatch.setattr(
+        locale_state, "aget_subject_prompt_locale", empty_subject_locale,
+    )
+    monkeypatch.setattr(
+        locale_state, "get_character_prompt_locale", lambda _name: "zh-TW",
+    )
+
+    request = routes.ScopedContextRequest(
+        subjects=[{"subject_kind": "group_chat", "subject_id": "qq:7788"}],
+    )
+
+    assert await routes.get_scoped_context("Neko", request) == "ok"
+    assert observed == [("Neko", None, "zh-TW")]
+
+
+@pytest.mark.asyncio
 async def test_scoped_history_activates_request_locale(monkeypatch):
     from app.memory_server import routes
     from utils.language_utils import get_global_language_full
@@ -3950,7 +4027,16 @@ async def test_plugins_without_session_locale_omit_process_fallback(monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_plugin_memory_query_forwards_full_locale(monkeypatch):
+async def test_plugin_memory_query_omits_process_locale(monkeypatch):
+    """The plugin server must not push its own process locale across the boundary.
+
+    ``/search_for_memory`` is a deprecated placeholder endpoint, and the plugin
+    server has no session locale to contribute. Its ``get_global_language_full()``
+    also misses the Steam resolver that only the main server registers, so on a
+    Steam=Traditional / system=English machine it resolves to ``en`` and would
+    override the memory server's own (correct) resolution. Same contract as the
+    WeChat bridge assertion directly above.
+    """
     from plugin.server.application.messages import memory_query_service
 
     calls = []
@@ -3980,11 +4066,6 @@ async def test_plugin_memory_query_forwards_full_locale(monkeypatch):
         "AsyncClient",
         lambda **_kwargs: Client(),
     )
-    monkeypatch.setattr(
-        memory_query_service,
-        "get_global_language_full",
-        lambda: "zh-TW",
-    )
 
     result = await memory_query_service.MemoryQueryService().query_memory(
         lanlan_name="Neko",
@@ -3993,7 +4074,11 @@ async def test_plugin_memory_query_forwards_full_locale(monkeypatch):
     )
 
     assert result == {"result": {"items": []}}
-    assert calls[0][1]["params"] == {"language": "zh-TW"}
+    assert calls, "the query must still reach the memory server"
+    assert all("params" not in kwargs for _url, kwargs in calls)
+    # The module must not even hold a handle to the process-locale resolver —
+    # re-importing it is how this regression would come back.
+    assert not hasattr(memory_query_service, "get_global_language_full")
 
 
 def test_persona_correction_locale_ignores_formatter_labels():

--- a/tests/unit/test_participant_memory_and_display_name.py
+++ b/tests/unit/test_participant_memory_and_display_name.py
@@ -2887,11 +2887,13 @@ async def test_bootstrap_section_participant_never_fetches_legacy():
     assert subjects == [
         {"subject_kind": "participant", "subject_id": "qq:1001"},
     ]
+    # The bridge must NOT receive a language here. What the caller holds is
+    # this process's default locale, not a per-conversation one, and sending
+    # it would outrank the durable per-subject locale the memory server
+    # restores on its own. (This assertion used to require the opposite.)
     assert (
-        plugin.memory_bridge.fetch_scoped_bootstrap_memory.await_args.kwargs[
-            "language"
-        ]
-        == "zh-TW"
+        "language"
+        not in plugin.memory_bridge.fetch_scoped_bootstrap_memory.await_args.kwargs
     )
 
     # sender 空：fail-closed 空 subjects → bridge 空串 → 无段；legacy 仍未被碰


### PR DESCRIPTION
## 改动概述 / Summary

#2616 建了 per-subject 的耐久 locale，但有几条路径没接上：调用方把自己的**进程 locale** 推过边界，而服务端在缺显式 locale 时**没有耐久回落** —— 两头一夹，那份 per-subject 状态一次都读不到。

Refs #2616

### 1. scoped 端点补 subject → character 两级回落

新增 `_resolve_scoped_memory_language`（**显式请求 > subject 耐久 > character 耐久 > 进程**），接到 `/internal/memory/{name}/scoped_context` 和 `/query_memory`。群聊 persona 渲染（`memory/persona/rendering.py` 的 `render_lang`）和召回的 rerank 现在跟着 subject 自己的语言走。

两个 resolver 对 `PromptLocalePersistenceError` **fail-soft**：`_load_locale_state_unlocked` 只在瞬时 `OSError` 时抛（`FileNotFoundError`/`JSONDecodeError` 都是 pass），而那个抛出对**写者**是故意的 —— 写者若把瞬时读失败缓存成空状态，会丢掉真实的 durable causal order。但这两处是渲染用的读者，落在端点自己的 fail-soft 契约里，所以降级到进程 locale 而不是让请求 500。

resolver 自身**有界**（`_SCOPED_LOCALE_LOOKUP_LIMIT = 8`）：它跑在端点自己的 `1..8 subjects` 校验之前，超量请求否则会按 subject 数逐个调度 `asyncio.to_thread`。把上限做成 resolver 自己的性质，而不是要求每个调用方先校验。

> 顺带修一个安全面：`get_scoped_context` 外层原本没有 `validate_lanlan_name`（只有内层 `_get_scoped_context` 有），而 locale 查询要拿这个名字拼 per-character 状态文件路径 —— 必须先校验再查。

### 2. QQ 侧：group / participant bootstrap 不再转发进程 locale

`session_instruction_service.py:260` 的 `user_language = get_global_language_full()`，经 `locale=user_language` 一路传到 `fetch_scoped_bootstrap_memory(language=locale)`。所以 bridge 里的 `is_supported_language_code(language)` 守卫恒为真 —— **改 bridge 内部是无效的，必须改调用方**。两个 bootstrap 调用点都不再转发该值。

插件进程没注册 Steam resolver（只有 `app/main_server/__init__.py` 注册），Steam=繁中 / 系统=en 的机器上它推的是 `en`，会盖掉服务端正确的 `zh-TW`。

`_build_core_memory_section` 的 `locale` 形参保留（调用方与既有测试都在传），但标注它不再转发给 memory bridge。

### 3. `query_relevant_memory` **保持原状**（评审后回退）

这一处一度也改成省略 `language`，后经评审指出并回退。分野在**谁渲染**：

| 方法 | 服务端返回 | 结论 |
|---|---|---|
| `fetch_scoped_bootstrap_memory` | 已渲染的文本 | 省略 `language` → 端到端用 subject locale ✅ |
| `query_relevant_memory` | 结构化行，tag 由 bridge 本地 `render_relevant_memory` 渲染 | 省略只会把服务端那一半挪走，tag 仍留在进程 locale ❌ |

改一半比不改更糟 —— 原状态两侧都用进程 locale，至少自洽。要挪需要服务端把解析出的 locale 放进响应（或把 tag 渲染搬到服务端），属于响应契约改动，另开 PR。

### 4. `/cache` 与三个兄弟端点统一

`/process` `/renew` `/settle` 都用 `_resolve_foreground_memory_language`，只有 `/cache` 还是 `_activate_request_language`。

### 5. `memory_query_service` 去掉无收益耦合

`/search_for_memory` 是 deprecated 占位端点（语义召回早已下线，只回固定文案），给它带进程 locale 只是把插件进程 locale 的传播面又扩大一格。连同模块级 import 一起删。

### 附带：修正一段过期的校准注释

`FACT_DEDUP_COSINE_THRESHOLD` 的注释引用 `≈0.88`（paraphrase）/ `≈0.78`（antonym）作为"实测值"，但那是换 embedding 模型**之前**测的，之后从未复核。阈值真正依赖的是 `paraphrase > antonym` 这个**序**，不是那两个值。

## 回归报告 / Regression Report

### 改动了什么

| 文件 | 改动 |
|---|---|
| `app/memory_server/routes.py` | 新增 `_resolve_scoped_memory_language`（分级回落 + fail-soft + 查询数上限）；`_resolve_foreground_memory_language` 加 fail-soft；`/scoped_context` 与 `/query_memory` 改用新 resolver 并补 `validate_lanlan_name`；`/cache` 改用 `_resolve_foreground_memory_language` |
| `plugin/plugins/qq_auto_reply/session_instruction_service.py` | group / participant 两个 scoped bootstrap 调用不再转发进程 locale |
| `plugin/plugins/qq_auto_reply/memory_bridge.py` | `fetch_scoped_bootstrap_memory` 无显式 locale 时省略字段；`query_relevant_memory` 保持原状并注明理由 |
| `plugin/server/application/messages/memory_query_service.py` | 删除 `/search_for_memory` 的 `language` param 与模块级 import |
| `memory/fact_dedup.py` | 仅注释：标记 cosine 阈值的两个引用数字已过期 |

### 理由 / 必要性

#2616 引入 per-subject 耐久 locale（`scoped_prompt_locales.json`），目的是让群聊记忆按 subject 各自的语言渲染。但调用方无条件发送进程 locale、服务端又只认请求字段不查耐久状态，两者叠加使那份状态在群聊 bootstrap 路径上**从未被读取**。

`/cache` 那条属于潜伏问题：它今天走 `update_history(compress=False)`，context 内没有 prompt 工作；但任何把 prompt 类工作挪进来的后续改动都会立刻踩中，而三个兄弟端点已经是正确形态。

### 改动前后的表现对比

| 场景 | 改动前 | 改动后 |
|---|---|---|
| QQ 群聊 / participant bootstrap | 调用方发进程 locale → 服务端直接采用 → persona 按插件进程语言渲染 | 不发 → 服务端取该 subject 的耐久 locale → 按群自己的语言渲染 |
| subject 尚无耐久 locale | 落插件进程 locale | 回落 character 耐久 locale，再无则进程 |
| 请求显式带 `language` | 采用请求值 | **不变**，仍优先采用 |
| locale sidecar 瞬时读失败 | （本 PR 新引入的读取会 500） | 降级到进程 locale 并 warning，请求正常完成 |
| `/scoped_context` 传入超量 subjects | （本 PR 新引入的查询会逐个调度） | 查询数封顶 8，之后仍由端点返回 422 |
| `query_relevant_memory` | 两侧都用进程 locale | **不变**（见上文第 3 节） |
| `/search_for_memory`（deprecated） | 占位文案按插件进程 locale | 按 memory server 自己解析的 locale |

### 潜在回归点与验证

- **显式 locale 优先级被破坏** → 既有 `test_scoped_context_activates_request_locale` 覆盖，未改其断言，仍绿。
- **locale 读失败穿透成 500** → 两个 resolver 各自 fail-soft；两条新增回归覆盖，变异（改回 `raise`）即转红。
- **未校验输入驱动有代价的操作** → 外层补 `validate_lanlan_name`；resolver 自带查询数上限，变异（去掉切片）即转红。
- **subject 描述符畸形导致端点 500** → resolver 对 `ValueError` 走 `continue`（畸形描述符在下游 `coerce_subject` 处 fail-closed）。
- **插件不再发 locale 后服务端拿不到语言** → 正是本 PR 补的耐久回落覆盖；两条新增测试分别验证 subject 命中与回落 character。
- **验证方式**：`pytest` 覆盖 `test_memory_zh_tw` / `test_group_memory_scopes` / `test_group_memory_consent_and_locking` / `test_participant_memory_and_display_name` / `test_group_memory_recall_tool` / `test_group_prompt_localization` / `test_memory_render_token_budget` / `test_fact_dedup` / `test_qq_auto_reply_prompting` → **959 passed**；ruff、`check_docstring_no_cjk --base origin/main` 均 exit 0。

### 测试改动说明

三处旧断言更新，它们钉的都是本次要改掉的行为：

- `test_plugin_memory_query_forwards_full_locale` → `_omits_process_locale`（且与紧邻的 WeChat 断言相反，那个不一致本身是 #2616 留下的）
- `test_qq_group_bootstrap_never_reads_legacy_private_memory`、`test_bootstrap_section_participant_never_fetches_legacy` 的 `language` 参数断言

## 不拆分理由 / Why Not Split

不适用（计入上限的文件 4 个，测试文件不计入）。

## 已知未做（另行排期）

- **`query_relevant_memory` 的 subject locale** —— 需要服务端把解析出的 locale 放进响应，或把 tag 渲染搬到服务端（响应契约改动）。
- **`/internal/memory/{name}/scoped_history` 同样缺耐久回落** —— 它是**写路径**，locale 决定落盘 fact 的字形，且有 legacy 单 subject 与 batched segments 两种形态要分别处理。
- **`capture_character_prompt_locale_order` 在 outbox 重放后的首次请求仍可能丢一次语言选择** —— `reserve` 的"直接采用"分支只写 `_character_locale_admission_orders`、不抬全局 `_character_locale_capture_order`。需 durable order 来自更快的时钟才触发，第二次请求即恢复。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
