### PR TITLE
修复主页面 API 错误全屏提示重复触发，并为 Web、Electron 和 TTS 错误上报增加去重保护

### DIFF
--- a/main_logic/core/manager.py
+++ b/main_logic/core/manager.py
@@ -283,6 +283,9 @@ class LLMSessionManager(
         self._tts_respawn_task: Optional[asyncio.Task] = None  # 延迟重试 Task，end_session 时取消
         self._last_tts_error_code: str = ''  # 上次 TTS 错误码
         self._tts_retry_notify_count: int = 0  # TTS 重试通知计数，前3次不通知前端
+        # User-facing TTS notices must survive handler replacement during a
+        # worker respawn. Entries are released by audio_done or session reset.
+        self._tts_notified_error_keys: set[tuple[str, str]] = set()
         self._tts_done_queued_for_turn: bool = False  # 防止同一轮次多次排入 TTS 结束信号
         self._tts_done_pending_until_ready: bool = False  # TTS未就绪时延迟到 flush 后再排入结束信号
         # Keep one utterance ledger so a replacement worker can replay consumed text.

--- a/main_logic/core/tts_runtime.py
+++ b/main_logic/core/tts_runtime.py
@@ -585,6 +585,9 @@ class TtsRuntimeMixin:
         self._last_tts_error_code = ''
         self._last_tts_respawn_time = 0.0
         self._tts_retry_notify_count = 0
+        notified_error_keys = getattr(self, "_tts_notified_error_keys", None)
+        if notified_error_keys is not None:
+            notified_error_keys.clear()
         self._tts_done_queued_for_turn = False
         self._tts_fallback_uses_default_voice = False
         self._reset_tts_replay_state()
@@ -997,7 +1000,13 @@ class TtsRuntimeMixin:
     async def tts_response_handler(self):
         q = self.tts_response_queue
         pending_failed_speech_id = ""
-        notified_error_keys: set[tuple[str, str]] = set()
+        notified_error_keys = getattr(self, "_tts_notified_error_keys", None)
+        if notified_error_keys is None:
+            # Some tests and compatibility callers construct the manager with
+            # ``__new__``. Lazily initialize while keeping normal runtimes on
+            # the manager-owned set created in ``LLMSessionManager.__init__``.
+            notified_error_keys = set()
+            self._tts_notified_error_keys = notified_error_keys
         logger.info(f"🎧 tts_response_handler started (queue id={id(q):#x})")
         while True:
             try:
@@ -1042,10 +1051,11 @@ class TtsRuntimeMixin:
                         await self.send_audio_done(data[1])
                         completed_speech_id = str(data[1] or "")
                         if completed_speech_id:
-                            notified_error_keys = {
+                            completed_keys = {
                                 key for key in notified_error_keys
-                                if key[0] != completed_speech_id
+                                if key[0] == completed_speech_id
                             }
+                            notified_error_keys.difference_update(completed_keys)
                         continue
                     if data[0] == "__ready__":
                         ready_flag = bool(data[1])

--- a/main_logic/core/tts_runtime.py
+++ b/main_logic/core/tts_runtime.py
@@ -996,6 +996,8 @@ class TtsRuntimeMixin:
 
     async def tts_response_handler(self):
         q = self.tts_response_queue
+        pending_failed_speech_id = ""
+        notified_error_keys: set[tuple[str, str]] = set()
         logger.info(f"🎧 tts_response_handler started (queue id={id(q):#x})")
         while True:
             try:
@@ -1017,6 +1019,11 @@ class TtsRuntimeMixin:
                     and data[0] in {"__tts_sentence_done__", "__tts_sentence_failed__"}
                 ):
                     _, speech_id, sentence = data
+                    if data[0] == "__tts_sentence_failed__":
+                        # Sentence workers put this marker immediately before the
+                        # matching ``__error__`` item.  Keep the speech identity so
+                        # parallel failures from one reply can share one user notice.
+                        pending_failed_speech_id = str(speech_id or "")
                     if speech_id == getattr(self, "_tts_replay_speech_id", None):
                         # marker 排在该句所有音频之后；只有音频实际送达前端才推进边界。
                         # 失败句若已播放过前缀也整体跳过，避免 fallback 从句首重念；
@@ -1033,6 +1040,12 @@ class TtsRuntimeMixin:
                         # __audio__/裸 bytes 之后。fire-and-forget 会插到尾音
                         # 前面，前端提前收尾——正是本信号要解决的问题。
                         await self.send_audio_done(data[1])
+                        completed_speech_id = str(data[1] or "")
+                        if completed_speech_id:
+                            notified_error_keys = {
+                                key for key in notified_error_keys
+                                if key[0] != completed_speech_id
+                            }
                         continue
                     if data[0] == "__ready__":
                         ready_flag = bool(data[1])
@@ -1096,6 +1109,10 @@ class TtsRuntimeMixin:
                     elif data[0] == "__error__":
                         error_msg = data[1]
                         error_msg_text = str(error_msg)
+                        error_speech_id = pending_failed_speech_id or str(
+                            getattr(self, "current_speech_id", "") or ""
+                        )
+                        pending_failed_speech_id = ""
                         logger.error(f"TTS Worker Error: {error_msg}")
 
                         # A configured endpoint failure is observable in the
@@ -1192,6 +1209,21 @@ class TtsRuntimeMixin:
                             if self._tts_retry_notify_count < 3:
                                 logger.info(f"TTS 错误重试 {self._tts_retry_notify_count}/3，暂不通知前端")
                                 continue
+                        error_code = str(self._last_tts_error_code or "")
+                        notification_key = (error_speech_id, error_code)
+                        if (
+                            error_speech_id
+                            and error_code
+                            and notification_key in notified_error_keys
+                        ):
+                            logger.info(
+                                "TTS user notice deduplicated: code=%s speech_id=%s",
+                                error_code,
+                                error_speech_id,
+                            )
+                            continue
+                        if error_speech_id and error_code:
+                            notified_error_keys.add(notification_key)
                         self._fire_task(self.send_status(user_msg))
                         continue
                 elif isinstance(data, tuple) and len(data) == 3 and data[0] == "__audio__":

--- a/static/app/app-ui/bootstrap-goodbye-and-toasts.js
+++ b/static/app/app-ui/bootstrap-goodbye-and-toasts.js
@@ -585,6 +585,20 @@ I.mod = window.appUi;
     // --- Prominent notice (modal queue) ---
     const _prominentNoticeQueue = [];
     let _prominentNoticeActive = false;
+    let _prominentNoticeActiveKey = '';
+
+    function _prominentNoticeDedupeKey(notice) {
+        if (!notice || typeof notice !== 'object') return '';
+        const visibleFields = [
+            notice.kind,
+            notice.code,
+            notice.version,
+            notice.title,
+            notice.message,
+            notice.message_en,
+        ].map(value => String(value || ''));
+        return visibleFields.some(Boolean) ? JSON.stringify(visibleFields) : '';
+    }
 
     function _prominentNoticeText(key, fallback) {
         try {
@@ -668,11 +682,13 @@ I.mod = window.appUi;
 
     function _drainProminentNoticeQueue() {
         if (_prominentNoticeActive || _prominentNoticeQueue.length === 0) return;
-        const { notice, resolve } = _prominentNoticeQueue.shift();
+        const { notice, resolve, dedupeKey } = _prominentNoticeQueue.shift();
         _prominentNoticeActive = true;
+        _prominentNoticeActiveKey = dedupeKey;
         _renderProminentNotice(notice, () => {
             resolve();
             _prominentNoticeActive = false;
+            _prominentNoticeActiveKey = '';
             _drainProminentNoticeQueue();
         });
     }
@@ -1000,7 +1016,15 @@ I.mod = window.appUi;
             notice = { message: String(noticeOrMessage ?? '') };
         }
         return new Promise((resolve) => {
-            _prominentNoticeQueue.push({ notice, resolve });
+            const dedupeKey = _prominentNoticeDedupeKey(notice);
+            const duplicatePending = dedupeKey && _prominentNoticeQueue.some(
+                item => item.dedupeKey === dedupeKey
+            );
+            if (dedupeKey && (_prominentNoticeActiveKey === dedupeKey || duplicatePending)) {
+                resolve();
+                return;
+            }
+            _prominentNoticeQueue.push({ notice, resolve, dedupeKey });
             _drainProminentNoticeQueue();
         });
     }

--- a/static/prominent-notice-dedupe.test.cjs
+++ b/static/prominent-notice-dedupe.test.cjs
@@ -90,6 +90,10 @@ test('browser prominent notices render one duplicate and advance after dismissal
     assert.deepEqual(harness.rendered, [first, second]);
     harness.dismiss();
     await secondDone;
+    const repeatedAfterDismissDone = harness.show({ ...second });
+    assert.deepEqual(harness.rendered, [first, second, second]);
+    harness.dismiss();
+    await repeatedAfterDismissDone;
 });
 
 test('desktop prominent notices render one duplicate and advance after dismissal', () => {
@@ -110,5 +114,8 @@ test('desktop prominent notices render one duplicate and advance after dismissal
     assert.deepEqual(harness.rendered, [first]);
     harness.dismiss();
     assert.deepEqual(harness.rendered, [first, second]);
+    harness.dismiss();
+    harness.show({ ...second });
+    assert.deepEqual(harness.rendered, [first, second, second]);
     harness.dismiss();
 });

--- a/static/prominent-notice-dedupe.test.cjs
+++ b/static/prominent-notice-dedupe.test.cjs
@@ -2,6 +2,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 const test = require('node:test');
+const vm = require('node:vm');
 
 const repoRoot = path.resolve(__dirname, '..');
 const browserNoticeSource = fs.readFileSync(
@@ -21,42 +22,93 @@ function sourceBetween(source, startMarker, endMarker) {
     return source.slice(start, end);
 }
 
-test('browser prominent notices merge an active or queued duplicate', () => {
-    const showBlock = sourceBetween(
-        browserNoticeSource,
-        'function showProminentNotice(noticeOrMessage)',
-        'I.mod.showProminentNotice = showProminentNotice',
+function buildNoticeHarness({ source, stateStart, renderName, showName }) {
+    const stateAndKey = sourceBetween(
+        source,
+        stateStart,
+        `function ${renderName}(`,
     );
-    const drainBlock = sourceBetween(
-        browserNoticeSource,
-        'function _drainProminentNoticeQueue()',
-        'function _renderProminentNotice(',
+    const showFunction = sourceBetween(
+        source,
+        `function ${showName}(`,
+        source === desktopToastSource ? '// ===== IPC' : 'I.mod.showProminentNotice',
     );
+    const rendered = [];
+    let dismissActive = null;
+    const context = {
+        rendered,
+        Promise,
+        String,
+        JSON,
+        setRenderCallback(callback) {
+            dismissActive = callback;
+        },
+    };
 
-    assert.match(showBlock, /_prominentNoticeDedupeKey\(notice\)/);
-    assert.match(showBlock, /_prominentNoticeQueue\.some/);
-    assert.match(showBlock, /_prominentNoticeActiveKey === dedupeKey/);
-    assert.match(showBlock, /resolve\(\);\s*return;/);
-    assert.match(drainBlock, /_prominentNoticeActiveKey = dedupeKey/);
-    assert.match(drainBlock, /_prominentNoticeActiveKey = ''/);
+    vm.runInNewContext(`
+        ${stateAndKey}
+        function ${renderName}(notice, onDismiss) {
+            rendered.push(JSON.parse(JSON.stringify(notice)));
+            setRenderCallback(onDismiss);
+        }
+        ${showFunction}
+        globalThis.noticeHarness = {
+            show: ${showName}
+        };
+    `, context);
+
+    return {
+        rendered,
+        show: context.noticeHarness.show,
+        dismiss() {
+            assert.equal(typeof dismissActive, 'function', 'expected an active notice');
+            const callback = dismissActive;
+            dismissActive = null;
+            callback();
+        },
+    };
+}
+
+test('browser prominent notices render one duplicate and advance after dismissal', async () => {
+    const harness = buildNoticeHarness({
+        source: browserNoticeSource,
+        stateStart: 'const _prominentNoticeQueue = [];',
+        renderName: '_renderProminentNotice',
+        showName: 'showProminentNotice',
+    });
+    const first = { code: 'API_KEY_REJECTED', message: 'invalid key' };
+    const second = { code: 'API_RATE_LIMIT', message: 'slow down' };
+
+    const firstDone = harness.show(first);
+    await harness.show({ ...first });
+    const secondDone = harness.show(second);
+    await harness.show({ ...second });
+
+    assert.deepEqual(harness.rendered, [first]);
+    harness.dismiss();
+    await firstDone;
+    assert.deepEqual(harness.rendered, [first, second]);
+    harness.dismiss();
+    await secondDone;
 });
 
-test('desktop prominent notices merge an active or queued duplicate', () => {
-    const showBlock = sourceBetween(
-        desktopToastSource,
-        'function showProminentNotice(notice)',
-        '// ===== IPC',
-    );
-    const drainBlock = sourceBetween(
-        desktopToastSource,
-        'function drainPnQueue()',
-        'function renderProminentNotice(',
-    );
+test('desktop prominent notices render one duplicate and advance after dismissal', () => {
+    const harness = buildNoticeHarness({
+        source: desktopToastSource,
+        stateStart: 'var pnQueue = [];',
+        renderName: 'renderProminentNotice',
+        showName: 'showProminentNotice',
+    });
+    const first = { code: 'API_KEY_REJECTED', message: 'invalid key' };
+    const second = { code: 'API_RATE_LIMIT', message: 'slow down' };
 
-    assert.match(showBlock, /prominentNoticeDedupeKey\(notice\)/);
-    assert.match(showBlock, /pnQueue\.some/);
-    assert.match(showBlock, /pnActiveKey === dedupeKey/);
-    assert.match(showBlock, /return;/);
-    assert.match(drainBlock, /pnActiveKey = item\.dedupeKey/);
-    assert.match(drainBlock, /pnActiveKey = ''/);
+    harness.show(first);
+    harness.show({ ...first });
+    harness.show(second);
+    harness.show({ ...second });
+
+    assert.deepEqual(harness.rendered, [first]);
+    harness.dismiss();
+    assert.deepEqual(harness.rendered, [first, second]);
+    harness.dismiss();
 });

--- a/static/prominent-notice-dedupe.test.cjs
+++ b/static/prominent-notice-dedupe.test.cjs
@@ -1,0 +1,62 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const repoRoot = path.resolve(__dirname, '..');
+const browserNoticeSource = fs.readFileSync(
+    path.join(repoRoot, 'static', 'app', 'app-ui', 'bootstrap-goodbye-and-toasts.js'),
+    'utf8',
+);
+const desktopToastSource = fs.readFileSync(
+    path.join(repoRoot, 'templates', 'toast.html'),
+    'utf8',
+);
+
+function sourceBetween(source, startMarker, endMarker) {
+    const start = source.indexOf(startMarker);
+    assert.notEqual(start, -1, `missing start marker: ${startMarker}`);
+    const end = source.indexOf(endMarker, start + startMarker.length);
+    assert.notEqual(end, -1, `missing end marker: ${endMarker}`);
+    return source.slice(start, end);
+}
+
+test('browser prominent notices merge an active or queued duplicate', () => {
+    const showBlock = sourceBetween(
+        browserNoticeSource,
+        'function showProminentNotice(noticeOrMessage)',
+        'I.mod.showProminentNotice = showProminentNotice',
+    );
+    const drainBlock = sourceBetween(
+        browserNoticeSource,
+        'function _drainProminentNoticeQueue()',
+        'function _renderProminentNotice(',
+    );
+
+    assert.match(showBlock, /_prominentNoticeDedupeKey\(notice\)/);
+    assert.match(showBlock, /_prominentNoticeQueue\.some/);
+    assert.match(showBlock, /_prominentNoticeActiveKey === dedupeKey/);
+    assert.match(showBlock, /resolve\(\);\s*return;/);
+    assert.match(drainBlock, /_prominentNoticeActiveKey = dedupeKey/);
+    assert.match(drainBlock, /_prominentNoticeActiveKey = ''/);
+});
+
+test('desktop prominent notices merge an active or queued duplicate', () => {
+    const showBlock = sourceBetween(
+        desktopToastSource,
+        'function showProminentNotice(notice)',
+        '// ===== IPC',
+    );
+    const drainBlock = sourceBetween(
+        desktopToastSource,
+        'function drainPnQueue()',
+        'function renderProminentNotice(',
+    );
+
+    assert.match(showBlock, /prominentNoticeDedupeKey\(notice\)/);
+    assert.match(showBlock, /pnQueue\.some/);
+    assert.match(showBlock, /pnActiveKey === dedupeKey/);
+    assert.match(showBlock, /return;/);
+    assert.match(drainBlock, /pnActiveKey = item\.dedupeKey/);
+    assert.match(drainBlock, /pnActiveKey = ''/);
+});

--- a/templates/toast.html
+++ b/templates/toast.html
@@ -226,6 +226,20 @@
         var pnAnimInjected = false;
         var pnQueue = [];
         var pnActive = false;
+        var pnActiveKey = '';
+
+        function prominentNoticeDedupeKey(notice) {
+            if (!notice || typeof notice !== 'object') return '';
+            var visibleFields = [
+                notice.kind,
+                notice.code,
+                notice.version,
+                notice.title,
+                notice.message,
+                notice.message_en,
+            ].map(function(value) { return String(value || ''); });
+            return visibleFields.some(Boolean) ? JSON.stringify(visibleFields) : '';
+        }
 
         function injectPnAnimations() {
             if (pnAnimInjected) return;
@@ -259,8 +273,10 @@
             if (pnActive || pnQueue.length === 0) return;
             var item = pnQueue.shift();
             pnActive = true;
-            renderProminentNotice(item, function() {
+            pnActiveKey = item.dedupeKey;
+            renderProminentNotice(item.notice, function() {
                 pnActive = false;
+                pnActiveKey = '';
                 drainPnQueue();
             });
         }
@@ -367,7 +383,12 @@
 
         function showProminentNotice(notice) {
             if (typeof notice === 'string') notice = { message: notice };
-            pnQueue.push(notice);
+            var dedupeKey = prominentNoticeDedupeKey(notice);
+            var duplicatePending = dedupeKey && pnQueue.some(function(item) {
+                return item.dedupeKey === dedupeKey;
+            });
+            if (dedupeKey && (pnActiveKey === dedupeKey || duplicatePending)) return;
+            pnQueue.push({ notice: notice, dedupeKey: dedupeKey });
             drainPnQueue();
         }
 

--- a/tests/unit/test_openai_compatible_tts.py
+++ b/tests/unit/test_openai_compatible_tts.py
@@ -1031,6 +1031,71 @@ async def test_tts_handler_deduplicates_api_error_notice_per_speech():
     ]
 
 
+@pytest.mark.asyncio
+async def test_tts_error_notice_dedup_survives_handler_restart_until_audio_done():
+    mgr = LLMSessionManager.__new__(LLMSessionManager)
+    api_key_error = (
+        "OpenAI TTS synthesis failed: Error code: 401 - "
+        "invalid_request_error.invalid_api_key"
+    )
+    mgr.tts_cache_lock = asyncio.Lock()
+    mgr.tts_ready = True
+    mgr.current_speech_id = "speech-1"
+    mgr._tts_replay_speech_id = None
+    mgr._tts_replay_sentence_audio_emitted = False
+    mgr._last_tts_error_code = ""
+    mgr._tts_retry_notify_count = 0
+    mgr._tts_notified_error_keys = set()
+    mgr._activate_configured_tts_fallback = lambda _stage: False
+
+    sent_statuses = []
+    status_tasks = []
+
+    async def send_status(message):
+        sent_statuses.append(json.loads(message))
+
+    async def send_audio_done(_speech_id):
+        return True
+
+    def fire_task(coro):
+        task = asyncio.create_task(coro)
+        status_tasks.append(task)
+        return task
+
+    async def run_handler(*items):
+        response_queue = queue.Queue()
+        for item in items:
+            response_queue.put(item)
+        mgr.tts_response_queue = response_queue
+        handler_task = asyncio.create_task(LLMSessionManager.tts_response_handler(mgr))
+        deadline = asyncio.get_running_loop().time() + 1
+        while not response_queue.empty() and asyncio.get_running_loop().time() < deadline:
+            await asyncio.sleep(0.01)
+        await asyncio.sleep(0.05)
+        handler_task.cancel()
+        await asyncio.gather(handler_task, return_exceptions=True)
+        if status_tasks:
+            await asyncio.gather(*status_tasks)
+
+    mgr.send_status = send_status
+    mgr.send_audio_done = send_audio_done
+    mgr._fire_task = fire_task
+
+    failed_sentence = ("__tts_sentence_failed__", "speech-1", "failed sentence")
+    await run_handler(failed_sentence, ("__error__", api_key_error))
+    await run_handler(
+        failed_sentence,
+        ("__error__", api_key_error),
+        ("__audio_done__", "speech-1"),
+    )
+    await run_handler(failed_sentence, ("__error__", api_key_error))
+
+    assert [status["code"] for status in sent_statuses] == [
+        "API_KEY_REJECTED",
+        "API_KEY_REJECTED",
+    ]
+
+
 def test_configured_tts_failure_replays_ledger_after_current_speech_id_rotates(
     monkeypatch,
 ):

--- a/tests/unit/test_openai_compatible_tts.py
+++ b/tests/unit/test_openai_compatible_tts.py
@@ -979,6 +979,58 @@ async def test_tts_handler_marks_audio_before_runtime_fallback(audio_message):
     assert observed == [True]
 
 
+@pytest.mark.asyncio
+async def test_tts_handler_deduplicates_api_error_notice_per_speech():
+    mgr = LLMSessionManager.__new__(LLMSessionManager)
+    response_queue = queue.Queue()
+    api_key_error = (
+        "OpenAI TTS synthesis failed: Error code: 401 - "
+        "invalid_request_error.invalid_api_key"
+    )
+    for speech_id in ("speech-1", "speech-1", "speech-2", "speech-2"):
+        response_queue.put(("__tts_sentence_failed__", speech_id, "failed sentence"))
+        response_queue.put(("__error__", api_key_error))
+
+    mgr.tts_response_queue = response_queue
+    mgr.tts_cache_lock = asyncio.Lock()
+    mgr.tts_ready = True
+    mgr.current_speech_id = "speech-2"
+    mgr._tts_replay_speech_id = None
+    mgr._tts_replay_sentence_audio_emitted = False
+    mgr._last_tts_error_code = ""
+    mgr._tts_retry_notify_count = 0
+    mgr._activate_configured_tts_fallback = lambda _stage: False
+
+    sent_statuses = []
+    status_tasks = []
+
+    async def send_status(message):
+        sent_statuses.append(json.loads(message))
+
+    def fire_task(coro):
+        task = asyncio.create_task(coro)
+        status_tasks.append(task)
+        return task
+
+    mgr.send_status = send_status
+    mgr._fire_task = fire_task
+
+    handler_task = asyncio.create_task(LLMSessionManager.tts_response_handler(mgr))
+    deadline = asyncio.get_running_loop().time() + 1
+    while not response_queue.empty() and asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(0.01)
+    await asyncio.sleep(0.05)
+    handler_task.cancel()
+    await asyncio.gather(handler_task, return_exceptions=True)
+    if status_tasks:
+        await asyncio.gather(*status_tasks)
+
+    assert [status["code"] for status in sent_statuses] == [
+        "API_KEY_REJECTED",
+        "API_KEY_REJECTED",
+    ]
+
+
 def test_configured_tts_failure_replays_ledger_after_current_speech_id_rotates(
     monkeypatch,
 ):


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复主页面 API 错误全屏提示重复触发，并为 Web、Electron 和 TTS 错误上报增加去重保护

## 回归报告 / Regression Report

- 改动内容：后端按 `(speech_id, error_code)` 去重用户可见的 TTS 错误通知，并让去重状态在 worker/handler 重启间保持；Web 与 Electron 全屏提示队列合并当前显示和等待中的相同通知。
- 理由：一句回复会被拆成多句 TTS 请求，同一 API 故障会逐句上报；worker 重启还可能重建 handler，导致相同错误再次弹窗。
- 前后表现：修改前同一轮 API 故障可能连续出现多个全屏提示；修改后同一轮同类错误只提示一次，不同语音轮次、不同错误码仍可独立提示。
- 潜在回归点：TTS 重试/回退、handler 重建、`audio_done` 清理、会话重置，以及 Web/Electron 提示队列顺序。已通过相应单元和行为测试覆盖。

## 不拆分理由 / Why Not Split

不适用：本 PR 计入上限的文件不超过 20 个。

## 测试 / Testing

- `uv run pytest`：TTS 相关 150 项通过。
- core/session 回归：231 项通过。
- `node --test static/prominent-notice-dedupe.test.cjs`：2 项通过。
- Electron 相关契约：92 项通过，34 项平台跳过，0 失败。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **错误修复**
  * 优化语音合成错误通知：同一语音轮次及错误类型仅提示一次，避免重复打扰。
  * 保留不同语音轮次和错误类型的独立通知，既有重试与服务回退行为不变。
  * 语音处理重启后仍能正确避免重复提示，并在音频完成后恢复后续通知。

* **体验优化**
  * 重要提示会自动合并重复内容，覆盖当前显示和等待中的通知。
  * 通知队列继续按原有顺序展示和关闭，确保其他提示正常显示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->