### PR TITLE
修复文本会话撤销语音租约后，同一连接无法重新开启语音导致启动超时的问题，并补充回归测试

### DIFF
--- a/main_routers/websocket_router.py
+++ b/main_routers/websocket_router.py
@@ -519,16 +519,42 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
 
     def _claim_voice_input_connection() -> None:
         nonlocal voice_input_claimed
-        if voice_input_claimed:
+        voice_mgr = session_manager[lanlan_name]
+        connection_id = str(this_session_id)
+        has_manager_lease_identity = hasattr(
+            voice_mgr,
+            "_voice_lease_connection_id",
+        )
+        manager_lease_connection_id = getattr(
+            voice_mgr,
+            "_voice_lease_connection_id",
+            None,
+        )
+        # ``voice_input_claimed`` means this socket engaged voice at least once;
+        # it does not guarantee the manager still binds the lease to it. A text
+        # session deliberately fail-closes the microphone route and vacates the
+        # manager lease while keeping this WebSocket alive. The next audio
+        # start on the same socket must therefore re-claim. Otherwise legacy
+        # authorization rejects before start_session is dispatched, leaving the
+        # frontend with no session_started/session_failed until its 15 s timeout.
+        #
+        # The global session-id guard above still prevents a superseded socket
+        # from reaching this path and stealing voice back from a newer window.
+        # Managers without the lease-identity field keep the historical
+        # claim-once behavior used by lightweight integrations and test doubles.
+        if voice_input_claimed and (
+            not has_manager_lease_identity
+            or manager_lease_connection_id == connection_id
+        ):
             return
         voice_input_claimed = True
         begin_voice_input = getattr(
-            session_manager[lanlan_name],
+            voice_mgr,
             "_begin_voice_input_connection",
             None,
         )
         if callable(begin_voice_input):
-            begin_voice_input(str(this_session_id))
+            begin_voice_input(connection_id)
             _voice_connection_sockets[lanlan_name] = (this_session_id, websocket)
             # Hand the socket to the manager too. mgr.websocket is reassigned
             # to every newly accepted socket, so it is the DISPLAY plane; the
@@ -537,12 +563,12 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
             # recorder superseded by a newer chat window never hears that its
             # route died and keeps the hardware mic open.
             set_voice_ws = getattr(
-                session_manager[lanlan_name],
+                voice_mgr,
                 "_set_voice_input_websocket",
                 None,
             )
             if callable(set_voice_ws):
-                set_voice_ws(str(this_session_id), websocket)
+                set_voice_ws(connection_id, websocket)
 
     def _owns_voice_connection() -> bool:
         """True while this socket still holds the manager voice identity.

--- a/tests/unit/test_websocket_binary_audio.py
+++ b/tests/unit/test_websocket_binary_audio.py
@@ -370,12 +370,26 @@ async def test_same_socket_reclaims_voice_after_text_route_revokes_lease(
     monkeypatch,
 ) -> None:
     class _TextRouteRevokesLeaseManager(_ProtocolManager):
+        def __init__(self) -> None:
+            super().__init__()
+            self.audio_authorization_count = 0
+            self.allow_text_revoke = asyncio.Event()
+            self.text_revoke_complete = asyncio.Event()
+
         async def _ensure_voice_input_session_authorized(
             self,
             connection_id: str,
         ) -> bool:
             self.calls.append(("authorize", connection_id))
-            return connection_id == self._voice_lease_connection_id
+            authorized = connection_id == self._voice_lease_connection_id
+            self.audio_authorization_count += 1
+            if self.audio_authorization_count == 2:
+                # The second audio request has already passed the router claim
+                # while the fire-and-forget text start still owns the lease.
+                # Let the delayed text task revoke only after that ordering is
+                # established, matching the production cross-mode race.
+                self.allow_text_revoke.set()
+            return authorized
 
         async def start_session(self, *_args, **_kwargs) -> None:
             input_mode = _args[2]
@@ -384,16 +398,43 @@ async def test_same_socket_reclaims_voice_after_text_route_revokes_lease(
                 # Mirrors _start_independent_asr_if_enabled: a text session
                 # fail-closes the microphone route and vacates the lease while
                 # the browser WebSocket itself remains connected.
+                await self.allow_text_revoke.wait()
                 await self._revoke_voice_input_connection(
                     self._voice_lease_connection_id
                 )
+                self.text_revoke_complete.set()
+            elif self.audio_authorization_count == 2:
+                # lifecycle._start_session_handle_inflight waits for the text
+                # start (including its revoke) before restarting audio. The
+                # frontend then sends its engaged lease_sync after receiving
+                # session_started(audio), which is the next gated WS message.
+                await self.text_revoke_complete.wait()
+
+    class _LeaseSyncAfterTextRevokeWebSocket(_EventWebSocket):
+        async def receive(self) -> dict:
+            next_event = self.events[0]
+            raw_message = next_event.get("text")
+            if isinstance(raw_message, str):
+                message = json.loads(raw_message)
+                if message.get("action") == "voice_input_control":
+                    await manager.text_revoke_complete.wait()
+            return await super().receive()
 
     manager = _TextRouteRevokesLeaseManager()
-    websocket = _EventWebSocket(
+    websocket = _LeaseSyncAfterTextRevokeWebSocket(
         [
             {"action": "start_session", "input_type": "audio"},
             {"action": "start_session", "input_type": "text"},
             {"action": "start_session", "input_type": "audio"},
+            {
+                "action": "voice_input_control",
+                "event": "lease_sync",
+                "lease_generation": 1,
+                "owner": "core",
+                "hard_muted": False,
+                "focus_suppressed": False,
+                "engaged": True,
+            },
         ]
     )
     _install_protocol_endpoint(
@@ -413,6 +454,17 @@ async def test_same_socket_reclaims_voice_after_text_route_revokes_lease(
     ]
     assert len(begin_calls) == 2
     assert authorize_calls == begin_calls
+    call_names = [name for name, _payload in manager.calls]
+    authorize_indexes = [
+        index for index, name in enumerate(call_names) if name == "authorize"
+    ]
+    begin_indexes = [
+        index for index, name in enumerate(call_names) if name == "begin"
+    ]
+    text_revoke_index = call_names.index("revoke")
+    control_index = call_names.index("control")
+    assert authorize_indexes[1] < text_revoke_index
+    assert text_revoke_index < begin_indexes[1] < control_index
     assert manager.statuses == []
 
 

--- a/tests/unit/test_websocket_binary_audio.py
+++ b/tests/unit/test_websocket_binary_audio.py
@@ -366,6 +366,57 @@ async def test_documented_legacy_audio_flow_authorizes_before_session_and_pcm(
 
 
 @pytest.mark.asyncio
+async def test_same_socket_reclaims_voice_after_text_route_revokes_lease(
+    monkeypatch,
+) -> None:
+    class _TextRouteRevokesLeaseManager(_ProtocolManager):
+        async def _ensure_voice_input_session_authorized(
+            self,
+            connection_id: str,
+        ) -> bool:
+            self.calls.append(("authorize", connection_id))
+            return connection_id == self._voice_lease_connection_id
+
+        async def start_session(self, *_args, **_kwargs) -> None:
+            input_mode = _args[2]
+            self.calls.append(("start_session", input_mode))
+            if input_mode == "text":
+                # Mirrors _start_independent_asr_if_enabled: a text session
+                # fail-closes the microphone route and vacates the lease while
+                # the browser WebSocket itself remains connected.
+                await self._revoke_voice_input_connection(
+                    self._voice_lease_connection_id
+                )
+
+    manager = _TextRouteRevokesLeaseManager()
+    websocket = _EventWebSocket(
+        [
+            {"action": "start_session", "input_type": "audio"},
+            {"action": "start_session", "input_type": "text"},
+            {"action": "start_session", "input_type": "audio"},
+        ]
+    )
+    _install_protocol_endpoint(
+        monkeypatch,
+        manager=manager,
+        websocket=websocket,
+    )
+
+    await websocket_router.websocket_endpoint(websocket, "Lan")
+
+    assert [
+        payload for name, payload in manager.calls if name == "start_session"
+    ] == ["audio", "text", "audio"]
+    begin_calls = [payload for name, payload in manager.calls if name == "begin"]
+    authorize_calls = [
+        payload for name, payload in manager.calls if name == "authorize"
+    ]
+    assert len(begin_calls) == 2
+    assert authorize_calls == begin_calls
+    assert manager.statuses == []
+
+
+@pytest.mark.asyncio
 async def test_start_session_forwards_independent_asr_handshake_before_dispatch(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复文本会话撤销语音租约后，同一连接无法重新开启语音导致启动超时的问题，并补充回归测试
在文本聊天猫娘准备回信息的瞬间开启语音会出现一个后端没有任何报错的前端有弹窗显示的错误并且无法正常使用语音
<img width="768" height="123" alt="image" src="https://github.com/user-attachments/assets/8348ead4-4d64-4a95-b20b-b0af105e3554" />

## 回归报告 / Regression Report

<!--
仅当本 PR 触碰 app/、main_logic/、memory/ 时必填。请逐项说明：
  - 改动了什么
  - 理由 / 必要性
  - 改动前后的表现对比
  - 潜在回归点（影响哪些链路、怎么验证的）
未触碰这三个模块：写「不适用」或删除本节。
-->
改动内容：调整 WebSocket 语音租约认领逻辑。当文本会话撤销语音租约但连接仍存活时，允许同一连接重新认领语音。
理由 / 必要性：此前连接级 voice_input_claimed 状态不会随后端租约撤销而重置，导致再次开启语音时跳过认领、授权失败，最终前端等待 15 秒后提示启动超时。
表现对比：改动前：文本回复期间切换语音，部分时序下后端不会启动音频会话，前端显示超时弹窗。
改动后：租约被文本会话撤销后，同一 WebSocket 可正常重新认领并启动语音。

潜在回归点与验证：涉及 WebSocket 语音租约、旧窗口接管保护、二进制音频传输及会话启动互斥。新增“语音 → 文本撤销租约 → 再次语音”回归测试，并运行相关测试共 164 项，全部通过；Ruff 与核心契约检查通过。

## 测试 / Testing

手动尝试复现方法测试是否修复


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 修复音频会话与文本会话切换后，语音连接无法重新声明或授权的问题。
  * 确保同一 WebSocket 在“音频 → 文本 → 音频”切换时，后续音频会话可正常恢复连接并通过授权。

* **测试**
  * 新增会话切换场景测试，验证连接声明、授权流程及会话启动顺序均符合预期。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->