### PR TITLE
ci: restrict automatic workflows to upstream

### DIFF
--- a/.github/workflows/dataforseo.yml
+++ b/.github/workflows/dataforseo.yml
@@ -75,7 +75,10 @@ jobs:
           npm run seo:dataforseo -- --config seo/dataforseo.online-zh.config.json --mode all --skip-keyword-difficulty --depth 100 --include-ai-overview --dry-run --output .seo-reports/dry-run-online-zh.json
 
   report:
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    if: >-
+      github.repository == 'Project-N-E-K-O/N.E.K.O' &&
+      (github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule')
     needs: test
     runs-on: ubuntu-latest
     timeout-minutes: 45

--- a/.github/workflows/docker-multi-arch.yml
+++ b/.github/workflows/docker-multi-arch.yml
@@ -56,6 +56,8 @@ jobs:
   # Job 1: Calculate version (shared by all build jobs)
   # ============================================================================
   calculate-version:
+    # Keep fork pushes from creating a runner job solely to calculate a version.
+    if: github.repository == 'Project-N-E-K-O/N.E.K.O'
     runs-on: ubuntu-latest
     outputs:
       image_version: ${{ steps.version_calc.outputs.VERSION }}

--- a/.github/workflows/docker-multi-arch.yml
+++ b/.github/workflows/docker-multi-arch.yml
@@ -56,8 +56,9 @@ jobs:
   # Job 1: Calculate version (shared by all build jobs)
   # ============================================================================
   calculate-version:
-    # Keep fork pushes from creating a runner job solely to calculate a version.
-    if: github.repository == 'Project-N-E-K-O/N.E.K.O'
+    # Fork pushes should not consume a runner; retain the documented manual
+    # validation path, which downstream Docker build jobs also allow.
+    if: github.event_name == 'workflow_dispatch' || github.repository == 'Project-N-E-K-O/N.E.K.O'
     runs-on: ubuntu-latest
     outputs:
       image_version: ${{ steps.version_calc.outputs.VERSION }}


### PR DESCRIPTION
## 改动概述 / Summary

- 将 DataForSEO 的付费 `report` job 限制为仅在 `Project-N-E-K-O/N.E.K.O` 运行；PR 的 dry-run 测试保持可用。
- fork 的 `push` 不再启动 Docker 版本计算 job；保留既有的 fork 手动 `workflow_dispatch` Docker 构建路径。

## 回归报告 / Regression Report

不适用：本 PR 未修改 `app/`、`main_logic/` 或 `memory/` 下的 Python 文件。

## 不拆分理由 / Why Not Split

不适用：本 PR 仅修改两份 GitHub Actions 工作流文件。

## 测试 / Testing

- `git diff --check`
- 使用 PyYAML 解析 `dataforseo.yml` 和 `docker-multi-arch.yml`
- 断言 `calculate-version`、`build-standard`、`build-full` 均保留 `workflow_dispatch` 路径，且版本计算 job 仍要求主仓库或手动触发。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **其他**
  * 优化自动化任务的运行条件，仅在指定仓库或符合特定触发条件时执行。
  * Fork 仓库推送不再单独触发版本计算任务，减少不必要的自动化运行。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->