### PR TITLE
test(asr)：修 Windows CI 上 ABBA 快照的计时 flake

### DIFF
--- a/tests/unit/test_asr_lifecycle_metrics.py
+++ b/tests/unit/test_asr_lifecycle_metrics.py
@@ -41,3 +41,35 @@ def test_async_detector_and_audio_ordering_metrics_are_low_cardinality() -> None
     assert snapshot["asr_abort_discarded_command_count"] == 0
     assert snapshot["provider_wire_sequence"] == 0
     assert snapshot["omni_mic_audio_bytes"] == 0
+
+
+def test_wall_clock_metrics_are_excluded_from_snapshot_comparisons():
+    """Guard the exclusion list in ``test_core_independent_asr`` against typos.
+
+    That test compares whole metric snapshots for equality, so any metric read
+    off ``time.monotonic()`` has to be excluded or the assertion turns into a
+    timing race. It cannot be derived (nothing marks a field as wall-clock), so
+    the least this can do is catch a name that no longer exists — a rename or
+    typo would silently stop excluding a real wall-clock metric.
+    """
+    import re
+    from pathlib import Path
+
+    from main_logic.asr_client.lifecycle import VoiceLifecycleMetrics
+
+    source = (
+        Path(__file__).with_name("test_core_independent_asr.py").read_text(encoding="utf-8")
+    )
+    block = re.search(
+        r"volatile_metric_names = frozenset\(\s*\{(.*?)\}\s*\)", source, re.DOTALL
+    )
+    assert block, "找不到 volatile_metric_names，测试形状变了"
+    excluded = set(re.findall(r'"([^"]+)"', block.group(1)))
+    assert excluded, "排除集是空的"
+
+    known = set(VoiceLifecycleMetrics().snapshot())
+    unknown = sorted(excluded - known)
+    assert not unknown, f"排除集里有不存在的指标名（改名或拼错）：{unknown}"
+
+    # The one that actually bit us: it is read off time.monotonic().
+    assert "asr_audio_command_queue_ms" in excluded

--- a/tests/unit/test_core_independent_asr.py
+++ b/tests/unit/test_core_independent_asr.py
@@ -8279,6 +8279,20 @@ async def test_speaker_shadow_abba_cannot_change_provider_authority(
         (SpeechActivityEvent.CANDIDATE_PAUSE,),
         (SpeechActivityEvent.SPEECH_STARTED,),
     )
+    # Metrics derived from wall-clock, excluded from the snapshot comparison
+    # because their value depends on how the runner happened to schedule us.
+    #
+    # ⚠️ Audio-duration metrics (local_audio_ms / cloud_audio_ms /
+    # provider_wire_audio_ms / suppressed_silence_ms / shadow_suppressed_audio_ms)
+    # are deliberately NOT here: they are computed from the frames fed in, so they
+    # are deterministic and are part of what this test asserts.
+    #
+    # ⚠️ Any new wall-clock metric must be added here. Nothing on the dataclass
+    # marks a field as wall-clock, so this list cannot be derived — which is how
+    # asr_audio_command_queue_ms was missed when it landed: it measures
+    # `time.monotonic() - queued_at` (asr_client/audio.py), reads 0 on an idle
+    # machine, and came back as 16 (the Windows timer granularity) on a busy CI
+    # runner, failing whole-snapshot equality on a single value.
     volatile_metric_names = frozenset(
         {
             "connect_latency_ms",
@@ -8290,6 +8304,7 @@ async def test_speaker_shadow_abba_cannot_change_provider_authority(
             "detector_queue_audio_ms",
             "detector_queue_high_water_ms",
             "detector_oldest_frame_age_ms",
+            "asr_audio_command_queue_ms",
         }
     )
     real_detector_runtime = DetectorRuntime


### PR DESCRIPTION
## 改动概述 / Summary

`test_speaker_shadow_abba_cannot_change_provider_authority` 在 Windows CI 上会随机红，红的是**一个墙钟计时值**。

它把整个 metrics snapshot 做精确相等比较，而 `asr_audio_command_queue_ms` 是真实测量：

```python
# main_logic/asr_client/audio.py
self.asr_audio_command_queue_ms = int((time.monotonic() - queued_at) * 1_000)
```

空闲机器上协程立刻被调度到，值是 `0`；CI runner 忙的时候变成 **16** —— 正好是 Windows 计时器粒度（15.6ms）。整条断言就因为这一个值而红：

```
Differing items:
{'snapshots': (...)} != {'snapshots': (...)}
-                     16,
?                     ^^
+                     0,
?                     ^
```

**这条测试本来就有排除机制**：`volatile_metric_names` 已经列了 9 个墙钟指标。`asr_audio_command_queue_ms` 是后加的字段（`lifecycle.py:198`，和 184-193 那一批分开写），加的人没同步更新排除集。补上它。

⚠️ **音频时长类指标故意不排除**：`local_audio_ms` / `cloud_audio_ms` / `provider_wire_audio_ms` / `suppressed_silence_ms` / `shadow_suppressed_audio_ms` 由喂进去的帧决定，是确定性的，正是这条测试要断言的东西。

## 回归报告 / Regression Report

不适用（只改测试文件，没有触碰 `app/` `main_logic/` `memory/` `main_routers/` 下的任何生产代码）。

## 不拆分理由 / Why Not Split

不适用。

## 测试 / Testing

顺带加一条守卫（`test_asr_lifecycle_metrics.py`）：断言排除集里的每个名字都真的存在于 metrics snapshot 中。

**它挡得住什么、挡不住什么，说清楚**：
- ✅ 改名 / 拼错导致某条排除静默失效
- ❌ **挡不住**「新加了墙钟指标但忘了排除」—— dataclass 上没有任何标记区分「墙钟」和「音频时长」两类，所以这个清单**无法**自动推导。注释里写明了新增墙钟指标必须手动加进来，以及为什么不能派生。

变异验证：撤掉新加的排除项 → 1 failed；把名字拼错一个字母 → 1 failed。

```
uv run pytest tests/unit/test_asr_lifecycle_metrics.py tests/unit/test_core_independent_asr.py -q
```
→ 281 passed。

## 为什么现在冒出来

和 [#2655](https://github.com/Project-N-E-K-O/N.E.K.O/pull/2655) / [#2659](https://github.com/Project-N-E-K-O/N.E.K.O/pull/2659) 的繁体中文改动**无关** —— 那两个 PR 新增了测试文件，改变了 `pytest-randomly` 对 `tests/unit` 的洗牌顺序，于是这条测试落到了不同的位置/机器负载下，把这条既有的 flake 撞了出来。

佐证：该测试单跑、以及只跑 `test_core_independent_asr.py` 整个文件，在 main 和那两个分支上都是绿的；本地全量跑（12322 passed）也绿。只有 CI 那次特定的调度撞上了。
