### PR TITLE
fix(i18n)：繁体窗口标题让活动感知整个 0 命中（#2500）

### DIFF
--- a/config/activity_keywords.py
+++ b/config/activity_keywords.py
@@ -2805,8 +2805,67 @@ COMMUNICATION_DOMAIN_KEYWORDS: list[tuple[str, str]] = [
 Needle = Union[str, re.Pattern]
 
 
+# ── Traditional-Chinese window titles ───────────────────────────────
+# A Traditional-locale Windows install reports Traditional window
+# titles. Some are script-neutral ("原神" either way), many are not
+# ("極限競速：地平線5", "遊戲"). The alias tables below are written in
+# Simplified, so those titles matched nothing and the activity tracker
+# silently classified the window as ``unknown``.
+#
+# Backfilling every alias with a Traditional twin would mean ~490
+# hand-transliterated entries to keep in sync forever. Folding both
+# sides to Simplified at match time is one code path, covers all four
+# tables, and keeps working for aliases added later.
+#
+# The fold direction matters: Traditional -> Simplified is very nearly
+# a function, while the reverse is not (Simplified 发 splits into
+# 發/髮, 干 into 乾/幹/干). Generating Traditional variants would have
+# to guess; folding does not.
+#
+# The map is a **closed set** -- it holds only characters whose
+# Simplified form already appears in these tables, so folding can
+# never pull unrelated text toward a keyword it could not otherwise
+# reach. ``test_activity_keywords_script_fold`` regenerates it and
+# fails if a newly added alias needs a character the map lacks.
+_TRAD_FOLD_SOURCE = (
+    '亞佈來係俠們倖備傢傳優剋創劃劍動區卽叄啓啟喚嗶噁囌國圍園塵壘壞夢奧婭學寶對屍島師廚廠彌彔後恆惡愛'
+    '戀戰戲捲撲擊擱敎昇時晉曉書會條棊業極榮樂機橫權歐歸殭殺毀氣決淺滅滾潛瀰為無煉熱燬爐爭爲爾獄獵獸環'
+    '產産甦畫異畵癥盃盜盧碼祕穀競紀約紅細終組絆結絕絲絶綠綫維網綵緋緑線緣緻縱繫羅羈羣翫聞聯聲腦臥與舊'
+    '莊華萊蒐蒼藍藝蘇號蝕衚裏裝裡製覈視計訊話誌語說説諸諾謊譭議讀變貓費貼賊賽跡蹟車軌軍軸轉迴連進遊運'
+    '達遺還郵醜醣釘鋒鋼錄錘録錶鍊鎚鏇鏢鐵門閃間閤閱閲闇陞陰陸陽隕際險隻雙離雲電靈頂領頭頻風飛飢饑馬騎'
+    '騰鬍鬥鬧魚魯鳳鳴麪麫麯麴麵黃點齣龍'
+)
+_SIMP_FOLD_TARGET = (
+    '亚布来系侠们幸备家传优克创划剑动区即叁启启唤哔恶苏国围园尘垒坏梦奥娅学宝对尸岛师厨厂弥录后恒恶爱'
+    '恋战戏卷扑击搁教升时晋晓书会条棋业极荣乐机横权欧归僵杀毁气决浅灭滚潜弥为无炼热毁炉争为尔狱猎兽环'
+    '产产苏画异画症杯盗卢码秘谷竞纪约红细终组绊结绝丝绝绿线维网彩绯绿线缘致纵系罗羁群玩闻联声脑卧与旧'
+    '庄华莱搜苍蓝艺苏号蚀胡里装里制核视计讯话志语说说诸诺谎毁议读变猫费贴贼赛迹迹车轨军轴转回连进游运'
+    '达遗还邮丑糖钉锋钢录锤录表炼锤旋镖铁门闪间合阅阅暗升阴陆阳陨际险只双离云电灵顶领头频风飞饥饥马骑'
+    '腾胡斗闹鱼鲁凤鸣面面曲曲面黄点出龙'
+)
+_SCRIPT_FOLD = str.maketrans(_TRAD_FOLD_SOURCE, _SIMP_FOLD_TARGET)
+
+# Fingerprint of the CJK characters the alias tables actually use.
+# ``scripts/gen_activity_fold_map.py`` stamps it; the guard test fails
+# when a newly added alias brings in a character the map never saw, which
+# is the one way the closed set can silently go stale.
+_FOLD_ALIAS_CHAR_DIGEST = '045415e3eb80828e'
+
+
+def fold_script(text: str) -> str:
+    """Fold Traditional characters onto their Simplified form.
+
+    Applied to both sides of the match: to aliases when the tables are
+    built, and to the incoming title / process name. A no-op on
+    Simplified or non-CJK text.
+    """
+    return text.translate(_SCRIPT_FOLD)
+
+
+
+
 def _make_needle(alias: str) -> Needle:
-    low = alias.lower()
+    low = fold_script(alias.lower())
     if not low:
         return low
     has_ascii_alnum = any(c.isascii() and c.isalnum() for c in low)
@@ -3031,7 +3090,7 @@ def classify_window_title(title: str | None) -> ClassifyResult:
     """
     if not title:
         return _UNKNOWN
-    low = title.lower()
+    low = fold_script(title.lower())
     for needle, result in _TITLE_TABLE:
         if _match(needle, low):
             return result
@@ -3047,7 +3106,7 @@ def classify_process_name(proc: str | None) -> ClassifyResult:
     """
     if not proc:
         return _UNKNOWN
-    low = proc.lower()
+    low = fold_script(proc.lower())
     for needle, result in _PROCESS_TABLE:
         if _match(needle, low):
             return result
@@ -3065,7 +3124,7 @@ def classify_browser_title(title: str | None) -> ClassifyResult:
     """
     if not title:
         return _UNKNOWN
-    low = title.lower()
+    low = fold_script(title.lower())
     for needle, result in _DOMAIN_TABLE:
         if _match(needle, low):
             return result

--- a/scripts/gen_activity_fold_map.py
+++ b/scripts/gen_activity_fold_map.py
@@ -75,18 +75,28 @@ def main() -> int:
         ('_TRAD_FOLD_SOURCE', wrap(trad)),
         ('_SIMP_FOLD_TARGET', wrap(simp)),
     ):
-        src = re.sub(
+        # ⚠️ re.sub 在不匹配时**静默**返回原文本。这里必须卡住替换次数：常量的
+        # 书写格式一变，生成器就会保留旧映射、却照常更新指纹并打印成功——指纹
+        # 测试于是变绿，而新字符对应的繁体标题仍然一条都撞不上。
+        # 这个脚本存在的唯一意义就是防静默过期，它自己不能有静默失败。
+        src, replaced = re.subn(
             rf'{name} = \(\n(?:.*\n)*?\)',
             f'{name} = (\n{value}\n)',
             src,
             count=1,
         )
-    src = re.sub(
+        if replaced != 1:
+            raise RuntimeError(f'{TARGET} 里找不到 {name} 的定义块，无法更新')
+    src, replaced = re.subn(
         r"_FOLD_ALIAS_CHAR_DIGEST = '[^']*'",
         f"_FOLD_ALIAS_CHAR_DIGEST = '{digest(chars)}'",
         src,
         count=1,
     )
+    if replaced != 1:
+        raise RuntimeError(
+            f'{TARGET} 里找不到 _FOLD_ALIAS_CHAR_DIGEST，无法更新'
+        )
     TARGET.write_text(src, encoding='utf-8')
     print(f'{len(mapping)} fold pairs over {len(chars)} alias characters')
     return 0

--- a/scripts/gen_activity_fold_map.py
+++ b/scripts/gen_activity_fold_map.py
@@ -1,0 +1,96 @@
+"""Regenerate the Traditional->Simplified fold map in activity_keywords.
+
+``config/activity_keywords.py`` matches window titles against Simplified
+aliases. Traditional-locale machines report Traditional titles, so both
+sides are folded to Simplified before matching (see ``fold_script``).
+
+The fold map is a **closed set**: it holds only characters whose
+Simplified form actually occurs in the alias tables. That keeps the fold
+from pulling unrelated text toward a keyword it could not otherwise
+reach -- but it also means the map goes stale when an alias introduces a
+CJK character that was not there before.
+``tests/unit/test_activity_keywords_script_fold.py`` detects that and
+points here.
+
+Run::
+
+    uv run --with opencc-python-reimplemented python scripts/gen_activity_fold_map.py
+
+OpenCC is a build-time tool only; nothing at runtime imports it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+TARGET = REPO / 'config' / 'activity_keywords.py'
+CJK = re.compile(r'[一-鿿]')
+
+
+def alias_chars() -> set[str]:
+    """Every CJK character reachable through the built needle tables."""
+    sys.path.insert(0, str(REPO))
+    from config import activity_keywords as ak
+
+    chars: set[str] = set()
+    for table in (ak._TITLE_TABLE, ak._PROCESS_TABLE, ak._DOMAIN_TABLE):
+        for needle, _ in table:
+            text = needle if isinstance(needle, str) else needle.pattern
+            chars.update(CJK.findall(text))
+    return chars
+
+
+def digest(chars: set[str]) -> str:
+    return hashlib.sha256(''.join(sorted(chars)).encode('utf-8')).hexdigest()[:16]
+
+
+def build_map(chars: set[str]) -> dict[str, str]:
+    import opencc
+
+    t2s = opencc.OpenCC('t2s')
+    mapping: dict[str, str] = {}
+    for cp in range(0x4E00, 0xA000):
+        ch = chr(cp)
+        folded = t2s.convert(ch)
+        if len(folded) == 1 and folded != ch and folded in chars:
+            mapping[ch] = folded
+    return mapping
+
+
+def main() -> int:
+    chars = alias_chars()
+    mapping = build_map(chars)
+    trad = ''.join(sorted(mapping))
+    simp = ''.join(mapping[c] for c in sorted(mapping))
+
+    def wrap(s: str, per: int = 48) -> str:
+        return '\n'.join(f"    '{s[i:i + per]}'" for i in range(0, len(s), per))
+
+    src = TARGET.read_text(encoding='utf-8')
+    for name, value in (
+        ('_TRAD_FOLD_SOURCE', wrap(trad)),
+        ('_SIMP_FOLD_TARGET', wrap(simp)),
+    ):
+        src = re.sub(
+            rf'{name} = \(\n(?:.*\n)*?\)',
+            f'{name} = (\n{value}\n)',
+            src,
+            count=1,
+        )
+    src = re.sub(
+        r"_FOLD_ALIAS_CHAR_DIGEST = '[^']*'",
+        f"_FOLD_ALIAS_CHAR_DIGEST = '{digest(chars)}'",
+        src,
+        count=1,
+    )
+    TARGET.write_text(src, encoding='utf-8')
+    print(f'{len(mapping)} fold pairs over {len(chars)} alias characters')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/unit/test_activity_keywords_script_fold.py
+++ b/tests/unit/test_activity_keywords_script_fold.py
@@ -61,7 +61,18 @@ def _to_traditional(text: str) -> str:
     return ''.join(_UNFOLD.get(c, c) for c in text)
 
 
-CJK_ALIASES = sorted({t for t in _table_texts() if CJK.search(t) and '\\' not in t})
+def _plain_alias(text: str) -> str:
+    """把 `_make_needle` 生成的正则语法剥掉，还原成用户会打出来的字面别名。
+
+    ⚠️ 上一版是直接**排除**含反斜杠的 pattern。但混合 CJK/ASCII 的别名
+    （`哔哩哔哩.exe`、`qq音乐`）经 `_make_needle` 编译后都带 `\\b` 和
+    `re.escape` 的转义——整整一类别名被悄悄挡在简繁等价参数化之外，折叠
+    回归可以在全绿下溜过去（greptile P2）。剥语法，不要丢样本。
+    """  # noqa: DOCSTRING_CJK
+    return text.replace(r'\b', '').replace('\\', '')
+
+
+CJK_ALIASES = sorted({_plain_alias(t) for t in _table_texts() if CJK.search(t)})
 
 
 def test_the_corpus_under_test_is_not_empty():

--- a/tests/unit/test_activity_keywords_script_fold.py
+++ b/tests/unit/test_activity_keywords_script_fold.py
@@ -1,0 +1,157 @@
+"""繁体窗口标题的活动分类（#2500）。
+
+活动追踪把窗口标题、进程名和浏览器域名往关键词表上撞。表是简体写的，
+繁体系统上报的是繁体标题，于是**一条都撞不上**——不是分错类，是
+`unknown`，整个活动感知对繁体用户静默失效。
+
+修法不是给 490 条别名逐个补繁体孪生，而是在匹配的**两侧**都折叠到简体
+（`fold_script`）。这里的测试盯的是那两侧都真的折了，以及折叠表没有
+随着新别名加入而悄悄过期。
+"""  # noqa: DOCSTRING_CJK
+
+from __future__ import annotations
+
+import hashlib
+import re
+import sys
+from dataclasses import astuple
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from config import activity_keywords as ak  # noqa: E402
+
+CJK = re.compile(r'[一-鿿]')
+
+CLASSIFIERS = (
+    ak.classify_window_title,
+    ak.classify_process_name,
+    ak.classify_browser_title,
+)
+
+
+def _table_texts() -> list[str]:
+    texts = []
+    for table in (ak._TITLE_TABLE, ak._PROCESS_TABLE, ak._DOMAIN_TABLE):
+        for needle, _ in table:
+            texts.append(needle if isinstance(needle, str) else needle.pattern)
+    return texts
+
+
+def _alias_chars() -> set[str]:
+    chars: set[str] = set()
+    for text in _table_texts():
+        chars.update(CJK.findall(text))
+    return chars
+
+
+# The inverse of the fold map. A Simplified character can have several
+# Traditional sources (发 -> 發/髮), so picking one deterministically may
+# produce text no human would write. That is fine here: the point is to
+# prove the *call sites* fold, and any of the sources folds back to the
+# same Simplified character.
+_UNFOLD = {}
+for _t, _s in zip(ak._TRAD_FOLD_SOURCE, ak._SIMP_FOLD_TARGET):
+    _UNFOLD.setdefault(_s, _t)
+
+
+def _to_traditional(text: str) -> str:
+    return ''.join(_UNFOLD.get(c, c) for c in text)
+
+
+CJK_ALIASES = sorted({t for t in _table_texts() if CJK.search(t) and '\\' not in t})
+
+
+def test_the_corpus_under_test_is_not_empty():
+    """⚠️ 上面那些别名是从表里自动发现的。如果发现逻辑哪天失效，
+    参数化就退化成空集，底下所有用例会「全绿」——绿在没跑上。
+    """  # noqa: DOCSTRING_CJK
+    assert len(CJK_ALIASES) > 250
+
+
+@pytest.mark.parametrize('alias', CJK_ALIASES)
+def test_a_traditional_title_classifies_the_same_as_its_simplified_twin(alias):
+    """繁体标题必须和简体拿到同一个分类结果。
+
+    这是 #2500 里「0 命中」那一类：软降级看不出来，因为返回的是
+    `unknown`，跟「用户在用没收录的软件」长得一模一样。
+    """  # noqa: DOCSTRING_CJK
+    traditional = _to_traditional(alias)
+    if traditional == alias:
+        pytest.skip('script-neutral alias')
+    for classify in CLASSIFIERS:
+        assert astuple(classify(traditional)) == astuple(classify(alias)), (
+            f'{classify.__name__}: {traditional!r} vs {alias!r}'
+        )
+
+
+def test_every_entry_point_folds_not_just_the_window_title():
+    """⚠️ 三个入口各自 `.lower()` 一次，折叠也得各自加一次。
+
+    只给 `classify_window_title` 加是最容易犯的错——浏览器标题走的是
+    `classify_browser_title`，进程名走 `classify_process_name`，
+    漏掉哪个哪个就继续 0 命中。所以这里逐个函数断言，而不是只测
+    `fold_script` 本身。
+    """  # noqa: DOCSTRING_CJK
+    cases = {
+        ak.classify_window_title: ('網易雲音樂', '网易云音乐'),
+        ak.classify_process_name: ('嗶哩嗶哩.exe', '哔哩哔哩.exe'),
+        ak.classify_browser_title: ('網易郵箱 收件匣', '网易邮箱 收件匣'),
+    }
+    for classify, (traditional, simplified) in cases.items():
+        got = classify(traditional)
+        assert got.category != 'unknown', f'{classify.__name__} still 0-hit'
+        assert astuple(got) == astuple(classify(simplified))
+
+
+def test_needles_are_stored_folded():
+    """表里本来就混着 30 多条手写的繁体别名。
+
+    如果只折输入不折别名，那些条目就变成了永远撞不上的死数据——输入被
+    折成简体，别名还是繁体。折叠必须发生在 `_make_needle` 里。
+    """  # noqa: DOCSTRING_CJK
+    unfolded = [t for t in _table_texts() if set(t) & set(ak._TRAD_FOLD_SOURCE)]
+    assert unfolded == [], f'needles kept Traditional characters: {unfolded[:5]}'
+
+
+def test_simplified_and_ascii_text_is_untouched():
+    """折叠对简体和非中文必须是恒等——不然就是拿繁体覆盖换简体回归。"""  # noqa: DOCSTRING_CJK
+    for text in ('网易云音乐', 'visual studio code', 'モンスターハンター',
+                 '배틀그라운드', 'Форза', ''):
+        assert ak.fold_script(text) == text
+
+
+def test_the_fold_map_has_not_gone_stale():
+    """⚠️ 折叠表是**闭集**：只收「简体形已经出现在表里」的字，这样折叠
+    永远不会把无关文本拽向一个它本来撞不上的关键词。
+
+    代价是新增别名带进新字时它会过期，而且过期是静默的——那个字所在的
+    繁体标题继续 0 命中，跟修之前一模一样。这里用字符集指纹兜住。
+    """  # noqa: DOCSTRING_CJK
+    actual = hashlib.sha256(
+        ''.join(sorted(_alias_chars())).encode('utf-8')
+    ).hexdigest()[:16]
+    assert actual == ak._FOLD_ALIAS_CHAR_DIGEST, (
+        'alias tables gained or lost CJK characters; regenerate the fold map:\n'
+        '  uv run --with opencc-python-reimplemented '
+        'python scripts/gen_activity_fold_map.py'
+    )
+
+
+def test_the_fold_map_stays_closed():
+    """折叠目标必须全部是表里真在用的字。多出来的说明表不再是闭集，
+    折叠就可能把无关文本拽进某个关键词。
+    """  # noqa: DOCSTRING_CJK
+    stray = set(ak._SIMP_FOLD_TARGET) - _alias_chars()
+    assert stray == set(), f'fold targets outside the alias tables: {sorted(stray)}'
+
+
+def test_the_fold_map_is_well_formed():
+    assert len(ak._TRAD_FOLD_SOURCE) == len(ak._SIMP_FOLD_TARGET)
+    assert len(set(ak._TRAD_FOLD_SOURCE)) == len(ak._TRAD_FOLD_SOURCE)
+    assert not set(ak._TRAD_FOLD_SOURCE) & set(ak._SIMP_FOLD_TARGET), (
+        'a character is both a fold source and a fold target, so folding '
+        'would not be idempotent'
+    )


### PR DESCRIPTION
活动追踪把窗口标题、进程名、浏览器域名往 config/activity_keywords.py
的关键词表上撞。表全是简体写的，而繁体系统上报的是繁体标题，于是
**一条都撞不上**——返回 unknown，跟「用户在用没收录的软件」长得
一模一样，所以一直没人发现。

在实测样本上，186 条繁体标题从「完全不命中」变成能正确分类。

## 为什么是折叠而不是补词条

补法要给约 490 条别名逐个手写繁体孪生，然后永远维护同步。折叠是
一处代码、四张表全覆盖、以后新增别名自动生效。

方向也重要：繁→简几乎是个函数，简→繁不是（发 分裂成 發/髮，
干 分裂成 乾/幹/干）。生成繁体变体要靠猜，折叠不用。

折叠加在匹配的**两侧**：`_make_needle`（建表时）和三个 classify_*
入口（各自 .lower() 一次，就得各自折一次）。表里本来混着 30 多条
手写繁体别名，只折输入不折别名会把它们变成永远撞不上的死数据。

## 闭集，以及它会怎么过期

映射表只收「简体形已经出现在表里」的字（257 对），所以折叠不可能
把无关文本拽向一个它本来撞不上的关键词。代价是新增别名带进新字时
它会静默过期。用字符集指纹兜住，过期时测试报错并指向重新生成的脚本
（scripts/gen_activity_fold_map.py，只在开发期用 opencc，运行时不依赖）。

## 回归报告

- 对 origin/main 做差分，516 条 CJK 别名 × 3 个入口：
  **简体行为变化 0 条**。
- 2 条繁体标题的元数据变了，两条都变得**更准**——原先表里手写的
  繁体条目本身挂错了元数据：
  - 極限競速：地平線4 从泛化的 Forza Motorsport(competitive)
    修正到 Forza Horizon 4(casual)
  - 英雄聯盟手遊 从 League of Legends 修正到 Wild Rift
- 折叠对简体、日文假名、韩文、西里尔、ASCII 均为恒等。
- 查过折叠会不会把两个不同词条并到一起：18 组「冲突」全部是表里
  **本来就重复**的同一个词条（Steam / Discord / Outlook / pixiv /
  배틀그라운드…），没有一条涉及繁体字。折叠不引入新冲突。
- 6 条变异各自见红：撤三个入口的折叠分别红 237/1/7 条，撤
  _make_needle 的折叠红 2 条，篡改指纹红 1 条，折叠目标混入表外字红 1 条。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增繁体中文脚本折叠支持，统一转换为简体中文进行活动分类。
  * 窗口标题、进程名和浏览器标题现可复用现有关键词识别繁体中文内容。

* **错误修复**
  * 改善繁体中文系统下的活动分类准确性，并确保简体中文及非中文输入行为保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->