### PR TITLE
fix(i18n)：mini-game 邀请文案对繁中是死数据，补 zh-TW 并让 locale 走得到（#2500 第八批）

### DIFF
--- a/config/prompts/prompts_proactive.py
+++ b/config/prompts/prompts_proactive.py
@@ -1303,6 +1303,22 @@ def _normalize_startup_greeting_language(lang: str) -> str:
     return normalize_prompt_locale(lang, default="en", simplified="zh", keep_traditional=True)
 
 
+def normalize_mini_game_invite_locale(lang: str) -> str:
+    """Normalize a locale to a key of the mini-game invite dicts, which include zh-TW.
+
+    Public on purpose: the consumer lives in ``main_logic.proactive_chat`` and the
+    two tables it indexes (``MINI_GAME_INVITE_LINES_BY_GAME`` and
+    ``MINI_GAME_INVITE_OPTION_LABELS``) live here. Exporting the normalizer next to
+    the tables keeps "which key scheme does this dict use" answerable in one place —
+    ``config.prompts._locale`` itself stays package-private.
+
+    ⚠️ This only pays off if the caller hands over a locale that still carries the
+    script. ``zh-TW`` that was already collapsed to ``zh`` upstream cannot be
+    recovered here, and the ``zh-TW`` rows above become unreachable data.
+    """
+    return normalize_prompt_locale(lang, default="en", simplified="zh", keep_traditional=True)
+
+
 def _resolve_master_for_template(master_name: str | None, lang_key: str) -> str:
     """Normalize master_name into a string that can go straight into the {master} placeholder.
 
@@ -3493,6 +3509,7 @@ PROACTIVE_SOURCE_LABELS = {
 MINI_GAME_INVITE_LINES_BY_GAME: dict[str, dict[str, str]] = {
     "soccer": {
         "zh": "{master_name}，要不要现在跟我一起踢一会儿足球小游戏？",
+        "zh-TW": "{master_name}，要不要現在跟我一起踢一下足球小遊戲？",
         "en": "{master_name}, want to play a quick round of the soccer mini-game with me?",
         "ja": "{master_name}、今ちょっとサッカーのミニゲーム、一緒にやらない？",
         "ko": "{master_name}, 지금 같이 축구 미니게임 한 판 어때?",
@@ -3502,6 +3519,8 @@ MINI_GAME_INVITE_LINES_BY_GAME: dict[str, dict[str, str]] = {
     },
     "badminton": {
         "zh": "{master_name}，要不要现在来一局羽毛球挑战？",
+        # 台湾惯用「羽球」而非「羽毛球」——这不是字形转换，是词汇选择。
+        "zh-TW": "{master_name}，要不要現在來一局羽球挑戰？",
         "en": "{master_name}, want to try a quick badminton rally challenge with me?",
         "ja": "{master_name}、今ちょっとバドミントンチャレンジやらない？",
         "ko": "{master_name}, 지금 배드민턴 랠리 챌린지 한 판 어때?",
@@ -3521,6 +3540,12 @@ MINI_GAME_INVITE_OPTION_LABELS: dict[str, dict[str, str]] = {
         "accept": "来一局！",
         "decline": "现在不想玩",
         "later": "等一会儿",
+    },
+    "zh-TW": {
+        "accept": "來一局！",
+        "decline": "現在不想玩",
+        # 「等一会儿」的台湾口语说法是「等一下」，不是「等一會兒」。
+        "later": "等一下",
     },
     "en": {
         "accept": "Let's play!",

--- a/main_logic/proactive_chat/mini_game_invite.py
+++ b/main_logic/proactive_chat/mini_game_invite.py
@@ -38,6 +38,7 @@ from config.prompts.prompts_proactive import (
     MINI_GAME_INVITE_KEYWORDS,
     MINI_GAME_INVITE_LINES_BY_GAME,
     MINI_GAME_INVITE_OPTION_LABELS,
+    normalize_mini_game_invite_locale,
 )
 from config.prompts.prompts_sys import _loc
 from utils.logger_config import get_module_logger
@@ -499,12 +500,7 @@ async def _attempt_mini_game_invite_delivery(
             import random as _random
             if _random.random() >= MINI_GAME_INVITE_TRIGGER_PROBABILITY:
                 return None
-    template = _loc(MINI_GAME_INVITE_LINES_BY_GAME[game_type], invite_lang)
-    safe_master = (master_name or '').strip()
-    try:
-        invite_text = template.format(master_name=safe_master).strip()
-    except Exception:
-        invite_text = template.replace('{master_name}', safe_master).strip()
+    invite_text = _render_mini_game_invite_line(game_type, invite_lang, master_name)
     if not invite_text:
         return None
 
@@ -698,6 +694,32 @@ async def _run_mini_game_invite_short_circuit(
     )
 
 
+def _render_mini_game_invite_line(
+    game_type: str, invite_lang: str, master_name: str,
+) -> str:
+    """Render the canned invite line for one game.
+
+    ``invite_lang`` is normalized to a prompt-dict key *here* rather than at the
+    call site. ``MINI_GAME_INVITE_LINES_BY_GAME`` carries a ``zh-TW`` row, and an
+    unnormalized tag (``zh_TW`` / ``zh-Hant`` / ``tchinese``) degrades through
+    ``_loc``'s Chinese fallback to the Simplified line — a wrong-script invite, not
+    an error, so nothing downstream would ever notice.
+
+    Extracted from ``_attempt_mini_game_invite_delivery`` so this is reachable
+    without standing up an activity snapshot and a delivery-capable manager: the
+    locale behaviour is otherwise only testable through the whole invite flow.
+    """
+    template = _loc(
+        MINI_GAME_INVITE_LINES_BY_GAME[game_type],
+        normalize_mini_game_invite_locale(invite_lang),
+    )
+    safe_master = (master_name or '').strip()
+    try:
+        return template.format(master_name=safe_master).strip()
+    except Exception:
+        return template.replace('{master_name}', safe_master).strip()
+
+
 def _build_mini_game_invite_options_payload(
     *,
     invite_lang: str,
@@ -708,9 +730,13 @@ def _build_mini_game_invite_options_payload(
 
     Labels go through i18n (the accept/decline/later options); choice is the
     wire-format identifier (used when the frontend button click posts back to
-    the endpoint) and stays unchanged."""
+    the endpoint) and stays unchanged.
+
+    ``invite_lang`` is normalized to a prompt-dict key first: the lookup is an
+    exact ``.get``, so an unnormalized tag (``zh_TW`` / ``zh-Hant`` / ``tchinese``)
+    would silently fall through to the Simplified labels."""
     labels = MINI_GAME_INVITE_OPTION_LABELS.get(
-        invite_lang,
+        normalize_mini_game_invite_locale(invite_lang),
         MINI_GAME_INVITE_OPTION_LABELS.get('zh', {}),
     )
     options = [

--- a/main_logic/proactive_chat/service.py
+++ b/main_logic/proactive_chat/service.py
@@ -273,6 +273,8 @@ def _command_language_candidates(
 def _resolve_proactive_locale(
     data: ProactiveChatCommand | dict,
     mgr,
+    *,
+    fmt: str = "short",
 ) -> str:
     """Resolve the active user locale for proactive chat flows.
 
@@ -280,6 +282,13 @@ def _resolve_proactive_locale(
     truth, and the process-level global language is only a final fallback. This
     keeps proactive invite copy and Phase 1-2 LLM output aligned with the live
     session whenever frontend i18n has already reported the user's language.
+
+    ``fmt="full"`` keeps the script: a short code has no room for one, so ``zh-TW``
+    and ``zh-CN`` both come out ``zh``. That is fine for consumers that only need a
+    language family, but it makes a ``zh-TW`` row in a prompt dict unreachable data.
+    Pass ``fmt="full"`` wherever the result ends up indexing such a dict — the one
+    precedence chain stays shared either way, which is the point of the parameter
+    rather than a second resolver (issue #2500).
     """
     request_lang = next(
         (value for value in _command_language_candidates(data) if value),
@@ -290,14 +299,16 @@ def _resolve_proactive_locale(
     # ``normalize_language_code`` 对未识别值默认回退 ``'en'``——必须先用公共白名单
     # 挡掉，否则 proactive 邀请文案会被静默短路成英文，错过本应命中的 session 真值。
     if request_lang and is_supported_language_code(request_lang):
-        normalized = normalize_language_code(request_lang, format="short")
+        normalized = normalize_language_code(request_lang, format=fmt)
         if normalized:
             return normalized
     session_lang = getattr(mgr, "user_language", None)
     if session_lang:
-        normalized = normalize_language_code(session_lang, format="short")
+        normalized = normalize_language_code(session_lang, format=fmt)
         if normalized:
             return normalized
+    if fmt == "full":
+        return get_global_language_full() or "en"
     return get_global_language() or "en"
 
 
@@ -729,8 +740,14 @@ async def handle_proactive_chat(
         ):
             try:
                 _break_lang = _resolve_proactive_locale(command, mgr)
+                # 邀请按钮 label 走 prompt dict（有 zh-TW 行），必须留住字形；
+                # break reminder 的其余消费点还在短码方案上，保持不动。
+                _break_invite_lang = _resolve_proactive_locale(
+                    command, mgr, fmt="full"
+                )
             except Exception:
                 _break_lang = "zh"
+                _break_invite_lang = "zh"
 
             # Resolve character_prompt up front and prepend it to every
             # break-reminder SystemMessage. Without this the model would
@@ -928,7 +945,7 @@ async def handle_proactive_chat(
                         # 埋点 best-effort，失败不影响邀请投递
                         pass
                     options_payload = _build_mini_game_invite_options_payload(
-                        invite_lang=_break_lang,
+                        invite_lang=_break_invite_lang,
                         game_type=chosen_game_type,
                         session_id=invite_session_id,
                     )
@@ -1125,7 +1142,9 @@ async def handle_proactive_chat(
         # 不再掷骰。activity_snapshot is None（隐私模式 / tracker 不可用）保守
         # 不发——无法判断是否在工作状态。
         try:
-            invite_lang = _resolve_proactive_locale(command, mgr)
+            # fmt="full"：邀请文案与三个按钮 label 都走带 zh-TW 行的 prompt dict，
+            # 短码会把 zh-TW 折成 zh，那些行就永远取不到（issue #2500）。
+            invite_lang = _resolve_proactive_locale(command, mgr, fmt="full")
         except Exception:
             invite_lang = "zh"
         # _user_invite_toggle 已经在上面 _debug_force_invite 计算前算过——把

--- a/tests/unit/test_mini_game_invite_locale_zh_tw.py
+++ b/tests/unit/test_mini_game_invite_locale_zh_tw.py
@@ -1,0 +1,299 @@
+# -*- coding: utf-8 -*-
+"""Traditional-Chinese reachability for the mini-game invite copy (issue #2500).
+
+The invite reply *keywords* were fixed in #2651 and need no locale plumbing —
+``_match_mini_game_invite_keyword`` scans every locale block at once. The invite
+**copy** is the opposite shape: one invite line and three button labels, both
+looked up by prompt-dict key. That makes them a *dead-code* risk rather than a
+zero-hit one — ``_resolve_proactive_locale`` normalized with ``format="short"``,
+and a short code has no room for a script, so ``zh-TW`` arrived as ``zh`` and any
+``zh-TW`` row would have been data nothing could ever reach.
+
+So this file pins both halves, because either one alone is silently useless:
+
+* the tables carry a ``zh-TW`` row, and
+* the locale actually gets to them with its script intact.
+
+The second half is the one that rots quietly — a later refactor that "simplifies"
+the invite call sites back to the short code leaves every test about the *table*
+green while the Traditional rows go dark again. Hence the call-site walk at the
+bottom, which discovers the call sites instead of listing them.
+"""  # noqa: DOCSTRING_CJK
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+from types import SimpleNamespace
+
+import pytest
+
+from config.prompts.prompts_proactive import (
+    MINI_GAME_INVITE_LINES_BY_GAME,
+    MINI_GAME_INVITE_OPTION_LABELS,
+    normalize_mini_game_invite_locale,
+)
+from config.prompts.prompts_sys import _loc
+from main_logic.proactive_chat import service
+from main_logic.proactive_chat.mini_game_invite import (
+    _build_mini_game_invite_options_payload,
+    _render_mini_game_invite_line,
+)
+
+# 一一对应的字形标记；两侧同形的字（局/不/想/玩/球…）不能拿来当标记，
+# 否则会把一条好好的词条判成"没转换"。
+TRADITIONAL_ONLY = "來現遊戲會戰"
+SIMPLIFIED_ONLY = "来现游戏会战"
+
+OPTION_KEYS = ("accept", "decline", "later")
+GAME_TYPES = tuple(MINI_GAME_INVITE_LINES_BY_GAME)
+
+
+# ── 1. 两张表都有 zh-TW 行 ───────────────────────────────────
+@pytest.mark.parametrize("game_type", GAME_TYPES)
+def test_every_game_invite_line_has_a_traditional_row(game_type):
+    """自动发现：新接一个 mini-game 时忘了写 zh-TW，这里就红。"""  # noqa: DOCSTRING_CJK
+    assert "zh-TW" in MINI_GAME_INVITE_LINES_BY_GAME[game_type], (
+        f"{game_type} 缺 zh-TW 邀请文案"
+    )
+
+
+def test_option_labels_have_a_traditional_row():
+    assert "zh-TW" in MINI_GAME_INVITE_OPTION_LABELS
+
+
+@pytest.mark.parametrize("game_type", GAME_TYPES)
+def test_traditional_invite_line_is_not_a_copy_of_the_simplified_one(game_type):
+    table = MINI_GAME_INVITE_LINES_BY_GAME[game_type]
+    assert table["zh-TW"] != table["zh"]
+    assert any(ch in TRADITIONAL_ONLY for ch in table["zh-TW"])
+    offenders = [ch for ch in table["zh-TW"] if ch in SIMPLIFIED_ONLY]
+    assert not offenders, f"{game_type} 的 zh-TW 文案里混进简体字：{offenders}"
+
+
+def test_traditional_option_labels_are_not_a_copy():
+    tw = MINI_GAME_INVITE_OPTION_LABELS["zh-TW"]
+    cn = MINI_GAME_INVITE_OPTION_LABELS["zh"]
+    assert set(tw) == set(cn) == set(OPTION_KEYS)
+    assert tw != cn
+    offenders = [ch for label in tw.values() for ch in label if ch in SIMPLIFIED_ONLY]
+    assert not offenders, f"zh-TW label 里混进简体字：{offenders}"
+
+
+@pytest.mark.parametrize("game_type", GAME_TYPES)
+def test_traditional_invite_line_keeps_the_placeholder(game_type):
+    """占位符丢了就会把 master_name 直接吞掉，用户看到的是一句没有称呼的邀请。"""  # noqa: DOCSTRING_CJK
+    assert "{master_name}" in MINI_GAME_INVITE_LINES_BY_GAME[game_type]["zh-TW"]
+
+
+# ── 2. locale 真的走得到那一行 ───────────────────────────────
+TRADITIONAL_SPELLINGS = ("zh-TW", "zh-tw", "zh_TW", "zh-Hant", "zh-Hant-TW", "tchinese")
+SIMPLIFIED_SPELLINGS = ("zh", "zh-CN", "zh_CN", "zh-Hans", "schinese")
+
+
+@pytest.mark.parametrize("spelling", TRADITIONAL_SPELLINGS)
+def test_every_traditional_spelling_resolves_to_the_traditional_key(spelling):
+    assert normalize_mini_game_invite_locale(spelling) == "zh-TW"
+
+
+@pytest.mark.parametrize("spelling", SIMPLIFIED_SPELLINGS)
+def test_simplified_spellings_still_resolve_to_the_simplified_key(spelling):
+    assert normalize_mini_game_invite_locale(spelling) == "zh"
+
+
+@pytest.mark.parametrize("spelling", ("en", "ja", "ko", "ru", "es", "pt"))
+def test_other_locales_are_untouched(spelling):
+    assert normalize_mini_game_invite_locale(spelling) == spelling
+
+
+@pytest.mark.parametrize("spelling", ("estonian", "undefined", "", None))
+def test_garbage_degrades_to_english_not_to_a_crash(spelling):
+    assert normalize_mini_game_invite_locale(spelling) == "en"
+
+
+def _expected_line(game_type: str, key: str, master: str) -> str:
+    return MINI_GAME_INVITE_LINES_BY_GAME[game_type][key].format(master_name=master)
+
+
+@pytest.mark.parametrize("spelling", TRADITIONAL_SPELLINGS)
+@pytest.mark.parametrize("game_type", GAME_TYPES)
+def test_invite_line_renders_traditional(game_type, spelling):
+    """⚠️ 走生产渲染函数，不在测试里先归一化再喂 ``_loc``——那样测的是
+    ``_loc`` 而不是调用点，把归一化从调用点拿掉测试照样绿。"""  # noqa: DOCSTRING_CJK
+    rendered = _render_mini_game_invite_line(game_type, spelling, "博士")
+    assert rendered == _expected_line(game_type, "zh-TW", "博士")
+
+
+@pytest.mark.parametrize("spelling", SIMPLIFIED_SPELLINGS)
+@pytest.mark.parametrize("game_type", GAME_TYPES)
+def test_invite_line_still_renders_simplified(game_type, spelling):
+    rendered = _render_mini_game_invite_line(game_type, spelling, "博士")
+    assert rendered == _expected_line(game_type, "zh", "博士")
+
+
+@pytest.mark.parametrize("game_type", GAME_TYPES)
+def test_invite_line_falls_back_to_simplified_via_loc(game_type):
+    """前提守卫：``_loc`` 对缺失的中文 key 会**静默**回落到简体（不报错），
+    所以少归一化一步的后果是"字形错了"而不是"崩了"——没有别的信号能发现。"""  # noqa: DOCSTRING_CJK
+    assert _loc(MINI_GAME_INVITE_LINES_BY_GAME[game_type], "zh-Hant") == (
+        MINI_GAME_INVITE_LINES_BY_GAME[game_type]["zh"]
+    )
+
+
+@pytest.mark.parametrize("spelling", TRADITIONAL_SPELLINGS)
+def test_option_payload_renders_traditional_labels(spelling):
+    """The payload builder does an exact ``.get``; an unnormalized tag would
+    have fallen through to the Simplified labels without any error."""
+    payload = _build_mini_game_invite_options_payload(
+        invite_lang=spelling, game_type=GAME_TYPES[0], session_id="s",
+    )
+    labels = {opt["choice"]: opt["label"] for opt in payload["options"]}
+    assert labels == MINI_GAME_INVITE_OPTION_LABELS["zh-TW"]
+    # choice 是 wire-format 标识符，不跟着 locale 变。
+    assert set(labels) == set(OPTION_KEYS)
+
+
+@pytest.mark.parametrize("spelling", SIMPLIFIED_SPELLINGS)
+def test_option_payload_still_renders_simplified_labels(spelling):
+    payload = _build_mini_game_invite_options_payload(
+        invite_lang=spelling, game_type=GAME_TYPES[0], session_id="s",
+    )
+    labels = {opt["choice"]: opt["label"] for opt in payload["options"]}
+    assert labels == MINI_GAME_INVITE_OPTION_LABELS["zh"]
+
+
+# ── 3. 解析器：短码方案会把 zh-TW 折掉 ──────────────────────
+@pytest.mark.parametrize("source", ("request", "session"))
+def test_short_format_collapses_traditional_and_full_keeps_it(source):
+    """This is the whole reason the invite path needs its own format.
+
+    Asserting the *collapse* as well as the preservation is deliberate: it
+    documents that ``fmt="short"`` is not merely suboptimal here but destroys
+    the only bit that distinguishes the two Chinese rows.
+    """
+    if source == "request":
+        data, mgr = {"language": "zh-TW"}, SimpleNamespace(user_language=None)
+    else:
+        data, mgr = {}, SimpleNamespace(user_language="zh-TW")
+
+    short = service._resolve_proactive_locale(data, mgr)
+    full = service._resolve_proactive_locale(data, mgr, fmt="full")
+
+    assert normalize_mini_game_invite_locale(short) == "zh", (
+        f"短码居然留住了字形（{short!r}），这条测试的前提没了"
+    )
+    assert normalize_mini_game_invite_locale(full) == "zh-TW", full
+
+
+@pytest.mark.parametrize("lang", ("en", "ja", "zh-CN"))
+def test_full_format_does_not_disturb_other_locales(lang):
+    mgr = SimpleNamespace(user_language=None)
+    resolved = service._resolve_proactive_locale({"language": lang}, mgr, fmt="full")
+    expected = normalize_mini_game_invite_locale(lang)
+    assert normalize_mini_game_invite_locale(resolved) == expected
+
+
+def test_request_language_still_wins_over_the_session():
+    mgr = SimpleNamespace(user_language="zh-TW")
+    resolved = service._resolve_proactive_locale({"language": "ja"}, mgr, fmt="full")
+    assert normalize_mini_game_invite_locale(resolved) == "ja"
+
+
+def test_garbage_request_language_still_falls_through_to_the_session():
+    """The supported-language whitelist predates this change and must survive it:
+    without it a corrupted localStorage short-circuits the copy to English."""
+    mgr = SimpleNamespace(user_language="zh-TW")
+    resolved = service._resolve_proactive_locale(
+        {"language": "estonian"}, mgr, fmt="full",
+    )
+    assert normalize_mini_game_invite_locale(resolved) == "zh-TW", resolved
+
+
+# ── 4. 调用点：谁给邀请路径喂 locale ─────────────────────────
+# ⚠️ 上面全是"表和解析器各自没问题"，但让 zh-TW 真正到达用户的是**调用点**。
+# 把调用点改回默认短码，上面每一条都还是绿的。所以这里 walk 一遍 service.py 的
+# AST 找出所有喂 invite_lang 的地方——自动发现，不是列清单：以后加第三个调用点
+# 也会被查到。
+INVITE_CALLEES = {
+    "_build_mini_game_invite_options_payload",
+    "run_mini_game_invite_short_circuit",
+}
+
+
+def _service_tree() -> ast.Module:
+    path = pathlib.Path(inspect.getsourcefile(service))
+    return ast.parse(path.read_text(encoding="utf-8"))
+
+
+def _callee_name(node: ast.Call) -> str:
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return ""
+
+
+def _invite_lang_arg_names() -> dict[str, set[str]]:
+    """callee -> the variable names handed to its ``invite_lang=``."""
+    found: dict[str, set[str]] = {}
+    for node in ast.walk(_service_tree()):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _callee_name(node)
+        if name not in INVITE_CALLEES:
+            continue
+        for kw in node.keywords:
+            if kw.arg != "invite_lang":
+                continue
+            assert isinstance(kw.value, ast.Name), (
+                f"{name} 的 invite_lang 不是个变量（{ast.dump(kw.value)}），"
+                "下面的赋值追踪跟不过去，请更新这条测试"
+            )
+            found.setdefault(name, set()).add(kw.value.id)
+    return found
+
+
+def test_both_invite_call_sites_are_found():
+    """Premise guard: 没找到调用点的话，下面那条测试是空转。"""  # noqa: DOCSTRING_CJK
+    found = _invite_lang_arg_names()
+    assert set(found) == INVITE_CALLEES, f"只找到 {sorted(found)}"
+
+
+def test_every_invite_locale_is_resolved_with_the_full_format():
+    """Each variable feeding ``invite_lang`` must come from a full-format resolve.
+
+    A bare string assignment (the ``except`` fallback) is fine — it carries no
+    script to lose. What must not appear is ``_resolve_proactive_locale`` called
+    without ``fmt="full"``.
+    """
+    tree = _service_tree()
+    wanted = {n for names in _invite_lang_arg_names().values() for n in names}
+
+    resolves: dict[str, list[ast.Call]] = {name: [] for name in wanted}
+    others: dict[str, list[ast.AST]] = {name: [] for name in wanted}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if not isinstance(target, ast.Name) or target.id not in wanted:
+                continue
+            value = node.value
+            if isinstance(value, ast.Call) and _callee_name(value) == "_resolve_proactive_locale":
+                resolves[target.id].append(value)
+            else:
+                others[target.id].append(value)
+
+    for name in sorted(wanted):
+        assert resolves[name], f"{name} 从来没有由 _resolve_proactive_locale 赋值过"
+        for call in resolves[name]:
+            fmt = next((kw.value for kw in call.keywords if kw.arg == "fmt"), None)
+            assert isinstance(fmt, ast.Constant) and fmt.value == "full", (
+                f"{name} 由 _resolve_proactive_locale 赋值时没有传 fmt=\"full\"，"
+                "zh-TW 会在这里被折成 zh，两张表的 zh-TW 行就成了死数据"
+            )
+        for value in others[name]:
+            assert isinstance(value, ast.Constant) and isinstance(value.value, str), (
+                f"{name} 还有一处非字符串常量的赋值（{ast.dump(value)}），"
+                "它可能带进一个被折过的短码"
+            )


### PR DESCRIPTION
承 #2500 第八批（第七批 #2666 正在 review）。

## 改动概述 / Summary

邀请**回应关键词**在 #2651 已经修好——`_match_mini_game_invite_keyword` 全语种遍历 `.values()`，压根不需要 locale 管线，繁体块写了就能命中。

邀请**文案**是相反的形状：一句邀请 + 三个按钮 label，都按 prompt-dict key 精确查表。而 `_resolve_proactive_locale` 用 `format="short"` 归一化，短码没有放字形的位置，`zh-TW` 到达时已经是 `zh`。所以这两张表**就算写了 zh-TW 行也永远取不到**——属于 issue 里的**死代码**类，不是 0 命中类。

两半必须一起补，缺一半都是白做：

| | 修前 | 修后 |
| --- | --- | --- |
| soccer 邀请句 | `要不要现在跟我一起踢一会儿足球小游戏？` | `要不要現在跟我一起踢一下足球小遊戲？` |
| badminton 邀请句 | `要不要现在来一局羽毛球挑战？` | `要不要現在來一局羽球挑戰？` |
| 三个按钮 | `来一局！` / `现在不想玩` / `等一会儿` | `來一局！` / `現在不想玩` / `等一下` |

不是逐字转换：badminton 用台湾惯用的**羽球**而非「羽毛球」，later 用**等一下**而非「等一會兒」（后者在台湾口语里基本不说）。

### locale 怎么走到那一行

- `_resolve_proactive_locale` 加 `fmt` 参数，邀请路径的两个调用点传 `fmt="full"`。**加参数而不是另写一个 resolver**：request → session → global 这条优先级链（含挡 garbage 的 `is_supported_language_code` 白名单）只应该有一份，#2500 前几批里「同一件事两份表各自维护然后漂开」出现过多次。break reminder 的其余消费点还在短码方案上，本 PR 不动它们。
- 查表处再归一化一次（`normalize_mini_game_invite_locale`，导出在两张表旁边）：`.get` 是精确匹配，`zh_TW` / `zh-Hant` / `tchinese` 会**静默**落回简体。

## 回归报告 / Regression Report

**改动了什么**

1. `main_logic/proactive_chat/service.py`：`_resolve_proactive_locale` 新增关键字参数 `fmt="short"`（默认值 = 原行为）。`fmt="full"` 时两处 `normalize_language_code(..., format=fmt)` 与末尾的 global fallback 一起换成 full 形态（`get_global_language_full()`）。两个邀请调用点改传 `fmt="full"`：短路路径的 `invite_lang`，以及 work-break 分支新增的 `_break_invite_lang`（`_break_lang` 本身不动）。
2. `main_logic/proactive_chat/mini_game_invite.py`：两处查表前归一化；把邀请句渲染从 `_attempt_mini_game_invite_delivery` 抽成 `_render_mini_game_invite_line`（纯搬移，无行为改动）。
3. `config/prompts/prompts_proactive.py`：两张表补 zh-TW 行；新增 `normalize_mini_game_invite_locale`。

**理由 / 必要性**

不改 locale 解析的话，补上的 zh-TW 行是取不到的死数据；只改解析不补表的话，`_loc` 会静默回落简体。这也是这条缺陷一直没被发现的原因：`_loc` 对缺失的中文 key **不报错**，后果是「字形错了」而不是「崩了」，没有任何信号。

**改动前后的表现对比**

繁中用户（Steam `tchinese` / 浏览器 `zh-TW` / `zh-Hant`）收到 mini-game 邀请时：修前邀请句和三个按钮全是简体；修后全是繁体。其余 locale 与简中用户的输出逐字不变（测试里对 `zh` / `zh-CN` / `zh_CN` / `zh-Hans` / `schinese` 和 en/ja/ko/ru/es/pt 都断言了）。

**潜在回归点 / 怎么验证的**

- `fmt` 默认值是 `"short"`，`_resolve_proactive_locale` 的其余六个消费点（Phase 1-2 LLM、topic hook、break reminder 文案）一个字节都没变。`test_proactive_service_boundary.py` 里那批「三条 import 路径对象同一性」和「legacy `data=` 关键字」的护栏全绿。
- `fmt="full"` 分支单独验了：garbage request lang（`estonian`）仍然穿透到 session 真值而不是短路成英文——这条白名单是之前 PR 加的，不能被这次改动带掉。
- 邀请句渲染抽函数是纯搬移；`_attempt_mini_game_invite_delivery` 的控制流、早退条件、`invite_text` 为空时返回 `None` 的语义都没动。
- work-break 分支的 `_break_invite_lang` 与 `_break_lang` 在同一个 `try/except` 里算，异常回退值同为 `"zh"`。

## 不拆分理由 / Why Not Split

不适用（计入上限 3 个文件）。

## 测试 / Testing

新增 `tests/unit/test_mini_game_invite_locale_zh_tw.py`：

- 表结构：每个 game_type 自动发现是否有 zh-TW 行（新接 mini-game 忘写就红）、不是简体的复制、没混进简体字、占位符还在
- 六种繁体写法 × 五种简体写法 × 六个其他 locale × 三种 garbage 的解析
- **走生产渲染函数**（`_render_mini_game_invite_line` / `_build_mini_game_invite_options_payload`），不在测试里先归一化再喂 `_loc`
- 前提守卫：断言 `_loc` 对缺失中文 key 确实**静默**回落简体，说明少归一化一步没有别的信号能发现
- 机制断言：同一份输入，`fmt="short"` 折成 `zh`、`fmt="full"` 留住 `zh-TW`——把「短码在这里不是次优而是把唯一的区分位销毁了」钉死
- **调用点**：walk `service.py` 的 AST 自动发现所有喂 `invite_lang` 的地方（不是列清单，以后加第三个也查得到），逐个追到赋值处断言来源是 `_resolve_proactive_locale(..., fmt="full")`，非 resolver 的赋值只允许字符串常量（`except` 兜底）

⚠️ 最后一条是这个 PR 里最重要的护栏：把两个调用点改回默认短码，上面所有关于表和解析器的用例**全是绿的**。

10 条变异全部见红：删 soccer / badminton 的 zh-TW 行、删按钮 zh-TW 块、`keep_traditional` 翻 False、两处查表去掉归一化、两个调用点改回短码、`fmt` 参数在 request / session 两个分支被忽略。

`tests/unit/test_mini_game_invite*.py`、`test_proactive_mini_game_short_circuit.py`、`test_proactive_service_boundary.py`、`test_zh_tw_input_parity.py` 共 1486 passed / 128 skipped。`check_docstring_no_cjk.py --base origin/main`、`check_prompt_zh_tw.py`、ruff 全过。
