### PR TITLE
fix(i18n)：下拉框「占位项」判定改用 dataset 标记，一次修好七种语言（#2500 第九批）

### DIFF
--- a/static/js/model_manager/dropdown-manager.js
+++ b/static/js/model_manager/dropdown-manager.js
@@ -25,6 +25,33 @@ window.addEventListener('unhandledrejection', (event) => {
 class DropdownManager {
     static instances = [];
 
+    /**
+     * 占位项 = 只是提示文案、没有真实取值的那一条（"请先加载模型" / "没有动作"）。
+     *
+     * ⚠️ 判据是 `data-placeholder` 标记，不是显示文本。按文本判断只在**简体中文**
+     * 界面下成立：这个项目支持 8 种语言，ja / ko / ru / es / pt 和 zh-TW 全部落空，
+     * 占位项被当成可选项，用户能选中一条"请先加载模型"并触发一次空加载。
+     * 生产侧用 DropdownManager.markAsPlaceholder() 打标记。
+     *
+     * 文本判断作为兜底保留：万一还有没迁过来的生产点，简中下不至于退化。
+     * 但它只是兜底——新代码一律打标记，测试里有护栏扫源码。
+     */
+    static LEGACY_PLACEHOLDER_TEXTS = ['请先加载', '请选择', '没有', '加载中', '选择模型', 'Select'];
+
+    static isPlaceholderOption(option) {
+        if (!option) return false;
+        if (option.dataset && option.dataset.placeholder === 'true') return true;
+        if (option.value !== '') return false;
+        const text = option.textContent || '';
+        return DropdownManager.LEGACY_PLACEHOLDER_TEXTS.some((t) => text.includes(t));
+    }
+
+    /** 建占位 option 时调用；返回同一个 option，方便链式写法。 */
+    static markAsPlaceholder(option) {
+        if (option && option.dataset) option.dataset.placeholder = 'true';
+        return option;
+    }
+
     static getVisualWidth(str) {
         let width = 0;
         for (const char of str) {
@@ -69,16 +96,7 @@ class DropdownManager {
                 }
                 return option.textContent;
             }),
-            shouldSkipOption: config.shouldSkipOption || ((option) => {
-                const value = option.value;
-                const text = option.textContent;
-                return value === '' && (
-                    text.includes('请先加载') ||
-                    text.includes('请选择') ||
-                    text.includes('没有') ||
-                    text.includes('加载中')
-                );
-            }),
+            shouldSkipOption: config.shouldSkipOption || DropdownManager.isPlaceholderOption,
             disabled: config.disabled || false,
             ...config
         };

--- a/static/js/model_manager/page-controller.js
+++ b/static/js/model_manager/page-controller.js
@@ -479,13 +479,6 @@ document.addEventListener('DOMContentLoaded', async () => {
                 iconAlt: window.i18next?.t('live2d.selectModel') || '选择模型',
                 iconAltKey: 'live2d.selectModel',
                 alwaysShowDefault: false,  // 显示选中的模型名字，而不是默认文本
-                shouldSkipOption: (option) => {
-                    return option.value === '' && (
-                        option.textContent.includes('请选择') ||
-                        option.textContent.includes('选择模型') ||
-                        option.textContent.includes('Select')
-                    );
-                },
                 onChange: () => {
                     updateLive2DModelSelectButtonText();
                 }
@@ -504,13 +497,6 @@ document.addEventListener('DOMContentLoaded', async () => {
                 defaultTextKey: 'live2d.selectMotion',
                 iconAlt: window.i18next?.t('live2d.selectMotion') || '选择动作',
                 iconAltKey: 'live2d.selectMotion',
-                shouldSkipOption: (option) => {
-                    return option.value === '' && (
-                        option.textContent.includes('请先加载') ||
-                        option.textContent.includes('没有动作') ||
-                        option.textContent.includes('Select')
-                    );
-                },
                 onChange: () => {
                     updateMotionSelectButtonText();
                 }
@@ -529,13 +515,6 @@ document.addEventListener('DOMContentLoaded', async () => {
                 defaultTextKey: 'live2d.selectExpression',
                 iconAlt: window.i18next?.t('live2d.selectExpression') || '选择表情',
                 iconAltKey: 'live2d.selectExpression',
-                shouldSkipOption: (option) => {
-                    return option.value === '' && (
-                        option.textContent.includes('请先加载') ||
-                        option.textContent.includes('没有表情') ||
-                        option.textContent.includes('Select')
-                    );
-                },
                 onChange: () => {
                     updateExpressionSelectButtonText();
                 }
@@ -572,12 +551,6 @@ document.addEventListener('DOMContentLoaded', async () => {
                 iconAlt: window.i18next?.t('live2d.selectVRMModel') || '选择模型',
                 iconAltKey: 'live2d.selectVRMModel',
                 alwaysShowDefault: false,
-                shouldSkipOption: (option) => {
-                    return option.value === '' && (
-                        option.textContent.includes('加载中') ||
-                        option.textContent.includes('Select')
-                    );
-                },
                 onChange: () => {
                     if (typeof updateVRMModelSelectButtonText === 'function') {
                         updateVRMModelSelectButtonText();
@@ -597,13 +570,6 @@ document.addEventListener('DOMContentLoaded', async () => {
                 defaultTextKey: 'live2d.vrmAnimation.selectAnimation',
                 iconAlt: window.i18next?.t('live2d.vrmAnimation.selectAnimation') || '选择动作',
                 iconAltKey: 'live2d.vrmAnimation.selectAnimation',
-                shouldSkipOption: (option) => {
-                    return option.value === '' && (
-                        option.textContent.includes('请先加载') ||
-                        option.textContent.includes('没有动作') ||
-                        option.textContent.includes('Select')
-                    );
-                },
                 onBeforeShow: async () => {
                     // 首次点击时加载动作列表
                     if (!animationsLoaded && currentModelType === 'live3d') {
@@ -636,13 +602,6 @@ document.addEventListener('DOMContentLoaded', async () => {
                 defaultTextKey: 'live2d.vrmExpression.selectExpression',
                 iconAlt: window.i18next?.t('live2d.vrmExpression.selectExpression') || '选择表情',
                 iconAltKey: 'live2d.vrmExpression.selectExpression',
-                shouldSkipOption: (option) => {
-                    return option.value === '' && (
-                        option.textContent.includes('请先加载') ||
-                        option.textContent.includes('没有表情') ||
-                        option.textContent.includes('Select')
-                    );
-                },
                 onChange: () => {
                     if (typeof updateVRMExpressionSelectButtonText === 'function') {
                         updateVRMExpressionSelectButtonText();
@@ -663,13 +622,6 @@ document.addEventListener('DOMContentLoaded', async () => {
                 defaultTextKey: 'live2d.mmdAnimation.selectAnimation',
                 iconAlt: window.i18next?.t('live2d.mmdAnimation.selectAnimation') || '选择VMD动画',
                 iconAltKey: 'live2d.mmdAnimation.selectAnimation',
-                shouldSkipOption: (option) => {
-                    return option.value === '' && (
-                        option.textContent.includes('请先加载') ||
-                        option.textContent.includes('没有动画') ||
-                        option.textContent.includes('Select')
-                    );
-                },
                 onChange: () => {
                     if (typeof updateMMDAnimationSelectButtonText === 'function') {
                         updateMMDAnimationSelectButtonText();
@@ -6387,7 +6339,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 const motionSelectBtn = document.getElementById('motion-select-btn');
                 if (motionSelectBtn) motionSelectBtn.disabled = true;
                 playMotionBtn.disabled = true;
-                motionSelect.innerHTML = `<option value="">${t('live2d.noMotionFiles', '没有动作文件')}</option>`;
+                motionSelect.innerHTML = `<option value="" data-placeholder="true">${t('live2d.noMotionFiles', '没有动作文件')}</option>`;
                 // 更新按钮文字
                 if (typeof updateMotionSelectButtonText === 'function') {
                     updateMotionSelectButtonText();
@@ -7656,7 +7608,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                     try {
                         const modelsResponse = await fetch('/api/live2d/models');
                         availableModels = await modelsResponse.json();
-                        modelSelect.innerHTML = `<option value="">${t('live2d.pleaseSelectModel', '选择模型')}</option>`;
+                        modelSelect.innerHTML = `<option value="" data-placeholder="true">${t('live2d.pleaseSelectModel', '选择模型')}</option>`;
                         availableModels.forEach(model => {
                             const option = document.createElement('option');
                             option.value = model.name;
@@ -8291,7 +8243,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (deletedLive2D && currentModelType === 'live2d') {
             try {
                 availableModels = await RequestHelper.fetchJson('/api/live2d/models');
-                modelSelect.innerHTML = `<option value="">${t('live2d.pleaseSelectModel', '选择模型')}</option>`;
+                modelSelect.innerHTML = `<option value="" data-placeholder="true">${t('live2d.pleaseSelectModel', '选择模型')}</option>`;
                 availableModels.forEach(model => {
                     const option = document.createElement('option');
                     option.value = model.name;

--- a/templates/model_manager.html
+++ b/templates/model_manager.html
@@ -215,7 +215,7 @@
                         <span class="round-stroke-text" id="motion-select-text" data-i18n="live2d.selectMotion" data-text="Select Motion">选择动作</span>
                     </button>
                     <select id="motion-select" class="control-select" style="display: none;" disabled>
-                        <option value="" data-i18n="live2d.pleaseLoadModel">请先加载模型</option>
+                        <option value="" data-placeholder="true" data-i18n="live2d.pleaseLoadModel">请先加载模型</option>
                     </select>
                     <div id="motion-dropdown" class="motion-dropdown" style="display: none;">
                         <!-- 下拉菜单项将动态生成 -->
@@ -235,7 +235,7 @@
                         <span class="round-stroke-text" id="expression-select-text" data-i18n="live2d.selectExpression" data-text="Select Expression">选择表情</span>
                     </button>
                     <select id="expression-select" class="control-select" style="display: none;" disabled>
-                        <option value="" data-i18n="live2d.pleaseLoadModel">请先加载模型</option>
+                        <option value="" data-placeholder="true" data-i18n="live2d.pleaseLoadModel">请先加载模型</option>
                     </select>
                     <div id="expression-dropdown" class="expression-dropdown" style="display: none;">
                         <!-- 下拉菜单项将动态生成 -->

--- a/tests/frontend/dropdown_placeholder_locale_independent.test.cjs
+++ b/tests/frontend/dropdown_placeholder_locale_independent.test.cjs
@@ -1,0 +1,161 @@
+// 下拉框的「占位项」判定必须与界面语言无关（issue #2500）。
+//
+// 原来 shouldSkipOption 按 **显示文本** 判断某个 <option> 是不是占位项：
+//     option.textContent.includes('请先加载') || ... || includes('Select')
+// 这只在简体中文界面下成立。项目支持 8 种语言，ja / ko / ru / es / pt 和 zh-TW
+// 全部落空——占位项被当成可选项，用户能选中一条「请先加载模型」并触发一次空加载。
+// 这不是「拿简体」的软降级，是 7 种语言的功能缺陷。
+//
+// 现在判据是 data-placeholder 标记；文本判断只作兜底（万一还有没迁的生产点，
+// 简中下不至于退化）。
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const PROJECT_ROOT = path.resolve(__dirname, '..', '..');
+const DROPDOWN_JS = path.join(
+    PROJECT_ROOT, 'static', 'js', 'model_manager', 'dropdown-manager.js');
+const PAGE_CONTROLLER_JS = path.join(
+    PROJECT_ROOT, 'static', 'js', 'model_manager', 'page-controller.js');
+const MODEL_MANAGER_HTML = path.join(PROJECT_ROOT, 'templates', 'model_manager.html');
+
+function loadDropdownManager() {
+    const source = fs.readFileSync(DROPDOWN_JS, 'utf8');
+    const sandbox = {
+        window: { addEventListener() {} },
+        document: { getElementById: () => null, addEventListener() {} },
+        console,
+    };
+    sandbox.globalThis = sandbox;
+    vm.createContext(sandbox);
+    vm.runInContext(source + '\n;globalThis.__DM = DropdownManager;', sandbox);
+    return sandbox.__DM;
+}
+
+const DropdownManager = loadDropdownManager();
+
+/** 最小 <option> 替身：只需要 value / textContent / dataset。 */
+function option({ value = '', text = '', placeholder = false } = {}) {
+    return { value, textContent: text, dataset: placeholder ? { placeholder: 'true' } : {} };
+}
+
+// 同一条占位文案的 8 种语言写法。只有简中那条能被旧的文本判断认出来。
+const PLACEHOLDER_TEXT_BY_LOCALE = {
+    'zh-CN': '请先加载模型',
+    'zh-TW': '請先載入模型',
+    en: 'Load a model first',
+    ja: 'まずモデルを読み込んでください',
+    ko: '먼저 모델을 불러오세요',
+    ru: 'Сначала загрузите модель',
+    es: 'Primero carga un modelo',
+    pt: 'Carregue um modelo primeiro',
+};
+
+test('打了标记的占位项，8 种语言下都被识别', () => {
+    for (const [locale, text] of Object.entries(PLACEHOLDER_TEXT_BY_LOCALE)) {
+        assert.equal(
+            DropdownManager.isPlaceholderOption(option({ text, placeholder: true })),
+            true,
+            `${locale} 的占位项没被识别：${text}`,
+        );
+    }
+});
+
+test('没有标记时，只有简中那条能靠文本兜底认出来——这正是原来的缺陷', () => {
+    const recognised = Object.entries(PLACEHOLDER_TEXT_BY_LOCALE)
+        .filter(([, text]) => DropdownManager.isPlaceholderOption(option({ text })))
+        .map(([locale]) => locale);
+    // 前提守卫：兜底确实只覆盖简中。如果哪天它覆盖了更多语言，上面那条测试
+    // 就不再证明「标记」在起作用了，得回来重写。
+    assert.deepEqual(recognised, ['zh-CN']);
+});
+
+test('真实可选项不会被当成占位项', () => {
+    const realOptions = [
+        option({ value: 'hiyori', text: 'Hiyori' }),
+        option({ value: '_no_motion_', text: '无动作' }),
+        option({ value: '_no_expression_', text: '无表情' }),
+        // ⚠️ 文案里带「没有」但有真实取值 —— 兜底的文本判断要求 value === ''
+        option({ value: 'x', text: '没有动作文件' }),
+    ];
+    for (const opt of realOptions) {
+        assert.equal(DropdownManager.isPlaceholderOption(opt), false,
+            `真实可选项被当成占位：${opt.textContent}`);
+    }
+});
+
+test('null / undefined 不炸', () => {
+    assert.equal(DropdownManager.isPlaceholderOption(null), false);
+    assert.equal(DropdownManager.isPlaceholderOption(undefined), false);
+});
+
+test('markAsPlaceholder 打的标记，isPlaceholderOption 认得', () => {
+    const opt = option({ text: 'まずモデルを読み込んでください' });
+    assert.equal(DropdownManager.isPlaceholderOption(opt), false);
+    assert.equal(DropdownManager.markAsPlaceholder(opt), opt);
+    assert.equal(DropdownManager.isPlaceholderOption(opt), true);
+});
+
+// ── 调用点：别再各写各的 ────────────────────────────────────
+test('DropdownManager 的默认 shouldSkipOption 就是这条共用判据', () => {
+    // ⚠️ 上面几条只测谓词。默认实现被换回按文本判断的闭包时它们全是绿的——
+    // 必须打调用点。构造函数在找不到 button 时提前 return，但 config 已经装好了。
+    const manager = new DropdownManager({ buttonId: 'nope', selectId: 'nope' });
+    assert.equal(manager.config.shouldSkipOption, DropdownManager.isPlaceholderOption);
+});
+
+test('page-controller 里不再有按显示文本判断占位项的闭包', () => {
+    const source = fs.readFileSync(PAGE_CONTROLLER_JS, 'utf8');
+    const offenders = source
+        .split('\n')
+        .map((line, i) => [i + 1, line])
+        .filter(([, line]) => /textContent\.includes\(/.test(line));
+    assert.deepEqual(offenders, [],
+        `这些行还在按显示文本判断，改用 DropdownManager.isPlaceholderOption：\n` +
+        offenders.map(([n, l]) => `  ${n}: ${l.trim()}`).join('\n'));
+});
+
+test('「所有选项都被跳过」这条路径有空值保护', () => {
+    // ⚠️ 这条路径对 ja / ko / ru / es / pt 是**新的**：改之前它们一条都不跳过，
+    // find() 从来没返回过 undefined。简中早就会走到这里（占位项本来就被跳过），
+    // 所以行为是对齐而不是新增，但代码得先扛得住。
+    const source = fs.readFileSync(DROPDOWN_JS, 'utf8');
+    const findLine = source.indexOf('.find(opt => !this.config.shouldSkipOption(opt))');
+    assert.ok(findLine > 0, 'find(...) 那处不见了，这条测试失去前提');
+    const after = source.slice(findLine, findLine + 200);
+    assert.match(after, /if\s*\(firstDisplayOption\)/,
+        'find() 可能返回 undefined，取值前必须判空');
+});
+
+test('兜底文案表是旧的 7 个闭包 + 默认实现的并集，简中行为不变', () => {
+    // 旧实现里出现过的全部文案（git 里逐条核对过）。'没有动作'/'没有动画'/
+    // '没有表情' 被 '没有' 覆盖。
+    const oldTexts = ['Select', '加载中', '没有动作', '没有动画', '没有表情',
+        '请先加载', '请选择', '选择模型'];
+    for (const text of oldTexts) {
+        assert.equal(
+            DropdownManager.isPlaceholderOption(option({ text: `X${text}X` })),
+            true,
+            `旧规则会跳过 ${text}，新规则不跳了——简中行为退化`,
+        );
+    }
+});
+
+test('HTML 里 value 为空的占位项要么打了标记，要么本来就不该跳过', () => {
+    const html = fs.readFileSync(MODEL_MANAGER_HTML, 'utf8');
+    // 只看 value="" 的（没有 value 属性时 option.value 等于文本，不会被判为占位）
+    const emptyValueOptions = [...html.matchAll(/<option value=""[^>]*>([^<]*)<\/option>/g)];
+    assert.ok(emptyValueOptions.length >= 4, '模板里的占位项都没了？这条测试失去了前提');
+    for (const m of emptyValueOptions) {
+        const tag = m[0];
+        const text = m[1];
+        const marked = tag.includes('data-placeholder="true"');
+        const wouldSkipByText = ['请先加载', '请选择', '没有', '加载中', '选择模型', 'Select']
+            .some((t) => text.includes(t));
+        assert.equal(marked, wouldSkipByText,
+            `${text}：打标记(${marked}) 与「旧文本规则会不会跳过」(${wouldSkipByText}) 不一致。` +
+            `本 PR 只做语言对齐，不改简中下跳不跳的既有判断。`);
+    }
+});


### PR DESCRIPTION
承 #2500 第九批。已合/在评审：#2616、#2651、#2652、#2655、#2659、#2662、#2666（ban-topic 正则）、#2668（mini-game 邀请文案）。

## 原本是什么样

下拉框判断某个 `<option>` 是不是「占位项」（`请先加载模型` / `没有动作`），用的是**显示文本**：

```js
// static/js/model_manager/page-controller.js
shouldSkipOption: (option) => option.value === '' && (
    option.textContent.includes('请先加载') ||
    option.textContent.includes('没有动作') ||
    option.textContent.includes('Select')
)
```

这只在**简体中文**界面下成立。项目支持 8 种语言，ja / ko / ru / es / pt **和 zh-TW** 全部落空——占位项被当成可选项，用户能在下拉里选中一条「请先加载模型」并触发一次空加载。

所以这条不是 issue 里的「拿简体」软降级，是**七种语言的功能缺陷**。

规模也比 issue 里写的「两处」大：`page-controller.js` 里 7 个 `shouldSkipOption` 闭包 + `dropdown-manager.js` 的默认实现，覆盖 9 个 select（model / motion / expression / vrm-model / vrm-animation / vrm-expression / mmd-animation / persistent-expression / pngtuber-state-preview）。那 7 个闭包本来就是同一个概念各抄了一份，文案列表还互相不一致。

## 改法

按 issue 里建议的方向：判 `data-placeholder` 标记，不判文本。

- `DropdownManager.isPlaceholderOption()` —— 一份共用判据
- `DropdownManager.markAsPlaceholder()` —— 生产侧用
- 7 个闭包全部删掉，走默认实现
- 旧的文本判断作为**兜底**保留：万一还有没迁过来的生产点，简中下不至于退化。兜底文案表是旧的 7 个闭包 + 默认实现的**并集**（`没有动作`/`没有动画`/`没有表情` 被 `没有` 覆盖），有测试钉住

### 两条刻意收窄的边界

⚠️ **只标记「旧规则在简中下本来就跳过」的占位项**（3 处 `innerHTML` + 2 处模板），其余保持不变。这个 PR 严格等于「其余七种语言对齐简中」，不顺手改简中下跳不跳的既有 UX 判断——`未找到可用模型` / `加载失败` 这类目前是可选项，就还让它是可选项。改这些是另一个判断，不该混在 i18n 修复里。

⚠️ **「所有选项都被跳过」对 ja/ko/ru/es/pt 是新路径**。改之前它们一条都不跳过，`find(...)` 从没返回过 `undefined`。查过两个消费点都有空值保护（`if (firstDisplayOption)` / `forEach` 内 `return`），所以结果是和简中对齐（空列表 + 按钮显示默认文案）而不是崩，并加了测试钉住这个保护。

## 回归报告 / Regression Report

不适用（未触碰 app/ | main_logic/ | main_routers/ | memory/）。

## 不拆分理由 / Why Not Split

不适用（计入上限 3 个文件）。

## 测试 / Testing

`tests/frontend/dropdown_placeholder_locale_independent.test.cjs`（`node --test`，10 passed），直接 `vm` 加载真实的 `dropdown-manager.js`，不是副本：

- 同一条占位文案的 **8 种语言写法**全部被识别
- **前提守卫**：断言兜底文本判断**只认得出简中那条**——否则上面那条测试就不再证明「标记」在起作用，得回来重写
- **调用点测试**：`DropdownManager` 的默认 `shouldSkipOption` 必须**就是**这条共用判据。只测谓词的话，把默认实现换回文本闭包依然全绿
- **源码扫描**：`page-controller.js` 里不许再出现 `textContent.includes(`
- **模板一致性**：`value=""` 的 option，打标记 ⟺ 旧文本规则会跳过（防止顺手改了简中 UX）
- 真实可选项（`_no_motion_` / `_no_expression_`）不被误判；`null` / `undefined` 不炸

7 条变异全部见红：拆掉 dataset 判据、`markAsPlaceholder` 不写 dataset、默认实现换回文本闭包、兜底表删 `没有`、兜底表整个删、page-controller 里重新写一个文本闭包、模板去掉 `data-placeholder`。

⚠️ **没有做浏览器实测**：这几个页面要起整个 NEKO 应用才能打开，`.claude/launch.json` 里没有对应的 dev server 配置。上面的验证全部是对真实源文件的 headless 断言（谓词 + 调用点 + 源码扫描 + 模板），DOM 层面的目视确认还欠着。

## 不在这个 PR 里

`static/js/live2d_parameter_editor.js:783` 是**另一个**消费者（不走 `DropdownManager`），同类缺陷，可分离，留到下一批。
