### PR TITLE
fix(ci): prevent SEO report jobs in forks

### DIFF
--- a/.github/workflows/dataforseo.yml
+++ b/.github/workflows/dataforseo.yml
@@ -45,6 +45,7 @@ concurrency:
 
 jobs:
   test:
+    if: github.repository == 'Project-N-E-K-O/N.E.K.O'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/docs/scripts/dataforseo/workflow.test.mjs
+++ b/docs/scripts/dataforseo/workflow.test.mjs
@@ -36,9 +36,13 @@ test('scheduled and manually dispatched paid runs force a depth-100 AIO baseline
 test('forks cannot run validation or paid report jobs', async () => {
   const workflow = await readWorkflow()
 
-  assert.equal(
-    (workflow.match(/github\.repository == 'Project-N-E-K-O\/N\.E\.K\.O'/gu) ?? []).length,
-    2,
+  assert.match(
+    workflow,
+    /jobs:\r?\n  test:\r?\n    if: github\.repository == 'Project-N-E-K-O\/N\.E\.K\.O'/,
+  )
+  assert.match(
+    workflow,
+    /\r?\n  report:\r?\n    if: >-\r?\n      github\.repository == 'Project-N-E-K-O\/N\.E\.K\.O' &&/,
   )
 })
 

--- a/docs/scripts/dataforseo/workflow.test.mjs
+++ b/docs/scripts/dataforseo/workflow.test.mjs
@@ -33,6 +33,15 @@ test('scheduled and manually dispatched paid runs force a depth-100 AIO baseline
   assert.doesNotMatch(workflow, /ENABLE_PAID_DATAFORSEO_SCHEDULE/)
 })
 
+test('forks cannot run validation or paid report jobs', async () => {
+  const workflow = await readWorkflow()
+
+  assert.equal(
+    (workflow.match(/github\.repository == 'Project-N-E-K-O\/N\.E\.K\.O'/gu) ?? []).length,
+    2,
+  )
+})
+
 test('maintainer documentation cannot revive the obsolete paid-schedule kill switch', async () => {
   const guide = await readMaintainerGuide()
 


### PR DESCRIPTION
## Summary
- complete the canonical-repository guard by applying it to the remaining `test` job
- keep the existing protected paid `report` job unchanged
- prevent fork schedules and manual dispatches from starting runners, reading secrets, or reaching DataForSEO collection
- add a regression test requiring guards on both workflow jobs

## Behavior
GitHub may still create a skipped workflow record in a fork after it syncs this commit, but no runner job starts and no API request or paid collection occurs. Pull requests evaluated in the canonical repository continue to run normally.

## Testing
- `node --test docs/scripts/dataforseo/workflow.test.mjs` (6/6 passed)
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **安全性改进**
  - 限制数据验证与付费报告工作流仅在指定官方仓库中执行，降低分叉仓库误触发任务的风险。
  - 手动或定时触发条件保持不变，并增加自动化检查，确保仓库限制持续生效。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->