### PR TITLE
为完整聊天框新增头像道具配置功能，并优化悬浮工具按钮排布

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -428,7 +428,7 @@ describe('App', () => {
 
       fireEvent.click(screen.getByRole('button', { name: 'Emoji' }));
       const toolGroup = screen.getByRole('group', { name: 'Tool icons' });
-      expect(Array.from(toolGroup.querySelectorAll<HTMLButtonElement>('.composer-icon-button'))
+      expect(Array.from(toolGroup.querySelectorAll<HTMLButtonElement>('.composer-icon-button[data-avatar-tool-id]'))
         .map(button => button.getAttribute('aria-label'))).toEqual(['棒棒糖', '猫爪', '锤子']);
       fireEvent.click(screen.getByRole('button', { name: '棒棒糖' }));
 
@@ -460,6 +460,43 @@ describe('App', () => {
     } finally {
       restoreLive2dBounds();
     }
+  });
+
+  it('lets the full chat configure the avatar tools shown in its emoji menu', async () => {
+    const onAvatarToolStateChange = vi.fn();
+    const { container } = render(
+      <App chatSurfaceMode="full" onAvatarToolStateChange={onAvatarToolStateChange} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Emoji' }));
+    const toolGroup = screen.getByRole('group', { name: 'Tool icons' });
+    expect(toolGroup.querySelectorAll('[data-avatar-tool-id]')).toHaveLength(3);
+    expect(toolGroup).toHaveAttribute('data-avatar-tool-button-count', '4');
+    expect(toolGroup.querySelector('.full-avatar-tool-settings-divider')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Edit quick tools' })).toHaveClass(
+      'composer-icon-button',
+      'full-avatar-tool-settings-button',
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit quick tools' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Manage tools' });
+    expect(dialog.querySelector('[data-avatar-tool-library-id="rps"]')).not.toBeNull();
+
+    fireEvent.click(dialog.querySelector('.avatar-tool-manager-remove') as HTMLButtonElement);
+    fireEvent.click(dialog.querySelector('[data-avatar-tool-library-id="rps"]') as HTMLButtonElement);
+    fireEvent.click(dialog.querySelector('.avatar-tool-manager-action.primary') as HTMLButtonElement);
+
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Manage tools' })).toBeNull());
+    expect(Array.from(toolGroup.querySelectorAll<HTMLElement>('[data-avatar-tool-id]'))
+      .map(button => button.dataset.avatarToolId)).toEqual(['rps', 'fist', 'hammer']);
+    expect(JSON.parse(window.localStorage.getItem(ACTIVE_AVATAR_TOOLS_STORAGE_KEY) || '[]'))
+      .toEqual(['rps', 'fist', 'hammer']);
+
+    fireEvent.click(container.querySelector('[data-avatar-tool-id="rps"]') as HTMLButtonElement);
+    await waitFor(() => expect(onAvatarToolStateChange).toHaveBeenLastCalledWith(expect.objectContaining({
+      active: true,
+      toolId: 'rps',
+    })));
   });
 
   it('publishes only the strict desktop descriptor from the full chat surface', async () => {

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -465,7 +465,11 @@ describe('App', () => {
   it('lets the full chat configure the avatar tools shown in its emoji menu', async () => {
     const onAvatarToolStateChange = vi.fn();
     const { container } = render(
-      <App chatSurfaceMode="full" onAvatarToolStateChange={onAvatarToolStateChange} />,
+      <App
+        chatSurfaceMode="full"
+        assistantName="Neko"
+        onAvatarToolStateChange={onAvatarToolStateChange}
+      />,
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Emoji' }));
@@ -496,6 +500,9 @@ describe('App', () => {
     await waitFor(() => expect(onAvatarToolStateChange).toHaveBeenLastCalledWith(expect.objectContaining({
       active: true,
       toolId: 'rps',
+      roundChoiceResultLabels: expect.objectContaining({
+        avatar_win: 'Neko wins',
+      }),
     })));
   });
 

--- a/frontend/react-neko-chat/src/FullChatSurface.tsx
+++ b/frontend/react-neko-chat/src/FullChatSurface.tsx
@@ -24,11 +24,17 @@ import CompactExportHistoryPanel, {
 import { getChatCompanionEmptyStateFallback, getChatEmptyStateFallback } from './chat-copy';
 import { i18n } from './i18n';
 import { useFocusGlow } from './useFocusGlow';
+import AvatarToolItemManager, { type AvatarToolManagerAnchorRect } from './AvatarToolItemManager';
 import AvatarToolVisuals from './avatar-tools/presentation';
 import { useAvatarToolRuntime } from './avatar-tools/runtime';
 import {
   AVAILABLE_FULL_AVATAR_TOOLS,
+  persistActiveAvatarToolIds,
+  readPersistedActiveAvatarToolIds,
   resolveAvatarToolMenuIconVisual,
+  sanitizeAvatarToolIds,
+  withAvatarToolAssetVersion,
+  type AvatarToolId,
   type AvatarToolItem,
 } from './avatarTools';
 import { useGuideChatButtonLock } from './useGuideChatButtonLock';
@@ -484,6 +490,9 @@ export default function FullChatSurface({
   const [catDraft, setCatDraft] = useState('');
   const visibleDraft = catLocalTextOnly ? catDraft : draft;
   const [toolMenuOpen, setToolMenuOpen] = useState(false);
+  const [activeAvatarToolIds, setActiveAvatarToolIds] = useState<AvatarToolId[]>(readPersistedActiveAvatarToolIds);
+  const [avatarToolManagerOpen, setAvatarToolManagerOpen] = useState(false);
+  const [avatarToolManagerAnchorRect, setAvatarToolManagerAnchorRect] = useState<AvatarToolManagerAnchorRect | null>(null);
   // Collapse the right-side tools into an overflow menu when the composer gets
   // narrow, while preserving the exit and re-entry animations for the tool row.
   type ComposerLayout = 'expanded' | 'collapsing' | 'compact' | 'expanding';
@@ -573,6 +582,29 @@ export default function FullChatSurface({
   const effectiveToolVariant = avatarToolRuntime.effectiveVariant;
   const clearAvatarTool = avatarToolRuntime.clearTool;
   const selectAvatarTool = avatarToolRuntime.selectTool;
+  const configuredToolIconItems = useMemo(() => {
+    const availableById = new Map(toolIconItems.map(item => [item.id, item]));
+    return activeAvatarToolIds
+      .map(toolId => availableById.get(toolId))
+      .filter((item): item is AvatarToolItem => !!item);
+  }, [activeAvatarToolIds]);
+
+  const handleAvatarToolManagerSave = useCallback((toolIds: AvatarToolId[]) => {
+    const nextToolIds = sanitizeAvatarToolIds(toolIds);
+    setActiveAvatarToolIds(nextToolIds);
+    persistActiveAvatarToolIds(nextToolIds);
+    setAvatarToolManagerOpen(false);
+    setAvatarToolManagerAnchorRect(null);
+    if (activeAvatarToolId && !nextToolIds.includes(activeAvatarToolId as AvatarToolId)) {
+      clearAvatarTool();
+    }
+  }, [activeAvatarToolId, clearAvatarTool]);
+
+  useEffect(() => {
+    if (!activeAvatarToolId) return;
+    if (activeAvatarToolIds.includes(activeAvatarToolId as AvatarToolId)) return;
+    clearAvatarTool();
+  }, [activeAvatarToolIds, activeAvatarToolId, clearAvatarTool]);
 
   // Rollback draft when host signals a RESPONSE_TOO_LONG error
   // Use _rollbackKey for dedup. It changes on every rollbackLastDraft() call
@@ -1969,10 +2001,19 @@ export default function FullChatSurface({
     if (!catLocalTextOnly) return;
     closeCompactInputToolFan();
     setToolMenuOpen(false);
+    setAvatarToolManagerOpen(false);
+    setAvatarToolManagerAnchorRect(null);
     setOverflowMenuOpen(false);
     setCompactExportPreviewOpen(false);
     clearAvatarTool();
   }, [catLocalTextOnly, clearAvatarTool, closeCompactInputToolFan]);
+
+  useEffect(() => {
+    if (!composerHidden) return;
+    setToolMenuOpen(false);
+    setAvatarToolManagerOpen(false);
+    setAvatarToolManagerAnchorRect(null);
+  }, [composerHidden]);
 
   useEffect(() => {
     if (!catLocalTextOnly) setCatDraft('');
@@ -2353,8 +2394,9 @@ export default function FullChatSurface({
           className="composer-icon-popover"
           role="group"
           aria-label={toolIconsAriaLabel}
+          data-avatar-tool-button-count={configuredToolIconItems.length + 1}
         >
-          {toolIconItems.map(item => {
+          {configuredToolIconItems.map(item => {
             const itemLabel = getToolItemLabel(item);
             const menuVariant = activeAvatarToolId === item.id
               ? effectiveToolVariant
@@ -2365,6 +2407,7 @@ export default function FullChatSurface({
               key={item.id}
               className={`composer-icon-button${activeAvatarToolId === item.id ? ' is-active' : ''}`}
               type="button"
+              data-avatar-tool-id={item.id}
               aria-pressed={activeAvatarToolId === item.id}
               aria-label={itemLabel}
               data-neko-tooltip={itemLabel}
@@ -2386,6 +2429,32 @@ export default function FullChatSurface({
             </button>
             );
           })}
+          <button
+            className="composer-icon-button full-avatar-tool-settings-button"
+            type="button"
+            aria-label={i18n('chat.avatarToolEdit', 'Edit quick tools')}
+            data-neko-tooltip={i18n('chat.avatarToolEdit', 'Edit quick tools')}
+            disabled={composerInteractionsDisabled}
+            onClick={(event) => {
+              const rect = event.currentTarget.getBoundingClientRect();
+              setAvatarToolManagerAnchorRect({
+                left: rect.left,
+                top: rect.top,
+                right: rect.right,
+                bottom: rect.bottom,
+                width: rect.width,
+                height: rect.height,
+              });
+              setAvatarToolManagerOpen(true);
+            }}
+          >
+            <img
+              className="composer-icon-button-image full-avatar-tool-settings-icon"
+              src={withAvatarToolAssetVersion('/static/assets/avatar-tools/ui/edit.png')}
+              alt=""
+              aria-hidden="true"
+            />
+          </button>
         </div>
       ) : null}
     </div>
@@ -2847,7 +2916,7 @@ export default function FullChatSurface({
           role="group"
           aria-label={toolIconsAriaLabel}
         >
-          {toolIconItems.map(item => {
+          {configuredToolIconItems.map(item => {
             const itemLabel = getToolItemLabel(item);
             const menuVariant = activeAvatarToolId === item.id
               ? effectiveToolVariant
@@ -2858,6 +2927,7 @@ export default function FullChatSurface({
               key={item.id}
               className={`composer-icon-button${activeAvatarToolId === item.id ? ' is-active' : ''}`}
               type="button"
+              data-avatar-tool-id={item.id}
               aria-pressed={activeAvatarToolId === item.id}
               aria-label={itemLabel}
               data-neko-tooltip={itemLabel}
@@ -3093,6 +3163,17 @@ export default function FullChatSurface({
       {compactExportHistoryNode}
       {compactChoiceLayerNode}
       <AvatarToolVisuals model={avatarToolRuntime.visualModel} />
+      <AvatarToolItemManager
+        open={!composerHidden && avatarToolManagerOpen}
+        activeToolIds={activeAvatarToolIds}
+        availableTools={toolIconItems}
+        anchorRect={avatarToolManagerAnchorRect}
+        onSave={handleAvatarToolManagerSave}
+        onCancel={() => {
+          setAvatarToolManagerOpen(false);
+          setAvatarToolManagerAnchorRect(null);
+        }}
+      />
       <section
         className={`chat-window ${surfaceModeClassName}`}
         aria-label={chatWindowAriaLabel}

--- a/frontend/react-neko-chat/src/FullChatSurface.tsx
+++ b/frontend/react-neko-chat/src/FullChatSurface.tsx
@@ -436,6 +436,7 @@ export default function FullChatSurface({
   title = i18n('chat.title', 'N.E.K.O Chat'),
   iconSrc = '/static/icons/chat_icon.png',
   messages = defaultMessages,
+  assistantName = '',
   inputPlaceholder = i18n('chat.textInputPlaceholder', 'Type a message...'),
   sendButtonLabel = i18n('chat.send', 'Send'),
   chatWindowAriaLabel = i18n('chat.reactWindowAriaLabel', 'Neko chat window'),
@@ -575,6 +576,7 @@ export default function FullChatSurface({
     onInteraction: onAvatarInteraction,
     onStateChange: onAvatarToolStateChange,
     getToolLabel: getToolItemLabel,
+    avatarName: assistantName,
     onDeactivate: () => setToolMenuOpen(false),
   });
   const activeAvatarToolId = avatarToolRuntime.activeToolId;

--- a/frontend/react-neko-chat/src/avatar-tools/catalog.test.ts
+++ b/frontend/react-neko-chat/src/avatar-tools/catalog.test.ts
@@ -32,11 +32,13 @@ describe('avatar tool definitions', () => {
     });
   });
 
-  it('projects all definitions into Compact while keeping Full on its fixed three tools', () => {
+  it('projects all definitions into both chat surfaces', () => {
     expect(AVAILABLE_COMPACT_AVATAR_TOOLS.map(tool => tool.id)).toEqual(
       AVATAR_TOOL_DEFINITIONS.map(definition => definition.id),
     );
-    expect(AVAILABLE_FULL_AVATAR_TOOLS.map(tool => tool.id)).toEqual(['lollipop', 'fist', 'hammer']);
+    expect(AVAILABLE_FULL_AVATAR_TOOLS.map(tool => tool.id)).toEqual(
+      AVATAR_TOOL_DEFINITIONS.map(definition => definition.id),
+    );
     AVATAR_TOOL_DEFINITIONS.forEach((definition) => {
       const tool = AVAILABLE_COMPACT_AVATAR_TOOLS.find(candidate => candidate.id === definition.id);
       expect(tool).toMatchObject({
@@ -53,7 +55,7 @@ describe('avatar tool definitions', () => {
     });
   });
 
-  it('keeps the three-slot defaults while allowing Compact to equip rps', () => {
+  it('keeps the three-slot defaults while allowing rps to be equipped', () => {
     expect(MAX_ACTIVE_AVATAR_TOOLS).toBe(3);
     expect(DEFAULT_ACTIVE_AVATAR_TOOL_IDS).toEqual(['lollipop', 'fist', 'hammer']);
     expect(sanitizeAvatarToolIds(['rps', 'fist', 'rps', 'hammer', 'lollipop'])).toEqual([

--- a/frontend/react-neko-chat/src/avatarTools.ts
+++ b/frontend/react-neko-chat/src/avatarTools.ts
@@ -44,7 +44,6 @@ export type AvatarToolItem = {
 export const ACTIVE_AVATAR_TOOLS_STORAGE_KEY = 'neko.reactChatWindow.activeAvatarTools';
 export const MAX_ACTIVE_AVATAR_TOOLS = 3;
 export const DEFAULT_ACTIVE_AVATAR_TOOL_IDS: AvatarToolId[] = ['lollipop', 'fist', 'hammer'];
-const FULL_AVATAR_TOOL_IDS = new Set<AvatarToolId>(['lollipop', 'fist', 'hammer']);
 
 function projectAvatarToolDefinitionToItem(definition: AvatarToolDefinition): AvatarToolItem {
   const { primary, secondary, tertiary } = definition.visual.variants;
@@ -107,9 +106,7 @@ const REGISTERED_AVATAR_TOOLS: AvatarToolItem[] =
   AVATAR_TOOL_DEFINITIONS.map(projectAvatarToolDefinitionToItem);
 
 export const AVAILABLE_COMPACT_AVATAR_TOOLS: AvatarToolItem[] = REGISTERED_AVATAR_TOOLS;
-export const AVAILABLE_FULL_AVATAR_TOOLS: AvatarToolItem[] = REGISTERED_AVATAR_TOOLS.filter(
-  item => FULL_AVATAR_TOOL_IDS.has(item.id),
-);
+export const AVAILABLE_FULL_AVATAR_TOOLS: AvatarToolItem[] = REGISTERED_AVATAR_TOOLS;
 
 const AVAILABLE_AVATAR_TOOL_IDS = new Set<AvatarToolId>(REGISTERED_AVATAR_TOOLS.map(item => item.id));
 

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -2070,6 +2070,39 @@ body.neko-electron-runtime .app-shell:not(.chat-surface-mode-compact)[data-focus
   animation: bubblePopoverAppear 0.24s cubic-bezier(0.2, 0.9, 0.2, 1.15) both;
 }
 
+.composer-icon-popover .full-avatar-tool-settings-button {
+  animation-delay: -1.55s;
+}
+
+.composer-icon-popover .full-avatar-tool-settings-icon {
+  width: 32px;
+  height: 32px;
+}
+
+.composer-icon-popover[data-avatar-tool-button-count="4"] .composer-icon-button:nth-child(1),
+.composer-icon-popover[data-avatar-tool-button-count="4"] .composer-icon-button:nth-child(4) {
+  top: 8px;
+}
+
+.composer-icon-popover[data-avatar-tool-button-count="4"] .composer-icon-button:nth-child(2),
+.composer-icon-popover[data-avatar-tool-button-count="4"] .composer-icon-button:nth-child(3) {
+  top: -2px;
+}
+
+.composer-icon-popover[data-avatar-tool-button-count="3"] .composer-icon-button:nth-child(1),
+.composer-icon-popover[data-avatar-tool-button-count="3"] .composer-icon-button:nth-child(3) {
+  top: 6px;
+}
+
+.composer-icon-popover[data-avatar-tool-button-count="3"] .composer-icon-button:nth-child(2) {
+  top: -3px;
+}
+
+.composer-icon-popover[data-avatar-tool-button-count="2"] .composer-icon-button,
+.composer-icon-popover[data-avatar-tool-button-count="1"] .composer-icon-button {
+  top: 0;
+}
+
 .composer-icon-button {
   --composer-icon-bubble-scale: 1;
   position: relative;


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

为完整聊天框新增头像道具配置功能，并优化悬浮工具按钮排布

## 测试 / Testing

手动测试使用

## UI小改动

- 之前：
<img width="181" height="108" alt="image" src="https://github.com/user-attachments/assets/d069b188-2eef-4a5d-b7f6-879f074299bd" />

- 之后：
<img width="258" height="121" alt="image" src="https://github.com/user-attachments/assets/dcff93a5-a414-4761-9664-88e4b5b24b9a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 支持自定义全量聊天中的头像工具快捷项，可添加或移除工具。
  - 快捷工具配置会自动保存，重新打开后仍可使用。
  - 头像工具菜单现支持全部已注册工具，并提供完整与紧凑两种展示方式。
- **样式优化**
  - 优化不同数量快捷工具的排列、动画与图标尺寸，提升菜单显示效果。
- **测试**
  - 新增快捷工具管理、持久化及工具选择行为的测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->