### PR TITLE
统一语音识别二级菜单机制，并在免费 Core 下禁用独立 ASR 开关，确保免费 API 不受该设置影响

### DIFF
--- a/main_logic/asr_client/__init__.py
+++ b/main_logic/asr_client/__init__.py
@@ -32,6 +32,7 @@ from ._infra import (
 from ._registry_meta import (
     ASR_PROVIDER_REGISTRY as _ASR_PROVIDER_REGISTRY,
     CORE_ASR_ROUTES as _CORE_ASR_ROUTES,
+    AsrCoreCapabilities,
     AsrEndpointingMode as _AsrEndpointingMode,
     AsrProviderAvailability as _AsrProviderAvailability,
 )
@@ -60,10 +61,24 @@ from .workers.step import (
 
 
 __all__ = [
+    "AsrCoreCapabilities",
     "AsrSessionConfig",
     "RealtimeAsrSession",
     "create_asr_session",
+    "get_asr_core_capabilities",
 ]
+
+
+def get_asr_core_capabilities(core_type: str) -> AsrCoreCapabilities | None:
+    """Return route-owned ASR capabilities, or ``None`` for an unknown Core.
+
+    Callers must preserve their fail-closed behavior for ``None`` instead of
+    treating an unrecognized route as native-only.
+    """
+
+    core_key = str(core_type or "").strip().lower()
+    route = _CORE_ASR_ROUTES.get(core_key)
+    return None if route is None else route.capabilities
 
 
 # Providers with a restricted language matrix reuse their worker's own

--- a/main_logic/asr_client/_registry_meta.py
+++ b/main_logic/asr_client/_registry_meta.py
@@ -14,7 +14,7 @@
 
 """Single source of truth for Core-to-ASR routing and provider metadata."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Literal
 
@@ -39,6 +39,13 @@ class AsrProviderAvailability(str, Enum):
 
 
 @dataclass(frozen=True, slots=True)
+class AsrCoreCapabilities:
+    """Feature capabilities owned by one Core-to-ASR route."""
+
+    supports_independent_asr: bool = True
+
+
+@dataclass(frozen=True, slots=True)
 class AsrCoreRoute:
     """Bind one Core to its ASR provider, credential slot, and region."""
 
@@ -46,6 +53,9 @@ class AsrCoreRoute:
     credential_field: str
     region: Literal["cn", "intl"] | None = None
     default_endpointing_mode: AsrEndpointingMode = "manual"
+    capabilities: AsrCoreCapabilities = field(
+        default_factory=AsrCoreCapabilities,
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -135,9 +145,17 @@ CORE_ASR_ROUTES: dict[str, AsrCoreRoute] = {
         provider_key="gemini",
         credential_field="ASSIST_API_KEY_GEMINI",
     ),
-    # The free backend is blocked before credential resolution. An empty field
-    # makes it impossible to accidentally borrow AUDIO_API_KEY in the future.
-    "free": AsrCoreRoute(provider_key="free", credential_field=""),
+    # Free Core owns microphone transcription natively. Keep that product
+    # capability separate from the provider's implementation status: callers
+    # deciding between native and independent routing must never attempt this
+    # provider, while direct independent-ASR construction continues to fail
+    # closed if it is called incorrectly. An empty credential field also makes
+    # it impossible to accidentally borrow AUDIO_API_KEY in the future.
+    "free": AsrCoreRoute(
+        provider_key="free",
+        credential_field="",
+        capabilities=AsrCoreCapabilities(supports_independent_asr=False),
+    ),
 }
 
 

--- a/main_logic/core/asr_runtime.py
+++ b/main_logic/core/asr_runtime.py
@@ -16,6 +16,7 @@ from typing import Callable, ClassVar, Literal
 
 from websockets import exceptions as web_exceptions
 
+from main_logic.asr_client import get_asr_core_capabilities
 from main_logic.asr_client.runtime import (
     AsrRuntimeCallbacks,
     AsrStartStatus,
@@ -558,6 +559,11 @@ class AsrRuntimeMixin:
             return
         self._omni_mic_audio_bytes = 0
         core_type = str(getattr(self, "core_api_type", "") or "").strip().lower()
+        core_asr_capabilities = get_asr_core_capabilities(core_type)
+        supports_independent_asr = bool(
+            core_asr_capabilities is None
+            or core_asr_capabilities.supports_independent_asr
+        )
         self._independent_asr_route_key = core_type
         session_epoch = self._capture_ingress_token().session_epoch
         start_connection_id = self._voice_lease_connection_id
@@ -631,7 +637,7 @@ class AsrRuntimeMixin:
                 if handshake_override is ...
                 else handshake_override
             )
-            if unreadable_handshake is False:
+            if not supports_independent_asr or unreadable_handshake is False:
                 if not core_start_is_current():
                     return
                 # Same landing as the ordinary `not enabled` path below.
@@ -681,7 +687,13 @@ class AsrRuntimeMixin:
             if handshake_override is ...
             else handshake_override
         )
-        if handshake_enabled is not None:
+        if not supports_independent_asr:
+            # Some Core routes own speech recognition natively. Their route
+            # capability takes precedence over both the persisted preference
+            # and the per-session handshake, so a stale enabled toggle cannot
+            # turn a healthy native voice session into a blocked one.
+            enabled = False
+        elif handshake_enabled is not None:
             # The start_session handshake carries the frontend's authoritative
             # toggle; it overrides the persisted read, which is stale when the
             # settings POST failed or was still in flight at session start.

--- a/main_routers/config_router/core_config.py
+++ b/main_routers/config_router/core_config.py
@@ -139,10 +139,12 @@ async def get_core_config_api():
             core_config_path = str(config_manager.get_runtime_config_path('core_config.json'))
             core_cfg = await read_json_async(core_config_path)
             api_key = core_cfg.get('coreApiKey', '')
+            runtime_core_config = await config_manager.aget_core_config()
         except FileNotFoundError:
             # 如果文件不存在，返回当前配置中的CORE_API_KEY
             _config_manager = get_config_manager()
             core_config = await _config_manager.aget_core_config()
+            runtime_core_config = core_config
             api_key = core_config.get('CORE_API_KEY','')
             # 创建空的配置对象用于返回默认值
             core_cfg = {}
@@ -161,6 +163,19 @@ async def get_core_config_api():
         _assist_api_provider = core_cfg.get('assistApi') or runtime_assist_api_provider
         if not _assist_api_provider:
             _assist_api_provider = 'free' if _core_api_provider == 'free' else 'qwen'
+        realtime_config = await config_manager.aget_model_api_config(
+            'realtime',
+            core_config=runtime_core_config,
+        )
+        _effective_core_api_provider = str(
+            realtime_config.get('api_type')
+            or runtime_core_config.get('CORE_API_TYPE')
+            or _core_api_provider
+        ).strip().lower()
+        from main_logic.asr_client import get_asr_core_capabilities
+        _core_asr_capabilities = get_asr_core_capabilities(
+            _effective_core_api_provider
+        )
         _fallback_providers = {_core_api_provider, _assist_api_provider}
         _doubao_tts_shared_key = ''
         if str(core_cfg.get('ttsModelProvider') or '').strip() == 'doubao_tts':
@@ -173,6 +188,12 @@ async def get_core_config_api():
         response = {
             "api_key": api_key,
             "coreApi": _core_api_provider,
+            "effectiveCoreApi": _effective_core_api_provider,
+            "supportsIndependentAsr": (
+                None
+                if _core_asr_capabilities is None
+                else _core_asr_capabilities.supports_independent_asr
+            ),
             "assistApi": _assist_api_provider,
             "assistApiKeyQwen": core_cfg.get('assistApiKeyQwen', '') or _fb('qwen'),
             "assistApiKeyQwenIntl": core_cfg.get('assistApiKeyQwenIntl', '') or _fb('qwen_intl'),

--- a/static/app/app-audio-capture.js
+++ b/static/app/app-audio-capture.js
@@ -360,11 +360,11 @@
         ensureShareToggleStateObserver();
 
         var mini = !!(options && options.mini);
-        // 用 span + role=button：迷你版会嵌在设置行 <button> 内，原生 button 嵌套是非法 HTML
-        var button = document.createElement('span');
+        // The control is a sibling of the action trigger in the shared row, so
+        // it can use native button semantics without nesting interactive UI.
+        var button = document.createElement('button');
+        button.type = 'button';
         button.className = 'neko-share-toggle-btn' + (mini ? ' neko-share-toggle-mini' : '');
-        button.setAttribute('role', 'button');
-        button.setAttribute('tabindex', '0');
         button.setAttribute('aria-busy', 'false');
         button.dataset.nekoScreenShareAction = 'toggle';
 
@@ -479,12 +479,6 @@
         }
 
         button.addEventListener('click', handleToggleClick);
-        button.addEventListener('keydown', function (event) {
-            if (event.key === 'Enter' || event.key === ' ') {
-                event.preventDefault();
-                handleToggleClick(event);
-            }
-        });
 
         pruneShareToggleButtons();
         shareToggleButtonRegistry.push(button);
@@ -3568,6 +3562,10 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
             }
 
             function isMicActionHoverSurfaceActive() {
+                var hoveredActionRow = leftColumn.querySelector(
+                    '[data-neko-mic-main-action-row]:hover'
+                );
+                if (hoveredActionRow) return true;
                 var hoveredAction = leftColumn.querySelector('[data-neko-mic-main-action]:hover');
                 if (hoveredAction) return true;
                 var panel = getOwnedMicSubwindow();
@@ -3590,8 +3588,10 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
                     micActionHoverCollapseTimer = null;
                     if (isMicActionHoverSurfaceActive()) return;
                     closeMicSubwindow();
-                    leftColumn.querySelectorAll('[data-neko-mic-main-action]').forEach(function (btn) {
-                        btn.style.background = 'transparent';
+                    leftColumn.querySelectorAll(
+                        '[data-neko-mic-main-action-row], [data-neko-mic-main-action]'
+                    ).forEach(function (surface) {
+                        surface.style.background = 'transparent';
                     });
                 }, MIC_ACTION_HOVER_COLLAPSE_MS);
             }
@@ -3754,7 +3754,7 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
                 return panel;
             }
 
-            function createMainActionButton(iconText, label, subLabel, actionKey, onClick, hoverGuard) {
+            function createMainActionButton(iconText, label, subLabel, actionKey, onClick) {
                 var button = document.createElement('button');
                 button.type = 'button';
                 button.dataset.nekoMicMainAction = actionKey;
@@ -3805,15 +3805,12 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
                 button.appendChild(textWrap);
                 button.appendChild(arrow);
 
+                function actionSurface() {
+                    return button._nekoMicActionRow || button;
+                }
+
                 function openActionPanel(event) {
-                    // 悬停守卫：指针在内嵌开关（如屏幕共享开关）上时不展开子面板，避免干扰点击
-                    if (
-                        typeof hoverGuard === 'function'
-                        && hoverGuard(event)
-                    ) {
-                        return Promise.resolve(null);
-                    }
-                    button.style.background = 'var(--neko-popup-hover)';
+                    actionSurface().style.background = 'var(--neko-popup-hover)';
                     return openMicActionPanel(actionKey, onClick).catch(function (error) {
                         console.error('[麦克风弹窗] 子窗口打开失败:', error);
                     });
@@ -3824,7 +3821,10 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
                     openActionPanel(event);
                 });
                 button.addEventListener('mouseleave', function () {
-                    button.style.background = 'transparent';
+                    // Shared rows own the full hover surface, including any
+                    // sibling toggle. Their mouseleave handler closes the panel.
+                    if (button._nekoMicActionRow) return;
+                    actionSurface().style.background = 'transparent';
                     scheduleMicActionHoverCollapse();
                 });
                 button.addEventListener('click', function (e) {
@@ -3832,6 +3832,41 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
                     openActionPanel(e);
                 });
                 return button;
+            }
+
+            function createMainActionRow(actionButton, trailingControl) {
+                var row = document.createElement('div');
+                row.className = 'neko-mic-main-action-row';
+                row.dataset.nekoMicMainActionRow = actionButton.dataset.nekoMicMainAction;
+                Object.assign(row.style, {
+                    width: '100%',
+                    minWidth: '0',
+                    maxWidth: '100%',
+                    boxSizing: 'border-box',
+                    display: 'flex',
+                    alignItems: 'center',
+                    borderRadius: '6px',
+                    background: 'transparent',
+                    transition: 'background 0.2s ease'
+                });
+                actionButton._nekoMicActionRow = row;
+                actionButton.style.width = '0';
+                actionButton.style.flex = '1 1 0%';
+                row.appendChild(actionButton);
+                if (trailingControl) {
+                    var arrow = actionButton.lastElementChild;
+                    if (arrow) arrow.remove();
+                    trailingControl.style.marginRight = '10px';
+                    row.appendChild(trailingControl);
+                }
+                row.addEventListener('mouseenter', function () {
+                    clearMicActionHoverCollapseTimer();
+                });
+                row.addEventListener('mouseleave', function () {
+                    row.style.background = 'transparent';
+                    scheduleMicActionHoverCollapse();
+                });
+                return row;
             }
 
             function createMicDeviceOption(label, deviceId) {
@@ -4017,50 +4052,20 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
             var screenButtonLabel = window.t ? window.t('buttons.screenShare') : 'Screen Share';
 
             var firstContent = leftColumn.firstChild;
-            function isPointerOverActionToggle(toggle, event) {
-                if (!toggle) return false;
-                // Keyboard-generated button clicks use detail=0 and synthetic
-                // coordinates (often 0,0); they must keep the native button's
-                // Enter/Space behavior regardless of the mouse position.
-                if (event && event.type === 'click' && event.detail === 0) {
-                    return false;
-                }
-                if (toggle.matches(':hover')) return true;
-                if (
-                    !event
-                    || event.type !== 'mouseenter'
-                    || typeof document.elementFromPoint !== 'function'
-                    || !Number.isFinite(event.clientX)
-                    || !Number.isFinite(event.clientY)
-                ) return false;
-                var pointerTarget = document.elementFromPoint(
-                    event.clientX,
-                    event.clientY
-                );
-                return !!(pointerTarget && toggle.contains(pointerTarget));
-            }
-            // 悬停守卫：指针落在行内开关上时不展开屏幕源面板，避免面板弹出干扰点击开关
-            var shareToggleButtonHolder = { current: null };
-            function screenRowHoverGuard(event) {
-                return isPointerOverActionToggle(
-                    shareToggleButtonHolder.current,
-                    event
-                );
-            }
             var screenActionButton = createMainActionButton(
                 null,
                 screenButtonLabel,
                 window.t ? window.t('app.screenSource.screens') : 'Screens',
                 'screen',
-                openScreenSourceSubwindow,
-                screenRowHoverGuard
+                openScreenSourceSubwindow
             );
-            leftColumn.insertBefore(screenActionButton, firstContent);
-            // 合并为一行：行右侧嵌入迷你胶囊开关（替换原来的 chevron 箭头），
-            // 点击行其余位置仍展开屏幕源选择，点击开关本身开始/停止共享
             var shareToggleButton = createScreenShareToggleButton({ mini: true });
-            shareToggleButtonHolder.current = shareToggleButton;
-            screenActionButton.replaceChild(shareToggleButton, screenActionButton.lastChild);
+            var screenActionRow = createMainActionRow(
+                screenActionButton,
+                shareToggleButton
+            );
+            leftColumn.insertBefore(screenActionRow, firstContent);
+            // 主按钮展开屏幕源，右侧独立按钮开始/停止共享；二者共用行级悬停生命周期。
             // 屏幕共享行：标题允许换行显示（去掉省略号截断），
             // 保证葡语 "Compartilhamento de tela"、俄语 "Демонстрация экрана" 等长文案也能完整显示
             var screenTextWrap = screenActionButton.querySelector('.neko-mic-action-text');
@@ -4077,34 +4082,28 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
                 openMicDeviceSubwindow
             );
             micActionButton.dataset.nekoMicAction = 'device';
-            leftColumn.insertBefore(micActionButton, firstContent);
+            var micActionRow = createMainActionRow(micActionButton, null);
+            leftColumn.insertBefore(micActionRow, firstContent);
 
             var voiceButtonLabel = window.t
                 ? window.t('microphone.independentAsr')
                 : '语音识别';
-            function voiceRowHoverGuard(event) {
-                return isPointerOverActionToggle(
-                    asrToggle.element,
-                    event
-                );
-            }
             var asrActionButton = createMainActionButton(
                 null,
                 voiceButtonLabel,
                 '',
                 'voice-recognition',
-                openVoiceRecognitionSubwindow,
-                voiceRowHoverGuard
-            );
-            asrActionButton.replaceChild(
-                asrToggle.element,
-                asrActionButton.lastChild
+                openVoiceRecognitionSubwindow
             );
             asrToggle.input.setAttribute('aria-label', voiceButtonLabel);
             asrSummary = asrActionButton.querySelector(
                 '.neko-mic-action-sub-label'
             );
-            leftColumn.insertBefore(asrActionButton, firstContent);
+            var asrActionRow = createMainActionRow(
+                asrActionButton,
+                asrToggle.element
+            );
+            leftColumn.insertBefore(asrActionRow, firstContent);
             updateVoiceRecognitionUi();
 
             // 组装

--- a/static/app/app-audio-capture.js
+++ b/static/app/app-audio-capture.js
@@ -3402,11 +3402,7 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
                 // Tear down the shared action state as well as its DOM. This
                 // clears an old render's pending hover-collapse timer so it
                 // cannot remove a subwindow created by the next render.
-                if (typeof closeMicSubwindow === 'function') {
-                    closeMicSubwindow();
-                } else if (voicePanel && voicePanel.isConnected) {
-                    voicePanel.remove();
-                }
+                closeMicSubwindow();
                 voicePanel = null;
                 noiseToggle = null;
                 optimizationToggle = null;
@@ -3787,7 +3783,7 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
                 Object.assign(labelEl.style, { display: 'block', maxWidth: '100%', fontSize: '13px', fontWeight: '600', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' });
                 var subEl = document.createElement('span');
                 subEl.className = 'neko-mic-action-sub-label';
-                subEl.textContent = subLabel || '';
+                subEl.textContent = subLabel == null ? '' : String(subLabel);
                 Object.assign(subEl.style, { display: 'block', maxWidth: '100%', fontSize: '11px', color: 'var(--neko-popup-text-sub)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' });
                 // Match settings menu chevron (Chat Settings / Animation / Advanced).
                 var arrow = document.createElement('span');
@@ -3799,7 +3795,7 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
                     flexShrink: '0'
                 });
                 textWrap.appendChild(labelEl);
-                if (subLabel) textWrap.appendChild(subEl);
+                if (subLabel != null) textWrap.appendChild(subEl);
                 if (iconText) {
                     var icon = document.createElement('span');
                     icon.textContent = iconText;
@@ -3909,6 +3905,8 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
 
                 voiceStatus = document.createElement('div');
                 voiceStatus.className = 'neko-voice-recognition-status';
+                voiceStatus.setAttribute('role', 'status');
+                voiceStatus.setAttribute('aria-live', 'polite');
                 Object.assign(voiceStatus.style, {
                     borderTop: '1px solid var(--neko-popup-separator)',
                     paddingTop: '11px',
@@ -4093,7 +4091,7 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
             var asrActionButton = createMainActionButton(
                 null,
                 voiceButtonLabel,
-                ' ',
+                '',
                 'voice-recognition',
                 openVoiceRecognitionSubwindow,
                 voiceRowHoverGuard

--- a/static/app/app-audio-capture.js
+++ b/static/app/app-audio-capture.js
@@ -2759,6 +2759,7 @@
         var micPopup = popupArg || document.getElementById('live2d-popup-mic') || document.getElementById('vrm-popup-mic') || document.getElementById('mmd-popup-mic');
         if (!micPopup) return false;
         var renderGeneration = ++voiceRecognitionPopoverRenderGeneration;
+        var coreApiCapabilityRefreshedAt = 0;
         if (disposeVoiceRecognitionPopover) {
             var previousDispose = disposeVoiceRecognitionPopover;
             disposeVoiceRecognitionPopover = null;
@@ -2773,6 +2774,16 @@
         if (!isPopupAvailable()) return false;
 
         try {
+            if (typeof window.refreshCoreApiCapability === 'function') {
+                coreApiCapabilityRefreshedAt = Date.now();
+                // Capability is tri-state and null is deliberately fail-open.
+                // Refresh in the background so a slow config endpoint can
+                // never hold the microphone device list hostage; the helper's
+                // change event updates this panel when the response arrives.
+                Promise.resolve(
+                    window.refreshCoreApiCapability({ force: true })
+                ).catch(function () { /* refresh helper owns reporting */ });
+            }
             ensureMicPopupScrollbarStyle();
             micPopup.classList.add('neko-mic-popup-surface');
             micPopup.style.minWidth = '220px';
@@ -3002,46 +3013,10 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
             Object.assign(sep1.style, { height: '1px', backgroundColor: 'var(--neko-popup-separator)', margin: '8px 0' });
             leftColumn.appendChild(sep1);
 
-            // ===== 语音识别设置入口 + body portal popover =====
-            var asrContainer = document.createElement('div');
-            asrContainer.tabIndex = 0;
-            asrContainer.setAttribute('role', 'button');
-            Object.assign(asrContainer.style, {
-                padding: '8px 12px',
-                cursor: 'pointer',
-                outline: 'none'
-            });
-
-            var asrRow = document.createElement('div');
-            Object.assign(asrRow.style, {
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItems: 'center',
-                gap: '12px'
-            });
-            var asrCopy = document.createElement('div');
-            Object.assign(asrCopy.style, { minWidth: '0', flex: '1' });
-            var asrLabel = document.createElement('span');
-            asrLabel.textContent = window.t
-                ? window.t('microphone.independentAsr')
-                : '语音识别';
-            asrLabel.setAttribute('data-i18n', 'microphone.independentAsr');
-            Object.assign(asrLabel.style, {
-                fontSize: '13px',
-                color: 'var(--neko-popup-text)',
-                fontWeight: '600'
-            });
-            var asrSummary = document.createElement('div');
-            Object.assign(asrSummary.style, {
-                fontSize: '11px',
-                color: 'var(--neko-popup-text-sub)',
-                marginTop: '4px',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap'
-            });
-            asrCopy.appendChild(asrLabel);
-            asrCopy.appendChild(asrSummary);
+            // Voice recognition uses the same main-action/subwindow pipeline as
+            // screen sharing and microphone selection. The trigger is assembled
+            // with those actions after the shared helpers are defined below.
+            var asrSummary = null;
 
             function createVoiceSettingToggle(checked, onChange) {
                 var focusStyle = document.getElementById(
@@ -3176,9 +3151,22 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
                 }
                 S.voiceSettingsPendingUntilEpoch = targetEpoch;
             }
+
+            function coreApiDisablesIndependentAsr() {
+                return S.coreApiSupportsIndependentAsr === false;
+            }
+
             var asrToggle = createVoiceSettingToggle(
-                S.independentAsrEnabled === true,
+                !coreApiDisablesIndependentAsr()
+                    && S.independentAsrEnabled === true,
                 function (enabled) {
+                    // The disabled switch is an effective view only. Keep the
+                    // persisted preference untouched so switching back to a
+                    // capable Core restores the user's previous choice.
+                    if (coreApiDisablesIndependentAsr()) {
+                        updateVoiceRecognitionUi();
+                        return;
+                    }
                     var activeRouteSnapshot = S.voiceChatActive === true
                         ? (
                             S.independentAsrActive === true
@@ -3194,21 +3182,9 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
                     persistVoiceSettingChange();
                 }
             );
-            asrRow.appendChild(asrCopy);
-            asrRow.appendChild(asrToggle.element);
-            asrContainer.appendChild(asrRow);
-            leftColumn.appendChild(asrContainer);
-
             var voicePanelId = (popupId || 'neko-mic')
                 + '-voice-recognition-settings';
-            asrContainer.setAttribute('aria-controls', voicePanelId);
-            asrContainer.setAttribute('aria-expanded', 'false');
             var voicePanel = null;
-            var voiceBridge = null;
-            var voicePanelOpen = false;
-            var voicePanelPinned = false;
-            var voiceOpenTimer = null;
-            var voiceCloseTimer = null;
             var voicePopupObserver = null;
             var noiseToggle = null;
             var optimizationToggle = null;
@@ -3230,14 +3206,8 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
                 return known[value.toLowerCase()] || value;
             }
 
-            function clearVoiceTimers() {
-                if (voiceOpenTimer !== null) clearTimeout(voiceOpenTimer);
-                if (voiceCloseTimer !== null) clearTimeout(voiceCloseTimer);
-                voiceOpenTimer = null;
-                voiceCloseTimer = null;
-            }
-
             function appendVoicePanelSetting(
+                panelBody,
                 labelKey,
                 fallbackLabel,
                 hintKey,
@@ -3280,148 +3250,14 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
                 block.appendChild(hint);
                 toggle.input.setAttribute('aria-labelledby', label.id);
                 toggle.input.setAttribute('aria-describedby', hint.id);
-                voicePanel.appendChild(block);
+                panelBody.appendChild(block);
                 return hint;
             }
 
-            function createVoicePanel() {
-                if (voicePanel) return voicePanel;
-                voicePanel = document.createElement('div');
-                voicePanel.id = voicePanelId;
-                voicePanel.setAttribute('role', 'dialog');
-                voicePanel.setAttribute(
-                    'aria-label',
-                    window.t
-                        ? window.t('microphone.voiceRecognitionSettings')
-                        : '语音识别设置'
-                );
-                Object.assign(voicePanel.style, {
-                    display: 'none',
-                    position: 'fixed',
-                    zIndex: '2147483000',
-                    width: '280px',
-                    boxSizing: 'border-box',
-                    padding: '14px',
-                    borderRadius: '10px',
-                    color: 'var(--neko-popup-text)',
-                    background: 'var(--neko-popup-bg, rgba(30, 30, 34, 0.98))',
-                    border: '1px solid var(--neko-popup-separator)',
-                    boxShadow: '0 10px 32px rgba(0, 0, 0, 0.28)'
-                });
-                document.body.appendChild(voicePanel);
-
-                var voicePanelTitle = document.createElement('div');
-                voicePanelTitle.textContent = window.t
-                    ? window.t('microphone.voiceRecognitionSettings')
-                    : '语音识别设置';
-                voicePanelTitle.setAttribute(
-                    'data-i18n',
-                    'microphone.voiceRecognitionSettings'
-                );
-                Object.assign(voicePanelTitle.style, {
-                    fontSize: '14px',
-                    fontWeight: '650',
-                    marginBottom: '14px'
-                });
-                voicePanel.appendChild(voicePanelTitle);
-
-                noiseToggle = createVoiceSettingToggle(
-                    S.noiseReductionEnabled === true,
-                    function (enabled) {
-                        S.noiseReductionEnabled = enabled;
-                        saveNoiseReductionSetting();
-                    }
-                );
-                appendVoicePanelSetting(
-                    'microphone.noiseReduction',
-                    '降噪',
-                    'microphone.noiseReductionHint',
-                    '让输入语音更加清晰',
-                    noiseToggle
-                );
-
-                optimizationToggle = createVoiceSettingToggle(
-                    S.voiceInputResourceOptimizationEnabled !== false,
-                    function (enabled) {
-                        S.voiceInputResourceOptimizationEnabled = enabled;
-                        markVoiceSettingsPending();
-                        updateVoiceRecognitionUi();
-                        persistVoiceSettingChange();
-                    }
-                );
-                optimizationHint = appendVoicePanelSetting(
-                    'microphone.voiceResourceOptimization',
-                    '智能资源优化',
-                    'microphone.voiceResourceOptimizationHintOn',
-                    '空闲时减少连接和音频上传',
-                    optimizationToggle
-                );
-
-                voiceStatus = document.createElement('div');
-                Object.assign(voiceStatus.style, {
-                    borderTop: '1px solid var(--neko-popup-separator)',
-                    paddingTop: '11px',
-                    fontSize: '11px',
-                    lineHeight: '1.45',
-                    color: 'var(--neko-popup-text-sub)'
-                });
-                voicePanel.appendChild(voiceStatus);
-
-                voiceBridge = document.createElement('div');
-                Object.assign(voiceBridge.style, {
-                    display: 'none',
-                    position: 'fixed',
-                    zIndex: '2147482999'
-                });
-                document.body.appendChild(voiceBridge);
-
-                voicePanel.addEventListener('mouseenter', clearVoiceTimers);
-                voicePanel.addEventListener('mouseleave', scheduleVoiceClose);
-                voicePanel.addEventListener('focusin', clearVoiceTimers);
-                voicePanel.addEventListener('focusout', scheduleVoiceClose);
-                voiceBridge.addEventListener('mouseenter', clearVoiceTimers);
-                voiceBridge.addEventListener('mouseleave', scheduleVoiceClose);
-
-                document.addEventListener('pointerdown', onVoiceDocumentPointerDown, true);
-                document.addEventListener(
-                    'keydown',
-                    onVoiceDocumentKeyDown,
-                    true
-                );
-                window.addEventListener('resize', positionVoicePanel);
-                window.addEventListener('scroll', positionVoicePanel, true);
-                window.addEventListener(
-                    'voice-input-lifecycle-changed',
-                    onVoiceLifecycleChanged
-                );
-                window.addEventListener(
-                    'neko:voice-session-started',
-                    onVoiceSessionStarted
-                );
-                window.addEventListener(
-                    'neko:voice-settings-pending-changed',
-                    onVoiceSettingsPendingChanged
-                );
-                voicePopupObserver = new MutationObserver(function () {
-                    if (!isPopupAvailable()) destroyVoicePanel();
-                });
-                var popupAncestor = micPopup.parentNode;
-                while (popupAncestor) {
-                    voicePopupObserver.observe(popupAncestor, {
-                        childList: true
-                    });
-                    popupAncestor = popupAncestor.parentNode;
-                }
-                voicePopupObserver.observe(micPopup, {
-                    attributes: true,
-                    attributeFilter: ['style', 'class']
-                });
-                updateVoiceRecognitionUi();
-                return voicePanel;
-            }
-
             function updateVoiceRecognitionUi() {
-                var enabled = S.independentAsrEnabled === true;
+                var capabilityUnavailable = coreApiDisablesIndependentAsr();
+                var enabled = !capabilityUnavailable
+                    && S.independentAsrEnabled === true;
                 if (
                     S.voiceSettingsPendingUntilEpoch !== null
                     && (Number(S.voiceSessionStartEpoch) || 0)
@@ -3430,36 +3266,53 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
                     S.voiceSettingsPendingUntilEpoch = null;
                     S.pendingVoiceRouteIndependentAsr = null;
                 }
-                var summaryUsesIndependentAsr =
-                    S.voiceSettingsPendingUntilEpoch !== null
-                    && S.pendingVoiceRouteIndependentAsr !== null
-                        ? S.pendingVoiceRouteIndependentAsr
-                        : enabled;
+                var summaryUsesIndependentAsr = capabilityUnavailable
+                    ? false
+                    : (
+                        S.voiceSettingsPendingUntilEpoch !== null
+                        && S.pendingVoiceRouteIndependentAsr !== null
+                            ? S.pendingVoiceRouteIndependentAsr
+                            : enabled
+                    );
                 var provider = providerDisplayName(S.independentAsrProvider);
                 var blocked = S.voiceInputLifecycleState === 'blocked';
                 asrToggle.setChecked(enabled);
-                asrSummary.textContent = summaryUsesIndependentAsr
-                    ? (
-                        window.t
-                            ? window.t(
-                                provider
-                                    ? 'microphone.independentAsrSummary'
-                                    : 'microphone.independentAsrSummaryGeneric',
-                                { provider: provider }
-                            )
-                            : ('独立 ASR' + (provider ? ' · ' + provider : ''))
-                    )
-                    : (
-                        window.t
-                            ? window.t('microphone.voiceRecognitionDisabled')
-                            : '当前使用 Omni 原生语音识别'
-                    );
-                if (!voicePanel) return;
+                asrToggle.setDisabled(capabilityUnavailable);
+                if (asrSummary) {
+                    asrSummary.textContent = summaryUsesIndependentAsr
+                        ? (
+                            window.t
+                                ? window.t(
+                                    provider
+                                        ? 'microphone.independentAsrSummary'
+                                        : 'microphone.independentAsrSummaryGeneric',
+                                    { provider: provider }
+                                )
+                                : ('独立 ASR' + (provider ? ' · ' + provider : ''))
+                        )
+                        : (
+                            window.t
+                                ? window.t('microphone.voiceRecognitionDisabled')
+                                : '当前使用 Omni 原生语音识别'
+                        );
+                }
+                if (
+                    !voicePanel
+                    || !voicePanel.isConnected
+                    || !noiseToggle
+                    || !optimizationToggle
+                    || !optimizationHint
+                    || !voiceStatus
+                ) return;
                 // RNNoise is local PCM preprocessing shared by both the
                 // independent-ASR and Omni-native routes.
                 noiseToggle.setDisabled(false);
                 optimizationToggle.setDisabled(!enabled);
-                if (S.voiceSettingsPendingUntilEpoch !== null) {
+                if (capabilityUnavailable) {
+                    voiceStatus.textContent = window.t
+                        ? window.t('microphone.voiceRecognitionNativeCoreHint')
+                        : '当前核心使用免费API；独立 ASR 相关开关不适用';
+                } else if (S.voiceSettingsPendingUntilEpoch !== null) {
                     voiceStatus.textContent = window.t
                         ? window.t('microphone.voiceRecognitionSettingsPending')
                         : '◐ 设置将在下次语音会话生效';
@@ -3480,190 +3333,28 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
                         ? window.t('microphone.voiceRecognitionSettingsPending')
                         : '◐ 设置将在下次语音会话生效';
                 }
-                var optimizationEnabled =
-                    S.voiceInputResourceOptimizationEnabled !== false;
+                var optimizationEnabled = !capabilityUnavailable
+                    && S.voiceInputResourceOptimizationEnabled !== false;
                 optimizationToggle.setChecked(optimizationEnabled);
                 optimizationHint.textContent = window.t
                     ? window.t(
-                        optimizationEnabled
-                            ? 'microphone.voiceResourceOptimizationHintOn'
-                            : 'microphone.voiceResourceOptimizationHintOff'
+                        capabilityUnavailable
+                            ? 'microphone.voiceRecognitionNativeCoreHint'
+                            : (
+                                optimizationEnabled
+                                    ? 'microphone.voiceResourceOptimizationHintOn'
+                                    : 'microphone.voiceResourceOptimizationHintOff'
+                            )
                     )
                     : (
-                        optimizationEnabled
-                            ? '空闲时减少连接和音频上传'
-                            : '持续保持语音识别，可能增加网络和资源占用'
+                        capabilityUnavailable
+                            ? '当前核心使用免费API；独立 ASR 相关开关不适用'
+                            : (
+                                optimizationEnabled
+                                    ? '空闲时减少连接和音频上传'
+                                    : '持续保持语音识别，可能增加网络和资源占用'
+                            )
                     );
-            }
-
-            function positionVoicePanel() {
-                if (!voicePanelOpen || !voicePanel || !asrContainer.isConnected) {
-                    return;
-                }
-                var rect = asrContainer.getBoundingClientRect();
-                var gap = 10;
-                var viewportWidth =
-                    window.innerWidth || document.documentElement.clientWidth;
-                var viewportHeight =
-                    window.innerHeight || document.documentElement.clientHeight;
-                var panelRect = voicePanel.getBoundingClientRect();
-                var panelWidth = panelRect.width || 280;
-                var panelHeight = panelRect.height || 240;
-                var placeRight =
-                    rect.right + gap + panelWidth <= viewportWidth - 12;
-                var placeLeft = rect.left - gap - panelWidth >= 12;
-                var placeBelow =
-                    rect.bottom + gap + panelHeight <= viewportHeight - 12;
-                var left;
-                var top;
-                var bridgeLeft;
-                var bridgeTop;
-                var bridgeWidth;
-                var bridgeHeight;
-                if (placeRight || placeLeft) {
-                    left = placeRight
-                        ? rect.right + gap
-                        : rect.left - panelWidth - gap;
-                    top = Math.max(
-                        12,
-                        Math.min(rect.top, viewportHeight - panelHeight - 12)
-                    );
-                    bridgeLeft = placeRight ? rect.right : left + panelWidth;
-                    bridgeTop = Math.min(rect.top, top);
-                    bridgeWidth = gap;
-                    bridgeHeight =
-                        Math.max(rect.bottom, top + panelHeight) - bridgeTop;
-                } else {
-                    left = Math.max(
-                        12,
-                        Math.min(rect.left, viewportWidth - panelWidth - 12)
-                    );
-                    top = placeBelow
-                        ? rect.bottom + gap
-                        : rect.top - panelHeight - gap;
-                    top = Math.max(
-                        12,
-                        Math.min(top, viewportHeight - panelHeight - 12)
-                    );
-                    bridgeLeft = Math.min(rect.left, left);
-                    bridgeTop = placeBelow ? rect.bottom : top + panelHeight;
-                    bridgeWidth =
-                        Math.max(rect.right, left + panelWidth) - bridgeLeft;
-                    bridgeHeight = gap;
-                }
-                voicePanel.style.left = Math.round(left) + 'px';
-                voicePanel.style.top = Math.round(top) + 'px';
-                voiceBridge.style.display = 'block';
-                voiceBridge.style.left = Math.round(bridgeLeft) + 'px';
-                voiceBridge.style.top = Math.round(bridgeTop) + 'px';
-                voiceBridge.style.width = Math.round(bridgeWidth) + 'px';
-                voiceBridge.style.height = Math.round(bridgeHeight) + 'px';
-            }
-
-            function openVoicePanel(pinned) {
-                clearVoiceTimers();
-                createVoicePanel();
-                if (pinned === true) voicePanelPinned = true;
-                voicePanelOpen = true;
-                voicePanel.style.display = 'block';
-                asrContainer.setAttribute('aria-expanded', 'true');
-                updateVoiceRecognitionUi();
-                positionVoicePanel();
-            }
-
-            function closeVoicePanel(force) {
-                if (voicePanelPinned && force !== true) return;
-                clearVoiceTimers();
-                voicePanelPinned = false;
-                voicePanelOpen = false;
-                if (voicePanel) voicePanel.style.display = 'none';
-                if (voiceBridge) voiceBridge.style.display = 'none';
-                asrContainer.setAttribute('aria-expanded', 'false');
-            }
-
-            function destroyVoicePanel() {
-                clearVoiceTimers();
-                closeVoicePanel(true);
-                if (voicePopupObserver) {
-                    voicePopupObserver.disconnect();
-                    voicePopupObserver = null;
-                }
-                document.removeEventListener('pointerdown', onVoiceDocumentPointerDown, true);
-                document.removeEventListener(
-                    'keydown',
-                    onVoiceDocumentKeyDown,
-                    true
-                );
-                window.removeEventListener('resize', positionVoicePanel);
-                window.removeEventListener('scroll', positionVoicePanel, true);
-                window.removeEventListener(
-                    'voice-input-lifecycle-changed',
-                    onVoiceLifecycleChanged
-                );
-                window.removeEventListener(
-                    'neko:voice-session-started',
-                    onVoiceSessionStarted
-                );
-                window.removeEventListener(
-                    'neko:voice-settings-pending-changed',
-                    onVoiceSettingsPendingChanged
-                );
-                if (voicePanel) voicePanel.remove();
-                if (voiceBridge) voiceBridge.remove();
-                voicePanel = null;
-                voiceBridge = null;
-                noiseToggle = null;
-                optimizationToggle = null;
-                optimizationHint = null;
-                voiceStatus = null;
-                if (disposeVoiceRecognitionPopover === destroyVoicePanel) {
-                    disposeVoiceRecognitionPopover = null;
-                }
-            }
-
-            function scheduleVoiceOpen() {
-                if (voicePanelOpen) return;
-                if (voiceOpenTimer !== null) clearTimeout(voiceOpenTimer);
-                voiceOpenTimer = setTimeout(function () {
-                    openVoicePanel(false);
-                }, 150);
-            }
-
-            function scheduleVoiceClose() {
-                if (voicePanelPinned) return;
-                if (voiceOpenTimer !== null) clearTimeout(voiceOpenTimer);
-                if (voiceCloseTimer !== null) clearTimeout(voiceCloseTimer);
-                voiceCloseTimer = setTimeout(function () {
-                    closeVoicePanel(false);
-                }, 300);
-            }
-
-            function togglePinnedVoicePanel(focusPanel) {
-                if (voicePanelOpen && voicePanelPinned) closeVoicePanel(true);
-                else {
-                    openVoicePanel(true);
-                    if (focusPanel === true && voicePanel) {
-                        var firstControl = voicePanel.querySelector(
-                            'input:not([disabled])'
-                        );
-                        if (firstControl) firstControl.focus();
-                    }
-                }
-            }
-
-            function onVoiceDocumentPointerDown(event) {
-                if (!voicePanelOpen || !voicePanel) return;
-                if (
-                    !asrContainer.contains(event.target)
-                    && !voicePanel.contains(event.target)
-                ) closeVoicePanel(true);
-            }
-
-            function onVoiceDocumentKeyDown(event) {
-                if (event.key === 'Escape' && voicePanelOpen) {
-                    closeVoicePanel(true);
-                    asrContainer.focus();
-                }
             }
 
             function onVoiceLifecycleChanged() {
@@ -3685,29 +3376,84 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
                 updateVoiceRecognitionUi();
             }
 
-            asrContainer.addEventListener('mouseenter', scheduleVoiceOpen);
-            asrContainer.addEventListener('mouseleave', scheduleVoiceClose);
-            asrContainer.addEventListener('focusin', function () {
-                openVoicePanel(false);
-            });
-            asrContainer.addEventListener('focusout', scheduleVoiceClose);
-            asrContainer.addEventListener('pointerup', function (event) {
-                if (event.button !== undefined && event.button !== 0) return;
-                togglePinnedVoicePanel();
-            });
-            asrContainer.addEventListener('keydown', function (event) {
-                if (event.target !== asrContainer) return;
-                if (event.key === 'Enter' || event.key === ' ') {
-                    event.preventDefault();
-                    togglePinnedVoicePanel(true);
-                }
-            });
-            disposeVoiceRecognitionPopover = destroyVoicePanel;
-            createVoicePanel();
+            function onCoreApiCapabilityChanged() {
+                updateVoiceRecognitionUi();
+            }
 
-            var sep1b = document.createElement('div');
-            Object.assign(sep1b.style, { height: '1px', backgroundColor: 'var(--neko-popup-separator)', margin: '8px 0' });
-            leftColumn.appendChild(sep1b);
+            var voiceControlsDisposed = false;
+            var voiceWindowListeners = [];
+
+            function addVoiceWindowListener(type, listener) {
+                voiceWindowListeners.push([type, listener]);
+                window.addEventListener(type, listener);
+            }
+
+            function destroyVoiceRecognitionControls() {
+                if (voiceControlsDisposed) return;
+                voiceControlsDisposed = true;
+                if (voicePopupObserver) {
+                    voicePopupObserver.disconnect();
+                    voicePopupObserver = null;
+                }
+                voiceWindowListeners.forEach(function (entry) {
+                    window.removeEventListener(entry[0], entry[1]);
+                });
+                voiceWindowListeners = [];
+                // Tear down the shared action state as well as its DOM. This
+                // clears an old render's pending hover-collapse timer so it
+                // cannot remove a subwindow created by the next render.
+                if (typeof closeMicSubwindow === 'function') {
+                    closeMicSubwindow();
+                } else if (voicePanel && voicePanel.isConnected) {
+                    voicePanel.remove();
+                }
+                voicePanel = null;
+                noiseToggle = null;
+                optimizationToggle = null;
+                optimizationHint = null;
+                voiceStatus = null;
+                asrSummary = null;
+                if (
+                    disposeVoiceRecognitionPopover
+                    === destroyVoiceRecognitionControls
+                ) {
+                    disposeVoiceRecognitionPopover = null;
+                }
+            }
+
+            disposeVoiceRecognitionPopover = destroyVoiceRecognitionControls;
+            addVoiceWindowListener(
+                'voice-input-lifecycle-changed',
+                onVoiceLifecycleChanged
+            );
+            addVoiceWindowListener(
+                'neko:voice-session-started',
+                onVoiceSessionStarted
+            );
+            addVoiceWindowListener(
+                'neko:core-api-capability-changed',
+                onCoreApiCapabilityChanged
+            );
+            addVoiceWindowListener(
+                'neko:voice-settings-pending-changed',
+                onVoiceSettingsPendingChanged
+            );
+            voicePopupObserver = new MutationObserver(function () {
+                if (!isPopupAvailable()) destroyVoiceRecognitionControls();
+            });
+            var popupAncestor = micPopup.parentNode;
+            while (popupAncestor) {
+                voicePopupObserver.observe(popupAncestor, {
+                    childList: true
+                });
+                popupAncestor = popupAncestor.parentNode;
+            }
+            voicePopupObserver.observe(micPopup, {
+                attributes: true,
+                attributeFilter: ['style', 'class']
+            });
+            updateVoiceRecognitionUi();
+
 
             // ===== 左栏 2. 麦克风增益 =====
             var gainContainer = document.createElement('div');
@@ -3834,6 +3580,7 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
 
             function closeMicSubwindow() {
                 clearMicActionHoverCollapseTimer();
+                micActionHoverOpenGeneration += 1;
                 activeMicActionKey = null;
                 var ownerSelector = micPopup.id ? '[data-neko-sidepanel-owner="' + micPopup.id + '"]' : '.neko-mic-subwindow';
                 document.querySelectorAll(ownerSelector + '.neko-mic-subwindow').forEach(function (panel) {
@@ -4062,9 +3809,12 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
                 button.appendChild(textWrap);
                 button.appendChild(arrow);
 
-                function openActionPanel() {
+                function openActionPanel(event) {
                     // 悬停守卫：指针在内嵌开关（如屏幕共享开关）上时不展开子面板，避免干扰点击
-                    if (typeof hoverGuard === 'function' && hoverGuard()) {
+                    if (
+                        typeof hoverGuard === 'function'
+                        && hoverGuard(event)
+                    ) {
                         return Promise.resolve(null);
                     }
                     button.style.background = 'var(--neko-popup-hover)';
@@ -4074,8 +3824,8 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
                 }
 
                 // Hover-to-expand like settings side panels.
-                button.addEventListener('mouseenter', function () {
-                    openActionPanel();
+                button.addEventListener('mouseenter', function (event) {
+                    openActionPanel(event);
                 });
                 button.addEventListener('mouseleave', function () {
                     button.style.background = 'transparent';
@@ -4083,7 +3833,7 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
                 });
                 button.addEventListener('click', function (e) {
                     e.stopPropagation();
-                    openActionPanel();
+                    openActionPanel(e);
                 });
                 return button;
             }
@@ -4108,6 +3858,85 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
                     });
                 });
                 return option;
+            }
+
+            function openVoiceRecognitionSubwindow() {
+                var panel = createMicSubwindow(
+                    window.t
+                        ? window.t('microphone.voiceRecognitionSettings')
+                        : '语音识别设置',
+                    null,
+                    '280px'
+                );
+                panel.id = voicePanelId;
+                panel.classList.add('neko-mic-voice-subwindow');
+                voicePanel = panel;
+                var panelBody = panel._nekoMicSubwindowBody || panel;
+
+                noiseToggle = createVoiceSettingToggle(
+                    S.noiseReductionEnabled === true,
+                    function (enabled) {
+                        S.noiseReductionEnabled = enabled;
+                        saveNoiseReductionSetting();
+                    }
+                );
+                appendVoicePanelSetting(
+                    panelBody,
+                    'microphone.noiseReduction',
+                    '降噪',
+                    'microphone.noiseReductionHint',
+                    '让输入语音更加清晰',
+                    noiseToggle
+                );
+
+                optimizationToggle = createVoiceSettingToggle(
+                    S.voiceInputResourceOptimizationEnabled !== false,
+                    function (enabled) {
+                        S.voiceInputResourceOptimizationEnabled = enabled;
+                        markVoiceSettingsPending();
+                        updateVoiceRecognitionUi();
+                        persistVoiceSettingChange();
+                    }
+                );
+                optimizationHint = appendVoicePanelSetting(
+                    panelBody,
+                    'microphone.voiceResourceOptimization',
+                    '智能资源优化',
+                    'microphone.voiceResourceOptimizationHintOn',
+                    '空闲时减少连接和音频上传',
+                    optimizationToggle
+                );
+
+                voiceStatus = document.createElement('div');
+                voiceStatus.className = 'neko-voice-recognition-status';
+                Object.assign(voiceStatus.style, {
+                    borderTop: '1px solid var(--neko-popup-separator)',
+                    paddingTop: '11px',
+                    fontSize: '11px',
+                    lineHeight: '1.45',
+                    color: 'var(--neko-popup-text-sub)'
+                });
+                panelBody.appendChild(voiceStatus);
+
+                updateVoiceRecognitionUi();
+                if (
+                    typeof window.refreshCoreApiCapability === 'function'
+                    && Date.now() - coreApiCapabilityRefreshedAt >= 1000
+                ) {
+                    var openedPanel = panel;
+                    Promise.resolve(
+                        window.refreshCoreApiCapability({ force: true })
+                    ).then(function () {
+                        coreApiCapabilityRefreshedAt = Date.now();
+                        if (
+                            voicePanel === openedPanel
+                            && openedPanel.isConnected
+                        ) updateVoiceRecognitionUi();
+                    }).catch(function () {
+                        // refreshCoreApiCapability owns failure reporting.
+                    });
+                }
+                return panel;
             }
 
             async function openMicDeviceSubwindow() {
@@ -4190,11 +4019,35 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
             var screenButtonLabel = window.t ? window.t('buttons.screenShare') : 'Screen Share';
 
             var firstContent = leftColumn.firstChild;
+            function isPointerOverActionToggle(toggle, event) {
+                if (!toggle) return false;
+                // Keyboard-generated button clicks use detail=0 and synthetic
+                // coordinates (often 0,0); they must keep the native button's
+                // Enter/Space behavior regardless of the mouse position.
+                if (event && event.type === 'click' && event.detail === 0) {
+                    return false;
+                }
+                if (toggle.matches(':hover')) return true;
+                if (
+                    !event
+                    || event.type !== 'mouseenter'
+                    || typeof document.elementFromPoint !== 'function'
+                    || !Number.isFinite(event.clientX)
+                    || !Number.isFinite(event.clientY)
+                ) return false;
+                var pointerTarget = document.elementFromPoint(
+                    event.clientX,
+                    event.clientY
+                );
+                return !!(pointerTarget && toggle.contains(pointerTarget));
+            }
             // 悬停守卫：指针落在行内开关上时不展开屏幕源面板，避免面板弹出干扰点击开关
             var shareToggleButtonHolder = { current: null };
-            function screenRowHoverGuard() {
-                var toggle = shareToggleButtonHolder.current;
-                return !!(toggle && toggle.matches(':hover'));
+            function screenRowHoverGuard(event) {
+                return isPointerOverActionToggle(
+                    shareToggleButtonHolder.current,
+                    event
+                );
             }
             var screenActionButton = createMainActionButton(
                 null,
@@ -4227,6 +4080,34 @@ if (typeof micPopup.__nekoMicScrollbarCleanup === 'function') {
             );
             micActionButton.dataset.nekoMicAction = 'device';
             leftColumn.insertBefore(micActionButton, firstContent);
+
+            var voiceButtonLabel = window.t
+                ? window.t('microphone.independentAsr')
+                : '语音识别';
+            function voiceRowHoverGuard(event) {
+                return isPointerOverActionToggle(
+                    asrToggle.element,
+                    event
+                );
+            }
+            var asrActionButton = createMainActionButton(
+                null,
+                voiceButtonLabel,
+                ' ',
+                'voice-recognition',
+                openVoiceRecognitionSubwindow,
+                voiceRowHoverGuard
+            );
+            asrActionButton.replaceChild(
+                asrToggle.element,
+                asrActionButton.lastChild
+            );
+            asrToggle.input.setAttribute('aria-label', voiceButtonLabel);
+            asrSummary = asrActionButton.querySelector(
+                '.neko-mic-action-sub-label'
+            );
+            leftColumn.insertBefore(asrActionButton, firstContent);
+            updateVoiceRecognitionUi();
 
             // 组装
             micPopup.appendChild(leftColumn);

--- a/static/app/app-state.js
+++ b/static/app/app-state.js
@@ -89,6 +89,11 @@
         microphoneGainDb: 0,
         noiseReductionEnabled: true,
         independentAsrEnabled: true,
+        // Current Core capability loaded from /api/config/core_api. Keep this
+        // tri-state: only an explicit false may disable the effective UI;
+        // null means unknown and leaves the user's persisted preference alone.
+        coreApiProvider: '',
+        coreApiSupportsIndependentAsr: null,
         voiceInputResourceOptimizationEnabled: true,
         // 设置是否已"水合"：server GET 合并成功或用户显式改过设置后才为 true。
         // 在此之前两个 true 都只是启动默认值，不代表服务器权威偏好；

--- a/static/app/app-websocket.js
+++ b/static/app/app-websocket.js
@@ -38,6 +38,8 @@
     let _pendingUserActivityCancelTurnId = null;
     let _lanlanNameWaitAttempts = 0;
     let _lanlanNameWaitLastLogAt = 0;
+    let _coreApiCapabilityRefreshPromise = null;
+    let _coreApiCapabilityRequestGeneration = 0;
     let _musicPlayUrlCoordChannel = null;
     let _musicPlayUrlCoordChannelReady = false;
     let _musicPlayUrlClaims = Object.create(null);
@@ -1697,6 +1699,117 @@
     var SETTINGS_SYNC_GATE_TIMEOUT_MS = 3000;
 
     /**
+     * Refresh the current Core's independent-ASR capability from the same
+     * configuration endpoint used by the API settings UI. The capability is
+     * deliberately tri-state: only an explicit false may disable the effective
+     * UI. It never rewrites the user's preference or handshake, and a failed or
+     * legacy response remains unknown.
+     *
+     * Forced refreshes may overlap (for example, a settings window saves while
+     * a popup request is pending), so a generation fence prevents an older
+     * response from overwriting the newer Core selection.
+     */
+    function publishCoreApiCapability(provider, capability) {
+        var previousProvider = S.coreApiProvider || '';
+        var previousCapability = S.coreApiSupportsIndependentAsr;
+        S.coreApiProvider = typeof provider === 'string' ? provider : '';
+        S.coreApiSupportsIndependentAsr =
+            typeof capability === 'boolean' ? capability : null;
+        if (
+            previousProvider !== S.coreApiProvider
+            || previousCapability !== S.coreApiSupportsIndependentAsr
+        ) {
+            try {
+                window.dispatchEvent(new CustomEvent(
+                    'neko:core-api-capability-changed',
+                    {
+                        detail: {
+                            provider: S.coreApiProvider,
+                            supportsIndependentAsr:
+                                S.coreApiSupportsIndependentAsr
+                        }
+                    }
+                ));
+            } catch (_) { /* optional UI notification */ }
+        }
+        return {
+            provider: S.coreApiProvider,
+            supportsIndependentAsr: S.coreApiSupportsIndependentAsr
+        };
+    }
+
+    function refreshCoreApiCapability(options) {
+        options = options || {};
+        if (
+            options.force !== true
+            && typeof S.coreApiSupportsIndependentAsr === 'boolean'
+        ) {
+            return Promise.resolve({
+                provider: S.coreApiProvider || '',
+                supportsIndependentAsr: S.coreApiSupportsIndependentAsr
+            });
+        }
+        if (
+            options.force !== true
+            && _coreApiCapabilityRefreshPromise
+        ) return _coreApiCapabilityRefreshPromise;
+        if (typeof window.fetch !== 'function') {
+            return Promise.resolve({
+                provider: S.coreApiProvider || '',
+                supportsIndependentAsr: S.coreApiSupportsIndependentAsr
+            });
+        }
+
+        var requestGeneration = ++_coreApiCapabilityRequestGeneration;
+        var refreshPromise = window.fetch('/api/config/core_api', {
+            cache: 'no-store',
+            headers: { Accept: 'application/json' }
+        }).then(function (response) {
+            if (!response || response.ok === false) {
+                throw new Error('Core API capability request failed');
+            }
+            return response.json();
+        }).then(function (data) {
+            if (requestGeneration !== _coreApiCapabilityRequestGeneration) {
+                return {
+                    provider: S.coreApiProvider || '',
+                    supportsIndependentAsr: S.coreApiSupportsIndependentAsr
+                };
+            }
+            data = data && typeof data === 'object' ? data : {};
+            if (data.success === false) {
+                throw new Error('Core API capability response was unsuccessful');
+            }
+            return publishCoreApiCapability(
+                typeof data.effectiveCoreApi === 'string'
+                    ? data.effectiveCoreApi
+                    : data.coreApi,
+                data.supportsIndependentAsr
+            );
+        }).catch(function (error) {
+            console.warn('[Core API] Failed to refresh ASR capability:', error);
+            if (requestGeneration === _coreApiCapabilityRequestGeneration) {
+                return publishCoreApiCapability('', null);
+            }
+            return {
+                provider: S.coreApiProvider || '',
+                supportsIndependentAsr: S.coreApiSupportsIndependentAsr
+            };
+        }).finally(function () {
+            if (_coreApiCapabilityRefreshPromise === refreshPromise) {
+                _coreApiCapabilityRefreshPromise = null;
+            }
+        });
+        _coreApiCapabilityRefreshPromise = refreshPromise;
+        return refreshPromise;
+    }
+
+    // Prime the capability once for both Web and Electron windows. API Core
+    // changes normally reload these pages; the microphone popup also forces a
+    // refresh so a window that missed that reload cannot keep a stale view.
+    refreshCoreApiCapability();
+
+    /**
      * Wait for the WebSocket to reach OPEN state.
      *   - Already OPEN  -> resolves immediately
      *   - CONNECTING     -> waits via addEventListener('open')
@@ -1833,6 +1946,7 @@
         });
     }
     mod.ensureWebSocketOpen = ensureWebSocketOpen;
+    mod.refreshCoreApiCapability = refreshCoreApiCapability;
 
     // ========================  connectWebSocket  ========================
 
@@ -1862,6 +1976,12 @@
     // test_start_session_handshake_missing_falls_back_to_persisted). If the
     // GET fails permanently the field simply stays omitted and the backend's
     // persisted value keeps governing — the correct fallback.
+    //
+    // Core capability is intentionally NOT folded into this payload. Another
+    // window may switch to a capable Core while this window still has a stale
+    // false capability cache. The handshake always carries the authoritative
+    // user preference; the backend applies the current Core capability as the
+    // final routing guard.
     function attachStartSessionHandshake(ws) {
         var rawSend = ws.send.bind(ws);
         ws.send = function (data) {
@@ -4543,6 +4663,7 @@
     // ========================  Backward-compat globals  ========================
     window.connectWebSocket = connectWebSocket;
     window.ensureWebSocketOpen = ensureWebSocketOpen;
+    window.refreshCoreApiCapability = refreshCoreApiCapability;
     window.ensureAssistantTurnStarted = ensureAssistantTurnStarted;
     window.clearPendingAssistantTurnStart = clearPendingAssistantTurnStart;
 

--- a/static/app/app-websocket.js
+++ b/static/app/app-websocket.js
@@ -1705,9 +1705,9 @@
      * UI. It never rewrites the user's preference or handshake, and a failed or
      * legacy response remains unknown.
      *
-     * Forced refreshes may overlap (for example, a settings window saves while
-     * a popup request is pending), so a generation fence prevents an older
-     * response from overwriting the newer Core selection.
+     * Concurrent callers in one window share the in-flight refresh. `force`
+     * only bypasses completed cache data; the generation fence remains a
+     * defensive guard around request publication.
      */
     function publishCoreApiCapability(provider, capability) {
         var previousProvider = S.coreApiProvider || '';
@@ -1740,6 +1740,11 @@
 
     function refreshCoreApiCapability(options) {
         options = options || {};
+        // `force` bypasses completed cache data, not a request that is already
+        // in flight. All callers in this window share the same fresh result.
+        if (_coreApiCapabilityRefreshPromise) {
+            return _coreApiCapabilityRefreshPromise;
+        }
         if (
             options.force !== true
             && typeof S.coreApiSupportsIndependentAsr === 'boolean'
@@ -1749,10 +1754,6 @@
                 supportsIndependentAsr: S.coreApiSupportsIndependentAsr
             });
         }
-        if (
-            options.force !== true
-            && _coreApiCapabilityRefreshPromise
-        ) return _coreApiCapabilityRefreshPromise;
         if (typeof window.fetch !== 'function') {
             return Promise.resolve({
                 provider: S.coreApiProvider || '',

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -942,7 +942,7 @@
         "voiceRecognitionSettings": "Speech Recognition Settings",
         "voiceRecognitionDisabled": "Using Omni native speech recognition",
         "voiceRecognitionDisabledHint": "Independent ASR is off; voice input uses Omni native speech recognition",
-    "voiceRecognitionNativeCoreHint": "This Core uses the free API; independent ASR controls do not apply",
+        "voiceRecognitionNativeCoreHint": "This Core uses the free API; independent ASR controls do not apply",
         "voiceRecognitionUnavailable": "Independent speech recognition is unavailable. Voice input has stopped for this session",
         "voiceRecognitionStatusReady": "● Running normally",
         "voiceRecognitionSettingsPending": "◐ Settings take effect in the next voice session",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -942,6 +942,7 @@
         "voiceRecognitionSettings": "Speech Recognition Settings",
         "voiceRecognitionDisabled": "Using Omni native speech recognition",
         "voiceRecognitionDisabledHint": "Independent ASR is off; voice input uses Omni native speech recognition",
+    "voiceRecognitionNativeCoreHint": "This Core uses the free API; independent ASR controls do not apply",
         "voiceRecognitionUnavailable": "Independent speech recognition is unavailable. Voice input has stopped for this session",
         "voiceRecognitionStatusReady": "● Running normally",
         "voiceRecognitionSettingsPending": "◐ Settings take effect in the next voice session",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -942,7 +942,7 @@
         "voiceRecognitionSettings": "Configuración de reconocimiento de voz",
         "voiceRecognitionDisabled": "Usando el reconocimiento de voz nativo de Omni",
         "voiceRecognitionDisabledHint": "El ASR independiente está desactivado; la entrada de voz usa el reconocimiento de voz nativo de Omni",
-    "voiceRecognitionNativeCoreHint": "Este Core usa la API gratuita; los controles de ASR independiente no se aplican",
+        "voiceRecognitionNativeCoreHint": "Este Core usa la API gratuita; los controles de ASR independiente no se aplican",
         "voiceRecognitionUnavailable": "El reconocimiento de voz independiente no está disponible. La entrada de voz de esta sesión se ha detenido",
         "voiceRecognitionStatusReady": "● Funciona con normalidad",
         "voiceRecognitionSettingsPending": "◐ La configuración se aplicará en la próxima sesión de voz",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -942,6 +942,7 @@
         "voiceRecognitionSettings": "Configuración de reconocimiento de voz",
         "voiceRecognitionDisabled": "Usando el reconocimiento de voz nativo de Omni",
         "voiceRecognitionDisabledHint": "El ASR independiente está desactivado; la entrada de voz usa el reconocimiento de voz nativo de Omni",
+    "voiceRecognitionNativeCoreHint": "Este Core usa la API gratuita; los controles de ASR independiente no se aplican",
         "voiceRecognitionUnavailable": "El reconocimiento de voz independiente no está disponible. La entrada de voz de esta sesión se ha detenido",
         "voiceRecognitionStatusReady": "● Funciona con normalidad",
         "voiceRecognitionSettingsPending": "◐ La configuración se aplicará en la próxima sesión de voz",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -942,7 +942,7 @@
         "voiceRecognitionSettings": "音声認識設定",
         "voiceRecognitionDisabled": "Omni ネイティブ音声認識を使用中",
         "voiceRecognitionDisabledHint": "独立 ASR はオフです。音声入力には Omni ネイティブ音声認識を使用します",
-    "voiceRecognitionNativeCoreHint": "この Core は無料 API を使用するため、独立 ASR の設定は適用されません",
+        "voiceRecognitionNativeCoreHint": "この Core は無料 API を使用するため、独立 ASR の設定は適用されません",
         "voiceRecognitionUnavailable": "独立音声認識を利用できないため、このセッションの音声入力を停止しました",
         "voiceRecognitionStatusReady": "● 正常に動作中",
         "voiceRecognitionSettingsPending": "◐ 設定は次の音声セッションから反映されます",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -942,6 +942,7 @@
         "voiceRecognitionSettings": "音声認識設定",
         "voiceRecognitionDisabled": "Omni ネイティブ音声認識を使用中",
         "voiceRecognitionDisabledHint": "独立 ASR はオフです。音声入力には Omni ネイティブ音声認識を使用します",
+    "voiceRecognitionNativeCoreHint": "この Core は無料 API を使用するため、独立 ASR の設定は適用されません",
         "voiceRecognitionUnavailable": "独立音声認識を利用できないため、このセッションの音声入力を停止しました",
         "voiceRecognitionStatusReady": "● 正常に動作中",
         "voiceRecognitionSettingsPending": "◐ 設定は次の音声セッションから反映されます",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -942,6 +942,7 @@
         "voiceRecognitionSettings": "음성 인식 설정",
         "voiceRecognitionDisabled": "Omni 네이티브 음성 인식 사용 중",
         "voiceRecognitionDisabledHint": "독립 ASR이 꺼져 있습니다. 음성 입력에는 Omni 네이티브 음성 인식을 사용합니다",
+    "voiceRecognitionNativeCoreHint": "이 Core는 무료 API를 사용하므로 독립 ASR 설정이 적용되지 않습니다",
         "voiceRecognitionUnavailable": "독립 음성 인식을 사용할 수 없어 이번 세션의 음성 입력이 중지되었습니다",
         "voiceRecognitionStatusReady": "● 정상 작동 중",
         "voiceRecognitionSettingsPending": "◐ 설정은 다음 음성 세션부터 적용됩니다",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -942,7 +942,7 @@
         "voiceRecognitionSettings": "음성 인식 설정",
         "voiceRecognitionDisabled": "Omni 네이티브 음성 인식 사용 중",
         "voiceRecognitionDisabledHint": "독립 ASR이 꺼져 있습니다. 음성 입력에는 Omni 네이티브 음성 인식을 사용합니다",
-    "voiceRecognitionNativeCoreHint": "이 Core는 무료 API를 사용하므로 독립 ASR 설정이 적용되지 않습니다",
+        "voiceRecognitionNativeCoreHint": "이 Core는 무료 API를 사용하므로 독립 ASR 설정이 적용되지 않습니다",
         "voiceRecognitionUnavailable": "독립 음성 인식을 사용할 수 없어 이번 세션의 음성 입력이 중지되었습니다",
         "voiceRecognitionStatusReady": "● 정상 작동 중",
         "voiceRecognitionSettingsPending": "◐ 설정은 다음 음성 세션부터 적용됩니다",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -942,6 +942,7 @@
         "voiceRecognitionSettings": "Configurações de reconhecimento de voz",
         "voiceRecognitionDisabled": "Usando o reconhecimento de voz nativo do Omni",
         "voiceRecognitionDisabledHint": "O ASR independente está desativado; a entrada de voz usa o reconhecimento de voz nativo do Omni",
+    "voiceRecognitionNativeCoreHint": "Este Core usa a API gratuita; os controles de ASR independente não se aplicam",
         "voiceRecognitionUnavailable": "O reconhecimento de voz independente está indisponível. A entrada de voz desta sessão foi interrompida",
         "voiceRecognitionStatusReady": "● Funcionando normalmente",
         "voiceRecognitionSettingsPending": "◐ As configurações terão efeito na próxima sessão de voz",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -942,7 +942,7 @@
         "voiceRecognitionSettings": "Configurações de reconhecimento de voz",
         "voiceRecognitionDisabled": "Usando o reconhecimento de voz nativo do Omni",
         "voiceRecognitionDisabledHint": "O ASR independente está desativado; a entrada de voz usa o reconhecimento de voz nativo do Omni",
-    "voiceRecognitionNativeCoreHint": "Este Core usa a API gratuita; os controles de ASR independente não se aplicam",
+        "voiceRecognitionNativeCoreHint": "Este Core usa a API gratuita; os controles de ASR independente não se aplicam",
         "voiceRecognitionUnavailable": "O reconhecimento de voz independente está indisponível. A entrada de voz desta sessão foi interrompida",
         "voiceRecognitionStatusReady": "● Funcionando normalmente",
         "voiceRecognitionSettingsPending": "◐ As configurações terão efeito na próxima sessão de voz",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -942,7 +942,7 @@
         "voiceRecognitionSettings": "Настройки распознавания речи",
         "voiceRecognitionDisabled": "Используется встроенное распознавание речи Omni",
         "voiceRecognitionDisabledHint": "Независимый ASR выключен; для голосового ввода используется встроенное распознавание речи Omni",
-    "voiceRecognitionNativeCoreHint": "Это ядро использует бесплатный API; настройки независимого ASR неприменимы",
+        "voiceRecognitionNativeCoreHint": "Это ядро использует бесплатный API; настройки независимого ASR неприменимы",
         "voiceRecognitionUnavailable": "Независимое распознавание речи недоступно. Голосовой ввод в этом сеансе остановлен",
         "voiceRecognitionStatusReady": "● Работает нормально",
         "voiceRecognitionSettingsPending": "◐ Настройки вступят в силу в следующем голосовом сеансе",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -942,6 +942,7 @@
         "voiceRecognitionSettings": "Настройки распознавания речи",
         "voiceRecognitionDisabled": "Используется встроенное распознавание речи Omni",
         "voiceRecognitionDisabledHint": "Независимый ASR выключен; для голосового ввода используется встроенное распознавание речи Omni",
+    "voiceRecognitionNativeCoreHint": "Это ядро использует бесплатный API; настройки независимого ASR неприменимы",
         "voiceRecognitionUnavailable": "Независимое распознавание речи недоступно. Голосовой ввод в этом сеансе остановлен",
         "voiceRecognitionStatusReady": "● Работает нормально",
         "voiceRecognitionSettingsPending": "◐ Настройки вступят в силу в следующем голосовом сеансе",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -942,6 +942,7 @@
         "voiceRecognitionSettings": "语音识别设置",
         "voiceRecognitionDisabled": "当前使用 Omni 原生语音识别",
         "voiceRecognitionDisabledHint": "独立 ASR 已关闭；语音输入使用 Omni 原生语音识别",
+    "voiceRecognitionNativeCoreHint": "当前核心使用免费API；独立 ASR 相关开关不适用",
         "voiceRecognitionUnavailable": "独立语音识别不可用，本次语音输入已停止",
         "voiceRecognitionStatusReady": "● 当前运行正常",
         "voiceRecognitionSettingsPending": "◐ 设置将在下次语音会话生效",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -942,7 +942,7 @@
         "voiceRecognitionSettings": "语音识别设置",
         "voiceRecognitionDisabled": "当前使用 Omni 原生语音识别",
         "voiceRecognitionDisabledHint": "独立 ASR 已关闭；语音输入使用 Omni 原生语音识别",
-    "voiceRecognitionNativeCoreHint": "当前核心使用免费API；独立 ASR 相关开关不适用",
+        "voiceRecognitionNativeCoreHint": "当前核心使用免费API；独立 ASR 相关开关不适用",
         "voiceRecognitionUnavailable": "独立语音识别不可用，本次语音输入已停止",
         "voiceRecognitionStatusReady": "● 当前运行正常",
         "voiceRecognitionSettingsPending": "◐ 设置将在下次语音会话生效",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -942,7 +942,7 @@
         "voiceRecognitionSettings": "語音辨識設定",
         "voiceRecognitionDisabled": "目前使用 Omni 原生語音辨識",
         "voiceRecognitionDisabledHint": "獨立 ASR 已關閉；語音輸入使用 Omni 原生語音辨識",
-    "voiceRecognitionNativeCoreHint": "目前核心使用免費 API；獨立 ASR 相關開關不適用",
+        "voiceRecognitionNativeCoreHint": "目前核心使用免費 API；獨立 ASR 相關開關不適用",
         "voiceRecognitionUnavailable": "獨立語音辨識無法使用，本次語音輸入已停止",
         "voiceRecognitionStatusReady": "● 目前運作正常",
         "voiceRecognitionSettingsPending": "◐ 設定將於下次語音會話生效",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -942,6 +942,7 @@
         "voiceRecognitionSettings": "語音辨識設定",
         "voiceRecognitionDisabled": "目前使用 Omni 原生語音辨識",
         "voiceRecognitionDisabledHint": "獨立 ASR 已關閉；語音輸入使用 Omni 原生語音辨識",
+    "voiceRecognitionNativeCoreHint": "目前核心使用免費 API；獨立 ASR 相關開關不適用",
         "voiceRecognitionUnavailable": "獨立語音辨識無法使用，本次語音輸入已停止",
         "voiceRecognitionStatusReady": "● 目前運作正常",
         "voiceRecognitionSettingsPending": "◐ 設定將於下次語音會話生效",

--- a/tests/frontend/test_voice_recognition_popover.py
+++ b/tests/frontend/test_voice_recognition_popover.py
@@ -7,13 +7,10 @@ from playwright.sync_api import Page
 ROOT = Path(__file__).resolve().parents[2]
 APP_AUDIO_CAPTURE = ROOT / "static" / "app" / "app-audio-capture.js"
 VOICE_POPOVER_GLOBAL_LISTENERS = (
-    "document:pointerdown",
-    "document:keydown",
-    "window:resize",
-    "window:scroll",
     "window:voice-input-lifecycle-changed",
     "window:neko:voice-session-started",
     "window:neko:voice-settings-pending-changed",
+    "window:neko:core-api-capability-changed",
 )
 
 
@@ -41,19 +38,35 @@ def _install_voice_popover_harness(
 ) -> None:
     permission_source, render_expression = _voice_popover_sources()
     page.set_content(
-        '<div id="live2d-popup-mic" style="display:flex;opacity:1"></div>'
+        '<div id="live2d-popup-mic" '
+        'style="display:flex;opacity:1;position:fixed;left:20px;top:20px"></div>'
+        '<button id="outside-target" '
+        'style="position:fixed;left:700px;top:500px;width:80px;height:40px">'
+        "outside</button>"
     )
 
     harness = r"""
 (() => {
     const listenerBalance = Object.create(null);
+    const trackedListenerKeys = new Set([
+        'document:pointerdown',
+        'document:keydown',
+        'window:resize',
+        'window:scroll',
+        'window:voice-input-lifecycle-changed',
+        'window:neko:voice-session-started',
+        'window:neko:voice-settings-pending-changed',
+        'window:neko:core-api-capability-changed',
+    ]);
     let failWindowListenerType = null;
     function trackListeners(target, prefix) {
         const originalAdd = target.addEventListener.bind(target);
         const originalRemove = target.removeEventListener.bind(target);
         target.addEventListener = function (type, listener, options) {
             const key = prefix + ':' + type;
-            listenerBalance[key] = (listenerBalance[key] || 0) + 1;
+            if (trackedListenerKeys.has(key)) {
+                listenerBalance[key] = (listenerBalance[key] || 0) + 1;
+            }
             const result = originalAdd(type, listener, options);
             if (prefix === 'window' && type === failWindowListenerType) {
                 failWindowListenerType = null;
@@ -63,7 +76,9 @@ def _install_voice_popover_harness(
         };
         target.removeEventListener = function (type, listener, options) {
             const key = prefix + ':' + type;
-            listenerBalance[key] = (listenerBalance[key] || 0) - 1;
+            if (trackedListenerKeys.has(key)) {
+                listenerBalance[key] = (listenerBalance[key] || 0) - 1;
+            }
             return originalRemove(type, listener, options);
         };
     }
@@ -101,6 +116,7 @@ def _install_voice_popover_harness(
         speakerGainNode: null,
         spatialAudioEnabled: true,
         independentAsrEnabled: true,
+        coreApiSupportsIndependentAsr: true,
         independentAsrActive: true,
         independentAsrProvider: 'qwen',
         voiceInputResourceOptimizationEnabled: true,
@@ -116,6 +132,8 @@ def _install_voice_popover_harness(
     };
     const C = {
         DEFAULT_SPEAKER_VOLUME: 100,
+        MAX_SPEAKER_VOLUME: 200,
+        SPEAKER_VOLUME_KNEE_RATIO: 0.75,
         MIN_MIC_GAIN_DB: -5,
         MAX_MIC_GAIN_DB: 25,
     };
@@ -148,8 +166,24 @@ def _install_voice_popover_harness(
     function ensureMicPopupScrollbarStyle() {}
     function attachTransientMicPopupScrollbar() { return () => {}; }
     function createScreenShareToggleButton() {
-        return document.createElement('button');
+        const button = document.createElement('button');
+        button.type = 'button';
+        return button;
     }
+    let deferScreenSources = false;
+    const screenSourceResolvers = [];
+    window.renderFloatingScreenSourceList = async (container) => {
+        if (deferScreenSources) {
+            await new Promise((resolve) => {
+                screenSourceResolvers.push(resolve);
+            });
+        }
+        const source = document.createElement('button');
+        source.type = 'button';
+        source.textContent = 'test-screen';
+        container.appendChild(source);
+        return true;
+    };
 
     let micPermissionGranted = false;
     let cachedMicDevices = null;
@@ -176,16 +210,37 @@ def _install_voice_popover_harness(
                 new Error('permission rejected')
             );
         },
+        deferScreenSources() {
+            deferScreenSources = true;
+        },
+        resolveScreenSources() {
+            deferScreenSources = false;
+            while (screenSourceResolvers.length) {
+                screenSourceResolvers.shift()();
+            }
+        },
+        pendingScreenSources: () => screenSourceResolvers.length,
         failMicVolumeVisualization() {
             failMicVolumeVisualization = true;
         },
-        failVoicePanelSetupOn(type) {
+        failVoiceControlsSetupOn(type) {
             failWindowListenerType = type;
         },
         pendingPermissions: () => mediaResolvers.length,
         popup: () => document.getElementById('live2d-popup-mic'),
-        panel: () => document.querySelector('[role="dialog"]'),
-        panels: () => document.querySelectorAll('[role="dialog"]').length,
+        action: (key) => document.querySelector(
+            '[data-neko-mic-main-action="' + key + '"]'
+        ),
+        voiceAction: () => document.querySelector(
+            '[data-neko-mic-main-action="voice-recognition"]'
+        ),
+        panel: (key = 'voice-recognition') => document.querySelector(
+            '.neko-mic-subwindow[data-neko-mic-action-key="' + key + '"]'
+        ),
+        ownedPanels: () => document.querySelectorAll(
+            '.neko-mic-subwindow[data-neko-sidepanel-owner="live2d-popup-mic"]'
+        ),
+        panels: () => document.querySelectorAll('.neko-mic-subwindow').length,
     };
 })();
 """
@@ -216,14 +271,23 @@ def test_overlapping_voice_popover_renders_keep_one_owned_instance(
             const afterOverlap = {
                 renderResults,
                 panels: window.__voicePopoverTest.panels(),
+                voiceActions: document.querySelectorAll(
+                    '[data-neko-mic-main-action="voice-recognition"]'
+                ).length,
                 capturedErrors: [...window.__voicePopoverTest.capturedErrors],
                 listenerBalance: { ...window.__voicePopoverTest.listenerBalance },
             };
             const third = await window.renderFloatingMicList(popup);
+            window.__voicePopoverTest.voiceAction().click();
+            await Promise.resolve();
+            const panel = window.__voicePopoverTest.panel();
             return {
                 afterOverlap,
                 third,
                 panelsAfterRerender: window.__voicePopoverTest.panels(),
+                panelOwner: panel?.getAttribute('data-neko-sidepanel-owner'),
+                panelIsSidePanel: panel?.hasAttribute('data-neko-sidepanel'),
+                panelActionKey: panel?.getAttribute('data-neko-mic-action-key'),
                 listenerBalanceAfterRerender: {
                     ...window.__voicePopoverTest.listenerBalance,
                 },
@@ -233,22 +297,27 @@ def test_overlapping_voice_popover_renders_keep_one_owned_instance(
 
     assert result["afterOverlap"]["renderResults"] == [False, True]
     assert not result["afterOverlap"]["capturedErrors"]
-    assert result["afterOverlap"]["panels"] == 1
+    assert result["afterOverlap"]["panels"] == 0
+    assert result["afterOverlap"]["voiceActions"] == 1
     assert result["third"] is True
     assert result["panelsAfterRerender"] == 1
+    assert result["panelOwner"] == "live2d-popup-mic"
+    assert result["panelIsSidePanel"] is True
+    assert result["panelActionKey"] == "voice-recognition"
 
     expected_global_listeners = {
-        "document:pointerdown": 1,
-        "document:keydown": 1,
-        "window:resize": 1,
-        "window:scroll": 1,
-        "window:voice-input-lifecycle-changed": 1,
-        "window:neko:voice-session-started": 1,
-        "window:neko:voice-settings-pending-changed": 1,
+        key: 1 for key in VOICE_POPOVER_GLOBAL_LISTENERS
     }
-    for key, expected in expected_global_listeners.items():
-        assert result["afterOverlap"]["listenerBalance"].get(key) == expected
-        assert result["listenerBalanceAfterRerender"].get(key) == expected
+    assert {
+        key: value
+        for key, value in result["afterOverlap"]["listenerBalance"].items()
+        if value
+    } == expected_global_listeners
+    assert {
+        key: value
+        for key, value in result["listenerBalanceAfterRerender"].items()
+        if value
+    } == expected_global_listeners
 
 
 @pytest.mark.frontend
@@ -286,6 +355,43 @@ def test_stale_voice_popover_failure_cannot_clear_new_render(page: Page) -> None
 
 
 @pytest.mark.frontend
+def test_hung_core_capability_refresh_does_not_block_microphone_popup(
+    page: Page,
+) -> None:
+    _install_voice_popover_harness(page, deferred_permission=False)
+
+    result = page.evaluate(
+        """async () => {
+            window.__voicePopoverTest.state.coreApiSupportsIndependentAsr = null;
+            window.refreshCoreApiCapability = () => new Promise(() => {});
+            const popup = window.__voicePopoverTest.popup();
+            return Promise.race([
+                window.renderFloatingMicList(popup).then(async (rendered) => {
+                    const panelsBeforeOpen = window.__voicePopoverTest.panels();
+                    window.__voicePopoverTest.voiceAction().click();
+                    await Promise.resolve();
+                    return {
+                        rendered,
+                        panelsBeforeOpen,
+                        panelsAfterOpen: window.__voicePopoverTest.panels(),
+                    };
+                }),
+                new Promise((resolve) => setTimeout(
+                    () => resolve({ timedOut: true }),
+                    250
+                )),
+            ]);
+        }"""
+    )
+
+    assert result == {
+        "rendered": True,
+        "panelsBeforeOpen": 0,
+        "panelsAfterOpen": 1,
+    }
+
+
+@pytest.mark.frontend
 def test_current_voice_popover_failure_disposes_owned_portal(page: Page) -> None:
     _install_voice_popover_harness(page, deferred_permission=False)
 
@@ -308,8 +414,11 @@ def test_current_voice_popover_failure_disposes_owned_portal(page: Page) -> None
     assert result["rendered"] is True
     assert result["panels"] == 0
     assert result["errorText"] == "microphone.loadFailed"
-    for key in VOICE_POPOVER_GLOBAL_LISTENERS:
-        assert result["listenerBalance"].get(key) == 0
+    assert not {
+        key: value
+        for key, value in result["listenerBalance"].items()
+        if value
+    }
 
 
 @pytest.mark.frontend
@@ -321,7 +430,7 @@ def test_voice_popover_setup_failure_disposes_registered_listeners(
     result = page.evaluate(
         """async () => {
             const popup = window.__voicePopoverTest.popup();
-            window.__voicePopoverTest.failVoicePanelSetupOn(
+            window.__voicePopoverTest.failVoiceControlsSetupOn(
                 'neko:voice-settings-pending-changed'
             );
             const rendered = await window.renderFloatingMicList(popup);
@@ -339,8 +448,11 @@ def test_voice_popover_setup_failure_disposes_registered_listeners(
     assert result["rendered"] is True
     assert result["panels"] == 0
     assert result["errorText"] == "microphone.loadFailed"
-    for key in VOICE_POPOVER_GLOBAL_LISTENERS:
-        assert result["listenerBalance"].get(key) == 0
+    assert not {
+        key: value
+        for key, value in result["listenerBalance"].items()
+        if value
+    }
 
 
 @pytest.mark.frontend
@@ -351,18 +463,27 @@ def test_voice_popover_disposes_when_popup_host_is_removed(page: Page) -> None:
         """async () => {
             const popup = window.__voicePopoverTest.popup();
             await window.renderFloatingMicList(popup);
+            window.__voicePopoverTest.voiceAction().click();
+            await Promise.resolve();
+            const panelsBeforeRemoval = window.__voicePopoverTest.panels();
             popup.remove();
             await Promise.resolve();
+            await new Promise((resolve) => setTimeout(resolve, 0));
             return {
+                panelsBeforeRemoval,
                 panels: window.__voicePopoverTest.panels(),
                 listenerBalance: { ...window.__voicePopoverTest.listenerBalance },
             };
         }"""
     )
 
+    assert result["panelsBeforeRemoval"] == 1
     assert result["panels"] == 0
-    for key in VOICE_POPOVER_GLOBAL_LISTENERS:
-        assert result["listenerBalance"].get(key) == 0
+    assert not {
+        key: value
+        for key, value in result["listenerBalance"].items()
+        if value
+    }
 
 
 @pytest.mark.frontend
@@ -375,6 +496,8 @@ def test_voice_popover_toggles_have_accessible_names_and_hints(
         """async () => {
             const popup = window.__voicePopoverTest.popup();
             await window.renderFloatingMicList(popup);
+            window.__voicePopoverTest.voiceAction().click();
+            await Promise.resolve();
             return Array.from(
                 window.__voicePopoverTest.panel().querySelectorAll(
                     'input[type="checkbox"]'
@@ -402,6 +525,305 @@ def test_voice_popover_toggles_have_accessible_names_and_hints(
 
 
 @pytest.mark.frontend
+def test_voice_device_and_screen_actions_share_one_owned_subwindow(
+    page: Page,
+) -> None:
+    _install_voice_popover_harness(page, deferred_permission=False)
+
+    result = page.evaluate(
+        """async () => {
+            const test = window.__voicePopoverTest;
+            await window.renderFloatingMicList(test.popup());
+
+            async function openAndSnapshot(key) {
+                test.action(key).click();
+                await new Promise((resolve) => setTimeout(resolve, 0));
+                const panels = Array.from(test.ownedPanels());
+                return {
+                    count: panels.length,
+                    actionKey: panels[0]?.getAttribute(
+                        'data-neko-mic-action-key'
+                    ),
+                    owner: panels[0]?.getAttribute(
+                        'data-neko-sidepanel-owner'
+                    ),
+                    sidePanel: panels[0]?.hasAttribute('data-neko-sidepanel'),
+                };
+            }
+
+            const voice = await openAndSnapshot('voice-recognition');
+            const device = await openAndSnapshot('device');
+            const screen = await openAndSnapshot('screen');
+            const closeButton = test.ownedPanels()[0].querySelector(
+                'button[aria-label="Close"]'
+            );
+            closeButton.click();
+            return {
+                voice,
+                device,
+                screen,
+                panelsAfterClose: test.ownedPanels().length,
+            };
+        }"""
+    )
+
+    assert result["voice"] == {
+        "count": 1,
+        "actionKey": "voice-recognition",
+        "owner": "live2d-popup-mic",
+        "sidePanel": True,
+    }
+    assert result["device"] == {
+        "count": 1,
+        "actionKey": "device",
+        "owner": "live2d-popup-mic",
+        "sidePanel": True,
+    }
+    assert result["screen"] == {
+        "count": 1,
+        "actionKey": "screen",
+        "owner": "live2d-popup-mic",
+        "sidePanel": True,
+    }
+    assert result["panelsAfterClose"] == 0
+
+
+@pytest.mark.frontend
+def test_voice_action_uses_shared_260ms_hover_collapse(page: Page) -> None:
+    _install_voice_popover_harness(page, deferred_permission=False)
+    page.evaluate(
+        """async () => {
+            await window.renderFloatingMicList(
+                window.__voicePopoverTest.popup()
+            );
+        }"""
+    )
+
+    page.locator(
+        '[data-neko-mic-main-action="voice-recognition"]'
+    ).hover()
+    page.wait_for_function("window.__voicePopoverTest.panels() === 1")
+    page.locator(
+        '.neko-mic-subwindow[data-neko-mic-action-key="voice-recognition"]'
+    ).hover()
+    page.wait_for_timeout(320)
+    assert page.evaluate("window.__voicePopoverTest.panels()") == 1
+
+    page.locator("#outside-target").hover()
+    page.wait_for_timeout(180)
+    assert page.evaluate("window.__voicePopoverTest.panels()") == 1
+    page.wait_for_timeout(150)
+    assert page.evaluate("window.__voicePopoverTest.panels()") == 0
+
+
+@pytest.mark.frontend
+def test_voice_action_rerender_clears_the_previous_hover_timer(
+    page: Page,
+) -> None:
+    _install_voice_popover_harness(page, deferred_permission=False)
+    page.evaluate(
+        """async () => {
+            await window.renderFloatingMicList(
+                window.__voicePopoverTest.popup()
+            );
+        }"""
+    )
+
+    page.locator(
+        '[data-neko-mic-main-action="voice-recognition"]'
+    ).hover()
+    page.wait_for_function("window.__voicePopoverTest.panels() === 1")
+    page.locator("#outside-target").hover()
+    page.wait_for_timeout(50)
+
+    page.evaluate(
+        """async () => {
+            const test = window.__voicePopoverTest;
+            await window.renderFloatingMicList(test.popup());
+            test.voiceAction().click();
+            await Promise.resolve();
+        }"""
+    )
+    page.wait_for_timeout(320)
+    assert page.evaluate("window.__voicePopoverTest.panels()") == 1
+
+
+@pytest.mark.frontend
+def test_stale_screen_open_cannot_relabel_a_new_voice_subwindow(
+    page: Page,
+) -> None:
+    _install_voice_popover_harness(page, deferred_permission=False)
+    result = page.evaluate(
+        """async () => {
+            const test = window.__voicePopoverTest;
+            const popup = test.popup();
+            await window.renderFloatingMicList(popup);
+            test.deferScreenSources();
+            test.action('screen').click();
+            if (test.pendingScreenSources() !== 1) {
+                throw new Error('expected the old screen panel to be pending');
+            }
+
+            await window.renderFloatingMicList(popup);
+            test.voiceAction().click();
+            await Promise.resolve();
+            const newVoicePanel = test.panel();
+            const beforeResolve = {
+                count: test.ownedPanels().length,
+                actionKey: newVoicePanel?.getAttribute(
+                    'data-neko-mic-action-key'
+                ),
+            };
+
+            test.resolveScreenSources();
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const currentPanel = test.ownedPanels()[0];
+            return {
+                beforeResolve,
+                afterResolve: {
+                    count: test.ownedPanels().length,
+                    samePanel: currentPanel === newVoicePanel,
+                    actionKey: currentPanel?.getAttribute(
+                        'data-neko-mic-action-key'
+                    ),
+                },
+            };
+        }"""
+    )
+
+    expected = {"count": 1, "actionKey": "voice-recognition"}
+    assert result["beforeResolve"] == expected
+    assert result["afterResolve"] == {
+        **expected,
+        "samePanel": True,
+    }
+
+
+@pytest.mark.frontend
+def test_voice_row_asr_toggle_does_not_open_the_subwindow(page: Page) -> None:
+    _install_voice_popover_harness(page, deferred_permission=False)
+    page.evaluate(
+        """async () => {
+            await window.renderFloatingMicList(
+                window.__voicePopoverTest.popup()
+            );
+        }"""
+    )
+
+    asr_input = page.locator(
+        '[data-neko-mic-main-action="voice-recognition"] '
+        'input[type="checkbox"]'
+    )
+    asr_input.hover()
+    page.wait_for_timeout(50)
+    assert page.evaluate("window.__voicePopoverTest.panels()") == 0
+
+    asr_input.click()
+    page.wait_for_timeout(50)
+    result = page.evaluate(
+        """() => ({
+            panels: window.__voicePopoverTest.panels(),
+            preference: window.__voicePopoverTest.state.independentAsrEnabled,
+            saveCalls: window.__saveCalls,
+        })"""
+    )
+    assert result == {"panels": 0, "preference": False, "saveCalls": 1}
+
+
+@pytest.mark.frontend
+def test_core_without_independent_asr_shows_native_effective_view_and_keeps_preference(
+    page: Page,
+) -> None:
+    _install_voice_popover_harness(page, deferred_permission=False)
+
+    result = page.evaluate(
+        """async () => {
+            const test = window.__voicePopoverTest;
+            const state = test.state;
+            state.coreApiSupportsIndependentAsr = false;
+            const popup = test.popup();
+            await window.renderFloatingMicList(popup);
+            const container = test.voiceAction();
+            container.click();
+            await Promise.resolve();
+
+            const panel = test.panel();
+            const asrInput = container.querySelector('input[type="checkbox"]');
+            const panelInputs = panel.querySelectorAll('input[type="checkbox"]');
+            const noiseInput = panelInputs[0];
+            const optimizationInput = panelInputs[1];
+            const summary = () => container.querySelector(
+                '.neko-mic-action-sub-label'
+            ).textContent;
+            const status = () => panel.querySelector(
+                '.neko-voice-recognition-status'
+            ).textContent;
+
+            const nativeView = {
+                preference: state.independentAsrEnabled,
+                asrChecked: asrInput.checked,
+                asrDisabled: asrInput.disabled,
+                optimizationChecked: optimizationInput.checked,
+                optimizationDisabled: optimizationInput.disabled,
+                noiseDisabled: noiseInput.disabled,
+                summary: summary(),
+                status: status(),
+            };
+
+            // Even a synthetic change event must not mutate or persist the
+            // preference while the effective control is disabled.
+            asrInput.checked = true;
+            asrInput.dispatchEvent(new Event('change', { bubbles: true }));
+            const afterDisabledChange = {
+                preference: state.independentAsrEnabled,
+                checked: asrInput.checked,
+                saveCalls: window.__saveCalls,
+            };
+
+            state.coreApiSupportsIndependentAsr = true;
+            window.dispatchEvent(new CustomEvent(
+                'neko:core-api-capability-changed'
+            ));
+            const restoredView = {
+                preference: state.independentAsrEnabled,
+                asrChecked: asrInput.checked,
+                asrDisabled: asrInput.disabled,
+                optimizationChecked: optimizationInput.checked,
+                optimizationDisabled: optimizationInput.disabled,
+                summary: summary(),
+                status: status(),
+            };
+            return { nativeView, afterDisabledChange, restoredView };
+        }"""
+    )
+
+    assert result["nativeView"] == {
+        "preference": True,
+        "asrChecked": False,
+        "asrDisabled": True,
+        "optimizationChecked": False,
+        "optimizationDisabled": True,
+        "noiseDisabled": False,
+        "summary": "microphone.voiceRecognitionDisabled",
+        "status": "microphone.voiceRecognitionNativeCoreHint",
+    }
+    assert result["afterDisabledChange"] == {
+        "preference": True,
+        "checked": False,
+        "saveCalls": 0,
+    }
+    assert result["restoredView"] == {
+        "preference": True,
+        "asrChecked": True,
+        "asrDisabled": False,
+        "optimizationChecked": True,
+        "optimizationDisabled": False,
+        "summary": "microphone.independentAsrSummary",
+        "status": "microphone.voiceRecognitionStatusReady",
+    }
+
+
+@pytest.mark.frontend
 def test_voice_settings_pending_clears_only_after_target_session(
     page: Page,
 ) -> None:
@@ -411,8 +833,12 @@ def test_voice_settings_pending_clears_only_after_target_session(
         """async () => {
             const popup = window.__voicePopoverTest.popup();
             await window.renderFloatingMicList(popup);
+            window.__voicePopoverTest.voiceAction().click();
+            await Promise.resolve();
             const firstPanel = window.__voicePopoverTest.panel();
-            const firstStatus = firstPanel.lastElementChild;
+            const firstStatus = firstPanel.querySelector(
+                '.neko-voice-recognition-status'
+            );
             const optimizationInput = firstPanel.querySelectorAll(
                 'input[type="checkbox"]'
             )[1];
@@ -444,9 +870,8 @@ def test_voice_settings_pending_clears_only_after_target_session(
             window.dispatchEvent(new CustomEvent('neko:voice-session-started'));
             const afterBlockedSession = firstStatus.textContent;
 
-            const asrInput = document.querySelector(
-                '[aria-controls="' + firstPanel.id + '"] input[type="checkbox"]'
-            );
+            const asrInput = window.__voicePopoverTest.voiceAction()
+                .querySelector('input[type="checkbox"]');
             asrInput.checked = false;
             asrInput.dispatchEvent(new Event('change', { bubbles: true }));
             window.__voicePopoverTest.state.voiceSessionStartEpoch = 13;
@@ -491,7 +916,7 @@ def test_voice_settings_pending_clears_only_after_target_session(
     assert result["oldStatusAfterDispose"] == pending_key
     assert result["oldStatusAfterEvent"] == pending_key
     assert result["oldPanelConnected"] is False
-    assert result["panels"] == 1
+    assert result["panels"] == 0
     assert result["listenerBalance"]["window:neko:voice-session-started"] == 1
     assert (
         result["listenerBalance"]["window:neko:voice-settings-pending-changed"]
@@ -505,48 +930,55 @@ def test_voice_popover_keeps_active_route_and_keyboard_access(
 ) -> None:
     _install_voice_popover_harness(page, deferred_permission=False)
 
-    result = page.evaluate(
+    before_open = page.evaluate(
         """async () => {
             const popup = window.__voicePopoverTest.popup();
             await window.renderFloatingMicList(popup);
-            const panel = window.__voicePopoverTest.panel();
-            const container = document.querySelector(
-                '[aria-controls="' + panel.id + '"]'
-            );
+            const container = window.__voicePopoverTest.voiceAction();
             const asrInput = container.querySelector('input[type="checkbox"]');
-            const panelInputs = panel.querySelectorAll('input[type="checkbox"]');
-            const noiseInput = panelInputs[0];
-            const optimizationInput = panelInputs[1];
 
             window.__voicePopoverTest.state.voiceChatActive = true;
             window.__voicePopoverTest.state.independentAsrActive = true;
             asrInput.checked = false;
             asrInput.dispatchEvent(new Event('change', { bubbles: true }));
 
-            const summary = container.firstElementChild
-                .firstElementChild.lastElementChild.textContent;
+            const summary = container.querySelector(
+                '.neko-mic-action-sub-label'
+            ).textContent;
             container.focus();
-            container.dispatchEvent(new KeyboardEvent('keydown', {
-                key: 'Enter',
-                bubbles: true,
-            }));
-
             return {
                 summary,
-                noiseDisabled: noiseInput.disabled,
-                optimizationDisabled: optimizationInput.disabled,
-                panelOpen: container.getAttribute('aria-expanded'),
-                focusedNoise: document.activeElement === noiseInput,
+                actionTag: container.tagName,
+                actionFocused: document.activeElement === container,
+                panelsBeforeEnter: window.__voicePopoverTest.panels(),
+            };
+        }"""
+    )
+    page.keyboard.press("Enter")
+    after_open = page.evaluate(
+        """() => {
+            const panel = window.__voicePopoverTest.panel();
+            const panelInputs = panel.querySelectorAll('input[type="checkbox"]');
+            return {
+                panels: window.__voicePopoverTest.panels(),
+                noiseDisabled: panelInputs[0].disabled,
+                optimizationDisabled: panelInputs[1].disabled,
+                actionKey: panel.getAttribute('data-neko-mic-action-key'),
             };
         }"""
     )
 
-    assert result == {
+    assert before_open == {
         "summary": "microphone.independentAsrSummary",
+        "actionTag": "BUTTON",
+        "actionFocused": True,
+        "panelsBeforeEnter": 0,
+    }
+    assert after_open == {
+        "panels": 1,
         "noiseDisabled": False,
         "optimizationDisabled": True,
-        "panelOpen": "true",
-        "focusedNoise": True,
+        "actionKey": "voice-recognition",
     }
 
 
@@ -572,15 +1004,18 @@ def test_voice_popover_preserves_cross_window_active_route_across_rerender(
             state.voiceSettingsPendingUntilEpoch = 11;
             state.independentAsrEnabled = false;
             await window.renderFloatingMicList(popup);
+            const container = window.__voicePopoverTest.voiceAction();
+            container.click();
+            await Promise.resolve();
 
             const panel = window.__voicePopoverTest.panel();
-            const container = document.querySelector(
-                '[aria-controls="' + panel.id + '"]'
-            );
             return {
-                summary: container.firstElementChild
-                    .firstElementChild.lastElementChild.textContent,
-                status: panel.lastElementChild.textContent,
+                summary: container.querySelector(
+                    '.neko-mic-action-sub-label'
+                ).textContent,
+                status: panel.querySelector(
+                    '.neko-voice-recognition-status'
+                ).textContent,
             };
         }"""
     )
@@ -598,10 +1033,7 @@ def test_voice_popover_keyboard_focus_ring_is_visible(page: Page) -> None:
         """async () => {
             const popup = window.__voicePopoverTest.popup();
             await window.renderFloatingMicList(popup);
-            const panel = window.__voicePopoverTest.panel();
-            const container = document.querySelector(
-                '[aria-controls="' + panel.id + '"]'
-            );
+            const container = window.__voicePopoverTest.voiceAction();
             container.focus();
         }"""
     )
@@ -612,6 +1044,7 @@ def test_voice_popover_keyboard_focus_ring_is_visible(page: Page) -> None:
         """() => {
             const panel = window.__voicePopoverTest.panel();
             const input = panel.querySelector('input[type="checkbox"]');
+            input.focus();
             const slider = input.nextElementSibling;
             return {
                 focused: document.activeElement === input,

--- a/tests/frontend/test_voice_recognition_popover.py
+++ b/tests/frontend/test_voice_recognition_popover.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pytest
@@ -6,6 +7,12 @@ from playwright.sync_api import Page
 
 ROOT = Path(__file__).resolve().parents[2]
 APP_AUDIO_CAPTURE = ROOT / "static" / "app" / "app-audio-capture.js"
+VOICE_POPOVER_LOCAL_LISTENERS = (
+    "document:pointerdown",
+    "document:keydown",
+    "window:resize",
+    "window:scroll",
+)
 VOICE_POPOVER_GLOBAL_LISTENERS = (
     "window:voice-input-lifecycle-changed",
     "window:neko:voice-session-started",
@@ -48,16 +55,7 @@ def _install_voice_popover_harness(
     harness = r"""
 (() => {
     const listenerBalance = Object.create(null);
-    const trackedListenerKeys = new Set([
-        'document:pointerdown',
-        'document:keydown',
-        'window:resize',
-        'window:scroll',
-        'window:voice-input-lifecycle-changed',
-        'window:neko:voice-session-started',
-        'window:neko:voice-settings-pending-changed',
-        'window:neko:core-api-capability-changed',
-    ]);
+    const trackedListenerKeys = new Set(__TRACKED_LISTENER_KEYS__);
     let failWindowListenerType = null;
     function trackListeners(target, prefix) {
         const originalAdd = target.addEventListener.bind(target);
@@ -244,6 +242,12 @@ def _install_voice_popover_harness(
     };
 })();
 """
+    harness = harness.replace(
+        "__TRACKED_LISTENER_KEYS__",
+        json.dumps(
+            [*VOICE_POPOVER_LOCAL_LISTENERS, *VOICE_POPOVER_GLOBAL_LISTENERS]
+        ),
+    )
     harness = harness.replace(
         "__DEFERRED_PERMISSION__", "true" if deferred_permission else "false"
     )
@@ -610,10 +614,11 @@ def test_voice_action_uses_shared_260ms_hover_collapse(page: Page) -> None:
     assert page.evaluate("window.__voicePopoverTest.panels()") == 1
 
     page.locator("#outside-target").hover()
-    page.wait_for_timeout(180)
+    page.wait_for_timeout(100)
     assert page.evaluate("window.__voicePopoverTest.panels()") == 1
-    page.wait_for_timeout(150)
-    assert page.evaluate("window.__voicePopoverTest.panels()") == 0
+    page.wait_for_function(
+        "window.__voicePopoverTest.panels() === 0", timeout=2000
+    )
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_voice_recognition_popover.py
+++ b/tests/frontend/test_voice_recognition_popover.py
@@ -163,9 +163,12 @@ def _install_voice_popover_harness(
     }
     function ensureMicPopupScrollbarStyle() {}
     function attachTransientMicPopupScrollbar() { return () => {}; }
+    window.__screenToggleCalls = 0;
     function createScreenShareToggleButton() {
         const button = document.createElement('button');
         button.type = 'button';
+        button.dataset.nekoScreenShareAction = 'toggle';
+        button.addEventListener('click', () => { window.__screenToggleCalls += 1; });
         return button;
     }
     let deferScreenSources = false;
@@ -231,6 +234,17 @@ def _install_voice_popover_harness(
         ),
         voiceAction: () => document.querySelector(
             '[data-neko-mic-main-action="voice-recognition"]'
+        ),
+        actionRow: (key) => document.querySelector(
+            '[data-neko-mic-main-action-row="' + key + '"]'
+        ),
+        voiceToggle: () => document.querySelector(
+            '[data-neko-mic-main-action-row="voice-recognition"] '
+            + '.neko-voice-setting-toggle-input'
+        ),
+        screenToggle: () => document.querySelector(
+            '[data-neko-mic-main-action-row="screen"] '
+            + '[data-neko-screen-share-action="toggle"]'
         ),
         panel: (key = 'voice-recognition') => document.querySelector(
             '.neko-mic-subwindow[data-neko-mic-action-key="' + key + '"]'
@@ -705,7 +719,7 @@ def test_stale_screen_open_cannot_relabel_a_new_voice_subwindow(
 
 
 @pytest.mark.frontend
-def test_voice_row_asr_toggle_does_not_open_the_subwindow(page: Page) -> None:
+def test_action_row_controls_are_siblings_and_do_not_cross_trigger(page: Page) -> None:
     _install_voice_popover_harness(page, deferred_permission=False)
     page.evaluate(
         """async () => {
@@ -715,9 +729,50 @@ def test_voice_row_asr_toggle_does_not_open_the_subwindow(page: Page) -> None:
         }"""
     )
 
+    structure = page.evaluate(
+        """() => {
+            const test = window.__voicePopoverTest;
+            const voiceAction = test.voiceAction();
+            const voiceToggle = test.voiceToggle();
+            const voiceRow = test.actionRow('voice-recognition');
+            const screenAction = test.action('screen');
+            const screenToggle = test.screenToggle();
+            const screenRow = test.actionRow('screen');
+            return {
+                voiceRowTag: voiceRow?.tagName,
+                voiceSiblings: voiceAction?.parentElement === voiceRow
+                    && voiceToggle?.closest('label')?.parentElement === voiceRow,
+                voiceNested: voiceAction?.contains(voiceToggle),
+                checkboxInsideButton: voiceToggle?.closest('button') !== null,
+                screenToggleTag: screenToggle?.tagName,
+                screenSiblings: screenAction?.parentElement === screenRow
+                    && screenToggle?.parentElement === screenRow,
+                screenNested: screenAction?.contains(screenToggle),
+            };
+        }"""
+    )
+    assert structure == {
+        "voiceRowTag": "DIV",
+        "voiceSiblings": True,
+        "voiceNested": False,
+        "checkboxInsideButton": False,
+        "screenToggleTag": "BUTTON",
+        "screenSiblings": True,
+        "screenNested": False,
+    }
+
+    screen_toggle = page.locator(
+        '[data-neko-mic-main-action-row="screen"] '
+        '[data-neko-screen-share-action="toggle"]'
+    )
+    screen_toggle.focus()
+    page.keyboard.press("Space")
+    assert page.evaluate("window.__screenToggleCalls") == 1
+    assert page.evaluate("window.__voicePopoverTest.panels()") == 0
+
     asr_input = page.locator(
-        '[data-neko-mic-main-action="voice-recognition"] '
-        'input[type="checkbox"]'
+        '[data-neko-mic-main-action-row="voice-recognition"] '
+        '.neko-voice-setting-toggle-input'
     )
     asr_input.hover()
     page.wait_for_timeout(50)
@@ -733,6 +788,42 @@ def test_voice_row_asr_toggle_does_not_open_the_subwindow(page: Page) -> None:
         })"""
     )
     assert result == {"panels": 0, "preference": False, "saveCalls": 1}
+
+    asr_input.focus()
+    page.keyboard.press("Space")
+    result = page.evaluate(
+        """() => ({
+            panels: window.__voicePopoverTest.panels(),
+            preference: window.__voicePopoverTest.state.independentAsrEnabled,
+            saveCalls: window.__saveCalls,
+        })"""
+    )
+    assert result == {"panels": 0, "preference": True, "saveCalls": 2}
+
+    voice_action = page.locator(
+        '[data-neko-mic-main-action="voice-recognition"]'
+    )
+    voice_action.focus()
+    page.keyboard.press("Enter")
+    page.wait_for_function("window.__voicePopoverTest.panels() === 1")
+    asr_input.hover()
+    page.wait_for_timeout(320)
+    result = page.evaluate(
+        """() => ({
+            panels: window.__voicePopoverTest.panels(),
+            preference: window.__voicePopoverTest.state.independentAsrEnabled,
+            checked: window.__voicePopoverTest.voiceToggle().checked,
+            saveCalls: window.__saveCalls,
+        })"""
+    )
+    assert result == {
+        "panels": 1,
+        "preference": True,
+        "checked": True,
+        "saveCalls": 2,
+    }
+    page.locator("#outside-target").hover()
+    page.wait_for_function("window.__voicePopoverTest.panels() === 0")
 
 
 @pytest.mark.frontend
@@ -753,7 +844,7 @@ def test_core_without_independent_asr_shows_native_effective_view_and_keeps_pref
             await Promise.resolve();
 
             const panel = test.panel();
-            const asrInput = container.querySelector('input[type="checkbox"]');
+            const asrInput = test.voiceToggle();
             const panelInputs = panel.querySelectorAll('input[type="checkbox"]');
             const noiseInput = panelInputs[0];
             const optimizationInput = panelInputs[1];
@@ -875,8 +966,7 @@ def test_voice_settings_pending_clears_only_after_target_session(
             window.dispatchEvent(new CustomEvent('neko:voice-session-started'));
             const afterBlockedSession = firstStatus.textContent;
 
-            const asrInput = window.__voicePopoverTest.voiceAction()
-                .querySelector('input[type="checkbox"]');
+            const asrInput = window.__voicePopoverTest.voiceToggle();
             asrInput.checked = false;
             asrInput.dispatchEvent(new Event('change', { bubbles: true }));
             window.__voicePopoverTest.state.voiceSessionStartEpoch = 13;
@@ -940,7 +1030,7 @@ def test_voice_popover_keeps_active_route_and_keyboard_access(
             const popup = window.__voicePopoverTest.popup();
             await window.renderFloatingMicList(popup);
             const container = window.__voicePopoverTest.voiceAction();
-            const asrInput = container.querySelector('input[type="checkbox"]');
+            const asrInput = window.__voicePopoverTest.voiceToggle();
 
             window.__voicePopoverTest.state.voiceChatActive = true;
             window.__voicePopoverTest.state.independentAsrActive = true;

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -618,7 +618,7 @@ def test_stale_unsupported_capability_does_not_override_paid_core_preference_har
     assert result.stdout.strip() == "ok"
 
 
-def test_core_capability_refresh_failures_fail_open_and_ignore_stale_requests_harness():
+def test_core_capability_refresh_failures_fail_open_and_coalesce_requests_harness():
     source = APP_WEBSOCKET_PATH.read_text(encoding="utf-8")
     start = source.index("function publishCoreApiCapability(provider, capability)")
     end = source.index("// Prime the capability once", start)
@@ -664,20 +664,39 @@ def test_core_capability_refresh_failures_fail_open_and_ignore_stale_requests_ha
           assert(S.coreApiSupportsIndependentAsr === null, 'legacy response must fail open');
           assert(S.coreApiProvider === 'qwen', 'usable provider context should be retained');
 
-          let rejectOld;
-          window.fetch = () => new Promise((resolve, reject) => { rejectOld = reject; });
-          const oldRequest = refreshCoreApiCapability({ force: true });
-          window.fetch = async () => response({
+          const validCapability = {
             success: true,
             coreApi: 'free',
             effectiveCoreApi: 'qwen',
             supportsIndependentAsr: true,
-          });
-          await refreshCoreApiCapability({ force: true });
-          rejectOld(new Error('late old request'));
-          await oldRequest;
-          assert(S.coreApiSupportsIndependentAsr === true, 'late failure must not clear newer capability');
-          assert(S.coreApiProvider === 'qwen', 'effective provider must win and survive a late failure');
+          };
+          let fetchCalls = 0;
+          let resolveShared;
+          window.fetch = () => {
+            fetchCalls += 1;
+            return new Promise((resolve) => { resolveShared = resolve; });
+          };
+          const firstRequest = refreshCoreApiCapability({ force: true });
+          const joinedForceRequest = refreshCoreApiCapability({ force: true });
+          const joinedDefaultRequest = refreshCoreApiCapability();
+          assert(firstRequest === joinedForceRequest, 'force callers must share the in-flight request');
+          assert(firstRequest === joinedDefaultRequest, 'all callers must share the in-flight request');
+          assert(fetchCalls === 1, 'coalesced callers must issue one fetch');
+          resolveShared(response(validCapability));
+          await firstRequest;
+          assert(S.coreApiSupportsIndependentAsr === true, 'shared success must publish capability');
+          assert(S.coreApiProvider === 'qwen', 'effective provider must win');
+
+          let resolveNext;
+          window.fetch = () => {
+            fetchCalls += 1;
+            return new Promise((resolve) => { resolveNext = resolve; });
+          };
+          const nextRequest = refreshCoreApiCapability({ force: true });
+          assert(nextRequest !== firstRequest, 'force must bypass completed cache data');
+          assert(fetchCalls === 2, 'force after settlement must issue a fresh fetch');
+          resolveNext(response(validCapability));
+          await nextRequest;
           assert(
             events.length === 3
               && events.every((event) => event.type === 'neko:core-api-capability-changed'),

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -261,7 +261,7 @@ def test_independent_asr_provider_copy_resolves_via_provider_names():
     # from the toggle handler so the visible route never lags the user's choice.
     summary_block = capture_source.split(
         "function updateVoiceRecognitionUi() {", 1
-    )[1].split("function positionVoicePanel()", 1)[0]
+    )[1].split("function onVoiceLifecycleChanged()", 1)[0]
     assert "'microphone.independentAsrSummary'" in summary_block
     assert "{ provider: provider }" in summary_block
     assert "'microphone.voiceRecognitionDisabled'" in summary_block
@@ -269,7 +269,7 @@ def test_independent_asr_provider_copy_resolves_via_provider_names():
 
     change_handler = capture_source.split(
         "var asrToggle = createVoiceSettingToggle(", 1
-    )[1].split("asrRow.appendChild(asrCopy);", 1)[0]
+    )[1].split("var voicePanelId", 1)[0]
     assert "updateVoiceRecognitionUi();" in change_handler
 
 
@@ -575,6 +575,7 @@ def test_start_session_payload_carries_independent_asr_handshake():
     # other messages pass through untouched.
     assert "typeof data === 'string'" in wrapper
     assert "msg.action === 'start_session'" in wrapper
+    assert "coreApiSupportsIndependentAsr" not in wrapper
 
     # The wrapper is attached at the single socket-creation seam, so every
     # start_session send site (including the ones in app-buttons.js) carries
@@ -582,6 +583,113 @@ def test_start_session_payload_carries_independent_asr_handshake():
     creation_index = websocket_source.index("S.socket = new WebSocket(wsUrl);")
     attach_index = websocket_source.index("attachStartSessionHandshake(S.socket);")
     assert 0 < attach_index - creation_index < 200
+
+
+def test_stale_unsupported_capability_does_not_override_paid_core_preference_harness():
+    source = APP_WEBSOCKET_PATH.read_text(encoding="utf-8")
+    start = source.index("function attachStartSessionHandshake(ws)")
+    end = source.index("function connectWebSocket()", start)
+    attach_source = source[start:end]
+    harness = (
+        """
+        const S = {
+          coreApiSupportsIndependentAsr: false,
+          settingsHydrated: true,
+          independentAsrAuthoritative: true,
+          independentAsrEnabled: true,
+          voiceInputResourceOptimizationAuthoritative: false,
+        };
+        """
+        + attach_source
+        + """
+        const frames = [];
+        const ws = { send(data) { frames.push(data); } };
+        attachStartSessionHandshake(ws);
+        ws.send(JSON.stringify({ action: 'start_session', input_type: 'audio' }));
+        const sent = JSON.parse(frames[0]);
+        if (sent.independent_asr_enabled !== true) {
+          throw new Error('stale capability must not replace the authoritative preference');
+        }
+        console.log('ok');
+        """
+    )
+    result = _run_settings_node_harness(harness)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"
+
+
+def test_core_capability_refresh_failures_fail_open_and_ignore_stale_requests_harness():
+    source = APP_WEBSOCKET_PATH.read_text(encoding="utf-8")
+    start = source.index("function publishCoreApiCapability(provider, capability)")
+    end = source.index("// Prime the capability once", start)
+    refresh_source = source[start:end]
+    harness = (
+        """
+        const S = {
+          coreApiProvider: 'free',
+          coreApiSupportsIndependentAsr: false,
+        };
+        let _coreApiCapabilityRefreshPromise = null;
+        let _coreApiCapabilityRequestGeneration = 0;
+        const events = [];
+        class CustomEvent {
+          constructor(type, options) {
+            this.type = type;
+            this.detail = options && options.detail;
+          }
+        }
+        const window = {
+          dispatchEvent(event) { events.push(event); },
+          fetch: null,
+        };
+        """
+        + refresh_source
+        + """
+        function response(data) {
+          return { ok: true, json: async () => data };
+        }
+        function assert(condition, message) {
+          if (!condition) throw new Error(message);
+        }
+        async function main() {
+          window.fetch = async () => response({ success: false, coreApi: 'qwen' });
+          await refreshCoreApiCapability({ force: true });
+          assert(S.coreApiSupportsIndependentAsr === null, 'success:false must fail open');
+          assert(S.coreApiProvider === '', 'failed response provider must become unknown');
+
+          S.coreApiProvider = 'free';
+          S.coreApiSupportsIndependentAsr = false;
+          window.fetch = async () => response({ success: true, coreApi: 'qwen' });
+          await refreshCoreApiCapability({ force: true });
+          assert(S.coreApiSupportsIndependentAsr === null, 'legacy response must fail open');
+          assert(S.coreApiProvider === 'qwen', 'usable provider context should be retained');
+
+          let rejectOld;
+          window.fetch = () => new Promise((resolve, reject) => { rejectOld = reject; });
+          const oldRequest = refreshCoreApiCapability({ force: true });
+          window.fetch = async () => response({
+            success: true,
+            coreApi: 'free',
+            effectiveCoreApi: 'qwen',
+            supportsIndependentAsr: true,
+          });
+          await refreshCoreApiCapability({ force: true });
+          rejectOld(new Error('late old request'));
+          await oldRequest;
+          assert(S.coreApiSupportsIndependentAsr === true, 'late failure must not clear newer capability');
+          assert(S.coreApiProvider === 'qwen', 'effective provider must win and survive a late failure');
+          assert(events.length >= 3, 'capability changes should notify the shared UI');
+          console.log('ok');
+        }
+        main().catch((error) => {
+          console.error(error);
+          process.exitCode = 1;
+        });
+        """
+    )
+    result = _run_settings_node_harness(harness)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"
 
 
 def test_start_session_payload_carries_resource_optimization_handshake():

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -678,7 +678,11 @@ def test_core_capability_refresh_failures_fail_open_and_ignore_stale_requests_ha
           await oldRequest;
           assert(S.coreApiSupportsIndependentAsr === true, 'late failure must not clear newer capability');
           assert(S.coreApiProvider === 'qwen', 'effective provider must win and survive a late failure');
-          assert(events.length >= 3, 'capability changes should notify the shared UI');
+          assert(
+            events.length === 3
+              && events.every((event) => event.type === 'neko:core-api-capability-changed'),
+            'capability changes should notify the shared UI exactly once per change'
+          );
           console.log('ok');
         }
         main().catch((error) => {

--- a/tests/unit/test_asr_client.py
+++ b/tests/unit/test_asr_client.py
@@ -139,9 +139,11 @@ async def _wrong_generation_ready_worker(
 
 def test_public_exports_are_frozen():
     assert asr_client.__all__ == [
+        "AsrCoreCapabilities",
         "AsrSessionConfig",
         "RealtimeAsrSession",
         "create_asr_session",
+        "get_asr_core_capabilities",
     ]
     assert not hasattr(asr_client, "get_asr_worker")
     assert not hasattr(asr_client, "AsrWorkerFn")
@@ -233,6 +235,23 @@ def test_phase2_registry_routes_and_capabilities():
     assert CORE_ASR_ROUTES["step"].default_endpointing_mode == "provider"
     assert CORE_ASR_ROUTES["grok"].credential_field == "ASSIST_API_KEY_GROK"
     assert CORE_ASR_ROUTES["grok"].default_endpointing_mode == "provider"
+    assert {
+        core_key: route.capabilities.supports_independent_asr
+        for core_key, route in CORE_ASR_ROUTES.items()
+    } == {
+        "qwen": True,
+        "qwen_intl": True,
+        "openai": True,
+        "step": True,
+        "grok": True,
+        "glm": True,
+        "gemini": True,
+        "free": False,
+    }
+    assert asr_client.get_asr_core_capabilities(" FREE ") == (
+        asr_client.AsrCoreCapabilities(supports_independent_asr=False)
+    )
+    assert asr_client.get_asr_core_capabilities("unknown") is None
 
     assert ASR_PROVIDER_REGISTRY["qwen"].supported_endpointing_modes == {
         "manual",

--- a/tests/unit/test_core_config_secret_redaction.py
+++ b/tests/unit/test_core_config_secret_redaction.py
@@ -121,6 +121,8 @@ def test_get_redacts_every_core_config_secret(
     response = asyncio.run(core_config_router.get_core_config_api())
 
     assert response['success'] is True
+    assert response['effectiveCoreApi'] == 'qwen'
+    assert response['supportsIndependentAsr'] is True
     response_secret_fields = (
         'api_key',
         *_ASSIST_API_KEY_FIELDS,
@@ -162,6 +164,8 @@ def test_get_preserves_empty_secrets_and_free_access(
     response = asyncio.run(core_config_router.get_core_config_api())
 
     assert response['success'] is True
+    assert response['effectiveCoreApi'] == 'free'
+    assert response['supportsIndependentAsr'] is False
     assert response['api_key'] == 'free-access'
     for field in (
         *_ASSIST_API_KEY_FIELDS,
@@ -169,6 +173,30 @@ def test_get_preserves_empty_secrets_and_free_access(
         *_MODEL_API_KEY_FIELDS,
     ):
         assert response[field] == ''
+
+
+@pytest.mark.unit
+def test_get_uses_effective_realtime_core_for_asr_capability(
+    config_manager,
+    core_config_router,
+):
+    _write_core_config(config_manager, {
+        'coreApiKey': 'free-access',
+        'coreApi': 'free',
+        'assistApi': 'free',
+        'enableCustomApi': True,
+        'omniModelProvider': 'custom',
+        'omniModelId': 'local-omni',
+        'omniModelUrl': 'http://127.0.0.1:8080/v1',
+        'omniModelApiKey': 'local-key',
+    })
+
+    response = asyncio.run(core_config_router.get_core_config_api())
+
+    assert response['success'] is True
+    assert response['coreApi'] == 'free'
+    assert response['effectiveCoreApi'] == 'local'
+    assert response['supportsIndependentAsr'] is None
 
 
 @pytest.mark.unit

--- a/tests/unit/test_core_independent_asr.py
+++ b/tests/unit/test_core_independent_asr.py
@@ -6399,9 +6399,72 @@ async def test_disabled_or_text_session_never_creates_provider(monkeypatch) -> N
     assert not hasattr(runtime._asr_runtime, "_asr_route_mode")
 
 
-async def test_free_core_reports_unavailable_and_blocks_omni(monkeypatch) -> None:
+@pytest.mark.parametrize(
+    ("persisted_enabled", "handshake_enabled"),
+    [
+        (True, None),
+        (False, None),
+        (False, True),
+        (True, False),
+    ],
+)
+async def test_free_core_always_uses_native_asr_regardless_of_toggle(
+    monkeypatch,
+    persisted_enabled: bool,
+    handshake_enabled: bool | None,
+) -> None:
     runtime = _Runtime()
     runtime.core_api_type = "free"
+    runtime.session.stream_audio = AsyncMock()
+    monkeypatch.setattr(
+        core_module,
+        "aload_global_conversation_settings",
+        AsyncMock(return_value={"independentAsrEnabled": persisted_enabled}),
+    )
+    start_mock = AsyncMock()
+    monkeypatch.setattr(runtime._asr_runtime, "start", start_mock)
+    runtime.set_independent_asr_handshake(handshake_enabled)
+
+    await runtime._start_independent_asr_if_enabled("audio")
+
+    assert runtime._asr_route_mode == "native"
+    assert runtime._independent_asr_route_key == "free"
+    assert runtime._independent_asr_provider is None
+    start_mock.assert_not_awaited()
+    assert "ASR_INDEPENDENT_DISABLED" in runtime.send_status.await_args.args[0]
+    assert "ASR_INDEPENDENT_UNAVAILABLE" not in runtime.send_status.await_args.args[0]
+
+    assert await runtime._route_microphone_audio(
+        b"\x01\x00" * 160,
+        sample_rate_hz=16_000,
+    ) is True
+    runtime.session.stream_audio.assert_awaited_once_with(b"\x01\x00" * 160)
+
+
+async def test_free_core_uses_native_asr_when_preferences_are_unreadable(
+    monkeypatch,
+) -> None:
+    runtime = _Runtime()
+    runtime.core_api_type = "free"
+    monkeypatch.setattr(
+        core_module,
+        "aload_global_conversation_settings",
+        AsyncMock(side_effect=OSError("preferences unavailable")),
+    )
+    start_mock = AsyncMock()
+    monkeypatch.setattr(runtime._asr_runtime, "start", start_mock)
+    runtime.set_independent_asr_handshake(True)
+
+    await runtime._start_independent_asr_if_enabled("audio")
+
+    assert runtime._asr_route_mode == "native"
+    start_mock.assert_not_awaited()
+    assert "ASR_INDEPENDENT_DISABLED" in runtime.send_status.await_args.args[0]
+
+
+async def test_unknown_core_capability_remains_fail_closed(monkeypatch) -> None:
+    runtime = _Runtime()
+    runtime.core_api_type = "unknown"
     monkeypatch.setattr(
         core_module,
         "aload_global_conversation_settings",
@@ -6411,7 +6474,10 @@ async def test_free_core_reports_unavailable_and_blocks_omni(monkeypatch) -> Non
     await runtime._start_independent_asr_if_enabled("audio")
 
     assert runtime._asr_route_mode == "blocked"
-    assert "ASR_INDEPENDENT_UNAVAILABLE" in runtime.send_status.await_args.args[0]
+    assert any(
+        "ASR_INDEPENDENT_FAILED" in status_call.args[0]
+        for status_call in runtime.send_status.await_args_list
+    )
 
 
 async def test_provider_error_without_audio_closes_and_blocks_omni() -> None:

--- a/tests/unit/test_voice_recognition_settings_static.py
+++ b/tests/unit/test_voice_recognition_settings_static.py
@@ -73,8 +73,9 @@ def test_voice_recognition_reuses_the_shared_mic_action_subwindow() -> None:
     assert "voiceStatus.setAttribute('aria-live', 'polite')" in voice_panel
     assert "'voice-recognition'" in voice_action
     assert "openVoiceRecognitionSubwindow" in voice_action
-    assert "voiceRowHoverGuard" in voice_action
-    assert "asrActionButton.replaceChild(" in voice_action
+    assert "createMainActionRow(" in source
+    assert "var asrActionRow = createMainActionRow(" in voice_action
+    assert "asrActionButton.replaceChild(" not in voice_action
 
     for legacy_name in (
         "createVoicePanel",

--- a/tests/unit/test_voice_recognition_settings_static.py
+++ b/tests/unit/test_voice_recognition_settings_static.py
@@ -14,6 +14,7 @@ def test_new_profile_voice_settings_default_enabled_without_becoming_authoritati
     state = APP_STATE.read_text(encoding="utf-8")
 
     assert "independentAsrEnabled: true" in state
+    assert "coreApiSupportsIndependentAsr: null" in state
     assert "voiceInputResourceOptimizationEnabled: true" in state
     assert "settingsHydrated: false" in state
     assert "independentAsrAuthoritative: false" in state
@@ -54,31 +55,38 @@ def test_resource_optimization_uses_only_the_canonical_shared_setting_key() -> N
     assert "voice_input_resource_optimization_enabled" not in settings
 
 
-def test_voice_recognition_popover_has_explicit_portal_lifecycle() -> None:
+def test_voice_recognition_reuses_the_shared_mic_action_subwindow() -> None:
     source = APP_AUDIO_CAPTURE.read_text(encoding="utf-8")
 
-    for function_name in (
+    voice_panel = source.split(
+        "function openVoiceRecognitionSubwindow()", maxsplit=1
+    )[1].split("async function openMicDeviceSubwindow()", maxsplit=1)[0]
+    voice_action = source.split(
+        "asrActionButton = createMainActionButton(", maxsplit=1
+    )[1].split("// 组装", maxsplit=1)[0]
+
+    assert "createMicSubwindow(" in voice_panel
+    assert "panel._nekoMicSubwindowBody" in voice_panel
+    assert "panel.classList.add('neko-mic-voice-subwindow')" in voice_panel
+    assert "'voice-recognition'" in voice_action
+    assert "openVoiceRecognitionSubwindow" in voice_action
+    assert "voiceRowHoverGuard" in voice_action
+    assert "asrActionButton.replaceChild(" in voice_action
+
+    for legacy_name in (
         "createVoicePanel",
         "openVoicePanel",
         "closeVoicePanel",
-        "destroyVoicePanel",
+        "positionVoicePanel",
+        "togglePinnedVoicePanel",
+        "voiceBridge",
+        "voicePanelPinned",
     ):
-        assert f"function {function_name}(" in source
+        assert legacy_name not in source
 
-    assert "document.body.appendChild(voicePanel)" in source
-    assert "position: 'fixed'" in source
-    assert "asrContainer.setAttribute('aria-expanded', 'true')" in source
-    assert "asrContainer.setAttribute('aria-expanded', 'false')" in source
-    assert "event.key === 'Escape'" in source
-    assert "document.addEventListener('pointerdown'" in source
-    assert "document.removeEventListener('pointerdown'" in source
-    assert "window.addEventListener('resize'" in source
-    assert "window.removeEventListener('resize'" in source
-    assert "window.addEventListener('scroll'" in source
-    assert "window.removeEventListener('scroll'" in source
-    assert "asrContainer.addEventListener('mouseenter'" in source
-    assert "asrContainer.addEventListener('focusin'" in source
-    assert "asrContainer.addEventListener('pointerup'" in source
+    assert "document.addEventListener('pointerdown'" not in source
+    assert "window.addEventListener('resize', positionVoicePanel)" not in source
+    assert "window.addEventListener('scroll', positionVoicePanel" not in source
 
 
 def test_cross_window_voice_settings_publish_a_shared_pending_route_snapshot() -> None:
@@ -102,6 +110,8 @@ def test_voice_recognition_copy_keeps_native_and_fail_closed_routes_distinct() -
     assert "window.t('microphone.voiceRecognitionDisabled')" in source
     assert "window.t('microphone.voiceRecognitionDisabledHint')" in source
     assert "window.t('microphone.voiceRecognitionUnavailable')" in source
+    assert "当前核心使用免费API；独立 ASR 相关开关不适用" in source
+    assert "当前核心使用 Omni 原生语音识别" not in source
     assert "语音输入已关闭" not in source
     assert "自动回退到 Omni" not in source
     assert "自动选择其他识别服务" not in source
@@ -118,6 +128,7 @@ def test_voice_recognition_popover_keys_match_across_all_locales() -> None:
         "voiceRecognitionSettings",
         "voiceRecognitionDisabled",
         "voiceRecognitionDisabledHint",
+        "voiceRecognitionNativeCoreHint",
         "voiceRecognitionUnavailable",
         "voiceRecognitionStatusReady",
         "voiceRecognitionSettingsPending",
@@ -138,6 +149,25 @@ def test_voice_recognition_popover_keys_match_across_all_locales() -> None:
         key_sets.append(set(microphone))
 
     assert all(keys == key_sets[0] for keys in key_sets[1:])
+
+
+def test_native_core_hint_describes_the_free_api_in_all_locales() -> None:
+    expected = {
+        "en": "This Core uses the free API; independent ASR controls do not apply",
+        "es": "Este Core usa la API gratuita; los controles de ASR independiente no se aplican",
+        "ja": "この Core は無料 API を使用するため、独立 ASR の設定は適用されません",
+        "ko": "이 Core는 무료 API를 사용하므로 독립 ASR 설정이 적용되지 않습니다",
+        "pt": "Este Core usa a API gratuita; os controles de ASR independente não se aplicam",
+        "ru": "Это ядро использует бесплатный API; настройки независимого ASR неприменимы",
+        "zh-CN": "当前核心使用免费API；独立 ASR 相关开关不适用",
+        "zh-TW": "目前核心使用免費 API；獨立 ASR 相關開關不適用",
+    }
+
+    for locale_name, expected_hint in expected.items():
+        locale = json.loads(
+            (LOCALE_DIR / f"{locale_name}.json").read_text(encoding="utf-8")
+        )
+        assert locale["microphone"]["voiceRecognitionNativeCoreHint"] == expected_hint
 
 
 def test_async_asr_status_copy_uses_the_caller_provider_key() -> None:

--- a/tests/unit/test_voice_recognition_settings_static.py
+++ b/tests/unit/test_voice_recognition_settings_static.py
@@ -1,4 +1,5 @@
 import json
+import re
 from pathlib import Path
 
 
@@ -68,6 +69,8 @@ def test_voice_recognition_reuses_the_shared_mic_action_subwindow() -> None:
     assert "createMicSubwindow(" in voice_panel
     assert "panel._nekoMicSubwindowBody" in voice_panel
     assert "panel.classList.add('neko-mic-voice-subwindow')" in voice_panel
+    assert "voiceStatus.setAttribute('role', 'status')" in voice_panel
+    assert "voiceStatus.setAttribute('aria-live', 'polite')" in voice_panel
     assert "'voice-recognition'" in voice_action
     assert "openVoiceRecognitionSubwindow" in voice_action
     assert "voiceRowHoverGuard" in voice_action
@@ -84,9 +87,12 @@ def test_voice_recognition_reuses_the_shared_mic_action_subwindow() -> None:
     ):
         assert legacy_name not in source
 
-    assert "document.addEventListener('pointerdown'" not in source
-    assert "window.addEventListener('resize', positionVoicePanel)" not in source
-    assert "window.addEventListener('scroll', positionVoicePanel" not in source
+    assert not re.search(
+        r"document\.addEventListener\(\s*['\"]pointerdown['\"]", source
+    )
+    assert not re.search(
+        r"window\.addEventListener\(\s*['\"](?:resize|scroll)['\"]", source
+    )
 
 
 def test_cross_window_voice_settings_publish_a_shared_pending_route_snapshot() -> None:
@@ -162,6 +168,8 @@ def test_native_core_hint_describes_the_free_api_in_all_locales() -> None:
         "zh-CN": "当前核心使用免费API；独立 ASR 相关开关不适用",
         "zh-TW": "目前核心使用免費 API；獨立 ASR 相關開關不適用",
     }
+
+    assert set(expected) == set(LOCALES)
 
     for locale_name, expected_hint in expected.items():
         locale = json.loads(

--- a/tests/unit/test_voice_start_failure_static.py
+++ b/tests/unit/test_voice_start_failure_static.py
@@ -395,10 +395,13 @@ def test_floating_mic_popup_exposes_screen_share_start_and_stop_action():
     render = source[render_start:render_end]
     screen_row = "leftColumn.insertBefore(screenActionButton, firstContent);"
     mic_row = "leftColumn.insertBefore(micActionButton, firstContent);"
-    assert screen_row in render and mic_row in render
+    voice_row = "leftColumn.insertBefore(asrActionButton, firstContent);"
+    assert screen_row in render and mic_row in render and voice_row in render
     assert render.index(screen_row) < render.index(mic_row)
+    assert render.index(mic_row) < render.index(voice_row)
     assert "createScreenShareToggleButton({ mini: true })" in render
     assert "screenActionButton.replaceChild(shareToggleButton, screenActionButton.lastChild);" in render
+    assert "asrActionButton.replaceChild(" in render
     assert "leftColumn.insertBefore(shareToggleButton, firstContent);" not in render
 
 
@@ -794,6 +797,9 @@ def test_mic_main_action_matches_settings_chevron_and_hover_expands():
     assert "screenActionButton.querySelector('.neko-mic-action-text')" in source
     assert "var screenActionButton = createMainActionButton(\n                null," in source
     assert "var micActionButton = createMainActionButton(\n                null," in source
+    assert "asrActionButton = createMainActionButton(\n                null," in source
+    assert "'voice-recognition'" in source
+    assert "openVoiceRecognitionSubwindow" in source
     subwindow = _js_function_block(source, "createMicSubwindow")
     assert "if (iconText) {" in subwindow
     assert "titleWrap.appendChild(icon);" in subwindow
@@ -805,6 +811,12 @@ def test_mic_main_action_matches_settings_chevron_and_hover_expands():
         "window.t ? window.t('buttons.screenShare') : 'Screen Share',\n"
         "                    null,"
     ) in source
+    voice_subwindow = _js_function_block(
+        source, "openVoiceRecognitionSubwindow"
+    )
+    assert "createMicSubwindow(" in voice_subwindow
+    assert "panel._nekoMicSubwindowBody" in voice_subwindow
+    assert "panel.classList.add('neko-mic-voice-subwindow')" in voice_subwindow
 
 
 def test_mic_device_subwindow_retries_permission_when_device_cache_is_empty():

--- a/tests/unit/test_voice_start_failure_static.py
+++ b/tests/unit/test_voice_start_failure_static.py
@@ -389,20 +389,26 @@ def test_floating_mic_popup_exposes_screen_share_start_and_stop_action():
     assert "button.setAttribute('aria-label', accessibleLabel);" in toggle_factory
     assert "button.setAttribute('aria-busy', 'true');" in toggle_factory
 
-    # 合并为一行：迷你胶囊开关嵌在「屏幕共享」设置行右侧（替换 chevron）
+    # 三个入口使用同一个非交互 action-row；行级开关与面板按钮互为兄弟。
     render_start = source.index("window.renderFloatingMicList = async function")
     render_end = source.index("function updateMicListSelection()", render_start)
     render = source[render_start:render_end]
-    screen_row = "leftColumn.insertBefore(screenActionButton, firstContent);"
-    mic_row = "leftColumn.insertBefore(micActionButton, firstContent);"
-    voice_row = "leftColumn.insertBefore(asrActionButton, firstContent);"
+    screen_row = "leftColumn.insertBefore(screenActionRow, firstContent);"
+    mic_row = "leftColumn.insertBefore(micActionRow, firstContent);"
+    voice_row = "leftColumn.insertBefore(asrActionRow, firstContent);"
     assert screen_row in render and mic_row in render and voice_row in render
     assert render.index(screen_row) < render.index(mic_row)
     assert render.index(mic_row) < render.index(voice_row)
     assert "createScreenShareToggleButton({ mini: true })" in render
-    assert "screenActionButton.replaceChild(shareToggleButton, screenActionButton.lastChild);" in render
-    assert "asrActionButton.replaceChild(" in render
+    assert "var screenActionRow = createMainActionRow(" in render
+    assert "var micActionRow = createMainActionRow(" in render
+    assert "var asrActionRow = createMainActionRow(" in render
+    assert "screenActionButton.replaceChild(" not in render
+    assert "asrActionButton.replaceChild(" not in render
     assert "leftColumn.insertBefore(shareToggleButton, firstContent);" not in render
+    assert "document.createElement('button')" in toggle_factory
+    assert "button.type = 'button';" in toggle_factory
+    assert "button.addEventListener('keydown'" not in toggle_factory
 
 
 def test_screen_share_start_is_single_flight_across_ui_entry_points():


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

<!-- 这个 PR 做了什么。若有对应 Issue 可关联（如 Closes #123），非必须。 -->
新增 Core 级独立 ASR 能力声明，免费 Core 明确标记为不支持独立 ASR。
免费 Core 无论持久化设置或会话握手是否开启，均忽略独立 ASR 开关并继续使用免费 API 的原生语音识别链路。
配置接口下发实际 realtime Core 及其 ASR 能力，前端据此禁用不适用的独立 ASR 和资源优化开关，同时保留用户偏好。
将“语音识别”迁移到与“屏幕分享”“选择麦克风”相同的二级菜单机制，统一定位、互斥、悬停收起、关闭及生命周期清理。
“当前核心使用免费API”提示已同步全部 8 个 locale。

## 回归报告 / Regression Report

<!--
仅当本 PR 触碰 app/、main_logic/、memory/ 时必填。请逐项说明：
  - 改动了什么
  - 理由 / 必要性
  - 改动前后的表现对比
  - 潜在回归点（影响哪些链路、怎么验证的）
未触碰这三个模块：写「不适用」或删除本节。
-->
### 改动内容与必要性
- 在 ASR 路由元数据中增加 AsrCoreCapabilities，并提供统一的能力查询接口。
- 语音会话启动时由后端能力声明最终决定是否启动独立 ASR，避免过期设置或前端握手使免费 Core 尝试创建不可用的 ASR Provider。
- /api/config/core_api 根据实际 realtime Core 返回 effectiveCoreApi 和 supportsIndependentAsr，让前端能够显示正确的有效状态。
- 前端能力刷新采用三态状态和请求代次保护；失败或旧接口缺少字段时保持 fail-open，由后端能力守卫兜底。
- 语音识别不再维护独立 portal、固定状态和键鼠监听，改为复用现有麦克风弹窗的共享二级菜单实现。
### 改动前后表现
- 改动前：免费 Core 在独立 ASR 开启时可能进入 Provider 不可用或语音阻断路径；前端仍可操作实际不适用的开关。语音识别二级菜单的定位、关闭和悬停行为也与另外两个入口不同。
- 改动后：免费 Core 始终使用免费 API 的原生语音识别，不受独立 ASR 开关影响；相关开关显示为关闭且禁用，但不会清除用户偏好，切回支持独立 ASR 的 Core 后可恢复。
- 三个二级菜单现在保持单实例互斥，并共用定位、标题栏、关闭按钮、260ms 悬停收起和宿主销毁逻辑。
### 潜在回归点与验证
- Core 路由映射：验证仅免费 Core 标记为不支持独立 ASR，其他已知 Core 保持原行为，未知 Core 不会被误判为原生识别 Core。
- 会话启动分流：覆盖免费 Core 的持久化设置、握手开关、配置读取异常及麦克风 PCM 原生转发。
- 配置接口：覆盖普通、免费及自定义 realtime Core 的有效能力解析，同时验证 API Key 脱敏和免费访问配置未回归。
- 前端状态：覆盖能力请求失败、超时、旧响应竞态、偏好保留以及免费 Core 的有效禁用状态。
- 菜单交互：覆盖语音识别、麦克风和屏幕分享的单实例互斥、悬停收起、行尾开关防误触、重渲染清理及陈旧异步结果隔离。
- Web/Electron：验证 / 与 /chat 共用脚本均可正常加载。

## 测试 / Testing

<!-- 怎么验证的：跑了哪些测试、手动验证了哪些场景。 -->
uv run pytest tests/unit/test_asr_client.py tests/unit/test_core_config_secret_redaction.py tests/unit/test_core_independent_asr.py tests/unit/test_app_websocket_static.py tests/unit/test_voice_recognition_settings_static.py tests/unit/test_voice_start_failure_static.py tests/frontend/test_voice_recognition_popover.py -q527 passed

uv run pytest tests/unit/test_check_core_contracts.py -q89 passed

uv run python scripts/check_core_contracts.py通过

修改文件的 Ruff 检查通过。
app-audio-capture.js、app-state.js、app-websocket.js 的 Node.js 语法检查通过。
git diff --check 通过。

手动验证免费API下语音功能可用

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增核心能力识别，动态显示是否支持独立语音识别。
  - 不支持独立 ASR 的核心将自动使用原生语音识别，并提供相应提示。
  - 麦克风、屏幕共享和语音识别入口统一使用共享子窗口与悬停交互。

- **改进**
  - 优化语音设置面板的状态同步、键盘操作、焦点提示及资源清理。
  - 改进麦克风启动、设备切换和失败回收流程，避免过期请求占用资源。
  - 新增多语言提示，说明免费 API 核心不适用独立 ASR 设置。

- **错误修复**
  - 修复能力刷新失败、过期响应或并发请求导致设置状态错误覆盖的问题。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->