### PR TITLE
fix(core): harden realtime sessions and test isolation

### DIFF
--- a/main_logic/core/lifecycle.py
+++ b/main_logic/core/lifecycle.py
@@ -1544,7 +1544,8 @@ class LifecycleMixin:
 
         logger.info("✅ LLM Session 已连接")
         logger.info(f"[语音会话诊断] LLM 连接并 connect 完成 (耗时: {time.time() - _llm_create_start:.2f}秒)")
-        print(initial_prompt)  #只在控制台显示，不输出到日志文件
+        # ``initial_prompt`` contains memory and raw conversation context.
+        # Never emit it to stdout or a persistent logger.
         return next_context_count
 
     async def _start_session_reset_state_for_new(self):
@@ -1821,7 +1822,6 @@ class LifecycleMixin:
                 + self._convert_cache_to_str(next_session_context_messages)
                 + self._convert_cache_to_str(self.message_cache_for_new_session)
             )
-            print(initial_prompt)
             self._bind_session_lifecycle_callbacks(self.pending_session)
             await self.pending_session.connect(initial_prompt, native_audio=not self.pending_use_tts)
 
@@ -2324,8 +2324,6 @@ class LifecycleMixin:
                         logger.warning(
                             f"Final Swap Sequence: passive ride-along prime failed (kept queued): {e}"
                         )
-
-            print(final_prime_text) #只在控制台显示，不输出到日志文件
 
             # 2. Start temporary listener for PENDING session's *second* ignored response
             if self.pending_session_final_prime_complete_event:

--- a/main_logic/omni_realtime_client/_transport.py
+++ b/main_logic/omni_realtime_client/_transport.py
@@ -1834,7 +1834,15 @@ class _TransportMixin:
                     # 就在这里被直接清空 → 前端有声无字。这里在清空前补一次 flush：只要本轮真
                     # 出过声（audio_delta_count>0）且 buffer 仍有残留就补发。streaming 分支每次都
                     # 会清空 buffer，故正常轮此处为 no-op，不会重复发送。
-                    await self._flush_pending_output_transcript()
+                    try:
+                        await self._flush_pending_output_transcript()
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as exc:
+                        logger.warning(
+                            "response.done transcript flush failed (%s); continuing",
+                            type(exc).__name__,
+                        )
                     self._reset_per_turn_output_state()
                     await self._notify_turn_finished()
                 elif event_type == "response.created":

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,15 +1,12 @@
 """Unit-test-scoped fixtures.
 
-Why this file exists: `main_routers.shared_state._state` is a module-level
-dict that `init_shared_state()` mutates in place (no teardown hook). Unit
-tests call `init_shared_state(role_state={}, config_manager=cm, ...)`
-where `cm` is a `ConfigManager` pointing at a `TemporaryDirectory`. When
-that temp dir is torn down, `_state['config_manager']` keeps holding the
-dangling reference, and the next test that reads shared state (without
-re-initializing) can grab a `config_manager` whose disk paths are gone.
+Why this file exists: `main_routers.shared_state._state` and the Steamworks
+handle in `utils.steam_state` are process-global state. Unit tests mutate both
+without a teardown hook. Tests that run later can otherwise observe a dangling
+`ConfigManager` or a real Steamworks object left by an earlier test.
 
-The `_reset_shared_state` fixture below snapshots `_state` before each
-unit test and restores it after, so cross-test pollution cannot happen.
+The `_reset_shared_state` fixture below snapshots these globals before each
+unit test and restores them after, so cross-test pollution cannot happen.
 Introduced in response to CodeRabbit review on PR #681 — flagged for
 tests/unit/test_character_memory_regression.py and
 tests/unit/test_cloudsave_autocloud_router.py, but applied globally
@@ -39,18 +36,47 @@ def _reset_shared_state():
     had_shared_state = shared_state is not None
     snapshot = dict(shared_state._state) if had_shared_state else {}
 
+    steam_state = sys.modules.get("utils.steam_state")
+    had_steam_state = steam_state is not None
+    steam_snapshot = (
+        (
+            steam_state._steamworks,
+            steam_state._steamworks_initializer,
+            steam_state._last_init_attempt_monotonic,
+        )
+        if had_steam_state
+        else (None, None, 0.0)
+    )
+
+    main_server = sys.modules.get("app.main_server")
+    had_main_server = main_server is not None
+    main_server_steamworks = (
+        getattr(main_server, "steamworks", None) if had_main_server else None
+    )
+
     try:
         yield
     finally:
         shared_state = sys.modules.get("main_routers.shared_state")
-        if shared_state is None:
-            return
-        if not had_shared_state:
+        if shared_state is not None:
             shared_state._state.clear()
-            return
+            if had_shared_state:
+                shared_state._state.update(snapshot)
 
-        shared_state._state.clear()
-        shared_state._state.update(snapshot)
+        steam_state = sys.modules.get("utils.steam_state")
+        if steam_state is not None:
+            with steam_state._steamworks_lock:
+                (
+                    steam_state._steamworks,
+                    steam_state._steamworks_initializer,
+                    steam_state._last_init_attempt_monotonic,
+                ) = steam_snapshot
+
+        main_server = sys.modules.get("app.main_server")
+        if main_server is not None:
+            main_server.steamworks = (
+                main_server_steamworks if had_main_server else None
+            )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_asr_voice_turn_adapter.py
+++ b/tests/unit/test_asr_voice_turn_adapter.py
@@ -790,7 +790,7 @@ async def test_incomplete_waits_for_continuation_and_resume_cancels_fallback() -
     await adapter.push_audio(
         generation=1, buffer_epoch=2, utterance_id=3, pcm16=b"\x01\x00"
     )
-    await _eventually(lambda: coordinator.evaluate_calls == 1)
+    await _eventually(lambda: adapter._fallback_task is not None)
     fallback_task = adapter._fallback_task
     assert fallback_task is not None
     await adapter.push_audio(

--- a/tests/unit/test_asr_voice_turn_adapter.py
+++ b/tests/unit/test_asr_voice_turn_adapter.py
@@ -782,7 +782,8 @@ async def test_incomplete_waits_for_continuation_and_resume_cancels_fallback() -
         gate=gate,
         coordinator=coordinator,
         on_commit=commit,
-        continuation_timeout_seconds=0.02,
+        continuation_timeout_seconds=60.0,
+        max_endpoint_wait_seconds=60.0,
     )
     await adapter.start()
 
@@ -790,13 +791,16 @@ async def test_incomplete_waits_for_continuation_and_resume_cancels_fallback() -
         generation=1, buffer_epoch=2, utterance_id=3, pcm16=b"\x01\x00"
     )
     await _eventually(lambda: coordinator.evaluate_calls == 1)
+    fallback_task = adapter._fallback_task
+    assert fallback_task is not None
     await adapter.push_audio(
         generation=1, buffer_epoch=2, utterance_id=3, pcm16=b"\x02\x00"
     )
-    await _eventually(
-        lambda: SpeechActivityEvent.SPEECH_RESUMED in coordinator.activity_events
-    )
-    await asyncio.sleep(0.04)
+    await _eventually(lambda: adapter._fallback_task is None)
+    await _eventually(fallback_task.done)
+
+    assert SpeechActivityEvent.SPEECH_RESUMED in coordinator.activity_events
+    assert fallback_task.cancelled()
     assert commits == []
 
     await adapter.push_audio(

--- a/tests/unit/test_cloudsave_lifecycle_flow.py
+++ b/tests/unit/test_cloudsave_lifecycle_flow.py
@@ -304,6 +304,11 @@ def test_full_cloudsave_chain_runtime_snapshot_steam_cloud_and_manual_apply():
 @pytest.mark.asyncio
 async def test_main_server_manual_startup_performs_fallback_import_and_continues_boot():
     from app import main_server
+    from utils import steam_state
+
+    leaked_steamworks = SimpleNamespace(source="prior-test")
+    main_server.steamworks = leaked_steamworks
+    steam_state.set_steamworks(leaked_steamworks)
 
     fake_config_manager = SimpleNamespace(
         app_docs_dir=Path("/tmp/N.E.K.O"),
@@ -333,6 +338,7 @@ async def test_main_server_manual_startup_performs_fallback_import_and_continues
         stack.enter_context(patch.object(main_server, "_runtime_startup_init_completed", False))
         stack.enter_context(patch.object(main_server, "_preload_task", None))
         stack.enter_context(patch.object(main_server, "agent_event_bridge", None))
+        stack.enter_context(patch.object(main_server, "steamworks", None))
         stack.enter_context(patch.object(main_server, "_config_manager", fake_config_manager))
         stack.enter_context(
             patch.object(main_server, "get_storage_startup_blocking_reason", Mock(return_value=""))

--- a/tests/unit/test_hot_swap_cancellation.py
+++ b/tests/unit/test_hot_swap_cancellation.py
@@ -293,6 +293,37 @@ async def test_final_swap_happy_path_still_promotes():
         await _drain_task(old_listener_task)
 
 
+@pytest.mark.asyncio
+async def test_final_swap_does_not_emit_prime_context(monkeypatch, capsys):
+    sentinel = "PRIVATE_FINAL_PRIME_SENTINEL_2635"
+    mgr = _make_swap_manager()
+    old_session = _FakeSession("old")
+    new_session = _FakeSession("pending")
+    mgr.session = old_session
+    mgr.pending_session = new_session
+    mgr.is_hot_swap_imminent = True
+    mgr.message_handler_task = None
+    mgr.message_cache_for_new_session = [object()]
+    mgr._convert_cache_to_str = lambda _cache: sentinel
+
+    logged = []
+
+    def _capture_log(message, *args, **kwargs):
+        del kwargs
+        logged.append(str(message) % args if args else str(message))
+
+    for level in ("debug", "info", "warning", "error", "exception"):
+        monkeypatch.setattr(core_module.logger, level, _capture_log)
+
+    try:
+        await mgr._perform_final_swap_sequence()
+        captured = capsys.readouterr()
+        emitted = captured.out + captured.err + "\n".join(logged)
+        assert sentinel not in emitted
+    finally:
+        await _drain_task(mgr.message_handler_task)
+
+
 def _extra_entry(delivery_id, summary):
     """A pending_extra_replies entry in the exact shape enqueue_agent_callback produces."""
     return {

--- a/tests/unit/test_realtime_arbiter_native_path.py
+++ b/tests/unit/test_realtime_arbiter_native_path.py
@@ -355,6 +355,65 @@ async def test_a_terminal_resets_the_per_turn_output_state():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_response_created_resets_the_per_response_output_state():
+    client = _native_client()
+    socket = _RecordingSocket()
+    client.ws = socket
+    receive_loop = asyncio.create_task(client.handle_messages())
+
+    client._interrupted = True
+    client._output_transcript_buffer = "previous buffered transcript"
+    client._current_response_transcript = "previous repetition transcript"
+    client._last_response_created_time = 0.0
+
+    socket.feed({"type": "response.created", "response": {"id": "resp-new"}})
+    await _settle()
+
+    assert client._interrupted is False
+    assert client._output_transcript_buffer == ""
+    assert client._current_response_transcript == ""
+    assert client._last_response_created_time > 0.0
+
+    socket.finish()
+    await asyncio.wait_for(receive_loop, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_transcript_flush_failure_does_not_stop_the_receive_loop(caplog):
+    async def _raise_from_output_transcript(_text: str, _is_first: bool) -> None:
+        raise RuntimeError("host transcript sink disconnected")
+
+    client = _native_client()
+    client.on_output_transcript = _raise_from_output_transcript
+    socket = _RecordingSocket()
+    client.ws = socket
+    receive_loop = asyncio.create_task(client.handle_messages())
+
+    socket.feed({"type": "response.created", "response": {"id": "resp-1"}})
+    await _settle()
+    client._audio_delta_count = 1
+    client._output_transcript_buffer = "already spoken"
+
+    with caplog.at_level(logging.WARNING):
+        socket.feed({"type": "response.done", "response": {"id": "resp-1"}})
+        await _settle()
+
+    assert receive_loop.done() is False
+    assert client._output_transcript_buffer == ""
+    assert "response.done transcript flush failed" in caplog.text
+
+    socket.feed({"type": "response.created", "response": {"id": "resp-2"}})
+    await _settle()
+    assert client._current_response_id == "resp-2"
+    assert client._response_created_total == 2
+
+    socket.finish()
+    await asyncio.wait_for(receive_loop, timeout=1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_a_terminal_clears_the_in_progress_flags():
     # The other half of ending a turn: the flags that say a response is in
     # flight. Untested before this, same as the per-turn reset was.

--- a/tests/unit/test_realtime_arbiter_native_path.py
+++ b/tests/unit/test_realtime_arbiter_native_path.py
@@ -43,6 +43,7 @@ import pytest
 
 from main_logic.omni_realtime_client import OmniRealtimeClient
 from main_logic.omni_realtime_client import _response_arbiter as _arbiter_module
+from main_logic.omni_realtime_client import _transport as _transport_module
 from main_logic.omni_realtime_client._response_arbiter import RealtimeResponseArbiter
 from main_logic.omni_realtime_client._shared import (
     _IMAGE_ANALYSIS_PENDING_DESCRIPTION,
@@ -380,7 +381,14 @@ async def test_response_created_resets_the_per_response_output_state():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_transcript_flush_failure_does_not_stop_the_receive_loop(caplog):
+async def test_transcript_flush_failure_does_not_stop_the_receive_loop(monkeypatch):
+    warnings: list[tuple[object, ...]] = []
+    monkeypatch.setattr(
+        _transport_module.logger,
+        "warning",
+        lambda *args, **_kwargs: warnings.append(args),
+    )
+
     async def _raise_from_output_transcript(_text: str, _is_first: bool) -> None:
         raise RuntimeError("host transcript sink disconnected")
 
@@ -395,13 +403,14 @@ async def test_transcript_flush_failure_does_not_stop_the_receive_loop(caplog):
     client._audio_delta_count = 1
     client._output_transcript_buffer = "already spoken"
 
-    with caplog.at_level(logging.WARNING):
-        socket.feed({"type": "response.done", "response": {"id": "resp-1"}})
-        await _settle()
+    socket.feed({"type": "response.done", "response": {"id": "resp-1"}})
+    await _settle()
 
     assert receive_loop.done() is False
     assert client._output_transcript_buffer == ""
-    assert "response.done transcript flush failed" in caplog.text
+    assert warnings == [
+        ("response.done transcript flush failed (%s); continuing", "RuntimeError")
+    ]
 
     socket.feed({"type": "response.created", "response": {"id": "resp-2"}})
     await _settle()

--- a/tests/unit/test_session_llm_start_paths.py
+++ b/tests/unit/test_session_llm_start_paths.py
@@ -28,7 +28,9 @@ end to end against stub collaborators, so any unbound name, missing argument,
 or renamed collaborator in either branch fails here.
 """
 
+import ast
 import asyncio
+import inspect
 import sys
 import types
 from pathlib import Path
@@ -178,6 +180,71 @@ async def test_session_creation_runs_end_to_end(monkeypatch, input_mode):
     client = _StubClient.instances[0]
     assert client.connected_with is not None, "构造了 client 却没有 connect"
     assert mgr.session is client, "connect 成功后必须提升为 self.session"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("input_mode", ["audio", "text"])
+async def test_session_creation_does_not_emit_prompt_content(
+    monkeypatch, capsys, input_mode
+):
+    sentinel = "PRIVATE_PROMPT_SENTINEL_2635"
+    mgr = _make_manager(monkeypatch, input_mode=input_mode)
+    mgr._build_initial_prompt = _async_return(sentinel)
+
+    logged = []
+
+    def _capture_log(message, *args, **kwargs):
+        del kwargs
+        logged.append(str(message) % args if args else str(message))
+
+    for level in ("debug", "info", "warning", "error", "exception"):
+        monkeypatch.setattr(lifecycle.logger, level, _capture_log)
+
+    await LLMSessionManager._start_session_start_llm(
+        mgr,
+        input_mode,
+        await mgr._config_manager.aget_core_config(),
+        await mgr._config_manager.aget_model_api_config("realtime"),
+        asyncio.create_task(_new_dialog_task()),
+        0.0,
+    )
+
+    captured = capsys.readouterr()
+    emitted = captured.out + captured.err + "\n".join(logged)
+    assert sentinel not in emitted
+
+
+@pytest.mark.unit
+def test_lifecycle_never_emits_sensitive_prompt_objects():
+    source = inspect.getsource(lifecycle)
+    tree = ast.parse(source)
+    sensitive_names = {"initial_prompt", "final_prime_text"}
+    offenders = []
+
+    for call in (node for node in ast.walk(tree) if isinstance(node, ast.Call)):
+        is_output_call = (
+            isinstance(call.func, ast.Name)
+            and call.func.id == "print"
+        ) or (
+            isinstance(call.func, ast.Attribute)
+            and isinstance(call.func.value, ast.Name)
+            and call.func.value.id == "logger"
+            and call.func.attr in {"debug", "info", "warning", "error", "exception"}
+        )
+        if not is_output_call:
+            continue
+        referenced_names = {
+            node.id
+            for argument in (*call.args, *(keyword.value for keyword in call.keywords))
+            for node in ast.walk(argument)
+            if isinstance(node, ast.Name)
+        }
+        leaked = sorted(referenced_names & sensitive_names)
+        if leaked:
+            offenders.append((call.lineno, leaked))
+
+    assert offenders == []
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## 改动概述 / Summary

- 删除正常语音建连、后台热切换准备和 final swap prime 中三处完整 prompt 控制台输出，避免 system prompt、记忆、原始对话和 callback 上下文泄露。
- 扩展 unit-test autouse fixture，测试前后恢复 Steamworks 句柄、initializer、重试时钟及 `main_server.steamworks` 镜像，避免组合运行污染。
- 为 `response.done` 的 transcript 兜底 flush 增加异常边界：宿主 callback 失败只记录脱敏异常类型并继续接收循环，`CancelledError` 仍原样传播，后续 per-turn reset 与 turn-finished hook 不被跳过。
- 增加真实 receive-loop 回归，覆盖 `response.created` 对 `_interrupted`、两个 transcript buffer 和创建时间的重置，并验证 flush 失败后下一条响应仍可被处理。
- 将 ASR continuation fallback 测试从 20ms 时间窗和 `sleep` 否定断言改为直接等待并断言旧 fallback task 被取消。

Fixes #2635
Fixes #2610
Fixes #2630
Fixes #2631

## 根因 / Root Cause

- Core 曾把包含完整上下文的 prompt 直接 `print` 到前台终端；终端仍可能被录屏、CI 或诊断附件保存。
- 测试侧只恢复 `main_routers.shared_state._state`，没有恢复 `utils.steam_state` 和 `app.main_server` 的进程全局 Steamworks 状态，导致组合运行读取前序测试残留对象。
- `response.done` 直接等待宿主的 `on_output_transcript`；前端 socket 等宿主 callback 抛异常时，异常会越过 `handle_messages`，永久终止该连接的接收循环。
- `response.created` 的关键状态写入没有真实 receive-loop 测试保护，删除 `_interrupted`、transcript reset 或创建时间写入时既有套件仍可全绿。
- ASR 测试把“resume 已取消 fallback”的契约压缩在 20ms Windows 调度窗口内，并用固定 `sleep` 推断没有 commit；共享 runner 抖动可让 timeout 与 resume 处理顺序反转。

## 回归报告 / Regression Report

### `main_logic/core/lifecycle.py`

- 改动：移除三处完整 prompt 控制台输出。
- 前后表现：会话准备与 hot-swap 仍使用相同 prompt 建连，但敏感上下文不再进入 stdout。
- 风险与覆盖：动态 sentinel 覆盖正常建连与 final swap；AST 守卫禁止 `initial_prompt` / `final_prime_text` 再进入 stdout 或 logger；system prompt 水印仍存在。

### `main_logic/omni_realtime_client/_transport.py`

- 改动：只在 `response.done` transcript fallback flush 周围捕获普通异常；取消继续抛出，`_reset_per_turn_output_state()` 和 `_notify_turn_finished()` 保持原顺序。
- 前后表现：宿主 transcript sink 断开不再打死 receive loop；下一条 `response.created` 仍能被接收并建立当前响应身份。
- 风险与覆盖：不能吞掉取消、不能跳过 per-turn reset、不能把 `_notify_turn_finished` 包进同一异常边界；真实 fake-socket receive loop 分别验证这些边界及四项 `response.created` 状态重置。

### 测试隔离与 ASR fallback

- Steamworks fixture 在每条 unit test 前后对称恢复共享状态，并由 CloudSave startup 组合顺序回归验证。
- ASR 测试使用 60s 非竞争 timeout，但不会实际等待 60s；它等待 adapter 清除 fallback 引用和原任务进入 done，再断言 `cancelled()`。删除取消动作会在测试的有界 eventually 等待内失败。

## 不拆分理由 / Why Not Split

用户明确选择将四个低风险修复放入一个 PR，以降低单一维护者在多个 PR 之间切换、排队和协调的成本。合并后共 8 个文件，其中只有 2 个生产文件，未超过门禁的 20 个 counted files 阈值。

审核边界仍由三个普通 commit 保持清晰：#2635 的 prompt/Steamworks 隔离、#2610 + #2630 的 realtime response lifecycle、#2631 的纯测试时序修复；每组都有独立的确定性回归，可分别审阅和回滚，不需要 squash、rebase 或改写历史。

## 测试 / Testing

- #2635 生命周期、hot-swap、context append、audio stream：`204 passed`。
- #2635 CloudSave、Steamworks、language、telemetry、workshop：`354 passed`。
- ASR adapter 与 realtime native path：`68 passed`。
- ASR/realtime 六文件随机顺序回归（seed `26312610`）：`279 passed`。
- `uv run ruff check`（全部 8 个改动文件）：passed。
- `uv run python -m compileall -q`（相关 core/realtime 模块与测试）：passed。
- `git diff --check upstream/main...HEAD`：passed。
- `rg --fixed-strings '======以上为'`：watermark preserved。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **安全与隐私**
  * 修复会话启动及热切换流程中的敏感提示词泄漏问题，避免内容出现在终端输出或日志中。
* **稳定性**
  * 改进会话初始化与状态清理流程，降低跨会话状态污染风险。
  * 改善实时转录异常处理，避免单次转录失败中断后续响应。
  * 增加音频、文本会话创建及热切换场景的回归验证，确保客户端连接和会话绑定正常。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->