### PR TITLE
统一 Live2D 动作与瞬态表情的互斥播放

### DIFF
--- a/static/app/app-interpage/bootstrap-resources-and-model-reload.js
+++ b/static/app/app-interpage/bootstrap-resources-and-model-reload.js
@@ -1867,10 +1867,27 @@ I.mod = window.appInterpage;
                 }
             }
 
-            // 8. 停止当前动作并播放保存的待机动作
+            // 8. 停止当前动作并以 IDLE 优先级播放保存的待机动作。
+            // IDLE 可以被一个 NORMAL 交互动作接管，同时 NORMAL 动作之间保持互斥；
+            // 这里不能使用 FORCE，否则后续交互只能继续用 FORCE 抢占并产生叠播。
+            if (
+                typeof live2dManager.hasActiveActionMotion === 'function'
+                && live2dManager.hasActiveActionMotion(live2dModel)
+            ) {
+                console.log('[Live2D Main] 当前有其他动作，跳过待机动作恢复');
+                return;
+            }
             motionManager.stopAllMotions();
-            live2dModel.motion(groupName, motionIndex, 3);
-            console.log('[Live2D Main] 已恢复待机动作并循环播放:', live2dIdleAnimation);
+            const started = await live2dModel.motion(
+                groupName,
+                motionIndex,
+                LIVE2D_MOTION_PRIORITY.IDLE
+            );
+            if (started) {
+                console.log('[Live2D Main] 已恢复待机动作并循环播放:', live2dIdleAnimation);
+            } else {
+                console.log('[Live2D Main] 当前有其他动作，跳过待机动作恢复');
+            }
 
         } catch (error) {
             console.error('[Live2D Main] 恢复待机动作失败:', error);

--- a/static/app/app-interpage/bootstrap-resources-and-model-reload.js
+++ b/static/app/app-interpage/bootstrap-resources-and-model-reload.js
@@ -1867,22 +1867,8 @@ I.mod = window.appInterpage;
                 }
             }
 
-            // 8. 停止当前动作并以 IDLE 优先级播放保存的待机动作。
-            // IDLE 可以被一个 NORMAL 交互动作接管，同时 NORMAL 动作之间保持互斥；
-            // 这里不能使用 FORCE，否则后续交互只能继续用 FORCE 抢占并产生叠播。
-            if (
-                typeof live2dManager.hasActiveActionMotion === 'function'
-                && live2dManager.hasActiveActionMotion(live2dModel)
-            ) {
-                console.log('[Live2D Main] 当前有其他动作，跳过待机动作恢复');
-                return;
-            }
-            motionManager.stopAllMotions();
-            const started = await live2dModel.motion(
-                groupName,
-                motionIndex,
-                LIVE2D_MOTION_PRIORITY.IDLE
-            );
+            // 8. 统一入口负责替换旧 Idle、清理其定时器，并避免覆盖普通动作。
+            const started = await live2dManager.playIdleMotion(groupName, motionIndex);
             if (started) {
                 console.log('[Live2D Main] 已恢复待机动作并循环播放:', live2dIdleAnimation);
             } else {

--- a/static/avatar/avatar-performance-stage.js
+++ b/static/avatar/avatar-performance-stage.js
@@ -1800,6 +1800,9 @@
             if (!manager || !model) {
                 return false;
             }
+            if (typeof manager.hasActiveActionMotion === 'function' && manager.hasActiveActionMotion(model)) {
+                return false;
+            }
             const candidates = this.collectMotionCandidates(motion, options);
             for (let index = 0; index < candidates.length; index += 1) {
                 const candidate = candidates[index];
@@ -1811,7 +1814,7 @@
 
                 if (groupName && explicitIndex !== null && model && typeof model.motion === 'function') {
                     try {
-                        const played = await this.withPerformanceBypass(() => model.motion(groupName, explicitIndex));
+                        const played = await this.withPerformanceBypass(() => manager.playActionMotion(groupName, explicitIndex));
                         if (played !== false) {
                             return true;
                         }
@@ -1822,7 +1825,7 @@
                     const runtimeRef = this.findMotionRuntimeReference(groupName, file);
                     if (runtimeRef) {
                         try {
-                            const played = await this.withPerformanceBypass(() => model.motion(runtimeRef.group, runtimeRef.index));
+                            const played = await this.withPerformanceBypass(() => manager.playActionMotion(runtimeRef.group, runtimeRef.index));
                             if (played !== false) {
                                 return true;
                             }

--- a/static/avatar/avatar-performance-stage.js
+++ b/static/avatar/avatar-performance-stage.js
@@ -1689,10 +1689,17 @@
             this.activeFrameTransformContainer = null;
             const manager = this.getManager();
             if (this.sessionHasCapability(session, 'motion') && manager && typeof manager.suspendTemporaryMotions === 'function') {
-                this.motionSuspendSource = 'avatar-performance-motion-' + (this.ownerSessionId || 'session');
-                try {
-                    manager.suspendTemporaryMotions(this.motionSuspendSource, this.getModel());
-                } catch (_) {}
+                const model = this.getModel();
+                const hasActiveAction = typeof manager.hasActiveActionMotion === 'function'
+                    && manager.hasActiveActionMotion(model);
+                if (!hasActiveAction) {
+                    this.motionSuspendSource = 'avatar-performance-motion-' + (this.ownerSessionId || 'session');
+                    try {
+                        manager.suspendTemporaryMotions(this.motionSuspendSource, model);
+                    } catch (_) {}
+                } else {
+                    this.motionSuspendSource = '';
+                }
             }
             const hasFrameCapability = this.sessionHasCapability(session, 'frame');
             if (hasFrameCapability && container) {

--- a/static/avatar/avatar-performance-stage.js
+++ b/static/avatar/avatar-performance-stage.js
@@ -2144,6 +2144,7 @@
             if (manager && typeof manager.resetTransientMotionAndExpressionState === 'function') {
                 await Promise.resolve(manager.resetTransientMotionAndExpressionState({
                     preserveExpression: false,
+                    preserveMotion: true,
                     resetAllParameters: false
                 })).catch(() => {});
             }

--- a/static/live2d/live2d-emotion.js
+++ b/static/live2d/live2d-emotion.js
@@ -1336,9 +1336,13 @@ Live2DManager.prototype.playSimpleMotion = function(emotion) {
             angry: ['ParamAngleX'],
             surprised: ['ParamAngleY']
         };
-        this._setActiveMotionParamIds(simpleMotionParams[emotion] || ['ParamAngleX', 'ParamAngleY']);
         if (Object.prototype.hasOwnProperty.call(simpleMotionParams, emotion)) {
+            this._setActiveMotionParamIds(simpleMotionParams[emotion]);
             this._simpleMotionActive = true;
+        } else {
+            // 未配置定时动作时只把角度立即归零，不应继续占有这些参数。
+            this._clearActiveMotionParamIds();
+            this._simpleMotionActive = false;
         }
 
         switch (emotion) {

--- a/static/live2d/live2d-emotion.js
+++ b/static/live2d/live2d-emotion.js
@@ -470,6 +470,7 @@ Live2DManager.prototype.hasActiveMotionPlayback = function() {
 
 Live2DManager.prototype._clearMotionTimer = function() {
     this._nextMotionTimerGeneration();
+    this._simpleMotionActive = false;
     if (!this.motionTimer) return false;
 
     console.log(`清除motion定时器，类型: ${this.motionTimer.type || 'unknown'}`);
@@ -1263,6 +1264,13 @@ Live2DManager.prototype.playMotion = async function(emotion, options = {}) {
                     } else {
                         console.warn('motion播放失败，返回值无效');
                     }
+                    if (
+                        typeof this.hasActiveActionMotion === 'function'
+                        && this.hasActiveActionMotion(this.currentModel)
+                    ) {
+                        console.log(`[Live2D] 动作闸门已被占用，跳过简单动作回退: ${emotion}`);
+                        return false;
+                    }
                 } catch (error) {
                     console.warn('模型motion方法失败:', error);
                 }
@@ -1293,6 +1301,14 @@ Live2DManager.prototype.playMotion = async function(emotion, options = {}) {
 
 // 播放简单动作（回退方案）
 Live2DManager.prototype.playSimpleMotion = function(emotion) {
+    if (
+        typeof this.hasActiveActionMotion === 'function'
+        && this.hasActiveActionMotion(this.currentModel)
+    ) {
+        console.log(`[Live2D] 已有动作正在播放，跳过简单动作: ${emotion}`);
+        return false;
+    }
+
     try {
         const generation = this._nextMotionTimerGeneration();
         const isCurrentMotion = () => this._isCurrentMotionTimerGeneration(generation);
@@ -1303,6 +1319,9 @@ Live2DManager.prototype.playSimpleMotion = function(emotion) {
             surprised: ['ParamAngleY']
         };
         this._setActiveMotionParamIds(simpleMotionParams[emotion] || ['ParamAngleX', 'ParamAngleY']);
+        if (Object.prototype.hasOwnProperty.call(simpleMotionParams, emotion)) {
+            this._simpleMotionActive = true;
+        }
 
         switch (emotion) {
             case 'happy': {
@@ -1360,8 +1379,11 @@ Live2DManager.prototype.playSimpleMotion = function(emotion) {
                 break;
         }
         console.log(`播放简单动作: ${emotion}`);
+        return true;
     } catch (paramError) {
+        this._simpleMotionActive = false;
         console.warn('设置简单动作参数失败:', paramError);
+        return false;
     }
 };
 

--- a/static/live2d/live2d-emotion.js
+++ b/static/live2d/live2d-emotion.js
@@ -1194,7 +1194,10 @@ Live2DManager.prototype.playMotion = async function(emotion) {
                     // 使用运行时 motion group/index 播放，确保播放文件和追踪清理文件一致。
                     console.log(`尝试使用motion组播放motion: ${runtimeChoice.group}[${runtimeChoice.index}]`);
 
-                    const motion = await this.currentModel.motion(runtimeChoice.group, runtimeChoice.index);
+                    const motion = await this.playActionMotion(
+                        runtimeChoice.group,
+                        runtimeChoice.index
+                    );
                     if (!isCurrentMotionInvocation()) return false;
 
                     if (motion) {

--- a/static/live2d/live2d-emotion.js
+++ b/static/live2d/live2d-emotion.js
@@ -1035,7 +1035,7 @@ Live2DManager.prototype.playExpression = async function(emotion, specifiedExpres
 };
 
 // 播放动作
-Live2DManager.prototype.playMotion = async function(emotion) {
+Live2DManager.prototype.playMotion = async function(emotion, options = {}) {
     if (!this.currentModel) {
         console.warn('无法播放动作：模型未加载');
         return false;
@@ -1045,6 +1045,13 @@ Live2DManager.prototype.playMotion = async function(emotion) {
         && typeof this.isAvatarPerformanceCapabilityLocked === 'function'
         && this.isAvatarPerformanceCapabilityLocked('motion')
     ) {
+        return false;
+    }
+    if (
+        typeof this.hasActiveActionMotion === 'function'
+        && this.hasActiveActionMotion(this.currentModel)
+    ) {
+        console.log(`[Live2D] 已有动作正在播放，忽略情感动作: ${emotion}`);
         return false;
     }
 
@@ -1194,10 +1201,9 @@ Live2DManager.prototype.playMotion = async function(emotion) {
                     // 使用运行时 motion group/index 播放，确保播放文件和追踪清理文件一致。
                     console.log(`尝试使用motion组播放motion: ${runtimeChoice.group}[${runtimeChoice.index}]`);
 
-                    const motion = await this.playActionMotion(
-                        runtimeChoice.group,
-                        runtimeChoice.index
-                    );
+                    const motion = options.motionPriority === LIVE2D_MOTION_PRIORITY.IDLE
+                        ? await this.playIdleMotion(runtimeChoice.group, runtimeChoice.index)
+                        : await this.playActionMotion(runtimeChoice.group, runtimeChoice.index);
                     if (!isCurrentMotionInvocation()) return false;
 
                     if (motion) {
@@ -1398,7 +1404,7 @@ Live2DManager.prototype.clearEmotionEffects = function() {
 };
 
 // 设置情感并播放对应的表情和动作
-Live2DManager.prototype.setEmotion = async function(emotion) {
+Live2DManager.prototype.setEmotion = async function(emotion, options = {}) {
     // 防止快速连续点击
     if (this.isEmotionChanging) {
         console.log('情感切换中，忽略新的情感请求');
@@ -1412,6 +1418,13 @@ Live2DManager.prototype.setEmotion = async function(emotion) {
             || this.isAvatarPerformanceCapabilityLocked('motion')
         )
     ) {
+        return false;
+    }
+    if (
+        typeof this.hasActiveActionMotion === 'function'
+        && this.hasActiveActionMotion(this.currentModel)
+    ) {
+        console.log(`[Live2D] 已有动作正在播放，忽略情感切换: ${emotion}`);
         return false;
     }
     
@@ -1462,7 +1475,7 @@ Live2DManager.prototype.setEmotion = async function(emotion) {
             // 相同情绪且相同表情，保留原有的50%概率随机播放动作机制
             if (Math.random() < 0.5) {
                 console.log(`检测到相同情绪且相同表情: ${emotion} (${targetExpressionFile})，已清理残留，仅随机播放motion`);
-                await this.playMotion(emotion);
+                await this.playMotion(emotion, options);
             } else {
                 console.log(`检测到相同情绪且相同表情: ${emotion} (${targetExpressionFile})，已清理残留，跳过播放`);
             }
@@ -1497,11 +1510,25 @@ Live2DManager.prototype.setEmotion = async function(emotion) {
         // 只清 motion 残留，不把当前情绪表情洗掉。
         if (!shouldPreserveExistingExpression) {
             await this.smoothResetToInitialState(LIVE2D_EMOTION_SOFT_RESET_MS);
+            if (
+                typeof this.hasActiveActionMotion === 'function'
+                && this.hasActiveActionMotion(this.currentModel)
+            ) {
+                console.log(`[Live2D] 情感切换期间已有动作开始播放，取消情感切换: ${emotion}`);
+                return false;
+            }
         }
         await this.resetTransientMotionAndExpressionState({
             preserveExpression: shouldPreserveExistingExpression,
             resetAllParameters: !shouldPreserveExistingExpression
         });
+        if (
+            typeof this.hasActiveActionMotion === 'function'
+            && this.hasActiveActionMotion(this.currentModel)
+        ) {
+            console.log(`[Live2D] 情感重置期间已有动作开始播放，取消情感切换: ${emotion}`);
+            return false;
+        }
 
         this.currentEmotion = emotion;
         this.currentExpressionFile = targetExpressionFile;
@@ -1530,7 +1557,7 @@ Live2DManager.prototype.setEmotion = async function(emotion) {
         }
 
         // 播放动作
-        await this.playMotion(emotion);
+        await this.playMotion(emotion, options);
 
         // reset/cleanup 后补回常驻表情；没有新 expression 时这一步也不影响当前表情保护。
         try {

--- a/static/live2d/live2d-emotion.js
+++ b/static/live2d/live2d-emotion.js
@@ -1224,7 +1224,7 @@ Live2DManager.prototype.playMotion = async function(emotion, options = {}) {
 
                     const motion = options.motionPriority === LIVE2D_MOTION_PRIORITY.IDLE
                         ? await this.playIdleMotion(runtimeChoice.group, runtimeChoice.index)
-                        : await this.playActionMotion(runtimeChoice.group, runtimeChoice.index);
+                        : await this.playActionMotion(runtimeChoice.group, runtimeChoice.index, false);
                     if (motion) {
                         // Replacing an Idle legitimately clears its timer. Keep guarding later
                         // async tracking work from newer timers without rejecting this action.

--- a/static/live2d/live2d-emotion.js
+++ b/static/live2d/live2d-emotion.js
@@ -1190,7 +1190,7 @@ Live2DManager.prototype.playMotion = async function(emotion, options = {}) {
     const motionParamTrackModel = this.currentModel;
     const motionParamTrackGeneration = (this._motionParameterTrackGeneration || 0) + 1;
     this._motionParameterTrackGeneration = motionParamTrackGeneration;
-    const motionTimerGuardGeneration = this._motionTimerGeneration || 0;
+    let motionTimerGuardGeneration = this._motionTimerGeneration || 0;
     const isCurrentMotionInvocation = () => (
         isCurrentPlayMotionInvocation()
         && this.currentModel === motionParamTrackModel
@@ -1225,6 +1225,11 @@ Live2DManager.prototype.playMotion = async function(emotion, options = {}) {
                     const motion = options.motionPriority === LIVE2D_MOTION_PRIORITY.IDLE
                         ? await this.playIdleMotion(runtimeChoice.group, runtimeChoice.index)
                         : await this.playActionMotion(runtimeChoice.group, runtimeChoice.index);
+                    if (motion) {
+                        // Replacing an Idle legitimately clears its timer. Keep guarding later
+                        // async tracking work from newer timers without rejecting this action.
+                        motionTimerGuardGeneration = this._motionTimerGeneration || 0;
+                    }
                     if (!isCurrentMotionInvocation()) return false;
 
                     if (motion) {

--- a/static/live2d/live2d-emotion.js
+++ b/static/live2d/live2d-emotion.js
@@ -188,7 +188,13 @@ Live2DManager.prototype.clearExpression = function(options = {}) {
         // 尝试使用官方API停止expression（可选，不依赖其结果）
         if (this.currentModel.internalModel.motionManager && this.currentModel.internalModel.motionManager.expressionManager) {
             try {
-                this.currentModel.internalModel.motionManager.expressionManager.stopAllExpressions();
+                const expressionManager = this.currentModel.internalModel.motionManager.expressionManager;
+                // The bundled SDK keeps async expression loads in this public reservation slot.
+                // Cancel it before stopping the current expression so a superseded load cannot apply later.
+                if ('reserveExpressionIndex' in expressionManager) {
+                    expressionManager.reserveExpressionIndex = -1;
+                }
+                expressionManager.stopAllExpressions();
             } catch (e) {
                 console.warn('停止expression失败（忽略）:', e);
             }
@@ -406,6 +412,9 @@ Live2DManager.prototype._resetRecordedParameterIds = function(paramIds, options 
     if (!coreModel || !paramIds || typeof paramIds.forEach !== 'function') return 0;
 
     const protectedIds = preserveExpression ? this._getActiveExpressionParamIds() : new Set();
+    if (options.preserveMotion === true && this._activeMotionParamIds instanceof Set) {
+        this._activeMotionParamIds.forEach(id => protectedIds.add(id));
+    }
     let resetCount = 0;
     const uniqueParamIds = new Set();
 

--- a/static/live2d/live2d-emotion.js
+++ b/static/live2d/live2d-emotion.js
@@ -169,6 +169,7 @@ Live2DManager.prototype.recordInitialParameters = function() {
 // 清除当前瞬态 expression；常驻 expression 只重放，不参与互斥状态。
 Live2DManager.prototype.clearExpression = function(options = {}) {
     this._transientExpressionGeneration = (this._transientExpressionGeneration || 0) + 1;
+    const preserveMotion = options.preserveMotion === true;
     const activeExpressionParamIds = this._activeExpressionParamIds
         && typeof this._activeExpressionParamIds.forEach === 'function'
         ? new Set(Array.from(this._activeExpressionParamIds))
@@ -196,10 +197,11 @@ Live2DManager.prototype.clearExpression = function(options = {}) {
         this._activeExpressionParamIds = null;
         if (activeExpressionParamIds && activeExpressionParamIds.size > 0) {
             const resetCount = this._resetRecordedParameterIds(activeExpressionParamIds, {
-                preserveExpression: false
+                preserveExpression: false,
+                preserveMotion
             });
             console.log(`expression已恢复${resetCount}个受影响参数到用户外观基准`);
-        } else {
+        } else if (!preserveMotion) {
             const resetCount = this._resetParametersToInitialState({ preserveExpression: false });
             console.log(`expression参数列表不可用，已降级恢复${resetCount}个参数到外观基准`);
         }
@@ -256,6 +258,9 @@ Live2DManager.prototype._resetParametersToInitialState = function(options = {}) 
 
     const coreModel = this.currentModel.internalModel.coreModel;
     const protectedIds = preserveExpression ? this._getActiveExpressionParamIds() : new Set();
+    if (options.preserveMotion && this._activeMotionParamIds instanceof Set) {
+        this._activeMotionParamIds.forEach(id => protectedIds.add(id));
+    }
     const protectedIndexes = new Set();
     if (preserveExpression && protectedIds.size > 0 && typeof coreModel.getParameterIndex === 'function') {
         protectedIds.forEach((id) => {
@@ -514,7 +519,7 @@ Live2DManager.prototype.resetTransientMotionAndExpressionState = async function(
         || (!preserveExpression && options.resetAllParameters !== false);
 
     if (!preserveExpression) {
-        this.clearExpression({ reapplyPersistent: false });
+        this.clearExpression({ reapplyPersistent: false, preserveMotion });
     } else {
         this._cancelSmoothReset();
     }
@@ -906,7 +911,7 @@ Live2DManager.prototype.playExpression = async function(emotion, specifiedExpres
     }
     if (!choiceFile) return false;
 
-    this.clearExpression({ reapplyPersistent: false });
+    this.clearExpression({ reapplyPersistent: false, preserveMotion: true });
     const generation = this._transientExpressionGeneration;
     const isCurrentExpressionRequest = () => (
         this.currentModel === model
@@ -1566,8 +1571,10 @@ Live2DManager.prototype.setEmotion = async function(emotion, options = {}) {
         }
 
         console.log(`情感 ${emotion} 设置完成`);
+        return true;
     } catch (error) {
         console.error(`设置情感 ${emotion} 失败:`, error);
+        return false;
     } finally {
         if (isCurrentEmotionRequest()) {
             this.isEmotionChanging = false;

--- a/static/live2d/live2d-emotion.js
+++ b/static/live2d/live2d-emotion.js
@@ -85,7 +85,7 @@ Live2DManager.prototype.recordInitialParameters = function() {
                      paramId = `param_${i}`;
                      if (_verbose) console.log(`getParameterId不可用，使用索引参数名: ${paramId}`);
                  }
-                
+
                 const currentValue = coreModel.getParameterValueByIndex(i);
                 const paramKey = paramId || `param_${i}`;
                 
@@ -166,8 +166,9 @@ Live2DManager.prototype.recordInitialParameters = function() {
     }
 };
 
-// 清除expression到默认状态（使用保存的初始参数）
-Live2DManager.prototype.clearExpression = function() {
+// 清除当前瞬态 expression；常驻 expression 只重放，不参与互斥状态。
+Live2DManager.prototype.clearExpression = function(options = {}) {
+    this._transientExpressionGeneration = (this._transientExpressionGeneration || 0) + 1;
     const activeExpressionParamIds = this._activeExpressionParamIds
         && typeof this._activeExpressionParamIds.forEach === 'function'
         ? new Set(Array.from(this._activeExpressionParamIds))
@@ -180,7 +181,7 @@ Live2DManager.prototype.clearExpression = function() {
         if (!this.currentModel || !this.currentModel.internalModel || !this.currentModel.internalModel.coreModel) {
             this._activeExpressionParamIds = null;
             console.warn('无法清除expression：模型未加载');
-            return;
+            return false;
         }
 
         // 尝试使用官方API停止expression（可选，不依赖其结果）
@@ -208,9 +209,12 @@ Live2DManager.prototype.clearExpression = function() {
         this._activeExpressionParamIds = null;
     }
 
-    // 如存在常驻表情，清除后立即重放常驻，保证不被清掉
-    // 注意：这里传入 skipBackup=true，因为我们只是重新应用已有的常驻表情，不需要再次备份
-    this.applyPersistentExpressionsNative(true);
+    if (options.reapplyPersistent !== false) {
+        Promise.resolve(this.applyPersistentExpressionsNative(true)).catch((error) => {
+            console.warn('重新应用常驻表情失败:', error);
+        });
+    }
+    return true;
 };
 
 Live2DManager.prototype._getActiveExpressionParamIds = function() {
@@ -505,51 +509,41 @@ Live2DManager.prototype._resetExplicitMotionParameters = function(options = {}) 
 
 Live2DManager.prototype.resetTransientMotionAndExpressionState = async function(options = {}) {
     const preserveExpression = options.preserveExpression === true;
+    const preserveMotion = options.preserveMotion === true;
     const resetAllParameters = options.resetAllParameters === true
         || (!preserveExpression && options.resetAllParameters !== false);
 
-    this._cancelSmoothReset();
-    this._clearMotionTimer();
-
     if (!preserveExpression) {
-        this._removeManualExpressionOverride();
-        this._activeExpressionParamIds = null;
-        try {
-            const exprMgr = this.currentModel?.internalModel?.motionManager?.expressionManager;
-            if (exprMgr && typeof exprMgr.stopAllExpressions === 'function') {
-                exprMgr.stopAllExpressions();
-            }
-        } catch (e) {
-            console.warn('停止expression失败（忽略）:', e);
-        }
+        this.clearExpression({ reapplyPersistent: false });
+    } else {
+        this._cancelSmoothReset();
     }
+
+    let resetCount = 0;
+    let explicitResetCount = 0;
+    if (!preserveMotion) {
+        this._clearMotionTimer();
+        try {
+            const motionManager = this.currentModel?.internalModel?.motionManager;
+            if (motionManager && typeof motionManager.stopAllMotions === 'function') {
+                motionManager.stopAllMotions();
+            }
+        } catch (motionError) {
+            console.warn('停止motion失败:', motionError);
+        }
+        resetCount = this._resetActiveMotionParameters({ preserveExpression });
+        explicitResetCount = this._resetExplicitMotionParameters({ preserveExpression });
+        if (resetAllParameters) {
+            resetCount = this._resetParametersToInitialState({ preserveExpression });
+        }
+        this._clearActiveMotionParamIds();
+    }
+    console.log(`已重置${resetCount}个参数，显式重置${explicitResetCount}个motion参数，preserveExpression=${preserveExpression}, preserveMotion=${preserveMotion}, resetAllParameters=${resetAllParameters}`);
 
     try {
-        const motionManager = this.currentModel?.internalModel?.motionManager;
-        if (motionManager && typeof motionManager.stopAllMotions === 'function') {
-            motionManager.stopAllMotions();
-        }
-    } catch (motionError) {
-        console.warn('停止motion失败:', motionError);
-    }
-
-    const activeMotionResetCount = this._resetActiveMotionParameters({ preserveExpression });
-    const explicitResetCount = this._resetExplicitMotionParameters({ preserveExpression });
-    let resetCount = activeMotionResetCount;
-
-    if (resetAllParameters) {
-        resetCount = this._resetParametersToInitialState({ preserveExpression });
-    }
-
-    this._clearActiveMotionParamIds();
-    console.log(`已重置${resetCount}个参数，显式重置${explicitResetCount}个motion参数，preserveExpression=${preserveExpression}, resetAllParameters=${resetAllParameters}`);
-
-    if (preserveExpression) {
-        try {
-            await this.applyPersistentExpressionsNative(true);
-        } catch (e) {
-            console.warn('重新应用常驻表情失败:', e);
-        }
+        await this.applyPersistentExpressionsNative(true);
+    } catch (e) {
+        console.warn('重新应用常驻表情失败:', e);
     }
 
     return resetCount;
@@ -865,9 +859,10 @@ Live2DManager.prototype._removeManualExpressionOverride = function() {
     this._manualExpressionParams = null;
 };
 
-// 播放表情（优先使用 EmotionMapping.expressions）
+// 瞬态表情后触发者替换前一个；常驻表情不占这个槽。
 Live2DManager.prototype.playExpression = async function(emotion, specifiedExpressionFile = null) {
-    if (!this.currentModel) {
+    const model = this.currentModel;
+    if (!model) {
         console.warn('无法播放表情：模型未加载');
         return false;
     }
@@ -910,6 +905,14 @@ Live2DManager.prototype.playExpression = async function(emotion, specifiedExpres
         choiceFile = this.getRandomElement(expressionFiles);
     }
     if (!choiceFile) return false;
+
+    this.clearExpression({ reapplyPersistent: false });
+    const generation = this._transientExpressionGeneration;
+    const isCurrentExpressionRequest = () => (
+        this.currentModel === model
+        && this._transientExpressionGeneration === generation
+    );
+    if (!isCurrentExpressionRequest()) return false;
     this.expressionApplied = false;
 
     // 将 basename（如 expression7.exp3.json）归一化回 FileReferences 中的真实路径（如 expressions/expression7.exp3.json）
@@ -965,6 +968,8 @@ Live2DManager.prototype.playExpression = async function(emotion, specifiedExpres
             }
         }
 
+        if (!isCurrentExpressionRequest()) return false;
+
         if (!expressionData || !loadedExpressionFile) {
             if (typeof this.markExpressionFileMissing === 'function') {
                 for (const file of candidateFiles) this.markExpressionFileMissing(file);
@@ -996,10 +1001,10 @@ Live2DManager.prototype.playExpression = async function(emotion, specifiedExpres
                     console.warn(`表情名疑似文件路径，跳过原生API避免404: ${expressionName}`);
                     throw new Error('Expression name appears to be a file path');
                 }
-                
                 console.log(`尝试使用原生API播放expression: ${expressionName} (file: ${loadedExpressionFile})`);
-                
-                const expression = await this.currentModel.expression(expressionName);
+
+                const expression = await model.expression(expressionName);
+                if (!isCurrentExpressionRequest()) return false;
                 if (expression) {
                     console.log(`成功使用原生API播放expression: ${expressionName}`);
                     try {
@@ -1017,6 +1022,7 @@ Live2DManager.prototype.playExpression = async function(emotion, specifiedExpres
         }
         
         // 方法2: 回退到手动参数设置（使用每帧应用 + 淡入效果，避免参数被 loadParameters 覆盖）
+        if (!isCurrentExpressionRequest()) return false;
         console.log('使用手动参数设置播放expression（带淡入过渡）');
         if (expressionData.Parameters && expressionData.Parameters.length > 0) {
             // 使用 _installManualExpressionOverride 在每帧中持续应用参数，并带有淡入效果
@@ -1032,7 +1038,7 @@ Live2DManager.prototype.playExpression = async function(emotion, specifiedExpres
     // 重放常驻表情，确保不被覆盖
     // skipBackup=true 因为只是重新应用，不需要再次备份
     try { await this.applyPersistentExpressionsNative(true); } catch (e) {}
-    return this.expressionApplied === true;
+    return isCurrentExpressionRequest() && this.expressionApplied === true;
 };
 
 // 播放动作
@@ -1264,13 +1270,6 @@ Live2DManager.prototype.playMotion = async function(emotion, options = {}) {
                     } else {
                         console.warn('motion播放失败，返回值无效');
                     }
-                    if (
-                        typeof this.hasActiveActionMotion === 'function'
-                        && this.hasActiveActionMotion(this.currentModel)
-                    ) {
-                        console.log(`[Live2D] 动作闸门已被占用，跳过简单动作回退: ${emotion}`);
-                        return false;
-                    }
                 } catch (error) {
                     console.warn('模型motion方法失败:', error);
                 }
@@ -1427,11 +1426,6 @@ Live2DManager.prototype.clearEmotionEffects = function() {
 
 // 设置情感并播放对应的表情和动作
 Live2DManager.prototype.setEmotion = async function(emotion, options = {}) {
-    // 防止快速连续点击
-    if (this.isEmotionChanging) {
-        console.log('情感切换中，忽略新的情感请求');
-        return false;
-    }
     if (
         this._avatarPerformanceBypassLocks !== true
         && typeof this.isAvatarPerformanceCapabilityLocked === 'function'
@@ -1442,13 +1436,13 @@ Live2DManager.prototype.setEmotion = async function(emotion, options = {}) {
     ) {
         return false;
     }
-    if (
-        typeof this.hasActiveActionMotion === 'function'
-        && this.hasActiveActionMotion(this.currentModel)
-    ) {
-        console.log(`[Live2D] 已有动作正在播放，忽略情感切换: ${emotion}`);
-        return false;
-    }
+
+    const requestGeneration = (this._emotionRequestGeneration || 0) + 1;
+    this._emotionRequestGeneration = requestGeneration;
+    const isCurrentEmotionRequest = () => (
+        this._emotionRequestGeneration === requestGeneration
+    );
+    this.isEmotionChanging = true;
     
     // 清除点击效果的 ID，这样点击效果的恢复定时器会检测到并跳过恢复
     // 避免点击效果的恢复覆盖正常的情感表达
@@ -1484,20 +1478,26 @@ Live2DManager.prototype.setEmotion = async function(emotion, options = {}) {
     const isIdleEmotion = typeof emotion === 'string' && emotion.toLowerCase() === 'idle';
     const willApplyNewExpression = !!targetExpressionFile;
     const shouldPreserveExistingExpression = isIdleEmotion && !willApplyNewExpression;
+    const hasActionMotion = () => (
+        typeof this.hasActiveActionMotion === 'function'
+        && this.hasActiveActionMotion(this.currentModel)
+    );
     
     // 检查是否需要重置：即使情绪和表情都相同，也先清掉上一条 motion 的 transient 残留。
     if (this.currentEmotion === emotion && this.currentExpressionFile === targetExpressionFile) {
-        this.isEmotionChanging = true;
         try {
             await this.resetTransientMotionAndExpressionState({
                 preserveExpression: !!targetExpressionFile || shouldPreserveExistingExpression,
+                preserveMotion: hasActionMotion(),
                 resetAllParameters: !targetExpressionFile && !shouldPreserveExistingExpression
             });
+            if (!isCurrentEmotionRequest()) return false;
 
             // 相同情绪且相同表情，保留原有的50%概率随机播放动作机制
             if (Math.random() < 0.5) {
                 console.log(`检测到相同情绪且相同表情: ${emotion} (${targetExpressionFile})，已清理残留，仅随机播放motion`);
                 await this.playMotion(emotion, options);
+                if (!isCurrentEmotionRequest()) return false;
             } else {
                 console.log(`检测到相同情绪且相同表情: ${emotion} (${targetExpressionFile})，已清理残留，跳过播放`);
             }
@@ -1509,9 +1509,11 @@ Live2DManager.prototype.setEmotion = async function(emotion, options = {}) {
         } catch (error) {
             console.error(`设置相同情感 ${emotion} 失败:`, error);
         } finally {
-            this.isEmotionChanging = false;
+            if (isCurrentEmotionRequest()) {
+                this.isEmotionChanging = false;
+            }
         }
-        return;
+        return isCurrentEmotionRequest();
     }
     
     // 相同情绪但不同表情，或者全新情绪，需要重置
@@ -1521,57 +1523,31 @@ Live2DManager.prototype.setEmotion = async function(emotion, options = {}) {
         console.log(`新情感触发: ${emotion}，当前情感: ${this.currentEmotion}`);
     }
     
-    // 设置标志，防止快速连续点击
-    this.isEmotionChanging = true;
-    
     try {
         console.log(`开始设置新情感: ${emotion}`);
 
-        // setEmotion 切入新情绪时应清理上一套 expression/motion 残留；
-        // 唯一例外是回退到 Idle 且没有新 expression，此时沿用旧语义：
-        // 只清 motion 残留，不把当前情绪表情洗掉。
-        if (!shouldPreserveExistingExpression) {
+        // 表情槽和动作槽独立：动作空闲时沿用原重置流程；动作占用时只替换
+        // 瞬态表情，不能重置或停止该动作。
+        const preserveActiveMotion = hasActionMotion();
+        if (!shouldPreserveExistingExpression && !preserveActiveMotion) {
             await this.smoothResetToInitialState(LIVE2D_EMOTION_SOFT_RESET_MS);
-            if (
-                typeof this.hasActiveActionMotion === 'function'
-                && this.hasActiveActionMotion(this.currentModel)
-            ) {
-                console.log(`[Live2D] 情感切换期间已有动作开始播放，取消情感切换: ${emotion}`);
-                return false;
-            }
+            if (!isCurrentEmotionRequest()) return false;
         }
         await this.resetTransientMotionAndExpressionState({
-            preserveExpression: shouldPreserveExistingExpression,
+            preserveExpression: willApplyNewExpression || shouldPreserveExistingExpression,
+            preserveMotion: preserveActiveMotion || hasActionMotion(),
             resetAllParameters: !shouldPreserveExistingExpression
         });
-        if (
-            typeof this.hasActiveActionMotion === 'function'
-            && this.hasActiveActionMotion(this.currentModel)
-        ) {
-            console.log(`[Live2D] 情感重置期间已有动作开始播放，取消情感切换: ${emotion}`);
-            return false;
-        }
+        if (!isCurrentEmotionRequest()) return false;
 
         this.currentEmotion = emotion;
         this.currentExpressionFile = targetExpressionFile;
         console.log(`情感已更新为: ${emotion}，表情文件: ${targetExpressionFile}`);
 
-        // 暂停idle动画，防止覆盖我们的动作
-        if (this.currentModel && this.currentModel.internalModel && this.currentModel.internalModel.motionManager) {
-            try {
-                // 尝试停止所有正在播放的动作
-                if (this.currentModel.internalModel.motionManager.stopAllMotions) {
-                    this.currentModel.internalModel.motionManager.stopAllMotions();
-                    console.log('已停止idle动画');
-                }
-            } catch (motionError) {
-                console.warn('停止idle动画失败:', motionError);
-            }
-        }
-
         // 播放表情（使用确定的表情文件以保持一致性）。
         if (willApplyNewExpression) {
             await this.playExpression(emotion, targetExpressionFile);
+            if (!isCurrentEmotionRequest()) return false;
         } else if (shouldPreserveExistingExpression) {
             console.log(`Idle 未配置新表情，保留当前表情`);
         } else {
@@ -1580,6 +1556,7 @@ Live2DManager.prototype.setEmotion = async function(emotion, options = {}) {
 
         // 播放动作
         await this.playMotion(emotion, options);
+        if (!isCurrentEmotionRequest()) return false;
 
         // reset/cleanup 后补回常驻表情；没有新 expression 时这一步也不影响当前表情保护。
         try {
@@ -1592,8 +1569,9 @@ Live2DManager.prototype.setEmotion = async function(emotion, options = {}) {
     } catch (error) {
         console.error(`设置情感 ${emotion} 失败:`, error);
     } finally {
-        // 重置标志
-        this.isEmotionChanging = false;
+        if (isCurrentEmotionRequest()) {
+            this.isEmotionChanging = false;
+        }
     }
 };
 

--- a/static/live2d/live2d-interaction.js
+++ b/static/live2d/live2d-interaction.js
@@ -2589,7 +2589,7 @@ Live2DManager.prototype._playTemporaryClickEffect = async function(emotion, prio
 
         // 1. 优先播放低优先级动作
         let motions = null;
-        let motionGroup = emotion; // 用于 this.currentModel.motion(group, index, priority)
+        let motionGroup = emotion; // 传给统一的单动作播放入口
         if (this.fileReferences && this.fileReferences.Motions && this.fileReferences.Motions[emotion]) {
             motions = this.fileReferences.Motions[emotion];
         } else if (this.emotionMapping && this.emotionMapping.motions && this.emotionMapping.motions[emotion]) {
@@ -2623,7 +2623,7 @@ Live2DManager.prototype._playTemporaryClickEffect = async function(emotion, prio
             // 使用低优先级播放动作
             // pixi-live2d-display 的 motion(group, index, priority) 支持优先级参数
             try {
-                const motion = await this.currentModel.motion(motionGroup, undefined, priority);
+                const motion = await this.playActionMotion(motionGroup, undefined);
                 if (!isCurrentPlayAttempt()) {
                     // 已被新的点击接管：停掉本次刚启动的动作，避免后台占用，并放弃写共享状态
                     if (motion && typeof motion.stop === 'function') {
@@ -3250,11 +3250,9 @@ Live2DManager.prototype.playTutorialMotion = async function() {
     const index = Math.floor(Math.random() * groupList.length);
 
     try {
-        const motion = await this.currentModel.motion(group, index, window.live2dManager.CLICK_MOTION_PRIORITY);
-        // const motion = await this.currentModel.motion(group, index, 2);
+        const motion = await this.playActionMotion(group, index);
         if (motion) {
             console.log(`[Interaction] 教程模式 - 播放动作: ${group}[${index}]（优先级: ${window.live2dManager.CLICK_MOTION_PRIORITY}）`);
-            // console.log(`[Interaction] 教程模式 - 播放动作: ${group}[${index}]（优先级: ${2}）`);
             return true;
         }
     } catch (error) {
@@ -3884,8 +3882,10 @@ Live2DManager.prototype._playTouchSetAnimation = async function(hitAreaId, optio
                             return false;
                         }
 
-                        motionManager.stopAllMotions();
-                        const result = await live2dModel.motion(groupName, 0, 3);
+                        // 普通交互动作统一使用 NORMAL：SDK 会在已有 NORMAL 动作时
+                        // 拒绝新请求，从而保证同一时间只有一个动作。FORCE 仅供模型
+                        // 管理器的显式预览切换使用，不能用于主界面交互。
+                        const result = await this.playActionMotion(groupName, 0);
 
                         if (result) {
                             triggerLog.motions.push({
@@ -3894,7 +3894,7 @@ Live2DManager.prototype._playTouchSetAnimation = async function(hitAreaId, optio
                                 index: 0,
                                 file: motion.File,
                                 durationMs: AnimHoldingTime,
-                                priority: 3
+                                priority: LIVE2D_MOTION_PRIORITY.NORMAL
                             });
                             console.log(`[TouchSet] ✅ 成功下发播放指令: ${groupName}[0]`);
                         } else {

--- a/static/live2d/live2d-interaction.js
+++ b/static/live2d/live2d-interaction.js
@@ -3295,7 +3295,7 @@ Live2DManager.prototype.triggerRandomEmotion = async function() {
 
                 const playedMotion = await this.playTutorialMotion();
 
-                if (!playedMotion) {
+                if (!playedMotion && !this.hasActiveActionMotion(this.currentModel)) {
                     // 动作不可用时，回退到参数动画模拟效果
                     const model = this.currentModel.internalModel;
                     if (model && model.coreModel) {

--- a/static/live2d/live2d-interaction.js
+++ b/static/live2d/live2d-interaction.js
@@ -3971,7 +3971,7 @@ Live2DManager.prototype._playTouchSetAnimation = async function(hitAreaId, optio
                     const holdingTime = Number.isFinite(faceHoldingTime) && faceHoldingTime > 0 ? faceHoldingTime : 3000;
                     this.expressionTimer = setTimeout(() => {
                         if (typeof this.clearExpression === 'function') {
-                            this.clearExpression();
+                            this.clearExpression({ preserveMotion: true });
                             console.log(`[TouchSet] 临时表情清除，准备恢复常驻状态`);
                             if (typeof this.applyPersistentExpressionsNative === 'function') {
                                 try {

--- a/static/live2d/live2d-interaction.js
+++ b/static/live2d/live2d-interaction.js
@@ -3282,16 +3282,16 @@ Live2DManager.prototype.triggerRandomEmotion = async function() {
         console.log('[Interaction] 教程模式 - 随机播放表情（低优先级，将自动恢复）');
         try {
             // 获取表情列表
-            let expressionNames = [];
+            let expressions = [];
             if (this.fileReferences && Array.isArray(this.fileReferences.Expressions)) {
-                expressionNames = this.fileReferences.Expressions.map(e => e.Name).filter(Boolean);
+                expressions = this.fileReferences.Expressions.filter(e => e && e.Name && e.File);
             }
 
             // 随机播放表情
-            if (expressionNames.length > 0) {
-                const randomExpression = expressionNames[Math.floor(Math.random() * expressionNames.length)];
-                console.log(`[Interaction] 教程模式 - 播放表情: ${randomExpression}（将在 ${window.live2dManager.CLICK_EFFECT_DURATION}ms 后恢复）`);
-                await this.currentModel.expression(randomExpression);
+            if (expressions.length > 0) {
+                const randomExpression = expressions[Math.floor(Math.random() * expressions.length)];
+                console.log(`[Interaction] 教程模式 - 播放表情: ${randomExpression.Name}（将在 ${window.live2dManager.CLICK_EFFECT_DURATION}ms 后恢复）`);
+                await this.playExpression(randomExpression.Name, randomExpression.File);
 
                 const playedMotion = await this.playTutorialMotion();
 

--- a/static/live2d/live2d-model.js
+++ b/static/live2d/live2d-model.js
@@ -105,7 +105,7 @@ Live2DManager.prototype._startIdleMotion = async function(model, groupName, inde
  * 正在加载或播放时拒绝本次请求。Idle 会保留到普通动作加载完成，再由
  * SDK 原子替换，避免加载空窗触发 SDK 自动 Idle。
  */
-Live2DManager.prototype.playActionMotion = async function(groupName, index) {
+Live2DManager.prototype.playActionMotion = async function(groupName, index, trackParameters = true) {
     const model = this.currentModel;
     const motionManager = model?.internalModel?.motionManager;
     if (!model || typeof model.motion !== 'function' || !motionManager) {
@@ -147,6 +147,13 @@ Live2DManager.prototype.playActionMotion = async function(groupName, index) {
     }
     if (started === false) {
         this._clearOwnedMotionReservation(motionManager, groupName, index, LIVE2D_MOTION_PRIORITY.NORMAL);
+    } else if (this.currentModel === model && trackParameters) {
+        const definitions = motionManager.definitions || motionManager._definitions || {};
+        const startedMotion = definitions[state.currentGroup || groupName]?.[state.currentIndex ?? index];
+        const startedFile = startedMotion && (startedMotion.File || startedMotion.file);
+        if (startedFile && typeof this._trackActiveMotionParametersFromFile === 'function') {
+            this._trackActiveMotionParametersFromFile(startedFile).catch(() => {});
+        }
     }
     return this.currentModel === model && started !== false;
 };

--- a/static/live2d/live2d-model.js
+++ b/static/live2d/live2d-model.js
@@ -1932,6 +1932,7 @@ Live2DManager.prototype._playIdleMotion = async function(motionManager) {
     if (!isCurrentIdleRequest()) return;
     try {
         const started = await this._startIdleMotion(expectedModel, 'Idle');
+        if (!isCurrentIdleRequest()) return;
         if (started === false) {
             this._clearActiveMotionParamIds();
             return;
@@ -1941,6 +1942,7 @@ Live2DManager.prototype._playIdleMotion = async function(motionManager) {
         const startedFile = getRegisteredMotionFile(startedGroup, startedIndex);
         trackMotionFile(startedFile);
     } catch (e) {
+        if (!isCurrentIdleRequest()) return;
         this._clearActiveMotionParamIds();
         console.warn('[Live2D] 随机 Idle motion 启动失败:', e);
     }

--- a/static/live2d/live2d-model.js
+++ b/static/live2d/live2d-model.js
@@ -15,6 +15,51 @@ const LIVE2D_MOTION_PRIORITY = Object.freeze({
     FORCE: 3
 });
 
+Live2DManager.prototype.hasActiveActionMotion = function(model = this.currentModel) {
+    const motionManager = model?.internalModel?.motionManager;
+    const state = motionManager?.state;
+    if (!motionManager || !state) return false;
+
+    const currentPriority = Number(state.currentPriority ?? LIVE2D_MOTION_PRIORITY.NONE);
+    const reservePriority = Number(state.reservePriority ?? LIVE2D_MOTION_PRIORITY.NONE);
+    return currentPriority > LIVE2D_MOTION_PRIORITY.IDLE
+        || reservePriority > LIVE2D_MOTION_PRIORITY.IDLE;
+};
+
+/**
+ * 播放一个主界面动作。普通动作统一使用 NORMAL 优先级；当另一个普通动作
+ * 正在加载或播放时拒绝本次请求。Idle 可以被接管，但会先立即停止，避免
+ * SDK 的淡出阶段把 Idle 与新动作叠在一起。
+ */
+Live2DManager.prototype.playActionMotion = async function(groupName, index) {
+    const model = this.currentModel;
+    const motionManager = model?.internalModel?.motionManager;
+    if (!model || typeof model.motion !== 'function' || !motionManager) {
+        return false;
+    }
+    if (this.hasActiveActionMotion(model)) {
+        console.log(`[Live2D] 已有动作正在播放，忽略新动作: ${groupName}`);
+        return false;
+    }
+
+    const state = motionManager.state;
+    const currentPriority = Number(state?.currentPriority ?? LIVE2D_MOTION_PRIORITY.NONE);
+    const hasReservedIdle = state?.reservedIdleGroup !== undefined;
+    if (
+        currentPriority === LIVE2D_MOTION_PRIORITY.IDLE
+        || hasReservedIdle
+    ) {
+        motionManager.stopAllMotions();
+    }
+
+    const started = await model.motion(
+        groupName,
+        index,
+        LIVE2D_MOTION_PRIORITY.NORMAL
+    );
+    return this.currentModel === model && started !== false;
+};
+
 // 缓动函数集合（用于眨眼、口型等动画的平滑过渡）
 const Easing = {
     linear: (t) => t,
@@ -1698,7 +1743,13 @@ Live2DManager.prototype._playIdleMotion = async function(motionManager) {
     const startTrackedMotion = async (groupName, index, file) => {
         if (!isCurrentIdleRequest()) return false;
         try {
-            const started = await motionManager.startMotion(groupName, index);
+            // Idle 必须使用 SDK 的 IDLE 优先级。若误用默认 NORMAL，后续普通动作
+            // 会被当成同优先级动作拒绝，只能靠 FORCE 插入，进而造成动作叠播。
+            const started = await motionManager.startMotion(
+                groupName,
+                index,
+                LIVE2D_MOTION_PRIORITY.IDLE
+            );
             if (!isCurrentIdleRequest()) return false;
             if (started === false) {
                 console.warn(`[Live2D] 启动 ${groupName} 待机动作失败，尝试下一个 Idle 候选`);
@@ -1770,7 +1821,10 @@ Live2DManager.prototype._playIdleMotion = async function(motionManager) {
 
     if (!isCurrentIdleRequest()) return;
     try {
-        const started = await motionManager.startRandomMotion('Idle');
+        const started = await motionManager.startRandomMotion(
+            'Idle',
+            LIVE2D_MOTION_PRIORITY.IDLE
+        );
         if (!isCurrentIdleRequest()) return;
         if (started === false) {
             this._clearActiveMotionParamIds();

--- a/static/live2d/live2d-model.js
+++ b/static/live2d/live2d-model.js
@@ -20,14 +20,79 @@ Live2DManager.prototype.hasActiveActionMotion = function(model = this.currentMod
         return true;
     }
 
-    const motionManager = model?.internalModel?.motionManager;
-    const state = motionManager?.state;
-    if (!motionManager || !state) return false;
+    const state = model?.internalModel?.motionManager?.state;
+    if (!state) return false;
 
     const currentPriority = Number(state.currentPriority ?? LIVE2D_MOTION_PRIORITY.NONE);
     const reservePriority = Number(state.reservePriority ?? LIVE2D_MOTION_PRIORITY.NONE);
     return currentPriority > LIVE2D_MOTION_PRIORITY.IDLE
         || reservePriority > LIVE2D_MOTION_PRIORITY.IDLE;
+};
+
+Live2DManager.prototype._clearOwnedMotionReservation = function(motionManager, groupName, index, priority) {
+    const state = motionManager?.state;
+    if (!state) return;
+    const isIdle = priority === LIVE2D_MOTION_PRIORITY.IDLE;
+    if (
+        state[isIdle ? 'reservedIdleGroup' : 'reservedGroup'] !== groupName
+        || (index != null && state[isIdle ? 'reservedIdleIndex' : 'reservedIndex'] !== index)
+    ) return;
+
+    if (isIdle) {
+        state.setReservedIdle(undefined, undefined);
+    } else {
+        state.setReserved(undefined, undefined, LIVE2D_MOTION_PRIORITY.NONE);
+    }
+};
+
+Live2DManager.prototype._stopIdleMotion = function(model) {
+    const motionManager = model?.internalModel?.motionManager;
+    const state = motionManager?.state;
+    if (
+        Number(state?.currentPriority ?? LIVE2D_MOTION_PRIORITY.NONE) !== LIVE2D_MOTION_PRIORITY.IDLE
+        && state?.reservedIdleGroup === undefined
+    ) return;
+    if (typeof this._clearMotionTimer === 'function') this._clearMotionTimer();
+    motionManager.stopAllMotions();
+};
+
+Live2DManager.prototype._startIdleMotion = async function(model, groupName, index) {
+    const motionManager = model?.internalModel?.motionManager;
+    if (model !== this.currentModel || !motionManager) return false;
+
+    const generation = (this._idleMotionRequestGeneration || 0) + 1;
+    this._idleMotionRequestGeneration = generation;
+    if (this.hasActiveActionMotion(model)) return false;
+    this._stopIdleMotion(model);
+
+    let started;
+    try {
+        started = await (index == null
+            ? motionManager.startRandomMotion(groupName, LIVE2D_MOTION_PRIORITY.IDLE)
+            : motionManager.startMotion(groupName, index, LIVE2D_MOTION_PRIORITY.IDLE));
+    } catch (error) {
+        this._clearOwnedMotionReservation(motionManager, groupName, index, LIVE2D_MOTION_PRIORITY.IDLE);
+        throw error;
+    }
+    if (started === false) {
+        this._clearOwnedMotionReservation(motionManager, groupName, index, LIVE2D_MOTION_PRIORITY.IDLE);
+        return false;
+    }
+    if (
+        this.currentModel !== model
+        || model.destroyed
+        || this._idleMotionRequestGeneration !== generation
+        || this.hasActiveActionMotion(model)
+    ) {
+        // SDK 允许加载中的 Idle 越过 NORMAL 预留。只停掉刚启动的过期
+        // Idle，并保留普通动作的预留。
+        if (Number(motionManager.state.currentPriority) === LIVE2D_MOTION_PRIORITY.IDLE) {
+            motionManager._stopAllMotions();
+            motionManager.state.complete();
+        }
+        return false;
+    }
+    return true;
 };
 
 /**
@@ -46,35 +111,7 @@ Live2DManager.prototype.playActionMotion = async function(groupName, index) {
         return false;
     }
     this._idleMotionRequestGeneration = (this._idleMotionRequestGeneration || 0) + 1;
-
-    const state = motionManager.state;
-    const currentPriority = Number(state?.currentPriority ?? LIVE2D_MOTION_PRIORITY.NONE);
-    const hasReservedIdle = state?.reservedIdleGroup !== undefined;
-    if (
-        currentPriority === LIVE2D_MOTION_PRIORITY.IDLE
-        || hasReservedIdle
-    ) {
-        if (typeof this._clearMotionTimer === 'function') {
-            this._clearMotionTimer();
-        }
-        motionManager.stopAllMotions();
-    }
-
-    const clearOwnedReservation = () => {
-        const currentState = motionManager.state;
-        if (!currentState || currentState !== state) return;
-        const ownsReservedGroup = currentState.reservedGroup === groupName;
-        const ownsReservedIndex = index == null || currentState.reservedIndex === index;
-        if (!ownsReservedGroup || !ownsReservedIndex) return;
-
-        if (typeof currentState.setReserved === 'function') {
-            currentState.setReserved(undefined, undefined, LIVE2D_MOTION_PRIORITY.NONE);
-        } else {
-            currentState.reservePriority = LIVE2D_MOTION_PRIORITY.NONE;
-            currentState.reservedGroup = undefined;
-            currentState.reservedIndex = undefined;
-        }
-    };
+    this._stopIdleMotion(model);
 
     let started;
     try {
@@ -84,16 +121,13 @@ Live2DManager.prototype.playActionMotion = async function(groupName, index) {
             LIVE2D_MOTION_PRIORITY.NORMAL
         );
     } catch (error) {
-        clearOwnedReservation();
+        this._clearOwnedMotionReservation(motionManager, groupName, index, LIVE2D_MOTION_PRIORITY.NORMAL);
         throw error;
     }
     if (started === false) {
-        clearOwnedReservation();
+        this._clearOwnedMotionReservation(motionManager, groupName, index, LIVE2D_MOTION_PRIORITY.NORMAL);
     }
-    if (this.currentModel !== model || started === false) {
-        return false;
-    }
-    return started === undefined ? true : started;
+    return this.currentModel === model && started !== false;
 };
 
 /**
@@ -105,19 +139,7 @@ Live2DManager.prototype.playIdleMotion = async function(groupName, index) {
     if (!model || typeof model.motion !== 'function' || !motionManager) {
         return false;
     }
-    if (this.hasActiveActionMotion(model)) {
-        return false;
-    }
-
-    const started = await model.motion(
-        groupName,
-        index,
-        LIVE2D_MOTION_PRIORITY.IDLE
-    );
-    if (this.currentModel !== model || started === false) {
-        return false;
-    }
-    return started === undefined ? true : started;
+    return this._startIdleMotion(model, groupName, index);
 };
 
 // 缓动函数集合（用于眨眼、口型等动画的平滑过渡）
@@ -194,6 +216,8 @@ Live2DManager.prototype.removeModel = async function(options = {}) {
     this.appearanceBaselineParameters = {};
     this._activeExpressionParamIds = null;
     this._activeMotionParamIds = null;
+    this._idleMotionRequestGeneration = (this._idleMotionRequestGeneration || 0) + 1;
+    this._transientExpressionGeneration = (this._transientExpressionGeneration || 0) + 1;
     this._motionParameterTrackGeneration = (this._motionParameterTrackGeneration || 0) + 1;
     if (typeof this._clearMotionTimer === 'function') {
         this._clearMotionTimer();
@@ -1755,19 +1779,13 @@ Live2DManager.prototype._playIdleMotion = async function(motionManager) {
         return;
     }
     const expectedModel = this.currentModel;
-    const idleMotionRequestGeneration = this._idleMotionRequestGeneration || 0;
     const isCurrentIdleRequest = () => (
         this.currentModel === expectedModel
         && expectedModel
         && !expectedModel.destroyed
-        && (this._idleMotionRequestGeneration || 0) === idleMotionRequestGeneration
         && window._currentMotionPreviewId == null
         && !this._temporaryMotionSuspendToken
         && !this.isAvatarPerformanceCapabilityLocked('motion')
-    );
-    const canStartIdleMotion = () => (
-        isCurrentIdleRequest()
-        && !this.hasActiveActionMotion(expectedModel)
     );
     const getRandomizedIndexes = (length) => {
         const indexes = [];
@@ -1807,49 +1825,10 @@ Live2DManager.prototype._playIdleMotion = async function(motionManager) {
         }
         this._trackActiveMotionParametersFromFile(file).catch(() => {});
     };
-    const stopStaleIdleMotion = (started) => {
-        const state = motionManager.state;
-        if (
-            started === false
-            || Number(state?.currentPriority ?? LIVE2D_MOTION_PRIORITY.NONE) !== LIVE2D_MOTION_PRIORITY.IDLE
-        ) {
-            return;
-        }
-
-        // IDLE 加载期间若被普通动作接管，SDK 仍可能在加载完成后启动旧 Idle。
-        // 停止该过期 Idle，同时保留正在加载的 NORMAL 动作预留。
-        const reservedGroup = state.reservedGroup;
-        const reservedIndex = state.reservedIndex;
-        const reservePriority = Number(state.reservePriority ?? LIVE2D_MOTION_PRIORITY.NONE);
-        try {
-            motionManager.stopAllMotions();
-        } catch (_) {
-            return;
-        }
-        if (reservePriority > LIVE2D_MOTION_PRIORITY.IDLE && reservedGroup !== undefined) {
-            if (typeof state.setReserved === 'function') {
-                state.setReserved(reservedGroup, reservedIndex, reservePriority);
-            } else {
-                state.reservePriority = reservePriority;
-                state.reservedGroup = reservedGroup;
-                state.reservedIndex = reservedIndex;
-            }
-        }
-    };
     const startTrackedMotion = async (groupName, index, file) => {
-        if (!canStartIdleMotion()) return false;
+        if (!isCurrentIdleRequest()) return false;
         try {
-            // Idle 必须使用 SDK 的 IDLE 优先级。若误用默认 NORMAL，后续普通动作
-            // 会被当成同优先级动作拒绝，只能靠 FORCE 插入，进而造成动作叠播。
-            const started = await motionManager.startMotion(
-                groupName,
-                index,
-                LIVE2D_MOTION_PRIORITY.IDLE
-            );
-            if (!isCurrentIdleRequest()) {
-                stopStaleIdleMotion(started);
-                return false;
-            }
+            const started = await this._startIdleMotion(expectedModel, groupName, index);
             if (started === false) {
                 console.warn(`[Live2D] 启动 ${groupName} 待机动作失败，尝试下一个 Idle 候选`);
                 return false;
@@ -1918,16 +1897,9 @@ Live2DManager.prototype._playIdleMotion = async function(motionManager) {
         return;
     }
 
-    if (!canStartIdleMotion()) return;
+    if (!isCurrentIdleRequest()) return;
     try {
-        const started = await motionManager.startRandomMotion(
-            'Idle',
-            LIVE2D_MOTION_PRIORITY.IDLE
-        );
-        if (!isCurrentIdleRequest()) {
-            stopStaleIdleMotion(started);
-            return;
-        }
+        const started = await this._startIdleMotion(expectedModel, 'Idle');
         if (started === false) {
             this._clearActiveMotionParamIds();
             return;

--- a/static/live2d/live2d-model.js
+++ b/static/live2d/live2d-model.js
@@ -78,17 +78,22 @@ Live2DManager.prototype._startIdleMotion = async function(model, groupName, inde
         this._clearOwnedMotionReservation(motionManager, groupName, index, LIVE2D_MOTION_PRIORITY.IDLE);
         return false;
     }
+    const actionActive = this.hasActiveActionMotion(model);
     if (
         this.currentModel !== model
         || model.destroyed
         || this._idleMotionRequestGeneration !== generation
-        || this.hasActiveActionMotion(model)
+        || actionActive
     ) {
-        // SDK 允许加载中的 Idle 越过 NORMAL 预留。只停掉刚启动的过期
-        // Idle，并保留普通动作的预留。
-        if (Number(motionManager.state.currentPriority) === LIVE2D_MOTION_PRIORITY.IDLE) {
+        const state = motionManager.state;
+        const ownsCurrentIdle = Number(state.currentPriority) === LIVE2D_MOTION_PRIORITY.IDLE
+            && state.currentGroup === groupName
+            && (index == null || state.currentIndex === index);
+        // NORMAL 加载期间保留当前 Idle，由 SDK 在动作真正开始时原子替换；
+        // 其他失效请求只停止自己刚启动的 Idle，不能误停更新的 Idle。
+        if (!actionActive && ownsCurrentIdle) {
             motionManager._stopAllMotions();
-            motionManager.state.complete();
+            state.complete();
         }
         return false;
     }
@@ -97,8 +102,8 @@ Live2DManager.prototype._startIdleMotion = async function(model, groupName, inde
 
 /**
  * 播放一个主界面动作。普通动作统一使用 NORMAL 优先级；当另一个普通动作
- * 正在加载或播放时拒绝本次请求。Idle 可以被接管，但会先立即停止，避免
- * SDK 的淡出阶段把 Idle 与新动作叠在一起。
+ * 正在加载或播放时拒绝本次请求。Idle 会保留到普通动作加载完成，再由
+ * SDK 原子替换，避免加载空窗触发 SDK 自动 Idle。
  */
 Live2DManager.prototype.playActionMotion = async function(groupName, index) {
     const model = this.currentModel;
@@ -111,7 +116,19 @@ Live2DManager.prototype.playActionMotion = async function(groupName, index) {
         return false;
     }
     this._idleMotionRequestGeneration = (this._idleMotionRequestGeneration || 0) + 1;
-    this._stopIdleMotion(model);
+    this._idleLoopRequestGeneration = (this._idleLoopRequestGeneration || 0) + 1;
+
+    const state = motionManager.state;
+    if (
+        Number(state.currentPriority ?? LIVE2D_MOTION_PRIORITY.NONE) === LIVE2D_MOTION_PRIORITY.IDLE
+        || state.reservedIdleGroup !== undefined
+    ) {
+        if (typeof this._clearMotionTimer === 'function') this._clearMotionTimer();
+    }
+    // MotionState.shouldRequestIdleMotion() 不检查 NORMAL reservation。用一个
+    // 仅在本次动作加载期间存在的 Idle reservation 阻止 SDK 自动启动 Idle。
+    const idleBlock = {};
+    state.setReservedIdle(idleBlock, undefined);
 
     let started;
     try {
@@ -123,6 +140,10 @@ Live2DManager.prototype.playActionMotion = async function(groupName, index) {
     } catch (error) {
         this._clearOwnedMotionReservation(motionManager, groupName, index, LIVE2D_MOTION_PRIORITY.NORMAL);
         throw error;
+    } finally {
+        if (state.reservedIdleGroup === idleBlock) {
+            state.setReservedIdle(undefined, undefined);
+        }
     }
     if (started === false) {
         this._clearOwnedMotionReservation(motionManager, groupName, index, LIVE2D_MOTION_PRIORITY.NORMAL);
@@ -139,6 +160,7 @@ Live2DManager.prototype.playIdleMotion = async function(groupName, index) {
     if (!model || typeof model.motion !== 'function' || !motionManager) {
         return false;
     }
+    this._idleLoopRequestGeneration = (this._idleLoopRequestGeneration || 0) + 1;
     return this._startIdleMotion(model, groupName, index);
 };
 
@@ -217,6 +239,7 @@ Live2DManager.prototype.removeModel = async function(options = {}) {
     this._activeExpressionParamIds = null;
     this._activeMotionParamIds = null;
     this._idleMotionRequestGeneration = (this._idleMotionRequestGeneration || 0) + 1;
+    this._idleLoopRequestGeneration = (this._idleLoopRequestGeneration || 0) + 1;
     this._transientExpressionGeneration = (this._transientExpressionGeneration || 0) + 1;
     this._motionParameterTrackGeneration = (this._motionParameterTrackGeneration || 0) + 1;
     if (typeof this._clearMotionTimer === 'function') {
@@ -1779,10 +1802,14 @@ Live2DManager.prototype._playIdleMotion = async function(motionManager) {
         return;
     }
     const expectedModel = this.currentModel;
+    const loopGeneration = (this._idleLoopRequestGeneration || 0) + 1;
+    this._idleLoopRequestGeneration = loopGeneration;
     const isCurrentIdleRequest = () => (
         this.currentModel === expectedModel
         && expectedModel
         && !expectedModel.destroyed
+        && this._idleLoopRequestGeneration === loopGeneration
+        && !this.hasActiveActionMotion(expectedModel)
         && window._currentMotionPreviewId == null
         && !this._temporaryMotionSuspendToken
         && !this.isAvatarPerformanceCapabilityLocked('motion')
@@ -1829,6 +1856,7 @@ Live2DManager.prototype._playIdleMotion = async function(motionManager) {
         if (!isCurrentIdleRequest()) return false;
         try {
             const started = await this._startIdleMotion(expectedModel, groupName, index);
+            if (!isCurrentIdleRequest()) return false;
             if (started === false) {
                 console.warn(`[Live2D] 启动 ${groupName} 待机动作失败，尝试下一个 Idle 候选`);
                 return false;
@@ -1846,6 +1874,7 @@ Live2DManager.prototype._playIdleMotion = async function(motionManager) {
             const definition = definitions[idx];
             const file = definition && (definition.File || definition.file);
             if (await startTrackedMotion(groupName, idx, file)) return true;
+            if (!isCurrentIdleRequest()) return false;
         }
         return false;
     };
@@ -1857,6 +1886,7 @@ Live2DManager.prototype._playIdleMotion = async function(motionManager) {
             if (filter && !filter(motion)) continue;
             const file = getMotionFile(motion);
             if (await startTrackedMotion(groupName, idx, file)) return true;
+            if (!isCurrentIdleRequest()) return false;
         }
         return false;
     };
@@ -1873,6 +1903,7 @@ Live2DManager.prototype._playIdleMotion = async function(motionManager) {
                 const motionFile = getMotionFile(motion);
                 return motionFile && idleAnimations.includes(motionFile.split('/').pop());
             });
+            if (!isCurrentIdleRequest()) return;
             if (startedUserIdle) {
                 return;
             }
@@ -1891,6 +1922,7 @@ Live2DManager.prototype._playIdleMotion = async function(motionManager) {
     if (await startTrackedDefinitionMotion('Idle', definitions.Idle)) {
         return;
     }
+    if (!isCurrentIdleRequest()) return;
 
     const motionGroups = motionManager.motionGroups || motionManager._motionGroups || {};
     if (await startTrackedGroupMotion('Idle', motionGroups.Idle)) {

--- a/static/live2d/live2d-model.js
+++ b/static/live2d/live2d-model.js
@@ -16,7 +16,10 @@ const LIVE2D_MOTION_PRIORITY = Object.freeze({
 });
 
 Live2DManager.prototype.hasActiveActionMotion = function(model = this.currentModel) {
-    if (model === this.currentModel && this._simpleMotionActive === true) {
+    if (
+        model === this.currentModel
+        && (this._simpleMotionActive === true || this._actionMotionRequestPendingModel === model)
+    ) {
         return true;
     }
 
@@ -115,10 +118,20 @@ Live2DManager.prototype.playActionMotion = async function(groupName, index, trac
         console.log(`[Live2D] 已有动作正在播放，忽略新动作: ${groupName}`);
         return false;
     }
+    const state = motionManager.state;
+    const definitions = motionManager.definitions || motionManager._definitions || {};
+    const availableIndexes = (definitions[groupName] || [])
+        .map((_, candidateIndex) => candidateIndex)
+        .filter(candidateIndex => motionManager.motionGroups?.[groupName]?.[candidateIndex] !== null
+            && (typeof state.isActive !== 'function' || !state.isActive(groupName, candidateIndex)));
+    const motionIndex = index == null && availableIndexes.length > 0
+        ? availableIndexes[Math.floor(Math.random() * availableIndexes.length)]
+        : index;
+    const requestedMotion = motionIndex == null ? null : definitions[groupName]?.[motionIndex];
+    const requestedFile = requestedMotion && (requestedMotion.File || requestedMotion.file);
+    this._actionMotionRequestPendingModel = model;
     this._idleMotionRequestGeneration = (this._idleMotionRequestGeneration || 0) + 1;
     this._idleLoopRequestGeneration = (this._idleLoopRequestGeneration || 0) + 1;
-
-    const state = motionManager.state;
     if (
         Number(state.currentPriority ?? LIVE2D_MOTION_PRIORITY.NONE) === LIVE2D_MOTION_PRIORITY.IDLE
         || state.reservedIdleGroup !== undefined
@@ -132,27 +145,33 @@ Live2DManager.prototype.playActionMotion = async function(groupName, index, trac
 
     let started;
     try {
+        if (trackParameters && requestedFile && typeof this._trackActiveMotionParametersFromFile === 'function') {
+            await this._trackActiveMotionParametersFromFile(requestedFile);
+        }
+        if (this.currentModel !== model) return false;
         started = await model.motion(
             groupName,
-            index,
+            motionIndex,
             LIVE2D_MOTION_PRIORITY.NORMAL
         );
     } catch (error) {
-        this._clearOwnedMotionReservation(motionManager, groupName, index, LIVE2D_MOTION_PRIORITY.NORMAL);
+        this._clearOwnedMotionReservation(motionManager, groupName, motionIndex, LIVE2D_MOTION_PRIORITY.NORMAL);
+        if (trackParameters && typeof this._clearActiveMotionParamIds === 'function') {
+            this._clearActiveMotionParamIds();
+        }
         throw error;
     } finally {
+        if (this._actionMotionRequestPendingModel === model) {
+            this._actionMotionRequestPendingModel = null;
+        }
         if (state.reservedIdleGroup === idleBlock) {
             state.setReservedIdle(undefined, undefined);
         }
     }
     if (started === false) {
-        this._clearOwnedMotionReservation(motionManager, groupName, index, LIVE2D_MOTION_PRIORITY.NORMAL);
-    } else if (this.currentModel === model && trackParameters) {
-        const definitions = motionManager.definitions || motionManager._definitions || {};
-        const startedMotion = definitions[state.currentGroup || groupName]?.[state.currentIndex ?? index];
-        const startedFile = startedMotion && (startedMotion.File || startedMotion.file);
-        if (startedFile && typeof this._trackActiveMotionParametersFromFile === 'function') {
-            this._trackActiveMotionParametersFromFile(startedFile).catch(() => {});
+        this._clearOwnedMotionReservation(motionManager, groupName, motionIndex, LIVE2D_MOTION_PRIORITY.NORMAL);
+        if (trackParameters && typeof this._clearActiveMotionParamIds === 'function') {
+            this._clearActiveMotionParamIds();
         }
     }
     return this.currentModel === model && started !== false;
@@ -1777,6 +1796,9 @@ Live2DManager.prototype.setupIdleMotionLoop = function(model) {
 
     this._idleMotionFinishModel = model;
     this._idleMotionFinishHandler = () => {
+        if (this._actionMotionRequestPendingModel === model) {
+            return;
+        }
         if (this._temporaryMotionSuspendToken) {
             return;
         }
@@ -2387,10 +2409,8 @@ Live2DManager.prototype._configureLoadedModel = async function(model, modelPath,
     if (!suppressInitialIdle && (hasIdleInEmotionMapping || hasIdleInFileReferences)) {
         try {
             console.log('[Live2D Model] 模型淡入完成，开始播放Idle情绪');
-            this.setEmotion('Idle', {
+            await this.setEmotion('Idle', {
                 motionPriority: LIVE2D_MOTION_PRIORITY.IDLE
-            }).catch(error => {
-                console.warn('[Live2D Model] 播放Idle情绪失败:', error);
             });
         } catch (error) {
             console.warn('[Live2D Model] 播放Idle情绪失败:', error);

--- a/static/live2d/live2d-model.js
+++ b/static/live2d/live2d-model.js
@@ -45,6 +45,7 @@ Live2DManager.prototype.playActionMotion = async function(groupName, index) {
         console.log(`[Live2D] 已有动作正在播放，忽略新动作: ${groupName}`);
         return false;
     }
+    this._idleMotionRequestGeneration = (this._idleMotionRequestGeneration || 0) + 1;
 
     const state = motionManager.state;
     const currentPriority = Number(state?.currentPriority ?? LIVE2D_MOTION_PRIORITY.NONE);
@@ -1754,10 +1755,12 @@ Live2DManager.prototype._playIdleMotion = async function(motionManager) {
         return;
     }
     const expectedModel = this.currentModel;
+    const idleMotionRequestGeneration = this._idleMotionRequestGeneration || 0;
     const isCurrentIdleRequest = () => (
         this.currentModel === expectedModel
         && expectedModel
         && !expectedModel.destroyed
+        && (this._idleMotionRequestGeneration || 0) === idleMotionRequestGeneration
         && window._currentMotionPreviewId == null
         && !this._temporaryMotionSuspendToken
         && !this.isAvatarPerformanceCapabilityLocked('motion')
@@ -1804,6 +1807,35 @@ Live2DManager.prototype._playIdleMotion = async function(motionManager) {
         }
         this._trackActiveMotionParametersFromFile(file).catch(() => {});
     };
+    const stopStaleIdleMotion = (started) => {
+        const state = motionManager.state;
+        if (
+            started === false
+            || Number(state?.currentPriority ?? LIVE2D_MOTION_PRIORITY.NONE) !== LIVE2D_MOTION_PRIORITY.IDLE
+        ) {
+            return;
+        }
+
+        // IDLE 加载期间若被普通动作接管，SDK 仍可能在加载完成后启动旧 Idle。
+        // 停止该过期 Idle，同时保留正在加载的 NORMAL 动作预留。
+        const reservedGroup = state.reservedGroup;
+        const reservedIndex = state.reservedIndex;
+        const reservePriority = Number(state.reservePriority ?? LIVE2D_MOTION_PRIORITY.NONE);
+        try {
+            motionManager.stopAllMotions();
+        } catch (_) {
+            return;
+        }
+        if (reservePriority > LIVE2D_MOTION_PRIORITY.IDLE && reservedGroup !== undefined) {
+            if (typeof state.setReserved === 'function') {
+                state.setReserved(reservedGroup, reservedIndex, reservePriority);
+            } else {
+                state.reservePriority = reservePriority;
+                state.reservedGroup = reservedGroup;
+                state.reservedIndex = reservedIndex;
+            }
+        }
+    };
     const startTrackedMotion = async (groupName, index, file) => {
         if (!canStartIdleMotion()) return false;
         try {
@@ -1814,7 +1846,10 @@ Live2DManager.prototype._playIdleMotion = async function(motionManager) {
                 index,
                 LIVE2D_MOTION_PRIORITY.IDLE
             );
-            if (!isCurrentIdleRequest()) return false;
+            if (!isCurrentIdleRequest()) {
+                stopStaleIdleMotion(started);
+                return false;
+            }
             if (started === false) {
                 console.warn(`[Live2D] 启动 ${groupName} 待机动作失败，尝试下一个 Idle 候选`);
                 return false;
@@ -1889,7 +1924,10 @@ Live2DManager.prototype._playIdleMotion = async function(motionManager) {
             'Idle',
             LIVE2D_MOTION_PRIORITY.IDLE
         );
-        if (!isCurrentIdleRequest()) return;
+        if (!isCurrentIdleRequest()) {
+            stopStaleIdleMotion(started);
+            return;
+        }
         if (started === false) {
             this._clearActiveMotionParamIds();
             return;

--- a/static/live2d/live2d-model.js
+++ b/static/live2d/live2d-model.js
@@ -149,6 +149,14 @@ Live2DManager.prototype.playActionMotion = async function(groupName, index, trac
             await this._trackActiveMotionParametersFromFile(requestedFile);
         }
         if (this.currentModel !== model) return false;
+        const actionMotion = motionManager.motionGroups?.[groupName]?.[motionIndex];
+        if (actionMotion) {
+            if (typeof actionMotion.setIsLoop === 'function') {
+                actionMotion.setIsLoop(false);
+            } else if (actionMotion._loop !== undefined) {
+                actionMotion._loop = false;
+            }
+        }
         started = await model.motion(
             groupName,
             motionIndex,

--- a/static/live2d/live2d-model.js
+++ b/static/live2d/live2d-model.js
@@ -92,9 +92,9 @@ Live2DManager.prototype._startIdleMotion = async function(model, groupName, inde
         const ownsCurrentIdle = Number(state.currentPriority) === LIVE2D_MOTION_PRIORITY.IDLE
             && state.currentGroup === groupName
             && (index == null || state.currentIndex === index);
-        // NORMAL 加载期间保留当前 Idle，由 SDK 在动作真正开始时原子替换；
-        // 其他失效请求只停止自己刚启动的 Idle，不能误停更新的 Idle。
-        if (!actionActive && ownsCurrentIdle) {
+        // 只有待启动的 NORMAL 动作需要保留当前 Idle；简单动作没有 SDK reservation，
+        // 必须停止这条迟到的 Idle，避免二者叠加。
+        if ((!actionActive || this._simpleMotionActive === true) && ownsCurrentIdle) {
             motionManager._stopAllMotions();
             state.complete();
         }
@@ -166,6 +166,9 @@ Live2DManager.prototype.playActionMotion = async function(groupName, index, trac
         }
         if (state.reservedIdleGroup === idleBlock) {
             state.setReservedIdle(undefined, undefined);
+        }
+        if (started !== true && this.currentModel === model && motionManager.playing === false) {
+            this.setupIdleMotionLoop(model);
         }
     }
     if (started === false) {

--- a/static/live2d/live2d-model.js
+++ b/static/live2d/live2d-model.js
@@ -53,14 +53,42 @@ Live2DManager.prototype.playActionMotion = async function(groupName, index) {
         currentPriority === LIVE2D_MOTION_PRIORITY.IDLE
         || hasReservedIdle
     ) {
+        if (typeof this._clearMotionTimer === 'function') {
+            this._clearMotionTimer();
+        }
         motionManager.stopAllMotions();
     }
 
-    const started = await model.motion(
-        groupName,
-        index,
-        LIVE2D_MOTION_PRIORITY.NORMAL
-    );
+    const clearOwnedReservation = () => {
+        const currentState = motionManager.state;
+        if (!currentState || currentState !== state) return;
+        const ownsReservedGroup = currentState.reservedGroup === groupName;
+        const ownsReservedIndex = index == null || currentState.reservedIndex === index;
+        if (!ownsReservedGroup || !ownsReservedIndex) return;
+
+        if (typeof currentState.setReserved === 'function') {
+            currentState.setReserved(undefined, undefined, LIVE2D_MOTION_PRIORITY.NONE);
+        } else {
+            currentState.reservePriority = LIVE2D_MOTION_PRIORITY.NONE;
+            currentState.reservedGroup = undefined;
+            currentState.reservedIndex = undefined;
+        }
+    };
+
+    let started;
+    try {
+        started = await model.motion(
+            groupName,
+            index,
+            LIVE2D_MOTION_PRIORITY.NORMAL
+        );
+    } catch (error) {
+        clearOwnedReservation();
+        throw error;
+    }
+    if (started === false) {
+        clearOwnedReservation();
+    }
     if (this.currentModel !== model || started === false) {
         return false;
     }
@@ -166,9 +194,10 @@ Live2DManager.prototype.removeModel = async function(options = {}) {
     this._activeExpressionParamIds = null;
     this._activeMotionParamIds = null;
     this._motionParameterTrackGeneration = (this._motionParameterTrackGeneration || 0) + 1;
-    if (typeof this._nextMotionTimerGeneration === 'function') {
-        this._nextMotionTimerGeneration();
+    if (typeof this._clearMotionTimer === 'function') {
+        this._clearMotionTimer();
     } else {
+        this._simpleMotionActive = false;
         this._motionTimerGeneration = (this._motionTimerGeneration || 0) + 1;
     }
 

--- a/static/live2d/live2d-model.js
+++ b/static/live2d/live2d-model.js
@@ -16,6 +16,10 @@ const LIVE2D_MOTION_PRIORITY = Object.freeze({
 });
 
 Live2DManager.prototype.hasActiveActionMotion = function(model = this.currentModel) {
+    if (model === this.currentModel && this._simpleMotionActive === true) {
+        return true;
+    }
+
     const motionManager = model?.internalModel?.motionManager;
     const state = motionManager?.state;
     if (!motionManager || !state) return false;

--- a/static/live2d/live2d-model.js
+++ b/static/live2d/live2d-model.js
@@ -63,6 +63,30 @@ Live2DManager.prototype.playActionMotion = async function(groupName, index) {
     return started === undefined ? true : started;
 };
 
+/**
+ * 以 IDLE 优先级播放一个待机动作，不抢占正在加载或播放的普通动作。
+ */
+Live2DManager.prototype.playIdleMotion = async function(groupName, index) {
+    const model = this.currentModel;
+    const motionManager = model?.internalModel?.motionManager;
+    if (!model || typeof model.motion !== 'function' || !motionManager) {
+        return false;
+    }
+    if (this.hasActiveActionMotion(model)) {
+        return false;
+    }
+
+    const started = await model.motion(
+        groupName,
+        index,
+        LIVE2D_MOTION_PRIORITY.IDLE
+    );
+    if (this.currentModel !== model || started === false) {
+        return false;
+    }
+    return started === undefined ? true : started;
+};
+
 // 缓动函数集合（用于眨眼、口型等动画的平滑过渡）
 const Easing = {
     linear: (t) => t,
@@ -1705,6 +1729,10 @@ Live2DManager.prototype._playIdleMotion = async function(motionManager) {
         && !this._temporaryMotionSuspendToken
         && !this.isAvatarPerformanceCapabilityLocked('motion')
     );
+    const canStartIdleMotion = () => (
+        isCurrentIdleRequest()
+        && !this.hasActiveActionMotion(expectedModel)
+    );
     const getRandomizedIndexes = (length) => {
         const indexes = [];
         for (let i = 0; i < length; i++) indexes.push(i);
@@ -1744,7 +1772,7 @@ Live2DManager.prototype._playIdleMotion = async function(motionManager) {
         this._trackActiveMotionParametersFromFile(file).catch(() => {});
     };
     const startTrackedMotion = async (groupName, index, file) => {
-        if (!isCurrentIdleRequest()) return false;
+        if (!canStartIdleMotion()) return false;
         try {
             // Idle 必须使用 SDK 的 IDLE 优先级。若误用默认 NORMAL，后续普通动作
             // 会被当成同优先级动作拒绝，只能靠 FORCE 插入，进而造成动作叠播。
@@ -1822,7 +1850,7 @@ Live2DManager.prototype._playIdleMotion = async function(motionManager) {
         return;
     }
 
-    if (!isCurrentIdleRequest()) return;
+    if (!canStartIdleMotion()) return;
     try {
         const started = await motionManager.startRandomMotion(
             'Idle',
@@ -2275,7 +2303,9 @@ Live2DManager.prototype._configureLoadedModel = async function(model, modelPath,
     if (!suppressInitialIdle && (hasIdleInEmotionMapping || hasIdleInFileReferences)) {
         try {
             console.log('[Live2D Model] 模型淡入完成，开始播放Idle情绪');
-            this.setEmotion('Idle').catch(error => {
+            this.setEmotion('Idle', {
+                motionPriority: LIVE2D_MOTION_PRIORITY.IDLE
+            }).catch(error => {
                 console.warn('[Live2D Model] 播放Idle情绪失败:', error);
             });
         } catch (error) {

--- a/static/live2d/live2d-model.js
+++ b/static/live2d/live2d-model.js
@@ -57,7 +57,10 @@ Live2DManager.prototype.playActionMotion = async function(groupName, index) {
         index,
         LIVE2D_MOTION_PRIORITY.NORMAL
     );
-    return this.currentModel === model && started !== false;
+    if (this.currentModel !== model || started === false) {
+        return false;
+    }
+    return started === undefined ? true : started;
 };
 
 // 缓动函数集合（用于眨眼、口型等动画的平滑过渡）

--- a/tests/unit/test_live2d_interaction_static_contracts.py
+++ b/tests/unit/test_live2d_interaction_static_contracts.py
@@ -166,7 +166,7 @@ def test_live2d_random_click_prefers_motion_and_uses_expression_as_fallback():
     motion_branch = click_effect.index("if (motions && motions.length > 0)")
     expression_fallback = click_effect.index("if (!didPlayEffect && expressionFiles.length > 0)")
     assert motion_branch < expression_fallback
-    assert "const motion = await this.currentModel.motion(motionGroup, undefined, priority);" in click_effect
+    assert "const motion = await this.playActionMotion(motionGroup, undefined);" in click_effect
     assert "triggerLog.motions.push({" in click_effect
     assert "triggerLog.expressions.push({ emotion, file: choiceFile, fallbackFor: 'motion' });" in click_effect
 

--- a/tests/unit/test_live2d_motion_exclusivity_static.py
+++ b/tests/unit/test_live2d_motion_exclusivity_static.py
@@ -179,6 +179,22 @@ def test_expression_slot_replaces_transient_expression_but_preserves_action():
     assert result.returncode == 0, result.stderr
 
 
+def test_untimed_simple_motion_does_not_leave_stale_parameter_ownership():
+    result = _run_node(
+        """
+        const manager = new context.Live2DManager();
+        manager.currentModel = {
+          internalModel: { coreModel: { setParameterValueById() {} } },
+        };
+        assert.strictEqual(manager.playSimpleMotion('custom'), true);
+        assert.strictEqual(manager._activeMotionParamIds, null);
+        assert.strictEqual(manager._simpleMotionActive, false);
+        """,
+        emotion=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
 def test_all_runtime_entries_use_the_central_slots_before_side_effects():
     model = MODEL.read_text(encoding="utf-8")
     emotion = EMOTION.read_text(encoding="utf-8")

--- a/tests/unit/test_live2d_motion_exclusivity_static.py
+++ b/tests/unit/test_live2d_motion_exclusivity_static.py
@@ -89,7 +89,7 @@ def test_motion_slot_rejects_actions_and_replaces_idle_without_races():
           const action = new context.Live2DManager(); action.currentModel = makeModel(actionMM);
           action._clearMotionTimer = () => actionEvents.push('clear-timer');
           assert.strictEqual(await action.playActionMotion('Tap', 0), true);
-          assert.deepStrictEqual(actionEvents, ['clear-timer', 'stop', 'start:Tap']);
+          assert.deepStrictEqual(actionEvents, ['clear-timer', 'start:Tap']);
 
           const failedMM = makeMotionManager([], () => false);
           const failed = new context.Live2DManager(); failed.currentModel = makeModel(failedMM);
@@ -119,11 +119,45 @@ def test_motion_slot_rejects_actions_and_replaces_idle_without_races():
           const actionPromise = manager.playActionMotion('Tap', 0);
           resolveIdle();
           assert.strictEqual(await idlePromise, false);
-          assert.strictEqual(deferredMM.state.currentPriority, 0);
+          assert.strictEqual(deferredMM.state.currentPriority, 1);
           assert.strictEqual(deferredMM.state.reservePriority, 2);
           resolveAction();
           assert.strictEqual(await actionPromise, true);
           assert.strictEqual(deferredMM.state.currentPriority, 2);
+
+          let resolveEmptyAction;
+          const emptyMM = makeMotionManager([], () => new Promise((resolve) => { resolveEmptyAction = resolve; }));
+          const empty = new context.Live2DManager(); empty.currentModel = makeModel(emptyMM);
+          const emptyAction = empty.playActionMotion('Tap', 0);
+          assert.notStrictEqual(emptyMM.state.reservedIdleGroup, undefined);
+          resolveEmptyAction(true);
+          assert.strictEqual(await emptyAction, true);
+          assert.strictEqual(emptyMM.state.reservedIdleGroup, undefined);
+
+          const staleStarts = [], staleResolvers = {};
+          const staleMM = makeMotionManager([], (state, group, index) => {
+            const key = `${group}:${index}`;
+            staleStarts.push(key);
+            if (staleStarts.length > 2) return false;
+            return new Promise((resolve) => {
+              staleResolvers[key] = () => {
+                state.setReservedIdle(undefined, undefined);
+                if (state.currentPriority !== 0) return resolve(false);
+                state.setCurrent(group, index, 1); resolve(true);
+              };
+            });
+          });
+          staleMM.definitions = { Idle: [{ File: 'a.motion3.json' }, { File: 'b.motion3.json' }] };
+          const stale = new context.Live2DManager(); stale.currentModel = makeModel(staleMM);
+          stale.isAvatarPerformanceCapabilityLocked = () => false;
+          const staleLoop = stale._playIdleMotion(staleMM);
+          while (staleStarts.length === 0) await new Promise((resolve) => setTimeout(resolve, 0));
+          const staleKey = staleStarts[0];
+          const savedIdle = stale.playIdleMotion('Saved', 0);
+          staleResolvers['Saved:0'](); assert.strictEqual(await savedIdle, true);
+          staleResolvers[staleKey](); await staleLoop;
+          assert.deepStrictEqual(staleStarts, [staleKey, 'Saved:0']);
+          assert.strictEqual(staleMM.state.currentGroup, 'Saved');
         })().catch((error) => { console.error(error); process.exitCode = 1; });
         """
     )
@@ -150,11 +184,20 @@ def test_expression_slot_replaces_transient_expression_but_preserves_action():
           manager.resetTransientMotionAndExpressionState = async (options) => { manager.resetOptions = options; };
           manager.playExpression = async () => { manager.expressionPlayed = true; return true; };
           manager.playMotion = async () => { manager.motionAttempted = true; return false; };
-          await manager.setEmotion('happy');
+          assert.strictEqual(await manager.setEmotion('happy'), true);
           assert.strictEqual(manager.expressionPlayed && manager.motionAttempted, true);
           assert.strictEqual(manager.resetOptions.preserveMotion, true);
           assert.strictEqual(state.currentPriority, 2);
           assert.strictEqual(manager.persistentApplied, true);
+
+          const clearing = new context.Live2DManager();
+          clearing.currentModel = {
+            internalModel: { coreModel: {}, motionManager: { expressionManager: { stopAllExpressions() {} } } },
+          };
+          clearing._cancelSmoothReset = () => {};
+          clearing._resetParametersToInitialState = () => { throw new Error('must not reset action parameters'); };
+          clearing.applyPersistentExpressionsNative = async () => {};
+          assert.strictEqual(clearing.clearExpression({ preserveMotion: true }), true);
 
           const expressions = new context.Live2DManager(), resolvers = {};
           expressions.currentModel = {
@@ -166,6 +209,7 @@ def test_expression_slot_replaces_transient_expression_but_preserves_action():
           expressions.resolveAssetPath = (file) => file;
           expressions.clearExpression = function() {
             this.clearCount = (this.clearCount || 0) + 1;
+            assert.strictEqual(arguments[0].preserveMotion, true);
             this._transientExpressionGeneration = (this._transientExpressionGeneration || 0) + 1;
           };
           expressions.applyPersistentExpressionsNative = async () => {};

--- a/tests/unit/test_live2d_motion_exclusivity_static.py
+++ b/tests/unit/test_live2d_motion_exclusivity_static.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+LIVE2D_MODEL_PATH = PROJECT_ROOT / "static" / "live2d" / "live2d-model.js"
+LIVE2D_INTERACTION_PATH = PROJECT_ROOT / "static" / "live2d" / "live2d-interaction.js"
+MODEL_RELOAD_PATH = (
+    PROJECT_ROOT
+    / "static"
+    / "app"
+    / "app-interpage"
+    / "bootstrap-resources-and-model-reload.js"
+)
+
+
+def test_idle_motion_starts_with_idle_priority():
+    source = LIVE2D_MODEL_PATH.read_text(encoding="utf-8")
+    idle_start = source[
+        source.index("const startTrackedMotion = async") : source.index(
+            "// 配置已加载的模型", source.index("const startTrackedMotion = async")
+        )
+    ]
+
+    tracked_idle_call = (
+        "motionManager.startMotion(\n"
+        "                groupName,\n"
+        "                index,\n"
+        "                LIVE2D_MOTION_PRIORITY.IDLE"
+    )
+    random_idle_call = (
+        "motionManager.startRandomMotion(\n"
+        "            'Idle',\n"
+        "            LIVE2D_MOTION_PRIORITY.IDLE"
+    )
+    assert tracked_idle_call in idle_start
+    assert random_idle_call in idle_start
+
+
+def test_main_action_entry_rejects_a_second_action_and_stops_only_idle():
+    source = LIVE2D_MODEL_PATH.read_text(encoding="utf-8")
+    action_start = source.index("Live2DManager.prototype.playActionMotion")
+    action_end = source.index("// 缓动函数集合", action_start)
+    action_source = source[action_start:action_end]
+
+    assert "this.hasActiveActionMotion(model)" in action_source
+    assert "return false" in action_source
+    assert "currentPriority === LIVE2D_MOTION_PRIORITY.IDLE" in action_source
+    assert "motionManager.stopAllMotions()" in action_source
+    assert "LIVE2D_MOTION_PRIORITY.NORMAL" in action_source
+
+
+def test_touch_actions_use_normal_priority_without_force_preemption():
+    source = LIVE2D_INTERACTION_PATH.read_text(encoding="utf-8")
+    touch_start = source.index("Live2DManager.prototype._playTouchSetAnimation")
+    touch_source = source[touch_start:]
+
+    assert "this.playActionMotion(groupName, 0)" in touch_source
+    assert "live2dModel.motion(groupName, 0, 3)" not in touch_source
+
+
+def test_all_main_runtime_motion_entry_points_use_the_single_action_gate():
+    emotion_source = (
+        PROJECT_ROOT / "static" / "live2d" / "live2d-emotion.js"
+    ).read_text(encoding="utf-8")
+    interaction_source = LIVE2D_INTERACTION_PATH.read_text(encoding="utf-8")
+    performance_source = (
+        PROJECT_ROOT / "static" / "avatar" / "avatar-performance-stage.js"
+    ).read_text(encoding="utf-8")
+
+    assert "await this.playActionMotion(" in emotion_source
+    assert interaction_source.count("await this.playActionMotion(") >= 3
+    assert performance_source.count("manager.playActionMotion(") >= 2
+
+
+def test_saved_idle_motion_does_not_use_force_priority():
+    source = MODEL_RELOAD_PATH.read_text(encoding="utf-8")
+    restore_start = source.index("async function restoreLive2DIdleAnimationOnMainPage")
+    restore_end = source.index("window.restoreLive2DIdleAnimationOnMainPage", restore_start)
+    restore_source = source[restore_start:restore_end]
+
+    assert "live2dManager.hasActiveActionMotion(live2dModel)" in restore_source
+    action_guard_index = restore_source.index(
+        "live2dManager.hasActiveActionMotion(live2dModel)"
+    )
+    stop_idle_index = restore_source.index("motionManager.stopAllMotions()")
+    assert action_guard_index < stop_idle_index
+    assert "LIVE2D_MOTION_PRIORITY.IDLE" in restore_source
+    assert "live2dModel.motion(groupName, motionIndex, 3)" not in restore_source

--- a/tests/unit/test_live2d_motion_exclusivity_static.py
+++ b/tests/unit/test_live2d_motion_exclusivity_static.py
@@ -158,6 +158,19 @@ def test_motion_slot_rejects_actions_and_replaces_idle_without_races():
           staleResolvers[staleKey](); await staleLoop;
           assert.deepStrictEqual(staleStarts, [staleKey, 'Saved:0']);
           assert.strictEqual(staleMM.state.currentGroup, 'Saved');
+
+          let resolveFallback;
+          const fallbackMM = makeMotionManager();
+          fallbackMM.definitions = {}; fallbackMM.motionGroups = {};
+          const fallback = new context.Live2DManager(); fallback.currentModel = makeModel(fallbackMM);
+          fallback.isAvatarPerformanceCapabilityLocked = () => false;
+          fallback._startIdleMotion = () => new Promise((resolve) => { resolveFallback = resolve; });
+          fallback._clearActiveMotionParamIds = () => { throw new Error('stale fallback cleared newer tracking'); };
+          const fallbackLoop = fallback._playIdleMotion(fallbackMM);
+          while (!resolveFallback) await new Promise((resolve) => setTimeout(resolve, 0));
+          fallback._idleLoopRequestGeneration++;
+          resolveFallback(false);
+          await fallbackLoop;
         })().catch((error) => { console.error(error); process.exitCode = 1; });
         """
     )
@@ -191,13 +204,23 @@ def test_expression_slot_replaces_transient_expression_but_preserves_action():
           assert.strictEqual(manager.persistentApplied, true);
 
           const clearing = new context.Live2DManager();
+          const resetParams = [];
+          const expressionManager = { reserveExpressionIndex: 3, stopAllExpressions() {} };
           clearing.currentModel = {
-            internalModel: { coreModel: {}, motionManager: { expressionManager: { stopAllExpressions() {} } } },
+            internalModel: {
+              coreModel: { setParameterValueById(id, value) { resetParams.push([id, value]); } },
+              motionManager: { expressionManager },
+            },
           };
           clearing._cancelSmoothReset = () => {};
           clearing._resetParametersToInitialState = () => { throw new Error('must not reset action parameters'); };
           clearing.applyPersistentExpressionsNative = async () => {};
+          clearing.initialParameters = { ParamAngleX: 0, ParamEyeLOpen: 1 };
+          clearing._activeExpressionParamIds = new Set(['ParamAngleX', 'ParamEyeLOpen']);
+          clearing._setActiveMotionParamIds(['ParamAngleX']);
           assert.strictEqual(clearing.clearExpression({ preserveMotion: true }), true);
+          assert.strictEqual(expressionManager.reserveExpressionIndex, -1);
+          assert.deepStrictEqual(resetParams, [['ParamEyeLOpen', 1]]);
 
           const expressions = new context.Live2DManager(), resolvers = {};
           expressions.currentModel = {

--- a/tests/unit/test_live2d_motion_exclusivity_static.py
+++ b/tests/unit/test_live2d_motion_exclusivity_static.py
@@ -287,6 +287,101 @@ def test_model_removal_clears_simple_motion_gate_with_motion_timer():
     assert result.returncode == 0, result.stderr
 
 
+def test_action_invalidates_an_idle_motion_that_finishes_loading_late():
+    script = _manager_harness(
+        """
+        (async () => {
+          let resolveIdle;
+          let resolveAction;
+          let stopCount = 0;
+          const state = {
+            currentPriority: 0,
+            reservePriority: 0,
+            currentGroup: undefined,
+            currentIndex: undefined,
+            reservedGroup: undefined,
+            reservedIndex: undefined,
+            reservedIdleGroup: 'Idle',
+            reservedIdleIndex: 0,
+            setReserved(group, index, priority) {
+              this.reservedGroup = group;
+              this.reservedIndex = index;
+              this.reservePriority = priority;
+            },
+            setCurrent(group, index, priority) {
+              this.currentGroup = group;
+              this.currentIndex = index;
+              this.currentPriority = priority;
+            },
+          };
+          const motionManager = {
+            state,
+            definitions: { Idle: [{ File: 'idle.motion3.json' }] },
+            motionGroups: {},
+            startMotion() {
+              return new Promise((resolve) => {
+                resolveIdle = () => {
+                  state.reservedIdleGroup = undefined;
+                  state.reservedIdleIndex = undefined;
+                  state.setCurrent('Idle', 0, 1);
+                  resolve(true);
+                };
+              });
+            },
+            startRandomMotion: async () => false,
+            stopAllMotions() {
+              stopCount += 1;
+              state.setCurrent(undefined, undefined, 0);
+              state.setReserved(undefined, undefined, 0);
+              state.reservedIdleGroup = undefined;
+              state.reservedIdleIndex = undefined;
+            },
+          };
+          const manager = new context.Live2DManager();
+          manager.isAvatarPerformanceCapabilityLocked = () => false;
+          manager._clearMotionTimer = () => {};
+          manager._clearActiveMotionParamIds = () => {};
+          manager._trackActiveMotionParametersFromFile = async () => {};
+          const model = {
+            destroyed: false,
+            internalModel: { motionManager },
+            motion(group, index, priority) {
+              state.setReserved(group, index, priority);
+              return new Promise((resolve) => {
+                resolveAction = () => {
+                  state.setReserved(undefined, undefined, 0);
+                  state.setCurrent(group, index, priority);
+                  resolve(true);
+                };
+              });
+            },
+          };
+          manager.currentModel = model;
+
+          const idlePromise = manager._playIdleMotion(motionManager);
+          const actionPromise = manager.playActionMotion('Tap', 0);
+          assert.strictEqual(typeof resolveIdle, 'function');
+          assert.strictEqual(typeof resolveAction, 'function');
+
+          resolveIdle();
+          await idlePromise;
+          assert.strictEqual(stopCount, 2);
+          assert.strictEqual(state.currentPriority, 0);
+          assert.strictEqual(state.reservePriority, 2);
+          assert.strictEqual(state.reservedGroup, 'Tap');
+          assert.strictEqual(state.reservedIndex, 0);
+
+          resolveAction();
+          assert.strictEqual(await actionPromise, true);
+          assert.strictEqual(state.currentPriority, 2);
+          assert.strictEqual(state.currentGroup, 'Tap');
+        })().catch((error) => { console.error(error); process.exitCode = 1; });
+        """
+    )
+    result = _run_node_harness(script)
+    assert result.returncode == 0, result.stderr
+
+
 def test_performance_session_checks_action_gate_before_suspending_motions():
     source = (
         PROJECT_ROOT / "static" / "avatar" / "avatar-performance-stage.js"

--- a/tests/unit/test_live2d_motion_exclusivity_static.py
+++ b/tests/unit/test_live2d_motion_exclusivity_static.py
@@ -47,6 +47,7 @@ def test_main_action_entry_rejects_a_second_action_and_stops_only_idle():
     assert "currentPriority === LIVE2D_MOTION_PRIORITY.IDLE" in action_source
     assert "motionManager.stopAllMotions()" in action_source
     assert "LIVE2D_MOTION_PRIORITY.NORMAL" in action_source
+    assert "return started === undefined ? true : started" in action_source
 
 
 def test_touch_actions_use_normal_priority_without_force_preemption():

--- a/tests/unit/test_live2d_motion_exclusivity_static.py
+++ b/tests/unit/test_live2d_motion_exclusivity_static.py
@@ -15,10 +15,9 @@ MODEL_RELOAD_PATH = (
 
 def test_idle_motion_starts_with_idle_priority():
     source = LIVE2D_MODEL_PATH.read_text(encoding="utf-8")
+    idle_method_start = source.index("Live2DManager.prototype._playIdleMotion")
     idle_start = source[
-        source.index("const startTrackedMotion = async") : source.index(
-            "// 配置已加载的模型", source.index("const startTrackedMotion = async")
-        )
+        idle_method_start : source.index("// 配置已加载的模型", idle_method_start)
     ]
 
     tracked_idle_call = (
@@ -34,6 +33,8 @@ def test_idle_motion_starts_with_idle_priority():
     )
     assert tracked_idle_call in idle_start
     assert random_idle_call in idle_start
+    assert idle_start.count("canStartIdleMotion()") >= 2
+    assert "!this.hasActiveActionMotion(expectedModel)" in idle_start
 
 
 def test_main_action_entry_rejects_a_second_action_and_stops_only_idle():
@@ -71,6 +72,42 @@ def test_all_main_runtime_motion_entry_points_use_the_single_action_gate():
     assert "await this.playActionMotion(" in emotion_source
     assert interaction_source.count("await this.playActionMotion(") >= 3
     assert performance_source.count("manager.playActionMotion(") >= 2
+
+
+def test_emotion_motion_checks_the_gate_before_resetting_existing_motion():
+    source = (
+        PROJECT_ROOT / "static" / "live2d" / "live2d-emotion.js"
+    ).read_text(encoding="utf-8")
+    play_motion_start = source.index("Live2DManager.prototype.playMotion")
+    play_motion_end = source.index("// 播放简单动作", play_motion_start)
+    play_motion_source = source[play_motion_start:play_motion_end]
+    set_emotion_start = source.index("Live2DManager.prototype.setEmotion")
+    set_emotion_end = source.index("// 同步服务器端的情绪映射", set_emotion_start)
+    set_emotion_source = source[set_emotion_start:set_emotion_end]
+
+    for block in (play_motion_source, set_emotion_source):
+        action_guard_index = block.index("this.hasActiveActionMotion(this.currentModel)")
+        reset_index = block.index("resetTransientMotionAndExpressionState")
+        assert action_guard_index < reset_index
+
+    smooth_reset_index = set_emotion_source.index("smoothResetToInitialState")
+    guard_after_smooth_reset = set_emotion_source.index(
+        "this.hasActiveActionMotion(this.currentModel)", smooth_reset_index
+    )
+    destructive_reset_index = set_emotion_source.index(
+        "resetTransientMotionAndExpressionState", smooth_reset_index
+    )
+    assert smooth_reset_index < guard_after_smooth_reset < destructive_reset_index
+
+
+def test_startup_idle_emotion_uses_idle_priority():
+    source = LIVE2D_MODEL_PATH.read_text(encoding="utf-8")
+    configure_start = source.index("Live2DManager.prototype._configureLoadedModel")
+    configure_source = source[configure_start:]
+
+    assert "this.setEmotion('Idle', {" in configure_source
+    assert "motionPriority: LIVE2D_MOTION_PRIORITY.IDLE" in configure_source
+    assert "Live2DManager.prototype.playIdleMotion" in source
 
 
 def test_saved_idle_motion_does_not_use_force_priority():

--- a/tests/unit/test_live2d_motion_exclusivity_static.py
+++ b/tests/unit/test_live2d_motion_exclusivity_static.py
@@ -206,7 +206,10 @@ def test_all_runtime_entries_use_the_central_slots_before_side_effects():
     action_slot = model[model.index("Live2DManager.prototype.playActionMotion") : model.index("Live2DManager.prototype.playIdleMotion")]
     assert "state.setReservedIdle(idleBlock, undefined)" in action_slot
     assert "state.reservedIdleGroup === idleBlock" in action_slot
-    assert "this._trackActiveMotionParametersFromFile(startedFile)" in action_slot
+    assert "await this._trackActiveMotionParametersFromFile(requestedFile)" in action_slot
+    assert "this._actionMotionRequestPendingModel = model" in action_slot
+    assert "if (this._actionMotionRequestPendingModel === model)" in model
+    assert "await this.setEmotion('Idle', {" in model
     idle_fallback = model[model.index("const started = await this._startIdleMotion(expectedModel, 'Idle');") : model.index("Live2DManager.prototype._configureLoadedModel")]
     assert idle_fallback.index("if (!isCurrentIdleRequest()) return;") < idle_fallback.index("if (started === false)")
 

--- a/tests/unit/test_live2d_motion_exclusivity_static.py
+++ b/tests/unit/test_live2d_motion_exclusivity_static.py
@@ -203,11 +203,15 @@ def test_all_runtime_entries_use_the_central_slots_before_side_effects():
     assert acquire.index("manager.hasActiveActionMotion(model)") < acquire.index(
         "manager.suspendTemporaryMotions("
     )
+    performance_clear = performance[performance.index("async clearExpression() {") : performance.index("hasMotion(group, options)")]
+    assert "preserveMotion: true" in performance_clear
     action_slot = model[model.index("Live2DManager.prototype.playActionMotion") : model.index("Live2DManager.prototype.playIdleMotion")]
     assert "state.setReservedIdle(idleBlock, undefined)" in action_slot
     assert "state.reservedIdleGroup === idleBlock" in action_slot
     assert "await this._trackActiveMotionParametersFromFile(requestedFile)" in action_slot
     assert "this._actionMotionRequestPendingModel = model" in action_slot
+    assert "started !== true && this.currentModel === model && motionManager.playing === false" in action_slot
+    assert "(!actionActive || this._simpleMotionActive === true) && ownsCurrentIdle" in model
     assert "if (this._actionMotionRequestPendingModel === model)" in model
     assert "await this.setEmotion('Idle', {" in model
     idle_fallback = model[model.index("const started = await this._startIdleMotion(expectedModel, 'Idle');") : model.index("Live2DManager.prototype._configureLoadedModel")]

--- a/tests/unit/test_live2d_motion_exclusivity_static.py
+++ b/tests/unit/test_live2d_motion_exclusivity_static.py
@@ -44,6 +44,7 @@ def test_main_action_entry_rejects_a_second_action_and_stops_only_idle():
     action_source = source[action_start:action_end]
 
     assert "this.hasActiveActionMotion(model)" in action_source
+    assert "this._simpleMotionActive === true" in source
     assert "return false" in action_source
     assert "currentPriority === LIVE2D_MOTION_PRIORITY.IDLE" in action_source
     assert "motionManager.stopAllMotions()" in action_source
@@ -98,6 +99,39 @@ def test_emotion_motion_checks_the_gate_before_resetting_existing_motion():
         "resetTransientMotionAndExpressionState", smooth_reset_index
     )
     assert smooth_reset_index < guard_after_smooth_reset < destructive_reset_index
+
+
+def test_simple_motion_fallback_does_not_overlap_an_action():
+    source = (
+        PROJECT_ROOT / "static" / "live2d" / "live2d-emotion.js"
+    ).read_text(encoding="utf-8")
+    play_motion_start = source.index("Live2DManager.prototype.playMotion")
+    play_motion_end = source.index("// 播放简单动作", play_motion_start)
+    play_motion_source = source[play_motion_start:play_motion_end]
+    motion_result_index = play_motion_source.index("const motion =")
+    late_action_guard_index = play_motion_source.index(
+        "this.hasActiveActionMotion(this.currentModel)", motion_result_index
+    )
+    simple_fallback_index = play_motion_source.index(
+        "this.playSimpleMotion(emotion)", motion_result_index
+    )
+    assert motion_result_index < late_action_guard_index < simple_fallback_index
+
+    simple_start = source.index("Live2DManager.prototype.playSimpleMotion")
+    simple_end = source.index("// 清理当前情感效果", simple_start)
+    simple_source = source[simple_start:simple_end]
+    centralized_guard_index = simple_source.index(
+        "this.hasActiveActionMotion(this.currentModel)"
+    )
+    parameter_write_index = simple_source.index("_setActiveMotionParamIds")
+    assert centralized_guard_index < parameter_write_index
+    assert "this._simpleMotionActive = true" in simple_source
+
+    clear_timer_start = source.index("Live2DManager.prototype._clearMotionTimer")
+    clear_timer_end = source.index(
+        "Live2DManager.prototype._resetExplicitMotionParameters", clear_timer_start
+    )
+    assert "this._simpleMotionActive = false" in source[clear_timer_start:clear_timer_end]
 
 
 def test_startup_idle_emotion_uses_idle_priority():

--- a/tests/unit/test_live2d_motion_exclusivity_static.py
+++ b/tests/unit/test_live2d_motion_exclusivity_static.py
@@ -84,10 +84,13 @@ def test_motion_slot_rejects_actions_and_replaces_idle_without_races():
           assert.strictEqual(busyMM.state.currentGroup, 'Busy');
           const actionEvents = [], actionMM = makeMotionManager(actionEvents);
           actionMM.state.setCurrent('Idle', 0, 1);
+          const cachedAction = { setIsLoop(value) { this.loop = value; }, loop: true };
+          actionMM.motionGroups = { Tap: [cachedAction] };
           const action = new context.Live2DManager(); action.currentModel = makeModel(actionMM);
           action._clearMotionTimer = () => actionEvents.push('clear-timer');
           assert.strictEqual(await action.playActionMotion('Tap', 0), true);
           assert.deepStrictEqual(actionEvents, ['clear-timer', 'start:Tap']);
+          assert.strictEqual(cachedAction.loop, false);
           const failedMM = makeMotionManager([], () => false);
           const failed = new context.Live2DManager(); failed.currentModel = makeModel(failedMM);
           assert.strictEqual(await failed.playActionMotion('Missing', 0), false);
@@ -238,6 +241,12 @@ def test_all_runtime_entries_use_the_central_slots_before_side_effects():
     recorded_reset = emotion[emotion.index("Live2DManager.prototype._resetRecordedParameterIds") : emotion.index("Live2DManager.prototype._getDefaultMotionParameterIds")]
     assert "options.preserveMotion === true" in recorded_reset
     assert "this.clearExpression({ preserveMotion: true })" in interaction
+    tutorial_fallback = interaction[
+        interaction.index("const playedMotion = await this.playTutorialMotion();") : interaction.index(
+            "return false;", interaction.index("const playedMotion = await this.playTutorialMotion();")
+        )
+    ]
+    assert "if (!playedMotion && !this.hasActiveActionMotion(this.currentModel))" in tutorial_fallback
     motion_start_index = emotion.index("const motion = options.motionPriority")
     first_motion_check = emotion.index("if (motion) {", motion_start_index)
     motion_start = emotion[motion_start_index : emotion.index("if (motion) {", first_motion_check + 1)]

--- a/tests/unit/test_live2d_motion_exclusivity_static.py
+++ b/tests/unit/test_live2d_motion_exclusivity_static.py
@@ -77,34 +77,29 @@ def test_motion_slot_rejects_actions_and_replaces_idle_without_races():
             internalModel: { motionManager: mm },
             motion(group, index, priority) { return mm.startMotion(group, index, priority); },
           });
-
           const busyMM = makeMotionManager();
           busyMM.state.setCurrent('Busy', 0, 2);
           const busy = new context.Live2DManager(); busy.currentModel = makeModel(busyMM);
           assert.strictEqual(await busy.playActionMotion('Next', 0), false);
           assert.strictEqual(busyMM.state.currentGroup, 'Busy');
-
           const actionEvents = [], actionMM = makeMotionManager(actionEvents);
           actionMM.state.setCurrent('Idle', 0, 1);
           const action = new context.Live2DManager(); action.currentModel = makeModel(actionMM);
           action._clearMotionTimer = () => actionEvents.push('clear-timer');
           assert.strictEqual(await action.playActionMotion('Tap', 0), true);
           assert.deepStrictEqual(actionEvents, ['clear-timer', 'start:Tap']);
-
           const failedMM = makeMotionManager([], () => false);
           const failed = new context.Live2DManager(); failed.currentModel = makeModel(failedMM);
           assert.strictEqual(await failed.playActionMotion('Missing', 0), false);
           assert.strictEqual(failedMM.state.reservedGroup, undefined);
           assert.strictEqual(await failed.playIdleMotion('Idle', 0), false);
           assert.strictEqual(failedMM.state.reservedIdleGroup, undefined);
-
           const idleEvents = [], idleMM = makeMotionManager(idleEvents);
           idleMM.state.setCurrent('OldIdle', 0, 1);
           const idle = new context.Live2DManager(); idle.currentModel = makeModel(idleMM);
           idle._clearMotionTimer = () => idleEvents.push('clear-timer');
           assert.strictEqual(await idle.playIdleMotion('SavedIdle', 0), true);
           assert.deepStrictEqual(idleEvents, ['clear-timer', 'stop', 'start:SavedIdle']);
-
           let resolveIdle, resolveAction;
           const deferredMM = makeMotionManager([], (state, group, index, priority) => new Promise((resolve) => {
             const finish = () => {
@@ -124,7 +119,6 @@ def test_motion_slot_rejects_actions_and_replaces_idle_without_races():
           resolveAction();
           assert.strictEqual(await actionPromise, true);
           assert.strictEqual(deferredMM.state.currentPriority, 2);
-
         })().catch((error) => { console.error(error); process.exitCode = 1; });
         """
     )
@@ -156,7 +150,6 @@ def test_expression_slot_replaces_transient_expression_but_preserves_action():
           assert.strictEqual(manager.resetOptions.preserveMotion, true);
           assert.strictEqual(state.currentPriority, 2);
           assert.strictEqual(manager.persistentApplied, true);
-
           const expressions = new context.Live2DManager(), resolvers = {};
           expressions.currentModel = {
             internalModel: { motionManager: { state: { currentPriority: 0, reservePriority: 0 } } },
@@ -172,7 +165,6 @@ def test_expression_slot_replaces_transient_expression_but_preserves_action():
           };
           expressions.applyPersistentExpressionsNative = async () => {};
           context.fetch = async () => ({ ok: true, json: async () => ({ Parameters: [] }) });
-
           const first = expressions.playExpression('first', 'a.exp3.json');
           while (!resolvers.a) await new Promise((resolve) => setTimeout(resolve, 0));
           const second = expressions.playExpression('second', 'b.exp3.json');
@@ -180,7 +172,6 @@ def test_expression_slot_replaces_transient_expression_but_preserves_action():
           resolvers.b(true); assert.strictEqual(await second, true);
           resolvers.a(true); assert.strictEqual(await first, false);
           assert.strictEqual(expressions.clearCount, 2);
-
         })().catch((error) => { console.error(error); process.exitCode = 1; });
         """,
         emotion=True,
@@ -212,11 +203,10 @@ def test_all_runtime_entries_use_the_central_slots_before_side_effects():
     assert acquire.index("manager.hasActiveActionMotion(model)") < acquire.index(
         "manager.suspendTemporaryMotions("
     )
-
     action_slot = model[model.index("Live2DManager.prototype.playActionMotion") : model.index("Live2DManager.prototype.playIdleMotion")]
     assert "state.setReservedIdle(idleBlock, undefined)" in action_slot
     assert "state.reservedIdleGroup === idleBlock" in action_slot
-
+    assert "this._trackActiveMotionParametersFromFile(startedFile)" in action_slot
     idle_fallback = model[model.index("const started = await this._startIdleMotion(expectedModel, 'Idle');") : model.index("Live2DManager.prototype._configureLoadedModel")]
     assert idle_fallback.index("if (!isCurrentIdleRequest()) return;") < idle_fallback.index("if (started === false)")
 
@@ -224,7 +214,7 @@ def test_all_runtime_entries_use_the_central_slots_before_side_effects():
     assert "expressionManager.reserveExpressionIndex = -1" in clear_expression
     recorded_reset = emotion[emotion.index("Live2DManager.prototype._resetRecordedParameterIds") : emotion.index("Live2DManager.prototype._getDefaultMotionParameterIds")]
     assert "options.preserveMotion === true" in recorded_reset
-
+    assert "this.clearExpression({ preserveMotion: true })" in interaction
     motion_start_index = emotion.index("const motion = options.motionPriority")
     first_motion_check = emotion.index("if (motion) {", motion_start_index)
     motion_start = emotion[motion_start_index : emotion.index("if (motion) {", first_motion_check + 1)]

--- a/tests/unit/test_live2d_motion_exclusivity_static.py
+++ b/tests/unit/test_live2d_motion_exclusivity_static.py
@@ -245,6 +245,44 @@ def test_expression_slot_replaces_transient_expression_but_preserves_action():
           resolvers.b(true); assert.strictEqual(await second, true);
           resolvers.a(true); assert.strictEqual(await first, false);
           assert.strictEqual(expressions.clearCount, 2);
+
+          const tracking = new context.Live2DManager();
+          const trackingState = {
+            currentPriority: 0, reservePriority: 0,
+            setReservedIdle(group, index) { this.reservedIdleGroup = group; this.reservedIdleIndex = index; },
+          };
+          const trackingMM = {
+            state: trackingState,
+            definitions: { happy: [{ File: 'happy.motion3.json' }] },
+          };
+          tracking.currentModel = {
+            internalModel: { motionManager: trackingMM },
+            motion(group, index) {
+              Object.assign(trackingState, { currentGroup: group, currentIndex: index, currentPriority: 2 });
+              return true;
+            },
+          };
+          Object.assign(tracking, {
+            fileReferences: { Motions: { happy: [{ File: 'happy.motion3.json' }] } },
+            emotionMapping: { motions: {} },
+            isAvatarPerformanceCapabilityLocked: () => false,
+            resolveAssetPath: (file) => file,
+            resetTransientMotionAndExpressionState: async () => {
+              await Promise.resolve();
+              Object.assign(trackingState, { currentGroup: 'Idle', currentIndex: 0, currentPriority: 1 });
+              const generation = tracking._nextMotionTimerGeneration();
+              tracking.motionTimer = { type: 'timeout', id: setTimeout(() => {}, 1000), generation };
+            },
+          });
+          context.fetch = async () => ({
+            ok: true,
+            json: async () => ({ Meta: { Duration: 1 }, Curves: [{ Target: 'Parameter', Id: 'ParamAngleX' }] }),
+          });
+          assert.strictEqual(await tracking.playMotion('happy'), true);
+          assert.strictEqual(trackingState.currentPriority, 2);
+          assert.strictEqual(tracking._activeMotionParamIds.has('ParamAngleX'), true);
+          assert.strictEqual(tracking.motionTimer.type, 'timeout');
+          tracking._clearMotionTimer();
         })().catch((error) => { console.error(error); process.exitCode = 1; });
         """,
         emotion=True,

--- a/tests/unit/test_live2d_motion_exclusivity_static.py
+++ b/tests/unit/test_live2d_motion_exclusivity_static.py
@@ -125,52 +125,6 @@ def test_motion_slot_rejects_actions_and_replaces_idle_without_races():
           assert.strictEqual(await actionPromise, true);
           assert.strictEqual(deferredMM.state.currentPriority, 2);
 
-          let resolveEmptyAction;
-          const emptyMM = makeMotionManager([], () => new Promise((resolve) => { resolveEmptyAction = resolve; }));
-          const empty = new context.Live2DManager(); empty.currentModel = makeModel(emptyMM);
-          const emptyAction = empty.playActionMotion('Tap', 0);
-          assert.notStrictEqual(emptyMM.state.reservedIdleGroup, undefined);
-          resolveEmptyAction(true);
-          assert.strictEqual(await emptyAction, true);
-          assert.strictEqual(emptyMM.state.reservedIdleGroup, undefined);
-
-          const staleStarts = [], staleResolvers = {};
-          const staleMM = makeMotionManager([], (state, group, index) => {
-            const key = `${group}:${index}`;
-            staleStarts.push(key);
-            if (staleStarts.length > 2) return false;
-            return new Promise((resolve) => {
-              staleResolvers[key] = () => {
-                state.setReservedIdle(undefined, undefined);
-                if (state.currentPriority !== 0) return resolve(false);
-                state.setCurrent(group, index, 1); resolve(true);
-              };
-            });
-          });
-          staleMM.definitions = { Idle: [{ File: 'a.motion3.json' }, { File: 'b.motion3.json' }] };
-          const stale = new context.Live2DManager(); stale.currentModel = makeModel(staleMM);
-          stale.isAvatarPerformanceCapabilityLocked = () => false;
-          const staleLoop = stale._playIdleMotion(staleMM);
-          while (staleStarts.length === 0) await new Promise((resolve) => setTimeout(resolve, 0));
-          const staleKey = staleStarts[0];
-          const savedIdle = stale.playIdleMotion('Saved', 0);
-          staleResolvers['Saved:0'](); assert.strictEqual(await savedIdle, true);
-          staleResolvers[staleKey](); await staleLoop;
-          assert.deepStrictEqual(staleStarts, [staleKey, 'Saved:0']);
-          assert.strictEqual(staleMM.state.currentGroup, 'Saved');
-
-          let resolveFallback;
-          const fallbackMM = makeMotionManager();
-          fallbackMM.definitions = {}; fallbackMM.motionGroups = {};
-          const fallback = new context.Live2DManager(); fallback.currentModel = makeModel(fallbackMM);
-          fallback.isAvatarPerformanceCapabilityLocked = () => false;
-          fallback._startIdleMotion = () => new Promise((resolve) => { resolveFallback = resolve; });
-          fallback._clearActiveMotionParamIds = () => { throw new Error('stale fallback cleared newer tracking'); };
-          const fallbackLoop = fallback._playIdleMotion(fallbackMM);
-          while (!resolveFallback) await new Promise((resolve) => setTimeout(resolve, 0));
-          fallback._idleLoopRequestGeneration++;
-          resolveFallback(false);
-          await fallbackLoop;
         })().catch((error) => { console.error(error); process.exitCode = 1; });
         """
     )
@@ -203,25 +157,6 @@ def test_expression_slot_replaces_transient_expression_but_preserves_action():
           assert.strictEqual(state.currentPriority, 2);
           assert.strictEqual(manager.persistentApplied, true);
 
-          const clearing = new context.Live2DManager();
-          const resetParams = [];
-          const expressionManager = { reserveExpressionIndex: 3, stopAllExpressions() {} };
-          clearing.currentModel = {
-            internalModel: {
-              coreModel: { setParameterValueById(id, value) { resetParams.push([id, value]); } },
-              motionManager: { expressionManager },
-            },
-          };
-          clearing._cancelSmoothReset = () => {};
-          clearing._resetParametersToInitialState = () => { throw new Error('must not reset action parameters'); };
-          clearing.applyPersistentExpressionsNative = async () => {};
-          clearing.initialParameters = { ParamAngleX: 0, ParamEyeLOpen: 1 };
-          clearing._activeExpressionParamIds = new Set(['ParamAngleX', 'ParamEyeLOpen']);
-          clearing._setActiveMotionParamIds(['ParamAngleX']);
-          assert.strictEqual(clearing.clearExpression({ preserveMotion: true }), true);
-          assert.strictEqual(expressionManager.reserveExpressionIndex, -1);
-          assert.deepStrictEqual(resetParams, [['ParamEyeLOpen', 1]]);
-
           const expressions = new context.Live2DManager(), resolvers = {};
           expressions.currentModel = {
             internalModel: { motionManager: { state: { currentPriority: 0, reservePriority: 0 } } },
@@ -246,43 +181,6 @@ def test_expression_slot_replaces_transient_expression_but_preserves_action():
           resolvers.a(true); assert.strictEqual(await first, false);
           assert.strictEqual(expressions.clearCount, 2);
 
-          const tracking = new context.Live2DManager();
-          const trackingState = {
-            currentPriority: 0, reservePriority: 0,
-            setReservedIdle(group, index) { this.reservedIdleGroup = group; this.reservedIdleIndex = index; },
-          };
-          const trackingMM = {
-            state: trackingState,
-            definitions: { happy: [{ File: 'happy.motion3.json' }] },
-          };
-          tracking.currentModel = {
-            internalModel: { motionManager: trackingMM },
-            motion(group, index) {
-              Object.assign(trackingState, { currentGroup: group, currentIndex: index, currentPriority: 2 });
-              return true;
-            },
-          };
-          Object.assign(tracking, {
-            fileReferences: { Motions: { happy: [{ File: 'happy.motion3.json' }] } },
-            emotionMapping: { motions: {} },
-            isAvatarPerformanceCapabilityLocked: () => false,
-            resolveAssetPath: (file) => file,
-            resetTransientMotionAndExpressionState: async () => {
-              await Promise.resolve();
-              Object.assign(trackingState, { currentGroup: 'Idle', currentIndex: 0, currentPriority: 1 });
-              const generation = tracking._nextMotionTimerGeneration();
-              tracking.motionTimer = { type: 'timeout', id: setTimeout(() => {}, 1000), generation };
-            },
-          });
-          context.fetch = async () => ({
-            ok: true,
-            json: async () => ({ Meta: { Duration: 1 }, Curves: [{ Target: 'Parameter', Id: 'ParamAngleX' }] }),
-          });
-          assert.strictEqual(await tracking.playMotion('happy'), true);
-          assert.strictEqual(trackingState.currentPriority, 2);
-          assert.strictEqual(tracking._activeMotionParamIds.has('ParamAngleX'), true);
-          assert.strictEqual(tracking.motionTimer.type, 'timeout');
-          tracking._clearMotionTimer();
         })().catch((error) => { console.error(error); process.exitCode = 1; });
         """,
         emotion=True,
@@ -291,6 +189,8 @@ def test_expression_slot_replaces_transient_expression_but_preserves_action():
 
 
 def test_all_runtime_entries_use_the_central_slots_before_side_effects():
+    model = MODEL.read_text(encoding="utf-8")
+    emotion = EMOTION.read_text(encoding="utf-8")
     interaction = (ROOT / "static/live2d/live2d-interaction.js").read_text(encoding="utf-8")
     performance = (ROOT / "static/avatar/avatar-performance-stage.js").read_text(
         encoding="utf-8"
@@ -312,3 +212,20 @@ def test_all_runtime_entries_use_the_central_slots_before_side_effects():
     assert acquire.index("manager.hasActiveActionMotion(model)") < acquire.index(
         "manager.suspendTemporaryMotions("
     )
+
+    action_slot = model[model.index("Live2DManager.prototype.playActionMotion") : model.index("Live2DManager.prototype.playIdleMotion")]
+    assert "state.setReservedIdle(idleBlock, undefined)" in action_slot
+    assert "state.reservedIdleGroup === idleBlock" in action_slot
+
+    idle_fallback = model[model.index("const started = await this._startIdleMotion(expectedModel, 'Idle');") : model.index("Live2DManager.prototype._configureLoadedModel")]
+    assert idle_fallback.index("if (!isCurrentIdleRequest()) return;") < idle_fallback.index("if (started === false)")
+
+    clear_expression = emotion[emotion.index("Live2DManager.prototype.clearExpression") : emotion.index("Live2DManager.prototype._getActiveExpressionParamIds")]
+    assert "expressionManager.reserveExpressionIndex = -1" in clear_expression
+    recorded_reset = emotion[emotion.index("Live2DManager.prototype._resetRecordedParameterIds") : emotion.index("Live2DManager.prototype._getDefaultMotionParameterIds")]
+    assert "options.preserveMotion === true" in recorded_reset
+
+    motion_start_index = emotion.index("const motion = options.motionPriority")
+    first_motion_check = emotion.index("if (motion) {", motion_start_index)
+    motion_start = emotion[motion_start_index : emotion.index("if (motion) {", first_motion_check + 1)]
+    assert motion_start.index("motionTimerGuardGeneration = this._motionTimerGeneration || 0") < motion_start.index("if (!isCurrentMotionInvocation()) return false")

--- a/tests/unit/test_live2d_motion_exclusivity_static.py
+++ b/tests/unit/test_live2d_motion_exclusivity_static.py
@@ -1,4 +1,12 @@
+import json
+import shutil
+import subprocess
+import textwrap
 from pathlib import Path
+
+import pytest
+
+from tests.node_harness import run_node_stdin
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -11,6 +19,41 @@ MODEL_RELOAD_PATH = (
     / "app-interpage"
     / "bootstrap-resources-and-model-reload.js"
 )
+
+
+def _run_node_harness(script: str) -> subprocess.CompletedProcess[str]:
+    node_executable = shutil.which("node")
+    if node_executable is None:
+        pytest.skip("node not found")
+    return run_node_stdin(
+        node_executable,
+        script,
+        capture_output=True,
+        cwd=PROJECT_ROOT,
+        timeout=10,
+        check=False,
+    )
+
+
+def _manager_harness(body: str) -> str:
+    return textwrap.dedent(
+        f"""
+        const assert = require('node:assert');
+        const fs = require('node:fs');
+        const vm = require('node:vm');
+        const context = {{
+          console: {{ log() {{}}, warn() {{}}, error() {{}} }},
+          window: {{}},
+          Live2DManager: function Live2DManager() {{}},
+          setTimeout, clearTimeout, setInterval, clearInterval,
+        }};
+        context.global = context;
+        context.window.Live2DManager = context.Live2DManager;
+        vm.createContext(context);
+        vm.runInContext(fs.readFileSync({json.dumps(str(LIVE2D_MODEL_PATH))}, 'utf8'), context);
+        {body}
+        """
+    )
 
 
 def test_idle_motion_starts_with_idle_priority():
@@ -47,6 +90,7 @@ def test_main_action_entry_rejects_a_second_action_and_stops_only_idle():
     assert "this._simpleMotionActive === true" in source
     assert "return false" in action_source
     assert "currentPriority === LIVE2D_MOTION_PRIORITY.IDLE" in action_source
+    assert "this._clearMotionTimer()" in action_source
     assert "motionManager.stopAllMotions()" in action_source
     assert "LIVE2D_MOTION_PRIORITY.NORMAL" in action_source
     assert "return started === undefined ? true : started" in action_source
@@ -158,3 +202,101 @@ def test_saved_idle_motion_does_not_use_force_priority():
     assert action_guard_index < stop_idle_index
     assert "LIVE2D_MOTION_PRIORITY.IDLE" in restore_source
     assert "live2dModel.motion(groupName, motionIndex, 3)" not in restore_source
+
+
+def test_failed_action_start_clears_only_its_motion_reservation():
+    script = _manager_harness(
+        """
+        (async () => {
+          const events = [];
+          const state = {
+            currentPriority: 1,
+            reservePriority: 0,
+            reservedGroup: undefined,
+            reservedIndex: undefined,
+            reservedIdleGroup: 'Idle',
+            setReserved(group, index, priority) {
+              this.reservedGroup = group;
+              this.reservedIndex = index;
+              this.reservePriority = priority;
+            },
+          };
+          const motionManager = {
+            state,
+            stopAllMotions() {
+              events.push('stop-idle');
+              state.currentPriority = 0;
+              state.reservedIdleGroup = undefined;
+            },
+          };
+          const manager = new context.Live2DManager();
+          manager._clearMotionTimer = () => { events.push('clear-idle-timer'); };
+          const model = {
+            internalModel: { motionManager },
+            async motion(group, index, priority) {
+              events.push('start-action');
+              state.setReserved(group, index, priority);
+              throw new Error('load failed');
+            },
+          };
+          manager.currentModel = model;
+
+          await assert.rejects(manager.playActionMotion('Tap', 0), /load failed/);
+          assert.deepStrictEqual(events, ['clear-idle-timer', 'stop-idle', 'start-action']);
+          assert.strictEqual(state.reservePriority, 0);
+          assert.strictEqual(state.reservedGroup, undefined);
+          assert.strictEqual(state.reservedIndex, undefined);
+
+          model.motion = async (group, index, priority) => {
+            state.setReserved(group, index, priority);
+            return false;
+          };
+          assert.strictEqual(await manager.playActionMotion('Missing', undefined), false);
+          assert.strictEqual(state.reservePriority, 0);
+          assert.strictEqual(state.reservedGroup, undefined);
+          assert.strictEqual(state.reservedIndex, undefined);
+        })().catch((error) => { console.error(error); process.exitCode = 1; });
+        """
+    )
+    result = _run_node_harness(script)
+    assert result.returncode == 0, result.stderr
+
+
+def test_model_removal_clears_simple_motion_gate_with_motion_timer():
+    script = _manager_harness(
+        """
+        (async () => {
+          let timerClears = 0;
+          const manager = new context.Live2DManager();
+          manager._simpleMotionActive = true;
+          manager.motionTimer = { type: 'timeout', id: 123 };
+          manager._clearMotionTimer = () => {
+            timerClears += 1;
+            manager._simpleMotionActive = false;
+            manager.motionTimer = null;
+          };
+
+          await manager.removeModel({ skipCloseWindows: true });
+          assert.strictEqual(timerClears, 1);
+          assert.strictEqual(manager._simpleMotionActive, false);
+          assert.strictEqual(manager.motionTimer, null);
+        })().catch((error) => { console.error(error); process.exitCode = 1; });
+        """
+    )
+    result = _run_node_harness(script)
+    assert result.returncode == 0, result.stderr
+
+
+def test_performance_session_checks_action_gate_before_suspending_motions():
+    source = (
+        PROJECT_ROOT / "static" / "avatar" / "avatar-performance-stage.js"
+    ).read_text(encoding="utf-8")
+    acquire_start = source.index("acquireSession(session) {")
+    acquire_end = source.index("releaseSession(session) {", acquire_start)
+    acquire_source = source[acquire_start:acquire_end]
+
+    action_guard_index = acquire_source.index("manager.hasActiveActionMotion(model)")
+    suspend_index = acquire_source.index("manager.suspendTemporaryMotions(")
+    assert action_guard_index < suspend_index
+    assert "if (!hasActiveAction)" in acquire_source
+    assert "this.motionSuspendSource = '';" in acquire_source

--- a/tests/unit/test_live2d_motion_exclusivity_static.py
+++ b/tests/unit/test_live2d_motion_exclusivity_static.py
@@ -1,7 +1,6 @@
 import json
 import shutil
 import subprocess
-import textwrap
 from pathlib import Path
 
 import pytest
@@ -9,389 +8,202 @@ import pytest
 from tests.node_harness import run_node_stdin
 
 
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
-LIVE2D_MODEL_PATH = PROJECT_ROOT / "static" / "live2d" / "live2d-model.js"
-LIVE2D_INTERACTION_PATH = PROJECT_ROOT / "static" / "live2d" / "live2d-interaction.js"
-MODEL_RELOAD_PATH = (
-    PROJECT_ROOT
-    / "static"
-    / "app"
-    / "app-interpage"
-    / "bootstrap-resources-and-model-reload.js"
-)
+ROOT = Path(__file__).resolve().parents[2]
+MODEL = ROOT / "static" / "live2d" / "live2d-model.js"
+EMOTION = ROOT / "static" / "live2d" / "live2d-emotion.js"
 
 
-def _run_node_harness(script: str) -> subprocess.CompletedProcess[str]:
-    node_executable = shutil.which("node")
-    if node_executable is None:
+def _run_node(body: str, *, emotion: bool = False) -> subprocess.CompletedProcess[str]:
+    node = shutil.which("node")
+    if node is None:
         pytest.skip("node not found")
+    load_emotion = (
+        f"vm.runInContext(fs.readFileSync({json.dumps(str(EMOTION))}, 'utf8'), context);"
+        if emotion
+        else ""
+    )
+    script = f"""
+    const assert = require('node:assert');
+    const fs = require('node:fs');
+    const vm = require('node:vm');
+    const context = {{
+      console: {{ log() {{}}, warn() {{}}, error() {{}} }}, window: {{}},
+      Live2DManager: function Live2DManager() {{}},
+      setTimeout, clearTimeout, setInterval, clearInterval,
+      requestAnimationFrame: (fn) => setTimeout(() => fn(Date.now()), 0),
+      cancelAnimationFrame: clearTimeout, performance: {{ now: Date.now }},
+    }};
+    context.global = context;
+    context.window.Live2DManager = context.Live2DManager;
+    vm.createContext(context);
+    vm.runInContext(fs.readFileSync({json.dumps(str(MODEL))}, 'utf8'), context);
+    {load_emotion}
+    {body}
+    """
     return run_node_stdin(
-        node_executable,
-        script,
-        capture_output=True,
-        cwd=PROJECT_ROOT,
-        timeout=10,
-        check=False,
+        node, script, capture_output=True, cwd=ROOT, timeout=10, check=False
     )
 
 
-def _manager_harness(body: str) -> str:
-    return textwrap.dedent(
-        f"""
-        const assert = require('node:assert');
-        const fs = require('node:fs');
-        const vm = require('node:vm');
-        const context = {{
-          console: {{ log() {{}}, warn() {{}}, error() {{}} }},
-          window: {{}},
-          Live2DManager: function Live2DManager() {{}},
-          setTimeout, clearTimeout, setInterval, clearInterval,
-        }};
-        context.global = context;
-        context.window.Live2DManager = context.Live2DManager;
-        vm.createContext(context);
-        vm.runInContext(fs.readFileSync({json.dumps(str(LIVE2D_MODEL_PATH))}, 'utf8'), context);
-        {body}
-        """
-    )
-
-
-def test_idle_motion_starts_with_idle_priority():
-    source = LIVE2D_MODEL_PATH.read_text(encoding="utf-8")
-    idle_method_start = source.index("Live2DManager.prototype._playIdleMotion")
-    idle_start = source[
-        idle_method_start : source.index("// 配置已加载的模型", idle_method_start)
-    ]
-
-    tracked_idle_call = (
-        "motionManager.startMotion(\n"
-        "                groupName,\n"
-        "                index,\n"
-        "                LIVE2D_MOTION_PRIORITY.IDLE"
-    )
-    random_idle_call = (
-        "motionManager.startRandomMotion(\n"
-        "            'Idle',\n"
-        "            LIVE2D_MOTION_PRIORITY.IDLE"
-    )
-    assert tracked_idle_call in idle_start
-    assert random_idle_call in idle_start
-    assert idle_start.count("canStartIdleMotion()") >= 2
-    assert "!this.hasActiveActionMotion(expectedModel)" in idle_start
-
-
-def test_main_action_entry_rejects_a_second_action_and_stops_only_idle():
-    source = LIVE2D_MODEL_PATH.read_text(encoding="utf-8")
-    action_start = source.index("Live2DManager.prototype.playActionMotion")
-    action_end = source.index("// 缓动函数集合", action_start)
-    action_source = source[action_start:action_end]
-
-    assert "this.hasActiveActionMotion(model)" in action_source
-    assert "this._simpleMotionActive === true" in source
-    assert "return false" in action_source
-    assert "currentPriority === LIVE2D_MOTION_PRIORITY.IDLE" in action_source
-    assert "this._clearMotionTimer()" in action_source
-    assert "motionManager.stopAllMotions()" in action_source
-    assert "LIVE2D_MOTION_PRIORITY.NORMAL" in action_source
-    assert "return started === undefined ? true : started" in action_source
-
-
-def test_touch_actions_use_normal_priority_without_force_preemption():
-    source = LIVE2D_INTERACTION_PATH.read_text(encoding="utf-8")
-    touch_start = source.index("Live2DManager.prototype._playTouchSetAnimation")
-    touch_source = source[touch_start:]
-
-    assert "this.playActionMotion(groupName, 0)" in touch_source
-    assert "live2dModel.motion(groupName, 0, 3)" not in touch_source
-
-
-def test_all_main_runtime_motion_entry_points_use_the_single_action_gate():
-    emotion_source = (
-        PROJECT_ROOT / "static" / "live2d" / "live2d-emotion.js"
-    ).read_text(encoding="utf-8")
-    interaction_source = LIVE2D_INTERACTION_PATH.read_text(encoding="utf-8")
-    performance_source = (
-        PROJECT_ROOT / "static" / "avatar" / "avatar-performance-stage.js"
-    ).read_text(encoding="utf-8")
-
-    assert "await this.playActionMotion(" in emotion_source
-    assert interaction_source.count("await this.playActionMotion(") >= 3
-    assert performance_source.count("manager.playActionMotion(") >= 2
-
-
-def test_emotion_motion_checks_the_gate_before_resetting_existing_motion():
-    source = (
-        PROJECT_ROOT / "static" / "live2d" / "live2d-emotion.js"
-    ).read_text(encoding="utf-8")
-    play_motion_start = source.index("Live2DManager.prototype.playMotion")
-    play_motion_end = source.index("// 播放简单动作", play_motion_start)
-    play_motion_source = source[play_motion_start:play_motion_end]
-    set_emotion_start = source.index("Live2DManager.prototype.setEmotion")
-    set_emotion_end = source.index("// 同步服务器端的情绪映射", set_emotion_start)
-    set_emotion_source = source[set_emotion_start:set_emotion_end]
-
-    for block in (play_motion_source, set_emotion_source):
-        action_guard_index = block.index("this.hasActiveActionMotion(this.currentModel)")
-        reset_index = block.index("resetTransientMotionAndExpressionState")
-        assert action_guard_index < reset_index
-
-    smooth_reset_index = set_emotion_source.index("smoothResetToInitialState")
-    guard_after_smooth_reset = set_emotion_source.index(
-        "this.hasActiveActionMotion(this.currentModel)", smooth_reset_index
-    )
-    destructive_reset_index = set_emotion_source.index(
-        "resetTransientMotionAndExpressionState", smooth_reset_index
-    )
-    assert smooth_reset_index < guard_after_smooth_reset < destructive_reset_index
-
-
-def test_simple_motion_fallback_does_not_overlap_an_action():
-    source = (
-        PROJECT_ROOT / "static" / "live2d" / "live2d-emotion.js"
-    ).read_text(encoding="utf-8")
-    play_motion_start = source.index("Live2DManager.prototype.playMotion")
-    play_motion_end = source.index("// 播放简单动作", play_motion_start)
-    play_motion_source = source[play_motion_start:play_motion_end]
-    motion_result_index = play_motion_source.index("const motion =")
-    late_action_guard_index = play_motion_source.index(
-        "this.hasActiveActionMotion(this.currentModel)", motion_result_index
-    )
-    simple_fallback_index = play_motion_source.index(
-        "this.playSimpleMotion(emotion)", motion_result_index
-    )
-    assert motion_result_index < late_action_guard_index < simple_fallback_index
-
-    simple_start = source.index("Live2DManager.prototype.playSimpleMotion")
-    simple_end = source.index("// 清理当前情感效果", simple_start)
-    simple_source = source[simple_start:simple_end]
-    centralized_guard_index = simple_source.index(
-        "this.hasActiveActionMotion(this.currentModel)"
-    )
-    parameter_write_index = simple_source.index("_setActiveMotionParamIds")
-    assert centralized_guard_index < parameter_write_index
-    assert "this._simpleMotionActive = true" in simple_source
-
-    clear_timer_start = source.index("Live2DManager.prototype._clearMotionTimer")
-    clear_timer_end = source.index(
-        "Live2DManager.prototype._resetExplicitMotionParameters", clear_timer_start
-    )
-    assert "this._simpleMotionActive = false" in source[clear_timer_start:clear_timer_end]
-
-
-def test_startup_idle_emotion_uses_idle_priority():
-    source = LIVE2D_MODEL_PATH.read_text(encoding="utf-8")
-    configure_start = source.index("Live2DManager.prototype._configureLoadedModel")
-    configure_source = source[configure_start:]
-
-    assert "this.setEmotion('Idle', {" in configure_source
-    assert "motionPriority: LIVE2D_MOTION_PRIORITY.IDLE" in configure_source
-    assert "Live2DManager.prototype.playIdleMotion" in source
-
-
-def test_saved_idle_motion_does_not_use_force_priority():
-    source = MODEL_RELOAD_PATH.read_text(encoding="utf-8")
-    restore_start = source.index("async function restoreLive2DIdleAnimationOnMainPage")
-    restore_end = source.index("window.restoreLive2DIdleAnimationOnMainPage", restore_start)
-    restore_source = source[restore_start:restore_end]
-
-    assert "live2dManager.hasActiveActionMotion(live2dModel)" in restore_source
-    action_guard_index = restore_source.index(
-        "live2dManager.hasActiveActionMotion(live2dModel)"
-    )
-    stop_idle_index = restore_source.index("motionManager.stopAllMotions()")
-    assert action_guard_index < stop_idle_index
-    assert "LIVE2D_MOTION_PRIORITY.IDLE" in restore_source
-    assert "live2dModel.motion(groupName, motionIndex, 3)" not in restore_source
-
-
-def test_failed_action_start_clears_only_its_motion_reservation():
-    script = _manager_harness(
+def test_motion_slot_rejects_actions_and_replaces_idle_without_races():
+    result = _run_node(
         """
         (async () => {
-          const events = [];
-          const state = {
-            currentPriority: 1,
-            reservePriority: 0,
-            reservedGroup: undefined,
-            reservedIndex: undefined,
-            reservedIdleGroup: 'Idle',
-            setReserved(group, index, priority) {
-              this.reservedGroup = group;
-              this.reservedIndex = index;
-              this.reservePriority = priority;
-            },
-          };
-          const motionManager = {
-            state,
-            stopAllMotions() {
-              events.push('stop-idle');
-              state.currentPriority = 0;
-              state.reservedIdleGroup = undefined;
-            },
-          };
-          const manager = new context.Live2DManager();
-          manager._clearMotionTimer = () => { events.push('clear-idle-timer'); };
-          const model = {
-            internalModel: { motionManager },
-            async motion(group, index, priority) {
-              events.push('start-action');
-              state.setReserved(group, index, priority);
-              throw new Error('load failed');
-            },
-          };
-          manager.currentModel = model;
+          function makeMotionManager(events = [], override = null) {
+            const state = {
+              currentPriority: 0, reservePriority: 0,
+              setCurrent(g, i, p) { Object.assign(this, { currentGroup: g, currentIndex: i, currentPriority: p }); },
+              setReserved(g, i, p) { Object.assign(this, { reservedGroup: g, reservedIndex: i, reservePriority: p }); },
+              setReservedIdle(g, i) { Object.assign(this, { reservedIdleGroup: g, reservedIdleIndex: i }); },
+              complete() { this.setCurrent(undefined, undefined, 0); },
+            };
+            return {
+              state,
+              stopAllMotions() {
+                events.push('stop'); state.complete();
+                state.setReserved(undefined, undefined, 0); state.setReservedIdle(undefined, undefined);
+              },
+              _stopAllMotions() { events.push('stop-stale-idle'); },
+              startMotion(group, index, priority) {
+                priority === 1 ? state.setReservedIdle(group, index) : state.setReserved(group, index, priority);
+                if (override) return override(state, group, index, priority);
+                priority === 1 ? state.setReservedIdle(undefined, undefined) : state.setReserved(undefined, undefined, 0);
+                state.setCurrent(group, index, priority); events.push(`start:${group}`); return true;
+              },
+              startRandomMotion(group, priority) { return this.startMotion(group, 0, priority); },
+            };
+          }
+          const makeModel = (mm) => ({
+            internalModel: { motionManager: mm },
+            motion(group, index, priority) { return mm.startMotion(group, index, priority); },
+          });
 
-          await assert.rejects(manager.playActionMotion('Tap', 0), /load failed/);
-          assert.deepStrictEqual(events, ['clear-idle-timer', 'stop-idle', 'start-action']);
-          assert.strictEqual(state.reservePriority, 0);
-          assert.strictEqual(state.reservedGroup, undefined);
-          assert.strictEqual(state.reservedIndex, undefined);
+          const busyMM = makeMotionManager();
+          busyMM.state.setCurrent('Busy', 0, 2);
+          const busy = new context.Live2DManager(); busy.currentModel = makeModel(busyMM);
+          assert.strictEqual(await busy.playActionMotion('Next', 0), false);
+          assert.strictEqual(busyMM.state.currentGroup, 'Busy');
 
-          model.motion = async (group, index, priority) => {
-            state.setReserved(group, index, priority);
-            return false;
-          };
-          assert.strictEqual(await manager.playActionMotion('Missing', undefined), false);
-          assert.strictEqual(state.reservePriority, 0);
-          assert.strictEqual(state.reservedGroup, undefined);
-          assert.strictEqual(state.reservedIndex, undefined);
-        })().catch((error) => { console.error(error); process.exitCode = 1; });
-        """
-    )
-    result = _run_node_harness(script)
-    assert result.returncode == 0, result.stderr
+          const actionEvents = [], actionMM = makeMotionManager(actionEvents);
+          actionMM.state.setCurrent('Idle', 0, 1);
+          const action = new context.Live2DManager(); action.currentModel = makeModel(actionMM);
+          action._clearMotionTimer = () => actionEvents.push('clear-timer');
+          assert.strictEqual(await action.playActionMotion('Tap', 0), true);
+          assert.deepStrictEqual(actionEvents, ['clear-timer', 'stop', 'start:Tap']);
 
+          const failedMM = makeMotionManager([], () => false);
+          const failed = new context.Live2DManager(); failed.currentModel = makeModel(failedMM);
+          assert.strictEqual(await failed.playActionMotion('Missing', 0), false);
+          assert.strictEqual(failedMM.state.reservedGroup, undefined);
+          assert.strictEqual(await failed.playIdleMotion('Idle', 0), false);
+          assert.strictEqual(failedMM.state.reservedIdleGroup, undefined);
 
-def test_model_removal_clears_simple_motion_gate_with_motion_timer():
-    script = _manager_harness(
-        """
-        (async () => {
-          let timerClears = 0;
-          const manager = new context.Live2DManager();
-          manager._simpleMotionActive = true;
-          manager.motionTimer = { type: 'timeout', id: 123 };
-          manager._clearMotionTimer = () => {
-            timerClears += 1;
-            manager._simpleMotionActive = false;
-            manager.motionTimer = null;
-          };
+          const idleEvents = [], idleMM = makeMotionManager(idleEvents);
+          idleMM.state.setCurrent('OldIdle', 0, 1);
+          const idle = new context.Live2DManager(); idle.currentModel = makeModel(idleMM);
+          idle._clearMotionTimer = () => idleEvents.push('clear-timer');
+          assert.strictEqual(await idle.playIdleMotion('SavedIdle', 0), true);
+          assert.deepStrictEqual(idleEvents, ['clear-timer', 'stop', 'start:SavedIdle']);
 
-          await manager.removeModel({ skipCloseWindows: true });
-          assert.strictEqual(timerClears, 1);
-          assert.strictEqual(manager._simpleMotionActive, false);
-          assert.strictEqual(manager.motionTimer, null);
-        })().catch((error) => { console.error(error); process.exitCode = 1; });
-        """
-    )
-    result = _run_node_harness(script)
-    assert result.returncode == 0, result.stderr
-
-
-def test_action_invalidates_an_idle_motion_that_finishes_loading_late():
-    script = _manager_harness(
-        """
-        (async () => {
-          let resolveIdle;
-          let resolveAction;
-          let stopCount = 0;
-          const state = {
-            currentPriority: 0,
-            reservePriority: 0,
-            currentGroup: undefined,
-            currentIndex: undefined,
-            reservedGroup: undefined,
-            reservedIndex: undefined,
-            reservedIdleGroup: 'Idle',
-            reservedIdleIndex: 0,
-            setReserved(group, index, priority) {
-              this.reservedGroup = group;
-              this.reservedIndex = index;
-              this.reservePriority = priority;
-            },
-            setCurrent(group, index, priority) {
-              this.currentGroup = group;
-              this.currentIndex = index;
-              this.currentPriority = priority;
-            },
-          };
-          const motionManager = {
-            state,
-            definitions: { Idle: [{ File: 'idle.motion3.json' }] },
-            motionGroups: {},
-            startMotion() {
-              return new Promise((resolve) => {
-                resolveIdle = () => {
-                  state.reservedIdleGroup = undefined;
-                  state.reservedIdleIndex = undefined;
-                  state.setCurrent('Idle', 0, 1);
-                  resolve(true);
-                };
-              });
-            },
-            startRandomMotion: async () => false,
-            stopAllMotions() {
-              stopCount += 1;
-              state.setCurrent(undefined, undefined, 0);
-              state.setReserved(undefined, undefined, 0);
-              state.reservedIdleGroup = undefined;
-              state.reservedIdleIndex = undefined;
-            },
-          };
-          const manager = new context.Live2DManager();
-          manager.isAvatarPerformanceCapabilityLocked = () => false;
+          let resolveIdle, resolveAction;
+          const deferredMM = makeMotionManager([], (state, group, index, priority) => new Promise((resolve) => {
+            const finish = () => {
+              priority === 1 ? state.setReservedIdle(undefined, undefined) : state.setReserved(undefined, undefined, 0);
+              state.setCurrent(group, index, priority); resolve(true);
+            };
+            if (priority === 1) resolveIdle = finish; else resolveAction = finish;
+          }));
+          const manager = new context.Live2DManager(); manager.currentModel = makeModel(deferredMM);
           manager._clearMotionTimer = () => {};
-          manager._clearActiveMotionParamIds = () => {};
-          manager._trackActiveMotionParametersFromFile = async () => {};
-          const model = {
-            destroyed: false,
-            internalModel: { motionManager },
-            motion(group, index, priority) {
-              state.setReserved(group, index, priority);
-              return new Promise((resolve) => {
-                resolveAction = () => {
-                  state.setReserved(undefined, undefined, 0);
-                  state.setCurrent(group, index, priority);
-                  resolve(true);
-                };
-              });
-            },
-          };
-          manager.currentModel = model;
-
-          const idlePromise = manager._playIdleMotion(motionManager);
+          const idlePromise = manager.playIdleMotion('Idle', 0);
           const actionPromise = manager.playActionMotion('Tap', 0);
-          assert.strictEqual(typeof resolveIdle, 'function');
-          assert.strictEqual(typeof resolveAction, 'function');
-
           resolveIdle();
-          await idlePromise;
-          assert.strictEqual(stopCount, 2);
-          assert.strictEqual(state.currentPriority, 0);
-          assert.strictEqual(state.reservePriority, 2);
-          assert.strictEqual(state.reservedGroup, 'Tap');
-          assert.strictEqual(state.reservedIndex, 0);
-
+          assert.strictEqual(await idlePromise, false);
+          assert.strictEqual(deferredMM.state.currentPriority, 0);
+          assert.strictEqual(deferredMM.state.reservePriority, 2);
           resolveAction();
           assert.strictEqual(await actionPromise, true);
-          assert.strictEqual(state.currentPriority, 2);
-          assert.strictEqual(state.currentGroup, 'Tap');
+          assert.strictEqual(deferredMM.state.currentPriority, 2);
         })().catch((error) => { console.error(error); process.exitCode = 1; });
         """
     )
-    result = _run_node_harness(script)
     assert result.returncode == 0, result.stderr
 
 
-def test_performance_session_checks_action_gate_before_suspending_motions():
-    source = (
-        PROJECT_ROOT / "static" / "avatar" / "avatar-performance-stage.js"
-    ).read_text(encoding="utf-8")
-    acquire_start = source.index("acquireSession(session) {")
-    acquire_end = source.index("releaseSession(session) {", acquire_start)
-    acquire_source = source[acquire_start:acquire_end]
+def test_expression_slot_replaces_transient_expression_but_preserves_action():
+    result = _run_node(
+        """
+        (async () => {
+          const manager = new context.Live2DManager();
+          const state = { currentPriority: 2, reservePriority: 0 };
+          manager.currentModel = { internalModel: { motionManager: { state } } };
+          Object.assign(manager, {
+            emotionMapping: { expressions: { happy: ['happy.exp3.json'] }, motions: {} },
+            fileReferences: { Expressions: [] }, currentEmotion: 'neutral',
+            currentExpressionFile: 'neutral.exp3.json', isEmotionChanging: true,
+            getRandomElement: (items) => items[0],
+            isAvatarPerformanceCapabilityLocked: () => false,
+            _cancelSmoothReset: () => {},
+            smoothResetToInitialState: async () => { throw new Error('must preserve active action'); },
+            applyPersistentExpressionsNative: async () => { manager.persistentApplied = true; },
+          });
+          manager.resetTransientMotionAndExpressionState = async (options) => { manager.resetOptions = options; };
+          manager.playExpression = async () => { manager.expressionPlayed = true; return true; };
+          manager.playMotion = async () => { manager.motionAttempted = true; return false; };
+          await manager.setEmotion('happy');
+          assert.strictEqual(manager.expressionPlayed && manager.motionAttempted, true);
+          assert.strictEqual(manager.resetOptions.preserveMotion, true);
+          assert.strictEqual(state.currentPriority, 2);
+          assert.strictEqual(manager.persistentApplied, true);
 
-    action_guard_index = acquire_source.index("manager.hasActiveActionMotion(model)")
-    suspend_index = acquire_source.index("manager.suspendTemporaryMotions(")
-    assert action_guard_index < suspend_index
-    assert "if (!hasActiveAction)" in acquire_source
-    assert "this.motionSuspendSource = '';" in acquire_source
+          const expressions = new context.Live2DManager(), resolvers = {};
+          expressions.currentModel = {
+            internalModel: { motionManager: { state: { currentPriority: 0, reservePriority: 0 } } },
+            expression(name) { return new Promise((resolve) => { resolvers[name] = resolve; }); },
+          };
+          expressions.isAvatarPerformanceCapabilityLocked = () => false;
+          expressions.resolveExpressionReferenceByFile = (file) => ({ name: file[0], file });
+          expressions.resolveAssetPath = (file) => file;
+          expressions.clearExpression = function() {
+            this.clearCount = (this.clearCount || 0) + 1;
+            this._transientExpressionGeneration = (this._transientExpressionGeneration || 0) + 1;
+          };
+          expressions.applyPersistentExpressionsNative = async () => {};
+          context.fetch = async () => ({ ok: true, json: async () => ({ Parameters: [] }) });
+
+          const first = expressions.playExpression('first', 'a.exp3.json');
+          while (!resolvers.a) await new Promise((resolve) => setTimeout(resolve, 0));
+          const second = expressions.playExpression('second', 'b.exp3.json');
+          while (!resolvers.b) await new Promise((resolve) => setTimeout(resolve, 0));
+          resolvers.b(true); assert.strictEqual(await second, true);
+          resolvers.a(true); assert.strictEqual(await first, false);
+          assert.strictEqual(expressions.clearCount, 2);
+        })().catch((error) => { console.error(error); process.exitCode = 1; });
+        """,
+        emotion=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_all_runtime_entries_use_the_central_slots_before_side_effects():
+    interaction = (ROOT / "static/live2d/live2d-interaction.js").read_text(encoding="utf-8")
+    performance = (ROOT / "static/avatar/avatar-performance-stage.js").read_text(
+        encoding="utf-8"
+    )
+    restore = (
+        ROOT / "static/app/app-interpage/bootstrap-resources-and-model-reload.js"
+    ).read_text(encoding="utf-8")
+    acquire = performance[
+        performance.index("acquireSession(session) {") : performance.index(
+            "releaseSession(session) {", performance.index("acquireSession(session) {")
+        )
+    ]
+
+    assert interaction.count("await this.playActionMotion(") >= 3
+    assert performance.count("manager.playActionMotion(") >= 2
+    assert "await this.playExpression(randomExpression.Name, randomExpression.File)" in interaction
+    assert "live2dManager.playIdleMotion(groupName, motionIndex)" in restore
+    assert "live2dModel.motion(groupName, motionIndex, 3)" not in restore
+    assert acquire.index("manager.hasActiveActionMotion(model)") < acquire.index(
+        "manager.suspendTemporaryMotions("
+    )


### PR DESCRIPTION
## 改动概述 / Summary

- 普通 Live2D 动作统一走单一播放槽：已有动作加载或播放时拒绝下一个动作。
- Idle 使用独立低优先级入口，可被普通动作接管；替换旧 Idle 时同步清理旧定时器。
- 瞬态表情使用“后触发覆盖前一个”的槽，新表情先重置旧表情；常驻表情不计入互斥并会在清理后重放。
- 情绪、点击、TouchSet、教程、演出和保存的待机恢复入口统一接入上述规则。

相关 issue：[多个动作卡在一起演示](https://github.com/Project-N-E-K-O/N.E.K.O/issues/2674)

## 测试 / Testing

- `311 passed`：Live2D / Avatar Python 单元与静态契约测试
- `75 passed`：相关 Node 测试
- `ruff check`、JavaScript `node --check`、`git diff --check` 均通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能优化**
  * 统一 Live2D 动作与待机播放规则，减少动作冲突和意外覆盖。
  * 优化动作优先级、切换与恢复机制，提升播放连贯性。
  * 改进临时表情和动作的异步处理，避免过期请求覆盖最新效果。
  * 优化模型切换、播放失败及状态清理，增强交互稳定性。

* **测试**
  * 新增动作互斥、待机恢复、表情切换及并发请求场景验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->