### PR TITLE
test(unit)：修掉 Steamworks 进程级句柄的跨用例污染（开发机独有的顺序依赖红）

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -82,6 +82,23 @@ def _reset_steamworks_handle():
     ``utils.steam_state``'s whole module namespace is snapshotted rather than a
     hand-listed set of names, so a global added there later is covered without
     anyone remembering to extend a checklist.
+
+    Restoring deliberately drops any handle a test installed instead of calling
+    ``STEAMWORKS.unload()`` on it, and that is not an oversight:
+
+    * ``unload()`` runs ``SteamAPI_Shutdown``, which is *process*-global — it
+      does not shut down "that instance". Unloading a handle a test created
+      would therefore also invalidate the snapshot handle this fixture is in the
+      middle of restoring, turning a dropped reference into a live-but-dead API.
+    * Production keeps the matching rule: ``SteamCloudBundleBridge.close()``
+      (utils/steam_cloud_bundle.py) unloads only ``_owned_steamworks``, the
+      handle it constructed itself, and never one that was passed in. A fixture
+      restoring a snapshot is by definition not the owner.
+
+    Dropping the reference is also strictly better than the status quo it
+    replaces: with the fixture in place the unit suite performs *zero* real
+    ``STEAMWORKS()`` initializations (measured; it was two without it), because
+    restoring ``_steamworks_initializer`` closes the lazy-init path as well.
     """
     # Importing here (not lazily via sys.modules) removes the "module not yet
     # imported" branch entirely; the module is a few globals and a lock, with no

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -14,6 +14,10 @@ Introduced in response to CodeRabbit review on PR #681 — flagged for
 tests/unit/test_character_memory_regression.py and
 tests/unit/test_cloudsave_autocloud_router.py, but applied globally
 because the same leak pattern exists in every cloudsave/character test.
+
+`_reset_steamworks_handle` covers the same class of leak for the process-global
+Steamworks handle, which used to live in that very `_state` dict before #1270
+moved it down to `utils.steam_state`. See that fixture's own docstring.
 """
 from __future__ import annotations
 
@@ -51,6 +55,58 @@ def _reset_shared_state():
 
         shared_state._state.clear()
         shared_state._state.update(snapshot)
+
+
+@pytest.fixture(autouse=True)
+def _reset_steamworks_handle():
+    """Restore the process-global Steamworks handle around every unit test.
+
+    ``utils.steam_state`` owns the process-singleton Steamworks handle plus the
+    lazy-init callback that ``main_routers.shared_state`` re-exports, and
+    ``app/main_server/__init__.py`` keeps a module-global mirror of the same
+    handle (``on_startup`` reads that mirror when it seeds shared state).
+
+    Any test that drives an endpoint calling ``ensure_steamworks()`` — e.g. a
+    ``TestClient`` GET on ``/api/config/steam_language`` — makes the registered
+    initializer run for real. On a developer machine with Steam installed that
+    call succeeds and installs a live ``STEAMWORKS`` object into *both* globals.
+    Nothing tore it down, so a later test that expects a pristine ``None`` handle
+    failed depending on execution order. CI never saw it: with no Steam client
+    the initializer returns ``None``, so the leak is invisible there.
+
+    Before #1270 the handle lived in ``main_routers.shared_state._state`` and the
+    ``_reset_shared_state`` fixture above covered it. Moving the singleton down to
+    the L1 ``utils`` layer silently dropped it out of that snapshot; this fixture
+    restores the lost coverage on the state's new home.
+
+    ``utils.steam_state``'s whole module namespace is snapshotted rather than a
+    hand-listed set of names, so a global added there later is covered without
+    anyone remembering to extend a checklist.
+    """
+    # Importing here (not lazily via sys.modules) removes the "module not yet
+    # imported" branch entirely; the module is a few globals and a lock, with no
+    # import side effects.
+    from utils import steam_state
+
+    steam_state_snapshot = dict(vars(steam_state))
+    # The mirror's definition-time value is None, so a main_server imported
+    # *during* the test restores to the value it was born with.
+    main_server_steamworks = getattr(sys.modules.get("app.main_server"), "steamworks", None)
+
+    try:
+        yield
+    finally:
+        # Same lock the module's own setters take, in case a test leaked a
+        # background thread that is mid-``ensure_steamworks()``.
+        with steam_state_snapshot["_steamworks_lock"]:
+            for name in [n for n in vars(steam_state) if n not in steam_state_snapshot]:
+                delattr(steam_state, name)
+            for name, value in steam_state_snapshot.items():
+                setattr(steam_state, name, value)
+
+        main_server = sys.modules.get("app.main_server")
+        if main_server is not None:
+            main_server.steamworks = main_server_steamworks
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_steamworks_state_isolation.py
+++ b/tests/unit/test_steamworks_state_isolation.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Guard the ``_reset_steamworks_handle`` fixture in ``tests/unit/conftest.py``.
+
+The process-global Steamworks handle lives in ``utils.steam_state`` and is
+mirrored by ``app.main_server.steamworks``. A test that reaches an endpoint
+calling ``ensure_steamworks()`` initializes the real SDK on a machine with Steam
+installed and used to leave that live handle installed for every later test.
+
+Each guard below asserts the globals carry no marker from *this* module, then
+installs one. Whichever of the two pytest happens to run second fails if the
+fixture stopped restoring — so the guard holds under any shuffle order, which
+matters because ``pytest-randomly`` reorders within the module (see pytest.ini).
+
+The assertions deliberately look for this module's own marker instead of
+``is None``: the point is "no test leaks its handle onward", not "the handle is
+always None", and the latter would break the day a session-scoped fixture
+legitimately installs one.
+"""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from utils import steam_state
+
+
+class _MarkerSteamworks:
+    """Stand-in handle installed only by the guards in this module."""
+
+
+_MARKER_LAST_ATTEMPT = 424242.0
+
+
+def _marker_initializer():
+    return _MarkerSteamworks()
+
+
+def _assert_no_marker_leaked_in() -> None:
+    assert not isinstance(steam_state._steamworks, _MarkerSteamworks), (
+        "utils.steam_state._steamworks leaked from another test — the "
+        "_reset_steamworks_handle fixture is no longer restoring it"
+    )
+    assert steam_state._steamworks_initializer is not _marker_initializer, (
+        "utils.steam_state._steamworks_initializer leaked from another test"
+    )
+    assert steam_state._last_init_attempt_monotonic != _MARKER_LAST_ATTEMPT, (
+        "utils.steam_state._last_init_attempt_monotonic leaked from another test"
+    )
+
+    main_server = sys.modules.get("app.main_server")
+    if main_server is not None:
+        assert not isinstance(main_server.steamworks, _MarkerSteamworks), (
+            "app.main_server.steamworks mirror leaked from another test — "
+            "on_startup seeds shared state from this global"
+        )
+
+
+def _install_marker_handle() -> None:
+    """Dirty every global the fixture is responsible for restoring."""
+    from app import main_server
+
+    steam_state._steamworks = _MarkerSteamworks()
+    steam_state._steamworks_initializer = _marker_initializer
+    steam_state._last_init_attempt_monotonic = _MARKER_LAST_ATTEMPT
+    main_server.steamworks = steam_state._steamworks
+
+
+@pytest.mark.unit
+def test_steamworks_globals_are_not_inherited_from_a_previous_test():
+    _assert_no_marker_leaked_in()
+    _install_marker_handle()
+
+
+@pytest.mark.unit
+def test_steamworks_globals_are_restored_between_tests():
+    _assert_no_marker_leaked_in()
+    _install_marker_handle()
+
+
+@pytest.mark.unit
+def test_ensure_steamworks_lazy_init_does_not_outlive_the_test():
+    """The concrete leak path: a lazy ``ensure_steamworks()`` from a request handler.
+
+    ``main_routers/config_router/language.py`` calls ``ensure_steamworks()``,
+    which runs whatever initializer ``main_server.on_startup`` registered. Here
+    the initializer is a stub so the guard runs identically with or without a
+    Steam client, which is what makes this reproduce on CI and not just on a
+    developer machine.
+    """
+    from main_routers.shared_state import ensure_steamworks
+
+    steam_state._steamworks = None
+    steam_state._steamworks_initializer = _marker_initializer
+    steam_state._last_init_attempt_monotonic = _MARKER_LAST_ATTEMPT
+
+    handle = ensure_steamworks(force=True)
+
+    assert isinstance(handle, _MarkerSteamworks)
+    assert steam_state._steamworks is handle
+    # Teardown must undo all of this; the two guards above are what observe it.


### PR DESCRIPTION
## 现象

`tests/unit/test_cloudsave_lifecycle_flow.py::test_main_server_manual_startup_performs_fallback_import_and_continues_boot`

- 单独跑（只指定这一个 node id）→ PASSED
- 整文件跑 → 该条 FAILED，同文件其余 34 条 PASSED

```
assert [call(<steamworks.STEAMWORKS object at 0x...>), call(None)] == [call(None), call(None)]
At index 0 diff: call(<steamworks.STEAMWORKS object at 0x...>) != call(None)
```

拿到的第一项是一个**真的** STEAMWORKS 对象。与 #2667 那条分支无关，`origin/main` 上就有。

## 根因

Steamworks 进程级单例在用例之间**没有任何还原**。

`main_routers/config_router/language.py` 的 `/api/config/steam_language` 会调 `ensure_steamworks()`，它执行 `main_server.on_startup` 注册过的 initializer，把活的 STEAMWORKS 句柄同时装进两处：

- `utils.steam_state._steamworks`（L1 单例本体）
- `app.main_server.steamworks`（同一句柄的模块级镜像）

目标用例并**不** patch 这个镜像，而 `on_startup` 恰恰是从它读值去 seed shared state（[app/main_server/\_\_init\_\_.py:1103](app/main_server/__init__.py#L1103)），于是读到了上一条用例漏下来的真句柄。

需要两条用例接力才触发：

1. 先有一条跑过 `_IS_MAIN_PROCESS=True` 的 `on_startup`，注册了 initializer；
2. 再由 `test_main_server_limited_mode_middleware_blocks_runtime_routes` 打那个端点，把 initializer 点着。

单独跑任一条都不复现——这就是"只有整文件跑才红"的原因。

**CI 一直看不见**：没有 Steam 客户端时 initializer 返回 `None`，泄漏不可观测。这是开发机独有的红。

## 覆盖是退化来的

#1270 之前这个句柄就在 `main_routers.shared_state._state` 里，`_reset_shared_state` 那条 autouse fixture 是**还原它的**。把单例下沉到 L1 的 `utils.steam_state` 修 layering 之后，它悄悄掉出了那份快照。本 PR 在它的新家上补回这份覆盖。

## 改动

- **[tests/unit/conftest.py](tests/unit/conftest.py)**：新增 autouse fixture `_reset_steamworks_handle`。快照/还原整个 `utils.steam_state` 模块命名空间——不列名字清单，将来往那个模块加全局会被自动覆盖；外加 `app.main_server.steamworks` 镜像。还原时拿模块自己那把锁。
- **[tests/unit/test_steamworks_state_isolation.py](tests/unit/test_steamworks_state_isolation.py)**：护栏。两条用例各自"先断言没收到本模块的 marker、再装一个"，所以无论 pytest-randomly 洗成什么顺序，**后跑**的那条都会在 fixture 失效时转红（顺序无关）；第三条走真实的 `ensure_steamworks()` 惰性初始化路径，用桩 initializer 让它在无 Steam 的 CI 上同样能复现，而不只在装了 Steam 的开发机上。

断言找的是"本模块的 marker"而不是 `is None`：要守的是"没有用例把句柄漏给下一条"，不是"句柄永远是 None"——后者会在将来某个 session 级 fixture 合法装一个句柄时误报。

## 变异验证

三条变异都按预期转红：

| 变异 | 护栏 | `test_cloudsave_lifecycle_flow.py` |
|---|---|---|
| 只关镜像还原 | 🔴 红 | 🟢 绿 |
| 只关 `steam_state` 还原 | 🔴 红 | 🟢 绿 |
| 整条 fixture 关掉 | 🔴 红 | 🔴 复现 1 failed / 34 passed |

前两行是重点：护栏比原始症状更强——单关一半时那个 cloudsave 用例已经不红了，护栏还红着。

## 验证

- `tests/unit` 全量：**15086 passed, 267 skipped**（autouse fixture 打到每条用例，所以跑了全量而不是只跑相关文件）
- `scripts/check_docstring_no_cjk.py --base origin/main` → exit 0
- `scripts/check_module_layering.py` → exit 0

复现/验证时注意 `-p no:randomly` 会改顺序（且 `pytest.ini` 的 `addopts` 里钉了 `--randomly-seed`，屏蔽插件会直接报参数错），不能拿来判定"已修好"——上面所有结论都是在默认固定 seed 下得到的。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
