### PR TITLE
fix: preserve passive callback ownership during hot-swap prime

### DIFF
--- a/main_logic/core/lifecycle.py
+++ b/main_logic/core/lifecycle.py
@@ -2420,6 +2420,9 @@ class LifecycleMixin:
                 core_voice_session_lock = asyncio.Lock()
                 self._core_voice_session_swap_lock = core_voice_session_lock
             async with core_voice_session_lock:
+                _abort_if_passive_claim_retracted(
+                    "while waiting for core voice swap lock"
+                )
                 # ── 步骤 2：旧 task 已停，安全关闭旧 session ─────────────────────
                 if old_main_session:
                     try:

--- a/main_logic/core/lifecycle.py
+++ b/main_logic/core/lifecycle.py
@@ -2442,6 +2442,7 @@ class LifecycleMixin:
                 # 镜像启动侧的强 CAS：任何偏离都意味着并发 start/end_session
                 # 已接管会话，此时覆盖 self.session 会孤儿化赢家。
                 async with self.lock:
+                    _abort_if_passive_claim_retracted("while waiting for promote lock")
                     _promote_allowed = self.session is old_main_session
                     if _promote_allowed:
                         self.session = new_session

--- a/main_logic/core/lifecycle.py
+++ b/main_logic/core/lifecycle.py
@@ -29,6 +29,7 @@ from main_logic.omni_realtime_client import OmniRealtimeClient
 from main_logic.omni_offline_client import OmniOfflineClient, _is_safety_violation_signal
 from main_logic.proactive_delivery import (
     DELIVERY_RETRACTED_KEY,
+    SWAP_PRIME_DELIVERY_CLAIM_KEY,
     resolve_callback_delivery_ack,
 )
 from utils.gptsovits_config import is_gsv_disabled_voice_id
@@ -1999,11 +2000,13 @@ class LifecycleMixin:
         swap (same semantics as the extras ``_deferred``).
 
         The queue is NOT drained here — removal is deferred to promote
-        success via :meth:`_remove_swap_delivered_passive_cbs`, mirroring the
-        ``_prime_selected_extras`` bookkeeping, so every pre-promote abort
-        keeps the queue intact with zero restore code. Topic-hook snapshots
-        are excluded: they have their own ack/retry lifecycle and delivery
-        gates that this path must not bypass.
+        success via :meth:`_remove_swap_delivered_passive_cbs`. Selected
+        entries are atomically marked provider-owned before this method
+        returns, so enqueue coalescing, text drain, staleness sweeps, and the
+        flood guard cannot retract them during the prime await. Every
+        pre-promote exit releases that claim in the swap sequence's ``finally``
+        block. Topic-hook snapshots are excluded: they have their own ack/retry
+        lifecycle and delivery gates that this path must not bypass.
         """
         try:
             candidates = [
@@ -2011,6 +2014,7 @@ class LifecycleMixin:
                 if isinstance(cb, dict)
                 and cb.get("delivery_mode") == "passive"
                 and not cb.get(DELIVERY_RETRACTED_KEY)
+                and not cb.get(SWAP_PRIME_DELIVERY_CLAIM_KEY)
                 and cb.get("channel") != "topic_hook"
             ]
             if not candidates:
@@ -2041,11 +2045,23 @@ class LifecycleMixin:
                 master_name=getattr(self, "master_name", "") or "",
                 passive=True,
             )
+            # No await exists between selection and this ownership claim. From
+            # here until promote/abort, every queue mutation sees the same
+            # provider-owned boundary as the swap sequence.
+            for cb in selected:
+                cb[SWAP_PRIME_DELIVERY_CLAIM_KEY] = True
             return selected, rendered
         except Exception as e:
             # 选取/渲染失败绝不能打断 swap：这批 passive 留在队列等下一轮。
             logger.warning(f"Final Swap Sequence: passive callback selection failed: {e}")
             return [], ""
+
+    @staticmethod
+    def _release_swap_prime_passive_claims(selected: list) -> None:
+        """Release provider ownership after promote or any abort exit."""
+        for cb in selected or []:
+            if isinstance(cb, dict):
+                cb.pop(SWAP_PRIME_DELIVERY_CLAIM_KEY, None)
 
     def _remove_swap_delivered_passive_cbs(self, selected: list) -> list:
         """[Hot-swap related] Dequeue prime-injected passive callbacks at
@@ -2058,6 +2074,7 @@ class LifecycleMixin:
         """
         if not selected:
             return []
+        self._release_swap_prime_passive_claims(selected)
         try:
             selected_obj_ids = {id(cb) for cb in selected}
             removed = [
@@ -2109,11 +2126,9 @@ class LifecycleMixin:
             if not restored:
                 return
             self.pending_agent_callbacks = restored + self.pending_agent_callbacks
-            # flood guard 与 enqueue_agent_callback 对齐：drop-oldest。
-            if len(self.pending_agent_callbacks) > AGENT_CALLBACK_QUEUE_MAX_ITEMS:
-                self.pending_agent_callbacks = (
-                    self.pending_agent_callbacks[-AGENT_CALLBACK_QUEUE_MAX_ITEMS:]
-                )
+            self._enforce_agent_callback_queue_limit(
+                AGENT_CALLBACK_QUEUE_MAX_ITEMS
+            )
             logger.info(
                 "Final Swap Sequence: %d undelivered passive callback(s) restored to queue head after aborted swap",
                 len(restored),
@@ -2170,6 +2185,16 @@ class LifecycleMixin:
             _passive_sel: list = []
             _passive_swap_text = ""
             _extras_for_budget: list = []
+
+            def _abort_if_passive_claim_retracted(stage: str) -> None:
+                if any(cb.get(DELIVERY_RETRACTED_KEY)
+                       for cb in _prime_selected_passive_cbs):
+                    logger.info(
+                        "Final Swap Sequence: passive callback retracted %s; abandoning pending session",
+                        stage,
+                    )
+                    raise asyncio.CancelledError()
+
             next_session_context_messages = getattr(self, "next_session_context_messages", []) or []
             incremental_next_session_context = next_session_context_messages[
                 self.initial_next_session_context_snapshot_len:
@@ -2304,11 +2329,9 @@ class LifecycleMixin:
             # 快照注进新会话（Codex P2）；剩余窗口只有本次注入自身的
             # await，与 extras 的 accepted residual window 对齐。skipped=True
             # 在非 Gemini 上走 session instructions（Qwen 同路），不产生
-            # turn，与播报 prime 物理隔离。失败 best-effort 兜住全部
-            # Exception（provider RuntimeError/超时不该中止已成功的主
-            # prime，Codex P2）：_prime_selected_passive_cbs 不赋值 →
-            # promote 不出队，条目留队等下一次热切换；pending session 若
-            # 真死了，promote 后的 ws 校验会兜住。
+            # turn，与播报 prime 物理隔离。provider 调用一旦开始后抛错，无法
+            # 证明远端是否已写入；因此必须放弃并关闭本次 pending session，
+            # 不能继续 promote 后又把 cue 留队造成未来重试/双投。
             if (isinstance(self.pending_session, OmniRealtimeClient)
                     and not getattr(self.pending_session, "_is_gemini", False)):
                 _passive_sel, _passive_swap_text = (
@@ -2322,8 +2345,14 @@ class LifecycleMixin:
                         _prime_selected_passive_cbs = _passive_sel
                     except Exception as e:
                         logger.warning(
-                            f"Final Swap Sequence: passive ride-along prime failed (kept queued): {e}"
+                            f"Final Swap Sequence: passive ride-along prime failed; abandoning pending session: {e}"
                         )
+                        await self._cleanup_pending_session_resources()
+                        await self._reset_preparation_state(clear_main_cache=True)
+                        self.is_hot_swap_imminent = False
+                        return
+
+            _abort_if_passive_claim_retracted("during prime")
 
             print(final_prime_text) #只在控制台显示，不输出到日志文件
 
@@ -2376,6 +2405,8 @@ class LifecycleMixin:
                 except Exception as e:
                     logger.warning(f"Final Swap Sequence: Old task exited with error: {e}")
 
+            _abort_if_passive_claim_retracted("before old session close")
+
             # Exclude Core voice-final delivery across the entire close+promote
             # window. The ASR dispatcher shares this lock, so a final either
             # completes before the old arbiter closes or sees the replacement
@@ -2395,6 +2426,8 @@ class LifecycleMixin:
                         await old_main_session.close()
                     except Exception as e:
                         logger.error(f"💥 Final Swap Sequence: Error closing old session: {e}")
+
+                _abort_if_passive_claim_retracted("before promote")
 
                 # ── promote 前的协作取消检查点 ───────────────────────────────────
                 # Python 3.11 的 asyncio.wait_for（步骤 1）以及部分 session.close()
@@ -2603,6 +2636,8 @@ class LifecycleMixin:
             if self.is_active and self.session and hasattr(self.session, 'handle_messages') and (not self.message_handler_task or self.message_handler_task.done()):
                 self.message_handler_task = asyncio.create_task(self.session.handle_messages())
         finally:
+            self._release_swap_prime_passive_claims(_passive_sel)
+            self._purge_retracted_agent_callbacks()
             self.is_hot_swap_imminent = False  # Always reset this flag
             if self.final_swap_task and self.final_swap_task.done():
                 self.final_swap_task = None

--- a/main_logic/core/proactive.py
+++ b/main_logic/core/proactive.py
@@ -31,6 +31,7 @@ from utils.llm_client import AIMessage
 from main_logic.session_state import SessionEvent, ProactivePhase
 from main_logic.proactive_delivery import (
     DELIVERY_RETRACTED_KEY,
+    SWAP_PRIME_DELIVERY_CLAIM_KEY,
     VOICE_DELIVERY_COMMITTED_KEY,
     resolve_callback_delivery_ack,
 )
@@ -552,20 +553,30 @@ class ProactiveMixin:
         return True
 
     def _purge_retracted_agent_callbacks(self) -> None:
+        callbacks = getattr(self, "pending_agent_callbacks", None)
+        if not callbacks:
+            return
+        purgeable = [
+            cb for cb in callbacks
+            if cb.get(DELIVERY_RETRACTED_KEY)
+            and not (
+                cb.get(VOICE_DELIVERY_COMMITTED_KEY)
+                or cb.get(SWAP_PRIME_DELIVERY_CLAIM_KEY)
+            )
+        ]
+        if not purgeable:
+            return
+        purgeable_obj_ids = {id(cb) for cb in purgeable}
         retracted_ids = {
             cb.get("_callback_delivery_id")
-            for cb in self.pending_agent_callbacks
-            if cb.get(DELIVERY_RETRACTED_KEY) and cb.get("_callback_delivery_id")
+            for cb in purgeable
+            if cb.get("_callback_delivery_id")
         }
-        has_retracted = any(
-            cb.get(DELIVERY_RETRACTED_KEY)
-            for cb in self.pending_agent_callbacks
-        )
-        if not has_retracted:
-            return
+        for cb in purgeable:
+            resolve_callback_delivery_ack(cb, False)
         self.pending_agent_callbacks = [
-            cb for cb in self.pending_agent_callbacks
-            if not cb.get(DELIVERY_RETRACTED_KEY)
+            cb for cb in callbacks
+            if id(cb) not in purgeable_obj_ids
         ]
         if retracted_ids:
             self.pending_extra_replies = [
@@ -577,7 +588,12 @@ class ProactiveMixin:
         retracted_ids = {
             cb.get("_callback_delivery_id")
             for cb in callbacks
-            if cb.get(DELIVERY_RETRACTED_KEY) and cb.get("_callback_delivery_id")
+            if cb.get(DELIVERY_RETRACTED_KEY)
+            and not (
+                cb.get(VOICE_DELIVERY_COMMITTED_KEY)
+                or cb.get(SWAP_PRIME_DELIVERY_CLAIM_KEY)
+            )
+            and cb.get("_callback_delivery_id")
         }
         if retracted_ids:
             self.pending_extra_replies = [
@@ -965,6 +981,10 @@ class ProactiveMixin:
                         cb for cb in voice_snapshot
                         if not cb.get(DELIVERY_RETRACTED_KEY)
                     ]
+                    self._clear_voice_delivery_committed([
+                        cb for cb in voice_commit_snapshot
+                        if cb.get(DELIVERY_RETRACTED_KEY)
+                    ])
                     self._purge_retracted_agent_callbacks()
                     if not voice_snapshot:
                         self._clear_voice_delivery_committed(
@@ -1566,11 +1586,12 @@ class ProactiveMixin:
         stale — coalescing stays strictly opt-in."""
         if not isinstance(entry, dict):
             return False
-        if entry.get(VOICE_DELIVERY_COMMITTED_KEY):
-            # Once provider media delivery has begun, the matching callback
-            # text must complete the same turn. A newer same-key cue remains
-            # queued for the following turn instead of orphaning media that
-            # may already be persisted in provider context.
+        if (entry.get(VOICE_DELIVERY_COMMITTED_KEY)
+                or entry.get(SWAP_PRIME_DELIVERY_CLAIM_KEY)):
+            # Once provider delivery has begun (voice media or hot-swap prime),
+            # the matching callback text must complete that same delivery.
+            # A newer same-key cue stays queued for the following turn instead
+            # of orphaning context that may already be persisted provider-side.
             return False
         key = str(entry.get("coalesce_key") or "").strip()
         seq = entry.get("_coalesce_submit_seq")
@@ -2121,6 +2142,95 @@ class ProactiveMixin:
                 n += 1
         return n
 
+    def _enforce_agent_callback_queue_limit(self, max_items: int) -> None:
+        """Drop the oldest safely retractable callbacks above ``max_items``.
+
+        Provider-owned entries are never flood victims: voice delivery marks
+        them committed, while hot-swap prime marks them claimed before its
+        await. When all older entries are protected, a newly appended callback
+        is rejected instead.
+        """
+        overflow = len(self.pending_agent_callbacks) - max_items
+        if overflow <= 0:
+            return
+
+        dropped: list = []
+        surviving: list = []
+        for queued in self.pending_agent_callbacks:
+            protected = (
+                isinstance(queued, dict)
+                and (
+                    queued.get(VOICE_DELIVERY_COMMITTED_KEY)
+                    or queued.get(SWAP_PRIME_DELIVERY_CLAIM_KEY)
+                )
+            )
+            if overflow > 0 and not protected:
+                dropped.append(queued)
+                overflow -= 1
+            else:
+                surviving.append(queued)
+
+        self.pending_agent_callbacks = surviving
+        dropped_ids = set()
+        for queued in dropped:
+            if not isinstance(queued, dict):
+                continue
+            resolve_callback_delivery_ack(queued, False)
+            queued[DELIVERY_RETRACTED_KEY] = True
+            delivery_id = queued.get("_callback_delivery_id")
+            if delivery_id:
+                dropped_ids.add(delivery_id)
+
+        if dropped_ids:
+            self.pending_extra_replies = [
+                extra for extra in self.pending_extra_replies
+                if not (
+                    isinstance(extra, dict)
+                    and extra.get("_callback_delivery_id") in dropped_ids
+                )
+            ]
+        if overflow > 0:
+            logger.warning(
+                "[%s] callback queue remains over limit: %d provider-owned entry(s) cannot be evicted",
+                self.lanlan_name,
+                overflow,
+            )
+
+    def _enforce_pending_extra_reply_queue_limit(self, max_items: int) -> None:
+        """Trim extras without orphaning a provider-owned callback mirror."""
+        overflow = len(self.pending_extra_replies) - max_items
+        if overflow <= 0:
+            return
+
+        provider_owned_ids = {
+            callback.get("_callback_delivery_id")
+            for callback in self.pending_agent_callbacks
+            if isinstance(callback, dict)
+            and (
+                callback.get(VOICE_DELIVERY_COMMITTED_KEY)
+                or callback.get(SWAP_PRIME_DELIVERY_CLAIM_KEY)
+            )
+            and callback.get("_callback_delivery_id")
+        }
+        surviving: list = []
+        for extra in self.pending_extra_replies:
+            delivery_id = (
+                extra.get("_callback_delivery_id")
+                if isinstance(extra, dict)
+                else None
+            )
+            if overflow > 0 and delivery_id not in provider_owned_ids:
+                overflow -= 1
+            else:
+                surviving.append(extra)
+        self.pending_extra_replies = surviving
+        if overflow > 0:
+            logger.warning(
+                "[%s] extra reply queue remains over limit: %d provider-owned mirror(s) cannot be evicted",
+                self.lanlan_name,
+                overflow,
+            )
+
     def enqueue_agent_callback(self, callback: dict) -> None:
         """Enqueue a structured agent task callback for LLM injection.
 
@@ -2230,6 +2340,7 @@ class ProactiveMixin:
                 incoming_superseded = False
                 dropped = 0
                 superseded_ids: set = set()
+                provider_owned_ids: set = set()
                 surviving: list[dict] = []
                 for _cb in self.pending_agent_callbacks:
                     # isinstance guard: the queue should hold dicts, but never let
@@ -2239,14 +2350,24 @@ class ProactiveMixin:
                             and str(_cb.get("coalesce_key") or "").strip() == new_key):
                         surviving.append(_cb)
                         continue
-                    if _cb.get(VOICE_DELIVERY_COMMITTED_KEY):
-                        # This cue has crossed the media-delivery commit
-                        # boundary. Keep it; the new cue queues for the next
-                        # turn instead of retracting already-persisted media.
-                        surviving.append(_cb)
-                        continue
                     _old_seq = _cb.get("_coalesce_submit_seq")
                     _old_seq = _old_seq if isinstance(_old_seq, int) else -1
+                    _provider_owned = (
+                        _cb.get(VOICE_DELIVERY_COMMITTED_KEY)
+                        or _cb.get(SWAP_PRIME_DELIVERY_CLAIM_KEY)
+                    )
+                    if _provider_owned:
+                        # This cue has crossed a provider-delivery ownership
+                        # boundary and cannot be retracted. A genuinely newer
+                        # cue queues for the next turn; an older/equal late
+                        # arrival loses without disturbing provider state.
+                        if _old_seq >= new_seq:
+                            incoming_superseded = True
+                        _did = _cb.get("_callback_delivery_id")
+                        if _did:
+                            provider_owned_ids.add(_did)
+                        surviving.append(_cb)
+                        continue
                     if _old_seq > new_seq:
                         # A newer same-key cue is already queued → the incoming one
                         # (an older manager-released respond) loses; keep the queued.
@@ -2280,6 +2401,11 @@ class ProactiveMixin:
                     kept_extras: list = []
                     for _extra in self.pending_extra_replies:
                         if not isinstance(_extra, dict):
+                            kept_extras.append(_extra)
+                            continue
+                        if _extra.get("_callback_delivery_id") in provider_owned_ids:
+                            # Mirror of a provider-owned callback: it belongs to
+                            # the same in-flight delivery and must survive too.
                             kept_extras.append(_extra)
                             continue
                         # A mirror paired with a just-retracted callback is
@@ -2324,33 +2450,15 @@ class ProactiveMixin:
                     "source_name": source_name,
                     "error_message": error_message,
                 })
-            # Flood guard: a runaway plugin event stream must not grow either
-            # queue without bound. Keep the most recent N (newest = most
-            # relevant); drop-oldest.
-            if len(self.pending_agent_callbacks) > AGENT_CALLBACK_QUEUE_MAX_ITEMS:
-                overflow = len(self.pending_agent_callbacks) - AGENT_CALLBACK_QUEUE_MAX_ITEMS
-                dropped = self.pending_agent_callbacks[:overflow]
-                dropped_ids = {
-                    _cb.get("_callback_delivery_id")
-                    for _cb in dropped
-                    if isinstance(_cb, dict) and _cb.get("_callback_delivery_id")
-                }
-                self.pending_agent_callbacks = self.pending_agent_callbacks[overflow:]
-                # Resolve any delivery-ack future on a dropped callback NOW, so a
-                # waiter (e.g. topic-hook delivery) unblocks immediately instead
-                # of stalling until its timeout.
-                for _cb in dropped:
-                    resolve_callback_delivery_ack(_cb, False)
-                # Drop the matching voice-queue mirrors by delivery_id (the two
-                # queues drift, so positional trimming is unreliable) — otherwise
-                # a callback acked False here could still be injected via hot-swap.
-                if dropped_ids:
-                    self.pending_extra_replies = [
-                        _extra for _extra in self.pending_extra_replies
-                        if _extra.get("_callback_delivery_id") not in dropped_ids
-                    ]
-            if len(self.pending_extra_replies) > AGENT_CALLBACK_QUEUE_MAX_ITEMS:
-                self.pending_extra_replies = self.pending_extra_replies[-AGENT_CALLBACK_QUEUE_MAX_ITEMS:]
+            # Flood guard: evict only callbacks that have not crossed a
+            # provider-delivery ownership boundary. If every older entry is
+            # claimed/committed, the just-appended callback is the safe victim.
+            self._enforce_agent_callback_queue_limit(
+                AGENT_CALLBACK_QUEUE_MAX_ITEMS
+            )
+            self._enforce_pending_extra_reply_queue_limit(
+                AGENT_CALLBACK_QUEUE_MAX_ITEMS
+            )
         except Exception:
             # Pruning is best-effort housekeeping — never let it break callback bookkeeping.
             pass
@@ -2388,6 +2496,7 @@ class ProactiveMixin:
         active_callbacks = [
             cb for cb in candidate_callbacks
             if not cb.get(DELIVERY_RETRACTED_KEY)
+            and not cb.get(SWAP_PRIME_DELIVERY_CLAIM_KEY)
         ]
         if not active_callbacks:
             return ""
@@ -2395,7 +2504,7 @@ class ProactiveMixin:
         # Budget-aware selection: render (and ack) only the callbacks that fit
         # the total budget this turn; defer the rest to the next drain instead
         # of acking them as delivered while their text falls off the cap.
-        callbacks_snapshot, deferred = _select_callbacks_within_token_budget(
+        callbacks_snapshot, _deferred = _select_callbacks_within_token_budget(
             active_callbacks, AGENT_CALLBACK_TOTAL_MAX_TOKENS
         )
         delivered_to_prompt = False
@@ -2414,6 +2523,10 @@ class ProactiveMixin:
             if delivered_to_prompt:
                 for cb in callbacks_snapshot:
                     resolve_callback_delivery_ack(cb, True)
-            # Keep deferred (over-budget) callbacks for the next turn; only the
-            # rendered+acked ones leave the queue.
-            self.pending_agent_callbacks = deferred
+            # Keep claimed and over-budget callbacks in their original order;
+            # only the entries actually rendered by this drain leave the queue.
+            delivered_obj_ids = {id(cb) for cb in callbacks_snapshot}
+            self.pending_agent_callbacks = [
+                cb for cb in self.pending_agent_callbacks
+                if id(cb) not in delivered_obj_ids
+            ]

--- a/main_logic/core/proactive.py
+++ b/main_logic/core/proactive.py
@@ -2326,7 +2326,6 @@ class ProactiveMixin:
             # snapshots, bounded only by the drop-oldest flood guard below. An
             # empty key never coalesces, so no existing producer regresses.
             new_key = str(callback.get("coalesce_key") or "").strip()
-            previous_latest_seq = None
             if new_key:
                 # Submission-order stamp: cues carry a monotonic seq assigned at
                 # submit_proactive_callback (manager-held respond cues) or here
@@ -2340,7 +2339,6 @@ class ProactiveMixin:
                 # Feed the pull-model staleness map: delivery-point guards
                 # (_retract_stale_coalesced / _coalesce_entry_is_stale) compare
                 # in-flight snapshot entries against this latest seq.
-                previous_latest_seq = getattr(self, "_coalesce_latest", {}).get(new_key)
                 self._note_coalesce_submission(new_key, new_seq)
                 incoming_superseded = False
                 dropped = 0
@@ -2466,13 +2464,23 @@ class ProactiveMixin:
                 and any(dropped is callback for dropped in flood_dropped)
                 and getattr(self, "_coalesce_latest", {}).get(new_key) == new_seq
             ):
-                # Flood rejection means this cue never became pending. Undo only
-                # this enqueue's latest-seq advance so the provider-owned older
-                # cue does not become stale merely because its successor was
-                # rejected. There is no await in this method, so the equality
-                # guard also prevents clobbering a genuinely newer submission.
-                if isinstance(previous_latest_seq, int):
-                    self._coalesce_latest[new_key] = previous_latest_seq
+                # Flood rejection means this cue never became pending. Rebuild
+                # latest from entries that actually survived in either live
+                # queue. This also covers manager-held respond cues, whose seq
+                # was already recorded at submit time before this enqueue.
+                surviving_seqs = [
+                    entry.get("_coalesce_submit_seq")
+                    for entry in (
+                        list(self.pending_agent_callbacks)
+                        + list(self.pending_extra_replies)
+                    )
+                    if isinstance(entry, dict)
+                    and not entry.get(DELIVERY_RETRACTED_KEY)
+                    and str(entry.get("coalesce_key") or "").strip() == new_key
+                    and isinstance(entry.get("_coalesce_submit_seq"), int)
+                ]
+                if surviving_seqs:
+                    self._coalesce_latest[new_key] = max(surviving_seqs)
                 else:
                     self._coalesce_latest.pop(new_key, None)
             self._enforce_pending_extra_reply_queue_limit(

--- a/main_logic/core/proactive.py
+++ b/main_logic/core/proactive.py
@@ -2479,6 +2479,16 @@ class ProactiveMixin:
                     and str(entry.get("coalesce_key") or "").strip() == new_key
                     and isinstance(entry.get("_coalesce_submit_seq"), int)
                 ]
+                delivery_manager = getattr(self, "proactive_manager", None)
+                manager_seq_reader = getattr(
+                    delivery_manager,
+                    "latest_queued_coalesce_seq",
+                    None,
+                )
+                if callable(manager_seq_reader):
+                    manager_seq = manager_seq_reader(new_key)
+                    if isinstance(manager_seq, int):
+                        surviving_seqs.append(manager_seq)
                 if surviving_seqs:
                     self._coalesce_latest[new_key] = max(surviving_seqs)
                 else:

--- a/main_logic/core/proactive.py
+++ b/main_logic/core/proactive.py
@@ -581,7 +581,8 @@ class ProactiveMixin:
         if retracted_ids:
             self.pending_extra_replies = [
                 extra for extra in self.pending_extra_replies
-                if extra.get("_callback_delivery_id") not in retracted_ids
+                if not isinstance(extra, dict)
+                or extra.get("_callback_delivery_id") not in retracted_ids
             ]
 
     def _purge_retracted_agent_callback_extras(self, callbacks: list) -> None:
@@ -598,7 +599,8 @@ class ProactiveMixin:
         if retracted_ids:
             self.pending_extra_replies = [
                 extra for extra in self.pending_extra_replies
-                if extra.get("_callback_delivery_id") not in retracted_ids
+                if not isinstance(extra, dict)
+                or extra.get("_callback_delivery_id") not in retracted_ids
             ]
 
     async def trigger_agent_callbacks(self) -> bool:
@@ -2142,7 +2144,7 @@ class ProactiveMixin:
                 n += 1
         return n
 
-    def _enforce_agent_callback_queue_limit(self, max_items: int) -> None:
+    def _enforce_agent_callback_queue_limit(self, max_items: int) -> list:
         """Drop the oldest safely retractable callbacks above ``max_items``.
 
         Provider-owned entries are never flood victims: voice delivery marks
@@ -2152,7 +2154,7 @@ class ProactiveMixin:
         """
         overflow = len(self.pending_agent_callbacks) - max_items
         if overflow <= 0:
-            return
+            return []
 
         dropped: list = []
         surviving: list = []
@@ -2195,6 +2197,7 @@ class ProactiveMixin:
                 self.lanlan_name,
                 overflow,
             )
+        return dropped
 
     def _enforce_pending_extra_reply_queue_limit(self, max_items: int) -> None:
         """Trim extras without orphaning a provider-owned callback mirror."""
@@ -2323,6 +2326,7 @@ class ProactiveMixin:
             # snapshots, bounded only by the drop-oldest flood guard below. An
             # empty key never coalesces, so no existing producer regresses.
             new_key = str(callback.get("coalesce_key") or "").strip()
+            previous_latest_seq = None
             if new_key:
                 # Submission-order stamp: cues carry a monotonic seq assigned at
                 # submit_proactive_callback (manager-held respond cues) or here
@@ -2336,6 +2340,7 @@ class ProactiveMixin:
                 # Feed the pull-model staleness map: delivery-point guards
                 # (_retract_stale_coalesced / _coalesce_entry_is_stale) compare
                 # in-flight snapshot entries against this latest seq.
+                previous_latest_seq = getattr(self, "_coalesce_latest", {}).get(new_key)
                 self._note_coalesce_submission(new_key, new_seq)
                 incoming_superseded = False
                 dropped = 0
@@ -2453,9 +2458,23 @@ class ProactiveMixin:
             # Flood guard: evict only callbacks that have not crossed a
             # provider-delivery ownership boundary. If every older entry is
             # claimed/committed, the just-appended callback is the safe victim.
-            self._enforce_agent_callback_queue_limit(
+            flood_dropped = self._enforce_agent_callback_queue_limit(
                 AGENT_CALLBACK_QUEUE_MAX_ITEMS
             )
+            if (
+                new_key
+                and any(dropped is callback for dropped in flood_dropped)
+                and getattr(self, "_coalesce_latest", {}).get(new_key) == new_seq
+            ):
+                # Flood rejection means this cue never became pending. Undo only
+                # this enqueue's latest-seq advance so the provider-owned older
+                # cue does not become stale merely because its successor was
+                # rejected. There is no await in this method, so the equality
+                # guard also prevents clobbering a genuinely newer submission.
+                if isinstance(previous_latest_seq, int):
+                    self._coalesce_latest[new_key] = previous_latest_seq
+                else:
+                    self._coalesce_latest.pop(new_key, None)
             self._enforce_pending_extra_reply_queue_limit(
                 AGENT_CALLBACK_QUEUE_MAX_ITEMS
             )

--- a/main_logic/proactive_delivery.py
+++ b/main_logic/proactive_delivery.py
@@ -291,6 +291,19 @@ class ProactiveDeliveryManager:
         self._queue = []
         return [c.callback for c in ordered]
 
+    def latest_queued_coalesce_seq(self, key: str) -> Optional[int]:
+        """Return the newest submit seq still waiting under ``key``."""
+        return max(
+            (
+                cue.callback.get("_coalesce_submit_seq")
+                for cue in self._queue
+                if cue.coalesce_key == key
+                and not cue.callback.get(DELIVERY_RETRACTED_KEY)
+                and isinstance(cue.callback.get("_coalesce_submit_seq"), int)
+            ),
+            default=None,
+        )
+
     # ── pump ─────────────────────────────────────────────────────────────
     def _suffix(self) -> str:
         return f":{self._name}" if self._name else ""

--- a/main_logic/proactive_delivery.py
+++ b/main_logic/proactive_delivery.py
@@ -67,6 +67,7 @@ logger = logging.getLogger("main_logic.proactive_delivery")
 DELIVERY_ACK_FUTURE_KEY = "_proactive_delivery_ack_future"
 DELIVERY_RETRACTED_KEY = "_proactive_delivery_retracted"
 VOICE_DELIVERY_COMMITTED_KEY = "_voice_delivery_committed"
+SWAP_PRIME_DELIVERY_CLAIM_KEY = "_swap_prime_delivery_claimed"
 
 
 def resolve_callback_delivery_ack(callback: dict, delivered: bool) -> None:

--- a/tests/unit/test_hot_swap_cancellation.py
+++ b/tests/unit/test_hot_swap_cancellation.py
@@ -607,15 +607,14 @@ async def test_final_swap_rechecks_retraction_after_core_voice_lock_wait():
 
     mgr.final_swap_task = asyncio.create_task(mgr._perform_final_swap_sequence())
     swap_task = mgr.final_swap_task
-    await asyncio.wait_for(prime_entered.wait(), timeout=5)
-    allow_prime.set()
-    await asyncio.wait_for(voice_lock.entered.wait(), timeout=5)
-    callback[DELIVERY_RETRACTED_KEY] = True
-    mgr._purge_retracted_agent_callbacks()
-    assert callback.get(SWAP_PRIME_DELIVERY_CLAIM_KEY) is True
-    voice_lock.release.set()
-
     try:
+        await asyncio.wait_for(prime_entered.wait(), timeout=5)
+        allow_prime.set()
+        await asyncio.wait_for(voice_lock.entered.wait(), timeout=5)
+        callback[DELIVERY_RETRACTED_KEY] = True
+        mgr._purge_retracted_agent_callbacks()
+        assert callback.get(SWAP_PRIME_DELIVERY_CLAIM_KEY) is True
+        voice_lock.release.set()
         await asyncio.wait_for(swap_task, timeout=10)
 
         assert mgr.session is old_session
@@ -626,6 +625,11 @@ async def test_final_swap_rechecks_retraction_after_core_voice_lock_wait():
         assert delivery_ack.done() and delivery_ack.result() is False
         assert mgr.is_hot_swap_imminent is False
     finally:
+        allow_prime.set()
+        voice_lock.release.set()
+        if not swap_task.done():
+            swap_task.cancel()
+        await _drain_task(swap_task)
         await _drain_task(mgr.message_handler_task)
 
 

--- a/tests/unit/test_hot_swap_cancellation.py
+++ b/tests/unit/test_hot_swap_cancellation.py
@@ -549,11 +549,12 @@ async def test_final_swap_retracted_claim_aborts_pending_session():
         "_callback_delivery_id": callback["_callback_delivery_id"],
         "summary": "cancelled music request",
     }
-    mgr.pending_extra_replies.append(mirror)
+    legacy_extra = "legacy plain-string extra"
+    mgr.pending_extra_replies.extend([legacy_extra, mirror])
     callback[DELIVERY_RETRACTED_KEY] = True
     mgr._purge_retracted_agent_callbacks()
     assert mgr.pending_agent_callbacks == [callback]
-    assert mgr.pending_extra_replies == [mirror]
+    assert mgr.pending_extra_replies == [legacy_extra, mirror]
     assert callback.get(SWAP_PRIME_DELIVERY_CLAIM_KEY) is True
 
     allow_prime.set()
@@ -562,9 +563,60 @@ async def test_final_swap_retracted_claim_aborts_pending_session():
     assert mgr.session is old_session
     assert new_session.closed
     assert mgr.pending_agent_callbacks == []
-    assert mgr.pending_extra_replies == []
+    assert mgr.pending_extra_replies == [legacy_extra]
     assert SWAP_PRIME_DELIVERY_CLAIM_KEY not in callback
     assert delivery_ack.done() and delivery_ack.result() is False
+
+
+@pytest.mark.asyncio
+async def test_final_swap_rechecks_retraction_after_waiting_for_promote_lock():
+    """A claim retracted while promote waits for the CAS lock must abort."""
+    mgr = _make_swap_manager()
+    mgr.pending_agent_callbacks = []
+    mgr._normalize_context_text_for_source = lambda _source, text: text
+    old_close_complete = asyncio.Event()
+
+    class _CloseSignals(_FakeSession):
+        async def close(self):
+            await super().close()
+            old_close_complete.set()
+
+    old_session = _CloseSignals("old")
+    new_session = _make_fake_realtime_session("pending")
+    prime_entered, allow_prime = _install_passive_prime_barrier(
+        new_session,
+        expected_text="retracted during CAS wait",
+    )
+    mgr.session = old_session
+    mgr.pending_session = new_session
+    mgr.is_hot_swap_imminent = True
+
+    delivery_ack = asyncio.get_running_loop().create_future()
+    callback = _passive_callback("retracted during CAS wait")
+    callback[DELIVERY_ACK_FUTURE_KEY] = delivery_ack
+    mgr.enqueue_agent_callback(callback)
+
+    await mgr.lock.acquire()
+    try:
+        mgr.final_swap_task = asyncio.create_task(mgr._perform_final_swap_sequence())
+        swap_task = mgr.final_swap_task
+        await asyncio.wait_for(prime_entered.wait(), timeout=5)
+        allow_prime.set()
+        await asyncio.wait_for(old_close_complete.wait(), timeout=5)
+        callback[DELIVERY_RETRACTED_KEY] = True
+        mgr._purge_retracted_agent_callbacks()
+        assert callback.get(SWAP_PRIME_DELIVERY_CLAIM_KEY) is True
+    finally:
+        mgr.lock.release()
+
+    await asyncio.wait_for(swap_task, timeout=10)
+
+    assert mgr.session is old_session
+    assert new_session.closed
+    assert mgr.pending_agent_callbacks == []
+    assert SWAP_PRIME_DELIVERY_CLAIM_KEY not in callback
+    assert delivery_ack.done() and delivery_ack.result() is False
+    assert mgr.is_hot_swap_imminent is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_hot_swap_cancellation.py
+++ b/tests/unit/test_hot_swap_cancellation.py
@@ -569,6 +569,67 @@ async def test_final_swap_retracted_claim_aborts_pending_session():
 
 
 @pytest.mark.asyncio
+async def test_final_swap_rechecks_retraction_after_core_voice_lock_wait():
+    """Retraction while the shared voice lock is held must not close old."""
+    mgr = _make_swap_manager()
+    mgr.pending_agent_callbacks = []
+    mgr._normalize_context_text_for_source = lambda _source, text: text
+    old_session = _make_fake_realtime_session("old")
+    new_session = _make_fake_realtime_session("pending")
+    prime_entered, allow_prime = _install_passive_prime_barrier(
+        new_session,
+        expected_text="retracted during voice lock wait",
+    )
+
+    class _CoreVoiceLockBarrier:
+        def __init__(self):
+            self.entered = asyncio.Event()
+            self.release = asyncio.Event()
+
+        async def __aenter__(self):
+            self.entered.set()
+            await self.release.wait()
+
+        async def __aexit__(self, *_exc):
+            return False
+
+    voice_lock = _CoreVoiceLockBarrier()
+    mgr._core_voice_session_swap_lock = voice_lock
+    mgr.session = old_session
+    mgr.pending_session = new_session
+    mgr.is_hot_swap_imminent = True
+    mgr.is_active = True
+
+    delivery_ack = asyncio.get_running_loop().create_future()
+    callback = _passive_callback("retracted during voice lock wait")
+    callback[DELIVERY_ACK_FUTURE_KEY] = delivery_ack
+    mgr.enqueue_agent_callback(callback)
+
+    mgr.final_swap_task = asyncio.create_task(mgr._perform_final_swap_sequence())
+    swap_task = mgr.final_swap_task
+    await asyncio.wait_for(prime_entered.wait(), timeout=5)
+    allow_prime.set()
+    await asyncio.wait_for(voice_lock.entered.wait(), timeout=5)
+    callback[DELIVERY_RETRACTED_KEY] = True
+    mgr._purge_retracted_agent_callbacks()
+    assert callback.get(SWAP_PRIME_DELIVERY_CLAIM_KEY) is True
+    voice_lock.release.set()
+
+    try:
+        await asyncio.wait_for(swap_task, timeout=10)
+
+        assert mgr.session is old_session
+        assert not old_session.closed and old_session.ws is not None
+        assert new_session.closed
+        assert mgr.pending_agent_callbacks == []
+        assert SWAP_PRIME_DELIVERY_CLAIM_KEY not in callback
+        assert delivery_ack.done() and delivery_ack.result() is False
+        assert mgr.is_hot_swap_imminent is False
+    finally:
+        await _drain_task(mgr.message_handler_task)
+
+
+@pytest.mark.asyncio
 async def test_final_swap_rechecks_retraction_after_waiting_for_promote_lock():
     """A claim retracted while promote waits for the CAS lock must abort."""
     mgr = _make_swap_manager()

--- a/tests/unit/test_hot_swap_cancellation.py
+++ b/tests/unit/test_hot_swap_cancellation.py
@@ -43,7 +43,11 @@ import pytest
 import main_logic.core as core_module
 from main_logic.omni_offline_client import OmniOfflineClient
 from main_logic.omni_realtime_client import OmniRealtimeClient
-from main_logic.proactive_delivery import DELIVERY_RETRACTED_KEY
+from main_logic.proactive_delivery import (
+    DELIVERY_ACK_FUTURE_KEY,
+    DELIVERY_RETRACTED_KEY,
+    SWAP_PRIME_DELIVERY_CLAIM_KEY,
+)
 
 
 class _FakeSession:
@@ -355,6 +359,248 @@ async def _run_swap_as_final_swap_task(mgr):
         # report the regression instead of the test erroring out.
         pass
     return task
+
+
+def _passive_callback(summary, *, coalesce_key=""):
+    return {
+        "event": "agent_task_callback",
+        "origin": "event",
+        "summary": summary,
+        "detail": summary,
+        "status": "completed",
+        "delivery_mode": "passive",
+        "coalesce_key": coalesce_key,
+    }
+
+
+def _install_passive_prime_barrier(session, *, expected_text):
+    prime_entered = asyncio.Event()
+    allow_prime = asyncio.Event()
+
+    async def _prime(text, *, skipped=False):
+        session.prime_calls.append((text, skipped))
+        if expected_text in text:
+            prime_entered.set()
+            await allow_prime.wait()
+
+    session.prime_context = _prime
+    return prime_entered, allow_prime
+
+
+@pytest.mark.asyncio
+async def test_final_swap_prime_claim_survives_flood_until_promote(monkeypatch):
+    """Exercise claim/flood/late-ACK through the complete swap sequence."""
+    import config
+
+    monkeypatch.setattr(config, "AGENT_CALLBACK_QUEUE_MAX_ITEMS", 2)
+    mgr = _make_swap_manager()
+    mgr.pending_agent_callbacks = []
+    mgr._normalize_context_text_for_source = lambda _source, text: text
+    old_session = _FakeSession("old")
+    new_session = _make_fake_realtime_session("pending")
+    prime_entered, allow_prime = _install_passive_prime_barrier(
+        new_session,
+        expected_text="selected before provider await",
+    )
+    mgr.session = old_session
+    mgr.pending_session = new_session
+    mgr.is_hot_swap_imminent = True
+
+    loop = asyncio.get_running_loop()
+    delivered_ack = loop.create_future()
+    dropped_ack = loop.create_future()
+    delivered = _passive_callback("selected before provider await")
+    delivered[DELIVERY_ACK_FUTURE_KEY] = delivered_ack
+    mgr.enqueue_agent_callback(delivered)
+
+    mgr.final_swap_task = asyncio.create_task(mgr._perform_final_swap_sequence())
+    swap_task = mgr.final_swap_task
+    await asyncio.wait_for(prime_entered.wait(), timeout=5)
+
+    dropped = _passive_callback("oldest retractable filler")
+    dropped[DELIVERY_ACK_FUTURE_KEY] = dropped_ack
+    newest = _passive_callback("newest filler")
+    mgr.enqueue_agent_callback(dropped)
+    mgr.enqueue_agent_callback(newest)
+
+    assert mgr.pending_agent_callbacks == [delivered, newest]
+    assert not delivered_ack.done()
+    assert dropped_ack.done() and dropped_ack.result() is False
+    assert delivered.get(SWAP_PRIME_DELIVERY_CLAIM_KEY) is True
+
+    allow_prime.set()
+    await asyncio.wait_for(swap_task, timeout=10)
+    try:
+        assert mgr.session is new_session
+        assert delivered_ack.done() and delivered_ack.result() is True
+        assert SWAP_PRIME_DELIVERY_CLAIM_KEY not in delivered
+        assert mgr.pending_agent_callbacks == [newest]
+    finally:
+        await _drain_task(mgr.message_handler_task)
+
+
+@pytest.mark.asyncio
+async def test_final_swap_cancel_releases_claim_after_same_key_update():
+    """A full-sequence abort releases claim without a premature ACK."""
+    mgr = _make_swap_manager()
+    mgr.pending_agent_callbacks = []
+    mgr._normalize_context_text_for_source = lambda _source, text: text
+    old_session = _FakeSession("old")
+    new_session = _make_fake_realtime_session("pending")
+    prime_entered, _allow_prime = _install_passive_prime_barrier(
+        new_session,
+        expected_text="old snapshot",
+    )
+    mgr.session = old_session
+    mgr.pending_session = new_session
+    mgr.is_hot_swap_imminent = True
+
+    old_ack = asyncio.get_running_loop().create_future()
+    old = _passive_callback("old snapshot", coalesce_key="state")
+    old[DELIVERY_ACK_FUTURE_KEY] = old_ack
+    mgr.enqueue_agent_callback(old)
+
+    mgr.final_swap_task = asyncio.create_task(mgr._perform_final_swap_sequence())
+    swap_task = mgr.final_swap_task
+    await asyncio.wait_for(prime_entered.wait(), timeout=5)
+
+    newer = _passive_callback("new snapshot", coalesce_key="state")
+    mgr.enqueue_agent_callback(newer)
+    assert mgr.pending_agent_callbacks == [old, newer]
+    assert old.get(SWAP_PRIME_DELIVERY_CLAIM_KEY) is True
+    assert not old_ack.done()
+
+    swap_task.cancel()
+    await asyncio.wait_for(swap_task, timeout=10)
+    assert mgr.session is old_session
+    assert new_session.closed
+    assert SWAP_PRIME_DELIVERY_CLAIM_KEY not in old
+    assert not old_ack.done()
+
+    selected, text = mgr._select_passive_callbacks_for_swap_prime()
+    assert old_ack.done() and old_ack.result() is False
+    assert selected == [newer]
+    assert "new snapshot" in text and "old snapshot" not in text
+    assert mgr.pending_agent_callbacks == [newer]
+    mgr._release_swap_prime_passive_claims(selected)
+
+
+@pytest.mark.asyncio
+async def test_final_swap_passive_prime_failure_aborts_pending_session():
+    """An uncertain provider write cannot be promoted and retried later."""
+    mgr = _make_swap_manager()
+    mgr.pending_agent_callbacks = []
+    mgr._normalize_context_text_for_source = lambda _source, text: text
+    old_session = _FakeSession("old")
+    new_session = _make_fake_realtime_session("pending")
+
+    async def _prime(text, *, skipped=False):
+        new_session.prime_calls.append((text, skipped))
+        if "uncertain provider write" in text:
+            raise RuntimeError("provider outcome unknown")
+
+    new_session.prime_context = _prime
+    mgr.session = old_session
+    mgr.pending_session = new_session
+    mgr.is_hot_swap_imminent = True
+
+    delivery_ack = asyncio.get_running_loop().create_future()
+    callback = _passive_callback("uncertain provider write")
+    callback[DELIVERY_ACK_FUTURE_KEY] = delivery_ack
+    mgr.enqueue_agent_callback(callback)
+
+    swap_task = await _run_swap_as_final_swap_task(mgr)
+
+    assert not swap_task.cancelled()
+    assert mgr.session is old_session
+    assert new_session.closed
+    assert mgr.pending_agent_callbacks == [callback]
+    assert SWAP_PRIME_DELIVERY_CLAIM_KEY not in callback
+    assert not delivery_ack.done()
+
+
+@pytest.mark.asyncio
+async def test_final_swap_retracted_claim_aborts_pending_session():
+    """A business retraction during prime wins without provider/local drift."""
+    mgr = _make_swap_manager()
+    mgr.pending_agent_callbacks = []
+    mgr._normalize_context_text_for_source = lambda _source, text: text
+    old_session = _FakeSession("old")
+    new_session = _make_fake_realtime_session("pending")
+    prime_entered, allow_prime = _install_passive_prime_barrier(
+        new_session,
+        expected_text="cancelled music request",
+    )
+    mgr.session = old_session
+    mgr.pending_session = new_session
+    mgr.is_hot_swap_imminent = True
+
+    delivery_ack = asyncio.get_running_loop().create_future()
+    callback = _passive_callback("cancelled music request")
+    callback["channel"] = "music_playback"
+    callback[DELIVERY_ACK_FUTURE_KEY] = delivery_ack
+    mgr.enqueue_agent_callback(callback)
+
+    mgr.final_swap_task = asyncio.create_task(mgr._perform_final_swap_sequence())
+    swap_task = mgr.final_swap_task
+    await asyncio.wait_for(prime_entered.wait(), timeout=5)
+
+    mirror = {
+        "_callback_delivery_id": callback["_callback_delivery_id"],
+        "summary": "cancelled music request",
+    }
+    mgr.pending_extra_replies.append(mirror)
+    callback[DELIVERY_RETRACTED_KEY] = True
+    mgr._purge_retracted_agent_callbacks()
+    assert mgr.pending_agent_callbacks == [callback]
+    assert mgr.pending_extra_replies == [mirror]
+    assert callback.get(SWAP_PRIME_DELIVERY_CLAIM_KEY) is True
+
+    allow_prime.set()
+    await asyncio.wait_for(swap_task, timeout=10)
+
+    assert mgr.session is old_session
+    assert new_session.closed
+    assert mgr.pending_agent_callbacks == []
+    assert mgr.pending_extra_replies == []
+    assert SWAP_PRIME_DELIVERY_CLAIM_KEY not in callback
+    assert delivery_ack.done() and delivery_ack.result() is False
+
+
+@pytest.mark.asyncio
+async def test_final_swap_promote_cas_loss_releases_passive_claim():
+    """A takeover at promote keeps the callback queued and unclaimed."""
+    mgr = _make_swap_manager()
+    mgr.pending_agent_callbacks = []
+    mgr._normalize_context_text_for_source = lambda _source, text: text
+    winner_session = _FakeSession("winner")
+    new_session = _make_fake_realtime_session("pending")
+
+    class _TakeoverOnClose(_FakeSession):
+        async def close(self):
+            await super().close()
+            mgr.session = winner_session
+            mgr.message_handler_task = object()
+
+    old_session = _TakeoverOnClose("old")
+    mgr.session = old_session
+    mgr.pending_session = new_session
+    mgr.is_hot_swap_imminent = True
+    mgr.message_handler_task = None
+
+    delivery_ack = asyncio.get_running_loop().create_future()
+    callback = _passive_callback("queued across CAS loss")
+    callback[DELIVERY_ACK_FUTURE_KEY] = delivery_ack
+    mgr.enqueue_agent_callback(callback)
+
+    swap_task = await _run_swap_as_final_swap_task(mgr)
+
+    assert not swap_task.cancelled()
+    assert mgr.session is winner_session
+    assert new_session.closed
+    assert mgr.pending_agent_callbacks == [callback]
+    assert SWAP_PRIME_DELIVERY_CLAIM_KEY not in callback
+    assert not delivery_ack.done()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_passive_swap_prime.py
+++ b/tests/unit/test_passive_swap_prime.py
@@ -15,6 +15,7 @@ import main_logic.core as core_module
 from main_logic.proactive_delivery import (
     DELIVERY_ACK_FUTURE_KEY,
     DELIVERY_RETRACTED_KEY,
+    SWAP_PRIME_DELIVERY_CLAIM_KEY,
 )
 
 pytestmark = pytest.mark.unit
@@ -82,6 +83,7 @@ def test_select_picks_only_passive_and_keeps_queue_intact():
     assert "respond now" not in text
     # Selection must NOT drain: removal is deferred to promote success.
     assert mgr.pending_agent_callbacks == [passive, proactive]
+    assert passive.get(SWAP_PRIME_DELIVERY_CLAIM_KEY) is True
 
 
 def test_select_returns_empty_when_no_passive():
@@ -160,6 +162,44 @@ def test_remove_at_promote_dequeues_by_identity_and_acks_true():
     assert removed == [delivered]
     assert mgr.pending_agent_callbacks == [other]
     assert ack.done() and ack.result is True
+
+
+def test_text_drain_skips_swap_prime_claimed_callback():
+    mgr = _make_session_mgr()
+    ack = _FakeAckFuture()
+    claimed = _passive_cb("provider already has this context")
+    claimed[DELIVERY_ACK_FUTURE_KEY] = ack
+    mgr.pending_agent_callbacks = [claimed]
+
+    selected, _ = mgr._select_passive_callbacks_for_swap_prime()
+    rendered = mgr.drain_agent_callbacks_for_llm()
+
+    assert rendered == ""
+    assert mgr.pending_agent_callbacks == [claimed]
+    assert not ack.done()
+    mgr._release_swap_prime_passive_claims(selected)
+
+
+def test_claimed_same_key_rejects_older_late_arrival():
+    mgr = _make_session_mgr()
+    old_ack = _FakeAckFuture()
+    late_ack = _FakeAckFuture()
+    claimed = _passive_cb("current snapshot", coalesce_key="state")
+    claimed["_coalesce_submit_seq"] = 5
+    claimed[DELIVERY_ACK_FUTURE_KEY] = old_ack
+    mgr.enqueue_agent_callback(claimed)
+    selected, _ = mgr._select_passive_callbacks_for_swap_prime()
+
+    late = _passive_cb("late stale snapshot", coalesce_key="state")
+    late["_coalesce_submit_seq"] = 2
+    late[DELIVERY_ACK_FUTURE_KEY] = late_ack
+    mgr.enqueue_agent_callback(late)
+
+    assert mgr.pending_agent_callbacks == [claimed]
+    assert not old_ack.done()
+    assert late_ack.done() and late_ack.result is False
+    assert late.get(DELIVERY_RETRACTED_KEY) is True
+    mgr._release_swap_prime_passive_claims(selected)
 
 
 def test_remove_noops_for_entries_consumed_in_window():

--- a/tests/unit/test_proactive_delivery.py
+++ b/tests/unit/test_proactive_delivery.py
@@ -498,6 +498,33 @@ def test_flood_rejected_newer_does_not_stale_provider_owned_old(
     assert mgr._retract_stale_coalesced([old]) is False
 
 
+def test_flood_rollback_preserves_newer_manager_held_sequence(monkeypatch):
+    import config
+
+    monkeypatch.setattr(config, "AGENT_CALLBACK_QUEUE_MAX_ITEMS", 1)
+    mgr = _make_session_mgr()
+    old = _passive_cb("claimed old", coalesce_key="state")
+    mgr.enqueue_agent_callback(old)
+    old[SWAP_PRIME_DELIVERY_CLAIM_KEY] = True
+
+    async def _deliver(_batch):
+        return None
+
+    mgr.proactive_manager = ProactiveDeliveryManager(deliver=_deliver)
+    mgr.is_goodbye_silent = lambda: False
+    held = _proactive_cb("manager-held newer", coalesce_key="state")
+    mgr.submit_proactive_callback(held, coalesce_key="state")
+
+    rejected = _passive_cb("flood-rejected newest", coalesce_key="state")
+    mgr.enqueue_agent_callback(rejected)
+
+    assert mgr.pending_agent_callbacks == [old]
+    assert rejected.get(DELIVERY_RETRACTED_KEY) is True
+    assert mgr._coalesce_latest["state"] == held["_coalesce_submit_seq"]
+    old.pop(SWAP_PRIME_DELIVERY_CLAIM_KEY)
+    assert mgr._retract_stale_coalesced([old]) is True
+
+
 def test_newer_same_key_keeps_committed_callback_voice_mirror():
     mgr = _make_session_mgr()
     committed = _proactive_cb("provider send started", coalesce_key="state")

--- a/tests/unit/test_proactive_delivery.py
+++ b/tests/unit/test_proactive_delivery.py
@@ -460,9 +460,11 @@ def test_flood_guard_rejects_incoming_when_older_send_started(monkeypatch):
     "ownership_key",
     [VOICE_DELIVERY_COMMITTED_KEY, SWAP_PRIME_DELIVERY_CLAIM_KEY],
 )
+@pytest.mark.parametrize("pre_submitted", [False, True])
 def test_flood_rejected_newer_does_not_stale_provider_owned_old(
     monkeypatch,
     ownership_key,
+    pre_submitted,
 ):
     import config
 
@@ -474,8 +476,19 @@ def test_flood_rejected_newer_does_not_stale_provider_owned_old(
     old_seq = old["_coalesce_submit_seq"]
 
     rejected_ack = _FakeAckFuture()
-    newer = _passive_cb("flood rejected newer", coalesce_key="state")
+    newer = _proactive_cb("flood rejected newer", coalesce_key="state")
     newer[DELIVERY_ACK_FUTURE_KEY] = rejected_ack
+    if pre_submitted:
+        class _ManagerStub:
+            def submit(self, callback, **_kwargs):
+                self.submitted = callback
+
+        manager = _ManagerStub()
+        mgr.proactive_manager = manager
+        mgr.is_goodbye_silent = lambda: False
+        mgr.submit_proactive_callback(newer, coalesce_key="state")
+        assert manager.submitted is newer
+        assert mgr._coalesce_latest["state"] == newer["_coalesce_submit_seq"]
     mgr.enqueue_agent_callback(newer)
 
     assert mgr.pending_agent_callbacks == [old]

--- a/tests/unit/test_proactive_delivery.py
+++ b/tests/unit/test_proactive_delivery.py
@@ -16,6 +16,7 @@ from main_logic.proactive_delivery import (
     DELIVERY_ACK_FUTURE_KEY,
     DELIVERY_RETRACTED_KEY,
     ProactiveDeliveryManager,
+    SWAP_PRIME_DELIVERY_CLAIM_KEY,
     VOICE_DELIVERY_COMMITTED_KEY,
     effective_priority,
 )
@@ -453,6 +454,35 @@ def test_flood_guard_rejects_incoming_when_older_send_started(monkeypatch):
     assert not committed_ack.done()
     assert incoming_ack.done() and incoming_ack.result is False
     assert incoming.get(DELIVERY_RETRACTED_KEY) is True
+
+
+@pytest.mark.parametrize(
+    "ownership_key",
+    [VOICE_DELIVERY_COMMITTED_KEY, SWAP_PRIME_DELIVERY_CLAIM_KEY],
+)
+def test_flood_rejected_newer_does_not_stale_provider_owned_old(
+    monkeypatch,
+    ownership_key,
+):
+    import config
+
+    monkeypatch.setattr(config, "AGENT_CALLBACK_QUEUE_MAX_ITEMS", 1)
+    mgr = _make_session_mgr()
+    old = _passive_cb("provider-owned old", coalesce_key="state")
+    mgr.enqueue_agent_callback(old)
+    old[ownership_key] = True
+    old_seq = old["_coalesce_submit_seq"]
+
+    rejected_ack = _FakeAckFuture()
+    newer = _passive_cb("flood rejected newer", coalesce_key="state")
+    newer[DELIVERY_ACK_FUTURE_KEY] = rejected_ack
+    mgr.enqueue_agent_callback(newer)
+
+    assert mgr.pending_agent_callbacks == [old]
+    assert rejected_ack.done() and rejected_ack.result is False
+    assert mgr._coalesce_latest["state"] == old_seq
+    old.pop(ownership_key)
+    assert mgr._retract_stale_coalesced([old]) is False
 
 
 def test_newer_same_key_keeps_committed_callback_voice_mirror():

--- a/tests/unit/test_proactive_delivery.py
+++ b/tests/unit/test_proactive_delivery.py
@@ -16,6 +16,7 @@ from main_logic.proactive_delivery import (
     DELIVERY_ACK_FUTURE_KEY,
     DELIVERY_RETRACTED_KEY,
     ProactiveDeliveryManager,
+    VOICE_DELIVERY_COMMITTED_KEY,
     effective_priority,
 )
 
@@ -430,6 +431,69 @@ def test_passive_flood_guard_bounds_callback_queue_without_extras(monkeypatch):
     ]
     assert mgr.pending_extra_replies == []
     assert dropped_ack.done() and dropped_ack.result is False
+
+
+def test_flood_guard_rejects_incoming_when_older_send_started(monkeypatch):
+    import config
+
+    monkeypatch.setattr(config, "AGENT_CALLBACK_QUEUE_MAX_ITEMS", 1)
+    mgr = _make_session_mgr()
+    committed_ack = _FakeAckFuture()
+    incoming_ack = _FakeAckFuture()
+    committed = _passive_cb("provider send started")
+    committed[VOICE_DELIVERY_COMMITTED_KEY] = True
+    committed[DELIVERY_ACK_FUTURE_KEY] = committed_ack
+    incoming = _passive_cb("cannot displace committed")
+    incoming[DELIVERY_ACK_FUTURE_KEY] = incoming_ack
+    mgr.pending_agent_callbacks = [committed]
+
+    mgr.enqueue_agent_callback(incoming)
+
+    assert mgr.pending_agent_callbacks == [committed]
+    assert not committed_ack.done()
+    assert incoming_ack.done() and incoming_ack.result is False
+    assert incoming.get(DELIVERY_RETRACTED_KEY) is True
+
+
+def test_newer_same_key_keeps_committed_callback_voice_mirror():
+    mgr = _make_session_mgr()
+    committed = _proactive_cb("provider send started", coalesce_key="state")
+    mgr.enqueue_agent_callback(committed)
+    committed[VOICE_DELIVERY_COMMITTED_KEY] = True
+    committed_id = committed["_callback_delivery_id"]
+
+    newer = _proactive_cb("next snapshot", coalesce_key="state")
+    mgr.enqueue_agent_callback(newer)
+
+    assert mgr.pending_agent_callbacks == [committed, newer]
+    assert [extra["summary"] for extra in mgr.pending_extra_replies] == [
+        "provider send started",
+        "next snapshot",
+    ]
+    assert mgr.pending_extra_replies[0]["_callback_delivery_id"] == committed_id
+
+
+def test_extra_flood_guard_keeps_provider_owned_voice_mirror(monkeypatch):
+    import config
+
+    monkeypatch.setattr(config, "AGENT_CALLBACK_QUEUE_MAX_ITEMS", 1)
+    mgr = _make_session_mgr()
+    committed = _proactive_cb("provider send started")
+    mgr.enqueue_agent_callback(committed)
+    committed[VOICE_DELIVERY_COMMITTED_KEY] = True
+    committed_mirror = mgr.pending_extra_replies[0]
+    mgr.pending_extra_replies.append({
+        "_callback_delivery_id": "orphan-id",
+        "summary": "safe orphan",
+    })
+
+    # A passive incoming callback triggers both flood guards. It is rejected
+    # from the callback queue; the unrelated orphan, not the committed mirror,
+    # is the only safe extra victim.
+    mgr.enqueue_agent_callback(_passive_cb("incoming"))
+
+    assert mgr.pending_agent_callbacks == [committed]
+    assert mgr.pending_extra_replies == [committed_mirror]
 
 
 def test_enqueue_coalesce_resolves_superseded_ack_false():


### PR DESCRIPTION
## 改动概述 / Summary

- 在 provider prime 的首次 `await` 前原子 claim passive callback。
- 让 coalesce、stale sweep、text drain、flood、purge 与 voice mirror 裁剪尊重 claimed/committed 所有权。
- 同 key 新 cue 仅在 seq 真正更新时排到 in-flight cue 后；旧或相等的迟到项立即 ACK false。
- passive prime 结果不确定或 claimed cue 被业务撤回时，关闭并放弃 pending session。
- promote、取消、CAS abort 与异常出口统一完成或释放 claim。

Closes #2638

## 回归报告 / Regression Report

- **改动内容：** 为 hot-swap passive prime 引入显式的 provider ownership claim，并将 callback 队列及 `pending_extra_replies` mirror 的并发变更统一到该所有权边界。
- **理由 / 必要性：** 原实现会在 `prime_context()` 让出事件循环时把已选 callback 无保护地留在共享队列。并发 enqueue、coalesce、purge 或 flood trimming 可能删除并 ACK false 一个 provider 已经接收或可能接收的 cue，造成 provider context 与本地 delivery ledger 分裂。
- **改动前：** prime await 窗口内 callback 可能被淘汰、覆盖或文本 drain 消费；之后 promote 找不到原对象，出现丢 cue、重复重试或错误 ACK。
- **改动后：** claim 在无 await 的选取边界内建立；provider-owned 项不会被并发队列操作撤回。promote 成功才 ACK true；不确定 prime、业务撤回、取消或 CAS abort 会关闭不可信 pending session并释放/失败结算 claim。
- **潜在回归点：** proactive text/voice delivery、same-key coalesce、callback/extras flood limit、显式音乐取消、Gemini/非 Gemini hot-swap、promote 后恢复与 CAS 接管。以上链路均由固定 seed 回归及 `asyncio.Event` barrier 完整序列测试覆盖；新增并发测试无 sleep、无网络。

## 不拆分理由 / Why Not Split

不适用：计入上限的生产文件仅 3 个；测试与实现必须在同一 PR 中保持所有权协议和确定性回归对应。

## 测试 / Testing

- 固定 seed 受影响回归：295 passed。
- 全量 unit：15,086 passed，270 skipped；4 个失败来自未改动模块中的既有 Windows locale/编码及随机导入顺序问题。
- Ruff、compileall、`git diff --check` 全部通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 提升热切换期间回调投递稳定性，避免已选内容被队列洪泛、重复更新或并发操作意外移除。
  * 优化取消、失败及投递中断后的状态清理与内容恢复，减少回调丢失、重复消费和错误重启。
  * 改进回调队列容量管理，优先保留正在投递或已确认的重要内容。
  * 修复同键回调更新及延迟回调处理，确保最新有效内容得到保留。

* **测试**
  * 补充热切换、回调撤回、队列洪泛、并发投递及投递失败等场景的覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->