### PR TITLE
fix(QQ): 修回 #2663 覆盖掉的投递回执与按钮载荷，补两条过时测试桩（main 转绿）

### DIFF
--- a/plugin/plugins/qq_auto_reply/qq_client.py
+++ b/plugin/plugins/qq_auto_reply/qq_client.py
@@ -990,39 +990,51 @@ class QQClient(QQConnectionBase):
         data = await self.call_action("get_group_list", timeout=10.0)
         return data if isinstance(data, list) else []
 
-    async def send_message(self, user_id: str, message: str):
-        """发送私聊消息"""
+    async def send_message(self, user_id: str, message: str) -> Optional[str]:
+        """发送私聊消息（CQ 码字符串），返回 message_id。
+
+        与 segments 版同一个 action，只是 message 字段是字符串——编码不能
+        改（把 CQ 码塞进 text 段会让 [CQ:at,qq=…] 原样显示给用户），但回执
+        可以要：没有它就分不清"发出去了"和"没发出去"，投递确认链只能无条件
+        判成功，未送达的回复会被当已投递清掉排除标、进 scoped 记忆。"""
+        return await self._send_text_action(
+            "send_private_msg", {"user_id": int(user_id), "message": message},
+            log_target=f"private {user_id}",
+        )
+
+    async def send_group_message(self, group_id: str, message: str) -> Optional[str]:
+        """发送群聊消息（CQ 码字符串），返回 message_id。见 send_message。"""
+        return await self._send_text_action(
+            "send_group_msg", {"group_id": int(group_id), "message": message},
+            log_target=f"group {group_id}", record_sent=True,
+        )
+
+    async def _send_text_action(
+        self, action: str, params: Dict[str, Any], *,
+        log_target: str, record_sent: bool = False,
+    ) -> Optional[str]:
+        """One echo round-trip for the CQ-string senders (same plumbing as
+        the segment senders; responses are dispatched by echo, not action)."""
         if not self._main_client:
             raise RuntimeError("No Napcat client connected")
 
-        payload = {
-            "action": "send_private_msg",
-            "params": {
-                "user_id": int(user_id),
-                "message": message,
-            },
-        }
-
-        await self._main_client.send(json.dumps(payload))
-        if self.logger:
-            self.logger.debug(f"Sent message to {user_id}")
-
-    async def send_group_message(self, group_id: str, message: str):
-        """发送群聊消息"""
-        if not self._main_client:
-            raise RuntimeError("No Napcat client connected")
-
-        payload = {
-            "action": "send_group_msg",
-            "params": {
-                "group_id": int(group_id),
-                "message": message,
-            },
-        }
-
-        await self._main_client.send(json.dumps(payload))
-        if self.logger:
-            self.logger.debug(f"Sent group message to {group_id}")
+        echo = secrets.token_hex(8)
+        payload = {"action": action, "params": params, "echo": echo}
+        future: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._pending_actions[echo] = future
+        try:
+            await self._main_client.send(json.dumps(payload))
+            response = await asyncio.wait_for(future, timeout=10.0)
+            message_id = str((response.get("data") or {}).get("message_id") or "")
+            if message_id and record_sent:
+                self.record_sent_message_id(message_id)
+            if self.logger:
+                self.logger.debug(f"Sent message to {log_target}")
+            return message_id if message_id else None
+        except asyncio.TimeoutError:
+            return None
+        finally:
+            self._pending_actions.pop(echo, None)
 
     async def send_private_message_segments(self, user_id: str, segments: list[Dict[str, Any]], *, record_sent: bool = True) -> Optional[str]:
         """发送私聊消息片段，返回 message_id。"""

--- a/plugin/plugins/qq_auto_reply/qq_open_plat.py
+++ b/plugin/plugins/qq_auto_reply/qq_open_plat.py
@@ -325,6 +325,17 @@ class QQOpenPlatformConnection(QQConnectionBase):
         if reply_msg_id:
             body["msg_id"] = reply_msg_id
 
+        if keyboard and body.get("msg_type") == 7:
+            # 富媒体（图片）载荷挂不了按钮：按钮只在 type-2 富文本上有效，
+            # 硬带上去平台可能整条拒收。把选项降级成可读正文，至少不让用户
+            # 收到一条"问了却没有选项"的消息。
+            labels = " / ".join(
+                b.strip() for b in keyboard.split("|") if b.strip()
+            )
+            if labels:
+                existing = str(body.get("content") or "")
+                body["content"] = (existing + "\n" + labels).strip()
+            keyboard = ""
         if keyboard:
             buttons = [b.strip() for b in keyboard.split("|") if b.strip()][:4]
             if buttons:
@@ -444,14 +455,14 @@ class QQOpenPlatformConnection(QQConnectionBase):
                 self.logger.warning(f"[QQOpenPlatform] 发送私聊失败: {e}")
             return None
 
-    async def send_group_poke(self, group_id: str, user_id: str) -> bool:
-        # QQ 开放平台不支持戳一戳
-        await self.send_group_message_segments(
+    async def send_group_poke(self, group_id: str, user_id: str) -> Optional[str]:
+        # QQ 开放平台不支持戳一戳——降级为文本。结果向上传播（None=失败
+        # 被吞），投递确认链据此决定是否清未投递标/记 mention。
+        return await self.send_group_message_segments(
             group_id,
             [{"type": "text", "data": {"text": f" (戳了戳 {user_id})"}}],
             record_sent=False,
         )
-        return True
 
     async def send_group_image(
         self, group_id: str, image_data: str, *, reply_message_id: str = "", at_user_id: str = "", sub_type: str = ""

--- a/plugin/plugins/qq_auto_reply/reply_delivery_node.py
+++ b/plugin/plugins/qq_auto_reply/reply_delivery_node.py
@@ -157,12 +157,12 @@ class QQReplyDeliveryNode:
         self, plan: QQDeliveryPlan, block: QQMessageBlock, text: str,
         *, keyboard: str = "",
     ) -> bool:
-        """Returns True when the send is confirmed or fire-and-forget.
+        """Returns True only when the send came back confirmed.
 
-        NapCat sends return None by design (failure surfaces as an
-        exception); the Open Platform client returns the message id, or
-        None on a swallowed failure - only that explicit None means the
-        message was not delivered."""
+        Both platforms report one: the Open Platform client returns the
+        message id (None when it swallowed a failure), and the NapCat
+        client returns the id from the echo round-trip (None on timeout).
+        None means the message was not confirmed delivered."""
         if not text:
             return False
         mode = self.plugin._get_reply_mode()
@@ -216,9 +216,8 @@ class QQReplyDeliveryNode:
                 result = await self.plugin.qq_client.send_group_message(plan.target_id, text)
         else:
             result = await self.plugin.qq_client.send_message(plan.target_id, text)
-        # NapCat 是 fire-and-forget（无异常=成功），开放平台显式返回 None = 失败
-        if self.plugin.qq_client and self.plugin.qq_client.needs_attention:
-            return True  # NapCat: no exception means delivered
+        # 两个平台的文本发送现在都有回执：开放平台失败吞异常返回 None，
+        # NapCat 走 echo 往返（超时返回 None）。显式 None = 未确认送达。
         return result is not None
 
     async def _send_sticker(self, plan: QQDeliveryPlan, block: QQMessageBlock) -> bool:

--- a/tests/unit/test_group_memory_scopes.py
+++ b/tests/unit/test_group_memory_scopes.py
@@ -4908,9 +4908,11 @@ async def test_delivery_result_reflects_open_platform_send_failure():
     # Open Platform success -> delivered.
     result = await _node(False, "msgid").deliver(plan)
     assert result.delivered is True
-    # NapCat is fire-and-forget: no exception means delivered.
+    # NapCat now has a receipt too (the CQ-string senders do the same echo
+    # round-trip as the segment ones), so a missing message id means the
+    # action never came back: unconfirmed, not delivered.
     result = await _node(True, None).deliver(plan)
-    assert result.delivered is True
+    assert result.delivered is False
     result = await _node(True, "napcat-mid").deliver(plan)
     assert result.delivered is True
 
@@ -10344,6 +10346,8 @@ async def test_private_segments_send_waits_for_the_echo_receipt():
     client = QQClient.__new__(QQClient)
     client._pending_actions = {}
     client.logger = None
+    client._sent_message_ids = []
+    client.record_sent_message_id = client._sent_message_ids.append
     sent: list = []
 
     class _WS:
@@ -10361,6 +10365,9 @@ async def test_private_segments_send_waits_for_the_echo_receipt():
     assert await client.send_private_record("2046", "file:///a.wav") == "pm-1"
     assert sent[-1]["action"] == "send_private_msg"
     assert not client._pending_actions  # no leaked futures
+    # A confirmed private send records its id too (the quoted-reply check
+    # asks "is this one of mine?" for private chats as well).
+    assert client._sent_message_ids == ["pm-1"]
 
     # No receipt -> None (the caller falls back to text).
     class _SilentWS:

--- a/tests/unit/test_qq_auto_reply_prompting.py
+++ b/tests/unit/test_qq_auto_reply_prompting.py
@@ -137,7 +137,14 @@ def test_open_platform_group_mentions_distinguish_bot_from_other_users():
     assert with_other_user["mentions_other_user"] is True
 
 
-def test_focus_rise_seconds_scales_new_focus_before_stabilizing():
+def test_focus_rise_window_boosts_the_focus_until_the_window_expires():
+    """rise 窗口给刚拿到焦点的群一份线性加成（0 → +2.0），窗口一过加成
+    归零、回落到原始分。
+
+    断言跟着 attention_service 的实现走：这条用例最初断言的是反方向的
+    语义（新焦点先被压到一半分数、再爬升回满分），跟同一次提交里的实现
+    相反，从来没有通过过。加成的方向是插件侧的产品取舍，这里只钉住实际
+    生效的那一份。"""
     from types import SimpleNamespace
 
     from plugin.plugins.qq_auto_reply.attention_service import QQAttentionService, QQGroupAttentionState
@@ -177,11 +184,11 @@ def test_focus_rise_seconds_scales_new_focus_before_stabilizing():
         ).to_dict(),
     }
 
-    # 刚拿到焦点时，焦点有效分数被爬升窗口压低，避免立刻把其他群压死。
-    assert service.get_focus_score() == pytest.approx(4.0, rel=1e-3)
+    # 窗口过半（5s / 10s）：原始分 8.0 之上加满额 2.0 的一半。
+    assert service.get_focus_score() == pytest.approx(9.0, rel=1e-3)
     assert service.get_snapshot()["focus_group_id"] == "focus"
 
-    # 窗口结束后恢复完整分数。
+    # 窗口结束后加成归零，回到原始分。
     service._current_time = lambda: 106
-    assert service.get_focus_score() > 7.5
+    assert service.get_focus_score() == pytest.approx(8.0, rel=1e-3)
     assert service.get_snapshot()["focus_group_id"] == "focus"

--- a/tests/unit/test_qq_auto_reply_prompting.py
+++ b/tests/unit/test_qq_auto_reply_prompting.py
@@ -138,13 +138,16 @@ def test_open_platform_group_mentions_distinguish_bot_from_other_users():
 
 
 def test_focus_rise_window_boosts_the_focus_until_the_window_expires():
-    """rise 窗口给刚拿到焦点的群一份线性加成（0 → +2.0），窗口一过加成
-    归零、回落到原始分。
+    """The rise window hands a freshly focused group a linear bonus
+    (0 -> +2.0); once the window passes the bonus is gone and the score
+    falls back to the raw one.
 
-    断言跟着 attention_service 的实现走：这条用例最初断言的是反方向的
-    语义（新焦点先被压到一半分数、再爬升回满分），跟同一次提交里的实现
-    相反，从来没有通过过。加成的方向是插件侧的产品取舍，这里只钉住实际
-    生效的那一份。"""
+    These assertions follow attention_service as implemented. The case
+    originally asserted the opposite semantic (a new focus scaled down to
+    half and climbing back up), contradicting the implementation landed in
+    the same commit, so it never passed. Which direction the window should
+    have is a product call for the plugin side; this pins the one that is
+    actually live."""
     from types import SimpleNamespace
 
     from plugin.plugins.qq_auto_reply.attention_service import QQAttentionService, QQGroupAttentionState


### PR DESCRIPTION
## 背景

`main` 从 d2da066e7（#2663）起 Unit Tests / Windows 一直是红的，5 条用例失败。上一条提交 d6992e358 是绿的。

因为 GitHub 的 `pull_request` 事件测的是 **merge commit**，main 红会把仓库里每个 PR 都染红（例如 #2690 本身没问题，只是被连累）。这个 PR 只做一件事：把这 5 条修回绿。

## 逐条根因与判断

### 1. 开放平台 `send_group_poke` 吞掉失败、恒报成功 → **改 production**

`test_delivery_result_reflects_open_platform_send_failure`

#2663 把 `QQOpenPlatformConnection.send_group_poke` 从"透传底层发送结果"改成了 `await ...; return True`：

```python
-        return await self.send_group_message_segments(...)
+        await self.send_group_message_segments(...)
+        return True
```

开放平台没有戳一戳通道，这个方法本来就是降级成一条文本发出去的。发文本失败时 `send_group_message_segments` 吞异常返回 `None`，恒返回 `True` 等于把"没发出去"报成"已投递"——投递确认链（`_confirm_platform_result`）据此决定要不要清未投递标、要不要记 mention、要不要进 scoped 记忆。

判据：**同一次提交里保留下来的其它开放平台路径全都是"显式 None = 失败"**（`reply_delivery_node` 自己的注释、`send_group_image`、`send_private_record` 都是这个契约），只有 poke 被改成恒真，属于跟自身设计不自洽。已恢复结果透传。

### 2. NapCat 的 CQ 码文本发送丢了 echo 回执 → **改 production**

`test_cq_string_senders_wait_for_the_echo_receipt`

#2663 删掉了 `_send_text_action`，`send_message` / `send_group_message` 变成 fire-and-forget（不带 echo、无返回值），并在 `reply_delivery_node._send_text` 里加了一条 `if needs_attention: return True` 兜底把结果盖成"已投递"。

这条路径是**文本回复的主路径**。丢掉回执的直接后果：

- 投递确认链在 NapCat 上退化为无条件判成功——没送达的回复照样清排除标、进 scoped 记忆；
- `_send_record` 的**语音失败回退文本**分支没被那条兜底覆盖：它走 `_confirm_platform_result(fb)`，而 `fb` 现在恒为 `None`，于是**回退成功也一律报未投递**（新引进的反向 bug）；
- 群消息不再 `record_sent_message_id`，"用户引用的是不是猫娘自己的消息"判断只能退回 `get_msg` API 兜底。

同一个类里的 segments 发送方（图片/语音/带按钮文本）在 #2663 之后仍然走 echo 往返，所以这不是协议或架构限制，NapCat 收发也不在同一协程上（收到的消息进 `_message_queue`，消费方另起），不存在自锁。已恢复 `_send_text_action`，并把 `_send_text` 里那条兜底撤掉。

顺带回滚了 #2663 一起改掉的那条断言（`_node(True, None)` → `delivered is False`），它跟上面的兜底是配套的。

另外把 `_send_text` 的 docstring 改成实际契约——它写着"NapCat sends return None by design"，这句在回执落地时（#2433）就没跟着更新，**#2663 大概率就是照着这句注释把回执删掉的**。

### 3. 图片消息里混进 keyboard 按钮载荷 → **改 production**

`test_image_message_does_not_carry_a_keyboard_payload`

#2663 删掉了 `msg_type == 7`（富媒体/图片）时把按钮降级成正文的那段：

```python
-        if keyboard and body.get("msg_type") == 7:
-            ...把选项拼进 content，keyboard = ""
```

按钮只在 type-2 富文本上有效，硬挂在 type-7 富媒体载荷上平台可能整条拒收——用户既看不到选项，也收不到这条回复。已恢复该降级分支（选项降级成可读正文，至少不让用户收到一条"问了却没有选项"的消息）。

### 4. `_sent_message_ids` AttributeError → **测试桩过时**

`test_private_segments_send_waits_for_the_echo_receipt`

#2663 给 `send_private_message_segments` 加了 `record_sent: bool = True`，确认送达后调 `record_sent_message_id`。这个改动本身是对的（和群聊那一路对偶：私聊里用户引用猫娘的消息同样要认得出来）。是测试桩没跟上——它用 `QQClient.__new__` 跳过 `__init__`，只塞了 `_pending_actions` / `logger` / `_main_client`，没有 `_sent_message_ids`。

按同文件里群聊那条用例的写法补上桩，并**补一条断言把这个新行为钉住**（`_sent_message_ids == ["pm-1"]`），而不是只把异常按掉。

### 5. focus rise 窗口：新测试与新实现互相矛盾 → **改测试，方向留给插件作者定** @ZhaiJiu

`test_focus_rise_seconds_scales_new_focus_before_stabilizing`

这条既不是 production 回归、也不是旧桩过时：`focus_acquired_at` / `_focus_rise_bonus` 整套机制**和这条用例都是 #2663 新加的**，两者语义相反，所以它**从合并那一刻起就没通过过**：

- 用例注释说的是"刚拿到焦点时焦点有效分数被**压低**，避免立刻把其他群压死"（8.0 × 50% = 4.0）；
- 实现给的是**加分**：`attention_score + 2.0 × elapsed/rise`（8.0 + 1.0 = 9.0），docstring 写的是"给焦点群一个自然优势窗口"。

两边都有旁证（UI 文案是"新焦点上升期"，偏用例那侧；代码 docstring 和 `_top_candidate_state` 改用 effective 分选焦点，偏实现那侧），而且**改哪一边都会改动线上评分行为**：ramp 语义会让新焦点在窗口内不再压制其他群（`get_group_multiplier` 的 gap 变小），bonus 语义则相反。

这属于插件侧的产品取舍，不该由一个"修红"的 PR 顺手替作者定。所以这里**只把用例对齐到实际生效的实现**（并改名、写清楚它原本断言的是反方向语义），保持 #2663 合进去的运行时行为一个字不动。

留一条给作者的观察：现在的加成是 `2.0 × elapsed/rise`，**在窗口内线性涨到 +2.0，然后在窗口边界瞬间掉回 0**。如果本意是 docstring 说的"焦点获取后的软性优势窗口"，形状应该是衰减（`1 - elapsed/rise`）而不是增长——现在这个形状在最需要保护的acquire 时刻给 0、在窗口结束时反而制造一个 2.0 的断崖。如果本意是 UI 文案的"上升期"，那要动的是 `_effective_focus_score` 而不是加一份 bonus。哪种都可以，需要你拍板，我可以照着改。

## 验证

- 5 条目标用例：全绿
- `tests/unit/test_group_memory_scopes.py` + `tests/unit/test_qq_auto_reply_prompting.py` 全量：293 passed, 2 skipped
- `tests/unit` 全量（本地 Windows）：15082 passed, 269 skipped, **1 failed**
- `scripts/check_docstring_no_cjk.py --base origin/main`：exit 0

那条 fail 是 `test_cloudsave_lifecycle_flow.py::test_main_server_manual_startup_performs_fallback_import_and_continues_boot`，**与本 PR 无关**：单跑通过、同文件跑挂，在本 PR 之前的 d2da066e7 上一模一样地挂。是那条只在装了 Steam 的开发机上复现的跨用例污染（CI 上是绿的），#2690 在处理，这里不碰。

## 不在范围

没有碰 #2690 / `claude/fix-steamworks-test-pollution`；#2663 其它未被测试覆盖的改动也没有一并回滚，这个 PR 只处理让 main 红的这 5 条。
