### PR TITLE
test(unit)：修掉三条跨用例顺序依赖（假握手 / sys.path 泄漏顶掉根 config 包 / SSL Warning 落进 capsys）

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -127,6 +127,41 @@ def _reset_steamworks_handle():
 
 
 @pytest.fixture(autouse=True)
+def _reset_sys_path():
+    """Restore ``sys.path`` around every unit test.
+
+    ``sys.path`` is process-global, and several product entry points prepend to
+    it as a deliberate, permanent side effect. ``_start_embedded_user_plugin_server``
+    (app/agent_server/plugin_host.py) inserts ``<repo>/plugin`` at index 1 so the
+    embedded server can import ``plugin.server.http_app``. In a real agent process
+    that entry is meant to stay for the process lifetime; in a unit test that calls
+    the function directly it stays for the rest of the session.
+
+    The leaked entry is not inert. ``<repo>/plugin`` ships its own ``config``
+    package, and under pytest the repo root is not ``sys.path[0]`` — the rootdir
+    insertions for ``tests`` and ``tests/unit/asr_client`` sit in front of it, so
+    a hardcoded index 1 lands *ahead* of the repo root. Every fresh resolution of
+    ``config`` then finds ``plugin/config``, and that includes ``importlib.reload``,
+    which re-runs the finder and rebinds the module object in place. So
+    ``launcher_core.runtime._reload_runtime_config_from_env`` — whose entire job is
+    to refresh the negotiated ``NEKO_*`` ports — reloaded ``plugin/config`` into the
+    root ``config`` module and left every port at its pre-negotiation value. That
+    is how ``test_runtime_config_reload_preserves_negotiated_fallback_ports``
+    turned red under seed 31337 while passing on its own.
+
+    The whole list is snapshotted rather than a named entry removed, so path leaks
+    nobody has thought of yet are covered without extending a checklist. Restoring
+    in place (``sys.path[:] =``) keeps the list identity that importers may hold.
+    """
+    snapshot = list(sys.path)
+    try:
+        yield
+    finally:
+        if sys.path != snapshot:
+            sys.path[:] = snapshot
+
+
+@pytest.fixture(autouse=True)
 def _reset_game_sessions(request):
     if not _needs_game_route_reset(request):
         yield

--- a/tests/unit/test_launcher_job_object.py
+++ b/tests/unit/test_launcher_job_object.py
@@ -3,6 +3,15 @@ import sys
 
 import pytest
 
+# 模块级导入是有意的，别挪回函数体里。``launcher_core.bootstrap`` 在 import 时会
+# 检查 ``ssl`` 是否已经被别人先 import 走，是就往 stdout 打一条 Warning。整套
+# tests/unit 跑起来 ssl 几乎必然已在 sys.modules 里，于是「谁第一个 import
+# launcher_core」决定了那条 Warning 落进谁的 capsys ——
+# test_relax_job_kill_on_close_clears_the_limit_flag 断言的恰好是
+# ``capsys.readouterr().out == ""``，轮到它当第一个导入者就红（seed 90210 实测）。
+# 放在模块级 = 导入发生在收集期，落在任何用例的捕获窗口之外。
+from launcher_core import runtime as launcher
+
 
 class _FakeJobApi:
     def __init__(self, *, set_information_result=1):
@@ -24,8 +33,6 @@ class _FakeJobApi:
         return self.job
 
     def SetInformationJobObject(self, job, _info_class, info_pointer, _size):
-        from launcher_core import runtime as launcher
-
         assert job == self.job
         info = ctypes.cast(
             info_pointer,
@@ -45,8 +52,6 @@ class _FakeJobApi:
 
 @pytest.mark.unit
 def test_setup_job_object_preserves_pointer_sized_handles(monkeypatch):
-    from launcher_core import runtime as launcher
-
     api = _FakeJobApi()
     previous_handle = launcher.JOB_HANDLE
     monkeypatch.setattr(launcher.sys, "platform", "win32")
@@ -65,8 +70,6 @@ def test_setup_job_object_preserves_pointer_sized_handles(monkeypatch):
 
 @pytest.mark.unit
 def test_relax_job_kill_on_close_clears_the_limit_flag(monkeypatch, capsys):
-    from launcher_core import runtime as launcher
-
     api = _FakeJobApi()
     previous_handle = launcher.JOB_HANDLE
     monkeypatch.setattr(launcher.sys, "platform", "win32")
@@ -87,8 +90,6 @@ def test_relax_job_kill_on_close_clears_the_limit_flag(monkeypatch, capsys):
 
 @pytest.mark.unit
 def test_relax_job_kill_on_close_reports_win32_failure(monkeypatch, capsys):
-    from launcher_core import runtime as launcher
-
     api = _FakeJobApi(set_information_result=0)
     previous_handle = launcher.JOB_HANDLE
     monkeypatch.setattr(launcher.sys, "platform", "win32")
@@ -109,8 +110,6 @@ def test_relax_job_kill_on_close_reports_win32_failure(monkeypatch, capsys):
 @pytest.mark.skipif(sys.platform != "win32", reason="real Win32 function signatures")
 def test_job_object_api_declares_pointer_sized_handle_signatures():
     from ctypes import wintypes
-
-    from launcher_core import runtime as launcher
 
     api = launcher._get_windows_job_api()
 

--- a/tests/unit/test_recent_file_lock.py
+++ b/tests/unit/test_recent_file_lock.py
@@ -639,9 +639,11 @@ def test_compression_splice_keeps_messages_appended_during_compression(tmp_path)
     _write_disk(path, seeded)
 
     gate = asyncio.Event()
+    compressing = asyncio.Event()
     memo = SystemMessage(content="先前对话的备忘录: compressed")
 
     async def _blocking_compress(messages, lanlan_name, detailed=False):
+        compressing.set()
         await gate.wait()
         return (memo, "compressed")
 
@@ -651,7 +653,12 @@ def test_compression_splice_keeps_messages_appended_during_compression(tmp_path)
         task = asyncio.create_task(
             mgr_a.update_history([HumanMessage(content="trigger")], name, compress=True)
         )
-        await asyncio.sleep(0)
+        # update_history 要先过两次真正的 asyncio.to_thread（云存档栅栏 +
+        # CS-1 落盘）才走到 compress_history，实测要 ~3000 个事件循环 tick。
+        # 用 sleep(0) 只让出 1 个 tick，等于没握手：谁先落盘完全由线程池调度
+        # 决定，负载一重（整套 tests/unit 跑在前面时）mgr_b 就可能抢先，
+        # "trigger" 落在 "Z" 后面，末尾断言随机转红。
+        await asyncio.wait_for(compressing.wait(), timeout=5)
         await mgr_b.update_history([HumanMessage(content="Z")], name, compress=False)
         assert [m.content for m in _read_disk(path)][-1] == "Z"
         gate.set()
@@ -1492,9 +1499,11 @@ def test_review_commit_does_not_lose_messages_appended_during_review(tmp_path, m
     monkeypatch.setattr(recent_file, "atomic_write_json", _spy_write)
 
     gate = asyncio.Event()
+    reviewing = asyncio.Event()
 
     class _BlockingLLM(_ReviewLLM):
         async def ainvoke(self, prompt: str, **kwargs: Any) -> Any:
+            reviewing.set()
             await gate.wait()
             return await super().ainvoke(prompt, **kwargs)
 
@@ -1502,7 +1511,10 @@ def test_review_commit_does_not_lose_messages_appended_during_review(tmp_path, m
 
     async def _go():
         review_task = asyncio.create_task(mgr.review_history(name, snapshot=list(snapshot)))
-        await asyncio.sleep(0)
+        # 同 test_compression_splice_*：review 走到 LLM 之前隔着真正的
+        # asyncio.to_thread，sleep(0) 只让出一个 tick，握不住这个窗口。
+        # 等 LLM 真的被调用才是确定的握手点。
+        await asyncio.wait_for(reviewing.wait(), timeout=5)
         # review LLM 卡在 gate 上时插一条新消息并确认已上盘
         await mgr.update_history([HumanMessage(content="Z")], name, compress=False)
         assert [m.content for m in _read_disk(path)][-1] == "Z"

--- a/tests/unit/test_sys_path_isolation.py
+++ b/tests/unit/test_sys_path_isolation.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+"""Guardrails for the autouse ``_reset_sys_path`` fixture in conftest.
+
+``sys.path`` is process-global and product code prepends to it on purpose
+(``_start_embedded_user_plugin_server`` puts ``<repo>/plugin`` at index 1). A unit
+test that drives such a path leaves the entry behind for the whole session, and
+``<repo>/plugin`` carries its own ``config`` package that then outranks the repo
+root — see the fixture's docstring for the full chain.
+
+The first two tests are a pair: each asserts it cannot see the *other* one's
+marker before planting its own. Whichever pytest-randomly happens to schedule
+second turns red the moment the fixture stops restoring, under any seed.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_MARKER_A = "<neko-sys-path-isolation-marker-a>"
+_MARKER_B = "<neko-sys-path-isolation-marker-b>"
+_MARKERS = (_MARKER_A, _MARKER_B)
+
+
+def _leaked_markers() -> list[str]:
+    return [entry for entry in sys.path if entry in _MARKERS]
+
+
+@pytest.mark.unit
+def test_sys_path_mutation_does_not_leak_forward_first():
+    assert _leaked_markers() == [], (
+        "另一条用例往 sys.path 里插的标记漏到这里了 —— conftest 的 "
+        "_reset_sys_path 没在还原"
+    )
+    sys.path.insert(0, _MARKER_A)
+
+
+@pytest.mark.unit
+def test_sys_path_mutation_does_not_leak_forward_second():
+    assert _leaked_markers() == [], (
+        "另一条用例往 sys.path 里插的标记漏到这里了 —— conftest 的 "
+        "_reset_sys_path 没在还原"
+    )
+    sys.path.insert(0, _MARKER_B)
+
+
+@pytest.mark.unit
+def test_repo_root_outranks_the_bundled_plugin_dir():
+    """``<repo>/plugin`` must never sit ahead of the repo root.
+
+    It ships ``plugin/config/``, so once it outranks the root the next
+    ``importlib.reload(config)`` rebinds the root ``config`` package to it. This
+    only catches a leak that happened *earlier* in the session, so it is a
+    second line of defence behind the marker pair above, not a replacement.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    plugin_dir = repo_root / "plugin"
+
+    plugin_at = root_at = -1
+    for index, entry in enumerate(sys.path):
+        if not entry:
+            continue
+        try:
+            resolved = Path(entry).resolve()
+        except (OSError, ValueError):
+            continue
+        if plugin_at < 0 and resolved == plugin_dir:
+            plugin_at = index
+        if root_at < 0 and resolved == repo_root:
+            root_at = index
+
+    if plugin_at < 0:
+        return
+    assert root_at >= 0 and root_at < plugin_at, (
+        f"{plugin_dir} 排在仓库根前面（plugin={plugin_at} root={root_at}）："
+        "任何一次 importlib.reload(config) 都会把根 config 包重指到 plugin/config"
+    )


### PR DESCRIPTION
排查「main CI 红是不是跨用例污染」的产物。结论分两半：

**main 那 5 条红不是顺序依赖**，是 #2663 (d2da066e7) 的回归 —— `unit-tests.yml` 在 main 上从那次 push（run 30916009770）开始红，前一次 #2675 还是绿的；那 5 条单独跑也红。已由 #2694 在修，本 PR 不碰。

**真的顺序依赖有三条**，本 PR 修这三条。都只动测试，没动运行时代码。

---

## 1. `test_recent_file_lock.py` 两条并发窗口用例的假握手

单独跑一直绿，跟在整套 `tests/unit` 后面跑会随机转红（大前缀下实测 2/9，单跑 0/24）。

两条用例都要造「后台任务卡在 gate 上时，第二个写者插一条消息」这个窗口，办法是：

```python
task = asyncio.create_task(mgr_a.update_history(..., compress=True))
await asyncio.sleep(0)          # ← 以为这样 task 就跑到 gate 了
await mgr_b.update_history(...)
```

但 `update_history` 走到 `compress_history` 之前隔着**两次真正的 `asyncio.to_thread`**（`assert_cloudsave_writable` 写入栅栏 + CS-1 落盘临界区）。插桩数了一下：

```
PROBE after one sleep(0): compressing = False
PROBE ticks needed to reach compress_history: 2807 / 2726 / 3158 / 2743 / 2890
```

`sleep(0)` 只让出 1 个 tick，实际要 ~3000 个。也就是 `mgr_a` / `mgr_b` 谁先落盘完全由线程池调度决定，跟用例写的顺序无关。平时 `mgr_b` 自己那两次 `to_thread` 恰好给了 `mgr_a` 足够时间所以看着是绿的；前面跑过几百个文件、进程里堆了一批后台线程之后，GIL 争用一变 `mgr_b` 就可能抢先，`"trigger"` 落在 `"Z"` 后面，末尾 splice 断言随机转红。

`test_review_commit_does_not_lose_messages_appended_during_review` 是同一个模子刻的，一并修。

**修法**：在被卡住的那个 callable 里（`_blocking_compress` / `_BlockingLLM.ainvoke`）`set()` 一个 Event，用例 `await` 它。窗口从此确定，不再依赖线程池时序。没给受害断言加防御性重置。

**变异验证**（确认护栏没被削弱）：给 `memory/recent.py` 两处「锁内重读」——`_splice_compressed_locked` / `_commit_review_locked` 的 `_load_history_unlocked` 之后插 `current = current[:-1]`，模拟「看不到并发追加的那条」，两条用例都按预期转红。

---

## 2. `sys.path` 泄漏让 `plugin/config` 顶掉根 `config` 包

`test_cloudsave_startup_flow.py::test_runtime_config_reload_preserves_negotiated_fallback_ports` 单独跑绿，全量在 seed 31337 下稳定红（2/2）：

```
AssertionError: assert 52111 == 53111
 +  where 52111 = getattr(<module 'config' from '...\plugin\config\__init__.py'>, 'MAIN_SERVER_PORT')
```

注意那个路径 —— `launcher.config_module` 指到 **`plugin/config/__init__.py`** 去了。

**污染源**：`test_agent_server_hardening.py::test_embedded_plugin_server_start_failure_clears_handles`。它直接调 `plugin_host._start_embedded_user_plugin_server()`，而那个函数会 `sys.path.insert(1, <repo>/plugin)`（好让内嵌插件服务器 import 得到 `plugin.server.http_app`）。真的 agent 进程里这是有意的、装一次管一辈子；用例里就永久留在会话里了。那条用例把 `_shared.Modules` 四个句柄都 `finally` 还原了，唯独 `sys.path` 没人管。

**index 1 为什么会出事**：pytest 下仓库根不在 `sys.path[0]`。插桩打出来的实况：

```
[0] tests/unit/asr_client
[1] <repo>/plugin        ← insert(1) 落在这
[2] tests
[3] tests/unit/asr_client
[4] <repo>               ← 仓库根被 basedir 前插挤到第 4 位
```

`<repo>/plugin` 底下有自己的 `config/` 包，于是任何一次新解析 `config` 都解到 `plugin/config` —— 包括 `importlib.reload()`，它会重跑 finder 并**就地重绑**模块对象。`_reload_runtime_config_from_env()` 干的正是 reload `config`，结果把 `plugin/config` 灌进根 `config` 模块，协商出来的 `NEKO_*` 端口一个都没进去。跟 #1679 的插件命名空间遮挡是同一族问题的另一面。

**修法**：照 #2690 的先例，`tests/unit/conftest.py` 加 autouse fixture `_reset_sys_path`，每条用例前后快照/还原整个 `sys.path`。整表还原而不是点名删条目 —— 将来别人漏的路径自动被盖住，不用维护清单。

**护栏** `tests/unit/test_sys_path_isolation.py`：
- 两条用例各自「先断言看不到对方的标记、再插自己的」，pytest-randomly 洗成什么顺序都一样，后跑那条在 fixture 失效时必红。
- 第三条钉住「`<repo>/plugin` 不得排在仓库根前面」这个不变量（只能抓到更早发生的泄漏，是第二道防线，不替代上面那对）。

**变异验证**：fixture 改成空 `yield`，seed 1/2/3 下标记对都按预期转红（`1 failed, 2 passed`，红的那条随 seed 换人）。

---

## 3. `test_launcher_job_object.py` 让 SSL 引导的 Warning 落进了自己的 capsys

`test_relax_job_kill_on_close_clears_the_limit_flag` 单独跑绿，全量在 seed 90210 下稳定红（**3/3**）：

```
AssertionError: assert '[Launcher] W...auncher.py.
' == ''
 + [Launcher] Warning: `ssl` was imported before _configure_ssl_cert_bundle() ran;
   SSL_CERT_FILE override won't affect the already-initialized default SSLContext.
```

`launcher_core/bootstrap.py:265` 在 **import 时**检查 `"ssl" in sys.modules`，是就往 **stdout** 打这条 Warning —— 有意为之的运维可见信号，产品侧不动。

问题在测试这边：这个文件里五处 `from launcher_core import runtime as launcher` 全是**函数体内的局部导入**。模块只会被导入一次，所以「谁第一个 import `launcher_core`」就决定了那条 Warning 落进谁的 `capsys`。整套 `tests/unit` 跑起来 `ssl` 几乎必然已在 `sys.modules` 里，而这条用例最后一句恰好是 `assert capsys.readouterr().out == ""` —— 轮到它当第一个导入者就红。兄弟用例 `test_relax_job_kill_on_close_reports_win32_failure` 用的是 `in`，所以免疫。

**修法**：导入提到模块级，收集期就完成，落在任何用例的捕获窗口之外。断言一个字没改，没降强度；加注释钉住「别挪回函数体」。

为什么只能靠全量验：两文件组合试了三种（`test_asr_client` / `test_geoip_region_gate` / `test_agent_browser_lifecycle` 打头）都复现不了 —— 小集合下 `launcher_core` 在收集期就被别人导入掉了，凑不出「这条用例当第一个导入者」的局面。

---

## 验证

`tests/unit` 全量，多种顺序（本地都先打上 #2694 的补丁，否则 main 那 5 条红会盖住信号）：

| 顺序 | 结果 |
| --- | --- |
| seed 90210（抓到 #3 的那轮，改前 3/3 红） | 15100 passed |
| seed 31337（抓到 #2 的那轮，改前 2/2 红） | 15100 passed |
| 默认 seed 20260731（CI 顺序） | 15100 passed |
| 强制顺序（关 randomly、纯参数顺序，抓到 #1 的那种排法） | 15100 passed |

修 #1 之前另跑过一轮 4 种顺序（默认 / 777 / 强制 ×2）全绿，`15097 passed`。

#2 的 fixture 还做了**全量规模**的变异验证：把它改成空 `yield` 之后跑全量，护栏用例 `test_sys_path_mutation_does_not_leak_forward_second` 在强制顺序和 seed 90210 两种排法下都按预期转红。同一轮归因也确认了 #3 那条红在带/不带该 fixture 时同样出现 —— 不是这个 PR 引入的。

## 观察到但没修的一条

`test_api_config_manager.py::TestGptsovitsEnabledSaveMigration::test_update_core_config_doubao_tts_respects_explicit_model_key_update[vllm_omni-ark-doubao-explicit-model-key]` 在强制顺序下红过**一次**，同一排法后续跑 3 次都没再红 —— 偶发，不是确定性顺序依赖。单次观测不足以定性，硬修等于瞎猜，所以本 PR 不动它。

## 顺带记一笔，本 PR 没动

`app/agent_server/plugin_host.py` 那个 `sys.path.insert(1, ...)` 的硬编码下标在产品侧本身就不稳：agent 进程里只要有别的东西往前插过，`<repo>/plugin` 就会盖过仓库根，之后任何 `import config` 都拿到 `plugin/config`。属于产品行为取舍，留给你拍。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 增强测试环境隔离，避免单元测试之间相互污染路径配置。
  * 新增路径恢复测试，验证测试执行顺序不会影响结果。
  * 改进并发测试同步机制，提升测试稳定性，减少因调度时序导致的偶发失败。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
