### PR TITLE
统一 Live2D 动作与临时表情互斥逻辑，动作播放期间拒绝新动作，表情切换时重置旧表情并保留常驻表情

### DIFF
--- a/static/app/app-interpage/bootstrap-resources-and-model-reload.js
+++ b/static/app/app-interpage/bootstrap-resources-and-model-reload.js
@@ -1869,6 +1869,13 @@ I.mod = window.appInterpage;
 
             // 8. 以 IDLE 优先级恢复；普通动作占用时不抢占
             if (live2dManager.hasActiveActionMotion(live2dModel)) return;
+            const motionState = motionManager.state;
+            if (
+                (Number(motionState?.currentPriority || 0) === 1 || motionState?.reservedIdleGroup !== undefined)
+                && typeof motionManager.stopAllMotions === 'function'
+            ) {
+                motionManager.stopAllMotions();
+            }
             const started = await live2dModel.motion(groupName, motionIndex, 1);
             if (started) {
                 console.log('[Live2D Main] 已恢复待机动作并循环播放:', live2dIdleAnimation);

--- a/static/app/app-interpage/bootstrap-resources-and-model-reload.js
+++ b/static/app/app-interpage/bootstrap-resources-and-model-reload.js
@@ -1867,10 +1867,12 @@ I.mod = window.appInterpage;
                 }
             }
 
-            // 8. 停止当前动作并播放保存的待机动作
-            motionManager.stopAllMotions();
-            live2dModel.motion(groupName, motionIndex, 3);
-            console.log('[Live2D Main] 已恢复待机动作并循环播放:', live2dIdleAnimation);
+            // 8. 以 IDLE 优先级恢复；普通动作占用时不抢占
+            if (live2dManager.hasActiveActionMotion(live2dModel)) return;
+            const started = await live2dModel.motion(groupName, motionIndex, 1);
+            if (started) {
+                console.log('[Live2D Main] 已恢复待机动作并循环播放:', live2dIdleAnimation);
+            }
 
         } catch (error) {
             console.error('[Live2D Main] 恢复待机动作失败:', error);

--- a/static/avatar/avatar-performance-stage.js
+++ b/static/avatar/avatar-performance-stage.js
@@ -2127,13 +2127,16 @@
         }
 
         async clearExpression() {
+            const manager = this.getManager();
+            const shouldClearManagerExpression = manager?._activeTransientExpression === true;
             if (this.expressionParamSnapshot) {
                 this.restoreParams(this.expressionParamSnapshot);
                 this.expressionParamSnapshot = null;
             }
-            const manager = this.getManager();
-            if (manager && typeof manager.clearExpression === 'function') {
+            if (shouldClearManagerExpression && typeof manager.clearExpression === 'function') {
                 await Promise.resolve(manager.clearExpression()).catch(() => {});
+            } else if (manager && typeof manager.applyPersistentExpressionsNative === 'function') {
+                await Promise.resolve(manager.applyPersistentExpressionsNative(true)).catch(() => {});
             }
             return true;
         }

--- a/static/avatar/avatar-performance-stage.js
+++ b/static/avatar/avatar-performance-stage.js
@@ -1809,20 +1809,20 @@
                 const file = typeof candidate === 'object' ? this.getMotionFile(candidate) : '';
                 const explicitIndex = candidate && Number.isInteger(Number(candidate.index)) ? Number(candidate.index) : null;
 
-                if (groupName && explicitIndex !== null && model && typeof model.motion === 'function') {
+                if (groupName && explicitIndex !== null && typeof manager.playActionMotion === 'function') {
                     try {
-                        const played = await this.withPerformanceBypass(() => model.motion(groupName, explicitIndex));
+                        const played = await this.withPerformanceBypass(() => manager.playActionMotion(groupName, explicitIndex));
                         if (played !== false) {
                             return true;
                         }
                     } catch (_) {}
                 }
 
-                if (file && model && typeof model.motion === 'function') {
+                if (file && typeof manager.playActionMotion === 'function') {
                     const runtimeRef = this.findMotionRuntimeReference(groupName, file);
                     if (runtimeRef) {
                         try {
-                            const played = await this.withPerformanceBypass(() => model.motion(runtimeRef.group, runtimeRef.index));
+                            const played = await this.withPerformanceBypass(() => manager.playActionMotion(runtimeRef.group, runtimeRef.index));
                             if (played !== false) {
                                 return true;
                             }
@@ -2082,6 +2082,7 @@
             if (!manager) {
                 return false;
             }
+            await this.clearExpression();
             const candidates = this.collectExpressionCandidates(expression, options);
             for (let index = 0; index < candidates.length; index += 1) {
                 const candidate = candidates[index];
@@ -2131,14 +2132,8 @@
                 this.expressionParamSnapshot = null;
             }
             const manager = this.getManager();
-            if (manager && typeof manager.resetTransientMotionAndExpressionState === 'function') {
-                await Promise.resolve(manager.resetTransientMotionAndExpressionState({
-                    preserveExpression: false,
-                    resetAllParameters: false
-                })).catch(() => {});
-            }
-            if (manager && typeof manager.applyPersistentExpressionsNative === 'function') {
-                await Promise.resolve(manager.applyPersistentExpressionsNative(true)).catch(() => {});
+            if (manager && typeof manager.clearExpression === 'function') {
+                await Promise.resolve(manager.clearExpression()).catch(() => {});
             }
             return true;
         }

--- a/static/live2d/live2d-core.js
+++ b/static/live2d/live2d-core.js
@@ -123,6 +123,11 @@ class Live2DManager {
         this.isInitialized = false;
         this.motionTimer = null;
         this._motionTimerGeneration = 0;
+        this._actionMotionRequestPendingModel = null;
+        this._simpleMotionActive = false;
+        this._transientExpressionGeneration = 0;
+        this._transientExpressionTask = null;
+        this._activeTransientExpression = false;
         this.isEmotionChanging = false;
         this.dragEnabled = false;
         this.isFocusing = false;

--- a/static/live2d/live2d-emotion.js
+++ b/static/live2d/live2d-emotion.js
@@ -175,6 +175,7 @@ Live2DManager.prototype.clearExpression = function() {
     // 必须先保存受影响参数，再取消正在进行的平滑过渡和手动表情覆盖。
     this._cancelSmoothReset();
     this._removeManualExpressionOverride();
+    this._activeTransientExpression = false;
 
     try {
         if (!this.currentModel || !this.currentModel.internalModel || !this.currentModel.internalModel.coreModel) {
@@ -193,7 +194,7 @@ Live2DManager.prototype.clearExpression = function() {
         }
 
         this._activeExpressionParamIds = null;
-        if (activeExpressionParamIds && activeExpressionParamIds.size > 0) {
+        if (activeExpressionParamIds) {
             const resetCount = this._resetRecordedParameterIds(activeExpressionParamIds, {
                 preserveExpression: false
             });
@@ -210,7 +211,10 @@ Live2DManager.prototype.clearExpression = function() {
 
     // 如存在常驻表情，清除后立即重放常驻，保证不被清掉
     // 注意：这里传入 skipBackup=true，因为我们只是重新应用已有的常驻表情，不需要再次备份
-    this.applyPersistentExpressionsNative(true);
+    return Promise.resolve(this.applyPersistentExpressionsNative(true)).catch((e) => {
+        console.warn('重新应用常驻表情失败:', e);
+        return false;
+    });
 };
 
 Live2DManager.prototype._getActiveExpressionParamIds = function() {
@@ -470,6 +474,7 @@ Live2DManager.prototype.hasActiveMotionPlayback = function() {
 
 Live2DManager.prototype._clearMotionTimer = function() {
     this._nextMotionTimerGeneration();
+    this._simpleMotionActive = false;
     if (!this.motionTimer) return false;
 
     console.log(`清除motion定时器，类型: ${this.motionTimer.type || 'unknown'}`);
@@ -864,8 +869,33 @@ Live2DManager.prototype._removeManualExpressionOverride = function() {
     this._manualExpressionParams = null;
 };
 
+Live2DManager.prototype.playExpression = function(emotion, specifiedExpressionFile = null) {
+    const model = this.currentModel;
+    if (!model) return Promise.resolve(false);
+
+    const generation = (this._transientExpressionGeneration || 0) + 1;
+    this._transientExpressionGeneration = generation;
+    const previousTask = this._transientExpressionTask || Promise.resolve(false);
+    const task = previousTask.catch(() => false).then(async () => {
+        if (this.currentModel !== model || this._transientExpressionGeneration !== generation) {
+            return false;
+        }
+        if (this._activeTransientExpression) {
+            await this.clearExpression();
+            if (this.currentModel !== model || this._transientExpressionGeneration !== generation) {
+                return false;
+            }
+        }
+        return this._playExpressionNow(emotion, specifiedExpressionFile, model);
+    });
+    this._transientExpressionTask = task;
+    return task.finally(() => {
+        if (this._transientExpressionTask === task) this._transientExpressionTask = null;
+    });
+};
+
 // 播放表情（优先使用 EmotionMapping.expressions）
-Live2DManager.prototype.playExpression = async function(emotion, specifiedExpressionFile = null) {
+Live2DManager.prototype._playExpressionNow = async function(emotion, specifiedExpressionFile = null, expressionModel = this.currentModel) {
     if (!this.currentModel) {
         console.warn('无法播放表情：模型未加载');
         return false;
@@ -970,6 +1000,7 @@ Live2DManager.prototype.playExpression = async function(emotion, specifiedExpres
             }
             throw lastFetchError || new Error('Failed to load expression');
         }
+        if (this.currentModel !== expressionModel) return false;
         console.log(`加载表情文件: ${loadedExpressionFile}`, expressionData);
         this._activeExpressionParamIds = new Set(
             (expressionData.Parameters || [])
@@ -998,8 +1029,10 @@ Live2DManager.prototype.playExpression = async function(emotion, specifiedExpres
                 
                 console.log(`尝试使用原生API播放expression: ${expressionName} (file: ${loadedExpressionFile})`);
                 
-                const expression = await this.currentModel.expression(expressionName);
+                const expression = await expressionModel.expression(expressionName);
+                if (this.currentModel !== expressionModel) return false;
                 if (expression) {
+                    this._activeTransientExpression = true;
                     console.log(`成功使用原生API播放expression: ${expressionName}`);
                     try {
                         await this.applyPersistentExpressionsNative(true);
@@ -1021,6 +1054,7 @@ Live2DManager.prototype.playExpression = async function(emotion, specifiedExpres
             // 使用 _installManualExpressionOverride 在每帧中持续应用参数，并带有淡入效果
             this._installManualExpressionOverride(expressionData.Parameters, LIVE2D_EMOTION_SOFT_EXPRESSION_FADE_IN_MS);
             this.expressionApplied = true;
+            this._activeTransientExpression = true;
         }
         
         console.log(`手动设置表情（带淡入过渡）: ${loadedExpressionFile}`);
@@ -1049,6 +1083,10 @@ Live2DManager.prototype.playMotion = async function(emotion) {
     }
 
     const playMotionModel = this.currentModel;
+    if (typeof this.hasActiveActionMotion === 'function' && this.hasActiveActionMotion(playMotionModel)) {
+        console.log(`[Live2D] 已有动作正在播放，忽略新动作: ${emotion}`);
+        return false;
+    }
     const playMotionInvocationGeneration = (this._playMotionInvocationGeneration || 0) + 1;
     this._playMotionInvocationGeneration = playMotionInvocationGeneration;
     const isCurrentPlayMotionInvocation = () => (
@@ -1125,7 +1163,14 @@ Live2DManager.prototype.playMotion = async function(emotion) {
     // 新 motion 开始前先回到干净基准。这里保留当前 expression，因为
     // setEmotion() 会先应用本轮表情再播放动作；单独调用 playMotion()
     // 时也应保留用户当前表情，只清掉上一条 motion 的残留。
-    await this.resetTransientMotionAndExpressionState({ preserveExpression: true });
+    this._actionMotionRequestPendingModel = playMotionModel;
+    try {
+        await this.resetTransientMotionAndExpressionState({ preserveExpression: true });
+    } finally {
+        if (this._actionMotionRequestPendingModel === playMotionModel) {
+            this._actionMotionRequestPendingModel = null;
+        }
+    }
     if (!isCurrentPlayMotionInvocation()) return false;
 
     if (!motions || motions.length === 0) {
@@ -1194,7 +1239,7 @@ Live2DManager.prototype.playMotion = async function(emotion) {
                     // 使用运行时 motion group/index 播放，确保播放文件和追踪清理文件一致。
                     console.log(`尝试使用motion组播放motion: ${runtimeChoice.group}[${runtimeChoice.index}]`);
 
-                    const motion = await this.currentModel.motion(runtimeChoice.group, runtimeChoice.index);
+                    const motion = await this.playActionMotion(runtimeChoice.group, runtimeChoice.index);
                     if (!isCurrentMotionInvocation()) return false;
 
                     if (motion) {
@@ -1284,6 +1329,10 @@ Live2DManager.prototype.playMotion = async function(emotion) {
 
 // 播放简单动作（回退方案）
 Live2DManager.prototype.playSimpleMotion = function(emotion) {
+    if (typeof this.hasActiveActionMotion === 'function' && this.hasActiveActionMotion(this.currentModel)) {
+        return false;
+    }
+
     try {
         const generation = this._nextMotionTimerGeneration();
         const isCurrentMotion = () => this._isCurrentMotionTimerGeneration(generation);
@@ -1294,6 +1343,7 @@ Live2DManager.prototype.playSimpleMotion = function(emotion) {
             surprised: ['ParamAngleY']
         };
         this._setActiveMotionParamIds(simpleMotionParams[emotion] || ['ParamAngleX', 'ParamAngleY']);
+        this._simpleMotionActive = Object.prototype.hasOwnProperty.call(simpleMotionParams, emotion);
 
         switch (emotion) {
             case 'happy': {
@@ -1351,8 +1401,11 @@ Live2DManager.prototype.playSimpleMotion = function(emotion) {
                 break;
         }
         console.log(`播放简单动作: ${emotion}`);
+        return true;
     } catch (paramError) {
+        this._simpleMotionActive = false;
         console.warn('设置简单动作参数失败:', paramError);
+        return false;
     }
 };
 
@@ -1446,22 +1499,20 @@ Live2DManager.prototype.setEmotion = async function(emotion) {
     const isIdleEmotion = typeof emotion === 'string' && emotion.toLowerCase() === 'idle';
     const willApplyNewExpression = !!targetExpressionFile;
     const shouldPreserveExistingExpression = isIdleEmotion && !willApplyNewExpression;
+    const emotionModel = this.currentModel;
+    const shouldAttemptMotion = typeof this.hasActiveActionMotion !== 'function'
+        || !this.hasActiveActionMotion(emotionModel);
     
-    // 检查是否需要重置：即使情绪和表情都相同，也先清掉上一条 motion 的 transient 残留。
+    // 相同表情保持不变，只尝试触发新的动作；动作槽忙时 playMotion 会直接拒绝。
     if (this.currentEmotion === emotion && this.currentExpressionFile === targetExpressionFile) {
         this.isEmotionChanging = true;
         try {
-            await this.resetTransientMotionAndExpressionState({
-                preserveExpression: !!targetExpressionFile || shouldPreserveExistingExpression,
-                resetAllParameters: !targetExpressionFile && !shouldPreserveExistingExpression
-            });
-
             // 相同情绪且相同表情，保留原有的50%概率随机播放动作机制
-            if (Math.random() < 0.5) {
-                console.log(`检测到相同情绪且相同表情: ${emotion} (${targetExpressionFile})，已清理残留，仅随机播放motion`);
+            if (shouldAttemptMotion && Math.random() < 0.5) {
+                console.log(`检测到相同情绪且相同表情: ${emotion} (${targetExpressionFile})，仅随机播放motion`);
                 await this.playMotion(emotion);
             } else {
-                console.log(`检测到相同情绪且相同表情: ${emotion} (${targetExpressionFile})，已清理残留，跳过播放`);
+                console.log(`检测到相同情绪且相同表情: ${emotion} (${targetExpressionFile})，跳过播放`);
             }
             try {
                 await this.applyPersistentExpressionsNative(true);
@@ -1485,37 +1536,21 @@ Live2DManager.prototype.setEmotion = async function(emotion) {
     
     // 设置标志，防止快速连续点击
     this.isEmotionChanging = true;
+    if (shouldAttemptMotion) this._actionMotionRequestPendingModel = emotionModel;
     
     try {
         console.log(`开始设置新情感: ${emotion}`);
 
-        // setEmotion 切入新情绪时应清理上一套 expression/motion 残留；
-        // 唯一例外是回退到 Idle 且没有新 expression，此时沿用旧语义：
-        // 只清 motion 残留，不把当前情绪表情洗掉。
-        if (!shouldPreserveExistingExpression) {
-            await this.smoothResetToInitialState(LIVE2D_EMOTION_SOFT_RESET_MS);
+        // 表情和动作分别使用独立槽：新表情替换旧表情，动作槽忙时保留当前动作。
+        if (!willApplyNewExpression && !shouldPreserveExistingExpression) {
+            this._transientExpressionGeneration = (this._transientExpressionGeneration || 0) + 1;
+            await Promise.resolve(this._transientExpressionTask).catch(() => false);
+            if (this._activeTransientExpression) await this.clearExpression();
         }
-        await this.resetTransientMotionAndExpressionState({
-            preserveExpression: shouldPreserveExistingExpression,
-            resetAllParameters: !shouldPreserveExistingExpression
-        });
 
         this.currentEmotion = emotion;
         this.currentExpressionFile = targetExpressionFile;
         console.log(`情感已更新为: ${emotion}，表情文件: ${targetExpressionFile}`);
-
-        // 暂停idle动画，防止覆盖我们的动作
-        if (this.currentModel && this.currentModel.internalModel && this.currentModel.internalModel.motionManager) {
-            try {
-                // 尝试停止所有正在播放的动作
-                if (this.currentModel.internalModel.motionManager.stopAllMotions) {
-                    this.currentModel.internalModel.motionManager.stopAllMotions();
-                    console.log('已停止idle动画');
-                }
-            } catch (motionError) {
-                console.warn('停止idle动画失败:', motionError);
-            }
-        }
 
         // 播放表情（使用确定的表情文件以保持一致性）。
         if (willApplyNewExpression) {
@@ -1527,7 +1562,16 @@ Live2DManager.prototype.setEmotion = async function(emotion) {
         }
 
         // 播放动作
-        await this.playMotion(emotion);
+        if (
+            shouldAttemptMotion
+            && this.currentModel === emotionModel
+            && this._actionMotionRequestPendingModel === emotionModel
+        ) {
+            this._actionMotionRequestPendingModel = null;
+            await this.playMotion(emotion);
+        } else {
+            console.log(`[Live2D] 情感 ${emotion} 触发时动作槽已占用，仅替换表情`);
+        }
 
         // reset/cleanup 后补回常驻表情；没有新 expression 时这一步也不影响当前表情保护。
         try {
@@ -1540,6 +1584,9 @@ Live2DManager.prototype.setEmotion = async function(emotion) {
     } catch (error) {
         console.error(`设置情感 ${emotion} 失败:`, error);
     } finally {
+        if (shouldAttemptMotion && this._actionMotionRequestPendingModel === emotionModel) {
+            this._actionMotionRequestPendingModel = null;
+        }
         // 重置标志
         this.isEmotionChanging = false;
     }

--- a/static/live2d/live2d-interaction.js
+++ b/static/live2d/live2d-interaction.js
@@ -2521,7 +2521,7 @@ Live2DManager.prototype._stopClickEffectAction = function(action = this._clickEf
         || action.generation !== this._actionMotionGeneration
         || state?.currentGroup !== action.group
         || state?.currentIndex !== action.index
-        || Number(state.currentPriority || 0) <= 1
+        || Number(state?.currentPriority || 0) <= 1
         || typeof motionManager?.stopAllMotions !== 'function'
     ) {
         return false;

--- a/static/live2d/live2d-interaction.js
+++ b/static/live2d/live2d-interaction.js
@@ -2512,15 +2512,13 @@ Live2DManager.prototype._restoreClickEffectState = async function(options = {}) 
 };
 
 /**
- * 播放临时点击效果（低优先级，会自动恢复）
+ * 播放临时点击效果（动作槽空闲时播放，并自动恢复）
  * @param {string} emotion - 情感名称
- * @param {number} priority - 动作优先级 (1=IDLE, 2=NORMAL, 3=FORCE)
  * @param {number} duration - 效果持续时间（毫秒）
  */
-Live2DManager.prototype._playTemporaryClickEffect = async function(emotion, priority = 1, duration = 3000) {
+Live2DManager.prototype._playTemporaryClickEffect = async function(emotion, duration = 3000) {
     const triggerLog = {
         emotion,
-        priority,
         durationMs: duration,
         motionCandidates: 0,
         expressionCandidates: 0,
@@ -2587,9 +2585,9 @@ Live2DManager.prototype._playTemporaryClickEffect = async function(emotion, prio
         }
         triggerLog.expressionCandidates = expressionFiles.length;
 
-        // 1. 优先播放低优先级动作
+        // 1. 动作槽空闲时优先播放动作
         let motions = null;
-        let motionGroup = emotion; // 用于 this.currentModel.motion(group, index, priority)
+        let motionGroup = emotion;
         if (this.fileReferences && this.fileReferences.Motions && this.fileReferences.Motions[emotion]) {
             motions = this.fileReferences.Motions[emotion];
         } else if (this.emotionMapping && this.emotionMapping.motions && this.emotionMapping.motions[emotion]) {
@@ -2620,10 +2618,9 @@ Live2DManager.prototype._playTemporaryClickEffect = async function(emotion, prio
         triggerLog.motionCandidates = Array.isArray(motions) ? motions.length : 0;
 
         if (motions && motions.length > 0) {
-            // 使用低优先级播放动作
-            // pixi-live2d-display 的 motion(group, index, priority) 支持优先级参数
             try {
-                const motion = await this.currentModel.motion(motionGroup, undefined, priority);
+                const motionIndex = Math.floor(Math.random() * motions.length);
+                const motion = await this.playActionMotion(motionGroup, motionIndex);
                 if (!isCurrentPlayAttempt()) {
                     // 已被新的点击接管：停掉本次刚启动的动作，避免后台占用，并放弃写共享状态
                     if (motion && typeof motion.stop === 'function') {
@@ -2633,20 +2630,20 @@ Live2DManager.prototype._playTemporaryClickEffect = async function(emotion, prio
                     return false;
                 }
                 if (motion) {
-                    console.log(`[ClickEffect] 播放临时动作: ${motionGroup}（优先级: ${priority}）`);
+                    console.log(`[ClickEffect] 播放临时动作: ${motionGroup}`);
                     this._clickEffectMotion = motion;
                     triggerLog.motions.push({
                         group: motionGroup,
-                        selection: 'random',
-                        priority,
+                        index: motionIndex,
+                        priority: 2,
                         candidateCount: motions.length
                     });
                     didPlayEffect = true;
                 } else {
                     triggerLog.failedMotions.push({
                         group: motionGroup,
-                        selection: 'random',
-                        priority,
+                        index: motionIndex,
+                        priority: 2,
                         reason: 'motion_returned_falsy'
                     });
                 }
@@ -2654,7 +2651,7 @@ Live2DManager.prototype._playTemporaryClickEffect = async function(emotion, prio
                 triggerLog.failedMotions.push({
                     group: motionGroup,
                     selection: 'random',
-                    priority,
+                    priority: 2,
                     reason: motionError?.message || String(motionError)
                 });
                 console.warn('[ClickEffect] 动作播放失败:', motionError);
@@ -3250,11 +3247,9 @@ Live2DManager.prototype.playTutorialMotion = async function() {
     const index = Math.floor(Math.random() * groupList.length);
 
     try {
-        const motion = await this.currentModel.motion(group, index, window.live2dManager.CLICK_MOTION_PRIORITY);
-        // const motion = await this.currentModel.motion(group, index, 2);
+        const motion = await this.playActionMotion(group, index);
         if (motion) {
-            console.log(`[Interaction] 教程模式 - 播放动作: ${group}[${index}]（优先级: ${window.live2dManager.CLICK_MOTION_PRIORITY}）`);
-            // console.log(`[Interaction] 教程模式 - 播放动作: ${group}[${index}]（优先级: ${2}）`);
+            console.log(`[Interaction] 教程模式 - 播放动作: ${group}[${index}]`);
             return true;
         }
     } catch (error) {
@@ -3281,65 +3276,25 @@ Live2DManager.prototype.triggerRandomEmotion = async function() {
 
     // 教程模式：直接随机播放表情
     if (window.isInTutorial) {
-        console.log('[Interaction] 教程模式 - 随机播放表情（低优先级，将自动恢复）');
+        console.log('[Interaction] 教程模式 - 随机播放表情（将在点击效果结束后恢复）');
         try {
             // 获取表情列表
-            let expressionNames = [];
+            let expressions = [];
             if (this.fileReferences && Array.isArray(this.fileReferences.Expressions)) {
-                expressionNames = this.fileReferences.Expressions.map(e => e.Name).filter(Boolean);
+                expressions = this.fileReferences.Expressions.filter(e => e && e.Name && e.File);
             }
 
             // 随机播放表情
-            if (expressionNames.length > 0) {
-                const randomExpression = expressionNames[Math.floor(Math.random() * expressionNames.length)];
-                console.log(`[Interaction] 教程模式 - 播放表情: ${randomExpression}（将在 ${window.live2dManager.CLICK_EFFECT_DURATION}ms 后恢复）`);
-                await this.currentModel.expression(randomExpression);
+            if (expressions.length > 0) {
+                const randomExpression = expressions[Math.floor(Math.random() * expressions.length)];
+                console.log(`[Interaction] 教程模式 - 播放表情: ${randomExpression.Name}（将在 ${window.live2dManager.CLICK_EFFECT_DURATION}ms 后恢复）`);
+                await this.playExpression(randomExpression.Name, randomExpression.File);
 
                 const playedMotion = await this.playTutorialMotion();
 
-                if (!playedMotion) {
-                    // 动作不可用时，回退到参数动画模拟效果
-                    const model = this.currentModel.internalModel;
-                    if (model && model.coreModel) {
-                        // 随机晃动头部
-                        const angleXIndex = model.coreModel.getParameterIndex('ParamAngleX');
-                        const angleYIndex = model.coreModel.getParameterIndex('ParamAngleY');
-                        const bodyAngleXIndex = model.coreModel.getParameterIndex('ParamBodyAngleX');
-
-                        const duration = 1000 + Math.random() * 1000; // 1-2秒
-                        const startTime = Date.now();
-
-                        const setParamByIndex = (index, value) => {
-                            if (index < 0) return;
-                            if (typeof model.coreModel.setParameterValueByIndex === 'function') {
-                                model.coreModel.setParameterValueByIndex(index, value);
-                            } else {
-                                model.coreModel.setParameterValueById(index, value);
-                            }
-                        };
-
-                        const animate = () => {
-                            const elapsed = Date.now() - startTime;
-                            const progress = Math.min(elapsed / duration, 1);
-                            const t = progress * Math.PI * 2; // 一个完整周期
-
-                            setParamByIndex(angleXIndex, Math.sin(t) * 15); // -15 到 15 度
-                            setParamByIndex(angleYIndex, Math.cos(t) * 10); // -10 到 10 度
-                            setParamByIndex(bodyAngleXIndex, Math.sin(t * 0.5) * 5); // 更慢的身体晃动
-
-                            if (progress < 1) {
-                                requestAnimationFrame(animate);
-                            } else {
-                                // 动画结束，恢复默认值
-                                setParamByIndex(angleXIndex, 0);
-                                setParamByIndex(angleYIndex, 0);
-                                setParamByIndex(bodyAngleXIndex, 0);
-                            }
-                        };
-
-                        animate();
-                        console.log('[Interaction] 教程模式 - 播放参数动画');
-                    }
+                if (!playedMotion && !this.hasActiveActionMotion(this.currentModel)) {
+                    const fallbackEmotion = this.getRandomElement(['happy', 'sad', 'angry', 'surprised']);
+                    this.playSimpleMotion(fallbackEmotion);
                 }
             }
         } catch (error) {
@@ -3368,8 +3323,8 @@ Live2DManager.prototype.triggerRandomEmotion = async function() {
         // 触发临时情感效果
         let didPlayEffect = false;
         try {
-            // 播放低优先级的表情和动作
-            didPlayEffect = await this._playTemporaryClickEffect(randomEmotion, 2, window.live2dManager.CLICK_EFFECT_DURATION);
+            // 播放临时表情，并在动作槽空闲时播放动作
+            didPlayEffect = await this._playTemporaryClickEffect(randomEmotion, window.live2dManager.CLICK_EFFECT_DURATION);
         } catch (error) {
             console.warn('[Interaction] 触发情感失败:', error);
         }
@@ -3884,8 +3839,7 @@ Live2DManager.prototype._playTouchSetAnimation = async function(hitAreaId, optio
                             return false;
                         }
 
-                        motionManager.stopAllMotions();
-                        const result = await live2dModel.motion(groupName, 0, 3);
+                        const result = await this.playActionMotion(groupName, 0);
 
                         if (result) {
                             triggerLog.motions.push({
@@ -3894,7 +3848,7 @@ Live2DManager.prototype._playTouchSetAnimation = async function(hitAreaId, optio
                                 index: 0,
                                 file: motion.File,
                                 durationMs: AnimHoldingTime,
-                                priority: 3
+                                priority: 2
                             });
                             console.log(`[TouchSet] ✅ 成功下发播放指令: ${groupName}[0]`);
                         } else {

--- a/static/live2d/live2d-interaction.js
+++ b/static/live2d/live2d-interaction.js
@@ -2454,7 +2454,7 @@ Live2DManager.prototype._restoreClickEffectState = async function(options = {}) 
             return false;
         }
         this._currentClickEffectId = null;
-        this._clickEffectMotion = null;
+        this._clickEffectAction = null;
         return true;
     };
 
@@ -2462,10 +2462,9 @@ Live2DManager.prototype._restoreClickEffectState = async function(options = {}) 
         return false;
     }
 
-    if (this._clickEffectMotion && typeof this._clickEffectMotion.stop === 'function') {
-        try { this._clickEffectMotion.stop(); } catch (_) {}
+    if (this._clickEffectAction) {
+        this._stopClickEffectAction(this._clickEffectAction);
     }
-    this._clickEffectMotion = null;
 
     const restoreIdleMotion = async () => {
         if (!restoreIdle || typeof window.restoreLive2DIdleAnimationOnMainPage !== 'function') {
@@ -2502,13 +2501,33 @@ Live2DManager.prototype._restoreClickEffectState = async function(options = {}) 
 
     try {
         if (typeof this.clearExpression === 'function') {
-            this.clearExpression();
+            await this.clearExpression();
         }
     } catch (e) {
         console.warn('[ClickEffect] 清除表情失败:', e);
     }
     await restoreIdleMotion();
     return finishClickEffectRestore();
+};
+
+Live2DManager.prototype._stopClickEffectAction = function(action = this._clickEffectAction) {
+    if (!action) return false;
+    if (this._clickEffectAction === action) this._clickEffectAction = null;
+
+    const motionManager = action.model?.internalModel?.motionManager;
+    const state = motionManager?.state;
+    if (
+        action.model !== this.currentModel
+        || action.generation !== this._actionMotionGeneration
+        || state?.currentGroup !== action.group
+        || state?.currentIndex !== action.index
+        || Number(state.currentPriority || 0) <= 1
+        || typeof motionManager?.stopAllMotions !== 'function'
+    ) {
+        return false;
+    }
+    motionManager.stopAllMotions();
+    return true;
 };
 
 /**
@@ -2539,7 +2558,7 @@ Live2DManager.prototype._playTemporaryClickEffect = async function(emotion, dura
     const hadClickEffectState = Boolean(
         previousClickEffectId ||
         this._clickEffectRestoreTimer ||
-        this._clickEffectMotion
+        this._clickEffectAction
     );
     this._clickEffectRestoreToken = (this._clickEffectRestoreToken || 0) + 1;
     const restoreToken = this._clickEffectRestoreToken;
@@ -2556,11 +2575,6 @@ Live2DManager.prototype._playTemporaryClickEffect = async function(emotion, dura
         this._cancelSmoothReset();
     }
     
-    if (this._clickEffectMotion && typeof this._clickEffectMotion.stop === 'function') {
-        try { this._clickEffectMotion.stop(); } catch (e) {}
-    }
-    this._clickEffectMotion = null;
-
     try {
         // 准备表情兜底：动作不可用或播放失败时才播放
         let expressionFiles = [];
@@ -2620,18 +2634,29 @@ Live2DManager.prototype._playTemporaryClickEffect = async function(emotion, dura
         if (motions && motions.length > 0) {
             try {
                 const motionIndex = Math.floor(Math.random() * motions.length);
+                const motionModel = this.currentModel;
                 const motion = await this.playActionMotion(motionGroup, motionIndex);
                 if (!isCurrentPlayAttempt()) {
                     // 已被新的点击接管：停掉本次刚启动的动作，避免后台占用，并放弃写共享状态
-                    if (motion && typeof motion.stop === 'function') {
-                        try { motion.stop(); } catch (_) {}
+                    if (motion) {
+                        this._stopClickEffectAction({
+                            model: motionModel,
+                            group: motionGroup,
+                            index: motionIndex,
+                            generation: this._actionMotionGeneration
+                        });
                     }
                     triggerLog.reason = 'superseded_after_motion';
                     return false;
                 }
                 if (motion) {
                     console.log(`[ClickEffect] 播放临时动作: ${motionGroup}`);
-                    this._clickEffectMotion = motion;
+                    this._clickEffectAction = {
+                        model: motionModel,
+                        group: motionGroup,
+                        index: motionIndex,
+                        generation: this._actionMotionGeneration
+                    };
                     triggerLog.motions.push({
                         group: motionGroup,
                         index: motionIndex,
@@ -3923,15 +3948,12 @@ Live2DManager.prototype._playTouchSetAnimation = async function(hitAreaId, optio
 
                     clearTimeout(this.expressionTimer);
                     const holdingTime = Number.isFinite(faceHoldingTime) && faceHoldingTime > 0 ? faceHoldingTime : 3000;
-                    this.expressionTimer = setTimeout(() => {
+                    this.expressionTimer = setTimeout(async () => {
                         if (typeof this.clearExpression === 'function') {
-                            this.clearExpression();
-                            console.log(`[TouchSet] 临时表情清除，准备恢复常驻状态`);
-                            if (typeof this.applyPersistentExpressionsNative === 'function') {
-                                try {
-                                    this.applyPersistentExpressionsNative(true);
-                                } catch (_) {}
-                            }
+                            try {
+                                await this.clearExpression();
+                                console.log(`[TouchSet] 临时表情清除，准备恢复常驻状态`);
+                            } catch (_) {}
                         }
                     }, holdingTime);
                 } catch (e) {

--- a/static/live2d/live2d-interaction.js
+++ b/static/live2d/live2d-interaction.js
@@ -2512,22 +2512,37 @@ Live2DManager.prototype._restoreClickEffectState = async function(options = {}) 
 
 Live2DManager.prototype._stopClickEffectAction = function(action = this._clickEffectAction) {
     if (!action) return false;
-    if (this._clickEffectAction === action) this._clickEffectAction = null;
+    if (this._clickEffectAction === action) {
+        this._clickEffectAction = null;
+        if (this._clickEffectActionTimer) {
+            clearTimeout(this._clickEffectActionTimer);
+            this._clickEffectActionTimer = null;
+        }
+    }
 
     const motionManager = action.model?.internalModel?.motionManager;
     const state = motionManager?.state;
-    if (
-        action.model !== this.currentModel
-        || action.generation !== this._actionMotionGeneration
-        || state?.currentGroup !== action.group
-        || state?.currentIndex !== action.index
-        || Number(state?.currentPriority || 0) <= 1
-        || typeof motionManager?.stopAllMotions !== 'function'
-    ) {
+    if (action.model !== this.currentModel || action.generation !== this._actionMotionGeneration) {
         return false;
     }
-    motionManager.stopAllMotions();
-    return true;
+
+    let stopped = false;
+    if (
+        state?.currentGroup === action.group
+        && state?.currentIndex === action.index
+        && Number(state?.currentPriority || 0) > 1
+        && typeof motionManager?.stopAllMotions === 'function'
+    ) {
+        motionManager.stopAllMotions();
+        stopped = true;
+    }
+    if (typeof this._resetActiveMotionParameters === 'function') {
+        this._resetActiveMotionParameters({ preserveExpression: true });
+    }
+    if (typeof this._clearActiveMotionParamIds === 'function') {
+        this._clearActiveMotionParamIds();
+    }
+    return stopped;
 };
 
 /**
@@ -2634,6 +2649,7 @@ Live2DManager.prototype._playTemporaryClickEffect = async function(emotion, dura
         if (motions && motions.length > 0) {
             try {
                 const motionIndex = Math.floor(Math.random() * motions.length);
+                const selectedMotion = motions[motionIndex];
                 const motionModel = this.currentModel;
                 const motion = await this.playActionMotion(motionGroup, motionIndex);
                 if (!isCurrentPlayAttempt()) {
@@ -2651,12 +2667,23 @@ Live2DManager.prototype._playTemporaryClickEffect = async function(emotion, dura
                 }
                 if (motion) {
                     console.log(`[ClickEffect] 播放临时动作: ${motionGroup}`);
-                    this._clickEffectAction = {
+                    const action = {
                         model: motionModel,
                         group: motionGroup,
                         index: motionIndex,
                         generation: this._actionMotionGeneration
                     };
+                    this._clickEffectAction = action;
+                    if (this._clickEffectActionTimer) clearTimeout(this._clickEffectActionTimer);
+                    this._clickEffectActionTimer = setTimeout(() => {
+                        if (this._clickEffectAction === action) this._stopClickEffectAction(action);
+                    }, duration);
+                    const motionFile = typeof selectedMotion === 'string'
+                        ? selectedMotion
+                        : (selectedMotion?.File || selectedMotion?.file);
+                    if (motionFile && typeof this._trackActiveMotionParametersFromFile === 'function') {
+                        this._trackActiveMotionParametersFromFile(motionFile).catch(() => {});
+                    }
                     triggerLog.motions.push({
                         group: motionGroup,
                         index: motionIndex,
@@ -3164,6 +3191,11 @@ Live2DManager.prototype.cleanupEventListeners = function () {
         clearTimeout(this._clickEffectRestoreTimer);
         this._clickEffectRestoreTimer = null;
     }
+    if (this._clickEffectActionTimer) {
+        clearTimeout(this._clickEffectActionTimer);
+        this._clickEffectActionTimer = null;
+    }
+    this._clickEffectAction = null;
     this._currentClickEffectId = null;
 
     // 清理页面卸载监听器（如果存在）

--- a/static/live2d/live2d-interaction.js
+++ b/static/live2d/live2d-interaction.js
@@ -2535,12 +2535,12 @@ Live2DManager.prototype._stopClickEffectAction = function(action = this._clickEf
     ) {
         motionManager.stopAllMotions();
         stopped = true;
-    }
-    if (typeof this._resetActiveMotionParameters === 'function') {
-        this._resetActiveMotionParameters({ preserveExpression: true });
-    }
-    if (typeof this._clearActiveMotionParamIds === 'function') {
-        this._clearActiveMotionParamIds();
+        if (typeof this._resetActiveMotionParameters === 'function') {
+            this._resetActiveMotionParameters({ preserveExpression: true });
+        }
+        if (typeof this._clearActiveMotionParamIds === 'function') {
+            this._clearActiveMotionParamIds();
+        }
     }
     return stopped;
 };

--- a/static/live2d/live2d-model.js
+++ b/static/live2d/live2d-model.js
@@ -39,7 +39,23 @@ Live2DManager.prototype.playActionMotion = async function(groupName, index) {
     }
 
     const cachedMotion = motionManager.motionGroups?.[groupName]?.[index];
+    let restoreCachedMotionLoop = null;
     if (cachedMotion) {
+        let previousLoop;
+        let hasPreviousLoop = false;
+        if (typeof cachedMotion.isLoop === 'function') {
+            previousLoop = cachedMotion.isLoop();
+            hasPreviousLoop = true;
+        } else if (cachedMotion._loop !== undefined) {
+            previousLoop = cachedMotion._loop;
+            hasPreviousLoop = true;
+        }
+        if (hasPreviousLoop) {
+            restoreCachedMotionLoop = () => {
+                if (typeof cachedMotion.setIsLoop === 'function') cachedMotion.setIsLoop(previousLoop);
+                else cachedMotion._loop = previousLoop;
+            };
+        }
         if (typeof cachedMotion.setIsLoop === 'function') cachedMotion.setIsLoop(false);
         else if (cachedMotion._loop !== undefined) cachedMotion._loop = false;
     }
@@ -48,8 +64,14 @@ Live2DManager.prototype.playActionMotion = async function(groupName, index) {
     let started;
     try {
         started = await model.motion(groupName, index, LIVE2D_MOTION_PRIORITY.NORMAL);
+        if (started === true) {
+            this._actionMotionGeneration = (this._actionMotionGeneration || 0) + 1;
+        }
         return started;
     } finally {
+        if (started !== true && restoreCachedMotionLoop) {
+            restoreCachedMotionLoop();
+        }
         if (
             started !== true
             && motionManager.state?.reservedGroup === groupName

--- a/static/live2d/live2d-model.js
+++ b/static/live2d/live2d-model.js
@@ -15,6 +15,54 @@ const LIVE2D_MOTION_PRIORITY = Object.freeze({
     FORCE: 3
 });
 
+Live2DManager.prototype.hasActiveActionMotion = function(model = this.currentModel) {
+    if (
+        model === this.currentModel
+        && (this._actionMotionRequestPendingModel === model || this._simpleMotionActive === true)
+    ) {
+        return true;
+    }
+
+    const state = model?.internalModel?.motionManager?.state;
+    if (!state) return false;
+    return Number(state.currentPriority || 0) > LIVE2D_MOTION_PRIORITY.IDLE
+        || Number(state.reservePriority || 0) > LIVE2D_MOTION_PRIORITY.IDLE;
+};
+
+Live2DManager.prototype.playActionMotion = async function(groupName, index) {
+    const model = this.currentModel;
+    const motionManager = model?.internalModel?.motionManager;
+    if (!model || typeof model.motion !== 'function' || !motionManager) return false;
+    if (this.hasActiveActionMotion(model)) {
+        console.log(`[Live2D] 已有动作正在播放，忽略新动作: ${groupName}`);
+        return false;
+    }
+
+    const cachedMotion = motionManager.motionGroups?.[groupName]?.[index];
+    if (cachedMotion) {
+        if (typeof cachedMotion.setIsLoop === 'function') cachedMotion.setIsLoop(false);
+        else if (cachedMotion._loop !== undefined) cachedMotion._loop = false;
+    }
+
+    this._actionMotionRequestPendingModel = model;
+    let started;
+    try {
+        started = await model.motion(groupName, index, LIVE2D_MOTION_PRIORITY.NORMAL);
+        return started;
+    } finally {
+        if (
+            started !== true
+            && motionManager.state?.reservedGroup === groupName
+            && (index == null || motionManager.state?.reservedIndex === index)
+        ) {
+            motionManager.state.setReserved(undefined, undefined, LIVE2D_MOTION_PRIORITY.NONE);
+        }
+        if (this._actionMotionRequestPendingModel === model) {
+            this._actionMotionRequestPendingModel = null;
+        }
+    }
+};
+
 // 缓动函数集合（用于眨眼、口型等动画的平滑过渡）
 const Easing = {
     linear: (t) => t,
@@ -89,6 +137,11 @@ Live2DManager.prototype.removeModel = async function(options = {}) {
     this.appearanceBaselineParameters = {};
     this._activeExpressionParamIds = null;
     this._activeMotionParamIds = null;
+    this._actionMotionRequestPendingModel = null;
+    this._simpleMotionActive = false;
+    this._transientExpressionGeneration = (this._transientExpressionGeneration || 0) + 1;
+    this._transientExpressionTask = null;
+    this._activeTransientExpression = false;
     this._motionParameterTrackGeneration = (this._motionParameterTrackGeneration || 0) + 1;
     if (typeof this._nextMotionTimerGeneration === 'function') {
         this._nextMotionTimerGeneration();
@@ -1698,7 +1751,7 @@ Live2DManager.prototype._playIdleMotion = async function(motionManager) {
     const startTrackedMotion = async (groupName, index, file) => {
         if (!isCurrentIdleRequest()) return false;
         try {
-            const started = await motionManager.startMotion(groupName, index);
+            const started = await motionManager.startMotion(groupName, index, LIVE2D_MOTION_PRIORITY.IDLE);
             if (!isCurrentIdleRequest()) return false;
             if (started === false) {
                 console.warn(`[Live2D] 启动 ${groupName} 待机动作失败，尝试下一个 Idle 候选`);
@@ -1770,7 +1823,7 @@ Live2DManager.prototype._playIdleMotion = async function(motionManager) {
 
     if (!isCurrentIdleRequest()) return;
     try {
-        const started = await motionManager.startRandomMotion('Idle');
+        const started = await motionManager.startRandomMotion('Idle', LIVE2D_MOTION_PRIORITY.IDLE);
         if (!isCurrentIdleRequest()) return;
         if (started === false) {
             this._clearActiveMotionParamIds();

--- a/tests/unit/test_live2d_interaction_static_contracts.py
+++ b/tests/unit/test_live2d_interaction_static_contracts.py
@@ -166,7 +166,7 @@ def test_live2d_random_click_prefers_motion_and_uses_expression_as_fallback():
     motion_branch = click_effect.index("if (motions && motions.length > 0)")
     expression_fallback = click_effect.index("if (!didPlayEffect && expressionFiles.length > 0)")
     assert motion_branch < expression_fallback
-    assert "const motion = await this.currentModel.motion(motionGroup, undefined, priority);" in click_effect
+    assert "const motion = await this.playActionMotion(motionGroup, motionIndex);" in click_effect
     assert "triggerLog.motions.push({" in click_effect
     assert "triggerLog.expressions.push({ emotion, file: choiceFile, fallbackFor: 'motion' });" in click_effect
 

--- a/tests/unit/test_live2d_interaction_static_contracts.py
+++ b/tests/unit/test_live2d_interaction_static_contracts.py
@@ -162,11 +162,19 @@ def test_live2d_click_touch_set_logs_trigger_summary():
 def test_live2d_random_click_prefers_motion_and_uses_expression_as_fallback():
     source = _live2d_source()
     click_effect = _js_block(source, "Live2DManager.prototype._playTemporaryClickEffect")
+    restore_effect = _js_block(source, "Live2DManager.prototype._restoreClickEffectState")
+    stop_action = _js_block(source, "Live2DManager.prototype._stopClickEffectAction")
 
     motion_branch = click_effect.index("if (motions && motions.length > 0)")
     expression_fallback = click_effect.index("if (!didPlayEffect && expressionFiles.length > 0)")
     assert motion_branch < expression_fallback
     assert "const motion = await this.playActionMotion(motionGroup, motionIndex);" in click_effect
+    assert "generation: this._actionMotionGeneration" in click_effect
+    assert "this._stopClickEffectAction(this._clickEffectAction);" in restore_effect
+    assert "state?.currentGroup !== action.group" in stop_action
+    assert "state?.currentIndex !== action.index" in stop_action
+    assert "action.generation !== this._actionMotionGeneration" in stop_action
+    assert "motionManager.stopAllMotions();" in stop_action
     assert "triggerLog.motions.push({" in click_effect
     assert "triggerLog.expressions.push({ emotion, file: choiceFile, fallbackFor: 'motion' });" in click_effect
 

--- a/tests/unit/test_live2d_interaction_static_contracts.py
+++ b/tests/unit/test_live2d_interaction_static_contracts.py
@@ -170,12 +170,15 @@ def test_live2d_random_click_prefers_motion_and_uses_expression_as_fallback():
     assert motion_branch < expression_fallback
     assert "const motion = await this.playActionMotion(motionGroup, motionIndex);" in click_effect
     assert "generation: this._actionMotionGeneration" in click_effect
+    assert "this._clickEffectActionTimer = setTimeout" in click_effect
+    assert "this._trackActiveMotionParametersFromFile(motionFile)" in click_effect
     assert "this._stopClickEffectAction(this._clickEffectAction);" in restore_effect
-    assert "state?.currentGroup !== action.group" in stop_action
-    assert "state?.currentIndex !== action.index" in stop_action
+    assert "state?.currentGroup === action.group" in stop_action
+    assert "state?.currentIndex === action.index" in stop_action
     assert "action.generation !== this._actionMotionGeneration" in stop_action
-    assert "Number(state?.currentPriority || 0) <= 1" in stop_action
+    assert "Number(state?.currentPriority || 0) > 1" in stop_action
     assert "motionManager.stopAllMotions();" in stop_action
+    assert "this._resetActiveMotionParameters({ preserveExpression: true });" in stop_action
     assert "triggerLog.motions.push({" in click_effect
     assert "triggerLog.expressions.push({ emotion, file: choiceFile, fallbackFor: 'motion' });" in click_effect
 

--- a/tests/unit/test_live2d_interaction_static_contracts.py
+++ b/tests/unit/test_live2d_interaction_static_contracts.py
@@ -177,8 +177,12 @@ def test_live2d_random_click_prefers_motion_and_uses_expression_as_fallback():
     assert "state?.currentIndex === action.index" in stop_action
     assert "action.generation !== this._actionMotionGeneration" in stop_action
     assert "Number(state?.currentPriority || 0) > 1" in stop_action
-    assert "motionManager.stopAllMotions();" in stop_action
-    assert "this._resetActiveMotionParameters({ preserveExpression: true });" in stop_action
+    assert (
+        "motionManager.stopAllMotions();\n"
+        "        stopped = true;\n"
+        "        if (typeof this._resetActiveMotionParameters === 'function') {\n"
+        "            this._resetActiveMotionParameters({ preserveExpression: true });"
+    ) in stop_action
     assert "triggerLog.motions.push({" in click_effect
     assert "triggerLog.expressions.push({ emotion, file: choiceFile, fallbackFor: 'motion' });" in click_effect
 

--- a/tests/unit/test_live2d_interaction_static_contracts.py
+++ b/tests/unit/test_live2d_interaction_static_contracts.py
@@ -174,6 +174,7 @@ def test_live2d_random_click_prefers_motion_and_uses_expression_as_fallback():
     assert "state?.currentGroup !== action.group" in stop_action
     assert "state?.currentIndex !== action.index" in stop_action
     assert "action.generation !== this._actionMotionGeneration" in stop_action
+    assert "Number(state?.currentPriority || 0) <= 1" in stop_action
     assert "motionManager.stopAllMotions();" in stop_action
     assert "triggerLog.motions.push({" in click_effect
     assert "triggerLog.expressions.push({ emotion, file: choiceFile, fallbackFor: 'motion' });" in click_effect

--- a/tests/unit/test_live2d_parameter_persistence_static.py
+++ b/tests/unit/test_live2d_parameter_persistence_static.py
@@ -519,7 +519,11 @@ def test_live2d_action_and_expression_slots_are_exclusive():
           const manager = new context.Live2DManager();
           manager.currentModel = {
             internalModel: { motionManager: { state, motionGroups: {
-              Tap: [{ setIsLoop(value) { this.loop = value; }, loop: true }],
+              Tap: [{
+                _loop: true,
+                isLoop() { return this._loop; },
+                setIsLoop(value) { this._loop = value; },
+              }],
             } } },
             motion(group, index, priority) {
               manager.lastPriority = priority;
@@ -529,11 +533,31 @@ def test_live2d_action_and_expression_slots_are_exclusive():
           const first = manager.playActionMotion('Tap', 0);
           assert.strictEqual(await manager.playActionMotion('Other', 0), false);
           assert.strictEqual(manager.lastPriority, 2);
-          assert.strictEqual(manager.currentModel.internalModel.motionManager.motionGroups.Tap[0].loop, false);
+          const tapMotion = manager.currentModel.internalModel.motionManager.motionGroups.Tap[0];
+          assert.strictEqual(tapMotion._loop, false);
           finishAction(true);
           await first;
           state.currentPriority = 2;
           assert.strictEqual(manager.hasActiveActionMotion(), true);
+
+          state.currentPriority = 0;
+          state.reservePriority = 0;
+          const reservedCalls = [];
+          state.setReserved = (group, index, priority) => {
+            reservedCalls.push([group, index, priority]);
+            Object.assign(state, { reservedGroup: group, reservedIndex: index, reservePriority: priority });
+          };
+          tapMotion._loop = true;
+          manager.currentModel.motion = async () => {
+            state.setReserved('Tap', 0, 2);
+            return false;
+          };
+          assert.strictEqual(await manager.playActionMotion('Tap', 0), false);
+          assert.strictEqual(tapMotion._loop, true);
+          assert.deepStrictEqual(reservedCalls, [
+            ['Tap', 0, 2],
+            [undefined, undefined, 0],
+          ]);
 
           const expressions = new context.Live2DManager();
           expressions.currentModel = {};
@@ -559,6 +583,21 @@ def test_live2d_action_and_expression_slots_are_exclusive():
     )
     result = _run_node_harness(script)
     assert result.returncode == 0, result.stderr
+
+
+def test_saved_idle_restore_stops_only_an_existing_idle_motion():
+    source = (APP_INTERPAGE_PATH / "bootstrap-resources-and-model-reload.js").read_text(
+        encoding="utf-8"
+    )
+    start = source.index("async function restoreLive2DIdleAnimationOnMainPage")
+    end = source.index("window.restoreLive2DIdleAnimationOnMainPage", start)
+    restore_source = source[start:end]
+
+    action_guard = restore_source.index("hasActiveActionMotion(live2dModel)")
+    idle_guard = restore_source.index("Number(motionState?.currentPriority || 0) === 1")
+    stop_idle = restore_source.index("motionManager.stopAllMotions()", idle_guard)
+    start_saved_idle = restore_source.index("live2dModel.motion(groupName, motionIndex, 1)")
+    assert action_guard < idle_guard < stop_idle < start_saved_idle
 
 
 def test_parameter_save_treats_preferences_as_authoritative_and_sends_one_refresh():

--- a/tests/unit/test_live2d_parameter_persistence_static.py
+++ b/tests/unit/test_live2d_parameter_persistence_static.py
@@ -15,6 +15,7 @@ LIVE2D_MODEL_PATH = PROJECT_ROOT / "static" / "live2d" / "live2d-model.js"
 LIVE2D_EMOTION_PATH = PROJECT_ROOT / "static" / "live2d" / "live2d-emotion.js"
 PARAMETER_EDITOR_PATH = PROJECT_ROOT / "static" / "js" / "live2d_parameter_editor.js"
 APP_INTERPAGE_PATH = PROJECT_ROOT / "static" / "app" / "app-interpage"
+AVATAR_PERFORMANCE_PATH = PROJECT_ROOT / "static" / "avatar" / "avatar-performance-stage.js"
 MAO_PRO_MODEL_PATH = PROJECT_ROOT / "static" / "mao_pro" / "mao_pro.model3.json"
 
 
@@ -598,6 +599,17 @@ def test_saved_idle_restore_stops_only_an_existing_idle_motion():
     stop_idle = restore_source.index("motionManager.stopAllMotions()", idle_guard)
     start_saved_idle = restore_source.index("live2dModel.motion(groupName, motionIndex, 1)")
     assert action_guard < idle_guard < stop_idle < start_saved_idle
+
+
+def test_live2d_avatar_performance_inline_expression_cleanup_stays_targeted():
+    source = AVATAR_PERFORMANCE_PATH.read_text(encoding="utf-8")
+    start = source.index("        async clearExpression() {")
+    end = source.index("        hasMotion(group, options) {", start)
+    clear_source = source[start:end]
+
+    assert "manager?._activeTransientExpression === true" in clear_source
+    assert "if (shouldClearManagerExpression" in clear_source
+    assert "manager.applyPersistentExpressionsNative(true)" in clear_source
 
 
 def test_parameter_save_treats_preferences_as_authoritative_and_sends_one_refresh():

--- a/tests/unit/test_live2d_parameter_persistence_static.py
+++ b/tests/unit/test_live2d_parameter_persistence_static.py
@@ -491,6 +491,7 @@ def test_clear_expression_restores_only_active_ids_to_appearance_baseline():
         manager.initialParameters = { ParamAllColor1: 0, ParamUnrelated: 0 };
         manager.motionBaselineParameters = {};
         manager.appearanceBaselineParameters = { ParamAllColor1: 0.8, ParamUnrelated: 0.4 };
+        manager.persistentExpressionNames = ['resident'];
         manager._activeExpressionParamIds = new Set(['ParamAllColor1']);
         manager._cancelSmoothReset = () => {};
         manager._removeManualExpressionOverride = () => {};
@@ -502,6 +503,58 @@ def test_clear_expression_restores_only_active_ids_to_appearance_baseline():
         assert.strictEqual(values[1], 0.7);
         assert.strictEqual(stopped, 1);
         assert.strictEqual(persistentReplayed, 1);
+        assert.deepStrictEqual(manager.persistentExpressionNames, ['resident']);
+        """
+    )
+    result = _run_node_harness(script)
+    assert result.returncode == 0, result.stderr
+
+
+def test_live2d_action_and_expression_slots_are_exclusive():
+    script = _manager_harness(
+        """
+        (async () => {
+          const state = { currentPriority: 0, reservePriority: 0, setReserved() {}, setReservedIdle() {} };
+          let finishAction;
+          const manager = new context.Live2DManager();
+          manager.currentModel = {
+            internalModel: { motionManager: { state, motionGroups: {
+              Tap: [{ setIsLoop(value) { this.loop = value; }, loop: true }],
+            } } },
+            motion(group, index, priority) {
+              manager.lastPriority = priority;
+              return new Promise(resolve => { finishAction = resolve; });
+            },
+          };
+          const first = manager.playActionMotion('Tap', 0);
+          assert.strictEqual(await manager.playActionMotion('Other', 0), false);
+          assert.strictEqual(manager.lastPriority, 2);
+          assert.strictEqual(manager.currentModel.internalModel.motionManager.motionGroups.Tap[0].loop, false);
+          finishAction(true);
+          await first;
+          state.currentPriority = 2;
+          assert.strictEqual(manager.hasActiveActionMotion(), true);
+
+          const expressions = new context.Live2DManager();
+          expressions.currentModel = {};
+          const events = [];
+          let finishExpression;
+          expressions.clearExpression = async () => { events.push('clear'); expressions._activeTransientExpression = false; };
+          expressions._playExpressionNow = async (name) => {
+            events.push(`start:${name}`);
+            expressions._activeTransientExpression = true;
+            if (name === 'first') await new Promise(resolve => { finishExpression = resolve; });
+            return true;
+          };
+          const expressionA = expressions.playExpression('first');
+          while (!finishExpression) await new Promise(resolve => setTimeout(resolve, 0));
+          const expressionB = expressions.playExpression('second');
+          assert.deepStrictEqual(events, ['start:first']);
+          finishExpression();
+          await expressionA;
+          await expressionB;
+          assert.deepStrictEqual(events, ['start:first', 'clear', 'start:second']);
+        })().catch(error => { console.error(error); process.exitCode = 1; });
         """
     )
     result = _run_node_harness(script)


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

统一 Live2D 动作与临时表情互斥逻辑，动作播放期间拒绝新动作，表情切换时重置旧表情并保留常驻表情

相关issues：[多个动作卡在一起演示](https://github.com/Project-N-E-K-O/N.E.K.O/issues/2674)

## 测试 / Testing

手动快速点击确保不会多次触发，并且查看浏览器日志确认拦截


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 功能优化

- 优化 Live2D 动作与表情播放，减少并发触发及模型切换时的冲突。
- 改进点击、教程、随机动作和待机动作的播放衔接。
- 优化临时表情清理流程，保持持久化表情状态。

## Bug 修复

- 恢复待机动作前检查当前播放状态，避免打断正在进行的动作。
- 改善动作播放失败及临时效果清理后的状态恢复。

## 测试

- 完善动作、表情互斥、状态恢复及持久化相关测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->